### PR TITLE
feat(Set): Add set notation for finite sets

### DIFF
--- a/Mathlib/Set.lean
+++ b/Mathlib/Set.lean
@@ -154,7 +154,7 @@ instance : LawfulFunctor Set where
      λ ⟨b, ⟨⟨a, ⟨h₁, h₂⟩⟩, h₃⟩⟩ => ⟨a, ⟨h₁, show h (g a) = c from h₂ ▸ h₃⟩⟩⟩
   map_const := rfl
 
-syntax (priority := high) "{ " term,+ " }" : term
+syntax (priority := high) "{" term,+ "}" : term
 
 macro_rules
   | `({$x}) => `(Set.singleton $x)

--- a/Mathlib/Set.lean
+++ b/Mathlib/Set.lean
@@ -25,10 +25,6 @@ I didn't call this file Data.Set.Basic because it contains core Lean 3
 stuff which happens before mathlib3's data.set.basic .
 This file is a port of the core Lean 3 file `lib/lean/library/init/data/set.lean`.
 
-## TODO
-
-Notation {a,b,c} for finite sets (both parser and prettyprinter).
-
 -/
 
 universes u v

--- a/Mathlib/Set.lean
+++ b/Mathlib/Set.lean
@@ -25,6 +25,10 @@ I didn't call this file Data.Set.Basic because it contains core Lean 3
 stuff which happens before mathlib3's data.set.basic .
 This file is a port of the core Lean 3 file `lib/lean/library/init/data/set.lean`.
 
+## TODO
+
+Notation {a,b,c} for finite sets (both parser and prettyprinter).
+
 -/
 
 universes u v
@@ -172,7 +176,6 @@ def singletonUnexpander : Lean.PrettyPrinter.Unexpander
 
 @[appUnexpander Set.insert]
 def insertUnexpander : Lean.PrettyPrinter.Unexpander
-| `(Set.insert $a { $t }) => `({$a, $t})
 | `(Set.insert $a { $ts,* }) => `({$a, $ts,*})
 | _ => throw ()
 

--- a/Mathlib/Set.lean
+++ b/Mathlib/Set.lean
@@ -180,6 +180,4 @@ def insertUnexpander : Lean.PrettyPrinter.Unexpander
 | `(Set.insert $a { $ts,* }) => `({$a, $ts,*})
 | _ => throw ()
 
-variable {α : Type _} {a b c : α}
-
 end Set

--- a/Mathlib/Set.lean
+++ b/Mathlib/Set.lean
@@ -154,20 +154,11 @@ instance : LawfulFunctor Set where
      λ ⟨b, ⟨⟨a, ⟨h₁, h₂⟩⟩, h₃⟩⟩ => ⟨a, ⟨h₁, show h (g a) = c from h₂ ▸ h₃⟩⟩⟩
   map_const := rfl
 
-syntax (priority := high) "{ " term,* " }" : term
+syntax (priority := high) "{ " term,+ " }" : term
 
-open Lean Macro in
 macro_rules
-| `({ $elems:term,* }) => do
-  let n := elems.elemsAndSeps.size
-  if n = 0 then throwUnsupported
-  let rec expandSetLit (i : Nat) (skip : Bool) (result : Syntax) : MacroM Syntax := do
-    match i, skip with
-    | 0, _ => result
-    | i + 1, true => expandSetLit i false result
-    | i + 1, false => expandSetLit i true (← ``(Set.insert $(elems.elemsAndSeps[i]) $result))
-  let some hd ← pure $ elems.elemsAndSeps.back? | throwUnsupported
-  expandSetLit (n - 1) true (← ``(Set.singleton $hd))
+  | `({$x}) => `(Set.singleton $x)
+  | `({$x, $xs:term,*}) => `(Set.insert $x {$xs,*})
 
 @[appUnexpander Set.singleton]
 def singletonUnexpander : Lean.PrettyPrinter.Unexpander


### PR DESCRIPTION
I've defined set notation for finite sets, based on the Lean 3 way of doing it. That is, `{ 1 } = singleton 1`, and `{ 1, 2 } = insert 1 (singleton 2)`. I've also defined the `appUnexpander` so that Lean can also use this to pretty print the sets. 