### PR TITLE
List: add missing repeat from Prelude

### DIFF
--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -88,4 +88,13 @@ theorem mem_bind {f : α → List β} {b} {l : List α} : b ∈ l.bind f ↔ ∃
   simp [List.bind, mem_map, mem_join]
   exact ⟨fun ⟨_, ⟨a, h₁, rfl⟩, h₂⟩ => ⟨a, h₁, h₂⟩, fun ⟨a, h₁, h₂⟩ => ⟨_, ⟨a, h₁, rfl⟩, h₂⟩⟩
 
+/-! ### repeat -/
+
+@[simp] def repeat (a: α): ℕ -> List α
+| 0 => []
+| Nat.succ n => a :: repeat a n
+
+@[simp] def repeatSucc (a: α) (n: ℕ): repeat a (n + 1) = a :: repeat a n := rfl
+
+
 end List


### PR DESCRIPTION
This adds the missing useful function `List.repeat` which I think was in Lean 3's prelude. I don't know if it makes sense to put it in Prelude, so feel free to suggest.