### PR TITLE
WIP: Digits lemmas for natural integers (port from mathlib3)

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -9,6 +9,7 @@ import Mathlib.Data.Equiv.Basic
 import Mathlib.Data.Equiv.Functor
 import Mathlib.Data.List.Basic
 import Mathlib.Data.Nat.Basic
+import Mathlib.Data.Nat.Digits
 import Mathlib.Data.UInt
 import Mathlib.Function
 import Mathlib.Logic.Basic

--- a/Mathlib/Algebra/Group/Defs.lean
+++ b/Mathlib/Algebra/Group/Defs.lean
@@ -1,5 +1,6 @@
 import Mathlib.Data.Nat.Basic -- *only* for notation ℕ which should be in a "prelude"
 import Mathlib.Tactic.Spread
+import Mathlib.Logic.Function.Basic
 
 /-!
 
@@ -123,9 +124,8 @@ IsAddLeftCancel.add_left_cancel a b c
 theorem add_left_cancel_iff : a + b = a + c ↔ b = c :=
 ⟨add_left_cancel, congrArg _⟩
 
--- no `function.injective`?
---theorem add_right_injective (a : G) : function.injective (c * .) :=
---λ a b => add_left_cancel
+theorem add_right_injective (a : A) : Function.injective (c + .) :=
+add_left_cancel
 
 @[simp] theorem add_right_inj (a : A) {b c : A} : a + b = a + c ↔ b = c :=
 ⟨add_left_cancel, congrArg _⟩
@@ -293,9 +293,8 @@ IsMulLeftCancel.mul_left_cancel a b c
 theorem mul_left_cancel_iff : a * b = a * c ↔ b = c :=
 ⟨mul_left_cancel, congrArg _⟩
 
--- no `function.injective`?
---theorem mul_right_injective (a : G) : function.injective (c * .) :=
---λ a b => mul_left_cancel
+theorem mul_right_injective (a : G) : Function.injective (c * .) :=
+mul_left_cancel
 
 @[simp] theorem mul_right_inj (a : G) {b c : G} : a * b = a * c ↔ b = c :=
 ⟨mul_left_cancel, congrArg _⟩

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -1,6 +1,7 @@
 import Mathlib.Logic.Basic
 import Mathlib.Data.Nat.Basic
 import Mathlib.Mem
+import Mathlib.Algebra.Group.Defs
 namespace List
 
 /-- The same as append, but with simpler defeq. (The one in the standard library is more efficient,
@@ -96,5 +97,12 @@ theorem mem_bind {f : α → List β} {b} {l : List α} : b ∈ l.bind f ↔ ∃
 
 @[simp] def repeatSucc (a: α) (n: ℕ): repeat a (n + 1) = a :: repeat a n := rfl
 
+/-! ### sum -/
+
+@[simp] def sum [Add α] [Zero α]: List α -> α
+| [] => (0: α)
+| x :: q => x + sum q
+
+@[simp] def sumCons [Add α] [Zero α] (L: List α) (a: α): sum (a :: L) = a + sum L := rfl
 
 end List

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -96,6 +96,7 @@ theorem mem_bind {f : α → List β} {b} {l : List α} : b ∈ l.bind f ↔ ∃
 | Nat.succ n => a :: repeat a n
 
 @[simp] def repeatSucc (a: α) (n: ℕ): repeat a (n + 1) = a :: repeat a n := rfl
+@[simp] def repeatSingleton (a: α): repeat a 1 = [a] := rfl
 
 /-! ### sum -/
 

--- a/Mathlib/Data/Nat/Basic.lean
+++ b/Mathlib/Data/Nat/Basic.lean
@@ -316,8 +316,8 @@ protected def strong_rec_on {p : ℕ → Sort u}
 Nat.lt_wf.fix' H n
 
 protected def case_strong_rec_on {p : ℕ → Sort u} (a : ℕ)
-  (hz : p 0) (hi : ∀ n, (∀ m, m ≤ n → p m) → p (succ n)) : p a :=
-Nat.strong_rec_on a fun | 0, _ => hz | n+1, ih => hi n ih
+  (base : p 0) (ind : ∀ n, (∀ m, m ≤ n → p m) → p (succ n)) : p a :=
+Nat.strong_rec_on a fun | 0, _ => base | n+1, ih => ind n ih
 
 lemma mod_add_div (m k : ℕ) : m % k + k * (m / k) = m := by
   induction m, k using mod.inductionOn with rw [div_eq, mod_eq]
@@ -738,5 +738,8 @@ lemma div_lt_self (h₁ : 0 < n) (h₂ : 1 < m) : n / m < n := by
     rw [Nat.one_mul, Nat.mul_comm] at this
     exact (Nat.div_lt_iff_lt_mul m_pos).2 this
   exact Nat.mul_lt_mul h₂ (Nat.le_refl _) h₁
+
+lemma div_lt_self' (n b: ℕ) : (n + 1) / (b + 2) < n + 1 :=
+  div_lt_self (succ_pos n) (succ_lt_succ $ succ_pos _)
 
 end Nat

--- a/Mathlib/Data/Nat/Basic.lean
+++ b/Mathlib/Data/Nat/Basic.lean
@@ -106,6 +106,14 @@ protected lemma le_or_le (a b : ℕ) : a ≤ b ∨ b ≤ a := (Nat.lt_or_le _ _)
 
 protected lemma le_of_not_le {a b : ℕ} : ¬ a ≤ b → b ≤ a := (Nat.le_or_le _ _).resolve_left
 
+lemma ne_of_lt {a b: ℕ} (h: a < b): a ≠ b :=
+  fun he => absurd h (he ▸ Nat.lt_irrefl a)
+
+lemma ne_of_gt {a b: ℕ} (h: b < a): a ≠ b :=
+  fun he => absurd h (he ▸ Nat.lt_irrefl a)
+
+lemma ne_zero_of_pos {n: ℕ} : 0 < n → n ≠ 0 := ne_of_gt
+
 @[simp] protected lemma not_lt {n m : ℕ} : ¬ n < m ↔ m ≤ n :=
 ⟨Nat.lt_of_not_le, Nat.not_lt_of_le⟩
 

--- a/Mathlib/Data/Nat/Digits.lean
+++ b/Mathlib/Data/Nat/Digits.lean
@@ -7,6 +7,7 @@ import Mathlib.Logic.Basic
 import Mathlib.Data.List.Basic
 import Mathlib.Data.Nat.Basic
 import Mathlib.Data.Nat.Instances
+import Mathlib.Logic.Function.Basic
 import Mathlib.Tactic.NormNum
 
 /-!
@@ -151,6 +152,12 @@ by induction L with
 ### Properties
 This section contains various lemmas of properties relating to `digits` and `ofDigits`.
 -/
+
+lemma digits.injective (b: ℕ): Function.injective b.digits :=
+Function.left_inverse.injective (ofDigitsDigits b)
+
+@[simp] lemma digitsInjIff {b n m: ℕ}:
+  b.digits n = b.digits m ↔ n = m := Function.injective.eq_iff (digits.injective b)
 
 lemma digitsEqNilIffEqZero {b n: ℕ} : digits b n = [] ↔ n = 0 :=
 by

--- a/Mathlib/Data/Nat/Digits.lean
+++ b/Mathlib/Data/Nat/Digits.lean
@@ -1,0 +1,122 @@
+/-
+Copyright (c) 2021 Scott Morrison. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Scott Morrison, Shing Tak Lam, Mario Carneiro, Ryan Lahfa
+-/
+import Mathlib.Logic.Basic
+import Mathlib.Data.List.Basic
+import Mathlib.Data.Nat.Basic
+import Mathlib.Data.Nat.Instances
+import Mathlib.Tactic.NormNum
+
+/-!
+# Digits of a natural number
+This provides a basic API for extracting the digits of a natural number in a given base,
+and reconstructing numbers from their digits.
+We also prove some divisibility tests based on digits, in particular completing
+Theorem #85 from https://www.cs.ru.nl/~freek/100/.
+A basic `norm_digits` tactic is also provided for proving goals of the form
+`nat.digits a b = l` where `a` and `b` are numerals.
+-/
+
+namespace Nat
+
+-- Naming convention stuff
+def digitsAux0 : ℕ -> List ℕ
+| 0 => []
+| (n + 1) => [n + 1]
+
+def digitsAux1 (n: ℕ): List ℕ := List.repeat 1 n
+
+def digitsAuxF (b: ℕ) (h: 2 ≤ b)
+  (n: ℕ) (f: ∀ m, m < n -> List ℕ): List ℕ :=
+  match (generalizing := true) n with
+  | 0 => []
+  | succ m =>
+    (succ m) % b :: f ((succ m) / b) (div_lt_self (succ_pos _) h)
+
+partial def unsafeDigitsAux (b: ℕ) (h: 2 ≤ b): ℕ -> List ℕ
+| 0 => []
+| succ n => (succ n) % b :: unsafeDigitsAux b h ((succ n) / b)
+
+@[implementedBy unsafeDigitsAux]
+noncomputable def digitsAux (b: ℕ) (h: 2 ≤ b): ℕ -> List ℕ :=
+fun n => WellFounded.fix Nat.ltWf (digitsAuxF b h) n
+
+@[simp] theorem digitsAuxZero (b: ℕ) (h: 2 ≤ b): digitsAux b h 0 = List.nil := rfl
+
+lemma digitsAuxDef (b: ℕ) (h: 2 ≤ b) (w: 0 < n):
+  digitsAux b h n = n % b :: digitsAux b h (n / b) := by
+  cases n
+  { trivial }
+  { rfl }
+
+
+/--
+`digits b n` gives the digits, in little-endian order,
+of a natural number `n` in a specified base `b`.
+In any base, we have `of_digits b L = L.foldr (λ x y, x + b * y) 0`.
+* For any `2 ≤ b`, we have `l < b` for any `l ∈ digits b n`,
+  and the last digit is not zero.
+  This uniquely specifies the behaviour of `digits b`.
+* For `b = 1`, we define `digits 1 n = list.repeat 1 n`.
+* For `b = 0`, we define `digits 0 n = [n]`, except `digits 0 0 = []`.
+Note this differs from the existing `nat.to_digits` in core, which is used for printing numerals.
+In particular, `nat.to_digits b 0 = [0]`, while `digits b 0 = []`.
+-/
+def digits : ℕ → ℕ → List ℕ
+| 0 => digitsAux0
+| 1 => digitsAux1
+| (b + 2) => digitsAux (b + 2) (by admit)
+
+@[simp] lemma digitsZero (b: ℕ) : digits b 0 = List.nil := by
+  match b with
+  | 0 => rfl
+  | 1 => rfl
+  | (n + 2) => rfl
+
+@[simp] lemma digitsZeroZero : digits 0 0 = List.nil := rfl
+@[simp] lemma digitsZeroSucc (n: ℕ) : digits 0 (n.succ) = [n + 1] := rfl
+
+@[simp] lemma digitsOne (n: ℕ): digits 1 n = List.repeat 1 n := rfl
+@[simp] lemma digitsOneSucc (n: ℕ): digits 1 (n + 1) = 1 :: digits 1 n := rfl
+
+@[simp] lemma digitsAddTwoAddOne (b n: ℕ):
+  digits (b + 2) (n + 1) = ((n + 1) % (b + 2)) :: digits (b + 2) ((n + 1) / (b + 2)) := rfl
+
+@[simp] lemma digitsOfLt (b x : ℕ) (w₁ : 0 < x) (w₂ : x < b): digits b x = [x] := by
+  match b with
+  | 0 => trivial
+  | 1 => simp; admit
+  | (b + 2) => match x with
+    | 0 => trivial
+    | (n + 1) => rw [digitsAddTwoAddOne, div_eq_of_lt w₂, digitsZero, mod_eq_of_lt w₂]
+
+lemma digitsAdd (b: ℕ) (h: 2 ≤ b) (x y: ℕ) (w: x < b) (w': 0 < x ∨ 0 < y):
+  digits b ( x + b * y) = x :: digits b y := by
+  match b with
+  | 0 => trivial
+  | 1 => trivial
+  |(b + 2) => match y with
+    | 0 => simp; admit -- require normNum for inequalities.
+    | (y + 1) => admit
+
+def ofDigits {α: Type} [Semiring α] (b: α) : List ℕ → α
+| [] => 0
+| h :: t => Numeric.ofNat h + b * ofDigits b t -- should have auto-coercions?
+
+-- @[simp] lemma ofDigitsSingleton {b n: ℕ} : ofDigits b [n] = n := by simp [ofDigits]
+@[simp] lemma ofDigitsOneCons {α: Type} [Semiring α] (h: ℕ) (L: List ℕ):
+  ofDigits (1: α) (h :: L) = Numeric.ofNat h + ofDigits 1 L := by simp [ofDigits]
+
+lemma ofDigitsAppend {b: ℕ} {l1 l2: List ℕ}:
+  ofDigits b (l1 ++ l2) = ofDigits b l1 + Monoid.npow (l1.length) b * ofDigits b l2 := by
+  induction l1 with
+  | nil => simp [ofDigits, Monoid.npow_zero']
+  | cons hd tl hl =>
+    simp [ofDigits, hl,
+    List.length_cons, Numeric.ofNat, Semiring.mul_add,
+    Monoid.npow_succ' (List.length tl),
+    Nat.mul_assoc,
+    Nat.add_assoc]
+end Nat

--- a/Mathlib/Data/Nat/Digits.lean
+++ b/Mathlib/Data/Nat/Digits.lean
@@ -46,7 +46,7 @@ fun n => WellFounded.fix Nat.ltWf (digitsAuxF b h) n
 
 @[simp] theorem digitsAuxZero (b: ℕ) (h: 2 ≤ b): digitsAux b h 0 = List.nil := rfl
 
-lemma digitsAuxDef (b: ℕ) (h: 2 ≤ b) (w: 0 < n):
+lemma digitsAuxDef (b n: ℕ) (h: 2 ≤ b) (w: 0 < n):
   digitsAux b h n = n % b :: digitsAux b h (n / b) := by
   cases n
   { trivial }
@@ -88,7 +88,8 @@ def digits : ℕ → ℕ → List ℕ
 @[simp] lemma digitsOfLt (b x : ℕ) (w₁ : 0 < x) (w₂ : x < b): digits b x = [x] := by
   match b with
   | 0 => trivial
-  | 1 => simp; admit
+  | 1 =>
+    simp; rw [eqZeroOfLeZero w₂] at w₁; exact absurd w₁ (Nat.ltIrrefl _)
   | (b + 2) => match x with
     | 0 => trivial
     | (n + 1) => rw [digitsAddTwoAddOne, div_eq_of_lt w₂, digitsZero, mod_eq_of_lt w₂]
@@ -166,7 +167,9 @@ lemma digitsZeroOfEqZero {b : ℕ} (h : 1 ≤ b) {L : List ℕ} (w : ofDigits b 
       simp at hmem
       match hmem with
       | Or.inl eq_hd => rw [eq_hd, eq_zero_of_add_eq_zero_right w]
-      | Or.inr mem_tl => apply hl _ mem_tl; admit
+      | Or.inr mem_tl =>
+        exact hl ((eq_zero_of_mul_eq_zero $ eq_zero_of_add_eq_zero_left w).resolve_left (
+          fun b_zero => absurd b_zero (Nat.ne_zero_of_pos h))) mem_tl
 
 lemma digits.injective (b: ℕ): Function.injective b.digits :=
 Function.left_inverse.injective (ofDigitsDigits b)

--- a/Mathlib/Data/Nat/Digits.lean
+++ b/Mathlib/Data/Nat/Digits.lean
@@ -106,7 +106,7 @@ def ofDigits {α: Type} [Semiring α] (b: α) : List ℕ → α
 | [] => 0
 | h :: t => Numeric.ofNat h + b * ofDigits b t -- should have auto-coercions?
 
--- @[simp] lemma ofDigitsSingleton {b n: ℕ} : ofDigits b [n] = n := by simp [ofDigits]
+@[simp] lemma ofDigitsSingleton {b n: ℕ} : ofDigits b [n] = n := by simp [ofDigits, Numeric.ofNat]
 @[simp] lemma ofDigitsOneCons {α: Type} [Semiring α] (h: ℕ) (L: List ℕ):
   ofDigits (1: α) (h :: L) = Numeric.ofNat h + ofDigits 1 L := by simp [ofDigits]
 
@@ -144,9 +144,10 @@ match b with
     rw [hn _ (Nat.div_lt_self' n b)]
     simp [Numeric.ofNat, Nat.mod_add_div]
 
-/-lemma ofDigitsOne (L: List ℕ) : ofDigits 1 L = L.sum :=
+lemma ofDigitsOne (L: List ℕ) : ofDigits 1 L = L.sum :=
 by induction L with
-| nil => rfl-/
+| nil => rfl
+| cons hd tl hl => simp [Numeric.ofNat, hl]
 
 /-!
 ### Properties

--- a/Mathlib/Data/Nat/Digits.lean
+++ b/Mathlib/Data/Nat/Digits.lean
@@ -93,7 +93,7 @@ def digits : ℕ → ℕ → List ℕ
     | (n + 1) => rw [digitsAddTwoAddOne, div_eq_of_lt w₂, digitsZero, mod_eq_of_lt w₂]
 
 lemma digitsAdd (b: ℕ) (h: 2 ≤ b) (x y: ℕ) (w: x < b) (w': 0 < x ∨ 0 < y):
-  digits b ( x + b * y) = x :: digits b y := by
+  digits b (x + b * y) = x :: digits b y := by
   match b with
   | 0 => trivial
   | 1 => trivial
@@ -119,4 +119,60 @@ lemma ofDigitsAppend {b: ℕ} {l1 l2: List ℕ}:
     Monoid.npow_succ' (List.length tl),
     Nat.mul_assoc,
     Nat.add_assoc]
+
+lemma ofDigitsDigits (b n: ℕ) : ofDigits b (digits b n) = n := by
+match b with
+| 0 =>
+  match n with
+  | 0 => rfl
+  | 1 => rfl
+  | (n + 2) => rfl
+| 1 =>
+  induction n with
+  | zero => rfl
+  | succ n hn =>
+    simp at hn
+    simp [hn, Numeric.ofNat]
+    rw [Nat.succ_Eq_add_one, Nat.add_comm]
+| (b + 2) =>
+  induction n using Nat.case_strong_rec_on with
+  | base => simp [ofDigits]
+  | ind n hn =>
+    simp [Nat.succ_Eq_add_one]
+    simp [ofDigits] -- dsimp?
+    rw [hn _ (Nat.div_lt_self' n b)]
+    simp [Numeric.ofNat, Nat.mod_add_div]
+
+/-lemma ofDigitsOne (L: List ℕ) : ofDigits 1 L = L.sum :=
+by induction L with
+| nil => rfl-/
+
+/-!
+### Properties
+This section contains various lemmas of properties relating to `digits` and `ofDigits`.
+-/
+
+lemma digitsEqNilIffEqZero {b n: ℕ} : digits b n = [] ↔ n = 0 :=
+by
+  split
+  intro h
+  rw [(ofDigitsDigits b n).symm, h]
+  simp [ofDigits]
+  intro h; rw [h]; simp
+
+private lemma digitsLastAux {b n: ℕ} (h: 2 ≤ b) (w: 0 < n):
+  digits b n = ((n % b) :: digits b (n / b)) :=
+by match b with
+| 0 => trivial
+| 1 => trivial
+| (b + 2) =>
+  match n with
+  | 0 => trivial
+  | (n + 1) => simp
+
+/-lemma digitsLast {b m: ℕ} (h: 2 ≤ b) (hm: 0 < m) (p q) :
+  (digits b m).last p = (digits b (m/b)).last q :=
+  by simp [digitsLastAux h hm]-/
+
+
 end Nat

--- a/Mathlib/Data/Nat/Digits.lean
+++ b/Mathlib/Data/Nat/Digits.lean
@@ -154,6 +154,20 @@ by induction L with
 This section contains various lemmas of properties relating to `digits` and `ofDigits`.
 -/
 
+lemma digitsZeroOfEqZero {b : ℕ} (h : 1 ≤ b) {L : List ℕ} (w : ofDigits b L = 0) :
+  ∀ l, l ∈ L -> l = 0 := fun l hmem =>
+  by induction L with
+  | nil => cases l <;> trivial
+  | cons hd tl hl =>
+    simp [ofDigits, Numeric.ofNat] at w
+    match l with
+    | 0 => rfl
+    | (l + 1) =>
+      simp at hmem
+      match hmem with
+      | Or.inl eq_hd => rw [eq_hd, eq_zero_of_add_eq_zero_right w]
+      | Or.inr mem_tl => apply hl _ mem_tl; admit
+
 lemma digits.injective (b: ℕ): Function.injective b.digits :=
 Function.left_inverse.injective (ofDigitsDigits b)
 

--- a/Mathlib/Data/Nat/Instances.lean
+++ b/Mathlib/Data/Nat/Instances.lean
@@ -1,0 +1,45 @@
+import Mathlib.Algebra.Ring.Basic
+
+instance : Numeric ℕ where
+  ofNat := id
+
+instance : One ℕ where
+  one := (1: ℕ)
+
+instance : Mul ℕ where
+  mul := Nat.mul
+
+instance : Semigroup ℕ where
+  mul_assoc := Nat.mul_assoc
+
+instance : Monoid ℕ where
+  mul_one := Nat.mul_one
+  one_mul := Nat.one_mul
+  npow_zero' := sorry
+  npow_succ' := sorry
+
+instance : AddSemigroup ℕ where
+  add_assoc := Nat.add_assoc
+
+instance : Zero ℕ where
+  zero := (0: ℕ)
+
+instance : AddMonoid ℕ where
+  add_zero := Nat.add_zero
+  zero_add := Nat.zero_add
+  nsmul_zero' := sorry
+  nsmul_succ' := sorry
+
+instance : AddCommMonoid ℕ where
+  add_comm := Nat.add_comm
+
+instance : Semiring ℕ where
+  __ := inferInstanceAs (Numeric ℕ)
+  __ := inferInstanceAs (AddCommMonoid ℕ)
+  __ := inferInstanceAs (Monoid ℕ)
+  zero_mul := Nat.zero_mul
+  mul_zero := Nat.mul_zero
+  mul_add := Nat.mul_add
+  add_mul := Nat.add_mul
+  ofNat_add := by simp [Numeric.ofNat]
+  ofNat_mul := by simp [Numeric.ofNat]

--- a/Mathlib/Logic/Function/Basic.lean
+++ b/Mathlib/Logic/Function/Basic.lean
@@ -15,3 +15,10 @@ theorem left_inverse.comp {f : α → β} {g : β → α} {h : β → γ} {i : �
 theorem right_inverse.comp {f : α → β} {g : β → α} {h : β → γ} {i : γ → β}
   (hf : right_inverse f g) (hh : right_inverse h i) : right_inverse (h ∘ f) (g ∘ i) :=
 left_inverse.comp hh hf
+
+@[simp] theorem injective.eq_iff {f: α → β} (I: injective f) {a b: α}:
+  f a = f b ↔ a = b := ⟨@I _ _, congr_arg f⟩
+
+theorem injective.eq_iff' {f: α → β} (I: injective f) {a b: α} {c: β} (h: f b = c) :
+  f a = c ↔ a = b :=
+  h ▸ I.eq_iff


### PR DESCRIPTION
Depends on #16 and #15 and maybe other dependencies along the way, notably, some improvements on `normNum` to keep it as much as close to mathlib 3 versions.

`normDigits` will not be included in this PR.