### PR TITLE
feat(Logic/Function/Basic) port most remaining items

### DIFF
--- a/Mathlib/Logic/Basic.lean
+++ b/Mathlib/Logic/Basic.lean
@@ -354,6 +354,12 @@ section equality
 by cases h
    exact rfl
 
+lemma congr_arg2 {α β γ : Type _} (f : α → β → γ) {x x' : α} {y y' : β}
+  (hx : x = x') (hy : y = y') : f x y = f x' y' :=
+by subst hx
+   subst hy
+   exact rfl
+
 end equality
 
 @[simp] theorem forall_const (α : Sort _) [i : Nonempty α] : (α → b) ↔ b :=
@@ -385,6 +391,9 @@ by simp [and_comm]
 @[simp] theorem exists_eq_left' {p : α → Prop} {a' : α} : (∃ a, a' = a ∧ p a) ↔ p a' :=
 by simp [@eq_comm _ a']
 
+@[simp] theorem exists_apply_eq_apply {α β : Type _} (f : α → β) (a' : α) : ∃ a, f a = f a' :=
+⟨a', rfl⟩
+
 protected theorem decidable.not_imp_symm [Decidable a] (h : ¬a → b) (hb : ¬b) : a :=
 Decidable.by_contradiction $ hb ∘ h
 
@@ -403,6 +412,26 @@ exists_imp_distrib
 
 theorem forall_prop_of_true {p : Prop} {q : p → Prop} (h : p) : (∀ h' : p, q h') ↔ q h :=
 @forall_const (q h) p ⟨h⟩
+
+/-- A function applied to a `dite` is a `dite` of that function applied to each of the branches. -/
+lemma apply_dite {α β : Sort _} (f : α → β) (P : Prop) [Decidable P] (x : P → α) (y : ¬ P → α) :
+  f (dite P x y) = dite P (λ h => f (x h)) (λ h => f (y h)) :=
+by by_cases h : P <;> simp[h]
+
+/-- A function applied to a `int` is a `ite` of that function applied to each of the branches. -/
+lemma apply_ite {α β : Sort _} (f : α → β) (P : Prop) [Decidable P] (x y : α) :
+  f (ite P x y) = ite P (f x) (f y) :=
+apply_dite f P (λ _ => x) (λ _ => y)
+
+/-- Negation of the condition `P : Prop` in a `dite` is the same as swapping the branches. -/
+@[simp] lemma dite_not {α : Sort _} (P : Prop) [Decidable P]  (x : ¬ P → α) (y : ¬¬ P → α) :
+  dite (¬ P) x y = dite P (λ h => y (not_not_intro h)) x :=
+by by_cases h : P <;> simp[h]
+
+/-- Negation of the condition `P : Prop` in a `ite` is the same as swapping the branches. -/
+@[simp] lemma ite_not {α : Sort _} (P : Prop) [Decidable P] (x y : α) :
+ ite (¬ P) x y = ite P y x :=
+dite_not P (λ _ => x) (λ _ => y)
 
 open Classical
 

--- a/Mathlib/Logic/Basic.lean
+++ b/Mathlib/Logic/Basic.lean
@@ -347,6 +347,18 @@ Iff.intro (λ h ha hb => h ⟨ha, hb⟩) (λ h ⟨ha, hb⟩ => h ha hb)
 
 @[simp] theorem not_and : ¬ (a ∧ b) ↔ (a → ¬ b) := and_imp
 
+section equality
+
+@[simp] lemma eq_rec_constant {α : Sort _} {a a' : α} {β : Sort _} (y : β) (h : a = a') :
+  (@Eq.rec α a (λ α _ => β) y a' h) = y :=
+by cases h
+   exact rfl
+
+end equality
+
+@[simp] theorem forall_const (α : Sort _) [i : Nonempty α] : (α → b) ↔ b :=
+⟨i.elim, λ hb x => hb⟩
+
 @[simp] theorem exists_imp_distrib {p : α → Prop} : ((∃ x, p x) → b) ↔ ∀ x, p x → b :=
 ⟨λ h x hpx => h ⟨x, hpx⟩, λ h ⟨x, hpx⟩ => h x hpx⟩
 
@@ -388,6 +400,9 @@ protected theorem Decidable.not_forall {p : α → Prop}
 
 @[simp] theorem not_exists {p : α → Prop} : (¬ ∃ x, p x) ↔ ∀ x, ¬ p x :=
 exists_imp_distrib
+
+theorem forall_prop_of_true {p : Prop} {q : p → Prop} (h : p) : (∀ h' : p, q h') ↔ q h :=
+@forall_const (q h) p ⟨h⟩
 
 open Classical
 

--- a/Mathlib/Logic/Function/Basic.lean
+++ b/Mathlib/Logic/Function/Basic.lean
@@ -6,6 +6,7 @@ Authors: Johannes Hölzl, Mario Carneiro
 import Mathlib.Logic.Basic
 import Mathlib.Function
 import Mathlib.Set
+import Mathlib.SetNotation
 
 universe u v w
 
@@ -280,3 +281,221 @@ theorem partial_inv_left {α β} {f : α → β} (I : injective f) : ∀ x, part
 is_partial_inv_left (partial_inv_of_injective I)
 
 end
+
+section inv_fun
+variable {α : Type u} [n : Nonempty α] {β : Sort v} {f : α → β} {s : Set α} {a : α} {b : β}
+attribute [local instance] Classical.propDecidable
+
+/-- Construct the inverse for a function `f` on domain `s`. This function is a right inverse of `f`
+on `f '' s`. For a computable version, see `function.injective.inv_of_mem_range`. -/
+noncomputable def inv_fun_on (f : α → β) (s : Set α) (b : β) : α :=
+if h : ∃a, a ∈ s ∧ f a = b then Classical.choose h else Classical.choice n
+
+theorem inv_fun_on_pos (h : ∃a∈s, f a = b) : inv_fun_on f s b ∈ s ∧ f (inv_fun_on f s b) = b :=
+by have h1 : inv_fun_on f s b =
+     if h : ∃a, a ∈ s ∧ f a = b then Classical.choose h else Classical.choice n := rfl
+   rw [dif_pos h] at h1
+   rw [h1]
+   exact Classical.chooseSpec h
+
+theorem inv_fun_on_mem (h : ∃a∈s, f a = b) : inv_fun_on f s b ∈ s := (inv_fun_on_pos h).left
+
+theorem inv_fun_on_eq (h : ∃a∈s, f a = b) : f (inv_fun_on f s b) = b := (inv_fun_on_pos h).right
+
+theorem inv_fun_on_eq' (h : ∀ x ∈ s, ∀ y ∈ s, f x = f y → x = y) (ha : a ∈ s) :
+  inv_fun_on f s (f a) = a :=
+have : ∃a'∈s, f a' = f a := ⟨a, ha, rfl⟩
+h _ (inv_fun_on_mem this) _ ha (inv_fun_on_eq this)
+
+theorem inv_fun_on_neg (h : ¬ ∃a∈s, f a = b) : inv_fun_on f s b = Classical.choice n :=
+by have h1 : inv_fun_on f s b =
+     if h : ∃a, a ∈ s ∧ f a = b then Classical.choose h else Classical.choice n := rfl
+   rwa [dif_neg h] at h1
+
+/-- The inverse of a function (which is a left inverse if `f` is injective
+  and a right inverse if `f` is surjective). -/
+noncomputable def inv_fun (f : α → β) : β → α := inv_fun_on f Set.univ
+
+theorem inv_fun_eq (h : ∃a, f a = b) : f (inv_fun f b) = b :=
+inv_fun_on_eq $ let ⟨a, ha⟩ := h
+                ⟨a, trivial, ha⟩
+
+lemma inv_fun_neg (h : ¬ ∃ a, f a = b) : inv_fun f b = Classical.choice n :=
+by refine inv_fun_on_neg (mt ?_ h); exact λ ⟨a, _, ha⟩ => ⟨a, ha⟩
+
+theorem inv_fun_eq_of_injective_of_right_inverse {g : β → α}
+  (hf : injective f) (hg : right_inverse g f) : inv_fun f = g :=
+funext $ λ b => hf (by rw [hg b]
+                       exact inv_fun_eq ⟨g b, hg b⟩)
+
+lemma right_inverse_inv_fun (hf : surjective f) : right_inverse (inv_fun f) f :=
+λ b => inv_fun_eq $ hf b
+
+lemma left_inverse_inv_fun (hf : injective f) : left_inverse (inv_fun f) f :=
+λ b => have : f (inv_fun f (f b)) = f b := inv_fun_eq ⟨b, rfl⟩
+       hf this
+
+lemma inv_fun_surjective (hf : injective f) : surjective (inv_fun f) :=
+(left_inverse_inv_fun hf).surjective
+
+lemma inv_fun_comp (hf : injective f) : inv_fun f ∘ f = id := funext $ left_inverse_inv_fun hf
+
+end inv_fun
+
+section inv_fun
+variable {α : Type u} [i : Nonempty α] {β : Sort v} {f : α → β}
+
+lemma injective.has_left_inverse (hf : injective f) : has_left_inverse f :=
+⟨inv_fun f, left_inverse_inv_fun hf⟩
+
+lemma injective_iff_has_left_inverse : injective f ↔ has_left_inverse f :=
+⟨injective.has_left_inverse, has_left_inverse.injective⟩
+
+end inv_fun
+
+section surj_inv
+variable {α : Sort u} {β : Sort v} {f : α → β}
+
+/-- The inverse of a surjective function. (Unlike `inv_fun`, this does not require
+  `α` to be inhabited.) -/
+noncomputable def surj_inv {f : α → β} (h : surjective f) (b : β) : α := Classical.choose (h b)
+
+lemma surj_inv_eq (h : surjective f) (b) : f (surj_inv h b) = b := Classical.chooseSpec (h b)
+
+lemma right_inverse_surj_inv (hf : surjective f) : right_inverse (surj_inv hf) f :=
+surj_inv_eq hf
+
+lemma left_inverse_surj_inv (hf : bijective f) : left_inverse (surj_inv hf.2) f :=
+right_inverse_of_injective_of_left_inverse hf.1 (right_inverse_surj_inv hf.2)
+
+lemma surjective.has_right_inverse (hf : surjective f) : has_right_inverse f :=
+⟨_, right_inverse_surj_inv hf⟩
+
+lemma surjective_iff_has_right_inverse : surjective f ↔ has_right_inverse f :=
+⟨surjective.has_right_inverse, has_right_inverse.surjective⟩
+
+lemma bijective_iff_has_inverse : bijective f ↔ ∃ g, left_inverse g f ∧ right_inverse g f :=
+⟨λ hf =>  ⟨_, left_inverse_surj_inv hf, right_inverse_surj_inv hf.2⟩,
+ λ ⟨g, gl, gr⟩ => ⟨gl.injective,  gr.surjective⟩⟩
+
+lemma injective_surj_inv (h : surjective f) : injective (surj_inv h) :=
+(right_inverse_surj_inv h).injective
+
+lemma surjective_to_subsingleton [na : Nonempty α] [Subsingleton β] (f : α → β) :
+  surjective f :=
+λ y => let ⟨a⟩ := na; ⟨a, Subsingleton.elim _ _⟩
+
+end surj_inv
+
+section update
+variable {α : Sort u} {β : α → Sort v} {α' : Sort w} [DecidableEq α] [DecidableEq α']
+
+/-- Replacing the value of a function at a given point by a given value. -/
+def update (f : ∀a, β a) (a' : α) (v : β a') (a : α) : β a :=
+if h : a = a' then Eq.rec (motive := λ a _ => β a) v h.symm else f a
+
+/-- On non-dependent functions, `function.update` can be expressed as an `ite` -/
+lemma update_apply {β : Sort _} (f : α → β) (a' : α) (b : β) (a : α) :
+  update f a' b a = if a = a' then b else f a :=
+by have h2 : (h : a = a') → Eq.rec (motive := λ a b => β) b h.symm = b :=
+     by intro h
+        rw [eq_rec_constant]
+   have h3 : (λ h : a = a' => Eq.rec (motive := λ a b => β) b h.symm) =
+             (λ _ : a = a' =>  b) := funext h2
+   let f := λ x => dite (a = a') x (λ (_: ¬ a = a') => (f a))
+   exact congrArg f h3
+
+@[simp] lemma update_same (a : α) (v : β a) (f : ∀a, β a) : update f a v a = v :=
+dif_pos rfl
+
+lemma update_injective (f : ∀a, β a) (a' : α) : injective (update f a') :=
+by intros v v' h
+   have h' := congrFun h a'
+   rwa [update_same, update_same] at h'
+
+@[simp] lemma update_noteq {a a' : α} (h : a ≠ a') (v : β a') (f : ∀a, β a) :
+  update f a' v a = f a :=
+dif_neg h
+
+lemma forall_update_iff (f : ∀a, β a) {a : α} {b : β a} (p : ∀a, β a → Prop) :
+  (∀ x, p x (update f a b x)) ↔ p a b ∧ ∀ x, x ≠ a → p x (f x) :=
+by have h1 : (∀ x, p x (update f a b x)) ↔ ∀ x, (x = a ∨ x ≠ a) → p x (update f a b x) :=
+     by simp only [Classical.em]
+        have h4: ∀ (x : α), ((True → p x (update f a b x)) ↔ p x (update f a b x)) :=
+          by intro x; rw [forall_const]
+        rw [forall_congr h4]
+   have h3 : (∀ x, (x = a ∨ x ≠ a) → p x (update f a b x)) ↔ p a b ∧ ∀ x, x ≠ a → p x (f x) :=
+     by simp [or_imp_distrib, forall_and_distrib]
+        admit
+   rw [h1, h3]
+
+lemma update_eq_iff {a : α} {b : β a} {f g : ∀ a, β a} :
+  update f a b = g ↔ b = g a ∧ ∀ x, x ≠ a -> f x = g x :=
+funext_iff.trans $ forall_update_iff _ (λ x y => y = g x)
+
+lemma eq_update_iff {a : α} {b : β a} {f g : ∀ a, β a} :
+  g = update f a b ↔ g a = b ∧ ∀ x, x ≠ a -> g x = f x :=
+funext_iff.trans $ forall_update_iff _ (λ x y => g x = y)
+
+@[simp] lemma update_eq_self (a : α) (f : ∀a, β a) : update f a (f a) = f :=
+update_eq_iff.2 ⟨rfl, λ _ _ => rfl⟩
+
+lemma update_comp_eq_of_forall_ne' {α'} (g : ∀ a, β a) {f : α' → α} {i : α} (a : β i)
+  (h : ∀ x, f x ≠ i) :
+  (λ j => (update g i a) (f j)) = (λ j => g (f j)) :=
+funext $ λ x => update_noteq (h _) _ _
+
+/-- Non-dependent version of `function.update_comp_eq_of_forall_ne'` -/
+lemma update_comp_eq_of_forall_ne {α β : Sort _} (g : α' → β) {f : α → α'} {i : α'} (a : β)
+  (h : ∀ x, f x ≠ i) :
+  (update g i a) ∘ f = g ∘ f :=
+update_comp_eq_of_forall_ne' g a h
+
+lemma update_comp_eq_of_injective' (g : ∀a, β a) {f : α' → α} (hf : Function.injective f)
+  (i : α') (a : β (f i)) :
+  (λ j => update g (f i) a (f j)) = update (λ i => g (f i)) i a :=
+eq_update_iff.2 ⟨update_same _ _ _, λ j hj => update_noteq (hf.ne hj) _ _⟩
+
+/-- Non-dependent version of `function.update_comp_eq_of_injective'` -/
+lemma update_comp_eq_of_injective {β : Sort _} (g : α' → β) {f : α → α'}
+  (hf : Function.injective f) (i : α) (a : β) :
+  (Function.update g (f i) a) ∘ f = Function.update (g ∘ f) i a :=
+update_comp_eq_of_injective' g hf i a
+
+lemma apply_update {ι : Sort _} [DecidableEq ι] {α β : ι → Sort _}
+  (f : ∀i, α i → β i) (g : ∀i, α i) (i : ι) (v : α i) (j : ι) :
+  f j (update g i v j) = update (λ k => f k (g k)) i (f i v) j :=
+by by_cases h : j = i
+   subst j; simp
+   simp[h]
+
+lemma comp_update {α' : Sort _} {β : Sort _} (f : α' → β) (g : α → α') (i : α) (v : α') :
+  f ∘ (update g i v) = update (f ∘ g) i (f v) :=
+funext $ apply_update _ _ _ _
+
+theorem update_comm {α} [DecidableEq α] {β : α → Sort _}
+  {a b : α} (h : a ≠ b) (v : β a) (w : β b) (f : ∀a, β a) :
+  update (update f a v) b w = update (update f b w) a v :=
+by funext c
+   simp only [update]
+   by_cases h₁ : c = b <;> by_cases h₂ : c = a
+
+   -- case 1
+   rw [dif_pos h₁, dif_pos h₂]
+   cases h (h₂.symm.trans h₁)
+
+   -- case 2
+   rw [dif_pos h₁, dif_pos h₁, dif_neg h₂]
+
+   -- case 3
+   rw [dif_neg h₁, dif_neg h₁, dif_pos h₂]
+
+   -- case 4
+   rw [dif_neg h₁, dif_neg h₁, dif_neg h₂]
+
+@[simp] theorem update_idem {α} [DecidableEq α] {β : α → Sort _}
+  {a : α} (v w : β a) (f : ∀a, β a) : update (update f a v) a w = update f a w :=
+by funext b
+   by_cases b = a <;> simp [update, h]
+
+end update

--- a/Mathlib/Logic/Function/Basic.lean
+++ b/Mathlib/Logic/Function/Basic.lean
@@ -487,20 +487,12 @@ theorem update_comm {α} [DecidableEq α] {β : α → Sort _}
   update (update f a v) b w = update (update f b w) a v :=
 by funext c
    simp only [update]
-   by_cases h₁ : c = b <;> by_cases h₂ : c = a
-
-   -- case 1
-   rw [dif_pos h₁, dif_pos h₂]
-   cases h (h₂.symm.trans h₁)
-
-   -- case 2
-   rw [dif_pos h₁, dif_pos h₁, dif_neg h₂]
-
-   -- case 3
-   rw [dif_neg h₁, dif_neg h₁, dif_pos h₂]
-
-   -- case 4
-   rw [dif_neg h₁, dif_neg h₁, dif_neg h₂]
+   (by_cases h₁ : c = b <;> by_cases h₂ : c = a)
+   - rw [dif_pos h₁, dif_pos h₂]
+     (cases h (h₂.symm.trans h₁))
+   - rw [dif_pos h₁, dif_pos h₁, dif_neg h₂]
+   - rw [dif_neg h₁, dif_neg h₁, dif_pos h₂]
+   - rw [dif_neg h₁, dif_neg h₁, dif_neg h₂]
 
 @[simp] theorem update_idem {α} [DecidableEq α] {β : α → Sort _}
   {a : α} (v w : β a) (f : ∀a, β a) : update (update f a v) a w = update f a w :=

--- a/Mathlib/Logic/Function/Basic.lean
+++ b/Mathlib/Logic/Function/Basic.lean
@@ -419,15 +419,24 @@ dif_neg h
 
 lemma forall_update_iff (f : ∀a, β a) {a : α} {b : β a} (p : ∀a, β a → Prop) :
   (∀ x, p x (update f a b x)) ↔ p a b ∧ ∀ x, x ≠ a → p x (f x) :=
-by have h1 : (∀ x, p x (update f a b x)) ↔ ∀ x, (x = a ∨ x ≠ a) → p x (update f a b x) :=
-     by simp only [Classical.em]
-        have h4: ∀ (x : α), ((True → p x (update f a b x)) ↔ p x (update f a b x)) :=
-          by intro x; rw [forall_const]
-        rw [forall_congr h4]
-   have h3 : (∀ x, (x = a ∨ x ≠ a) → p x (update f a b x)) ↔ p a b ∧ ∀ x, x ≠ a → p x (f x) :=
-     by simp [or_imp_distrib, forall_and_distrib]
-        admit
-   rw [h1, h3]
+Iff.intro
+  (by intro h
+      have h1 := h a
+      have h2 : update f a b a = b := update_same _ _ _
+      rw [h2] at h1
+      refine ⟨h1, ?_⟩
+      intro x hx
+      have h3 := update_noteq hx b f
+      rw [←h3]
+      exact h x)
+  (by intro ⟨hp,h⟩ x
+      have h1 : x = a ∨ x ≠ a := Classical.em _
+      match h1 with
+      | Or.inl he => rw [he, update_same]
+                     exact hp
+      | Or.inr hne => have h4 := update_noteq hne b f
+                      rw [h4]
+                      exact h x hne)
 
 lemma update_eq_iff {a : α} {b : β a} {f g : ∀ a, β a} :
   update f a b = g ↔ b = g a ∧ ∀ x, x ≠ a -> f x = g x :=


### PR DESCRIPTION
This is a continuation of #24, porting all but a handful of the remaining items, and adding a `TODO` for all of the unported items.

Also adds some needed items in `Logic/Basic.lean`.