### PR TITLE
update lean to nightly-2021-08-06

### DIFF
--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -952,7 +952,9 @@ theorem erasep_map (f : β → α) :
   ∀ (l : List β), (map f l).erasep p = map f (l.erasep (p ∘ f))
 | []     => rfl
 | (b::l) => by
-  byCases h : p (f b) <;> simp [h, erasep_map f l]
+  byCases h : p (f b) <;> simp [erasep, h, erasep_map f l]
+  - simp [if_pos h]
+  - simp [if_neg h]
 
 -- @[simp] theorem extractp_eq_find_erasep :
 --   ∀ l : List α, extractp p l = (find p l, erasep p l)

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -952,9 +952,9 @@ theorem erasep_map (f : β → α) :
   ∀ (l : List β), (map f l).erasep p = map f (l.erasep (p ∘ f))
 | []     => rfl
 | (b::l) => by
-  byCases h : p (f b) <;> simp [erasep, h, erasep_map f l]
-  - simp [if_pos h]
-  - simp [if_neg h]
+  (byCases h : p (f b))
+  - simp [h, erasep_map f l, @erasep_cons_of_pos β (p ∘ f) _ b l h]
+  - simp [h, erasep_map f l, @erasep_cons_of_neg β (p ∘ f) _ b l h]
 
 -- @[simp] theorem extractp_eq_find_erasep :
 --   ∀ l : List α, extractp p l = (find p l, erasep p l)

--- a/Mathlib/Tactic/OpenPrivate.lean
+++ b/Mathlib/Tactic/OpenPrivate.lean
@@ -30,7 +30,7 @@ def elabOpenPrivateLike (ids : Array Syntax) (tgts mods : Option (Array Syntax))
   (f : (priv full user : Name) → CommandElabM Name) : CommandElabM Unit := do
   let mut names := NameSet.empty
   for tgt in tgts.getD #[] do
-    let n ← resolveGlobalConstNoOverload tgt.getId
+    let n ← resolveGlobalConstNoOverload tgt
     names ← Meta.collectPrivateIn n names
   for mod in mods.getD #[] do
     let some modIdx ← (← getEnv).moduleIdxForModule? mod.getId

--- a/Mathlib/Tactic/PrintPrefix.lean
+++ b/Mathlib/Tactic/PrintPrefix.lean
@@ -47,9 +47,9 @@ the namespace `foo`.
 -/
 @[commandElab printPrefix] def elabPrintPrefix : CommandElab
 | `(#print prefix%$tk $name:ident) => do
-  let name := name.getId
+  let nameId := name.getId
   liftTermElabM none do
-    let mut msg ← find "" fun cinfo => name.isPrefixOf cinfo.name
+    let mut msg ← find "" fun cinfo => nameId.isPrefixOf cinfo.name
     if msg.isEmpty then
       if let [name] ← resolveGlobalConst name then
         msg ← find msg fun cinfo => name.isPrefixOf cinfo.name

--- a/leanpkg.toml
+++ b/leanpkg.toml
@@ -1,4 +1,4 @@
 [package]
 name = "mathlib4"
 version = "0.1"
-lean_version = "leanprover/lean4:nightly-2021-07-27"
+lean_version = "leanprover/lean4:nightly-2021-08-06"


### PR DESCRIPTION
- Accounts for new signatures of `resolveGlobalConst` and `resolveGlobalConstNoOverload`, from https://github.com/leanprover/lean4/pull/583.
- Fixes the proof of `erasep_map`. Something changed between `nightly-2021-07-29` and `nightly-2021-07-30` and broke the proof. (It might be worthwhile to investigate exactly what changed there.)
- Avoids dealing with the mass renamings from https://github.com/leanprover/lean4/commit/a821dcbff25b1323b213f275ae77860b42021fee for now. Those will make for a much larger revision.