### PR TITLE
update lean to nightly-2021-08-11

### DIFF
--- a/Mathlib/Algebra/Ring/Basic.lean
+++ b/Mathlib/Algebra/Ring/Basic.lean
@@ -37,7 +37,7 @@ class Ring (R : Type u) extends Monoid R, AddCommGroup R, Numeric R where
 
 instance (R : Type u) [Ring R] : Semiring R where
   zero_mul := λ a => by rw [← add_right_eq_self (a := 0 * a), ← Ring.add_mul, zero_add]
-  mul_zero := λ a => by rw [← add_right_eq_self (a := a * 0), ← Ring.mul_add, add_zero]
+  mul_zero := λ a => by rw [← add_right_eq_self (a := a * 0), ← Ring.mul_add]; simp
   __ := ‹Ring R›
 
 class CommRing (R : Type u) extends Ring R where

--- a/Mathlib/Data/Array/Basic.lean
+++ b/Mathlib/Data/Array/Basic.lean
@@ -15,7 +15,9 @@ theorem ext' : {a b : Array α} → a.data = b.data → a = b
 @[simp] theorem data_toArray : (a : Array α) → a.data.toArray = a
 | ⟨l⟩ => ext' l.toArray_data
 
-theorem toArrayLit_eq (a : Array α) (n : Nat) (hsz : a.size = n) : a = toArrayLit a n hsz := by
+-- Port note: The Lean 4 core library has `toArrayLit_eq` with the same signature as this,
+-- but currently its proof is `sorry`.
+theorem toArrayLit_eq' (a : Array α) (n : Nat) (hsz : a.size = n) : a = toArrayLit a n hsz := by
   have := aux n
   rw [List.drop_eq_nil_of_le (Nat.le_of_eq hsz)] at this
   exact (data_toArray a).symm.trans $ congrArg List.toArray (this _).symm

--- a/Mathlib/Data/ByteArray.lean
+++ b/Mathlib/Data/ByteArray.lean
@@ -85,7 +85,7 @@ def String.toAsciiByteArray.loop (s : String) (out : ByteArray) (p : Pos) : Byte
     let c := s.get p
     IH (s.next p) (out := out.push c.toUInt8)
       ⟨Nat.lt_add_of_pos_right (String.csize_pos _),
-      Nat.lt_of_not_le (mt decideEqTrue h)⟩
+      Nat.lt_of_not_le (mt decide_eq_true h)⟩
 
 /-- Convert a string of assumed-ASCII characters into a byte array.
 (If any characters are non-ASCII they will be reduced modulo 256.) -/

--- a/Mathlib/Data/Int/Basic.lean
+++ b/Mathlib/Data/Int/Basic.lean
@@ -299,7 +299,7 @@ sub_nat_nat (m - n) k = sub_nat_nat m (k + n) := by
 
 lemma sub_nat_nat_add (m n k : ℕ) : sub_nat_nat (m + n) k = ofNat m + sub_nat_nat n k :=
 by
-  have h := Nat.lt_or_le n k
+  have h := Nat.lt_or_ge n k
   cases h with
   | inl h' =>
     rw [sub_nat_nat_of_lt h']
@@ -318,7 +318,7 @@ by
 lemma sub_nat_nat_add_neg_succ_of_nat (m n k : ℕ) :
     sub_nat_nat m n + -[1+ k] = sub_nat_nat m (n + succ k) :=
 by
-  have h := Nat.lt_or_le m n
+  have h := Nat.lt_or_ge m n
   cases h with
   | inr h' =>
     rw [sub_nat_nat_of_le h']
@@ -422,7 +422,7 @@ by
   | zero =>
     simp [of_nat_zero, Int.zero_mul, Nat.zero_mul]
   | succ m =>
-    have h := Nat.lt_or_le n k
+    have h := Nat.lt_or_ge n k
     cases h with
     | inl h =>
       have h' : (succ m) * n < (succ m) * k := Nat.mul_lt_mul_of_pos_left h (Nat.succ_pos m)
@@ -447,14 +447,14 @@ lemma neg_of_nat_add : ∀ m n : ℕ, neg_of_nat m + neg_of_nat n = neg_of_nat (
 lemma neg_succ_of_nat_mul_sub_nat_nat (m n k : ℕ) :
   -[1+ m] * sub_nat_nat n k = sub_nat_nat (succ m * k) (succ m * n) :=
 by
-  have h := Nat.lt_or_le n k
+  have h := Nat.lt_or_ge n k
   cases h with
   | inl h =>
     have h' : succ m * n < succ m * k := Nat.mul_lt_mul_of_pos_left h (Nat.succ_pos m)
     rw [sub_nat_nat_of_lt h, sub_nat_nat_of_le (Nat.le_of_lt h')]
     simp [succ_pred_eq_of_pos (Nat.sub_pos_of_lt h), Nat.mul_sub_left_distrib]
   | inr h =>
-    cases Nat.lt_or_le k n with
+    cases Nat.lt_or_ge k n with
     | inl h' =>
 
       have h₁ : succ m * n > succ m * k := Nat.mul_lt_mul_of_pos_left h' (Nat.succ_pos m)

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -202,7 +202,7 @@ Iff.intro
  (fun ⟨pa, al⟩ x o => o.elim (fun e => by rw [e]; exact pa) (al x))
 
 instance decidableMem [DecidableEq α] (a : α) : ∀ (l : List α), Decidable (a ∈ l)
-  | []     => isFalse notFalse
+  | []     => isFalse not_false
   | b :: l =>
     if h₁ : a = b then isTrue (Or.inl h₁)
     else match decidableMem a l with

--- a/Mathlib/Data/Nat/Basic.lean
+++ b/Mathlib/Data/Nat/Basic.lean
@@ -5,78 +5,6 @@ notation "ℕ" => Nat
 
 namespace Nat
 
--- Edits to the naming convention pending upstream
-def eq_of_beq_eq_true := @eqOfBeqEqTrue
-def ne_of_beq_eq_false := @neOfBeqEqFalse
-@[simp] lemma not_succ_le_zero : ∀ n, ¬ succ n ≤ 0 := @notSuccLeZero
-def not_lt_zero := @notLtZero
-def zero_le := @zeroLe
-def succ_le_succ := @succLeSucc
-def zero_lt_succ := @zeroLtSucc
-def le_step := @leStep
-protected def le_trans := @Nat.leTrans
-protected def lt_trans := @Nat.ltTrans
-def le_succ := @leSucc
-def le_succ_of_le := @leSuccOfLe
-protected def eq_or_lt_of_le := @Nat.eqOrLtOfLe
-protected def le_refl := @Nat.leRefl
-protected def lt_or_le : (n m : ℕ) → n < m ∨ m ≤ n := @Nat.ltOrGe
-protected def le_antisymm := @Nat.leAntisymm
-protected def lt_of_le_of_ne := @Nat.ltOfLeAndNe
-def pred_le_pred := @predLePred
-def le_of_succ_le_succ := @leOfSuccLeSucc
-def le_of_lt_succ := @leOfLtSucc
-def zero_eq := @zero_Eq
-def succ_eq_add_one := @succ_Eq_add_one
-protected def mul_add := @Nat.left_distrib
-protected def add_mul := @Nat.right_distrib
-def not_succ_le_self := @notSuccLeSelf
-protected def lt_irrefl := @Nat.ltIrrefl
-def pred_le := @predLe
-def pred_lt := @predLt
-def sub_le := @subLe
-def sub_lt := @subLt
-protected def lt_of_lt_of_le := @Nat.ltOfLtOfLe
-protected def lt_of_lt_of_eq := @Nat.ltOfLtOfEq
-protected def le_of_eq := @Nat.leOfEq
-def le_of_succ_le := @leOfSuccLe
-protected def le_of_lt := @Nat.leOfLt
-def succ_pos := @succPos
-lemma eq_zero_or_pos : (n : ℕ) → n = 0 ∨ 0 < n := @eqZeroOrPos
-def lt_succ_self := @ltSuccSelf
-protected def le_total := @Nat.leTotal
-def eq_zero_of_le_zero := @eqZeroOfLeZero
-def lt_of_succ_lt := @ltOfSuccLt
-def lt_of_succ_le := @ltOfSuccLe
-def succ_le_of_lt := @succLeOfLt
-def lt_or_eq_of_le_succ := @ltOrEqOrLeSucc
-def le_add_right := @leAddRight
-def le_add_left := @leAddLeft
-protected lemma not_le_of_gt : {n m : ℕ} → m < n → ¬ n ≤ m := @Nat.notLeOfGt
-protected lemma lt_of_not_ge : {n m : ℕ} → ¬ n ≤ m → m < n := @Nat.gtOfNotLe
-protected def add_le_add_left := @Nat.addLeAddLeft
-protected def add_le_add_right := @Nat.addLeAddRight
-protected def add_lt_add_left := @Nat.addLtAddLeft
-protected def add_lt_add_right := @Nat.addLtAddRight
-protected def zero_lt_one := @Nat.zeroLtOne
-protected def add_le_add := @Nat.addLeAdd
-protected def add_lt_add := @Nat.addLtAdd
-def nat_zero_eq_zero := @natZeroEqZero
-protected def one_ne_zero := @Nat.oneNeZero
-protected def zero_ne_one := @Nat.zeroNeOne
-def succ_ne_zero := @succNeZero
-protected def mul_le_mul_left := @mulLeMulLeft
-protected def mul_le_mul_right := @mulLeMulRight
-protected def mul_le_mul := @Nat.mulLeMul
-protected def mul_lt_mul_of_pos_left := @Nat.mulLtMulOfPosLeft
-protected def mul_lt_mul_of_pos_right := @Nat.mulLtMulOfPosRight
-protected def mul_pos := @Nat.mulPos
-def pow_succ := @Nat.powSucc
-def pow_zero := @Nat.powZero
-def pow_le_pow_of_le_left := @Nat.powLePowOfLeLeft
-def pow_le_pow_of_le_right := @Nat.powLePowOfLeRight
-def pos_pos_of_pos := @Nat.posPowOfPos
-
 lemma succ_ne_self : ∀ n : ℕ, succ n ≠ n
 | 0,   h => absurd h (Nat.succ_ne_zero 0)
 | n+1, h => succ_ne_self n (Nat.noConfusion h id)
@@ -107,9 +35,9 @@ protected lemma pos_iff_ne_zero {n : ℕ} : 0 < n ↔ n ≠ 0 := by
 
 protected lemma not_lt_of_le {n m : ℕ} (h₁ : m ≤ n) : ¬ n < m | h₂ => Nat.not_le_of_gt h₂ h₁
 
-protected lemma lt_of_not_le {a b : ℕ} : ¬ a ≤ b → b < a := (Nat.lt_or_le b a).resolve_right
+protected lemma lt_of_not_le {a b : ℕ} : ¬ a ≤ b → b < a := (Nat.lt_or_ge b a).resolve_right
 
-protected lemma le_or_le (a b : ℕ) : a ≤ b ∨ b ≤ a := (Nat.lt_or_le _ _).imp_left Nat.le_of_lt
+protected lemma le_or_le (a b : ℕ) : a ≤ b ∨ b ≤ a := (Nat.lt_or_ge _ _).imp_left Nat.le_of_lt
 
 protected lemma le_of_not_le {a b : ℕ} : ¬ a ≤ b → b ≤ a := (Nat.le_or_le _ _).resolve_left
 
@@ -120,13 +48,10 @@ protected lemma le_of_not_le {a b : ℕ} : ¬ a ≤ b → b ≤ a := (Nat.le_or_
 ⟨Nat.lt_of_not_le, Nat.not_lt_of_le⟩
 
 protected lemma lt_or_eq_of_le {n m : ℕ} (h : n ≤ m) : n < m ∨ n = m :=
-(Nat.lt_or_le _ _).imp_right (Nat.le_antisymm h)
-
-protected lemma lt_of_le_of_lt {n m k : ℕ} (h₁ : n ≤ m) : m < k → n < k :=
-Nat.le_trans (succ_le_succ h₁)
+(Nat.lt_or_ge _ _).imp_right (Nat.le_antisymm h)
 
 protected lemma lt_iff_le_not_le {m n : ℕ} : m < n ↔ m ≤ n ∧ ¬ n ≤ m :=
-⟨fun h => ⟨Nat.le_of_lt h, Nat.not_le_of_gt h⟩, fun h => Nat.lt_of_not_ge h.2⟩
+⟨fun h => ⟨Nat.le_of_lt h, Nat.not_le_of_gt h⟩, fun h => Nat.gt_of_not_le h.2⟩
 
 lemma pred_lt_pred : ∀ {n m : ℕ}, n ≠ 0 → n < m → pred n < pred m
 | 0,   _,   h, _ => (h rfl).elim
@@ -262,7 +187,7 @@ protected lemma lt_of_add_lt_add_right {a b c : ℕ} (h : a + b < c + b) : a < c
 
 protected lemma sub_pos_of_lt (h : m < n) : 0 < n - m := by
   apply Nat.lt_of_add_lt_add_right (b := m)
-  rw [Nat.zero_add, Nat.sub_add_cancel (Nat.leOfLt h)]; exact h
+  rw [Nat.zero_add, Nat.sub_add_cancel (Nat.le_of_lt h)]; exact h
 
 protected lemma sub_lt_sub_left : ∀ {k m n : ℕ} (H : k < m) (h : k < n), m - n < m - k
 | 0, m+1, n+1, _, _ => by rw [Nat.add_sub_add_right]; exact lt_succ_of_le (Nat.sub_le _ _)
@@ -351,7 +276,7 @@ lemma le_div_iff_mul_le (k0 : 0 < k) : x ≤ y / k ↔ x * k ≤ y := by
   induction y, k using mod.inductionOn generalizing x with
     (rw [div_eq]; simp [h]; cases x with simp [zero_le] | succ x => ?_)
   | base y k h =>
-    simp [succ_mul, Nat.add_comm]
+    simp [eq_false (not_succ_le_zero x), succ_mul, Nat.add_comm]
     refine Nat.lt_of_lt_of_le ?_ (Nat.le_add_right _ _)
     exact Nat.lt_of_not_le fun h' => h ⟨k0, h'⟩
   | ind y k h IH =>
@@ -601,7 +526,7 @@ else by
   | _ n IH =>
     have y0 : y > 0 := Nat.pos_of_ne_zero y0
     have z0 : z > 0 := Nat.pos_of_ne_zero z0
-    cases Nat.lt_or_le n y with
+    cases Nat.lt_or_ge n y with
     | inl yn => rw [mod_eq_of_lt yn, mod_eq_of_lt (Nat.mul_lt_mul_of_pos_left yn z0)]
     | inr yn =>
       rw [mod_eq_sub_mod yn, mod_eq_sub_mod (Nat.mul_le_mul_left z yn),

--- a/Mathlib/Data/Nat/Gcd.lean
+++ b/Mathlib/Data/Nat/Gcd.lean
@@ -75,13 +75,13 @@ theorem le_of_dvd {m n : ℕ} (h : 0 < n) : m ∣ n → m ≤ n :=
    | 0 => intro hn
           simp at hn
    | pk+1 => intro _
-             let t := Nat.mul_le_mul_left m (succPos pk)
+             let t := Nat.mul_le_mul_left m (succ_pos pk)
              rwa [Nat.mul_one] at t
 
 theorem dvd_antisymm : ∀ {m n : ℕ}, m ∣ n → n ∣ m → m = n
 | m,     0, h₁, h₂ => Nat.eq_zero_of_zero_dvd h₂
 | 0,     n, h₁, h₂ => (Nat.eq_zero_of_zero_dvd h₁).symm
-| m+1, n+1, h₁, h₂ => Nat.le_antisymm (le_of_dvd (succPos _) h₁) (le_of_dvd (succPos _) h₂)
+| m+1, n+1, h₁, h₂ => Nat.le_antisymm (le_of_dvd (succ_pos _) h₁) (le_of_dvd (succ_pos _) h₂)
 
 theorem pos_of_dvd_of_pos {m n : ℕ} (H1 : m ∣ n) (H2 : 0 < n) : 0 < m :=
 Nat.pos_of_ne_zero $ λ m0 =>
@@ -91,8 +91,8 @@ Nat.pos_of_ne_zero $ λ m0 =>
 
 theorem eq_one_of_dvd_one {n : ℕ} (H : n ∣ 1) : n = 1 :=
   Nat.le_antisymm
-   (le_of_dvd (ofDecideEqTrue (by trivial)) H)
-   (pos_of_dvd_of_pos H (ofDecideEqTrue (by trivial)))
+   (le_of_dvd (of_decide_eq_true (by trivial)) H)
+   (pos_of_dvd_of_pos H (of_decide_eq_true (by trivial)))
 
 theorem dvd_of_mod_eq_zero {m n : ℕ} (H : n % m = 0) : m ∣ n :=
 Exists.intro
@@ -141,7 +141,7 @@ theorem gcd.induction
     (λ k IH =>
       match k with
       | 0 => H0
-      | pk+1 => λ n => H1 _ _ (succPos _) (IH _ (mod_lt _ (succPos _)) _) )
+      | pk+1 => λ n => H1 _ _ (succ_pos _) (IH _ (mod_lt _ (succ_pos _)) _) )
     n
 
 def lcm (m n : ℕ) : ℕ := m * n / gcd m n

--- a/Mathlib/Data/UInt.lean
+++ b/Mathlib/Data/UInt.lean
@@ -27,8 +27,8 @@ def isAlphanum (c : UInt8) : Bool :=
 
 theorem toChar_aux (n : Nat) (h : n < size) : Nat.isValidChar (UInt32.ofNat n).1 := by
   rw [UInt32.val_eq_of_lt]
-  exact Or.inl $ Nat.ltTrans h $ by decide
-  exact Nat.ltTrans h $ by decide
+  exact Or.inl $ Nat.lt_trans h $ by decide
+  exact Nat.lt_trans h $ by decide
 
 /-- The numbers from 0 to 256 are all valid UTF-8 characters, so we can embed one in the other. -/
 def toChar (n : UInt8) : Char := ⟨n.toUInt32, toChar_aux n.1 n.1.2⟩

--- a/Mathlib/Logic/Basic.lean
+++ b/Mathlib/Logic/Basic.lean
@@ -2,43 +2,28 @@ import Mathlib.Tactic.Basic
 
 -- TODO(Jeremy): where is the best place to put these?
 lemma EqIffBeqTrue [DecidableEq α] {a b : α} : a = b ↔ ((a == b) = true) :=
-⟨decideEqTrue, ofDecideEqTrue⟩
+⟨decide_eq_true, of_decide_eq_true⟩
 
 lemma NeqIffBeqFalse [DecidableEq α] {a b : α} : a ≠ b ↔ ((a == b) = false) :=
-⟨decideEqFalse, ofDecideEqFalse⟩
+⟨decide_eq_false, of_decide_eq_false⟩
 
 lemma decide_eq_true_iff (p : Prop) [Decidable p] : (decide p = true) ↔ p :=
-⟨ofDecideEqTrue, decideEqTrue⟩
+⟨of_decide_eq_true, decide_eq_true⟩
 
 lemma decide_eq_false_iff_not (p : Prop) [Decidable p] : (decide p = false) ↔ ¬ p :=
-⟨ofDecideEqFalse, decideEqFalse⟩
+⟨of_decide_eq_false, decide_eq_false⟩
 
-lemma optParam_eq (α : Sort u) (default : α) : optParam α default = α := rfl
-
-def not_false := notFalse
 def proof_irrel := @proofIrrel
 def congr_fun := @congrFun
 def congr_arg := @congrArg
-def of_eq_true := @ofEqTrue
 
 lemma not_of_eq_false {p : Prop} (h : p = False) : ¬p := fun hp => h ▸ hp
 
 lemma cast_proof_irrel (h₁ h₂ : α = β) (a : α) : cast h₁ a = cast h₂ a := rfl
 
-def cast_eq := @castEq
-
 lemma Ne.def (a b : α) : (a ≠ b) = ¬ (a = b) := rfl
 
-def false_of_ne := @falseOfNe
-def ne_false_of_self := @neFalseOfSelf
-def ne_true_of_not := @neTrueOfNot
-def true_ne_false := trueNeFalse
-def eq_of_heq := @eqOfHEq
-def heq_of_eq := @heqOfEq
-def heq_of_heq_of_eq := @heqOfHEqOfEq
-def heq_of_eq_of_heq := @heqOfEqOfHEq
-def type_eq_of_heq := @typeEqOfHEq
-def eq_rec_heq := @eqRecHEq
+def eq_rec_heq := @eqRec_heq
 
 lemma heq_of_eq_rec_left {φ : α → Sort v} {a a' : α} {p₁ : φ a} {p₂ : φ a'} :
   (e : a = a') → (h₂ : Eq.rec (motive := fun a _ => φ a) p₁ e = p₂) → p₁ ≅ p₂
@@ -49,8 +34,6 @@ lemma heq_of_eq_rec_right {φ : α → Sort v} {a a' : α} {p₁ : φ a} {p₂ :
 | rfl, rfl => HEq.rfl
 
 lemma of_heq_true (h : a ≅ True) : a := of_eq_true (eq_of_heq h)
-
-def cast_heq := @castHEq
 
 def And.elim (f : a → b → α) (h : a ∧ b) : α := f h.1 h.2
 
@@ -73,9 +56,6 @@ def Iff.elim_left : (a ↔ b) → a → b := Iff.mp
 def Iff.elim_right : (a ↔ b) → b → a := Iff.mpr
 
 lemma iff_comm : (a ↔ b) ↔ (b ↔ a) := ⟨Iff.symm, Iff.symm⟩
-
-lemma iff_iff_implies_and_implies : (a ↔ b) ↔ (a → b) ∧ (b → a) :=
-  ⟨fun ⟨ha, hb⟩ => ⟨ha, hb⟩, fun ⟨ha, hb⟩ => ⟨ha, hb⟩⟩
 
 lemma Eq.to_iff : a = b → (a ↔ b) | rfl => Iff.rfl
 
@@ -152,18 +132,8 @@ lemma and_iff_left (hb : b) : a ∧ b ↔ a := ⟨And.left, fun ha => ⟨ha, hb�
 
 lemma and_iff_right (ha : a) : a ∧ b ↔ b := ⟨And.right, fun hb => ⟨ha, hb⟩⟩
 
-lemma and_true : a ∧ True ↔ a := and_iff_left ⟨⟩
-
-lemma true_and : True ∧ a ↔ a := and_iff_right ⟨⟩
-
-lemma and_false : a ∧ False ↔ False := iff_false_intro And.right
-
-lemma false_and : False ∧ a ↔ False := iff_false_intro And.left
-
 lemma and_not_self : ¬(a ∧ ¬a) | ⟨ha, hn⟩ => hn ha
 lemma not_and_self : ¬(¬a ∧ a) | ⟨hn, ha⟩ => hn ha
-
-lemma and_self : a ∧ a ↔ a := ⟨And.left, fun h => ⟨h, h⟩⟩
 
 lemma Or.imp (f : a → c) (g : b → d) (h : a ∨ b) : c ∨ d := h.elim (inl ∘ f) (inr ∘ g)
 
@@ -196,30 +166,10 @@ lemma or_assoc {a b c} : (a ∨ b) ∨ c ↔ a ∨ (b ∨ c) :=
 lemma or_left_comm : a ∨ (b ∨ c) ↔ b ∨ (a ∨ c) :=
 by rw [← or_assoc, ← or_assoc, @or_comm a b]
 
-lemma or_true : a ∨ True ↔ True := iff_true_intro (Or.inr ⟨⟩)
-
-lemma true_or : True ∨ a ↔ True := iff_true_intro (Or.inl ⟨⟩)
-
-lemma or_false : a ∨ False ↔ a := ⟨fun h => h.resolve_right id, Or.inl⟩
-
-lemma false_or : False ∨ a ↔ a := ⟨fun h => h.resolve_left id, Or.inr⟩
-
-lemma or_self : a ∨ a ↔ a := ⟨fun h => h.elim id id, Or.inl⟩
-
 lemma not_or_intro : (na : ¬a) → (nb : ¬b) → ¬(a ∨ b) := Or.elim
 
 lemma not_or (p q) : ¬ (p ∨ q) ↔ ¬ p ∧ ¬ q :=
 ⟨fun H => ⟨mt Or.inl H, mt Or.inr H⟩, fun ⟨hp, hq⟩ pq => pq.elim hp hq⟩
-
-@[simp] lemma iff_true : (a ↔ True) ↔ a := ⟨fun h => h.2 ⟨⟩, iff_true_intro⟩
-
-@[simp] lemma true_iff : (True ↔ a) ↔ a := iff_comm.trans iff_true
-
-@[simp] lemma iff_false : (a ↔ False) ↔ ¬a := ⟨Iff.mp, iff_false_intro⟩
-
-@[simp] lemma false_iff : (False ↔ a) ↔ ¬a := iff_comm.trans iff_false
-
-@[simp] lemma iff_self : (a ↔ a) ↔ True := iff_true_intro Iff.rfl
 
 lemma iff_congr (h₁ : a ↔ c) (h₂ : b ↔ d) : (a ↔ b) ↔ (c ↔ d) :=
 ⟨fun h => h₁.symm.trans $ h.trans h₂, fun h => h₁.trans $ h.trans h₂.symm⟩
@@ -242,7 +192,9 @@ lemma ExistsUnique.unique {p : α → Prop} (h : ∃! x, p x)
   {y₁ y₂ : α} (py₁ : p y₁) (py₂ : p y₂) : y₁ = y₂ :=
 let ⟨x, hx, hy⟩ := h; (hy _ py₁).trans (hy _ py₂).symm
 
-lemma forall_congr {p q : α → Prop} (h : ∀ a, p a ↔ q a) : (∀ a, p a) ↔ ∀ a, q a :=
+-- Port note: this is `forall_congr` from Lean 3. In Lean 4, there is already something
+-- with that name and a slightly different type.
+lemma forall_congr' {p q : α → Prop} (h : ∀ a, p a ↔ q a) : (∀ a, p a) ↔ ∀ a, q a :=
 ⟨fun H a => (h a).1 (H a), fun H a => (h a).2 (H a)⟩
 
 lemma Exists.imp {p q : α → Prop} (h : ∀ a, p a → q a) : (∃ a, p a) → ∃ a, q a
@@ -252,7 +204,7 @@ lemma exists_congr {p q : α → Prop} (h : ∀ a, p a ↔ q a) : (∃ a, p a) �
 ⟨Exists.imp fun x => (h x).1, Exists.imp fun x => (h x).2⟩
 
 lemma exists_unique_congr {p q : α → Prop} (h : ∀ a, p a ↔ q a) : (∃! a, p a) ↔ ∃! a, q a :=
-exists_congr fun x => and_congr (h _) $ forall_congr fun y => imp_congr_left (h _)
+exists_congr fun x => and_congr (h _) $ forall_congr' fun y => imp_congr_left (h _)
 
 lemma forall_not_of_not_exists {p : α → Prop} (hne : ¬∃ x, p x) (x) : ¬p x | hp => hne ⟨x, hp⟩
 
@@ -270,9 +222,8 @@ theorem forall_and_distrib {p q : α → Prop} : (∀ x, p x ∧ q x) ↔ (∀ x
 
 def Decidable.by_cases := @byCases
 def Decidable.by_contradiction := @byContradiction
-def Decidable.of_not_not := @ofNotNot
 
-lemma Decidable.not_and [Decidable p] [Decidable q] : ¬ (p ∧ q) ↔ ¬ p ∨ ¬ q := notAndIffOrNot _ _
+lemma Decidable.not_and [Decidable p] [Decidable q] : ¬ (p ∧ q) ↔ ¬ p ∨ ¬ q := not_and_iff_or_not _ _
 
 def decidable_of_decidable_of_iff {p q : Prop} (hp : Decidable p) (h : p ↔ q) : Decidable q :=
 if hp : p then isTrue (Iff.mp h hp)
@@ -286,11 +237,6 @@ if hq : q then h₂ hq else h₁ (h.resolve_right hq)
 
 lemma Exists.nonempty {p : α → Prop} : (∃ x, p x) → Nonempty α | ⟨x, _⟩ => ⟨x⟩
 
-@[simp] def if_pos := @ifPos
-@[simp] def if_neg := @ifNeg
-@[simp] def dif_pos := @difPos
-@[simp] def dif_neg := @difNeg
-
 lemma ite_id [h : Decidable c] {α} (t : α) : (if c then t else t) = t := by cases h <;> rfl
 
 @[simp] lemma if_true {h : Decidable True} (t e : α) : (@ite α True h t e) = t :=
@@ -298,9 +244,6 @@ if_pos trivial
 
 @[simp] lemma if_false {h : Decidable False} (t e : α) : (@ite α False h t e) = e :=
 if_neg not_false
-
-lemma dif_eq_if [h : Decidable c] {α} (t : α) (e : α) : (if h : c then t else e) = ite c t e :=
-by cases h <;> rfl
 
 /-- Universe lifting operation -/
 structure ulift.{r, s} (α : Type s) : Type (max s r) :=

--- a/Mathlib/Logic/Function/Basic.lean
+++ b/Mathlib/Logic/Function/Basic.lean
@@ -145,11 +145,11 @@ theorem surjective.forall {f : α → β} (hf : surjective f) {p : β → Prop} 
 
 theorem surjective.forall₂ {f : α → β} (hf : surjective f) {p : β → β → Prop} :
   (∀ y₁ y₂, p y₁ y₂) ↔ ∀ x₁ x₂, p (f x₁) (f x₂) :=
-hf.forall.trans $ forall_congr $ λ x => hf.forall
+hf.forall.trans $ forall_congr' $ λ x => hf.forall
 
 theorem surjective.forall₃ {f : α → β} (hf : surjective f) {p : β → β → β → Prop} :
   (∀ y₁ y₂ y₃, p y₁ y₂ y₃) ↔ ∀ x₁ x₂ x₃, p (f x₁) (f x₂) (f x₃) :=
-hf.forall.trans $ forall_congr $ λ x => hf.forall₂
+hf.forall.trans $ forall_congr' $ λ x => hf.forall₂
 
 theorem surjective.exists {f : α → β} (hf : surjective f) {p : β → Prop} :
   (∃ y, p y) ↔ ∃ x, p (f x) :=
@@ -272,10 +272,10 @@ theorem partial_inv_of_injective {α β} {f : α → β} (I : injective f) :
         then by rw [hpi, dif_pos h'] at h
                 injection h with h
                 subst h
-                apply Classical.chooseSpec h'
+                apply Classical.choose_spec h'
         else by rw [hpi, dif_neg h'] at h; contradiction,
  λ e => e ▸ have h : ∃ a', f a' = f a := ⟨_, rfl⟩
-            (dif_pos h).trans (congr_arg _ (I $ Classical.chooseSpec h))⟩
+            (dif_pos h).trans (congr_arg _ (I $ Classical.choose_spec h))⟩
 
 theorem partial_inv_left {α β} {f : α → β} (I : injective f) : ∀ x, partial_inv f (f x) = some x :=
 is_partial_inv_left (partial_inv_of_injective I)
@@ -296,7 +296,7 @@ by have h1 : inv_fun_on f s b =
      if h : ∃a, a ∈ s ∧ f a = b then Classical.choose h else Classical.choice n := rfl
    rw [dif_pos h] at h1
    rw [h1]
-   exact Classical.chooseSpec h
+   exact Classical.choose_spec h
 
 theorem inv_fun_on_mem (h : ∃a∈s, f a = b) : inv_fun_on f s b ∈ s := (inv_fun_on_pos h).left
 
@@ -360,7 +360,7 @@ variable {α : Sort u} {β : Sort v} {f : α → β}
   `α` to be inhabited.) -/
 noncomputable def surj_inv {f : α → β} (h : surjective f) (b : β) : α := Classical.choose (h b)
 
-lemma surj_inv_eq (h : surjective f) (b) : f (surj_inv h b) = b := Classical.chooseSpec (h b)
+lemma surj_inv_eq (h : surjective f) (b) : f (surj_inv h b) = b := Classical.choose_spec (h b)
 
 lemma right_inverse_surj_inv (hf : surjective f) : right_inverse (surj_inv hf) f :=
 surj_inv_eq hf
@@ -524,7 +524,7 @@ lemma extend_def (f : α → β) (g : α → γ) (e' : β → γ) (b : β) [hd :
 @[simp] lemma extend_apply (hf : injective f) (g : α → γ) (e' : β → γ) (a : α) :
   extend f g e' (f a) = g a :=
 by simp only [extend_def, dif_pos, exists_apply_eq_apply]
-   exact congr_arg g (hf $ Classical.chooseSpec (exists_apply_eq_apply f a))
+   exact congr_arg g (hf $ Classical.choose_spec (exists_apply_eq_apply f a))
 
 @[simp] lemma extend_comp (hf : injective f) (g : α → γ) (e' : β → γ) :
   extend f g e' ∘ f = g :=

--- a/leanpkg.toml
+++ b/leanpkg.toml
@@ -1,4 +1,4 @@
 [package]
 name = "mathlib4"
 version = "0.1"
-lean_version = "leanprover/lean4:nightly-2021-08-06"
+lean_version = "leanprover/lean4:nightly-2021-08-11"


### PR DESCRIPTION
Fixes the fallout from upstream's mass renaming in https://github.com/leanprover/lean4/commit/a821dcbff25b1323b213f275ae77860b42021fee.

Deletes a bunch of redefinitions that are no longer needed because upstream has adopted the camel-case naming convention. Keeps (and renames) definitions where the upstream version is notably different from our current version.

Fixes `instance (R : Type u) [Ring R] : Semiring R`, which broke for reasons that I don't understand.

Fixes `lemma le_div_iff_mul_le`, which broke because the upstream `not_succ_le_zero` is not annotated as `@[simp]`. (Note that the Lean 3 version is also not annotated as `@[simp]` : https://github.com/leanprover-community/lean/blob/86ca45a647554edcb46fe9d1feb335ac2a45b244/library/init/data/nat/basic.lean#L88)

