### PR TITLE
split out Lean 3 prelude items from Logic/Basic.lean into Init/Logic.lean

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -18,6 +18,7 @@ import Mathlib.Data.Subtype
 import Mathlib.Data.UInt
 import Mathlib.Dvd
 import Mathlib.Function
+import Mathlib.Init.Logic
 import Mathlib.Logic.Basic
 import Mathlib.Logic.Function.Basic
 import Mathlib.Set

--- a/Mathlib/Init/Logic.lean
+++ b/Mathlib/Init/Logic.lean
@@ -1,0 +1,551 @@
+/-
+Copyright (c) 2014 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Leonardo de Moura, Jeremy Avigad, Floris van Doorn
+-/
+
+import Mathlib.Tactic.Basic
+
+universe u v w
+
+@[simp] theorem opt_param_eq (α : Sort u) (default : α) : optParam α default = α := optParam_eq α default
+
+theorem Not.intro {a : Prop} (h : a → False) : ¬ a := h
+
+/- not -/
+
+def non_contradictory (a : Prop) : Prop := ¬¬a
+
+theorem non_contradictory_intro {a : Prop} (ha : a) : ¬¬a :=
+λ hna : ¬a => absurd ha hna
+
+/- eq -/
+
+-- proof irrelevance is built in
+def proof_irrel := @proofIrrel
+
+def congr_fun := @congrFun
+def congr_arg := @congrArg
+
+lemma trans_rel_left {α : Sort u} {a b c : α} (r : α → α → Prop) (h₁ : r a b) (h₂ : b = c) : r a c :=
+h₂ ▸ h₁
+
+lemma trans_rel_right {α : Sort u} {a b c : α} (r : α → α → Prop) (h₁ : a = b) (h₂ : r b c) : r a c :=
+h₁.symm ▸ h₂
+
+lemma not_of_eq_false {p : Prop} (h : p = False) : ¬p := fun hp => h ▸ hp
+
+lemma cast_proof_irrel (h₁ h₂ : α = β) (a : α) : cast h₁ a = cast h₂ a := rfl
+
+/- ne -/
+
+@[simp] lemma Ne.def {α : Sort u} (a b : α) : (a ≠ b) = ¬ (a = b) := rfl
+
+def eq_rec_heq := @eqRec_heq
+
+lemma heq_of_eq_rec_left {φ : α → Sort v} {a a' : α} {p₁ : φ a} {p₂ : φ a'} :
+  (e : a = a') → (h₂ : Eq.rec (motive := fun a _ => φ a) p₁ e = p₂) → p₁ ≅ p₂
+| rfl, rfl => HEq.rfl
+
+lemma heq_of_eq_rec_right {φ : α → Sort v} {a a' : α} {p₁ : φ a} {p₂ : φ a'} :
+  (e : a' = a) → (h₂ : p₁ = Eq.rec (motive := fun a _ => φ a) p₂ e) → p₁ ≅ p₂
+| rfl, rfl => HEq.rfl
+
+lemma of_heq_true (h : a ≅ True) : a := of_eq_true (eq_of_heq h)
+
+-- TODO eq_rec_compose
+
+/- and -/
+
+variable {a b c d : Prop}
+
+def And.elim (f : a → b → α) (h : a ∧ b) : α := f h.1 h.2
+
+lemma and.swap : a ∧ b → b ∧ a :=
+λ ⟨ha, hb⟩ => ⟨hb, ha⟩
+
+lemma And.symm : a ∧ b → b ∧ a | ⟨ha, hb⟩ => ⟨hb, ha⟩
+
+/- or -/
+
+lemma Or.elim {a b c : Prop} (h₁ : a → c) (h₂ : b → c) : (h : a ∨ b) → c
+| inl ha => h₁ ha
+| inr hb => h₂ hb
+
+-- Port note: in Lean 3, this is named Or.elim.
+lemma Or.elim_on (h₁ : a ∨ b) (h₂ : a → c) (h₃ : b → c) : c :=
+Or.rec (motive := λ _ => c) h₂ h₃ h₁
+
+lemma non_contradictory_em (a : Prop) : ¬¬(a ∨ ¬a) :=
+λ not_em : ¬(a ∨ ¬a) =>
+  have neg_a : ¬a := λ pos_a : a => absurd (Or.inl pos_a) not_em
+  absurd (Or.inr neg_a) not_em
+
+lemma Or.swap : a ∨ b → b ∨ a := Or.rec Or.inr Or.inl
+
+lemma Or.symm : a ∨ b → b ∨ a
+| Or.inl h => Or.inr h
+| Or.inr h => Or.inl h
+
+/- xor -/
+
+def xor (a b : Prop) := (a ∧ ¬ b) ∨ (b ∧ ¬ a)
+
+/- iff -/
+
+def Iff.elim (f : (a → b) → (b → a) → c) (h : a ↔ b) : c := f h.1 h.2
+
+def Iff.elim_left : (a ↔ b) → a → b := Iff.mp
+
+def Iff.elim_right : (a ↔ b) → b → a := Iff.mpr
+
+lemma Eq.to_iff : a = b → (a ↔ b) | rfl => Iff.rfl
+
+lemma neq_of_not_iff : ¬(a ↔ b) → a ≠ b := mt Eq.to_iff
+
+lemma not_iff_not_of_iff (h₁ : a ↔ b) : ¬ a ↔ ¬ b :=
+Iff.intro
+  (λ (hna : ¬ a) (hb : b) => hna (Iff.elim_right h₁ hb))
+  (λ (hnb : ¬ b) (ha : a) => hnb (Iff.elim_left h₁ ha))
+
+lemma of_iff_true (h : a ↔ True) : a := h.2 ⟨⟩
+
+lemma not_of_iff_false : (a ↔ False) → ¬a := Iff.mp
+
+lemma iff_true_intro (h : a) : a ↔ True := ⟨fun _ => ⟨⟩, fun _ => h⟩
+
+lemma iff_false_intro (h : ¬a) : a ↔ False := ⟨h, fun h => h.elim⟩
+
+lemma not_not_intro : a → ¬¬a := fun a h => h a
+
+lemma not_iff_false_intro (h : a) : ¬a ↔ False := iff_false_intro (not_not_intro h)
+
+lemma not_non_contradictory_iff_absurd (a : Prop) : ¬¬¬a ↔ ¬a := ⟨mt not_not_intro, not_not_intro⟩
+
+lemma imp_congr_left (h : a ↔ b) : (a → c) ↔ (b → c) :=
+⟨fun hac ha => hac (h.2 ha), fun hbc ha => hbc (h.1 ha)⟩
+
+lemma imp_congr_right (h : a → (b ↔ c)) : (a → b) ↔ (a → c) :=
+⟨fun hab ha => (h ha).1 (hab ha), fun hcd ha => (h ha).2 (hcd ha)⟩
+
+lemma imp_congr_ctx (h₁ : a ↔ c) (h₂ : c → (b ↔ d)) : (a → b) ↔ (c → d) :=
+(imp_congr_left h₁).trans (imp_congr_right h₂)
+
+lemma imp_congr (h₁ : a ↔ c) (h₂ : b ↔ d) : (a → b) ↔ (c → d) := imp_congr_ctx h₁ fun _ => h₂
+
+lemma not_of_not_not_not (h : ¬¬¬a) : ¬a :=
+λ ha => absurd (not_not_intro ha) h
+
+@[simp] lemma not_true : (¬ True) ↔ False :=
+iff_false_intro (not_not_intro trivial)
+
+@[simp] lemma not_false_iff : (¬ False) ↔ True :=
+iff_true_intro not_false
+
+lemma not_congr (h : a ↔ b) : ¬a ↔ ¬b := ⟨mt h.2, mt h.1⟩
+
+lemma ne_self_iff_false (a : α) : a ≠ a ↔ False := not_iff_false_intro rfl
+
+@[simp] lemma eq_self_iff_true (a : α) : a = a ↔ True := iff_true_intro rfl
+
+lemma heq_self_iff_true (a : α) : a ≅ a ↔ True := iff_true_intro HEq.rfl
+
+lemma iff_not_self : ¬(a ↔ ¬a) | H => let f h := H.1 h h; f (H.2 f)
+
+@[simp] lemma not_iff_self : ¬(¬a ↔ a) | H => iff_not_self H.symm
+
+lemma true_iff_false : (True ↔ False) ↔ False :=
+iff_false_intro (λ h => Iff.mp h trivial)
+
+lemma false_iff_true : (False ↔ True) ↔ False :=
+iff_false_intro (λ h => Iff.mpr h trivial)
+
+lemma false_of_true_iff_false : (True ↔ False) → False :=
+λ h => Iff.mp h trivial
+
+lemma false_of_true_eq_false : (True = False) → False :=
+λ h => h ▸ trivial
+
+lemma true_eq_false_of_false : False → (True = False) :=
+False.elim
+
+lemma eq_comm {a b : α} : a = b ↔ b = a := ⟨Eq.symm, Eq.symm⟩
+
+/- and simp rules -/
+lemma And.imp (f : a → c) (g : b → d) (h : a ∧ b) : c ∧ d := ⟨f h.1, g h.2⟩
+
+lemma and_implies (hac : a → c) (hbd : b → d) : a ∧ b → c ∧ d := And.imp hac hbd
+
+lemma and_congr (h₁ : a ↔ c) (h₂ : b ↔ d) : a ∧ b ↔ c ∧ d := ⟨And.imp h₁.1 h₂.1, And.imp h₁.2 h₂.2⟩
+
+lemma and_congr_right (h : a → (b ↔ c)) : (a ∧ b) ↔ (a ∧ c) :=
+⟨fun ⟨ha, hb⟩ => ⟨ha, (h ha).1 hb⟩, fun ⟨ha, hb⟩ => ⟨ha, (h ha).2 hb⟩⟩
+
+lemma And.comm : a ∧ b ↔ b ∧ a := ⟨And.symm, And.symm⟩
+
+lemma and_comm (a b : Prop) : a ∧ b ↔ b ∧ a := And.comm
+
+lemma And.assoc : (a ∧ b) ∧ c ↔ a ∧ (b ∧ c) :=
+⟨fun ⟨⟨ha, hb⟩, hc⟩ => ⟨ha, hb, hc⟩, fun ⟨ha, hb, hc⟩ => ⟨⟨ha, hb⟩, hc⟩⟩
+
+lemma and_assoc (a b : Prop) : (a ∧ b) ∧ c ↔ a ∧ (b ∧ c) := And.assoc
+
+lemma and_left_comm : a ∧ (b ∧ c) ↔ b ∧ (a ∧ c) :=
+by rw [← and_assoc, ← and_assoc, @And.comm a b]
+
+lemma and_iff_left (hb : b) : a ∧ b ↔ a := ⟨And.left, fun ha => ⟨ha, hb⟩⟩
+
+lemma and_iff_right (ha : a) : a ∧ b ↔ b := ⟨And.right, fun hb => ⟨ha, hb⟩⟩
+
+@[simp] lemma and_not_self : ¬(a ∧ ¬a) | ⟨ha, hn⟩ => hn ha
+
+@[simp] lemma not_and_self : ¬(¬a ∧ a) | ⟨hn, ha⟩ => hn ha
+
+/- or simp rules -/
+
+lemma Or.imp (f : a → c) (g : b → d) (h : a ∨ b) : c ∨ d := h.elim (inl ∘ f) (inr ∘ g)
+
+lemma Or.imp_left (f : a → b) : a ∨ c → b ∨ c := Or.imp f id
+
+lemma Or.imp_right (f : b → c) : a ∨ b → a ∨ c := Or.imp id f
+
+lemma or_congr (h₁ : a ↔ c) (h₂ : b ↔ d) : (a ∨ b) ↔ (c ∨ d) :=
+⟨Or.imp h₁.1 h₂.1, Or.imp h₁.2 h₂.2⟩
+
+lemma Or.comm : a ∨ b ↔ b ∨ a := ⟨Or.symm, Or.symm⟩
+
+lemma or_comm (a b : Prop) : a ∨ b ↔ b ∨ a := Or.comm
+
+lemma Or.assoc : (a ∨ b) ∨ c ↔ a ∨ (b ∨ c) :=
+Iff.intro
+  (Or.rec (Or.imp_right Or.inl) (λ h => Or.inr (Or.inr h)))
+  (Or.rec (λ h => Or.inl (Or.inl h)) (Or.imp_left Or.inr))
+
+lemma or_assoc (a b : Prop) : (a ∨ b) ∨ c ↔ a ∨ (b ∨ c) :=
+Or.assoc
+
+lemma Or.left_comm : a ∨ (b ∨ c) ↔ b ∨ (a ∨ c) :=
+Iff.trans (Iff.symm Or.assoc) (Iff.trans (or_congr Or.comm (Iff.refl c)) Or.assoc)
+
+theorem or_iff_right_of_imp (ha : a → b) : (a ∨ b) ↔ b :=
+Iff.intro (Or.rec ha id) Or.inr
+
+theorem or_iff_left_of_imp (hb : b → a) : (a ∨ b) ↔ a :=
+Iff.intro (Or.rec id hb) Or.inl
+
+-- Port note: in mathlib3, this is not_or
+lemma not_or_intro {a b : Prop} : ¬ a → ¬ b → ¬ (a ∨ b)
+| hna, hnb, (Or.inl ha) => absurd ha hna
+| hna, hnb, (Or.inr hb) => absurd hb hnb
+
+lemma not_or (p q) : ¬ (p ∨ q) ↔ ¬ p ∧ ¬ q :=
+⟨fun H => ⟨mt Or.inl H, mt Or.inr H⟩, fun ⟨hp, hq⟩ pq => pq.elim hp hq⟩
+
+/- or resolution rules -/
+
+lemma Or.resolve_left {a b : Prop} (h: a ∨ b) (na : ¬ a) : b :=
+Or.elim_on h (λ ha => absurd ha na) id
+
+lemma Or.neg_resolve_left (h : ¬a ∨ b) (ha : a) : b := h.elim (absurd ha) id
+
+lemma Or.resolve_right {a b : Prop} (h: a ∨ b) (nb : ¬ b) : a :=
+Or.elim_on h id (λ hb => absurd hb nb)
+
+lemma Or.neg_resolve_right (h : a ∨ ¬b) (nb : b) : a := h.elim id (absurd nb)
+
+lemma iff_congr (h₁ : a ↔ c) (h₂ : b ↔ d) : (a ↔ b) ↔ (c ↔ d) :=
+⟨fun h => h₁.symm.trans $ h.trans h₂, fun h => h₁.trans $ h.trans h₂.symm⟩
+
+/- implies simp rule -/
+@[simp] lemma implies_true_iff (α : Sort u) : (α → True) ↔ True :=
+Iff.intro (λ h => trivial) (λ ha h => trivial)
+
+lemma false_implies_iff (a : Prop) : (False → a) ↔ True :=
+Iff.intro (λ h => trivial) (λ ha h => False.elim h)
+
+theorem true_implies_iff (α : Prop) : (True → α) ↔ α :=
+Iff.intro (λ h => h trivial) (λ h h' => h)
+
+/- exists unique -/
+
+def ExistsUnique (p : α → Prop) := ∃ x, p x ∧ ∀ y, p y → y = x
+
+open Lean in
+macro "∃! " xs:explicitBinders ", " b:term : term => expandExplicitBinders ``ExistsUnique xs b
+
+lemma ExistsUnique.intro {p : α → Prop} (w : α)
+  (h₁ : p w) (h₂ : ∀ y, p y → y = w) : ∃! x, p x := ⟨w, h₁, h₂⟩
+
+lemma ExistsUnique.elim {α : Sort u} {p : α → Prop} {b : Prop}
+    (h₂ : ∃! x, p x) (h₁ : ∀ x, p x → (∀ y, p y → y = x) → b) : b :=
+Exists.elim h₂ (λ w hw => h₁ w (And.left hw) (And.right hw))
+
+lemma exists_unique_of_exists_of_unique {α : Sort u} {p : α → Prop}
+    (hex : ∃ x, p x) (hunique : ∀ y₁ y₂, p y₁ → p y₂ → y₁ = y₂) : ∃! x, p x :=
+Exists.elim hex (λ x px => ExistsUnique.intro x px (λ y (h : p y) => hunique y x h px))
+
+lemma exists_of_exists_unique {α : Sort u} {p : α → Prop} (h : ∃! x, p x) : ∃ x, p x :=
+Exists.elim h (λ x hx => ⟨x, And.left hx⟩)
+
+lemma unique_of_exists_unique {α : Sort u} {p : α → Prop}
+    (h : ∃! x, p x) {y₁ y₂ : α} (py₁ : p y₁) (py₂ : p y₂) : y₁ = y₂ :=
+let ⟨x, hx, hy⟩ := h; (hy _ py₁).trans (hy _ py₂).symm
+
+/- exists, forall, exists unique congruences -/
+
+-- Port note: this is `forall_congr` from Lean 3. In Lean 4, there is already something
+-- with that name and a slightly different type.
+lemma forall_congr' {p q : α → Prop} (h : ∀ a, p a ↔ q a) : (∀ a, p a) ↔ ∀ a, q a :=
+⟨fun H a => (h a).1 (H a), fun H a => (h a).2 (H a)⟩
+
+lemma exists_imp_exists {α : Sort u} {p q : α → Prop} (h : ∀ a, (p a → q a)) (p : ∃ a, p a) : ∃ a, q a :=
+Exists.elim p (λ a hp => ⟨a, h a hp⟩)
+
+lemma exists_congr {p q : α → Prop} (h : ∀ a, p a ↔ q a) : (∃ a, p a) ↔ ∃ a, q a :=
+⟨exists_imp_exists fun x => (h x).1, exists_imp_exists fun x => (h x).2⟩
+
+lemma exists_unique_congr {p q : α → Prop} (h : ∀ a, p a ↔ q a) : (∃! a, p a) ↔ ∃! a, q a :=
+exists_congr fun x => and_congr (h _) $ forall_congr' fun y => imp_congr_left (h _)
+
+lemma forall_not_of_not_exists {p : α → Prop} (hne : ¬∃ x, p x) (x) : ¬p x | hp => hne ⟨x, hp⟩
+
+/- decidable -/
+
+def Decidable.to_bool (p : Prop) [h : Decidable p] : Bool := @Decidable.decide p h
+
+@[simp] lemma to_bool_true_eq_tt (h : Decidable True) : @Decidable.to_bool True h = true :=
+match h with
+| isFalse hf => False.elim (Iff.mp not_true hf)
+| isTrue _ => rfl
+
+@[simp] lemma to_bool_false_eq_ff (h : Decidable False) : @Decidable.to_bool False h = false :=
+match h with
+| isFalse _ => rfl
+| isTrue ht => False.elim ht
+
+namespace Decidable
+  variable {p q : Prop}
+
+  -- TODO: rec_on_true and rec_on_false
+
+  def by_cases {q : Sort u} [φ : Decidable p] : (p → q) → (¬p → q) → q := byCases
+
+  lemma by_contradiction [φ : Decidable p] (h : ¬ p → False) : p := @byContradiction p φ h
+
+  lemma not_not_iff (p) [Decidable p] : (¬ ¬ p) ↔ p :=
+  Iff.intro of_not_not not_not_intro
+
+  lemma not_or_iff_and_not (p q) [d₁ : Decidable p] [d₂ : Decidable q] : ¬ (p ∨ q) ↔ ¬ p ∧ ¬ q :=
+  Iff.intro
+    (λ h => match d₁ with
+          | isTrue h₁  => False.elim $ h (Or.inl h₁)
+          | isFalse h₁ =>
+            match d₂ with
+            | isTrue h₂  => False.elim $ h (Or.inr h₂)
+            | isFalse h₂ => ⟨h₁, h₂⟩)
+    (λ ⟨np, nq⟩ h => Or.elim_on h np nq)
+
+end Decidable
+
+section
+  variable {p q : Prop}
+  def decidable_of_decidable_of_iff (hp : Decidable p) (h : p ↔ q) : Decidable q :=
+  if hp : p then isTrue (Iff.mp h hp)
+  else isFalse (Iff.mp (not_iff_not_of_iff h) hp)
+
+  def decidable_of_decidable_of_eq (hp : Decidable p) (h : p = q) : Decidable q :=
+  decidable_of_decidable_of_iff hp h.to_iff
+
+  protected def Or.by_cases [Decidable p] [Decidable q] {α : Sort u}
+                                   (h : p ∨ q) (h₁ : p → α) (h₂ : q → α) : α :=
+  if hp : p then h₁ hp else
+    if hq : q then h₂ hq else
+      False.elim (Or.elim_on h hp hq)
+end
+
+section
+  variable {p q : Prop}
+
+  instance [Decidable p] [Decidable q] : Decidable (xor p q) :=
+  if hp : p then
+    if hq : q then isFalse (Or.rec (λ ⟨_, h⟩ => h hq : ¬(p ∧ ¬ q)) (λ ⟨_, h⟩ => h hp : ¬(q ∧ ¬ p)))
+    else isTrue $ Or.inl ⟨hp, hq⟩
+  else
+    if hq : q then isTrue $ Or.inr ⟨hq, hp⟩
+    else isFalse (Or.rec (λ ⟨h, _⟩ => hp h : ¬(p ∧ ¬ q)) (λ ⟨h, _⟩ => hq h : ¬(q ∧ ¬ p)))
+
+  instance exists_prop_decidable {p} (P : p → Prop)
+    [Dp : Decidable p] [DP : ∀ h, Decidable (P h)] : Decidable (∃ h, P h) :=
+  if h : p then decidable_of_decidable_of_iff (DP h)
+    ⟨λ h2 => ⟨h, h2⟩, λ⟨h', h2⟩ => h2⟩ else isFalse (mt (λ⟨h, _⟩ => h) h)
+
+  instance forall_prop_decidable {p} (P : p → Prop)
+    [Dp : Decidable p] [DP : ∀ h, Decidable (P h)] : Decidable (∀ h, P h) :=
+  if h : p
+  then decidableOfDecidableOfIff (DP h) ⟨λ h2 _ => h2, λ al => al h⟩
+  else isTrue (λ h2 => absurd h2 h)
+end
+
+lemma bool.ff_ne_tt : false = true → False := Bool.noConfusion
+
+def is_dec_eq {α : Sort u} (p : α → α → Bool) : Prop   := ∀ ⦃x y : α⦄, p x y = true → x = y
+def is_dec_refl {α : Sort u} (p : α → α → Bool) : Prop := ∀ x, p x x = true
+
+def decidable_eq_of_bool_pred {α : Sort u} {p : α → α → Bool} (h₁ : is_dec_eq p) (h₂ : is_dec_refl p) :
+  DecidableEq α :=
+λ (x y : α) =>
+ if hp : p x y = true then isTrue (h₁ hp)
+ else isFalse (λ hxy : x = y => absurd (h₂ y) (by rwa [hxy] at hp))
+
+lemma decidable_eq_inl_refl {α : Sort u} [h : DecidableEq α] (a : α) : h a a = isTrue (Eq.refl a) :=
+match (h a a) with
+| (isTrue e)  => rfl
+| (isFalse n) => absurd rfl n
+
+lemma decidable_eq_inr_neg {α : Sort u} [h : DecidableEq α] {a b : α} : ∀ n : a ≠ b, h a b = isFalse n :=
+λ n =>
+match (h a b) with
+| (isTrue e)   => absurd e n
+| (isFalse n₁) => proof_irrel n n₁ ▸ Eq.refl (isFalse n)
+
+/- subsingleton -/
+
+-- TODO: rec_subsingleton
+
+@[simp]
+lemma if_t_t (c : Prop) [h : Decidable c] {α : Sort u} (t : α) : (ite c t t) = t :=
+match h with
+| (isTrue hc)   => rfl
+| (isFalse hnc) => rfl
+
+lemma implies_of_if_pos {c t e : Prop} [Decidable c] (h : ite c t e) : c → t :=
+by intro hc
+   have hp : ite c t e = t := if_pos hc
+   rwa [hp] at h
+
+lemma implies_of_if_neg {c t e : Prop} [Decidable c] (h : ite c t e) : ¬c → e :=
+by intro hnc
+   have hn : ite c t e = e := if_neg hnc
+   rwa [hn] at h
+
+lemma if_ctx_congr {α : Sort u} {b c : Prop} [dec_b : Decidable b] [dec_c : Decidable c]
+                   {x y u v : α}
+                   (h_c : b ↔ c) (h_t : c → x = u) (h_e : ¬c → y = v) :
+        ite b x y = ite c u v :=
+match dec_b, dec_c with
+| (isFalse h₁), (isFalse h₂) => h_e h₂
+| (isTrue h₁),  (isTrue h₂)  => h_t h₂
+| (isFalse h₁), (isTrue h₂)  => absurd h₂ (Iff.mp (not_iff_not_of_iff h_c) h₁)
+| (isTrue h₁),  (isFalse h₂) => absurd h₁ (Iff.mpr (not_iff_not_of_iff h_c) h₂)
+
+lemma if_congr {α : Sort u} {b c : Prop} [dec_b : Decidable b] [dec_c : Decidable c]
+               {x y u v : α}
+               (h_c : b ↔ c) (h_t : x = u) (h_e : y = v) :
+        ite b x y = ite c u v :=
+@if_ctx_congr α b c dec_b dec_c x y u v h_c (λ h => h_t) (λ h => h_e)
+
+@[simp] lemma if_true {h : Decidable True} (t e : α) : (@ite α True h t e) = t :=
+if_pos trivial
+
+@[simp] lemma if_false {h : Decidable False} (t e : α) : (@ite α False h t e) = e :=
+if_neg not_false
+
+lemma if_ctx_congr_prop {b c x y u v : Prop} [dec_b : Decidable b] [dec_c : Decidable c]
+                      (h_c : b ↔ c) (h_t : c → (x ↔ u)) (h_e : ¬c → (y ↔ v)) :
+        ite b x y ↔ ite c u v :=
+match dec_b, dec_c with
+| (isFalse h₁), (isFalse h₂) => h_e h₂
+| (isTrue h₁),  (isTrue h₂)  => h_t h₂
+| (isFalse h₁), (isTrue h₂)  => absurd h₂ (Iff.mp (not_iff_not_of_iff h_c) h₁)
+| (isTrue h₁),  (isFalse h₂) => absurd h₁ (Iff.mpr (not_iff_not_of_iff h_c) h₂)
+
+lemma if_congr_prop {b c x y u v : Prop} [dec_b : Decidable b] [dec_c : Decidable c]
+                    (h_c : b ↔ c) (h_t : x ↔ u) (h_e : y ↔ v) :
+        ite b x y ↔ ite c u v :=
+if_ctx_congr_prop h_c (λ h => h_t) (λ h => h_e)
+
+lemma if_ctx_simp_congr_prop {b c x y u v : Prop} [dec_b : Decidable b]
+                               (h_c : b ↔ c) (h_t : c → (x ↔ u)) (h_e : ¬c → (y ↔ v)) :
+        ite b x y ↔ (@ite Prop c (decidable_of_decidable_of_iff dec_b h_c) u v) :=
+@if_ctx_congr_prop b c x y u v dec_b (decidable_of_decidable_of_iff dec_b h_c) h_c h_t h_e
+
+lemma if_simp_congr_prop {b c x y u v : Prop} [dec_b : Decidable b]
+                           (h_c : b ↔ c) (h_t : x ↔ u) (h_e : y ↔ v) :
+        ite b x y ↔ (@ite Prop c (decidable_of_decidable_of_iff dec_b h_c) u v) :=
+@if_ctx_simp_congr_prop b c x y u v dec_b h_c (λ h => h_t) (λ h => h_e)
+
+lemma dif_ctx_congr {α : Sort u} {b c : Prop} [dec_b : Decidable b] [dec_c : Decidable c]
+                    {x : b → α} {u : c → α} {y : ¬b → α} {v : ¬c → α}
+                    (h_c : b ↔ c)
+                    (h_t : ∀ (h : c),    x (Iff.mpr h_c h)                      = u h)
+                    (h_e : ∀ (h : ¬c),   y (Iff.mpr (not_iff_not_of_iff h_c) h) = v h) :
+        (@dite α b dec_b x y) = (@dite α c dec_c u v) :=
+match dec_b, dec_c with
+| (isFalse h₁), (isFalse h₂) => h_e h₂
+| (isTrue h₁),  (isTrue h₂)  => h_t h₂
+| (isFalse h₁), (isTrue h₂)  => absurd h₂ (Iff.mp (not_iff_not_of_iff h_c) h₁)
+| (isTrue h₁),  (isFalse h₂) => absurd h₁ (Iff.mpr (not_iff_not_of_iff h_c) h₂)
+
+lemma dif_ctx_simp_congr {α : Sort u} {b c : Prop} [dec_b : Decidable b]
+                         {x : b → α} {u : c → α} {y : ¬b → α} {v : ¬c → α}
+                         (h_c : b ↔ c)
+                         (h_t : ∀ (h : c),    x (Iff.mpr h_c h)                      = u h)
+                         (h_e : ∀ (h : ¬c),   y (Iff.mpr (not_iff_not_of_iff h_c) h) = v h) :
+        (@dite α b dec_b x y) = (@dite α c (decidable_of_decidable_of_iff dec_b h_c) u v) :=
+@dif_ctx_congr α b c dec_b (decidable_of_decidable_of_iff dec_b h_c) x u y v h_c h_t h_e
+
+def as_true (c : Prop) [Decidable c] : Prop :=
+if c then True else False
+
+def as_false (c : Prop) [Decidable c] : Prop :=
+if c then False else True
+
+lemma of_as_true {c : Prop} [h₁ : Decidable c] (h₂ : as_true c) : c :=
+match h₁, h₂ with
+| (isTrue h_c),  h₂ => h_c
+| (isFalse h_c), h₂ => False.elim h₂
+
+/-- Universe lifting operation -/
+structure ulift.{r, s} (α : Type s) : Type (max s r) :=
+up :: (down : α)
+
+namespace ulift
+
+/- Bijection between α and ulift.{v} α -/
+lemma up_down {α : Type u} : ∀ (b : ulift.{v} α), up (down b) = b
+| up a => rfl
+
+lemma down_up {α : Type u} (a : α) : down (up.{v} a) = a := rfl
+
+end ulift
+
+/-- Universe lifting operation from Sort to Type -/
+structure plift (α : Sort u) : Type u :=
+up :: (down : α)
+
+namespace plift
+/- Bijection between α and plift α -/
+lemma up_down : ∀ (b : plift α), up (down b) = b
+| (up a) => rfl
+
+lemma down_up (a : α) : down (up a) = a := rfl
+end plift
+
+/- Equalities for rewriting let-expressions -/
+lemma let_value_eq {α : Sort u} {β : Sort v} {a₁ a₂ : α} (b : α → β) :
+                   a₁ = a₂ → (let x : α := a₁; b x) = (let x : α := a₂; b x) :=
+λ h => Eq.recOn (motive := (λ a _ => (let x : α := a₁; b x) = (let x : α := a; b x))) h rfl
+
+lemma let_value_heq {α : Sort v} {β : α → Sort u} {a₁ a₂ : α} (b : ∀ x : α, β x) :
+                    a₁ = a₂ → (let x : α := a₁; b x) ≅ (let x : α := a₂; b x) :=
+by intro h; rw [h]; exact HEq.refl _
+
+lemma let_body_eq {α : Sort v} {β : α → Sort u} (a : α) {b₁ b₂ : ∀ x : α, β x} :
+                  (∀ x, b₁ x = b₂ x) → (let x : α := a; b₁ x) = (let x : α := a; b₂ x) :=
+by intro h; rw [h]
+
+lemma let_eq {α : Sort v} {β : Sort u} {a₁ a₂ : α} {b₁ b₂ : α → β} :
+             a₁ = a₂ → (∀ x, b₁ x = b₂ x) → (let x : α := a₁; b₁ x) = (let x : α := a₂; b₂ x) :=
+λ h₁ h₂ => Eq.recOn (motive := λ a _ => (let x := a₁; b₁ x) = (let x := a; b₂ x)) h₁ (h₂ a₁)
+
+-- TODO: `section relation` and `section binary`

--- a/Mathlib/Logic/Basic.lean
+++ b/Mathlib/Logic/Basic.lean
@@ -1,4 +1,15 @@
+/-
+Copyright (c) 2016 Jeremy Avigad. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jeremy Avigad, Leonardo de Moura
+-/
+import Mathlib.Init.Logic
 import Mathlib.Tactic.Basic
+
+section needs_better_home
+/- This section contains items that have no direct counterpart from Lean 3 / Mathlib 3.
+   They should probably probably live elsewhere and maybe in some cases should be removed.
+-/
 
 -- TODO(Jeremy): where is the best place to put these?
 lemma EqIffBeqTrue [DecidableEq α] {a b : α} : a = b ↔ ((a == b) = true) :=
@@ -13,224 +24,16 @@ lemma decide_eq_true_iff (p : Prop) [Decidable p] : (decide p = true) ↔ p :=
 lemma decide_eq_false_iff_not (p : Prop) [Decidable p] : (decide p = false) ↔ ¬ p :=
 ⟨of_decide_eq_false, decide_eq_false⟩
 
-def proof_irrel := @proofIrrel
-def congr_fun := @congrFun
-def congr_arg := @congrArg
-
-lemma not_of_eq_false {p : Prop} (h : p = False) : ¬p := fun hp => h ▸ hp
-
-lemma cast_proof_irrel (h₁ h₂ : α = β) (a : α) : cast h₁ a = cast h₂ a := rfl
-
-lemma Ne.def (a b : α) : (a ≠ b) = ¬ (a = b) := rfl
-
-def eq_rec_heq := @eqRec_heq
-
-lemma heq_of_eq_rec_left {φ : α → Sort v} {a a' : α} {p₁ : φ a} {p₂ : φ a'} :
-  (e : a = a') → (h₂ : Eq.rec (motive := fun a _ => φ a) p₁ e = p₂) → p₁ ≅ p₂
-| rfl, rfl => HEq.rfl
-
-lemma heq_of_eq_rec_right {φ : α → Sort v} {a a' : α} {p₁ : φ a} {p₂ : φ a'} :
-  (e : a' = a) → (h₂ : p₁ = Eq.rec (motive := fun a _ => φ a) p₂ e) → p₁ ≅ p₂
-| rfl, rfl => HEq.rfl
-
-lemma of_heq_true (h : a ≅ True) : a := of_eq_true (eq_of_heq h)
-
-def And.elim (f : a → b → α) (h : a ∧ b) : α := f h.1 h.2
-
-lemma And.symm : a ∧ b → b ∧ a | ⟨ha, hb⟩ => ⟨hb, ha⟩
-
-lemma Or.elim {a b c : Prop} (h₁ : a → c) (h₂ : b → c) : (h : a ∨ b) → c
-| inl ha => h₁ ha
-| inr hb => h₂ hb
-
 lemma not_not_em (a : Prop) : ¬¬(a ∨ ¬a) := fun H => H (Or.inr fun h => H (Or.inl h))
 
-lemma Or.symm : a ∨ b → b ∨ a
-| Or.inl h => Or.inr h
-| Or.inr h => Or.inl h
-
-def Iff.elim (f : (a → b) → (b → a) → c) (h : a ↔ b) : c := f h.1 h.2
-
-def Iff.elim_left : (a ↔ b) → a → b := Iff.mp
-
-def Iff.elim_right : (a ↔ b) → b → a := Iff.mpr
-
-lemma iff_comm : (a ↔ b) ↔ (b ↔ a) := ⟨Iff.symm, Iff.symm⟩
-
-lemma Eq.to_iff : a = b → (a ↔ b) | rfl => Iff.rfl
-
-lemma neq_of_not_iff : ¬(a ↔ b) → a ≠ b := mt Eq.to_iff
-
-lemma not_iff_not_of_iff (h₁ : a ↔ b) : ¬ a ↔ ¬ b :=
-Iff.intro
-  (λ (hna : ¬ a) (hb : b) => hna (Iff.elim_right h₁ hb))
-  (λ (hnb : ¬ b) (ha : a) => hnb (Iff.elim_left h₁ ha))
-
-lemma of_iff_true (h : a ↔ True) : a := h.2 ⟨⟩
-
-lemma not_of_iff_false : (a ↔ False) → ¬a := Iff.mp
-
-lemma not_not_intro : a → ¬¬a := fun a h => h a
-
-lemma iff_true_intro (h : a) : a ↔ True := ⟨fun _ => ⟨⟩, fun _ => h⟩
-
-lemma iff_false_intro (h : ¬a) : a ↔ False := ⟨h, fun h => h.elim⟩
-
-lemma not_iff_false_intro (h : a) : ¬a ↔ False := iff_false_intro (not_not_intro h)
-
 lemma not_not_not : ¬¬¬a ↔ ¬a := ⟨mt not_not_intro, not_not_intro⟩
-
-lemma imp_congr_left (h : a ↔ b) : (a → c) ↔ (b → c) :=
-⟨fun hac ha => hac (h.2 ha), fun hbc ha => hbc (h.1 ha)⟩
-
-lemma imp_congr_right (h : a → (b ↔ c)) : (a → b) ↔ (a → c) :=
-⟨fun hab ha => (h ha).1 (hab ha), fun hcd ha => (h ha).2 (hcd ha)⟩
-
-lemma imp_congr_ctx (h₁ : a ↔ c) (h₂ : c → (b ↔ d)) : (a → b) ↔ (c → d) :=
-(imp_congr_left h₁).trans (imp_congr_right h₂)
-
-lemma imp_congr (h₁ : a ↔ c) (h₂ : b ↔ d) : (a → b) ↔ (c → d) := imp_congr_ctx h₁ fun _ => h₂
-
-lemma Not.intro {a : Prop} (h : a → False) : ¬a := h
-
-def Not.elim (h : ¬a) (ha : a) : α := absurd ha h
-
-lemma not_true : ¬True ↔ False := not_iff_false_intro ⟨⟩
-
-lemma not_false_iff : ¬False ↔ True := iff_true_intro not_false
-
-lemma not_congr (h : a ↔ b) : ¬a ↔ ¬b := ⟨mt h.2, mt h.1⟩
-
-lemma ne_self_iff_false (a : α) : a ≠ a ↔ False := not_iff_false_intro rfl
-
-lemma eq_self_iff_true (a : α) : a = a ↔ True := iff_true_intro rfl
-
-lemma heq_self_iff_true (a : α) : a ≅ a ↔ True := iff_true_intro HEq.rfl
-
-lemma iff_not_self : ¬(a ↔ ¬a) | H => let f h := H.1 h h; f (H.2 f)
-
-lemma not_iff_self : ¬(¬a ↔ a) | H => iff_not_self H.symm
-
-lemma eq_comm {a b : α} : a = b ↔ b = a := ⟨Eq.symm, Eq.symm⟩
-
-lemma And.imp (f : a → c) (g : b → d) (h : a ∧ b) : c ∧ d := ⟨f h.1, g h.2⟩
-
-lemma and_congr (h₁ : a ↔ c) (h₂ : b ↔ d) : a ∧ b ↔ c ∧ d := ⟨And.imp h₁.1 h₂.1, And.imp h₁.2 h₂.2⟩
-
-lemma and_congr_right (h : a → (b ↔ c)) : (a ∧ b) ↔ (a ∧ c) :=
-⟨fun ⟨ha, hb⟩ => ⟨ha, (h ha).1 hb⟩, fun ⟨ha, hb⟩ => ⟨ha, (h ha).2 hb⟩⟩
-
-lemma and_comm : a ∧ b ↔ b ∧ a := ⟨And.symm, And.symm⟩
-
-lemma and_assoc : (a ∧ b) ∧ c ↔ a ∧ (b ∧ c) :=
-⟨fun ⟨⟨ha, hb⟩, hc⟩ => ⟨ha, hb, hc⟩, fun ⟨ha, hb, hc⟩ => ⟨⟨ha, hb⟩, hc⟩⟩
-
-lemma and_left_comm : a ∧ (b ∧ c) ↔ b ∧ (a ∧ c) :=
-by rw [← and_assoc, ← and_assoc, @and_comm a b]
-
-lemma and_iff_left (hb : b) : a ∧ b ↔ a := ⟨And.left, fun ha => ⟨ha, hb⟩⟩
-
-lemma and_iff_right (ha : a) : a ∧ b ↔ b := ⟨And.right, fun hb => ⟨ha, hb⟩⟩
-
-lemma and_not_self : ¬(a ∧ ¬a) | ⟨ha, hn⟩ => hn ha
-lemma not_and_self : ¬(¬a ∧ a) | ⟨hn, ha⟩ => hn ha
-
-lemma Or.imp (f : a → c) (g : b → d) (h : a ∨ b) : c ∨ d := h.elim (inl ∘ f) (inr ∘ g)
-
-lemma Or.imp_left (f : a → b) : a ∨ c → b ∨ c := Or.imp f id
-
-lemma Or.imp_right (f : b → c) : a ∨ b → a ∨ c := Or.imp id f
-
-lemma or_congr (h₁ : a ↔ c) (h₂ : b ↔ d) : (a ∨ b) ↔ (c ∨ d) :=
-⟨Or.imp h₁.1 h₂.1, Or.imp h₁.2 h₂.2⟩
-
-lemma or_comm : a ∨ b ↔ b ∨ a := ⟨Or.symm, Or.symm⟩
-
-lemma Or.resolve_left (h : a ∨ b) (na : ¬a) : b := h.elim na.elim id
-
-lemma Or.neg_resolve_left (h : ¬a ∨ b) (ha : a) : b := h.elim (absurd ha) id
-
-lemma Or.resolve_right (h : a ∨ b) (nb : ¬b) : a := h.elim id nb.elim
-
-lemma Or.neg_resolve_right (h : a ∨ ¬b) (nb : b) : a := h.elim id (absurd nb)
-
-open Or in
-lemma or_assoc {a b c} : (a ∨ b) ∨ c ↔ a ∨ (b ∨ c) :=
-⟨fun | inl (inl h) => inl h
-     | inl (inr h) => inr (inl h)
-     | inr h => inr (inr h),
- fun | inl h => inl (inl h)
-     | inr (inl h) => inl (inr h)
-     | inr (inr h) => inr h⟩
 
 lemma or_left_comm : a ∨ (b ∨ c) ↔ b ∨ (a ∨ c) :=
 by rw [← or_assoc, ← or_assoc, @or_comm a b]
 
-lemma not_or_intro : (na : ¬a) → (nb : ¬b) → ¬(a ∨ b) := Or.elim
-
-lemma not_or (p q) : ¬ (p ∨ q) ↔ ¬ p ∧ ¬ q :=
-⟨fun H => ⟨mt Or.inl H, mt Or.inr H⟩, fun ⟨hp, hq⟩ pq => pq.elim hp hq⟩
-
-lemma iff_congr (h₁ : a ↔ c) (h₂ : b ↔ d) : (a ↔ b) ↔ (c ↔ d) :=
-⟨fun h => h₁.symm.trans $ h.trans h₂, fun h => h₁.trans $ h.trans h₂.symm⟩
-
-@[simp] lemma imp_true_iff : (α → True) ↔ True := iff_true_intro fun _ => ⟨⟩
-
-@[simp] lemma false_imp_iff : (False → a) ↔ True := iff_true_intro False.elim
-
-def ExistsUnique (p : α → Prop) := ∃ x, p x ∧ ∀ y, p y → y = x
-
-open Lean in
-macro "∃! " xs:explicitBinders ", " b:term : term => expandExplicitBinders ``ExistsUnique xs b
-
-lemma ExistsUnique.intro {p : α → Prop} (w : α)
-  (h₁ : p w) (h₂ : ∀ y, p y → y = w) : ∃! x, p x := ⟨w, h₁, h₂⟩
-
 lemma ExistsUnique.exists {p : α → Prop} : (∃! x, p x) → ∃ x, p x | ⟨x, h, _⟩ => ⟨x, h⟩
 
-lemma ExistsUnique.unique {p : α → Prop} (h : ∃! x, p x)
-  {y₁ y₂ : α} (py₁ : p y₁) (py₂ : p y₂) : y₁ = y₂ :=
-let ⟨x, hx, hy⟩ := h; (hy _ py₁).trans (hy _ py₂).symm
-
--- Port note: this is `forall_congr` from Lean 3. In Lean 4, there is already something
--- with that name and a slightly different type.
-lemma forall_congr' {p q : α → Prop} (h : ∀ a, p a ↔ q a) : (∀ a, p a) ↔ ∀ a, q a :=
-⟨fun H a => (h a).1 (H a), fun H a => (h a).2 (H a)⟩
-
-lemma Exists.imp {p q : α → Prop} (h : ∀ a, p a → q a) : (∃ a, p a) → ∃ a, q a
-| ⟨a, ha⟩ => ⟨a, h a ha⟩
-
-lemma exists_congr {p q : α → Prop} (h : ∀ a, p a ↔ q a) : (∃ a, p a) ↔ ∃ a, q a :=
-⟨Exists.imp fun x => (h x).1, Exists.imp fun x => (h x).2⟩
-
-lemma exists_unique_congr {p q : α → Prop} (h : ∀ a, p a ↔ q a) : (∃! a, p a) ↔ ∃! a, q a :=
-exists_congr fun x => and_congr (h _) $ forall_congr' fun y => imp_congr_left (h _)
-
-lemma forall_not_of_not_exists {p : α → Prop} (hne : ¬∃ x, p x) (x) : ¬p x | hp => hne ⟨x, hp⟩
-
-instance forall_prop_decidable {p} (P : p → Prop)
-  [Dp : Decidable p] [DP : ∀ h, Decidable (P h)] : Decidable (∀ h, P h) :=
-  if h : p
-  then decidableOfDecidableOfIff (DP h) ⟨λ h2 _ => h2, λ al => al h⟩
-  else isTrue (λ h2 => absurd h2 h)
-
-@[simp] theorem forall_eq {p : α → Prop} {a' : α} : (∀a, a = a' → p a) ↔ p a' :=
-⟨λ h => h a' rfl, λ h a e => e.symm ▸ h⟩
-
-theorem forall_and_distrib {p q : α → Prop} : (∀ x, p x ∧ q x) ↔ (∀ x, p x) ∧ (∀ x, q x) :=
-⟨λ h => ⟨λ x => (h x).left, λ x => (h x).right⟩, λ ⟨h₁, h₂⟩ x => ⟨h₁ x, h₂ x⟩⟩
-
-def Decidable.by_cases := @byCases
-def Decidable.by_contradiction := @byContradiction
-
 lemma Decidable.not_and [Decidable p] [Decidable q] : ¬ (p ∧ q) ↔ ¬ p ∨ ¬ q := not_and_iff_or_not _ _
-
-def decidable_of_decidable_of_iff {p q : Prop} (hp : Decidable p) (h : p ↔ q) : Decidable q :=
-if hp : p then isTrue (Iff.mp h hp)
-else isFalse (Iff.mp (not_iff_not_of_iff h) hp)
-
-@[inline] def Or.by_cases [Decidable p] (h : p ∨ q) (h₁ : p → α) (h₂ : q → α) : α :=
-if hp : p then h₁ hp else h₂ (h.resolve_left hp)
 
 @[inline] def Or.by_cases' [Decidable q] (h : p ∨ q) (h₁ : p → α) (h₂ : q → α) : α :=
 if hq : q then h₂ hq else h₁ (h.resolve_right hq)
@@ -238,36 +41,6 @@ if hq : q then h₂ hq else h₁ (h.resolve_right hq)
 lemma Exists.nonempty {p : α → Prop} : (∃ x, p x) → Nonempty α | ⟨x, _⟩ => ⟨x⟩
 
 lemma ite_id [h : Decidable c] {α} (t : α) : (if c then t else t) = t := by cases h <;> rfl
-
-@[simp] lemma if_true {h : Decidable True} (t e : α) : (@ite α True h t e) = t :=
-if_pos trivial
-
-@[simp] lemma if_false {h : Decidable False} (t e : α) : (@ite α False h t e) = e :=
-if_neg not_false
-
-/-- Universe lifting operation -/
-structure ulift.{r, s} (α : Type s) : Type (max s r) :=
-up :: (down : α)
-
-namespace ulift
-/- Bijection between α and ulift.{v} α -/
-lemma up_down {α : Type u} : ∀ (b : ulift.{v} α), up (down b) = b
-| up a => rfl
-
-lemma down_up {α : Type u} (a : α) : down (up.{v} a) = a := rfl
-end ulift
-
-/-- Universe lifting operation from Sort to Type -/
-structure plift (α : Sort u) : Type u :=
-up :: (down : α)
-
-namespace plift
-/- Bijection between α and plift α -/
-lemma up_down : ∀ (b : plift α), up (down b) = b
-| (up a) => rfl
-
-lemma down_up (a : α) : down (up a) = a := rfl
-end plift
 
 namespace WellFounded
 
@@ -282,26 +55,146 @@ def fix' (hwf : WellFounded r) (F : ∀ x, (∀ y, r y x → C y) → C x) (x : 
 
 end WellFounded
 
--- Below are items ported from mathlib/src/logic/basic.lean
+end needs_better_home
+
+-- Below are items ported from mathlib3/src/logic/basic.lean.
+
+attribute [local instance] Classical.propDecidable
+
+section miscellany
+
+variable {α : Type _} {β : Type _}
+
+/-- An identity function with its main argument implicit. This will be printed as `hidden` even
+if it is applied to a large term, so it can be used for elision,
+as done in the `elide` and `unelide` tactics. -/
+@[reducible] def hidden {α : Sort _} {a : α} := a
+
+/-- Ex falso, the nondependent eliminator for the `empty` type. -/
+def Empty.elim {C : Sort _} : Empty → C := λ e => match e with.
+
+instance : Subsingleton Empty := ⟨λa => a.elim⟩
+
+end miscellany
+
+/-!
+### Declarations about propositional connectives
+-/
+
+theorem false_ne_true : False ≠ True
+| h => h.symm ▸ trivial
+
+section propositional
+variable {a b c d : Prop}
+
+/-! ### Declarations about `implies` -/
 
 theorem iff_of_eq (e : a = b) : a ↔ b := e ▸ Iff.rfl
 
-def decidable_of_iff (a : Prop) (h : a ↔ b) [D : Decidable a] : Decidable b :=
-decidableOfDecidableOfIff D h
+theorem iff_iff_eq : (a ↔ b) ↔ a = b := ⟨propext, iff_of_eq⟩
 
-/-
-Stuff from mathlib's logic/basic.lean.
-TODO: import the whole thing.
--/
+@[simp] lemma eq_iff_iff {p q : Prop} : (p = q) ↔ (p ↔ q) := iff_iff_eq.symm
+
+@[simp] theorem imp_self : (a → a) ↔ True := iff_true_intro id
+
+theorem imp_intro {α β : Prop} (h : α) : β → α := λ _ => h
+
+theorem imp_false : (a → False) ↔ ¬ a := Iff.rfl
+
+theorem imp_and_distrib {α} : (α → b ∧ c) ↔ (α → b) ∧ (α → c) :=
+⟨λ h => ⟨λ ha => (h ha).left, λ ha=> (h ha).right⟩,
+ λ h ha => ⟨h.left ha, h.right ha⟩⟩
+
+@[simp] theorem and_imp : (a ∧ b → c) ↔ (a → b → c) :=
+Iff.intro (λ h ha hb => h ⟨ha, hb⟩) (λ h ⟨ha, hb⟩ => h ha hb)
+
+theorem iff_def : (a ↔ b) ↔ (a → b) ∧ (b → a) :=
+iff_iff_implies_and_implies _ _
+
+theorem iff_def' : (a ↔ b) ↔ (b → a) ∧ (a → b) :=
+iff_def.trans And.comm
+
+theorem imp_true_iff {α : Sort _} : (α → True) ↔ True :=
+iff_true_intro $ λ_ => trivial
+
+theorem imp_iff_right (ha : a) : (a → b) ↔ b :=
+⟨λf => f ha, imp_intro⟩
+
+/-! ### Declarations about `not` -/
+
+/-- Ex falso for negation. From `¬ a` and `a` anything follows. This is the same as `absurd` with
+the arguments flipped, but it is in the `not` namespace so that projection notation can be used. -/
+def Not.elim {α : Sort _} (H1 : ¬a) (H2 : a) : α := absurd H2 H1
+
+@[reducible] theorem Not.imp {a b : Prop} (H2 : ¬b) (H1 : a → b) : ¬a := mt H1 H2
+
+theorem not_not_of_not_imp : ¬(a → b) → ¬¬a :=
+mt Not.elim
+
+theorem not_of_not_imp {a : Prop} : ¬(a → b) → ¬b :=
+mt imp_intro
+
+theorem dec_em (p : Prop) [Decidable p] : p ∨ ¬p := Decidable.em p
+
+theorem dec_em' (p : Prop) [Decidable p] : ¬p ∨ p := (dec_em p).swap
+
+theorem em (p : Prop) : p ∨ ¬p := Classical.em _
+
+theorem em' (p : Prop) : ¬p ∨ p := (em p).swap
+
+theorem or_not {p : Prop} : p ∨ ¬p := em _
+
+section eq_or_ne
+
+variable {α : Sort _} (x y : α)
+
+theorem Decidable.eq_or_ne [Decidable (x = y)] : x = y ∨ x ≠ y := dec_em $ x = y
+
+theorem Decidable.ne_or_eq [Decidable (x = y)] : x ≠ y ∨ x = y := dec_em' $ x = y
+
+theorem eq_or_ne : x = y ∨ x ≠ y := em $ x = y
+
+theorem ne_or_eq : x ≠ y ∨ x = y := em' $ x = y
+
+end eq_or_ne
+
+theorem by_contradiction {p} : (¬p → False) → p := Decidable.by_contradiction
+
+protected theorem Decidable.not_imp_symm [Decidable a] (h : ¬a → b) (hb : ¬b) : a :=
+Decidable.by_contradiction $ hb ∘ h
+
+/-! ### Declarations about `or` -/
+
+theorem or_congr_left (h : a ↔ b) : a ∨ c ↔ b ∨ c := or_congr h Iff.rfl
+
+theorem or_congr_right (h : b ↔ c) : a ∨ b ↔ a ∨ c := or_congr Iff.rfl h
+
+theorem or.right_comm : (a ∨ b) ∨ c ↔ (a ∨ c) ∨ b := by rw [or_assoc, or_assoc, or_comm b]
+
+theorem or_of_or_of_imp_of_imp (h₁ : a ∨ b) (h₂ : a → c) (h₃ : b → d) : c ∨ d :=
+Or.imp h₂ h₃ h₁
+
+theorem or_of_or_of_imp_left (h₁ : a ∨ c) (h : a → b) : b ∨ c :=
+Or.imp_left h h₁
+
+theorem or_of_or_of_imp_right (h₁ : c ∨ a) (h : a → b) : c ∨ b :=
+Or.imp_right h h₁
+
+theorem or.elim3 (h : a ∨ b ∨ c) (ha : a → d) (hb : b → d) (hc : c → d) : d :=
+Or.elim_on h ha (λ h₂ => Or.elim_on h₂ hb hc)
 
 theorem or_imp_distrib : (a ∨ b → c) ↔ (a → c) ∧ (b → c) :=
 ⟨fun h => ⟨fun ha => h (Or.inl ha), fun hb => h (Or.inr hb)⟩,
   fun ⟨ha, hb⟩ => Or.rec ha hb⟩
 
-@[simp] theorem and_imp : (a ∧ b → c) ↔ (a → b → c) :=
-Iff.intro (λ h ha hb => h ⟨ha, hb⟩) (λ h ⟨ha, hb⟩ => h ha hb)
+def decidable_of_iff (a : Prop) (h : a ↔ b) [D : Decidable a] : Decidable b :=
+decidableOfDecidableOfIff D h
 
 @[simp] theorem not_and : ¬ (a ∧ b) ↔ (a → ¬ b) := and_imp
+
+end propositional
+
+/-! ### Declarations about equality -/
 
 section equality
 
@@ -309,6 +202,11 @@ variable {α : Sort _} {a b : α}
 
 @[simp] theorem heq_iff_eq : HEq a b ↔ a = b :=
 ⟨eq_of_heq, heq_of_eq⟩
+
+theorem proof_irrel_heq {p q : Prop} (hp : p) (hq : q) : HEq hp hq :=
+have : p = q := propext ⟨λ _ => hq, λ _ => hp⟩
+by subst q
+   exact HEq.rfl
 
 @[simp] lemma eq_rec_constant {α : Sort _} {a a' : α} {β : Sort _} (y : β) (h : a = a') :
   (@Eq.rec α a (λ α _ => β) y a' h) = y :=
@@ -323,42 +221,69 @@ by subst hx
 
 end equality
 
-@[simp] theorem forall_const (α : Sort _) [i : Nonempty α] : (α → b) ↔ b :=
-⟨i.elim, λ hb x => hb⟩
+/-! ### Declarations about quantifiers -/
 
-@[simp] theorem exists_imp_distrib {p : α → Prop} : ((∃ x, p x) → b) ↔ ∀ x, p x → b :=
+section quantifiers
+variable {α : Sort _} {β : Sort _} {p q : α → Prop} {b : Prop}
+
+lemma forall_imp (h : ∀ a, p a → q a) : (∀ a, p a) → ∀ a, q a :=
+λ h' a => h a (h' a)
+
+lemma forall₂_congr {p q : α → β → Prop} (h : ∀ a b, p a b ↔ q a b) :
+  (∀ a b, p a b) ↔ (∀ a b, q a b) :=
+forall_congr' (λ a => forall_congr' (h a))
+
+lemma forall₃_congr {γ : Sort _} {p q : α → β → γ → Prop}
+  (h : ∀ a b c, p a b c ↔ q a b c) :
+  (∀ a b c, p a b c) ↔ (∀ a b c, q a b c) :=
+forall_congr' (λ a => forall₂_congr (h a))
+
+lemma forall₄_congr {γ δ : Sort _} {p q : α → β → γ → δ → Prop}
+  (h : ∀ a b c d, p a b c d ↔ q a b c d) :
+  (∀ a b c d, p a b c d) ↔ (∀ a b c d, q a b c d) :=
+forall_congr' (λ a => forall₃_congr (h a))
+
+lemma Exists.imp (h : ∀ a, (p a → q a)) (p : ∃ a, p a) : ∃ a, q a := exists_imp_exists h p
+
+lemma exists_imp_exists' {p : α → Prop} {q : β → Prop} (f : α → β) (hpq : ∀ a, p a → q (f a))
+  (hp : ∃ a, p a) : ∃ b, q b :=
+Exists.elim hp (λ a hp' => ⟨_, hpq _ hp'⟩)
+
+lemma exists₂_congr {p q : α → β → Prop} (h : ∀ a b, p a b ↔ q a b) :
+  (∃ a b, p a b) ↔ (∃ a b, q a b) :=
+exists_congr (λ a => exists_congr (h a))
+
+lemma exists₃_congr {γ : Sort _} {p q : α → β → γ → Prop}
+  (h : ∀ a b c, p a b c ↔ q a b c) :
+  (∃ a b c, p a b c) ↔ (∃ a b c, q a b c) :=
+exists_congr (λ a => exists₂_congr (h a))
+
+lemma exists₄_congr {γ δ : Sort _} {p q : α → β → γ → δ → Prop}
+  (h : ∀ a b c d, p a b c d ↔ q a b c d) :
+  (∃ a b c d, p a b c d) ↔ (∃ a b c d, q a b c d) :=
+exists_congr (λ a => exists₃_congr (h a))
+
+@[simp] theorem exists_imp_distrib : ((∃ x, p x) → b) ↔ ∀ x, p x → b :=
 ⟨λ h x hpx => h ⟨x, hpx⟩, λ h ⟨x, hpx⟩ => h x hpx⟩
 
-@[simp] theorem exists_false : ¬ (∃a:α, False) := fun ⟨a, h⟩ => h
+/--
+Extract an element from a existential statement, using `Classical.choose`.
+-/
+-- This enables projection notation.
+@[reducible] noncomputable def Exists.choose {p : α → Prop} (P : ∃ a, p a) : α := Classical.choose P
 
-@[simp] theorem exists_and_distrib_left {q : Prop} {p : α → Prop} :
-  (∃x, q ∧ p x) ↔ q ∧ (∃x, p x) :=
-⟨λ ⟨x, hq, hp⟩ => ⟨hq, x, hp⟩, λ ⟨hq, x, hp⟩ => ⟨x, hq, hp⟩⟩
+/--
+Show that an element extracted from `P : ∃ a, p a` using `P.some` satisfies `p`.
+-/
+lemma Exists.choose_spec {p : α → Prop} (P : ∃ a, p a) : p (P.choose) := Classical.choose_spec P
 
-@[simp] theorem exists_and_distrib_right {q : Prop} {p : α → Prop} :
-  (∃x, p x ∧ q) ↔ (∃x, p x) ∧ q :=
-by simp [and_comm]
+theorem not_exists_of_forall_not (h : ∀ x, ¬ p x) : ¬ ∃ x, p x :=
+exists_imp_distrib.2 h
 
-@[simp] theorem exists_eq {a' : α} : ∃ a, a = a' := ⟨_, rfl⟩
+@[simp] theorem not_exists : (¬ ∃ x, p x) ↔ ∀ x, ¬ p x :=
+exists_imp_distrib
 
-@[simp] theorem exists_eq' {a' : α} : ∃ a, a' = a := ⟨_, rfl⟩
-
-@[simp] theorem exists_eq_left {p : α → Prop} {a' : α} : (∃ a, a = a' ∧ p a) ↔ p a' :=
-⟨λ ⟨a, e, h⟩ => e ▸ h, λ h => ⟨_, rfl, h⟩⟩
-
-@[simp] theorem exists_eq_right {p : α → Prop} {a' : α} : (∃ a, p a ∧ a = a') ↔ p a' :=
-(exists_congr $ by exact λ a => and_comm).trans exists_eq_left
-
-@[simp] theorem exists_eq_left' {p : α → Prop} {a' : α} : (∃ a, a' = a ∧ p a) ↔ p a' :=
-by simp [@eq_comm _ a']
-
-@[simp] theorem exists_apply_eq_apply {α β : Type _} (f : α → β) (a' : α) : ∃ a, f a = f a' :=
-⟨a', rfl⟩
-
-protected theorem decidable.not_imp_symm [Decidable a] (h : ¬a → b) (hb : ¬b) : a :=
-Decidable.by_contradiction $ hb ∘ h
-
-theorem not.decidable_imp_symm [Decidable a] : (¬a → b) → ¬b → a := decidable.not_imp_symm
+theorem not.decidable_imp_symm [Decidable a] : (¬a → b) → ¬b → a := Decidable.not_imp_symm
 
 theorem not_forall_of_exists_not {p : α → Prop} : (∃ x, ¬ p x) → ¬ ∀ x, p x
 | ⟨x, hn⟩, h => hn (h x)
@@ -368,11 +293,49 @@ protected theorem Decidable.not_forall {p : α → Prop}
 ⟨not.decidable_imp_symm $ λ nx x => not.decidable_imp_symm (λ h => ⟨x, h⟩) nx,
  not_forall_of_exists_not⟩
 
-@[simp] theorem not_exists {p : α → Prop} : (¬ ∃ x, p x) ↔ ∀ x, ¬ p x :=
-exists_imp_distrib
+@[simp] theorem not_forall {p : α → Prop} : (¬ ∀ x, p x) ↔ ∃ x, ¬ p x := Decidable.not_forall
+
+@[simp] theorem forall_const (α : Sort _) [i : Nonempty α] : (α → b) ↔ b :=
+⟨i.elim, λ hb x => hb⟩
+
+theorem forall_and_distrib {p q : α → Prop} : (∀ x, p x ∧ q x) ↔ (∀ x, p x) ∧ (∀ x, q x) :=
+⟨λ h => ⟨λ x => (h x).left, λ x => (h x).right⟩, λ ⟨h₁, h₂⟩ x => ⟨h₁ x, h₂ x⟩⟩
+
+@[simp] theorem forall_eq {p : α → Prop} {a' : α} : (∀a, a = a' → p a) ↔ p a' :=
+⟨λ h => h a' rfl, λ h a e => e.symm ▸ h⟩
+
+@[simp] theorem exists_false : ¬ (∃a:α, False) := fun ⟨a, h⟩ => h
+
+@[simp] theorem exists_and_distrib_left {q : Prop} {p : α → Prop} :
+  (∃x, q ∧ p x) ↔ q ∧ (∃x, p x) :=
+⟨λ ⟨x, hq, hp⟩ => ⟨hq, x, hp⟩, λ ⟨hq, x, hp⟩ => ⟨x, hq, hp⟩⟩
+
+@[simp] theorem exists_and_distrib_right {q : Prop} {p : α → Prop} :
+  (∃x, p x ∧ q) ↔ (∃x, p x) ∧ q :=
+by simp [And.comm]
+
+@[simp] theorem exists_eq {a' : α} : ∃ a, a = a' := ⟨_, rfl⟩
+
+@[simp] theorem exists_eq' {a' : α} : ∃ a, a' = a := ⟨_, rfl⟩
+
+@[simp] theorem exists_eq_left {p : α → Prop} {a' : α} : (∃ a, a = a' ∧ p a) ↔ p a' :=
+⟨λ ⟨a, e, h⟩ => e ▸ h, λ h => ⟨_, rfl, h⟩⟩
+
+@[simp] theorem exists_eq_right {p : α → Prop} {a' : α} : (∃ a, p a ∧ a = a') ↔ p a' :=
+(exists_congr $ by exact λ a => And.comm).trans exists_eq_left
+
+@[simp] theorem exists_eq_left' {p : α → Prop} {a' : α} : (∃ a, a' = a ∧ p a) ↔ p a' :=
+by simp [@eq_comm _ a']
+
+@[simp] theorem exists_apply_eq_apply {α β : Type _} (f : α → β) (a' : α) : ∃ a, f a = f a' :=
+⟨a', rfl⟩
 
 theorem forall_prop_of_true {p : Prop} {q : p → Prop} (h : p) : (∀ h' : p, q h') ↔ q h :=
 @forall_const (q h) p ⟨h⟩
+
+end quantifiers
+
+section ite
 
 /-- A function applied to a `dite` is a `dite` of that function applied to each of the branches. -/
 lemma apply_dite {α β : Sort _} (f : α → β) (P : Prop) [Decidable P] (x : P → α) (y : ¬ P → α) :
@@ -394,6 +357,4 @@ by by_cases h : P <;> simp[h]
  ite (¬ P) x y = ite P y x :=
 dite_not P (λ _ => x) (λ _ => y)
 
-open Classical
-
-@[simp] theorem not_forall {p : α → Prop} : (¬ ∀ x, p x) ↔ ∃ x, ¬ p x := Decidable.not_forall
+end ite

--- a/Mathlib/Logic/Function/Basic.lean
+++ b/Mathlib/Logic/Function/Basic.lean
@@ -170,7 +170,7 @@ lemma bijective_iff_exists_unique (f : α → β) : bijective f ↔
 ⟨ λ hf b => let ⟨a, ha⟩ := hf.surjective b
             ⟨a, ha, λ a' ha' => hf.injective (ha'.trans ha.symm)⟩,
   λ he => ⟨
-    λ {a a'} h => ExistsUnique.unique (he (f a')) h rfl,
+    λ {a a'} h => unique_of_exists_unique (he (f a')) h rfl,
     λ b => ExistsUnique.exists (he b) ⟩⟩
 
 /-- Shorthand for using projection notation with `function.bijective_iff_exists_unique`. -/


### PR DESCRIPTION
Currently Mathlib/Logic/Basic.lean contains items from both lean3/library/init/logic.lean and mathlib3/src/logic/basic.lean.
My sense is that porting would go more smoothly if we instead maintained a one-to-one mapping between Lean 3 and Lean 4 files.

To that end, this revision splits out the lean3/library/init/logic.lean items and puts them in a new file Mathlib/Init/Logic.lean.
As I did this, I examined every item from the Lean 3 source and either:
  1. omitted it if it is already in the Lean 4 prelude,
  2. ported it / moved it from Mathlib/Logic/Basic.lean, or
  3. added a TODO
 
Similarly, for Mathlib/Logic/Basic, I organized/reordered the items to better match the Lean 3 source, and I ported some new items (though most remain unported). There were some odds and ends in that file that don't match up to the Lean 3 source; I collected those at the top in a `needs_new_home` section.

I expect that, following this revision, we will want to do a similar reorganization for Mathlib/Data/Nat/Basic.lean.