### PR TITLE
move Mathlib/Algebra/Order.lean to Mathlib/Init/Algebra/Order.lean

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1,7 +1,6 @@
 import Mathlib.Algebra.Group.Basic
 import Mathlib.Algebra.Group.Defs
 import Mathlib.Algebra.GroupWithZero.Defs
-import Mathlib.Algebra.Order
 import Mathlib.Algebra.Ring.Basic
 import Mathlib.Data.Array.Basic
 import Mathlib.Data.ByteArray
@@ -18,6 +17,7 @@ import Mathlib.Data.Subtype
 import Mathlib.Data.UInt
 import Mathlib.Dvd
 import Mathlib.Function
+import Mathlib.Init.Algebra.Order
 import Mathlib.Init.Logic
 import Mathlib.Logic.Basic
 import Mathlib.Logic.Function.Basic

--- a/Mathlib/Init/Algebra/Order.lean
+++ b/Mathlib/Init/Algebra/Order.lean
@@ -7,7 +7,7 @@ Original file's license:
   Released under Apache 2.0 license as described in the file LICENSE.
   Authors: Leonardo de Moura
 -/
-import Mathlib.Logic.Basic -- Only for Or.elim
+import Mathlib.Init.Logic
 
 /-!
 # Orders


### PR DESCRIPTION
Moves the file added https://github.com/leanprover-community/mathlib4/pull/18 into the new Mathlib/Init directory, added in https://github.com/leanprover-community/mathlib4/pull/34. This keeps the Lean 3 prelude code cleanly separated, and makes room for `mathlib3/src/algebra/order.lean`, when we eventually want to port that.