### PR TITLE
port remaining items from 'section propositional' in logic/basic

### DIFF
--- a/Mathlib/Data/List/Card.lean
+++ b/Mathlib/Data/List/Card.lean
@@ -45,7 +45,7 @@ theorem mem_remove_iff {a b : α} {as : List α} : b ∈ remove a as ↔ b ∈ a
     simp [remove]
     cases Decidable.em (a = a') with
     | inl h =>
-      simp [if_pos h, ih]
+      simp only [if_pos h, ih]
       exact ⟨fun ⟨h1, h2⟩ => ⟨Or.inr h1, h2⟩, fun ⟨h1, h2⟩ => ⟨Or.resolve_left h1 (h ▸ h2), h2⟩⟩
     | inr h =>
       simp [if_neg h, ih]

--- a/Mathlib/Init/Logic.lean
+++ b/Mathlib/Init/Logic.lean
@@ -190,7 +190,7 @@ lemma And.assoc : (a ∧ b) ∧ c ↔ a ∧ (b ∧ c) :=
 
 lemma and_assoc (a b : Prop) : (a ∧ b) ∧ c ↔ a ∧ (b ∧ c) := And.assoc
 
-lemma and_left_comm : a ∧ (b ∧ c) ↔ b ∧ (a ∧ c) :=
+lemma And.left_comm : a ∧ (b ∧ c) ↔ b ∧ (a ∧ c) :=
 by rw [← and_assoc, ← and_assoc, @And.comm a b]
 
 lemma and_iff_left (hb : b) : a ∧ b ↔ a := ⟨And.left, fun ha => ⟨ha, hb⟩⟩
@@ -386,7 +386,7 @@ section
   else isTrue (λ h2 => absurd h2 h)
 end
 
-lemma bool.ff_ne_tt : false = true → False := Bool.noConfusion
+lemma Bool.ff_ne_tt : false = true → False := Bool.noConfusion
 
 def is_dec_eq {α : Sort u} (p : α → α → Bool) : Prop   := ∀ ⦃x y : α⦄, p x y = true → x = y
 def is_dec_refl {α : Sort u} (p : α → α → Bool) : Prop := ∀ x, p x x = true

--- a/Mathlib/Logic/Basic.lean
+++ b/Mathlib/Logic/Basic.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura
 -/
 import Mathlib.Init.Logic
+import Mathlib.Function
 import Mathlib.Tactic.Basic
 
 section needs_better_home
@@ -160,8 +161,149 @@ end eq_or_ne
 
 theorem by_contradiction {p} : (¬p → False) → p := Decidable.by_contradiction
 
+-- alias by_contradiction ← by_contra
+theorem by_contra {p} : (¬p → False) → p := Decidable.by_contradiction
+
+/-
+In most of mathlib, we use the law of excluded middle (LEM) and the axiom of choice (AC) freely.
+The `decidable` namespace contains versions of lemmas from the root namespace that explicitly
+attempt to avoid the axiom of choice, usually by adding decidability assumptions on the inputs.
+
+You can check if a lemma uses the axiom of choice by using `#print axioms foo` and seeing if
+`classical.choice` appears in the list.
+-/
+--library_note "decidable namespace"
+
+/-
+As mathlib is primarily classical,
+if the type signature of a `def` or `lemma` does not require any `decidable` instances to state,
+it is preferable not to introduce any `decidable` instances that are needed in the proof
+as arguments, but rather to use the `classical` tactic as needed.
+
+In the other direction, when `decidable` instances do appear in the type signature,
+it is better to use explicitly introduced ones rather than allowing Lean to automatically infer
+classical ones, as these may cause instance mismatch errors later.
+-/
+--library_note "decidable arguments"
+
+-- See Note [decidable namespace]
+protected theorem Decidable.not_not [Decidable a] : ¬¬a ↔ a :=
+Iff.intro Decidable.by_contradiction not_not_intro
+
+/-- The Double Negation Theorem: `¬ ¬ P` is equivalent to `P`.
+The left-to-right direction, double negation elimination (DNE),
+is classically true but not constructively. -/
+@[simp] theorem not_not : ¬¬a ↔ a := Decidable.not_not
+
+theorem of_not_not : ¬¬a → a := by_contra
+
+-- See Note [decidable namespace]
+protected theorem Decidable.of_not_imp [Decidable a] (h : ¬ (a → b)) : a :=
+Decidable.by_contradiction (not_not_of_not_imp h)
+
+theorem of_not_imp : ¬ (a → b) → a := Decidable.of_not_imp
+
+-- See Note [decidable namespace]
 protected theorem Decidable.not_imp_symm [Decidable a] (h : ¬a → b) (hb : ¬b) : a :=
 Decidable.by_contradiction $ hb ∘ h
+
+theorem Not.decidable_imp_symm [Decidable a] : (¬a → b) → ¬b → a := Decidable.not_imp_symm
+
+theorem Not.imp_symm : (¬a → b) → ¬b → a := Not.decidable_imp_symm
+
+-- See Note [decidable namespace]
+protected theorem Decidable.not_imp_comm [Decidable a] [Decidable b] : (¬a → b) ↔ (¬b → a) :=
+⟨Not.decidable_imp_symm, Not.decidable_imp_symm⟩
+
+theorem not_imp_comm : (¬a → b) ↔ (¬b → a) := Decidable.not_imp_comm
+
+@[simp] theorem imp_not_self : (a → ¬a) ↔ ¬a := ⟨λ h ha => h ha ha, λ h _ => h⟩
+
+theorem Decidable.not_imp_self [Decidable a] : (¬a → a) ↔ a :=
+by have := @imp_not_self (¬a); rwa [Decidable.not_not] at this
+
+@[simp] theorem not_imp_self : (¬a → a) ↔ a := Decidable.not_imp_self
+
+theorem imp.swap : (a → b → c) ↔ (b → a → c) :=
+⟨Function.swap, Function.swap⟩
+
+theorem imp_not_comm : (a → ¬b) ↔ (b → ¬a) :=
+imp.swap
+
+/-! ### Declarations about `xor` -/
+
+@[simp] theorem xor_true : xor True = Not := funext $ λ a => by simp [xor]
+
+@[simp] theorem xor_false : xor False = id := funext $ λ a => by simp [xor]
+
+theorem xor_comm (a b) : xor a b = xor b a := by simp [xor, and_comm, or_comm]
+
+-- TODO is_commutative instance
+
+@[simp] theorem xor_self (a : Prop) : xor a a = False := by simp [xor]
+
+/-! ### Declarations about `and` -/
+
+theorem and_congr_left (h : c → (a ↔ b)) : a ∧ c ↔ b ∧ c :=
+And.comm.trans $ (and_congr_right h).trans And.comm
+
+theorem and_congr_left' (h : a ↔ b) : a ∧ c ↔ b ∧ c := and_congr h Iff.rfl
+
+theorem and_congr_right' (h : b ↔ c) : a ∧ b ↔ a ∧ c := and_congr Iff.rfl h
+
+theorem not_and_of_not_left (b : Prop) : ¬a → ¬(a ∧ b) :=
+mt And.left
+
+theorem not_and_of_not_right (a : Prop) {b : Prop} : ¬b → ¬(a ∧ b) :=
+mt And.right
+
+theorem And.imp_left (h : a → b) : a ∧ c → b ∧ c :=
+And.imp h id
+
+theorem And.imp_right (h : a → b) : c ∧ a → c ∧ b :=
+And.imp id h
+
+lemma And.right_comm : (a ∧ b) ∧ c ↔ (a ∧ c) ∧ b :=
+by simp only [And.left_comm, And.comm]; exact Iff.rfl
+
+lemma And.rotate : a ∧ b ∧ c ↔ b ∧ c ∧ a :=
+by simp only [And.left_comm, And.comm]; exact Iff.rfl
+
+theorem and_not_self_iff (a : Prop) : a ∧ ¬ a ↔ False :=
+Iff.intro (λ h => (h.right) (h.left)) (λ h => h.elim)
+
+theorem not_and_self_iff (a : Prop) : ¬ a ∧ a ↔ False :=
+Iff.intro (λ ⟨hna, ha⟩ => hna ha) False.elim
+
+theorem and_iff_left_of_imp {a b : Prop} (h : a → b) : (a ∧ b) ↔ a :=
+Iff.intro And.left (λ ha => ⟨ha, h ha⟩)
+
+theorem and_iff_right_of_imp {a b : Prop} (h : b → a) : (a ∧ b) ↔ b :=
+Iff.intro And.right (λ hb => ⟨h hb, hb⟩)
+
+@[simp] theorem and_iff_left_iff_imp {a b : Prop} : ((a ∧ b) ↔ a) ↔ (a → b) :=
+⟨λ h ha => (h.2 ha).2, and_iff_left_of_imp⟩
+
+@[simp] theorem and_iff_right_iff_imp {a b : Prop} : ((a ∧ b) ↔ b) ↔ (b → a) :=
+⟨λ h ha => (h.2 ha).1, and_iff_right_of_imp⟩
+
+@[simp] lemma iff_self_and {p q : Prop} : (p ↔ p ∧ q) ↔ (p → q) :=
+by rw [@Iff.comm p, and_iff_left_iff_imp]
+
+@[simp] lemma iff_and_self {p q : Prop} : (p ↔ q ∧ p) ↔ (p → q) :=
+by rw [and_comm, iff_self_and]
+
+@[simp] lemma And.congr_right_iff : (a ∧ b ↔ a ∧ c) ↔ (a → (b ↔ c)) :=
+⟨λ h ha => by simp [ha] at h; exact h, and_congr_right⟩
+
+@[simp] lemma And.congr_left_iff : (a ∧ c ↔ b ∧ c) ↔ c → (a ↔ b) :=
+by simp only [And.comm, ← And.congr_right_iff]; exact Iff.rfl
+
+@[simp] lemma and_self_left : a ∧ a ∧ b ↔ a ∧ b :=
+⟨λ h => ⟨h.1, h.2.2⟩, λ h => ⟨h.1, h.1, h.2⟩⟩
+
+@[simp] lemma and_self_right : (a ∧ b) ∧ b ↔ a ∧ b :=
+⟨λ h => ⟨h.1.1, h.2⟩, λ h => ⟨⟨h.1, h.2⟩, h.2⟩⟩
 
 /-! ### Declarations about `or` -/
 
@@ -180,17 +322,250 @@ Or.imp_left h h₁
 theorem or_of_or_of_imp_right (h₁ : c ∨ a) (h : a → b) : c ∨ b :=
 Or.imp_right h h₁
 
-theorem or.elim3 (h : a ∨ b ∨ c) (ha : a → d) (hb : b → d) (hc : c → d) : d :=
+theorem Or.elim3 (h : a ∨ b ∨ c) (ha : a → d) (hb : b → d) (hc : c → d) : d :=
 Or.elim_on h ha (λ h₂ => Or.elim_on h₂ hb hc)
 
 theorem or_imp_distrib : (a ∨ b → c) ↔ (a → c) ∧ (b → c) :=
 ⟨fun h => ⟨fun ha => h (Or.inl ha), fun hb => h (Or.inr hb)⟩,
   fun ⟨ha, hb⟩ => Or.rec ha hb⟩
 
-def decidable_of_iff (a : Prop) (h : a ↔ b) [D : Decidable a] : Decidable b :=
-decidableOfDecidableOfIff D h
+-- See Note [decidable namespace]
+protected theorem Decidable.or_iff_not_imp_left [Decidable a] : a ∨ b ↔ (¬ a → b) :=
+⟨Or.resolve_left, λ h => dite _ Or.inl (Or.inr ∘ h)⟩
+
+theorem or_iff_not_imp_left : a ∨ b ↔ (¬ a → b) := Decidable.or_iff_not_imp_left
+
+-- See Note [decidable namespace]
+protected theorem Decidable.or_iff_not_imp_right [Decidable b] : a ∨ b ↔ (¬ b → a) :=
+Or.comm.trans Decidable.or_iff_not_imp_left
+
+theorem or_iff_not_imp_right : a ∨ b ↔ (¬ b → a) := Decidable.or_iff_not_imp_right
+
+-- See Note [decidable namespace]
+protected theorem Decidable.not_imp_not [Decidable a] : (¬ a → ¬ b) ↔ (b → a) :=
+⟨λ h hb => Decidable.by_contradiction $ λ na => h na hb, mt⟩
+
+theorem not_imp_not : (¬ a → ¬ b) ↔ (b → a) := Decidable.not_imp_not
+
+@[simp] theorem or_iff_left_iff_imp : (a ∨ b ↔ a) ↔ (b → a) :=
+⟨λ h hb => h.1 (Or.inr hb), or_iff_left_of_imp⟩
+
+@[simp] theorem or_iff_right_iff_imp : (a ∨ b ↔ b) ↔ (a → b) :=
+by rw [or_comm, or_iff_left_iff_imp]
+
+/-! ### Declarations about distributivity -/
+
+/-- `∧` distributes over `∨` (on the left). -/
+theorem and_or_distrib_left : a ∧ (b ∨ c) ↔ (a ∧ b) ∨ (a ∧ c) :=
+⟨λ ⟨ha, hbc⟩ => hbc.imp (And.intro ha) (And.intro ha),
+ Or.rec (And.imp_right Or.inl) (And.imp_right Or.inr)⟩
+
+/-- `∧` distributes over `∨` (on the right). -/
+theorem or_and_distrib_right : (a ∨ b) ∧ c ↔ (a ∧ c) ∨ (b ∧ c) :=
+(And.comm.trans and_or_distrib_left).trans (or_congr And.comm And.comm)
+
+/-- `∨` distributes over `∧` (on the left). -/
+theorem or_and_distrib_left : a ∨ (b ∧ c) ↔ (a ∨ b) ∧ (a ∨ c) :=
+⟨Or.rec (λha => And.intro (Or.inl ha) (Or.inl ha)) (And.imp Or.inr Or.inr),
+ And.rec $ Or.rec (imp_intro ∘ Or.inl) (Or.imp_right ∘ And.intro)⟩
+
+/-- `∨` distributes over `∧` (on the right). -/
+theorem and_or_distrib_right : (a ∧ b) ∨ c ↔ (a ∨ c) ∧ (b ∨ c) :=
+(Or.comm.trans or_and_distrib_left).trans (and_congr Or.comm Or.comm)
+
+@[simp] lemma or_self_left : a ∨ a ∨ b ↔ a ∨ b :=
+⟨λ h => h.elim Or.inl id, λ h => h.elim Or.inl (Or.inr ∘ Or.inr)⟩
+
+@[simp] lemma or_self_right : (a ∨ b) ∨ b ↔ a ∨ b :=
+⟨λ h => h.elim id Or.inr, λ h => h.elim (Or.inl ∘ Or.inl) Or.inr⟩
+
+/-! Declarations about `iff` -/
+
+theorem iff_of_true (ha : a) (hb : b) : a ↔ b :=
+⟨λ_ => hb, λ _ => ha⟩
+
+theorem iff_of_false (ha : ¬a) (hb : ¬b) : a ↔ b :=
+⟨ha.elim, hb.elim⟩
+
+theorem iff_true_left (ha : a) : (a ↔ b) ↔ b :=
+⟨λ h => h.1 ha, iff_of_true ha⟩
+
+theorem iff_true_right (ha : a) : (b ↔ a) ↔ b :=
+Iff.comm.trans (iff_true_left ha)
+
+theorem iff_false_left (ha : ¬a) : (a ↔ b) ↔ ¬b :=
+⟨λ h => mt h.2 ha, iff_of_false ha⟩
+
+theorem iff_false_right (ha : ¬a) : (b ↔ a) ↔ ¬b :=
+Iff.comm.trans (iff_false_left ha)
+
+@[simp]
+lemma iff_mpr_iff_true_intro {P : Prop} (h : P) : Iff.mpr (iff_true_intro h) True.intro = h := rfl
+
+-- See Note [decidable namespace]
+protected theorem Decidable.not_or_of_imp [Decidable a] (h : a → b) : ¬ a ∨ b :=
+if ha : a then Or.inr (h ha) else Or.inl ha
+
+theorem not_or_of_imp : (a → b) → ¬ a ∨ b := Decidable.not_or_of_imp
+
+-- See Note [decidable namespace]
+protected theorem Decidable.imp_iff_not_or [Decidable a] : (a → b) ↔ (¬ a ∨ b) :=
+⟨Decidable.not_or_of_imp, Or.neg_resolve_left⟩
+
+theorem imp_iff_not_or : (a → b) ↔ (¬ a ∨ b) := Decidable.imp_iff_not_or
+
+-- See Note [decidable namespace]
+protected theorem Decidable.imp_or_distrib [Decidable a] : (a → b ∨ c) ↔ (a → b) ∨ (a → c) :=
+by simp [Decidable.imp_iff_not_or, Or.comm, Or.left_comm]
+
+theorem imp_or_distrib : (a → b ∨ c) ↔ (a → b) ∨ (a → c) := Decidable.imp_or_distrib
+
+-- See Note [decidable namespace]
+protected theorem Decidable.imp_or_distrib' [Decidable b] : (a → b ∨ c) ↔ (a → b) ∨ (a → c) :=
+by (by_cases b)
+   - simp [h]
+   - rw [eq_false h, false_or]
+     exact Iff.symm (or_iff_right_of_imp (λhx x => False.elim (hx x)))
+
+theorem imp_or_distrib' : (a → b ∨ c) ↔ (a → b) ∨ (a → c) := Decidable.imp_or_distrib'
+
+theorem not_imp_of_and_not : a ∧ ¬ b → ¬ (a → b)
+| ⟨ha, hb⟩, h => hb $ h ha
+
+-- See Note [decidable namespace]
+protected theorem Decidable.not_imp [Decidable a] : ¬(a → b) ↔ a ∧ ¬b :=
+⟨λ h => ⟨Decidable.of_not_imp h, not_of_not_imp h⟩, not_imp_of_and_not⟩
+
+theorem not_imp : ¬(a → b) ↔ a ∧ ¬b := Decidable.not_imp
+
+-- for monotonicity
+lemma imp_imp_imp (h₀ : c → a) (h₁ : b → d) : (a → b) → (c → d) :=
+λ (h₂ : a → b) => h₁ ∘ h₂ ∘ h₀
+
+-- See Note [decidable namespace]
+protected theorem Decidable.peirce (a b : Prop) [Decidable a] : ((a → b) → a) → a :=
+if ha : a then λ h => ha else λ h => h ha.elim
+
+theorem peirce (a b : Prop) : ((a → b) → a) → a := Decidable.peirce _ _
+
+theorem peirce' {a : Prop} (H : ∀ b : Prop, (a → b) → a) : a := H _ id
+
+-- See Note [decidable namespace]
+protected theorem Decidable.not_iff_not [Decidable a] [Decidable b] : (¬ a ↔ ¬ b) ↔ (a ↔ b) :=
+by rw [@iff_def (¬ a), @iff_def' a]; exact and_congr Decidable.not_imp_not Decidable.not_imp_not
+
+theorem not_iff_not : (¬ a ↔ ¬ b) ↔ (a ↔ b) := Decidable.not_iff_not
+
+-- See Note [decidable namespace]
+protected theorem Decidable.not_iff_comm [Decidable a] [Decidable b] : (¬ a ↔ b) ↔ (¬ b ↔ a) :=
+by rw [@iff_def (¬ a), @iff_def (¬ b)]; exact and_congr Decidable.not_imp_comm imp_not_comm
+
+theorem not_iff_comm : (¬ a ↔ b) ↔ (¬ b ↔ a) := Decidable.not_iff_comm
+
+-- See Note [decidable namespace]
+protected theorem Decidable.not_iff : ∀ [Decidable b], ¬ (a ↔ b) ↔ (¬ a ↔ b) :=
+by intro h
+   match h with
+   | isTrue h => simp[h, iff_true]
+   | isFalse h => simp[h, iff_false]
+
+theorem not_iff : ¬ (a ↔ b) ↔ (¬ a ↔ b) := Decidable.not_iff
+
+-- See Note [decidable namespace]
+protected theorem Decidable.iff_not_comm [Decidable a] [Decidable b] : (a ↔ ¬ b) ↔ (b ↔ ¬ a) :=
+by rw [@iff_def a, @iff_def b]; exact and_congr imp_not_comm Decidable.not_imp_comm
+
+theorem iff_not_comm : (a ↔ ¬ b) ↔ (b ↔ ¬ a) := Decidable.iff_not_comm
+
+-- See Note [decidable namespace]
+protected theorem Decidable.iff_iff_and_or_not_and_not [Decidable b] :
+  (a ↔ b) ↔ (a ∧ b) ∨ (¬ a ∧ ¬ b) :=
+by split
+   - intro h; rw [h]
+     (by_cases b)
+     - (exact Or.inl (And.intro h h))
+     - (exact Or.inr (And.intro h h))
+   - intro h
+     match h with
+     | Or.inl h => exact Iff.intro (λ _ => h.2) (λ _ => h.1)
+     | Or.inr h => exact Iff.intro (λ a => False.elim $ h.1 a) (λ b => False.elim $ h.2 b)
+
+theorem iff_iff_and_or_not_and_not : (a ↔ b) ↔ (a ∧ b) ∨ (¬ a ∧ ¬ b) :=
+Decidable.iff_iff_and_or_not_and_not
+
+lemma Decidable.iff_iff_not_or_and_or_not [Decidable a] [Decidable b] :
+  (a ↔ b) ↔ ((¬a ∨ b) ∧ (a ∨ ¬b)) :=
+by rw [iff_iff_implies_and_implies a b]
+   simp only [Decidable.imp_iff_not_or, Or.comm]
+   exact Iff.rfl
+
+lemma iff_iff_not_or_and_or_not : (a ↔ b) ↔ ((¬a ∨ b) ∧ (a ∨ ¬b)) :=
+Decidable.iff_iff_not_or_and_or_not
+
+-- See Note [decidable namespace]
+protected theorem Decidable.not_and_not_right [Decidable b] : ¬(a ∧ ¬b) ↔ (a → b) :=
+⟨λ h ha => h.decidable_imp_symm $ And.intro ha, λ h ⟨ha, hb⟩ => hb $ h ha⟩
+
+theorem not_and_not_right : ¬(a ∧ ¬b) ↔ (a → b) := Decidable.not_and_not_right
+
+/-- Transfer decidability of `a` to decidability of `b`, if the propositions are equivalent.
+**Important**: this function should be used instead of `rw` on `decidable b`, because the
+kernel will get stuck reducing the usage of `propext` otherwise,
+and `dec_trivial` will not work. -/
+@[inline] def decidable_of_iff (a : Prop) (h : a ↔ b) [D : Decidable a] : Decidable b :=
+decidable_of_decidable_of_iff D h
+
+/-- Transfer decidability of `b` to decidability of `a`, if the propositions are equivalent.
+This is the same as `decidable_of_iff` but the iff is flipped. -/
+@[inline] def decidable_of_iff' (b : Prop) (h : a ↔ b) [D : Decidable b] : Decidable a :=
+decidable_of_decidable_of_iff D h.symm
+
+/-- Prove that `a` is decidable by constructing a boolean `b` and a proof that `b ↔ a`.
+(This is sometimes taken as an alternate definition of decidability.) -/
+def decidable_of_bool : ∀ (b : Bool) (h : b ↔ a), Decidable a
+| true, h => isTrue (h.1 rfl)
+| false, h => isFalse (mt h.2 Bool.ff_ne_tt)
+
+/-! ### De Morgan's laws -/
+
+theorem not_and_of_not_or_not (h : ¬ a ∨ ¬ b) : ¬ (a ∧ b)
+| ⟨ha, hb⟩ => Or.elim_on h (absurd ha) (absurd hb)
+
+-- See Note [decidable namespace]
+protected theorem Decidable.not_and_distrib [Decidable a] : ¬ (a ∧ b) ↔ ¬a ∨ ¬b :=
+⟨λ h => if ha : a then Or.inr (λ hb => h ⟨ha, hb⟩) else Or.inl ha, not_and_of_not_or_not⟩
+
+-- See Note [decidable namespace]
+protected theorem Decidable.not_and_distrib' [Decidable b] : ¬ (a ∧ b) ↔ ¬a ∨ ¬b :=
+⟨λ h => if hb : b then Or.inl (λ ha => h ⟨ha, hb⟩) else Or.inr hb, not_and_of_not_or_not⟩
+
+/-- One of de Morgan's laws: the negation of a conjunction is logically equivalent to the
+disjunction of the negations. -/
+theorem not_and_distrib : ¬ (a ∧ b) ↔ ¬a ∨ ¬b := Decidable.not_and_distrib
 
 @[simp] theorem not_and : ¬ (a ∧ b) ↔ (a → ¬ b) := and_imp
+
+theorem not_and' : ¬ (a ∧ b) ↔ b → ¬a :=
+not_and.trans imp_not_comm
+
+/-- One of de Morgan's laws: the negation of a disjunction is logically equivalent to the
+conjunction of the negations. -/
+theorem not_or_distrib : ¬ (a ∨ b) ↔ ¬ a ∧ ¬ b :=
+⟨λ h => ⟨λ ha => h (Or.inl ha), λ hb => h (Or.inr hb)⟩,
+ λ ⟨h₁, h₂⟩ h => Or.elim_on h h₁ h₂⟩
+
+-- See Note [decidable namespace]
+protected theorem Decidable.or_iff_not_and_not [Decidable a] [Decidable b] : a ∨ b ↔ ¬ (¬a ∧ ¬b) :=
+by rw [← not_or_distrib, Decidable.not_not]
+
+theorem or_iff_not_and_not : a ∨ b ↔ ¬ (¬a ∧ ¬b) := Decidable.or_iff_not_and_not
+
+-- See Note [decidable namespace]
+protected theorem Decidable.and_iff_not_or_not [Decidable a] [Decidable b] :
+  a ∧ b ↔ ¬ (¬ a ∨ ¬ b) :=
+by rw [← Decidable.not_and_distrib, Decidable.not_not]
+
+theorem and_iff_not_or_not : a ∧ b ↔ ¬ (¬ a ∨ ¬ b) := Decidable.and_iff_not_or_not
 
 end propositional
 


### PR DESCRIPTION
Ports the remaining items from mathlib3's `section propositional` in logic/basic.lean.

Also fixes up some names of existing items.