### PR TITLE
port init/algebra/functions.lean

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -17,6 +17,7 @@ import Mathlib.Data.Subtype
 import Mathlib.Data.UInt
 import Mathlib.Dvd
 import Mathlib.Function
+import Mathlib.Init.Algebra.Functions
 import Mathlib.Init.Algebra.Order
 import Mathlib.Init.Logic
 import Mathlib.Logic.Basic

--- a/Mathlib/Init/Algebra/Functions.lean
+++ b/Mathlib/Init/Algebra/Functions.lean
@@ -1,0 +1,125 @@
+/-
+Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jeremy Avigad, Leonardo de Moura
+-/
+
+import Mathlib.Init.Algebra.Order
+
+universe u
+
+section
+
+variable {α : Type u} [LinearOrder α]
+
+lemma min_le_left (a b : α) : min a b ≤ a :=
+if h : a ≤ b
+then by simp[min, if_pos h, le_refl]
+else by simp[min, if_neg h]
+        exact le_of_not_le h
+
+lemma min_le_right (a b : α) : min a b ≤ b :=
+if h : a ≤ b
+then by simp[min, if_pos h]; exact h
+else by simp[min, if_neg h, le_refl]
+
+lemma le_min {a b c : α} (h₁ : c ≤ a) (h₂ : c ≤ b) : c ≤ min a b :=
+if h : a ≤ b
+then by simp[min, if_pos h]; exact h₁
+else by simp[min, if_neg h]; exact h₂
+
+lemma le_max_left (a b : α) : a ≤ max a b :=
+if h : b < a
+then by simp[max, if_pos h, le_refl]
+else by simp[max, if_neg h]
+        exact le_of_not_lt h
+
+lemma le_max_right (a b : α) : b ≤ max a b :=
+if h : b < a
+then by simp[max, if_pos h]; exact le_of_lt h
+else by simp[max, if_neg h, le_refl]
+
+lemma max_le {a b c : α} (h₁ : a ≤ c) (h₂ : b ≤ c) : max a b ≤ c :=
+if h : b < a
+then by simp[max, if_pos h]; exact h₁
+else by simp[max, if_neg h]; exact h₂
+
+lemma eq_min {a b c : α} (h₁ : c ≤ a) (h₂ : c ≤ b) (h₃ : ∀{d}, d ≤ a → d ≤ b → d ≤ c) :
+  c = min a b :=
+le_antisymm (le_min h₁ h₂) (h₃ (min_le_left a b) (min_le_right a b))
+
+lemma min_comm (a b : α) : min a b = min b a :=
+eq_min (min_le_right a b) (min_le_left a b) (λ {c} h₁ h₂ => le_min h₂ h₁)
+
+lemma min_assoc (a b c : α) : min (min a b) c = min a (min b c) :=
+by (apply eq_min)
+   - (apply le_trans; apply min_le_left; apply min_le_left)
+   - (apply le_min; apply le_trans; apply min_le_left; apply min_le_right; apply min_le_right)
+   - (intros d h₁ h₂; apply le_min; apply le_min h₁; apply le_trans h₂; apply min_le_left;
+      apply le_trans h₂; apply min_le_right )
+
+lemma min_left_comm : @left_commutative α α min :=
+left_comm min (@min_comm α _) (@min_assoc α _)
+
+@[simp]
+lemma min_self (a : α) : min a a = a := by simp[min]
+
+lemma min_eq_left {a b : α} (h : a ≤ b) : min a b = a :=
+by apply Eq.symm; apply eq_min (le_refl _) h; intros; assumption
+
+lemma min_eq_right {a b : α} (h : b ≤ a) : min a b = b :=
+by rw [min_comm]
+   exact min_eq_left h
+
+lemma eq_max {a b c : α} (h₁ : a ≤ c) (h₂ : b ≤ c) (h₃ : ∀{d}, a ≤ d → b ≤ d → c ≤ d) : c = max a b :=
+le_antisymm (h₃ (le_max_left a b) (le_max_right a b)) (max_le h₁ h₂)
+
+lemma max_comm (a b : α) : max a b = max b a :=
+eq_max (le_max_right a b) (le_max_left a b) (λ {c} h₁ h₂ => max_le h₂ h₁)
+
+lemma max_assoc (a b c : α) : max (max a b) c = max a (max b c) := by
+  (apply eq_max)
+  - (apply le_trans; apply le_max_left a b; apply le_max_left)
+  - (apply max_le; apply le_trans; apply le_max_right a b; apply le_max_left; apply le_max_right)
+  - (intros d h₁ h₂; apply max_le; apply max_le h₁; apply le_trans (le_max_left _ _) h₂;
+     apply le_trans (le_max_right _ _) h₂)
+
+lemma max_left_comm : ∀ (a b c : α), max a (max b c) = max b (max a c) :=
+left_comm max (@max_comm α _) (@max_assoc α _)
+
+@[simp]
+lemma max_self (a : α) : max a a = a := by simp[max]
+
+lemma max_eq_left {a b : α} (h : b ≤ a) : max a b = a :=
+by apply Eq.symm; apply eq_max (le_refl _) h; intros; assumption
+
+lemma max_eq_right {a b : α} (h : a ≤ b) : max a b = b :=
+by rw [←max_comm b a]; exact max_eq_left h
+
+/- these rely on lt_of_lt -/
+
+lemma min_eq_left_of_lt {a b : α} (h : a < b) : min a b = a :=
+min_eq_left (le_of_lt h)
+
+lemma min_eq_right_of_lt {a b : α} (h : b < a) : min a b = b :=
+min_eq_right (le_of_lt h)
+
+lemma max_eq_left_of_lt {a b : α} (h : b < a) : max a b = a :=
+max_eq_left (le_of_lt h)
+
+lemma max_eq_right_of_lt {a b : α} (h : a < b) : max a b = b :=
+max_eq_right (le_of_lt h)
+
+/- these use the fact that it is a linear ordering -/
+
+lemma lt_min {a b c : α} (h₁ : a < b) (h₂ : a < c) : a < min b c :=
+Or.elim_on (le_or_gt b c)
+  (λ h : b ≤ c => by rwa [min_eq_left h])
+  (λ h : b > c => by rwa [min_eq_right_of_lt h])
+
+lemma max_lt {a b c : α} (h₁ : a < c) (h₂ : b < c) : max a b < c :=
+Or.elim_on (le_or_gt a b)
+  (λ h : a ≤ b => by rwa [max_eq_right h])
+  (λ h : a > b => by rwa [max_eq_left_of_lt h])
+
+end

--- a/Mathlib/Init/Logic.lean
+++ b/Mathlib/Init/Logic.lean
@@ -546,4 +546,39 @@ lemma let_eq {α : Sort v} {β : Sort u} {a₁ a₂ : α} {b₁ b₂ : α → β
              a₁ = a₂ → (∀ x, b₁ x = b₂ x) → (let x : α := a₁; b₁ x) = (let x : α := a₂; b₂ x) :=
 λ h₁ h₂ => Eq.recOn (motive := λ a _ => (let x := a₁; b₁ x) = (let x := a; b₂ x)) h₁ (h₂ a₁)
 
--- TODO: `section relation` and `section binary`
+-- TODO: `section relation`
+
+section binary
+variable {α : Type u} {β : Type v}
+variable (f : α → α → α)
+variable (inv : α → α)
+variable (one : α)
+variable (g : α → α → α)
+
+def commutative        := ∀ a b, f a b = f b a
+def associative        := ∀ a b c, f (f a b) c = f a (f b c)
+def left_identity      := ∀ a, f one a = a
+def right_identity     := ∀ a, f a one = a
+def right_inverse      := ∀ a, f a (inv a) = one
+def left_cancelative   := ∀ a b c, f a b = f a c → b = c
+def right_cancelative  := ∀ a b c, f a b = f c b → a = c
+def left_distributive  := ∀ a b c, f a (g b c) = g (f a b) (f a c)
+def right_distributive := ∀ a b c, f (g a b) c = g (f a c) (f b c)
+def right_commutative (h : β → α → β) := ∀ b a₁ a₂, h (h b a₁) a₂ = h (h b a₂) a₁
+def left_commutative  (h : α → β → β) := ∀ a₁ a₂ b, h a₁ (h a₂ b) = h a₂ (h a₁ b)
+
+lemma left_comm : commutative f → associative f → left_commutative f :=
+by intros hcomm hassoc a b c
+   have h1 : f a (f b c) = f (f a b) c := Eq.symm (hassoc a b c)
+   have h2 : f (f a b) c = f (f b a) c := hcomm a b ▸ rfl
+   have h3 : f (f b a) c = f b (f a c) := hassoc b a c
+   rw [←h3, ←h2, ←h1]
+
+lemma right_comm : commutative f → associative f → right_commutative f :=
+by intros hcomm hassoc a b c
+   have h1 : f (f a b) c = f a (f b c) := hassoc a b c
+   have h2 : f a (f b c) = f a (f c b) := hcomm b c ▸ rfl
+   have h3 : f a (f c b) = f (f a c) b := Eq.symm (hassoc a c b)
+   rw [←h3, ←h2, ←h1]
+
+end binary


### PR DESCRIPTION
Ports lean3/library/init/algebra/functions.lean and adds `section binary` in `logic.lean`.

Uses some slightly-more-manual proofs to avoid the need for the SMT-based tactics used in the Lean 3 version.