### PR TITLE
update lean version

### DIFF
--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -194,7 +194,7 @@ lemma bex_cons (p : α → Prop) (a : α) (l : List α) :
       | inl h => { rw [h] at px; exact Or.inl px }
       | inr h => { exact Or.inr ⟨x, h, px⟩ }
   intro h
-  apply Or.elim _ _ h
+  apply Or.elim h
   { exact fun pa => ⟨a, mem_cons_self a l, pa⟩ }
   exact fun ⟨x, xmem, px⟩ => ⟨x, mem_cons_of_mem _ xmem, px⟩
 
@@ -216,18 +216,18 @@ theorem mem_singleton_self (a : α) : a ∈ [a] := mem_cons_self _ _
 
 theorem eq_of_mem_singleton {a b : α} : a ∈ [b] → a = b :=
 fun this : a ∈ [b] => Or.elim
+  (eq_or_mem_of_mem_cons this)
   (fun this : a = b => this)
   (fun this : a ∈ [] => absurd this (not_mem_nil a))
-  (eq_or_mem_of_mem_cons this)
 
 @[simp] theorem mem_singleton {a b : α} : a ∈ [b] ↔ a = b :=
 ⟨eq_of_mem_singleton, Or.inl⟩
 
 theorem mem_of_mem_cons_of_mem {a b : α} {l : List α} : a ∈ b::l → b ∈ l → a ∈ l :=
 fun ainbl binl => Or.elim
+  (eq_or_mem_of_mem_cons ainbl)
   (fun this : a = b => by subst a; exact binl)
   (fun this : a ∈ l => this)
-  (eq_or_mem_of_mem_cons ainbl)
 
 theorem _root_.decidable.List.eq_or_ne_mem_of_mem [DecidableEq α]
   {a b : α} {l : List α} (h : a ∈ b :: l) : a = b ∨ (a ≠ b ∧ a ∈ l) :=
@@ -256,7 +256,7 @@ theorem mem_split {a : α} {l : List α} (h : a ∈ l) : ∃ s t : List α, l = 
           rw [h', cons_append]
 
 theorem mem_of_ne_of_mem {a y : α} {l : List α} (h₁ : a ≠ y) (h₂ : a ∈ y :: l) : a ∈ l :=
-Or.elim (fun e => absurd e h₁) (fun r => r) $ eq_or_mem_of_mem_cons h₂
+Or.elim (eq_or_mem_of_mem_cons h₂) (fun e => absurd e h₁) (fun r => r)
 
 theorem ne_of_not_mem_cons {a b : α} {l : List α} : (a ∉ b::l) → a ≠ b :=
 fun nin aeqb => absurd (Or.inl aeqb) nin
@@ -512,7 +512,7 @@ theorem or_exists_of_exists_mem_cons {p : α → Prop} {a : α} {l : List α} :
 theorem exists_mem_cons_iff (p : α → Prop) (a : α) (l : List α) :
   (∃ x ∈ a :: l, p x) ↔ p a ∨ ∃ x ∈ l, p x :=
 Iff.intro or_exists_of_exists_mem_cons
-  (fun h => Or.elim (exists_mem_cons_of l) exists_mem_cons_of_exists h)
+  (fun h => Or.elim h (exists_mem_cons_of l) exists_mem_cons_of_exists)
 
 /-! ### List subset -/
 
@@ -537,9 +537,9 @@ lemma subset_of_cons_subset {a : α} {l₁ l₂ : List α} : a::l₁ ⊆ l₂ �
 
 lemma cons_subset_cons {l₁ l₂ : List α} (a : α) (s : l₁ ⊆ l₂) : (a::l₁) ⊆ (a::l₂) :=
 λ {b} hin => Or.elim
+  (eq_or_mem_of_mem_cons hin)
   (λ e : b = a => Or.inl e)
   (λ i : b ∈ l₁ => Or.inr (s i))
-  (eq_or_mem_of_mem_cons hin)
 
 @[simp] lemma subset_append_left (l₁ l₂ : List α) : l₁ ⊆ l₁++l₂ :=
 λ {b} => mem_append_left _
@@ -942,7 +942,7 @@ theorem mem_of_mem_erasep {a : α} {l : List α} : a ∈ l.erasep p → a ∈ l 
 @[simp] theorem mem_erasep_of_neg {a : α} {l : List α} (pa : ¬ p a) : a ∈ l.erasep p ↔ a ∈ l := by
   refine ⟨mem_of_mem_erasep, ?_⟩
   intro al
-  refine Or.elim ?_ ?_ $ exists_or_eq_self_of_erasep p l
+  apply Or.elim (exists_or_eq_self_of_erasep p l)
   { intro h; rw [h]; assumption }
   intro ⟨c, l₁, l₂, h₁, h₂, h₃, h₄⟩
   rw [h₄]

--- a/Mathlib/Init/Algebra/Functions.lean
+++ b/Mathlib/Init/Algebra/Functions.lean
@@ -113,12 +113,12 @@ max_eq_right (le_of_lt h)
 /- these use the fact that it is a linear ordering -/
 
 lemma lt_min {a b c : α} (h₁ : a < b) (h₂ : a < c) : a < min b c :=
-Or.elim_on (le_or_gt b c)
+Or.elim (le_or_gt b c)
   (λ h : b ≤ c => by rwa [min_eq_left h])
   (λ h : b > c => by rwa [min_eq_right_of_lt h])
 
 lemma max_lt {a b c : α} (h₁ : a < c) (h₂ : b < c) : max a b < c :=
-Or.elim_on (le_or_gt a b)
+Or.elim (le_or_gt a b)
   (λ h : a ≤ b => by rwa [max_eq_right h])
   (λ h : a > b => by rwa [max_eq_left_of_lt h])
 

--- a/Mathlib/Init/Algebra/Order.lean
+++ b/Mathlib/Init/Algebra/Order.lean
@@ -225,15 +225,15 @@ lt_asymm h
 
 theorem lt_trichotomy (a b : α) : a < b ∨ a = b ∨ b < a :=
 Or.elim
-  (λ h : a ≤ b   => Or.elim
-    (λ h : a < b => Or.inl h)
-    (λ h : a = b => Or.inr (Or.inl h))
-    (Decidable.lt_or_eq_of_le h))
-  (λ h : b ≤ a   => Or.elim
-    (λ h : b < a => Or.inr (Or.inr h))
-    (λ h : b = a => Or.inr (Or.inl h.symm))
-    (Decidable.lt_or_eq_of_le h))
   (le_total a b)
+  (λ h : a ≤ b   => Or.elim
+    (Decidable.lt_or_eq_of_le h)
+    (λ h : a < b => Or.inl h)
+    (λ h : a = b => Or.inr (Or.inl h)))
+  (λ h : b ≤ a   => Or.elim
+    (Decidable.lt_or_eq_of_le h)
+    (λ h : b < a => Or.inr (Or.inr h))
+    (λ h : b = a => Or.inr (Or.inl h.symm)))
 
 theorem le_of_not_lt {a b : α} (h : ¬ b < a) : a ≤ b :=
 match lt_trichotomy a b with

--- a/Mathlib/Init/Logic.lean
+++ b/Mathlib/Init/Logic.lean
@@ -68,14 +68,6 @@ lemma And.symm : a ∧ b → b ∧ a | ⟨ha, hb⟩ => ⟨hb, ha⟩
 
 /- or -/
 
-lemma Or.elim {a b c : Prop} (h₁ : a → c) (h₂ : b → c) : (h : a ∨ b) → c
-| inl ha => h₁ ha
-| inr hb => h₂ hb
-
--- Port note: in Lean 3, this is named Or.elim.
-lemma Or.elim_on (h₁ : a ∨ b) (h₂ : a → c) (h₃ : b → c) : c :=
-Or.rec (motive := λ _ => c) h₂ h₃ h₁
-
 lemma non_contradictory_em (a : Prop) : ¬¬(a ∨ ¬a) :=
 λ not_em : ¬(a ∨ ¬a) =>
   have neg_a : ¬a := λ pos_a : a => absurd (Or.inl pos_a) not_em
@@ -242,12 +234,12 @@ lemma not_or (p q) : ¬ (p ∨ q) ↔ ¬ p ∧ ¬ q :=
 /- or resolution rules -/
 
 lemma Or.resolve_left {a b : Prop} (h: a ∨ b) (na : ¬ a) : b :=
-Or.elim_on h (λ ha => absurd ha na) id
+Or.elim h (λ ha => absurd ha na) id
 
 lemma Or.neg_resolve_left (h : ¬a ∨ b) (ha : a) : b := h.elim (absurd ha) id
 
 lemma Or.resolve_right {a b : Prop} (h: a ∨ b) (nb : ¬ b) : a :=
-Or.elim_on h id (λ hb => absurd hb nb)
+Or.elim h id (λ hb => absurd hb nb)
 
 lemma Or.neg_resolve_right (h : a ∨ ¬b) (nb : b) : a := h.elim id (absurd nb)
 
@@ -341,7 +333,7 @@ namespace Decidable
             match d₂ with
             | isTrue h₂  => False.elim $ h (Or.inr h₂)
             | isFalse h₂ => ⟨h₁, h₂⟩)
-    (λ ⟨np, nq⟩ h => Or.elim_on h np nq)
+    (λ ⟨np, nq⟩ h => Or.elim h np nq)
 
 end Decidable
 
@@ -358,7 +350,7 @@ section
                                    (h : p ∨ q) (h₁ : p → α) (h₂ : q → α) : α :=
   if hp : p then h₁ hp else
     if hq : q then h₂ hq else
-      False.elim (Or.elim_on h hp hq)
+      False.elim (Or.elim h hp hq)
 end
 
 section

--- a/Mathlib/Logic/Basic.lean
+++ b/Mathlib/Logic/Basic.lean
@@ -323,7 +323,7 @@ theorem or_of_or_of_imp_right (h₁ : c ∨ a) (h : a → b) : c ∨ b :=
 Or.imp_right h h₁
 
 theorem Or.elim3 (h : a ∨ b ∨ c) (ha : a → d) (hb : b → d) (hc : c → d) : d :=
-Or.elim_on h ha (λ h₂ => Or.elim_on h₂ hb hc)
+Or.elim h ha (λ h₂ => Or.elim h₂ hb hc)
 
 theorem or_imp_distrib : (a ∨ b → c) ↔ (a → c) ∧ (b → c) :=
 ⟨fun h => ⟨fun ha => h (Or.inl ha), fun hb => h (Or.inr hb)⟩,
@@ -529,7 +529,7 @@ def decidable_of_bool : ∀ (b : Bool) (h : b ↔ a), Decidable a
 /-! ### De Morgan's laws -/
 
 theorem not_and_of_not_or_not (h : ¬ a ∨ ¬ b) : ¬ (a ∧ b)
-| ⟨ha, hb⟩ => Or.elim_on h (absurd ha) (absurd hb)
+| ⟨ha, hb⟩ => Or.elim h (absurd ha) (absurd hb)
 
 -- See Note [decidable namespace]
 protected theorem Decidable.not_and_distrib [Decidable a] : ¬ (a ∧ b) ↔ ¬a ∨ ¬b :=
@@ -552,7 +552,7 @@ not_and.trans imp_not_comm
 conjunction of the negations. -/
 theorem not_or_distrib : ¬ (a ∨ b) ↔ ¬ a ∧ ¬ b :=
 ⟨λ h => ⟨λ ha => h (Or.inl ha), λ hb => h (Or.inr hb)⟩,
- λ ⟨h₁, h₂⟩ h => Or.elim_on h h₁ h₂⟩
+ λ ⟨h₁, h₂⟩ h => Or.elim h h₁ h₂⟩
 
 -- See Note [decidable namespace]
 protected theorem Decidable.or_iff_not_and_not [Decidable a] [Decidable b] : a ∨ b ↔ ¬ (¬a ∧ ¬b) :=

--- a/leanpkg.toml
+++ b/leanpkg.toml
@@ -1,4 +1,4 @@
 [package]
 name = "mathlib4"
 version = "0.1"
-lean_version = "leanprover/lean4:nightly-2021-08-24"
+lean_version = "leanprover/lean4:nightly-2021-08-25"


### PR DESCRIPTION
Updates lean version to leanprover/lean4:nightly-2021-08-25.

`Or.elim` was added to core Lean 4 in https://github.com/leanprover/lean4/commit/63b11368cab0ff9e82744d5333e6493d76874b0a. We previously had a definition of `Or.elim` with a different order of arguments and a definition of `Or.elim_on` that matched the new `Or.elim` (and the lean3 version of `or.elim`). I had introduced `Or.elim_on` based on this discussion on zulip: https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/argument.20order.20of.20Or.2Eelim
Now it think it would be better to standardize on the new upstream `Or.elim`, so this revision migrates all usages to that.