### PR TITLE
refactor(Tactic/NormNum): change to isNat function

### DIFF
--- a/Mathlib/Algebra/Group/Defs.lean
+++ b/Mathlib/Algebra/Group/Defs.lean
@@ -18,13 +18,13 @@ import Mathlib.Tactic.Spread
 class Zero (α : Type u) where
   zero : α
 
-instance [Zero α] : OfNat α (nat_lit 0) where
+instance instOfNatZero [Zero α] : OfNat α (nat_lit 0) where
   ofNat := Zero.zero
 
 class One (α : Type u) where
   one : α
 
-instance [One α] : OfNat α (nat_lit 1) where
+instance instOfNatOne [One α] : OfNat α (nat_lit 1) where
   ofNat := One.one
 
 class Inv (α : Type u) where

--- a/Mathlib/Algebra/Ring/Basic.lean
+++ b/Mathlib/Algebra/Ring/Basic.lean
@@ -77,7 +77,7 @@ instance (R : Type u) [CommRing R] : CommSemiring R where
 namespace Nat
 
 instance : Numeric Nat := ⟨id⟩
-@[simp] theorem ofNat_eq_Nat (n : Nat): Numeric.ofNat n = n := rfl
+@[simp] theorem ofNat_eq_Nat (n : Nat) : Numeric.ofNat n = n := rfl
 
 instance : CommSemiring Nat where
   mul_comm := Nat.mul_comm
@@ -89,7 +89,7 @@ instance : CommSemiring Nat where
   ofNat_zero := rfl
   mul_one := Nat.mul_one
   one_mul := Nat.one_mul
-  npow (n x) := HPow.hPow x n
+  npow (n x) := x ^ n
   npow_zero' := Nat.pow_zero
   npow_succ' n x := by simp [Nat.pow_succ, Nat.mul_comm]
   one := 1
@@ -99,7 +99,7 @@ instance : CommSemiring Nat where
   add_assoc := Nat.add_assoc
   add_zero := Nat.add_zero
   zero_add := Nat.zero_add
-  nsmul := HMul.hMul
+  nsmul := (·*·)
   nsmul_zero' := Nat.zero_mul
   nsmul_succ' n x := by simp [Nat.add_comm, (Nat.succ_mul n x)]
   zero_mul := Nat.zero_mul


### PR DESCRIPTION
The algorithm here is overall simpler and does not need to special case zero and one, and is also more robust to unusual instances, but it uses instance search to find proofs that each input numeral is constructed using an approved `OfNat` instance, using a `LawfulOfNat` class. This work is proportional to the size of the input equation. (It is not needed for internal numerals, unlike the original version, since internal numerals use raw nat literals so there is no `OfNat` instance to speak of.) If this turns out to be still too expensive, it is possible to special case the common cases (there are currently 5 distinct paths to an `OfNat` instance, so these could be special cased).