### PR TITLE
[Merged by Bors] - feat: list permutations and pairwise

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -10,6 +10,7 @@ import Mathlib.Data.Equiv.Functor
 import Mathlib.Data.Int.Basic
 import Mathlib.Data.List.Basic
 import Mathlib.Data.List.Card
+import Mathlib.Data.List.Perm
 import Mathlib.Data.Nat.Basic
 import Mathlib.Data.Nat.Gcd
 import Mathlib.Data.Prod

--- a/Mathlib/Data/List/Card.lean
+++ b/Mathlib/Data/List/Card.lean
@@ -21,7 +21,9 @@ theorem inj_on_of_subset {f : α → β} {as bs : List α} (h : inj_on f bs) (hs
 protected def equiv (as bs : List α) := ∀ x, x ∈ as ↔ x ∈ bs
 
 theorem equiv_iff_subset_and_subset {as bs : List α} : as.equiv bs ↔ as ⊆ bs ∧ bs ⊆ as :=
-  ⟨fun h => ⟨fun xas => (h _).1 xas, fun xbs => (h _).2 xbs⟩, fun ⟨h1, h2⟩ x => ⟨h1, h2⟩⟩
+Iff.intro
+  (fun h => ⟨fun _ xas => (h _).1 xas, fun _ xbs => (h _).2 xbs⟩)
+  (fun ⟨h1, h2⟩ x => ⟨@h1 x, @h2 x⟩)
 
 theorem insert_equiv_cons [DecidableEq α] (a : α) (as : List α) : (insert a as).equiv (a :: as) :=
   fun x => by simp
@@ -124,7 +126,7 @@ theorem card_subset_le : ∀ {as bs : List α}, as ⊆ bs → card as ≤ card b
   | (a :: as), bs, hsub => by
     cases Decidable.em (a ∈ as) with
     | inl h' =>
-      have hsub' : as ⊆ bs := fun xmem => hsub (mem_cons_of_mem a xmem)
+      have hsub' : as ⊆ bs := fun _ xmem => hsub (mem_cons_of_mem a xmem)
       simp [h', card_subset_le hsub']
     | inr h' =>
       have : a ∈ bs := hsub (Or.inl rfl)

--- a/Mathlib/Data/List/Perm.lean
+++ b/Mathlib/Data/List/Perm.lean
@@ -1,0 +1,64 @@
+import Mathlib.Set
+import Mathlib.Data.List.Basic
+
+namespace List
+
+/-- `Perm l₁ l₂` or `l₁ ~ l₂` asserts that `l₁` and `l₂` are Permutations
+  of each other. This is defined by induction using pairwise swaps. -/
+inductive Perm : List α → List α → Prop
+| nil   : Perm [] []
+| cons  : ∀ (x : α) {l₁ l₂ : List α}, Perm l₁ l₂ → Perm (x::l₁) (x::l₂)
+| swap  : ∀ (x y : α) (l : List α), Perm (y::x::l) (x::y::l)
+| trans : ∀ {l₁ l₂ l₃ : List α}, Perm l₁ l₂ → Perm l₂ l₃ → Perm l₁ l₃
+
+open Perm
+
+infixl:50 " ~ " => Perm
+
+protected theorem Perm.refl : ∀ (l : List α), l ~ l
+| []      => Perm.nil
+| (x::xs) => (Perm.refl xs).cons x
+
+protected theorem Perm.symm {l₁ l₂ : List α} (p : l₁ ~ l₂) : l₂ ~ l₁ := by
+induction p with
+| nil => exact Perm.nil
+| cons x _ ih => exact Perm.cons x ih
+| swap x y l => exact Perm.swap y x l
+| trans _ _ ih₁ ih₂ => exact Perm.trans ih₂ ih₁
+
+theorem Perm_comm {l₁ l₂ : List α} : l₁ ~ l₂ ↔ l₂ ~ l₁ := ⟨Perm.symm, Perm.symm⟩
+
+theorem Perm.swap'
+  (x y : α)
+  {l₁ l₂ : List α}
+  (p : l₁ ~ l₂) :
+  y::x::l₁ ~ x::y::l₂ :=
+  have h1 : y :: l₁ ~ y :: l₂ := Perm.cons y p
+  have h2 : x :: y :: l₁ ~ x :: y :: l₂ := Perm.cons x h1
+  have h3 : y :: x :: l₁ ~ x :: y :: l₁ := Perm.swap x y l₁
+  Perm.trans h3 h2
+
+theorem Perm.Equivalence : Equivalence (@Perm α) := ⟨Perm.refl, Perm.symm, Perm.trans⟩
+
+instance (α : Type u) : Setoid (List α) := ⟨Perm, Perm.Equivalence⟩
+
+theorem Perm.subset {α : Type u} {l₁ l₂ : List α} (p : l₁ ~ l₂) : l₁ ⊆ l₂ := by
+induction p with
+| nil => exact nil_subset _
+| cons _ _ ih => exact cons_subset_cons _ ih
+| swap x y l =>
+  intro a
+  rw [mem_cons]
+  exact fun
+  | Or.inl a_eq_y => Or.inr (Or.inl a_eq_y)
+  | Or.inr eq_or_mem =>
+    match eq_or_mem with
+    | Or.inl a_eq_x => Or.inl a_eq_x
+    | Or.inr a_mem_l => Or.inr (Or.inr a_mem_l)
+| trans h1 h2 ih₁ ih₂ => exact subset.trans ih₁ ih₂
+
+theorem perm_middle {a : α} : ∀ {l₁ l₂ : List α}, l₁++a::l₂ ~ a::(l₁++l₂)
+| [], l₂ => Perm.refl _
+| (b::l₁), l₂ =>
+  let h2 := @perm_middle α a l₁ l₂
+  (h2.cons _).trans (swap a b _)


### PR DESCRIPTION
The only thing that isn't just an addition from mathlib is changing the binder on subset to a weak implicit.