### PR TITLE
[Merged by Bors] - feat: librarySearch

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -33,6 +33,7 @@ import Mathlib.Tactic.Cache
 import Mathlib.Tactic.Coe
 import Mathlib.Tactic.Core
 import Mathlib.Tactic.Find
+import Mathlib.Tactic.LibrarySearch
 import Mathlib.Tactic.NoMatch
 import Mathlib.Tactic.NormNum
 import Mathlib.Tactic.OpenPrivate

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -29,6 +29,7 @@ import Mathlib.Logic.Function.Basic
 import Mathlib.Set
 import Mathlib.SetNotation
 import Mathlib.Tactic.Basic
+import Mathlib.Tactic.Cache
 import Mathlib.Tactic.Coe
 import Mathlib.Tactic.Core
 import Mathlib.Tactic.Find

--- a/Mathlib/Tactic/Cache.lean
+++ b/Mathlib/Tactic/Cache.lean
@@ -1,0 +1,120 @@
+/-
+Copyright (c) 2021 Gabriel Ebner. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Gabriel Ebner
+-/
+import Lean
+
+/-!
+# Once-per-file cache for tactics
+
+This file defines cache data structures for tactics
+that are initialized the first time they are accessed.
+Since Lean 4 starts one process per file,
+these caches are once-per-file
+and can for example be used to cache information
+about the imported modules.
+
+The `Cache α` data structure is
+the most generic version we define.
+It is created using `Cache.mk f`
+where `f : MetaM α` performs
+the initialization of the cache:
+```
+initialize numberOfImports : Cache Nat ← Cache.mk do
+  (← getEnv).imports.size
+
+-- (does not work in the same module where the cache is defined)
+#eval show MetaM Nat from numberOfImports.get
+```
+
+The `DeclCache α` data structure computes
+a fold over the environment's constants:
+`DeclCache.mk empty f` constructs such a cache
+where `empty : α` and `f : Name → ConstantInfo → α → MetaM α`.
+The result of the constants in the imports is cached
+between tactic invocations,
+while for constants defined in the same file
+`f` is evaluated again every time.
+This kind of cache can be used e.g.
+to populate discrimination trees.
+-/
+
+open Lean Meta
+
+namespace Tactic
+
+/-- Once-per-file cache. -/
+def Cache (α : Type) :=
+  IO.Ref <| Sum (MetaM α) <|
+    Task <| Except IO.Error <| Except Exception α
+
+instance : Inhabited (Cache α) :=
+  inferInstanceAs <| Inhabited (IO.Ref _)
+
+/-- Creates a cache with an initialization function. -/
+def Cache.mk (init : MetaM α) : IO (Cache α) :=
+  IO.mkRef <| Sum.inl init
+
+/--
+Access the cache.
+Calling this function for the first time
+will initialize the cache with the function
+provided in the constructor.
+-/
+def Cache.get [Monad m] [MonadEnv m] [MonadOptions m] [MonadLiftT IO m] [MonadExcept Exception m]
+    (cache : Cache α) : m α := do
+  let t ← match ← show IO _ from ST.Ref.get cache with
+    | Sum.inr t => t
+    | Sum.inl init =>
+      let env ← getEnv
+      let options ← getOptions -- TODO: sanitize options?
+      let res ← IO.asTask do EIO.toIO' do
+        let metaCtx : Meta.Context := {}
+        let metaState : Meta.State := {}
+        let coreCtx : Core.Context := {options}
+        let coreState : Core.State := {env}
+        (← ((init ‹_›).run ‹_› ‹_›).run ‹_›).1.1
+      show IO _ from cache.set (Sum.inr res)
+      pure res
+  match t.get with
+    | Except.ok (Except.ok res) => return res
+    | Except.error err => show IO _ from throw err
+    | Except.ok (Except.error err) => throw err
+
+/--
+Cached fold over the environment's declarations,
+where a given function is applied to `α` for every constant.
+-/
+def DeclCache (α : Type) :=
+  Cache α × (Name → ConstantInfo → α → MetaM α)
+
+instance : Inhabited (DeclCache α) :=
+  inferInstanceAs <| Inhabited (_ × _)
+
+/--
+Creates a `DeclCache`.
+The cached structure `α` is initialied with `empty`,
+and then `addDecl` is called for every constant in the environment.
+Calls to `addDecl` for imported constants are cached.
+-/
+def DeclCache.mk (profilingName : String) (empty : α) (addDecl : Name → ConstantInfo → α → MetaM α) : IO (DeclCache α) := do
+  let cache ← Cache.mk do
+    profileitM Exception profilingName (← getOptions) do
+    let mut a ← empty
+    for (n, c) in (← getEnv).constants.map₁.toList do
+      a ← addDecl n c a
+    return a
+  (cache, addDecl)
+
+/--
+Access the cache.
+Calling this function for the first time
+will initialize the cache with the function
+provided in the constructor.
+-/
+def DeclCache.get (cache : DeclCache α) : MetaM α := do
+  let mut a ← cache.1.get
+  for (n, c) in (← getEnv).constants.map₂.toList do
+    a ← cache.2 n c a
+  return a

--- a/Mathlib/Tactic/Cache.lean
+++ b/Mathlib/Tactic/Cache.lean
@@ -94,7 +94,7 @@ instance : Inhabited (DeclCache α) :=
 
 /--
 Creates a `DeclCache`.
-The cached structure `α` is initialied with `empty`,
+The cached structure `α` is initialized with `empty`,
 and then `addDecl` is called for every constant in the environment.
 Calls to `addDecl` for imported constants are cached.
 -/

--- a/Mathlib/Tactic/Find.lean
+++ b/Mathlib/Tactic/Find.lean
@@ -66,7 +66,6 @@ def findType (t : Expr) : TermElabM Unit := withReducible do
 
   let env ← getEnv
   let mut numFound := 0
-  -- TODO for consistency, we may want to filter the local declarations by head index as well.
   for n in (← findDeclsPerHead.get).findD head #[] do
     let c := env.find? n |>.get!
     let cTy ← c.instantiateTypeLevelParams (← mkFreshLevelMVars c.numLevelParams)

--- a/Mathlib/Tactic/LibrarySearch.lean
+++ b/Mathlib/Tactic/LibrarySearch.lean
@@ -1,0 +1,123 @@
+/-
+Copyright (c) 2021 Gabriel Ebner. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Gabriel Ebner
+-/
+import Mathlib.Tactic.Cache
+import Mathlib.Tactic.SolveByElim
+import Mathlib.Tactic.OpenPrivate
+
+/-!
+# Library search
+
+This file defines a tactic `librarySearch`
+and a term elaborator `librarySearch%`
+that tries to find a lemma
+solving the current goal
+(subgoals are solved using `solveByElim`).
+
+```
+example : x < x + 1 := librarySearch%
+example : Nat := by librarySearch
+```
+-/
+
+namespace Tactic
+namespace LibrarySearch
+
+open Lean Meta
+
+initialize registerTraceClass `Tactic.librarySearch
+
+-- from Lean.Server.Completion
+private def isBlackListed (declName : Name) : MetaM Bool := do
+  if declName matches Name.str _ "inj" _ then return false
+  if declName matches Name.str _ "noConfusionType" _ then return false
+  let env ← getEnv
+  declName.isInternal
+  <||> isAuxRecursor env declName
+  <||> isNoConfusion env declName
+  <||> isRec declName <||> isMatcher declName
+
+initialize librarySearchLemmas : DeclCache (DiscrTree Name) ←
+  DeclCache.mk "librarySearch: init cache" {} fun name constInfo lemmas => do
+    if constInfo.isUnsafe then return lemmas
+    if ← isBlackListed name then return lemmas
+    withNewMCtxDepth do
+      let (xs, bis, type) ← withReducible <| forallMetaTelescopeReducing constInfo.type
+      let keys ← withReducible <| DiscrTree.mkPath type
+      lemmas.insertCore keys name
+
+def librarySearch (mvarId : MVarId) (lemmas : DiscrTree Name) (solveByElimDepth := 6) :
+    MetaM <| Option (Array <| MetavarContext × List MVarId) := do
+  profileitM Exception "librarySearch" (← getOptions) do
+  let mvar := mkMVar mvarId
+  let ty ← inferType mvar
+
+  let mut suggestions := #[]
+
+  let state0 ← get
+
+  try
+    solveByElim solveByElimDepth mvarId
+    return none
+  catch _ =>
+    set state0
+
+  for lem in ← lemmas.getMatch ty do
+    trace[Tactic.librarySearch] "{lem}"
+    match ← traceCtx `Tactic.librarySearch try
+        let newMVars ← apply mvarId (← mkConstWithFreshMVarLevels lem)
+        (try
+          for newMVar in newMVars do
+            withMVarContext newMVar do
+              trace[Tactic.librarySearch] "proving {← addMessageContextFull (mkMVar newMVar)}"
+              solveByElim solveByElimDepth newMVar
+          some (Sum.inr ())
+        catch _ =>
+          let res := some (Sum.inl <| (← getMCtx, newMVars))
+          set state0
+          res)
+      catch _ =>
+        set state0
+        none
+      with
+      | none => ()
+      | some (Sum.inr ()) => return none
+      | some (Sum.inl suggestion) => suggestions := suggestions.push suggestion
+
+  some suggestions
+
+def lines (ls : List MessageData) :=
+  MessageData.joinSep ls (MessageData.ofFormat Format.line)
+
+open Elab.Tactic Elab Tactic in
+elab "librarySearch" : tactic =>do
+  withNestedTraces do
+  trace[Tactic.librarySearch] "proving {← getMainTarget}"
+  let mvar ← getMainGoal
+  let (hs, introdMVar) ← intros (← getMainGoal)
+  withMVarContext introdMVar do
+    if let some suggestions ← librarySearch introdMVar (← librarySearchLemmas.get) then
+      logError <| lines <|<- suggestions.toList.mapM fun (mctx, _) =>
+        withMCtx mctx do addMessageContextFull <|<- do
+          m!"{← mkLambdaFVars (hs.map (mkFVar ·)) <|<-
+            instantiateMVars <| mkMVar introdMVar}"
+    else
+      logInfo <|<- instantiateMVars <| mkMVar mvar
+
+open Elab Term in
+elab "librarySearch%" : term <= expectedType => do
+  withNestedTraces do
+  trace[Tactic.librarySearch] "proving {expectedType}"
+  let mvar ← mkFreshExprMVar expectedType
+  let (hs, introdMVar) ← intros mvar.mvarId!
+  withMVarContext introdMVar do
+    if let some suggestions ← librarySearch introdMVar (← librarySearchLemmas.get) then
+      throwError "{lines <|<- suggestions.toList.mapM fun (mctx, _) =>
+        withMCtx mctx do addMessageContextFull <|<- do
+          m!"{← mkLambdaFVars (hs.map (mkFVar ·)) <|<-
+            instantiateMVars <| mkMVar introdMVar}"}" -- "
+    else
+      logInfo <|<- instantiateMVars <| mvar
+  instantiateMVars mvar

--- a/test/Find.lean
+++ b/test/Find.lean
@@ -1,5 +1,7 @@
 import Mathlib.Tactic.Find
 
+theorem add_comm_zero : 0 + n = n + 0 := Nat.add_comm _ _
+
 #find _ + _ = _ + _
 #find ?n + _ = _ + ?n
 #find (_ : Nat) + _ = _ + _

--- a/test/librarySearch.lean
+++ b/test/librarySearch.lean
@@ -1,0 +1,11 @@
+import Mathlib
+
+example (x : Nat) : x ≠ x.succ := ne_of_lt (by librarySearch)
+example : 0 ≠ 1 + 1 := ne_of_lt (by librarySearch)
+example (x y : Nat) : x + y = y + x := by librarySearch
+example (n m k : Nat) : n ≤ m → n + k ≤ m + k := by librarySearch
+example (ha : a > 0) (w : b ∣ c) : a * b ∣ a * c := by librarySearch
+
+example : Int := by librarySearch
+
+example : x < x + 1 := librarySearch%

--- a/test/librarySearch.lean
+++ b/test/librarySearch.lean
@@ -9,3 +9,103 @@ example (ha : a > 0) (w : b ∣ c) : a * b ∣ a * c := by librarySearch
 example : Int := by librarySearch
 
 example : x < x + 1 := librarySearch%
+
+example (P : Prop) (p : P) : P := by librarySearch
+example (P : Prop) (p : P) (np : ¬P) : false := by librarySearch
+-- TODO example (X : Type) (P : Prop) (x : X) (h : ∀ x : X, x = x → P) : P := by librarySearch
+
+example (α : Prop) : α → α := by librarySearch -- says: `exact id`
+
+example (p : Prop) : (¬¬p) → p := by librarySearch -- says: `exact not_not.mp`
+-- TODO example (a b : Prop) (h : a ∧ b) : a := by librarySearch -- says: `exact h.left`
+
+-- TODO example (P Q : Prop) : (¬ Q → ¬ P) → (P → Q) := by librarySearch -- says: `exact not_imp_not.mp`
+
+example (a b : ℕ) : a + b = b + a :=
+by librarySearch -- says: `exact add_comm a b`
+
+example (n m k : ℕ) : n * (m - k) = n * m - n * k :=
+by librarySearch -- says: `exact nat.mul_sub_left_distrib n m k`
+
+example (n m k : ℕ) : n * m - n * k = n * (m - k) :=
+Eq.symm <| -- TODO: shouldn't be required
+by librarySearch -- says: `exact eq.symm (nat.mul_sub_left_distrib n m k)`
+
+example {α : Type} (x y : α) : x = y ↔ y = x := by librarySearch -- says: `exact eq_comm`
+
+-- TODO example (a b : ℕ) (ha : 0 < a) (hb : 0 < b) : 0 < a + b := by librarySearch -- says: `exact add_pos ha hb`
+
+section synonym
+
+-- TODO example (a b : ℕ) (ha : a > 0) (hb : 0 < b) : 0 < a + b := by librarySearch -- says: `exact add_pos ha hb`
+
+example (a b : ℕ) (h : a ∣ b) (w : b > 0) : a ≤ b :=
+by librarySearch -- says: `exact nat.le_of_dvd w h`
+
+-- TODO example (a b : ℕ) (h : a ∣ b) (w : b > 0) : b ≥ a := by librarySearch -- says: `exact nat.le_of_dvd w h`
+
+
+-- TODO: A lemma with head symbol `¬` can be used to prove `¬ p` or `⊥`
+example (a : ℕ) : ¬ (a < 0) := by librarySearch -- says `exact not_lt_bot`
+-- TODO example (a : ℕ) (h : a < 0) : False := by librarySearch -- says `exact not_lt_bot h`
+
+-- An inductive type hides the constructor's arguments enough
+-- so that `librarySearch` doesn't accidentally close the goal.
+inductive P : ℕ → Prop
+| gt_in_head {n : ℕ} : n < 0 → P n
+
+-- This lemma with `>` as its head symbol should also be found for goals with head symbol `<`.
+theorem lemma_with_gt_in_head (a : ℕ) (h : P a) : 0 > a := by cases h; assumption
+
+-- This lemma with `false` as its head symbols should also be found for goals with head symbol `¬`.
+theorem lemma_with_false_in_head (a b : ℕ) (h1 : a < b) (h2 : P a) : False :=
+by apply Nat.not_lt_zero; cases h2; assumption
+
+example (a : ℕ) (h : P a) : 0 > a := by librarySearch -- says `exact lemma_with_gt_in_head a h`
+-- TODO example (a : ℕ) (h : P a) : a < 0 := by librarySearch -- says `exact lemma_with_gt_in_head a h`
+
+-- TODO example (a b : ℕ) (h1 : a < b) (h2 : P a) : False := by librarySearch -- says `exact lemma_with_false_in_head a b h1 h2`
+
+-- TODO example (a b : ℕ) (h1 : a < b) : ¬ (P a) := by librarySearch -- says `exact lemma_with_false_in_head a b h1`
+
+end synonym
+
+-- We even find `iff` results:
+
+example : ∀ P : Prop, ¬(P ↔ ¬P) := by librarySearch -- says: `λ (a : Prop), (iff_not_self a).mp`
+
+-- TODO example {a b c : ℕ} (h₁ : a ∣ c) (h₂ : a ∣ b + c) : a ∣ b := by librarySearch -- says `exact (nat.dvd_add_left h₁).mp h₂`
+
+example {α : Sort _} (h : Empty) : α := by librarySearch
+example {α : Type _} (h : Empty) : α := by librarySearch
+
+-- TODO example (f : A → C) (g : B → C) : (A ⊕ B) → C := by librarySearch
+
+constant f : ℕ → ℕ
+axiom F (a b : ℕ) : f a ≤ f b ↔ a ≤ b
+-- TODO example (a b : ℕ) (h : a ≤ b) : f a ≤ f b := by librarySearch
+
+-- TODO theorem nonzero_gt_one (n : ℕ) : ¬ n = 0 → n ≥ 1 := by librarySearch   -- `exact nat.pos_of_ne_zero`
+
+/- TODO: using
+
+example (L : List (List ℕ)) : List ℕ :=
+by librarySearch using L
+
+example (n m : ℕ) : ℕ :=
+by librarySearch using n m
+
+example (P Q : list ℕ) (h : ℕ) : list ℕ :=
+by librarySearch using h Q
+
+example (P Q : list ℕ) (h : ℕ) : list ℕ :=
+by librarySearch using P Q
+
+-- Make sure `librarySearch` finds nothing when we list too many hypotheses after `using`.
+example (P Q R S T : list ℕ) : list ℕ :=
+begin
+  success_if_fail { librarySearch using P Q R S T, },
+  exact []
+end
+
+-/


### PR DESCRIPTION
This adds a simple version of the `librarySearch` tactic from mathlib.
 - The implementation uses discrimination trees, with the hope of better scalability.
 - A new cache data structure is introduced to simplify the caching of such indexing data structures.

Some todos:
 - There is no "try this" yet.  I'm waiting for code actions to land in Lean 4.
 - It only does reducible matching for now.  I hope that I'll be able to abuse the discrimination trees to do indexing for semireducible matching as well.
 - `Iff.mp`, etc. projections are not implemented yet.