### PR TITLE
[Merged by Bors] - feat(coercion for decidable predicates to bool)

### DIFF
--- a/Mathlib/Logic/Basic.lean
+++ b/Mathlib/Logic/Basic.lean
@@ -217,6 +217,9 @@ theorem imp.swap : (a → b → c) ↔ (b → a → c) :=
 theorem imp_not_comm : (a → ¬b) ↔ (b → ¬a) :=
 imp.swap
 
+instance Decidable.predToBool {α : Type u} (p : α → Prop) [DecidablePred p] : CoeDep (α → Prop) p (α → Bool) where
+  coe := fun b => decide $ p b
+
 /-! ### Declarations about `xor` -/
 
 @[simp] theorem xor_true : xor True = Not := by simp [xor]


### PR DESCRIPTION
Very small addition of a coercion for decidable predicates `(A -> Prop)` to `(A -> Bool)`. I was surprised this isn't in the prelude; passing a decidable predicate to something like List.filter currently fails.