### PR TITLE
[Merged by Bors] - fix: add precedence for guardExpr

### DIFF
--- a/Mathlib/Tactic/Basic.lean
+++ b/Mathlib/Tactic/Basic.lean
@@ -83,7 +83,7 @@ elab "exacts" "[" hs:term,* "]" : tactic => do
 /-- Check syntactic equality of two expressions.
 See also `guardExprEq` and `guardExprEq'` for testing
 up to alpha equality and definitional equality. -/
-elab (name := guardExprStrict) "guardExpr " r:term " == " p:term : tactic => withMainContext do
+elab (name := guardExprStrict) "guardExpr " r:term:51 " == " p:term : tactic => withMainContext do
   let r ← elabTerm r none
   let p ← elabTerm p none
   if not (r == p) then throwError "failed: {r} != {p}"


### PR DESCRIPTION
This may have gotten lost when moving from `Mathport/Syntax`: https://github.com/leanprover-community/mathlib4/blob/master/Mathlib/Mathport/Syntax.lean#L308-L309