### PR TITLE
feat(Data/UInt, Data/Fin/Basic) instances

### DIFF
--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -1,5 +1,6 @@
 import Mathlib.Data.Nat.Basic
 import Mathlib.Algebra.Group.Defs
+import Mathlib.Algebra.GroupWithZero.Defs
 
 section Fin
 
@@ -19,10 +20,14 @@ instance : One (Fin n.succ) where
 lemma Fin.of_nat_zero : (Fin.ofNat 0 : Fin n.succ) = (0 : Fin n.succ) := by
   apply Fin.eq_of_val_eq; simp only [Fin.ofNat, Nat.zero_mod, Fin.val_zero]
 
+instance : Neg (Fin n) where
+  neg a := ⟨(n - a) % n, Nat.mod_lt _ (lt_of_le_of_lt (Nat.zero_le _) a.isLt)⟩
+
 @[simp]
-lemma Fin.val_one : (1 : Fin n.succ).val = (1 % n.succ : Nat) := by
-  have h0 : ∀ x, (OfNat.ofNat x : Fin n.succ) = Fin.ofNat x := by simp [OfNat.ofNat]
-  simp only [h0, Fin.ofNat]
+lemma Fin.val_one: (1 : Fin n.succ).val = (1 % n.succ : Nat) :=
+  show (Fin.ofNat 1).val = 1 % n.succ by simp [Fin.ofNat]
+
+theorem Fin.val_eq_of_lt : a < n.succ → (@Fin.ofNat n a).val = a := Nat.mod_eq_of_lt
 
 /-- If you actually have an element of `Fin n`, then the `n` is always positive -/
 lemma Fin.positive_size : ∀ (x : Fin n), 0 < n
@@ -48,34 +53,61 @@ lemma Fin.sub_def : ∀ (a b : Fin n), a - b = (Fin.mk ((a + (n - b)) % n) (Nat.
   simp only [Fin.modn_def, Nat.mod_mod]
   exact Nat.mod_eq_of_lt a.isLt
 
+@[simp] lemma Fin.mod_eq_val (a : Fin n) : a.val % n = a.val := by
+  simp only [Fin.modn_def, Nat.mod_mod]
+  exact Nat.mod_eq_of_lt a.isLt
+
 lemma Fin.add_comm (a b : Fin n) : a + b = b + a := by
-apply Fin.eq_of_val_eq
-simp only [Fin.add_def, Nat.add_comm]
+  apply Fin.eq_of_val_eq
+  simp only [Fin.add_def, Nat.add_comm]
 
 @[simp] lemma Fin.add_zero (a : Fin n.succ) : a + 0 = a := by
-apply Fin.eq_of_val_eq
-simp only [Fin.add_def, Fin.val_zero, Nat.add_zero]
-exact Nat.mod_eq_of_lt a.isLt
+  apply Fin.eq_of_val_eq
+  simp only [Fin.add_def, Fin.val_zero, Nat.add_zero]
+  exact Nat.mod_eq_of_lt a.isLt
 
-@[simp] lemma Fin.zero_add (a : Fin n.succ) : 0 + a = a := by
-rw [Fin.add_comm]
-exact Fin.add_zero a
-
-@[simp] lemma Fin.zero_mul (a : Fin n.succ) : 0 * a = 0 := by
-apply Fin.eq_of_val_eq
-simp only [Fin.mul_def, Fin.val_zero, Nat.zero_mul]
-simp [Nat.zero_mod]
+@[simp] lemma Fin.zero_add (a : Fin n.succ) : 0 + a = a := (Fin.add_comm _ _) ▸ Fin.add_zero a
 
 lemma Fin.mul_comm (a b : Fin n) : a * b = b * a := by
+  apply Fin.eq_of_val_eq
+  simp only [Fin.mul_def, Nat.mul_comm]
+
+@[simp] lemma Fin.zero_mul (a : Fin n.succ) : 0 * a = 0 := by
+  apply Fin.eq_of_val_eq
+  simp only [Fin.mul_def, Fin.val_zero, Nat.zero_mul]
+  simp [Nat.zero_mod]
+
+@[simp] lemma Fin.mul_zero (a : Fin n.succ) : a * 0 = 0 := by
+  rw [Fin.mul_comm]
+  exact Fin.zero_mul a
+
+@[simp] lemma Fin.one_mul (a : Fin n.succ) : 1 * a = a := by
 apply Fin.eq_of_val_eq
-simp only [Fin.mul_def, Nat.mul_comm]
+simp only [Fin.mul_def]
+cases n with
+| zero => simp only [Nat.eq_zero_of_le_zero (Nat.le_of_succ_le_succ a.isLt)]
+| succ n =>
+  have _ : (1 : Fin n.succ.succ).val = 1 := Nat.mod_eq_of_lt (Nat.succ_le_succ (Nat.succ_le_succ (Nat.zero_le n)))
+  rw [‹(1 : Fin n.succ.succ).val = 1›, Nat.one_mul, Nat.mod_eq_of_lt a.isLt]
+
+@[simp] lemma Fin.mul_one (a : Fin n.succ) : a * 1 = a := by
+  rw [Fin.mul_comm, Fin.one_mul]
 
 lemma Fin.add_assoc (a b c : Fin n) : (a + b) + c = a + (b + c) := by
 apply Fin.eq_of_val_eq
-simp only [Fin.mul_def, Fin.add_def, Nat.mod_add_mod, Nat.add_mod_mod, Nat.add_assoc]
+simp only [Fin.add_def, Nat.mod_add_mod, Nat.add_mod_mod, Nat.add_assoc]
 
-instance : Neg (Fin n) where
-  neg a := ⟨(n - a) % n, Nat.mod_lt _ (lt_of_le_of_lt (Nat.zero_le _) a.isLt)⟩
+lemma Fin.mul_assoc (a b c : Fin n) : (a * b) * c = a * (b * c) := by
+  apply Fin.eq_of_val_eq
+  simp only [Fin.mul_def]
+  generalize lhs : ((a.val * b.val) % n * c.val) % n = l
+  have hl : (a.val * b.val % n) * (c.val % n) % n = (a.val * b.val * c.val) % n := (Nat.mul_mod (a.val * b.val) c.val n).symm
+  rw [<- Nat.mod_eq_of_lt c.isLt, hl] at lhs
+  generalize rhs : a.val * (b.val * c.val % n) % n = r
+  have hr :  a.val % n * ((b.val * c.val) % n) % n = a.val * (b.val * c.val) % n := (Nat.mul_mod a.val (b.val * c.val) n).symm
+  rw [<- Nat.mod_eq_of_lt a.isLt, hr] at rhs
+  simp only [<- Nat.mul_assoc a.val b.val c.val] at rhs
+  rw [<- rhs, <- lhs]
 
 @[simp] lemma Fin.add_left_neg : ∀ (a : Fin n.succ), -a + a = 0
 | ⟨a, isLt⟩ => by
@@ -86,7 +118,7 @@ instance : Neg (Fin n) where
   | succ a =>
     have h1 : (n.succ - a.succ) % n.succ = (n.succ - a.succ) :=
       Nat.mod_eq_of_lt (Nat.sub_lt (Nat.succ_pos _) (Nat.succ_pos _))
-    have h_aux : (Nat.succ n - Nat.succ a + Nat.succ a) = Nat.succ n := by
+    have h_aux : (n.succ - a.succ + a.succ) = n.succ := by
       rw [Nat.add_comm]
       exact Nat.add_sub_of_le (Nat.le_of_lt isLt)
     rw [h1, h_aux, Nat.mod_self]
@@ -104,7 +136,7 @@ lemma Fin.nsmuls_eq (x : Nat) : ∀ (a : Fin n.succ), Fin.nsmul x a = Fin.ofNat 
   apply Fin.eq_of_val_eq
   simp only [Fin.nsmul, Fin.ofNat, Fin.mul_def]
   have hh : a % n.succ = a := Nat.mod_eq_of_lt isLt
-  generalize hq : x * a % Nat.succ n = q
+  generalize hq : x * a % n.succ = q
   rw [<- hh, <- Nat.mul_mod, hq]
 
 lemma Fin.nsmul_succ' (x : Nat) (a : Fin n.succ) : Fin.nsmul x.succ a = a + (Fin.nsmul x a) := by
@@ -134,6 +166,9 @@ instance : AddMonoid (Fin n.succ) where
   nsmul_zero' := Fin.zero_mul
   nsmul_succ' := Fin.nsmul_succ'
 
+instance : AddCommMonoid (Fin n.succ) where
+  add_comm := Fin.add_comm
+
 instance : SubNegMonoid (Fin n.succ) where
   sub_eq_add_neg := Fin.sub_eq_add_neg
   gsmul := Fin.gsmul
@@ -143,6 +178,19 @@ instance : SubNegMonoid (Fin n.succ) where
 
 instance : AddGroup (Fin n.succ) where
   add_left_neg := Fin.add_left_neg
+
+instance : Monoid (Fin n.succ) where
+  mul_one := Fin.mul_one
+  one_mul := Fin.one_mul
+  mul_assoc := Fin.mul_assoc
+  npow_zero' := fun _ => rfl
+  npow_succ' := fun _ _ => rfl
+
+def Fin.addOverflows? (a b : Fin n) : Bool := n <= a.val + b.val
+
+def Fin.mulOverflows? (a b : Fin n) : Bool := n <= a.val * b.val
+
+def Fin.subUnderflows? (a b : Fin n) : Bool := a.val < b.val
 
 def Fin.overflowingAdd (a b : Fin n) : (Bool × Fin n) := (n <= a.val + b.val, a + b)
 
@@ -186,5 +234,28 @@ lemma Fin.checked_sub_spec (a b : Fin n) : (Fin.checkedSub a b).isSome = true <-
     case pos => simp only [(decide_eq_true_iff (a.val < b.val)).mpr hx] at h
     case neg => exact Nat.le_of_not_lt hx
   case mpr => simp only [decide_eq_false (Nat.not_lt_of_le h : ¬a.val < b.val)]
+
+instance : CommMonoid (Fin n.succ) where
+  mul_comm := Fin.mul_comm
+
+instance : MonoidWithZero (Fin n.succ) where
+  zero_mul := Fin.zero_mul
+  mul_zero := Fin.mul_zero
+
+instance : AddSemigroup (Fin UInt8.size) := inferInstanceAs (AddSemigroup (Fin (_ + 1)))
+
+instance : AddMonoid (Fin UInt8.size) := inferInstanceAs (AddMonoid (Fin (_ + 1)))
+
+instance : AddCommMonoid (Fin UInt8.size) := inferInstanceAs (AddCommMonoid (Fin (_ + 1)))
+
+instance : SubNegMonoid (Fin UInt8.size) := inferInstanceAs (SubNegMonoid (Fin (_ + 1)))
+
+instance : AddGroup (Fin UInt8.size) := inferInstanceAs (AddGroup (Fin (_ + 1)))
+
+instance : Monoid (Fin UInt8.size) := inferInstanceAs (Monoid (Fin (_ + 1)))
+
+instance : CommMonoid (Fin UInt8.size)  := inferInstanceAs (CommMonoid (Fin (_ + 1)))
+
+instance : MonoidWithZero (Fin UInt8.size) := inferInstanceAs (MonoidWithZero (Fin (_ + 1)))
 
 end Fin

--- a/Mathlib/Data/UInt.lean
+++ b/Mathlib/Data/UInt.lean
@@ -1,5 +1,7 @@
-
-theorem Fin.val_eq_of_lt : a < n.succ → (@Fin.ofNat n a).val = a := Nat.mod_eq_of_lt
+import Mathlib.Data.Nat.Basic
+import Mathlib.Data.Fin.Basic
+import Mathlib.Algebra.Group.Defs
+import Mathlib.Algebra.GroupWithZero.Defs
 
 theorem UInt32.val_eq_of_lt : a < UInt32.size → (UInt32.ofNat a).val = a := Fin.val_eq_of_lt
 
@@ -34,3 +36,166 @@ theorem toChar_aux (n : Nat) (h : n < size) : Nat.isValidChar (UInt32.ofNat n).1
 def toChar (n : UInt8) : Char := ⟨n.toUInt32, toChar_aux n.1 n.1.2⟩
 
 end UInt8
+
+lemma UInt8.sub_def (a b : UInt8) : a - b = UInt8.mk (a.val - b.val) := rfl
+
+lemma UInt8.mul_def (a b : UInt8) : a * b = UInt8.mk (a.val * b.val) := rfl
+
+lemma UInt8.mod_def (a b : UInt8) : a % b = UInt8.mk (a.val % b.val) := rfl
+
+lemma UInt8.add_def (a b : UInt8) : a + b = UInt8.mk (a.val + b.val) := rfl
+
+lemma UInt8.eq_of_val_eq : ∀ {a b : UInt8}, a.val = b.val -> a = b
+| ⟨f1⟩, ⟨f2⟩, h => congrArg mk h
+
+lemma UInt8.val_eq_of_eq : ∀ {a b : UInt8}, a = b -> a.val = b.val
+| ⟨f1⟩, ⟨f2⟩, h => congrArg val h
+
+@[simp] lemma UInt8.mk_val_eq (a : UInt8) : mk a.val = a := by
+  cases h:a with
+  | mk aFin =>
+    have _ : a.val = aFin := h ▸ rfl
+    simp only [‹a.val = aFin›]
+
+lemma UInt8.add_assoc (a b c : UInt8) : (a + b) + c = a + (b + c) :=
+  congrArg UInt8.mk (Fin.add_assoc _ _ _)
+
+lemma UInt8.mul_comm (a b : UInt8) : a * b = b * a := congrArg UInt8.mk (Fin.mul_comm _ _)
+
+lemma UInt8.add_comm (a b : UInt8) : a + b = b + a := congrArg UInt8.mk (Fin.add_comm _ _)
+
+@[simp] lemma UInt8.add_zero (a : UInt8) : a + 0 = a := by
+  have h0 : a.val + (0 : UInt8).val = a.val := AddMonoid.add_zero a.val
+  simp only [UInt8.add_def, h0, UInt8.mk_val_eq]
+
+@[simp] lemma UInt8.zero_add (a : UInt8) : 0 + a = a :=
+  (UInt8.add_comm _ _) ▸ UInt8.add_zero _
+
+@[simp] lemma UInt8.zero_mul (a : UInt8) : 0 * a = 0 := by
+  have h0 : (0 : UInt8).val * a.val = (0 : Fin UInt8.size) := MonoidWithZero.zero_mul a.val
+  simp only [UInt8.mul_def, h0, UInt8.mk_val_eq]
+
+@[simp] lemma UInt8.mul_zero (a : UInt8) : a * 0 = 0 :=
+  (UInt8.mul_comm a _) ▸ UInt8.zero_mul _
+
+@[simp] lemma UInt8.one_mul (a : UInt8) : 1 * a = a := by
+  have h0 : (1 : UInt8).val * a.val = a.val := Monoid.one_mul a.val
+  simp only [UInt8.mul_def, h0, UInt8.mk_val_eq]
+
+@[simp] lemma UInt8.mul_one (a : UInt8) : a * 1 = a := (UInt8.mul_comm _ _) ▸ UInt8.one_mul _
+
+instance : Neg UInt8 where
+  neg a := UInt8.mk (-a.val)
+
+lemma UInt8.neg_def (a : UInt8) : -a = UInt8.mk (-a.val) := rfl
+
+lemma UInt8.sub_eq_add_neg (a b : UInt8) : a - b = a + -b :=
+  congrArg UInt8.mk (SubNegMonoid.sub_eq_add_neg _ _)
+
+def UInt8.nsmul (x : Nat) (a : UInt8) : UInt8 := UInt8.mk (AddMonoid.nsmul x a.val)
+
+def UInt8.gsmul (x : Int) (a : UInt8) : UInt8 := UInt8.mk (SubNegMonoid.gsmul x a.val)
+
+@[simp] lemma UInt8.gsmul_zero' (a : UInt8) : UInt8.gsmul 0 a = (0 : UInt8) :=
+  congrArg UInt8.mk (SubNegMonoid.gsmul_zero' a.val)
+
+lemma UInt8.gsmul_succ' (m : ℕ) (a : UInt8) : UInt8.gsmul (Int.ofNat m.succ) a = a + UInt8.gsmul (Int.ofNat m) a :=
+  congrArg UInt8.mk (SubNegMonoid.gsmul_succ' m a.val)
+
+lemma UInt8.gsmul_neg' (m : ℕ) (a : UInt8) : gsmul (Int.negSucc m) a = -(gsmul m.succ a) :=
+  congrArg UInt8.mk (SubNegMonoid.gsmul_neg' m a.val)
+
+instance : AddSemigroup UInt8 where
+  add_assoc := UInt8.add_assoc
+
+@[simp] lemma UInt8.nsmul_zero' (x : UInt8) : UInt8.nsmul 0 x = 0 :=
+  congrArg UInt8.mk (AddMonoid.nsmul_zero' x.val)
+
+lemma UInt8.nsmul_succ' (n : ℕ) (x : UInt8) : UInt8.nsmul n.succ x = x + UInt8.nsmul n x :=
+  congrArg UInt8.mk (AddMonoid.nsmul_succ' n x.val)
+
+@[simp] lemma UInt8.add_left_neg (a : UInt8) : -a + a = 0 :=
+  congrArg UInt8.mk (AddGroup.add_left_neg a.val)
+
+lemma UInt8.mul_assoc (a b c : UInt8) : (a * b) * c = a * (b * c) :=
+  congrArg UInt8.mk (Semigroup.mul_assoc _ _ _)
+
+instance : AddMonoid UInt8 where
+  add_zero := UInt8.add_zero
+  zero_add := UInt8.zero_add
+  nsmul := UInt8.nsmul
+  nsmul_zero' := UInt8.nsmul_zero'
+  nsmul_succ' := UInt8.nsmul_succ'
+
+instance : AddCommMonoid UInt8 where
+  add_comm := UInt8.add_comm
+
+instance : SubNegMonoid UInt8 where
+  sub_eq_add_neg := UInt8.sub_eq_add_neg
+  gsmul := UInt8.gsmul
+  gsmul_zero' := UInt8.gsmul_zero'
+  gsmul_succ' := UInt8.gsmul_succ'
+  gsmul_neg' := UInt8.gsmul_neg'
+
+instance : Monoid UInt8 where
+  mul_one := UInt8.mul_one
+  one_mul := UInt8.one_mul
+  mul_assoc := UInt8.mul_assoc
+  npow_zero' := fun _ => rfl
+  npow_succ' := fun _ _ => rfl
+
+instance : CommMonoid UInt8 where
+  mul_comm := UInt8.mul_comm
+
+instance : MonoidWithZero UInt8 where
+  zero_mul := UInt8.zero_mul
+  mul_zero := UInt8.mul_zero
+
+def UInt8.addOverflows? (a b : UInt8) : Bool := UInt8.size <= a.toNat + b.toNat
+
+def UInt8.mulOverflows? (a b : UInt8) : Bool := UInt8.size <= a.toNat * b.toNat
+
+def UInt8.subUnderflows? (a b : UInt8) : Bool := a.toNat < b.toNat
+
+def UInt8.overflowingAdd (a b : UInt8) : (Bool × UInt8) := (UInt8.size <= a.toNat + b.toNat, a + b)
+
+def UInt8.overflowingMul (a b : UInt8) : (Bool × UInt8) := (UInt8.size <= a.toNat * b.toNat, a * b)
+
+def UInt8.underflowingSub (a b : UInt8) : (Bool × UInt8) := (a.toNat < b.toNat, a - b)
+
+def UInt8.checkedAdd (a b : UInt8) : Option UInt8 :=
+  match a.overflowingAdd b with
+  | (true, _) => none
+  | (false, sum) => some (sum)
+
+def UInt8.checkedMul (a b : UInt8) : Option UInt8 :=
+  match a.overflowingMul b with
+  | (true, _) => none
+  | (false, prod) => some (prod)
+
+def UInt8.checkedSub (a b : UInt8) : Option UInt8 :=
+  match a.underflowingSub b with
+  | (true, _) => none
+  | (false, diff) => some (diff)
+
+lemma UInt8.checked_add_spec (a b : UInt8) : (UInt8.checkedAdd a b).isSome = true <-> a.toNat + b.toNat < UInt8.size := by
+  by_cases UInt8.size <= a.toNat + b.toNat <;>
+    simp_all [checkedAdd, Option.isSome, overflowingAdd, decide_eq_true, decide_eq_false]
+
+lemma UInt8.checked_mul_spec (a b : UInt8) : (UInt8.checkedMul a b).isSome = true <-> a.toNat * b.toNat < UInt8.size := by
+  simp only [checkedMul, overflowingMul, Option.isSome]
+  refine Iff.intro ?mp ?mpr <;> intro h
+  case mp =>
+    by_cases hx : UInt8.size <= a.toNat * b.toNat
+    case pos => simp only [(decide_eq_true_iff (UInt8.size <= a.toNat * b.toNat)).mpr hx] at h
+    case neg => exact Nat.lt_of_not_le hx
+  case mpr => simp only [decide_eq_false (Nat.not_le_of_lt h : ¬UInt8.size <= a.toNat * b.toNat)]
+
+lemma UInt8.checked_sub_spec (a b : UInt8) : (UInt8.checkedSub a b).isSome = true <-> b.toNat <= a.toNat := by
+  simp only [checkedSub, underflowingSub, Option.isSome]
+  refine Iff.intro ?mp ?mpr <;> intro h
+  case mp =>
+    by_cases hx : a.val < b.val
+    case pos => simp only [(decide_eq_true_iff (a.toNat < b.toNat)).mpr hx] at h
+    case neg => exact Nat.le_of_not_lt hx
+  case mpr => simp only [decide_eq_false (Nat.not_lt_of_le h : ¬a.toNat < b.toNat)]


### PR DESCRIPTION
Add new typeclass instances for Fin and UInt8. This incorporates gebner's suggestions to add boolean methods for checking under/overflow, and adding separate instances of e.g. `Fin UInt8.size`. The plan was to make a macro that would extend the UInt stuff to all the UInt sizes, but I couldn't figure out how to deal with namespaces and identifiers properly in a macro, so I'll have to get some outside guidance and improve the macro docs.