### PR TITLE
[Merged by Bors] - chore: bump to nightly-2021-11-10 and cleanup

### DIFF
--- a/Mathlib/Tactic/Cache.lean
+++ b/Mathlib/Tactic/Cache.lean
@@ -64,9 +64,7 @@ provided in the constructor.
 -/
 def Cache.get [Monad m] [MonadEnv m] [MonadOptions m] [MonadLiftT BaseIO m] [MonadExcept Exception m]
     (cache : Cache α) : m α := do
-  -- If https://github.com/leanprover/lean4/pull/772 is merged,
-  -- we can shorten `show BaseIO _ from show EIO Empty _` to `show BaseIO _ from` here and below.
-  let t ← match ← show BaseIO _ from show EIO Empty _ from ST.Ref.get cache with
+  let t ← match ← show BaseIO _ from ST.Ref.get cache with
     | Sum.inr t => t
     | Sum.inl init =>
       let env ← getEnv
@@ -77,7 +75,7 @@ def Cache.get [Monad m] [MonadEnv m] [MonadOptions m] [MonadLiftT BaseIO m] [Mon
         let coreCtx : Core.Context := {options}
         let coreState : Core.State := {env}
         (← ((init ‹_›).run ‹_› ‹_›).run ‹_›).1.1
-      show BaseIO _ from show EIO Empty _  from cache.set (Sum.inr res)
+      show BaseIO _ from cache.set (Sum.inr res)
       pure res
   match t.get with
     | Except.ok res => pure res

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2021-11-07
+leanprover/lean4:nightly-2021-11-10


### PR DESCRIPTION
Bumps to the Lean 4 nightly from 2021-11-10, and cleans up `Cache.lean` post https://github.com/leanprover/lean4/pull/772.