### PR TITLE
[Merged by Bors] - feat(Data/UInt, Data/Fin/Basic) declarations

### DIFF
--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -1,5 +1,6 @@
 import Mathlib.Data.Nat.Basic
 import Mathlib.Algebra.Group.Defs
+import Mathlib.Algebra.GroupWithZero.Defs
 
 section Fin
 
@@ -8,21 +9,23 @@ variable {n : Nat}
 instance : Zero (Fin n.succ) where
   zero := Fin.ofNat 0
 
-@[simp]
-lemma Fin.val_zero : (0 : Fin n.succ).val = (0 : Nat) :=
+@[simp] lemma Fin.val_zero : (0 : Fin n.succ).val = (0 : Nat) :=
   show (Fin.ofNat 0).val = 0 by simp [Fin.ofNat]
 
 instance : One (Fin n.succ) where
   one := ⟨1 % n.succ, Nat.mod_lt 1 (Nat.zero_lt_succ n)⟩
 
-@[simp]
-lemma Fin.of_nat_zero : (Fin.ofNat 0 : Fin n.succ) = (0 : Fin n.succ) := by
+@[simp] lemma Fin.val_one: (1 : Fin n.succ).val = (1 % n.succ : Nat) :=
+  show (Fin.ofNat 1).val = 1 % n.succ by simp [Fin.ofNat]
+
+@[simp] lemma Fin.of_nat_zero : (Fin.ofNat 0 : Fin n.succ) = (0 : Fin n.succ) := by
   apply Fin.eq_of_val_eq; simp only [Fin.ofNat, Nat.zero_mod, Fin.val_zero]
 
-@[simp]
-lemma Fin.val_one : (1 : Fin n.succ).val = (1 % n.succ : Nat) := by
-  have h0 : ∀ x, (OfNat.ofNat x : Fin n.succ) = Fin.ofNat x := by simp [OfNat.ofNat]
-  simp only [h0, Fin.ofNat]
+instance : Neg (Fin n) where
+  neg a := ⟨(n - a) % n, Nat.mod_lt _ (lt_of_le_of_lt (Nat.zero_le _) a.isLt)⟩
+
+lemma Fin.val_eq_of_lt : a < n.succ → (@Fin.ofNat n a).val = a := Nat.mod_eq_of_lt
+
 
 /-- If you actually have an element of `Fin n`, then the `n` is always positive -/
 lemma Fin.positive_size : ∀ (x : Fin n), 0 < n
@@ -33,6 +36,9 @@ lemma Fin.positive_size : ∀ (x : Fin n), 0 < n
 
 lemma Fin.modn_def : ∀ (a : Fin n) (m : Nat), a % m = Fin.mk ((a.val % m) % n) (Nat.mod_lt (a.val % m) (Fin.positive_size a))
 | ⟨a, pa⟩, m => by simp only [HMod.hMod, Fin.modn]
+
+lemma Fin.mod_def : ∀ (a m : Fin n), a % m = Fin.mk ((a.val % m.val) % n) (Nat.mod_lt (a.val % m.val) (Fin.positive_size a))
+| ⟨a, pa⟩, ⟨m, pm⟩ => by simp only [HMod.hMod, Mod.mod, Fin.mod]
 
 lemma Fin.add_def : ∀ (a b : Fin n), a + b = (Fin.mk ((a.val + b.val) % n) (Nat.mod_lt _ (Fin.positive_size a)))
 | ⟨a, pa⟩, ⟨b, pb⟩ => by simp only [HAdd.hAdd, Add.add, Fin.add]
@@ -48,34 +54,74 @@ lemma Fin.sub_def : ∀ (a b : Fin n), a - b = (Fin.mk ((a + (n - b)) % n) (Nat.
   simp only [Fin.modn_def, Nat.mod_mod]
   exact Nat.mod_eq_of_lt a.isLt
 
+@[simp] lemma Fin.mod_eq_val (a : Fin n) : a.val % n = a.val := by
+  simp only [Fin.modn_def, Nat.mod_mod]
+  exact Nat.mod_eq_of_lt a.isLt
+
+theorem Fin.mod_eq_of_lt {a b : Fin n} (h : a < b) : a % b = a := by
+  apply Fin.eq_of_val_eq
+  simp only [Fin.mod_def]
+  rw [Nat.mod_eq_of_lt h, Nat.mod_eq_of_lt a.isLt]
+
+theorem Fin.mod_lt : ∀ (i : Fin n.succ) {m : Fin n.succ}, (0 : Fin n.succ) < m → (i % m) < m
+  | ⟨a, aLt⟩, ⟨m, mLt⟩, hp =>  by
+    have _ : (0 : Nat) < m := Fin.val_zero ▸ hp
+    have _ : a % m < m := Nat.mod_lt _ ‹0 < m›
+    simp only [Fin.mod_def, LT.lt]
+    rw [(Nat.mod_eq_of_lt (Nat.lt_trans ‹a % m < m› mLt) : a % m % n.succ = a % m)]
+    exact Nat.mod_lt _ ‹0 < m›
+
 lemma Fin.add_comm (a b : Fin n) : a + b = b + a := by
-apply Fin.eq_of_val_eq
-simp only [Fin.add_def, Nat.add_comm]
+  apply Fin.eq_of_val_eq
+  simp only [Fin.add_def, Nat.add_comm]
 
 @[simp] lemma Fin.add_zero (a : Fin n.succ) : a + 0 = a := by
-apply Fin.eq_of_val_eq
-simp only [Fin.add_def, Fin.val_zero, Nat.add_zero]
-exact Nat.mod_eq_of_lt a.isLt
+  apply Fin.eq_of_val_eq
+  simp only [Fin.add_def, Fin.val_zero, Nat.add_zero]
+  exact Nat.mod_eq_of_lt a.isLt
 
-@[simp] lemma Fin.zero_add (a : Fin n.succ) : 0 + a = a := by
-rw [Fin.add_comm]
-exact Fin.add_zero a
-
-@[simp] lemma Fin.zero_mul (a : Fin n.succ) : 0 * a = 0 := by
-apply Fin.eq_of_val_eq
-simp only [Fin.mul_def, Fin.val_zero, Nat.zero_mul]
-simp [Nat.zero_mod]
+@[simp] lemma Fin.zero_add (a : Fin n.succ) : 0 + a = a := (Fin.add_comm _ _) ▸ Fin.add_zero a
 
 lemma Fin.mul_comm (a b : Fin n) : a * b = b * a := by
+  apply Fin.eq_of_val_eq
+  simp only [Fin.mul_def, Nat.mul_comm]
+
+@[simp] lemma Fin.zero_mul (a : Fin n.succ) : 0 * a = 0 := by
+  apply Fin.eq_of_val_eq
+  simp only [Fin.mul_def, Fin.val_zero, Nat.zero_mul]
+  simp [Nat.zero_mod]
+
+@[simp] lemma Fin.mul_zero (a : Fin n.succ) : a * 0 = 0 := by
+  rw [Fin.mul_comm]
+  exact Fin.zero_mul a
+
+@[simp] lemma Fin.one_mul (a : Fin n.succ) : 1 * a = a := by
 apply Fin.eq_of_val_eq
-simp only [Fin.mul_def, Nat.mul_comm]
+simp only [Fin.mul_def]
+cases n with
+| zero => simp only [Nat.eq_zero_of_le_zero (Nat.le_of_succ_le_succ a.isLt)]
+| succ n =>
+  have _ : (1 : Fin n.succ.succ).val = 1 := Nat.mod_eq_of_lt (Nat.succ_le_succ (Nat.succ_le_succ (Nat.zero_le n)))
+  rw [‹(1 : Fin n.succ.succ).val = 1›, Nat.one_mul, Nat.mod_eq_of_lt a.isLt]
+
+@[simp] lemma Fin.mul_one (a : Fin n.succ) : a * 1 = a := by
+  rw [Fin.mul_comm, Fin.one_mul]
 
 lemma Fin.add_assoc (a b c : Fin n) : (a + b) + c = a + (b + c) := by
 apply Fin.eq_of_val_eq
-simp only [Fin.mul_def, Fin.add_def, Nat.mod_add_mod, Nat.add_mod_mod, Nat.add_assoc]
+simp only [Fin.add_def, Nat.mod_add_mod, Nat.add_mod_mod, Nat.add_assoc]
 
-instance : Neg (Fin n) where
-  neg a := ⟨(n - a) % n, Nat.mod_lt _ (lt_of_le_of_lt (Nat.zero_le _) a.isLt)⟩
+lemma Fin.mul_assoc (a b c : Fin n) : (a * b) * c = a * (b * c) := by
+  apply Fin.eq_of_val_eq
+  simp only [Fin.mul_def]
+  generalize lhs : ((a.val * b.val) % n * c.val) % n = l
+  have hl : (a.val * b.val % n) * (c.val % n) % n = (a.val * b.val * c.val) % n := (Nat.mul_mod (a.val * b.val) c.val n).symm
+  rw [<- Nat.mod_eq_of_lt c.isLt, hl] at lhs
+  generalize rhs : a.val * (b.val * c.val % n) % n = r
+  have hr :  a.val % n * ((b.val * c.val) % n) % n = a.val * (b.val * c.val) % n := (Nat.mul_mod a.val (b.val * c.val) n).symm
+  rw [<- Nat.mod_eq_of_lt a.isLt, hr] at rhs
+  simp only [<- Nat.mul_assoc a.val b.val c.val] at rhs
+  rw [<- rhs, <- lhs]
 
 @[simp] lemma Fin.add_left_neg : ∀ (a : Fin n.succ), -a + a = 0
 | ⟨a, isLt⟩ => by
@@ -86,7 +132,7 @@ instance : Neg (Fin n) where
   | succ a =>
     have h1 : (n.succ - a.succ) % n.succ = (n.succ - a.succ) :=
       Nat.mod_eq_of_lt (Nat.sub_lt (Nat.succ_pos _) (Nat.succ_pos _))
-    have h_aux : (Nat.succ n - Nat.succ a + Nat.succ a) = Nat.succ n := by
+    have h_aux : (n.succ - a.succ + a.succ) = n.succ := by
       rw [Nat.add_comm]
       exact Nat.add_sub_of_le (Nat.le_of_lt isLt)
     rw [h1, h_aux, Nat.mod_self]
@@ -104,7 +150,7 @@ lemma Fin.nsmuls_eq (x : Nat) : ∀ (a : Fin n.succ), Fin.nsmul x a = Fin.ofNat 
   apply Fin.eq_of_val_eq
   simp only [Fin.nsmul, Fin.ofNat, Fin.mul_def]
   have hh : a % n.succ = a := Nat.mod_eq_of_lt isLt
-  generalize hq : x * a % Nat.succ n = q
+  generalize hq : x * a % n.succ = q
   rw [<- hh, <- Nat.mul_mod, hq]
 
 lemma Fin.nsmul_succ' (x : Nat) (a : Fin n.succ) : Fin.nsmul x.succ a = a + (Fin.nsmul x a) := by
@@ -134,6 +180,9 @@ instance : AddMonoid (Fin n.succ) where
   nsmul_zero' := Fin.zero_mul
   nsmul_succ' := Fin.nsmul_succ'
 
+instance : AddCommMonoid (Fin n.succ) where
+  add_comm := Fin.add_comm
+
 instance : SubNegMonoid (Fin n.succ) where
   sub_eq_add_neg := Fin.sub_eq_add_neg
   gsmul := Fin.gsmul
@@ -143,6 +192,19 @@ instance : SubNegMonoid (Fin n.succ) where
 
 instance : AddGroup (Fin n.succ) where
   add_left_neg := Fin.add_left_neg
+
+instance : Monoid (Fin n.succ) where
+  mul_one := Fin.mul_one
+  one_mul := Fin.one_mul
+  mul_assoc := Fin.mul_assoc
+  npow_zero' := fun _ => rfl
+  npow_succ' := fun _ _ => rfl
+
+def Fin.addOverflows? (a b : Fin n) : Bool := n <= a.val + b.val
+
+def Fin.mulOverflows? (a b : Fin n) : Bool := n <= a.val * b.val
+
+def Fin.subUnderflows? (a b : Fin n) : Bool := a.val < b.val
 
 def Fin.overflowingAdd (a b : Fin n) : (Bool × Fin n) := (n <= a.val + b.val, a + b)
 
@@ -186,5 +248,12 @@ lemma Fin.checked_sub_spec (a b : Fin n) : (Fin.checkedSub a b).isSome = true <-
     case pos => simp only [(decide_eq_true_iff (a.val < b.val)).mpr hx] at h
     case neg => exact Nat.le_of_not_lt hx
   case mpr => simp only [decide_eq_false (Nat.not_lt_of_le h : ¬a.val < b.val)]
+
+instance : CommMonoid (Fin n.succ) where
+  mul_comm := Fin.mul_comm
+
+instance : MonoidWithZero (Fin n.succ) where
+  zero_mul := Fin.zero_mul
+  mul_zero := Fin.mul_zero
 
 end Fin

--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -1,31 +1,7 @@
 import Mathlib.Data.Nat.Basic
+import Mathlib.Init.Data.Nat.Lemmas
 import Mathlib.Algebra.Group.Defs
 import Mathlib.Algebra.GroupWithZero.Defs
-
-section Fin
-
-variable {n : Nat}
-
-instance : Zero (Fin n.succ) where
-  zero := Fin.ofNat 0
-
-@[simp] lemma Fin.val_zero : (0 : Fin n.succ).val = (0 : Nat) :=
-  show (Fin.ofNat 0).val = 0 by simp [Fin.ofNat]
-
-instance : One (Fin n.succ) where
-  one := ⟨1 % n.succ, Nat.mod_lt 1 (Nat.zero_lt_succ n)⟩
-
-@[simp] lemma Fin.val_one: (1 : Fin n.succ).val = (1 % n.succ : Nat) :=
-  show (Fin.ofNat 1).val = 1 % n.succ by simp [Fin.ofNat]
-
-@[simp] lemma Fin.of_nat_zero : (Fin.ofNat 0 : Fin n.succ) = (0 : Fin n.succ) := by
-  apply Fin.eq_of_val_eq; simp only [Fin.ofNat, Nat.zero_mod, Fin.val_zero]
-
-instance : Neg (Fin n) where
-  neg a := ⟨(n - a) % n, Nat.mod_lt _ (lt_of_le_of_lt (Nat.zero_le _) a.isLt)⟩
-
-lemma Fin.val_eq_of_lt : a < n.succ → (@Fin.ofNat n a).val = a := Nat.mod_eq_of_lt
-
 
 /-- If you actually have an element of `Fin n`, then the `n` is always positive -/
 lemma Fin.positive_size : ∀ (x : Fin n), 0 < n
@@ -34,20 +10,29 @@ lemma Fin.positive_size : ∀ (x : Fin n), 0 < n
   | Or.inl h_eq => h_eq ▸ h
   | Or.inr h_lt => Nat.lt_trans h_lt h
 
-lemma Fin.modn_def : ∀ (a : Fin n) (m : Nat), a % m = Fin.mk ((a.val % m) % n) (Nat.mod_lt (a.val % m) (Fin.positive_size a))
-| ⟨a, pa⟩, m => by simp only [HMod.hMod, Fin.modn]
+lemma Fin.positive_size' [Inhabited (Fin n)] : 0 < n := Fin.positive_size (Inhabited.default)
 
-lemma Fin.mod_def : ∀ (a m : Fin n), a % m = Fin.mk ((a.val % m.val) % n) (Nat.mod_lt (a.val % m.val) (Fin.positive_size a))
-| ⟨a, pa⟩, ⟨m, pm⟩ => by simp only [HMod.hMod, Mod.mod, Fin.mod]
+lemma zero_lt_of_lt {a : Nat} : ∀ {x : Nat}, x < a -> 0 < a
+| 0, h   => h
+| x+1, h => Nat.lt_trans (Nat.zero_lt_succ x) h
 
-lemma Fin.add_def : ∀ (a b : Fin n), a + b = (Fin.mk ((a.val + b.val) % n) (Nat.mod_lt _ (Fin.positive_size a)))
-| ⟨a, pa⟩, ⟨b, pb⟩ => by simp only [HAdd.hAdd, Add.add, Fin.add]
+lemma Fin.val_eq_of_lt {n a : Nat} (h : a < n) : (Fin.ofNat' a (zero_lt_of_lt h)).val = a := by
+  simp only [Fin.ofNat', Nat.mod_eq_of_lt h]
 
-lemma Fin.mul_def : ∀ (a b : Fin n), a * b = (Fin.mk ((a.val * b.val) % n) (Nat.mod_lt _ (Fin.positive_size a)))
-| ⟨a, pa⟩, ⟨b, pb⟩ => by simp only [HMul.hMul, Mul.mul, Fin.mul]
+lemma Fin.modn_def : ∀ (a : Fin n) (m : Nat), a % m = Fin.mk ((a.val % m) % n) (Nat.mod_lt (a.val % m) (a.positive_size))
+| ⟨a, pa⟩, m => rfl
 
-lemma Fin.sub_def : ∀ (a b : Fin n), a - b = (Fin.mk ((a + (n - b)) % n) (Nat.mod_lt _ (Fin.positive_size a)))
-| ⟨a, pa⟩, ⟨b, pb⟩ => by simp only [HSub.hSub, Sub.sub, Fin.sub]
+lemma Fin.mod_def : ∀ (a m : Fin n), a % m = Fin.mk ((a.val % m.val) % n) (Nat.mod_lt (a.val % m.val) (a.positive_size))
+| ⟨a, pa⟩, ⟨m, pm⟩ => rfl
+
+lemma Fin.add_def : ∀ (a b : Fin n), a + b = (Fin.mk ((a.val + b.val) % n) (Nat.mod_lt _ (a.positive_size)))
+| ⟨a, pa⟩, ⟨b, pb⟩ => rfl
+
+lemma Fin.mul_def : ∀ (a b : Fin n), a * b = (Fin.mk ((a.val * b.val) % n) (Nat.mod_lt _ (a.positive_size)))
+| ⟨a, pa⟩, ⟨b, pb⟩ => rfl
+
+lemma Fin.sub_def : ∀ (a b : Fin n), a - b = (Fin.mk ((a + (n - b)) % n) (Nat.mod_lt _ (a.positive_size)))
+| ⟨a, pa⟩, ⟨b, pb⟩ => rfl
 
 @[simp] lemma Fin.mod_eq (a : Fin n) : a % n = a := by
   apply Fin.eq_of_val_eq
@@ -63,142 +48,141 @@ theorem Fin.mod_eq_of_lt {a b : Fin n} (h : a < b) : a % b = a := by
   simp only [Fin.mod_def]
   rw [Nat.mod_eq_of_lt h, Nat.mod_eq_of_lt a.isLt]
 
-theorem Fin.mod_lt : ∀ (i : Fin n.succ) {m : Fin n.succ}, (0 : Fin n.succ) < m → (i % m) < m
-  | ⟨a, aLt⟩, ⟨m, mLt⟩, hp =>  by
-    have _ : (0 : Nat) < m := Fin.val_zero ▸ hp
-    have _ : a % m < m := Nat.mod_lt _ ‹0 < m›
+/- The basic structures on `Fin` are predicated on `Fin n` being inhabited.
+The Inhabited bound is there so that we can implement `Zero` in a way that satisfies
+the requirements of the relevant typeclasses (for example, AddMonoid). If we were to
+use `Fin n+1` for the `Zero` implementation, we would be shutting out some irreducible
+definitions (notably USize.size) that are known to be inhabited, but not defined in terms
+of `Nat.succ`. Since there's a blanket implementation of `∀ n, Inhabited (Fin n+1)` in
+the prelude, this hopefully won't be a significant impediment. -/
+section Fin
+
+variable {n : Nat} [Inhabited (Fin n)]
+
+instance : AddSemigroup (Fin n) where
+  add_assoc := fun _ _ _ => by
+    apply Fin.eq_of_val_eq
+    simp only [Fin.add_def, Nat.mod_add_mod, Nat.add_mod_mod, Nat.add_assoc]
+
+instance : AddCommSemigroup (Fin n) where
+  add_comm := fun _ _ => by
+    apply Fin.eq_of_val_eq
+    simp only [Fin.add_def, Nat.add_comm]
+
+instance : Semigroup (Fin n) where
+  mul_assoc := fun a b c => by
+    apply Fin.eq_of_val_eq
+    simp only [Fin.mul_def]
+    generalize lhs : ((a.val * b.val) % n * c.val) % n = l
+    generalize rhs : a.val * (b.val * c.val % n) % n = r
+    rw [<- Nat.mod_eq_of_lt c.isLt, (Nat.mul_mod (a.val * b.val) c.val n).symm] at lhs
+    rw [<- Nat.mod_eq_of_lt a.isLt, (Nat.mul_mod a.val (b.val * c.val) n).symm, <- Nat.mul_assoc] at rhs
+    rw [<- lhs, <- rhs]
+
+instance : CommSemigroup (Fin n) where
+  mul_comm := fun _ _ => by apply Fin.eq_of_val_eq; simp only [Fin.mul_def, Nat.mul_comm]
+
+instance : Zero (Fin n) where
+  zero := Fin.ofNat' 0 Fin.positive_size'
+
+@[simp] lemma Fin.val_zero : (0 : Fin n).val = (0 : Nat) :=
+  show (Fin.ofNat' 0 Fin.positive_size').val = (0 : Nat) by simp only [Fin.ofNat', Nat.zero_mod]
+
+theorem Fin.mod_lt : ∀ (i : Fin n) {m : Fin n}, (0 : Fin n) < m → (i % m) < m
+| ⟨a, aLt⟩, ⟨m, mLt⟩, hp =>  by
+    have zero_lt : (0 : Nat) < m := Fin.val_zero ▸ hp
+    have a_mod_lt : a % m < m := Nat.mod_lt _ zero_lt
     simp only [Fin.mod_def, LT.lt]
-    rw [(Nat.mod_eq_of_lt (Nat.lt_trans ‹a % m < m› mLt) : a % m % n.succ = a % m)]
-    exact Nat.mod_lt _ ‹0 < m›
-
-lemma Fin.add_comm (a b : Fin n) : a + b = b + a := by
-  apply Fin.eq_of_val_eq
-  simp only [Fin.add_def, Nat.add_comm]
-
-@[simp] lemma Fin.add_zero (a : Fin n.succ) : a + 0 = a := by
-  apply Fin.eq_of_val_eq
-  simp only [Fin.add_def, Fin.val_zero, Nat.add_zero]
-  exact Nat.mod_eq_of_lt a.isLt
-
-@[simp] lemma Fin.zero_add (a : Fin n.succ) : 0 + a = a := (Fin.add_comm _ _) ▸ Fin.add_zero a
-
-lemma Fin.mul_comm (a b : Fin n) : a * b = b * a := by
-  apply Fin.eq_of_val_eq
-  simp only [Fin.mul_def, Nat.mul_comm]
-
-@[simp] lemma Fin.zero_mul (a : Fin n.succ) : 0 * a = 0 := by
-  apply Fin.eq_of_val_eq
-  simp only [Fin.mul_def, Fin.val_zero, Nat.zero_mul]
-  simp [Nat.zero_mod]
-
-@[simp] lemma Fin.mul_zero (a : Fin n.succ) : a * 0 = 0 := by
-  rw [Fin.mul_comm]
-  exact Fin.zero_mul a
-
-@[simp] lemma Fin.one_mul (a : Fin n.succ) : 1 * a = a := by
-apply Fin.eq_of_val_eq
-simp only [Fin.mul_def]
-cases n with
-| zero => simp only [Nat.eq_zero_of_le_zero (Nat.le_of_succ_le_succ a.isLt)]
-| succ n =>
-  have _ : (1 : Fin n.succ.succ).val = 1 := Nat.mod_eq_of_lt (Nat.succ_le_succ (Nat.succ_le_succ (Nat.zero_le n)))
-  rw [‹(1 : Fin n.succ.succ).val = 1›, Nat.one_mul, Nat.mod_eq_of_lt a.isLt]
-
-@[simp] lemma Fin.mul_one (a : Fin n.succ) : a * 1 = a := by
-  rw [Fin.mul_comm, Fin.one_mul]
-
-lemma Fin.add_assoc (a b c : Fin n) : (a + b) + c = a + (b + c) := by
-apply Fin.eq_of_val_eq
-simp only [Fin.add_def, Nat.mod_add_mod, Nat.add_mod_mod, Nat.add_assoc]
-
-lemma Fin.mul_assoc (a b c : Fin n) : (a * b) * c = a * (b * c) := by
-  apply Fin.eq_of_val_eq
-  simp only [Fin.mul_def]
-  generalize lhs : ((a.val * b.val) % n * c.val) % n = l
-  have hl : (a.val * b.val % n) * (c.val % n) % n = (a.val * b.val * c.val) % n := (Nat.mul_mod (a.val * b.val) c.val n).symm
-  rw [<- Nat.mod_eq_of_lt c.isLt, hl] at lhs
-  generalize rhs : a.val * (b.val * c.val % n) % n = r
-  have hr :  a.val % n * ((b.val * c.val) % n) % n = a.val * (b.val * c.val) % n := (Nat.mul_mod a.val (b.val * c.val) n).symm
-  rw [<- Nat.mod_eq_of_lt a.isLt, hr] at rhs
-  simp only [<- Nat.mul_assoc a.val b.val c.val] at rhs
-  rw [<- rhs, <- lhs]
-
-@[simp] lemma Fin.add_left_neg : ∀ (a : Fin n.succ), -a + a = 0
-| ⟨a, isLt⟩ => by
-  apply Fin.eq_of_val_eq
-  simp only [Neg.neg, Fin.add_def, Fin.val_zero]
-  cases a with
-  | zero => rw [Nat.sub_zero, Nat.add_zero, Nat.mod_mod, Nat.mod_self]
-  | succ a =>
-    have h1 : (n.succ - a.succ) % n.succ = (n.succ - a.succ) :=
-      Nat.mod_eq_of_lt (Nat.sub_lt (Nat.succ_pos _) (Nat.succ_pos _))
-    have h_aux : (n.succ - a.succ + a.succ) = n.succ := by
-      rw [Nat.add_comm]
-      exact Nat.add_sub_of_le (Nat.le_of_lt isLt)
-    rw [h1, h_aux, Nat.mod_self]
-
-def Fin.nsmul (x : Nat) (a : Fin n.succ) : Fin n.succ := (Fin.ofNat x) * a
-
-def Fin.gsmul (x : Int) (a : Fin n.succ) : Fin n.succ :=
-  match x with
-  | Int.ofNat x' => Fin.nsmul x' a
-  | Int.negSucc x' => -(Fin.nsmul x'.succ a)
+    rw [(Nat.mod_eq_of_lt (Nat.lt_trans a_mod_lt mLt) : a % m % n = a % m)]
+    exact Nat.mod_lt _ zero_lt
 
 /- Aux lemma that makes nsmul_succ' easier -/
-lemma Fin.nsmuls_eq (x : Nat) : ∀ (a : Fin n.succ), Fin.nsmul x a = Fin.ofNat (x * a.val)
+protected lemma Fin.nsmuls_eq (x : Nat) : ∀ (a : Fin n), ((Fin.ofNat' x Fin.positive_size') * a) = Fin.ofNat' (x * a.val) Fin.positive_size'
 | ⟨a, isLt⟩ => by
   apply Fin.eq_of_val_eq
-  simp only [Fin.nsmul, Fin.ofNat, Fin.mul_def]
-  have hh : a % n.succ = a := Nat.mod_eq_of_lt isLt
-  generalize hq : x * a % n.succ = q
-  rw [<- hh, <- Nat.mul_mod, hq]
+  simp only [Fin.ofNat', Fin.mul_def]
+  generalize hy : x * a % n = y
+  rw [<- Nat.mod_eq_of_lt isLt, <- Nat.mul_mod, hy]
 
-lemma Fin.nsmul_succ' (x : Nat) (a : Fin n.succ) : Fin.nsmul x.succ a = a + (Fin.nsmul x a) := by
-  simp only [Fin.nsmuls_eq]
-  simp [nsmul, Fin.ofNat, Fin.add_def]
-  exact congrArg (fun x => x % n.succ) (Nat.add_comm (x * a.val) (a.val) ▸ Nat.succ_mul x a.val)
+instance : AddMonoid (Fin n) :=
+  let add_zero_ : ∀ (a : Fin n), a + 0 = a := fun a => by
+    apply Fin.eq_of_val_eq
+    simp only [Fin.add_def, Fin.val_zero, Nat.add_zero]
+    exact Nat.mod_eq_of_lt a.isLt
+  {
+    add_zero := add_zero_
+    zero_add := fun _ => by rw [add_comm]; exact add_zero_ _
+    nsmul := fun x a => (Fin.ofNat' x a.positive_size) * a
+    nsmul_zero' := fun _ => by
+      apply Fin.eq_of_val_eq
+      simp [Fin.mul_def, Fin.ofNat', Fin.val_zero, Nat.zero_mul, Nat.zero_mod]
+    nsmul_succ' := fun x a => by
+      simp only [Fin.nsmuls_eq]
+      simp [Fin.ofNat', Fin.add_def]
+      exact congrArg (fun x => x % n) (Nat.add_comm (x * a.val) (a.val) ▸ Nat.succ_mul x a.val)
+  }
 
-lemma Fin.sub_eq_add_neg (a b : Fin n) : a - b = a + -b := by
-  simp [Fin.add_def, Fin.sub_def, Neg.neg]
+instance : AddCommMonoid (Fin n) where
+  add_comm := add_comm
 
-@[simp] lemma Fin.gsmul_zero' (a : Fin n.succ) : Fin.gsmul 0 a = (0 : Fin n.succ) := by
-  simp only [Fin.gsmul, Fin.nsmul, Fin.of_nat_zero, Fin.zero_mul]
+instance : One (Fin n) where
+  one := ⟨1 % n, (Nat.mod_lt 1 Fin.positive_size')⟩
 
-lemma Fin.gsmul_succ' (m : ℕ) (a : Fin n.succ) : Fin.gsmul (Int.ofNat m.succ) a = a + Fin.gsmul (Int.ofNat m) a := by
-  simp only [Fin.gsmul, Fin.nsmul_succ']
+@[simp] lemma Fin.val_one: (1 : Fin n).val = (1 % n : Nat) :=
+  show (Fin.ofNat' 1 Fin.positive_size').val = 1 % n by simp [Fin.ofNat']
 
-lemma Fin.gsmul_neg' (m : ℕ) (a : Fin n.succ) : gsmul (Int.negSucc m) a = -(gsmul (m.succ) a) := by
-  simp only [Fin.gsmul, Fin.nsmul]
+instance : Neg (Fin n) where
+  neg a := ⟨(n - a) % n, Nat.mod_lt _ (lt_of_le_of_lt (Nat.zero_le _) a.isLt)⟩
 
-instance : AddSemigroup (Fin n.succ) where
-  add_assoc := Fin.add_assoc
+instance : SubNegMonoid (Fin n) where
+  sub_eq_add_neg := fun _ _ => by simp [Fin.add_def, Fin.sub_def, Neg.neg]
+  gsmul := fun x a =>
+    match x with
+    | Int.ofNat x' => AddMonoid.nsmul x' a
+    | Int.negSucc x' => -(AddMonoid.nsmul x'.succ a)
+  gsmul_zero' := fun _ => by
+    apply Fin.eq_of_val_eq
+    simp only [AddMonoid.nsmul, Fin.ofNat', Fin.mul_def, Nat.zero_mod, Nat.zero_mul, Fin.val_zero]
+  gsmul_succ' := by simp [AddMonoid.nsmul_succ']
+  gsmul_neg' := by simp [AddMonoid.nsmul]
 
-instance : AddMonoid (Fin n.succ) where
-  add_zero := Fin.add_zero
-  zero_add := Fin.zero_add
-  nsmul := Fin.nsmul
-  nsmul_zero' := Fin.zero_mul
-  nsmul_succ' := Fin.nsmul_succ'
+instance : AddGroup (Fin n) where
+  add_left_neg :=
+    fun
+    | ⟨a, isLt⟩ => by
+      apply Fin.eq_of_val_eq
+      simp only [Neg.neg, Fin.add_def, Fin.val_zero]
+      cases a with
+      | zero => rw [Nat.sub_zero, Nat.add_zero, Nat.mod_mod, Nat.mod_self]
+      | succ a =>
+        have h1 : (n - a.succ) % n = (n - a.succ) :=
+          Nat.mod_eq_of_lt (Nat.sub_lt (Fin.positive_size') (Nat.succ_pos _))
+        have h_aux : (n - a.succ + a.succ) = n := by
+          rw [Nat.add_comm]
+          exact Nat.add_sub_of_le (Nat.le_of_lt isLt)
+        rw [h1, h_aux, Nat.mod_self]
 
-instance : AddCommMonoid (Fin n.succ) where
-  add_comm := Fin.add_comm
-
-instance : SubNegMonoid (Fin n.succ) where
-  sub_eq_add_neg := Fin.sub_eq_add_neg
-  gsmul := Fin.gsmul
-  gsmul_zero' := Fin.gsmul_zero'
-  gsmul_succ' := Fin.gsmul_succ'
-  gsmul_neg' := Fin.gsmul_neg'
-
-instance : AddGroup (Fin n.succ) where
-  add_left_neg := Fin.add_left_neg
-
-instance : Monoid (Fin n.succ) where
-  mul_one := Fin.mul_one
-  one_mul := Fin.one_mul
-  mul_assoc := Fin.mul_assoc
-  npow_zero' := fun _ => rfl
-  npow_succ' := fun _ _ => rfl
+instance : Monoid (Fin n) :=
+  let mul_one_ : ∀ (a : Fin n), a * 1 = a := fun a => by
+    apply Fin.eq_of_val_eq
+    simp only [Fin.mul_def, Fin.val_one]
+    cases n with
+    | zero => exact (False.elim a.elim0)
+    | succ n =>
+      match Nat.lt_or_eq_of_le (Nat.mod_le 1 n.succ) with
+      | Or.inl h_lt =>
+        have h_eq : 1 % n.succ = 0 := Nat.eq_zero_of_le_zero (Nat.le_of_lt_succ h_lt)
+        have hnz : n = 0 := Nat.eq_zero_of_le_zero (Nat.le_of_succ_le_succ (Nat.le_of_mod_lt h_lt))
+        have haz : a.val = 0 := Nat.eq_zero_of_le_zero (Nat.le_of_succ_le_succ (hnz ▸ a.isLt))
+        rw [h_eq, haz]
+        simp only [Nat.zero_mul, Nat.zero_mod]
+      | Or.inr h_eq => simp only [h_eq, Nat.mul_one, Nat.mod_eq_of_lt (a.isLt)]
+  {
+    mul_one := mul_one_
+    one_mul := fun _ => by rw [mul_comm]; exact mul_one_ _
+    npow_zero' := fun _ => rfl
+    npow_succ' := fun _ _ => rfl
+  }
 
 def Fin.addOverflows? (a b : Fin n) : Bool := n <= a.val + b.val
 
@@ -249,11 +233,16 @@ lemma Fin.checked_sub_spec (a b : Fin n) : (Fin.checkedSub a b).isSome = true <-
     case neg => exact Nat.le_of_not_lt hx
   case mpr => simp only [decide_eq_false (Nat.not_lt_of_le h : ¬a.val < b.val)]
 
-instance : CommMonoid (Fin n.succ) where
-  mul_comm := Fin.mul_comm
+instance : CommMonoid (Fin n) where
+  mul_comm := CommSemigroup.mul_comm
 
-instance : MonoidWithZero (Fin n.succ) where
-  zero_mul := Fin.zero_mul
-  mul_zero := Fin.mul_zero
+instance : MonoidWithZero (Fin n) :=
+  let zero_mul_ : ∀ (x : Fin n), 0 * x = 0 := fun _ => by
+    apply Fin.eq_of_val_eq
+    simp only [Fin.mul_def, Fin.val_zero, Nat.zero_mul, Nat.zero_mod]
+  {
+    zero_mul := zero_mul_
+    mul_zero := fun _ => by rw [mul_comm]; exact zero_mul_ _
+  }
 
 end Fin

--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -2,15 +2,16 @@ import Mathlib.Data.Nat.Basic
 import Mathlib.Init.Data.Nat.Lemmas
 import Mathlib.Algebra.Group.Defs
 import Mathlib.Algebra.GroupWithZero.Defs
+import Mathlib.Algebra.Ring.Basic
 
 /-- If you actually have an element of `Fin n`, then the `n` is always positive -/
-lemma Fin.positive_size : ∀ (x : Fin n), 0 < n
+lemma Fin.size_positive : ∀ (x : Fin n), 0 < n
 | ⟨x, h⟩ =>
   match Nat.eq_or_lt_of_le (Nat.zero_le x) with
   | Or.inl h_eq => h_eq ▸ h
   | Or.inr h_lt => Nat.lt_trans h_lt h
 
-lemma Fin.positive_size' [Inhabited (Fin n)] : 0 < n := Fin.positive_size (Inhabited.default)
+lemma Fin.size_positive' [Inhabited (Fin n)] : 0 < n := Fin.size_positive (Inhabited.default)
 
 lemma zero_lt_of_lt {a : Nat} : ∀ {x : Nat}, x < a -> 0 < a
 | 0, h   => h
@@ -19,19 +20,19 @@ lemma zero_lt_of_lt {a : Nat} : ∀ {x : Nat}, x < a -> 0 < a
 lemma Fin.val_eq_of_lt {n a : Nat} (h : a < n) : (Fin.ofNat' a (zero_lt_of_lt h)).val = a := by
   simp only [Fin.ofNat', Nat.mod_eq_of_lt h]
 
-lemma Fin.modn_def : ∀ (a : Fin n) (m : Nat), a % m = Fin.mk ((a.val % m) % n) (Nat.mod_lt (a.val % m) (a.positive_size))
+lemma Fin.modn_def : ∀ (a : Fin n) (m : Nat), a % m = Fin.mk ((a.val % m) % n) (Nat.mod_lt (a.val % m) (a.size_positive))
 | ⟨a, pa⟩, m => rfl
 
-lemma Fin.mod_def : ∀ (a m : Fin n), a % m = Fin.mk ((a.val % m.val) % n) (Nat.mod_lt (a.val % m.val) (a.positive_size))
+lemma Fin.mod_def : ∀ (a m : Fin n), a % m = Fin.mk ((a.val % m.val) % n) (Nat.mod_lt (a.val % m.val) (a.size_positive))
 | ⟨a, pa⟩, ⟨m, pm⟩ => rfl
 
-lemma Fin.add_def : ∀ (a b : Fin n), a + b = (Fin.mk ((a.val + b.val) % n) (Nat.mod_lt _ (a.positive_size)))
+lemma Fin.add_def : ∀ (a b : Fin n), a + b = (Fin.mk ((a.val + b.val) % n) (Nat.mod_lt _ (a.size_positive)))
 | ⟨a, pa⟩, ⟨b, pb⟩ => rfl
 
-lemma Fin.mul_def : ∀ (a b : Fin n), a * b = (Fin.mk ((a.val * b.val) % n) (Nat.mod_lt _ (a.positive_size)))
+lemma Fin.mul_def : ∀ (a b : Fin n), a * b = (Fin.mk ((a.val * b.val) % n) (Nat.mod_lt _ (a.size_positive)))
 | ⟨a, pa⟩, ⟨b, pb⟩ => rfl
 
-lemma Fin.sub_def : ∀ (a b : Fin n), a - b = (Fin.mk ((a + (n - b)) % n) (Nat.mod_lt _ (a.positive_size)))
+lemma Fin.sub_def : ∀ (a b : Fin n), a - b = (Fin.mk ((a + (n - b)) % n) (Nat.mod_lt _ (a.size_positive)))
 | ⟨a, pa⟩, ⟨b, pb⟩ => rfl
 
 @[simp] lemma Fin.mod_eq (a : Fin n) : a % n = a := by
@@ -59,6 +60,9 @@ section Fin
 
 variable {n : Nat} [Inhabited (Fin n)]
 
+instance : Numeric (Fin n) where
+  ofNat a := Fin.ofNat' a Fin.size_positive'
+
 instance : AddSemigroup (Fin n) where
   add_assoc := fun _ _ _ => by
     apply Fin.eq_of_val_eq
@@ -79,110 +83,27 @@ instance : Semigroup (Fin n) where
     rw [<- Nat.mod_eq_of_lt a.isLt, (Nat.mul_mod a.val (b.val * c.val) n).symm, <- Nat.mul_assoc] at rhs
     rw [<- lhs, <- rhs]
 
-instance : CommSemigroup (Fin n) where
-  mul_comm := fun _ _ => by apply Fin.eq_of_val_eq; simp only [Fin.mul_def, Nat.mul_comm]
-
-instance : Zero (Fin n) where
-  zero := Fin.ofNat' 0 Fin.positive_size'
-
-@[simp] lemma Fin.val_zero : (0 : Fin n).val = (0 : Nat) :=
-  show (Fin.ofNat' 0 Fin.positive_size').val = (0 : Nat) by simp only [Fin.ofNat', Nat.zero_mod]
+@[simp] lemma Fin.zero_def : (0 : Fin n).val = (0 : Nat) :=
+  show (Fin.ofNat' 0 Fin.size_positive').val = (0 : Nat) by simp only [Fin.ofNat', Nat.zero_mod]
 
 theorem Fin.mod_lt : ∀ (i : Fin n) {m : Fin n}, (0 : Fin n) < m → (i % m) < m
 | ⟨a, aLt⟩, ⟨m, mLt⟩, hp =>  by
-    have zero_lt : (0 : Nat) < m := Fin.val_zero ▸ hp
+    have zero_lt : (0 : Nat) < m := Fin.zero_def ▸ hp
     have a_mod_lt : a % m < m := Nat.mod_lt _ zero_lt
     simp only [Fin.mod_def, LT.lt]
     rw [(Nat.mod_eq_of_lt (Nat.lt_trans a_mod_lt mLt) : a % m % n = a % m)]
     exact Nat.mod_lt _ zero_lt
 
 /- Aux lemma that makes nsmul_succ' easier -/
-protected lemma Fin.nsmuls_eq (x : Nat) : ∀ (a : Fin n), ((Fin.ofNat' x Fin.positive_size') * a) = Fin.ofNat' (x * a.val) Fin.positive_size'
+protected lemma Fin.nsmuls_eq (x : Nat) : ∀ (a : Fin n), ((Fin.ofNat' x Fin.size_positive') * a) = Fin.ofNat' (x * a.val) Fin.size_positive'
 | ⟨a, isLt⟩ => by
   apply Fin.eq_of_val_eq
   simp only [Fin.ofNat', Fin.mul_def]
   generalize hy : x * a % n = y
   rw [<- Nat.mod_eq_of_lt isLt, <- Nat.mul_mod, hy]
 
-instance : AddMonoid (Fin n) :=
-  let add_zero_ : ∀ (a : Fin n), a + 0 = a := fun a => by
-    apply Fin.eq_of_val_eq
-    simp only [Fin.add_def, Fin.val_zero, Nat.add_zero]
-    exact Nat.mod_eq_of_lt a.isLt
-  {
-    add_zero := add_zero_
-    zero_add := fun _ => by rw [add_comm]; exact add_zero_ _
-    nsmul := fun x a => (Fin.ofNat' x a.positive_size) * a
-    nsmul_zero' := fun _ => by
-      apply Fin.eq_of_val_eq
-      simp [Fin.mul_def, Fin.ofNat', Fin.val_zero, Nat.zero_mul, Nat.zero_mod]
-    nsmul_succ' := fun x a => by
-      simp only [Fin.nsmuls_eq]
-      simp [Fin.ofNat', Fin.add_def]
-      exact congrArg (fun x => x % n) (Nat.add_comm (x * a.val) (a.val) ▸ Nat.succ_mul x a.val)
-  }
-
-instance : AddCommMonoid (Fin n) where
-  add_comm := add_comm
-
-instance : One (Fin n) where
-  one := ⟨1 % n, (Nat.mod_lt 1 Fin.positive_size')⟩
-
-@[simp] lemma Fin.val_one: (1 : Fin n).val = (1 % n : Nat) :=
-  show (Fin.ofNat' 1 Fin.positive_size').val = 1 % n by simp [Fin.ofNat']
-
-instance : Neg (Fin n) where
-  neg a := ⟨(n - a) % n, Nat.mod_lt _ (lt_of_le_of_lt (Nat.zero_le _) a.isLt)⟩
-
-instance : SubNegMonoid (Fin n) where
-  sub_eq_add_neg := fun _ _ => by simp [Fin.add_def, Fin.sub_def, Neg.neg]
-  gsmul := fun x a =>
-    match x with
-    | Int.ofNat x' => AddMonoid.nsmul x' a
-    | Int.negSucc x' => -(AddMonoid.nsmul x'.succ a)
-  gsmul_zero' := fun _ => by
-    apply Fin.eq_of_val_eq
-    simp only [AddMonoid.nsmul, Fin.ofNat', Fin.mul_def, Nat.zero_mod, Nat.zero_mul, Fin.val_zero]
-  gsmul_succ' := by simp [AddMonoid.nsmul_succ']
-  gsmul_neg' := by simp [AddMonoid.nsmul]
-
-instance : AddGroup (Fin n) where
-  add_left_neg :=
-    fun
-    | ⟨a, isLt⟩ => by
-      apply Fin.eq_of_val_eq
-      simp only [Neg.neg, Fin.add_def, Fin.val_zero]
-      cases a with
-      | zero => rw [Nat.sub_zero, Nat.add_zero, Nat.mod_mod, Nat.mod_self]
-      | succ a =>
-        have h1 : (n - a.succ) % n = (n - a.succ) :=
-          Nat.mod_eq_of_lt (Nat.sub_lt (Fin.positive_size') (Nat.succ_pos _))
-        have h_aux : (n - a.succ + a.succ) = n := by
-          rw [Nat.add_comm]
-          exact Nat.add_sub_of_le (Nat.le_of_lt isLt)
-        rw [h1, h_aux, Nat.mod_self]
-
-instance : Monoid (Fin n) :=
-  let mul_one_ : ∀ (a : Fin n), a * 1 = a := fun a => by
-    apply Fin.eq_of_val_eq
-    simp only [Fin.mul_def, Fin.val_one]
-    cases n with
-    | zero => exact (False.elim a.elim0)
-    | succ n =>
-      match Nat.lt_or_eq_of_le (Nat.mod_le 1 n.succ) with
-      | Or.inl h_lt =>
-        have h_eq : 1 % n.succ = 0 := Nat.eq_zero_of_le_zero (Nat.le_of_lt_succ h_lt)
-        have hnz : n = 0 := Nat.eq_zero_of_le_zero (Nat.le_of_succ_le_succ (Nat.le_of_mod_lt h_lt))
-        have haz : a.val = 0 := Nat.eq_zero_of_le_zero (Nat.le_of_succ_le_succ (hnz ▸ a.isLt))
-        rw [h_eq, haz]
-        simp only [Nat.zero_mul, Nat.zero_mod]
-      | Or.inr h_eq => simp only [h_eq, Nat.mul_one, Nat.mod_eq_of_lt (a.isLt)]
-  {
-    mul_one := mul_one_
-    one_mul := fun _ => by rw [mul_comm]; exact mul_one_ _
-    npow_zero' := fun _ => rfl
-    npow_succ' := fun _ _ => rfl
-  }
+@[simp] lemma Fin.one_def: (1 : Fin n).val = (1 % n : Nat) :=
+  show (Fin.ofNat' 1 Fin.size_positive').val = 1 % n by simp [Fin.ofNat']
 
 def Fin.addOverflows? (a b : Fin n) : Bool := n <= a.val + b.val
 
@@ -233,16 +154,86 @@ lemma Fin.checked_sub_spec (a b : Fin n) : (Fin.checkedSub a b).isSome = true <-
     case neg => exact Nat.le_of_not_lt hx
   case mpr => simp only [decide_eq_false (Nat.not_lt_of_le h : ¬a.val < b.val)]
 
-instance : CommMonoid (Fin n) where
-  mul_comm := CommSemigroup.mul_comm
-
-instance : MonoidWithZero (Fin n) :=
+instance : Semiring (Fin n) :=
+  let add_zero_ : ∀ (a : Fin n), a + 0 = a := fun a => by
+    apply Fin.eq_of_val_eq
+    simp only [Fin.add_def, Fin.zero_def, Nat.add_zero]
+    exact Nat.mod_eq_of_lt a.isLt
   let zero_mul_ : ∀ (x : Fin n), 0 * x = 0 := fun _ => by
     apply Fin.eq_of_val_eq
-    simp only [Fin.mul_def, Fin.val_zero, Nat.zero_mul, Nat.zero_mod]
+    simp only [Fin.mul_def, Fin.zero_def, Nat.zero_mul, Nat.zero_mod]
+  let mul_add_ : ∀ (a b c : Fin n), a * (b + c) = a * b + a * c := fun a b c => by
+    apply Fin.eq_of_val_eq
+    simp [Fin.mul_def, Fin.add_def]
+    generalize lhs : a.val * ((b.val + c.val) % n) % n = l
+    rw [(Nat.mod_eq_of_lt a.isLt).symm, <- Nat.mul_mod] at lhs
+    rw [<- lhs, Semiring.mul_add]
+  let mul_comm : ∀ (a b : Fin n), a * b = b * a := fun _ _ => by apply Fin.eq_of_val_eq; simp only [Fin.mul_def, Nat.mul_comm]
+
+  let mul_one_ : ∀ (a : Fin n), a * 1 = a := fun a => by
+    apply Fin.eq_of_val_eq
+    simp only [Fin.mul_def, Fin.one_def]
+    cases n with
+    | zero => exact (False.elim a.elim0)
+    | succ n =>
+      match Nat.lt_or_eq_of_le (Nat.mod_le 1 n.succ) with
+      | Or.inl h_lt =>
+        have h_eq : 1 % n.succ = 0 := Nat.eq_zero_of_le_zero (Nat.le_of_lt_succ h_lt)
+        have hnz : n = 0 := Nat.eq_zero_of_le_zero (Nat.le_of_succ_le_succ (Nat.le_of_mod_lt h_lt))
+        have haz : a.val = 0 := Nat.eq_zero_of_le_zero (Nat.le_of_succ_le_succ (hnz ▸ a.isLt))
+        rw [h_eq, haz]
+        simp only [Nat.zero_mul, Nat.zero_mod]
+      | Or.inr h_eq => simp only [h_eq, Nat.mul_one, Nat.mod_eq_of_lt (a.isLt)]
   {
+    ofNat_succ := fun _ => by simp [Numeric.ofNat, Fin.ofNat', Fin.add_def]
+    add_zero := add_zero_
+    zero_add := fun _ => by rw [add_comm]; exact add_zero_ _
+    nsmul := fun x a => (Fin.ofNat' x a.size_positive) * a
+    nsmul_zero' := fun _ => by
+      apply Fin.eq_of_val_eq
+      simp [Numeric.ofNat, Fin.mul_def, Fin.ofNat', Fin.zero_def, Nat.zero_mul, Nat.zero_mod]
+    nsmul_succ' := fun x a => by
+      simp only [Fin.nsmuls_eq]
+      simp [Fin.ofNat', Fin.add_def]
+      exact congrArg (fun x => x % n) (Nat.add_comm (x * a.val) (a.val) ▸ Nat.succ_mul x a.val)
     zero_mul := zero_mul_
     mul_zero := fun _ => by rw [mul_comm]; exact zero_mul_ _
+    mul_one := mul_one_
+    one_mul := fun _ => by rw [mul_comm]; exact mul_one_ _
+    npow_zero' := fun _ => rfl
+    npow_succ' := fun _ _ => rfl
+    mul_add := mul_add_
+    add_mul := fun a b c => by
+      have h0 := mul_add_ c a b
+      have h1 : (a + b) * c = c * (a + b) := mul_comm (a + b) c
+      have h2 : a * c = c * a := mul_comm a _
+      have h3 : b * c = c * b := mul_comm b _
+      rw [h1, h2, h3, h0]
   }
+
+instance : Neg (Fin n) where
+  neg a := ⟨(n - a) % n, Nat.mod_lt _ (lt_of_le_of_lt (Nat.zero_le _) a.isLt)⟩
+
+instance : Ring (Fin n) :=
+  let sub_eq_add_neg_ : ∀ (a b : Fin n), a - b = a + -b := fun _ _ => by simp [Fin.add_def, Fin.sub_def, Neg.neg]
+  {
+    sub_eq_add_neg := sub_eq_add_neg_
+    gsmul := fun x a =>
+      match x with
+      | Int.ofNat x' => Semiring.nsmul x' a
+      | Int.negSucc x' => -(Semiring.nsmul x'.succ a)
+    gsmul_zero' := fun _ => by
+      apply Fin.eq_of_val_eq
+      simp only [Semiring.nsmul, Fin.ofNat', Fin.mul_def, Nat.zero_mod, Nat.zero_mul, Fin.zero_def]
+    gsmul_succ' := by simp [Semiring.nsmul_succ']
+    gsmul_neg' := by simp [Semiring.nsmul]
+    add_left_neg := fun a => by
+      rw [add_comm, <- sub_eq_add_neg_]
+      apply Fin.eq_of_val_eq
+      simp [Fin.sub_def, (Nat.add_sub_cancel' (Nat.le_of_lt a.isLt)), Nat.mod_self]
+  }
+
+instance : CommRing (Fin n) where
+  mul_comm := fun _ _ => by apply Fin.eq_of_val_eq; simp only [Fin.mul_def, Nat.mul_comm]
 
 end Fin

--- a/Mathlib/Data/Nat/Basic.lean
+++ b/Mathlib/Data/Nat/Basic.lean
@@ -17,6 +17,9 @@ protected lemma not_lt_of_le {n m : ℕ} (h₁ : m ≤ n) : ¬ n < m
 
 protected lemma not_le_of_lt {n m : ℕ} : m < n → ¬ n ≤ m  := Nat.not_le_of_gt
 
+protected lemma ne_of_lt {a b : Nat} : a < b -> a ≠ b :=
+  fun h_lt h_eq => (Nat.not_le_of_lt h_lt : ¬b <= a) (h_eq ▸ Nat.le_refl b : b <= a)
+
 protected lemma lt_of_not_le {a b : ℕ} : ¬ a ≤ b → b < a := (Nat.lt_or_ge b a).resolve_right
 
 protected lemma le_of_not_lt {a b : ℕ} : ¬ a < b → b ≤ a := (Nat.lt_or_ge a b).resolve_left

--- a/Mathlib/Data/UInt.lean
+++ b/Mathlib/Data/UInt.lean
@@ -1,9 +1,230 @@
+import Mathlib.Data.Nat.Basic
+import Mathlib.Data.Fin.Basic
+import Mathlib.Algebra.Group.Defs
+import Mathlib.Algebra.GroupWithZero.Defs
 
-theorem Fin.val_eq_of_lt : a < n.succ → (@Fin.ofNat n a).val = a := Nat.mod_eq_of_lt
+lemma UInt8.size_positive : 0 < UInt8.size := by decide
 
-theorem UInt32.val_eq_of_lt : a < UInt32.size → (UInt32.ofNat a).val = a := Fin.val_eq_of_lt
+lemma UInt16.size_positive : 0 < UInt16.size := by decide
+
+lemma UInt32.size_positive : 0 < UInt32.size := by decide
+
+lemma UInt64.size_positive : 0 < UInt64.size := by decide
+
+lemma USize.size_positive : 0 < USize.size := by
+  simp only [USize.size]
+  cases System.Platform.numBits_eq with
+  | inl eq32 => simp [eq32]
+  | inr eq64 => simp [eq64]
+
+set_option hygiene false
+macro "genIntDeclars" typeName:ident : command => do
+  `(
+    namespace $typeName
+      instance : Zero (Fin size) := (Nat.succ_pred_eq_of_pos size_positive) ▸ inferInstance
+
+      instance : One (Fin size) := (Nat.succ_pred_eq_of_pos size_positive) ▸ inferInstance
+
+      instance : Neg (Fin size) := (Nat.succ_pred_eq_of_pos size_positive) ▸ inferInstance
+
+      instance : AddSemigroup (Fin size) := (Nat.succ_pred_eq_of_pos size_positive) ▸ inferInstance
+
+      instance : AddMonoid (Fin size) := (Nat.succ_pred_eq_of_pos size_positive) ▸ inferInstance
+
+      instance : AddCommMonoid (Fin size) := (Nat.succ_pred_eq_of_pos size_positive) ▸ inferInstance
+
+      instance : SubNegMonoid (Fin size) := (Nat.succ_pred_eq_of_pos size_positive) ▸ inferInstance
+
+      instance : AddGroup (Fin size) := (Nat.succ_pred_eq_of_pos size_positive) ▸ inferInstance
+
+      instance : Monoid (Fin size) := (Nat.succ_pred_eq_of_pos size_positive) ▸ inferInstance
+
+      instance : CommMonoid (Fin size) := (Nat.succ_pred_eq_of_pos size_positive) ▸ inferInstance
+
+      instance : MonoidWithZero (Fin size) := (Nat.succ_pred_eq_of_pos size_positive) ▸ inferInstance
+
+      lemma val_eq_of_lt : a < size → (ofNat a).val = a := Fin.val_eq_of_lt
+
+      lemma sub_def (a b : $typeName) : a - b = ⟨a.val - b.val⟩ := rfl
+
+      lemma mul_def (a b : $typeName) : a * b = ⟨a.val * b.val⟩ := rfl
+
+      lemma mod_def (a b : $typeName) : a % b = ⟨a.val % b.val⟩ := rfl
+
+      lemma add_def (a b : $typeName) : a + b = ⟨a.val + b.val⟩ := rfl
+
+      lemma eq_of_val_eq : ∀ {a b : $typeName}, a.val = b.val -> a = b
+      | ⟨f1⟩, ⟨f2⟩, h => congrArg mk h
+
+      lemma val_eq_of_eq : ∀ {a b : $typeName}, a = b -> a.val = b.val
+      | ⟨f1⟩, ⟨f2⟩, h => congrArg val h
+
+      @[simp] lemma mk_val_eq (a : $typeName) : mk a.val = a := by
+        cases h:a with
+        | mk aFin =>
+          have _ : a.val = aFin := h ▸ rfl
+          simp only [‹a.val = aFin›]
+
+      lemma add_assoc (a b c : $typeName) : (a + b) + c = a + (b + c) :=
+        congrArg mk (Fin.add_assoc _ _ _)
+
+      lemma mul_comm (a b : $typeName) : a * b = b * a := congrArg mk (Fin.mul_comm _ _)
+
+      lemma add_comm (a b : $typeName) : a + b = b + a := congrArg mk (Fin.add_comm _ _)
+
+      @[simp] lemma add_zero (a : $typeName) : a + 0 = a := by
+        have h0 : a.val + (0 : $typeName).val = a.val := AddMonoid.add_zero a.val
+        simp only [add_def, h0, mk_val_eq]
+
+      @[simp] lemma zero_add (a : $typeName) : 0 + a = a :=
+        (add_comm _ _) ▸ add_zero _
+
+      @[simp] lemma zero_mul (a : $typeName) : 0 * a = 0 := by
+        have h0 : (0 : $typeName).val * a.val = (0 : Fin size) := MonoidWithZero.zero_mul a.val
+        simp only [mul_def, h0, mk_val_eq]
+
+      @[simp] lemma mul_zero (a : $typeName) : a * 0 = 0 :=
+        (mul_comm a _) ▸ zero_mul _
+
+      @[simp] lemma one_mul (a : $typeName) : 1 * a = a := by
+        have h0 : (1 : $typeName).val * a.val = a.val := Monoid.one_mul a.val
+        simp only [mul_def, h0, mk_val_eq]
+
+      @[simp] lemma mul_one (a : $typeName) : a * 1 = a := (mul_comm _ _) ▸ one_mul _
+
+      instance : Neg $typeName where
+        neg a := mk (-a.val)
+
+      lemma neg_def (a : $typeName) : -a = mk (-a.val) := rfl
+
+      lemma sub_eq_add_neg (a b : $typeName) : a - b = a + -b :=
+        congrArg mk (SubNegMonoid.sub_eq_add_neg _ _)
+
+      def nsmul (x : Nat) (a : $typeName) : $typeName := mk (AddMonoid.nsmul x a.val)
+
+      def gsmul (x : Int) (a : $typeName) : $typeName := mk (SubNegMonoid.gsmul x a.val)
+
+      @[simp] lemma gsmul_zero' (a : $typeName) : gsmul 0 a = (0 : $typeName) :=
+        congrArg mk (SubNegMonoid.gsmul_zero' a.val)
+
+      lemma gsmul_succ' (m : ℕ) (a : $typeName) : gsmul (Int.ofNat m.succ) a = a + gsmul (Int.ofNat m) a :=
+        congrArg mk (SubNegMonoid.gsmul_succ' m a.val)
+
+      lemma gsmul_neg' (m : ℕ) (a : $typeName) : gsmul (Int.negSucc m) a = -(gsmul m.succ a) :=
+        congrArg mk (SubNegMonoid.gsmul_neg' m a.val)
+
+      instance : AddSemigroup $typeName where
+        add_assoc := add_assoc
+
+      @[simp] lemma nsmul_zero' (x : $typeName) : nsmul 0 x = 0 :=
+        congrArg mk (AddMonoid.nsmul_zero' x.val)
+
+      lemma nsmul_succ' (n : ℕ) (x : $typeName) : nsmul n.succ x = x + nsmul n x :=
+        congrArg mk (AddMonoid.nsmul_succ' n x.val)
+
+      @[simp] lemma add_left_neg (a : $typeName) : -a + a = 0 :=
+        congrArg mk (AddGroup.add_left_neg a.val)
+
+      lemma mul_assoc (a b c : $typeName) : (a * b) * c = a * (b * c) :=
+        congrArg mk (Semigroup.mul_assoc _ _ _)
+
+      instance : AddMonoid $typeName where
+        add_zero := add_zero
+        zero_add := zero_add
+        nsmul := nsmul
+        nsmul_zero' := nsmul_zero'
+        nsmul_succ' := nsmul_succ'
+
+      instance : AddCommMonoid $typeName where
+        add_comm := add_comm
+
+      instance : SubNegMonoid $typeName where
+        sub_eq_add_neg := sub_eq_add_neg
+        gsmul := gsmul
+        gsmul_zero' := gsmul_zero'
+        gsmul_succ' := gsmul_succ'
+        gsmul_neg' := gsmul_neg'
+
+      instance : Monoid $typeName where
+        mul_one := mul_one
+        one_mul := one_mul
+        mul_assoc := mul_assoc
+        npow_zero' := fun _ => rfl
+        npow_succ' := fun _ _ => rfl
+
+      instance : CommMonoid $typeName where
+        mul_comm := mul_comm
+
+      instance : MonoidWithZero $typeName where
+        zero_mul := zero_mul
+        mul_zero := mul_zero
+
+      def addOverflows? (a b : $typeName) : Bool := size <= a.toNat + b.toNat
+
+      def mulOverflows? (a b : $typeName) : Bool := size <= a.toNat * b.toNat
+
+      def subUnderflows? (a b : $typeName) : Bool := a.toNat < b.toNat
+
+      def overflowingAdd (a b : $typeName) : (Bool × $typeName) := (size <= a.toNat + b.toNat, a + b)
+
+      def overflowingMul (a b : $typeName) : (Bool × $typeName) := (size <= a.toNat * b.toNat, a * b)
+
+      def underflowingSub (a b : $typeName) : (Bool × $typeName) := (a.toNat < b.toNat, a - b)
+
+      def checkedAdd (a b : $typeName) : Option $typeName :=
+        match a.overflowingAdd b with
+        | (true, _) => none
+        | (false, sum) => some (sum)
+
+      def checkedMul (a b : $typeName) : Option $typeName :=
+        match a.overflowingMul b with
+        | (true, _) => none
+        | (false, prod) => some (prod)
+
+      def checkedSub (a b : $typeName) : Option $typeName :=
+        match a.underflowingSub b with
+        | (true, _) => none
+        | (false, diff) => some (diff)
+
+      lemma checked_add_spec (a b : $typeName) : (a.checkedAdd b).isSome = true <-> a.toNat + b.toNat < size := by
+        by_cases size <= a.toNat + b.toNat <;>
+          simp_all [checkedAdd, Option.isSome, overflowingAdd, decide_eq_true, decide_eq_false]
+
+      lemma checked_mul_spec (a b : $typeName) : (a.checkedMul b).isSome = true <-> a.toNat * b.toNat < size := by
+        simp only [checkedMul, overflowingMul, Option.isSome]
+        refine Iff.intro ?mp ?mpr <;> intro h
+        case mp =>
+          by_cases hx : size <= a.toNat * b.toNat
+          case pos => simp only [(decide_eq_true_iff (size <= a.toNat * b.toNat)).mpr hx] at h
+          case neg => exact Nat.lt_of_not_le hx
+        case mpr => simp only [decide_eq_false (Nat.not_le_of_lt h : ¬size <= a.toNat * b.toNat)]
+
+      lemma checked_sub_spec (a b : $typeName) : (a.checkedSub b).isSome = true <-> b.toNat <= a.toNat := by
+        simp only [checkedSub, underflowingSub, Option.isSome]
+        refine Iff.intro ?mp ?mpr <;> intro h
+        case mp =>
+          by_cases hx : a.val < b.val
+          case pos => simp only [(decide_eq_true_iff (a.toNat < b.toNat)).mpr hx] at h
+          case neg => exact Nat.le_of_not_lt hx
+        case mpr => simp only [decide_eq_false (Nat.not_lt_of_le h : ¬a.toNat < b.toNat)]
+
+      lemma mod_lt (x : $typeName) {y : $typeName} : 0 < y -> x % y < y :=
+        fun y_pos => Fin.mod_lt x.val y_pos
+
+      lemma mod_eq_of_lt {a b : $typeName} : a < b -> a % b = a :=
+        fun a_lt_b => eq_of_val_eq (Fin.mod_eq_of_lt a_lt_b)
+
+    end $typeName
+  )
+
+genIntDeclars UInt8
+genIntDeclars UInt16
+genIntDeclars UInt32
+genIntDeclars UInt64
+--genIntDeclars USize
 
 namespace UInt8
+
 
 /-- Is this an uppercase ASCII letter? -/
 def isUpper (c : UInt8) : Bool :=

--- a/Mathlib/Init/Data/Nat/Lemmas.lean
+++ b/Mathlib/Init/Data/Nat/Lemmas.lean
@@ -527,6 +527,12 @@ end find
 
 /- mod -/
 
+lemma le_of_mod_lt {a b : Nat} (h : a % b < a) : b <= a :=
+  Decidable.byContradiction $ fun hf =>
+  have h0 : a % b = a := Nat.mod_eq_of_lt ((Nat.lt_or_ge a b).resolve_right hf)
+  have h1 : a % b ≠ a := ne_of_lt h
+  False.elim (h1 h0)
+
 @[simp] theorem add_mod_right (x z : ℕ) : (x + z) % z = x % z :=
 by rw [mod_eq_sub_mod (Nat.le_add_left _ _), Nat.add_sub_cancel]
 


### PR DESCRIPTION
Add new Fin instances, extend the UInt declarations to other UInt types using a macro. This incorporates @gebner's suggestions to add boolean methods for checking under/overflow, and adding separate instances of `Fin size`. I still can't figure out the elaboration issue mentioned [here on zulip](https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/simp.20type.20annotations/near/260877092), so I can't use the macro on USize yet.