### PR TITLE
add LAKE and LEAN variables to make commands configurable

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,13 +1,15 @@
 TESTS = $(wildcard test/*.lean)
+LAKE = lake
+LEAN = lean
 
 .PHONY: all build test
 
 all: build test
 
 build:
-	lake build
+	$(LAKE) build
 
 test: $(addsuffix .run, $(TESTS))
 
 test/%.run: build
-	env LEAN_PATH=build/lib lean test/$*
+	env LEAN_PATH=build/lib $(LEAN) test/$*


### PR DESCRIPTION
Just a small change making the `GNUmakefile` a bit more configurable

# Motivation
```bash
make LAKE=$(elan which lake)
```