### PR TITLE
[Merged by Bors] - fix(Tactic): assumption'

### DIFF
--- a/Mathlib/Mathport/Syntax.lean
+++ b/Mathlib/Mathport/Syntax.lean
@@ -156,7 +156,6 @@ syntax (name := fapply) "fapply " term : tactic
 syntax (name := eapply) "eapply " term : tactic
 syntax (name := applyWith) "apply " term " with " term : tactic
 syntax (name := mapply) "mapply " term : tactic
-macro "assumption'" : tactic => `(all_goals assumption)
 syntax (name := exacts) "exacts" " [" term,* "]" : tactic
 syntax (name := toExpr') "toExpr' " term : tactic
 syntax (name := rwa) "rwa " rwRuleSeq (ppSpace location)? : tactic

--- a/Mathlib/Tactic/Basic.lean
+++ b/Mathlib/Tactic/Basic.lean
@@ -73,7 +73,8 @@ where
       let (_, mvarId) ← Meta.intro1P mvarId
       pure [mvarId]
 
-macro "assumption'" : tactic => `(all_goals assumption)
+/-- Try calling `assumption` on all goals; succeeds if it closes at least one goal. -/
+macro "assumption'" : tactic => `(any_goals assumption)
 
 elab "exacts" "[" hs:term,* "]" : tactic => do
   for stx in hs.getElems do


### PR DESCRIPTION
`assumption'` was duplicated in `Mathport/Syntax.lean` and `Tactic/Basic.Lean`, and in both cases incorrectly used `all_goals` rather than `any_goals`.