### PR TITLE
[Merged by Bors] - chore(Tactic/Basic): cleanup and add doc-strings

### DIFF
--- a/Mathlib/Mathport/Syntax.lean
+++ b/Mathlib/Mathport/Syntax.lean
@@ -149,7 +149,8 @@ end Tactic
 namespace Tactic
 
 syntax (name := propagateTags) "propagateTags " tacticSeq : tactic
-syntax (name := introv) "introv" (ppSpace binderIdent)* : tactic
+-- Moved to Mathlib/Tactic/Basic.lean
+-- syntax (name := introv) "introv" (ppSpace binderIdent)* : tactic
 syntax renameArg := ident " => " ident
 syntax (name := rename') "rename'" (ppSpace renameArg),+ : tactic
 syntax (name := fapply) "fapply " term : tactic
@@ -157,9 +158,11 @@ syntax (name := eapply) "eapply " term : tactic
 syntax (name := applyWith) "apply " term " with " term : tactic
 syntax (name := mapply) "mapply " term : tactic
 macro "assumption'" : tactic => `(all_goals assumption)
-syntax (name := exacts) "exacts" " [" term,* "]" : tactic
+-- Moved to Mathlib/Tactic/Basic.lean
+-- syntax (name := exacts) "exacts" " [" term,* "]" : tactic
 syntax (name := toExpr') "toExpr' " term : tactic
-syntax (name := rwa) "rwa " rwRuleSeq (ppSpace location)? : tactic
+-- Moved to Mathlib/Tactic/Basic.lean
+-- syntax (name := rwa) "rwa " rwRuleSeq (ppSpace location)? : tactic
 syntax (name := withCases) "withCases " tacticSeq : tactic
 syntax (name := induction') "induction' " casesTarget,+ (" using " ident)?
   (" with " (colGt binderIdent)+)? (" generalizing " (colGt ident)+)? : tactic
@@ -171,9 +174,12 @@ syntax (name := cases') "cases' " casesTarget,+ (" using " ident)?
 syntax (name := casesM) "casesM" "*"? ppSpace term,* : tactic
 syntax (name := casesType) "casesType" "*"? ppSpace ident* : tactic
 syntax (name := casesType!) "casesType!" "*"? ppSpace ident* : tactic
-syntax (name := «sorry») "sorry" : tactic
+-- Moved to Mathlib/Tactic/Basic.lean
+-- syntax (name := «sorry») "sorry" : tactic
+-- Implemented in Mathlib/Tactic/Basic.lean but with different syntax
 syntax (name := iterate) "iterate" (num)? ppSpace tacticSeq : tactic
-syntax (name := repeat') "repeat' " tacticSeq : tactic
+-- Moved to Mathlib/Tactic/Basic.lean
+-- syntax (name := repeat') "repeat' " tacticSeq : tactic
 syntax (name := abstract) "abstract" (ppSpace ident)? ppSpace tacticSeq : tactic
 syntax (name := have'') "have " Term.haveIdLhs : tactic
 syntax (name := let'') "let " Term.haveIdLhs : tactic
@@ -184,7 +190,8 @@ syntax (name := eConstructor) "econstructor" : tactic
 syntax (name := left) "left" : tactic
 syntax (name := right) "right" : tactic
 syntax (name := constructorM) "constructorM" "*"? ppSpace term,* : tactic
-syntax (name := exFalso) "exFalso" : tactic
+-- Moved to Mathlib/Tactic/Basic.lean (although note casing as `exfalso` there)
+-- syntax (name := exFalso) "exFalso" : tactic
 syntax (name := injections') "injections" (" with " (colGt (ident <|> "_"))+)? : tactic
 syntax (name := simp') "simp'" "*"? (" (" &"config" " := " term ")")? (&" only")?
   (" [" simpArg,* "]")? (" with " (colGt ident)+)? (ppSpace location)? : tactic
@@ -220,7 +227,8 @@ syntax (name := guardTarget) "guardTarget" " =ₐ " term : tactic -- alpha equal
 -- so for now we add a primed version to support the optional identifier,
 -- and available `decidable` instances.
 syntax (name := byCases') "byCases' " atomic(ident " : ")? term : tactic
-syntax (name := byContra) "byContra " (colGt ident)? : tactic
+-- Moved to Mathlib.Tactic.Basic
+-- syntax (name := byContra) "byContra " (colGt ident)? : tactic
 syntax (name := typeCheck) "typeCheck " term : tactic
 syntax (name := rsimp) "rsimp" : tactic
 syntax (name := compVal) "compVal" : tactic

--- a/Mathlib/Tactic/Basic.lean
+++ b/Mathlib/Tactic/Basic.lean
@@ -25,11 +25,12 @@ macro "_" : tactic => `({})
 
 macro_rules | `(tactic| rfl) => `(tactic| exact Iff.rfl)
 
+/-- `change` is a synonym for `show`,
+and can be used to replace a goal with a definitionally equal one. -/
 macro_rules
   | `(tactic| change $e:term) => `(tactic| show $e)
 
-macro "sorry" : tactic => `(tactic| admit)
-
+/-- `rwa` calls `rw`, then closes any remaining goals using `assumption`. -/
 syntax "rwa " rwRuleSeq (location)? : tactic
 
 macro_rules
@@ -53,6 +54,38 @@ macro_rules
   | `(tactic| transitivity) => `(tactic| apply Nat.lt_trans)
   | `(tactic| transitivity $e) => `(tactic| apply Nat.lt_trans (m := $e))
 
+/--
+The tactic `introv` allows the user to automatically introduce the variables of a theorem and
+explicitly name the non-dependent hypotheses.
+Any dependent hypotheses are assigned their default names.
+
+Examples:
+```
+example : ∀ a b : Nat, a = b → b = a := by
+  introv h,
+  exact h.symm
+```
+The state after `introv h` is
+```
+a b : ℕ,
+h : a = b
+⊢ b = a
+```
+
+```
+example : ∀ a b : Nat, a = b → ∀ c, b = c → a = c := by
+  introv h₁ h₂,
+  exact h₁.trans h₂
+```
+The state after `introv h₁ h₂` is
+```
+a b : ℕ,
+h₁ : a = b,
+c : ℕ,
+h₂ : b = c
+⊢ a = c
+```
+-/
 syntax (name := introv) "introv " (colGt ident)* : tactic
 @[tactic introv] partial def evalIntrov : Tactic := fun stx => do
   match stx with
@@ -75,7 +108,10 @@ where
 
 macro "assumption'" : tactic => `(all_goals assumption)
 
-elab "exacts" "[" hs:term,* "]" : tactic => do
+/--
+Like `exact`, but takes a list of terms and checks that all goals are discharged after the tactic.
+-/
+elab (name := exacts) "exacts" "[" hs:term,* "]" : tactic => do
   for stx in hs.getElems do
     evalTactic (← `(tactic| exact $stx))
   evalTactic (← `(tactic| done))
@@ -149,8 +185,9 @@ macro_rules
   | `(tactic| byContra) => `(tactic| (apply Classical.byContradiction; intro))
   | `(tactic| byContra $e) => `(tactic| (apply Classical.byContradiction; intro $e))
 
-macro "sorry" : tactic => `(exact sorry)
+macro (name := «sorry») "sorry" : tactic => `(exact sorry)
 
+-- TODO `n:num` should be an optional argument; if missing, repeat until failure
 elab "iterate " n:num seq:tacticSeq : tactic => do
   for i in [:n.toNat] do
     evalTactic seq


### PR DESCRIPTION
This gets Tactic/Basic.lean and Mathport/Syntax.lean closer to being in sync, and also copies across some tactic doc-strings from mathlib3.

Not perfect yet, but hopefully all changes are improvements...