### PR TITLE
[Merged by Bors] - feat: add simp linter

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,5 +33,8 @@ jobs:
       - name: test mathlib
         run: make test
 
+      - name: lint mathlib
+        run: env LEAN_PATH=build/lib lean scripts/runLinter.lean || true
+
       - name: check that all files are imported
         run: git diff --exit-code

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
         run: make test
 
       - name: lint mathlib
-        run: env LEAN_PATH=build/lib lean scripts/runLinter.lean || true
+        run: env LEAN_PATH=build/lib lean scripts/runLinter.lean
 
       - name: check that all files are imported
         run: git diff --exit-code

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -42,6 +42,10 @@ import Mathlib.Tactic.Core
 import Mathlib.Tactic.Ext
 import Mathlib.Tactic.Find
 import Mathlib.Tactic.LibrarySearch
+import Mathlib.Tactic.Lint
+import Mathlib.Tactic.Lint.Basic
+import Mathlib.Tactic.Lint.Frontend
+import Mathlib.Tactic.Lint.Simp
 import Mathlib.Tactic.NoMatch
 import Mathlib.Tactic.NormNum
 import Mathlib.Tactic.OpenPrivate

--- a/Mathlib/Algebra/Group/Defs.lean
+++ b/Mathlib/Algebra/Group/Defs.lean
@@ -222,7 +222,7 @@ theorem neg_add_self (a : A) : -a + a = 0 := add_left_neg a
 @[simp] theorem neg_add_cancel_left (a b : A) : -a + (a + b) = b :=
 by rw [← add_assoc, add_left_neg, zero_add]
 
-@[simp] theorem neg_eq_of_add_eq_zero (h : a + b = 0) : -a = b :=
+theorem neg_eq_of_add_eq_zero (h : a + b = 0) : -a = b :=
 left_neg_eq_right_neg (neg_add_self a) h
 
 @[simp] theorem neg_neg (a : A) : -(-a) = a :=

--- a/Mathlib/Data/Equiv/Basic.lean
+++ b/Mathlib/Data/Equiv/Basic.lean
@@ -36,7 +36,9 @@ namespace equiv
 instance : CoeFun (α ≃ β) (λ _ => α → β):=
 ⟨to_fun⟩
 
-@[simp] theorem coe_fn_mk (f : α → β) (g l r) : (equiv.mk f g l r : α → β) = f :=
+-- Does not need to be simp, since the coercion is the projection,
+-- which simp has built-in support for.
+theorem coe_fn_mk (f : α → β) (g l r) : (equiv.mk f g l r : α → β) = f :=
 rfl
 
 def refl (α) : α ≃ α := ⟨id, id, λ _ => rfl, λ _ => rfl⟩

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -139,15 +139,15 @@ def mem (a : α) : List α → Prop
 
 instance : Mem α (List α) := ⟨mem⟩
 
-@[simp] lemma mem_nil (a : α) : a ∈ [] ↔ False := Iff.rfl
+lemma mem_nil (a : α) : a ∈ [] ↔ False := Iff.rfl
 
-@[simp] lemma mem_cons {a b : α} {l : List α} :
+lemma mem_cons {a b : α} {l : List α} :
   a ∈ (b :: l) ↔ a = b ∨ a ∈ l := Iff.rfl
 
-lemma mem_nil_iff (a : α) : a ∈ ([] : List α) ↔ False :=
+@[simp] lemma mem_nil_iff (a : α) : a ∈ ([] : List α) ↔ False :=
 Iff.rfl
 
-@[simp] lemma not_mem_nil (a : α) : a ∉ ([] : List α) :=
+lemma not_mem_nil (a : α) : a ∉ ([] : List α) :=
 not_false
 
 lemma mem_cons_self (a : α) (l : List α) : a ∈ a :: l :=
@@ -220,7 +220,7 @@ fun this : a ∈ [b] => Or.elim
   (fun this : a = b => this)
   (fun this : a ∈ [] => absurd this (not_mem_nil a))
 
-@[simp] theorem mem_singleton {a b : α} : a ∈ [b] ↔ a = b :=
+@[simp 1100] theorem mem_singleton {a b : α} : a ∈ [b] ↔ a = b :=
 ⟨eq_of_mem_singleton, Or.inl⟩
 
 theorem mem_of_mem_cons_of_mem {a b : α} {l : List α} : a ∈ b::l → b ∈ l → a ∈ l :=
@@ -400,7 +400,7 @@ theorem ne_nil_of_length_eq_succ {l : List α} : ∀ {n : Nat}, length l = Nat.s
 theorem length_eq_zero {l : List α} : length l = 0 ↔ l = [] :=
 ⟨eq_nil_of_length_eq_zero, fun h => by rw [h]; rfl⟩
 
-@[simp] lemma length_singleton (a : α) : length [a] = 1 := rfl
+@[simp 1100] lemma length_singleton (a : α) : length [a] = 1 := rfl
 
 theorem length_pos_of_mem {a : α} : ∀ {l : List α}, a ∈ l → 0 < length l
 | nil,  h => by cases h
@@ -644,7 +644,7 @@ theorem mem_filter (as : List α) (p : α → Bool) (x : α) :
 
 lemma append_eq_has_append {L₁ L₂ : List α} : List.append L₁ L₂ = L₁ ++ L₂ := rfl
 
-@[simp] lemma singleton_append {x : α} {l : List α} : [x] ++ l = x :: l := rfl
+@[simp 1100] lemma singleton_append {x : α} {l : List α} : [x] ++ l = x :: l := rfl
 
 theorem append_ne_nil_of_ne_nil_left (s t : List α) : s ≠ [] → s ++ t ≠ [] := by
   induction s with
@@ -779,7 +779,7 @@ cases a with
 | 0 => []
 | Nat.succ n => a :: repeat a n
 
-@[simp] def repeatSucc (a: α) (n: ℕ): repeat a (n + 1) = a :: repeat a n := rfl
+theorem repeatSucc (a: α) (n: ℕ) : repeat a (n + 1) = a :: repeat a n := rfl
 theorem exists_of_mem_bind {b : β} {l : List α} {f : α → List β} :
   b ∈ List.bind l f → ∃ a, a ∈ l ∧ b ∈ f a :=
 mem_bind.1
@@ -999,7 +999,6 @@ theorem erase_eq_erasep (a : α) (l : List α) : l.erase a = l.erasep (Eq a) := 
         simp [h]
       simp [h, Ne.symm h, ih]
 
-@[simp]
 theorem erase_of_not_mem {a : α} {l : List α} (h : a ∉ l) : l.erase a = l := by
   induction l with
     | nil => rfl

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -665,10 +665,7 @@ theorem append_ne_nil_of_ne_nil_right (s t : List α) : t ≠ [] → s ++ t ≠ 
 by rw [eq_comm, append_eq_nil]
 
 
-@[simp] lemma append_ne_nil_of_left_ne_nil {A : Type u} (a b : List A) (h0 : a ≠ []) : a ++ b ≠ [] := by
-cases a with
-| nil => exact absurd rfl h0
-| cons h t => simp
+lemma append_ne_nil_of_left_ne_nil (a b : List α) (h0 : a ≠ []) : a ++ b ≠ [] := by simp [*]
 
 -- lemma append_eq_cons_iff {a b c : List α} {x : α} :
 --   a ++ b = x :: c ↔ (a = [] ∧ b = x :: c) ∨ (∃a', a = x :: a' ∧ c = a' ++ b) := by

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -813,7 +813,7 @@ def insert (a : α) (l : List α) := if a ∈ l then l else a :: l
   focus
     rw [insert_of_not_mem h]; rfl
 
-@[simp] theorem mem_insert_self (a : α) (l : List α) : a ∈ insert a l :=
+@[simp 900] theorem mem_insert_self (a : α) (l : List α) : a ∈ insert a l :=
 mem_insert_iff.2 (Or.inl rfl)
 
 theorem mem_insert_of_mem {a b : α} {l : List α} (h : a ∈ l) : a ∈ insert b l :=

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -220,7 +220,7 @@ fun this : a ∈ [b] => Or.elim
   (fun this : a = b => this)
   (fun this : a ∈ [] => absurd this (not_mem_nil a))
 
-@[simp 1100] theorem mem_singleton {a b : α} : a ∈ [b] ↔ a = b :=
+@[simp 900] theorem mem_singleton {a b : α} : a ∈ [b] ↔ a = b :=
 ⟨eq_of_mem_singleton, Or.inl⟩
 
 theorem mem_of_mem_cons_of_mem {a b : α} {l : List α} : a ∈ b::l → b ∈ l → a ∈ l :=
@@ -400,7 +400,7 @@ theorem ne_nil_of_length_eq_succ {l : List α} : ∀ {n : Nat}, length l = Nat.s
 theorem length_eq_zero {l : List α} : length l = 0 ↔ l = [] :=
 ⟨eq_nil_of_length_eq_zero, fun h => by rw [h]; rfl⟩
 
-@[simp 1100] lemma length_singleton (a : α) : length [a] = 1 := rfl
+@[simp 900] lemma length_singleton (a : α) : length [a] = 1 := rfl
 
 theorem length_pos_of_mem {a : α} : ∀ {l : List α}, a ∈ l → 0 < length l
 | nil,  h => by cases h
@@ -644,7 +644,7 @@ theorem mem_filter (as : List α) (p : α → Bool) (x : α) :
 
 lemma append_eq_has_append {L₁ L₂ : List α} : List.append L₁ L₂ = L₁ ++ L₂ := rfl
 
-@[simp 1100] lemma singleton_append {x : α} {l : List α} : [x] ++ l = x :: l := rfl
+@[simp 900] lemma singleton_append {x : α} {l : List α} : [x] ++ l = x :: l := rfl
 
 theorem append_ne_nil_of_ne_nil_left (s t : List α) : s ≠ [] → s ++ t ≠ [] := by
   induction s with

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -646,20 +646,12 @@ lemma append_eq_has_append {L₁ L₂ : List α} : List.append L₁ L₂ = L₁ 
 
 @[simp 900] lemma singleton_append {x : α} {l : List α} : [x] ++ l = x :: l := rfl
 
-theorem append_ne_nil_of_ne_nil_left (s t : List α) : s ≠ [] → s ++ t ≠ [] := by
-  induction s with
-  | nil => intros; contradiction
-  | cons a s ih => rw [cons_append]; intros _ h; contradiction
-
-theorem append_ne_nil_of_ne_nil_right (s t : List α) : t ≠ [] → s ++ t ≠ [] := by
-  induction s with
-  | nil => intros; rw [nil_append]; assumption
-  | cons a s ih => rw [cons_append]; intros _ h; contradiction
-
 @[simp] lemma append_eq_nil {p q : List α} : (p ++ q) = [] ↔ p = [] ∧ q = [] := by
-  cases p with
-  | nil => simp
-  | cons a p => simp
+  cases p <;> simp
+
+theorem append_ne_nil_of_ne_nil_left (s t : List α) : s ≠ [] → s ++ t ≠ [] := by simp_all
+
+theorem append_ne_nil_of_ne_nil_right (s t : List α) : t ≠ [] → s ++ t ≠ [] := by simp_all
 
 @[simp] lemma nil_eq_append_iff {a b : List α} : [] = a ++ b ↔ a = [] ∧ b = [] :=
 by rw [eq_comm, append_eq_nil]

--- a/Mathlib/Data/Nat/Basic.lean
+++ b/Mathlib/Data/Nat/Basic.lean
@@ -28,10 +28,10 @@ protected lemma le_or_le (a b : ℕ) : a ≤ b ∨ b ≤ a := (Nat.lt_or_ge _ _)
 
 protected lemma le_of_not_le {a b : ℕ} : ¬ a ≤ b → b ≤ a := (Nat.le_or_le _ _).resolve_left
 
-@[simp] protected lemma not_lt {n m : ℕ} : ¬ n < m ↔ m ≤ n :=
+protected lemma not_lt {n m : ℕ} : ¬ n < m ↔ m ≤ n :=
 ⟨Nat.le_of_not_lt, Nat.not_lt_of_le⟩
 
-@[simp] protected lemma not_le {n m : ℕ} : ¬ n ≤ m ↔ m < n :=
+protected lemma not_le {n m : ℕ} : ¬ n ≤ m ↔ m < n :=
 ⟨Nat.lt_of_not_le, Nat.not_le_of_lt⟩
 
 protected lemma lt_or_eq_of_le {n m : ℕ} (h : n ≤ m) : n < m ∨ n = m :=

--- a/Mathlib/Data/Prod.lean
+++ b/Mathlib/Data/Prod.lean
@@ -17,10 +17,8 @@ This file defines `Prod.swap : α × β → β × α` and proves various simple 
 
 variable {α : Type _} {β : Type _} {γ : Type _} {δ : Type _}
 
-@[simp] lemma prod_map (f : α → γ) (g : β → δ) (p : α × β) : Prod.map f g p = (f p.1, g p.2) :=
-by have : p = ⟨p.1, p.2⟩ := (Prod.ext _).symm
-   rw [this]
-   exact rfl
+@[simp] lemma prod_map (f : α → γ) (g : β → δ) (p : α × β) : Prod.map f g p = (f p.1, g p.2) := by
+  cases p; rfl
 
 namespace Prod
 
@@ -36,12 +34,10 @@ Prod.forall
 theorem exists' {p : α → β → Prop} : (∃ x : α × β, p x.1 x.2) ↔ ∃ a b, p a b :=
 Prod.exists
 
-@[simp] lemma map_mk (f : α → γ) (g : β → δ) (a : α) (b : β) : map f g (a, b) = (f a, g b) := rfl
+lemma map_mk (f : α → γ) (g : β → δ) (a : α) (b : β) : map f g (a, b) = (f a, g b) := rfl
 
-@[simp]
 lemma map_fst (f : α → γ) (g : β → δ) (p : α × β) : (map f g p).1 = f (p.1) := by simp
 
-@[simp]
 lemma map_snd (f : α → γ) (g : β → δ) (p : α × β) : (map f g p).2 = g (p.2) := by simp
 
 lemma map_fst' (f : α → γ) (g : β → δ) : (Prod.fst ∘ map f g) = f ∘ Prod.fst :=
@@ -67,7 +63,7 @@ lemma map_map {ε ζ : Type _}
   (f : α → β) (f' : γ → δ) (g : β → ε) (g' : δ → ζ) (x : α × γ) :
   Prod.map g g' (Prod.map f f' x) = Prod.map (g ∘ f) (g' ∘ f') x := by simp
 
-@[simp] theorem mk.inj_iff {a₁ a₂ : α} {b₁ b₂ : β} : (a₁, b₁) = (a₂, b₂) ↔ (a₁ = a₂ ∧ b₁ = b₂) :=
+theorem mk.inj_iff {a₁ a₂ : α} {b₁ b₂ : β} : (a₁, b₁) = (a₂, b₂) ↔ (a₁ = a₂ ∧ b₁ = b₂) :=
 ⟨Prod.mk.inj,
  by intro hab; rw [hab.left, hab.right]⟩
 
@@ -125,10 +121,10 @@ def swap : α × β → β × α := λp => (p.2, p.1)
 @[simp] lemma swap_swap_eq : swap ∘ swap = @id (α × β) :=
 funext swap_swap
 
-@[simp] lemma swap_left_inverse : Function.left_inverse (@swap α β) swap :=
+lemma swap_left_inverse : Function.left_inverse (@swap α β) swap :=
 swap_swap
 
-@[simp] lemma swap_right_inverse : Function.right_inverse (@swap α β) swap :=
+lemma swap_right_inverse : Function.right_inverse (@swap α β) swap :=
 swap_swap
 
 lemma swap_injective : Function.injective (@swap α β) :=

--- a/Mathlib/Data/String/Lemmas.lean
+++ b/Mathlib/Data/String/Lemmas.lean
@@ -3,8 +3,8 @@ import Mathlib.Data.String.Defs
 
 namespace String
 
-@[simp] lemma congr_append : ∀ (a b : String), a ++ b = String.mk (a.data ++ b.data)
-| ⟨a⟩, ⟨b⟩ => by simp only [HAppend.hAppend, Append.append, String.append]
+lemma congr_append : ∀ (a b : String), a ++ b = String.mk (a.data ++ b.data)
+| ⟨a⟩, ⟨b⟩ => rfl
 
 @[simp] lemma length_append : ∀ (as bs : String), (as ++ bs).length = as.length + bs.length
 | ⟨as⟩, ⟨bs⟩ => by

--- a/Mathlib/Data/Subtype.lean
+++ b/Mathlib/Data/Subtype.lean
@@ -170,6 +170,7 @@ namespace Subtype
 /-! Some facts about sets, which require that `α` is a type. -/
 variable {α : Type _} {β : Type _} {γ : Type _} {p : α → Prop}
 
-@[simp] lemma val_prop {S : Set α} (a : {a // a ∈ S}) : a.val ∈ S := a.property
+-- ∈-notation is reducible in Lean 4, so this won't trigger as a simp-lemma
+lemma val_prop {S : Set α} (a : {a // a ∈ S}) : a.val ∈ S := a.property
 
 end Subtype

--- a/Mathlib/Data/Subtype.lean
+++ b/Mathlib/Data/Subtype.lean
@@ -62,9 +62,8 @@ ext_iff
 
 @[simp] theorem coe_eta (a : {a // p a}) (h : p (a : α)) : mk (a : α) h = a := Subtype.ext rfl
 
-@[simp] theorem coe_mk (a h) : (@mk α p a h : α) = a := rfl
+theorem coe_mk (a h) : (@mk α p a h : α) = a := rfl
 
-@[simp]
 theorem mk_eq_mk {a h a' h'} : @mk α p a h = @mk α p a' h' ↔ a = a' :=
 ext_iff
 

--- a/Mathlib/Init/Data/Nat/Basic.lean
+++ b/Mathlib/Init/Data/Nat/Basic.lean
@@ -14,7 +14,4 @@ namespace Nat
 instance : Dvd ℕ where
   dvd a b := ∃ c, b = a * c
 
-@[simp] lemma nat_zero_eq_zero : Nat.zero = 0 :=
-rfl
-
 end Nat

--- a/Mathlib/Init/Logic.lean
+++ b/Mathlib/Init/Logic.lean
@@ -45,7 +45,7 @@ lemma cast_proof_irrel (h₁ h₂ : α = β) (a : α) : cast h₁ a = cast h₂ 
 
 /- ne -/
 
-@[simp] lemma Ne.def {α : Sort u} (a b : α) : (a ≠ b) = ¬ (a = b) := rfl
+lemma Ne.def {α : Sort u} (a b : α) : (a ≠ b) = ¬ (a = b) := rfl
 
 def eq_rec_heq := @eqRec_heq
 
@@ -142,7 +142,7 @@ lemma not_congr (h : a ↔ b) : ¬a ↔ ¬b := ⟨mt h.2, mt h.1⟩
 
 lemma ne_self_iff_false (a : α) : a ≠ a ↔ False := not_iff_false_intro rfl
 
-@[simp] lemma eq_self_iff_true (a : α) : a = a ↔ True := iff_true_intro rfl
+lemma eq_self_iff_true (a : α) : a = a ↔ True := iff_true_intro rfl
 
 lemma heq_self_iff_true (a : α) : HEq a a ↔ True := iff_true_intro HEq.rfl
 

--- a/Mathlib/Init/Logic.lean
+++ b/Mathlib/Init/Logic.lean
@@ -14,7 +14,7 @@ import Mathlib.Tactic.Ext
 @[ext] protected lemma Unit.ext (x y : Unit) : x = y := Subsingleton.allEq _ _
 @[ext] protected lemma PUnit.ext (x y : Unit) : x = y := Subsingleton.allEq _ _
 
-@[simp] theorem opt_param_eq (α : Sort u) (default : α) : optParam α default = α := optParam_eq α default
+theorem opt_param_eq (α : Sort u) (default : α) : optParam α default = α := optParam_eq α default
 
 theorem Not.intro {a : Prop} (h : a → False) : ¬ a := h
 
@@ -132,10 +132,12 @@ lemma imp_congr (h₁ : a ↔ c) (h₂ : b ↔ d) : (a → b) ↔ (c → d) := i
 lemma not_of_not_not_not (h : ¬¬¬a) : ¬a :=
 λ ha => absurd (not_not_intro ha) h
 
-@[simp] lemma not_true : (¬ True) ↔ False :=
+-- @[simp] -- Lean 4 has this built-in because it simplifies using decidable instances
+lemma not_true : (¬ True) ↔ False :=
 iff_false_intro (not_not_intro trivial)
 
-@[simp] lemma not_false_iff : (¬ False) ↔ True :=
+-- @[simp] -- Lean 4 has this built-in because it simplifies using decidable instances
+lemma not_false_iff : (¬ False) ↔ True :=
 iff_true_intro not_false
 
 lemma not_congr (h : a ↔ b) : ¬a ↔ ¬b := ⟨mt h.2, mt h.1⟩

--- a/Mathlib/Logic/Basic.lean
+++ b/Mathlib/Logic/Basic.lean
@@ -400,7 +400,6 @@ theorem iff_false_left (ha : ¬a) : (a ↔ b) ↔ ¬b :=
 theorem iff_false_right (ha : ¬a) : (b ↔ a) ↔ ¬b :=
 Iff.comm.trans (iff_false_left ha)
 
-@[simp]
 lemma iff_mpr_iff_true_intro {P : Prop} (h : P) : Iff.mpr (iff_true_intro h) True.intro = h := rfl
 
 -- See Note [decidable namespace]

--- a/Mathlib/Logic/Function/Basic.lean
+++ b/Mathlib/Logic/Function/Basic.lean
@@ -7,6 +7,7 @@ import Mathlib.Logic.Basic
 import Mathlib.Init.Function
 import Mathlib.Init.Set
 import Mathlib.Init.SetNotation
+import Mathlib.Tactic.Lint.Basic
 
 universe u v w
 
@@ -26,7 +27,7 @@ lemma comp_apply {α : Sort u} {β : Sort v} {φ : Sort w} (f : β → φ) (g : 
 
 lemma const_def {y : β} : (λ x : α => y) = const α y := rfl
 
-@[simp] lemma const_apply {y : β} {x : α} : const α y x = y := rfl
+@[simp, nolint simpNF] lemma const_apply {y : β} {x : α} : const α y x = y := rfl
 
 @[simp] lemma const_comp {f : α → β} {c : γ} : const β c ∘ f = const α c := rfl
 

--- a/Mathlib/Mathport/Attributes.lean
+++ b/Mathlib/Mathport/Attributes.lean
@@ -12,8 +12,5 @@ initialize symmAttr : TagAttribute ← registerTagAttribute `symm "symmetric rel
 initialize transAttr : TagAttribute ← registerTagAttribute `trans "transitive relation"
 initialize substAttr : TagAttribute ← registerTagAttribute `subst "substitution"
 
-initialize linterAttr : TagAttribute ←
-  registerTagAttribute `linter "Use this declaration as a linting test in #lint"
-
 initialize hintTacticAttr : TagAttribute ←
   registerTagAttribute `hintTactic "A tactic that should be tried by `hint`."

--- a/Mathlib/Mathport/Syntax.lean
+++ b/Mathlib/Mathport/Syntax.lean
@@ -641,8 +641,6 @@ namespace Attr
 syntax (name := intro) "intro" : attr
 syntax (name := intro!) "intro!" : attr
 
-syntax (name := nolint) "nolint" (ppSpace ident)* : attr
-
 syntax (name := ext) "ext" (ppSpace ident)? : attr
 
 syntax (name := higherOrder) "higherOrder" (ppSpace ident)? : attr
@@ -685,11 +683,6 @@ syntax opts := (verbosity "*"?) <|> ("*"? (verbosity)?)
 syntax args := opts " only"? ident*
 
 end Lint
-
-syntax (name := lint) "#lint" Lint.args : command
-syntax (name := lintMathlib) "#lint_mathlib" Lint.args : command
-syntax (name := lintAll) "#lint_all" Lint.args : command
-syntax (name := listLinters) "#list_linters" : command
 
 syntax (name := copyDocString) "copy_doc_string " ident " → " ident* : command
 syntax (name := libraryNote) docComment "library_note " str : command

--- a/Mathlib/Tactic/Lint.lean
+++ b/Mathlib/Tactic/Lint.lean
@@ -1,0 +1,2 @@
+import Mathlib.Tactic.Lint.Simp
+import Mathlib.Tactic.Lint.Frontend

--- a/Mathlib/Tactic/Lint/Basic.lean
+++ b/Mathlib/Tactic/Lint/Basic.lean
@@ -14,13 +14,13 @@ namespace Mathlib.Tactic.Lint
 
 This file defines the basic types and attributes used by the linting
 framework.  A linter essentially consists of a function
-`declaration → tactic (option string)`, this function together with some
-metadata is stored in the `linter` structure. We define two attributes:
+`(declaration : Name) → MetaM (Option MessageData)`, this function together with some
+metadata is stored in the `Linter` structure. We define two attributes:
 
- * `@[linter]` applies to a declaration of type `linter` and adds it to the default linter set.
+ * `@[mathlibLinter]` applies to a declaration of type `Linter` and adds it to the default linter set.
 
- * `@[nolint linter_name]` omits the tagged declaration from being checked by
-   the linter with name `linter_name`.
+ * `@[nolint linterName]` omits the tagged declaration from being checked by
+   the linter with name `linterName`.
 -/
 
 syntax (name := nolint) "nolint" (ppSpace ident)+ : attr

--- a/Mathlib/Tactic/Lint/Basic.lean
+++ b/Mathlib/Tactic/Lint/Basic.lean
@@ -1,0 +1,89 @@
+/-
+Copyright (c) 2020 Floris van Doorn. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Floris van Doorn, Robert Y. Lewis, Gabriel Ebner
+-/
+
+import Lean
+open Lean Meta
+
+namespace Mathlib.Tactic.Lint
+
+/-!
+# Basic linter types and attributes
+
+This file defines the basic types and attributes used by the linting
+framework.  A linter essentially consists of a function
+`declaration → tactic (option string)`, this function together with some
+metadata is stored in the `linter` structure. We define two attributes:
+
+ * `@[linter]` applies to a declaration of type `linter` and adds it to the default linter set.
+
+ * `@[nolint linter_name]` omits the tagged declaration from being checked by
+   the linter with name `linter_name`.
+-/
+
+syntax (name := nolint) "nolint" (ppSpace ident)+ : attr
+
+-- Defines the user attribute `nolint` for skipping `#lint`
+initialize nolintAttr : ParametricAttribute (Array Name) ←
+  registerParametricAttribute {
+    name := `nolint
+    descr := "Do not report this declaration in any of the tests of `#lint`"
+    getParam := fun decl stx =>
+      match stx with
+        -- TODO: validate linter names
+        | `(attr|nolint $[$ids]*) => ids.mapM (·.getId.eraseMacroScopes)
+        | _ => throwError "unexpected nolint syntax {stx}"
+  }
+
+/-- Returns true if `decl` should be checked
+using `linter`, i.e., if there is no `nolint` attribute. -/
+def shouldBeLinted [Monad m] [MonadEnv m] (linter : Name) (decl : Name) : m Bool := do
+  !((← nolintAttr.getParam (← getEnv) decl).getD {}).contains linter
+
+def isAutoDecl (decl : Name) : CoreM Bool :=
+  false -- TODO
+
+/--
+A linting test for the `#lint` command.
+
+`test` defines a test to perform on every declaration. It should never fail. Returning `none`
+signifies a passing test. Returning `some msg` reports a failing test with error `msg`.
+
+`noErrorsFound` is the message printed when all tests are negative, and `errorsFound` is printed
+when at least one test is positive.
+
+If `isFast` is false, this test will be omitted from `#lint-`.
+-/
+structure Linter where
+  test : Name → MetaM (Option MessageData)
+  noErrorsFound : MessageData
+  errorsFound : MessageData
+  isFast := true
+
+structure NamedLinter extends Linter where
+  declName : Name
+
+def NamedLinter.name (l : NamedLinter) : Name := l.declName.updatePrefix Name.anonymous
+
+private unsafe def getLinterImpl (declName : Name) : CoreM NamedLinter :=
+  return { ← evalConstCheck Linter ``Linter declName with declName }
+
+@[implementedBy getLinterImpl]
+constant getLinter (declName : Name) : CoreM NamedLinter
+
+/-- Takes a list of names that resolve to declarations of type `linter`,
+and produces a list of linters. -/
+def getLinters (l : List Name) : CoreM (List NamedLinter) :=
+  l.mapM getLinter
+
+-- Defines the user attribute `linter` for adding a linter to the default set.
+initialize mathlibLinterAttr : TagAttribute ←
+  registerTagAttribute
+    (name := `mathlibLinter)
+    (descr := "Use this declaration as a linting test in #lint")
+    (validate := fun name => do
+      let constInfo ← getConstInfo name
+      unless ← (isDefEq constInfo.type (mkConst ``Linter)).run' do
+        throwError "must have type Linter, got {constInfo.type}")

--- a/Mathlib/Tactic/Lint/Frontend.lean
+++ b/Mathlib/Tactic/Lint/Frontend.lean
@@ -1,0 +1,228 @@
+/-
+Copyright (c) 2020 Floris van Doorn. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Floris van Doorn, Robert Y. Lewis, Gabriel Ebner
+-/
+import Mathlib.Tactic.Lint.Basic
+import Mathlib.Tactic.Lint.Simp
+
+/-!
+# Linter frontend and commands
+
+This file defines the linter commands which spot common mistakes in the code.
+* `#lint`: check all declarations in the current file
+* `#lint mathlib`: check all declarations in mathlib (so excluding core or other projects,
+  and also excluding the current file)
+* `#lint all`: check all declarations in the environment (the current file and all
+  imported files)
+
+For a list of default / non-default linters, see the "Linting Commands" user command doc entry.
+
+The command `#list_linters` prints a list of the names of all available linters.
+
+You can append a `*` to any command (e.g. `#lint mathlib*`) to omit the slow tests (4).
+
+You can append a `-` to any command (e.g. `#lint mathlib-`) to run a silent lint
+that suppresses the output if all checks pass.
+A silent lint will fail if any test fails.
+
+You can append a `+` to any command (e.g. `#lint mathlib+`) to run a verbose lint
+that reports the result of each linter, including  the successes.
+
+You can append a sequence of linter names to any command to run extra tests, in addition to the
+default ones. e.g. `#lint doc_blame_thm` will run all default tests and `doc_blame_thm`.
+
+You can append `only name1 name2 ...` to any command to run a subset of linters, e.g.
+`#lint only unused_arguments`
+
+You can add custom linters by defining a term of type `Linter` in the `Mathlib.Tactic.Lint` namespace.
+A linter defined with the name `Mathlib.Tactic.Lint.myNewCheck` can be run with `#lint myNewCheck`
+or `lint only myNewCheck`.
+If you add the attribute `@[mathlibLinter]` to `linter.myNewCheck` it will run by default.
+
+Adding the attribute `@[nolint doc_blame unused_arguments]` to a declaration
+omits it from only the specified linter checks.
+
+## Tags
+
+sanity check, lint, cleanup, command, tactic
+-/
+
+def Lean.TagAttribute.getDecls (attr : TagAttribute) (env : Environment) : Array Name := do
+  let st := attr.ext.toEnvExtension.getState env
+  let mut decls := st.state.toArray
+  for ds in st.importedEntries do
+    decls := decls ++ ds
+  decls
+
+namespace Mathlib.Tactic.Lint
+open Lean Std
+
+/--
+Verbosity for the linter output.
+* `low`: only print failing checks, print nothing on success.
+* `medium`: only print failing checks, print confirmation on success.
+* `high`: print output of every check.
+-/
+inductive LintVerbosity | low | medium | high
+  deriving Inhabited, DecidableEq, Repr
+
+/-- `getChecks slow extra use_only` produces a list of linters.
+`extras` is a list of names that should resolve to declarations with type `linter`.
+If `useOnly` is true, it only uses the linters in `extra`.
+Otherwise, it uses all linters in the environment tagged with `@[linter]`.
+If `slow` is false, it only uses the fast default tests. -/
+def getChecks (slow : Bool) (extra : List Name) (useOnly : Bool) : CoreM (List NamedLinter) := do
+  let default ← if useOnly then [] else
+    getLinters (← mathlibLinterAttr.getDecls (← getEnv)).toList
+  let default := if slow then default else default.filter (·.isFast)
+  default ++ (← getLinters extra)
+
+def lintCore (decls : Array Name) (linters : Array NamedLinter) :
+    CoreM (Array (NamedLinter × HashMap Name MessageData)) := do
+  let env ← getEnv
+  let options ← getOptions -- TODO: sanitize options?
+
+  let tasks : Array (NamedLinter × Array (Name × Task (Option MessageData))) ←
+    linters.mapM fun linter => do
+      let decls ← decls.filterM (shouldBeLinted linter.name)
+      (linter, ·) <|<- decls.mapM fun decl => do (decl, ·) <|<- do
+        BaseIO.asTask do
+          match ← (linter.test decl).run'.run' {options} {env} |>.toBaseIO with
+          | Except.ok msg? => msg?
+          | Except.error err => m!"LINTER FAILED:\n{err.toMessageData}"
+
+  tasks.mapM fun (linter, decls) => do
+    let mut msgs : HashMap Name MessageData := {}
+    for (declName, msg?) in decls do
+      if let some msg := msg?.get then
+        msgs := msgs.insert declName msg
+    (linter, msgs)
+
+def findDeclarationRanges? (e : Environment) (n : Name) : Option DeclarationRanges :=
+  have : MonadEnv Id := { getEnv := e, modifyEnv := fun _ => () }
+  Id.run do Lean.findDeclarationRanges? n
+
+/-- Sorts a map with declaration keys as names by line number. -/
+def sortResults {α} [Inhabited α] (e : Environment) (results : HashMap Name α) : Array (Name × α) :=
+  let key (n : Name) :=
+    match findDeclarationRanges? e n with
+    | some range => range.range.pos.line
+    | none => 0
+  results.toArray.qsort fun (a, _) (b, _) => key a < key b
+
+/-- Formats a linter warning as `#check` command with comment. -/
+def printWarning (declName : Name) (warning : MessageData) : MessageData :=
+  m!"#check @{declName} /- {warning} -/"
+
+/-- Formats a map of linter warnings using `print_warning`, sorted by line number. -/
+def printWarnings (env : Environment) (results : HashMap Name MessageData) : MessageData :=
+  (MessageData.joinSep ·.toList Format.line) <|
+    (sortResults env results).map fun (declName, warning) => printWarning declName warning
+
+/--
+Formats a map of linter warnings grouped by filename with `-- filename` comments.
+The first `drop_fn_chars` characters are stripped from the filename.
+-/
+def groupedByFilename (results : HashMap Name MessageData) : CoreM MessageData := do
+  let mut grouped : HashMap Name (HashMap Name MessageData) := {}
+  for (declName, msg) in results.toArray do
+    let mod ← findModuleOf? declName
+    let mod := mod.getD (← getEnv).mainModule
+    grouped := grouped.insert mod <| grouped.findD mod {} |>.insert declName msg
+  let grouped' := grouped.toArray.qsort fun (a, _) (b, _) => toString a < toString b
+  let env ← getEnv
+  (MessageData.joinSep · (Format.line ++ Format.line)) <|
+    grouped'.toList.map fun (mod, msgs) =>
+      m!"-- {mod}\n{printWarnings env msgs}"
+
+/--
+Formats the linter results as Lean code with comments and `#print` commands.
+-/
+def formatLinterResults
+    (results : Array (NamedLinter × HashMap Name MessageData))
+    (decls : Array Name)
+    (groupByFilename : Bool)
+    (whereDesc : String) (runSlowLinters : Bool)
+    (verbose : LintVerbosity) (numLinters : Nat) :
+    CoreM MessageData := do
+  let formattedResults ← results.filterMapM fun (linter, results) => do
+    if !results.isEmpty then
+      let warnings ←
+        if groupByFilename then
+          groupedByFilename results
+        else
+          printWarnings (← getEnv) results
+      some m!"/- The `{linter.name}` linter reports:\n{linter.errorsFound} -/\n{warnings}\n"
+    else if verbose = LintVerbosity.high then
+      some m!"/- OK: {linter.noErrorsFound} -/"
+    else
+      none
+  let mut s := MessageData.joinSep formattedResults.toList Format.line
+  let numAutoDecls := (← decls.filterM isAutoDecl).size
+  unless verbose matches LintVerbosity.low do
+    s := m!"-- Checking {decls.size - numAutoDecls} declarations (plus {
+      numAutoDecls} automatically generated ones) {whereDesc
+      } with {numLinters} linters\n\n{s}"
+  unless runSlowLinters do s := m!"{s}-- (slow linters skipped)\n"
+  s
+
+def getDeclsInCurrModule : CoreM (Array Name) := do
+  (← getEnv).constants.map₂.toList.toArray.map (·.1)
+
+def getAllDecls : CoreM (Array Name) := do
+  (← getDeclsInCurrModule) ++
+    (← getEnv).constants.map₁.toArray.map (·.1)
+
+def getDeclsInMathlib : CoreM (Array Name) := do
+  let mut decls ← getDeclsInCurrModule
+  let mathlibModules := (← getEnv).header.moduleNames.map ((`Mathlib).isPrefixOf ·)
+  for (declName, moduleIdx) in (← getEnv).const2ModIdx.toArray do
+    if mathlibModules[moduleIdx] then
+      decls := decls.push declName
+  decls
+
+open Elab Command in
+elab "#lint"
+    project:(&"mathlib" <|> &"all")?
+    verbosity:("+" <|> "-")?
+    fast:"*"?
+    only:(&"only")? linters:(ident)*
+    : command => do
+  let (decls, whereDesc, groupByFilename) ← match project.getOptional? with
+    | none => do (← liftCoreM getDeclsInCurrModule, "in the current file", false)
+    | some (Syntax.atom _ "mathlib") => do (← liftCoreM getDeclsInMathlib, "in mathlib", true)
+    | some (Syntax.atom _ "all") => do (← liftCoreM getAllDecls, "in all files", true)
+    | _ => throwUnsupportedSyntax
+  let verbosity : LintVerbosity ← match verbosity.getOptional? with
+    | none => LintVerbosity.medium
+    | some (Syntax.atom _ "+") => LintVerbosity.high
+    | some (Syntax.atom _ "-") => LintVerbosity.low
+    | _ => throwUnsupportedSyntax
+  let fast := fast.getOptional?.isSome
+  let only := only.getOptional?.isSome
+  let extraLinters ← linters.getArgs.mapM fun id =>
+    withScope ({ · with currNamespace := `Mathlib.Tactic.Lint }) <|
+      resolveGlobalConstNoOverload id
+  let linters ← liftCoreM <| getChecks (slow := !fast) extraLinters.toList only
+  let results ← liftCoreM <| lintCore decls linters.toArray
+  let failed := results.any (!·.2.isEmpty)
+  let mut fmtResults ← liftCoreM <|
+    formatLinterResults results decls (groupByFilename := groupByFilename)
+      whereDesc (runSlowLinters := !fast) verbosity linters.length
+  if failed then
+    logError fmtResults
+  else if verbosity != LintVerbosity.low then
+    logInfo m!"{fmtResults}\n-- All linting checks passed!"
+
+open Elab Command in
+/-- The command `#list_linters` prints a list of all available linters. -/
+elab "#list_linters" : command => do
+  let env ← getEnv
+  let ns : Array Name := env.constants.fold (init := #[]) fun ns n ci =>
+    if n.getPrefix == `Mathlib.Tactic.Lint && ci.type == mkConst ``Mathlib.Tactic.Lint.Linter
+      then ns.push n else ns
+  let linters ← ns.mapM fun n => do
+    let b := mathlibLinterAttr.hasTag (← getEnv) n
+    toString (n.updatePrefix Name.anonymous) ++ if b then " (*)" else ""
+  logInfo m!"Available linters (linters marked with (*) are in the default lint set):\n{Format.joinSep linters.toList Format.line}"

--- a/Mathlib/Tactic/Lint/Frontend.lean
+++ b/Mathlib/Tactic/Lint/Frontend.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn, Robert Y. Lewis, Gabriel Ebner
 -/
 import Mathlib.Tactic.Lint.Basic
-import Mathlib.Tactic.Lint.Simp
 
 /-!
 # Linter frontend and commands

--- a/Mathlib/Tactic/Lint/Frontend.lean
+++ b/Mathlib/Tactic/Lint/Frontend.lean
@@ -159,8 +159,10 @@ def formatLinterResults
       none
   let mut s := MessageData.joinSep formattedResults.toList Format.line
   let numAutoDecls := (← decls.filterM isAutoDecl).size
+  let failed := results.map (·.2.size) |>.foldl (·+·) 0
   unless verbose matches LintVerbosity.low do
-    s := m!"-- Checking {decls.size - numAutoDecls} declarations (plus {
+    s := m!"-- Found {failed} error{if failed == 1 then "" else "s"
+      } in {decls.size - numAutoDecls} declarations (plus {
       numAutoDecls} automatically generated ones) {whereDesc
       } with {numLinters} linters\n\n{s}"
   unless runSlowLinters do s := m!"{s}-- (slow linters skipped)\n"

--- a/Mathlib/Tactic/Lint/Simp.lean
+++ b/Mathlib/Tactic/Lint/Simp.lean
@@ -7,6 +7,10 @@ import Mathlib.Tactic.Lint.Basic
 import Mathlib.Tactic.OpenPrivate
 open Lean Meta
 
+def Option.mapM [Monad m] (f : α → m β) : Option α → m (Option β)
+  | none => none
+  | some a => f a
+
 namespace Mathlib.Tactic.Lint
 
 /-!
@@ -54,7 +58,7 @@ def isSimpEq (a b : Expr) : MetaM Bool := withReducible do
   isDefEq a b
 
 def checkAllSimpLemmaInfos (ty : Expr) (k : SimpLemmaInfo → MetaM (Option MessageData)) : MetaM (Option MessageData) := do
-  let errors := (← withSimpLemmaInfos ty k).filterMap id
+  let errors := (← withSimpLemmaInfos ty fun i => do (← k i).mapM addMessageContextFull).filterMap id
   if errors.isEmpty then
     return none
   else

--- a/Mathlib/Tactic/Lint/Simp.lean
+++ b/Mathlib/Tactic/Lint/Simp.lean
@@ -40,8 +40,8 @@ def isConditionalHyps (eq : Expr) : List Expr → MetaM Bool
     isConditionalHyps eq hs
 
 open private preprocess from Lean.Meta.Tactic.Simp.SimpLemmas in
-def withSimpLemmaInfos (ty : Expr) (k : SimpLemmaInfo → MetaM α) : MetaM (Array α) := do
-  (← preprocess (← mkSorry ty true) ty false).toArray.mapM fun (_, ty') => withReducible do
+def withSimpLemmaInfos (ty : Expr) (k : SimpLemmaInfo → MetaM α) : MetaM (Array α) := withReducible do
+  (← preprocess (← mkSorry ty true) ty false).toArray.mapM fun (_, ty') => do
     forallTelescopeReducing ty' fun hyps eq => do
       let some (_, lhs, rhs) ← eq.eq? | throwError "not an equality {eq}"
       k {

--- a/Mathlib/Tactic/Lint/Simp.lean
+++ b/Mathlib/Tactic/Lint/Simp.lean
@@ -63,6 +63,7 @@ def checkAllSimpLemmaInfos (ty : Expr) (k : SimpLemmaInfo → MetaM (Option Mess
 def isSimpLemma (declName : Name) : MetaM Bool := do
   (← getSimpLemmas).lemmaNames.contains declName
 
+-- TODO: trace aux lemmas back to original simp lemma
 def heuristicallyExtractSimpLemmas (prf : Expr) : MetaM (Array Name) :=
   prf.getUsedConstants.filterM isSimpLemma
 
@@ -79,7 +80,6 @@ https://leanprover-community.github.io/mathlib_docs/notes.html#simp-normal%20for
   test := fun declName => do
     unless ← isSimpLemma declName do return none
     -- TODO: equation lemmas
-    -- TODO: timeout
     let ctx ← Simp.Context.mkDefault
     checkAllSimpLemmaInfos (← getConstInfo declName).type fun {lhs, rhs, isConditional, ..} => do
     let ⟨lhs', prf1⟩ ← decorateError "simplify fails on left-hand side:" <| simp lhs ctx

--- a/Mathlib/Tactic/Lint/Simp.lean
+++ b/Mathlib/Tactic/Lint/Simp.lean
@@ -1,0 +1,197 @@
+/-
+Copyright (c) 2020 Gabriel Ebner. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Gabriel Ebner
+-/
+import Mathlib.Tactic.Lint.Basic
+import Mathlib.Tactic.OpenPrivate
+open Lean Meta
+
+namespace Mathlib.Tactic.Lint
+
+/-!
+# Linter for simplification lemmas
+
+This files defines several linters that prevent common mistakes when declaring simp lemmas:
+
+ * `simpNF` checks that the left-hand side of a simp lemma is not simplified by a different lemma.
+ * `simpVarHead` checks that the head symbol of the left-hand side is not a variable.
+ * `simpComm` checks that commutativity lemmas are not marked as simplification lemmas.
+-/
+
+structure SimpLemmaInfo where
+  hyps : Array Expr
+  isConditional : Bool
+  lhs : Expr
+  rhs : Expr
+
+def isConditionalHyps (eq : Expr) : List Expr → MetaM Bool
+  | [] => false
+  | h :: hs => do
+    let ldecl ← getFVarLocalDecl h
+    if !ldecl.binderInfo.isInstImplicit
+        && !(← hs.anyM fun h' => do (← inferType h').containsFVar h.fvarId!)
+        && !eq.containsFVar h.fvarId! then
+      return true
+    isConditionalHyps eq hs
+
+open private preprocess from Lean.Meta.Tactic.Simp.SimpLemmas in
+def withSimpLemmaInfos (ty : Expr) (k : SimpLemmaInfo → MetaM α) : MetaM (Array α) := do
+  (← preprocess (← mkSorry ty true) ty false).toArray.mapM fun (_, ty') => withReducible do
+    forallTelescopeReducing ty' fun hyps eq => do
+      let some (_, lhs, rhs) ← eq.eq? | throwError "not an equality {eq}"
+      k {
+        hyps, lhs, rhs
+        isConditional := ← isConditionalHyps eq hyps.toList
+      }
+
+/-- Checks whether two expressions are equal for the simplifier. That is,
+they are reducibly-definitional equal, and they have the same head symbol. -/
+def isSimpEq (a b : Expr) : MetaM Bool := withReducible do
+  let a ← whnf a
+  let b ← whnf b
+  if a.getAppFn.constName? != b.getAppFn.constName? then return false
+  isDefEq a b
+
+def checkAllSimpLemmaInfos (ty : Expr) (k : SimpLemmaInfo → MetaM (Option MessageData)) : MetaM (Option MessageData) := do
+  let errors := (← withSimpLemmaInfos ty k).filterMap id
+  if errors.isEmpty then
+    return none
+  else
+    return MessageData.joinSep errors.toList Format.line
+
+def isSimpLemma (declName : Name) : MetaM Bool := do
+  (← getSimpLemmas).lemmaNames.contains declName
+
+def heuristicallyExtractSimpLemmas (prf : Expr) : MetaM (Array Name) :=
+  prf.getUsedConstants.filterM isSimpLemma
+
+def decorateError (msg : MessageData) (k : MetaM α) : MetaM α := do
+  try k catch e => throw e
+
+/-- A linter for simp lemmas whose lhs is not in simp-normal form, and which hence never fire. -/
+@[mathlibLinter] def simpNF : Linter where
+  noErrorsFound := "All left-hand sides of simp lemmas are in simp-normal form."
+  errorsFound := "SOME SIMP LEMMAS ARE NOT IN SIMP-NORMAL FORM.
+see note [simp-normal form] for tips how to debug this.
+https://leanprover-community.github.io/mathlib_docs/notes.html#simp-normal%20form"
+
+  test := fun declName => do
+    unless ← isSimpLemma declName do return none
+    -- TODO: equation lemmas
+    -- TODO: timeout
+    let ctx ← Simp.Context.mkDefault
+    checkAllSimpLemmaInfos (← getConstInfo declName).type fun {lhs, rhs, isConditional, ..} => do
+    let ⟨lhs', prf1⟩ ← decorateError "simplify fails on left-hand side:" <| simp lhs ctx
+    let prf1_lems ← heuristicallyExtractSimpLemmas (prf1.getD (mkBVar 0))
+    if prf1_lems.contains declName then return none
+    let ⟨rhs', prf2⟩ ← decorateError "simplify fails on right-hand side:" <| simp rhs ctx
+    let lhs'_eq_rhs' ← isSimpEq lhs' rhs'
+    let lhs_in_nf ← isSimpEq lhs' lhs
+    if lhs'_eq_rhs' then do
+      let used_lemmas ← heuristicallyExtractSimpLemmas <|
+        mkApp (prf1.getD (mkBVar 0)) (prf2.getD (mkBVar 0))
+      return m!"simp can prove this:
+  by simp only {used_lemmas}
+One of the lemmas above could be a duplicate.
+If that's not the case try reordering lemmas or adding @[priority].
+"
+    else if ¬ lhs_in_nf then do
+      return m!"Left-hand side simplifies from
+  {lhs}
+to
+  {lhs'}
+using
+  {prf1_lems}
+Try to change the left-hand side to the simplified term!
+"
+    else if !isConditional && lhs == lhs' then
+      return m!"Left-hand side does not simplify.
+You need to debug this yourself using `set_option trace.Meta.Tactic.simp.rewrite true`"
+    else
+      return none
+
+/-
+This note gives you some tips to debug any errors that the simp-normal form linter raises.
+
+The reason that a lemma was considered faulty is because its left-hand side is not in simp-normal
+form.
+These lemmas are hence never used by the simplifier.
+
+This linter gives you a list of other simp lemmas: look at them!
+
+Here are some tips depending on the error raised by the linter:
+
+  1. 'the left-hand side reduces to XYZ':
+     you should probably use XYZ as the left-hand side.
+
+  2. 'simp can prove this':
+     This typically means that lemma is a duplicate, or is shadowed by another lemma:
+
+     2a. Always put more general lemmas after specific ones:
+      ```
+      @[simp] lemma zero_add_zero : 0 + 0 = 0 := rfl
+      @[simp] lemma add_zero : x + 0 = x := rfl
+      ```
+
+      And not the other way around!  The simplifier always picks the last matching lemma.
+
+     2b. You can also use `@[priority]` instead of moving simp-lemmas around in the file.
+
+      Tip: the default priority is 1000.
+      Use `@[priority 1100]` instead of moving a lemma down,
+      and `@[priority 900]` instead of moving a lemma up.
+
+     2c. Conditional simp lemmas are tried last. If they are shadowed
+         just remove the `simp` attribute.
+
+     2d. If two lemmas are duplicates, the linter will complain about the first one.
+         Try to fix the second one instead!
+         (You can find it among the other simp lemmas the linter prints out!)
+
+  3. 'try_for tactic failed, timeout':
+     This typically means that there is a loop of simp lemmas.
+     Try to apply squeeze_simp to the right-hand side (removing this lemma from the simp set) to see
+     what lemmas might be causing the loop.
+
+     Another trick is to `set_option trace.simplify.rewrite true` and
+     then apply `try_for 10000 { simp }` to the right-hand side.  You will
+     see a periodic sequence of lemma applications in the trace message.
+-/
+-- library_note "simp-normal form"
+-- TODO
+
+/--
+A linter for simp lemmas whose lhs has a variable as head symbol,
+and which hence never fire.
+-/
+@[mathlibLinter] def simpVarHead : Linter where
+  noErrorsFound :=
+    "No left-hand sides of a simp lemma has a variable as head symbol."
+  errorsFound := "LEFT-HAND SIDE HAS VARIABLE AS HEAD SYMBOL.
+Some simp lemmas have a variable as head symbol of the left-hand side:"
+  test := fun declName => do
+    unless ← isSimpLemma declName do return none
+    checkAllSimpLemmaInfos (← getConstInfo declName).type fun {lhs, ..} => do
+    let headSym := lhs.getAppFn
+    unless headSym.isFVar do return none
+    return m!"Left-hand side has variable as head symbol: {headSym}"
+
+/-- A linter for commutativity lemmas that are marked simp. -/
+@[mathlibLinter] def simpComm : Linter where
+  noErrorsFound := "No commutativity lemma is marked simp."
+  errorsFound := "COMMUTATIVITY LEMMA IS SIMP.
+Some commutativity lemmas are simp lemmas:"
+  test := fun declName => withReducible do
+    unless ← isSimpLemma declName do return none
+    let ty := (← getConstInfo declName).type
+    forallTelescopeReducing ty fun xs ty => do
+    let some (_, lhs, rhs) ← ty.eq? | none
+    unless lhs.getAppFn.constName? == rhs.getAppFn.constName? do return none
+    let (mvars, bis, ty') ← forallMetaTelescopeReducing ty
+    let some (_, lhs', rhs') ← ty'.eq? | none
+    unless ← isDefEq rhs lhs' do return none
+    unless ← withNewMCtxDepth (isDefEq rhs lhs') do return none
+    -- ensure that the second application makes progress:
+    if ← isDefEq lhs' rhs' then return none
+    m!"should not be marked simp"

--- a/Mathlib/Tactic/Lint/Simp.lean
+++ b/Mathlib/Tactic/Lint/Simp.lean
@@ -105,6 +105,9 @@ def heuristicallyExtractSimpLemmasCore (ctx : Simp.Context) (constToSimpDecl : H
 def decorateError (msg : MessageData) (k : MetaM α) : MetaM α := do
   try k catch e => throw e
 
+def formatLemmas (lems : Array Name) : CoreM MessageData := do
+  toMessageData <|<- lems.mapM mkConstWithLevelParams
+
 /-- A linter for simp lemmas whose lhs is not in simp-normal form, and which hence never fire. -/
 @[mathlibLinter] def simpNF : Linter where
   noErrorsFound := "All left-hand sides of simp lemmas are in simp-normal form."
@@ -127,7 +130,7 @@ https://leanprover-community.github.io/mathlib_docs/notes.html#simp-normal%20for
       let used_lemmas := heuristicallyExtractSimpLemmas ctx <|
         mkApp (prf1.getD (mkBVar 0)) (prf2.getD (mkBVar 0))
       return m!"simp can prove this:
-  by simp only {used_lemmas}
+  by simp only {← formatLemmas used_lemmas}
 One of the lemmas above could be a duplicate.
 If that's not the case try reordering lemmas or adding @[priority].
 "
@@ -137,7 +140,7 @@ If that's not the case try reordering lemmas or adding @[priority].
 to
   {lhs'}
 using
-  {prf1_lems}
+  {← formatLemmas prf1_lems}
 Try to change the left-hand side to the simplified term!
 "
     else if !isConditional && lhs == lhs' then

--- a/Mathlib/Tactic/Lint/Simp.lean
+++ b/Mathlib/Tactic/Lint/Simp.lean
@@ -51,9 +51,9 @@ def withSimpLemmaInfos (ty : Expr) (k : SimpLemmaInfo → MetaM α) : MetaM (Arr
 
 /-- Checks whether two expressions are equal for the simplifier. That is,
 they are reducibly-definitional equal, and they have the same head symbol. -/
-def isSimpEq (a b : Expr) : MetaM Bool := withReducible do
-  let a ← whnf a
-  let b ← whnf b
+def isSimpEq (a b : Expr) (whnfFirst := true) : MetaM Bool := withReducible do
+  let a ← if whnfFirst then whnf a else a
+  let b ← if whnfFirst then whnf b else b
   if a.getAppFn.constName? != b.getAppFn.constName? then return false
   isDefEq a b
 
@@ -128,7 +128,7 @@ https://leanprover-community.github.io/mathlib_docs/notes.html#simp-normal%20for
     let prf1_lems := heuristicallyExtractSimpLemmas ctx (prf1.getD (mkBVar 0))
     if prf1_lems.contains declName then return none
     let ⟨rhs', prf2⟩ ← decorateError "simplify fails on right-hand side:" <| simp rhs ctx
-    let lhs'_eq_rhs' ← isSimpEq lhs' rhs'
+    let lhs'_eq_rhs' ← isSimpEq lhs' rhs' (whnfFirst := false)
     let lhs_in_nf ← isSimpEq lhs' lhs
     if lhs'_eq_rhs' then do
       let used_lemmas := heuristicallyExtractSimpLemmas ctx <|

--- a/scripts/runLinter.lean
+++ b/scripts/runLinter.lean
@@ -1,0 +1,3 @@
+import Mathlib
+
+#lint mathlib


### PR DESCRIPTION
Still requires a bit more testing.
1. Lean now has a built-in feature called "linter" which is something different, I've tried to use `mathlibLinter` for the attribute.
1. ~~I haven't checked that nolint works yet.~~
1. ~~The simp linter is still a bit buggy (reports "can be replace by `by simp only []`" way too often)~~
1. ~~Detecting automatically generated declarations is a todo.~~
1. CI integration with nolints.txt is missing.
1. Other linters are also missing.