### PR TITLE
[Merged by Bors] - feat: add rename' tactic

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -52,6 +52,7 @@ import Mathlib.Tactic.NormNum
 import Mathlib.Tactic.OpenPrivate
 import Mathlib.Tactic.PrintPrefix
 import Mathlib.Tactic.Rcases
+import Mathlib.Tactic.Rename
 import Mathlib.Tactic.Ring
 import Mathlib.Tactic.RunCmd
 import Mathlib.Tactic.RunTac

--- a/Mathlib/Mathport/Syntax.lean
+++ b/Mathlib/Mathport/Syntax.lean
@@ -70,8 +70,6 @@ end Tactic
 namespace Tactic
 
 syntax (name := propagateTags) "propagateTags " tacticSeq : tactic
-syntax renameArg := ident " => " ident
-syntax (name := rename') "rename'" (ppSpace renameArg),+ : tactic
 syntax (name := fapply) "fapply " term : tactic
 syntax (name := eapply) "eapply " term : tactic
 syntax (name := applyWith) "apply " term " with " term : tactic

--- a/Mathlib/Tactic/Rename.lean
+++ b/Mathlib/Tactic/Rename.lean
@@ -1,0 +1,24 @@
+/-
+Copyright (c) 2021 Gabriel Ebner. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Gabriel Ebner
+-/
+import Lean
+
+namespace Mathlib.Tactic
+
+open Lean Elab.Tactic Meta
+
+/-- `rename' h => hnew` renames the hypothesis named `h` to `hnew`. -/
+syntax (name := rename') "rename'" (ppSpace term " => " ident),* : tactic
+
+elab_rules : tactic
+  | `(tactic| rename' $[$as:term => $bs:ident],*) =>
+    for a in as, b in bs do
+      withMainContext do
+        let fvarId ← getFVarId a
+        let lctxNew := (← getLCtx).setUserName fvarId b.getId
+        let mvarNew ← mkFreshExprMVarAt lctxNew (← getLocalInstances)
+          (← getMainTarget) MetavarKind.syntheticOpaque (← getMainTag)
+        assignExprMVar (← getMainGoal) mvarNew
+        replaceMainGoal [mvarNew.mvarId!]


### PR DESCRIPTION
Not to be confused with the core tactic called rename.
```lean
rename x = y => h
-- is equivalent to:
rename' ‹x = y› => h
```