### PR TITLE
[Merged by Bors] - feat: `{ x + 10 | x < 10 }`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -25,6 +25,7 @@ import Mathlib.Init.Data.Int.Basic
 import Mathlib.Init.Data.Nat.Basic
 import Mathlib.Init.Data.Nat.Lemmas
 import Mathlib.Init.Dvd
+import Mathlib.Init.ExtendedBinder
 import Mathlib.Init.Function
 import Mathlib.Init.Logic
 import Mathlib.Init.Set

--- a/Mathlib/Init/ExtendedBinder.lean
+++ b/Mathlib/Init/ExtendedBinder.lean
@@ -1,0 +1,88 @@
+/-
+Copyright (c) 2021 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Gabriel Ebner
+-/
+import Lean
+open Lean
+
+/-!
+Defines an extended binder syntax supporting `∀ ε > 0, ...` etc.
+-/
+
+namespace Mathlib.ExtendedBinder
+
+/-
+The syntax category of binder predicates contains predicates like `> 0`, `∈ s`, etc.
+(`: t` should not be a binder predicate because it would clash with the built-in syntax for ∀/∃.)
+-/
+declare_syntax_cat binderPred
+
+/--
+`satisfiesBinderPred% t pred` expands to a proposition expressing that `t` satisfies `pred`.
+-/
+syntax "satisfiesBinderPred% " term:max binderPred : term
+
+-- Extend ∀ and ∃ to binder predicates.
+macro "∃ " x:ident pred:binderPred ", " p:term : term =>
+  `(∃ $x:ident, satisfiesBinderPred% $x $pred ∧ $p)
+macro "∀ " x:ident pred:binderPred ", " p:term : term =>
+  `(∀ $x:ident, satisfiesBinderPred% $x $pred → $p)
+
+-- We also provide special versions of ∀/∃ that take a list of extended binders.
+-- The built-in binders are not reused because that results in overloaded syntax.
+
+syntax extBinder := ident ((" : " term) <|> binderPred)?
+syntax extBinderParenthesized := " (" extBinder ")" -- TODO: inlining this definition breaks
+syntax extBinderCollection := extBinderParenthesized*
+syntax extBinders := extBinder <|> extBinderCollection
+
+syntax "∃ᵉ " extBinders ", " term : term
+macro_rules
+  | `(∃ᵉ, $b) => b
+  | `(∃ᵉ ($p:extBinder) $[($ps:extBinder)]*, $b) =>
+    `(∃ᵉ $p:extBinder, ∃ᵉ $[($ps:extBinder)]*, $b)
+macro_rules -- TODO: merging the two macro_rules breaks expansion
+  | `(∃ᵉ $x:ident, $b) => `(∃ $x:ident, $b)
+  | `(∃ᵉ $x:ident : $ty:term, $b) => `(∃ $x:ident : $ty:term, $b)
+  | `(∃ᵉ $x:ident $p:binderPred, $b) => `(∃ $x:ident $p:binderPred, $b)
+
+syntax "∀ᵉ " extBinders ", " term : term
+macro_rules
+  | `(∀ᵉ, $b) => b
+  | `(∀ᵉ ($p:extBinder) $[($ps:extBinder)]*, $b) =>
+    `(∀ᵉ $p:extBinder, ∀ᵉ $[($ps:extBinder)]*, $b)
+macro_rules -- TODO: merging the two macro_rules breaks expansion
+  | `(∀ᵉ $x:ident, $b) => `(∀ $x:ident, $b)
+  | `(∀ᵉ $x:ident : $ty:term, $b) => `(∀ $x:ident : $ty:term, $b)
+  | `(∀ᵉ $x:ident $p:binderPred, $b) => `(∀ $x:ident $p:binderPred, $b)
+
+open Parser.Command in
+/--
+Declares a binder predicate.  For example:
+```
+binder_predicate x " > " y:term => `($x > $y)
+```
+-/
+syntax (docComment)? (attrKind)? "binder_predicate " optNamedName optNamedPrio ident macroArg* " => " term : command
+
+-- adapted from the macro macro
+open Elab Command in
+macro_rules
+  | `($[$doc?:docComment]? $attrKind:attrKind binder_predicate%$tk $[(name := $name?)]? $[(priority := $prio?)]? $x $args:macroArg* => $rhs) => do
+    let prio  ← evalOptPrio prio?
+    let (stxParts, patArgs) := (← args.mapM expandMacroArg).unzip
+    let name ← match name? with
+      | some name => pure name.getId
+      | none => mkNameFromParserSyntax `binderTerm (mkNullNode stxParts)
+    /- The command `syntax [<kind>] ...` adds the current namespace to the syntax node kind.
+      So, we must include current namespace when we create a pattern for the following `macro_rules` commands. -/
+    let pat := mkNode ((← Macro.getCurrNamespace) ++ name) patArgs
+    `($[$doc?:docComment]? $attrKind:attrKind syntax%$tk (name := $(← mkIdentFromRef name)) (priority := $(quote prio)) $[$stxParts]* : binderPred
+      $[$doc?:docComment]? macro_rules%$tk | `(satisfiesBinderPred% $$($x):term $pat:binderPred) => $rhs)
+
+
+binder_predicate x " > " y:term => `($x > $y)
+binder_predicate x " ≥ " y:term => `($x ≥ $y)
+binder_predicate x " < " y:term => `($x < $y)
+binder_predicate x " ≤ " y:term => `($x ≤ $y)

--- a/Mathlib/Init/SetNotation.lean
+++ b/Mathlib/Init/SetNotation.lean
@@ -1,3 +1,5 @@
+import Mathlib.Init.ExtendedBinder
+
 class Mem (α : outParam $ Type u) (γ : Type v) where
   mem : α → γ → Prop
 
@@ -25,15 +27,4 @@ class Sdiff (α : Type u) where
 
 infix:70 " \\ " => Sdiff.sdiff
 
-declare_syntax_cat binderterm -- notation for `a` or `a : A` or `a ∈ S`
-syntax ident : binderterm
-syntax ident " ∈ " term : binderterm
-
-syntax "∀ " binderterm ", " term : term
-syntax "∃ " binderterm ", " term : term
-
-macro_rules
--- ∀ x ∈ s, p := ∀ x, x ∈ s → p
-| `(∀ $x:ident ∈ $s, $p) => `(∀ $x:ident, $x ∈ $s → $p)
--- ∃ x ∈ s, p := ∃ x, x ∈ s ∧ p
-| `(∃ $x:ident ∈ $s, $p) => `(∃ $x:ident, $x ∈ $s ∧ $p)
+binder_predicate x " ∈ " y:term => `($x ∈ $y)

--- a/Mathlib/Mathport/Syntax.lean
+++ b/Mathlib/Mathport/Syntax.lean
@@ -53,7 +53,6 @@ end Parser.Command
 
 namespace Parser.Term
 
-syntax (priority := low) "{" term " | " bracketedBinder+ " }" : term
 syntax "quoteₓ " term : term
 syntax "pquoteₓ " term : term
 syntax "ppquoteₓ " term : term


### PR DESCRIPTION
Ports the set replacement syntax from Lean 3.

For that, I've also added a general framework where you can register relations to use in binders (e.g. `∀ ε > 0, ∃ x ∈ ball y ε, ...`).  You can register a new relation with a single command, and it automatically works in quantifiers, set comprehensions, etc.:
```lean
local binder_predicate x " within " eps:term " of " y:term => `(dist $x $y <= $eps)
-- ∃ x within ε of y, ...
-- { x within ε of y | ... }
```

The quantified variable can only be at the beginning, because this makes parsing much easier.  (So no `∀ 42 < x < 99, x < 300`.)  There is also no unexpander support yet.

See also https://github.com/leanprover-community/mathport/issues/13.  Mario suggested also supporting `∀ ε δ > 0, ...` there, but I'm not sure how important that is.