### PR TITLE
refactor: add term syntax for unsafe

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -67,4 +67,5 @@ import Mathlib.Tactic.Spread
 import Mathlib.Tactic.SudoSetOption
 import Mathlib.Tactic.TryThis
 import Mathlib.Util.Export
+import Mathlib.Util.TermUnsafe
 import Mathlib.Util.Time

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -66,6 +66,7 @@ import Mathlib.Tactic.SolveByElim
 import Mathlib.Tactic.Spread
 import Mathlib.Tactic.SudoSetOption
 import Mathlib.Tactic.TryThis
+import Mathlib.Util.Eval
 import Mathlib.Util.Export
 import Mathlib.Util.TermUnsafe
 import Mathlib.Util.Time

--- a/Mathlib/Tactic/Lint/Basic.lean
+++ b/Mathlib/Tactic/Lint/Basic.lean
@@ -5,6 +5,7 @@ Authors: Floris van Doorn, Robert Y. Lewis, Gabriel Ebner
 -/
 
 import Lean
+import Mathlib.Util.TermUnsafe
 open Lean Meta
 
 namespace Mathlib.Tactic.Lint
@@ -82,11 +83,8 @@ structure NamedLinter extends Linter where
 
 def NamedLinter.name (l : NamedLinter) : Name := l.declName.updatePrefix Name.anonymous
 
-private unsafe def getLinterImpl (declName : Name) : CoreM NamedLinter :=
+def getLinter (declName : Name) : CoreM NamedLinter := unsafe
   return { ← evalConstCheck Linter ``Linter declName with declName }
-
-@[implementedBy getLinterImpl]
-constant getLinter (declName : Name) : CoreM NamedLinter
 
 /-- Takes a list of names that resolve to declarations of type `linter`,
 and produces a list of linters. -/

--- a/Mathlib/Tactic/RunCmd.lean
+++ b/Mathlib/Tactic/RunCmd.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
 import Lean
+import Mathlib.Tactic.RunTac
 
 /-!
 Define a `run_cmd a; b` command which executes code in `CoreM Unit`.
@@ -12,37 +13,10 @@ except that it doesn't print an empty diagnostic.
 -/
 
 namespace Lean.Parser.Command
-open Meta Elab.Command Elab
-
-unsafe def elabRunCmdUnsafe : CommandElab := fun e => do
-  let n := `_runCmd
-  runTermElabM (some n) fun _ => do
-    let e ← Term.elabTerm e none
-    Term.synthesizeSyntheticMVarsNoPostponing
-    let e ← withLocalDeclD `env (mkConst ``Lean.Environment) fun env =>
-      withLocalDeclD `opts (mkConst ``Lean.Options) fun opts => do
-        let e ← mkAppM ``Lean.runMetaEval #[env, opts, e]
-        mkLambdaFVars #[env, opts] e
-    let env ← getEnv
-    let opts ← getOptions
-    let act ← try
-      let type ← inferType e
-      let decl := Declaration.defnDecl {
-        name        := n
-        levelParams := []
-        type        := type
-        value       := e
-        hints       := ReducibilityHints.opaque
-        safety      := DefinitionSafety.unsafe }
-      Term.ensureNoUnassignedMVars decl
-      addAndCompile decl
-      evalConst (Environment → Options → IO (String × Except IO.Error Environment)) n
-    finally setEnv env
-    match (← act env opts).2 with
-    | Except.error e => throwError e.toString
-    | Except.ok env  => setEnv env
-
-@[implementedBy elabRunCmdUnsafe] constant elabRunCmd : CommandElab
+open Mathlib.RunTac Meta Elab Elab.Command Term
 
 elab (name := runCmd) "run_cmd " elems:doSeq : command => do
-  elabRunCmd <|<- `((do $elems : CoreM Unit))
+  ← liftTermElabM `runCmd <|
+    unsafe evalTerm (CommandElabM Unit)
+      (mkApp (mkConst ``CommandElabM) (mkConst ``Unit))
+      (← `(discard do $elems))

--- a/Mathlib/Tactic/RunCmd.lean
+++ b/Mathlib/Tactic/RunCmd.lean
@@ -4,7 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
 import Lean
-import Mathlib.Tactic.RunTac
+import Mathlib.Util.Eval
+import Mathlib.Util.TermUnsafe
 
 /-!
 Define a `run_cmd a; b` command which executes code in `CoreM Unit`.
@@ -13,7 +14,7 @@ except that it doesn't print an empty diagnostic.
 -/
 
 namespace Lean.Parser.Command
-open Mathlib.RunTac Meta Elab Elab.Command Term
+open Mathlib.Eval Meta Elab Elab.Command Term
 
 elab (name := runCmd) "run_cmd " elems:doSeq : command => do
   ← liftTermElabM `runCmd <|

--- a/Mathlib/Tactic/RunTac.lean
+++ b/Mathlib/Tactic/RunTac.lean
@@ -29,9 +29,6 @@ unsafe def evalTerm (α) (type : Expr) (value : Syntax) (safety := DefinitionSaf
   if ← logUnassignedUsingErrorInfos (← getMVars v) then throwAbortTerm
   evalExpr α type v safety
 
-
-set_option trace.Elab.step true
-set_option pp.rawOnError true
 open Tactic in
 elab "runTac" e:doSeq : tactic => do
   ← unsafe evalTerm (TacticM Unit) (mkApp (mkConst ``TacticM) (mkConst ``Unit))

--- a/Mathlib/Tactic/RunTac.lean
+++ b/Mathlib/Tactic/RunTac.lean
@@ -4,30 +4,11 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: Sebastian Ullrich
 -/
 import Lean.Elab.SyntheticMVars
+import Mathlib.Util.Eval
 import Mathlib.Util.TermUnsafe
 
 namespace Mathlib.RunTac
-open Lean Elab Term Meta
-
-unsafe def evalExpr (α) (expectedType : Expr) (value : Expr) (safety := DefinitionSafety.unsafe) : MetaM α :=
-  withoutModifyingEnv do
-    let name ← mkFreshUserName `_tmp
-    let type ← inferType value
-    unless ← isDefEq type expectedType do
-      throwError "unexpected type at evalExpr: {type} ≠ {expectedType}"
-    let decl := Declaration.defnDecl {
-       name, levelParams := [], type, safety, value
-       hints := ReducibilityHints.opaque
-    }
-    addAndCompile decl
-    evalConst α name
-
-unsafe def evalTerm (α) (type : Expr) (value : Syntax) (safety := DefinitionSafety.unsafe) : TermElabM α := do
-  let v ← Term.elabTermEnsuringType value type
-  synthesizeSyntheticMVarsNoPostponing
-  let v ← instantiateMVars v
-  if ← logUnassignedUsingErrorInfos (← getMVars v) then throwAbortTerm
-  evalExpr α type v safety
+open Lean Elab Term Meta Mathlib.Eval
 
 open Tactic in
 elab "runTac" e:doSeq : tactic => do

--- a/Mathlib/Util/Eval.lean
+++ b/Mathlib/Util/Eval.lean
@@ -1,0 +1,29 @@
+/-
+Copyright (c) 2018 Sebastian Ullrich. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Sebastian Ullrich
+-/
+import Lean.Elab.SyntheticMVars
+
+namespace Mathlib.Eval
+open Lean Elab Term Meta
+
+unsafe def evalExpr (α) (expectedType : Expr) (value : Expr) (safety := DefinitionSafety.safe) : MetaM α :=
+  withoutModifyingEnv do
+    let name ← mkFreshUserName `_tmp
+    let type ← inferType value
+    unless ← isDefEq type expectedType do
+      throwError "unexpected type at evalExpr: {type} ≠ {expectedType}"
+    let decl := Declaration.defnDecl {
+       name, levelParams := [], type, safety, value
+       hints := ReducibilityHints.opaque
+    }
+    addAndCompile decl
+    evalConst α name
+
+unsafe def evalTerm (α) (type : Expr) (value : Syntax) (safety := DefinitionSafety.safe) : TermElabM α := do
+  let v ← Term.elabTermEnsuringType value type
+  synthesizeSyntheticMVarsNoPostponing
+  let v ← instantiateMVars v
+  if ← logUnassignedUsingErrorInfos (← getMVars v) then throwAbortTerm
+  evalExpr α type v safety

--- a/Mathlib/Util/TermUnsafe.lean
+++ b/Mathlib/Util/TermUnsafe.lean
@@ -1,0 +1,55 @@
+/-
+Copyright (c) 2021 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Gabriel Ebner
+-/
+import Lean
+
+/-!
+Defines term syntax to call unsafe functions.
+
+```
+def cool :=
+  unsafe (unsafeCast () : Nat)
+
+#eval cool
+```
+-/
+
+namespace Mathlib.TermUnsafe
+open Lean Meta Elab Term
+
+def mkAuxName (hint : Name) : TermElabM Name :=
+  withFreshMacroScope do
+    let name := (← getDeclName?).getD Name.anonymous ++ hint
+    addMacroScope (← getMainModule) name (← getCurrMacroScope)
+
+syntax "unsafe " term : term
+
+elab_rules : term <= expectedType
+  | `(unsafe ?$mvar) => do
+    let t ← elabTerm (← `(?$mvar)) none
+    let t ← instantiateMVars t
+    let t ← if !t.hasExprMVar then t else
+      tryPostpone
+      synthesizeSyntheticMVarsNoPostponing
+      instantiateMVars t
+    if ← logUnassignedUsingErrorInfos (← getMVars t) then throwAbortTerm
+    let t ← mkAuxDefinitionFor (← mkAuxName `unsafe) t
+    let Expr.const unsafeFn unsafeLvls .. ← t.getAppFn | unreachable!
+    let ConstantInfo.defnInfo unsafeDefn ← getConstInfo unsafeFn | unreachable!
+    let implName ← mkAuxName `impl
+    addDecl <| Declaration.defnDecl {
+      name := implName
+      type := unsafeDefn.type
+      levelParams := unsafeDefn.levelParams
+      value := (← mkArbitrary unsafeDefn.type)
+      hints := ReducibilityHints.opaque
+      safety := DefinitionSafety.safe
+    }
+    setImplementedBy implName unsafeFn
+    mkAppN (mkConst implName unsafeLvls) t.getAppArgs
+  | `(unsafe $t) => do
+    let m ← elabTerm (← `(?m)) expectedType
+    assignExprMVar m.mvarId! (← elabTerm t expectedType)
+    elabTerm (← `(unsafe ?m)) expectedType


### PR DESCRIPTION
This makes it easier to call unsafe functions without the `implementedBy` boilerplate.  You can now write `unsafe (unsafeCast () : Nat)` just like in Rust.

I've also refactored the duplicate runCmd/runTac code while I was at it.