### PR TITLE
[Merged by Bors] - perf: use CoeTail for coercion from Nat to Numeric

### DIFF
--- a/Mathlib/Algebra/Ring/Basic.lean
+++ b/Mathlib/Algebra/Ring/Basic.lean
@@ -12,7 +12,7 @@ class Numeric (α : Type u) where
   ofNat : Nat → α
 
 instance Numeric.OfNat [Numeric α] : OfNat α n := ⟨Numeric.ofNat n⟩
-instance [Numeric α] : Coe ℕ α := ⟨Numeric.ofNat⟩
+instance [Numeric α] : CoeTail ℕ α := ⟨Numeric.ofNat⟩
 
 theorem ofNat_eq_ofNat (α) (n : ℕ) [Numeric α] : Numeric.ofNat (α := α) n = OfNat.ofNat n := rfl
 


### PR DESCRIPTION
The blanket coercion leads to slow type class search (because `Numeric ?α` is introduced as a subgoal).

https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Deterministic.20timeout.20with.20Inhabited.20from.20Zero/near/264682061