### PR TITLE
bump: nightly-2021-12-15

### DIFF
--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2021-12-14
+leanprover/lean4:nightly-2021-12-15


### PR DESCRIPTION
Hopefully this will fix the problem `lake` has been having with `mathlib3port`.