### PR TITLE
[Merged by Bors] - feat: binary heaps

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4,6 +4,7 @@ import Mathlib.Algebra.GroupWithZero.Defs
 import Mathlib.Algebra.Ring.Basic
 import Mathlib.Data.Array.Basic
 import Mathlib.Data.Array.Defs
+import Mathlib.Data.BinaryHeap
 import Mathlib.Data.ByteArray
 import Mathlib.Data.Char
 import Mathlib.Data.Equiv.Basic
@@ -32,6 +33,7 @@ import Mathlib.Init.Function
 import Mathlib.Init.Logic
 import Mathlib.Init.Set
 import Mathlib.Init.SetNotation
+import Mathlib.Init.WF
 import Mathlib.Lean.Expr
 import Mathlib.Lean.LocalContext
 import Mathlib.Logic.Basic

--- a/Mathlib/Data/BinaryHeap.lean
+++ b/Mathlib/Data/BinaryHeap.lean
@@ -3,7 +3,6 @@ Copyright (c) 2021 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
-import Mathlib.Init.WF
 import Mathlib.Data.Fin.Basic
 
 /-- A max-heap data structure. -/

--- a/Mathlib/Data/BinaryHeap.lean
+++ b/Mathlib/Data/BinaryHeap.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2021 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro
+-/
 import Mathlib.Init.WF
 import Mathlib.Data.Fin.Basic
 

--- a/Mathlib/Data/BinaryHeap.lean
+++ b/Mathlib/Data/BinaryHeap.lean
@@ -1,0 +1,139 @@
+import Mathlib.Init.WF
+import Mathlib.Data.Fin.Basic
+
+/-- A max-heap data structure. -/
+structure BinaryHeap (α) (lt : α → α → Bool) where
+  arr : Array α
+
+namespace BinaryHeap
+
+/-- Core operation for binary heaps, expressed directly on arrays.
+Given an array which is a max-heap, push item `i` down to restore the max-heap property. -/
+def heapifyDown (lt : α → α → Bool) (a : Array α) (i : Fin a.size) :
+  {a' : Array α // a'.size = a.size} :=
+  let left := 2 * i.1 + 1
+  let right := left + 1
+  have left_le : i ≤ left := Nat.le_trans
+    (by rw [Nat.succ_mul, Nat.one_mul]; exact Nat.le_add_left i i)
+    (Nat.le_add_right ..)
+  have right_le : i ≤ right := Nat.le_trans left_le (Nat.le_add_right ..)
+  have i_le : i ≤ i := Nat.le_refl _
+  have j : {j : Fin a.size // i ≤ j} := if h : left < a.size then
+    if lt (a.get i) (a.get ⟨left, h⟩) then ⟨⟨left, h⟩, left_le⟩ else ⟨i, i_le⟩ else ⟨i, i_le⟩
+  have j := if h : right < a.size then
+    if lt (a.get j) (a.get ⟨right, h⟩) then ⟨⟨right, h⟩, right_le⟩ else j else j
+  if h : i.1 = j then ⟨a, rfl⟩ else
+    let a' := a.swap i j
+    let j' := ⟨j, by rw [a.size_swap i j]; exact j.1.2⟩
+    have : (skipLeft Fin.upRel).1 ⟨a'.size, j'⟩ ⟨a.size, i⟩ := by
+      have H {n} (h : n = a.size) (j' : Fin n) (e' : i.1 < j'.1) :
+        (skipLeft Fin.upRel).1 ⟨n, j'⟩ ⟨a.size, i⟩ := by
+        subst n; exact PSigma.Lex.right _ e'
+      exact H (a.size_swap i j) _ (lt_of_le_of_ne j.2 h)
+    let ⟨a₂, h₂⟩ := heapifyDown lt a' j'
+    ⟨a₂, h₂.trans (a.size_swap i j)⟩
+termination_by invImage (fun ⟨_, _, a, i⟩ => (⟨a.size, i⟩ : (n : ℕ) ×' Fin n)) $ skipLeft Fin.upRel
+decreasing_by assumption
+
+@[simp] theorem size_heapifyDown (lt : α → α → Bool) (a : Array α) (i : Fin a.size) :
+  (heapifyDown lt a i).1.size = a.size := (heapifyDown lt a i).2
+
+/-- Core operation for binary heaps, expressed directly on arrays.
+Construct a heap from an unsorted array, by heapifying all the elements. -/
+def mkHeap (lt : α → α → Bool) (a : Array α) : {a' : Array α // a'.size = a.size} :=
+  let rec loop : (i : Nat) → (a : Array α) → i ≤ a.size → {a' : Array α // a'.size = a.size}
+  | 0, a, _ => ⟨a, rfl⟩
+  | i+1, a, h =>
+    let h := Nat.lt_of_succ_le h
+    let a' := heapifyDown lt a ⟨i, h⟩
+    let ⟨a₂, h₂⟩ := loop i a' ((heapifyDown ..).2.symm ▸ le_of_lt h)
+    ⟨a₂, h₂.trans a'.2⟩
+  loop (a.size / 2) a (Nat.div_le_self ..)
+
+@[simp] theorem size_mkHeap (lt : α → α → Bool) (a : Array α) (i : Fin a.size) :
+  (mkHeap lt a).1.size = a.size := (mkHeap lt a).2
+
+/-- Core operation for binary heaps, expressed directly on arrays.
+Given an array which is a max-heap, push item `i` up to restore the max-heap property. -/
+def heapifyUp (lt : α → α → Bool) (a : Array α) (i : Fin a.size) :
+  {a' : Array α // a'.size = a.size} :=
+if i0 : i.1 = 0 then ⟨a, rfl⟩ else
+  have : (i.1 - 1) / 2 < i := lt_of_le_of_lt (Nat.div_le_self ..) $
+    Nat.sub_lt (Nat.pos_iff_ne_zero.2 i0) Nat.one_pos
+  let j := ⟨(i.1 - 1) / 2, lt_trans this i.2⟩
+  if lt (a.get j) (a.get i) then
+    let a' := a.swap i j
+    let ⟨a₂, h₂⟩ := heapifyUp lt a' ⟨j.1, by rw [a.size_swap i j]; exact j.2⟩
+    ⟨a₂, h₂.trans (a.size_swap i j)⟩
+  else ⟨a, rfl⟩
+termination_by measure (·.2.2.2)
+decreasing_by assumption
+
+@[simp] theorem size_heapifyUp (lt : α → α → Bool) (a : Array α) (i : Fin a.size) :
+  (heapifyUp lt a i).1.size = a.size := (heapifyUp lt a i).2
+
+/-- `O(1)`. Build a new empty heap. -/
+@[inline] def empty (lt) : BinaryHeap α lt := ⟨#[]⟩
+
+instance (lt) : Inhabited (BinaryHeap α lt) := ⟨empty _⟩
+
+/-- `O(1)`. Get the number of elements in a `BinaryHeap`. -/
+@[inline] def size {lt} (self : BinaryHeap α lt) : Nat := self.1.size
+
+/-- `O(log n)`. Insert an element into a `BinaryHeap`, preserving the max-heap property. -/
+def insert {lt} (self : BinaryHeap α lt) (x : α) : BinaryHeap α lt where
+  arr := let n := self.size;
+    heapifyUp lt (self.1.push x) ⟨n, by rw [Array.size_push]; apply Nat.lt_succ_self⟩
+
+@[simp] theorem size_insert {lt} (self : BinaryHeap α lt) (x : α) :
+  (self.insert x).size = self.size + 1 := by
+  simp [insert, size, size_heapifyUp]
+
+/-- `O(1)`. Get the maximum element in a `BinaryHeap`. -/
+def max {lt} (self : BinaryHeap α lt) : Option α := self.1.get? 0
+
+/-- Auxiliary for `popMax`. -/
+def popMaxAux {lt} (self : BinaryHeap α lt) : {a' : BinaryHeap α lt // a'.size = self.size - 1} :=
+  match e: self.1.size with
+  | 0 => ⟨self, by simp [size, e]⟩
+  | n+1 =>
+    have h0 := by rw [e]; apply Nat.succ_pos
+    have hn := by rw [e]; apply Nat.lt_succ_self
+    if hn0 : 0 < n then
+      let a := self.1.swap ⟨0, h0⟩ ⟨n, hn⟩ |>.pop
+      ⟨⟨heapifyDown lt a ⟨0, by rwa [Array.size_pop, Array.size_swap, e, Nat.add_sub_cancel]⟩⟩,
+        by simp [size]⟩
+    else
+      ⟨⟨self.1.pop⟩, by simp [size]⟩
+
+/-- `O(log n)`. Remove the maximum element from a `BinaryHeap`.
+Call `max` first to actually retrieve the maximum element. -/
+@[inline] def popMax {lt} (self : BinaryHeap α lt) : BinaryHeap α lt := self.popMaxAux
+
+@[simp] theorem size_popMax {lt} (self : BinaryHeap α lt) :
+  self.popMax.size = self.size - 1 := self.popMaxAux.2
+
+/-- `O(log n)`. Return and remove the maximum element from a `BinaryHeap`. -/
+def extractMax {lt} (self : BinaryHeap α lt) : Option α × BinaryHeap α lt :=
+  (self.max, self.popMax)
+
+end BinaryHeap
+
+/-- `O(n)`. Convert an unsorted array to a `BinaryHeap`. -/
+@[inline] def Array.toBinaryHeap (lt : α → α → Bool) (a : Array α) : BinaryHeap α lt where
+  arr := BinaryHeap.mkHeap lt a
+
+/-- `O(n log n)`. Sort an array using a `BinaryHeap`. -/
+@[inline] def Array.heapSort (a : Array α) (lt : α → α → Bool) : Array α :=
+  let gt y x := lt x y
+  let rec loop (a : BinaryHeap α gt) (out : Array α) : Array α :=
+    match e: a.max with
+    | none => out
+    | some x =>
+      have : a.popMax.size < a.size := by
+        simp; refine Nat.sub_lt (Decidable.of_not_not fun h: ¬ 0 < a.1.size => ?_) Nat.zero_lt_one
+        simp [BinaryHeap.max, Array.get?, h] at e
+      loop a.popMax (out.push x)
+  loop (a.toBinaryHeap gt) #[]
+termination_by measure (·.2.2.1.size)
+decreasing_by assumption

--- a/Mathlib/Data/ByteArray.lean
+++ b/Mathlib/Data/ByteArray.lean
@@ -41,8 +41,8 @@ def forIn.loop [Monad m] (f : UInt8 → β → m (ForInStep β))
     | ForInStep.yield b => have := Nat.Up.next h; loop f arr off _end (i+1) b
   else b
 termination_by by
-  iterate 6 refine skipLeft fun _ => ?_
-  exact skipLeft fun _end => generalizeRight (Nat.upRel _end)
+  iterate 6 refine skipLeft' fun _ => ?_
+  exact skipLeft' fun _end => generalizeRight (Nat.upRel _end)
 decreasing_by (iterate 7 apply PSigma.Lex.right); assumption
 
 instance : ForIn m ByteSlice UInt8 :=
@@ -67,7 +67,7 @@ def String.toAsciiByteArray (s : String) : ByteArray :=
       ⟨Nat.lt_add_of_pos_right (String.csize_pos _), Nat.lt_of_not_le (mt decide_eq_true h)⟩
     loop (s.next p) (out.push c.toUInt8)
   loop 0 ByteArray.empty
-termination_by skipLeft fun s => generalizeRight $ Nat.upRel (utf8ByteSize s)
+termination_by skipLeft' fun s => generalizeRight $ Nat.upRel (utf8ByteSize s)
 decreasing_by apply PSigma.Lex.right; assumption
 
 /-- Convert a byte slice into a string. This does not handle non-ASCII characters correctly:

--- a/Mathlib/Data/ByteArray.lean
+++ b/Mathlib/Data/ByteArray.lean
@@ -1,3 +1,4 @@
+import Mathlib.Init.WF
 import Mathlib.Data.Nat.Basic
 import Mathlib.Data.Char
 import Mathlib.Data.UInt
@@ -30,29 +31,19 @@ def toArray : ByteSlice → ByteArray
 /-- Index into a byte slice. The `getOp` function allows the use of the `buf[i]` notation. -/
 @[inline] def getOp (self : ByteSlice) (idx : Nat) : UInt8 := self.arr.get! (self.off + idx)
 
-/-- Implementation of `forIn.loop`. -/
-partial def forIn.loop.impl [Monad m] (f : UInt8 → β → m (ForInStep β))
+
+/-- The inner loop of the `forIn` implementation for byte slices. -/
+def forIn.loop [Monad m] (f : UInt8 → β → m (ForInStep β))
   (arr : ByteArray) (off _end : Nat) (i : Nat) (b : β) : m β :=
-  if i < _end then do
+  if h : i < _end then do
     match ← f (arr.get! i) b with
     | ForInStep.done b => pure b
-    | ForInStep.yield b => impl f arr off _end (i+1) b
+    | ForInStep.yield b => have := Nat.Up.next h; loop f arr off _end (i+1) b
   else b
-
-set_option codegen false in
-/-- The inner loop of the `forIn` implementation for byte slices. It is defined twice:
-this version is the model, while `forIn.loop.impl` is the version used for code generation. -/
-@[implementedBy forIn.loop.impl]
-def forIn.loop [Monad m] (f : UInt8 → β → m (ForInStep β))
-  (arr : ByteArray) (off _end : Nat) (i : Nat) (b : β) : m β := do
-(Nat.Up.WF _end).fix (x := i) (C := fun _ => ∀ b, m β) (b := b)
-  fun i IH b =>
-    if h : i < _end then do
-      let b ← f (arr.get! i) b
-      match b with
-      | ForInStep.done b => pure b
-      | ForInStep.yield b => IH (i+1) (Nat.Up.next h) b
-    else b
+termination_by by
+  iterate 6 refine skipLeft fun _ => ?_
+  exact skipLeft fun _end => generalizeRight (Nat.upRel _end)
+decreasing_by (iterate 7 apply PSigma.Lex.right); assumption
 
 instance : ForIn m ByteSlice UInt8 :=
   ⟨fun ⟨arr, off, len⟩ b f => forIn.loop f arr off (off + len) off b⟩
@@ -66,31 +57,18 @@ def ByteSliceT.toSlice : ByteSliceT → ByteSlice
 /-- Convert a byte array into a byte slice. -/
 def ByteArray.toSlice (arr : ByteArray) : ByteSlice := ⟨arr, 0, arr.size⟩
 
-/-- Implementation of `String.toAsciiByteArray.loop`. -/
-partial def String.toAsciiByteArray.loop.impl
-  (s : String) (out : ByteArray) (p : Pos) : ByteArray :=
-  if s.atEnd p then out else
-  let c := s.get p
-  impl s (out.push c.toUInt8) (s.next p)
-
-set_option codegen false in
-/-- The inner loop of  `String.toAsciiByteArray`. Because it uses well founded recursion, we have
-to write the compiler version of the implementation separately from the version used for
-reasoning inside lean. -/
-@[implementedBy String.toAsciiByteArray.loop.impl]
-def String.toAsciiByteArray.loop (s : String) (out : ByteArray) (p : Pos) : ByteArray :=
-(Nat.Up.WF (utf8ByteSize s)).fix (x := p) (C := fun _ => ∀ out, ByteArray) (out := out)
-  fun p IH i =>
-    if h : s.atEnd p then out else
-    let c := s.get p
-    IH (s.next p) (out := out.push c.toUInt8)
-      ⟨Nat.lt_add_of_pos_right (String.csize_pos _),
-      Nat.lt_of_not_le (mt decide_eq_true h)⟩
-
 /-- Convert a string of assumed-ASCII characters into a byte array.
 (If any characters are non-ASCII they will be reduced modulo 256.) -/
 def String.toAsciiByteArray (s : String) : ByteArray :=
-  String.toAsciiByteArray.loop s ByteArray.empty 0
+  let rec loop (p : Pos) (out : ByteArray) : ByteArray :=
+    if h : s.atEnd p then out else
+    let c := s.get p
+    have : Nat.Up (utf8ByteSize s) (next s p) p :=
+      ⟨Nat.lt_add_of_pos_right (String.csize_pos _), Nat.lt_of_not_le (mt decide_eq_true h)⟩
+    loop (s.next p) (out.push c.toUInt8)
+  loop 0 ByteArray.empty
+termination_by skipLeft fun s => generalizeRight $ Nat.upRel (utf8ByteSize s)
+decreasing_by apply PSigma.Lex.right; assumption
 
 /-- Convert a byte slice into a string. This does not handle non-ASCII characters correctly:
 every byte will become a unicode character with codepoint < 256. -/

--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -20,19 +20,24 @@ lemma zero_lt_of_lt {a : Nat} : ∀ {x : Nat}, x < a -> 0 < a
 lemma Fin.val_eq_of_lt {n a : Nat} (h : a < n) : (Fin.ofNat' a (zero_lt_of_lt h)).val = a := by
   simp only [Fin.ofNat', Nat.mod_eq_of_lt h]
 
-lemma Fin.modn_def : ∀ (a : Fin n) (m : Nat), a % m = Fin.mk ((a.val % m) % n) (Nat.mod_lt (a.val % m) (a.size_positive))
+lemma Fin.modn_def : ∀ (a : Fin n) (m : Nat),
+  a % m = Fin.mk ((a.val % m) % n) (Nat.mod_lt (a.val % m) (a.size_positive))
 | ⟨a, pa⟩, m => rfl
 
-lemma Fin.mod_def : ∀ (a m : Fin n), a % m = Fin.mk ((a.val % m.val) % n) (Nat.mod_lt (a.val % m.val) (a.size_positive))
+lemma Fin.mod_def : ∀ (a m : Fin n),
+  a % m = Fin.mk ((a.val % m.val) % n) (Nat.mod_lt (a.val % m.val) (a.size_positive))
 | ⟨a, pa⟩, ⟨m, pm⟩ => rfl
 
-lemma Fin.add_def : ∀ (a b : Fin n), a + b = (Fin.mk ((a.val + b.val) % n) (Nat.mod_lt _ (a.size_positive)))
+lemma Fin.add_def : ∀ (a b : Fin n),
+  a + b = (Fin.mk ((a.val + b.val) % n) (Nat.mod_lt _ (a.size_positive)))
 | ⟨a, pa⟩, ⟨b, pb⟩ => rfl
 
-lemma Fin.mul_def : ∀ (a b : Fin n), a * b = (Fin.mk ((a.val * b.val) % n) (Nat.mod_lt _ (a.size_positive)))
+lemma Fin.mul_def : ∀ (a b : Fin n),
+  a * b = (Fin.mk ((a.val * b.val) % n) (Nat.mod_lt _ (a.size_positive)))
 | ⟨a, pa⟩, ⟨b, pb⟩ => rfl
 
-lemma Fin.sub_def : ∀ (a b : Fin n), a - b = (Fin.mk ((a + (n - b)) % n) (Nat.mod_lt _ (a.size_positive)))
+lemma Fin.sub_def : ∀ (a b : Fin n),
+  a - b = (Fin.mk ((a + (n - b)) % n) (Nat.mod_lt _ (a.size_positive)))
 | ⟨a, pa⟩, ⟨b, pb⟩ => rfl
 
 @[simp] lemma Fin.mod_eq (a : Fin n) : a % n = a := by
@@ -64,24 +69,25 @@ instance : Numeric (Fin n) where
   ofNat a := Fin.ofNat' a Fin.size_positive'
 
 instance : AddSemigroup (Fin n) where
-  add_assoc := fun _ _ _ => by
+  add_assoc _ _ _ := by
     apply Fin.eq_of_val_eq
     simp only [Fin.add_def, Nat.mod_add_mod, Nat.add_mod_mod, Nat.add_assoc]
 
 instance : AddCommSemigroup (Fin n) where
-  add_comm := fun _ _ => by
+  add_comm _ _ := by
     apply Fin.eq_of_val_eq
     simp only [Fin.add_def, Nat.add_comm]
 
 instance : Semigroup (Fin n) where
-  mul_assoc := fun a b c => by
+  mul_assoc a b c := by
     apply Fin.eq_of_val_eq
     simp only [Fin.mul_def]
     generalize lhs : ((a.val * b.val) % n * c.val) % n = l
     generalize rhs : a.val * (b.val * c.val % n) % n = r
-    rw [<- Nat.mod_eq_of_lt c.isLt, (Nat.mul_mod (a.val * b.val) c.val n).symm] at lhs
-    rw [<- Nat.mod_eq_of_lt a.isLt, (Nat.mul_mod a.val (b.val * c.val) n).symm, <- Nat.mul_assoc] at rhs
-    rw [<- lhs, <- rhs]
+    rw [← Nat.mod_eq_of_lt c.isLt, (Nat.mul_mod (a.val * b.val) c.val n).symm] at lhs
+    rw [← Nat.mod_eq_of_lt a.isLt, (Nat.mul_mod a.val (b.val * c.val) n).symm,
+        ← Nat.mul_assoc] at rhs
+    rw [← lhs, ← rhs]
 
 @[simp] lemma Fin.zero_def : (0 : Fin n).val = (0 : Nat) :=
   show (Fin.ofNat' 0 Fin.size_positive').val = (0 : Nat) by simp only [Fin.ofNat', Nat.zero_mod]
@@ -95,14 +101,15 @@ theorem Fin.mod_lt : ∀ (i : Fin n) {m : Fin n}, (0 : Fin n) < m → (i % m) < 
     exact Nat.mod_lt _ zero_lt
 
 /- Aux lemma that makes nsmul_succ' easier -/
-protected lemma Fin.nsmuls_eq (x : Nat) : ∀ (a : Fin n), ((Fin.ofNat' x Fin.size_positive') * a) = Fin.ofNat' (x * a.val) Fin.size_positive'
+protected lemma Fin.nsmuls_eq (x : Nat) : ∀ (a : Fin n),
+  ((Fin.ofNat' x Fin.size_positive') * a) = Fin.ofNat' (x * a.val) Fin.size_positive'
 | ⟨a, isLt⟩ => by
   apply Fin.eq_of_val_eq
   simp only [Fin.ofNat', Fin.mul_def]
   generalize hy : x * a % n = y
-  rw [<- Nat.mod_eq_of_lt isLt, <- Nat.mul_mod, hy]
+  rw [← Nat.mod_eq_of_lt isLt, ← Nat.mul_mod, hy]
 
-@[simp] lemma Fin.one_def: (1 : Fin n).val = (1 % n : Nat) :=
+@[simp] lemma Fin.one_def : (1 : Fin n).val = (1 % n : Nat) :=
   show (Fin.ofNat' 1 Fin.size_positive').val = 1 % n by simp [Fin.ofNat']
 
 def Fin.addOverflows? (a b : Fin n) : Bool := n <= a.val + b.val
@@ -132,11 +139,13 @@ def Fin.checkedSub (a b : Fin n) : Option (Fin n) :=
   | (true, _) => none
   | (false, diff) => some (diff)
 
-lemma Fin.checked_add_spec (a b : Fin n) : (Fin.checkedAdd a b).isSome = true <-> a.val + b.val < n := by
+lemma Fin.checked_add_spec (a b : Fin n) :
+  (Fin.checkedAdd a b).isSome = true ↔ a.val + b.val < n := by
   by_cases n <= a.val + b.val <;>
     simp_all [checkedAdd, Option.isSome, overflowingAdd, decide_eq_true, decide_eq_false]
 
-lemma Fin.checked_mul_spec (a b : Fin n) : (Fin.checkedMul a b).isSome = true <-> a.val * b.val < n := by
+lemma Fin.checked_mul_spec (a b : Fin n) :
+  (Fin.checkedMul a b).isSome = true ↔ a.val * b.val < n := by
   simp only [checkedMul, overflowingMul, Option.isSome]
   refine Iff.intro ?mp ?mpr <;> intro h
   case mp =>
@@ -145,7 +154,8 @@ lemma Fin.checked_mul_spec (a b : Fin n) : (Fin.checkedMul a b).isSome = true <-
     case neg => exact Nat.lt_of_not_le hx
   case mpr => simp only [decide_eq_false (Nat.not_le_of_lt h : ¬n <= a.val * b.val)]
 
-lemma Fin.checked_sub_spec (a b : Fin n) : (Fin.checkedSub a b).isSome = true <-> b.val <= a.val := by
+lemma Fin.checked_sub_spec (a b : Fin n) :
+  (Fin.checkedSub a b).isSome = true ↔ b.val <= a.val := by
   simp only [checkedSub, underflowingSub, Option.isSome]
   refine Iff.intro ?mp ?mpr <;> intro h
   case mp =>
@@ -155,22 +165,23 @@ lemma Fin.checked_sub_spec (a b : Fin n) : (Fin.checkedSub a b).isSome = true <-
   case mpr => simp only [decide_eq_false (Nat.not_lt_of_le h : ¬a.val < b.val)]
 
 instance : Semiring (Fin n) :=
-  let add_zero_ : ∀ (a : Fin n), a + 0 = a := fun a => by
+  let add_zero (a : Fin n) : a + 0 = a := by
     apply Fin.eq_of_val_eq
     simp only [Fin.add_def, Fin.zero_def, Nat.add_zero]
     exact Nat.mod_eq_of_lt a.isLt
-  let zero_mul_ : ∀ (x : Fin n), 0 * x = 0 := fun _ => by
+  let zero_mul (x : Fin n) : 0 * x = 0 := by
     apply Fin.eq_of_val_eq
     simp only [Fin.mul_def, Fin.zero_def, Nat.zero_mul, Nat.zero_mod]
-  let mul_add_ : ∀ (a b c : Fin n), a * (b + c) = a * b + a * c := fun a b c => by
+  let mul_add (a b c : Fin n) : a * (b + c) = a * b + a * c := by
     apply Fin.eq_of_val_eq
     simp [Fin.mul_def, Fin.add_def]
     generalize lhs : a.val * ((b.val + c.val) % n) % n = l
-    rw [(Nat.mod_eq_of_lt a.isLt).symm, <- Nat.mul_mod] at lhs
-    rw [<- lhs, Semiring.mul_add]
-  let mul_comm : ∀ (a b : Fin n), a * b = b * a := fun _ _ => by apply Fin.eq_of_val_eq; simp only [Fin.mul_def, Nat.mul_comm]
+    rw [(Nat.mod_eq_of_lt a.isLt).symm, ← Nat.mul_mod] at lhs
+    rw [← lhs, Semiring.mul_add]
+  let mul_comm (a b : Fin n) : a * b = b * a := by
+    apply Fin.eq_of_val_eq; simp only [Fin.mul_def, Nat.mul_comm]
 
-  let mul_one_ : ∀ (a : Fin n), a * 1 = a := fun a => by
+  let mul_one (a : Fin n) : a * 1 = a := by
     apply Fin.eq_of_val_eq
     simp only [Fin.mul_def, Fin.one_def]
     cases n with
@@ -186,8 +197,8 @@ instance : Semiring (Fin n) :=
       | Or.inr h_eq => simp only [h_eq, Nat.mul_one, Nat.mod_eq_of_lt (a.isLt)]
   {
     ofNat_succ := fun _ => by simp [Numeric.ofNat, Fin.ofNat', Fin.add_def]
-    add_zero := add_zero_
-    zero_add := fun _ => by rw [add_comm]; exact add_zero_ _
+    add_zero
+    zero_add := fun _ => by rw [add_comm]; exact add_zero _
     nsmul := fun x a => (Fin.ofNat' x a.size_positive) * a
     nsmul_zero' := fun _ => by
       apply Fin.eq_of_val_eq
@@ -196,15 +207,15 @@ instance : Semiring (Fin n) :=
       simp only [Fin.nsmuls_eq]
       simp [Fin.ofNat', Fin.add_def]
       exact congrArg (fun x => x % n) (Nat.add_comm (x * a.val) (a.val) ▸ Nat.succ_mul x a.val)
-    zero_mul := zero_mul_
-    mul_zero := fun _ => by rw [mul_comm]; exact zero_mul_ _
-    mul_one := mul_one_
-    one_mul := fun _ => by rw [mul_comm]; exact mul_one_ _
+    zero_mul
+    mul_zero := fun _ => by rw [mul_comm]; exact zero_mul _
+    mul_one
+    one_mul := fun _ => by rw [mul_comm]; exact mul_one _
     npow_zero' := fun _ => rfl
     npow_succ' := fun _ _ => rfl
-    mul_add := mul_add_
+    mul_add
     add_mul := fun a b c => by
-      have h0 := mul_add_ c a b
+      have h0 := mul_add c a b
       have h1 : (a + b) * c = c * (a + b) := mul_comm (a + b) c
       have h2 : a * c = c * a := mul_comm a _
       have h3 : b * c = c * b := mul_comm b _
@@ -215,9 +226,10 @@ instance : Neg (Fin n) where
   neg a := ⟨(n - a) % n, Nat.mod_lt _ (lt_of_le_of_lt (Nat.zero_le _) a.isLt)⟩
 
 instance : Ring (Fin n) :=
-  let sub_eq_add_neg_ : ∀ (a b : Fin n), a - b = a + -b := fun _ _ => by simp [Fin.add_def, Fin.sub_def, Neg.neg]
+  let sub_eq_add_neg :∀ (a b : Fin n), a - b = a + -b := by
+    simp [Fin.add_def, Fin.sub_def, Neg.neg]
   {
-    sub_eq_add_neg := sub_eq_add_neg_
+    sub_eq_add_neg
     gsmul := fun x a =>
       match x with
       | Int.ofNat x' => Semiring.nsmul x' a
@@ -228,12 +240,18 @@ instance : Ring (Fin n) :=
     gsmul_succ' := by simp [Semiring.nsmul_succ']
     gsmul_neg' := by simp [Semiring.nsmul]
     add_left_neg := fun a => by
-      rw [add_comm, <- sub_eq_add_neg_]
+      rw [add_comm, ← sub_eq_add_neg]
       apply Fin.eq_of_val_eq
       simp [Fin.sub_def, (Nat.add_sub_cancel' (Nat.le_of_lt a.isLt)), Nat.mod_self]
   }
 
 instance : CommRing (Fin n) where
-  mul_comm := fun _ _ => by apply Fin.eq_of_val_eq; simp only [Fin.mul_def, Nat.mul_comm]
+  mul_comm _ _ := by apply Fin.eq_of_val_eq; simp only [Fin.mul_def, Nat.mul_comm]
+
+lemma Fin.gt_wf : WellFounded (fun a b : Fin n => b < a) :=
+  Subrelation.wf (@fun a i h => ⟨h, i.2⟩) (invImage (fun i => i.1) (Nat.upRel n)).wf
+
+/-- A well-ordered relation for "upwards" induction on `Fin n`. -/
+def Fin.upRel (n : ℕ) : WellFoundedRelation (Fin n) := ⟨_, gt_wf⟩
 
 end Fin

--- a/Mathlib/Data/Nat/Basic.lean
+++ b/Mathlib/Data/Nat/Basic.lean
@@ -96,12 +96,15 @@ lemma mul_div_le (m n : ℕ) : n * (m / n) ≤ m := by
 
 /- Up -/
 
-/-- A well-ordered relation for "upwards" induction on the ℕural numbers up to some bound `ub`. -/
+/-- A well-ordered relation for "upwards" induction on the natural numbers up to some bound `ub`. -/
 def Up (ub a i : ℕ) := i < a ∧ i < ub
 
 lemma Up.next {ub i} (h : i < ub) : Up ub (i+1) i := ⟨Nat.lt_succ_self _, h⟩
 
 lemma Up.WF (ub) : WellFounded (Up ub) :=
   Subrelation.wf (h₂ := (measure (ub - .)).wf) @fun a i ⟨ia, iu⟩ => Nat.sub_lt_sub_left iu ia
+
+/-- A well-ordered relation for "upwards" induction on the natural numbers up to some bound `ub`. -/
+def upRel (ub : ℕ) : WellFoundedRelation Nat := ⟨Up ub, Up.WF ub⟩
 
 end Nat

--- a/Mathlib/Init/WF.lean
+++ b/Mathlib/Init/WF.lean
@@ -1,0 +1,12 @@
+
+noncomputable def skipLeft {β : α → Sort _}
+  (w : (a : α) → WellFoundedRelation (β a)) : WellFoundedRelation ((a : α) ×' β a) :=
+  ⟨_, PSigma.lex emptyWf.2 fun b => (w b).2⟩
+
+noncomputable def generalizeRight {β : α → Sort _}
+  (w : WellFoundedRelation α) : WellFoundedRelation ((a : α) ×' β a) :=
+  invImage PSigma.fst w
+
+noncomputable def generalizeLeft
+  (w : WellFoundedRelation β) : WellFoundedRelation ((a : α) ×' β) :=
+  invImage PSigma.snd w

--- a/Mathlib/Init/WF.lean
+++ b/Mathlib/Init/WF.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
 
-noncomputable def skipLeft {β : α → Sort _}
+noncomputable def skipLeft' {β : α → Sort _}
   (w : (a : α) → WellFoundedRelation (β a)) : WellFoundedRelation ((a : α) ×' β a) :=
   ⟨_, PSigma.lex emptyWf.2 fun b => (w b).2⟩
 

--- a/Mathlib/Init/WF.lean
+++ b/Mathlib/Init/WF.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2021 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro
+-/
 
 noncomputable def skipLeft {β : α → Sort _}
   (w : (a : α) → WellFoundedRelation (β a)) : WellFoundedRelation ((a : α) ×' β a) :=


### PR DESCRIPTION
The main addition is a type `BinaryHeap α lt` of binary max-heaps stored in an array.

Also some cleanup:

* Fix line length and formatting in `Data.Fin.Basic`
* Add `Mathlib.Init.WF` for some more tools for proving well foundedness
* Use `termination_by` instead of manual termination compilation for `String.toAsciiByteArray` and `ByteSlice.forIn`

I originally wrote `heapifyDown` et al without the embedded postcondition, but proving facts about definitions like `heapifyDown` is incredibly painful right now.