### PR TITLE
feat: porting Data.List.Defs, Init.Data.List.Basic

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -17,6 +17,8 @@ import Mathlib.Data.List.Defs
 import Mathlib.Data.List.Perm
 import Mathlib.Data.Nat.Basic
 import Mathlib.Data.Nat.Gcd
+import Mathlib.Data.Option.Basic
+import Mathlib.Data.Option.Defs
 import Mathlib.Data.Prod
 import Mathlib.Data.String.Defs
 import Mathlib.Data.String.Lemmas
@@ -27,8 +29,11 @@ import Mathlib.Init.Algebra.Order
 import Mathlib.Init.Data.Int.Basic
 import Mathlib.Init.Data.List.Basic
 import Mathlib.Init.Data.List.Instances
+import Mathlib.Init.Data.List.Lemmas
 import Mathlib.Init.Data.Nat.Basic
 import Mathlib.Init.Data.Nat.Lemmas
+import Mathlib.Init.Data.Option.Basic
+import Mathlib.Init.Data.Option.Instances
 import Mathlib.Init.Dvd
 import Mathlib.Init.ExtendedBinder
 import Mathlib.Init.Function

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -25,6 +25,8 @@ import Mathlib.Data.UInt
 import Mathlib.Init.Algebra.Functions
 import Mathlib.Init.Algebra.Order
 import Mathlib.Init.Data.Int.Basic
+import Mathlib.Init.Data.List.Basic
+import Mathlib.Init.Data.List.Instances
 import Mathlib.Init.Data.Nat.Basic
 import Mathlib.Init.Data.Nat.Lemmas
 import Mathlib.Init.Dvd

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -715,10 +715,10 @@ section insert
 variable [DecidableEq α]
 
 @[simp] theorem insert_of_mem {a : α} {l : List α} (h : a ∈ l) : insert a l = l := by
-  simp only [insert, ite_true, h]
+  simp only [insert, if_pos h]
 
 @[simp] theorem insert_of_not_mem {a : α} {l : List α} (h : a ∉ l) : insert a l = a :: l := by
-  simp only [insert, ite_false, h]
+  simp only [insert, if_neg h]
 
 @[simp] theorem mem_insert_iff {a b : α} {l : List α} : a ∈ insert b l ↔ a = b ∨ a ∈ l := by
   byCases h : b ∈ l

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -769,22 +769,22 @@ theorem modifyNthTail_length (f : List α → List α) (H : ∀ l, length (f l) 
 @[simp] theorem modify_get?_length (f : α → α) : ∀ n l, length (modifyNth f n l) = length l :=
   modifyNthTail_length _ fun l => by cases l <;> rfl
 
-@[simp] theorem nth_modifyNth_eq (f : α → α) (n) (l : List α) :
+@[simp] theorem get?_modifyNth_eq (f : α → α) (n) (l : List α) :
   (modifyNth f n l).get? n = f <$> l.get? n := by
   simp only [get?_modifyNth, if_pos]
 
-@[simp] theorem nth_modifyNth_ne (f : α → α) {m n} (l : List α) (h : m ≠ n) :
+@[simp] theorem get?_modifyNth_ne (f : α → α) {m n} (l : List α) (h : m ≠ n) :
   (modifyNth f m l).get? n = l.get? n := by
   simp only [get?_modifyNth, if_neg h, id_map']
 
-theorem nth_set_eq (a : α) n (l : List α) : (set l n a).get? n = (fun _ => a) <$> l.get? n := by
-  simp only [set_eq_modifyNth, nth_modifyNth_eq]
+theorem get?_set_eq (a : α) (n) (l : List α) : (set l n a).get? n = (fun _ => a) <$> l.get? n := by
+  simp only [set_eq_modifyNth, get?_modifyNth_eq]
 
-theorem nth_set_of_lt (a : α) {n} {l : List α} (h : n < length l) :
-  (set l n a).get? n = some a := by rw [nth_set_eq, get?_eq_get h]; rfl
+theorem get?_set_of_lt (a : α) {n} {l : List α} (h : n < length l) :
+  (set l n a).get? n = some a := by rw [get?_set_eq, get?_eq_get h]; rfl
 
-theorem nth_set_ne (a : α) {m n} (l : List α) (h : m ≠ n) : (set l m a).get? n = l.get? n := by
-  simp only [set_eq_modifyNth, nth_modifyNth_ne _ _ h]
+theorem get?_set_ne (a : α) {m n} (l : List α) (h : m ≠ n) : (set l m a).get? n = l.get? n := by
+  simp only [set_eq_modifyNth, get?_modifyNth_ne _ _ h]
 
 @[simp] theorem set_nil (n : ℕ) (a : α) : [].set n a = [] := rfl
 
@@ -804,12 +804,12 @@ theorem set_comm (a b : α) : ∀ {n m : ℕ} (l : List α) (h : n ≠ m),
 
 @[simp] theorem get_set_eq (l : List α) (i : ℕ) (a : α) (h : i < (l.set i a).length) :
   (l.set i a).get i h = a := by
-  rw [← Option.some_inj, ← get?_eq_get, nth_set_eq, get?_eq_get] <;> simp_all
+  rw [← Option.some_inj, ← get?_eq_get, get?_set_eq, get?_eq_get] <;> simp_all
 
-@[simp] theorem get_set_of_ne {l : List α} {i j : ℕ} (h : i ≠ j) (a : α)
+@[simp] theorem get_set_ne {l : List α} {i j : ℕ} (h : i ≠ j) (a : α)
   (hj : j < (l.set i a).length) :
   (l.set i a).get j hj = l.get j (by simp at hj; exact hj) := by
-  rw [← Option.some_inj, ← List.get?_eq_get, List.nth_set_ne _ _ h, List.get?_eq_get]
+  rw [← Option.some_inj, ← List.get?_eq_get, List.get?_set_ne _ _ h, List.get?_eq_get]
 
 theorem mem_or_eq_of_mem_set : ∀ {l : List α} {n : ℕ} {a b : α} h : a ∈ l.set n b, a ∈ l ∨ a = b
 | [], n, a, b, h => False.elim h

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -531,7 +531,7 @@ theorem map_eq_append_split {f : α → β} {l : List α} {s₁ s₂ : List β}
 
 /-! ### repeat -/
 
-@[simp] theorem repeat_succ (a : α) n : repeat a (n+1) = a :: repeat a n := rfl
+theorem repeat_succ (a : α) n : repeat a (n+1) = a :: repeat a n := rfl
 
 theorem mem_repeat {a b : α} : ∀ {n}, b ∈ repeat a n ↔ n ≠ 0 ∧ b = a
 | 0 => by simp
@@ -542,12 +542,11 @@ theorem eq_of_mem_repeat {a b : α} {n} (h : b ∈ repeat a n) : b = a :=
 
 /-! ### last -/
 
-@[simp] theorem last_cons {a : α} {l : List α} : ∀ (h₁ : a :: l ≠ nil) (h₂ : l ≠ nil),
+theorem last_cons {a : α} {l : List α} : ∀ (h₁ : a :: l ≠ nil) (h₂ : l ≠ nil),
   last (a :: l) h₁ = last l h₂ := by
   induction l <;> intros; {contradiction}; rfl
 
-@[simp]
-theorem last_append {a : α} : ∀ (l : List α) (h : l ++ [a] ≠ []), last (l ++ [a]) h = a
+@[simp] theorem last_append {a : α} : ∀ (l : List α) (h : l ++ [a] ≠ []), last (l ++ [a]) h = a
 | [], _ => rfl
 | a::t, h => by
   show last (_ :: (_ ++ _)) _ = _
@@ -556,7 +555,7 @@ theorem last_append {a : α} : ∀ (l : List α) (h : l ++ [a] ≠ []), last (l 
 theorem last_concat {a : α} (l : List α) : (h : concat l a ≠ []) → last (concat l a) h = a := by
   rw [concat_eq_append]; apply last_append
 
-@[simp] theorem last_singleton (a : α) (h : [a] ≠ []) : last [a] h = a := rfl
+theorem last_singleton (a : α) (h : [a] ≠ []) : last [a] h = a := rfl
 
 /-! ### nth element -/
 
@@ -769,9 +768,6 @@ theorem modifyNthTail_length (f : List α → List α) (H : ∀ l, length (f l) 
 
 @[simp] theorem modify_get?_length (f : α → α) : ∀ n l, length (modifyNth f n l) = length l :=
   modifyNthTail_length _ fun l => by cases l <;> rfl
-
-@[simp] theorem update_getngth (l : List α) n (a : α) : length (set l n a) = length l := by
-  simp only [set_eq_modifyNth, modify_get?_length]
 
 @[simp] theorem nth_modifyNth_eq (f : α → α) (n) (l : List α) :
   (modifyNth f n l).get? n = f <$> l.get? n := by

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -63,9 +63,9 @@ def modifyLast (f : α → α) : List α → List α
 | [x] => [f x]
 | x :: xs => x :: modifyLast f xs
 
-/-- `insert_nth n a l` inserts `a` into the list `l` after the first `n` elements of `l`
- `insert_nth 2 1 [1, 2, 3, 4] = [1, 2, 1, 3, 4]`-/
-def insert_nth (n : ℕ) (a : α) : List α → List α :=
+/-- `insertNth n a l` inserts `a` into the list `l` after the first `n` elements of `l`
+ `insertNth 2 1 [1, 2, 3, 4] = [1, 2, 1, 3, 4]`-/
+def insertNth (n : ℕ) (a : α) : List α → List α :=
   modifyNthTail (cons a) n
 
 /-- Take `n` elements from a list `l`. If `l` has less than `n` elements, append `n - length l`
@@ -304,7 +304,7 @@ def ofFnAux {n} (f : Fin n → α) : ∀ m, m ≤ n → List α → List α
 | m+1, h, l => ofFnAux f m (Nat.le_of_lt h) (f ⟨m, h⟩ :: l)
 
 /-- `ofFn f` with `f : fin n → α` returns the list whose ith element is `f i`
-  `of_fun f = [f 0, f 1, ... , f(n - 1)]` -/
+  `ofFn f = [f 0, f 1, ... , f(n - 1)]` -/
 def ofFn {n} (f : Fin n → α) : List α :=
   ofFnAux f n (Nat.le_refl _) []
 

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Parikshit Khanna, Jeremy Avigad, Leonardo de Moura, Floris van Doorn, Mario Carneiro
 -/
 import Lean
+import Mathlib.Init.Data.List.Instances
 import Mathlib.Init.Data.Nat.Basic
 
 /-!
@@ -15,24 +16,693 @@ proofs about these definitions, those are contained in other files in `Mathlib.D
 
 namespace List
 
-/-- Given a function `f : ℕ → α → β` and `as : list α`, `as = [a₀, a₁, ...]`, returns the list
-`[f 0 a₀, f 1 a₁, ...]`. -/
-def mapIdx (as : List α) (f : ℕ → α → β) : List β :=
-  let rec loop : ℕ → List α → List β
-  | _,  [] => []
-  | n, a :: as => f n a :: loop (n + 1) as
-  loop 0 as
+/-- Split a list at an index.
+     splitAt 2 [a, b, c] = ([a, b], [c]) -/
+def splitAt : ℕ → List α → List α × List α
+| 0, a => ([], a)
+| n+1, [] => ([], [])
+| n+1, x :: xs => let (l, r) := splitAt n xs; (x :: l, r)
 
-/-- Applicative variant of `mapWithIndex`. -/
-def mapIdxM {m : Type v → Type w} [Applicative m] (as : List α) (f : ℕ → α → m β) :
-  m (List β) :=
-  let rec loop : ℕ → List α → m (List β)
-  | _,  [] => []
-  | n, a :: as => List.cons <$> f n a <*> loop (n + 1) as
-  loop 0 as
+/-- An auxiliary function for `splitOnP`. -/
+def splitOnPAux {α : Type u} (P : α → Prop) [DecidablePred P] : List α → (List α → List α) → List (List α)
+| [], f => [f []]
+| h :: t, f => if P h then f [] :: splitOnPAux P t id else splitOnPAux P t fun l => f (h :: l)
+
+/-- Split a list at every element satisfying a predicate. -/
+def splitOnP {α : Type u} (P : α → Prop) [DecidablePred P] (l : List α) : List (List α) :=
+  splitOnPAux P l id
+
+/-- Split a list at every occurrence of an element.
+    [1,1,2,3,2,4,4].split_on 2 = [[1,1],[3],[4,4]] -/
+def splitOn {α : Type u} [DecidableEq α] (a : α) (as : List α) : List (List α) :=
+  as.splitOnP (· = a)
+
+/-- Apply a function to the nth tail of `l`. Returns the input without
+  using `f` if the index is larger than the length of the List.
+     modifyNthTail f 2 [a, b, c] = [a, b] ++ f [c] -/
+@[simp]
+def modifyNthTail (f : List α → List α) : ℕ → List α → List α
+| 0, l => f l
+| n+1, [] => []
+| n+1, a :: l => a :: modifyNthTail f n l
+
+/-- Apply `f` to the head of the list, if it exists. -/
+@[simp]
+def modifyHead (f : α → α) : List α → List α
+| [] => []
+| a :: l => f a :: l
+
+/-- Apply `f` to the nth element of the list, if it exists. -/
+def modifyNth (f : α → α) : ℕ → List α → List α :=
+  modifyNthTail (modifyHead f)
+
+/-- Apply `f` to the last element of `l`, if it exists. -/
+@[simp]
+def modifyLast (f : α → α) : List α → List α
+| [] => []
+| [x] => [f x]
+| x :: xs => x :: modifyLast f xs
+
+/-- `insert_nth n a l` inserts `a` into the list `l` after the first `n` elements of `l`
+ `insert_nth 2 1 [1, 2, 3, 4] = [1, 2, 1, 3, 4]`-/
+def insert_nth (n : ℕ) (a : α) : List α → List α :=
+  modifyNthTail (cons a) n
+
+/-- Take `n` elements from a list `l`. If `l` has less than `n` elements, append `n - length l`
+elements `x`. -/
+def takeD : ∀ n : ℕ, List α → α → List α
+| 0, l, _ => []
+| n+1, l, x => l.headD x :: takeD n l.tail x
+
+/-- Fold a function `f` over the list from the left, returning the list
+  of partial results.
+     scanl (+) 0 [1, 2, 3] = [0, 1, 3, 6] -/
+def scanl (f : α → β → α) : α → List β → List α
+| a, [] => [a]
+| a, b :: l => a :: scanl f (f a b) l
+
+/-- Auxiliary definition used to define `scanr`. If `scanrAux f b l = (b', l')`
+then `scanr f b l = b' :: l'` -/
+def scanrAux (f : α → β → β) (b : β) : List α → β × List β
+| [] => (b, [])
+| a :: l =>
+  let (b', l') := scanrAux f b l
+  (f a b', b' :: l')
+
+/-- Fold a function `f` over the list from the right, returning the list
+  of partial results.
+     scanr (+) 0 [1, 2, 3] = [6, 5, 3, 0] -/
+def scanr (f : α → β → β) (b : β) (l : List α) : List β :=
+  let (b', l') := scanrAux f b l
+  b' :: l'
+
+/-- Given a function `f : α → β ⊕ γ`, `partitionMap f l` maps the list by `f`
+  whilst partitioning the result it into a pair of lists, `list β × list γ`,
+  partitioning the `sum.inl _` into the left list, and the `sum.inr _` into the right List.
+  `partitionMap (id : ℕ ⊕ ℕ → ℕ ⊕ ℕ) [inl 0, inr 1, inl 2] = ([0,2], [1])`    -/
+def partitionMap (f : α → β ⊕ γ) : List α → List β × List γ
+| [] => ([], [])
+| x :: xs =>
+  match f x with
+  | Sum.inr r => Prod.map id (cons r) $ partitionMap f xs
+  | Sum.inl l => Prod.map (cons l) id $ partitionMap f xs
+
+/-- `find p l` is the first element of `l` satisfying `p`, or `none` if no such
+  element exists. -/
+def find (p : α → Prop) [DecidablePred p] : List α → Option α
+| [] => none
+| a :: l => if p a then some a else find p l
+
+/-- Auxiliary definition for `foldlIdx`. -/
+def foldlIdxAux (f : ℕ → α → β → α) : ℕ → α → List β → α
+| _, a, [] => a
+| i, a, b :: l => foldlIdxAux f (i+1) (f i a b) l
+
+/-- Fold a list from left to right as with `foldl`, but the combining function
+also receives each element's index. -/
+def foldlIdx (f : ℕ → α → β → α) (a : α) (l : List β) : α :=
+  foldlIdxAux f 0 a l
+
+/-- Auxiliary definition for `foldrIdx`. -/
+def foldrIdxAux (f : ℕ → α → β → β) : ℕ → β → List α → β
+| _, b, [] => b
+| i, b, a :: l => f i a (foldrIdxAux f (i+1) b l)
+
+/-- Fold a list from right to left as with `foldr`, but the combining function
+also receives each element's index. -/
+def foldrIdx (f : ℕ → α → β → β) (b : β) (l : List α) : β :=
+  foldrIdxAux f 0 b l
+
+/-- `findIdxs p l` is the list of indexes of elements of `l` that satisfy `p`. -/
+def findIdxs (p : α → Prop) [DecidablePred p] (l : List α) : List Nat :=
+  foldrIdx (fun i a is => if p a then i :: is else is) [] l
+
+/-- Returns the elements of `l` that satisfy `p` together with their indexes in
+`l`. The returned list is ordered by index. -/
+def indexesValues (p : α → Prop) [DecidablePred p] (l : List α) : List (ℕ × α) :=
+  foldrIdx (fun i a l => if p a then (i, a) :: l else l) [] l
+
+/-- `indexesOf a l` is the list of all indexes of `a` in `l`. For example:
+```
+indexesOf a [a, b, a, a] = [0, 2, 3]
+```
+-/
+def indexesOf [DecidableEq α] (a : α) : List α → List Nat :=
+  findIdxs (Eq a)
+
+/-- `lookmap` is a combination of `lookup` and `filterMap`.
+  `lookmap f l` will apply `f : α → option α` to each element of the list,
+  replacing `a → b` at the first value `a` in the list such that `f a = some b`. -/
+def lookmap (f : α → Option α) : List α → List α
+| [] => []
+| a :: l =>
+  match f a with
+  | some b => b :: l
+  | none => a :: lookmap f l
+
+/-- `countp p l` is the number of elements of `l` that satisfy `p`. -/
+def countp (p : α → Prop) [DecidablePred p] : List α → Nat
+| [] => 0
+| x :: xs => if p x then countp p xs + 1 else countp p xs
+
+/-- `count a l` is the number of occurrences of `a` in `l`. -/
+def count [DecidableEq α] (a : α) : List α → Nat :=
+  countp (Eq a)
+
+/-- `isPrefix l₁ l₂`, or `l₁ <+: l₂`, means that `l₁` is a prefix of `l₂`,
+  that is, `l₂` has the form `l₁ ++ t` for some `t`. -/
+def isPrefix (l₁ : List α) (l₂ : List α) : Prop :=
+  ∃ t, l₁ ++ t = l₂
+
+/-- `isSuffix l₁ l₂`, or `l₁ <:+ l₂`, means that `l₁` is a suffix of `l₂`,
+  that is, `l₂` has the form `t ++ l₁` for some `t`. -/
+def isSuffix (l₁ : List α) (l₂ : List α) : Prop :=
+  ∃ t, t ++ l₁ = l₂
+
+/-- `isInfix l₁ l₂`, or `l₁ <:+: l₂`, means that `l₁` is a contiguous
+  substring of `l₂`, that is, `l₂` has the form `s ++ l₁ ++ t` for some `s, t`. -/
+def isInfix (l₁ : List α) (l₂ : List α) : Prop :=
+  ∃ s t, s ++ l₁ ++ t = l₂
+
+infixl:50 " <+: " => isPrefix
+
+infixl:50 " <:+ " => isSuffix
+
+infixl:50 " <:+: " => isInfix
+
+/-- `inits l` is the list of initial segments of `l`.
+     inits [1, 2, 3] = [[], [1], [1, 2], [1, 2, 3]] -/
+@[simp] def inits : List α → List (List α)
+| [] => [[]]
+| a :: l => [] :: map (fun t => a :: t) (inits l)
+
+/-- `tails l` is the list of terminal segments of `l`.
+     tails [1, 2, 3] = [[1, 2, 3], [2, 3], [3], []] -/
+@[simp] def tails : List α → List (List α)
+| [] => [[]]
+| a :: l => (a :: l) :: tails l
+
+def sublists'Aux : List α → (List α → List β) → List (List β) → List (List β)
+| [], f, r => f [] :: r
+| a :: l, f, r => sublists'Aux l f (sublists'Aux l (f ∘ cons a) r)
+
+/-- `sublists' l` is the list of all (non-contiguous) sublists of `l`.
+  It differs from `sublists` only in the order of appearance of the sublists;
+  `sublists'` uses the first element of the list as the MSB,
+  `sublists` uses the first element of the list as the LSB.
+     sublists' [1, 2, 3] = [[], [3], [2], [2, 3], [1], [1, 3], [1, 2], [1, 2, 3]] -/
+def sublists' (l : List α) : List (List α) :=
+  sublists'Aux l id []
+
+def sublistsAux : List α → (List α → List β → List β) → List β
+| [], f => []
+| a :: l, f => f [a] (sublistsAux l fun ys r => f ys (f (a :: ys) r))
+
+/-- `sublists l` is the list of all (non-contiguous) sublists of `l`; cf. `sublists'`
+  for a different ordering.
+     sublists [1, 2, 3] = [[], [1], [2], [1, 2], [3], [1, 3], [2, 3], [1, 2, 3]] -/
+def sublists (l : List α) : List (List α) :=
+  [] :: sublistsAux l cons
+
+def sublistsAux₁ : List α → (List α → List β) → List β
+| [], f => []
+| a :: l, f => f [a] ++ sublistsAux₁ l fun ys => f ys ++ f (a :: ys)
+
+section Forall₂
+
+variable {r : α → β → Prop} {p : γ → δ → Prop}
+
+/-- `Forall₂ R l₁ l₂` means that `l₁` and `l₂` have the same length,
+  and whenever `a` is the nth element of `l₁`, and `b` is the nth element of `l₂`,
+  then `R a b` is satisfied. -/
+inductive Forall₂ (R : α → β → Prop) : List α → List β → Prop
+  | nil : Forall₂ R [] []
+  | cons {a b l₁ l₂} : R a b → Forall₂ R l₁ l₂ → Forall₂ R (a :: l₁) (b :: l₂)
+
+attribute [simp] Forall₂.nil
+
+end Forall₂
+
+/-- Auxiliary definition used to define `transpose`.
+  `transposeAux l L` takes each element of `l` and appends it to the start of
+  each element of `L`.
+  `transposeAux [a, b, c] [l₁, l₂, l₃] = [a::l₁, b::l₂, c::l₃]` -/
+def transposeAux : List α → List (List α) → List (List α)
+| [], ls => ls
+| a :: i, [] => [a] :: transposeAux i []
+| a :: i, l :: ls => (a :: l) :: transposeAux i ls
+
+/-- transpose of a list of lists, treated as a matrix.
+     transpose [[1, 2], [3, 4], [5, 6]] = [[1, 3, 5], [2, 4, 6]] -/
+def transpose : List (List α) → List (List α)
+| [] => []
+| l :: ls => transposeAux l (transpose ls)
+
+/-- List of all sections through a list of lists. A section
+  of `[L₁, L₂, ..., Lₙ]` is a list whose first element comes from
+  `L₁`, whose second element comes from `L₂`, and so on. -/
+def sections : List (List α) → List (List α)
+| [] => [[]]
+| l :: L => (sections L).bind fun s => l.map fun a => a :: s
+
+/-- `erasep p l` removes the first element of `l` satisfying the predicate `p`. -/
+def erasep (p : α → Prop) [DecidablePred p] : List α → List α
+| [] => []
+| a :: l => if p a then l else a :: erasep p l
+
+/-- `extractp p l` returns a pair of an element `a` of `l` satisfying the predicate
+  `p`, and `l`, with `a` removed. If there is no such element `a` it returns `(none, l)`. -/
+def extractp (p : α → Prop) [DecidablePred p] : List α → Option α × List α
+| [] => (none, [])
+| a :: l =>
+  if p a then (some a, l) else
+    let (a', l') := extractp p l
+    (a', a :: l')
+
+/-- `revzip l` returns a list of pairs of the elements of `l` paired
+  with the elements of `l` in reverse order.
+`revzip [1,2,3,4,5] = [(1, 5), (2, 4), (3, 3), (4, 2), (5, 1)]`
+ -/
+def revzip (l : List α) : List (α × α) :=
+  zip l l.reverse
+
+/-- `product l₁ l₂` is the list of pairs `(a, b)` where `a ∈ l₁` and `b ∈ l₂`.
+     product [1, 2] [5, 6] = [(1, 5), (1, 6), (2, 5), (2, 6)] -/
+def product (l₁ : List α) (l₂ : List β) : List (α × β) :=
+  l₁.bind $ fun a => l₂.map $ Prod.mk a
+
+/-- `sigma l₁ l₂` is the list of dependent pairs `(a, b)` where `a ∈ l₁` and `b ∈ l₂ a`.
+     sigma [1, 2] (λ_, [(5 : ℕ), 6]) = [(1, 5), (1, 6), (2, 5), (2, 6)] -/
+protected def sigma {σ : α → Type _} (l₁ : List α) (l₂ : ∀ a, List (σ a)) : List (Σ a, σ a) :=
+  l₁.bind $ fun a => (l₂ a).map $ Sigma.mk a
+
+/-- Auxliary definition used to define `ofFn`.
+  `ofFnAux f m h l` returns the first `m` elements of `ofFn f`
+  appended to `l` -/
+def ofFnAux {n} (f : Fin n → α) : ∀ m, m ≤ n → List α → List α
+| 0, h, l => l
+| m+1, h, l => ofFnAux f m (Nat.le_of_lt h) (f ⟨m, h⟩ :: l)
+
+/-- `ofFn f` with `f : fin n → α` returns the list whose ith element is `f i`
+  `of_fun f = [f 0, f 1, ... , f(n - 1)]` -/
+def ofFn {n} (f : Fin n → α) : List α :=
+  ofFnAux f n (Nat.le_refl _) []
+
+/-- `ofFnNthVal f i` returns `some (f i)` if `i < n` and `none` otherwise. -/
+def ofFnNthVal {n} (f : Fin n → α) (i : ℕ) : Option α :=
+  if h : i < n then some (f ⟨i, h⟩) else none
+
+/-- `disjoint l₁ l₂` means that `l₁` and `l₂` have no elements in common. -/
+def disjoint (l₁ l₂ : List α) : Prop :=
+  ∀ ⦃a⦄, a ∈ l₁ → a ∈ l₂ → False
+
+section Pairwise
+
+variable (R : α → α → Prop)
+
+-- ././Mathport/Syntax/Translate/Basic.lean:452:2: warning: expanding binder collection (a' «expr ∈ » l)
+/-- `Pairwise R l` means that all the elements with earlier indexes are
+  `R`-related to all the elements with later indexes.
+     Pairwise R [1, 2, 3] ↔ R 1 2 ∧ R 1 3 ∧ R 2 3
+  For example if `R = (≠)` then it asserts `l` has no duplicates,
+  and if `R = (<)` then it asserts that `l` is (strictly) sorted. -/
+inductive Pairwise : List α → Prop
+  | nil : Pairwise []
+  | cons : ∀ {a : α} {l : List α}, (∀ a' ∈ l, R a a') → Pairwise l → Pairwise (a :: l)
+
+end Pairwise
+
+-- ././Mathport/Syntax/Translate/Basic.lean:452:2: warning: expanding binder collection (y «expr ∈ » IH)
+/-- `pwFilter R l` is a maximal sublist of `l` which is `Pairwise R`.
+  `pwFilter (≠)` is the erase duplicates function (cf. `eraseDup`), and `pwFilter (<)` finds
+  a maximal increasing subsequence in `l`. For example,
+     pwFilter (<) [0, 1, 5, 2, 6, 3, 4] = [0, 1, 2, 3, 4] -/
+def pwFilter (R : α → α → Prop) [DecidableRel R] : List α → List α
+| [] => []
+| x :: xs =>
+  let IH := pwFilter R xs
+  if ∀ y ∈ IH, R x y then x :: IH else IH
+
+section Chain
+
+variable (R : α → α → Prop)
+
+/-- `Chain R a l` means that `R` holds between adjacent elements of `a::l`.
+     Chain R a [b, c, d] ↔ R a b ∧ R b c ∧ R c d -/
+inductive Chain : α → List α → Prop
+  | nil {a : α} : Chain a []
+  | cons : ∀ {a b : α} {l : List α}, R a b → Chain b l → Chain a (b :: l)
+
+/-- `Chain' R l` means that `R` holds between adjacent elements of `l`.
+     Chain' R [a, b, c, d] ↔ R a b ∧ R b c ∧ R c d -/
+def Chain' : List α → Prop
+| [] => True
+| a :: l => Chain R a l
+
+end Chain
+
+/-- `Nodup l` means that `l` has no duplicates, that is, any element appears at most
+  once in the List. It is defined as `Pairwise (≠)`. -/
+def Nodup : List α → Prop :=
+  Pairwise (· ≠ ·)
+
+/-- `eraseDup l` removes duplicates from `l` (taking only the first occurrence).
+  Defined as `pwFilter (≠)`.
+     eraseDup [1, 0, 2, 2, 1] = [0, 2, 1] -/
+def eraseDup [DecidableEq α] : List α → List α :=
+  pwFilter (· ≠ ·)
+
+/-- `range' s n` is the list of numbers `[s, s+1, ..., s+n-1]`.
+  It is intended mainly for proving properties of `range` and `iota`. -/
+@[simp]
+def range' : ℕ → ℕ → List ℕ
+| s, 0 => []
+| s, n+1 => s :: range' (s+1) n
 
 /-- Drop `none`s from a list, and replace each remaining `some a` with `a`. -/
-def reduceOption (l : List (Option α)) : List α :=
-l.filterMap id
+def reduceOption {α} : List (Option α) → List α :=
+  List.filterMap id
+
+/-- `ilast' x xs` returns the last element of `xs` if `xs` is non-empty;
+it returns `x` otherwise -/
+@[simp]
+def ilast' {α} : α → List α → α
+| a, [] => a
+| a, b :: l => ilast' b l
+
+/-- `last' xs` returns the last element of `xs` if `xs` is non-empty;
+it returns `none` otherwise -/
+@[simp]
+def last' {α} : List α → Option α
+| [] => none
+| [a] => some a
+| b :: l => last' l
+
+/-- `rotate l n` rotates the elements of `l` to the left by `n`
+     rotate [0, 1, 2, 3, 4, 5] 2 = [2, 3, 4, 5, 0, 1] -/
+def rotate (l : List α) (n : ℕ) : List α :=
+  let (l₁, l₂) := List.splitAt (n % l.length) l
+  l₂ ++ l₁
+
+/-- rotate' is the same as `rotate`, but slower. Used for proofs about `rotate`-/
+def rotate' : List α → ℕ → List α
+| [], n => []
+| l, 0 => l
+| a :: l, n+1 => rotate' (l ++ [a]) n
+
+def mmap {m : Type u → Type v} [Monad m] {α β} (f : α → m β) : List α → m (List β)
+| [] => []
+| h :: t => do (← f h) :: (← mmap f t)
+
+def mmap' {m : Type → Type v} [Monad m] {α β} (f : α → m β) : List α → m Unit
+| [] => ()
+| h :: t => f h *> t.mmap' f
+
+/-- Filters and maps elements of a list -/
+def mmapFilter {m : Type → Type v} [Monad m] {α β} (f : α → m (Option β)) : List α → m (List β)
+| [] => []
+| h :: t => do
+  let b ← f h
+  let t' ← t.mmapFilter f
+  pure $ match b with
+  | none => t'
+  | some x => x :: t'
+
+/--
+`mmapUpperTriangle f l` calls `f` on all elements in the upper triangular part of `l × l`.
+That is, for each `e ∈ l`, it will run `f e e` and then `f e e'`
+for each `e'` that appears after `e` in `l`.
+Example: suppose `l = [1, 2, 3]`. `mmapUpperTriangle f l` will produce the list
+`[f 1 1, f 1 2, f 1 3, f 2 2, f 2 3, f 3 3]`.
+-/
+def mmapUpperTriangle {m} [Monad m] {α β : Type u} (f : α → α → m β) : List α → m (List β)
+| [] => []
+| h :: t => do (← f h h) :: (← t.mmap (f h)) ++ (← t.mmapUpperTriangle f)
+
+/--
+`mmap'Diag f l` calls `f` on all elements in the upper triangular part of `l × l`.
+That is, for each `e ∈ l`, it will run `f e e` and then `f e e'`
+for each `e'` that appears after `e` in `l`.
+Example: suppose `l = [1, 2, 3]`. `mmap'Diag f l` will evaluate, in this order,
+`f 1 1`, `f 1 2`, `f 1 3`, `f 2 2`, `f 2 3`, `f 3 3`.
+-/
+def mmap'Diag {m} [Monad m] {α} (f : α → α → m Unit) : List α → m Unit
+| [] => return ()
+| h :: t => do f h h; t.mmap' (f h); t.mmap'Diag f
+
+protected def traverse {F : Type u → Type v} [Applicative F] {α β} (f : α → F β) : List α → F (List β)
+| [] => pure []
+| x :: xs => cons <$> f x <*> List.traverse f xs
+
+/-- `getRest l l₁` returns `some l₂` if `l = l₁ ++ l₂`.
+  If `l₁` is not a prefix of `l`, returns `none` -/
+def getRest [DecidableEq α] : List α → List α → Option (List α)
+| l, [] => some l
+| [], _ => none
+| x :: l, y :: l₁ => if x = y then getRest l l₁ else none
+
+/--
+`List.slice n m xs` removes a slice of length `m` at index `n` in list `xs`.
+-/
+def slice {α} : ℕ → ℕ → List α → List α
+| 0, n, xs => xs.drop n
+| n+1, m, [] => []
+| n+1, m, x :: xs => x :: slice n m xs
+
+/--
+Left-biased version of `List.map₂`. `map₂Left' f as bs` applies `f` to each
+pair of elements `aᵢ ∈ as` and `bᵢ ∈ bs`. If `bs` is shorter than `as`, `f` is
+applied to `none` for the remaining `aᵢ`. Returns the results of the `f`
+applications and the remaining `bs`.
+```
+map₂Left' prod.mk [1, 2] ['a'] = ([(1, some 'a'), (2, none)], [])
+map₂Left' prod.mk [1] ['a', 'b'] = ([(1, some 'a')], ['b'])
+```
+-/
+@[simp]
+def map₂Left' (f : α → Option β → γ) : List α → List β → List γ × List β
+| [], bs => ([], bs)
+| a :: as, [] => ((a :: as).map fun a => f a none, [])
+| a :: as, b :: bs => let r := map₂Left' f as bs; (f a (some b) :: r.1, r.2)
+
+/--
+Right-biased version of `List.map₂`. `map₂Right' f as bs` applies `f` to each
+pair of elements `aᵢ ∈ as` and `bᵢ ∈ bs`. If `as` is shorter than `bs`, `f` is
+applied to `none` for the remaining `bᵢ`. Returns the results of the `f`
+applications and the remaining `as`.
+```
+map₂Right' prod.mk [1] ['a', 'b'] = ([(some 1, 'a'), (none, 'b')], [])
+map₂Right' prod.mk [1, 2] ['a'] = ([(some 1, 'a')], [2])
+```
+-/
+def map₂Right' (f : Option α → β → γ) (as : List α) (bs : List β) : List γ × List α :=
+  map₂Left' (flip f) bs as
+
+/--
+Left-biased version of `List.zip`. `zipLeft' as bs` returns the list of
+pairs `(aᵢ, bᵢ)` for `aᵢ ∈ as` and `bᵢ ∈ bs`. If `bs` is shorter than `as`, the
+remaining `aᵢ` are paired with `none`. Also returns the remaining `bs`.
+```
+zipLeft' [1, 2] ['a'] = ([(1, some 'a'), (2, none)], [])
+zipLeft' [1] ['a', 'b'] = ([(1, some 'a')], ['b'])
+zipLeft' = map₂Left' prod.mk
+```
+-/
+def zipLeft' : List α → List β → List (α × Option β) × List β :=
+  map₂Left' Prod.mk
+
+/--
+Right-biased version of `List.zip`. `zipRight' as bs` returns the list of
+pairs `(aᵢ, bᵢ)` for `aᵢ ∈ as` and `bᵢ ∈ bs`. If `as` is shorter than `bs`, the
+remaining `bᵢ` are paired with `none`. Also returns the remaining `as`.
+```
+zipRight' [1] ['a', 'b'] = ([(some 1, 'a'), (none, 'b')], [])
+zipRight' [1, 2] ['a'] = ([(some 1, 'a')], [2])
+zipRight' = map₂Right' prod.mk
+```
+-/
+def zipRight' : List α → List β → List (Option α × β) × List α :=
+  map₂Right' Prod.mk
+
+/--
+Left-biased version of `List.map₂`. `map₂Left f as bs` applies `f` to each pair
+`aᵢ ∈ as` and `bᵢ ‌∈ bs`. If `bs` is shorter than `as`, `f` is applied to `none`
+for the remaining `aᵢ`.
+```
+map₂Left prod.mk [1, 2] ['a'] = [(1, some 'a'), (2, none)]
+map₂Left prod.mk [1] ['a', 'b'] = [(1, some 'a')]
+map₂Left f as bs = (map₂Left' f as bs).fst
+```
+-/
+@[simp]
+def map₂Left (f : α → Option β → γ) : List α → List β → List γ
+| [], _ => []
+| a :: as, [] => (a :: as).map fun a => f a none
+| a :: as, b :: bs => f a (some b) :: map₂Left f as bs
+
+/--
+Right-biased version of `List.map₂`. `map₂Right f as bs` applies `f` to each
+pair `aᵢ ∈ as` and `bᵢ ‌∈ bs`. If `as` is shorter than `bs`, `f` is applied to
+`none` for the remaining `bᵢ`.
+```
+map₂Right prod.mk [1, 2] ['a'] = [(some 1, 'a')]
+map₂Right prod.mk [1] ['a', 'b'] = [(some 1, 'a'), (none, 'b')]
+map₂Right f as bs = (map₂Right' f as bs).fst
+```
+-/
+def map₂Right (f : Option α → β → γ) (as : List α) (bs : List β) : List γ :=
+  map₂Left (flip f) bs as
+
+/--
+Left-biased version of `List.zip`. `zipLeft as bs` returns the list of pairs
+`(aᵢ, bᵢ)` for `aᵢ ∈ as` and `bᵢ ∈ bs`. If `bs` is shorter than `as`, the
+remaining `aᵢ` are paired with `none`.
+```
+zipLeft [1, 2] ['a'] = [(1, some 'a'), (2, none)]
+zipLeft [1] ['a', 'b'] = [(1, some 'a')]
+zipLeft = map₂Left prod.mk
+```
+-/
+def zipLeft : List α → List β → List (α × Option β) :=
+  map₂Left Prod.mk
+
+/--
+Right-biased version of `List.zip`. `zipRight as bs` returns the list of pairs
+`(aᵢ, bᵢ)` for `aᵢ ∈ as` and `bᵢ ∈ bs`. If `as` is shorter than `bs`, the
+remaining `bᵢ` are paired with `none`.
+```
+zipRight [1, 2] ['a'] = [(some 1, 'a')]
+zipRight [1] ['a', 'b'] = [(some 1, 'a'), (none, 'b')]
+zipRight = map₂Right prod.mk
+```
+-/
+def zipRight : List α → List β → List (Option α × β) :=
+  map₂Right Prod.mk
+
+/--
+If all elements of `xs` are `some xᵢ`, `allSome xs` returns the `xᵢ`. Otherwise
+it returns `none`.
+```
+allSome [some 1, some 2] = some [1, 2]
+allSome [some 1, none  ] = none
+```
+-/
+def allSome : List (Option α) → Option (List α)
+| [] => some []
+| some a :: as => cons a <$> allSome as
+| none :: as => none
+
+/--
+`fillNones xs ys` replaces the `none`s in `xs` with elements of `ys`. If there
+are not enough `ys` to replace all the `none`s, the remaining `none`s are
+dropped from `xs`.
+```
+fillNones [none, some 1, none, none] [2, 3] = [2, 1, 3]
+```
+-/
+def fillNones {α} : List (Option α) → List α → List α
+| [], _ => []
+| some a :: as, as' => a :: fillNones as as'
+| none :: as, [] => as.reduceOption
+| none :: as, a :: as' => a :: fillNones as as'
+
+/--
+`takeList as ns` extracts successive sublists from `as`. For `ns = n₁ ... nₘ`,
+it first takes the `n₁` initial elements from `as`, then the next `n₂` ones,
+etc. It returns the sublists of `as` -- one for each `nᵢ` -- and the remaining
+elements of `as`. If `as` does not have at least as many elements as the sum of
+the `nᵢ`, the corresponding sublists will have less than `nᵢ` elements.
+```
+takeList ['a', 'b', 'c', 'd', 'e'] [2, 1, 1] = ([['a', 'b'], ['c'], ['d']], ['e'])
+takeList ['a', 'b'] [3, 1] = ([['a', 'b'], []], [])
+```
+-/
+def takeList {α} : List α → List ℕ → List (List α) × List α
+| xs, [] => ([], xs)
+| xs, n :: ns =>
+  let ⟨xs₁, xs₂⟩ := xs.splitAt n
+  let ⟨xss, rest⟩ := takeList xs₂ ns
+  (xs₁ :: xss, rest)
+
+/-- Auxliary definition used to define `toChunks`.
+  `toChunksAux n xs i` returns `(xs.take i, (xs.drop i).toChunks (n+1))`,
+  that is, the first `i` elements of `xs`, and the remaining elements chunked into
+  sublists of length `n+1`. -/
+def toChunksAux {α} (n : ℕ) : List α → ℕ → List α × List (List α)
+| [], i => ([], [])
+| x :: xs, 0 =>
+  let (l, L) := toChunksAux n xs n
+  ([], (x :: l) :: L)
+| x :: xs, i+1 =>
+  let (l, L) := toChunksAux n xs i
+  (x :: l, L)
+
+/--
+`xs.toChunks n` splits the list into sublists of size at most `n`,
+such that `(xs.toChunks n).join = xs`.
+```
+[1, 2, 3, 4, 5, 6, 7, 8].toChunks 10 = [[1, 2, 3, 4, 5, 6, 7, 8]]
+[1, 2, 3, 4, 5, 6, 7, 8].toChunks 3 = [[1, 2, 3], [4, 5, 6], [7, 8]]
+[1, 2, 3, 4, 5, 6, 7, 8].toChunks 2 = [[1, 2], [3, 4], [5, 6], [7, 8]]
+[1, 2, 3, 4, 5, 6, 7, 8].toChunks 0 = [[1, 2, 3, 4, 5, 6, 7, 8]]
+```
+-/
+def toChunks {α} : ℕ → List α → List (List α)
+| _, [] => []
+| 0, xs => [xs]
+| n+1, x :: xs =>
+  let (l, L) := toChunksAux n xs n
+  (x :: l) :: L
+
+/-!
+We add some n-ary versions of `List.zipWith` for functions with more than two arguments.
+These can also be written in terms of `List.zip` or `List.zipWith`.
+For example, `zipWith₃ f xs ys zs` could also be written as
+`zipWith id (zipWith f xs ys) zs`
+or as
+`(zip xs $ zip ys zs).map $ λ ⟨x, y, z⟩, f x y z`.
+-/
+
+
+/-- Ternary version of `List.zipWith`. -/
+def zipWith₃ (f : α → β → γ → δ) : List α → List β → List γ → List δ
+| x :: xs, y :: ys, z :: zs => f x y z :: zipWith₃ f xs ys zs
+| _, _, _ => []
+
+/-- Quaternary version of `List.zipWith`. -/
+def zipWith₄ (f : α → β → γ → δ → ε) : List α → List β → List γ → List δ → List ε
+| x :: xs, y :: ys, z :: zs, u :: us => f x y z u :: zipWith₄ f xs ys zs us
+| _, _, _, _ => []
+
+/-- Quinary version of `List.zipWith`. -/
+def zipWith₅ (f : α → β → γ → δ → ε → ζ) : List α → List β → List γ → List δ → List ε → List ζ
+| x :: xs, y :: ys, z :: zs, u :: us, v :: vs => f x y z u v :: zipWith₅ f xs ys zs us vs
+| _, _, _, _, _ => []
+
+/-- An auxiliary function for `List.mapWithPrefixSuffix`. -/
+def mapWithPrefixSuffixAux {α β} (f : List α → α → List α → β) : List α → List α → List β
+| prev, [] => []
+| prev, h :: t => f prev h t :: mapWithPrefixSuffixAux f (prev.concat h) t
+
+/--
+`List.mapWithPrefixSuffix f l` maps `f` across a list `l`.
+For each `a ∈ l` with `l = pref ++ [a] ++ suff`, `a` is mapped to `f pref a suff`.
+Example: if `f : list ℕ → ℕ → list ℕ → β`,
+`List.mapWithPrefixSuffix f [1, 2, 3]` will produce the list
+`[f [] 1 [2, 3], f [1] 2 [3], f [1, 2] 3 []]`.
+-/
+def mapWithPrefixSuffix {α β} (f : List α → α → List α → β) (l : List α) : List β :=
+  mapWithPrefixSuffixAux f [] l
+
+/--
+`List.mapWithComplement f l` is a variant of `List.mapWithPrefixSuffix`
+that maps `f` across a list `l`.
+For each `a ∈ l` with `l = pref ++ [a] ++ suff`, `a` is mapped to `f a (pref ++ suff)`,
+i.e., the list input to `f` is `l` with `a` removed.
+Example: if `f : ℕ → list ℕ → β`, `List.mapWithComplement f [1, 2, 3]` will produce the list
+`[f 1 [2, 3], f 2 [1, 3], f 3 [1, 2]]`.
+-/
+def mapWithComplement {α β} (f : α → List α → β) : List α → List β :=
+  mapWithPrefixSuffix fun pref a suff => f a (pref ++ suff)
 
 end List

--- a/Mathlib/Data/Nat/Basic.lean
+++ b/Mathlib/Data/Nat/Basic.lean
@@ -5,6 +5,8 @@ import Mathlib.Logic.Basic
 
 namespace Nat
 
+attribute [simp] succ_ne_zero lt_succ_self
+
 -- TODO: in mathlib, this is done for ordered monoids
 protected lemma pos_iff_ne_zero {n : ℕ} : 0 < n ↔ n ≠ 0 := by
   refine ⟨?_, Nat.pos_of_ne_zero⟩
@@ -40,6 +42,15 @@ protected lemma lt_or_eq_of_le {n m : ℕ} (h : n ≤ m) : n < m ∨ n = m :=
 lemma eq_of_mul_eq_mul_right {n m k : ℕ} (Hm : 0 < m) (H : n * m = k * m) : n = k :=
 by rw [Nat.mul_comm n m, Nat.mul_comm k m] at H
    exact Nat.eq_of_mul_eq_mul_left Hm H
+
+theorem le_zero_iff {i : ℕ} : i ≤ 0 ↔ i = 0 :=
+  ⟨Nat.eq_zero_of_le_zero, λ h => h ▸ le_refl i⟩
+
+theorem lt_succ_iff {m n : ℕ} : m < succ n ↔ m ≤ n :=
+⟨le_of_lt_succ, lt_succ_of_le⟩
+
+theorem succ_inj' {n m : ℕ} : succ n = succ m ↔ n = m :=
+⟨succ.inj, congr_arg _⟩
 
 /- sub properties -/
 

--- a/Mathlib/Data/Option/Basic.lean
+++ b/Mathlib/Data/Option/Basic.lean
@@ -1,0 +1,251 @@
+/-
+Copyright (c) 2017 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro
+-/
+import Mathlib.Init.Data.Option.Basic
+import Mathlib.Init.Data.Option.Instances
+import Mathlib.Init.Function
+import Mathlib.Data.Option.Defs
+import Mathlib.Logic.Basic
+
+namespace Option
+
+variable {α : Type _} {β : Type _} {γ : Type _}
+
+theorem some_ne_none (x : α) : some x ≠ none :=
+  fun h => Option.noConfusion h
+
+protected theorem «forall» {p : Option α → Prop} : (∀ x, p x) ↔ p none ∧ ∀ x, p (some x) :=
+  ⟨fun h => ⟨h _, fun x => h _⟩, fun h x => Option.casesOn x h.1 h.2⟩
+
+protected theorem «exists» {p : Option α → Prop} : (∃ x, p x) ↔ p none ∨ ∃ x, p (some x) :=
+  ⟨fun | ⟨none, hx⟩ => Or.inl hx | ⟨some x, hx⟩ => Or.inr ⟨x, hx⟩,
+    fun h => h.elim (fun h => ⟨_, h⟩) fun ⟨x, hx⟩ => ⟨_, hx⟩⟩
+
+@[simp] theorem get_mem : ∀ {o : Option α} h : isSome o, Option.get h ∈ o
+| some a, _ => rfl
+
+theorem get_of_mem {a : α} : ∀ {o : Option α} h : isSome o, a ∈ o → Option.get h = a
+| _, _, rfl => rfl
+
+@[simp] theorem not_mem_none (a : α) : a ∉ (none : Option α) := fun h => Option.noConfusion h
+
+@[simp] theorem some_get : ∀ {x : Option α} h : isSome x, some (Option.get h) = x
+| some x, hx => rfl
+
+@[simp] theorem get_some (x : α) (h : isSome (some x)) : Option.get h = x := rfl
+
+@[simp] theorem getD_some (x y : α) : Option.getD (some x) y = x := rfl
+
+@[simp] theorem getD_none (x : α) : Option.getD none x = x := rfl
+
+theorem getD_of_ne_none {x : Option α} (hx : x ≠ none) (y : α) : some (x.getD y) = x := by
+  cases x; {contradiction}; rw [getD_some]
+
+theorem mem_unique {o : Option α} {a b : α} (ha : a ∈ o) (hb : b ∈ o) : a = b :=
+  Option.some.inj $ ha.symm.trans hb
+
+theorem some_injective (α : Type _) : Function.injective (@some α) :=
+  fun _ _ => some_inj.mp
+
+/-- `option.map f` is injective if `f` is injective. -/
+theorem map_injective {f : α → β} (Hf : Function.injective f) : Function.injective (Option.map f)
+| none, none, H => rfl
+| some a₁, some a₂, H => by rw [Hf (Option.some.inj H)]
+
+@[ext] theorem ext : ∀ {o₁ o₂ : Option α}, (∀ a, a ∈ o₁ ↔ a ∈ o₂) → o₁ = o₂
+| none, none, H => rfl
+| some a, o, H => ((H _).1 rfl).symm
+| o, some b, H => (H _).2 rfl
+
+theorem eq_none_iff_forall_not_mem {o : Option α} : o = none ↔ ∀ a, a ∉ o :=
+  ⟨fun e a h => by rw [e] at h; (cases h), fun h => ext $ by simp; exact h⟩
+
+@[simp] theorem none_bind (f : α → Option β) : none.bind f = none := rfl
+
+@[simp] theorem some_bind (a : α) (f : α → Option β) : (some a).bind f = f a := rfl
+
+@[simp] theorem bind_some (x : Option α) : x.bind some = x := by cases x <;> rfl
+
+@[simp] theorem bind_eq_some {α β} {x : Option α} {f : α → Option β} {b : β} :
+  x.bind f = some b ↔ ∃ a, x = some a ∧ f a = some b := by cases x <;> simp
+
+@[simp] theorem bind_eq_none {o : Option α} {f : α → Option β} :
+  o.bind f = none ↔ ∀ b a, a ∈ o → b ∉ f a := by
+  simp only [eq_none_iff_forall_not_mem, not_exists, not_and, mem_def, bind_eq_some]; rfl
+
+theorem bind_comm {α β γ} {f : α → β → Option γ} (a : Option α) (b : Option β) :
+  (a.bind fun x => b.bind (f x)) = b.bind fun y => a.bind fun x => f x y := by
+  cases a <;> cases b <;> rfl
+
+theorem bind_assoc (x : Option α) (f : α → Option β) (g : β → Option γ) :
+  (x.bind f).bind g = x.bind fun y => (f y).bind g := by cases x <;> rfl
+
+theorem join_eq_some {x : Option (Option α)} {a : α} : x.join = some a ↔ x = some (some a) := by
+  simp
+
+theorem join_ne_none {x : Option (Option α)} : x.join ≠ none ↔ ∃ z, x = some (some z) := by
+  simp
+
+theorem join_ne_none' {x : Option (Option α)} : ¬x.join = none ↔ ∃ z, x = some (some z) := by
+  simp
+
+-- theorem join_eq_none {o : Option (Option α)} : o.join = none ↔ o = none ∨ o = some none := by
+--   rcases o with _|_|_; simp
+
+theorem bind_id_eq_join {x : Option (Option α)} : x.bind id = x.join := rfl
+
+@[simp] theorem map_eq_map {α β} {f : α → β} : Functor.map f = Option.map f := rfl
+
+theorem map_none {α β} {f : α → β} : f <$> none = none := rfl
+
+theorem map_some {α β} {a : α} {f : α → β} : f <$> some a = some (f a) := rfl
+
+@[simp] theorem map_none' {f : α → β} : none.map f = none := rfl
+
+@[simp] theorem map_some' {a : α} {f : α → β} : (some a).map f = some (f a) := rfl
+
+theorem map_eq_some {α β} {x : Option α} {f : α → β} {b : β} :
+  f <$> x = some b ↔ ∃ a, x = some a ∧ f a = b := by cases x <;> simp
+
+@[simp] theorem map_eq_some' {x : Option α} {f : α → β} {b : β} :
+  x.map f = some b ↔ ∃ a, x = some a ∧ f a = b := by cases x <;> simp
+
+@[simp] theorem map_eq_none' {x : Option α} {f : α → β} : x.map f = none ↔ x = none := by
+  cases x <;> simp only [map_none', map_some', eq_self_iff_true]
+
+theorem map_eq_none {α β} {x : Option α} {f : α → β} : f <$> x = none ↔ x = none := map_eq_none'
+
+theorem map_congr {f g : α → β} {x : Option α} (h : ∀ a ∈ x, f a = g a) : x.map f = x.map g := by
+  cases x <;> simp only [map_none', map_some', h, mem_def]
+
+@[simp] theorem map_id' : Option.map (@id α) = id := map_id
+
+@[simp] theorem map_map (h : β → γ) (g : α → β) (x : Option α) :
+  (x.map g).map h = x.map (h ∘ g) := by
+  cases x <;> simp only [map_none', map_some', ·∘·]
+
+theorem comp_map (h : β → γ) (g : α → β) (x : Option α) : x.map (h ∘ g) = (x.map g).map h :=
+  (map_map ..).symm
+
+@[simp] theorem map_comp_map (f : α → β) (g : β → γ) :
+  Option.map g ∘ Option.map f = Option.map (g ∘ f) := by funext x; simp
+
+theorem mem_map_of_mem {α β : Type _} {a : α} {x : Option α} (g : α → β) (h : a ∈ x) :
+  g a ∈ x.map g :=
+  mem_def.mpr ((mem_def.mp h).symm ▸ map_some')
+
+theorem bind_map_comm {α β} {x : Option (Option α)} {f : α → β} :
+  x.bind (Option.map f) = (x.map (Option.map f)).bind id := by cases x <;> simp
+
+theorem join_map_eq_map_join {f : α → β} {x : Option (Option α)} :
+  (x.map (Option.map f)).join = x.join.map f := by
+  -- rcases x with (_ | _ | x) <;> simp
+  cases x; {simp}; rename_i x; cases x <;> simp
+
+theorem join_join {x : Option (Option (Option α))} : x.join.join = (x.map join).join := by
+  (iterate 2 cases x; {simp}; rename_i x); cases x <;> simp
+  -- rcases x with (_ | _ | _ | x) <;> simp
+
+theorem mem_of_mem_join {a : α} {x : Option (Option α)} (h : a ∈ x.join) : some a ∈ x :=
+  mem_def.mpr ((mem_def.mp h).symm ▸ join_eq_some.mp h)
+
+@[simp] theorem some_orelse (a : α) (x : Option α) : (some a <|> x) = some a := rfl
+
+@[simp] theorem none_orelse (x : Option α) : (none <|> x) = x := by cases x <;> rfl
+
+@[simp] theorem orelse_none (x : Option α) : (x <|> none) = x := by cases x <;> rfl
+
+@[simp] theorem isSome_none : @isSome α none = false := rfl
+
+@[simp] theorem isSome_some {a : α} : isSome (some a) = true := rfl
+
+theorem isSome_iff_exists {x : Option α} : isSome x ↔ ∃ a, x = some a := by
+  cases x <;> simp [isSome] <;> exact ⟨_, rfl⟩
+
+@[simp] theorem isNone_none : @isNone α none = true := rfl
+
+@[simp] theorem isNone_some {a : α} : isNone (some a) = false := rfl
+
+@[simp] theorem not_isSome {a : Option α} : isSome a = false ↔ a.isNone = true := by
+  cases a <;> simp
+
+theorem eq_some_iff_get_eq {o : Option α} {a : α} :
+  o = some a ↔ ∃ h : o.isSome, Option.get h = a := by cases o <;> simp; intro.
+
+theorem not_isSome_iff_eq_none {o : Option α} : ¬o.isSome ↔ o = none := by
+  cases o <;> simp
+
+theorem ne_none_iff_isSome {o : Option α} : o ≠ none ↔ o.isSome := by cases o <;> simp
+
+theorem ne_none_iff_exists {o : Option α} : o ≠ none ↔ ∃ x : α, some x = o := by cases o <;> simp
+
+theorem ne_none_iff_exists' {o : Option α} : o ≠ none ↔ ∃ x : α, o = some x :=
+  ne_none_iff_exists.trans $ exists_congr fun _ => eq_comm
+
+theorem bex_ne_none {p : Option α → Prop} : (∃ x, ∃ (_ : x ≠ none), p x) ↔ ∃ x, p (some x) :=
+  ⟨fun ⟨x, hx, hp⟩ => ⟨get $ ne_none_iff_isSome.1 hx, by rwa [some_get]⟩,
+    fun ⟨x, hx⟩ => ⟨some x, some_ne_none x, hx⟩⟩
+
+theorem ball_ne_none {p : Option α → Prop} : (∀ x (_ : x ≠ none), p x) ↔ ∀ x, p (some x) :=
+  ⟨fun h x => h (some x) (some_ne_none x),
+    fun h x hx => by
+      have := h (get $ ne_none_iff_isSome.1 hx)
+      simp [some_get] at this ⊢
+      exact this⟩
+
+@[simp] theorem guard_eq_some {p : α → Prop} [DecidablePred p] {a b : α} :
+  guard p a = some b ↔ a = b ∧ p a := by
+  by_cases h : p a <;> simp [Option.guard, h]
+
+theorem lift_or_get_choice {f : α → α → α} (h : ∀ a b, f a b = a ∨ f a b = b) :
+  ∀ o₁ o₂, lift_or_get f o₁ o₂ = o₁ ∨ lift_or_get f o₁ o₂ = o₂
+| none, none => Or.inl rfl
+| some a, none => Or.inl rfl
+| none, some b => Or.inr rfl
+| some a, some b => by have := h a b; simp [lift_or_get] at this ⊢; exact this
+
+@[simp] theorem lift_or_get_none_left {f} {b : Option α} : lift_or_get f none b = b := by
+  cases b <;> rfl
+
+@[simp] theorem lift_or_get_none_right {f} {a : Option α} : lift_or_get f a none = a := by
+  cases a <;> rfl
+
+@[simp] theorem lift_or_get_some_some {f} {a b : α} :
+  lift_or_get f (some a) (some b) = f a b := rfl
+
+@[simp] theorem elim_none (x : β) (f : α → β) : none.elim x f = x := rfl
+
+@[simp] theorem elim_some (x : β) (f : α → β) (a : α) : (some a).elim x f = f a := rfl
+
+@[simp] theorem getD_map (f : α → β) (x : α) (o : Option α) :
+  (o.map f).getD (f x) = f (getD o x) := by cases o <;> rfl
+
+section
+
+attribute [local instance] Classical.propDecidable
+
+/-- An arbitrary `some a` with `a : α` if `α` is nonempty, and otherwise `none`. -/
+noncomputable def choice (α : Type _) : Option α :=
+  if h : Nonempty α then some (Classical.choice h) else none
+
+theorem choice_eq {α : Type _} [Subsingleton α] (a : α) : choice α = some a := by
+  simp [choice]
+  rw [dif_pos (⟨a⟩ : Nonempty α)]
+  simp; apply Subsingleton.elim
+
+theorem choice_isSome_iff_nonempty {α : Type _} : (choice α).isSome ↔ Nonempty α := by
+  constructor
+  · intro h
+    exact ⟨Option.get h⟩
+  · intro h
+    simp only [choice]
+    rw [dif_pos h]
+    exact isSome_some
+
+end
+
+@[simp] theorem to_list_some (a : α) : (a : Option α).toList = [a] := rfl
+
+@[simp] theorem to_list_none (α : Type _) : (none : Option α).toList = [] := rfl

--- a/Mathlib/Data/Option/Basic.lean
+++ b/Mathlib/Data/Option/Basic.lean
@@ -23,15 +23,15 @@ protected theorem «exists» {p : Option α → Prop} : (∃ x, p x) ↔ p none 
   ⟨fun | ⟨none, hx⟩ => Or.inl hx | ⟨some x, hx⟩ => Or.inr ⟨x, hx⟩,
     fun h => h.elim (fun h => ⟨_, h⟩) fun ⟨x, hx⟩ => ⟨_, hx⟩⟩
 
-@[simp] theorem get_mem : ∀ {o : Option α} h : isSome o, Option.get h ∈ o
+theorem get_mem : ∀ {o : Option α} (h : isSome o), Option.get h ∈ o
 | some a, _ => rfl
 
-theorem get_of_mem {a : α} : ∀ {o : Option α} h : isSome o, a ∈ o → Option.get h = a
+theorem get_of_mem {a : α} : ∀ {o : Option α} (h : isSome o), a ∈ o → Option.get h = a
 | _, _, rfl => rfl
 
-@[simp] theorem not_mem_none (a : α) : a ∉ (none : Option α) := fun h => Option.noConfusion h
+theorem not_mem_none (a : α) : a ∉ (none : Option α) := fun h => Option.noConfusion h
 
-@[simp] theorem some_get : ∀ {x : Option α} h : isSome x, some (Option.get h) = x
+@[simp] theorem some_get : ∀ {x : Option α} (h : isSome x), some (Option.get h) = x
 | some x, hx => rfl
 
 @[simp] theorem get_some (x : α) (h : isSome (some x)) : Option.get h = x := rfl
@@ -215,9 +215,9 @@ theorem lift_or_get_choice {f : α → α → α} (h : ∀ a b, f a b = a ∨ f 
 @[simp] theorem lift_or_get_some_some {f} {a b : α} :
   lift_or_get f (some a) (some b) = f a b := rfl
 
-@[simp] theorem elim_none (x : β) (f : α → β) : none.elim x f = x := rfl
+theorem elim_none (x : β) (f : α → β) : none.elim x f = x := rfl
 
-@[simp] theorem elim_some (x : β) (f : α → β) (a : α) : (some a).elim x f = f a := rfl
+theorem elim_some (x : β) (f : α → β) (a : α) : (some a).elim x f = f a := rfl
 
 @[simp] theorem getD_map (f : α → β) (x : α) (o : Option α) :
   (o.map f).getD (f x) = f (getD o x) := by cases o <;> rfl

--- a/Mathlib/Data/Option/Defs.lean
+++ b/Mathlib/Data/Option/Defs.lean
@@ -1,0 +1,141 @@
+/-
+Copyright (c) 2018 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro
+-/
+import Mathlib.Init.SetNotation
+import Mathlib.Init.Data.List.Basic
+
+/-!
+# Extra definitions on `Option`
+
+This file defines more operations involving `Option α`. Lemmas about them are located in other
+files under `Data.Option.`.
+Other basic operations on `Option` are defined in the core library.
+-/
+
+
+namespace Option
+
+variable {α : Type _} {β : Type _}
+
+/-- An elimination principle for `Option`. It is a nondependent version of `Option.rec_on`. -/
+@[simp]
+protected def elim : Option α → β → (α → β) → β
+| some x, y, f => f x
+| none, y, f => y
+
+instance HasMem : Mem α (Option α) :=
+  ⟨fun a b => b = some a⟩
+
+@[simp]
+theorem mem_def {a : α} {b : Option α} : a ∈ b ↔ b = some a :=
+  Iff.rfl
+
+theorem mem_iff {a : α} {b : Option α} : a ∈ b ↔ b = a :=
+  Iff.rfl
+
+theorem isNone_iff_eq_none {o : Option α} : o.isNone ↔ o = none :=
+  ⟨Option.eq_none_of_isNone, fun e => e.symm ▸ rfl⟩
+
+theorem some_inj {a b : α} : some a = some b ↔ a = b := by simp
+
+/--
+`o = none` is decidable even if the wrapped type does not have decidable equality.
+This is not an instance because it is not definitionally equal to `Option.decidable_eq`.
+Try to use `o.is_none` or `o.is_some` instead.
+-/
+@[inline]
+def decidable_eq_none {o : Option α} : Decidable (o = none) :=
+  decidableOfDecidableOfIff (instDecidableEqBool _ _) isNone_iff_eq_none
+
+instance decidable_forall_mem {p : α → Prop} [DecidablePred p] :
+  ∀ o : Option α, Decidable (∀ a ∈ o, p a)
+| none => isTrue (by simp)
+| some a =>
+  if h : p a then isTrue fun o e => some_inj.1 e ▸ h
+  else isFalse $ mt (fun H => H _ rfl) h
+
+instance decidable_exists_mem {p : α → Prop} [DecidablePred p] : ∀ o : Option α, Decidable (∃ a ∈ o, p a)
+| none => isFalse fun ⟨a, ⟨h, _⟩⟩ => by cases h
+| some a => if h : p a then isTrue ⟨_, rfl, h⟩ else isFalse fun ⟨_, ⟨rfl, hn⟩⟩ => h hn
+
+/-- `guard p a` returns `some a` if `p a` holds, otherwise `none`. -/
+def guard (p : α → Prop) [DecidablePred p] (a : α) : Option α :=
+  if p a then some a else none
+
+/-- Cast of `Option` to `List`. Returns `[a]` if the input is `some a`, and `[]` if it is
+`none`. -/
+def toList : Option α → List α
+| none => []
+| some a => [a]
+
+@[simp]
+theorem mem_toList {a : α} {o : Option α} : a ∈ toList o ↔ a ∈ o := by
+  cases o <;> simp [toList, eq_comm]
+
+/-- Two arguments failsafe function. Returns `f a b` if the inputs are `some a` and `some b`, and
+"does nothing" otherwise. -/
+def lift_or_get (f : α → α → α) : Option α → Option α → Option α
+| none, none => none
+| some a, none => some a
+| none, some b => some b
+| some a, some b => some (f a b)
+
+/-- Lifts a relation `α → β → Prop` to a relation `option α → option β → Prop` by just adding
+`none ~ none`. -/
+inductive rel (r : α → β → Prop) : Option α → Option β → Prop
+| /-- If `a ~ b`, then `some a ~ some b` -/
+  some {a b} : r a b → rel r (some a) (some b)
+| /-- `none ~ none` -/
+  none : rel r none none
+
+/-- Partial bind. If for some `x : option α`, `f : Π (a : α), a ∈ x → option β` is a
+  partial function defined on `a : α` giving an `option β`, where `some a = x`,
+  then `pbind x f h` is essentially the same as `bind x f`
+  but is defined only when all `x = some a`, using the proof to apply `f`. -/
+@[simp]
+def pbind : ∀ x : Option α, (∀ a : α, a ∈ x → Option β) → Option β
+| none, _ => none
+| some a, f => f a rfl
+
+-- ././Mathport/Syntax/Translate/Basic.lean:452:2: warning: expanding binder collection (a «expr ∈ » x)
+/-- Partial map. If `f : Π a, p a → β` is a partial function defined on `a : α` satisfying `p`,
+then `pmap f x h` is essentially the same as `map f x` but is defined only when all members of `x`
+satisfy `p`, using the proof to apply `f`. -/
+@[simp]
+def pmap {p : α → Prop} (f : ∀ a : α, p a → β) : ∀ x : Option α, (∀ a ∈ x, p a) → Option β
+| none, _ => none
+| some a, H => some (f a (H a (mem_def.mpr rfl)))
+
+/-- Flatten an `option` of `option`, a specialization of `mjoin`. -/
+@[simp]
+def join : Option (Option α) → Option α :=
+  fun x => x.bind id
+
+protected def traverse.{u, v} {F : Type u → Type v} [Applicative F] {α β : Type _} (f : α → F β) :
+  Option α → F (Option β)
+| none => pure none
+| some x => some <$> f x
+
+/-- If you maybe have a monadic computation in a `[monad m]` which produces a term of type `α`, then
+there is a naturally associated way to always perform a computation in `m` which maybe produces a
+result. -/
+def maybe.{u, v} {m : Type u → Type v} [Monad m] {α : Type u} : Option (m α) → m (Option α)
+| none => none
+| some fn => some <$> fn
+
+/-- Map a monadic function `f : α → m β` over an `o : option α`, maybe producing a result. -/
+def mmap.{u, v, w} {m : Type u → Type v} [Monad m] {α : Type w} {β : Type u} (f : α → m β) (o : Option α) :
+  m (Option β) :=
+  (o.map f).maybe
+
+/-- A monadic analogue of `Option.elim`. -/
+def melim {α β : Type _} {m : Type _ → Type _} [Monad m] (x : m (Option α)) (y : m β) (z : α → m β) : m β :=
+  do (← x).elim y z
+
+/-- A monadic analogue of `Option.getD`. -/
+def mgetD {α : Type _} {m : Type _ → Type _} [Monad m] (x : m (Option α)) (y : m α) : m α :=
+  melim x y pure
+
+end Option

--- a/Mathlib/Data/Prod.lean
+++ b/Mathlib/Data/Prod.lean
@@ -69,11 +69,11 @@ theorem mk.inj_iff {a₁ a₂ : α} {b₁ b₂ : β} : (a₁, b₁) = (a₂, b�
 
 lemma mk.inj_left {α β : Type _} (a : α) :
   Function.injective (Prod.mk a : β → α × β) :=
-fun h => (Prod.mk.inj h).right
+fun _ _ h => (Prod.mk.inj h).right
 
 lemma mk.inj_right {α β : Type _} (b : β) :
   Function.injective (λ a => Prod.mk a b : α → α × β) :=
-fun h => (Prod.mk.inj h).left
+fun _ _ h => (Prod.mk.inj h).left
 
 -- Port note: this lemma comes from lean3/library/init/data/prod.lean.
 @[simp] lemma mk.eta : ∀{p : α × β}, (p.1, p.2) = p

--- a/Mathlib/Init/Data/List/Basic.lean
+++ b/Mathlib/Init/Data/List/Basic.lean
@@ -1,0 +1,127 @@
+/-
+Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Leonardo de Moura
+-/
+import Mathlib.Init.SetNotation
+import Mathlib.Init.Logic
+
+open Decidable List
+
+universe u v w
+
+instance (α : Type u) : Inhabited (List α) :=
+  ⟨List.nil⟩
+
+variable {α : Type u} {β : Type v} {γ : Type w}
+
+namespace List
+
+def mem (a : α) : List α → Prop
+| [] => False
+| (b :: l) => a = b ∨ mem a l
+
+instance : Mem α (List α) := ⟨mem⟩
+
+theorem mem_nil (a : α) : a ∈ [] ↔ False := Iff.rfl
+
+theorem mem_cons {a b : α} {l : List α} :
+  a ∈ (b :: l) ↔ a = b ∨ a ∈ l := Iff.rfl
+
+instance instDecidableMem [DecidableEq α] (a : α) : ∀ l : List α, Decidable (a ∈ l)
+| [] => isFalse not_false
+| b :: l =>
+  if h₁ : a = b then isTrue (Or.inl h₁) else
+    match instDecidableMem a l with
+    | isTrue h₂ => isTrue (Or.inr h₂)
+    | isFalse h₂ => isFalse (not_or_intro h₁ h₂)
+
+protected def bagInter {α} [BEq α] : List α → List α → List α
+| [], _ => []
+| _, [] => []
+| a :: l₁, l₂ => if l₂.elem a then a :: List.bagInter l₁ (l₂.erase a) else List.bagInter l₁ l₂
+
+protected def diff {α} [BEq α] : List α → List α → List α
+| l, [] => l
+| l₁, a :: l₂ => if l₁.elem a then List.diff (l₁.erase a) l₂ else List.diff l₁ l₂
+
+open Option Nat
+
+/-- Get the tail of a nonempty list, or return `[]` for `[]`. -/
+def tail : List α → List α
+| []    => []
+| a::as => as
+
+
+def mapIdxAux (f : Nat → α → β) : Nat → List α → List β
+| k, [] => []
+| k, a :: as => f k a :: mapIdxAux f (k+1) as
+
+/-- Given a function `f : Nat → α → β` and `as : list α`, `as = [a₀, a₁, ...]`, returns the list
+`[f 0 a₀, f 1 a₁, ...]`. -/
+def mapIdx (f : Nat → α → β) (as : List α) : List β :=
+  mapIdxAux f 0 as
+
+/-- Applicative variant of `mapIdx`. -/
+def mapIdxM {m : Type v → Type w} [Applicative m] (as : List α) (f : Nat → α → m β) :
+  m (List β) :=
+  let rec loop : Nat → List α → m (List β)
+  | _,  [] => []
+  | n, a :: as => List.cons <$> f n a <*> loop (n + 1) as
+  loop 0 as
+
+/-- `after p xs` is the suffix of `xs` after the first element that satisfies
+  `p`, not including that element.
+  ```lean
+  after      (eq 1)       [0, 1, 2, 3] = [2, 3]
+  drop_while (not ∘ eq 1) [0, 1, 2, 3] = [1, 2, 3]
+  ```
+-/
+def after (p : α → Prop) [DecidablePred p] : List α → List α
+| [] => []
+| x :: xs => if p x then xs else after p xs
+
+def findIdx (p : α → Prop) [DecidablePred p] : List α → Nat
+| [] => 0
+| a :: l => if p a then 0 else succ (findIdx p l)
+
+def indexOf [BEq α] (a : α) : List α → Nat := findIdx (a == ·)
+
+@[simp] def removeNth : List α → Nat → List α
+| [], _ => []
+| x :: xs, 0 => xs
+| x :: xs, i+1 => x :: removeNth xs i
+
+def bor (l : List Bool) : Bool := any l id
+
+def band (l : List Bool) : Bool := all l id
+
+-- TODO(Mario): restore `protected` when general `insert` is added
+def insert [DecidableEq α] (a : α) (l : List α) : List α :=
+  if a ∈ l then l else a :: l
+
+protected def union [DecidableEq α] (l₁ l₂ : List α) : List α :=
+  foldr insert l₂ l₁
+
+instance [DecidableEq α] : Union (List α) :=
+  ⟨List.union⟩
+
+protected def inter [DecidableEq α] (l₁ l₂ : List α) : List α :=
+  filter (· ∈ l₂) l₁
+
+instance [DecidableEq α] : Inter (List α) := ⟨List.inter⟩
+
+@[simp] def repeat (a : α) : Nat → List α
+| 0 => []
+| succ n => a :: repeat a n
+
+@[simp] def last : ∀ l : List α, l ≠ [] → α
+| [], h => absurd rfl h
+| [a], h => a
+| a :: b :: l, h => last (b :: l) fun h => List.noConfusion h
+
+def last! [Inhabited α] : List α → α
+| [] => panic! "empty list"
+| [a] => a
+| [a, b] => b
+| a :: b :: l => last! l

--- a/Mathlib/Init/Data/List/Basic.lean
+++ b/Mathlib/Init/Data/List/Basic.lean
@@ -17,15 +17,20 @@ variable {α : Type u} {β : Type v} {γ : Type w}
 
 namespace List
 
+attribute [simp] get! get? get head? headD head tail! tail? tailD getLast getLast! getLast?
+  getLastD reverseAux eraseIdx isEmpty map map₂ join filterMap dropWhile find? findSome?
+  replace elem lookup drop take takeWhile foldr zipWith unzip rangeAux iota enumFrom init
+  intersperse isPrefixOf isEqv dropLast
+
 def mem (a : α) : List α → Prop
 | [] => False
 | (b :: l) => a = b ∨ mem a l
 
 instance : Mem α (List α) := ⟨mem⟩
 
-theorem mem_nil (a : α) : a ∈ [] ↔ False := Iff.rfl
+@[simp] theorem mem_nil (a : α) : a ∈ [] ↔ False := Iff.rfl
 
-theorem mem_cons {a b : α} {l : List α} :
+@[simp] theorem mem_cons {a b : α} {l : List α} :
   a ∈ (b :: l) ↔ a = b ∨ a ∈ l := Iff.rfl
 
 instance instDecidableMem [DecidableEq α] (a : α) : ∀ l : List α, Decidable (a ∈ l)

--- a/Mathlib/Init/Data/List/Instances.lean
+++ b/Mathlib/Init/Data/List/Instances.lean
@@ -1,0 +1,18 @@
+/-
+Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Leonardo de Moura
+-/
+import Mathlib.Init.Data.List.Basic
+
+instance decidableBEx (p : α → Prop) [DecidablePred p] : ∀ l : List α, Decidable (∃ x ∈ l, p x)
+| [] => isFalse (fun x => nomatch x)
+| x :: xs =>
+  if h₁ : p x then isTrue ⟨x, Or.inl rfl, h₁⟩ else
+    match decidableBEx p xs with
+    | isTrue h₂ => isTrue $ match h₂ with | ⟨y, hm, hp⟩ => ⟨y, Or.inr hm, hp⟩
+    | isFalse h₂ => isFalse $ fun ⟨y, Or.inr h, hp⟩ => absurd ⟨y, h, hp⟩ h₂
+
+instance decidableBAll (p : α → Prop) [DecidablePred p] (l : List α) : Decidable (∀ x ∈ l, p x) :=
+  if h : ∃ x ∈ l, ¬p x then isFalse $ let ⟨x, h, np⟩ := h; fun al => np (al x h)
+  else isTrue $ fun x hx => if h' : p x then h' else (h ⟨x, hx, h'⟩).elim

--- a/Mathlib/Init/Data/List/Lemmas.lean
+++ b/Mathlib/Init/Data/List/Lemmas.lean
@@ -1,0 +1,175 @@
+/-
+Copyright (c) 2014 Parikshit Khanna. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Parikshit Khanna, Jeremy Avigad, Leonardo de Moura, Floris van Doorn
+-/
+import Mathlib.Init.Data.List.Basic
+import Mathlib.Init.Data.Nat.Lemmas
+
+namespace List
+
+open Nat
+
+@[simp] theorem append_eq_append (l₁ l₂ : List α) : List.append l₁ l₂ = l₁ ++ l₂ := rfl
+
+@[simp] theorem length_repeat (a : α) (n : Nat) : length (repeat a n) = n := by
+  induction n <;> simp_all
+
+@[simp] theorem length_tail (l : List α) : length (tail l) = length l - 1 := by cases l <;> rfl
+
+@[simp] theorem length_drop : ∀ (i : Nat) (l : List α), length (drop i l) = length l - i
+| 0, l => rfl
+| succ i, [] => Eq.symm (Nat.zero_sub (succ i))
+| succ i, x :: l => calc
+  length (drop (succ i) (x :: l)) = length l - i := length_drop i l
+  _ = succ (length l) - succ i := (Nat.succ_sub_succ_eq_sub (length l) i).symm
+
+theorem map_nil {f : α → β} : map f [] = [] := rfl
+
+theorem map_cons (f : α → β) a l : map f (a :: l) = f a :: map f l := rfl
+
+@[simp] theorem map_append (f : α → β) : ∀ l₁ l₂, map f (l₁ ++ l₂) = map f l₁ ++ map f l₂ := by
+  intro l₁ <;> induction l₁ <;> intros <;> simp_all
+
+theorem map_singleton (f : α → β) (a : α) : map f [a] = [f a] := rfl
+
+@[simp] theorem map_id (l : List α) : map id l = l := by induction l <;> simp_all
+
+@[simp] theorem map_map (g : β → γ) (f : α → β) (l : List α) :
+  map g (map f l) = map (g ∘ f) l := by induction l <;> simp_all
+
+@[simp] theorem length_map (f : α → β) (l : List α) : length (map f l) = length l := by
+  induction l <;> simp_all
+
+@[simp] theorem nil_bind (f : α → List β) : List.bind [] f = [] := by simp [join, List.bind]
+
+@[simp] theorem cons_bind x xs (f : α → List β) :
+  List.bind (x :: xs) f = f x ++ List.bind xs f := by simp [join, List.bind]
+
+@[simp] theorem append_bind xs ys (f : α → List β) :
+  List.bind (xs ++ ys) f = List.bind xs f ++ List.bind ys f := by
+  induction xs; {rfl}; simp_all [cons_bind, append_assoc]
+
+theorem mem_nil_iff (a : α) : a ∈ ([] : List α) ↔ False := Iff.rfl
+
+@[simp] theorem not_mem_nil (a : α) : a ∉ ([] : List α) := not_false
+
+theorem mem_cons_self (a : α) (l : List α) : a ∈ a :: l := Or.inl rfl
+
+@[simp] theorem mem_cons_iff (a y : α) (l : List α) : a ∈ y :: l ↔ a = y ∨ a ∈ l := Iff.rfl
+
+theorem mem_cons_eq (a y : α) (l : List α) : (a ∈ y :: l) = (a = y ∨ a ∈ l) := rfl
+
+theorem mem_cons_of_mem (y : α) {a : α} {l : List α} : a ∈ l → a ∈ y :: l := fun H => Or.inr H
+
+theorem eq_or_mem_of_mem_cons {a y : α} {l : List α} : a ∈ y :: l → a = y ∨ a ∈ l := id
+
+@[simp] theorem mem_append {a : α} {s t : List α} : a ∈ s ++ t ↔ a ∈ s ∨ a ∈ t := by
+  induction s <;> simp_all [or_assoc]
+
+theorem mem_append_eq (a : α) (s t : List α) : (a ∈ s ++ t) = (a ∈ s ∨ a ∈ t) :=
+  propext mem_append
+
+theorem mem_append_left {a : α} {l₁ : List α} (l₂ : List α) (h : a ∈ l₁) : a ∈ l₁ ++ l₂ :=
+  mem_append.2 (Or.inl h)
+
+theorem mem_append_right {a : α} (l₁ : List α) {l₂ : List α} (h : a ∈ l₂) : a ∈ l₁ ++ l₂ :=
+  mem_append.2 (Or.inr h)
+
+theorem not_bex_nil (p : α → Prop) : ¬∃ x ∈ @nil α, p x := fun ⟨x, hx, px⟩ => hx
+
+theorem ball_nil (p : α → Prop) : ∀ x ∈ @nil α, p x := fun x => False.elim
+
+theorem bex_cons (p : α → Prop) (a : α) (l : List α) :
+  (∃ x ∈ a :: l, p x) ↔ p a ∨ ∃ x ∈ l, p x :=
+  ⟨fun
+    | ⟨_, Or.inl rfl, px⟩ => Or.inl px
+    | ⟨x, Or.inr h, px⟩ => Or.inr ⟨x, h, px⟩,
+  fun o => o.elim
+    (fun pa => ⟨a, mem_cons_self _ _, pa⟩)
+    (fun ⟨x, h, px⟩ => ⟨x, mem_cons_of_mem _ h, px⟩)⟩
+
+theorem ball_cons (p : α → Prop) (a : α) (l : List α) : (∀ x ∈ a :: l, p x) ↔ p a ∧ ∀ x ∈ l, p x :=
+  ⟨fun al => ⟨al a (mem_cons_self _ _), fun x h => al x (mem_cons_of_mem _ h)⟩,
+    fun ⟨pa, al⟩ x o => o.elim (fun e => e.symm ▸ pa) (al x)⟩
+
+protected def subset (l₁ l₂ : List α) :=
+  ∀ ⦃a : α⦄, a ∈ l₁ → a ∈ l₂
+
+instance : Subset (List α) := ⟨List.subset⟩
+
+@[simp] theorem nil_subset (l : List α) : [] ⊆ l :=
+  fun b i => False.elim (Iff.mp (mem_nil_iff b) i)
+
+-- @[refl]
+@[simp] theorem subset.refl (l : List α) : l ⊆ l := fun b i => i
+
+-- @[trans]
+theorem subset.trans {l₁ l₂ l₃ : List α} (h₁ : l₁ ⊆ l₂) (h₂ : l₂ ⊆ l₃) : l₁ ⊆ l₃ :=
+  fun b i => h₂ (h₁ i)
+
+@[simp] theorem subset_cons (a : α) (l : List α) : l ⊆ a :: l := fun b i => Or.inr i
+
+theorem subset_of_cons_subset {a : α} {l₁ l₂ : List α} : a :: l₁ ⊆ l₂ → l₁ ⊆ l₂ :=
+  fun s b i => s (mem_cons_of_mem _ i)
+
+theorem cons_subset_cons {l₁ l₂ : List α} (a : α) (s : l₁ ⊆ l₂) : a :: l₁ ⊆ a :: l₂ :=
+  fun b hin => match eq_or_mem_of_mem_cons hin with
+  | Or.inl e => Or.inl e
+  | Or.inr i => Or.inr (s i)
+
+@[simp]
+theorem subset_append_left (l₁ l₂ : List α) : l₁ ⊆ l₁ ++ l₂ :=
+  fun b => mem_append_left _
+
+@[simp]
+theorem subset_append_right (l₁ l₂ : List α) : l₂ ⊆ l₁ ++ l₂ :=
+  fun b => mem_append_right _
+
+theorem subset_cons_of_subset (a : α) {l₁ l₂ : List α} : l₁ ⊆ l₂ → l₁ ⊆ a :: l₂ :=
+  fun s a i => Or.inr (s i)
+
+theorem eq_nil_of_length_eq_zero {l : List α} : length l = 0 → l = [] :=   by
+  induction l <;> intros; {rfl}; contradiction
+
+theorem ne_nil_of_length_eq_succ {l : List α} : ∀ {n : Nat}, length l = succ n → l ≠ [] := by
+  induction l <;> intros _ _ _ <;> contradiction
+
+@[simp] theorem length_map₂ (f : α → β → γ) l₁ :
+  ∀ l₂, length (map₂ f l₁ l₂) = min (length l₁) (length l₂) := by
+  induction l₁ <;> intro l₂ <;> cases l₂ <;>
+    simp_all [add_one, min_succ_succ, Nat.zero_min, Nat.min_zero]
+
+@[simp] theorem length_take : ∀ (i : Nat) (l : List α), length (take i l) = min i (length l)
+| 0, l => by simp [Nat.zero_min]
+| succ n, [] => by simp [Nat.min_zero]
+| succ n, a :: l => by simp [Nat.min_succ_succ, add_one, length_take]
+
+theorem length_take_le (n) (l : List α) : length (take n l) ≤ n := by simp [min_le_left]
+
+theorem length_removeNth : ∀ (l : List α) (i : ℕ),
+  i < length l → length (removeNth l i) = length l - 1
+| [], _, h => rfl
+| x::xs, 0, h => by simp [removeNth]; rfl
+| x::xs, i+1, h => by
+  have : i < length xs := Nat.lt_of_succ_lt_succ h
+  simp [removeNth, ← Nat.add_one]
+  rw [length_removeNth xs i this, Nat.sub_add_cancel (lt_of_le_of_lt (Nat.zero_le _) this)]; rfl
+
+-- @[simp] theorem partition_eq_filter_filter (p : α → Bool) :
+--   ∀ l : List α, partition p l = (filter p l, filter (not ∘ p) l)
+-- | [] => rfl
+-- | a :: l => by
+--   cases pa: p a <;> simp [partition, partitionAux, filter, pa, partition_eq_filter_filter p l]
+
+inductive sublist : List α → List α → Prop
+  | slnil : sublist [] []
+  | cons l₁ l₂ a : sublist l₁ l₂ → sublist l₁ (a :: l₂)
+  | cons2 l₁ l₂ a : sublist l₁ l₂ → sublist (a :: l₁) (a :: l₂)
+
+infixl:50 " <+ " => sublist
+
+theorem length_le_of_sublist : ∀ {l₁ l₂ : List α}, l₁ <+ l₂ → length l₁ ≤ length l₂
+| _, _, sublist.slnil => le_refl 0
+| _, _, sublist.cons l₁ l₂ a s => le_succ_of_le (length_le_of_sublist s)
+| _, _, sublist.cons2 l₁ l₂ a s => succ_le_succ (length_le_of_sublist s)

--- a/Mathlib/Init/Data/List/Lemmas.lean
+++ b/Mathlib/Init/Data/List/Lemmas.lean
@@ -52,11 +52,9 @@ theorem map_singleton (f : α → β) (a : α) : map f [a] = [f a] := rfl
 
 theorem mem_nil_iff (a : α) : a ∈ ([] : List α) ↔ False := Iff.rfl
 
-@[simp] theorem not_mem_nil (a : α) : a ∉ ([] : List α) := not_false
+theorem not_mem_nil (a : α) : a ∉ ([] : List α) := not_false
 
 theorem mem_cons_self (a : α) (l : List α) : a ∈ a :: l := Or.inl rfl
-
-@[simp] theorem mem_cons_iff (a y : α) (l : List α) : a ∈ y :: l ↔ a = y ∨ a ∈ l := Iff.rfl
 
 theorem mem_cons_eq (a y : α) (l : List α) : (a ∈ y :: l) = (a = y ∨ a ∈ l) := rfl
 

--- a/Mathlib/Init/Data/Nat/Lemmas.lean
+++ b/Mathlib/Init/Data/Nat/Lemmas.lean
@@ -209,10 +209,12 @@ protected lemma sub_eq_iff_eq_add {a b c : ℕ} (ab : b ≤ a) : a - b = c ↔ a
 protected lemma lt_of_sub_eq_succ (H : m - n = succ l) : n < m :=
 not_le.1 fun H' => by simp [Nat.sub_eq_zero_of_le H'] at H
 
-protected lemma zero_min (a : ℕ) : Nat.min 0 a = 0 :=
+@[simp] protected lemma min_eq_min (a : ℕ) : Nat.min a b = min a b := rfl
+
+protected lemma zero_min (a : ℕ) : min 0 a = 0 :=
 min_eq_left (zero_le a)
 
-protected lemma min_zero (a : ℕ) : Nat.min a 0 = 0 :=
+protected lemma min_zero (a : ℕ) : min a 0 = 0 :=
 min_eq_right (zero_le a)
 
 -- Distribute succ over min

--- a/Mathlib/Init/Data/Option/Basic.lean
+++ b/Mathlib/Init/Data/Option/Basic.lean
@@ -1,0 +1,10 @@
+/-
+Copyright (c) 2014 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Leonardo de Moura
+-/
+
+namespace Option
+
+def get {α : Type u} : ∀ {o : Option α}, isSome o → α
+| some x, h => x

--- a/Mathlib/Init/Data/Option/Instances.lean
+++ b/Mathlib/Init/Data/Option/Instances.lean
@@ -1,0 +1,10 @@
+/-
+Copyright (c) 2021 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro
+-/
+
+instance : LawfulFunctor Option where
+  map_const := rfl
+  id_map x := by cases x <;> rfl
+  comp_map f g x := by cases x <;> rfl

--- a/Mathlib/Init/Function.lean
+++ b/Mathlib/Init/Function.lean
@@ -48,11 +48,11 @@ theorem comp.assoc (f : φ → δ) (g : β → φ) (h : α → β) : (f ∘ g) �
 theorem comp_const_right (f : β → φ) (b : β) : f ∘ (const α b) = const α (f b) := rfl
 
 /-- A function `f : α → β` is called injective if `f x = f y` implies `x = y`. -/
-@[reducible] def injective (f : α → β) : Prop := ∀ {a₁ a₂}, f a₁ = f a₂ → a₁ = a₂
+@[reducible] def injective (f : α → β) : Prop := ∀ ⦃a₁ a₂⦄, f a₁ = f a₂ → a₁ = a₂
 
 theorem injective.comp {g : β → φ} {f : α → β} (hg : injective g) (hf : injective f) :
   injective (g ∘ f) :=
-λ h => hf (hg h)
+fun _ _ h => hf (hg h)
 
 /-- A function `f : α → β` is calles surjective if every `b : β` is equal to `f a`
 for some `a : α`. -/
@@ -104,7 +104,7 @@ theorem left_inverse_of_surjective_of_right_inverse {f : α → β} {g : β → 
   let ⟨x, hx⟩ := surjf y
   by rw [← hx, rfg]
 
-theorem injective_id : injective (@id α) := id
+theorem injective_id : injective (@id α) := fun _ _ => id
 
 theorem surjective_id : surjective (@id α) := λ a => ⟨a, rfl⟩
 


### PR DESCRIPTION
This ports the files:

* `Init.Data.Option.{Basic, Instances}`
* `Init.Data.List.{Basic, Instances, Lemmas}`
* `Data.Option.{Basic, Defs}`
* `Data.List.Defs`

nearly in their entirety; a few definitions were skipped for missing prerequisites.

* `length'` and `append'` were removed, since they have been upstreamed
* `Nat.min` is now simp-reduced in favor of `min`, and existing theorems restated using  `min`
* `Function.injective` now uses `{{}}` arguments