### PR TITLE
[Merged by Bors] - chore: snake case tactics

### DIFF
--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -570,8 +570,7 @@ theorem get?_eq_get : ∀ {l : List α} {n} h, l.get? n = some (get l n h)
 | a :: l, n+1, h => @get?_eq_get _ l n _
 
 theorem get?_len_le : ∀ {l : List α} {n}, length l ≤ n → l.get? n = none
-| [], n, h => by cases n <;> rfl
-  -- rfl -- TODO: lean4#887
+| [], n, h => rfl
 | a :: l, n+1, h => @get?_len_le _ l n $ Nat.le_of_succ_le_succ h
 
 theorem get?_eq_some {l : List α} {n a} : l.get? n = some a ↔ ∃ h, get l n h = a :=
@@ -584,7 +583,7 @@ theorem get?_eq_some {l : List α} {n a} : l.get? n = some a ↔ ∃ h, get l n 
 @[simp] theorem get?_eq_none_iff {l : List α} {n} : l.get? n = none ↔ length l ≤ n := by
   constructor
   · intro h
-    byContra h'
+    by_contra h'
     have h₂ : ∃ h , l.get n h = l.get n (lt_of_not_ge h') := ⟨lt_of_not_ge h', rfl⟩
     rw [← get?_eq_some, h] at h₂
     cases h₂
@@ -610,8 +609,7 @@ theorem mem_iff_get {a} {l : List α} : a ∈ l ↔ ∃ n h, get l n h = a :=
 theorem mem_iff_get? {a} {l : List α} : a ∈ l ↔ ∃ n, l.get? n = some a :=
   mem_iff_get.trans $ exists_congr fun n => get?_eq_some.symm
 
-theorem get?_zero (l : List α) : l.get? 0 = l.head? := by
-  cases l <;> rfl
+theorem get?_zero (l : List α) : l.get? 0 = l.head? := by cases l <;> rfl
 
 theorem get?_injective {α : Type u} {xs : List α} {i j : ℕ}
   (h₀ : i < xs.length)
@@ -633,7 +631,7 @@ theorem get?_injective {α : Type u} {xs : List α} {i j : ℕ}
     exact ⟨_, h₂⟩; exact ⟨_ , h₂.symm⟩
 
 @[simp] theorem get?_map (f : α → β) : ∀ l n, (map f l).get? n = (l.get? n).map f
-| [], n => by cases n <;> rfl
+| [], n => rfl
 | a :: l, 0 => rfl
 | a :: l, n+1 => get?_map f l n
 
@@ -664,7 +662,6 @@ theorem get_zero [Inhabited α] {L : List α} (h : 0 < L.length) : L.get 0 h = L
   cases L; {cases h}; simp
 
 theorem get_append : ∀ {l₁ l₂ : List α} {n : ℕ} hn₁ hn₂, (l₁ ++ l₂).get n hn₁ = l₁.get n hn₂
-| [], _, n, hn₁, hn₂ => (Nat.not_lt_zero _ hn₂).elim
 | a :: l, _, 0, hn₁, hn₂ => rfl
 | a :: l, _, n+1, hn₁, hn₂ => by
   simp only [get, cons_append] <;> exact get_append _ _
@@ -794,7 +791,6 @@ theorem get?_set_ne (a : α) {m n} (l : List α) (h : m ≠ n) : (set l m a).get
 theorem set_comm (a b : α) : ∀ {n m : ℕ} (l : List α) (h : n ≠ m),
   (l.set n a).set m b = (l.set m b).set n a
 | _, _, [], _ => by simp
-| 0, 0, x :: t, h => absurd rfl h
 | n+1, 0, x :: t, h => by simp [set]
 | 0, m+1, x :: t, h => by simp [set]
 | n+1, m+1, x :: t, h => by
@@ -812,7 +808,6 @@ theorem set_comm (a b : α) : ∀ {n m : ℕ} (l : List α) (h : n ≠ m),
   rw [← Option.some_inj, ← List.get?_eq_get, List.get?_set_ne _ _ h, List.get?_eq_get]
 
 theorem mem_or_eq_of_mem_set : ∀ {l : List α} {n : ℕ} {a b : α} h : a ∈ l.set n b, a ∈ l ∨ a = b
-| [], n, a, b, h => False.elim h
 | c :: l, 0, a, b, h => ((mem_cons ..).1 h).elim Or.inr (Or.inl ∘ mem_cons_of_mem _)
 | c :: l, n+1, a, b, h =>
   ((mem_cons ..).1 h).elim (fun h => h ▸ Or.inl (mem_cons_self ..))
@@ -898,8 +893,8 @@ theorem exists_or_eq_self_of_erasep (p : α → Prop) [DecidablePred p] (l : Lis
     l.erasep p = l ∨
       ∃ a l₁ l₂, (∀ b ∈ l₁, ¬ p b) ∧ p a ∧ l = l₁ ++ a :: l₂ ∧ l.erasep p = l₁ ++ l₂ := by
   by_cases h : ∃ a ∈ l, p a
-  · match h with
-    | ⟨a, ha, pa⟩ => exact Or.inr (exists_of_erasep ha pa)
+  · let ⟨a, ha, pa⟩ := h
+    exact Or.inr (exists_of_erasep ha pa)
   · simp at h
     exact Or.inl (erasep_of_forall_not h)
 

--- a/Mathlib/Mathport/Syntax.lean
+++ b/Mathlib/Mathport/Syntax.lean
@@ -111,13 +111,13 @@ end Tactic
 
 namespace Tactic
 
-syntax (name := propagateTags) "propagateTags " tacticSeq : tactic
+syntax (name := propagateTags) "propagate_tags " tacticSeq : tactic
 syntax (name := fapply) "fapply " term : tactic
 syntax (name := eapply) "eapply " term : tactic
 syntax (name := applyWith) "apply " term " with " term : tactic
 syntax (name := mapply) "mapply " term : tactic
-syntax (name := toExpr') "toExpr' " term : tactic
-syntax (name := withCases) "withCases " tacticSeq : tactic
+syntax (name := toExpr') "to_expr' " term : tactic
+syntax (name := withCases) "with_cases " tacticSeq : tactic
 syntax (name := induction') "induction' " casesTarget,+ (" using " ident)?
   (" with " (colGt binderIdent)+)? (" generalizing " (colGt ident)+)? : tactic
 syntax caseArg := binderIdent,+ (" :" (ppSpace (ident <|> "_"))+)?
@@ -125,9 +125,9 @@ syntax (name := case') "case' " (("[" caseArg,* "]") <|> caseArg) " => " tacticS
 syntax "destruct " term : tactic
 syntax (name := cases') "cases' " casesTarget,+ (" using " ident)?
   (" with " (colGt binderIdent)+)? : tactic
-syntax (name := casesM) "casesM" "*"? ppSpace term,* : tactic
-syntax (name := casesType) "casesType" "*"? ppSpace ident* : tactic
-syntax (name := casesType!) "casesType!" "*"? ppSpace ident* : tactic
+syntax (name := casesM) "casesm" "*"? ppSpace term,* : tactic
+syntax (name := casesType) "cases_type" "*"? ppSpace ident* : tactic
+syntax (name := casesType!) "cases_type!" "*"? ppSpace ident* : tactic
 syntax (name := abstract) "abstract" (ppSpace ident)? ppSpace tacticSeq : tactic
 
 -- unstructured have/let/suffices
@@ -140,41 +140,41 @@ syntax (name := existsi) "exists " term,* : tactic
 syntax (name := eConstructor) "econstructor" : tactic
 syntax (name := left) "left" : tactic
 syntax (name := right) "right" : tactic
-syntax (name := constructorM) "constructorM" "*"? ppSpace term,* : tactic
+syntax (name := constructorM) "constructorm" "*"? ppSpace term,* : tactic
 syntax (name := injections') "injections" (" with " (colGt (ident <|> "_"))+)? : tactic
 syntax (name := simp') "simp'" "*"? (" (" &"config" " := " term ")")? (&" only")?
   (" [" simpArg,* "]")? (" with " (colGt ident)+)? (ppSpace location)? : tactic
-syntax (name := simpIntro) "simpIntro" (" (" &"config" " := " term ")")?
+syntax (name := simpIntro) "simp_intro" (" (" &"config" " := " term ")")?
   (ppSpace (colGt (ident <|> "_")))* (&" only")? (" [" simpArg,* "]")? (" with " ident+)? : tactic
 syntax (name := dsimp) "dsimp" (" (" &"config" " := " term ")")? (&" only")?
   (" [" simpArg,* "]")? (" with " (colGt ident)+)? (ppSpace location)? : tactic
 syntax (name := symm) "symm" : tactic
 syntax (name := trans) "trans" (ppSpace (colGt term))? : tactic
-syntax (name := acRfl) "acRfl" : tactic
+syntax (name := acRfl) "ac_rfl" : tactic
 syntax (name := cc) "cc" : tactic
-syntax (name := substVars) "substVars" : tactic
+syntax (name := substVars) "subst_vars" : tactic
 syntax (name := dUnfold) "dunfold" (" (" &"config" " := " term ")")?
   (ppSpace (colGt ident))* (ppSpace location)? : tactic
 syntax (name := delta') "delta'" (colGt ident)* (ppSpace location)? : tactic
-syntax (name := unfoldProjs) "unfoldProjs" (" (" &"config" " := " term ")")?
+syntax (name := unfoldProjs) "unfold_projs" (" (" &"config" " := " term ")")?
   (ppSpace location)? : tactic
 syntax (name := unfold) "unfold" (" (" &"config" " := " term ")")?
   (ppSpace (colGt ident))* (ppSpace location)? : tactic
 syntax (name := unfold1) "unfold1" (" (" &"config" " := " term ")")?
   (ppSpace (colGt ident))* (ppSpace location)? : tactic
-syntax (name := inferOptParam) "inferOptParam" : tactic
-syntax (name := inferAutoParam) "inferAutoParam" : tactic
-syntax (name := guardExprEq) "guardExpr " term:51 " =ₐ " term : tactic -- alpha equality
-syntax (name := guardTarget) "guardTarget" " =ₐ " term : tactic -- alpha equality
+syntax (name := inferOptParam) "infer_opt_param" : tactic
+syntax (name := inferAutoParam) "infer_auto_param" : tactic
+syntax (name := guardExprEq) "guard_expr " term:51 " =ₐ " term : tactic -- alpha equality
+syntax (name := guardTarget) "guard_target" " =ₐ " term : tactic -- alpha equality
 
--- There is already a `byCases` tactic in core (in `src/init/classical.lean`)
+-- There is already a `by_cases` tactic in core (in `src/init/classical.lean`)
 -- so for now we add a primed version to support the optional identifier,
 -- and available `decidable` instances.
-syntax (name := byCases') "byCases' " atomic(ident " : ")? term : tactic
+syntax (name := byCases') "by_cases' " atomic(ident " : ")? term : tactic
 
-syntax (name := typeCheck) "typeCheck " term : tactic
+syntax (name := typeCheck) "type_check " term : tactic
 syntax (name := rsimp) "rsimp" : tactic
-syntax (name := compVal) "compVal" : tactic
+syntax (name := compVal) "comp_val" : tactic
 syntax (name := async) "async " tacticSeq : tactic
 
 namespace Conv
@@ -183,7 +183,7 @@ open Tactic (simpArg rwRuleSeq)
 syntax (name := «for») "for " term:max " [" num,* "]" " => " tacticSeq : conv
 syntax (name := dsimp) "dsimp" (" (" &"config" " := " term ")")? (&" only")?
   (" [" simpArg,* "]")? (" with " (colGt ident)+)? : conv
-syntax (name := guardLHS) "guardLHS " " =ₐ " term : conv
+syntax (name := guardLHS) "guard_lhs " " =ₐ " term : conv
 
 end Conv
 
@@ -204,21 +204,21 @@ syntax (name := ext?) "ext?" (ppSpace rcasesPat)* (" : " num)? : tactic
 syntax (name := apply') "apply' " term : tactic
 syntax (name := fapply') "fapply' " term : tactic
 syntax (name := eapply') "eapply' " term : tactic
-syntax (name := applyWith') "applyWith' " ("(" &"config" " := " term ")")? term : tactic
+syntax (name := applyWith') "apply_with' " ("(" &"config" " := " term ")")? term : tactic
 syntax (name := mapply') "mapply' " term : tactic
 syntax (name := rfl') "rfl'" : tactic
 syntax (name := symm') "symm'" (ppSpace location)? : tactic
 syntax (name := trans') "trans'" (ppSpace term)? : tactic
 
 syntax (name := fsplit) "fsplit" : tactic
-syntax (name := injectionsAndClear) "injectionsAndClear" : tactic
+syntax (name := injectionsAndClear) "injections_and_clear" : tactic
 
 syntax (name := fconstructor) "fconstructor" : tactic
-syntax (name := tryFor) "tryFor " term:max tacticSeq : tactic
+syntax (name := tryFor) "try_for " term:max tacticSeq : tactic
 syntax (name := substs) "substs" (ppSpace ident)* : tactic
-syntax (name := unfoldCoes) "unfoldCoes" (ppSpace location)? : tactic
-syntax (name := unfoldWf) "unfoldWf" : tactic
-syntax (name := unfoldAux) "unfoldAux" : tactic
+syntax (name := unfoldCoes) "unfold_coes" (ppSpace location)? : tactic
+syntax (name := unfoldWf) "unfold_wf" : tactic
+syntax (name := unfoldAux) "unfold_aux" : tactic
 syntax (name := recover) "recover" : tactic
 syntax (name := «continue») "continue " tacticSeq : tactic
 syntax (name := swap) "swap" (ppSpace num)? : tactic
@@ -230,40 +230,40 @@ syntax (name := classical) "classical" : tactic
 syntax (name := generalizeHyp) "generalize " atomic(ident " : ")? term:51 " = " ident
   ppSpace location : tactic
 syntax (name := clean) "clean " term : tactic
-syntax (name := refineStruct) "refineStruct " term : tactic
-syntax (name := matchHyp) "matchHyp " ("(" &"m" " := " term ") ")? ident " : " term : tactic
-syntax (name := guardHypNums) "guardHypNums " num : tactic
-syntax (name := guardTags) "guardTags" (ppSpace ident)* : tactic
-syntax (name := guardProofTerm) "guardProofTerm " tactic:51 " => " term : tactic
-syntax (name := failIfSuccess?) "failIfSuccess? " str ppSpace tacticSeq : tactic
+syntax (name := refineStruct) "refine_struct " term : tactic
+syntax (name := matchHyp) "match_hyp " ("(" &"m" " := " term ") ")? ident " : " term : tactic
+syntax (name := guardHypNums) "guard_hyp_nums " num : tactic
+syntax (name := guardTags) "guard_tags" (ppSpace ident)* : tactic
+syntax (name := guardProofTerm) "guard_proof_term " tactic:51 " => " term : tactic
+syntax (name := failIfSuccess?) "fail_if_success? " str ppSpace tacticSeq : tactic
 syntax (name := field) "field " ident " => " tacticSeq : tactic
-syntax (name := haveField) "haveField" : tactic
-syntax (name := applyField) "applyField" : tactic
-syntax (name := applyRules) "applyRules" (" (" &"config" " := " term ")")?
+syntax (name := haveField) "have_field" : tactic
+syntax (name := applyField) "apply_field" : tactic
+syntax (name := applyRules) "apply_rules" (" (" &"config" " := " term ")")?
   " [" term,* "]" (ppSpace num)? : tactic
-syntax (name := hGeneralize) "hGeneralize " atomic(binderIdent " : ")? term:51 " = " ident
+syntax (name := hGeneralize) "h_generalize " atomic(binderIdent " : ")? term:51 " = " ident
   (" with " binderIdent)? : tactic
-syntax (name := hGeneralize!) "hGeneralize! " atomic(binderIdent " : ")? term:51 " = " ident
+syntax (name := hGeneralize!) "h_generalize! " atomic(binderIdent " : ")? term:51 " = " ident
   (" with " binderIdent)? : tactic
-syntax (name := guardExprEq') "guardExpr " term:51 " = " term : tactic -- definitional equality
-syntax (name := guardTarget') "guardTarget" " = " term : tactic -- definitional equality
+syntax (name := guardExprEq') "guard_expr " term:51 " = " term : tactic -- definitional equality
+syntax (name := guardTarget') "guard_target" " = " term : tactic -- definitional equality
 syntax (name := triv) "triv" : tactic
 syntax (name := use) "use " term,+ : tactic
-syntax (name := clearAuxDecl) "clearAuxDecl" : tactic
+syntax (name := clearAuxDecl) "clear_aux_decl" : tactic
 syntax (name := set) "set " ident (" : " term)? " := " term (" with " "←"? ident)? : tactic
 syntax (name := set!) "set! " ident (" : " term)? " := " term (" with " "←"? ident)? : tactic
 syntax (name := clearExcept) "clear " "*" " - " ident* : tactic
-syntax (name := extractGoal) "extractGoal" (ppSpace ident)?
+syntax (name := extractGoal) "extract_goal" (ppSpace ident)?
   (" with" (ppSpace (colGt ident))*)? : tactic
-syntax (name := extractGoal!) "extractGoal!" (ppSpace ident)?
+syntax (name := extractGoal!) "extract_goal!" (ppSpace ident)?
   (" with" (ppSpace (colGt ident))*)? : tactic
 syntax (name := inhabit) "inhabit " atomic(ident " : ")? term : tactic
-syntax (name := revertDeps) "revertDeps" (ppSpace (colGt ident))* : tactic
-syntax (name := revertAfter) "revertAfter " ident : tactic
-syntax (name := revertTargetDeps) "revertTargetDeps" : tactic
-syntax (name := clearValue) "clearValue" (ppSpace (colGt ident))* : tactic
+syntax (name := revertDeps) "revert_deps" (ppSpace (colGt ident))* : tactic
+syntax (name := revertAfter) "revert_after " ident : tactic
+syntax (name := revertTargetDeps) "revert_target_deps" : tactic
+syntax (name := clearValue) "clear_value" (ppSpace (colGt ident))* : tactic
 
-syntax (name := applyAssumption) "applyAssumption" : tactic
+syntax (name := applyAssumption) "apply_assumption" : tactic
 
 syntax (name := hint) "hint" : tactic
 
@@ -277,11 +277,11 @@ syntax (name := congr) "congr" (ppSpace (colGt num))?
 syntax (name := rcongr) "rcongr" (ppSpace (colGt rcasesPat))* : tactic
 syntax (name := convert) "convert " "← "? term (" using " num)? : tactic
 syntax (name := convertTo) "convertTo " term (" using " num)? : tactic
-syntax (name := acChange) "acChange " term (" using " num)? : tactic
+syntax (name := acChange) "ac_change " term (" using " num)? : tactic
 
 syntax (name := decide!) "decide!" : tactic
 
-syntax (name := deltaInstance) "deltaInstance" (ppSpace ident)* : tactic
+syntax (name := deltaInstance) "delta_instance" (ppSpace ident)* : tactic
 
 syntax (name := elide) "elide " num (ppSpace location)? : tactic
 syntax (name := unelide) "unelide" (ppSpace location)? : tactic
@@ -296,7 +296,7 @@ syntax (name := finish) "finish" (" (" &"config" " := " term ")")?
 syntax generalizesArg := (ident " : ")? term:51 " = " ident
 syntax (name := generalizes) "generalizes " "[" generalizesArg,* "]" : tactic
 
-syntax (name := generalizeProofs) "generalizeProofs"
+syntax (name := generalizeProofs) "generalize_proofs"
   (ppSpace (colGt binderIdent))* (ppSpace location)? : tactic
 
 syntax (name := itauto) "itauto" : tactic
@@ -304,32 +304,32 @@ syntax (name := itauto) "itauto" : tactic
 syntax (name := lift) "lift " term " to " term
   (" using " term)? (" with " binderIdent+)? : tactic
 
-syntax (name := pushCast) "pushCast"
+syntax (name := pushCast) "push_cast"
   (" [" Parser.Tactic.simpArg,* "]")? (ppSpace location)? : tactic
-syntax (name := normCast) "normCast" (ppSpace location)? : tactic
-syntax (name := rwModCast) "rwModCast " rwRuleSeq (ppSpace location)? : tactic
-syntax (name := exactModCast) "exactModCast " term : tactic
-syntax (name := applyModCast) "applyModCast " term : tactic
-syntax (name := assumptionModCast) "assumptionModCast" : tactic
+syntax (name := normCast) "norm_cast" (ppSpace location)? : tactic
+syntax (name := rwModCast) "rw_mod_cast " rwRuleSeq (ppSpace location)? : tactic
+syntax (name := exactModCast) "exact_mod_cast " term : tactic
+syntax (name := applyModCast) "apply_mod_cast " term : tactic
+syntax (name := assumptionModCast) "assumption_mod_cast" : tactic
 
 syntax (name := obviously) "obviously" : tactic
 
-syntax (name := prettyCases) "prettyCases" : tactic
+syntax (name := prettyCases) "pretty_cases" : tactic
 
-syntax (name := pushNeg) "pushNeg" (ppSpace location)? : tactic
+syntax (name := pushNeg) "push_neg" (ppSpace location)? : tactic
 
 syntax (name := contrapose) "contrapose" (ppSpace ident (" with " ident)?)? : tactic
 syntax (name := contrapose!) "contrapose!" (ppSpace ident (" with " ident)?)? : tactic
 
-syntax (name := renameVar) "renameVar " ident " → " ident (ppSpace location)? : tactic
+syntax (name := renameVar) "rename_var " ident " → " ident (ppSpace location)? : tactic
 
-syntax (name := assocRw) "assocRw " rwRuleSeq (ppSpace location)? : tactic
+syntax (name := assocRw) "assoc_rw " rwRuleSeq (ppSpace location)? : tactic
 
-syntax (name := simpRw) "simpRw " rwRuleSeq (ppSpace location)? : tactic
+syntax (name := simpRw) "simp_rw " rwRuleSeq (ppSpace location)? : tactic
 
-syntax (name := dsimpResult) "dsimpResult " (&"only ")? ("[" Tactic.simpArg,* "]")?
+syntax (name := dsimpResult) "dsimp_result " (&"only ")? ("[" Tactic.simpArg,* "]")?
   (" with " ident+)? " => " tacticSeq : tactic
-syntax (name := simpResult) "simpResult " (&"only ")? ("[" Tactic.simpArg,* "]")?
+syntax (name := simpResult) "simp_result " (&"only ")? ("[" Tactic.simpArg,* "]")?
   (" with " ident+)? " => " tacticSeq : tactic
 
 syntax (name := simpa) "simpa" (" (" &"config" " := " term ")")? (&" only")?
@@ -341,46 +341,46 @@ syntax (name := simpa?) "simpa?" (" (" &"config" " := " term ")")? (&" only")?
 syntax (name := simpa!?) "simpa!?" (" (" &"config" " := " term ")")? (&" only")?
   (" [" Tactic.simpArg,* "]")? (" with " (colGt ident)+)? (" using " term)? : tactic
 
-syntax (name := splitIfs) "splitIfs" (ppSpace location)? (" with " binderIdent+)? : tactic
+syntax (name := splitIfs) "split_ifs" (ppSpace location)? (" with " binderIdent+)? : tactic
 
-syntax (name := squeezeScope) "squeezeScope " tacticSeq : tactic
-syntax (name := squeezeSimp) "squeezeSimp" (" (" &"config" " := " term ")")? (&" only")?
+syntax (name := squeezeScope) "squeeze_scope " tacticSeq : tactic
+syntax (name := squeezeSimp) "squeeze_simp" (" (" &"config" " := " term ")")? (&" only")?
   (" [" simpArg,* "]")? (" with " (colGt ident)+)? (ppSpace location)? : tactic
-syntax (name := squeezeSimp?) "squeezeSimp?" (" (" &"config" " := " term ")")? (&" only")?
+syntax (name := squeezeSimp?) "squeeze_simp?" (" (" &"config" " := " term ")")? (&" only")?
   (" [" simpArg,* "]")? (" with " (colGt ident)+)? (ppSpace location)? : tactic
-syntax (name := squeezeSimp!) "squeezeSimp!" (" (" &"config" " := " term ")")? (&" only")?
+syntax (name := squeezeSimp!) "squeeze_simp!" (" (" &"config" " := " term ")")? (&" only")?
   (" [" simpArg,* "]")? (" with " (colGt ident)+)? (ppSpace location)? : tactic
-syntax (name := squeezeSimp?!) "squeezeSimp?!" (" (" &"config" " := " term ")")? (&" only")?
+syntax (name := squeezeSimp?!) "squeeze_simp?!" (" (" &"config" " := " term ")")? (&" only")?
   (" [" simpArg,* "]")? (" with " (colGt ident)+)? (ppSpace location)? : tactic
-syntax (name := squeezeSimpa) "squeezeSimpa" (" (" &"config" " := " term ")")? (&" only")?
+syntax (name := squeezeSimpa) "squeeze_simpa" (" (" &"config" " := " term ")")? (&" only")?
   (" [" simpArg,* "]")? (" with " (colGt ident)+)? (" using " term)? : tactic
-syntax (name := squeezeSimpa?) "squeezeSimpa?" (" (" &"config" " := " term ")")? (&" only")?
+syntax (name := squeezeSimpa?) "squeeze_simpa?" (" (" &"config" " := " term ")")? (&" only")?
   (" [" simpArg,* "]")? (" with " (colGt ident)+)? (" using " term)? : tactic
-syntax (name := squeezeSimpa!) "squeezeSimpa!" (" (" &"config" " := " term ")")? (&" only")?
+syntax (name := squeezeSimpa!) "squeeze_simpa!" (" (" &"config" " := " term ")")? (&" only")?
   (" [" simpArg,* "]")? (" with " (colGt ident)+)? (" using " term)? : tactic
-syntax (name := squeezeSimpa?!) "squeezeSimpa?!" (" (" &"config" " := " term ")")? (&" only")?
+syntax (name := squeezeSimpa?!) "squeeze_simpa?!" (" (" &"config" " := " term ")")? (&" only")?
   (" [" simpArg,* "]")? (" with " (colGt ident)+)? (" using " term)? : tactic
-syntax (name := squeezeDSimp) "squeezeDSimp" (" (" &"config" " := " term ")")? (&" only")?
+syntax (name := squeezeDSimp) "squeeze_dsimp" (" (" &"config" " := " term ")")? (&" only")?
   (" [" simpArg,* "]")? (" with " (colGt ident)+)? (ppSpace location)? : tactic
-syntax (name := squeezeDSimp?) "squeezeDSimp?" (" (" &"config" " := " term ")")? (&" only")?
+syntax (name := squeezeDSimp?) "squeeze_dsimp?" (" (" &"config" " := " term ")")? (&" only")?
   (" [" simpArg,* "]")? (" with " (colGt ident)+)? (ppSpace location)? : tactic
-syntax (name := squeezeDSimp!) "squeezeDSimp!" (" (" &"config" " := " term ")")? (&" only")?
+syntax (name := squeezeDSimp!) "squeeze_dsimp!" (" (" &"config" " := " term ")")? (&" only")?
   (" [" simpArg,* "]")? (" with " (colGt ident)+)? (ppSpace location)? : tactic
-syntax (name := squeezeDSimp?!) "squeezeDSimp?!" (" (" &"config" " := " term ")")? (&" only")?
+syntax (name := squeezeDSimp?!) "squeeze_dsimp?!" (" (" &"config" " := " term ")")? (&" only")?
   (" [" simpArg,* "]")? (" with " (colGt ident)+)? (ppSpace location)? : tactic
 
 syntax (name := suggest) "suggest" (" (" &"config" " := " term ")")? (ppSpace num)?
   (" [" simpArg,* "]")? (" with " (colGt ident)+)? (" using " (colGt ident)+)? : tactic
-syntax (name := librarySearch!) "librarySearch!" (" (" &"config" " := " term ")")?
+syntax (name := librarySearch!) "library_search!" (" (" &"config" " := " term ")")?
   (" [" simpArg,* "]")? (" with " (colGt ident)+)? (" using " (colGt ident)+)? : tactic
 
 syntax (name := tauto) "tauto" (" (" &"config" " := " term ")")? : tactic
 syntax (name := tauto!) "tauto!" (" (" &"config" " := " term ")")? : tactic
 
-syntax (name := truncCases) "truncCases " term (" with " (colGt binderIdent)+)? : tactic
+syntax (name := truncCases) "trunc_cases " term (" with " (colGt binderIdent)+)? : tactic
 
-syntax (name := normNum1) "normNum1" (ppSpace location)? : tactic
-syntax (name := applyNormed) "applyNormed " term : tactic
+syntax (name := normNum1) "norm_num1" (ppSpace location)? : tactic
+syntax (name := applyNormed) "apply_normed " term : tactic
 
 syntax (name := abel1) "abel1" : tactic
 syntax (name := abel) "abel" (ppSpace (&"raw" <|> &"term"))? (ppSpace location)? : tactic
@@ -390,16 +390,16 @@ syntax (name := ring1) "ring1" : tactic
 syntax (name := ring1!) "ring1!" : tactic
 
 syntax ringMode := &"SOP" <|> &"raw" <|> &"horner"
-syntax (name := ringNF) "ringNF" (ppSpace ringMode)? (ppSpace location)? : tactic
-syntax (name := ringNF!) "ringNF!" (ppSpace ringMode)? (ppSpace location)? : tactic
+syntax (name := ringNF) "ring_nf" (ppSpace ringMode)? (ppSpace location)? : tactic
+syntax (name := ringNF!) "ring_nf!" (ppSpace ringMode)? (ppSpace location)? : tactic
 syntax (name := ring!) "ring!" : tactic
 
-syntax (name := ringExpEq) "ringExpEq" : tactic
-syntax (name := ringExpEq!) "ringExpEq!" : tactic
-syntax (name := ringExp) "ringExp" (ppSpace location)? : tactic
-syntax (name := ringExp!) "ringExp!" (ppSpace location)? : tactic
+syntax (name := ringExpEq) "ring_exp_eq" : tactic
+syntax (name := ringExpEq!) "ring_exp_eq!" : tactic
+syntax (name := ringExp) "ring_exp" (ppSpace location)? : tactic
+syntax (name := ringExp!) "ring_exp!" (ppSpace location)? : tactic
 
-syntax (name := noncommRing) "noncommRing" : tactic
+syntax (name := noncommRing) "noncomm_ring" : tactic
 
 syntax (name := linarith) "linarith" (" (" &"config" " := " term ")")?
   (&" only")? (" [" term,* "]")? : tactic
@@ -412,58 +412,58 @@ syntax (name := nlinarith!) "nlinarith!" (" (" &"config" " := " term ")")?
 
 syntax (name := omega) "omega" (&" manual")? (&" nat" <|> &" int")? : tactic
 
-syntax (name := tfaeHave) "tfaeHave " (ident " : ")? num (" → " <|> " ↔ " <|> " ← ") num : tactic
-syntax (name := tfaeFinish) "tfaeFinish" : tactic
+syntax (name := tfaeHave) "tfae_have " (ident " : ")? num (" → " <|> " ↔ " <|> " ← ") num : tactic
+syntax (name := tfaeFinish) "tfae_finish" : tactic
 
 syntax mono.side := &"left" <|> &"right" <|> &"both"
 syntax (name := mono) "mono" "*"? (ppSpace mono.side)?
   (" with " (colGt term),+)? (" using " (colGt simpArg),+)? : tactic
 
-syntax (name := acMono) "acMono" ("*" <|> ("^" num))?
+syntax (name := acMono) "ac_mono" ("*" <|> ("^" num))?
   (" (" &"config" " := " term ")")? ((" : " term) <|> (" := " term))? : tactic
 
-syntax (name := applyFun) "applyFun " term (ppSpace location)? (" using " term)? : tactic
+syntax (name := applyFun) "apply_fun " term (ppSpace location)? (" using " term)? : tactic
 
-syntax (name := finCases) "finCases " ("*" <|> (term,+)) (" with " term)? : tactic
+syntax (name := finCases) "fin_cases " ("*" <|> (term,+)) (" with " term)? : tactic
 
-syntax (name := intervalCases) "intervalCases" (ppSpace (colGt term))?
+syntax (name := intervalCases) "interval_cases" (ppSpace (colGt term))?
   (" using " term ", " term)? (" with " ident)? : tactic
 
 syntax (name := reassoc) "reassoc" (ppSpace (colGt ident))* : tactic
 syntax (name := reassoc!) "reassoc!" (ppSpace (colGt ident))* : tactic
-syntax (name := deriveReassocProof) "deriveReassocProof" : tactic
+syntax (name := deriveReassocProof) "derive_reassoc_proof" : tactic
 
-syntax (name := sliceLHS) "sliceLHS " num num " => " Conv.convSeq : tactic
-syntax (name := sliceRHS) "sliceRHS " num num " => " Conv.convSeq : tactic
+syntax (name := sliceLHS) "slice_lhs " num num " => " Conv.convSeq : tactic
+syntax (name := sliceRHS) "slice_rhs " num num " => " Conv.convSeq : tactic
 
-syntax (name := subtypeInstance) "subtypeInstance" : tactic
+syntax (name := subtypeInstance) "subtype_instance" : tactic
 
 syntax (name := group) "group" (ppSpace location)? : tactic
 
-syntax (name := cancelDenoms) "cancelDenoms" (ppSpace location)? : tactic
+syntax (name := cancelDenoms) "cancel_denoms" (ppSpace location)? : tactic
 
 syntax (name := zify) "zify" (" [" simpArg,* "]")? (ppSpace location)? : tactic
 
 syntax (name := transport) "transport" (ppSpace term)? " using " term : tactic
 
-syntax (name := unfoldCases) "unfoldCases " tacticSeq : tactic
+syntax (name := unfoldCases) "unfold_cases " tacticSeq : tactic
 
-syntax (name := fieldSimp) "fieldSimp" (" (" &"config" " := " term ")")? (&" only")?
+syntax (name := fieldSimp) "field_simp" (" (" &"config" " := " term ")")? (&" only")?
   (" [" Tactic.simpArg,* "]")? (" with " (colGt ident)+)? (ppSpace location)? : tactic
 
-syntax (name := equivRw) "equivRw " ("(" &"config" " := " term ") ")?
+syntax (name := equivRw) "equiv_rw " ("(" &"config" " := " term ") ")?
   term (ppSpace location)? : tactic
-syntax (name := equivRwType) "equivRwType " ("(" &"config" " := " term ") ")? term : tactic
+syntax (name := equivRwType) "equiv_rw_type " ("(" &"config" " := " term ") ")? term : tactic
 
-syntax (name := nthRw) "nthRw " num rwRuleSeq (ppSpace location)? : tactic
-syntax (name := nthRwLHS) "nthRwLHS " num rwRuleSeq (ppSpace location)? : tactic
-syntax (name := nthRwRHS) "nthRwRHS " num rwRuleSeq (ppSpace location)? : tactic
+syntax (name := nthRw) "nth_rw " num rwRuleSeq (ppSpace location)? : tactic
+syntax (name := nthRwLHS) "nth_rw_lhs " num rwRuleSeq (ppSpace location)? : tactic
+syntax (name := nthRwRHS) "nth_rw_rhs " num rwRuleSeq (ppSpace location)? : tactic
 
-syntax (name := rwSearch) "rwSearch " ("(" &"config" " := " term ") ")? rwRuleSeq : tactic
-syntax (name := rwSearch?) "rwSearch? " ("(" &"config" " := " term ") ")? rwRuleSeq : tactic
+syntax (name := rwSearch) "rw_search " ("(" &"config" " := " term ") ")? rwRuleSeq : tactic
+syntax (name := rwSearch?) "rw_search? " ("(" &"config" " := " term ") ")? rwRuleSeq : tactic
 
-syntax (name := piInstanceDeriveField) "piInstanceDeriveField" : tactic
-syntax (name := piInstance) "piInstance" : tactic
+syntax (name := piInstanceDeriveField) "pi_instance_derive_field" : tactic
+syntax (name := piInstance) "pi_instance" : tactic
 
 syntax (name := tidy) "tidy" (" (" &"config" " := " term ")")? : tactic
 syntax (name := tidy?) "tidy?" (" (" &"config" " := " term ")")? : tactic
@@ -473,60 +473,60 @@ syntax (name := wlog) "wlog" (" (" &"discharger" " := " term ")")?
 
 syntax (name := elementwise) "elementwise" (ppSpace (colGt ident))* : tactic
 syntax (name := elementwise!) "elementwise!" (ppSpace (colGt ident))* : tactic
-syntax (name := deriveElementwiseProof) "deriveElementwiseProof" : tactic
+syntax (name := deriveElementwiseProof) "derive_elementwise_proof" : tactic
 
-syntax (name := mkDecorations) "mkDecorations" : tactic
+syntax (name := mkDecorations) "mk_decorations" : tactic
 
 syntax (name := nontriviality) "nontriviality"
   (ppSpace (colGt term))? (" using " simpArg,+)? : tactic
 
-syntax (name := filterUpwards) "filterUpwards" " [" term,* "]" (ppSpace (colGt term))? : tactic
+syntax (name := filterUpwards) "filter_upwards" " [" term,* "]" (ppSpace (colGt term))? : tactic
 
-syntax (name := isBounded_default) "isBounded_default" : tactic
+syntax (name := isBounded_default) "is_bounded_default" : tactic
 
-syntax (name := opInduction) "opInduction" (ppSpace (colGt term))? : tactic
+syntax (name := opInduction) "op_induction" (ppSpace (colGt term))? : tactic
 
-syntax (name := mvBisim) "mvBisim" (ppSpace (colGt term))? (" with " binderIdent+)? : tactic
+syntax (name := mvBisim) "mv_bisim" (ppSpace (colGt term))? (" with " binderIdent+)? : tactic
 
 syntax (name := continuity) "continuity" (" (" &"config" " := " term ")")? : tactic
 syntax (name := continuity!) "continuity!" (" (" &"config" " := " term ")")? : tactic
 syntax (name := continuity?) "continuity?" (" (" &"config" " := " term ")")? : tactic
 syntax (name := continuity!?) "continuity!?" (" (" &"config" " := " term ")")? : tactic
 
-syntax (name := unitInterval) "unitInterval" : tactic
-syntax (name := mfldSetTac) "mfldSetTac" : tactic
+syntax (name := unitInterval) "unit_interval" : tactic
+syntax (name := mfldSetTac) "mfld_set_tac" : tactic
 
 syntax (name := measurability) "measurability" (" (" &"config" " := " term ")")? : tactic
 syntax (name := measurability!) "measurability!" (" (" &"config" " := " term ")")? : tactic
 syntax (name := measurability?) "measurability?" (" (" &"config" " := " term ")")? : tactic
 syntax (name := measurability!?) "measurability!?" (" (" &"config" " := " term ")")? : tactic
-syntax (name := padicIndexSimp) "padicIndexSimp" " [" term,* "]" (ppSpace location)? : tactic
+syntax (name := padicIndexSimp) "padic_index_simp" " [" term,* "]" (ppSpace location)? : tactic
 
 syntax (name := uniqueDiffWithinAt_Ici_Iic_univ) "uniqueDiffWithinAt_Ici_Iic_univ" : tactic
 
-syntax (name := ghostFunTac) "ghostFunTac " term ", " term : tactic
-syntax (name := ghostCalc) "ghostCalc" (ppSpace binderIdent)* : tactic
-syntax (name := initRing) "initRing" (" using " term)? : tactic
-syntax (name := ghostSimp) "ghostSimp" (" [" simpArg,* "]")? : tactic
-syntax (name := wittTruncateFunTac) "wittTruncateFunTac" : tactic
+syntax (name := ghostFunTac) "ghost_fun_tac " term ", " term : tactic
+syntax (name := ghostCalc) "ghost_calc" (ppSpace binderIdent)* : tactic
+syntax (name := initRing) "init_ring" (" using " term)? : tactic
+syntax (name := ghostSimp) "ghost_simp" (" [" simpArg,* "]")? : tactic
+syntax (name := wittTruncateFunTac) "witt_truncate_fun_tac" : tactic
 
 namespace Conv
 
-syntax (name := applyCongr) "applyCongr" (ppSpace (colGt term))? : conv
-syntax (name := guardTarget) "guardTarget" " =ₐ " term : conv
+syntax (name := applyCongr) "apply_congr" (ppSpace (colGt term))? : conv
+syntax (name := guardTarget) "guard_target" " =ₐ " term : conv
 
-syntax (name := normCast) "normCast" : conv
+syntax (name := normCast) "norm_cast" : conv
 
-syntax (name := normNum1) "normNum1" : conv
-syntax (name := normNum) "normNum" (" [" simpArg,* "]")? : conv
+syntax (name := normNum1) "norm_num1" : conv
+syntax (name := normNum) "norm_num" (" [" simpArg,* "]")? : conv
 
-syntax (name := ringNF) "ringNF" (ppSpace ringMode)? : conv
-syntax (name := ringNF!) "ringNF!" (ppSpace ringMode)? : conv
+syntax (name := ringNF) "ring_nf" (ppSpace ringMode)? : conv
+syntax (name := ringNF!) "ring_nf!" (ppSpace ringMode)? : conv
 syntax (name := ring) "ring" : conv
 syntax (name := ring!) "ring!" : conv
 
-syntax (name := ringExp) "ringExp" : conv
-syntax (name := ringExp!) "ringExp!" : conv
+syntax (name := ringExp) "ring_exp" : conv
+syntax (name := ringExp!) "ring_exp!" : conv
 
 syntax (name := slice) "slice " num num : conv
 
@@ -540,16 +540,16 @@ syntax (name := intro!) "intro!" : attr
 
 syntax (name := ext) "ext" (ppSpace ident)? : attr
 
-syntax (name := higherOrder) "higherOrder" (ppSpace ident)? : attr
+syntax (name := higherOrder) "higher_order" (ppSpace ident)? : attr
 syntax (name := interactive) "interactive" : attr
 
-syntax (name := mkIff) "mkIff" (ppSpace ident)? : attr
+syntax (name := mkIff) "mk_iff" (ppSpace ident)? : attr
 
-syntax (name := normCast) "normCast" (ppSpace (&"elim" <|> &"move" <|> &"squash"))? : attr
+syntax (name := normCast) "norm_cast" (ppSpace (&"elim" <|> &"move" <|> &"squash"))? : attr
 
-syntax (name := protectProj) "protectProj" (&" without" (ppSpace ident)+)? : attr
+syntax (name := protectProj) "protect_proj" (&" without" (ppSpace ident)+)? : attr
 
-syntax (name := notationClass) "notationClass" "*"? (ppSpace ident)? : attr
+syntax (name := notationClass) "notation_class" "*"? (ppSpace ident)? : attr
 
 syntax (name := mono) "mono" (ppSpace Tactic.mono.side)? : attr
 
@@ -559,12 +559,12 @@ syntax (name := ancestor) "ancestor" (ppSpace ident)* : attr
 
 syntax (name := elementwise) "elementwise" (ppSpace ident)? : attr
 
-syntax (name := toAdditiveIgnoreArgs) "toAdditiveIgnoreArgs" num* : attr
-syntax (name := toAdditiveReorder) "toAdditiveReorder" num* : attr
-syntax (name := toAdditive) "toAdditive" (ppSpace ident)? (ppSpace str)? : attr
-syntax (name := toAdditive!) "toAdditive!" (ppSpace ident)? (ppSpace str)? : attr
-syntax (name := toAdditive?) "toAdditive?" (ppSpace ident)? (ppSpace str)? : attr
-syntax (name := toAdditive!?) "toAdditive!?" (ppSpace ident)? (ppSpace str)? : attr
+syntax (name := toAdditiveIgnoreArgs) "to_additive_ignore_args" num* : attr
+syntax (name := toAdditiveReorder) "to_additive_reorder" num* : attr
+syntax (name := toAdditive) "to_additive" (ppSpace ident)? (ppSpace str)? : attr
+syntax (name := toAdditive!) "to_additive!" (ppSpace ident)? (ppSpace str)? : attr
+syntax (name := toAdditive?) "to_additive?" (ppSpace ident)? (ppSpace str)? : attr
+syntax (name := toAdditive!?) "to_additive!?" (ppSpace ident)? (ppSpace str)? : attr
 
 end Attr
 

--- a/Mathlib/Mathport/Syntax.lean
+++ b/Mathlib/Mathport/Syntax.lean
@@ -276,7 +276,7 @@ syntax (name := congr) "congr" (ppSpace (colGt num))?
   (" with " (colGt rcasesPat)* (" : " num)?)? : tactic
 syntax (name := rcongr) "rcongr" (ppSpace (colGt rcasesPat))* : tactic
 syntax (name := convert) "convert " "← "? term (" using " num)? : tactic
-syntax (name := convertTo) "convertTo " term (" using " num)? : tactic
+syntax (name := convertTo) "convert_to " term (" using " num)? : tactic
 syntax (name := acChange) "ac_change " term (" using " num)? : tactic
 
 syntax (name := decide!) "decide!" : tactic
@@ -482,7 +482,7 @@ syntax (name := nontriviality) "nontriviality"
 
 syntax (name := filterUpwards) "filter_upwards" " [" term,* "]" (ppSpace (colGt term))? : tactic
 
-syntax (name := isBounded_default) "is_bounded_default" : tactic
+syntax (name := isBounded_default) "isBounded_default" : tactic
 
 syntax (name := opInduction) "op_induction" (ppSpace (colGt term))? : tactic
 

--- a/Mathlib/Tactic/Basic.lean
+++ b/Mathlib/Tactic/Basic.lean
@@ -120,7 +120,7 @@ elab (name := exacts) "exacts" "[" hs:term,* "]" : tactic => do
 /-- Check syntactic equality of two expressions.
 See also `guardExprEq` and `guardExprEq'` for testing
 up to alpha equality and definitional equality. -/
-elab (name := guardExprStrict) "guardExpr " r:term:51 " == " p:term : tactic => withMainContext do
+elab (name := guardExprStrict) "guard_expr " r:term:51 " == " p:term : tactic => withMainContext do
   let r ← elabTerm r none
   let p ← elabTerm p none
   if not (r == p) then throwError "failed: {r} != {p}"
@@ -128,13 +128,13 @@ elab (name := guardExprStrict) "guardExpr " r:term:51 " == " p:term : tactic => 
 /-- Check the target agrees (syntactically) with a given expression.
 See also `guardTarget` and `guardTarget'` for testing
 up to alpha equality and definitional equality. -/
-elab (name := guardTargetStrict) "guardTarget" " == " r:term : tactic => withMainContext do
+elab (name := guardTargetStrict) "guard_target" " == " r:term : tactic => withMainContext do
   let r ← elabTerm r none
   let t ← getMainTarget
   let t ← t.consumeMData
   if not (r == t) then throwError m!"target of main goal is {t}, not {r}"
 
-syntax (name := guardHyp) "guardHyp " ident
+syntax (name := guardHyp) "guard_hyp " ident
   ((" : " <|> " :ₐ ") term)? ((" := " <|> " :=ₐ ") term)? : tactic
 
 /-- Check that a named hypothesis has a given type and/or value.
@@ -146,7 +146,7 @@ while `guardHyp h :=ₐ v` checks the value up to alpha equality. -/
 -- TODO implement checking type or value up to alpha equality.
 @[tactic guardHyp] def evalGuardHyp : Lean.Elab.Tactic.Tactic := fun stx =>
   match stx with
-  | `(tactic| guardHyp $h $[: $ty]? $[:= $val]?) => do
+  | `(tactic| guard_hyp $h $[: $ty]? $[:= $val]?) => do
     withMainContext do
       let fvarid ← getFVarId h
       let lDecl ←
@@ -169,22 +169,22 @@ while `guardHyp h :=ₐ v` checks the value up to alpha equality. -/
       | none, none          => ()
   | _ => throwUnsupportedSyntax
 
-elab "matchTarget" t:term : tactic  => do
+elab "match_target" t:term : tactic  => do
   withMainContext do
     let (val) ← elabTerm t (← inferType (← getMainTarget))
     if not (← isDefEq val (← getMainTarget)) then
       throwError "failed"
 
-syntax (name := byContra) "byContra " (colGt ident)? : tactic
+syntax (name := byContra) "by_contra" (ppSpace colGt ident)? : tactic
 macro_rules
-  | `(tactic| byContra) => `(tactic| (matchTarget Not _; intro))
-  | `(tactic| byContra $e) => `(tactic| (matchTarget Not _; intro $e))
+  | `(tactic| by_contra) => `(tactic| (match_target Not _; intro))
+  | `(tactic| by_contra $e) => `(tactic| (match_target Not _; intro $e))
 macro_rules
-  | `(tactic| byContra) => `(tactic| (apply Decidable.byContradiction; intro))
-  | `(tactic| byContra $e) => `(tactic| (apply Decidable.byContradiction; intro $e))
+  | `(tactic| by_contra) => `(tactic| (apply Decidable.byContradiction; intro))
+  | `(tactic| by_contra $e) => `(tactic| (apply Decidable.byContradiction; intro $e))
 macro_rules
-  | `(tactic| byContra) => `(tactic| (apply Classical.byContradiction; intro))
-  | `(tactic| byContra $e) => `(tactic| (apply Classical.byContradiction; intro $e))
+  | `(tactic| by_contra) => `(tactic| (apply Classical.byContradiction; intro))
+  | `(tactic| by_contra $e) => `(tactic| (apply Classical.byContradiction; intro $e))
 
 macro (name := «sorry») "sorry" : tactic => `(exact sorry)
 
@@ -192,7 +192,7 @@ macro (name := «sorry») "sorry" : tactic => `(exact sorry)
 `iterate n { ... }` runs the tactic block exactly `n` times.
 `iterate { ... }` runs the tactic block repeatedly until failure.
 -/
-syntax "iterate " (num)? ppSpace tacticSeq : tactic
+syntax "iterate" (ppSpace num)? ppSpace tacticSeq : tactic
 macro_rules
   | `(tactic|iterate $seq:tacticSeq) =>
     `(tactic|try ($seq:tacticSeq); iterate $seq:tacticSeq)
@@ -215,7 +215,7 @@ elab "repeat' " seq:tacticSeq : tactic => do
   let gs ← getGoals
   repeat'Aux seq gs
 
-elab "anyGoals " seq:tacticSeq : tactic => do
+elab "any_goals " seq:tacticSeq : tactic => do
   let mvarIds ← getGoals
   let mut mvarIdsNew := #[]
   let mut anySuccess := false
@@ -233,11 +233,11 @@ elab "anyGoals " seq:tacticSeq : tactic => do
   setGoals mvarIdsNew.toList
 
 /--
-`workOnGoal n { tac }` creates a block scope for the `n`-th goal (indexed from zero),
+`work_on_goal n { tac }` creates a block scope for the `n`-th goal (indexed from zero),
 but does not require that the goal be solved at the end of the block
 (any resulting subgoals are inserted back into the list of goals, replacing the `n`-th goal).
 -/
-elab (name := workOnGoal) "workOnGoal " n:num ppSpace seq:tacticSeq : tactic => do
+elab (name := workOnGoal) "work_on_goal " n:num ppSpace seq:tacticSeq : tactic => do
   let goals ← getGoals
   let n := n.toNat
   if h : n < goals.length then

--- a/Mathlib/Tactic/Conv.lean
+++ b/Mathlib/Tactic/Conv.lean
@@ -14,20 +14,20 @@ open Lean Parser.Tactic Parser.Tactic.Conv
 
 macro "try " t:convSeq : conv => `(conv| first | $t | skip)
 
-macro (name := traceLHS) "traceLHS" : conv =>
+macro (name := traceLHS) "trace_lhs" : conv =>
   `(conv| trace_state) -- FIXME
 
-syntax (name := convLHS) "convLHS" (" at " ident)? (" in " term)? " => " convSeq : tactic
+syntax (name := convLHS) "conv_lhs" (" at " ident)? (" in " term)? " => " convSeq : tactic
 macro_rules
-  | `(tactic| convLHS $[at $id?]? $[in $pat?]? => $seq) =>
+  | `(tactic| conv_lhs $[at $id?]? $[in $pat?]? => $seq) =>
     `(tactic| conv $[at $id?]? $[in $pat?]? => lhs; ($seq:convSeq))
 
-syntax (name := convRHS) "convRHS" (" at " ident)? (" in " term)? " => " convSeq : tactic
+syntax (name := convRHS) "conv_rhs" (" at " ident)? (" in " term)? " => " convSeq : tactic
 macro_rules
-  | `(tactic| convRHS $[at $id?]? $[in $pat?]? => $seq) =>
+  | `(tactic| conv_rhs $[at $id?]? $[in $pat?]? => $seq) =>
     `(tactic| conv $[at $id?]? $[in $pat?]? => rhs; ($seq:convSeq))
 
-macro "runConv" e:doSeq : conv => `(conv| tactic' => runTac $e)
+macro "run_conv" e:doSeq : conv => `(conv| tactic' => run_tac $e)
 
 macro (name := find) "find " pat:term " => " seq:convSeq : conv =>
   `(conv| conv => pattern $pat; ($seq:convSeq))

--- a/Mathlib/Tactic/LibrarySearch.lean
+++ b/Mathlib/Tactic/LibrarySearch.lean
@@ -98,14 +98,14 @@ open Lean.Parser.Tactic
 -- in particular including additional lemmas
 -- with `library_search [X, Y, Z]` or `library_search with attr`,
 -- or requiring that a particular hypothesis is used in the solution, with `library_search using h`.
-syntax (name := librarySearch') "librarySearch" (" (" &"config" " := " term ")")?
+syntax (name := librarySearch') "library_search" (" (" &"config" " := " term ")")?
   (" [" simpArg,* "]")? (" with " (colGt ident)+)? (" using " (colGt ident)+)? : tactic
 
 -- For now we only implement the basic functionality.
 -- The full syntax is recognized, but will produce a "Tactic has not been implemented" error.
 
 open Elab.Tactic Elab Tactic in
-elab_rules : tactic | `(tactic| librarySearch%$tk) => do
+elab_rules : tactic | `(tactic| library_search%$tk) => do
   withNestedTraces do
   trace[Tactic.librarySearch] "proving {← getMainTarget}"
   let mvar ← getMainGoal
@@ -119,7 +119,7 @@ elab_rules : tactic | `(tactic| librarySearch%$tk) => do
       addExactSuggestion tk (← instantiateMVars (mkMVar mvar))
 
 open Elab Term in
-elab tk:"librarySearch%" : term <= expectedType => do
+elab tk:"library_search%" : term <= expectedType => do
   withNestedTraces do
   trace[Tactic.librarySearch] "proving {expectedType}"
   let mvar ← mkFreshExprMVar expectedType

--- a/Mathlib/Tactic/NormNum.lean
+++ b/Mathlib/Tactic/NormNum.lean
@@ -141,10 +141,10 @@ end Meta
 namespace Tactic
 
 open Lean.Parser.Tactic in
-syntax (name := normNum) "normNum" (" [" simpArg,* "]")? (ppSpace location)? : tactic
+syntax (name := normNum) "norm_num" (" [" simpArg,* "]")? (ppSpace location)? : tactic
 
 open Meta Elab.Tactic in
-elab_rules : tactic | `(tactic| normNum) => do
+elab_rules : tactic | `(tactic| norm_num) => do
   liftMetaTactic fun g => do
     let some (α, lhs, rhs) ← matchEq? (← getMVarType g) | throwError "fail"
     let p ← NormNum.evalEq α lhs rhs
@@ -156,8 +156,8 @@ end Tactic
 end Lean
 
 variable (α) [Semiring α]
-example : (1 + 0 : α) = (0 + 1 : α) := by normNum
-example : (0 + (2 + 3) + 1 : α) = 6 := by normNum
-example : (70 * (33 + 2) : α) = 2450 := by normNum
-example : (8 + 2 ^ 2 * 3 : α) = 20 := by normNum
-example : ((2 * 1 + 1) ^ 2 : α) = (3 * 3 : α) := by normNum
+example : (1 + 0 : α) = (0 + 1 : α) := by norm_num
+example : (0 + (2 + 3) + 1 : α) = 6 := by norm_num
+example : (70 * (33 + 2) : α) = 2450 := by norm_num
+example : (8 + 2 ^ 2 * 3 : α) = 20 := by norm_num
+example : ((2 * 1 + 1) ^ 2 : α) = (3 * 3 : α) := by norm_num

--- a/Mathlib/Tactic/RunTac.lean
+++ b/Mathlib/Tactic/RunTac.lean
@@ -11,6 +11,6 @@ namespace Mathlib.RunTac
 open Lean Elab Term Meta Mathlib.Eval
 
 open Tactic in
-elab "runTac" e:doSeq : tactic => do
+elab "run_tac" e:doSeq : tactic => do
   ← unsafe evalTerm (TacticM Unit) (mkApp (mkConst ``TacticM) (mkConst ``Unit))
     (← `(discard do $e))

--- a/Mathlib/Tactic/ShowTerm.lean
+++ b/Mathlib/Tactic/ShowTerm.lean
@@ -14,12 +14,12 @@ open Tactic.TryThis
 namespace Lean.Elab.Tactic
 
 /--
-`showTerm tac` runs `tac`, then prints the generated term in the form
+`show_term tac` runs `tac`, then prints the generated term in the form
 "Try this: exact X Y Z" or "Try this: refine X ?_ Z" if there are remaining subgoals.
 
 (For some tactics, the printed term will not be human readable.)
 -/
-elab (name := showTerm) tk:"showTerm " t:tacticSeq : tactic => withMainContext do
+elab (name := showTerm) tk:"show_term " t:tacticSeq : tactic => withMainContext do
   let g ← getMainGoal
   evalTactic t
   addExactSuggestion tk /- FIXME: we'd like the range for the whole tactic -/

--- a/Mathlib/Tactic/SolveByElim.lean
+++ b/Mathlib/Tactic/SolveByElim.lean
@@ -29,10 +29,10 @@ namespace Lean.Tactic
 
 open Lean.Parser.Tactic
 
-syntax (name := solveByElim) "solveByElim" "*"? (" (" &"config" " := " term ")")?
+syntax (name := solveByElim) "solve_by_elim" "*"? (" (" &"config" " := " term ")")?
   (&" only")? (" [" simpArg,* "]")? (" with " (colGt ident)+)? : tactic
 
-elab_rules : tactic | `(tactic| solveByElim) => do withMainContext do
+elab_rules : tactic | `(tactic| solve_by_elim) => do withMainContext do
   Meta.solveByElim 6 (← getMainGoal)
 
 end Lean.Tactic

--- a/test/SolveByElim.lean
+++ b/test/SolveByElim.lean
@@ -5,9 +5,9 @@ Author: Scott Morrison
 -/
 import Mathlib.Tactic.SolveByElim
 
-def test1 (h : Nat) : Nat := by solveByElim
-def test2 {α β : Type} (f : α → β) (a : α) : β := by solveByElim
-def test3 {α β : Type} (f : α → α → β) (a : α) : β := by solveByElim
-def test4 {α β γ : Type} (f : α → β) (g : β → γ) (a : α) : γ := by solveByElim
-def test5 {α β γ : Type} (f : α → β) (g : β → γ) (b : β) : γ := by solveByElim
-def test6 {α : Nat → Type} (f : (n : Nat) → α n → α (n+1)) (a : α 0) : α 5 := by solveByElim
+def test1 (h : Nat) : Nat := by solve_by_elim
+def test2 {α β : Type} (f : α → β) (a : α) : β := by solve_by_elim
+def test3 {α β : Type} (f : α → α → β) (a : α) : β := by solve_by_elim
+def test4 {α β γ : Type} (f : α → β) (g : β → γ) (a : α) : γ := by solve_by_elim
+def test5 {α β γ : Type} (f : α → β) (g : β → γ) (b : β) : γ := by solve_by_elim
+def test6 {α : Nat → Type} (f : (n : Nat) → α n → α (n+1)) (a : α 0) : α 5 := by solve_by_elim

--- a/test/basicTactics.lean
+++ b/test/basicTactics.lean
@@ -10,26 +10,26 @@ example (n : Nat) : n = n := by
   exacts []
 
 example (n : Nat) : Nat := by
-  guardHyp n : Nat
+  guard_hyp n : Nat
   let m : Nat := 1
-  guardHyp m := 1
-  guardHyp m : Nat := 1
-  guardTarget == Nat
+  guard_hyp m := 1
+  guard_hyp m : Nat := 1
+  guard_target == Nat
   exact 0
 
 example (a b : Nat) : a ≠ b → ¬ a = b := by
   intros
-  byContra H
+  by_contra H
   contradiction
 
 example (a b : Nat) : ¬¬ a = b → a = b := by
   intros
-  byContra H
+  by_contra H
   contradiction
 
 example (p q : Prop) : ¬¬ p → p := by
   intros
-  byContra H
+  by_contra H
   contradiction
 
 -- Test `iterate n ...`
@@ -62,16 +62,16 @@ example (p q : Prop) : p → q → (p ∧ q) ∧ (p ∧ q ∧ p) := by
   constructor
   any_goals assumption
 
--- Verify correct behaviour of `workOnGoal`.
+-- Verify correct behaviour of `work_on_goal`.
 example (p q r : Prop) : p → q → r → p ∧ q ∧ r := by
   intros
   constructor
-  workOnGoal 1
-    guardTarget == q ∧ r
+  work_on_goal 1
+    guard_target == q ∧ r
     constructor
     assumption
     -- Note that we have not closed all the subgoals here.
-  guardTarget == p
+  guard_target == p
   assumption
-  guardTarget == r
+  guard_target == r
   assumption

--- a/test/ext.lean
+++ b/test/ext.lean
@@ -14,11 +14,11 @@ structure B (n) extends A n where
 
 example (a b : C n) : a = b := by
   ext
-  guardTarget == a.a = b.a; admit
-  guardTarget == a.b = b.b; admit
-  guardTarget == HEq a.i b.i; admit
-  guardTarget == a.c = b.c; admit
+  guard_target == a.a = b.a; admit
+  guard_target == a.b = b.b; admit
+  guard_target == HEq a.i b.i; admit
+  guard_target == a.c = b.c; admit
 
 example (f g : Nat × Nat → Nat) : f = g := by
   ext (x, y)
-  guardTarget == f (x, y) = g (x, y); admit
+  guard_target == f (x, y) = g (x, y); admit

--- a/test/librarySearch.lean
+++ b/test/librarySearch.lean
@@ -1,56 +1,56 @@
 import Mathlib
 
-example (x : Nat) : x ≠ x.succ := ne_of_lt (by librarySearch)
-example : 0 ≠ 1 + 1 := ne_of_lt (by librarySearch)
-example (x y : Nat) : x + y = y + x := by librarySearch
-example (n m k : Nat) : n ≤ m → n + k ≤ m + k := by librarySearch
-example (ha : a > 0) (w : b ∣ c) : a * b ∣ a * c := by librarySearch
+example (x : Nat) : x ≠ x.succ := ne_of_lt (by library_search)
+example : 0 ≠ 1 + 1 := ne_of_lt (by library_search)
+example (x y : Nat) : x + y = y + x := by library_search
+example (n m k : Nat) : n ≤ m → n + k ≤ m + k := by library_search
+example (ha : a > 0) (w : b ∣ c) : a * b ∣ a * c := by library_search
 
-example : Int := by librarySearch
+example : Int := by library_search
 
-example : x < x + 1 := librarySearch%
+example : x < x + 1 := library_search%
 
-example (P : Prop) (p : P) : P := by librarySearch
-example (P : Prop) (p : P) (np : ¬P) : false := by librarySearch
--- TODO example (X : Type) (P : Prop) (x : X) (h : ∀ x : X, x = x → P) : P := by librarySearch
+example (P : Prop) (p : P) : P := by library_search
+example (P : Prop) (p : P) (np : ¬P) : false := by library_search
+-- TODO example (X : Type) (P : Prop) (x : X) (h : ∀ x : X, x = x → P) : P := by library_search
 
-example (α : Prop) : α → α := by librarySearch -- says: `exact id`
+example (α : Prop) : α → α := by library_search -- says: `exact id`
 
-example (p : Prop) : (¬¬p) → p := by librarySearch -- says: `exact not_not.mp`
--- TODO example (a b : Prop) (h : a ∧ b) : a := by librarySearch -- says: `exact h.left`
+example (p : Prop) : (¬¬p) → p := by library_search -- says: `exact not_not.mp`
+-- TODO example (a b : Prop) (h : a ∧ b) : a := by library_search -- says: `exact h.left`
 
--- TODO example (P Q : Prop) : (¬ Q → ¬ P) → (P → Q) := by librarySearch -- says: `exact not_imp_not.mp`
+-- TODO example (P Q : Prop) : (¬ Q → ¬ P) → (P → Q) := by library_search -- says: `exact not_imp_not.mp`
 
 example (a b : ℕ) : a + b = b + a :=
-by librarySearch -- says: `exact add_comm a b`
+by library_search -- says: `exact add_comm a b`
 
 example (n m k : ℕ) : n * (m - k) = n * m - n * k :=
-by librarySearch -- says: `exact nat.mul_sub_left_distrib n m k`
+by library_search -- says: `exact nat.mul_sub_left_distrib n m k`
 
 example (n m k : ℕ) : n * m - n * k = n * (m - k) :=
 Eq.symm <| -- TODO: shouldn't be required
-by librarySearch -- says: `exact eq.symm (nat.mul_sub_left_distrib n m k)`
+by library_search -- says: `exact eq.symm (nat.mul_sub_left_distrib n m k)`
 
-example {α : Type} (x y : α) : x = y ↔ y = x := by librarySearch -- says: `exact eq_comm`
+example {α : Type} (x y : α) : x = y ↔ y = x := by library_search -- says: `exact eq_comm`
 
--- TODO example (a b : ℕ) (ha : 0 < a) (hb : 0 < b) : 0 < a + b := by librarySearch -- says: `exact add_pos ha hb`
+-- TODO example (a b : ℕ) (ha : 0 < a) (hb : 0 < b) : 0 < a + b := by library_search -- says: `exact add_pos ha hb`
 
 section synonym
 
--- TODO example (a b : ℕ) (ha : a > 0) (hb : 0 < b) : 0 < a + b := by librarySearch -- says: `exact add_pos ha hb`
+-- TODO example (a b : ℕ) (ha : a > 0) (hb : 0 < b) : 0 < a + b := by library_search -- says: `exact add_pos ha hb`
 
 example (a b : ℕ) (h : a ∣ b) (w : b > 0) : a ≤ b :=
-by librarySearch -- says: `exact nat.le_of_dvd w h`
+by library_search -- says: `exact nat.le_of_dvd w h`
 
--- TODO example (a b : ℕ) (h : a ∣ b) (w : b > 0) : b ≥ a := by librarySearch -- says: `exact nat.le_of_dvd w h`
+-- TODO example (a b : ℕ) (h : a ∣ b) (w : b > 0) : b ≥ a := by library_search -- says: `exact nat.le_of_dvd w h`
 
 
 -- TODO: A lemma with head symbol `¬` can be used to prove `¬ p` or `⊥`
-example (a : ℕ) : ¬ (a < 0) := by librarySearch -- says `exact not_lt_bot`
--- TODO example (a : ℕ) (h : a < 0) : False := by librarySearch -- says `exact not_lt_bot h`
+example (a : ℕ) : ¬ (a < 0) := by library_search -- says `exact not_lt_bot`
+-- TODO example (a : ℕ) (h : a < 0) : False := by library_search -- says `exact not_lt_bot h`
 
 -- An inductive type hides the constructor's arguments enough
--- so that `librarySearch` doesn't accidentally close the goal.
+-- so that `library_search` doesn't accidentally close the goal.
 inductive P : ℕ → Prop
 | gt_in_head {n : ℕ} : n < 0 → P n
 
@@ -61,50 +61,50 @@ theorem lemma_with_gt_in_head (a : ℕ) (h : P a) : 0 > a := by cases h; assumpt
 theorem lemma_with_false_in_head (a b : ℕ) (h1 : a < b) (h2 : P a) : False :=
 by apply Nat.not_lt_zero; cases h2; assumption
 
-example (a : ℕ) (h : P a) : 0 > a := by librarySearch -- says `exact lemma_with_gt_in_head a h`
--- TODO example (a : ℕ) (h : P a) : a < 0 := by librarySearch -- says `exact lemma_with_gt_in_head a h`
+example (a : ℕ) (h : P a) : 0 > a := by library_search -- says `exact lemma_with_gt_in_head a h`
+-- TODO example (a : ℕ) (h : P a) : a < 0 := by library_search -- says `exact lemma_with_gt_in_head a h`
 
--- TODO example (a b : ℕ) (h1 : a < b) (h2 : P a) : False := by librarySearch -- says `exact lemma_with_false_in_head a b h1 h2`
+-- TODO example (a b : ℕ) (h1 : a < b) (h2 : P a) : False := by library_search -- says `exact lemma_with_false_in_head a b h1 h2`
 
--- TODO example (a b : ℕ) (h1 : a < b) : ¬ (P a) := by librarySearch -- says `exact lemma_with_false_in_head a b h1`
+-- TODO example (a b : ℕ) (h1 : a < b) : ¬ (P a) := by library_search -- says `exact lemma_with_false_in_head a b h1`
 
 end synonym
 
 -- We even find `iff` results:
 
-example : ∀ P : Prop, ¬(P ↔ ¬P) := by librarySearch -- says: `λ (a : Prop), (iff_not_self a).mp`
+example : ∀ P : Prop, ¬(P ↔ ¬P) := by library_search -- says: `λ (a : Prop), (iff_not_self a).mp`
 
--- TODO example {a b c : ℕ} (h₁ : a ∣ c) (h₂ : a ∣ b + c) : a ∣ b := by librarySearch -- says `exact (nat.dvd_add_left h₁).mp h₂`
+-- TODO example {a b c : ℕ} (h₁ : a ∣ c) (h₂ : a ∣ b + c) : a ∣ b := by library_search -- says `exact (nat.dvd_add_left h₁).mp h₂`
 
-example {α : Sort u} (h : Empty) : α := by librarySearch
-example {α : Type _} (h : Empty) : α := by librarySearch
+example {α : Sort u} (h : Empty) : α := by library_search
+example {α : Type _} (h : Empty) : α := by library_search
 
--- TODO example (f : A → C) (g : B → C) : (A ⊕ B) → C := by librarySearch
+-- TODO example (f : A → C) (g : B → C) : (A ⊕ B) → C := by library_search
 
 constant f : ℕ → ℕ
 axiom F (a b : ℕ) : f a ≤ f b ↔ a ≤ b
--- TODO example (a b : ℕ) (h : a ≤ b) : f a ≤ f b := by librarySearch
+-- TODO example (a b : ℕ) (h : a ≤ b) : f a ≤ f b := by library_search
 
--- TODO theorem nonzero_gt_one (n : ℕ) : ¬ n = 0 → n ≥ 1 := by librarySearch   -- `exact nat.pos_of_ne_zero`
+-- TODO theorem nonzero_gt_one (n : ℕ) : ¬ n = 0 → n ≥ 1 := by library_search   -- `exact nat.pos_of_ne_zero`
 
 /- TODO: using
 
 example (L : List (List ℕ)) : List ℕ :=
-by librarySearch using L
+by library_search using L
 
 example (n m : ℕ) : ℕ :=
-by librarySearch using n m
+by library_search using n m
 
 example (P Q : list ℕ) (h : ℕ) : list ℕ :=
-by librarySearch using h Q
+by library_search using h Q
 
 example (P Q : list ℕ) (h : ℕ) : list ℕ :=
-by librarySearch using P Q
+by library_search using P Q
 
--- Make sure `librarySearch` finds nothing when we list too many hypotheses after `using`.
+-- Make sure `library_search` finds nothing when we list too many hypotheses after `using`.
 example (P Q R S T : list ℕ) : list ℕ :=
 begin
-  success_if_fail { librarySearch using P Q R S T, },
+  success_if_fail { library_search using P Q R S T, },
   exact []
 end
 

--- a/test/runTac.lean
+++ b/test/runTac.lean
@@ -4,5 +4,5 @@ import Mathlib.Tactic.RunTac
 open Lean Elab Tactic
 
 example : True := by
-  runTac do
+  run_tac do
     evalApplyLikeTactic Meta.apply (← `(True.intro))

--- a/test/showTerm.lean
+++ b/test/showTerm.lean
@@ -6,11 +6,11 @@ Author: Scott Morrison
 import Mathlib.Tactic.ShowTerm
 
 example (n : Nat) : Nat × Nat := by
-  showTerm
+  show_term
     constructor
     exact n
     exact 37
 
 example (n : Nat) : Nat × Nat := by
-  showTerm constructor
+  show_term constructor
   repeat exact 42


### PR DESCRIPTION
Per the discussion at https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/tactic.20naming.20convention , tactics should be snake-cased. This implements the mathlib4 part of the conversion, and the mathport part is leanprover-community/mathport#79 .