### PR TITLE
[Merged by Bors] - feat: decl_name! macro

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -79,6 +79,7 @@ import Mathlib.Tactic.SolveByElim
 import Mathlib.Tactic.Spread
 import Mathlib.Tactic.SudoSetOption
 import Mathlib.Tactic.TryThis
+import Mathlib.Util.DeclName
 import Mathlib.Util.Eval
 import Mathlib.Util.Export
 import Mathlib.Util.TermUnsafe

--- a/Mathlib/Util/DeclName.lean
+++ b/Mathlib/Util/DeclName.lean
@@ -18,7 +18,7 @@ def bar : Name := decl_name!
 
 open Lean Elab Term
 
-elab "decl_name!" : term => do
+elab "decl_name%" : term => do
   let some declName ← getDeclName?
     | throwError "invalid `decl_name!` macro, it must be used in definitions"
   elabTerm (quote declName) none

--- a/Mathlib/Util/DeclName.lean
+++ b/Mathlib/Util/DeclName.lean
@@ -1,0 +1,24 @@
+/-
+Copyright (c) 2021 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro
+-/
+import Lean
+
+/-!
+Defines a macro that returns the name of the enclosing definition.
+
+```
+namespace Foo
+def bar : Name := decl_name!
+
+#eval Foo.bar -- `Foo.bar
+```
+-/
+
+open Lean Elab Term
+
+elab "decl_name!" : term => do
+  let some declName ← getDeclName?
+    | throwError "invalid `decl_name!` macro, it must be used in definitions"
+  elabTerm (quote declName) none


### PR DESCRIPTION
I was hoping to be able to use this in `NormCast.lean`, but unfortunately it does not work because it picks up the name of the internal declaration `initFn` from the desugaring of `initialize`:
```lean
`(def initFn : IO $type := do $doSeq
  @[$attrId:ident initFn] constant $id : $type)
```
@Kha What do you think about changing the desugaring to `def initFn : IO $type := with_decl_name% $id do $doSeq`? Will this interfere with other uses of `getDeclName?`? It seems to be mostly used in error messages and `leading_parser` type stuff, so grabbing the internal name seems less useful than the one the user wrote.
