### PR TITLE
[Merged by Bors] - feat: add withWeakNamespace

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -84,3 +84,4 @@ import Mathlib.Util.Eval
 import Mathlib.Util.Export
 import Mathlib.Util.TermUnsafe
 import Mathlib.Util.Time
+import Mathlib.Util.WithWeakNamespace

--- a/Mathlib/Mathport/Syntax.lean
+++ b/Mathlib/Mathport/Syntax.lean
@@ -17,6 +17,7 @@ import Mathlib.Tactic.ShowTerm
 import Mathlib.Tactic.Simps
 import Mathlib.Tactic.SolveByElim
 import Mathlib.Init.ExtendedBinder
+import Mathlib.Util.WithWeakNamespace
 
 -- To fix upstream:
 -- * bracketedExplicitBinders doesn't support optional types
@@ -588,11 +589,13 @@ syntax (name := localized) "localized " "[" ident "] " command : command
 -- hope that localized is only used the corresponding namespace. :shrug:
 macro_rules
   | `(localized [$ns] notation $[$prec:precedence]? $[$n:namedName]? $[$prio:namedPrio]? $sym => $t) =>
-    `(scoped notation $[$prec:precedence]? $[$n:namedName]? $[$prio:namedPrio]? $sym => $t)
+    `(with_weak_namespace $ns
+      scoped notation $[$prec:precedence]? $[$n:namedName]? $[$prio:namedPrio]? $sym => $t)
   | `(localized [$ns] $attrKind:attrKind $mixfixKind $prec:precedence $[$n:namedName]? $[$prio:namedPrio]? $sym => $t) =>
-    `(scoped $mixfixKind $prec:precedence $[$n:namedName]? $[$prio:namedPrio]? $sym => $t)
+    `(with_weak_namespace $ns
+      scoped $mixfixKind $prec:precedence $[$n:namedName]? $[$prio:namedPrio]? $sym => $t)
   | `(localized [$ns] attribute [$attr:attr] $ids*) =>
-    `(attribute [scoped $attr:attr] $ids*)
+    `(with_weak_namespace $ns attribute [scoped $attr:attr] $ids*)
 
 syntax (name := listUnusedDecls) "#list_unused_decls" : command
 syntax (name := mkIffOfInductiveProp) "mk_iff_of_inductive_prop" ident ident : command

--- a/Mathlib/Mathport/Syntax.lean
+++ b/Mathlib/Mathport/Syntax.lean
@@ -589,12 +589,15 @@ syntax (name := localized) "localized " "[" ident "] " command : command
 -- hope that localized is only used the corresponding namespace. :shrug:
 macro_rules
   | `(localized [$ns] notation $[$prec:precedence]? $[$n:namedName]? $[$prio:namedPrio]? $sym => $t) =>
+    let ns := mkIdentFrom ns <| rootNamespace ++ ns.getId
     `(with_weak_namespace $ns
       scoped notation $[$prec:precedence]? $[$n:namedName]? $[$prio:namedPrio]? $sym => $t)
   | `(localized [$ns] $attrKind:attrKind $mixfixKind $prec:precedence $[$n:namedName]? $[$prio:namedPrio]? $sym => $t) =>
+    let ns := mkIdentFrom ns <| rootNamespace ++ ns.getId
     `(with_weak_namespace $ns
       scoped $mixfixKind $prec:precedence $[$n:namedName]? $[$prio:namedPrio]? $sym => $t)
   | `(localized [$ns] attribute [$attr:attr] $ids*) =>
+    let ns := mkIdentFrom ns <| rootNamespace ++ ns.getId
     `(with_weak_namespace $ns attribute [scoped $attr:attr] $ids*)
 
 syntax (name := listUnusedDecls) "#list_unused_decls" : command

--- a/Mathlib/Util/WithWeakNamespace.lean
+++ b/Mathlib/Util/WithWeakNamespace.lean
@@ -1,0 +1,22 @@
+/-
+Copyright (c) 2021 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro, Daniel Selsam, Gabriel Ebner
+-/
+
+import Lean
+
+namespace Lean.Elab.Command
+
+/-- Changes the current namespace without causing scoped things to go out of scope -/
+def withWeakNamespace (ns : Name) (m : CommandElabM α) : CommandElabM α := do
+  let old ← getCurrNamespace
+  modifyScope ({ · with currNamespace := ns })
+  try m finally modifyScope ({ · with currNamespace := old })
+
+def withWeakNamespaceRelative (ns : Name) (m : CommandElabM α) : CommandElabM α := do
+  withWeakNamespace ((← getCurrNamespace) ++ ns) m
+
+/-- Changes the current namespace without causing scoped things to go out of scope -/
+elab "with_weak_namespace " ns:ident cmd:command : command =>
+  withWeakNamespace ns.getId (elabCommand cmd)


### PR DESCRIPTION
This is slightly different and potentially more useful than the mathport version, because it lets you escape the current namespace.  Which is what we want for the localized notation.  I've put in a version which appends the namespace for use in mathport (although I can't really tell what it's used for there---it appends the current module name when adding notations?).