### PR TITLE
[Merged by Bors] - fix: align has_[zero|one]

### DIFF
--- a/Mathlib/Mathport/SpecialNames.lean
+++ b/Mathlib/Mathport/SpecialNames.lean
@@ -51,6 +51,8 @@ namespace Mathlib.Prelude
 
 -- Generic 'has'-stripping
 -- Note: we don't currently strip automatically for various reasons.
+#align has_zero      Zero
+#align has_one       One
 #align has_add       Add
 #align has_sub       Sub
 #align has_mul       Mul


### PR DESCRIPTION
If I recall, these were omitted originally simply because the Lean4 classes didn't exist at the time. Note: I am currently unable to run mathport to confirm that this change does not cause unexpected issues.