### PR TITLE
[Merged by Bors] - feat: whatsnew in ...

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -84,4 +84,5 @@ import Mathlib.Util.Eval
 import Mathlib.Util.Export
 import Mathlib.Util.TermUnsafe
 import Mathlib.Util.Time
+import Mathlib.Util.WhatsNew
 import Mathlib.Util.WithWeakNamespace

--- a/Mathlib/Util/WhatsNew.lean
+++ b/Mathlib/Util/WhatsNew.lean
@@ -113,8 +113,3 @@ elab "whatsnew" "in" ppLine cmd:command : command => do
   finally
     let newEnv ← getEnv
     logInfo (← liftCoreM <| whatsNew oldEnv newEnv)
-
-end Mathlib.WhatsNew
-
-whatsnew in
-theorem foo : 42 = 6 * 7 := rfl

--- a/Mathlib/Util/WhatsNew.lean
+++ b/Mathlib/Util/WhatsNew.lean
@@ -1,0 +1,120 @@
+/-
+Copyright (c) 2021 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Gabriel Ebner
+-/
+import Lean
+import Mathlib.Util.TermUnsafe
+import Mathlib.Tactic.OpenPrivate
+
+/-!
+Defines a command wrapper that prints the changes the command makes to the
+environment.
+
+```
+whatsnew in
+theorem foo : 42 = 6 * 7 := rfl
+```
+-/
+
+open Lean Elab Command
+
+namespace Mathlib.WhatsNew
+
+private def throwUnknownId (id : Name) : CommandElabM Unit :=
+  throwError "unknown identifier '{mkConst id}'"
+
+private def levelParamsToMessageData (levelParams : List Name) : MessageData :=
+  match levelParams with
+  | []    => ""
+  | u::us => Id.run <| do
+    let mut m := m!".\{{u}"
+    for u in us do
+      m := m ++ ", " ++ toMessageData u
+    return m ++ "}"
+
+private def mkHeader (kind : String) (id : Name) (levelParams : List Name) (type : Expr) (safety : DefinitionSafety) : CoreM MessageData := do
+  let m : MessageData :=
+    match safety with
+    | DefinitionSafety.unsafe  => "unsafe "
+    | DefinitionSafety.partial => "partial "
+    | DefinitionSafety.safe    => ""
+  let m := if isProtected (← getEnv) id then m ++ "protected " else m
+  let (m, id) := match privateToUserName? id with
+    | some id => (m ++ "private ", id)
+    | none    => (m, id)
+  let m := m ++ kind ++ " " ++ id ++ levelParamsToMessageData levelParams ++ " : " ++ type
+  pure m
+
+private def mkHeader' (kind : String) (id : Name) (levelParams : List Name) (type : Expr) (isUnsafe : Bool) : CoreM MessageData :=
+  mkHeader kind id levelParams type (if isUnsafe then DefinitionSafety.unsafe else DefinitionSafety.safe)
+
+private def printDefLike (kind : String) (id : Name) (levelParams : List Name) (type : Expr) (value : Expr) (safety := DefinitionSafety.safe) : CoreM MessageData :=
+  return (← mkHeader kind id levelParams type safety) ++ " :=" ++ Format.line ++ value
+
+private def printInduct (id : Name) (levelParams : List Name) (numParams : Nat) (numIndices : Nat) (type : Expr)
+    (ctors : List Name) (isUnsafe : Bool) : CoreM MessageData := do
+  let mut m ← mkHeader' "inductive" id levelParams type isUnsafe
+  m := m ++ Format.line ++ "constructors:"
+  for ctor in ctors do
+    let cinfo ← getConstInfo ctor
+    m := m ++ Format.line ++ ctor ++ " : " ++ cinfo.type
+  m
+
+private def printIdCore (id : Name) : ConstantInfo → CoreM MessageData
+  | ConstantInfo.axiomInfo { levelParams := us, type := t, isUnsafe := u, .. } =>
+    mkHeader' "axiom" id us t u
+  | ConstantInfo.defnInfo  { levelParams := us, type := t, value := v, safety := s, .. } =>
+    printDefLike "def" id us t v s
+  | ConstantInfo.thmInfo  { levelParams := us, type := t, value := v, .. } =>
+    printDefLike "theorem" id us t v
+  | ConstantInfo.opaqueInfo  { levelParams := us, type := t, isUnsafe := u, .. } =>
+    mkHeader' "constant" id us t u
+  | ConstantInfo.quotInfo  { kind := kind, levelParams := us, type := t, .. } =>
+    mkHeader' "Quotient primitive" id us t false
+  | ConstantInfo.ctorInfo { levelParams := us, type := t, isUnsafe := u, .. } =>
+    mkHeader' "constructor" id us t u
+  | ConstantInfo.recInfo { levelParams := us, type := t, isUnsafe := u, .. } =>
+    mkHeader' "recursor" id us t u
+  | ConstantInfo.inductInfo { levelParams := us, numParams := numParams, numIndices := numIndices, type := t, ctors := ctors, isUnsafe := u, .. } =>
+    printInduct id us numParams numIndices t ctors u
+
+def diffExtension (old new : Environment)
+    (ext : PersistentEnvExtension EnvExtensionEntry EnvExtensionEntry EnvExtensionState) :
+    CoreM (Option MessageData) := unsafe do
+  let oldSt ← ext.toEnvExtension.getState old
+  let newSt ← ext.toEnvExtension.getState new
+  if ptrAddrUnsafe oldSt == ptrAddrUnsafe newSt then return none
+  let oldEntries ← ext.exportEntriesFn oldSt.state
+  let newEntries ← ext.exportEntriesFn newSt.state
+  m!"-- {ext.name} extension: {(newEntries.size - oldEntries.size : Int)} new entries"
+
+def whatsNew (old new : Environment) : CoreM MessageData := do
+  let mut diffs := #[]
+
+  for (c, i) in new.constants.map₂.toList do
+    unless old.constants.map₂.contains c do
+      diffs := diffs.push (← printIdCore c i)
+
+  for ext in ← persistentEnvExtensionsRef.get do
+    if let some diff := ← diffExtension old new ext then
+      diffs := diffs.push diff
+
+  if diffs.isEmpty then "no new constants" else
+
+  MessageData.joinSep diffs.toList "\n\n"
+
+/-- `whatsnew in $command` executes the command and then prints the
+declarations that were added to the environment. -/
+elab "whatsnew" "in" ppLine cmd:command : command => do
+  let oldEnv ← getEnv
+  try
+    elabCommand cmd
+  finally
+    let newEnv ← getEnv
+    logInfo (← liftCoreM <| whatsNew oldEnv newEnv)
+
+end Mathlib.WhatsNew
+
+whatsnew in
+theorem foo : 42 = 6 * 7 := rfl


### PR DESCRIPTION
```lean
whatsnew in
attribute [simp] List.iota
```

Prints:

```lean
theorem List.iota.match_1.eq_2.{u_1} : ∀ (motive : Nat → Sort u_1) (h_1 : Unit → motive 0)
  (h_2 : (m n : Nat) → m = n + 1 → motive (Nat.succ n)) (n : Nat),
  (match Nat.succ n with
    | 0 => h_1 ()
    | m@h:(Nat.succ n) => h_2 m n h) =
    h_2 (n + 1) n (_ : n + 1 = n + 1) :=
fun motive h_1 h_2 n => Eq.refl (h_2 (Nat.succ n) n (Eq.refl (Nat.succ n)))

theorem List.iota.match_1.splitter.{u_1} : (motive : Nat → Sort u_1) →
  (x : Nat) → motive 0 → ((n : Nat) → motive (Nat.succ n)) → motive x :=
fun motive x h_1 h_2 => Nat.casesOn x h_1 fun n => h_2 n

theorem List.iota._eq_2 : ∀ (n : Nat), List.iota (Nat.succ n) = Nat.succ n :: List.iota n :=
fun n => Eq.refl (List.iota (Nat.succ n))

theorem List.iota.match_1.eq_1.{u_1} : ∀ (motive : Nat → Sort u_1) (h_1 : Unit → motive 0)
  (h_2 : (m n : Nat) → m = n + 1 → motive (Nat.succ n)),
  (match 0 with
    | 0 => h_1 ()
    | m@h:(Nat.succ n) => h_2 m n h) =
    h_1 () :=
fun motive h_1 h_2 => Eq.refl (h_1 ())

theorem List.iota._eq_1 : List.iota 0 = [] :=
Eq.refl (List.iota 0)

-- simpExt extension: 4 new entries
```