### PR TITLE
[Merged by Bors] - refactor: use `List.splitAt` in `work_on_goal`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -80,6 +80,7 @@ import Mathlib.Tactic.SolveByElim
 import Mathlib.Tactic.Spread
 import Mathlib.Tactic.SudoSetOption
 import Mathlib.Tactic.TryThis
+import Mathlib.Tactic.WorkOnGoal
 import Mathlib.Util.DeclName
 import Mathlib.Util.Eval
 import Mathlib.Util.Export

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -19,9 +19,8 @@ namespace List
 /-- Split a list at an index.
      splitAt 2 [a, b, c] = ([a, b], [c]) -/
 def splitAt : ℕ → List α → List α × List α
-| 0, a => ([], a)
-| n+1, [] => ([], [])
 | n+1, x :: xs => let (l, r) := splitAt n xs; (x :: l, r)
+| _, xs => ([], xs)
 
 /-- An auxiliary function for `splitOnP`. -/
 def splitOnPAux {α : Type u} (P : α → Prop) [DecidablePred P] : List α → (List α → List α) → List (List α)

--- a/Mathlib/Tactic/Basic.lean
+++ b/Mathlib/Tactic/Basic.lean
@@ -243,24 +243,3 @@ elab "any_goals " seq:tacticSeq : tactic => do
   if not anySuccess then
     throwError "failed on all goals"
   setGoals mvarIdsNew.toList
-
--- TODO: move these
-def List.splitAux {α : Type} : List α → Nat → List α → List α × List α
-  | h :: t, n + 1, acc => splitAux t n (h :: acc)
-  | l,      _,     acc => (acc.reverse, l)
-
-def List.split {α : Type} (l : List α) (i : Nat) : List α × List α :=
-  l.splitAux i []
-
-/--
-`work_on_goal n { tac }` creates a block scope for the `n`-th goal (indexed from zero),
-but does not require that the goal be solved at the end of the block
-(any resulting subgoals are inserted back into the list of goals, replacing the `n`-th goal).
--/
-elab (name := workOnGoal) "work_on_goal " n:num ppSpace seq:tacticSeq : tactic => do
-  match (← getGoals).split n.toNat with
-    | (_, []) => throwError "not enough goals"
-    | (gls, g :: grs) =>
-      setGoals [g]
-      evalTactic seq
-      setGoals $ gls ++ (← getUnsolvedGoals) ++ grs

--- a/Mathlib/Tactic/WorkOnGoal.lean
+++ b/Mathlib/Tactic/WorkOnGoal.lean
@@ -1,0 +1,25 @@
+/-
+Copyright (c) 2022 Arthur Paulino. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Arthur Paulino, Mario Carneiro
+-/
+
+import Lean
+import Mathlib.Data.List.Defs
+
+namespace Mathlib.Tactic
+
+open Lean Elab.Tactic
+
+/--
+`work_on_goal n { tac }` creates a block scope for the `n`-th goal (indexed from zero),
+but does not require that the goal be solved at the end of the block
+(any resulting subgoals are inserted back into the list of goals, replacing the `n`-th goal).
+-/
+elab (name := workOnGoal) "work_on_goal " n:num ppSpace seq:tacticSeq : tactic => do
+  match (← getGoals).splitAt n.toNat with
+    | (_, []) => throwError "not enough goals"
+    | (gls, g :: grs) =>
+      setGoals [g]
+      evalTactic seq
+      setGoals $ gls ++ (← getUnsolvedGoals) ++ grs

--- a/Mathlib/Tactic/WorkOnGoal.lean
+++ b/Mathlib/Tactic/WorkOnGoal.lean
@@ -12,9 +12,11 @@ namespace Mathlib.Tactic
 open Lean Elab.Tactic
 
 /--
-`work_on_goal n { tac }` creates a block scope for the `n`-th goal (indexed from zero),
-but does not require that the goal be solved at the end of the block
-(any resulting subgoals are inserted back into the list of goals, replacing the `n`-th goal).
+`work_on_goal n tacSeq` creates a block scope for the `n`-th goal (indexed from zero) and
+tries the sequence of tactics `tacSeq` on it.
+
+The goal is not required to be solved and any resulting subgoals are inserted back into the
+list of goals, replacing the `n`-th goal.
 -/
 elab (name := workOnGoal) "work_on_goal " n:num ppSpace seq:tacticSeq : tactic => do
   match (← getGoals).splitAt n.toNat with

--- a/test/basicTactics.lean
+++ b/test/basicTactics.lean
@@ -61,17 +61,3 @@ example (p q : Prop) : p → q → (p ∧ q) ∧ (p ∧ q ∧ p) := by
   any_goals assumption
   constructor
   any_goals assumption
-
--- Verify correct behaviour of `work_on_goal`.
-example (p q r : Prop) : p → q → r → p ∧ q ∧ r := by
-  intros
-  constructor
-  work_on_goal 1
-    guard_target == q ∧ r
-    constructor
-    assumption
-    -- Note that we have not closed all the subgoals here.
-  guard_target == p
-  assumption
-  guard_target == r
-  assumption

--- a/test/workOnGoal.lean
+++ b/test/workOnGoal.lean
@@ -1,0 +1,14 @@
+import Mathlib.Tactic.WorkOnGoal
+
+example (p q r : Prop) : p → q → r → p ∧ q ∧ r := by
+  intros
+  constructor
+  work_on_goal 1
+    guard_target == q ∧ r
+    constructor
+    assumption
+    -- Note that we have not closed all the subgoals here.
+  guard_target == p
+  assumption
+  guard_target == r
+  assumption


### PR DESCRIPTION
This implementation traverses the list of goals less times.

It also adds some functions that can be useful in the future (where should they go?)