### PR TITLE
[Merged by Bors] - refactor: remove numeric

### DIFF
--- a/Mathlib/Algebra/Group/Defs.lean
+++ b/Mathlib/Algebra/Group/Defs.lean
@@ -175,11 +175,10 @@ end AddMonoid_lemmas
 
 -/
 
-class AddCommMonoid (A : Type u) extends AddMonoid A where
-  add_comm (a b : A) : a + b = b + a
-
-instance (A : Type u) [AddCommMonoid A] : AddCommSemigroup A where
-  __ := ‹AddCommMonoid A›
+class AddCommMonoid (A : Type u) extends AddMonoid A, AddCommSemigroup A where
+  -- TODO: doesn't work
+  zero_add a := (by rw [add_comm, add_zero])
+  add_zero a := (by rw [add_comm, zero_add])
 
 /-
 
@@ -198,6 +197,8 @@ class SubNegMonoid (A : Type u) extends AddMonoid A, Neg A, Sub A where
   gsmul_zero' : ∀ (a : A), gsmul 0 a = 0
   gsmul_succ' (n : ℕ) (a : A) : gsmul (Int.ofNat n.succ) a = a + gsmul (Int.ofNat n) a
   gsmul_neg' (n : ℕ) (a : A) : gsmul (Int.negSucc n) a = -(gsmul ↑(n.succ) a)
+
+export SubNegMonoid (sub_eq_add_neg)
 
 /-
 
@@ -242,6 +243,9 @@ instance (A : Type u) [AddGroup A] : IsAddRightCancel A where
 instance (A : Type u) [AddGroup A] : IsAddLeftCancel A where
   add_left_cancel a b c h := by
   rw [← neg_add_cancel_left a b, h, neg_add_cancel_left]
+
+lemma eq_of_sub_eq_zero' (h : a - b = 0) : a = b :=
+  add_right_cancel <| show a + (-b) = b + (-b) by rw [← sub_eq_add_neg, h, add_neg_self]
 
 end AddGroup_lemmas
 

--- a/Mathlib/Algebra/Ring/Basic.lean
+++ b/Mathlib/Algebra/Ring/Basic.lean
@@ -2,44 +2,45 @@ import Mathlib.Init.Data.Int.Basic
 import Mathlib.Algebra.GroupWithZero.Defs
 import Mathlib.Algebra.Group.Basic
 import Mathlib.Tactic.Spread
+import Mathlib.Util.WhatsNew
+
+@[reducible, inline]
+protected def Nat.cast [Add α] [Zero α] [One α] : Nat → α
+  | 0 => 0
+  | 1 => 1
+  | n + 1 => Nat.cast n + 1
+
+@[simp] lemma Nat.cast_zero [Add α] [Zero α] [One α] : Nat.cast 0 = (0 : α) := rfl
+@[simp] lemma Nat.cast_one [Add α] [Zero α] [One α] : Nat.cast 1 = (1 : α) := rfl
+lemma Nat.cast_succ_succ [Add α] [Zero α] [One α] : Nat.cast (n+2) = ((n + 1).cast + 1 : α) := rfl
+
+@[simp]
+lemma Nat.cast_Nat : ∀ {n : Nat}, n.cast = n
+  | 0 => rfl
+  | 1 => rfl
+  | n + 2 => by simp [Nat.cast, cast_Nat]; rfl
+
+@[simp]
+lemma Nat.cast_Int : ∀ {n : Nat}, n.cast = (n : Int)
+  | 0 => rfl
+  | 1 => rfl
+  | n + 2 => by simp [Nat.cast, cast_Int]; rfl
+
+class HasNumerals (α : Type u) extends Add α, Zero α, One α
+
+instance (priority := low) [HasNumerals α] : OfNat α n where
+  ofNat := n.cast
+
 /-
-
 # Semirings and rings
-
 -/
 
-class Numeric (α : Type u) where
-  ofNat : Nat → α
-
-instance Numeric.OfNat [Numeric α] : OfNat α n := ⟨Numeric.ofNat n⟩
-instance [Numeric α] : CoeTail ℕ α := ⟨Numeric.ofNat⟩
-
-theorem ofNat_eq_ofNat (α) (n : ℕ) [Numeric α] : Numeric.ofNat (α := α) n = OfNat.ofNat n := rfl
-
-class Semiring (R : Type u) extends Semigroup R, AddCommSemigroup R, Numeric R where
-  add_zero (a : R) : a + 0 = a
-  zero_add (a : R) : 0 + a = a
-  nsmul : ℕ → R → R := nsmul_rec
-  nsmul_zero' : ∀ x, nsmul 0 x = 0 -- fill in with tactic once we can do this
-  nsmul_succ' : ∀ (n : ℕ) x, nsmul n.succ x = x + nsmul n x -- fill in with tactic
-
-  zero_mul (a : R) : 0 * a = 0
-  mul_zero (a : R) : a * 0 = 0
-
-  -- Monoid R
-  one_mul (a : R) : 1 * a = a
-  mul_one (a : R) : a * 1 = a
-  npow : ℕ → R → R := npow_rec
-  npow_zero' : ∀ x, npow 0 x = 1 -- fill in with tactic once we can do this
-  npow_succ' : ∀ (n : ℕ) x, npow n.succ x = x * npow n x -- fill in with tactic
-
+class Semiring (R : Type u) extends AddCommMonoid R, MonoidWithZero R, HasNumerals R where
   mul_add (a b c : R) : a * (b + c) = a * b + a * c
   add_mul (a b c : R) : (a + b) * c = a * c + b * c
-  ofNat_succ (a : Nat) : ofNat (a + 1) = ofNat a + 1
 
 section Semiring
 variable {R} [Semiring R]
-open Numeric
 
 instance : MonoidWithZero R where
   __ := ‹Semiring R›
@@ -51,31 +52,35 @@ theorem mul_add (a b c : R) : a * (b + c) = a * b + a * c := Semiring.mul_add a 
 
 theorem add_mul (a b c : R) : (a + b) * c = a * c + b * c := Semiring.add_mul a b c
 
-@[simp] lemma ofNat_zero : (ofNat 0 : R) = 0 := rfl
-@[simp] lemma ofNat_one : (ofNat 1 : R) = 1 := rfl
+lemma Nat.cast_succ {R} [Semiring R] {n : ℕ} : Nat.cast (n + 1) = (Nat.cast n + 1 : R) := by
+  cases n <;> simp [Nat.cast_succ_succ]
 
-@[simp] lemma ofNat_add : ∀ {a b}, (ofNat (a + b) : R) = ofNat a + ofNat b
-  | a, 0 => (add_zero _).symm
-  | a, b + 1 => trans (Semiring.ofNat_succ _)
-    (by simp [Semiring.ofNat_succ, ofNat_add (b := b), add_assoc])
+lemma Nat.cast_succ' {R} [Semiring R] {n : ℕ} : Nat.cast n.succ = (Nat.cast n + 1 : R) :=
+  Nat.cast_succ
 
-@[simp] lemma ofNat_mul : ∀ {a b}, (ofNat (a * b) : R) = ofNat a * ofNat b
-  | a, 0 => by simp
-  | a, b + 1 => by simp [Nat.mul_succ, mul_add,
-    (show ofNat (a * b) = ofNat a * ofNat b from ofNat_mul)]
+lemma Nat.cast_add {R} [Semiring R] {m n : ℕ} : (m + n).cast = (m.cast + n.cast : R) := by
+  induction n generalizing m
+  case zero => simp
+  case succ n ih =>
+    show Nat.cast ((m + n) + 1) = _ + Nat.cast (n + 1)
+    simp [Nat.cast_succ, ih, add_assoc]
 
-@[simp] theorem ofNat_pow (a n : ℕ) : Numeric.ofNat (a^n) = (Numeric.ofNat a : R)^n := by
-  induction n with
-  | zero =>
-    rw [pow_zero, Nat.pow_zero]
-    exact rfl
-  | succ n ih =>
-    rw [pow_succ, Nat.pow_succ, ofNat_mul, ih]
+lemma Nat.cast_mul {R} [Semiring R] {m n : ℕ} : (m * n).cast = (m.cast * n.cast : R) := by
+  induction n generalizing m <;> simp_all [mul_succ, cast_add, cast_succ', mul_add]
+
+lemma Nat.pow_succ' {m n : Nat} : m ^ n.succ = m * m ^ n := by
+  rw [Nat.pow_succ, Nat.mul_comm]
+
+lemma Nat.cast_pow {R} [Semiring R] {m n : ℕ} : (m ^ n).cast = (m.cast ^ n : R) := by
+  induction n generalizing m <;>
+    simp_all [cast_mul, cast_add, cast_succ', Nat.pow_succ', _root_.pow_succ', pow_zero]
 
 end Semiring
 
 class CommSemiring (R : Type u) extends Semiring R where
   mul_comm (a b : R) : a * b = b * a
+  -- TODO: doesn't work
+  add_mul a b c := (by rw [mul_comm, mul_add, mul_comm c, mul_comm c])
 
 instance (R : Type u) [CommSemiring R] : CommMonoid R where
   __ := ‹CommSemiring R›
@@ -92,6 +97,11 @@ class Ring (R : Type u) extends Semiring R, Neg R, Sub R where
 
 instance {R} [Ring R] : AddCommGroup R := { ‹Ring R› with }
 
+theorem neg_mul_eq_neg_mul {R} [Ring R] (a b : R) : -(a * b) = (-a) * b :=
+  Eq.symm <| eq_of_sub_eq_zero' <| by
+    rw [sub_eq_add_neg, neg_neg (a * b) /- TODO: why is arg necessary? -/]
+    rw [← add_mul, neg_add_self a /- TODO: why is arg necessary? -/, zero_mul]
+
 class CommRing (R : Type u) extends Ring R where
   mul_comm (a b : R) : a * b = b * a
 
@@ -103,15 +113,10 @@ instance (R : Type u) [CommRing R] : CommSemiring R where
 
 namespace Nat
 
-instance : Numeric Nat := ⟨id⟩
-
-@[simp] theorem ofNat_eq_Nat (n : Nat) : Numeric.ofNat n = n := rfl
-
 instance : CommSemiring ℕ where
   mul_comm := Nat.mul_comm
   mul_add := Nat.left_distrib
   add_mul := Nat.right_distrib
-  ofNat_succ := fun _ => rfl
   mul_one := Nat.mul_one
   one_mul := Nat.one_mul
   npow (n x) := x ^ n
@@ -132,15 +137,12 @@ end Nat
 
 namespace Int
 
-instance : Numeric ℤ := ⟨Int.ofNat⟩
-
 instance : CommRing ℤ where
   zero_mul := Int.zero_mul
   mul_zero := Int.mul_zero
   mul_comm := Int.mul_comm
   mul_add := Int.distrib_left
   add_mul := Int.distrib_right
-  ofNat_succ := fun _ => rfl
   mul_one := Int.mul_one
   one_mul := Int.one_mul
   npow (n x) := HPow.hPow x n

--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -4,6 +4,12 @@ import Mathlib.Algebra.Group.Defs
 import Mathlib.Algebra.GroupWithZero.Defs
 import Mathlib.Algebra.Ring.Basic
 
+instance : Subsingleton (Fin 0) where
+  allEq := fun.
+
+instance : Subsingleton (Fin 1) where
+  allEq := fun ⟨0, _⟩ ⟨0, _⟩ => rfl
+
 /-- If you actually have an element of `Fin n`, then the `n` is always positive -/
 lemma Fin.size_positive : ∀ (x : Fin n), 0 < n
 | ⟨x, h⟩ =>
@@ -11,7 +17,14 @@ lemma Fin.size_positive : ∀ (x : Fin n), 0 < n
   | Or.inl h_eq => h_eq ▸ h
   | Or.inr h_lt => Nat.lt_trans h_lt h
 
-lemma Fin.size_positive' [Inhabited (Fin n)] : 0 < n := Fin.size_positive (Inhabited.default)
+lemma Fin.ext {a b : Fin n} : a.val = b.val → a = b := by
+  cases a; cases b; intro h; cases h; rfl
+
+lemma Fin.ext_iff {a b : Fin n} : a = b ↔ a.val = b.val :=
+  ⟨congrArg _, ext⟩
+
+lemma Fin.size_positive' [Nonempty (Fin n)] : 0 < n :=
+  ‹Nonempty (Fin n)›.elim fun i => Fin.size_positive i
 
 lemma zero_lt_of_lt {a : Nat} : ∀ {x : Nat}, x < a -> 0 < a
 | 0, h   => h
@@ -19,6 +32,11 @@ lemma zero_lt_of_lt {a : Nat} : ∀ {x : Nat}, x < a -> 0 < a
 
 lemma Fin.val_eq_of_lt {n a : Nat} (h : a < n) : (Fin.ofNat' a (zero_lt_of_lt h)).val = a := by
   simp only [Fin.ofNat', Nat.mod_eq_of_lt h]
+
+@[simp] lemma Fin.one_val : (1 : Fin (n + 2)).val = 1 := by
+  simp only [OfNat.ofNat, Fin.ofNat]
+  rw [Nat.mod_eq_of_lt]
+  exact Nat.succ_lt_succ (Nat.zero_lt_succ _)
 
 lemma Fin.modn_def : ∀ (a : Fin n) (m : Nat),
   a % m = Fin.mk ((a.val % m) % n) (Nat.mod_lt (a.val % m) (a.size_positive))
@@ -54,31 +72,38 @@ theorem Fin.mod_eq_of_lt {a b : Fin n} (h : a < b) : a % b = a := by
   simp only [Fin.mod_def]
   rw [Nat.mod_eq_of_lt h, Nat.mod_eq_of_lt a.isLt]
 
-/- The basic structures on `Fin` are predicated on `Fin n` being inhabited.
-The Inhabited bound is there so that we can implement `Zero` in a way that satisfies
+/- The basic structures on `Fin` are predicated on `Fin n` being nonempty.
+The Nonempty bound is there so that we can implement `Zero` in a way that satisfies
 the requirements of the relevant typeclasses (for example, AddMonoid). If we were to
 use `Fin n+1` for the `Zero` implementation, we would be shutting out some irreducible
 definitions (notably USize.size) that are known to be inhabited, but not defined in terms
 of `Nat.succ`. Since there's a blanket implementation of `∀ n, Inhabited (Fin n+1)` in
 the prelude, this hopefully won't be a significant impediment. -/
-section Fin
+section
 
-variable {n : Nat} [Inhabited (Fin n)]
+variable {n : Nat} [Nonempty (Fin n)]
 
-instance : Numeric (Fin n) where
-  ofNat a := Fin.ofNat' a Fin.size_positive'
+instance : OfNat (Fin n) a where
+  ofNat := Fin.ofNat' a Fin.size_positive'
 
-instance : AddSemigroup (Fin n) where
+@[simp] lemma Fin.ofNat'_zero : (Fin.ofNat' 0 h : Fin n) = 0 := rfl
+@[simp] lemma Fin.ofNat'_one : (Fin.ofNat' 1 h : Fin n) = 1 := rfl
+
+lemma Fin.ofNat'_succ : (Fin.ofNat' i.succ Fin.size_positive' : Fin n) = (Fin.ofNat' i Fin.size_positive' : Fin n) + 1 := by
+  revert n; exact fun
+    | n + 2, h => ext (by simp [Fin.ofNat', Fin.add_def])
+    | 1, h => Subsingleton.allEq _ _
+    | 0, h => Subsingleton.allEq _ _
+
+instance : AddCommSemigroup (Fin n) where
   add_assoc _ _ _ := by
     apply Fin.eq_of_val_eq
     simp only [Fin.add_def, Nat.mod_add_mod, Nat.add_mod_mod, Nat.add_assoc]
-
-instance : AddCommSemigroup (Fin n) where
   add_comm _ _ := by
     apply Fin.eq_of_val_eq
     simp only [Fin.add_def, Nat.add_comm]
 
-instance : Semigroup (Fin n) where
+instance : CommSemigroup (Fin n) where
   mul_assoc a b c := by
     apply Fin.eq_of_val_eq
     simp only [Fin.mul_def]
@@ -88,6 +113,8 @@ instance : Semigroup (Fin n) where
     rw [← Nat.mod_eq_of_lt a.isLt, (Nat.mul_mod a.val (b.val * c.val) n).symm,
         ← Nat.mul_assoc] at rhs
     rw [← lhs, ← rhs]
+  mul_comm (a b : Fin n) : a * b = b * a := by
+    apply Fin.eq_of_val_eq; simp only [Fin.mul_def, Nat.mul_comm]
 
 @[simp] lemma Fin.zero_def : (0 : Fin n).val = (0 : Nat) :=
   show (Fin.ofNat' 0 Fin.size_positive').val = (0 : Nat) by simp only [Fin.ofNat', Nat.zero_mod]
@@ -164,89 +191,111 @@ lemma Fin.checked_sub_spec (a b : Fin n) :
     case neg => exact Nat.le_of_not_lt hx
   case mpr => simp only [decide_eq_false (Nat.not_lt_of_le h : ¬a.val < b.val)]
 
-instance : Semiring (Fin n) :=
-  let add_zero (a : Fin n) : a + 0 = a := by
+instance : AddCommMonoid (Fin n) where
+  __ := inferInstanceAs (AddCommSemigroup (Fin n))
+
+  add_zero (a : Fin n) : a + 0 = a := by
     apply Fin.eq_of_val_eq
     simp only [Fin.add_def, Fin.zero_def, Nat.add_zero]
     exact Nat.mod_eq_of_lt a.isLt
-  let zero_mul (x : Fin n) : 0 * x = 0 := by
+  zero_add (a : Fin n) : 0 + a = a := by
+    apply Fin.eq_of_val_eq
+    simp only [Fin.add_def, Fin.zero_def, Nat.zero_add]
+    exact Nat.mod_eq_of_lt a.isLt
+
+  nsmul := fun x a => (Fin.ofNat' x a.size_positive) * a
+  nsmul_zero' := fun _ => by
+    apply Fin.eq_of_val_eq
+    simp [Fin.mul_def, Fin.ofNat', Fin.zero_def, Nat.zero_mul, Nat.zero_mod]
+  nsmul_succ' := fun x a => by
+    simp only [Fin.nsmuls_eq]
+    simp [Fin.ofNat', Fin.add_def]
+    exact congrArg (fun x => x % n) (Nat.add_comm (x * a.val) (a.val) ▸ Nat.succ_mul x a.val)
+
+private theorem Fin.mul_one (a : Fin n) : a * 1 = a := by
+  apply Fin.eq_of_val_eq
+  simp only [Fin.mul_def, Fin.one_def]
+  cases n with
+  | zero => exact (False.elim a.elim0)
+  | succ n =>
+    match Nat.lt_or_eq_of_le (Nat.mod_le 1 n.succ) with
+    | Or.inl h_lt =>
+      have h_eq : 1 % n.succ = 0 := Nat.eq_zero_of_le_zero (Nat.le_of_lt_succ h_lt)
+      have hnz : n = 0 := Nat.eq_zero_of_le_zero (Nat.le_of_succ_le_succ (Nat.le_of_mod_lt h_lt))
+      have haz : a.val = 0 := Nat.eq_zero_of_le_zero (Nat.le_of_succ_le_succ (hnz ▸ a.isLt))
+      rw [h_eq, haz]
+      simp only [Nat.zero_mul, Nat.zero_mod]
+    | Or.inr h_eq => simp only [h_eq, Nat.mul_one, Nat.mod_eq_of_lt (a.isLt)]
+
+instance : MonoidWithZero (Fin n) where
+  __ := inferInstanceAs (CommSemigroup (Fin n))
+  mul_one := Fin.mul_one
+  one_mul _ := by rw [mul_comm, Fin.mul_one]
+  npow_zero' _ := rfl
+  npow_succ' _ _ := rfl
+  zero_mul x := by
     apply Fin.eq_of_val_eq
     simp only [Fin.mul_def, Fin.zero_def, Nat.zero_mul, Nat.zero_mod]
-  let mul_add (a b c : Fin n) : a * (b + c) = a * b + a * c := by
+  mul_zero x := by
+    apply Fin.eq_of_val_eq
+    simp only [Fin.mul_def, Fin.zero_def, Nat.mul_zero, Nat.zero_mod]
+
+private theorem Fin.mul_add (a b c : Fin n) : a * (b + c) = a * b + a * c := by
     apply Fin.eq_of_val_eq
     simp [Fin.mul_def, Fin.add_def]
     generalize lhs : a.val * ((b.val + c.val) % n) % n = l
     rw [(Nat.mod_eq_of_lt a.isLt).symm, ← Nat.mul_mod] at lhs
     rw [← lhs, Semiring.mul_add]
-  let mul_comm (a b : Fin n) : a * b = b * a := by
-    apply Fin.eq_of_val_eq; simp only [Fin.mul_def, Nat.mul_comm]
 
-  let mul_one (a : Fin n) : a * 1 = a := by
-    apply Fin.eq_of_val_eq
-    simp only [Fin.mul_def, Fin.one_def]
-    cases n with
-    | zero => exact (False.elim a.elim0)
-    | succ n =>
-      match Nat.lt_or_eq_of_le (Nat.mod_le 1 n.succ) with
-      | Or.inl h_lt =>
-        have h_eq : 1 % n.succ = 0 := Nat.eq_zero_of_le_zero (Nat.le_of_lt_succ h_lt)
-        have hnz : n = 0 := Nat.eq_zero_of_le_zero (Nat.le_of_succ_le_succ (Nat.le_of_mod_lt h_lt))
-        have haz : a.val = 0 := Nat.eq_zero_of_le_zero (Nat.le_of_succ_le_succ (hnz ▸ a.isLt))
-        rw [h_eq, haz]
-        simp only [Nat.zero_mul, Nat.zero_mod]
-      | Or.inr h_eq => simp only [h_eq, Nat.mul_one, Nat.mod_eq_of_lt (a.isLt)]
-  {
-    ofNat_succ := fun _ => by simp [Numeric.ofNat, Fin.ofNat', Fin.add_def]
-    add_zero
-    zero_add := fun _ => by rw [add_comm]; exact add_zero _
-    nsmul := fun x a => (Fin.ofNat' x a.size_positive) * a
-    nsmul_zero' := fun _ => by
-      apply Fin.eq_of_val_eq
-      simp [Numeric.ofNat, Fin.mul_def, Fin.ofNat', Fin.zero_def, Nat.zero_mul, Nat.zero_mod]
-    nsmul_succ' := fun x a => by
-      simp only [Fin.nsmuls_eq]
-      simp [Fin.ofNat', Fin.add_def]
-      exact congrArg (fun x => x % n) (Nat.add_comm (x * a.val) (a.val) ▸ Nat.succ_mul x a.val)
-    zero_mul
-    mul_zero := fun _ => by rw [mul_comm]; exact zero_mul _
-    mul_one
-    one_mul := fun _ => by rw [mul_comm]; exact mul_one _
-    npow_zero' := fun _ => rfl
-    npow_succ' := fun _ _ => rfl
-    mul_add
-    add_mul := fun a b c => by
-      have h0 := mul_add c a b
-      have h1 : (a + b) * c = c * (a + b) := mul_comm (a + b) c
-      have h2 : a * c = c * a := mul_comm a _
-      have h3 : b * c = c * b := mul_comm b _
-      rw [h1, h2, h3, h0]
-  }
+instance : CommSemiring (Fin n) where
+  __ := inferInstanceAs (MonoidWithZero (Fin n))
+  __ := inferInstanceAs (CommSemigroup (Fin n))
+  __ := inferInstanceAs (AddCommMonoid (Fin n))
+  mul_add := Fin.mul_add
+  add_mul a b c := (by rw [mul_comm, Fin.mul_add, mul_comm c, mul_comm c])
 
 instance : Neg (Fin n) where
   neg a := ⟨(n - a) % n, Nat.mod_lt _ (lt_of_le_of_lt (Nat.zero_le _) a.isLt)⟩
 
-instance : Ring (Fin n) :=
-  let sub_eq_add_neg :∀ (a b : Fin n), a - b = a + -b := by
-    simp [Fin.add_def, Fin.sub_def, Neg.neg]
-  {
-    sub_eq_add_neg
-    gsmul := fun x a =>
-      match x with
-      | Int.ofNat x' => Semiring.nsmul x' a
-      | Int.negSucc x' => -(Semiring.nsmul x'.succ a)
-    gsmul_zero' := fun _ => by
-      apply Fin.eq_of_val_eq
-      simp only [Semiring.nsmul, Fin.ofNat', Fin.mul_def, Nat.zero_mod, Nat.zero_mul, Fin.zero_def]
-    gsmul_succ' := by simp [Semiring.nsmul_succ']
-    gsmul_neg' := by simp [Semiring.nsmul]
-    add_left_neg := fun a => by
-      rw [add_comm, ← sub_eq_add_neg]
-      apply Fin.eq_of_val_eq
-      simp [Fin.sub_def, (Nat.add_sub_cancel' (Nat.le_of_lt a.isLt)), Nat.mod_self]
+lemma Fin.neg_def : (-a : Fin n) = ⟨(n - a) % n, Nat.mod_lt _ (lt_of_le_of_lt (Nat.zero_le _) a.isLt)⟩ := rfl
+
+protected def Fin.ofInt'' : Int → Fin n
+  | Int.ofNat a => Fin.ofNat' a Fin.size_positive'
+  | Int.negSucc a => -(Fin.ofNat' a.succ Fin.size_positive')
+
+private theorem Fin.sub_eq_add_neg : ∀ (a b : Fin n), a - b = a + -b := by
+  simp [Fin.add_def, Fin.sub_def, Neg.neg]
+
+private theorem Fin.add_left_neg (a : Fin n) : -a + a = 0 := by
+    rw [add_comm, ← Fin.sub_eq_add_neg]
+    apply Fin.eq_of_val_eq
+    simp [Fin.sub_def, (Nat.add_sub_cancel' (Nat.le_of_lt a.isLt)), Nat.mod_self]
+
+private theorem Fin.neg_mul_eq_neg_mul (a b : Fin n) : -(a * b) = (-a) * b :=
+  let this : Ring (Fin n) := {
+    sub_eq_add_neg, add_left_neg
+    gsmul_zero' := by simp [gsmul_rec, nsmul_rec]
+    gsmul_succ' := by simp [gsmul_rec, nsmul_rec]
+    gsmul_neg' := by simp [gsmul_rec, nsmul_rec]
   }
+  _root_.neg_mul_eq_neg_mul a b
+
+instance : Ring (Fin n) where
+  sub_eq_add_neg := Fin.sub_eq_add_neg
+  gsmul (x : Int) (a : Fin n) : Fin n := Fin.ofInt'' x * a
+  gsmul_zero' := fun _ => by
+    apply Fin.eq_of_val_eq
+    simp only [Fin.ofNat', Fin.ofInt'', Fin.mul_def, Nat.zero_mod, Nat.zero_mul, Fin.zero_def]
+  gsmul_succ' k a := by simp only [Fin.ofInt'', Fin.ofNat'_succ, add_mul, one_mul, add_comm a]
+  gsmul_neg' k a := by simp only [Fin.ofInt'', Fin.neg_mul_eq_neg_mul]
+  add_left_neg a := by
+    rw [add_comm, ← Fin.sub_eq_add_neg]
+    apply Fin.eq_of_val_eq
+    simp [Fin.sub_def, (Nat.add_sub_cancel' (Nat.le_of_lt a.isLt)), Nat.mod_self]
 
 instance : CommRing (Fin n) where
-  mul_comm _ _ := by apply Fin.eq_of_val_eq; simp only [Fin.mul_def, Nat.mul_comm]
+  __ := inferInstanceAs (CommSemigroup (Fin n))
+  __ := inferInstanceAs (Ring (Fin n))
 
 lemma Fin.gt_wf : WellFounded (fun a b : Fin n => b < a) :=
   Subrelation.wf (@fun a i h => ⟨h, i.2⟩) (invImage (fun i => i.1) (Nat.upRel n)).wf
@@ -254,4 +303,4 @@ lemma Fin.gt_wf : WellFounded (fun a b : Fin n => b < a) :=
 /-- A well-ordered relation for "upwards" induction on `Fin n`. -/
 def Fin.upRel (n : ℕ) : WellFoundedRelation (Fin n) := ⟨_, gt_wf⟩
 
-end Fin
+end

--- a/Mathlib/Data/UInt.lean
+++ b/Mathlib/Data/UInt.lean
@@ -31,8 +31,8 @@ local macro "genIntDeclars" typeName:ident : command => do
       instance : Inhabited (Fin size) where
         default := Fin.ofNat' 0 size_positive
 
-      instance : Numeric $typeName where
-        ofNat a := mk (Numeric.ofNat a)
+      -- instance : Numeric $typeName where
+      --   ofNat a := mk (Numeric.ofNat a)
 
       instance : AddSemigroup $typeName where
         add_assoc := fun _ _ _ => congrArg mk (AddSemigroup.add_assoc _ _ _)
@@ -70,18 +70,13 @@ local macro "genIntDeclars" typeName:ident : command => do
       lemma one_def : (1 : $typeName) = ⟨1⟩ := rfl
 
       instance : Semiring $typeName where
-        ofNat_succ a := by
-          apply eq_of_val_eq
-          simp only [add_def, Numeric.ofNat, one_def]
-          have h0 := (@instSemiringFin size).ofNat_succ a
-          simp only [Numeric.ofNat] at h0
-          simp [h0]
         add_zero := by simp [add_def, zero_def]
         zero_add := by simp [add_def, zero_def]
+        add_comm := by simp [add_def, add_comm]
         mul_one  := by simp [mul_def, one_def]
         one_mul  := by simp [mul_def, one_def]
-        nsmul n a := ⟨Semiring.nsmul n a.val⟩
-        nsmul_zero' x := congrArg mk (Semiring.nsmul_zero' x.val)
+        nsmul n a := ⟨AddMonoid.nsmul n a.val⟩
+        nsmul_zero' x := congrArg mk (AddMonoid.nsmul_zero' x.val)
         nsmul_succ' n a := congrArg mk (AddMonoid.nsmul_succ' n a.val)
         zero_mul := by simp [mul_def, zero_def]
         mul_zero := by simp [mul_def, zero_def]

--- a/Mathlib/Data/UInt.lean
+++ b/Mathlib/Data/UInt.lean
@@ -31,9 +31,6 @@ local macro "genIntDeclars" typeName:ident : command => do
       instance : Inhabited (Fin size) where
         default := Fin.ofNat' 0 size_positive
 
-      -- instance : Numeric $typeName where
-      --   ofNat a := mk (Numeric.ofNat a)
-
       instance : AddSemigroup $typeName where
         add_assoc := fun _ _ _ => congrArg mk (AddSemigroup.add_assoc _ _ _)
 

--- a/test/ring.lean
+++ b/test/ring.lean
@@ -1,5 +1,8 @@
 import Mathlib.Tactic.Ring
 
+local instance [CommSemiring α] : CoeTail Nat α where
+  coe n := n.cast
+
 example (x y : ℕ) : x + y = y + x := by ring
 example (x y : ℕ) : x + y + y = 2 * y + x := by ring
 example (x y : ℕ) : x + id y = y + id x := by ring


### PR DESCRIPTION
This removes the `Numeric` parent for `Semiring` which was used for both coercions and numerals, and replaces it by a low-priority instance for `OfNat` on `Semiring`.  The coercion from Nat to R is removed.

Numerals are now implemented using `Nat.cast`.  As Sebastian has noted, to avoid diamonds for *numerals* it suffices that `Nat.cast n` and `(n : R)` are definitionally equal for every `n : Nat`.  It is not necessary that `(Nat.cast ∙)` and `(∙ : R)` are definitionally equal as functions (and after this PR they are not, for most rings).  Similarly, `Nat.cast` is carefully defined so that both `0 = 0` and `1 = 1` are true definitionally in any ring.

The setup still has a couple of downsides:
1. `OfNat.ofNat` must never be applied to anything except concrete natural numbers (or we get diamonds).
2. `(123456 : R)` is a massive performance issue when executing in the VM. :-/  (Which is not entirely true, in reality it fails quickly due to a stack overflow.)

We do not register `Nat.cast` as a coercion because of the performance issues.