### PR TITLE
feat: add on_goals tactic

### DIFF
--- a/Mathlib/Tactic/PermuteGoals.lean
+++ b/Mathlib/Tactic/PermuteGoals.lean
@@ -43,6 +43,8 @@ elab "pick_goal " reverse:"-"? n:num : tactic => do
 /-- `swap` is a shortcut for `pick_goal 2`, which interchanges the 1st and 2nd goals. -/
 macro "swap" : tactic => `(pick_goal 2)
 
+syntax signedNum := "-"? num
+
 /--
 `on_goal n => tacSeq` creates a block scope for the `n`-th goal and tries the sequence
 of tactics `tacSeq` on it.
@@ -50,11 +52,65 @@ of tactics `tacSeq` on it.
 `on_goal -n => tacSeq` does the same, but the `n`-th goal is chosen by counting from the
 bottom.
 
+`on_goal n₁ n₂ n₃ => tacSeq` runs the tactic sequence on each of the selected goals.
+
 The goal is not required to be solved and any resulting subgoals are inserted back into the
-list of goals, replacing the chosen goal.
+list of goals without reordering the list. For example, if goals `2` and `4` are selected
+in the list `[1, 2, 3, 4, 5]`, where goal `2` produces `2a`, `2b`, and `4` produces `4a`,
+the resulting list of goals is `[1, 2a, 2b, 3, 4a, 5]`.
 -/
-elab "on_goal " reverse:"-"? n:num " => " seq:tacticSeq : tactic => do
-  let (g, gl, gr) ← splitGoalsAndGetNth n.toNat !reverse.isNone
-  setGoals [g]
+elab "on_goal" args:(ppSpace signedNum)+ " => " seq:tacticSeq : tactic => do
+  match args.getArgs with
+  | #[arg] =>
+    let (g, gl, gr) ← splitGoalsAndGetNth arg[1].toNat !arg[0].isNone
+    setGoals [g]
+    evalTactic seq
+    setGoals $ gl ++ (← getUnsolvedGoals) ++ gr
+  | args =>
+    let goals := (← getGoals).toArray
+    let idxs ← args.mapM fun arg => do
+      let nth := arg[1].toNat
+      if nth = 0 then throwError "goals are 1-indexed"
+      if nth > goals.size then throwError "goal index out of bounds"
+      pure $ if arg[0].isNone then nth - 1 else goals.size - nth
+    let newGoals ← idxs.mapM fun i => (i, ·) <$> do
+      let g := goals[i]
+      if ← Meta.isExprMVarAssigned g then return []
+      setGoals [g]
+      evalTactic seq
+      getUnsolvedGoals
+    let mut start := 0
+    let mut result := #[]
+    for (i, out) in newGoals.insertionSort (·.1 < ·.1) do
+      for j in [start:i] do result := result.push goals[j]
+      for g in out do result := result.push g
+      start := i + 1
+    for j in [start:goals.size] do result := result.push goals[j]
+    setGoals result.toList
+
+/--
+`on_goals n₁ n₂ n₃ => tacSeq` is similar to `on_goal n₁ n₂ n₃ => tacSeq`, but `tacSeq` is
+only run once, on a goal state composed of all the selected goals.
+The subgoals that are generated are placed at the head of the list, and any unselected
+goals are placed at the end. For example, if goals `2` and `4` are selected from `[1, 2, 3, 4, 5]`
+and the tactic on `[2, 4]` produces goals `[a, b, c]`, then the resulting list of goals
+is `[a, b, c, 1, 3, 5]`.
+-/
+elab "on_goals" args:(ppSpace signedNum)+ " => " seq:tacticSeq : tactic => do
+  let goals := (← getGoals).toArray
+  let mut usedGoals := mkArray goals.size false
+  let mut idxs := #[]
+  for arg in args.getArgs do
+    let nth := arg[1].toNat
+    if nth = 0 then throwError "goals are 1-indexed"
+    if nth > goals.size then throwError "goal index out of bounds"
+    let i := if arg[0].isNone then nth - 1 else goals.size - nth
+    idxs := idxs.push i
+    usedGoals := usedGoals.set! i true
+  setGoals (idxs.map (goals[·])).toList
   evalTactic seq
-  setGoals $ gl ++ (← getUnsolvedGoals) ++ gr
+  let mut result := #[]
+  for i in [:goals.size] do
+    if !usedGoals[i] then
+      result := result.push goals[i]
+  appendGoals result.toList

--- a/test/PermuteGoals.lean
+++ b/test/PermuteGoals.lean
@@ -41,3 +41,31 @@ example (p : Prop) : p → p := by
   intros
   fail_if_success swap -- can't swap with a single goal
   assumption
+
+example {P : ℕ → Prop} (h : ∀ n, P n) : P 1 ∧ P 2 ∧ P 3 ∧ P 4 ∧ P 5 := by
+  refine ⟨?_, ?_, ?_, ?_, ?_⟩
+  on_goal 2 => guard_target == P 2
+  on_goal 2 => guard_target == P 2
+  on_goal 1 => guard_target == P 1
+  on_goal 1 3 => apply fun {α} x y : α => x
+  on_goal 1 => guard_target == P 1
+  on_goal 2 => guard_target == P 1
+  on_goal 3 => guard_target == P 2
+  on_goal 4 => guard_target == P 3
+  on_goal 5 => guard_target == P 3
+  on_goal 6 => guard_target == P 4
+  on_goal 7 => guard_target == P 5
+  all_goals apply h
+
+example {P : ℕ → Prop} (h : ∀ n, P n) : P 1 ∧ P 2 ∧ P 3 ∧ P 4 ∧ P 5 := by
+  refine ⟨?_, ?_, ?_, ?_, ?_⟩
+  on_goals 2 4 =>
+    on_goal 1 => guard_target == P 2
+    on_goal 2 => guard_target == P 4
+    swap
+  on_goal 1 => guard_target == P 4
+  on_goal 2 => guard_target == P 2
+  on_goal 3 => guard_target == P 1
+  on_goal 4 => guard_target == P 3
+  on_goal 5 => guard_target == P 5
+  all_goals apply h


### PR DESCRIPTION
This generalizes the `on_goal` tactic to allow targeting multiple goals at once, and it focuses on each of them when calling the given tactic sequence, like `all_goals` but for a subset of goals. It retains its "in-place" behavior: the remaining goals retain the same relative positions to the new goals as the old ones.

It also adds another tactic `on_goals`, with the same syntax. `on_goals` will run its tactic block only once, on a tactic state consisting of all selected goals. It does not keep subgoal ordering: all the newly generated goals will be at the start of the list and all unselected goals will be at the end. (So `on_goals 1 3 5 => skip` is a useful operation: it will place 1,3,5 at the start of the list.)