### PR TITLE
feat:  added 6 list functions 

### DIFF
--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -828,7 +828,7 @@ def average [Add α] [HDiv α Nat α] [OfNat α 0] : List α -> α
 `List.average` computes the average of the given list after
 applying `p` to each element.
 -/
-def averageBy [Add α] [HDiv α Nat α] [HAdd α α $ outParam α] [OfNat α 0] (p: β → α) : List β → α
+def averageBy [Add α] [HDiv α Nat α] [OfNat α 0] (p: β → α) : List β → α
   | [] => 0
   | xs => xs.sumBy p / xs.length
 

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -808,4 +808,11 @@ have instances of `Add` and `OfNat`.
 def sum [Add α] [OfNat α 0] (l : List α) : α :=
   l.foldl (.+.) 0
 
+/--
+`List.sumBy` sums the results of `f` mapped to each element of `l`. The return type of `f`
+must haave instances of `Add` and `OfNat`.
+-/
+def List.sumBy [Add β] [OfNat β 0] (l : List α) (f : α → β) : β :=
+  l.map f |>.sum
+
 end List

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -765,7 +765,7 @@ def oneTwo? : Nat → Option Nat
 ```
 -/
 def choose (chooser : α → Option β) (l : List α) : List α :=
-  l.filter (chooser · |>.isSome)
+  l.filter (Option.isSome ∘ chooser)
 
 /--
 Auxiliary function for `List.compareWith`

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -767,4 +767,38 @@ def oneTwo? : Nat → Option Nat
 def choose (chooser : α → Option β) (l : List α) : List α :=
   l.filter (chooser · |>.isSome)
 
+/--
+Auxiliary function for `List.compareWith`
+-/
+def compareWithAux (comparer : α → α → Int) : List α → List α → Int
+  | x::xs, y::ys =>
+    let c := comparer x y
+    if c = 0 then
+      compareWithAux comparer xs ys
+    else c
+  | [], [] => 0
+  | _, [] => 1
+  | [], _ => -1
+
+/--
+`List.compareWith` compares two lists `l₁` and `l₂` with the given function `comparer`,
+element by element.
+Example:
+```
+def compare' (x y : Int) : Int :=
+  if x = y then 0
+  else
+    if x > y then 1
+    else -1
+
+[1, 5].compareWith compare' [1, 8] = -1
+[1, 10].compareWith compare' [1, 10] = 0
+[1, 11].compareWith compare' [1, 13] = 1
+[1, 5].compareWith compare' [1] = -1
+[1].compareWith compare' [1, 8] = 1
+```
+-/
+def compareWith (comparer : α → α → Int) (l₁ l₂ : List α) : Int :=
+  compareWithAux comparer l₁ l₂
+
 end List

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -801,4 +801,11 @@ def compare' (x y : Int) : Int :=
 def compareWith (comparer : α → α → Int) (l₁ l₂ : List α) : Int :=
   compareWithAux comparer l₁ l₂
 
+/--
+`List.sum` sums all of the elements of of list `l`, whose elements
+have instances of `Add` and `OfNat`.
+-/
+def sum [Add α] [OfNat α 0] (l : List α) : α :=
+  l.foldl (.+.) 0
+
 end List

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -792,21 +792,21 @@ def compareWith' (f : α → α → Ordering) (l₁ l₂ : List α) : Ordering :
 `List.sum` sums all of the elements of of list `l`, whose elements
 have instances of `Add` and `OfNat`.
 -/
-def sum [Add α] [OfNat α 0] (l : List α) : α :=
+def sum [Add α] [OfNat α (nat_lit 0)] (l : List α) : α :=
   l.foldl (.+.) 0
 
 /--
 `List.sumBy` sums the results of `f` mapped to each element of `l`. The return type of `f`
 must have instances of `Add` and `OfNat`.
 -/
-def sumBy [Add β] [OfNat β 0] (l : List α) (f : α → β) : β :=
+def sumBy [Add β] [OfNat β (nat_lit 0)] (l : List α) (f : α → β) : β :=
   l.map f |>.sum
 
 /--
 `List.average` computes the average of all the elements in the
 given list.
 -/
-def average [Add α] [HDiv α Nat α] [OfNat α 0] : List α -> α
+def average [Add α] [HDiv α Nat α] [OfNat α (nat_lit 0)] : List α -> α
   | [] => 0
   | xs => xs.sum / xs.length
 
@@ -814,7 +814,7 @@ def average [Add α] [HDiv α Nat α] [OfNat α 0] : List α -> α
 `List.average` computes the average of the given list after
 applying `p` to each element.
 -/
-def averageBy [Add α] [HDiv α Nat α] [OfNat α 0] (p: β → α) : List β → α
+def averageBy [Add α] [HDiv α Nat α] [OfNat α (nat_lit 0)] (p: β → α) : List β → α
   | [] => 0
   | xs => xs.sumBy p / xs.length
 

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -798,13 +798,19 @@ def sumBy [Add β] [OfNat β 0] (l : List α) (f : α → β) : β :=
   l.map f |>.sum
 
 /--
+Allows `List.average` and `List.averageBy` to take `Float` as `α`s type,
+not restricting it to `Nat`.
+-/
+instance : HDiv Float Nat Float where
+  hDiv f n := f / (UInt64.ofNat n).toFloat
+
+/--
 `List.average` computes the average of all the elements in the
 given list.
 -/
 def average [Add α] [HDiv α Nat α] [OfNat α 0] : List α -> α
   | [] => 0
   | xs => xs.sum / xs.length
-
 
 /--
 `List.average` computes the average of the given list after

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -752,15 +752,15 @@ def mapWithComplement {α β} (f : α → List α → β) : List α → List β 
 /--
 Auxiliary function for `List.compareWith`
 -/
-def compareWithAux (comparer : α → α → Int) : List α → List α → Int
+def compareWithAux [Ord α] : List α → List α → Ordering
   | x::xs, y::ys =>
-    let c := comparer x y
-    if c = 0 then
-      compareWithAux comparer xs ys
+    let c := compare x y
+    if c == Ordering.eq then
+      compareWithAux xs ys
     else c
-  | [], [] => 0
-  | _, [] => 1
-  | [], _ => -1
+  | [], [] => Ordering.eq
+  | _, [] => Ordering.gt
+  | [], _ => Ordering.lt
 
 /--
 `List.compareWith` compares two lists `l₁` and `l₂` with the given function `comparer`,
@@ -780,8 +780,8 @@ def compare' (x y : Int) : Int :=
 [1].compareWith compare' [1, 8] = 1
 ```
 -/
-def compareWith (comparer : α → α → Int) (l₁ l₂ : List α) : Int :=
-  compareWithAux comparer l₁ l₂
+def compareWith [Ord α] (l₁ l₂ : List α) : Ordering :=
+  compareWithAux l₁ l₂
 
 /--
 `List.sum` sums all of the elements of of list `l`, whose elements

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -770,11 +770,11 @@ an instance of this typeclass. `List.comparewith` returns a contructor from the
 
 Examples:
 ```
-[1, 5].compareWith compare' [1, 8] = Ordering.lt
-[1, 10].compareWith compare' [1, 10] = Ordering.eq
-[1, 11].compareWith compare' [1, 13] = Ordering.gt
-[1, 5].compareWith compare' [1] = Ordering.lt
-[1].compareWith compare' [1, 8] = Ordering.gt
+[1, 5].compareWith [1, 8] = Ordering.lt
+[1, 10].compareWith  [1, 10] = Ordering.eq
+[1, 11].compareWith  [1, 13] = Ordering.gt
+[1, 5].compareWith [1] = Ordering.lt
+[1].compareWith [1, 8] = Ordering.gt
 ```
 -/
 def compareWith [Ord α] (l₁ l₂ : List α) : Ordering :=

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -810,7 +810,7 @@ def sum [Add α] [OfNat α 0] (l : List α) : α :=
 
 /--
 `List.sumBy` sums the results of `f` mapped to each element of `l`. The return type of `f`
-must haave instances of `Add` and `OfNat`.
+must have instances of `Add` and `OfNat`.
 -/
 def sumBy [Add β] [OfNat β 0] (l : List α) (f : α → β) : β :=
   l.map f |>.sum

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -763,21 +763,18 @@ def compareWithAux [Ord α] : List α → List α → Ordering
   | [], _ => Ordering.lt
 
 /--
-`List.compareWith` compares two lists `l₁` and `l₂` with the given function `comparer`,
-element by element.
-Example:
-```
-def compare' (x y : Int) : Int :=
-  if x = y then 0
-  else
-    if x > y then 1
-    else -1
+`List.compareWith` compares two lists `l₁` and `l₂` using thee function `compare` from
+the `Ord` typeclass, which means that the type of the list's elements have to have
+an instance of this typeclass. `List.comparewith` returns a contructor from the
+`Ordering` inductive type.
 
-[1, 5].compareWith compare' [1, 8] = -1
-[1, 10].compareWith compare' [1, 10] = 0
-[1, 11].compareWith compare' [1, 13] = 1
-[1, 5].compareWith compare' [1] = -1
-[1].compareWith compare' [1, 8] = 1
+Examples:
+```
+[1, 5].compareWith compare' [1, 8] = Ordering.lt
+[1, 10].compareWith compare' [1, 10] = Ordering.eq
+[1, 11].compareWith compare' [1, 13] = Ordering.gt
+[1, 5].compareWith compare' [1] = Ordering.lt
+[1].compareWith compare' [1, 8] = Ordering.gt
 ```
 -/
 def compareWith [Ord α] (l₁ l₂ : List α) : Ordering :=

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -795,13 +795,6 @@ def sumBy [Add β] [OfNat β 0] (l : List α) (f : α → β) : β :=
   l.map f |>.sum
 
 /--
-Allows `List.average` and `List.averageBy` to take `Float` as `α`s type,
-not restricting it to `Nat`.
--/
-instance : HDiv Float Nat Float where
-  hDiv f n := f / (UInt64.ofNat n).toFloat
-
-/--
 `List.average` computes the average of all the elements in the
 given list.
 -/

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -750,24 +750,6 @@ def mapWithComplement {α β} (f : α → List α → β) : List α → List β 
   mapWithPrefixSuffix fun pref a suff => f a (pref ++ suff)
 
 /--
-`List.choose` filters list `l` of type `List α` with `chooser` which is of type `α → Option β`,
-yet `β` is ignored.
-It keeps the elements where `chooser x` is `some _` and discards the ones that are `none`
-
-Example:
-```
-def oneTwo? : Nat → Option Nat
-  | 1 => some 1
-  | 2 => some 2
-  | _ => none
-
-[1, 2, 3, 5, 1, 4, 2].choose oneTwo? = [1, 2, 1, 2]
-```
--/
-def choose (chooser : α → Option β) (l : List α) : List α :=
-  l.filter (Option.isSome ∘ chooser)
-
-/--
 Auxiliary function for `List.compareWith`
 -/
 def compareWithAux (comparer : α → α → Int) : List α → List α → Int

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -749,4 +749,22 @@ Example: if `f : ℕ → list ℕ → β`, `List.mapWithComplement f [1, 2, 3]` 
 def mapWithComplement {α β} (f : α → List α → β) : List α → List β :=
   mapWithPrefixSuffix fun pref a suff => f a (pref ++ suff)
 
+/--
+`List.choose` filters list `l` of type `List α` with `chooser` which is of type `α → Option β`,
+yet `β` is ignored.
+It keeps the elements where `chooser x` is `some _` and discards the ones that are `none`
+
+Example:
+```
+def oneTwo? : Nat → Option Nat
+  | 1 => some 1
+  | 2 => some 2
+  | _ => none
+
+[1, 2, 3, 5, 1, 4, 2].choose oneTwo? = [1, 2, 1, 2]
+```
+-/
+def choose (chooser : α → Option β) (l : List α) : List α :=
+  l.filter (chooser · |>.isSome)
+
 end List

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -752,18 +752,18 @@ def mapWithComplement {α β} (f : α → List α → β) : List α → List β 
 /--
 Auxiliary function for `List.compareWith`
 -/
-def compareWithAux [Ord α] : List α → List α → Ordering
+def compareWithAux (f : α → α → Ordering) : List α → List α → Ordering
   | x::xs, y::ys =>
-    let c := compare x y
+    let c := f x y
     if c == Ordering.eq then
-      compareWithAux xs ys
+      compareWithAux f xs ys
     else c
   | [], [] => Ordering.eq
   | _, [] => Ordering.gt
   | [], _ => Ordering.lt
 
 /--
-`List.compareWith` compares two lists `l₁` and `l₂` using thee function `compare` from
+`List.compareWith` compares two lists `l₁` and `l₂` using the function `compare` from
 the `Ord` typeclass, which means that the type of the list's elements have to have
 an instance of this typeclass. `List.comparewith` returns a contructor from the
 `Ordering` inductive type.
@@ -778,7 +778,15 @@ Examples:
 ```
 -/
 def compareWith [Ord α] (l₁ l₂ : List α) : Ordering :=
-  compareWithAux l₁ l₂
+  compareWithAux compare l₁ l₂
+
+/--
+`List.compareWith'` functions exactly like `List.compareWith`, except you can
+provide your own custom function for it to use as a comparer, of type
+`α → α → Ordering`.
+-/
+def compareWith' (f : α → α → Ordering) (l₁ l₂ : List α) : Ordering :=
+  compareWithAux f l₁ l₂
 
 /--
 `List.sum` sums all of the elements of of list `l`, whose elements

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -812,7 +812,24 @@ def sum [Add α] [OfNat α 0] (l : List α) : α :=
 `List.sumBy` sums the results of `f` mapped to each element of `l`. The return type of `f`
 must haave instances of `Add` and `OfNat`.
 -/
-def List.sumBy [Add β] [OfNat β 0] (l : List α) (f : α → β) : β :=
+def sumBy [Add β] [OfNat β 0] (l : List α) (f : α → β) : β :=
   l.map f |>.sum
+
+/--
+`List.average` computes the average of all the elements in the
+given list.
+-/
+def average [Add α] [HDiv α Nat α] [OfNat α 0] : List α -> α
+  | [] => 0
+  | xs => xs.sum / xs.length
+
+
+/--
+`List.average` computes the average of the given list after
+applying `p` to each element.
+-/
+def averageBy [Add α] [HDiv α Nat α] [HAdd α α $ outParam α] [OfNat α 0] (p: β → α) : List β → α
+  | [] => 0
+  | xs => xs.sumBy p / xs.length
 
 end List


### PR DESCRIPTION
Added `choose`, `compareWith`, `sum`, `sumBy`, `average`, and `averageBy` to `Mathlib.Data.List.Defs`. See docstrings and commit messages for each function for more information on what they do. They don't all have to be added, and I tried my best to make sure these weren't already created.