### PR TITLE
[Merged by Bors] - feat: `AddMonoidWithOne`, `AddGroupWithOne`

### DIFF
--- a/Mathlib/Algebra/Group/Defs.lean
+++ b/Mathlib/Algebra/Group/Defs.lean
@@ -179,6 +179,7 @@ class AddMonoidWithOne (R : Type u) extends AddMonoid R, One R where
 def Nat.cast [AddMonoidWithOne R] : ℕ → R := AddMonoidWithOne.natCast
 
 instance [AddMonoidWithOne R] : CoeTail ℕ R where coe := Nat.cast
+instance [AddMonoidWithOne R] : CoeHTCT ℕ R where coe := Nat.cast
 
 @[simp] theorem Nat.cast_zero [AddMonoidWithOne R] : ((0 : ℕ) : R) = 0 := AddMonoidWithOne.natCast_zero
 @[simp] theorem Nat.cast_succ [AddMonoidWithOne R] : ((Nat.succ n : ℕ) : R) = (n : R) + 1 := AddMonoidWithOne.natCast_succ _
@@ -290,7 +291,6 @@ class AddGroupWithOne (R : Type u) extends AddMonoidWithOne R, AddGroup R where
 
 def Int.cast [AddGroupWithOne R] : ℤ → R := AddGroupWithOne.intCast
 
-attribute [-instance] instCoeNatInt
 instance [AddGroupWithOne R] : CoeTail ℤ R where coe := Int.cast
 
 theorem Int.cast_ofNat [AddGroupWithOne R] : (Int.cast (Int.ofNat n) : R) = Nat.cast n :=

--- a/Mathlib/Data/UInt.lean
+++ b/Mathlib/Data/UInt.lean
@@ -79,10 +79,6 @@ local macro "genIntDeclars" typeName:ident : command => do
         mul_zero := by simp [mul_def, zero_def]
         npow_zero' := fun _ => rfl
         npow_succ' := fun _ _ => rfl
-        mul_assoc a b c := by
-          simp only [mul_def]
-          apply eq_of_val_eq
-          exact mul_assoc a.val b.val c.val
         right_distrib a b c := by
           simp only [mul_def, add_def]
           apply eq_of_val_eq
@@ -91,20 +87,28 @@ local macro "genIntDeclars" typeName:ident : command => do
           simp only [mul_def, add_def]
           apply eq_of_val_eq
           exact left_distrib a.val b.val c.val
+        natCast n := ⟨n⟩
+        natCast_zero := rfl
+        natCast_succ _ := congrArg mk (Fin.ofNat'_succ)
+        __ := inferInstanceAs (AddCommSemigroup $typeName)
+        __ := inferInstanceAs (Semigroup $typeName)
 
       instance : Ring $typeName where
-        sub_eq_add_neg := fun _ _ => congrArg mk (Ring.sub_eq_add_neg _ _)
+        sub_eq_add_neg := fun _ _ => congrArg mk (sub_eq_add_neg _ _)
         gsmul := fun x a => mk (Ring.gsmul x a.val)
-        gsmul_zero' := fun a => congrArg mk (Ring.gsmul_zero' a.val)
-        gsmul_succ' := fun x a => congrArg mk (Ring.gsmul_succ' x a.val)
+        gsmul_zero' := fun a => congrArg mk (SubNegMonoid.gsmul_zero' a.val)
+        gsmul_succ' := fun x a => congrArg mk (SubNegMonoid.gsmul_succ' x a.val)
         gsmul_neg' := fun x a => congrArg mk (SubNegMonoid.gsmul_neg' x a.val)
         add_left_neg := fun a => by apply eq_of_val_eq; simp [neg_def, add_def, zero_def]
+        intCast n := ⟨n⟩
+        intCast_ofNat _ := rfl
+        intCast_negSucc _ := rfl
 
       instance : CommRing $typeName where
         mul_comm := fun _ _ => by
           apply eq_of_val_eq
           simp [mul_def, zero_def]
-          exact CommSemiring.mul_comm _ _
+          exact mul_comm _ _
 
     end $typeName
   )

--- a/Mathlib/Init/Data/Int/Order.lean
+++ b/Mathlib/Init/Data/Int/Order.lean
@@ -6,6 +6,7 @@ Authors: Jeremy Avigad
 The order relation on the integers.
 -/
 import Mathlib.Init.Data.Int.Basic
+import Mathlib.Algebra.Ring.Basic
 
 namespace Int
 
@@ -68,7 +69,7 @@ theorem lt.dest {a b : ℤ} (h : a < b) : ∃ n : ℕ, a + Nat.succ n = b :=
     rwa [Int.add_comm, Int.add_left_comm] at h
 
 @[simp] theorem ofNat_lt {n m : ℕ} : (↑n : ℤ) < ↑m ↔ n < m := by
-  rw [lt_iff_add_one_le, ← Int.ofNat_succ, ofNat_le]; rfl
+  rw [lt_iff_add_one_le, ← Nat.cast_succ, ofNat_le]; rfl
 
 theorem ofNat_nonneg (n : ℕ) : 0 ≤ ofNat n := ⟨_⟩
 
@@ -79,13 +80,13 @@ protected theorem le_refl (a : ℤ) : a ≤ a :=
 
 protected theorem le_trans {a b c : ℤ} (h₁ : a ≤ b) (h₂ : b ≤ c) : a ≤ c :=
   let ⟨n, hn⟩ := le.dest h₁; let ⟨m, hm⟩ := le.dest h₂
-  le.intro (n + m) $ by rw [← hm, ← hn, Int.add_assoc, ofNat_add]
+  le.intro (n + m) $ by rw [← hm, ← hn, Int.add_assoc, Nat.cast_add]
 
 protected theorem le_antisymm {a b : ℤ} (h₁ : a ≤ b) (h₂ : b ≤ a) : a = b := by
   let ⟨n, hn⟩ := le.dest h₁; let ⟨m, hm⟩ := le.dest h₂
-  have := hn; rw [← hm, Int.add_assoc, ← Int.ofNat_add] at this
+  have := hn; rw [← hm, Int.add_assoc, ← Nat.cast_add] at this
   have := Int.ofNat.inj $ Int.add_left_cancel $ this.trans (Int.add_zero _).symm
-  rw [← hn, Nat.eq_zero_of_add_eq_zero_left this, Int.ofNat_zero, Int.add_zero a]
+  rw [← hn, Nat.eq_zero_of_add_eq_zero_left this, Nat.cast_zero, Int.add_zero a]
 
 protected theorem lt_irrefl (a : ℤ) : ¬a < a := fun H =>
   let ⟨n, hn⟩ := lt.dest H
@@ -104,7 +105,7 @@ protected theorem lt_iff_le_and_ne {a b : ℤ} : a < b ↔ a ≤ b ∧ a ≠ b :
   refine ⟨fun h => ⟨le_of_lt h, Int.ne_of_lt h⟩, fun ⟨aleb, aneb⟩ => ?_⟩
   let ⟨n, hn⟩ := le.dest aleb
   have : n ≠ 0 := aneb.imp fun this' => by
-    rw [← hn, this', Int.ofNat_zero, Int.add_zero]
+    rw [← hn, this', Nat.cast_zero, Int.add_zero]
   exact lt.intro $ by rwa [← Nat.succ_pred_eq_of_pos (Nat.pos_of_ne_zero this)] at hn
 
 theorem lt_succ (a : ℤ) : a < a + 1 := Int.le_refl (a + 1)
@@ -119,12 +120,12 @@ protected theorem add_lt_add_left {a b : ℤ} (h : a < b) (c : ℤ) : c + a < c 
 protected theorem mul_nonneg {a b : ℤ} (ha : 0 ≤ a) (hb : 0 ≤ b) : 0 ≤ a * b := by
   let ⟨n, hn⟩ := eq_ofNat_of_zero_le ha
   let ⟨m, hm⟩ := eq_ofNat_of_zero_le hb
-  rw [hn, hm, ← ofNat_mul]; exact ofNat_nonneg _
+  rw [hn, hm, ← Nat.cast_mul]; exact ofNat_nonneg _
 
 protected theorem mul_pos {a b : ℤ} (ha : 0 < a) (hb : 0 < b) : 0 < a * b := by
   let ⟨n, hn⟩ := eq_succ_of_zero_lt ha
   let ⟨m, hm⟩ := eq_succ_of_zero_lt hb
-  rw [hn, hm, ← ofNat_mul]; exact ofNat_succ_pos _
+  rw [hn, hm, ← Nat.cast_mul]; exact ofNat_succ_pos _
 
 protected theorem zero_lt_one : (0 : ℤ) < 1 := ⟨_⟩
 

--- a/Mathlib/Init/Data/Nat/Lemmas.lean
+++ b/Mathlib/Init/Data/Nat/Lemmas.lean
@@ -867,4 +867,9 @@ cases n with
     simp only [hterm]
     exact to_digits_core_length 10 (by decide) (Nat.succ n + 1) (Nat.succ n) e ‹n.succ < 10 ^ e› ‹0 < e›
 
+lemma Nat.pow_succ' {m n : Nat} : m ^ n.succ = m * m ^ n := by
+  rw [Nat.pow_succ, Nat.mul_comm]
+
+@[simp] lemma Nat.pow_eq {m n : Nat} : m.pow n = m ^ n := rfl
+
 end Nat

--- a/Mathlib/Tactic/NormNum.lean
+++ b/Mathlib/Tactic/NormNum.lean
@@ -31,14 +31,14 @@ namespace Meta
 
 namespace NormNum
 
-def isNat [Semiring α] (a : α) (n : ℕ) := a = OfNat.ofNat n
+def isNat [Semiring α] (a : α) (n : ℕ) := a = n
 
 class LawfulOfNat (α) [Semiring α] (n) [OfNat α n] : Prop where
   isNat_ofNat : isNat (@OfNat.ofNat _ n ‹_› : α) n
 
-instance (α) [Semiring α] : LawfulOfNat α n := ⟨rfl⟩
-instance (α) [Semiring α] : LawfulOfNat α (nat_lit 0) := ⟨rfl⟩
-instance (α) [Semiring α] : LawfulOfNat α (nat_lit 1) := ⟨rfl⟩
+instance (α) [Semiring α] [Nat.AtLeastTwo n] : LawfulOfNat α n := ⟨rfl⟩
+instance (α) [Semiring α] : LawfulOfNat α (nat_lit 0) := ⟨Nat.cast_zero.symm⟩
+instance (α) [Semiring α] : LawfulOfNat α (nat_lit 1) := ⟨Nat.cast_one.symm⟩
 instance : LawfulOfNat Nat n := ⟨show n = Nat.cast n by simp⟩
 instance : LawfulOfNat Int n := ⟨show Int.ofNat n = Nat.cast n by simp⟩
 
@@ -47,12 +47,12 @@ theorem isNat_rawNat (n : ℕ) : isNat n n := LawfulOfNat.isNat_ofNat
 class LawfulZero (α) [Semiring α] [Zero α] : Prop where
   isNat_zero : isNat (Zero.zero : α) (nat_lit 0)
 
-instance (α) [Semiring α] : LawfulZero α := ⟨rfl⟩
+instance (α) [Semiring α] : LawfulZero α := ⟨Nat.cast_zero.symm⟩
 
 class LawfulOne (α) [Semiring α] [One α] : Prop where
   isNat_one : isNat (One.one : α) (nat_lit 1)
 
-instance (α) [Semiring α] : LawfulOne α := ⟨rfl⟩
+instance (α) [Semiring α] : LawfulOne α := ⟨Nat.cast_one.symm⟩
 
 theorem isNat_add {α} [Semiring α] : (a b : α) → (a' b' c : Nat) →
   isNat a a' → isNat b b' → Nat.add a' b' = c → isNat (a + b) c
@@ -64,8 +64,7 @@ theorem isNat_mul {α} [Semiring α] : (a b : α) → (a' b' c : Nat) →
 
 theorem isNat_pow {α} [Semiring α] : (a : α) → (b a' b' c : Nat) →
   isNat a a' → isNat b b' → Nat.pow a' b' = c → isNat (a ^ b) c
-| _, _, _, _, _, rfl, rfl, rfl => by
-  simp only [OfNat.ofNat, isNat, Nat.cast_Nat, ← Nat.cast_pow]; rfl
+| _, _, _, _, _, rfl, rfl, rfl => by simp [isNat]
 
 def instSemiringNat : Semiring Nat := inferInstance
 


### PR DESCRIPTION
Counterpart to leanprover-community/mathlib#12182.  Solves the performance issues with polymorphic numerals from #177, as well as the diamonds with Nat.

A noteworthy feature is that after importing mathlib, the coercion `ℕ → ℤ` changes from `Int.ofNat` to `Nat.cast`.