### PR TITLE
[Merged by Bors] - fix: auto-bounds should be parameters, not indices

### DIFF
--- a/Mathlib/Data/List/Perm.lean
+++ b/Mathlib/Data/List/Perm.lean
@@ -5,8 +5,8 @@ namespace List
 
 /-- `Perm l₁ l₂` or `l₁ ~ l₂` asserts that `l₁` and `l₂` are Permutations
   of each other. This is defined by induction using pairwise swaps. -/
-inductive Perm : List α → List α → Prop
-| nil   : @Perm α [] []
+inductive Perm {α} : List α → List α → Prop
+| nil   : Perm [] []
 | cons  : ∀ (x : α) {l₁ l₂ : List α}, Perm l₁ l₂ → Perm (x::l₁) (x::l₂)
 | swap  : ∀ (x y : α) (l : List α), Perm (y::x::l) (x::y::l)
 | trans : ∀ {l₁ l₂ l₃ : List α}, Perm l₁ l₂ → Perm l₂ l₃ → Perm l₁ l₃

--- a/Mathlib/Init/Data/List/Lemmas.lean
+++ b/Mathlib/Init/Data/List/Lemmas.lean
@@ -157,10 +157,10 @@ theorem length_removeNth : ∀ (l : List α) (i : ℕ),
 -- | a :: l => by
 --   cases pa: p a <;> simp [partition, partitionAux, filter, pa, partition_eq_filter_filter p l]
 
-inductive sublist : List α → List α → Prop
-  | slnil : @sublist α [] []
-  | cons l₁ l₂ a : @sublist α l₁ l₂ → sublist l₁ (a :: l₂)
-  | cons2 l₁ l₂ a : @sublist α l₁ l₂ → sublist (a :: l₁) (a :: l₂)
+inductive sublist {α} : List α → List α → Prop
+  | slnil : sublist [] []
+  | cons l₁ l₂ a : sublist l₁ l₂ → sublist l₁ (a :: l₂)
+  | cons2 l₁ l₂ a : sublist l₁ l₂ → sublist (a :: l₁) (a :: l₂)
 
 infixl:50 " <+ " => sublist
 


### PR DESCRIPTION
See: https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/Regression.20in.20implicit.20argument.20inference