### PR TITLE
[Merged by Bors] - feat: slim check

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -99,6 +99,8 @@ import Mathlib.Tactic.SudoSetOption
 import Mathlib.Tactic.TryThis
 import Mathlib.Tactic.Use
 import Mathlib.Testing.SlimCheck.Gen
+import Mathlib.Testing.SlimCheck.Sampleable
+import Mathlib.Testing.SlimCheck.Testable
 import Mathlib.Util.DeclName
 import Mathlib.Util.Eval
 import Mathlib.Util.Export

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -98,6 +98,7 @@ import Mathlib.Tactic.Spread
 import Mathlib.Tactic.SudoSetOption
 import Mathlib.Tactic.TryThis
 import Mathlib.Tactic.Use
+import Mathlib.Testing.SlimCheck.Gen
 import Mathlib.Util.DeclName
 import Mathlib.Util.Eval
 import Mathlib.Util.Export

--- a/Mathlib/Control/Random.lean
+++ b/Mathlib/Control/Random.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2021 Henrik Böving. All rights reserved.
+Copyright (c) 2022 Henrik Böving. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Henrik Böving
 -/

--- a/Mathlib/Control/Random.lean
+++ b/Mathlib/Control/Random.lean
@@ -124,3 +124,6 @@ def IO.runRand (cmd : Rand α) : BaseIO α := do
   let (res, new) := Id.run <| StateT.run cmd rng
   stdGenRef.set new.down
   pure res
+
+def IO.runRandWith (seed : Nat) (cmd : Rand α) : BaseIO α := do
+  pure $ (cmd.run (ULift.up $ mkStdGen seed)).1

--- a/Mathlib/Data/List/Perm.lean
+++ b/Mathlib/Data/List/Perm.lean
@@ -60,3 +60,19 @@ theorem perm_middle {a : α} : ∀ {l₁ l₂ : List α}, l₁++a::l₂ ~ a::(l�
 | (b::l₁), l₂ =>
   let h2 := @perm_middle α a l₁ l₂
   (h2.cons _).trans (swap a b _)
+
+theorem perm_insertNth {x : α} {l : List α} {n : Nat} (h : n ≤ l.length) : insertNth n x l ~ x :: l := by
+  induction l generalizing n with
+  | nil =>
+    cases n with
+    | zero => exact Perm.refl _
+    | succ m => exact False.elim (Nat.not_succ_le_zero _ h)
+  | cons y ys ih =>
+    cases n with
+    | zero => exact Perm.refl _
+    | succ m =>
+      apply Perm.trans
+      apply Perm.cons
+      apply ih
+      apply Nat.le_of_succ_le_succ h
+      apply Perm.swap

--- a/Mathlib/Data/List/Perm.lean
+++ b/Mathlib/Data/List/Perm.lean
@@ -61,18 +61,12 @@ theorem perm_middle {a : α} : ∀ {l₁ l₂ : List α}, l₁++a::l₂ ~ a::(l�
   let h2 := @perm_middle α a l₁ l₂
   (h2.cons _).trans (swap a b _)
 
-theorem perm_insertNth {x : α} {l : List α} {n : Nat} (h : n ≤ l.length) : insertNth n x l ~ x :: l := by
-  induction l generalizing n with
-  | nil =>
-    cases n with
-    | zero => exact Perm.refl _
-    | succ m => exact False.elim (Nat.not_succ_le_zero _ h)
-  | cons y ys ih =>
-    cases n with
-    | zero => exact Perm.refl _
-    | succ m =>
-      apply Perm.trans
-      apply Perm.cons
-      apply ih
-      apply Nat.le_of_succ_le_succ h
-      apply Perm.swap
+theorem perm_insertNth {x : α} {l : List α} {n : Nat} (h : n ≤ l.length) : insertNth n x l ~ x :: l :=
+  match l, n with
+  | [], 0 => Perm.refl _
+  | [],  m + 1 => False.elim (Nat.not_succ_le_zero _ h)
+  | y :: ys, 0 => Perm.refl _
+  | y :: ys, m + 1 =>
+    Perm.trans
+      (Perm.cons _ (perm_insertNth (Nat.le_of_succ_le_succ h)))
+      (Perm.swap _ _ _)

--- a/Mathlib/Data/Nat/Basic.lean
+++ b/Mathlib/Data/Nat/Basic.lean
@@ -95,6 +95,9 @@ protected def case_strong_rec_on {p : ℕ → Sort u} (a : ℕ)
   (hz : p 0) (hi : ∀ n, (∀ m, m ≤ n → p m) → p (succ n)) : p a :=
 Nat.strong_rec_on a fun | 0, _ => hz | n+1, ih => hi n (λ m w => ih m (lt_succ_of_le w))
 
+theorem le_pred_of_lt {m n : Nat} (h : m < n) : m ≤ n - 1 :=
+  Nat.sub_le_sub_right h 1
+
 /- div -/
 
 lemma mul_div_le (m n : ℕ) : n * (m / n) ≤ m := by

--- a/Mathlib/Testing/SlimCheck/Gen.lean
+++ b/Mathlib/Testing/SlimCheck/Gen.lean
@@ -93,6 +93,9 @@ def permutationOf : (xs : List α) → Gen { ys // ys ~ xs }
   let ⟨n, h2, h3⟩ ← choose Nat 0 ys.length (Nat.zero_le _)
   pure ⟨insertNth n x ys, Perm.trans (perm_insertNth h3) (Perm.cons _ h1)⟩
 
+def prodOf (x : Gen α) (y : Gen β) : Gen (Prod α β) := do
+  pure (←x, ←y)
+
 /-- Execute a `Gen` inside the `IO` monad using `size` as the example size-/
 def IO.runGen (x : Gen α) (size : Nat) : BaseIO α :=
   IO.runRand $ ReaderT.run x ⟨size⟩

--- a/Mathlib/Testing/SlimCheck/Gen.lean
+++ b/Mathlib/Testing/SlimCheck/Gen.lean
@@ -1,0 +1,72 @@
+import Mathlib.Control.Random
+import Mathlib.Data.List.Perm
+import Mathlib.Data.Subtype
+import Mathlib.Data.Nat.Basic
+
+namespace SlimCheck
+
+open Random
+
+abbrev Gen (α : Type u) := ReaderT (ULift Nat) Rand α
+
+/-- Lift `Random.random` to the `Gen` monad. -/
+def chooseAny (α : Type u) [Random α] : Gen α :=
+  λ _ => rand α
+
+/-- Lift `BoundedRandom.randomR` to the `Gen` monad. -/
+def choose (α : Type u) [Preorder α] [BoundedRandom α] (lo hi : α) (h : lo ≤ hi) : Gen {a // lo ≤ a ∧ a ≤ hi} :=
+  λ _ => randBound α lo hi h
+
+lemma chooseNatLt_aux {lo hi : Nat} (a : Nat) (h : Nat.succ lo ≤ a ∧ a ≤ hi) : lo ≤ Nat.pred a ∧ Nat.pred a < hi :=
+  And.intro
+    (Nat.le_pred_of_lt (Nat.lt_of_succ_le h.left))
+    (have : a.pred.succ ≤ hi := by
+       rw [Nat.succ_pred_eq_of_pos]
+       exact h.right
+       exact lt_of_le_of_lt (Nat.zero_le lo) h.left
+     this
+    )
+
+def chooseNatLt (lo hi : Nat) (h : lo < hi) : Gen {a // lo ≤ a ∧ a < hi} :=
+  Subtype.map Nat.pred chooseNatLt_aux <$> choose Nat (lo.succ) hi (Nat.succ_le_of_lt h)
+
+def getSize : Gen Nat :=
+  read >>= pure ∘ ULift.down
+
+def sized (f : Nat → Gen α) : Gen α :=
+  getSize >>= f
+
+def resize (f : Nat → Nat) (x : Gen α) : Gen α :=
+  withReader (ULift.up ∘ f ∘ ULift.down) x
+
+def arrayOf (x : Gen α) : Gen (Array α) := do
+  let sz ← choose Nat 0 (←getSize) (Nat.zero_le _)
+  let mut res := #[]
+  for i in [0:sz] do
+    res := res.push (←x)
+  pure res
+
+def listOf (x : Gen α) : Gen (List α) :=
+  arrayOf x >>= pure ∘ Array.toList
+
+def oneOf (xs : List (Gen α)) (pos : 0 < xs.length) : Gen α := do
+  let ⟨x, h1, h2⟩ ← chooseNatLt 0 xs.length pos
+  xs.get ⟨x, h2⟩
+
+def elements (xs : List α) (pos : 0 < xs.length) : Gen α := do
+  let ⟨x, h1, h2⟩ ← chooseNatLt 0 xs.length pos
+  pure $ xs.get ⟨x, h2⟩
+
+open List in
+def permutationOf : (xs : List α) → Gen { ys // ys ~ xs }
+| [] => pure ⟨[], Perm.nil⟩
+| x::xs => do
+  let ⟨ys, h1⟩ ← permutationOf xs
+  let ⟨n, h2, h3⟩ ← choose Nat 0 ys.length (Nat.zero_le _)
+  pure ⟨insertNth n x ys, Perm.trans (perm_insertNth h3) (Perm.cons _ h1)⟩
+
+/-- Execute a `Gen` inside the `IO` monad using `size` as the example size-/
+def IO.runGen (x : Gen α) (size : Nat) : BaseIO α :=
+  IO.runRand $ ReaderT.run x ⟨size⟩
+
+end SlimCheck

--- a/Mathlib/Testing/SlimCheck/Gen.lean
+++ b/Mathlib/Testing/SlimCheck/Gen.lean
@@ -1,12 +1,33 @@
+/-
+Copyright (c) 2021 Henrik Böving. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Henrik Böving
+-/
 import Mathlib.Control.Random
 import Mathlib.Data.List.Perm
 import Mathlib.Data.Subtype
 import Mathlib.Data.Nat.Basic
 
+/-!
+# `Gen` Monad
+This monad is used to formulate randomized computations with a parameter
+to specify the desired size of the result.
+This is a port of the Haskell QuickCheck library.
+## Main definitions
+  * `Gen` monad
+## Tags
+random testing
+## References
+  * https://hackage.haskell.org/package/QuickCheck
+-/
+
 namespace SlimCheck
 
 open Random
 
+/-- Monad to generate random examples to test properties with.
+It has a `Nat` parameter so that the caller can decide on the
+size of the examples. -/
 abbrev Gen (α : Type u) := ReaderT (ULift Nat) Rand α
 
 /-- Lift `Random.random` to the `Gen` monad. -/
@@ -27,18 +48,20 @@ lemma chooseNatLt_aux {lo hi : Nat} (a : Nat) (h : Nat.succ lo ≤ a ∧ a ≤ h
      this
     )
 
+/-- Generate a `Nat` example between `x` and `y` (exclusively). -/
 def chooseNatLt (lo hi : Nat) (h : lo < hi) : Gen {a // lo ≤ a ∧ a < hi} :=
   Subtype.map Nat.pred chooseNatLt_aux <$> choose Nat (lo.succ) hi (Nat.succ_le_of_lt h)
 
+/-- Get access to the size parameter of the `Gen` monad. -/
 def getSize : Gen Nat :=
   read >>= pure ∘ ULift.down
 
-def sized (f : Nat → Gen α) : Gen α :=
-  getSize >>= f
-
+/-- Apply a function to the size parameter. -/
 def resize (f : Nat → Nat) (x : Gen α) : Gen α :=
   withReader (ULift.up ∘ f ∘ ULift.down) x
 
+/-- Create an `Array` of examples using `x`. The size is controlled
+by the size parameter of `Gen`. -/
 def arrayOf (x : Gen α) : Gen (Array α) := do
   let sz ← choose Nat 0 (←getSize) (Nat.zero_le _)
   let mut res := #[]
@@ -46,18 +69,23 @@ def arrayOf (x : Gen α) : Gen (Array α) := do
     res := res.push (←x)
   pure res
 
+/-- Create an `List` of examples using `x`. The size is controlled
+by the size parameter of `Gen`. -/
 def listOf (x : Gen α) : Gen (List α) :=
   arrayOf x >>= pure ∘ Array.toList
 
+/-- Given a list of example generators, choose one to create an example. -/
 def oneOf (xs : List (Gen α)) (pos : 0 < xs.length) : Gen α := do
   let ⟨x, h1, h2⟩ ← chooseNatLt 0 xs.length pos
   xs.get ⟨x, h2⟩
 
+/-- Given a list of examples, choose one to create an example. -/
 def elements (xs : List α) (pos : 0 < xs.length) : Gen α := do
   let ⟨x, h1, h2⟩ ← chooseNatLt 0 xs.length pos
   pure $ xs.get ⟨x, h2⟩
 
 open List in
+/-- Generate a random permutation of a given list. -/
 def permutationOf : (xs : List α) → Gen { ys // ys ~ xs }
 | [] => pure ⟨[], Perm.nil⟩
 | x::xs => do

--- a/Mathlib/Testing/SlimCheck/Gen.lean
+++ b/Mathlib/Testing/SlimCheck/Gen.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2021 Henrik Böving. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Henrik Böving
+Authors: Henrik Böving, Simon Hudon
 -/
 import Mathlib.Control.Random
 import Mathlib.Data.List.Perm

--- a/Mathlib/Testing/SlimCheck/Gen.lean
+++ b/Mathlib/Testing/SlimCheck/Gen.lean
@@ -30,6 +30,8 @@ It has a `Nat` parameter so that the caller can decide on the
 size of the examples. -/
 abbrev Gen (α : Type u) := ReaderT (ULift Nat) Rand α
 
+namespace Gen
+
 /-- Lift `Random.random` to the `Gen` monad. -/
 def chooseAny (α : Type u) [Random α] : Gen α :=
   λ _ => rand α
@@ -96,8 +98,11 @@ def permutationOf : (xs : List α) → Gen { ys // ys ~ xs }
 def prodOf (x : Gen α) (y : Gen β) : Gen (Prod α β) := do
   pure (←x, ←y)
 
+end Gen
+
 /-- Execute a `Gen` inside the `IO` monad using `size` as the example size-/
 def IO.runGen (x : Gen α) (size : Nat) : BaseIO α :=
   IO.runRand $ ReaderT.run x ⟨size⟩
+
 
 end SlimCheck

--- a/Mathlib/Testing/SlimCheck/Gen.lean
+++ b/Mathlib/Testing/SlimCheck/Gen.lean
@@ -13,10 +13,14 @@ import Mathlib.Data.Nat.Basic
 This monad is used to formulate randomized computations with a parameter
 to specify the desired size of the result.
 This is a port of the Haskell QuickCheck library.
+
 ## Main definitions
   * `Gen` monad
+
 ## Tags
+
 random testing
+
 ## References
   * https://hackage.haskell.org/package/QuickCheck
 -/

--- a/Mathlib/Testing/SlimCheck/Gen.lean
+++ b/Mathlib/Testing/SlimCheck/Gen.lean
@@ -50,8 +50,6 @@ lemma chooseNatLt_aux {lo hi : Nat} (a : Nat) (h : Nat.succ lo ≤ a ∧ a ≤ h
        rw [Nat.succ_pred_eq_of_pos]
        exact h.right
        exact lt_of_le_of_lt (Nat.zero_le lo) h.left
-     this
-    )
 
 /-- Generate a `Nat` example between `x` and `y` (exclusively). -/
 def chooseNatLt (lo hi : Nat) (h : lo < hi) : Gen {a // lo ≤ a ∧ a < hi} :=
@@ -81,7 +79,7 @@ def listOf (x : Gen α) : Gen (List α) :=
 
 /-- Given a list of example generators, choose one to create an example. -/
 def oneOf (xs : Array (Gen α)) (pos : 0 < xs.size := by decide) : Gen α := do
-  let ⟨x, h1, h2⟩ ← chooseNatLt 0 xs.length pos
+  let ⟨x, h1, h2⟩ ← chooseNatLt 0 xs.size pos
   xs.get ⟨x, h2⟩
 
 /-- Given a list of examples, choose one to create an example. -/

--- a/Mathlib/Testing/SlimCheck/Gen.lean
+++ b/Mathlib/Testing/SlimCheck/Gen.lean
@@ -95,6 +95,7 @@ def permutationOf : (xs : List α) → Gen { ys // ys ~ xs }
   let ⟨n, h2, h3⟩ ← choose Nat 0 ys.length (Nat.zero_le _)
   pure ⟨insertNth n x ys, Perm.trans (perm_insertNth h3) (Perm.cons _ h1)⟩
 
+/-- Given two generators produces a tuple consisting out of the result of both -/
 def prodOf (x : Gen α) (y : Gen β) : Gen (Prod α β) := do
   pure (←x, ←y)
 

--- a/Mathlib/Testing/SlimCheck/Gen.lean
+++ b/Mathlib/Testing/SlimCheck/Gen.lean
@@ -45,9 +45,8 @@ def choose (α : Type u) [Preorder α] [BoundedRandom α] (lo hi : α) (h : lo �
   λ _ => randBound α lo hi h
 
 lemma chooseNatLt_aux {lo hi : Nat} (a : Nat) (h : Nat.succ lo ≤ a ∧ a ≤ hi) : lo ≤ Nat.pred a ∧ Nat.pred a < hi :=
-  And.intro
-    (Nat.le_pred_of_lt (Nat.lt_of_succ_le h.left))
-    (have : a.pred.succ ≤ hi := by
+  And.intro (Nat.le_pred_of_lt (Nat.lt_of_succ_le h.left)) <|
+    show a.pred.succ ≤ hi by
        rw [Nat.succ_pred_eq_of_pos]
        exact h.right
        exact lt_of_le_of_lt (Nat.zero_le lo) h.left
@@ -60,7 +59,7 @@ def chooseNatLt (lo hi : Nat) (h : lo < hi) : Gen {a // lo ≤ a ∧ a < hi} :=
 
 /-- Get access to the size parameter of the `Gen` monad. -/
 def getSize : Gen Nat :=
-  read >>= pure ∘ ULift.down
+  return (← read).down
 
 /-- Apply a function to the size parameter. -/
 def resize (f : Nat → Nat) (x : Gen α) : Gen α :=
@@ -81,7 +80,7 @@ def listOf (x : Gen α) : Gen (List α) :=
   arrayOf x >>= pure ∘ Array.toList
 
 /-- Given a list of example generators, choose one to create an example. -/
-def oneOf (xs : List (Gen α)) (pos : 0 < xs.length) : Gen α := do
+def oneOf (xs : Array (Gen α)) (pos : 0 < xs.size := by decide) : Gen α := do
   let ⟨x, h1, h2⟩ ← chooseNatLt 0 xs.length pos
   xs.get ⟨x, h2⟩
 
@@ -106,7 +105,7 @@ def prodOf (x : Gen α) (y : Gen β) : Gen (Prod α β) := do
 end Gen
 
 /-- Execute a `Gen` inside the `IO` monad using `size` as the example size-/
-def IO.runGen (x : Gen α) (size : Nat) : BaseIO α :=
+def Gen.run (x : Gen α) (size : Nat) : BaseIO α :=
   IO.runRand $ ReaderT.run x ⟨size⟩
 
 

--- a/Mathlib/Testing/SlimCheck/Sampleable.lean
+++ b/Mathlib/Testing/SlimCheck/Sampleable.lean
@@ -1,0 +1,156 @@
+/-
+Copyright (c) 2022 Henrik Böving. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Henrik Böving
+-/
+import Mathlib.Testing.SlimCheck.Gen
+import Mathlib.Tactic.LibrarySearch
+import Mathlib.Tactic.Find
+
+namespace SlimCheck
+
+open Random
+
+structure ShrinkFn (α : Type u) [sz : SizeOf α] where
+  run : (x : α) → List { y : α // sz.sizeOf y < sz.sizeOf x }
+
+class Sampleable (α : Type u) where
+  sample : Gen α
+
+class Shrinkable (α : Type u) [wf : SizeOf α] where
+  shrink : @ShrinkFn α wf
+
+class SampleableExt (α : Sort u) where
+  proxyRepr : Type v
+  [samp : Sampleable proxyRepr]
+  [shrink : Shrinkable proxyRepr]
+  interp : proxyRepr → α
+
+attribute [instance] SampleableExt.samp
+
+section GenericSampleableInstances
+
+instance (priority := low) [Sampleable α] [SizeOf α] : Shrinkable α where
+  shrink := ⟨λ _ => []⟩
+
+instance SampleableExt.ofSampleable {α : Type u} [Sampleable α] [Shrinkable α] [SizeOf α] : SampleableExt α where
+  proxyRepr := α 
+  samp := inferInstance
+  shrink := inferInstance
+  interp := id
+
+end GenericSampleableInstances
+
+section Shrinkers
+
+def Nat.shrink (n : Nat) : List { y : Nat // sizeOf y < sizeOf n } :=
+  if h : 0 < n then
+    let m := n/2
+    have h : m < n := by
+      apply Nat.div_lt_self h
+      decide
+    let rest := shrink m
+    ⟨m, h⟩ :: rest.map (λ x => {x with property := Nat.lt_trans x.property h})
+  else
+    []
+
+instance Nat.sampleable : Sampleable Nat where
+  sample := do choose Nat 0 (←getSize) (Nat.zero_le _)
+
+instance Nat.shrinkable : Shrinkable Nat where
+  shrink := ⟨Nat.shrink⟩
+
+def Fin.shrink {n : Nat} (m : Fin n.succ) : List { y : Fin n.succ // sizeOf y < sizeOf m } :=
+  let shrinks := Nat.shrink m.val
+  shrinks.map (λ x => {x with property := sorry})
+
+instance Fin.sampleable {n : Nat} : Sampleable (Fin (n.succ)) where
+  sample := do choose (Fin n.succ) (Fin.ofNat 0) (Fin.ofNat (←getSize)) (by
+    simp [Fin.ofNat, LE.le]
+    exact Nat.zero_le _
+  )
+
+instance Fin.shrinkable {n : Nat} : Shrinkable (Fin n.succ) where
+  shrink := ⟨Fin.shrink⟩
+
+abbrev Int.sizeOfAbs : SizeOf Int := ⟨Int.natAbs⟩
+
+attribute [local instance] Int.sizeOfAbs
+
+def Int.shrink (n : Int) : List { y : Int // sizeOfAbs.sizeOf y < sizeOfAbs.sizeOf n } :=
+  Nat.shrink n.natAbs |>.map λ ⟨x, h⟩ => ⟨-x, (by simp only [SizeOf.sizeOf]; rw [Int.natAbs_neg]; exact h)⟩
+
+instance Int.sampleable : Sampleable Int where
+  sample := do choose Int (-(←getSize)) (←getSize) (le_trans (Int.neg_nonpos_of_nonneg (Int.ofNat_zero_le _)) (Int.ofNat_zero_le _))
+
+instance Int.shrinkable : Shrinkable Int where
+  shrink := ⟨Int.shrink⟩
+
+instance Bool.sampleable : Sampleable Bool where
+  sample := chooseAny Bool
+
+def Prod.shrink [SizeOf α] [SizeOf β] (shrA : ShrinkFn α) (shrB : ShrinkFn β) : ShrinkFn (α × β) := ⟨λ (fst, snd) =>
+  let shrink1 := shrA.run fst |>.map fun ⟨x, _⟩ => ⟨(x, snd), by simp_all_arith⟩
+  let shrink2 := shrB.run snd |>.map fun ⟨x, _⟩ => ⟨(fst, x), by simp_all_arith⟩
+  shrink1 ++ shrink2⟩
+
+instance Prod.sampleable [Sampleable α] [Sampleable β] : Sampleable (Prod α β) where
+  sample := prodOf Sampleable.sample Sampleable.sample
+
+instance Prod.shrinkable [SizeOf α] [SizeOf β] [Shrinkable α] [Shrinkable β] : Shrinkable (Prod α β) where
+  shrink := Prod.shrink Shrinkable.shrink Shrinkable.shrink
+
+def Char.sampleable (length : Nat) (chars : List Char) (pos : 0 < chars.length) : Sampleable Char :=
+  {
+    sample := do
+      let x ← choose Nat 0 length (Nat.zero_le _)
+      if x.val == 0 then
+        let n ← Sampleable.sample
+        pure $ Char.ofNat n
+      else
+        elements chars pos
+  }
+
+instance Char.sampleableDefault : Sampleable Char :=
+  Char.sampleable 3 " 0123abcABC:,;`\\/".toList (by decide)
+
+section ListShrink
+
+variable {α : Type u} [SizeOf α] (shr : ShrinkFn α)
+-- TODO: List shrinker
+
+end ListShrink
+end Shrinkers
+
+instance Prop.sampleableExt : SampleableExt Prop where
+  proxyRepr := Bool 
+  samp := inferInstance
+  shrink := inferInstance
+  interp := Coe.coe
+
+def NoShrink (α : Type u) := α
+
+namespace NoShrink
+
+def mk (x : α) : NoShrink α := x
+def get (x : NoShrink α) : α := x
+
+instance inhabited [Inhabited α] : Inhabited (NoShrink α) := ⟨(default : α)⟩
+
+instance sampleable [Sampleable α] : Sampleable (NoShrink α) where
+  sample := NoShrink.mk <$> Sampleable.sample
+
+instance shrinkable : Shrinkable α where
+  shrink := ⟨λ _ => []⟩
+
+end NoShrink
+
+instance String.sampleable : Sampleable String where
+  sample := do
+    let xs ← listOf Sampleable.sample
+    pure xs.asString
+
+instance String.shrinkable : Shrinkable String where
+  shrink := sorry -- requires List.shrinkable
+
+end SlimCheck

--- a/Mathlib/Testing/SlimCheck/Sampleable.lean
+++ b/Mathlib/Testing/SlimCheck/Sampleable.lean
@@ -5,21 +5,70 @@ Authors: Henrik Böving
 -/
 import Mathlib.Testing.SlimCheck.Gen
 
+structure PhantomFunction (α : Sort u) (β : Sort v) where
+  f : α → β → Prop
+  total : ∀ x, ∃ y, f x y
+  determ : ∀ x y0 y1, f x y0 → f x y1 → y0 = y1
+
+namespace PhantomFunction
+
+noncomputable def eval (ph : PhantomFunction α β) (x : α) : β := Classical.choose $ ph.total x
+
+theorem eval_eq (ph : PhantomFunction α β) : ∀ (x : α) (y : β), ph.eval x = y ↔ ph.f x y := by
+  intro x y
+  simp [eval]
+  have h' := Classical.choose_spec <| ph.total x
+  constructor <;> intro h
+  next =>
+    rw [h] at h'
+    assumption
+  next =>
+    apply ph.determ x
+    exact h'
+    exact h
+
+def mkPhantomFunction (g : α → β) : PhantomFunction α β where
+  f x y := g x = y
+  total x := ⟨_, rfl⟩
+  determ x y0 y1 h0 h1 := by rw [←h0, ←h1]
+
+def mkSizeOf (α : Type u) [inst : SizeOf α] : PhantomFunction α Nat :=
+  mkPhantomFunction inst.sizeOf
+
+class PhantomSizeOf (α : Sort u) where
+  sizeOf : PhantomFunction α Nat
+
+instance phantomSizeOf [SizeOf α] : PhantomSizeOf α where
+  sizeOf := mkSizeOf α
+
+noncomputable instance  (priority := high) sizeOfPhantom [ph : PhantomSizeOf α] : SizeOf α where
+  sizeOf := ph.sizeOf.eval
+
+theorem sizeOfPhantom_eq_SizeOf [inst : SizeOf α] : @sizeOfPhantom α (@phantomSizeOf α inst) = inst := by
+  cases inst
+  unfold sizeOfPhantom
+  apply congrArg
+  funext x
+  rw [eval_eq]
+  rfl
+
+end PhantomFunction
+
 namespace SlimCheck
 
-open Random Gen
+open Random Gen PhantomFunction
 
-structure ShrinkFn (α : Type u) [sz : SizeOf α] where
-  run : (x : α) → List { y : α // sz.sizeOf y < sz.sizeOf x }
+abbrev ShrinkFn (α : Type u) [PhantomSizeOf α] := (x : α) → List { y : α // sizeOfPhantom.sizeOf y < sizeOfPhantom.sizeOf x }
 
 class Sampleable (α : Type u) [Repr α] where
-  sample : Gen α
+  sample {} : Gen α
 
-class Shrinkable (α : Type u) [wf : SizeOf α] where
-  shrink : @ShrinkFn α wf
+class Shrinkable (α : Type u) [phSz : PhantomSizeOf α] where
+  shrink : @ShrinkFn α phSz := λ _ => []
 
 class SampleableExt (α : Sort u) where
   proxy : Type v
+  [phSz : PhantomSizeOf proxy]
   [proxyRepr : Repr proxy]
   [samp : Sampleable proxy]
   [shrink : Shrinkable proxy]
@@ -28,43 +77,26 @@ class SampleableExt (α : Sort u) where
 attribute [instance] SampleableExt.samp
 attribute [instance] SampleableExt.proxyRepr
 attribute [instance] SampleableExt.shrink
+attribute [instance] SampleableExt.phSz
 
-section GenericSampleableInstances
+namespace SampleableExt
 
-instance (priority := low) [Repr α] [Sampleable α] [SizeOf α] : Shrinkable α where
-  shrink := ⟨λ _ => []⟩
+def sample (α : Type u) [SampleableExt α] : Gen (SampleableExt.proxy α) := SampleableExt.samp.sample
 
-instance SampleableExt.ofSampleable [Repr α] [Sampleable α] [Shrinkable α] [SizeOf α] : SampleableExt α where
+instance ofSampleable [Repr α] [Sampleable α] [sz : SizeOf α] [PhantomSizeOf α] [Shrinkable α] : SampleableExt α where
   proxy := α 
+  phSz := inferInstance
   proxyRepr := inferInstance
   samp := inferInstance
   shrink := inferInstance
   interp := id
 
-end GenericSampleableInstances
+end SampleableExt
 
-section Shrinkers
-
-def Nat.shrink (n : Nat) : List { y : Nat // sizeOf y < sizeOf n } :=
-  if h : 0 < n then
-    let m := n/2
-    have h : m < n := by
-      apply Nat.div_lt_self h
-      decide
-    let rest := shrink m
-    ⟨m, h⟩ :: rest.map (λ x => {x with property := Nat.lt_trans x.property h})
-  else
-    []
+section Samplers
 
 instance Nat.sampleable : Sampleable Nat where
   sample := do choose Nat 0 (←getSize) (Nat.zero_le _)
-
-instance Nat.shrinkable : Shrinkable Nat where
-  shrink := ⟨Nat.shrink⟩
-
-def Fin.shrink {n : Nat} (m : Fin n.succ) : List { y : Fin n.succ // sizeOf y < sizeOf m } :=
-  let shrinks := Nat.shrink m.val
-  shrinks.map (λ x => {x with property := sorry})
 
 instance Fin.sampleable {n : Nat} : Sampleable (Fin (n.succ)) where
   sample := do choose (Fin n.succ) (Fin.ofNat 0) (Fin.ofNat (←getSize)) (by
@@ -72,42 +104,18 @@ instance Fin.sampleable {n : Nat} : Sampleable (Fin (n.succ)) where
     exact Nat.zero_le _
   )
 
-instance Fin.shrinkable {n : Nat} : Shrinkable (Fin n.succ) where
-  shrink := ⟨Fin.shrink⟩
-
-abbrev Int.sizeOfAbs : SizeOf Int := ⟨Int.natAbs⟩
-
-attribute [local instance] Int.sizeOfAbs
-
-def Int.shrink (n : Int) : List { y : Int // sizeOfAbs.sizeOf y < sizeOfAbs.sizeOf n } :=
-  Nat.shrink n.natAbs |>.map λ ⟨x, h⟩ => ⟨-x, (by simp only [SizeOf.sizeOf]; rw [Int.natAbs_neg]; exact h)⟩
-
 instance Int.sampleable : Sampleable Int where
   sample := do choose Int (-(←getSize)) (←getSize) (le_trans (Int.neg_nonpos_of_nonneg (Int.ofNat_zero_le _)) (Int.ofNat_zero_le _))
 
-instance Int.shrinkable : Shrinkable Int where
-  shrink := ⟨Int.shrink⟩
-
 instance Bool.sampleable : Sampleable Bool where
   sample := chooseAny Bool
-
-def Prod.shrink [SizeOf α] [SizeOf β] (shrA : ShrinkFn α) (shrB : ShrinkFn β) : ShrinkFn (α × β) := ⟨λ (fst, snd) =>
-  let shrink1 := shrA.run fst |>.map fun ⟨x, _⟩ => ⟨(x, snd), by simp_all_arith⟩
-  let shrink2 := shrB.run snd |>.map fun ⟨x, _⟩ => ⟨(fst, x), by simp_all_arith⟩
-  shrink1 ++ shrink2⟩
-
-instance Prod.sampleable [Repr α] [Repr β] [Sampleable α] [Sampleable β] : Sampleable (Prod α β) where
-  sample := prodOf Sampleable.sample Sampleable.sample
-
-instance Prod.shrinkable [SizeOf α] [SizeOf β] [Shrinkable α] [Shrinkable β] : Shrinkable (Prod α β) where
-  shrink := Prod.shrink Shrinkable.shrink Shrinkable.shrink
 
 def Char.sampleable (length : Nat) (chars : List Char) (pos : 0 < chars.length) : Sampleable Char :=
   {
     sample := do
       let x ← choose Nat 0 length (Nat.zero_le _)
       if x.val == 0 then
-        let n ← Sampleable.sample
+        let n ← Sampleable.sample Nat
         pure $ Char.ofNat n
       else
         elements chars pos
@@ -116,19 +124,69 @@ def Char.sampleable (length : Nat) (chars : List Char) (pos : 0 < chars.length) 
 instance Char.sampleableDefault : Sampleable Char :=
   Char.sampleable 3 " 0123abcABC:,;`\\/".toList (by decide)
 
-section ListShrink
+instance Prod.sampleable [Repr α] [Repr β] [Sampleable α] [Sampleable β] : Sampleable (Prod α β) where
+  sample := prodOf (Sampleable.sample α) (Sampleable.sample β)
 
-variable {α : Type u} [SizeOf α] (shr : ShrinkFn α)
--- TODO: List shrinker
+end Samplers
 
-end ListShrink
-end Shrinkers
+section Shrinkers
+
+def Nat.shrink (n : Nat) : List { y : Nat // sizeOfPhantom.sizeOf y < sizeOfPhantom.sizeOf n } :=
+  if h : 0 < n then
+    let m := n/2
+    have h : m < n := by
+      apply Nat.div_lt_self h
+      decide
+    let rest := shrink m
+    let current := ⟨m, by rw [sizeOfPhantom_eq_SizeOf]; exact h⟩
+    current ::
+      rest.map (λ x => {x with property := by
+        let h2 := x.property
+        simp [sizeOfPhantom_eq_SizeOf]
+        simp [sizeOfPhantom_eq_SizeOf] at h2
+        exact Nat.lt_trans h2 h
+      })
+  else
+    []
+
+instance Nat.shrinkable : Shrinkable Nat where
+  shrink := Nat.shrink
+
+def Fin.shrink {n : Nat} (m : Fin n.succ) : List { y : Fin n.succ // sizeOfPhantom.sizeOf y < sizeOfPhantom.sizeOf m } :=
+  let shrinks := Nat.shrink m.val
+  shrinks.map (λ x => {x with property := sorry})
+
+instance Fin.shrinkable {n : Nat} : Shrinkable (Fin n.succ) where
+  shrink := Fin.shrink
+
+abbrev Int.sizeOfAbs : SizeOf Int := ⟨Int.natAbs⟩
+
+attribute [local instance] Int.sizeOfAbs
+
+def Int.shrink (n : Int) : List { y : Int // sizeOfPhantom.sizeOf y < sizeOfPhantom.sizeOf n } :=
+  Nat.shrink n.natAbs |>.map λ ⟨x, h⟩ => ⟨-x, (by rw [sizeOfPhantom_eq_SizeOf] at *; simp only [SizeOf.sizeOf]; rw [Int.natAbs_neg]; exact h)⟩
+
+instance Int.shrinkable : Shrinkable Int where
+  shrink := Int.shrink
+
+instance Bool.shrinkable : Shrinkable Bool := {}
+
+def Prod.shrink [SizeOf α] [SizeOf β] [shrA : Shrinkable α] [shrB : Shrinkable β] : ShrinkFn (α × β) := λ (fst, snd) =>
+  let shrink1 := shrA.shrink fst |>.map fun ⟨x, _⟩ => ⟨(x, snd), by rw [sizeOfPhantom_eq_SizeOf] at *; simp_all_arith⟩
+  let shrink2 := shrB.shrink snd |>.map fun ⟨x, _⟩ => ⟨(fst, x), by rw [sizeOfPhantom_eq_SizeOf] at *; simp_all_arith⟩
+  shrink1 ++ shrink2
+
+instance Prod.shrinkable [SizeOf α] [SizeOf β] [Shrinkable α] [Shrinkable β] : Shrinkable (Prod α β) where
+  shrink := Prod.shrink
 
 instance Prop.sampleableExt : SampleableExt Prop where
-  proxy := Bool 
+  proxy := Bool
+  phSz := inferInstance
   samp := inferInstance
   shrink := inferInstance
   interp := Coe.coe
+
+end Shrinkers
 
 def NoShrink (α : Type u) := α
 
@@ -141,19 +199,16 @@ instance inhabited [inst : Inhabited α] : Inhabited (NoShrink α) := inst
 instance repr [inst : Repr α] : Repr (NoShrink α) := inst
 
 instance sampleable [Repr α] [Sampleable α] : Sampleable (NoShrink α) where
-  sample := NoShrink.mk <$> Sampleable.sample
+  sample := NoShrink.mk <$> Sampleable.sample α
 
-instance shrinkable : Shrinkable α where
-  shrink := ⟨λ _ => []⟩
+instance shrinkable : Shrinkable (NoShrink α) where
+  shrink := λ _ => []
 
 end NoShrink
 
 instance String.sampleable : Sampleable String where
   sample := do
-    let xs ← listOf Sampleable.sample
+    let xs ← listOf $ Sampleable.sample Char
     pure xs.asString
-
-instance String.shrinkable : Shrinkable String where
-  shrink := sorry -- requires List.shrinkable
 
 end SlimCheck

--- a/Mathlib/Testing/SlimCheck/Sampleable.lean
+++ b/Mathlib/Testing/SlimCheck/Sampleable.lean
@@ -216,7 +216,6 @@ def Char.sampleable (length : Nat) (chars : List Char) (pos : 0 < chars.length) 
         pure $ Char.ofNat n
       else
         elements chars pos
-  }
 
 instance Char.sampleableDefault : Sampleable Char :=
   Char.sampleable 3 " 0123abcABC:,;`\\/".toList (by decide)
@@ -263,8 +262,7 @@ def Fin.shrink {n : Nat} (m : Fin n.succ) : List { y : Fin n.succ // sizeOfPhant
 instance Fin.shrinkable {n : Nat} : Shrinkable (Fin n.succ) where
   shrink := Fin.shrink
 
-@[local instance]
-def Int.sizeOfAbs : SizeOf Int := ⟨Int.natAbs⟩
+local instance Int_sizeOfAbs : SizeOf Int := ⟨Int.natAbs⟩
 
 /-- `Int.shrinkable` operates like `Nat.shrinkable` but also includes the negative variants. -/
 instance Int.shrinkable : Shrinkable Int where

--- a/Mathlib/Testing/SlimCheck/Sampleable.lean
+++ b/Mathlib/Testing/SlimCheck/Sampleable.lean
@@ -4,7 +4,79 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Henrik Böving
 -/
 import Mathlib.Testing.SlimCheck.Gen
+/-!
+# `Sampleable` Class
+This class permits the creation samples of a given type
+controlling the size of those values using the `Gen` monad`.
 
+# `Shrinkable` Class
+This class helps minimize examples by creating smaller versions of
+given values.
+
+When testing a proposition like `∀ n : ℕ, prime n → n ≤ 100`,
+`SlimCheck` requires that `ℕ` have an instance of `Sampleable` and for
+`prime n` to be decidable.  `SlimCheck will then use the instance of
+`Sampleable` to generate small examples of ℕ and progressively increase
+in size. For each example `n`, `prime n` is tested. If it is false,
+the example will be rejected (not a test success nor a failure) and
+`SlimCheck` will move on to other examples. If `prime n` is true, `n
+≤ 100` will be tested. If it is false, `n` is a counter-example of `∀
+n : ℕ, prime n → n ≤ 100` and the test fails. If `n ≤ 100` is true,
+the test passes and `SlimCheck` moves on to trying more examples.
+
+This is a port of the Haskell QuickCheck library.
+
+## Main definitions
+  * `Sampleable` class
+  * `Shrinkable` class
+  * `SampleableExt` class
+
+### `Sampleable`
+`Sampleable α` provides ways of creating examples of type `α`,
+
+### `Shrinkable
+Given an example `x : α`, `Shrinkable α` gives us a way to shrink it
+and suggest simpler examples.
+
+### `SampleableExt`
+`SampleableExt` generalizes the behavior of `Sampleable` and `Shrinkable`
+and makes it possible to express instances for types that
+do not lend themselves to introspection, such as `ℕ → ℕ`.
+If we test a quantification over functions the
+counter-examples cannot be shrunken or printed meaningfully.
+For that purpose, `SampleableExt` provides a proxy representation
+`proxy` that can be printed and shrunken as well
+as interpreted (using `interp`) as an object of the right type.
+
+## Shrinking
+Shrinking happens when `SlimCheck` find a counter-example to a
+property.  It is likely that the example will be more complicated than
+necessary so `SlimCheck` proceeds to shrink it as much as
+possible. Although equally valid, a smaller counter-example is easier
+for a user to understand and use.
+
+The `Shrinkable` class, , has a `shrink` function so that we can use
+specialized knowledge while shrinking a value. It is not responsible
+for the whole shrinking process however. It only has to take one step
+in the shrinking process. `SlimCheck` will repeatedly call `shrink`
+until no more steps can be taken. Because `shrink` guarantees that the
+size of the candidates it produces is strictly smaller than the
+argument, we know that `SlimCheck` is guaranteed to terminate.
+
+## Tags
+
+random testing
+
+## References
+  * https://hackage.haskell.org/package/QuickCheck
+-/
+
+/-- This structure allows us to hide functions (especially noncomputable
+ones) in `Prop`, thus not requiring the compiler to generate any code
+for them. This is interesting if you have (noncomputable) functions
+you want to store in datatypes for proofs but not have generated any
+code for since they are not used.
+-/
 structure PhantomFunction (α : Sort u) (β : Sort v) where
   f : α → β → Prop
   total : ∀ x, ∃ y, f x y
@@ -12,8 +84,11 @@ structure PhantomFunction (α : Sort u) (β : Sort v) where
 
 namespace PhantomFunction
 
+/-- Evaluate the function hidden inside `ph`. -/
 noncomputable def eval (ph : PhantomFunction α β) (x : α) : β := Classical.choose $ ph.total x
 
+/-- Evaluating the function hidden inside a `PhantomFunction` is equivalent
+to evaluating the original function. -/
 theorem eval_eq (ph : PhantomFunction α β) : ∀ (x : α) (y : β), ph.eval x = y ↔ ph.f x y := by
   intro x y
   simp [eval]
@@ -27,23 +102,29 @@ theorem eval_eq (ph : PhantomFunction α β) : ∀ (x : α) (y : β), ph.eval x 
     exact h'
     exact h
 
+/-- Hide a regular function inside a `PhantomFunction`. -/
 def mkPhantomFunction (g : α → β) : PhantomFunction α β where
   f x y := g x = y
   total x := ⟨_, rfl⟩
   determ x y0 y1 h0 h1 := by rw [←h0, ←h1]
 
+/-- A specialized `mkPhantomFunction` for `SizeOf` instances. -/
 def mkSizeOf (α : Type u) [inst : SizeOf α] : PhantomFunction α Nat :=
   mkPhantomFunction inst.sizeOf
 
+/-- A typeclass to contain `SizeOf` instances hidden inside a `PhantomFunction`
+unlike the auto generated `SizeOf` instances this one can be stored
+in datatypes for proof purposes. -/
 class PhantomSizeOf (α : Sort u) where
   sizeOf : PhantomFunction α Nat
 
 instance phantomSizeOf [SizeOf α] : PhantomSizeOf α where
   sizeOf := mkSizeOf α
 
-noncomputable instance  (priority := high) sizeOfPhantom [ph : PhantomSizeOf α] : SizeOf α where
+noncomputable instance (priority := high) sizeOfPhantom [ph : PhantomSizeOf α] : SizeOf α where
   sizeOf := ph.sizeOf.eval
 
+/-- A specialized `eval_eq` for `SizeOf` instances. -/
 theorem sizeOfPhantom_eq_SizeOf [inst : SizeOf α] : @sizeOfPhantom α (@phantomSizeOf α inst) = inst := by
   cases inst
   unfold sizeOfPhantom
@@ -58,14 +139,26 @@ namespace SlimCheck
 
 open Random Gen PhantomFunction
 
+/-- `ShrinkFn α` is the type of functions that shrink an argument of type `α` -/
 abbrev ShrinkFn (α : Type u) [PhantomSizeOf α] := (x : α) → List { y : α // sizeOfPhantom.sizeOf y < sizeOfPhantom.sizeOf x }
 
+/-- `Sampleable α` provides ways of creating examples of type `α`. -/
 class Sampleable (α : Type u) [Repr α] where
   sample {} : Gen α
 
+/-- Given an example `x : α`, `Shrinkable α` gives us a way to shrink it
+and suggest simpler examples. -/
 class Shrinkable (α : Type u) [phSz : PhantomSizeOf α] where
-  shrink : @ShrinkFn α phSz := λ _ => []
 
+  shrink : @ShrinkFn α phSz := λ _ => []
+/-- `SampleableExt` generalizes the behavior of `Sampleable` and `Shrinkable`
+and makes it possible to express instances for types that
+do not lend themselves to introspection, such as `ℕ → ℕ`.
+If we test a quantification over functions the
+counter-examples cannot be shrunken or printed meaningfully.
+For that purpose, `SampleableExt` provides a proxy representation
+`proxy` that can be printed and shrunken as well
+as interpreted (using `interp`) as an object of the right type. -/
 class SampleableExt (α : Sort u) where
   proxy : Type v
   [phSz : PhantomSizeOf proxy]
@@ -110,6 +203,9 @@ instance Int.sampleable : Sampleable Int where
 instance Bool.sampleable : Sampleable Bool where
   sample := chooseAny Bool
 
+/-- This can be specialized into customized `Sampleable Char` instances.
+The resulting instance has `1 / length` chances of making an unrestricted choice of characters
+and it otherwise chooses a character from `chars` with uniform probabilities.  -/
 def Char.sampleable (length : Nat) (chars : List Char) (pos : 0 < chars.length) : Sampleable Char :=
   {
     sample := do
@@ -131,6 +227,8 @@ end Samplers
 
 section Shrinkers
 
+/-- `Nat.shrink' n` creates a list of smaller natural numbers by
+successively dividing `n` by 2 . For example, `Nat.shrink 5 = [2, 1, 0]`. -/
 def Nat.shrink (n : Nat) : List { y : Nat // sizeOfPhantom.sizeOf y < sizeOfPhantom.sizeOf n } :=
   if h : 0 < n then
     let m := n/2
@@ -152,6 +250,7 @@ def Nat.shrink (n : Nat) : List { y : Nat // sizeOfPhantom.sizeOf y < sizeOfPhan
 instance Nat.shrinkable : Shrinkable Nat where
   shrink := Nat.shrink
 
+/-- `Fin.shrink` works like `Nat.shrink` but instead operates on `Fin`. -/
 def Fin.shrink {n : Nat} (m : Fin n.succ) : List { y : Fin n.succ // sizeOfPhantom.sizeOf y < sizeOfPhantom.sizeOf m } :=
   let shrinks := Nat.shrink m.val
   shrinks.map (λ x => {x with property := sorry})
@@ -163,6 +262,7 @@ abbrev Int.sizeOfAbs : SizeOf Int := ⟨Int.natAbs⟩
 
 attribute [local instance] Int.sizeOfAbs
 
+/-- `Int.shrink` operates like `Nat.shrink` but also includes the negative variants. -/
 def Int.shrink (n : Int) : List { y : Int // sizeOfPhantom.sizeOf y < sizeOfPhantom.sizeOf n } :=
   Nat.shrink n.natAbs |>.map λ ⟨x, h⟩ => ⟨-x, (by rw [sizeOfPhantom_eq_SizeOf] at *; simp only [SizeOf.sizeOf]; rw [Int.natAbs_neg]; exact h)⟩
 
@@ -171,6 +271,9 @@ instance Int.shrinkable : Shrinkable Int where
 
 instance Bool.shrinkable : Shrinkable Bool := {}
 
+/-- `Prod.shrink` returns one half of candidates with the first element
+unchanged and the 2nd shrinked and the other half with the second element
+unchanged and the 1st shrinked. -/
 def Prod.shrink [SizeOf α] [SizeOf β] [shrA : Shrinkable α] [shrB : Shrinkable β] : ShrinkFn (α × β) := λ (fst, snd) =>
   let shrink1 := shrA.shrink fst |>.map fun ⟨x, _⟩ => ⟨(x, snd), by rw [sizeOfPhantom_eq_SizeOf] at *; simp_all_arith⟩
   let shrink2 := shrB.shrink snd |>.map fun ⟨x, _⟩ => ⟨(fst, x), by rw [sizeOfPhantom_eq_SizeOf] at *; simp_all_arith⟩
@@ -188,7 +291,8 @@ instance Prop.sampleableExt : SampleableExt Prop where
 
 end Shrinkers
 
-def NoShrink (α : Type u) := α
+/-- An annotation for values that should never get shrinked. -/
+abbrev NoShrink (α : Type u) := α
 
 namespace NoShrink
 

--- a/Mathlib/Testing/SlimCheck/Sampleable.lean
+++ b/Mathlib/Testing/SlimCheck/Sampleable.lean
@@ -179,7 +179,7 @@ namespace SampleableExt
 def sample (α : Type u) [SampleableExt α] : Gen (SampleableExt.proxy α) := SampleableExt.samp.sample
 
 instance ofSampleable [Repr α] [Sampleable α] [PhantomSizeOf α] [Shrinkable α] : SampleableExt α where
-  proxy := α 
+  proxy := α
   phSz := inferInstance
   proxyRepr := inferInstance
   samp := inferInstance

--- a/Mathlib/Testing/SlimCheck/Sampleable.lean
+++ b/Mathlib/Testing/SlimCheck/Sampleable.lean
@@ -208,8 +208,7 @@ instance Bool.sampleable : Sampleable Bool where
 /-- This can be specialized into customized `Sampleable Char` instances.
 The resulting instance has `1 / length` chances of making an unrestricted choice of characters
 and it otherwise chooses a character from `chars` with uniform probabilities.  -/
-def Char.sampleable (length : Nat) (chars : List Char) (pos : 0 < chars.length) : Sampleable Char :=
-  {
+def Char.sampleable (length : Nat) (chars : List Char) (pos : 0 < chars.length) : Sampleable Char where
     sample := do
       let x ← choose Nat 0 length (Nat.zero_le _)
       if x.val == 0 then
@@ -242,8 +241,8 @@ def Nat.shrink (n : Nat) : List { y : Nat // sizeOfPhantom.sizeOf y < sizeOfPhan
     current ::
       rest.map (λ x => {x with property := by
         let h2 := x.property
-        simp [sizeOfPhantom_eq_SizeOf]
-        simp [sizeOfPhantom_eq_SizeOf] at h2
+        simp only [sizeOfPhantom_eq_SizeOf]
+        simp only [sizeOfPhantom_eq_SizeOf] at h2
         exact Nat.lt_trans h2 h
       })
   else
@@ -264,16 +263,13 @@ def Fin.shrink {n : Nat} (m : Fin n.succ) : List { y : Fin n.succ // sizeOfPhant
 instance Fin.shrinkable {n : Nat} : Shrinkable (Fin n.succ) where
   shrink := Fin.shrink
 
-abbrev Int.sizeOfAbs : SizeOf Int := ⟨Int.natAbs⟩
+@[local instance]
+def Int.sizeOfAbs : SizeOf Int := ⟨Int.natAbs⟩
 
-attribute [local instance] Int.sizeOfAbs
-
-/-- `Int.shrink` operates like `Nat.shrink` but also includes the negative variants. -/
-def Int.shrink (n : Int) : List { y : Int // sizeOfPhantom.sizeOf y < sizeOfPhantom.sizeOf n } :=
-  Nat.shrink n.natAbs |>.map λ ⟨x, h⟩ => ⟨-x, (by rw [sizeOfPhantom_eq_SizeOf] at *; simp only [SizeOf.sizeOf]; rw [Int.natAbs_neg]; exact h)⟩
-
+/-- `Int.shrinkable` operates like `Nat.shrinkable` but also includes the negative variants. -/
 instance Int.shrinkable : Shrinkable Int where
-  shrink := Int.shrink
+  shrink n :=
+    Nat.shrink n.natAbs |>.map λ ⟨x, h⟩ => ⟨-x, (by rw [sizeOfPhantom_eq_SizeOf] at *; simp only [SizeOf.sizeOf]; rw [Int.natAbs_neg]; exact h)⟩
 
 instance Bool.shrinkable : Shrinkable Bool := {}
 
@@ -298,7 +294,7 @@ instance Prop.sampleableExt : SampleableExt Prop where
 end Shrinkers
 
 /-- An annotation for values that should never get shrinked. -/
-abbrev NoShrink (α : Type u) := α
+def NoShrink (α : Type u) := α
 
 namespace NoShrink
 

--- a/Mathlib/Testing/SlimCheck/Sampleable.lean
+++ b/Mathlib/Testing/SlimCheck/Sampleable.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2022 Henrik Böving. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Henrik Böving
+Authors: Henrik Böving, Simon Hudon
 -/
 import Mathlib.Testing.SlimCheck.Gen
 /-!

--- a/Mathlib/Testing/SlimCheck/Sampleable.lean
+++ b/Mathlib/Testing/SlimCheck/Sampleable.lean
@@ -253,7 +253,11 @@ instance Nat.shrinkable : Shrinkable Nat where
 /-- `Fin.shrink` works like `Nat.shrink` but instead operates on `Fin`. -/
 def Fin.shrink {n : Nat} (m : Fin n.succ) : List { y : Fin n.succ // sizeOfPhantom.sizeOf y < sizeOfPhantom.sizeOf m } :=
   let shrinks := Nat.shrink m.val
-  shrinks.map (λ x => {x with property := sorry})
+  shrinks.map (λ x => {x with property := by
+    have h := x.property
+    simp [sizeOfPhantom_eq_SizeOf]
+    simp [sizeOfPhantom_eq_SizeOf] at h
+    exact Nat.succ_lt_succ $ lt_of_le_of_lt (Nat.mod_le _ _) h})
 
 instance Fin.shrinkable {n : Nat} : Shrinkable (Fin n.succ) where
   shrink := Fin.shrink

--- a/Mathlib/Testing/SlimCheck/Sampleable.lean
+++ b/Mathlib/Testing/SlimCheck/Sampleable.lean
@@ -89,6 +89,7 @@ noncomputable def eval (ph : PhantomFunction α β) (x : α) : β := Classical.c
 
 /-- Evaluating the function hidden inside a `PhantomFunction` is equivalent
 to evaluating the original function. -/
+@[simp]
 theorem eval_eq (ph : PhantomFunction α β) : ∀ (x : α) (y : β), ph.eval x = y ↔ ph.f x y := by
   intro x y
   simp [eval]
@@ -116,15 +117,16 @@ def mkSizeOf (α : Type u) [inst : SizeOf α] : PhantomFunction α Nat :=
 unlike the auto generated `SizeOf` instances this one can be stored
 in datatypes for proof purposes. -/
 class PhantomSizeOf (α : Sort u) where
-  sizeOf : PhantomFunction α Nat
+  phSizeOf : PhantomFunction α Nat
 
 instance phantomSizeOf [SizeOf α] : PhantomSizeOf α where
-  sizeOf := mkSizeOf α
+  phSizeOf := mkSizeOf α
 
 noncomputable instance sizeOfPhantom [ph : PhantomSizeOf α] : SizeOf α where
-  sizeOf := ph.sizeOf.eval
+  sizeOf := ph.phSizeOf.eval
 
 /-- A specialized `eval_eq` for `SizeOf` instances. -/
+@[simp]
 theorem sizeOfPhantom_eq_SizeOf [inst : SizeOf α] : @sizeOfPhantom α (@phantomSizeOf α inst) = inst := by
   cases inst
   unfold sizeOfPhantom

--- a/Mathlib/Testing/SlimCheck/Sampleable.lean
+++ b/Mathlib/Testing/SlimCheck/Sampleable.lean
@@ -71,88 +71,15 @@ random testing
   * https://hackage.haskell.org/package/QuickCheck
 -/
 
-/-- This structure allows us to hide functions (especially noncomputable
-ones) in `Prop`, thus not requiring the compiler to generate any code
-for them. This is interesting if you have (noncomputable) functions
-you want to store in datatypes for proofs but not have generated any
-code for since they are not used.
--/
-structure PhantomFunction (α : Sort u) (β : Sort v) where
-  f : α → β → Prop
-  total : ∀ x, ∃ y, f x y
-  determ : ∀ x y0 y1, f x y0 → f x y1 → y0 = y1
-
-namespace PhantomFunction
-
-/-- Evaluate the function hidden inside `ph`. -/
-noncomputable def eval (ph : PhantomFunction α β) (x : α) : β := Classical.choose $ ph.total x
-
-/-- Evaluating the function hidden inside a `PhantomFunction` is equivalent
-to evaluating the original function. -/
-@[simp]
-theorem eval_eq (ph : PhantomFunction α β) : ∀ (x : α) (y : β), ph.eval x = y ↔ ph.f x y := by
-  intro x y
-  simp [eval]
-  have h' := Classical.choose_spec <| ph.total x
-  constructor <;> intro h
-  next =>
-    rw [h] at h'
-    assumption
-  next =>
-    apply ph.determ x
-    exact h'
-    exact h
-
-/-- Hide a regular function inside a `PhantomFunction`. -/
-def mkPhantomFunction (g : α → β) : PhantomFunction α β where
-  f x y := g x = y
-  total x := ⟨_, rfl⟩
-  determ x y0 y1 h0 h1 := by rw [←h0, ←h1]
-
-/-- A specialized `mkPhantomFunction` for `SizeOf` instances. -/
-def mkSizeOf (α : Type u) [inst : SizeOf α] : PhantomFunction α Nat :=
-  mkPhantomFunction inst.sizeOf
-
-/-- A typeclass to contain `SizeOf` instances hidden inside a `PhantomFunction`
-unlike the auto generated `SizeOf` instances this one can be stored
-in datatypes for proof purposes. -/
-class PhantomSizeOf (α : Sort u) where
-  phSizeOf : PhantomFunction α Nat
-
-instance phantomSizeOf [SizeOf α] : PhantomSizeOf α where
-  phSizeOf := mkSizeOf α
-
-noncomputable instance sizeOfPhantom [ph : PhantomSizeOf α] : SizeOf α where
-  sizeOf := ph.phSizeOf.eval
-
-/-- A specialized `eval_eq` for `SizeOf` instances. -/
-@[simp]
-theorem sizeOfPhantom_eq_SizeOf [inst : SizeOf α] : @sizeOfPhantom α (@phantomSizeOf α inst) = inst := by
-  cases inst
-  unfold sizeOfPhantom
-  apply congrArg
-  funext x
-  rw [eval_eq]
-  rfl
-
-end PhantomFunction
-
 namespace SlimCheck
 
-open Random Gen PhantomFunction
-
-/-- `ShrinkFn α` is the type of functions that shrink an argument of type `α` -/
-abbrev ShrinkFn (α : Type u) [PhantomSizeOf α] := (x : α) → List { y : α // sizeOfPhantom.sizeOf y < sizeOfPhantom.sizeOf x }
-
-/-- `Sampleable α` provides ways of creating examples of type `α`. -/
-class Sampleable (α : Type u) [Repr α] where
-  sample {} : Gen α
+open Random Gen
 
 /-- Given an example `x : α`, `Shrinkable α` gives us a way to shrink it
 and suggest simpler examples. -/
-class Shrinkable (α : Type u) [phSz : PhantomSizeOf α] where
+class Shrinkable (α : Type u) extends WellFoundedRelation α where
+  shrink : (x : α) → List { y : α // WellFoundedRelation.rel y x } := λ _ => []
 
-  shrink : @ShrinkFn α phSz := λ _ => []
 /-- `SampleableExt` generalizes the behavior of `Sampleable` and `Shrinkable`
 and makes it possible to express instances for types that
 do not lend themselves to introspection, such as `ℕ → ℕ`.
@@ -162,88 +89,40 @@ For that purpose, `SampleableExt` provides a proxy representation
 `proxy` that can be printed and shrunken as well
 as interpreted (using `interp`) as an object of the right type. -/
 class SampleableExt (α : Sort u) where
-  proxy : Type v
-  [phSz : PhantomSizeOf proxy]
+  proxy {} : Type v
   [proxyRepr : Repr proxy]
-  [samp : Sampleable proxy]
   [shrink : Shrinkable proxy]
+  sample {} : Gen proxy
   interp : proxy → α
 
-attribute [instance] SampleableExt.samp
 attribute [instance] SampleableExt.proxyRepr
 attribute [instance] SampleableExt.shrink
-attribute [instance] SampleableExt.phSz
 
 namespace SampleableExt
 
-def sample (α : Type u) [SampleableExt α] : Gen (SampleableExt.proxy α) := SampleableExt.samp.sample
-
-instance ofSampleable [Repr α] [Sampleable α] [PhantomSizeOf α] [Shrinkable α] : SampleableExt α where
+def mkSelfContained [Repr α] [Shrinkable α] (sample : Gen α) : SampleableExt α where
   proxy := α
-  phSz := inferInstance
   proxyRepr := inferInstance
-  samp := inferInstance
   shrink := inferInstance
+  sample := sample
   interp := id
 
 end SampleableExt
-
-section Samplers
-
-instance Nat.sampleable : Sampleable Nat where
-  sample := do choose Nat 0 (←getSize) (Nat.zero_le _)
-
-instance Fin.sampleable {n : Nat} : Sampleable (Fin (n.succ)) where
-  sample := do choose (Fin n.succ) (Fin.ofNat 0) (Fin.ofNat (←getSize)) (by
-    simp [Fin.ofNat, LE.le]
-    exact Nat.zero_le _
-  )
-
-instance Int.sampleable : Sampleable Int where
-  sample := do choose Int (-(←getSize)) (←getSize) (le_trans (Int.neg_nonpos_of_nonneg (Int.ofNat_zero_le _)) (Int.ofNat_zero_le _))
-
-instance Bool.sampleable : Sampleable Bool where
-  sample := chooseAny Bool
-
-/-- This can be specialized into customized `Sampleable Char` instances.
-The resulting instance has `1 / length` chances of making an unrestricted choice of characters
-and it otherwise chooses a character from `chars` with uniform probabilities.  -/
-def Char.sampleable (length : Nat) (chars : List Char) (pos : 0 < chars.length) : Sampleable Char where
-    sample := do
-      let x ← choose Nat 0 length (Nat.zero_le _)
-      if x.val == 0 then
-        let n ← Sampleable.sample Nat
-        pure $ Char.ofNat n
-      else
-        elements chars pos
-
-instance Char.sampleableDefault : Sampleable Char :=
-  Char.sampleable 3 " 0123abcABC:,;`\\/".toList (by decide)
-
-instance Prod.sampleable [Repr α] [Repr β] [Sampleable α] [Sampleable β] : Sampleable (Prod α β) where
-  sample := prodOf (Sampleable.sample α) (Sampleable.sample β)
-
-end Samplers
 
 section Shrinkers
 
 /-- `Nat.shrink' n` creates a list of smaller natural numbers by
 successively dividing `n` by 2 . For example, `Nat.shrink 5 = [2, 1, 0]`. -/
-def Nat.shrink (n : Nat) : List { y : Nat // sizeOfPhantom.sizeOf y < sizeOfPhantom.sizeOf n } :=
+def Nat.shrink (n : Nat) : List { y : Nat // WellFoundedRelation.rel y n } :=
   if h : 0 < n then
     let m := n/2
     have h : m < n := by
       apply Nat.div_lt_self h
       decide
     let rest := shrink m
-    let current := ⟨m, by rw [sizeOfPhantom_eq_SizeOf]; exact h⟩
+    let current := ⟨m, h⟩
     current ::
-      rest.map (λ x => {x with property := by
-        let h2 := x.property
-        simp only [sizeOfPhantom_eq_SizeOf]
-        simp only [sizeOfPhantom_eq_SizeOf] at h2
-        exact Nat.lt_trans h2 h
-      })
+      rest.map (λ x => {x with property := Nat.lt_trans x.property h})
   else
     []
 
@@ -251,13 +130,11 @@ instance Nat.shrinkable : Shrinkable Nat where
   shrink := Nat.shrink
 
 /-- `Fin.shrink` works like `Nat.shrink` but instead operates on `Fin`. -/
-def Fin.shrink {n : Nat} (m : Fin n.succ) : List { y : Fin n.succ // sizeOfPhantom.sizeOf y < sizeOfPhantom.sizeOf m } :=
+def Fin.shrink {n : Nat} (m : Fin n.succ) : List { y : Fin n.succ // WellFoundedRelation.rel y m } :=
   let shrinks := Nat.shrink m.val
   shrinks.map (λ x => {x with property := by
-    have h := x.property
-    simp [sizeOfPhantom_eq_SizeOf]
-    simp [sizeOfPhantom_eq_SizeOf] at h
-    exact Nat.succ_lt_succ $ lt_of_le_of_lt (Nat.mod_le _ _) h})
+    simp_wf
+    exact Nat.succ_lt_succ $ lt_of_le_of_lt (Nat.mod_le _ _) x.property})
 
 instance Fin.shrinkable {n : Nat} : Shrinkable (Fin n.succ) where
   shrink := Fin.shrink
@@ -267,29 +144,68 @@ local instance Int_sizeOfAbs : SizeOf Int := ⟨Int.natAbs⟩
 /-- `Int.shrinkable` operates like `Nat.shrinkable` but also includes the negative variants. -/
 instance Int.shrinkable : Shrinkable Int where
   shrink n :=
-    Nat.shrink n.natAbs |>.map λ ⟨x, h⟩ => ⟨-x, (by rw [sizeOfPhantom_eq_SizeOf] at *; simp only [SizeOf.sizeOf]; rw [Int.natAbs_neg]; exact h)⟩
+    Nat.shrink n.natAbs |>.map λ ⟨x, h⟩ => ⟨-x, (by simp_wf; simp only [SizeOf.sizeOf]; rw [Int.natAbs_neg]; exact h)⟩
 
 instance Bool.shrinkable : Shrinkable Bool := {}
+instance Char.shrinkable : Shrinkable Char := {}
 
-/-- `Prod.shrink` returns one half of candidates with the first element
-unchanged and the 2nd shrinked and the other half with the second element
-unchanged and the 1st shrinked. -/
-def Prod.shrink [SizeOf α] [SizeOf β] [shrA : Shrinkable α] [shrB : Shrinkable β] : ShrinkFn (α × β) := λ (fst, snd) =>
-  let shrink1 := shrA.shrink fst |>.map fun ⟨x, _⟩ => ⟨(x, snd), by rw [sizeOfPhantom_eq_SizeOf] at *; simp_all_arith⟩
-  let shrink2 := shrB.shrink snd |>.map fun ⟨x, _⟩ => ⟨(fst, x), by rw [sizeOfPhantom_eq_SizeOf] at *; simp_all_arith⟩
-  shrink1 ++ shrink2
+instance Prod.shrinkable [shrA : Shrinkable α] [shrB : Shrinkable β] : Shrinkable (Prod α β) where
+  shrink := λ (fst,snd) =>
+    let shrink1 := shrA.shrink fst |>.map fun ⟨x, _⟩ => ⟨(x, snd), by simp_wf; apply Prod.Lex.left; simp_all_arith⟩
+    let shrink2 := shrB.shrink snd |>.map fun ⟨x, _⟩ => ⟨(fst, x), by simp_wf; apply Prod.Lex.right; simp_all_arith⟩
+    shrink1 ++ shrink2
 
-instance Prod.shrinkable [SizeOf α] [SizeOf β] [Shrinkable α] [Shrinkable β] : Shrinkable (Prod α β) where
-  shrink := Prod.shrink
+end Shrinkers
+
+section Samplers
+
+open SampleableExt
+
+instance Nat.sampleableExt : SampleableExt Nat :=
+  mkSelfContained (do choose Nat 0 (←getSize) (Nat.zero_le _))
+
+instance Fin.sampleableExt {n : Nat} : SampleableExt (Fin (n.succ)) :=
+  mkSelfContained (do choose (Fin n.succ) (Fin.ofNat 0) (Fin.ofNat (←getSize)) (by
+    simp [Fin.ofNat, LE.le]
+    exact Nat.zero_le _
+  ))
+
+instance Int.sampleableExt : SampleableExt Int :=
+  mkSelfContained (do choose Int (-(←getSize)) (←getSize) (le_trans (Int.neg_nonpos_of_nonneg (Int.ofNat_zero_le _)) (Int.ofNat_zero_le _)))
+
+instance Bool.sampleableExt : SampleableExt Bool :=
+  mkSelfContained $ chooseAny Bool
+
+/-- This can be specialized into customized `Sampleable Char` instances.
+The resulting instance has `1 / length` chances of making an unrestricted choice of characters
+and it otherwise chooses a character from `chars` with uniform probabilities.  -/
+def Char.sampleable (length : Nat) (chars : List Char) (pos : 0 < chars.length) : SampleableExt Char :=
+    mkSelfContained do
+      let x ← choose Nat 0 length (Nat.zero_le _)
+      if x.val == 0 then
+        let n ← sample Nat
+        pure $ Char.ofNat n
+      else
+        elements chars pos
+
+instance Char.sampleableDefault : SampleableExt Char :=
+  Char.sampleable 3 " 0123abcABC:,;`\\/".toList (by decide)
+
+instance Prod.sampleableExt [SampleableExt α] [SampleableExt β] : SampleableExt (Prod α β) where
+  proxy := Prod (proxy α) (proxy β)
+  proxyRepr := inferInstance
+  shrink := inferInstance
+  sample := prodOf (sample α) (sample β)
+  interp := Prod.map interp interp
 
 instance Prop.sampleableExt : SampleableExt Prop where
   proxy := Bool
-  phSz := inferInstance
-  samp := inferInstance
+  proxyRepr := inferInstance
+  sample := sample Bool
   shrink := inferInstance
   interp := Coe.coe
 
-end Shrinkers
+end Samplers
 
 /-- An annotation for values that should never get shrinked. -/
 def NoShrink (α : Type u) := α
@@ -302,17 +218,12 @@ def get (x : NoShrink α) : α := x
 instance inhabited [inst : Inhabited α] : Inhabited (NoShrink α) := inst
 instance repr [inst : Repr α] : Repr (NoShrink α) := inst
 
-instance sampleable [Repr α] [Sampleable α] : Sampleable (NoShrink α) where
-  sample := NoShrink.mk <$> Sampleable.sample α
-
 instance shrinkable : Shrinkable (NoShrink α) where
   shrink := λ _ => []
 
-end NoShrink
+instance sampleableExt [SampleableExt α] [Repr α] : SampleableExt (NoShrink α) :=
+  SampleableExt.mkSelfContained $ (NoShrink.mk ∘ SampleableExt.interp) <$> SampleableExt.sample α
 
-instance String.sampleable : Sampleable String where
-  sample := do
-    let xs ← listOf $ Sampleable.sample Char
-    pure xs.asString
+end NoShrink
 
 end SlimCheck

--- a/Mathlib/Testing/SlimCheck/Sampleable.lean
+++ b/Mathlib/Testing/SlimCheck/Sampleable.lean
@@ -176,7 +176,7 @@ namespace SampleableExt
 
 def sample (α : Type u) [SampleableExt α] : Gen (SampleableExt.proxy α) := SampleableExt.samp.sample
 
-instance ofSampleable [Repr α] [Sampleable α] [sz : SizeOf α] [PhantomSizeOf α] [Shrinkable α] : SampleableExt α where
+instance ofSampleable [Repr α] [Sampleable α] [PhantomSizeOf α] [Shrinkable α] : SampleableExt α where
   proxy := α 
   phSz := inferInstance
   proxyRepr := inferInstance

--- a/Mathlib/Testing/SlimCheck/Sampleable.lean
+++ b/Mathlib/Testing/SlimCheck/Sampleable.lean
@@ -121,7 +121,7 @@ class PhantomSizeOf (α : Sort u) where
 instance phantomSizeOf [SizeOf α] : PhantomSizeOf α where
   sizeOf := mkSizeOf α
 
-noncomputable instance (priority := high) sizeOfPhantom [ph : PhantomSizeOf α] : SizeOf α where
+noncomputable instance sizeOfPhantom [ph : PhantomSizeOf α] : SizeOf α where
   sizeOf := ph.sizeOf.eval
 
 /-- A specialized `eval_eq` for `SizeOf` instances. -/

--- a/Mathlib/Testing/SlimCheck/Testable.lean
+++ b/Mathlib/Testing/SlimCheck/Testable.lean
@@ -125,7 +125,7 @@ instance (priority := low) : PrintableProp p where
 class Testable (p : Prop) where
   run {} (cfg : Configuration) (minimize : Bool) : Gen (TestResult p)
 
-abbrev NamedBinder (n : String) (p : Prop) : Prop := p
+def NamedBinder (n : String) (p : Prop) : Prop := p
 
 namespace TestResult
 

--- a/Mathlib/Testing/SlimCheck/Testable.lean
+++ b/Mathlib/Testing/SlimCheck/Testable.lean
@@ -52,7 +52,7 @@ def toString : TestResult p → String
 
 instance : ToString (TestResult p) := ⟨toString⟩
 
-def combine : PSum Unit (p → q) → PSum Unit p → PSum Unit q
+def combine {p q : Prop} : PSum Unit (p → q) → PSum Unit p → PSum Unit q
 | PSum.inr f, PSum.inr proof => PSum.inr $ f proof
 | _, _ => PSum.inl ()
 
@@ -372,10 +372,7 @@ def Testable.check (p : Prop) (cfg : Configuration := {}) (p' : Decorations.Deco
   | TestResult.gaveUp n => if !cfg.quiet then IO.println s!"Gave up {n} times"
   | TestResult.failure _ xs n => throw (IO.userError $ formatFailureAux "Found problems!" xs n)
 
--- Works
--- #eval Testable.check (∀ (x y z a : Nat) (h1 : 3 < x) (h2 : 3 < y), x - y = y - x) { Configuration.verbose with randomSeed := some 10000}
--- Broken
--- #eval Testable.check (∀ (x y z a : Nat) (h1 : 3 < x) (h2 : 3 < y), x - y = y - x) { Configuration.verbose with randomSeed := some 1000}
+-- #eval Testable.check (∀ (x y z a : Nat) (h1 : 3 < x) (h2 : 3 < y), x - y = y - x) Configuration.verbose
 -- #eval Testable.check (∀ x : Nat, ∀ y : Nat, x + y = y + x) Configuration.verbose
 -- #eval Testable.check (∀ (x : (Nat × Nat)), x.fst - x.snd - 10 = x.snd - x.fst - 10) Configuration.verbose
 -- #eval Testable.check (∀ (x : Nat) (h : 10 < x), 5 < x) Configuration.verbose

--- a/Mathlib/Testing/SlimCheck/Testable.lean
+++ b/Mathlib/Testing/SlimCheck/Testable.lean
@@ -7,16 +7,96 @@ Authors: Henrik Böving
 import Mathlib.Testing.SlimCheck.Sampleable
 import Lean
 
+/-!
+# `Testable` Class
+Testable propositions have a procedure that can generate counter-examples
+together with a proof that they invalidate the proposition.
+
+This is a port of the Haskell QuickCheck library.
+
+## Creating Customized Instances
+The type classes `Testable`, `Sampleable` and `Shrinkable` are the
+means by which `SlimCheck` creates samples and tests them. For instance,
+the proposition `∀ i j : ℕ, i ≤ j` has a `Testable` instance because `ℕ`
+is sampleable and `i ≤ j` is decidable. Once `SlimCheck` finds the `Testable`
+instance, it can start using the instance to repeatedly creating samples
+and checking whether they satisfy the property. Once it has found a
+counter-example it will then use a `Shrinkable` instance to reduce the
+example. This allows the user to create new instances and apply
+`SlimCheck` to new situations.
+
+### What do I do if I'm testing a property about my newly defined type?
+Let us consider a type made for a new formalization:
+```lean
+structure MyType where
+  x : ℕ
+  y : ℕ
+  h : x ≤ y
+  deriving Repr
+```
+How do we test a property about `MyType`? For instance, let us consider
+`Testable.check $ ∀ a b : MyType, a.y ≤ b.x → a.x ≤ b.y`. Writing this
+property as is will give us an error because we do not have an instance
+of `Sampleable MyType`. We can define one as follows:
+```lean
+instance : Sampleable MyType where
+  sample := do
+    let x ← Sampleable.sample Nat
+    let xyDiff ← Sampleable.sample Nat
+    pure $ ⟨x, x + xyDiff, sorrere
+  shrink := λ ⟨x,y,h⟩ =>
+    let proxy := Shrinkable.shrink (x, y - x)
+    proxy.map (λ ⟨⟨fst, snd⟩, ha⟩ => ⟨⟨fst, fst + snd, sorry⟩, sorry⟩)
+```
+Again, we take advantage of the fact that other types have useful
+`Shrinkable` implementations, in this case `Prod`. Note that the second
+proof is heavily based on `SizeOf` since its used for termination so
+the first step you want to take is almost always to `simp` in order to
+get through both `SizeOf` abstraction by `SlimCheck` and the auto generated
+`SizeOf` instances.
+
+## Main definitions
+  * `Testable` class
+  * `Testable.check`: a way to test a proposition using random examples
+
+## Tags
+
+random testing
+
+## References
+  * https://hackage.haskell.org/package/QuickCheck
+-/
+
 namespace SlimCheck
 
 variable {β : α → Prop}
 
+/-- Result of trying to disprove `p`
+The constructors are:
+  *  `success : (PSum Unit p) → TestResult p`
+     succeed when we find another example satisfying `p`
+     In `success h`, `h` is an optional proof of the proposition.
+     Without the proof, all we know is that we found one example
+     where `p` holds. With a proof, the one test was sufficient to
+     prove that `p` holds and we do not need to keep finding examples.
+   * `gaveUp : ℕ → TestResult p`
+     give up when a well-formed example cannot be generated.
+     `gaveUp n` tells us that `n` invalid examples were tried.
+     Above 100, we give up on the proposition and report that we
+     did not find a way to properly test it.
+   * `failure : ¬ p → (List String) → ℕ → TestResult p`
+     a counter-example to `p`; the strings specify values for the relevant variables.
+     `failure h vs n` also carries a proof that `p` does not hold. This way, we can
+     guarantee that there will be no false positive. The last component, `n`,
+     is the number of times that the counter-example was shrunk.
+-/
 inductive TestResult (p : Prop) where
 | success : PSum Unit p → TestResult p
 | gaveUp : Nat → TestResult p
 | failure : ¬p → List String → Nat → TestResult p
 deriving Inhabited
 
+/-- Configuration for testing a property. -/
 structure Configuration where
   numInst : Nat := 100
   maxSize : Nat := 100
@@ -28,7 +108,11 @@ structure Configuration where
   randomSeed : Option Nat := none
   quiet : Bool := false
   deriving Inhabited
-
+/--
+`PrintableProp p` allows one to print a proposition so that
+`SlimCheck` can indicate how values relate to each other.
+It's basically a poor man's delaborator.
+-/
 class PrintableProp (p : Prop) where
   printProp : Option String
 
@@ -37,6 +121,7 @@ export PrintableProp (printProp)
 instance (priority := low) : PrintableProp p where
   printProp := none
 
+/-- `Testable p` uses random examples to try to disprove `p`. -/
 class Testable (p : Prop) where
   run {} (cfg : Configuration) (minimize : Bool) : Gen (TestResult p)
 
@@ -52,10 +137,12 @@ def toString : TestResult p → String
 
 instance : ToString (TestResult p) := ⟨toString⟩
 
+/-- Applicative combinator proof carrying test results. -/
 def combine {p q : Prop} : PSum Unit (p → q) → PSum Unit p → PSum Unit q
 | PSum.inr f, PSum.inr proof => PSum.inr $ f proof
 | _, _ => PSum.inl ()
 
+/-- Combine the test result for properties `p` and `q` to create a test for their conjunction. -/
 def and : TestResult p → TestResult q → TestResult (p ∧ q)
 | failure h xs n, _ => failure (λ h2 => h h2.left) xs n
 | _, failure h xs n => failure (λ h2 => h h2.right) xs n
@@ -64,6 +151,7 @@ def and : TestResult p → TestResult q → TestResult (p ∧ q)
 | gaveUp n, _ => gaveUp n
 | _, gaveUp n => gaveUp n
 
+/-- Combine the test result for properties `p` and `q` to create a test for their disjunction. -/
 def or : TestResult p → TestResult q → TestResult (p ∨ q)
 | failure h1 xs n, failure h2 ys m =>
   let h3 := λ h =>
@@ -77,6 +165,8 @@ def or : TestResult p → TestResult q → TestResult (p ∨ q)
 | gaveUp n, _ => gaveUp n
 | _, gaveUp n => gaveUp n
 
+/-- If `q → p`, then `¬ p → ¬ q` which means that testing `p` can allow us
+to find counter-examples to `q`. -/
 def imp (h : q → p) (r : TestResult p)
     (p : PSum Unit (p → q) := PSum.inl ()) : TestResult q :=
   match r with
@@ -84,9 +174,13 @@ def imp (h : q → p) (r : TestResult p)
   | success h2 => success $ combine p h2
   | gaveUp n => gaveUp n
 
+/-- Test `q` by testing `p` and proving the equivalence between the two. -/
 def iff (h : q ↔ p) (r : TestResult p) : TestResult q :=
   imp h.mp r (PSum.inr h.mpr)
 
+/-- When we assign a value to a universally quantified variable,
+we record that value using this function so that our counter-examples
+can be informative. -/
 def addInfo (x : String) (h : q → p) (r : TestResult p)
     (p : PSum Unit (p → q) := PSum.inl ()) : TestResult q :=
   if let failure h2 xs n := r then
@@ -94,6 +188,7 @@ def addInfo (x : String) (h : q → p) (r : TestResult p)
   else
     imp h r p
 
+/-- Add some formatting to the information recorded by `addInfo`. -/
 def addVarInfo [Repr γ] (var : String) (x : γ) (h : q → p) (r : TestResult p)
     (p : PSum Unit (p → q) := PSum.inl ()) : TestResult q  :=
   addInfo s!"{var} := {repr x}" h r p
@@ -106,6 +201,7 @@ end TestResult
 
 namespace Configuration
 
+/-- A configuration with all the trace options enabled, useful for debugging. -/
 def verbose : Configuration := {
   traceDiscarded := true,
   traceSuccesses := true,
@@ -119,6 +215,7 @@ namespace Testable
 
 open TestResult
 
+/-- A `dbgTrace` with special formatting -/
 def slimTrace [Pure m] (s : String) : m PUnit := dbgTrace s!"[SlimCheck: {s}]" (λ _ => pure ())
 
 instance andTestable [Testable p] [Testable q] : Testable (p ∧ q) where
@@ -164,14 +261,18 @@ instance forallTypesTestable {f : Type → Prop} [Testable (f Int)] : Testable (
     let r ← run (f Int) cfg min
     pure $ addVarInfo var "ℤ" (· $ Int) r
 
+/-- Test proposition `p` by randomly selecting one of the provided
+testable instances. -/
 def combine (ts : List (Testable p)) (h : 0 < ts.length) : Testable p := ⟨λ cfg min => do
   let f := (@Testable.run _ · cfg min)
   have : 0 < List.length (List.map f ts) := by
     rw [List.length_map]
     exact h
   Gen.oneOf (ts.map f) this⟩
-
-def formatFailureAux (s : String) (xs : List String) (n : Nat) : String :=
+/--
+Format the counter-examples found in a test failure.
+-/
+def formatFailure (s : String) (xs : List String) (n : Nat) : String :=
   let counter := String.intercalate "\n" xs
   let parts := [
     "\n===================",
@@ -182,10 +283,18 @@ def formatFailureAux (s : String) (xs : List String) (n : Nat) : String :=
   ]
   String.intercalate "\n" parts
 
+/--
+Increase the number of shrinking steps in a test result.
+-/
 def addShrinks (n : Nat) : TestResult p → TestResult p
 | TestResult.failure p xs m => TestResult.failure p xs (m + n)
 | p => p
 
+/-- Shrink a counter-example `x` by using `Shrinkable.shrink x`, picking the first
+candidate that falsifies a property and recursively shrinking that one.
+The process is guaranteed to terminate because `shrink x` produces
+a proof that all the values it produces are smaller (according to `SizeOf`)
+than `x`. -/
 def minimizeAux [SampleableExt α] [∀ x, Testable (β x)] (cfg : Configuration) (var : String)
     (x : SampleableExt.proxy α) (n : Nat) : OptionT Gen (Σ x, TestResult (β (SampleableExt.interp x))) := do
   let candidates := SampleableExt.shrink.shrink x
@@ -205,6 +314,8 @@ def minimizeAux [SampleableExt α] [∀ x, Testable (β x)] (cfg : Configuration
     slimTrace s!"No shrinking possible for {var} := {repr x}"
   failure
 
+/-- Once a property fails to hold on an example, look for smaller counter-examples
+to show the user. -/
 def minimize [SampleableExt α] [∀ x, Testable (β x)] (cfg : Configuration) (var : String)
     (x : SampleableExt.proxy α) (r : TestResult (β $ SampleableExt.interp x)) : Gen (Σ x, TestResult (β $ SampleableExt.interp x)) := do
   if cfg.traceShrink then
@@ -213,6 +324,8 @@ def minimize [SampleableExt α] [∀ x, Testable (β x)] (cfg : Configuration) (
   let res ← OptionT.run $ minimizeAux cfg var x 0
   pure $ res.getD ⟨x, r⟩
 
+/-- Test a universal property by creating a sample of the right type and instantiating the
+bound variable with it. -/
 instance varTestable [SampleableExt α] [∀ x, Testable (β x)] : Testable (NamedBinder var $ ∀ x : α, β x) where
   run := λ cfg min => do
     let x ← SampleableExt.sample α
@@ -231,6 +344,7 @@ instance varTestable [SampleableExt α] [∀ x, Testable (β x)] : Testable (Nam
         pure $ ⟨x, r⟩
     pure $ addVarInfo var finalX (· $ SampleableExt.interp finalX) finalR
 
+/-- Test a universal property about propositions -/
 instance propVarTestable {β : Prop → Prop} [∀ b : Bool, Testable (β b)] : Testable (NamedBinder var $ ∀ p : Prop, β p) where
   run := λ cfg min =>
     imp (λ h (b : Bool) => h b) <$> Testable.run (NamedBinder var $ ∀ b : Bool, β b) cfg min
@@ -297,6 +411,7 @@ end PrintableProp
 section IO
 open TestResult
 
+/-- Execute `cmd` and repeat every time the result is `gave_up` (at most `n` times). -/
 def retry (cmd : Rand (TestResult p)) (cfg : Configuration) : Nat → Rand (TestResult p)
 | 0 => pure $ TestResult.gaveUp 1
 | n+1 => do
@@ -306,12 +421,14 @@ def retry (cmd : Rand (TestResult p)) (cfg : Configuration) : Nat → Rand (Test
   | TestResult.failure h xs n => pure $ failure h xs n
   | gaveUp _ => retry cmd cfg n
 
+/-- Count the number of times the test procedure gave up. -/
 def giveUp (x : Nat) : TestResult p → TestResult p
 | success (PSum.inl ()) => gaveUp x
 | success (PSum.inr p) => success $ (PSum.inr p)
 | gaveUp n => gaveUp $ n + x
 | TestResult.failure h xs n => failure h xs n
 
+/-- Try `n` times to find a counter-example for `p`. -/
 def Testable.runSuiteAux (p : Prop) [Testable p] (cfg : Configuration) : TestResult p → Nat → Rand (TestResult p)
 | r, 0 => pure r
 | r, n+1 => do
@@ -325,9 +442,11 @@ def Testable.runSuiteAux (p : Prop) [Testable p] (cfg : Configuration) : TestRes
   | (gaveUp g) => runSuiteAux p cfg (giveUp g r) n
   | _ => pure $ x
 
+/-- Try to find a counter-example of `p`. -/
 def Testable.runSuite (p : Prop) [Testable p] (cfg : Configuration := {}) : Rand (TestResult p) :=
   Testable.runSuiteAux p cfg (success $ PSum.inl ()) cfg.numInst
 
+/-- Run a test suite for `p` in `BaseIO` using the global RNG in `stdGenRef`. -/
 def Testable.checkIO (p : Prop) [Testable p] (cfg : Configuration := {}) : BaseIO (TestResult p) :=
   match cfg.randomSeed with
   | none => IO.runRand (Testable.runSuite p cfg)
@@ -339,6 +458,8 @@ namespace Decorations
 
 open Lean
 
+/-- Traverse the syntax of a proposition to find universal quantifiers
+quantifiers and add `NamedBinder` annotations next to them. -/
 partial def addDecorations (e : Expr) : Expr :=
   e.replace $ λ expr =>
     match expr with
@@ -350,13 +471,26 @@ partial def addDecorations (e : Expr) : Expr :=
       some $ mkApp2 (mkConst `SlimCheck.NamedBinder) (mkStrLit n) rest
     | _ => none
 
+/-- `DecorationsOf p` is used as a hint to `mk_decorations` to specify
+that the goal should be satisfied with a proposition equivalent to `p`
+with added annotations. -/
 abbrev DecorationsOf (p : Prop) := Prop
 
-syntax (name := mkDecorations) "mk_decorations" : tactic
+syntax "mk_decorations" : tactic
 
 open Elab.Tactic
 open Meta
 
+/-- In a goal of the shape `⊢ DecorationsOf p`, `mk_decoration` examines
+the syntax of `p` and adds `NamedBinder` around universal quantifications
+to improve error messages. This tool can be used in the declaration of a
+function as follows:
+```lean
+def foo (p : Prop) (p' : Decorations.DecorationsOf p := by mk_decorations) [Testable p'] : ...
+```
+`p` is the parameter given by the user, `p'` is a definitionally equivalent
+proposition where the quantifiers are annotated with `NamedBinder`.
+-/
 elab_rules : tactic | `(tactic| mk_decorations) => do
   let goal ← getMainGoal
   let goalType ← getMVarType goal
@@ -365,12 +499,13 @@ elab_rules : tactic | `(tactic| mk_decorations) => do
 
 end Decorations
 
+/-- Run a test suite for `p` and throw an exception if `p` does not not hold.-/
 def Testable.check (p : Prop) (cfg : Configuration := {}) (p' : Decorations.DecorationsOf p := by mk_decorations) [Testable p'] : IO PUnit := do
   let x ← Testable.checkIO p' cfg
   match x with
   | TestResult.success _ => if !cfg.quiet then IO.println "Success" else pure ()
   | TestResult.gaveUp n => if !cfg.quiet then IO.println s!"Gave up {n} times"
-  | TestResult.failure _ xs n => throw (IO.userError $ formatFailureAux "Found problems!" xs n)
+  | TestResult.failure _ xs n => throw (IO.userError $ formatFailure "Found problems!" xs n)
 
 -- #eval Testable.check (∀ (x y z a : Nat) (h1 : 3 < x) (h2 : 3 < y), x - y = y - x) Configuration.verbose
 -- #eval Testable.check (∀ x : Nat, ∀ y : Nat, x + y = y + x) Configuration.verbose
@@ -378,3 +513,4 @@ def Testable.check (p : Prop) (cfg : Configuration := {}) (p' : Decorations.Deco
 -- #eval Testable.check (∀ (x : Nat) (h : 10 < x), 5 < x) Configuration.verbose
 
 end SlimCheck
+

--- a/Mathlib/Testing/SlimCheck/Testable.lean
+++ b/Mathlib/Testing/SlimCheck/Testable.lean
@@ -302,6 +302,7 @@ def minimizeAux [SampleableExt α] {β : α → Prop} [∀ x, Testable (β x)] (
   if cfg.traceShrink then
     slimTrace s!"No shrinking possible for {var} := {repr x}"
   failure
+  termination_by minimizeAux cfg var x n => x
 
 /-- Once a property fails to hold on an example, look for smaller counter-examples
 to show the user. -/

--- a/Mathlib/Testing/SlimCheck/Testable.lean
+++ b/Mathlib/Testing/SlimCheck/Testable.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2022 Henrik Böving. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Henrik Böving
+Authors: Henrik Böving, Simon Hudon
 -/
 
 import Mathlib.Testing.SlimCheck.Sampleable

--- a/Mathlib/Testing/SlimCheck/Testable.lean
+++ b/Mathlib/Testing/SlimCheck/Testable.lean
@@ -1,0 +1,209 @@
+/-
+Copyright (c) 2022 Henrik Böving. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Henrik Böving
+-/
+import Mathlib.Testing.SlimCheck.Sampleable
+import Mathlib.Tactic.LibrarySearch
+import Mathlib.Tactic.Find
+
+namespace SlimCheck
+
+inductive TestResult (p : Prop) where
+| success : PSum Unit p → TestResult p
+| gaveUp : Nat → TestResult p
+| failure : ¬p → List String → Nat → TestResult p
+deriving Inhabited
+
+structure Configuration where
+  numInst : Nat := 100
+  maxSize : Nat := 100
+  minSize : Nat := 1
+  traceDiscarded : Bool := false
+  traceSuccesses : Bool := false
+  traceShrink : Bool := false
+  traceShrinkCandidates : Bool := false
+  randomSeed : Option Nat := none
+  quiet : Bool := false
+  deriving Inhabited
+
+class PrintableProp (p : Prop) where
+  printProp : Option String
+
+export PrintableProp (printProp)
+
+instance (priority := low) : PrintableProp p where
+  printProp := none
+
+class Testable (p : Prop) where
+  run {} (cfg : Configuration) (minimize : Bool) : Gen (TestResult p)
+
+def NamedBinder (n : String) (p : Prop) : Prop := p
+
+namespace TestResult
+
+def toString : TestResult p → String
+| success (PSum.inl _) => "success (no proof)"
+| success (PSum.inr _) => "success (proof)"
+| gaveUp n => s!"gave {n} times"
+| failure _ counters n => s!"failed {counters}"
+
+instance : ToString (TestResult p) := ⟨toString⟩
+
+def combine {p q : Prop} : PSum Unit (p → q) → PSum Unit p → PSum Unit q
+| PSum.inr f, PSum.inr proof => PSum.inr $ f proof
+| _, _ => PSum.inl ()
+
+def and : TestResult p → TestResult q → TestResult (p ∧ q)
+| failure h xs n, _ => failure (λ h2 => h h2.left) xs n
+| _, failure h xs n => failure (λ h2 => h h2.right) xs n
+| success h1, success h2 => success $ combine (combine (PSum.inr And.intro) h1) h2
+| gaveUp n, gaveUp m => gaveUp $ n + m
+| gaveUp n, _ => gaveUp n
+| _, gaveUp n => gaveUp n
+
+def or : TestResult p → TestResult q → TestResult (p ∨ q)
+| failure h1 xs n, failure h2 ys m =>
+  let h3 := λ h =>
+    match h with
+    | Or.inl h3 => h1 h3
+    | Or.inr h3 => h2 h3
+  failure h3 (xs ++ ys) (n + m)
+| success h, _ => success $ combine (PSum.inr Or.inl) h
+| _, success h => success $ combine (PSum.inr Or.inr) h
+| gaveUp n, gaveUp m => gaveUp $ n + m
+| gaveUp n, _ => gaveUp n
+| _, gaveUp n => gaveUp n
+
+def imp (h : q → p) (r : TestResult p)
+    (p : PSum Unit (p → q) := PSum.inl ()) : TestResult q :=
+  match r with
+  | failure h2 xs n => failure (mt h h2) xs n
+  | success h2 => success $ combine p h2
+  | gaveUp n => gaveUp n
+
+def iff (h : q ↔ p) (r : TestResult p) : TestResult q :=
+  imp h.mp r (PSum.inr h.mpr)
+
+def addInfo (x : String) (h : q → p) (r : TestResult p)
+    (p : PSum Unit (p → q) := PSum.inl ()) : TestResult q :=
+  if let failure h2 xs n := r then
+    failure (mt h h2) (x :: xs) n
+  else
+    imp h r p
+
+def addVarInfo [Repr γ] (var : String) (x : γ) (h : q → p) (r : TestResult p)
+    (p : PSum Unit (p → q) := PSum.inl ()) : TestResult q  :=
+  addInfo s!"{var} := {repr x}" h r p
+
+def isFailure : TestResult p → Bool
+| failure _ _ _ => true
+| _ => false
+
+end TestResult
+
+namespace Testable
+
+open TestResult
+
+instance andTestable [Testable p] [Testable q] : Testable (p ∧ q) where
+  run := λ cfg min => do
+    let xp ← run p cfg min 
+    let xq ← run q cfg min
+    pure $ and xp xq
+
+instance orTestable [Testable p] [Testable q] : Testable (p ∨ q) where
+  run := λ cfg min => do
+    let xp ← run p cfg min 
+    -- As a little performance optimization we can just not run the second
+    -- test if the first succeeds
+    match xp with
+    | success (PSum.inl h) => pure $ success (PSum.inl h)
+    | success (PSum.inr h) => pure $ success (PSum.inr $ Or.inl h)
+    | _ =>
+      let xq ← run q cfg min
+      pure $ or xp xq
+
+instance iffTestable [Testable ((p ∧ q) ∨ (¬ p ∧ ¬ q))] : Testable (p ↔ q) where
+  run := λ cfg min => do
+    let h ← run ((p ∧ q) ∨ (¬ p ∧ ¬ q)) cfg min
+    pure $ iff iff_iff_and_or_not_and_not h 
+
+instance decTestable [PrintableProp p] [Decidable p] {β : p → Prop} [∀ h, Testable (β h)] : Testable (NamedBinder var $ ∀ h, β h) where
+  run := λ cfg min => do
+    if h : p then
+      let res := (run (β h) cfg min)
+      match printProp p with
+      | none => (λ r => imp (· $ h) r (PSum.inr $ λ q _ => q)) <$> res
+      | some s => (λ r => addInfo s!"guard: {s}" (· $ h) r (PSum.inr $ λ q _ => q)) <$> res
+    else if cfg.traceDiscarded || cfg.traceSuccesses then
+      let res := (λ _ => pure $ gaveUp 1)
+      match printProp p with
+      | none => dbgTrace "discard" res
+      | some s => dbgTrace s!"discard: {s} does not hold" res
+    else
+      pure $ gaveUp 1
+
+instance forallTypesTestable {f : Type → Prop} [Testable (f Int)] : Testable (NamedBinder var $ ∀ x, f x) where
+  run := λ cfg min => do
+    let r ← run (f Int) cfg min
+    pure $ addVarInfo var "ℤ" (· $ Int) r
+
+def traceGiveup [Repr α] (tracing : Bool) (var : String) (val : α) : TestResult p → (Unit → β) → β
+| gaveUp _ => if tracing then dbgTrace s!"{var} = {repr val}" else (· $ ())
+| _ => (· $ ())
+
+def combine (ts : List (Testable p)) (h : 0 < ts.length) : Testable p := ⟨λ cfg min => do
+  let f := (@Testable.run _ · cfg min)
+  have : 0 < List.length (List.map f ts) := by
+    rw [List.length_map]
+    exact h
+  Gen.oneOf (ts.map f) this⟩
+
+
+def formatFailureAux (s : String) (xs : List String) (n : Nat) : String :=
+  let counter := String.intercalate "\n" xs
+  let parts := [
+    "===================",
+    s,
+    "\n",
+    counter,
+    s!"({n} shrinks)",
+    "-------------------"
+  ]
+  String.intercalate "\n" parts
+
+def formatFailure (s : String) : TestResult p → String
+| TestResult.failure _ xs n => formatFailureAux s xs n
+| _ => ""
+
+def addShrinks (n : Nat) : TestResult p → TestResult p
+| TestResult.failure p xs m => TestResult.failure p xs (m + n)
+| p => p
+
+def minimizeAux {β : α → Prop} [SampleableExt α] [∀ x, Testable (β x)] (cfg : Configuration) (var : String)
+    (x : SampleableExt.proxy α) (n : Nat) : OptionT Gen (Σ x, TestResult (β (SampleableExt.interp x))) := do
+  let candidates := Shrinkable.shrink.run x
+  if cfg.traceShrinkCandidates then
+    dbg_trace "candidates for {var} :=\n{repr candidates}\n"
+  for ⟨candidate, h⟩ in candidates do
+    let res ← OptionT.lift $ Testable.run (β (SampleableExt.interp candidate)) cfg true
+    if !res.isFailure then
+      if cfg.traceShrink then
+        dbg_trace s!"{var} := {repr candidate}" ++ formatFailure "Shrink counter-example:" res
+      let currentStep := OptionT.lift $ pure $ Sigma.mk candidate (addShrinks (n + 1) res)
+      let nextStep := minimizeAux cfg var candidate (n + 1) <|> currentStep
+      return ←nextStep
+  failure
+  termination_by minimizeAux cfg var x n => x
+  decreasing_by simp_all
+
+def minimize {β : α → Prop} [SampleableExt α] [∀ x, Testable (β x)] (cfg : Configuration) (var : String)
+    (x : SampleableExt.proxy α) (r : TestResult (β $ SampleableExt.interp x)) : Gen (Σ x, TestResult (β $ SampleableExt.interp x)) := do
+  if cfg.traceShrink then
+    dbg_trace (s!"{var} := {repr x}" ++ formatFailure "Shrink counter-example:" r)
+  let res ← OptionT.run $ minimizeAux cfg var x 0
+  pure $ res.getD ⟨x, r⟩
+end Testable
+
+end SlimCheck

--- a/Mathlib/Testing/SlimCheck/Testable.lean
+++ b/Mathlib/Testing/SlimCheck/Testable.lean
@@ -219,13 +219,13 @@ def slimTrace [Pure m] (s : String) : m PUnit := dbgTrace s!"[SlimCheck: {s}]" (
 
 instance andTestable [Testable p] [Testable q] : Testable (p ∧ q) where
   run := λ cfg min => do
-    let xp ← run p cfg min 
+    let xp ← run p cfg min
     let xq ← run q cfg min
     pure $ and xp xq
 
 instance orTestable [Testable p] [Testable q] : Testable (p ∨ q) where
   run := λ cfg min => do
-    let xp ← run p cfg min 
+    let xp ← run p cfg min
     -- As a little performance optimization we can just not run the second
     -- test if the first succeeds
     match xp with
@@ -238,7 +238,7 @@ instance orTestable [Testable p] [Testable q] : Testable (p ∨ q) where
 instance iffTestable [Testable ((p ∧ q) ∨ (¬ p ∧ ¬ q))] : Testable (p ↔ q) where
   run := λ cfg min => do
     let h ← run ((p ∧ q) ∨ (¬ p ∧ ¬ q)) cfg min
-    pure $ iff iff_iff_and_or_not_and_not h 
+    pure $ iff iff_iff_and_or_not_and_not h
 
 instance decGuardTestable [PrintableProp p] [Decidable p] {β : p → Prop} [∀ h, Testable (β h)] : Testable (NamedBinder var $ ∀ h, β h) where
   run := λ cfg min => do
@@ -329,7 +329,7 @@ instance varTestable [SampleableExt α] {β : α → Prop} [∀ x, Testable (β 
           minimize cfg var x r
         else
           pure $ ⟨x, r⟩
-      else 
+      else
         pure $ ⟨x, r⟩
     pure $ addVarInfo var finalX (· $ SampleableExt.interp finalX) finalR
 
@@ -500,4 +500,3 @@ def Testable.check (p : Prop) (cfg : Configuration := {}) (p' : Decorations.Deco
 -- #eval Testable.check (∀ (x : Nat) (h : 10 < x), 5 < x) Configuration.verbose
 
 end SlimCheck
-

--- a/Mathlib/Testing/SlimCheck/Testable.lean
+++ b/Mathlib/Testing/SlimCheck/Testable.lean
@@ -221,7 +221,8 @@ instance varTestable [SampleableExt α] [∀ x, Testable (β x)] : Testable (Nam
     let r ← Testable.run (β $ SampleableExt.interp x) cfg false
     let ⟨finalX, finalR⟩ ←
       if isFailure r then
-        slimTrace s!"{var} := {repr x} is a failure"
+        if cfg.traceSuccesses then
+          slimTrace s!"{var} := {repr x} is a failure"
         if min then
           minimize cfg var x r
         else
@@ -371,7 +372,10 @@ def Testable.check (p : Prop) (cfg : Configuration := {}) (p' : Decorations.Deco
   | TestResult.gaveUp n => if !cfg.quiet then IO.println s!"Gave up {n} times"
   | TestResult.failure _ xs n => throw (IO.userError $ formatFailureAux "Found problems!" xs n)
 
--- #eval Testable.check (∀ (x y z a : Nat) (h1 : 3 < x) (h2 : 3 < y), x - y = y - x) Configuration.verbose
+-- Works
+-- #eval Testable.check (∀ (x y z a : Nat) (h1 : 3 < x) (h2 : 3 < y), x - y = y - x) { Configuration.verbose with randomSeed := some 10000}
+-- Broken
+-- #eval Testable.check (∀ (x y z a : Nat) (h1 : 3 < x) (h2 : 3 < y), x - y = y - x) { Configuration.verbose with randomSeed := some 1000}
 -- #eval Testable.check (∀ x : Nat, ∀ y : Nat, x + y = y + x) Configuration.verbose
 -- #eval Testable.check (∀ (x : (Nat × Nat)), x.fst - x.snd - 10 = x.snd - x.fst - 10) Configuration.verbose
 -- #eval Testable.check (∀ (x : Nat) (h : 10 < x), 5 < x) Configuration.verbose


### PR DESCRIPTION
An absolute minimal port of Lean 3's slim_check, not featuring stuff like subtypes, existential quantifiers etc. But the basic infrastructure to set all of this up and some basic instances already as well.

The `PhantomFunction` was introduced to avoid noncomputable instances since `SizeOf` is not computable but we need to store it as a field in `SampleableExt` so we work around this by defining a `PhantomFunction` which is guaranteed to be eliminated by the compiler during code generation. I do however believe that this is not the right file for it to live in?