### PR TITLE
[Merged by Bors] - chore: bump to nightly 05-31

### DIFF
--- a/Mathlib/Mathport/Syntax.lean
+++ b/Mathlib/Mathport/Syntax.lean
@@ -194,7 +194,6 @@ syntax caseArg := binderIdent,+ (" :" (ppSpace (ident <|> "_"))+)?
 /- E -/ syntax (name := trans) "trans" (ppSpace colGt term)? : tactic
 /- B -/ syntax (name := acRfl) "ac_rfl" : tactic
 /- B -/ syntax (name := cc) "cc" : tactic
-/- E -/ syntax (name := substVars) "subst_vars" : tactic
 
 -- builtin unfold only accepts single ident
 /- M -/ syntax (name := unfold') (priority := low) "unfold" (config)? (ppSpace colGt ident)* (ppSpace location)? : tactic

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2022-05-19
+leanprover/lean4:nightly-2022-05-31


### PR DESCRIPTION
I deleted substVars from the syntax file as it is now in core lean since https://github.com/leanprover/lean4/commit/40fc64480a15e551025f16218050bc83802c3463 and the syntax is pretty foolproof. Is that the correct thing to do?