### PR TITLE
[Merged by Bors] - chore: fix unused variables from linter

### DIFF
--- a/Mathlib/Algebra/Group/Defs.lean
+++ b/Mathlib/Algebra/Group/Defs.lean
@@ -63,7 +63,7 @@ variable {M : Type u}
 /-- The fundamental scalar multiplication in an additive monoid. `nsmul_rec n a = a+a+...+a` n
 times. Use instead `n • a`, which has better definitional behavior. -/
 def nsmul_rec [Zero M] [Add M] : ℕ → M → M
-| 0  , a => 0
+| 0  , _ => 0
 | n+1, a => a + nsmul_rec n a
 
 -- use `x * npow_rec n x` and not `npow_rec n x * x` in the definition to make sure that
@@ -71,7 +71,7 @@ def nsmul_rec [Zero M] [Add M] : ℕ → M → M
 /-- The fundamental power operation in a monoid. `npow_rec n a = a*a*...*a` n times.
 Use instead `a ^ n`,  which has better definitional behavior. -/
 def npow_rec [One M] [Mul M] : ℕ → M → M
-| 0  , a => 1
+| 0  , _ => 1
 | n+1, a => a * npow_rec n a
 
 attribute [to_additive_reorder 3] npow_rec

--- a/Mathlib/Control/Random.lean
+++ b/Mathlib/Control/Random.lean
@@ -92,17 +92,13 @@ instance : BoundedRandom Nat where
 
 instance : BoundedRandom Int where
   randomR := λ lo hi h _ => do
-    let ⟨z, h1, h2⟩ ← randBound Nat 0 (Int.natAbs $ hi - lo) (Nat.zero_le _)
+    let ⟨z, _, h2⟩ ← randBound Nat 0 (Int.natAbs $ hi - lo) (Nat.zero_le _)
     pure ⟨
       z + lo,
       Int.le_add_of_nonneg_left (Int.ofNat_zero_le z),
       Int.add_le_of_le_sub_right $ Int.le_trans
         (Int.ofNat_le.mpr h2)
-        (by
-          apply le_of_eq
-          apply Int.ofNat_natAbs_eq_of_nonneg
-          exact Int.sub_nonneg_of_le h)
-    ⟩
+        (le_of_eq $ Int.ofNat_natAbs_eq_of_nonneg _ $ Int.sub_nonneg_of_le h)⟩
 
 instance {n : Nat} : BoundedRandom (Fin n) where
   randomR := λ lo hi h _ => do

--- a/Mathlib/Data/Array/Basic.lean
+++ b/Mathlib/Data/Array/Basic.lean
@@ -10,7 +10,7 @@ import Mathlib.Data.List.Basic
 namespace Array
 
 theorem ext' : {a b : Array α} → a.data = b.data → a = b
-| ⟨a⟩, ⟨_⟩, rfl => rfl
+| ⟨_⟩, ⟨_⟩, rfl => rfl
 
 @[simp] theorem data_toArray : (a : Array α) → a.data.toArray = a
 | ⟨l⟩ => ext' l.toArray_data

--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -11,7 +11,7 @@ instance : Subsingleton (Fin 1) where
   allEq := fun ⟨0, _⟩ ⟨0, _⟩ => rfl
 
 /-- If you actually have an element of `Fin n`, then the `n` is always positive -/
-lemma Fin.size_positive : ∀ (x : Fin n), 0 < n
+lemma Fin.size_positive : Fin n → 0 < n
 | ⟨x, h⟩ =>
   match Nat.eq_or_lt_of_le (Nat.zero_le x) with
   | Or.inl h_eq => h_eq ▸ h
@@ -40,23 +40,23 @@ lemma Fin.val_eq_of_lt {n a : Nat} (h : a < n) : (Fin.ofNat' a (zero_lt_of_lt h)
 
 lemma Fin.modn_def : ∀ (a : Fin n) (m : Nat),
   a % m = Fin.mk ((a.val % m) % n) (Nat.mod_lt (a.val % m) (a.size_positive))
-| ⟨a, pa⟩, m => rfl
+| ⟨_, _⟩, _ => rfl
 
 lemma Fin.mod_def : ∀ (a m : Fin n),
   a % m = Fin.mk ((a.val % m.val) % n) (Nat.mod_lt (a.val % m.val) (a.size_positive))
-| ⟨a, pa⟩, ⟨m, pm⟩ => rfl
+| ⟨_, _⟩, ⟨_, _⟩ => rfl
 
 lemma Fin.add_def : ∀ (a b : Fin n),
   a + b = (Fin.mk ((a.val + b.val) % n) (Nat.mod_lt _ (a.size_positive)))
-| ⟨a, pa⟩, ⟨b, pb⟩ => rfl
+| ⟨_, _⟩, ⟨_, _⟩ => rfl
 
 lemma Fin.mul_def : ∀ (a b : Fin n),
   a * b = (Fin.mk ((a.val * b.val) % n) (Nat.mod_lt _ (a.size_positive)))
-| ⟨a, pa⟩, ⟨b, pb⟩ => rfl
+| ⟨_, _⟩, ⟨_, _⟩ => rfl
 
 lemma Fin.sub_def : ∀ (a b : Fin n),
   a - b = (Fin.mk ((a + (n - b)) % n) (Nat.mod_lt _ (a.size_positive)))
-| ⟨a, pa⟩, ⟨b, pb⟩ => rfl
+| ⟨_, _⟩, ⟨_, _⟩ => rfl
 
 @[simp] lemma Fin.mod_eq (a : Fin n) : a % n = a := by
   apply Fin.eq_of_val_eq
@@ -298,7 +298,7 @@ instance : CommRing (Fin n) where
   __ := inferInstanceAs (CommSemiring (Fin n))
 
 lemma Fin.gt_wf : WellFounded (fun a b : Fin n => b < a) :=
-  Subrelation.wf (@fun a i h => ⟨h, i.2⟩) (invImage (fun i => i.1) (Nat.upRel n)).wf
+  Subrelation.wf (fun {_ i} h => ⟨h, i.2⟩) (invImage (fun i => i.1) (Nat.upRel n)).wf
 
 /-- A well-ordered relation for "upwards" induction on `Fin n`. -/
 def Fin.upRel (n : ℕ) : WellFoundedRelation (Fin n) := ⟨_, gt_wf⟩

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -21,10 +21,10 @@ theorem concat_eq_append : ∀ (l : List α) a, concat l a = l ++ [a]
 
 theorem get_cons_drop : ∀ (l : List α) i,
   List.get l i :: List.drop (i + 1) l = List.drop i l
-| _::_, ⟨0, h⟩ => rfl
-| _::_, ⟨i+1, h⟩ => get_cons_drop _ ⟨i, _⟩
+| _::_, ⟨0, _⟩ => rfl
+| _::_, ⟨i+1, _⟩ => get_cons_drop _ ⟨i, _⟩
 
-theorem drop_eq_nil_of_le : ∀ {l : List α} {k : Nat} (h : l.length ≤ k), l.drop k = []
+theorem drop_eq_nil_of_le : ∀ {l : List α} {k : Nat}, l.length ≤ k → l.drop k = []
 | [], k, _ => by cases k <;> rfl
 | a::l, 0, h => by cases h
 | a::l, k+1, h => by have h0 : length (a :: l) = length l + 1 := rfl
@@ -56,11 +56,11 @@ theorem cons_ne_self (a : α) (l : List α) : a::l ≠ l :=
 
 theorem head_eq_of_cons_eq {h₁ h₂ : α} {t₁ t₂ : List α} :
       (h₁::t₁) = (h₂::t₂) → h₁ = h₂ :=
-fun Peq => List.noConfusion Peq fun Pheq Pteq => Pheq
+fun Peq => List.noConfusion Peq fun Pheq _ => Pheq
 
 theorem tail_eq_of_cons_eq {h₁ h₂ : α} {t₁ t₂ : List α} :
       (h₁::t₁) = (h₂::t₂) → t₁ = t₂ :=
-fun Peq => List.noConfusion Peq (fun Pheq Pteq => Pteq)
+fun Peq => List.noConfusion Peq (fun _ Pteq => Pteq)
 
 -- @[simp] theorem cons_injective {a : α} : injective (cons a) :=
 -- assume l₁ l₂, assume Pe, tail_eq_of_cons_eq Pe
@@ -69,9 +69,9 @@ fun Peq => List.noConfusion Peq (fun Pheq Pteq => Pteq)
 -- cons_injective.eq_iff
 
 theorem exists_cons_of_ne_nil {l : List α} (h : l ≠ nil) : ∃ b L, l = b :: L := by
-  induction l with
-    | nil          => contradiction
-    | cons c l' ih => exact ⟨c, l', rfl⟩
+  cases l with
+  | nil       => contradiction
+  | cons c l' => exact ⟨c, l', rfl⟩
 
 /-! ### mem -/
 
@@ -155,7 +155,7 @@ theorem mem_map {f : α → β} {b} : ∀ {l : List α}, b ∈ l.map f ↔ ∃ a
 
 theorem mem_map_of_injective {f : α → β} (H : injective f) {a : α} {l : List α} :
   f a ∈ map f l ↔ a ∈ l :=
-⟨fun m => let ⟨a', m', e⟩ := exists_of_mem_map m
+⟨fun m => let ⟨_, m', e⟩ := exists_of_mem_map m
           H e ▸ m', mem_map_of_mem _⟩
 
 lemma forall_mem_map_iff {f : α → β} {l : List α} {P : β → Prop} :
@@ -234,7 +234,7 @@ theorem exists_mem_of_length_pos : ∀ {l : List α}, 0 < length l → ∃ a, a 
 | b::l, _   => ⟨b, mem_cons_self _ _⟩
 
 theorem length_pos_iff_exists_mem {l : List α} : 0 < length l ↔ ∃ a, a ∈ l :=
-⟨exists_mem_of_length_pos, fun  ⟨a, h⟩ => length_pos_of_mem h⟩
+⟨exists_mem_of_length_pos, fun ⟨_, h⟩ => length_pos_of_mem h⟩
 
 theorem ne_nil_of_length_pos {l : List α} : 0 < length l → l ≠ [] :=
 fun h1 h2 => Nat.lt_irrefl 0 ((length_eq_zero.2 h2).subst h1)
@@ -260,7 +260,7 @@ theorem length_eq_one {l : List α} : length l = 1 ↔ ∃ a, l = [a] := by
 lemma exists_of_length_succ {n} :
   ∀ l : List α, l.length = n + 1 → ∃ h t, l = h :: t
 | [], H => absurd H.symm $ Nat.succ_ne_zero n
-| (h :: t), H => ⟨h, t, rfl⟩
+| h :: t, _ => ⟨h, t, rfl⟩
 
 -- @[simp] lemma length_injective_iff : injective (List.length : List α → ℕ) ↔ subsingleton α :=
 -- begin
@@ -350,19 +350,19 @@ cons_subset.2 ⟨ainm, lsubm⟩
 
 theorem append_subset_of_subset_of_subset {l₁ l₂ l : List α} (l₁subl : l₁ ⊆ l) (l₂subl : l₂ ⊆ l) :
   l₁ ++ l₂ ⊆ l :=
-fun {a} h => (mem_append.1 h).elim (@l₁subl _) (@l₂subl _)
+fun _ h => (mem_append.1 h).elim (@l₁subl _) (@l₂subl _)
 
 @[simp] theorem append_subset_iff {l₁ l₂ l : List α} :
     l₁ ++ l₂ ⊆ l ↔ l₁ ⊆ l ∧ l₂ ⊆ l := by
   constructor
-  { intro h; simp only [subset_def] at *
+  · intro h; simp only [subset_def] at *
     constructor
-    { intros; apply h; apply mem_append_left; assumption }
-    { intros; apply h; apply mem_append_right; assumption } }
-  { intro h; match h with | ⟨h1, h2⟩ => apply append_subset_of_subset_of_subset h1 h2 }
+    · intros; apply h; apply mem_append_left; assumption
+    · intros; apply h; apply mem_append_right; assumption
+  · intro h; match h with | ⟨h1, h2⟩ => apply append_subset_of_subset_of_subset h1 h2
 
 theorem eq_nil_of_subset_nil : ∀ {l : List α}, l ⊆ [] → l = []
-| [],     s => rfl
+| [],     _ => rfl
 | (a::l), s => nomatch s $ mem_cons_self a l
 
 theorem eq_nil_iff_forall_not_mem {l : List α} : l = [] ↔ ∀ a, a ∉ l :=
@@ -467,16 +467,16 @@ lemma cons_eq_append_iff {a b c : List α} {x : α} :
 -- | n+1, x :: xs => by simp only [split_at, split_at_eq_take_drop n xs, take, drop]
 
 @[simp] theorem take_append_drop : ∀ (n : ℕ) (l : List α), take n l ++ drop n l = l
-| 0, a => rfl
-| n+1, [] => rfl
+| 0, _ => rfl
+| _+1, [] => rfl
 | n+1, x :: xs => congr_arg (cons x) $ take_append_drop n xs
 
 -- TODO(Leo): cleanup proof after arith dec proc
 theorem append_inj :
   ∀ {s₁ s₂ t₁ t₂ : List α}, s₁ ++ t₁ = s₂ ++ t₂ → length s₁ = length s₂ → s₁ = s₂ ∧ t₁ = t₂
-| [], [], t₁, t₂, h, hl => ⟨rfl, h⟩
-| a :: s₁, [], t₁, t₂, h, hl => List.noConfusion $ eq_nil_of_length_eq_zero hl
-| [], b :: s₂, t₁, t₂, h, hl => List.noConfusion $ eq_nil_of_length_eq_zero hl.symm
+| [], [], t₁, t₂, h, _ => ⟨rfl, h⟩
+| a :: s₁, [], t₁, t₂, _, hl => List.noConfusion $ eq_nil_of_length_eq_zero hl
+| [], b :: s₂, t₁, t₂, _, hl => List.noConfusion $ eq_nil_of_length_eq_zero hl.symm
 | a :: s₁, b :: s₂, t₁, t₂, h, hl => List.noConfusion h fun ab hap =>
   let ⟨e1, e2⟩ := @append_inj _ s₁ s₂ t₁ t₂ hap (Nat.succ.inj hl)
   by rw [ab, e1, e2] <;> exact ⟨rfl, rfl⟩
@@ -559,18 +559,18 @@ theorem getLast_concat {a : α} (l : List α) : (h : concat l a ≠ []) → getL
 /-! ### nth element -/
 
 theorem get_of_mem : ∀ {a} {l : List α}, a ∈ l → ∃ n, get l n = a
-| a, _ :: l, Mem.head .. => ⟨⟨0, Nat.succ_pos _⟩, rfl⟩
-| a, b :: l, Mem.tail _ m =>
+| _, _ :: _, Mem.head .. => ⟨⟨0, Nat.succ_pos _⟩, rfl⟩
+| _, _ :: _, Mem.tail _ m =>
   let ⟨⟨n, h⟩, e⟩ := get_of_mem m
   ⟨⟨n+1, Nat.succ_lt_succ h⟩, e⟩
 
 theorem get?_eq_get : ∀ {l : List α} {n} h, l.get? n = some (get l ⟨n, h⟩)
-| a :: l, 0, h => rfl
-| a :: l, n+1, h => @get?_eq_get _ l n _
+| _ :: _, 0, _ => rfl
+| _ :: l, n+1, _ => @get?_eq_get _ l n _
 
 theorem get?_len_le : ∀ {l : List α} {n}, length l ≤ n → l.get? n = none
-| [], n, h => rfl
-| a :: l, n+1, h => @get?_len_le _ l n $ Nat.le_of_succ_le_succ h
+| [], _, _ => rfl
+| _ :: l, n+1, h => @get?_len_le _ l n $ Nat.le_of_succ_le_succ h
 
 theorem get?_eq_some {l : List α} {n a} : l.get? n = some a ↔ ∃ h, get l ⟨n, h⟩ = a :=
   ⟨fun e =>
@@ -595,11 +595,11 @@ theorem get?_of_mem {a} {l : List α} (h : a ∈ l) : ∃ n, l.get? n = some a :
       rw [get?_eq_get, e]⟩
 
 theorem get_mem : ∀ (l : List α) n h, get l ⟨n, h⟩ ∈ l
-| a :: l, 0, h => mem_cons_self _ _
-| a :: l, n+1, h => mem_cons_of_mem _ (get_mem l _ _)
+| _ :: _, 0, _ => mem_cons_self _ _
+| _ :: l, _+1, _ => mem_cons_of_mem _ (get_mem l _ _)
 
 theorem get?_mem {l : List α} {n a} (e : l.get? n = some a) : a ∈ l :=
-  let ⟨h, e⟩ := get?_eq_some.1 e
+  let ⟨_, e⟩ := get?_eq_some.1 e
   e ▸ get_mem _ _ _
 
 theorem mem_iff_get {a} {l : List α} : a ∈ l ↔ ∃ n, get l n = a :=
@@ -633,9 +633,9 @@ theorem get?_injective {α : Type u} {xs : List α} {i j : ℕ}
     exact ⟨_, h₂⟩; exact ⟨_ , h₂.symm⟩
 
 @[simp] theorem get?_map (f : α → β) : ∀ l n, (map f l).get? n = (l.get? n).map f
-| [], n => rfl
-| a :: l, 0 => rfl
-| a :: l, n+1 => get?_map f l n
+| [], _ => rfl
+| _ :: _, 0 => rfl
+| _ :: l, n+1 => get?_map f l n
 
 @[simp]
 theorem get_map (f : α → β) {l n} : get (map f l) n = f (get l ⟨n, length_map l f ▸ n.2⟩) :=
@@ -662,9 +662,9 @@ theorem get_append : ∀ {l₁ l₂ : List α} (n : ℕ) (h : n < l₁.length),
 | a :: l, _, n+1, h => by
   simp only [get, cons_append] <;> exact get_append _ _
 
-theorem get?_append_right : ∀ {l₁ l₂ : List α} {n : ℕ} (hn : l₁.length ≤ n),
+theorem get?_append_right : ∀ {l₁ l₂ : List α} {n : ℕ}, l₁.length ≤ n →
   (l₁ ++ l₂).get? n = l₂.get? (n - l₁.length)
-| [], _, n, h₁ => rfl
+| [], _, n, _ => rfl
 | a :: l, _, n+1, h₁ => by
   rw [cons_append]; simp
   rw [Nat.add_sub_add_right, get?_append_right (Nat.lt_succ_iff.mp h₁)]
@@ -702,7 +702,7 @@ theorem get_cons_length (x : α) (xs : List α) (n : ℕ) (h : n = xs.length) :
   rw [getLast_eq_get]; cases h; rfl
 
 @[ext] theorem ext : ∀ {l₁ l₂ : List α}, (∀ n, l₁.get? n = l₂.get? n) → l₁ = l₂
-| [], [], h => rfl
+| [], [], _ => rfl
 | a :: l₁, [], h => nomatch h 0
 | [], a' :: l₂, h => nomatch h 0
 | a :: l₁, a' :: l₂, h => by
@@ -719,8 +719,8 @@ theorem ext_get {l₁ l₂ : List α} (hl : length l₁ = length l₂)
       rw [get?_len_le h₁, get?_len_le]; rwa [← hl]
 
 theorem modifyNthTail_id : ∀ n (l : List α), l.modifyNthTail id n = l
-| 0, l => rfl
-| n+1, [] => rfl
+| 0, _ => rfl
+| _+1, [] => rfl
 | n+1, a :: l => congr_arg (List.cons a) (modifyNthTail_id n l)
 
 theorem removeNth_eq_nth_tail : ∀ n (l : List α), removeNth l n = modifyNthTail tail n l
@@ -745,7 +745,7 @@ theorem get?_modifyNth (f : α → α) :
   ∀ n (l : List α) m, (modifyNth f n l).get? m = (fun a => if n = m then f a else a) <$> l.get? m
 | n, l, 0 => by cases l <;> cases n <;> rfl
 | n, [], m+1 => by cases n <;> rfl
-| 0, a :: l, m+1 => by cases l.get? m <;> rfl
+| 0, _ :: l, m+1 => by cases l.get? m <;> rfl
 | n+1, a :: l, m+1 =>
   (get?_modifyNth f n l m).trans $ by
     cases l.get? m <;> by_cases h : n = m <;>
@@ -753,9 +753,9 @@ theorem get?_modifyNth (f : α → α) :
 
 theorem modifyNthTail_length (f : List α → List α) (H : ∀ l, length (f l) = length l) :
   ∀ n l, length (modifyNthTail f n l) = length l
-| 0, l => H _
-| n+1, [] => rfl
-| n+1, a :: l => congr_arg (·+1) (modifyNthTail_length _ H _ _)
+| 0, _ => H _
+| _+1, [] => rfl
+| _+1, _ :: _ => congr_arg (·+1) (modifyNthTail_length _ H _ _)
 
 @[simp] theorem modify_get?_length (f : α → α) : ∀ n l, length (modifyNth f n l) = length l :=
   modifyNthTail_length _ fun l => by cases l <;> rfl
@@ -782,11 +782,11 @@ theorem get?_set_ne (a : α) {m n} (l : List α) (h : m ≠ n) : (set l m a).get
 @[simp] theorem set_succ (x : α) (xs : List α) (n : ℕ) (a : α) :
   (x :: xs).set n.succ a = x :: xs.set n a := rfl
 
-theorem set_comm (a b : α) : ∀ {n m : ℕ} (l : List α) (h : n ≠ m),
+theorem set_comm (a b : α) : ∀ {n m : ℕ} (l : List α), n ≠ m →
   (l.set n a).set m b = (l.set m b).set n a
 | _, _, [], _ => by simp
-| n+1, 0, x :: t, h => by simp [set]
-| 0, m+1, x :: t, h => by simp [set]
+| n+1, 0, _ :: _, _ => by simp [set]
+| 0, m+1, _ :: _, _ => by simp [set]
 | n+1, m+1, x :: t, h => by
   simp only [set, true_and, eq_self_iff_true]
   conv => lhs; rhs; tactic' =>
@@ -801,9 +801,9 @@ theorem set_comm (a b : α) : ∀ {n m : ℕ} (l : List α) (h : n ≠ m),
     (l.set i a).get ⟨j, hj⟩ = l.get ⟨j, by simp at hj; exact hj⟩ := by
   rw [← Option.some_inj, ← List.get?_eq_get, List.get?_set_ne _ _ h, List.get?_eq_get]
 
-theorem mem_or_eq_of_mem_set : ∀ {l : List α} {n : ℕ} {a b : α} h : a ∈ l.set n b, a ∈ l ∨ a = b
-| c :: l, 0, a, b, h => ((mem_cons ..).1 h).elim Or.inr (Or.inl ∘ mem_cons_of_mem _)
-| c :: l, n+1, a, b, h =>
+theorem mem_or_eq_of_mem_set : ∀ {l : List α} {n : ℕ} {a b : α}, a ∈ l.set n b → a ∈ l ∨ a = b
+| _ :: _, 0, _, _, h => ((mem_cons ..).1 h).elim Or.inr (Or.inl ∘ mem_cons_of_mem _)
+| _ :: _, _+1, _, _, h =>
   ((mem_cons ..).1 h).elim (fun h => h ▸ Or.inl (mem_cons_self ..))
     fun h => (mem_or_eq_of_mem_set h).elim (Or.inl ∘ mem_cons_of_mem _) Or.inr
 
@@ -906,7 +906,7 @@ theorem erasep_append_left {a : α} (pa : p a) :
 
 theorem erasep_append_right :
   ∀ {l₁ : List α} (l₂), (∀ b ∈ l₁, ¬ p b) → erasep p (l₁++l₂) = l₁ ++ l₂.erasep p
-| [],      l₂, h => rfl
+| [],      l₂, _ => rfl
 | (x::xs), l₂, h => by
   simp [(forall_mem_cons.1 h).1, erasep_append_right _ (forall_mem_cons.1 h).2]
 
@@ -917,7 +917,7 @@ theorem erasep_append_right :
 theorem erasep_subset (l : List α) : l.erasep p ⊆ l := fun a => by
   match exists_or_eq_self_of_erasep p l with
   | Or.inl h => rw [h]; apply subset.refl
-  | Or.inr ⟨c, l₁, l₂, h₁, h₂, h₃, h₄⟩ =>
+  | Or.inr ⟨c, l₁, l₂, _, _, h₃, h₄⟩ =>
     rw [h₄, h₃, mem_append, mem_append]
     intro
     | Or.inl h => exact Or.inl h
@@ -1102,13 +1102,13 @@ lemma disjoint_left : disjoint l₁ l₂ ↔ ∀ ⦃a⦄, a ∈ l₁ → a ∉ l
 lemma disjoint_right : disjoint l₁ l₂ ↔ ∀ ⦃a⦄, a ∈ l₂ → a ∉ l₁ := disjoint_comm
 
 lemma disjoint_iff_ne : disjoint l₁ l₂ ↔ ∀ a ∈ l₁, ∀ b ∈ l₂, a ≠ b :=
-  ⟨fun h a al1 b bl2 ab => h al1 (ab ▸ bl2), fun h a al1 al2 => h _ al1 _ al2 rfl⟩
+  ⟨fun h _ al1 _ bl2 ab => h al1 (ab ▸ bl2), fun h _ al1 al2 => h _ al1 _ al2 rfl⟩
 
 lemma disjoint_of_subset_left (ss : l₁ ⊆ l) (d : disjoint l l₂) : disjoint l₁ l₂ :=
-λ x m => d (ss m)
+λ _ m => d (ss m)
 
 lemma disjoint_of_subset_right (ss : l₂ ⊆ l) (d : disjoint l₁ l) : disjoint l₁ l₂ :=
-λ x m m₁ => d m (ss m₁)
+λ _ m m₁ => d m (ss m₁)
 
 lemma disjoint_of_disjoint_cons_left {l₁ l₂} : disjoint (a :: l₁) l₂ → disjoint l₁ l₂ :=
 disjoint_of_subset_left (List.subset_cons _ _)
@@ -1217,7 +1217,7 @@ theorem Pairwise_cons {a : α} {l : List α} :
   ⟨fun | Pairwise.cons h1 h2 => ⟨h1, h2⟩, And.elim Pairwise.cons⟩
 
 instance decidablePairwise [DecidableRel R] (l : List α) : Decidable (Pairwise R l) :=
-  match h: l with
+  match l with
   | [] => isTrue Pairwise.nil
   | hd :: tl =>
     match decidablePairwise tl with
@@ -1228,7 +1228,7 @@ instance decidablePairwise [DecidableRel R] (l : List α) : Decidable (Pairwise 
         hf hAnd.left
       | isTrue ht' =>  isTrue $ Pairwise_cons.mpr (And.intro ht' ht)
     | isFalse hf => isFalse fun
-      | Pairwise.cons h ih => hf ih
+      | Pairwise.cons _ ih => hf ih
 
 end Pairwise
 

--- a/Mathlib/Data/List/Card.lean
+++ b/Mathlib/Data/List/Card.lean
@@ -172,7 +172,7 @@ theorem card_eq_of_equiv {as bs : List α} (h : as.equiv bs) : card as = card bs
 
 theorem card_append_disjoint : ∀ {as bs : List α},
     disjoint as bs → card (as ++ bs) = card as + card bs
-  | [], bs, disj => by simp
+  | [], _, _ => by simp
   | a :: as, bs, disj => by
     have disj' : disjoint as bs := fun _ h1 h2 => disj (mem_cons_of_mem a h1) h2
     cases Decidable.em (a ∈ as) with

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -31,7 +31,7 @@ splitAtD 2 [a, b, c] x = ([a, b], [c])
 splitAtD 4 [a, b, c] x = ([a, b, c, x], [])
 ``` -/
 def splitAtD : ℕ → List α → α → List α × List α
-| 0, xs, a => ([], xs)
+| 0, xs, _ => ([], xs)
 | n+1, [], a => let (l, r) := splitAtD n [] a; (a :: l, r)
 | n+1, x :: xs, a => let (l, r) := splitAtD n xs a; (x :: l, r)
 
@@ -59,7 +59,7 @@ modifyNthTail f 2 [a, b, c] = [a, b] ++ f [c]
 @[simp]
 def modifyNthTail (f : List α → List α) : ℕ → List α → List α
 | 0, l => f l
-| n+1, [] => []
+| _+1, [] => []
 | n+1, a :: l => a :: modifyNthTail f n l
 
 /-- Apply `f` to the head of the list, if it exists. -/
@@ -88,8 +88,8 @@ def insertNth (n : ℕ) (a : α) : List α → List α :=
 
 /-- Take `n` elements from a list `l`. If `l` has less than `n` elements, append `n - length l`
 elements `x`. -/
-def takeD : ∀ n : ℕ, List α → α → List α
-| 0, l, _ => []
+def takeD : ℕ → List α → α → List α
+| 0, _, _ => []
 | n+1, l, x => l.headD x :: takeD n l.tail x
 
 /-- Fold a function `f` over the list from the left, returning the list
@@ -246,7 +246,7 @@ def sublists' (l : List α) : List (List α) :=
   sublists'Aux l id []
 
 def sublistsAux : List α → (List α → List β → List β) → List β
-| [], f => []
+| [], _ => []
 | a :: l, f => f [a] (sublistsAux l fun ys r => f ys (f (a :: ys) r))
 
 /-- `sublists l` is the list of all (non-contiguous) sublists of `l`; cf. `sublists'`
@@ -258,7 +258,7 @@ def sublists (l : List α) : List (List α) :=
   [] :: sublistsAux l cons
 
 def sublistsAux₁ : List α → (List α → List β) → List β
-| [], f => []
+| [], _ => []
 | a :: l, f => f [a] ++ sublistsAux₁ l fun ys => f ys ++ f (a :: ys)
 
 section Forall₂
@@ -340,7 +340,7 @@ protected def sigma {σ : α → Type _} (l₁ : List α) (l₂ : ∀ a, List (�
   `ofFnAux f m h l` returns the first `m` elements of `ofFn f`
   appended to `l` -/
 def ofFnAux {n} (f : Fin n → α) : ∀ m, m ≤ n → List α → List α
-| 0, h, l => l
+| 0, _, l => l
 | m+1, h, l => ofFnAux f m (Nat.le_of_lt h) (f ⟨m, h⟩ :: l)
 
 /-- `ofFn f` with `f : fin n → α` returns the list whose ith element is `f i`
@@ -423,7 +423,7 @@ def eraseDup [DecidableEq α] : List α → List α :=
   It is intended mainly for proving properties of `range` and `iota`. -/
 @[simp]
 def range' : ℕ → ℕ → List ℕ
-| s, 0 => []
+| _, 0 => []
 | s, n+1 => s :: range' (s+1) n
 
 /-- Drop `none`s from a list, and replace each remaining `some a` with `a`. -/
@@ -435,7 +435,7 @@ it returns `x` otherwise -/
 @[simp]
 def ilast' {α} : α → List α → α
 | a, [] => a
-| a, b :: l => ilast' b l
+| _, b :: l => ilast' b l
 
 /-- `last' xs` returns the last element of `xs` if `xs` is non-empty;
 it returns `none` otherwise -/
@@ -443,7 +443,7 @@ it returns `none` otherwise -/
 def last' {α} : List α → Option α
 | [] => none
 | [a] => some a
-| b :: l => last' l
+| _ :: l => last' l
 
 /-- `rotate l n` rotates the elements of `l` to the left by `n`
 ```
@@ -455,7 +455,7 @@ def rotate (l : List α) (n : ℕ) : List α :=
 
 /-- rotate' is the same as `rotate`, but slower. Used for proofs about `rotate`-/
 def rotate' : List α → ℕ → List α
-| [], n => []
+| [], _ => []
 | l, 0 => l
 | a :: l, n+1 => rotate' (l ++ [a]) n
 
@@ -516,7 +516,7 @@ def getRest [DecidableEq α] : List α → List α → Option (List α)
 -/
 def slice {α} : ℕ → ℕ → List α → List α
 | 0, n, xs => xs.drop n
-| n+1, m, [] => []
+| _+1, _, [] => []
 | n+1, m, x :: xs => x :: slice n m xs
 
 /--
@@ -640,7 +640,7 @@ allSome [some 1, none  ] = none
 def allSome : List (Option α) → Option (List α)
 | [] => some []
 | some a :: as => cons a <$> allSome as
-| none :: as => none
+| none :: _ => none
 
 /--
 `fillNones xs ys` replaces the `none`s in `xs` with elements of `ys`. If there
@@ -679,7 +679,7 @@ def takeList {α} : List α → List ℕ → List (List α) × List α
   that is, the first `i` elements of `xs`, and the remaining elements chunked into
   sublists of length `n+1`. -/
 def toChunksAux {α} (n : ℕ) : List α → ℕ → List α × List (List α)
-| [], i => ([], [])
+| [], _ => ([], [])
 | x :: xs, 0 =>
   let (l, L) := toChunksAux n xs n
   ([], (x :: l) :: L)
@@ -731,7 +731,7 @@ def zipWith₅ (f : α → β → γ → δ → ε → ζ) : List α → List β
 
 /-- An auxiliary function for `List.mapWithPrefixSuffix`. -/
 def mapWithPrefixSuffixAux {α β} (f : List α → α → List α → β) : List α → List α → List β
-| prev, [] => []
+| _, [] => []
 | prev, h :: t => f prev h t :: mapWithPrefixSuffixAux f (prev.concat h) t
 
 /--

--- a/Mathlib/Data/Nat/Basic.lean
+++ b/Mathlib/Data/Nat/Basic.lean
@@ -59,7 +59,7 @@ lemma sub_lt_self {a b : ℕ} (h₀ : 0 < a) (h₁ : a ≤ b) : b - a < b := by
 protected lemma add_sub_cancel' {n m : ℕ} (h : m ≤ n) : m + (n - m) = n :=
 by rw [Nat.add_comm, Nat.sub_add_cancel h]
 
-protected lemma sub_lt_sub_left : ∀ {k m n : ℕ} (H : k < m) (h : k < n), m - n < m - k
+protected lemma sub_lt_sub_left : ∀ {k m n : ℕ}, k < m → k < n → m - n < m - k
 | 0, m+1, n+1, _, _ => by rw [Nat.add_sub_add_right]; exact lt_succ_of_le (Nat.sub_le _ _)
 | k+1, m+1, n+1, h1, h2 => by
   rw [Nat.add_sub_add_right, Nat.add_sub_add_right]
@@ -113,7 +113,7 @@ def Up (ub a i : ℕ) := i < a ∧ i < ub
 lemma Up.next {ub i} (h : i < ub) : Up ub (i+1) i := ⟨Nat.lt_succ_self _, h⟩
 
 lemma Up.WF (ub) : WellFounded (Up ub) :=
-  Subrelation.wf (h₂ := (measure (ub - .)).wf) @fun a i ⟨ia, iu⟩ => Nat.sub_lt_sub_left iu ia
+  Subrelation.wf (h₂ := (measure (ub - .)).wf) fun ⟨ia, iu⟩ => Nat.sub_lt_sub_left iu ia
 
 /-- A well-ordered relation for "upwards" induction on the natural numbers up to some bound `ub`. -/
 def upRel (ub : ℕ) : WellFoundedRelation Nat := ⟨Up ub, Up.WF ub⟩

--- a/Mathlib/Data/Option/Basic.lean
+++ b/Mathlib/Data/Option/Basic.lean
@@ -17,14 +17,14 @@ theorem some_ne_none (x : α) : some x ≠ none :=
   fun h => Option.noConfusion h
 
 protected theorem «forall» {p : Option α → Prop} : (∀ x, p x) ↔ p none ∧ ∀ x, p (some x) :=
-  ⟨fun h => ⟨h _, fun x => h _⟩, fun h x => Option.casesOn x h.1 h.2⟩
+  ⟨fun h => ⟨h _, fun _ => h _⟩, fun h x => Option.casesOn x h.1 h.2⟩
 
 protected theorem «exists» {p : Option α → Prop} : (∃ x, p x) ↔ p none ∨ ∃ x, p (some x) :=
   ⟨fun | ⟨none, hx⟩ => Or.inl hx | ⟨some x, hx⟩ => Or.inr ⟨x, hx⟩,
-    fun h => h.elim (fun h => ⟨_, h⟩) fun ⟨x, hx⟩ => ⟨_, hx⟩⟩
+    fun h => h.elim (fun h => ⟨_, h⟩) fun ⟨_, hx⟩ => ⟨_, hx⟩⟩
 
 theorem get_mem : ∀ {o : Option α} (h : isSome o), Option.get h ∈ o
-| some a, _ => rfl
+| some _, _ => rfl
 
 theorem get_of_mem {a : α} : ∀ {o : Option α} (h : isSome o), a ∈ o → Option.get h = a
 | _, _, rfl => rfl
@@ -32,7 +32,7 @@ theorem get_of_mem {a : α} : ∀ {o : Option α} (h : isSome o), a ∈ o → Op
 theorem not_mem_none (a : α) : a ∉ (none : Option α) := fun h => Option.noConfusion h
 
 @[simp] theorem some_get : ∀ {x : Option α} (h : isSome x), some (Option.get h) = x
-| some x, hx => rfl
+| some _, _ => rfl
 
 @[simp] theorem get_some (x : α) (h : isSome (some x)) : Option.get h = x := rfl
 
@@ -51,13 +51,13 @@ theorem some_injective (α : Type _) : Function.injective (@some α) :=
 
 /-- `option.map f` is injective if `f` is injective. -/
 theorem map_injective {f : α → β} (Hf : Function.injective f) : Function.injective (Option.map f)
-| none, none, H => rfl
+| none, none, _ => rfl
 | some a₁, some a₂, H => by rw [Hf (Option.some.inj H)]
 
 @[ext] theorem ext : ∀ {o₁ o₂ : Option α}, (∀ a, a ∈ o₁ ↔ a ∈ o₂) → o₁ = o₂
-| none, none, H => rfl
-| some a, o, H => ((H _).1 rfl).symm
-| o, some b, H => (H _).2 rfl
+| none, none, _ => rfl
+| some _, _, H => ((H _).1 rfl).symm
+| _, some _, H => (H _).2 rfl
 
 theorem eq_none_iff_forall_not_mem {o : Option α} : o = none ↔ ∀ a, a ∉ o :=
   ⟨fun e a h => by rw [e] at h; (cases h), fun h => ext $ by simp; exact h⟩

--- a/Mathlib/Data/Option/Defs.lean
+++ b/Mathlib/Data/Option/Defs.lean
@@ -21,8 +21,8 @@ variable {α : Type _} {β : Type _}
 /-- An elimination principle for `Option`. It is a nondependent version of `Option.rec_on`. -/
 @[simp]
 protected def elim : Option α → β → (α → β) → β
-| some x, y, f => f x
-| none, y, f => y
+| some x, _, f => f x
+| none, y, _ => y
 
 instance : Membership α (Option α) :=
   ⟨fun a b => b = some a⟩

--- a/Mathlib/Data/Prod.lean
+++ b/Mathlib/Data/Prod.lean
@@ -77,7 +77,7 @@ fun _ _ h => (Prod.mk.inj h).left
 
 -- Port note: this lemma comes from lean3/library/init/data/prod.lean.
 @[simp] lemma mk.eta : ∀{p : α × β}, (p.1, p.2) = p
-| (a,b) => rfl
+| (_, _) => rfl
 
 lemma ext_iff {p q : α × β} : p = q ↔ p.1 = q.1 ∧ p.2 = q.2 :=
 by rw [← @mk.eta _ _ p, ← @mk.eta _ _ q, mk.inj_iff]
@@ -92,7 +92,7 @@ lemma map_def {f : α → γ} {g : β → δ} : Prod.map f g = λ p => (f p.1, g
 by ext <;> simp
 
 lemma id_prod : (λ (p : α × α) => (p.1, p.2)) = id :=
-funext $ λ ⟨a, b⟩ => rfl
+funext $ λ ⟨_, _⟩ => rfl
 
 lemma fst_surjective [h : Nonempty β] : Function.surjective (@fst α β) :=
 λ x => h.elim $ λ y => ⟨⟨x, y⟩, rfl⟩
@@ -101,16 +101,16 @@ lemma snd_surjective [h : Nonempty α] : Function.surjective (@snd α β) :=
 λ y => h.elim $ λ x => ⟨⟨x, y⟩, rfl⟩
 
 lemma fst_injective [Subsingleton β] : Function.injective (@fst α β) :=
-λ {x y} h => ext' h (Subsingleton.elim x.snd y.snd)
+λ x y h => ext' h (Subsingleton.elim x.snd y.snd)
 
 lemma snd_injective [Subsingleton α] : Function.injective (@snd α β) :=
-λ {x y} h => ext' (Subsingleton.elim _ _) h
+λ _ _ h => ext' (Subsingleton.elim _ _) h
 
 /-- Swap the factors of a product. `swap (a, b) = (b, a)` -/
 def swap : α × β → β × α := λp => (p.2, p.1)
 
 @[simp] lemma swap_swap : ∀ x : α × β, swap (swap x) = x
-| ⟨a, b⟩ => rfl
+| ⟨_, _⟩ => rfl
 
 @[simp] lemma fst_swap {p : α × β} : (swap p).1 = p.2 := rfl
 
@@ -161,7 +161,7 @@ theorem lex_def (r : α → α → Prop) (s : β → β → Prop)
 instance Lex.decidable [DecidableEq α]
   (r : α → α → Prop) (s : β → β → Prop) [DecidableRel r] [DecidableRel s] :
   DecidableRel (Prod.Lex r s) :=
-λ p q => decidable_of_decidable_of_iff (lex_def r s).symm
+λ _ _ => decidable_of_decidable_of_iff (lex_def r s).symm
 
 end Prod
 

--- a/Mathlib/Data/String/Lemmas.lean
+++ b/Mathlib/Data/String/Lemmas.lean
@@ -4,7 +4,7 @@ import Mathlib.Data.String.Defs
 namespace String
 
 lemma congr_append : ∀ (a b : String), a ++ b = String.mk (a.data ++ b.data)
-| ⟨a⟩, ⟨b⟩ => rfl
+| ⟨_⟩, ⟨_⟩ => rfl
 
 @[simp] lemma length_append : ∀ (as bs : String), (as ++ bs).length = as.length + bs.length
 | ⟨as⟩, ⟨bs⟩ => by

--- a/Mathlib/Data/Subtype.lean
+++ b/Mathlib/Data/Subtype.lean
@@ -44,7 +44,7 @@ lemma ext_iff {a1 a2 : {x // p x}} : a1 = a2 ↔ (a1 : α) = (a2 : α) :=
 lemma heq_iff_coe_eq (h : ∀ x, p x ↔ q x) {a1 : {x // p x}} {a2 : {x // q x}} :
   HEq a1 a2 ↔ (a1 : α) = (a2 : α) :=
 Eq.rec (motive := λ (pp: (α → Prop)) _ => ∀ a2' : {x // pp x}, HEq a1 a2' ↔ (a1 : α) = (a2' : α))
-       (λ a2' => heq_iff_eq.trans ext_iff) (funext $ λ x => propext (h x)) a2
+       (λ _ => heq_iff_eq.trans ext_iff) (funext $ λ x => propext (h x)) a2
 
 lemma heq_iff_coe_heq {α β : Sort _} {p : α → Prop} {q : β → Prop} {a : {x // p x}}
   {b : {y // q y}} (h : α = β) (h' : HEq p q) :
@@ -68,7 +68,7 @@ theorem mk_eq_mk {a h a' h'} : @mk α p a h = @mk α p a' h' ↔ a = a' :=
 ext_iff
 
 theorem coe_eq_iff {a : {a // p a}} {b : α} : ↑a = b ↔ ∃ h, a = ⟨b, h⟩ :=
-⟨λ h => h ▸ ⟨a.2, (coe_eta _ _).symm⟩, λ ⟨hb, ha⟩ => ha.symm ▸ rfl⟩
+⟨λ h => h ▸ ⟨a.2, (coe_eta _ _).symm⟩, λ ⟨_, ha⟩ => ha.symm ▸ rfl⟩
 
 theorem coe_injective : injective ((↑·) : Subtype p → α) :=
 by intros a b hab
@@ -120,7 +120,7 @@ theorem map_comp {p : α → Prop} {q : β → Prop} {r : γ → Prop} {x : Subt
 rfl
 
 theorem map_id {p : α → Prop} {h : ∀a, p a → p (id a)} : map (@id α) h = id :=
-funext $ λ ⟨v, h⟩ => rfl
+funext fun ⟨_, _⟩ => rfl
 
 lemma map_injective {p : α → Prop} {q : β → Prop} {f : α → β} (h : ∀a, p a → q (f a))
   (hf : injective f) : injective (map f h) :=

--- a/Mathlib/Data/UnionFind.lean
+++ b/Mathlib/Data/UnionFind.lean
@@ -15,7 +15,7 @@ namespace UFModel
 
 def empty : UFModel 0 where
   parent i := i.elim0
-  rank i := 0
+  rank _ := 0
   rank_lt i := i.elim0
 
 def push {n} (m : UFModel n) (k) (le : n ≤ k) : UFModel k where
@@ -24,7 +24,7 @@ def push {n} (m : UFModel n) (k) (le : n ≤ k) : UFModel k where
       let ⟨a, h'⟩ := m.parent ⟨i, h⟩
       ⟨a, lt_of_lt_of_le h' le⟩
     else i
-  rank i := if h : i < n then m.rank i else 0
+  rank i := if i < n then m.rank i else 0
   rank_lt i := by
     simp; split <;> rename_i h
     · simp [(m.parent ⟨i, h⟩).2, h]; exact m.rank_lt _
@@ -102,7 +102,7 @@ theorem push {arr : Array α} {n} {m : Fin n → β} (H : Agrees arr f m)
 
 theorem set {arr : Array α} {n} {m : Fin n → β} (H : Agrees arr f m)
   {i : Fin arr.size} {x} {m' : Fin n → β}
-  (hm₁ : ∀ (j : Fin n) (h : j.1 ≠ i), m' j = m j)
+  (hm₁ : ∀ (j : Fin n), j.1 ≠ i → m' j = m j)
   (hm₂ : ∀ (h : i < n), f x = m' ⟨i, h⟩) : Agrees (arr.set i x) f m' := by
   cases H
   refine mk' (by simp) fun j hj₁ hj₂ => ?_
@@ -209,7 +209,7 @@ theorem parent_lt (self : UnionFind α) (i) : (self.arr.get i).parent < self.siz
 
 def push (self : UnionFind α) (x : α) : UnionFind α where
   arr := self.arr.push ⟨self.arr.size, x, 0⟩
-  model := let ⟨m, hm⟩ := self.model'; ⟨_, _, hm.push _ rfl _⟩
+  model := let ⟨_, hm⟩ := self.model'; ⟨_, _, hm.push _ rfl _⟩
 
 def findAux (self : UnionFind α) (x : Fin self.size) :
   (s : Array (UFNode α)) ×' (root : Fin s.size) ×'
@@ -261,7 +261,7 @@ def link (self : UnionFind α) (x y : Fin self.size)
       ⟨self.arr.set y {ny with parent := x}, ?a⟩
     else
       let arr₁ := self.arr.set x {nx with parent := y}
-      let arr₂ := if e : nx.rank = ny.rank then
+      let arr₂ := if nx.rank = ny.rank then
         arr₁.set ⟨y, by simp; exact y.2⟩ {ny with rank := ny.rank + 1}
       else arr₁
       ⟨arr₂, ?b⟩
@@ -282,7 +282,7 @@ def link (self : UnionFind α) (x y : Fin self.size)
       · exact this.set (fun i h => by simp [h.symm]) (fun h => by simp [ne, hm.parent_eq'])
       · exact this
     have : UFModel.Agrees arr₁ (·.rank) (fun i : Fin n => m.rank i) :=
-      hm.2.set (fun i h => by simp) (fun h => by simp [hm.rank_eq])
+      hm.2.set (fun i _ => by simp) (fun _ => by simp [hm.rank_eq])
     let rank (i : Fin n) := if y.1 = i ∧ m.rank x = m.rank y then m.rank y + 1 else m.rank i
     have H2 : UFModel.Agrees arr₂ (·.rank) rank := by
       simp; split <;> (rename_i xy; simp [hm.rank_eq] at xy; simp [xy])

--- a/Mathlib/Init/Algebra/Functions.lean
+++ b/Mathlib/Init/Algebra/Functions.lean
@@ -49,7 +49,7 @@ lemma eq_min {a b c : α} (h₁ : c ≤ a) (h₂ : c ≤ b) (h₃ : ∀{d}, d �
 le_antisymm (le_min h₁ h₂) (h₃ (min_le_left a b) (min_le_right a b))
 
 lemma min_comm (a b : α) : min a b = min b a :=
-eq_min (min_le_right a b) (min_le_left a b) (λ {c} h₁ h₂ => le_min h₂ h₁)
+eq_min (min_le_right a b) (min_le_left a b) (λ {_} h₁ h₂ => le_min h₂ h₁)
 
 lemma min_assoc (a b c : α) : min (min a b) c = min a (min b c) :=
 by apply eq_min
@@ -75,7 +75,7 @@ lemma eq_max {a b c : α} (h₁ : a ≤ c) (h₂ : b ≤ c) (h₃ : ∀{d}, a �
 le_antisymm (h₃ (le_max_left a b) (le_max_right a b)) (max_le h₁ h₂)
 
 lemma max_comm (a b : α) : max a b = max b a :=
-eq_max (le_max_right a b) (le_max_left a b) (λ {c} h₁ h₂ => max_le h₂ h₁)
+eq_max (le_max_right a b) (le_max_left a b) (λ {_} h₁ h₂ => max_le h₂ h₁)
 
 lemma max_assoc (a b c : α) : max (max a b) c = max a (max b c) := by
   apply eq_max

--- a/Mathlib/Init/Algebra/Order.lean
+++ b/Mathlib/Init/Algebra/Order.lean
@@ -55,10 +55,10 @@ theorem lt_iff_le_not_le : ∀ {a b : α}, a < b ↔ (a ≤ b ∧ ¬ b ≤ a) :=
 Preorder.lt_iff_le_not_le _ _
 
 theorem lt_of_le_not_le : ∀ {a b : α}, a ≤ b → ¬ b ≤ a → a < b
-| a, b, hab, hba => lt_iff_le_not_le.mpr ⟨hab, hba⟩
+| _a, _b, hab, hba => lt_iff_le_not_le.mpr ⟨hab, hba⟩
 
 theorem le_not_le_of_lt : ∀ {a b : α}, a < b → a ≤ b ∧ ¬ b ≤ a
-| a, b, hab => lt_iff_le_not_le.mp hab
+| _a, _b, hab => lt_iff_le_not_le.mp hab
 
 theorem le_of_eq {a b : α} : a = b → a ≤ b :=
 λ h => h ▸ le_refl a
@@ -67,16 +67,16 @@ theorem ge_trans : ∀ {a b c : α}, a ≥ b → b ≥ c → a ≥ c :=
 λ h₁ h₂ => le_trans h₂ h₁
 
 theorem lt_irrefl : ∀ a : α, ¬ a < a
-| a, haa => match le_not_le_of_lt haa with
+| _a, haa => match le_not_le_of_lt haa with
   | ⟨h1, h2⟩ => h2 h1
 
 theorem gt_irrefl : ∀ a : α, ¬ a > a :=
 lt_irrefl
 
 theorem lt_trans : ∀ {a b c : α}, a < b → b < c → a < c
-| a, b, c, hab, hbc =>
+| _a, _b, _c, hab, hbc =>
   match le_not_le_of_lt hab, le_not_le_of_lt hbc with
-  | ⟨hab, hba⟩, ⟨hbc, hcb⟩ => lt_of_le_not_le (le_trans hab hbc) (λ hca => hcb (le_trans hca hab))
+  | ⟨hab, _⟩, ⟨hbc, hcb⟩ => lt_of_le_not_le (le_trans hab hbc) (λ hca => hcb (le_trans hca hab))
 
 theorem gt_trans : ∀ {a b c : α}, a > b → b > c → a > c :=
 λ h₁ h₂ => lt_trans h₂ h₁
@@ -91,15 +91,15 @@ theorem lt_asymm {a b : α} (h : a < b) : ¬ b < a :=
 λ h1 : b < a => lt_irrefl a (lt_trans h h1)
 
 theorem le_of_lt : ∀ {a b : α}, a < b → a ≤ b
-| a, b, hab => (le_not_le_of_lt hab).left
+| _a, _b, hab => (le_not_le_of_lt hab).left
 
 theorem lt_of_lt_of_le : ∀ {a b c : α}, a < b → b ≤ c → a < c
-| a, b, c, hab, hbc =>
+| _a, _b, _c, hab, hbc =>
   let ⟨hab, hba⟩ := le_not_le_of_lt hab
   lt_of_le_not_le (le_trans hab hbc) $ λ hca => hba (le_trans hbc hca)
 
 theorem lt_of_le_of_lt : ∀ {a b c : α}, a ≤ b → b < c → a < c
-| a, b, c, hab, hbc =>
+| _a, _b, _c, hab, hbc =>
   let ⟨hbc, hcb⟩ := le_not_le_of_lt hbc
   lt_of_le_not_le (le_trans hab hbc) $ λ hca => hcb (le_trans hca hab)
 
@@ -123,8 +123,8 @@ theorem not_lt_of_ge {a b : α} (h : a ≥ b) : ¬ a < b :=
 λ hab => not_le_of_gt hab h
 
 theorem le_of_lt_or_eq : ∀ {a b : α}, (a < b ∨ a = b) → a ≤ b
-| a, b, (Or.inl hab) => le_of_lt hab
-| a, b, (Or.inr hab) => hab ▸ le_refl _
+| _a, _b, Or.inl hab => le_of_lt hab
+| _a, _b, Or.inr hab => hab ▸ le_refl _
 
 theorem le_of_eq_or_lt {a b : α} (h : a = b ∨ a < b) : a ≤ b := match h with
 | (Or.inl h) => le_of_eq h

--- a/Mathlib/Init/Data/Int/Basic.lean
+++ b/Mathlib/Init/Data/Int/Basic.lean
@@ -89,8 +89,8 @@ lemma negSucc_ofNat_eq (n : ℕ) : -[1+ n] = -((↑n) + 1) := rfl
 
 protected lemma neg_neg : ∀ a : ℤ, -(-a) = a
 | ofNat 0     => rfl
-| ofNat (n+1) => rfl
-| -[1+ n]     => rfl
+| ofNat (_+1) => rfl
+| -[1+ _]     => rfl
 
 protected lemma neg_inj {a b : ℤ} (h : -a = -b) : a = b :=
 by rw [← Int.neg_neg a, ← Int.neg_neg b, h]
@@ -188,9 +188,9 @@ lemma eq_x_or_neg (a : ℤ) : ∃n : ℕ, a = n ∨ a = -↑n := ⟨_, natAbs_eq
 /- ## sign -/
 
 def sign : ℤ → ℤ
-| (n+1:ℕ) => 1
+| (_+1:ℕ) => 1
 | 0       => 0
-| -[1+ n] => -1
+| -[1+ _] => -1
 
 @[simp] theorem sign_zero : sign 0 = 0 := rfl
 @[simp] theorem sign_one : sign 1 = 1 := rfl
@@ -209,7 +209,7 @@ def fdiv : ℤ → ℤ → ℤ
 | 0,       _       => 0
 | (m : ℕ), (n : ℕ) => ofNat (m / n)
 | (m+1:ℕ), -[1+ n] => -[1+ m / succ n]
-| -[1+ m], 0       => 0
+| -[1+ _], 0       => 0
 | -[1+ m], (n+1:ℕ) => -[1+ m / succ n]
 | -[1+ m], -[1+ n] => ofNat (succ m / succ n)
 
@@ -247,8 +247,8 @@ protected lemma add_comm : ∀ a b : ℤ, a + b = b + a
 | -[1+ _], -[1+ _] => by simp [Nat.add_comm]
 
 protected lemma add_zero : ∀ a : ℤ, a + 0 = a
-| (ofNat n) => rfl
-| -[1+ n]   => rfl
+| ofNat _ => rfl
+| -[1+ _] => rfl
 
 protected lemma zero_add (a : ℤ) : 0 + a = a := Int.add_comm a 0 ▸ Int.add_zero a
 
@@ -341,8 +341,8 @@ protected lemma mul_comm : ∀ a b : ℤ, a * b = b * a
 | a, b => by cases a <;> cases b <;> simp [Nat.mul_comm]
 
 lemma ofNat_mul_negOfNat (m : ℕ) : ∀ n, ofNat m * negOfNat n = negOfNat (m * n)
-| 0        => rfl
-| (succ n) => rfl
+| 0      => rfl
+| succ _ => rfl
 
 lemma negOfNat_mul_ofNat (m n : ℕ) : negOfNat m * ofNat n = negOfNat (m * n) := by
     rw [Int.mul_comm]
@@ -350,8 +350,8 @@ lemma negOfNat_mul_ofNat (m n : ℕ) : negOfNat m * ofNat n = negOfNat (m * n) :
 
 lemma negSucc_ofNat_mul_negOfNat (m : ℕ) :
   ∀ n, -[1+ m] * negOfNat n = ofNat (succ m * n)
-| 0        => rfl
-| (succ n) => rfl
+| 0      => rfl
+| succ _ => rfl
 
 lemma negOfNat_mul_negSucc_ofNat (m n : ℕ) :
   negOfNat n * -[1+ m] = ofNat (n * succ m) := by
@@ -364,15 +364,15 @@ protected lemma mul_assoc : ∀ a b c : ℤ, a * b * c = a * (b * c)
 | a, b, c => by cases a <;> cases b <;> cases c <;> simp [Nat.mul_assoc]
 
 protected lemma mul_zero : ∀ (a : ℤ), a * 0 = 0
-| (ofNat m) => rfl
-| -[1+ m]   => rfl
+| ofNat _ => rfl
+| -[1+ _] => rfl
 
 protected lemma zero_mul (a : ℤ) : 0 * a = 0 :=
 Int.mul_comm a 0 ▸ Int.mul_zero a
 
 lemma negOfNat_eq_subNatNat_zero : ∀ n, negOfNat n = subNatNat 0 n
-| 0        => rfl
-| (succ n) => rfl
+| 0      => rfl
+| succ _ => rfl
 
 lemma ofNat_mul_subNatNat (m n k : ℕ) :
   ofNat m * subNatNat n k = subNatNat (m * n) (m * k) :=
@@ -442,8 +442,7 @@ protected lemma zero_ne_one : (0 : ℤ) ≠ 1 := λ h => Int.noConfusion h fun.
 lemma ofNat_sub {n m : ℕ} (h : m ≤ n) : ofNat (n - m) = ofNat n - ofNat m := by
   show ofNat (n - m) = ofNat n + negOfNat m
   match m, h with
-  | 0, h =>
-    rfl
+  | 0, _ => rfl
   | succ m, h =>
     show ofNat (n - succ m) = subNatNat n (succ m)
     simp [subNatNat, subNatNat] -- TODO: How to avoid having to simp through rename definitions to unfold them?
@@ -492,8 +491,8 @@ protected lemma neg_eq_neg_one_mul : ∀ a : ℤ, -a = -1 * a
 | -[1+ n]       => show _ = ofNat _ by rw [Nat.one_mul] rfl
 
 theorem sign_mul_natAbs : ∀ (a : ℤ), sign a * natAbs a = a
-| (n+1:ℕ) => Int.one_mul _
+| (_+1:ℕ) => Int.one_mul _
 | 0       => rfl
-| -[1+ n] => (Int.neg_eq_neg_one_mul _).symm
+| -[1+ _] => (Int.neg_eq_neg_one_mul _).symm
 
 end Int

--- a/Mathlib/Init/Data/Int/Order.lean
+++ b/Mathlib/Init/Data/Int/Order.lean
@@ -15,8 +15,9 @@ theorem nonneg_def {a : ℤ} : NonNeg a ↔ ∃ n : ℕ, a = n :=
 
 lemma NonNeg.elim {a : ℤ} : NonNeg a → ∃ n : ℕ, a = n := nonneg_def.1
 
-lemma nonneg_or_nonneg_neg (a : ℤ) : NonNeg a ∨ NonNeg (-a) :=
-match a with | ofNat n => Or.inl ⟨_⟩ | negSucc n => Or.inr ⟨_⟩
+lemma nonneg_or_nonneg_neg : ∀ (a : ℤ), NonNeg a ∨ NonNeg (-a)
+| ofNat _ => Or.inl ⟨_⟩
+| negSucc _ => Or.inr ⟨_⟩
 
 theorem le_def (a b : ℤ) : a ≤ b ↔ NonNeg (b - a) := Iff.refl _
 
@@ -99,7 +100,7 @@ protected theorem ne_of_lt {a b : ℤ} (h : a < b) : a ≠ b := fun e => by
   cases e; exact Int.lt_irrefl _ h
 
 theorem le_of_lt {a b : ℤ} (h : a < b) : a ≤ b :=
-  let ⟨n, hn⟩ := lt.dest h; le.intro _ hn
+  let ⟨_, hn⟩ := lt.dest h; le.intro _ hn
 
 protected theorem lt_iff_le_and_ne {a b : ℤ} : a < b ↔ a ≤ b ∧ a ≠ b := by
   refine ⟨fun h => ⟨le_of_lt h, Int.ne_of_lt h⟩, fun ⟨aleb, aneb⟩ => ?_⟩
@@ -157,13 +158,11 @@ theorem le_natAbs {a : ℤ} : a ≤ natAbs a :=
     fun h => le_trans h (ofNat_zero_le _)
 
 theorem neg_succ_lt_zero (n : ℕ) : -[1+ n] < 0 :=
-  lt_of_not_ge $ fun h => by
-    let ⟨m, h⟩ := eq_ofNat_of_zero_le h
-    contradiction
+  lt_of_not_ge fun h => by rcases eq_ofNat_of_zero_le h with ⟨_, ⟨⟩⟩
 
 theorem eq_neg_succ_of_lt_zero : ∀ {a : ℤ}, a < 0 → ∃ n : ℕ, a = -[1+ n]
   | (n : ℕ), h => absurd h (not_lt_of_ge (ofNat_zero_le _))
-  | -[1+ n], h => ⟨n, rfl⟩
+  | -[1+ n], _ => ⟨n, rfl⟩
 
 protected theorem eq_neg_of_eq_neg {a b : ℤ} (h : a = -b) : b = -a := by
   rw [h, Int.neg_neg]
@@ -719,7 +718,7 @@ theorem exists_eq_neg_ofNat {a : ℤ} (H : a ≤ 0) : ∃ n : ℕ, a = -(n : ℤ
 
 theorem natAbs_of_nonneg {a : ℤ} (H : 0 ≤ a) : (natAbs a : ℤ) = a :=
   match a, eq_ofNat_of_zero_le H with
-  | _, ⟨n, rfl⟩ => rfl
+  | _, ⟨_, rfl⟩ => rfl
 
 theorem ofNat_natAbs_of_nonpos {a : ℤ} (H : a ≤ 0) : (natAbs a : ℤ) = -a := by
   rw [← natAbs_neg, natAbs_of_nonneg (Int.neg_nonneg_of_nonpos H)]
@@ -746,22 +745,22 @@ theorem sign_of_succ (n : Nat) : sign (Nat.succ n) = 1 := rfl
 
 theorem sign_eq_one_of_pos {a : ℤ} (h : 0 < a) : sign a = 1 :=
   match a, eq_succ_of_zero_lt h with
-  | _, ⟨n, rfl⟩ => rfl
+  | _, ⟨_, rfl⟩ => rfl
 
 theorem sign_eq_neg_one_of_neg {a : ℤ} (h : a < 0) : sign a = -1 :=
   match a, eq_neg_succ_of_lt_zero h with
-  | _, ⟨n, rfl⟩ => rfl
+  | _, ⟨_, rfl⟩ => rfl
 
 theorem eq_zero_of_sign_eq_zero : ∀ {a : ℤ}, sign a = 0 → a = 0
   | 0, _ => rfl
 
 theorem pos_of_sign_eq_one : ∀ {a : ℤ}, sign a = 1 → 0 < a
-  | (n + 1 : ℕ), _ => ofNat_lt.2 (Nat.succ_pos _)
+  | (_ + 1 : ℕ), _ => ofNat_lt.2 (Nat.succ_pos _)
 
 theorem neg_of_sign_eq_neg_one : ∀ {a : ℤ}, sign a = -1 → a < 0
-  | (n + 1 : ℕ), h => nomatch h
+  | (_ + 1 : ℕ), h => nomatch h
   | 0, h => nomatch h
-  | -[1+ n], _ => neg_succ_lt_zero _
+  | -[1+ _], _ => neg_succ_lt_zero _
 
 theorem sign_eq_one_iff_pos (a : ℤ) : sign a = 1 ↔ 0 < a :=
   ⟨pos_of_sign_eq_one, sign_eq_one_of_pos⟩
@@ -817,7 +816,7 @@ theorem eq_one_of_mul_eq_self_right {a b : ℤ} (Hpos : b ≠ 0) (H : b * a = b)
   Int.eq_of_mul_eq_mul_left Hpos $ by rw [Int.mul_one, H]
 
 lemma ofNat_natAbs_eq_of_nonneg : ∀ a : ℤ, 0 ≤ a → Int.ofNat (Int.natAbs a) = a
-| (ofNat n), h => rfl
-| -[1+ n],   h => absurd (neg_succ_lt_zero n) (not_lt_of_ge h)
+| ofNat _, _ => rfl
+| -[1+ n], h => absurd (neg_succ_lt_zero n) (not_lt_of_ge h)
 
 end Int

--- a/Mathlib/Init/Data/List/Basic.lean
+++ b/Mathlib/Init/Data/List/Basic.lean
@@ -57,11 +57,11 @@ open Option Nat
 /-- Get the tail of a nonempty list, or return `[]` for `[]`. -/
 def tail : List α → List α
 | []    => []
-| a::as => as
+| _::as => as
 
 
 def mapIdxAux (f : Nat → α → β) : Nat → List α → List β
-| k, [] => []
+| _, [] => []
 | k, a :: as => f k a :: mapIdxAux f (k+1) as
 
 /-- Given a function `f : Nat → α → β` and `as : list α`, `as = [a₀, a₁, ...]`, returns the list
@@ -96,7 +96,7 @@ def indexOf [BEq α] (a : α) : List α → Nat := findIdx (a == ·)
 
 @[simp] def removeNth : List α → Nat → List α
 | [], _ => []
-| x :: xs, 0 => xs
+| _ :: xs, 0 => xs
 | x :: xs, i+1 => x :: removeNth xs i
 
 def bor (l : List Bool) : Bool := any l id
@@ -125,5 +125,5 @@ instance [DecidableEq α] : Inter (List α) := ⟨List.inter⟩
 def last! [Inhabited α] : List α → α
 | [] => panic! "empty list"
 | [a] => a
-| [a, b] => b
-| a :: b :: l => last! l
+| [_, b] => b
+| _ :: _ :: l => last! l

--- a/Mathlib/Init/Data/List/Lemmas.lean
+++ b/Mathlib/Init/Data/List/Lemmas.lean
@@ -16,7 +16,7 @@ open Nat
 @[simp] theorem length_tail (l : List α) : length (tail l) = length l - 1 := by cases l <;> rfl
 
 @[simp] theorem length_drop : ∀ (i : Nat) (l : List α), length (drop i l) = length l - i
-| 0, l => rfl
+| 0, _ => rfl
 | succ i, [] => Eq.symm (Nat.zero_sub (succ i))
 | succ i, x :: l => calc
   length (drop (succ i) (x :: l)) = length l - i := length_drop i l
@@ -94,32 +94,32 @@ instance : Subset (List α) := ⟨List.subset⟩
   fun b i => False.elim (Iff.mp (mem_nil_iff b) i)
 
 -- @[refl]
-@[simp] theorem subset.refl (l : List α) : l ⊆ l := fun b i => i
+@[simp] theorem subset.refl (l : List α) : l ⊆ l := fun _ i => i
 
 -- @[trans]
 theorem subset.trans {l₁ l₂ l₃ : List α} (h₁ : l₁ ⊆ l₂) (h₂ : l₂ ⊆ l₃) : l₁ ⊆ l₃ :=
-  fun b i => h₂ (h₁ i)
+  fun _ i => h₂ (h₁ i)
 
-@[simp] theorem subset_cons (a : α) (l : List α) : l ⊆ a :: l := fun b i => Mem.tail _ i
+@[simp] theorem subset_cons (a : α) (l : List α) : l ⊆ a :: l := fun _ => Mem.tail _
 
 theorem subset_of_cons_subset {a : α} {l₁ l₂ : List α} : a :: l₁ ⊆ l₂ → l₁ ⊆ l₂ :=
-  fun s b i => s (mem_cons_of_mem _ i)
+  fun s _ i => s (mem_cons_of_mem _ i)
 
 theorem cons_subset_cons {l₁ l₂ : List α} (a : α) (s : l₁ ⊆ l₂) : a :: l₁ ⊆ a :: l₂ :=
-  fun b hin => mem_cons.2 $ match eq_or_mem_of_mem_cons hin with
+  fun _ hin => mem_cons.2 $ match eq_or_mem_of_mem_cons hin with
   | Or.inl e => Or.inl e
   | Or.inr i => Or.inr (s i)
 
 @[simp]
 theorem subset_append_left (l₁ l₂ : List α) : l₁ ⊆ l₁ ++ l₂ :=
-  fun b => mem_append_left _
+  fun _ => mem_append_left _
 
 @[simp]
 theorem subset_append_right (l₁ l₂ : List α) : l₂ ⊆ l₁ ++ l₂ :=
-  fun b => mem_append_right _
+  fun _ => mem_append_right _
 
 theorem subset_cons_of_subset (a : α) {l₁ l₂ : List α} : l₁ ⊆ l₂ → l₁ ⊆ a :: l₂ :=
-  fun s a i => Mem.tail _ (s i)
+  fun s _ i => Mem.tail _ (s i)
 
 theorem eq_nil_of_length_eq_zero {l : List α} : length l = 0 → l = [] :=   by
   induction l <;> intros; {rfl}; contradiction
@@ -135,14 +135,14 @@ theorem ne_nil_of_length_eq_succ {l : List α} : ∀ {n : Nat}, length l = succ 
 @[simp] theorem length_take : ∀ (i : Nat) (l : List α), length (take i l) = min i (length l)
 | 0, l => by simp [Nat.zero_min]
 | succ n, [] => by simp [Nat.min_zero]
-| succ n, a :: l => by simp [Nat.min_succ_succ, add_one, length_take]
+| succ n, _ :: l => by simp [Nat.min_succ_succ, add_one, length_take]
 
 theorem length_take_le (n) (l : List α) : length (take n l) ≤ n := by simp [min_le_left]
 
 theorem length_removeNth : ∀ (l : List α) (i : ℕ),
   i < length l → length (removeNth l i) = length l - 1
-| [], _, h => rfl
-| x::xs, 0, h => by simp [removeNth]; rfl
+| [], _, _ => rfl
+| x::xs, 0, _ => by simp [removeNth]; rfl
 | x::xs, i+1, h => by
   have : i < length xs := Nat.lt_of_succ_lt_succ h
   simp [removeNth, ← Nat.add_one]
@@ -163,5 +163,5 @@ infixl:50 " <+ " => sublist
 
 theorem length_le_of_sublist : ∀ {l₁ l₂ : List α}, l₁ <+ l₂ → length l₁ ≤ length l₂
 | _, _, sublist.slnil => le_refl 0
-| _, _, sublist.cons l₁ l₂ a s => le_succ_of_le (length_le_of_sublist s)
-| _, _, sublist.cons2 l₁ l₂ a s => succ_le_succ (length_le_of_sublist s)
+| _, _, sublist.cons l₁ _ _ s => le_succ_of_le (length_le_of_sublist s)
+| _, _, sublist.cons2 _ _ _ s => succ_le_succ (length_le_of_sublist s)

--- a/Mathlib/Init/Data/Option/Basic.lean
+++ b/Mathlib/Init/Data/Option/Basic.lean
@@ -7,4 +7,4 @@ Authors: Leonardo de Moura
 namespace Option
 
 def get {α : Type u} : ∀ {o : Option α}, isSome o → α
-| some x, h => x
+| some x, _ => x

--- a/Mathlib/Init/Function.lean
+++ b/Mathlib/Init/Function.lean
@@ -85,7 +85,7 @@ theorem LeftInverse.injective {g : β → α} {f : α → β} : LeftInverse g f 
 λ h a b hf => h a ▸ h b ▸ hf ▸ rfl
 
 theorem has_LeftInverse.injective {f : α → β} : has_LeftInverse f → injective f :=
-λ h => Exists.elim h (λ finv inv => inv.injective)
+λ h => Exists.elim h (λ _ inv => inv.injective)
 
 theorem RightInverse_of_injective_of_LeftInverse {f : α → β} {g : β → α}
     (injf : injective f) (lfg : LeftInverse f g) :
@@ -96,7 +96,7 @@ theorem RightInverse.surjective {f : α → β} {g : β → α} (h : RightInvers
 λ y => ⟨g y, h y⟩
 
 theorem has_RightInverse.surjective {f : α → β} : has_RightInverse f → surjective f
-| ⟨finv, inv⟩ => inv.surjective
+| ⟨_, inv⟩ => inv.surjective
 
 theorem LeftInverse_of_surjective_of_RightInverse {f : α → β} {g : β → α} (surjf : surjective f)
   (rfg : RightInverse f g) : LeftInverse f g :=
@@ -128,7 +128,7 @@ variable {α : Type u₁} {β : Type u₂} {φ : Type u₃}
 rfl
 
 @[simp] theorem uncurry_curry (f : α × β → φ) : uncurry (curry f) = f :=
-funext (λ ⟨a, b⟩ => rfl)
+funext (λ ⟨_, _⟩ => rfl)
 
 protected theorem LeftInverse.id {g : β → α} {f : α → β} (h : LeftInverse g f) : g ∘ f = id :=
 funext h

--- a/Mathlib/Init/Logic.lean
+++ b/Mathlib/Init/Logic.lean
@@ -242,8 +242,8 @@ Iff.intro (Or.rec id hb) Or.inl
 
 -- Port note: in mathlib3, this is not_or
 lemma not_or_intro {a b : Prop} : ¬ a → ¬ b → ¬ (a ∨ b)
-| hna, hnb, (Or.inl ha) => absurd ha hna
-| hna, hnb, (Or.inr hb) => absurd hb hnb
+| hna, _, Or.inl ha => absurd ha hna
+| _, hnb, Or.inr hb => absurd hb hnb
 
 lemma not_or (p q) : ¬ (p ∨ q) ↔ ¬ p ∧ ¬ q :=
 ⟨fun H => ⟨mt Or.inl H, mt Or.inr H⟩, fun ⟨hp, hq⟩ pq => pq.elim hp hq⟩
@@ -266,13 +266,13 @@ lemma iff_congr (h₁ : a ↔ c) (h₂ : b ↔ d) : (a ↔ b) ↔ (c ↔ d) :=
 /- implies simp rule -/
 -- This is not marked `@[simp]` because we have `implies_true : (α → True) = True` in core.
 lemma implies_true_iff (α : Sort u) : (α → True) ↔ True :=
-Iff.intro (λ h => trivial) (λ ha h => trivial)
+Iff.intro (λ _ => trivial) (λ _ _ => trivial)
 
 lemma false_implies_iff (a : Prop) : (False → a) ↔ True :=
-Iff.intro (λ h => trivial) (λ ha h => False.elim h)
+Iff.intro (λ _ => trivial) (λ _ => False.elim)
 
 theorem true_implies_iff (α : Prop) : (True → α) ↔ α :=
-Iff.intro (λ h => h trivial) (λ h h' => h)
+Iff.intro (λ h => h trivial) (λ h _ => h)
 
 /- exists unique -/
 
@@ -297,7 +297,7 @@ Exists.elim h (λ x hx => ⟨x, And.left hx⟩)
 
 lemma unique_of_exists_unique {α : Sort u} {p : α → Prop}
     (h : ∃! x, p x) {y₁ y₂ : α} (py₁ : p y₁) (py₂ : p y₂) : y₁ = y₂ :=
-let ⟨x, hx, hy⟩ := h; (hy _ py₁).trans (hy _ py₂).symm
+let ⟨_, _, hy⟩ := h; (hy _ py₁).trans (hy _ py₂).symm
 
 /- exists, forall, exists unique congruences -/
 
@@ -317,7 +317,7 @@ lemma exists_congr {p q : α → Prop} (h : ∀ a, p a ↔ q a) : (∃ a, p a) �
 ⟨exists_imp_exists fun x => (h x).1, exists_imp_exists fun x => (h x).2⟩
 
 lemma exists_unique_congr {p q : α → Prop} (h : ∀ a, p a ↔ q a) : (∃! a, p a) ↔ ∃! a, q a :=
-exists_congr fun x => and_congr (h _) $ forall_congr' fun y => imp_congr_left (h _)
+exists_congr fun _ => and_congr (h _) $ forall_congr' fun _ => imp_congr_left (h _)
 
 lemma forall_not_of_not_exists {p : α → Prop} (hne : ¬∃ x, p x) (x) : ¬p x | hp => hne ⟨x, hp⟩
 
@@ -328,7 +328,7 @@ namespace Decidable
 
   -- TODO: rec_on_true and rec_on_false
 
-  def by_cases {q : Sort u} [φ : Decidable p] : (p → q) → (¬p → q) → q := byCases
+  def by_cases {q : Sort u} [Decidable p] : (p → q) → (¬p → q) → q := byCases
 
   lemma by_contradiction [φ : Decidable p] (h : ¬ p → False) : p := @byContradiction p φ h
 
@@ -367,12 +367,12 @@ section
     else isFalse (Or.rec (λ ⟨h, _⟩ => hp h : ¬(p ∧ ¬ q)) (λ ⟨h, _⟩ => hq h : ¬(q ∧ ¬ p)))
 
   instance exists_prop_decidable {p} (P : p → Prop)
-    [Dp : Decidable p] [DP : ∀ h, Decidable (P h)] : Decidable (∃ h, P h) :=
+    [Decidable p] [∀ h, Decidable (P h)] : Decidable (∃ h, P h) :=
   if h : p then decidable_of_decidable_of_iff
-    ⟨λ h2 => ⟨h, h2⟩, λ⟨h', h2⟩ => h2⟩ else isFalse (mt (λ⟨h, _⟩ => h) h)
+    ⟨λ h2 => ⟨h, h2⟩, λ ⟨_, h2⟩ => h2⟩ else isFalse (mt (λ ⟨h, _⟩ => h) h)
 
   instance forall_prop_decidable {p} (P : p → Prop)
-    [Dp : Decidable p] [DP : ∀ h, Decidable (P h)] : Decidable (∀ h, P h) :=
+    [Decidable p] [∀ h, Decidable (P h)] : Decidable (∀ h, P h) :=
   if h : p
   then decidable_of_decidable_of_iff ⟨λ h2 _ => h2, λ al => al h⟩
   else isTrue (λ h2 => absurd h2 h)
@@ -391,14 +391,14 @@ def decidable_eq_of_bool_pred {α : Sort u} {p : α → α → Bool} (h₁ : is_
 
 lemma decidable_eq_inl_refl {α : Sort u} [h : DecidableEq α] (a : α) : h a a = isTrue (Eq.refl a) :=
 match (h a a) with
-| (isTrue e)  => rfl
-| (isFalse n) => absurd rfl n
+| isTrue _  => rfl
+| isFalse n => absurd rfl n
 
 lemma decidable_eq_inr_neg {α : Sort u} [h : DecidableEq α] {a b : α} : ∀ n : a ≠ b, h a b = isFalse n :=
 λ n =>
 match (h a b) with
-| (isTrue e)   => absurd e n
-| (isFalse n₁) => proof_irrel n n₁ ▸ Eq.refl (isFalse n)
+| isTrue e   => absurd e n
+| isFalse n₁ => proof_irrel n n₁ ▸ Eq.refl (isFalse n)
 
 /- subsingleton -/
 
@@ -419,16 +419,16 @@ lemma if_ctx_congr {α : Sort u} {b c : Prop} [dec_b : Decidable b] [dec_c : Dec
                    (h_c : b ↔ c) (h_t : c → x = u) (h_e : ¬c → y = v) :
         ite b x y = ite c u v :=
 match dec_b, dec_c with
-| (isFalse h₁), (isFalse h₂) => h_e h₂
-| (isTrue h₁),  (isTrue h₂)  => h_t h₂
-| (isFalse h₁), (isTrue h₂)  => absurd h₂ (Iff.mp (not_iff_not_of_iff h_c) h₁)
-| (isTrue h₁),  (isFalse h₂) => absurd h₁ (Iff.mpr (not_iff_not_of_iff h_c) h₂)
+| isFalse _,  isFalse h₂ => h_e h₂
+| isTrue _,   isTrue h₂  => h_t h₂
+| isFalse h₁, isTrue h₂  => absurd h₂ (Iff.mp (not_iff_not_of_iff h_c) h₁)
+| isTrue h₁,  isFalse h₂ => absurd h₁ (Iff.mpr (not_iff_not_of_iff h_c) h₂)
 
 lemma if_congr {α : Sort u} {b c : Prop} [dec_b : Decidable b] [dec_c : Decidable c]
                {x y u v : α}
                (h_c : b ↔ c) (h_t : x = u) (h_e : y = v) :
         ite b x y = ite c u v :=
-@if_ctx_congr α b c dec_b dec_c x y u v h_c (λ h => h_t) (λ h => h_e)
+@if_ctx_congr α b c dec_b dec_c x y u v h_c (λ _ => h_t) (λ _ => h_e)
 
 @[simp] lemma if_true {h : Decidable True} (t e : α) : (@ite α True h t e) = t :=
 if_pos trivial
@@ -440,15 +440,15 @@ lemma if_ctx_congr_prop {b c x y u v : Prop} [dec_b : Decidable b] [dec_c : Deci
                       (h_c : b ↔ c) (h_t : c → (x ↔ u)) (h_e : ¬c → (y ↔ v)) :
         ite b x y ↔ ite c u v :=
 match dec_b, dec_c with
-| (isFalse h₁), (isFalse h₂) => h_e h₂
-| (isTrue h₁),  (isTrue h₂)  => h_t h₂
-| (isFalse h₁), (isTrue h₂)  => absurd h₂ (Iff.mp (not_iff_not_of_iff h_c) h₁)
-| (isTrue h₁),  (isFalse h₂) => absurd h₁ (Iff.mpr (not_iff_not_of_iff h_c) h₂)
+| isFalse _,  isFalse h₂ => h_e h₂
+| isTrue _,   isTrue h₂  => h_t h₂
+| isFalse h₁, isTrue h₂  => absurd h₂ (Iff.mp (not_iff_not_of_iff h_c) h₁)
+| isTrue h₁,  isFalse h₂ => absurd h₁ (Iff.mpr (not_iff_not_of_iff h_c) h₂)
 
-lemma if_congr_prop {b c x y u v : Prop} [dec_b : Decidable b] [dec_c : Decidable c]
+lemma if_congr_prop {b c x y u v : Prop} [Decidable b] [Decidable c]
                     (h_c : b ↔ c) (h_t : x ↔ u) (h_e : y ↔ v) :
         ite b x y ↔ ite c u v :=
-if_ctx_congr_prop h_c (λ h => h_t) (λ h => h_e)
+if_ctx_congr_prop h_c (λ _ => h_t) (λ _ => h_e)
 
 lemma if_ctx_simp_congr_prop {b c x y u v : Prop} [dec_b : Decidable b]
                                (h_c : b ↔ c) (h_t : c → (x ↔ u)) (h_e : ¬c → (y ↔ v)) :
@@ -458,7 +458,7 @@ lemma if_ctx_simp_congr_prop {b c x y u v : Prop} [dec_b : Decidable b]
 lemma if_simp_congr_prop {b c x y u v : Prop} [dec_b : Decidable b]
                            (h_c : b ↔ c) (h_t : x ↔ u) (h_e : y ↔ v) :
         ite b x y ↔ (@ite Prop c (decidable_of_decidable_of_iff h_c) u v) :=
-@if_ctx_simp_congr_prop b c x y u v dec_b h_c (λ h => h_t) (λ h => h_e)
+@if_ctx_simp_congr_prop b c x y u v dec_b h_c (λ _ => h_t) (λ _ => h_e)
 
 lemma dif_ctx_congr {α : Sort u} {b c : Prop} [dec_b : Decidable b] [dec_c : Decidable c]
                     {x : b → α} {u : c → α} {y : ¬b → α} {v : ¬c → α}
@@ -467,10 +467,10 @@ lemma dif_ctx_congr {α : Sort u} {b c : Prop} [dec_b : Decidable b] [dec_c : De
                     (h_e : ∀ (h : ¬c),   y (Iff.mpr (not_iff_not_of_iff h_c) h) = v h) :
         (@dite α b dec_b x y) = (@dite α c dec_c u v) :=
 match dec_b, dec_c with
-| (isFalse h₁), (isFalse h₂) => h_e h₂
-| (isTrue h₁),  (isTrue h₂)  => h_t h₂
-| (isFalse h₁), (isTrue h₂)  => absurd h₂ (Iff.mp (not_iff_not_of_iff h_c) h₁)
-| (isTrue h₁),  (isFalse h₂) => absurd h₁ (Iff.mpr (not_iff_not_of_iff h_c) h₂)
+| isFalse _,  isFalse h₂ => h_e h₂
+| isTrue _,   isTrue h₂  => h_t h₂
+| isFalse h₁, isTrue h₂  => absurd h₂ (Iff.mp (not_iff_not_of_iff h_c) h₁)
+| isTrue h₁,  isFalse h₂ => absurd h₁ (Iff.mpr (not_iff_not_of_iff h_c) h₂)
 
 lemma dif_ctx_simp_congr {α : Sort u} {b c : Prop} [dec_b : Decidable b]
                          {x : b → α} {u : c → α} {y : ¬b → α} {v : ¬c → α}
@@ -488,8 +488,8 @@ if c then False else True
 
 lemma of_as_true {c : Prop} [h₁ : Decidable c] (h₂ : as_true c) : c :=
 match h₁, h₂ with
-| (isTrue h_c),  h₂ => h_c
-| (isFalse h_c), h₂ => False.elim h₂
+| isTrue h_c, _ => h_c
+| isFalse _, h₂ => False.elim h₂
 
 /-- Universe lifting operation -/
 structure ulift.{r, s} (α : Type s) : Type (max s r) :=
@@ -499,7 +499,7 @@ namespace ulift
 
 /- Bijection between α and ulift.{v} α -/
 lemma up_down {α : Type u} : ∀ (b : ulift.{v} α), up (down b) = b
-| up a => rfl
+| up _ => rfl
 
 lemma down_up {α : Type u} (a : α) : down (up.{v} a) = a := rfl
 
@@ -512,7 +512,7 @@ up :: (down : α)
 namespace plift
 /- Bijection between α and plift α -/
 lemma up_down : ∀ (b : plift α), up (down b) = b
-| (up a) => rfl
+| up _ => rfl
 
 lemma down_up (a : α) : down (up a) = a := rfl
 end plift

--- a/Mathlib/Init/Set.lean
+++ b/Mathlib/Init/Set.lean
@@ -52,7 +52,7 @@ instance : Subset (Set α) :=
 ⟨Set.subset⟩
 
 instance : EmptyCollection (Set α) :=
-⟨λ a => false⟩
+⟨λ _ => false⟩
 
 open Mathlib.ExtendedBinder in
 syntax "{ " extBinder " | " term " }" : term
@@ -73,7 +73,7 @@ open Mathlib.ExtendedBinder in
 macro (priority := low) "{ " t:term " | " bs:extBinders " }" : term =>
   `({ x | ∃ᵉ $bs:extBinders, $t = x })
 
-def univ : Set α := {a | True }
+def univ : Set α := {_a | True}
 
 protected def insert (a : α) (s : Set α) : Set α :=
 {b | b = a ∨ b ∈ s}
@@ -119,10 +119,10 @@ instance : Functor Set :=
 { map := @Set.image }
 
 instance : LawfulFunctor Set where
-  id_map s := funext $ λ b => propext ⟨λ ⟨_, sb, rfl⟩ => sb, λ sb => ⟨_, sb, rfl⟩⟩
-  comp_map g h s := funext $ λ c => propext
+  id_map _ := funext fun _ => propext ⟨λ ⟨_, sb, rfl⟩ => sb, λ sb => ⟨_, sb, rfl⟩⟩
+  comp_map g h _ := funext $ λ c => propext
     ⟨λ ⟨a, ⟨h₁, h₂⟩⟩ => ⟨g a, ⟨⟨a, ⟨h₁, rfl⟩⟩, h₂⟩⟩,
-     λ ⟨b, ⟨⟨a, ⟨h₁, h₂⟩⟩, h₃⟩⟩ => ⟨a, ⟨h₁, show h (g a) = c from h₂ ▸ h₃⟩⟩⟩
+     λ ⟨_, ⟨⟨a, ⟨h₁, h₂⟩⟩, h₃⟩⟩ => ⟨a, ⟨h₁, show h (g a) = c from h₂ ▸ h₃⟩⟩⟩
   map_const := rfl
 
 syntax "{" term,+ "}" : term

--- a/Mathlib/Lean/Expr/Basic.lean
+++ b/Mathlib/Lean/Expr/Basic.lean
@@ -78,17 +78,17 @@ def updateValue : ConstantInfo → Expr → ConstantInfo
   | defnInfo   info, v => defnInfo   {info with value := v}
   | thmInfo    info, v => thmInfo    {info with value := v}
   | opaqueInfo info, v => opaqueInfo {info with value := v}
-  | d, v => d
+  | d, _ => d
 
 def toDeclaration! : ConstantInfo → Declaration
   | defnInfo   info => Declaration.defnDecl info
   | thmInfo    info => Declaration.thmDecl     info
   | axiomInfo  info => Declaration.axiomDecl   info
   | opaqueInfo info => Declaration.opaqueDecl  info
-  | quotInfo   info => panic! "toDeclaration for quotInfo not implemented"
-  | inductInfo info => panic! "toDeclaration for inductInfo not implemented"
-  | ctorInfo   info => panic! "toDeclaration for ctorInfo not implemented"
-  | recInfo    info => panic! "toDeclaration for recInfo not implemented"
+  | quotInfo   _ => panic! "toDeclaration for quotInfo not implemented"
+  | inductInfo _ => panic! "toDeclaration for inductInfo not implemented"
+  | ctorInfo   _ => panic! "toDeclaration for ctorInfo not implemented"
+  | recInfo    _ => panic! "toDeclaration for recInfo not implemented"
 
 end ConstantInfo
 
@@ -133,7 +133,7 @@ def modifyArg (modifier : Expr → Expr) (e : Expr) (i : Nat) (n := e.getAppNumA
   modifyRevArg modifier (n - i - 1) e
 
 def getRevArg? : Expr → Nat → Option Expr
-  | app f a _, 0   => a
+  | app _ a _, 0   => a
   | app f _ _, i+1 => getRevArg! f i
   | _,         _   => none
 

--- a/Mathlib/Logic/Basic.lean
+++ b/Mathlib/Logic/Basic.lean
@@ -441,7 +441,7 @@ lemma imp_imp_imp (h₀ : c → a) (h₁ : b → d) : (a → b) → (c → d) :=
 
 -- See Note [decidable namespace]
 protected theorem Decidable.peirce (a b : Prop) [Decidable a] : ((a → b) → a) → a :=
-if ha : a then λ h => ha else λ h => h ha.elim
+if ha : a then λ _ => ha else λ h => h ha.elim
 
 theorem peirce (a b : Prop) : ((a → b) → a) → a := Decidable.peirce _ _
 
@@ -509,17 +509,17 @@ theorem not_and_not_right : ¬(a ∧ ¬b) ↔ (a → b) := Decidable.not_and_not
 **Important**: this function should be used instead of `rw` on `decidable b`, because the
 kernel will get stuck reducing the usage of `propext` otherwise,
 and `dec_trivial` will not work. -/
-@[inline] def decidable_of_iff (a : Prop) (h : a ↔ b) [D : Decidable a] : Decidable b :=
+@[inline] def decidable_of_iff (a : Prop) (h : a ↔ b) [Decidable a] : Decidable b :=
 decidable_of_decidable_of_iff h
 
 /-- Transfer decidability of `b` to decidability of `a`, if the propositions are equivalent.
 This is the same as `decidable_of_iff` but the iff is flipped. -/
-@[inline] def decidable_of_iff' (b : Prop) (h : a ↔ b) [D : Decidable b] : Decidable a :=
+@[inline] def decidable_of_iff' (b : Prop) (h : a ↔ b) [Decidable b] : Decidable a :=
 decidable_of_decidable_of_iff h.symm
 
 /-- Prove that `a` is decidable by constructing a boolean `b` and a proof that `b ↔ a`.
 (This is sometimes taken as an alternate definition of decidability.) -/
-def decidable_of_bool : ∀ (b : Bool) (h : b ↔ a), Decidable a
+def decidable_of_bool : ∀ (b : Bool), (b ↔ a) → Decidable a
 | true, h => isTrue (h.1 rfl)
 | false, h => isFalse (mt h.2 Bool.ff_ne_tt)
 
@@ -617,7 +617,7 @@ forall_congr' (λ a => forall₃_congr (h a))
 
 lemma exists_imp_exists' {p : α → Prop} {q : β → Prop} (f : α → β) (hpq : ∀ a, p a → q (f a))
   (hp : ∃ a, p a) : ∃ b, q b :=
-Exists.elim hp (λ a hp' => ⟨_, hpq _ hp'⟩)
+Exists.elim hp (λ _ hp' => ⟨_, hpq _ hp'⟩)
 
 lemma exists₂_congr {p q : α → β → Prop} (h : ∀ a b, p a b ↔ q a b) :
   (∃ a b, p a b) ↔ (∃ a b, q a b) :=
@@ -666,18 +666,18 @@ protected theorem Decidable.not_forall {p : α → Prop}
 @[simp] theorem not_forall {p : α → Prop} : (¬ ∀ x, p x) ↔ ∃ x, ¬ p x := Decidable.not_forall
 
 @[simp] theorem forall_const (α : Sort _) [i : Nonempty α] : (α → b) ↔ b :=
-⟨i.elim, λ hb x => hb⟩
+⟨i.elim, λ hb _ => hb⟩
 
 theorem forall_and_distrib {p q : α → Prop} : (∀ x, p x ∧ q x) ↔ (∀ x, p x) ∧ (∀ x, q x) :=
 ⟨λ h => ⟨λ x => (h x).left, λ x => (h x).right⟩, λ ⟨h₁, h₂⟩ x => ⟨h₁ x, h₂ x⟩⟩
 
 @[simp] theorem forall_eq {p : α → Prop} {a' : α} : (∀ a, a = a' → p a) ↔ p a' :=
-⟨λ h => h a' rfl, λ h a e => e.symm ▸ h⟩
+⟨λ h => h a' rfl, λ h _ e => e.symm ▸ h⟩
 
 @[simp] theorem forall_eq' {a' : α} : (∀ a, a' = a → p a) ↔ p a' :=
 by simp [@eq_comm _ a']
 
-@[simp] theorem exists_false : ¬ (∃ a : α, False) := fun ⟨a, h⟩ => h
+@[simp] theorem exists_false : ¬ (∃ _a : α, False) := fun ⟨_, h⟩ => h
 
 @[simp] theorem exists_and_distrib_left {q : Prop} {p : α → Prop} :
   (∃ x, q ∧ p x) ↔ q ∧ (∃ x, p x) :=
@@ -692,7 +692,7 @@ by simp [And.comm]
 @[simp] theorem exists_eq' {a' : α} : ∃ a, a' = a := ⟨_, rfl⟩
 
 @[simp] theorem exists_eq_left {p : α → Prop} {a' : α} : (∃ a, a = a' ∧ p a) ↔ p a' :=
-⟨λ ⟨a, e, h⟩ => e ▸ h, λ h => ⟨_, rfl, h⟩⟩
+⟨λ ⟨_, e, h⟩ => e ▸ h, λ h => ⟨_, rfl, h⟩⟩
 
 @[simp] theorem exists_eq_right {p : α → Prop} {a' : α} : (∃ a, p a ∧ a = a') ↔ p a' :=
 (exists_congr $ by exact λ a => And.comm).trans exists_eq_left
@@ -714,7 +714,7 @@ by simp [@eq_comm _ a']
 
 
 @[simp]
-theorem exists_prop {p q : Prop} : (∃ h : p, q) ↔ p ∧ q :=
+theorem exists_prop {p q : Prop} : (∃ _h : p, q) ↔ p ∧ q :=
 Iff.intro (fun ⟨hp, hq⟩ => And.intro hp hq) (fun ⟨hp, hq⟩ => Exists.intro hp hq)
 
 @[simp] theorem exists_apply_eq_apply {α β : Type _} (f : α → β) (a' : α) : ∃ a, f a = f a' :=

--- a/Mathlib/Logic/Function/Basic.lean
+++ b/Mathlib/Logic/Function/Basic.lean
@@ -21,7 +21,7 @@ variable {α β γ : Sort _} {f : α → β}
   `Function.eval x : (∀ x, β x) → β x`. -/
 @[reducible, simp] def eval {β : α → Sort _} (x : α) (f : ∀ x, β x) : β x := f x
 
-lemma const_def {y : β} : (λ x : α => y) = const α y := rfl
+lemma const_def {y : β} : (λ _x : α => y) = const α y := rfl
 
 @[simp] lemma const_comp {f : α → β} {c : γ} : const β c ∘ f = const α c := rfl
 
@@ -41,7 +41,7 @@ lemma hfunext {α α': Sort u} {β : α → Sort v} {β' : α' → Sort v} {f : 
   exact eq_of_heq (this a)
 
 lemma funext_iff {β : α → Sort _} {f₁ f₂ : ∀ (x : α), β x} : f₁ = f₂ ↔ (∀a, f₁ a = f₂ a) :=
-Iff.intro (λ h a => h ▸ rfl) funext
+Iff.intro (λ h _ => h ▸ rfl) funext
 
 protected lemma bijective.injective {f : α → β} (hf : bijective f) : injective f := hf.1
 protected lemma bijective.surjective {f : α → β} (hf : bijective f) : surjective f := hf.2
@@ -67,7 +67,7 @@ h ▸ hf.ne_iff
 /-- If the co-domain `β` of an injective function `f : α → β` has decidable equality, then
 the domain `α` also has decidable equality. -/
 def injective.decidable_eq [DecidableEq β] (I : injective f) : DecidableEq α :=
-λ a b => decidable_of_iff _ I.eq_iff
+λ _ _ => decidable_of_iff _ I.eq_iff
 
 lemma injective.of_comp {g : γ → α} (I : injective (f ∘ g)) : injective g :=
 λ {x y} h => I $ show f (g x) = f (g y) from congr_arg f h
@@ -78,14 +78,14 @@ lemma injective.of_comp_iff {f : α → β} (hf : injective f) (g : γ → α) :
 
 lemma injective.of_comp_iff' (f : α → β) {g : γ → α} (hg : bijective g) :
   injective (f ∘ g) ↔ injective f :=
-⟨ λ h x y => let ⟨x', hx⟩ := hg.surjective x
-             let ⟨y', hy⟩ := hg.surjective y
+⟨ λ h x y => let ⟨_, hx⟩ := hg.surjective x
+             let ⟨_, hy⟩ := hg.surjective y
              hx ▸ hy ▸ λ hf => h hf ▸ rfl,
   λ h => h.comp hg.injective⟩
 
 lemma injective_of_subsingleton [Subsingleton α] (f : α → β) :
   injective f :=
-λ {a b} ab => Subsingleton.elim _ _
+λ _ _ _ => Subsingleton.elim _ _
 
 lemma injective.dite (p : α → Prop) [DecidablePred p]
   {f : {a : α // p a} → β} {f' : {a : α // ¬ p a} → β}
@@ -140,11 +140,11 @@ theorem surjective.forall {f : α → β} (hf : surjective f) {p : β → Prop} 
 
 theorem surjective.forall₂ {f : α → β} (hf : surjective f) {p : β → β → Prop} :
   (∀ y₁ y₂, p y₁ y₂) ↔ ∀ x₁ x₂, p (f x₁) (f x₂) :=
-hf.forall.trans $ forall_congr' $ λ x => hf.forall
+hf.forall.trans $ forall_congr' fun _ => hf.forall
 
 theorem surjective.forall₃ {f : α → β} (hf : surjective f) {p : β → β → β → Prop} :
   (∀ y₁ y₂ y₃, p y₁ y₂ y₃) ↔ ∀ x₁ x₂ x₃, p (f x₁) (f x₂) (f x₃) :=
-hf.forall.trans $ forall_congr' $ λ x => hf.forall₂
+hf.forall.trans $ forall_congr' fun _ => hf.forall₂
 
 theorem surjective.exists {f : α → β} (hf : surjective f) {p : β → Prop} :
   (∃ y, p y) ↔ ∃ x, p (f x) :=
@@ -154,18 +154,18 @@ theorem surjective.exists {f : α → β} (hf : surjective f) {p : β → Prop} 
 
 theorem surjective.exists₂ {f : α → β} (hf : surjective f) {p : β → β → Prop} :
   (∃ y₁ y₂, p y₁ y₂) ↔ ∃ x₁ x₂, p (f x₁) (f x₂) :=
-hf.exists.trans $ exists_congr $ λ x => hf.exists
+hf.exists.trans $ exists_congr fun _ => hf.exists
 
 theorem surjective.exists₃ {f : α → β} (hf : surjective f) {p : β → β → β → Prop} :
   (∃ y₁ y₂ y₃, p y₁ y₂ y₃) ↔ ∃ x₁ x₂ x₃, p (f x₁) (f x₂) (f x₃) :=
-hf.exists.trans $ exists_congr $ λ x => hf.exists₂
+hf.exists.trans $ exists_congr fun _ => hf.exists₂
 
 lemma bijective_iff_exists_unique (f : α → β) : bijective f ↔
   ∀ b : β, ∃! (a : α), f a = b :=
 ⟨ λ hf b => let ⟨a, ha⟩ := hf.surjective b
-            ⟨a, ha, λ a' ha' => hf.injective (ha'.trans ha.symm)⟩,
+            ⟨a, ha, λ _ ha' => hf.injective (ha'.trans ha.symm)⟩,
   λ he => ⟨
-    λ {a a'} h => unique_of_exists_unique (he (f a')) h rfl,
+    λ {_a a'} h => unique_of_exists_unique (he (f a')) h rfl,
     λ b => ExistsUnique.exists (he b) ⟩⟩
 
 /-- Shorthand for using projection notation with `function.bijective_iff_exists_unique`. -/
@@ -191,7 +191,7 @@ theorem cantor_injective {α : Type _} (f : (Set α) → α) :
   ¬ Function.injective f
 | i => cantor_surjective (λ a b => ∀ U, a = f U → U b) $
        RightInverse.surjective
-         (λ U => funext $ λ a => propext ⟨λ h => h U rfl, λ h' U' e => i e ▸ h'⟩)
+         (λ U => funext $ λ _a => propext ⟨λ h => h U rfl, λ h' _U e => i e ▸ h'⟩)
 
 /-- `g` is a partial inverse to `f` (an injective but not necessarily
   surjective function) if `g y = some x` implies `f x = y`, and `g y = none`
@@ -203,7 +203,7 @@ theorem is_partial_inv_left {α β} {f : α → β} {g} (H : is_partial_inv f g)
 (H _ _).2 rfl
 
 theorem injective_of_partial_inv {α β} {f : α → β} {g} (H : is_partial_inv f g) : injective f :=
-λ {a b} h => Option.some.inj $ ((H _ _).2 h).symm.trans ((H _ _).2 rfl)
+λ _ _ h => Option.some.inj $ ((H _ _).2 h).symm.trans ((H _ _).2 rfl)
 
 -- TODO mathlib3 uses Mem here
 theorem injective_of_partial_inv_right {α β} {f : α → β} {g} (H : is_partial_inv f g)
@@ -370,14 +370,14 @@ lemma surjective_iff_has_RightInverse : surjective f ↔ has_RightInverse f :=
 
 lemma bijective_iff_has_inverse : bijective f ↔ ∃ g, LeftInverse g f ∧ RightInverse g f :=
 ⟨λ hf =>  ⟨_, LeftInverse_surj_inv hf, RightInverse_surj_inv hf.2⟩,
- λ ⟨g, gl, gr⟩ => ⟨gl.injective,  gr.surjective⟩⟩
+ λ ⟨_, gl, gr⟩ => ⟨gl.injective,  gr.surjective⟩⟩
 
 lemma injective_surj_inv (h : surjective f) : injective (surj_inv h) :=
 (RightInverse_surj_inv h).injective
 
 lemma surjective_to_subsingleton [na : Nonempty α] [Subsingleton β] (f : α → β) :
   surjective f :=
-λ y => let ⟨a⟩ := na; ⟨a, Subsingleton.elim _ _⟩
+λ _ => let ⟨a⟩ := na; ⟨a, Subsingleton.elim _ _⟩
 
 end surj_inv
 
@@ -391,10 +391,10 @@ if h : a = a' then Eq.rec (motive := λ a _ => β a) v h.symm else f a
 /-- On non-dependent functions, `function.update` can be expressed as an `ite` -/
 lemma update_apply {β : Sort _} (f : α → β) (a' : α) (b : β) (a : α) :
   update f a' b a = if a = a' then b else f a :=
-by have h2 : (h : a = a') → Eq.rec (motive := λ a b => β) b h.symm = b :=
+by have h2 : (h : a = a') → Eq.rec (motive := λ _ _ => β) b h.symm = b :=
      by intro h
         rw [eq_rec_constant]
-   have h3 : (λ h : a = a' => Eq.rec (motive := λ a b => β) b h.symm) =
+   have h3 : (λ h : a = a' => Eq.rec (motive := λ _ _ => β) b h.symm) =
              (λ _ : a = a' =>  b) := funext h2
    let f := λ x => dite (a = a') x (λ (_: ¬ a = a') => (f a))
    exact congrArg f h3
@@ -446,7 +446,7 @@ update_eq_iff.2 ⟨rfl, λ _ _ => rfl⟩
 lemma update_comp_eq_of_forall_ne' {α'} (g : ∀ a, β a) {f : α' → α} {i : α} (a : β i)
   (h : ∀ x, f x ≠ i) :
   (λ j => (update g i a) (f j)) = (λ j => g (f j)) :=
-funext $ λ x => update_noteq (h _) _ _
+funext $ λ _ => update_noteq (h _) _ _
 
 /-- Non-dependent version of `function.update_comp_eq_of_forall_ne'` -/
 lemma update_comp_eq_of_forall_ne {α β : Sort _} (g : α' → β) {f : α → α'} {i : α'} (a : β)
@@ -457,7 +457,7 @@ update_comp_eq_of_forall_ne' g a h
 lemma update_comp_eq_of_injective' (g : ∀a, β a) {f : α' → α} (hf : Function.injective f)
   (i : α') (a : β (f i)) :
   (λ j => update g (f i) a (f j)) = update (λ i => g (f i)) i a :=
-eq_update_iff.2 ⟨update_same _ _ _, λ j hj => update_noteq (hf.ne hj) _ _⟩
+eq_update_iff.2 ⟨update_same _ _ _, λ _ hj => update_noteq (hf.ne hj) _ _⟩
 
 /-- Non-dependent version of `function.update_comp_eq_of_injective'` -/
 lemma update_comp_eq_of_injective {β : Sort _} (g : α' → β) {f : α → α'}

--- a/Mathlib/Logic/Nonempty.lean
+++ b/Mathlib/Logic/Nonempty.lean
@@ -18,7 +18,7 @@ This file proves a few extra facts about `Nonempty`, which is defined in core Le
 -/
 
 
-theorem exists_true_iff_nonempty {α : Sort _} : (∃ a : α, True) ↔ Nonempty α :=
+theorem exists_true_iff_nonempty {α : Sort _} : (∃ _a : α, True) ↔ Nonempty α :=
   Iff.intro (fun ⟨a, _⟩ => ⟨a⟩) fun ⟨a⟩ => ⟨a, trivial⟩
 
 @[simp]
@@ -86,7 +86,7 @@ theorem nonempty_plift : Nonempty (PLift α) ↔ Nonempty α :=
 
 @[simp]
 theorem Nonempty.forall {p : Nonempty α → Prop} : (∀ h : Nonempty α, p h) ↔ ∀ a, p ⟨a⟩ :=
-  Iff.intro (fun h a => h _) fun h ⟨a⟩ => h a
+  Iff.intro (fun h _ => h _) fun h ⟨a⟩ => h a
 
 @[simp]
 theorem Nonempty.exists {p : Nonempty α → Prop} : (∃ h : Nonempty α, p h) ↔ ∃ a, p ⟨a⟩ :=
@@ -133,5 +133,4 @@ theorem subsingleton_of_not_nonempty (h : ¬Nonempty α) : Subsingleton α :=
   ⟨fun x => False.elim $ not_nonempty_iff_imp_false.mp h x⟩
 
 instance {β : α → Sort v} [∀ a, Nonempty (β a)] : Nonempty (∀ a, β a) :=
-  ⟨fun a => Classical.arbitrary _⟩
-
+  ⟨fun _ => Classical.arbitrary _⟩

--- a/Mathlib/Mathport/Rename.lean
+++ b/Mathlib/Mathport/Rename.lean
@@ -34,7 +34,7 @@ open Lean.Elab Lean.Elab.Command
 syntax (name := align) "#align " ident ident : command
 
 @[commandElab align] def elabAlign : CommandElab
-  | `(#align%$tk $id3:ident $id4:ident) =>
+  | `(#align $id3:ident $id4:ident) =>
     liftCoreM $ addNameAlignment id3.getId id4.getId
   | _ => throwUnsupportedSyntax
 

--- a/Mathlib/Mathport/Syntax.lean
+++ b/Mathlib/Mathport/Syntax.lean
@@ -64,7 +64,7 @@ syntax "expandBinders% " "(" ident " => " term ")" extBinders ", " term : term
 macro_rules
   | `(expandBinders% ($x => $term) $y:extBinder, $res) =>
     `(expandBinders% ($x => $term) ($y:extBinder), $res)
-  | `(expandBinders% ($x => $term), $res) => pure res
+  | `(expandBinders% ($_ => $_), $res) => pure res
 macro_rules
   | `(expandBinders% ($x => $term) ($y:ident $[: $ty]?) $binders*, $res) => do
     let ty := ty.getD (← `(_))
@@ -593,7 +593,7 @@ macro_rules
     let ns := mkIdentFrom ns <| rootNamespace ++ ns.getId
     `(with_weak_namespace $ns
       scoped notation $[$prec:precedence]? $[$n:namedName]? $[$prio:namedPrio]? $sym => $t)
-  | `(localized [$ns] $attrKind:attrKind $mixfixKind $prec:precedence $[$n:namedName]? $[$prio:namedPrio]? $sym => $t) =>
+  | `(localized [$ns] $_:attrKind $mixfixKind $prec:precedence $[$n:namedName]? $[$prio:namedPrio]? $sym => $t) =>
     let ns := mkIdentFrom ns <| rootNamespace ++ ns.getId
     `(with_weak_namespace $ns
       scoped $mixfixKind $prec:precedence $[$n:namedName]? $[$prio:namedPrio]? $sym => $t)

--- a/Mathlib/Tactic/Basic.lean
+++ b/Mathlib/Tactic/Basic.lean
@@ -238,7 +238,7 @@ elab "any_goals " seq:tacticSeq : tactic => do
         evalTactic seq
         mvarIdsNew := mvarIdsNew ++ (← getUnsolvedGoals)
         anySuccess := true
-      catch ex =>
+      catch _ =>
         mvarIdsNew := mvarIdsNew.push mvarId
   if not anySuccess then
     throwError "failed on all goals"

--- a/Mathlib/Tactic/Ext.lean
+++ b/Mathlib/Tactic/Ext.lean
@@ -105,13 +105,13 @@ initialize extExtension : SimpleScopedEnvExtension (Name × Array DiscrTree.Key)
 def extAttribute : AttributeImpl where
   name := `ext
   descr := "Marks a lemma as extensionality lemma"
-  add decl stx kind := do
+  add decl _stx kind := do
     if isStructure (← getEnv) decl then
       liftCommandElabM do
         Elab.Command.elabCommand <|<- `(declareExtTheoremsFor $(mkIdent decl))
     else MetaM.run' do
       let declTy := (← getConstInfo decl).type
-      let (xs, bis, declTy) ← withReducible <| forallMetaTelescopeReducing declTy
+      let (_, _, declTy) ← withReducible <| forallMetaTelescopeReducing declTy
       if declTy.isAppOfArity ``Eq 3 && (declTy.getArg! 1).isMVar && (declTy.getArg! 2).isMVar then
         let ty := declTy.getArg! 0
         let key ←
@@ -139,8 +139,7 @@ elab "apply_ext_lemma" : tactic => do
     try
       liftMetaTactic (apply · (← mkConstWithFreshMVarLevels lem))
       return
-    catch e =>
-      s.restore
+    catch _ => s.restore
   throwError "no applicable extensionality lemma found for{indentExpr ty}"
 
 scoped syntax "ext_or_skip" (ppSpace rintroPat)* : tactic

--- a/Mathlib/Tactic/LibrarySearch.lean
+++ b/Mathlib/Tactic/LibrarySearch.lean
@@ -46,7 +46,7 @@ initialize librarySearchLemmas : DeclCache (DiscrTree Name) ←
     if constInfo.isUnsafe then return lemmas
     if ← isBlackListed name then return lemmas
     withNewMCtxDepth do
-      let (xs, bis, type) ← withReducible <| forallMetaTelescopeReducing constInfo.type
+      let (_, _, type) ← withReducible <| forallMetaTelescopeReducing constInfo.type
       let keys ← withReducible <| DiscrTree.mkPath type
       pure $ lemmas.insertCore keys name
 
@@ -112,7 +112,7 @@ elab_rules : tactic | `(tactic| library_search%$tk) => do
   withNestedTraces do
   trace[Tactic.librarySearch] "proving {← getMainTarget}"
   let mvar ← getMainGoal
-  let (hs, introdMVar) ← intros (← getMainGoal)
+  let (_, introdMVar) ← intros (← getMainGoal)
   withMVarContext introdMVar do
     if let some suggestions ← librarySearch introdMVar (← librarySearchLemmas.get) then
       for suggestion in suggestions do
@@ -127,7 +127,7 @@ elab tk:"library_search%" : term <= expectedType => do
   withNestedTraces do
   trace[Tactic.librarySearch] "proving {expectedType}"
   let mvar ← mkFreshExprMVar expectedType
-  let (hs, introdMVar) ← intros mvar.mvarId!
+  let (_, introdMVar) ← intros mvar.mvarId!
   withMVarContext introdMVar do
     if let some suggestions ← librarySearch introdMVar (← librarySearchLemmas.get) then
       for suggestion in suggestions do

--- a/Mathlib/Tactic/Lint/Basic.lean
+++ b/Mathlib/Tactic/Lint/Basic.lean
@@ -32,7 +32,7 @@ initialize nolintAttr : NameMapAttribute (Array Name) ←
   registerNameMapAttribute {
     name := `nolint
     descr := "Do not report this declaration in any of the tests of `#lint`"
-    add := fun decl stx =>
+    add := fun _decl stx =>
       match stx with
         -- TODO: validate linter names
         | `(attr|nolint $[$ids]*) => pure $ ids.map (·.getId.eraseMacroScopes)

--- a/Mathlib/Tactic/Lint/Misc.lean
+++ b/Mathlib/Tactic/Lint/Misc.lean
@@ -47,7 +47,7 @@ We skip all declarations that contain `sorry` in their value. -/
         e := mkApp e ldecl.type
         if let some val := ldecl.value? then
           e := mkApp e val
-      let unused := args.zip (.range args.size) |>.filter fun (arg, i) =>
+      let unused := args.zip (.range args.size) |>.filter fun (arg, _) =>
         !e.containsFVar arg.fvarId!
       if unused.isEmpty then return none
       addMessageContextFull <| .joinSep (← unused.toList.mapM fun (arg, i) =>

--- a/Mathlib/Tactic/Lint/Simp.lean
+++ b/Mathlib/Tactic/Lint/Simp.lean
@@ -139,7 +139,7 @@ https://leanprover-community.github.io/mathlib_docs/notes.html#simp-normal%20for
     let lhs_in_nf ← isSimpEq lhs' lhs
     if lhs'_eq_rhs' then do
       if prf1.isNone then return none -- TODO: cannot detect used rfl-lemmas
-      if let Name.str n "sizeOf_spec" _ := declName then
+      if let Name.str _n "sizeOf_spec" _ := declName then
         return none -- HACK: these often use rfl-lemmas but are not rfl
       let used_lemmas := heuristicallyExtractSimpTheorems ctx <|
         mkApp (prf1.getD (mkBVar 0)) (prf2.getD (mkBVar 0))
@@ -235,10 +235,10 @@ Some commutativity lemmas are simp lemmas:"
   test := fun declName => withReducible do
     unless ← isSimpTheorem declName do return none
     let ty := (← getConstInfo declName).type
-    forallTelescopeReducing ty fun xs ty => do
+    forallTelescopeReducing ty fun _ ty => do
     let some (_, lhs, rhs) := ty.eq? | return none
     unless lhs.getAppFn.constName? == rhs.getAppFn.constName? do return none
-    let (mvars, bis, ty') ← forallMetaTelescopeReducing ty
+    let (_, _, ty') ← forallMetaTelescopeReducing ty
     let some (_, lhs', rhs') := ty'.eq? | return none
     unless ← isDefEq rhs lhs' do return none
     unless ← withNewMCtxDepth (isDefEq rhs lhs') do return none

--- a/Mathlib/Tactic/NoMatch.lean
+++ b/Mathlib/Tactic/NoMatch.lean
@@ -38,10 +38,10 @@ open private elabMatchAux waitExpectedType from Lean.Elab.Match in
 
 elab tk:"fun" "." : term <= expectedType => do
   let (binders, discrs) ← (·.unzip) <$>
-    Meta.forallTelescopeReducing expectedType fun args _ => do
-      args.mapM fun arg => withFreshMacroScope do
+    Meta.forallTelescopeReducing expectedType fun args _ =>
+      args.mapM fun _ => withFreshMacroScope do
         return (← `(a), ← `(matchDiscr| a))
-  elabTerm (← `(@fun $binders:ident* => match $discrs:matchDiscr,* with.)) expectedType
+  elabTerm (← `(@fun%$tk $binders:ident* => match%$tk $discrs:matchDiscr,* with.)) expectedType
 
 macro tk:"λ" "." : term => `(fun%$tk .)
 

--- a/Mathlib/Tactic/NormCast/Ext.lean
+++ b/Mathlib/Tactic/NormCast/Ext.lean
@@ -44,7 +44,7 @@ partial def countHeadCoes (e : Expr) : MetaM Nat := do
 
 /-- Count how many coercions are inside the expression, including the top ones. -/
 partial def countCoes (e : Expr) : MetaM Nat :=
-  lambdaTelescope e fun xs e => do
+  lambdaTelescope e fun _ e => do
     if let Expr.const fn .. := e.getAppFn then
       if let some info ← getCoeFnInfo? fn then
         if e.getAppNumArgs >= info.numArgs then
@@ -60,7 +60,7 @@ def countInternalCoes (e : Expr) : MetaM Nat :=
 
 /-- Classifies a declaration of type `ty` as a `norm_cast` rule. -/
 def classifyType (ty : Expr) : MetaM Label :=
-  forallTelescopeReducing ty fun xs ty => do
+  forallTelescopeReducing ty fun _ ty => do
     let ty ← whnf ty
     let (lhs, rhs) ←
       if ty.isAppOfArity ``Eq 3 then pure (ty.getArg! 1, ty.getArg! 2)
@@ -69,7 +69,6 @@ def classifyType (ty : Expr) : MetaM Label :=
     let lhsCoes ← countCoes lhs
     if lhsCoes = 0 then throwError "norm_cast: badly shaped lemma, lhs must contain at least one coe{indentExpr lhs}"
     let lhsHeadCoes ← countHeadCoes lhs
-    let lhsInternalCoes ← countInternalCoes lhs
     let rhsHeadCoes ← countHeadCoes rhs
     let rhsInternalCoes ← countInternalCoes rhs
     if lhsHeadCoes = 0 then

--- a/Mathlib/Tactic/NormCast/Tactic.lean
+++ b/Mathlib/Tactic/NormCast/Tactic.lean
@@ -86,14 +86,14 @@ def splittingProcedure (expr : Expr) : MetaM Simp.Result := do
       let some y_y2 ← proveEqUsingDown y y2 | failure
       Simp.mkCongr {expr := mkApp op x} y_y2)
   catch _ => try
-    let some (β, n) := isNumeral? y | failure
+    let some (_, n) := isNumeral? y | failure
     let some x' ← isCoeOf? x | failure
     let α ← inferType x'
     let y2 ← mkCoe (← mkNumeral α n) γ
     let some y_y2 ← proveEqUsingDown y y2 | failure
     Simp.mkCongr {expr := mkApp op x} y_y2
   catch _ => try
-    let some (α, n) := isNumeral? x | failure
+    let some (_, n) := isNumeral? x | failure
     let some y' ← isCoeOf? y | failure
     let β ← inferType y'
     let x2 ← mkCoe (← mkNumeral β n) γ
@@ -245,7 +245,7 @@ macro "apply_mod_cast " e:term : tactic => `(apply mod_cast ($e : _))
 
 syntax (name := convNormCast) "norm_cast" : conv
 @[tactic convNormCast] def evalConvNormCast : Tactic :=
-  open Elab.Tactic.Conv in fun stx => withMainContext do
+  open Elab.Tactic.Conv in fun _ => withMainContext do
     applySimpResult (← derive (← getLhs))
 
 syntax (name := pushCast) "push_cast " (config)? (discharger)? (&"only ")? ("[" (simpStar <|> simpErase <|> simpLemma),* "]")? (location)? : tactic

--- a/Mathlib/Tactic/NormNum.lean
+++ b/Mathlib/Tactic/NormNum.lean
@@ -56,11 +56,11 @@ instance (α) [Semiring α] : LawfulOne α := ⟨Nat.cast_one.symm⟩
 
 theorem isNat_add {α} [Semiring α] : (a b : α) → (a' b' c : Nat) →
   isNat a a' → isNat b b' → Nat.add a' b' = c → isNat (a + b) c
-| _, _, _, _, _, rfl, rfl, rfl => Nat.cast_add.symm
+| _, _, _a', _b', _, rfl, rfl, rfl => Nat.cast_add.symm
 
 theorem isNat_mul {α} [Semiring α] : (a b : α) → (a' b' c : Nat) →
   isNat a a' → isNat b b' → Nat.mul a' b' = c → isNat (a * b) c
-| _, _, _, _, _, rfl, rfl, rfl => Nat.cast_mul.symm
+| _, _, _a', _b', _, rfl, rfl, rfl => Nat.cast_mul.symm
 
 theorem isNat_pow {α} [Semiring α] : (a : α) → (b a' b' c : Nat) →
   isNat a a' → isNat b b' → Nat.pow a' b' = c → isNat (a ^ b) c
@@ -74,7 +74,7 @@ partial def evalIsNat (u : Level) (α sα e : Expr) : MetaM (Expr × Expr) := do
   | (``HMul.hMul, #[_, _, _, _, a, b]) => evalBinOp ``NormNum.isNat_mul (·*·) a b
   | (``HPow.hPow, #[_, _, _, _, a, b]) => evalPow ``NormNum.isNat_pow (·^·) a b
   | (``OfNat.ofNat, #[_, ln, inst]) =>
-    let some n := ln.natLit? | throwError "fail"
+    unless ln.isNatLit do throwError "fail"
     let lawful ← synthInstance (mkApp4 (mkConst ``LawfulOfNat [u]) α sα ln inst)
     pure (ln, mkApp5 (mkConst ``LawfulOfNat.isNat_ofNat [u]) α sα ln inst lawful)
   | (``Zero.zero, #[_, inst]) =>

--- a/Mathlib/Tactic/RestateAxiom.lean
+++ b/Mathlib/Tactic/RestateAxiom.lean
@@ -58,4 +58,4 @@ elab "restate_axiom " oldName:ident newName:optional(ident) : command => do
     addAndCompile $  Declaration.defnDecl { info with name := newName }
   | ConstantInfo.thmInfo info =>
     addAndCompile $  Declaration.thmDecl { info with name := newName }
-  | x => throwError "Constant {oldName} is not a definition or theorem."
+  | _ => throwError "Constant {oldName} is not a definition or theorem."

--- a/Mathlib/Tactic/Ring.lean
+++ b/Mathlib/Tactic/Ring.lean
@@ -110,8 +110,8 @@ def reflConv (e : HornerExpr) : RingM (HornerExpr × Expr) := do pure (e, ← mk
 
 /-- Pretty printer for `horner_expr`. -/
 def pp : HornerExpr → MetaM Format
-| (const e c) => pure $ toString c
-| (xadd e a x (_, n) b) => do
+| const _ c => pure $ toString c
+| xadd _ a x (_, n) b => do
   let pa ← a.pp
   let pb ← b.pp
   let px ← PrettyPrinter.ppExpr x.1
@@ -132,11 +132,11 @@ by simp [h.symm, horner, pow_add, mul_assoc]
 
 /-- Evaluate `horner a n x b` where `a` and `b` are already in normal form. -/
 def evalHorner : HornerExpr → Expr × ℕ → Expr × ℕ → HornerExpr → RingM (HornerExpr × Expr)
-| ha@(const a coeff), x, n, b => do
+| ha@(const _ coeff), x, n, b => do
   if coeff = 0 then
     return (b, ← mkAppCS ``zero_horner #[x.1, n.1, b])
   else (← xadd' ha x n b).reflConv
-| ha@(xadd a a₁ x₁ n₁ b₁), x, n, b => do
+| ha@(xadd _ a₁ x₁ n₁ b₁), x, n, b => do
   if x₁.2 = x.2 ∧ b₁.e.numeral? = some 0 then do
     let n' := mkRawNatLit (n₁.2 + n.2)
     let h ← mkEqRefl n'
@@ -198,7 +198,6 @@ partial def evalAdd : HornerExpr → HornerExpr → RingM (HornerExpr × Expr)
     return (← xadd' a x n b',
       ← mkAppCS ``horner_add_const #[a, x.1, n.1, b, e₂, b', h])
 | he₁@(xadd e₁ a₁ x₁ n₁ b₁), he₂@(xadd e₂ a₂ x₂ n₂ b₂) => do
-  let c ← get
   if x₁.2 < x₂.2 then
     let (b', h) ← evalAdd b₁ he₂
     return (← xadd' a₁ x₁ n₁ b',
@@ -211,7 +210,6 @@ partial def evalAdd : HornerExpr → HornerExpr → RingM (HornerExpr × Expr)
     let k := n₂.2 - n₁.2
     let ek := mkRawNatLit k
     let h₁ ← mkEqRefl n₂.1
-    let c ← read
     let α0 ← mkAppOptM ``OfNat.ofNat #[(← read).α, mkRawNatLit 0, none]
     let (a', h₂) ← evalAdd a₁ (← xadd' a₂ x₁ (ek, k) (const α0 0))
     let (b', h₃) ← evalAdd b₁ b₂
@@ -246,10 +244,10 @@ by simp [horner, ← h₁, ← h₂, add_mul, mul_assoc, mul_comm c]
 
 /-- Evaluate `k * a` where `k` is a rational numeral and `a` is in normal form. -/
 def evalConstMul (k : Expr × ℕ) : HornerExpr → RingM (HornerExpr × Expr)
-| (const e coeff) => do
+| const e coeff => do
   let (e', p) ← NormNum.eval $ ← mkMul k.1 e
   return (const e' (k.2 * coeff), p)
-| (xadd e a x n b) => do
+| xadd _ a x n b => do
   let (a', h₁) ← evalConstMul k a
   let (b', h₂) ← evalConstMul k b
   return (← xadd' a' x n b',
@@ -289,7 +287,7 @@ partial def evalMul : HornerExpr → HornerExpr → RingM (HornerExpr × Expr)
     let p ←  mkAppM ``one_mul #[e₂]
     return (e₂, p)
   else evalConstMul (e₁, c₁) e₂
-| e₁, he₂@(const e₂ c₂) => do
+| e₁, he₂@(const e₂ _) => do
   let p₁ ← mkAppM ``mul_comm #[e₁, e₂]
   let (e', p₂) ← evalMul he₂ e₁
   let p ← mkEqTrans p₁ p₂

--- a/Mathlib/Tactic/Sat/FromLRAT.lean
+++ b/Mathlib/Tactic/Sat/FromLRAT.lean
@@ -120,8 +120,9 @@ def Fmla.proof (f : Fmla) (c : Clause) : Prop :=
 
 /-- If `f` subsumes `c` (i.e. `c ∈ f`), then `f.proof c`. -/
 theorem Fmla.proof_of_subsumes (H : Fmla.subsumes f (Fmla.one c)) : f.proof c :=
-  fun v h => h.1 _ $ H.1 _ $ List.Mem.head ..
+  fun _ h => h.1 _ $ H.1 _ $ List.Mem.head ..
 
+set_option linter.unusedVariables false in -- FIXME: lean4#1214
 /-- The core unit-propagation step.
 
 We have a local context of assumptions `¬l'` (sometimes called an assignment)
@@ -146,9 +147,9 @@ def Valuation.implies (v : Valuation) (p : Prop) : List Prop → Nat → Prop
 /-- `Valuation.mk [a, b, c]` is a valuation which is `a` at 0, `b` at 1 and `c` at 2, and false
 everywhere else. -/
 def Valuation.mk : List Prop → Valuation
-| [], n => False
-| a::as, 0 => a
-| a::as, n+1 => mk as n
+| [], _ => False
+| a::_, 0 => a
+| _::as, n+1 => mk as n
 
 /-- The fundamental relationship between `mk` and `implies`:
 `(mk ps).implies p ps 0` is equivalent to `p`. -/
@@ -433,7 +434,7 @@ partial def buildReify (ctx ctx' proof : Expr) (nvars : Nat) : Expr × Expr := I
   | 0 => e
   | n+1 => mkPS (depth+1) (mkApp2 cons (mkBVar depth) e) n
   pr := mkApp5 (mkConst ``Sat.Fmla.refute) e (mkPS 0 nil nvars) ctx proof pr
-  for i in [0:nvars] do
+  for _ in [0:nvars] do
     e := mkForall `a default (mkSort levelZero) e
     pr := mkLambda `a default (mkSort levelZero) pr
   pure (e, pr)
@@ -516,7 +517,7 @@ def parseDimacs : Parsec (Nat × Array (Array Int)) := do
   let nvars ← parseNat <* ws
   let nclauses ← parseNat <* ws
   let mut clauses := Array.mkEmpty nclauses
-  for i in [:nclauses] do
+  for _ in [:nclauses] do
     clauses := clauses.push (← parseInts)
   pure (nvars, clauses)
 

--- a/Mathlib/Tactic/Simps.lean
+++ b/Mathlib/Tactic/Simps.lean
@@ -49,9 +49,8 @@ initialize simpsAttr : ParametricAttribute (Array Name) ←
   registerParametricAttribute {
     name := `simps
     descr := "Automatically derive lemmas specifying the projections of this declaration.",
-    getParam := fun decl stx =>
-      match stx with
-        -- TODO implement support for `config := ...`
-        | `(attr|simps $[$ids]*) => pure $ ids.map (·.getId.eraseMacroScopes)
-        | _ => throwError "unexpected simps syntax {stx}"
+    getParam := fun
+    -- TODO implement support for `config := ...`
+    | _, `(attr|simps $[$ids]*) => pure $ ids.map (·.getId.eraseMacroScopes)
+    | _, stx => throwError "unexpected simps syntax {stx}"
   }

--- a/Mathlib/Tactic/SolveByElim.lean
+++ b/Mathlib/Tactic/SolveByElim.lean
@@ -17,7 +17,7 @@ open Lean.Elab.Tactic
 
 /-- Attempt to solve the given metavariable by repeating applying a local hypothesis. -/
 def Lean.Meta.solveByElim : Nat → MVarId → MetaM Unit
-  | 0, mvarId => throwError "fail"
+  | 0, _ => throwError "fail"
   | (n+1), mvarId => do
       -- We attempt to find a local declaration which can be applied,
       -- and for which all resulting sub-goals can be discharged using `solveByElim n`.

--- a/Mathlib/Tactic/TryThis.lean
+++ b/Mathlib/Tactic/TryThis.lean
@@ -20,7 +20,7 @@ open Lean Elab Elab.Tactic PrettyPrinter Meta
 
 partial def replaceMVarsByUnderscores [Monad m] [MonadQuotation m]
     (s : Syntax) : m Syntax := do
-  if s matches `(?$mvar:ident) then
+  if s matches `(?$_:ident) then
     `(?_)
   else if let Syntax.node _ kind args := s then
     mkNode kind <$> args.mapM replaceMVarsByUnderscores

--- a/Mathlib/Testing/SlimCheck/Gen.lean
+++ b/Mathlib/Testing/SlimCheck/Gen.lean
@@ -68,8 +68,8 @@ by the size parameter of `Gen`. -/
 def arrayOf (x : Gen α) : Gen (Array α) := do
   let sz ← choose Nat 0 (←getSize) (Nat.zero_le _)
   let mut res := #[]
-  for i in [0:sz] do
-    res := res.push (←x)
+  for _ in [0:sz] do
+    res := res.push (← x)
   pure res
 
 /-- Create an `List` of examples using `x`. The size is controlled
@@ -79,12 +79,12 @@ def listOf (x : Gen α) : Gen (List α) :=
 
 /-- Given a list of example generators, choose one to create an example. -/
 def oneOf (xs : Array (Gen α)) (pos : 0 < xs.size := by decide) : Gen α := do
-  let ⟨x, h1, h2⟩ ← chooseNatLt 0 xs.size pos
+  let ⟨x, _, h2⟩ ← chooseNatLt 0 xs.size pos
   xs.get ⟨x, h2⟩
 
 /-- Given a list of examples, choose one to create an example. -/
 def elements (xs : List α) (pos : 0 < xs.length) : Gen α := do
-  let ⟨x, h1, h2⟩ ← chooseNatLt 0 xs.length pos
+  let ⟨x, _, h2⟩ ← chooseNatLt 0 xs.length pos
   pure $ xs.get ⟨x, h2⟩
 
 open List in
@@ -93,7 +93,7 @@ def permutationOf : (xs : List α) → Gen { ys // ys ~ xs }
 | [] => pure ⟨[], Perm.nil⟩
 | x::xs => do
   let ⟨ys, h1⟩ ← permutationOf xs
-  let ⟨n, h2, h3⟩ ← choose Nat 0 ys.length (Nat.zero_le _)
+  let ⟨n, _, h3⟩ ← choose Nat 0 ys.length (Nat.zero_le _)
   pure ⟨insertNth n x ys, Perm.trans (perm_insertNth h3) (Perm.cons _ h1)⟩
 
 /-- Given two generators produces a tuple consisting out of the result of both -/

--- a/Mathlib/Testing/SlimCheck/Testable.lean
+++ b/Mathlib/Testing/SlimCheck/Testable.lean
@@ -127,7 +127,7 @@ class Testable (p : Prop) where
   run (cfg : Configuration) (minimize : Bool) : Gen (TestResult p)
 
 @[nolint unusedArguments]
-def NamedBinder (n : String) (p : Prop) : Prop := p
+def NamedBinder (_n : String) (p : Prop) : Prop := p
 
 namespace TestResult
 
@@ -135,7 +135,7 @@ def toString : TestResult p → String
 | success (PSum.inl _) => "success (no proof)"
 | success (PSum.inr _) => "success (proof)"
 | gaveUp n => s!"gave {n} times"
-| failure _ counters n => s!"failed {counters}"
+| failure _ counters _ => s!"failed {counters}"
 
 instance : ToString (TestResult p) := ⟨toString⟩
 
@@ -339,11 +339,15 @@ instance varTestable [SampleableExt α] {β : α → Prop} [∀ x, Testable (β 
     pure $ addVarInfo var finalX (· $ SampleableExt.interp finalX) finalR
 
 /-- Test a universal property about propositions -/
-instance propVarTestable {β : Prop → Prop} [∀ b : Bool, Testable (β b)] : Testable (NamedBinder var $ ∀ p : Prop, β p) where
+instance propVarTestable {β : Prop → Prop} [∀ b : Bool, Testable (β b)] :
+  Testable (NamedBinder var $ ∀ p : Prop, β p)
+where
   run := λ cfg min =>
     imp (λ h (b : Bool) => h b) <$> Testable.runProp (NamedBinder var $ ∀ b : Bool, β b) cfg min
 
-instance (priority := high) unusedVarTestable [Nonempty α] [Testable β] : Testable (NamedBinder var $ ∀ x : α, β) where
+instance (priority := high) unusedVarTestable [Nonempty α] [Testable β] :
+  Testable (NamedBinder var $ ∀ _x : α, β)
+where
   run := λ cfg min => do
     if cfg.traceDiscarded || cfg.traceSuccesses then
       slimTrace s!"{var} is unused"
@@ -352,7 +356,7 @@ instance (priority := high) unusedVarTestable [Nonempty α] [Testable β] : Test
     pure $ imp (· $ Classical.ofNonempty) finalR (PSum.inr $ λ x _ => x)
 
 instance (priority := low) decidableTestable {p : Prop} [PrintableProp p] [Decidable p] : Testable p where
-  run := λ cfg min =>
+  run := λ _ _ =>
     if h : p then
       pure $ success (PSum.inr h)
     else
@@ -468,7 +472,7 @@ partial def addDecorations (e : Expr) : Expr :=
 that the goal should be satisfied with a proposition equivalent to `p`
 with added annotations. -/
 @[nolint unusedArguments]
-abbrev DecorationsOf (p : Prop) := Prop
+abbrev DecorationsOf (_p : Prop) := Prop
 
 open Elab.Tactic
 open Meta

--- a/Mathlib/Util/Export.lean
+++ b/Mathlib/Util/Export.lean
@@ -94,7 +94,7 @@ def exportLevel (L : Level) : ExportM Nat := do
       let i ← alloc L; IO.println s!"{i} #UIM {← exportLevel l₁} {← exportLevel l₂}"; pure i
     | Level.param n _ =>
       let i ← alloc L; IO.println s!"{i} #UP {← exportName n}"; pure i
-    | Level.mvar n _ => unreachable!
+    | Level.mvar _ _ => unreachable!
 
 def biStr : BinderInfo → String
 | BinderInfo.default        => "#BD"
@@ -122,18 +122,18 @@ partial def exportExpr (E : Expr) : ExportM Nat := do
       IO.println s; pure i
     | Expr.app e₁ e₂ _ =>
       let i ← alloc E; IO.println s!"{i} #EA {← exportExpr e₁} {← exportExpr e₂}"; pure i
-    | Expr.lam n e₁ e₂ d =>
+    | Expr.lam _ e₁ e₂ d =>
       let i ← alloc E
       IO.println s!"{i} #EL {biStr d.binderInfo} {← exportExpr e₁} {← exportExpr e₂}"; pure i
-    | Expr.forallE n e₁ e₂ d =>
+    | Expr.forallE _ e₁ e₂ d =>
       let i ← alloc E
       IO.println s!"{i} #EP {biStr d.binderInfo} {← exportExpr e₁} {← exportExpr e₂}"; pure i
-    | Expr.letE n e₁ e₂ e₃ _ =>
+    | Expr.letE _ e₁ e₂ e₃ _ =>
       let i ← alloc E
       IO.println s!"{i} #EP {← exportExpr e₁} {← exportExpr e₂} {← exportExpr e₃}"; pure i
     | Expr.lit (Literal.natVal n) _ => let i ← alloc E; IO.println s!"{i} #EN {n}"; pure i
     | Expr.lit (Literal.strVal s) _ => let i ← alloc E; IO.println s!"{i} #ET {s}"; pure i
-    | Expr.mdata _ e _ => unreachable!
+    | Expr.mdata _ _ _ => unreachable!
     | Expr.proj n k e _ =>
       let i ← alloc E; IO.println s!"{i} #EJ {← exportName n} {k} {← exportExpr e}"; pure i
 
@@ -148,7 +148,7 @@ partial def exportDef (n : Name) : ExportM Unit := do
   | defnInfo    val => defn "#DEF" val.name val.type val.value val.levelParams
   | thmInfo     val => defn "#THM" val.name val.type val.value val.levelParams
   | opaqueInfo  val => defn "#CN" val.name val.type val.value val.levelParams
-  | quotInfo    val =>
+  | quotInfo    _ =>
     IO.println "#QUOT"
     for n in [``Quot, ``Quot.mk, ``Quot.lift, ``Quot.ind] do
       insert n
@@ -177,7 +177,7 @@ where
     | n => s!"#MUT {val.numParams} {n}"
     for j in is do insert j; insert (mkRecName j)
     for j in is do
-      let vals ← getConstInfoInduct j
+      let val ← getConstInfoInduct j
       s := s ++ s!" {← exportName val.name} {← exportExpr val.type} {val.ctors.length}"
       for c in val.ctors do
         insert c

--- a/Mathlib/Util/WhatsNew.lean
+++ b/Mathlib/Util/WhatsNew.lean
@@ -52,7 +52,7 @@ private def mkHeader' (kind : String) (id : Name) (levelParams : List Name) (typ
 private def printDefLike (kind : String) (id : Name) (levelParams : List Name) (type : Expr) (value : Expr) (safety := DefinitionSafety.safe) : CoreM MessageData :=
   return (← mkHeader kind id levelParams type safety) ++ " :=" ++ Format.line ++ value
 
-private def printInduct (id : Name) (levelParams : List Name) (numParams : Nat) (numIndices : Nat) (type : Expr)
+private def printInduct (id : Name) (levelParams : List Name) (_numParams : Nat) (_numIndices : Nat) (type : Expr)
     (ctors : List Name) (isUnsafe : Bool) : CoreM MessageData := do
   let mut m ← mkHeader' "inductive" id levelParams type isUnsafe
   m := m ++ Format.line ++ "constructors:"
@@ -70,7 +70,7 @@ private def printIdCore (id : Name) : ConstantInfo → CoreM MessageData
     printDefLike "theorem" id us t v
   | ConstantInfo.opaqueInfo  { levelParams := us, type := t, isUnsafe := u, .. } =>
     mkHeader' "constant" id us t u
-  | ConstantInfo.quotInfo  { kind := kind, levelParams := us, type := t, .. } =>
+  | ConstantInfo.quotInfo  { levelParams := us, type := t, .. } =>
     mkHeader' "Quotient primitive" id us t false
   | ConstantInfo.ctorInfo { levelParams := us, type := t, isUnsafe := u, .. } =>
     mkHeader' "constructor" id us t u

--- a/test/rcases.lean
+++ b/test/rcases.lean
@@ -11,10 +11,10 @@ example (x : α × β × γ) : True := by
   trivial
 
 example (x : α × β × γ) : True := by
-  rcases x with ⟨a, -, c⟩
+  rcases x with ⟨(a : α) : id α, -, c : id γ⟩
   guard_hyp a : α
   fail_if_success have : β := by assumption
-  guard_hyp c : γ
+  guard_hyp c : id γ
   trivial
 
 example (x : (α × β) × γ) : True := by
@@ -108,8 +108,8 @@ example (i j : Nat) : (Σ' x, i ≤ x ∧ x ≤ j) → i ≤ j := by
 example (x : Quot fun _ _ : α => True) (h : x = x): x = x := by
   rcases x with ⟨z⟩
   guard_hyp z : α
-  guard_hyp h : Quot.mk (fun x x => True) z = Quot.mk (fun x x => True) z
-  guard_target == Quot.mk (fun x x => True) z = Quot.mk (fun x x => True) z
+  guard_hyp h : Quot.mk (fun _ _ => True) z = Quot.mk (fun _ _ => True) z
+  guard_target == Quot.mk (fun _ _ => True) z = Quot.mk (fun _ _ => True) z
   exact h
 
 example (n : Nat) : True := by
@@ -121,9 +121,9 @@ example (n : Nat) : True := by
   {trivial}; trivial
 
 open Lean Elab Tactic in
-elab "checkNumHyps " n:num : tactic => liftMetaMAtMain fun g => do
+elab "checkNumHyps " n:num : tactic => liftMetaMAtMain fun _ => do
   -- +1 because the _example recursion decl is in the list
-  guard $ (← getLCtx).foldl (fun i d => i+1) 0 = n.toNat + 1
+  guard $ (← getLCtx).foldl (fun i _ => i+1) 0 = n.toNat + 1
 
 example (h : ∃ x : Nat, x = x ∧ 1 = 1) : True := by
   rcases h with ⟨-, _⟩


### PR DESCRIPTION
This makes mathlib pass the new unused variables linter added to lean 4 core.