### PR TITLE
[Merged by Bors] - feat: port the 'alias' command

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -57,6 +57,7 @@ import Mathlib.Mathport.Attributes
 import Mathlib.Mathport.Rename
 import Mathlib.Mathport.SpecialNames
 import Mathlib.Mathport.Syntax
+import Mathlib.Tactic.Alias
 import Mathlib.Tactic.Basic
 import Mathlib.Tactic.Cache
 import Mathlib.Tactic.Cases

--- a/Mathlib/Mathport/Syntax.lean
+++ b/Mathlib/Mathport/Syntax.lean
@@ -5,6 +5,7 @@ Authors: Mario Carneiro
 -/
 import Lean.Elab.Command
 import Lean.Elab.Quotation
+import Mathlib.Tactic.Alias
 import Mathlib.Tactic.Cases
 import Mathlib.Tactic.Core
 import Mathlib.Tactic.CommandQuote
@@ -582,8 +583,6 @@ namespace Command
   (" from" (ppSpace ident)+)? (" := " str)? : command
 
 /- M -/ syntax (name := addHintTactic) "add_hint_tactic " tactic : command
-/- M -/ syntax (name := alias) "alias " ident " ← " ident* : command
-/- M -/ syntax (name := aliasLR) "alias " ident " ↔ " (".." <|> (binderIdent binderIdent)) : command
 
 /- S -/ syntax (name := explode) "#explode " ident : command
 

--- a/Mathlib/Tactic/Alias.lean
+++ b/Mathlib/Tactic/Alias.lean
@@ -1,0 +1,156 @@
+/-
+Copyright (c) 2017 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro
+-/
+import Lean.Elab.Command
+import Lean.Elab.Term
+import Lean
+
+/-!
+# The `alias` command
+
+This file defines an `alias` command, which can be used to create copies
+of a theorem or definition with different names.
+
+Syntax:
+
+```lean
+/-- doc string -/
+alias my_theorem ← alias1 alias2 ...
+```
+
+This produces defs or theorems of the form:
+
+```lean
+/-- doc string -/
+theorem alias1 : <type of my_theorem> := my_theorem
+
+/-- doc string -/
+theorem alias2 : <type of my_theorem> := my_theorem
+```
+
+Iff alias syntax:
+
+```lean
+alias A_iff_B ↔ B_of_A A_of_B
+alias A_iff_B ↔ ..
+```
+
+This gets an existing biconditional theorem `A_iff_B` and produces
+the one-way implications `B_of_A` and `A_of_B` (with no change in
+implicit arguments). A blank `_` can be used to avoid generating one direction.
+The `..` notation attempts to generate the 'of'-names automatically when the
+input theorem has the form `A_iff_B` or `A_iff_B_left` etc.
+-/
+
+namespace Tactic
+namespace Alias
+
+open Lean
+
+syntax (name := alias) "alias " ident " ← " ident* : command
+syntax (name := aliasLR) "alias " ident " ↔ " binderIdent binderIdent : command
+syntax (name := aliasLRDots) "alias " ident " ↔ " ".." : command
+
+@[commandElab «alias»] def elabAlias : Elab.Command.CommandElab
+| `(alias $name:ident ← $aliases:ident*) => do
+  let resolved ← resolveGlobalConstNoOverload name
+  let constant ← match (← Lean.getEnv).constants.find? resolved with
+                 | none => throwError "failed to resolve alias LHS"
+                 | some c => pure c
+
+  for a in aliases do
+    let decl ← match constant with
+    | Lean.ConstantInfo.defnInfo d =>
+      pure $ Lean.Declaration.defnDecl {
+        d with name := a.getId
+               value := mkConst resolved
+      }
+    | Lean.ConstantInfo.thmInfo t =>
+      pure $ Lean.Declaration.thmDecl {
+        t with name := a.getId
+               value := mkConst resolved
+      }
+    | _ => throwError "alias only works with def or theorem"
+
+    -- TODO add @alias attribute
+    Lean.addDecl decl
+
+| _ => Lean.Elab.throwUnsupportedSyntax
+
+-- Given the type of an iff decl, produce a value for one of the implication
+-- directions (determined by `iffmp`).
+def mkIffMpApp (iffmp: Name) : Expr → (Nat → Expr) → MetaM Expr
+| (Expr.forallE n varType body d), f => do
+     let rest ← mkIffMpApp iffmp body (λ n => mkApp (f (n+1)) (mkBVar n))
+     pure $ mkLambda n d.binderInfo varType rest
+| (Expr.app (Expr.app (Expr.const ``Iff _ _) e1 _) e2 _), f =>
+  pure $ mkApp3 (mkConst iffmp) e1 e2 (f 0)
+| _, _ => throwError "Target theorem must have the form `Π x y z, a ↔ b`"
+
+def aliasIff (ci : ConstantInfo) (al : Name) (isForward : Bool) : MetaM Unit := do
+  let ls := ci.levelParams
+  let t := ci.type
+  let iffmp := if isForward then ``Iff.mp else ``Iff.mpr
+  let v ← mkIffMpApp iffmp t (λ _ => mkConst ci.name (lvls := (ls.map mkLevelParam)))
+  let t' ← Meta.inferType v
+  -- TODO add @alias attribute
+  addDecl $ Lean.Declaration.thmDecl {
+      name := al
+      value := v
+      type := t'
+      levelParams := ls
+  }
+
+@[commandElab aliasLR] def elabAliasLR : Lean.Elab.Command.CommandElab
+| `(alias $name:ident ↔ $left:binderIdent $right:binderIdent ) => do
+   let resolved ← resolveGlobalConstNoOverload name
+   let constant ← match (← Lean.getEnv).constants.find? resolved with
+                  | none => throwError "failed to resolve alias LHS"
+                  | some c => pure c
+
+   Lean.Elab.Command.liftTermElabM none do
+     match left with
+     | `(binderIdent| $x:ident) =>
+       aliasIff constant x.getId true
+
+     | `(binderIdent| _) => pure ()
+
+     | _ => Lean.Elab.throwUnsupportedSyntax
+
+     match right with
+     | `(binderIdent| $x:ident) =>
+       aliasIff constant x.getId false
+
+     | `(binderIdent| _) => pure ()
+     | _ => Lean.Elab.throwUnsupportedSyntax
+
+| _ => Lean.Elab.throwUnsupportedSyntax
+
+@[commandElab aliasLRDots] def elabAliasLRDots : Lean.Elab.Command.CommandElab
+| `(alias $name:ident ↔ ..) => do
+  let resolved ← resolveGlobalConstNoOverload name
+  let constant ← match (← Lean.getEnv).constants.find? resolved with
+                 | none => throwError "failed to resolve alias LHS"
+                 | some c => pure c
+
+  let (parent, base) ← match resolved with
+                       | Name.str n s _ => pure (n,s)
+                       | _ => throwError "alias only works for string names"
+
+  let components := base.splitOn "_iff_"
+  if components.length != 2 then throwError "LHS must be of the form *_iff_*"
+  let forward := String.intercalate "_of_" components.reverse
+  let backward := String.intercalate "_of_" components
+  let forwardName := Name.mkStr parent forward
+  let backwardName := Name.mkStr parent backward
+
+  Lean.Elab.Command.liftTermElabM none do
+    aliasIff constant forwardName true
+    aliasIff constant backwardName false
+
+| _ => Lean.Elab.throwUnsupportedSyntax
+
+end Alias
+end Tactic

--- a/Mathlib/Tactic/Alias.lean
+++ b/Mathlib/Tactic/Alias.lean
@@ -79,16 +79,23 @@ syntax (name := aliasLRDots) "alias " ident " ↔ " ".." : command
 
 | _ => Lean.Elab.throwUnsupportedSyntax
 
--- Given the type of an iff decl, produce a value for one of the implication
--- directions (determined by `iffmp`).
+
+/--
+  Given the type of an iff decl, produce a value for one of the implication
+  directions (determined by `iffmp`).
+-/
 def mkIffMpApp (iffmp: Name) : Expr → (Nat → Expr) → MetaM Expr
 | (Expr.forallE n varType body d), f => do
      let rest ← mkIffMpApp iffmp body (λ n => mkApp (f (n+1)) (mkBVar n))
      pure $ mkLambda n d.binderInfo varType rest
 | (Expr.app (Expr.app (Expr.const ``Iff _ _) e1 _) e2 _), f =>
   pure $ mkApp3 (mkConst iffmp) e1 e2 (f 0)
-| _, _ => throwError "Target theorem must have the form `Π x y z, a ↔ b`"
+| _, _ => throwError "Target theorem must have the form `∀ x y z, a ↔ b`"
 
+/--
+  Given a constant represent an iff decl, adds a decl for one of the implication
+  directions.
+-/
 def aliasIff (ci : ConstantInfo) (al : Name) (isForward : Bool) : MetaM Unit := do
   let ls := ci.levelParams
   let t := ci.type

--- a/Mathlib/Tactic/Alias.lean
+++ b/Mathlib/Tactic/Alias.lean
@@ -63,17 +63,18 @@ syntax (name := aliasLRDots) "alias " ident " ↔ " ".." : command
 | `(alias $name:ident ← $aliases:ident*) => do
   let resolved ← resolveGlobalConstNoOverload name
   let constant ← getConstInfo resolved
+  let ns ← getCurrNamespace
 
   for a in aliases do
     let decl ← match constant with
     | Lean.ConstantInfo.defnInfo d =>
       pure $ .defnDecl {
-        d with name := a.getId
+        d with name := (ns.append a.getId)
                value := mkConst resolved (d.levelParams.map mkLevelParam)
       }
     | Lean.ConstantInfo.thmInfo t =>
       pure $ .thmDecl {
-        t with name := a.getId
+        t with name := (ns.append a.getId)
                value := mkConst resolved (t.levelParams.map mkLevelParam)
       }
     | _ => throwError "alias only works with def or theorem"

--- a/Mathlib/Tactic/Alias.lean
+++ b/Mathlib/Tactic/Alias.lean
@@ -116,10 +116,11 @@ def aliasIff (ci : ConstantInfo) (al : Name) (isForward : Bool) : MetaM Unit := 
 | `(alias $name:ident ↔ $left:binderIdent $right:binderIdent ) => do
    let resolved ← resolveGlobalConstNoOverload name
    let constant ← getConstInfo resolved
+   let ns ← getCurrNamespace
 
    Lean.Elab.Command.liftTermElabM none do
-     if let `(binderIdent| $x:ident) := left then aliasIff constant x.getId true
-     if let `(binderIdent| $x:ident) := right then aliasIff constant x.getId false
+     if let `(binderIdent| $x:ident) := left then aliasIff constant (ns.append x.getId) true
+     if let `(binderIdent| $x:ident) := right then aliasIff constant (ns.append x.getId) false
 
 | _ => Lean.Elab.throwUnsupportedSyntax
 

--- a/Mathlib/Tactic/Alias.lean
+++ b/Mathlib/Tactic/Alias.lean
@@ -121,20 +121,8 @@ def aliasIff (ci : ConstantInfo) (al : Name) (isForward : Bool) : MetaM Unit := 
    let constant ← getConstInfo resolved
 
    Lean.Elab.Command.liftTermElabM none do
-     match left with
-     | `(binderIdent| $x:ident) =>
-       aliasIff constant x.getId true
-
-     | `(binderIdent| _) => pure ()
-
-     | _ => Lean.Elab.throwUnsupportedSyntax
-
-     match right with
-     | `(binderIdent| $x:ident) =>
-       aliasIff constant x.getId false
-
-     | `(binderIdent| _) => pure ()
-     | _ => Lean.Elab.throwUnsupportedSyntax
+     if let `(binderIdent| $x:ident) := left then aliasIff constant x.getId true
+     if let `(binderIdent| $x:ident) := right then aliasIff constant x.getId false
 
 | _ => Lean.Elab.throwUnsupportedSyntax
 

--- a/Mathlib/Tactic/Alias.lean
+++ b/Mathlib/Tactic/Alias.lean
@@ -49,10 +49,16 @@ namespace Alias
 
 open Lean
 
+/-- Adds some copies of a theorem or definition. -/
 syntax (name := alias) "alias " ident " ← " ident* : command
+
+/-- Adds one-way implication declarations. -/
 syntax (name := aliasLR) "alias " ident " ↔ " binderIdent binderIdent : command
+
+/-- Adds one-way implication declarations, inferring names for them. -/
 syntax (name := aliasLRDots) "alias " ident " ↔ " ".." : command
 
+/-- Elaborates an `alias ←` command. -/
 @[commandElab «alias»] def elabAlias : Elab.Command.CommandElab
 | `(alias $name:ident ← $aliases:ident*) => do
   let resolved ← resolveGlobalConstNoOverload name
@@ -110,6 +116,7 @@ def aliasIff (ci : ConstantInfo) (al : Name) (isForward : Bool) : MetaM Unit := 
       levelParams := ls
   }
 
+/-- Elaborates an `alias ↔` command. -/
 @[commandElab aliasLR] def elabAliasLR : Lean.Elab.Command.CommandElab
 | `(alias $name:ident ↔ $left:binderIdent $right:binderIdent ) => do
    let resolved ← resolveGlobalConstNoOverload name
@@ -135,6 +142,7 @@ def aliasIff (ci : ConstantInfo) (al : Name) (isForward : Bool) : MetaM Unit := 
 
 | _ => Lean.Elab.throwUnsupportedSyntax
 
+/-- Elaborates an `alias ↔ ..` command. -/
 @[commandElab aliasLRDots] def elabAliasLRDots : Lean.Elab.Command.CommandElab
 | `(alias $name:ident ↔ ..) => do
   let resolved ← resolveGlobalConstNoOverload name

--- a/Mathlib/Tactic/Alias.lean
+++ b/Mathlib/Tactic/Alias.lean
@@ -67,12 +67,12 @@ syntax (name := aliasLRDots) "alias " ident " ↔ " ".." : command
   for a in aliases do
     let decl ← match constant with
     | Lean.ConstantInfo.defnInfo d =>
-      pure $ Lean.Declaration.defnDecl {
+      pure $ .defnDecl {
         d with name := a.getId
                value := mkConst resolved (d.levelParams.map mkLevelParam)
       }
     | Lean.ConstantInfo.thmInfo t =>
-      pure $ Lean.Declaration.thmDecl {
+      pure $ .thmDecl {
         t with name := a.getId
                value := mkConst resolved (t.levelParams.map mkLevelParam)
       }
@@ -107,7 +107,7 @@ def aliasIff (ci : ConstantInfo) (al : Name) (isForward : Bool) : MetaM Unit := 
   let v ← mkIffMpApp iffmp t (λ _ => mkConst ci.name (lvls := (ls.map mkLevelParam)))
   let t' ← Meta.inferType v
   -- TODO add @alias attribute
-  addDecl $ Lean.Declaration.thmDecl {
+  addDecl $ .thmDecl {
       name := al
       value := v
       type := t'

--- a/test/Alias.lean
+++ b/test/Alias.lean
@@ -4,7 +4,7 @@ namespace Alias
 namespace A
 
 theorem foo : 1 + 1 = 2 := rfl
-alias foo ← foo1 foo2 foo3
+alias foo ← foo1 foo2 foo3 _root_.B.foo4
 example : 1 + 1 = 2 := foo1
 example : 1 + 1 = 2 := foo2
 example : 1 + 1 = 2 := foo3
@@ -40,8 +40,19 @@ end A
 
 -- test namespacing
 example : 1 + 1 = 2 := A.foo1
+example : 1 + 1 = 2 := B.foo4
 example : True → True ∧ True := A.a_and_a_of_a True
 example : True → True ∧ True := A.forward True
 example : True ∧ True → True := A.backward True
+
+namespace C
+
+alias A.a_iff_a_and_a ↔ _root_.B.forward2 _
+alias A.a_iff_a_and_a ↔ _ _root_.B.backward2
+
+end C
+
+example : True → True ∧ True := B.forward2 True
+example : True ∧ True → True := B.backward2 True
 
 end Alias

--- a/test/Alias.lean
+++ b/test/Alias.lean
@@ -39,5 +39,7 @@ example : True ∧ True → True := a_of_a_and_a True
 end A
 
 example : True → True ∧ True := A.a_and_a_of_a True
+example : True → True ∧ True := A.forward True
+example : True ∧ True → True := A.backward True
 
 end Alias

--- a/test/Alias.lean
+++ b/test/Alias.lean
@@ -38,6 +38,8 @@ example : True ∧ True → True := a_of_a_and_a True
 
 end A
 
+-- test namespacing
+example : 1 + 1 = 2 := A.foo1
 example : True → True ∧ True := A.a_and_a_of_a True
 example : True → True ∧ True := A.forward True
 example : True ∧ True → True := A.backward True

--- a/test/Alias.lean
+++ b/test/Alias.lean
@@ -1,6 +1,7 @@
 import Mathlib
 
 namespace Alias
+namespace A
 
 theorem foo : 1 + 1 = 2 := rfl
 alias foo ← foo1 foo2 foo3
@@ -34,5 +35,9 @@ example : True ∧ True → True := backward True
 alias a_iff_a_and_a ↔ ..
 example : True → True ∧ True := a_and_a_of_a True
 example : True ∧ True → True := a_of_a_and_a True
+
+end A
+
+example : True → True ∧ True := A.a_and_a_of_a True
 
 end Alias

--- a/test/Alias.lean
+++ b/test/Alias.lean
@@ -1,0 +1,38 @@
+import Mathlib
+
+namespace Alias
+
+theorem foo : 1 + 1 = 2 := rfl
+alias foo ← foo1 foo2 foo3
+example : 1 + 1 = 2 := foo1
+example : 1 + 1 = 2 := foo2
+example : 1 + 1 = 2 := foo3
+
+def bar : Nat := 5
+alias bar ← bar1 bar2
+example : bar1 = 5 := rfl
+example : bar2 = 5 := rfl
+
+theorem baz (x : Nat) : x = x := rfl
+alias baz ← baz1
+example : 3 = 3 := baz1 3
+
+theorem ab_iff_ba {t : Type} {a b : t} : a = b ↔ b = a := Iff.intro Eq.symm Eq.symm
+alias ab_iff_ba ↔ ba_of_ab ab_of_ba
+example {a b : Nat} : a = b → b = a := ba_of_ab
+example {t : Type} {a b : t} : b = a → a = b := ab_of_ba
+
+theorem a_iff_a_and_a (a : Prop) : a ↔ a ∧ a :=
+  Iff.intro (λ x => ⟨x,x⟩) (λ x => x.1)
+
+alias a_iff_a_and_a ↔ forward _
+alias a_iff_a_and_a ↔ _ backward
+
+example : True → True ∧ True := forward True
+example : True ∧ True → True := backward True
+
+alias a_iff_a_and_a ↔ ..
+example : True → True ∧ True := a_and_a_of_a True
+example : True ∧ True → True := a_of_a_and_a True
+
+end Alias


### PR DESCRIPTION
Compare to https://github.com/leanprover-community/mathlib/blob/07c83c81c0016c1ac08e8c9c3f1260c2f4c6ac7f/src/tactic/alias.lean

The `mkIffMpApp` and `aliasIff` functions are direct translations of the mathlib3 versions.