### PR TITLE
[Merged by Bors] - fix: make `(command|...) produce correct type

### DIFF
--- a/Mathlib/Tactic/CommandQuote.lean
+++ b/Mathlib/Tactic/CommandQuote.lean
@@ -5,10 +5,10 @@ Authors: Mario Carneiro
 -/
 import Lean
 
-namespace Lean
+open Lean Parser
 
-@[termParser default+1] def Parser.Term.Command.quot : Parser :=
+@[termParser default+1] def command.quot : Parser :=
   leading_parser "`(command|" >> incQuotDepth commandParser >> ")"
 
-@[termElab Command.quot] def Elab.Term.elabCommandQuot : TermElab :=
+@[termElab command.quot] def Lean.Elab.Term.elabCommandQuot : TermElab :=
   adaptExpander Quotation.stxQuot.expand

--- a/Mathlib/Tactic/CommandQuote.lean
+++ b/Mathlib/Tactic/CommandQuote.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
 import Lean
+import Mathlib.Tactic.Lint.Basic
 
 open Lean Parser
 

--- a/Mathlib/Tactic/CommandQuote.lean
+++ b/Mathlib/Tactic/CommandQuote.lean
@@ -4,10 +4,13 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
 import Lean
+import Mathlib.Tactic.Lint
 
 open Lean Parser
 
 @[termParser default+1] def command.quot : Parser :=
   leading_parser "`(command|" >> incQuotDepth commandParser >> ")"
+
+attribute [nolint docBlame] command.quot command.quot.parenthesizer command.quot.formatter
 
 elab_stx_quot command.quot

--- a/Mathlib/Tactic/CommandQuote.lean
+++ b/Mathlib/Tactic/CommandQuote.lean
@@ -10,5 +10,4 @@ open Lean Parser
 @[termParser default+1] def command.quot : Parser :=
   leading_parser "`(command|" >> incQuotDepth commandParser >> ")"
 
-@[termElab command.quot] def Lean.Elab.Term.elabCommandQuot : TermElab :=
-  adaptExpander Quotation.stxQuot.expand
+elab_stx_quot command.quot

--- a/Mathlib/Tactic/CommandQuote.lean
+++ b/Mathlib/Tactic/CommandQuote.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
 import Lean
-import Mathlib.Tactic.Lint
 
 open Lean Parser
 


### PR DESCRIPTION
Apparently the elaborated type of a syntax quotation depends on the kind name, which needs to be `command.quot` so that we get ``TSyntax `command``.