### PR TITLE
[Merged by Bors] - feat: `haveI` and `letI` syntax

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -68,6 +68,7 @@ import Mathlib.Tactic.Core
 import Mathlib.Tactic.Ext
 import Mathlib.Tactic.Find
 import Mathlib.Tactic.Have
+import Mathlib.Tactic.HaveI
 import Mathlib.Tactic.IrreducibleDef
 import Mathlib.Tactic.LeftRight
 import Mathlib.Tactic.LibrarySearch

--- a/Mathlib/Data/Array/Basic.lean
+++ b/Mathlib/Data/Array/Basic.lean
@@ -1,4 +1,5 @@
 import Mathlib.Data.List.Basic
+import Mathlib.Tactic.HaveI
 
 macro_rules | `($x[$i]'$h) => `(getElem $x $i $h)
 
@@ -38,7 +39,8 @@ theorem data_get?_eq_getElem? (a : Array α) (i : Nat) : a.data.get? i = a[i]? :
   by_cases i < a.size <;> simp_all [getElem?_pos, getElem?_neg, List.get?_eq_get] <;> rfl
 
 theorem get_push_lt (a : Array α) (x : α) (i : Nat) (h : i < a.size) :
-    (a.push x)[i]'(by simp_all [Nat.lt_succ_iff, le_of_lt]) = a[i] := by
+    haveI : i < (a.push x).size := by simp_all [Nat.lt_succ_iff, le_of_lt]
+    (a.push x)[i] = a[i] := by
   simp only [push, ← data_get_eq_getElem, List.concat_eq_append]
   simp [data_get_eq_getElem, List.get_append, getElem?_pos, h]
 

--- a/Mathlib/Tactic/HaveI.lean
+++ b/Mathlib/Tactic/HaveI.lean
@@ -1,0 +1,53 @@
+/-
+Copyright (c) 2022 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Gabriel Ebner
+-/
+import Lean
+open Lean Elab Parser Term Meta Macro
+
+/-!
+Defines variants of `have` and `let` syntax which do not produce `let_fun` or `let` bindings,
+but instead inline the value instead.
+
+This is useful to declare local instances and proofs in theorem statements
+and subgoals, where the extra binding is inconvenient.
+-/
+
+namespace Mathlib.Tactic
+
+/-- `haveI` behaves like `have`, but inlines the value instead of producing a `let_fun` term. -/
+@[termParser] def «haveI» := leading_parser withPosition ("haveI " >> haveDecl) >> optSemicolon termParser
+/-- `letI` behaves like `let`, but inlines the value instead of producing a `let_fun` term. -/
+@[termParser] def «letI» := leading_parser withPosition ("letI " >> haveDecl) >> optSemicolon termParser
+
+macro_rules
+  | `(haveI $_ : $_ := $_; $_) => throwUnsupported -- handled by elab
+  | `(haveI $[: $ty]? := $val; $body) => `(haveI $(mkIdent `this) $[: $ty]? := $val; $body)
+  | `(haveI $x := $val; $body) => `(haveI $x : _ := $val; $body)
+  | `(haveI $decl:haveDecl; $body) => `(haveI x := have $decl:haveDecl; x; $body)
+
+macro_rules
+  | `(letI $_ : $_ := $_; $_) => throwUnsupported -- handled by elab
+  | `(letI $[: $ty]? := $val; $body) => `(letI $(mkIdent `this) $[: $ty]? := $val; $body)
+  | `(letI $x := $val; $body) => `(letI $x : _ := $val; $body)
+  | `(letI $decl:haveDecl; $body) => `(letI x := have $decl:haveDecl; x; $body)
+
+elab_rules <= expectedType
+  | `(haveI $x : $ty := $val; $body) => do
+    let ty ← elabType ty
+    let val ← elabTermEnsuringType val ty
+    withLocalDeclD x.getId ty fun x => do
+      return (← abstract (← elabTerm body expectedType) #[x]).instantiate #[val]
+
+elab_rules <= expectedType
+  | `(letI $x : $ty := $val; $body) => do
+    let ty ← elabType ty
+    let val ← elabTermEnsuringType val ty
+    withLetDecl x.getId ty val fun x => do
+      return (← abstract (← elabTerm body expectedType) #[x]).instantiate #[val]
+
+/-- `haveI` behaves like `have`, but inlines the value instead of producing a `let_fun` term. -/
+macro "haveI " d:haveDecl : tactic => `(refine_lift haveI $d:haveDecl; ?_)
+/-- `letI` behaves like `let`, but inlines the value instead of producing a `let_fun` term. -/
+macro "letI " d:haveDecl : tactic => `(refine_lift letI $d:haveDecl; ?_)

--- a/Mathlib/Tactic/Lint/Misc.lean
+++ b/Mathlib/Tactic/Lint/Misc.lean
@@ -60,6 +60,8 @@ We skip all declarations that contain `sorry` in their value. -/
   test declName := do
     if (← isAutoDecl declName) || isGlobalInstance (← getEnv) declName then
       return none
+    if declName matches .str _ "parenthesizer" | .str _ "formatter" then
+      return none
     let kind ← match ← getConstInfo declName with
       | .axiomInfo .. => pure "axiom"
       | .opaqueInfo .. => pure "constant"


### PR DESCRIPTION
`haveI := inst; val` simulates the `by haveI := inst; exact val` syntax from Lean 3.

While the Lean 4 `have` always introduces a local instance, it creates a `let_fun` term even when in tactic mode.  The Lean 3 `have` tactic however inlined the value.  The new `haveI` and `letI` syntax always inlines the value.

See https://github.com/leanprover/lean4/issues/1313