### PR TITLE
[Merged by Bors] - chore(Mathport/Syntax): add syntax for coherence tactic

### DIFF
--- a/Mathlib/Mathport/Syntax.lean
+++ b/Mathlib/Mathport/Syntax.lean
@@ -524,8 +524,8 @@ syntax mono.side := &"left" <|> &"right" <|> &"both"
 /- E -/ syntax (name := ghostSimp) "ghost_simp" (" [" simpArg,* "]")? : tactic
 /- E -/ syntax (name := wittTruncateFunTac) "witt_truncate_fun_tac" : tactic
 
-@[nolint docBlame] /- M -/ syntax (name := pure_coherence) "pure_coherence" : tactic
-@[nolint docBlame] /- M -/ syntax (name := coherence) "coherence" : tactic
+/- M -/ syntax (name := pure_coherence) "pure_coherence" : tactic
+/- M -/ syntax (name := coherence) "coherence" : tactic
 
 namespace Conv
 

--- a/Mathlib/Mathport/Syntax.lean
+++ b/Mathlib/Mathport/Syntax.lean
@@ -523,10 +523,8 @@ syntax mono.side := &"left" <|> &"right" <|> &"both"
 /- E -/ syntax (name := ghostSimp) "ghost_simp" (" [" simpArg,* "]")? : tactic
 /- E -/ syntax (name := wittTruncateFunTac) "witt_truncate_fun_tac" : tactic
 
-/- M -/ syntax (name := pure_coherence) "pure_coherence" : tactic
-/- M -/ syntax (name := coherence) "coherence" : tactic
-
-attribute [nolint docBlame] coherence pure_coherence
+/- M -/ @[nolint docBlame] syntax (name := pure_coherence) "pure_coherence" : tactic
+/- M -/ @[nolint docBlame] syntax (name := coherence) "coherence" : tactic
 
 namespace Conv
 

--- a/Mathlib/Mathport/Syntax.lean
+++ b/Mathlib/Mathport/Syntax.lean
@@ -524,8 +524,8 @@ syntax mono.side := &"left" <|> &"right" <|> &"both"
 /- E -/ syntax (name := ghostSimp) "ghost_simp" (" [" simpArg,* "]")? : tactic
 /- E -/ syntax (name := wittTruncateFunTac) "witt_truncate_fun_tac" : tactic
 
-/- M -/ syntax (name := pure_coherence) "pure_coherence" : tactic
-/- M -/ syntax (name := coherence) "coherence" : tactic
+@[nolint docBlame] /- M -/ syntax (name := pure_coherence) "pure_coherence" : tactic
+@[nolint docBlame] /- M -/ syntax (name := coherence) "coherence" : tactic
 
 namespace Conv
 

--- a/Mathlib/Mathport/Syntax.lean
+++ b/Mathlib/Mathport/Syntax.lean
@@ -527,6 +527,8 @@ syntax mono.side := &"left" <|> &"right" <|> &"both"
 /- M -/ syntax (name := pure_coherence) "pure_coherence" : tactic
 /- M -/ syntax (name := coherence) "coherence" : tactic
 
+attribute [nolint docBlame] coherence pure_coherence
+
 namespace Conv
 
 -- https://github.com/leanprover-community/mathlib/issues/2882

--- a/Mathlib/Mathport/Syntax.lean
+++ b/Mathlib/Mathport/Syntax.lean
@@ -524,6 +524,9 @@ syntax mono.side := &"left" <|> &"right" <|> &"both"
 /- E -/ syntax (name := ghostSimp) "ghost_simp" (" [" simpArg,* "]")? : tactic
 /- E -/ syntax (name := wittTruncateFunTac) "witt_truncate_fun_tac" : tactic
 
+/- M -/ syntax (name := pure_coherence) "pure_coherence" : tactic
+/- M -/ syntax (name := coherence) "coherence" : tactic
+
 namespace Conv
 
 -- https://github.com/leanprover-community/mathlib/issues/2882


### PR DESCRIPTION
Should have been added after https://github.com/leanprover-community/mathlib/pull/13417.