### PR TITLE
[Merged by Bors] - feat: GuardHypNums tactic

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -68,6 +68,7 @@ import Mathlib.Tactic.Core
 import Mathlib.Tactic.Ext
 import Mathlib.Tactic.Find
 import Mathlib.Tactic.GuardGoalNums
+import Mathlib.Tactic.GuardHypNums
 import Mathlib.Tactic.Have
 import Mathlib.Tactic.HaveI
 import Mathlib.Tactic.IrreducibleDef

--- a/Mathlib/Mathport/Syntax.lean
+++ b/Mathlib/Mathport/Syntax.lean
@@ -259,7 +259,6 @@ end Conv
 /- M -/ syntax (name := clean) "clean " term : tactic
 /- B -/ syntax (name := refineStruct) "refine_struct " term : tactic
 /- M -/ syntax (name := matchHyp) "match_hyp " ("(" &"m" " := " term ") ")? ident " : " term : tactic
-/- E -/ syntax (name := guardHypNums) "guard_hyp_nums " num : tactic
 /- E -/ syntax (name := guardTags) "guard_tags" (ppSpace ident)* : tactic
 /- E -/ syntax (name := guardProofTerm) "guard_proof_term " tactic:51 " => " term : tactic
 /- E -/ syntax (name := failIfSuccess?) "fail_if_success? " str ppSpace tacticSeq : tactic

--- a/Mathlib/Tactic/GuardHypNums.lean
+++ b/Mathlib/Tactic/GuardHypNums.lean
@@ -1,0 +1,33 @@
+/-
+Copyright (c) 2022 Robert Y. Lewis. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Y. Lewis
+-/
+
+import Lean
+
+/-!
+A tactic stub file for the `guard_hyp_nums` tactic.
+-/
+
+open Lean Meta Elab Tactic
+
+/-- `localContextLength` returns the number of hypotheses in the local context,
+including hidden and auxiliary hypotheses. -/
+def localContextLength : TacticM Nat := do
+  let mut numHyps := 0
+  for _ in (← getLCtx) do
+    numHyps := numHyps + 1
+  return numHyps
+
+/--
+`guard_hyp_nums n` succeeds if there are exactly `n` hypotheses and fails otherwise.
+
+Note that, depending on what options are set, some hypotheses in the local context might
+not be printed in the goal view. This tactic computes the total number of hypotheses,
+not the number of visible hypotheses.
+-/
+elab (name := guardHypNums) "guard_hyp_nums " n:num : tactic => do
+  let numHyps ← localContextLength
+  guard (numHyps = n.getNat) <|>
+    throwError "expected {n.getNat} goals but found {numHyps}"

--- a/Mathlib/Tactic/GuardHypNums.lean
+++ b/Mathlib/Tactic/GuardHypNums.lean
@@ -12,13 +12,11 @@ A tactic stub file for the `guard_hyp_nums` tactic.
 
 open Lean Meta Elab Tactic
 
+-- has been PRed to core in https://github.com/leanprover/lean4/pull/1323
 /-- `localContextLength` returns the number of hypotheses in the local context,
 including hidden and auxiliary hypotheses. -/
-def localContextLength : TacticM Nat := do
-  let mut numHyps := 0
-  for _ in (← getLCtx) do
-    numHyps := numHyps + 1
-  return numHyps
+def Lean.LocalContext.size (lctx : LocalContext) : Nat :=
+  lctx.foldl (fun n _ => n+1) 0
 
 /--
 `guard_hyp_nums n` succeeds if there are exactly `n` hypotheses and fails otherwise.
@@ -28,6 +26,6 @@ not be printed in the goal view. This tactic computes the total number of hypoth
 not the number of visible hypotheses.
 -/
 elab (name := guardHypNums) "guard_hyp_nums " n:num : tactic => do
-  let numHyps ← localContextLength
+  let numHyps := (← getLCtx).size
   guard (numHyps = n.getNat) <|>
     throwError "expected {n.getNat} goals but found {numHyps}"

--- a/test/GuardHypNums.lean
+++ b/test/GuardHypNums.lean
@@ -1,0 +1,9 @@
+import Mathlib.Tactic.GuardHypNums
+
+example (a b c : Nat) (_ : a = b) (_ : c = 3) : true := by
+  guard_hyp_nums 6
+  trivial
+
+example : true := by
+  guard_hyp_nums 1
+  trivial


### PR DESCRIPTION
There seems to be a bug that makes this crash when no numeral is provided. Sebastian has been notified.

Should the length function move somewhere else?