### PR TITLE
[Merged by Bors] - feat(Mathlib/Tactic/Basic): add `triv` tactic

### DIFF
--- a/Mathlib/Mathport/Syntax.lean
+++ b/Mathlib/Mathport/Syntax.lean
@@ -273,7 +273,6 @@ end Conv
   (" with " binderIdent)? : tactic
 /- M -/ syntax (name := guardExprEq') "guard_expr " term:51 " = " term : tactic -- definitional equality
 /- M -/ syntax (name := guardTarget') "guard_target" " = " term : tactic -- definitional equality
-/- E -/ syntax (name := triv) "triv" : tactic
 /- N -/ syntax (name := clearAuxDecl) "clear_aux_decl" : tactic
 /- M -/ syntax (name := clearExcept) "clear " "*" " - " ident* : tactic
 /- M -/ syntax (name := extractGoal) "extract_goal" (ppSpace ident)?

--- a/Mathlib/Tactic/Basic.lean
+++ b/Mathlib/Tactic/Basic.lean
@@ -261,7 +261,7 @@ elab "eapply " e:term : tactic =>
   evalApplyLikeTactic (Meta.apply (cfg := {newGoals := ApplyNewGoals.nonDependentOnly})) e
 
 /--
-Tries to solve the goal using a canonical proof of `true` or the `reflexivity` tactic.
+Tries to solve the goal using a canonical proof of `True`, or the `rfl` tactic.
 Unlike `trivial` or `trivial'`, does not use the `contradiction` tactic.
 -/
 macro (name := triv) "triv" : tactic =>

--- a/Mathlib/Tactic/Basic.lean
+++ b/Mathlib/Tactic/Basic.lean
@@ -262,6 +262,7 @@ elab "eapply " e:term : tactic =>
 
 /--
 Tries to solve the goal using a canonical proof of `true` or the `reflexivity` tactic.
+Unlike `trivial` or `trivial'`, does not use the `contradiction` tactic.
 -/
 macro (name := triv) "triv" : tactic =>
   `(tactic| first | exact trivial | rfl | fail "triv tactic failed")

--- a/Mathlib/Tactic/Basic.lean
+++ b/Mathlib/Tactic/Basic.lean
@@ -256,3 +256,14 @@ elab "fapply " e:term : tactic =>
 
 elab "eapply " e:term : tactic =>
   evalApplyLikeTactic (Meta.apply (cfg := {newGoals := ApplyNewGoals.nonDependentOnly})) e
+
+/--
+Tries to solve the goal using a canonical proof of `true` or the `reflexivity` tactic.
+-/
+syntax (name := triv) "triv" : tactic
+
+macro_rules
+  | `(tactic| triv) => `(tactic| exact trivial)
+
+macro_rules
+  | `(tactic| triv) => `(tactic| rfl)

--- a/Mathlib/Tactic/Basic.lean
+++ b/Mathlib/Tactic/Basic.lean
@@ -260,7 +260,5 @@ elab "eapply " e:term : tactic =>
 /--
 Tries to solve the goal using a canonical proof of `true` or the `reflexivity` tactic.
 -/
-syntax (name := triv) "triv" : tactic
-
-macro_rules
-  | `(tactic| triv) => `(tactic| first | exact trivial | rfl | fail "triv tactic failed")
+macro (name := triv) "triv" : tactic =>
+  `(tactic| first | exact trivial | rfl | fail "triv tactic failed")

--- a/Mathlib/Tactic/Basic.lean
+++ b/Mathlib/Tactic/Basic.lean
@@ -263,7 +263,4 @@ Tries to solve the goal using a canonical proof of `true` or the `reflexivity` t
 syntax (name := triv) "triv" : tactic
 
 macro_rules
-  | `(tactic| triv) => `(tactic| exact trivial)
-
-macro_rules
-  | `(tactic| triv) => `(tactic| rfl)
+  | `(tactic| triv) => `(tactic| first | exact trivial | rfl | fail "triv tactic failed")

--- a/test/triv.lean
+++ b/test/triv.lean
@@ -1,0 +1,7 @@
+import Mathlib.Tactic.Basic
+
+example : True := by
+  triv
+
+example : 2 + 2 = 4 := by
+  triv

--- a/test/triv.lean
+++ b/test/triv.lean
@@ -5,3 +5,8 @@ example : True := by
 
 example : 2 + 2 = 4 := by
   triv
+  
+-- Verify the difference in behaviour between `triv` and `trivial`.
+example (P : Prop) (h1 : P) (h2 : ¬ P) : False := by
+  fail_if_success triv -- fails
+  trivial -- succeeds  


### PR DESCRIPTION
My first tactic, please check carefully!

mathlib3 tactic is https://github.com/leanprover-community/mathlib/blob/903e8941f0862f6c34f28babbb607842a7f8a6c7/src/tactic/interactive.lean#L663