### PR TITLE
feat(Mathlib/Tactic/Basic): Add `clear_aux_decl` tactic

### DIFF
--- a/Mathlib/Mathport/Syntax.lean
+++ b/Mathlib/Mathport/Syntax.lean
@@ -274,7 +274,6 @@ end Conv
 /- M -/ syntax (name := guardExprEq') "guard_expr " term:51 " = " term : tactic -- definitional equality
 /- M -/ syntax (name := guardTarget') "guard_target" " = " term : tactic -- definitional equality
 /- E -/ syntax (name := triv) "triv" : tactic
-/- N -/ syntax (name := clearAuxDecl) "clear_aux_decl" : tactic
 /- M -/ syntax (name := clearExcept) "clear " "*" " - " ident* : tactic
 /- M -/ syntax (name := extractGoal) "extract_goal" (ppSpace ident)?
   (" with" (ppSpace (colGt ident))*)? : tactic

--- a/Mathlib/Tactic/Basic.lean
+++ b/Mathlib/Tactic/Basic.lean
@@ -262,7 +262,8 @@ elab "eapply " e:term : tactic =>
 
 /-- This tactic clears all auxiliary declarations from the context. -/
 elab (name := clearAuxDecl) "clear_aux_decl" : tactic => withMainContext do
-  for ldec in (←getLCtx) do
+  let mut g ← getMainGoal
+  for ldec in ← getLCtx do
     if ldec.isAuxDecl then
-      try replaceMainGoal [←Meta.clear (←getMainGoal) ldec.fvarId]
-      catch | _ => pure ()
+      g ← Meta.tryClear g ldec.fvarId
+  replaceMainGoal [g]

--- a/Mathlib/Tactic/Basic.lean
+++ b/Mathlib/Tactic/Basic.lean
@@ -259,3 +259,10 @@ elab "fapply " e:term : tactic =>
 
 elab "eapply " e:term : tactic =>
   evalApplyLikeTactic (Meta.apply (cfg := {newGoals := ApplyNewGoals.nonDependentOnly})) e
+
+/-- This tactic clears all auxiliary declarations from the context. -/
+elab (name := clearAuxDecl) "clear_aux_decl" : tactic => withMainContext do
+  for ldec in (←getLCtx) do
+    if ldec.isAuxDecl then
+      try replaceMainGoal [←Meta.clear (←getMainGoal) ldec.fvarId]
+      catch | _ => pure ()


### PR DESCRIPTION
This PR implements the `clear_aux_decl` tactic, which clears auxiliary declarations from the context.