### PR TITLE
feat: add trace tactic

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -103,6 +103,7 @@ import Mathlib.Tactic.SolveByElim
 import Mathlib.Tactic.Spread
 import Mathlib.Tactic.SudoSetOption
 import Mathlib.Tactic.ToAdditive
+import Mathlib.Tactic.Trace
 import Mathlib.Tactic.TryThis
 import Mathlib.Tactic.Use
 import Mathlib.Testing.SlimCheck.Gen

--- a/Mathlib/Mathport/Syntax.lean
+++ b/Mathlib/Mathport/Syntax.lean
@@ -21,6 +21,7 @@ import Mathlib.Tactic.Set
 import Mathlib.Tactic.ShowTerm
 import Mathlib.Tactic.Simps
 import Mathlib.Tactic.SolveByElim
+import Mathlib.Tactic.Trace
 import Mathlib.Init.ExtendedBinder
 import Mathlib.Util.WithWeakNamespace
 import Mathlib.Util.Syntax
@@ -182,7 +183,6 @@ syntax caseArg := binderIdent,+ (" :" (ppSpace (ident <|> "_"))+)?
 /- M -/ syntax (name := casesType!) "cases_type!" "*"? ppSpace ident* : tactic
 /- N -/ syntax (name := abstract) "abstract" (ppSpace ident)? ppSpace tacticSeq : tactic
 
-/- E -/ syntax (name := trace) "trace " term : tactic
 /- E -/ syntax (name := existsi) (priority := low) "exists " term,* : tactic
 /- E -/ syntax (name := eConstructor) "econstructor" : tactic
 /- M -/ syntax (name := constructorM) "constructorm" "*"? ppSpace term,* : tactic

--- a/Mathlib/Tactic/Trace.lean
+++ b/Mathlib/Tactic/Trace.lean
@@ -1,7 +1,6 @@
 import Mathlib.Util.TermUnsafe
 
 open Lean Meta Elab Tactic
-elab (name := Lean.Parser.Tactic.trace) tk:"trace " val:term : tactic =>
-  withRef tk do
-    let e ← elabTerm (← `(toString $val)) (some (mkConst `String))
-    logInfo <|← unsafe evalExpr String (mkConst `String) e
+elab (name := Lean.Parser.Tactic.trace) tk:"trace " val:term : tactic => do
+  let e ← elabTerm (← `(toString $val)) (some (mkConst `String))
+  logInfoAt tk <|← unsafe evalExpr String (mkConst `String) e

--- a/Mathlib/Tactic/Trace.lean
+++ b/Mathlib/Tactic/Trace.lean
@@ -1,6 +1,8 @@
 import Mathlib.Util.TermUnsafe
 
 open Lean Meta Elab Tactic
+
+/-- Evaluates a term to a string (when possible), and prints it as a trace message. -/
 elab (name := Lean.Parser.Tactic.trace) tk:"trace " val:term : tactic => do
   let e ← elabTerm (← `(toString $val)) (some (mkConst `String))
   logInfoAt tk <|← unsafe evalExpr String (mkConst `String) e

--- a/Mathlib/Tactic/Trace.lean
+++ b/Mathlib/Tactic/Trace.lean
@@ -1,0 +1,7 @@
+import Mathlib.Util.TermUnsafe
+
+open Lean Meta Elab Tactic
+elab (name := Lean.Parser.Tactic.trace) tk:"trace " val:term : tactic =>
+  withRef tk do
+    let e ← elabTerm (← `(toString $val)) (some (mkConst `String))
+    logInfo <|← unsafe evalExpr String (mkConst `String) e

--- a/test/trace.lean
+++ b/test/trace.lean
@@ -1,0 +1,9 @@
+import Mathlib.Tactic.Trace
+
+example : True := by
+  trace 2 + 2 + 3
+  trivial
+
+example : True := by
+  trace "hello" ++ " world"
+  trivial


### PR DESCRIPTION
Implements the `trace` tactic from lean 3.
```lean
 example : True := by
  trace 2 + 2 + 3
  trivial
```