### PR TITLE
[Merged by Bors] - feat: simultaneous `rename'`

### DIFF
--- a/test/Rename.lean
+++ b/test/Rename.lean
@@ -3,3 +3,7 @@ import Mathlib.Tactic.Rename
 example (a : Nat) (b : Int) : Int × Nat := by
   rename' a => c, b => d
   exact (d, c)
+
+example (a : Nat) (b : Int) : Int × Nat := by
+  rename' a => b, b => a
+  exact (a, b)


### PR DESCRIPTION
This implements the simultaneous rename behavior mentioned in https://github.com/leanprover-community/mathlib4/pull/309#discussion_r923711774 , and also fixes some of the go-to-definition behavior on the identifiers.