### PR TITLE
[Merged by Bors] - feat(Mathlib/Tactic/SeqFocus): implement mapTacs and seqFocus tactics

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -96,6 +96,7 @@ import Mathlib.Tactic.Ring
 import Mathlib.Tactic.RunCmd
 import Mathlib.Tactic.RunTac
 import Mathlib.Tactic.Sat.FromLRAT
+import Mathlib.Tactic.SeqFocus
 import Mathlib.Tactic.Set
 import Mathlib.Tactic.ShowTerm
 import Mathlib.Tactic.SimpRw

--- a/Mathlib/Mathport/Syntax.lean
+++ b/Mathlib/Mathport/Syntax.lean
@@ -164,12 +164,6 @@ end Term
 
 namespace Tactic
 
-/- E -/ syntax tactic " <;> " "[" tactic,* "]" : tactic
-
-end Tactic
-
-namespace Tactic
-
 /- N -/ syntax (name := propagateTags) "propagate_tags " tacticSeq : tactic
 /- N -/ syntax (name := applyWith) "apply " term " with " term : tactic
 /- E -/ syntax (name := mapply) "mapply " term : tactic

--- a/Mathlib/Tactic/SeqFocus.lean
+++ b/Mathlib/Tactic/SeqFocus.lean
@@ -9,11 +9,11 @@ open Lean Elab Meta Tactic
 
 namespace Tactic
 
-/-- Assuming there are `n` goals, `mapTacs [t1, t2, ..., tn]` applies each `ti` to the respective
+/-- Assuming there are `n` goals, `map_tacs [t1, t2, ..., tn]` applies each `ti` to the respective
 goal and leaves the resulting subgoals. -/
-elab "mapTacs " "[" ts:tactic,* "]" : tactic => do
+elab "map_tacs " "[" ts:tactic,* "]" : tactic => do
   let mvarIds ← getGoals
-  let tacs := (ts : Array Syntax)
+  let tacs := ts.getElems
   let length := tacs.size
   if length < mvarIds.length then
     throwError "not enough tactics"
@@ -21,7 +21,7 @@ elab "mapTacs " "[" ts:tactic,* "]" : tactic => do
     throwError "too many tactics"
   let mut mvarIdsNew := #[]
   for tac in tacs, mvarId in mvarIds do
-    unless (← isExprMVarAssigned mvarId) do
+    unless ← isExprMVarAssigned mvarId do
       setGoals [mvarId]
       try
         evalTactic tac
@@ -37,7 +37,7 @@ elab "mapTacs " "[" ts:tactic,* "]" : tactic => do
 /-- `t <;> [t1, t2, ..., tn]` focuses on the first goal and applies `t`, which should result in `n`
 subgoals. It then applies each `ti` to the corresponding goal and collects the resulting
 subgoals. -/
-macro (name := seqFocus) t:tactic " <;> " "[" ts:tactic,* "]" : tactic =>
-  `(tactic| focus ( $t:tactic; mapTacs [$ts,*]) )
+macro (name := seq_focus) t:tactic " <;> " "[" ts:tactic,* "]" : tactic =>
+  `(tactic| focus ( $t:tactic; map_tacs [$ts,*]) )
 
 end Tactic

--- a/Mathlib/Tactic/SeqFocus.lean
+++ b/Mathlib/Tactic/SeqFocus.lean
@@ -1,0 +1,43 @@
+/-
+Copyright (c) 2022 Jeremy Avigad. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Jeremy Avigad
+-/
+import Lean
+
+open Lean Elab Meta Tactic
+
+namespace Tactic
+
+/-- Assuming there are `n` goals, `mapTacs [t1, t2, ..., tn]` applies each `ti` to the respective
+goal and leaves the resulting subgoals. -/
+elab "mapTacs " "[" ts:tactic,* "]" : tactic => do
+  let mvarIds ← getGoals
+  let tacs := (ts : Array Syntax)
+  let length := tacs.size
+  if length < mvarIds.length then
+    throwError "not enough tactics"
+  else if length > mvarIds.length then
+    throwError "too many tactics"
+  let mut mvarIdsNew := #[]
+  for tac in tacs, mvarId in mvarIds do
+    unless (← isExprMVarAssigned mvarId) do
+      setGoals [mvarId]
+      try
+        evalTactic tac
+        mvarIdsNew := mvarIdsNew ++ (← getUnsolvedGoals)
+      catch ex =>
+        if (← read).recover then
+          logException ex
+          mvarIdsNew := mvarIdsNew.push mvarId
+        else
+          throw ex
+  setGoals mvarIdsNew.toList
+
+/-- `t <;> [t1, t2, ..., tn]` focuses on the first goal and applies `t`, which should result in `n`
+subgoals. It then applies each `ti` to the corresponding goal and collects the resulting
+subgoals. -/
+macro (name := seqFocus) t:tactic " <;> " "[" ts:tactic,* "]" : tactic =>
+  `(tactic| focus ( $t:tactic; mapTacs [$ts,*]) )
+
+end Tactic

--- a/test/SeqFocus.lean
+++ b/test/SeqFocus.lean
@@ -3,39 +3,15 @@ import Mathlib.Tactic.SeqFocus
 example : (True ∧ (∃ x : Nat, x = x)) ∧ True := by
   constructor
   constructor
-  mapTacs [trivial, exact ⟨0, rfl⟩, trivial]
-
-/-
--- error: too many tactics
-example : (True ∧ (∃ x : Nat, x = x)) ∧ True := by
-  constructor
-  constructor
-  mapTacs [trivial, exact ⟨0, rfl⟩, trivial, trivial]
--/
-
-/-
--- error: not enough tactics
-example : (True ∧ (∃ x : Nat, x = x)) ∧ True := by
-  constructor
-  constructor
-  mapTacs [trivial, exact ⟨0, rfl⟩]
--/
+  map_tacs [trivial, exact ⟨0, rfl⟩, trivial]
 
 example : ((True ∧ True) ∧ (∃ x : Nat, x = x)) ∧ (True ∧ (∃ x : Nat, x = x)) := by
   constructor
   constructor
-  mapTacs [(constructor; trivial), exact ⟨0, rfl⟩, constructor]
+  map_tacs [(constructor; trivial), exact ⟨0, rfl⟩, constructor]
   trivial
   trivial
   exact ⟨0, rfl⟩
-
-/-
--- error: not enough tactics
-example : (True ∧ (∃ x : Nat, x = x)) ∧ True := by
-  constructor
-  focus
-  constructor <;> [trivial]
--/
 
 example : (True ∧ (∃ x : Nat, x = x)) ∧ True := by
   constructor

--- a/test/SeqFocus.lean
+++ b/test/SeqFocus.lean
@@ -1,0 +1,43 @@
+import Mathlib.Tactic.SeqFocus
+
+example : (True ∧ (∃ x : Nat, x = x)) ∧ True := by
+  constructor
+  constructor
+  mapTacs [trivial, exact ⟨0, rfl⟩, trivial]
+
+/-
+-- error: too many tactics
+example : (True ∧ (∃ x : Nat, x = x)) ∧ True := by
+  constructor
+  constructor
+  mapTacs [trivial, exact ⟨0, rfl⟩, trivial, trivial]
+-/
+
+/-
+-- error: not enough tactics
+example : (True ∧ (∃ x : Nat, x = x)) ∧ True := by
+  constructor
+  constructor
+  mapTacs [trivial, exact ⟨0, rfl⟩]
+-/
+
+example : ((True ∧ True) ∧ (∃ x : Nat, x = x)) ∧ (True ∧ (∃ x : Nat, x = x)) := by
+  constructor
+  constructor
+  mapTacs [(constructor; trivial), exact ⟨0, rfl⟩, constructor]
+  trivial
+  trivial
+  exact ⟨0, rfl⟩
+
+/-
+-- error: not enough tactics
+example : (True ∧ (∃ x : Nat, x = x)) ∧ True := by
+  constructor
+  focus
+  constructor <;> [trivial]
+-/
+
+example : (True ∧ (∃ x : Nat, x = x)) ∧ True := by
+  constructor
+  constructor <;> [trivial, exact ⟨0, rfl⟩]
+  trivial

--- a/test/SeqFocus.lean
+++ b/test/SeqFocus.lean
@@ -3,6 +3,10 @@ import Mathlib.Tactic.SeqFocus
 example : (True ∧ (∃ x : Nat, x = x)) ∧ True := by
   constructor
   constructor
+  -- error: too many tactics
+  fail_if_success map_tacs [trivial, exact ⟨0, rfl⟩, trivial, trivial]
+  -- error: not enough tactics
+  fail_if_success map_tacs [trivial, exact ⟨0, rfl⟩]
   map_tacs [trivial, exact ⟨0, rfl⟩, trivial]
 
 example : ((True ∧ True) ∧ (∃ x : Nat, x = x)) ∧ (True ∧ (∃ x : Nat, x = x)) := by
@@ -15,5 +19,6 @@ example : ((True ∧ True) ∧ (∃ x : Nat, x = x)) ∧ (True ∧ (∃ x : Nat,
 
 example : (True ∧ (∃ x : Nat, x = x)) ∧ True := by
   constructor
-  constructor <;> [trivial, exact ⟨0, rfl⟩]
-  trivial
+  -- error: not enough tactics
+  fail_if_success constructor <;> [trivial]
+  map_tacs [constructor <;> [trivial, exact ⟨0, rfl⟩], constructor]


### PR DESCRIPTION
This implements a new tactic, `mapTacs`, which applies a sequence of tactics to the sequence of goals, which is assumed to have the same length. It then uses this tactic to implement `seq_focus` from Lean 3. 