### PR TITLE
[Merged by Bors] - feat: recover as a tactic combinator

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -93,6 +93,7 @@ import Mathlib.Tactic.OpenPrivate
 import Mathlib.Tactic.PermuteGoals
 import Mathlib.Tactic.PrintPrefix
 import Mathlib.Tactic.RCases
+import Mathlib.Tactic.Recover
 import Mathlib.Tactic.Rename
 import Mathlib.Tactic.Replace
 import Mathlib.Tactic.RestateAxiom

--- a/Mathlib/Mathport/Syntax.lean
+++ b/Mathlib/Mathport/Syntax.lean
@@ -16,6 +16,7 @@ import Mathlib.Tactic.LibrarySearch
 import Mathlib.Tactic.NormCast
 import Mathlib.Tactic.NormNum
 import Mathlib.Tactic.RCases
+import Mathlib.Tactic.Recover
 import Mathlib.Tactic.Ring
 import Mathlib.Tactic.Set
 import Mathlib.Tactic.ShowTerm
@@ -250,7 +251,6 @@ end Conv
 /- E -/ syntax (name := unfoldCoes) "unfold_coes" (ppSpace location)? : tactic
 /- E -/ syntax (name := unfoldWf) "unfold_wf" : tactic
 /- M -/ syntax (name := unfoldAux) "unfold_aux" : tactic
-/- E -/ syntax (name := recover) "recover" : tactic
 /- E -/ syntax (name := «continue») "continue " tacticSeq : tactic
 /- M -/ syntax (name := clear_) "clear_" : tactic
 /- M -/ syntax (name := replace') "replace " Term.haveIdLhs : tactic

--- a/Mathlib/Tactic/Recover.lean
+++ b/Mathlib/Tactic/Recover.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2021 Gabriel Ebner. All rights reserved.
+Copyright (c) 2022 Siddhartha Gadgil. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: Gabriel Ebner
 -/

--- a/Mathlib/Tactic/Recover.lean
+++ b/Mathlib/Tactic/Recover.lean
@@ -35,6 +35,7 @@ partial def getUnassignedGoalMVarDependencies (mvarId : MVarId) :
     MetaM (HashSet MVarId) :=
   return (← go mvarId |>.run {}).snd
   where
+    /-- auxiliary function for `getUnassignedGoalMVarDependencies` -/
     addMVars (e : Expr) : StateRefT (HashSet MVarId) MetaM Unit := do
       let mvars ← getMVars e
       let mut s ← get
@@ -44,7 +45,7 @@ partial def getUnassignedGoalMVarDependencies (mvarId : MVarId) :
           s := s.insert mvarId
       set s
       mvars.forM go
-
+    /-- auxiliary function for `getUnassignedGoalMVarDependencies` -/
     go (mvarId : MVarId) : StateRefT (HashSet MVarId) MetaM Unit :=
       withIncRecDepth do
         let mdecl ← getMVarDecl mvarId

--- a/Mathlib/Tactic/Recover.lean
+++ b/Mathlib/Tactic/Recover.lean
@@ -38,11 +38,12 @@ partial def getUnassignedGoalMVarDependencies (mvarId : MVarId) :
     MetaM (HashSet MVarId) :=
   return (← go mvarId |>.run {}).snd
   where
+    /-- helper for adding metavariables -/
     addMVars (e : Expr) : StateRefT (HashSet MVarId) MetaM Unit := do
       let mvars ← getMVarsNoDelayed e
       modify (fun s => Std.HashSet.insertMany s mvars)
       mvars.forM go
-
+    /-- main loop for metavariables-/
     go (mvarId : MVarId) : StateRefT (HashSet MVarId) MetaM Unit :=
       withIncRecDepth do
         instantiateMVarsInGoal mvarId

--- a/Mathlib/Tactic/Recover.lean
+++ b/Mathlib/Tactic/Recover.lean
@@ -1,0 +1,71 @@
+/-
+Copyright (c) 2021 Gabriel Ebner. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Gabriel Ebner
+-/
+import Lean
+import Mathlib.Tactic.Cache
+import Mathlib.Tactic.RCases
+import Std
+
+open Std (HashSet PHashSet)
+open Lean Meta Elab Tactic
+
+/- The code below (up to the tactic) is from Aesop due to Janis Limperg-/
+namespace Mathlib.Tactic
+
+namespace Std.HashSet
+
+/-- insert many elements in a HashSet (from Aesop) -/
+def insertMany [ForIn Id ρ α] [BEq α] [Hashable α] (s : HashSet α) (as : ρ) :
+    HashSet α := Id.run do
+  let mut s := s
+  for a in as do
+    s := s.insert a
+  return s
+
+end Std.HashSet
+
+/-- instantiating MVars in goal (from Aesop) -/
+def instantiateMVarsInGoal (mvarId : MVarId) : MetaM Unit := do
+  discard $ getMVarDecl mvarId
+    -- The line above throws an error if the `mvarId` is not declared. The line
+    -- below panics.
+  instantiateMVarDeclMVars mvarId
+
+/-- Returns unassigned metavariable dependencies (from Aesop) -/
+partial def getUnassignedGoalMVarDependencies (mvarId : MVarId) :
+    MetaM (HashSet MVarId) :=
+  return (← go mvarId |>.run {}).snd
+  where
+    addMVars (e : Expr) : StateRefT (HashSet MVarId) MetaM Unit := do
+      let mvars ← getMVarsNoDelayed e
+      modify (fun s => Std.HashSet.insertMany s mvars)
+      mvars.forM go
+
+    go (mvarId : MVarId) : StateRefT (HashSet MVarId) MetaM Unit :=
+      withIncRecDepth do
+        instantiateMVarsInGoal mvarId
+        let mdecl ← getMVarDecl mvarId
+        addMVars mdecl.type
+        for ldecl in mdecl.lctx do
+          addMVars ldecl.type
+          if let (some val) := ldecl.value? then
+            addMVars val
+
+/- Above code from Aesop -/
+
+/-- Modifier `recover` for a tactic (sequence) to debug cases where goals are closed incorrectly. The tactic `recover tacs` for a tactic (sequence) tacs applies the tactics and then adds goals that are not closed starting from the original -/
+elab "recover" tacs:tacticSeq : tactic => do
+  let originalGoals ← getGoals
+  evalTactic tacs
+  let mut unassigned : HashSet MVarId := {}
+  for mvarId in originalGoals do
+    unless ← isExprMVarAssigned mvarId do
+      unassigned := unassigned.insert mvarId
+    let unassignedMVarDependencies ←
+        getUnassignedGoalMVarDependencies mvarId
+    unassigned :=
+        Std.HashSet.insertMany
+            unassigned unassignedMVarDependencies.toList
+  setGoals <| (← getGoals) ++ unassigned.toList

--- a/Mathlib/Tactic/Recover.lean
+++ b/Mathlib/Tactic/Recover.lean
@@ -57,7 +57,9 @@ partial def getUnassignedGoalMVarDependencies (mvarId : MVarId) :
 namespace Mathlib.Tactic
 
 
-/-- Modifier `recover` for a tactic (sequence) to debug cases where goals are closed incorrectly. The tactic `recover tacs` for a tactic (sequence) tacs applies the tactics and then adds goals that are not closed starting from the original -/
+/-- Modifier `recover` for a tactic (sequence) to debug cases where goals are closed incorrectly.
+The tactic `recover tacs` for a tactic (sequence) tacs applies the tactics and then adds goals
+that are not closed starting from the original -/
 elab "recover" tacs:tacticSeq : tactic => do
   let originalGoals ← getGoals
   evalTactic tacs

--- a/Mathlib/Tactic/Recover.lean
+++ b/Mathlib/Tactic/Recover.lean
@@ -12,7 +12,6 @@ open Std (HashSet PHashSet)
 open Lean Meta Elab Tactic
 
 /- The code below (up to the tactic) is from Aesop due to Janis Limperg-/
-namespace Mathlib.Tactic
 
 namespace Std.HashSet
 
@@ -41,7 +40,7 @@ partial def getUnassignedGoalMVarDependencies (mvarId : MVarId) :
     /-- helper for adding metavariables -/
     addMVars (e : Expr) : StateRefT (HashSet MVarId) MetaM Unit := do
       let mvars ← getMVarsNoDelayed e
-      modify (fun s => Std.HashSet.insertMany s mvars)
+      modify (·.insertMany mvars)
       mvars.forM go
     /-- main loop for metavariables-/
     go (mvarId : MVarId) : StateRefT (HashSet MVarId) MetaM Unit :=
@@ -55,6 +54,9 @@ partial def getUnassignedGoalMVarDependencies (mvarId : MVarId) :
 
 /- Above code from Aesop -/
 
+namespace Mathlib.Tactic
+
+
 /-- Modifier `recover` for a tactic (sequence) to debug cases where goals are closed incorrectly. The tactic `recover tacs` for a tactic (sequence) tacs applies the tactics and then adds goals that are not closed starting from the original -/
 elab "recover" tacs:tacticSeq : tactic => do
   let originalGoals ← getGoals
@@ -66,6 +68,5 @@ elab "recover" tacs:tacticSeq : tactic => do
     let unassignedMVarDependencies ←
         getUnassignedGoalMVarDependencies mvarId
     unassigned :=
-        Std.HashSet.insertMany
-            unassigned unassignedMVarDependencies.toList
+            unassigned.insertMany unassignedMVarDependencies.toList
   setGoals <| ((← getGoals) ++ unassigned.toList).eraseDups

--- a/test/recover.lean
+++ b/test/recover.lean
@@ -1,0 +1,21 @@
+import Mathlib.Tactic.Recover
+
+/-- problematic tactic for testing recovery -/
+elab "this" "is" "a" "problem" : tactic =>
+  Lean.Elab.Tactic.setGoals []
+
+/- The main test-/
+example : 1 = 1 := by
+  recover this is a problem
+  rfl
+
+/- Tests that recover does no harm -/
+example : 3 < 4 := by
+    recover decide
+
+example : 1 = 1 := by
+    recover skip ; rfl
+
+example : 2 = 2 := by
+    recover skip
+    rfl


### PR DESCRIPTION
Following a suggestion of @digama0 `recover` is implemented as wrapping tactics so that if goals are closed incorrectly they are reopened. Below are examples (test suggested by @gebner). Some code is from Aesop.

```lean
/-- problematic tactic for testing recovery -/
elab "this" "is" "a" "problem" : tactic =>
  Lean.Elab.Tactic.setGoals []

/- The main test-/
example : 1 = 1 := by
  recover this is a problem
  rfl

/- Tests that recover does no harm -/
example : 3 < 4 := by
    recover decide

example : 1 = 1 := by
    recover skip ; rfl

example : 2 = 2 := by
    recover skip
    rfl
```