### PR TITLE
[Merged by Bors] - hack: disable docblame lint for initializers

### DIFF
--- a/Mathlib/Tactic/Lint/Misc.lean
+++ b/Mathlib/Tactic/Lint/Misc.lean
@@ -62,6 +62,7 @@ We skip all declarations that contain `sorry` in their value. -/
       return none
     if declName matches .str _ "parenthesizer" | .str _ "formatter" then
       return none
+    if hasInitAttr (← getEnv) declName then return none -- https://github.com/leanprover/lean4/issues/1324
     let kind ← match ← getConstInfo declName with
       | .axiomInfo .. => pure "axiom"
       | .opaqueInfo .. => pure "constant"


### PR DESCRIPTION
To be removed once https://github.com/leanprover/lean4/issues/1324 lands.