### PR TITLE
[Merged by Bors] - feat(Mathlib/Tactic/Replace): add version of `replace` without `:=`

### DIFF
--- a/Mathlib/Tactic/Replace.lean
+++ b/Mathlib/Tactic/Replace.lean
@@ -28,7 +28,7 @@ h : β
 ⊢ goal
 ```
 
-Where `have h := f h` would result in:
+whereas `have h := f h` would result in:
 
 ```lean
 f : α → β

--- a/Mathlib/Tactic/Replace.lean
+++ b/Mathlib/Tactic/Replace.lean
@@ -10,8 +10,6 @@ namespace Mathlib.Tactic
 
 open Lean Elab.Tactic
 
-syntax "replace " haveDecl : tactic
-
 /--
 Acts like `have`, but removes a hypothesis with the same name as
 this one if possible. For example, if the state is:
@@ -41,6 +39,8 @@ h : β
 
 This can be used to simulate the `specialize` and `apply at` tactics of Coq.
 -/
+syntax "replace " haveDecl : tactic
+
 elab_rules : tactic
   | `(tactic|replace $[$n?:ident]? $[: $t?:term]? := $v:term) =>
     withMainContext do

--- a/Mathlib/Tactic/Replace.lean
+++ b/Mathlib/Tactic/Replace.lean
@@ -11,7 +11,6 @@ namespace Mathlib.Tactic
 open Lean Elab.Tactic
 
 syntax "replace " haveDecl : tactic
-syntax (name := replace') "replace " Parser.Term.haveIdLhs' : tactic
 
 /--
 Acts like `have`, but removes a hypothesis with the same name as
@@ -87,6 +86,8 @@ h: β
 ⊢ goal
 ```
 -/
+syntax (name := replace') "replace " Parser.Term.haveIdLhs' : tactic
+
 elab_rules : tactic
 | `(tactic| replace $[$n:ident $bs*]? $[: $t:term]?) => withMainContext do
     let (mvar1, mvar2) ← haveLetCore (← getMainGoal) n (bs.getD #[]) t false

--- a/Mathlib/Tactic/Replace.lean
+++ b/Mathlib/Tactic/Replace.lean
@@ -67,22 +67,22 @@ f : α → β
 h : α
 ⊢ β
 
-f: α → β
-h: β
+f : α → β
+h : β
 ⊢ goal
 ```
 
-Where `have h : β` would result in:
+whereas `have h : β` would result in:
 
 ```lean
 case h
-f: α → β
-h: α
+f : α → β
+h : α
 ⊢ β
 
-f: α → β
-h✝: α
-h: β
+f : α → β
+h✝ : α
+h : β
 ⊢ goal
 ```
 -/

--- a/Mathlib/Tactic/Replace.lean
+++ b/Mathlib/Tactic/Replace.lean
@@ -4,12 +4,14 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Arthur Paulino, Mario Carneiro
 -/
 import Lean
+import Mathlib.Tactic.Have
 
 namespace Mathlib.Tactic
 
 open Lean Elab.Tactic
 
 syntax "replace " haveDecl : tactic
+syntax (name := replace') "replace " Parser.Term.haveIdLhs' : tactic
 
 /--
 Acts like `have`, but removes a hypothesis with the same name as
@@ -38,6 +40,18 @@ h : β
 ⊢ goal
 ```
 
+Likewise, after `replace h : β`, the state will be:
+```lean
+case h
+f : α → β
+h : α
+⊢ β
+
+f: α → β
+h: β
+⊢ goal
+```
+
 This can be used to simulate the `specialize` and `apply at` tactics of Coq.
 -/
 elab_rules : tactic
@@ -53,3 +67,16 @@ elab_rules : tactic
         try replaceMainGoal [← Meta.clear (← getMainGoal) hId]
         catch | _ => pure ()
       | none     => pure ()
+
+elab_rules : tactic
+| `(tactic| replace $[$n:ident $bs*]? $[: $t:term]?) => withMainContext do
+    let (mvar1, mvar2) ← haveLetCore (← getMainGoal) n (bs.getD #[]) t false
+    let name : Name := match n with
+    | none   => `this
+    | some n => n.getId
+    let hId? := (← getLCtx).findFromUserName? name |>.map fun d => d.fvarId
+    match hId? with
+    | some hId =>
+      try replaceMainGoal [mvar1, ← Meta.clear mvar2 hId]
+      catch | _ => pure ()
+    | none     => replaceMainGoal [mvar1, mvar2]

--- a/Mathlib/Tactic/Replace.lean
+++ b/Mathlib/Tactic/Replace.lean
@@ -40,18 +40,6 @@ h : β
 ⊢ goal
 ```
 
-Likewise, after `replace h : β`, the state will be:
-```lean
-case h
-f : α → β
-h : α
-⊢ β
-
-f: α → β
-h: β
-⊢ goal
-```
-
 This can be used to simulate the `specialize` and `apply at` tactics of Coq.
 -/
 elab_rules : tactic
@@ -68,6 +56,37 @@ elab_rules : tactic
         catch | _ => pure ()
       | none     => pure ()
 
+/--
+Acts like `have`, but removes a hypothesis with the same name as
+this one if possible. For example, if the state is:
+
+Then after `replace h : β` the state will be:
+
+```lean
+case h
+f : α → β
+h : α
+⊢ β
+
+f: α → β
+h: β
+⊢ goal
+```
+
+Where `have h : β` would result in:
+
+```lean
+case h
+f: α → β
+h: α
+⊢ β
+
+f: α → β
+h✝: α
+h: β
+⊢ goal
+```
+-/
 elab_rules : tactic
 | `(tactic| replace $[$n:ident $bs*]? $[: $t:term]?) => withMainContext do
     let (mvar1, mvar2) ← haveLetCore (← getMainGoal) n (bs.getD #[]) t false

--- a/test/Replace.lean
+++ b/test/Replace.lean
@@ -47,3 +47,16 @@ example {a : Nat} : a = a := by
   have : Nat := by assumption -- old `a` is not gone
   have : Int := by exact a    -- new `a` is of type `Int`
   simp
+
+-- tests without `:=`, creating a new subgoal
+
+example (z : Int) : Nat := by
+  replace z : Nat
+  exact 0
+  assumption
+
+example : True := by
+  have : 1 + 1 = 2 := by simp_arith
+  replace : 2 + 2 = 4
+  simp_arith
+  trivial


### PR DESCRIPTION
As @digama0 said in #332, `replace` was missing part of its implementation, namely the case where the proof is not immediately given but rather deferred to an additional goal. This PR adds this case.