### PR TITLE
[Merged by Bors] - make simpsAttr comment a real doc comment and remove nolint

### DIFF
--- a/Mathlib/Tactic/Simps.lean
+++ b/Mathlib/Tactic/Simps.lean
@@ -44,7 +44,9 @@ syntax (name := initializeSimpsProjections?) "initialize_simps_projections?"
 end Command
 end Lean.Parser
 
--- Defines the user attribute `simps` for automatic generation of `@[simp]` lemmas for projections.
+/--
+  Defines the user attribute `simps` for automatic generation of `@[simp]` lemmas for projections.
+-/
 initialize simpsAttr : ParametricAttribute (Array Name) ←
   registerParametricAttribute {
     name := `simps

--- a/scripts/nolints.json
+++ b/scripts/nolints.json
@@ -69,7 +69,6 @@
  ["docBlame", "right_distributive"],
  ["docBlame", "right_identity"],
  ["docBlame", "setOf"],
- ["docBlame", "simpsAttr"],
  ["docBlame", "successIfFail"],
  ["docBlame", "tacticAny_goals_"],
  ["docBlame", "tacticBy_cases_"],


### PR DESCRIPTION
Now that https://github.com/leanprover/lean4/commit/cdb855d281de74c9e7f89ddd9aa258261685e364 has landed,
`initialize` statements can get real docstrings, and we no longer need to silence the linter.