### PR TITLE
[Merged by Bors] - port some lemmas for use in fin_cases

### DIFF
--- a/Mathlib/Init/Data/List/Lemmas.lean
+++ b/Mathlib/Init/Data/List/Lemmas.lean
@@ -49,7 +49,8 @@ theorem mem_nil_iff (a : α) : a ∈ ([] : List α) ↔ False := by simp
 
 theorem mem_cons_self (a : α) (l : List α) : a ∈ a :: l := by simp
 
-@[simp] lemma mem_cons_iff (a y : α) (l : List α) : a ∈ y :: l ↔ (a = y ∨ a ∈ l) := mem_cons
+-- No @[simp] annotation because `mem_cons` already has it, so adding it trips the `simpNF` linter.
+lemma mem_cons_iff (a y : α) (l : List α) : a ∈ y :: l ↔ (a = y ∨ a ∈ l) := mem_cons
 
 theorem mem_cons_eq (a y : α) (l : List α) : (a ∈ y :: l) = (a = y ∨ a ∈ l) := by simp
 

--- a/Mathlib/Init/Data/List/Lemmas.lean
+++ b/Mathlib/Init/Data/List/Lemmas.lean
@@ -49,6 +49,8 @@ theorem mem_nil_iff (a : α) : a ∈ ([] : List α) ↔ False := by simp
 
 theorem mem_cons_self (a : α) (l : List α) : a ∈ a :: l := by simp
 
+@[simp] lemma mem_cons_iff (a y : α) (l : List α) : a ∈ y :: l ↔ (a = y ∨ a ∈ l) := mem_cons
+
 theorem mem_cons_eq (a y : α) (l : List α) : (a ∈ y :: l) = (a = y ∨ a ∈ l) := by simp
 
 theorem mem_cons_of_mem (y : α) {a : α} {l : List α} : a ∈ l → a ∈ y :: l := List.Mem.tail _

--- a/Mathlib/Logic/Basic.lean
+++ b/Mathlib/Logic/Basic.lean
@@ -679,7 +679,8 @@ by simp [@eq_comm _ a']
 
 -- this lemma is needed to simplify the output of `list.mem_cons_iff`
 @[simp] theorem forall_eq_or_imp {a' : α} : (∀ a, a = a' ∨ q a → p a) ↔ p a' ∧ ∀ a, q a → p a :=
-by simp [or_imp_distrib, forall_and_distrib, forall_eq]
+by simp only [or_imp_distrib, forall_and_distrib, forall_eq]
+   exact Iff.rfl
 
 @[simp] theorem exists_false : ¬ (∃ _a : α, False) := fun ⟨_, h⟩ => h
 

--- a/Mathlib/Logic/Basic.lean
+++ b/Mathlib/Logic/Basic.lean
@@ -677,6 +677,10 @@ theorem forall_and_distrib {p q : α → Prop} : (∀ x, p x ∧ q x) ↔ (∀ x
 @[simp] theorem forall_eq' {a' : α} : (∀ a, a' = a → p a) ↔ p a' :=
 by simp [@eq_comm _ a']
 
+-- this lemma is needed to simplify the output of `list.mem_cons_iff`
+@[simp] theorem forall_eq_or_imp {a' : α} : (∀ a, a = a' ∨ q a → p a) ↔ p a' ∧ ∀ a, q a → p a :=
+by simp [or_imp_distrib, forall_and_distrib, forall_eq]
+
 @[simp] theorem exists_false : ¬ (∃ _a : α, False) := fun ⟨_, h⟩ => h
 
 @[simp] theorem exists_and_distrib_left {q : Prop} {p : α → Prop} :


### PR DESCRIPTION
Ports [`mem_cons_iff`](https://github.com/leanprover-community/lean/blob/3526539070ea6268df5dd373deeb3ac8b9621952/library/init/data/list/lemmas.lean#L100-L101) and [`forall_eq_or_imp`](https://github.com/leanprover-community/mathlib/blob/8edffc250c25db5a7bada5472dd02a166f7f8bfc/src/logic/basic.lean#L1135-L1137), to be used in the proof of `Chain.Pairwise` in https://github.com/leanprover-community/mathlib4/pull/346.