### PR TITLE
[Merged by Bors] - chore: revert #337 after #1324 landed in lean4

### DIFF
--- a/Mathlib/Tactic/Lint/Misc.lean
+++ b/Mathlib/Tactic/Lint/Misc.lean
@@ -62,7 +62,6 @@ We skip all declarations that contain `sorry` in their value. -/
       return none
     if declName matches .str _ "parenthesizer" | .str _ "formatter" then
       return none
-    if hasInitAttr (← getEnv) declName then return none -- https://github.com/leanprover/lean4/issues/1324
     let kind ← match ← getConstInfo declName with
       | .axiomInfo .. => pure "axiom"
       | .opaqueInfo .. => pure "constant"


### PR DESCRIPTION
Reverting #337, now that https://github.com/leanprover/lean4/issues/1324 has landed and we've bumped to a relevant nightly.