### PR TITLE
[Merged by Bors] - chore: normalise copyright headers

### DIFF
--- a/Mathlib/Data/List/Card.lean
+++ b/Mathlib/Data/List/Card.lean
@@ -1,5 +1,5 @@
 /-
-Author: Jeremy Avigad
+Authors: Jeremy Avigad
 
 This is a makeshift theory of the cardinality of a list. Any list can be taken to represent the
 finite set of its elements. Cardinality counts the number of distinct elements. Cardinality

--- a/Mathlib/Init/Data/List/Basic.lean
+++ b/Mathlib/Init/Data/List/Basic.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2016 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Leonardo de Moura
+Authors: Leonardo de Moura
 -/
 import Mathlib.Init.SetNotation
 import Mathlib.Init.Logic

--- a/Mathlib/Init/Data/List/Instances.lean
+++ b/Mathlib/Init/Data/List/Instances.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2016 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Leonardo de Moura
+Authors: Leonardo de Moura
 -/
 import Mathlib.Init.Data.List.Basic
 

--- a/Mathlib/Init/Data/List/Lemmas.lean
+++ b/Mathlib/Init/Data/List/Lemmas.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2014 Parikshit Khanna. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Parikshit Khanna, Jeremy Avigad, Leonardo de Moura, Floris van Doorn
+Authors: Parikshit Khanna, Jeremy Avigad, Leonardo de Moura, Floris van Doorn
 -/
 import Mathlib.Init.Data.List.Basic
 import Mathlib.Init.Data.Nat.Lemmas

--- a/Mathlib/Init/Function.lean
+++ b/Mathlib/Init/Function.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2014 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Leonardo de Moura, Jeremy Avigad, Haitao Zhang
+Authors: Leonardo de Moura, Jeremy Avigad, Haitao Zhang
 -/
 -- a port of core Lean `init/function.lean`
 

--- a/Mathlib/Lean/Exception.lean
+++ b/Mathlib/Lean/Exception.lean
@@ -6,6 +6,9 @@ Author: E.W.Ayers
 import Lean
 open Lean
 
+/--
+A generalisation of `fail_if_success` to an arbitrary `MonadError`.
+-/
 def successIfFail [MonadError M] [Monad M] (m : M α) : M Exception := do
   match ← tryCatch (m *> pure none) (pure ∘ some) with
   | none => throwError "Expected an exception."

--- a/Mathlib/Lean/LocalContext.lean
+++ b/Mathlib/Lean/LocalContext.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2021 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Scott Morrison
+Authors: Scott Morrison
 -/
 import Lean.Meta.Tactic.Apply
 

--- a/Mathlib/Lean/NameMapAttribute.lean
+++ b/Mathlib/Lean/NameMapAttribute.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2022 E.W.Ayers. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: E.W.Ayers
+Authors: E.W.Ayers
 -/
 import Lean
 

--- a/Mathlib/Tactic/Basic.lean
+++ b/Mathlib/Tactic/Basic.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2021 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Mario Carneiro
+Authors: Mario Carneiro
 -/
 import Mathlib.Tactic.NoMatch
 import Lean.Elab.Command

--- a/Mathlib/Tactic/Cache.lean
+++ b/Mathlib/Tactic/Cache.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2021 Gabriel Ebner. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Gabriel Ebner
+Authors: Gabriel Ebner
 -/
 import Lean
 import Mathlib.Logic.Nonempty

--- a/Mathlib/Tactic/Coe.lean
+++ b/Mathlib/Tactic/Coe.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2021 Gabriel Ebner. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Gabriel Ebner
+Authors: Gabriel Ebner
 -/
 import Lean
 

--- a/Mathlib/Tactic/Constructor.lean
+++ b/Mathlib/Tactic/Constructor.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2022 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Scott Morrison
+Authors: Scott Morrison
 -/
 import Lean.Elab.Command
 import Lean.Meta.Tactic.Constructor

--- a/Mathlib/Tactic/Conv.lean
+++ b/Mathlib/Tactic/Conv.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2021 Gabriel Ebner. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Gabriel Ebner
+Authors: Gabriel Ebner
 -/
 import Mathlib.Tactic.RunTac
 

--- a/Mathlib/Tactic/Ext.lean
+++ b/Mathlib/Tactic/Ext.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2021 Gabriel Ebner. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Gabriel Ebner
+Authors: Gabriel Ebner
 -/
 import Lean
 import Mathlib.Tactic.Cache

--- a/Mathlib/Tactic/Find.lean
+++ b/Mathlib/Tactic/Find.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2021 Sebastian Ullrich. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Sebastian Ullrich
+Authors: Sebastian Ullrich
 -/
 import Lean
 import Mathlib.Tactic.Cache

--- a/Mathlib/Tactic/IrreducibleDef.lean
+++ b/Mathlib/Tactic/IrreducibleDef.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2021 Gabriel Ebner. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Gabriel Ebner
+Authors: Gabriel Ebner
 -/
 import Lean
 

--- a/Mathlib/Tactic/LeftRight.lean
+++ b/Mathlib/Tactic/LeftRight.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2022 Siddhartha Gadgil. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Siddhartha Gadgil
+Authors: Siddhartha Gadgil
 -/
 import Lean
 

--- a/Mathlib/Tactic/LibrarySearch.lean
+++ b/Mathlib/Tactic/LibrarySearch.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2021 Gabriel Ebner. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Gabriel Ebner
+Authors: Gabriel Ebner
 -/
 import Mathlib.Tactic.Cache
 import Mathlib.Tactic.Core

--- a/Mathlib/Tactic/NoMatch.lean
+++ b/Mathlib/Tactic/NoMatch.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2021 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Mario Carneiro
+Authors: Mario Carneiro
 -/
 import Mathlib.Tactic.OpenPrivate
 import Lean

--- a/Mathlib/Tactic/OpenPrivate.lean
+++ b/Mathlib/Tactic/OpenPrivate.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2021 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Mario Carneiro
+Authors: Mario Carneiro
 -/
 import Lean.Elab.Command
 import Lean.Util.FoldConsts

--- a/Mathlib/Tactic/PermuteGoals.lean
+++ b/Mathlib/Tactic/PermuteGoals.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2022 Arthur Paulino. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Arthur Paulino, Mario Carneiro
+Authors: Arthur Paulino, Mario Carneiro
 -/
 
 import Lean

--- a/Mathlib/Tactic/Rename.lean
+++ b/Mathlib/Tactic/Rename.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2021 Gabriel Ebner. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Gabriel Ebner
+Authors: Gabriel Ebner
 -/
 import Lean
 

--- a/Mathlib/Tactic/RunTac.lean
+++ b/Mathlib/Tactic/RunTac.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2018 Sebastian Ullrich. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Sebastian Ullrich
+Authors: Sebastian Ullrich
 -/
 import Lean.Elab.SyntheticMVars
 import Mathlib.Util.TermUnsafe

--- a/Mathlib/Tactic/Sat/FromLRAT.lean
+++ b/Mathlib/Tactic/Sat/FromLRAT.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2022 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Mario Carneiro
+Authors: Mario Carneiro
 -/
 import Mathlib.Data.List.Basic
 

--- a/Mathlib/Tactic/SeqFocus.lean
+++ b/Mathlib/Tactic/SeqFocus.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2022 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Jeremy Avigad
+Authors: Jeremy Avigad
 -/
 import Lean
 

--- a/Mathlib/Tactic/Set.lean
+++ b/Mathlib/Tactic/Set.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2022 Ian Benway. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Ian Benway.
+Authors: Ian Benway.
 -/
 import Lean
 namespace Mathlib.Tactic

--- a/Mathlib/Tactic/ShowTerm.lean
+++ b/Mathlib/Tactic/ShowTerm.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2021 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Scott Morrison
+Authors: Scott Morrison
 -/
 import Lean.Elab.Tactic.Basic
 import Mathlib.Tactic.TryThis

--- a/Mathlib/Tactic/SolveByElim.lean
+++ b/Mathlib/Tactic/SolveByElim.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2021 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Scott Morrison
+Authors: Scott Morrison
 -/
 import Lean.Meta.Tactic.Apply
 import Lean.Elab.Tactic.Basic

--- a/Mathlib/Tactic/Spread.lean
+++ b/Mathlib/Tactic/Spread.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2021 Gabriel Ebner. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Gabriel Ebner
+Authors: Gabriel Ebner
 -/
 import Lean
 

--- a/Mathlib/Tactic/Trace.lean
+++ b/Mathlib/Tactic/Trace.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2022 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Mario Carneiro
+Authors: Mario Carneiro
 -/
 import Mathlib.Util.TermUnsafe
 

--- a/Mathlib/Tactic/TryThis.lean
+++ b/Mathlib/Tactic/TryThis.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2021 Gabriel Ebner. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Gabriel Ebner
+Authors: Gabriel Ebner
 -/
 import Lean
 

--- a/Mathlib/Util/Export.lean
+++ b/Mathlib/Util/Export.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2021 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Mario Carneiro
+Authors: Mario Carneiro
 -/
 import Lean
 import Std.Data.HashMap

--- a/Mathlib/Util/WhatsNew.lean
+++ b/Mathlib/Util/WhatsNew.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2021 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Gabriel Ebner
+Authors: Gabriel Ebner
 -/
 import Lean
 import Mathlib.Util.TermUnsafe

--- a/test/Set.lean
+++ b/test/Set.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2022 Ian Benway. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Ian Benway.
+Authors: Ian Benway.
 -/
 
 import Mathlib.Tactic.Set

--- a/test/SolveByElim.lean
+++ b/test/SolveByElim.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2021 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Scott Morrison
+Authors: Scott Morrison
 -/
 import Mathlib.Tactic.SolveByElim
 

--- a/test/Use.lean
+++ b/test/Use.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2022 Arthur Paulino. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Arthur Paulino
+Authors: Arthur Paulino
 -/
 
 import Mathlib.Tactic.Use

--- a/test/showTerm.lean
+++ b/test/showTerm.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2021 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Scott Morrison
+Authors: Scott Morrison
 -/
 import Mathlib.Tactic.ShowTerm
 

--- a/test/toAdditive.lean
+++ b/test/toAdditive.lean
@@ -96,7 +96,7 @@ if some_def.in_namespace then x * x else x
 
 -- cannot apply `@[to_additive]` to `some_def` if `some_def.in_namespace` doesn't have the attribute
 run_cmd do
-  Lean.Elab.Command.liftCoreM <| successIfFail (ToAdditive.transformDecl `Test.some_def `Test.add_some_def)
+  Lean.Elab.Command.liftCoreM <| fail_if_success (ToAdditive.transformDecl `Test.some_def `Test.add_some_def)
 
 
 attribute [to_additive some_other_name] some_def.in_namespace

--- a/test/toAdditive.lean
+++ b/test/toAdditive.lean
@@ -96,7 +96,7 @@ if some_def.in_namespace then x * x else x
 
 -- cannot apply `@[to_additive]` to `some_def` if `some_def.in_namespace` doesn't have the attribute
 run_cmd do
-  Lean.Elab.Command.liftCoreM <| fail_if_success (ToAdditive.transformDecl `Test.some_def `Test.add_some_def)
+  Lean.Elab.Command.liftCoreM <| successIfFail (ToAdditive.transformDecl `Test.some_def `Test.add_some_def)
 
 
 attribute [to_additive some_other_name] some_def.in_namespace


### PR DESCRIPTION
Easier to normalise all `Author: X` to `Authors: X`, rather than adding flexibility to the linting scripts. This is already the style in the template, and hopefully once it is uniform it will trivially stay uniform as everyone copies and pastes.