### PR TITLE
[Merged by Bors] - update library_search documentation to refer to new snake_case syntax

### DIFF
--- a/Mathlib/Tactic/LibrarySearch.lean
+++ b/Mathlib/Tactic/LibrarySearch.lean
@@ -11,15 +11,15 @@ import Mathlib.Tactic.TryThis
 /-!
 # Library search
 
-This file defines a tactic `librarySearch`
-and a term elaborator `librarySearch%`
+This file defines a tactic `library_search`
+and a term elaborator `library_search%`
 that tries to find a lemma
 solving the current goal
 (subgoals are solved using `solveByElim`).
 
 ```
-example : x < x + 1 := librarySearch%
-example : Nat := by librarySearch
+example : x < x + 1 := library_search%
+example : Nat := by library_search
 ```
 -/
 


### PR DESCRIPTION
Updates the documentation to keep it in sync with the changes in #141, where the syntax was changed from `librarySearch` to `library_search`.