### PR TITLE
[Merged by Bors] - fix: remove @[reducible] attribute from Function.injective

### DIFF
--- a/Mathlib/Init/Function.lean
+++ b/Mathlib/Init/Function.lean
@@ -48,7 +48,7 @@ theorem comp.assoc (f : φ → δ) (g : β → φ) (h : α → β) : (f ∘ g) �
 theorem comp_const_right (f : β → φ) (b : β) : f ∘ (const α b) = const α (f b) := rfl
 
 /-- A function `f : α → β` is called injective if `f x = f y` implies `x = y`. -/
-@[reducible] def injective (f : α → β) : Prop := ∀ ⦃a₁ a₂⦄, f a₁ = f a₂ → a₁ = a₂
+def injective (f : α → β) : Prop := ∀ ⦃a₁ a₂⦄, f a₁ = f a₂ → a₁ = a₂
 
 theorem injective.comp {g : β → φ} {f : α → β} (hg : injective g) (hf : injective f) :
   injective (g ∘ f) :=

--- a/Mathlib/Tactic/Ext.lean
+++ b/Mathlib/Tactic/Ext.lean
@@ -120,7 +120,7 @@ def extAttribute : AttributeImpl where
         Elab.Command.elabCommand <|<- `(declareExtTheoremsFor $(mkIdent decl))
     else MetaM.run' do
       let declTy := (← getConstInfo decl).type
-      let (_, _, declTy) ← withReducible <| forallMetaTelescopeReducing declTy
+      let (_, _, declTy) ← withDefault <| forallMetaTelescopeReducing declTy
       if declTy.isAppOfArity ``Eq 3 && (declTy.getArg! 1).isMVar && (declTy.getArg! 2).isMVar then
         let ty := declTy.getArg! 0
         let key ←


### PR DESCRIPTION
In mathlib3, [`function.injective`](https://github.com/leanprover-community/lean/blob/4b58f26becf336a50cf037c3e2894b6f2938956e/library/init/function.lean#L73) is not reducible, so `Function.injective` should not be reducible here either.

To avoid errors in `Order/Basic` ("@[ext] attribute only applies to structures or lemmas proving x = y"), we need to adjust `extAttribute` too.

Fixes some problems seen in #372.