### PR TITLE
[Merged by Bors] - feat: port List.length_injective_iff and List.length_injective

### DIFF
--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -5,6 +5,7 @@ import Mathlib.Logic.Function.Basic
 import Mathlib.Data.Nat.Basic
 import Mathlib.Data.Option.Basic
 import Mathlib.Data.List.Defs
+import Mathlib.Tactic.Simpa
 import Lean
 
 open Function
@@ -237,17 +238,23 @@ lemma exists_of_length_succ {n} :
 | [], H => absurd H.symm $ Nat.succ_ne_zero n
 | h :: t, _ => ⟨h, t, rfl⟩
 
--- @[simp] lemma length_injective_iff : injective (List.length : List α → ℕ) ↔ subsingleton α :=
--- begin
---   constructor,
---   { intro h, refine ⟨fun  x y, _⟩, suffices : [x] = [y], { simpa using this }, apply h, refl },
---   { intros hα l1 l2 hl, induction l1 generalizing l2; cases l2,
---     { refl }, { cases hl }, { cases hl },
---     congr, exactI subsingleton.elim _ _, apply l1_ih, simpa using hl }
--- end
+@[simp]
+lemma length_injective_iff : injective (List.length : List α → ℕ) ↔ Subsingleton α := by
+  constructor
+  · intro h; refine ⟨λ x y => ?_⟩; (suffices [x] = [y] by simpa using this); apply h; rfl
+  · intros hα l1 l2 hl
+    induction l1 generalizing l2 with
+    | nil => cases l2 with | nil => rfl | cons _ _ => cases hl
+    | cons a _ ih =>
+      cases l2 with
+      | nil => cases hl
+      | cons b bl => congr
+                     · exact Subsingleton.elim _ _
+                     · apply ih; simpa using hl
 
--- @[simp] lemma length_injective [subsingleton α] : injective (length : List α → ℕ) :=
--- length_injective_iff.mpr $ by apply_instance
+-- TODO this is @[simp] in mathlib3, but here would run into the simpNF linter.
+lemma length_injective [Subsingleton α] : injective (length : List α → ℕ) :=
+length_injective_iff.mpr inferInstance
 
 /-! ### set-theoretic notation of Lists -/
 

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -251,8 +251,6 @@ lemma length_injective_iff : injective (List.length : List α → ℕ) ↔ Subsi
                              · exact Subsingleton.elim _ _
                              · apply ih; simpa using hl
 
-@[simp] theorem subsingleton_of_subsingleton [Subsingleton α] : Subsingleton α := ‹_›
-
 @[simp default+1]
 lemma length_injective [Subsingleton α] : injective (length : List α → ℕ) :=
 length_injective_iff.mpr inferInstance

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -243,14 +243,13 @@ lemma length_injective_iff : injective (List.length : List α → ℕ) ↔ Subsi
   constructor
   · intro h; refine ⟨λ x y => ?_⟩; (suffices [x] = [y] by simpa using this); apply h; rfl
   · intros hα l1 l2 hl
-    induction l1 generalizing l2 with
-    | nil => cases l2 with | nil => rfl | cons _ _ => cases hl
-    | cons a _ ih =>
-      cases l2 with
-      | nil => cases hl
-      | cons b bl => congr
-                     · exact Subsingleton.elim _ _
-                     · apply ih; simpa using hl
+    induction l1 generalizing l2 with | nil => ?_ | cons _ _ ih => ?_ <;> cases l2
+    · rfl
+    · cases hl
+    · cases hl
+    · congr
+      · exact Subsingleton.elim _ _
+      · apply ih; simpa using hl
 
 -- TODO this is @[simp] in mathlib3, but here would run into the simpNF linter.
 lemma length_injective [Subsingleton α] : injective (length : List α → ℕ) :=

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -243,13 +243,13 @@ lemma length_injective_iff : injective (List.length : List α → ℕ) ↔ Subsi
   constructor
   · intro h; refine ⟨λ x y => ?_⟩; (suffices [x] = [y] by simpa using this); apply h; rfl
   · intros hα l1 l2 hl
-    induction l1 generalizing l2 with | nil => ?_ | cons _ _ ih => ?_ <;> cases l2
-    · rfl
-    · cases hl
-    · cases hl
-    · congr
-      · exact Subsingleton.elim _ _
-      · apply ih; simpa using hl
+    induction l1 generalizing l2 <;> cases l2
+    case nil.nil => rfl
+    case nil.cons => cases hl
+    case cons.nil => cases hl
+    case cons.cons ih _ _ => congr
+                             · exact Subsingleton.elim _ _
+                             · apply ih; simpa using hl
 
 -- TODO this is @[simp] in mathlib3, but here would run into the simpNF linter.
 lemma length_injective [Subsingleton α] : injective (length : List α → ℕ) :=

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -251,7 +251,9 @@ lemma length_injective_iff : injective (List.length : List α → ℕ) ↔ Subsi
                              · exact Subsingleton.elim _ _
                              · apply ih; simpa using hl
 
--- TODO this is @[simp] in mathlib3, but here would run into the simpNF linter.
+@[simp] theorem subsingleton_of_subsingleton [Subsingleton α] : Subsingleton α := ‹_›
+
+@[simp default+1]
 lemma length_injective [Subsingleton α] : injective (length : List α → ℕ) :=
 length_injective_iff.mpr inferInstance
 


### PR DESCRIPTION
Replace commented-out Lean 3 `List.length_injective_iff` and `List.length_injective` lemmas, port them to Lean 4.

Compare to the current mathlib3 versions: https://github.com/leanprover-community/mathlib/blob/6f1ad8258079beb8437c2e402d4218f4e6b7f9f6/src/data/list/basic.lean#L256-L266

