### PR TITLE
[Merged by Bors] - chore: disable decide in simp linter

### DIFF
--- a/Mathlib/Init/Logic.lean
+++ b/Mathlib/Init/Logic.lean
@@ -141,11 +141,11 @@ lemma imp_congr (h₁ : a ↔ c) (h₂ : b ↔ d) : (a → b) ↔ (c → d) := i
 lemma not_of_not_not_not (h : ¬¬¬a) : ¬a :=
 λ ha => absurd (not_not_intro ha) h
 
--- @[simp] -- Lean 4 has this built-in because it simplifies using decidable instances
+@[simp]
 lemma not_true : (¬ True) ↔ False :=
 iff_false_intro (not_not_intro trivial)
 
--- @[simp] -- Lean 4 has this built-in because it simplifies using decidable instances
+@[simp]
 lemma not_false_iff : (¬ False) ↔ True :=
 iff_true_intro not_false
 

--- a/Mathlib/Tactic/Lint/Simp.lean
+++ b/Mathlib/Tactic/Lint/Simp.lean
@@ -130,6 +130,7 @@ https://leanprover-community.github.io/mathlib_docs/notes.html#simp-normal%20for
     unless ← isSimpTheorem declName do return none
     -- TODO: equation lemmas
     let ctx ← Simp.Context.mkDefault
+    let ctx := { ctx with config.decide := false }
     checkAllSimpTheoremInfos (← getConstInfo declName).type fun {lhs, rhs, isConditional, ..} => do
     let ⟨lhs', prf1, _⟩ ← decorateError "simplify fails on left-hand side:" <| simp lhs ctx
     let prf1_lems := heuristicallyExtractSimpTheorems ctx (prf1.getD (mkBVar 0))


### PR DESCRIPTION
The `decide` support is pretty flaky in simp.