### PR TITLE
[Merged by Bors] - fix: rename and.swap to And.swap

### DIFF
--- a/Mathlib/Init/Logic.lean
+++ b/Mathlib/Init/Logic.lean
@@ -76,7 +76,7 @@ variable {a b c d : Prop}
 
 def And.elim (f : a → b → α) (h : a ∧ b) : α := f h.1 h.2
 
-lemma and.swap : a ∧ b → b ∧ a :=
+lemma And.swap : a ∧ b → b ∧ a :=
 λ ⟨ha, hb⟩ => ⟨hb, ha⟩
 
 lemma And.symm : a ∧ b → b ∧ a | ⟨ha, hb⟩ => ⟨hb, ha⟩


### PR DESCRIPTION
Fixes typo from #34.

Compare to lean3port: https://github.com/leanprover-community/lean3port/blob/f32c612cbcf601def6e4546470e8d2776a7f54d1/Leanbin/Init/Logic.lean#L217