### PR TITLE
[Merged by Bors] - feat: align Classical.choose and Classical.choose_spec

### DIFF
--- a/Mathlib/Mathport/SpecialNames.lean
+++ b/Mathlib/Mathport/SpecialNames.lean
@@ -26,6 +26,9 @@ namespace Mathlib.Prelude
 #align psum                    PSum
 #align ulift                   ULift
 
+#align classical.some          Classical.choose
+#align classical.some_spec     Classical.choose_spec
+
 #align has_coe Coe
 #align has_coe.coe Coe.coe
 


### PR DESCRIPTION
`classical.some` and `classical.some_spec` become `Classical.choose` and `Classical.choose_spec`.

Lean 3: 
https://github.com/leanprover-community/lean/blob/741670c439f1ca266bc7fe61ef7212cc9afd9dd8/library/init/classical.lean#L19-L23

Lean 4:
https://github.com/leanprover/lean4/blob/e80028b7d1be11b190e5439fab33f9a034f6babf/src/Init/Classical.lean#L19-L23