### PR TITLE
[Merged by Bors] - feat(Mathlib/Tactic/Existsi): the existsi tactic

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -67,6 +67,7 @@ import Mathlib.Tactic.CommandQuote
 import Mathlib.Tactic.Constructor
 import Mathlib.Tactic.Conv
 import Mathlib.Tactic.Core
+import Mathlib.Tactic.Existsi
 import Mathlib.Tactic.Expect
 import Mathlib.Tactic.Find
 import Mathlib.Tactic.GuardGoalNums

--- a/Mathlib/Mathport/Syntax.lean
+++ b/Mathlib/Mathport/Syntax.lean
@@ -16,6 +16,7 @@ import Mathlib.Tactic.ClearExcept
 import Mathlib.Tactic.Clear_
 import Mathlib.Tactic.Core
 import Mathlib.Tactic.CommandQuote
+import Mathlib.Tactic.Existsi
 import Mathlib.Tactic.Find
 import Mathlib.Tactic.InferParam
 import Mathlib.Tactic.Inhabit
@@ -186,7 +187,6 @@ syntax caseArg := binderIdent,+ (" :" (ppSpace (ident <|> "_"))+)?
 /- M -/ syntax (name := casesType!) "cases_type!" "*"? ppSpace ident* : tactic
 /- N -/ syntax (name := abstract) "abstract" (ppSpace ident)? ppSpace tacticSeq : tactic
 
-/- E -/ syntax (name := existsi) (priority := low) "exists " term,* : tactic
 /- E -/ syntax (name := eConstructor) "econstructor" : tactic
 /- M -/ syntax (name := constructorM) "constructorm" "*"? ppSpace term,* : tactic
 /- M -/ syntax (name := injections') "injections" (" with " (colGt (ident <|> "_"))+)? : tactic

--- a/Mathlib/Tactic/Existsi.lean
+++ b/Mathlib/Tactic/Existsi.lean
@@ -1,0 +1,29 @@
+/-
+Copyright (c) 2022 Moritz Doll. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Arthur Paulino, Gabriel Ebner, Moritz Doll
+-/
+
+import Mathlib.Tactic.Basic
+
+namespace Mathlib.Tactic
+
+/--
+`existsi e₁, e₂, ⋯` applies the tactic `refine ⟨e₁, e₂, ⋯, ?_⟩`. It's purpose is to instantiate
+existential quantifiers.
+
+Examples:
+
+```lean
+example : ∃ x : Nat, x = x := by
+  existsi 42
+  rfl
+
+example : ∃ x : Nat, ∃ y : Nat, x = y := by
+  existsi 42, 42
+  rfl
+```
+-/
+
+macro "existsi " es:term,+ : tactic =>
+  `(tactic|refine ⟨$es,*, ?_⟩)

--- a/test/Existsi.lean
+++ b/test/Existsi.lean
@@ -1,0 +1,15 @@
+/-
+Copyright (c) 2022 Moritz Doll. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Moritz Doll
+-/
+
+import Mathlib.Tactic.Existsi
+
+example : ∃ x : Nat, x = x := by
+  existsi 42
+  rfl
+
+example : ∃ x : Nat, ∃ y : Nat, x = y := by
+  existsi 42, 42
+  rfl


### PR DESCRIPTION
As suggested by Gabriel, we define `existsi` as a macro and `existsi a` expands to `refine ⟨a, ?_⟩`.