### PR TITLE
[Merged by Bors] - fix: use `False` instead of `false` in empty set

### DIFF
--- a/Mathlib/Init/Set.lean
+++ b/Mathlib/Init/Set.lean
@@ -55,7 +55,7 @@ instance : Subset (Set α) :=
 ⟨Set.subset⟩
 
 instance : EmptyCollection (Set α) :=
-⟨λ _ => false⟩
+⟨λ _ => False⟩
 
 open Std.ExtendedBinder in
 syntax "{ " extBinder " | " term " }" : term


### PR DESCRIPTION
fixes #423