### PR TITLE
[Merged by Bors] - chore: cleanup after lean4#1396

### DIFF
--- a/Mathlib/Data/List/Perm.lean
+++ b/Mathlib/Data/List/Perm.lean
@@ -57,8 +57,6 @@ theorem perm_middle {a : α} : ∀ {l₁ l₂ : List α}, l₁++a::l₂ ~ a::(l�
   let h2 := @perm_middle α a l₁ l₂
   (h2.cons _).trans (swap a b _)
 
-
-set_option linter.unusedVariables false in -- FIXME: lean4#1214
 theorem perm_insertNth {x : α} : ∀ {l : List α} {n : Nat}, n ≤ l.length →
   insertNth n x l ~ x :: l
 | [], 0, _ => Perm.refl _

--- a/Mathlib/Init/Data/Nat/Lemmas.lean
+++ b/Mathlib/Init/Data/Nat/Lemmas.lean
@@ -62,7 +62,6 @@ notation f "^["n"]" => iterate f n
 
 /- successor and predecessor -/
 
-set_option linter.unusedVariables false in -- FIXME: lean4#1214
 def discriminate (H1 : n = 0 → α) (H2 : ∀m, n = succ m → α) : α :=
   match n with
   | 0 => H1 rfl

--- a/Mathlib/Tactic/Sat/FromLRAT.lean
+++ b/Mathlib/Tactic/Sat/FromLRAT.lean
@@ -121,7 +121,6 @@ def Fmla.proof (f : Fmla) (c : Clause) : Prop :=
 theorem Fmla.proof_of_subsumes (H : Fmla.subsumes f (Fmla.one c)) : f.proof c :=
   fun _ h => h.1 _ $ H.1 _ $ List.Mem.head ..
 
-set_option linter.unusedVariables false in -- FIXME: lean4#1214
 /-- The core unit-propagation step.
 
 We have a local context of assumptions `¬l'` (sometimes called an assignment)
@@ -134,8 +133,8 @@ We continue the proof in `h₂`, with the assumption that `l` is falsified. -/
 theorem Valuation.by_cases {v : Valuation} {l}
   (h₁ : v.neg l.negate → False) (h₂ : v.neg l → False) : False :=
 match l with
-| Literal.pos i => h₂ h₁
-| Literal.neg i => h₁ h₂
+| Literal.pos _ => h₂ h₁
+| Literal.neg _ => h₁ h₂
 
 /-- `v.implies p [a, b, c] 0` definitionally unfolds to `(v 0 ↔ a) → (v 1 ↔ b) → (v 2 ↔ c) → p`.
 This is used to introduce assumptions about the first `n` values of `v` during reification. -/

--- a/Mathlib/Tactic/Sat/FromLRAT.lean
+++ b/Mathlib/Tactic/Sat/FromLRAT.lean
@@ -121,6 +121,7 @@ def Fmla.proof (f : Fmla) (c : Clause) : Prop :=
 theorem Fmla.proof_of_subsumes (H : Fmla.subsumes f (Fmla.one c)) : f.proof c :=
   fun _ h => h.1 _ $ H.1 _ $ List.Mem.head ..
 
+set_option linter.unusedVariables false in -- FIXME: lean4#1214
 /-- The core unit-propagation step.
 
 We have a local context of assumptions `¬l'` (sometimes called an assignment)

--- a/Mathlib/Tactic/Sat/FromLRAT.lean
+++ b/Mathlib/Tactic/Sat/FromLRAT.lean
@@ -121,7 +121,6 @@ def Fmla.proof (f : Fmla) (c : Clause) : Prop :=
 theorem Fmla.proof_of_subsumes (H : Fmla.subsumes f (Fmla.one c)) : f.proof c :=
   fun _ h => h.1 _ $ H.1 _ $ List.Mem.head ..
 
-set_option linter.unusedVariables false in -- FIXME: lean4#1214
 /-- The core unit-propagation step.
 
 We have a local context of assumptions `¬l'` (sometimes called an assignment)


### PR DESCRIPTION
Remove `set_option linter.unusedVariables false` that a no longer needed after https://github.com/leanprover/lean4/pull/1396.