### PR TITLE
[Merged by Bors] - feat: add appUnexpander for ExistsUnique

### DIFF
--- a/Mathlib/Init/Logic.lean
+++ b/Mathlib/Init/Logic.lean
@@ -86,6 +86,14 @@ def ExistsUnique (p : α → Prop) := ∃ x, p x ∧ ∀ y, p y → y = x
 open Lean in
 macro "∃! " xs:explicitBinders ", " b:term : term => expandExplicitBinders ``ExistsUnique xs b
 
+/-- Pretty-printing for `ExistsUnique`, following the same pattern as pretty printing
+    for `Exists`. -/
+@[appUnexpander ExistsUnique] def unexpandExistsUnique : Lean.PrettyPrinter.Unexpander
+  | `($(_) fun $x:ident => ∃! $xs:binderIdent*, $b) => `(∃! $x:ident $xs:binderIdent*, $b)
+  | `($(_) fun $x:ident => $b)                      => `(∃! $x:ident, $b)
+  | `($(_) fun ($x:ident : $t) => $b)               => `(∃! ($x:ident : $t), $b)
+  | _                                               => throw ()
+
 lemma ExistsUnique.intro {p : α → Prop} (w : α)
   (h₁ : p w) (h₂ : ∀ y, p y → y = w) : ∃! x, p x := ⟨w, h₁, h₂⟩
 


### PR DESCRIPTION
Follows the same pattern as the unexpander for `Exists`:
https://github.com/leanprover/lean4/blob/ad0f8d32584496330c15055c5e1c3dc795bb8679/src/Init/NotationExtra.lean#L170-L174

Closes #421.