### PR TITLE
[Merged by Bors] - feat: minimal port of Fintype

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -12,9 +12,14 @@ import Mathlib.Data.Char
 import Mathlib.Data.Equiv.Basic
 import Mathlib.Data.Equiv.Functor
 import Mathlib.Data.Fin.Basic
+import Mathlib.Data.Finset.Basic
+import Mathlib.Data.Fintype.Basic
 import Mathlib.Data.List.Basic
 import Mathlib.Data.List.Card
+import Mathlib.Data.List.Pairwise
 import Mathlib.Data.List.Perm
+import Mathlib.Data.Multiset.Basic
+import Mathlib.Data.Multiset.Nodup
 import Mathlib.Data.Nat.Basic
 import Mathlib.Data.Option.Basic
 import Mathlib.Data.Option.Defs

--- a/Mathlib/Data/Finset/Basic.lean
+++ b/Mathlib/Data/Finset/Basic.lean
@@ -8,11 +8,6 @@ import Mathlib.Data.Multiset.Nodup
 /-!
 # Finite sets
 
-TODO: This is currently extremely minimal,
-containing only the definitions required to implement the `fin_cases` tactic.
-Please update this module doc as changes are made,
-eventually restoring the original mathlib3 module doc.
-
 Terms of type `Finset α` are one way of talking about finite subsets of `α` in mathlib.
 Below, `Finset α` is defined as a structure with 2 fields:
 
@@ -54,8 +49,6 @@ namespace Finset
 
 /-! ### membership -/
 
-instance : Membership α (Finset α) :=
-  ⟨fun a s => a ∈ s.1⟩
+instance : Membership α (Finset α) := ⟨fun a s => a ∈ s.1⟩
 
-theorem mem_def {a : α} {s : Finset α} : a ∈ s ↔ a ∈ s.1 :=
-  Iff.rfl
+theorem mem_def {a : α} {s : Finset α} : a ∈ s ↔ a ∈ s.1 := Iff.rfl

--- a/Mathlib/Data/Finset/Basic.lean
+++ b/Mathlib/Data/Finset/Basic.lean
@@ -1,0 +1,59 @@
+/-
+Copyright (c) 2015 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Leonardo de Moura, Jeremy Avigad, Minchao Wu, Mario Carneiro
+-/
+import Mathlib.Data.Multiset.Nodup
+
+/-!
+# Finite sets
+
+TODO: This is currently extremely minimal,
+containing only the definitions required to implement the `fin_cases` tactic.
+Please update this module doc as changes are made,
+eventually restoring the original mathlib3 module doc.
+
+Terms of type `Finset α` are one way of talking about finite subsets of `α` in mathlib.
+Below, `Finset α` is defined as a structure with 2 fields:
+
+  1. `val` is a `Multiset α` of elements;
+  2. `nodup` is a proof that `val` has no duplicates.
+
+Finsets in Lean are constructive in that they have an underlying `List` that enumerates their
+elements. In particular, any function that uses the data of the underlying list cannot depend on its
+ordering. This is handled on the `Multiset` level by multiset API, so in most cases one needn't
+worry about it explicitly.
+
+## Main declarations
+
+### Main definitions
+
+* `Finset`: Defines a type for the finite subsets of `α`.
+  Constructing a `Finset` requires two pieces of data: `val`, a `Multiset α` of elements,
+  and `nodup`, a proof that `val` has no duplicates.
+* `Finset.Membership`: Defines membership `a ∈ (s : Finset α)`.
+
+-/
+
+
+open Multiset Subtype Nat Function
+
+universe u
+
+variable {α : Type _} {β : Type _} {γ : Type _}
+
+/-- `finset α` is the type of finite sets of elements of `α`. It is implemented
+  as a multiset (a list up to permutation) which has no duplicate elements. -/
+structure Finset (α : Type _) where
+  val : Multiset α
+  Nodup : Nodup val
+
+namespace Finset
+
+/-! ### membership -/
+
+instance : Membership α (Finset α) :=
+  ⟨fun a s => a ∈ s.1⟩
+
+theorem mem_def {a : α} {s : Finset α} : a ∈ s ↔ a ∈ s.1 :=
+  Iff.rfl

--- a/Mathlib/Data/Finset/Basic.lean
+++ b/Mathlib/Data/Finset/Basic.lean
@@ -45,8 +45,10 @@ variable {α : Type _} {β : Type _} {γ : Type _}
 /-- `finset α` is the type of finite sets of elements of `α`. It is implemented
   as a multiset (a list up to permutation) which has no duplicate elements. -/
 structure Finset (α : Type _) where
+  /-- The underlying `Multiset` of a `Finset`. -/
   val : Multiset α
-  Nodup : Nodup val
+  /-- The proof that the underlying `Multiset` of a `Finset` has no duplicates. -/
+  nodup : Nodup val
 
 namespace Finset
 

--- a/Mathlib/Data/Fintype/Basic.lean
+++ b/Mathlib/Data/Fintype/Basic.lean
@@ -1,0 +1,45 @@
+/-
+Copyright (c) 2017 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro
+-/
+import Mathlib.Data.Finset.Basic
+
+/-!
+# Finite types
+
+TODO: This is currently extremely minimal,
+containing only the definitions required to implement the `fin_cases` tactic.
+Please update this module doc as changes are made,
+eventually restoring the original mathlib3 module doc.
+
+This file defines a typeclass to state that a type is finite.
+
+## Main declarations
+
+* `Fintype α`:  Typeclass saying that a type is finite. It takes as fields a `Finset` and a proof
+  that all terms of type `α` are in it.
+* `Finset.univ`: The finset of all elements of a fintype.
+
+-/
+
+/-- `fintype α` means that `α` is finite, i.e. there are only
+  finitely many distinct elements of type `α`. The evidence of this
+  is a finset `elems` (a list up to permutation without duplicates),
+  together with a proof that everything of type `α` is in the list. -/
+class Fintype (α : Type _) where
+  elems : Finset α
+  complete : ∀ x : α, x ∈ elems
+
+namespace Finset
+
+variable [Fintype α]
+
+/-- `univ` is the universal finite set of type `finset α` implied from
+  the assumption `fintype α`. -/
+def univ : Finset α :=
+  Fintype.elems
+
+@[simp]
+theorem mem_univ (x : α) : x ∈ (univ : Finset α) :=
+  Fintype.complete x

--- a/Mathlib/Data/Fintype/Basic.lean
+++ b/Mathlib/Data/Fintype/Basic.lean
@@ -8,16 +8,11 @@ import Mathlib.Data.Finset.Basic
 /-!
 # Finite types
 
-TODO: This is currently extremely minimal,
-containing only the definitions required to implement the `fin_cases` tactic.
-Please update this module doc as changes are made,
-eventually restoring the original mathlib3 module doc.
-
 This file defines a typeclass to state that a type is finite.
 
 ## Main declarations
 
-* `Fintype α`:  Typeclass saying that a type is finite. It takes as fields a `Finset` and a proof
+* `Fintype α`: Typeclass saying that a type is finite. It takes as fields a `Finset` and a proof
   that all terms of type `α` are in it.
 * `Finset.univ`: The finset of all elements of a fintype.
 
@@ -39,9 +34,6 @@ variable [Fintype α]
 
 /-- `univ` is the universal finite set of type `finset α` implied from
   the assumption `fintype α`. -/
-def univ : Finset α :=
-  Fintype.elems
+def univ : Finset α := Fintype.elems
 
-@[simp]
-theorem mem_univ (x : α) : x ∈ (univ : Finset α) :=
-  Fintype.complete x
+@[simp] theorem mem_univ (x : α) : x ∈ (univ : Finset α) := Fintype.complete x

--- a/Mathlib/Data/Fintype/Basic.lean
+++ b/Mathlib/Data/Fintype/Basic.lean
@@ -28,7 +28,9 @@ This file defines a typeclass to state that a type is finite.
   is a finset `elems` (a list up to permutation without duplicates),
   together with a proof that everything of type `α` is in the list. -/
 class Fintype (α : Type _) where
+  /-- The `Finset` of elements of a `Fintype`. -/
   elems : Finset α
+  /-- The proof that every term of the type is contained in the `Finset` of elements. -/
   complete : ∀ x : α, x ∈ elems
 
 namespace Finset

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -61,11 +61,11 @@ theorem mem_split {a : α} {l : List α} (h : a ∈ l) : ∃ s t : List α, l = 
   induction l with
   | nil => cases h
   | cons b l ih =>
-      cases h with
-      | head => exact ⟨[], l, rfl⟩
-      | tail _ h =>
-          rcases ih h with ⟨s, t, rfl⟩
-          exact ⟨b :: s, t, rfl⟩
+    cases h with
+    | head => exact ⟨[], l, rfl⟩
+    | tail _ h =>
+      rcases ih h with ⟨s, t, rfl⟩
+      exact ⟨b :: s, t, rfl⟩
 
 /-! ### length -/
 

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -57,6 +57,16 @@ theorem mem_map_of_injective {f : α → β} (H : injective f) {a : α} {l : Lis
 ⟨fun m => let ⟨_, m', e⟩ := exists_of_mem_map m
           H e ▸ m', mem_map_of_mem _⟩
 
+theorem mem_split {a : α} {l : List α} (h : a ∈ l) : ∃ s t : List α, l = s ++ a :: t := by
+  induction l with
+  | nil => cases h
+  | cons b l ih =>
+      cases h with
+      | head => exact ⟨[], l, rfl⟩
+      | tail _ h =>
+          rcases ih h with ⟨s, t, rfl⟩
+          exact ⟨b :: s, t, rfl⟩
+
 /-! ### length -/
 
 alias length_pos ↔ ne_nil_of_length_pos length_pos_of_ne_nil

--- a/Mathlib/Data/List/Pairwise.lean
+++ b/Mathlib/Data/List/Pairwise.lean
@@ -1,0 +1,42 @@
+/-
+Copyright (c) 2018 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro
+-/
+import Mathlib.Data.List.Basic
+
+/-!
+# Pairwise relations on a list
+
+TODO: This is currently extremely minimal,
+containing only the definitions required to implement the `fin_cases` tactic.
+Please update this module doc as changes are made,
+eventually restoring the original mathlib3 module doc.
+
+-/
+
+namespace List
+
+variable {α β : Type _} {R S T : α → α → Prop} {a : α} {l : List α}
+
+theorem pairwise_append {l₁ l₂ : List α} :
+    Pairwise R (l₁ ++ l₂) ↔ Pairwise R l₁ ∧ Pairwise R l₂ ∧ (∀ x, x ∈ l₁ → ∀ y, y ∈ l₂ → R x y) := by
+  induction l₁ with
+  | nil => simp [Pairwise.nil]
+  | cons a l₁ ih =>
+      simp only [cons_append, Pairwise_cons, forall_mem_append, ih, forall_mem_cons,
+        forall_and_distrib, and_assoc, And.left_comm]
+      rfl
+
+theorem pairwise_append_comm (s : symmetric R) {l₁ l₂ : List α} :
+  Pairwise R (l₁ ++ l₂) ↔ Pairwise R (l₂ ++ l₁) := by
+  have : ∀ l₁ l₂ : List α, (∀ x : α, x ∈ l₁ → ∀ y : α, y ∈ l₂ → R x y) →
+    ∀ x : α, x ∈ l₂ → ∀ y : α, y ∈ l₁ → R x y := fun l₁ l₂ a x xm y ym => s (a y ym x xm)
+  simp only [pairwise_append, And.left_comm] <;> rw [Iff.intro (this l₁ l₂) (this l₂ l₁)]
+
+theorem pairwise_middle (s : symmetric R) {a : α} {l₁ l₂ : List α} :
+    Pairwise R (l₁ ++ a :: l₂) ↔ Pairwise R (a :: (l₁ ++ l₂)) :=
+  show Pairwise R (l₁ ++ ([a] ++ l₂)) ↔ Pairwise R ([a] ++ l₁ ++ l₂) by
+    rw [← append_assoc, pairwise_append, @pairwise_append _ _ ([a] ++ l₁), pairwise_append_comm s]
+    simp only [mem_append, or_comm]
+    rfl

--- a/Mathlib/Data/List/Pairwise.lean
+++ b/Mathlib/Data/List/Pairwise.lean
@@ -20,7 +20,8 @@ namespace List
 variable {α β : Type _} {R S T : α → α → Prop} {a : α} {l : List α}
 
 theorem pairwise_append {l₁ l₂ : List α} :
-    Pairwise R (l₁ ++ l₂) ↔ Pairwise R l₁ ∧ Pairwise R l₂ ∧ (∀ x, x ∈ l₁ → ∀ y, y ∈ l₂ → R x y) := by
+    Pairwise R (l₁ ++ l₂) ↔ Pairwise R l₁ ∧ Pairwise R l₂ ∧ (∀ x, x ∈ l₁ → ∀ y, y ∈ l₂ → R x y) :=
+by
   induction l₁ with
   | nil => simp [Pairwise.nil]
   | cons a l₁ ih =>

--- a/Mathlib/Data/List/Pairwise.lean
+++ b/Mathlib/Data/List/Pairwise.lean
@@ -7,30 +7,23 @@ import Mathlib.Data.List.Basic
 
 /-!
 # Pairwise relations on a list
-
-TODO: This is currently extremely minimal,
-containing only the definitions required to implement the `fin_cases` tactic.
-Please update this module doc as changes are made,
-eventually restoring the original mathlib3 module doc.
-
 -/
 
 namespace List
 
 variable {α β : Type _} {R S T : α → α → Prop} {a : α} {l : List α}
 
-theorem pairwise_append {l₁ l₂ : List α} :
-    Pairwise R (l₁ ++ l₂) ↔ Pairwise R l₁ ∧ Pairwise R l₂ ∧ (∀ x, x ∈ l₁ → ∀ y, y ∈ l₂ → R x y) :=
-by
+theorem pairwise_append {l₁ l₂ : List α} : Pairwise R (l₁ ++ l₂) ↔
+    Pairwise R l₁ ∧ Pairwise R l₂ ∧ (∀ x, x ∈ l₁ → ∀ y, y ∈ l₂ → R x y) := by
   induction l₁ with
   | nil => simp [Pairwise.nil]
   | cons a l₁ ih =>
-      simp only [cons_append, Pairwise_cons, forall_mem_append, ih, forall_mem_cons,
-        forall_and_distrib, and_assoc, And.left_comm]
-      rfl
+    simp only [cons_append, Pairwise_cons, forall_mem_append, ih, forall_mem_cons,
+      forall_and_distrib, and_assoc, And.left_comm]
+    rfl
 
 theorem pairwise_append_comm (s : symmetric R) {l₁ l₂ : List α} :
-  Pairwise R (l₁ ++ l₂) ↔ Pairwise R (l₂ ++ l₁) := by
+    Pairwise R (l₁ ++ l₂) ↔ Pairwise R (l₂ ++ l₁) := by
   have : ∀ l₁ l₂ : List α, (∀ x : α, x ∈ l₁ → ∀ y : α, y ∈ l₂ → R x y) →
     ∀ x : α, x ∈ l₂ → ∀ y : α, y ∈ l₁ → R x y := fun l₁ l₂ a x xm y ym => s (a y ym x xm)
   simp only [pairwise_append, And.left_comm] <;> rw [Iff.intro (this l₁ l₂) (this l₂ l₁)]

--- a/Mathlib/Data/List/Perm.lean
+++ b/Mathlib/Data/List/Perm.lean
@@ -147,9 +147,9 @@ theorem Perm.cons_inv {a : α} {l₁ l₂ : List α} : a :: l₁ ~ a :: l₂ →
 theorem Perm.length_eq {l₁ l₂ : List α} (p : l₁ ~ l₂) : length l₁ = length l₂ := by
   induction p with
   | nil => simp
-  | cons _ _ ih => sorry
-  | swap x y l => simp
-  | trans _ _ ih₁ ih₂ => sorry
+  | cons _ _ ih => simp [ih]
+  | swap _ _ l => simp
+  | trans _ _ ih₁ ih₂ => exact ih₁.trans ih₂
 
 theorem Perm.eq_nil {l : List α} (p : l ~ []) : l = [] :=
   eq_nil_of_length_eq_zero p.length_eq
@@ -158,7 +158,7 @@ theorem Perm.nil_eq {l : List α} (p : [] ~ l) : [] = l :=
   p.symm.eq_nil.symm
 
 theorem Perm.pairwise_iff {R : α → α → Prop} (S : symmetric R) :
-  ∀ {l₁ l₂ : List α} (p : l₁ ~ l₂), Pairwise R l₁ ↔ Pairwise R l₂ := by
+  ∀ {l₁ l₂ : List α}, l₁ ~ l₂ → (Pairwise R l₁ ↔ Pairwise R l₂) := by
   suffices ∀ {l₁ l₂}, l₁ ~ l₂ → Pairwise R l₁ → Pairwise R l₂ from
     fun l₁ l₂ p => ⟨this p, this p.symm⟩
   intros l₁ l₂ p d

--- a/Mathlib/Data/List/Perm.lean
+++ b/Mathlib/Data/List/Perm.lean
@@ -79,67 +79,43 @@ for an explanation of the change made here relative to mathlib3.
 @[elabAsElim]
 theorem perm_induction_on
     {P : (l₁ : List α) → (l₂ : List α) → l₁ ~ l₂ → Prop} {l₁ l₂ : List α} (p : l₁ ~ l₂)
-    (h₁ : P [] [] .nil)
-    (h₂ : ∀ x l₁ l₂, (h : l₁ ~ l₂) → P l₁ l₂ h → P (x :: l₁) (x :: l₂) (.cons x h))
-    (h₃ : ∀ x y l₁ l₂, (h : l₁ ~ l₂) → P l₁ l₂ h →
+    (nil : P [] [] .nil)
+    (cons : ∀ x l₁ l₂, (h : l₁ ~ l₂) → P l₁ l₂ h → P (x :: l₁) (x :: l₂) (.cons x h))
+    (swap : ∀ x y l₁ l₂, (h : l₁ ~ l₂) → P l₁ l₂ h →
       P (y :: x :: l₁) (x :: y :: l₂) (.trans (.swap x y _) (.cons _ (.cons _ h))))
-    (h₄ : ∀ l₁ l₂ l₃, (h₁ : l₁ ~ l₂) → (h₂ : l₂ ~ l₃) → P l₁ l₂ h₁ → P l₂ l₃ h₂ →
+    (trans : ∀ l₁ l₂ l₃, (h₁ : l₁ ~ l₂) → (h₂ : l₂ ~ l₃) → P l₁ l₂ h₁ → P l₂ l₃ h₂ →
       P l₁ l₃ (.trans h₁ h₂)) : P l₁ l₂ p :=
-  have P_refl : ∀ l, P l l (.refl l) :=
-    fun l => List.recOn l h₁ fun x xs ih => h₂ x xs xs (Perm.refl xs) ih
-  Perm.recOn p h₁ h₂ (fun x y l => h₃ x y l l (Perm.refl l) (P_refl l)) @h₄
+  have P_refl l : P l l (.refl l) :=
+    List.recOn l nil fun x xs ih => cons x xs xs (Perm.refl xs) ih
+  Perm.recOn p nil cons (fun x y l => swap x y l l (Perm.refl l) (P_refl l)) @trans
 
 theorem perm_inv_core {a : α} {l₁ l₂ r₁ r₂ : List α} :
     l₁ ++ a :: r₁ ~ l₂ ++ a :: r₂ → l₁ ++ r₁ ~ l₂ ++ r₂ := by
-  generalize e₁ : l₁ ++ a :: r₁ = s₁
-  generalize e₂ : l₂ ++ a :: r₂ = s₂
-  intro p
-  revert l₁ l₂ r₁ r₂ e₁ e₂
-  refine' @(perm_induction_on p _ _ _ _)
-  · intro l₁ l₂ r₁ r₂ e₁ _
-    apply (not_mem_nil a).elim
-    rw [← e₁]
-    simp
-  · intro x t₁ t₂ p w l₁ l₂ r₁ r₂ e₁ e₂
-    rcases l₁ with ⟨⟩ | ⟨y,l₁⟩ <;> rcases l₂ with ⟨⟩ | ⟨z,l₂⟩ <;> dsimp at e₁ e₂
-      <;> injections <;> subst x
-    · subst t₁ t₂
-      exact p
-    · subst z t₁ t₂
-      exact p.trans perm_middle
-    · subst y t₁ t₂
-      exact perm_middle.symm.trans p
-    · subst z t₁ t₂
-      exact (w rfl rfl).cons y
-  · intro x y t₁ t₂ p w l₁ l₂ r₁ r₂ e₁ e₂
-    rcases l₁ with (_ | ⟨y, _ | ⟨z, l₁⟩⟩) <;>
-      rcases l₂ with (_ | ⟨u, _ | ⟨v, l₂⟩⟩) <;> dsimp at e₁ e₂ <;> injections <;> subst x y
-    · subst r₁ r₂
-      exact p.cons a
-    · subst r₁ r₂
-      exact p.cons u
-    · subst r₁ v t₂
-      exact (p.trans perm_middle).cons u
-    · subst r₁ r₂
-      exact p.cons y
-    · subst r₁ r₂ y u
-      exact p.cons a
-    · subst r₁ u v t₂
-      exact ((p.trans perm_middle).cons y).trans (swap _ _ _)
-    · subst r₂ z t₁
-      exact (perm_middle.symm.trans p).cons y
-    · subst r₂ y z t₁
-      exact (swap _ _ _).trans ((perm_middle.symm.trans p).cons u)
-    · subst u v t₁ t₂
-      exact (w rfl rfl).swap' _ _
-  · intro t₁ t₂ t₃ p₁ p₂ w₁ w₂ l₁ l₂ r₁ r₂ e₁ e₂
+  generalize e₁ : l₁ ++ a :: r₁ = s₁; generalize e₂ : l₂ ++ a :: r₂ = s₂
+  intro p; induction p using perm_induction_on generalizing l₁ l₂ r₁ r₂ with
+  | nil => apply (not_mem_nil a).elim; rw [← e₁]; simp
+  | cons x t₁ t₂ p w =>
+    rcases l₁ with _ | ⟨y, l₁⟩ <;> rcases l₂ with _ | ⟨z, l₂⟩ <;> injections <;> subst_vars
+    · exact p
+    · exact p.trans perm_middle
+    · exact perm_middle.symm.trans p
+    · exact (w rfl rfl).cons z
+  | swap x y t₁ t₂ p w =>
+    rcases l₁ with _ | ⟨y, _ | ⟨z, l₁⟩⟩ <;> rcases l₂ with _ | ⟨u, _ | ⟨v, l₂⟩⟩ <;>
+      injections <;> subst_vars
+    · exact p.cons y
+    · exact p.cons u
+    · exact (p.trans perm_middle).cons u
+    · exact p.cons y
+    · exact p.cons u
+    · exact ((p.trans perm_middle).cons v).trans (swap _ _ _)
+    · exact (perm_middle.symm.trans p).cons y
+    · exact (swap _ _ _).trans ((perm_middle.symm.trans p).cons u)
+    · exact (w rfl rfl).swap' _ _
+  | trans t₁ t₂ t₃ p₁ p₂ w₁ w₂ =>
     subst t₁ t₃
-    have : a ∈ t₂ :=
-      p₁.subset
-        (by simp)
-    rcases mem_split this with ⟨l₂, r₂, e₂⟩
-    subst t₂
-    exact (w₁ rfl rfl).trans (w₂ rfl rfl)
+    let ⟨l₂, r₂, e₂⟩ := mem_split (p₁.subset (by simp) : a ∈ t₂)
+    subst t₂; exact (w₁ rfl rfl).trans (w₂ rfl rfl)
 
 theorem Perm.cons_inv {a : α} {l₁ l₂ : List α} : a :: l₁ ~ a :: l₂ → l₁ ~ l₂ :=
   @perm_inv_core _ _ [] [] _ _
@@ -151,28 +127,21 @@ theorem Perm.length_eq {l₁ l₂ : List α} (p : l₁ ~ l₂) : length l₁ = l
   | swap _ _ l => simp
   | trans _ _ ih₁ ih₂ => exact ih₁.trans ih₂
 
-theorem Perm.eq_nil {l : List α} (p : l ~ []) : l = [] :=
-  eq_nil_of_length_eq_zero p.length_eq
+theorem Perm.eq_nil {l : List α} (p : l ~ []) : l = [] := eq_nil_of_length_eq_zero p.length_eq
 
-theorem Perm.nil_eq {l : List α} (p : [] ~ l) : [] = l :=
-  p.symm.eq_nil.symm
+theorem Perm.nil_eq {l : List α} (p : [] ~ l) : [] = l := p.symm.eq_nil.symm
 
 theorem Perm.pairwise_iff {R : α → α → Prop} (S : symmetric R) :
-  ∀ {l₁ l₂ : List α}, l₁ ~ l₂ → (Pairwise R l₁ ↔ Pairwise R l₂) := by
+    ∀ {l₁ l₂ : List α}, l₁ ~ l₂ → (Pairwise R l₁ ↔ Pairwise R l₂) := by
   suffices ∀ {l₁ l₂}, l₁ ~ l₂ → Pairwise R l₁ → Pairwise R l₂ from
     fun l₁ l₂ p => ⟨this p, this p.symm⟩
   intros l₁ l₂ p d
   induction d generalizing l₂ with
-  | nil =>
-      rw [←p.nil_eq]
-      constructor
+  | nil => rw [← p.nil_eq]; constructor
   | @cons a h d _ ih =>
-      have : a ∈ l₂ := p.subset (mem_cons_self _ _)
-      rcases mem_split this with ⟨s₂, t₂, rfl⟩
-      have p' := (p.trans perm_middle).cons_inv
-      refine' (pairwise_middle S).2 (Pairwise_cons.2 ⟨_, ih p'⟩)
-      intro b m
-      exact d _ (p'.symm.subset m)
+    obtain ⟨s₂, t₂, rfl⟩ := mem_split (p.subset (.head ..) : a ∈ l₂)
+    have p' := (p.trans perm_middle).cons_inv
+    exact (pairwise_middle S).2 (Pairwise_cons.2 ⟨fun b m => d _ (p'.symm.subset m), ih p'⟩)
 
 theorem Perm.nodup_iff {l₁ l₂ : List α} : l₁ ~ l₂ → (Nodup l₁ ↔ Nodup l₂) :=
   Perm.pairwise_iff <| @Ne.symm α

--- a/Mathlib/Data/List/Perm.lean
+++ b/Mathlib/Data/List/Perm.lean
@@ -1,6 +1,5 @@
 import Mathlib.Init.Set
-import Mathlib.Data.List.Basic
-import Mathlib.Tactic.ShowTerm
+import Mathlib.Data.List.Pairwise
 
 namespace List
 
@@ -167,12 +166,13 @@ theorem Perm.pairwise_iff {R : α → α → Prop} (S : symmetric R) :
   | nil =>
       rw [←p.nil_eq]
       constructor
-  | @cons a h d ih =>
+  | @cons a h d _ ih =>
       have : a ∈ l₂ := p.subset (mem_cons_self _ _)
       rcases mem_split this with ⟨s₂, t₂, rfl⟩
       have p' := (p.trans perm_middle).cons_inv
-      refine' (pairwise_middle S).2 (pairwise_cons.2 ⟨fun b m => _, IH _ p'⟩)
-      exact h _ (p'.symm.subset m)
+      refine' (pairwise_middle S).2 (Pairwise_cons.2 ⟨_, ih p'⟩)
+      intro b m
+      exact d _ (p'.symm.subset m)
 
 theorem Perm.nodup_iff {l₁ l₂ : List α} : l₁ ~ l₂ → (Nodup l₁ ↔ Nodup l₂) :=
   Perm.pairwise_iff <| @Ne.symm α

--- a/Mathlib/Data/List/Perm.lean
+++ b/Mathlib/Data/List/Perm.lean
@@ -84,9 +84,9 @@ theorem perm_inv_core {a : α} {l₁ l₂ r₁ r₂ : List α} : l₁ ++ a :: r�
   generalize e₂ : l₂ ++ a :: r₂ = s₂
   intro p
   revert l₁ l₂ r₁ r₂ e₁ e₂
-  refine' perm_induction_on p _ (fun x t₁ t₂ p IH => _) (fun x y t₁ t₂ p IH => _) (fun t₁ t₂ t₃ p₁ p₂ IH₁ IH₂ => _)
-  · intro e₁ e₂
-    apply (not_mem_nil a).elim
+  refine' @(perm_induction_on p _ (fun x t₁ t₂ p IH => _) (fun x y t₁ t₂ p IH => _) (fun t₁ t₂ t₃ p₁ p₂ IH₁ IH₂ => _))
+    <;> intro l₁ l₂ r₁ r₂ e₁ e₂
+  · apply (not_mem_nil a).elim
     rw [← e₁]
     simp
   · rcases l₁ with ⟨y,l₁⟩ <;> rcases l₂ with ⟨z,l₂⟩ <;> dsimp at e₁ e₂ <;> injections <;> subst x

--- a/Mathlib/Data/List/Perm.lean
+++ b/Mathlib/Data/List/Perm.lean
@@ -72,7 +72,8 @@ theorem Perm.mem_iff {a : α} {l₁ l₂ : List α} (h : l₁ ~ l₂) : a ∈ l�
 
 /-- The way Lean 4 computes the motive with `elabAsElim` has changed
 relative to the behaviour of `elab_as_eliminator` in Lean 3.
-See https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/Potential.20elaboration.20bug.20with.20.60elabAsElim.60/near/299573172
+See
+https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/Potential.20elaboration.20bug.20with.20.60elabAsElim.60/near/299573172
 for an explanation of the change made here relative to mathlib3.
 -/
 @[elabAsElim]

--- a/Mathlib/Data/Multiset/Basic.lean
+++ b/Mathlib/Data/Multiset/Basic.lean
@@ -8,11 +8,6 @@ import Mathlib.Data.List.Perm
 /-!
 # Multisets
 These are implemented as the quotient of a list by permutations.
-
-TODO: This is currently extremely minimal,
-containing only the definitions required to implement the `fin_cases` tactic.
-Please update this module doc as changes are made,
-eventually restoring the original mathlib3 module doc.
 -/
 
 
@@ -22,8 +17,7 @@ variable {α : Type _} {β : Type _} {γ : Type _}
 
 /-- `Multiset α` is the quotient of `List α` by list permutation. The result
   is a type of finite sets with duplicates allowed.  -/
-def Multiset.{u} (α : Type u) : Type u :=
-  Quotient (List.instSetoidList α)
+def Multiset (α : Type u) : Type u := Quotient (List.instSetoidList α)
 
 section Mem
 
@@ -31,5 +25,4 @@ section Mem
 def Mem (a : α) (s : Multiset α) : Prop :=
   Quot.liftOn s (fun l => a ∈ l) fun l₁ l₂ (e : l₁ ~ l₂) => propext <| e.mem_iff
 
-instance : Membership α (Multiset α) :=
-  ⟨Mem⟩
+instance : Membership α (Multiset α) := ⟨Mem⟩

--- a/Mathlib/Data/Multiset/Basic.lean
+++ b/Mathlib/Data/Multiset/Basic.lean
@@ -1,0 +1,35 @@
+/-
+Copyright (c) 2015 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro
+-/
+import Mathlib.Data.List.Perm
+
+/-!
+# Multisets
+These are implemented as the quotient of a list by permutations.
+
+TODO: This is currently extremely minimal,
+containing only the definitions required to implement the `fin_cases` tactic.
+Please update this module doc as changes are made,
+eventually restoring the original mathlib3 module doc.
+-/
+
+
+open List Subtype Nat
+
+variable {α : Type _} {β : Type _} {γ : Type _}
+
+/-- `Multiset α` is the quotient of `List α` by list permutation. The result
+  is a type of finite sets with duplicates allowed.  -/
+def Multiset.{u} (α : Type u) : Type u :=
+  Quotient (List.instSetoidList α)
+
+section Mem
+
+/-- `a ∈ s` means that `a` has nonzero multiplicity in `s`. -/
+def Mem (a : α) (s : Multiset α) : Prop :=
+  Quot.liftOn s (fun l => a ∈ l) fun l₁ l₂ (e : l₁ ~ l₂) => propext <| e.mem_iff
+
+instance : Membership α (Multiset α) :=
+  ⟨Mem⟩

--- a/Mathlib/Data/Multiset/Nodup.lean
+++ b/Mathlib/Data/Multiset/Nodup.lean
@@ -6,11 +6,6 @@ Authors: Mario Carneiro
 import Mathlib.Data.Multiset.Basic
 /-!
 # The `nodup` predicate for multisets without duplicate elements.
-
-TODO: This is currently extremely minimal,
-containing only the definitions required to implement the `fin_cases` tactic.
-Please update this module doc as changes are made,
-eventually restoring the original mathlib3 module doc.
 -/
 
 

--- a/Mathlib/Data/Multiset/Nodup.lean
+++ b/Mathlib/Data/Multiset/Nodup.lean
@@ -1,0 +1,26 @@
+/-
+Copyright (c) 2015 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro
+-/
+import Mathlib.Data.Multiset.Basic
+/-!
+# The `nodup` predicate for multisets without duplicate elements.
+
+TODO: This is currently extremely minimal,
+containing only the definitions required to implement the `fin_cases` tactic.
+Please update this module doc as changes are made,
+eventually restoring the original mathlib3 module doc.
+-/
+
+
+namespace Multiset
+
+open Function List
+
+variable {α β γ : Type _} {r : α → α → Prop} {s t : Multiset α} {a : α}
+
+/-- `nodup s` means that `s` has no duplicates, i.e. the multiplicity of
+  any element is at most 1. -/
+def Nodup (s : Multiset α) : Prop :=
+  Quot.liftOn s List.Nodup fun _ _ p => propext p.nodup_iff

--- a/Mathlib/Logic/Basic.lean
+++ b/Mathlib/Logic/Basic.lean
@@ -238,3 +238,9 @@ end quantifiers
 
 /-- In classical logic, we can decide a proposition. -/
 noncomputable def Classical.dec (p : Prop) : Decidable p := inferInstance
+
+theorem forall_true_iff : α → True ↔ True :=
+Iff.intro (fun _ => trivial) (fun _ _ => trivial)
+
+theorem forall_prop_of_false {p : Prop} {q : p → Prop} (hn : ¬p) : (∀ h' : p, q h') ↔ True :=
+  iff_true_intro fun h => hn.elim h

--- a/Mathlib/Logic/Basic.lean
+++ b/Mathlib/Logic/Basic.lean
@@ -239,8 +239,7 @@ end quantifiers
 /-- In classical logic, we can decide a proposition. -/
 noncomputable def Classical.dec (p : Prop) : Decidable p := inferInstance
 
-theorem forall_true_iff : α → True ↔ True :=
-Iff.intro (fun _ => trivial) (fun _ _ => trivial)
+theorem forall_true_iff : α → True ↔ True := iff_true_intro fun _ => trivial
 
 theorem forall_prop_of_false {p : Prop} {q : p → Prop} (hn : ¬p) : (∀ h' : p, q h') ↔ True :=
   iff_true_intro fun h => hn.elim h


### PR DESCRIPTION
This is a bare minimum port of the definitions of `Finset` / `Multiset` / `Fintype`. I am hoping that these are enough to port the `fin_cases` tactic. (i.e. replacing the unfinished work in #346, which still had sorries in the corresponding material)

Where possible I have started by copying and pasting the output from `mathlib3port`.

