### PR TITLE
[Merged by Bors] - chore: import induction' everywhere

### DIFF
--- a/Mathlib/Tactic/Basic.lean
+++ b/Mathlib/Tactic/Basic.lean
@@ -5,6 +5,7 @@ Authors: Mario Carneiro
 -/
 import Lean
 import Std
+import Mathlib.Tactic.Cases
 
 open Lean Parser.Tactic Elab Command Elab.Tactic Meta
 


### PR DESCRIPTION
By adding `import Mathlib.Tactic.Cases` to `Mathlib/Tactic/Basic`, we ensure that `induction'`, which is used frequently by `mathport`'s output, is available everywhere.