### PR TITLE
[Merged by Bors] - chore: remove fsplit from Syntax.lean

### DIFF
--- a/Mathlib/Mathport/Syntax.lean
+++ b/Mathlib/Mathport/Syntax.lean
@@ -221,7 +221,6 @@ end Conv
 /- E -/ syntax (name := symm') "symm'" (ppSpace location)? : tactic
 /- E -/ syntax (name := trans') "trans'" (ppSpace term)? : tactic
 
-/- E -/ syntax (name := fsplit) "fsplit" : tactic
 /- M -/ syntax (name := injectionsAndClear) "injections_and_clear" : tactic
 
 /- E -/ syntax (name := tryFor) "try_for " term:max tacticSeq : tactic


### PR DESCRIPTION
mathport replaces `split` with `constructor`, and `fsplit` with `fconstructor`, so there's no need to port anything for `fsplit`.