### PR TITLE
[Merged by Bors] - feat: `simp_intro` tactic

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -120,6 +120,7 @@ import Mathlib.Tactic.RunCmd
 import Mathlib.Tactic.Sat.FromLRAT
 import Mathlib.Tactic.SeqFocus
 import Mathlib.Tactic.Set
+import Mathlib.Tactic.SimpIntro
 import Mathlib.Tactic.SimpRw
 import Mathlib.Tactic.SimpTrace
 import Mathlib.Tactic.Simps

--- a/Mathlib/Mathport/Syntax.lean
+++ b/Mathlib/Mathport/Syntax.lean
@@ -45,6 +45,7 @@ import Mathlib.Tactic.Ring
 import Mathlib.Tactic.RunCmd
 import Mathlib.Tactic.SeqFocus
 import Mathlib.Tactic.Set
+import Mathlib.Tactic.SimpIntro
 import Mathlib.Tactic.SimpRw
 import Mathlib.Tactic.Simps
 import Mathlib.Tactic.SimpTrace
@@ -203,8 +204,6 @@ namespace Tactic
 /- S -/ syntax "destruct " term : tactic
 /- N -/ syntax (name := abstract) "abstract" (ppSpace ident)? ppSpace tacticSeq : tactic
 
-/- N -/ syntax (name := simpIntro) "simp_intro" (config)?
-  (ppSpace colGt (ident <|> "_"))* (&" only")? (simpArgs)? : tactic
 /- E -/ syntax (name := symm) "symm" : tactic
 /- E -/ syntax (name := trans) "trans" (ppSpace colGt term)? : tactic
 /- B -/ syntax (name := cc) "cc" : tactic

--- a/Mathlib/Tactic/SimpIntro.lean
+++ b/Mathlib/Tactic/SimpIntro.lean
@@ -1,0 +1,74 @@
+/-
+Copyright (c) 2022 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro
+-/
+import Lean
+import Std.Lean.Parser
+
+/-! # `simp_intro` tactic -/
+
+namespace Mathlib.Tactic
+open Lean Meta Elab Tactic
+
+/--
+Main loop of the `simp_intro` tactic.
+* `g`: the original goal
+* `ctx`: the simp context, which is extended with local variables as we enter the binders
+* `discharge?`: the discharger
+* `more`: if true, we will keep introducing binders as long as we can
+* `ids`: the list of binder identifiers
+-/
+partial def simpIntroCore (g : MVarId) (ctx : Simp.Context) (discharge? : Option Simp.Discharge)
+    (more : Bool) (ids : List (TSyntax ``binderIdent)) : TermElabM (Option MVarId) := do
+  let done := return (← simpTargetCore g ctx discharge?).1
+  let (transp, var, ids') ← match ids with
+    | [] => if more then pure (.reducible, mkHole (← getRef), []) else return ← done
+    | v::ids => pure (.default, v.raw[0], ids)
+  let t ← withTransparency transp g.getType'
+  let n := if var.isIdent then var.getId else `_
+  let withFVar := fun (fvar, g) => g.withContext do
+    Term.addLocalVarInfo var (mkFVar fvar)
+    let simpTheorems ← ctx.simpTheorems.addTheorem (.fvar fvar) (.fvar fvar)
+    simpIntroCore g { ctx with simpTheorems } discharge? more ids'
+  match t with
+  | .letE .. => withFVar (← g.intro n)
+  | .forallE (body := body) .. =>
+    let (fvar, g) ← g.intro n
+    if body.hasLooseBVars then withFVar (fvar, g) else
+    match (← simpLocalDecl g fvar ctx discharge?).1 with
+    | none =>
+      g.withContext <| Term.addLocalVarInfo var (mkFVar fvar)
+      return none
+    | some g' => withFVar g'
+  | _ =>
+    if more && ids.isEmpty then done else
+    throwErrorAt var "simp_intro failed to introduce {var}\n{g}"
+
+open Parser.Tactic
+/--
+The `simp_intro` tactic is a combination of `simp` and `intro`: it will simplify the types of
+variables as it introduces them and uses the new variables to simplify later arguments
+and the goal.
+* `simp_intro x y z` introduces variables named `x y z`
+* `simp_intro x y z ..` introduces variables named `x y z` and then keeps introducing `_` binders
+* `simp_intro (config := cfg) (discharger := tac) x y .. only [h₁, h₂]`:
+  `simp_intro` takes the same options as `simp` (see `simp`)
+```
+example : x + 0 = y → x = z := by
+  simp_intro h
+  -- h: x = y ⊢ y = z
+  sorry
+```
+-/
+elab "simp_intro" cfg:(config)? disch:(discharger)?
+    ids:(ppSpace colGt binderIdent)* more:" .."? only:(&" only")? args:(simpArgs)? : tactic => do
+  let args := args.map fun args => ⟨args.raw[1].getArgs⟩
+  let stx ← `(tactic| simp $(cfg)? $(disch)? $[only%$only]? $[[$args,*]]?)
+  let { ctx, dischargeWrapper } ← withMainContext <| mkSimpContext stx (eraseLocal := false)
+  dischargeWrapper.with fun discharge? => do
+    let g ← getMainGoal
+    g.checkNotAssigned `simp_intro
+    g.withContext do
+      let g? ← simpIntroCore g ctx discharge? more.isSome ids.toList
+      replaceMainGoal <| if let some g := g? then [g] else []

--- a/test/simp_intro.lean
+++ b/test/simp_intro.lean
@@ -1,0 +1,20 @@
+import Std.Tactic.GuardExpr
+import Mathlib.Tactic.SimpIntro
+
+example : x + 0 = y → x = y := by
+  simp_intro
+  guard_target == x = y → x = y
+  exact id
+
+example : x + 0 = y → x = y := by simp_intro h₁
+example : x + 0 ≠ y → x ≠ y := by simp_intro h₁ h₂ -- h₂ is bound but not needed
+example : x + 0 ≠ y → x ≠ y := by simp_intro h₁ h₂ h₃ -- h₃ is not bound
+
+example (h : x = z) : x + 0 = y → x = z := by simp_intro [h]
+
+example (h : y = z) : x + 0 = y → x = z := by
+  simp_intro
+  guard_target == x = y → x = z
+  simp_intro .. [h]
+
+example (h : y = z) : x + 0 = y → x = z := by simp_intro _; exact h


### PR DESCRIPTION
The `simp_intro` tactic is a combination of `simp` and `intro`: it will simplify the types of variables as it introduces them and uses the new variables to simplify later arguments and the goal.
```lean
example : x + 0 = y → x = z := by
  simp_intro h
  -- h: x = y ⊢ y = z
  sorry
```