### PR TITLE
[Merged by Bors] - feat(Mathlib/Tactic/Contrapose): add `contrapose` tactic

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -70,6 +70,7 @@ import Mathlib.Tactic.Clear_
 import Mathlib.Tactic.Coe
 import Mathlib.Tactic.CommandQuote
 import Mathlib.Tactic.Constructor
+import Mathlib.Tactic.Contrapose
 import Mathlib.Tactic.Conv
 import Mathlib.Tactic.Core
 import Mathlib.Tactic.Existsi

--- a/Mathlib/Mathport/Syntax.lean
+++ b/Mathlib/Mathport/Syntax.lean
@@ -294,9 +294,6 @@ syntax termList := " [" term,* "]"
 
 /- S -/ syntax (name := prettyCases) "pretty_cases" : tactic
 
-/- M -/ syntax (name := contrapose) "contrapose" (ppSpace ident (" with " ident)?)? : tactic
-/- M -/ syntax (name := contrapose!) "contrapose!" (ppSpace ident (" with " ident)?)? : tactic
-
 /- M -/ syntax (name := assocRw) "assoc_rw " rwRuleSeq (ppSpace location)? : tactic
 
 /- N -/ syntax (name := dsimpResult) "dsimp_result "

--- a/Mathlib/Tactic/Contrapose.lean
+++ b/Mathlib/Tactic/Contrapose.lean
@@ -1,0 +1,29 @@
+import Mathlib.Tactic.PushNeg
+
+namespace Mathlib.Tactic.Contrapose
+
+lemma mtr {p q : Prop} : (¬ q → ¬ p) → (p → q) := fun h hp => by_contra (fun h' => h h' hp)
+
+/--
+Transforms the goal into its contrapositive.
+* `contrapose`     turns a goal `P → Q` into `¬ Q → ¬ P`
+* `contrapose h`   first reverts the local assumption `h`, and then uses `contrapose` and `intro h`
+* `contrapose h with new_h` uses the name `new_h` for the introduced hypothesis
+-/
+syntax (name := contrapose) "contrapose" (ppSpace colGt ident (" with " ident)?)? : tactic
+macro_rules
+  | `(tactic| contrapose) => `(tactic| (refine mtr ?_))
+  | `(tactic| contrapose $e) => `(tactic| (revert $e:ident; contrapose; intro $e:ident))
+  | `(tactic| contrapose $e with $e') => `(tactic| (revert $e:ident; contrapose; intro $e':ident))
+
+/--
+Transforms the goal into its contrapositive and uses pushes negations inside `P` and `Q`.
+Usage matches `contrapose`
+-/
+syntax (name := contrapose!) "contrapose!" (ppSpace colGt ident (" with " ident)?)? : tactic
+macro_rules
+  | `(tactic| contrapose!) => `(tactic| (contrapose; push_neg))
+  | `(tactic| contrapose! $e) => `(tactic| (revert $e:ident; contrapose!; intro $e:ident))
+  | `(tactic| contrapose! $e with $e') => `(tactic| (revert $e:ident; contrapose!; intro $e':ident))
+
+end Mathlib.Tactic.Contrapose

--- a/Mathlib/Tactic/Contrapose.lean
+++ b/Mathlib/Tactic/Contrapose.lean
@@ -1,5 +1,24 @@
+/-
+Copyright (c) 2022 Jireh Loreaux. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jireh Loreaux
+-/
+
 import Mathlib.Tactic.PushNeg
 
+/-! # Contrapose
+
+The `contrapose` tactic transforms the goal into its contrapositive when that goal is an
+implication.
+
+* `contrapose`     turns a goal `P → Q` into `¬ Q → ¬ P`
+* `contrapose!`    turns a goal `P → Q` into `¬ Q → ¬ P` and pushes negations inside `P` and `Q`
+  using `push_neg`
+* `contrapose h`   first reverts the local assumption `h`, and then uses `contrapose` and `intro h`
+* `contrapose! h`  first reverts the local assumption `h`, and then uses `contrapose!` and `intro h`
+* `contrapose h with new_h` uses the name `new_h` for the introduced hypothesis
+
+-/
 namespace Mathlib.Tactic.Contrapose
 
 lemma mtr {p q : Prop} : (¬ q → ¬ p) → (p → q) := fun h hp => by_contra (fun h' => h h' hp)

--- a/test/Contrapose.lean
+++ b/test/Contrapose.lean
@@ -1,3 +1,9 @@
+/-
+Copyright (c) 2022 Jireh Loreaux. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jireh Loreaux
+-/
+
 import Mathlib.Tactic.Basic
 import Mathlib.Tactic.Contrapose
 

--- a/test/Contrapose.lean
+++ b/test/Contrapose.lean
@@ -1,0 +1,40 @@
+import Mathlib.Tactic.Basic
+import Mathlib.Tactic.Contrapose
+
+example (p q : Prop) (h : ¬q → ¬p) : p → q := by
+  contrapose
+  guard_target == ¬q → ¬p
+  exact h
+
+example (p q : Prop) (h : p) (hpq : ¬q → ¬p) : q := by
+  contrapose h
+  guard_target == ¬p
+  exact hpq h
+
+example (p q : Prop) (h : p) (hpq : ¬q → ¬p) : q := by
+  contrapose h with h'
+  guard_target == ¬p
+  exact hpq h'
+
+example (p q : Prop) (h : q → p) : ¬p → ¬q := by
+  contrapose!
+  guard_target == q → p
+  exact h
+
+example (p q : Prop) (h : ¬p) (hpq : q → p) : ¬q := by
+  contrapose! h
+  guard_target == p
+  exact hpq h
+
+example (p q : Prop) (h : ¬p) (hpq : q → p) : ¬q := by
+  contrapose! h with h'
+  guard_target == p
+  exact hpq h'
+
+example (p : Prop) (h : p) : p := by
+  fail_if_success { contrapose }
+  exact h
+
+example (p q : Type) (h : p → q) : p → q := by
+  fail_if_success { contrapose }
+  exact h


### PR DESCRIPTION
This ports `contrapose` and `contrapose!` as a collection of macro rules and provides a few basic tests.