### PR TITLE
[Merged by Bors] - Mark `h_generalize` as `S`

### DIFF
--- a/Mathlib/Mathport/Syntax.lean
+++ b/Mathlib/Mathport/Syntax.lean
@@ -226,9 +226,9 @@ namespace Tactic
 /- S -/ syntax (name := haveField) "have_field" : tactic
 /- S -/ syntax (name := applyField) "apply_field" : tactic
 /- M -/ syntax (name := applyRules) "apply_rules" (config)? " [" term,* "]" (ppSpace num)? : tactic
-/- M -/ syntax (name := hGeneralize) "h_generalize " atomic(binderIdent " : ")? term:51 " = " ident
+/- S -/ syntax (name := hGeneralize) "h_generalize " atomic(binderIdent " : ")? term:51 " = " ident
   (" with " binderIdent)? : tactic
-/- M -/ syntax (name := hGeneralize!) "h_generalize! " atomic(binderIdent " : ")? term:51 " = " ident
+/- S -/ syntax (name := hGeneralize!) "h_generalize! " atomic(binderIdent " : ")? term:51 " = " ident
   (" with " binderIdent)? : tactic
 /- S -/ syntax (name := extractGoal) "extract_goal" (ppSpace ident)?
   (" with" (ppSpace (colGt ident))*)? : tactic


### PR DESCRIPTION
In https://github.com/leanprover-community/mathlib/pull/16839 I removed all uses of the `h_generalize` tactics in mathlib, so that we can ignore it for the purposes of a working port of mathlib

Due dilligence reveals that it is used a few times in flypitch, https://github.com/flypitch/flypitch/blob/aea5800db1f4cce53fc4a113711454b27388ecf8/src/forcing.lean, so maybe a more ambitious mathport would cover it, but it certainly seems low priority to me