### PR TITLE
[Merged by Bors] - feat: align Exists.choose and Exists.choose_spec

### DIFF
--- a/Mathlib/Mathport/SpecialNames.lean
+++ b/Mathlib/Mathport/SpecialNames.lean
@@ -29,6 +29,9 @@ namespace Mathlib.Prelude
 #align classical.some          Classical.choose
 #align classical.some_spec     Classical.choose_spec
 
+#align Exists.some             Exists.choose
+#align Exists.some_spec        Exists.choose_spec
+
 #align has_coe Coe
 #align has_coe.coe Coe.coe
 


### PR DESCRIPTION
Continuing from https://github.com/leanprover-community/mathlib4/pull/391, aligns mathlib3's `Exists.some` to std4's `Exists.choose` and, mathlib3's `Exists.some_spec` to std4's `Exists.choose_spec`.



Lean 3: https://github.com/leanprover-community/mathlib/blob/d20f598ea7bbf11ae0f59ef4b95adb413ef7698d/src/logic/basic.lean#L1029-L1038

Lean 4: https://github.com/leanprover/std4/blob/b3590e627717a7d7b981924fa7b1ae0527a7627e/Std/Logic.lean#L409-L414