### PR TITLE
[Merged by Bors] - feat: port algebra.abs

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1,3 +1,4 @@
+import Mathlib.Algebra.Abs
 import Mathlib.Algebra.CovariantAndContravariant
 import Mathlib.Algebra.Group.Basic
 import Mathlib.Algebra.Group.Commute

--- a/Mathlib/Algebra/Abs.lean
+++ b/Mathlib/Algebra/Abs.lean
@@ -3,18 +3,18 @@ Copyright (c) 2021 Christopher Hoskin. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Christopher Hoskin
 -/
-
+import Mathlib.Mathport.Rename
 /-!
 # Absolute value
 
-This file defines a notational class `has_abs` which adds the unary operator `abs` and the notation
+This file defines a notational class `Abs` which adds the unary operator `abs` and the notation
 `|.|`. The concept of an absolute value occurs in lattice ordered groups and in GL and GM spaces.
 
 Mathematical structures possessing an absolute value often also possess a unique decomposition of
 elements into "positive" and "negative" parts which are in some sense "disjoint" (e.g. the Jordan
-decomposition of a measure). This file also defines `has_pos_part` and `has_neg_part` classes
+decomposition of a measure). This file also defines `PosPart` and `NegPart` classes
 which add unary operators `pos` and `neg`, representing the maps taking an element to its positive
-and negative part respectively along with the notation ⁺ and ⁻.
+and negative part respectively along with the notation `⁺` and `⁻`.
 
 ## Notations
 
@@ -30,25 +30,32 @@ absolute
 -/
 
 
-/-- Absolute value is a unary operator with properties similar to the absolute value of a real number.
+/--
+Absolute value is a unary operator with properties similar to the absolute value of a real number.
 -/
-class HasAbs (α : Type _) where
+class Abs (α : Type _) where
   abs : α → α
 
-export HasAbs (abs)
+#align has_abs Abs
+
+export Abs (abs)
 
 /-- The positive part of an element admiting a decomposition into positive and negative parts.
 -/
-class HasPosPart (α : Type _) where
+class PosPart (α : Type _) where
   Pos : α → α
+
+#align has_pos_part PosPart
 
 /-- The negative part of an element admiting a decomposition into positive and negative parts.
 -/
-class HasNegPart (α : Type _) where
+class NegPart (α : Type _) where
   neg : α → α
 
--- mathport name: «expr ⁺»
-postfix:1000 "⁺" => HasPosPart.pos
+#align has_neg_part NegPart
 
--- mathport name: «expr ⁻»
-postfix:1000 "⁻" => HasNegPart.neg
+macro atomic("|" noWs) a:term noWs "|" : term => `(abs $a)
+
+postfix:1000 "⁺" => PosPart.pos
+
+postfix:1000 "⁻" => NegPart.neg

--- a/Mathlib/Algebra/Abs.lean
+++ b/Mathlib/Algebra/Abs.lean
@@ -1,0 +1,54 @@
+/-
+Copyright (c) 2021 Christopher Hoskin. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Christopher Hoskin
+-/
+
+/-!
+# Absolute value
+
+This file defines a notational class `has_abs` which adds the unary operator `abs` and the notation
+`|.|`. The concept of an absolute value occurs in lattice ordered groups and in GL and GM spaces.
+
+Mathematical structures possessing an absolute value often also possess a unique decomposition of
+elements into "positive" and "negative" parts which are in some sense "disjoint" (e.g. the Jordan
+decomposition of a measure). This file also defines `has_pos_part` and `has_neg_part` classes
+which add unary operators `pos` and `neg`, representing the maps taking an element to its positive
+and negative part respectively along with the notation ⁺ and ⁻.
+
+## Notations
+
+The following notation is introduced:
+
+* `|.|` for the absolute value;
+* `.⁺` for the positive part;
+* `.⁻` for the negative part.
+
+## Tags
+
+absolute
+-/
+
+
+/-- Absolute value is a unary operator with properties similar to the absolute value of a real number.
+-/
+class HasAbs (α : Type _) where
+  abs : α → α
+
+export HasAbs (abs)
+
+/-- The positive part of an element admiting a decomposition into positive and negative parts.
+-/
+class HasPosPart (α : Type _) where
+  Pos : α → α
+
+/-- The negative part of an element admiting a decomposition into positive and negative parts.
+-/
+class HasNegPart (α : Type _) where
+  neg : α → α
+
+-- mathport name: «expr ⁺»
+postfix:1000 "⁺" => HasPosPart.pos
+
+-- mathport name: «expr ⁻»
+postfix:1000 "⁻" => HasNegPart.neg

--- a/Mathlib/Algebra/Abs.lean
+++ b/Mathlib/Algebra/Abs.lean
@@ -34,6 +34,7 @@ absolute
 Absolute value is a unary operator with properties similar to the absolute value of a real number.
 -/
 class Abs (α : Type _) where
+  /-- The absolute value function. -/
   abs : α → α
 
 #align has_abs Abs
@@ -43,19 +44,24 @@ export Abs (abs)
 /-- The positive part of an element admiting a decomposition into positive and negative parts.
 -/
 class PosPart (α : Type _) where
-  Pos : α → α
+  /-- The positive part function. -/
+  pos : α → α
 
 #align has_pos_part PosPart
 
 /-- The negative part of an element admiting a decomposition into positive and negative parts.
 -/
 class NegPart (α : Type _) where
+  /-- The negative part function. -/
   neg : α → α
 
 #align has_neg_part NegPart
 
+@[inheritDoc Abs.abs]
 macro atomic("|" noWs) a:term noWs "|" : term => `(abs $a)
 
+@[inheritDoc]
 postfix:1000 "⁺" => PosPart.pos
 
+@[inheritDoc]
 postfix:1000 "⁻" => NegPart.neg


### PR DESCRIPTION
Note that `mathport` completely dropped the line ``notation `|`a`|` := abs a`` in https://github.com/leanprover-community/mathlib3port/blob/5a66d9b4aff2f94aabca7f3daead2a383d7f2117/Mathbin/Algebra/Abs.lean.