### PR TITLE
[Merged by Bors] - feat: port Data.Prop.PProd

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -40,7 +40,7 @@ import Mathlib.Data.Nat.Basic
 import Mathlib.Data.Option.Basic
 import Mathlib.Data.Option.Defs
 import Mathlib.Data.Prod
-import Mathlib.Data.Prod.PProp
+import Mathlib.Data.Prod.PProd
 import Mathlib.Data.Sigma.Basic
 import Mathlib.Data.String.Defs
 import Mathlib.Data.String.Lemmas

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -40,6 +40,7 @@ import Mathlib.Data.Nat.Basic
 import Mathlib.Data.Option.Basic
 import Mathlib.Data.Option.Defs
 import Mathlib.Data.Prod
+import Mathlib.Data.Prod.PProp
 import Mathlib.Data.Sigma.Basic
 import Mathlib.Data.String.Defs
 import Mathlib.Data.String.Lemmas

--- a/Mathlib/Data/Prod/PProd.lean
+++ b/Mathlib/Data/Prod/PProd.lean
@@ -1,0 +1,43 @@
+/-
+Copyright (c) 2020 Eric Wieser. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Eric Wieser
+-/
+import Mathlib.Logic.Basic
+
+/-!
+# Extra facts about `pprod`
+-/
+
+
+open Function
+
+variable {α β γ δ : Sort _}
+
+namespace PProd
+
+@[simp]
+theorem mk.eta {p : PProd α β} : PProd.mk p.1 p.2 = p :=
+  PProd.casesOn p fun _ _ => rfl
+
+@[simp]
+theorem «forall» {p : PProd α β → Prop} : (∀ x, p x) ↔ ∀ a b, p ⟨a, b⟩ :=
+  ⟨fun h a b => h ⟨a, b⟩, fun h ⟨a, b⟩ => h a b⟩
+
+@[simp]
+theorem «exists» {p : PProd α β → Prop} : (∃ x, p x) ↔ ∃ a b, p ⟨a, b⟩ :=
+  ⟨fun ⟨⟨a, b⟩, h⟩ => ⟨a, b, h⟩, fun ⟨a, b, h⟩ => ⟨⟨a, b⟩, h⟩⟩
+
+theorem forall' {p : α → β → Prop} : (∀ x : PProd α β, p x.1 x.2) ↔ ∀ a b, p a b :=
+  PProd.forall
+
+theorem exists' {p : α → β → Prop} : (∃ x : PProd α β, p x.1 x.2) ↔ ∃ a b, p a b :=
+  PProd.exists
+
+end PProd
+
+theorem Function.Injective.pprod_map {f : α → β} {g : γ → δ} (hf : injective f) (hg : injective g) :
+    injective (fun x => ⟨f x.1, g x.2⟩ : PProd α γ → PProd β δ) := fun _ _ h =>
+  have A := congr_arg PProd.fst h
+  have B := congr_arg PProd.snd h
+  congr_arg2 PProd.mk (hf A) (hg B)

--- a/Mathlib/Data/Prod/PProd.lean
+++ b/Mathlib/Data/Prod/PProd.lean
@@ -40,4 +40,4 @@ theorem Function.Injective.pprod_map {f : α → β} {g : γ → δ} (hf : injec
     injective (fun x => ⟨f x.1, g x.2⟩ : PProd α γ → PProd β δ) := fun _ _ h =>
   have A := congr_arg PProd.fst h
   have B := congr_arg PProd.snd h
-  congr_arg2 PProd.mk (hf A) (hg B)
+  congr_arg₂ PProd.mk (hf A) (hg B)

--- a/Mathlib/Data/Prod/PProd.lean
+++ b/Mathlib/Data/Prod/PProd.lean
@@ -36,7 +36,7 @@ theorem exists' {p : α → β → Prop} : (∃ x : PProd α β, p x.1 x.2) ↔ 
 
 end PProd
 
-theorem Function.injective.pprod_map {f : α → β} {g : γ → δ} (hf : injective f) (hg : injective g) :
+theorem Function.Injective.pprod_map {f : α → β} {g : γ → δ} (hf : injective f) (hg : injective g) :
     injective (fun x => ⟨f x.1, g x.2⟩ : PProd α γ → PProd β δ) := fun _ _ h =>
   have A := congr_arg PProd.fst h
   have B := congr_arg PProd.snd h

--- a/Mathlib/Data/Prod/PProd.lean
+++ b/Mathlib/Data/Prod/PProd.lean
@@ -36,8 +36,8 @@ theorem exists' {p : α → β → Prop} : (∃ x : PProd α β, p x.1 x.2) ↔ 
 
 end PProd
 
-theorem Function.Injective.pprod_map {f : α → β} {g : γ → δ} (hf : injective f) (hg : injective g) :
-    injective (fun x => ⟨f x.1, g x.2⟩ : PProd α γ → PProd β δ) := fun _ _ h =>
+theorem Function.Injective.pprod_map {f : α → β} {g : γ → δ} (hf : Injective f) (hg : Injective g) :
+    Injective (fun x => ⟨f x.1, g x.2⟩ : PProd α γ → PProd β δ) := fun _ _ h =>
   have A := congr_arg PProd.fst h
   have B := congr_arg PProd.snd h
   congr_arg₂ PProd.mk (hf A) (hg B)

--- a/Mathlib/Data/Prod/PProd.lean
+++ b/Mathlib/Data/Prod/PProd.lean
@@ -36,7 +36,7 @@ theorem exists' {p : α → β → Prop} : (∃ x : PProd α β, p x.1 x.2) ↔ 
 
 end PProd
 
-theorem Function.Injective.pprod_map {f : α → β} {g : γ → δ} (hf : injective f) (hg : injective g) :
+theorem Function.injective.pprod_map {f : α → β} {g : γ → δ} (hf : injective f) (hg : injective g) :
     injective (fun x => ⟨f x.1, g x.2⟩ : PProd α γ → PProd β δ) := fun _ _ h =>
   have A := congr_arg PProd.fst h
   have B := congr_arg PProd.snd h


### PR DESCRIPTION
Doesn't need the full port of `logic.basic` so we can port without depending on the other PR