### PR TITLE
feat: port add_decl_doc

### DIFF
--- a/Mathlib/Mathport/Syntax.lean
+++ b/Mathlib/Mathport/Syntax.lean
@@ -512,7 +512,6 @@ end Attr
 namespace Command
 
 /- N -/ syntax (name := addTacticDoc) (docComment)? "add_tactic_doc " term : command
-/- N -/ syntax (name := addDeclDoc) docComment "add_decl_doc " ident : command
 
 /- S -/ syntax (name := setupTacticParser) "setup_tactic_parser" : command
 /- N -/ syntax (name := mkSimpAttribute) "mk_simp_attribute " ident

--- a/Mathlib/Tactic/DocCommands.lean
+++ b/Mathlib/Tactic/DocCommands.lean
@@ -11,6 +11,9 @@ import Mathlib.Lean.Expr.Basic
 -/
 open Lean Elab
 
+-- TODO we need to check whether `inherit_doc` attribute works on foreign definitions.
+-- If it does, then we don't need `copy_doc_string`, because we can
+-- use `attribute [inherit_doc fr] to1 to2.`
 /--
 `copy_doc_string source → target_1 target_2 ... target_n` copies the doc string of the
 declaration named `source` to each of `target_1`, `target_2`, ..., `target_n`.

--- a/test/DocCommands.lean
+++ b/test/DocCommands.lean
@@ -1,8 +1,7 @@
 import Mathlib.Tactic.DocCommands
+open Lean
 
-/--
-This is my amazing docstring.
--/
+/--This is my amazing docstring.-/
 def hi (x: Nat) := x + 1
 
 def one : Nat := 2 + 3
@@ -11,6 +10,7 @@ def three : Nat := 10
 
 copy_doc_string hi → one two
 
-#print one   -- we see a docstring
-#print two   -- we see a docstring
-#print three -- no docstring
+#eval show MetaM _ from do
+  guard ((<- findDocString? (<- getEnv) `one) == some "This is my amazing docstring.")
+  guard ((<- findDocString? (<- getEnv) `two) == some "This is my amazing docstring.")
+  guard ((<- findDocString? (<- getEnv) `three) == none)

--- a/test/DocCommands.lean
+++ b/test/DocCommands.lean
@@ -11,6 +11,17 @@ def three : Nat := 10
 copy_doc_string hi → one two
 
 #eval show MetaM _ from do
-  guard ((<- findDocString? (<- getEnv) `one) == some "This is my amazing docstring.")
-  guard ((<- findDocString? (<- getEnv) `two) == some "This is my amazing docstring.")
-  guard ((<- findDocString? (<- getEnv) `three) == none)
+  guard ((← findDocString? (← getEnv) `one) == some "This is my amazing docstring.")
+  guard ((← findDocString? (← getEnv) `two) == some "This is my amazing docstring.")
+  guard ((← findDocString? (← getEnv) `three) == none)
+
+
+def four := 4
+def five := 5
+
+/--Doc string for four.-/
+add_decl_doc four
+
+#eval show MetaM _ from do
+  guard ((← findDocString? (← getEnv) `four) == some "Doc string for four.")
+  guard ((← findDocString? (← getEnv) `five) == none)


### PR DESCRIPTION
- Add tests for `copy_doc_string` and `add_decl_doc`
- Remove `add_decl_doc` from `Syntax.lean` (because it's already implemented in Lean4)