### PR TITLE
[Merged by Bors] - chore: capitalise Injective

### DIFF
--- a/Mathlib/Algebra/Group/Basic.lean
+++ b/Mathlib/Algebra/Group/Basic.lean
@@ -143,15 +143,15 @@ section HasInvolutiveInv
 variable [HasInvolutiveInv G] {a b : G}
 
 @[simp, to_additive]
-theorem inv_involutive : Function.involutive (Inv.inv : G → G) :=
+theorem inv_involutive : Function.Involutive (Inv.inv : G → G) :=
   inv_inv
 
 @[simp, to_additive]
-theorem inv_surjective : Function.surjective (Inv.inv : G → G) :=
+theorem inv_surjective : Function.Surjective (Inv.inv : G → G) :=
   inv_involutive.surjective
 
 @[to_additive]
-theorem inv_injective : Function.injective (Inv.inv : G → G) :=
+theorem inv_injective : Function.Injective (Inv.inv : G → G) :=
   inv_involutive.injective
 
 @[simp, to_additive]
@@ -403,11 +403,11 @@ variable [Group G] {a b c d : G}
 theorem div_eq_inv_self : a / b = b⁻¹ ↔ a = 1 := by rw [div_eq_mul_inv, mul_left_eq_self]
 
 @[to_additive]
-theorem mul_left_surjective (a : G) : Function.surjective ((· * ·) a) :=
+theorem mul_left_surjective (a : G) : Function.Surjective ((· * ·) a) :=
   fun x => ⟨a⁻¹ * x, mul_inv_cancel_left a x⟩
 
 @[to_additive]
-theorem mul_right_surjective (a : G) : Function.surjective fun x => x * a := fun x =>
+theorem mul_right_surjective (a : G) : Function.Surjective fun x => x * a := fun x =>
   ⟨x * a⁻¹, inv_mul_cancel_right x a⟩
 
 @[to_additive]
@@ -473,13 +473,13 @@ theorem mul_inv_eq_one : a * b⁻¹ = 1 ↔ a = b := by rw [mul_eq_one_iff_eq_in
 theorem inv_mul_eq_one : a⁻¹ * b = 1 ↔ a = b := by rw [mul_eq_one_iff_eq_inv, inv_inj]
 
 @[to_additive]
-theorem div_left_injective : Function.injective fun a => a / b := by
+theorem div_left_injective : Function.Injective fun a => a / b := by
   -- FIXME this could be by `simpa`, but it fails. This is probably a bug in `simpa`.
   simp only [div_eq_mul_inv]
   exact fun a a' h => mul_left_injective b⁻¹ h
 
 @[to_additive]
-theorem div_right_injective : Function.injective fun a => b / a := by
+theorem div_right_injective : Function.Injective fun a => b / a := by
   -- FIXME see above
   simp only [div_eq_mul_inv]
   exact fun a a' h => inv_injective (mul_right_injective b h)

--- a/Mathlib/Algebra/Group/Defs.lean
+++ b/Mathlib/Algebra/Group/Defs.lean
@@ -177,7 +177,7 @@ theorem mul_left_cancel_iff : a * b = a * c ↔ b = c :=
   ⟨mul_left_cancel, congr_arg _⟩
 
 @[to_additive]
-theorem mul_right_injective (a : G) : Function.injective ((· * ·) a) := fun _ _ => mul_left_cancel
+theorem mul_right_injective (a : G) : Function.Injective ((· * ·) a) := fun _ _ => mul_left_cancel
 
 @[simp, to_additive]
 theorem mul_right_inj (a : G) {b c : G} : a * b = a * c ↔ b = c :=
@@ -215,7 +215,7 @@ theorem mul_right_cancel_iff : b * a = c * a ↔ b = c :=
   ⟨mul_right_cancel, congr_arg (· * a)⟩
 
 @[to_additive]
-theorem mul_left_injective (a : G) : Function.injective (· * a) := fun _ _ => mul_right_cancel
+theorem mul_left_injective (a : G) : Function.Injective (· * a) := fun _ _ => mul_right_cancel
 
 @[simp, to_additive]
 theorem mul_left_inj (a : G) {b c : G} : b * a = c * a ↔ b = c :=
@@ -846,7 +846,7 @@ end Group
 
 @[to_additive]
 theorem Group.toDivInvMonoid_injective {G : Type _} :
-    Function.injective (@Group.toDivInvMonoid G) := by rintro ⟨⟩ ⟨⟩ ⟨⟩; rfl
+    Function.Injective (@Group.toDivInvMonoid G) := by rintro ⟨⟩ ⟨⟩ ⟨⟩; rfl
 
 /-- An additive commutative group is an additive group with commutative `(+)`. -/
 class AddCommGroup (G : Type u) extends AddGroup G, AddCommMonoid G
@@ -860,7 +860,7 @@ attribute [to_additive AddCommGroup.toAddCommMonoid] CommGroup.toCommMonoid
 attribute [instance] AddCommGroup.toAddCommMonoid
 
 @[to_additive]
-theorem CommGroup.toGroup_injective {G : Type u} : Function.injective (@CommGroup.toGroup G) := by
+theorem CommGroup.toGroup_injective {G : Type u} : Function.Injective (@CommGroup.toGroup G) := by
   rintro ⟨⟩ ⟨⟩ ⟨⟩; rfl
 
 section CommGroup

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -28,7 +28,7 @@ namespace List
 -- instance : is_associative (List α) has_append.append :=
 -- ⟨ append_assoc ⟩
 
-@[simp] theorem cons_injective {a : α} : injective (cons a) :=
+@[simp] theorem cons_injective {a : α} : Injective (cons a) :=
 λ _ _ Pe => tail_eq_of_cons_eq Pe
 
 /-! ### mem -/
@@ -53,7 +53,7 @@ fun p1 p2 => fun Pain => absurd (eq_or_mem_of_mem_cons Pain) (not_or.mpr ⟨p1, 
 theorem ne_and_not_mem_of_not_mem_cons {a y : α} {l : List α} : (a ∉ y::l) → a ≠ y ∧ a ∉ l :=
 fun p => And.intro (ne_of_not_mem_cons p) (not_mem_of_not_mem_cons p)
 
-theorem mem_map_of_injective {f : α → β} (H : injective f) {a : α} {l : List α} :
+theorem mem_map_of_injective {f : α → β} (H : Injective f) {a : α} {l : List α} :
   f a ∈ map f l ↔ a ∈ l :=
 ⟨fun m => let ⟨_, m', e⟩ := exists_of_mem_map m
           H e ▸ m', mem_map_of_mem _⟩
@@ -78,7 +78,7 @@ lemma exists_of_length_succ {n} :
 | h :: t, _ => ⟨h, t, rfl⟩
 
 @[simp]
-lemma length_injective_iff : injective (List.length : List α → ℕ) ↔ Subsingleton α := by
+lemma length_injective_iff : Injective (List.length : List α → ℕ) ↔ Subsingleton α := by
   constructor
   · intro h; refine ⟨λ x y => ?_⟩; (suffices [x] = [y] by simpa using this); apply h; rfl
   · intros hα l1 l2 hl
@@ -91,7 +91,7 @@ lemma length_injective_iff : injective (List.length : List α → ℕ) ↔ Subsi
                              · apply ih; simpa using hl
 
 @[simp default+1]
-lemma length_injective [Subsingleton α] : injective (length : List α → ℕ) :=
+lemma length_injective [Subsingleton α] : Injective (length : List α → ℕ) :=
 length_injective_iff.mpr inferInstance
 
 /-! ### set-theoretic notation of Lists -/
@@ -173,10 +173,10 @@ theorem append_left_cancel {s t₁ t₂ : List α} (h : s ++ t₁ = s ++ t₂) :
 theorem append_right_cancel {s₁ s₂ t : List α} (h : s₁ ++ t = s₂ ++ t) : s₁ = s₂ :=
   (append_left_inj _).1 h
 
-theorem append_right_injective (s : List α) : injective fun t => s ++ t :=
+theorem append_right_injective (s : List α) : Injective fun t => s ++ t :=
 fun _ _ => append_left_cancel
 
-theorem append_left_injective (t : List α) : injective fun s => s ++ t :=
+theorem append_left_injective (t : List α) : Injective fun s => s ++ t :=
 fun _ _ => append_right_cancel
 
 /-! ### nth element -/

--- a/Mathlib/Data/List/Nodup.lean
+++ b/Mathlib/Data/List/Nodup.lean
@@ -20,7 +20,7 @@ theorem Nodup.map_on {f : α → β} (H : ∀ x ∈ l, ∀ y ∈ l, f x = f y �
     (map f l).Nodup :=
   Pairwise.map _ (fun a b ⟨ma, mb, n⟩ e => n (H a ma b mb e)) (Pairwise.and_mem.1 d)
 
-protected theorem Nodup.map {f : α → β} (hf : Function.injective f) : Nodup l → Nodup (map f l) :=
+protected theorem Nodup.map {f : α → β} (hf : Function.Injective f) : Nodup l → Nodup (map f l) :=
   Nodup.map_on fun _ _ _ _ h => hf h
 
 theorem Nodup.of_map (f : α → β) {l : List α} : Nodup (map f l) → Nodup l :=

--- a/Mathlib/Data/Option/Basic.lean
+++ b/Mathlib/Data/Option/Basic.lean
@@ -9,11 +9,11 @@ import Mathlib.Logic.Basic
 
 namespace Option
 
-theorem some_injective (α : Type _) : Function.injective (@some α) :=
+theorem some_injective (α : Type _) : Function.Injective (@some α) :=
   fun _ _ => some_inj.mp
 
 /-- `option.map f` is injective if `f` is injective. -/
-theorem map_injective {f : α → β} (Hf : Function.injective f) : Function.injective (Option.map f)
+theorem map_injective {f : α → β} (Hf : Function.Injective f) : Function.Injective (Option.map f)
 | none, none, _ => rfl
 | some a₁, some a₂, H => by rw [Hf (Option.some.inj H)]
 

--- a/Mathlib/Data/Prod.lean
+++ b/Mathlib/Data/Prod.lean
@@ -68,11 +68,11 @@ theorem mk.inj_iff {a₁ a₂ : α} {b₁ b₂ : β} : (a₁, b₁) = (a₂, b�
  by intro hab; rw [hab.left, hab.right]⟩
 
 lemma mk.inj_left {α β : Type _} (a : α) :
-  Function.injective (Prod.mk a : β → α × β) :=
+  Function.Injective (Prod.mk a : β → α × β) :=
 fun _ _ h => (Prod.mk.inj h).right
 
 lemma mk.inj_right {α β : Type _} (b : β) :
-  Function.injective (λ a => Prod.mk a b : α → α × β) :=
+  Function.Injective (λ a => Prod.mk a b : α → α × β) :=
 fun _ _ h => (Prod.mk.inj h).left
 
 -- Port note: this lemma comes from lean3/library/init/data/prod.lean.
@@ -94,16 +94,16 @@ by ext <;> simp
 lemma id_prod : (λ (p : α × α) => (p.1, p.2)) = id :=
 funext $ λ ⟨_, _⟩ => rfl
 
-lemma fst_surjective [h : Nonempty β] : Function.surjective (@fst α β) :=
+lemma fst_surjective [h : Nonempty β] : Function.Surjective (@fst α β) :=
 λ x => h.elim $ λ y => ⟨⟨x, y⟩, rfl⟩
 
-lemma snd_surjective [h : Nonempty α] : Function.surjective (@snd α β) :=
+lemma snd_surjective [h : Nonempty α] : Function.Surjective (@snd α β) :=
 λ y => h.elim $ λ x => ⟨⟨x, y⟩, rfl⟩
 
-lemma fst_injective [Subsingleton β] : Function.injective (@fst α β) :=
+lemma fst_injective [Subsingleton β] : Function.Injective (@fst α β) :=
 λ x y h => ext' h (Subsingleton.elim x.snd y.snd)
 
-lemma snd_injective [Subsingleton α] : Function.injective (@snd α β) :=
+lemma snd_injective [Subsingleton α] : Function.Injective (@snd α β) :=
 λ _ _ h => ext' (Subsingleton.elim _ _) h
 
 /-- Swap the factors of a product. `swap (a, b) = (b, a)` -/
@@ -127,13 +127,13 @@ swap_swap
 lemma swap_RightInverse : Function.RightInverse (@swap α β) swap :=
 swap_swap
 
-lemma swap_injective : Function.injective (@swap α β) :=
+lemma swap_injective : Function.Injective (@swap α β) :=
 swap_LeftInverse.injective
 
-lemma swap_surjective : Function.surjective (@swap α β) :=
+lemma swap_surjective : Function.Surjective (@swap α β) :=
 Function.RightInverse.surjective swap_LeftInverse
 
-lemma swap_bijective : Function.bijective (@swap α β) :=
+lemma swap_bijective : Function.Bijective (@swap α β) :=
 ⟨swap_injective, swap_surjective⟩
 
 @[simp] lemma swap_inj {p q : α × β} : swap p = swap q ↔ p = q :=
@@ -167,8 +167,8 @@ end Prod
 
 open Function
 
-lemma Function.injective.prod_map {f : α → γ} {g : β → δ} (hf : injective f) (hg : injective g) :
-  injective (Prod.map f g) :=
+lemma Function.Injective.prod_map {f : α → γ} {g : β → δ} (hf : Injective f) (hg : Injective g) :
+  Injective (Prod.map f g) :=
 by intros x y h
    have h1 := (Prod.ext_iff.1 h).1
    rw [Prod.map_fst, Prod.map_fst] at h1
@@ -176,8 +176,8 @@ by intros x y h
    rw [Prod.map_snd, Prod.map_snd] at h2
    exact Prod.ext' (hf h1) (hg h2)
 
-lemma Function.surjective.prod_map {f : α → γ} {g : β → δ} (hf : surjective f) (hg : surjective g) :
-  surjective (Prod.map f g) :=
+lemma Function.Surjective.prod_map {f : α → γ} {g : β → δ} (hf : Surjective f) (hg : Surjective g) :
+  Surjective (Prod.map f g) :=
 λ p => let ⟨x, hx⟩ := hf p.1
        let ⟨y, hy⟩ := hg p.2
        ⟨(x, y), Prod.ext' hx hy⟩

--- a/Mathlib/Data/Sigma/Basic.lean
+++ b/Mathlib/Data/Sigma/Basic.lean
@@ -90,31 +90,31 @@ def map (f₁ : α₁ → α₂) (f₂ : ∀ a, β₁ a → β₂ (f₁ a)) (x :
 
 end Sigma
 
-theorem sigma_mk_injective {i : α} : Function.injective (@Sigma.mk α β i)
+theorem sigma_mk_injective {i : α} : Function.Injective (@Sigma.mk α β i)
   | _, _, rfl => rfl
 
-theorem Function.injective.sigma_map {f₁ : α₁ → α₂} {f₂ : ∀ a, β₁ a → β₂ (f₁ a)}
-  (h₁ : Function.injective f₁) (h₂ : ∀ a, Function.injective (f₂ a)) :
-    Function.injective (Sigma.map f₁ f₂)
+theorem Function.Injective.sigma_map {f₁ : α₁ → α₂} {f₂ : ∀ a, β₁ a → β₂ (f₁ a)}
+  (h₁ : Function.Injective f₁) (h₂ : ∀ a, Function.Injective (f₂ a)) :
+    Function.Injective (Sigma.map f₁ f₂)
   | ⟨i, x⟩, ⟨j, y⟩, h => by
     obtain rfl : i = j := h₁ (Sigma.mk.inj_iff.mp h).1
     obtain rfl : x = y := h₂ i (sigma_mk_injective h)
     rfl
 
-theorem Function.injective.of_sigma_map {f₁ : α₁ → α₂} {f₂ : ∀ a, β₁ a → β₂ (f₁ a)}
-    (h : Function.injective (Sigma.map f₁ f₂)) (a : α₁) : Function.injective (f₂ a) :=
+theorem Function.Injective.of_sigma_map {f₁ : α₁ → α₂} {f₂ : ∀ a, β₁ a → β₂ (f₁ a)}
+    (h : Function.Injective (Sigma.map f₁ f₂)) (a : α₁) : Function.Injective (f₂ a) :=
   fun x y hxy =>
   sigma_mk_injective <| @h ⟨a, x⟩ ⟨a, y⟩ (Sigma.ext rfl (heq_of_eq hxy))
 
-theorem Function.injective.sigma_map_iff {f₁ : α₁ → α₂} {f₂ : ∀ a, β₁ a → β₂ (f₁ a)}
-  (h₁ : Function.injective f₁) :
-    Function.injective (Sigma.map f₁ f₂) ↔ ∀ a, Function.injective (f₂ a) :=
+theorem Function.Injective.sigma_map_iff {f₁ : α₁ → α₂} {f₂ : ∀ a, β₁ a → β₂ (f₁ a)}
+  (h₁ : Function.Injective f₁) :
+    Function.Injective (Sigma.map f₁ f₂) ↔ ∀ a, Function.Injective (f₂ a) :=
   ⟨fun h => h.of_sigma_map, h₁.sigma_map⟩
 
-theorem Function.surjective.sigma_map {f₁ : α₁ → α₂} {f₂ : ∀ a, β₁ a → β₂ (f₁ a)}
-  (h₁ : Function.surjective f₁) (h₂ : ∀ a, Function.surjective (f₂ a)) :
-    Function.surjective (Sigma.map f₁ f₂) := by
-  simp only [Function.surjective, Sigma.forall, h₁.forall]
+theorem Function.Surjective.sigma_map {f₁ : α₁ → α₂} {f₂ : ∀ a, β₁ a → β₂ (f₁ a)}
+  (h₁ : Function.Surjective f₁) (h₂ : ∀ a, Function.Surjective (f₂ a)) :
+    Function.Surjective (Sigma.map f₁ f₂) := by
+  simp only [Function.Surjective, Sigma.forall, h₁.forall]
   exact fun i => (h₂ _).forall.2 fun x => ⟨⟨i, x⟩, rfl⟩
 
 /-- Interpret a function on `Σ x : α, β x` as a dependent function with two arguments.

--- a/Mathlib/Data/Subtype.lean
+++ b/Mathlib/Data/Subtype.lean
@@ -70,11 +70,11 @@ ext_iff
 theorem coe_eq_iff {a : {a // p a}} {b : α} : ↑a = b ↔ ∃ h, a = ⟨b, h⟩ :=
 ⟨λ h => h ▸ ⟨a.2, (coe_eta _ _).symm⟩, λ ⟨_, ha⟩ => ha.symm ▸ rfl⟩
 
-theorem coe_injective : injective ((↑·) : Subtype p → α) :=
+theorem coe_injective : Injective ((↑·) : Subtype p → α) :=
 by intros a b hab
    exact Subtype.ext hab
 
-theorem val_injective : injective (@val _ p) :=
+theorem val_injective : Injective (@val _ p) :=
 coe_injective
 
 /-- Restrict a (dependent) function to a subtype -/
@@ -87,8 +87,8 @@ lemma restrict_apply {α} {β : α → Type _} (f : ∀x, β x) (p : α → Prop
 -- FIXME: replace Subtype.val with (↑)
 lemma restrict_def {α β} (f : α → β) (p : α → Prop) : restrict f p = f ∘ Subtype.val := rfl
 
-lemma restrict_injective {α β} {f : α → β} (p : α → Prop) (h : injective f) :
-  injective (restrict f p) :=
+lemma restrict_injective {α β} {f : α → β} (p : α → Prop) (h : Injective f) :
+  Injective (restrict f p) :=
 h.comp coe_injective
 
 /-- Defining a map into a subtype, this can be seen as an "coinduction principle" of `Subtype`-/
@@ -96,18 +96,18 @@ def coind {α β} (f : α → β) {p : β → Prop} (h : ∀a, p (f a)) : α →
 λ a => ⟨f a, h a⟩
 
 theorem coind_injective {α β} {f : α → β} {p : β → Prop} (h : ∀a, p (f a))
-  (hf : injective f) : injective (coind f h) :=
+  (hf : Injective f) : Injective (coind f h) :=
 by intros x y hxy
    refine hf ?_
    apply congrArg Subtype.val hxy
 
 theorem coind_surjective {α β} {f : α → β} {p : β → Prop} (h : ∀a, p (f a))
-  (hf : surjective f) : surjective (coind f h) :=
+  (hf : Surjective f) : Surjective (coind f h) :=
 λ x => let ⟨a, ha⟩ := hf x
        ⟨a, coe_injective ha⟩
 
 theorem coind_bijective {α β} {f : α → β} {p : β → Prop} (h : ∀a, p (f a))
-  (hf : bijective f) : bijective (coind f h) :=
+  (hf : Bijective f) : Bijective (coind f h) :=
 ⟨coind_injective h hf.1, coind_surjective h hf.2⟩
 
 /-- Restriction of a function to a function on subtypes. -/
@@ -124,11 +124,11 @@ theorem map_id {p : α → Prop} {h : ∀a, p a → p (id a)} : map (@id α) h =
 funext fun ⟨_, _⟩ => rfl
 
 lemma map_injective {p : α → Prop} {q : β → Prop} {f : α → β} (h : ∀a, p a → q (f a))
-  (hf : injective f) : injective (map f h) :=
+  (hf : Injective f) : Injective (map f h) :=
 coind_injective _ $ hf.comp coe_injective
 
 lemma map_involutive {p : α → Prop} {f : α → α} (h : ∀a, p a → p (f a))
-  (hf : involutive f) : involutive (map f h) :=
+  (hf : Involutive f) : Involutive (map f h) :=
 λ x => Subtype.ext (hf x)
 
 instance [HasEquiv α] (p : α → Prop) : HasEquiv (Subtype p) :=

--- a/Mathlib/Init/Function.lean
+++ b/Mathlib/Init/Function.lean
@@ -48,25 +48,25 @@ theorem comp.assoc (f : φ → δ) (g : β → φ) (h : α → β) : (f ∘ g) �
 theorem comp_const_right (f : β → φ) (b : β) : f ∘ (const α b) = const α (f b) := rfl
 
 /-- A function `f : α → β` is called injective if `f x = f y` implies `x = y`. -/
-def injective (f : α → β) : Prop := ∀ ⦃a₁ a₂⦄, f a₁ = f a₂ → a₁ = a₂
+def Injective (f : α → β) : Prop := ∀ ⦃a₁ a₂⦄, f a₁ = f a₂ → a₁ = a₂
 
-theorem injective.comp {g : β → φ} {f : α → β} (hg : injective g) (hf : injective f) :
-  injective (g ∘ f) :=
+theorem Injective.comp {g : β → φ} {f : α → β} (hg : Injective g) (hf : Injective f) :
+  Injective (g ∘ f) :=
 fun _ _ h => hf (hg h)
 
 /-- A function `f : α → β` is calles surjective if every `b : β` is equal to `f a`
 for some `a : α`. -/
-@[reducible] def surjective (f : α → β) : Prop := ∀ b, ∃ a, f a = b
+@[reducible] def Surjective (f : α → β) : Prop := ∀ b, ∃ a, f a = b
 
-theorem surjective.comp {g : β → φ} {f : α → β} (hg : surjective g) (hf : surjective f) :
-  surjective (g ∘ f) :=
+theorem Surjective.comp {g : β → φ} {f : α → β} (hg : Surjective g) (hf : Surjective f) :
+  Surjective (g ∘ f) :=
 λ (c : φ) => Exists.elim (hg c) (λ b hb => Exists.elim (hf b) (λ a ha =>
   Exists.intro a (show g (f a) = c from (Eq.trans (congrArg g ha) hb))))
 
 /-- A function is called bijective if it is both injective and surjective. -/
-def bijective (f : α → β) := injective f ∧ surjective f
+def Bijective (f : α → β) := Injective f ∧ Surjective f
 
-theorem bijective.comp {g : β → φ} {f : α → β} : bijective g → bijective f → bijective (g ∘ f)
+theorem Bijective.comp {g : β → φ} {f : α → β} : Bijective g → Bijective f → Bijective (g ∘ f)
 | ⟨h_ginj, h_gsurj⟩, ⟨h_finj, h_fsurj⟩ => ⟨h_ginj.comp h_finj, h_gsurj.comp h_fsurj⟩
 
 /-- `LeftInverse g f` means that g is a left inverse to f. That is, `g ∘ f = id`. -/
@@ -81,34 +81,34 @@ def RightInverse (g : β → α) (f : α → β) : Prop := LeftInverse f g
 /-- `has_RightInverse f` means that `f` has an unspecified right inverse. -/
 def has_RightInverse (f : α → β) : Prop := ∃ finv : β → α, RightInverse finv f
 
-theorem LeftInverse.injective {g : β → α} {f : α → β} : LeftInverse g f → injective f :=
+theorem LeftInverse.injective {g : β → α} {f : α → β} : LeftInverse g f → Injective f :=
 λ h a b hf => h a ▸ h b ▸ hf ▸ rfl
 
-theorem has_LeftInverse.injective {f : α → β} : has_LeftInverse f → injective f :=
+theorem has_LeftInverse.injective {f : α → β} : has_LeftInverse f → Injective f :=
 λ h => Exists.elim h (λ _ inv => inv.injective)
 
 theorem RightInverse_of_injective_of_LeftInverse {f : α → β} {g : β → α}
-    (injf : injective f) (lfg : LeftInverse f g) :
+    (injf : Injective f) (lfg : LeftInverse f g) :
   RightInverse f g :=
 λ x => injf $ lfg $ f x
 
-theorem RightInverse.surjective {f : α → β} {g : β → α} (h : RightInverse g f) : surjective f :=
+theorem RightInverse.surjective {f : α → β} {g : β → α} (h : RightInverse g f) : Surjective f :=
 λ y => ⟨g y, h y⟩
 
-theorem has_RightInverse.surjective {f : α → β} : has_RightInverse f → surjective f
+theorem has_RightInverse.surjective {f : α → β} : has_RightInverse f → Surjective f
 | ⟨_, inv⟩ => inv.surjective
 
-theorem LeftInverse_of_surjective_of_RightInverse {f : α → β} {g : β → α} (surjf : surjective f)
+theorem LeftInverse_of_surjective_of_RightInverse {f : α → β} {g : β → α} (surjf : Surjective f)
   (rfg : RightInverse f g) : LeftInverse f g :=
 λ y =>
   let ⟨x, hx⟩ := surjf y
   by rw [← hx, rfg]
 
-theorem injective_id : injective (@id α) := fun _ _ => id
+theorem injective_id : Injective (@id α) := fun _ _ => id
 
-theorem surjective_id : surjective (@id α) := λ a => ⟨a, rfl⟩
+theorem surjective_id : Surjective (@id α) := λ a => ⟨a, rfl⟩
 
-theorem bijective_id : bijective (@id α) := ⟨injective_id, surjective_id⟩
+theorem bijective_id : Bijective (@id α) := ⟨injective_id, surjective_id⟩
 
 end Function
 

--- a/Mathlib/Logic/Basic.lean
+++ b/Mathlib/Logic/Basic.lean
@@ -128,13 +128,13 @@ theorem congr_arg_heq {α} {β : α → Sort _} (f : ∀ a, β a) :
     ∀ {a₁ a₂ : α}, a₁ = a₂ → HEq (f a₁) (f a₂)
   | _, _, rfl => HEq.rfl
 
-theorem ULift.down_injective {α : Sort _} : Function.injective (@ULift.down α)
+theorem ULift.down_injective {α : Sort _} : Function.Injective (@ULift.down α)
   | ⟨a⟩, ⟨b⟩, _ => by congr
 
 @[simp] theorem ULift.down_inj {α : Sort _} {a b : ULift α} : a.down = b.down ↔ a = b :=
   ⟨fun h => ULift.down_injective h, fun h => by rw [h]⟩
 
-theorem PLift.down_injective {α : Sort _} : Function.injective (@PLift.down α)
+theorem PLift.down_injective {α : Sort _} : Function.Injective (@PLift.down α)
   | ⟨a⟩, ⟨b⟩, _ => by congr
 
 @[simp] theorem PLift.down_inj {α : Sort _} {a b : PLift α} : a.down = b.down ↔ a = b :=

--- a/Mathlib/Logic/Function/Basic.lean
+++ b/Mathlib/Logic/Function/Basic.lean
@@ -45,55 +45,55 @@ lemma hfunext {α α': Sort u} {β : α → Sort v} {β' : α' → Sort v} {f : 
 lemma funext_iff {β : α → Sort _} {f₁ f₂ : ∀ (x : α), β x} : f₁ = f₂ ↔ (∀a, f₁ a = f₂ a) :=
 Iff.intro (λ h _ => h ▸ rfl) funext
 
-protected lemma bijective.injective {f : α → β} (hf : bijective f) : injective f := hf.1
-protected lemma bijective.surjective {f : α → β} (hf : bijective f) : surjective f := hf.2
+protected lemma Bijective.injective {f : α → β} (hf : Bijective f) : Injective f := hf.1
+protected lemma Bijective.surjective {f : α → β} (hf : Bijective f) : Surjective f := hf.2
 
-theorem injective.eq_iff (I : injective f) {a b : α} :
+theorem Injective.eq_iff (I : Injective f) {a b : α} :
   f a = f b ↔ a = b :=
 ⟨@I _ _, congr_arg f⟩
 
-theorem injective.eq_iff' (I : injective f) {a b : α} {c : β} (h : f b = c) :
+theorem Injective.eq_iff' (I : Injective f) {a b : α} {c : β} (h : f b = c) :
   f a = c ↔ a = b :=
 h ▸ I.eq_iff
 
-lemma injective.ne (hf : injective f) {a₁ a₂ : α} : a₁ ≠ a₂ → f a₁ ≠ f a₂ :=
+lemma Injective.ne (hf : Injective f) {a₁ a₂ : α} : a₁ ≠ a₂ → f a₁ ≠ f a₂ :=
 mt (λ h => hf h)
 
-lemma injective.ne_iff (hf : injective f) {x y : α} : f x ≠ f y ↔ x ≠ y :=
+lemma Injective.ne_iff (hf : Injective f) {x y : α} : f x ≠ f y ↔ x ≠ y :=
 ⟨mt $ congr_arg f, hf.ne⟩
 
-lemma injective.ne_iff' (hf : injective f) {x y : α} {z : β} (h : f y = z) :
+lemma Injective.ne_iff' (hf : Injective f) {x y : α} {z : β} (h : f y = z) :
   f x ≠ z ↔ x ≠ y :=
 h ▸ hf.ne_iff
 
 /-- If the co-domain `β` of an injective function `f : α → β` has decidable equality, then
 the domain `α` also has decidable equality. -/
-def injective.decidable_eq [DecidableEq β] (I : injective f) : DecidableEq α :=
+def Injective.decidable_eq [DecidableEq β] (I : Injective f) : DecidableEq α :=
 λ _ _ => decidable_of_iff _ I.eq_iff
 
-lemma injective.of_comp {g : γ → α} (I : injective (f ∘ g)) : injective g :=
+lemma Injective.of_comp {g : γ → α} (I : Injective (f ∘ g)) : Injective g :=
 λ {x y} h => I $ show f (g x) = f (g y) from congr_arg f h
 
-lemma injective.of_comp_iff {f : α → β} (hf : injective f) (g : γ → α) :
-  injective (f ∘ g) ↔ injective g :=
-⟨injective.of_comp, hf.comp⟩
+lemma Injective.of_comp_iff {f : α → β} (hf : Injective f) (g : γ → α) :
+  Injective (f ∘ g) ↔ Injective g :=
+⟨Injective.of_comp, hf.comp⟩
 
-lemma injective.of_comp_iff' (f : α → β) {g : γ → α} (hg : bijective g) :
-  injective (f ∘ g) ↔ injective f :=
+lemma Injective.of_comp_iff' (f : α → β) {g : γ → α} (hg : Bijective g) :
+  Injective (f ∘ g) ↔ Injective f :=
 ⟨ λ h x y => let ⟨_, hx⟩ := hg.surjective x
              let ⟨_, hy⟩ := hg.surjective y
              hx ▸ hy ▸ λ hf => h hf ▸ rfl,
   λ h => h.comp hg.injective⟩
 
 lemma injective_of_subsingleton [Subsingleton α] (f : α → β) :
-  injective f :=
+  Injective f :=
 λ _ _ _ => Subsingleton.elim _ _
 
-lemma injective.dite (p : α → Prop) [DecidablePred p]
+lemma Injective.dite (p : α → Prop) [DecidablePred p]
   {f : {a : α // p a} → β} {f' : {a : α // ¬ p a} → β}
-  (hf : injective f) (hf' : injective f')
+  (hf : Injective f) (hf' : Injective f')
   (im_disj : ∀ {x x' : α} {hx : p x} {hx' : ¬ p x'}, f ⟨x, hx⟩ ≠ f' ⟨x', hx'⟩) :
-  Function.injective (λ x => if h : p x then f ⟨x, h⟩ else f' ⟨x, h⟩) :=
+  Function.Injective (λ x => if h : p x then f ⟨x, h⟩ else f' ⟨x, h⟩) :=
 by intros x₁ x₂ h
    dsimp only at h
    by_cases h₁ : p x₁ <;> by_cases h₂ : p x₂
@@ -102,16 +102,16 @@ by intros x₁ x₂ h
    · rw [dif_neg h₁, dif_pos h₂] at h; exact (im_disj h.symm).elim
    · rw [dif_neg h₁, dif_neg h₂] at h; injection (hf' h); assumption
 
-lemma surjective.of_comp {g : γ → α} (S : surjective (f ∘ g)) : surjective f :=
+lemma Surjective.of_comp {g : γ → α} (S : Surjective (f ∘ g)) : Surjective f :=
 λ y => let ⟨x, h⟩ := S y
        ⟨g x, h⟩
 
-lemma surjective.of_comp_iff (f : α → β) {g : γ → α} (hg : surjective g) :
-  surjective (f ∘ g) ↔ surjective f :=
-⟨surjective.of_comp, λ h => h.comp hg⟩
+lemma Surjective.of_comp_iff (f : α → β) {g : γ → α} (hg : Surjective g) :
+  Surjective (f ∘ g) ↔ Surjective f :=
+⟨Surjective.of_comp, λ h => h.comp hg⟩
 
-lemma surjective.of_comp_iff' {f : α → β} (hf : bijective f) (g : γ → α) :
-  surjective (f ∘ g) ↔ surjective g :=
+lemma Surjective.of_comp_iff' {f : α → β} (hf : Bijective f) (g : γ → α) :
+  Surjective (f ∘ g) ↔ Surjective g :=
 ⟨λ h x => let ⟨x', hx'⟩ := h (f x)
           ⟨x', hf.injective hx'⟩, hf.surjective.comp⟩
 
@@ -119,60 +119,60 @@ instance decidable_eq_pfun (p : Prop) [Decidable p] (α : p → Type _)
   [∀ hp, DecidableEq (α hp)] : DecidableEq (∀hp, α hp)
 | f, g => decidable_of_iff (∀ hp, f hp = g hp) funext_iff.symm
 
-theorem surjective.forall {f : α → β} (hf : surjective f) {p : β → Prop} :
+theorem Surjective.forall {f : α → β} (hf : Surjective f) {p : β → Prop} :
   (∀ y, p y) ↔ ∀ x, p (f x) :=
 ⟨λ h x => h (f x),
  λ h y => let ⟨x, hx⟩ := hf y
           hx ▸ h x⟩
 
-theorem surjective.forall₂ {f : α → β} (hf : surjective f) {p : β → β → Prop} :
+theorem Surjective.forall₂ {f : α → β} (hf : Surjective f) {p : β → β → Prop} :
   (∀ y₁ y₂, p y₁ y₂) ↔ ∀ x₁ x₂, p (f x₁) (f x₂) :=
 hf.forall.trans $ forall_congr' fun _ => hf.forall
 
-theorem surjective.forall₃ {f : α → β} (hf : surjective f) {p : β → β → β → Prop} :
+theorem Surjective.forall₃ {f : α → β} (hf : Surjective f) {p : β → β → β → Prop} :
   (∀ y₁ y₂ y₃, p y₁ y₂ y₃) ↔ ∀ x₁ x₂ x₃, p (f x₁) (f x₂) (f x₃) :=
 hf.forall.trans $ forall_congr' fun _ => hf.forall₂
 
-theorem surjective.exists {f : α → β} (hf : surjective f) {p : β → Prop} :
+theorem Surjective.exists {f : α → β} (hf : Surjective f) {p : β → Prop} :
   (∃ y, p y) ↔ ∃ x, p (f x) :=
 ⟨fun ⟨y, hy⟩ => let ⟨x, hx⟩ := hf y; ⟨x, hx.symm ▸ hy⟩,
  fun ⟨x, hx⟩ => ⟨f x, hx⟩⟩
 
-theorem surjective.exists₂ {f : α → β} (hf : surjective f) {p : β → β → Prop} :
+theorem Surjective.exists₂ {f : α → β} (hf : Surjective f) {p : β → β → Prop} :
   (∃ y₁ y₂, p y₁ y₂) ↔ ∃ x₁ x₂, p (f x₁) (f x₂) :=
 hf.exists.trans $ exists_congr fun _ => hf.exists
 
-theorem surjective.exists₃ {f : α → β} (hf : surjective f) {p : β → β → β → Prop} :
+theorem Surjective.exists₃ {f : α → β} (hf : Surjective f) {p : β → β → β → Prop} :
   (∃ y₁ y₂ y₃, p y₁ y₂ y₃) ↔ ∃ x₁ x₂ x₃, p (f x₁) (f x₂) (f x₃) :=
 hf.exists.trans $ exists_congr fun _ => hf.exists₂
 
-lemma bijective_iff_exists_unique (f : α → β) : bijective f ↔
+lemma bijective_iff_exists_unique (f : α → β) : Bijective f ↔
   ∀ b : β, ∃! (a : α), f a = b :=
 ⟨ fun hf b => let ⟨a, ha⟩ := hf.surjective b
               ⟨a, ha, fun _ ha' => hf.injective (ha'.trans ha.symm)⟩,
   fun he => ⟨fun {_a a'} h => (he (f a')).unique h rfl, fun b => (he b).exists⟩⟩
 
 /-- Shorthand for using projection notation with `function.bijective_iff_exists_unique`. -/
-lemma bijective.exists_unique {f : α → β} (hf : bijective f) (b : β) : ∃! (a : α), f a = b :=
+lemma Bijective.exists_unique {f : α → β} (hf : Bijective f) (b : β) : ∃! (a : α), f a = b :=
 (bijective_iff_exists_unique f).mp hf b
 
-lemma bijective.of_comp_iff (f : α → β) {g : γ → α} (hg : bijective g) :
-  bijective (f ∘ g) ↔ bijective f :=
-and_congr (injective.of_comp_iff' _ hg) (surjective.of_comp_iff _ hg.surjective)
+lemma Bijective.of_comp_iff (f : α → β) {g : γ → α} (hg : Bijective g) :
+  Bijective (f ∘ g) ↔ Bijective f :=
+and_congr (Injective.of_comp_iff' _ hg) (Surjective.of_comp_iff _ hg.surjective)
 
-lemma bijective.of_comp_iff' {f : α → β} (hf : bijective f) (g : γ → α) :
-  Function.bijective (f ∘ g) ↔ Function.bijective g :=
-and_congr (injective.of_comp_iff hf.injective _) (surjective.of_comp_iff' hf _)
+lemma Bijective.of_comp_iff' {f : α → β} (hf : Bijective f) (g : γ → α) :
+  Bijective (f ∘ g) ↔ Bijective g :=
+and_congr (Injective.of_comp_iff hf.injective _) (Surjective.of_comp_iff' hf _)
 
 /-- Cantor's diagonal argument implies that there are no surjective functions from `α`
 to `Set α`. -/
-theorem cantor_surjective {α} (f : α → Set α) : ¬ Function.surjective f
+theorem cantor_surjective {α} (f : α → Set α) : ¬ Surjective f
 | h => let ⟨D, e⟩ := h (λ a => ¬ f a a)
        (@iff_not_self (f D D)) $ iff_of_eq (congr_fun e D)
 
 /-- Cantor's diagonal argument implies that there are no injective functions from `Set α` to `α`. -/
 theorem cantor_injective {α : Type _} (f : (Set α) → α) :
-  ¬ Function.injective f
+  ¬ Injective f
 | i => cantor_surjective (λ a b => ∀ U, a = f U → U b) $
        RightInverse.surjective
          (λ U => funext $ λ _a => propext ⟨λ h => h U rfl, λ h' _U e => i e ▸ h'⟩)
@@ -186,7 +186,7 @@ def is_partial_inv {α β} (f : α → β) (g : β → Option α) : Prop :=
 theorem is_partial_inv_left {α β} {f : α → β} {g} (H : is_partial_inv f g) (x) : g (f x) = some x :=
 (H _ _).2 rfl
 
-theorem injective_of_partial_inv {α β} {f : α → β} {g} (H : is_partial_inv f g) : injective f :=
+theorem injective_of_partial_inv {α β} {f : α → β} {g} (H : is_partial_inv f g) : Injective f :=
 λ _ _ h => Option.some.inj $ ((H _ _).2 h).symm.trans ((H _ _).2 rfl)
 
 theorem injective_of_partial_inv_right {α β} {f : α → β} {g} (H : is_partial_inv f g)
@@ -220,11 +220,11 @@ theorem RightInverse.LeftInverse {f : α → β} {g : β → α} (h : RightInver
   LeftInverse f g := h
 
 theorem LeftInverse.surjective {f : α → β} {g : β → α} (h : LeftInverse f g) :
-  surjective f :=
+  Surjective f :=
 h.RightInverse.surjective
 
 theorem RightInverse.injective {f : α → β} {g : β → α} (h : RightInverse f g) :
-  injective f :=
+  Injective f :=
 h.LeftInverse.injective
 
 theorem LeftInverse.eq_RightInverse {f : α → β} {g₁ g₂ : β → α} (h₁ : LeftInverse g₁ f)
@@ -241,7 +241,7 @@ attribute [local instance] Classical.propDecidable
 noncomputable def partial_inv {α β} (f : α → β) (b : β) : Option α :=
 if h : ∃ a, f a = b then some (Classical.choose h) else none
 
-theorem partial_inv_of_injective {α β} {f : α → β} (I : injective f) :
+theorem partial_inv_of_injective {α β} {f : α → β} (I : Injective f) :
   is_partial_inv f (partial_inv f)
 | a, b =>
 ⟨λ h => have hpi : partial_inv f b = if h : ∃ a, f a = b then some (Classical.choose h) else none :=
@@ -255,7 +255,7 @@ theorem partial_inv_of_injective {α β} {f : α → β} (I : injective f) :
  λ e => e ▸ have h : ∃ a', f a' = f a := ⟨_, rfl⟩
             (dif_pos h).trans (congr_arg _ (I $ Classical.choose_spec h))⟩
 
-theorem partial_inv_left {α β} {f : α → β} (I : injective f) : ∀ x, partial_inv f (f x) = some x :=
+theorem partial_inv_left {α β} {f : α → β} (I : Injective f) : ∀ x, partial_inv f (f x) = some x :=
 is_partial_inv_left (partial_inv_of_injective I)
 
 end
@@ -265,7 +265,7 @@ variable {α : Type u} [n : Nonempty α] {β : Sort v} {f : α → β} {s : Set 
 attribute [local instance] Classical.propDecidable
 
 /-- Construct the inverse for a function `f` on domain `s`. This function is a right inverse of `f`
-on `f '' s`. For a computable version, see `function.injective.inv_of_mem_range`. -/
+on `f '' s`. For a computable version, see `Function.Injective.inv_of_mem_range`. -/
 noncomputable def inv_fun_on (f : α → β) (s : Set α) (b : β) : α :=
 if h : ∃a, a ∈ s ∧ f a = b then Classical.choose h else Classical.choice n
 
@@ -302,32 +302,32 @@ lemma inv_fun_neg (h : ¬ ∃ a, f a = b) : inv_fun f b = Classical.choice n :=
 by refine inv_fun_on_neg (mt ?_ h); exact λ ⟨a, _, ha⟩ => ⟨a, ha⟩
 
 theorem inv_fun_eq_of_injective_of_RightInverse {g : β → α}
-  (hf : injective f) (hg : RightInverse g f) : inv_fun f = g :=
+  (hf : Injective f) (hg : RightInverse g f) : inv_fun f = g :=
 funext $ λ b => hf (by rw [hg b]
                        exact inv_fun_eq ⟨g b, hg b⟩)
 
-lemma RightInverse_inv_fun (hf : surjective f) : RightInverse (inv_fun f) f :=
+lemma RightInverse_inv_fun (hf : Surjective f) : RightInverse (inv_fun f) f :=
 λ b => inv_fun_eq $ hf b
 
-lemma LeftInverse_inv_fun (hf : injective f) : LeftInverse (inv_fun f) f :=
+lemma LeftInverse_inv_fun (hf : Injective f) : LeftInverse (inv_fun f) f :=
 λ b => have : f (inv_fun f (f b)) = f b := inv_fun_eq ⟨b, rfl⟩
        hf this
 
-lemma inv_fun_surjective (hf : injective f) : surjective (inv_fun f) :=
+lemma inv_fun_surjective (hf : Injective f) : Surjective (inv_fun f) :=
 (LeftInverse_inv_fun hf).surjective
 
-lemma inv_fun_comp (hf : injective f) : inv_fun f ∘ f = id := funext $ LeftInverse_inv_fun hf
+lemma inv_fun_comp (hf : Injective f) : inv_fun f ∘ f = id := funext $ LeftInverse_inv_fun hf
 
 end inv_fun
 
 section inv_fun
 variable {α : Type u} [i : Nonempty α] {β : Sort v} {f : α → β}
 
-lemma injective.has_LeftInverse (hf : injective f) : has_LeftInverse f :=
+lemma Injective.has_LeftInverse (hf : Injective f) : has_LeftInverse f :=
 ⟨inv_fun f, LeftInverse_inv_fun hf⟩
 
-lemma injective_iff_has_LeftInverse : injective f ↔ has_LeftInverse f :=
-⟨injective.has_LeftInverse, has_LeftInverse.injective⟩
+lemma injective_iff_has_LeftInverse : Injective f ↔ has_LeftInverse f :=
+⟨Injective.has_LeftInverse, has_LeftInverse.injective⟩
 
 end inv_fun
 
@@ -336,31 +336,31 @@ variable {α : Sort u} {β : Sort v} {f : α → β}
 
 /-- The inverse of a surjective function. (Unlike `inv_fun`, this does not require
   `α` to be inhabited.) -/
-noncomputable def surj_inv {f : α → β} (h : surjective f) (b : β) : α := Classical.choose (h b)
+noncomputable def surj_inv {f : α → β} (h : Surjective f) (b : β) : α := Classical.choose (h b)
 
-lemma surj_inv_eq (h : surjective f) (b) : f (surj_inv h b) = b := Classical.choose_spec (h b)
+lemma surj_inv_eq (h : Surjective f) (b) : f (surj_inv h b) = b := Classical.choose_spec (h b)
 
-lemma RightInverse_surj_inv (hf : surjective f) : RightInverse (surj_inv hf) f :=
+lemma RightInverse_surj_inv (hf : Surjective f) : RightInverse (surj_inv hf) f :=
 surj_inv_eq hf
 
-lemma LeftInverse_surj_inv (hf : bijective f) : LeftInverse (surj_inv hf.2) f :=
+lemma LeftInverse_surj_inv (hf : Bijective f) : LeftInverse (surj_inv hf.2) f :=
 RightInverse_of_injective_of_LeftInverse hf.1 (RightInverse_surj_inv hf.2)
 
-lemma surjective.has_RightInverse (hf : surjective f) : has_RightInverse f :=
+lemma Surjective.has_RightInverse (hf : Surjective f) : has_RightInverse f :=
 ⟨_, RightInverse_surj_inv hf⟩
 
-lemma surjective_iff_has_RightInverse : surjective f ↔ has_RightInverse f :=
-⟨surjective.has_RightInverse, has_RightInverse.surjective⟩
+lemma surjective_iff_has_RightInverse : Surjective f ↔ has_RightInverse f :=
+⟨Surjective.has_RightInverse, has_RightInverse.surjective⟩
 
-lemma bijective_iff_has_inverse : bijective f ↔ ∃ g, LeftInverse g f ∧ RightInverse g f :=
+lemma bijective_iff_has_inverse : Bijective f ↔ ∃ g, LeftInverse g f ∧ RightInverse g f :=
 ⟨λ hf =>  ⟨_, LeftInverse_surj_inv hf, RightInverse_surj_inv hf.2⟩,
  λ ⟨_, gl, gr⟩ => ⟨gl.injective,  gr.surjective⟩⟩
 
-lemma injective_surj_inv (h : surjective f) : injective (surj_inv h) :=
+lemma injective_surj_inv (h : Surjective f) : Injective (surj_inv h) :=
 (RightInverse_surj_inv h).injective
 
 lemma surjective_to_subsingleton [na : Nonempty α] [Subsingleton β] (f : α → β) :
-  surjective f :=
+  Surjective f :=
 λ _ => let ⟨a⟩ := na; ⟨a, Subsingleton.elim _ _⟩
 
 end surj_inv
@@ -386,7 +386,7 @@ by have h2 : (h : a = a') → Eq.rec (motive := λ _ _ => β) b h.symm = b :=
 @[simp] lemma update_same (a : α) (v : β a) (f : ∀a, β a) : update f a v a = v :=
 dif_pos rfl
 
-lemma update_injective (f : ∀a, β a) (a' : α) : injective (update f a') :=
+lemma update_injective (f : ∀a, β a) (a' : α) : Injective (update f a') :=
 by intros v v' h
    have h' := congrFun h a'
    rwa [update_same, update_same] at h'
@@ -438,14 +438,14 @@ lemma update_comp_eq_of_forall_ne {α β : Sort _} (g : α' → β) {f : α → 
   (update g i a) ∘ f = g ∘ f :=
 update_comp_eq_of_forall_ne' g a h
 
-lemma update_comp_eq_of_injective' (g : ∀a, β a) {f : α' → α} (hf : Function.injective f)
+lemma update_comp_eq_of_injective' (g : ∀a, β a) {f : α' → α} (hf : Injective f)
   (i : α') (a : β (f i)) :
   (λ j => update g (f i) a (f j)) = update (λ i => g (f i)) i a :=
 eq_update_iff.2 ⟨update_same _ _ _, λ _ hj => update_noteq (hf.ne hj) _ _⟩
 
 /-- Non-dependent version of `function.update_comp_eq_of_injective'` -/
 lemma update_comp_eq_of_injective {β : Sort _} (g : α' → β) {f : α → α'}
-  (hf : Function.injective f) (i : α) (a : β) :
+  (hf : Injective f) (i : α) (a : β) :
   (Function.update g (f i) a) ∘ f = Function.update (g ∘ f) i a :=
 update_comp_eq_of_injective' g hf i a
 
@@ -499,7 +499,7 @@ lemma extend_def (f : α → β) (g : α → γ) (e' : β → γ) (b : β) [hd :
   by rw [Subsingleton.elim hd] -- align the Decidable instances implicitly used by `dite`
      exact rfl
 
-@[simp] lemma extend_apply (hf : injective f) (g : α → γ) (e' : β → γ) (a : α) :
+@[simp] lemma extend_apply (hf : Injective f) (g : α → γ) (e' : β → γ) (a : α) :
   extend f g e' (f a) = g a :=
 by simp only [extend_def, dif_pos, exists_apply_eq_apply]
    exact congr_arg g (hf $ Classical.choose_spec (exists_apply_eq_apply f a))
@@ -509,7 +509,7 @@ theorem extend_apply' (g : α → γ) (e' : β → γ) (b : β) (hb : ¬∃ a, f
   extend f g e' b = e' b := by
   simp [Function.extend_def, hb]
 
-@[simp] lemma extend_comp (hf : injective f) (g : α → γ) (e' : β → γ) :
+@[simp] lemma extend_comp (hf : Injective f) (g : α → γ) (e' : β → γ) :
   extend f g e' ∘ f = g :=
 funext $ λ a => extend_apply hf g e' a
 
@@ -571,13 +571,13 @@ instance HasUncurry_induction [HasUncurry β γ δ] : HasUncurry (α → β) (α
 end uncurry
 
 /-- A function is involutive, if `f ∘ f = id`. -/
-def involutive {α} (f : α → α) : Prop := ∀ x, f (f x) = x
+def Involutive {α} (f : α → α) : Prop := ∀ x, f (f x) = x
 
-lemma involutive_iff_iter_2_eq_id {α} {f : α → α} : involutive f ↔ (f^[2] = id) :=
+lemma involutive_iff_iter_2_eq_id {α} {f : α → α} : Involutive f ↔ (f^[2] = id) :=
 funext_iff.symm
 
-namespace involutive
-variable {α : Sort u} {f : α → α} (h : involutive f)
+namespace Involutive
+variable {α : Sort u} {f : α → α} (h : Involutive f)
 
 @[simp]
 lemma comp_self : f ∘ f = id := funext h
@@ -585,9 +585,9 @@ lemma comp_self : f ∘ f = id := funext h
 protected lemma LeftInverse : LeftInverse f f := h
 protected lemma RightInverse : RightInverse f f := h
 
-protected lemma injective : injective f := h.LeftInverse.injective
-protected lemma surjective : surjective f := λ x => ⟨f x, h x⟩
-protected lemma bijective : bijective f := ⟨h.injective, h.surjective⟩
+protected lemma injective : Injective f := h.LeftInverse.injective
+protected lemma surjective : Surjective f := λ x => ⟨f x, h x⟩
+protected lemma bijective : Bijective f := ⟨h.injective, h.surjective⟩
 
 /-- Involuting an `ite` of an involuted value `x : α` negates the `Prop` condition in the `ite`. -/
 protected lemma ite_not (P : Prop) [Decidable P] (x : α) :
@@ -596,29 +596,29 @@ by rw [apply_ite f, h, ite_not]
 
 /-- An involution commutes across an equality. Compare to `function.injective.eq_iff`. -/
 protected lemma eq_iff {x y : α} : f x = y ↔ x = f y :=
-Function.injective.eq_iff' (involutive.injective h) (h y)
+Injective.eq_iff' (Involutive.injective h) (h y)
 
-end involutive
+end Involutive
 
 /-- The property of a binary function `f : α → β → γ` being injective.
 Mathematically this should be thought of as the corresponding function `α × β → γ` being injective.
 -/
-@[reducible] def injective2 {α β γ} (f : α → β → γ) : Prop :=
+@[reducible] def Injective2 {α β γ} (f : α → β → γ) : Prop :=
 ∀ {a₁ a₂ b₁ b₂}, f a₁ b₁ = f a₂ b₂ → a₁ = a₂ ∧ b₁ = b₂
 
-namespace injective2
+namespace Injective2
 variable {α β γ : Type _} (f : α → β → γ)
 
-protected lemma left (hf : injective2 f) {a₁ a₂ b₁ b₂} (h : f a₁ b₁ = f a₂ b₂) : a₁ = a₂ :=
+protected lemma left (hf : Injective2 f) {a₁ a₂ b₁ b₂} (h : f a₁ b₁ = f a₂ b₂) : a₁ = a₂ :=
 (hf h).1
 
-protected lemma right (hf : injective2 f) {a₁ a₂ b₁ b₂} (h : f a₁ b₁ = f a₂ b₂) : b₁ = b₂ :=
+protected lemma right (hf : Injective2 f) {a₁ a₂ b₁ b₂} (h : f a₁ b₁ = f a₂ b₂) : b₁ = b₂ :=
 (hf h).2
 
-lemma eq_iff (hf : injective2 f) {a₁ a₂ b₁ b₂} : f a₁ b₁ = f a₂ b₂ ↔ a₁ = a₂ ∧ b₁ = b₂ :=
+lemma eq_iff (hf : Injective2 f) {a₁ a₂ b₁ b₂} : f a₁ b₁ = f a₂ b₂ ↔ a₁ = a₂ ∧ b₁ = b₂ :=
 ⟨λ h => hf h, λ⟨h1, h2⟩ => congr_arg₂ f h1 h2⟩
 
-end injective2
+end Injective2
 
 section sometimes
 attribute [local instance] Classical.propDecidable

--- a/Mathlib/Order/Basic.lean
+++ b/Mathlib/Order/Basic.lean
@@ -315,7 +315,7 @@ lemma le_implies_le_of_le_of_le {a b c d : α} [Preorder α] (hca : c ≤ a) (hb
 λ hab => (hca.trans hab).trans hbd
 
 @[ext]
-theorem Preorder.to_le_injective {α : Type _} : Function.injective (@Preorder.toLE α) :=
+theorem Preorder.to_le_injective {α : Type _} : Function.Injective (@Preorder.toLE α) :=
 λ A B h => by
   cases A with | @mk A_toLE A_toLT A_le_refl A_le_trans A_lt_iff_le_not_le =>
   cases B with | @mk B_toLE B_toLT B_le_refl B_le_trans B_lt_iff_le_not_le =>
@@ -339,7 +339,7 @@ theorem Preorder.to_le_injective {α : Type _} : Function.injective (@Preorder.t
 
 @[ext]
 lemma PartialOrder.to_preorder_injective {α : Type _} :
-  Function.injective (@PartialOrder.toPreorder α) := λ A B h => by
+  Function.Injective (@PartialOrder.toPreorder α) := λ A B h => by
     cases A
     cases B
     subst h
@@ -347,7 +347,7 @@ lemma PartialOrder.to_preorder_injective {α : Type _} :
 
 @[ext]
 lemma LinearOrder.to_partial_order_injective {α : Type _} :
-  Function.injective (@LinearOrder.toPartialOrder α) := by
+  Function.Injective (@LinearOrder.toPartialOrder α) := by
   intros A B h
   cases A with | @mk A_toPartialOrder A_le_total A_decidable_le A_decidable_eq A_decidable_lt =>
   cases B with | @mk B_toPartialOrder B_le_total B_decidable_le B_decidable_eq B_decidable_lt =>
@@ -531,13 +531,13 @@ See note [reducible non-instances]. -/
 
 /-- Transfer a `PartialOrder` on `β` to a `PartialOrder` on `α` using an injective
 function `f : α → β`. See note [reducible non-instances]. -/
-@[reducible] def PartialOrder.lift {α β} [PartialOrder β] (f : α → β) (inj : injective f) :
+@[reducible] def PartialOrder.lift {α β} [PartialOrder β] (f : α → β) (inj : Injective f) :
   PartialOrder α :=
 { Preorder.lift f with le_antisymm := λ _ _ h₁ h₂ => inj (h₁.antisymm h₂) }
 
 /-- Transfer a `LinearOrder` on `β` to a `LinearOrder` on `α` using an injective
 function `f : α → β`. See note [reducible non-instances]. -/
-@[reducible] def LinearOrder.lift {α β} [LinearOrder β] (f : α → β) (inj : injective f) :
+@[reducible] def LinearOrder.lift {α β} [LinearOrder β] (f : α → β) (inj : Injective f) :
   LinearOrder α :=
 { PartialOrder.lift f inj with
     le_total     := λ x y => le_total (f x) (f y),

--- a/Mathlib/Order/Monotone.lean
+++ b/Mathlib/Order/Monotone.lean
@@ -179,10 +179,10 @@ section PartialOrder
 
 variable [PartialOrder β] {f : α → β}
 
-theorem Monotone.strict_mono_of_injective (h₁ : Monotone f) (h₂ : injective f) : StrictMono f :=
+theorem Monotone.strict_mono_of_injective (h₁ : Monotone f) (h₂ : Injective f) : StrictMono f :=
   fun _ _ h => (h₁ h.le).lt_of_ne fun H => h.ne <| h₂ H
 
-theorem Antitone.strict_anti_of_injective (h₁ : Antitone f) (h₂ : injective f) : StrictAnti f :=
+theorem Antitone.strict_anti_of_injective (h₁ : Antitone f) (h₂ : Injective f) : StrictAnti f :=
   fun _ _ h => (h₁ h.le).lt_of_ne fun H => h.ne <| h₂ H.symm
 
 end PartialOrder
@@ -280,7 +280,7 @@ theorem antitone_on_const [Preorder α] [Preorder β] {c : β} {s : Set α} :
   fun _ _ _ _ _ => le_rfl
 
 theorem injective_of_le_imp_le
-    [PartialOrder α] [Preorder β] (f : α → β) (h : ∀ {x y}, f x ≤ f y → x ≤ y) : injective f :=
+    [PartialOrder α] [Preorder β] (f : α → β) (h : ∀ {x y}, f x ≤ f y → x ≤ y) : Injective f :=
   fun _ _ hxy => (h hxy.le).antisymm (h hxy.ge)
 
 /-! ### Monotonicity under composition -/

--- a/test/Simps.lean
+++ b/test/Simps.lean
@@ -987,8 +987,8 @@ instance {α β} : CoeFun (α ≃ β) (λ _ => α → β) := ⟨Equiv'.toFun⟩
 ⟨f.invFun, f, f.right_inv, f.left_inv⟩
 
 structure DecoratedEquiv (α : Sort _) (β : Sort _) extends Equiv' α β :=
-(P_toFun    : Function.injective toFun )
-(P_invFun   : Function.injective invFun)
+(P_toFun    : Function.Injective toFun )
+(P_invFun   : Function.Injective invFun)
 
 instance {α β} : CoeFun (DecoratedEquiv α β) (λ _ => α → β) := ⟨λ f => f.toEquiv'⟩
 
@@ -1038,8 +1038,8 @@ example {α : Type} (x z : α) (h : x = z) : foo2 α x = z := by
   rw [h]
 
 structure FurtherDecoratedEquiv (α : Sort _) (β : Sort _) extends DecoratedEquiv α β :=
-(Q_toFun    : Function.surjective toFun )
-(Q_invFun   : Function.surjective invFun )
+(Q_toFun    : Function.Surjective toFun )
+(Q_invFun   : Function.Surjective invFun )
 
 instance {α β} : CoeFun (FurtherDecoratedEquiv α β) (λ _ => α → β) :=
 ⟨λ f => f.toDecoratedEquiv⟩


### PR DESCRIPTION
We had previously been changing mathport output to write `Function.injective` rather than `Function.Injective`. 

At https://github.com/leanprover-community/mathlib4/pull/498#discussion_r1003840030 @digama0 pointed out that mathport is capitalising correctly here.

This PR re-capitalises `Injective`, `Surjective`, `Bijective`, and `Involutive`, all in the `Function` namespace.