### PR TITLE
[Merged by Bors] - feat: integer operations in `norm_num`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -6,6 +6,7 @@ import Mathlib.Algebra.Group.Defs
 import Mathlib.Algebra.Group.Semiconj
 import Mathlib.Algebra.Group.Units
 import Mathlib.Algebra.GroupPower.Basic
+import Mathlib.Algebra.GroupPower.Lemmas
 import Mathlib.Algebra.GroupWithZero.Defs
 import Mathlib.Algebra.Order.Group
 import Mathlib.Algebra.Order.Monoid
@@ -26,6 +27,9 @@ import Mathlib.Data.Fin.Basic
 import Mathlib.Data.Fin.Fin2
 import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Fintype.Basic
+import Mathlib.Data.Int.Basic
+import Mathlib.Data.Int.Cast
+import Mathlib.Data.Int.Cast.Defs
 import Mathlib.Data.KVMap
 import Mathlib.Data.List.Basic
 import Mathlib.Data.List.Card

--- a/Mathlib/Algebra/GroupPower/Lemmas.lean
+++ b/Mathlib/Algebra/GroupPower/Lemmas.lean
@@ -1,0 +1,20 @@
+/-
+Copyright (c) 2015 Jeremy Avigad. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jeremy Avigad, Robert Y. Lewis
+-/
+import Mathlib.Data.Int.Cast
+
+/-!
+# Lemmas about power operations on monoids and groups
+
+This file contains lemmas about `monoid.pow`, `group.pow`, `nsmul`, `zsmul`
+which require additional imports besides those available in `algebra.group_power.basic`.
+-/
+
+@[simp, norm_cast]
+theorem Int.cast_pow [Ring R] (n : ℤ) : ∀ m : ℕ, (↑(n ^ m) : R) = (n : R) ^ m
+  | 0 => by rw [pow_zero, pow_zero, Int.cast_one]
+  | n+1 => by rw [pow_succ, pow_succ, Int.cast_mul, Int.cast_pow _ n]
+
+@[simp] theorem pow_eq {m : ℤ} {n : ℕ} : m.pow n = m ^ n := rfl

--- a/Mathlib/Algebra/GroupWithZero/Defs.lean
+++ b/Mathlib/Algebra/GroupWithZero/Defs.lean
@@ -75,19 +75,25 @@ class AddGroupWithOne (R : Type u) extends AddMonoidWithOne R, AddGroup R where
   intCast_ofNat : ∀ n : ℕ, intCast n = natCast n
   intCast_negSucc : ∀ n : ℕ, intCast (Int.negSucc n) = - natCast (n + 1)
 
-@[coe]
-def Int.cast [AddGroupWithOne R] : ℤ → R := AddGroupWithOne.intCast
+namespace Int
 
-instance [AddGroupWithOne R] : CoeTail ℤ R where coe := Int.cast
+@[coe] def cast [AddGroupWithOne R] : ℤ → R := AddGroupWithOne.intCast
 
-theorem Int.cast_ofNat [AddGroupWithOne R] : (Int.cast (Int.ofNat n) : R) = Nat.cast n :=
+instance [AddGroupWithOne R] : CoeTail ℤ R where coe := cast
+
+@[simp] theorem cast_ofNat [AddGroupWithOne R] : (cast (ofNat n) : R) = Nat.cast n :=
   AddGroupWithOne.intCast_ofNat _
-@[simp, norm_cast]
-theorem Int.cast_negSucc [AddGroupWithOne R] :
-    (Int.cast (Int.negSucc n) : R) = (-(Nat.cast (n + 1)) : R) :=
-  AddGroupWithOne.intCast_negSucc _
+#align int.cast_coe_nat Int.cast_ofNat
 
-@[simp, norm_cast] theorem Int.cast_zero [AddGroupWithOne R] : ((0 : ℤ) : R) = 0 := by
-  erw [Int.cast_ofNat, Nat.cast_zero]
-@[simp, norm_cast] theorem Int.cast_one [AddGroupWithOne R] : ((1 : ℤ) : R) = 1 := by
-  erw [Int.cast_ofNat, Nat.cast_one]
+@[simp, norm_cast]
+theorem cast_negSucc [AddGroupWithOne R] :
+    (cast (negSucc n) : R) = (-(Nat.cast (n + 1)) : R) :=
+  AddGroupWithOne.intCast_negSucc _
+#align int.cast_neg_succ_of_nat Int.cast_negSucc
+
+@[simp, norm_cast] theorem cast_zero [AddGroupWithOne R] : ((0 : ℤ) : R) = 0 := by
+  erw [cast_ofNat, Nat.cast_zero]
+@[simp, norm_cast] theorem cast_one [AddGroupWithOne R] : ((1 : ℤ) : R) = 1 := by
+  erw [cast_ofNat, Nat.cast_one]
+
+end Int

--- a/Mathlib/Algebra/GroupWithZero/Defs.lean
+++ b/Mathlib/Algebra/GroupWithZero/Defs.lean
@@ -81,7 +81,7 @@ namespace Int
 
 instance [AddGroupWithOne R] : CoeTail ℤ R where coe := cast
 
-theorem cast_ofNat [AddGroupWithOne R] : (cast (ofNat n) : R) = Nat.cast n :=
+@[simp] theorem cast_ofNat [AddGroupWithOne R] : (cast (ofNat n) : R) = Nat.cast n :=
   AddGroupWithOne.intCast_ofNat _
 #align int.cast_coe_nat Int.cast_ofNat
 

--- a/Mathlib/Algebra/GroupWithZero/Defs.lean
+++ b/Mathlib/Algebra/GroupWithZero/Defs.lean
@@ -81,7 +81,7 @@ namespace Int
 
 instance [AddGroupWithOne R] : CoeTail ℤ R where coe := cast
 
-@[simp] theorem cast_ofNat [AddGroupWithOne R] : (cast (ofNat n) : R) = Nat.cast n :=
+theorem cast_ofNat [AddGroupWithOne R] : (cast (ofNat n) : R) = Nat.cast n :=
   AddGroupWithOne.intCast_ofNat _
 #align int.cast_coe_nat Int.cast_ofNat
 

--- a/Mathlib/Algebra/GroupWithZero/Defs.lean
+++ b/Mathlib/Algebra/GroupWithZero/Defs.lean
@@ -81,7 +81,8 @@ namespace Int
 
 instance [AddGroupWithOne R] : CoeTail ℤ R where coe := cast
 
-@[simp] theorem cast_ofNat [AddGroupWithOne R] : (cast (ofNat n) : R) = Nat.cast n :=
+@[simp high, nolint simpNF] -- this lemma competes with `Int.ofNat_eq_cast` to come later
+theorem cast_ofNat [AddGroupWithOne R] : (cast (ofNat n) : R) = Nat.cast n :=
   AddGroupWithOne.intCast_ofNat _
 #align int.cast_coe_nat Int.cast_ofNat
 

--- a/Mathlib/Algebra/Ring/Basic.lean
+++ b/Mathlib/Algebra/Ring/Basic.lean
@@ -57,6 +57,11 @@ theorem neg_mul_eq_neg_mul {R} [Ring R] (a b : R) : -(a * b) = (-a) * b :=
     rw [sub_eq_add_neg, neg_neg (a * b) /- TODO: why is arg necessary? -/]
     rw [← add_mul, neg_add_self a /- TODO: why is arg necessary? -/, zero_mul]
 
+theorem mul_sub_right_distrib [Ring R] (a b c : R) : (a - b) * c = a * c - b * c := by
+  simpa only [sub_eq_add_neg, neg_mul_eq_neg_mul] using add_mul a (-b) c
+
+alias mul_sub_right_distrib ← sub_mul
+
 class CommRing (R : Type u) extends Ring R, CommSemiring R
 
 /- Instances -/
@@ -100,9 +105,9 @@ instance : CommRing ℤ where
   right_distrib := Int.add_mul
   mul_one := Int.mul_one
   one_mul := Int.one_mul
-  npow (n x) := x ^ n
-  npow_zero' n := rfl
-  npow_succ' n x := by rw [Int.mul_comm]; rfl
+  npow n x := x ^ n
+  npow_zero' _ := rfl
+  npow_succ' _ _ := by rw [Int.mul_comm]; rfl
   mul_assoc := Int.mul_assoc
   add_comm := Int.add_comm
   add_assoc := Int.add_assoc
@@ -114,7 +119,7 @@ instance : CommRing ℤ where
   nsmul_succ' n x := by
     show ofNat (Nat.succ n) * x = x + ofNat n * x
     rw [Int.ofNat_succ, Int.add_mul, Int.add_comm, Int.one_mul]
-  sub_eq_add_neg a b := Int.sub_eq_add_neg
+  sub_eq_add_neg _ _ := Int.sub_eq_add_neg
   natCast := (·)
   natCast_zero := rfl
   natCast_succ _ := rfl

--- a/Mathlib/Data/Int/Basic.lean
+++ b/Mathlib/Data/Int/Basic.lean
@@ -1,0 +1,52 @@
+/-
+Copyright (c) 2016 Jeremy Avigad. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jeremy Avigad
+-/
+import Std
+import Mathlib.Tactic.Convert
+import Mathlib.Init.Data.Int.Notation
+import Mathlib.Algebra.Ring.Basic
+
+/-!
+# Basic operations on the integers
+
+This file contains:
+* instances on `ℤ`. The stronger one is `int.linear_ordered_comm_ring`.
+* some basic lemmas about integers
+
+## Recursors
+
+* `int.rec`: Sign disjunction. Something is true/defined on `ℤ` if it's true/defined for nonnegative
+  and for negative values.
+* `int.bit_cases_on`: Parity disjunction. Something is true/defined on `ℤ` if it's true/defined for
+  even and for odd values.
+* `int.induction_on`: Simple growing induction on positive numbers, plus simple decreasing induction
+  on negative numbers. Note that this recursor is currently only `Prop`-valued.
+* `int.induction_on'`: Simple growing induction for numbers greater than `b`, plus simple decreasing
+  induction on numbers less than `b`.
+-/
+
+namespace Int
+
+/-- Inductively define a function on `ℤ` by defining it at `b`, for the `succ` of a number greater
+than `b`, and the `pred` of a number less than `b`. -/
+@[elab_as_elim] protected def inductionOn' {C : ℤ → Sort _}
+    (z : ℤ) (b : ℤ) (H0 : C b) (Hs : ∀ k, b ≤ k → C k → C (k + 1))
+    (Hp : ∀ k ≤ b, C k → C (k - 1)) : C z := by
+  rw [← sub_add_cancel (G := ℤ) z b, add_comm]
+  exact match z - b with
+  | .ofNat n =>
+    let rec pos : ∀ n : ℕ, C (b + n)
+    | 0 => _root_.cast (by erw [add_zero]) H0
+    | n+1 => _root_.cast (by rw [add_assoc]; rfl) <|
+      Hs _ (Int.le_add_of_nonneg_right (ofNat_nonneg _)) (pos n)
+    pos n
+  | .negSucc n =>
+    let rec neg : ∀ n : ℕ, C (b + -[n+1])
+    | 0 => Hp _ (Int.le_refl _) H0
+    | n+1 => by
+      refine _root_.cast (by rw [add_sub_assoc]; rfl) (Hp _ (Int.le_of_lt ?_) (neg n))
+      conv => rhs; apply (add_zero b).symm
+      rw [Int.add_lt_add_iff_left]; apply negSucc_lt_zero
+    neg n

--- a/Mathlib/Data/Int/Basic.lean
+++ b/Mathlib/Data/Int/Basic.lean
@@ -36,17 +36,19 @@ than `b`, and the `pred` of a number less than `b`. -/
     (Hp : ∀ k ≤ b, C k → C (k - 1)) : C z := by
   rw [← sub_add_cancel (G := ℤ) z b, add_comm]
   exact match z - b with
-  | .ofNat n =>
-    let rec pos : ∀ n : ℕ, C (b + n)
-    | 0 => _root_.cast (by erw [add_zero]) H0
-    | n+1 => _root_.cast (by rw [add_assoc]; rfl) <|
-      Hs _ (Int.le_add_of_nonneg_right (ofNat_nonneg _)) (pos n)
-    pos n
-  | .negSucc n =>
-    let rec neg : ∀ n : ℕ, C (b + -[n+1])
-    | 0 => Hp _ (Int.le_refl _) H0
-    | n+1 => by
-      refine _root_.cast (by rw [add_sub_assoc]; rfl) (Hp _ (Int.le_of_lt ?_) (neg n))
-      conv => rhs; apply (add_zero b).symm
-      rw [Int.add_lt_add_iff_left]; apply negSucc_lt_zero
-    neg n
+  | .ofNat n => pos n
+  | .negSucc n => neg n
+where
+  /-- The positive case of `Int.inductionOn'`. -/
+  pos : ∀ n : ℕ, C (b + n)
+  | 0 => _root_.cast (by erw [add_zero]) H0
+  | n+1 => _root_.cast (by rw [add_assoc]; rfl) <|
+    Hs _ (Int.le_add_of_nonneg_right (ofNat_nonneg _)) (pos n)
+
+  /-- The negative case of `Int.inductionOn'`. -/
+  neg : ∀ n : ℕ, C (b + -[n+1])
+  | 0 => Hp _ (Int.le_refl _) H0
+  | n+1 => by
+    refine _root_.cast (by rw [add_sub_assoc]; rfl) (Hp _ (Int.le_of_lt ?_) (neg n))
+    conv => rhs; apply (add_zero b).symm
+    rw [Int.add_lt_add_iff_left]; apply negSucc_lt_zero

--- a/Mathlib/Data/Int/Cast.lean
+++ b/Mathlib/Data/Int/Cast.lean
@@ -1,0 +1,29 @@
+/-
+Copyright (c) 2017 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro
+-/
+import Mathlib.Data.Int.Cast.Defs
+import Mathlib.Data.Int.Basic
+import Mathlib.Algebra.Ring.Basic
+
+/-!
+# Cast of integers (additional theorems)
+
+This file proves additional properties about the *canonical* homomorphism from
+the integers into an additive group with a one (`int.cast`).
+
+## Main declarations
+
+* `cast_add_hom`: `cast` bundled as an `add_monoid_hom`.
+* `cast_ring_hom`: `cast` bundled as a `ring_hom`.
+-/
+
+namespace Int
+
+@[simp, norm_cast]
+theorem cast_mul [Ring α] : -- FIXME: NonAssocRing
+    ∀ m n, ((m * n : ℤ) : α) = m * n := fun m =>
+  Int.inductionOn' m 0 (by simp)
+    (fun k _ ih n => by simp [add_mul, ih])
+    (fun k _ ih n => by simp [sub_mul, ih])

--- a/Mathlib/Data/Int/Cast/Defs.lean
+++ b/Mathlib/Data/Int/Cast/Defs.lean
@@ -1,0 +1,66 @@
+/-
+Copyright (c) 2017 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro, Gabriel Ebner
+-/
+import Mathlib.Algebra.GroupWithZero.Defs
+import Mathlib.Algebra.Group.Basic
+import Mathlib.Tactic.NormCast
+
+/-!
+# Cast of integers
+
+This file defines the *canonical* homomorphism from the integers into an
+additive group with a one (typically a `ring`).  In additive groups with a one
+element, there exists a unique such homomorphism and we store it in the
+`int_cast : ℤ → R` field.
+
+Preferentially, the homomorphism is written as a coercion.
+
+## Main declarations
+
+* `int.cast`: Canonical homomorphism `ℤ → R`.
+* `add_group_with_one`: Type class for `int.cast`.
+-/
+
+namespace Nat
+variable [AddGroupWithOne R]
+
+@[simp, norm_cast]
+theorem cast_sub {m n} (h : m ≤ n) : ((n - m : ℕ) : R) = n - m :=
+  eq_sub_of_add_eq <| by rw [← cast_add, Nat.sub_add_cancel h]
+
+end Nat
+
+namespace Int
+variable [AddGroupWithOne R]
+
+@[simp, norm_cast]
+theorem cast_neg [AddGroupWithOne R] : ∀ n:ℤ, ((-n : ℤ) : R) = -↑n
+  | (0 : ℕ) => by erw [cast_zero, neg_zero]
+  | (n + 1 : ℕ) => by erw [cast_ofNat, cast_negSucc]
+  | -[n +1] => by erw [cast_ofNat, cast_negSucc, neg_neg]
+
+@[simp]
+theorem cast_subNatNat [AddGroupWithOne R] (m n) : ((subNatNat m n : ℤ) : R) = m - n := by
+  unfold Int.subNatNat
+  cases e : n - m
+  · simp only [subNatNat, cast_ofNat]
+    simp [e, Nat.le_of_sub_eq_zero e]
+  · rw [cast_negSucc, Nat.add_one, ← e, Nat.cast_sub <| _root_.le_of_lt <| Nat.lt_of_sub_eq_succ e,
+      neg_sub]
+#align int.cast_sub_nat_nat Int.cast_subNatNat
+
+@[simp, norm_cast]
+theorem cast_add [AddGroupWithOne R] : ∀ m n, ((m + n : ℤ) : R) = m + n
+  | (m : ℕ), (n : ℕ) => by simp [← ofNat_add]
+  | (m : ℕ), -[n+1] => by erw [cast_subNatNat, cast_ofNat, cast_negSucc, sub_eq_add_neg]
+  | -[m+1], (n : ℕ) => by
+    erw [cast_subNatNat, cast_ofNat, cast_negSucc, sub_eq_iff_eq_add,
+      add_assoc, eq_neg_add_iff_add_eq, ← Nat.cast_add, ← Nat.cast_add, Nat.add_comm]
+  | -[m+1], -[n+1] => show (-[m + n + 1 +1] : R) = _ by
+    rw [cast_negSucc, cast_negSucc, cast_negSucc, ← neg_add_rev, ← Nat.cast_add,
+      Nat.add_right_comm m n 1, Nat.add_assoc, Nat.add_comm]
+
+@[simp, norm_cast]
+theorem cast_sub (m n) : ((m - n : ℤ) : R) = m - n := by simp [Int.sub_eq_add_neg, sub_eq_add_neg]

--- a/Mathlib/Tactic/Convert.lean
+++ b/Mathlib/Tactic/Convert.lean
@@ -104,8 +104,9 @@ syntax (name := convert) "convert " "← "? term (" using " num)? : tactic
 
 elab_rules : tactic
 | `(tactic| convert $[←%$sym]? $term $[using $n]?) => withMainContext do
-  let e ← Term.elabTerm term (← mkFreshExprMVar (mkSort (← getLevel (← getMainTarget))))
-  liftMetaTactic (Lean.MVarId.convert e sym.isSome (n.map (·.getNat)))
+  let (e, gs) ← elabTermWithHoles term
+    (← mkFreshExprMVar (mkSort (← getLevel (← getMainTarget)))) (← getMainTag)
+  liftMetaTactic fun g => return (← g.convert e sym.isSome (n.map (·.getNat))) ++ gs
 
 -- FIXME restore when `add_tactic_doc` is ported.
 -- add_tactic_doc

--- a/Mathlib/Tactic/NormNum/Basic.lean
+++ b/Mathlib/Tactic/NormNum/Basic.lean
@@ -4,6 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
 import Mathlib.Tactic.NormNum.Core
+import Mathlib.Data.Int.Cast
+import Mathlib.Algebra.GroupPower.Lemmas
 import Qq.Match
 
 /-!
@@ -21,7 +23,7 @@ open Lean Meta
   - `Nat.zero`
   - `Nat.succ x` where `isNumeral x`
   - `OfNat.ofNat _ x _` where `isNumeral x` -/
-partial def _root_.Lean.Expr.numeral? (e : Expr) : Option Nat :=
+partial def _root_.Lean.Expr.numeral? (e : Expr) : Option ℕ :=
   if let some n := e.natLit? then n
   else
     let f := e.getAppFn
@@ -36,100 +38,191 @@ partial def _root_.Lean.Expr.numeral? (e : Expr) : Option Nat :=
 namespace Meta.NormNum
 open Qq
 
-/-- Given a monadic function `k`
-which takes typed expressions representing a semiring element to a `NormNum.Result`,
-and lifts it to a `norm_num` extension. -/
-def withSemiring
-  (k : {u : Level} → (α : Q(Type u)) → Q($α) → Q(Semiring «$α») → MetaM Result) :
-    NormNumExt where eval e := do
-  let ⟨.succ u, α, e'⟩ ← inferTypeQ e | throwError "not data"
-  k α e' (← synthInstanceQ (q(Semiring $α) : Q(Type u)) <|> throwError "not a semiring")
-
-theorem isNat_zero (α) [Semiring α] : isNat (Zero.zero : α) (nat_lit 0) := Nat.cast_zero.symm
+theorem isNat_zero (α) [Semiring α] : IsNat (Zero.zero : α) (nat_lit 0) := ⟨Nat.cast_zero.symm⟩
 
 /-- The `norm_num` extension which identifies the expression `Zero.zero`, returning `0`. -/
-@[norm_num Zero.zero] def evalZero : NormNumExt := withSemiring fun α e _i => do
+@[norm_num Zero.zero] def evalZero : NormNumExt where eval {u α} e := do
+  let sα ← inferSemiring α
   match e with
-  | ~q(Zero.zero) =>
-    return .isNat (mkRawNatLit 0) q(isNat_zero $α)
+  | ~q(Zero.zero) => return (.isNat sα (mkRawNatLit 0) q(isNat_zero $α) : Result q(Zero.zero))
 
-theorem isNat_one (α) [Semiring α] : isNat (One.one : α) (nat_lit 1) := Nat.cast_one.symm
+theorem isNat_one (α) [Semiring α] : IsNat (One.one : α) (nat_lit 1) := ⟨Nat.cast_one.symm⟩
 
 /-- The `norm_num` extension which identifies the expression `One.one`, returning `1`. -/
-@[norm_num One.one] def evalOne : NormNumExt := withSemiring fun α e _i => do
+@[norm_num One.one] def evalOne : NormNumExt where eval {u α} e := do
+  let sα ← inferSemiring α
   match e with
-  | ~q(One.one) =>
-    return .isNat (mkRawNatLit 1) q(isNat_one $α)
+  | ~q(One.one) => return (.isNat sα (mkRawNatLit 1) q(isNat_one $α) : Result q(One.one))
+
+theorem isNat_ofNat (α : Type u_1) [Semiring α] (n : ℕ) [OfNat α n]
+  [LawfulOfNat α n] : IsNat (OfNat.ofNat n : α) n := ⟨LawfulOfNat.eq_ofNat.symm⟩
 
 /-- The `norm_num` extension which identifies an expression `OfNat.ofNat n`, returning `n`. -/
-@[norm_num OfNat.ofNat _] def evalOfNat : NormNumExt := withSemiring fun α e _ => do
+@[norm_num OfNat.ofNat _] def evalOfNat : NormNumExt where eval {u α} e := do
+  let sα ← inferSemiring α
   match e with
   | ~q(@OfNat.ofNat _ $n $oα) =>
     let n : Q(ℕ) ← whnf n
     guard n.isNatLit
     have : Q(OfNat $α $n) := oα
     _ ← synthInstanceQ (q(LawfulOfNat $α $n) : Q(Prop))
-    return .isNat n q(LawfulOfNat.isNat_ofNat (α := $α) (n := $n))
+    return (.isNat sα n q(isNat_ofNat $α $n) : Result q((OfNat.ofNat $n : $α)))
 
-theorem isNat_add {α} [Semiring α] : {a b : α} → {a' b' c : Nat} →
-    isNat a a' → isNat b b' → Nat.add a' b' = c → isNat (a + b) c
-  | _, _, _, _, _, rfl, rfl, rfl => Nat.cast_add.symm
+theorem isNat_cast {R} [Semiring R] (n m : ℕ) :
+    IsNat n m → IsNat (n : R) m := by rintro ⟨⟨⟩⟩; exact ⟨rfl⟩
+
+/-- The `norm_num` extension which identifies an expression `Nat.cast n`, returning `n`. -/
+@[norm_num Nat.cast _] def evalNatCast : NormNumExt where eval {u α} e := do
+  let sα ← inferSemiring α
+  match e with
+  | ~q(Nat.cast $a) =>
+    let ⟨na, pa⟩ ← deriveNat a q(instSemiringNat)
+    let pa : Q(IsNat $a $na) := pa
+    return (.isNat sα na q(@isNat_cast $α _ $a $na $pa) : Result q((Nat.cast $a : $α)))
+
+theorem isNat_int_cast {R} [Ring R] (n : ℤ) (m : ℕ) :
+    IsNat n m → IsNat (n : R) m := by rintro ⟨⟨⟩⟩; exact ⟨by simp⟩
+
+theorem isInt_cast {R} [Ring R] (n m : ℤ) :
+    IsInt n m → IsInt (n : R) m := by rintro ⟨⟨⟩⟩; exact ⟨rfl⟩
+
+/-- The `norm_num` extension which identifies an expression `Nat.cast n`, returning `n`. -/
+@[norm_num Int.cast _] def evalIntCast : NormNumExt where eval {u α} e := do
+  let rα ← inferRing α
+  match e with
+  | ~q(Int.cast $a) =>
+    match ← derive (α := q(ℤ)) a with
+    | .isNat _ na pa =>
+      let sα : Q(Semiring $α) := q(Ring.toSemiring)
+      let pa : Q(@IsNat _ Ring.toSemiring $a $na) := pa
+      return (.isNat sα na q(@isNat_int_cast $α _ $a $na $pa) : Result q((Int.cast $a : $α)))
+    | .isNegNat _ na pa =>
+      let pa : Q(@IsInt _ instRingInt $a (.negOfNat $na)) := pa
+      return (.isNegNat rα na q(isInt_cast $a (.negOfNat $na) $pa) : Result q((Int.cast $a : $α)))
+    | _ => failure
+
+theorem isNat_add {α} [Semiring α] : {a b : α} → {a' b' c : ℕ} →
+    IsNat a a' → IsNat b b' → Nat.add a' b' = c → IsNat (a + b) c
+  | _, _, _, _, _, ⟨rfl⟩, ⟨rfl⟩, rfl => ⟨Nat.cast_add.symm⟩
+
+theorem isInt_add {α} [Ring α] : {a b : α} → {a' b' c : ℤ} →
+    IsInt a a' → IsInt b b' → Int.add a' b' = c → IsInt (a + b) c
+  | _, _, _, _, _, ⟨rfl⟩, ⟨rfl⟩, rfl => ⟨(Int.cast_add ..).symm⟩
 
 /-- The `norm_num` extension which identifies expressions of the form `a + b`,
 such that `norm_num` successfully recognises both `a` and `b`. -/
-@[norm_num _ + _, Add.add _ _] def evalAdd : NormNumExt := withSemiring fun α e _i => do
-  let arm (a b : Q($α)) : MetaM Result := do
-    let (⟨na, pa⟩, ⟨nb, pb⟩) := (← deriveQ a, ← deriveQ b)
-    have c : Q(Nat) := mkRawNatLit (na.natLit! + nb.natLit!)
-    let r : Q(Nat.add «$na» «$nb» = «$c») := (q(Eq.refl $c) : Expr)
-    return .isNat c q(isNat_add $pa $pb $r)
-  match e with
-  | ~q($a + $b) => arm a b
-  | ~q(Add.add $a $b) => arm a b
+@[norm_num _ + _, Add.add _ _] def evalAdd : NormNumExt where eval {u α} e := do
+  let .app (.app f (a : Q($α))) (b : Q($α)) ← withReducible (whnf e) | failure
+  let ra ← derive a; let rb ← derive b
+  let intArm (rα : Q(Ring $α)) := do
+    let ⟨za, na, pa⟩ ← ra.toInt; let ⟨zb, nb, pb⟩ ← rb.toInt
+    let zc := za + zb
+    have c := mkRawIntLit zc
+    let r : Q(Int.add $na $nb = $c) := (q(Eq.refl $c) : Expr)
+    return (.isInt rα zc q(isInt_add $pa $pb $r) : Result q($a + $b))
+  match ra, rb with
+  | .isNat _ na pa, .isNat sα nb pb =>
+    have pa : Q(IsNat $a $na) := pa
+    guard <|← withNewMCtxDepth <| isDefEq f q(HAdd.hAdd (α := $α))
+    have c : Q(ℕ) := mkRawNatLit (na.natLit! + nb.natLit!)
+    let r : Q(Nat.add $na $nb = $c) := (q(Eq.refl $c) : Expr)
+    return (.isNat sα c q(isNat_add $pa $pb $r) : Result q($a + $b))
+  | .isNat _ .., .isNegNat rα ..
+  | .isNegNat rα .., .isNat _ ..
+  | .isNegNat _ .., .isNegNat rα .. => intArm rα
+  | _, _ => failure
 
-theorem isNat_mul {α} [Semiring α] : {a b : α} → {a' b' c : Nat} →
-    isNat a a' → isNat b b' → Nat.mul a' b' = c → isNat (a * b) c
-  | _, _, _, _, _, rfl, rfl, rfl => Nat.cast_mul.symm
+theorem isInt_neg {α} [Ring α] : {a : α} → {a' b : ℤ} →
+    IsInt a a' → Int.neg a' = b → IsInt (-a) b
+  | _, _, _, ⟨rfl⟩, rfl => ⟨(Int.cast_neg ..).symm⟩
+
+/-- The `norm_num` extension which identifies expressions of the form `-a`,
+such that `norm_num` successfully recognises `a`. -/
+@[norm_num -_] def evalNeg : NormNumExt where eval {u α} e := do
+  let .app f (a : Q($α)) ← withReducible (whnf e) | failure
+  let rα ← inferRing α
+  guard <|← withNewMCtxDepth <| isDefEq f q(Neg.neg (α := $α))
+  let ⟨za, na, pa⟩ ← (← derive a).toInt
+  let zb := -za
+  have b := mkRawIntLit zb
+  let r : Q(Int.neg $na = $b) := (q(Eq.refl $b) : Expr)
+  return (.isInt rα zb (z := b) q(isInt_neg $pa $r) : Result q(-$a))
+
+theorem isInt_sub {α} [Ring α] : {a b : α} → {a' b' c : ℤ} →
+    IsInt a a' → IsInt b b' → Int.sub a' b' = c → IsInt (a - b) c
+  | _, _, _, _, _, ⟨rfl⟩, ⟨rfl⟩, rfl => ⟨(Int.cast_sub ..).symm⟩
+
+/-- The `norm_num` extension which identifies expressions of the form `a - b`,
+such that `norm_num` successfully recognises both `a` and `b`. -/
+@[norm_num _ - _, Sub.sub _ _] def evalSub : NormNumExt where eval {u α} e := do
+  let .app (.app f (a : Q($α))) (b : Q($α)) ← withReducible (whnf e) | failure
+  let rα ← inferRing α
+  guard <|← withNewMCtxDepth <| isDefEq f q(HSub.hSub (α := $α))
+  let ⟨za, na, pa⟩ ← (← derive a).toInt; let ⟨zb, nb, pb⟩ ← (← derive b).toInt
+  let zc := za - zb
+  have c := mkRawIntLit zc
+  let r : Q(Int.sub $na $nb = $c) := (q(Eq.refl $c) : Expr)
+  return (.isInt rα zc (z := c) q(isInt_sub $pa $pb $r) : Result q($a - $b))
+
+theorem isNat_mul {α} [Semiring α] : {a b : α} → {a' b' c : ℕ} →
+    IsNat a a' → IsNat b b' → Nat.mul a' b' = c → IsNat (a * b) c
+  | _, _, _, _, _, ⟨rfl⟩, ⟨rfl⟩, rfl => ⟨Nat.cast_mul.symm⟩
+
+theorem isInt_mul {α} [Ring α] : {a b : α} → {a' b' c : ℤ} →
+    IsInt a a' → IsInt b b' → Int.mul a' b' = c → IsInt (a * b) c
+  | _, _, _, _, _, ⟨rfl⟩, ⟨rfl⟩, rfl => ⟨(Int.cast_mul ..).symm⟩
 
 /-- The `norm_num` extension which identifies expressions of the form `a * b`,
 such that `norm_num` successfully recognises both `a` and `b`. -/
-@[norm_num _ * _, Mul.mul _ _] def evalMul : NormNumExt := withSemiring fun α e _i => do
-  let arm (a b : Q($α)) : MetaM Result := do
-    let (⟨na, pa⟩, ⟨nb, pb⟩) := (← deriveQ a, ← deriveQ b)
-    have c : Q(Nat) := mkRawNatLit (na.natLit! * nb.natLit!)
-    let r : Q(Nat.mul «$na» «$nb» = «$c») := (q(Eq.refl $c) : Expr)
-    return .isNat c q(isNat_mul $pa $pb $r)
-  match e with
-  | ~q($a * $b) => arm a b
-  | ~q(Mul.mul $a $b) => arm a b
+@[norm_num _ * _, Mul.mul _ _] def evalMul : NormNumExt where eval {u α} e := do
+  let .app (.app f (a : Q($α))) (b : Q($α)) ← withReducible (whnf e) | failure
+  let ra ← derive a; let rb ← derive b
+  let intArm (rα : Q(Ring $α)) := do
+    guard <|← withNewMCtxDepth <| isDefEq f q(HMul.hMul (α := $α))
+    let ⟨za, na, pa⟩ ← ra.toInt; let ⟨zb, nb, pb⟩ ← rb.toInt
+    let zc := za * zb
+    have c := mkRawIntLit zc
+    let r : Q(Int.mul $na $nb = $c) := (q(Eq.refl $c) : Expr)
+    return (.isInt rα zc q(isInt_mul $pa $pb $r) : Result q($a * $b))
+  match ra, rb with
+  | .isNat _ na pa, .isNat sα nb pb =>
+    have pa : Q(IsNat $a $na) := pa
+    guard <|← withNewMCtxDepth <| isDefEq f q(HMul.hMul (α := $α))
+    have c : Q(ℕ) := mkRawNatLit (na.natLit! * nb.natLit!)
+    let r : Q(Nat.mul $na $nb = $c) := (q(Eq.refl $c) : Expr)
+    return (.isNat sα c q(isNat_mul $pa $pb $r) : Result q($a * $b))
+  | .isNat _ .., .isNegNat rα ..
+  | .isNegNat rα .., .isNat _ ..
+  | .isNegNat _ .., .isNegNat rα .. => intArm rα
+  | _, _ => failure
 
-theorem isNat_pow {α} [Semiring α] : {a : α} → {b a' b' c : Nat} →
-    isNat a a' → isNat b b' → Nat.pow a' b' = c → isNat (a ^ b) c
-  | _, _, _, _, _, rfl, rfl, rfl => by simp [isNat]
+theorem isNat_pow {α} [Semiring α] : {a : α} → {b a' b' c : ℕ} →
+    IsNat a a' → IsNat b b' → Nat.pow a' b' = c → IsNat (a ^ b) c
+  | _, _, _, _, _, ⟨rfl⟩, ⟨rfl⟩, rfl => ⟨by simp⟩
 
-def instSemiringNat : Semiring Nat := inferInstance
+theorem isInt_pow {α} [Ring α] : {a : α} → {b : ℕ} → {a' : ℤ} → {b' : ℕ} → {c : ℤ} →
+    IsInt a a' → IsNat b b' → Int.pow a' b' = c → IsInt (a ^ b) c
+  | _, _, _, _, _, ⟨rfl⟩, ⟨rfl⟩, rfl => ⟨by simp⟩
 
 /-- The `norm_num` extension which identifies expressions of the form `a ^ b`,
 such that `norm_num` successfully recognises both `a` and `b`, with `b : ℕ`. -/
-@[norm_num (_ : α) ^ (_ : Nat), Pow.pow _ (_ : Nat)]
-def evalPow : NormNumExt := withSemiring fun α e _i => do
-  let arm (a : Q($α)) (b : Q(Nat)) : MetaM Result := do
-    let (⟨na, pa⟩, ⟨nb, pb⟩) := (← deriveQ a, ← deriveQ b q(instSemiringNat))
-    have c : Q(Nat) := mkRawNatLit (na.natLit! ^ nb.natLit!)
-    let r : Q(Nat.pow «$na» «$nb» = «$c») := (q(Eq.refl $c) : Expr)
-    return .isNat c q(isNat_pow $pa $pb $r)
-  match e with
-  | ~q($a ^ ($b : Nat)) => arm a b
-  | ~q(Pow.pow $a ($b : Nat)) => arm a b
-
-theorem isNat_cast {R} [Semiring R] (n m : Nat) :
-    isNat n m → isNat (n : R) m := by
-  rintro ⟨⟩; rfl
-
-/-- The `norm_num` extension which identifies an expression `Nat.cast n`, returning `n`. -/
-@[norm_num Nat.cast _] def evalNatCast : NormNumExt := withSemiring fun α e _i => do
-  match e with
-  | ~q(Nat.cast $a) =>
-    let ⟨na, pa⟩ ← deriveQ a q(instSemiringNat)
-    let pa : Q(isNat $a $na) := pa
-    return .isNat na q(@isNat_cast $α _ $a $na $pa)
+@[norm_num (_ : α) ^ (_ : ℕ), Pow.pow _ (_ : ℕ)]
+def evalPow : NormNumExt where eval {u α} e := do
+  let .app (.app f (a : Q($α))) (b : Q(ℕ)) ← withReducible (whnf e) | failure
+  let ⟨nb, pb⟩ ← deriveNat b q(instSemiringNat)
+  let ra ← derive a
+  match ra with
+  | .isNat sα na pa =>
+    guard <|← withDefault <| withNewMCtxDepth <| isDefEq f q(HPow.hPow (α := $α))
+    have c : Q(ℕ) := mkRawNatLit (na.natLit! ^ nb.natLit!)
+    let r : Q(Nat.pow $na $nb = $c) := (q(Eq.refl $c) : Expr)
+    let pb : Q(IsNat $b $nb) := pb
+    return (.isNat sα c q(isNat_pow $pa $pb $r) : Result q($a ^ $b))
+  | .isNegNat rα .. =>
+    guard <|← withDefault <| withNewMCtxDepth <| isDefEq f q(HPow.hPow (α := $α))
+    let ⟨za, na, pa⟩ ← ra.toInt
+    let zc := za ^ nb.natLit!
+    let c := mkRawIntLit zc
+    let r : Q(Int.pow $na $nb = $c) := (q(Eq.refl $c) : Expr)
+    return (.isInt rα zc (z := c) q(isInt_pow $pa $pb $r) : Result q($a ^ $b))
+  | _ => failure

--- a/Mathlib/Tactic/NormNum/Basic.lean
+++ b/Mathlib/Tactic/NormNum/Basic.lean
@@ -86,7 +86,7 @@ theorem isNat_int_cast {R} [Ring R] (n : ℤ) (m : ℕ) :
 theorem isInt_cast {R} [Ring R] (n m : ℤ) :
     IsInt n m → IsInt (n : R) m := by rintro ⟨⟨⟩⟩; exact ⟨rfl⟩
 
-/-- The `norm_num` extension which identifies an expression `Nat.cast n`, returning `n`. -/
+/-- The `norm_num` extension which identifies an expression `Int.cast n`, returning `n`. -/
 @[norm_num Int.cast _] def evalIntCast : NormNumExt where eval {u α} e := do
   let rα ← inferRing α
   match e with

--- a/Mathlib/Tactic/NormNum/Core.lean
+++ b/Mathlib/Tactic/NormNum/Core.lean
@@ -118,7 +118,7 @@ section
 set_option linter.unusedVariables false
 
 /-- The result of `norm_num` running on an expression `x` of type `α`. -/
-def Result {α : Q(Type u)} (x : Q($α)) := Result'
+@[nolint unusedArguments] def Result {α : Q(Type u)} (x : Q($α)) := Result'
 
 /-- The result is `lit : ℕ` (a raw nat literal) and `proof : isNat x lit`. -/
 @[match_pattern, inline] def Result.isNat {α : Q(Type u)} {x : Q($α)} :
@@ -261,14 +261,6 @@ def deriveNat {α : Q(Type u)} (e : Q($α))
     MetaM ((lit : Q(ℕ)) × Q(IsNat $e $lit)) := do
   let .isNat _ lit proof ← derive e | failure
   pure ⟨lit, proof⟩
-
-/-- Run each registered `norm_num` extension on a typed expression `e : α`,
-returning a typed expression `lit : ℤ`, and a proof of `isInt e lit`. -/
-def deriveInt' {α : Q(Type u)} (e : Q($α)) :
-    MetaM ((_inst : Q(Ring $α)) × (lit : Q(ℤ)) × Q(IsInt $e $lit)) := do
-  let rα ← inferRing α
-  let ⟨_, lit, proof⟩ ← (← derive e).toInt
-  pure ⟨rα, lit, proof⟩
 
 /-- Run each registered `norm_num` extension on a typed expression `e : α`,
 returning a typed expression `lit : ℤ`, and a proof of `isInt e lit`. -/

--- a/Mathlib/Tactic/NormNum/Core.lean
+++ b/Mathlib/Tactic/NormNum/Core.lean
@@ -147,7 +147,7 @@ def inferRing (α : Q(Type u)) : MetaM Q(Ring $α) :=
   return ← synthInstanceQ (q(Ring $α) : Q(Type u)) <|> throwError "not a semiring"
 
 /-- Run each registered `norm_num` extension on a typed expression `e : α`,
-returning a typed expression `lit : ℕ`, and a proof of `isNat e lit`. -/
+returning a typed expression `lit : ℤ`, and a proof of `isInt e lit`. -/
 def Result.toInt {α : Q(Type u)} {e : Q($α)} (_i : Q(Ring $α) := by with_reducible assumption) :
     Result e → MetaM (ℤ × (lit : Q(ℤ)) × Q(IsInt $e $lit))
   | .isNat _ lit proof => do
@@ -186,7 +186,7 @@ structure NormNumExt where
   pre := true
   /-- The extension should be run in the `post` phase when used as simp plugin. -/
   post := true
-  /-- Attempts to prove an expression is equal to some natural number. -/
+  /-- Attempts to prove an expression is equal to some explicit number of the relevant type. -/
   eval {α : Q(Type u)} (e : Q($α)) : MetaM (Result e)
 
 /-- Read a `norm_num` extension from a declaration of the right type. -/

--- a/lean_packages/manifest.json
+++ b/lean_packages/manifest.json
@@ -1,7 +1,7 @@
 {"version": 2,
  "packages":
  [{"url": "https://github.com/leanprover/std4",
-   "rev": "d1d14d616938a07210b11d78165421a9a9163e48",
+   "rev": "d43a2592860dc76f17f19a41421761df7574c7ed",
    "name": "std",
    "inputRev": "main"},
   {"url": "https://github.com/gebner/quote4",

--- a/test/norm_num.lean
+++ b/test/norm_num.lean
@@ -115,10 +115,10 @@ section
   variable {α : Type}
   variable [Ring α]
 
-  -- example : (-1 :α) * 1 = -1 := by norm_num -- [fixme] support subtraction
-  -- example : (-2 :α) * 1 = -2 := by norm_num -- [fixme]
-  -- example : (-2 :α) * -1 = 2 := by norm_num -- [fixme]
-  -- example : (-2 :α) * -2 = 4 := by norm_num -- [fixme]
+  example : (-1 : α) * 1 = -1 := by norm_num
+  example : (-2 : α) * 1 = -2 := by norm_num
+  example : (-2 : α) * -1 = 2 := by norm_num
+  example : (-2 : α) * -2 = 4 := by norm_num
   example : (1 : α) * 0 = 0 := by norm_num
 
   example : ((1 : α) + 1) * 5 = 6 + 4 := by norm_num
@@ -148,15 +148,14 @@ section
 
   example : (45000000000 : α) = 23000000000 + 22000000000 := by norm_num
 
-  -- [fixme] needs to support subtraction.
-  -- example : (0 : α) - 3 = -3 := by norm_num
-  -- example : (0 : α) - 2 = -2 := by norm_num
-  -- example : (1 : α) - 3 = -2 := by norm_num
-  -- example : (1 : α) - 1 = 0 := by norm_num
-  -- example : (0 : α) - 3 = -3 := by norm_num
-  -- example : (0 : α) - 3 = -3 := by norm_num
-  -- example : (12 : α) - 4 - (5 + -2) = 5 := by norm_num
-  -- example : (12 : α) - 4 - (5 + -2) - 20 = -15 := by norm_num
+  example : (0 : α) - 3 = -3 := by norm_num
+  example : (0 : α) - 2 = -2 := by norm_num
+  example : (1 : α) - 3 = -2 := by norm_num
+  example : (1 : α) - 1 = 0 := by norm_num
+  example : (0 : α) - 3 = -3 := by norm_num
+  example : (0 : α) - 3 = -3 := by norm_num
+  example : (12 : α) - 4 - (5 + -2) = 5 := by norm_num
+  example : (12 : α) - 4 - (5 + -2) - 20 = -15 := by norm_num
 
   example : (0 : α) * 0 = 0 := by norm_num
   example : (0 : α) * 1 = 0 := by norm_num


### PR DESCRIPTION
Another major rewrite of `norm_num`, this time to support returning integers as well as nats. Rational numbers are included but stubbed for now pending the rest of the algebraic typeclasses.