### PR TITLE
[Merged by Bors] - feat: port `zify`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -156,6 +156,7 @@ import Mathlib.Tactic.TypeCheck
 import Mathlib.Tactic.UnsetOption
 import Mathlib.Tactic.Use
 import Mathlib.Tactic.Zify
+import Mathlib.Tactic.Zify.Attr
 import Mathlib.Testing.SlimCheck.Gen
 import Mathlib.Testing.SlimCheck.Sampleable
 import Mathlib.Testing.SlimCheck.Testable

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -155,6 +155,7 @@ import Mathlib.Tactic.Trace
 import Mathlib.Tactic.TypeCheck
 import Mathlib.Tactic.UnsetOption
 import Mathlib.Tactic.Use
+import Mathlib.Tactic.Zify
 import Mathlib.Testing.SlimCheck.Gen
 import Mathlib.Testing.SlimCheck.Sampleable
 import Mathlib.Testing.SlimCheck.Testable

--- a/Mathlib/Mathport/Syntax.lean
+++ b/Mathlib/Mathport/Syntax.lean
@@ -58,6 +58,7 @@ import Mathlib.Tactic.SwapVar
 import Mathlib.Tactic.Trace
 import Mathlib.Tactic.TypeCheck
 import Mathlib.Tactic.Use
+import Mathlib.Tactic.Zify
 import Mathlib.Util.Syntax
 import Mathlib.Util.WithWeakNamespace
 
@@ -389,8 +390,6 @@ syntax mono.side := &"left" <|> &"right" <|> &"both"
 /- M -/ syntax (name := group) "group" (ppSpace location)? : tactic
 
 /- M -/ syntax (name := cancelDenoms) "cancel_denoms" (ppSpace location)? : tactic
-
-/- M -/ syntax (name := zify) "zify" (simpArgs)? (ppSpace location)? : tactic
 
 /- S -/ syntax (name := transport) "transport" (ppSpace term)? " using " term : tactic
 

--- a/Mathlib/Tactic/Zify.lean
+++ b/Mathlib/Tactic/Zify.lean
@@ -5,7 +5,7 @@ Authors: Moritz Doll, Mario Carneiro, Robert Y. Lewis
 -/
 import Mathlib.Tactic.Basic
 import Mathlib.Tactic.NormCast
-import Mathlib.Tactic.ZifyAttr
+import Mathlib.Tactic.Zify.Attr
 import Mathlib.Algebra.Ring.Basic
 
 /-!

--- a/Mathlib/Tactic/Zify.lean
+++ b/Mathlib/Tactic/Zify.lean
@@ -43,8 +43,6 @@ subtype) to propositions about `ℤ` (the supertype), without changing the type 
 syntax (name := zify) "zify" (simpArgs)? (ppSpace location)? : tactic
 
 macro_rules
-| `(tactic| zify $[at $location]?) =>
-  `(tactic| simp only [zify_simps, push_cast] $[at $location]?)
 | `(tactic| zify $[[$simpArgs,*]]? $[at $location]?) =>
   let args := simpArgs.map (·.getElems) |>.getD #[]
   `(tactic| simp only [zify_simps, push_cast, $args,*] $[at $location]?)

--- a/Mathlib/Tactic/Zify.lean
+++ b/Mathlib/Tactic/Zify.lean
@@ -7,8 +7,9 @@ Authors: Moritz Doll, Mario Carneiro, Robert Y. Lewis
 import Mathlib.Tactic.Basic
 import Mathlib.Tactic.NormCast
 import Mathlib.Tactic.ZifyAttr
+import Mathlib.Algebra.Ring.Basic
 
-namespace Mathlib.Tactic
+namespace Mathlib.Tactic.Zify
 
 open Lean
 open Lean.Parser.Tactic
@@ -48,7 +49,7 @@ macro_rules
   let args := simpArgs.map (·.getElems) |>.getD #[]
   `(tactic| simp only [zify_simps, push_cast, $args,*] $[at $location]?)
 
-@[zify_simps] lemma zify.intOfNat_eq (a b : ℕ) : a = b ↔ (a : ℤ) = (b : ℤ) := Int.ofNat_inj.symm
-@[zify_simps] lemma zify.intOfNat_le (a b : ℕ) : a ≤ b ↔ (a : ℤ) ≤ (b : ℤ) := Int.ofNat_le.symm
-@[zify_simps] lemma zify.intOfNat_lt (a b : ℕ) : a < b ↔ (a : ℤ) < (b : ℤ) := Int.ofNat_lt.symm
-@[zify_simps] lemma zify.intOfNat_ne (a b : ℕ) : a ≠ b ↔ (a : ℤ) ≠ (b : ℤ) := by simp
+@[zify_simps] lemma nat_cast_eq (a b : ℕ) : a = b ↔ (a : ℤ) = (b : ℤ) := Int.ofNat_inj.symm
+@[zify_simps] lemma nat_cast_le (a b : ℕ) : a ≤ b ↔ (a : ℤ) ≤ (b : ℤ) := Int.ofNat_le.symm
+@[zify_simps] lemma nat_cast_lt (a b : ℕ) : a < b ↔ (a : ℤ) < (b : ℤ) := Int.ofNat_lt.symm
+@[zify_simps] lemma nat_cast_ne (a b : ℕ) : a ≠ b ↔ (a : ℤ) ≠ (b : ℤ) := by simp

--- a/Mathlib/Tactic/Zify.lean
+++ b/Mathlib/Tactic/Zify.lean
@@ -1,0 +1,54 @@
+/-
+Copyright (c) 2022 Moritz Doll. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Moritz Doll, Mario Carneiro, Robert Y. Lewis
+-/
+
+import Mathlib.Tactic.Basic
+import Mathlib.Tactic.NormCast
+import Mathlib.Tactic.ZifyAttr
+
+namespace Mathlib.Tactic
+
+open Lean
+open Lean.Parser.Tactic
+
+/--
+The `zify` tactic is used to shift propositions from `ℕ` to `ℤ`.
+This is often useful since `ℤ` has well-behaved subtraction.
+```lean4
+example (a b c x y z : ℕ) (h : ¬ x*y*z < 0) : c < a + 3*b := by
+  zify
+  zify at h
+  /-
+  h : ¬↑x * ↑y * ↑z < 0
+  ⊢ ↑c < ↑a + 3 * ↑b
+  -/
+```
+`zify` can be given extra lemmas to use in simplification. This is especially useful in the
+presence of nat subtraction: passing `≤` arguments will allow `push_cast` to do more work.
+```
+example (a b c : ℕ) (h : a - b < c) (hab : b ≤ a) : false := by
+  zify [hab] at h
+  /- h : ↑a - ↑b < ↑c -/
+```
+`zify` makes use of the `@[zify_simps]` attribute to move propositions,
+and the `push_cast` tactic to simplify the `ℤ`-valued expressions.
+`zify` is in some sense dual to the `lift` tactic. `lift (z : ℤ) to ℕ` will change the type of an
+integer `z` (in the supertype) to `ℕ` (the subtype), given a proof that `z ≥ 0`;
+propositions concerning `z` will still be over `ℤ`. `zify` changes propositions about `ℕ` (the
+subtype) to propositions about `ℤ` (the supertype), without changing the type of any variable.
+-/
+syntax (name := zify) "zify" (simpArgs)? (ppSpace location)? : tactic
+
+macro_rules
+| `(tactic| zify $[at $location]?) =>
+  `(tactic| simp only [zify_simps, push_cast] $[at $location]?)
+| `(tactic| zify $[[$simpArgs,*]]? $[at $location]?) =>
+  let args := simpArgs.map (·.getElems) |>.getD #[]
+  `(tactic| simp only [zify_simps, push_cast, $args,*] $[at $location]?)
+
+@[zify_simps] lemma zify.intOfNat_eq (a b : ℕ) : a = b ↔ (a : ℤ) = (b : ℤ) := Int.ofNat_inj.symm
+@[zify_simps] lemma zify.intOfNat_le (a b : ℕ) : a ≤ b ↔ (a : ℤ) ≤ (b : ℤ) := Int.ofNat_le.symm
+@[zify_simps] lemma zify.intOfNat_lt (a b : ℕ) : a < b ↔ (a : ℤ) < (b : ℤ) := Int.ofNat_lt.symm
+@[zify_simps] lemma zify.intOfNat_ne (a b : ℕ) : a ≠ b ↔ (a : ℤ) ≠ (b : ℤ) := by simp

--- a/Mathlib/Tactic/Zify.lean
+++ b/Mathlib/Tactic/Zify.lean
@@ -3,11 +3,26 @@ Copyright (c) 2022 Moritz Doll. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Moritz Doll, Mario Carneiro, Robert Y. Lewis
 -/
-
 import Mathlib.Tactic.Basic
 import Mathlib.Tactic.NormCast
 import Mathlib.Tactic.ZifyAttr
 import Mathlib.Algebra.Ring.Basic
+
+/-!
+# `zify` tactic
+
+The `zify` tactic is used to shift propositions from `ℕ` to `ℤ`.
+This is often useful since `ℤ` has well-behaved subtraction.
+```
+example (a b c x y z : ℕ) (h : ¬ x*y*z < 0) : c < a + 3*b := by
+  zify
+  zify at h
+  /-
+  h : ¬↑x * ↑y * ↑z < 0
+  ⊢ ↑c < ↑a + 3 * ↑b
+  -/
+```
+-/
 
 namespace Mathlib.Tactic.Zify
 
@@ -17,7 +32,7 @@ open Lean.Parser.Tactic
 /--
 The `zify` tactic is used to shift propositions from `ℕ` to `ℤ`.
 This is often useful since `ℤ` has well-behaved subtraction.
-```lean4
+```
 example (a b c x y z : ℕ) (h : ¬ x*y*z < 0) : c < a + 3*b := by
   zify
   zify at h

--- a/Mathlib/Tactic/Zify/Attr.lean
+++ b/Mathlib/Tactic/Zify/Attr.lean
@@ -1,0 +1,12 @@
+/-
+Copyright (c) 2022 Moritz Doll. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Moritz Doll, Mario Carneiro, Robert Y. Lewis
+-/
+import Lean.Meta.Tactic.Simp.SimpTheorems
+
+/-! # Internal simp attribute for `zify` tactic -/
+
+/-- The simpset `zify_simps` is used by the tactic `zify` to moved expression from `ℕ` to `ℤ`
+which gives a well-behaved substraction. -/
+register_simp_attr zify_simps

--- a/Mathlib/Tactic/ZifyAttr.lean
+++ b/Mathlib/Tactic/ZifyAttr.lean
@@ -1,0 +1,5 @@
+import Lean
+
+/-- The simpset `zify_simps` is used by the tactic `zify` to moved expression from `ℕ` to `ℤ`
+which gives a well-behaved substraction. -/
+register_simp_attr zify_simps

--- a/Mathlib/Tactic/ZifyAttr.lean
+++ b/Mathlib/Tactic/ZifyAttr.lean
@@ -1,5 +1,0 @@
-import Lean
-
-/-- The simpset `zify_simps` is used by the tactic `zify` to moved expression from `ℕ` to `ℤ`
-which gives a well-behaved substraction. -/
-register_simp_attr zify_simps

--- a/test/Zify.lean
+++ b/test/Zify.lean
@@ -1,0 +1,44 @@
+/-
+Copyright (c) 2022 Moritz Doll. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Moritz Doll, Robert Y. Lewis
+-/
+
+import Mathlib.Tactic.Zify
+import Std.Tactic.GuardExpr
+import Mathlib.Algebra.Group.Basic
+
+-- Todo: These are verbatim copies of the tests from mathlib3. There
+
+@[norm_cast] theorem ofNat_zero : Int.ofNat 0 = 0 := rfl
+
+example (a b c x y z : ℕ) (h : ¬ x*y*z < 0) (h2 : (c : ℤ) < a + 3 * b) : a + 3*b > c := by
+  zify at h ⊢
+  push_cast at h
+  -- fails because Int.ofNat_mul and Int.ofNat_zero are not flagged as `norm_cast`:
+  --guard_hyp h : ¬↑x * ↑y * ↑z < (0 : ℤ)
+  -- fails
+  --guard_target =ₐ ↑c < (↑a : ℤ) + 3 * ↑b
+  exact h2
+
+example (a b : ℕ) (h : (a : ℤ) ≤ b) : a ≤ b := by
+  zify
+  guard_target == (a : ℤ) ≤ b
+  exact h
+
+/-example (a b : ℕ) (h : a = b ∧ b < a) : False := by
+  zify at h
+  rcases h with ⟨ha, hb⟩
+  -- Preorder for `ℤ` is missing
+  exact ne_of_lt hb ha-/
+
+example (a b c : ℕ) (h : a - b < c) (hab : b ≤ a) : True := by
+  zify [hab] at h
+  -- fails because `Int.ofNat_sub` is not flagged as `norm_cast`
+  --guard_hyp h : (a : ℤ) - b < c,
+  trivial
+
+example (a b c : ℕ) (h : a + b ≠ c) : True := by
+  zify at h
+  --guard_hyp h : (a + b : ℤ) ≠ c
+  trivial

--- a/test/Zify.lean
+++ b/test/Zify.lean
@@ -6,24 +6,16 @@ Authors: Moritz Doll, Robert Y. Lewis
 
 import Mathlib.Tactic.Zify
 import Std.Tactic.GuardExpr
-import Mathlib.Algebra.Group.Basic
 import Mathlib.Tactic.LibrarySearch
 
 -- TODO: These are verbatim copies of the tests from mathlib3. It would be nice to add more.
 
--- TODO move these attributes to their correct homes.
-attribute [norm_cast] Int.ofNat_mul
-attribute [norm_cast] Int.ofNat_add
-attribute [norm_cast] Int.ofNat_sub
-attribute [norm_cast] Int.ofNat_zero
-
-@[norm_cast] lemma Int.ofNat_ofNat (n : ℕ) : (Int.ofNat (OfNat.ofNat n : ℕ)) = OfNat.ofNat n := rfl
-
+set_option pp.coercions false
 example (a b c x y z : ℕ) (h : ¬ x*y*z < 0) (h2 : (c : ℤ) < a + 3 * b) : a + 3*b > c := by
   zify at h ⊢
   push_cast at h
-  guard_hyp h : ¬↑x * ↑y * ↑z < (0 : ℤ)
-  guard_target =ₐ ↑c < (↑a : ℤ) + 3 * ↑b
+  guard_expr type_of% h = ¬↑x * ↑y * ↑z < (0 : ℤ) -- TODO: canonize instances?
+  guard_target = ↑c < (↑a : ℤ) + 3 * ↑b
   exact h2
 
 example (a b : ℕ) (h : (a : ℤ) ≤ b) : a ≤ b := by
@@ -44,5 +36,5 @@ example (a b c : ℕ) (h : a - b < c) (hab : b ≤ a) : True := by
 
 example (a b c : ℕ) (h : a + b ≠ c) : True := by
   zify at h
-  guard_hyp h : (a + b : ℤ) ≠ c
+  guard_expr type_of% h = (a + b : ℤ) ≠ c
   trivial

--- a/test/Zify.lean
+++ b/test/Zify.lean
@@ -7,18 +7,23 @@ Authors: Moritz Doll, Robert Y. Lewis
 import Mathlib.Tactic.Zify
 import Std.Tactic.GuardExpr
 import Mathlib.Algebra.Group.Basic
+import Mathlib.Tactic.LibrarySearch
 
--- Todo: These are verbatim copies of the tests from mathlib3. There
+-- TODO: These are verbatim copies of the tests from mathlib3. It would be nice to add more.
 
-@[norm_cast] theorem ofNat_zero : Int.ofNat 0 = 0 := rfl
+-- TODO move these attributes to their correct homes.
+attribute [norm_cast] Int.ofNat_mul
+attribute [norm_cast] Int.ofNat_add
+attribute [norm_cast] Int.ofNat_sub
+attribute [norm_cast] Int.ofNat_zero
+
+@[norm_cast] lemma Int.ofNat_ofNat (n : ℕ) : (Int.ofNat (OfNat.ofNat n : ℕ)) = OfNat.ofNat n := rfl
 
 example (a b c x y z : ℕ) (h : ¬ x*y*z < 0) (h2 : (c : ℤ) < a + 3 * b) : a + 3*b > c := by
   zify at h ⊢
   push_cast at h
-  -- fails because Int.ofNat_mul and Int.ofNat_zero are not flagged as `norm_cast`:
-  --guard_hyp h : ¬↑x * ↑y * ↑z < (0 : ℤ)
-  -- fails
-  --guard_target =ₐ ↑c < (↑a : ℤ) + 3 * ↑b
+  guard_hyp h : ¬↑x * ↑y * ↑z < (0 : ℤ)
+  guard_target =ₐ ↑c < (↑a : ℤ) + 3 * ↑b
   exact h2
 
 example (a b : ℕ) (h : (a : ℤ) ≤ b) : a ≤ b := by
@@ -34,11 +39,10 @@ example (a b : ℕ) (h : (a : ℤ) ≤ b) : a ≤ b := by
 
 example (a b c : ℕ) (h : a - b < c) (hab : b ≤ a) : True := by
   zify [hab] at h
-  -- fails because `Int.ofNat_sub` is not flagged as `norm_cast`
-  --guard_hyp h : (a : ℤ) - b < c,
+  guard_hyp h : (a : ℤ) - b < c
   trivial
 
 example (a b c : ℕ) (h : a + b ≠ c) : True := by
   zify at h
-  --guard_hyp h : (a + b : ℤ) ≠ c
+  guard_hyp h : (a + b : ℤ) ≠ c
   trivial


### PR DESCRIPTION
Initial port of `zify`. The tests are not really good, this is due to the fact that the relevant `norm_cast` lemmas do not exist yet.