### PR TITLE
[Merged by Bors] - feat: `ring_exp` tactic, subtraction in `ring`

### DIFF
--- a/Mathlib/Algebra/GroupPower/Basic.lean
+++ b/Mathlib/Algebra/GroupPower/Basic.lean
@@ -14,8 +14,10 @@ section Monoid
 
 variable [Monoid M]
 
-@[simp]
-theorem pow_one (a : M) : a ^ 1 = a := by rw [pow_succ, pow_zero, mul_one]
+@[simp] theorem pow_one (a : M) : a ^ 1 = a := by rw [pow_succ, pow_zero, mul_one]
+
+@[simp] theorem one_pow (n : ℕ) : (1 : M) ^ n = 1 := by
+  induction n <;> simp [*, pow_succ]
 
 theorem pow_add (a : M) (m n : ℕ) : a ^ (m + n) = a ^ m * a ^ n := by
   induction' n with n ih

--- a/Mathlib/Algebra/GroupPower/Basic.lean
+++ b/Mathlib/Algebra/GroupPower/Basic.lean
@@ -27,6 +27,9 @@ theorem add_nsmul (a : M) (m n : ℕ) : (m + n) • a = m • a + n • a := by
   | zero => rw [Nat.zero_add, zero_nsmul, zero_add]
   | succ m ih => rw [Nat.succ_add, Nat.succ_eq_add_one, succ_nsmul, ih, succ_nsmul, add_assoc]
 
+theorem succ_nsmul' (a : M) (n : ℕ) : (n + 1) • a = n • a + a := by
+  rw [add_nsmul, one_nsmul]
+
 end AddMonoid
 
 section Monoid
@@ -56,6 +59,8 @@ theorem Commute.mul_pow {a b : M} (h : Commute a b) (n : ℕ) : (a * b) ^ n = a 
   induction' n with n ih
   · rw [pow_zero, pow_zero, pow_zero, one_mul]
   · simp only [pow_succ, ih, ← mul_assoc, (h.pow_left n).right_comm]
+
+attribute [to_additive succ_nsmul'] pow_succ'
 
 end Monoid
 

--- a/Mathlib/Algebra/GroupPower/Lemmas.lean
+++ b/Mathlib/Algebra/GroupPower/Lemmas.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Robert Y. Lewis
 -/
 import Mathlib.Data.Int.Cast
+import Mathlib.Algebra.GroupPower.Basic
 
 /-!
 # Lemmas about power operations on monoids and groups
@@ -18,3 +19,11 @@ theorem Int.cast_pow [Ring R] (n : ℤ) : ∀ m : ℕ, (↑(n ^ m) : R) = (n : R
   | n+1 => by rw [pow_succ, pow_succ, Int.cast_mul, Int.cast_pow _ n]
 
 @[simp] theorem pow_eq {m : ℤ} {n : ℕ} : m.pow n = m ^ n := rfl
+
+theorem nsmul_eq_mul' [Semiring R] (a : R) (n : ℕ) : n • a = a * n := by
+  induction' n with n ih
+  · rw [zero_nsmul, Nat.cast_zero, mul_zero]
+  · rw [succ_nsmul', ih, Nat.cast_succ, mul_add, mul_one]
+
+@[simp] theorem nsmul_eq_mul [Semiring R] (n : ℕ) (a : R) : n • a = n * a := by
+  rw [nsmul_eq_mul', (n.cast_commute a).eq]

--- a/Mathlib/Algebra/Ring/Basic.lean
+++ b/Mathlib/Algebra/Ring/Basic.lean
@@ -52,10 +52,13 @@ class Ring (R : Type u) extends Semiring R, AddCommGroup R, AddGroupWithOne R
 
 example [Ring R] : HasInvolutiveNeg R := inferInstance
 
-theorem neg_mul_eq_neg_mul {R} [Ring R] (a b : R) : -(a * b) = (-a) * b :=
-  Eq.symm <| eq_of_sub_eq_zero' <| by
-    rw [sub_eq_add_neg, neg_neg (a * b) /- TODO: why is arg necessary? -/]
-    rw [← add_mul, neg_add_self a /- TODO: why is arg necessary? -/, zero_mul]
+@[simp] theorem neg_mul {R} [Ring R] (a b : R) : (-a) * b = -(a * b) :=
+  eq_of_sub_eq_zero' <| by rw [sub_eq_add_neg, neg_neg, ← add_mul, neg_add_self, zero_mul]
+
+@[simp] lemma mul_neg [Ring R] (a b : R) : a * -b = - (a * b) :=
+  eq_of_sub_eq_zero' <| by rw [sub_eq_add_neg, neg_neg, ← mul_add, neg_add_self, mul_zero]
+
+theorem neg_mul_eq_neg_mul {R} [Ring R] (a b : R) : -(a * b) = (-a) * b := (neg_mul ..).symm
 
 theorem mul_sub_right_distrib [Ring R] (a b c : R) : (a - b) * c = a * c - b * c := by
   simpa only [sub_eq_add_neg, neg_mul_eq_neg_mul] using add_mul a (-b) c

--- a/Mathlib/Algebra/Ring/Basic.lean
+++ b/Mathlib/Algebra/Ring/Basic.lean
@@ -34,6 +34,21 @@ class Semiring (R : Type u) extends NonUnitalSemiring R, NonAssocSemiring R, Mon
 
 section Semiring
 
+-- TODO: put these in the right place
+@[simp] theorem Commute.zero_right [Semiring R] (a : R) : Commute a 0 :=
+  (mul_zero _).trans (zero_mul _).symm
+
+@[simp] theorem Commute.zero_left [Semiring R] (a : R) : Commute 0 a :=
+  (zero_mul _).trans (mul_zero _).symm
+
+@[simp] theorem Commute.add_right [Semiring R] {a b c : R} (h : Commute a b) (h' : Commute a c) :
+    Commute a (b + c) := by
+  simp only [Commute, SemiconjBy, left_distrib, right_distrib, h.eq, h'.eq]
+
+@[simp] theorem Commute.add_left [Semiring R] {a b c : R} (h : Commute a c) (h' : Commute b c) :
+    Commute (a + b) c := by
+  simp only [Commute, SemiconjBy, left_distrib, right_distrib, h.eq, h'.eq]
+
 @[simp]
 lemma Nat.cast_mul [Semiring R] {m n : ℕ} : (m * n).cast = (m.cast * n.cast : R) := by
   induction n generalizing m <;> simp_all [mul_succ, mul_add]
@@ -41,6 +56,11 @@ lemma Nat.cast_mul [Semiring R] {m n : ℕ} : (m * n).cast = (m.cast * n.cast : 
 @[simp]
 lemma Nat.cast_pow [Semiring R] {m n : ℕ} : (m ^ n).cast = (m.cast ^ n : R) := by
   induction n generalizing m <;> simp_all [Nat.pow_succ', _root_.pow_succ'', pow_zero]
+
+theorem Nat.cast_commute [Semiring α] (n : ℕ) (x : α) : Commute (↑n) x := by
+  induction n with
+  | zero => rw [Nat.cast_zero]; exact Commute.zero_left x
+  | succ n ihn => rw [Nat.cast_succ] <;> exact ihn.add_left (Commute.one_left x)
 
 end Semiring
 

--- a/Mathlib/Mathport/Syntax.lean
+++ b/Mathlib/Mathport/Syntax.lean
@@ -333,18 +333,9 @@ syntax termList := " [" term,* "]"
 /- B -/ syntax (name := abel) "abel" (ppSpace (&"raw" <|> &"term"))? (ppSpace location)? : tactic
 /- B -/ syntax (name := abel!) "abel!" (ppSpace (&"raw" <|> &"term"))? (ppSpace location)? : tactic
 
-/- E -/ syntax (name := ring1) "ring1" : tactic
-/- E -/ syntax (name := ring1!) "ring1!" : tactic
-
 syntax ringMode := &"SOP" <|> &"raw" <|> &"horner"
 /- E -/ syntax (name := ringNF) "ring_nf" (ppSpace ringMode)? (ppSpace location)? : tactic
 /- E -/ syntax (name := ringNF!) "ring_nf!" (ppSpace ringMode)? (ppSpace location)? : tactic
-/- E -/ syntax (name := ring!) "ring!" : tactic
-
-/- B -/ syntax (name := ringExpEq) "ring_exp_eq" : tactic
-/- B -/ syntax (name := ringExpEq!) "ring_exp_eq!" : tactic
-/- B -/ syntax (name := ringExp) "ring_exp" (ppSpace location)? : tactic
-/- B -/ syntax (name := ringExp!) "ring_exp!" (ppSpace location)? : tactic
 
 /- E -/ syntax (name := noncommRing) "noncomm_ring" : tactic
 

--- a/Mathlib/Tactic/Ring.lean
+++ b/Mathlib/Tactic/Ring.lean
@@ -144,7 +144,7 @@ inductive ExProd : ∀ {α : Q(Type u)}, Q(CommSemiring $α) → (e : Q($α)) �
   | const (value : ℤ) : ExProd sα e
   /-- A product `x ^ e * b` is a monomial if `b` is a monomial. Here `x` is a `ExBase`
   and `e` is a `ExProd` representing a monomial expression in `ℕ` (it is a monomial instead of
-  a polynomial because we eagerly normalize `x ^ (a + b) = x ^ a + x ^ b`.) -/
+  a polynomial because we eagerly normalize `x ^ (a + b) = x ^ a * x ^ b`.) -/
   | mul {α : Q(Type u)} {sα : Q(CommSemiring $α)} {x : Q($α)} {e : Q(ℕ)} {b : Q($α)} :
     ExBase sα x → ExProd sℕ e → ExProd sα b → ExProd sα q($x ^ $e * $b)
 

--- a/lean_packages/manifest.json
+++ b/lean_packages/manifest.json
@@ -1,7 +1,7 @@
 {"version": 2,
  "packages":
  [{"url": "https://github.com/leanprover/std4",
-   "rev": "439263f585961c94df05c181616b1561063d8f3f",
+   "rev": "a74e9b2f605bfcf9a7b29fe15eb9ec49effb7283",
    "name": "std",
    "inputRev": "main"},
   {"url": "https://github.com/gebner/quote4",

--- a/test/ring.lean
+++ b/test/ring.lean
@@ -5,9 +5,10 @@ local instance [CommSemiring α] : CoeTail Nat α where
 
 example (x y : ℕ) : x + y = y + x := by ring
 example (x y : ℕ) : x + y + y = 2 * y + x := by ring
-example (x y : ℕ) : x + id y = y + id x := by ring
--- example {α} [CommRing α] (x y : α) : x + y + y - x = 2 * y := by ring
+example (x y : ℕ) : x + id y = y + id x := by ring!
+example {α} [CommRing α] (x y : α) : x + y + y - x = 2 * y := by ring
 -- example (x y : ℚ) : x / 2 + x / 2 = x := by ring
+set_option trace.Tactic.norm_num true
 example (x y : ℕ) : (x + y) ^ 3 = x ^ 3 + y ^ 3 + 3 * (x * y ^ 2 + x ^ 2 * y) := by ring
 -- example (x y : ℝ) : (x + y) ^ 3 = x ^ 3 + y ^ 3 + 3 * (x * y ^ 2 + x ^ 2 * y) := by ring
 example {α} [CommSemiring α] (x : α) : (x + 1) ^ 6 = (1 + x) ^ 6 := by ring
@@ -26,8 +27,8 @@ example (n : ℕ) : (n / 2) + (n / 2) = 2 * (n / 2) := by ring
 example {α} [CommSemiring α] (x y z : α) (n : ℕ) :
   (x + y) * (z * (y * y) + (x * x ^ n + (1 + ↑n) * x ^ n * y)) =
     x * (x * x ^ n) + ((2 + ↑n) * (x * x ^ n) * y + (x * z + (z * y + (1 + ↑n) * x ^ n)) * (y * y)) := by ring
--- example {α} [CommRing α] (a b c d e : α) :
---   (-(a * b) + c + d) * e = (c + (d + -a * b)) * e := by ring
+example {α} [CommRing α] (a b c d e : α) :
+  (-(a * b) + c + d) * e = (c + (d + -a * b)) * e := by ring
 example (a n s: ℕ) : a * (n - s) = (n - s) * a := by ring
 
 example (A : ℕ) : (2 * A) ^ 2 = (2 * A) ^ 2 := by ring
@@ -46,7 +47,7 @@ example (A : ℕ) : (2 * A) ^ 2 = (2 * A) ^ 2 := by ring
 --   ring
 -- end
 
--- example : (876544 : ℤ) * -1 + (1000000 - 123456) = 0 := by ring
+example : (876544 : ℤ) * -1 + (1000000 - 123456) = 0 := by ring
 
 -- example (x y : ℝ) (hx : x ≠ 0) (hy : y ≠ 0) :
 --   2 * x ^ 3 * 2 / (24 * x) = x ^ 2 / 6 :=

--- a/test/ring.lean
+++ b/test/ring.lean
@@ -8,7 +8,7 @@ example (x y : ℕ) : x + y + y = 2 * y + x := by ring
 example (x y : ℕ) : x + id y = y + id x := by ring!
 example {α} [CommRing α] (x y : α) : x + y + y - x = 2 * y := by ring
 -- example (x y : ℚ) : x / 2 + x / 2 = x := by ring
-set_option trace.Tactic.norm_num true
+
 example (x y : ℕ) : (x + y) ^ 3 = x ^ 3 + y ^ 3 + 3 * (x * y ^ 2 + x ^ 2 * y) := by ring
 -- example (x y : ℝ) : (x + y) ^ 3 = x ^ 3 + y ^ 3 + 3 * (x * y ^ 2 + x ^ 2 * y) := by ring
 example {α} [CommSemiring α] (x : α) : (x + 1) ^ 6 = (1 + x) ^ 6 := by ring
@@ -26,7 +26,8 @@ example (n : ℕ) : (n / 2) + (n / 2) = 2 * (n / 2) := by ring
 --   b ^ 2 - 4 * a * c = 4 * a * 0 + b * b - 4 * a * c := by ring
 example {α} [CommSemiring α] (x y z : α) (n : ℕ) :
   (x + y) * (z * (y * y) + (x * x ^ n + (1 + ↑n) * x ^ n * y)) =
-    x * (x * x ^ n) + ((2 + ↑n) * (x * x ^ n) * y + (x * z + (z * y + (1 + ↑n) * x ^ n)) * (y * y)) := by ring
+  x * (x * x ^ n) + ((2 + ↑n) * (x * x ^ n) * y +
+    (x * z + (z * y + (1 + ↑n) * x ^ n)) * (y * y)) := by ring
 example {α} [CommRing α] (a b c d e : α) :
   (-(a * b) + c + d) * e = (c + (d + -a * b)) * e := by ring
 example (a n s: ℕ) : a * (n - s) = (n - s) * a := by ring
@@ -58,3 +59,7 @@ example : (876544 : ℤ) * -1 + (1000000 - 123456) = 0 := by ring
 
 -- -- this proof style is not recommended practice
 -- example (A B : ℕ) (H : B * A = 2) : A * B = 2 := by {ring_nf, exact H}
+
+example (n : ℕ) (m : ℤ) : 2^(n+1) * m = 2 * 2^n * m := by ring
+example (a b : ℤ) (n : ℕ) : (a + b)^(n + 2) = (a^2 + b^2 + a * b + b * a) * (a + b)^n := by ring
+example (x y : ℕ) : x + id y = y + id x := by ring!

--- a/test/ring.lean
+++ b/test/ring.lean
@@ -8,6 +8,7 @@ example (x y : ℕ) : x + y + y = 2 * y + x := by ring
 example (x y : ℕ) : x + id y = y + id x := by ring!
 example {α} [CommRing α] (x y : α) : x + y + y - x = 2 * y := by ring
 -- example (x y : ℚ) : x / 2 + x / 2 = x := by ring
+example {α} [CommSemiring α] (x y : α) : (x + y)^2 = x^2 + 2 • x * y + y^2 := by ring
 
 example (x y : ℕ) : (x + y) ^ 3 = x ^ 3 + y ^ 3 + 3 * (x * y ^ 2 + x ^ 2 * y) := by ring
 -- example (x y : ℝ) : (x + y) ^ 3 = x ^ 3 + y ^ 3 + 3 * (x * y ^ 2 + x ^ 2 * y) := by ring


### PR DESCRIPTION
Another complete rewrite. This implements one `ring` to rule them all: it incorporates both `ring_exp` and `ring` behaviors, now under the name `ring`. (`ring_exp` had some small (1.4x) performance issues that prevented it from being used by default; I'm hoping that those issues are fixed now, and we can revisit later if it becomes an issue.)