### PR TITLE
[Merged by Bors] - feat: typeclasses for linarith

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -81,6 +81,7 @@ import Mathlib.Logic.Equiv.MfldSimpsAttr
 import Mathlib.Logic.Function.Basic
 import Mathlib.Logic.IsEmpty
 import Mathlib.Logic.Nonempty
+import Mathlib.Logic.Nontrivial
 import Mathlib.Logic.Relator
 import Mathlib.Mathport.Attributes
 import Mathlib.Mathport.Rename

--- a/Mathlib/Algebra/Group/Defs.lean
+++ b/Mathlib/Algebra/Group/Defs.lean
@@ -132,11 +132,13 @@ end Semigroup
 /-- A commutative semigroup is a type with an associative commutative `(*)`. -/
 @[ext]
 class CommSemigroup (G : Type u) extends Semigroup G where
+  /-- Multiplication is commutative in a commutative semigroup. -/
   mul_comm : ∀ a b : G, a * b = b * a
 
 /-- A commutative additive semigroup is a type with an associative commutative `(+)`. -/
 @[ext]
 class AddCommSemigroup (G : Type u) extends AddSemigroup G where
+  /-- Addition is commutative in an additive commutative semigroup. -/
   add_comm : ∀ a b : G, a + b = b + a
 
 attribute [to_additive AddCommSemigroup] CommSemigroup

--- a/Mathlib/Algebra/Order/Monoid.lean
+++ b/Mathlib/Algebra/Order/Monoid.lean
@@ -110,3 +110,9 @@ instance (priority := 100) OrderedCancelCommMonoid.toOrderedCommMonoid [OrderedC
 
 -- TODO `to_additive` should copy this
 attribute [instance] OrderedCancelAddCommMonoid.toOrderedAddCommMonoid
+
+/-- A linearly ordered additive commutative monoid. -/
+class LinearOrderedAddCommMonoid (α : Type _) extends LinearOrder α, OrderedAddCommMonoid α
+
+/-- A linearly ordered commutative monoid. -/
+class LinearOrderedCommMonoid (α : Type _) extends LinearOrder α, OrderedCommMonoid α

--- a/Mathlib/Algebra/Order/Ring.lean
+++ b/Mathlib/Algebra/Order/Ring.lean
@@ -168,11 +168,13 @@ explore changing this, but be warned that the instances involving `domain` may c
 search loops. -/
 /-- A `linear_ordered_semiring` is a nontrivial semiring with a linear order such that
 addition is monotone and multiplication by a positive number is strictly monotone. -/
-class LinearOrderedSemiring (α : Type u) extends StrictOrderedSemiring α, LinearOrderedAddCommMonoid α, Nontrivial α
+class LinearOrderedSemiring (α : Type u) extends StrictOrderedSemiring α,
+  LinearOrderedAddCommMonoid α, Nontrivial α
 
 /-- A `linear_ordered_comm_semiring` is a nontrivial commutative semiring with a linear order such
 that addition is monotone and multiplication by a positive number is strictly monotone. -/
-class LinearOrderedCommSemiring (α : Type _) extends StrictOrderedCommSemiring α, LinearOrderedSemiring α
+class LinearOrderedCommSemiring (α : Type _) extends StrictOrderedCommSemiring α,
+  LinearOrderedSemiring α
 
 /-- A `linear_ordered_ring` is a ring with a linear order such that addition is monotone and
 multiplication by a positive number is strictly monotone. -/

--- a/Mathlib/Algebra/Order/Ring.lean
+++ b/Mathlib/Algebra/Order/Ring.lean
@@ -7,6 +7,7 @@ Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro
 import Mathlib.Algebra.Ring.Basic
 import Mathlib.Algebra.Order.Monoid
 import Mathlib.Algebra.Order.Group
+import Mathlib.Logic.Nontrivial
 
 
 /-!
@@ -127,3 +128,56 @@ class OrderedRing (α : Type u) extends Ring α, OrderedAddCommGroup α where
 attribute [nolint docBlame] OrderedSemiring.le_of_add_le_add_left
 attribute [nolint docBlame] OrderedSemiring.add_le_add_left
 attribute [nolint docBlame] OrderedRing.add_le_add_left
+
+/-- An `ordered_comm_semiring` is a commutative semiring with a partial order such that addition is
+monotone and multiplication by a nonnegative number is monotone. -/
+class OrderedCommSemiring (α : Type u) extends OrderedSemiring α, CommSemiring α
+
+/-- An `ordered_comm_ring` is a commutative ring with a partial order such that addition is monotone
+and multiplication by a nonnegative number is monotone. -/
+class OrderedCommRing (α : Type u) extends OrderedRing α, CommRing α
+
+/-- A `strict_ordered_semiring` is a semiring with a partial order such that addition is strictly
+monotone and multiplication by a positive number is strictly monotone. -/
+class StrictOrderedSemiring (α : Type u) extends Semiring α, OrderedCancelAddCommMonoid α where
+  /-- In a strict ordered semiring, `0 ≤ 1`. -/
+  zero_le_one : (0 : α) ≤ 1
+  /-- Left multiplication by a positive element is strictly monotone. -/
+  mul_lt_mul_of_pos_left : ∀ a b c : α, a < b → 0 < c → c * a < c * b
+  /-- Right multiplication by a positive element is strictly monotone. -/
+  mul_lt_mul_of_pos_right : ∀ a b c : α, a < b → 0 < c → a * c < b * c
+
+/-- A `strict_ordered_comm_semiring` is a commutative semiring with a partial order such that
+addition is strictly monotone and multiplication by a positive number is strictly monotone. -/
+class StrictOrderedCommSemiring (α : Type u) extends StrictOrderedSemiring α, CommSemiring α
+
+/-- A `strict_ordered_ring` is a ring with a partial order such that addition is strictly monotone
+and multiplication by a positive number is strictly monotone. -/
+class StrictOrderedRing (α : Type u) extends Ring α, OrderedAddCommGroup α where
+  /-- In a strict ordered ring, `0 ≤ 1`. -/
+  zero_le_one : 0 ≤ (1 : α)
+  /-- The product of two positive elements is positive. -/
+  mul_pos : ∀ a b : α, 0 < a → 0 < b → 0 < a * b
+
+/-- A `strict_ordered_comm_ring` is a commutative ring with a partial order such that addition is
+strictly monotone and multiplication by a positive number is strictly monotone. -/
+class StrictOrderedCommRing (α : Type _) extends StrictOrderedRing α, CommRing α
+
+/- It's not entirely clear we should assume `nontrivial` at this point; it would be reasonable to
+explore changing this, but be warned that the instances involving `domain` may cause typeclass
+search loops. -/
+/-- A `linear_ordered_semiring` is a nontrivial semiring with a linear order such that
+addition is monotone and multiplication by a positive number is strictly monotone. -/
+class LinearOrderedSemiring (α : Type u) extends StrictOrderedSemiring α, LinearOrderedAddCommMonoid α, Nontrivial α
+
+/-- A `linear_ordered_comm_semiring` is a nontrivial commutative semiring with a linear order such
+that addition is monotone and multiplication by a positive number is strictly monotone. -/
+class LinearOrderedCommSemiring (α : Type _) extends StrictOrderedCommSemiring α, LinearOrderedSemiring α
+
+/-- A `linear_ordered_ring` is a ring with a linear order such that addition is monotone and
+multiplication by a positive number is strictly monotone. -/
+class LinearOrderedRing (α : Type u) extends StrictOrderedRing α, LinearOrder α, Nontrivial α
+
+/-- A `linear_ordered_comm_ring` is a commutative ring with a linear order such that addition is
+monotone and multiplication by a positive number is strictly monotone. -/
+class LinearOrderedCommRing (α : Type u) extends LinearOrderedRing α, CommMonoid α

--- a/Mathlib/Algebra/Order/Ring.lean
+++ b/Mathlib/Algebra/Order/Ring.lean
@@ -183,3 +183,5 @@ class LinearOrderedRing (α : Type u) extends StrictOrderedRing α, LinearOrder 
 /-- A `linear_ordered_comm_ring` is a commutative ring with a linear order such that addition is
 monotone and multiplication by a positive number is strictly monotone. -/
 class LinearOrderedCommRing (α : Type u) extends LinearOrderedRing α, CommMonoid α
+
+#print LinearOrderedCommRing.mul_comm

--- a/Mathlib/Logic/Nontrivial.lean
+++ b/Mathlib/Logic/Nontrivial.lean
@@ -17,4 +17,5 @@ We introduce a typeclass `nontrivial` formalizing this property.
 /-- Predicate typeclass for expressing that a type is not reduced to a single element. In rings,
 this is equivalent to `0 ≠ 1`. In vector spaces, this is equivalent to positive dimension. -/
 class Nontrivial (α : Type _) : Prop where
+  /-- In a nontrivial type, there exists a pair of distinct terms. -/
   exists_pair_ne : ∃ x y : α, x ≠ y

--- a/Mathlib/Logic/Nontrivial.lean
+++ b/Mathlib/Logic/Nontrivial.lean
@@ -1,0 +1,20 @@
+/-
+Copyright (c) 2020 Sébastien Gouëzel. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sébastien Gouëzel
+-/
+
+/-!
+# Nontrivial types
+
+A type is *nontrivial* if it contains at least two elements. This is useful in particular for rings
+(where it is equivalent to the fact that zero is different from one) and for vector spaces
+(where it is equivalent to the fact that the dimension is positive).
+
+We introduce a typeclass `nontrivial` formalizing this property.
+-/
+
+/-- Predicate typeclass for expressing that a type is not reduced to a single element. In rings,
+this is equivalent to `0 ≠ 1`. In vector spaces, this is equivalent to positive dimension. -/
+class Nontrivial (α : Type _) : Prop where
+  exists_pair_ne : ∃ x y : α, x ≠ y


### PR DESCRIPTION
These are just partial ports of files, containing the typeclasses that `linarith` wants.