### PR TITLE
[Merged by Bors] - chore: remove nolints

### DIFF
--- a/Mathlib/Algebra/Order/Group.lean
+++ b/Mathlib/Algebra/Order/Group.lean
@@ -90,9 +90,3 @@ attribute [to_additive neg_pos_of_neg] one_lt_inv_of_inv
 additive commutative group with a linear order in which
 addition is monotone. -/
 class LinearOrderedAddCommGroup (α : Type u) extends OrderedAddCommGroup α, LinearOrder α
-
--- TODO These are necessary because of https://github.com/leanprover/lean4/issues/1730
-attribute [nolint docBlame] LinearOrderedAddCommGroup.decidable_lt
-attribute [nolint docBlame] LinearOrderedAddCommGroup.decidable_le
-attribute [nolint docBlame] LinearOrderedAddCommGroup.decidable_eq
-attribute [nolint docBlame] LinearOrderedAddCommGroup.le_total

--- a/Mathlib/Algebra/Order/Ring.lean
+++ b/Mathlib/Algebra/Order/Ring.lean
@@ -122,8 +122,3 @@ class OrderedRing (α : Type u) extends Ring α, OrderedAddCommGroup α where
   zero_le_one : 0 ≤ (1 : α)
   /-- The product of positive elements is positive. -/
   mul_pos : ∀ a b : α, 0 < a → 0 < b → 0 < a * b
-
--- TODO These are necessary because of https://github.com/leanprover/lean4/issues/1730
-attribute [nolint docBlame] OrderedSemiring.le_of_add_le_add_left
-attribute [nolint docBlame] OrderedSemiring.add_le_add_left
-attribute [nolint docBlame] OrderedRing.add_le_add_left


### PR DESCRIPTION
After https://github.com/leanprover/lean4/issues/1730 was closed, we can remove some nolints.