### PR TITLE
[Merged by Bors] - chore(init/data/int): move lemmas

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -59,7 +59,7 @@ import Mathlib.Init.Algebra.Order
 import Mathlib.Init.Align
 import Mathlib.Init.Classical
 import Mathlib.Init.Core
-import Mathlib.Init.Data.Int.Basic
+import Mathlib.Init.Data.Int.Order
 import Mathlib.Init.Data.Int.Notation
 import Mathlib.Init.Data.Nat.Basic
 import Mathlib.Init.Data.Nat.Lemmas

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -59,8 +59,8 @@ import Mathlib.Init.Algebra.Order
 import Mathlib.Init.Align
 import Mathlib.Init.Classical
 import Mathlib.Init.Core
-import Mathlib.Init.Data.Int.Order
 import Mathlib.Init.Data.Int.Notation
+import Mathlib.Init.Data.Int.Order
 import Mathlib.Init.Data.Nat.Basic
 import Mathlib.Init.Data.Nat.Lemmas
 import Mathlib.Init.Function

--- a/Mathlib/Control/Random.lean
+++ b/Mathlib/Control/Random.lean
@@ -5,7 +5,7 @@ Authors: Henrik Böving
 -/
 import Mathlib.Init.Algebra.Order
 import Mathlib.Init.Data.Nat.Lemmas
-import Mathlib.Init.Data.Int.Basic
+import Mathlib.Init.Data.Int.Order
 import Mathlib.Data.Fin.Basic
 import Mathlib.Data.Nat.Basic
 

--- a/Mathlib/Data/Int/Basic.lean
+++ b/Mathlib/Data/Int/Basic.lean
@@ -29,6 +29,10 @@ This file contains:
 
 namespace Int
 
+@[simp, norm_cast] theorem coe_nat_le {m n : ℕ} : (↑m : ℤ) ≤ ↑n ↔ m ≤ n := ofNat_le
+
+@[simp, norm_cast] theorem coe_nat_lt {n m : ℕ} : (↑n : ℤ) < ↑m ↔ n < m := ofNat_lt
+
 /-- Inductively define a function on `ℤ` by defining it at `b`, for the `succ` of a number greater
 than `b`, and the `pred` of a number less than `b`. -/
 @[elab_as_elim] protected def inductionOn' {C : ℤ → Sort _}

--- a/Mathlib/Init/Data/Int/Order.lean
+++ b/Mathlib/Init/Data/Int/Order.lean
@@ -4,16 +4,12 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad
 -/
 
-import Std.Data.Int.Basic
-import Std.Data.Int.Lemmas
-import Mathlib.Init.Data.Nat.Lemmas
+import Mathlib.Init.Algebra.Order
 import Mathlib.Init.Data.Int.Notation
-import Mathlib.Tactic.Basic
-import Mathlib.Tactic.Coe
-import Mathlib.Algebra.Ring.Basic
-open Nat
 
 /-! # The order relation on the integers -/
+
+open Nat
 
 namespace Int
 

--- a/Mathlib/Init/Data/Int/Order.lean
+++ b/Mathlib/Init/Data/Int/Order.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2016 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Jeremy Avigad, Deniz Aydin, Floris van Doorn
+Authors: Jeremy Avigad
 -/
 
 import Std.Data.Int.Basic
@@ -12,6 +12,8 @@ import Mathlib.Tactic.Basic
 import Mathlib.Tactic.Coe
 import Mathlib.Algebra.Ring.Basic
 open Nat
+
+/-! # The order relation on the integers -/
 
 namespace Int
 

--- a/Mathlib/Init/Data/Int/Order.lean
+++ b/Mathlib/Init/Data/Int/Order.lean
@@ -15,7 +15,7 @@ open Nat
 
 namespace Int
 
-instance : LinearOrder Int where
+instance : LinearOrder ℤ where
   le := (·≤·)
   le_refl := Int.le_refl
   le_trans := @Int.le_trans
@@ -26,7 +26,3 @@ instance : LinearOrder Int where
   decidable_eq := by infer_instance
   decidable_le := by infer_instance
   decidable_lt := by infer_instance
-
-@[simp, norm_cast] theorem coe_nat_le {m n : ℕ} : (↑m : ℤ) ≤ ↑n ↔ m ≤ n := ofNat_le
-
-@[simp, norm_cast] theorem coe_nat_lt {n m : ℕ} : (↑n : ℤ) < ↑m ↔ n < m := ofNat_lt

--- a/test/norm_cast.lean
+++ b/test/norm_cast.lean
@@ -3,7 +3,6 @@ Tests for norm_cast
 -/
 
 import Mathlib.Tactic.NormCast
-import Mathlib.Init.Data.Int.Basic
 import Mathlib.Tactic.Ring
 import Mathlib.Data.Option.Defs
 -- import data.complex.basic -- ℕ, ℤ, ℚ, ℝ, ℂ


### PR DESCRIPTION
The file `Init.Data.Int.Basic` contained three declarations:
* `Int.LinearOrder`
* `Int.coe_nat_le`
* `Int.coe_nat_lt`

In mathlib3 all three of these were in other files: the first in `Init.Data.Int.Order` and the two last in `Data.Int.Basic`.  I propose moving them to the corresponding mathlib4 files so that people know where to look for them.

[Zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Porting.20status.20for.20lean3.20core/near/306899172)