### PR TITLE
[Merged by Bors] - feat: port convert_to

### DIFF
--- a/Mathlib/Mathport/Syntax.lean
+++ b/Mathlib/Mathport/Syntax.lean
@@ -268,7 +268,6 @@ namespace Tactic
 /- N -/ syntax (name := congr') "congr" (ppSpace colGt num)?
   (" with " (colGt rcasesPat)* (" : " num)?)? : tactic
 /- M -/ syntax (name := rcongr) "rcongr" (ppSpace colGt rcasesPat)* : tactic
-/- E -/ syntax (name := convertTo) "convert_to " term (" using " num)? : tactic
 /- E -/ syntax (name := acChange) "ac_change " term (" using " num)? : tactic
 
 /- S -/ syntax (name := rcases?) "rcases?" casesTarget,* (" : " num)? : tactic

--- a/Mathlib/Tactic/Convert.lean
+++ b/Mathlib/Tactic/Convert.lean
@@ -105,7 +105,7 @@ syntax (name := convert) "convert " "← "? term (" using " num)? : tactic
 elab_rules : tactic
 | `(tactic| convert $[←%$sym]? $term $[using $n]?) => withMainContext do
   let (e, gs) ← elabTermWithHoles term
-    (← mkFreshExprMVar (mkSort (← getLevel (← getMainTarget)))) (← getMainTag)
+    (← mkFreshExprMVar (mkSort (← getLevel (← getMainTarget)))) (← getMainTag) true
   liftMetaTactic fun g => return (← g.convert e sym.isSome (n.map (·.getNat))) ++ gs
 
 -- FIXME restore when `add_tactic_doc` is ported.
@@ -114,3 +114,9 @@ elab_rules : tactic
 --   category   := doc_category.tactic,
 --   decl_names := [`tactic.interactive.convert],
 --   tags       := ["congruence"] }
+
+syntax (name := convertTo) "convert_to " term (" using " num)? : tactic
+
+macro_rules
+| `(tactic| convert_to $term $[using $n]?) =>
+  `(tactic| convert (_ : $term) $[using $n]?)

--- a/Mathlib/Tactic/Convert.lean
+++ b/Mathlib/Tactic/Convert.lean
@@ -115,6 +115,14 @@ elab_rules : tactic
 --   decl_names := [`tactic.interactive.convert],
 --   tags       := ["congruence"] }
 
+/--
+`convert_to g using n` attempts to change the current goal to `g`, but unlike `change`,
+it will generate equality proof obligations using `congr n` to resolve discrepancies.
+`convert_to g` defaults to using `congr 1`.
+`convert_to` is similar to `convert`, but `convert_to` takes a type (the desired subgoal) while
+`convert` takes a proof term.
+That is, `convert_to g using n` is equivalent to `convert (_ : g) using n`.
+-/
 syntax (name := convertTo) "convert_to " term (" using " num)? : tactic
 
 macro_rules

--- a/Mathlib/Tactic/Convert.lean
+++ b/Mathlib/Tactic/Convert.lean
@@ -121,7 +121,7 @@ it will generate equality proof obligations using `congr n` to resolve discrepan
 `convert_to g` defaults to using `congr 1`.
 `convert_to` is similar to `convert`, but `convert_to` takes a type (the desired subgoal) while
 `convert` takes a proof term.
-That is, `convert_to g using n` is equivalent to `convert (_ : g) using n`.
+That is, `convert_to g using n` is equivalent to `convert (?_ : g) using n`.
 -/
 syntax (name := convertTo) "convert_to " term (" using " num)? : tactic
 

--- a/Mathlib/Tactic/Convert.lean
+++ b/Mathlib/Tactic/Convert.lean
@@ -105,7 +105,7 @@ syntax (name := convert) "convert " "← "? term (" using " num)? : tactic
 elab_rules : tactic
 | `(tactic| convert $[←%$sym]? $term $[using $n]?) => withMainContext do
   let (e, gs) ← elabTermWithHoles term
-    (← mkFreshExprMVar (mkSort (← getLevel (← getMainTarget)))) (← getMainTag) true
+    (← mkFreshExprMVar (mkSort (← getLevel (← getMainTarget)))) (← getMainTag)
   liftMetaTactic fun g => return (← g.convert e sym.isSome (n.map (·.getNat))) ++ gs
 
 -- FIXME restore when `add_tactic_doc` is ported.
@@ -127,4 +127,4 @@ syntax (name := convertTo) "convert_to " term (" using " num)? : tactic
 
 macro_rules
 | `(tactic| convert_to $term $[using $n]?) =>
-  `(tactic| convert (_ : $term) $[using $n]?)
+  `(tactic| convert (?_ : $term) $[using $n]?)

--- a/test/convert.lean
+++ b/test/convert.lean
@@ -46,16 +46,22 @@ example (α β : Type) (h : α = β) (b : β) : Nat × Nat × Nat × α := by
 
 section convert_to
 
+-- TODO: The original tests from mathlib are commented out, because `convert` does not
+-- support holes in types yet
+
 example {α} [AddCommMonoid α] {a b c d : α} (H : a = c) (H' : b = d) : a + b = d + c := by
   convert_to c + d = d + c
+  --convert_to c + d = _
   rw [add_comm]
 
 example {α} [AddCommMonoid α] {a b c d : α} (H : a = c) (H' : b = d) : a + b = d + c := by
   convert_to c + d = d + c using 2
+  --convert_to c + d = _ using 2
   rw [add_comm]
 
 example {α} [AddCommMonoid α] {a b c d : α} (H : a = c) (H' : b = d) : a + b = d + c := by
   convert_to c + d = d + c using 0
+  --convert_to c + d = _ using 0
   congr 2
   rw [add_comm]
 

--- a/test/convert.lean
+++ b/test/convert.lean
@@ -1,5 +1,6 @@
 import Mathlib.Tactic.Convert
 import Std.Tactic.GuardExpr
+import Mathlib.Algebra.Group.Basic
 
 example (P : Prop) (h : P) : P := by convert h
 
@@ -42,3 +43,20 @@ example (α β : Type) (h : α = β) (b : β) : Nat × Nat × Nat × α := by
 --   convert preimage_empty,
 --   rw [←preimage_inter,this],
 -- end
+
+section convert_to
+
+example {α} [AddCommMonoid α] {a b c d : α} (H : a = c) (H' : b = d) : a + b = d + c := by
+  convert_to c + d = d + c
+  rw [add_comm]
+
+example {α} [AddCommMonoid α] {a b c d : α} (H : a = c) (H' : b = d) : a + b = d + c := by
+  convert_to c + d = d + c using 2
+  rw [add_comm]
+
+example {α} [AddCommMonoid α] {a b c d : α} (H : a = c) (H' : b = d) : a + b = d + c := by
+  convert_to c + d = d + c using 0
+  congr 2
+  rw [add_comm]
+
+end convert_to

--- a/test/convert.lean
+++ b/test/convert.lean
@@ -46,22 +46,16 @@ example (α β : Type) (h : α = β) (b : β) : Nat × Nat × Nat × α := by
 
 section convert_to
 
--- TODO: The original tests from mathlib are commented out, because `convert` does not
--- support holes in types yet
-
 example {α} [AddCommMonoid α] {a b c d : α} (H : a = c) (H' : b = d) : a + b = d + c := by
-  convert_to c + d = d + c
-  --convert_to c + d = _
+  convert_to c + d = _
   rw [add_comm]
 
 example {α} [AddCommMonoid α] {a b c d : α} (H : a = c) (H' : b = d) : a + b = d + c := by
-  convert_to c + d = d + c using 2
-  --convert_to c + d = _ using 2
+  convert_to c + d = _ using 2
   rw [add_comm]
 
 example {α} [AddCommMonoid α] {a b c d : α} (H : a = c) (H' : b = d) : a + b = d + c := by
-  convert_to c + d = d + c using 0
-  --convert_to c + d = _ using 0
+  convert_to c + d = _ using 0
   congr 2
   rw [add_comm]
 


### PR DESCRIPTION
There is still the issue that the original mathlib3 version allows for holes in the type, but the simplest version of `convert_to` works.