### PR TITLE
[Merged by Bors] - feat: port data.bool.basic

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -19,6 +19,7 @@ import Mathlib.Control.Writer
 import Mathlib.Data.Array.Basic
 import Mathlib.Data.Array.Defs
 import Mathlib.Data.BinaryHeap
+import Mathlib.Data.Bool.Basic
 import Mathlib.Data.Bracket
 import Mathlib.Data.ByteArray
 import Mathlib.Data.Char

--- a/Mathlib/Data/Bool/Basic.lean
+++ b/Mathlib/Data/Bool/Basic.lean
@@ -1,0 +1,388 @@
+/-
+Copyright (c) 2014 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Leonardo de Moura, Jeremy Avigad
+-/
+import Mathlib.Init.Data.Bool.Lemmas
+import Mathlib.Init.Data.Nat.Lemmas
+import Mathlib.Init.Function
+
+/-!
+# Booleans
+
+This file proves various trivial lemmas about booleans and their
+relation to decidable propositions.
+
+## Tags
+bool, boolean, Bool, De Morgan
+
+-/
+
+namespace Bool
+
+-- probably happening already
+#align bool Bool
+
+theorem decide_True {h} : @decide True h = true :=
+  decide_eq_true True.intro
+#align bool.to_bool_true Bool.decide_True
+
+theorem decide_False {h} : @decide False h = false :=
+  decide_eq_false id
+#align bool.to_bool_false Bool.decide_False
+
+@[simp]
+theorem decide_coe (b : Bool) {h} : @decide b h = b := by
+  cases b
+  { exact decide_eq_false $ λ j => by cases j }
+  { exact decide_eq_true $ rfl }
+#align bool.to_bool_coe Bool.decide_coe
+
+theorem coe_decide (p : Prop) [d : Decidable p] : decide p ↔ p :=
+  match d with
+  | isTrue hp => ⟨λ _ => hp, λ _ => rfl⟩
+  | isFalse hnp => ⟨λ h => Bool.noConfusion h, λ hp => (hnp hp).elim⟩
+#align bool.coe_to_bool Bool.coe_decide
+
+theorem of_decide_iff {p : Prop} [Decidable p] : decide p ↔ p :=
+  coe_decide p
+#align bool.of_to_bool_iff Bool.of_decide_iff
+
+@[simp]
+theorem true_eq_decide_iff {p : Prop} [Decidable p] : true = decide p ↔ p :=
+  eq_comm.trans of_decide_iff
+#align bool.tt_eq_to_bool_iff Bool.true_eq_decide_iff
+
+@[simp]
+theorem false_eq_decide_iff {p : Prop} [Decidable p] : false = decide p ↔ ¬p :=
+  eq_comm.trans (decide_false_iff _)
+#align bool.ff_eq_to_bool_iff Bool.false_eq_decide_iff
+
+theorem decide_not (p : Prop) [Decidable p] : (decide ¬p) = !(decide p) := by
+  by_cases p <;> simp [*]
+#align bool.to_bool_not Bool.decide_not
+
+@[simp]
+theorem decide_and (p q : Prop) [Decidable p] [Decidable q] : decide (p ∧ q) = (p && q) := by
+  by_cases p <;> by_cases q <;> simp [*]
+#align bool.to_bool_and Bool.decide_and
+
+@[simp]
+theorem decide_or (p q : Prop) [Decidable p] [Decidable q] : decide (p ∨ q) = (p || q) := by
+  by_cases p <;> by_cases q <;> simp [*]
+#align bool.to_bool_or Bool.decide_or
+
+@[simp]
+theorem decide_eq {p q : Prop} [Decidable p] [Decidable q] : decide p = decide q ↔ (p ↔ q) :=
+  ⟨fun h => (coe_decide p).symm.trans <| by simp [h], decide_congr⟩
+#align bool.decide_eq Bool.to_bool_eq
+
+theorem not_false' : ¬false := fun.
+#align bool.not_ff Bool.not_false'
+
+@[simp]
+theorem default_bool : default = false :=
+  rfl
+
+theorem dichotomy (b : Bool) : b = false ∨ b = true := by cases b <;> simp
+
+@[simp]
+theorem forall_bool {p : Bool → Prop} : (∀ b, p b) ↔ p false ∧ p true :=
+  ⟨fun h => by simp [h], fun ⟨h₁, h₂⟩ b => by cases b <;> assumption⟩
+
+@[simp]
+theorem exists_bool {p : Bool → Prop} : (∃ b, p b) ↔ p false ∨ p true :=
+  ⟨fun ⟨b, h⟩ => by cases b; exact Or.inl h; exact Or.inr h,
+  fun h => match h with
+  | .inl h => ⟨_, h⟩
+  | .inr h => ⟨_, h⟩ ⟩
+
+/-- If `p b` is decidable for all `b : bool`, then `∀ b, p b` is decidable -/
+instance decidableForallBool {p : Bool → Prop} [∀ b, Decidable (p b)] : Decidable (∀ b, p b) :=
+  decidable_of_decidable_of_iff forall_bool.symm
+#align bool.decidable_forall_bool Bool.decidableForallBool
+
+/-- If `p b` is decidable for all `b : bool`, then `∃ b, p b` is decidable -/
+instance decidableExistsBool {p : Bool → Prop} [∀ b, Decidable (p b)] : Decidable (∃ b, p b) :=
+  decidable_of_decidable_of_iff exists_bool.symm
+#align bool.decidable_exists_bool Bool.decidableExistsBool
+
+theorem cond_eq_ite {α} (b : Bool) (t e : α) : cond b t e = if b then t else e := by
+  cases b <;> simp
+
+@[simp]
+theorem cond_decide {α} (p : Prop) [Decidable p] (t e : α) : cond (decide p) t e = if p then t else e := by
+  by_cases p <;> simp [*]
+#align bool.cond_to_bool Bool.cond_decide
+
+@[simp]
+theorem cond_not {α} (b : Bool) (t e : α) : cond (!b) t e = cond b e t := by cases b <;> rfl
+#align bool.cond_bnot Bool.cond_not
+
+theorem not_ne_id : not ≠ id := fun h => ff_ne_tt <| congrFun h true
+#align bool.bnot_ne_id Bool.not_ne_id
+
+theorem coe_bool_iff : ∀ {a b : Bool}, (a ↔ b) ↔ a = b := by decide
+
+theorem eq_true_of_ne_false : ∀ {a : Bool}, a ≠ false → a = true := by decide
+#align bool.eq_tt_of_ne_ff Bool.eq_true_of_ne_false
+
+theorem eq_false_of_ne_true : ∀ {a : Bool}, a ≠ true → a = false := by decide
+#align bool.eq_ff_of_ne_tt Bool.eq_false_of_ne_true
+
+theorem or_comm : ∀ a b, (a || b) = (b || a) := by decide
+#align bool.bor_comm Bool.or_comm
+
+#align bool.bor_assoc Bool.or_assoc
+
+theorem or_left_comm : ∀ a b c, (a || (b || c)) = (b || (a || c)) := by decide
+#align bool.bor_left_comm Bool.or_left_comm
+
+theorem or_inl {a b : Bool} (H : a) : a || b := by simp [H]
+#align bool.bor_inl Bool.or_inl
+
+theorem or_inr {a b : Bool} (H : b) : a || b := by cases a <;> simp [H]
+#align bool.bot_inr Bool.or_inr
+
+theorem and_comm : ∀ a b, (a && b) = (b && a) := by decide
+#align bool.band_comm Bool.and_comm
+
+#align bool.band_assoc Bool.and_assoc
+
+theorem and_left_comm : ∀ a b c, (a && (b && c)) = (b && (a && c)) := by decide
+#align bool.band_left_comm Bool.and_left_comm
+
+theorem and_elim_left : ∀ {a b : Bool}, a && b → a := by decide
+#align bool.band_elim_left Bool.and_elim_left
+
+theorem and_intro : ∀ {a b : Bool}, a → b → a && b := by decide
+#align bool.band_intro Bool.and_intro
+
+theorem and_elim_right : ∀ {a b : Bool}, a && b → b := by decide
+#align bool.band_elim_right Bool.and_elim_right
+
+theorem and_or_distrib_left (a b c : Bool) : (a && (b || c)) = (a && b || a && c) := by
+  cases a <;> simp
+#align bool.band_bor_distrib_left Bool.and_or_distrib_left
+
+theorem and_or_distrib_right (a b c : Bool) : ((a || b) && c) = (a && c || b && c) := by
+  cases a <;> cases b <;> cases c <;> simp
+#align bool.band_bor_distrib_right Bool.and_or_distrib_right
+
+theorem or_and_distrib_left (a b c : Bool) : (a || b && c) = ((a || b) && (a || c)) := by
+  cases a <;> simp
+#align bool.bor_band_distrib_left Bool.or_and_distrib_left
+
+theorem or_and_distrib_right (a b c : Bool) : (a && b || c) = ((a || c) && (b || c)) := by
+  cases a <;> cases b <;> cases c <;> simp
+#align bool.bor_band_distrib_right Bool.or_and_distrib_right
+
+#align bool.bnot_ff Bool.not_false
+#align bool.bnot_tt Bool.not_true
+
+lemma eq_not_iff : ∀ {a b : Bool}, a = !b ↔ a ≠ b := by decide
+#align bool.eq_bnot_iff Bool.eq_not_iff
+
+lemma not_eq_iff : ∀ {a b : Bool}, !a = b ↔ a ≠ b := by decide
+#align bool.bnot_eq_iff Bool.not_eq_iff
+
+-- **TODO** mention examples like this and other Not with caps
+@[simp]
+theorem Not_eq_not : ∀ {a b : Bool}, ¬a = !b ↔ a = b := by decide
+#align bool.not_eq_bnot Bool.Not_eq_not
+
+@[simp]
+theorem Not_not_eq : ∀ {a b : Bool}, ¬(!a) = b ↔ a = b := by decide
+#align bool.bnot_not_eq Bool.Not_not_eq
+
+theorem ne_not {a b : Bool} : a ≠ !b ↔ a = b :=
+  Not_eq_not
+#align bool.ne_bnot Bool.ne_not
+
+theorem not_ne : ∀ {a b : Bool}, (!a) ≠ b ↔ a = b := Not_not_eq
+#align bool.bnot_ne Bool.not_ne
+
+lemma not_ne_self : ∀ b : Bool, !b ≠ b := by decide
+#align bool.bnot_ne_self Bool.not_ne_self
+
+lemma self_ne_not : ∀ b : Bool, b ≠ !b := by decide
+#align bool.self_ne_bnot Bool.self_ne_not
+
+lemma eq_or_eq_not : ∀ a b, a = b ∨ a = !b := by decide
+#align bool.eq_or_eq_bnot Bool.eq_or_eq_not
+
+-- **TODO** mention examples like this and other Not
+theorem not_iff_Not : ∀ {b : Bool}, !b ↔ ¬b := by simp
+#align bool.bnot_iff_not Bool.not_iff_Not
+
+theorem eq_true_of_not_eq_false' {a : Bool} : !a = false → a = true := by
+  cases a <;> decide
+#align bool.eq_tt_of_bnot_eq_ff Bool.eq_true_of_not_eq_false'
+
+theorem eq_false_of_not_eq_true' {a : Bool} : !a = true → a = false := by
+  cases a <;> decide
+#align bool.eq_ff_of_bnot_eq_tt Bool.eq_false_of_not_eq_true'
+
+@[simp]
+theorem and_not_self : ∀ x, (x && !x) = false := by decide
+#align bool.band_bnot_self Bool.and_not_self
+
+@[simp]
+theorem not_and_self : ∀ x, (!x && x) = false := by decide
+#align bool.bnot_band_self Bool.not_and_self
+
+@[simp]
+theorem or_not_self : ∀ x, (x || !x) = true := by decide
+#align bool.bor_bnot_self Bool.or_not_self
+
+@[simp]
+theorem not_or_self : ∀ x, (!x || x) = true := by decide
+#align bool.bnot_bor_self Bool.not_or_self
+
+theorem xor_comm : ∀ a b, xor a b = xor b a := by decide
+#align bool.bxor_comm Bool.xor_comm
+
+@[simp]
+theorem xor_assoc : ∀ a b c, xor (xor a b) c = xor a (xor b c) := by decide
+#align bool.bxor_assoc Bool.xor_assoc
+
+theorem xor_left_comm : ∀ a b c, xor a (xor b c) = xor b (xor a c) := by decide
+#align bool.bxor_left_comm Bool.xor_left_comm
+
+@[simp]
+theorem xor_not_left : ∀ a, xor (!a) a = true := by decide
+#align bool.bxor_bnot_left Bool.xor_not_left
+
+@[simp]
+theorem xor_not_right : ∀ a, xor a (!a) = true := by decide
+#align bool.bxor_bnot_right Bool.xor_not_right
+
+@[simp]
+theorem xor_not_not : ∀ a b, xor (!a) (!b) = xor a b := by decide
+#align bool.bxor_bnot_bnot Bool.xor_not_not
+
+@[simp]
+theorem xor_false_left : ∀ a, xor false a = a := by decide
+#align bool.bxor_ff_left Bool.xor_false_left
+
+@[simp]
+theorem xor_false_right : ∀ a, xor a false = a := by decide
+#align bool.bxor_ff_right Bool.xor_false_right
+
+theorem and_xor_distrib_left (a b c : Bool) : (a && xor b c) = xor (a && b) (a && c) := by
+  cases a <;> simp
+#align bool.band_bxor_distrib_left Bool.and_xor_distrib_left
+
+theorem and_xor_distrib_right (a b c : Bool) : (xor a b && c) = xor (a && c) (b && c) := by
+  cases a <;> cases b <;> cases c <;> simp
+#align bool.band_bxor_distrib_right Bool.and_xor_distrib_right
+
+theorem xor_iff_ne : ∀ {x y : Bool}, xor x y = true ↔ x ≠ y := by decide
+#align bool.bxor_iff_ne Bool.xor_iff_ne
+
+/-! ### De Morgan's laws for booleans-/
+
+@[simp]
+theorem not_and : ∀ a b : Bool, !(a && b) = (!a || !b) := by decide
+#align bool.bnot_band Bool.not_and
+
+@[simp]
+theorem not_or : ∀ a b : Bool, !(a || b) = (!a && !b) := by decide
+#align bool.bnot_bor Bool.not_or
+
+theorem not_inj : ∀ {a b : Bool}, !a = !b → a = b := by decide
+#align bool.bnot_inj Bool.not_inj
+
+-- *TODO* flag
+instance : LinearOrder Bool where
+  le := fun a b => a = false ∨ b = true
+  le_refl := by unfold LE.le; decide
+  le_trans := by unfold LE.le; decide
+  le_antisymm := by unfold LE.le Preorder.toLE; decide
+  le_total := by unfold LE.le Preorder.toLE PartialOrder.toPreorder; decide
+  decidable_le := by unfold LE.le Preorder.toLE PartialOrder.toPreorder; exact inferInstance
+  decidable_eq := inferInstance
+  max := or
+  max_def := λ a b => by cases a <;> cases b <;> decide
+  min := and
+  min_def := λ a b => by cases a <;> cases b <;> decide
+  -- as of the time of writing, autoparams don't exist in Lean 4
+  lt_iff_le_not_le := λ _ _ => Iff.rfl
+#align bool.linear_order Bool.instLinearOrderBool
+
+@[simp]
+theorem false_le {x : Bool} : false ≤ x :=
+  Or.intro_left _ rfl
+#align bool.ff_le Bool.false_le
+
+@[simp]
+theorem le_true {x : Bool} : x ≤ true :=
+  Or.intro_right _ rfl
+#align bool.le_tt Bool.le_true
+
+-- *TODO* check I don't need to #align this because name the same
+theorem lt_iff : ∀ {x y : Bool}, x < y ↔ x = false ∧ y = true := by decide
+
+@[simp]
+theorem false_lt_true : false < true :=
+  lt_iff.2 ⟨rfl, rfl⟩
+#align bool.ff_lt_tt Bool.false_lt_true
+
+theorem le_iff_imp : ∀ {x y : Bool}, x ≤ y ↔ x → y := by decide
+
+theorem and_le_left : ∀ x y : Bool, (x && y) ≤ x := by decide
+#align bool.band_le_left Bool.and_le_left
+
+theorem and_le_right : ∀ x y : Bool, (x && y) ≤ y := by decide
+#align bool.band_le_right Bool.and_le_right
+
+theorem le_and : ∀ {x y z : Bool}, x ≤ y → x ≤ z → x ≤ (y && z) := by decide
+#align bool.le_band Bool.le_and
+
+theorem left_le_or : ∀ x y : Bool, x ≤ (x || y) := by decide
+#align bool.left_le_bor Bool.left_le_or
+
+theorem right_le_or : ∀ x y : Bool, y ≤ (x || y) := by decide
+#align bool.right_le_bor Bool.right_le_or
+
+theorem or_le : ∀ {x y z}, x ≤ z → y ≤ z → (x || y) ≤ z := by decide
+#align bool.bor_le Bool.or_le
+
+/-- convert a `bool` to a `ℕ`, `false -> 0`, `true -> 1` -/
+def toNat (b : Bool) : Nat :=
+  cond b 1 0
+#align bool.to_nat Bool.toNat
+
+/-- convert a `ℕ` to a `bool`, `0 -> false`, everything else -> `true` -/
+def ofNat (n : Nat) : Bool :=
+  decide (n ≠ 0)
+#align bool.of_nat Bool.ofNat
+
+theorem of_nat_le_of_nat {n m : Nat} (h : n ≤ m) : ofNat n ≤ ofNat m := by
+  simp only [ofNat, ne_eq, _root_.decide_not];
+  cases Nat.decEq n 0 with
+  | isTrue hn => rw [decide_eq_true hn]; exact false_le
+  | isFalse hn =>
+    cases Nat.decEq m 0 with
+    | isFalse hm => rw [decide_eq_false hm]; exact le_true
+    | isTrue hm => subst hm; have h := le_antisymm h (Nat.zero_le n); contradiction
+
+theorem to_nat_le_to_nat {b₀ b₁ : Bool} (h : b₀ ≤ b₁) : toNat b₀ ≤ toNat b₁ := by
+  cases h with
+  | inl h => subst h; exact Nat.zero_le _
+  | inr h => subst h; cases b₀ <;> simp;
+
+theorem of_nat_to_nat (b : Bool) : ofNat (toNat b) = b := by
+  cases b <;> rfl
+
+@[simp]
+theorem injective_iff {α : Sort _} {f : Bool → α} : Function.Injective f ↔ f false ≠ f true :=
+  ⟨fun Hinj Heq => ff_ne_tt (Hinj Heq), fun H x y hxy => by
+    cases x <;> cases y
+    exacts[rfl, (H hxy).elim, (H hxy.symm).elim, rfl]⟩
+
+/-- **Kaminski's Equation** -/
+theorem apply_apply_apply (f : Bool → Bool) (x : Bool) : f (f (f x)) = f x := by
+  cases x <;> cases h₁ : f true <;> cases h₂ : f false <;> simp only [h₁, h₂]
+
+end Bool

--- a/Mathlib/Data/Bool/Basic.lean
+++ b/Mathlib/Data/Bool/Basic.lean
@@ -294,6 +294,9 @@ theorem not_or : ∀ a b : Bool, !(a || b) = (!a && !b) := by decide
 theorem not_inj : ∀ {a b : Bool}, !a = !b → a = b := by decide
 #align bool.bnot_inj Bool.not_inj
 
+-- Porting note: having to unfold here is not pretty.
+-- There is a discussion on zulip about this at
+-- https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/LinearOrder.20in.20mathlib3.2F4/near/308228493
 instance : LinearOrder Bool where
   le := fun a b => a = false ∨ b = true
   le_refl := by unfold LE.le; decide

--- a/Mathlib/Data/Bool/Basic.lean
+++ b/Mathlib/Data/Bool/Basic.lean
@@ -184,19 +184,23 @@ lemma eq_not_iff : ∀ {a b : Bool}, a = !b ↔ a ≠ b := by decide
 lemma not_eq_iff : ∀ {a b : Bool}, !a = b ↔ a ≠ b := by decide
 #align bool.bnot_eq_iff Bool.not_eq_iff
 
+-- Porting note: this is a case where our naming scheme is less than ideal.
+-- The two `not`s in this name are different.
+-- For now we're going with consistency at the expense of ambiguity.
 @[simp]
-theorem Not_eq_not : ∀ {a b : Bool}, ¬a = !b ↔ a = b := by decide
-#align bool.not_eq_bnot Bool.Not_eq_not
+theorem not_eq_not : ∀ {a b : Bool}, ¬a = !b ↔ a = b := by decide
+#align bool.not_eq_bnot Bool.not_eq_not
 
+-- Porting note: and here again.
 @[simp]
-theorem Not_not_eq : ∀ {a b : Bool}, ¬(!a) = b ↔ a = b := by decide
-#align bool.bnot_not_eq Bool.Not_not_eq
+theorem not_not_eq : ∀ {a b : Bool}, ¬(!a) = b ↔ a = b := by decide
+#align bool.bnot_not_eq Bool.not_not_eq
 
 theorem ne_not {a b : Bool} : a ≠ !b ↔ a = b :=
-  Not_eq_not
+  not_eq_not
 #align bool.ne_bnot Bool.ne_not
 
-theorem not_ne : ∀ {a b : Bool}, (!a) ≠ b ↔ a = b := Not_not_eq
+theorem not_ne : ∀ {a b : Bool}, (!a) ≠ b ↔ a = b := not_not_eq
 #align bool.bnot_ne Bool.not_ne
 
 lemma not_ne_self : ∀ b : Bool, !b ≠ b := by decide
@@ -208,8 +212,9 @@ lemma self_ne_not : ∀ b : Bool, b ≠ !b := by decide
 lemma eq_or_eq_not : ∀ a b, a = b ∨ a = !b := by decide
 #align bool.eq_or_eq_bnot Bool.eq_or_eq_not
 
-theorem not_iff_Not : ∀ {b : Bool}, !b ↔ ¬b := by simp
-#align bool.bnot_iff_not Bool.not_iff_Not
+-- Porting note: naming issue again: these two `not` are different.
+theorem not_iff_not : ∀ {b : Bool}, !b ↔ ¬b := by simp
+#align bool.bnot_iff_not Bool.not_iff_not
 
 theorem eq_true_of_not_eq_false' {a : Bool} : !a = false → a = true := by
   cases a <;> decide

--- a/Mathlib/Data/Bool/Basic.lean
+++ b/Mathlib/Data/Bool/Basic.lean
@@ -20,9 +20,6 @@ bool, boolean, Bool, De Morgan
 
 namespace Bool
 
--- probably happening already
-#align bool Bool
-
 theorem decide_True {h} : @decide True h = true :=
   decide_eq_true True.intro
 #align bool.to_bool_true Bool.decide_True
@@ -304,7 +301,6 @@ instance : LinearOrder Bool where
   max_def := λ a b => by cases a <;> cases b <;> decide
   min := and
   min_def := λ a b => by cases a <;> cases b <;> decide
-  lt_iff_le_not_le := λ _ _ => Iff.rfl
 #align bool.linear_order Bool.instLinearOrderBool
 
 @[simp]

--- a/Mathlib/Data/Bool/Basic.lean
+++ b/Mathlib/Data/Bool/Basic.lean
@@ -111,7 +111,8 @@ theorem cond_eq_ite {α} (b : Bool) (t e : α) : cond b t e = if b then t else e
   cases b <;> simp
 
 @[simp]
-theorem cond_decide {α} (p : Prop) [Decidable p] (t e : α) : cond (decide p) t e = if p then t else e := by
+theorem cond_decide {α} (p : Prop) [Decidable p] (t e : α) :
+    cond (decide p) t e = if p then t else e := by
   by_cases p <;> simp [*]
 #align bool.cond_to_bool Bool.cond_decide
 

--- a/Mathlib/Data/Bool/Basic.lean
+++ b/Mathlib/Data/Bool/Basic.lean
@@ -186,7 +186,6 @@ lemma eq_not_iff : ∀ {a b : Bool}, a = !b ↔ a ≠ b := by decide
 lemma not_eq_iff : ∀ {a b : Bool}, !a = b ↔ a ≠ b := by decide
 #align bool.bnot_eq_iff Bool.not_eq_iff
 
--- **TODO** mention examples like this and other Not with caps
 @[simp]
 theorem Not_eq_not : ∀ {a b : Bool}, ¬a = !b ↔ a = b := by decide
 #align bool.not_eq_bnot Bool.Not_eq_not
@@ -211,7 +210,6 @@ lemma self_ne_not : ∀ b : Bool, b ≠ !b := by decide
 lemma eq_or_eq_not : ∀ a b, a = b ∨ a = !b := by decide
 #align bool.eq_or_eq_bnot Bool.eq_or_eq_not
 
--- **TODO** mention examples like this and other Not
 theorem not_iff_Not : ∀ {b : Bool}, !b ↔ ¬b := by simp
 #align bool.bnot_iff_not Bool.not_iff_Not
 
@@ -293,7 +291,6 @@ theorem not_or : ∀ a b : Bool, !(a || b) = (!a && !b) := by decide
 theorem not_inj : ∀ {a b : Bool}, !a = !b → a = b := by decide
 #align bool.bnot_inj Bool.not_inj
 
--- *TODO* flag
 instance : LinearOrder Bool where
   le := fun a b => a = false ∨ b = true
   le_refl := by unfold LE.le; decide
@@ -306,7 +303,6 @@ instance : LinearOrder Bool where
   max_def := λ a b => by cases a <;> cases b <;> decide
   min := and
   min_def := λ a b => by cases a <;> cases b <;> decide
-  -- as of the time of writing, autoparams don't exist in Lean 4
   lt_iff_le_not_le := λ _ _ => Iff.rfl
 #align bool.linear_order Bool.instLinearOrderBool
 
@@ -320,7 +316,6 @@ theorem le_true {x : Bool} : x ≤ true :=
   Or.intro_right _ rfl
 #align bool.le_tt Bool.le_true
 
--- *TODO* check I don't need to #align this because name the same
 theorem lt_iff : ∀ {x y : Bool}, x < y ↔ x = false ∧ y = true := by decide
 
 @[simp]

--- a/Mathlib/Init/Algebra/Order.lean
+++ b/Mathlib/Init/Algebra/Order.lean
@@ -39,7 +39,7 @@ class Preorder (α : Type u) extends LE α, LT α :=
 (le_refl : ∀ a : α, a ≤ a)
 (le_trans : ∀ a b c : α, a ≤ b → b ≤ c → a ≤ c)
 (lt := λ a b => a ≤ b ∧ ¬ b ≤ a)
-(lt_iff_le_not_le : ∀ a b : α, a < b ↔ (a ≤ b ∧ ¬ b ≤ a)) -- . order_laws_tac)
+(lt_iff_le_not_le : ∀ a b : α, a < b ↔ (a ≤ b ∧ ¬ b ≤ a) := by intros; rfl)
 
 variable [Preorder α]
 


### PR DESCRIPTION
Issues that came up: 
1) my understanding of the lean 4 naming convention is that capital/small letter choices are often dictated to you. However Lean 4 has `not` for bools and `Not` for props. This causes the following issue: in my port I have gone for the name

   ```lean4
   theorem Not_eq_not : ∀ {a b : Bool}, ¬a = !b ↔ a = b
   ```

   What should this theorem be called? The algorithm says `not_eq_not` which is misleading...or is it? It comes up a few times (the others are `not_iff_Not` and `Not_not_eq`)

2) When defining LinearOrder I had to do a lot of unfolding which is not present in Lean 3.
```
instance : LinearOrder Bool where
  le := fun a b => a = false ∨ b = true
  le_refl := by unfold LE.le; decide
  le_trans := by unfold LE.le; decide
  le_antisymm := by unfold LE.le Preorder.toLE; decide
  le_total := by unfold LE.le Preorder.toLE PartialOrder.toPreorder; decide
  decidable_le := by unfold LE.le Preorder.toLE PartialOrder.toPreorder; exact inferInstance
...
```

3) Again on orders: `lt_iff_le_not_le` is not an autoparam so I had to prove it explicitly with `Iff.rfl`. Do autoparams exist in Lean 4 yet? Does this need to be flagged?

4) Because the names of many functions on booleans changed (`bor` -> `or`, `bnot` -> `not` etc) I had to #align a lot of stuff. However the namespace also changed (`bool` -> `Bool`). Am I right in thinking that the few theorems like `bool.lt_iff`, which becomes `Bool.lt_iff` (i.e. the theorem name itself survived the naming change but the namespace did not) do *not* need to be #align ed?