### PR TITLE
[Merged by Bors] - feat: `#conv` command: `#simp`, `#norm_num` etc.

### DIFF
--- a/Mathlib/Mathport/Syntax.lean
+++ b/Mathlib/Mathport/Syntax.lean
@@ -468,9 +468,6 @@ namespace Conv
 -- https://github.com/leanprover-community/mathlib/issues/2882
 /- M -/ syntax (name := applyCongr) "apply_congr" (ppSpace (colGt term))? : conv
 
-/- E -/ syntax (name := normNum1) "norm_num1" : conv
-/- E -/ syntax (name := normNum) "norm_num" (simpArgs)? : conv
-
 /- E -/ syntax (name := ringNF) "ring_nf" (config)? (ppSpace ringMode)? : conv
 /- E -/ syntax (name := ringNF!) "ring_nf!" (config)? (ppSpace ringMode)? : conv
 /- E -/ syntax (name := ring) "ring" : conv
@@ -488,8 +485,6 @@ namespace Attr
 
 /- S -/ syntax (name := intro) "intro" : attr
 /- S -/ syntax (name := intro!) "intro!" : attr
-
-/- M -/ syntax (name := ext) "ext" (ppSpace ident)? : attr
 
 /- M -/ syntax (name := higherOrder) "higher_order" (ppSpace ident)? : attr
 /- S -/ syntax (name := interactive) "interactive" : attr
@@ -545,17 +540,10 @@ macro_rules
 
 /- N -/ syntax (name := defReplacer) "def_replacer " ident Term.optType : command
 
-/- S -/ syntax (name := simp) "#simp" (&" only")? (Tactic.simpArgs)? " :"? ppSpace term : command
-
 /- S -/ syntax (name := «where») "#where" : command
 
 /- M -/ syntax (name := reassoc_axiom) "reassoc_axiom " ident : command
 
 /- S -/ syntax (name := sample) "#sample " term : command
-
-/- S -/ syntax (name := normNum) "#norm_num" (&" only")? (Tactic.simpArgs)? " :"? ppSpace term :
-  command
-
-/- S -/ syntax (name := pushNeg) "#push_neg " term : command
 
 end Command

--- a/Mathlib/Tactic/Conv.lean
+++ b/Mathlib/Tactic/Conv.lean
@@ -4,6 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Gabriel Ebner
 -/
 import Mathlib.Tactic.RunCmd
+import Lean.Elab.Tactic.Conv.Basic
+import Std.Lean.Parser
 
 /-!
 Additional `conv` tactics.
@@ -23,3 +25,59 @@ macro_rules
     `(tactic| conv $[at $id]? $[in $[$occs]? $pat]? => rhs; ($seq:convSeq))
 
 macro "run_conv" e:doSeq : conv => `(conv| tactic' => run_tac $e)
+
+open Elab Tactic
+/--
+The command `#conv tac => e` will run a conv tactic `tac` on `e`, and display the resulting
+expression (discarding the proof).
+For example, `#conv rw [true_and] => True ∧ False` displays `False`.
+There are also shorthand commands for several common conv tactics:
+
+* `#whnf e` is short for `#conv whnf => e`
+* `#simp e` is short for `#conv simp => e`
+* `#norm_num e` is short for `#conv norm_num => e`
+* `#push_neg e` is short for `#conv push_neg => e`
+-/
+elab tk:"#conv " conv:conv " => " e:term : command =>
+  Command.runTermElabM fun _ => do
+    let e ← Elab.Term.elabTermAndSynthesize e none
+    let (rhs, g) ← Conv.mkConvGoalFor e
+    _ ← Tactic.run g.mvarId! do
+      evalTactic conv
+      for mvarId in (← getGoals) do
+        liftM <| mvarId.refl <|> mvarId.inferInstance <|> pure ()
+      pruneSolvedGoals
+      let e' ← instantiateMVars rhs
+      logInfoAt tk e'
+
+/--
+The command `#whnf e` evaluates `e` to Weak Head Normal Form, which means that the "head"
+of the expression is reduced to a primitive - a lambda or forall, or an axiom or inductive type.
+It is similar to `#reduce e`, but it does not reduce the expression completely,
+only until the first constructor is exposed. For example:
+```
+open Nat List
+set_option pp.notation false
+#whnf [1, 2, 3].map succ
+-- cons (succ 1) (map succ (cons 2 (cons 3 nil)))
+#reduce [1, 2, 3].map succ
+-- cons 2 (cons 3 (cons 4 nil))
+```
+The head of this expression is the `List.cons` constructor,
+so we can see from this much that the list is not empty,
+but the subterms `Nat.succ 1` and `List.map Nat.succ (List.cons 2 (List.cons 3 List.nil))` are
+still unevaluated. `#reduce` is equivalent to using `#whnf` on every subexpression.
+-/
+macro tk:"#whnf " e:term : command => `(command| #conv%$tk whnf => $e)
+
+/--
+* `#simp => e` runs `simp` on the expression `e` and displays the resulting expression after
+  simplification.
+* `#simp only [lems] => e` runs `simp only [lems]` on `e`.
+* The `=>` is optional, so `#simp e` and `#simp only [lems] e` have the same behavior.
+  It is mostly useful for disambiguating the expression `e` from the lemmas.
+-/
+syntax "#simp" (&" only")? (simpArgs)? " =>"? ppSpace term : command
+macro_rules
+  | `(#simp%$tk $[only%$o]? $[[$args,*]]? $[=>]? $e) =>
+    `(#conv%$tk simp $[only%$o]? $[[$args,*]]? => $e)

--- a/Mathlib/Tactic/PushNeg.lean
+++ b/Mathlib/Tactic/PushNeg.lean
@@ -8,6 +8,7 @@ import Lean
 import Mathlib.Lean.Expr
 import Mathlib.Logic.Basic
 import Mathlib.Init.Algebra.Order
+import Mathlib.Tactic.Conv
 
 namespace Mathlib.Tactic.PushNeg
 
@@ -83,30 +84,63 @@ partial def transformNegation (e : Expr) : SimpM Simp.Step := do
       let Simp.Step.visit r₂ ← transformNegation r₁.expr | return Simp.Step.visit r₁
       return Simp.Step.visit (← Simp.mkEqTrans r₁ r₂)
 
-/-- Execute main loop of `push_neg` at the main goal. -/
-def pushNegTarget : TacticM Unit := withMainContext do
+/-- Common entry point to `push_neg` as a conv. -/
+def pushNegCore (tgt : Expr) : MetaM Simp.Result := do
   let myctx : Simp.Context :=
     { config := { eta := true },
       simpTheorems := #[ ]
       congrTheorems := (← getSimpCongrTheorems) }
+  (·.1) <$> Simp.main tgt myctx (methods := { pre := transformNegation })
+
+/--
+Push negations into the conclusion of an expression.
+For instance, an expression `¬ ∀ x, ∃ y, x ≤ y` will be transformed by `push_neg` into
+`∃ x, ∀ y, y < x`. Variable names are conserved.
+This tactic pushes negations inside expressions. For instance, given a hypothesis
+```lean
+| ¬ ∀ ε > 0, ∃ δ > 0, ∀ x, |x - x₀| ≤ δ → |f x - y₀| ≤ ε)
+```
+writing `push_neg` will turn the target into
+```lean
+| ∃ ε, ε > 0 ∧ ∀ δ, δ > 0 → (∃ x, |x - x₀| ≤ δ ∧ ε < |f x - y₀|),
+```
+(The pretty printer does *not* use the abreviations `∀ δ > 0` and `∃ ε > 0` but this issue
+has nothing to do with `push_neg`).
+
+Note that names are conserved by this tactic, contrary to what would happen with `simp`
+using the relevant lemmas.
+
+This tactic has two modes: in standard mode, it transforms `¬(p ∧ q)` into `p → ¬q`, whereas in
+distrib mode it produces `¬p ∨ ¬q`. To use distrib mode, use `set_option push_neg.use_distrib true`.
+-/
+syntax (name := pushNegConv) "push_neg" : conv
+
+/-- Execute `push_neg` as a conv tactic. -/
+@[tactic pushNegConv] def elabPushNegConv : Tactic := fun _ => withMainContext do
+  Conv.applySimpResult (← pushNegCore (← instantiateMVars (← Conv.getLhs)))
+
+/--
+The syntax is `#push_neg e`, where `e` is an expression,
+which will print the `push_neg` form of `e`.
+
+`#push_neg` understands local variables, so you can use them to introduce parameters.
+-/
+macro (name := pushNeg) tk:"#push_neg " e:term : command => `(command| #conv%$tk push_neg => $e)
+
+/-- Execute main loop of `push_neg` at the main goal. -/
+def pushNegTarget : TacticM Unit := withMainContext do
   let goal ← getMainGoal
   let tgt ← instantiateMVars (← goal.getType)
-  let (myres, _) ← Simp.main tgt myctx (methods := { pre := transformNegation })
-  replaceMainGoal [← applySimpResultToTarget goal tgt myres]
+  replaceMainGoal [← applySimpResultToTarget goal tgt (← pushNegCore tgt)]
 
 /-- Execute main loop of `push_neg` at a local hypothesis. -/
 def pushNegLocalDecl (fvarId : FVarId): TacticM Unit := withMainContext do
   let ldecl ← fvarId.getDecl
   if ldecl.isAuxDecl then return
-  let tgt := (← fvarId.getDecl).type
-  let tgt ← instantiateMVars tgt
-  let myctx : Simp.Context :=
-    { config := { eta := true },
-      simpTheorems := #[ ]
-      congrTheorems := (← getSimpCongrTheorems) }
+  let tgt ← instantiateMVars ldecl.type
   let goal ← getMainGoal
-  let (myres, _) ← Simp.main tgt myctx (methods := { pre := transformNegation })
-  let some ⟨_, newGoal⟩ ← applySimpResultToLocalDecl goal fvarId myres False | throwError "fail"
+  let myres ← pushNegCore tgt
+  let some (_, newGoal) ← applySimpResultToLocalDecl goal fvarId myres False | failure
   replaceMainGoal [newGoal]
 
 /--
@@ -132,12 +166,9 @@ using say `push_neg at h h' ⊢` as usual.
 This tactic has two modes: in standard mode, it transforms `¬(p ∧ q)` into `p → ¬q`, whereas in
 distrib mode it produces `¬p ∨ ¬q`. To use distrib mode, use `set_option push_neg.use_distrib true`.
 -/
-elab "push_neg " loc:(ppSpace location)? : tactic =>
-  match loc with
-  | none => pushNegTarget
-  | some loc =>
-      let loc := expandLocation loc
-      withLocation loc
-        pushNegLocalDecl
-        pushNegTarget
-        (fun _ => logInfo "push_neg couldn't find a negation to push")
+elab "push_neg" loc:(ppSpace location)? : tactic =>
+  let loc := (loc.map expandLocation).getD (.targets #[] true)
+  withLocation loc
+    pushNegLocalDecl
+    pushNegTarget
+    (fun _ => logInfo "push_neg couldn't find a negation to push")


### PR DESCRIPTION
The command `#conv $tac => $e` will run a conv tactic `tac` on `e` and display the resulting simplified version of `e'`. This is used to implement several other user commands:

* `#whnf e` displays the weak head normal form of `e`
* `#simp e` displays the simp normal form of `e`
* `#norm_num e` evaluates `e` using `norm_num`
* `#push_neg e` shows the result of `push_neg` on `e`

The `conv` versions of `norm_num` and `push_neg` are also added here, so that the commands can be implemented as macros.