### PR TITLE
[Merged by Bors] - feat: `classical` tactic

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -103,6 +103,7 @@ import Mathlib.Tactic.Cache
 import Mathlib.Tactic.Cases
 import Mathlib.Tactic.CasesM
 import Mathlib.Tactic.Choose
+import Mathlib.Tactic.Classical
 import Mathlib.Tactic.Clear!
 import Mathlib.Tactic.ClearExcept
 import Mathlib.Tactic.Clear_

--- a/Mathlib/Mathport/Syntax.lean
+++ b/Mathlib/Mathport/Syntax.lean
@@ -41,6 +41,8 @@ import Mathlib.Tactic.PermuteGoals
 import Mathlib.Tactic.PushNeg
 import Mathlib.Tactic.Recover
 import Mathlib.Tactic.Relation.Rfl
+import Mathlib.Tactic.Relation.Symm
+import Mathlib.Tactic.Relation.Trans
 import Mathlib.Tactic.Rename
 import Mathlib.Tactic.RenameBVar
 import Mathlib.Tactic.Replace
@@ -210,8 +212,6 @@ namespace Tactic
 /- S -/ syntax "destruct " term : tactic
 /- N -/ syntax (name := abstract) "abstract" (ppSpace ident)? ppSpace tacticSeq : tactic
 
-/- E -/ syntax (name := symm) "symm" : tactic
-/- E -/ syntax (name := trans) "trans" (ppSpace colGt term)? : tactic
 /- B -/ syntax (name := cc) "cc" : tactic
 
 /- M -/ syntax (name := unfoldProjs) "unfold_projs" (config)? (ppSpace location)? : tactic
@@ -230,8 +230,6 @@ namespace Tactic
 /- E -/ syntax (name := rfl') "rfl'" : tactic
 /- E -/ syntax (name := symm') "symm'" (ppSpace location)? : tactic
 /- E -/ syntax (name := trans') "trans'" (ppSpace term)? : tactic
-
-/- E -/ syntax (name := classical) "classical" : tactic
 
 /- M -/ syntax (name := injectionsAndClear) "injections_and_clear" : tactic
 

--- a/Mathlib/Tactic/Basic.lean
+++ b/Mathlib/Tactic/Basic.lean
@@ -33,9 +33,6 @@ resulting in two subgoals `h : p ⊢` and `h : ¬ p ⊢`.
 macro "by_cases " e:term : tactic =>
   `(tactic| by_cases $(mkIdent `h) : $e)
 
-macro (name := classical!) "classical!" : tactic =>
-  `(tactic| have em := Classical.propDecidable)
-
 syntax "transitivity" (colGt term)? : tactic
 set_option hygiene false in
 macro_rules

--- a/Mathlib/Tactic/Classical.lean
+++ b/Mathlib/Tactic/Classical.lean
@@ -1,0 +1,49 @@
+/-
+Copyright (c) 2021 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro
+-/
+import Lean.Elab.ElabRules
+
+/-! # `classical` and `classical!` tactics -/
+
+namespace Mathlib.Tactic
+open Lean Meta
+
+/--
+`classical!` adds a proof of `Classical.propDecidable` as a local variable, which makes it
+available for instance search and effectively makes all propositions decidable.
+```
+noncomputable def foo : Bool := by
+  classical!
+  have := ∀ p, decide p -- uses the classical instance
+  exact decide (0 < 1) -- uses the classical instance even though `0 < 1` is decidable
+```
+Consider using `classical` instead if you want to use the decidable instance when available.
+-/
+macro (name := classical!) "classical!" : tactic =>
+  `(tactic| have em := Classical.propDecidable)
+
+/--
+`classical tacs` runs `tacs` in a scope where `Classical.propDecidable` is a low priority
+local instance. It differs from `classical!` in that `classical!` uses a local variable,
+which has high priority:
+```
+noncomputable def foo : Bool := by
+  classical!
+  have := ∀ p, decide p -- uses the classical instance
+  exact decide (0 < 1) -- uses the classical instance even though `0 < 1` is decidable
+
+def bar : Bool := by
+  classical
+  have := ∀ p, decide p -- uses the classical instance
+  exact decide (0 < 1) -- uses the decidable instance
+```
+Note that (unlike lean 3) `classical` is a scoping tactic - it adds the instance only within the
+scope of the tactic.
+-/
+elab "classical" tacs:tacticSeq : tactic => do
+  modifyEnv Meta.instanceExtension.pushScope
+  Meta.addInstance ``Classical.propDecidable .local 10
+  try Elab.Tactic.evalTactic tacs
+  finally modifyEnv Meta.instanceExtension.popScope

--- a/test/classical.lean
+++ b/test/classical.lean
@@ -1,4 +1,5 @@
 import Mathlib.Tactic.Classical
+import Mathlib.Tactic.PermuteGoals
 import Std.Tactic.GuardExpr
 
 noncomputable def foo : Bool := by
@@ -19,4 +20,13 @@ def bar : Bool := by
 -- double check no leakage
 def bar' : Bool := by
   fail_if_success have := ∀ p, decide p -- no classical in scope
+  exact decide (0 < 1) -- uses the decidable instance
+  
+-- check that classical respects tactic blocks
+def bar'' : Bool := by
+  fail_if_success have := ∀ p, decide p -- no classical in scope
+  on_goal 1 =>
+    classical
+    have := ∀ p, decide p -- uses the classical instance
+  fail_if_success have := ∀ p, decide p -- no classical in scope again
   exact decide (0 < 1) -- uses the decidable instance

--- a/test/classical.lean
+++ b/test/classical.lean
@@ -1,0 +1,22 @@
+import Mathlib.Tactic.Classical
+import Std.Tactic.GuardExpr
+
+noncomputable def foo : Bool := by
+  fail_if_success have := ∀ p, decide p -- no classical in scope
+  classical!
+  have := ∀ p, decide p -- uses the classical instance
+  -- uses the classical instance even though `0 < 1` is decidable
+  guard_expr decide (0 < 1) = @decide (0 < 1) (‹(a : Prop) → Decidable a› _)
+  exact decide (0 < 1)
+
+def bar : Bool := by
+  fail_if_success have := ∀ p, decide p -- no classical in scope
+  classical
+  have := ∀ p, decide p -- uses the classical instance
+  guard_expr decide (0 < 1) = @decide (0 < 1) (Nat.decLt 0 1)
+  exact decide (0 < 1) -- uses the decidable instance
+
+-- double check no leakage
+def bar' : Bool := by
+  fail_if_success have := ∀ p, decide p -- no classical in scope
+  exact decide (0 < 1) -- uses the decidable instance


### PR DESCRIPTION
Note that `classical` had to be turned into a scoping tactic, because AFAIK there isn't a way to perform additional actions at the end of elaboration. In lean 3 this wasn't a problem since the environment is rolled back after a `theorem` is elaborated, but in lean 4 you can add global definitions during elaboration of a theorem so something has to clean up afterward.