### PR TITLE
[Merged by Bors] - feat: port `onFun` and `combine` notations in Init.Logic

### DIFF
--- a/Mathlib/Init/Function.lean
+++ b/Mathlib/Init/Function.lean
@@ -23,9 +23,13 @@ variable {α : Sort u₁} {β : Sort u₂} {φ : Sort u₃} {δ : Sort u₄} {ζ
 /-- Given functions `f : β → β → φ` and `g : α → β`, produce a function `α → α → φ` that evaluates
 `g` on each argument, then applies `f` to the results. Can be used, e.g., to transfer a relation
 from `β` to `α`. -/
-@[reducible] def on_fun (f : β → β → φ) (g : α → β) : α → α → φ :=
+@[reducible] def onFun (f : β → β → φ) (g : α → β) : α → α → φ :=
 λ x y => f (g x) (g y)
 
+/-- Given functions `f : α → β → φ`, `g : α → β → δ` and a binary operator `op : φ → δ → ζ`,
+produce a function `α → β → ζ` that applies `f` and `g` on each argument and then applies
+`op` to the results.
+-/
 @[reducible] def combine (f : α → β → φ) (op : φ → δ → ζ) (g : α → β → δ)
   : α → β → ζ :=
 λ x y => op (f x y) (g x y)
@@ -35,6 +39,12 @@ from `β` to `α`. -/
 
 @[reducible] def app {β : α → Sort u₂} (f : ∀ x, β x) (x : α) : β x :=
 f x
+
+@[inherit_doc onFun]
+infixl:2 " on " => onFun
+
+@[inherit_doc combine]
+notation f " -[" op "]- " g => combine f op g
 
 theorem left_id (f : α → β) : id ∘ f = f := rfl
 
@@ -57,7 +67,7 @@ theorem Injective.comp {g : β → φ} {f : α → β} (hg : Injective g) (hf : 
   Injective (g ∘ f) :=
 fun _ _ h => hf (hg h)
 
-/-- A function `f : α → β` is calles surjective if every `b : β` is equal to `f a`
+/-- A function `f : α → β` is called surjective if every `b : β` is equal to `f a`
 for some `a : α`. -/
 @[reducible] def Surjective (f : α → β) : Prop := ∀ b, ∃ a, f a = b
 

--- a/scripts/nolints.json
+++ b/scripts/nolints.json
@@ -150,7 +150,6 @@
  ["docBlame", "Fin.subUnderflows?"],
  ["docBlame", "Fin.underflowingSub"],
  ["docBlame", "Function.app"],
- ["docBlame", "Function.combine"],
  ["docBlame", "Function.comp_left"],
  ["docBlame", "Function.comp_right"],
  ["docBlame", "Function.swap"],


### PR DESCRIPTION
* Adds two notation declarations that present in [lean 3](https://github.com/leanprover-community/lean/blob/fc13c8c72a15dab71a2c2b31410c2cadc3526bd7/library/init/function.lean#L55-L56) and [Lean3port](https://github.com/leanprover-community/lean3port/blob/ae7ce5b9527a8b90ea052208fc8d9f670725420c/Leanbin/Init/Function.lean#L61-L65) but not yet in mathlib4. The `onFun` notation is needed in Logic/Relation. I'm not sure whether the `combine` notation is ever actually used, but we should include it for consistency.
* Updates the name of `on_fun` to `onFun`, to match the naming conventions in the mathport output.
* Adds a docstring to `combine` to satisfy the linter.
* Fixes a typo in another docstring: "calles"` -> "called".