### PR TITLE
[Merged by Bors] - feat: port Init.Data.Prod

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -69,6 +69,7 @@ import Mathlib.Init.Data.Int.Notation
 import Mathlib.Init.Data.Int.Order
 import Mathlib.Init.Data.Nat.Basic
 import Mathlib.Init.Data.Nat.Lemmas
+import Mathlib.Init.Data.Prod
 import Mathlib.Init.Function
 import Mathlib.Init.Logic
 import Mathlib.Init.Propext

--- a/Mathlib/Data/Prod.lean
+++ b/Mathlib/Data/Prod.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl
 -/
 import Std.Tactic.Ext
+import Mathlib.Init.Data.Prod
 import Mathlib.Init.Function
 import Mathlib.Logic.Basic
 import Mathlib.Logic.Function.Basic
@@ -74,10 +75,6 @@ fun _ _ h => (Prod.mk.inj h).right
 lemma mk.inj_right {α β : Type _} (b : β) :
   Function.Injective (λ a => Prod.mk a b : α → α × β) :=
 fun _ _ h => (Prod.mk.inj h).left
-
--- Port note: this lemma comes from lean3/library/init/data/prod.lean.
-@[simp] lemma mk.eta : ∀{p : α × β}, (p.1, p.2) = p
-| (_, _) => rfl
 
 lemma ext_iff {p q : α × β} : p = q ↔ p.1 = q.1 ∧ p.2 = q.2 :=
 by rw [← @mk.eta _ _ p, ← @mk.eta _ _ q, mk.inj_iff]

--- a/Mathlib/Init/Core.lean
+++ b/Mathlib/Init/Core.lean
@@ -30,6 +30,7 @@ import Std.Classes.SetNotation
 #align quot.ind Quot.ind
 
 #align heq HEq
+#align prod Prod
 #align pprod PProd
 
 #align and.left And.left

--- a/Mathlib/Init/Data/Prod.lean
+++ b/Mathlib/Init/Data/Prod.lean
@@ -3,7 +3,6 @@ Copyright (c) 2014 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura, Jeremy Avigad
 -/
-prelude
 import Mathlib.Init.Logic
 
 /-! ### alignments from lean 3 `init.data.prod` -/

--- a/Mathlib/Init/Data/Prod.lean
+++ b/Mathlib/Init/Data/Prod.lean
@@ -1,10 +1,12 @@
 /-
 Copyright (c) 2014 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Leonardo de Moura, Jeremy Avigad
+Authors: Leonardo de Moura, Jeremy Avigad
 -/
 prelude
 import Mathlib.Init.Logic
+
+/-! ### alignments from lean 3 `init.data.prod` -/
 
 universe u v
 

--- a/Mathlib/Init/Data/Prod.lean
+++ b/Mathlib/Init/Data/Prod.lean
@@ -1,0 +1,19 @@
+/-
+Copyright (c) 2014 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Leonardo de Moura, Jeremy Avigad
+-/
+prelude
+import Mathlib.Init.Logic
+
+universe u v
+
+section
+
+variable {α : Type u} {β : Type v}
+
+@[simp]
+theorem Prod.mk.eta : ∀ {p : α × β}, (p.1, p.2) = p
+  | (_, _) => rfl
+
+end


### PR DESCRIPTION
add `#align prod Prod` to Init.Data.Core

should the align be in Init.Data.Prod instead?