### PR TITLE
feat: Support `prelude` as a valid import line for style linter

### DIFF
--- a/scripts/lint-style.py
+++ b/scripts/lint-style.py
@@ -204,7 +204,7 @@ def regular_check(lines, path):
         if copy_done and line == "\n":
             continue
         words = line.split()
-        if words[0] != "import" and words[0] != "/-!":
+        if words != ["prelude"] and words[0] != "import" and words[0] != "/-!":
             errors += [(ERR_MOD, line_nr, path)]
             break
         if words[0] == "/-!":


### PR DESCRIPTION
Without this, a file that contains with
```
prelude
import Mathlib.Init.Logic

/-! ### alignments from lean 3 `init.data.prod` -/
```
would make the Module docstring linter upset