### PR TITLE
[Merged by Bors] - feat: `norm_num` addition on `AddMonoidWithOne`

### DIFF
--- a/Mathlib/Tactic/NormNum/Basic.lean
+++ b/Mathlib/Tactic/NormNum/Basic.lean
@@ -38,28 +38,29 @@ partial def _root_.Lean.Expr.numeral? (e : Expr) : Option ℕ :=
 namespace Meta.NormNum
 open Qq
 
-theorem isNat_zero (α) [Semiring α] : IsNat (Zero.zero : α) (nat_lit 0) := ⟨Nat.cast_zero.symm⟩
+theorem isNat_zero (α) [AddMonoidWithOne α] : IsNat (Zero.zero : α) (nat_lit 0) :=
+  ⟨Nat.cast_zero.symm⟩
 
 /-- The `norm_num` extension which identifies the expression `Zero.zero`, returning `0`. -/
 @[norm_num Zero.zero] def evalZero : NormNumExt where eval {u α} e := do
-  let sα ← inferSemiring α
+  let sα ← inferAddMonoidWithOne α
   match e with
   | ~q(Zero.zero) => return (.isNat sα (mkRawNatLit 0) q(isNat_zero $α) : Result q(Zero.zero))
 
-theorem isNat_one (α) [Semiring α] : IsNat (One.one : α) (nat_lit 1) := ⟨Nat.cast_one.symm⟩
+theorem isNat_one (α) [AddMonoidWithOne α] : IsNat (One.one : α) (nat_lit 1) := ⟨Nat.cast_one.symm⟩
 
 /-- The `norm_num` extension which identifies the expression `One.one`, returning `1`. -/
 @[norm_num One.one] def evalOne : NormNumExt where eval {u α} e := do
-  let sα ← inferSemiring α
+  let sα ← inferAddMonoidWithOne α
   match e with
   | ~q(One.one) => return (.isNat sα (mkRawNatLit 1) q(isNat_one $α) : Result q(One.one))
 
-theorem isNat_ofNat (α : Type u_1) [Semiring α] (n : ℕ) [OfNat α n]
+theorem isNat_ofNat (α : Type u_1) [AddMonoidWithOne α] (n : ℕ) [OfNat α n]
   [LawfulOfNat α n] : IsNat (OfNat.ofNat n : α) n := ⟨LawfulOfNat.eq_ofNat.symm⟩
 
 /-- The `norm_num` extension which identifies an expression `OfNat.ofNat n`, returning `n`. -/
 @[norm_num OfNat.ofNat _] def evalOfNat : NormNumExt where eval {u α} e := do
-  let sα ← inferSemiring α
+  let sα ← inferAddMonoidWithOne α
   match e with
   | ~q(@OfNat.ofNat _ $n $oα) =>
     let n : Q(ℕ) ← whnf n
@@ -68,15 +69,15 @@ theorem isNat_ofNat (α : Type u_1) [Semiring α] (n : ℕ) [OfNat α n]
     _ ← synthInstanceQ (q(LawfulOfNat $α $n) : Q(Prop))
     return (.isNat sα n q(isNat_ofNat $α $n) : Result q((OfNat.ofNat $n : $α)))
 
-theorem isNat_cast {R} [Semiring R] (n m : ℕ) :
+theorem isNat_cast {R} [AddMonoidWithOne R] (n m : ℕ) :
     IsNat n m → IsNat (n : R) m := by rintro ⟨⟨⟩⟩; exact ⟨rfl⟩
 
 /-- The `norm_num` extension which identifies an expression `Nat.cast n`, returning `n`. -/
 @[norm_num Nat.cast _] def evalNatCast : NormNumExt where eval {u α} e := do
-  let sα ← inferSemiring α
+  let sα ← inferAddMonoidWithOne α
   match e with
   | ~q(Nat.cast $a) =>
-    let ⟨na, pa⟩ ← deriveNat a q(instSemiringNat)
+    let ⟨na, pa⟩ ← deriveNat a q(instAddMonoidWithOneNat)
     let pa : Q(IsNat $a $na) := pa
     return (.isNat sα na q(@isNat_cast $α _ $a $na $pa) : Result q((Nat.cast $a : $α)))
 
@@ -93,15 +94,15 @@ theorem isInt_cast {R} [Ring R] (n m : ℤ) :
   | ~q(Int.cast $a) =>
     match ← derive (α := q(ℤ)) a with
     | .isNat _ na pa =>
-      let sα : Q(Semiring $α) := q(Ring.toSemiring)
-      let pa : Q(@IsNat _ Ring.toSemiring $a $na) := pa
+      let sα : Q(AddMonoidWithOne $α) := q(instAddMonoidWithOne)
+      let pa : Q(@IsNat _ instAddMonoidWithOne $a $na) := pa
       return (.isNat sα na q(@isNat_int_cast $α _ $a $na $pa) : Result q((Int.cast $a : $α)))
     | .isNegNat _ na pa =>
       let pa : Q(@IsInt _ instRingInt $a (.negOfNat $na)) := pa
       return (.isNegNat rα na q(isInt_cast $a (.negOfNat $na) $pa) : Result q((Int.cast $a : $α)))
     | _ => failure
 
-theorem isNat_add {α} [Semiring α] : {a b : α} → {a' b' c : ℕ} →
+theorem isNat_add {α} [AddMonoidWithOne α] : {a b : α} → {a' b' c : ℕ} →
     IsNat a a' → IsNat b b' → Nat.add a' b' = c → IsNat (a + b) c
   | _, _, _, _, _, ⟨rfl⟩, ⟨rfl⟩, rfl => ⟨Nat.cast_add.symm⟩
 
@@ -189,12 +190,9 @@ theorem isInt_mul {α} [Ring α] : {a b : α} → {a' b' c : ℤ} →
 such that `norm_num` successfully recognises both `a` and `b`. -/
 @[norm_num _ * _, Mul.mul _ _] def evalMul : NormNumExt where eval {u α} e := do
   let .app (.app f (a : Q($α))) (b : Q($α)) ← withReducible (whnf e) | failure
+  let sα ← inferSemiring α
   let ra ← derive a; let rb ← derive b
-  match ra, rb with
-  | .isNat _ .., .isNat _ .. | .isNat _ .., .isNegNat _ ..
-  | .isNegNat _ .., .isNat _ .. | .isNegNat _ .., .isNegNat _ .. =>
-    guard <|← withNewMCtxDepth <| isDefEq f q(HMul.hMul (α := $α))
-  | _, _ => failure
+  guard <|← withNewMCtxDepth <| isDefEq f q(HMul.hMul (α := $α))
   let rec
   /-- Main part of `evalMul`. -/
   core : Option (Result e) := do
@@ -203,13 +201,14 @@ such that `norm_num` successfully recognises both `a` and `b`. -/
       let zc := za * zb
       have c := mkRawIntLit zc
       let r : Q(Int.mul $na $nb = $c) := (q(Eq.refl $c) : Expr)
-      return (.isInt rα zc q(isInt_mul $pa $pb $r) : Result q($a * $b))
+      return (.isInt rα zc (z := c) (q(isInt_mul $pa $pb $r) : Expr) : Result q($a * $b))
     match ra, rb with
-    | .isNat _ na pa, .isNat sα nb pb =>
-      have pa : Q(IsNat $a $na) := pa
+    | .isNat _ na pa, .isNat mα nb pb =>
+      let pa : Q(@IsNat _ NonUnitalNonAssocSemiring.toAddMonoidWithOne $a $na) := pa
+      let pb : Q(@IsNat _ NonUnitalNonAssocSemiring.toAddMonoidWithOne $b $nb) := pb
       have c : Q(ℕ) := mkRawNatLit (na.natLit! * nb.natLit!)
       let r : Q(Nat.mul $na $nb = $c) := (q(Eq.refl $c) : Expr)
-      return (.isNat sα c q(isNat_mul $pa $pb $r) : Result q($a * $b))
+      return (.isNat mα c (q(isNat_mul (α := $α) $pa $pb $r) : Expr) : Result q($a * $b))
     | .isNat _ .., .isNegNat rα ..
     | .isNegNat rα .., .isNat _ ..
     | .isNegNat _ .., .isNegNat rα .. => intArm rα
@@ -229,26 +228,25 @@ such that `norm_num` successfully recognises both `a` and `b`, with `b : ℕ`. -
 @[norm_num (_ : α) ^ (_ : ℕ), Pow.pow _ (_ : ℕ)]
 def evalPow : NormNumExt where eval {u α} e := do
   let .app (.app f (a : Q($α))) (b : Q(ℕ)) ← withReducible (whnf e) | failure
-  let ⟨nb, pb⟩ ← deriveNat b q(instSemiringNat)
+  let ⟨nb, pb⟩ ← deriveNat b q(instAddMonoidWithOneNat)
+  let sα ← inferSemiring α
   let ra ← derive a
-  match ra with
-  | .isNat _ .. | .isNegNat _ .. =>
-    guard <|← withDefault <| withNewMCtxDepth <| isDefEq f q(HPow.hPow (α := $α))
-  | _ => failure
+  guard <|← withDefault <| withNewMCtxDepth <| isDefEq f q(HPow.hPow (α := $α))
   let rec
   /-- Main part of `evalPow`. -/
   core : Option (Result e) := do
     match ra with
     | .isNat sα na pa =>
+      let pa : Q(@IsNat _ NonUnitalNonAssocSemiring.toAddMonoidWithOne $a $na) := pa
       have c : Q(ℕ) := mkRawNatLit (na.natLit! ^ nb.natLit!)
       let r : Q(Nat.pow $na $nb = $c) := (q(Eq.refl $c) : Expr)
       let pb : Q(IsNat $b $nb) := pb
-      return (.isNat sα c q(isNat_pow $pa $pb $r) : Result q($a ^ $b))
+      return (.isNat sα c (q(isNat_pow $pa $pb $r) : Expr) : Result q($a ^ $b))
     | .isNegNat rα .. =>
       let ⟨za, na, pa⟩ ← ra.toInt
       let zc := za ^ nb.natLit!
       let c := mkRawIntLit zc
       let r : Q(Int.pow $na $nb = $c) := (q(Eq.refl $c) : Expr)
-      return (.isInt rα zc (z := c) q(isInt_pow $pa $pb $r) : Result q($a ^ $b))
+      return (.isInt rα zc (z := c) (q(isInt_pow $pa $pb $r) : Expr) : Result q($a ^ $b))
     | _ => failure
   core

--- a/Mathlib/Tactic/NormNum/Core.lean
+++ b/Mathlib/Tactic/NormNum/Core.lean
@@ -28,7 +28,7 @@ namespace Meta.NormNum
 initialize registerTraceClass `Tactic.norm_num
 
 /-- Assert that an element of a semiring is equal to the coercion of some natural number. -/
-structure IsNat [Semiring α] (a : α) (n : ℕ) : Prop where
+structure IsNat [AddMonoidWithOne α] (a : α) (n : ℕ) : Prop where
   /-- The element is equal to the coercion of the natural number. -/
   out : a = n
 
@@ -39,27 +39,27 @@ A "raw nat cast" is an expression of the form `(Nat.rawCast lit : α)` where `li
 natural number literal. These expressions are used by tactics like `ring` to decrease the number
 of typeclass arguments required in each use of a number literal at type `α`.
 -/
-@[simp] def _root_.Nat.rawCast [Semiring α] (n : ℕ) : α := n
+@[simp] def _root_.Nat.rawCast [AddMonoidWithOne α] (n : ℕ) : α := n
 
 /-- Asserting that the `OfNat α n` instance provides the same value as the coercion. -/
-class LawfulOfNat (α) [Semiring α] (n) [OfNat α n] : Prop where
+class LawfulOfNat (α) [AddMonoidWithOne α] (n) [OfNat α n] : Prop where
   /-- Assert `n = (OfNat.ofNat n α)`, with the parametrising instance. -/
   eq_ofNat : n = (@OfNat.ofNat _ n ‹_› : α)
 
-instance (α) [Semiring α] [Nat.AtLeastTwo n] : LawfulOfNat α n := ⟨rfl⟩
-instance (α) [Semiring α] : LawfulOfNat α (nat_lit 0) := ⟨Nat.cast_zero⟩
-instance (α) [Semiring α] : LawfulOfNat α (nat_lit 1) := ⟨Nat.cast_one⟩
+instance (α) [AddMonoidWithOne α] [Nat.AtLeastTwo n] : LawfulOfNat α n := ⟨rfl⟩
+instance (α) [AddMonoidWithOne α] : LawfulOfNat α (nat_lit 0) := ⟨Nat.cast_zero⟩
+instance (α) [AddMonoidWithOne α] : LawfulOfNat α (nat_lit 1) := ⟨Nat.cast_one⟩
 instance : LawfulOfNat ℕ n := ⟨show n = Nat.cast n by simp⟩
 instance : LawfulOfNat ℤ n := ⟨show Int.ofNat n = Nat.cast n by simp⟩
 
-theorem IsNat.to_eq [Semiring α] (n) [OfNat α n] [LawfulOfNat α n] :
+theorem IsNat.to_eq [AddMonoidWithOne α] (n) [OfNat α n] [LawfulOfNat α n] :
     (a : α) → IsNat a n → a = OfNat.ofNat n
   | _, ⟨rfl⟩ => LawfulOfNat.eq_ofNat
 
-theorem IsNat.to_raw_eq [Semiring α] : IsNat (a : α) n → a = n.rawCast
+theorem IsNat.to_raw_eq [AddMonoidWithOne α] : IsNat (a : α) n → a = n.rawCast
   | ⟨e⟩ => e
 
-theorem IsNat.of_raw (α) [Semiring α] (n : ℕ) : IsNat (n.rawCast : α) n := ⟨rfl⟩
+theorem IsNat.of_raw (α) [AddMonoidWithOne α] (n : ℕ) : IsNat (n.rawCast : α) n := ⟨rfl⟩
 
 /-- Assert that an element of a ring is equal to the coercion of some integer. -/
 structure IsInt [Ring α] (a : α) (n : ℤ) : Prop where
@@ -101,8 +101,8 @@ def mkRawIntLit (n : ℤ) : Q(ℤ) :=
   let lit : Q(ℕ) := mkRawNatLit n.natAbs
   if 0 ≤ n then q(.ofNat $lit) else q(.negOfNat $lit)
 
-/-- A shortcut (non)instance for `Semiring ℕ` to shrink generated proofs. -/
-def instSemiringNat : Semiring ℕ := inferInstance
+/-- A shortcut (non)instance for `AddMonoidWithOne ℕ` to shrink generated proofs. -/
+def instAddMonoidWithOneNat : AddMonoidWithOne ℕ := inferInstance
 
 /-- A shortcut (non)instance for `Ring ℤ` to shrink generated proofs. -/
 def instRingInt : Ring ℤ := inferInstance
@@ -154,7 +154,7 @@ instance : Inhabited (Result x) := inferInstanceAs (Inhabited Result')
 
 /-- The result is `lit : ℕ` (a raw nat literal) and `proof : isNat x lit`. -/
 @[match_pattern, inline] def Result.isNat {α : Q(Type u)} {x : Q($α)} :
-    ∀ (inst : Q(Semiring $α) := by assumption) (lit : Q(ℕ)) (proof : Q(IsNat $x $lit)),
+    ∀ (inst : Q(AddMonoidWithOne $α) := by assumption) (lit : Q(ℕ)) (proof : Q(IsNat $x $lit)),
       Result x := Result'.isNat
 
 /-- The result is `-lit` where `lit` is a raw nat literal
@@ -170,6 +170,9 @@ and `q` is the value of `n / d`. -/
     ∀ (inst : Q(Ring $α) := by assumption) (q : Rat) (n : Q(ℤ)) (d : Q(ℕ))
       (proof : Q(IsRat $x $n $d)), Result x := Result'.isRat
 
+/-- A shortcut (non)instance for `AddMonoidWithOne α` from `Ring α` to shrink generated proofs. -/
+def instAddMonoidWithOne [Ring α] : AddMonoidWithOne α := inferInstance
+
 /-- The result is `z : ℤ` and `proof : isNat x z`. -/
 -- Note the independent arguments `z : Q(ℤ)` and `n : ℤ`.
 -- We ensure these are "the same" when calling.
@@ -178,11 +181,16 @@ def Result.isInt {α : Q(Type u)} {x : Q($α)} {z : Q(ℤ)}
   have lit : Q(ℕ) := z.appArg!
   if 0 ≤ n then
     let proof : Q(IsInt $x (.ofNat $lit)) := proof
-    .isNat q(Ring.toSemiring) lit q(IsInt.to_isNat $proof)
+    .isNat q(instAddMonoidWithOne) lit q(IsInt.to_isNat $proof)
   else
     .isNegNat inst lit proof
 
 end
+
+/-- Helper functor to synthesize a typed `AddMonoidWithOne α` expression. -/
+def inferAddMonoidWithOne (α : Q(Type u)) : MetaM Q(AddMonoidWithOne $α) :=
+  return ← synthInstanceQ (q(AddMonoidWithOne $α) : Q(Type u)) <|>
+    throwError "not a AddMonoidWithOne"
 
 /-- Helper functor to synthesize a typed `Semiring α` expression. -/
 def inferSemiring (α : Q(Type u)) : MetaM Q(Semiring $α) :=
@@ -199,7 +207,7 @@ and the proof that the original expression is equal to this integer.
 def Result.toInt {α : Q(Type u)} {e : Q($α)} (_i : Q(Ring $α) := by with_reducible assumption) :
     Result e → Option (ℤ × (lit : Q(ℤ)) × Q(IsInt $e $lit))
   | .isNat _ lit proof => do
-    have proof : Q(@IsNat _ Ring.toSemiring $e $lit) := proof
+    have proof : Q(@IsNat _ instAddMonoidWithOne $e $lit) := proof
     pure ⟨lit.natLit!, q(.ofNat $lit), q(($proof).to_isInt)⟩
   | .isNegNat _ lit proof => pure ⟨-lit.natLit!, q(.negOfNat $lit), proof⟩
   | _ => failure
@@ -222,7 +230,7 @@ def Result.toRawEq {α : Q(Type u)} {e : Q($α)} : Result e → (ℤ × (e' : Q(
 
 /-- Constructs a `Result` out of a raw nat cast. Assumes `e` is a raw nat cast expression. -/
 def Result.ofRawNat {α : Q(Type u)} (e : Q($α)) : Result e := Id.run do
-  let .app (.app _ (sα : Q(Semiring $α))) (lit : Q(ℕ)) := e | panic! "not a raw nat cast"
+  let .app (.app _ (sα : Q(AddMonoidWithOne $α))) (lit : Q(ℕ)) := e | panic! "not a raw nat cast"
   .isNat sα lit (q(IsNat.of_raw $α $lit) : Expr)
 
 /-- Constructs a `Result` out of a raw int cast.
@@ -287,7 +295,8 @@ initialize normNumExt : PersistentEnvExtension Entry (Entry × NormNumExt)
 def derive {α : Q(Type u)} (e : Q($α)) (post := false) : MetaM (Result e) := do
   if e.isNatLit then
     let lit : Q(ℕ) := e
-    return .isNat (q(instSemiringNat) : Q(Semiring ℕ)) lit (q(IsNat.raw_refl $lit) : Expr)
+    return .isNat (q(instAddMonoidWithOneNat) : Q(AddMonoidWithOne ℕ))
+      lit (q(IsNat.raw_refl $lit) : Expr)
   let s ← saveState
   let arr ← (normNumExt.getState (← getEnv)).2.getMatch e
   for ext in arr do
@@ -304,14 +313,14 @@ def derive {α : Q(Type u)} (e : Q($α)) (post := false) : MetaM (Result e) := d
 /-- Run each registered `norm_num` extension on a typed expression `e : α`,
 returning a typed expression `lit : ℕ`, and a proof of `isNat e lit`. -/
 def deriveNat' {α : Q(Type u)} (e : Q($α)) :
-    MetaM ((_inst : Q(Semiring $α)) × (lit : Q(ℕ)) × Q(IsNat $e $lit)) := do
+    MetaM ((_inst : Q(AddMonoidWithOne $α)) × (lit : Q(ℕ)) × Q(IsNat $e $lit)) := do
   let .isNat inst lit proof ← derive e | failure
   pure ⟨inst, lit, proof⟩
 
 /-- Run each registered `norm_num` extension on a typed expression `e : α`,
 returning a typed expression `lit : ℕ`, and a proof of `isNat e lit`. -/
 def deriveNat {α : Q(Type u)} (e : Q($α))
-    (_inst : Q(Semiring $α) := by with_reducible assumption) :
+    (_inst : Q(AddMonoidWithOne $α) := by with_reducible assumption) :
     MetaM ((lit : Q(ℕ)) × Q(IsNat $e $lit)) := do
   let .isNat _ lit proof ← derive e | failure
   pure ⟨lit, proof⟩

--- a/Mathlib/Tactic/Ring.lean
+++ b/Mathlib/Tactic/Ring.lean
@@ -397,7 +397,8 @@ partial def evalMulProd (va : ExProd sα a) (vb : ExProd sα b) : Result (ExProd
       ⟨a, .const za, (q(mul_one $a) : Expr)⟩
     else
       let ra := Result.ofRawInt za a; let rb := Result.ofRawInt zb b
-      let ⟨zc, c, pc⟩ := (NormNum.evalMul.core q($a * $b) _ _ ra rb).get!.toRawEq
+      let ⟨zc, c, pc⟩ :=
+        (NormNum.evalMul.core q($a * $b) _ _ q(CommSemiring.toSemiring) ra rb).get!.toRawEq
       ⟨c, .const zc, pc⟩
   | .mul (x := a₁) (e := a₂) va₁ va₂ va₃, .const _ =>
     let ⟨_, vc, pc⟩ := evalMulProd va₃ vb
@@ -552,7 +553,7 @@ def evalNegProd (rα : Q(Ring $α)) (va : ExProd sα a) : Result (ExProd sα) q(
     let rm := Result.isNegNat rα lit (q(IsInt.of_raw $α (.negOfNat $lit)) : Expr)
     let ra := Result.ofRawInt za a
     let ⟨zb, b, (pb : Q((Int.negOfNat (nat_lit 1)).rawCast * $a = $b))⟩ :=
-      (NormNum.evalMul.core q($m1 * $a) _ _ rm ra).get!.toRawEq
+      (NormNum.evalMul.core q($m1 * $a) _ _ q(CommSemiring.toSemiring) rm ra).get!.toRawEq
     ⟨b, .const zb, (q(neg_one_mul (R := $α) $pb) : Expr)⟩
   | .mul (x := a₁) (e := a₂) va₁ va₂ va₃ =>
     let ⟨_, vb, pb⟩ := evalNegProd rα va₃
@@ -721,7 +722,8 @@ def evalPowProd (va : ExProd sα a) (vb : ExProd sℕ b) : Result (ExProd sα) q
       let ra := Result.ofRawInt za a
       have lit : Q(ℕ) := b.appArg!
       let rb := (q(IsNat.of_raw ℕ $lit) : Expr)
-      let ⟨zc, c, pc⟩ := (← NormNum.evalPow.core q($a ^ $b) _ b lit rb ra).toRawEq
+      let ⟨zc, c, pc⟩ :=
+        (← NormNum.evalPow.core q($a ^ $b) _ b lit rb q(CommSemiring.toSemiring) ra).toRawEq
       some ⟨c, .const zc, pc⟩
     | .mul vxa₁ vea₁ va₂, vb => do
       let ⟨_, vc₁, pc₁⟩ := evalMulProd sℕ vea₁ vb

--- a/test/norm_num.lean
+++ b/test/norm_num.lean
@@ -102,11 +102,14 @@ example : 10 - 5 * 5 + (7 - 3) * 6 = 27 - 3 := by norm_num
 def foo : ℕ := 1
 
 example : foo = 1 := by norm_num
+section
+  variable (α : Type u) [AddMonoidWithOne α]
+  example : (1 + 0 : α) = (0 + 1 : α) := by norm_num
+  example : (0 + (2 + 3) + 1 : α) = 6 := by norm_num
+end
 
 section
   variable (α : Type u) [Semiring α]
-  example : (1 + 0 : α) = (0 + 1 : α) := by norm_num
-  example : (0 + (2 + 3) + 1 : α) = 6 := by norm_num
   example : (70 * (33 + 2) : α) = 2450 := by norm_num
   example : (8 + 2 ^ 2 * 3 : α) = 20 := by norm_num
   example : ((2 * 1 + 1) ^ 2 : α) = (3 * 3 : α) := by norm_num


### PR DESCRIPTION
As [requested on Zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/norm_num.20for.20non-semirings/near/308145432).