### PR TITLE
[Merged by Bors] - feat: `ring` conv tactic

### DIFF
--- a/Mathlib/Mathport/Syntax.lean
+++ b/Mathlib/Mathport/Syntax.lean
@@ -454,12 +454,6 @@ namespace Conv
 -- https://github.com/leanprover-community/mathlib/issues/2882
 /- M -/ syntax (name := applyCongr) "apply_congr" (ppSpace (colGt term))? : conv
 
-/- E -/ syntax (name := ring) "ring" : conv
-/- E -/ syntax (name := ring!) "ring!" : conv
-
-/- E -/ syntax (name := ringExp) "ring_exp" : conv
-/- E -/ syntax (name := ringExp!) "ring_exp!" : conv
-
 /- M -/ syntax (name := slice) "slice " num num : conv
 
 end Conv

--- a/Mathlib/Tactic/Ring/RingNF.lean
+++ b/Mathlib/Tactic/Ring/RingNF.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Tim Baanen
 -/
 import Mathlib.Tactic.Ring.Basic
+import Mathlib.Tactic.Conv
 
 /-!
 # `ring_nf` tactic
@@ -197,3 +198,14 @@ macro (name := ring) "ring" : tactic =>
   `(tactic| first | ring1 | ring_nf; trace "Try this: ring_nf")
 @[inherit_doc ring] macro "ring!" : tactic =>
   `(tactic| first | ring1! | ring_nf!; trace "Try this: ring_nf!")
+
+/--
+The tactic `ring` evaluates expressions in *commutative* (semi)rings.
+This is the conv tactic version, which rewrites a target which is a ring equality to `True`.
+
+See also the `ring` tactic.
+-/
+macro (name := ringConv) "ring" : conv =>
+  `(conv| first | discharge => ring1 | ring_nf; tactic => trace "Try this: ring_nf")
+@[inherit_doc ringConv] macro "ring!" : conv =>
+  `(conv| first | discharge => ring1! | ring_nf!; tactic => trace "Try this: ring_nf!")

--- a/test/ring.lean
+++ b/test/ring.lean
@@ -67,3 +67,24 @@ example (f : ℕ → ℕ) :
 example (n : ℕ) (m : ℤ) : 2^(n+1) * m = 2 * 2^n * m := by ring
 example (a b : ℤ) (n : ℕ) : (a + b)^(n + 2) = (a^2 + b^2 + a * b + b * a) * (a + b)^n := by ring
 example (x y : ℕ) : x + id y = y + id x := by ring!
+
+-- Example with ring discharging the goal
+example : 22 + 7 * 4 + 3 * 8 = 0 + 7 * 4 + 46 := by
+  conv => ring
+  trivial -- FIXME: not needed in lean 3
+
+-- Example with ring failing to discharge, to normalizing the goal
+example : (22 + 7 * 4 + 3 * 8 = 0 + 7 * 4 + 47) = (74 = 75) := by
+  conv => ring
+  trivial
+
+-- Example with ring discharging the goal
+example (x : ℕ) : 22 + 7 * x + 3 * 8 = 0 + 7 * x + 46 := by
+  conv => ring
+  trivial
+
+-- Example with ring failing to discharge, to normalizing the goal
+example (x : ℕ) : (22 + 7 * x + 3 * 8 = 0 + 7 * x + 46 + 1)
+                    = (7 * x + 46 = 7 * x + 47) := by
+  conv => ring
+  trivial


### PR DESCRIPTION
* [x] depends on #539
* [x] depends on #552

This implements the `ring` conv tactic, which rewrites a target that is an equality in rings to `True`. I'm not sure if anyone uses this, but it is what it is and it brings down our metrics.