### PR TITLE
[Merged by Bors] - feat: port Algebra.NeZero

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -9,6 +9,7 @@ import Mathlib.Algebra.GroupPower.Basic
 import Mathlib.Algebra.GroupPower.Identities
 import Mathlib.Algebra.GroupPower.Lemmas
 import Mathlib.Algebra.GroupWithZero.Defs
+import Mathlib.Algebra.NeZero
 import Mathlib.Algebra.Order.Group
 import Mathlib.Algebra.Order.Monoid
 import Mathlib.Algebra.Order.MonoidLemmas

--- a/Mathlib/Algebra/NeZero.lean
+++ b/Mathlib/Algebra/NeZero.lean
@@ -1,0 +1,50 @@
+/-
+Copyright (c) 2021 Eric Rodriguez. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Eric Rodriguez
+-/
+
+import Mathlib.Logic.Basic
+import Mathlib.Init.ZeroOne
+import Mathlib.Init.Algebra.Order
+
+/-!
+# `ne_zero` typeclass
+We create a typeclass `ne_zero n` which carries around the fact that `(n : R) ≠ 0`.
+## Main declarations
+* `ne_zero`: `n ≠ 0` as a typeclass.
+-/
+
+/-- A type-class version of `n ≠ 0`.  -/
+class NeZero {R} [Zero R] (n : R) : Prop where
+  out : n ≠ 0
+
+theorem NeZero.ne {R} [Zero R] (n : R) [h : NeZero n] : n ≠ 0 :=
+  h.out
+
+theorem ne_zero_iff {R : Type _} [Zero R] {n : R} : NeZero n ↔ n ≠ 0 :=
+  ⟨fun h => h.out, NeZero.mk⟩
+
+theorem not_ne_zero {R : Type _} [Zero R] {n : R} : ¬NeZero n ↔ n = 0 := by simp [ne_zero_iff]
+
+theorem eq_zero_or_ne_zero {α} [Zero α] (a : α) : a = 0 ∨ NeZero a :=
+  (eq_or_ne a 0).imp_right NeZero.mk
+
+namespace NeZero
+
+variable {R S M F : Type _} {r : R} {x y : M} {n p : Nat}
+
+--{a : ℕ+}
+instance succ : NeZero (n + 1) :=
+  ⟨n.succ_ne_zero⟩
+
+theorem of_pos [Preorder M] [Zero M] (h : 0 < x) : NeZero x :=
+  ⟨ne_of_gt h⟩
+
+instance coe_trans [Zero M] [Coe R S] [CoeTC S M] [h : NeZero (r : M)] : NeZero ((r : S) : M) :=
+  ⟨h.out⟩
+
+theorem trans [Zero M] [Coe R S] [CoeTC S M] (h : NeZero ((r : S) : M)) : NeZero (r : M) :=
+  ⟨h.out⟩
+
+end NeZero

--- a/Mathlib/Algebra/NeZero.lean
+++ b/Mathlib/Algebra/NeZero.lean
@@ -9,10 +9,13 @@ import Mathlib.Init.ZeroOne
 import Mathlib.Init.Algebra.Order
 
 /-!
-# `ne_zero` typeclass
+# `NeZero` typeclass
+
 We create a typeclass `ne_zero n` which carries around the fact that `(n : R) ≠ 0`.
+
 ## Main declarations
-* `ne_zero`: `n ≠ 0` as a typeclass.
+
+* `NeZero`: `n ≠ 0` as a typeclass.
 -/
 
 /-- A type-class version of `n ≠ 0`.  -/
@@ -41,10 +44,10 @@ instance succ : NeZero (n + 1) :=
 theorem of_pos [Preorder M] [Zero M] (h : 0 < x) : NeZero x :=
   ⟨ne_of_gt h⟩
 
-instance coe_trans [Zero M] [Coe R S] [CoeTC S M] [h : NeZero (r : M)] : NeZero ((r : S) : M) :=
+instance coe_trans [Zero M] [Coe R S] [CoeTail S M] [h : NeZero (r : M)] : NeZero ((r : S) : M) :=
   ⟨h.out⟩
 
-theorem trans [Zero M] [Coe R S] [CoeTC S M] (h : NeZero ((r : S) : M)) : NeZero (r : M) :=
+theorem trans [Zero M] [Coe R S] [CoeTail S M] (h : NeZero ((r : S) : M)) : NeZero (r : M) :=
   ⟨h.out⟩
 
 end NeZero

--- a/Mathlib/Algebra/NeZero.lean
+++ b/Mathlib/Algebra/NeZero.lean
@@ -26,13 +26,16 @@ class NeZero {R} [Zero R] (n : R) : Prop where
 theorem NeZero.ne {R} [Zero R] (n : R) [h : NeZero n] : n ≠ 0 :=
   h.out
 
-theorem ne_zero_iff {R : Type _} [Zero R] {n : R} : NeZero n ↔ n ≠ 0 :=
+theorem neZero_iff {R : Type _} [Zero R] {n : R} : NeZero n ↔ n ≠ 0 :=
   ⟨fun h => h.out, NeZero.mk⟩
+#align ne_zero_iff neZero_iff
 
-theorem not_ne_zero {R : Type _} [Zero R] {n : R} : ¬NeZero n ↔ n = 0 := by simp [ne_zero_iff]
+theorem not_neZero {R : Type _} [Zero R] {n : R} : ¬NeZero n ↔ n = 0 := by simp [neZero_iff]
+#align not_ne_zero not_neZero
 
-theorem eq_zero_or_ne_zero {α} [Zero α] (a : α) : a = 0 ∨ NeZero a :=
+theorem eq_zero_or_neZero {α} [Zero α] (a : α) : a = 0 ∨ NeZero a :=
   (eq_or_ne a 0).imp_right NeZero.mk
+#align eq_zero_or_ne_zero eq_zero_or_neZero
 
 namespace NeZero
 

--- a/Mathlib/Algebra/NeZero.lean
+++ b/Mathlib/Algebra/NeZero.lean
@@ -20,6 +20,7 @@ We create a typeclass `ne_zero n` which carries around the fact that `(n : R) �
 
 /-- A type-class version of `n ≠ 0`.  -/
 class NeZero {R} [Zero R] (n : R) : Prop where
+  /-- The proposition that `n` is not zero. -/
   out : n ≠ 0
 
 theorem NeZero.ne {R} [Zero R] (n : R) [h : NeZero n] : n ≠ 0 :=

--- a/Mathlib/Algebra/NeZero.lean
+++ b/Mathlib/Algebra/NeZero.lean
@@ -11,7 +11,7 @@ import Mathlib.Init.Algebra.Order
 /-!
 # `NeZero` typeclass
 
-We create a typeclass `ne_zero n` which carries around the fact that `(n : R) ≠ 0`.
+We create a typeclass `NeZero n` which carries around the fact that `(n : R) ≠ 0`.
 
 ## Main declarations
 
@@ -36,12 +36,10 @@ theorem eq_zero_or_ne_zero {α} [Zero α] (a : α) : a = 0 ∨ NeZero a :=
 
 namespace NeZero
 
-variable {R S M F : Type _} {r : R} {x y : M} {n p : Nat}
+variable {M : Type _} {x : M}
 
-instance succ : NeZero (n + 1) :=
-  ⟨n.succ_ne_zero⟩
+instance succ : NeZero (n + 1) := ⟨n.succ_ne_zero⟩
 
-theorem of_pos [Preorder M] [Zero M] (h : 0 < x) : NeZero x :=
-  ⟨ne_of_gt h⟩
+theorem of_pos [Preorder M] [Zero M] (h : 0 < x) : NeZero x := ⟨ne_of_gt h⟩
 
 end NeZero

--- a/Mathlib/Algebra/NeZero.lean
+++ b/Mathlib/Algebra/NeZero.lean
@@ -38,17 +38,10 @@ namespace NeZero
 
 variable {R S M F : Type _} {r : R} {x y : M} {n p : Nat}
 
---{a : ℕ+}
 instance succ : NeZero (n + 1) :=
   ⟨n.succ_ne_zero⟩
 
 theorem of_pos [Preorder M] [Zero M] (h : 0 < x) : NeZero x :=
   ⟨ne_of_gt h⟩
-
-instance coe_trans [Zero M] [Coe R S] [CoeTail S M] [h : NeZero (r : M)] : NeZero ((r : S) : M) :=
-  ⟨h.out⟩
-
-theorem trans [Zero M] [Coe R S] [CoeTail S M] (h : NeZero ((r : S) : M)) : NeZero (r : M) :=
-  ⟨h.out⟩
 
 end NeZero


### PR DESCRIPTION
The lemmas `coe_trans` and `trans` were removed (see [zulip discussion](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/mathlib4.23557/near/308688583)).