### PR TITLE
[Merged by Bors] - fix: make `clear!` delete class instances

### DIFF
--- a/Mathlib/Tactic/Clear!.lean
+++ b/Mathlib/Tactic/Clear!.lean
@@ -15,10 +15,4 @@ open Lean Meta Elab.Tactic
 elab (name := clear!) "clear!" hs:(ppSpace colGt ident)* : tactic => do
   let fvarIds ← getFVarIds hs
   liftMetaTactic1 fun goal => do
-    let mut toClear : Array FVarId := #[]
-    let lctx ← getLCtx
-    for fvar in fvarIds do
-      let deps := (← collectForwardDeps #[mkFVar fvar] true).map (·.fvarId!)
-      if ← deps.allM fun dep => return (← isClass? (lctx.get! dep).type).isNone then
-        toClear := toClear ++ deps
-    goal.tryClearMany toClear
+    goal.tryClearMany <| (← collectForwardDeps (fvarIds.map .fvar) true).map (·.fvarId!)

--- a/test/Clear!.lean
+++ b/test/Clear!.lean
@@ -6,10 +6,11 @@ example (delete_this : Nat) (delete_this_dep : delete_this = delete_this) : Nat 
   fail_if_success assumption
   exact 0
 
--- Confirms clear! does not delete class instances
-example [dont_delete_this : Inhabited Nat] : Inhabited Nat := by
-  clear! dont_delete_this
-  assumption
+-- Confirms clear! deletes class instances
+example [delete_this : Inhabited Nat] : Inhabited Nat := by
+  clear! delete_this
+  fail_if_success assumption
+  infer_instance
 
 -- Confirms clear! can clear the dependencies of multiple hypotheses
 example (delete_this : Nat) (delete_this2 : Nat) (delete_this_dep : delete_this = delete_this2) : Nat := by


### PR DESCRIPTION
Although this was part of the original implementation, this behavior is actually undesirable for one of the main use cases of `clear!`, which is to remove a local class instance which is messing up typeclass inference, since it will just silently do nothing even if you say specifically to remove the instance (and everything that depends on it).

If we need to recover the old behavior, I suggest adding it under a flag.