### PR TITLE
[Merged by Bors] - chore: update std4 11-13

### DIFF
--- a/Mathlib/Algebra/Group/Basic.lean
+++ b/Mathlib/Algebra/Group/Basic.lean
@@ -497,7 +497,7 @@ theorem mul_div_cancel'' (a b : G) : a * b / b = a :=
 
 @[simp, to_additive]
 theorem mul_div_mul_right_eq_div (a b c : G) : a * c / (b * c) = a / b := by
-  rw [div_mul_eq_div_div_swap] <;> simp only [mul_left_inj, eq_self_iff_true, mul_div_cancel'']
+  rw [div_mul_eq_div_div_swap]; simp only [mul_left_inj, eq_self_iff_true, mul_div_cancel'']
 
 @[to_additive eq_sub_of_add_eq]
 theorem eq_div_of_mul_eq' (h : a * c = b) : a = b / c := by simp [← h]
@@ -633,8 +633,8 @@ theorem div_eq_iff_eq_mul' : a / b = c ↔ a = b * c := by rw [div_eq_iff_eq_mul
 theorem mul_div_cancel''' (a b : G) : a * b / a = b := by rw [div_eq_inv_mul, inv_mul_cancel_left]
 
 @[simp, to_additive]
-theorem mul_div_cancel'_right (a b : G) : a * (b / a) = b :=
-  by rw [← mul_div_assoc, mul_div_cancel''']
+theorem mul_div_cancel'_right (a b : G) : a * (b / a) = b := by
+  rw [← mul_div_assoc, mul_div_cancel''']
 
 @[simp, to_additive sub_add_cancel']
 theorem div_mul_cancel'' (a b : G) : a / (a * b) = b⁻¹ := by rw [← inv_div, mul_div_cancel''']
@@ -643,24 +643,24 @@ theorem div_mul_cancel'' (a b : G) : a / (a * b) = b⁻¹ := by rw [← inv_div,
 -- along with the additive version `add_neg_cancel_comm_assoc`,
 -- defined  in `algebra/group/commute`
 @[to_additive]
-theorem mul_mul_inv_cancel'_right (a b : G) : a * (b * a⁻¹) = b :=
-  by rw [← div_eq_mul_inv, mul_div_cancel'_right a b]
+theorem mul_mul_inv_cancel'_right (a b : G) : a * (b * a⁻¹) = b := by
+  rw [← div_eq_mul_inv, mul_div_cancel'_right a b]
 
 @[simp, to_additive]
-theorem mul_mul_div_cancel (a b c : G) : a * c * (b / c) = a * b :=
-  by rw [mul_assoc, mul_div_cancel'_right]
+theorem mul_mul_div_cancel (a b c : G) : a * c * (b / c) = a * b := by
+  rw [mul_assoc, mul_div_cancel'_right]
 
 @[simp, to_additive]
-theorem div_mul_mul_cancel (a b c : G) : a / c * (b * c) = a * b :=
-  by rw [mul_left_comm, div_mul_cancel', mul_comm]
+theorem div_mul_mul_cancel (a b c : G) : a / c * (b * c) = a * b := by
+  rw [mul_left_comm, div_mul_cancel', mul_comm]
 
 @[simp, to_additive sub_add_sub_cancel']
-theorem div_mul_div_cancel'' (a b c : G) : a / b * (c / a) = c / b :=
-  by rw [mul_comm] <;> apply div_mul_div_cancel'
+theorem div_mul_div_cancel'' (a b c : G) : a / b * (c / a) = c / b := by
+  rw [mul_comm]; apply div_mul_div_cancel'
 
 @[simp, to_additive]
-theorem mul_div_div_cancel (a b c : G) : a * b / (a / c) = b * c :=
-  by rw [← div_mul, mul_div_cancel''']
+theorem mul_div_div_cancel (a b c : G) : a * b / (a / c) = b * c := by
+  rw [← div_mul, mul_div_cancel''']
 
 @[simp, to_additive]
 theorem div_div_div_cancel_left (a b c : G) : c / a / (c / b) = b / a := by

--- a/Mathlib/Algebra/Ring/Basic.lean
+++ b/Mathlib/Algebra/Ring/Basic.lean
@@ -60,7 +60,7 @@ lemma Nat.cast_pow [Semiring R] {m n : ℕ} : (m ^ n).cast = (m.cast ^ n : R) :=
 theorem Nat.cast_commute [Semiring α] (n : ℕ) (x : α) : Commute (↑n) x := by
   induction n with
   | zero => rw [Nat.cast_zero]; exact Commute.zero_left x
-  | succ n ihn => rw [Nat.cast_succ] <;> exact ihn.add_left (Commute.one_left x)
+  | succ n ihn => rw [Nat.cast_succ]; exact ihn.add_left (Commute.one_left x)
 
 end Semiring
 

--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -28,7 +28,7 @@ lemma Fin.size_positive' [Nonempty (Fin n)] : 0 < n :=
 
 @[simp]
 protected theorem Fin.eta (a : Fin n) (h : (a : ℕ) < n) : (⟨(a : ℕ), h⟩ : Fin n) = a := by
-  cases a <;> rfl
+  cases a; rfl
 
 lemma zero_lt_of_lt {a : Nat} : ∀ {x : Nat}, x < a -> 0 < a
 | 0, h   => h

--- a/Mathlib/Data/FunLike/Basic.lean
+++ b/Mathlib/Data/FunLike/Basic.lean
@@ -157,7 +157,7 @@ theorem coe_injective : Function.Injective (fun f : F => (f : ∀ a : α, β a))
 
 @[simp]
 theorem coe_fn_eq {f g : F} : (f : ∀ a : α, β a) = (g : ∀ a : α, β a) ↔ f = g :=
-  ⟨fun h => FunLike.coe_injective' h, fun h => by cases h <;> rfl⟩
+  ⟨fun h => FunLike.coe_injective' h, fun h => by cases h; rfl⟩
 
 theorem ext' {f g : F} (h : (f : ∀ a : α, β a) = (g : ∀ a : α, β a)) : f = g :=
   FunLike.coe_injective' h

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -250,10 +250,10 @@ theorem pmap_map {p : β → Prop} (g : ∀ b, p b → γ) (f : α → β) (l H)
 
 theorem pmap_eq_map_attach {p : α → Prop} (f : ∀ a, p a → β) (l H) :
     pmap f l H = l.attach.map fun x => f x.1 (H _ x.2) := by
-  rw [attach, map_pmap] <;> exact pmap_congr l fun _ _ _ _ => rfl
+  rw [attach, map_pmap]; exact pmap_congr l fun _ _ _ _ => rfl
 
 theorem attach_map_val (l : List α) : l.attach.map Subtype.val = l := by
-  rw [attach, map_pmap] <;> exact (pmap_eq_map _ _ _ _).trans (map_id l)
+  rw [attach, map_pmap]; exact (pmap_eq_map ..).trans (map_id l)
 
 @[simp]
 theorem mem_attach (l : List α) : ∀ x, x ∈ l.attach

--- a/Mathlib/Data/List/Pairwise.lean
+++ b/Mathlib/Data/List/Pairwise.lean
@@ -17,7 +17,7 @@ theorem pairwise_append_comm (s : Symmetric R) {l₁ l₂ : List α} :
     Pairwise R (l₁ ++ l₂) ↔ Pairwise R (l₂ ++ l₁) := by
   have : ∀ l₁ l₂ : List α, (∀ x : α, x ∈ l₁ → ∀ y : α, y ∈ l₂ → R x y) →
     ∀ x : α, x ∈ l₂ → ∀ y : α, y ∈ l₁ → R x y := fun l₁ l₂ a x xm y ym => s (a y ym x xm)
-  simp only [pairwise_append, and_left_comm] <;> rw [Iff.intro (this l₁ l₂) (this l₂ l₁)]
+  simp only [pairwise_append, and_left_comm]; rw [Iff.intro (this l₁ l₂) (this l₂ l₁)]
 
 theorem pairwise_middle (s : Symmetric R) {a : α} {l₁ l₂ : List α} :
     Pairwise R (l₁ ++ a :: l₂) ↔ Pairwise R (a :: (l₁ ++ l₂)) :=

--- a/Mathlib/Data/List/Range.lean
+++ b/Mathlib/Data/List/Range.lean
@@ -32,8 +32,7 @@ theorem mem_range' {m : ℕ} : ∀ {s n : ℕ}, m ∈ range' s n ↔ s ≤ m ∧
     have l : m = s ∨ s + 1 ≤ m ↔ s ≤ m := by
       simpa only [eq_comm] using (@Decidable.le_iff_eq_or_lt _ _ _ s m).symm
     mem_cons.trans <| by
-      simp only [mem_range', or_and_left, or_iff_right_of_imp this, l, Nat.add_right_comm]
-        <;> rfl
+      simp only [mem_range', or_and_left, or_iff_right_of_imp this, l, Nat.add_right_comm]; rfl
 
 theorem rangeAux_range' : ∀ s n : ℕ, rangeAux s (range' s n) = range' 0 (n + s)
   | 0, n => rfl

--- a/Mathlib/Data/Option/Basic.lean
+++ b/Mathlib/Data/Option/Basic.lean
@@ -273,7 +273,7 @@ theorem getD_default_eq_iget [Inhabited α] (o : Option α) :
 @[simp]
 theorem guard_eq_some' {p : Prop} [Decidable p] (u) : _root_.guard p = some u ↔ p := by
   cases u
-  by_cases p <;> simp [_root_.guard, h] <;> first |rfl|contradiction
+  by_cases p <;> simp [_root_.guard, h]
 
 theorem liftOrGet_choice {f : α → α → α} (h : ∀ a b, f a b = a ∨ f a b = b) :
     ∀ o₁ o₂, liftOrGet f o₁ o₂ = o₁ ∨ liftOrGet f o₁ o₂ = o₂

--- a/Mathlib/Data/Prod/Basic.lean
+++ b/Mathlib/Data/Prod/Basic.lean
@@ -180,7 +180,7 @@ theorem Lex_def (r : α → α → Prop) (s : β → β → Prop) {p q : α × �
   ⟨fun h => by cases h <;> simp [*], fun h =>
     match p, q, h with
     | (a, b), (c, d), Or.inl h => Lex.left _ _ h
-    | (a, b), (c, d), Or.inr ⟨e, h⟩ => by subst e <;> exact Lex.right _ h⟩
+    | (a, b), (c, d), Or.inr ⟨e, h⟩ => by subst e; exact Lex.right _ h⟩
 
 instance Lex.decidable [DecidableEq α]
     (r : α → α → Prop) (s : β → β → Prop) [DecidableRel r] [DecidableRel s] :

--- a/Mathlib/Init/CcLemmas.lean
+++ b/Mathlib/Init/CcLemmas.lean
@@ -49,16 +49,16 @@ theorem or_eq_of_eq {a b : Prop} (h : a = b) : (a ∨ b) = a :=
   h ▸ propext or_self_iff
 
 theorem imp_eq_of_eq_true_left {a b : Prop} (h : a = True) : (a → b) = b :=
-  h.symm ▸ propext (Iff.intro (fun h => h trivial) fun h₁ _ => h₁)
+  h.symm ▸ propext ⟨fun h => h trivial, fun h₁ _ => h₁⟩
 
 theorem imp_eq_of_eq_true_right {a b : Prop} (h : b = True) : (a → b) = True :=
-  h.symm ▸ propext (Iff.intro (fun h => trivial) fun h₁ _ => h₁)
+  h.symm ▸ propext ⟨fun _ => trivial, fun h₁ _ => h₁⟩
 
 theorem imp_eq_of_eq_false_left {a b : Prop} (h : a = False) : (a → b) = True :=
-  h.symm ▸ propext (Iff.intro (fun h => trivial) fun _ h₂ => False.elim h₂)
+  h.symm ▸ propext ⟨fun _ => trivial, fun _ h₂ => False.elim h₂⟩
 
 theorem imp_eq_of_eq_false_right {a b : Prop} (h : b = False) : (a → b) = Not a :=
-  h.symm ▸ propext (Iff.intro (fun h => h) fun hna ha => hna ha)
+  h.symm ▸ propext ⟨fun h => h, fun hna ha => hna ha⟩
 
 /- Remark: the congruence closure module will only use the following lemma is
    cc_config.em is tt. -/
@@ -67,7 +67,7 @@ theorem not_imp_eq_of_eq_false_right {a b : Prop} (h : b = False) : (Not a → b
     fun h' => Classical.byContradiction fun hna => h' hna) fun ha hna => hna ha)
 
 theorem imp_eq_true_of_eq {a b : Prop} (h : a = b) : (a → b) = True :=
-  h ▸ propext (Iff.intro (fun _ => trivial) fun _ ha => ha)
+  h ▸ propext ⟨fun _ => trivial, fun _ ha => ha⟩
 
 theorem not_eq_of_eq_true {a : Prop} (h : a = True) : Not a = False :=
   h.symm ▸ propext not_true

--- a/Mathlib/Init/Core.lean
+++ b/Mathlib/Init/Core.lean
@@ -107,9 +107,11 @@ attribute [simp] insert_emptyc_eq
 
 @[deprecated] def Std.Priority.default : Nat := 1000
 @[deprecated] def Std.Priority.max : Nat := 4294967295
+set_option linter.deprecated false in
 @[deprecated] protected def Nat.prio := Std.Priority.default + 100
 @[deprecated] def Std.Prec.max : Nat := 1024
 @[deprecated] def Std.Prec.arrow : Nat := 25
+set_option linter.deprecated false in
 @[deprecated] def Std.Prec.maxPlus : Nat := Std.Prec.max + 10
 
 #align has_sizeof SizeOf

--- a/Mathlib/Init/Data/Nat/Lemmas.lean
+++ b/Mathlib/Init/Data/Nat/Lemmas.lean
@@ -143,8 +143,7 @@ end find
 lemma to_digits_core_lens_eq_aux (b f : Nat) :
   ∀ (n : Nat) (l1 l2 : List Char), l1.length = l2.length →
     (Nat.toDigitsCore b f n l1).length = (Nat.toDigitsCore b f n l2).length := by
-  induction f with
-    simp only [Nat.toDigitsCore, List.length] <;> intro n l1 l2 hlen
+  induction f with (simp only [Nat.toDigitsCore, List.length]; intro n l1 l2 hlen)
   | zero => assumption
   | succ f ih =>
     by_cases hx : n / b = 0
@@ -157,8 +156,7 @@ lemma to_digits_core_lens_eq_aux (b f : Nat) :
 
 lemma to_digits_core_lens_eq (b f : Nat) : ∀ (n : Nat) (c : Char) (tl : List Char),
     (Nat.toDigitsCore b f n (c :: tl)).length = (Nat.toDigitsCore b f n tl).length + 1 := by
-  induction f with
-    intro n c tl <;> simp only [Nat.toDigitsCore, List.length]
+  induction f with (intro n c tl; simp only [Nat.toDigitsCore, List.length])
   | succ f ih =>
     by_cases hnb : (n / b) = 0
     case pos => simp only [hnb, if_true, List.length]

--- a/Mathlib/Init/ZeroOne.lean
+++ b/Mathlib/Init/ZeroOne.lean
@@ -33,4 +33,5 @@ instance One.ofOfNat1 {α} [OfNat α (nat_lit 1)] : One α where
 
 @[deprecated, match_pattern] def bit0 {α : Type u} [Add α] (a : α) : α := a + a
 
+set_option linter.deprecated false in
 @[deprecated, match_pattern] def bit1 {α : Type u} [One α] [Add α] (a : α) : α := bit0 a + 1

--- a/Mathlib/Logic/Basic.lean
+++ b/Mathlib/Logic/Basic.lean
@@ -498,10 +498,10 @@ theorem heq_of_cast_eq : ∀ (e : α = β) (_ : cast e a = a'), HEq a a'
   | rfl, h => Eq.recOn h (HEq.refl _)
 
 theorem cast_eq_iff_heq : cast e a = a' ↔ HEq a a' :=
-  ⟨heq_of_cast_eq _, fun h => by cases h <;> rfl⟩
+  ⟨heq_of_cast_eq _, fun h => by cases h; rfl⟩
 
 theorem rec_heq_of_heq {C : α → Sort _} {x : C a} {y : β} (e : a = b) (h : HEq x y) :
-    HEq (@Eq.ndrec α a C x b e) y := by subst e <;> exact h
+    HEq (@Eq.ndrec α a C x b e) y := by subst e; exact h
 
 protected theorem Eq.congr (h₁ : x₁ = y₁) (h₂ : x₂ = y₂) : x₁ = x₂ ↔ y₁ = y₂ := by
   subst h₁; subst h₂; rfl

--- a/Mathlib/Logic/Nontrivial.lean
+++ b/Mathlib/Logic/Nontrivial.lean
@@ -45,7 +45,7 @@ protected theorem Decidable.exists_ne [Nontrivial α] [DecidableEq α] (x : α) 
 
 
 theorem exists_ne [Nontrivial α] (x : α) : ∃ y, y ≠ x := by
-  letI := Classical.decEq α <;> exact Decidable.exists_ne x
+  letI := Classical.decEq α; exact Decidable.exists_ne x
 
 -- `x` and `y` are explicit here, as they are often needed to guide typechecking of `h`.
 theorem nontrivial_of_ne (x y : α) (h : x ≠ y) : Nontrivial α :=

--- a/Mathlib/Logic/Unique.lean
+++ b/Mathlib/Logic/Unique.lean
@@ -149,7 +149,7 @@ end
 
 @[ext]
 protected theorem subsingleton_unique' : ∀ h₁ h₂ : Unique α, h₁ = h₂
-  | ⟨⟨x⟩, h⟩, ⟨⟨y⟩, _⟩ => by congr <;> rw [h x, h y]
+  | ⟨⟨x⟩, h⟩, ⟨⟨y⟩, _⟩ => by congr; rw [h x, h y]
 
 instance subsingleton_unique : Subsingleton (Unique α) :=
   ⟨Unique.subsingleton_unique'⟩

--- a/Mathlib/Tactic/Abel.lean
+++ b/Mathlib/Tactic/Abel.lean
@@ -13,6 +13,9 @@ Evaluate expressions in the language of additive, commutative monoids and groups
 
 -/
 
+-- FIXME: remove this when the sorries are gone
+set_option warningAsError false
+
 open Lean Elab Meta Tactic
 open Qq
 

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -5,7 +5,8 @@ open Lake DSL
 package mathlib
 
 @[default_target]
-lean_lib Mathlib
+lean_lib Mathlib where
+  moreLeanArgs := #["-DwarningAsError=true"]
 
 @[default_target]
 lean_exe runLinter where

--- a/lean_packages/manifest.json
+++ b/lean_packages/manifest.json
@@ -1,7 +1,7 @@
 {"version": 2,
  "packages":
  [{"url": "https://github.com/leanprover/std4",
-   "rev": "54a7731d9dd4738d1fb9a9664b3ac3802d8e3cf2",
+   "rev": "1d2fc0d2ee07110dd0ccfee5015c89d04e5fe86e",
    "name": "std",
    "inputRev": "main"},
   {"url": "https://github.com/gebner/quote4",


### PR DESCRIPTION
The main work is cleaning up all the new linter warnings. Also turns on `warningAsError` globally, which in particular means that `sorry`s will break the build; you have to use `set_option warningAsError false` to locally disable this behavior when needed.