### PR TITLE
[Merged by Bors] - fix: naming convention for `cmp` and `cmpUsing`

### DIFF
--- a/Mathlib/Init/Data/Ordering/Basic.lean
+++ b/Mathlib/Init/Data/Ordering/Basic.lean
@@ -25,14 +25,13 @@ end Ordering
 Lift a decidable relation to an `Ordering`,
 assuming that incomparable terms are `Ordering.eq`.
 -/
-def CmpUsing {α : Type u} (lt : α → α → Prop) [DecidableRel lt] (a b : α) : Ordering :=
+def cmpUsing {α : Type u} (lt : α → α → Prop) [DecidableRel lt] (a b : α) : Ordering :=
   if lt a b then Ordering.lt else if lt b a then Ordering.gt else Ordering.eq
-#align cmp_using CmpUsing
+#align cmp_using cmpUsing
 
 /--
 Construct an `Ordering` from a type with a decidable `LT` instance,
 assuming that incomparable terms are `Ordering.eq`.
 -/
-def Cmp {α : Type u} [LT α] [DecidableRel ((· < ·) : α → α → Prop)] (a b : α) : Ordering :=
-  CmpUsing (· < ·) a b
-#align cmp Cmp
+def cmp {α : Type u} [LT α] [DecidableRel ((· < ·) : α → α → Prop)] (a b : α) : Ordering :=
+  cmpUsing (· < ·) a b


### PR DESCRIPTION
according to
https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/naming.20conventions/near/309189032