### PR TITLE
[Merged by Bors] - feat: add doc strings in alias command

### DIFF
--- a/Mathlib/Tactic/Alias.lean
+++ b/Mathlib/Tactic/Alias.lean
@@ -102,7 +102,8 @@ def appendNamespace (ns : Name) : Name → Name
     Command.liftTermElabM do
       Lean.addDecl decl
       Term.addTermInfo' a (← mkConstWithLevelParams declName) (isBinder := true)
-    -- TODO add doc string
+      if let some docString ← findDocString? (← getEnv) resolved then
+        addDocString declName docString
 | _ => throwUnsupportedSyntax
 
 /--

--- a/Mathlib/Tactic/Alias.lean
+++ b/Mathlib/Tactic/Alias.lean
@@ -73,6 +73,24 @@ def appendNamespace (ns : Name) : Name → Name
 | .num p n          => Name.mkNum (appendNamespace ns p) n
 | .anonymous        => ns
 
+/-- An alias can be in one of three forms -/
+inductive Target
+| plain : Name → Target
+| forward : Name → Target
+| backwards : Name → Target
+
+/-- The name underlying an alias target -/
+def Target.toName : Target → Name
+| Target.plain n => n
+| Target.forward n => n
+| Target.backwards n => n
+
+/-- The docstring for an alias. -/
+def Target.toString : Target → String
+| Target.plain n => f!"**Alias** of `{n}`.".pretty
+| Target.forward n => f!"**Alias** of the forward direction of `{n}`.".pretty
+| Target.backwards n => f!"**Alias** of the reverse direction of `{n}`.".pretty
+
 /-- Elaborates an `alias ←` command. -/
 @[command_elab «alias»] def elabAlias : Command.CommandElab
 | `($[$doc]? alias $name:ident ← $aliases:ident*) => do
@@ -102,8 +120,10 @@ def appendNamespace (ns : Name) : Name → Name
     Command.liftTermElabM do
       Lean.addDecl decl
       Term.addTermInfo' a (← mkConstWithLevelParams declName) (isBinder := true)
-      if let some docString ← findDocString? (← getEnv) resolved then
-        addDocString declName docString
+      let target := Target.plain resolved
+      let docString := match doc with | none => target.toString
+                                      | some d => d.getDocString
+      addDocString declName docString
 | _ => throwUnsupportedSyntax
 
 /--
@@ -121,8 +141,9 @@ def mkIffMpApp (mp : Bool) (prf : Expr) : MetaM Expr := do
   Given a constant representing an iff decl, adds a decl for one of the implication
   directions.
 -/
-def aliasIff (ci : ConstantInfo) (ref : Syntax) (al : Name) (isForward : Bool) :
-    TermElabM Unit := do
+def aliasIff (doc : Option (TSyntax `Lean.Parser.Command.docComment)) (ci : ConstantInfo)
+  (ref : Syntax) (al : Name) (isForward : Bool) :
+  TermElabM Unit := do
   let ls := ci.levelParams
   let v ← mkIffMpApp isForward ci.value!
   let t' ← Meta.inferType v
@@ -138,6 +159,10 @@ def aliasIff (ci : ConstantInfo) (ref : Syntax) (al : Name) (isForward : Bool) :
     levelParams := ls
   }
   Term.addTermInfo' ref (← mkConstWithLevelParams al) (isBinder := true)
+  let target := if isForward then Target.forward ci.name else Target.backwards ci.name
+  let docString := match doc with | none => target.toString
+                                  | some d => d.getDocString
+  addDocString al docString
 
 /-- Elaborates an `alias ↔` command. -/
 @[command_elab aliasLR] def elabAliasLR : Command.CommandElab
@@ -147,9 +172,9 @@ def aliasIff (ci : ConstantInfo) (ref : Syntax) (al : Name) (isForward : Bool) :
   let ns ← getCurrNamespace
   Command.liftTermElabM do
     if let `(binderIdent| $x:ident) := left then
-      aliasIff constant x (appendNamespace ns x.getId) true
+      aliasIff doc constant x (appendNamespace ns x.getId) true
     if let `(binderIdent| $x:ident) := right then
-      aliasIff constant x (appendNamespace ns x.getId) false
+      aliasIff doc constant x (appendNamespace ns x.getId) false
 | _ => throwUnsupportedSyntax
 
 /-- Elaborates an `alias ↔ ..` command. -/
@@ -167,9 +192,8 @@ def aliasIff (ci : ConstantInfo) (ref : Syntax) (al : Name) (isForward : Bool) :
   let forwardName := Name.mkStr parent forward
   let backwardName := Name.mkStr parent backward
   Command.liftTermElabM do
-    aliasIff constant tk forwardName true
-    aliasIff constant tk backwardName false
-  -- TODO add doc string
+    aliasIff doc constant tk forwardName true
+    aliasIff doc constant tk backwardName false
 | _ => throwUnsupportedSyntax
 
 end Alias

--- a/Mathlib/Tactic/Alias.lean
+++ b/Mathlib/Tactic/Alias.lean
@@ -87,9 +87,9 @@ def Target.toName : Target → Name
 
 /-- The docstring for an alias. -/
 def Target.toString : Target → String
-| Target.plain n => f!"**Alias** of `{n}`.".pretty
-| Target.forward n => f!"**Alias** of the forward direction of `{n}`.".pretty
-| Target.backwards n => f!"**Alias** of the reverse direction of `{n}`.".pretty
+| Target.plain n => s!"**Alias** of `{n}`."
+| Target.forward n => s!"**Alias** of the forward direction of `{n}`."
+| Target.backwards n => s!"**Alias** of the reverse direction of `{n}`."
 
 /-- Elaborates an `alias ←` command. -/
 @[command_elab «alias»] def elabAlias : Command.CommandElab

--- a/test/Alias.lean
+++ b/test/Alias.lean
@@ -5,7 +5,10 @@ namespace A
 
 /-- doc string for foo -/
 theorem foo : 1 + 1 = 2 := rfl
+
+/-- doc string for `alias foo` -/
 alias foo ← foo1 foo2 foo3 _root_.B.foo4
+
 example : 1 + 1 = 2 := foo1
 example : 1 + 1 = 2 := foo2
 example : 1 + 1 = 2 := foo3
@@ -33,6 +36,7 @@ alias a_iff_a_and_a ↔ _ backward
 example : True → True ∧ True := forward True
 example : True ∧ True → True := backward True
 
+/-- doc string for `alias a_iff_a_and_a` -/
 alias a_iff_a_and_a ↔ ..
 example : True → True ∧ True := a_and_a_of_a True
 example : True ∧ True → True := a_of_a_and_a True

--- a/test/Alias.lean
+++ b/test/Alias.lean
@@ -3,6 +3,7 @@ import Mathlib
 namespace Alias
 namespace A
 
+/-- doc string for foo -/
 theorem foo : 1 + 1 = 2 := rfl
 alias foo ← foo1 foo2 foo3 _root_.B.foo4
 example : 1 + 1 = 2 := foo1


### PR DESCRIPTION
Follows the mathlib3 version: https://github.com/leanprover-community/mathlib/blob/1158f6d88df46d30c657ffce6bfdb9e9aceb4955/src/tactic/alias.lean#L85