### PR TITLE
[Merged by Bors] - feat: port data.num.basic

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -50,6 +50,7 @@ import Mathlib.Data.List.Range
 import Mathlib.Data.Multiset.Basic
 import Mathlib.Data.Multiset.Nodup
 import Mathlib.Data.Nat.Basic
+import Mathlib.Data.Num.Basic
 import Mathlib.Data.Option.Basic
 import Mathlib.Data.Option.Defs
 import Mathlib.Data.Prod.Basic

--- a/Mathlib/Data/Num/Basic.lean
+++ b/Mathlib/Data/Num/Basic.lean
@@ -332,14 +332,14 @@ namespace ZNum
 open PosNum
 
 /-- The negation of a `ZNum`. -/
-def zneg : ZNum → ZNum
+def zNeg : ZNum → ZNum
   | 0 => 0
   | pos a => neg a
   | neg a => pos a
-#align znum.zneg ZNum.zneg
+#align znum.zneg ZNum.zNeg
 
 instance : Neg ZNum :=
-  ⟨zneg⟩
+  ⟨zNeg⟩
 
 /-- The absolute value of a `ZNum` as a `Num`. -/
 def abs : ZNum → Num
@@ -549,32 +549,32 @@ end ZNum
 
 namespace PosNum
 
-/-- Auxiliary definition for `PosNum.divmod`. -/
-def divmodAux (d : PosNum) (q r : Num) : Num × Num :=
+/-- Auxiliary definition for `PosNum.divMod`. -/
+def divModAux (d : PosNum) (q r : Num) : Num × Num :=
   match Num.ofZNum' (Num.sub' r (Num.pos d)) with
   | some r' => (Num.bit1 q, r')
   | none => (Num.bit0 q, r)
-#align pos_num.divmod_aux PosNum.divmodAux
+#align pos_num.divmod_aux PosNum.divModAux
 
-/-- `divmod x y = (y / x, y % x)`. -/
-def divmod (d : PosNum) : PosNum → Num × Num
+/-- `divMod x y = (y / x, y % x)`. -/
+def divMod (d : PosNum) : PosNum → Num × Num
   | bit0 n =>
-    let (q, r₁) := divmod d n
-    divmodAux d q (Num.bit0 r₁)
+    let (q, r₁) := divMod d n
+    divModAux d q (Num.bit0 r₁)
   | bit1 n =>
-    let (q, r₁) := divmod d n
-    divmodAux d q (Num.bit1 r₁)
-  | 1 => divmodAux d 0 1
-#align pos_num.divmod PosNum.divmod
+    let (q, r₁) := divMod d n
+    divModAux d q (Num.bit1 r₁)
+  | 1 => divModAux d 0 1
+#align pos_num.divmod PosNum.divMod
 
 /-- Division of `PosNum`, -/
 def div' (n d : PosNum) : Num :=
-  (divmod d n).1
+  (divMod d n).1
 #align pos_num.div' PosNum.div'
 
 /-- Modulus of `PosNum`s. -/
 def mod' (n d : PosNum) : Num :=
-  (divmod d n).2
+  (divMod d n).2
 #align pos_num.mod' PosNum.mod'
 
 /-

--- a/Mathlib/Data/Num/Basic.lean
+++ b/Mathlib/Data/Num/Basic.lean
@@ -186,6 +186,7 @@ section
 
 variable {α : Type _} [One α] [Add α]
 
+section deprecated
 set_option linter.deprecated false
 
 /-- `castPosNum` casts a `PosNum` into any type which has `1` and `+`. -/
@@ -211,7 +212,7 @@ set_option linter.deprecated false
   ⟨castNum⟩
 #align num_nat_coe numNatCoe
 
-set_option linter.deprecated true
+end deprecated
 
 instance : Repr PosNum :=
   ⟨fun _ n => repr (n : ℕ)⟩

--- a/Mathlib/Data/Num/Basic.lean
+++ b/Mathlib/Data/Num/Basic.lean
@@ -9,7 +9,7 @@ import Mathlib
 
 Note: Unlike in Coq, where this representation is preferred because of
 the reliance on kernel reduction, in Lean this representation is discouraged
-in favor of the "Peano" natural numbers `nat`, and the purpose of this
+in favor of the "Peano" natural numbers `Nat`, and the purpose of this
 collection of theorems is to show the equivalence of the different approaches.
 -/
 
@@ -21,7 +21,7 @@ inductive PosNum : Type
   | one : PosNum
   | bit1 : PosNum → PosNum
   | bit0 : PosNum → PosNum
-  deriving DecidableEq -- Lean.ToExpr
+  deriving DecidableEq
 #align pos_num PosNum
 
 instance : One PosNum :=
@@ -30,13 +30,13 @@ instance : One PosNum :=
 instance : Inhabited PosNum :=
   ⟨1⟩
 
-/-- The type of nonnegative binary numbers, using `pos_num`.
+/-- The type of nonnegative binary numbers, using `PosNum`.
 
      13 = 1101(base 2) = pos (bit1 (bit0 (bit1 one))) -/
 inductive Num : Type
   | zero : Num
   | pos : PosNum → Num
-  deriving DecidableEq --, has_reflect,
+  deriving DecidableEq
 #align num Num
 #align num.pos Num.pos
 
@@ -53,48 +53,44 @@ instance : Inhabited Num :=
 
      13 = 1101(base 2) = pos (bit1 (bit0 (bit1 one)))
      -13 = -1101(base 2) = neg (bit1 (bit0 (bit1 one))) -/
-inductive Znum : Type
-  | zero : Znum
-  | pos : PosNum → Znum
-  | neg : PosNum → Znum
-  deriving DecidableEq --has_reflect,
-#align znum Znum
-#align znum.pos Znum.pos
+inductive ZNum : Type
+  | zero : ZNum
+  | pos : PosNum → ZNum
+  | neg : PosNum → ZNum
+  deriving DecidableEq
+#align znum ZNum
+#align znum.pos ZNum.pos
 
-instance : Zero Znum :=
-  ⟨Znum.zero⟩
+instance : Zero ZNum :=
+  ⟨ZNum.zero⟩
 
-instance : One Znum :=
-  ⟨Znum.pos 1⟩
+instance : One ZNum :=
+  ⟨ZNum.pos 1⟩
 
-instance : Inhabited Znum :=
+instance : Inhabited ZNum :=
   ⟨0⟩
 
 namespace PosNum
 
-/-- `bit b n` appends the bit `b` to the end of `n`, where `bit tt x = x1` and `bit ff x = x0`.
-  -/
+/-- `bit b n` appends the bit `b` to the end of `n`, where `bit tt x = x1` and `bit ff x = x0`. -/
 def bit (b : Bool) : PosNum → PosNum :=
   cond b bit1 bit0
 #align pos_num.bit PosNum.bit
 
-/-- The successor of a `pos_num`.
-  -/
+/-- The successor of a `PosNum`. -/
 def succ : PosNum → PosNum
   | 1 => bit0 one
   | bit1 n => bit0 (succ n)
   | bit0 n => bit1 n
 #align pos_num.succ PosNum.succ
 
-/-- Returns a boolean for whether the `pos_num` is `one`.
-  -/
+/-- Returns a boolean for whether the `PosNum` is `one`. -/
 def isOne : PosNum → Bool
   | 1 => true
   | _ => false
 #align pos_num.is_one PosNum.isOne
 
-/-- Addition of two `pos_num`s.
-  -/
+/-- Addition of two `PosNum`s. -/
 protected def add : PosNum → PosNum → PosNum
   | 1, b => succ b
   | a, 1 => succ a
@@ -107,38 +103,33 @@ protected def add : PosNum → PosNum → PosNum
 instance : Add PosNum :=
   ⟨PosNum.add⟩
 
-/-- The predecessor of a `pos_num` as a `num`.
-  -/
+/-- The predecessor of a `PosNum` as a `Num`. -/
 def pred' : PosNum → Num
   | 1 => 0
   | bit0 n => Num.pos (Num.casesOn (pred' n) 1 bit1)
   | bit1 n => Num.pos (bit0 n)
 #align pos_num.pred' PosNum.pred'
 
-/-- The predecessor of a `pos_num` as a `pos_num`. This means that `pred 1 = 1`.
-  -/
+/-- The predecessor of a `PosNum` as a `PosNum`. This means that `pred 1 = 1`. -/
 def pred (a : PosNum) : PosNum :=
   Num.casesOn (pred' a) 1 id
 #align pos_num.pred PosNum.pred
 
-/-- The number of bits of a `pos_num`, as a `pos_num`.
-  -/
+/-- The number of bits of a `PosNum`, as a `PosNum`. -/
 def size : PosNum → PosNum
   | 1 => 1
   | bit0 n => succ (size n)
   | bit1 n => succ (size n)
 #align pos_num.size PosNum.size
 
-/-- The number of bits of a `pos_num`, as a `nat`.
-  -/
+/-- The number of bits of a `PosNum`, as a `Nat`. -/
 def natSize : PosNum → Nat
   | 1 => 1
   | bit0 n => Nat.succ (natSize n)
   | bit1 n => Nat.succ (natSize n)
 #align pos_num.nat_size PosNum.natSize
 
-/-- Multiplication of two `pos_num`s.
-  -/
+/-- Multiplication of two `PosNum`s. -/
 protected def mul (a : PosNum) : PosNum → PosNum
   | 1 => a
   | bit0 b => bit0 (PosNum.mul a b)
@@ -148,23 +139,20 @@ protected def mul (a : PosNum) : PosNum → PosNum
 instance : Mul PosNum :=
   ⟨PosNum.mul⟩
 
-/-- `of_nat_succ n` is the `pos_num` corresponding to `n + 1`.
-  -/
+/-- `ofNatSucc n` is the `PosNum` corresponding to `n + 1`. -/
 def ofNatSucc : ℕ → PosNum
   | 0 => 1
   | Nat.succ n => succ (ofNatSucc n)
 #align pos_num.of_nat_succ PosNum.ofNatSucc
 
-/-- `of_nat n` is the `pos_num` corresponding to `n`, except for `of_nat 0 = 1`.
-  -/
+/-- `ofNat n` is the `PosNum` corresponding to `n`, except for `ofNat 0 = 1`. -/
 def ofNat (n : ℕ) : PosNum :=
   ofNatSucc (Nat.pred n)
 #align pos_num.of_nat PosNum.ofNat
 
 open Ordering
 
-/-- Ordering of `pos_num`s.
-  -/
+/-- Ordering of `PosNum`s. -/
 def cmp : PosNum → PosNum → Ordering
   | 1, 1 => eq
   | _, 1 => gt
@@ -195,16 +183,14 @@ section
 
 variable {α : Type _} [One α] [Add α]
 
-/-- `cast_pos_num` casts a `pos_num` into any type which has `1` and `+`.
-  -/
+/-- `castPosNum` casts a `PosNum` into any type which has `1` and `+`. -/
 @[deprecated] def castPosNum : PosNum → α
   | 1 => 1
   | PosNum.bit0 a => bit0 (castPosNum a)
   | PosNum.bit1 a => bit1 (castPosNum a)
 #align cast_pos_num castPosNum
 
-/-- `cast_num` casts a `num` into any type which has `0`, `1` and `+`.
-  -/
+/-- `castNum` casts a `Num` into any type which has `0`, `1` and `+`. -/
 def castNum [Zero α] : Num → α
   | 0 => 0
   | Num.pos p => castPosNum p
@@ -232,21 +218,18 @@ namespace Num
 
 open PosNum
 
-/-- The successor of a `num` as a `pos_num`.
-  -/
+/-- The successor of a `Num` as a `PosNum`. -/
 def succ' : Num → PosNum
   | 0 => 1
   | pos p => succ p
 #align num.succ' Num.succ'
 
-/-- The successor of a `num` as a `num`.
-  -/
+/-- The successor of a `Num` as a `Num`. -/
 def succ (n : Num) : Num :=
   pos (succ' n)
 #align num.succ Num.succ
 
-/-- Addition of two `num`s.
-  -/
+/-- Addition of two `Num`s. -/
 protected def add : Num → Num → Num
   | 0, a => a
   | b, 0 => b
@@ -256,42 +239,36 @@ protected def add : Num → Num → Num
 instance : Add Num :=
   ⟨Num.add⟩
 
-/-- `bit0 n` appends a `0` to the end of `n`, where `bit0 n = n0`.
-  -/
+/-- `bit0 n` appends a `0` to the end of `n`, where `bit0 n = n0`. -/
 protected def bit0 : Num → Num
   | 0 => 0
   | pos n => pos (PosNum.bit0 n)
 #align num.bit0 Num.bit0
 
-/-- `bit1 n` appends a `1` to the end of `n`, where `bit1 n = n1`.
-  -/
+/-- `bit1 n` appends a `1` to the end of `n`, where `bit1 n = n1`. -/
 protected def bit1 : Num → Num
   | 0 => 1
   | pos n => pos (PosNum.bit1 n)
 #align num.bit1 Num.bit1
 
-/-- `bit b n` appends the bit `b` to the end of `n`, where `bit tt x = x1` and `bit ff x = x0`.
-  -/
+/-- `bit b n` appends the bit `b` to the end of `n`, where `bit tt x = x1` and `bit ff x = x0`. -/
 def bit (b : Bool) : Num → Num :=
   cond b Num.bit1 Num.bit0
 #align num.bit Num.bit
 
-/-- The number of bits required to represent a `num`, as a `num`. `size 0` is defined to be `0`.
-  -/
+/-- The number of bits required to represent a `Num`, as a `Num`. `size 0` is defined to be `0`. -/
 def size : Num → Num
   | 0 => 0
   | pos n => pos (PosNum.size n)
 #align num.size Num.size
 
-/-- The number of bits required to represent a `num`, as a `nat`. `size 0` is defined to be `0`.
-  -/
+/-- The number of bits required to represent a `Num`, as a `Nat`. `size 0` is defined to be `0`. -/
 def natSize : Num → Nat
   | 0 => 0
   | pos n => PosNum.natSize n
 #align num.nat_size Num.natSize
 
-/-- Multiplication of two `num`s.
-  -/
+/-- Multiplication of two `Num`s. -/
 protected def mul : Num → Num → Num
   | 0, _ => 0
   | _, 0 => 0
@@ -303,8 +280,7 @@ instance : Mul Num :=
 
 open Ordering
 
-/-- Ordering of `num`s.
-  -/
+/-- Ordering of `Num`s. -/
 def cmp : Num → Num → Ordering
   | 0, 0 => eq
   | _, 0 => gt
@@ -326,22 +302,19 @@ instance decidableLe : @DecidableRel Num (· ≤ ·)
   | a, b => by dsimp [LE.le]; infer_instance
 #align num.decidable_le Num.decidableLe
 
-/-- Converts a `num` to a `znum`.
-  -/
-def toZnum : Num → Znum
+/-- Converts a `Num` to a `ZNum`. -/
+def toZNum : Num → ZNum
   | 0 => 0
-  | pos a => Znum.pos a
-#align num.to_znum Num.toZnum
+  | pos a => ZNum.pos a
+#align num.to_znum Num.toZNum
 
-/-- Converts `x : num` to `-x : znum`.
-  -/
-def toZnumNeg : Num → Znum
+/-- Converts `x : Num` to `-x : ZNum`. -/
+def toZNumNeg : Num → ZNum
   | 0 => 0
-  | pos a => Znum.neg a
-#align num.to_znum_neg Num.toZnumNeg
+  | pos a => ZNum.neg a
+#align num.to_znum_neg Num.toZNumNeg
 
-/-- Converts a `nat` to a `num`.
-  -/
+/-- Converts a `Nat` to a `Num`. -/
 def ofNat' : ℕ → Num
   | 0 => 0
   | n + 1 => if (n + 1) % 2 = 0
@@ -352,113 +325,101 @@ decreasing_by (exact Nat.div_lt_self (Nat.succ_pos n) (show 1 < 2 from le_rfl))
 
 end Num
 
-namespace Znum
+namespace ZNum
 
 open PosNum
 
-/-- The negation of a `znum`.
-  -/
-def zneg : Znum → Znum
+/-- The negation of a `ZNum`. -/
+def zneg : ZNum → ZNum
   | 0 => 0
   | pos a => neg a
   | neg a => pos a
-#align znum.zneg Znum.zneg
+#align znum.zneg ZNum.zneg
 
-instance : Neg Znum :=
+instance : Neg ZNum :=
   ⟨zneg⟩
 
-/-- The absolute value of a `znum` as a `num`.
-  -/
-def abs : Znum → Num
+/-- The absolute value of a `ZNum` as a `Num`. -/
+def abs : ZNum → Num
   | 0 => 0
   | pos a => Num.pos a
   | neg a => Num.pos a
-#align znum.abs Znum.abs
+#align znum.abs ZNum.abs
 
-/-- The successor of a `znum`.
-  -/
-def succ : Znum → Znum
+/-- The successor of a `ZNum`. -/
+def succ : ZNum → ZNum
   | 0 => 1
   | pos a => pos (PosNum.succ a)
-  | neg a => (PosNum.pred' a).toZnumNeg
-#align znum.succ Znum.succ
+  | neg a => (PosNum.pred' a).toZNumNeg
+#align znum.succ ZNum.succ
 
-/-- The predecessor of a `znum`.
-  -/
-def pred : Znum → Znum
+/-- The predecessor of a `ZNum`. -/
+def pred : ZNum → ZNum
   | 0 => neg 1
-  | pos a => (PosNum.pred' a).toZnum
+  | pos a => (PosNum.pred' a).toZNum
   | neg a => neg (PosNum.succ a)
-#align znum.pred Znum.pred
+#align znum.pred ZNum.pred
 
-/-- `bit0 n` appends a `0` to the end of `n`, where `bit0 n = n0`.
-  -/
-protected def bit0 : Znum → Znum
+/-- `bit0 n` appends a `0` to the end of `n`, where `bit0 n = n0`. -/
+protected def bit0 : ZNum → ZNum
   | 0 => 0
   | pos n => pos (PosNum.bit0 n)
   | neg n => neg (PosNum.bit0 n)
-#align znum.bit0 Znum.bit0
+#align znum.bit0 ZNum.bit0
 
-/-- `bit1 x` appends a `1` to the end of `x`, mapping `x` to `2 * x + 1`.
-  -/
-protected def bit1 : Znum → Znum
+/-- `bit1 x` appends a `1` to the end of `x`, mapping `x` to `2 * x + 1`. -/
+protected def bit1 : ZNum → ZNum
   | 0 => 1
   | pos n => pos (PosNum.bit1 n)
   | neg n => neg (Num.casesOn (pred' n) 1 PosNum.bit1)
-#align znum.bit1 Znum.bit1
+#align znum.bit1 ZNum.bit1
 
-/-- `bitm1 x` appends a `1` to the end of `x`, mapping `x` to `2 * x - 1`.
-  -/
-protected def bitm1 : Znum → Znum
+/-- `bitm1 x` appends a `1` to the end of `x`, mapping `x` to `2 * x - 1`. -/
+protected def bitm1 : ZNum → ZNum
   | 0 => neg 1
   | pos n => pos (Num.casesOn (pred' n) 1 PosNum.bit1)
   | neg n => neg (PosNum.bit1 n)
-#align znum.bitm1 Znum.bitm1
+#align znum.bitm1 ZNum.bitm1
 
-/-- Converts an `int` to a `znum`.
-  -/
-def ofInt' : ℤ → Znum
-  | (n : ℕ) => Num.toZnum (Num.ofNat' n)
-  | Int.negSucc n => Num.toZnumNeg (Num.ofNat' (n + 1))
-#align znum.of_int' Znum.ofInt'
+/-- Converts an `Int` to a `ZNum`. -/
+def ofInt' : ℤ → ZNum
+  | (n : ℕ) => Num.toZNum (Num.ofNat' n)
+  | Int.negSucc n => Num.toZNumNeg (Num.ofNat' (n + 1))
+#align znum.of_int' ZNum.ofInt'
 
-end Znum
+end ZNum
 
 namespace PosNum
 
-open Znum
+open ZNum
 
-/-- Subtraction of two `pos_num`s, producing a `znum`.
-  -/
-def sub' : PosNum → PosNum → Znum
-  | a, 1 => (pred' a).toZnum
-  | 1, b => (pred' b).toZnumNeg
+/-- Subtraction of two `PosNum`s, producing a `ZNum`. -/
+def sub' : PosNum → PosNum → ZNum
+  | a, 1 => (pred' a).toZNum
+  | 1, b => (pred' b).toZNumNeg
   | bit0 a, bit0 b => (sub' a b).bit0
   | bit0 a, bit1 b => (sub' a b).bitm1
   | bit1 a, bit0 b => (sub' a b).bit1
   | bit1 a, bit1 b => (sub' a b).bit0
 #align pos_num.sub' PosNum.sub'
 
-/-- Converts a `znum` to `option pos_num`, where it is `some` if the `znum` was positive and `none`
-  otherwise.
-  -/
-def ofZnum' : Znum → Option PosNum
-  | Znum.pos p => some p
+/-- Converts a `ZNum` to `Option PosNum`, where it is `some` if the `ZNum` was positive and `none`
+  otherwise. -/
+def ofZNum' : ZNum → Option PosNum
+  | ZNum.pos p => some p
   | _ => none
-#align pos_num.of_znum' PosNum.ofZnum'
+#align pos_num.of_znum' PosNum.ofZNum'
 
-/-- Converts a `znum` to a `pos_num`, mapping all out of range values to `1`.
-  -/
-def ofZnum : Znum → PosNum
-  | Znum.pos p => p
+/-- Converts a `ZNum` to a `PosNum`, mapping all out of range values to `1`. -/
+def ofZNum : ZNum → PosNum
+  | ZNum.pos p => p
   | _ => 1
-#align pos_num.of_znum PosNum.ofZnum
+#align pos_num.of_znum PosNum.ofZNum
 
-/-- Subtraction of `pos_num`s, where if `a < b`, then `a - b = 1`.
-  -/
+/-- Subtraction of `PosNum`s, where if `a < b`, then `a - b = 1`. -/
 protected def sub (a b : PosNum) : PosNum :=
   match sub' a b with
-  | Znum.pos p => p
+  | ZNum.pos p => p
   | _ => 1
 #align pos_num.sub PosNum.sub
 
@@ -469,22 +430,19 @@ end PosNum
 
 namespace Num
 
-/-- The predecessor of a `num` as an `option num`, where `ppred 0 = none`
-  -/
+/-- The predecessor of a `Num` as an `Option Num`, where `ppred 0 = none` -/
 def ppred : Num → Option Num
   | 0 => none
   | pos p => some p.pred'
 #align num.ppred Num.ppred
 
-/-- The predecessor of a `num` as a `num`, where `pred 0 = 0`.
-  -/
+/-- The predecessor of a `Num` as a `Num`, where `pred 0 = 0`. -/
 def pred : Num → Num
   | 0 => 0
   | pos p => p.pred'
 #align num.pred Num.pred
 
-/-- Divides a `num` by `2`
-  -/
+/-- Divides a `Num` by `2` -/
 def div2 : Num → Num
   | 0 => 0
   | 1 => 0
@@ -492,40 +450,35 @@ def div2 : Num → Num
   | pos (PosNum.bit1 p) => pos p
 #align num.div2 Num.div2
 
-/-- Converts a `znum` to an `option num`, where `of_znum' p = none` if `p < 0`.
-  -/
-def ofZnum' : Znum → Option Num
+/-- Converts a `ZNum` to an `Option Num`, where `ofZNum' p = none` if `p < 0`. -/
+def ofZNum' : ZNum → Option Num
   | 0 => some 0
-  | Znum.pos p => some (pos p)
-  | Znum.neg _ => none
-#align num.of_znum' Num.ofZnum'
+  | ZNum.pos p => some (pos p)
+  | ZNum.neg _ => none
+#align num.of_znum' Num.ofZNum'
 
-/-- Converts a `znum` to an `option num`, where `of_znum p = 0` if `p < 0`.
-  -/
-def ofZnum : Znum → Num
-  | Znum.pos p => pos p
+/-- Converts a `ZNum` to an `Option Num`, where `ofZNum p = 0` if `p < 0`. -/
+def ofZNum : ZNum → Num
+  | ZNum.pos p => pos p
   | _ => 0
-#align num.of_znum Num.ofZnum
+#align num.of_znum Num.ofZNum
 
-/-- Subtraction of two `num`s, producing a `znum`.
-  -/
-def sub' : Num → Num → Znum
+/-- Subtraction of two `Num`s, producing a `ZNum`. -/
+def sub' : Num → Num → ZNum
   | 0, 0 => 0
-  | pos a, 0 => Znum.pos a
-  | 0, pos b => Znum.neg b
+  | pos a, 0 => ZNum.pos a
+  | 0, pos b => ZNum.neg b
   | pos a, pos b => a.sub' b
 #align num.sub' Num.sub'
 
-/-- Subtraction of two `num`s, producing an `option num`.
-  -/
+/-- Subtraction of two `Num`s, producing an `Option Num`. -/
 def psub (a b : Num) : Option Num :=
-  ofZnum' (sub' a b)
+  ofZNum' (sub' a b)
 #align num.psub Num.psub
 
-/-- Subtraction of two `num`s, where if `a < b`, `a - b = 0`.
-  -/
+/-- Subtraction of two `Num`s, where if `a < b`, `a - b = 0`. -/
 protected def sub (a b : Num) : Num :=
-  ofZnum (sub' a b)
+  ofZNum (sub' a b)
 #align num.sub Num.sub
 
 instance : Sub Num :=
@@ -533,43 +486,40 @@ instance : Sub Num :=
 
 end Num
 
-namespace Znum
+namespace ZNum
 
 open PosNum
 
-/-- Addition of `znum`s.
-  -/
-protected def add : Znum → Znum → Znum
+/-- Addition of `ZNum`s. -/
+protected def add : ZNum → ZNum → ZNum
   | 0, a => a
   | b, 0 => b
   | pos a, pos b => pos (a + b)
   | pos a, neg b => sub' a b
   | neg a, pos b => sub' b a
   | neg a, neg b => neg (a + b)
-#align znum.add Znum.add
+#align znum.add ZNum.add
 
-instance : Add Znum :=
-  ⟨Znum.add⟩
+instance : Add ZNum :=
+  ⟨ZNum.add⟩
 
-/-- Multiplication of `znum`s.
-  -/
-protected def mul : Znum → Znum → Znum
+/-- Multiplication of `ZNum`s. -/
+protected def mul : ZNum → ZNum → ZNum
   | 0, _ => 0
   | _, 0 => 0
   | pos a, pos b => pos (a * b)
   | pos a, neg b => neg (a * b)
   | neg a, pos b => neg (a * b)
   | neg a, neg b => pos (a * b)
-#align znum.mul Znum.mul
+#align znum.mul ZNum.mul
 
-instance : Mul Znum :=
-  ⟨Znum.mul⟩
+instance : Mul ZNum :=
+  ⟨ZNum.mul⟩
 
 open Ordering
 
-/-- Ordering on `znum`s.
-  -/
-def cmp : Znum → Znum → Ordering
+/-- Ordering on `ZNum`s. -/
+def cmp : ZNum → ZNum → Ordering
   | 0, 0 => eq
   | pos a, pos b => PosNum.cmp a b
   | neg a, neg b => PosNum.cmp b a
@@ -577,35 +527,34 @@ def cmp : Znum → Znum → Ordering
   | neg _, _ => lt
   | _, pos _ => lt
   | _, neg _ => gt
-#align znum.cmp Znum.cmp
+#align znum.cmp ZNum.cmp
 
-instance : LT Znum :=
+instance : LT ZNum :=
   ⟨fun a b => cmp a b = Ordering.lt⟩
 
-instance : LE Znum :=
+instance : LE ZNum :=
   ⟨fun a b => ¬b < a⟩
 
-instance decidableLt : @DecidableRel Znum (· < ·)
+instance decidableLt : @DecidableRel ZNum (· < ·)
   | a, b => by dsimp [LT.lt]; infer_instance
-#align znum.decidable_lt Znum.decidableLt
+#align znum.decidable_lt ZNum.decidableLt
 
-instance decidableLe : @DecidableRel Znum (· ≤ ·)
+instance decidableLe : @DecidableRel ZNum (· ≤ ·)
   | a, b => by dsimp [LE.le]; infer_instance
-#align znum.decidable_le Znum.decidableLe
+#align znum.decidable_le ZNum.decidableLe
 
-end Znum
+end ZNum
 
 namespace PosNum
 
-/-- Auxiliary definition for `pos_num.divmod`. -/
+/-- Auxiliary definition for `PosNum.divmod`. -/
 def divmodAux (d : PosNum) (q r : Num) : Num × Num :=
-  match Num.ofZnum' (Num.sub' r (Num.pos d)) with
+  match Num.ofZNum' (Num.sub' r (Num.pos d)) with
   | some r' => (Num.bit1 q, r')
   | none => (Num.bit0 q, r)
 #align pos_num.divmod_aux PosNum.divmodAux
 
-/-- `divmod x y = (y / x, y % x)`.
-  -/
+/-- `divmod x y = (y / x, y % x)`. -/
 def divmod (d : PosNum) : PosNum → Num × Num
   | bit0 n =>
     let (q, r₁) := divmod d n
@@ -616,14 +565,12 @@ def divmod (d : PosNum) : PosNum → Num × Num
   | 1 => divmodAux d 0 1
 #align pos_num.divmod PosNum.divmod
 
-/-- Division of `pos_num`,
-  -/
+/-- Division of `PosNum`, -/
 def div' (n d : PosNum) : Num :=
   (divmod d n).1
 #align pos_num.div' PosNum.div'
 
-/-- Modulus of `pos_num`s.
-  -/
+/-- Modulus of `PosNum`s. -/
 def mod' (n d : PosNum) : Num :=
   (divmod d n).2
 #align pos_num.mod' PosNum.mod'
@@ -663,16 +610,14 @@ end PosNum
 
 namespace Num
 
-/-- Division of `num`s, where `x / 0 = 0`.
-  -/
+/-- Division of `Num`s, where `x / 0 = 0`. -/
 def div : Num → Num → Num
   | 0, _ => 0
   | _, 0 => 0
   | pos n, pos d => PosNum.div' n d
 #align num.div Num.div
 
-/-- Modulus of `num`s.
-  -/
+/-- Modulus of `Num`s. -/
 def mod : Num → Num → Num
   | 0, _ => 0
   | n, 0 => n
@@ -685,74 +630,69 @@ instance : Div Num :=
 instance : Mod Num :=
   ⟨Num.mod⟩
 
-/-- Auxiliary definition for `num.gcd`. -/
+/-- Auxiliary definition for `Num.gcd`. -/
 def gcdAux : Nat → Num → Num → Num
   | 0, _, b => b
   | Nat.succ _, 0, b => b
   | Nat.succ n, a, b => gcdAux n (b % a) a
 #align num.gcd_aux Num.gcdAux
 
-/-- Greatest Common Divisor (GCD) of two `num`s.
-  -/
+/-- Greatest Common Divisor (GCD) of two `Num`s. -/
 def gcd (a b : Num) : Num :=
   if a ≤ b then gcdAux (a.natSize + b.natSize) a b else gcdAux (b.natSize + a.natSize) b a
 #align num.gcd Num.gcd
 
 end Num
 
-namespace Znum
+namespace ZNum
 
-/-- Division of `znum`, where `x / 0 = 0`.
-  -/
-def div : Znum → Znum → Znum
+/-- Division of `ZNum`, where `x / 0 = 0`. -/
+def div : ZNum → ZNum → ZNum
   | 0, _ => 0
   | _, 0 => 0
-  | pos n, pos d => Num.toZnum (PosNum.div' n d)
-  | pos n, neg d => Num.toZnumNeg (PosNum.div' n d)
+  | pos n, pos d => Num.toZNum (PosNum.div' n d)
+  | pos n, neg d => Num.toZNumNeg (PosNum.div' n d)
   | neg n, pos d => neg (PosNum.pred' n / Num.pos d).succ'
   | neg n, neg d => pos (PosNum.pred' n / Num.pos d).succ'
-#align znum.div Znum.div
+#align znum.div ZNum.div
 
-/-- Modulus of `znum`s.
-  -/
-def mod : Znum → Znum → Znum
+/-- Modulus of `ZNum`s. -/
+def mod : ZNum → ZNum → ZNum
   | 0, _ => 0
-  | pos n, d => Num.toZnum (Num.pos n % d.abs)
+  | pos n, d => Num.toZNum (Num.pos n % d.abs)
   | neg n, d => d.abs.sub' (PosNum.pred' n % d.abs).succ
-#align znum.mod Znum.mod
+#align znum.mod ZNum.mod
 
-instance : Div Znum :=
-  ⟨Znum.div⟩
+instance : Div ZNum :=
+  ⟨ZNum.div⟩
 
-instance : Mod Znum :=
-  ⟨Znum.mod⟩
+instance : Mod ZNum :=
+  ⟨ZNum.mod⟩
 
-/-- Greatest Common Divisor (GCD) of two `znum`s.
-  -/
-def gcd (a b : Znum) : Num :=
+/-- Greatest Common Divisor (GCD) of two `ZNum`s. -/
+def gcd (a b : ZNum) : Num :=
   a.abs.gcd b.abs
-#align znum.gcd Znum.gcd
+#align znum.gcd ZNum.gcd
 
-end Znum
+end ZNum
 
 section
 
 variable {α : Type _} [Zero α] [One α] [Add α] [Neg α]
 
-/-- `cast_znum` casts a `znum` into any type which has `0`, `1`, `+` and `neg`
-  -/
-def castZnum : Znum → α
+/-- `castZNum` casts a `ZNum` into any type which has `0`, `1`, `+` and `neg` -/
+def castZNum : ZNum → α
   | 0 => 0
-  | Znum.pos p => p
-  | Znum.neg p => -p
-#align cast_znum castZnum
+  | ZNum.pos p => p
+  | ZNum.neg p => -p
+#align cast_znum castZNum
 
 -- see Note [coercion into rings]
-instance (priority := 900) znumCoe : CoeTC Znum α :=
-  ⟨castZnum⟩
+instance (priority := 900) znumCoe : CoeTC ZNum α :=
+  ⟨castZNum⟩
 #align znum_coe znumCoe
 
-instance : Repr Znum :=
+instance : Repr ZNum :=
   ⟨fun _ n => repr (n : ℤ)⟩
 
 end

--- a/Mathlib/Data/Num/Basic.lean
+++ b/Mathlib/Data/Num/Basic.lean
@@ -583,11 +583,13 @@ def mod' (n d : PosNum) : Num :=
   (divMod d n).2
 #align pos_num.mod' PosNum.mod'
 
+/-- Auxiliary definition for `sqrtAux`. -/
 private def sqrtAux1 (b : PosNum) (r n : Num) : Num × Num :=
   match Num.ofZNum' (n.sub' (r + Num.pos b)) with
   | some n' => (r.div2 + Num.pos b, n')
   | none => (r.div2, n)
 
+/-- Auxiliary definition for a `sqrt` function which is not currently implemented. -/
 private def sqrtAux : PosNum → Num → Num → Num
   | b@(bit0 b') => fun r n => let (r', n') := sqrtAux1 b r n; sqrtAux b' r' n'
   | b@(bit1 b') => fun r n => let (r', n') := sqrtAux1 b r n; sqrtAux b' r' n'

--- a/Mathlib/Data/Num/Basic.lean
+++ b/Mathlib/Data/Num/Basic.lean
@@ -667,17 +667,18 @@ end ZNum
 
 section
 
+set_option linter.deprecated false
 variable {α : Type _} [Zero α] [One α] [Add α] [Neg α]
 
 /-- `castZNum` casts a `ZNum` into any type which has `0`, `1`, `+` and `neg` -/
-def castZNum : ZNum → α
+@[deprecated] def castZNum : ZNum → α
   | 0 => 0
   | ZNum.pos p => p
   | ZNum.neg p => -p
 #align cast_znum castZNum
 
 -- see Note [coercion into rings]
-instance (priority := 900) znumCoe : CoeTC ZNum α :=
+@[deprecated] instance (priority := 900) znumCoe : CoeTC ZNum α :=
   ⟨castZNum⟩
 #align znum_coe znumCoe
 

--- a/Mathlib/Data/Num/Basic.lean
+++ b/Mathlib/Data/Num/Basic.lean
@@ -583,37 +583,16 @@ def mod' (n d : PosNum) : Num :=
   (divMod d n).2
 #align pos_num.mod' PosNum.mod'
 
-/-
-  private def sqrt_aux1 (b : pos_num) (r n : num) : num × num :=
-  match num.of_znum' (n.sub' (r + num.pos b)) with
-  | some n' := (r.div2 + num.pos b, n')
-  | none := (r.div2, n)
-  end
+private def sqrtAux1 (b : PosNum) (r n : Num) : Num × Num :=
+  match Num.ofZNum' (n.sub' (r + Num.pos b)) with
+  | some n' => (r.div2 + Num.pos b, n')
+  | none => (r.div2, n)
 
-  private def sqrt_aux : pos_num → num → num → num
-  | b@(bit0 b') r n := let (r', n') := sqrt_aux1 b r n in sqrt_aux b' r' n'
-  | b@(bit1 b') r n := let (r', n') := sqrt_aux1 b r n in sqrt_aux b' r' n'
-  | 1           r n := (sqrt_aux1 1 r n).1
-  -/
-/-
+private def sqrtAux : PosNum → Num → Num → Num
+  | b@(bit0 b') => fun r n => let (r', n') := sqrtAux1 b r n; sqrtAux b' r' n'
+  | b@(bit1 b') => fun r n => let (r', n') := sqrtAux1 b r n; sqrtAux b' r' n'
+  | 1           => fun r n => (sqrtAux1 1 r n).1
 
-def sqrt_aux : ℕ → ℕ → ℕ → ℕ
-| b r n := if b0 : b = 0 then r else
-  let b' := shiftr b 2 in
-  have b' < b, from sqrt_aux_dec b0,
-  match (n - (r + b : ℕ) : ℤ) with
-  | (n' : ℕ) := sqrt_aux b' (div2 r + b) n'
-  | _ := sqrt_aux b' (div2 r) n
-  end
-
-/-- `sqrt n` is the square root of a natural number `n`. If `n` is not a
-  perfect square, it returns the largest `k:ℕ` such that `k*k ≤ n`. -/
-def sqrt (n : ℕ) : ℕ :=
-match size n with
-| 0      := 0
-| succ s := sqrt_aux (shiftl 1 (bit0 (div2 s))) 0 n
-end
--/
 end PosNum
 
 namespace Num

--- a/Mathlib/Data/Num/Basic.lean
+++ b/Mathlib/Data/Num/Basic.lean
@@ -1,0 +1,753 @@
+/-
+Copyright (c) 2014 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Leonardo de Moura, Mario Carneiro
+-/
+
+/-!
+# Binary representation of integers using inductive types
+
+Note: Unlike in Coq, where this representation is preferred because of
+the reliance on kernel reduction, in Lean this representation is discouraged
+in favor of the "Peano" natural numbers `nat`, and the purpose of this
+collection of theorems is to show the equivalence of the different approaches.
+-/
+
+
+/-- The type of positive binary numbers.
+
+     13 = 1101(base 2) = bit1 (bit0 (bit1 one)) -/
+inductive PosNum : Type
+  | one : PosNum
+  | bit1 : PosNum → PosNum
+  | bit0 : PosNum → PosNum
+  deriving has_reflect, DecidableEq
+#align pos_num PosNum
+
+instance : One PosNum :=
+  ⟨PosNum.one⟩
+
+instance : Inhabited PosNum :=
+  ⟨1⟩
+
+/-- The type of nonnegative binary numbers, using `pos_num`.
+
+     13 = 1101(base 2) = pos (bit1 (bit0 (bit1 one))) -/
+inductive Num : Type
+  | zero : Num
+  | Pos : PosNum → Num
+  deriving has_reflect, DecidableEq
+#align num Num
+
+instance : Zero Num :=
+  ⟨Num.zero⟩
+
+instance : One Num :=
+  ⟨Num.pos 1⟩
+
+instance : Inhabited Num :=
+  ⟨0⟩
+
+/-- Representation of integers using trichotomy around zero.
+
+     13 = 1101(base 2) = pos (bit1 (bit0 (bit1 one)))
+     -13 = -1101(base 2) = neg (bit1 (bit0 (bit1 one))) -/
+inductive Znum : Type
+  | zero : Znum
+  | Pos : PosNum → Znum
+  | neg : PosNum → Znum
+  deriving has_reflect, DecidableEq
+#align znum Znum
+
+instance : Zero Znum :=
+  ⟨Znum.zero⟩
+
+instance : One Znum :=
+  ⟨Znum.pos 1⟩
+
+instance : Inhabited Znum :=
+  ⟨0⟩
+
+namespace PosNum
+
+/-- `bit b n` appends the bit `b` to the end of `n`, where `bit tt x = x1` and `bit ff x = x0`.
+  -/
+def bit (b : Bool) : PosNum → PosNum :=
+  cond b bit1 bit0
+#align pos_num.bit PosNum.bit
+
+/-- The successor of a `pos_num`.
+  -/
+def succ : PosNum → PosNum
+  | 1 => bit0 one
+  | bit1 n => bit0 (succ n)
+  | bit0 n => bit1 n
+#align pos_num.succ PosNum.succ
+
+/-- Returns a boolean for whether the `pos_num` is `one`.
+  -/
+def isOne : PosNum → Bool
+  | 1 => true
+  | _ => false
+#align pos_num.is_one PosNum.isOne
+
+/-- Addition of two `pos_num`s.
+  -/
+protected def add : PosNum → PosNum → PosNum
+  | 1, b => succ b
+  | a, 1 => succ a
+  | bit0 a, bit0 b => bit0 (add a b)
+  | bit1 a, bit1 b => bit0 (succ (add a b))
+  | bit0 a, bit1 b => bit1 (add a b)
+  | bit1 a, bit0 b => bit1 (add a b)
+#align pos_num.add PosNum.add
+
+instance : Add PosNum :=
+  ⟨PosNum.add⟩
+
+/-- The predecessor of a `pos_num` as a `num`.
+  -/
+def pred' : PosNum → Num
+  | 1 => 0
+  | bit0 n => Num.pos (Num.casesOn (pred' n) 1 bit1)
+  | bit1 n => Num.pos (bit0 n)
+#align pos_num.pred' PosNum.pred'
+
+/-- The predecessor of a `pos_num` as a `pos_num`. This means that `pred 1 = 1`.
+  -/
+def pred (a : PosNum) : PosNum :=
+  Num.casesOn (pred' a) 1 id
+#align pos_num.pred PosNum.pred
+
+/-- The number of bits of a `pos_num`, as a `pos_num`.
+  -/
+def size : PosNum → PosNum
+  | 1 => 1
+  | bit0 n => succ (size n)
+  | bit1 n => succ (size n)
+#align pos_num.size PosNum.size
+
+/-- The number of bits of a `pos_num`, as a `nat`.
+  -/
+def natSize : PosNum → Nat
+  | 1 => 1
+  | bit0 n => Nat.succ (nat_size n)
+  | bit1 n => Nat.succ (nat_size n)
+#align pos_num.nat_size PosNum.natSize
+
+/-- Multiplication of two `pos_num`s.
+  -/
+protected def mul (a : PosNum) : PosNum → PosNum
+  | 1 => a
+  | bit0 b => bit0 (mul b)
+  | bit1 b => bit0 (mul b) + a
+#align pos_num.mul PosNum.mul
+
+instance : Mul PosNum :=
+  ⟨PosNum.mul⟩
+
+/-- `of_nat_succ n` is the `pos_num` corresponding to `n + 1`.
+  -/
+def ofNatSucc : ℕ → PosNum
+  | 0 => 1
+  | Nat.succ n => succ (of_nat_succ n)
+#align pos_num.of_nat_succ PosNum.ofNatSucc
+
+/-- `of_nat n` is the `pos_num` corresponding to `n`, except for `of_nat 0 = 1`.
+  -/
+def ofNat (n : ℕ) : PosNum :=
+  ofNatSucc (Nat.pred n)
+#align pos_num.of_nat PosNum.ofNat
+
+open Ordering
+
+/-- Ordering of `pos_num`s.
+  -/
+def cmp : PosNum → PosNum → Ordering
+  | 1, 1 => Eq
+  | _, 1 => GT.gt
+  | 1, _ => lt
+  | bit0 a, bit0 b => Cmp a b
+  | bit0 a, bit1 b => Ordering.casesOn (Cmp a b) lt lt GT.gt
+  | bit1 a, bit0 b => Ordering.casesOn (Cmp a b) lt GT.gt GT.gt
+  | bit1 a, bit1 b => Cmp a b
+#align pos_num.cmp PosNum.cmp
+
+instance : LT PosNum :=
+  ⟨fun a b => cmp a b = Ordering.lt⟩
+
+instance : LE PosNum :=
+  ⟨fun a b => ¬b < a⟩
+
+instance decidableLt : @DecidableRel PosNum (· < ·)
+  | a, b => by dsimp [(· < ·)] <;> infer_instance
+#align pos_num.decidable_lt PosNum.decidableLt
+
+instance decidableLe : @DecidableRel PosNum (· ≤ ·)
+  | a, b => by dsimp [(· ≤ ·)] <;> infer_instance
+#align pos_num.decidable_le PosNum.decidableLe
+
+end PosNum
+
+section
+
+variable {α : Type _} [One α] [Add α]
+
+/-- `cast_pos_num` casts a `pos_num` into any type which has `1` and `+`.
+  -/
+def castPosNum : PosNum → α
+  | 1 => 1
+  | PosNum.bit0 a => bit0 (castPosNum a)
+  | PosNum.bit1 a => bit1 (castPosNum a)
+#align cast_pos_num castPosNum
+
+/-- `cast_num` casts a `num` into any type which has `0`, `1` and `+`.
+  -/
+def castNum [z : Zero α] : Num → α
+  | 0 => 0
+  | Num.pos p => castPosNum p
+#align cast_num castNum
+
+-- see Note [coercion into rings]
+instance (priority := 900) posNumCoe : CoeTC PosNum α :=
+  ⟨castPosNum⟩
+#align pos_num_coe posNumCoe
+
+-- see Note [coercion into rings]
+instance (priority := 900) numNatCoe [z : Zero α] : CoeTC Num α :=
+  ⟨castNum⟩
+#align num_nat_coe numNatCoe
+
+instance : Repr PosNum :=
+  ⟨fun n => repr (n : ℕ)⟩
+
+instance : Repr Num :=
+  ⟨fun n => repr (n : ℕ)⟩
+
+end
+
+namespace Num
+
+open PosNum
+
+/-- The successor of a `num` as a `pos_num`.
+  -/
+def succ' : Num → PosNum
+  | 0 => 1
+  | Pos p => succ p
+#align num.succ' Num.succ'
+
+/-- The successor of a `num` as a `num`.
+  -/
+def succ (n : Num) : Num :=
+  pos (succ' n)
+#align num.succ Num.succ
+
+/-- Addition of two `num`s.
+  -/
+protected def add : Num → Num → Num
+  | 0, a => a
+  | b, 0 => b
+  | Pos a, Pos b => pos (a + b)
+#align num.add Num.add
+
+instance : Add Num :=
+  ⟨Num.add⟩
+
+/-- `bit0 n` appends a `0` to the end of `n`, where `bit0 n = n0`.
+  -/
+protected def bit0 : Num → Num
+  | 0 => 0
+  | Pos n => pos (PosNum.bit0 n)
+#align num.bit0 Num.bit0
+
+/-- `bit1 n` appends a `1` to the end of `n`, where `bit1 n = n1`.
+  -/
+protected def bit1 : Num → Num
+  | 0 => 1
+  | Pos n => pos (PosNum.bit1 n)
+#align num.bit1 Num.bit1
+
+/-- `bit b n` appends the bit `b` to the end of `n`, where `bit tt x = x1` and `bit ff x = x0`.
+  -/
+def bit (b : Bool) : Num → Num :=
+  cond b Num.bit1 Num.bit0
+#align num.bit Num.bit
+
+/-- The number of bits required to represent a `num`, as a `num`. `size 0` is defined to be `0`.
+  -/
+def size : Num → Num
+  | 0 => 0
+  | Pos n => pos (PosNum.size n)
+#align num.size Num.size
+
+/-- The number of bits required to represent a `num`, as a `nat`. `size 0` is defined to be `0`.
+  -/
+def natSize : Num → Nat
+  | 0 => 0
+  | Pos n => PosNum.natSize n
+#align num.nat_size Num.natSize
+
+/-- Multiplication of two `num`s.
+  -/
+protected def mul : Num → Num → Num
+  | 0, _ => 0
+  | _, 0 => 0
+  | Pos a, Pos b => pos (a * b)
+#align num.mul Num.mul
+
+instance : Mul Num :=
+  ⟨Num.mul⟩
+
+open Ordering
+
+/-- Ordering of `num`s.
+  -/
+def cmp : Num → Num → Ordering
+  | 0, 0 => Eq
+  | _, 0 => GT.gt
+  | 0, _ => lt
+  | Pos a, Pos b => PosNum.cmp a b
+#align num.cmp Num.cmp
+
+instance : LT Num :=
+  ⟨fun a b => cmp a b = Ordering.lt⟩
+
+instance : LE Num :=
+  ⟨fun a b => ¬b < a⟩
+
+instance decidableLt : @DecidableRel Num (· < ·)
+  | a, b => by dsimp [(· < ·)] <;> infer_instance
+#align num.decidable_lt Num.decidableLt
+
+instance decidableLe : @DecidableRel Num (· ≤ ·)
+  | a, b => by dsimp [(· ≤ ·)] <;> infer_instance
+#align num.decidable_le Num.decidableLe
+
+/-- Converts a `num` to a `znum`.
+  -/
+def toZnum : Num → Znum
+  | 0 => 0
+  | Pos a => Znum.pos a
+#align num.to_znum Num.toZnum
+
+/-- Converts `x : num` to `-x : znum`.
+  -/
+def toZnumNeg : Num → Znum
+  | 0 => 0
+  | Pos a => Znum.neg a
+#align num.to_znum_neg Num.toZnumNeg
+
+/-- Converts a `nat` to a `num`.
+  -/
+def ofNat' : ℕ → Num :=
+  Nat.binaryRec 0 fun b n => cond b Num.bit1 Num.bit0
+#align num.of_nat' Num.ofNat'
+
+end Num
+
+namespace Znum
+
+open PosNum
+
+/-- The negation of a `znum`.
+  -/
+def zneg : Znum → Znum
+  | 0 => 0
+  | Pos a => neg a
+  | neg a => pos a
+#align znum.zneg Znum.zneg
+
+instance : Neg Znum :=
+  ⟨zneg⟩
+
+/-- The absolute value of a `znum` as a `num`.
+  -/
+def abs : Znum → Num
+  | 0 => 0
+  | Pos a => Num.pos a
+  | neg a => Num.pos a
+#align znum.abs Znum.abs
+
+/-- The successor of a `znum`.
+  -/
+def succ : Znum → Znum
+  | 0 => 1
+  | Pos a => pos (PosNum.succ a)
+  | neg a => (PosNum.pred' a).toZnumNeg
+#align znum.succ Znum.succ
+
+/-- The predecessor of a `znum`.
+  -/
+def pred : Znum → Znum
+  | 0 => neg 1
+  | Pos a => (PosNum.pred' a).toZnum
+  | neg a => neg (PosNum.succ a)
+#align znum.pred Znum.pred
+
+/-- `bit0 n` appends a `0` to the end of `n`, where `bit0 n = n0`.
+  -/
+protected def bit0 : Znum → Znum
+  | 0 => 0
+  | Pos n => pos (PosNum.bit0 n)
+  | neg n => neg (PosNum.bit0 n)
+#align znum.bit0 Znum.bit0
+
+/-- `bit1 x` appends a `1` to the end of `x`, mapping `x` to `2 * x + 1`.
+  -/
+protected def bit1 : Znum → Znum
+  | 0 => 1
+  | Pos n => pos (PosNum.bit1 n)
+  | neg n => neg (Num.casesOn (pred' n) 1 PosNum.bit1)
+#align znum.bit1 Znum.bit1
+
+/-- `bitm1 x` appends a `1` to the end of `x`, mapping `x` to `2 * x - 1`.
+  -/
+protected def bitm1 : Znum → Znum
+  | 0 => neg 1
+  | Pos n => pos (Num.casesOn (pred' n) 1 PosNum.bit1)
+  | neg n => neg (PosNum.bit1 n)
+#align znum.bitm1 Znum.bitm1
+
+/-- Converts an `int` to a `znum`.
+  -/
+def ofInt' : ℤ → Znum
+  | (n : ℕ) => Num.toZnum (Num.ofNat' n)
+  | -[n+1] => Num.toZnumNeg (Num.ofNat' (n + 1))
+#align znum.of_int' Znum.ofInt'
+
+end Znum
+
+namespace PosNum
+
+open Znum
+
+/-- Subtraction of two `pos_num`s, producing a `znum`.
+  -/
+def sub' : PosNum → PosNum → Znum
+  | a, 1 => (pred' a).toZnum
+  | 1, b => (pred' b).toZnumNeg
+  | bit0 a, bit0 b => (sub' a b).bit0
+  | bit0 a, bit1 b => (sub' a b).bitm1
+  | bit1 a, bit0 b => (sub' a b).bit1
+  | bit1 a, bit1 b => (sub' a b).bit0
+#align pos_num.sub' PosNum.sub'
+
+/-- Converts a `znum` to `option pos_num`, where it is `some` if the `znum` was positive and `none`
+  otherwise.
+  -/
+def ofZnum' : Znum → Option PosNum
+  | Znum.pos p => some p
+  | _ => none
+#align pos_num.of_znum' PosNum.ofZnum'
+
+/-- Converts a `znum` to a `pos_num`, mapping all out of range values to `1`.
+  -/
+def ofZnum : Znum → PosNum
+  | Znum.pos p => p
+  | _ => 1
+#align pos_num.of_znum PosNum.ofZnum
+
+/-- Subtraction of `pos_num`s, where if `a < b`, then `a - b = 1`.
+  -/
+protected def sub (a b : PosNum) : PosNum :=
+  match sub' a b with
+  | Znum.pos p => p
+  | _ => 1
+#align pos_num.sub PosNum.sub
+
+instance : Sub PosNum :=
+  ⟨PosNum.sub⟩
+
+end PosNum
+
+namespace Num
+
+/-- The predecessor of a `num` as an `option num`, where `ppred 0 = none`
+  -/
+def ppred : Num → Option Num
+  | 0 => none
+  | Pos p => some p.pred'
+#align num.ppred Num.ppred
+
+/-- The predecessor of a `num` as a `num`, where `pred 0 = 0`.
+  -/
+def pred : Num → Num
+  | 0 => 0
+  | Pos p => p.pred'
+#align num.pred Num.pred
+
+/-- Divides a `num` by `2`
+  -/
+def div2 : Num → Num
+  | 0 => 0
+  | 1 => 0
+  | Pos (PosNum.bit0 p) => pos p
+  | Pos (PosNum.bit1 p) => pos p
+#align num.div2 Num.div2
+
+/-- Converts a `znum` to an `option num`, where `of_znum' p = none` if `p < 0`.
+  -/
+def ofZnum' : Znum → Option Num
+  | 0 => some 0
+  | Znum.pos p => some (pos p)
+  | Znum.neg p => none
+#align num.of_znum' Num.ofZnum'
+
+/-- Converts a `znum` to an `option num`, where `of_znum p = 0` if `p < 0`.
+  -/
+def ofZnum : Znum → Num
+  | Znum.pos p => pos p
+  | _ => 0
+#align num.of_znum Num.ofZnum
+
+/-- Subtraction of two `num`s, producing a `znum`.
+  -/
+def sub' : Num → Num → Znum
+  | 0, 0 => 0
+  | Pos a, 0 => Znum.pos a
+  | 0, Pos b => Znum.neg b
+  | Pos a, Pos b => a.sub' b
+#align num.sub' Num.sub'
+
+/-- Subtraction of two `num`s, producing an `option num`.
+  -/
+def psub (a b : Num) : Option Num :=
+  ofZnum' (sub' a b)
+#align num.psub Num.psub
+
+/-- Subtraction of two `num`s, where if `a < b`, `a - b = 0`.
+  -/
+protected def sub (a b : Num) : Num :=
+  ofZnum (sub' a b)
+#align num.sub Num.sub
+
+instance : Sub Num :=
+  ⟨Num.sub⟩
+
+end Num
+
+namespace Znum
+
+open PosNum
+
+/-- Addition of `znum`s.
+  -/
+protected def add : Znum → Znum → Znum
+  | 0, a => a
+  | b, 0 => b
+  | Pos a, Pos b => pos (a + b)
+  | Pos a, neg b => sub' a b
+  | neg a, Pos b => sub' b a
+  | neg a, neg b => neg (a + b)
+#align znum.add Znum.add
+
+instance : Add Znum :=
+  ⟨Znum.add⟩
+
+/-- Multiplication of `znum`s.
+  -/
+protected def mul : Znum → Znum → Znum
+  | 0, a => 0
+  | b, 0 => 0
+  | Pos a, Pos b => pos (a * b)
+  | Pos a, neg b => neg (a * b)
+  | neg a, Pos b => neg (a * b)
+  | neg a, neg b => pos (a * b)
+#align znum.mul Znum.mul
+
+instance : Mul Znum :=
+  ⟨Znum.mul⟩
+
+open Ordering
+
+/-- Ordering on `znum`s.
+  -/
+def cmp : Znum → Znum → Ordering
+  | 0, 0 => Eq
+  | Pos a, Pos b => PosNum.cmp a b
+  | neg a, neg b => PosNum.cmp b a
+  | Pos _, _ => GT.gt
+  | neg _, _ => lt
+  | _, Pos _ => lt
+  | _, neg _ => GT.gt
+#align znum.cmp Znum.cmp
+
+instance : LT Znum :=
+  ⟨fun a b => cmp a b = Ordering.lt⟩
+
+instance : LE Znum :=
+  ⟨fun a b => ¬b < a⟩
+
+instance decidableLt : @DecidableRel Znum (· < ·)
+  | a, b => by dsimp [(· < ·)] <;> infer_instance
+#align znum.decidable_lt Znum.decidableLt
+
+instance decidableLe : @DecidableRel Znum (· ≤ ·)
+  | a, b => by dsimp [(· ≤ ·)] <;> infer_instance
+#align znum.decidable_le Znum.decidableLe
+
+end Znum
+
+namespace PosNum
+
+/-- Auxiliary definition for `pos_num.divmod`. -/
+def divmodAux (d : PosNum) (q r : Num) : Num × Num :=
+  match Num.ofZnum' (Num.sub' r (Num.pos d)) with
+  | some r' => (Num.bit1 q, r')
+  | none => (Num.bit0 q, r)
+#align pos_num.divmod_aux PosNum.divmodAux
+
+/-- `divmod x y = (y / x, y % x)`.
+  -/
+def divmod (d : PosNum) : PosNum → Num × Num
+  | bit0 n =>
+    let (q, r₁) := divmod n
+    divmodAux d q (Num.bit0 r₁)
+  | bit1 n =>
+    let (q, r₁) := divmod n
+    divmodAux d q (Num.bit1 r₁)
+  | 1 => divmodAux d 0 1
+#align pos_num.divmod PosNum.divmod
+
+/-- Division of `pos_num`,
+  -/
+def div' (n d : PosNum) : Num :=
+  (divmod d n).1
+#align pos_num.div' PosNum.div'
+
+/-- Modulus of `pos_num`s.
+  -/
+def mod' (n d : PosNum) : Num :=
+  (divmod d n).2
+#align pos_num.mod' PosNum.mod'
+
+/-
+  private def sqrt_aux1 (b : pos_num) (r n : num) : num × num :=
+  match num.of_znum' (n.sub' (r + num.pos b)) with
+  | some n' := (r.div2 + num.pos b, n')
+  | none := (r.div2, n)
+  end
+
+  private def sqrt_aux : pos_num → num → num → num
+  | b@(bit0 b') r n := let (r', n') := sqrt_aux1 b r n in sqrt_aux b' r' n'
+  | b@(bit1 b') r n := let (r', n') := sqrt_aux1 b r n in sqrt_aux b' r' n'
+  | 1           r n := (sqrt_aux1 1 r n).1
+  -/
+/-
+
+def sqrt_aux : ℕ → ℕ → ℕ → ℕ
+| b r n := if b0 : b = 0 then r else
+  let b' := shiftr b 2 in
+  have b' < b, from sqrt_aux_dec b0,
+  match (n - (r + b : ℕ) : ℤ) with
+  | (n' : ℕ) := sqrt_aux b' (div2 r + b) n'
+  | _ := sqrt_aux b' (div2 r) n
+  end
+
+/-- `sqrt n` is the square root of a natural number `n`. If `n` is not a
+  perfect square, it returns the largest `k:ℕ` such that `k*k ≤ n`. -/
+def sqrt (n : ℕ) : ℕ :=
+match size n with
+| 0      := 0
+| succ s := sqrt_aux (shiftl 1 (bit0 (div2 s))) 0 n
+end
+-/
+end PosNum
+
+namespace Num
+
+/-- Division of `num`s, where `x / 0 = 0`.
+  -/
+def div : Num → Num → Num
+  | 0, _ => 0
+  | _, 0 => 0
+  | Pos n, Pos d => PosNum.div' n d
+#align num.div Num.div
+
+/-- Modulus of `num`s.
+  -/
+def mod : Num → Num → Num
+  | 0, _ => 0
+  | n, 0 => n
+  | Pos n, Pos d => PosNum.mod' n d
+#align num.mod Num.mod
+
+instance : Div Num :=
+  ⟨Num.div⟩
+
+instance : Mod Num :=
+  ⟨Num.mod⟩
+
+/-- Auxiliary definition for `num.gcd`. -/
+def gcdAux : Nat → Num → Num → Num
+  | 0, a, b => b
+  | Nat.succ n, 0, b => b
+  | Nat.succ n, a, b => gcd_aux n (b % a) a
+#align num.gcd_aux Num.gcdAux
+
+/-- Greatest Common Divisor (GCD) of two `num`s.
+  -/
+def gcd (a b : Num) : Num :=
+  if a ≤ b then gcdAux (a.natSize + b.natSize) a b else gcdAux (b.natSize + a.natSize) b a
+#align num.gcd Num.gcd
+
+end Num
+
+namespace Znum
+
+/-- Division of `znum`, where `x / 0 = 0`.
+  -/
+def div : Znum → Znum → Znum
+  | 0, _ => 0
+  | _, 0 => 0
+  | Pos n, Pos d => Num.toZnum (PosNum.div' n d)
+  | Pos n, neg d => Num.toZnumNeg (PosNum.div' n d)
+  | neg n, Pos d => neg (PosNum.pred' n / Num.pos d).succ'
+  | neg n, neg d => pos (PosNum.pred' n / Num.pos d).succ'
+#align znum.div Znum.div
+
+/-- Modulus of `znum`s.
+  -/
+def mod : Znum → Znum → Znum
+  | 0, d => 0
+  | Pos n, d => Num.toZnum (Num.pos n % d.abs)
+  | neg n, d => d.abs.sub' (PosNum.pred' n % d.abs).succ
+#align znum.mod Znum.mod
+
+instance : Div Znum :=
+  ⟨Znum.div⟩
+
+instance : Mod Znum :=
+  ⟨Znum.mod⟩
+
+/-- Greatest Common Divisor (GCD) of two `znum`s.
+  -/
+def gcd (a b : Znum) : Num :=
+  a.abs.gcd b.abs
+#align znum.gcd Znum.gcd
+
+end Znum
+
+section
+
+variable {α : Type _} [Zero α] [One α] [Add α] [Neg α]
+
+/-- `cast_znum` casts a `znum` into any type which has `0`, `1`, `+` and `neg`
+  -/
+def castZnum : Znum → α
+  | 0 => 0
+  | Znum.pos p => p
+  | Znum.neg p => -p
+#align cast_znum castZnum
+
+-- see Note [coercion into rings]
+instance (priority := 900) znumCoe : CoeTC Znum α :=
+  ⟨castZnum⟩
+#align znum_coe znumCoe
+
+instance : Repr Znum :=
+  ⟨fun n => repr (n : ℤ)⟩
+
+end
+

--- a/Mathlib/Data/Num/Basic.lean
+++ b/Mathlib/Data/Num/Basic.lean
@@ -6,6 +6,7 @@ Authors: Leonardo de Moura, Mario Carneiro
 import Mathlib.Mathport.Rename
 import Mathlib.Init.Data.Nat.Lemmas
 import Mathlib.Init.Data.Int.Basic
+import Lean.Linter.Deprecated
 /-!
 # Binary representation of integers using inductive types
 
@@ -185,6 +186,8 @@ section
 
 variable {α : Type _} [One α] [Add α]
 
+set_option linter.deprecated false
+
 /-- `castPosNum` casts a `PosNum` into any type which has `1` and `+`. -/
 @[deprecated] def castPosNum : PosNum → α
   | 1 => 1
@@ -193,20 +196,22 @@ variable {α : Type _} [One α] [Add α]
 #align cast_pos_num castPosNum
 
 /-- `castNum` casts a `Num` into any type which has `0`, `1` and `+`. -/
-def castNum [Zero α] : Num → α
+@[deprecated] def castNum [Zero α] : Num → α
   | 0 => 0
   | Num.pos p => castPosNum p
 #align cast_num castNum
 
 -- see Note [coercion into rings]
-instance (priority := 900) posNumCoe : CoeTC PosNum α :=
+@[deprecated] instance (priority := 900) posNumCoe : CoeTC PosNum α :=
   ⟨castPosNum⟩
 #align pos_num_coe posNumCoe
 
 -- see Note [coercion into rings]
-instance (priority := 900) numNatCoe [Zero α] : CoeTC Num α :=
+@[deprecated] instance (priority := 900) numNatCoe [Zero α] : CoeTC Num α :=
   ⟨castNum⟩
 #align num_nat_coe numNatCoe
+
+set_option linter.deprecated true
 
 instance : Repr PosNum :=
   ⟨fun _ n => repr (n : ℕ)⟩

--- a/Mathlib/Data/Num/Basic.lean
+++ b/Mathlib/Data/Num/Basic.lean
@@ -3,7 +3,9 @@ Copyright (c) 2014 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura, Mario Carneiro
 -/
-import Mathlib
+import Mathlib.Mathport.Rename
+import Mathlib.Init.Data.Nat.Lemmas
+import Mathlib.Init.Data.Int.Basic
 /-!
 # Binary representation of integers using inductive types
 
@@ -320,7 +322,7 @@ def ofNat' : ℕ → Num
   | n + 1 => if (n + 1) % 2 = 0
     then Num.bit0 (ofNat' ((n + 1) / 2))
     else Num.bit1 (ofNat' ((n + 1) / 2))
-decreasing_by (exact Nat.div_lt_self (Nat.succ_pos n) (show 1 < 2 from le_rfl))
+decreasing_by (exact Nat.div_lt_self (Nat.succ_pos n) (Nat.le_refl 2))
 #align num.of_nat' Num.ofNat'
 
 end Num
@@ -383,7 +385,7 @@ protected def bitm1 : ZNum → ZNum
 
 /-- Converts an `Int` to a `ZNum`. -/
 def ofInt' : ℤ → ZNum
-  | (n : ℕ) => Num.toZNum (Num.ofNat' n)
+  | Int.ofNat n => Num.toZNum (Num.ofNat' n)
   | Int.negSucc n => Num.toZNumNeg (Num.ofNat' (n + 1))
 #align znum.of_int' ZNum.ofInt'
 


### PR DESCRIPTION
Mathlib3 SHA: aab56fd783b265168f660d6b46709961153c4c20

Notes:

1. This is the first file I've ported, so I'm sure I've made some errors somewhere; be on the lookout!
2. The `deriving has_reflect` instances have been omitted because the corresponding class `Lean.ToExpr` has no default implementation currently, and these can safely be omitted for now.
3. `castPosNum` (and a few friends nearby) are marked as deprecated because it uses the deprecated `bit0` and `bit1` in its implementation.
4. `Num.ofNat'` needed to be redefined from scratch because there is no corresponding declaration for `nat.binary_rec` in Lean 4.