### PR TITLE
[Merged by Bors] - perf: optimizations in `norm_num` and `ring`

### DIFF
--- a/Mathlib/Tactic/NormNum/Basic.lean
+++ b/Mathlib/Tactic/NormNum/Basic.lean
@@ -55,8 +55,8 @@ theorem isNat_one (α) [AddMonoidWithOne α] : IsNat (One.one : α) (nat_lit 1) 
   match e with
   | ~q(One.one) => return (.isNat sα (mkRawNatLit 1) q(isNat_one $α) : Result q(One.one))
 
-theorem isNat_ofNat (α : Type u_1) [AddMonoidWithOne α] (n : ℕ) [OfNat α n]
-  [LawfulOfNat α n] : IsNat (OfNat.ofNat n : α) n := ⟨LawfulOfNat.eq_ofNat.symm⟩
+theorem isNat_ofNat (α : Type u_1) [AddMonoidWithOne α] {a : α} {n : ℕ}
+    (h : n = a) : IsNat a n := ⟨h.symm⟩
 
 /-- The `norm_num` extension which identifies an expression `OfNat.ofNat n`, returning `n`. -/
 @[norm_num OfNat.ofNat _] def evalOfNat : NormNumExt where eval {u α} e := do
@@ -65,9 +65,9 @@ theorem isNat_ofNat (α : Type u_1) [AddMonoidWithOne α] (n : ℕ) [OfNat α n]
   | ~q(@OfNat.ofNat _ $n $oα) =>
     let n : Q(ℕ) ← whnf n
     guard n.isNatLit
-    have : Q(OfNat $α $n) := oα
-    _ ← synthInstanceQ (q(LawfulOfNat $α $n) : Q(Prop))
-    return (.isNat sα n q(isNat_ofNat $α $n) : Result q((OfNat.ofNat $n : $α)))
+    let ⟨a, (pa : Q($n = $e))⟩ ← mkOfNat α sα n
+    guard <|← isDefEq a e
+    return .isNat sα n (q(isNat_ofNat $α $pa) : Expr)
 
 theorem isNat_cast {R} [AddMonoidWithOne R] (n m : ℕ) :
     IsNat n m → IsNat (n : R) m := by rintro ⟨⟨⟩⟩; exact ⟨rfl⟩
@@ -79,7 +79,7 @@ theorem isNat_cast {R} [AddMonoidWithOne R] (n m : ℕ) :
   | ~q(Nat.cast $a) =>
     let ⟨na, pa⟩ ← deriveNat a q(instAddMonoidWithOneNat)
     let pa : Q(IsNat $a $na) := pa
-    return (.isNat sα na q(@isNat_cast $α _ $a $na $pa) : Result q((Nat.cast $a : $α)))
+    return (.isNat sα na q(@isNat_cast $α _ $a $na $pa) : Result q(Nat.cast $a : $α))
 
 theorem isNat_int_cast {R} [Ring R] (n : ℤ) (m : ℕ) :
     IsNat n m → IsNat (n : R) m := by rintro ⟨⟨⟩⟩; exact ⟨by simp⟩
@@ -96,10 +96,10 @@ theorem isInt_cast {R} [Ring R] (n m : ℤ) :
     | .isNat _ na pa =>
       let sα : Q(AddMonoidWithOne $α) := q(instAddMonoidWithOne)
       let pa : Q(@IsNat _ instAddMonoidWithOne $a $na) := pa
-      return (.isNat sα na q(@isNat_int_cast $α _ $a $na $pa) : Result q((Int.cast $a : $α)))
+      return (.isNat sα na q(@isNat_int_cast $α _ $a $na $pa) : Result q(Int.cast $a : $α))
     | .isNegNat _ na pa =>
       let pa : Q(@IsInt _ instRingInt $a (.negOfNat $na)) := pa
-      return (.isNegNat rα na q(isInt_cast $a (.negOfNat $na) $pa) : Result q((Int.cast $a : $α)))
+      return (.isNegNat rα na q(isInt_cast $a (.negOfNat $na) $pa) : Result q(Int.cast $a : $α))
     | _ => failure
 
 theorem isNat_add {α} [AddMonoidWithOne α] : {a b : α} → {a' b' c : ℕ} →

--- a/Mathlib/Tactic/NormNum/Core.lean
+++ b/Mathlib/Tactic/NormNum/Core.lean
@@ -43,20 +43,8 @@ of typeclass arguments required in each use of a number literal at type `α`.
 -/
 @[simp] def _root_.Nat.rawCast [AddMonoidWithOne α] (n : ℕ) : α := n
 
-/-- Asserting that the `OfNat α n` instance provides the same value as the coercion. -/
-class LawfulOfNat (α) [AddMonoidWithOne α] (n) [OfNat α n] : Prop where
-  /-- Assert `n = (OfNat.ofNat n α)`, with the parametrising instance. -/
-  eq_ofNat : n = (@OfNat.ofNat _ n ‹_› : α)
-
-instance (α) [AddMonoidWithOne α] [Nat.AtLeastTwo n] : LawfulOfNat α n := ⟨rfl⟩
-instance (α) [AddMonoidWithOne α] : LawfulOfNat α (nat_lit 0) := ⟨Nat.cast_zero⟩
-instance (α) [AddMonoidWithOne α] : LawfulOfNat α (nat_lit 1) := ⟨Nat.cast_one⟩
-instance : LawfulOfNat ℕ n := ⟨show n = Nat.cast n by simp⟩
-instance : LawfulOfNat ℤ n := ⟨show Int.ofNat n = Nat.cast n by simp⟩
-
-theorem IsNat.to_eq [AddMonoidWithOne α] (n) [OfNat α n] [LawfulOfNat α n] :
-    (a : α) → IsNat a n → a = OfNat.ofNat n
-  | _, ⟨rfl⟩ => LawfulOfNat.eq_ofNat
+theorem IsNat.to_eq [AddMonoidWithOne α] {n} : {a a' : α} → IsNat a n → n = a' → a = a'
+  | _, _, ⟨rfl⟩, rfl => rfl
 
 theorem IsNat.to_raw_eq [AddMonoidWithOne α] : IsNat (a : α) n → a = n.rawCast
   | ⟨e⟩ => e
@@ -91,12 +79,12 @@ theorem IsInt.to_raw_eq [Ring α] : IsInt (a : α) n → a = n.rawCast
 
 theorem IsInt.of_raw (α) [Ring α] (n : ℤ) : IsInt (n.rawCast : α) n := ⟨rfl⟩
 
-theorem IsInt.neg_to_eq {α} [Ring α] (n) [OfNat α n] [LawfulOfNat α n] :
-    (a : α) → IsInt a (.negOfNat n) → a = -OfNat.ofNat n
-  | _, ⟨rfl⟩ => by simp [Int.negOfNat_eq, Int.cast_neg]; apply LawfulOfNat.eq_ofNat
+theorem IsInt.neg_to_eq {α} [Ring α] {n} :
+    {a a' : α} → IsInt a (.negOfNat n) → n = a' → a = -a'
+  | _, _, ⟨rfl⟩, rfl => by simp [Int.negOfNat_eq, Int.cast_neg]
 
-theorem IsInt.nonneg_to_eq {α} [Ring α] (n) [OfNat α n] [LawfulOfNat α n]
-    (a : α) (h : IsInt a (.ofNat n)) : a = OfNat.ofNat n := h.to_isNat.to_eq
+theorem IsInt.nonneg_to_eq {α} [Ring α] {n}
+    {a a' : α} (h : IsInt a (.ofNat n)) (e : n = a') : a = a' := h.to_isNat.to_eq e
 
 /-- Represent an integer as a typed expression. -/
 def mkRawIntLit (n : ℤ) : Q(ℤ) :=
@@ -245,17 +233,41 @@ def Result.ofRawInt {α : Q(Type u)} (n : ℤ) (e : Q($α)) : Result e :=
     .isNegNat rα lit (q(IsInt.of_raw $α (.negOfNat $lit)) : Expr)
 
 /--
-Convert a `Result` to a `Simp.Result`.
+Constructs an `ofNat` application `a'` with the canonical instance, together with a proof that
+the instance is equal to the result of `Nat.cast` on the given `AddMonoidWithOne` instance.
+
+This function is performance-critical, as many higher level tactics have to construct numerals.
+So rather than using typeclass search we hardcode the (relatively small) set of solutions
+to the typeclass problem.
 -/
+def mkOfNat (α : Q(Type u)) (_sα : Q(AddMonoidWithOne $α)) (lit : Q(ℕ)) :
+    MetaM ((a' : Q($α)) × Q($lit = $a')) := do
+  if α.isConstOf ``Nat then
+    let a' : Q(ℕ) := q(OfNat.ofNat $lit : ℕ)
+    pure ⟨a', (q(Eq.refl $a') : Expr)⟩
+  else if α.isConstOf ``Int then
+    let a' : Q(ℤ) := q(OfNat.ofNat $lit : ℤ)
+    pure ⟨a', (q(Eq.refl $a') : Expr)⟩
+  else
+    let some n := lit.natLit? | failure
+    match n with
+    | 0 => pure ⟨q(0 : $α), (q(Nat.cast_zero (R := $α)) : Expr)⟩
+    | 1 => pure ⟨q(1 : $α), (q(Nat.cast_one (R := $α)) : Expr)⟩
+    | k+2 =>
+      let k : Q(ℕ) := mkRawNatLit k
+      let _x : Q(Nat.AtLeastTwo $lit) :=
+        (q(instAtLeastTwoHAddNatInstHAddInstAddNatOfNat (n := $k)) : Expr)
+      let a' : Q($α) := q(OfNat.ofNat $lit)
+      pure ⟨a', (q(Eq.refl $a') : Expr)⟩
+
+/-- Convert a `Result` to a `Simp.Result`. -/
 def Result.toSimpResult {α : Q(Type u)} {e : Q($α)} : Result e → MetaM Simp.Result
-  | .isNat _sα lit p => do
-    let _ofNatInst ← synthInstanceQ (q(OfNat $α $lit) : Q(Type u))
-    let _lawfulInst ← synthInstanceQ (q(LawfulOfNat $α $lit) : Q(Prop))
-    return { expr := q((OfNat.ofNat $lit : $α)), proof? := q(IsNat.to_eq $lit $e $p) }
+  | .isNat sα lit p => do
+    let ⟨a', pa'⟩ ← mkOfNat α sα lit
+    return { expr := a', proof? := q(IsNat.to_eq $p $pa') }
   | .isNegNat _rα lit p => do
-    let _ofNatInst ← synthInstanceQ (q(OfNat $α $lit) : Q(Type u))
-    let _lawfulInst ← synthInstanceQ (q(LawfulOfNat $α $lit) : Q(Prop))
-    return { expr := q(-(OfNat.ofNat $lit : $α)), proof? := q(IsInt.neg_to_eq $lit $e $p) }
+    let ⟨a', pa'⟩ ← mkOfNat α q(NonUnitalNonAssocSemiring.toAddMonoidWithOne) lit
+    return { expr := q(-$a'), proof? := q(IsInt.neg_to_eq $p $pa') }
   | .isRat _ .. => failure -- TODO
 
 /--
@@ -299,18 +311,19 @@ def derive {α : Q(Type u)} (e : Q($α)) (post := false) : MetaM (Result e) := d
     let lit : Q(ℕ) := e
     return .isNat (q(instAddMonoidWithOneNat) : Q(AddMonoidWithOne ℕ))
       lit (q(IsNat.raw_refl $lit) : Expr)
-  let s ← saveState
-  let arr ← (normNumExt.getState (← getEnv)).2.getMatch e
-  for ext in arr do
-    if (bif post then ext.post else ext.pre) then
-      try
-        let new ← ext.eval e
-        trace[Tactic.norm_num] "{e} ==> {new}"
-        return new
-      catch err =>
-        trace[Tactic.norm_num] "{e} failed: {err.toMessageData}"
-        s.restore
-  throwError "{e}: no norm_nums apply"
+  profileitM Exception "norm_num" (← getOptions) do
+    let s ← saveState
+    let arr ← (normNumExt.getState (← getEnv)).2.getMatch e
+    for ext in arr do
+      if (bif post then ext.post else ext.pre) then
+        try
+          let new ← ext.eval e
+          trace[Tactic.norm_num] "{e} ==> {new}"
+          return new
+        catch err =>
+          trace[Tactic.norm_num] "{e} failed: {err.toMessageData}"
+          s.restore
+    throwError "{e}: no norm_nums apply"
 
 /-- Run each registered `norm_num` extension on a typed expression `e : α`,
 returning a typed expression `lit : ℕ`, and a proof of `isNat e lit`. -/

--- a/Mathlib/Tactic/Ring/Basic.lean
+++ b/Mathlib/Tactic/Ring/Basic.lean
@@ -156,7 +156,7 @@ inductive ExProd : ∀ {α : Q(Type u)}, Q(CommSemiring $α) → (e : Q($α)) �
 /-- A polynomial expression, which is a sum of monomials. -/
 inductive ExSum : ∀ {α : Q(Type u)}, Q(CommSemiring $α) → (e : Q($α)) → Type
   /-- Zero is a polynomial. `e` is the expression `0`. -/
-  | zero {α : Q(Type u)} {sα : Q(CommSemiring $α)} : ExSum sα q((0 : $α))
+  | zero {α : Q(Type u)} {sα : Q(CommSemiring $α)} : ExSum sα q(0 : $α)
   /-- A sum `a + b` is a polynomial if `a` is a monomial and `b` is another polynomial. -/
   | add {α : Q(Type u)} {sα : Q(CommSemiring $α)} {a b : Q($α)} :
     ExProd sα a → ExSum sα b → ExSum sα q($a + $b)
@@ -256,7 +256,7 @@ Constructs the expression corresponding to `.const n`.
 -/
 def ExProd.mkNat (n : ℕ) : (e : Q($α)) × ExProd sα e :=
   let lit : Q(ℕ) := mkRawNatLit n
-  ⟨q((($lit).rawCast : $α)), .const n⟩
+  ⟨q(($lit).rawCast : $α), .const n⟩
 
 /--
 Constructs the expression corresponding to `.const (-n)`.
@@ -264,7 +264,7 @@ Constructs the expression corresponding to `.const (-n)`.
 -/
 def ExProd.mkNegNat (_ : Q(Ring $α)) (n : ℕ) : (e : Q($α)) × ExProd sα e :=
   let lit : Q(ℕ) := mkRawNatLit n
-  ⟨q(((Int.negOfNat $lit).rawCast : $α)), .const (-n)⟩
+  ⟨q((Int.negOfNat $lit).rawCast : $α), .const (-n)⟩
 
 section
 variable {sα}
@@ -333,7 +333,7 @@ theorem add_pf_add_overlap
 
 theorem add_pf_add_overlap_zero
     (h : IsNat (a₁ + b₁) (nat_lit 0)) (h₄ : a₂ + b₂ = c) : (a₁ + a₂ : R) + (b₁ + b₂) = c := by
-  subst_vars; rw [add_add_add_comm, h.to_eq, add_pf_zero_add]
+  subst_vars; rw [add_add_add_comm, h.1, Nat.cast_zero, add_pf_zero_add]
 
 theorem add_pf_add_lt (a₁ : R) (_ : a₂ + b = c) : (a₁ + a₂) + b = a₁ + c := by simp [*, add_assoc]
 
@@ -900,43 +900,52 @@ This is the main driver of `ring`, which calls out to `evalAdd`, `evalMul` etc.
 -/
 partial def eval {u} {α : Q(Type u)} (sα : Q(CommSemiring $α))
     (c : Cache α) (e : Q($α)) : RingM (Result (ExSum sα) e) := do
-  match e with
-  | ~q($a + $b) =>
-    let ⟨_, va, pa⟩ ← eval sα c a
-    let ⟨_, vb, pb⟩ ← eval sα c b
-    let ⟨c, vc, p⟩ := evalAdd sα va vb
-    pure ⟨c, vc, (q(add_congr $pa $pb $p) : Expr)⟩
-  | ~q($a * $b) =>
-    let ⟨_, va, pa⟩ ← eval sα c a
-    let ⟨_, vb, pb⟩ ← eval sα c b
-    let ⟨c, vc, p⟩ := evalMul sα va vb
-    pure ⟨c, vc, (q(mul_congr $pa $pb $p) : Expr)⟩
-  | ~q(($a : ℕ) • $b) =>
-    let ⟨_, va, pa⟩ ← eval sℕ .nat a
-    let ⟨_, vb, pb⟩ ← eval sα c b
-    let ⟨c, vc, p⟩ ← evalNSMul sα va vb
-    pure ⟨c, vc, (q(nsmul_congr $pa $pb $p) : Expr)⟩
-  | ~q($a ^ $b) =>
-    let ⟨_, va, pa⟩ ← eval sα c a
-    let ⟨_, vb, pb⟩ ← eval sℕ .nat b
-    let ⟨c, vc, p⟩ := evalPow sα va vb
-    pure ⟨c, vc, (q(pow_congr $pa $pb $p) : Expr)⟩
-  | _ =>
-    let els := do
-      try evalCast sα (← derive e)
-      catch _ => evalAtom sα e
-    let some rα := c.rα | els
-    match e with
+  let els := do
+    try evalCast sα (← derive e)
+    catch _ => evalAtom sα e
+  let .const n _ := (← withReducible <| whnf e).getAppFn | els
+  match n, c.rα with
+  | ``HAdd.hAdd, _ | ``Add.add, _ => match e with
+    | ~q($a + $b) =>
+      let ⟨_, va, pa⟩ ← eval sα c a
+      let ⟨_, vb, pb⟩ ← eval sα c b
+      let ⟨c, vc, p⟩ := evalAdd sα va vb
+      pure ⟨c, vc, (q(add_congr $pa $pb $p) : Expr)⟩
+    | _ => els
+  | ``HMul.hMul, _ | ``Mul.mul, _ => match e with
+    | ~q($a * $b) =>
+      let ⟨_, va, pa⟩ ← eval sα c a
+      let ⟨_, vb, pb⟩ ← eval sα c b
+      let ⟨c, vc, p⟩ := evalMul sα va vb
+      pure ⟨c, vc, (q(mul_congr $pa $pb $p) : Expr)⟩
+    | _ => els
+  | ``HasSmul.smul, _ => match e with
+    | ~q(($a : ℕ) • $b) =>
+      let ⟨_, va, pa⟩ ← eval sℕ .nat a
+      let ⟨_, vb, pb⟩ ← eval sα c b
+      let ⟨c, vc, p⟩ ← evalNSMul sα va vb
+      pure ⟨c, vc, (q(nsmul_congr $pa $pb $p) : Expr)⟩
+    | _ => els
+  | ``HPow.hPow, _ | ``Pow.pow, _ => match e with
+    | ~q($a ^ $b) =>
+      let ⟨_, va, pa⟩ ← eval sα c a
+      let ⟨_, vb, pb⟩ ← eval sℕ .nat b
+      let ⟨c, vc, p⟩ := evalPow sα va vb
+      pure ⟨c, vc, (q(pow_congr $pa $pb $p) : Expr)⟩
+    | _ => els
+  | ``Neg.neg, some rα => match e with
     | ~q(-$a) =>
       let ⟨_, va, pa⟩ ← eval sα c a
       let ⟨b, vb, p⟩ := evalNeg sα rα va
       pure ⟨b, vb, (q(neg_congr $pa $p) : Expr)⟩
+  | ``HSub.hSub, some rα | ``Sub.sub, some rα => match e with
     | ~q($a - $b) => do
       let ⟨_, va, pa⟩ ← eval sα c a
       let ⟨_, vb, pb⟩ ← eval sα c b
       let ⟨c, vc, p⟩ := evalSub sα rα va vb
       pure ⟨c, vc, (q(sub_congr $pa $pb $p) : Expr)⟩
     | _ => els
+  | _, _ => els
 
 open Lean Parser.Tactic Elab Command Elab.Tactic Meta Qq
 
@@ -963,13 +972,14 @@ def proveEq (g : MVarId) : RingM Unit := do
   have e₁ : Q($α) := e₁; have e₂ : Q($α) := e₂
   let sα ← synthInstanceQ (q(CommSemiring $α) : Q(Type u))
   let c := { rα := (← trySynthInstanceQ (q(Ring $α) : Q(Type u))).toOption }
-  let ⟨a, va, pa⟩ ← eval sα c e₁
-  let ⟨b, vb, pb⟩ ← eval sα c e₂
-  unless va.eq vb do
-    let g ← mkFreshExprMVar (← (← ringCleanupRef.get) q($a = $b))
-    throwError "ring failed, ring expressions not equal\n{g.mvarId!}"
-  let pb : Q($e₂ = $a) := pb
-  g.assign q(of_eq $pa $pb)
+  profileitM Exception "ring" (← getOptions) do
+    let ⟨a, va, pa⟩ ← eval sα c e₁
+    let ⟨b, vb, pb⟩ ← eval sα c e₂
+    unless va.eq vb do
+      let g ← mkFreshExprMVar (← (← ringCleanupRef.get) q($a = $b))
+      throwError "ring failed, ring expressions not equal\n{g.mvarId!}"
+    let pb : Q($e₂ = $a) := pb
+    g.assign q(of_eq $pa $pb)
 
 /--
 Tactic for solving equations of *commutative* (semi)rings,


### PR DESCRIPTION
With a little help from perf and hotspot, I managed to find and improve some expensive bits in `norm_num` and `ring`. As a result, the time spent in `linear_combination` in the linear_combination test suite (which is spent almost 100% in `ring1`, of which about 35% is in `norm_num`) is decreased by just over 50%.