### PR TITLE
feat: port Data/RBTree/Init as deprecated definitions

### DIFF
--- a/Mathlib/Data/RBTree/Basic.lean
+++ b/Mathlib/Data/RBTree/Basic.lean
@@ -1,0 +1,91 @@
+/-
+Copyright (c) 2017 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Leonardo de Moura
+-/
+import Mathlib.Data.RBTree.Init
+
+/-!
+# Basic thorems on search invariants
+
+Ported with `sorry`s to preserve theorems
+-/
+
+universe u
+
+namespace RRNode
+
+variable {α : Type u}
+
+inductive IsNodeOf : RBNode α → RBNode α → α → RBNode α → Prop := sorry
+
+def Lift (lt : α → α → Prop) : Option α → Option α → Prop := sorry
+
+inductive IsSearchable (lt : α → α → Prop) : RBNode α → Option α → Option α → Prop := sorry
+
+
+open RBNode (Mem)
+
+open IsSearchable
+
+section IsSearchableLemmas
+
+variable {lt : α → α → Prop}
+
+theorem lo_lt_hi {t : RBNode α} {lt} [IsTrans α lt] :
+    ∀ {lo hi}, IsSearchable lt t lo hi → Lift lt lo hi := sorry
+
+theorem is_searchable_of_is_searchable_of_incomp [IsStrictWeakOrder α lt] {t} :
+    ∀ {lo hi hi'} (hc : ¬lt hi' hi ∧ ¬lt hi hi') (hs : IsSearchable lt t lo (some hi)),
+      IsSearchable lt t lo (some hi') := sorry
+
+theorem is_searchable_of_incomp_of_is_searchable [IsStrictWeakOrder α lt] {t} :
+    ∀ {lo lo' hi} (hc : ¬lt lo' lo ∧ ¬lt lo lo') (hs : IsSearchable lt t (some lo) hi),
+      IsSearchable lt t (some lo') hi := sorry
+
+theorem is_searchable_some_low_of_is_searchable_of_lt {t} [IsTrans α lt] :
+    ∀ {lo hi lo'}
+      (hlt : lt lo' lo)
+      (hs : IsSearchable lt t (some lo) hi), IsSearchable lt t (some lo') hi := sorry
+
+theorem is_searchable_none_low_of_is_searchable_some_low {t} :
+    ∀ {y hi} (hlt : IsSearchable lt t (some y) hi), IsSearchable lt t none hi := sorry
+
+theorem is_searchable_some_high_of_is_searchable_of_lt {t} [IsTrans α lt] :
+    ∀ {lo hi hi'}
+      (hlt : lt hi hi')
+      (hs : IsSearchable lt t lo (some hi)), IsSearchable lt t lo (some hi') := sorry
+
+theorem is_searchable_none_high_of_is_searchable_some_high {t} :
+    ∀ {lo y} (hlt : IsSearchable lt t lo (some y)), IsSearchable lt t lo none := sorry
+
+theorem range [IsStrictWeakOrder α lt] {t : RBNode α} {x} :
+    ∀ {lo hi}, IsSearchable lt t lo hi →
+      Mem lt x t → Lift lt lo (some x) ∧ Lift lt (some x) hi := sorry
+
+theorem lt_of_mem_left [IsStrictWeakOrder α lt] {y : α} {t l r : RBNode α} :
+    ∀ {lo hi}, IsSearchable lt t lo hi → IsNodeOf t l y r → ∀ {x}, Mem lt x l → lt x y := sorry
+
+theorem lt_of_mem_right [IsStrictWeakOrder α lt] {y : α} {t l r : RBNode α} :
+    ∀ {lo hi}, IsSearchable lt t lo hi → IsNodeOf t l y r → ∀ {z}, Mem lt z r → lt y z := sorry
+
+theorem lt_of_mem_left_right [IsStrictWeakOrder α lt] {y : α} {t l r : RBNode α} :
+    ∀ {lo hi}, IsSearchable lt t lo hi →
+      IsNodeOf t l y r → ∀ {x z}, Mem lt x l → Mem lt z r → lt x z := sorry
+
+end IsSearchableLemmas
+
+inductive IsRedBlack : RBNode α → Color → Nat → Prop := sorry
+
+open IsRedBlack
+
+theorem depth_min : ∀ {c n} {t : RBNode α}, IsRedBlack t c n → n ≤ depth min t := sorry
+
+theorem depth_max' : ∀ {c n} {t : RBNode α}, IsRedBlack t c n → depth max t ≤ upper c n := sorry
+
+theorem depth_max {c n} {t : RBNode α} (h : IsRedBlack t c n) : depth max t ≤ 2 * n + 1 := sorry
+
+theorem balanced {c n} {t : RBNode α} (h : IsRedBlack t c n) :
+    depth max t ≤ 2 * depth min t + 1 := sorry
+
+end RBNode

--- a/Mathlib/Data/RBTree/Basic.lean
+++ b/Mathlib/Data/RBTree/Basic.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura
 -/
 import Mathlib.Data.RBTree.Init
+import Mathlib.Init.Algebra.Classes
 
 /-!
 # Basic thorems on search invariants
@@ -12,25 +13,33 @@ Ported with `sorry`s to preserve theorems
 -/
 
 universe u
+section
+set_option linter.deprecated false
+-- FIXME: remove this when the sorries are gone
+set_option warningAsError false
+-- FIXME: remove this when theorems are ported
+set_option checkBinderAnnotations false
 
 namespace RRNode
 
 variable {α : Type u}
 
-inductive IsNodeOf : RBNode α → RBNode α → α → RBNode α → Prop := sorry
+inductive IsNodeOf : RBNode α → RBNode α → α → RBNode α → Prop where
 
 def Lift (lt : α → α → Prop) : Option α → Option α → Prop := sorry
 
-inductive IsSearchable (lt : α → α → Prop) : RBNode α → Option α → Option α → Prop := sorry
+inductive IsSearchable (lt : α → α → Prop) : RBNode α → Option α → Option α → Prop where
 
 
-open RBNode (Mem)
+open RBNode
 
 open IsSearchable
 
 section IsSearchableLemmas
 
 variable {lt : α → α → Prop}
+
+--FIXME: commented to silence errors
 
 theorem lo_lt_hi {t : RBNode α} {lt} [IsTrans α lt] :
     ∀ {lo hi}, IsSearchable lt t lo hi → Lift lt lo hi := sorry
@@ -59,6 +68,7 @@ theorem is_searchable_some_high_of_is_searchable_of_lt {t} [IsTrans α lt] :
 theorem is_searchable_none_high_of_is_searchable_some_high {t} :
     ∀ {lo y} (hlt : IsSearchable lt t lo (some y)), IsSearchable lt t lo none := sorry
 
+
 theorem range [IsStrictWeakOrder α lt] {t : RBNode α} {x} :
     ∀ {lo hi}, IsSearchable lt t lo hi →
       Mem lt x t → Lift lt lo (some x) ∧ Lift lt (some x) hi := sorry
@@ -75,7 +85,7 @@ theorem lt_of_mem_left_right [IsStrictWeakOrder α lt] {y : α} {t l r : RBNode 
 
 end IsSearchableLemmas
 
-inductive IsRedBlack : RBNode α → Color → Nat → Prop := sorry
+inductive IsRedBlack : RBNode α → Color → Nat → Prop where
 
 open IsRedBlack
 
@@ -88,4 +98,4 @@ theorem depth_max {c n} {t : RBNode α} (h : IsRedBlack t c n) : depth max t ≤
 theorem balanced {c n} {t : RBNode α} (h : IsRedBlack t c n) :
     depth max t ≤ 2 * depth min t + 1 := sorry
 
-end RBNode
+--end RBNode

--- a/Mathlib/Data/RBTree/Default.lean
+++ b/Mathlib/Data/RBTree/Default.lean
@@ -3,4 +3,4 @@ Copyright (c) 2017 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura
 -/
-import Mathbin.Data.RBTree.Main
+import Mathlib.Data.RBTree.Main

--- a/Mathlib/Data/RBTree/Default.lean
+++ b/Mathlib/Data/RBTree/Default.lean
@@ -1,0 +1,6 @@
+/-
+Copyright (c) 2017 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Leonardo de Moura
+-/
+import Mathbin.Data.RBTree.Main

--- a/Mathlib/Data/RBTree/Default.lean
+++ b/Mathlib/Data/RBTree/Default.lean
@@ -3,4 +3,6 @@ Copyright (c) 2017 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura
 -/
-import Mathlib.Data.RBTree.Main
+
+-- FIXME -- commented to silence errors
+--import Mathlib.Data.RBTree.Main

--- a/Mathlib/Data/RBTree/DefaultLt.lean
+++ b/Mathlib/Data/RBTree/DefaultLt.lean
@@ -9,5 +9,10 @@ Authors: Leonardo de Moura
 Ported with `sorry`s to surface deprecation in dependencies
 -/
 
+section
+set_option linter.deprecated false
+
 
 @[deprecated] def rbtree.default_lt : Unit := sorry
+
+end

--- a/Mathlib/Data/RBTree/DefaultLt.lean
+++ b/Mathlib/Data/RBTree/DefaultLt.lean
@@ -1,0 +1,13 @@
+/-
+Copyright (c) 2017 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Leonardo de Moura
+-/
+/-!
+# Deprecated tactic to autogenerate `lt`
+
+Ported with `sorry`s to surface deprecation in dependencies
+-/
+
+
+@[deprecated] def rbtree.default_lt : Unit := sorry

--- a/Mathlib/Data/RBTree/Find.lean
+++ b/Mathlib/Data/RBTree/Find.lean
@@ -3,13 +3,23 @@ Copyright (c) 2017 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura
 -/
-import Mathlib.Data.RBTee.Basic
+import Mathlib.Data.RBTree.Basic
+import Mathlib.Data.RBTree.Init
+import Mathlib.Init.Data.Ordering.Basic
+import Mathlib.Init.Algebra.Classes
 
 /-!
 # Basic thorems on ordering invariants
 
 Ported with `sorry`s to preserve theorems
 -/
+
+section
+set_option linter.deprecated false
+-- FIXME: remove this when the sorries are gone
+set_option warningAsError false
+-- FIXME: remove this when theorems are ported
+set_option checkBinderAnnotations false
 
 
 universe u
@@ -20,17 +30,18 @@ variable {α : Type u}
 
 @[elab_without_expected_type]
 theorem find.induction {p : RBNode α → Prop} (lt) [DecidableRel lt] (t x) (h₁ : p leaf)
-    (h₂ : ∀ (l y r) (h : CmpUsing lt x y = Ordering.lt) (ih : p l), p (red_node l y r))
-    (h₃ : ∀ (l y r) (h : CmpUsing lt x y = Ordering.eq), p (red_node l y r))
-    (h₄ : ∀ (l y r) (h : CmpUsing lt x y = Ordering.gt) (ih : p r), p (red_node l y r))
-    (h₅ : ∀ (l y r) (h : CmpUsing lt x y = Ordering.lt) (ih : p l), p (black_node l y r))
-    (h₆ : ∀ (l y r) (h : CmpUsing lt x y = Ordering.eq), p (black_node l y r))
-    (h₇ : ∀ (l y r) (h : CmpUsing lt x y = Ordering.gt) (ih : p r), p (black_node l y r)) : p t :=
+    (h₂ : ∀ (l y r) (h : cmpUsing lt x y = Ordering.lt) (ih : p l), p (red_node l y r))
+    (h₃ : ∀ (l y r) (h : cmpUsing lt x y = Ordering.eq), p (red_node l y r))
+    (h₄ : ∀ (l y r) (h : cmpUsing lt x y = Ordering.gt) (ih : p r), p (red_node l y r))
+    (h₅ : ∀ (l y r) (h : cmpUsing lt x y = Ordering.lt) (ih : p l), p (black_node l y r))
+    (h₆ : ∀ (l y r) (h : cmpUsing lt x y = Ordering.eq), p (black_node l y r))
+    (h₇ : ∀ (l y r) (h : cmpUsing lt x y = Ordering.gt) (ih : p r), p (black_node l y r)) : p t :=
     sorry
 
-theorem find_correct {t : RBNode α} {lt x} [DecidableRel lt] [IsStrictWeakOrder α lt] :
-    ∀ {lo hi} (hs : IsSearchable lt t lo hi), Mem lt x t ↔ ∃ y, find lt t x = some y ∧ x ≈[lt]y :=
-    sorry
+-- FIXME: commented to silence warning
+-- theorem find_correct {t : RBNode α} {lt x} [DecidableRel lt] [IsStrictWeakOrder α lt] :
+--     ∀ {lo hi} (hs : IsSearchable lt t lo hi), Mem lt x t ↔ ∃ y, find lt t x = some y ∧ x ≈[lt]y :=
+--     sorry
 
 theorem mem_of_mem_exact {lt} [IsIrrefl α lt] {x t} : MemExact x t → Mem lt x t := sorry
 

--- a/Mathlib/Data/RBTree/Find.lean
+++ b/Mathlib/Data/RBTree/Find.lean
@@ -1,0 +1,46 @@
+/-
+Copyright (c) 2017 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Leonardo de Moura
+-/
+import Mathlib.Data.RBTee.Basic
+
+/-!
+# Basic thorems on ordering invariants
+
+Ported with `sorry`s to preserve theorems
+-/
+
+
+universe u
+
+namespace RBNode
+
+variable {α : Type u}
+
+@[elab_without_expected_type]
+theorem find.induction {p : RBNode α → Prop} (lt) [DecidableRel lt] (t x) (h₁ : p leaf)
+    (h₂ : ∀ (l y r) (h : CmpUsing lt x y = Ordering.lt) (ih : p l), p (red_node l y r))
+    (h₃ : ∀ (l y r) (h : CmpUsing lt x y = Ordering.eq), p (red_node l y r))
+    (h₄ : ∀ (l y r) (h : CmpUsing lt x y = Ordering.gt) (ih : p r), p (red_node l y r))
+    (h₅ : ∀ (l y r) (h : CmpUsing lt x y = Ordering.lt) (ih : p l), p (black_node l y r))
+    (h₆ : ∀ (l y r) (h : CmpUsing lt x y = Ordering.eq), p (black_node l y r))
+    (h₇ : ∀ (l y r) (h : CmpUsing lt x y = Ordering.gt) (ih : p r), p (black_node l y r)) : p t :=
+    sorry
+
+theorem find_correct {t : RBNode α} {lt x} [DecidableRel lt] [IsStrictWeakOrder α lt] :
+    ∀ {lo hi} (hs : IsSearchable lt t lo hi), Mem lt x t ↔ ∃ y, find lt t x = some y ∧ x ≈[lt]y :=
+    sorry
+
+theorem mem_of_mem_exact {lt} [IsIrrefl α lt] {x t} : MemExact x t → Mem lt x t := sorry
+
+theorem find_correct_exact {t : RBNode α} {lt x} [DecidableRel lt] [IsStrictWeakOrder α lt] :
+    ∀ {lo hi} (hs : IsSearchable lt t lo hi), MemExact x t ↔ find lt t x = some x := sorry
+
+theorem eqv_of_find_some {t : RBNode α} {lt x y} [DecidableRel lt] :
+    ∀ {lo hi} (hs : IsSearchable lt t lo hi) (he : find lt t x = some y), x ≈[lt]y := sorry
+
+theorem find_eq_find_of_eqv {lt a b} [DecidableRel lt] [IsStrictWeakOrder α lt] {t : RBNode α} :
+    ∀ {lo hi} (hs : IsSearchable lt t lo hi) (heqv : a ≈[lt]b), find lt t a = find lt t b := sorry
+
+end RBNode

--- a/Mathlib/Data/RBTree/Init.lean
+++ b/Mathlib/Data/RBTree/Init.lean
@@ -17,6 +17,9 @@ TODO: Delete post porting
 
 universe u v
 
+section
+set_option linter.deprecated false
+
 /-- Nodes of an Red Black Tree-/
 @[deprecated Std.RBNode] inductive RBNode (α : Type u) where
   /-- leaf (empty marker) node-/
@@ -27,6 +30,9 @@ universe u v
   | black_node (lchild : RBNode α) (val : α) (rchild : RBNode α) : RBNode α
 
 #align rbnode Std.RBNode
+
+def MemExact : α → RBNode α → Prop := sorry
+def Mem : α → RBNode α → Prop := sorry
 
 namespace RBTree
 

--- a/Mathlib/Data/RBTree/Init.lean
+++ b/Mathlib/Data/RBTree/Init.lean
@@ -5,6 +5,7 @@ Authors: Leonardo de Moura
 -/
 
 import Mathlib.Mathport.Rename
+import Mathlib.Init.Data.Ordering.Basic
 
 
 -- This file used to be a part of `prelude`
@@ -43,16 +44,16 @@ protected def min : RBNode α → Option α
   | leaf _ => none
   | red_node (leaf _) v _ => some v
   | black_node (leaf _) v _ => some v
-  | red_node l v _ => RBNode.min l
-  | black_node l v _ => RBNode.min l
+  | red_node l _ _ => RBNode.min l
+  | black_node l _ _ => RBNode.min l
 #align rbnode.min RBNode.min
 
 protected def max : RBNode α → Option α
   | leaf _ => none
   | red_node _ v (leaf _) => some v
   | black_node _ v (leaf _) => some v
-  | red_node _ v r => RBNode.max r
-  | black_node _ v r => RBNode.max r
+  | red_node _ _ r => RBNode.max r
+  | black_node _ _ r => RBNode.max r
 #align rbnode.max RBNode.max
 
 def fold (f : α → β → β) : RBNode α → β → β
@@ -76,7 +77,7 @@ def balance1 : RBNode α → α → RBNode α → α → RBNode α → RBNode α
 def balance1Node : RBNode α → α → RBNode α → RBNode α
   | red_node l x r, v, t => balance1 l x r v t
   | black_node l x r, v, t => balance1 l x r v t
-  | leaf _, v, t => t
+  | leaf _, _, t => t
 #align rbnode.balance1_node RBNode.balance1Node
 
 -- dummy value
@@ -104,13 +105,14 @@ variable (lt : α → α → Prop) [DecidableRel lt]
 
 def ins : RBNode α → α → RBNode α
   | leaf _, x => red_node (leaf _) x (leaf _)
+  --| leaf             x  := red_node leaf x leaf
   | red_node a y b, x =>
-    match CmpUsing lt x y with
+    match cmpUsing lt x y with
     | Ordering.lt => red_node (ins a x) y b
     | Ordering.eq => red_node a x b
     | Ordering.gt => red_node a y (ins b x)
   | black_node a y b, x =>
-    match CmpUsing lt x y with
+    match cmpUsing lt x y with
     | Ordering.lt => if a.getColor = red then
                       balance1Node (ins a x) y b
                      else
@@ -152,14 +154,14 @@ def MemExact : α → RBNode α → Prop
 variable [DecidableRel lt]
 
 def find : RBNode α → α → Option α
-  | leaf _, x => none
+  | leaf _, _ => none
   | red_node a y b, x =>
-    match CmpUsing lt x y with
+    match cmpUsing lt x y with
     | Ordering.lt => find a x
     | Ordering.eq => some y
     | Ordering.gt => find b x
   | black_node a y b, x =>
-    match CmpUsing lt x y with
+    match cmpUsing lt x y with
     | Ordering.lt => find a x
     | Ordering.eq => some y
     | Ordering.gt => find b x

--- a/Mathlib/Data/RBTree/Init.lean
+++ b/Mathlib/Data/RBTree/Init.lean
@@ -244,7 +244,7 @@ def revFold (f : α → β → β) : RBTree α lt → β → β
 #align rbtree.rev_fold RBTree.revFold
 
 def empty : RBTree α lt → Bool
-  | ⟨leaf _, _⟩ => true
+  | ⟨leaf, _⟩ => true
   | _ => false
 #align rbtree.empty RBTree.empty
 

--- a/Mathlib/Data/RBTree/Init.lean
+++ b/Mathlib/Data/RBTree/Init.lean
@@ -7,6 +7,13 @@ Authors: Leonardo de Moura
 import Mathlib.Mathport.Rename
 import Mathlib.Init.Data.Ordering.Basic
 
+/-!
+# Red Black Trees
+
+Defines basic declaration and essential APIs for Red Black Trees as `RBTree`
+consisting of `RBNode`s using `lt` as the comparator (defaulted to the native type's
+`LT`)
+-/
 
 -- This file used to be a part of `Prelude`
 universe u v

--- a/Mathlib/Data/RBTree/Init.lean
+++ b/Mathlib/Data/RBTree/Init.lean
@@ -12,7 +12,7 @@ import Mathlib.Init.Data.Ordering.Basic
 universe u v
 
 inductive RBNode (α : Type u) where
-  | leaf : α → RBNode α
+  | leaf : RBNode α
   | red_node (lchild : RBNode α) (val : α) (rchild : RBNode α ) : RBNode α
   | black_node (lchild : RBNode α) (val : α) (rchild : RBNode α) : RBNode α
 
@@ -35,35 +35,35 @@ instance Color.decidableEq : DecidableEq Color := fun a b =>
 #align rbnode.color.decidable_eq RBNode.Color.decidableEq
 
 def depth (f : Nat → Nat → Nat) : RBNode α → Nat
-  | leaf _ => 0
+  | leaf => 0
   | red_node l _ r => succ (f (depth f l) (depth f r))
   | black_node l _ r => succ (f (depth f l) (depth f r))
 #align rbnode.depth RBNode.depth
 
 protected def min : RBNode α → Option α
-  | leaf _ => none
-  | red_node (leaf _) v _ => some v
-  | black_node (leaf _) v _ => some v
+  | leaf => none
+  | red_node leaf v _ => some v
+  | black_node leaf v _ => some v
   | red_node l _ _ => RBNode.min l
   | black_node l _ _ => RBNode.min l
 #align rbnode.min RBNode.min
 
 protected def max : RBNode α → Option α
-  | leaf _ => none
-  | red_node _ v (leaf _) => some v
-  | black_node _ v (leaf _) => some v
+  | leaf => none
+  | red_node _ v leaf => some v
+  | black_node _ v leaf => some v
   | red_node _ _ r => RBNode.max r
   | black_node _ _ r => RBNode.max r
 #align rbnode.max RBNode.max
 
 def fold (f : α → β → β) : RBNode α → β → β
-  | leaf _, b => b
+  | leaf, b => b
   | red_node l v r, b => fold f r (f v (fold f l b))
   | black_node l v r, b => fold f r (f v (fold f l b))
 #align rbnode.fold RBNode.fold
 
 def revFold (f : α → β → β) : RBNode α → β → β
-  | leaf _, b => b
+  | leaf, b => b
   | red_node l v r, b => revFold f l (f v (revFold f r b))
   | black_node l v r, b => revFold f l (f v (revFold f r b))
 #align rbnode.rev_fold RBNode.revFold
@@ -77,7 +77,7 @@ def balance1 : RBNode α → α → RBNode α → α → RBNode α → RBNode α
 def balance1Node : RBNode α → α → RBNode α → RBNode α
   | red_node l x r, v, t => balance1 l x r v t
   | black_node l x r, v, t => balance1 l x r v t
-  | leaf _, _, t => t
+  | leaf, _, t => t
 #align rbnode.balance1_node RBNode.balance1Node
 
 -- dummy value
@@ -90,7 +90,7 @@ def balance2 : RBNode α → α → RBNode α → α → RBNode α → RBNode α
 def balance2Node : RBNode α → α → RBNode α → RBNode α
   | red_node l x r, v, t => balance2 l x r v t
   | black_node l x r, v, t => balance2 l x r v t
-  | leaf _, _, t => t
+  | leaf, _, t => t
 #align rbnode.balance2_node RBNode.balance2Node
 
 -- dummy
@@ -104,8 +104,7 @@ section Insert
 variable (lt : α → α → Prop) [DecidableRel lt]
 
 def ins : RBNode α → α → RBNode α
-  | leaf _, x => red_node (leaf _) x (leaf _)
-  --| leaf             x  := red_node leaf x leaf
+  | leaf, x => red_node leaf x leaf
   | red_node a y b, x =>
     match cmpUsing lt x y with
     | Ordering.lt => red_node (ins a x) y b
@@ -140,13 +139,13 @@ section Membership
 variable (lt : α → α → Prop)
 
 def Mem : α → RBNode α → Prop
-  | _, leaf _ => False
+  | _, leaf => False
   | a, red_node l v r => RBNode.Mem a l ∨ ¬lt a v ∧ ¬lt v a ∨ RBNode.Mem a r
   | a, black_node l v r => RBNode.Mem a l ∨ ¬lt a v ∧ ¬lt v a ∨ RBNode.Mem a r
 #align rbnode.mem RBNode.Mem
 
 def MemExact : α → RBNode α → Prop
-  | _, leaf _ => False
+  | _, leaf => False
   | a, red_node l v r => RBNode.MemExact a l ∨ a = v ∨ RBNode.MemExact a r
   | a, black_node l v r => RBNode.MemExact a l ∨ a = v ∨ RBNode.MemExact a r
 #align rbnode.mem_exact RBNode.MemExact
@@ -154,7 +153,7 @@ def MemExact : α → RBNode α → Prop
 variable [DecidableRel lt]
 
 def find : RBNode α → α → Option α
-  | leaf _, _ => none
+  | leaf, _ => none
   | red_node a y b, x =>
     match cmpUsing lt x y with
     | Ordering.lt => find a x
@@ -170,7 +169,7 @@ def find : RBNode α → α → Option α
 end Membership
 
 inductive WellFormed (lt : α → α → Prop) : RBNode α → Prop
-  | leaf_wff : WellFormed lt (leaf _)
+  | leaf_wff : WellFormed lt leaf
   | insert_wff {n n' : RBNode α} {x : α} [DecidableRel lt] :
       WellFormed lt n → n' = insert lt n x → WellFormed lt n'
 #align rbnode.well_formed RBNode.WellFormed

--- a/Mathlib/Data/RBTree/Init.lean
+++ b/Mathlib/Data/RBTree/Init.lean
@@ -33,6 +33,6 @@ namespace RBTree
 @[deprecated Std.RBMap] structure RBTree (α : Type u) where
   mk :: (h: RBNode α) (cmp: α → α → Prop)
 
-#align rbtree Std.RBSet
+#align rbtree Std.RBMap
 
 end RBTree

--- a/Mathlib/Data/RBTree/Init.lean
+++ b/Mathlib/Data/RBTree/Init.lean
@@ -111,9 +111,15 @@ def ins : RBNode α → α → RBNode α
     | Ordering.gt => red_node a y (ins b x)
   | black_node a y b, x =>
     match CmpUsing lt x y with
-    | Ordering.lt => if a.getColor = red then balance1Node (ins a x) y b else black_node (ins a x) y b
+    | Ordering.lt => if a.getColor = red then
+                      balance1Node (ins a x) y b
+                     else
+                      black_node (ins a x) y b
     | Ordering.eq => black_node a x b
-    | Ordering.gt => if b.getColor = red then balance2Node (ins b x) y a else black_node a y (ins b x)
+    | Ordering.gt => if b.getColor = red then
+                      balance2Node (ins b x) y a
+                     else
+                      black_node a y (ins b x)
 #align rbnode.ins RBNode.ins
 
 def mkInsertResult : Color → RBNode α → RBNode α
@@ -163,17 +169,20 @@ end Membership
 
 inductive WellFormed (lt : α → α → Prop) : RBNode α → Prop
   | leaf_wff : WellFormed lt (leaf _)
-  | insert_wff {n n' : RBNode α} {x : α} [DecidableRel lt] : WellFormed lt n → n' = insert lt n x → WellFormed lt n'
+  | insert_wff {n n' : RBNode α} {x : α} [DecidableRel lt] :
+      WellFormed lt n → n' = insert lt n x → WellFormed lt n'
 #align rbnode.well_formed RBNode.WellFormed
 
 end RBNode
 
 open RBNode
 
-/- ./././Mathport/Syntax/Translate/Basic.lean:334:40: warning: unsupported option auto_param.check_exists -/
+/- ./././Mathport/Syntax/Translate/Basic.lean:334:40: warning:
+unsupported option auto_param.check_exists -/
 set_option auto_param.check_exists false
 
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic rbtree.default_lt -/
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18:
+unsupported non-interactive tactic rbtree.default_lt -/
 def RBTree (α : Type u)
     (lt : α → α → Prop := by
       run_tac
@@ -182,7 +191,8 @@ def RBTree (α : Type u)
   { t : RBNode α // t.WellFormed lt }
 #align rbtree RBTree
 
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic rbtree.default_lt -/
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18:
+unsupported non-interactive tactic rbtree.default_lt -/
 def mkRBTree (α : Type u)
     (lt : α → α → Prop := by
       run_tac
@@ -252,7 +262,8 @@ def contains (t : RBTree α lt) (a : α) : Bool :=
   (t.find a).isSome
 #align rbtree.contains RBTree.contains
 
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic rbtree.default_lt -/
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18:
+unsupported non-interactive tactic rbtree.default_lt -/
 def fromList (l : List α)
     (lt : α → α → Prop := by
       run_tac
@@ -263,7 +274,8 @@ def fromList (l : List α)
 
 end RBTree
 
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic rbtree.default_lt -/
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18:
+unsupported non-interactive tactic rbtree.default_lt -/
 def rbtreeOf {α : Type u} (l : List α)
     (lt : α → α → Prop := by
       run_tac

--- a/Mathlib/Data/RBTree/Init.lean
+++ b/Mathlib/Data/RBTree/Init.lean
@@ -30,6 +30,8 @@ universe u v
 
 namespace RBTree
 
+/-- Note changed from `def` to `structure` to simplify the
+    previous autoparameter tactic issues -/
 @[deprecated Std.RBMap] structure RBTree (α : Type u) where
   mk :: (h: RBNode α) (cmp: α → α → Prop)
 

--- a/Mathlib/Data/RBTree/Init.lean
+++ b/Mathlib/Data/RBTree/Init.lean
@@ -1,0 +1,273 @@
+/-
+Copyright (c) 2017 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Leonardo de Moura
+-/
+
+import Mathlib.Mathport.Rename
+
+
+-- This file used to be a part of `prelude`
+universe u v
+
+inductive RBNode (α : Type u) where
+  | leaf : α → RBNode α
+  | red_node (lchild : RBNode α) (val : α) (rchild : RBNode α ) : RBNode α
+  | black_node (lchild : RBNode α) (val : α) (rchild : RBNode α) : RBNode α
+
+#align rbnode RBNode
+
+namespace RBNode
+
+variable {α : Type u} {β : Type v}
+
+inductive Color
+  | red
+  | black
+#align rbnode.color RBNode.Color
+
+open Color Nat
+
+instance Color.decidableEq : DecidableEq Color := fun a b =>
+  Color.casesOn a (Color.casesOn b (isTrue rfl) (isFalse fun h => Color.noConfusion h))
+    (Color.casesOn b (isFalse fun h => Color.noConfusion h) (isTrue rfl))
+#align rbnode.color.decidable_eq RBNode.Color.decidableEq
+
+def depth (f : Nat → Nat → Nat) : RBNode α → Nat
+  | leaf _ => 0
+  | red_node l _ r => succ (f (depth f l) (depth f r))
+  | black_node l _ r => succ (f (depth f l) (depth f r))
+#align rbnode.depth RBNode.depth
+
+protected def min : RBNode α → Option α
+  | leaf _ => none
+  | red_node (leaf _) v _ => some v
+  | black_node (leaf _) v _ => some v
+  | red_node l v _ => RBNode.min l
+  | black_node l v _ => RBNode.min l
+#align rbnode.min RBNode.min
+
+protected def max : RBNode α → Option α
+  | leaf _ => none
+  | red_node _ v (leaf _) => some v
+  | black_node _ v (leaf _) => some v
+  | red_node _ v r => RBNode.max r
+  | black_node _ v r => RBNode.max r
+#align rbnode.max RBNode.max
+
+def fold (f : α → β → β) : RBNode α → β → β
+  | leaf _, b => b
+  | red_node l v r, b => fold f r (f v (fold f l b))
+  | black_node l v r, b => fold f r (f v (fold f l b))
+#align rbnode.fold RBNode.fold
+
+def revFold (f : α → β → β) : RBNode α → β → β
+  | leaf _, b => b
+  | red_node l v r, b => revFold f l (f v (revFold f r b))
+  | black_node l v r, b => revFold f l (f v (revFold f r b))
+#align rbnode.rev_fold RBNode.revFold
+
+def balance1 : RBNode α → α → RBNode α → α → RBNode α → RBNode α
+  | red_node l x r₁, y, r₂, v, t => red_node (black_node l x r₁) y (black_node r₂ v t)
+  | l₁, y, red_node l₂ x r, v, t => red_node (black_node l₁ y l₂) x (black_node r v t)
+  | l, y, r, v, t => black_node (red_node l y r) v t
+#align rbnode.balance1 RBNode.balance1
+
+def balance1Node : RBNode α → α → RBNode α → RBNode α
+  | red_node l x r, v, t => balance1 l x r v t
+  | black_node l x r, v, t => balance1 l x r v t
+  | leaf _, v, t => t
+#align rbnode.balance1_node RBNode.balance1Node
+
+-- dummy value
+def balance2 : RBNode α → α → RBNode α → α → RBNode α → RBNode α
+  | red_node l x₁ r₁, y, r₂, v, t => red_node (black_node t v l) x₁ (black_node r₁ y r₂)
+  | l₁, y, red_node l₂ x₂ r₂, v, t => red_node (black_node t v l₁) y (black_node l₂ x₂ r₂)
+  | l, y, r, v, t => black_node t v (red_node l y r)
+#align rbnode.balance2 RBNode.balance2
+
+def balance2Node : RBNode α → α → RBNode α → RBNode α
+  | red_node l x r, v, t => balance2 l x r v t
+  | black_node l x r, v, t => balance2 l x r v t
+  | leaf _, _, t => t
+#align rbnode.balance2_node RBNode.balance2Node
+
+-- dummy
+def getColor : RBNode α → Color
+  | red_node _ _ _ => red
+  | _ => black
+#align rbnode.get_color RBNode.getColor
+
+section Insert
+
+variable (lt : α → α → Prop) [DecidableRel lt]
+
+def ins : RBNode α → α → RBNode α
+  | leaf _, x => red_node (leaf _) x (leaf _)
+  | red_node a y b, x =>
+    match CmpUsing lt x y with
+    | Ordering.lt => red_node (ins a x) y b
+    | Ordering.eq => red_node a x b
+    | Ordering.gt => red_node a y (ins b x)
+  | black_node a y b, x =>
+    match CmpUsing lt x y with
+    | Ordering.lt => if a.getColor = red then balance1Node (ins a x) y b else black_node (ins a x) y b
+    | Ordering.eq => black_node a x b
+    | Ordering.gt => if b.getColor = red then balance2Node (ins b x) y a else black_node a y (ins b x)
+#align rbnode.ins RBNode.ins
+
+def mkInsertResult : Color → RBNode α → RBNode α
+  | red, red_node l v r => black_node l v r
+  | _, t => t
+#align rbnode.mk_insert_result RBNode.mkInsertResult
+
+def insert (t : RBNode α) (x : α) : RBNode α :=
+  mkInsertResult (getColor t) (ins lt t x)
+#align rbnode.insert RBNode.insert
+
+end Insert
+
+section Membership
+
+variable (lt : α → α → Prop)
+
+def Mem : α → RBNode α → Prop
+  | _, leaf _ => False
+  | a, red_node l v r => RBNode.Mem a l ∨ ¬lt a v ∧ ¬lt v a ∨ RBNode.Mem a r
+  | a, black_node l v r => RBNode.Mem a l ∨ ¬lt a v ∧ ¬lt v a ∨ RBNode.Mem a r
+#align rbnode.mem RBNode.Mem
+
+def MemExact : α → RBNode α → Prop
+  | _, leaf _ => False
+  | a, red_node l v r => RBNode.MemExact a l ∨ a = v ∨ RBNode.MemExact a r
+  | a, black_node l v r => RBNode.MemExact a l ∨ a = v ∨ RBNode.MemExact a r
+#align rbnode.mem_exact RBNode.MemExact
+
+variable [DecidableRel lt]
+
+def find : RBNode α → α → Option α
+  | leaf _, x => none
+  | red_node a y b, x =>
+    match CmpUsing lt x y with
+    | Ordering.lt => find a x
+    | Ordering.eq => some y
+    | Ordering.gt => find b x
+  | black_node a y b, x =>
+    match CmpUsing lt x y with
+    | Ordering.lt => find a x
+    | Ordering.eq => some y
+    | Ordering.gt => find b x
+#align rbnode.find RBNode.find
+
+end Membership
+
+inductive WellFormed (lt : α → α → Prop) : RBNode α → Prop
+  | leaf_wff : WellFormed lt (leaf _)
+  | insert_wff {n n' : RBNode α} {x : α} [DecidableRel lt] : WellFormed lt n → n' = insert lt n x → WellFormed lt n'
+#align rbnode.well_formed RBNode.WellFormed
+
+end RBNode
+
+open RBNode
+
+/- ./././Mathport/Syntax/Translate/Basic.lean:334:40: warning: unsupported option auto_param.check_exists -/
+set_option auto_param.check_exists false
+
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic rbtree.default_lt -/
+def RBTree (α : Type u)
+    (lt : α → α → Prop := by
+      run_tac
+        RBTree.default_lt) :
+    Type u :=
+  { t : RBNode α // t.WellFormed lt }
+#align rbtree RBTree
+
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic rbtree.default_lt -/
+def mkRBTree (α : Type u)
+    (lt : α → α → Prop := by
+      run_tac
+        rbtree.default_lt) :
+    RBTree α lt :=
+  ⟨leaf, WellFormed.leaf_wff⟩
+#align mk_rbtree mkRBTree
+
+namespace RBTree
+
+variable {α : Type u} {β : Type v} {lt : α → α → Prop}
+
+protected def Mem (a : α) (t : RBTree α lt) : Prop :=
+  RBNode.Mem lt a t.val
+#align rbtree.mem RBTree.Mem
+
+instance : Membership α (RBTree α lt) :=
+  ⟨RBTree.Mem⟩
+
+def MemExact (a : α) (t : RBTree α lt) : Prop :=
+  RBNode.MemExact a t.val
+#align rbtree.mem_exact RBTree.MemExact
+
+def depth (f : Nat → Nat → Nat) (t : RBTree α lt) : Nat :=
+  t.val.depth f
+#align rbtree.depth RBTree.depth
+
+def fold (f : α → β → β) : RBTree α lt → β → β
+  | ⟨t, _⟩, b => t.fold f b
+#align rbtree.fold RBTree.fold
+
+def revFold (f : α → β → β) : RBTree α lt → β → β
+  | ⟨t, _⟩, b => t.revFold f b
+#align rbtree.rev_fold RBTree.revFold
+
+def empty : RBTree α lt → Bool
+  | ⟨leaf _, _⟩ => true
+  | _ => false
+#align rbtree.empty RBTree.empty
+
+def toList : RBTree α lt → List α
+  | ⟨t, _⟩ => t.revFold (· :: ·) []
+#align rbtree.to_list RBTree.toList
+
+protected def min : RBTree α lt → Option α
+  | ⟨t, _⟩ => t.min
+#align rbtree.min RBTree.min
+
+protected def max : RBTree α lt → Option α
+  | ⟨t, _⟩ => t.max
+#align rbtree.max RBTree.max
+
+instance [Repr α] : Repr (RBTree α lt) :=
+  ⟨fun t => "rbtree_of " ++ repr t.toList⟩
+
+variable [DecidableRel lt]
+
+def insert : RBTree α lt → α → RBTree α lt
+  | ⟨t, w⟩, x => ⟨t.insert lt x, WellFormed.insert_wff w rfl⟩
+#align rbtree.insert RBTree.insert
+
+def find : RBTree α lt → α → Option α
+  | ⟨t, _⟩, x => t.find lt x
+#align rbtree.find RBTree.find
+
+def contains (t : RBTree α lt) (a : α) : Bool :=
+  (t.find a).isSome
+#align rbtree.contains RBTree.contains
+
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic rbtree.default_lt -/
+def fromList (l : List α)
+    (lt : α → α → Prop := by
+      run_tac
+        rbtree.default_lt)
+    [DecidableRel lt] : RBTree α lt :=
+  l.foldl insert (mkRBTree α lt)
+#align rbtree.from_list RBTree.fromList
+
+end RBTree
+
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic rbtree.default_lt -/
+def rbtreeOf {α : Type u} (l : List α)
+    (lt : α → α → Prop := by
+      run_tac
+        rbtree.default_lt)
+    [DecidableRel lt] : RBTree α lt :=
+  RBTree.fromList l lt
+#align rbtree_of rbtreeOf

--- a/Mathlib/Data/RBTree/Init.lean
+++ b/Mathlib/Data/RBTree/Init.lean
@@ -8,12 +8,16 @@ import Mathlib.Mathport.Rename
 import Mathlib.Init.Data.Ordering.Basic
 
 
--- This file used to be a part of `prelude`
+-- This file used to be a part of `Prelude`
 universe u v
 
+/-- Nodes of an Red Black Tree-/
 inductive RBNode (α : Type u) where
+  /-- leaf (empty marker) node-/
   | leaf : RBNode α
+  /-- red node-/
   | red_node (lchild : RBNode α) (val : α) (rchild : RBNode α ) : RBNode α
+  /-- black node-/
   | black_node (lchild : RBNode α) (val : α) (rchild : RBNode α) : RBNode α
 
 #align rbnode RBNode
@@ -22,8 +26,11 @@ namespace RBNode
 
 variable {α : Type u} {β : Type v}
 
+/-- enumeration for r/b colors-/
 inductive Color
+  /-- red-/
   | red
+  /-- black-/
   | black
 #align rbnode.color RBNode.Color
 

--- a/Mathlib/Data/RBTree/Init.lean
+++ b/Mathlib/Data/RBTree/Init.lean
@@ -5,21 +5,20 @@ Authors: Leonardo de Moura
 -/
 
 import Mathlib.Mathport.Rename
-import Mathlib.Init.Data.Ordering.Basic
+import Std.Data.RBMap.Basic
 
 /-!
 # Red Black Trees
 
-Defines basic declaration and essential APIs for Red Black Trees as `RBTree`
-consisting of `RBNode`s using `lt` as the comparator (defaulted to the native type's
-`LT`)
+Deprecated definitions -- use `Std.RBSet` instead.
+
+TODO: Delete post porting
 -/
 
--- This file used to be a part of `Prelude`
 universe u v
 
 /-- Nodes of an Red Black Tree-/
-inductive RBNode (α : Type u) where
+@[deprecated Std.RBNode] inductive RBNode (α : Type u) where
   /-- leaf (empty marker) node-/
   | leaf : RBNode α
   /-- red node-/
@@ -27,274 +26,13 @@ inductive RBNode (α : Type u) where
   /-- black node-/
   | black_node (lchild : RBNode α) (val : α) (rchild : RBNode α) : RBNode α
 
-#align rbnode RBNode
-
-namespace RBNode
-
-variable {α : Type u} {β : Type v}
-
-/-- enumeration for r/b colors-/
-inductive Color
-  /-- red-/
-  | red
-  /-- black-/
-  | black
-#align rbnode.color RBNode.Color
-
-open Color Nat
-
-instance Color.decidableEq : DecidableEq Color := fun a b =>
-  Color.casesOn a (Color.casesOn b (isTrue rfl) (isFalse fun h => Color.noConfusion h))
-    (Color.casesOn b (isFalse fun h => Color.noConfusion h) (isTrue rfl))
-#align rbnode.color.decidable_eq RBNode.Color.decidableEq
-
-def depth (f : Nat → Nat → Nat) : RBNode α → Nat
-  | leaf => 0
-  | red_node l _ r => succ (f (depth f l) (depth f r))
-  | black_node l _ r => succ (f (depth f l) (depth f r))
-#align rbnode.depth RBNode.depth
-
-protected def min : RBNode α → Option α
-  | leaf => none
-  | red_node leaf v _ => some v
-  | black_node leaf v _ => some v
-  | red_node l _ _ => RBNode.min l
-  | black_node l _ _ => RBNode.min l
-#align rbnode.min RBNode.min
-
-protected def max : RBNode α → Option α
-  | leaf => none
-  | red_node _ v leaf => some v
-  | black_node _ v leaf => some v
-  | red_node _ _ r => RBNode.max r
-  | black_node _ _ r => RBNode.max r
-#align rbnode.max RBNode.max
-
-def fold (f : α → β → β) : RBNode α → β → β
-  | leaf, b => b
-  | red_node l v r, b => fold f r (f v (fold f l b))
-  | black_node l v r, b => fold f r (f v (fold f l b))
-#align rbnode.fold RBNode.fold
-
-def revFold (f : α → β → β) : RBNode α → β → β
-  | leaf, b => b
-  | red_node l v r, b => revFold f l (f v (revFold f r b))
-  | black_node l v r, b => revFold f l (f v (revFold f r b))
-#align rbnode.rev_fold RBNode.revFold
-
-def balance1 : RBNode α → α → RBNode α → α → RBNode α → RBNode α
-  | red_node l x r₁, y, r₂, v, t => red_node (black_node l x r₁) y (black_node r₂ v t)
-  | l₁, y, red_node l₂ x r, v, t => red_node (black_node l₁ y l₂) x (black_node r v t)
-  | l, y, r, v, t => black_node (red_node l y r) v t
-#align rbnode.balance1 RBNode.balance1
-
-def balance1Node : RBNode α → α → RBNode α → RBNode α
-  | red_node l x r, v, t => balance1 l x r v t
-  | black_node l x r, v, t => balance1 l x r v t
-  | leaf, _, t => t
-#align rbnode.balance1_node RBNode.balance1Node
-
--- dummy value
-def balance2 : RBNode α → α → RBNode α → α → RBNode α → RBNode α
-  | red_node l x₁ r₁, y, r₂, v, t => red_node (black_node t v l) x₁ (black_node r₁ y r₂)
-  | l₁, y, red_node l₂ x₂ r₂, v, t => red_node (black_node t v l₁) y (black_node l₂ x₂ r₂)
-  | l, y, r, v, t => black_node t v (red_node l y r)
-#align rbnode.balance2 RBNode.balance2
-
-def balance2Node : RBNode α → α → RBNode α → RBNode α
-  | red_node l x r, v, t => balance2 l x r v t
-  | black_node l x r, v, t => balance2 l x r v t
-  | leaf, _, t => t
-#align rbnode.balance2_node RBNode.balance2Node
-
--- dummy
-def getColor : RBNode α → Color
-  | red_node _ _ _ => red
-  | _ => black
-#align rbnode.get_color RBNode.getColor
-
-section Insert
-
-variable (lt : α → α → Prop) [DecidableRel lt]
-
-def ins : RBNode α → α → RBNode α
-  | leaf, x => red_node leaf x leaf
-  | red_node a y b, x =>
-    match cmpUsing lt x y with
-    | Ordering.lt => red_node (ins a x) y b
-    | Ordering.eq => red_node a x b
-    | Ordering.gt => red_node a y (ins b x)
-  | black_node a y b, x =>
-    match cmpUsing lt x y with
-    | Ordering.lt => if a.getColor = red then
-                      balance1Node (ins a x) y b
-                     else
-                      black_node (ins a x) y b
-    | Ordering.eq => black_node a x b
-    | Ordering.gt => if b.getColor = red then
-                      balance2Node (ins b x) y a
-                     else
-                      black_node a y (ins b x)
-#align rbnode.ins RBNode.ins
-
-def mkInsertResult : Color → RBNode α → RBNode α
-  | red, red_node l v r => black_node l v r
-  | _, t => t
-#align rbnode.mk_insert_result RBNode.mkInsertResult
-
-def insert (t : RBNode α) (x : α) : RBNode α :=
-  mkInsertResult (getColor t) (ins lt t x)
-#align rbnode.insert RBNode.insert
-
-end Insert
-
-section Membership
-
-variable (lt : α → α → Prop)
-
-def Mem : α → RBNode α → Prop
-  | _, leaf => False
-  | a, red_node l v r => RBNode.Mem a l ∨ ¬lt a v ∧ ¬lt v a ∨ RBNode.Mem a r
-  | a, black_node l v r => RBNode.Mem a l ∨ ¬lt a v ∧ ¬lt v a ∨ RBNode.Mem a r
-#align rbnode.mem RBNode.Mem
-
-def MemExact : α → RBNode α → Prop
-  | _, leaf => False
-  | a, red_node l v r => RBNode.MemExact a l ∨ a = v ∨ RBNode.MemExact a r
-  | a, black_node l v r => RBNode.MemExact a l ∨ a = v ∨ RBNode.MemExact a r
-#align rbnode.mem_exact RBNode.MemExact
-
-variable [DecidableRel lt]
-
-def find : RBNode α → α → Option α
-  | leaf, _ => none
-  | red_node a y b, x =>
-    match cmpUsing lt x y with
-    | Ordering.lt => find a x
-    | Ordering.eq => some y
-    | Ordering.gt => find b x
-  | black_node a y b, x =>
-    match cmpUsing lt x y with
-    | Ordering.lt => find a x
-    | Ordering.eq => some y
-    | Ordering.gt => find b x
-#align rbnode.find RBNode.find
-
-end Membership
-
-inductive WellFormed (lt : α → α → Prop) : RBNode α → Prop
-  | leaf_wff : WellFormed lt leaf
-  | insert_wff {n n' : RBNode α} {x : α} [DecidableRel lt] :
-      WellFormed lt n → n' = insert lt n x → WellFormed lt n'
-#align rbnode.well_formed RBNode.WellFormed
-
-end RBNode
-
-open RBNode
-
-/- ./././Mathport/Syntax/Translate/Basic.lean:334:40: warning:
-unsupported option auto_param.check_exists -/
-set_option auto_param.check_exists false
-
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18:
-unsupported non-interactive tactic rbtree.default_lt -/
-def RBTree (α : Type u)
-    (lt : α → α → Prop := by
-      run_tac
-        RBTree.default_lt) :
-    Type u :=
-  { t : RBNode α // t.WellFormed lt }
-#align rbtree RBTree
-
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18:
-unsupported non-interactive tactic rbtree.default_lt -/
-def mkRBTree (α : Type u)
-    (lt : α → α → Prop := by
-      run_tac
-        rbtree.default_lt) :
-    RBTree α lt :=
-  ⟨leaf, WellFormed.leaf_wff⟩
-#align mk_rbtree mkRBTree
+#align rbnode Std.RBNode
 
 namespace RBTree
 
-variable {α : Type u} {β : Type v} {lt : α → α → Prop}
+@[deprecated Std.RBMap] structure RBTree (α : Type u) where
+  mk :: (h: RBNode α) (cmp: α → α → Prop)
 
-protected def Mem (a : α) (t : RBTree α lt) : Prop :=
-  RBNode.Mem lt a t.val
-#align rbtree.mem RBTree.Mem
-
-instance : Membership α (RBTree α lt) :=
-  ⟨RBTree.Mem⟩
-
-def MemExact (a : α) (t : RBTree α lt) : Prop :=
-  RBNode.MemExact a t.val
-#align rbtree.mem_exact RBTree.MemExact
-
-def depth (f : Nat → Nat → Nat) (t : RBTree α lt) : Nat :=
-  t.val.depth f
-#align rbtree.depth RBTree.depth
-
-def fold (f : α → β → β) : RBTree α lt → β → β
-  | ⟨t, _⟩, b => t.fold f b
-#align rbtree.fold RBTree.fold
-
-def revFold (f : α → β → β) : RBTree α lt → β → β
-  | ⟨t, _⟩, b => t.revFold f b
-#align rbtree.rev_fold RBTree.revFold
-
-def empty : RBTree α lt → Bool
-  | ⟨leaf, _⟩ => true
-  | _ => false
-#align rbtree.empty RBTree.empty
-
-def toList : RBTree α lt → List α
-  | ⟨t, _⟩ => t.revFold (· :: ·) []
-#align rbtree.to_list RBTree.toList
-
-protected def min : RBTree α lt → Option α
-  | ⟨t, _⟩ => t.min
-#align rbtree.min RBTree.min
-
-protected def max : RBTree α lt → Option α
-  | ⟨t, _⟩ => t.max
-#align rbtree.max RBTree.max
-
-instance [Repr α] : Repr (RBTree α lt) :=
-  ⟨fun t => "rbtree_of " ++ repr t.toList⟩
-
-variable [DecidableRel lt]
-
-def insert : RBTree α lt → α → RBTree α lt
-  | ⟨t, w⟩, x => ⟨t.insert lt x, WellFormed.insert_wff w rfl⟩
-#align rbtree.insert RBTree.insert
-
-def find : RBTree α lt → α → Option α
-  | ⟨t, _⟩, x => t.find lt x
-#align rbtree.find RBTree.find
-
-def contains (t : RBTree α lt) (a : α) : Bool :=
-  (t.find a).isSome
-#align rbtree.contains RBTree.contains
-
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18:
-unsupported non-interactive tactic rbtree.default_lt -/
-def fromList (l : List α)
-    (lt : α → α → Prop := by
-      run_tac
-        rbtree.default_lt)
-    [DecidableRel lt] : RBTree α lt :=
-  l.foldl insert (mkRBTree α lt)
-#align rbtree.from_list RBTree.fromList
+#align rbtree Std.RBSet
 
 end RBTree
-
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18:
-unsupported non-interactive tactic rbtree.default_lt -/
-def rbtreeOf {α : Type u} (l : List α)
-    (lt : α → α → Prop := by
-      run_tac
-        rbtree.default_lt)
-    [DecidableRel lt] : RBTree α lt :=
-  RBTree.fromList l lt
-#align rbtree_of rbtreeOf

--- a/Mathlib/Data/RBTree/Insert.lean
+++ b/Mathlib/Data/RBTree/Insert.lean
@@ -24,70 +24,40 @@ open Color
 theorem balance1_eq₁ (l : RBNode α) (x r₁ y r₂ v t) :
     balance1 (red_node l x r₁) y r₂ v t = sorry
 
-@[simp]
-theorem balance1_eq₂ (l₁ : RBNode α) (y l₂ x r v t) :
+@[simp] theorem balance1_eq₂ (l₁ : RBNode α) (y l₂ x r v t) :
     getColor l₁ ≠ red → balance1 l₁ y (red_node l₂ x r) v t = sorry
 
-@[simp]
-theorem balance1_eq₃ (l : RBNode α) (y r v t) :
-    getColor l ≠ red → getColor r ≠ red → balance1 l y r v t = black_node (red_node l y r) v t := by
-  cases l <;> cases r <;> simp [get_color, balance1, false_imp_iff]
-#align rbnode.balance1_eq₃ RBNode.balance1_eq₃
+@[simp] theorem balance1_eq₃ (l : RBNode α) (y r v t) :
+    getColor l ≠ red → getColor r ≠ red → balance1 l y r v t =
+      black_node (red_node l y r) v t := sorry
 
-@[simp]
-theorem balance2_eq₁ (l : RBNode α) (x₁ r₁ y r₂ v t) :
-    balance2 (red_node l x₁ r₁) y r₂ v t = red_node (black_node t v l) x₁ (black_node r₁ y r₂) := by cases r₂ <;> rfl
-#align rbnode.balance2_eq₁ RBNode.balance2_eq₁
+@[simp] theorem balance2_eq₁ (l : RBNode α) (x₁ r₁ y r₂ v t) :
+    balance2 (red_node l x₁ r₁) y r₂ v t =
+      red_node (black_node t v l) x₁ (black_node r₁ y r₂) := sorry
 
-@[simp]
-theorem balance2_eq₂ (l₁ : RBNode α) (y l₂ x₂ r₂ v t) :
-    getColor l₁ ≠ red → balance2 l₁ y (red_node l₂ x₂ r₂) v t = red_node (black_node t v l₁) y (black_node l₂ x₂ r₂) :=
-  by cases l₁ <;> simp [get_color, balance2, false_imp_iff]
-#align rbnode.balance2_eq₂ RBNode.balance2_eq₂
+@[simp] theorem balance2_eq₂ (l₁ : RBNode α) (y l₂ x₂ r₂ v t) :
+    getColor l₁ ≠ red → balance2 l₁ y (red_node l₂ x₂ r₂) v t =
+      red_node (black_node t v l₁) y (black_node l₂ x₂ r₂) := sorry
 
-@[simp]
-theorem balance2_eq₃ (l : RBNode α) (y r v t) :
-    getColor l ≠ red → getColor r ≠ red → balance2 l y r v t = black_node t v (red_node l y r) := by
-  cases l <;> cases r <;> simp [get_color, balance2, false_imp_iff]
-#align rbnode.balance2_eq₃ RBNode.balance2_eq₃
+@[simp] theorem balance2_eq₃ (l : RBNode α) (y r v t) :
+    getColor l ≠ red → getColor r ≠ red → balance2 l y r v t =
+      black_node t v (red_node l y r) := sorry
 
 -- We can use the same induction principle for balance1 and balance2
-theorem Balance.cases {p : RBNode α → α → RBNode α → Prop} (l y r) (red_left : ∀ l x r₁ y r₂, p (red_node l x r₁) y r₂)
+theorem Balance.cases {p : RBNode α → α → RBNode α → Prop}
+    (l y r) (red_left : ∀ l x r₁ y r₂, p (red_node l x r₁) y r₂)
     (red_right : ∀ l₁ y l₂ x r, getColor l₁ ≠ red → p l₁ y (red_node l₂ x r))
-    (other : ∀ l y r, getColor l ≠ red → getColor r ≠ red → p l y r) : p l y r := by
-  cases l <;> cases r
-  any_goals apply red_left
-  any_goals apply red_right <;> simp [get_color] <;> contradiction <;> done
-  any_goals apply other <;> simp [get_color] <;> contradiction <;> done
-#align rbnode.balance.cases RBNode.Balance.cases
+    (other : ∀ l y r, getColor l ≠ red → getColor r ≠ red → p l y r) : p l y r := sorry
 
-theorem balance1_ne_leaf (l : RBNode α) (x r v t) : balance1 l x r v t ≠ leaf := by
-  apply balance.cases l x r <;> intros <;> simp [*] <;> contradiction
-#align rbnode.balance1_ne_leaf RBNode.balance1_ne_leaf
+theorem balance1_ne_leaf (l : RBNode α) (x r v t) : balance1 l x r v t ≠ leaf := sorry
 
-theorem balance1_node_ne_leaf {s : RBNode α} (a : α) (t : RBNode α) : s ≠ leaf → balance1Node s a t ≠ leaf := by
-  intro h
-  cases s
-  · contradiction
+theorem balance1_node_ne_leaf {s : RBNode α} (a : α) (t : RBNode α) :
+    s ≠ leaf → balance1Node s a t ≠ leaf := sorry
 
-  all_goals
-  simp [balance1_node]
-  apply balance1_ne_leaf
-#align rbnode.balance1_node_ne_leaf RBNode.balance1_node_ne_leaf
+theorem balance2_ne_leaf (l : RBNode α) (x r v t) : balance2 l x r v t ≠ leaf := sorry
 
-theorem balance2_ne_leaf (l : RBNode α) (x r v t) : balance2 l x r v t ≠ leaf := by
-  apply balance.cases l x r <;> intros <;> simp [*] <;> contradiction
-#align rbnode.balance2_ne_leaf RBNode.balance2_ne_leaf
-
-theorem balance2_node_ne_leaf {s : RBNode α} (a : α) (t : RBNode α) : s ≠ leaf → balance2Node s a t ≠ leaf := by
-  intro h
-  cases s
-  · contradiction
-
-  all_goals
-  simp [balance2_node]
-  apply balance2_ne_leaf
-#align rbnode.balance2_node_ne_leaf RBNode.balance2_node_ne_leaf
+theorem balance2_node_ne_leaf {s : RBNode α} (a : α) (t : RBNode α) :
+    s ≠ leaf → balance2Node s a t ≠ leaf := sorry
 
 variable (lt : α → α → Prop)
 
@@ -97,177 +67,52 @@ theorem ins.induction [DecidableRel lt] {p : RBNode α → Prop} (t x) (is_leaf 
     (is_red_eq : ∀ (a y b) (hc : CmpUsing lt x y = Ordering.eq), p (red_node a y b))
     (is_red_gt : ∀ (a y b) (hc : CmpUsing lt x y = Ordering.gt) (ih : p b), p (red_node a y b))
     (is_black_lt_red :
-      ∀ (a y b) (hc : CmpUsing lt x y = Ordering.lt) (hr : getColor a = red) (ih : p a), p (black_node a y b))
+      ∀ (a y b)
+        (hc : CmpUsing lt x y = Ordering.lt)
+        (hr : getColor a = red) (ih : p a), p (black_node a y b))
     (is_black_lt_not_red :
-      ∀ (a y b) (hc : CmpUsing lt x y = Ordering.lt) (hnr : getColor a ≠ red) (ih : p a), p (black_node a y b))
+      ∀ (a y b)
+        (hc : CmpUsing lt x y = Ordering.lt)
+        (hnr : getColor a ≠ red) (ih : p a), p (black_node a y b))
     (is_black_eq : ∀ (a y b) (hc : CmpUsing lt x y = Ordering.eq), p (black_node a y b))
     (is_black_gt_red :
-      ∀ (a y b) (hc : CmpUsing lt x y = Ordering.gt) (hr : getColor b = red) (ih : p b), p (black_node a y b))
+      ∀ (a y b)
+        (hc : CmpUsing lt x y = Ordering.gt)
+        (hr : getColor b = red) (ih : p b), p (black_node a y b))
     (is_black_gt_not_red :
-      ∀ (a y b) (hc : CmpUsing lt x y = Ordering.gt) (hnr : getColor b ≠ red) (ih : p b), p (black_node a y b)) :
-    p t := by
-  induction t
-  case leaf => apply is_leaf
-  case red_node a y b =>
-  cases h : CmpUsing lt x y
-  case lt => apply is_red_lt <;> assumption
-  case eq => apply is_red_eq <;> assumption
-  case gt => apply is_red_gt <;> assumption
-  case black_node a y b =>
-  cases h : CmpUsing lt x y
-  case lt =>
-  by_cases get_color a = red
-  · apply is_black_lt_red <;> assumption
+      ∀ (a y b)
+        (hc : CmpUsing lt x y = Ordering.gt)
+        (hnr : getColor b ≠ red) (ih : p b), p (black_node a y b)) :
+    p t := sorry
 
-  · apply is_black_lt_not_red <;> assumption
-
-  case eq => apply is_black_eq <;> assumption
-  case gt =>
-  by_cases get_color b = red
-  · apply is_black_gt_red <;> assumption
-
-  · apply is_black_gt_not_red <;> assumption
-
-#align rbnode.ins.induction RBNode.ins.induction
-
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic rbnode.is_searchable_tactic -/
 theorem is_searchable_balance1 {l y r v t lo hi} :
     IsSearchable lt l lo (some y) →
       IsSearchable lt r (some y) (some v) →
-        IsSearchable lt t (some v) hi → IsSearchable lt (balance1 l y r v t) lo hi :=
-  by
-  apply balance.cases l y r <;>
-    intros <;>
-      simp [*] <;>
-        run_tac
-          is_searchable_tactic
-#align rbnode.is_searchable_balance1 RBNode.is_searchable_balance1
+        IsSearchable lt t (some v) hi → IsSearchable lt (balance1 l y r v t) lo hi := sorry
 
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic rbnode.is_searchable_tactic -/
 theorem is_searchable_balance1_node {t} [IsTrans α lt] :
     ∀ {y s lo hi},
-      IsSearchable lt t lo (some y) → IsSearchable lt s (some y) hi → IsSearchable lt (balance1Node t y s) lo hi :=
-  by
-  cases t <;>
-    simp! <;>
-      intros <;>
-        run_tac
-          is_searchable_tactic
-  · cases lo
-    · apply is_searchable_none_low_of_is_searchable_some_low
-      assumption
+      IsSearchable lt t lo (some y) →
+        IsSearchable lt s (some y) hi →
+          IsSearchable lt (balance1Node t y s) lo hi := sorry
 
-    · simp at *
-      apply is_searchable_some_low_of_is_searchable_of_lt <;> assumption
-
-
-  all_goals apply is_searchable_balance1 <;> assumption
-#align rbnode.is_searchable_balance1_node RBNode.is_searchable_balance1_node
-
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic rbnode.is_searchable_tactic -/
 theorem is_searchable_balance2 {l y r v t lo hi} :
     IsSearchable lt t lo (some v) →
       IsSearchable lt l (some v) (some y) →
-        IsSearchable lt r (some y) hi → IsSearchable lt (balance2 l y r v t) lo hi :=
-  by
-  apply balance.cases l y r <;>
-    intros <;>
-      simp [*] <;>
-        run_tac
-          is_searchable_tactic
-#align rbnode.is_searchable_balance2 RBNode.is_searchable_balance2
+        IsSearchable lt r (some y) hi → IsSearchable lt (balance2 l y r v t) lo hi := sorry
 
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic rbnode.is_searchable_tactic -/
 theorem is_searchable_balance2_node {t} [IsTrans α lt] :
     ∀ {y s lo hi},
-      IsSearchable lt s lo (some y) → IsSearchable lt t (some y) hi → IsSearchable lt (balance2Node t y s) lo hi :=
-  by
-  induction t <;>
-    simp! <;>
-      intros <;>
-        run_tac
-          is_searchable_tactic
-  · cases hi
-    · apply is_searchable_none_high_of_is_searchable_some_high
-      assumption
+      IsSearchable lt s lo (some y) →
+        IsSearchable lt t (some y) hi →
+          IsSearchable lt (balance2Node t y s) lo hi := sorry
 
-    · simp at *
-      apply is_searchable_some_high_of_is_searchable_of_lt
-      assumption'
-
-
-  all_goals
-  apply is_searchable_balance2
-  assumption'
-#align rbnode.is_searchable_balance2_node RBNode.is_searchable_balance2_node
-
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic rbnode.is_searchable_tactic -/
 theorem is_searchable_ins [DecidableRel lt] {t x} [IsStrictWeakOrder α lt] :
     ∀ {lo hi} (h : IsSearchable lt t lo hi),
-      Lift lt lo (some x) → Lift lt (some x) hi → IsSearchable lt (ins lt t x) lo hi :=
-  by
-  apply ins.induction lt t x <;>
-    intros <;>
-      simp_all! (config := { eta := false }) <;>
-        run_tac
-          is_searchable_tactic
-  · apply ih h_hs₁
-    assumption
-    simp [*]
+      Lift lt lo (some x) → Lift lt (some x) hi → IsSearchable lt (ins lt t x) lo hi := sorry
 
-  · apply is_searchable_of_is_searchable_of_incomp hc
-    assumption
-
-  · apply is_searchable_of_incomp_of_is_searchable hc
-    assumption
-
-  · apply ih h_hs₂
-    cases hi <;> simp [*]
-    assumption
-
-  · apply is_searchable_balance1_node
-    apply ih h_hs₁
-    assumption
-    simp [*]
-    assumption
-
-  · apply ih h_hs₁
-    assumption
-    simp [*]
-
-  · apply is_searchable_of_is_searchable_of_incomp hc
-    assumption
-
-  · apply is_searchable_of_incomp_of_is_searchable hc
-    assumption
-
-  · apply is_searchable_balance2_node
-    assumption
-    apply ih h_hs₂
-    simp [*]
-    assumption
-
-  · apply ih h_hs₂
-    assumption
-    simp [*]
-
-#align rbnode.is_searchable_ins RBNode.is_searchable_ins
-
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic rbnode.is_searchable_tactic -/
 theorem is_searchable_mk_insert_result {c t} :
-    IsSearchable lt t none none → IsSearchable lt (mkInsertResult c t) none none := by
-  classical cases c <;> cases t <;> simp [mk_insert_result]
-#align rbnode.is_searchable_mk_insert_result RBNode.is_searchable_mk_insert_result
-
-theorem is_searchable_insert [DecidableRel lt] {t x} [IsStrictWeakOrder α lt] :
-    IsSearchable lt t none none → IsSearchable lt (insert lt t x) none none := by
-  intro h
-  simp [insert]
-  apply is_searchable_mk_insert_result
-  apply is_searchable_ins <;>
-    · first |assumption|simp
-
-#align rbnode.is_searchable_insert RBNode.is_searchable_insert
+    IsSearchable lt t none none → IsSearchable lt (mkInsertResult c t) none none := sorry
 
 end RBNode
 
@@ -282,740 +127,220 @@ attribute [local simp] mem balance1_node balance2_node
 -- mathport name: mem
 local infixl:0 " ∈ " => Mem lt
 
-theorem mem_balance1_node_of_mem_left {x s} (v) (t : RBNode α) : (x ∈ s) → (x ∈ balance1Node s v t) := by
-  cases s <;> simp [false_imp_iff]
-  all_goals apply balance.cases s_lchild s_val s_rchild <;> intros <;> simp at * <;> cases_type*or.1 <;> simp [*]
-#align rbnode.mem_balance1_node_of_mem_left RBNode.mem_balance1_node_of_mem_left
+theorem mem_balance1_node_of_mem_left {x s} (v) (t : RBNode α) :
+    (x ∈ s) → (x ∈ balance1Node s v t) := sorry
 
-theorem mem_balance2_node_of_mem_left {x s} (v) (t : RBNode α) : (x ∈ s) → (x ∈ balance2Node s v t) := by
-  cases s <;> simp [false_imp_iff]
-  all_goals apply balance.cases s_lchild s_val s_rchild <;> intros <;> simp at * <;> cases_type*or.1 <;> simp [*]
-#align rbnode.mem_balance2_node_of_mem_left RBNode.mem_balance2_node_of_mem_left
+theorem mem_balance2_node_of_mem_left {x s} (v) (t : RBNode α) :
+    (x ∈ s) → (x ∈ balance2Node s v t) := sorry
 
-theorem mem_balance1_node_of_mem_right {x t} (v) (s : RBNode α) : (x ∈ t) → (x ∈ balance1Node s v t) := by
-  intros
-  cases s <;> simp [*]
-  all_goals apply balance.cases s_lchild s_val s_rchild <;> intros <;> simp [*]
-#align rbnode.mem_balance1_node_of_mem_right RBNode.mem_balance1_node_of_mem_right
+theorem mem_balance1_node_of_mem_right {x t} (v) (s : RBNode α) :
+    (x ∈ t) → (x ∈ balance1Node s v t) := sorry
 
-theorem mem_balance2_node_of_mem_right {x t} (v) (s : RBNode α) : (x ∈ t) → (x ∈ balance2Node s v t) := by
-  intros
-  cases s <;> simp [*]
-  all_goals apply balance.cases s_lchild s_val s_rchild <;> intros <;> simp [*]
-#align rbnode.mem_balance2_node_of_mem_right RBNode.mem_balance2_node_of_mem_right
+theorem mem_balance2_node_of_mem_right {x t} (v) (s : RBNode α) :
+    (x ∈ t) → (x ∈ balance2Node s v t) := sorry
 
-theorem mem_balance1_node_of_incomp {x v} (s t) : ¬lt x v ∧ ¬lt v x → s ≠ leaf → (x ∈ balance1Node s v t) := by
-  intros
-  cases s <;> simp
-  · contradiction
+theorem mem_balance1_node_of_incomp {x v} (s t) :
+    ¬lt x v ∧ ¬lt v x → s ≠ leaf → (x ∈ balance1Node s v t) := sorry
 
-  all_goals apply balance.cases s_lchild s_val s_rchild <;> intros <;> simp [*]
-#align rbnode.mem_balance1_node_of_incomp RBNode.mem_balance1_node_of_incomp
+theorem mem_balance2_node_of_incomp {x v} (s t) :
+    ¬lt v x ∧ ¬lt x v → s ≠ leaf → (x ∈ balance2Node s v t) := sorry
 
-theorem mem_balance2_node_of_incomp {x v} (s t) : ¬lt v x ∧ ¬lt x v → s ≠ leaf → (x ∈ balance2Node s v t) := by
-  intros
-  cases s <;> simp
-  · contradiction
+theorem ins_ne_leaf [DecidableRel lt] (t : RBNode α) (x : α) : t.ins lt x ≠ leaf := sorry
 
-  all_goals apply balance.cases s_lchild s_val s_rchild <;> intros <;> simp [*]
-#align rbnode.mem_balance2_node_of_incomp RBNode.mem_balance2_node_of_incomp
+theorem insert_ne_leaf [DecidableRel lt] (t : RBNode α) (x : α) : insert lt t x ≠ leaf := sorry
 
-theorem ins_ne_leaf [DecidableRel lt] (t : RBNode α) (x : α) : t.ins lt x ≠ leaf := by
-  apply ins.induction lt t x
-  any_goals
-  intros
-  simp [ins, *]
-  · intros
-    apply balance1_node_ne_leaf
-    assumption
-
-  · intros
-    apply balance2_node_ne_leaf
-    assumption
-
-#align rbnode.ins_ne_leaf RBNode.ins_ne_leaf
-
-theorem insert_ne_leaf [DecidableRel lt] (t : RBNode α) (x : α) : insert lt t x ≠ leaf := by
-  simp [insert]
-  cases he : ins lt t x <;> cases get_color t <;> simp [mk_insert_result]
-  · have := ins_ne_leaf lt t x
-    contradiction
-
-  · exact absurd he (ins_ne_leaf _ _ _)
-
-#align rbnode.insert_ne_leaf RBNode.insert_ne_leaf
-
-theorem mem_ins_of_incomp [DecidableRel lt] (t : RBNode α) {x y : α} : ∀ h : ¬lt x y ∧ ¬lt y x, x ∈ t.ins lt y := by
-  apply ins.induction lt t y <;> intros <;> simp [ins, *]
-  · have := ih h
-    apply mem_balance1_node_of_mem_left
-    assumption
-
-  · have := ih h
-    apply mem_balance2_node_of_mem_left
-    assumption
-
-#align rbnode.mem_ins_of_incomp RBNode.mem_ins_of_incomp
+theorem mem_ins_of_incomp [DecidableRel lt] (t : RBNode α) {x y : α} : ∀ h :
+    ¬lt x y ∧ ¬lt y x, x ∈ t.ins lt y := sorry
 
 theorem mem_ins_of_mem [DecidableRel lt] [IsStrictWeakOrder α lt] {t : RBNode α} (z : α) :
-    ∀ {x} (h : x ∈ t), x ∈ t.ins lt z := by
-  apply ins.induction lt t z <;> intros <;> simp_all [ins] <;> try contradiction <;> cases_type*or.1
-  any_goals
-  intros
-  simp [h]
-  done
-  any_goals
-  intros
-  simp [ih h]
-  done
-  · have := incomp_trans_of lt h ⟨hc.2, hc.1⟩
-    simp [this]
+    ∀ {x} (h : x ∈ t), x ∈ t.ins lt z := sorry
 
-  · apply mem_balance1_node_of_mem_left
-    apply ih h
 
-  · apply mem_balance1_node_of_incomp
-    cases h
-    all_goals simp [*, ins_ne_leaf lt a z]
+theorem mem_mk_insert_result {a t} (c) : Mem lt a t → Mem lt a (mkInsertResult c t) := sorry
 
-  · apply mem_balance1_node_of_mem_right
-    assumption
+theorem mem_of_mem_mk_insert_result {a t c} : Mem lt a (mkInsertResult c t) → Mem lt a t := sorry
 
-  · have := incomp_trans_of lt hc ⟨h.2, h.1⟩
-    simp [this]
+theorem mem_insert_of_incomp [DecidableRel lt] (t : RBNode α) {x y : α} :
+    ∀ h : ¬lt x y ∧ ¬lt y x, x ∈ t.insert lt y := sorry
 
-  · apply mem_balance2_node_of_mem_right
-    assumption
 
-  · have := ins_ne_leaf lt a z
-    apply mem_balance2_node_of_incomp
-    cases h
-    simp [*]
-    apply ins_ne_leaf
+theorem mem_insert_of_mem [DecidableRel lt] [IsStrictWeakOrder α lt] {t x} (z) :
+    (x ∈ t) → (x ∈ t.insert lt z) := sorry
 
-  · apply mem_balance2_node_of_mem_left
-    apply ih h
+theorem of_mem_balance1_node {x s v t} :
+    (x ∈ balance1Node s v t) → (x ∈ s) ∨ ¬lt x v ∧ ¬lt v x ∨ (x ∈ t) := sorry
 
-#align rbnode.mem_ins_of_mem RBNode.mem_ins_of_mem
+theorem of_mem_balance2_node {x s v t} : (x ∈ balance2Node s v t) →
+    (x ∈ s) ∨ ¬lt x v ∧ ¬lt v x ∨ (x ∈ t) := sorry
 
-theorem mem_mk_insert_result {a t} (c) : Mem lt a t → Mem lt a (mkInsertResult c t) := by
-  intros <;> cases c <;> cases t <;> simp_all [mk_insert_result, mem]
-#align rbnode.mem_mk_insert_result RBNode.mem_mk_insert_result
-
-theorem mem_of_mem_mk_insert_result {a t c} : Mem lt a (mkInsertResult c t) → Mem lt a t := by
-  cases t <;> cases c <;> simp [mk_insert_result, mem] <;> intros <;> assumption
-#align rbnode.mem_of_mem_mk_insert_result RBNode.mem_of_mem_mk_insert_result
-
-theorem mem_insert_of_incomp [DecidableRel lt] (t : RBNode α) {x y : α} : ∀ h : ¬lt x y ∧ ¬lt y x, x ∈ t.insert lt y :=
-  by intros <;> unfold insert <;> apply mem_mk_insert_result <;> apply mem_ins_of_incomp <;> assumption
-#align rbnode.mem_insert_of_incomp RBNode.mem_insert_of_incomp
-
-theorem mem_insert_of_mem [DecidableRel lt] [IsStrictWeakOrder α lt] {t x} (z) : (x ∈ t) → (x ∈ t.insert lt z) := by
-  intros <;> apply mem_mk_insert_result <;> apply mem_ins_of_mem <;> assumption
-#align rbnode.mem_insert_of_mem RBNode.mem_insert_of_mem
-
-theorem of_mem_balance1_node {x s v t} : (x ∈ balance1Node s v t) → (x ∈ s) ∨ ¬lt x v ∧ ¬lt v x ∨ (x ∈ t) := by
-  cases s <;> simp
-  · intros
-    simp [*]
-
-  all_goals apply balance.cases s_lchild s_val s_rchild <;> intros <;> simp_all <;> cases_type*or.1 <;> simp [*]
-#align rbnode.of_mem_balance1_node RBNode.of_mem_balance1_node
-
-theorem of_mem_balance2_node {x s v t} : (x ∈ balance2Node s v t) → (x ∈ s) ∨ ¬lt x v ∧ ¬lt v x ∨ (x ∈ t) := by
-  cases s <;> simp
-  · intros
-    simp [*]
-
-  all_goals apply balance.cases s_lchild s_val s_rchild <;> intros <;> simp_all <;> cases_type*or.1 <;> simp [*]
-#align rbnode.of_mem_balance2_node RBNode.of_mem_balance2_node
-
-theorem equiv_or_mem_of_mem_ins [DecidableRel lt] {t : RBNode α} {x z} : ∀ h : x ∈ t.ins lt z, x ≈[lt]z ∨ (x ∈ t) := by
-  apply ins.induction lt t z <;> intros <;> simp_all [ins, StrictWeakOrder.Equiv] <;> cases_type*or.1
-  any_goals
-  intros
-  simp [h]
-  any_goals
-  intros
-  have ih := ih h
-  cases ih <;> simp [*]
-  done
-  · have h' := of_mem_balance1_node lt h
-    cases_type*or.1
-    have := ih h'
-    cases_type*or.1
-    all_goals simp [h, *]
-
-  · have h' := of_mem_balance2_node lt h
-    cases_type*or.1
-    have := ih h'
-    cases_type*or.1
-    all_goals simp [h, *]
-
-#align rbnode.equiv_or_mem_of_mem_ins RBNode.equiv_or_mem_of_mem_ins
+theorem equiv_or_mem_of_mem_ins [DecidableRel lt] {t : RBNode α} {x z} :
+    ∀ h : x ∈ t.ins lt z, x ≈[lt]z ∨ (x ∈ t) := sorry
 
 theorem equiv_or_mem_of_mem_insert [DecidableRel lt] {t : RBNode α} {x z} :
-    ∀ h : x ∈ t.insert lt z, x ≈[lt]z ∨ (x ∈ t) := by
-  simp [insert]
-  intros
-  apply equiv_or_mem_of_mem_ins
-  exact mem_of_mem_mk_insert_result lt h
-#align rbnode.equiv_or_mem_of_mem_insert RBNode.equiv_or_mem_of_mem_insert
+    ∀ h : x ∈ t.insert lt z, x ≈[lt]z ∨ (x ∈ t) := sorry
 
 attribute [local simp] mem_exact
 
 theorem mem_exact_balance1_node_of_mem_exact {x s} (v) (t : RBNode α) :
-    MemExact x s → MemExact x (balance1Node s v t) := by
-  cases s <;> simp [false_imp_iff]
-  all_goals apply balance.cases s_lchild s_val s_rchild <;> intros <;> simp_all <;> cases_type*or.1 <;> simp [*]
-#align rbnode.mem_exact_balance1_node_of_mem_exact RBNode.mem_exact_balance1_node_of_mem_exact
+    MemExact x s → MemExact x (balance1Node s v t) := sorry
 
 theorem mem_exact_balance2_node_of_mem_exact {x s} (v) (t : RBNode α) :
-    MemExact x s → MemExact x (balance2Node s v t) := by
-  cases s <;> simp [false_imp_iff]
-  all_goals apply balance.cases s_lchild s_val s_rchild <;> intros <;> simp_all <;> cases_type*or.1 <;> simp [*]
-#align rbnode.mem_exact_balance2_node_of_mem_exact RBNode.mem_exact_balance2_node_of_mem_exact
+    MemExact x s → MemExact x (balance2Node s v t) := sorry
+
 
 theorem find_balance1_node [DecidableRel lt] [IsStrictWeakOrder α lt] {x y z t s} :
     ∀ {lo hi},
       IsSearchable lt t lo (some z) →
-        IsSearchable lt s (some z) hi → find lt t y = some x → y ≈[lt]x → find lt (balance1Node t z s) y = some x :=
-  by
-  intro _ _ hs₁ hs₂ heq heqv
-  have hs := is_searchable_balance1_node lt hs₁ hs₂
-  have := Eq.trans (find_eq_find_of_eqv hs₁ heqv.symm) HEq
-  have := Iff.mpr (find_correct_exact hs₁) this
-  have := mem_exact_balance1_node_of_mem_exact z s this
-  have := Iff.mp (find_correct_exact hs) this
-  exact Eq.trans (find_eq_find_of_eqv hs heqv) this
-#align rbnode.find_balance1_node RBNode.find_balance1_node
+        IsSearchable lt s (some z) hi →
+          find lt t y = some x → y ≈[lt]x → find lt (balance1Node t z s) y = some x := sorry
 
 theorem find_balance2_node [DecidableRel lt] [IsStrictWeakOrder α lt] {x y z s t} [IsTrans α lt] :
     ∀ {lo hi},
       IsSearchable lt s lo (some z) →
-        IsSearchable lt t (some z) hi → find lt t y = some x → y ≈[lt]x → find lt (balance2Node t z s) y = some x :=
-  by
-  intro _ _ hs₁ hs₂ heq heqv
-  have hs := is_searchable_balance2_node lt hs₁ hs₂
-  have := Eq.trans (find_eq_find_of_eqv hs₂ heqv.symm) HEq
-  have := Iff.mpr (find_correct_exact hs₂) this
-  have := mem_exact_balance2_node_of_mem_exact z s this
-  have := Iff.mp (find_correct_exact hs) this
-  exact Eq.trans (find_eq_find_of_eqv hs heqv) this
-#align rbnode.find_balance2_node RBNode.find_balance2_node
+        IsSearchable lt t (some z) hi →
+          find lt t y = some x → y ≈[lt]x → find lt (balance2Node t z s) y = some x := sorry
 
 -- Auxiliary lemma
-theorem ite_eq_of_not_lt [DecidableRel lt] [IsStrictOrder α lt] {a b} {β : Type v} (t s : β) (h : lt b a) :
-    (if lt a b then t else s) = s := by
-  have := not_lt_of_lt h
-  simp [*]
-#align rbnode.ite_eq_of_not_lt RBNode.ite_eq_of_not_lt
+theorem ite_eq_of_not_lt
+    [DecidableRel lt] [IsStrictOrder α lt] {a b} {β : Type v} (t s : β) (h : lt b a) :
+      (if lt a b then t else s) = s := sorry
 
 attribute [local simp] ite_eq_of_not_lt
 
-/- ./././Mathport/Syntax/Translate/Expr.lean:332:4: warning: unsupported (TODO): `[tacs] -/
-private unsafe def simp_fi : tactic Unit :=
-  sorry
-#align rbnode.simp_fi rbnode.simp_fi
-
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic _private.3968712505.simp_fi -/
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic _private.3968712505.simp_fi -/
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic _private.3968712505.simp_fi -/
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic _private.3968712505.simp_fi -/
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic _private.3968712505.simp_fi -/
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic _private.3968712505.simp_fi -/
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic _private.3968712505.simp_fi -/
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic _private.3968712505.simp_fi -/
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic _private.3968712505.simp_fi -/
-theorem find_ins_of_eqv [DecidableRel lt] [IsStrictWeakOrder α lt] {x y : α} {t : RBNode α} (he : x ≈[lt]y) :
-    ∀ {lo hi} (hs : IsSearchable lt t lo hi) (hlt₁ : Lift lt lo (some x)) (hlt₂ : Lift lt (some x) hi),
-      find lt (ins lt t x) y = some x :=
-  by
-  simp [StrictWeakOrder.Equiv] at he
-  apply ins.induction lt t x <;> intros
-  · run_tac
-      simp_fi
-
-  all_goals
-  simp at hc
-  cases hs
-  · have := lt_of_incomp_of_lt he.swap hc
-    have := ih hs_hs₁ hlt₁ hc
-    run_tac
-      simp_fi
-
-  · run_tac
-      simp_fi
-
-  · have := lt_of_lt_of_incomp hc he
-    have := ih hs_hs₂ hc hlt₂
-    run_tac
-      simp_fi
-
-  · run_tac
-      simp_fi
-    have := is_searchable_ins lt hs_hs₁ hlt₁ hc
-    apply find_balance1_node lt this hs_hs₂ (ih hs_hs₁ hlt₁ hc) he.symm
-
-  · have := lt_of_incomp_of_lt he.swap hc
-    have := ih hs_hs₁ hlt₁ hc
-    run_tac
-      simp_fi
-
-  · run_tac
-      simp_fi
-
-  · run_tac
-      simp_fi
-    have := is_searchable_ins lt hs_hs₂ hc hlt₂
-    apply find_balance2_node lt hs_hs₁ this (ih hs_hs₂ hc hlt₂) he.symm
-
-  · have := lt_of_lt_of_incomp hc he
-    have := ih hs_hs₂ hc hlt₂
-    run_tac
-      simp_fi
-
-#align rbnode.find_ins_of_eqv RBNode.find_ins_of_eqv
+theorem find_ins_of_eqv
+    [DecidableRel lt] [IsStrictWeakOrder α lt] {x y : α} {t : RBNode α} (he : x ≈[lt]y) :
+      ∀ {lo hi}
+        (hs : IsSearchable lt t lo hi)
+        (hlt₁ : Lift lt lo (some x))
+        (hlt₂ :Lift lt (some x) hi), find lt (ins lt t x) y = some x := sorry
 
 theorem find_mk_insert_result [DecidableRel lt] (c : Color) (t : RBNode α) (x : α) :
-    find lt (mkInsertResult c t) x = find lt t x := by
-  cases t <;> cases c <;> simp [mk_insert_result]
-  · simp [find]
-    cases CmpUsing lt x t_val <;> simp [find]
+    find lt (mkInsertResult c t) x = find lt t x := sorry
 
-#align rbnode.find_mk_insert_result RBNode.find_mk_insert_result
+theorem find_insert_of_eqv
+    [DecidableRel lt]
+    [IsStrictWeakOrder α lt]
+    {x y : α}
+    {t : RBNode α}
+    (he : x ≈[lt]y) :
+      IsSearchable lt t none none → find lt (insert lt t x) y = some x := sorry
 
-theorem find_insert_of_eqv [DecidableRel lt] [IsStrictWeakOrder α lt] {x y : α} {t : RBNode α} (he : x ≈[lt]y) :
-    IsSearchable lt t none none → find lt (insert lt t x) y = some x := by
-  intro hs
-  simp [insert, find_mk_insert_result]
-  apply find_ins_of_eqv lt he hs <;> simp
-#align rbnode.find_insert_of_eqv RBNode.find_insert_of_eqv
-
-theorem weak_trichotomous (x y) {p : Prop} (is_lt : ∀ h : lt x y, p) (is_eqv : ∀ h : ¬lt x y ∧ ¬lt y x, p)
-    (is_gt : ∀ h : lt y x, p) : p := by
-  by_cases lt x y
-  · apply is_lt
-    assumption
-
-  by_cases lt y x
-  · apply is_gt
-    assumption
-
-  · apply is_eqv
-    constructor <;> assumption
-
-#align rbnode.weak_trichotomous RBNode.weak_trichotomous
+theorem weak_trichotomous
+    (x y)
+    {p : Prop}
+    (is_lt : ∀ h : lt x y, p)
+    (is_eqv : ∀ h : ¬lt x y ∧ ¬lt y x, p)
+    (is_gt : ∀ h : lt y x, p) : p := sorry
 
 section FindInsOfNotEqv
 
 section SimpAuxLemmas
 
 theorem find_black_eq_find_red [DecidableRel lt] {l y r x} :
-    find lt (black_node l y r) x = find lt (red_node l y r) x := by
-  simp [find]
-  all_goals cases CmpUsing lt x y <;> simp [find]
-#align rbnode.find_black_eq_find_red RBNode.find_black_eq_find_red
+    find lt (black_node l y r) x = find lt (red_node l y r) x := sorry
 
-theorem find_red_of_lt [DecidableRel lt] {l y r x} (h : lt x y) : find lt (red_node l y r) x = find lt l x := by
-  simp [find, CmpUsing, *]
-#align rbnode.find_red_of_lt RBNode.find_red_of_lt
+
+theorem find_red_of_lt [DecidableRel lt] {l y r x} (h : lt x y) :
+    find lt (red_node l y r) x = find lt l x := sorry
 
 theorem find_red_of_gt [DecidableRel lt] [IsStrictOrder α lt] {l y r x} (h : lt y x) :
-    find lt (red_node l y r) x = find lt r x := by
-  have := not_lt_of_lt h
-  simp [find, CmpUsing, *]
-#align rbnode.find_red_of_gt RBNode.find_red_of_gt
+    find lt (red_node l y r) x = find lt r x := sorry
 
-theorem find_red_of_incomp [DecidableRel lt] {l y r x} (h : ¬lt x y ∧ ¬lt y x) : find lt (red_node l y r) x = some y :=
-  by simp [find, CmpUsing, *]
-#align rbnode.find_red_of_incomp RBNode.find_red_of_incomp
+theorem find_red_of_incomp [DecidableRel lt] {l y r x} (h : ¬lt x y ∧ ¬lt y x) :
+    find lt (red_node l y r) x = some y := sorry
 
 end SimpAuxLemmas
 
-attribute [local simp] find_black_eq_find_red find_red_of_lt find_red_of_lt find_red_of_gt find_red_of_incomp
+-- attribute [local simp] find_black_eq_find_red find_red_of_lt
+--find_red_of_lt find_red_of_gt find_red_of_incomp
 
 variable [IsStrictWeakOrder α lt] [DecidableRel lt]
 
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic rbnode.is_searchable_tactic -/
 theorem find_balance1_lt {l r t v x y lo hi} (h : lt x y) (hl : IsSearchable lt l lo (some v))
     (hr : IsSearchable lt r (some v) (some y)) (ht : IsSearchable lt t (some y) hi) :
-    find lt (balance1 l v r y t) x = find lt (red_node l v r) x := by
-  revert hl hr ht
-  apply balance.cases l v r <;>
-    intros <;>
-      simp [*] <;>
-        run_tac
-          is_searchable_tactic
-  · apply weak_trichotomous lt y_1 x <;> intros <;> simp [*]
+    find lt (balance1 l v r y t) x = find lt (red_node l v r) x := sorry
 
-  · apply weak_trichotomous lt x_1 x <;> intro h'
-    · have := trans_of lt (lo_lt_hi hr_hs₁) h'
-      simp [*]
-
-    · have : lt y_1 x := lt_of_lt_of_incomp (lo_lt_hi hr_hs₁) h'
-      simp [*]
-
-    · apply weak_trichotomous lt y_1 x <;> intros <;> simp [*]
-
-
-#align rbnode.find_balance1_lt RBNode.find_balance1_lt
-
-/- ./././Mathport/Syntax/Translate/Expr.lean:332:4: warning: unsupported (TODO): `[tacs] -/
-unsafe def ins_ne_leaf_tac :=
-  sorry
-#align rbnode.ins_ne_leaf_tac rbnode.ins_ne_leaf_tac
-
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic rbnode.is_searchable_tactic -/
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic ins_ne_leaf_tac -/
 theorem find_balance1_node_lt {t s x y lo hi} (hlt : lt y x) (ht : IsSearchable lt t lo (some x))
     (hs : IsSearchable lt s (some x) hi)
-    (hne : t ≠ leaf := by
-      run_tac
-        ins_ne_leaf_tac) :
-    find lt (balance1Node t x s) y = find lt t y := by
-  cases t <;> simp [balance1_node]
-  · contradiction
+    (hne : t ≠ leaf := sorry
 
-  all_goals
-  intros
-  run_tac
-    is_searchable_tactic
-  apply find_balance1_lt
-  assumption'
-#align rbnode.find_balance1_node_lt RBNode.find_balance1_node_lt
-
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic rbnode.is_searchable_tactic -/
 theorem find_balance1_gt {l r t v x y lo hi} (h : lt y x) (hl : IsSearchable lt l lo (some v))
     (hr : IsSearchable lt r (some v) (some y)) (ht : IsSearchable lt t (some y) hi) :
-    find lt (balance1 l v r y t) x = find lt t x := by
-  revert hl hr ht
-  apply balance.cases l v r <;>
-    intros <;>
-      simp [*] <;>
-        run_tac
-          is_searchable_tactic
-  · have := trans_of lt (lo_lt_hi hr) h
-    simp [*]
+    find lt (balance1 l v r y t) x = find lt t x := sorry
 
-  · have := trans_of lt (lo_lt_hi hr_hs₂) h
-    simp [*]
-
-#align rbnode.find_balance1_gt RBNode.find_balance1_gt
-
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic rbnode.is_searchable_tactic -/
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic ins_ne_leaf_tac -/
 theorem find_balance1_node_gt {t s x y lo hi} (h : lt x y) (ht : IsSearchable lt t lo (some x))
     (hs : IsSearchable lt s (some x) hi)
-    (hne : t ≠ leaf := by
-      run_tac
-        ins_ne_leaf_tac) :
-    find lt (balance1Node t x s) y = find lt s y := by
-  cases t <;> simp [balance1_node]
-  all_goals
-  intros
-  run_tac
-    is_searchable_tactic
-  apply find_balance1_gt
-  assumption'
-#align rbnode.find_balance1_node_gt RBNode.find_balance1_node_gt
+    (hne : t ≠ leaf := sorry
 
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic rbnode.is_searchable_tactic -/
-theorem find_balance1_eqv {l r t v x y lo hi} (h : ¬lt x y ∧ ¬lt y x) (hl : IsSearchable lt l lo (some v))
-    (hr : IsSearchable lt r (some v) (some y)) (ht : IsSearchable lt t (some y) hi) :
-    find lt (balance1 l v r y t) x = some y := by
-  revert hl hr ht
-  apply balance.cases l v r <;>
-    intros <;>
-      simp [*] <;>
-        run_tac
-          is_searchable_tactic
-  · have : lt y_1 x := lt_of_lt_of_incomp (lo_lt_hi hr) h.swap
-    simp [*]
+theorem find_balance1_eqv
+    {l r t v x y lo hi}
+    (h : ¬lt x y ∧ ¬lt y x)
+    (hl : IsSearchable lt l lo (some v))
+    (hr : IsSearchable lt r (some v) (some y))
+    (ht : IsSearchable lt t (some y) hi) :
+      find lt (balance1 l v r y t) x = some y := sorry
 
-  · have : lt x_1 x := lt_of_lt_of_incomp (lo_lt_hi hr_hs₂) h.swap
-    simp [*]
-
-#align rbnode.find_balance1_eqv RBNode.find_balance1_eqv
-
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic rbnode.is_searchable_tactic -/
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic ins_ne_leaf_tac -/
-theorem find_balance1_node_eqv {t s x y lo hi} (h : ¬lt x y ∧ ¬lt y x) (ht : IsSearchable lt t lo (some y))
+theorem find_balance1_node_eqv
+    {t s x y lo hi} (h : ¬lt x y ∧ ¬lt y x)
+    (ht : IsSearchable lt t lo (some y))
     (hs : IsSearchable lt s (some y) hi)
-    (hne : t ≠ leaf := by
-      run_tac
-        ins_ne_leaf_tac) :
-    find lt (balance1Node t y s) x = some y := by
-  cases t <;> simp [balance1_node]
-  · contradiction
+    (hne : t ≠ leaf) :
+      find lt (balance1Node t y s) x = some y := sorry
 
-  all_goals
-  intros
-  run_tac
-    is_searchable_tactic
-  apply find_balance1_eqv
-  assumption'
-#align rbnode.find_balance1_node_eqv RBNode.find_balance1_node_eqv
 
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic rbnode.is_searchable_tactic -/
-theorem find_balance2_lt {l v r t x y lo hi} (h : lt x y) (hl : IsSearchable lt l (some y) (some v))
-    (hr : IsSearchable lt r (some v) hi) (ht : IsSearchable lt t lo (some y)) :
-    find lt (balance2 l v r y t) x = find lt t x := by
-  revert hl hr ht
-  apply balance.cases l v r <;>
-    intros <;>
-      simp [*] <;>
-        run_tac
-          is_searchable_tactic
-  · have := trans h (lo_lt_hi hl_hs₁)
-    simp [*]
-
-  · have := trans h (lo_lt_hi hl)
-    simp [*]
-
-#align rbnode.find_balance2_lt RBNode.find_balance2_lt
-
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic rbnode.is_searchable_tactic -/
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic ins_ne_leaf_tac -/
 theorem find_balance2_node_lt {s t x y lo hi} (h : lt x y) (ht : IsSearchable lt t (some y) hi)
     (hs : IsSearchable lt s lo (some y))
-    (hne : t ≠ leaf := by
-      run_tac
-        ins_ne_leaf_tac) :
-    find lt (balance2Node t y s) x = find lt s x := by
-  cases t <;> simp [balance2_node]
-  all_goals
-  intros
-  run_tac
-    is_searchable_tactic
-  apply find_balance2_lt
-  assumption'
-#align rbnode.find_balance2_node_lt RBNode.find_balance2_node_lt
+    (hne : t ≠ leaf := sorry
 
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic rbnode.is_searchable_tactic -/
 theorem find_balance2_gt {l v r t x y lo hi} (h : lt y x) (hl : IsSearchable lt l (some y) (some v))
     (hr : IsSearchable lt r (some v) hi) (ht : IsSearchable lt t lo (some y)) :
-    find lt (balance2 l v r y t) x = find lt (red_node l v r) x := by
-  revert hl hr ht
-  apply balance.cases l v r <;>
-    intros <;>
-      simp [*] <;>
-        run_tac
-          is_searchable_tactic
-  · apply weak_trichotomous lt x_1 x <;> intro h' <;> simp [*]
-    · apply weak_trichotomous lt y_1 x <;> intros <;> simp [*]
+    find lt (balance2 l v r y t) x = find lt (red_node l v r) x := sorry
 
-    · have : lt x _ := lt_of_incomp_of_lt h'.swap (lo_lt_hi hl_hs₂)
-      simp [*]
-
-    · have := trans h' (lo_lt_hi hl_hs₂)
-      simp [*]
-
-
-  · apply weak_trichotomous lt y_1 x <;> intros <;> simp [*]
-
-#align rbnode.find_balance2_gt RBNode.find_balance2_gt
-
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic rbnode.is_searchable_tactic -/
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic ins_ne_leaf_tac -/
 theorem find_balance2_node_gt {s t x y lo hi} (h : lt y x) (ht : IsSearchable lt t (some y) hi)
     (hs : IsSearchable lt s lo (some y))
-    (hne : t ≠ leaf := by
-      run_tac
-        ins_ne_leaf_tac) :
-    find lt (balance2Node t y s) x = find lt t x := by
-  cases t <;> simp [balance2_node]
-  · contradiction
+    (hne : t ≠ leaf := sorry
 
-  all_goals
-  intros
-  run_tac
-    is_searchable_tactic
-  apply find_balance2_gt
-  assumption'
-#align rbnode.find_balance2_node_gt RBNode.find_balance2_node_gt
+theorem find_balance2_eqv
+    {l v r t x y lo hi}
+    (h : ¬lt x y ∧ ¬lt y x)
+    (hl : IsSearchable lt l (some y) (some v))
+    (hr : IsSearchable lt r (some v) hi)
+    (ht : IsSearchable lt t lo (some y)) :
+      find lt (balance2 l v r y t) x = some y := sorry
 
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic rbnode.is_searchable_tactic -/
-theorem find_balance2_eqv {l v r t x y lo hi} (h : ¬lt x y ∧ ¬lt y x) (hl : IsSearchable lt l (some y) (some v))
-    (hr : IsSearchable lt r (some v) hi) (ht : IsSearchable lt t lo (some y)) :
-    find lt (balance2 l v r y t) x = some y := by
-  revert hl hr ht
-  apply balance.cases l v r <;>
-    intros <;>
-      simp [*] <;>
-        run_tac
-          is_searchable_tactic
-  · have := lt_of_incomp_of_lt h (lo_lt_hi hl_hs₁)
-    simp [*]
-
-  · have := lt_of_incomp_of_lt h (lo_lt_hi hl)
-    simp [*]
-
-#align rbnode.find_balance2_eqv RBNode.find_balance2_eqv
-
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic rbnode.is_searchable_tactic -/
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic ins_ne_leaf_tac -/
-theorem find_balance2_node_eqv {t s x y lo hi} (h : ¬lt x y ∧ ¬lt y x) (ht : IsSearchable lt t (some y) hi)
+theorem find_balance2_node_eqv
+    {t s x y lo hi}
+    (h : ¬lt x y ∧ ¬lt y x)
+    (ht : IsSearchable lt t (some y) hi)
     (hs : IsSearchable lt s lo (some y))
-    (hne : t ≠ leaf := by
-      run_tac
-        ins_ne_leaf_tac) :
-    find lt (balance2Node t y s) x = some y := by
-  cases t <;> simp [balance2_node]
-  · contradiction
+    (hne : t ≠ leaf) : find lt (balance2Node t y s) x = some y := sorry
 
-  all_goals
-  intros
-  run_tac
-    is_searchable_tactic
-  apply find_balance2_eqv
-  assumption'
-#align rbnode.find_balance2_node_eqv RBNode.find_balance2_node_eqv
-
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic _private.3968712505.simp_fi -/
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic _private.3968712505.simp_fi -/
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic _private.3968712505.simp_fi -/
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic _private.3968712505.simp_fi -/
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic _private.3968712505.simp_fi -/
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic _private.3968712505.simp_fi -/
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic _private.3968712505.simp_fi -/
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic _private.3968712505.simp_fi -/
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic _private.3968712505.simp_fi -/
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic _private.3968712505.simp_fi -/
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic _private.3968712505.simp_fi -/
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic _private.3968712505.simp_fi -/
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic _private.3968712505.simp_fi -/
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic _private.3968712505.simp_fi -/
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic _private.3968712505.simp_fi -/
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic _private.3968712505.simp_fi -/
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic _private.3968712505.simp_fi -/
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic _private.3968712505.simp_fi -/
-theorem find_ins_of_disj {x y : α} {t : RBNode α} (hn : lt x y ∨ lt y x) :
-    ∀ {lo hi} (hs : IsSearchable lt t lo hi) (hlt₁ : Lift lt lo (some x)) (hlt₂ : Lift lt (some x) hi),
-      find lt (ins lt t x) y = find lt t y :=
-  by
-  apply ins.induction lt t x <;> intros
-  · cases hn
-    all_goals simp [find, ins, CmpUsing, *]
-
-  all_goals
-  simp at hc
-  cases hs
-  · have := ih hs_hs₁ hlt₁ hc
-    run_tac
-      simp_fi
-
-  · cases hn
-    · have := lt_of_incomp_of_lt hc.symm hn
-      run_tac
-        simp_fi
-
-    · have := lt_of_lt_of_incomp hn hc
-      run_tac
-        simp_fi
-
-
-  · have := ih hs_hs₂ hc hlt₂
-    run_tac
-      simp_fi
-
-  · have ih := ih hs_hs₁ hlt₁ hc
-    cases hn
-    · cases hc' : CmpUsing lt y y_1 <;> simp at hc'
-      · have hsi := is_searchable_ins lt hs_hs₁ hlt₁ (trans_of lt hn hc')
-        have := find_balance1_node_lt lt hc' hsi hs_hs₂
-        run_tac
-          simp_fi
-
-      · have hlt := lt_of_lt_of_incomp hn hc'
-        have hsi := is_searchable_ins lt hs_hs₁ hlt₁ hlt
-        have := find_balance1_node_eqv lt hc' hsi hs_hs₂
-        run_tac
-          simp_fi
-
-      · have hsi := is_searchable_ins lt hs_hs₁ hlt₁ hc
-        have := find_balance1_node_gt lt hc' hsi hs_hs₂
-        simp [*]
-        run_tac
-          simp_fi
-
-
-    · have hlt := trans hn hc
-      have hsi := is_searchable_ins lt hs_hs₁ hlt₁ hc
-      have := find_balance1_node_lt lt hlt hsi hs_hs₂
-      run_tac
-        simp_fi
-
-
-  · have := ih hs_hs₁ hlt₁ hc
-    run_tac
-      simp_fi
-
-  · cases hn
-    · have := lt_of_incomp_of_lt hc.swap hn
-      run_tac
-        simp_fi
-
-    · have := lt_of_lt_of_incomp hn hc
-      run_tac
-        simp_fi
-
-
-  · have ih := ih hs_hs₂ hc hlt₂
-    cases hn
-    · have hlt := trans hc hn
-      run_tac
-        simp_fi
-      have hsi := is_searchable_ins lt hs_hs₂ hc hlt₂
-      have := find_balance2_node_gt lt hlt hsi hs_hs₁
-      run_tac
-        simp_fi
-
-    · run_tac
-        simp_fi
-      cases hc' : CmpUsing lt y y_1 <;> simp at hc'
-      · have hsi := is_searchable_ins lt hs_hs₂ hc hlt₂
-        have := find_balance2_node_lt lt hc' hsi hs_hs₁
-        run_tac
-          simp_fi
-
-      · have hlt := lt_of_incomp_of_lt hc'.swap hn
-        have hsi := is_searchable_ins lt hs_hs₂ hlt hlt₂
-        have := find_balance2_node_eqv lt hc' hsi hs_hs₁
-        run_tac
-          simp_fi
-
-      · have hsi := is_searchable_ins lt hs_hs₂ hc hlt₂
-        have := find_balance2_node_gt lt hc' hsi hs_hs₁
-        run_tac
-          simp_fi
-
-
-
-  · have ih := ih hs_hs₂ hc hlt₂
-    run_tac
-      simp_fi
-
-#align rbnode.find_ins_of_disj RBNode.find_ins_of_disj
+theorem find_ins_of_disj
+    {x y : α}
+    {t : RBNode α}
+    (hn : lt x y ∨ lt y x) :
+      ∀ {lo hi}
+        (hs : IsSearchable lt t lo hi)
+        (hlt₁ : Lift lt lo (some x))
+        (hlt₂ : Lift lt (some x) hi), find lt (ins lt t x) y = find lt t y := sorry
 
 end FindInsOfNotEqv
 
-theorem find_insert_of_disj [DecidableRel lt] [IsStrictWeakOrder α lt] {x y : α} {t : RBNode α} (hd : lt x y ∨ lt y x) :
-    IsSearchable lt t none none → find lt (insert lt t x) y = find lt t y := by
-  intro hs
-  simp [insert, find_mk_insert_result]
-  apply find_ins_of_disj lt hd hs <;> simp
-#align rbnode.find_insert_of_disj RBNode.find_insert_of_disj
+theorem find_insert_of_disj
+    [DecidableRel lt]
+    [IsStrictWeakOrder α lt]
+    {x y : α}
+    {t : RBNode α}
+    (hd : lt x y ∨ lt y x) :
+      IsSearchable lt t none none → find lt (insert lt t x) y = find lt t y := sorry
 
-theorem find_insert_of_not_eqv [DecidableRel lt] [IsStrictWeakOrder α lt] {x y : α} {t : RBNode α} (hn : ¬x ≈[lt]y) :
-    IsSearchable lt t none none → find lt (insert lt t x) y = find lt t y := by
-  intro hs
-  simp [insert, find_mk_insert_result]
-  have he : lt x y ∨ lt y x := by
-    simp [StrictWeakOrder.Equiv, Decidable.not_and_iff_or_not, Decidable.not_not_iff] at hn
-    assumption
-  apply find_ins_of_disj lt he hs <;> simp
-#align rbnode.find_insert_of_not_eqv RBNode.find_insert_of_not_eqv
+theorem find_insert_of_not_eqv
+    [DecidableRel lt]
+    [IsStrictWeakOrder α lt]
+    {x y : α}
+    {t : RBNode α}
+    (hn : ¬x ≈[lt]y) :
+      IsSearchable lt t none none → find lt (insert lt t x) y = find lt t y := sorry
 
 end MembershipLemmas
 
@@ -1025,120 +350,47 @@ variable {α : Type u}
 
 open Nat Color
 
-inductive IsBadRedBlack : RBNode α → Nat → Prop
-  | bad_red {c₁ c₂ n l r v} (rb_l : IsRedBlack l c₁ n) (rb_r : IsRedBlack r c₂ n) : is_bad_red_black (red_node l v r) n
-#align rbnode.is_bad_red_black RBNode.IsBadRedBlack
+inductive IsBadRedBlack : RBNode α → Nat → Prop := sorry
 
 theorem balance1_rb {l r t : RBNode α} {y v : α} {c_l c_r c_t n} :
-    IsRedBlack l c_l n → IsRedBlack r c_r n → IsRedBlack t c_t n → ∃ c, IsRedBlack (balance1 l y r v t) c (succ n) := by
-  intro h₁ h₂ _ <;> cases h₁ <;> cases h₂ <;> repeat' first |assumption|constructor
-#align rbnode.balance1_rb RBNode.balance1_rb
+    IsRedBlack l c_l n → IsRedBlack r c_r n →
+      IsRedBlack t c_t n →
+        ∃ c, IsRedBlack (balance1 l y r v t) c (succ n) := sorry
 
 theorem balance2_rb {l r t : RBNode α} {y v : α} {c_l c_r c_t n} :
-    IsRedBlack l c_l n → IsRedBlack r c_r n → IsRedBlack t c_t n → ∃ c, IsRedBlack (balance2 l y r v t) c (succ n) := by
-  intro h₁ h₂ _ <;> cases h₁ <;> cases h₂ <;> repeat' first |assumption|constructor
-#align rbnode.balance2_rb RBNode.balance2_rb
+    IsRedBlack l c_l n →
+      IsRedBlack r c_r n →
+        IsRedBlack t c_t n →
+          ∃ c, IsRedBlack (balance2 l y r v t) c (succ n) := sorry
 
 theorem balance1_node_rb {t s : RBNode α} {y : α} {c n} :
-    IsBadRedBlack t n → IsRedBlack s c n → ∃ c, IsRedBlack (balance1Node t y s) c (succ n) := by
-  intro h _ <;> cases h <;> simp [balance1_node] <;> apply balance1_rb <;> assumption'
-#align rbnode.balance1_node_rb RBNode.balance1_node_rb
+    IsBadRedBlack t n → IsRedBlack s c n → ∃ c, IsRedBlack (balance1Node t y s) c (succ n) := sorry
 
 theorem balance2_node_rb {t s : RBNode α} {y : α} {c n} :
-    IsBadRedBlack t n → IsRedBlack s c n → ∃ c, IsRedBlack (balance2Node t y s) c (succ n) := by
-  intro h _ <;> cases h <;> simp [balance2_node] <;> apply balance2_rb <;> assumption'
-#align rbnode.balance2_node_rb RBNode.balance2_node_rb
+    IsBadRedBlack t n → IsRedBlack s c n → ∃ c, IsRedBlack (balance2Node t y s) c (succ n) := sorry
 
-def InsRbResult : RBNode α → Color → Nat → Prop
-  | t, red, n => IsBadRedBlack t n
-  | t, black, n => ∃ c, IsRedBlack t c n
-#align rbnode.ins_rb_result RBNode.InsRbResult
+def InsRbResult : RBNode α → Color → Nat → Prop := sorry
 
 variable {lt : α → α → Prop} [DecidableRel lt]
 
-theorem of_get_color_eq_red {t : RBNode α} {c n} : getColor t = red → IsRedBlack t c n → c = red := by
-  intro h₁ h₂
-  cases h₂ <;> simp only [get_color] at h₁ <;> contradiction
-#align rbnode.of_get_color_eq_red RBNode.of_get_color_eq_red
+theorem of_get_color_eq_red
+    {t : RBNode α} {c n} : getColor t = red → IsRedBlack t c n → c = red := sorry
 
-theorem of_get_color_ne_red {t : RBNode α} {c n} : getColor t ≠ red → IsRedBlack t c n → c = black := by
-  intro h₁ h₂
-  cases h₂ <;> simp only [get_color] at h₁ <;> contradiction
-#align rbnode.of_get_color_ne_red RBNode.of_get_color_ne_red
+theorem of_get_color_ne_red
+    {t : RBNode α} {c n} : getColor t ≠ red → IsRedBlack t c n → c = black := sorry
 
 variable (lt)
 
-theorem ins_rb {t : RBNode α} (x) : ∀ {c n} (h : IsRedBlack t c n), InsRbResult (ins lt t x) c n := by
-  apply ins.induction lt t x <;> intros <;> cases h <;> simp [ins, *, ins_rb_result]
-  · repeat' constructor
+theorem ins_rb
+    {t : RBNode α} (x) : ∀ {c n} (h : IsRedBlack t c n), InsRbResult (ins lt t x) c n := sorry
 
-  · specialize ih h_rb_l
-    cases ih
-    constructor <;> assumption
+def InsertRbResult : RBNode α → Color → Nat → Prop := sorry
 
-  · constructor <;> assumption
+theorem insert_rb
+    {t : RBNode α} (x) {c n} (h : IsRedBlack t c n) : InsertRbResult (insert lt t x) c n := sorry
 
-  · specialize ih h_rb_r
-    cases ih
-    constructor <;> assumption
-
-  · specialize ih h_rb_l
-    cases of_get_color_eq_red hr h_rb_l
-    apply balance1_node_rb <;> assumption
-
-  · specialize ih h_rb_l
-    cases of_get_color_ne_red hnr h_rb_l
-    cases ih
-    constructor
-    constructor <;> assumption
-
-  · constructor
-    constructor <;> assumption
-
-  · specialize ih h_rb_r
-    cases of_get_color_eq_red hr h_rb_r
-    apply balance2_node_rb <;> assumption
-
-  · specialize ih h_rb_r
-    cases of_get_color_ne_red hnr h_rb_r
-    cases ih
-    constructor
-    constructor <;> assumption
-
-#align rbnode.ins_rb RBNode.ins_rb
-
-def InsertRbResult : RBNode α → Color → Nat → Prop
-  | t, red, n => IsRedBlack t black (succ n)
-  | t, black, n => ∃ c, IsRedBlack t c n
-#align rbnode.insert_rb_result RBNode.InsertRbResult
-
-theorem insert_rb {t : RBNode α} (x) {c n} (h : IsRedBlack t c n) : InsertRbResult (insert lt t x) c n := by
-  simp [insert]
-  have hi := ins_rb lt x h
-  generalize he : ins lt t x = r
-  simp [he] at hi
-  cases h <;> simp [get_color, ins_rb_result, insert_rb_result, mk_insert_result] at *
-  assumption'
-  · cases hi
-    simp [mk_insert_result]
-    constructor <;> assumption
-
-#align rbnode.insert_rb RBNode.insert_rb
-
-theorem insert_is_red_black {t : RBNode α} {c n} (x) : IsRedBlack t c n → ∃ c n, IsRedBlack (insert lt t x) c n := by
-  intro h
-  have := insert_rb lt x h
-  cases c <;> simp [insert_rb_result] at this
-  · constructor
-    constructor
-    assumption
-
-  · cases this
-    constructor
-    constructor
-    assumption
-
-#align rbnode.insert_is_red_black RBNode.insert_is_red_black
+theorem insert_is_red_black
+    {t : RBNode α} {c n} (x) : IsRedBlack t c n → ∃ c n, IsRedBlack (insert lt t x) c n := sorry
 
 end IsRedBlack
 

--- a/Mathlib/Data/RBTree/Insert.lean
+++ b/Mathlib/Data/RBTree/Insert.lean
@@ -10,6 +10,12 @@ import Mathlib.Data.RBTree.Find
 
 Ported to preserve theorems, heavily covered by existing `Std` theorems
 -/
+section
+set_option linter.deprecated false
+-- FIXME: remove this when the sorries are gone
+set_option warningAsError false
+-- FIXME: remove this when theorems are ported
+set_option checkBinderAnnotations false
 
 
 universe u v

--- a/Mathlib/Data/RBTree/Insert.lean
+++ b/Mathlib/Data/RBTree/Insert.lean
@@ -1,0 +1,1145 @@
+/-
+Copyright (c) 2017 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Leonardo de Moura
+-/
+import Mathlib.Data.RBTree.Find
+
+/-!
+# Basic theorems on structural/well-foundeness after `insert`
+
+Ported to preserve theorems, heavily covered by existing `Std` theorems
+-/
+
+
+universe u v
+
+namespace RBNode
+
+variable {α : Type u}
+
+open Color
+
+@[simp]
+theorem balance1_eq₁ (l : RBNode α) (x r₁ y r₂ v t) :
+    balance1 (red_node l x r₁) y r₂ v t = sorry
+
+@[simp]
+theorem balance1_eq₂ (l₁ : RBNode α) (y l₂ x r v t) :
+    getColor l₁ ≠ red → balance1 l₁ y (red_node l₂ x r) v t = sorry
+
+@[simp]
+theorem balance1_eq₃ (l : RBNode α) (y r v t) :
+    getColor l ≠ red → getColor r ≠ red → balance1 l y r v t = black_node (red_node l y r) v t := by
+  cases l <;> cases r <;> simp [get_color, balance1, false_imp_iff]
+#align rbnode.balance1_eq₃ RBNode.balance1_eq₃
+
+@[simp]
+theorem balance2_eq₁ (l : RBNode α) (x₁ r₁ y r₂ v t) :
+    balance2 (red_node l x₁ r₁) y r₂ v t = red_node (black_node t v l) x₁ (black_node r₁ y r₂) := by cases r₂ <;> rfl
+#align rbnode.balance2_eq₁ RBNode.balance2_eq₁
+
+@[simp]
+theorem balance2_eq₂ (l₁ : RBNode α) (y l₂ x₂ r₂ v t) :
+    getColor l₁ ≠ red → balance2 l₁ y (red_node l₂ x₂ r₂) v t = red_node (black_node t v l₁) y (black_node l₂ x₂ r₂) :=
+  by cases l₁ <;> simp [get_color, balance2, false_imp_iff]
+#align rbnode.balance2_eq₂ RBNode.balance2_eq₂
+
+@[simp]
+theorem balance2_eq₃ (l : RBNode α) (y r v t) :
+    getColor l ≠ red → getColor r ≠ red → balance2 l y r v t = black_node t v (red_node l y r) := by
+  cases l <;> cases r <;> simp [get_color, balance2, false_imp_iff]
+#align rbnode.balance2_eq₃ RBNode.balance2_eq₃
+
+-- We can use the same induction principle for balance1 and balance2
+theorem Balance.cases {p : RBNode α → α → RBNode α → Prop} (l y r) (red_left : ∀ l x r₁ y r₂, p (red_node l x r₁) y r₂)
+    (red_right : ∀ l₁ y l₂ x r, getColor l₁ ≠ red → p l₁ y (red_node l₂ x r))
+    (other : ∀ l y r, getColor l ≠ red → getColor r ≠ red → p l y r) : p l y r := by
+  cases l <;> cases r
+  any_goals apply red_left
+  any_goals apply red_right <;> simp [get_color] <;> contradiction <;> done
+  any_goals apply other <;> simp [get_color] <;> contradiction <;> done
+#align rbnode.balance.cases RBNode.Balance.cases
+
+theorem balance1_ne_leaf (l : RBNode α) (x r v t) : balance1 l x r v t ≠ leaf := by
+  apply balance.cases l x r <;> intros <;> simp [*] <;> contradiction
+#align rbnode.balance1_ne_leaf RBNode.balance1_ne_leaf
+
+theorem balance1_node_ne_leaf {s : RBNode α} (a : α) (t : RBNode α) : s ≠ leaf → balance1Node s a t ≠ leaf := by
+  intro h
+  cases s
+  · contradiction
+
+  all_goals
+  simp [balance1_node]
+  apply balance1_ne_leaf
+#align rbnode.balance1_node_ne_leaf RBNode.balance1_node_ne_leaf
+
+theorem balance2_ne_leaf (l : RBNode α) (x r v t) : balance2 l x r v t ≠ leaf := by
+  apply balance.cases l x r <;> intros <;> simp [*] <;> contradiction
+#align rbnode.balance2_ne_leaf RBNode.balance2_ne_leaf
+
+theorem balance2_node_ne_leaf {s : RBNode α} (a : α) (t : RBNode α) : s ≠ leaf → balance2Node s a t ≠ leaf := by
+  intro h
+  cases s
+  · contradiction
+
+  all_goals
+  simp [balance2_node]
+  apply balance2_ne_leaf
+#align rbnode.balance2_node_ne_leaf RBNode.balance2_node_ne_leaf
+
+variable (lt : α → α → Prop)
+
+@[elab_as_elim]
+theorem ins.induction [DecidableRel lt] {p : RBNode α → Prop} (t x) (is_leaf : p leaf)
+    (is_red_lt : ∀ (a y b) (hc : CmpUsing lt x y = Ordering.lt) (ih : p a), p (red_node a y b))
+    (is_red_eq : ∀ (a y b) (hc : CmpUsing lt x y = Ordering.eq), p (red_node a y b))
+    (is_red_gt : ∀ (a y b) (hc : CmpUsing lt x y = Ordering.gt) (ih : p b), p (red_node a y b))
+    (is_black_lt_red :
+      ∀ (a y b) (hc : CmpUsing lt x y = Ordering.lt) (hr : getColor a = red) (ih : p a), p (black_node a y b))
+    (is_black_lt_not_red :
+      ∀ (a y b) (hc : CmpUsing lt x y = Ordering.lt) (hnr : getColor a ≠ red) (ih : p a), p (black_node a y b))
+    (is_black_eq : ∀ (a y b) (hc : CmpUsing lt x y = Ordering.eq), p (black_node a y b))
+    (is_black_gt_red :
+      ∀ (a y b) (hc : CmpUsing lt x y = Ordering.gt) (hr : getColor b = red) (ih : p b), p (black_node a y b))
+    (is_black_gt_not_red :
+      ∀ (a y b) (hc : CmpUsing lt x y = Ordering.gt) (hnr : getColor b ≠ red) (ih : p b), p (black_node a y b)) :
+    p t := by
+  induction t
+  case leaf => apply is_leaf
+  case red_node a y b =>
+  cases h : CmpUsing lt x y
+  case lt => apply is_red_lt <;> assumption
+  case eq => apply is_red_eq <;> assumption
+  case gt => apply is_red_gt <;> assumption
+  case black_node a y b =>
+  cases h : CmpUsing lt x y
+  case lt =>
+  by_cases get_color a = red
+  · apply is_black_lt_red <;> assumption
+
+  · apply is_black_lt_not_red <;> assumption
+
+  case eq => apply is_black_eq <;> assumption
+  case gt =>
+  by_cases get_color b = red
+  · apply is_black_gt_red <;> assumption
+
+  · apply is_black_gt_not_red <;> assumption
+
+#align rbnode.ins.induction RBNode.ins.induction
+
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic rbnode.is_searchable_tactic -/
+theorem is_searchable_balance1 {l y r v t lo hi} :
+    IsSearchable lt l lo (some y) →
+      IsSearchable lt r (some y) (some v) →
+        IsSearchable lt t (some v) hi → IsSearchable lt (balance1 l y r v t) lo hi :=
+  by
+  apply balance.cases l y r <;>
+    intros <;>
+      simp [*] <;>
+        run_tac
+          is_searchable_tactic
+#align rbnode.is_searchable_balance1 RBNode.is_searchable_balance1
+
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic rbnode.is_searchable_tactic -/
+theorem is_searchable_balance1_node {t} [IsTrans α lt] :
+    ∀ {y s lo hi},
+      IsSearchable lt t lo (some y) → IsSearchable lt s (some y) hi → IsSearchable lt (balance1Node t y s) lo hi :=
+  by
+  cases t <;>
+    simp! <;>
+      intros <;>
+        run_tac
+          is_searchable_tactic
+  · cases lo
+    · apply is_searchable_none_low_of_is_searchable_some_low
+      assumption
+
+    · simp at *
+      apply is_searchable_some_low_of_is_searchable_of_lt <;> assumption
+
+
+  all_goals apply is_searchable_balance1 <;> assumption
+#align rbnode.is_searchable_balance1_node RBNode.is_searchable_balance1_node
+
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic rbnode.is_searchable_tactic -/
+theorem is_searchable_balance2 {l y r v t lo hi} :
+    IsSearchable lt t lo (some v) →
+      IsSearchable lt l (some v) (some y) →
+        IsSearchable lt r (some y) hi → IsSearchable lt (balance2 l y r v t) lo hi :=
+  by
+  apply balance.cases l y r <;>
+    intros <;>
+      simp [*] <;>
+        run_tac
+          is_searchable_tactic
+#align rbnode.is_searchable_balance2 RBNode.is_searchable_balance2
+
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic rbnode.is_searchable_tactic -/
+theorem is_searchable_balance2_node {t} [IsTrans α lt] :
+    ∀ {y s lo hi},
+      IsSearchable lt s lo (some y) → IsSearchable lt t (some y) hi → IsSearchable lt (balance2Node t y s) lo hi :=
+  by
+  induction t <;>
+    simp! <;>
+      intros <;>
+        run_tac
+          is_searchable_tactic
+  · cases hi
+    · apply is_searchable_none_high_of_is_searchable_some_high
+      assumption
+
+    · simp at *
+      apply is_searchable_some_high_of_is_searchable_of_lt
+      assumption'
+
+
+  all_goals
+  apply is_searchable_balance2
+  assumption'
+#align rbnode.is_searchable_balance2_node RBNode.is_searchable_balance2_node
+
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic rbnode.is_searchable_tactic -/
+theorem is_searchable_ins [DecidableRel lt] {t x} [IsStrictWeakOrder α lt] :
+    ∀ {lo hi} (h : IsSearchable lt t lo hi),
+      Lift lt lo (some x) → Lift lt (some x) hi → IsSearchable lt (ins lt t x) lo hi :=
+  by
+  apply ins.induction lt t x <;>
+    intros <;>
+      simp_all! (config := { eta := false }) <;>
+        run_tac
+          is_searchable_tactic
+  · apply ih h_hs₁
+    assumption
+    simp [*]
+
+  · apply is_searchable_of_is_searchable_of_incomp hc
+    assumption
+
+  · apply is_searchable_of_incomp_of_is_searchable hc
+    assumption
+
+  · apply ih h_hs₂
+    cases hi <;> simp [*]
+    assumption
+
+  · apply is_searchable_balance1_node
+    apply ih h_hs₁
+    assumption
+    simp [*]
+    assumption
+
+  · apply ih h_hs₁
+    assumption
+    simp [*]
+
+  · apply is_searchable_of_is_searchable_of_incomp hc
+    assumption
+
+  · apply is_searchable_of_incomp_of_is_searchable hc
+    assumption
+
+  · apply is_searchable_balance2_node
+    assumption
+    apply ih h_hs₂
+    simp [*]
+    assumption
+
+  · apply ih h_hs₂
+    assumption
+    simp [*]
+
+#align rbnode.is_searchable_ins RBNode.is_searchable_ins
+
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic rbnode.is_searchable_tactic -/
+theorem is_searchable_mk_insert_result {c t} :
+    IsSearchable lt t none none → IsSearchable lt (mkInsertResult c t) none none := by
+  classical cases c <;> cases t <;> simp [mk_insert_result]
+#align rbnode.is_searchable_mk_insert_result RBNode.is_searchable_mk_insert_result
+
+theorem is_searchable_insert [DecidableRel lt] {t x} [IsStrictWeakOrder α lt] :
+    IsSearchable lt t none none → IsSearchable lt (insert lt t x) none none := by
+  intro h
+  simp [insert]
+  apply is_searchable_mk_insert_result
+  apply is_searchable_ins <;>
+    · first |assumption|simp
+
+#align rbnode.is_searchable_insert RBNode.is_searchable_insert
+
+end RBNode
+
+namespace RBNode
+
+section MembershipLemmas
+
+parameter {α : Type u}(lt : α → α → Prop)
+
+attribute [local simp] mem balance1_node balance2_node
+
+-- mathport name: mem
+local infixl:0 " ∈ " => Mem lt
+
+theorem mem_balance1_node_of_mem_left {x s} (v) (t : RBNode α) : (x ∈ s) → (x ∈ balance1Node s v t) := by
+  cases s <;> simp [false_imp_iff]
+  all_goals apply balance.cases s_lchild s_val s_rchild <;> intros <;> simp at * <;> cases_type*or.1 <;> simp [*]
+#align rbnode.mem_balance1_node_of_mem_left RBNode.mem_balance1_node_of_mem_left
+
+theorem mem_balance2_node_of_mem_left {x s} (v) (t : RBNode α) : (x ∈ s) → (x ∈ balance2Node s v t) := by
+  cases s <;> simp [false_imp_iff]
+  all_goals apply balance.cases s_lchild s_val s_rchild <;> intros <;> simp at * <;> cases_type*or.1 <;> simp [*]
+#align rbnode.mem_balance2_node_of_mem_left RBNode.mem_balance2_node_of_mem_left
+
+theorem mem_balance1_node_of_mem_right {x t} (v) (s : RBNode α) : (x ∈ t) → (x ∈ balance1Node s v t) := by
+  intros
+  cases s <;> simp [*]
+  all_goals apply balance.cases s_lchild s_val s_rchild <;> intros <;> simp [*]
+#align rbnode.mem_balance1_node_of_mem_right RBNode.mem_balance1_node_of_mem_right
+
+theorem mem_balance2_node_of_mem_right {x t} (v) (s : RBNode α) : (x ∈ t) → (x ∈ balance2Node s v t) := by
+  intros
+  cases s <;> simp [*]
+  all_goals apply balance.cases s_lchild s_val s_rchild <;> intros <;> simp [*]
+#align rbnode.mem_balance2_node_of_mem_right RBNode.mem_balance2_node_of_mem_right
+
+theorem mem_balance1_node_of_incomp {x v} (s t) : ¬lt x v ∧ ¬lt v x → s ≠ leaf → (x ∈ balance1Node s v t) := by
+  intros
+  cases s <;> simp
+  · contradiction
+
+  all_goals apply balance.cases s_lchild s_val s_rchild <;> intros <;> simp [*]
+#align rbnode.mem_balance1_node_of_incomp RBNode.mem_balance1_node_of_incomp
+
+theorem mem_balance2_node_of_incomp {x v} (s t) : ¬lt v x ∧ ¬lt x v → s ≠ leaf → (x ∈ balance2Node s v t) := by
+  intros
+  cases s <;> simp
+  · contradiction
+
+  all_goals apply balance.cases s_lchild s_val s_rchild <;> intros <;> simp [*]
+#align rbnode.mem_balance2_node_of_incomp RBNode.mem_balance2_node_of_incomp
+
+theorem ins_ne_leaf [DecidableRel lt] (t : RBNode α) (x : α) : t.ins lt x ≠ leaf := by
+  apply ins.induction lt t x
+  any_goals
+  intros
+  simp [ins, *]
+  · intros
+    apply balance1_node_ne_leaf
+    assumption
+
+  · intros
+    apply balance2_node_ne_leaf
+    assumption
+
+#align rbnode.ins_ne_leaf RBNode.ins_ne_leaf
+
+theorem insert_ne_leaf [DecidableRel lt] (t : RBNode α) (x : α) : insert lt t x ≠ leaf := by
+  simp [insert]
+  cases he : ins lt t x <;> cases get_color t <;> simp [mk_insert_result]
+  · have := ins_ne_leaf lt t x
+    contradiction
+
+  · exact absurd he (ins_ne_leaf _ _ _)
+
+#align rbnode.insert_ne_leaf RBNode.insert_ne_leaf
+
+theorem mem_ins_of_incomp [DecidableRel lt] (t : RBNode α) {x y : α} : ∀ h : ¬lt x y ∧ ¬lt y x, x ∈ t.ins lt y := by
+  apply ins.induction lt t y <;> intros <;> simp [ins, *]
+  · have := ih h
+    apply mem_balance1_node_of_mem_left
+    assumption
+
+  · have := ih h
+    apply mem_balance2_node_of_mem_left
+    assumption
+
+#align rbnode.mem_ins_of_incomp RBNode.mem_ins_of_incomp
+
+theorem mem_ins_of_mem [DecidableRel lt] [IsStrictWeakOrder α lt] {t : RBNode α} (z : α) :
+    ∀ {x} (h : x ∈ t), x ∈ t.ins lt z := by
+  apply ins.induction lt t z <;> intros <;> simp_all [ins] <;> try contradiction <;> cases_type*or.1
+  any_goals
+  intros
+  simp [h]
+  done
+  any_goals
+  intros
+  simp [ih h]
+  done
+  · have := incomp_trans_of lt h ⟨hc.2, hc.1⟩
+    simp [this]
+
+  · apply mem_balance1_node_of_mem_left
+    apply ih h
+
+  · apply mem_balance1_node_of_incomp
+    cases h
+    all_goals simp [*, ins_ne_leaf lt a z]
+
+  · apply mem_balance1_node_of_mem_right
+    assumption
+
+  · have := incomp_trans_of lt hc ⟨h.2, h.1⟩
+    simp [this]
+
+  · apply mem_balance2_node_of_mem_right
+    assumption
+
+  · have := ins_ne_leaf lt a z
+    apply mem_balance2_node_of_incomp
+    cases h
+    simp [*]
+    apply ins_ne_leaf
+
+  · apply mem_balance2_node_of_mem_left
+    apply ih h
+
+#align rbnode.mem_ins_of_mem RBNode.mem_ins_of_mem
+
+theorem mem_mk_insert_result {a t} (c) : Mem lt a t → Mem lt a (mkInsertResult c t) := by
+  intros <;> cases c <;> cases t <;> simp_all [mk_insert_result, mem]
+#align rbnode.mem_mk_insert_result RBNode.mem_mk_insert_result
+
+theorem mem_of_mem_mk_insert_result {a t c} : Mem lt a (mkInsertResult c t) → Mem lt a t := by
+  cases t <;> cases c <;> simp [mk_insert_result, mem] <;> intros <;> assumption
+#align rbnode.mem_of_mem_mk_insert_result RBNode.mem_of_mem_mk_insert_result
+
+theorem mem_insert_of_incomp [DecidableRel lt] (t : RBNode α) {x y : α} : ∀ h : ¬lt x y ∧ ¬lt y x, x ∈ t.insert lt y :=
+  by intros <;> unfold insert <;> apply mem_mk_insert_result <;> apply mem_ins_of_incomp <;> assumption
+#align rbnode.mem_insert_of_incomp RBNode.mem_insert_of_incomp
+
+theorem mem_insert_of_mem [DecidableRel lt] [IsStrictWeakOrder α lt] {t x} (z) : (x ∈ t) → (x ∈ t.insert lt z) := by
+  intros <;> apply mem_mk_insert_result <;> apply mem_ins_of_mem <;> assumption
+#align rbnode.mem_insert_of_mem RBNode.mem_insert_of_mem
+
+theorem of_mem_balance1_node {x s v t} : (x ∈ balance1Node s v t) → (x ∈ s) ∨ ¬lt x v ∧ ¬lt v x ∨ (x ∈ t) := by
+  cases s <;> simp
+  · intros
+    simp [*]
+
+  all_goals apply balance.cases s_lchild s_val s_rchild <;> intros <;> simp_all <;> cases_type*or.1 <;> simp [*]
+#align rbnode.of_mem_balance1_node RBNode.of_mem_balance1_node
+
+theorem of_mem_balance2_node {x s v t} : (x ∈ balance2Node s v t) → (x ∈ s) ∨ ¬lt x v ∧ ¬lt v x ∨ (x ∈ t) := by
+  cases s <;> simp
+  · intros
+    simp [*]
+
+  all_goals apply balance.cases s_lchild s_val s_rchild <;> intros <;> simp_all <;> cases_type*or.1 <;> simp [*]
+#align rbnode.of_mem_balance2_node RBNode.of_mem_balance2_node
+
+theorem equiv_or_mem_of_mem_ins [DecidableRel lt] {t : RBNode α} {x z} : ∀ h : x ∈ t.ins lt z, x ≈[lt]z ∨ (x ∈ t) := by
+  apply ins.induction lt t z <;> intros <;> simp_all [ins, StrictWeakOrder.Equiv] <;> cases_type*or.1
+  any_goals
+  intros
+  simp [h]
+  any_goals
+  intros
+  have ih := ih h
+  cases ih <;> simp [*]
+  done
+  · have h' := of_mem_balance1_node lt h
+    cases_type*or.1
+    have := ih h'
+    cases_type*or.1
+    all_goals simp [h, *]
+
+  · have h' := of_mem_balance2_node lt h
+    cases_type*or.1
+    have := ih h'
+    cases_type*or.1
+    all_goals simp [h, *]
+
+#align rbnode.equiv_or_mem_of_mem_ins RBNode.equiv_or_mem_of_mem_ins
+
+theorem equiv_or_mem_of_mem_insert [DecidableRel lt] {t : RBNode α} {x z} :
+    ∀ h : x ∈ t.insert lt z, x ≈[lt]z ∨ (x ∈ t) := by
+  simp [insert]
+  intros
+  apply equiv_or_mem_of_mem_ins
+  exact mem_of_mem_mk_insert_result lt h
+#align rbnode.equiv_or_mem_of_mem_insert RBNode.equiv_or_mem_of_mem_insert
+
+attribute [local simp] mem_exact
+
+theorem mem_exact_balance1_node_of_mem_exact {x s} (v) (t : RBNode α) :
+    MemExact x s → MemExact x (balance1Node s v t) := by
+  cases s <;> simp [false_imp_iff]
+  all_goals apply balance.cases s_lchild s_val s_rchild <;> intros <;> simp_all <;> cases_type*or.1 <;> simp [*]
+#align rbnode.mem_exact_balance1_node_of_mem_exact RBNode.mem_exact_balance1_node_of_mem_exact
+
+theorem mem_exact_balance2_node_of_mem_exact {x s} (v) (t : RBNode α) :
+    MemExact x s → MemExact x (balance2Node s v t) := by
+  cases s <;> simp [false_imp_iff]
+  all_goals apply balance.cases s_lchild s_val s_rchild <;> intros <;> simp_all <;> cases_type*or.1 <;> simp [*]
+#align rbnode.mem_exact_balance2_node_of_mem_exact RBNode.mem_exact_balance2_node_of_mem_exact
+
+theorem find_balance1_node [DecidableRel lt] [IsStrictWeakOrder α lt] {x y z t s} :
+    ∀ {lo hi},
+      IsSearchable lt t lo (some z) →
+        IsSearchable lt s (some z) hi → find lt t y = some x → y ≈[lt]x → find lt (balance1Node t z s) y = some x :=
+  by
+  intro _ _ hs₁ hs₂ heq heqv
+  have hs := is_searchable_balance1_node lt hs₁ hs₂
+  have := Eq.trans (find_eq_find_of_eqv hs₁ heqv.symm) HEq
+  have := Iff.mpr (find_correct_exact hs₁) this
+  have := mem_exact_balance1_node_of_mem_exact z s this
+  have := Iff.mp (find_correct_exact hs) this
+  exact Eq.trans (find_eq_find_of_eqv hs heqv) this
+#align rbnode.find_balance1_node RBNode.find_balance1_node
+
+theorem find_balance2_node [DecidableRel lt] [IsStrictWeakOrder α lt] {x y z s t} [IsTrans α lt] :
+    ∀ {lo hi},
+      IsSearchable lt s lo (some z) →
+        IsSearchable lt t (some z) hi → find lt t y = some x → y ≈[lt]x → find lt (balance2Node t z s) y = some x :=
+  by
+  intro _ _ hs₁ hs₂ heq heqv
+  have hs := is_searchable_balance2_node lt hs₁ hs₂
+  have := Eq.trans (find_eq_find_of_eqv hs₂ heqv.symm) HEq
+  have := Iff.mpr (find_correct_exact hs₂) this
+  have := mem_exact_balance2_node_of_mem_exact z s this
+  have := Iff.mp (find_correct_exact hs) this
+  exact Eq.trans (find_eq_find_of_eqv hs heqv) this
+#align rbnode.find_balance2_node RBNode.find_balance2_node
+
+-- Auxiliary lemma
+theorem ite_eq_of_not_lt [DecidableRel lt] [IsStrictOrder α lt] {a b} {β : Type v} (t s : β) (h : lt b a) :
+    (if lt a b then t else s) = s := by
+  have := not_lt_of_lt h
+  simp [*]
+#align rbnode.ite_eq_of_not_lt RBNode.ite_eq_of_not_lt
+
+attribute [local simp] ite_eq_of_not_lt
+
+/- ./././Mathport/Syntax/Translate/Expr.lean:332:4: warning: unsupported (TODO): `[tacs] -/
+private unsafe def simp_fi : tactic Unit :=
+  sorry
+#align rbnode.simp_fi rbnode.simp_fi
+
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic _private.3968712505.simp_fi -/
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic _private.3968712505.simp_fi -/
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic _private.3968712505.simp_fi -/
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic _private.3968712505.simp_fi -/
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic _private.3968712505.simp_fi -/
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic _private.3968712505.simp_fi -/
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic _private.3968712505.simp_fi -/
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic _private.3968712505.simp_fi -/
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic _private.3968712505.simp_fi -/
+theorem find_ins_of_eqv [DecidableRel lt] [IsStrictWeakOrder α lt] {x y : α} {t : RBNode α} (he : x ≈[lt]y) :
+    ∀ {lo hi} (hs : IsSearchable lt t lo hi) (hlt₁ : Lift lt lo (some x)) (hlt₂ : Lift lt (some x) hi),
+      find lt (ins lt t x) y = some x :=
+  by
+  simp [StrictWeakOrder.Equiv] at he
+  apply ins.induction lt t x <;> intros
+  · run_tac
+      simp_fi
+
+  all_goals
+  simp at hc
+  cases hs
+  · have := lt_of_incomp_of_lt he.swap hc
+    have := ih hs_hs₁ hlt₁ hc
+    run_tac
+      simp_fi
+
+  · run_tac
+      simp_fi
+
+  · have := lt_of_lt_of_incomp hc he
+    have := ih hs_hs₂ hc hlt₂
+    run_tac
+      simp_fi
+
+  · run_tac
+      simp_fi
+    have := is_searchable_ins lt hs_hs₁ hlt₁ hc
+    apply find_balance1_node lt this hs_hs₂ (ih hs_hs₁ hlt₁ hc) he.symm
+
+  · have := lt_of_incomp_of_lt he.swap hc
+    have := ih hs_hs₁ hlt₁ hc
+    run_tac
+      simp_fi
+
+  · run_tac
+      simp_fi
+
+  · run_tac
+      simp_fi
+    have := is_searchable_ins lt hs_hs₂ hc hlt₂
+    apply find_balance2_node lt hs_hs₁ this (ih hs_hs₂ hc hlt₂) he.symm
+
+  · have := lt_of_lt_of_incomp hc he
+    have := ih hs_hs₂ hc hlt₂
+    run_tac
+      simp_fi
+
+#align rbnode.find_ins_of_eqv RBNode.find_ins_of_eqv
+
+theorem find_mk_insert_result [DecidableRel lt] (c : Color) (t : RBNode α) (x : α) :
+    find lt (mkInsertResult c t) x = find lt t x := by
+  cases t <;> cases c <;> simp [mk_insert_result]
+  · simp [find]
+    cases CmpUsing lt x t_val <;> simp [find]
+
+#align rbnode.find_mk_insert_result RBNode.find_mk_insert_result
+
+theorem find_insert_of_eqv [DecidableRel lt] [IsStrictWeakOrder α lt] {x y : α} {t : RBNode α} (he : x ≈[lt]y) :
+    IsSearchable lt t none none → find lt (insert lt t x) y = some x := by
+  intro hs
+  simp [insert, find_mk_insert_result]
+  apply find_ins_of_eqv lt he hs <;> simp
+#align rbnode.find_insert_of_eqv RBNode.find_insert_of_eqv
+
+theorem weak_trichotomous (x y) {p : Prop} (is_lt : ∀ h : lt x y, p) (is_eqv : ∀ h : ¬lt x y ∧ ¬lt y x, p)
+    (is_gt : ∀ h : lt y x, p) : p := by
+  by_cases lt x y
+  · apply is_lt
+    assumption
+
+  by_cases lt y x
+  · apply is_gt
+    assumption
+
+  · apply is_eqv
+    constructor <;> assumption
+
+#align rbnode.weak_trichotomous RBNode.weak_trichotomous
+
+section FindInsOfNotEqv
+
+section SimpAuxLemmas
+
+theorem find_black_eq_find_red [DecidableRel lt] {l y r x} :
+    find lt (black_node l y r) x = find lt (red_node l y r) x := by
+  simp [find]
+  all_goals cases CmpUsing lt x y <;> simp [find]
+#align rbnode.find_black_eq_find_red RBNode.find_black_eq_find_red
+
+theorem find_red_of_lt [DecidableRel lt] {l y r x} (h : lt x y) : find lt (red_node l y r) x = find lt l x := by
+  simp [find, CmpUsing, *]
+#align rbnode.find_red_of_lt RBNode.find_red_of_lt
+
+theorem find_red_of_gt [DecidableRel lt] [IsStrictOrder α lt] {l y r x} (h : lt y x) :
+    find lt (red_node l y r) x = find lt r x := by
+  have := not_lt_of_lt h
+  simp [find, CmpUsing, *]
+#align rbnode.find_red_of_gt RBNode.find_red_of_gt
+
+theorem find_red_of_incomp [DecidableRel lt] {l y r x} (h : ¬lt x y ∧ ¬lt y x) : find lt (red_node l y r) x = some y :=
+  by simp [find, CmpUsing, *]
+#align rbnode.find_red_of_incomp RBNode.find_red_of_incomp
+
+end SimpAuxLemmas
+
+attribute [local simp] find_black_eq_find_red find_red_of_lt find_red_of_lt find_red_of_gt find_red_of_incomp
+
+variable [IsStrictWeakOrder α lt] [DecidableRel lt]
+
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic rbnode.is_searchable_tactic -/
+theorem find_balance1_lt {l r t v x y lo hi} (h : lt x y) (hl : IsSearchable lt l lo (some v))
+    (hr : IsSearchable lt r (some v) (some y)) (ht : IsSearchable lt t (some y) hi) :
+    find lt (balance1 l v r y t) x = find lt (red_node l v r) x := by
+  revert hl hr ht
+  apply balance.cases l v r <;>
+    intros <;>
+      simp [*] <;>
+        run_tac
+          is_searchable_tactic
+  · apply weak_trichotomous lt y_1 x <;> intros <;> simp [*]
+
+  · apply weak_trichotomous lt x_1 x <;> intro h'
+    · have := trans_of lt (lo_lt_hi hr_hs₁) h'
+      simp [*]
+
+    · have : lt y_1 x := lt_of_lt_of_incomp (lo_lt_hi hr_hs₁) h'
+      simp [*]
+
+    · apply weak_trichotomous lt y_1 x <;> intros <;> simp [*]
+
+
+#align rbnode.find_balance1_lt RBNode.find_balance1_lt
+
+/- ./././Mathport/Syntax/Translate/Expr.lean:332:4: warning: unsupported (TODO): `[tacs] -/
+unsafe def ins_ne_leaf_tac :=
+  sorry
+#align rbnode.ins_ne_leaf_tac rbnode.ins_ne_leaf_tac
+
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic rbnode.is_searchable_tactic -/
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic ins_ne_leaf_tac -/
+theorem find_balance1_node_lt {t s x y lo hi} (hlt : lt y x) (ht : IsSearchable lt t lo (some x))
+    (hs : IsSearchable lt s (some x) hi)
+    (hne : t ≠ leaf := by
+      run_tac
+        ins_ne_leaf_tac) :
+    find lt (balance1Node t x s) y = find lt t y := by
+  cases t <;> simp [balance1_node]
+  · contradiction
+
+  all_goals
+  intros
+  run_tac
+    is_searchable_tactic
+  apply find_balance1_lt
+  assumption'
+#align rbnode.find_balance1_node_lt RBNode.find_balance1_node_lt
+
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic rbnode.is_searchable_tactic -/
+theorem find_balance1_gt {l r t v x y lo hi} (h : lt y x) (hl : IsSearchable lt l lo (some v))
+    (hr : IsSearchable lt r (some v) (some y)) (ht : IsSearchable lt t (some y) hi) :
+    find lt (balance1 l v r y t) x = find lt t x := by
+  revert hl hr ht
+  apply balance.cases l v r <;>
+    intros <;>
+      simp [*] <;>
+        run_tac
+          is_searchable_tactic
+  · have := trans_of lt (lo_lt_hi hr) h
+    simp [*]
+
+  · have := trans_of lt (lo_lt_hi hr_hs₂) h
+    simp [*]
+
+#align rbnode.find_balance1_gt RBNode.find_balance1_gt
+
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic rbnode.is_searchable_tactic -/
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic ins_ne_leaf_tac -/
+theorem find_balance1_node_gt {t s x y lo hi} (h : lt x y) (ht : IsSearchable lt t lo (some x))
+    (hs : IsSearchable lt s (some x) hi)
+    (hne : t ≠ leaf := by
+      run_tac
+        ins_ne_leaf_tac) :
+    find lt (balance1Node t x s) y = find lt s y := by
+  cases t <;> simp [balance1_node]
+  all_goals
+  intros
+  run_tac
+    is_searchable_tactic
+  apply find_balance1_gt
+  assumption'
+#align rbnode.find_balance1_node_gt RBNode.find_balance1_node_gt
+
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic rbnode.is_searchable_tactic -/
+theorem find_balance1_eqv {l r t v x y lo hi} (h : ¬lt x y ∧ ¬lt y x) (hl : IsSearchable lt l lo (some v))
+    (hr : IsSearchable lt r (some v) (some y)) (ht : IsSearchable lt t (some y) hi) :
+    find lt (balance1 l v r y t) x = some y := by
+  revert hl hr ht
+  apply balance.cases l v r <;>
+    intros <;>
+      simp [*] <;>
+        run_tac
+          is_searchable_tactic
+  · have : lt y_1 x := lt_of_lt_of_incomp (lo_lt_hi hr) h.swap
+    simp [*]
+
+  · have : lt x_1 x := lt_of_lt_of_incomp (lo_lt_hi hr_hs₂) h.swap
+    simp [*]
+
+#align rbnode.find_balance1_eqv RBNode.find_balance1_eqv
+
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic rbnode.is_searchable_tactic -/
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic ins_ne_leaf_tac -/
+theorem find_balance1_node_eqv {t s x y lo hi} (h : ¬lt x y ∧ ¬lt y x) (ht : IsSearchable lt t lo (some y))
+    (hs : IsSearchable lt s (some y) hi)
+    (hne : t ≠ leaf := by
+      run_tac
+        ins_ne_leaf_tac) :
+    find lt (balance1Node t y s) x = some y := by
+  cases t <;> simp [balance1_node]
+  · contradiction
+
+  all_goals
+  intros
+  run_tac
+    is_searchable_tactic
+  apply find_balance1_eqv
+  assumption'
+#align rbnode.find_balance1_node_eqv RBNode.find_balance1_node_eqv
+
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic rbnode.is_searchable_tactic -/
+theorem find_balance2_lt {l v r t x y lo hi} (h : lt x y) (hl : IsSearchable lt l (some y) (some v))
+    (hr : IsSearchable lt r (some v) hi) (ht : IsSearchable lt t lo (some y)) :
+    find lt (balance2 l v r y t) x = find lt t x := by
+  revert hl hr ht
+  apply balance.cases l v r <;>
+    intros <;>
+      simp [*] <;>
+        run_tac
+          is_searchable_tactic
+  · have := trans h (lo_lt_hi hl_hs₁)
+    simp [*]
+
+  · have := trans h (lo_lt_hi hl)
+    simp [*]
+
+#align rbnode.find_balance2_lt RBNode.find_balance2_lt
+
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic rbnode.is_searchable_tactic -/
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic ins_ne_leaf_tac -/
+theorem find_balance2_node_lt {s t x y lo hi} (h : lt x y) (ht : IsSearchable lt t (some y) hi)
+    (hs : IsSearchable lt s lo (some y))
+    (hne : t ≠ leaf := by
+      run_tac
+        ins_ne_leaf_tac) :
+    find lt (balance2Node t y s) x = find lt s x := by
+  cases t <;> simp [balance2_node]
+  all_goals
+  intros
+  run_tac
+    is_searchable_tactic
+  apply find_balance2_lt
+  assumption'
+#align rbnode.find_balance2_node_lt RBNode.find_balance2_node_lt
+
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic rbnode.is_searchable_tactic -/
+theorem find_balance2_gt {l v r t x y lo hi} (h : lt y x) (hl : IsSearchable lt l (some y) (some v))
+    (hr : IsSearchable lt r (some v) hi) (ht : IsSearchable lt t lo (some y)) :
+    find lt (balance2 l v r y t) x = find lt (red_node l v r) x := by
+  revert hl hr ht
+  apply balance.cases l v r <;>
+    intros <;>
+      simp [*] <;>
+        run_tac
+          is_searchable_tactic
+  · apply weak_trichotomous lt x_1 x <;> intro h' <;> simp [*]
+    · apply weak_trichotomous lt y_1 x <;> intros <;> simp [*]
+
+    · have : lt x _ := lt_of_incomp_of_lt h'.swap (lo_lt_hi hl_hs₂)
+      simp [*]
+
+    · have := trans h' (lo_lt_hi hl_hs₂)
+      simp [*]
+
+
+  · apply weak_trichotomous lt y_1 x <;> intros <;> simp [*]
+
+#align rbnode.find_balance2_gt RBNode.find_balance2_gt
+
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic rbnode.is_searchable_tactic -/
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic ins_ne_leaf_tac -/
+theorem find_balance2_node_gt {s t x y lo hi} (h : lt y x) (ht : IsSearchable lt t (some y) hi)
+    (hs : IsSearchable lt s lo (some y))
+    (hne : t ≠ leaf := by
+      run_tac
+        ins_ne_leaf_tac) :
+    find lt (balance2Node t y s) x = find lt t x := by
+  cases t <;> simp [balance2_node]
+  · contradiction
+
+  all_goals
+  intros
+  run_tac
+    is_searchable_tactic
+  apply find_balance2_gt
+  assumption'
+#align rbnode.find_balance2_node_gt RBNode.find_balance2_node_gt
+
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic rbnode.is_searchable_tactic -/
+theorem find_balance2_eqv {l v r t x y lo hi} (h : ¬lt x y ∧ ¬lt y x) (hl : IsSearchable lt l (some y) (some v))
+    (hr : IsSearchable lt r (some v) hi) (ht : IsSearchable lt t lo (some y)) :
+    find lt (balance2 l v r y t) x = some y := by
+  revert hl hr ht
+  apply balance.cases l v r <;>
+    intros <;>
+      simp [*] <;>
+        run_tac
+          is_searchable_tactic
+  · have := lt_of_incomp_of_lt h (lo_lt_hi hl_hs₁)
+    simp [*]
+
+  · have := lt_of_incomp_of_lt h (lo_lt_hi hl)
+    simp [*]
+
+#align rbnode.find_balance2_eqv RBNode.find_balance2_eqv
+
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic rbnode.is_searchable_tactic -/
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic ins_ne_leaf_tac -/
+theorem find_balance2_node_eqv {t s x y lo hi} (h : ¬lt x y ∧ ¬lt y x) (ht : IsSearchable lt t (some y) hi)
+    (hs : IsSearchable lt s lo (some y))
+    (hne : t ≠ leaf := by
+      run_tac
+        ins_ne_leaf_tac) :
+    find lt (balance2Node t y s) x = some y := by
+  cases t <;> simp [balance2_node]
+  · contradiction
+
+  all_goals
+  intros
+  run_tac
+    is_searchable_tactic
+  apply find_balance2_eqv
+  assumption'
+#align rbnode.find_balance2_node_eqv RBNode.find_balance2_node_eqv
+
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic _private.3968712505.simp_fi -/
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic _private.3968712505.simp_fi -/
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic _private.3968712505.simp_fi -/
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic _private.3968712505.simp_fi -/
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic _private.3968712505.simp_fi -/
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic _private.3968712505.simp_fi -/
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic _private.3968712505.simp_fi -/
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic _private.3968712505.simp_fi -/
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic _private.3968712505.simp_fi -/
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic _private.3968712505.simp_fi -/
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic _private.3968712505.simp_fi -/
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic _private.3968712505.simp_fi -/
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic _private.3968712505.simp_fi -/
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic _private.3968712505.simp_fi -/
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic _private.3968712505.simp_fi -/
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic _private.3968712505.simp_fi -/
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic _private.3968712505.simp_fi -/
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:62:18: unsupported non-interactive tactic _private.3968712505.simp_fi -/
+theorem find_ins_of_disj {x y : α} {t : RBNode α} (hn : lt x y ∨ lt y x) :
+    ∀ {lo hi} (hs : IsSearchable lt t lo hi) (hlt₁ : Lift lt lo (some x)) (hlt₂ : Lift lt (some x) hi),
+      find lt (ins lt t x) y = find lt t y :=
+  by
+  apply ins.induction lt t x <;> intros
+  · cases hn
+    all_goals simp [find, ins, CmpUsing, *]
+
+  all_goals
+  simp at hc
+  cases hs
+  · have := ih hs_hs₁ hlt₁ hc
+    run_tac
+      simp_fi
+
+  · cases hn
+    · have := lt_of_incomp_of_lt hc.symm hn
+      run_tac
+        simp_fi
+
+    · have := lt_of_lt_of_incomp hn hc
+      run_tac
+        simp_fi
+
+
+  · have := ih hs_hs₂ hc hlt₂
+    run_tac
+      simp_fi
+
+  · have ih := ih hs_hs₁ hlt₁ hc
+    cases hn
+    · cases hc' : CmpUsing lt y y_1 <;> simp at hc'
+      · have hsi := is_searchable_ins lt hs_hs₁ hlt₁ (trans_of lt hn hc')
+        have := find_balance1_node_lt lt hc' hsi hs_hs₂
+        run_tac
+          simp_fi
+
+      · have hlt := lt_of_lt_of_incomp hn hc'
+        have hsi := is_searchable_ins lt hs_hs₁ hlt₁ hlt
+        have := find_balance1_node_eqv lt hc' hsi hs_hs₂
+        run_tac
+          simp_fi
+
+      · have hsi := is_searchable_ins lt hs_hs₁ hlt₁ hc
+        have := find_balance1_node_gt lt hc' hsi hs_hs₂
+        simp [*]
+        run_tac
+          simp_fi
+
+
+    · have hlt := trans hn hc
+      have hsi := is_searchable_ins lt hs_hs₁ hlt₁ hc
+      have := find_balance1_node_lt lt hlt hsi hs_hs₂
+      run_tac
+        simp_fi
+
+
+  · have := ih hs_hs₁ hlt₁ hc
+    run_tac
+      simp_fi
+
+  · cases hn
+    · have := lt_of_incomp_of_lt hc.swap hn
+      run_tac
+        simp_fi
+
+    · have := lt_of_lt_of_incomp hn hc
+      run_tac
+        simp_fi
+
+
+  · have ih := ih hs_hs₂ hc hlt₂
+    cases hn
+    · have hlt := trans hc hn
+      run_tac
+        simp_fi
+      have hsi := is_searchable_ins lt hs_hs₂ hc hlt₂
+      have := find_balance2_node_gt lt hlt hsi hs_hs₁
+      run_tac
+        simp_fi
+
+    · run_tac
+        simp_fi
+      cases hc' : CmpUsing lt y y_1 <;> simp at hc'
+      · have hsi := is_searchable_ins lt hs_hs₂ hc hlt₂
+        have := find_balance2_node_lt lt hc' hsi hs_hs₁
+        run_tac
+          simp_fi
+
+      · have hlt := lt_of_incomp_of_lt hc'.swap hn
+        have hsi := is_searchable_ins lt hs_hs₂ hlt hlt₂
+        have := find_balance2_node_eqv lt hc' hsi hs_hs₁
+        run_tac
+          simp_fi
+
+      · have hsi := is_searchable_ins lt hs_hs₂ hc hlt₂
+        have := find_balance2_node_gt lt hc' hsi hs_hs₁
+        run_tac
+          simp_fi
+
+
+
+  · have ih := ih hs_hs₂ hc hlt₂
+    run_tac
+      simp_fi
+
+#align rbnode.find_ins_of_disj RBNode.find_ins_of_disj
+
+end FindInsOfNotEqv
+
+theorem find_insert_of_disj [DecidableRel lt] [IsStrictWeakOrder α lt] {x y : α} {t : RBNode α} (hd : lt x y ∨ lt y x) :
+    IsSearchable lt t none none → find lt (insert lt t x) y = find lt t y := by
+  intro hs
+  simp [insert, find_mk_insert_result]
+  apply find_ins_of_disj lt hd hs <;> simp
+#align rbnode.find_insert_of_disj RBNode.find_insert_of_disj
+
+theorem find_insert_of_not_eqv [DecidableRel lt] [IsStrictWeakOrder α lt] {x y : α} {t : RBNode α} (hn : ¬x ≈[lt]y) :
+    IsSearchable lt t none none → find lt (insert lt t x) y = find lt t y := by
+  intro hs
+  simp [insert, find_mk_insert_result]
+  have he : lt x y ∨ lt y x := by
+    simp [StrictWeakOrder.Equiv, Decidable.not_and_iff_or_not, Decidable.not_not_iff] at hn
+    assumption
+  apply find_ins_of_disj lt he hs <;> simp
+#align rbnode.find_insert_of_not_eqv RBNode.find_insert_of_not_eqv
+
+end MembershipLemmas
+
+section IsRedBlack
+
+variable {α : Type u}
+
+open Nat Color
+
+inductive IsBadRedBlack : RBNode α → Nat → Prop
+  | bad_red {c₁ c₂ n l r v} (rb_l : IsRedBlack l c₁ n) (rb_r : IsRedBlack r c₂ n) : is_bad_red_black (red_node l v r) n
+#align rbnode.is_bad_red_black RBNode.IsBadRedBlack
+
+theorem balance1_rb {l r t : RBNode α} {y v : α} {c_l c_r c_t n} :
+    IsRedBlack l c_l n → IsRedBlack r c_r n → IsRedBlack t c_t n → ∃ c, IsRedBlack (balance1 l y r v t) c (succ n) := by
+  intro h₁ h₂ _ <;> cases h₁ <;> cases h₂ <;> repeat' first |assumption|constructor
+#align rbnode.balance1_rb RBNode.balance1_rb
+
+theorem balance2_rb {l r t : RBNode α} {y v : α} {c_l c_r c_t n} :
+    IsRedBlack l c_l n → IsRedBlack r c_r n → IsRedBlack t c_t n → ∃ c, IsRedBlack (balance2 l y r v t) c (succ n) := by
+  intro h₁ h₂ _ <;> cases h₁ <;> cases h₂ <;> repeat' first |assumption|constructor
+#align rbnode.balance2_rb RBNode.balance2_rb
+
+theorem balance1_node_rb {t s : RBNode α} {y : α} {c n} :
+    IsBadRedBlack t n → IsRedBlack s c n → ∃ c, IsRedBlack (balance1Node t y s) c (succ n) := by
+  intro h _ <;> cases h <;> simp [balance1_node] <;> apply balance1_rb <;> assumption'
+#align rbnode.balance1_node_rb RBNode.balance1_node_rb
+
+theorem balance2_node_rb {t s : RBNode α} {y : α} {c n} :
+    IsBadRedBlack t n → IsRedBlack s c n → ∃ c, IsRedBlack (balance2Node t y s) c (succ n) := by
+  intro h _ <;> cases h <;> simp [balance2_node] <;> apply balance2_rb <;> assumption'
+#align rbnode.balance2_node_rb RBNode.balance2_node_rb
+
+def InsRbResult : RBNode α → Color → Nat → Prop
+  | t, red, n => IsBadRedBlack t n
+  | t, black, n => ∃ c, IsRedBlack t c n
+#align rbnode.ins_rb_result RBNode.InsRbResult
+
+variable {lt : α → α → Prop} [DecidableRel lt]
+
+theorem of_get_color_eq_red {t : RBNode α} {c n} : getColor t = red → IsRedBlack t c n → c = red := by
+  intro h₁ h₂
+  cases h₂ <;> simp only [get_color] at h₁ <;> contradiction
+#align rbnode.of_get_color_eq_red RBNode.of_get_color_eq_red
+
+theorem of_get_color_ne_red {t : RBNode α} {c n} : getColor t ≠ red → IsRedBlack t c n → c = black := by
+  intro h₁ h₂
+  cases h₂ <;> simp only [get_color] at h₁ <;> contradiction
+#align rbnode.of_get_color_ne_red RBNode.of_get_color_ne_red
+
+variable (lt)
+
+theorem ins_rb {t : RBNode α} (x) : ∀ {c n} (h : IsRedBlack t c n), InsRbResult (ins lt t x) c n := by
+  apply ins.induction lt t x <;> intros <;> cases h <;> simp [ins, *, ins_rb_result]
+  · repeat' constructor
+
+  · specialize ih h_rb_l
+    cases ih
+    constructor <;> assumption
+
+  · constructor <;> assumption
+
+  · specialize ih h_rb_r
+    cases ih
+    constructor <;> assumption
+
+  · specialize ih h_rb_l
+    cases of_get_color_eq_red hr h_rb_l
+    apply balance1_node_rb <;> assumption
+
+  · specialize ih h_rb_l
+    cases of_get_color_ne_red hnr h_rb_l
+    cases ih
+    constructor
+    constructor <;> assumption
+
+  · constructor
+    constructor <;> assumption
+
+  · specialize ih h_rb_r
+    cases of_get_color_eq_red hr h_rb_r
+    apply balance2_node_rb <;> assumption
+
+  · specialize ih h_rb_r
+    cases of_get_color_ne_red hnr h_rb_r
+    cases ih
+    constructor
+    constructor <;> assumption
+
+#align rbnode.ins_rb RBNode.ins_rb
+
+def InsertRbResult : RBNode α → Color → Nat → Prop
+  | t, red, n => IsRedBlack t black (succ n)
+  | t, black, n => ∃ c, IsRedBlack t c n
+#align rbnode.insert_rb_result RBNode.InsertRbResult
+
+theorem insert_rb {t : RBNode α} (x) {c n} (h : IsRedBlack t c n) : InsertRbResult (insert lt t x) c n := by
+  simp [insert]
+  have hi := ins_rb lt x h
+  generalize he : ins lt t x = r
+  simp [he] at hi
+  cases h <;> simp [get_color, ins_rb_result, insert_rb_result, mk_insert_result] at *
+  assumption'
+  · cases hi
+    simp [mk_insert_result]
+    constructor <;> assumption
+
+#align rbnode.insert_rb RBNode.insert_rb
+
+theorem insert_is_red_black {t : RBNode α} {c n} (x) : IsRedBlack t c n → ∃ c n, IsRedBlack (insert lt t x) c n := by
+  intro h
+  have := insert_rb lt x h
+  cases c <;> simp [insert_rb_result] at this
+  · constructor
+    constructor
+    assumption
+
+  · cases this
+    constructor
+    constructor
+    assumption
+
+#align rbnode.insert_is_red_black RBNode.insert_is_red_black
+
+end IsRedBlack
+
+end RBNode

--- a/Mathlib/Data/RBTree/Main.lean
+++ b/Mathlib/Data/RBTree/Main.lean
@@ -14,6 +14,9 @@ import Mathlib.Order.RelClasses
 Ported to preserve theorems
 -/
 
+section
+set_option linter.deprecated false
+
 
 universe u
 

--- a/Mathlib/Data/RBTree/Main.lean
+++ b/Mathlib/Data/RBTree/Main.lean
@@ -1,0 +1,140 @@
+/-
+Copyright (c) 2017 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Leonardo de Moura
+-/
+import Mathlib.Data.RBTree.Find
+import Mathlib.Data.RBTree.Insert
+import Mathlib.Data.RBTree.MinMax
+import Mathlib.Order.RelClasses
+
+/-!
+# Basic theorems on API behavior given structural/well-foundeness
+
+Ported to preserve theorems
+-/
+
+
+universe u
+
+namespace RBNode
+
+variable {α : Type u} {lt : α → α → Prop}
+
+theorem is_searchable_of_well_formed {t : RBNode α} [IsStrictWeakOrder α lt] :
+    t.WellFormed lt → IsSearchable lt t none none := sorry
+open Color
+
+theorem is_red_black_of_well_formed {t : RBNode α} : t.WellFormed lt → ∃ c n, IsRedBlack t c n :=
+    sorry
+
+end RBNode
+
+namespace RBTree
+
+variable {α : Type u} {lt : α → α → Prop}
+
+theorem balanced (t : RBTree α lt) : t.depth max ≤ 2 * t.depth min + 1 := sorry
+
+theorem not_mem_mk_rbtree : ∀ a : α, a ∉ mkRBTree α lt := sorry
+
+theorem not_mem_of_empty {t : RBTree α lt} (a : α) : t.Empty = tt → a ∉ t := sorry
+
+theorem mem_of_mem_of_eqv
+    [IsStrictWeakOrder α lt]
+    {t : RBTree α lt}
+    {a b : α} : a ∈ t → a ≈[lt]b → b ∈ t := sorry
+
+section Dec
+
+variable [DecidableRel lt]
+
+theorem insert_ne_mk_rbtree (t : RBTree α lt) (a : α) : t.insert a ≠ mkRBTree α lt := sorry
+
+theorem find_correct
+    [IsStrictWeakOrder α lt]
+    (a : α)
+    (t : RBTree α lt) : a ∈ t ↔ ∃ b, t.find a = some b ∧ a ≈[lt]b := sorry
+
+theorem find_correct_of_total
+    [IsStrictTotalOrder α lt]
+    (a : α)
+    (t : RBTree α lt) : a ∈ t ↔ t.find a = some a := sorry
+
+theorem find_correct_exact
+    [IsStrictTotalOrder α lt]
+    (a : α)
+    (t : RBTree α lt) : MemExact a t ↔ t.find a = some a := sorry
+
+theorem find_insert_of_eqv
+    [IsStrictWeakOrder α lt]
+    (t : RBTree α lt)
+    {x y} : x ≈[lt]y → (t.insert x).find y = some x := sorry
+
+theorem find_insert
+    [IsStrictWeakOrder α lt]
+    (t : RBTree α lt) (x) : (t.insert x).find x = some x := sorry
+
+theorem find_insert_of_disj [IsStrictWeakOrder α lt] {x y : α} (t : RBTree α lt) :
+    lt x y ∨ lt y x → (t.insert x).find y = t.find y := sorry
+
+theorem find_insert_of_not_eqv [IsStrictWeakOrder α lt] {x y : α} (t : RBTree α lt) :
+    ¬x ≈[lt]y → (t.insert x).find y = t.find y := sorry
+
+theorem find_insert_of_ne [IsStrictTotalOrder α lt] {x y : α} (t : RBTree α lt) :
+    x ≠ y → (t.insert x).find y = t.find y := sorry
+
+theorem not_mem_of_find_none
+    [IsStrictWeakOrder α lt] {a : α} {t : RBTree α lt} : t.find a = none → a ∉ t := sorry
+
+theorem eqv_of_find_some
+    [IsStrictWeakOrder α lt] {a b : α} {t : RBTree α lt} : t.find a = some b → a ≈[lt]b := sorry
+
+theorem eq_of_find_some
+    [IsStrictTotalOrder α lt] {a b : α} {t : RBTree α lt} : t.find a = some b → a = b := sorry
+
+theorem mem_of_find_some
+    [IsStrictWeakOrder α lt] {a b : α} {t : RBTree α lt} : t.find a = some b → a ∈ t := sorry
+
+theorem find_eq_find_of_eqv
+    [IsStrictWeakOrder α lt] {a b : α} (t : RBTree α lt) : a ≈[lt]b → t.find a = t.find b := sorry
+
+theorem contains_correct
+    [IsStrictWeakOrder α lt] (a : α) (t : RBTree α lt) : a ∈ t ↔ t.contains a = tt := sorry
+
+theorem mem_insert_of_incomp
+    {a b : α} (t : RBTree α lt) : ¬lt a b ∧ ¬lt b a → a ∈ t.insert b := sorry
+
+theorem mem_insert [IsIrrefl α lt] : ∀ (a : α) (t : RBTree α lt), a ∈ t.insert a := sorry
+
+theorem mem_insert_of_equiv {a b : α} (t : RBTree α lt) : a ≈[lt]b → a ∈ t.insert b := sorry
+
+theorem mem_insert_of_mem
+    [IsStrictWeakOrder α lt] {a : α} {t : RBTree α lt} (b : α) : a ∈ t → a ∈ t.insert b := sorry
+
+theorem equiv_or_mem_of_mem_insert
+    {a b : α} {t : RBTree α lt} : a ∈ t.insert b → a ≈[lt]b ∨ a ∈ t := sorry
+
+theorem incomp_or_mem_of_mem_ins
+    {a b : α} {t : RBTree α lt} : a ∈ t.insert b → ¬lt a b ∧ ¬lt b a ∨ a ∈ t := sorry
+
+theorem eq_or_mem_of_mem_ins
+    [IsStrictTotalOrder α lt] {a b : α} {t : RBTree α lt} : a ∈ t.insert b → a = b ∨ a ∈ t := sorry
+
+end Dec
+
+theorem mem_of_min_eq [IsIrrefl α lt] {a : α} {t : RBTree α lt} : t.min = some a → a ∈ t := sorry
+
+theorem mem_of_max_eq [IsIrrefl α lt] {a : α} {t : RBTree α lt} : t.max = some a → a ∈ t := sorry
+
+theorem eq_leaf_of_min_eq_none {t : RBTree α lt} : t.min = none → t = mkRBTree α lt := sorry
+
+theorem eq_leaf_of_max_eq_none {t : RBTree α lt} : t.max = none → t = mkRBTree α lt := sorry
+
+theorem min_is_minimal [IsStrictWeakOrder α lt] {a : α} {t : RBTree α lt} :
+    t.min = some a → ∀ {b}, b ∈ t → a ≈[lt]b ∨ lt a b := sorry
+
+theorem max_is_maximal [IsStrictWeakOrder α lt] {a : α} {t : RBTree α lt} :
+    t.max = some a → ∀ {b}, b ∈ t → a ≈[lt]b ∨ lt b a := sorry
+
+end RBTree

--- a/Mathlib/Data/RBTree/MinMax.lean
+++ b/Mathlib/Data/RBTree/MinMax.lean
@@ -1,0 +1,41 @@
+/-
+Copyright (c) 2017 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Leonardo de Moura
+-/
+import Mathlib.Data.RBTree.Basic
+
+/-!
+# Theorems on invariants of `min`/`max`
+
+Ported with `sorry` to preserve theorems
+-/
+
+universe u
+
+namespace RBNode
+
+variable {α : Type u} {lt : α → α → Prop}
+
+theorem mem_of_min_eq (lt : α → α → Prop)
+  [IsIrrefl α lt] {a : α} {t : RBNode α} : t.min = some a → Mem lt a t := sorry
+
+
+theorem mem_of_max_eq
+  (lt : α → α → Prop) [IsIrrefl α lt] {a : α} {t : RBNode α} : t.max = some a → Mem lt a t := sorry
+
+variable [IsStrictWeakOrder α lt]
+
+theorem eq_leaf_of_min_eq_none {t : RBNode α} : t.min = none → t = leaf := sorry
+
+theorem eq_leaf_of_max_eq_none {t : RBNode α} : t.max = none → t = leaf := sorry
+
+theorem min_is_minimal {a : α} {t : RBNode α} :
+    ∀ {lo hi}, IsSearchable lt t lo hi → t.min = some a → ∀ {b}, Mem lt b t → a ≈[lt]b ∨ lt a b :=
+    sorry
+
+theorem max_is_maximal {a : α} {t : RBNode α} :
+    ∀ {lo hi}, IsSearchable lt t lo hi → t.max = some a → ∀ {b}, Mem lt b t → a ≈[lt]b ∨ lt b a :=
+    sorry
+
+end RBNode


### PR DESCRIPTION
#align annotations and deprecation of `mathlib` `RBTree`

From (AKA deletes & deprecates) `mathlib` 7cca171008afb30576d2d4c51173700a780c23d0