### PR TITLE
[Merged by Bors] - feat: `scoped[NS]` command (was: `localized`)

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -174,6 +174,7 @@ import Mathlib.Tactic.Ring.Basic
 import Mathlib.Tactic.Ring.RingNF
 import Mathlib.Tactic.RunCmd
 import Mathlib.Tactic.Sat.FromLRAT
+import Mathlib.Tactic.ScopedNS
 import Mathlib.Tactic.SeqFocus
 import Mathlib.Tactic.Set
 import Mathlib.Tactic.SimpIntro

--- a/Mathlib/Mathport/Syntax.lean
+++ b/Mathlib/Mathport/Syntax.lean
@@ -55,6 +55,7 @@ import Mathlib.Tactic.Replace
 import Mathlib.Tactic.RestateAxiom
 import Mathlib.Tactic.Ring
 import Mathlib.Tactic.RunCmd
+import Mathlib.Tactic.ScopedNS
 import Mathlib.Tactic.SeqFocus
 import Mathlib.Tactic.Set
 import Mathlib.Tactic.SimpIntro
@@ -495,22 +496,6 @@ namespace Command
 /- M -/ syntax (name := addHintTactic) "add_hint_tactic " tactic : command
 
 /- S -/ syntax (name := explode) "#explode " ident : command
-
-syntax (name := localized) "localized " "[" ident "] " command : command
-macro_rules
-  | `(localized [$ns] notation $[$prec:precedence]? $[$n:namedName]? $[$prio:namedPrio]?
-       $sym => $t) =>
-    let ns := mkIdentFrom ns <| rootNamespace ++ ns.getId
-    `(with_weak_namespace $ns
-      scoped notation $[$prec:precedence]? $[$n:namedName]? $[$prio:namedPrio]? $sym => $t)
-  | `(localized [$ns] $_:attrKind $mixfixKind $prec:precedence $[$n:namedName]? $[$prio:namedPrio]?
-       $sym => $t) =>
-    let ns := mkIdentFrom ns <| rootNamespace ++ ns.getId
-    `(with_weak_namespace $ns
-      scoped $mixfixKind $prec:precedence $[$n:namedName]? $[$prio:namedPrio]? $sym => $t)
-  | `(localized [$ns] attribute [$attr:attr] $ids*) =>
-    let ns := mkIdentFrom ns <| rootNamespace ++ ns.getId
-    `(with_weak_namespace $ns attribute [scoped $attr:attr] $ids*)
 
 /- S -/ syntax (name := listUnusedDecls) "#list_unused_decls" : command
 

--- a/Mathlib/Tactic/ScopedNS.lean
+++ b/Mathlib/Tactic/ScopedNS.lean
@@ -1,0 +1,46 @@
+/-
+Copyright (c) 2021 Gabriel Ebner. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Gabriel Ebner, Mario Carneiro
+-/
+import Mathlib.Util.WithWeakNamespace
+
+/-! # `scoped[NS]` syntax
+
+This is a replacement for the `localized` command in mathlib. It is similar to `scoped`,
+but it scopes the syntax in the specified namespace instead of the current namespace.
+-/
+
+namespace Mathlib.Tactic
+open Lean
+
+/--
+`scoped[NS]` is similar to the `scoped` modifier on attributes and notations,
+but it scopes the syntax in the specified namespace instead of the current namespace.
+```
+scoped[Matrix] infixl:75 " ⬝ " => Matrix.mul
+-- declares `⬝` as a notation for matrix multiplication
+-- which is only accessible if you `open Matrix` or `open scoped Matrix`.
+
+namespace Nat
+
+scoped[Nat.Count] attribute [instance] CountSet.fintype
+-- make the definition Nat.CountSet.fintype an instance,
+-- but only if `Nat.Count` is open
+```
+-/
+syntax (name := scopedNS) "scoped" "[" ident "] " command : command
+macro_rules
+  | `(scoped[$ns] notation $[$prec:precedence]? $[$n:namedName]? $[$prio:namedPrio]?
+       $sym => $t) =>
+    let ns := mkIdentFrom ns <| rootNamespace ++ ns.getId
+    `(with_weak_namespace $ns
+      scoped notation $[$prec:precedence]? $[$n:namedName]? $[$prio:namedPrio]? $sym => $t)
+  | `(scoped[$ns] $mixfixKind:prefix $prec:precedence $[$n:namedName]? $[$prio:namedPrio]?
+       $sym => $t) =>
+    let ns := mkIdentFrom ns <| rootNamespace ++ ns.getId
+    `(with_weak_namespace $ns
+      scoped $mixfixKind $prec:precedence $[$n:namedName]? $[$prio:namedPrio]? $sym => $t)
+  | `(scoped[$ns] attribute [$attr:attr] $ids*) =>
+    let ns := mkIdentFrom ns <| rootNamespace ++ ns.getId
+    `(with_weak_namespace $ns attribute [scoped $attr:attr] $ids*)


### PR DESCRIPTION
This just moves the `localized` command from `Mathlib.Mathport.Syntax` into its own file and adds some documentation. Also renames `localized` to `scoped` per the [Zulip discussion](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/porting.20.60localized.60/near/310546999). 