### PR TITLE
[Merged by Bors] - feat: port Control.EquivFunctor

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -19,6 +19,7 @@ import Mathlib.Algebra.Order.Ring
 import Mathlib.Algebra.PEmptyInstances
 import Mathlib.Algebra.Ring.Basic
 import Mathlib.CategoryTheory.ConcreteCategory.Bundled
+import Mathlib.Control.EquivFunctor
 import Mathlib.Control.Random
 import Mathlib.Control.Writer
 import Mathlib.Data.Array.Basic

--- a/Mathlib/Control/EquivFunctor.lean
+++ b/Mathlib/Control/EquivFunctor.lean
@@ -67,7 +67,7 @@ theorem mapEquiv_symm_apply (y : f β) : (mapEquiv f e).symm y = EquivFunctor.ma
 
 @[simp]
 theorem mapEquiv_refl (α) : mapEquiv f (Equiv.refl α) = Equiv.refl (f α) := by
- simpa [EquivFunctor.mapEquiv]
+ simp [EquivFunctor.mapEquiv]; rfl
 #align equiv_functor.map_equiv_refl EquivFunctor.mapEquiv_refl
 
 @[simp]
@@ -89,11 +89,11 @@ end
 
 instance (priority := 100) ofIsLawfulFunctor (f : Type u₀ → Type u₁) [Functor f] [LawfulFunctor f] :
     EquivFunctor f where
-  map α β e := Functor.map e
+  map {α β} e := Functor.map e
   map_refl' α := by
     ext
     apply LawfulFunctor.id_map
-  map_trans' α β γ k h := by
+  map_trans' {α β γ} k h := by
     ext x
     apply LawfulFunctor.comp_map k h x
 #align equiv_functor.of_is_lawful_functor EquivFunctor.ofIsLawfulFunctor

--- a/Mathlib/Control/EquivFunctor.lean
+++ b/Mathlib/Control/EquivFunctor.lean
@@ -86,7 +86,7 @@ theorem mapEquiv_trans {γ : Type u₀} (ab : α ≃ β) (bc : β ≃ γ) :
 
 end
 
-instance (priority := 100) ofIsLawfulFunctor (f : Type u₀ → Type u₁) [Functor f] [LawfulFunctor f] :
+instance (priority := 100) ofLawfulFunctor (f : Type u₀ → Type u₁) [Functor f] [LawfulFunctor f] :
     EquivFunctor f where
   map {α β} e := Functor.map e
   map_refl' α := by
@@ -95,7 +95,7 @@ instance (priority := 100) ofIsLawfulFunctor (f : Type u₀ → Type u₁) [Func
   map_trans' {α β γ} k h := by
     ext x
     apply LawfulFunctor.comp_map k h x
-#align equiv_functor.of_is_lawful_functor EquivFunctor.ofIsLawfulFunctor
+#align equiv_functor.of_is_lawful_functor EquivFunctor.ofLawfulFunctor
 
 theorem mapEquiv.injective (f : Type u₀ → Type u₁)
     [Applicative f] [LawfulApplicative f] {α β : Type u₀}

--- a/Mathlib/Control/EquivFunctor.lean
+++ b/Mathlib/Control/EquivFunctor.lean
@@ -27,14 +27,13 @@ an equivalence `α ≃ β`, and then prove the functor laws. It's then a consequ
 this function is part of an equivalence, provided by `EquivFunctor.map_equiv`.
 -/
 class EquivFunctor (f : Type u₀ → Type u₁) where
+  /-- `f` preserves equality-/
   map : ∀ {α β}, α ≃ β → f α → f β
+  /-- `map` of `f` preserves reflectivity-/
   map_refl' : ∀ α, map (Equiv.refl α) = @id (f α) := by rfl
+  /-- composition of `map`s of `f` over equality preserve transitivity-/
   map_trans' : ∀ {α β γ} (k : α ≃ β) (h : β ≃ γ), map (k.trans h) = map h ∘ map k := by rfl
 #align equiv_functor EquivFunctor
-
---restate_axiom EquivFunctor.map_refl'
-
---restate_axiom EquivFunctor.map_trans'
 
 attribute [simp] EquivFunctor.map_refl'
 

--- a/Mathlib/Control/EquivFunctor.lean
+++ b/Mathlib/Control/EquivFunctor.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
 import Mathlib.Logic.Equiv.Defs
+import Mathlib.Tactic.Convert
 
 /-!
 # Functions functorial with respect to equivalences
@@ -51,38 +52,38 @@ def mapEquiv : f α ≃ f β where
     convert (congr_fun (EquivFunctor.map_trans' e e.symm) x).symm
     simp
   right_inv y := by
-    apply (congr_fun (EquivFunctor.map_trans e.symm e) y).symm
+    convert (congr_fun (EquivFunctor.map_trans' e.symm e) y).symm
     simp
 #align equiv_functor.map_equiv EquivFunctor.mapEquiv
 
 @[simp]
-theorem map_equiv_apply (x : f α) : mapEquiv f e x = EquivFunctor.map e x :=
+theorem mapEquiv_apply (x : f α) : mapEquiv f e x = EquivFunctor.map e x :=
   rfl
-#align equiv_functor.map_equiv_apply EquivFunctor.map_equiv_apply
+#align equiv_functor.map_equiv_apply EquivFunctor.mapEquiv_apply
 
-theorem map_equiv_symm_apply (y : f β) : (mapEquiv f e).symm y = EquivFunctor.map e.symm y :=
+theorem mapEquiv_symm_apply (y : f β) : (mapEquiv f e).symm y = EquivFunctor.map e.symm y :=
   rfl
-#align equiv_functor.map_equiv_symm_apply EquivFunctor.map_equiv_symm_apply
+#align equiv_functor.map_equiv_symm_apply EquivFunctor.mapEquiv_symm_apply
 
 @[simp]
-theorem map_equiv_refl (α) : mapEquiv f (Equiv.refl α) = Equiv.refl (f α) := by
+theorem mapEquiv_refl (α) : mapEquiv f (Equiv.refl α) = Equiv.refl (f α) := by
  simpa [EquivFunctor.mapEquiv]
-#align equiv_functor.map_equiv_refl EquivFunctor.map_equiv_refl
+#align equiv_functor.map_equiv_refl EquivFunctor.mapEquiv_refl
 
 @[simp]
-theorem map_equiv_symm : (mapEquiv f e).symm = mapEquiv f e.symm :=
-  Equiv.ext $ map_equiv_symm_apply f e
-#align equiv_functor.map_equiv_symm EquivFunctor.map_equiv_symm
+theorem mapEquiv_symm : (mapEquiv f e).symm = mapEquiv f e.symm :=
+  Equiv.ext $ mapEquiv_symm_apply f e
+#align equiv_functor.map_equiv_symm EquivFunctor.mapEquiv_symm
 
 /-- The composition of `mapEquiv`s is carried over the `EquivFunctor`.
 For plain `Functor`s, this lemma is named `map_map` when applied
 or `map_comp_map` when not applied.
 -/
 @[simp]
-theorem map_equiv_trans {γ : Type u₀} (ab : α ≃ β) (bc : β ≃ γ) :
+theorem mapEquiv_trans {γ : Type u₀} (ab : α ≃ β) (bc : β ≃ γ) :
     (mapEquiv f ab).trans (mapEquiv f bc) = mapEquiv f (ab.trans bc) :=
-  Equiv.ext $ fun x => by simp [map_equiv, map_trans']
-#align equiv_functor.map_equiv_trans EquivFunctor.map_equiv_trans
+  Equiv.ext $ fun x => by simp [mapEquiv, map_trans']
+#align equiv_functor.map_equiv_trans EquivFunctor.mapEquiv_trans
 
 end
 

--- a/Mathlib/Control/EquivFunctor.lean
+++ b/Mathlib/Control/EquivFunctor.lean
@@ -1,0 +1,108 @@
+/-
+Copyright (c) 2020 Scott Morrison. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Scott Morrison
+-/
+import Mathlib.Logic.Equiv.Defs
+
+/-!
+# Functions functorial with respect to equivalences
+
+An `EquivFunctor` is a function from `Type → Type` equipped with the additional data of
+coherently mapping equivalences to equivalences.
+
+In categorical language, it is an endofunctor of the "core" of the category `Type`.
+-/
+
+
+universe u₀ u₁ u₂ v₀ v₁ v₂
+
+open Function
+
+/-- An `EquivFunctor` is only functorial with respect to equivalences.
+
+To construct an `EquivFunctor`, it suffices to supply just the function `f α → f β` from
+an equivalence `α ≃ β`, and then prove the functor laws. It's then a consequence that
+this function is part of an equivalence, provided by `EquivFunctor.map_equiv`.
+-/
+class EquivFunctor (f : Type u₀ → Type u₁) where
+  map : ∀ {α β}, α ≃ β → f α → f β
+  map_refl' : ∀ α, map (Equiv.refl α) = @id (f α) := by rfl
+  map_trans' : ∀ {α β γ} (k : α ≃ β) (h : β ≃ γ), map (k.trans h) = map h ∘ map k := by rfl
+#align equiv_functor EquivFunctor
+
+--restate_axiom EquivFunctor.map_refl'
+
+--restate_axiom EquivFunctor.map_trans'
+
+attribute [simp] EquivFunctor.map_refl'
+
+namespace EquivFunctor
+
+section
+
+variable (f : Type u₀ → Type u₁) [EquivFunctor f] {α β : Type u₀} (e : α ≃ β)
+
+/-- An `EquivFunctor` in fact takes every equiv to an equiv. -/
+def mapEquiv : f α ≃ f β where
+  toFun := EquivFunctor.map e
+  invFun := EquivFunctor.map e.symm
+  left_inv x := by
+    convert (congr_fun (EquivFunctor.map_trans' e e.symm) x).symm
+    simp
+  right_inv y := by
+    apply (congr_fun (EquivFunctor.map_trans e.symm e) y).symm
+    simp
+#align equiv_functor.map_equiv EquivFunctor.mapEquiv
+
+@[simp]
+theorem map_equiv_apply (x : f α) : mapEquiv f e x = EquivFunctor.map e x :=
+  rfl
+#align equiv_functor.map_equiv_apply EquivFunctor.map_equiv_apply
+
+theorem map_equiv_symm_apply (y : f β) : (mapEquiv f e).symm y = EquivFunctor.map e.symm y :=
+  rfl
+#align equiv_functor.map_equiv_symm_apply EquivFunctor.map_equiv_symm_apply
+
+@[simp]
+theorem map_equiv_refl (α) : mapEquiv f (Equiv.refl α) = Equiv.refl (f α) := by
+ simpa [EquivFunctor.mapEquiv]
+#align equiv_functor.map_equiv_refl EquivFunctor.map_equiv_refl
+
+@[simp]
+theorem map_equiv_symm : (mapEquiv f e).symm = mapEquiv f e.symm :=
+  Equiv.ext $ map_equiv_symm_apply f e
+#align equiv_functor.map_equiv_symm EquivFunctor.map_equiv_symm
+
+/-- The composition of `mapEquiv`s is carried over the `EquivFunctor`.
+For plain `Functor`s, this lemma is named `map_map` when applied
+or `map_comp_map` when not applied.
+-/
+@[simp]
+theorem map_equiv_trans {γ : Type u₀} (ab : α ≃ β) (bc : β ≃ γ) :
+    (mapEquiv f ab).trans (mapEquiv f bc) = mapEquiv f (ab.trans bc) :=
+  Equiv.ext $ fun x => by simp [map_equiv, map_trans']
+#align equiv_functor.map_equiv_trans EquivFunctor.map_equiv_trans
+
+end
+
+instance (priority := 100) ofIsLawfulFunctor (f : Type u₀ → Type u₁) [Functor f] [LawfulFunctor f] :
+    EquivFunctor f where
+  map α β e := Functor.map e
+  map_refl' α := by
+    ext
+    apply LawfulFunctor.id_map
+  map_trans' α β γ k h := by
+    ext x
+    apply LawfulFunctor.comp_map k h x
+#align equiv_functor.of_is_lawful_functor EquivFunctor.ofIsLawfulFunctor
+
+theorem mapEquiv.injective (f : Type u₀ → Type u₁)
+    [Applicative f] [LawfulApplicative f] {α β : Type u₀}
+    (h : ∀ γ, Function.Injective (pure : γ → f γ)) :
+      Function.Injective (@EquivFunctor.mapEquiv f _ α β) :=
+  fun e₁ e₂ H =>
+    Equiv.ext $ fun x => h β (by simpa [EquivFunctor.map] using Equiv.congr_fun H (pure x))
+#align equiv_functor.map_equiv.injective EquivFunctor.mapEquiv.injective
+
+end EquivFunctor

--- a/Mathlib/Control/EquivFunctor.lean
+++ b/Mathlib/Control/EquivFunctor.lean
@@ -24,7 +24,7 @@ open Function
 
 To construct an `EquivFunctor`, it suffices to supply just the function `f α → f β` from
 an equivalence `α ≃ β`, and then prove the functor laws. It's then a consequence that
-this function is part of an equivalence, provided by `EquivFunctor.map_equiv`.
+this function is part of an equivalence, provided by `EquivFunctor.mapEquiv`.
 -/
 class EquivFunctor (f : Type u₀ → Type u₁) where
   /-- `f` preserves equality-/

--- a/Mathlib/Control/EquivFunctor.lean
+++ b/Mathlib/Control/EquivFunctor.lean
@@ -27,11 +27,11 @@ an equivalence `α ≃ β`, and then prove the functor laws. It's then a consequ
 this function is part of an equivalence, provided by `EquivFunctor.mapEquiv`.
 -/
 class EquivFunctor (f : Type u₀ → Type u₁) where
-  /-- `f` preserves equality-/
+  /-- The action of `f` on isomorphisms. -/
   map : ∀ {α β}, α ≃ β → f α → f β
-  /-- `map` of `f` preserves reflectivity-/
+  /-- `map` of `f` preserves the identity morphism. -/
   map_refl' : ∀ α, map (Equiv.refl α) = @id (f α) := by rfl
-  /-- composition of `map`s of `f` over equality preserve transitivity-/
+  /-- `map` is functorial on equivalences. -/
   map_trans' : ∀ {α β γ} (k : α ≃ β) (h : β ≃ γ), map (k.trans h) = map h ∘ map k := by rfl
 #align equiv_functor EquivFunctor
 


### PR DESCRIPTION
Initial port, fixed naming, comments and line breaks.

Against fd47bdf09e90f553519c712378e651975fe8c829