### PR TITLE
[Merged by Bors] - feat: port Algebra.Group.OrderSynonym

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4,6 +4,7 @@ import Mathlib.Algebra.Group.Basic
 import Mathlib.Algebra.Group.Commutator
 import Mathlib.Algebra.Group.Commute
 import Mathlib.Algebra.Group.Defs
+import Mathlib.Algebra.Group.OrderSynonym
 import Mathlib.Algebra.Group.Semiconj
 import Mathlib.Algebra.Group.Units
 import Mathlib.Algebra.GroupPower.Basic

--- a/Mathlib/Algebra/Group/OrderSynonym.lean
+++ b/Mathlib/Algebra/Group/OrderSynonym.lean
@@ -21,8 +21,7 @@ variable {α β : Type _}
 
 
 @[to_additive]
-instance [h : One α] : One αᵒᵈ :=
-  h
+instance [h : One α] : One αᵒᵈ := h
 
 @[to_additive]
 instance [h : Mul α] : Mul αᵒᵈ :=

--- a/Mathlib/Algebra/Group/OrderSynonym.lean
+++ b/Mathlib/Algebra/Group/OrderSynonym.lean
@@ -124,84 +124,84 @@ instance [h : CommGroup α] : CommGroup αᵒᵈ :=
   h
 
 @[simp, to_additive]
-theorem to_dual_one [One α] : toDual (1 : α) = 1 :=
+theorem toDual_one [One α] : toDual (1 : α) = 1 :=
   rfl
-#align to_dual_one to_dual_one
+#align to_dual_one toDual_one
 
 @[simp, to_additive]
-theorem of_dual_one [One α] : (ofDual 1 : α) = 1 :=
+theorem ofDual_one [One α] : (ofDual 1 : α) = 1 :=
   rfl
-#align of_dual_one of_dual_one
+#align of_dual_one ofDual_one
 
 @[simp, to_additive]
-theorem to_dual_mul [Mul α] (a b : α) : toDual (a * b) = toDual a * toDual b :=
+theorem toDual_mul [Mul α] (a b : α) : toDual (a * b) = toDual a * toDual b :=
   rfl
-#align to_dual_mul to_dual_mul
+#align to_dual_mul toDual_mul
 
 @[simp, to_additive]
-theorem of_dual_mul [Mul α] (a b : αᵒᵈ) : ofDual (a * b) = ofDual a * ofDual b :=
+theorem ofDual_mul [Mul α] (a b : αᵒᵈ) : ofDual (a * b) = ofDual a * ofDual b :=
   rfl
-#align of_dual_mul of_dual_mul
+#align of_dual_mul ofDual_mul
 
 @[simp, to_additive]
-theorem to_dual_inv [Inv α] (a : α) : toDual a⁻¹ = (toDual a)⁻¹ :=
+theorem toDual_inv [Inv α] (a : α) : toDual a⁻¹ = (toDual a)⁻¹ :=
   rfl
-#align to_dual_inv to_dual_inv
+#align to_dual_inv toDual_inv
 
 @[simp, to_additive]
-theorem of_dual_inv [Inv α] (a : αᵒᵈ) : ofDual a⁻¹ = (ofDual a)⁻¹ :=
+theorem ofDual_inv [Inv α] (a : αᵒᵈ) : ofDual a⁻¹ = (ofDual a)⁻¹ :=
   rfl
-#align of_dual_inv of_dual_inv
+#align of_dual_inv ofDual_inv
 
 @[simp, to_additive]
-theorem to_dual_div [Div α] (a b : α) : toDual (a / b) = toDual a / toDual b :=
+theorem toDual_div [Div α] (a b : α) : toDual (a / b) = toDual a / toDual b :=
   rfl
-#align to_dual_div to_dual_div
+#align to_dual_div toDual_div
 
 @[simp, to_additive]
-theorem of_dual_div [Div α] (a b : αᵒᵈ) : ofDual (a / b) = ofDual a / ofDual b :=
+theorem ofDual_div [Div α] (a b : αᵒᵈ) : ofDual (a / b) = ofDual a / ofDual b :=
   rfl
-#align of_dual_div of_dual_div
+#align of_dual_div ofDual_div
 
 @[simp, to_additive]
-theorem to_dual_smul [HasSmul α β] (a : α) (b : β) : toDual (a • b) = a • toDual b :=
+theorem toDual_smul [HasSmul α β] (a : α) (b : β) : toDual (a • b) = a • toDual b :=
   rfl
-#align to_dual_smul to_dual_smul
+#align to_dual_smul toDual_smul
 
 @[simp, to_additive]
-theorem of_dual_smul [HasSmul α β] (a : α) (b : βᵒᵈ) : ofDual (a • b) = a • ofDual b :=
+theorem ofDual_smul [HasSmul α β] (a : α) (b : βᵒᵈ) : ofDual (a • b) = a • ofDual b :=
   rfl
-#align of_dual_smul of_dual_smul
+#align of_dual_smul ofDual_smul
 
 @[simp, to_additive]
-theorem to_dual_smul' [HasSmul α β] (a : α) (b : β) : toDual a • b = a • b :=
+theorem toDual_smul' [HasSmul α β] (a : α) (b : β) : toDual a • b = a • b :=
   rfl
-#align to_dual_smul' to_dual_smul'
+#align to_dual_smul' toDual_smul'
 
 @[simp, to_additive]
-theorem of_dual_smul' [HasSmul α β] (a : αᵒᵈ) (b : β) : ofDual a • b = a • b :=
+theorem ofDual_smul' [HasSmul α β] (a : αᵒᵈ) (b : β) : ofDual a • b = a • b :=
   rfl
-#align of_dual_smul' of_dual_smul'
+#align of_dual_smul' ofDual_smul'
 
-@[simp, to_additive to_dual_smul, to_additive_reorder 1 4]
-theorem to_dual_pow [Pow α β] (a : α) (b : β) : toDual (a ^ b) = toDual a ^ b :=
+@[simp, to_additive toDual_smul, to_additive_reorder 1 4]
+theorem toDual_pow [Pow α β] (a : α) (b : β) : toDual (a ^ b) = toDual a ^ b :=
   rfl
-#align to_dual_pow to_dual_pow
+#align to_dual_pow toDual_pow
 
-@[simp, to_additive of_dual_smul, to_additive_reorder 1 4]
-theorem of_dual_pow [Pow α β] (a : αᵒᵈ) (b : β) : ofDual (a ^ b) = ofDual a ^ b :=
+@[simp, to_additive ofDual_smul, to_additive_reorder 1 4]
+theorem ofDual_pow [Pow α β] (a : αᵒᵈ) (b : β) : ofDual (a ^ b) = ofDual a ^ b :=
   rfl
-#align of_dual_pow of_dual_pow
+#align of_dual_pow ofDual_pow
 
-@[simp, to_additive to_dual_smul', to_additive_reorder 1 4]
-theorem pow_to_dual [Pow α β] (a : α) (b : β) : a ^ toDual b = a ^ b :=
+@[simp, to_additive toDual_smul', to_additive_reorder 1 4]
+theorem pow_toDual [Pow α β] (a : α) (b : β) : a ^ toDual b = a ^ b :=
   rfl
-#align pow_to_dual pow_to_dual
+#align pow_to_dual pow_toDual
 
-@[simp, to_additive of_dual_smul', to_additive_reorder 1 4]
-theorem pow_of_dual [Pow α β] (a : α) (b : βᵒᵈ) : a ^ ofDual b = a ^ b :=
+@[simp, to_additive ofDual_smul', to_additive_reorder 1 4]
+theorem pow_ofDual [Pow α β] (a : α) (b : βᵒᵈ) : a ^ ofDual b = a ^ b :=
   rfl
-#align pow_of_dual pow_of_dual
+#align pow_of_dual pow_ofDual
 
 /-! ### Lexicographical order -/
 
@@ -310,81 +310,81 @@ instance [h : CommGroup α] : CommGroup (Lex α) :=
   h
 
 @[simp, to_additive]
-theorem to_lex_one [One α] : toLex (1 : α) = 1 :=
+theorem toLex_one [One α] : toLex (1 : α) = 1 :=
   rfl
-#align to_lex_one to_lex_one
+#align to_lex_one toLex_one
 
 @[simp, to_additive]
-theorem of_lex_one [One α] : (ofLex 1 : α) = 1 :=
+theorem ofLex_one [One α] : (ofLex 1 : α) = 1 :=
   rfl
-#align of_lex_one of_lex_one
+#align of_lex_one ofLex_one
 
 @[simp, to_additive]
-theorem to_lex_mul [Mul α] (a b : α) : toLex (a * b) = toLex a * toLex b :=
+theorem toLex_mul [Mul α] (a b : α) : toLex (a * b) = toLex a * toLex b :=
   rfl
-#align to_lex_mul to_lex_mul
+#align to_lex_mul toLex_mul
 
 @[simp, to_additive]
-theorem of_lex_mul [Mul α] (a b : Lex α) : ofLex (a * b) = ofLex a * ofLex b :=
+theorem ofLex_mul [Mul α] (a b : Lex α) : ofLex (a * b) = ofLex a * ofLex b :=
   rfl
-#align of_lex_mul of_lex_mul
+#align of_lex_mul ofLex_mul
 
 @[simp, to_additive]
-theorem to_lex_inv [Inv α] (a : α) : toLex a⁻¹ = (toLex a)⁻¹ :=
+theorem toLex_inv [Inv α] (a : α) : toLex a⁻¹ = (toLex a)⁻¹ :=
   rfl
-#align to_lex_inv to_lex_inv
+#align to_lex_inv toLex_inv
 
 @[simp, to_additive]
-theorem of_lex_inv [Inv α] (a : Lex α) : ofLex a⁻¹ = (ofLex a)⁻¹ :=
+theorem ofLex_inv [Inv α] (a : Lex α) : ofLex a⁻¹ = (ofLex a)⁻¹ :=
   rfl
-#align of_lex_inv of_lex_inv
+#align of_lex_inv ofLex_inv
 
 @[simp, to_additive]
-theorem to_lex_div [Div α] (a b : α) : toLex (a / b) = toLex a / toLex b :=
+theorem toLex_div [Div α] (a b : α) : toLex (a / b) = toLex a / toLex b :=
   rfl
-#align to_lex_div to_lex_div
+#align to_lex_div toLex_div
 
 @[simp, to_additive]
-theorem of_lex_div [Div α] (a b : Lex α) : ofLex (a / b) = ofLex a / ofLex b :=
+theorem ofLex_div [Div α] (a b : Lex α) : ofLex (a / b) = ofLex a / ofLex b :=
   rfl
-#align of_lex_div of_lex_div
+#align of_lex_div ofLex_div
 
 @[simp, to_additive]
-theorem to_lex_smul [HasSmul α β] (a : α) (b : β) : toLex (a • b) = a • toLex b :=
+theorem toLex_smul [HasSmul α β] (a : α) (b : β) : toLex (a • b) = a • toLex b :=
   rfl
-#align to_lex_smul to_lex_smul
+#align to_lex_smul toLex_smul
 
 @[simp, to_additive]
-theorem of_lex_smul [HasSmul α β] (a : α) (b : Lex β) : ofLex (a • b) = a • ofLex b :=
+theorem ofLex_smul [HasSmul α β] (a : α) (b : Lex β) : ofLex (a • b) = a • ofLex b :=
   rfl
-#align of_lex_smul of_lex_smul
+#align of_lex_smul ofLex_smul
 
 @[simp, to_additive]
-theorem to_lex_smul' [HasSmul α β] (a : α) (b : β) : toLex a • b = a • b :=
+theorem toLex_smul' [HasSmul α β] (a : α) (b : β) : toLex a • b = a • b :=
   rfl
-#align to_lex_smul' to_lex_smul'
+#align to_lex_smul' toLex_smul'
 
 @[simp, to_additive]
-theorem of_lex_smul' [HasSmul α β] (a : Lex α) (b : β) : ofLex a • b = a • b :=
+theorem ofLex_smul' [HasSmul α β] (a : Lex α) (b : β) : ofLex a • b = a • b :=
   rfl
-#align of_lex_smul' of_lex_smul'
+#align of_lex_smul' ofLex_smul'
 
-@[simp, to_additive to_lex_smul, to_additive_reorder 1 4]
-theorem to_lex_pow [Pow α β] (a : α) (b : β) : toLex (a ^ b) = toLex a ^ b :=
+@[simp, to_additive toLex_smul, to_additive_reorder 1 4]
+theorem toLex_pow [Pow α β] (a : α) (b : β) : toLex (a ^ b) = toLex a ^ b :=
   rfl
-#align to_lex_pow to_lex_pow
+#align to_lex_pow toLex_pow
 
-@[simp, to_additive of_lex_smul, to_additive_reorder 1 4]
-theorem of_lex_pow [Pow α β] (a : Lex α) (b : β) : ofLex (a ^ b) = ofLex a ^ b :=
+@[simp, to_additive ofLex_smul, to_additive_reorder 1 4]
+theorem ofLex_pow [Pow α β] (a : Lex α) (b : β) : ofLex (a ^ b) = ofLex a ^ b :=
   rfl
-#align of_lex_pow of_lex_pow
+#align of_lex_pow ofLex_pow
 
-@[simp, to_additive to_lex_smul, to_additive_reorder 1 4]
-theorem pow_to_lex [Pow α β] (a : α) (b : β) : a ^ toLex b = a ^ b :=
+@[simp, to_additive toLex_smul, to_additive_reorder 1 4]
+theorem pow_toLex [Pow α β] (a : α) (b : β) : a ^ toLex b = a ^ b :=
   rfl
-#align pow_to_lex pow_to_lex
+#align pow_to_lex pow_toLex
 
-@[simp, to_additive of_lex_smul, to_additive_reorder 1 4]
-theorem pow_of_lex [Pow α β] (a : α) (b : Lex β) : a ^ ofLex b = a ^ b :=
+@[simp, to_additive ofLex_smul, to_additive_reorder 1 4]
+theorem pow_ofLex [Pow α β] (a : α) (b : Lex β) : a ^ ofLex b = a ^ b :=
   rfl
-#align pow_of_lex pow_of_lex
+#align pow_of_lex pow_ofLex

--- a/Mathlib/Algebra/Group/OrderSynonym.lean
+++ b/Mathlib/Algebra/Group/OrderSynonym.lean
@@ -1,0 +1,390 @@
+/-
+Copyright (c) 2021 Yury Kudryashov. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yury Kudryashov, Yaël Dillies
+-/
+import Mathbin.Algebra.Group.Defs
+import Mathbin.Order.Synonym
+
+/-!
+# Group structure on the order type synonyms
+
+Transfer algebraic instances from `α` to `αᵒᵈ` and `lex α`.
+-/
+
+
+open OrderDual
+
+variable {α β : Type _}
+
+/-! ### `order_dual` -/
+
+
+@[to_additive]
+instance [h : One α] : One αᵒᵈ :=
+  h
+
+@[to_additive]
+instance [h : Mul α] : Mul αᵒᵈ :=
+  h
+
+@[to_additive]
+instance [h : Inv α] : Inv αᵒᵈ :=
+  h
+
+@[to_additive]
+instance [h : Div α] : Div αᵒᵈ :=
+  h
+
+@[to_additive]
+instance [h : HasSmul α β] : HasSmul α βᵒᵈ :=
+  h
+
+@[to_additive]
+instance OrderDual.hasSmul' [h : HasSmul α β] : HasSmul αᵒᵈ β :=
+  h
+#align order_dual.has_smul' OrderDual.hasSmul'
+
+@[to_additive OrderDual.hasSmul]
+instance OrderDual.hasPow [h : Pow α β] : Pow αᵒᵈ β :=
+  h
+#align order_dual.has_pow OrderDual.hasPow
+
+@[to_additive OrderDual.hasSmul']
+instance OrderDual.hasPow' [h : Pow α β] : Pow α βᵒᵈ :=
+  h
+#align order_dual.has_pow' OrderDual.hasPow'
+
+@[to_additive]
+instance [h : Semigroup α] : Semigroup αᵒᵈ :=
+  h
+
+@[to_additive]
+instance [h : CommSemigroup α] : CommSemigroup αᵒᵈ :=
+  h
+
+@[to_additive]
+instance [h : LeftCancelSemigroup α] : LeftCancelSemigroup αᵒᵈ :=
+  h
+
+@[to_additive]
+instance [h : RightCancelSemigroup α] : RightCancelSemigroup αᵒᵈ :=
+  h
+
+@[to_additive]
+instance [h : MulOneClass α] : MulOneClass αᵒᵈ :=
+  h
+
+@[to_additive]
+instance [h : Monoid α] : Monoid αᵒᵈ :=
+  h
+
+@[to_additive]
+instance [h : CommMonoid α] : CommMonoid αᵒᵈ :=
+  h
+
+@[to_additive]
+instance [h : LeftCancelMonoid α] : LeftCancelMonoid αᵒᵈ :=
+  h
+
+@[to_additive]
+instance [h : RightCancelMonoid α] : RightCancelMonoid αᵒᵈ :=
+  h
+
+@[to_additive]
+instance [h : CancelMonoid α] : CancelMonoid αᵒᵈ :=
+  h
+
+@[to_additive]
+instance [h : CancelCommMonoid α] : CancelCommMonoid αᵒᵈ :=
+  h
+
+@[to_additive]
+instance [h : HasInvolutiveInv α] : HasInvolutiveInv αᵒᵈ :=
+  h
+
+@[to_additive]
+instance [h : DivInvMonoid α] : DivInvMonoid αᵒᵈ :=
+  h
+
+@[to_additive OrderDual.subtractionMonoid]
+instance [h : DivisionMonoid α] : DivisionMonoid αᵒᵈ :=
+  h
+
+@[to_additive OrderDual.subtractionCommMonoid]
+instance [h : DivisionCommMonoid α] : DivisionCommMonoid αᵒᵈ :=
+  h
+
+@[to_additive]
+instance [h : Group α] : Group αᵒᵈ :=
+  h
+
+@[to_additive]
+instance [h : CommGroup α] : CommGroup αᵒᵈ :=
+  h
+
+@[simp, to_additive]
+theorem to_dual_one [One α] : toDual (1 : α) = 1 :=
+  rfl
+#align to_dual_one to_dual_one
+
+@[simp, to_additive]
+theorem of_dual_one [One α] : (ofDual 1 : α) = 1 :=
+  rfl
+#align of_dual_one of_dual_one
+
+@[simp, to_additive]
+theorem to_dual_mul [Mul α] (a b : α) : toDual (a * b) = toDual a * toDual b :=
+  rfl
+#align to_dual_mul to_dual_mul
+
+@[simp, to_additive]
+theorem of_dual_mul [Mul α] (a b : αᵒᵈ) : ofDual (a * b) = ofDual a * ofDual b :=
+  rfl
+#align of_dual_mul of_dual_mul
+
+@[simp, to_additive]
+theorem to_dual_inv [Inv α] (a : α) : toDual a⁻¹ = (toDual a)⁻¹ :=
+  rfl
+#align to_dual_inv to_dual_inv
+
+@[simp, to_additive]
+theorem of_dual_inv [Inv α] (a : αᵒᵈ) : ofDual a⁻¹ = (ofDual a)⁻¹ :=
+  rfl
+#align of_dual_inv of_dual_inv
+
+@[simp, to_additive]
+theorem to_dual_div [Div α] (a b : α) : toDual (a / b) = toDual a / toDual b :=
+  rfl
+#align to_dual_div to_dual_div
+
+@[simp, to_additive]
+theorem of_dual_div [Div α] (a b : αᵒᵈ) : ofDual (a / b) = ofDual a / ofDual b :=
+  rfl
+#align of_dual_div of_dual_div
+
+@[simp, to_additive]
+theorem to_dual_smul [HasSmul α β] (a : α) (b : β) : toDual (a • b) = a • toDual b :=
+  rfl
+#align to_dual_smul to_dual_smul
+
+@[simp, to_additive]
+theorem of_dual_smul [HasSmul α β] (a : α) (b : βᵒᵈ) : ofDual (a • b) = a • ofDual b :=
+  rfl
+#align of_dual_smul of_dual_smul
+
+@[simp, to_additive]
+theorem to_dual_smul' [HasSmul α β] (a : α) (b : β) : toDual a • b = a • b :=
+  rfl
+#align to_dual_smul' to_dual_smul'
+
+@[simp, to_additive]
+theorem of_dual_smul' [HasSmul α β] (a : αᵒᵈ) (b : β) : ofDual a • b = a • b :=
+  rfl
+#align of_dual_smul' of_dual_smul'
+
+@[simp, to_additive to_dual_smul, to_additive_reorder 1 4]
+theorem to_dual_pow [Pow α β] (a : α) (b : β) : toDual (a ^ b) = toDual a ^ b :=
+  rfl
+#align to_dual_pow to_dual_pow
+
+@[simp, to_additive of_dual_smul, to_additive_reorder 1 4]
+theorem of_dual_pow [Pow α β] (a : αᵒᵈ) (b : β) : ofDual (a ^ b) = ofDual a ^ b :=
+  rfl
+#align of_dual_pow of_dual_pow
+
+@[simp, to_additive to_dual_smul', to_additive_reorder 1 4]
+theorem pow_to_dual [Pow α β] (a : α) (b : β) : a ^ toDual b = a ^ b :=
+  rfl
+#align pow_to_dual pow_to_dual
+
+@[simp, to_additive of_dual_smul', to_additive_reorder 1 4]
+theorem pow_of_dual [Pow α β] (a : α) (b : βᵒᵈ) : a ^ ofDual b = a ^ b :=
+  rfl
+#align pow_of_dual pow_of_dual
+
+/-! ### Lexicographical order -/
+
+
+@[to_additive]
+instance [h : One α] : One (Lex α) :=
+  h
+
+@[to_additive]
+instance [h : Mul α] : Mul (Lex α) :=
+  h
+
+@[to_additive]
+instance [h : Inv α] : Inv (Lex α) :=
+  h
+
+@[to_additive]
+instance [h : Div α] : Div (Lex α) :=
+  h
+
+@[to_additive]
+instance [h : HasSmul α β] : HasSmul α (Lex β) :=
+  h
+
+@[to_additive]
+instance Lex.hasSmul' [h : HasSmul α β] : HasSmul (Lex α) β :=
+  h
+#align lex.has_smul' Lex.hasSmul'
+
+@[to_additive Lex.hasSmul]
+instance Lex.hasPow [h : Pow α β] : Pow (Lex α) β :=
+  h
+#align lex.has_pow Lex.hasPow
+
+@[to_additive Lex.hasSmul']
+instance Lex.hasPow' [h : Pow α β] : Pow α (Lex β) :=
+  h
+#align lex.has_pow' Lex.hasPow'
+
+@[to_additive]
+instance [h : Semigroup α] : Semigroup (Lex α) :=
+  h
+
+@[to_additive]
+instance [h : CommSemigroup α] : CommSemigroup (Lex α) :=
+  h
+
+@[to_additive]
+instance [h : LeftCancelSemigroup α] : LeftCancelSemigroup (Lex α) :=
+  h
+
+@[to_additive]
+instance [h : RightCancelSemigroup α] : RightCancelSemigroup (Lex α) :=
+  h
+
+@[to_additive]
+instance [h : MulOneClass α] : MulOneClass (Lex α) :=
+  h
+
+@[to_additive]
+instance [h : Monoid α] : Monoid (Lex α) :=
+  h
+
+@[to_additive]
+instance [h : CommMonoid α] : CommMonoid (Lex α) :=
+  h
+
+@[to_additive]
+instance [h : LeftCancelMonoid α] : LeftCancelMonoid (Lex α) :=
+  h
+
+@[to_additive]
+instance [h : RightCancelMonoid α] : RightCancelMonoid (Lex α) :=
+  h
+
+@[to_additive]
+instance [h : CancelMonoid α] : CancelMonoid (Lex α) :=
+  h
+
+@[to_additive]
+instance [h : CancelCommMonoid α] : CancelCommMonoid (Lex α) :=
+  h
+
+@[to_additive]
+instance [h : HasInvolutiveInv α] : HasInvolutiveInv (Lex α) :=
+  h
+
+@[to_additive]
+instance [h : DivInvMonoid α] : DivInvMonoid (Lex α) :=
+  h
+
+@[to_additive OrderDual.subtractionMonoid]
+instance [h : DivisionMonoid α] : DivisionMonoid (Lex α) :=
+  h
+
+@[to_additive OrderDual.subtractionCommMonoid]
+instance [h : DivisionCommMonoid α] : DivisionCommMonoid (Lex α) :=
+  h
+
+@[to_additive]
+instance [h : Group α] : Group (Lex α) :=
+  h
+
+@[to_additive]
+instance [h : CommGroup α] : CommGroup (Lex α) :=
+  h
+
+@[simp, to_additive]
+theorem to_lex_one [One α] : toLex (1 : α) = 1 :=
+  rfl
+#align to_lex_one to_lex_one
+
+@[simp, to_additive]
+theorem of_lex_one [One α] : (ofLex 1 : α) = 1 :=
+  rfl
+#align of_lex_one of_lex_one
+
+@[simp, to_additive]
+theorem to_lex_mul [Mul α] (a b : α) : toLex (a * b) = toLex a * toLex b :=
+  rfl
+#align to_lex_mul to_lex_mul
+
+@[simp, to_additive]
+theorem of_lex_mul [Mul α] (a b : Lex α) : ofLex (a * b) = ofLex a * ofLex b :=
+  rfl
+#align of_lex_mul of_lex_mul
+
+@[simp, to_additive]
+theorem to_lex_inv [Inv α] (a : α) : toLex a⁻¹ = (toLex a)⁻¹ :=
+  rfl
+#align to_lex_inv to_lex_inv
+
+@[simp, to_additive]
+theorem of_lex_inv [Inv α] (a : Lex α) : ofLex a⁻¹ = (ofLex a)⁻¹ :=
+  rfl
+#align of_lex_inv of_lex_inv
+
+@[simp, to_additive]
+theorem to_lex_div [Div α] (a b : α) : toLex (a / b) = toLex a / toLex b :=
+  rfl
+#align to_lex_div to_lex_div
+
+@[simp, to_additive]
+theorem of_lex_div [Div α] (a b : Lex α) : ofLex (a / b) = ofLex a / ofLex b :=
+  rfl
+#align of_lex_div of_lex_div
+
+@[simp, to_additive]
+theorem to_lex_smul [HasSmul α β] (a : α) (b : β) : toLex (a • b) = a • toLex b :=
+  rfl
+#align to_lex_smul to_lex_smul
+
+@[simp, to_additive]
+theorem of_lex_smul [HasSmul α β] (a : α) (b : Lex β) : ofLex (a • b) = a • ofLex b :=
+  rfl
+#align of_lex_smul of_lex_smul
+
+@[simp, to_additive]
+theorem to_lex_smul' [HasSmul α β] (a : α) (b : β) : toLex a • b = a • b :=
+  rfl
+#align to_lex_smul' to_lex_smul'
+
+@[simp, to_additive]
+theorem of_lex_smul' [HasSmul α β] (a : Lex α) (b : β) : ofLex a • b = a • b :=
+  rfl
+#align of_lex_smul' of_lex_smul'
+
+@[simp, to_additive to_lex_smul, to_additive_reorder 1 4]
+theorem to_lex_pow [Pow α β] (a : α) (b : β) : toLex (a ^ b) = toLex a ^ b :=
+  rfl
+#align to_lex_pow to_lex_pow
+
+@[simp, to_additive of_lex_smul, to_additive_reorder 1 4]
+theorem of_lex_pow [Pow α β] (a : Lex α) (b : β) : ofLex (a ^ b) = ofLex a ^ b :=
+  rfl
+#align of_lex_pow of_lex_pow
+
+@[simp, to_additive to_lex_smul, to_additive_reorder 1 4]
+theorem pow_to_lex [Pow α β] (a : α) (b : β) : a ^ toLex b = a ^ b :=
+  rfl
+#align pow_to_lex pow_to_lex
+
+@[simp, to_additive of_lex_smul, to_additive_reorder 1 4]
+theorem pow_of_lex [Pow α β] (a : α) (b : Lex β) : a ^ ofLex b = a ^ b :=
+  rfl
+#align pow_of_lex pow_of_lex

--- a/Mathlib/Algebra/Group/OrderSynonym.lean
+++ b/Mathlib/Algebra/Group/OrderSynonym.lean
@@ -3,8 +3,8 @@ Copyright (c) 2021 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov, Yaël Dillies
 -/
-import Mathbin.Algebra.Group.Defs
-import Mathbin.Order.Synonym
+import Mathlib.Algebra.Group.Defs
+import Mathlib.Order.Synonym
 
 /-!
 # Group structure on the order type synonyms

--- a/Mathlib/Algebra/Group/OrderSynonym.lean
+++ b/Mathlib/Algebra/Group/OrderSynonym.lean
@@ -388,3 +388,16 @@ theorem pow_toLex [Pow α β] (a : α) (b : β) : a ^ toLex b = a ^ b :=
 theorem pow_ofLex [Pow α β] (a : α) (b : Lex β) : a ^ ofLex b = a ^ b :=
   rfl
 #align pow_of_lex pow_ofLex
+
+attribute [instance 100] instZeroOrderDual instAddOrderDual instNegOrderDual instSubOrderDual
+  instHasVaddOrderDual hasVadd' hasSmul instAddSemigroupOrderDual instAddCommSemigroupOrderDual
+  instAddLeftCancelSemigroupOrderDual instAddRightCancelSemigroupOrderDual instAddZeroClassOrderDual
+  instAddMonoidOrderDual instAddCommMonoidOrderDual instAddLeftCancelMonoidOrderDual
+  instAddRightCancelMonoidOrderDual instAddCancelMonoidOrderDual instAddCancelCommMonoidOrderDual
+  instHasInvolutiveNegOrderDual instSubNegAddMonoidOrderDual subtractionMonoid subtractionCommMonoid
+  instAddGroupOrderDual instAddCommGroupOrderDual instZeroLex instAddLex instNegLex instSubLex
+  instHasVaddLex Lex.hasVadd' Lex.hasSmul instAddSemigroupLex instAddCommSemigroupLex
+  instAddLeftCancelSemigroupLex instAddRightCancelSemigroupLex instAddZeroClassLex instAddMonoidLex
+  instAddCommMonoidLex instAddLeftCancelMonoidLex instAddRightCancelMonoidLex instAddCancelMonoidLex
+  instAddCancelCommMonoidLex instHasInvolutiveNegLex instSubNegAddMonoidLex instAddGroupLex
+  instAddCommGroupLex

--- a/Mathlib/Algebra/Group/OrderSynonym.lean
+++ b/Mathlib/Algebra/Group/OrderSynonym.lean
@@ -24,368 +24,287 @@ variable {α β : Type _}
 instance [h : One α] : One αᵒᵈ := h
 
 @[to_additive]
-instance [h : Mul α] : Mul αᵒᵈ :=
-  h
+instance [h : Mul α] : Mul αᵒᵈ := h
 
 @[to_additive]
-instance [h : Inv α] : Inv αᵒᵈ :=
-  h
+instance [h : Inv α] : Inv αᵒᵈ := h
 
 @[to_additive]
-instance [h : Div α] : Div αᵒᵈ :=
-  h
+instance [h : Div α] : Div αᵒᵈ := h
 
 @[to_additive]
-instance [h : HasSmul α β] : HasSmul α βᵒᵈ :=
-  h
+instance [h : HasSmul α β] : HasSmul α βᵒᵈ := h
 
 @[to_additive]
-instance OrderDual.hasSmul' [h : HasSmul α β] : HasSmul αᵒᵈ β :=
-  h
+instance OrderDual.hasSmul' [h : HasSmul α β] : HasSmul αᵒᵈ β := h
 #align order_dual.has_smul' OrderDual.hasSmul'
 
 @[to_additive OrderDual.hasSmul]
-instance OrderDual.hasPow [h : Pow α β] : Pow αᵒᵈ β :=
-  h
+instance OrderDual.hasPow [h : Pow α β] : Pow αᵒᵈ β := h
 #align order_dual.has_pow OrderDual.hasPow
 
 @[to_additive OrderDual.hasSmul']
-instance OrderDual.hasPow' [h : Pow α β] : Pow α βᵒᵈ :=
-  h
+instance OrderDual.hasPow' [h : Pow α β] : Pow α βᵒᵈ := h
 #align order_dual.has_pow' OrderDual.hasPow'
 
 @[to_additive]
-instance [h : Semigroup α] : Semigroup αᵒᵈ :=
-  h
+instance [h : Semigroup α] : Semigroup αᵒᵈ := h
 
 @[to_additive]
-instance [h : CommSemigroup α] : CommSemigroup αᵒᵈ :=
-  h
+instance [h : CommSemigroup α] : CommSemigroup αᵒᵈ := h
 
 @[to_additive]
-instance [h : LeftCancelSemigroup α] : LeftCancelSemigroup αᵒᵈ :=
-  h
+instance [h : LeftCancelSemigroup α] : LeftCancelSemigroup αᵒᵈ := h
 
 @[to_additive]
-instance [h : RightCancelSemigroup α] : RightCancelSemigroup αᵒᵈ :=
-  h
+instance [h : RightCancelSemigroup α] : RightCancelSemigroup αᵒᵈ := h
 
 @[to_additive]
-instance [h : MulOneClass α] : MulOneClass αᵒᵈ :=
-  h
+instance [h : MulOneClass α] : MulOneClass αᵒᵈ := h
 
 @[to_additive]
-instance [h : Monoid α] : Monoid αᵒᵈ :=
-  h
+instance [h : Monoid α] : Monoid αᵒᵈ := h
 
 @[to_additive]
-instance [h : CommMonoid α] : CommMonoid αᵒᵈ :=
-  h
+instance [h : CommMonoid α] : CommMonoid αᵒᵈ := h
 
 @[to_additive]
-instance [h : LeftCancelMonoid α] : LeftCancelMonoid αᵒᵈ :=
-  h
+instance [h : LeftCancelMonoid α] : LeftCancelMonoid αᵒᵈ := h
 
 @[to_additive]
-instance [h : RightCancelMonoid α] : RightCancelMonoid αᵒᵈ :=
-  h
+instance [h : RightCancelMonoid α] : RightCancelMonoid αᵒᵈ := h
 
 @[to_additive]
-instance [h : CancelMonoid α] : CancelMonoid αᵒᵈ :=
-  h
+instance [h : CancelMonoid α] : CancelMonoid αᵒᵈ := h
 
 @[to_additive]
-instance [h : CancelCommMonoid α] : CancelCommMonoid αᵒᵈ :=
-  h
+instance [h : CancelCommMonoid α] : CancelCommMonoid αᵒᵈ := h
 
 @[to_additive]
-instance [h : HasInvolutiveInv α] : HasInvolutiveInv αᵒᵈ :=
-  h
+instance [h : HasInvolutiveInv α] : HasInvolutiveInv αᵒᵈ := h
 
 @[to_additive]
-instance [h : DivInvMonoid α] : DivInvMonoid αᵒᵈ :=
-  h
+instance [h : DivInvMonoid α] : DivInvMonoid αᵒᵈ := h
 
 @[to_additive OrderDual.subtractionMonoid]
-instance [h : DivisionMonoid α] : DivisionMonoid αᵒᵈ :=
-  h
+instance [h : DivisionMonoid α] : DivisionMonoid αᵒᵈ := h
 
 @[to_additive OrderDual.subtractionCommMonoid]
-instance [h : DivisionCommMonoid α] : DivisionCommMonoid αᵒᵈ :=
-  h
+instance [h : DivisionCommMonoid α] : DivisionCommMonoid αᵒᵈ := h
 
 @[to_additive]
-instance [h : Group α] : Group αᵒᵈ :=
-  h
+instance [h : Group α] : Group αᵒᵈ := h
 
 @[to_additive]
-instance [h : CommGroup α] : CommGroup αᵒᵈ :=
-  h
+instance [h : CommGroup α] : CommGroup αᵒᵈ := h
 
 @[simp, to_additive]
-theorem toDual_one [One α] : toDual (1 : α) = 1 :=
-  rfl
+theorem toDual_one [One α] : toDual (1 : α) = 1 := rfl
 #align to_dual_one toDual_one
 
 @[simp, to_additive]
-theorem ofDual_one [One α] : (ofDual 1 : α) = 1 :=
-  rfl
+theorem ofDual_one [One α] : (ofDual 1 : α) = 1 := rfl
 #align of_dual_one ofDual_one
 
 @[simp, to_additive]
-theorem toDual_mul [Mul α] (a b : α) : toDual (a * b) = toDual a * toDual b :=
-  rfl
+theorem toDual_mul [Mul α] (a b : α) : toDual (a * b) = toDual a * toDual b := rfl
 #align to_dual_mul toDual_mul
 
 @[simp, to_additive]
-theorem ofDual_mul [Mul α] (a b : αᵒᵈ) : ofDual (a * b) = ofDual a * ofDual b :=
-  rfl
+theorem ofDual_mul [Mul α] (a b : αᵒᵈ) : ofDual (a * b) = ofDual a * ofDual b := rfl
 #align of_dual_mul ofDual_mul
 
 @[simp, to_additive]
-theorem toDual_inv [Inv α] (a : α) : toDual a⁻¹ = (toDual a)⁻¹ :=
-  rfl
+theorem toDual_inv [Inv α] (a : α) : toDual a⁻¹ = (toDual a)⁻¹ := rfl
 #align to_dual_inv toDual_inv
 
 @[simp, to_additive]
-theorem ofDual_inv [Inv α] (a : αᵒᵈ) : ofDual a⁻¹ = (ofDual a)⁻¹ :=
-  rfl
+theorem ofDual_inv [Inv α] (a : αᵒᵈ) : ofDual a⁻¹ = (ofDual a)⁻¹ := rfl
 #align of_dual_inv ofDual_inv
 
 @[simp, to_additive]
-theorem toDual_div [Div α] (a b : α) : toDual (a / b) = toDual a / toDual b :=
-  rfl
+theorem toDual_div [Div α] (a b : α) : toDual (a / b) = toDual a / toDual b := rfl
 #align to_dual_div toDual_div
 
 @[simp, to_additive]
-theorem ofDual_div [Div α] (a b : αᵒᵈ) : ofDual (a / b) = ofDual a / ofDual b :=
-  rfl
+theorem ofDual_div [Div α] (a b : αᵒᵈ) : ofDual (a / b) = ofDual a / ofDual b := rfl
 #align of_dual_div ofDual_div
 
 @[simp, to_additive]
-theorem toDual_smul [HasSmul α β] (a : α) (b : β) : toDual (a • b) = a • toDual b :=
-  rfl
+theorem toDual_smul [HasSmul α β] (a : α) (b : β) : toDual (a • b) = a • toDual b := rfl
 #align to_dual_smul toDual_smul
 
 @[simp, to_additive]
-theorem ofDual_smul [HasSmul α β] (a : α) (b : βᵒᵈ) : ofDual (a • b) = a • ofDual b :=
-  rfl
+theorem ofDual_smul [HasSmul α β] (a : α) (b : βᵒᵈ) : ofDual (a • b) = a • ofDual b := rfl
 #align of_dual_smul ofDual_smul
 
 @[simp, to_additive]
-theorem toDual_smul' [HasSmul α β] (a : α) (b : β) : toDual a • b = a • b :=
-  rfl
+theorem toDual_smul' [HasSmul α β] (a : α) (b : β) : toDual a • b = a • b := rfl
 #align to_dual_smul' toDual_smul'
 
 @[simp, to_additive]
-theorem ofDual_smul' [HasSmul α β] (a : αᵒᵈ) (b : β) : ofDual a • b = a • b :=
-  rfl
+theorem ofDual_smul' [HasSmul α β] (a : αᵒᵈ) (b : β) : ofDual a • b = a • b := rfl
 #align of_dual_smul' ofDual_smul'
 
 @[simp, to_additive toDual_smul, to_additive_reorder 1 4]
-theorem toDual_pow [Pow α β] (a : α) (b : β) : toDual (a ^ b) = toDual a ^ b :=
-  rfl
+theorem toDual_pow [Pow α β] (a : α) (b : β) : toDual (a ^ b) = toDual a ^ b := rfl
 #align to_dual_pow toDual_pow
 
 @[simp, to_additive ofDual_smul, to_additive_reorder 1 4]
-theorem ofDual_pow [Pow α β] (a : αᵒᵈ) (b : β) : ofDual (a ^ b) = ofDual a ^ b :=
-  rfl
+theorem ofDual_pow [Pow α β] (a : αᵒᵈ) (b : β) : ofDual (a ^ b) = ofDual a ^ b := rfl
 #align of_dual_pow ofDual_pow
 
 @[simp, to_additive toDual_smul', to_additive_reorder 1 4]
-theorem pow_toDual [Pow α β] (a : α) (b : β) : a ^ toDual b = a ^ b :=
-  rfl
+theorem pow_toDual [Pow α β] (a : α) (b : β) : a ^ toDual b = a ^ b := rfl
 #align pow_to_dual pow_toDual
 
 @[simp, to_additive ofDual_smul', to_additive_reorder 1 4]
-theorem pow_ofDual [Pow α β] (a : α) (b : βᵒᵈ) : a ^ ofDual b = a ^ b :=
-  rfl
+theorem pow_ofDual [Pow α β] (a : α) (b : βᵒᵈ) : a ^ ofDual b = a ^ b := rfl
 #align pow_of_dual pow_ofDual
 
 /-! ### Lexicographical order -/
 
 
 @[to_additive]
-instance [h : One α] : One (Lex α) :=
-  h
+instance [h : One α] : One (Lex α) := h
 
 @[to_additive]
-instance [h : Mul α] : Mul (Lex α) :=
-  h
+instance [h : Mul α] : Mul (Lex α) := h
 
 @[to_additive]
-instance [h : Inv α] : Inv (Lex α) :=
-  h
+instance [h : Inv α] : Inv (Lex α) := h
 
 @[to_additive]
-instance [h : Div α] : Div (Lex α) :=
-  h
+instance [h : Div α] : Div (Lex α) := h
 
 @[to_additive]
-instance [h : HasSmul α β] : HasSmul α (Lex β) :=
-  h
+instance [h : HasSmul α β] : HasSmul α (Lex β) := h
 
 @[to_additive]
-instance Lex.hasSmul' [h : HasSmul α β] : HasSmul (Lex α) β :=
-  h
+instance Lex.hasSmul' [h : HasSmul α β] : HasSmul (Lex α) β := h
 #align lex.has_smul' Lex.hasSmul'
 
 @[to_additive Lex.hasSmul]
-instance Lex.hasPow [h : Pow α β] : Pow (Lex α) β :=
-  h
+instance Lex.hasPow [h : Pow α β] : Pow (Lex α) β := h
 #align lex.has_pow Lex.hasPow
 
 @[to_additive Lex.hasSmul']
-instance Lex.hasPow' [h : Pow α β] : Pow α (Lex β) :=
-  h
+instance Lex.hasPow' [h : Pow α β] : Pow α (Lex β) := h
 #align lex.has_pow' Lex.hasPow'
 
 @[to_additive]
-instance [h : Semigroup α] : Semigroup (Lex α) :=
-  h
+instance [h : Semigroup α] : Semigroup (Lex α) := h
 
 @[to_additive]
-instance [h : CommSemigroup α] : CommSemigroup (Lex α) :=
-  h
+instance [h : CommSemigroup α] : CommSemigroup (Lex α) := h
 
 @[to_additive]
-instance [h : LeftCancelSemigroup α] : LeftCancelSemigroup (Lex α) :=
-  h
+instance [h : LeftCancelSemigroup α] : LeftCancelSemigroup (Lex α) := h
 
 @[to_additive]
-instance [h : RightCancelSemigroup α] : RightCancelSemigroup (Lex α) :=
-  h
+instance [h : RightCancelSemigroup α] : RightCancelSemigroup (Lex α) := h
 
 @[to_additive]
-instance [h : MulOneClass α] : MulOneClass (Lex α) :=
-  h
+instance [h : MulOneClass α] : MulOneClass (Lex α) := h
 
 @[to_additive]
-instance [h : Monoid α] : Monoid (Lex α) :=
-  h
+instance [h : Monoid α] : Monoid (Lex α) := h
 
 @[to_additive]
-instance [h : CommMonoid α] : CommMonoid (Lex α) :=
-  h
+instance [h : CommMonoid α] : CommMonoid (Lex α) := h
 
 @[to_additive]
-instance [h : LeftCancelMonoid α] : LeftCancelMonoid (Lex α) :=
-  h
+instance [h : LeftCancelMonoid α] : LeftCancelMonoid (Lex α) := h
 
 @[to_additive]
-instance [h : RightCancelMonoid α] : RightCancelMonoid (Lex α) :=
-  h
+instance [h : RightCancelMonoid α] : RightCancelMonoid (Lex α) := h
 
 @[to_additive]
-instance [h : CancelMonoid α] : CancelMonoid (Lex α) :=
-  h
+instance [h : CancelMonoid α] : CancelMonoid (Lex α) := h
 
 @[to_additive]
-instance [h : CancelCommMonoid α] : CancelCommMonoid (Lex α) :=
-  h
+instance [h : CancelCommMonoid α] : CancelCommMonoid (Lex α) := h
 
 @[to_additive]
-instance [h : HasInvolutiveInv α] : HasInvolutiveInv (Lex α) :=
-  h
+instance [h : HasInvolutiveInv α] : HasInvolutiveInv (Lex α) := h
 
 @[to_additive]
-instance [h : DivInvMonoid α] : DivInvMonoid (Lex α) :=
-  h
+instance [h : DivInvMonoid α] : DivInvMonoid (Lex α) := h
 
 @[to_additive OrderDual.subtractionMonoid]
-instance [h : DivisionMonoid α] : DivisionMonoid (Lex α) :=
-  h
+instance [h : DivisionMonoid α] : DivisionMonoid (Lex α) := h
 
 @[to_additive OrderDual.subtractionCommMonoid]
-instance [h : DivisionCommMonoid α] : DivisionCommMonoid (Lex α) :=
-  h
+instance [h : DivisionCommMonoid α] : DivisionCommMonoid (Lex α) := h
 
 @[to_additive]
-instance [h : Group α] : Group (Lex α) :=
-  h
+instance [h : Group α] : Group (Lex α) := h
 
 @[to_additive]
-instance [h : CommGroup α] : CommGroup (Lex α) :=
-  h
+instance [h : CommGroup α] : CommGroup (Lex α) := h
 
 @[simp, to_additive]
-theorem toLex_one [One α] : toLex (1 : α) = 1 :=
-  rfl
+theorem toLex_one [One α] : toLex (1 : α) = 1 := rfl
 #align to_lex_one toLex_one
 
 @[simp, to_additive]
-theorem ofLex_one [One α] : (ofLex 1 : α) = 1 :=
-  rfl
+theorem ofLex_one [One α] : (ofLex 1 : α) = 1 := rfl
 #align of_lex_one ofLex_one
 
 @[simp, to_additive]
-theorem toLex_mul [Mul α] (a b : α) : toLex (a * b) = toLex a * toLex b :=
-  rfl
+theorem toLex_mul [Mul α] (a b : α) : toLex (a * b) = toLex a * toLex b := rfl
 #align to_lex_mul toLex_mul
 
 @[simp, to_additive]
-theorem ofLex_mul [Mul α] (a b : Lex α) : ofLex (a * b) = ofLex a * ofLex b :=
-  rfl
+theorem ofLex_mul [Mul α] (a b : Lex α) : ofLex (a * b) = ofLex a * ofLex b := rfl
 #align of_lex_mul ofLex_mul
 
 @[simp, to_additive]
-theorem toLex_inv [Inv α] (a : α) : toLex a⁻¹ = (toLex a)⁻¹ :=
-  rfl
+theorem toLex_inv [Inv α] (a : α) : toLex a⁻¹ = (toLex a)⁻¹ := rfl
 #align to_lex_inv toLex_inv
 
 @[simp, to_additive]
-theorem ofLex_inv [Inv α] (a : Lex α) : ofLex a⁻¹ = (ofLex a)⁻¹ :=
-  rfl
+theorem ofLex_inv [Inv α] (a : Lex α) : ofLex a⁻¹ = (ofLex a)⁻¹ := rfl
 #align of_lex_inv ofLex_inv
 
 @[simp, to_additive]
-theorem toLex_div [Div α] (a b : α) : toLex (a / b) = toLex a / toLex b :=
-  rfl
+theorem toLex_div [Div α] (a b : α) : toLex (a / b) = toLex a / toLex b := rfl
 #align to_lex_div toLex_div
 
 @[simp, to_additive]
-theorem ofLex_div [Div α] (a b : Lex α) : ofLex (a / b) = ofLex a / ofLex b :=
-  rfl
+theorem ofLex_div [Div α] (a b : Lex α) : ofLex (a / b) = ofLex a / ofLex b := rfl
 #align of_lex_div ofLex_div
 
 @[simp, to_additive]
-theorem toLex_smul [HasSmul α β] (a : α) (b : β) : toLex (a • b) = a • toLex b :=
-  rfl
+theorem toLex_smul [HasSmul α β] (a : α) (b : β) : toLex (a • b) = a • toLex b := rfl
 #align to_lex_smul toLex_smul
 
 @[simp, to_additive]
-theorem ofLex_smul [HasSmul α β] (a : α) (b : Lex β) : ofLex (a • b) = a • ofLex b :=
-  rfl
+theorem ofLex_smul [HasSmul α β] (a : α) (b : Lex β) : ofLex (a • b) = a • ofLex b := rfl
 #align of_lex_smul ofLex_smul
 
 @[simp, to_additive]
-theorem toLex_smul' [HasSmul α β] (a : α) (b : β) : toLex a • b = a • b :=
-  rfl
+theorem toLex_smul' [HasSmul α β] (a : α) (b : β) : toLex a • b = a • b := rfl
 #align to_lex_smul' toLex_smul'
 
 @[simp, to_additive]
-theorem ofLex_smul' [HasSmul α β] (a : Lex α) (b : β) : ofLex a • b = a • b :=
-  rfl
+theorem ofLex_smul' [HasSmul α β] (a : Lex α) (b : β) : ofLex a • b = a • b := rfl
 #align of_lex_smul' ofLex_smul'
 
 @[simp, to_additive toLex_smul, to_additive_reorder 1 4]
-theorem toLex_pow [Pow α β] (a : α) (b : β) : toLex (a ^ b) = toLex a ^ b :=
-  rfl
+theorem toLex_pow [Pow α β] (a : α) (b : β) : toLex (a ^ b) = toLex a ^ b := rfl
 #align to_lex_pow toLex_pow
 
 @[simp, to_additive ofLex_smul, to_additive_reorder 1 4]
-theorem ofLex_pow [Pow α β] (a : Lex α) (b : β) : ofLex (a ^ b) = ofLex a ^ b :=
-  rfl
+theorem ofLex_pow [Pow α β] (a : Lex α) (b : β) : ofLex (a ^ b) = ofLex a ^ b := rfl
 #align of_lex_pow ofLex_pow
 
 @[simp, to_additive toLex_smul, to_additive_reorder 1 4]
-theorem pow_toLex [Pow α β] (a : α) (b : β) : a ^ toLex b = a ^ b :=
-  rfl
+theorem pow_toLex [Pow α β] (a : α) (b : β) : a ^ toLex b = a ^ b := rfl
 #align pow_to_lex pow_toLex
 
 @[simp, to_additive ofLex_smul, to_additive_reorder 1 4]
-theorem pow_ofLex [Pow α β] (a : α) (b : Lex β) : a ^ ofLex b = a ^ b :=
-  rfl
+theorem pow_ofLex [Pow α β] (a : α) (b : Lex β) : a ^ ofLex b = a ^ b := rfl
 #align pow_of_lex pow_ofLex
 
 attribute [instance 100] instZeroOrderDual instAddOrderDual instNegOrderDual instSubOrderDual

--- a/Mathlib/Tactic/ToAdditive.lean
+++ b/Mathlib/Tactic/ToAdditive.lean
@@ -359,7 +359,8 @@ are not stored by the environment.
 [todo] add more attributes. A change is coming to core that should
 allow us to iterate the attributes applied to a given decalaration.
 -/
--- TODO once we can copy `instance`, tidy up `Algebra/CovariantAndContravariant.lean`.
+-- TODO once we can copy `instance`, tidy up `Algebra/CovariantAndContravariant.lean` and
+-- `Algebra/Group/OrderSynonym.lean`.
 def copyAttributes (src tgt : Name) : CoreM Unit := do
   -- [todo] other simp theorems
   let some ext ← getSimpExtension? `simp | return


### PR DESCRIPTION
Tracking mathlib commit: [c3019c79074b0619edb4b27553a91b2e82242395](https://github.com/leanprover-community/mathlib/commit/c3019c79074b0619edb4b27553a91b2e82242395)