### PR TITLE
[Merged by Bors] - fix: use new `coerce?` API

### DIFF
--- a/test/coe.lean
+++ b/test/coe.lean
@@ -1,0 +1,3 @@
+import Mathlib.Tactic.Coe
+
+example : { n : Nat // n > 3 } → Nat := (↑)


### PR DESCRIPTION
https://github.com/leanprover/lean4/pull/1729 introduced a coercion API that is similar to the functions currently implemented by `Mathlib.Tactic.Coe`, so we can now directly use the core functions.

Apparently I also changed the `mkCoe` API, which broke the `(↑)` notation.  This is also fixed by using the new functions.