### PR TITLE
feat: Port Algebra.Order.ZeroLEOne

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -17,6 +17,7 @@ import Mathlib.Algebra.Order.Group
 import Mathlib.Algebra.Order.Monoid
 import Mathlib.Algebra.Order.Monoid.Lemmas
 import Mathlib.Algebra.Order.Ring
+import Mathlib.Algebra.Order.ZeroLEOne
 import Mathlib.Algebra.PEmptyInstances
 import Mathlib.Algebra.Ring.Basic
 import Mathlib.CategoryTheory.ConcreteCategory.Bundled

--- a/Mathlib/Algebra/Order/ZeroLEOne.lean
+++ b/Mathlib/Algebra/Order/ZeroLEOne.lean
@@ -47,6 +47,8 @@ theorem zero_le_four [Preorder α] [One α] [AddZeroClass α] [ZeroLEOneClass α
   add_nonneg zero_le_three zero_le_one
 #align zero_le_four zero_le_four
 
+lemma one_eq_one [One α] [AddZeroClass α] : ((1 : ℕ).unaryCast : α) = 1 := zero_add 1
+
 lemma one_add_one [One α] [AddZeroClass α] : (1 : α) + 1 = (2 : ℕ).unaryCast := by
   change 1 + 1 = (0 + 1) + 1
   rw [zero_add 1]

--- a/Mathlib/Algebra/Order/ZeroLEOne.lean
+++ b/Mathlib/Algebra/Order/ZeroLEOne.lean
@@ -1,0 +1,63 @@
+/-
+Copyright (c) 2016 Jeremy Avigad. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro, Johannes Hölzl
+-/
+import Mathbin.Algebra.Group.Defs
+import Mathbin.Algebra.CovariantAndContravariant
+import Mathbin.Algebra.Order.Monoid.Lemmas
+
+/-!
+# Typeclass expressing `0 ≤ 1`.
+-/
+
+
+variable {α : Type _}
+
+open Function
+
+/-- Typeclass for expressing that the `0` of a type is less or equal to its `1`. -/
+class ZeroLeOneClass (α : Type _) [Zero α] [One α] [LE α] where
+  zero_le_one : (0 : α) ≤ 1
+#align zero_le_one_class ZeroLeOneClass
+
+@[simp]
+theorem zero_le_one [Zero α] [One α] [LE α] [ZeroLeOneClass α] : (0 : α) ≤ 1 :=
+  ZeroLeOneClass.zero_le_one
+#align zero_le_one zero_le_one
+
+-- `zero_le_one` with an explicit type argument.
+theorem zero_le_one' (α) [Zero α] [One α] [LE α] [ZeroLeOneClass α] : (0 : α) ≤ 1 :=
+  zero_le_one
+#align zero_le_one' zero_le_one'
+
+theorem zero_le_two [Preorder α] [One α] [AddZeroClass α] [ZeroLeOneClass α] [CovariantClass α α (· + ·) (· ≤ ·)] :
+    (0 : α) ≤ 2 :=
+  add_nonneg zero_le_one zero_le_one
+#align zero_le_two zero_le_two
+
+theorem zero_le_three [Preorder α] [One α] [AddZeroClass α] [ZeroLeOneClass α] [CovariantClass α α (· + ·) (· ≤ ·)] :
+    (0 : α) ≤ 3 :=
+  add_nonneg zero_le_two zero_le_one
+#align zero_le_three zero_le_three
+
+theorem zero_le_four [Preorder α] [One α] [AddZeroClass α] [ZeroLeOneClass α] [CovariantClass α α (· + ·) (· ≤ ·)] :
+    (0 : α) ≤ 4 :=
+  add_nonneg zero_le_two zero_le_two
+#align zero_le_four zero_le_four
+
+theorem one_le_two [LE α] [One α] [AddZeroClass α] [ZeroLeOneClass α] [CovariantClass α α (· + ·) (· ≤ ·)] :
+    (1 : α) ≤ 2 :=
+  calc
+    1 = 1 + 0 := (add_zero 1).symm
+    _ ≤ 1 + 1 := add_le_add_left zero_le_one _
+
+#align one_le_two one_le_two
+
+theorem one_le_two' [LE α] [One α] [AddZeroClass α] [ZeroLeOneClass α] [CovariantClass α α (swap (· + ·)) (· ≤ ·)] :
+    (1 : α) ≤ 2 :=
+  calc
+    1 = 0 + 1 := (zero_add 1).symm
+    _ ≤ 1 + 1 := add_le_add_right zero_le_one _
+
+#align one_le_two' one_le_two'

--- a/Mathlib/Algebra/Order/ZeroLEOne.lean
+++ b/Mathlib/Algebra/Order/ZeroLEOne.lean
@@ -3,61 +3,64 @@ Copyright (c) 2016 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro, Johannes Hölzl
 -/
-import Mathbin.Algebra.Group.Defs
-import Mathbin.Algebra.CovariantAndContravariant
-import Mathbin.Algebra.Order.Monoid.Lemmas
+import Mathlib.Algebra.CovariantAndContravariant
+import Mathlib.Algebra.Order.Monoid.Lemmas
+import Mathlib.Data.Nat.Cast.Defs
 
 /-!
 # Typeclass expressing `0 ≤ 1`.
 -/
 
-
-variable {α : Type _}
-
 open Function
 
 /-- Typeclass for expressing that the `0` of a type is less or equal to its `1`. -/
-class ZeroLeOneClass (α : Type _) [Zero α] [One α] [LE α] where
+class ZeroLEOneClass (α : Type _) [Zero α] [One α] [LE α] where
   zero_le_one : (0 : α) ≤ 1
-#align zero_le_one_class ZeroLeOneClass
+#align zero_le_one_class ZeroLEOneClass
 
 @[simp]
-theorem zero_le_one [Zero α] [One α] [LE α] [ZeroLeOneClass α] : (0 : α) ≤ 1 :=
-  ZeroLeOneClass.zero_le_one
+theorem zero_le_one [Zero α] [One α] [LE α] [ZeroLEOneClass α] : (0 : α) ≤ 1 :=
+  ZeroLEOneClass.zero_le_one
 #align zero_le_one zero_le_one
 
 -- `zero_le_one` with an explicit type argument.
-theorem zero_le_one' (α) [Zero α] [One α] [LE α] [ZeroLeOneClass α] : (0 : α) ≤ 1 :=
+theorem zero_le_one' (α) [Zero α] [One α] [LE α] [ZeroLEOneClass α] : (0 : α) ≤ 1 :=
   zero_le_one
 #align zero_le_one' zero_le_one'
 
-theorem zero_le_two [Preorder α] [One α] [AddZeroClass α] [ZeroLeOneClass α] [CovariantClass α α (· + ·) (· ≤ ·)] :
-    (0 : α) ≤ 2 :=
-  add_nonneg zero_le_one zero_le_one
+theorem zero_le_two [Preorder α] [One α] [AddZeroClass α] [ZeroLEOneClass α]
+  [CovariantClass α α (· + ·) (· ≤ ·)] :
+    (0 : α) ≤ (2 : ℕ).unaryCast := by
+  refine add_nonneg ?_ zero_le_one
+  refine add_nonneg rfl.le zero_le_one
 #align zero_le_two zero_le_two
 
-theorem zero_le_three [Preorder α] [One α] [AddZeroClass α] [ZeroLeOneClass α] [CovariantClass α α (· + ·) (· ≤ ·)] :
-    (0 : α) ≤ 3 :=
+theorem zero_le_three [Preorder α] [One α] [AddZeroClass α] [ZeroLEOneClass α]
+  [CovariantClass α α (· + ·) (· ≤ ·)] :
+    (0 : α) ≤ (3 : ℕ).unaryCast :=
   add_nonneg zero_le_two zero_le_one
 #align zero_le_three zero_le_three
 
-theorem zero_le_four [Preorder α] [One α] [AddZeroClass α] [ZeroLeOneClass α] [CovariantClass α α (· + ·) (· ≤ ·)] :
-    (0 : α) ≤ 4 :=
-  add_nonneg zero_le_two zero_le_two
+theorem zero_le_four [Preorder α] [One α] [AddZeroClass α] [ZeroLEOneClass α]
+  [CovariantClass α α (· + ·) (· ≤ ·)] :
+    (0 : α) ≤ (4 : ℕ).unaryCast :=
+  add_nonneg zero_le_three zero_le_one
 #align zero_le_four zero_le_four
 
-theorem one_le_two [LE α] [One α] [AddZeroClass α] [ZeroLeOneClass α] [CovariantClass α α (· + ·) (· ≤ ·)] :
-    (1 : α) ≤ 2 :=
-  calc
-    1 = 1 + 0 := (add_zero 1).symm
-    _ ≤ 1 + 1 := add_le_add_left zero_le_one _
+lemma one_add_one [One α] [AddZeroClass α] : (1 : α) + 1 = (2 : ℕ).unaryCast := by
+  change 1 + 1 = (0 + 1) + 1
+  rw [zero_add 1]
 
+theorem one_le_two [LE α] [One α] [AddZeroClass α] [ZeroLEOneClass α]
+  [CovariantClass α α (· + ·) (· ≤ ·)] :
+    (1 : α) ≤ (2 : ℕ).unaryCast := by
+  rw [← add_zero 1, ← one_add_one]
+  exact add_le_add_left zero_le_one _
 #align one_le_two one_le_two
 
-theorem one_le_two' [LE α] [One α] [AddZeroClass α] [ZeroLeOneClass α] [CovariantClass α α (swap (· + ·)) (· ≤ ·)] :
-    (1 : α) ≤ 2 :=
-  calc
-    1 = 0 + 1 := (zero_add 1).symm
-    _ ≤ 1 + 1 := add_le_add_right zero_le_one _
-
+theorem one_le_two' [LE α] [One α] [AddZeroClass α] [ZeroLEOneClass α]
+  [CovariantClass α α (swap (· + ·)) (· ≤ ·)] :
+    (1 : α) ≤ (2 : ℕ).unaryCast := by
+  rw [← zero_add 1, ← one_add_one]
+  exact add_le_add_right zero_le_one _
 #align one_le_two' one_le_two'


### PR DESCRIPTION
mathlib3 SHA: 39af7d3bf61a98e928812dbc3e16f4ea8b795ca3

---

I think I want to add a `ofNat` instance here, but I am afraid that then I have two `1 : α` that are not defeq. (`One.one` and `Nat.unaryCast 1` - they are equal by `zero_add`, but not defeq)