### PR TITLE
[Merged by Bors] - feat: port Data.Int.Cast.Basic

### DIFF
--- a/Mathlib/Algebra/Ring/Basic.lean
+++ b/Mathlib/Algebra/Ring/Basic.lean
@@ -1,6 +1,6 @@
 import Mathlib.Algebra.Group.Commute
 import Mathlib.Algebra.GroupWithZero.Defs
-import Mathlib.Data.Int.Cast.Defs
+import Mathlib.Data.Int.Cast.Basic
 import Mathlib.Tactic.Spread
 import Mathlib.Algebra.Ring.Defs
 
@@ -115,7 +115,7 @@ instance : CommRing ℤ where
 
 @[simp, norm_cast]
 lemma cast_Nat_cast [AddGroupWithOne R] : (Int.cast (Nat.cast n) : R) = Nat.cast n :=
-  Int.cast_ofNat
+  Int.cast_ofNat _
 
 @[simp, norm_cast]
 lemma cast_eq_cast_iff_Nat (m n : ℕ) : (m : ℤ) = (n : ℤ) ↔ m = n := ofNat_inj

--- a/Mathlib/Data/Int/Cast/Basic.lean
+++ b/Mathlib/Data/Int/Cast/Basic.lean
@@ -82,7 +82,6 @@ theorem cast_subNatNat (m n) : ((Int.subNatNat m n : ℤ) : R) = m - n := by
       neg_sub]
 #align int.cast_sub_nat_nat Int.cast_subNatNatₓ
 
--- porting note: already exists in `Std`, but still needs `#align`ed
 #align int.neg_of_nat_eq Int.negOfNat_eq
 
 @[simp]

--- a/Mathlib/Data/Int/Cast/Basic.lean
+++ b/Mathlib/Data/Int/Cast/Basic.lean
@@ -30,7 +30,7 @@ variable {R : Type u} [AddGroupWithOne R]
 theorem cast_sub {m n} (h : m ≤ n) : ((n - m : ℕ) : R) = n - m :=
   eq_sub_of_add_eq <| by rw [← cast_add, Nat.sub_add_cancel h]
 #align nat.cast_sub Nat.cast_subₓ
--- I think this was a dubious translation because of `HasLiftT` appearing in the type signature
+-- `HasLiftT` appeared in the type signature
 
 @[simp, norm_cast]
 theorem cast_pred : ∀ {n}, 0 < n → ((n - 1 : ℕ) : R) = n - 1
@@ -50,25 +50,25 @@ variable {R : Type u} [AddGroupWithOne R]
 theorem cast_negSucc (n : ℕ) : (-[n+1] : R) = -(n + 1 : ℕ) :=
   AddGroupWithOne.intCast_negSucc n
 #align int.cast_neg_succ_of_nat Int.cast_negSuccₓ
--- dubious because for some reason it expected `n` to be implicit, and `HasLiftT`
+-- expected `n` to be implicit, and `HasLiftT`
 
 @[simp, norm_cast]
 theorem cast_zero : ((0 : ℤ) : R) = 0 :=
   (AddGroupWithOne.intCast_ofNat 0).trans Nat.cast_zero
 #align int.cast_zero Int.cast_zeroₓ
--- dubious because of `HasLiftT`
+-- type had `HasLiftT`
 
 @[simp high, nolint simpNF] -- this lemma competes with `Int.ofNat_eq_cast` to come later
 theorem cast_ofNat (n : ℕ) : ((n : ℤ) : R) = n :=
   AddGroupWithOne.intCast_ofNat _
 #align int.cast_coe_nat Int.cast_ofNatₓ
--- dubious because for some reason it expected `n` to be implicit, and `HasLiftT`
+-- expected `n` to be implicit, and `HasLiftT`
 
 @[simp, norm_cast]
 theorem cast_one : ((1 : ℤ) : R) = 1 := by
   erw [cast_ofNat, Nat.cast_one]
 #align int.cast_one Int.cast_oneₓ
--- dubious because of `HasLiftT`
+-- type had `HasLiftT`
 
 @[simp, norm_cast]
 theorem cast_neg : ∀ n, ((-n : ℤ) : R) = -n
@@ -76,7 +76,7 @@ theorem cast_neg : ∀ n, ((-n : ℤ) : R) = -n
   | (n + 1 : ℕ) => by erw [cast_ofNat, cast_negSucc]
   | -[n+1] => by erw [cast_ofNat, cast_negSucc, neg_neg]
 #align int.cast_neg Int.cast_negₓ
--- dubious because of `HasLiftT`
+-- type had `HasLiftT`
 
 @[simp, norm_cast]
 theorem cast_subNatNat (m n) : ((Int.subNatNat m n : ℤ) : R) = m - n := by
@@ -87,7 +87,7 @@ theorem cast_subNatNat (m n) : ((Int.subNatNat m n : ℤ) : R) = m - n := by
   · rw [cast_negSucc, Nat.add_one, ← e, Nat.cast_sub <| _root_.le_of_lt <| Nat.lt_of_sub_eq_succ e,
       neg_sub]
 #align int.cast_sub_nat_nat Int.cast_subNatNatₓ
--- dubious because of `HasLiftT`
+-- type had `HasLiftT`
 
 #align int.neg_of_nat_eq Int.negOfNat_eq
 
@@ -107,13 +107,13 @@ theorem cast_add : ∀ m n, ((m + n : ℤ) : R) = m + n
       rw [cast_negSucc, cast_negSucc, cast_negSucc, ← neg_add_rev, ← Nat.cast_add,
         Nat.add_right_comm m n 1, Nat.add_assoc, Nat.add_comm]
 #align int.cast_add Int.cast_addₓ
--- dubious because of `HasLiftT`
+-- type had `HasLiftT`
 
 @[simp, norm_cast]
 theorem cast_sub (m n) : ((m - n : ℤ) : R) = m - n := by
   simp [Int.sub_eq_add_neg, sub_eq_add_neg, Int.cast_neg, Int.cast_add]
 #align int.cast_sub Int.cast_subₓ
--- dubious because of `HasLiftT`
+-- type had `HasLiftT`
 
 section deprecated
 set_option linter.deprecated false

--- a/Mathlib/Data/Int/Cast/Basic.lean
+++ b/Mathlib/Data/Int/Cast/Basic.lean
@@ -3,8 +3,8 @@ Copyright (c) 2017 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Gabriel Ebner
 -/
-import Mathbin.Data.Int.Cast.Defs
-import Mathbin.Algebra.Group.Basic
+import Mathlib.Data.Int.Cast.Defs
+import Mathlib.Algebra.Group.Basic
 
 /-!
 # Cast of integers (additional theorems)
@@ -12,11 +12,11 @@ import Mathbin.Algebra.Group.Basic
 This file proves additional properties about the *canonical* homomorphism from
 the integers into an additive group with a one (`int.cast`).
 
-There is also `data.int.cast.lemmas`,
+There is also `Data.Int.Cast.Lemmas`,
 which includes lemmas stated in terms of algebraic homomorphisms,
 and results involving the order structure of `ℤ`.
 
-By contrast, this file's only import beyond `data.int.cast.defs` is `algebra.group.basic`.
+By contrast, this file's only import beyond `Data.Int.Cast.Defs` is `Algebra.Group.Basic`.
 -/
 
 
@@ -35,12 +35,12 @@ Case conversion may be inaccurate. Consider using '#align nat.cast_sub Nat.cast_
 @[simp, norm_cast]
 theorem cast_sub {m n} (h : m ≤ n) : ((n - m : ℕ) : R) = n - m :=
   eq_sub_of_add_eq <| by rw [← cast_add, Nat.sub_add_cancel h]
-#align nat.cast_sub Nat.cast_sub
+#align nat.cast_sub Nat.cast_subₓ
 
 @[simp, norm_cast]
 theorem cast_pred : ∀ {n}, 0 < n → ((n - 1 : ℕ) : R) = n - 1
   | 0, h => by cases h
-  | n + 1, h => by rw [cast_succ, add_sub_cancel] <;> rfl
+  | n + 1, _ => by rw [cast_succ, add_sub_cancel]; rfl
 #align nat.cast_pred Nat.cast_pred
 
 end Nat
@@ -57,10 +57,10 @@ lean 3 declaration is
 but is expected to have type
   forall {R : Type.{u_1}} {n : Nat} [inst._@.Mathlib.Algebra.GroupWithZero.Defs._hyg.811 : AddGroupWithOne.{u_1} R], Eq.{succ u_1} R (Int.cast.{u_1} R inst._@.Mathlib.Algebra.GroupWithZero.Defs._hyg.811 (Int.negSucc n)) (Neg.neg.{u_1} R (AddGroupWithOne.toNeg.{u_1} R inst._@.Mathlib.Algebra.GroupWithZero.Defs._hyg.811) (Nat.cast.{u_1} R (AddGroupWithOne.toAddMonoidWithOne.{u_1} R inst._@.Mathlib.Algebra.GroupWithZero.Defs._hyg.811) (HAdd.hAdd.{0 0 0} Nat Nat Nat (instHAdd.{0} Nat instAddNat) n (OfNat.ofNat.{0} Nat 1 (instOfNatNat 1)))))
 Case conversion may be inaccurate. Consider using '#align int.cast_neg_succ_of_nat Int.cast_negSuccₓ'. -/
-@[simp]
+@[simp, norm_cast]
 theorem cast_negSucc (n : ℕ) : (-[n+1] : R) = -(n + 1 : ℕ) :=
-  AddGroupWithOne.int_cast_neg_succ_of_nat n
-#align int.cast_neg_succ_of_nat Int.cast_negSucc
+  AddGroupWithOne.intCast_negSucc n
+#align int.cast_neg_succ_of_nat Int.cast_negSuccₓ
 
 /- warning: int.cast_zero -> Int.cast_zero is a dubious translation:
 lean 3 declaration is
@@ -68,10 +68,10 @@ lean 3 declaration is
 but is expected to have type
   forall {R : Type.{u_1}} [inst._@.Mathlib.Algebra.GroupWithZero.Defs._hyg.848 : AddGroupWithOne.{u_1} R], Eq.{succ u_1} R (Int.cast.{u_1} R inst._@.Mathlib.Algebra.GroupWithZero.Defs._hyg.848 (OfNat.ofNat.{0} Int 0 (instOfNatInt 0))) (OfNat.ofNat.{u_1} R 0 (Zero.toOfNat0.{u_1} R (AddRightCancelMonoid.toZero.{u_1} R (AddCancelMonoid.toAddRightCancelMonoid.{u_1} R (AddGroup.toAddCancelMonoid.{u_1} R (AddGroupWithOne.toAddGroup.{u_1} R inst._@.Mathlib.Algebra.GroupWithZero.Defs._hyg.848))))))
 Case conversion may be inaccurate. Consider using '#align int.cast_zero Int.cast_zeroₓ'. -/
-@[norm_cast]
+@[simp, norm_cast]
 theorem cast_zero : ((0 : ℤ) : R) = 0 :=
-  (cast_of_nat 0).trans Nat.cast_zero
-#align int.cast_zero Int.cast_zero
+  (AddGroupWithOne.intCast_ofNat 0).trans Nat.cast_zero
+#align int.cast_zero Int.cast_zeroₓ
 
 /- warning: int.cast_coe_nat -> Int.cast_ofNat is a dubious translation:
 lean 3 declaration is
@@ -79,10 +79,10 @@ lean 3 declaration is
 but is expected to have type
   forall {R : Type.{u_1}} {n : Nat} [inst._@.Mathlib.Algebra.GroupWithZero.Defs._hyg.772 : AddGroupWithOne.{u_1} R], Eq.{succ u_1} R (Int.cast.{u_1} R inst._@.Mathlib.Algebra.GroupWithZero.Defs._hyg.772 (Int.ofNat n)) (Nat.cast.{u_1} R (AddGroupWithOne.toAddMonoidWithOne.{u_1} R inst._@.Mathlib.Algebra.GroupWithZero.Defs._hyg.772) n)
 Case conversion may be inaccurate. Consider using '#align int.cast_coe_nat Int.cast_ofNatₓ'. -/
-@[simp, norm_cast]
+@[simp high, nolint simpNF, norm_cast] -- this lemma competes with `Int.ofNat_eq_cast` to come later
 theorem cast_ofNat (n : ℕ) : ((n : ℤ) : R) = n :=
-  cast_of_nat _
-#align int.cast_coe_nat Int.cast_ofNat
+  AddGroupWithOne.intCast_ofNat _
+#align int.cast_coe_nat Int.cast_ofNatₓ
 
 /- warning: int.cast_one -> Int.cast_one is a dubious translation:
 lean 3 declaration is
@@ -90,23 +90,23 @@ lean 3 declaration is
 but is expected to have type
   forall {R : Type.{u_1}} [inst._@.Mathlib.Algebra.GroupWithZero.Defs._hyg.908 : AddGroupWithOne.{u_1} R], Eq.{succ u_1} R (Int.cast.{u_1} R inst._@.Mathlib.Algebra.GroupWithZero.Defs._hyg.908 (OfNat.ofNat.{0} Int 1 (instOfNatInt 1))) (OfNat.ofNat.{u_1} R 1 (One.toOfNat1.{u_1} R (AddMonoidWithOne.toOne.{u_1} R (AddGroupWithOne.toAddMonoidWithOne.{u_1} R inst._@.Mathlib.Algebra.GroupWithZero.Defs._hyg.908))))
 Case conversion may be inaccurate. Consider using '#align int.cast_one Int.cast_oneₓ'. -/
-@[norm_cast]
-theorem cast_one : ((1 : ℤ) : R) = 1 :=
-  show (((1 : ℕ) : ℤ) : R) = 1 by simp [Nat.cast_zero]
-#align int.cast_one Int.cast_one
+@[simp, norm_cast]
+theorem cast_one : ((1 : ℤ) : R) = 1 := by
+  erw [cast_ofNat, Nat.cast_one]
+#align int.cast_one Int.cast_oneₓ
 
 /- warning: int.cast_neg -> Int.cast_neg is a dubious translation:
 lean 3 declaration is
   forall {R : Type.{u}} [_inst_1 : AddGroupWithOne.{u} R] (n : Int), Eq.{succ u} R ((fun (a : Type) (b : Type.{u}) [self : HasLiftT.{1 succ u} a b] => self.0) Int R (HasLiftT.mk.{1 succ u} Int R (CoeTCₓ.coe.{1 succ u} Int R (Int.castCoe.{u} R (AddGroupWithOne.toHasIntCast.{u} R _inst_1)))) (Neg.neg.{0} Int Int.hasNeg n)) (Neg.neg.{u} R (SubNegMonoid.toHasNeg.{u} R (AddGroup.toSubNegMonoid.{u} R (AddGroupWithOne.toAddGroup.{u} R _inst_1))) ((fun (a : Type) (b : Type.{u}) [self : HasLiftT.{1 succ u} a b] => self.0) Int R (HasLiftT.mk.{1 succ u} Int R (CoeTCₓ.coe.{1 succ u} Int R (Int.castCoe.{u} R (AddGroupWithOne.toHasIntCast.{u} R _inst_1)))) n))
 but is expected to have type
   forall {R : Type.{u_1}} [inst._@.Mathlib.Data.Int.Cast.Defs._hyg.97 : AddGroupWithOne.{u_1} R] (n : Int), Eq.{succ u_1} R (Int.cast.{u_1} R inst._@.Mathlib.Data.Int.Cast.Defs._hyg.97 (Neg.neg.{0} Int Int.instNegInt n)) (Neg.neg.{u_1} R (AddGroupWithOne.toNeg.{u_1} R inst._@.Mathlib.Data.Int.Cast.Defs._hyg.97) (Int.cast.{u_1} R inst._@.Mathlib.Data.Int.Cast.Defs._hyg.97 n))
-Case conversion may be inaccurate. Consider using '#align int.cast_neg Int.cast_negₓ'. -/
+Case conversion may be inaccurate. Consider using '#align int.cast_neg Int.cast_negₓ'.  -/
 @[norm_cast]
 theorem cast_neg : ∀ n, ((-n : ℤ) : R) = -n
   | (0 : ℕ) => by erw [cast_zero, neg_zero]
-  | (n + 1 : ℕ) => by erw [cast_of_nat, cast_neg_succ_of_nat] <;> rfl
-  | -[n+1] => by erw [cast_of_nat, cast_neg_succ_of_nat, neg_neg]
-#align int.cast_neg Int.cast_neg
+  | (n + 1 : ℕ) => by erw [cast_ofNat, cast_negSucc]
+  | -[n+1] => by erw [cast_ofNat, cast_negSucc, neg_neg]
+#align int.cast_neg Int.cast_negₓ
 
 /- warning: int.cast_sub_nat_nat -> Int.cast_subNatNat is a dubious translation:
 lean 3 declaration is
@@ -116,22 +116,20 @@ but is expected to have type
 Case conversion may be inaccurate. Consider using '#align int.cast_sub_nat_nat Int.cast_subNatNatₓ'. -/
 @[simp]
 theorem cast_subNatNat (m n) : ((Int.subNatNat m n : ℤ) : R) = m - n := by
-  unfold sub_nat_nat
+  unfold subNatNat
   cases e : n - m
-  · simp only [sub_nat_nat, cast_of_nat]
+  · rw [cast_ofNat]
     simp [e, Nat.le_of_sub_eq_zero e]
-    
-  · rw [sub_nat_nat, cast_neg_succ_of_nat, Nat.add_one, ← e, Nat.cast_sub <| _root_.le_of_lt <| Nat.lt_of_sub_eq_succ e,
+  · rw [cast_negSucc, Nat.add_one, ← e, Nat.cast_sub <| _root_.le_of_lt <| Nat.lt_of_sub_eq_succ e,
       neg_sub]
-    
-#align int.cast_sub_nat_nat Int.cast_subNatNat
+#align int.cast_sub_nat_nat Int.cast_subNatNatₓ
 
-theorem neg_of_nat_eq (n : ℕ) : negOfNat n = -(n : ℤ) := by cases n <;> rfl
-#align int.neg_of_nat_eq Int.neg_of_nat_eq
+-- porting note: already exists in `Std`, but still needs `#align`ed
+#align int.neg_of_nat_eq Int.negOfNat_eq
 
 @[simp]
-theorem cast_neg_of_nat (n : ℕ) : ((negOfNat n : ℤ) : R) = -n := by simp [Int.cast_neg, neg_of_nat_eq]
-#align int.cast_neg_of_nat Int.cast_neg_of_nat
+theorem cast_negOfNat (n : ℕ) : ((negOfNat n : ℤ) : R) = -n := by simp [Int.cast_neg, negOfNat_eq]
+#align int.cast_neg_of_nat Int.cast_negOfNat
 
 /- warning: int.cast_add -> Int.cast_add is a dubious translation:
 lean 3 declaration is
@@ -142,15 +140,15 @@ Case conversion may be inaccurate. Consider using '#align int.cast_add Int.cast_
 @[norm_cast]
 theorem cast_add : ∀ m n, ((m + n : ℤ) : R) = m + n
   | (m : ℕ), (n : ℕ) => by simp [← Int.ofNat_add, Nat.cast_add]
-  | (m : ℕ), -[n+1] => by erw [cast_sub_nat_nat, cast_coe_nat, cast_neg_succ_of_nat, sub_eq_add_neg]
+  | (m : ℕ), -[n+1] => by erw [cast_subNatNat, cast_ofNat, cast_negSucc, sub_eq_add_neg]
   | -[m+1], (n : ℕ) => by
-    erw [cast_sub_nat_nat, cast_coe_nat, cast_neg_succ_of_nat, sub_eq_iff_eq_add, add_assoc, eq_neg_add_iff_add_eq, ←
-      Nat.cast_add, ← Nat.cast_add, Nat.add_comm]
+    erw [cast_subNatNat, cast_ofNat, cast_negSucc, sub_eq_iff_eq_add, add_assoc,
+      eq_neg_add_iff_add_eq, ← Nat.cast_add, ← Nat.cast_add, Nat.add_comm]
   | -[m+1], -[n+1] =>
     show (-[m + n + 1+1] : R) = _ by
-      rw [cast_neg_succ_of_nat, cast_neg_succ_of_nat, cast_neg_succ_of_nat, ← neg_add_rev, ← Nat.cast_add,
+      rw [cast_negSucc, cast_negSucc, cast_negSucc, ← neg_add_rev, ← Nat.cast_add,
         Nat.add_right_comm m n 1, Nat.add_assoc, Nat.add_comm]
-#align int.cast_add Int.cast_add
+#align int.cast_add Int.cast_addₓ
 
 /- warning: int.cast_sub -> Int.cast_sub is a dubious translation:
 lean 3 declaration is
@@ -161,35 +159,43 @@ Case conversion may be inaccurate. Consider using '#align int.cast_sub Int.cast_
 @[norm_cast]
 theorem cast_sub (m n) : ((m - n : ℤ) : R) = m - n := by
   simp [Int.sub_eq_add_neg, sub_eq_add_neg, Int.cast_neg, Int.cast_add]
-#align int.cast_sub Int.cast_sub
+#align int.cast_sub Int.cast_subₓ
 
-@[norm_cast]
-theorem coe_nat_bit0 (n : ℕ) : (↑(bit0 n) : ℤ) = bit0 ↑n :=
+section deprecated
+set_option linter.deprecated false
+
+@[norm_cast, deprecated]
+theorem ofNat_bit0 (n : ℕ) : (↑(bit0 n) : ℤ) = bit0 ↑n :=
   rfl
-#align int.coe_nat_bit0 Int.coe_nat_bit0
+#align int.coe_nat_bit0 Int.ofNat_bit0
 
-@[norm_cast]
-theorem coe_nat_bit1 (n : ℕ) : (↑(bit1 n) : ℤ) = bit1 ↑n :=
+@[norm_cast, deprecated]
+theorem ofNat_bit1 (n : ℕ) : (↑(bit1 n) : ℤ) = bit1 ↑n :=
   rfl
-#align int.coe_nat_bit1 Int.coe_nat_bit1
+#align int.coe_nat_bit1 Int.ofNat_bit1
 
-@[norm_cast]
-theorem cast_bit0 (n : ℤ) : ((bit0 n : ℤ) : R) = bit0 n :=
+@[norm_cast, deprecated]
+theorem cast_bit0 (n : ℤ) : ((bit0 n : ℤ) : R) = bit0 (n : R) :=
   Int.cast_add _ _
 #align int.cast_bit0 Int.cast_bit0
 
-@[norm_cast]
-theorem cast_bit1 (n : ℤ) : ((bit1 n : ℤ) : R) = bit1 n := by rw [bit1, Int.cast_add, Int.cast_one, cast_bit0] <;> rfl
+@[norm_cast, deprecated]
+theorem cast_bit1 (n : ℤ) : ((bit1 n : ℤ) : R) = bit1 (n : R) :=
+  by rw [bit1, Int.cast_add, Int.cast_one, cast_bit0]; rfl
 #align int.cast_bit1 Int.cast_bit1
 
-theorem cast_two : ((2 : ℤ) : R) = 2 := by simp [cast_bit0, cast_bit1, cast_one]
+end deprecated
+
+theorem cast_two : ((2 : ℤ) : R) = 2 :=
+  show (((2 : ℕ) : ℤ) : R) = ((2 : ℕ) : R) by rw [cast_ofNat, Nat.cast_ofNat]
 #align int.cast_two Int.cast_two
 
-theorem cast_three : ((3 : ℤ) : R) = 3 := by simp [cast_bit0, cast_bit1, cast_one]
+theorem cast_three : ((3 : ℤ) : R) = 3 :=
+  show (((3 : ℕ) : ℤ) : R) = ((3 : ℕ) : R) by rw [cast_ofNat, Nat.cast_ofNat]
 #align int.cast_three Int.cast_three
 
-theorem cast_four : ((4 : ℤ) : R) = 4 := by simp [cast_bit0, cast_bit1, cast_one]
+theorem cast_four : ((4 : ℤ) : R) = 4 :=
+  show (((4 : ℕ) : ℤ) : R) = ((4 : ℕ) : R) by rw [cast_ofNat, Nat.cast_ofNat]
 #align int.cast_four Int.cast_four
 
 end Int
-

--- a/Mathlib/Data/Int/Cast/Basic.lean
+++ b/Mathlib/Data/Int/Cast/Basic.lean
@@ -30,6 +30,7 @@ variable {R : Type u} [AddGroupWithOne R]
 theorem cast_sub {m n} (h : m ≤ n) : ((n - m : ℕ) : R) = n - m :=
   eq_sub_of_add_eq <| by rw [← cast_add, Nat.sub_add_cancel h]
 #align nat.cast_sub Nat.cast_subₓ
+-- I think this was a dubious translation because of `HasLiftT` appearing in the type signature
 
 @[simp, norm_cast]
 theorem cast_pred : ∀ {n}, 0 < n → ((n - 1 : ℕ) : R) = n - 1
@@ -49,21 +50,25 @@ variable {R : Type u} [AddGroupWithOne R]
 theorem cast_negSucc (n : ℕ) : (-[n+1] : R) = -(n + 1 : ℕ) :=
   AddGroupWithOne.intCast_negSucc n
 #align int.cast_neg_succ_of_nat Int.cast_negSuccₓ
+-- dubious because for some reason it expected `n` to be implicit, and `HasLiftT`
 
 @[simp, norm_cast]
 theorem cast_zero : ((0 : ℤ) : R) = 0 :=
   (AddGroupWithOne.intCast_ofNat 0).trans Nat.cast_zero
 #align int.cast_zero Int.cast_zeroₓ
+-- dubious because of `HasLiftT`
 
 @[simp high, nolint simpNF] -- this lemma competes with `Int.ofNat_eq_cast` to come later
 theorem cast_ofNat (n : ℕ) : ((n : ℤ) : R) = n :=
   AddGroupWithOne.intCast_ofNat _
 #align int.cast_coe_nat Int.cast_ofNatₓ
+-- dubious because for some reason it expected `n` to be implicit, and `HasLiftT`
 
 @[simp, norm_cast]
 theorem cast_one : ((1 : ℤ) : R) = 1 := by
   erw [cast_ofNat, Nat.cast_one]
 #align int.cast_one Int.cast_oneₓ
+-- dubious because of `HasLiftT`
 
 @[simp, norm_cast]
 theorem cast_neg : ∀ n, ((-n : ℤ) : R) = -n
@@ -71,6 +76,7 @@ theorem cast_neg : ∀ n, ((-n : ℤ) : R) = -n
   | (n + 1 : ℕ) => by erw [cast_ofNat, cast_negSucc]
   | -[n+1] => by erw [cast_ofNat, cast_negSucc, neg_neg]
 #align int.cast_neg Int.cast_negₓ
+-- dubious because of `HasLiftT`
 
 @[simp, norm_cast]
 theorem cast_subNatNat (m n) : ((Int.subNatNat m n : ℤ) : R) = m - n := by
@@ -81,6 +87,7 @@ theorem cast_subNatNat (m n) : ((Int.subNatNat m n : ℤ) : R) = m - n := by
   · rw [cast_negSucc, Nat.add_one, ← e, Nat.cast_sub <| _root_.le_of_lt <| Nat.lt_of_sub_eq_succ e,
       neg_sub]
 #align int.cast_sub_nat_nat Int.cast_subNatNatₓ
+-- dubious because of `HasLiftT`
 
 #align int.neg_of_nat_eq Int.negOfNat_eq
 
@@ -100,11 +107,13 @@ theorem cast_add : ∀ m n, ((m + n : ℤ) : R) = m + n
       rw [cast_negSucc, cast_negSucc, cast_negSucc, ← neg_add_rev, ← Nat.cast_add,
         Nat.add_right_comm m n 1, Nat.add_assoc, Nat.add_comm]
 #align int.cast_add Int.cast_addₓ
+-- dubious because of `HasLiftT`
 
 @[simp, norm_cast]
 theorem cast_sub (m n) : ((m - n : ℤ) : R) = m - n := by
   simp [Int.sub_eq_add_neg, sub_eq_add_neg, Int.cast_neg, Int.cast_add]
 #align int.cast_sub Int.cast_subₓ
+-- dubious because of `HasLiftT`
 
 section deprecated
 set_option linter.deprecated false

--- a/Mathlib/Data/Int/Cast/Basic.lean
+++ b/Mathlib/Data/Int/Cast/Basic.lean
@@ -3,63 +3,193 @@ Copyright (c) 2017 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Gabriel Ebner
 -/
-import Mathlib.Data.Int.Cast.Defs
-import Mathlib.Algebra.Group.Basic
+import Mathbin.Data.Int.Cast.Defs
+import Mathbin.Algebra.Group.Basic
 
 /-!
-# Cast of integers
+# Cast of integers (additional theorems)
 
-This file defines the *canonical* homomorphism from the integers into an
-additive group with a one (typically a `ring`).  In additive groups with a one
-element, there exists a unique such homomorphism and we store it in the
-`int_cast : ℤ → R` field.
+This file proves additional properties about the *canonical* homomorphism from
+the integers into an additive group with a one (`int.cast`).
 
-Preferentially, the homomorphism is written as a coercion.
+There is also `data.int.cast.lemmas`,
+which includes lemmas stated in terms of algebraic homomorphisms,
+and results involving the order structure of `ℤ`.
 
-## Main declarations
-
-* `int.cast`: Canonical homomorphism `ℤ → R`.
-* `add_group_with_one`: Type class for `int.cast`.
+By contrast, this file's only import beyond `data.int.cast.defs` is `algebra.group.basic`.
 -/
 
-namespace Nat
-variable [AddGroupWithOne R]
 
+universe u
+
+namespace Nat
+
+variable {R : Type u} [AddGroupWithOne R]
+
+/- warning: nat.cast_sub -> Nat.cast_sub is a dubious translation:
+lean 3 declaration is
+  forall {R : Type.{u}} [_inst_1 : AddGroupWithOne.{u} R] {m : Nat} {n : Nat}, (LE.le.{0} Nat Nat.hasLe m n) -> (Eq.{succ u} R ((fun (a : Type) (b : Type.{u}) [self : HasLiftT.{1 succ u} a b] => self.0) Nat R (HasLiftT.mk.{1 succ u} Nat R (CoeTCₓ.coe.{1 succ u} Nat R (Nat.castCoe.{u} R (AddMonoidWithOne.toHasNatCast.{u} R (AddGroupWithOne.toAddMonoidWithOne.{u} R _inst_1))))) (HSub.hSub.{0 0 0} Nat Nat Nat (instHSub.{0} Nat Nat.hasSub) n m)) (HSub.hSub.{u u u} R R R (instHSub.{u} R (SubNegMonoid.toHasSub.{u} R (AddGroup.toSubNegMonoid.{u} R (AddGroupWithOne.toAddGroup.{u} R _inst_1)))) ((fun (a : Type) (b : Type.{u}) [self : HasLiftT.{1 succ u} a b] => self.0) Nat R (HasLiftT.mk.{1 succ u} Nat R (CoeTCₓ.coe.{1 succ u} Nat R (Nat.castCoe.{u} R (AddMonoidWithOne.toHasNatCast.{u} R (AddGroupWithOne.toAddMonoidWithOne.{u} R _inst_1))))) n) ((fun (a : Type) (b : Type.{u}) [self : HasLiftT.{1 succ u} a b] => self.0) Nat R (HasLiftT.mk.{1 succ u} Nat R (CoeTCₓ.coe.{1 succ u} Nat R (Nat.castCoe.{u} R (AddMonoidWithOne.toHasNatCast.{u} R (AddGroupWithOne.toAddMonoidWithOne.{u} R _inst_1))))) m)))
+but is expected to have type
+  forall {R : Type.{u_1}} [inst._@.Mathlib.Data.Int.Cast.Defs._hyg.16 : AddGroupWithOne.{u_1} R] {m : Nat} {n : Nat}, (LE.le.{0} Nat instLENat m n) -> (Eq.{succ u_1} R (Nat.cast.{u_1} R (AddGroupWithOne.toAddMonoidWithOne.{u_1} R inst._@.Mathlib.Data.Int.Cast.Defs._hyg.16) (HSub.hSub.{0 0 0} Nat Nat Nat (instHSub.{0} Nat instSubNat) n m)) (HSub.hSub.{u_1 u_1 u_1} R R R (instHSub.{u_1} R (AddGroupWithOne.toSub.{u_1} R inst._@.Mathlib.Data.Int.Cast.Defs._hyg.16)) (Nat.cast.{u_1} R (AddGroupWithOne.toAddMonoidWithOne.{u_1} R inst._@.Mathlib.Data.Int.Cast.Defs._hyg.16) n) (Nat.cast.{u_1} R (AddGroupWithOne.toAddMonoidWithOne.{u_1} R inst._@.Mathlib.Data.Int.Cast.Defs._hyg.16) m)))
+Case conversion may be inaccurate. Consider using '#align nat.cast_sub Nat.cast_subₓ'. -/
 @[simp, norm_cast]
 theorem cast_sub {m n} (h : m ≤ n) : ((n - m : ℕ) : R) = n - m :=
   eq_sub_of_add_eq <| by rw [← cast_add, Nat.sub_add_cancel h]
+#align nat.cast_sub Nat.cast_sub
+
+@[simp, norm_cast]
+theorem cast_pred : ∀ {n}, 0 < n → ((n - 1 : ℕ) : R) = n - 1
+  | 0, h => by cases h
+  | n + 1, h => by rw [cast_succ, add_sub_cancel] <;> rfl
+#align nat.cast_pred Nat.cast_pred
 
 end Nat
 
+open Nat
+
 namespace Int
-variable [AddGroupWithOne R]
 
-@[simp, norm_cast]
-theorem cast_neg [AddGroupWithOne R] : ∀ n:ℤ, ((-n : ℤ) : R) = -↑n
-  | (0 : ℕ) => by erw [cast_zero, neg_zero]
-  | (n + 1 : ℕ) => by erw [cast_ofNat, cast_negSucc]
-  | -[n +1] => by erw [cast_ofNat, cast_negSucc, neg_neg]
+variable {R : Type u} [AddGroupWithOne R]
 
+/- warning: int.cast_neg_succ_of_nat -> Int.cast_negSucc is a dubious translation:
+lean 3 declaration is
+  forall {R : Type.{u}} [_inst_1 : AddGroupWithOne.{u} R] (n : Nat), Eq.{succ u} R ((fun (a : Type) (b : Type.{u}) [self : HasLiftT.{1 succ u} a b] => self.0) Int R (HasLiftT.mk.{1 succ u} Int R (CoeTCₓ.coe.{1 succ u} Int R (Int.castCoe.{u} R (AddGroupWithOne.toHasIntCast.{u} R _inst_1)))) (Int.negSucc n)) (Neg.neg.{u} R (SubNegMonoid.toHasNeg.{u} R (AddGroup.toSubNegMonoid.{u} R (AddGroupWithOne.toAddGroup.{u} R _inst_1))) ((fun (a : Type) (b : Type.{u}) [self : HasLiftT.{1 succ u} a b] => self.0) Nat R (HasLiftT.mk.{1 succ u} Nat R (CoeTCₓ.coe.{1 succ u} Nat R (Nat.castCoe.{u} R (AddMonoidWithOne.toHasNatCast.{u} R (AddGroupWithOne.toAddMonoidWithOne.{u} R _inst_1))))) (HAdd.hAdd.{0 0 0} Nat Nat Nat (instHAdd.{0} Nat Nat.hasAdd) n (OfNat.ofNat.{0} Nat 1 (OfNat.mk.{0} Nat 1 (One.one.{0} Nat Nat.hasOne))))))
+but is expected to have type
+  forall {R : Type.{u_1}} {n : Nat} [inst._@.Mathlib.Algebra.GroupWithZero.Defs._hyg.811 : AddGroupWithOne.{u_1} R], Eq.{succ u_1} R (Int.cast.{u_1} R inst._@.Mathlib.Algebra.GroupWithZero.Defs._hyg.811 (Int.negSucc n)) (Neg.neg.{u_1} R (AddGroupWithOne.toNeg.{u_1} R inst._@.Mathlib.Algebra.GroupWithZero.Defs._hyg.811) (Nat.cast.{u_1} R (AddGroupWithOne.toAddMonoidWithOne.{u_1} R inst._@.Mathlib.Algebra.GroupWithZero.Defs._hyg.811) (HAdd.hAdd.{0 0 0} Nat Nat Nat (instHAdd.{0} Nat instAddNat) n (OfNat.ofNat.{0} Nat 1 (instOfNatNat 1)))))
+Case conversion may be inaccurate. Consider using '#align int.cast_neg_succ_of_nat Int.cast_negSuccₓ'. -/
 @[simp]
-theorem cast_subNatNat [AddGroupWithOne R] (m n) : ((subNatNat m n : ℤ) : R) = m - n := by
-  unfold Int.subNatNat
+theorem cast_negSucc (n : ℕ) : (-[n+1] : R) = -(n + 1 : ℕ) :=
+  AddGroupWithOne.int_cast_neg_succ_of_nat n
+#align int.cast_neg_succ_of_nat Int.cast_negSucc
+
+/- warning: int.cast_zero -> Int.cast_zero is a dubious translation:
+lean 3 declaration is
+  forall {R : Type.{u}} [_inst_1 : AddGroupWithOne.{u} R], Eq.{succ u} R ((fun (a : Type) (b : Type.{u}) [self : HasLiftT.{1 succ u} a b] => self.0) Int R (HasLiftT.mk.{1 succ u} Int R (CoeTCₓ.coe.{1 succ u} Int R (Int.castCoe.{u} R (AddGroupWithOne.toHasIntCast.{u} R _inst_1)))) (OfNat.ofNat.{0} Int 0 (OfNat.mk.{0} Int 0 (Zero.zero.{0} Int Int.hasZero)))) (OfNat.ofNat.{u} R 0 (OfNat.mk.{u} R 0 (Zero.zero.{u} R (AddZeroClass.toHasZero.{u} R (AddMonoid.toAddZeroClass.{u} R (AddMonoidWithOne.toAddMonoid.{u} R (AddGroupWithOne.toAddMonoidWithOne.{u} R _inst_1)))))))
+but is expected to have type
+  forall {R : Type.{u_1}} [inst._@.Mathlib.Algebra.GroupWithZero.Defs._hyg.848 : AddGroupWithOne.{u_1} R], Eq.{succ u_1} R (Int.cast.{u_1} R inst._@.Mathlib.Algebra.GroupWithZero.Defs._hyg.848 (OfNat.ofNat.{0} Int 0 (instOfNatInt 0))) (OfNat.ofNat.{u_1} R 0 (Zero.toOfNat0.{u_1} R (AddRightCancelMonoid.toZero.{u_1} R (AddCancelMonoid.toAddRightCancelMonoid.{u_1} R (AddGroup.toAddCancelMonoid.{u_1} R (AddGroupWithOne.toAddGroup.{u_1} R inst._@.Mathlib.Algebra.GroupWithZero.Defs._hyg.848))))))
+Case conversion may be inaccurate. Consider using '#align int.cast_zero Int.cast_zeroₓ'. -/
+@[norm_cast]
+theorem cast_zero : ((0 : ℤ) : R) = 0 :=
+  (cast_of_nat 0).trans Nat.cast_zero
+#align int.cast_zero Int.cast_zero
+
+/- warning: int.cast_coe_nat -> Int.cast_ofNat is a dubious translation:
+lean 3 declaration is
+  forall {R : Type.{u}} [_inst_1 : AddGroupWithOne.{u} R] (n : Nat), Eq.{succ u} R ((fun (a : Type) (b : Type.{u}) [self : HasLiftT.{1 succ u} a b] => self.0) Int R (HasLiftT.mk.{1 succ u} Int R (CoeTCₓ.coe.{1 succ u} Int R (Int.castCoe.{u} R (AddGroupWithOne.toHasIntCast.{u} R _inst_1)))) ((fun (a : Type) (b : Type) [self : HasLiftT.{1 1} a b] => self.0) Nat Int (HasLiftT.mk.{1 1} Nat Int (CoeTCₓ.coe.{1 1} Nat Int (CoeTCₓ.mk.{1 1} Nat Int Int.ofNat))) n)) ((fun (a : Type) (b : Type.{u}) [self : HasLiftT.{1 succ u} a b] => self.0) Nat R (HasLiftT.mk.{1 succ u} Nat R (CoeTCₓ.coe.{1 succ u} Nat R (Nat.castCoe.{u} R (AddMonoidWithOne.toHasNatCast.{u} R (AddGroupWithOne.toAddMonoidWithOne.{u} R _inst_1))))) n)
+but is expected to have type
+  forall {R : Type.{u_1}} {n : Nat} [inst._@.Mathlib.Algebra.GroupWithZero.Defs._hyg.772 : AddGroupWithOne.{u_1} R], Eq.{succ u_1} R (Int.cast.{u_1} R inst._@.Mathlib.Algebra.GroupWithZero.Defs._hyg.772 (Int.ofNat n)) (Nat.cast.{u_1} R (AddGroupWithOne.toAddMonoidWithOne.{u_1} R inst._@.Mathlib.Algebra.GroupWithZero.Defs._hyg.772) n)
+Case conversion may be inaccurate. Consider using '#align int.cast_coe_nat Int.cast_ofNatₓ'. -/
+@[simp, norm_cast]
+theorem cast_ofNat (n : ℕ) : ((n : ℤ) : R) = n :=
+  cast_of_nat _
+#align int.cast_coe_nat Int.cast_ofNat
+
+/- warning: int.cast_one -> Int.cast_one is a dubious translation:
+lean 3 declaration is
+  forall {R : Type.{u}} [_inst_1 : AddGroupWithOne.{u} R], Eq.{succ u} R ((fun (a : Type) (b : Type.{u}) [self : HasLiftT.{1 succ u} a b] => self.0) Int R (HasLiftT.mk.{1 succ u} Int R (CoeTCₓ.coe.{1 succ u} Int R (Int.castCoe.{u} R (AddGroupWithOne.toHasIntCast.{u} R _inst_1)))) (OfNat.ofNat.{0} Int 1 (OfNat.mk.{0} Int 1 (One.one.{0} Int Int.hasOne)))) (OfNat.ofNat.{u} R 1 (OfNat.mk.{u} R 1 (One.one.{u} R (AddMonoidWithOne.toHasOne.{u} R (AddGroupWithOne.toAddMonoidWithOne.{u} R _inst_1)))))
+but is expected to have type
+  forall {R : Type.{u_1}} [inst._@.Mathlib.Algebra.GroupWithZero.Defs._hyg.908 : AddGroupWithOne.{u_1} R], Eq.{succ u_1} R (Int.cast.{u_1} R inst._@.Mathlib.Algebra.GroupWithZero.Defs._hyg.908 (OfNat.ofNat.{0} Int 1 (instOfNatInt 1))) (OfNat.ofNat.{u_1} R 1 (One.toOfNat1.{u_1} R (AddMonoidWithOne.toOne.{u_1} R (AddGroupWithOne.toAddMonoidWithOne.{u_1} R inst._@.Mathlib.Algebra.GroupWithZero.Defs._hyg.908))))
+Case conversion may be inaccurate. Consider using '#align int.cast_one Int.cast_oneₓ'. -/
+@[norm_cast]
+theorem cast_one : ((1 : ℤ) : R) = 1 :=
+  show (((1 : ℕ) : ℤ) : R) = 1 by simp [Nat.cast_zero]
+#align int.cast_one Int.cast_one
+
+/- warning: int.cast_neg -> Int.cast_neg is a dubious translation:
+lean 3 declaration is
+  forall {R : Type.{u}} [_inst_1 : AddGroupWithOne.{u} R] (n : Int), Eq.{succ u} R ((fun (a : Type) (b : Type.{u}) [self : HasLiftT.{1 succ u} a b] => self.0) Int R (HasLiftT.mk.{1 succ u} Int R (CoeTCₓ.coe.{1 succ u} Int R (Int.castCoe.{u} R (AddGroupWithOne.toHasIntCast.{u} R _inst_1)))) (Neg.neg.{0} Int Int.hasNeg n)) (Neg.neg.{u} R (SubNegMonoid.toHasNeg.{u} R (AddGroup.toSubNegMonoid.{u} R (AddGroupWithOne.toAddGroup.{u} R _inst_1))) ((fun (a : Type) (b : Type.{u}) [self : HasLiftT.{1 succ u} a b] => self.0) Int R (HasLiftT.mk.{1 succ u} Int R (CoeTCₓ.coe.{1 succ u} Int R (Int.castCoe.{u} R (AddGroupWithOne.toHasIntCast.{u} R _inst_1)))) n))
+but is expected to have type
+  forall {R : Type.{u_1}} [inst._@.Mathlib.Data.Int.Cast.Defs._hyg.97 : AddGroupWithOne.{u_1} R] (n : Int), Eq.{succ u_1} R (Int.cast.{u_1} R inst._@.Mathlib.Data.Int.Cast.Defs._hyg.97 (Neg.neg.{0} Int Int.instNegInt n)) (Neg.neg.{u_1} R (AddGroupWithOne.toNeg.{u_1} R inst._@.Mathlib.Data.Int.Cast.Defs._hyg.97) (Int.cast.{u_1} R inst._@.Mathlib.Data.Int.Cast.Defs._hyg.97 n))
+Case conversion may be inaccurate. Consider using '#align int.cast_neg Int.cast_negₓ'. -/
+@[norm_cast]
+theorem cast_neg : ∀ n, ((-n : ℤ) : R) = -n
+  | (0 : ℕ) => by erw [cast_zero, neg_zero]
+  | (n + 1 : ℕ) => by erw [cast_of_nat, cast_neg_succ_of_nat] <;> rfl
+  | -[n+1] => by erw [cast_of_nat, cast_neg_succ_of_nat, neg_neg]
+#align int.cast_neg Int.cast_neg
+
+/- warning: int.cast_sub_nat_nat -> Int.cast_subNatNat is a dubious translation:
+lean 3 declaration is
+  forall {R : Type.{u}} [_inst_1 : AddGroupWithOne.{u} R] (m : Nat) (n : Nat), Eq.{succ u} R ((fun (a : Type) (b : Type.{u}) [self : HasLiftT.{1 succ u} a b] => self.0) Int R (HasLiftT.mk.{1 succ u} Int R (CoeTCₓ.coe.{1 succ u} Int R (Int.castCoe.{u} R (AddGroupWithOne.toHasIntCast.{u} R _inst_1)))) (Int.subNatNat m n)) (HSub.hSub.{u u u} R R R (instHSub.{u} R (SubNegMonoid.toHasSub.{u} R (AddGroup.toSubNegMonoid.{u} R (AddGroupWithOne.toAddGroup.{u} R _inst_1)))) ((fun (a : Type) (b : Type.{u}) [self : HasLiftT.{1 succ u} a b] => self.0) Nat R (HasLiftT.mk.{1 succ u} Nat R (CoeTCₓ.coe.{1 succ u} Nat R (Nat.castCoe.{u} R (AddMonoidWithOne.toHasNatCast.{u} R (AddGroupWithOne.toAddMonoidWithOne.{u} R _inst_1))))) m) ((fun (a : Type) (b : Type.{u}) [self : HasLiftT.{1 succ u} a b] => self.0) Nat R (HasLiftT.mk.{1 succ u} Nat R (CoeTCₓ.coe.{1 succ u} Nat R (Nat.castCoe.{u} R (AddMonoidWithOne.toHasNatCast.{u} R (AddGroupWithOne.toAddMonoidWithOne.{u} R _inst_1))))) n))
+but is expected to have type
+  forall {R : Type.{u_1}} [inst._@.Mathlib.Data.Int.Cast.Defs._hyg.297 : AddGroupWithOne.{u_1} R] (m : Nat) (n : Nat), Eq.{succ u_1} R (Int.cast.{u_1} R inst._@.Mathlib.Data.Int.Cast.Defs._hyg.297 (Int.subNatNat m n)) (HSub.hSub.{u_1 u_1 u_1} R R R (instHSub.{u_1} R (AddGroupWithOne.toSub.{u_1} R inst._@.Mathlib.Data.Int.Cast.Defs._hyg.297)) (Nat.cast.{u_1} R (AddGroupWithOne.toAddMonoidWithOne.{u_1} R inst._@.Mathlib.Data.Int.Cast.Defs._hyg.297) m) (Nat.cast.{u_1} R (AddGroupWithOne.toAddMonoidWithOne.{u_1} R inst._@.Mathlib.Data.Int.Cast.Defs._hyg.297) n))
+Case conversion may be inaccurate. Consider using '#align int.cast_sub_nat_nat Int.cast_subNatNatₓ'. -/
+@[simp]
+theorem cast_subNatNat (m n) : ((Int.subNatNat m n : ℤ) : R) = m - n := by
+  unfold sub_nat_nat
   cases e : n - m
-  · simp only [subNatNat, cast_ofNat]
+  · simp only [sub_nat_nat, cast_of_nat]
     simp [e, Nat.le_of_sub_eq_zero e]
-  · rw [cast_negSucc, Nat.add_one, ← e, Nat.cast_sub <| _root_.le_of_lt <| Nat.lt_of_sub_eq_succ e,
+    
+  · rw [sub_nat_nat, cast_neg_succ_of_nat, Nat.add_one, ← e, Nat.cast_sub <| _root_.le_of_lt <| Nat.lt_of_sub_eq_succ e,
       neg_sub]
+    
 #align int.cast_sub_nat_nat Int.cast_subNatNat
 
-@[simp, norm_cast]
-theorem cast_add [AddGroupWithOne R] : ∀ m n, ((m + n : ℤ) : R) = m + n
-  | (m : ℕ), (n : ℕ) => by simp [← ofNat_add]
-  | (m : ℕ), -[n+1] => by erw [cast_subNatNat, cast_ofNat, cast_negSucc, sub_eq_add_neg]
-  | -[m+1], (n : ℕ) => by
-    erw [cast_subNatNat, cast_ofNat, cast_negSucc, sub_eq_iff_eq_add,
-      add_assoc, eq_neg_add_iff_add_eq, ← Nat.cast_add, ← Nat.cast_add, Nat.add_comm]
-  | -[m+1], -[n+1] => show (-[m + n + 1 +1] : R) = _ by
-    rw [cast_negSucc, cast_negSucc, cast_negSucc, ← neg_add_rev, ← Nat.cast_add,
-      Nat.add_right_comm m n 1, Nat.add_assoc, Nat.add_comm]
+theorem neg_of_nat_eq (n : ℕ) : negOfNat n = -(n : ℤ) := by cases n <;> rfl
+#align int.neg_of_nat_eq Int.neg_of_nat_eq
 
-@[simp, norm_cast]
-theorem cast_sub (m n) : ((m - n : ℤ) : R) = m - n := by simp [Int.sub_eq_add_neg, sub_eq_add_neg]
+@[simp]
+theorem cast_neg_of_nat (n : ℕ) : ((negOfNat n : ℤ) : R) = -n := by simp [Int.cast_neg, neg_of_nat_eq]
+#align int.cast_neg_of_nat Int.cast_neg_of_nat
+
+/- warning: int.cast_add -> Int.cast_add is a dubious translation:
+lean 3 declaration is
+  forall {R : Type.{u}} [_inst_1 : AddGroupWithOne.{u} R] (m : Int) (n : Int), Eq.{succ u} R ((fun (a : Type) (b : Type.{u}) [self : HasLiftT.{1 succ u} a b] => self.0) Int R (HasLiftT.mk.{1 succ u} Int R (CoeTCₓ.coe.{1 succ u} Int R (Int.castCoe.{u} R (AddGroupWithOne.toHasIntCast.{u} R _inst_1)))) (HAdd.hAdd.{0 0 0} Int Int Int (instHAdd.{0} Int Int.hasAdd) m n)) (HAdd.hAdd.{u u u} R R R (instHAdd.{u} R (AddZeroClass.toHasAdd.{u} R (AddMonoid.toAddZeroClass.{u} R (AddMonoidWithOne.toAddMonoid.{u} R (AddGroupWithOne.toAddMonoidWithOne.{u} R _inst_1))))) ((fun (a : Type) (b : Type.{u}) [self : HasLiftT.{1 succ u} a b] => self.0) Int R (HasLiftT.mk.{1 succ u} Int R (CoeTCₓ.coe.{1 succ u} Int R (Int.castCoe.{u} R (AddGroupWithOne.toHasIntCast.{u} R _inst_1)))) m) ((fun (a : Type) (b : Type.{u}) [self : HasLiftT.{1 succ u} a b] => self.0) Int R (HasLiftT.mk.{1 succ u} Int R (CoeTCₓ.coe.{1 succ u} Int R (Int.castCoe.{u} R (AddGroupWithOne.toHasIntCast.{u} R _inst_1)))) n))
+but is expected to have type
+  forall {R : Type.{u_1}} [inst._@.Mathlib.Data.Int.Cast.Defs._hyg.392 : AddGroupWithOne.{u_1} R] (m : Int) (n : Int), Eq.{succ u_1} R (Int.cast.{u_1} R inst._@.Mathlib.Data.Int.Cast.Defs._hyg.392 (HAdd.hAdd.{0 0 0} Int Int Int (instHAdd.{0} Int Int.instAddInt) m n)) (HAdd.hAdd.{u_1 u_1 u_1} R R R (instHAdd.{u_1} R (AddZeroClass.toAdd.{u_1} R (AddMonoid.toAddZeroClass.{u_1} R (AddMonoidWithOne.toAddMonoid.{u_1} R (AddGroupWithOne.toAddMonoidWithOne.{u_1} R inst._@.Mathlib.Data.Int.Cast.Defs._hyg.392))))) (Int.cast.{u_1} R inst._@.Mathlib.Data.Int.Cast.Defs._hyg.392 m) (Int.cast.{u_1} R inst._@.Mathlib.Data.Int.Cast.Defs._hyg.392 n))
+Case conversion may be inaccurate. Consider using '#align int.cast_add Int.cast_addₓ'. -/
+@[norm_cast]
+theorem cast_add : ∀ m n, ((m + n : ℤ) : R) = m + n
+  | (m : ℕ), (n : ℕ) => by simp [← Int.ofNat_add, Nat.cast_add]
+  | (m : ℕ), -[n+1] => by erw [cast_sub_nat_nat, cast_coe_nat, cast_neg_succ_of_nat, sub_eq_add_neg]
+  | -[m+1], (n : ℕ) => by
+    erw [cast_sub_nat_nat, cast_coe_nat, cast_neg_succ_of_nat, sub_eq_iff_eq_add, add_assoc, eq_neg_add_iff_add_eq, ←
+      Nat.cast_add, ← Nat.cast_add, Nat.add_comm]
+  | -[m+1], -[n+1] =>
+    show (-[m + n + 1+1] : R) = _ by
+      rw [cast_neg_succ_of_nat, cast_neg_succ_of_nat, cast_neg_succ_of_nat, ← neg_add_rev, ← Nat.cast_add,
+        Nat.add_right_comm m n 1, Nat.add_assoc, Nat.add_comm]
+#align int.cast_add Int.cast_add
+
+/- warning: int.cast_sub -> Int.cast_sub is a dubious translation:
+lean 3 declaration is
+  forall {R : Type.{u}} [_inst_1 : AddGroupWithOne.{u} R] (m : Int) (n : Int), Eq.{succ u} R ((fun (a : Type) (b : Type.{u}) [self : HasLiftT.{1 succ u} a b] => self.0) Int R (HasLiftT.mk.{1 succ u} Int R (CoeTCₓ.coe.{1 succ u} Int R (Int.castCoe.{u} R (AddGroupWithOne.toHasIntCast.{u} R _inst_1)))) (HSub.hSub.{0 0 0} Int Int Int (instHSub.{0} Int Int.hasSub) m n)) (HSub.hSub.{u u u} R R R (instHSub.{u} R (SubNegMonoid.toHasSub.{u} R (AddGroup.toSubNegMonoid.{u} R (AddGroupWithOne.toAddGroup.{u} R _inst_1)))) ((fun (a : Type) (b : Type.{u}) [self : HasLiftT.{1 succ u} a b] => self.0) Int R (HasLiftT.mk.{1 succ u} Int R (CoeTCₓ.coe.{1 succ u} Int R (Int.castCoe.{u} R (AddGroupWithOne.toHasIntCast.{u} R _inst_1)))) m) ((fun (a : Type) (b : Type.{u}) [self : HasLiftT.{1 succ u} a b] => self.0) Int R (HasLiftT.mk.{1 succ u} Int R (CoeTCₓ.coe.{1 succ u} Int R (Int.castCoe.{u} R (AddGroupWithOne.toHasIntCast.{u} R _inst_1)))) n))
+but is expected to have type
+  forall {R : Type.{u_1}} [inst._@.Mathlib.Data.Int.Cast.Defs._hyg.666 : AddGroupWithOne.{u_1} R] (m : Int) (n : Int), Eq.{succ u_1} R (Int.cast.{u_1} R inst._@.Mathlib.Data.Int.Cast.Defs._hyg.666 (HSub.hSub.{0 0 0} Int Int Int (instHSub.{0} Int Int.instSubInt) m n)) (HSub.hSub.{u_1 u_1 u_1} R R R (instHSub.{u_1} R (AddGroupWithOne.toSub.{u_1} R inst._@.Mathlib.Data.Int.Cast.Defs._hyg.666)) (Int.cast.{u_1} R inst._@.Mathlib.Data.Int.Cast.Defs._hyg.666 m) (Int.cast.{u_1} R inst._@.Mathlib.Data.Int.Cast.Defs._hyg.666 n))
+Case conversion may be inaccurate. Consider using '#align int.cast_sub Int.cast_subₓ'. -/
+@[norm_cast]
+theorem cast_sub (m n) : ((m - n : ℤ) : R) = m - n := by
+  simp [Int.sub_eq_add_neg, sub_eq_add_neg, Int.cast_neg, Int.cast_add]
+#align int.cast_sub Int.cast_sub
+
+@[norm_cast]
+theorem coe_nat_bit0 (n : ℕ) : (↑(bit0 n) : ℤ) = bit0 ↑n :=
+  rfl
+#align int.coe_nat_bit0 Int.coe_nat_bit0
+
+@[norm_cast]
+theorem coe_nat_bit1 (n : ℕ) : (↑(bit1 n) : ℤ) = bit1 ↑n :=
+  rfl
+#align int.coe_nat_bit1 Int.coe_nat_bit1
+
+@[norm_cast]
+theorem cast_bit0 (n : ℤ) : ((bit0 n : ℤ) : R) = bit0 n :=
+  Int.cast_add _ _
+#align int.cast_bit0 Int.cast_bit0
+
+@[norm_cast]
+theorem cast_bit1 (n : ℤ) : ((bit1 n : ℤ) : R) = bit1 n := by rw [bit1, Int.cast_add, Int.cast_one, cast_bit0] <;> rfl
+#align int.cast_bit1 Int.cast_bit1
+
+theorem cast_two : ((2 : ℤ) : R) = 2 := by simp [cast_bit0, cast_bit1, cast_one]
+#align int.cast_two Int.cast_two
+
+theorem cast_three : ((3 : ℤ) : R) = 3 := by simp [cast_bit0, cast_bit1, cast_one]
+#align int.cast_three Int.cast_three
+
+theorem cast_four : ((4 : ℤ) : R) = 4 := by simp [cast_bit0, cast_bit1, cast_one]
+#align int.cast_four Int.cast_four
+
+end Int
+

--- a/Mathlib/Data/Int/Cast/Basic.lean
+++ b/Mathlib/Data/Int/Cast/Basic.lean
@@ -26,12 +26,6 @@ namespace Nat
 
 variable {R : Type u} [AddGroupWithOne R]
 
-/- warning: nat.cast_sub -> Nat.cast_sub is a dubious translation:
-lean 3 declaration is
-  forall {R : Type.{u}} [_inst_1 : AddGroupWithOne.{u} R] {m : Nat} {n : Nat}, (LE.le.{0} Nat Nat.hasLe m n) -> (Eq.{succ u} R ((fun (a : Type) (b : Type.{u}) [self : HasLiftT.{1 succ u} a b] => self.0) Nat R (HasLiftT.mk.{1 succ u} Nat R (CoeTCₓ.coe.{1 succ u} Nat R (Nat.castCoe.{u} R (AddMonoidWithOne.toHasNatCast.{u} R (AddGroupWithOne.toAddMonoidWithOne.{u} R _inst_1))))) (HSub.hSub.{0 0 0} Nat Nat Nat (instHSub.{0} Nat Nat.hasSub) n m)) (HSub.hSub.{u u u} R R R (instHSub.{u} R (SubNegMonoid.toHasSub.{u} R (AddGroup.toSubNegMonoid.{u} R (AddGroupWithOne.toAddGroup.{u} R _inst_1)))) ((fun (a : Type) (b : Type.{u}) [self : HasLiftT.{1 succ u} a b] => self.0) Nat R (HasLiftT.mk.{1 succ u} Nat R (CoeTCₓ.coe.{1 succ u} Nat R (Nat.castCoe.{u} R (AddMonoidWithOne.toHasNatCast.{u} R (AddGroupWithOne.toAddMonoidWithOne.{u} R _inst_1))))) n) ((fun (a : Type) (b : Type.{u}) [self : HasLiftT.{1 succ u} a b] => self.0) Nat R (HasLiftT.mk.{1 succ u} Nat R (CoeTCₓ.coe.{1 succ u} Nat R (Nat.castCoe.{u} R (AddMonoidWithOne.toHasNatCast.{u} R (AddGroupWithOne.toAddMonoidWithOne.{u} R _inst_1))))) m)))
-but is expected to have type
-  forall {R : Type.{u_1}} [inst._@.Mathlib.Data.Int.Cast.Defs._hyg.16 : AddGroupWithOne.{u_1} R] {m : Nat} {n : Nat}, (LE.le.{0} Nat instLENat m n) -> (Eq.{succ u_1} R (Nat.cast.{u_1} R (AddGroupWithOne.toAddMonoidWithOne.{u_1} R inst._@.Mathlib.Data.Int.Cast.Defs._hyg.16) (HSub.hSub.{0 0 0} Nat Nat Nat (instHSub.{0} Nat instSubNat) n m)) (HSub.hSub.{u_1 u_1 u_1} R R R (instHSub.{u_1} R (AddGroupWithOne.toSub.{u_1} R inst._@.Mathlib.Data.Int.Cast.Defs._hyg.16)) (Nat.cast.{u_1} R (AddGroupWithOne.toAddMonoidWithOne.{u_1} R inst._@.Mathlib.Data.Int.Cast.Defs._hyg.16) n) (Nat.cast.{u_1} R (AddGroupWithOne.toAddMonoidWithOne.{u_1} R inst._@.Mathlib.Data.Int.Cast.Defs._hyg.16) m)))
-Case conversion may be inaccurate. Consider using '#align nat.cast_sub Nat.cast_subₓ'. -/
 @[simp, norm_cast]
 theorem cast_sub {m n} (h : m ≤ n) : ((n - m : ℕ) : R) = n - m :=
   eq_sub_of_add_eq <| by rw [← cast_add, Nat.sub_add_cancel h]
@@ -51,56 +45,26 @@ namespace Int
 
 variable {R : Type u} [AddGroupWithOne R]
 
-/- warning: int.cast_neg_succ_of_nat -> Int.cast_negSucc is a dubious translation:
-lean 3 declaration is
-  forall {R : Type.{u}} [_inst_1 : AddGroupWithOne.{u} R] (n : Nat), Eq.{succ u} R ((fun (a : Type) (b : Type.{u}) [self : HasLiftT.{1 succ u} a b] => self.0) Int R (HasLiftT.mk.{1 succ u} Int R (CoeTCₓ.coe.{1 succ u} Int R (Int.castCoe.{u} R (AddGroupWithOne.toHasIntCast.{u} R _inst_1)))) (Int.negSucc n)) (Neg.neg.{u} R (SubNegMonoid.toHasNeg.{u} R (AddGroup.toSubNegMonoid.{u} R (AddGroupWithOne.toAddGroup.{u} R _inst_1))) ((fun (a : Type) (b : Type.{u}) [self : HasLiftT.{1 succ u} a b] => self.0) Nat R (HasLiftT.mk.{1 succ u} Nat R (CoeTCₓ.coe.{1 succ u} Nat R (Nat.castCoe.{u} R (AddMonoidWithOne.toHasNatCast.{u} R (AddGroupWithOne.toAddMonoidWithOne.{u} R _inst_1))))) (HAdd.hAdd.{0 0 0} Nat Nat Nat (instHAdd.{0} Nat Nat.hasAdd) n (OfNat.ofNat.{0} Nat 1 (OfNat.mk.{0} Nat 1 (One.one.{0} Nat Nat.hasOne))))))
-but is expected to have type
-  forall {R : Type.{u_1}} {n : Nat} [inst._@.Mathlib.Algebra.GroupWithZero.Defs._hyg.811 : AddGroupWithOne.{u_1} R], Eq.{succ u_1} R (Int.cast.{u_1} R inst._@.Mathlib.Algebra.GroupWithZero.Defs._hyg.811 (Int.negSucc n)) (Neg.neg.{u_1} R (AddGroupWithOne.toNeg.{u_1} R inst._@.Mathlib.Algebra.GroupWithZero.Defs._hyg.811) (Nat.cast.{u_1} R (AddGroupWithOne.toAddMonoidWithOne.{u_1} R inst._@.Mathlib.Algebra.GroupWithZero.Defs._hyg.811) (HAdd.hAdd.{0 0 0} Nat Nat Nat (instHAdd.{0} Nat instAddNat) n (OfNat.ofNat.{0} Nat 1 (instOfNatNat 1)))))
-Case conversion may be inaccurate. Consider using '#align int.cast_neg_succ_of_nat Int.cast_negSuccₓ'. -/
 @[simp, norm_cast]
 theorem cast_negSucc (n : ℕ) : (-[n+1] : R) = -(n + 1 : ℕ) :=
   AddGroupWithOne.intCast_negSucc n
 #align int.cast_neg_succ_of_nat Int.cast_negSuccₓ
 
-/- warning: int.cast_zero -> Int.cast_zero is a dubious translation:
-lean 3 declaration is
-  forall {R : Type.{u}} [_inst_1 : AddGroupWithOne.{u} R], Eq.{succ u} R ((fun (a : Type) (b : Type.{u}) [self : HasLiftT.{1 succ u} a b] => self.0) Int R (HasLiftT.mk.{1 succ u} Int R (CoeTCₓ.coe.{1 succ u} Int R (Int.castCoe.{u} R (AddGroupWithOne.toHasIntCast.{u} R _inst_1)))) (OfNat.ofNat.{0} Int 0 (OfNat.mk.{0} Int 0 (Zero.zero.{0} Int Int.hasZero)))) (OfNat.ofNat.{u} R 0 (OfNat.mk.{u} R 0 (Zero.zero.{u} R (AddZeroClass.toHasZero.{u} R (AddMonoid.toAddZeroClass.{u} R (AddMonoidWithOne.toAddMonoid.{u} R (AddGroupWithOne.toAddMonoidWithOne.{u} R _inst_1)))))))
-but is expected to have type
-  forall {R : Type.{u_1}} [inst._@.Mathlib.Algebra.GroupWithZero.Defs._hyg.848 : AddGroupWithOne.{u_1} R], Eq.{succ u_1} R (Int.cast.{u_1} R inst._@.Mathlib.Algebra.GroupWithZero.Defs._hyg.848 (OfNat.ofNat.{0} Int 0 (instOfNatInt 0))) (OfNat.ofNat.{u_1} R 0 (Zero.toOfNat0.{u_1} R (AddRightCancelMonoid.toZero.{u_1} R (AddCancelMonoid.toAddRightCancelMonoid.{u_1} R (AddGroup.toAddCancelMonoid.{u_1} R (AddGroupWithOne.toAddGroup.{u_1} R inst._@.Mathlib.Algebra.GroupWithZero.Defs._hyg.848))))))
-Case conversion may be inaccurate. Consider using '#align int.cast_zero Int.cast_zeroₓ'. -/
 @[simp, norm_cast]
 theorem cast_zero : ((0 : ℤ) : R) = 0 :=
   (AddGroupWithOne.intCast_ofNat 0).trans Nat.cast_zero
 #align int.cast_zero Int.cast_zeroₓ
 
-/- warning: int.cast_coe_nat -> Int.cast_ofNat is a dubious translation:
-lean 3 declaration is
-  forall {R : Type.{u}} [_inst_1 : AddGroupWithOne.{u} R] (n : Nat), Eq.{succ u} R ((fun (a : Type) (b : Type.{u}) [self : HasLiftT.{1 succ u} a b] => self.0) Int R (HasLiftT.mk.{1 succ u} Int R (CoeTCₓ.coe.{1 succ u} Int R (Int.castCoe.{u} R (AddGroupWithOne.toHasIntCast.{u} R _inst_1)))) ((fun (a : Type) (b : Type) [self : HasLiftT.{1 1} a b] => self.0) Nat Int (HasLiftT.mk.{1 1} Nat Int (CoeTCₓ.coe.{1 1} Nat Int (CoeTCₓ.mk.{1 1} Nat Int Int.ofNat))) n)) ((fun (a : Type) (b : Type.{u}) [self : HasLiftT.{1 succ u} a b] => self.0) Nat R (HasLiftT.mk.{1 succ u} Nat R (CoeTCₓ.coe.{1 succ u} Nat R (Nat.castCoe.{u} R (AddMonoidWithOne.toHasNatCast.{u} R (AddGroupWithOne.toAddMonoidWithOne.{u} R _inst_1))))) n)
-but is expected to have type
-  forall {R : Type.{u_1}} {n : Nat} [inst._@.Mathlib.Algebra.GroupWithZero.Defs._hyg.772 : AddGroupWithOne.{u_1} R], Eq.{succ u_1} R (Int.cast.{u_1} R inst._@.Mathlib.Algebra.GroupWithZero.Defs._hyg.772 (Int.ofNat n)) (Nat.cast.{u_1} R (AddGroupWithOne.toAddMonoidWithOne.{u_1} R inst._@.Mathlib.Algebra.GroupWithZero.Defs._hyg.772) n)
-Case conversion may be inaccurate. Consider using '#align int.cast_coe_nat Int.cast_ofNatₓ'. -/
 @[simp high, nolint simpNF, norm_cast] -- this lemma competes with `Int.ofNat_eq_cast` to come later
 theorem cast_ofNat (n : ℕ) : ((n : ℤ) : R) = n :=
   AddGroupWithOne.intCast_ofNat _
 #align int.cast_coe_nat Int.cast_ofNatₓ
 
-/- warning: int.cast_one -> Int.cast_one is a dubious translation:
-lean 3 declaration is
-  forall {R : Type.{u}} [_inst_1 : AddGroupWithOne.{u} R], Eq.{succ u} R ((fun (a : Type) (b : Type.{u}) [self : HasLiftT.{1 succ u} a b] => self.0) Int R (HasLiftT.mk.{1 succ u} Int R (CoeTCₓ.coe.{1 succ u} Int R (Int.castCoe.{u} R (AddGroupWithOne.toHasIntCast.{u} R _inst_1)))) (OfNat.ofNat.{0} Int 1 (OfNat.mk.{0} Int 1 (One.one.{0} Int Int.hasOne)))) (OfNat.ofNat.{u} R 1 (OfNat.mk.{u} R 1 (One.one.{u} R (AddMonoidWithOne.toHasOne.{u} R (AddGroupWithOne.toAddMonoidWithOne.{u} R _inst_1)))))
-but is expected to have type
-  forall {R : Type.{u_1}} [inst._@.Mathlib.Algebra.GroupWithZero.Defs._hyg.908 : AddGroupWithOne.{u_1} R], Eq.{succ u_1} R (Int.cast.{u_1} R inst._@.Mathlib.Algebra.GroupWithZero.Defs._hyg.908 (OfNat.ofNat.{0} Int 1 (instOfNatInt 1))) (OfNat.ofNat.{u_1} R 1 (One.toOfNat1.{u_1} R (AddMonoidWithOne.toOne.{u_1} R (AddGroupWithOne.toAddMonoidWithOne.{u_1} R inst._@.Mathlib.Algebra.GroupWithZero.Defs._hyg.908))))
-Case conversion may be inaccurate. Consider using '#align int.cast_one Int.cast_oneₓ'. -/
 @[simp, norm_cast]
 theorem cast_one : ((1 : ℤ) : R) = 1 := by
   erw [cast_ofNat, Nat.cast_one]
 #align int.cast_one Int.cast_oneₓ
 
-/- warning: int.cast_neg -> Int.cast_neg is a dubious translation:
-lean 3 declaration is
-  forall {R : Type.{u}} [_inst_1 : AddGroupWithOne.{u} R] (n : Int), Eq.{succ u} R ((fun (a : Type) (b : Type.{u}) [self : HasLiftT.{1 succ u} a b] => self.0) Int R (HasLiftT.mk.{1 succ u} Int R (CoeTCₓ.coe.{1 succ u} Int R (Int.castCoe.{u} R (AddGroupWithOne.toHasIntCast.{u} R _inst_1)))) (Neg.neg.{0} Int Int.hasNeg n)) (Neg.neg.{u} R (SubNegMonoid.toHasNeg.{u} R (AddGroup.toSubNegMonoid.{u} R (AddGroupWithOne.toAddGroup.{u} R _inst_1))) ((fun (a : Type) (b : Type.{u}) [self : HasLiftT.{1 succ u} a b] => self.0) Int R (HasLiftT.mk.{1 succ u} Int R (CoeTCₓ.coe.{1 succ u} Int R (Int.castCoe.{u} R (AddGroupWithOne.toHasIntCast.{u} R _inst_1)))) n))
-but is expected to have type
-  forall {R : Type.{u_1}} [inst._@.Mathlib.Data.Int.Cast.Defs._hyg.97 : AddGroupWithOne.{u_1} R] (n : Int), Eq.{succ u_1} R (Int.cast.{u_1} R inst._@.Mathlib.Data.Int.Cast.Defs._hyg.97 (Neg.neg.{0} Int Int.instNegInt n)) (Neg.neg.{u_1} R (AddGroupWithOne.toNeg.{u_1} R inst._@.Mathlib.Data.Int.Cast.Defs._hyg.97) (Int.cast.{u_1} R inst._@.Mathlib.Data.Int.Cast.Defs._hyg.97 n))
-Case conversion may be inaccurate. Consider using '#align int.cast_neg Int.cast_negₓ'.  -/
 @[norm_cast]
 theorem cast_neg : ∀ n, ((-n : ℤ) : R) = -n
   | (0 : ℕ) => by erw [cast_zero, neg_zero]
@@ -108,12 +72,6 @@ theorem cast_neg : ∀ n, ((-n : ℤ) : R) = -n
   | -[n+1] => by erw [cast_ofNat, cast_negSucc, neg_neg]
 #align int.cast_neg Int.cast_negₓ
 
-/- warning: int.cast_sub_nat_nat -> Int.cast_subNatNat is a dubious translation:
-lean 3 declaration is
-  forall {R : Type.{u}} [_inst_1 : AddGroupWithOne.{u} R] (m : Nat) (n : Nat), Eq.{succ u} R ((fun (a : Type) (b : Type.{u}) [self : HasLiftT.{1 succ u} a b] => self.0) Int R (HasLiftT.mk.{1 succ u} Int R (CoeTCₓ.coe.{1 succ u} Int R (Int.castCoe.{u} R (AddGroupWithOne.toHasIntCast.{u} R _inst_1)))) (Int.subNatNat m n)) (HSub.hSub.{u u u} R R R (instHSub.{u} R (SubNegMonoid.toHasSub.{u} R (AddGroup.toSubNegMonoid.{u} R (AddGroupWithOne.toAddGroup.{u} R _inst_1)))) ((fun (a : Type) (b : Type.{u}) [self : HasLiftT.{1 succ u} a b] => self.0) Nat R (HasLiftT.mk.{1 succ u} Nat R (CoeTCₓ.coe.{1 succ u} Nat R (Nat.castCoe.{u} R (AddMonoidWithOne.toHasNatCast.{u} R (AddGroupWithOne.toAddMonoidWithOne.{u} R _inst_1))))) m) ((fun (a : Type) (b : Type.{u}) [self : HasLiftT.{1 succ u} a b] => self.0) Nat R (HasLiftT.mk.{1 succ u} Nat R (CoeTCₓ.coe.{1 succ u} Nat R (Nat.castCoe.{u} R (AddMonoidWithOne.toHasNatCast.{u} R (AddGroupWithOne.toAddMonoidWithOne.{u} R _inst_1))))) n))
-but is expected to have type
-  forall {R : Type.{u_1}} [inst._@.Mathlib.Data.Int.Cast.Defs._hyg.297 : AddGroupWithOne.{u_1} R] (m : Nat) (n : Nat), Eq.{succ u_1} R (Int.cast.{u_1} R inst._@.Mathlib.Data.Int.Cast.Defs._hyg.297 (Int.subNatNat m n)) (HSub.hSub.{u_1 u_1 u_1} R R R (instHSub.{u_1} R (AddGroupWithOne.toSub.{u_1} R inst._@.Mathlib.Data.Int.Cast.Defs._hyg.297)) (Nat.cast.{u_1} R (AddGroupWithOne.toAddMonoidWithOne.{u_1} R inst._@.Mathlib.Data.Int.Cast.Defs._hyg.297) m) (Nat.cast.{u_1} R (AddGroupWithOne.toAddMonoidWithOne.{u_1} R inst._@.Mathlib.Data.Int.Cast.Defs._hyg.297) n))
-Case conversion may be inaccurate. Consider using '#align int.cast_sub_nat_nat Int.cast_subNatNatₓ'. -/
 @[simp]
 theorem cast_subNatNat (m n) : ((Int.subNatNat m n : ℤ) : R) = m - n := by
   unfold subNatNat
@@ -131,12 +89,6 @@ theorem cast_subNatNat (m n) : ((Int.subNatNat m n : ℤ) : R) = m - n := by
 theorem cast_negOfNat (n : ℕ) : ((negOfNat n : ℤ) : R) = -n := by simp [Int.cast_neg, negOfNat_eq]
 #align int.cast_neg_of_nat Int.cast_negOfNat
 
-/- warning: int.cast_add -> Int.cast_add is a dubious translation:
-lean 3 declaration is
-  forall {R : Type.{u}} [_inst_1 : AddGroupWithOne.{u} R] (m : Int) (n : Int), Eq.{succ u} R ((fun (a : Type) (b : Type.{u}) [self : HasLiftT.{1 succ u} a b] => self.0) Int R (HasLiftT.mk.{1 succ u} Int R (CoeTCₓ.coe.{1 succ u} Int R (Int.castCoe.{u} R (AddGroupWithOne.toHasIntCast.{u} R _inst_1)))) (HAdd.hAdd.{0 0 0} Int Int Int (instHAdd.{0} Int Int.hasAdd) m n)) (HAdd.hAdd.{u u u} R R R (instHAdd.{u} R (AddZeroClass.toHasAdd.{u} R (AddMonoid.toAddZeroClass.{u} R (AddMonoidWithOne.toAddMonoid.{u} R (AddGroupWithOne.toAddMonoidWithOne.{u} R _inst_1))))) ((fun (a : Type) (b : Type.{u}) [self : HasLiftT.{1 succ u} a b] => self.0) Int R (HasLiftT.mk.{1 succ u} Int R (CoeTCₓ.coe.{1 succ u} Int R (Int.castCoe.{u} R (AddGroupWithOne.toHasIntCast.{u} R _inst_1)))) m) ((fun (a : Type) (b : Type.{u}) [self : HasLiftT.{1 succ u} a b] => self.0) Int R (HasLiftT.mk.{1 succ u} Int R (CoeTCₓ.coe.{1 succ u} Int R (Int.castCoe.{u} R (AddGroupWithOne.toHasIntCast.{u} R _inst_1)))) n))
-but is expected to have type
-  forall {R : Type.{u_1}} [inst._@.Mathlib.Data.Int.Cast.Defs._hyg.392 : AddGroupWithOne.{u_1} R] (m : Int) (n : Int), Eq.{succ u_1} R (Int.cast.{u_1} R inst._@.Mathlib.Data.Int.Cast.Defs._hyg.392 (HAdd.hAdd.{0 0 0} Int Int Int (instHAdd.{0} Int Int.instAddInt) m n)) (HAdd.hAdd.{u_1 u_1 u_1} R R R (instHAdd.{u_1} R (AddZeroClass.toAdd.{u_1} R (AddMonoid.toAddZeroClass.{u_1} R (AddMonoidWithOne.toAddMonoid.{u_1} R (AddGroupWithOne.toAddMonoidWithOne.{u_1} R inst._@.Mathlib.Data.Int.Cast.Defs._hyg.392))))) (Int.cast.{u_1} R inst._@.Mathlib.Data.Int.Cast.Defs._hyg.392 m) (Int.cast.{u_1} R inst._@.Mathlib.Data.Int.Cast.Defs._hyg.392 n))
-Case conversion may be inaccurate. Consider using '#align int.cast_add Int.cast_addₓ'. -/
 @[norm_cast]
 theorem cast_add : ∀ m n, ((m + n : ℤ) : R) = m + n
   | (m : ℕ), (n : ℕ) => by simp [← Int.ofNat_add, Nat.cast_add]
@@ -150,12 +102,6 @@ theorem cast_add : ∀ m n, ((m + n : ℤ) : R) = m + n
         Nat.add_right_comm m n 1, Nat.add_assoc, Nat.add_comm]
 #align int.cast_add Int.cast_addₓ
 
-/- warning: int.cast_sub -> Int.cast_sub is a dubious translation:
-lean 3 declaration is
-  forall {R : Type.{u}} [_inst_1 : AddGroupWithOne.{u} R] (m : Int) (n : Int), Eq.{succ u} R ((fun (a : Type) (b : Type.{u}) [self : HasLiftT.{1 succ u} a b] => self.0) Int R (HasLiftT.mk.{1 succ u} Int R (CoeTCₓ.coe.{1 succ u} Int R (Int.castCoe.{u} R (AddGroupWithOne.toHasIntCast.{u} R _inst_1)))) (HSub.hSub.{0 0 0} Int Int Int (instHSub.{0} Int Int.hasSub) m n)) (HSub.hSub.{u u u} R R R (instHSub.{u} R (SubNegMonoid.toHasSub.{u} R (AddGroup.toSubNegMonoid.{u} R (AddGroupWithOne.toAddGroup.{u} R _inst_1)))) ((fun (a : Type) (b : Type.{u}) [self : HasLiftT.{1 succ u} a b] => self.0) Int R (HasLiftT.mk.{1 succ u} Int R (CoeTCₓ.coe.{1 succ u} Int R (Int.castCoe.{u} R (AddGroupWithOne.toHasIntCast.{u} R _inst_1)))) m) ((fun (a : Type) (b : Type.{u}) [self : HasLiftT.{1 succ u} a b] => self.0) Int R (HasLiftT.mk.{1 succ u} Int R (CoeTCₓ.coe.{1 succ u} Int R (Int.castCoe.{u} R (AddGroupWithOne.toHasIntCast.{u} R _inst_1)))) n))
-but is expected to have type
-  forall {R : Type.{u_1}} [inst._@.Mathlib.Data.Int.Cast.Defs._hyg.666 : AddGroupWithOne.{u_1} R] (m : Int) (n : Int), Eq.{succ u_1} R (Int.cast.{u_1} R inst._@.Mathlib.Data.Int.Cast.Defs._hyg.666 (HSub.hSub.{0 0 0} Int Int Int (instHSub.{0} Int Int.instSubInt) m n)) (HSub.hSub.{u_1 u_1 u_1} R R R (instHSub.{u_1} R (AddGroupWithOne.toSub.{u_1} R inst._@.Mathlib.Data.Int.Cast.Defs._hyg.666)) (Int.cast.{u_1} R inst._@.Mathlib.Data.Int.Cast.Defs._hyg.666 m) (Int.cast.{u_1} R inst._@.Mathlib.Data.Int.Cast.Defs._hyg.666 n))
-Case conversion may be inaccurate. Consider using '#align int.cast_sub Int.cast_subₓ'. -/
 @[norm_cast]
 theorem cast_sub (m n) : ((m - n : ℤ) : R) = m - n := by
   simp [Int.sub_eq_add_neg, sub_eq_add_neg, Int.cast_neg, Int.cast_add]

--- a/Mathlib/Data/Int/Cast/Basic.lean
+++ b/Mathlib/Data/Int/Cast/Basic.lean
@@ -55,7 +55,7 @@ theorem cast_zero : ((0 : ℤ) : R) = 0 :=
   (AddGroupWithOne.intCast_ofNat 0).trans Nat.cast_zero
 #align int.cast_zero Int.cast_zeroₓ
 
-@[simp high, nolint simpNF, norm_cast] -- this lemma competes with `Int.ofNat_eq_cast` to come later
+@[simp high, nolint simpNF] -- this lemma competes with `Int.ofNat_eq_cast` to come later
 theorem cast_ofNat (n : ℕ) : ((n : ℤ) : R) = n :=
   AddGroupWithOne.intCast_ofNat _
 #align int.cast_coe_nat Int.cast_ofNatₓ
@@ -65,14 +65,14 @@ theorem cast_one : ((1 : ℤ) : R) = 1 := by
   erw [cast_ofNat, Nat.cast_one]
 #align int.cast_one Int.cast_oneₓ
 
-@[norm_cast]
+@[simp, norm_cast]
 theorem cast_neg : ∀ n, ((-n : ℤ) : R) = -n
   | (0 : ℕ) => by erw [cast_zero, neg_zero]
   | (n + 1 : ℕ) => by erw [cast_ofNat, cast_negSucc]
   | -[n+1] => by erw [cast_ofNat, cast_negSucc, neg_neg]
 #align int.cast_neg Int.cast_negₓ
 
-@[simp]
+@[simp, norm_cast]
 theorem cast_subNatNat (m n) : ((Int.subNatNat m n : ℤ) : R) = m - n := by
   unfold subNatNat
   cases e : n - m
@@ -89,7 +89,7 @@ theorem cast_subNatNat (m n) : ((Int.subNatNat m n : ℤ) : R) = m - n := by
 theorem cast_negOfNat (n : ℕ) : ((negOfNat n : ℤ) : R) = -n := by simp [Int.cast_neg, negOfNat_eq]
 #align int.cast_neg_of_nat Int.cast_negOfNat
 
-@[norm_cast]
+@[simp, norm_cast]
 theorem cast_add : ∀ m n, ((m + n : ℤ) : R) = m + n
   | (m : ℕ), (n : ℕ) => by simp [← Int.ofNat_add, Nat.cast_add]
   | (m : ℕ), -[n+1] => by erw [cast_subNatNat, cast_ofNat, cast_negSucc, sub_eq_add_neg]
@@ -102,7 +102,7 @@ theorem cast_add : ∀ m n, ((m + n : ℤ) : R) = m + n
         Nat.add_right_comm m n 1, Nat.add_assoc, Nat.add_comm]
 #align int.cast_add Int.cast_addₓ
 
-@[norm_cast]
+@[simp, norm_cast]
 theorem cast_sub (m n) : ((m - n : ℤ) : R) = m - n := by
   simp [Int.sub_eq_add_neg, sub_eq_add_neg, Int.cast_neg, Int.cast_add]
 #align int.cast_sub Int.cast_subₓ

--- a/Mathlib/Data/Int/Cast/Defs.lean
+++ b/Mathlib/Data/Int/Cast/Defs.lean
@@ -65,23 +65,6 @@ namespace Int
 
 instance [IntCast R] : CoeTail ℤ R where coe := cast
 
-@[simp high, nolint simpNF] -- this lemma competes with `Int.ofNat_eq_cast` to come later
-theorem cast_ofNat [AddGroupWithOne R] : (cast (ofNat n) : R) = Nat.cast n :=
-  AddGroupWithOne.intCast_ofNat _
-#align int.cast_coe_nat Int.cast_ofNat
-
-@[simp, norm_cast]
-theorem cast_negSucc [AddGroupWithOne R] : (cast (negSucc n) : R) = (-(Nat.cast (n + 1)) : R) :=
-  AddGroupWithOne.intCast_negSucc _
-#align int.cast_neg_succ_of_nat Int.cast_negSucc
-
-@[simp, norm_cast] theorem cast_zero [AddGroupWithOne R] : ((0 : ℤ) : R) = 0 := by
-  erw [cast_ofNat, Nat.cast_zero]
-#align int.cast_zero Int.cast_zero
-@[simp, norm_cast] theorem cast_one [AddGroupWithOne R] : ((1 : ℤ) : R) = 1 := by
-  erw [cast_ofNat, Nat.cast_one]
-#align int.cast_one Int.cast_one
-
 end Int
 
 /-- An `AddCommGroupWithOne` is an `AddGroupWithOne` satisfying `a + b = b + a`. -/


### PR DESCRIPTION
mathlib3 SHA: 39af7d3bf61a98e928812dbc3e16f4ea8b795ca3

Porting notes:

1. Some lemmas were transferred from `Data.Int.Cast.Defs` in order to match mathlib3 (I accidentally put them in the wrong place when I had ported that file because those lemmas were already present in mathlib4.)
2. The lemmas just mentioned have retained their `simp` attribute for the reason Gabriel mentioned on that PR (#641), even though that attribute isn't present on the mathlib3 version.
3. The `bit0` and `bit1` lemmas have been marked as deprecated.
4. There were many dubious translation errors, I believe primarily because of the difference in the way coercions are handled, so I have `#align`ed all of these with `ₓ`. I believe this is the correct thing to do, but confirmation would be nice.

---

* The first commit is the raw mathport output
* After getting the file to compile, I left one commit before I deleted the dubious translation warnings, so you can look at that to compare.