### PR TITLE
Fix lakefile.lean capitalisation of @[defaultTarget]

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -4,11 +4,11 @@ open Lake DSL
 
 package mathlib
 
-@[default_target]
+@[defaultTarget]
 lean_lib Mathlib where
   moreLeanArgs := #["-DwarningAsError=true"]
 
-@[default_target]
+@[defaultTarget]
 lean_exe runLinter where
   root := `scripts.runLinter
   supportInterpreter := true


### PR DESCRIPTION
When I install a fresh nightly toolchain I get errors while trying to build mathlib.
I hope this change will fix that.