### PR TITLE
[Merged by Bors] - doc: remove obsolete note about mk_iff

### DIFF
--- a/Mathlib/Order/RelClasses.lean
+++ b/Mathlib/Order/RelClasses.lean
@@ -237,7 +237,6 @@ instance (priority := 100) isStrictTotalOrder_of_isStrictTotalOrder [IsStrictTot
 /-! ### Well-order -/
 
 
--- Porting note: no `mk_iff` yet, so hard-coded iff
 /-- A well-founded relation. Not to be confused with `isWellOrder`. -/
 @[mk_iff] class IsWellFounded (α : Type u) (r : α → α → Prop) : Prop where
   /-- The relation is `WellFounded`, as a proposition. -/


### PR DESCRIPTION
This note was added in #560. Since then, `@[mk_iff]` was implemented in #561, and was added to `IsWellFounded` in #663.