### PR TITLE
[Merged by Bors] - feat: port data.finite.defs

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -41,6 +41,7 @@ import Mathlib.Data.Char
 import Mathlib.Data.Equiv.Functor
 import Mathlib.Data.Fin.Basic
 import Mathlib.Data.Fin.Fin2
+import Mathlib.Data.Finite.Defs
 import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Fintype.Basic
 import Mathlib.Data.FunLike.Basic

--- a/Mathlib/Data/Finite/Defs.lean
+++ b/Mathlib/Data/Finite/Defs.lean
@@ -116,7 +116,7 @@ instance {α : Type v} [Infinite α] : Infinite (ULift.{u} α) :=
   Equiv.ulift.infinite_iff.2 ‹_›
 
 theorem finite_orInfinite (α : Sort _) : Finite α ∨ Infinite α :=
-  or_iff_not_imp_left.2 <| notFinite_iff_infinite.1
+  or_iff_not_imp_left.2 notFinite_iff_infinite.1
 #align finite_or_infinite finite_orInfinite
 
 /-- `Infinite α` is not `Finite`-/

--- a/Mathlib/Data/Finite/Defs.lean
+++ b/Mathlib/Data/Finite/Defs.lean
@@ -91,21 +91,22 @@ instance {α : Type v} [Finite α] : Finite (ULift.{u} α) :=
 /-- A type is said to be infinite if it is not finite. Note that `Infinite α` is equivalent to
 `isEmpty (Fintype α)` or `isEmpty (Finite α)`. -/
 class Infinite (α : Sort _) : Prop where
-  not_finite : ¬Finite α
+  /-- assertion that `α` is `¬Finite`-/
+  notFinite : ¬Finite α
 #align infinite Infinite
 
 @[simp]
-theorem not_finite_iff_infinite : ¬Finite α ↔ Infinite α :=
+theorem notFinite_iff_infinite : ¬Finite α ↔ Infinite α :=
   ⟨Infinite.mk, fun h => h.1⟩
-#align not_finite_iff_infinite not_finite_iff_infinite
+#align not_finite_iff_infinite notFinite_iff_infinite
 
 @[simp]
 theorem not_infinite_iff_finite : ¬Infinite α ↔ Finite α :=
-  not_finite_iff_infinite.not_right.symm
+  notFinite_iff_infinite.not_right.symm
 #align not_infinite_iff_finite not_infinite_iff_finite
 
 theorem Equiv.infinite_iff (e : α ≃ β) : Infinite α ↔ Infinite β :=
-  not_finite_iff_infinite.symm.trans <| e.finite_iff.not.trans not_finite_iff_infinite
+  notFinite_iff_infinite.symm.trans <| e.finite_iff.not.trans notFinite_iff_infinite
 #align equiv.infinite_iff Equiv.infinite_iff
 
 instance [Infinite α] : Infinite (PLift α) :=
@@ -114,13 +115,13 @@ instance [Infinite α] : Infinite (PLift α) :=
 instance {α : Type v} [Infinite α] : Infinite (ULift.{u} α) :=
   Equiv.ulift.infinite_iff.2 ‹_›
 
-theorem finite_or_infinite (α : Sort _) : Finite α ∨ Infinite α :=
-  or_iff_not_imp_left.2 <| not_finite_iff_infinite.1
-#align finite_or_infinite finite_or_infinite
+theorem finite_orInfinite (α : Sort _) : Finite α ∨ Infinite α :=
+  or_iff_not_imp_left.2 <| notFinite_iff_infinite.1
+#align finite_or_infinite finite_orInfinite
 
 /-- `Infinite α` is not `Finite`-/
 theorem notFinite (α : Sort _) [Infinite α] [Finite α] : False :=
-  @Infinite.not_finite α ‹_› ‹_›
+  @Infinite.notFinite α ‹_› ‹_›
 #align not_finite notFinite
 
 protected theorem Finite.false [Infinite α] (_ : Finite α) : False :=
@@ -132,4 +133,3 @@ protected theorem Infinite.false [Finite α] (_ : Infinite α) : False :=
 #align infinite.false Infinite.false
 
 alias not_infinite_iff_finite ↔ Finite.of_not_infinite Finite.not_infinite
-

--- a/Mathlib/Data/Finite/Defs.lean
+++ b/Mathlib/Data/Finite/Defs.lean
@@ -129,7 +129,7 @@ protected theorem Finite.false [Infinite α] (_ : Finite α) : False :=
 #align finite.false Finite.false
 
 protected theorem Infinite.false [Finite α] (_ : Infinite α) : False :=
-  notFinite α
+  @Infinite.notFinite α ‹_› ‹_›
 #align infinite.false Infinite.false
 
 alias not_infinite_iff_finite ↔ Finite.of_not_infinite Finite.not_infinite

--- a/Mathlib/Data/Finite/Defs.lean
+++ b/Mathlib/Data/Finite/Defs.lean
@@ -92,21 +92,21 @@ instance {α : Type v} [Finite α] : Finite (ULift.{u} α) :=
 `isEmpty (Fintype α)` or `isEmpty (Finite α)`. -/
 class Infinite (α : Sort _) : Prop where
   /-- assertion that `α` is `¬Finite`-/
-  notFinite : ¬Finite α
+  not_finite : ¬Finite α
 #align infinite Infinite
 
 @[simp]
-theorem notFinite_iff_infinite : ¬Finite α ↔ Infinite α :=
+theorem not_finite_iff_infinite : ¬Finite α ↔ Infinite α :=
   ⟨Infinite.mk, fun h => h.1⟩
-#align not_finite_iff_infinite notFinite_iff_infinite
+#align not_finite_iff_infinite not_finite_iff_infinite
 
 @[simp]
 theorem not_infinite_iff_finite : ¬Infinite α ↔ Finite α :=
-  notFinite_iff_infinite.not_right.symm
+  not_finite_iff_infinite.not_right.symm
 #align not_infinite_iff_finite not_infinite_iff_finite
 
 theorem Equiv.infinite_iff (e : α ≃ β) : Infinite α ↔ Infinite β :=
-  notFinite_iff_infinite.symm.trans <| e.finite_iff.not.trans notFinite_iff_infinite
+  not_finite_iff_infinite.symm.trans <| e.finite_iff.not.trans not_finite_iff_infinite
 #align equiv.infinite_iff Equiv.infinite_iff
 
 instance [Infinite α] : Infinite (PLift α) :=
@@ -116,20 +116,20 @@ instance {α : Type v} [Infinite α] : Infinite (ULift.{u} α) :=
   Equiv.ulift.infinite_iff.2 ‹_›
 
 theorem finite_orInfinite (α : Sort _) : Finite α ∨ Infinite α :=
-  or_iff_not_imp_left.2 notFinite_iff_infinite.1
+  or_iff_not_imp_left.2 not_finite_iff_infinite.1
 #align finite_or_infinite finite_orInfinite
 
 /-- `Infinite α` is not `Finite`-/
-theorem notFinite (α : Sort _) [Infinite α] [Finite α] : False :=
-  @Infinite.notFinite α ‹_› ‹_›
-#align not_finite notFinite
+theorem not_finite (α : Sort _) [Infinite α] [Finite α] : False :=
+  @Infinite.not_finite α ‹_› ‹_›
+#align not_finite not_finite
 
 protected theorem Finite.false [Infinite α] (_ : Finite α) : False :=
-  notFinite α
+  not_finite α
 #align finite.false Finite.false
 
 protected theorem Infinite.false [Finite α] (_ : Infinite α) : False :=
-  @Infinite.notFinite α ‹_› ‹_›
+  @Infinite.not_finite α ‹_› ‹_›
 #align infinite.false Infinite.false
 
 alias not_infinite_iff_finite ↔ Finite.of_not_infinite Finite.not_infinite

--- a/Mathlib/Data/Finite/Defs.lean
+++ b/Mathlib/Data/Finite/Defs.lean
@@ -115,9 +115,9 @@ instance [Infinite α] : Infinite (PLift α) :=
 instance {α : Type v} [Infinite α] : Infinite (ULift.{u} α) :=
   Equiv.ulift.infinite_iff.2 ‹_›
 
-theorem finite_orInfinite (α : Sort _) : Finite α ∨ Infinite α :=
+theorem finite_or_infinite (α : Sort _) : Finite α ∨ Infinite α :=
   or_iff_not_imp_left.2 not_finite_iff_infinite.1
-#align finite_or_infinite finite_orInfinite
+#align finite_or_infinite finite_or_infinite
 
 /-- `Infinite α` is not `Finite`-/
 theorem not_finite (α : Sort _) [Infinite α] [Finite α] : False :=

--- a/Mathlib/Data/Finite/Defs.lean
+++ b/Mathlib/Data/Finite/Defs.lean
@@ -6,7 +6,7 @@ Authors: Kyle Miller
 import Mathlib.Logic.Equiv.Basic
 
 /-!
-# Definition of the `finite` typeclass
+# Definition of the `Finite` typeclass
 
 This file defines a typeclass `Finite` saying that `α : Sort*` is finite. A type is `Finite` if it
 is equivalent to `Fin n` for some `n`. We also define `Infinite α` as a typeclass equivalent to

--- a/Mathlib/Data/Finite/Defs.lean
+++ b/Mathlib/Data/Finite/Defs.lean
@@ -89,7 +89,7 @@ instance {α : Type v} [Finite α] : Finite (ULift.{u} α) :=
   Finite.of_equiv α Equiv.ulift.symm
 
 /-- A type is said to be infinite if it is not finite. Note that `Infinite α` is equivalent to
-`isEmpty (Fintype α)` or `isEmpty (Finite α)`. -/
+`IsEmpty (Fintype α)` or `IsEmpty (Finite α)`. -/
 class Infinite (α : Sort _) : Prop where
   /-- assertion that `α` is `¬Finite`-/
   not_finite : ¬Finite α

--- a/Mathlib/Data/Finite/Defs.lean
+++ b/Mathlib/Data/Finite/Defs.lean
@@ -1,0 +1,135 @@
+/-
+Copyright (c) 2022 Kyle Miller. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kyle Miller
+-/
+import Mathlib.Logic.Equiv.Basic
+
+/-!
+# Definition of the `finite` typeclass
+
+This file defines a typeclass `Finite` saying that `α : Sort*` is finite. A type is `Finite` if it
+is equivalent to `Fin n` for some `n`. We also define `Infinite α` as a typeclass equivalent to
+`¬Finite α`.
+
+The `Finite` predicate has no computational relevance and, being `Prop`-valued, gets to enjoy proof
+irrelevance -- it represents the mere fact that the type is finite.  While the `Finite` class also
+represents finiteness of a type, a key difference is that a `Fintype` instance represents finiteness
+in a computable way: it gives a concrete algorithm to produce a `Finset` whose elements enumerate
+the terms of the given type. As such, one generally relies on congruence lemmas when rewriting
+expressions involving `Fintype` instances.
+
+Every `Fintype` instance automatically gives a `Finite` instance, see `Fintype.finite`, but not vice
+versa. Every `Fintype` instance should be computable since they are meant for computation. If it's
+not possible to write a computable `Fintype` instance, one should prefer writing a `Finite` instance
+instead.
+
+## Main definitions
+
+* `Finite α` denotes that `α` is a finite type.
+* `Infinite α` denotes that `α` is an infinite type.
+
+## Implementation notes
+
+The definition of `Finite α` is not just `NonEmpty (Fintype α)` since `Fintype` requires
+that `α : Type*`, and the definition in this module allows for `α : Sort*`. This means
+we can write the instance `Finite.prop`.
+
+## Tags
+
+finite, fintype
+-/
+
+
+universe u v
+
+open Function
+
+variable {α β : Sort _}
+
+/-- A type is `Finite` if it is in bijective correspondence to some
+`Fin n`.
+
+While this could be defined as `NonEmpty (Fintype α)`, it is defined
+in this way to allow there to be `Finite` instances for propositions.
+-/
+class inductive Finite (α : Sort _) : Prop
+  | intro {n : ℕ} : α ≃ Fin n → Finite _
+#align finite Finite
+
+theorem finite_iff_exists_equiv_fin {α : Sort _} : Finite α ↔ ∃ n, Nonempty (α ≃ Fin n) :=
+  ⟨fun ⟨e⟩ => ⟨_, ⟨e⟩⟩, fun ⟨_, ⟨e⟩⟩ => ⟨e⟩⟩
+#align finite_iff_exists_equiv_fin finite_iff_exists_equiv_fin
+
+theorem Finite.exists_equiv_fin (α : Sort _) [h : Finite α] : ∃ n : ℕ, Nonempty (α ≃ Fin n) :=
+  finite_iff_exists_equiv_fin.mp h
+#align finite.exists_equiv_fin Finite.exists_equiv_fin
+
+theorem Finite.of_equiv (α : Sort _) [h : Finite α] (f : α ≃ β) : Finite β := by
+  cases' h with n e
+  exact Finite.intro (f.symm.trans e)
+#align finite.of_equiv Finite.of_equiv
+
+theorem Equiv.finite_iff (f : α ≃ β) : Finite α ↔ Finite β :=
+  ⟨fun _ => Finite.of_equiv _ f, fun _ => Finite.of_equiv _ f.symm⟩
+#align equiv.finite_iff Equiv.finite_iff
+
+theorem Function.Bijective.finite_iff {f : α → β} (h : Bijective f) : Finite α ↔ Finite β :=
+  (Equiv.ofBijective f h).finite_iff
+#align function.bijective.finite_iff Function.Bijective.finite_iff
+
+theorem Finite.ofBijective [Finite α] {f : α → β} (h : Bijective f) : Finite β :=
+  h.finite_iff.mp ‹_›
+#align finite.of_bijective Finite.ofBijective
+
+instance [Finite α] : Finite (PLift α) :=
+  Finite.of_equiv α Equiv.plift.symm
+
+instance {α : Type v} [Finite α] : Finite (ULift.{u} α) :=
+  Finite.of_equiv α Equiv.ulift.symm
+
+/-- A type is said to be infinite if it is not finite. Note that `Infinite α` is equivalent to
+`isEmpty (Fintype α)` or `isEmpty (Finite α)`. -/
+class Infinite (α : Sort _) : Prop where
+  not_finite : ¬Finite α
+#align infinite Infinite
+
+@[simp]
+theorem not_finite_iff_infinite : ¬Finite α ↔ Infinite α :=
+  ⟨Infinite.mk, fun h => h.1⟩
+#align not_finite_iff_infinite not_finite_iff_infinite
+
+@[simp]
+theorem not_infinite_iff_finite : ¬Infinite α ↔ Finite α :=
+  not_finite_iff_infinite.not_right.symm
+#align not_infinite_iff_finite not_infinite_iff_finite
+
+theorem Equiv.infinite_iff (e : α ≃ β) : Infinite α ↔ Infinite β :=
+  not_finite_iff_infinite.symm.trans <| e.finite_iff.not.trans not_finite_iff_infinite
+#align equiv.infinite_iff Equiv.infinite_iff
+
+instance [Infinite α] : Infinite (PLift α) :=
+  Equiv.plift.infinite_iff.2 ‹_›
+
+instance {α : Type v} [Infinite α] : Infinite (ULift.{u} α) :=
+  Equiv.ulift.infinite_iff.2 ‹_›
+
+theorem finite_or_infinite (α : Sort _) : Finite α ∨ Infinite α :=
+  or_iff_not_imp_left.2 <| not_finite_iff_infinite.1
+#align finite_or_infinite finite_or_infinite
+
+/-- `Infinite α` is not `Finite`-/
+theorem notFinite (α : Sort _) [Infinite α] [Finite α] : False :=
+  @Infinite.not_finite α ‹_› ‹_›
+#align not_finite notFinite
+
+protected theorem Finite.false [Infinite α] (_ : Finite α) : False :=
+  notFinite α
+#align finite.false Finite.false
+
+protected theorem Infinite.false [Finite α] (_ : Infinite α) : False :=
+  notFinite α
+#align infinite.false Infinite.false
+
+alias not_infinite_iff_finite ↔ Finite.of_not_infinite Finite.not_infinite
+


### PR DESCRIPTION
Ports `data.finite.defs` with renaming to address `Mathlib4` naming conventions

Based on `mathlib` e50b8c261b0a000b806ec0e1356b41945eda61f7