### PR TITLE
[Merged by Bors] - chore: enable bots

### DIFF
--- a/.github/workflows/add_label_from_comment.yml
+++ b/.github/workflows/add_label_from_comment.yml
@@ -1,0 +1,143 @@
+name: Add "ready-to-merge" and "delegated" label from comment
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  add_ready_to_merge_label:
+    name: Add ready-to-merge label
+    if: (toJSON(github.event.issue.pull_request) != 'null') && (startsWith(github.event.comment.body, 'bors r+') || contains(toJSON(github.event.comment.body), '\r\nbors r+') || startsWith(github.event.comment.body, 'bors merge') || contains(toJSON(github.event.comment.body), '\r\nbors merge'))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: octokit/request-action@v2.x
+        name: Get PR head
+        id: get_pr_head
+        with:
+          route: GET /repos/:repository/pulls/:pull_number
+          repository: ${{ github.repository }}
+          pull_number: ${{ github.event.issue.number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Parse steps.get_pr_head.outputs.data, since it is a string
+      - id: parse_pr_head
+        name: Parse PR head
+        uses: gr2m/get-json-paths-action@v1.x
+        with:
+          json: ${{ steps.get_pr_head.outputs.data }}
+          head_user: 'head.user.login'
+
+      # we skip the rest if this PR is from a fork,
+      # since the GITHUB_TOKEN doesn't have write perms
+      - if: steps.parse_pr_head.outputs.head_user == 'leanprover-community'
+        uses: octokit/request-action@v2.x
+        name: Get comment author
+        id: get_user
+        with:
+          route: GET /repos/:repository/collaborators/:username/permission
+          repository: ${{ github.repository }}
+          username: ${{ github.event.comment.user.login }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Parse steps.get_user.outputs.data, since it is a string
+      - if: steps.parse_pr_head.outputs.head_user == 'leanprover-community'
+        id: parse_user
+        name: Parse comment author permission
+        uses: gr2m/get-json-paths-action@v1.x
+        with:
+          json: ${{ steps.get_user.outputs.data }}
+          permission: 'permission'
+
+      - if: (steps.parse_pr_head.outputs.head_user == 'leanprover-community') && (steps.parse_user.outputs.permission == 'admin')
+        uses: octokit/request-action@v2.x
+        id: add_label
+        name: Add label
+        with:
+          route: POST /repos/:repository/issues/:issue_number/labels
+          repository: ${{ github.repository }}
+          issue_number: ${{ github.event.issue.number }}
+          labels: '["ready-to-merge"]'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - if: (steps.parse_pr_head.outputs.head_user == 'leanprover-community') && (steps.parse_user.outputs.permission == 'admin')
+        id: remove_labels
+        name: Remove "awaiting-review" and "awaiting-author"
+        # we use curl rather than octokit/request-action so that the job won't fail
+        # (and send an annoying email) if the labels don't exist
+        run: |
+          curl --request DELETE \
+            --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/labels/awaiting-review \
+            --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
+          curl --request DELETE \
+            --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/labels/awaiting-author \
+            --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
+
+  add_delegated_label:
+    name: Add delegated label
+    if: (toJSON(github.event.issue.pull_request) != 'null') && (startsWith(github.event.comment.body, 'bors d') || contains(toJSON(github.event.comment.body), '\r\nbors d'))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: octokit/request-action@v2.x
+        name: Get PR head
+        id: get_pr_head
+        with:
+          route: GET /repos/:repository/pulls/:pull_number
+          repository: ${{ github.repository }}
+          pull_number: ${{ github.event.issue.number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Parse steps.get_pr_head.outputs.data, since it is a string
+      - id: parse_pr_head
+        name: Parse PR head
+        uses: gr2m/get-json-paths-action@v1.x
+        with:
+          json: ${{ steps.get_pr_head.outputs.data }}
+          head_user: 'head.user.login'
+
+      # we skip the rest if this PR is from a fork,
+      # since the GITHUB_TOKEN doesn't have write perms
+      - if: steps.parse_pr_head.outputs.head_user == 'leanprover-community'
+        uses: octokit/request-action@v2.x
+        name: Get comment author
+        id: get_user
+        with:
+          route: GET /repos/:repository/collaborators/:username/permission
+          repository: ${{ github.repository }}
+          username: ${{ github.event.comment.user.login }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Parse steps.get_user.outputs.data, since it is a string
+      - if: steps.parse_pr_head.outputs.head_user == 'leanprover-community'
+        id: parse_user
+        name: Parse comment author permission
+        uses: gr2m/get-json-paths-action@v1.x
+        with:
+          json: ${{ steps.get_user.outputs.data }}
+          permission: 'permission'
+
+      - if: (steps.parse_pr_head.outputs.head_user == 'leanprover-community') && (steps.parse_user.outputs.permission == 'admin')
+        uses: octokit/request-action@v2.x
+        id: add_label
+        name: Add label
+        with:
+          route: POST /repos/:repository/issues/:issue_number/labels
+          repository: ${{ github.repository }}
+          issue_number: ${{ github.event.issue.number }}
+          labels: '["delegated"]'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - if: (steps.parse_pr_head.outputs.head_user == 'leanprover-community') && (steps.parse_user.outputs.permission == 'admin')
+        id: remove_labels
+        name: Remove "awaiting-review"
+        # we use curl rather than octokit/request-action so that the job won't fail
+        # (and send an annoying email) if the labels don't exist
+        run: |
+          curl --request DELETE \
+            --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/labels/awaiting-review \
+            --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/add_label_from_review.yml
+++ b/.github/workflows/add_label_from_review.yml
@@ -1,0 +1,143 @@
+name: Add "ready-to-merge" and "delegated" label from PR review
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  add_ready_to_merge_label:
+    name: Add ready-to-merge label
+    if: (startsWith(github.event.review.body, 'bors r+') || contains(toJSON(github.event.review.body), '\r\nbors r+') || startsWith(github.event.review.body, 'bors merge') || contains(toJSON(github.event.review.body), '\r\nbors merge'))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: octokit/request-action@v2.x
+        name: Get PR head
+        id: get_pr_head
+        with:
+          route: GET /repos/:repository/pulls/:pull_number
+          repository: ${{ github.repository }}
+          pull_number: ${{ github.event.pull_request.number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.TRIAGE_TOKEN }}
+
+      # Parse steps.get_pr_head.outputs.data, since it is a string
+      - id: parse_pr_head
+        name: Parse PR head
+        uses: gr2m/get-json-paths-action@v1.x
+        with:
+          json: ${{ steps.get_pr_head.outputs.data }}
+          head_user: 'head.user.login'
+
+      # we skip the rest if this PR is from a fork,
+      # since the GITHUB_TOKEN doesn't have write perms
+      - if: steps.parse_pr_head.outputs.head_user == 'leanprover-community'
+        uses: octokit/request-action@v2.x
+        name: Get comment author
+        id: get_user
+        with:
+          route: GET /repos/:repository/collaborators/:username/permission
+          repository: ${{ github.repository }}
+          username: ${{ github.event.review.user.login }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.TRIAGE_TOKEN }}
+
+      # Parse steps.get_user.outputs.data, since it is a string
+      - if: steps.parse_pr_head.outputs.head_user == 'leanprover-community'
+        id: parse_user
+        name: Parse comment author permission
+        uses: gr2m/get-json-paths-action@v1.x
+        with:
+          json: ${{ steps.get_user.outputs.data }}
+          permission: 'permission'
+
+      - if: (steps.parse_pr_head.outputs.head_user == 'leanprover-community') && (steps.parse_user.outputs.permission == 'admin')
+        uses: octokit/request-action@v2.x
+        id: add_label
+        name: Add label
+        with:
+          route: POST /repos/:repository/issues/:issue_number/labels
+          repository: ${{ github.repository }}
+          issue_number: ${{ github.event.pull_request.number }}
+          labels: '["ready-to-merge"]'
+        env:
+          GITHUB_TOKEN: ${{ secrets.TRIAGE_TOKEN }}
+
+      - if: (steps.parse_pr_head.outputs.head_user == 'leanprover-community') && (steps.parse_user.outputs.permission == 'admin')
+        id: remove_labels
+        name: Remove "awaiting-review" and "awaiting-author"
+        # we use curl rather than octokit/request-action so that the job won't fail
+        # (and send an annoying email) if the labels don't exist
+        run: |
+          curl --request DELETE \
+            --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/awaiting-review \
+            --header 'authorization: Bearer ${{ secrets.TRIAGE_TOKEN }}'
+          curl --request DELETE \
+            --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/awaiting-author \
+            --header 'authorization: Bearer ${{ secrets.TRIAGE_TOKEN }}'
+
+  add_delegated_label:
+    name: Add delegated label
+    if: (startsWith(github.event.review.body, 'bors d') || contains(toJSON(github.event.review.body), '\r\nbors d'))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: octokit/request-action@v2.x
+        name: Get PR head
+        id: get_pr_head
+        with:
+          route: GET /repos/:repository/pulls/:pull_number
+          repository: ${{ github.repository }}
+          pull_number: ${{ github.event.pull_request.number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.TRIAGE_TOKEN }}
+
+      # Parse steps.get_pr_head.outputs.data, since it is a string
+      - id: parse_pr_head
+        name: Parse PR head
+        uses: gr2m/get-json-paths-action@v1.x
+        with:
+          json: ${{ steps.get_pr_head.outputs.data }}
+          head_user: 'head.user.login'
+
+      # we skip the rest if this PR is from a fork,
+      # since the GITHUB_TOKEN doesn't have write perms
+      - if: steps.parse_pr_head.outputs.head_user == 'leanprover-community'
+        uses: octokit/request-action@v2.x
+        name: Get comment author
+        id: get_user
+        with:
+          route: GET /repos/:repository/collaborators/:username/permission
+          repository: ${{ github.repository }}
+          username: ${{ github.event.review.user.login }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.TRIAGE_TOKEN }}
+
+      # Parse steps.get_user.outputs.data, since it is a string
+      - if: steps.parse_pr_head.outputs.head_user == 'leanprover-community'
+        id: parse_user
+        name: Parse comment author permission
+        uses: gr2m/get-json-paths-action@v1.x
+        with:
+          json: ${{ steps.get_user.outputs.data }}
+          permission: 'permission'
+
+      - if: (steps.parse_pr_head.outputs.head_user == 'leanprover-community') && (steps.parse_user.outputs.permission == 'admin')
+        uses: octokit/request-action@v2.x
+        id: add_label
+        name: Add label
+        with:
+          route: POST /repos/:repository/issues/:issue_number/labels
+          repository: ${{ github.repository }}
+          issue_number: ${{ github.event.pull_request.number }}
+          labels: '["delegated"]'
+        env:
+          GITHUB_TOKEN: ${{ secrets.TRIAGE_TOKEN }}
+
+      - if: (steps.parse_pr_head.outputs.head_user == 'leanprover-community') && (steps.parse_user.outputs.permission == 'admin')
+        id: remove_labels
+        name: Remove "awaiting-review"
+        # we use curl rather than octokit/request-action so that the job won't fail
+        # (and send an annoying email) if the labels don't exist
+        run: |
+          curl --request DELETE \
+            --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/awaiting-review \
+            --header 'authorization: Bearer ${{ secrets.TRIAGE_TOKEN }}'

--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -1,0 +1,35 @@
+name: Dependent Issues
+
+on:
+  schedule:
+    - cron: '*/15 * * * *' # run every 15 minutes
+
+jobs:
+  cancel:
+    name: 'Cancel Previous Runs (dependent issues)'
+    runs-on: ubuntu-latest
+    # timeout-minutes: 3
+    steps:
+      - uses: styfle/cancel-workflow-action@0.9.0
+        with:
+          all_but_latest: true
+          access_token: ${{ github.token }}
+
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: z0al/dependent-issues@v1
+        env:
+          # (Required) The token to use to make API calls to GitHub.
+          GITHUB_TOKEN: ${{ secrets.DEPENDENT_ISSUES_TOKEN }}
+        with:
+          # (Optional) The label to use to mark dependent issues
+          label: blocked-by-other-PR
+
+          # (Optional) Enable checking for dependencies in issues. Enable by
+          # setting the value to "on". Default "off"
+          check_issues: off
+
+          # (Optional) A comma-separated list of keywords. Default
+          # "depends on, blocked by"
+          keywords: "- \\[ \\] depends on:,- \\[x\\] depends on:"

--- a/.github/workflows/maintainer_merge_comment.yml
+++ b/.github/workflows/maintainer_merge_comment.yml
@@ -1,0 +1,42 @@
+name: Maintainer merge (comment)
+
+on:
+  issue_comment:
+    types: [created, edited]
+
+jobs:
+  ping_zulip:
+    name: Ping maintainers on Zulip
+    if: (github.event.issue.pull_request != 'null') && (startsWith(github.event.comment.body, 'maintainer merge') || contains(toJSON(github.event.comment.body), '\r\nmaintainer merge'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check whether user is part of mathlib-reviewers team
+        uses: TheModdingInquisition/actions-team-membership@v1.0
+        with:
+          organization: 'leanprover-community'
+          team: 'mathlib-reviewers' # required. The team to check for
+          token: ${{ secrets.MATHLIB_REVIEWERS_TEAM_KEY }} # required. Personal Access Token with the `read:org` permission
+          comment: 'You seem to not be authorized' # optional. A comment to post if the user is not part of the team.
+                                                  # This feature is only applicable in an issue (or PR) context
+          exit: true # optional. If the action should exit if the user is not part of the team. Defaults to true.
+
+      - name: Send message on Zulip
+        uses: zulip/github-actions-zulip/send-message@v1
+        with:
+          api-key: ${{ secrets.ZULIP_API_KEY }}
+          email: 'github-bot@leanprover.zulipchat.com'
+          organization-url: 'https://leanprover.zulipchat.com'
+          to: 'mathlib reviewers'
+          type: 'stream'
+          topic: 'maintainer merge'
+          content: |
+            ${{ format('{0} requested a maintainer merge on PR #{1}:', github.event.comment.user.login, github.event.issue.number) }}
+
+            > ${{ github.event.issue.title }}
+
+      - name: Add comment to PR
+        uses: GrantBirki/comment@v2.0.1
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            🚀 Pull request has been placed on the maintainer queue by ${{ github.event.comment.user.login }}.

--- a/.github/workflows/maintainer_merge_review.yml
+++ b/.github/workflows/maintainer_merge_review.yml
@@ -1,0 +1,40 @@
+name: Maintainer merge (review)
+
+on:
+  pull_request_review:
+    types: [submitted, edited]
+
+jobs:
+  ping_zulip:
+    name: Ping maintainers on Zulip
+    if: (github.event.issue.pull_request != 'null') && (startsWith(github.event.review.body, 'maintainer merge') || contains(toJSON(github.event.review.body), '\r\nmaintainer merge'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check whether user is part of mathlib-reviewers team
+        uses: TheModdingInquisition/actions-team-membership@v1.0
+        with:
+          organization: 'leanprover-community'
+          team: 'mathlib-reviewers' # required. The team to check for
+          token: ${{ secrets.MATHLIB_REVIEWERS_TEAM_KEY }} # required. Personal Access Token with the `read:org` permission
+          exit: true # optional. If the action should exit if the user is not part of the team. Defaults to true.
+
+      - name: Send message on Zulip
+        uses: zulip/github-actions-zulip/send-message@v1
+        with:
+          api-key: ${{ secrets.ZULIP_API_KEY }}
+          email: 'github-bot@leanprover.zulipchat.com'
+          organization-url: 'https://leanprover.zulipchat.com'
+          to: 'mathlib reviewers'
+          type: 'stream'
+          topic: 'maintainer merge'
+          content: |
+            ${{ format('{0} requested a maintainer merge on PR #{1}:', github.event.review.user.login, github.event.pull_request.number) }}
+
+            > ${{ github.event.pull_request.title }}
+
+      - name: Add comment to PR
+        uses: GrantBirki/comment@v2.0.1
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            🚀 Pull request has been placed on the maintainer queue by ${{ github.event.review.user.login }}.

--- a/.github/workflows/maintainer_merge_review_comment.yml
+++ b/.github/workflows/maintainer_merge_review_comment.yml
@@ -1,0 +1,40 @@
+name: Maintainer merge (review comment)
+
+on:
+  pull_request_review_comment:
+    types: [created, edited]
+
+jobs:
+  ping_zulip:
+    name: Ping maintainers on Zulip
+    if: (github.event.issue.pull_request != 'null') && (startsWith(github.event.comment.body, 'maintainer merge') || contains(toJSON(github.event.comment.body), '\r\nmaintainer merge'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check whether user is part of mathlib-reviewers team
+        uses: TheModdingInquisition/actions-team-membership@v1.0
+        with:
+          organization: 'leanprover-community'
+          team: 'mathlib-reviewers' # required. The team to check for
+          token: ${{ secrets.MATHLIB_REVIEWERS_TEAM_KEY }} # required. Personal Access Token with the `read:org` permission
+          exit: true # optional. If the action should exit if the user is not part of the team. Defaults to true.
+
+      - name: Send message on Zulip
+        uses: zulip/github-actions-zulip/send-message@v1
+        with:
+          api-key: ${{ secrets.ZULIP_API_KEY }}
+          email: 'github-bot@leanprover.zulipchat.com'
+          organization-url: 'https://leanprover.zulipchat.com'
+          to: 'mathlib reviewers'
+          type: 'stream'
+          topic: 'maintainer merge'
+          content: |
+            ${{ format('{0} requested a maintainer merge on PR #{1}:', github.event.comment.user.login, github.event.pull_request.number) }}
+
+            > ${{ github.event.pull_request.title }}
+
+      - name: Add comment to PR
+        uses: GrantBirki/comment@v2.0.1
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            🚀 Pull request has been placed on the maintainer queue by ${{ github.event.comment.user.login }}.

--- a/.github/workflows/merge_conflicts.yml
+++ b/.github/workflows/merge_conflicts.yml
@@ -1,0 +1,15 @@
+name: Merge conflicts
+
+on:
+  schedule:
+    - cron: '*/15 * * * *' # run every 15 minutes
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: check if prs are dirty
+        uses: eps1lon/actions-label-merge-conflict@releases/2.x
+        with:
+          dirtyLabel: "merge-conflict"
+          repoToken: "${{ secrets.MERGE_CONFLICTS_TOKEN }}"

--- a/.github/workflows/sync_closed_tasks.yaml
+++ b/.github/workflows/sync_closed_tasks.yaml
@@ -1,0 +1,18 @@
+name: Cross off linked issues
+
+on:
+  # the closed event type causes unchecked checkbox references to be checked / marked complete
+  # the reopened event type causes checked checkbox references to be unchecked / marked incomplete
+  issues:
+    types: [closed, reopened]
+
+  # the action works on pull request events as well
+  pull_request:
+    types: [closed, reopened]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cross off any linked issue and PR references
+        uses: jonabc/sync-task-issues@v1


### PR DESCRIPTION
This copies across all the bots we had running on mathlib, in particular:

* the bot that adds and removes `ready-to-merge` and `delegated`
* the merge conflicts bot
* the dependent issues bots (adding the dependent issues tag, and ticking off closed issues)
* the maintainer merge bot

I think I have added appropriate github secrets that allow these bots to run. Presumably after we merge this we should exercise all the bots.