### PR TITLE
[Merged by Bors] - feat: stubs in ad-hoc ported files for linarith algebra requirements

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -82,7 +82,9 @@ import Mathlib.Data.PNat.Defs
 import Mathlib.Data.Prod.Basic
 import Mathlib.Data.Prod.PProd
 import Mathlib.Data.Quot
+import Mathlib.Data.Rat.Defs
 import Mathlib.Data.Rat.Init
+import Mathlib.Data.Rat.Order
 import Mathlib.Data.Sigma.Basic
 import Mathlib.Data.Sigma.Lex
 import Mathlib.Data.String.Defs

--- a/Mathlib/Algebra/Order/Ring.lean
+++ b/Mathlib/Algebra/Order/Ring.lean
@@ -9,7 +9,6 @@ import Mathlib.Algebra.Order.Monoid
 import Mathlib.Algebra.Order.Group
 import Mathlib.Logic.Nontrivial
 
-
 /-!
 # Ordered rings and semirings
 
@@ -104,25 +103,27 @@ We're still missing some typeclasses, like
 They have yet to come up in practice.
 -/
 
+set_option warningAsError false
+
 /-- An `OrderedSemiring α` is a semiring `α` with a partial order such that
 addition is monotone and multiplication by a positive number is strictly monotone. -/
-class OrderedSemiring (α : Type u) extends Semiring α, OrderedCancelAddCommMonoid α where
+class OrderedSemiring (α : Type u) extends Semiring α, OrderedAddCommMonoid α where
   /-- `0 ≤ 1` in any ordered semiring. -/
   zero_le_one : (0 : α) ≤ 1
-  /-- In an ordered semiring, we can multiply an inequality `a < b` on the left
-  by a positive element `0 < c` to obtain `c * a < c * b`. -/
-  mul_lt_mul_of_pos_left : ∀ a b c : α, a < b → 0 < c → c * a < c * b
-  /-- In an ordered semiring, we can multiply an inequality `a < b` on the right
-  by a positive element `0 < c` to obtain `a * c < b * c`. -/
-  mul_lt_mul_of_pos_right : ∀ a b c : α, a < b → 0 < c → a * c < b * c
+  /-- In an ordered semiring, we can multiply an inequality `a ≤ b` on the left
+  by a non-negative element `0 ≤ c` to obtain `c * a ≤ c * b`. -/
+  mul_le_mul_of_nonneg_left  : ∀ a b c : α, a ≤ b → 0 ≤ c → c * a ≤ c * b
+  /-- In an ordered semiring, we can multiply an inequality `a ≤ b` on the right
+  by a non-negative element `0 ≤ c` to obtain `a * c ≤ b * c`. -/
+  mul_le_mul_of_nonneg_right : ∀ a b c : α, a ≤ b → 0 ≤ c → a * c ≤ b * c
 
 /-- An `OrderedRing α` is a ring `α` with a partial order such that
-addition is monotone and multiplication by a positive number is strictly monotone. -/
+addition is monotone and multiplication by a non-negative number is monotone. -/
 class OrderedRing (α : Type u) extends Ring α, OrderedAddCommGroup α where
   /-- `0 ≤ 1` in any ordered ring. -/
   zero_le_one : 0 ≤ (1 : α)
-  /-- The product of positive elements is positive. -/
-  mul_pos : ∀ a b : α, 0 < a → 0 < b → 0 < a * b
+  /-- The product of non-negative elements is non-negative. -/
+  mul_nonneg : ∀ a b : α, 0 ≤ a → 0 ≤ b → 0 ≤ a * b
 
 /-- An `ordered_comm_semiring` is a commutative semiring with a partial order such that addition is
 monotone and multiplication by a nonnegative number is monotone. -/
@@ -181,4 +182,54 @@ class LinearOrderedRing (α : Type u) extends StrictOrderedRing α, LinearOrder 
 monotone and multiplication by a positive number is strictly monotone. -/
 class LinearOrderedCommRing (α : Type u) extends LinearOrderedRing α, CommMonoid α
 
-#print LinearOrderedCommRing.mul_comm
+-- see Note [lower instance priority]
+instance (priority := 100) OrderedRing.toOrderedSemiring [OrderedRing α] : OrderedSemiring α :=
+  { ‹OrderedRing α›, (Ring.toSemiring : Semiring α) with
+    mul_le_mul_of_nonneg_left := sorry,
+    mul_le_mul_of_nonneg_right := sorry }
+
+section StrictOrderedSemiring
+
+variable [StrictOrderedSemiring α]
+
+-- see Note [lower instance priority]
+instance (priority := 100) StrictOrderedSemiring.toOrderedSemiring : OrderedSemiring α :=
+  { ‹StrictOrderedSemiring α› with
+    mul_le_mul_of_nonneg_left := sorry
+    mul_le_mul_of_nonneg_right := sorry }
+
+end StrictOrderedSemiring
+
+section StrictOrderedRing
+
+variable [StrictOrderedRing α]
+
+-- see Note [lower instance priority]
+instance (priority := 100) StrictOrderedRing.toStrictOrderedSemiring : StrictOrderedSemiring α :=
+  { ‹StrictOrderedRing α›, (Ring.toSemiring : Semiring α) with
+    le_of_add_le_add_left := sorry,
+    mul_lt_mul_of_pos_left := sorry,
+    mul_lt_mul_of_pos_right := sorry }
+
+-- see Note [lower instance priority]
+instance (priority := 100) StrictOrderedRing.toOrderedRing : OrderedRing α :=
+  { ‹StrictOrderedRing α› with
+    mul_nonneg := sorry, }
+
+end StrictOrderedRing
+
+section StrictOrderedCommRing
+
+variable [StrictOrderedCommRing α]
+
+-- See note [lower instance priority]
+instance (priority := 100) StrictOrderedCommRing.toStrictOrderedCommSemiring :
+    StrictOrderedCommSemiring α :=
+  { ‹StrictOrderedCommRing α›, StrictOrderedRing.toStrictOrderedSemiring with }
+
+end StrictOrderedCommRing
+
+-- see Note [lower instance priority]
+instance (priority := 100) LinearOrderedCommRing.toStrictOrderedCommRing
+    [d : LinearOrderedCommRing α] : StrictOrderedCommRing α :=
+  { d with }

--- a/Mathlib/Data/Int/Basic.lean
+++ b/Mathlib/Data/Int/Basic.lean
@@ -50,6 +50,9 @@ instance : Distrib ℤ          := by infer_instance
 #align int.neg_succ_mul_coe_nat Int.negSucc_mul_ofNat
 #align int.neg_succ_mul_neg_succ Int.negSucc_mul_negSucc
 
+instance : Nontrivial ℤ :=
+  ⟨⟨0, 1, Int.zero_ne_one⟩⟩
+
 @[simp, norm_cast] theorem coe_nat_le {m n : ℕ} : (↑m : ℤ) ≤ ↑n ↔ m ≤ n := ofNat_le
 #align int.coe_nat_le Int.coe_nat_le
 

--- a/Mathlib/Data/Int/Basic.lean
+++ b/Mathlib/Data/Int/Basic.lean
@@ -50,9 +50,6 @@ instance : Distrib ℤ          := by infer_instance
 #align int.neg_succ_mul_coe_nat Int.negSucc_mul_ofNat
 #align int.neg_succ_mul_neg_succ Int.negSucc_mul_negSucc
 
-instance : Nontrivial ℤ :=
-  ⟨⟨0, 1, Int.zero_ne_one⟩⟩
-
 @[simp, norm_cast] theorem coe_nat_le {m n : ℕ} : (↑m : ℤ) ≤ ↑n ↔ m ≤ n := ofNat_le
 #align int.coe_nat_le Int.coe_nat_le
 

--- a/Mathlib/Data/Int/Order/Basic.lean
+++ b/Mathlib/Data/Int/Order/Basic.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad
 -/
 import Mathlib.Data.Int.Basic
+import Mathlib.Algebra.Order.Ring
 
 /-!
 # Order instances on the integers
@@ -22,7 +23,20 @@ This file contains:
   induction on numbers less than `b`.
 -/
 
+set_option warningAsError false
+
 namespace Int
+
+instance : LinearOrderedCommRing ℤ where
+  mul_comm := sorry
+  add_le_add_left := sorry
+  zero_le_one := sorry
+  mul_lt_mul_of_pos_left := sorry
+  mul_lt_mul_of_pos_right := sorry
+  le_total := sorry
+  decidable_le := sorry
+  min_def := sorry
+  max_def := sorry
 
 /-- Inductively define a function on `ℤ` by defining it at `b`, for the `succ` of a number greater
 than `b`, and the `pred` of a number less than `b`. -/

--- a/Mathlib/Data/Rat/Defs.lean
+++ b/Mathlib/Data/Rat/Defs.lean
@@ -1,0 +1,40 @@
+/-
+Copyright (c) 2022 Scott Morrison. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Scott Morrison
+-/
+
+import Std.Data.Rat
+import Mathlib.Algebra.Ring.Basic
+
+/-!
+# Stub port for `linarith`.
+-/
+
+set_option warningAsError false
+
+instance : AddCommGroup Rat where
+  add_comm := sorry
+  add_assoc := sorry
+  add_zero := sorry
+  zero_add := sorry
+  sub_eq_add_neg := sorry
+  add_left_neg := sorry
+
+instance : CommRing Rat where
+  left_distrib := sorry
+  right_distrib := sorry
+  sub_eq_add_neg := sorry
+  zero_mul := sorry
+  mul_zero := sorry
+  natCast := (·)
+  natCast_zero := sorry
+  natCast_succ := sorry
+  add_left_neg := sorry
+  intCast := (·)
+  intCast_ofNat := sorry
+  intCast_negSucc := sorry
+  mul_assoc := sorry
+  mul_one := sorry
+  one_mul := sorry
+  mul_comm := sorry

--- a/Mathlib/Data/Rat/Order.lean
+++ b/Mathlib/Data/Rat/Order.lean
@@ -1,0 +1,40 @@
+/-
+Copyright (c) 2022 Scott Morrison. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Scott Morrison
+-/
+import Mathlib.Data.Rat.Defs
+import Mathlib.Algebra.Order.Ring
+
+/-!
+# Stub port for `linarith`.
+-/
+
+set_option warningAsError false
+
+instance : Preorder Rat where
+  le               := (· ≤· )
+  le_refl          := sorry
+  le_trans         := sorry
+  lt_iff_le_not_le := sorry
+
+instance : PartialOrder Rat where
+  le_antisymm := sorry
+
+instance : LinearOrder Rat where
+  min := fun a b => if a ≤ b then a else b
+  max := fun a b => if a ≤ b then b else a
+  le_total := sorry
+  decidable_le := inferInstance
+
+instance : LinearOrderedCommRing Rat where
+  add_le_add_left := sorry
+  zero_le_one := sorry
+  le_total := sorry
+  decidable_le := sorry
+  exists_pair_ne := sorry
+  mul_comm := sorry
+  min_def := sorry
+  max_def := sorry
+  mul_lt_mul_of_pos_left := sorry
+  mul_lt_mul_of_pos_right := sorry

--- a/Mathlib/Tactic/Positivity/Basic.lean
+++ b/Mathlib/Tactic/Positivity/Basic.lean
@@ -25,11 +25,11 @@ open Function
 -- TODO: these classes are mostly nonsense stubs which should be replaced by the real things
 -- when the theory files are ready
 
-instance [OrderedSemiring α] : PosMulStrictMono α :=
-  ⟨fun ⟨_, ha⟩ _ _ h => OrderedSemiring.mul_lt_mul_of_pos_left _ _ _ h ha⟩
+instance [OrderedSemiring α] : PosMulMono α :=
+  ⟨fun ⟨_, ha⟩ _ _ h => OrderedSemiring.mul_le_mul_of_nonneg_left _ _ _ h ha⟩
 
-instance [StrictOrderedRing α] : PosMulStrictMono α :=
-  ⟨fun ⟨_, ha⟩ _ _ h => StrictOrderedRing.mul_lt_mul_of_pos_left _ _ _ h ha⟩
+instance [StrictOrderedSemiring α] : PosMulStrictMono α :=
+  ⟨fun ⟨_, ha⟩ _ _ h => StrictOrderedSemiring.mul_lt_mul_of_pos_left _ _ _ h ha⟩
 
 theorem mul_nonneg_of_pos_of_nonneg [OrderedSemiring α] {a b : α}
     (ha : 0 < a) (hb : 0 ≤ b) : 0 ≤ a * b :=
@@ -133,14 +133,14 @@ such that `positivity` successfully recognises both `a` and `b`. -/
 @[positivity _ * _, Mul.mul _ _] def evalMul : PositivityExt where eval {u α} zα pα e := do
   let .app (.app f (a : Q($α))) (b : Q($α)) ← withReducible (whnf e) | throwError "not *"
   let ra ← core zα pα a; let rb ← core zα pα b
-  let _a ← synthInstanceQ (q(OrderedSemiring $α) : Q(Type u))
+  let _a ← synthInstanceQ (q(StrictOrderedSemiring $α) : Q(Type u))
   guard <|← withDefault <| withNewMCtxDepth <| isDefEq f q(HMul.hMul (α := $α))
   -- FIXME: this code is pretty horrible, we should improve Qq or something
   match ra, rb with
   | .positive pa, .positive pb =>
     have pa' : Q(by clear! «$zα» «$pα»; exact 0 < $a) := pa
     have pb' : Q(by clear! «$zα» «$pα»; exact 0 < $b) := pb
-    pure (.positive (by clear! zα pα; exact q(mul_pos $pa' $pb') : Expr))
+    pure (.positive (by clear! zα pα; exact q(@mul_pos $α _ _ _ _ _ $pa' $pb') : Expr))
   | .positive pa, .nonnegative pb =>
     have pa' : Q(by clear! «$zα» «$pα»; exact 0 < $a) := pa
     have pb' : Q(by clear! «$zα» «$pα»; exact 0 ≤ $b) := pb

--- a/test/positivity.lean
+++ b/test/positivity.lean
@@ -13,7 +13,7 @@ instance [OrderedSemiring α] : OrderedMonoidWithZero α :=
     zero_le_one := sorry }
 
 instance [LinearOrderedRing α] : OrderedSemiring α := by
-  refine' { inferInstanceAs (LinearOrderedRing α) with .. }; sorry
+  refine' { inferInstanceAs (LinearOrderedRing α) with .. } <;> sorry
 
 instance [OrderedSemiring α] : CovariantClass α α (·+·) (·<·) := sorry
 


### PR DESCRIPTION
`linarith` needs various things that haven't been ported yet. This PR adds various sorried stubs in ad-hoc ported files ahead of where we're currently up to.