### PR TITLE
[Merged by Bors] - feat(Algebra/Regular/Basic): port file

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -29,6 +29,7 @@ import Mathlib.Algebra.Order.Ring.Lemmas
 import Mathlib.Algebra.Order.Sub.Defs
 import Mathlib.Algebra.PEmptyInstances
 import Mathlib.Algebra.Quotient
+import Mathlib.Algebra.Regular.Basic
 import Mathlib.Algebra.Ring.Basic
 import Mathlib.Algebra.Ring.Defs
 import Mathlib.Algebra.Ring.InjSurj

--- a/Mathlib/Algebra/Regular/Basic.lean
+++ b/Mathlib/Algebra/Regular/Basic.lean
@@ -36,7 +36,7 @@ variable [Mul R]
 is injective. -/
 @[to_additive "An add-left-regular element is an element `c` such that addition on the left by `c`\nis injective. -/\n"]
 def IsLeftRegular (c : R) :=
-  ((· * ·) c).Injective
+  (c * ·).Injective
 #align is_left_regular IsLeftRegular
 
 /-- A right-regular element is an element `c` such that multiplication on the right by `c`
@@ -49,7 +49,7 @@ def IsRightRegular (c : R) :=
 /-- An add-regular element is an element `c` such that addition by `c` both on the left and
 on the right is injective. -/
 structure IsAddRegular {R : Type _} [Add R] (c : R) : Prop where
-  left : IsAddLeftRegular c
+  left : IsAddLeftRegular c -- Porting note: It seems like to_additive is misbehaving
   right : IsAddRightRegular c
 #align is_add_regular IsAddRegular
 
@@ -63,10 +63,10 @@ structure IsRegular (c : R) : Prop where
 attribute [to_additive] IsRegular
 
 @[to_additive]
-protected theorem MulLeCancellable.is_left_regular [PartialOrder R] {a : R} (ha : MulLeCancellable a) :
+protected theorem MulLECancellable.is_left_regular [PartialOrder R] {a : R} (ha : MulLECancellable a) :
     IsLeftRegular a :=
   ha.Injective
-#align mul_le_cancellable.is_left_regular MulLeCancellable.is_left_regular
+#align mul_le_cancellable.is_left_regular MulLECancellable.is_left_regular
 
 theorem IsLeftRegular.right_of_commute {a : R} (ca : ∀ b, Commute a b) (h : IsLeftRegular a) : IsRightRegular a :=
   fun x y xy => h <| (ca x).trans <| xy.trans <| (ca y).symm
@@ -85,7 +85,7 @@ variable [Semigroup R] {a b : R}
 /-- In a semigroup, the product of left-regular elements is left-regular. -/
 @[to_additive "In an additive semigroup, the sum of add-left-regular elements is add-left.regular."]
 theorem IsLeftRegular.mul (lra : IsLeftRegular a) (lrb : IsLeftRegular b) : IsLeftRegular (a * b) :=
-  show Function.Injective ((· * ·) (a * b)) from comp_mul_left a b ▸ lra.comp lrb
+  show Function.Injective (((a * b) * ·)) from comp_mul_left a b ▸ lra.comp lrb
 #align is_left_regular.mul IsLeftRegular.mul
 
 /-- In a semigroup, the product of right-regular elements is right-regular. -/
@@ -171,12 +171,12 @@ theorem IsRightRegular.subsingleton (h : IsRightRegular (0 : R)) : Subsingleton 
 
 /-- The element `0` is regular if and only if `R` is trivial. -/
 theorem IsRegular.subsingleton (h : IsRegular (0 : R)) : Subsingleton R :=
-  h.left.Subsingleton
+  h.left.subsingleton
 #align is_regular.subsingleton IsRegular.subsingleton
 
 /-- The element `0` is left-regular if and only if `R` is trivial. -/
 theorem is_left_regular_zero_iff_subsingleton : IsLeftRegular (0 : R) ↔ Subsingleton R :=
-  ⟨fun h => h.Subsingleton, fun H a b h => @Subsingleton.elim _ H a b⟩
+  ⟨fun h => h.subsingleton, fun H a b _ => @Subsingleton.elim _ H a b⟩
 #align is_left_regular_zero_iff_subsingleton is_left_regular_zero_iff_subsingleton
 
 /-- In a non-trivial `mul_zero_class`, the `0` element is not left-regular. -/
@@ -188,7 +188,7 @@ theorem not_is_left_regular_zero_iff : ¬IsLeftRegular (0 : R) ↔ Nontrivial R 
 
 /-- The element `0` is right-regular if and only if `R` is trivial. -/
 theorem is_right_regular_zero_iff_subsingleton : IsRightRegular (0 : R) ↔ Subsingleton R :=
-  ⟨fun h => h.Subsingleton, fun H a b h => @Subsingleton.elim _ H a b⟩
+  ⟨fun h => h.subsingleton, fun H a b _ => @Subsingleton.elim _ H a b⟩
 #align is_right_regular_zero_iff_subsingleton is_right_regular_zero_iff_subsingleton
 
 /-- In a non-trivial `mul_zero_class`, the `0` element is not right-regular. -/
@@ -200,7 +200,7 @@ theorem not_is_right_regular_zero_iff : ¬IsRightRegular (0 : R) ↔ Nontrivial 
 
 /-- The element `0` is regular if and only if `R` is trivial. -/
 theorem is_regular_iff_subsingleton : IsRegular (0 : R) ↔ Subsingleton R :=
-  ⟨fun h => h.left.Subsingleton, fun h =>
+  ⟨fun h => h.left.subsingleton, fun h =>
     ⟨is_left_regular_zero_iff_subsingleton.mpr h, is_right_regular_zero_iff_subsingleton.mpr h⟩⟩
 #align is_regular_iff_subsingleton is_regular_iff_subsingleton
 
@@ -209,7 +209,7 @@ theorem IsLeftRegular.ne_zero [Nontrivial R] (la : IsLeftRegular a) : a ≠ 0 :=
   rintro rfl
   rcases exists_pair_ne R with ⟨x, y, xy⟩
   refine' xy (la _)
-  rw [zero_mul, zero_mul]
+  rw [zero_mul, zero_mul] -- Porting note: This seems like this should work. A difference in lean4?
 #align is_left_regular.ne_zero IsLeftRegular.ne_zero
 
 /-- A right-regular element of a `nontrivial` `mul_zero_class` is non-zero. -/
@@ -222,7 +222,7 @@ theorem IsRightRegular.ne_zero [Nontrivial R] (ra : IsRightRegular a) : a ≠ 0 
 
 /-- A regular element of a `nontrivial` `mul_zero_class` is non-zero. -/
 theorem IsRegular.ne_zero [Nontrivial R] (la : IsRegular a) : a ≠ 0 :=
-  la.left.NeZero
+  la.left.ne_zero
 #align is_regular.ne_zero IsRegular.ne_zero
 
 /-- In a non-trivial ring, the element `0` is not left-regular -- with typeclasses. -/
@@ -334,7 +334,7 @@ variable [CancelMonoidWithZero R] {a : R}
 
 /-- Non-zero elements of an integral domain are regular. -/
 theorem is_regular_of_ne_zero (a0 : a ≠ 0) : IsRegular a :=
-  ⟨fun b c => (mul_right_inj' a0).mp, fun b c => (mul_left_inj' a0).mp⟩
+  ⟨fun _ _ => (mul_right_inj' a0).mp, fun _ _ => (mul_left_inj' a0).mp⟩
 #align is_regular_of_ne_zero is_regular_of_ne_zero
 
 /-- In a non-trivial integral domain, an element is regular iff it is non-zero. -/

--- a/Mathlib/Algebra/Regular/Basic.lean
+++ b/Mathlib/Algebra/Regular/Basic.lean
@@ -208,8 +208,8 @@ theorem is_regular_iff_subsingleton : IsRegular (0 : R) ↔ Subsingleton R :=
 theorem IsLeftRegular.ne_zero [Nontrivial R] (la : IsLeftRegular a) : a ≠ 0 := by
   rintro rfl
   rcases exists_pair_ne R with ⟨x, y, xy⟩
-  refine' xy (la _)
-  rw [zero_mul, zero_mul] -- Porting note: This seems like this should work. A difference in lean4?
+  refine' xy (la (_ : 0 * x = 0 * y)) -- Porting note: lean4 seems to need the type signature
+  rw [zero_mul, zero_mul]
 #align is_left_regular.ne_zero IsLeftRegular.ne_zero
 
 /-- A right-regular element of a `nontrivial` `mul_zero_class` is non-zero. -/

--- a/Mathlib/Algebra/Regular/Basic.lean
+++ b/Mathlib/Algebra/Regular/Basic.lean
@@ -39,6 +39,7 @@ is injective. -/
 def IsLeftRegular (c : R) :=
   (c * ·).Injective
 #align is_left_regular IsLeftRegular
+#align is_add_left_regular IsAddLeftRegular
 
 /-- A right-regular element is an element `c` such that multiplication on the right by `c`
 is injective. -/
@@ -47,6 +48,7 @@ is injective. -/
 def IsRightRegular (c : R) :=
   (· * c).Injective
 #align is_right_regular IsRightRegular
+#align is_add_right_regular IsAddRightRegular
 
 /-- An add-regular element is an element `c` such that addition by `c` both on the left and
 on the right is injective. -/
@@ -73,6 +75,7 @@ protected theorem MulLECancellable.isLeftRegular [PartialOrder R] {a : R}
     (ha : MulLECancellable a) : IsLeftRegular a :=
   ha.Injective
 #align mul_le_cancellable.is_left_regular MulLECancellable.isLeftRegular
+#align add_le_cancellable.is_add_left_regular AddLECancellable.isAddLeftRegular
 
 theorem IsLeftRegular.right_of_commute {a : R}
     (ca : ∀ b, Commute a b) (h : IsLeftRegular a) : IsRightRegular a :=
@@ -94,6 +97,7 @@ variable [Semigroup R] {a b : R}
 theorem IsLeftRegular.mul (lra : IsLeftRegular a) (lrb : IsLeftRegular b) : IsLeftRegular (a * b) :=
   show Function.Injective (((a * b) * ·)) from comp_mul_left a b ▸ lra.comp lrb
 #align is_left_regular.mul IsLeftRegular.mul
+#align is_add_left_regular.add IsAddLeftRegular.add
 
 /-- In a semigroup, the product of right-regular elements is right-regular. -/
 @[to_additive "In an additive semigroup, the sum of add-right-regular elements is
@@ -102,6 +106,7 @@ theorem IsRightRegular.mul (rra : IsRightRegular a) (rrb : IsRightRegular b) :
     IsRightRegular (a * b) :=
   show Function.Injective (· * (a * b)) from comp_mul_right b a ▸ rrb.comp rra
 #align is_right_regular.mul IsRightRegular.mul
+#align is_add_right_regular.add IsAddRightRegular.add
 
 /-- If an element `b` becomes left-regular after multiplying it on the left by a left-regular
 element, then `b` is left-regular. -/
@@ -110,6 +115,7 @@ a add-left-regular element, then `b` is add-left-regular."]
 theorem IsLeftRegular.of_mul (ab : IsLeftRegular (a * b)) : IsLeftRegular b :=
   Function.Injective.of_comp (by rwa [comp_mul_left a b])
 #align is_left_regular.of_mul IsLeftRegular.of_mul
+#align is_add_left_regular.of_add IsAddLeftRegular.of_add
 
 /-- An element is left-regular if and only if multiplying it on the left by a left-regular element
 is left-regular. -/
@@ -119,6 +125,7 @@ theorem mul_isLeftRegular_iff (b : R) (ha : IsLeftRegular a) :
     IsLeftRegular (a * b) ↔ IsLeftRegular b :=
   ⟨fun ab => IsLeftRegular.of_mul ab, fun ab => IsLeftRegular.mul ha ab⟩
 #align mul_is_left_regular_iff mul_isLeftRegular_iff
+#align add_is_add_left_regular_iff add_isAddLeftRegular_iff
 
 /-- If an element `b` becomes right-regular after multiplying it on the right by a right-regular
 element, then `b` is right-regular. -/
@@ -129,6 +136,7 @@ theorem IsRightRegular.of_mul (ab : IsRightRegular (b * a)) : IsRightRegular b :
   rw [← mul_assoc, ← mul_assoc]
   exact congr_fun (congr_arg (· * ·) xy) a
 #align is_right_regular.of_mul IsRightRegular.of_mul
+#align is_add_right_regular.of_add IsAddRightRegular.of_add
 
 /-- An element is right-regular if and only if multiplying it on the right with a right-regular
 element is right-regular. -/
@@ -138,6 +146,7 @@ theorem mul_isRightRegular_iff (b : R) (ha : IsRightRegular a) :
     IsRightRegular (b * a) ↔ IsRightRegular b :=
   ⟨fun ab => IsRightRegular.of_mul ab, fun ab => IsRightRegular.mul ab ha⟩
 #align mul_is_right_regular_iff mul_isRightRegular_iff
+#align add_is_add_right_regular_iff add_isAddRightRegular_iff
 
 /-- Two elements `a` and `b` are regular if and only if both products `a * b` and `b * a`
 are regular. -/
@@ -157,6 +166,7 @@ theorem isRegular_mul_and_mul_iff :
         ⟨(mul_isLeftRegular_iff _ hb.left).mpr ha.left,
           (mul_isRightRegular_iff _ ha.right).mpr hb.right⟩⟩
 #align is_regular_mul_and_mul_iff isRegular_mul_and_mul_iff
+#align is_add_regular_add_and_add_iff isAddRegular_add_and_add_iff
 
 /-- The "most used" implication of `mul_and_mul_iff`, with split hypotheses, instead of `∧`. -/
 @[to_additive "The \"most used\" implication of `add_and_add_iff`, with split
@@ -165,6 +175,7 @@ theorem IsRegular.and_of_mul_of_mul (ab : IsRegular (a * b)) (ba : IsRegular (b 
     IsRegular a ∧ IsRegular b :=
   isRegular_mul_and_mul_iff.mp ⟨ab, ba⟩
 #align is_regular.and_of_mul_of_mul IsRegular.and_of_mul_of_mul
+#align is_add_regular.and_of_add_of_add IsAddRegular.and_of_add_of_add
 
 end Semigroup
 
@@ -264,6 +275,7 @@ theorem isRegular_one : IsRegular (1 : R) :=
   ⟨fun a b ab => (one_mul a).symm.trans (Eq.trans ab (one_mul b)), fun a b ab =>
     (mul_one a).symm.trans (Eq.trans ab (mul_one b))⟩
 #align is_regular_one isRegular_one
+#align is_add_regular_zero isAddRegular_zero
 
 end MulOneClass
 
@@ -277,6 +289,7 @@ theorem isRegular_mul_iff : IsRegular (a * b) ↔ IsRegular a ∧ IsRegular b :=
   refine' Iff.trans _ isRegular_mul_and_mul_iff
   refine' ⟨fun ab => ⟨ab, by rwa [mul_comm]⟩, fun rab => rab.1⟩
 #align is_regular_mul_iff isRegular_mul_iff
+#align is_add_regular_add_iff isAddRegular_add_iff
 
 end CommSemigroup
 
@@ -289,18 +302,21 @@ variable [Monoid R] {a b : R}
 theorem isLeftRegular_of_mul_eq_one (h : b * a = 1) : IsLeftRegular a :=
   @IsLeftRegular.of_mul R _ _ _ (by rw [h]; exact isRegular_one.left)
 #align is_left_regular_of_mul_eq_one isLeftRegular_of_mul_eq_one
+#align is_add_left_regular_of_add_eq_zero isAddLeftRegular_of_add_eq_zero
 
 /-- An element admitting a right inverse is right-regular. -/
 @[to_additive "An element admitting a right additive opposite is add-right-regular."]
 theorem isRightRegular_of_mul_eq_one (h : a * b = 1) : IsRightRegular a :=
   IsRightRegular.of_mul (by rw [h]; exact isRegular_one.right)
 #align is_right_regular_of_mul_eq_one isRightRegular_of_mul_eq_one
+#align is_add_right_regular_of_add_eq_zero isAddRightRegular_of_add_eq_zero
 
 /-- If `R` is a monoid, an element in `Rˣ` is regular. -/
 @[to_additive "If `R` is an additive monoid, an element in `add_units R` is add-regular."]
 theorem Units.isRegular (a : Rˣ) : IsRegular (a : R) :=
   ⟨isLeftRegular_of_mul_eq_one a.inv_mul, isRightRegular_of_mul_eq_one a.mul_inv⟩
 #align units.is_regular Units.isRegular
+#align add_units.is_add_regular AddUnits.isAddRegular
 
 /-- A unit in a monoid is regular. -/
 @[to_additive "An additive unit in an additive monoid is add-regular."]
@@ -308,6 +324,7 @@ theorem IsUnit.isRegular (ua : IsUnit a) : IsRegular a := by
   rcases ua with ⟨a, rfl⟩
   exact Units.isRegular a
 #align is_unit.is_regular IsUnit.isRegular
+#align is_add_unit.is_add_regular IsAddUnit.isAddRegular
 
 end Monoid
 
@@ -317,6 +334,7 @@ theorem isLeftRegular_of_leftCancelSemigroup [LeftCancelSemigroup R]
     (g : R) : IsLeftRegular g :=
   mul_right_injective g
 #align is_left_regular_of_left_cancel_semigroup isLeftRegular_of_leftCancelSemigroup
+#align is_add_left_regular_of_add_left_cancel_semigroup isAddLeftRegular_of_addLeftCancelSemigroup
 
 /-- Elements of a right cancel semigroup are right regular. -/
 @[to_additive "Elements of an add right cancel semigroup are add-right-regular"]
@@ -324,6 +342,8 @@ theorem isRightRegular_of_rightCancelSemigroup [RightCancelSemigroup R]
     (g : R) : IsRightRegular g :=
   mul_left_injective g
 #align is_right_regular_of_right_cancel_semigroup isRightRegular_of_rightCancelSemigroup
+#align is_add_right_regular_of_add_right_cancel_semigroup
+    isAddRightRegular_of_addRightCancelSemigroup
 
 section CancelMonoid
 
@@ -335,6 +355,7 @@ Add cancel semigroups do not appear to exist."]
 theorem isRegular_of_cancelMonoid (g : R) : IsRegular g :=
   ⟨mul_right_injective g, mul_left_injective g⟩
 #align is_regular_of_cancel_monoid isRegular_of_cancelMonoid
+#align is_add_regular_of_add_cancel_monoid isAddRegular_of_addCancelMonoid
 
 end CancelMonoid
 

--- a/Mathlib/Algebra/Regular/Basic.lean
+++ b/Mathlib/Algebra/Regular/Basic.lean
@@ -35,7 +35,7 @@ variable [Mul R]
 /-- A left-regular element is an element `c` such that multiplication on the left by `c`
 is injective. -/
 @[to_additive IsAddLeftRegular "An add-left-regular element is an element `c` such that addition
-    on the left by `c`\nis injective. -/\n"]
+    on the left by `c` is injective."]
 def IsLeftRegular (c : R) :=
   (c * ·).Injective
 #align is_left_regular IsLeftRegular
@@ -43,7 +43,7 @@ def IsLeftRegular (c : R) :=
 /-- A right-regular element is an element `c` such that multiplication on the right by `c`
 is injective. -/
 @[to_additive IsAddRightRegular "An add-right-regular element is an element `c` such that addition
-    on the right by `c`\nis injective."]
+    on the right by `c` is injective."]
 def IsRightRegular (c : R) :=
   (· * c).Injective
 #align is_right_regular IsRightRegular
@@ -106,7 +106,7 @@ theorem IsRightRegular.mul (rra : IsRightRegular a) (rrb : IsRightRegular b) :
 /-- If an element `b` becomes left-regular after multiplying it on the left by a left-regular
 element, then `b` is left-regular. -/
 @[to_additive "If an element `b` becomes add-left-regular after adding to it on the left
-a\nadd-left-regular element, then `b` is add-left-regular."]
+a add-left-regular element, then `b` is add-left-regular."]
 theorem IsLeftRegular.of_mul (ab : IsLeftRegular (a * b)) : IsLeftRegular b :=
   Function.Injective.of_comp (by rwa [comp_mul_left a b])
 #align is_left_regular.of_mul IsLeftRegular.of_mul
@@ -114,7 +114,7 @@ theorem IsLeftRegular.of_mul (ab : IsLeftRegular (a * b)) : IsLeftRegular b :=
 /-- An element is left-regular if and only if multiplying it on the left by a left-regular element
 is left-regular. -/
 @[simp, to_additive "An element is add-left-regular if and only if adding to it on the left
-a\nadd-left-regular element is add-left-regular."]
+a add-left-regular element is add-left-regular."]
 theorem mul_isLeftRegular_iff (b : R) (ha : IsLeftRegular a) :
     IsLeftRegular (a * b) ↔ IsLeftRegular b :=
   ⟨fun ab => IsLeftRegular.of_mul ab, fun ab => IsLeftRegular.mul ha ab⟩
@@ -123,7 +123,7 @@ theorem mul_isLeftRegular_iff (b : R) (ha : IsLeftRegular a) :
 /-- If an element `b` becomes right-regular after multiplying it on the right by a right-regular
 element, then `b` is right-regular. -/
 @[to_additive "If an element `b` becomes add-right-regular after adding to it on the right
-a\nadd-right-regular element, then `b` is add-right-regular."]
+a add-right-regular element, then `b` is add-right-regular."]
 theorem IsRightRegular.of_mul (ab : IsRightRegular (b * a)) : IsRightRegular b := by
   refine' fun x y xy => ab (_ : x * (b * a) = y * (b * a))
   rw [← mul_assoc, ← mul_assoc]
@@ -133,16 +133,16 @@ theorem IsRightRegular.of_mul (ab : IsRightRegular (b * a)) : IsRightRegular b :
 /-- An element is right-regular if and only if multiplying it on the right with a right-regular
 element is right-regular. -/
 @[simp, to_additive "An element is add-right-regular if and only if adding it on the right to
-a\nadd-right-regular element is add-right-regular."]
-theorem mul_isRightRegular_iff (b : R) (ha : IsRightRegular a)
-    : IsRightRegular (b * a) ↔ IsRightRegular b :=
+a add-right-regular element is add-right-regular."]
+theorem mul_isRightRegular_iff (b : R) (ha : IsRightRegular a) :
+    IsRightRegular (b * a) ↔ IsRightRegular b :=
   ⟨fun ab => IsRightRegular.of_mul ab, fun ab => IsRightRegular.mul ab ha⟩
 #align mul_is_right_regular_iff mul_isRightRegular_iff
 
 /-- Two elements `a` and `b` are regular if and only if both products `a * b` and `b * a`
 are regular. -/
 @[to_additive "Two elements `a` and `b` are add-regular if and only if both sums `a + b` and
-`b + a`\nare add-regular."]
+`b + a` are add-regular."]
 theorem isRegular_mul_and_mul_iff :
     IsRegular (a * b) ∧ IsRegular (b * a) ↔ IsRegular a ∧ IsRegular b := by
   refine' ⟨_, _⟩
@@ -150,19 +150,17 @@ theorem isRegular_mul_and_mul_iff :
     exact
       ⟨⟨IsLeftRegular.of_mul ba.left, IsRightRegular.of_mul ab.right⟩,
         ⟨IsLeftRegular.of_mul ab.left, IsRightRegular.of_mul ba.right⟩⟩
-
   · rintro ⟨ha, hb⟩
     exact
       ⟨⟨(mul_isLeftRegular_iff _ ha.left).mpr hb.left,
           (mul_isRightRegular_iff _ hb.right).mpr ha.right⟩,
         ⟨(mul_isLeftRegular_iff _ hb.left).mpr ha.left,
           (mul_isRightRegular_iff _ ha.right).mpr hb.right⟩⟩
-
 #align is_regular_mul_and_mul_iff isRegular_mul_and_mul_iff
 
 /-- The "most used" implication of `mul_and_mul_iff`, with split hypotheses, instead of `∧`. -/
 @[to_additive "The \"most used\" implication of `add_and_add_iff`, with split
-hypotheses,\ninstead of `∧`."]
+hypotheses, instead of `∧`."]
 theorem IsRegular.and_of_mul_of_mul (ab : IsRegular (a * b)) (ba : IsRegular (b * a)) :
     IsRegular a ∧ IsRegular b :=
   isRegular_mul_and_mul_iff.mp ⟨ab, ba⟩
@@ -289,19 +287,13 @@ variable [Monoid R] {a b : R}
 /-- An element admitting a left inverse is left-regular. -/
 @[to_additive "An element admitting a left additive opposite is add-left-regular."]
 theorem isLeftRegular_of_mul_eq_one (h : b * a = 1) : IsLeftRegular a :=
-  @IsLeftRegular.of_mul R _ _ _
-    (by
-      rw [h]
-      exact isRegular_one.left)
+  @IsLeftRegular.of_mul R _ _ _ (by rw [h]; exact isRegular_one.left)
 #align is_left_regular_of_mul_eq_one isLeftRegular_of_mul_eq_one
 
 /-- An element admitting a right inverse is right-regular. -/
 @[to_additive "An element admitting a right additive opposite is add-right-regular."]
 theorem isRightRegular_of_mul_eq_one (h : a * b = 1) : IsRightRegular a :=
-  IsRightRegular.of_mul
-    (by
-      rw [h]
-      exact isRegular_one.right)
+  IsRightRegular.of_mul (by rw [h]; exact isRegular_one.right)
 #align is_right_regular_of_mul_eq_one isRightRegular_of_mul_eq_one
 
 /-- If `R` is a monoid, an element in `Rˣ` is regular. -/

--- a/Mathlib/Algebra/Regular/Basic.lean
+++ b/Mathlib/Algebra/Regular/Basic.lean
@@ -14,11 +14,11 @@ We introduce left-regular, right-regular and regular elements, along with their 
 analogues add-left-regular, add-right-regular and add-regular elements.
 
 By definition, a regular element in a commutative ring is a non-zero divisor.
-Lemma `is_regular_of_ne_zero` implies that every non-zero element of an integral domain is regular.
-Since it assumes that the ring is a `cancel_monoid_with_zero` it applies also, for instance, to `ℕ`.
+Lemma `isRegular_of_ne_zero` implies that every non-zero element of an integral domain is regular.
+Since it assumes that the ring is a `CancelMonoidWithZero` it applies also, for instance, to `ℕ`.
 
-The lemmas in Section `mul_zero_class` show that the `0` element is (left/right-)regular if and
-only if the `mul_zero_class` is trivial.  This is useful when figuring out stopping conditions for
+The lemmas in Section `MulZeroClass` show that the `0` element is (left/right-)regular if and
+only if the `MulZeroClass` is trivial.  This is useful when figuring out stopping conditions for
 regular sequences: if `0` is ever an element of a regular sequence, then we can extend the sequence
 by adding one further `0`.
 
@@ -34,14 +34,16 @@ variable [Mul R]
 
 /-- A left-regular element is an element `c` such that multiplication on the left by `c`
 is injective. -/
-@[to_additive IsAddLeftRegular "An add-left-regular element is an element `c` such that addition on the left by `c`\nis injective. -/\n"]
+@[to_additive IsAddLeftRegular "An add-left-regular element is an element `c` such that addition
+    on the left by `c`\nis injective. -/\n"]
 def IsLeftRegular (c : R) :=
   (c * ·).Injective
 #align is_left_regular IsLeftRegular
 
 /-- A right-regular element is an element `c` such that multiplication on the right by `c`
 is injective. -/
-@[to_additive IsAddRightRegular "An add-right-regular element is an element `c` such that addition on the right by `c`\nis injective."]
+@[to_additive IsAddRightRegular "An add-right-regular element is an element `c` such that addition
+    on the right by `c`\nis injective."]
 def IsRightRegular (c : R) :=
   (· * c).Injective
 #align is_right_regular IsRightRegular
@@ -49,32 +51,37 @@ def IsRightRegular (c : R) :=
 /-- An add-regular element is an element `c` such that addition by `c` both on the left and
 on the right is injective. -/
 structure IsAddRegular {R : Type _} [Add R] (c : R) : Prop where
+  /-- An add-regular element `c` is left-regular -/
   left : IsAddLeftRegular c -- Porting note: It seems like to_additive is misbehaving
+  /-- An add-regular element `c` is right-regular -/
   right : IsAddRightRegular c
 #align is_add_regular IsAddRegular
 
 /-- A regular element is an element `c` such that multiplication by `c` both on the left and
 on the right is injective. -/
 structure IsRegular (c : R) : Prop where
+  /-- A regular element `c` is left-regular -/
   left : IsLeftRegular c
+  /-- A regular element `c` is right-regular -/
   right : IsRightRegular c
 #align is_regular IsRegular
 
 attribute [to_additive IsAddRegular] IsRegular
 
 @[to_additive]
-protected theorem MulLECancellable.is_left_regular [PartialOrder R] {a : R} (ha : MulLECancellable a) :
-    IsLeftRegular a :=
+protected theorem MulLECancellable.isLeftRegular [PartialOrder R] {a : R}
+    (ha : MulLECancellable a) : IsLeftRegular a :=
   ha.Injective
-#align mul_le_cancellable.is_left_regular MulLECancellable.is_left_regular
+#align mul_le_cancellable.is_left_regular MulLECancellable.isLeftRegular
 
-theorem IsLeftRegular.right_of_commute {a : R} (ca : ∀ b, Commute a b) (h : IsLeftRegular a) : IsRightRegular a :=
+theorem IsLeftRegular.right_of_commute {a : R}
+    (ca : ∀ b, Commute a b) (h : IsLeftRegular a) : IsRightRegular a :=
   fun x y xy => h <| (ca x).trans <| xy.trans <| (ca y).symm
 #align is_left_regular.right_of_commute IsLeftRegular.right_of_commute
 
-theorem Commute.is_regular_iff {a : R} (ca : ∀ b, Commute a b) : IsRegular a ↔ IsLeftRegular a :=
+theorem Commute.isRegular_iff {a : R} (ca : ∀ b, Commute a b) : IsRegular a ↔ IsLeftRegular a :=
   ⟨fun h => h.left, fun h => ⟨h, h.right_of_commute ca⟩⟩
-#align commute.is_regular_iff Commute.is_regular_iff
+#align commute.is_regular_iff Commute.isRegular_iff
 
 end Mul
 
@@ -89,32 +96,34 @@ theorem IsLeftRegular.mul (lra : IsLeftRegular a) (lrb : IsLeftRegular b) : IsLe
 #align is_left_regular.mul IsLeftRegular.mul
 
 /-- In a semigroup, the product of right-regular elements is right-regular. -/
-@[to_additive "In an additive semigroup, the sum of add-right-regular elements is add-right-regular."]
-theorem IsRightRegular.mul (rra : IsRightRegular a) (rrb : IsRightRegular b) : IsRightRegular (a * b) :=
+@[to_additive "In an additive semigroup, the sum of add-right-regular elements is
+add-right-regular."]
+theorem IsRightRegular.mul (rra : IsRightRegular a) (rrb : IsRightRegular b) :
+    IsRightRegular (a * b) :=
   show Function.Injective (· * (a * b)) from comp_mul_right b a ▸ rrb.comp rra
 #align is_right_regular.mul IsRightRegular.mul
 
 /-- If an element `b` becomes left-regular after multiplying it on the left by a left-regular
 element, then `b` is left-regular. -/
-@[to_additive
-      "If an element `b` becomes add-left-regular after adding to it on the left a\nadd-left-regular element, then `b` is add-left-regular."]
+@[to_additive "If an element `b` becomes add-left-regular after adding to it on the left
+a\nadd-left-regular element, then `b` is add-left-regular."]
 theorem IsLeftRegular.of_mul (ab : IsLeftRegular (a * b)) : IsLeftRegular b :=
   Function.Injective.of_comp (by rwa [comp_mul_left a b])
 #align is_left_regular.of_mul IsLeftRegular.of_mul
 
 /-- An element is left-regular if and only if multiplying it on the left by a left-regular element
 is left-regular. -/
-@[simp,
-  to_additive
-      "An element is add-left-regular if and only if adding to it on the left a\nadd-left-regular element is add-left-regular."]
-theorem mul_is_left_regular_iff (b : R) (ha : IsLeftRegular a) : IsLeftRegular (a * b) ↔ IsLeftRegular b :=
+@[simp, to_additive "An element is add-left-regular if and only if adding to it on the left
+a\nadd-left-regular element is add-left-regular."]
+theorem mul_isLeftRegular_iff (b : R) (ha : IsLeftRegular a) :
+    IsLeftRegular (a * b) ↔ IsLeftRegular b :=
   ⟨fun ab => IsLeftRegular.of_mul ab, fun ab => IsLeftRegular.mul ha ab⟩
-#align mul_is_left_regular_iff mul_is_left_regular_iff
+#align mul_is_left_regular_iff mul_isLeftRegular_iff
 
 /-- If an element `b` becomes right-regular after multiplying it on the right by a right-regular
 element, then `b` is right-regular. -/
-@[to_additive
-      "If an element `b` becomes add-right-regular after adding to it on the right a\nadd-right-regular element, then `b` is add-right-regular."]
+@[to_additive "If an element `b` becomes add-right-regular after adding to it on the right
+a\nadd-right-regular element, then `b` is add-right-regular."]
 theorem IsRightRegular.of_mul (ab : IsRightRegular (b * a)) : IsRightRegular b := by
   refine' fun x y xy => ab (_ : x * (b * a) = y * (b * a))
   rw [← mul_assoc, ← mul_assoc]
@@ -123,17 +132,19 @@ theorem IsRightRegular.of_mul (ab : IsRightRegular (b * a)) : IsRightRegular b :
 
 /-- An element is right-regular if and only if multiplying it on the right with a right-regular
 element is right-regular. -/
-@[simp,
-  to_additive
-      "An element is add-right-regular if and only if adding it on the right to a\nadd-right-regular element is add-right-regular."]
-theorem mul_is_right_regular_iff (b : R) (ha : IsRightRegular a) : IsRightRegular (b * a) ↔ IsRightRegular b :=
+@[simp, to_additive "An element is add-right-regular if and only if adding it on the right to
+a\nadd-right-regular element is add-right-regular."]
+theorem mul_isRightRegular_iff (b : R) (ha : IsRightRegular a)
+    : IsRightRegular (b * a) ↔ IsRightRegular b :=
   ⟨fun ab => IsRightRegular.of_mul ab, fun ab => IsRightRegular.mul ab ha⟩
-#align mul_is_right_regular_iff mul_is_right_regular_iff
+#align mul_is_right_regular_iff mul_isRightRegular_iff
 
 /-- Two elements `a` and `b` are regular if and only if both products `a * b` and `b * a`
 are regular. -/
-@[to_additive "Two elements `a` and `b` are add-regular if and only if both sums `a + b` and `b + a`\nare add-regular."]
-theorem is_regular_mul_and_mul_iff : IsRegular (a * b) ∧ IsRegular (b * a) ↔ IsRegular a ∧ IsRegular b := by
+@[to_additive "Two elements `a` and `b` are add-regular if and only if both sums `a + b` and
+`b + a`\nare add-regular."]
+theorem isRegular_mul_and_mul_iff :
+    IsRegular (a * b) ∧ IsRegular (b * a) ↔ IsRegular a ∧ IsRegular b := by
   refine' ⟨_, _⟩
   · rintro ⟨ab, ba⟩
     exact
@@ -142,15 +153,19 @@ theorem is_regular_mul_and_mul_iff : IsRegular (a * b) ∧ IsRegular (b * a) ↔
 
   · rintro ⟨ha, hb⟩
     exact
-      ⟨⟨(mul_is_left_regular_iff _ ha.left).mpr hb.left, (mul_is_right_regular_iff _ hb.right).mpr ha.right⟩,
-        ⟨(mul_is_left_regular_iff _ hb.left).mpr ha.left, (mul_is_right_regular_iff _ ha.right).mpr hb.right⟩⟩
+      ⟨⟨(mul_isLeftRegular_iff _ ha.left).mpr hb.left,
+          (mul_isRightRegular_iff _ hb.right).mpr ha.right⟩,
+        ⟨(mul_isLeftRegular_iff _ hb.left).mpr ha.left,
+          (mul_isRightRegular_iff _ ha.right).mpr hb.right⟩⟩
 
-#align is_regular_mul_and_mul_iff is_regular_mul_and_mul_iff
+#align is_regular_mul_and_mul_iff isRegular_mul_and_mul_iff
 
 /-- The "most used" implication of `mul_and_mul_iff`, with split hypotheses, instead of `∧`. -/
-@[to_additive "The \"most used\" implication of `add_and_add_iff`, with split hypotheses,\ninstead of `∧`."]
-theorem IsRegular.and_of_mul_of_mul (ab : IsRegular (a * b)) (ba : IsRegular (b * a)) : IsRegular a ∧ IsRegular b :=
-  is_regular_mul_and_mul_iff.mp ⟨ab, ba⟩
+@[to_additive "The \"most used\" implication of `add_and_add_iff`, with split
+hypotheses,\ninstead of `∧`."]
+theorem IsRegular.and_of_mul_of_mul (ab : IsRegular (a * b)) (ba : IsRegular (b * a)) :
+    IsRegular a ∧ IsRegular b :=
+  isRegular_mul_and_mul_iff.mp ⟨ab, ba⟩
 #align is_regular.and_of_mul_of_mul IsRegular.and_of_mul_of_mul
 
 end Semigroup
@@ -175,36 +190,36 @@ theorem IsRegular.subsingleton (h : IsRegular (0 : R)) : Subsingleton R :=
 #align is_regular.subsingleton IsRegular.subsingleton
 
 /-- The element `0` is left-regular if and only if `R` is trivial. -/
-theorem is_left_regular_zero_iff_subsingleton : IsLeftRegular (0 : R) ↔ Subsingleton R :=
+theorem isLeftRegular_zero_iff_subsingleton : IsLeftRegular (0 : R) ↔ Subsingleton R :=
   ⟨fun h => h.subsingleton, fun H a b _ => @Subsingleton.elim _ H a b⟩
-#align is_left_regular_zero_iff_subsingleton is_left_regular_zero_iff_subsingleton
+#align is_left_regular_zero_iff_subsingleton isLeftRegular_zero_iff_subsingleton
 
-/-- In a non-trivial `mul_zero_class`, the `0` element is not left-regular. -/
-theorem not_is_left_regular_zero_iff : ¬IsLeftRegular (0 : R) ↔ Nontrivial R := by
-  rw [nontrivial_iff, not_iff_comm, is_left_regular_zero_iff_subsingleton, subsingleton_iff]
+/-- In a non-trivial `MulZeroClass`, the `0` element is not left-regular. -/
+theorem not_isLeftRegular_zero_iff : ¬IsLeftRegular (0 : R) ↔ Nontrivial R := by
+  rw [nontrivial_iff, not_iff_comm, isLeftRegular_zero_iff_subsingleton, subsingleton_iff]
   push_neg
   exact Iff.rfl
-#align not_is_left_regular_zero_iff not_is_left_regular_zero_iff
+#align not_is_left_regular_zero_iff not_isLeftRegular_zero_iff
 
 /-- The element `0` is right-regular if and only if `R` is trivial. -/
-theorem is_right_regular_zero_iff_subsingleton : IsRightRegular (0 : R) ↔ Subsingleton R :=
+theorem isRightRegular_zero_iff_subsingleton : IsRightRegular (0 : R) ↔ Subsingleton R :=
   ⟨fun h => h.subsingleton, fun H a b _ => @Subsingleton.elim _ H a b⟩
-#align is_right_regular_zero_iff_subsingleton is_right_regular_zero_iff_subsingleton
+#align is_right_regular_zero_iff_subsingleton isRightRegular_zero_iff_subsingleton
 
-/-- In a non-trivial `mul_zero_class`, the `0` element is not right-regular. -/
-theorem not_is_right_regular_zero_iff : ¬IsRightRegular (0 : R) ↔ Nontrivial R := by
-  rw [nontrivial_iff, not_iff_comm, is_right_regular_zero_iff_subsingleton, subsingleton_iff]
+/-- In a non-trivial `MulZeroClass`, the `0` element is not right-regular. -/
+theorem not_isRightRegular_zero_iff : ¬IsRightRegular (0 : R) ↔ Nontrivial R := by
+  rw [nontrivial_iff, not_iff_comm, isRightRegular_zero_iff_subsingleton, subsingleton_iff]
   push_neg
   exact Iff.rfl
-#align not_is_right_regular_zero_iff not_is_right_regular_zero_iff
+#align not_is_right_regular_zero_iff not_isRightRegular_zero_iff
 
 /-- The element `0` is regular if and only if `R` is trivial. -/
-theorem is_regular_iff_subsingleton : IsRegular (0 : R) ↔ Subsingleton R :=
+theorem isRegular_iff_subsingleton : IsRegular (0 : R) ↔ Subsingleton R :=
   ⟨fun h => h.left.subsingleton, fun h =>
-    ⟨is_left_regular_zero_iff_subsingleton.mpr h, is_right_regular_zero_iff_subsingleton.mpr h⟩⟩
-#align is_regular_iff_subsingleton is_regular_iff_subsingleton
+    ⟨isLeftRegular_zero_iff_subsingleton.mpr h, isRightRegular_zero_iff_subsingleton.mpr h⟩⟩
+#align is_regular_iff_subsingleton isRegular_iff_subsingleton
 
-/-- A left-regular element of a `nontrivial` `mul_zero_class` is non-zero. -/
+/-- A left-regular element of a `Nontrivial` `MulZeroClass` is non-zero. -/
 theorem IsLeftRegular.ne_zero [Nontrivial R] (la : IsLeftRegular a) : a ≠ 0 := by
   rintro rfl
   rcases exists_pair_ne R with ⟨x, y, xy⟩
@@ -212,7 +227,7 @@ theorem IsLeftRegular.ne_zero [Nontrivial R] (la : IsLeftRegular a) : a ≠ 0 :=
   rw [zero_mul, zero_mul]
 #align is_left_regular.ne_zero IsLeftRegular.ne_zero
 
-/-- A right-regular element of a `nontrivial` `mul_zero_class` is non-zero. -/
+/-- A right-regular element of a `Nontrivial` `MulZeroClass` is non-zero. -/
 theorem IsRightRegular.ne_zero [Nontrivial R] (ra : IsRightRegular a) : a ≠ 0 := by
   rintro rfl
   rcases exists_pair_ne R with ⟨x, y, xy⟩
@@ -220,24 +235,24 @@ theorem IsRightRegular.ne_zero [Nontrivial R] (ra : IsRightRegular a) : a ≠ 0 
   rw [mul_zero, mul_zero]
 #align is_right_regular.ne_zero IsRightRegular.ne_zero
 
-/-- A regular element of a `nontrivial` `mul_zero_class` is non-zero. -/
+/-- A regular element of a `Nontrivial` `MulZeroClass` is non-zero. -/
 theorem IsRegular.ne_zero [Nontrivial R] (la : IsRegular a) : a ≠ 0 :=
   la.left.ne_zero
 #align is_regular.ne_zero IsRegular.ne_zero
 
 /-- In a non-trivial ring, the element `0` is not left-regular -- with typeclasses. -/
-theorem not_is_left_regular_zero [nR : Nontrivial R] : ¬IsLeftRegular (0 : R) :=
-  not_is_left_regular_zero_iff.mpr nR
-#align not_is_left_regular_zero not_is_left_regular_zero
+theorem not_isLeftRegular_zero [nR : Nontrivial R] : ¬IsLeftRegular (0 : R) :=
+  not_isLeftRegular_zero_iff.mpr nR
+#align not_is_left_regular_zero not_isLeftRegular_zero
 
 /-- In a non-trivial ring, the element `0` is not right-regular -- with typeclasses. -/
-theorem not_is_right_regular_zero [nR : Nontrivial R] : ¬IsRightRegular (0 : R) :=
-  not_is_right_regular_zero_iff.mpr nR
-#align not_is_right_regular_zero not_is_right_regular_zero
+theorem not_isRightRegular_zero [nR : Nontrivial R] : ¬IsRightRegular (0 : R) :=
+  not_isRightRegular_zero_iff.mpr nR
+#align not_is_right_regular_zero not_isRightRegular_zero
 
 /-- In a non-trivial ring, the element `0` is not regular -- with typeclasses. -/
-theorem not_is_regular_zero [Nontrivial R] : ¬IsRegular (0 : R) := fun h => IsRegular.ne_zero h rfl
-#align not_is_regular_zero not_is_regular_zero
+theorem not_isRegular_zero [Nontrivial R] : ¬IsRegular (0 : R) := fun h => IsRegular.ne_zero h rfl
+#align not_is_regular_zero not_isRegular_zero
 
 end MulZeroClass
 
@@ -247,10 +262,10 @@ variable [MulOneClass R]
 
 /-- If multiplying by `1` on either side is the identity, `1` is regular. -/
 @[to_additive "If adding `0` on either side is the identity, `0` is regular."]
-theorem is_regular_one : IsRegular (1 : R) :=
+theorem isRegular_one : IsRegular (1 : R) :=
   ⟨fun a b ab => (one_mul a).symm.trans (Eq.trans ab (one_mul b)), fun a b ab =>
     (mul_one a).symm.trans (Eq.trans ab (mul_one b))⟩
-#align is_regular_one is_regular_one
+#align is_regular_one isRegular_one
 
 end MulOneClass
 
@@ -260,10 +275,10 @@ variable [CommSemigroup R] {a b : R}
 
 /-- A product is regular if and only if the factors are. -/
 @[to_additive "A sum is add-regular if and only if the summands are."]
-theorem is_regular_mul_iff : IsRegular (a * b) ↔ IsRegular a ∧ IsRegular b := by
-  refine' Iff.trans _ is_regular_mul_and_mul_iff
+theorem isRegular_mul_iff : IsRegular (a * b) ↔ IsRegular a ∧ IsRegular b := by
+  refine' Iff.trans _ isRegular_mul_and_mul_iff
   refine' ⟨fun ab => ⟨ab, by rwa [mul_comm]⟩, fun rab => rab.1⟩
-#align is_regular_mul_iff is_regular_mul_iff
+#align is_regular_mul_iff isRegular_mul_iff
 
 end CommSemigroup
 
@@ -273,58 +288,61 @@ variable [Monoid R] {a b : R}
 
 /-- An element admitting a left inverse is left-regular. -/
 @[to_additive "An element admitting a left additive opposite is add-left-regular."]
-theorem is_left_regular_of_mul_eq_one (h : b * a = 1) : IsLeftRegular a :=
+theorem isLeftRegular_of_mul_eq_one (h : b * a = 1) : IsLeftRegular a :=
   @IsLeftRegular.of_mul R _ _ _
     (by
       rw [h]
-      exact is_regular_one.left)
-#align is_left_regular_of_mul_eq_one is_left_regular_of_mul_eq_one
+      exact isRegular_one.left)
+#align is_left_regular_of_mul_eq_one isLeftRegular_of_mul_eq_one
 
 /-- An element admitting a right inverse is right-regular. -/
 @[to_additive "An element admitting a right additive opposite is add-right-regular."]
-theorem is_right_regular_of_mul_eq_one (h : a * b = 1) : IsRightRegular a :=
+theorem isRightRegular_of_mul_eq_one (h : a * b = 1) : IsRightRegular a :=
   IsRightRegular.of_mul
     (by
       rw [h]
-      exact is_regular_one.right)
-#align is_right_regular_of_mul_eq_one is_right_regular_of_mul_eq_one
+      exact isRegular_one.right)
+#align is_right_regular_of_mul_eq_one isRightRegular_of_mul_eq_one
 
 /-- If `R` is a monoid, an element in `Rˣ` is regular. -/
 @[to_additive "If `R` is an additive monoid, an element in `add_units R` is add-regular."]
-theorem Units.is_regular (a : Rˣ) : IsRegular (a : R) :=
-  ⟨is_left_regular_of_mul_eq_one a.inv_mul, is_right_regular_of_mul_eq_one a.mul_inv⟩
-#align units.is_regular Units.is_regular
+theorem Units.isRegular (a : Rˣ) : IsRegular (a : R) :=
+  ⟨isLeftRegular_of_mul_eq_one a.inv_mul, isRightRegular_of_mul_eq_one a.mul_inv⟩
+#align units.is_regular Units.isRegular
 
 /-- A unit in a monoid is regular. -/
 @[to_additive "An additive unit in an additive monoid is add-regular."]
-theorem IsUnit.is_regular (ua : IsUnit a) : IsRegular a := by
+theorem IsUnit.isRegular (ua : IsUnit a) : IsRegular a := by
   rcases ua with ⟨a, rfl⟩
-  exact Units.is_regular a
-#align is_unit.is_regular IsUnit.is_regular
+  exact Units.isRegular a
+#align is_unit.is_regular IsUnit.isRegular
 
 end Monoid
 
 /-- Elements of a left cancel semigroup are left regular. -/
 @[to_additive "Elements of an add left cancel semigroup are add-left-regular."]
-theorem is_left_regular_of_left_cancel_semigroup [LeftCancelSemigroup R] (g : R) : IsLeftRegular g :=
+theorem isLeftRegular_of_leftCancelSemigroup [LeftCancelSemigroup R]
+    (g : R) : IsLeftRegular g :=
   mul_right_injective g
-#align is_left_regular_of_left_cancel_semigroup is_left_regular_of_left_cancel_semigroup
+#align is_left_regular_of_left_cancel_semigroup isLeftRegular_of_leftCancelSemigroup
 
 /-- Elements of a right cancel semigroup are right regular. -/
 @[to_additive "Elements of an add right cancel semigroup are add-right-regular"]
-theorem is_right_regular_of_right_cancel_semigroup [RightCancelSemigroup R] (g : R) : IsRightRegular g :=
+theorem isRightRegular_of_rightCancelSemigroup [RightCancelSemigroup R]
+    (g : R) : IsRightRegular g :=
   mul_left_injective g
-#align is_right_regular_of_right_cancel_semigroup is_right_regular_of_right_cancel_semigroup
+#align is_right_regular_of_right_cancel_semigroup isRightRegular_of_rightCancelSemigroup
 
 section CancelMonoid
 
 variable [CancelMonoid R]
 
 /-- Elements of a cancel monoid are regular.  Cancel semigroups do not appear to exist. -/
-@[to_additive "Elements of an add cancel monoid are regular.  Add cancel semigroups do not appear to exist."]
-theorem is_regular_of_cancel_monoid (g : R) : IsRegular g :=
+@[to_additive "Elements of an add cancel monoid are regular.
+Add cancel semigroups do not appear to exist."]
+theorem isRegular_of_cancelMonoid (g : R) : IsRegular g :=
   ⟨mul_right_injective g, mul_left_injective g⟩
-#align is_regular_of_cancel_monoid is_regular_of_cancel_monoid
+#align is_regular_of_cancel_monoid isRegular_of_cancelMonoid
 
 end CancelMonoid
 
@@ -333,13 +351,13 @@ section CancelMonoidWithZero
 variable [CancelMonoidWithZero R] {a : R}
 
 /-- Non-zero elements of an integral domain are regular. -/
-theorem is_regular_of_ne_zero (a0 : a ≠ 0) : IsRegular a :=
+theorem isRegular_of_ne_zero (a0 : a ≠ 0) : IsRegular a :=
   ⟨fun _ _ => (mul_right_inj' a0).mp, fun _ _ => (mul_left_inj' a0).mp⟩
-#align is_regular_of_ne_zero is_regular_of_ne_zero
+#align is_regular_of_ne_zero isRegular_of_ne_zero
 
 /-- In a non-trivial integral domain, an element is regular iff it is non-zero. -/
-theorem is_regular_iff_ne_zero [Nontrivial R] : IsRegular a ↔ a ≠ 0 :=
-  ⟨IsRegular.ne_zero, is_regular_of_ne_zero⟩
-#align is_regular_iff_ne_zero is_regular_iff_ne_zero
+theorem isRegular_iff_ne_zero [Nontrivial R] : IsRegular a ↔ a ≠ 0 :=
+  ⟨IsRegular.ne_zero, isRegular_of_ne_zero⟩
+#align is_regular_iff_ne_zero isRegular_iff_ne_zero
 
 end CancelMonoidWithZero

--- a/Mathlib/Algebra/Regular/Basic.lean
+++ b/Mathlib/Algebra/Regular/Basic.lean
@@ -1,0 +1,345 @@
+/-
+Copyright (c) 2021 Damiano Testa. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Damiano Testa
+-/
+import Mathlib.Algebra.Group.Commute
+import Mathlib.Algebra.Order.Monoid.Lemmas
+import Mathlib.Algebra.GroupWithZero.Basic
+
+/-!
+# Regular elements
+
+We introduce left-regular, right-regular and regular elements, along with their `to_additive`
+analogues add-left-regular, add-right-regular and add-regular elements.
+
+By definition, a regular element in a commutative ring is a non-zero divisor.
+Lemma `is_regular_of_ne_zero` implies that every non-zero element of an integral domain is regular.
+Since it assumes that the ring is a `cancel_monoid_with_zero` it applies also, for instance, to `ℕ`.
+
+The lemmas in Section `mul_zero_class` show that the `0` element is (left/right-)regular if and
+only if the `mul_zero_class` is trivial.  This is useful when figuring out stopping conditions for
+regular sequences: if `0` is ever an element of a regular sequence, then we can extend the sequence
+by adding one further `0`.
+
+The final goal is to develop part of the API to prove, eventually, results about non-zero-divisors.
+-/
+
+
+variable {R : Type _}
+
+section Mul
+
+variable [Mul R]
+
+/-- A left-regular element is an element `c` such that multiplication on the left by `c`
+is injective. -/
+@[to_additive "An add-left-regular element is an element `c` such that addition on the left by `c`\nis injective. -/\n"]
+def IsLeftRegular (c : R) :=
+  ((· * ·) c).Injective
+#align is_left_regular IsLeftRegular
+
+/-- A right-regular element is an element `c` such that multiplication on the right by `c`
+is injective. -/
+@[to_additive "An add-right-regular element is an element `c` such that addition on the right by `c`\nis injective."]
+def IsRightRegular (c : R) :=
+  (· * c).Injective
+#align is_right_regular IsRightRegular
+
+/-- An add-regular element is an element `c` such that addition by `c` both on the left and
+on the right is injective. -/
+structure IsAddRegular {R : Type _} [Add R] (c : R) : Prop where
+  left : IsAddLeftRegular c
+  right : IsAddRightRegular c
+#align is_add_regular IsAddRegular
+
+/-- A regular element is an element `c` such that multiplication by `c` both on the left and
+on the right is injective. -/
+structure IsRegular (c : R) : Prop where
+  left : IsLeftRegular c
+  right : IsRightRegular c
+#align is_regular IsRegular
+
+attribute [to_additive] IsRegular
+
+@[to_additive]
+protected theorem MulLeCancellable.is_left_regular [PartialOrder R] {a : R} (ha : MulLeCancellable a) :
+    IsLeftRegular a :=
+  ha.Injective
+#align mul_le_cancellable.is_left_regular MulLeCancellable.is_left_regular
+
+theorem IsLeftRegular.right_of_commute {a : R} (ca : ∀ b, Commute a b) (h : IsLeftRegular a) : IsRightRegular a :=
+  fun x y xy => h <| (ca x).trans <| xy.trans <| (ca y).symm
+#align is_left_regular.right_of_commute IsLeftRegular.right_of_commute
+
+theorem Commute.is_regular_iff {a : R} (ca : ∀ b, Commute a b) : IsRegular a ↔ IsLeftRegular a :=
+  ⟨fun h => h.left, fun h => ⟨h, h.right_of_commute ca⟩⟩
+#align commute.is_regular_iff Commute.is_regular_iff
+
+end Mul
+
+section Semigroup
+
+variable [Semigroup R] {a b : R}
+
+/-- In a semigroup, the product of left-regular elements is left-regular. -/
+@[to_additive "In an additive semigroup, the sum of add-left-regular elements is add-left.regular."]
+theorem IsLeftRegular.mul (lra : IsLeftRegular a) (lrb : IsLeftRegular b) : IsLeftRegular (a * b) :=
+  show Function.Injective ((· * ·) (a * b)) from comp_mul_left a b ▸ lra.comp lrb
+#align is_left_regular.mul IsLeftRegular.mul
+
+/-- In a semigroup, the product of right-regular elements is right-regular. -/
+@[to_additive "In an additive semigroup, the sum of add-right-regular elements is add-right-regular."]
+theorem IsRightRegular.mul (rra : IsRightRegular a) (rrb : IsRightRegular b) : IsRightRegular (a * b) :=
+  show Function.Injective (· * (a * b)) from comp_mul_right b a ▸ rrb.comp rra
+#align is_right_regular.mul IsRightRegular.mul
+
+/-- If an element `b` becomes left-regular after multiplying it on the left by a left-regular
+element, then `b` is left-regular. -/
+@[to_additive
+      "If an element `b` becomes add-left-regular after adding to it on the left a\nadd-left-regular element, then `b` is add-left-regular."]
+theorem IsLeftRegular.of_mul (ab : IsLeftRegular (a * b)) : IsLeftRegular b :=
+  Function.Injective.of_comp (by rwa [comp_mul_left a b])
+#align is_left_regular.of_mul IsLeftRegular.of_mul
+
+/-- An element is left-regular if and only if multiplying it on the left by a left-regular element
+is left-regular. -/
+@[simp,
+  to_additive
+      "An element is add-left-regular if and only if adding to it on the left a\nadd-left-regular element is add-left-regular."]
+theorem mul_is_left_regular_iff (b : R) (ha : IsLeftRegular a) : IsLeftRegular (a * b) ↔ IsLeftRegular b :=
+  ⟨fun ab => IsLeftRegular.of_mul ab, fun ab => IsLeftRegular.mul ha ab⟩
+#align mul_is_left_regular_iff mul_is_left_regular_iff
+
+/-- If an element `b` becomes right-regular after multiplying it on the right by a right-regular
+element, then `b` is right-regular. -/
+@[to_additive
+      "If an element `b` becomes add-right-regular after adding to it on the right a\nadd-right-regular element, then `b` is add-right-regular."]
+theorem IsRightRegular.of_mul (ab : IsRightRegular (b * a)) : IsRightRegular b := by
+  refine' fun x y xy => ab (_ : x * (b * a) = y * (b * a))
+  rw [← mul_assoc, ← mul_assoc]
+  exact congr_fun (congr_arg (· * ·) xy) a
+#align is_right_regular.of_mul IsRightRegular.of_mul
+
+/-- An element is right-regular if and only if multiplying it on the right with a right-regular
+element is right-regular. -/
+@[simp,
+  to_additive
+      "An element is add-right-regular if and only if adding it on the right to a\nadd-right-regular element is add-right-regular."]
+theorem mul_is_right_regular_iff (b : R) (ha : IsRightRegular a) : IsRightRegular (b * a) ↔ IsRightRegular b :=
+  ⟨fun ab => IsRightRegular.of_mul ab, fun ab => IsRightRegular.mul ab ha⟩
+#align mul_is_right_regular_iff mul_is_right_regular_iff
+
+/-- Two elements `a` and `b` are regular if and only if both products `a * b` and `b * a`
+are regular. -/
+@[to_additive "Two elements `a` and `b` are add-regular if and only if both sums `a + b` and `b + a`\nare add-regular."]
+theorem is_regular_mul_and_mul_iff : IsRegular (a * b) ∧ IsRegular (b * a) ↔ IsRegular a ∧ IsRegular b := by
+  refine' ⟨_, _⟩
+  · rintro ⟨ab, ba⟩
+    exact
+      ⟨⟨IsLeftRegular.of_mul ba.left, IsRightRegular.of_mul ab.right⟩,
+        ⟨IsLeftRegular.of_mul ab.left, IsRightRegular.of_mul ba.right⟩⟩
+
+  · rintro ⟨ha, hb⟩
+    exact
+      ⟨⟨(mul_is_left_regular_iff _ ha.left).mpr hb.left, (mul_is_right_regular_iff _ hb.right).mpr ha.right⟩,
+        ⟨(mul_is_left_regular_iff _ hb.left).mpr ha.left, (mul_is_right_regular_iff _ ha.right).mpr hb.right⟩⟩
+
+#align is_regular_mul_and_mul_iff is_regular_mul_and_mul_iff
+
+/-- The "most used" implication of `mul_and_mul_iff`, with split hypotheses, instead of `∧`. -/
+@[to_additive "The \"most used\" implication of `add_and_add_iff`, with split hypotheses,\ninstead of `∧`."]
+theorem IsRegular.and_of_mul_of_mul (ab : IsRegular (a * b)) (ba : IsRegular (b * a)) : IsRegular a ∧ IsRegular b :=
+  is_regular_mul_and_mul_iff.mp ⟨ab, ba⟩
+#align is_regular.and_of_mul_of_mul IsRegular.and_of_mul_of_mul
+
+end Semigroup
+
+section MulZeroClass
+
+variable [MulZeroClass R] {a b : R}
+
+/-- The element `0` is left-regular if and only if `R` is trivial. -/
+theorem IsLeftRegular.subsingleton (h : IsLeftRegular (0 : R)) : Subsingleton R :=
+  ⟨fun a b => h <| Eq.trans (zero_mul a) (zero_mul b).symm⟩
+#align is_left_regular.subsingleton IsLeftRegular.subsingleton
+
+/-- The element `0` is right-regular if and only if `R` is trivial. -/
+theorem IsRightRegular.subsingleton (h : IsRightRegular (0 : R)) : Subsingleton R :=
+  ⟨fun a b => h <| Eq.trans (mul_zero a) (mul_zero b).symm⟩
+#align is_right_regular.subsingleton IsRightRegular.subsingleton
+
+/-- The element `0` is regular if and only if `R` is trivial. -/
+theorem IsRegular.subsingleton (h : IsRegular (0 : R)) : Subsingleton R :=
+  h.left.Subsingleton
+#align is_regular.subsingleton IsRegular.subsingleton
+
+/-- The element `0` is left-regular if and only if `R` is trivial. -/
+theorem is_left_regular_zero_iff_subsingleton : IsLeftRegular (0 : R) ↔ Subsingleton R :=
+  ⟨fun h => h.Subsingleton, fun H a b h => @Subsingleton.elim _ H a b⟩
+#align is_left_regular_zero_iff_subsingleton is_left_regular_zero_iff_subsingleton
+
+/-- In a non-trivial `mul_zero_class`, the `0` element is not left-regular. -/
+theorem not_is_left_regular_zero_iff : ¬IsLeftRegular (0 : R) ↔ Nontrivial R := by
+  rw [nontrivial_iff, not_iff_comm, is_left_regular_zero_iff_subsingleton, subsingleton_iff]
+  push_neg
+  exact Iff.rfl
+#align not_is_left_regular_zero_iff not_is_left_regular_zero_iff
+
+/-- The element `0` is right-regular if and only if `R` is trivial. -/
+theorem is_right_regular_zero_iff_subsingleton : IsRightRegular (0 : R) ↔ Subsingleton R :=
+  ⟨fun h => h.Subsingleton, fun H a b h => @Subsingleton.elim _ H a b⟩
+#align is_right_regular_zero_iff_subsingleton is_right_regular_zero_iff_subsingleton
+
+/-- In a non-trivial `mul_zero_class`, the `0` element is not right-regular. -/
+theorem not_is_right_regular_zero_iff : ¬IsRightRegular (0 : R) ↔ Nontrivial R := by
+  rw [nontrivial_iff, not_iff_comm, is_right_regular_zero_iff_subsingleton, subsingleton_iff]
+  push_neg
+  exact Iff.rfl
+#align not_is_right_regular_zero_iff not_is_right_regular_zero_iff
+
+/-- The element `0` is regular if and only if `R` is trivial. -/
+theorem is_regular_iff_subsingleton : IsRegular (0 : R) ↔ Subsingleton R :=
+  ⟨fun h => h.left.Subsingleton, fun h =>
+    ⟨is_left_regular_zero_iff_subsingleton.mpr h, is_right_regular_zero_iff_subsingleton.mpr h⟩⟩
+#align is_regular_iff_subsingleton is_regular_iff_subsingleton
+
+/-- A left-regular element of a `nontrivial` `mul_zero_class` is non-zero. -/
+theorem IsLeftRegular.ne_zero [Nontrivial R] (la : IsLeftRegular a) : a ≠ 0 := by
+  rintro rfl
+  rcases exists_pair_ne R with ⟨x, y, xy⟩
+  refine' xy (la _)
+  rw [zero_mul, zero_mul]
+#align is_left_regular.ne_zero IsLeftRegular.ne_zero
+
+/-- A right-regular element of a `nontrivial` `mul_zero_class` is non-zero. -/
+theorem IsRightRegular.ne_zero [Nontrivial R] (ra : IsRightRegular a) : a ≠ 0 := by
+  rintro rfl
+  rcases exists_pair_ne R with ⟨x, y, xy⟩
+  refine' xy (ra (_ : x * 0 = y * 0))
+  rw [mul_zero, mul_zero]
+#align is_right_regular.ne_zero IsRightRegular.ne_zero
+
+/-- A regular element of a `nontrivial` `mul_zero_class` is non-zero. -/
+theorem IsRegular.ne_zero [Nontrivial R] (la : IsRegular a) : a ≠ 0 :=
+  la.left.NeZero
+#align is_regular.ne_zero IsRegular.ne_zero
+
+/-- In a non-trivial ring, the element `0` is not left-regular -- with typeclasses. -/
+theorem not_is_left_regular_zero [nR : Nontrivial R] : ¬IsLeftRegular (0 : R) :=
+  not_is_left_regular_zero_iff.mpr nR
+#align not_is_left_regular_zero not_is_left_regular_zero
+
+/-- In a non-trivial ring, the element `0` is not right-regular -- with typeclasses. -/
+theorem not_is_right_regular_zero [nR : Nontrivial R] : ¬IsRightRegular (0 : R) :=
+  not_is_right_regular_zero_iff.mpr nR
+#align not_is_right_regular_zero not_is_right_regular_zero
+
+/-- In a non-trivial ring, the element `0` is not regular -- with typeclasses. -/
+theorem not_is_regular_zero [Nontrivial R] : ¬IsRegular (0 : R) := fun h => IsRegular.ne_zero h rfl
+#align not_is_regular_zero not_is_regular_zero
+
+end MulZeroClass
+
+section MulOneClass
+
+variable [MulOneClass R]
+
+/-- If multiplying by `1` on either side is the identity, `1` is regular. -/
+@[to_additive "If adding `0` on either side is the identity, `0` is regular."]
+theorem is_regular_one : IsRegular (1 : R) :=
+  ⟨fun a b ab => (one_mul a).symm.trans (Eq.trans ab (one_mul b)), fun a b ab =>
+    (mul_one a).symm.trans (Eq.trans ab (mul_one b))⟩
+#align is_regular_one is_regular_one
+
+end MulOneClass
+
+section CommSemigroup
+
+variable [CommSemigroup R] {a b : R}
+
+/-- A product is regular if and only if the factors are. -/
+@[to_additive "A sum is add-regular if and only if the summands are."]
+theorem is_regular_mul_iff : IsRegular (a * b) ↔ IsRegular a ∧ IsRegular b := by
+  refine' Iff.trans _ is_regular_mul_and_mul_iff
+  refine' ⟨fun ab => ⟨ab, by rwa [mul_comm]⟩, fun rab => rab.1⟩
+#align is_regular_mul_iff is_regular_mul_iff
+
+end CommSemigroup
+
+section Monoid
+
+variable [Monoid R] {a b : R}
+
+/-- An element admitting a left inverse is left-regular. -/
+@[to_additive "An element admitting a left additive opposite is add-left-regular."]
+theorem is_left_regular_of_mul_eq_one (h : b * a = 1) : IsLeftRegular a :=
+  @IsLeftRegular.of_mul R _ _ _
+    (by
+      rw [h]
+      exact is_regular_one.left)
+#align is_left_regular_of_mul_eq_one is_left_regular_of_mul_eq_one
+
+/-- An element admitting a right inverse is right-regular. -/
+@[to_additive "An element admitting a right additive opposite is add-right-regular."]
+theorem is_right_regular_of_mul_eq_one (h : a * b = 1) : IsRightRegular a :=
+  IsRightRegular.of_mul
+    (by
+      rw [h]
+      exact is_regular_one.right)
+#align is_right_regular_of_mul_eq_one is_right_regular_of_mul_eq_one
+
+/-- If `R` is a monoid, an element in `Rˣ` is regular. -/
+@[to_additive "If `R` is an additive monoid, an element in `add_units R` is add-regular."]
+theorem Units.is_regular (a : Rˣ) : IsRegular (a : R) :=
+  ⟨is_left_regular_of_mul_eq_one a.inv_mul, is_right_regular_of_mul_eq_one a.mul_inv⟩
+#align units.is_regular Units.is_regular
+
+/-- A unit in a monoid is regular. -/
+@[to_additive "An additive unit in an additive monoid is add-regular."]
+theorem IsUnit.is_regular (ua : IsUnit a) : IsRegular a := by
+  rcases ua with ⟨a, rfl⟩
+  exact Units.is_regular a
+#align is_unit.is_regular IsUnit.is_regular
+
+end Monoid
+
+/-- Elements of a left cancel semigroup are left regular. -/
+@[to_additive "Elements of an add left cancel semigroup are add-left-regular."]
+theorem is_left_regular_of_left_cancel_semigroup [LeftCancelSemigroup R] (g : R) : IsLeftRegular g :=
+  mul_right_injective g
+#align is_left_regular_of_left_cancel_semigroup is_left_regular_of_left_cancel_semigroup
+
+/-- Elements of a right cancel semigroup are right regular. -/
+@[to_additive "Elements of an add right cancel semigroup are add-right-regular"]
+theorem is_right_regular_of_right_cancel_semigroup [RightCancelSemigroup R] (g : R) : IsRightRegular g :=
+  mul_left_injective g
+#align is_right_regular_of_right_cancel_semigroup is_right_regular_of_right_cancel_semigroup
+
+section CancelMonoid
+
+variable [CancelMonoid R]
+
+/-- Elements of a cancel monoid are regular.  Cancel semigroups do not appear to exist. -/
+@[to_additive "Elements of an add cancel monoid are regular.  Add cancel semigroups do not appear to exist."]
+theorem is_regular_of_cancel_monoid (g : R) : IsRegular g :=
+  ⟨mul_right_injective g, mul_left_injective g⟩
+#align is_regular_of_cancel_monoid is_regular_of_cancel_monoid
+
+end CancelMonoid
+
+section CancelMonoidWithZero
+
+variable [CancelMonoidWithZero R] {a : R}
+
+/-- Non-zero elements of an integral domain are regular. -/
+theorem is_regular_of_ne_zero (a0 : a ≠ 0) : IsRegular a :=
+  ⟨fun b c => (mul_right_inj' a0).mp, fun b c => (mul_left_inj' a0).mp⟩
+#align is_regular_of_ne_zero is_regular_of_ne_zero
+
+/-- In a non-trivial integral domain, an element is regular iff it is non-zero. -/
+theorem is_regular_iff_ne_zero [Nontrivial R] : IsRegular a ↔ a ≠ 0 :=
+  ⟨IsRegular.ne_zero, is_regular_of_ne_zero⟩
+#align is_regular_iff_ne_zero is_regular_iff_ne_zero
+
+end CancelMonoidWithZero

--- a/Mathlib/Algebra/Regular/Basic.lean
+++ b/Mathlib/Algebra/Regular/Basic.lean
@@ -34,7 +34,7 @@ variable [Mul R]
 
 /-- A left-regular element is an element `c` such that multiplication on the left by `c`
 is injective. -/
-@[to_additive IsAddLeftRegular "An add-left-regular element is an element `c` such that addition
+@[to_additive "An add-left-regular element is an element `c` such that addition
     on the left by `c` is injective."]
 def IsLeftRegular (c : R) :=
   (c * ·).Injective
@@ -42,7 +42,7 @@ def IsLeftRegular (c : R) :=
 
 /-- A right-regular element is an element `c` such that multiplication on the right by `c`
 is injective. -/
-@[to_additive IsAddRightRegular "An add-right-regular element is an element `c` such that addition
+@[to_additive "An add-right-regular element is an element `c` such that addition
     on the right by `c` is injective."]
 def IsRightRegular (c : R) :=
   (· * c).Injective
@@ -66,7 +66,7 @@ structure IsRegular (c : R) : Prop where
   right : IsRightRegular c
 #align is_regular IsRegular
 
-attribute [to_additive IsAddRegular] IsRegular
+attribute [to_additive] IsRegular
 
 @[to_additive]
 protected theorem MulLECancellable.isLeftRegular [PartialOrder R] {a : R}

--- a/Mathlib/Algebra/Regular/Basic.lean
+++ b/Mathlib/Algebra/Regular/Basic.lean
@@ -34,14 +34,14 @@ variable [Mul R]
 
 /-- A left-regular element is an element `c` such that multiplication on the left by `c`
 is injective. -/
-@[to_additive "An add-left-regular element is an element `c` such that addition on the left by `c`\nis injective. -/\n"]
+@[to_additive IsAddLeftRegular "An add-left-regular element is an element `c` such that addition on the left by `c`\nis injective. -/\n"]
 def IsLeftRegular (c : R) :=
   (c * ·).Injective
 #align is_left_regular IsLeftRegular
 
 /-- A right-regular element is an element `c` such that multiplication on the right by `c`
 is injective. -/
-@[to_additive "An add-right-regular element is an element `c` such that addition on the right by `c`\nis injective."]
+@[to_additive IsAddRightRegular "An add-right-regular element is an element `c` such that addition on the right by `c`\nis injective."]
 def IsRightRegular (c : R) :=
   (· * c).Injective
 #align is_right_regular IsRightRegular
@@ -60,7 +60,7 @@ structure IsRegular (c : R) : Prop where
   right : IsRightRegular c
 #align is_regular IsRegular
 
-attribute [to_additive] IsRegular
+attribute [to_additive IsAddRegular] IsRegular
 
 @[to_additive]
 protected theorem MulLECancellable.is_left_regular [PartialOrder R] {a : R} (ha : MulLECancellable a) :

--- a/Mathlib/Tactic/ToAdditive.lean
+++ b/Mathlib/Tactic/ToAdditive.lean
@@ -631,6 +631,12 @@ def fixAbbreviation : List String → List String
 | "Add" :: "Indicator" :: s         => "Indicator" :: fixAbbreviation s
 | "add" :: "Indicator" :: s         => "indicator" :: fixAbbreviation s
 | "add" :: "_" :: "indicator" :: s  => "indicator" :: fixAbbreviation s
+| "is" :: "Regular" :: s            => "isAddRegular" :: fixAbbreviation s
+| "Is" :: "Regular" :: s            => "IsAddRegular" :: fixAbbreviation s
+| "is" :: "Left" :: "Regular" :: s  => "isAddLeftRegular" :: fixAbbreviation s
+| "Is" :: "Left" :: "Regular" :: s  => "IsAddLeftRegular" :: fixAbbreviation s
+| "is" :: "Right" :: "Regular" :: s => "isAddRightRegular" :: fixAbbreviation s
+| "Is" :: "Right" :: "Regular" :: s => "IsAddRightRegular" :: fixAbbreviation s
 -- the capitalization heuristic of `applyNameDict` doesn't work in the following cases
 | "Smul"  :: s                      => "SMul" :: fixAbbreviation s
 | "HSmul" :: s                      => "HSMul" :: fixAbbreviation s

--- a/Mathlib/Tactic/ToAdditive.lean
+++ b/Mathlib/Tactic/ToAdditive.lean
@@ -599,6 +599,8 @@ def applyNameDict : List String → List String
 There are a few abbreviations we use. For example "Nonneg" instead of "ZeroLE"
 or "addComm" instead of "commAdd".
 Note: The input to this function is case sensitive!
+Todo: A lot of abbreviations here are manual fixes and there might be room to
+      improve the naming logic to reduce the size of `fixAbbreviation`.
 -/
 def fixAbbreviation : List String → List String
 | "cancel" :: "Add" :: s            => "addCancel" :: fixAbbreviation s
@@ -631,6 +633,9 @@ def fixAbbreviation : List String → List String
 | "Add" :: "Indicator" :: s         => "Indicator" :: fixAbbreviation s
 | "add" :: "Indicator" :: s         => "indicator" :: fixAbbreviation s
 | "add" :: "_" :: "indicator" :: s  => "indicator" :: fixAbbreviation s
+-- "Regular" is well-used in mathlib3 with various meanings (e.g. in
+-- measure theory) and a direct translation
+-- "regular" --> ["add", "Regular"] in `nameDict` above seems error-prone.
 | "is" :: "Regular" :: s            => "isAddRegular" :: fixAbbreviation s
 | "Is" :: "Regular" :: s            => "IsAddRegular" :: fixAbbreviation s
 | "is" :: "Left" :: "Regular" :: s  => "isAddLeftRegular" :: fixAbbreviation s

--- a/test/toAdditive.lean
+++ b/test/toAdditive.lean
@@ -246,6 +246,10 @@ run_cmd
   checkGuessName "LeftCancelMonoid" "AddLeftCancelMonoid"
   checkGuessName "leftCancelMonoid" "addLeftCancelMonoid"
 
+  checkGuessName "IsLeftRegular" "IsAddLeftRegular"
+  checkGuessName "isRightRegular" "isAddRightRegular"
+  checkGuessName "IsRegular" "IsAddRegular"
+
   checkGuessName "LTOne_LEOne_OneLE_OneLT" "Neg_Nonpos_Nonneg_Pos"
   checkGuessName "LTHMulHPowLEHDiv" "LTHAddHSMulLEHSub"
   checkGuessName "OneLEHMul" "NonnegHAdd"


### PR DESCRIPTION
mathlib SHA: 76171581280d5b5d1e2d1f4f37e5420357bdc636

Porting notes:
1. It seems like `to_additive` is not correctly converting `IsLeftRegular`, `IsRightRegular`, and `IsRegular`. Giving explicit names for their conversion fixes this issue.
2. The proof of `IsLeftRegular.ne_zero` needed an additional type annotation to behave properly