### PR TITLE
[Merged by Bors] - feat(Algebra/Ring/Commute): port file

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -30,6 +30,7 @@ import Mathlib.Algebra.Order.Sub.Defs
 import Mathlib.Algebra.PEmptyInstances
 import Mathlib.Algebra.Quotient
 import Mathlib.Algebra.Ring.Basic
+import Mathlib.Algebra.Ring.Commute
 import Mathlib.Algebra.Ring.Defs
 import Mathlib.Algebra.Ring.InjSurj
 import Mathlib.Algebra.Ring.OrderSynonym

--- a/Mathlib/Algebra/Group/Commute.lean
+++ b/Mathlib/Algebra/Group/Commute.lean
@@ -226,19 +226,19 @@ theorem units_inv_left_iff : Commute (↑u⁻¹) a ↔ Commute (↑u) a :=
 
 @[to_additive]
 theorem units_val : Commute u₁ u₂ → Commute (u₁ : M) u₂ :=
-  SemiconjBy.units_coe
+  SemiconjBy.units_val
 #align commute.units_coe Commute.units_val
 #align add_commute.add_units_coe AddCommute.addUnits_val
 
 @[to_additive]
 theorem units_of_val : Commute (u₁ : M) u₂ → Commute u₁ u₂ :=
-  SemiconjBy.units_of_coe
+  SemiconjBy.units_of_val
 #align commute.units_of_coe Commute.units_of_val
 #align add_commute.add_units_of_coe AddCommute.addUnits_of_val
 
 @[simp, to_additive]
 theorem units_val_iff : Commute (u₁ : M) u₂ ↔ Commute u₁ u₂ :=
-  SemiconjBy.units_coe_iff
+  SemiconjBy.units_val_iff
 #align commute.units_coe_iff Commute.units_val_iff
 #align add_commute.add_units_coe_iff AddCommute.addUnits_val_iff
 

--- a/Mathlib/Algebra/Group/Commute.lean
+++ b/Mathlib/Algebra/Group/Commute.lean
@@ -3,15 +3,15 @@ Copyright (c) 2019 Neil Strickland. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Neil Strickland, Yury Kudryashov
 -/
-import Mathbin.Algebra.Group.Semiconj
+import Mathlib.Algebra.Group.Semiconj
 
 /-!
 # Commuting pairs of elements in monoids
 
-We define the predicate `commute a b := a * b = b * a` and provide some operations on terms `(h :
-commute a b)`. E.g., if `a`, `b`, and c are elements of a semiring, and that `hb : commute a b` and
-`hc : commute a c`.  Then `hb.pow_left 5` proves `commute (a ^ 5) b` and `(hb.pow_right 2).add_right
-(hb.mul_right hc)` proves `commute a (b ^ 2 + b * c)`.
+We define the predicate `Commute a b := a * b = b * a` and provide some operations on terms
+`(h : Commute a b)`. E.g., if `a`, `b`, and c are elements of a semiring, and that
+`hb : Commute a b` and `hc : Commute a c`.  Then `hb.pow_left 5` proves `Commute (a ^ 5) b` and
+`(hb.pow_right 2).add_right (hb.mul_right hc)` proves `commute a (b ^ 2 + b * c)`.
 
 Lean does not immediately recognise these terms as equations, so for rewriting we need syntax like
 `rw [(hb.pow_left 5).eq]` rather than just `rw [hb.pow_left 5]`.
@@ -21,19 +21,18 @@ This file defines only a few operations (`mul_left`, `inv_right`, etc).  Other o
 
 ## Implementation details
 
-Most of the proofs come from the properties of `semiconj_by`.
+Most of the proofs come from the properties of `SemiconjBy`.
 -/
 
 
 variable {G : Type _}
 
-#print Commute /-
 /-- Two elements commute if `a * b = b * a`. -/
 @[to_additive AddCommute "Two elements additively commute if `a + b = b + a`"]
 def Commute {S : Type _} [Mul S] (a b : S) : Prop :=
   SemiconjBy a b b
 #align commute Commute
--/
+#align add_commute AddCommute
 
 namespace Commute
 
@@ -41,43 +40,38 @@ section Mul
 
 variable {S : Type _} [Mul S]
 
-#print Commute.eq /-
-/-- Equality behind `commute a b`; useful for rewriting. -/
+/-- Equality behind `Commute a b`; useful for rewriting. -/
 @[to_additive "Equality behind `add_commute a b`; useful for rewriting."]
 protected theorem eq {a b : S} (h : Commute a b) : a * b = b * a :=
   h
 #align commute.eq Commute.eq
--/
+#align add_commute.eq AddCommute.eq
 
-#print Commute.refl /-
 /-- Any element commutes with itself. -/
 @[refl, simp, to_additive "Any element commutes with itself."]
 protected theorem refl (a : S) : Commute a a :=
   Eq.refl (a * a)
 #align commute.refl Commute.refl
--/
+#align add_commute.refl AddCommute.refl
 
-#print Commute.symm /-
 /-- If `a` commutes with `b`, then `b` commutes with `a`. -/
 @[symm, to_additive "If `a` commutes with `b`, then `b` commutes with `a`."]
 protected theorem symm {a b : S} (h : Commute a b) : Commute b a :=
   Eq.symm h
 #align commute.symm Commute.symm
--/
+#align add_commute.symm AddCommute.symm
 
-#print Commute.semiconjBy /-
 @[to_additive]
 protected theorem semiconjBy {a b : S} (h : Commute a b) : SemiconjBy a b b :=
   h
 #align commute.semiconj_by Commute.semiconjBy
--/
+#align add_commute.semiconj_by AddCommute.semiconjBy
 
-#print Commute.symm_iff /-
 @[to_additive]
 protected theorem symm_iff {a b : S} : Commute a b ↔ Commute b a :=
   ⟨Commute.symm, Commute.symm⟩
 #align commute.symm_iff Commute.symm_iff
--/
+#align add_commute.symm_iff AddCommute.symm_iff
 
 @[to_additive]
 instance : IsRefl S Commute :=
@@ -85,9 +79,10 @@ instance : IsRefl S Commute :=
 
 -- This instance is useful for `finset.noncomm_prod`
 @[to_additive]
-instance on_is_refl {f : G → S} : IsRefl G fun a b => Commute (f a) (f b) :=
+instance on_isRefl {f : G → S} : IsRefl G fun a b => Commute (f a) (f b) :=
   ⟨fun _ => Commute.refl _⟩
-#align commute.on_is_refl Commute.on_is_refl
+#align commute.on_is_refl Commute.on_isRefl
+#align add_commute.on_is_refl AddCommute.on_isRefl
 
 end Mul
 
@@ -95,88 +90,104 @@ section Semigroup
 
 variable {S : Type _} [Semigroup S] {a b c : S}
 
+/-- If `a` commutes with both `b` and `c`, then it commutes with their product. -/
+@[simp, to_additive "If `a` commutes with both `b` and `c`, then it commutes with their sum."]
+theorem mul_right (hab : Commute a b) (hac : Commute a c) : Commute a (b * c) :=
+  SemiconjBy.mul_right hab hac
+#align commute.mul_right Commute.mul_rightₓ
+#align add_commute.add_right AddCommute.add_rightₓ
+-- I think `ₓ` is necessary because of the `mul` vs `HMul` distinction
 /- warning: commute.mul_right -> Commute.mul_right is a dubious translation:
 lean 3 declaration is
   forall {S : Type.{u_2}} [_inst_1 : Semigroup.{u_2} S] {a : S} {b : S} {c : S}, (Commute.{u_2} S (Semigroup.toHasMul.{u_2} S _inst_1) a b) -> (Commute.{u_2} S (Semigroup.toHasMul.{u_2} S _inst_1) a c) -> (Commute.{u_2} S (Semigroup.toHasMul.{u_2} S _inst_1) a (HMul.hMul.{u_2 u_2 u_2} S S S (instHMul.{u_2} S (Semigroup.toHasMul.{u_2} S _inst_1)) b c))
 but is expected to have type
   forall {S : Type.{u_1}} [inst._@.Mathlib.Algebra.Group.Commute._hyg.141 : Semigroup.{u_1} S] {a : S} {b : S} {c : S}, (Commute.{u_1} S (Semigroup.toMul.{u_1} S inst._@.Mathlib.Algebra.Group.Commute._hyg.141) a b) -> (Commute.{u_1} S (Semigroup.toMul.{u_1} S inst._@.Mathlib.Algebra.Group.Commute._hyg.141) a c) -> (Commute.{u_1} S (Semigroup.toMul.{u_1} S inst._@.Mathlib.Algebra.Group.Commute._hyg.141) a (HMul.hMul.{u_1 u_1 u_1} S S S (instHMul.{u_1} S (Semigroup.toMul.{u_1} S inst._@.Mathlib.Algebra.Group.Commute._hyg.141)) b c))
 Case conversion may be inaccurate. Consider using '#align commute.mul_right Commute.mul_rightₓ'. -/
-/-- If `a` commutes with both `b` and `c`, then it commutes with their product. -/
-@[simp, to_additive "If `a` commutes with both `b` and `c`, then it commutes with their sum."]
-theorem mul_right (hab : Commute a b) (hac : Commute a c) : Commute a (b * c) :=
-  hab.mul_right hac
-#align commute.mul_right Commute.mul_right
 
+/-- If both `a` and `b` commute with `c`, then their product commutes with `c`. -/
+@[simp, to_additive "If both `a` and `b` commute with `c`, then their product commutes with `c`."]
+theorem mul_left (hac : Commute a c) (hbc : Commute b c) : Commute (a * b) c :=
+  SemiconjBy.mul_left hac hbc
+#align commute.mul_left Commute.mul_leftₓ
+#align add_commute.add_left AddCommute.add_leftₓ
+-- I think `ₓ` is necessary because of the `mul` vs `HMul` distinction
 /- warning: commute.mul_left -> Commute.mul_left is a dubious translation:
 lean 3 declaration is
   forall {S : Type.{u_2}} [_inst_1 : Semigroup.{u_2} S] {a : S} {b : S} {c : S}, (Commute.{u_2} S (Semigroup.toHasMul.{u_2} S _inst_1) a c) -> (Commute.{u_2} S (Semigroup.toHasMul.{u_2} S _inst_1) b c) -> (Commute.{u_2} S (Semigroup.toHasMul.{u_2} S _inst_1) (HMul.hMul.{u_2 u_2 u_2} S S S (instHMul.{u_2} S (Semigroup.toHasMul.{u_2} S _inst_1)) a b) c)
 but is expected to have type
   forall {S : Type.{u_1}} [inst._@.Mathlib.Algebra.Group.Commute._hyg.168 : Semigroup.{u_1} S] {a : S} {b : S} {c : S}, (Commute.{u_1} S (Semigroup.toMul.{u_1} S inst._@.Mathlib.Algebra.Group.Commute._hyg.168) a c) -> (Commute.{u_1} S (Semigroup.toMul.{u_1} S inst._@.Mathlib.Algebra.Group.Commute._hyg.168) b c) -> (Commute.{u_1} S (Semigroup.toMul.{u_1} S inst._@.Mathlib.Algebra.Group.Commute._hyg.168) (HMul.hMul.{u_1 u_1 u_1} S S S (instHMul.{u_1} S (Semigroup.toMul.{u_1} S inst._@.Mathlib.Algebra.Group.Commute._hyg.168)) a b) c)
 Case conversion may be inaccurate. Consider using '#align commute.mul_left Commute.mul_leftₓ'. -/
-/-- If both `a` and `b` commute with `c`, then their product commutes with `c`. -/
-@[simp, to_additive "If both `a` and `b` commute with `c`, then their product commutes with `c`."]
-theorem mul_left (hac : Commute a c) (hbc : Commute b c) : Commute (a * b) c :=
-  hac.mul_left hbc
-#align commute.mul_left Commute.mul_left
 
+@[to_additive]
+protected theorem right_comm (h : Commute b c) (a : S) : a * b * c = a * c * b :=
+  by simp only [mul_assoc, h.eq]
+#align commute.right_comm Commute.right_commₓ
+#align add_commute.right_comm AddCommute.right_commₓ
+-- I think `ₓ` is necessary because of the `mul` vs `HMul` distinction
 /- warning: commute.right_comm -> Commute.right_comm is a dubious translation:
 lean 3 declaration is
   forall {S : Type.{u_2}} [_inst_1 : Semigroup.{u_2} S] {b : S} {c : S}, (Commute.{u_2} S (Semigroup.toHasMul.{u_2} S _inst_1) b c) -> (forall (a : S), Eq.{succ u_2} S (HMul.hMul.{u_2 u_2 u_2} S S S (instHMul.{u_2} S (Semigroup.toHasMul.{u_2} S _inst_1)) (HMul.hMul.{u_2 u_2 u_2} S S S (instHMul.{u_2} S (Semigroup.toHasMul.{u_2} S _inst_1)) a b) c) (HMul.hMul.{u_2 u_2 u_2} S S S (instHMul.{u_2} S (Semigroup.toHasMul.{u_2} S _inst_1)) (HMul.hMul.{u_2 u_2 u_2} S S S (instHMul.{u_2} S (Semigroup.toHasMul.{u_2} S _inst_1)) a c) b))
 but is expected to have type
   forall {S : Type.{u_1}} [inst._@.Mathlib.Algebra.Group.Commute._hyg.195 : Semigroup.{u_1} S] {b : S} {c : S}, (Commute.{u_1} S (Semigroup.toMul.{u_1} S inst._@.Mathlib.Algebra.Group.Commute._hyg.195) b c) -> (forall (a : S), Eq.{succ u_1} S (HMul.hMul.{u_1 u_1 u_1} S S S (instHMul.{u_1} S (Semigroup.toMul.{u_1} S inst._@.Mathlib.Algebra.Group.Commute._hyg.195)) (HMul.hMul.{u_1 u_1 u_1} S S S (instHMul.{u_1} S (Semigroup.toMul.{u_1} S inst._@.Mathlib.Algebra.Group.Commute._hyg.195)) a b) c) (HMul.hMul.{u_1 u_1 u_1} S S S (instHMul.{u_1} S (Semigroup.toMul.{u_1} S inst._@.Mathlib.Algebra.Group.Commute._hyg.195)) (HMul.hMul.{u_1 u_1 u_1} S S S (instHMul.{u_1} S (Semigroup.toMul.{u_1} S inst._@.Mathlib.Algebra.Group.Commute._hyg.195)) a c) b))
 Case conversion may be inaccurate. Consider using '#align commute.right_comm Commute.right_commₓ'. -/
-@[to_additive]
-protected theorem right_comm (h : Commute b c) (a : S) : a * b * c = a * c * b := by simp only [mul_assoc, h.eq]
-#align commute.right_comm Commute.right_comm
 
+@[to_additive]
+protected theorem left_comm (h : Commute a b) (c) : a * (b * c) = b * (a * c) :=
+  by simp only [← mul_assoc, h.eq]
+#align commute.left_comm Commute.left_commₓ
+#align add_commute.left_comm AddCommute.left_commₓ
+-- I think `ₓ` is necessary because of the `mul` vs `HMul` distinction
 /- warning: commute.left_comm -> Commute.left_comm is a dubious translation:
 lean 3 declaration is
   forall {S : Type.{u_2}} [_inst_1 : Semigroup.{u_2} S] {a : S} {b : S}, (Commute.{u_2} S (Semigroup.toHasMul.{u_2} S _inst_1) a b) -> (forall (c : S), Eq.{succ u_2} S (HMul.hMul.{u_2 u_2 u_2} S S S (instHMul.{u_2} S (Semigroup.toHasMul.{u_2} S _inst_1)) a (HMul.hMul.{u_2 u_2 u_2} S S S (instHMul.{u_2} S (Semigroup.toHasMul.{u_2} S _inst_1)) b c)) (HMul.hMul.{u_2 u_2 u_2} S S S (instHMul.{u_2} S (Semigroup.toHasMul.{u_2} S _inst_1)) b (HMul.hMul.{u_2 u_2 u_2} S S S (instHMul.{u_2} S (Semigroup.toHasMul.{u_2} S _inst_1)) a c)))
 but is expected to have type
   forall {S : Type.{u_1}} [inst._@.Mathlib.Algebra.Group.Commute._hyg.226 : Semigroup.{u_1} S] {a : S} {b : S}, (Commute.{u_1} S (Semigroup.toMul.{u_1} S inst._@.Mathlib.Algebra.Group.Commute._hyg.226) a b) -> (forall (c : S), Eq.{succ u_1} S (HMul.hMul.{u_1 u_1 u_1} S S S (instHMul.{u_1} S (Semigroup.toMul.{u_1} S inst._@.Mathlib.Algebra.Group.Commute._hyg.226)) a (HMul.hMul.{u_1 u_1 u_1} S S S (instHMul.{u_1} S (Semigroup.toMul.{u_1} S inst._@.Mathlib.Algebra.Group.Commute._hyg.226)) b c)) (HMul.hMul.{u_1 u_1 u_1} S S S (instHMul.{u_1} S (Semigroup.toMul.{u_1} S inst._@.Mathlib.Algebra.Group.Commute._hyg.226)) b (HMul.hMul.{u_1 u_1 u_1} S S S (instHMul.{u_1} S (Semigroup.toMul.{u_1} S inst._@.Mathlib.Algebra.Group.Commute._hyg.226)) a c)))
 Case conversion may be inaccurate. Consider using '#align commute.left_comm Commute.left_commₓ'. -/
-@[to_additive]
-protected theorem left_comm (h : Commute a b) (c) : a * (b * c) = b * (a * c) := by simp only [← mul_assoc, h.eq]
-#align commute.left_comm Commute.left_comm
 
 end Semigroup
 
+@[to_additive]
+protected theorem all {S : Type _} [CommSemigroup S] (a b : S) : Commute a b :=
+  mul_comm a b
+#align commute.all Commute.allₓ
+#align add_commute.all AddCommute.allₓ
+-- not sure why this needs an `ₓ`, maybe instance names not aligned?
 /- warning: commute.all -> Commute.all is a dubious translation:
 lean 3 declaration is
   forall {S : Type.{u_1}} [_inst_1 : CommSemigroup.{u_1} S] (a : S) (b : S), Commute.{u_1} S (Semigroup.toHasMul.{u_1} S (CommSemigroup.toSemigroup.{u_1} S _inst_1)) a b
 but is expected to have type
   forall {S : Type.{u_1}} [inst._@.Mathlib.Algebra.Group.Commute._hyg.258 : CommSemigroup.{u_1} S] (a : S) (b : S), Commute.{u_1} S (Semigroup.toMul.{u_1} S (CommSemigroup.toSemigroup.{u_1} S inst._@.Mathlib.Algebra.Group.Commute._hyg.258)) a b
 Case conversion may be inaccurate. Consider using '#align commute.all Commute.allₓ'. -/
-@[to_additive]
-protected theorem all {S : Type _} [CommSemigroup S] (a b : S) : Commute a b :=
-  mul_comm a b
-#align commute.all Commute.all
 
 section MulOneClass
 
 variable {M : Type _} [MulOneClass M]
 
+@[simp, to_additive]
+theorem one_right (a : M) : Commute a 1 :=
+  SemiconjBy.one_right a
+#align commute.one_right Commute.one_rightₓ
+#align add_commute.zero_right AddCommute.zero_rightₓ
+-- I think `ₓ` is necessary because `One.toOfNat1` appears in the Lean 4 version
 /- warning: commute.one_right -> Commute.one_right is a dubious translation:
 lean 3 declaration is
   forall {M : Type.{u_2}} [_inst_1 : MulOneClass.{u_2} M] (a : M), Commute.{u_2} M (MulOneClass.toHasMul.{u_2} M _inst_1) a (OfNat.ofNat.{u_2} M 1 (OfNat.mk.{u_2} M 1 (One.one.{u_2} M (MulOneClass.toHasOne.{u_2} M _inst_1))))
 but is expected to have type
   forall {M : Type.{u_1}} [inst._@.Mathlib.Algebra.Group.Commute._hyg.281 : MulOneClass.{u_1} M] (a : M), Commute.{u_1} M (MulOneClass.toMul.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.281) a (OfNat.ofNat.{u_1} M 1 (One.toOfNat1.{u_1} M (MulOneClass.toOne.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.281)))
 Case conversion may be inaccurate. Consider using '#align commute.one_right Commute.one_rightₓ'. -/
-@[simp, to_additive]
-theorem one_right (a : M) : Commute a 1 :=
-  SemiconjBy.one_right a
-#align commute.one_right Commute.one_right
 
+@[simp, to_additive]
+theorem one_left (a : M) : Commute 1 a :=
+  SemiconjBy.one_left a
+#align commute.one_left Commute.one_leftₓ
+#align add_commute.zero_left AddCommute.zero_leftₓ
+-- I think `ₓ` is necessary because `One.toOfNat1` appears in the Lean 4 version
 /- warning: commute.one_left -> Commute.one_left is a dubious translation:
 lean 3 declaration is
   forall {M : Type.{u_2}} [_inst_1 : MulOneClass.{u_2} M] (a : M), Commute.{u_2} M (MulOneClass.toHasMul.{u_2} M _inst_1) (OfNat.ofNat.{u_2} M 1 (OfNat.mk.{u_2} M 1 (One.one.{u_2} M (MulOneClass.toHasOne.{u_2} M _inst_1)))) a
 but is expected to have type
   forall {M : Type.{u_1}} [inst._@.Mathlib.Algebra.Group.Commute._hyg.293 : MulOneClass.{u_1} M] (a : M), Commute.{u_1} M (MulOneClass.toMul.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.293) (OfNat.ofNat.{u_1} M 1 (One.toOfNat1.{u_1} M (MulOneClass.toOne.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.293))) a
 Case conversion may be inaccurate. Consider using '#align commute.one_left Commute.one_leftₓ'. -/
-@[simp, to_additive]
-theorem one_left (a : M) : Commute 1 a :=
-  SemiconjBy.one_left a
-#align commute.one_left Commute.one_left
 
 end MulOneClass
 
@@ -184,138 +195,165 @@ section Monoid
 
 variable {M : Type _} [Monoid M] {a b : M} {u u₁ u₂ : Mˣ}
 
+@[simp, to_additive]
+theorem pow_right (h : Commute a b) (n : ℕ) : Commute a (b ^ n) :=
+  SemiconjBy.pow_right h n
+#align commute.pow_right Commute.pow_rightₓ
+#align add_commute.smul_right AddCommute.smul_rightₓ
+-- `MulOneClass.toHasMul` vs. `MulOneClass.toMul`
 /- warning: commute.pow_right -> Commute.pow_right is a dubious translation:
 lean 3 declaration is
   forall {M : Type.{u_2}} [_inst_1 : Monoid.{u_2} M] {a : M} {b : M}, (Commute.{u_2} M (MulOneClass.toHasMul.{u_2} M (Monoid.toMulOneClass.{u_2} M _inst_1)) a b) -> (forall (n : Nat), Commute.{u_2} M (MulOneClass.toHasMul.{u_2} M (Monoid.toMulOneClass.{u_2} M _inst_1)) a (HPow.hPow.{u_2 0 u_2} M Nat M (instHPow.{u_2 0} M Nat (Monoid.hasPow.{u_2} M _inst_1)) b n))
 but is expected to have type
   forall {M : Type.{u_1}} [inst._@.Mathlib.Algebra.Group.Commute._hyg.319 : Monoid.{u_1} M] {a : M} {b : M}, (Commute.{u_1} M (MulOneClass.toMul.{u_1} M (Monoid.toMulOneClass.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.319)) a b) -> (forall (n : Nat), Commute.{u_1} M (MulOneClass.toMul.{u_1} M (Monoid.toMulOneClass.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.319)) a (HPow.hPow.{u_1 0 u_1} M Nat M (instHPow.{u_1 0} M Nat (Monoid.Pow.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.319)) b n))
 Case conversion may be inaccurate. Consider using '#align commute.pow_right Commute.pow_rightₓ'. -/
-@[simp, to_additive]
-theorem pow_right (h : Commute a b) (n : ℕ) : Commute a (b ^ n) :=
-  h.pow_right n
-#align commute.pow_right Commute.pow_right
 
+@[simp, to_additive]
+theorem pow_left (h : Commute a b) (n : ℕ) : Commute (a ^ n) b :=
+  (h.symm.pow_right n).symm
+#align commute.pow_left Commute.pow_leftₓ
+#align add_commute.smul_left AddCommute.smul_leftₓ
+-- `MulOneClass.toHasMul` vs. `MulOneClass.toMul`
 /- warning: commute.pow_left -> Commute.pow_left is a dubious translation:
 lean 3 declaration is
   forall {M : Type.{u_2}} [_inst_1 : Monoid.{u_2} M] {a : M} {b : M}, (Commute.{u_2} M (MulOneClass.toHasMul.{u_2} M (Monoid.toMulOneClass.{u_2} M _inst_1)) a b) -> (forall (n : Nat), Commute.{u_2} M (MulOneClass.toHasMul.{u_2} M (Monoid.toMulOneClass.{u_2} M _inst_1)) (HPow.hPow.{u_2 0 u_2} M Nat M (instHPow.{u_2 0} M Nat (Monoid.hasPow.{u_2} M _inst_1)) a n) b)
 but is expected to have type
   forall {M : Type.{u_1}} [inst._@.Mathlib.Algebra.Group.Commute._hyg.345 : Monoid.{u_1} M] {a : M} {b : M}, (Commute.{u_1} M (MulOneClass.toMul.{u_1} M (Monoid.toMulOneClass.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.345)) a b) -> (forall (n : Nat), Commute.{u_1} M (MulOneClass.toMul.{u_1} M (Monoid.toMulOneClass.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.345)) (HPow.hPow.{u_1 0 u_1} M Nat M (instHPow.{u_1 0} M Nat (Monoid.Pow.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.345)) a n) b)
 Case conversion may be inaccurate. Consider using '#align commute.pow_left Commute.pow_leftₓ'. -/
-@[simp, to_additive]
-theorem pow_left (h : Commute a b) (n : ℕ) : Commute (a ^ n) b :=
-  (h.symm.pow_right n).symm
-#align commute.pow_left Commute.pow_left
 
+@[simp, to_additive]
+theorem pow_pow (h : Commute a b) (m n : ℕ) : Commute (a ^ m) (b ^ n) :=
+  (h.pow_left m).pow_right n
+#align commute.pow_pow Commute.pow_powₓ
+#align add_commute.smul_smul AddCommute.smul_smulₓ
+-- `MulOneClass.toHasMul` vs. `MulOneClass.toMul`
 /- warning: commute.pow_pow -> Commute.pow_pow is a dubious translation:
 lean 3 declaration is
   forall {M : Type.{u_2}} [_inst_1 : Monoid.{u_2} M] {a : M} {b : M}, (Commute.{u_2} M (MulOneClass.toHasMul.{u_2} M (Monoid.toMulOneClass.{u_2} M _inst_1)) a b) -> (forall (m : Nat) (n : Nat), Commute.{u_2} M (MulOneClass.toHasMul.{u_2} M (Monoid.toMulOneClass.{u_2} M _inst_1)) (HPow.hPow.{u_2 0 u_2} M Nat M (instHPow.{u_2 0} M Nat (Monoid.hasPow.{u_2} M _inst_1)) a m) (HPow.hPow.{u_2 0 u_2} M Nat M (instHPow.{u_2 0} M Nat (Monoid.hasPow.{u_2} M _inst_1)) b n))
 but is expected to have type
   forall {M : Type.{u_1}} [inst._@.Mathlib.Algebra.Group.Commute._hyg.373 : Monoid.{u_1} M] {a : M} {b : M}, (Commute.{u_1} M (MulOneClass.toMul.{u_1} M (Monoid.toMulOneClass.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.373)) a b) -> (forall (m : Nat) (n : Nat), Commute.{u_1} M (MulOneClass.toMul.{u_1} M (Monoid.toMulOneClass.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.373)) (HPow.hPow.{u_1 0 u_1} M Nat M (instHPow.{u_1 0} M Nat (Monoid.Pow.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.373)) a m) (HPow.hPow.{u_1 0 u_1} M Nat M (instHPow.{u_1 0} M Nat (Monoid.Pow.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.373)) b n))
 Case conversion may be inaccurate. Consider using '#align commute.pow_pow Commute.pow_powₓ'. -/
-@[simp, to_additive]
-theorem pow_pow (h : Commute a b) (m n : ℕ) : Commute (a ^ m) (b ^ n) :=
-  (h.pow_left m).pow_right n
-#align commute.pow_pow Commute.pow_pow
 
+@[simp, to_additive]
+theorem self_pow (a : M) (n : ℕ) : Commute a (a ^ n) :=
+  (Commute.refl a).pow_right n
+#align commute.self_pow Commute.self_powₓ
+#align add_commute.self_smul AddCommute.self_smulₓ
+-- `MulOneClass.toHasMul` vs. `MulOneClass.toMul`
 /- warning: commute.self_pow -> Commute.self_pow is a dubious translation:
 lean 3 declaration is
   forall {M : Type.{u_2}} [_inst_1 : Monoid.{u_2} M] (a : M) (n : Nat), Commute.{u_2} M (MulOneClass.toHasMul.{u_2} M (Monoid.toMulOneClass.{u_2} M _inst_1)) a (HPow.hPow.{u_2 0 u_2} M Nat M (instHPow.{u_2 0} M Nat (Monoid.hasPow.{u_2} M _inst_1)) a n)
 but is expected to have type
   forall {M : Type.{u_1}} [inst._@.Mathlib.Algebra.Group.Commute._hyg.411 : Monoid.{u_1} M] (a : M) (n : Nat), Commute.{u_1} M (MulOneClass.toMul.{u_1} M (Monoid.toMulOneClass.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.411)) a (HPow.hPow.{u_1 0 u_1} M Nat M (instHPow.{u_1 0} M Nat (Monoid.Pow.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.411)) a n)
 Case conversion may be inaccurate. Consider using '#align commute.self_pow Commute.self_powₓ'. -/
-@[simp, to_additive]
-theorem self_pow (a : M) (n : ℕ) : Commute a (a ^ n) :=
-  (Commute.refl a).pow_right n
-#align commute.self_pow Commute.self_pow
 
+@[simp, to_additive]
+theorem pow_self (a : M) (n : ℕ) : Commute (a ^ n) a :=
+  (Commute.refl a).pow_left n
+#align add_commute.smul_self AddCommute.smul_selfₓ
+-- `MulOneClass.toHasMul` vs. `MulOneClass.toMul`
 /- warning: commute.pow_self -> Commute.pow_self is a dubious translation:
 lean 3 declaration is
   forall {M : Type.{u_2}} [_inst_1 : Monoid.{u_2} M] (a : M) (n : Nat), Commute.{u_2} M (MulOneClass.toHasMul.{u_2} M (Monoid.toMulOneClass.{u_2} M _inst_1)) (HPow.hPow.{u_2 0 u_2} M Nat M (instHPow.{u_2 0} M Nat (Monoid.hasPow.{u_2} M _inst_1)) a n) a
 but is expected to have type
   forall {M : Type.{u_1}} [inst._@.Mathlib.Algebra.Group.Commute._hyg.438 : Monoid.{u_1} M] (a : M) (n : Nat), Commute.{u_1} M (MulOneClass.toMul.{u_1} M (Monoid.toMulOneClass.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.438)) (HPow.hPow.{u_1 0 u_1} M Nat M (instHPow.{u_1 0} M Nat (Monoid.Pow.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.438)) a n) a
 Case conversion may be inaccurate. Consider using '#align commute.pow_self Commute.pow_selfₓ'. -/
-@[simp, to_additive]
-theorem pow_self (a : M) (n : ℕ) : Commute (a ^ n) a :=
-  (Commute.refl a).pow_left n
-#align commute.pow_self Commute.pow_self
 
+@[simp, to_additive]
+theorem pow_pow_self (a : M) (m n : ℕ) : Commute (a ^ m) (a ^ n) :=
+  (Commute.refl a).pow_pow m n
+#align commute.pow_pow_self Commute.pow_pow_selfₓ
+#align add_commute.smul_smul_self AddCommute.smul_smul_selfₓ
+-- `MulOneClass.toHasMul` vs. `MulOneClass.toMul`
 /- warning: commute.pow_pow_self -> Commute.pow_pow_self is a dubious translation:
 lean 3 declaration is
   forall {M : Type.{u_2}} [_inst_1 : Monoid.{u_2} M] (a : M) (m : Nat) (n : Nat), Commute.{u_2} M (MulOneClass.toHasMul.{u_2} M (Monoid.toMulOneClass.{u_2} M _inst_1)) (HPow.hPow.{u_2 0 u_2} M Nat M (instHPow.{u_2 0} M Nat (Monoid.hasPow.{u_2} M _inst_1)) a m) (HPow.hPow.{u_2 0 u_2} M Nat M (instHPow.{u_2 0} M Nat (Monoid.hasPow.{u_2} M _inst_1)) a n)
 but is expected to have type
   forall {M : Type.{u_1}} [inst._@.Mathlib.Algebra.Group.Commute._hyg.465 : Monoid.{u_1} M] (a : M) (m : Nat) (n : Nat), Commute.{u_1} M (MulOneClass.toMul.{u_1} M (Monoid.toMulOneClass.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.465)) (HPow.hPow.{u_1 0 u_1} M Nat M (instHPow.{u_1 0} M Nat (Monoid.Pow.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.465)) a m) (HPow.hPow.{u_1 0 u_1} M Nat M (instHPow.{u_1 0} M Nat (Monoid.Pow.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.465)) a n)
 Case conversion may be inaccurate. Consider using '#align commute.pow_pow_self Commute.pow_pow_selfₓ'. -/
-@[simp, to_additive]
-theorem pow_pow_self (a : M) (m n : ℕ) : Commute (a ^ m) (a ^ n) :=
-  (Commute.refl a).pow_pow m n
-#align commute.pow_pow_self Commute.pow_pow_self
 
 @[to_additive succ_nsmul']
 theorem _root_.pow_succ' (a : M) (n : ℕ) : a ^ (n + 1) = a ^ n * a :=
   (pow_succ a n).trans (self_pow _ _)
-#align commute._root_.pow_succ' commute._root_.pow_succ'
+#align pow_succ' pow_succ'
+#align succ_nsmul' succ_nsmul'
 
 @[to_additive]
 theorem units_inv_right : Commute a u → Commute a ↑u⁻¹ :=
   SemiconjBy.units_inv_right
 #align commute.units_inv_right Commute.units_inv_right
+#align add_commute.add_units_neg_right AddCommute.addUnits_neg_right
 
 @[simp, to_additive]
 theorem units_inv_right_iff : Commute a ↑u⁻¹ ↔ Commute a u :=
   SemiconjBy.units_inv_right_iff
 #align commute.units_inv_right_iff Commute.units_inv_right_iff
+#align add_commute.add_units_neg_right_iff AddCommute.addUnits_neg_right_iff
 
 @[to_additive]
 theorem units_inv_left : Commute (↑u) a → Commute (↑u⁻¹) a :=
   SemiconjBy.units_inv_symm_left
 #align commute.units_inv_left Commute.units_inv_left
+#align add_commute.add_units_neg_left AddCommute.addUnits_neg_left
 
 @[simp, to_additive]
 theorem units_inv_left_iff : Commute (↑u⁻¹) a ↔ Commute (↑u) a :=
   SemiconjBy.units_inv_symm_left_iff
 #align commute.units_inv_left_iff Commute.units_inv_left_iff
+#align add_commute.add_units_neg_left_iff AddCommute.addUnits_neg_left_iff
 
 @[to_additive]
-theorem units_coe : Commute u₁ u₂ → Commute (u₁ : M) u₂ :=
+theorem units_val : Commute u₁ u₂ → Commute (u₁ : M) u₂ :=
   SemiconjBy.units_coe
-#align commute.units_coe Commute.units_coe
+#align commute.units_coe Commute.units_val
+#align add_commute.add_units_coe AddCommute.addUnits_val
 
 @[to_additive]
-theorem units_of_coe : Commute (u₁ : M) u₂ → Commute u₁ u₂ :=
+theorem units_of_val : Commute (u₁ : M) u₂ → Commute u₁ u₂ :=
   SemiconjBy.units_of_coe
-#align commute.units_of_coe Commute.units_of_coe
+#align commute.units_of_coe Commute.units_of_val
+#align add_commute.add_units_of_coe AddCommute.addUnits_of_val
 
 @[simp, to_additive]
-theorem units_coe_iff : Commute (u₁ : M) u₂ ↔ Commute u₁ u₂ :=
+theorem units_val_iff : Commute (u₁ : M) u₂ ↔ Commute u₁ u₂ :=
   SemiconjBy.units_coe_iff
-#align commute.units_coe_iff Commute.units_coe_iff
+#align commute.units_coe_iff Commute.units_val_iff
+#align add_commute.add_units_coe_iff AddCommute.addUnits_val_iff
 
 /-- If the product of two commuting elements is a unit, then the left multiplier is a unit. -/
-@[to_additive "If the sum of two commuting elements is an additive unit, then the left summand is an\nadditive unit."]
-def _root_.units.left_of_mul (u : Mˣ) (a b : M) (hu : a * b = u) (hc : Commute a b) : Mˣ where
+@[to_additive "If the sum of two commuting elements is an additive unit, then the left summand is
+an additive unit."]
+def _root_.Units.leftOfMul (u : Mˣ) (a b : M) (hu : a * b = u) (hc : Commute a b) : Mˣ where
   val := a
   inv := b * ↑u⁻¹
   val_inv := by rw [← mul_assoc, hu, u.mul_inv]
   inv_val := by
     have : Commute a u := hu ▸ (Commute.refl _).mul_right hc
     rw [← this.units_inv_right.right_comm, ← hc.eq, hu, u.mul_inv]
-#align commute._root_.units.left_of_mul commute._root_.units.left_of_mul
+#align units.left_of_mul Units.leftOfMul
+#align add_units.left_of_add AddUnits.leftOfAdd
 
 /-- If the product of two commuting elements is a unit, then the right multiplier is a unit. -/
-@[to_additive "If the sum of two commuting elements is an additive unit, then the right summand is\nan additive unit."]
-def _root_.units.right_of_mul (u : Mˣ) (a b : M) (hu : a * b = u) (hc : Commute a b) : Mˣ :=
-  u.leftOfMul b a (hc.Eq ▸ hu) hc.symm
-#align commute._root_.units.right_of_mul commute._root_.units.right_of_mul
+@[to_additive "If the sum of two commuting elements is an additive unit, then the right summand
+is an additive unit."]
+def _root_.Units.rightOfMul (u : Mˣ) (a b : M) (hu : a * b = u) (hc : Commute a b) : Mˣ :=
+  u.leftOfMul b a (hc.eq ▸ hu) hc.symm
+#align units.right_of_mul Units.rightOfMul
+#align add_units.right_of_add AddUnits.rightOfAdd
 
 @[to_additive]
-theorem is_unit_mul_iff (h : Commute a b) : IsUnit (a * b) ↔ IsUnit a ∧ IsUnit b :=
-  ⟨fun ⟨u, hu⟩ => ⟨(u.leftOfMul a b hu.symm h).IsUnit, (u.rightOfMul a b hu.symm h).IsUnit⟩, fun H => H.1.mul H.2⟩
-#align commute.is_unit_mul_iff Commute.is_unit_mul_iff
+theorem isUnit_mul_iff (h : Commute a b) : IsUnit (a * b) ↔ IsUnit a ∧ IsUnit b :=
+  ⟨fun ⟨u, hu⟩ => ⟨(u.leftOfMul a b hu.symm h).isUnit, (u.rightOfMul a b hu.symm h).isUnit⟩,
+  fun H => H.1.mul H.2⟩
+#align commute.is_unit_mul_iff Commute.isUnit_mul_iff
+#align add_commute.is_add_unit_add_iff AddCommute.isAddUnit_add_iff
 
 @[simp, to_additive]
-theorem _root_.is_unit_mul_self_iff : IsUnit (a * a) ↔ IsUnit a :=
-  (Commute.refl a).is_unit_mul_iff.trans (and_self_iff _)
-#align commute._root_.is_unit_mul_self_iff commute._root_.is_unit_mul_self_iff
+theorem _root_.isUnit_mul_self_iff : IsUnit (a * a) ↔ IsUnit a :=
+  (Commute.refl a).isUnit_mul_iff.trans and_self_iff
+  -- porting note: `and_self_iff` now has an implicit argument instead of an explicit one.
+#align is_unit_mul_self_iff isUnit_mul_self_iff
+#align is_add_unit_add_self_iff isAddUnit_add_self_iff
 
 end Monoid
 
@@ -327,11 +365,13 @@ variable [DivisionMonoid G] {a b : G}
 theorem inv_inv : Commute a b → Commute a⁻¹ b⁻¹ :=
   SemiconjBy.inv_inv_symm
 #align commute.inv_inv Commute.inv_inv
+#align add_commute.neg_neg AddCommute.neg_neg
 
 @[simp, to_additive]
 theorem inv_inv_iff : Commute a⁻¹ b⁻¹ ↔ Commute a b :=
   SemiconjBy.inv_inv_symm_iff
 #align commute.inv_inv_iff Commute.inv_inv_iff
+#align add_commute.neg_neg_iff AddCommute.neg_neg_iff
 
 end DivisionMonoid
 
@@ -343,37 +383,49 @@ variable [Group G] {a b : G}
 theorem inv_right : Commute a b → Commute a b⁻¹ :=
   SemiconjBy.inv_right
 #align commute.inv_right Commute.inv_right
+#align add_commute.neg_right AddCommute.neg_right
 
 @[simp, to_additive]
 theorem inv_right_iff : Commute a b⁻¹ ↔ Commute a b :=
   SemiconjBy.inv_right_iff
 #align commute.inv_right_iff Commute.inv_right_iff
+#align add_commute.neg_right_iff AddCommute.neg_right_iff
 
 @[to_additive]
 theorem inv_left : Commute a b → Commute a⁻¹ b :=
   SemiconjBy.inv_symm_left
 #align commute.inv_left Commute.inv_left
+#align add_commute.neg_left AddCommute.neg_left
 
 @[simp, to_additive]
 theorem inv_left_iff : Commute a⁻¹ b ↔ Commute a b :=
   SemiconjBy.inv_symm_left_iff
 #align commute.inv_left_iff Commute.inv_left_iff
+#align add_commute.neg_left_iff AddCommute.neg_left_iff
 
 @[to_additive]
-protected theorem inv_mul_cancel (h : Commute a b) : a⁻¹ * b * a = b := by rw [h.inv_left.eq, inv_mul_cancel_right]
+protected theorem inv_mul_cancel (h : Commute a b) : a⁻¹ * b * a = b := by
+  rw [h.inv_left.eq, inv_mul_cancel_right]
 #align commute.inv_mul_cancel Commute.inv_mul_cancel
+#align add_commute.neg_add_cancel AddCommute.neg_add_cancel
 
 @[to_additive]
-theorem inv_mul_cancel_assoc (h : Commute a b) : a⁻¹ * (b * a) = b := by rw [← mul_assoc, h.inv_mul_cancel]
+theorem inv_mul_cancel_assoc (h : Commute a b) : a⁻¹ * (b * a) = b := by
+  rw [← mul_assoc, h.inv_mul_cancel]
 #align commute.inv_mul_cancel_assoc Commute.inv_mul_cancel_assoc
+#align add_commute.neg_add_cancel_assoc AddCommute.neg_add_cancel_assoc
 
 @[to_additive]
-protected theorem mul_inv_cancel (h : Commute a b) : a * b * a⁻¹ = b := by rw [h.eq, mul_inv_cancel_right]
+protected theorem mul_inv_cancel (h : Commute a b) : a * b * a⁻¹ = b := by
+  rw [h.eq, mul_inv_cancel_right]
 #align commute.mul_inv_cancel Commute.mul_inv_cancel
+#align add_commute.add_neg_cancel AddCommute.add_neg_cancel
 
 @[to_additive]
-theorem mul_inv_cancel_assoc (h : Commute a b) : a * (b * a⁻¹) = b := by rw [← mul_assoc, h.mul_inv_cancel]
+theorem mul_inv_cancel_assoc (h : Commute a b) : a * (b * a⁻¹) = b := by
+  rw [← mul_assoc, h.mul_inv_cancel]
 #align commute.mul_inv_cancel_assoc Commute.mul_inv_cancel_assoc
+#align add_commute.add_neg_cancel_assoc AddCommute.add_neg_cancel_assoc
 
 end Group
 
@@ -387,21 +439,23 @@ variable [CommGroup G] (a b : G)
 theorem mul_inv_cancel_comm : a * b * a⁻¹ = b :=
   (Commute.all a b).mul_inv_cancel
 #align mul_inv_cancel_comm mul_inv_cancel_comm
+#align add_neg_cancel_comm add_neg_cancel_comm
 
 @[simp, to_additive]
 theorem mul_inv_cancel_comm_assoc : a * (b * a⁻¹) = b :=
   (Commute.all a b).mul_inv_cancel_assoc
 #align mul_inv_cancel_comm_assoc mul_inv_cancel_comm_assoc
+#align add_neg_cancel_comm_assoc add_neg_cancel_comm_assoc
 
 @[simp, to_additive]
 theorem inv_mul_cancel_comm : a⁻¹ * b * a = b :=
   (Commute.all a b).inv_mul_cancel
 #align inv_mul_cancel_comm inv_mul_cancel_comm
+#align neg_add_cancel_comm neg_add_cancel_comm
 
 @[simp, to_additive]
 theorem inv_mul_cancel_comm_assoc : a⁻¹ * (b * a) = b :=
   (Commute.all a b).inv_mul_cancel_assoc
-#align inv_mul_cancel_comm_assoc inv_mul_cancel_comm_assoc
+#align neg_add_cancel_comm_assoc neg_add_cancel_comm_assoc
 
 end CommGroup
-

--- a/Mathlib/Algebra/Group/Commute.lean
+++ b/Mathlib/Algebra/Group/Commute.lean
@@ -3,15 +3,13 @@ Copyright (c) 2019 Neil Strickland. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Neil Strickland, Yury Kudryashov
 -/
-import Mathlib.Tactic.Relation.Symm
-import Mathlib.Algebra.Group.Semiconj
+import Mathbin.Algebra.Group.Semiconj
 
 /-!
 # Commuting pairs of elements in monoids
 
-We define the predicate `commute a b := a * b = b * a` and provide some operations on terms
-`(h : commute a b)`.
-E.g., if `a`, `b`, and `c` are elements of a semiring, and that `hb : commute a b` and
+We define the predicate `commute a b := a * b = b * a` and provide some operations on terms `(h :
+commute a b)`. E.g., if `a`, `b`, and c are elements of a semiring, and that `hb : commute a b` and
 `hc : commute a c`.  Then `hb.pow_left 5` proves `commute (a ^ 5) b` and `(hb.pow_right 2).add_right
 (hb.mul_right hc)` proves `commute a (b ^ 2 + b * c)`.
 
@@ -29,10 +27,13 @@ Most of the proofs come from the properties of `semiconj_by`.
 
 variable {G : Type _}
 
+#print Commute /-
 /-- Two elements commute if `a * b = b * a`. -/
 @[to_additive AddCommute "Two elements additively commute if `a + b = b + a`"]
 def Commute {S : Type _} [Mul S] (a b : S) : Prop :=
   SemiconjBy a b b
+#align commute Commute
+-/
 
 namespace Commute
 
@@ -40,30 +41,53 @@ section Mul
 
 variable {S : Type _} [Mul S]
 
+#print Commute.eq /-
 /-- Equality behind `commute a b`; useful for rewriting. -/
 @[to_additive "Equality behind `add_commute a b`; useful for rewriting."]
 protected theorem eq {a b : S} (h : Commute a b) : a * b = b * a :=
   h
+#align commute.eq Commute.eq
+-/
 
+#print Commute.refl /-
 /-- Any element commutes with itself. -/
--- TODO: restore @[refl]
-@[simp, to_additive "Any element commutes with itself."]
+@[refl, simp, to_additive "Any element commutes with itself."]
 protected theorem refl (a : S) : Commute a a :=
   Eq.refl (a * a)
+#align commute.refl Commute.refl
+-/
 
+#print Commute.symm /-
 /-- If `a` commutes with `b`, then `b` commutes with `a`. -/
 @[symm, to_additive "If `a` commutes with `b`, then `b` commutes with `a`."]
 protected theorem symm {a b : S} (h : Commute a b) : Commute b a :=
   Eq.symm h
+#align commute.symm Commute.symm
+-/
 
+#print Commute.semiconjBy /-
 @[to_additive]
 protected theorem semiconjBy {a b : S} (h : Commute a b) : SemiconjBy a b b :=
   h
 #align commute.semiconj_by Commute.semiconjBy
+-/
 
+#print Commute.symm_iff /-
 @[to_additive]
 protected theorem symm_iff {a b : S} : Commute a b ↔ Commute b a :=
   ⟨Commute.symm, Commute.symm⟩
+#align commute.symm_iff Commute.symm_iff
+-/
+
+@[to_additive]
+instance : IsRefl S Commute :=
+  ⟨Commute.refl⟩
+
+-- This instance is useful for `finset.noncomm_prod`
+@[to_additive]
+instance on_is_refl {f : G → S} : IsRefl G fun a b => Commute (f a) (f b) :=
+  ⟨fun _ => Commute.refl _⟩
+#align commute.on_is_refl Commute.on_is_refl
 
 end Mul
 
@@ -71,68 +95,313 @@ section Semigroup
 
 variable {S : Type _} [Semigroup S] {a b c : S}
 
+/- warning: commute.mul_right -> Commute.mul_right is a dubious translation:
+lean 3 declaration is
+  forall {S : Type.{u_2}} [_inst_1 : Semigroup.{u_2} S] {a : S} {b : S} {c : S}, (Commute.{u_2} S (Semigroup.toHasMul.{u_2} S _inst_1) a b) -> (Commute.{u_2} S (Semigroup.toHasMul.{u_2} S _inst_1) a c) -> (Commute.{u_2} S (Semigroup.toHasMul.{u_2} S _inst_1) a (HMul.hMul.{u_2 u_2 u_2} S S S (instHMul.{u_2} S (Semigroup.toHasMul.{u_2} S _inst_1)) b c))
+but is expected to have type
+  forall {S : Type.{u_1}} [inst._@.Mathlib.Algebra.Group.Commute._hyg.141 : Semigroup.{u_1} S] {a : S} {b : S} {c : S}, (Commute.{u_1} S (Semigroup.toMul.{u_1} S inst._@.Mathlib.Algebra.Group.Commute._hyg.141) a b) -> (Commute.{u_1} S (Semigroup.toMul.{u_1} S inst._@.Mathlib.Algebra.Group.Commute._hyg.141) a c) -> (Commute.{u_1} S (Semigroup.toMul.{u_1} S inst._@.Mathlib.Algebra.Group.Commute._hyg.141) a (HMul.hMul.{u_1 u_1 u_1} S S S (instHMul.{u_1} S (Semigroup.toMul.{u_1} S inst._@.Mathlib.Algebra.Group.Commute._hyg.141)) b c))
+Case conversion may be inaccurate. Consider using '#align commute.mul_right Commute.mul_rightₓ'. -/
 /-- If `a` commutes with both `b` and `c`, then it commutes with their product. -/
 @[simp, to_additive "If `a` commutes with both `b` and `c`, then it commutes with their sum."]
 theorem mul_right (hab : Commute a b) (hac : Commute a c) : Commute a (b * c) :=
-  SemiconjBy.mul_right hab hac
+  hab.mul_right hac
+#align commute.mul_right Commute.mul_right
 
+/- warning: commute.mul_left -> Commute.mul_left is a dubious translation:
+lean 3 declaration is
+  forall {S : Type.{u_2}} [_inst_1 : Semigroup.{u_2} S] {a : S} {b : S} {c : S}, (Commute.{u_2} S (Semigroup.toHasMul.{u_2} S _inst_1) a c) -> (Commute.{u_2} S (Semigroup.toHasMul.{u_2} S _inst_1) b c) -> (Commute.{u_2} S (Semigroup.toHasMul.{u_2} S _inst_1) (HMul.hMul.{u_2 u_2 u_2} S S S (instHMul.{u_2} S (Semigroup.toHasMul.{u_2} S _inst_1)) a b) c)
+but is expected to have type
+  forall {S : Type.{u_1}} [inst._@.Mathlib.Algebra.Group.Commute._hyg.168 : Semigroup.{u_1} S] {a : S} {b : S} {c : S}, (Commute.{u_1} S (Semigroup.toMul.{u_1} S inst._@.Mathlib.Algebra.Group.Commute._hyg.168) a c) -> (Commute.{u_1} S (Semigroup.toMul.{u_1} S inst._@.Mathlib.Algebra.Group.Commute._hyg.168) b c) -> (Commute.{u_1} S (Semigroup.toMul.{u_1} S inst._@.Mathlib.Algebra.Group.Commute._hyg.168) (HMul.hMul.{u_1 u_1 u_1} S S S (instHMul.{u_1} S (Semigroup.toMul.{u_1} S inst._@.Mathlib.Algebra.Group.Commute._hyg.168)) a b) c)
+Case conversion may be inaccurate. Consider using '#align commute.mul_left Commute.mul_leftₓ'. -/
 /-- If both `a` and `b` commute with `c`, then their product commutes with `c`. -/
 @[simp, to_additive "If both `a` and `b` commute with `c`, then their product commutes with `c`."]
 theorem mul_left (hac : Commute a c) (hbc : Commute b c) : Commute (a * b) c :=
-  SemiconjBy.mul_left hac hbc
+  hac.mul_left hbc
+#align commute.mul_left Commute.mul_left
 
-protected theorem right_comm (h : Commute b c) (a : S) : a * b * c = a * c * b :=
-  by simp only [mul_assoc, h.eq]
+/- warning: commute.right_comm -> Commute.right_comm is a dubious translation:
+lean 3 declaration is
+  forall {S : Type.{u_2}} [_inst_1 : Semigroup.{u_2} S] {b : S} {c : S}, (Commute.{u_2} S (Semigroup.toHasMul.{u_2} S _inst_1) b c) -> (forall (a : S), Eq.{succ u_2} S (HMul.hMul.{u_2 u_2 u_2} S S S (instHMul.{u_2} S (Semigroup.toHasMul.{u_2} S _inst_1)) (HMul.hMul.{u_2 u_2 u_2} S S S (instHMul.{u_2} S (Semigroup.toHasMul.{u_2} S _inst_1)) a b) c) (HMul.hMul.{u_2 u_2 u_2} S S S (instHMul.{u_2} S (Semigroup.toHasMul.{u_2} S _inst_1)) (HMul.hMul.{u_2 u_2 u_2} S S S (instHMul.{u_2} S (Semigroup.toHasMul.{u_2} S _inst_1)) a c) b))
+but is expected to have type
+  forall {S : Type.{u_1}} [inst._@.Mathlib.Algebra.Group.Commute._hyg.195 : Semigroup.{u_1} S] {b : S} {c : S}, (Commute.{u_1} S (Semigroup.toMul.{u_1} S inst._@.Mathlib.Algebra.Group.Commute._hyg.195) b c) -> (forall (a : S), Eq.{succ u_1} S (HMul.hMul.{u_1 u_1 u_1} S S S (instHMul.{u_1} S (Semigroup.toMul.{u_1} S inst._@.Mathlib.Algebra.Group.Commute._hyg.195)) (HMul.hMul.{u_1 u_1 u_1} S S S (instHMul.{u_1} S (Semigroup.toMul.{u_1} S inst._@.Mathlib.Algebra.Group.Commute._hyg.195)) a b) c) (HMul.hMul.{u_1 u_1 u_1} S S S (instHMul.{u_1} S (Semigroup.toMul.{u_1} S inst._@.Mathlib.Algebra.Group.Commute._hyg.195)) (HMul.hMul.{u_1 u_1 u_1} S S S (instHMul.{u_1} S (Semigroup.toMul.{u_1} S inst._@.Mathlib.Algebra.Group.Commute._hyg.195)) a c) b))
+Case conversion may be inaccurate. Consider using '#align commute.right_comm Commute.right_commₓ'. -/
+@[to_additive]
+protected theorem right_comm (h : Commute b c) (a : S) : a * b * c = a * c * b := by simp only [mul_assoc, h.eq]
+#align commute.right_comm Commute.right_comm
 
-protected theorem left_comm (h : Commute a b) (c) : a * (b * c) = b * (a * c) :=
-  by simp only [← mul_assoc, h.eq]
+/- warning: commute.left_comm -> Commute.left_comm is a dubious translation:
+lean 3 declaration is
+  forall {S : Type.{u_2}} [_inst_1 : Semigroup.{u_2} S] {a : S} {b : S}, (Commute.{u_2} S (Semigroup.toHasMul.{u_2} S _inst_1) a b) -> (forall (c : S), Eq.{succ u_2} S (HMul.hMul.{u_2 u_2 u_2} S S S (instHMul.{u_2} S (Semigroup.toHasMul.{u_2} S _inst_1)) a (HMul.hMul.{u_2 u_2 u_2} S S S (instHMul.{u_2} S (Semigroup.toHasMul.{u_2} S _inst_1)) b c)) (HMul.hMul.{u_2 u_2 u_2} S S S (instHMul.{u_2} S (Semigroup.toHasMul.{u_2} S _inst_1)) b (HMul.hMul.{u_2 u_2 u_2} S S S (instHMul.{u_2} S (Semigroup.toHasMul.{u_2} S _inst_1)) a c)))
+but is expected to have type
+  forall {S : Type.{u_1}} [inst._@.Mathlib.Algebra.Group.Commute._hyg.226 : Semigroup.{u_1} S] {a : S} {b : S}, (Commute.{u_1} S (Semigroup.toMul.{u_1} S inst._@.Mathlib.Algebra.Group.Commute._hyg.226) a b) -> (forall (c : S), Eq.{succ u_1} S (HMul.hMul.{u_1 u_1 u_1} S S S (instHMul.{u_1} S (Semigroup.toMul.{u_1} S inst._@.Mathlib.Algebra.Group.Commute._hyg.226)) a (HMul.hMul.{u_1 u_1 u_1} S S S (instHMul.{u_1} S (Semigroup.toMul.{u_1} S inst._@.Mathlib.Algebra.Group.Commute._hyg.226)) b c)) (HMul.hMul.{u_1 u_1 u_1} S S S (instHMul.{u_1} S (Semigroup.toMul.{u_1} S inst._@.Mathlib.Algebra.Group.Commute._hyg.226)) b (HMul.hMul.{u_1 u_1 u_1} S S S (instHMul.{u_1} S (Semigroup.toMul.{u_1} S inst._@.Mathlib.Algebra.Group.Commute._hyg.226)) a c)))
+Case conversion may be inaccurate. Consider using '#align commute.left_comm Commute.left_commₓ'. -/
+@[to_additive]
+protected theorem left_comm (h : Commute a b) (c) : a * (b * c) = b * (a * c) := by simp only [← mul_assoc, h.eq]
+#align commute.left_comm Commute.left_comm
 
 end Semigroup
 
+/- warning: commute.all -> Commute.all is a dubious translation:
+lean 3 declaration is
+  forall {S : Type.{u_1}} [_inst_1 : CommSemigroup.{u_1} S] (a : S) (b : S), Commute.{u_1} S (Semigroup.toHasMul.{u_1} S (CommSemigroup.toSemigroup.{u_1} S _inst_1)) a b
+but is expected to have type
+  forall {S : Type.{u_1}} [inst._@.Mathlib.Algebra.Group.Commute._hyg.258 : CommSemigroup.{u_1} S] (a : S) (b : S), Commute.{u_1} S (Semigroup.toMul.{u_1} S (CommSemigroup.toSemigroup.{u_1} S inst._@.Mathlib.Algebra.Group.Commute._hyg.258)) a b
+Case conversion may be inaccurate. Consider using '#align commute.all Commute.allₓ'. -/
 @[to_additive]
 protected theorem all {S : Type _} [CommSemigroup S] (a b : S) : Commute a b :=
   mul_comm a b
+#align commute.all Commute.all
 
 section MulOneClass
 
 variable {M : Type _} [MulOneClass M]
 
-@[simp]
+/- warning: commute.one_right -> Commute.one_right is a dubious translation:
+lean 3 declaration is
+  forall {M : Type.{u_2}} [_inst_1 : MulOneClass.{u_2} M] (a : M), Commute.{u_2} M (MulOneClass.toHasMul.{u_2} M _inst_1) a (OfNat.ofNat.{u_2} M 1 (OfNat.mk.{u_2} M 1 (One.one.{u_2} M (MulOneClass.toHasOne.{u_2} M _inst_1))))
+but is expected to have type
+  forall {M : Type.{u_1}} [inst._@.Mathlib.Algebra.Group.Commute._hyg.281 : MulOneClass.{u_1} M] (a : M), Commute.{u_1} M (MulOneClass.toMul.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.281) a (OfNat.ofNat.{u_1} M 1 (One.toOfNat1.{u_1} M (MulOneClass.toOne.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.281)))
+Case conversion may be inaccurate. Consider using '#align commute.one_right Commute.one_rightₓ'. -/
+@[simp, to_additive]
 theorem one_right (a : M) : Commute a 1 :=
   SemiconjBy.one_right a
+#align commute.one_right Commute.one_right
 
-@[simp]
+/- warning: commute.one_left -> Commute.one_left is a dubious translation:
+lean 3 declaration is
+  forall {M : Type.{u_2}} [_inst_1 : MulOneClass.{u_2} M] (a : M), Commute.{u_2} M (MulOneClass.toHasMul.{u_2} M _inst_1) (OfNat.ofNat.{u_2} M 1 (OfNat.mk.{u_2} M 1 (One.one.{u_2} M (MulOneClass.toHasOne.{u_2} M _inst_1)))) a
+but is expected to have type
+  forall {M : Type.{u_1}} [inst._@.Mathlib.Algebra.Group.Commute._hyg.293 : MulOneClass.{u_1} M] (a : M), Commute.{u_1} M (MulOneClass.toMul.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.293) (OfNat.ofNat.{u_1} M 1 (One.toOfNat1.{u_1} M (MulOneClass.toOne.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.293))) a
+Case conversion may be inaccurate. Consider using '#align commute.one_left Commute.one_leftₓ'. -/
+@[simp, to_additive]
 theorem one_left (a : M) : Commute 1 a :=
   SemiconjBy.one_left a
+#align commute.one_left Commute.one_left
 
 end MulOneClass
 
 section Monoid
 
-variable {M : Type _} [Monoid M] {a b : M}
+variable {M : Type _} [Monoid M] {a b : M} {u u₁ u₂ : Mˣ}
 
-@[simp]
+/- warning: commute.pow_right -> Commute.pow_right is a dubious translation:
+lean 3 declaration is
+  forall {M : Type.{u_2}} [_inst_1 : Monoid.{u_2} M] {a : M} {b : M}, (Commute.{u_2} M (MulOneClass.toHasMul.{u_2} M (Monoid.toMulOneClass.{u_2} M _inst_1)) a b) -> (forall (n : Nat), Commute.{u_2} M (MulOneClass.toHasMul.{u_2} M (Monoid.toMulOneClass.{u_2} M _inst_1)) a (HPow.hPow.{u_2 0 u_2} M Nat M (instHPow.{u_2 0} M Nat (Monoid.hasPow.{u_2} M _inst_1)) b n))
+but is expected to have type
+  forall {M : Type.{u_1}} [inst._@.Mathlib.Algebra.Group.Commute._hyg.319 : Monoid.{u_1} M] {a : M} {b : M}, (Commute.{u_1} M (MulOneClass.toMul.{u_1} M (Monoid.toMulOneClass.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.319)) a b) -> (forall (n : Nat), Commute.{u_1} M (MulOneClass.toMul.{u_1} M (Monoid.toMulOneClass.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.319)) a (HPow.hPow.{u_1 0 u_1} M Nat M (instHPow.{u_1 0} M Nat (Monoid.Pow.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.319)) b n))
+Case conversion may be inaccurate. Consider using '#align commute.pow_right Commute.pow_rightₓ'. -/
+@[simp, to_additive]
 theorem pow_right (h : Commute a b) (n : ℕ) : Commute a (b ^ n) :=
-  SemiconjBy.pow_right h n
+  h.pow_right n
+#align commute.pow_right Commute.pow_right
 
-@[simp]
+/- warning: commute.pow_left -> Commute.pow_left is a dubious translation:
+lean 3 declaration is
+  forall {M : Type.{u_2}} [_inst_1 : Monoid.{u_2} M] {a : M} {b : M}, (Commute.{u_2} M (MulOneClass.toHasMul.{u_2} M (Monoid.toMulOneClass.{u_2} M _inst_1)) a b) -> (forall (n : Nat), Commute.{u_2} M (MulOneClass.toHasMul.{u_2} M (Monoid.toMulOneClass.{u_2} M _inst_1)) (HPow.hPow.{u_2 0 u_2} M Nat M (instHPow.{u_2 0} M Nat (Monoid.hasPow.{u_2} M _inst_1)) a n) b)
+but is expected to have type
+  forall {M : Type.{u_1}} [inst._@.Mathlib.Algebra.Group.Commute._hyg.345 : Monoid.{u_1} M] {a : M} {b : M}, (Commute.{u_1} M (MulOneClass.toMul.{u_1} M (Monoid.toMulOneClass.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.345)) a b) -> (forall (n : Nat), Commute.{u_1} M (MulOneClass.toMul.{u_1} M (Monoid.toMulOneClass.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.345)) (HPow.hPow.{u_1 0 u_1} M Nat M (instHPow.{u_1 0} M Nat (Monoid.Pow.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.345)) a n) b)
+Case conversion may be inaccurate. Consider using '#align commute.pow_left Commute.pow_leftₓ'. -/
+@[simp, to_additive]
 theorem pow_left (h : Commute a b) (n : ℕ) : Commute (a ^ n) b :=
   (h.symm.pow_right n).symm
+#align commute.pow_left Commute.pow_left
 
-@[simp]
+/- warning: commute.pow_pow -> Commute.pow_pow is a dubious translation:
+lean 3 declaration is
+  forall {M : Type.{u_2}} [_inst_1 : Monoid.{u_2} M] {a : M} {b : M}, (Commute.{u_2} M (MulOneClass.toHasMul.{u_2} M (Monoid.toMulOneClass.{u_2} M _inst_1)) a b) -> (forall (m : Nat) (n : Nat), Commute.{u_2} M (MulOneClass.toHasMul.{u_2} M (Monoid.toMulOneClass.{u_2} M _inst_1)) (HPow.hPow.{u_2 0 u_2} M Nat M (instHPow.{u_2 0} M Nat (Monoid.hasPow.{u_2} M _inst_1)) a m) (HPow.hPow.{u_2 0 u_2} M Nat M (instHPow.{u_2 0} M Nat (Monoid.hasPow.{u_2} M _inst_1)) b n))
+but is expected to have type
+  forall {M : Type.{u_1}} [inst._@.Mathlib.Algebra.Group.Commute._hyg.373 : Monoid.{u_1} M] {a : M} {b : M}, (Commute.{u_1} M (MulOneClass.toMul.{u_1} M (Monoid.toMulOneClass.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.373)) a b) -> (forall (m : Nat) (n : Nat), Commute.{u_1} M (MulOneClass.toMul.{u_1} M (Monoid.toMulOneClass.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.373)) (HPow.hPow.{u_1 0 u_1} M Nat M (instHPow.{u_1 0} M Nat (Monoid.Pow.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.373)) a m) (HPow.hPow.{u_1 0 u_1} M Nat M (instHPow.{u_1 0} M Nat (Monoid.Pow.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.373)) b n))
+Case conversion may be inaccurate. Consider using '#align commute.pow_pow Commute.pow_powₓ'. -/
+@[simp, to_additive]
 theorem pow_pow (h : Commute a b) (m n : ℕ) : Commute (a ^ m) (b ^ n) :=
   (h.pow_left m).pow_right n
+#align commute.pow_pow Commute.pow_pow
 
+/- warning: commute.self_pow -> Commute.self_pow is a dubious translation:
+lean 3 declaration is
+  forall {M : Type.{u_2}} [_inst_1 : Monoid.{u_2} M] (a : M) (n : Nat), Commute.{u_2} M (MulOneClass.toHasMul.{u_2} M (Monoid.toMulOneClass.{u_2} M _inst_1)) a (HPow.hPow.{u_2 0 u_2} M Nat M (instHPow.{u_2 0} M Nat (Monoid.hasPow.{u_2} M _inst_1)) a n)
+but is expected to have type
+  forall {M : Type.{u_1}} [inst._@.Mathlib.Algebra.Group.Commute._hyg.411 : Monoid.{u_1} M] (a : M) (n : Nat), Commute.{u_1} M (MulOneClass.toMul.{u_1} M (Monoid.toMulOneClass.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.411)) a (HPow.hPow.{u_1 0 u_1} M Nat M (instHPow.{u_1 0} M Nat (Monoid.Pow.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.411)) a n)
+Case conversion may be inaccurate. Consider using '#align commute.self_pow Commute.self_powₓ'. -/
+@[simp, to_additive]
 theorem self_pow (a : M) (n : ℕ) : Commute a (a ^ n) :=
   (Commute.refl a).pow_right n
+#align commute.self_pow Commute.self_pow
 
+/- warning: commute.pow_self -> Commute.pow_self is a dubious translation:
+lean 3 declaration is
+  forall {M : Type.{u_2}} [_inst_1 : Monoid.{u_2} M] (a : M) (n : Nat), Commute.{u_2} M (MulOneClass.toHasMul.{u_2} M (Monoid.toMulOneClass.{u_2} M _inst_1)) (HPow.hPow.{u_2 0 u_2} M Nat M (instHPow.{u_2 0} M Nat (Monoid.hasPow.{u_2} M _inst_1)) a n) a
+but is expected to have type
+  forall {M : Type.{u_1}} [inst._@.Mathlib.Algebra.Group.Commute._hyg.438 : Monoid.{u_1} M] (a : M) (n : Nat), Commute.{u_1} M (MulOneClass.toMul.{u_1} M (Monoid.toMulOneClass.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.438)) (HPow.hPow.{u_1 0 u_1} M Nat M (instHPow.{u_1 0} M Nat (Monoid.Pow.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.438)) a n) a
+Case conversion may be inaccurate. Consider using '#align commute.pow_self Commute.pow_selfₓ'. -/
+@[simp, to_additive]
 theorem pow_self (a : M) (n : ℕ) : Commute (a ^ n) a :=
   (Commute.refl a).pow_left n
+#align commute.pow_self Commute.pow_self
 
+/- warning: commute.pow_pow_self -> Commute.pow_pow_self is a dubious translation:
+lean 3 declaration is
+  forall {M : Type.{u_2}} [_inst_1 : Monoid.{u_2} M] (a : M) (m : Nat) (n : Nat), Commute.{u_2} M (MulOneClass.toHasMul.{u_2} M (Monoid.toMulOneClass.{u_2} M _inst_1)) (HPow.hPow.{u_2 0 u_2} M Nat M (instHPow.{u_2 0} M Nat (Monoid.hasPow.{u_2} M _inst_1)) a m) (HPow.hPow.{u_2 0 u_2} M Nat M (instHPow.{u_2 0} M Nat (Monoid.hasPow.{u_2} M _inst_1)) a n)
+but is expected to have type
+  forall {M : Type.{u_1}} [inst._@.Mathlib.Algebra.Group.Commute._hyg.465 : Monoid.{u_1} M] (a : M) (m : Nat) (n : Nat), Commute.{u_1} M (MulOneClass.toMul.{u_1} M (Monoid.toMulOneClass.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.465)) (HPow.hPow.{u_1 0 u_1} M Nat M (instHPow.{u_1 0} M Nat (Monoid.Pow.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.465)) a m) (HPow.hPow.{u_1 0 u_1} M Nat M (instHPow.{u_1 0} M Nat (Monoid.Pow.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.465)) a n)
+Case conversion may be inaccurate. Consider using '#align commute.pow_pow_self Commute.pow_pow_selfₓ'. -/
+@[simp, to_additive]
 theorem pow_pow_self (a : M) (m n : ℕ) : Commute (a ^ m) (a ^ n) :=
   (Commute.refl a).pow_pow m n
+#align commute.pow_pow_self Commute.pow_pow_self
 
+@[to_additive succ_nsmul']
 theorem _root_.pow_succ' (a : M) (n : ℕ) : a ^ (n + 1) = a ^ n * a :=
   (pow_succ a n).trans (self_pow _ _)
+#align commute._root_.pow_succ' commute._root_.pow_succ'
+
+@[to_additive]
+theorem units_inv_right : Commute a u → Commute a ↑u⁻¹ :=
+  SemiconjBy.units_inv_right
+#align commute.units_inv_right Commute.units_inv_right
+
+@[simp, to_additive]
+theorem units_inv_right_iff : Commute a ↑u⁻¹ ↔ Commute a u :=
+  SemiconjBy.units_inv_right_iff
+#align commute.units_inv_right_iff Commute.units_inv_right_iff
+
+@[to_additive]
+theorem units_inv_left : Commute (↑u) a → Commute (↑u⁻¹) a :=
+  SemiconjBy.units_inv_symm_left
+#align commute.units_inv_left Commute.units_inv_left
+
+@[simp, to_additive]
+theorem units_inv_left_iff : Commute (↑u⁻¹) a ↔ Commute (↑u) a :=
+  SemiconjBy.units_inv_symm_left_iff
+#align commute.units_inv_left_iff Commute.units_inv_left_iff
+
+@[to_additive]
+theorem units_coe : Commute u₁ u₂ → Commute (u₁ : M) u₂ :=
+  SemiconjBy.units_coe
+#align commute.units_coe Commute.units_coe
+
+@[to_additive]
+theorem units_of_coe : Commute (u₁ : M) u₂ → Commute u₁ u₂ :=
+  SemiconjBy.units_of_coe
+#align commute.units_of_coe Commute.units_of_coe
+
+@[simp, to_additive]
+theorem units_coe_iff : Commute (u₁ : M) u₂ ↔ Commute u₁ u₂ :=
+  SemiconjBy.units_coe_iff
+#align commute.units_coe_iff Commute.units_coe_iff
+
+/-- If the product of two commuting elements is a unit, then the left multiplier is a unit. -/
+@[to_additive "If the sum of two commuting elements is an additive unit, then the left summand is an\nadditive unit."]
+def _root_.units.left_of_mul (u : Mˣ) (a b : M) (hu : a * b = u) (hc : Commute a b) : Mˣ where
+  val := a
+  inv := b * ↑u⁻¹
+  val_inv := by rw [← mul_assoc, hu, u.mul_inv]
+  inv_val := by
+    have : Commute a u := hu ▸ (Commute.refl _).mul_right hc
+    rw [← this.units_inv_right.right_comm, ← hc.eq, hu, u.mul_inv]
+#align commute._root_.units.left_of_mul commute._root_.units.left_of_mul
+
+/-- If the product of two commuting elements is a unit, then the right multiplier is a unit. -/
+@[to_additive "If the sum of two commuting elements is an additive unit, then the right summand is\nan additive unit."]
+def _root_.units.right_of_mul (u : Mˣ) (a b : M) (hu : a * b = u) (hc : Commute a b) : Mˣ :=
+  u.leftOfMul b a (hc.Eq ▸ hu) hc.symm
+#align commute._root_.units.right_of_mul commute._root_.units.right_of_mul
+
+@[to_additive]
+theorem is_unit_mul_iff (h : Commute a b) : IsUnit (a * b) ↔ IsUnit a ∧ IsUnit b :=
+  ⟨fun ⟨u, hu⟩ => ⟨(u.leftOfMul a b hu.symm h).IsUnit, (u.rightOfMul a b hu.symm h).IsUnit⟩, fun H => H.1.mul H.2⟩
+#align commute.is_unit_mul_iff Commute.is_unit_mul_iff
+
+@[simp, to_additive]
+theorem _root_.is_unit_mul_self_iff : IsUnit (a * a) ↔ IsUnit a :=
+  (Commute.refl a).is_unit_mul_iff.trans (and_self_iff _)
+#align commute._root_.is_unit_mul_self_iff commute._root_.is_unit_mul_self_iff
 
 end Monoid
+
+section DivisionMonoid
+
+variable [DivisionMonoid G] {a b : G}
+
+@[to_additive]
+theorem inv_inv : Commute a b → Commute a⁻¹ b⁻¹ :=
+  SemiconjBy.inv_inv_symm
+#align commute.inv_inv Commute.inv_inv
+
+@[simp, to_additive]
+theorem inv_inv_iff : Commute a⁻¹ b⁻¹ ↔ Commute a b :=
+  SemiconjBy.inv_inv_symm_iff
+#align commute.inv_inv_iff Commute.inv_inv_iff
+
+end DivisionMonoid
+
+section Group
+
+variable [Group G] {a b : G}
+
+@[to_additive]
+theorem inv_right : Commute a b → Commute a b⁻¹ :=
+  SemiconjBy.inv_right
+#align commute.inv_right Commute.inv_right
+
+@[simp, to_additive]
+theorem inv_right_iff : Commute a b⁻¹ ↔ Commute a b :=
+  SemiconjBy.inv_right_iff
+#align commute.inv_right_iff Commute.inv_right_iff
+
+@[to_additive]
+theorem inv_left : Commute a b → Commute a⁻¹ b :=
+  SemiconjBy.inv_symm_left
+#align commute.inv_left Commute.inv_left
+
+@[simp, to_additive]
+theorem inv_left_iff : Commute a⁻¹ b ↔ Commute a b :=
+  SemiconjBy.inv_symm_left_iff
+#align commute.inv_left_iff Commute.inv_left_iff
+
+@[to_additive]
+protected theorem inv_mul_cancel (h : Commute a b) : a⁻¹ * b * a = b := by rw [h.inv_left.eq, inv_mul_cancel_right]
+#align commute.inv_mul_cancel Commute.inv_mul_cancel
+
+@[to_additive]
+theorem inv_mul_cancel_assoc (h : Commute a b) : a⁻¹ * (b * a) = b := by rw [← mul_assoc, h.inv_mul_cancel]
+#align commute.inv_mul_cancel_assoc Commute.inv_mul_cancel_assoc
+
+@[to_additive]
+protected theorem mul_inv_cancel (h : Commute a b) : a * b * a⁻¹ = b := by rw [h.eq, mul_inv_cancel_right]
+#align commute.mul_inv_cancel Commute.mul_inv_cancel
+
+@[to_additive]
+theorem mul_inv_cancel_assoc (h : Commute a b) : a * (b * a⁻¹) = b := by rw [← mul_assoc, h.mul_inv_cancel]
+#align commute.mul_inv_cancel_assoc Commute.mul_inv_cancel_assoc
+
+end Group
+
+end Commute
+
+section CommGroup
+
+variable [CommGroup G] (a b : G)
+
+@[simp, to_additive]
+theorem mul_inv_cancel_comm : a * b * a⁻¹ = b :=
+  (Commute.all a b).mul_inv_cancel
+#align mul_inv_cancel_comm mul_inv_cancel_comm
+
+@[simp, to_additive]
+theorem mul_inv_cancel_comm_assoc : a * (b * a⁻¹) = b :=
+  (Commute.all a b).mul_inv_cancel_assoc
+#align mul_inv_cancel_comm_assoc mul_inv_cancel_comm_assoc
+
+@[simp, to_additive]
+theorem inv_mul_cancel_comm : a⁻¹ * b * a = b :=
+  (Commute.all a b).inv_mul_cancel
+#align inv_mul_cancel_comm inv_mul_cancel_comm
+
+@[simp, to_additive]
+theorem inv_mul_cancel_comm_assoc : a⁻¹ * (b * a) = b :=
+  (Commute.all a b).inv_mul_cancel_assoc
+#align inv_mul_cancel_comm_assoc inv_mul_cancel_comm_assoc
+
+end CommGroup
+

--- a/Mathlib/Algebra/Group/Commute.lean
+++ b/Mathlib/Algebra/Group/Commute.lean
@@ -174,20 +174,23 @@ theorem pow_pow (h : Commute a b) (m n : ℕ) : Commute (a ^ m) (b ^ n) :=
 #align add_commute.smul_smul AddCommute.smul_smulₓ
 -- `MulOneClass.toHasMul` vs. `MulOneClass.toMul`
 
-@[simp, to_additive]
+-- porting note: `simpNF` told me to remove the `simp` attribute
+@[to_additive]
 theorem self_pow (a : M) (n : ℕ) : Commute a (a ^ n) :=
   (Commute.refl a).pow_right n
 #align commute.self_pow Commute.self_powₓ
 #align add_commute.self_smul AddCommute.self_smulₓ
 -- `MulOneClass.toHasMul` vs. `MulOneClass.toMul`
 
-@[simp, to_additive]
+-- porting note: `simpNF` told me to remove the `simp` attribute
+@[to_additive]
 theorem pow_self (a : M) (n : ℕ) : Commute (a ^ n) a :=
   (Commute.refl a).pow_left n
 #align add_commute.smul_self AddCommute.smul_selfₓ
 -- `MulOneClass.toHasMul` vs. `MulOneClass.toMul`
 
-@[simp, to_additive]
+-- porting note: `simpNF` told me to remove the `simp` attribute
+@[to_additive]
 theorem pow_pow_self (a : M) (m n : ℕ) : Commute (a ^ m) (a ^ n) :=
   (Commute.refl a).pow_pow m n
 #align commute.pow_pow_self Commute.pow_pow_selfₓ

--- a/Mathlib/Algebra/Group/Commute.lean
+++ b/Mathlib/Algebra/Group/Commute.lean
@@ -97,12 +97,6 @@ theorem mul_right (hab : Commute a b) (hac : Commute a c) : Commute a (b * c) :=
 #align commute.mul_right Commute.mul_rightₓ
 #align add_commute.add_right AddCommute.add_rightₓ
 -- I think `ₓ` is necessary because of the `mul` vs `HMul` distinction
-/- warning: commute.mul_right -> Commute.mul_right is a dubious translation:
-lean 3 declaration is
-  forall {S : Type.{u_2}} [_inst_1 : Semigroup.{u_2} S] {a : S} {b : S} {c : S}, (Commute.{u_2} S (Semigroup.toHasMul.{u_2} S _inst_1) a b) -> (Commute.{u_2} S (Semigroup.toHasMul.{u_2} S _inst_1) a c) -> (Commute.{u_2} S (Semigroup.toHasMul.{u_2} S _inst_1) a (HMul.hMul.{u_2 u_2 u_2} S S S (instHMul.{u_2} S (Semigroup.toHasMul.{u_2} S _inst_1)) b c))
-but is expected to have type
-  forall {S : Type.{u_1}} [inst._@.Mathlib.Algebra.Group.Commute._hyg.141 : Semigroup.{u_1} S] {a : S} {b : S} {c : S}, (Commute.{u_1} S (Semigroup.toMul.{u_1} S inst._@.Mathlib.Algebra.Group.Commute._hyg.141) a b) -> (Commute.{u_1} S (Semigroup.toMul.{u_1} S inst._@.Mathlib.Algebra.Group.Commute._hyg.141) a c) -> (Commute.{u_1} S (Semigroup.toMul.{u_1} S inst._@.Mathlib.Algebra.Group.Commute._hyg.141) a (HMul.hMul.{u_1 u_1 u_1} S S S (instHMul.{u_1} S (Semigroup.toMul.{u_1} S inst._@.Mathlib.Algebra.Group.Commute._hyg.141)) b c))
-Case conversion may be inaccurate. Consider using '#align commute.mul_right Commute.mul_rightₓ'. -/
 
 /-- If both `a` and `b` commute with `c`, then their product commutes with `c`. -/
 @[simp, to_additive "If both `a` and `b` commute with `c`, then their product commutes with `c`."]
@@ -111,12 +105,6 @@ theorem mul_left (hac : Commute a c) (hbc : Commute b c) : Commute (a * b) c :=
 #align commute.mul_left Commute.mul_leftₓ
 #align add_commute.add_left AddCommute.add_leftₓ
 -- I think `ₓ` is necessary because of the `mul` vs `HMul` distinction
-/- warning: commute.mul_left -> Commute.mul_left is a dubious translation:
-lean 3 declaration is
-  forall {S : Type.{u_2}} [_inst_1 : Semigroup.{u_2} S] {a : S} {b : S} {c : S}, (Commute.{u_2} S (Semigroup.toHasMul.{u_2} S _inst_1) a c) -> (Commute.{u_2} S (Semigroup.toHasMul.{u_2} S _inst_1) b c) -> (Commute.{u_2} S (Semigroup.toHasMul.{u_2} S _inst_1) (HMul.hMul.{u_2 u_2 u_2} S S S (instHMul.{u_2} S (Semigroup.toHasMul.{u_2} S _inst_1)) a b) c)
-but is expected to have type
-  forall {S : Type.{u_1}} [inst._@.Mathlib.Algebra.Group.Commute._hyg.168 : Semigroup.{u_1} S] {a : S} {b : S} {c : S}, (Commute.{u_1} S (Semigroup.toMul.{u_1} S inst._@.Mathlib.Algebra.Group.Commute._hyg.168) a c) -> (Commute.{u_1} S (Semigroup.toMul.{u_1} S inst._@.Mathlib.Algebra.Group.Commute._hyg.168) b c) -> (Commute.{u_1} S (Semigroup.toMul.{u_1} S inst._@.Mathlib.Algebra.Group.Commute._hyg.168) (HMul.hMul.{u_1 u_1 u_1} S S S (instHMul.{u_1} S (Semigroup.toMul.{u_1} S inst._@.Mathlib.Algebra.Group.Commute._hyg.168)) a b) c)
-Case conversion may be inaccurate. Consider using '#align commute.mul_left Commute.mul_leftₓ'. -/
 
 @[to_additive]
 protected theorem right_comm (h : Commute b c) (a : S) : a * b * c = a * c * b :=
@@ -124,12 +112,6 @@ protected theorem right_comm (h : Commute b c) (a : S) : a * b * c = a * c * b :
 #align commute.right_comm Commute.right_commₓ
 #align add_commute.right_comm AddCommute.right_commₓ
 -- I think `ₓ` is necessary because of the `mul` vs `HMul` distinction
-/- warning: commute.right_comm -> Commute.right_comm is a dubious translation:
-lean 3 declaration is
-  forall {S : Type.{u_2}} [_inst_1 : Semigroup.{u_2} S] {b : S} {c : S}, (Commute.{u_2} S (Semigroup.toHasMul.{u_2} S _inst_1) b c) -> (forall (a : S), Eq.{succ u_2} S (HMul.hMul.{u_2 u_2 u_2} S S S (instHMul.{u_2} S (Semigroup.toHasMul.{u_2} S _inst_1)) (HMul.hMul.{u_2 u_2 u_2} S S S (instHMul.{u_2} S (Semigroup.toHasMul.{u_2} S _inst_1)) a b) c) (HMul.hMul.{u_2 u_2 u_2} S S S (instHMul.{u_2} S (Semigroup.toHasMul.{u_2} S _inst_1)) (HMul.hMul.{u_2 u_2 u_2} S S S (instHMul.{u_2} S (Semigroup.toHasMul.{u_2} S _inst_1)) a c) b))
-but is expected to have type
-  forall {S : Type.{u_1}} [inst._@.Mathlib.Algebra.Group.Commute._hyg.195 : Semigroup.{u_1} S] {b : S} {c : S}, (Commute.{u_1} S (Semigroup.toMul.{u_1} S inst._@.Mathlib.Algebra.Group.Commute._hyg.195) b c) -> (forall (a : S), Eq.{succ u_1} S (HMul.hMul.{u_1 u_1 u_1} S S S (instHMul.{u_1} S (Semigroup.toMul.{u_1} S inst._@.Mathlib.Algebra.Group.Commute._hyg.195)) (HMul.hMul.{u_1 u_1 u_1} S S S (instHMul.{u_1} S (Semigroup.toMul.{u_1} S inst._@.Mathlib.Algebra.Group.Commute._hyg.195)) a b) c) (HMul.hMul.{u_1 u_1 u_1} S S S (instHMul.{u_1} S (Semigroup.toMul.{u_1} S inst._@.Mathlib.Algebra.Group.Commute._hyg.195)) (HMul.hMul.{u_1 u_1 u_1} S S S (instHMul.{u_1} S (Semigroup.toMul.{u_1} S inst._@.Mathlib.Algebra.Group.Commute._hyg.195)) a c) b))
-Case conversion may be inaccurate. Consider using '#align commute.right_comm Commute.right_commₓ'. -/
 
 @[to_additive]
 protected theorem left_comm (h : Commute a b) (c) : a * (b * c) = b * (a * c) :=
@@ -137,12 +119,6 @@ protected theorem left_comm (h : Commute a b) (c) : a * (b * c) = b * (a * c) :=
 #align commute.left_comm Commute.left_commₓ
 #align add_commute.left_comm AddCommute.left_commₓ
 -- I think `ₓ` is necessary because of the `mul` vs `HMul` distinction
-/- warning: commute.left_comm -> Commute.left_comm is a dubious translation:
-lean 3 declaration is
-  forall {S : Type.{u_2}} [_inst_1 : Semigroup.{u_2} S] {a : S} {b : S}, (Commute.{u_2} S (Semigroup.toHasMul.{u_2} S _inst_1) a b) -> (forall (c : S), Eq.{succ u_2} S (HMul.hMul.{u_2 u_2 u_2} S S S (instHMul.{u_2} S (Semigroup.toHasMul.{u_2} S _inst_1)) a (HMul.hMul.{u_2 u_2 u_2} S S S (instHMul.{u_2} S (Semigroup.toHasMul.{u_2} S _inst_1)) b c)) (HMul.hMul.{u_2 u_2 u_2} S S S (instHMul.{u_2} S (Semigroup.toHasMul.{u_2} S _inst_1)) b (HMul.hMul.{u_2 u_2 u_2} S S S (instHMul.{u_2} S (Semigroup.toHasMul.{u_2} S _inst_1)) a c)))
-but is expected to have type
-  forall {S : Type.{u_1}} [inst._@.Mathlib.Algebra.Group.Commute._hyg.226 : Semigroup.{u_1} S] {a : S} {b : S}, (Commute.{u_1} S (Semigroup.toMul.{u_1} S inst._@.Mathlib.Algebra.Group.Commute._hyg.226) a b) -> (forall (c : S), Eq.{succ u_1} S (HMul.hMul.{u_1 u_1 u_1} S S S (instHMul.{u_1} S (Semigroup.toMul.{u_1} S inst._@.Mathlib.Algebra.Group.Commute._hyg.226)) a (HMul.hMul.{u_1 u_1 u_1} S S S (instHMul.{u_1} S (Semigroup.toMul.{u_1} S inst._@.Mathlib.Algebra.Group.Commute._hyg.226)) b c)) (HMul.hMul.{u_1 u_1 u_1} S S S (instHMul.{u_1} S (Semigroup.toMul.{u_1} S inst._@.Mathlib.Algebra.Group.Commute._hyg.226)) b (HMul.hMul.{u_1 u_1 u_1} S S S (instHMul.{u_1} S (Semigroup.toMul.{u_1} S inst._@.Mathlib.Algebra.Group.Commute._hyg.226)) a c)))
-Case conversion may be inaccurate. Consider using '#align commute.left_comm Commute.left_commₓ'. -/
 
 end Semigroup
 
@@ -152,12 +128,6 @@ protected theorem all {S : Type _} [CommSemigroup S] (a b : S) : Commute a b :=
 #align commute.all Commute.allₓ
 #align add_commute.all AddCommute.allₓ
 -- not sure why this needs an `ₓ`, maybe instance names not aligned?
-/- warning: commute.all -> Commute.all is a dubious translation:
-lean 3 declaration is
-  forall {S : Type.{u_1}} [_inst_1 : CommSemigroup.{u_1} S] (a : S) (b : S), Commute.{u_1} S (Semigroup.toHasMul.{u_1} S (CommSemigroup.toSemigroup.{u_1} S _inst_1)) a b
-but is expected to have type
-  forall {S : Type.{u_1}} [inst._@.Mathlib.Algebra.Group.Commute._hyg.258 : CommSemigroup.{u_1} S] (a : S) (b : S), Commute.{u_1} S (Semigroup.toMul.{u_1} S (CommSemigroup.toSemigroup.{u_1} S inst._@.Mathlib.Algebra.Group.Commute._hyg.258)) a b
-Case conversion may be inaccurate. Consider using '#align commute.all Commute.allₓ'. -/
 
 section MulOneClass
 
@@ -169,12 +139,6 @@ theorem one_right (a : M) : Commute a 1 :=
 #align commute.one_right Commute.one_rightₓ
 #align add_commute.zero_right AddCommute.zero_rightₓ
 -- I think `ₓ` is necessary because `One.toOfNat1` appears in the Lean 4 version
-/- warning: commute.one_right -> Commute.one_right is a dubious translation:
-lean 3 declaration is
-  forall {M : Type.{u_2}} [_inst_1 : MulOneClass.{u_2} M] (a : M), Commute.{u_2} M (MulOneClass.toHasMul.{u_2} M _inst_1) a (OfNat.ofNat.{u_2} M 1 (OfNat.mk.{u_2} M 1 (One.one.{u_2} M (MulOneClass.toHasOne.{u_2} M _inst_1))))
-but is expected to have type
-  forall {M : Type.{u_1}} [inst._@.Mathlib.Algebra.Group.Commute._hyg.281 : MulOneClass.{u_1} M] (a : M), Commute.{u_1} M (MulOneClass.toMul.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.281) a (OfNat.ofNat.{u_1} M 1 (One.toOfNat1.{u_1} M (MulOneClass.toOne.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.281)))
-Case conversion may be inaccurate. Consider using '#align commute.one_right Commute.one_rightₓ'. -/
 
 @[simp, to_additive]
 theorem one_left (a : M) : Commute 1 a :=
@@ -182,12 +146,6 @@ theorem one_left (a : M) : Commute 1 a :=
 #align commute.one_left Commute.one_leftₓ
 #align add_commute.zero_left AddCommute.zero_leftₓ
 -- I think `ₓ` is necessary because `One.toOfNat1` appears in the Lean 4 version
-/- warning: commute.one_left -> Commute.one_left is a dubious translation:
-lean 3 declaration is
-  forall {M : Type.{u_2}} [_inst_1 : MulOneClass.{u_2} M] (a : M), Commute.{u_2} M (MulOneClass.toHasMul.{u_2} M _inst_1) (OfNat.ofNat.{u_2} M 1 (OfNat.mk.{u_2} M 1 (One.one.{u_2} M (MulOneClass.toHasOne.{u_2} M _inst_1)))) a
-but is expected to have type
-  forall {M : Type.{u_1}} [inst._@.Mathlib.Algebra.Group.Commute._hyg.293 : MulOneClass.{u_1} M] (a : M), Commute.{u_1} M (MulOneClass.toMul.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.293) (OfNat.ofNat.{u_1} M 1 (One.toOfNat1.{u_1} M (MulOneClass.toOne.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.293))) a
-Case conversion may be inaccurate. Consider using '#align commute.one_left Commute.one_leftₓ'. -/
 
 end MulOneClass
 
@@ -201,12 +159,6 @@ theorem pow_right (h : Commute a b) (n : ℕ) : Commute a (b ^ n) :=
 #align commute.pow_right Commute.pow_rightₓ
 #align add_commute.smul_right AddCommute.smul_rightₓ
 -- `MulOneClass.toHasMul` vs. `MulOneClass.toMul`
-/- warning: commute.pow_right -> Commute.pow_right is a dubious translation:
-lean 3 declaration is
-  forall {M : Type.{u_2}} [_inst_1 : Monoid.{u_2} M] {a : M} {b : M}, (Commute.{u_2} M (MulOneClass.toHasMul.{u_2} M (Monoid.toMulOneClass.{u_2} M _inst_1)) a b) -> (forall (n : Nat), Commute.{u_2} M (MulOneClass.toHasMul.{u_2} M (Monoid.toMulOneClass.{u_2} M _inst_1)) a (HPow.hPow.{u_2 0 u_2} M Nat M (instHPow.{u_2 0} M Nat (Monoid.hasPow.{u_2} M _inst_1)) b n))
-but is expected to have type
-  forall {M : Type.{u_1}} [inst._@.Mathlib.Algebra.Group.Commute._hyg.319 : Monoid.{u_1} M] {a : M} {b : M}, (Commute.{u_1} M (MulOneClass.toMul.{u_1} M (Monoid.toMulOneClass.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.319)) a b) -> (forall (n : Nat), Commute.{u_1} M (MulOneClass.toMul.{u_1} M (Monoid.toMulOneClass.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.319)) a (HPow.hPow.{u_1 0 u_1} M Nat M (instHPow.{u_1 0} M Nat (Monoid.Pow.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.319)) b n))
-Case conversion may be inaccurate. Consider using '#align commute.pow_right Commute.pow_rightₓ'. -/
 
 @[simp, to_additive]
 theorem pow_left (h : Commute a b) (n : ℕ) : Commute (a ^ n) b :=
@@ -214,12 +166,6 @@ theorem pow_left (h : Commute a b) (n : ℕ) : Commute (a ^ n) b :=
 #align commute.pow_left Commute.pow_leftₓ
 #align add_commute.smul_left AddCommute.smul_leftₓ
 -- `MulOneClass.toHasMul` vs. `MulOneClass.toMul`
-/- warning: commute.pow_left -> Commute.pow_left is a dubious translation:
-lean 3 declaration is
-  forall {M : Type.{u_2}} [_inst_1 : Monoid.{u_2} M] {a : M} {b : M}, (Commute.{u_2} M (MulOneClass.toHasMul.{u_2} M (Monoid.toMulOneClass.{u_2} M _inst_1)) a b) -> (forall (n : Nat), Commute.{u_2} M (MulOneClass.toHasMul.{u_2} M (Monoid.toMulOneClass.{u_2} M _inst_1)) (HPow.hPow.{u_2 0 u_2} M Nat M (instHPow.{u_2 0} M Nat (Monoid.hasPow.{u_2} M _inst_1)) a n) b)
-but is expected to have type
-  forall {M : Type.{u_1}} [inst._@.Mathlib.Algebra.Group.Commute._hyg.345 : Monoid.{u_1} M] {a : M} {b : M}, (Commute.{u_1} M (MulOneClass.toMul.{u_1} M (Monoid.toMulOneClass.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.345)) a b) -> (forall (n : Nat), Commute.{u_1} M (MulOneClass.toMul.{u_1} M (Monoid.toMulOneClass.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.345)) (HPow.hPow.{u_1 0 u_1} M Nat M (instHPow.{u_1 0} M Nat (Monoid.Pow.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.345)) a n) b)
-Case conversion may be inaccurate. Consider using '#align commute.pow_left Commute.pow_leftₓ'. -/
 
 @[simp, to_additive]
 theorem pow_pow (h : Commute a b) (m n : ℕ) : Commute (a ^ m) (b ^ n) :=
@@ -227,12 +173,6 @@ theorem pow_pow (h : Commute a b) (m n : ℕ) : Commute (a ^ m) (b ^ n) :=
 #align commute.pow_pow Commute.pow_powₓ
 #align add_commute.smul_smul AddCommute.smul_smulₓ
 -- `MulOneClass.toHasMul` vs. `MulOneClass.toMul`
-/- warning: commute.pow_pow -> Commute.pow_pow is a dubious translation:
-lean 3 declaration is
-  forall {M : Type.{u_2}} [_inst_1 : Monoid.{u_2} M] {a : M} {b : M}, (Commute.{u_2} M (MulOneClass.toHasMul.{u_2} M (Monoid.toMulOneClass.{u_2} M _inst_1)) a b) -> (forall (m : Nat) (n : Nat), Commute.{u_2} M (MulOneClass.toHasMul.{u_2} M (Monoid.toMulOneClass.{u_2} M _inst_1)) (HPow.hPow.{u_2 0 u_2} M Nat M (instHPow.{u_2 0} M Nat (Monoid.hasPow.{u_2} M _inst_1)) a m) (HPow.hPow.{u_2 0 u_2} M Nat M (instHPow.{u_2 0} M Nat (Monoid.hasPow.{u_2} M _inst_1)) b n))
-but is expected to have type
-  forall {M : Type.{u_1}} [inst._@.Mathlib.Algebra.Group.Commute._hyg.373 : Monoid.{u_1} M] {a : M} {b : M}, (Commute.{u_1} M (MulOneClass.toMul.{u_1} M (Monoid.toMulOneClass.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.373)) a b) -> (forall (m : Nat) (n : Nat), Commute.{u_1} M (MulOneClass.toMul.{u_1} M (Monoid.toMulOneClass.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.373)) (HPow.hPow.{u_1 0 u_1} M Nat M (instHPow.{u_1 0} M Nat (Monoid.Pow.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.373)) a m) (HPow.hPow.{u_1 0 u_1} M Nat M (instHPow.{u_1 0} M Nat (Monoid.Pow.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.373)) b n))
-Case conversion may be inaccurate. Consider using '#align commute.pow_pow Commute.pow_powₓ'. -/
 
 @[simp, to_additive]
 theorem self_pow (a : M) (n : ℕ) : Commute a (a ^ n) :=
@@ -240,24 +180,12 @@ theorem self_pow (a : M) (n : ℕ) : Commute a (a ^ n) :=
 #align commute.self_pow Commute.self_powₓ
 #align add_commute.self_smul AddCommute.self_smulₓ
 -- `MulOneClass.toHasMul` vs. `MulOneClass.toMul`
-/- warning: commute.self_pow -> Commute.self_pow is a dubious translation:
-lean 3 declaration is
-  forall {M : Type.{u_2}} [_inst_1 : Monoid.{u_2} M] (a : M) (n : Nat), Commute.{u_2} M (MulOneClass.toHasMul.{u_2} M (Monoid.toMulOneClass.{u_2} M _inst_1)) a (HPow.hPow.{u_2 0 u_2} M Nat M (instHPow.{u_2 0} M Nat (Monoid.hasPow.{u_2} M _inst_1)) a n)
-but is expected to have type
-  forall {M : Type.{u_1}} [inst._@.Mathlib.Algebra.Group.Commute._hyg.411 : Monoid.{u_1} M] (a : M) (n : Nat), Commute.{u_1} M (MulOneClass.toMul.{u_1} M (Monoid.toMulOneClass.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.411)) a (HPow.hPow.{u_1 0 u_1} M Nat M (instHPow.{u_1 0} M Nat (Monoid.Pow.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.411)) a n)
-Case conversion may be inaccurate. Consider using '#align commute.self_pow Commute.self_powₓ'. -/
 
 @[simp, to_additive]
 theorem pow_self (a : M) (n : ℕ) : Commute (a ^ n) a :=
   (Commute.refl a).pow_left n
 #align add_commute.smul_self AddCommute.smul_selfₓ
 -- `MulOneClass.toHasMul` vs. `MulOneClass.toMul`
-/- warning: commute.pow_self -> Commute.pow_self is a dubious translation:
-lean 3 declaration is
-  forall {M : Type.{u_2}} [_inst_1 : Monoid.{u_2} M] (a : M) (n : Nat), Commute.{u_2} M (MulOneClass.toHasMul.{u_2} M (Monoid.toMulOneClass.{u_2} M _inst_1)) (HPow.hPow.{u_2 0 u_2} M Nat M (instHPow.{u_2 0} M Nat (Monoid.hasPow.{u_2} M _inst_1)) a n) a
-but is expected to have type
-  forall {M : Type.{u_1}} [inst._@.Mathlib.Algebra.Group.Commute._hyg.438 : Monoid.{u_1} M] (a : M) (n : Nat), Commute.{u_1} M (MulOneClass.toMul.{u_1} M (Monoid.toMulOneClass.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.438)) (HPow.hPow.{u_1 0 u_1} M Nat M (instHPow.{u_1 0} M Nat (Monoid.Pow.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.438)) a n) a
-Case conversion may be inaccurate. Consider using '#align commute.pow_self Commute.pow_selfₓ'. -/
 
 @[simp, to_additive]
 theorem pow_pow_self (a : M) (m n : ℕ) : Commute (a ^ m) (a ^ n) :=
@@ -265,12 +193,6 @@ theorem pow_pow_self (a : M) (m n : ℕ) : Commute (a ^ m) (a ^ n) :=
 #align commute.pow_pow_self Commute.pow_pow_selfₓ
 #align add_commute.smul_smul_self AddCommute.smul_smul_selfₓ
 -- `MulOneClass.toHasMul` vs. `MulOneClass.toMul`
-/- warning: commute.pow_pow_self -> Commute.pow_pow_self is a dubious translation:
-lean 3 declaration is
-  forall {M : Type.{u_2}} [_inst_1 : Monoid.{u_2} M] (a : M) (m : Nat) (n : Nat), Commute.{u_2} M (MulOneClass.toHasMul.{u_2} M (Monoid.toMulOneClass.{u_2} M _inst_1)) (HPow.hPow.{u_2 0 u_2} M Nat M (instHPow.{u_2 0} M Nat (Monoid.hasPow.{u_2} M _inst_1)) a m) (HPow.hPow.{u_2 0 u_2} M Nat M (instHPow.{u_2 0} M Nat (Monoid.hasPow.{u_2} M _inst_1)) a n)
-but is expected to have type
-  forall {M : Type.{u_1}} [inst._@.Mathlib.Algebra.Group.Commute._hyg.465 : Monoid.{u_1} M] (a : M) (m : Nat) (n : Nat), Commute.{u_1} M (MulOneClass.toMul.{u_1} M (Monoid.toMulOneClass.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.465)) (HPow.hPow.{u_1 0 u_1} M Nat M (instHPow.{u_1 0} M Nat (Monoid.Pow.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.465)) a m) (HPow.hPow.{u_1 0 u_1} M Nat M (instHPow.{u_1 0} M Nat (Monoid.Pow.{u_1} M inst._@.Mathlib.Algebra.Group.Commute._hyg.465)) a n)
-Case conversion may be inaccurate. Consider using '#align commute.pow_pow_self Commute.pow_pow_selfₓ'. -/
 
 @[to_additive succ_nsmul']
 theorem _root_.pow_succ' (a : M) (n : ℕ) : a ^ (n + 1) = a ^ n * a :=

--- a/Mathlib/Algebra/Group/Commute.lean
+++ b/Mathlib/Algebra/Group/Commute.lean
@@ -275,7 +275,7 @@ theorem isUnit_mul_iff (h : Commute a b) : IsUnit (a * b) ↔ IsUnit a ∧ IsUni
 
 @[simp, to_additive]
 theorem _root_.isUnit_mul_self_iff : IsUnit (a * a) ↔ IsUnit a :=
-  (Commute.refl a).isUnit_mul_iff.trans and_self_iff
+  (Commute.refl a).isUnit_mul_iff.trans (and_self_iff _)
   -- porting note: `and_self_iff` now has an implicit argument instead of an explicit one.
 #align is_unit_mul_self_iff isUnit_mul_self_iff
 #align is_add_unit_add_self_iff isAddUnit_add_self_iff

--- a/Mathlib/Algebra/Group/Commute.lean
+++ b/Mathlib/Algebra/Group/Commute.lean
@@ -11,7 +11,7 @@ import Mathlib.Algebra.Group.Semiconj
 We define the predicate `Commute a b := a * b = b * a` and provide some operations on terms
 `(h : Commute a b)`. E.g., if `a`, `b`, and c are elements of a semiring, and that
 `hb : Commute a b` and `hc : Commute a c`.  Then `hb.pow_left 5` proves `Commute (a ^ 5) b` and
-`(hb.pow_right 2).add_right (hb.mul_right hc)` proves `commute a (b ^ 2 + b * c)`.
+`(hb.pow_right 2).add_right (hb.mul_right hc)` proves `Commute a (b ^ 2 + b * c)`.
 
 Lean does not immediately recognise these terms as equations, so for rewriting we need syntax like
 `rw [(hb.pow_left 5).eq]` rather than just `rw [hb.pow_left 5]`.
@@ -381,6 +381,7 @@ theorem inv_mul_cancel_comm : a⁻¹ * b * a = b :=
 @[simp, to_additive]
 theorem inv_mul_cancel_comm_assoc : a⁻¹ * (b * a) = b :=
   (Commute.all a b).inv_mul_cancel_assoc
+#align inv_mul_cancel_comm_assoc inv_mul_cancel_comm_assoc
 #align neg_add_cancel_comm_assoc neg_add_cancel_comm_assoc
 
 end CommGroup

--- a/Mathlib/Algebra/Group/Semiconj.lean
+++ b/Mathlib/Algebra/Group/Semiconj.lean
@@ -141,22 +141,22 @@ theorem units_inv_symm_left_iff {a : Mˣ} {x y : M} : SemiconjBy (↑a⁻¹) y x
 #align add_semiconj_by.add_units_neg_symm_left_iff AddSemiconjBy.addUnits_neg_symm_left_iff
 
 @[to_additive]
-theorem units_coe {a x y : Mˣ} (h : SemiconjBy a x y) : SemiconjBy (a : M) x y :=
+theorem units_val {a x y : Mˣ} (h : SemiconjBy a x y) : SemiconjBy (a : M) x y :=
   congr_arg Units.val h
-#align semiconj_by.units_coe SemiconjBy.units_coe
-#align add_semiconj_by.add_units_coe AddSemiconjBy.addUnits_coe
+#align semiconj_by.units_coe SemiconjBy.units_val
+#align add_semiconj_by.add_units_coe AddSemiconjBy.addUnits_val
 
 @[to_additive]
-theorem units_of_coe {a x y : Mˣ} (h : SemiconjBy (a : M) x y) : SemiconjBy a x y :=
+theorem units_of_val {a x y : Mˣ} (h : SemiconjBy (a : M) x y) : SemiconjBy a x y :=
   Units.ext h
-#align semiconj_by.units_of_coe SemiconjBy.units_of_coe
-#align add_semiconj_by.addUnits_of_coe AddSemiconjBy.addUnits_of_coe
+#align semiconj_by.units_of_coe SemiconjBy.units_of_val
+#align add_semiconj_by.addUnits_of_coe AddSemiconjBy.addUnits_of_val
 
 @[simp, to_additive]
-theorem units_coe_iff {a x y : Mˣ} : SemiconjBy (a : M) x y ↔ SemiconjBy a x y :=
-  ⟨units_of_coe, units_coe⟩
-#align semiconj_by.units_coe_iff SemiconjBy.units_coe_iff
-#align add_semiconj_by.add_units_coe_iff AddSemiconjBy.addUnits_coe_iff
+theorem units_val_iff {a x y : Mˣ} : SemiconjBy (a : M) x y ↔ SemiconjBy a x y :=
+  ⟨units_of_val, units_val⟩
+#align semiconj_by.units_coe_iff SemiconjBy.units_val_iff
+#align add_semiconj_by.add_units_coe_iff AddSemiconjBy.addUnits_val_iff
 
 @[simp, to_additive]
 theorem pow_right {a x y : M} (h : SemiconjBy a x y) (n : ℕ) : SemiconjBy a (x ^ n) (y ^ n) := by

--- a/Mathlib/Algebra/GroupPower/Basic.lean
+++ b/Mathlib/Algebra/GroupPower/Basic.lean
@@ -27,9 +27,6 @@ theorem add_nsmul (a : M) (m n : ℕ) : (m + n) • a = m • a + n • a := by
   | zero => rw [Nat.zero_add, zero_nsmul, zero_add]
   | succ m ih => rw [Nat.succ_add, Nat.succ_eq_add_one, succ_nsmul, ih, succ_nsmul, add_assoc]
 
-theorem succ_nsmul' (a : M) (n : ℕ) : (n + 1) • a = n • a + a := by
-  rw [add_nsmul, one_nsmul]
-
 end AddMonoid
 
 section Monoid
@@ -59,8 +56,6 @@ theorem Commute.mul_pow {a b : M} (h : Commute a b) (n : ℕ) : (a * b) ^ n = a 
   induction' n with n ih
   · rw [pow_zero, pow_zero, pow_zero, one_mul]
   · simp only [pow_succ, ih, ← mul_assoc, (h.pow_left n).right_comm]
-
-attribute [to_additive succ_nsmul'] pow_succ'
 
 end Monoid
 

--- a/Mathlib/Algebra/Ring/Basic.lean
+++ b/Mathlib/Algebra/Ring/Basic.lean
@@ -1,4 +1,4 @@
-import Mathlib.Algebra.Group.Commute
+import Mathlib.Algebra.Ring.Commute
 import Mathlib.Algebra.GroupWithZero.Defs
 import Mathlib.Data.Int.Cast.Basic
 import Mathlib.Tactic.Spread
@@ -19,14 +19,6 @@ section Semiring
 
 @[simp] theorem Commute.zero_left [Semiring R] (a : R) : Commute 0 a :=
   (zero_mul _).trans (mul_zero _).symm
-
-@[simp] theorem Commute.add_right [Semiring R] {a b c : R} (h : Commute a b) (h' : Commute a c) :
-    Commute a (b + c) := by
-  simp only [Commute, SemiconjBy, left_distrib, right_distrib, h.eq, h'.eq]
-
-@[simp] theorem Commute.add_left [Semiring R] {a b c : R} (h : Commute a c) (h' : Commute b c) :
-    Commute (a + b) c := by
-  simp only [Commute, SemiconjBy, left_distrib, right_distrib, h.eq, h'.eq]
 
 @[simp]
 lemma Nat.cast_mul [Semiring R] {m n : ℕ} : (m * n).cast = (m.cast * n.cast : R) := by

--- a/Mathlib/Algebra/Ring/Commute.lean
+++ b/Mathlib/Algebra/Ring/Commute.lean
@@ -1,0 +1,170 @@
+/-
+Copyright (c) 2014 Jeremy Avigad. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jeremy Avigad, Leonardo de Moura, Floris van Doorn, Yury Kudryashov, Neil Strickland
+-/
+import Mathbin.Algebra.Ring.Semiconj
+import Mathbin.Algebra.Ring.Units
+import Mathbin.Algebra.Group.Commute
+
+/-!
+# Semirings and rings
+
+This file gives lemmas about semirings, rings and domains.
+This is analogous to `algebra.group.basic`,
+the difference being that the former is about `+` and `*` separately, while
+the present file is about their interaction.
+
+For the definitions of semirings and rings see `algebra.ring.defs`.
+
+-/
+
+
+universe u v w x
+
+variable {α : Type u} {β : Type v} {γ : Type w} {R : Type x}
+
+open Function
+
+namespace Commute
+
+/- warning: commute.add_right -> Commute.add_right is a dubious translation:
+lean 3 declaration is
+  forall {R : Type.{x}} [_inst_1 : Distrib.{x} R] {a : R} {b : R} {c : R}, (Commute.{x} R (Distrib.toHasMul.{x} R _inst_1) a b) -> (Commute.{x} R (Distrib.toHasMul.{x} R _inst_1) a c) -> (Commute.{x} R (Distrib.toHasMul.{x} R _inst_1) a (HAdd.hAdd.{x x x} R R R (instHAdd.{x} R (Distrib.toHasAdd.{x} R _inst_1)) b c))
+but is expected to have type
+  forall {R : Type.{u_1}} [inst._@.Mathlib.Algebra.Ring.Basic._hyg.61 : Semiring.{u_1} R] {a : R} {b : R} {c : R}, (Commute.{u_1} R (NonUnitalNonAssocSemiring.toMul.{u_1} R (NonAssocSemiring.toNonUnitalNonAssocSemiring.{u_1} R (Semiring.toNonAssocSemiring.{u_1} R inst._@.Mathlib.Algebra.Ring.Basic._hyg.61))) a b) -> (Commute.{u_1} R (NonUnitalNonAssocSemiring.toMul.{u_1} R (NonAssocSemiring.toNonUnitalNonAssocSemiring.{u_1} R (Semiring.toNonAssocSemiring.{u_1} R inst._@.Mathlib.Algebra.Ring.Basic._hyg.61))) a c) -> (Commute.{u_1} R (NonUnitalNonAssocSemiring.toMul.{u_1} R (NonAssocSemiring.toNonUnitalNonAssocSemiring.{u_1} R (Semiring.toNonAssocSemiring.{u_1} R inst._@.Mathlib.Algebra.Ring.Basic._hyg.61))) a (HAdd.hAdd.{u_1 u_1 u_1} R R R (instHAdd.{u_1} R (Distrib.toAdd.{u_1} R (NonUnitalNonAssocSemiring.toDistrib.{u_1} R (NonAssocSemiring.toNonUnitalNonAssocSemiring.{u_1} R (Semiring.toNonAssocSemiring.{u_1} R inst._@.Mathlib.Algebra.Ring.Basic._hyg.61))))) b c))
+Case conversion may be inaccurate. Consider using '#align commute.add_right Commute.add_rightₓ'. -/
+@[simp]
+theorem add_right [Distrib R] {a b c : R} : Commute a b → Commute a c → Commute a (b + c) :=
+  SemiconjBy.add_right
+#align commute.add_right Commute.add_right
+
+/- warning: commute.add_left -> Commute.add_left is a dubious translation:
+lean 3 declaration is
+  forall {R : Type.{x}} [_inst_1 : Distrib.{x} R] {a : R} {b : R} {c : R}, (Commute.{x} R (Distrib.toHasMul.{x} R _inst_1) a c) -> (Commute.{x} R (Distrib.toHasMul.{x} R _inst_1) b c) -> (Commute.{x} R (Distrib.toHasMul.{x} R _inst_1) (HAdd.hAdd.{x x x} R R R (instHAdd.{x} R (Distrib.toHasAdd.{x} R _inst_1)) a b) c)
+but is expected to have type
+  forall {R : Type.{u_1}} [inst._@.Mathlib.Algebra.Ring.Basic._hyg.96 : Semiring.{u_1} R] {a : R} {b : R} {c : R}, (Commute.{u_1} R (NonUnitalNonAssocSemiring.toMul.{u_1} R (NonAssocSemiring.toNonUnitalNonAssocSemiring.{u_1} R (Semiring.toNonAssocSemiring.{u_1} R inst._@.Mathlib.Algebra.Ring.Basic._hyg.96))) a c) -> (Commute.{u_1} R (NonUnitalNonAssocSemiring.toMul.{u_1} R (NonAssocSemiring.toNonUnitalNonAssocSemiring.{u_1} R (Semiring.toNonAssocSemiring.{u_1} R inst._@.Mathlib.Algebra.Ring.Basic._hyg.96))) b c) -> (Commute.{u_1} R (NonUnitalNonAssocSemiring.toMul.{u_1} R (NonAssocSemiring.toNonUnitalNonAssocSemiring.{u_1} R (Semiring.toNonAssocSemiring.{u_1} R inst._@.Mathlib.Algebra.Ring.Basic._hyg.96))) (HAdd.hAdd.{u_1 u_1 u_1} R R R (instHAdd.{u_1} R (Distrib.toAdd.{u_1} R (NonUnitalNonAssocSemiring.toDistrib.{u_1} R (NonAssocSemiring.toNonUnitalNonAssocSemiring.{u_1} R (Semiring.toNonAssocSemiring.{u_1} R inst._@.Mathlib.Algebra.Ring.Basic._hyg.96))))) a b) c)
+Case conversion may be inaccurate. Consider using '#align commute.add_left Commute.add_leftₓ'. -/
+@[simp]
+theorem add_left [Distrib R] {a b c : R} : Commute a c → Commute b c → Commute (a + b) c :=
+  SemiconjBy.add_left
+#align commute.add_left Commute.add_left
+
+theorem bit0_right [Distrib R] {x y : R} (h : Commute x y) : Commute x (bit0 y) :=
+  h.add_right h
+#align commute.bit0_right Commute.bit0_right
+
+theorem bit0_left [Distrib R] {x y : R} (h : Commute x y) : Commute (bit0 x) y :=
+  h.add_left h
+#align commute.bit0_left Commute.bit0_left
+
+theorem bit1_right [NonAssocSemiring R] {x y : R} (h : Commute x y) : Commute x (bit1 y) :=
+  h.bit0_right.add_right (Commute.one_right x)
+#align commute.bit1_right Commute.bit1_right
+
+theorem bit1_left [NonAssocSemiring R] {x y : R} (h : Commute x y) : Commute (bit1 x) y :=
+  h.bit0_left.add_left (Commute.one_left y)
+#align commute.bit1_left Commute.bit1_left
+
+/-- Representation of a difference of two squares of commuting elements as a product. -/
+theorem mul_self_sub_mul_self_eq [NonUnitalNonAssocRing R] {a b : R} (h : Commute a b) :
+    a * a - b * b = (a + b) * (a - b) := by rw [add_mul, mul_sub, mul_sub, h.eq, sub_add_sub_cancel]
+#align commute.mul_self_sub_mul_self_eq Commute.mul_self_sub_mul_self_eq
+
+theorem mul_self_sub_mul_self_eq' [NonUnitalNonAssocRing R] {a b : R} (h : Commute a b) :
+    a * a - b * b = (a - b) * (a + b) := by rw [mul_add, sub_mul, sub_mul, h.eq, sub_add_sub_cancel]
+#align commute.mul_self_sub_mul_self_eq' Commute.mul_self_sub_mul_self_eq'
+
+theorem mul_self_eq_mul_self_iff [NonUnitalNonAssocRing R] [NoZeroDivisors R] {a b : R} (h : Commute a b) :
+    a * a = b * b ↔ a = b ∨ a = -b := by
+  rw [← sub_eq_zero, h.mul_self_sub_mul_self_eq, mul_eq_zero, or_comm', sub_eq_zero, add_eq_zero_iff_eq_neg]
+#align commute.mul_self_eq_mul_self_iff Commute.mul_self_eq_mul_self_iff
+
+section
+
+variable [Mul R] [HasDistribNeg R] {a b : R}
+
+theorem neg_right : Commute a b → Commute a (-b) :=
+  SemiconjBy.neg_right
+#align commute.neg_right Commute.neg_right
+
+@[simp]
+theorem neg_right_iff : Commute a (-b) ↔ Commute a b :=
+  SemiconjBy.neg_right_iff
+#align commute.neg_right_iff Commute.neg_right_iff
+
+theorem neg_left : Commute a b → Commute (-a) b :=
+  SemiconjBy.neg_left
+#align commute.neg_left Commute.neg_left
+
+@[simp]
+theorem neg_left_iff : Commute (-a) b ↔ Commute a b :=
+  SemiconjBy.neg_left_iff
+#align commute.neg_left_iff Commute.neg_left_iff
+
+end
+
+section
+
+variable [MulOneClass R] [HasDistribNeg R] {a : R}
+
+@[simp]
+theorem neg_one_right (a : R) : Commute a (-1) :=
+  SemiconjBy.neg_one_right a
+#align commute.neg_one_right Commute.neg_one_right
+
+@[simp]
+theorem neg_one_left (a : R) : Commute (-1) a :=
+  SemiconjBy.neg_one_left a
+#align commute.neg_one_left Commute.neg_one_left
+
+end
+
+section
+
+variable [NonUnitalNonAssocRing R] {a b c : R}
+
+@[simp]
+theorem sub_right : Commute a b → Commute a c → Commute a (b - c) :=
+  SemiconjBy.sub_right
+#align commute.sub_right Commute.sub_right
+
+@[simp]
+theorem sub_left : Commute a c → Commute b c → Commute (a - b) c :=
+  SemiconjBy.sub_left
+#align commute.sub_left Commute.sub_left
+
+end
+
+end Commute
+
+/-- Representation of a difference of two squares in a commutative ring as a product. -/
+theorem mul_self_sub_mul_self [CommRing R] (a b : R) : a * a - b * b = (a + b) * (a - b) :=
+  (Commute.all a b).mul_self_sub_mul_self_eq
+#align mul_self_sub_mul_self mul_self_sub_mul_self
+
+theorem mul_self_sub_one [NonAssocRing R] (a : R) : a * a - 1 = (a + 1) * (a - 1) := by
+  rw [← (Commute.one_right a).mul_self_sub_mul_self_eq, mul_one]
+#align mul_self_sub_one mul_self_sub_one
+
+theorem mul_self_eq_mul_self_iff [CommRing R] [NoZeroDivisors R] {a b : R} : a * a = b * b ↔ a = b ∨ a = -b :=
+  (Commute.all a b).mul_self_eq_mul_self_iff
+#align mul_self_eq_mul_self_iff mul_self_eq_mul_self_iff
+
+theorem mul_self_eq_one_iff [NonAssocRing R] [NoZeroDivisors R] {a : R} : a * a = 1 ↔ a = 1 ∨ a = -1 := by
+  rw [← (Commute.one_right a).mul_self_eq_mul_self_iff, mul_one]
+#align mul_self_eq_one_iff mul_self_eq_one_iff
+
+namespace Units
+
+/-- In the unit group of an integral domain, a unit is its own inverse iff the unit is one or
+  one's additive inverse. -/
+theorem inv_eq_self_iff [Ring R] [NoZeroDivisors R] (u : Rˣ) : u⁻¹ = u ↔ u = 1 ∨ u = -1 := by
+  rw [inv_eq_iff_mul_eq_one]
+  simp only [ext_iff]
+  push_cast
+  exact mul_self_eq_one_iff
+#align units.inv_eq_self_iff Units.inv_eq_self_iff
+
+end Units
+

--- a/Mathlib/Algebra/Ring/Commute.lean
+++ b/Mathlib/Algebra/Ring/Commute.lean
@@ -110,12 +110,14 @@ section
 
 variable [MulOneClass R] [HasDistribNeg R] {a : R}
 
-@[simp]
+-- Porting note: no longer needs to be `@[simp]` since `simp` can prove it.
+-- @[simp]
 theorem neg_one_right (a : R) : Commute a (-1) :=
   SemiconjBy.neg_one_right a
 #align commute.neg_one_right Commute.neg_one_right
 
-@[simp]
+-- Porting note: no longer needs to be `@[simp]` since `simp` can prove it.
+-- @[simp]
 theorem neg_one_left (a : R) : Commute (-1) a :=
   SemiconjBy.neg_one_left a
 #align commute.neg_one_left Commute.neg_one_left

--- a/Mathlib/Algebra/Ring/Commute.lean
+++ b/Mathlib/Algebra/Ring/Commute.lean
@@ -28,24 +28,12 @@ open Function
 
 namespace Commute
 
-/- warning: commute.add_right -> Commute.add_right is a dubious translation:
-lean 3 declaration is
-  forall {R : Type.{x}} [_inst_1 : Distrib.{x} R] {a : R} {b : R} {c : R}, (Commute.{x} R (Distrib.toHasMul.{x} R _inst_1) a b) -> (Commute.{x} R (Distrib.toHasMul.{x} R _inst_1) a c) -> (Commute.{x} R (Distrib.toHasMul.{x} R _inst_1) a (HAdd.hAdd.{x x x} R R R (instHAdd.{x} R (Distrib.toHasAdd.{x} R _inst_1)) b c))
-but is expected to have type
-  forall {R : Type.{u_1}} [inst._@.Mathlib.Algebra.Ring.Basic._hyg.61 : Semiring.{u_1} R] {a : R} {b : R} {c : R}, (Commute.{u_1} R (NonUnitalNonAssocSemiring.toMul.{u_1} R (NonAssocSemiring.toNonUnitalNonAssocSemiring.{u_1} R (Semiring.toNonAssocSemiring.{u_1} R inst._@.Mathlib.Algebra.Ring.Basic._hyg.61))) a b) -> (Commute.{u_1} R (NonUnitalNonAssocSemiring.toMul.{u_1} R (NonAssocSemiring.toNonUnitalNonAssocSemiring.{u_1} R (Semiring.toNonAssocSemiring.{u_1} R inst._@.Mathlib.Algebra.Ring.Basic._hyg.61))) a c) -> (Commute.{u_1} R (NonUnitalNonAssocSemiring.toMul.{u_1} R (NonAssocSemiring.toNonUnitalNonAssocSemiring.{u_1} R (Semiring.toNonAssocSemiring.{u_1} R inst._@.Mathlib.Algebra.Ring.Basic._hyg.61))) a (HAdd.hAdd.{u_1 u_1 u_1} R R R (instHAdd.{u_1} R (Distrib.toAdd.{u_1} R (NonUnitalNonAssocSemiring.toDistrib.{u_1} R (NonAssocSemiring.toNonUnitalNonAssocSemiring.{u_1} R (Semiring.toNonAssocSemiring.{u_1} R inst._@.Mathlib.Algebra.Ring.Basic._hyg.61))))) b c))
-Case conversion may be inaccurate. Consider using '#align commute.add_right Commute.add_rightₓ'. -/
 @[simp]
 theorem add_right [Distrib R] {a b c : R} : Commute a b → Commute a c → Commute a (b + c) :=
   SemiconjBy.add_right
 #align commute.add_right Commute.add_rightₓ
 -- for some reason mathport expected `Semiring` instead of `Distrib`?
 
-/- warning: commute.add_left -> Commute.add_left is a dubious translation:
-lean 3 declaration is
-  forall {R : Type.{x}} [_inst_1 : Distrib.{x} R] {a : R} {b : R} {c : R}, (Commute.{x} R (Distrib.toHasMul.{x} R _inst_1) a c) -> (Commute.{x} R (Distrib.toHasMul.{x} R _inst_1) b c) -> (Commute.{x} R (Distrib.toHasMul.{x} R _inst_1) (HAdd.hAdd.{x x x} R R R (instHAdd.{x} R (Distrib.toHasAdd.{x} R _inst_1)) a b) c)
-but is expected to have type
-  forall {R : Type.{u_1}} [inst._@.Mathlib.Algebra.Ring.Basic._hyg.96 : Semiring.{u_1} R] {a : R} {b : R} {c : R}, (Commute.{u_1} R (NonUnitalNonAssocSemiring.toMul.{u_1} R (NonAssocSemiring.toNonUnitalNonAssocSemiring.{u_1} R (Semiring.toNonAssocSemiring.{u_1} R inst._@.Mathlib.Algebra.Ring.Basic._hyg.96))) a c) -> (Commute.{u_1} R (NonUnitalNonAssocSemiring.toMul.{u_1} R (NonAssocSemiring.toNonUnitalNonAssocSemiring.{u_1} R (Semiring.toNonAssocSemiring.{u_1} R inst._@.Mathlib.Algebra.Ring.Basic._hyg.96))) b c) -> (Commute.{u_1} R (NonUnitalNonAssocSemiring.toMul.{u_1} R (NonAssocSemiring.toNonUnitalNonAssocSemiring.{u_1} R (Semiring.toNonAssocSemiring.{u_1} R inst._@.Mathlib.Algebra.Ring.Basic._hyg.96))) (HAdd.hAdd.{u_1 u_1 u_1} R R R (instHAdd.{u_1} R (Distrib.toAdd.{u_1} R (NonUnitalNonAssocSemiring.toDistrib.{u_1} R (NonAssocSemiring.toNonUnitalNonAssocSemiring.{u_1} R (Semiring.toNonAssocSemiring.{u_1} R inst._@.Mathlib.Algebra.Ring.Basic._hyg.96))))) a b) c)
-Case conversion may be inaccurate. Consider using '#align commute.add_left Commute.add_leftₓ'. -/
 @[simp]
 theorem add_left [Distrib R] {a b c : R} : Commute a c → Commute b c → Commute (a + b) c :=
   SemiconjBy.add_left

--- a/Mathlib/Algebra/Ring/Commute.lean
+++ b/Mathlib/Algebra/Ring/Commute.lean
@@ -3,19 +3,19 @@ Copyright (c) 2014 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura, Floris van Doorn, Yury Kudryashov, Neil Strickland
 -/
-import Mathbin.Algebra.Ring.Semiconj
-import Mathbin.Algebra.Ring.Units
-import Mathbin.Algebra.Group.Commute
+import Mathlib.Algebra.Ring.Semiconj
+import Mathlib.Algebra.Ring.Units
+import Mathlib.Algebra.Group.Commute
 
 /-!
 # Semirings and rings
 
 This file gives lemmas about semirings, rings and domains.
-This is analogous to `algebra.group.basic`,
+This is analogous to `Mathlib.Algebra.Group.Basic`,
 the difference being that the former is about `+` and `*` separately, while
 the present file is about their interaction.
 
-For the definitions of semirings and rings see `algebra.ring.defs`.
+For the definitions of semirings and rings see `Mathlib.Algebra.Ring.Defs`.
 
 -/
 
@@ -37,7 +37,8 @@ Case conversion may be inaccurate. Consider using '#align commute.add_right Comm
 @[simp]
 theorem add_right [Distrib R] {a b c : R} : Commute a b → Commute a c → Commute a (b + c) :=
   SemiconjBy.add_right
-#align commute.add_right Commute.add_right
+#align commute.add_right Commute.add_rightₓ
+-- for some reason mathport expected `Semiring` instead of `Distrib`?
 
 /- warning: commute.add_left -> Commute.add_left is a dubious translation:
 lean 3 declaration is
@@ -48,36 +49,49 @@ Case conversion may be inaccurate. Consider using '#align commute.add_left Commu
 @[simp]
 theorem add_left [Distrib R] {a b c : R} : Commute a c → Commute b c → Commute (a + b) c :=
   SemiconjBy.add_left
-#align commute.add_left Commute.add_left
+#align commute.add_left Commute.add_leftₓ
+-- for some reason mathport expected `Semiring` instead of `Distrib`?
 
+section deprecated
+set_option linter.deprecated false
+
+@[deprecated]
 theorem bit0_right [Distrib R] {x y : R} (h : Commute x y) : Commute x (bit0 y) :=
   h.add_right h
 #align commute.bit0_right Commute.bit0_right
 
+@[deprecated]
 theorem bit0_left [Distrib R] {x y : R} (h : Commute x y) : Commute (bit0 x) y :=
   h.add_left h
 #align commute.bit0_left Commute.bit0_left
 
+@[deprecated]
 theorem bit1_right [NonAssocSemiring R] {x y : R} (h : Commute x y) : Commute x (bit1 y) :=
   h.bit0_right.add_right (Commute.one_right x)
 #align commute.bit1_right Commute.bit1_right
 
+@[deprecated]
 theorem bit1_left [NonAssocSemiring R] {x y : R} (h : Commute x y) : Commute (bit1 x) y :=
   h.bit0_left.add_left (Commute.one_left y)
 #align commute.bit1_left Commute.bit1_left
 
+end deprecated
+
 /-- Representation of a difference of two squares of commuting elements as a product. -/
 theorem mul_self_sub_mul_self_eq [NonUnitalNonAssocRing R] {a b : R} (h : Commute a b) :
-    a * a - b * b = (a + b) * (a - b) := by rw [add_mul, mul_sub, mul_sub, h.eq, sub_add_sub_cancel]
+    a * a - b * b = (a + b) * (a - b) := by
+  rw [add_mul, mul_sub, mul_sub, h.eq, sub_add_sub_cancel]
 #align commute.mul_self_sub_mul_self_eq Commute.mul_self_sub_mul_self_eq
 
 theorem mul_self_sub_mul_self_eq' [NonUnitalNonAssocRing R] {a b : R} (h : Commute a b) :
-    a * a - b * b = (a - b) * (a + b) := by rw [mul_add, sub_mul, sub_mul, h.eq, sub_add_sub_cancel]
+    a * a - b * b = (a - b) * (a + b) := by
+  rw [mul_add, sub_mul, sub_mul, h.eq, sub_add_sub_cancel]
 #align commute.mul_self_sub_mul_self_eq' Commute.mul_self_sub_mul_self_eq'
 
-theorem mul_self_eq_mul_self_iff [NonUnitalNonAssocRing R] [NoZeroDivisors R] {a b : R} (h : Commute a b) :
-    a * a = b * b ↔ a = b ∨ a = -b := by
-  rw [← sub_eq_zero, h.mul_self_sub_mul_self_eq, mul_eq_zero, or_comm', sub_eq_zero, add_eq_zero_iff_eq_neg]
+theorem mul_self_eq_mul_self_iff [NonUnitalNonAssocRing R] [NoZeroDivisors R] {a b : R}
+    (h : Commute a b) : a * a = b * b ↔ a = b ∨ a = -b := by
+  rw [← sub_eq_zero, h.mul_self_sub_mul_self_eq, mul_eq_zero, or_comm, sub_eq_zero,
+    add_eq_zero_iff_eq_neg]
 #align commute.mul_self_eq_mul_self_iff Commute.mul_self_eq_mul_self_iff
 
 section
@@ -147,11 +161,13 @@ theorem mul_self_sub_one [NonAssocRing R] (a : R) : a * a - 1 = (a + 1) * (a - 1
   rw [← (Commute.one_right a).mul_self_sub_mul_self_eq, mul_one]
 #align mul_self_sub_one mul_self_sub_one
 
-theorem mul_self_eq_mul_self_iff [CommRing R] [NoZeroDivisors R] {a b : R} : a * a = b * b ↔ a = b ∨ a = -b :=
+theorem mul_self_eq_mul_self_iff [CommRing R] [NoZeroDivisors R] {a b : R} :
+    a * a = b * b ↔ a = b ∨ a = -b :=
   (Commute.all a b).mul_self_eq_mul_self_iff
 #align mul_self_eq_mul_self_iff mul_self_eq_mul_self_iff
 
-theorem mul_self_eq_one_iff [NonAssocRing R] [NoZeroDivisors R] {a : R} : a * a = 1 ↔ a = 1 ∨ a = -1 := by
+theorem mul_self_eq_one_iff [NonAssocRing R] [NoZeroDivisors R] {a : R} :
+    a * a = 1 ↔ a = 1 ∨ a = -1 := by
   rw [← (Commute.one_right a).mul_self_eq_mul_self_iff, mul_one]
 #align mul_self_eq_one_iff mul_self_eq_one_iff
 
@@ -167,4 +183,3 @@ theorem inv_eq_self_iff [Ring R] [NoZeroDivisors R] (u : Rˣ) : u⁻¹ = u ↔ u
 #align units.inv_eq_self_iff Units.inv_eq_self_iff
 
 end Units
-


### PR DESCRIPTION
mathlib3 SHA: 76171581280d5b5d1e2d1f4f37e5420357bdc636

- [x] depends on: #750 

porting notes: basically perfect by mathport!
1. I marked things involving `bit0` and `bit1` as deprecated, but left them in.
2. For some reason `Commute.add_right` and `Commute.add_left` were marked as dubious translations, and this seemed to be because from Lean 3 we have `Distrib`, but Lean 4 expected `Semiring`, so I just `#align`ed with an `ₓ`