### PR TITLE
[Merged by Bors] - fix: update context in recursive calls in split_ifs

### DIFF
--- a/Mathlib/Tactic/SplitIfs.lean
+++ b/Mathlib/Tactic/SplitIfs.lean
@@ -105,7 +105,7 @@ private def valueKnown (cond : Expr) : TacticM Bool := do
 Stops if it encounters a condition in the passed-in `List Expr`.
 -/
 private partial def splitIfsCore (loc : Location) (hNames : IO.Ref (List Name)) :
-  List Expr → TacticM Unit := fun done ↦ do
+  List Expr → TacticM Unit := fun done ↦ withMainContext do
   let some (_,cond) ← findIfCondAt loc
       | Meta.throwTacticEx `split_ifs (←getMainGoal) "no if-the-else conditions to split"
 

--- a/test/SplitIfs.lean
+++ b/test/SplitIfs.lean
@@ -67,6 +67,7 @@ example : True := by
 open Classical in
 example (P Q : Prop) (w : if P then (if Q then true else true) else true = true) : true := by
   split_ifs at w
+  -- check that we've fully split w into three subgoals
   · trivial
   · trivial
   · trivial

--- a/test/SplitIfs.lean
+++ b/test/SplitIfs.lean
@@ -63,3 +63,12 @@ example (p q : Prop) [Decidable p] [Decidable q] :
 example : True := by
   fail_if_success { split_ifs }
   trivial
+
+open Classical in
+example (P Q : Prop) (w : if P then (if Q then true else true) else true = true) : true := by
+  split_ifs at w
+  · trivial
+  · trivial
+  · trivial
+
+

--- a/test/SplitIfs.lean
+++ b/test/SplitIfs.lean
@@ -71,5 +71,3 @@ example (P Q : Prop) (w : if P then (if Q then true else true) else true = true)
   · trivial
   · trivial
   · trivial
-
-


### PR DESCRIPTION
Fixes #760.

Before this change, we were failing at an fvar lookup here:
https://github.com/leanprover-community/mathlib4/blob/91897c46c6cdf35faad92219848764a4e6f87d86/Mathlib/Tactic/SplitIfs.lean#L44