### PR TITLE
[Merged by Bors] - fix: to_additive generates equation lemmas for target

### DIFF
--- a/Mathlib/Tactic/ToAdditive.lean
+++ b/Mathlib/Tactic/ToAdditive.lean
@@ -476,8 +476,10 @@ This is used to implement `@[to_additive]`.
 -/
 def transformDecl (ref : Option Syntax) (src tgt : Name) : CoreM Unit := do
   transformDeclAux ref src tgt src
-  let srcEqns? ← MetaM.run' (getEqnsFor? src)
-  let tgtEqns? ← MetaM.run' (getEqnsFor? src)
+  /- We need to generate all equation lemmas for `src`, otherwise they will be generated later
+  when doing a `rw`, but not for `tgt`. -/
+  let srcEqns? ← MetaM.run' (getEqnsFor? src true)
+  let tgtEqns? ← MetaM.run' (getEqnsFor? tgt true)
   -- now transform all of the equational lemmas
   match srcEqns?, tgtEqns? with
   | some srcEqns, some tgtEqns =>

--- a/Mathlib/Tactic/ToAdditive.lean
+++ b/Mathlib/Tactic/ToAdditive.lean
@@ -476,8 +476,9 @@ This is used to implement `@[to_additive]`.
 -/
 def transformDecl (ref : Option Syntax) (src tgt : Name) : CoreM Unit := do
   transformDeclAux ref src tgt src
-  /- We need to generate all equation lemmas for `src`, otherwise they will be generated later
-  when doing a `rw`, but not for `tgt`. -/
+  /- We need to generate all equation lemmas for `src` and `tgt`, even for non-recursive
+  definitions. If we don't do that, the equation lemma for `src` might be generated later
+  when doing a `rw`, but it won't be generated for `tgt`. -/
   let srcEqns? ← MetaM.run' (getEqnsFor? src true)
   let tgtEqns? ← MetaM.run' (getEqnsFor? tgt true)
   -- now transform all of the equational lemmas


### PR DESCRIPTION
* Also copy attributes for equation lemmas
* Add a comment why we generate equation lemmas for non-recursive definitions.
* This will allow us to doubly additivize a declaration (e.g. `Pow -> SMul -> VAdd`)