### PR TITLE
[Merged by Bors] - feat: better name guessing for to_additive

### DIFF
--- a/Mathlib/Data/String/Defs.lean
+++ b/Mathlib/Data/String/Defs.lean
@@ -20,4 +20,9 @@ then reassembles the string by intercalating the separator token `c` over the ma
 def mapTokens (c : Char) (f : String → String) : String → String :=
 intercalate (singleton c) ∘ List.map f ∘ (·.split (· = c))
 
+/-- `isPrefixOf? pre s` returns `some post` if `s = pre ++ post`.
+  If `pre` is not a prefix of `s`, it returns `none`. -/
+def isPrefixOf? (pre s : String) : Option String :=
+  if startsWith s pre then some <| s.drop pre.length else none
+
 end String

--- a/Mathlib/Tactic/ToAdditive.lean
+++ b/Mathlib/Tactic/ToAdditive.lean
@@ -85,13 +85,14 @@ Id.run do
   if (s.get i₁).isUpper then
     if let some strs := endCapitalNames.find? (s.extract 0 i₁) then
       if let some (pref, newS) := strs.findSome?
-        fun x : String => x.isPrefixOf? (s.extract i₁ s.endPos) |>.map (x, ·) then
+        fun x ↦ x.isPrefixOf? (s.extract i₁ s.endPos) |>.map (x, ·) then
         return splitCase newS 0 <| (s.extract 0 i₁ ++ pref)::r
     if !(s.get i₀).isUpper then
       return splitCase (s.extract i₁ s.endPos) 0 <| (s.extract 0 i₁)::r
   return splitCase s i₁ r
 
 namespace ToAdditive
+
 initialize registerTraceClass `to_additive
 initialize registerTraceClass `to_additive_detail
 
@@ -542,9 +543,7 @@ structure ValueType : Type where
   /-- An optional doc string.-/
   doc : Option String := none
   /-- If `allowAutoName` is `false` (default) then
-  `@[to_additive]` will check whether the given name can be auto-generated.
-  If it is set to true, the given name will always be used (so `tgt` should not be `Name.anonymous`)
-  -/
+  `@[to_additive]` will check whether the given name can be auto-generated. -/
   allowAutoName : Bool := false
   /-- The `Syntax` element corresponding to the original multiplicative declaration
   (or the `to_additive` attribute if it is added later),

--- a/Mathlib/Tactic/ToAdditive.lean
+++ b/Mathlib/Tactic/ToAdditive.lean
@@ -46,7 +46,7 @@ macro "to_additive!?" rest:to_additiveRest : attr => `(attr| to_additive ! ? $re
 macro "to_additive?!" rest:to_additiveRest : attr => `(attr| to_additive ! ? $rest)
 
 /-- A set of strings of names that end in a capital letter.
-* If the string contains a lowercase letter, the string should be split between the first occurence
+* If the string contains a lowercase letter, the string should be split between the first occurrence
   of a lower-case letter followed by a upper-case letter.
 * If multiple strings have the same prefix, they should be grouped by prefix
 * In this case, the second list should be prefix-free

--- a/Mathlib/Tactic/ToAdditive.lean
+++ b/Mathlib/Tactic/ToAdditive.lean
@@ -713,6 +713,8 @@ private def proceedFieldsAux (src tgt : Name) (f : Name → CoreM (Array Name)) 
   for (srcField, tgtField) in srcFields.zip tgtFields do
     if srcField != tgtField then
       insertTranslation (src ++ srcField) (tgt ++ tgtField)
+    else
+      trace[to_additive] "Translation {src ++ srcField} ↦ {tgt ++ tgtField} is automatic."
 
 /-- Add the structure fields of `src` to the translations dictionary
 so that future uses of `to_additive` will map them to the corresponding `tgt` fields. -/

--- a/test/toAdditive.lean
+++ b/test/toAdditive.lean
@@ -103,6 +103,9 @@ run_cmd do
   let t ← Elab.Command.liftCoreM <| Lean.Meta.MetaM.run' <| ToAdditive.expand c.type
   let decl := c |>.updateName `Test.barr6 |>.updateType t |>.updateValue e |>.toDeclaration!
   Elab.Command.liftCoreM <| addAndCompile decl
+  -- test that we cannot transport a declaration to itself
+  successIfFail <| Elab.Command.liftCoreM <|
+    ToAdditive.addToAdditiveAttr `bar11_works { ref := .missing }
 
 /-! Test the namespace bug (#8733). This code should *not* generate a lemma
   `add_some_def.in_namespace`. -/

--- a/test/toAdditive.lean
+++ b/test/toAdditive.lean
@@ -105,7 +105,7 @@ run_cmd do
   Elab.Command.liftCoreM <| addAndCompile decl
   -- test that we cannot transport a declaration to itself
   successIfFail <| Elab.Command.liftCoreM <|
-    ToAdditive.addToAdditiveAttr `bar11_works { ref := .missing }
+    ToAdditive.addToAdditiveAttr `bar11_works { ref := ← getRef }
 
 /-! Test the namespace bug (#8733). This code should *not* generate a lemma
   `add_some_def.in_namespace`. -/

--- a/test/toAdditive.lean
+++ b/test/toAdditive.lean
@@ -160,7 +160,7 @@ def pi_nat_has_one {I : Type} : One ((x : I) → Nat)  := pi.has_one
 
 example : @pi_nat_has_one = @pi_nat_has_zero := rfl
 
-section noncomputablee
+section test_noncomputable
 
 @[to_additive Bar.bar]
 noncomputable def Foo.foo (h : ∃ _ : α, True) : α := Classical.choose h
@@ -171,9 +171,9 @@ def Foo.foo' : ℕ := 2
 theorem Bar.bar'_works : Bar.bar' = 2 := by decide
 
 run_cmd (do
-  if !isNoncomputable (← getEnv) `Bar.bar then throwError "bar shouldn't be computable"
-  if isNoncomputable (← getEnv) `Bar.bar' then throwError "bar' should be computable")
-end noncomputablee
+  if !isNoncomputable (← getEnv) `Test.Bar.bar then throwError "bar shouldn't be computable"
+  if isNoncomputable (← getEnv) `Test.Bar.bar' then throwError "bar' should be computable")
+end test_noncomputable
 
 section instances
 
@@ -254,6 +254,9 @@ run_cmd
   checkGuessName "LTHMulHPowLEHDiv" "LTHAddHSMulLEHSub"
   checkGuessName "OneLEHMul" "NonnegHAdd"
   checkGuessName "OneLTHPow" "PosHSMul"
+  checkGuessName "instCoeTCOneHom" "instCoeTCZeroHom"
+  checkGuessName "instCoeTOneHom" "instCoeTZeroHom"
+  checkGuessName "instCoeOneHom" "instCoeZeroHom"
 
 end guessName
 


### PR DESCRIPTION
* `@[to_additive]` will now correctly guess names with `CoeTC`, `CoeT` and `CoeHTCT` in it
* rewrite function `targetName`. 
  - It will now warn the user if it gives a composite name that can be auto-generated (before `to_additive` would never warn if a composite name was given). 
  - the logic when `allowAutoName = true` now corresponds to the docstring
  - Fix a bug where declarations were silently allowed to translate to itself (maybe because the `return` statements returned a value for the whole function?)
  - Add some more tracing
  - The behavior of namespaces when giving a composite name has been changed. It will always generate a name with the same number of components. Example:
```lean
namespace MeasureTheory.MulMeasure
@[to_additive AddMeasure.myOperation] def myOperation := ...
-- before: generates `AddMeasure.myOperation` (and never gives a warning)
-- after: generates `MeasureTheory.AddMeasure.myOperation` (and probably warns that the name can be auto-generated)
end MeasureTheory.MulMeasure
```
* This should fix all problems in #659 other than #660

Minor changes:
* When applying `@[to_additive]` to a structure, add a trace message if no translation is inserted for a field.
* Define `Name.fromComponents` and `Name.splitAt`
* Reduce transitive imports of `Tactic/toAdditive`
* Move some auxiliary declarations from `Tactic/Simps` to more appropriate places 
  - swap arguments of `String.isPrefixOf?`
  - improve `Name.getString`