### PR TITLE
[Merged by Bors] - fix: delete superfluous to_additive names

### DIFF
--- a/Mathlib/Algebra/Group/Defs.lean
+++ b/Mathlib/Algebra/Group/Defs.lean
@@ -514,7 +514,7 @@ class Monoid (M : Type u) extends Semigroup M, MulOneClass M where
 #align monoid.npow_succ' Monoid.npow_succ
 
 -- Bug #660
-attribute [to_additive AddMonoid.toAddZeroClass] Monoid.toMulOneClass
+attribute [to_additive] Monoid.toMulOneClass
 
 @[default_instance high] instance Monoid.Pow {M : Type _} [Monoid M] : Pow M ℕ :=
   ⟨fun x n ↦ Monoid.npow n x⟩
@@ -522,7 +522,7 @@ attribute [to_additive AddMonoid.toAddZeroClass] Monoid.toMulOneClass
 instance AddMonoid.SMul {M : Type _} [AddMonoid M] : SMul ℕ M :=
   ⟨AddMonoid.nsmul⟩
 
-attribute [to_additive AddMonoid.SMul] Monoid.Pow
+attribute [to_additive] Monoid.Pow
 
 section
 
@@ -560,7 +560,7 @@ class AddCommMonoid (M : Type u) extends AddMonoid M, AddCommSemigroup M
 @[to_additive]
 class CommMonoid (M : Type u) extends Monoid M, CommSemigroup M
 
-attribute [to_additive AddCommMonoid.toAddCommSemigroup] CommMonoid.toCommSemigroup
+attribute [to_additive] CommMonoid.toCommSemigroup
 
 section LeftCancelMonoid
 
@@ -573,7 +573,7 @@ class AddLeftCancelMonoid (M : Type u) extends AddLeftCancelSemigroup M, AddMono
 @[to_additive]
 class LeftCancelMonoid (M : Type u) extends LeftCancelSemigroup M, Monoid M
 
-attribute [to_additive AddLeftCancelMonoid.toAddMonoid] LeftCancelMonoid.toMonoid
+attribute [to_additive] LeftCancelMonoid.toMonoid
 
 end LeftCancelMonoid
 
@@ -588,7 +588,7 @@ class AddRightCancelMonoid (M : Type u) extends AddRightCancelSemigroup M, AddMo
 @[to_additive]
 class RightCancelMonoid (M : Type u) extends RightCancelSemigroup M, Monoid M
 
-attribute [to_additive AddRightCancelMonoid.toAddMonoid] RightCancelMonoid.toMonoid
+attribute [to_additive] RightCancelMonoid.toMonoid
 
 end RightCancelMonoid
 
@@ -603,7 +603,7 @@ class AddCancelMonoid (M : Type u) extends AddLeftCancelMonoid M, AddRightCancel
 @[to_additive]
 class CancelMonoid (M : Type u) extends LeftCancelMonoid M, RightCancelMonoid M
 
-attribute [to_additive AddCancelMonoid.toAddRightCancelMonoid] CancelMonoid.toRightCancelMonoid
+attribute [to_additive] CancelMonoid.toRightCancelMonoid
 
 /-- Commutative version of `AddCancelMonoid`. -/
 class AddCancelCommMonoid (M : Type u) extends AddLeftCancelMonoid M, AddCommMonoid M
@@ -612,7 +612,7 @@ class AddCancelCommMonoid (M : Type u) extends AddLeftCancelMonoid M, AddCommMon
 @[to_additive]
 class CancelCommMonoid (M : Type u) extends LeftCancelMonoid M, CommMonoid M
 
-attribute [to_additive AddCancelCommMonoid.toAddCommMonoid] CancelCommMonoid.toCommMonoid
+attribute [to_additive] CancelCommMonoid.toCommMonoid
 
 -- see Note [lower instance priority]
 @[to_additive CancelCommMonoid.toAddCancelMonoid]
@@ -824,7 +824,7 @@ class InvOneClass (G : Type _) extends One G, Inv G where
 class DivInvOneMonoid (G : Type _) extends DivInvMonoid G, InvOneClass G
 
 -- FIXME: `to_additive` is not operating on the second parent. (#660)
-attribute [to_additive SubNegZeroMonoid.toNegZeroClass] DivInvOneMonoid.toInvOneClass
+attribute [to_additive] DivInvOneMonoid.toInvOneClass
 
 variable [InvOneClass G]
 
@@ -853,7 +853,7 @@ class DivisionMonoid (G : Type u) extends DivInvMonoid G, HasInvolutiveInv G whe
   involutivity of inversion. -/
   inv_eq_of_mul (a b : G) : a * b = 1 → a⁻¹ = b
 
-attribute [to_additive SubtractionMonoid.toHasInvolutiveNeg] DivisionMonoid.toHasInvolutiveInv
+attribute [to_additive] DivisionMonoid.toHasInvolutiveInv
 
 section DivisionMonoid
 
@@ -878,7 +878,7 @@ This is the immediate common ancestor of `comm_group` and `CommGroupWithZero`. -
 @[to_additive SubtractionCommMonoid]
 class DivisionCommMonoid (G : Type u) extends DivisionMonoid G, CommMonoid G
 
-attribute [to_additive SubtractionCommMonoid.toAddCommMonoid] DivisionCommMonoid.toCommMonoid
+attribute [to_additive] DivisionCommMonoid.toCommMonoid
 
 /-- A `group` is a `monoid` with an operation `⁻¹` satisfying `a⁻¹ * a = 1`.
 
@@ -946,7 +946,7 @@ instance (priority := 100) Group.toDivisionMonoid : DivisionMonoid G :=
     inv_eq_of_mul := fun _ _ ↦ inv_eq_of_mul }
 
 -- see Note [lower instance priority]
-@[to_additive AddGroup.toAddCancelMonoid]
+@[to_additive]
 instance (priority := 100) Group.toCancelMonoid : CancelMonoid G :=
   { ‹Group G› with
     mul_right_cancel := fun a b c h ↦ by rw [← mul_inv_cancel_right a b, h, mul_inv_cancel_right]
@@ -965,7 +965,7 @@ class AddCommGroup (G : Type u) extends AddGroup G, AddCommMonoid G
 @[to_additive]
 class CommGroup (G : Type u) extends Group G, CommMonoid G
 
-attribute [to_additive AddCommGroup.toAddCommMonoid] CommGroup.toCommMonoid
+attribute [to_additive] CommGroup.toCommMonoid
 
 @[to_additive]
 theorem CommGroup.toGroup_injective {G : Type u} : Function.Injective (@CommGroup.toGroup G) := by
@@ -976,12 +976,12 @@ section CommGroup
 variable [CommGroup G]
 
 -- see Note [lower instance priority]
-@[to_additive AddCommGroup.toAddCancelCommMonoid]
+@[to_additive]
 instance (priority := 100) CommGroup.toCancelCommMonoid : CancelCommMonoid G :=
   { ‹CommGroup G›, Group.toCancelMonoid with }
 
 -- see Note [lower instance priority]
-@[to_additive AddCommGroup.toSubtractionCommMonoid]
+@[to_additive]
 instance (priority := 100) CommGroup.toDivisionCommMonoid : DivisionCommMonoid G :=
   { ‹CommGroup G›, Group.toDivisionMonoid with }
 

--- a/Mathlib/Algebra/Group/Units.lean
+++ b/Mathlib/Algebra/Group/Units.lean
@@ -518,13 +518,12 @@ attribute [nontriviality] isAddUnit_of_subsingleton
 
 -- Porting note: removing the `CanLift` instance
 
--- Porting note: `[to_additive]` places the instance in the `Units` namespace by default
 /-- A subsingleton `Monoid` has a unique unit. -/
-@[to_additive AddUnits.instUniqueAddUnits "A subsingleton `AddMonoid` has a unique additive unit."]
+@[to_additive "A subsingleton `AddMonoid` has a unique additive unit."]
 instance [Monoid M] [Subsingleton M] : Unique Mˣ where
   default := 1
   uniq a := Units.val_eq_one.mp <| Subsingleton.elim (a : M) 1
-attribute [instance] AddUnits.instUniqueAddUnits
+
 
 @[simp, to_additive]
 protected theorem Units.isUnit [Monoid M] (u : Mˣ) : IsUnit (u : M) :=
@@ -634,7 +633,7 @@ protected noncomputable def _root_.IsAddUnit.addUnit [AddMonoid N] {a : N} (h : 
     AddUnits N :=
   (Classical.choose h).copy a (Classical.choose_spec h).symm _ rfl
 #align is_add_unit.add_unit IsAddUnit.addUnit
-attribute [to_additive IsAddUnit.addUnit] IsUnit.unit
+attribute [to_additive] IsUnit.unit
 
 @[simp, to_additive]
 theorem unit_of_val_units {a : Mˣ} (h : IsUnit (a : M)) : h.unit = a :=

--- a/Mathlib/Algebra/Order/Group.lean
+++ b/Mathlib/Algebra/Order/Group.lean
@@ -33,7 +33,7 @@ class OrderedCommGroup (α : Type u) extends CommGroup α, PartialOrder α where
   /-- Multiplication is monotone in a ordered commutative group. -/
   mul_le_mul_left : ∀ a b : α, a ≤ b → ∀ c : α, c * a ≤ c * b
 
-attribute [to_additive OrderedAddCommGroup] OrderedCommGroup
+attribute [to_additive] OrderedCommGroup
 
 @[to_additive]
 instance OrderedCommGroup.to_covariantClass_left_le [OrderedCommGroup α] :

--- a/Mathlib/Data/Pi/Algebra.lean
+++ b/Mathlib/Data/Pi/Algebra.lean
@@ -109,15 +109,15 @@ theorem smul_const [SMul α β] (a : α) (b : β) : a • const I b = const I (a
 theorem smul_comp [SMul α γ] (a : α) (x : β → γ) (y : I → β) : (a • x) ∘ y = a • x ∘ y :=
   rfl
 
-@[to_additive Pi.instSMul]
+@[to_additive]
 instance instPow [∀ i, Pow (f i) β] : Pow (∀ i, f i) β :=
   ⟨fun x b i => x i ^ b⟩
 
-@[simp, to_additive Pi.smul_apply, to_additive_reorder 5]
+@[simp, to_additive, to_additive_reorder 5]
 theorem pow_apply [∀ i, Pow (f i) β] (x : ∀ i, f i) (b : β) (i : I) : (x ^ b) i = x i ^ b :=
   rfl
 
-@[to_additive Pi.smul_def, to_additive_reorder 5]
+@[to_additive, to_additive_reorder 5]
 theorem pow_def [∀ i, Pow (f i) β] (x : ∀ i, f i) (b : β) : x ^ b = fun i => x i ^ b :=
   rfl
 
@@ -126,7 +126,7 @@ theorem pow_def [∀ i, Pow (f i) β] (x : ∀ i, f i) (b : β) : x ^ b = fun i 
 theorem const_pow [Pow β α] (b : β) (a : α) : const I b ^ a = const I (b ^ a) :=
   rfl
 
-@[to_additive smul_comp, to_additive_reorder 6]
+@[to_additive, to_additive_reorder 6]
 theorem pow_comp [Pow γ α] (x : β → γ) (a : α) (y : I → β) : (x ^ a) ∘ y = x ∘ y ^ a :=
   rfl
 
@@ -387,7 +387,7 @@ def uniqueOfSurjectiveOne (α : Type _) {β : Type _} [One β] (h : Function.Sur
     Unique β :=
   h.uniqueOfSurjectiveConst α (1 : β)
 
-@[to_additive Subsingleton.pi_single_eq]
+@[to_additive]
 theorem Subsingleton.pi_mulSingle_eq {α : Type _} [DecidableEq I] [Subsingleton I] [One α]
     (i : I) (x : α) : Pi.mulSingle i x = fun _ => x :=
   funext fun j => by rw [Subsingleton.elim j i, Pi.mulSingle_eq_same]


### PR DESCRIPTION
* Most of these were already giving trace messages, but they are only shown in the command-line when running `lake build --verbose`
* Use the name default name for the additive version for `instUniqueUnits` (the previous name didn't correspond to the multiplicative version at all)