### PR TITLE
[Merged by Bors] - fix: remove unnecessary example in Data.Pi.Algebra

### DIFF
--- a/Mathlib/Data/Pi/Algebra.lean
+++ b/Mathlib/Data/Pi/Algebra.lean
@@ -130,8 +130,6 @@ theorem const_pow [Pow β α] (b : β) (a : α) : const I b ^ a = const I (b ^ a
 theorem pow_comp [Pow γ α] (x : β → γ) (a : α) (y : I → β) : (x ^ a) ∘ y = x ∘ y ^ a :=
   rfl
 
-example [∀ i, Add <| f i] : Add <| ∀ i, f i := inferInstance
-
 /-!
 Porting note: `bit0` and `bit1` are deprecated. This section can be removed entirely
 (without replacement?).


### PR DESCRIPTION
It seems that during the port of Data.Pi.Algebra I accidentally left in an `example` testing if stuff worked.