### PR TITLE
[Merged by Bors] - feat: align LawfulApplicative.pure_seq

### DIFF
--- a/Mathlib/Init/Align.lean
+++ b/Mathlib/Init/Align.lean
@@ -64,6 +64,7 @@ set_option align.precheck false in #align _sorry_placeholder_ _sorry_placeholder
 
 #align is_lawful_applicative LawfulApplicative
 #align is_lawful_monad LawfulMonad
+#align is_lawful_applicative.pure_seq_eq_map LawfulApplicative.pure_seq
 
 /-! ## `init.control.lift` -/
 


### PR DESCRIPTION
In core Lean 3, the class `is_lawful_applicative` has a field `pure_seq_eq_map`. In core Lean 4 the name of the corresponding field in `LawfulApplicative` has been shortened to `pure_seq`, so it needs aligning.