### PR TITLE
[Merged by Bors] - feat: port data.list.defs

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -79,6 +79,7 @@ import Mathlib.Data.LazyList
 import Mathlib.Data.List.Basic
 import Mathlib.Data.List.Card
 import Mathlib.Data.List.Chain
+import Mathlib.Data.List.Defs
 import Mathlib.Data.List.Lex
 import Mathlib.Data.List.Nodup
 import Mathlib.Data.List.Pairwise

--- a/Mathlib/Control/Functor.lean
+++ b/Mathlib/Control/Functor.lean
@@ -298,10 +298,16 @@ theorem of_mem_supp {α : Type u} {x : F α} {p : α → Prop} (h : Liftp p x) :
   fun _ hy => hy h
 #align functor.of_mem_supp Functor.of_mem_supp
 
+/-- If `f` is a functor, if `fb : f β` and `a : α`, then `mapConstRev fb a` is the result of
+  applying `f.map` to the constant function `β → α` sending everything to `a`, and then
+  evaluating at `fb`. In other words it's `const a <$> fb`. -/
 @[reducible] def mapConstRev {f : Type u → Type v} [Functor f] {α β : Type u} :
     f β → α → f α :=
   fun a b => Functor.mapConst b a
 #align functor.map_const_rev Functor.mapConstRev
+/-- If `f` is a functor, if `fb : f β` and `a : α`, then `mapConstRev fb a` is the result of
+  applying `f.map` to the constant function `β → α` sending everything to `a`, and then
+  evaluating at `fb`. In other words it's `const a <$> fb`. -/
 infix:100 " $> " => Functor.mapConstRev
 
 end Functor

--- a/Mathlib/Control/Functor.lean
+++ b/Mathlib/Control/Functor.lean
@@ -298,4 +298,10 @@ theorem of_mem_supp {α : Type u} {x : F α} {p : α → Prop} (h : Liftp p x) :
   fun _ hy => hy h
 #align functor.of_mem_supp Functor.of_mem_supp
 
+@[reducible] def mapConstRev {f : Type u → Type v} [Functor f] {α β : Type u} :
+    f β → α → f α :=
+  fun a b => Functor.mapConst b a
+#align functor.map_const_rev Functor.mapConstRev
+infix:100 " $> " => Functor.mapConstRev
+
 end Functor

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -447,22 +447,7 @@ def choose (hp : ∃ a, a ∈ l ∧ p a) : α :=
 end Choose
 
 #align list.mmap_filter List.filterMapM
-
-/-- `mapUpperTriangleM f l` calls `f` on all elements in the upper triangular part of `l × l`.
-That is, for each `e ∈ l`, it will run `f e e` and then `f e e'`
-for each `e'` that appears after `e` in `l`.
-
-Example: suppose `l = [1, 2, 3]`. `mapUpperTriangleM f l` will produce the list
-`[f 1 1, f 1 2, f 1 3, f 2 2, f 2 3, f 3 3]`.
--/
-def mapUpperTriangleM {m} [Monad m] {α β : Type u} (f : α → α → m β) : List α → m (List β)
-  | [] => return []
-  | h :: t => do
-    let v ← f h h
-    let l ← t.mapM (f h)
-    let t ← t.mapUpperTriangleM f
-    return v :: l ++ t
-#align list.mmap_upper_triangle List.mapUpperTriangleM
+#align list.mmap_upper_triangle List.mapDiagM
 
 /-- `mapDiagM' f l` calls `f` on all elements in the upper triangular part of `l × l`.
 That is, for each `e ∈ l`, it will run `f e e` and then `f e e'`

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -68,7 +68,7 @@ def prod [Mul α] [One α] : List α → α :=
   foldl (· * ·) 1
 #align list.prod List.prod
 
-Later this will be tagged with `to_additive`, but this can't be done yet because of imports.
+-- Later this will be tagged with `to_additive`, but this can't be done yet because of imports.
 -- dependencies.
 /-- Sum of a list.
 

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -3,10 +3,11 @@ Copyright (c) 2014 Parikshit Khanna. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Parikshit Khanna, Jeremy Avigad, Leonardo de Moura, Floris van Doorn, Mario Carneiro
 -/
-import Mathlib.Logic.Basic
-import Mathlib.Data.Nat.Basic
 import Mathlib.Algebra.Group.Defs
+import Mathlib.Control.Functor
 import Mathlib.Data.List.Chain
+import Mathlib.Data.Nat.Basic
+import Mathlib.Logic.Basic
 import Std.Tactic.Lint.Basic
 import Std.Data.RBMap.Basic
 
@@ -45,7 +46,7 @@ instance [DecidableEq α] : SDiff (List α) :=
 /-- "default" `nth` function: returns `d` instead of `none` in the case
   that the index is out of bounds. -/
 @[nolint unusedArguments]
-def nthd (d : α) : ∀ (l : List α) (n : ℕ), α
+def nthd (d : α) : ∀ (_ : List α) (_ : ℕ), α
   | [], _ => d
   | x :: _, 0 => x
   | _ :: xs, n + 1 => nthd d xs n
@@ -54,7 +55,7 @@ def nthd (d : α) : ∀ (l : List α) (n : ℕ), α
 /-- "inhabited" `nth` function: returns `default` instead of `none` in the case
   that the index is out of bounds. -/
 @[nolint unusedArguments]
-def inth [h : Inhabited α] (l : List α) (n : Nat) : α :=
+def inth [Inhabited α] (l : List α) (n : Nat) : α :=
   nthd default l n
 #align list.inth List.inth
 
@@ -428,7 +429,7 @@ variable (p : α → Prop) [DecidablePred p] (l : List α)
 /-- Given a decidable predicate `p` and a proof of existence of `a ∈ l` such that `p a`,
 choose the first element with this property. This version returns both `a` and proofs
 of `a ∈ l` and `p a`. -/
-def chooseX : ∀ l : List α, ∀ hp : ∃ a, a ∈ l ∧ p a, { a // a ∈ l ∧ p a }
+def chooseX : ∀ l : List α, ∀ _ : ∃ a, a ∈ l ∧ p a, { a // a ∈ l ∧ p a }
   | [], hp => False.elim (Exists.elim hp fun a h => not_mem_nil a h.left)
   | l :: ls, hp =>
     if pl : p l then ⟨l, ⟨mem_cons.mpr <| Or.inl rfl, pl⟩⟩

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -42,16 +42,14 @@ instance [DecidableEq α] : SDiff (List α) :=
 #align list.head' List.head?
 #align list.to_array List.toArray
 
-/-- "default" `nth` function: returns `d` instead of `none` in the case
-  that the index is out of bounds. -/
-@[nolint unusedArguments]
-def getD' (d : α) : ∀ (_ : List α) (_ : ℕ), α
-  | [], _ => d
-  | x :: _, 0 => x
-  | _ :: xs, n + 1 => nthd d xs n
-#align list.nthd List.nthd
+#align list.nthd List.getD
 
-#align list.inth List.getD
+/-- "inhabited" `nth` function: returns `default` instead of `none` in the case
+  that the index is out of bounds. -/
+def getI [Inhabited α] (l : List α) (n : Nat) : α :=
+  nthd default l n
+#align list.inth List.getI
+
 #align list.modify_nth_tail List.modifyNthTail
 #align list.modify_head List.modifyHead
 #align list.modify_nth List.modifyNth

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -260,14 +260,6 @@ def permutationsAux2 (t : α) (ts : List α) (r : List β) : List α → (List �
     (y :: us, f (t :: y :: us) :: zs)
 #align list.permutations_aux2 List.permutationsAux2
 
-private def meas : (Σ'_ : List α, List α) → ℕ × ℕ
-  | ⟨l, i⟩ => (length l + length i, length l)
-
-/-- Local notation for termination relationship used in `rec` below
--/
-local infixl:50 " ≺ " => InvImage (Prod.Lex (· < ·) (· < ·)) meas
-
-
 -- porting comment removed `[elab_as_elim]` per Mario C
 -- https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Status.20of.20data.2Elist.2Edefs.3F/near/313571979
 /-- A recursor for pairs of lists. To have `C l₁ l₂` for all `l₁`, `l₂`, it suffices to have it for

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -555,7 +555,7 @@ def map₂Right (f : Option α → β → γ) (as : List α) (bs : List β) : Li
 -/
 def mapAsyncChunked {α β} (f : α → β) (xs : List α) (chunk_size := 1024) : List β :=
   ((xs.toChunks chunk_size).map fun xs => Task.spawn fun _ => List.map f xs).bind Task.get
-#align list.map_async_chunked List.map_async_chunked
+#align list.map_async_chunked List.mapAsyncChunked
 
 
 /-!

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -29,60 +29,57 @@ variable {α β γ δ ε ζ : Type _}
 instance [DecidableEq α] : SDiff (List α) :=
   ⟨List.diff⟩
 
--- Defined in `Std` so not ported
--- List.splitAt
--- List.splitOnP
--- List.splitOn
--- List.concat
--- List.toArray
--- List.modifyNthTail
--- List.modifyHead
--- List.modifyNth
--- List.modifyLast
--- List.insertNth
--- List.takeWhile
--- List.scanl
--- List.scanr
--- List.partitionMap
--- List.indexesValues
--- List.indexesOf
--- List.lookmap
--- List.countp
--- List.count
--- List.inits
--- List.tails
--- List.sublists'
--- List.sublists
--- List.Forall₂
--- List.transpose
--- List.sections
--- List.revzip
--- List.product
--- mathport name: list.product
+#align list.split_at List.splitAt
+#align list.split_on_p List.splitOnP
+#align list.split_on List.splitOn
+#align list.concat List.concat
+#align list.to_array List.toArray
+#align list.modify_nth_tail List.modifyNthTail
+#align list.modify_head List.modifyHead
+#align list.modify_nth List.modifyNth
+#align list.modify_last List.modifyLast
+#align list.insert_nth List.insertNth
+#align list.take_while List.takeWhile
+#align list.scanl List.scanl
+#align list.scanr List.scanr
+#align list.partition_map List.partitionMap
+#align list.indexes_values List.indexesValues
+#align list.indexes_of List.indexesOf
+#align list.lookmap List.lookmap
+#align list.countp List.countp
+#align list.count List.count
+#align list.inits List.inits
+#align list.tails List.tails
+#align list.sublists' List.sublists'
+#align list.sublists List.sublists
+#align list.forall₂ List.Forall₂
+#align list.transpose List.transpose
+#align list.sections List.sections
+#align list.revzip List.revzip
+#align list.product List.product
 infixr:82
   " ×ˢ " =>-- This notation binds more strongly than (pre)images, unions and intersections.
   List.product
-
--- List.sigma
--- List.ofFn
--- List.ofFnNthVal
--- List.Disjoint
--- List.Pairwise
--- List.pariwise_cons
--- List.decidablePairwise
--- List.pwFilter
--- List.Chain
--- List.Chain'
--- in Mathlib.Data.List.Chain: List.chain_cons
--- List.Nodup
--- List.nodupDecidable
--- List.range'
--- List.reduceOption
--- List.ilast'
--- List.last'
--- List.rotate
--- List.rotate'
--- List.getRest
+#align list.sigma List.sigma
+#align list.of_fn List.ofFn
+#align list.of_fn_nth_val List.ofFnNthVal
+#align list.disjoint List.Disjoint
+#align list.pairwise List.Pairwise
+#align list.pairwise_cons List.pairwise_cons
+#align list.decidable_pairwise List.instDecidablePairwise
+#align list.pw_filter List.pwFilter
+#align list.chain List.Chain
+#align list.chain' List.Chain'
+#align list.chain_cons List.chain_cons
+#align list.nodup List.Nodup
+#align list.nodup_decidable List.nodupDecidable
+#align list.range' List.range'
+#align list.reduce_option List.reduceOption
+#align list.ilast' List.ilast'
+#align list.last' List.last'
+#align list.rotate List.rotate
+#align list.rotate' List.rotate'
+#align list.get_rest List.getRest
 
 -- The following exist in `Std` with name changes, noted through `#align`
 

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -57,6 +57,8 @@ instance [DecidableEq α] : SDiff (List α) :=
 #align list.sections List.sections
 #align list.revzip List.revzip
 #align list.product List.product
+/-- Notation for calculating the product of a `List`
+-/
 infixr:82
   " ×ˢ " =>-- This notation binds more strongly than (pre)images, unions and intersections.
   List.product
@@ -96,11 +98,14 @@ infixr:82
 #align list.is_prefix List.isPrefix
 #align list.is_suffix List.isSuffix
 #align list.is_infix List.isInfix
--- mathport name: «expr <+: »
+/-- Notation for `List.isPrefix`
+-/
 infixl:50 " <+: " => isPrefix
--- mathport name: «expr <:+ »
+/--  Notation for `List.isSuffix`
+-/
 infixl:50 " <:+ " => isSuffix
--- mathport name: «expr <:+: »
+/-- Notation for `List.isInfix`
+-/
 infixl:50 " <:+: " => isInfix
 #align list.mmap_filter List.filterMapM
 #align list.slice List.dropSlice
@@ -314,7 +319,8 @@ def permutationsAux2 (t : α) (ts : List α) (r : List β) : List α → (List �
 private def meas : (Σ'_ : List α, List α) → ℕ × ℕ
   | ⟨l, i⟩ => (length l + length i, length l)
 
--- mathport name: «expr ≺ »
+/-- Local notation for termination relationship used in `rec` below
+-/
 local infixl:50 " ≺ " => InvImage (Prod.Lex (· < ·) (· < ·)) meas
 
 /-- A recursor for pairs of lists. To have `C l₁ l₂` for all `l₁`, `l₂`, it suffices to have it for
@@ -495,6 +501,9 @@ def mapDiagM' {m} [Monad m] {α} (f : α → α → m Unit) : List α → m Unit
   | h :: t => (f h h >> t.mapM' (f h)) >> t.mapDiagM'
 #align list.mmap'_diag List.mapDiagM'
 
+/-- Map each element of a `List` to an action, evaluate these actions in order,
+    and collect the results.
+-/
 protected def traverse
     {F : Type u → Type v}
     [Applicative F]

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -223,8 +223,8 @@ infixl:50 " <:+: " => isInfix
 #align list.sublists List.sublists
 #align list.forall₂ List.Forall₂
 
--- TODO: keep? seems to be orphaned. Search in mathlib codebase for refs.
-/--
+/-- Definition of a `sublists` function with an explicit list construction function
+    Used in `Data.Lists.Sublists`: TODO: move there when ported.
 -/
 def sublistsAux₁ : List α → (List α → List β) → List β
   | [], _ => []

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -14,9 +14,15 @@ import Std.Data.RBMap.Basic
 ## Definitions on lists
 
 This file contains various definitions on lists. It does not contain
-proofs about these definitions, those are contained in other files in `data/list`
+proofs about these definitions, those are contained in other files in `Data.List`
 -/
 
+-- Porting notes
+-- Many of the definitions in `Data.List.Defs` were already defined upstream in `Std4`
+-- These have been annotated with `#align`s
+-- To make this easier for review, the `#align`s have been placed in order of occurrence
+-- in `mathlib`
+-- TODO: post port, reorder `#align`s to the end.
 
 namespace List
 
@@ -33,104 +39,8 @@ instance [DecidableEq α] : SDiff (List α) :=
 #align list.split_on_p List.splitOnP
 #align list.split_on List.splitOn
 #align list.concat List.concat
-#align list.to_array List.toArray
-#align list.modify_nth_tail List.modifyNthTail
-#align list.modify_head List.modifyHead
-#align list.modify_nth List.modifyNth
-#align list.modify_last List.modifyLast
-#align list.insert_nth List.insertNth
-#align list.take_while List.takeWhile
-#align list.scanl List.scanl
-#align list.scanr List.scanr
-#align list.partition_map List.partitionMap
-#align list.indexes_values List.indexesValues
-#align list.indexes_of List.indexesOf
-#align list.lookmap List.lookmap
-#align list.countp List.countp
-#align list.count List.count
-#align list.inits List.inits
-#align list.tails List.tails
-#align list.sublists' List.sublists'
-#align list.sublists List.sublists
-#align list.forall₂ List.Forall₂
-#align list.transpose List.transpose
-#align list.sections List.sections
-#align list.revzip List.revzip
-#align list.product List.product
-/-- Notation for calculating the product of a `List`
--/
-infixr:82
-  " ×ˢ " =>-- This notation binds more strongly than (pre)images, unions and intersections.
-  List.product
-#align list.sigma List.sigma
-#align list.of_fn List.ofFn
-#align list.of_fn_nth_val List.ofFnNthVal
-#align list.disjoint List.Disjoint
-#align list.pairwise List.Pairwise
-#align list.pairwise_cons List.pairwise_cons
-#align list.decidable_pairwise List.instDecidablePairwise
-#align list.pw_filter List.pwFilter
-#align list.chain List.Chain
-#align list.chain' List.Chain'
-#align list.chain_cons List.chain_cons
-#align list.nodup List.Nodup
-#align list.nodup_decidable List.nodupDecidable
-#align list.range' List.range'
-#align list.reduce_option List.reduceOption
-#align list.ilast' List.ilast'
-#align list.last' List.last'
-#align list.rotate List.rotate
-#align list.rotate' List.rotate'
-#align list.get_rest List.getRest
-
--- The following exist in `Std` with name changes, noted through `#align`
-
--- name changed in Std
 #align list.head' List.head?
-#align list.find List.find?
-#align list.take' List.takeD
-#align list.find_indexes List.findIdxs
-#align list.mbfind List.findM?
-#align list.many List.anyM
-#align list.mall List.allM
-#align list.foldr_with_index List.foldrIdx
-#align list.foldl_with_index List.foldlIdx
-#align list.is_prefix List.isPrefix
-#align list.is_suffix List.isSuffix
-#align list.is_infix List.isInfix
-/-- Notation for `List.isPrefix`
--/
-infixl:50 " <+: " => isPrefix
-/--  Notation for `List.isSuffix`
--/
-infixl:50 " <:+ " => isSuffix
-/-- Notation for `List.isInfix`
--/
-infixl:50 " <:+: " => isInfix
-#align list.mmap_filter List.filterMapM
-#align list.slice List.dropSlice
-#align list.zip_right List.zipRight
-#align list.zip_left' List.zipLeft'
-#align list.zip_right' List.zipRight'
-#align list.zip_left List.zipLeft
-#align list.all_some List.allSome
-#align list.fill_nones List.fillNones
-#align list.take_list List.takeList
-#align list.to_chunks_aux List.toChunksAux
-#align list.to_chunks List.toChunks
-#align list.map_with_prefix_suffix_aux List.mapWithPrefixSuffixAux
-#align list.map_with_prefix_suffix List.mapWithPrefixSuffix
-#align list.map_with_complement List.mapWithComplement
-
-
-
-
-
-
-
-
-
-
+#align list.to_array List.toArray
 
 /-- "default" `nth` function: returns `d` instead of `none` in the case
   that the index is out of bounds. -/
@@ -148,6 +58,15 @@ def inth [h : Inhabited α] (l : List α) (n : Nat) : α :=
   nthd default l n
 #align list.inth List.inth
 
+#align list.modify_nth_tail List.modifyNthTail
+#align list.modify_head List.modifyHead
+#align list.modify_nth List.modifyNth
+#align list.modify_last List.modifyLast
+#align list.insert_nth List.insertNth
+#align list.take' List.takeD
+#align list.take_while List.takeWhile
+#align list.scanl List.scanl
+#align list.scanr List.scanr
 
 /-- Product of a list.
 
@@ -179,13 +98,14 @@ def alternatingProd {G : Type _} [One G] [Mul G] [Inv G] : List G → G
   | g :: h :: t => g * h⁻¹ * alternatingProd t
 #align list.alternating_prod List.alternatingProd
 
-
+#align list.partition_map List.partitionMap
+#align list.find List.find?
 
 /-- `mfind tac l` returns the first element of `l` on which `tac` succeeds, and
 fails otherwise. -/
-def mfind {α} {m : Type u → Type v} [Monad m] [Alternative m] (tac : α → m PUnit) : List α → m α :=
+def findM {α} {m : Type u → Type v} [Monad m] [Alternative m] (tac : α → m PUnit) : List α → m α :=
   List.firstM fun a => m (tac a) $> a
-#align list.mfind List.mfind
+#align list.mfind List.findM
 
 /-- `mbfind' p l` returns the first element `a` of `l` for which `p a` returns
 true. `mbfind'` short-circuits, so `p` is not necessarily run on every `a` in
@@ -200,11 +120,13 @@ def findM?'
     if px then pure (some x) else findM?' p xs
 #align list.mbfind' List.findM?'
 
+#align list.mbfind List.findM?
+#align list.many List.anyM
+#align list.mall List.allM
+
 section
 
 variable {m : Type → Type v} [Monad m]
-
-
 
 /-- `orM xs` runs the actions in `xs`, returning true if any of them returns
 true. `orM` short-circuits, so if an action returns true, later actions are
@@ -222,9 +144,13 @@ def andM : List (m Bool) → m Bool :=
 
 end
 
+#align list.foldr_with_index List.foldrIdx
+#align list.foldl_with_index List.foldlIdx
+#align list.find_indexes List.findIdxs
+#align list.indexes_values List.indexesValues
+#align list.indexes_of List.indexesOf
 
-
-section MfoldWithIndex
+section foldIdxM
 
 variable {m : Type v → Type w} [Monad m]
 
@@ -246,41 +172,63 @@ def foldrIdxM {α β} (f : ℕ → α → β → m β) (b : β) (as : List α) :
     (pure b)
 #align list.mfoldr_with_index List.foldrIdxM
 
-end MfoldWithIndex
+end foldIdxM
 
-section MmapWithIndex
+
+section mapIdxA
 
 variable {m : Type v → Type w} [Applicative m]
 
 -- FIXME: Idx, find the right appplicative suffix
 
 /-- Auxiliary definition for `mmap_with_index`. -/
-def mmapWithIndexAux {α β} (f : ℕ → α → m β) : ℕ → List α → m (List β)
+def mapIdxAAux {α β} (f : ℕ → α → m β) : ℕ → List α → m (List β)
   | _, [] => pure []
-  | i, a :: as => List.cons <$> f i a <*> mmapWithIndexAux f (i + 1) as
-#align list.mmap_with_index_aux List.mmapWithIndexAux
+  | i, a :: as => List.cons <$> f i a <*> mapIdxAAux f (i + 1) as
+#align list.mmap_with_index_aux List.mapIdxAAux
 
 /-- Applicative variant of `map_with_index`. -/
-def mmapWithIndex {α β} (f : ℕ → α → m β) (as : List α) : m (List β) :=
-  mmapWithIndexAux f 0 as
-#align list.mmap_with_index List.mmapWithIndex
+def mapIdxA {α β} (f : ℕ → α → m β) (as : List α) : m (List β) :=
+  mapIdxAAux f 0 as
+#align list.mmap_with_index List.mapIdxA
 
 /-- Auxiliary definition for `mmap_with_index'`. -/
-def mmapWithIndex'Aux {α} (f : ℕ → α → m PUnit) : ℕ → List α → m PUnit
+def mapIdxAAux' {α} (f : ℕ → α → m PUnit) : ℕ → List α → m PUnit
   | _, [] => pure ⟨⟩
-  | i, a :: as => f i a *> mmapWithIndex'Aux f (i + 1) as
-#align list.mmap_with_index'_aux List.mmapWithIndex'Aux
+  | i, a :: as => f i a *> mapIdxAAux' f (i + 1) as
+#align list.mmap_with_index'_aux List.mapIdxAAux'
 
 /-- A variant of `mmap_with_index` specialised to applicative actions which
 return `unit`. -/
-def mmapWithIndex' {α} (f : ℕ → α → m PUnit) (as : List α) : m PUnit :=
-  mmapWithIndex'Aux f 0 as
-#align list.mmap_with_index' List.mmapWithIndex'
+def mapIdxA' {α} (f : ℕ → α → m PUnit) (as : List α) : m PUnit :=
+  mapIdxAAux' f 0 as
+#align list.mmap_with_index' List.mapIdxA'
 
-end MmapWithIndex
+end mapIdxA
 
+#align list.lookmap List.lookmap
+#align list.countp List.countp
+#align list.count List.count
+#align list.is_prefix List.isPrefix
+#align list.is_suffix List.isSuffix
+#align list.is_infix List.isInfix
+/-- Notation for `List.isPrefix`
+-/
+infixl:50 " <+: " => isPrefix
+/--  Notation for `List.isSuffix`
+-/
+infixl:50 " <:+ " => isSuffix
+/-- Notation for `List.isInfix`
+-/
+infixl:50 " <:+: " => isInfix
 
--- keep?
+#align list.inits List.inits
+#align list.tails List.tails
+#align list.sublists' List.sublists'
+#align list.sublists List.sublists
+#align list.forall₂ List.Forall₂
+
+-- TODO: keep? seems to be orphaned. Search in mathlib codebase for refs.
 /--
 -/
 def sublistsAux₁ : List α → (List α → List β) → List β
@@ -297,6 +245,8 @@ def All₂ (p : α → Prop) : List α → Prop
   | x :: l => p x ∧ All₂ p l
 #align list.all₂ List.All₂
 
+#align list.transpose List.transpose
+#align list.sections List.sections
 
 section Permutations
 
@@ -406,7 +356,24 @@ def extractp (p : α → Prop) [DecidablePred p] : List α → Option α × List
       (a', a :: l')
 #align list.extractp List.extractp
 
-
+#align list.revzip List.revzip
+#align list.product List.product
+/-- Notation for calculating the product of a `List`
+-/
+infixr:82
+  " ×ˢ " =>-- This notation binds more strongly than (pre)images, unions and intersections.
+  List.product
+#align list.sigma List.sigma
+#align list.of_fn List.ofFn
+#align list.of_fn_nth_val List.ofFnNthVal
+#align list.disjoint List.Disjoint
+#align list.pairwise List.Pairwise
+#align list.pairwise_cons List.pairwise_cons
+#align list.decidable_pairwise List.instDecidablePairwise
+#align list.pw_filter List.pwFilter
+#align list.chain List.Chain
+#align list.chain' List.Chain'
+#align list.chain_cons List.chain_cons
 
 section Chain
 
@@ -420,9 +387,11 @@ instance decidableChain' [DecidableRel R] (l : List α) : Decidable (Chain' R l)
 
 end Chain
 
+#align list.nodup List.Nodup
+#align list.nodup_decidable List.nodupDecidable
 
 /-- `dedup l` removes duplicates from `l` (taking only the last occurrence).
-  Defined as `pw_filter (≠)`.
+  Defined as `pwFilter (≠)`.
 
      dedup [1, 0, 2, 2, 1] = [0, 2, 1] -/
 def dedup [DecidableEq α] : List α → List α :=
@@ -437,6 +406,7 @@ def destutter' (R : α → α → Prop) [DecidableRel R] : α → List α → Li
   | a, h :: l => if R a h then a :: destutter' R h l else destutter' R a l
 #align list.destutter' List.destutter'
 
+-- TODO: should below be "lazily"?
 /-- Greedily create a sublist of `l` such that, for every two adjacent elements `a, b ∈ l`,
 `R a b` holds. Mostly used with ≠; for example, `destutter (≠) [1, 2, 2, 1, 1] = [1, 2, 1]`,
 `destutter (≠) [1, 2, 3, 3] = [1, 2, 3]`, `destutter (<) [1, 2, 5, 2, 3, 4, 9] = [1, 2, 5, 9]`. -/
@@ -445,6 +415,12 @@ def destutter (R : α → α → Prop) [DecidableRel R] : List α → List α
   | [] => []
 #align list.destutter List.destutter
 
+#align list.range' List.range'
+#align list.reduce_option List.reduceOption
+#align list.ilast' List.ilast'
+#align list.last' List.last'
+#align list.rotate List.rotate
+#align list.rotate' List.rotate'
 
 
 section Choose
@@ -472,6 +448,8 @@ def choose (hp : ∃ a, a ∈ l ∧ p a) : α :=
 #align list.choose List.choose
 
 end Choose
+
+#align list.mmap_filter List.filterMapM
 
 /-- `mapUpperTriangleM f l` calls `f` on all elements in the upper triangular part of `l × l`.
 That is, for each `e ∈ l`, it will run `f e e` and then `f e e'`
@@ -513,6 +491,8 @@ protected def traverse
   | x :: xs => List.cons <$> f x <*> List.traverse f xs
 #align list.traverse List.traverse
 
+#align list.get_rest List.getRest
+#align list.slice List.dropSlice
 
 /-- Left-biased version of `list.map₂`. `map₂_left' f as bs` applies `f` to each
 pair of elements `aᵢ ∈ as` and `bᵢ ∈ bs`. If `bs` is shorter than `as`, `f` is
@@ -585,16 +565,24 @@ def map₂Right (f : Option α → β → γ) (as : List α) (bs : List β) : Li
   map₂Left (flip f) bs as
 #align list.map₂_right List.map₂Right
 
-
-
+#align list.zip_right List.zipRight
+#align list.zip_left' List.zipLeft'
+#align list.zip_right' List.zipRight'
+#align list.zip_left List.zipLeft
+#align list.all_some List.allSome
+#align list.fill_nones List.fillNones
+#align list.take_list List.takeList
 #align list.to_rbmap List.toRBMap
+#align list.to_chunks_aux List.toChunksAux
+#align list.to_chunks List.toChunks
 
-
+-- porting notes -- was `unsafe` but removed for Lean 4 port
 /-- Asynchronous version of `List.map`.
 -/
-unsafe def map_async_chunked {α β} (f : α → β) (xs : List α) (chunk_size := 1024) : List β :=
+def map_async_chunked {α β} (f : α → β) (xs : List α) (chunk_size := 1024) : List β :=
   ((xs.toChunks chunk_size).map fun xs => Task.spawn fun _ => List.map f xs).bind Task.get
 #align list.map_async_chunked List.map_async_chunked
+
 
 /-!
 We add some n-ary versions of `list.zip_with` for functions with more than two arguments.
@@ -604,7 +592,6 @@ For example, `zip_with3 f xs ys zs` could also be written as
 or as
 `(zip xs $ zip ys zs).map $ λ ⟨x, y, z⟩, f x y z`.
 -/
-
 
 /-- Ternary version of `list.zip_with`. -/
 def zipWith3 (f : α → β → γ → δ) : List α → List β → List γ → List δ
@@ -633,6 +620,11 @@ def replaceIf : List α → List Bool → List α → List α
   | l, [], _ => l
   | n :: ns, tf :: bs, e@(c :: cs) => if tf then c :: ns.replaceIf bs cs else n :: ns.replaceIf bs e
 #align list.replace_if List.replaceIf
+
+#align list.map_with_prefix_suffix_aux List.mapWithPrefixSuffixAux
+#align list.map_with_prefix_suffix List.mapWithPrefixSuffix
+#align list.map_with_complement List.mapWithComplement
+
 
 end List
 #lint

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -179,7 +179,7 @@ section mapIdxM
 
 -- porting notes: This was defined in `mathlib` with an `Applicative`
 -- constraint on `m` and have been `#align`ed to the `Std` versions defined
--- with a with a `Monad` typeclass constraint
+-- with a `Monad` typeclass constraint
 -- since all `Monad`s are `Applicative` this won't cause issues
 -- downstream & `Monad`ic code is more performant per Mario C
 

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -42,7 +42,7 @@ instance [DecidableEq α] : SDiff (List α) :=
 #align list.head' List.head?
 #align list.to_array List.toArray
 #align list.nthd List.getD
-/-- "inhabited" `nth` function: returns `default` instead of `none` in the case
+/-- "inhabited" `get` function: returns `default` instead of `none` in the case
   that the index is out of bounds. -/
 def getI [Inhabited α] (l : List α) (n : Nat) : α :=
   getD  l n default

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -105,12 +105,12 @@ def alternatingProd {G : Type _} [One G] [Mul G] [Inv G] : List G → G
 @[reducible] def Functor.mapConstRev {f : Type u → Type v} [Functor f] {α β : Type u} :
   f β → α → f α :=
 fun a b => Functor.mapConst b a
---infixr ` $> `:100  := functor.map_const_rev
+infix:100 " $> " => Functor.mapConstRev
 
 /-- `mfind tac l` returns the first element of `l` on which `tac` succeeds, and
 fails otherwise. -/
 def findM {α} {m : Type u → Type v} [Monad m] [Alternative m] (tac : α → m PUnit) : List α → m α :=
-  List.firstM <| fun a => Functor.mapConstRev (tac a) a
+  List.firstM <| fun a => (tac a) $> a
 #align list.mfind List.findM
 
 /-- `mbfind' p l` returns the first element `a` of `l` for which `p a` returns

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -276,7 +276,7 @@ def permutationsAux.rec {C : List α → List α → Sort v} (H0 : ∀ is, C [] 
 /-- An auxiliary function for defining `permutations`. `permutations_aux ts is` is the set of all
 permutations of `is ++ ts` that do not fix `ts`. -/
 def permutationsAux : List α → List α → List (List α) :=
-  @permutationsAux.rec (fun _ _ => List (List α)) (fun is => []) fun t ts is IH1 IH2 =>
+  permutationsAux.rec (fun _ => []) fun t ts is IH1 IH2 =>
     foldr (fun y r => (permutationsAux2 t ts r y id).2) IH1 (is :: IH2)
 #align list.permutations_aux List.permutationsAux
 

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -470,11 +470,8 @@ def mapDiagM' {m} [Monad m] {α} (f : α → α → m Unit) : List α → m Unit
 /-- Map each element of a `List` to an action, evaluate these actions in order,
     and collect the results.
 -/
-protected def traverse
-    {F : Type u → Type v}
-    [Applicative F]
-    {α β : Type _}
-    (f : α → F β) : List α → F (List β)
+protected def traverse {F : Type u → Type v}[Applicative F] {α β : Type _} (f : α → F β)
+    : List α → F (List β)
   | [] => pure []
   | x :: xs => List.cons <$> f x <*> List.traverse f xs
 #align list.traverse List.traverse

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -238,7 +238,7 @@ def All₂ (p : α → Prop) : List α → Prop
 
 section Permutations
 
-/-- An auxiliary function for defining `permutations`. `permutations_aux2 t ts r ys f` is equal to
+/-- An auxiliary function for defining `permutations`. `permutationsAux2 t ts r ys f` is equal to
 `(ys ++ ts, (insert_left ys t ts).map f ++ r)`, where `insert_left ys t ts` (not explicitly
 defined) is the list of lists of the form `insert_nth n t (ys ++ ts)` for `0 ≤ n < length ys`.
 
@@ -254,7 +254,7 @@ def permutationsAux2 (t : α) (ts : List α) (r : List β) : List α → (List �
     (y :: us, f (t :: y :: us) :: zs)
 #align list.permutations_aux2 List.permutationsAux2
 
--- porting comment removed `[elab_as_elim]` per Mario C
+-- porting note: removed `[elab_as_elim]` per Mario C
 -- https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Status.20of.20data.2Elist.2Edefs.3F/near/313571979
 /-- A recursor for pairs of lists. To have `C l₁ l₂` for all `l₁`, `l₂`, it suffices to have it for
 `l₂ = []` and to be able to pour the elements of `l₁` into `l₂`. -/
@@ -267,7 +267,7 @@ def permutationsAux.rec {C : List α → List α → Sort v} (H0 : ∀ is, C [] 
   decreasing_by simp_wf; simp [Nat.succ_add]; decreasing_tactic
 #align list.permutations_aux.rec List.permutationsAux.rec
 
-/-- An auxiliary function for defining `permutations`. `permutations_aux ts is` is the set of all
+/-- An auxiliary function for defining `permutations`. `permutationsAux ts is` is the set of all
 permutations of `is ++ ts` that do not fix `ts`. -/
 def permutationsAux : List α → List α → List (List α) :=
   permutationsAux.rec (fun _ => []) fun t ts is IH1 IH2 =>
@@ -283,16 +283,16 @@ def permutations (l : List α) : List (List α) :=
   l :: permutationsAux l []
 #align list.permutations List.permutations
 
-/-- `permutations'_aux t ts` inserts `t` into every position in `ts`, including the last.
-This function is intended for use in specifications, so it is simpler than `permutations_aux2`,
+/-- `permutations'Aux t ts` inserts `t` into every position in `ts`, including the last.
+This function is intended for use in specifications, so it is simpler than `permutationsAux2`,
 which plays roughly the same role in `permutations`.
 
-Note that `(permutations_aux2 t [] [] ts id).2` is similar to this function, but skips the last
+Note that `(permutationsAux2 t [] [] ts id).2` is similar to this function, but skips the last
 position:
 
-    permutations'_aux 10 [1, 2, 3] =
+    permutations'Aux 10 [1, 2, 3] =
       [[10, 1, 2, 3], [1, 10, 2, 3], [1, 2, 10, 3], [1, 2, 3, 10]]
-    (permutations_aux2 10 [] [] [1, 2, 3] id).2 =
+    (permutationsAux2 10 [] [] [1, 2, 3] id).2 =
       [[10, 1, 2, 3], [1, 10, 2, 3], [1, 2, 10, 3]] -/
 @[simp]
 def permutations'Aux (t : α) : List α → List (List α)

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -267,22 +267,18 @@ private def meas : (Σ'_ : List α, List α) → ℕ × ℕ
 -/
 local infixl:50 " ≺ " => InvImage (Prod.Lex (· < ·) (· < ·)) meas
 
+
+-- porting comment removed `[elab_as_elim]` per Mario C
+-- https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Status.20of.20data.2Elist.2Edefs.3F/near/313571979
 /-- A recursor for pairs of lists. To have `C l₁ l₂` for all `l₁`, `l₂`, it suffices to have it for
 `l₂ = []` and to be able to pour the elements of `l₁` into `l₂`. -/
-@[elab_as_elim]
 def permutationsAux.rec {C : List α → List α → Sort v} (H0 : ∀ is, C [] is)
     (H1 : ∀ t ts is, C ts (t :: is) → C is [] → C (t :: ts) is) : ∀ l₁ l₂, C l₁ l₂
   | [], is => H0 is
   | t :: ts, is =>
-    have h1 : ⟨ts, t :: is⟩ ≺ ⟨t :: ts, is⟩ :=
-      show Prod.Lex _ _
-           (succ (length ts + length is), length ts)
-           (succ (length ts) + length is, length (t :: ts)) by
-        rw [Nat.succ_add] <;> exact Prod.Lex.right _ (lt_succ_self _)
-    have h2 : ⟨is, []⟩ ≺ ⟨t :: ts, is⟩ := Prod.Lex.left _ _ (Nat.lt_add_of_pos_left (succ_pos _))
-    H1 t ts is (permutationsAux.rec H0 H1 ts (t :: is)) (permutationsAux.rec H0 H1 is [])
-    termination_by'
-      ⟨(· ≺ ·), @InvImage.wf _ _ _ meas (Prod.instWellFoundedRelationProd lt_wfRel lt_wfRel)⟩
+      H1 t ts is (permutationsAux.rec H0 H1 ts (t :: is)) (permutationsAux.rec H0 H1 is [])
+  termination_by _ ts is => (length ts + length is, length ts)
+  decreasing_by simp_wf; simp [Nat.succ_add]; decreasing_tactic
 #align list.permutations_aux.rec List.permutationsAux.rec
 
 /-- An auxiliary function for defining `permutations`. `permutations_aux ts is` is the set of all

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -475,8 +475,14 @@ Example: suppose `l = [1, 2, 3]`. `mapDiagM' f l` will evaluate, in this order,
 `f 1 1`, `f 1 2`, `f 1 3`, `f 2 2`, `f 2 3`, `f 3 3`.
 -/
 def mapDiagM' {m} [Monad m] {α} (f : α → α → m Unit) : List α → m Unit
+-- as ported:
+--   | [] => return ()
+--   | h :: t => (f h h >> t.mapM' (f h)) >> t.mapDiagM'
   | [] => return ()
-  | h :: t => (f h h >> t.mapM' (f h)) >> t.mapDiagM'
+  | h :: t => do
+    _ <- f h h
+    _ <- t.mapM' (f h)
+    t.mapDiagM' f
 #align list.mmap'_diag List.mapDiagM'
 
 /-- Map each element of a `List` to an action, evaluate these actions in order,

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -101,7 +101,7 @@ def alternatingProd {G : Type _} [One G] [Mul G] [Inv G] : List G → G
 #align list.partition_map List.partitionMap
 #align list.find List.find?
 
-/-- `mfind tac l` returns the first element of `l` on which `tac` succeeds, and
+/-- `findM tac l` returns the first element of `l` on which `tac` succeeds, and
 fails otherwise. -/
 def findM {α} {m : Type u → Type v} [Monad m] [Alternative m] (tac : α → m PUnit) : List α → m α :=
   List.firstM <| fun a => (tac a) $> a

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -68,7 +68,7 @@ def prod [Mul α] [One α] : List α → α :=
   foldl (· * ·) 1
 #align list.prod List.prod
 
--- TODO: tag with `to_additive`, but this can't be done yet because of import
+Later this will be tagged with `to_additive`, but this can't be done yet because of imports.
 -- dependencies.
 /-- Sum of a list.
 

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -63,7 +63,7 @@ def getI [Inhabited α] (l : List α) (n : Nat) : α :=
 
 /-- Product of a list.
 
-     prod [a, b, c] = ((1 * a) * b) * c -/
+     `prod [a, b, c] = ((1 * a) * b) * c` -/
 def prod [Mul α] [One α] : List α → α :=
   foldl (· * ·) 1
 #align list.prod List.prod

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -175,37 +175,31 @@ def foldrIdxM {α β} (f : ℕ → α → β → m β) (b : β) (as : List α) :
 end foldIdxM
 
 
-section mapIdxA
+section mapIdxM
 
-variable {m : Type v → Type w} [Applicative m]
+-- porting notes: This was defined in `mathlib` with an `Applicative`
+-- constraint on `m` and have been `#align`ed to the `Std` versions defined
+-- with a with a `Monad` typeclass constraint
+-- since all `Monad`s are `Applicative` this won't cause issues
+-- downstream & `Monad`ic code is more performant per Mario C
 
--- porting notes: These already exist with a `Monad` typeclass constraint
--- could either delete, or go with the suggested `A` suffix.
+#align list.mmap_with_index List.mapIdxM
 
-/-- Auxiliary definition for `mmap_with_index`. -/
-def mapIdxAAux {α β} (f : ℕ → α → m β) : ℕ → List α → m (List β)
-  | _, [] => pure []
-  | i, a :: as => List.cons <$> f i a <*> mapIdxAAux f (i + 1) as
-#align list.mmap_with_index_aux List.mapIdxAAux
-
-/-- Applicative variant of `map_with_index`. -/
-def mapIdxA {α β} (f : ℕ → α → m β) (as : List α) : m (List β) :=
-  mapIdxAAux f 0 as
-#align list.mmap_with_index List.mapIdxA
+variable {m : Type v → Type w} [Monad m]
 
 /-- Auxiliary definition for `mmap_with_index'`. -/
-def mapIdxAAux' {α} (f : ℕ → α → m PUnit) : ℕ → List α → m PUnit
+def mapIdxMAux' {α} (f : ℕ → α → m PUnit) : ℕ → List α → m PUnit
   | _, [] => pure ⟨⟩
-  | i, a :: as => f i a *> mapIdxAAux' f (i + 1) as
-#align list.mmap_with_index'_aux List.mapIdxAAux'
+  | i, a :: as => f i a *> mapIdxMAux' f (i + 1) as
+#align list.mmap_with_index'_aux List.mapIdxMAux'
 
 /-- A variant of `mmap_with_index` specialised to applicative actions which
 return `unit`. -/
-def mapIdxA' {α} (f : ℕ → α → m PUnit) (as : List α) : m PUnit :=
-  mapIdxAAux' f 0 as
-#align list.mmap_with_index' List.mapIdxA'
+def mapIdxM' {α} (f : ℕ → α → m PUnit) (as : List α) : m PUnit :=
+  mapIdxMAux' f 0 as
+#align list.mmap_with_index' List.mapIdxM'
 
-end mapIdxA
+end mapIdxM
 
 #align list.lookmap List.lookmap
 #align list.countp List.countp

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -479,8 +479,8 @@ def mapDiagM' {m} [Monad m] {α} (f : α → α → m Unit) : List α → m Unit
 --   | h :: t => (f h h >> t.mapM' (f h)) >> t.mapDiagM'
   | [] => return ()
   | h :: t => do
-    _ <- f h h
-    _ <- t.mapM' (f h)
+    _ ← f h h
+    _ ← t.mapM' (f h)
     t.mapDiagM' f
 #align list.mmap'_diag List.mapDiagM'
 

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -355,9 +355,8 @@ def extractp (p : α → Prop) [DecidablePred p] : List α → Option α × List
 #align list.product List.product
 /-- Notation for calculating the product of a `List`
 -/
-infixr:82
-  " ×ˢ " =>-- This notation binds more strongly than (pre)images, unions and intersections.
-  List.product
+-- This notation binds more strongly than (pre)images, unions and intersections.
+infixr:82 " ×ˢ " => List.product
 #align list.sigma List.sigma
 #align list.of_fn List.ofFn
 #align list.of_fn_nth_val List.ofFnNthVal

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -107,9 +107,9 @@ def findM {α} {m : Type u → Type v} [Monad m] [Alternative m] (tac : α → m
   List.firstM <| fun a => (tac a) $> a
 #align list.mfind List.findM
 
-/-- `mbfind' p l` returns the first element `a` of `l` for which `p a` returns
-true. `mbfind'` short-circuits, so `p` is not necessarily run on every `a` in
-`l`. This is a monadic version of `list.find`. -/
+/-- `findM? p l` returns the first element `a` of `l` for which `p a` returns
+true. `findM?` short-circuits, so `p` is not necessarily run on every `a` in
+`l`. This is a monadic version of `List.find`. -/
 def findM?'
     {m : Type u → Type v}
     [Monad m] {α : Type u}

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -23,7 +23,6 @@ proofs about these definitions, those are contained in other files in `Data.List
 -- These have been annotated with `#align`s
 -- To make this easier for review, the `#align`s have been placed in order of occurrence
 -- in `mathlib`
--- TODO: post port, reorder `#align`s to the end.
 
 namespace List
 

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -1,0 +1,638 @@
+/-
+Copyright (c) 2014 Parikshit Khanna. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Parikshit Khanna, Jeremy Avigad, Leonardo de Moura, Floris van Doorn, Mario Carneiro
+-/
+import Mathlib.Logic.Basic
+import Mathlib.Data.Nat.Basic
+import Mathlib.Algebra.Group.Defs
+import Mathlib.Data.List.Chain
+import Std.Tactic.Lint.Basic
+import Std.Data.RBMap.Basic
+
+/-!
+## Definitions on lists
+
+This file contains various definitions on lists. It does not contain
+proofs about these definitions, those are contained in other files in `data/list`
+-/
+
+
+namespace List
+
+open Function Nat
+
+universe u v w x
+
+variable {α β γ δ ε ζ : Type _}
+
+instance [DecidableEq α] : SDiff (List α) :=
+  ⟨List.diff⟩
+
+-- Defined in `Std` so not ported
+-- List.splitAt
+-- List.splitOnP
+-- List.splitOn
+-- List.concat
+-- List.toArray
+-- List.modifyNthTail
+-- List.modifyHead
+-- List.modifyNth
+-- List.modifyLast
+-- List.insertNth
+-- List.takeWhile
+-- List.scanl
+-- List.scanr
+-- List.partitionMap
+-- List.indexesValues
+-- List.indexesOf
+-- List.lookmap
+-- List.countp
+-- List.count
+-- List.inits
+-- List.tails
+-- List.sublists'
+-- List.sublists
+-- List.Forall₂
+-- List.transpose
+-- List.sections
+-- List.revzip
+-- List.product
+-- mathport name: list.product
+infixr:82
+  " ×ˢ " =>-- This notation binds more strongly than (pre)images, unions and intersections.
+  List.product
+
+-- List.sigma
+-- List.ofFn
+-- List.ofFnNthVal
+-- List.Disjoint
+-- List.Pairwise
+-- List.pariwise_cons
+-- List.decidablePairwise
+-- List.pwFilter
+-- List.Chain
+-- List.Chain'
+-- in Mathlib.Data.List.Chain: List.chain_cons
+-- List.Nodup
+-- List.nodupDecidable
+-- List.range'
+-- List.reduceOption
+-- List.ilast'
+-- List.last'
+-- List.rotate
+-- List.rotate'
+-- List.getRest
+
+-- The following exist in `Std` with name changes, noted through `#align`
+
+-- name changed in Std
+#align list.head' List.head?
+#align list.find List.find?
+#align list.take' List.takeD
+#align list.find_indexes List.findIdxs
+#align list.mbfind List.findM?
+#align list.many List.anyM
+#align list.mall List.allM
+#align list.foldr_with_index List.foldrIdx
+#align list.foldl_with_index List.foldlIdx
+#align list.is_prefix List.isPrefix
+#align list.is_suffix List.isSuffix
+#align list.is_infix List.isInfix
+-- mathport name: «expr <+: »
+infixl:50 " <+: " => isPrefix
+-- mathport name: «expr <:+ »
+infixl:50 " <:+ " => isSuffix
+-- mathport name: «expr <:+: »
+infixl:50 " <:+: " => isInfix
+#align list.mmap_filter List.filterMapM
+#align list.slice List.dropSlice
+#align list.zip_right List.zipRight
+#align list.zip_left' List.zipLeft'
+#align list.zip_right' List.zipRight'
+#align list.zip_left List.zipLeft
+#align list.all_some List.allSome
+#align list.fill_nones List.fillNones
+#align list.take_list List.takeList
+#align list.to_chunks_aux List.toChunksAux
+#align list.to_chunks List.toChunks
+#align list.map_with_prefix_suffix_aux List.mapWithPrefixSuffixAux
+#align list.map_with_prefix_suffix List.mapWithPrefixSuffix
+#align list.map_with_complement List.mapWithComplement
+
+
+
+
+
+
+
+
+
+
+
+/-- "default" `nth` function: returns `d` instead of `none` in the case
+  that the index is out of bounds. -/
+@[nolint unusedArguments]
+def nthd (d : α) : ∀ (l : List α) (n : ℕ), α
+  | [], _ => d
+  | x :: _, 0 => x
+  | _ :: xs, n + 1 => nthd d xs n
+#align list.nthd List.nthd
+
+/-- "inhabited" `nth` function: returns `default` instead of `none` in the case
+  that the index is out of bounds. -/
+@[nolint unusedArguments]
+def inth [h : Inhabited α] (l : List α) (n : Nat) : α :=
+  nthd default l n
+#align list.inth List.inth
+
+
+/-- Product of a list.
+
+     prod [a, b, c] = ((1 * a) * b) * c -/
+def prod [Mul α] [One α] : List α → α :=
+  foldl (· * ·) 1
+#align list.prod List.prod
+
+-- TODO: tag with `to_additive`, but this can't be done yet because of import
+-- dependencies.
+/-- Sum of a list.
+
+     sum [a, b, c] = ((0 + a) + b) + c -/
+def sum [Add α] [Zero α] : List α → α :=
+  foldl (· + ·) 0
+#align list.sum List.sum
+
+/-- The alternating sum of a list. -/
+def alternatingSum {G : Type _} [Zero G] [Add G] [Neg G] : List G → G
+  | [] => 0
+  | g :: [] => g
+  | g :: h :: t => g + -h + alternatingSum t
+#align list.alternating_sum List.alternatingSum
+
+/-- The alternating product of a list. -/
+def alternatingProd {G : Type _} [One G] [Mul G] [Inv G] : List G → G
+  | [] => 1
+  | g :: [] => g
+  | g :: h :: t => g * h⁻¹ * alternatingProd t
+#align list.alternating_prod List.alternatingProd
+
+
+
+/-- `mfind tac l` returns the first element of `l` on which `tac` succeeds, and
+fails otherwise. -/
+def mfind {α} {m : Type u → Type v} [Monad m] [Alternative m] (tac : α → m PUnit) : List α → m α :=
+  List.firstM fun a => m (tac a) $> a
+#align list.mfind List.mfind
+
+/-- `mbfind' p l` returns the first element `a` of `l` for which `p a` returns
+true. `mbfind'` short-circuits, so `p` is not necessarily run on every `a` in
+`l`. This is a monadic version of `list.find`. -/
+def mbfind' {m : Type u → Type v} [Monad m] {α : Type u} (p : α → m (ULift Bool)) : List α → m (Option α)
+  | [] => pure none
+  | x :: xs => do
+    let ⟨px⟩ ← p x
+    if px then pure (some x) else mbfind' p xs
+#align list.mbfind' List.mbfind'
+
+section
+
+variable {m : Type → Type v} [Monad m]
+
+
+
+/-- `orM xs` runs the actions in `xs`, returning true if any of them returns
+true. `orM` short-circuits, so if an action returns true, later actions are
+not run. -/
+def orM : List (m Bool) → m Bool :=
+  anyM id
+#align list.mbor List.orM
+
+/-- `andM xs` runs the actions in `xs`, returning true if all of them return
+true. `andM` short-circuits, so if an action returns false, later actions are
+not run. -/
+def andM : List (m Bool) → m Bool :=
+  allM id
+#align list.mband List.andM
+
+end
+
+
+
+section MfoldWithIndex
+
+variable {m : Type v → Type w} [Monad m]
+
+/-- Monadic variant of `foldlIdx`. -/
+def foldlIdxM {α β} (f : ℕ → β → α → m β) (b : β) (as : List α) : m β :=
+  as.foldlIdx
+    (fun i ma b => do
+      let a ← ma
+      f i a b)
+    (pure b)
+#align list.mfoldl_with_index List.foldlIdxM
+
+/-- Monadic variant of `foldrIdx`. -/
+def foldrIdxM {α β} (f : ℕ → α → β → m β) (b : β) (as : List α) : m β :=
+  as.foldrIdx
+    (fun i a mb => do
+      let b ← mb
+      f i a b)
+    (pure b)
+#align list.mfoldr_with_index List.foldrIdxM
+
+end MfoldWithIndex
+
+section MmapWithIndex
+
+variable {m : Type v → Type w} [Applicative m]
+
+-- FIXME: Idx, find the right appplicative suffix
+
+/-- Auxiliary definition for `mmap_with_index`. -/
+def mmapWithIndexAux {α β} (f : ℕ → α → m β) : ℕ → List α → m (List β)
+  | _, [] => pure []
+  | i, a :: as => List.cons <$> f i a <*> mmapWithIndexAux f (i + 1) as
+#align list.mmap_with_index_aux List.mmapWithIndexAux
+
+/-- Applicative variant of `map_with_index`. -/
+def mmapWithIndex {α β} (f : ℕ → α → m β) (as : List α) : m (List β) :=
+  mmapWithIndexAux f 0 as
+#align list.mmap_with_index List.mmapWithIndex
+
+/-- Auxiliary definition for `mmap_with_index'`. -/
+def mmapWithIndex'Aux {α} (f : ℕ → α → m PUnit) : ℕ → List α → m PUnit
+  | _, [] => pure ⟨⟩
+  | i, a :: as => f i a *> mmapWithIndex'Aux f (i + 1) as
+#align list.mmap_with_index'_aux List.mmapWithIndex'Aux
+
+/-- A variant of `mmap_with_index` specialised to applicative actions which
+return `unit`. -/
+def mmapWithIndex' {α} (f : ℕ → α → m PUnit) (as : List α) : m PUnit :=
+  mmapWithIndex'Aux f 0 as
+#align list.mmap_with_index' List.mmapWithIndex'
+
+end MmapWithIndex
+
+
+-- keep?
+/--
+-/
+def sublistsAux₁ : List α → (List α → List β) → List β
+  | [], _ => []
+  | a :: l, f => f [a] ++ sublistsAux₁ l fun ys => f ys ++ f (a :: ys)
+#align list.sublists_aux₁ List.sublistsAux₁
+
+/-- `l.all₂ p` is equivalent to `∀ a ∈ l, p a`, but unfolds directly to a conjunction, i.e.
+`list.all₂ p [0, 1, 2] = p 0 ∧ p 1 ∧ p 2`. -/
+@[simp]
+def All₂ (p : α → Prop) : List α → Prop
+  | [] => True
+  | x :: [] => p x
+  | x :: l => p x ∧ All₂ p l
+#align list.all₂ List.All₂
+
+
+section Permutations
+
+/-- An auxiliary function for defining `permutations`. `permutations_aux2 t ts r ys f` is equal to
+`(ys ++ ts, (insert_left ys t ts).map f ++ r)`, where `insert_left ys t ts` (not explicitly
+defined) is the list of lists of the form `insert_nth n t (ys ++ ts)` for `0 ≤ n < length ys`.
+
+    permutations_aux2 10 [4, 5, 6] [] [1, 2, 3] id =
+      ([1, 2, 3, 4, 5, 6],
+       [[10, 1, 2, 3, 4, 5, 6],
+        [1, 10, 2, 3, 4, 5, 6],
+        [1, 2, 10, 3, 4, 5, 6]]) -/
+def permutationsAux2 (t : α) (ts : List α) (r : List β) : List α → (List α → β) → List α × List β
+  | [], f => (ts, r)
+  | y :: ys, f =>
+    let (us, zs) := permutationsAux2 t ys fun x : List α => f (y :: x)
+    (y :: us, f (t :: y :: us) :: zs)
+#align list.permutations_aux2 List.permutationsAux2
+
+private def meas : (Σ'_ : List α, List α) → ℕ × ℕ
+  | ⟨l, i⟩ => (length l + length i, length l)
+
+-- mathport name: «expr ≺ »
+local infixl:50 " ≺ " => InvImage (Prod.Lex (· < ·) (· < ·)) meas
+
+/-- A recursor for pairs of lists. To have `C l₁ l₂` for all `l₁`, `l₂`, it suffices to have it for
+`l₂ = []` and to be able to pour the elements of `l₁` into `l₂`. -/
+@[elab_as_elim]
+def PermutationsAux.rec {C : List α → List α → Sort v} (H0 : ∀ is, C [] is)
+    (H1 : ∀ t ts is, C ts (t :: is) → C is [] → C (t :: ts) is) : ∀ l₁ l₂, C l₁ l₂
+  | [], is => H0 is
+  | t :: ts, is =>
+    have h1 : ⟨ts, t :: is⟩ ≺ ⟨t :: ts, is⟩ :=
+      show Prod.Lex _ _
+           (succ (length ts + length is), length ts)
+           (succ (length ts) + length is, length (t :: ts)) by
+        rw [Nat.succ_add] <;> exact Prod.Lex.right _ (lt_succ_self _)
+    have h2 : ⟨is, []⟩ ≺ ⟨t :: ts, is⟩ := Prod.Lex.left _ _ (Nat.lt_add_of_pos_left (succ_pos _))
+    H1 t ts is (PermutationsAux.rec H0 H1 ts (t :: is)) (PermutationsAux.rec H0 H1 is [])
+    termination_by' ⟨(· ≺ ·), @InvImage.wf _ _ _ meas (Prod.lex_wf lt_wf lt_wf)⟩
+#align list.permutations_aux.rec List.PermutationsAux.rec
+
+/-- An auxiliary function for defining `permutations`. `permutations_aux ts is` is the set of all
+permutations of `is ++ ts` that do not fix `ts`. -/
+def permutationsAux : List α → List α → List (List α) :=
+  @PermutationsAux.rec (fun _ _ => List (List α)) (fun is => []) fun t ts is IH1 IH2 =>
+    foldr (fun y r => (permutationsAux2 t ts r y id).2) IH1 (is :: IH2)
+#align list.permutations_aux List.permutationsAux
+
+/-- List of all permutations of `l`.
+
+     permutations [1, 2, 3] =
+       [[1, 2, 3], [2, 1, 3], [3, 2, 1],
+        [2, 3, 1], [3, 1, 2], [1, 3, 2]] -/
+def permutations (l : List α) : List (List α) :=
+  l :: permutationsAux l []
+#align list.permutations List.permutations
+
+/-- `permutations'_aux t ts` inserts `t` into every position in `ts`, including the last.
+This function is intended for use in specifications, so it is simpler than `permutations_aux2`,
+which plays roughly the same role in `permutations`.
+
+Note that `(permutations_aux2 t [] [] ts id).2` is similar to this function, but skips the last
+position:
+
+    permutations'_aux 10 [1, 2, 3] =
+      [[10, 1, 2, 3], [1, 10, 2, 3], [1, 2, 10, 3], [1, 2, 3, 10]]
+    (permutations_aux2 10 [] [] [1, 2, 3] id).2 =
+      [[10, 1, 2, 3], [1, 10, 2, 3], [1, 2, 10, 3]] -/
+@[simp]
+def permutations'Aux (t : α) : List α → List (List α)
+  | [] => [[t]]
+  | y :: ys => (t :: y :: ys) :: (permutations'Aux t ys).map (cons y)
+#align list.permutations'_aux List.permutations'Aux
+
+/-- List of all permutations of `l`. This version of `permutations` is less efficient but has
+simpler definitional equations. The permutations are in a different order,
+but are equal up to permutation, as shown by `list.permutations_perm_permutations'`.
+
+     permutations [1, 2, 3] =
+       [[1, 2, 3], [2, 1, 3], [2, 3, 1],
+        [1, 3, 2], [3, 1, 2], [3, 2, 1]] -/
+@[simp]
+def permutations' : List α → List (List α)
+  | [] => [[]]
+  | t :: ts => (permutations' ts).bind <| permutations'Aux t
+#align list.permutations' List.permutations'
+
+end Permutations
+
+/-- `erasep p l` removes the first element of `l` satisfying the predicate `p`. -/
+def erasep (p : α → Prop) [DecidablePred p] : List α → List α
+  | [] => []
+  | a :: l => if p a then l else a :: erasep p l
+#align list.erasep List.erasep
+
+/-- `extractp p l` returns a pair of an element `a` of `l` satisfying the predicate
+  `p`, and `l`, with `a` removed. If there is no such element `a` it returns `(none, l)`. -/
+def extractp (p : α → Prop) [DecidablePred p] : List α → Option α × List α
+  | [] => (none, [])
+  | a :: l =>
+    if p a then (some a, l)
+    else
+      let (a', l') := extractp p l
+      (a', a :: l')
+#align list.extractp List.extractp
+
+
+
+section Chain
+
+instance decidableChain [DecidableRel R] (a : α) (l : List α) : Decidable (Chain R a l) := by
+  induction l generalizing a <;> simp only [List.Chain.nil, chain_cons] <;> skip <;> infer_instance
+#align list.decidable_chain List.decidableChain
+
+instance decidableChain' [DecidableRel R] (l : List α) : Decidable (Chain' R l) := by
+  cases l <;> dsimp only [List.Chain'] <;> infer_instance
+#align list.decidable_chain' List.decidableChain'
+
+end Chain
+
+
+/-- `dedup l` removes duplicates from `l` (taking only the last occurrence).
+  Defined as `pw_filter (≠)`.
+
+     dedup [1, 0, 2, 2, 1] = [0, 2, 1] -/
+def dedup [DecidableEq α] : List α → List α :=
+  pwFilter (· ≠ ·)
+#align list.dedup List.dedup
+
+/-- Greedily create a sublist of `a :: l` such that, for every two adjacent elements `a, b`,
+`R a b` holds. Mostly used with ≠; for example, `destutter' (≠) 1 [2, 2, 1, 1] = [1, 2, 1]`,
+`destutter' (≠) 1, [2, 3, 3] = [1, 2, 3]`, `destutter' (<) 1 [2, 5, 2, 3, 4, 9] = [1, 2, 5, 9]`. -/
+def destutter' (R : α → α → Prop) [DecidableRel R] : α → List α → List α
+  | a, [] => [a]
+  | a, h :: l => if R a h then a :: destutter' R h l else destutter' R a l
+#align list.destutter' List.destutter'
+
+/-- Greedily create a sublist of `l` such that, for every two adjacent elements `a, b ∈ l`,
+`R a b` holds. Mostly used with ≠; for example, `destutter (≠) [1, 2, 2, 1, 1] = [1, 2, 1]`,
+`destutter (≠) [1, 2, 3, 3] = [1, 2, 3]`, `destutter (<) [1, 2, 5, 2, 3, 4, 9] = [1, 2, 5, 9]`. -/
+def destutter (R : α → α → Prop) [DecidableRel R] : List α → List α
+  | h :: l => destutter' R h l
+  | [] => []
+#align list.destutter List.destutter
+
+
+
+section Choose
+
+variable (p : α → Prop) [DecidablePred p] (l : List α)
+
+/-- Given a decidable predicate `p` and a proof of existence of `a ∈ l` such that `p a`,
+choose the first element with this property. This version returns both `a` and proofs
+of `a ∈ l` and `p a`. -/
+def chooseX : ∀ l : List α, ∀ hp : ∃ a, a ∈ l ∧ p a, { a // a ∈ l ∧ p a }
+  | [], hp => False.elim (Exists.elim hp fun a h => not_mem_nil a h.left)
+  | l :: ls, hp =>
+    if pl : p l then ⟨l, ⟨Or.inl rfl, pl⟩⟩
+    else
+      let ⟨a, ⟨a_mem_ls, pa⟩⟩ :=
+        chooseX ls (hp.imp fun b ⟨o, h₂⟩ => ⟨o.resolve_left fun e => pl <| e ▸ h₂, h₂⟩)
+      ⟨a, ⟨Or.inr a_mem_ls, pa⟩⟩
+#align list.choose_x List.chooseX
+
+/-- Given a decidable predicate `p` and a proof of existence of `a ∈ l` such that `p a`,
+choose the first element with this property. This version returns `a : α`, and properties
+are given by `choose_mem` and `choose_property`. -/
+def choose (hp : ∃ a, a ∈ l ∧ p a) : α :=
+  chooseX p l hp
+#align list.choose List.choose
+
+end Choose
+
+/-- `mapUpperTriangleM f l` calls `f` on all elements in the upper triangular part of `l × l`.
+That is, for each `e ∈ l`, it will run `f e e` and then `f e e'`
+for each `e'` that appears after `e` in `l`.
+
+Example: suppose `l = [1, 2, 3]`. `mapUpperTriangleM f l` will produce the list
+`[f 1 1, f 1 2, f 1 3, f 2 2, f 2 3, f 3 3]`.
+-/
+def mapUpperTriangleM {m} [Monad m] {α β : Type u} (f : α → α → m β) : List α → m (List β)
+  | [] => return []
+  | h :: t => do
+    let v ← f h h
+    let l ← t.mapM (f h)
+    let t ← t.mapUpperTriangleM f
+    return v :: l ++ t
+#align list.mmap_upper_triangle List.mapUpperTriangleM
+
+/-- `mapDiagM' f l` calls `f` on all elements in the upper triangular part of `l × l`.
+That is, for each `e ∈ l`, it will run `f e e` and then `f e e'`
+for each `e'` that appears after `e` in `l`.
+
+Example: suppose `l = [1, 2, 3]`. `mapDiagM' f l` will evaluate, in this order,
+`f 1 1`, `f 1 2`, `f 1 3`, `f 2 2`, `f 2 3`, `f 3 3`.
+-/
+def mapDiagM' {m} [Monad m] {α} (f : α → α → m Unit) : List α → m Unit
+  | [] => return ()
+  | h :: t => (f h h >> t.mapM' (f h)) >> t.mapDiagM'
+#align list.mmap'_diag List.mapDiagM'
+
+protected def traverse
+    {F : Type u → Type v}
+    [Applicative F]
+    {α β : Type _}
+    (f : α → F β) : List α → F (List β)
+  | [] => pure []
+  | x :: xs => List.cons <$> f x <*> List.traverse f xs
+#align list.traverse List.traverse
+
+
+/-- Left-biased version of `list.map₂`. `map₂_left' f as bs` applies `f` to each
+pair of elements `aᵢ ∈ as` and `bᵢ ∈ bs`. If `bs` is shorter than `as`, `f` is
+applied to `none` for the remaining `aᵢ`. Returns the results of the `f`
+applications and the remaining `bs`.
+
+```
+map₂_left' prod.mk [1, 2] ['a'] = ([(1, some 'a'), (2, none)], [])
+
+map₂_left' prod.mk [1] ['a', 'b'] = ([(1, some 'a')], ['b'])
+```
+-/
+@[simp]
+def map₂Left' (f : α → Option β → γ) : List α → List β → List γ × List β
+  | [], bs => ([], bs)
+  | a :: as, [] => ((a :: as).map fun a => f a none, [])
+  | a :: as, b :: bs =>
+    let rec' := map₂Left' f as bs
+    (f a (some b) :: rec'.fst, rec'.snd)
+#align list.map₂_left' List.map₂Left'
+
+/-- Right-biased version of `list.map₂`. `map₂_right' f as bs` applies `f` to each
+pair of elements `aᵢ ∈ as` and `bᵢ ∈ bs`. If `as` is shorter than `bs`, `f` is
+applied to `none` for the remaining `bᵢ`. Returns the results of the `f`
+applications and the remaining `as`.
+
+```
+map₂_right' prod.mk [1] ['a', 'b'] = ([(some 1, 'a'), (none, 'b')], [])
+
+map₂_right' prod.mk [1, 2] ['a'] = ([(some 1, 'a')], [2])
+```
+-/
+def map₂Right' (f : Option α → β → γ) (as : List α) (bs : List β) : List γ × List α :=
+  map₂Left' (flip f) bs as
+#align list.map₂_right' List.map₂Right'
+
+
+/-- Left-biased version of `list.map₂`. `map₂_left f as bs` applies `f` to each pair
+`aᵢ ∈ as` and `bᵢ ‌∈ bs`. If `bs` is shorter than `as`, `f` is applied to `none`
+for the remaining `aᵢ`.
+
+```
+map₂_left prod.mk [1, 2] ['a'] = [(1, some 'a'), (2, none)]
+
+map₂_left prod.mk [1] ['a', 'b'] = [(1, some 'a')]
+
+map₂_left f as bs = (map₂_left' f as bs).fst
+```
+-/
+@[simp]
+def map₂Left (f : α → Option β → γ) : List α → List β → List γ
+  | [], _ => []
+  | a :: as, [] => (a :: as).map fun a => f a none
+  | a :: as, b :: bs => f a (some b) :: map₂Left f as bs
+#align list.map₂_left List.map₂Left
+
+/-- Right-biased version of `list.map₂`. `map₂_right f as bs` applies `f` to each
+pair `aᵢ ∈ as` and `bᵢ ‌∈ bs`. If `as` is shorter than `bs`, `f` is applied to
+`none` for the remaining `bᵢ`.
+
+```
+map₂_right prod.mk [1, 2] ['a'] = [(some 1, 'a')]
+
+map₂_right prod.mk [1] ['a', 'b'] = [(some 1, 'a'), (none, 'b')]
+
+map₂_right f as bs = (map₂_right' f as bs).fst
+```
+-/
+def map₂Right (f : Option α → β → γ) (as : List α) (bs : List β) : List γ :=
+  map₂Left (flip f) bs as
+#align list.map₂_right List.map₂Right
+
+
+
+
+/-- `to_rbmap as` is the map that associates each index `i` of `as` with the
+corresponding element of `as`.
+
+```
+to_rbmap ['a', 'b', 'c'] = rbmap_of [(0, 'a'), (1, 'b'), (2, 'c')]
+```
+-/
+def toRbmap {α : Type _} : List α → RBMap ℕ α :=
+  foldlIdx (fun i mapp a => mapp.insert i a) (mkRbmap ℕ α)
+#align list.to_rbmap List.toRbmap
+
+
+/-- Asynchronous version of `List.map`.
+-/
+unsafe def map_async_chunked {α β} (f : α → β) (xs : List α) (chunk_size := 1024) : List β :=
+  ((xs.toChunks chunk_size).map fun xs => Task.spawn fun _ => List.map f xs).bind Task.get
+#align list.map_async_chunked List.map_async_chunked
+
+/-!
+We add some n-ary versions of `list.zip_with` for functions with more than two arguments.
+These can also be written in terms of `list.zip` or `list.zip_with`.
+For example, `zip_with3 f xs ys zs` could also be written as
+`zip_with id (zip_with f xs ys) zs`
+or as
+`(zip xs $ zip ys zs).map $ λ ⟨x, y, z⟩, f x y z`.
+-/
+
+
+/-- Ternary version of `list.zip_with`. -/
+def zipWith3 (f : α → β → γ → δ) : List α → List β → List γ → List δ
+  | x :: xs, y :: ys, z :: zs => f x y z :: zipWith3 f xs ys zs
+  | _, _, _ => []
+#align list.zip_with3 List.zipWith3
+
+/-- Quaternary version of `list.zip_with`. -/
+def zipWith4 (f : α → β → γ → δ → ε) : List α → List β → List γ → List δ → List ε
+  | x :: xs, y :: ys, z :: zs, u :: us => f x y z u :: zipWith4 f xs ys zs us
+  | _, _, _, _ => []
+#align list.zip_with4 List.zipWith4
+
+/-- Quinary version of `list.zip_with`. -/
+def zipWith5 (f : α → β → γ → δ → ε → ζ) : List α → List β → List γ → List δ → List ε → List ζ
+  | x :: xs, y :: ys, z :: zs, u :: us, v :: vs => f x y z u v :: zipWith5 f xs ys zs us vs
+  | _, _, _, _, _ => []
+#align list.zip_with5 List.zipWith5
+
+/-- Given a starting list `old`, a list of booleans and a replacement list `new`,
+read the items in `old` in succession and either replace them with the next element of `new` or
+not, according as to whether the corresponding boolean is `tt` or `ff`. -/
+def replaceIf : List α → List Bool → List α → List α
+  | l, _, [] => l
+  | [], _, _ => []
+  | l, [], _ => l
+  | n :: ns, tf :: bs, e@(c :: cs) => if tf then c :: ns.replaceIf bs cs else n :: ns.replaceIf bs e
+#align list.replace_if List.replaceIf
+
+end List
+#lint

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -179,7 +179,8 @@ section mapIdxA
 
 variable {m : Type v → Type w} [Applicative m]
 
--- FIXME: Idx, find the right appplicative suffix
+-- porting notes: These already exist with a `Monad` typeclass constraint
+-- could either delete, or go with the suggested `A` suffix.
 
 /-- Auxiliary definition for `mmap_with_index`. -/
 def mapIdxAAux {α β} (f : ℕ → α → m β) : ℕ → List α → m (List β)
@@ -577,6 +578,7 @@ def map₂Right (f : Option α → β → γ) (as : List α) (bs : List β) : Li
 #align list.to_chunks List.toChunks
 
 -- porting notes -- was `unsafe` but removed for Lean 4 port
+-- TODO: naming is awkward...
 /-- Asynchronous version of `List.map`.
 -/
 def map_async_chunked {α β} (f : α → β) (xs : List α) (chunk_size := 1024) : List β :=

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -53,7 +53,6 @@ def nthd (d : α) : ∀ (_ : List α) (_ : ℕ), α
 
 /-- "inhabited" `nth` function: returns `default` instead of `none` in the case
   that the index is out of bounds. -/
-@[nolint unusedArguments]
 def inth [Inhabited α] (l : List α) (n : Nat) : α :=
   nthd default l n
 #align list.inth List.inth

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -179,10 +179,10 @@ section mapIdxM
 
 -- porting notes: This was defined in `mathlib` with an `Applicative`
 -- constraint on `m` and have been `#align`ed to the `Std` versions defined
--- with a `Monad` typeclass constraint
--- since all `Monad`s are `Applicative` this won't cause issues
+-- with a `Monad` typeclass constraint.
+-- Since all `Monad`s are `Applicative` this won't cause issues
 -- downstream & `Monad`ic code is more performant per Mario C
-
+-- See https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Applicative.20variants.20of.20Monadic.20functions/near/313213172
 #align list.mmap_with_index List.mapIdxM
 
 variable {m : Type v → Type w} [Monad m]

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -42,6 +42,9 @@ instance [DecidableEq α] : SDiff (List α) :=
 #align list.head' List.head?
 #align list.to_array List.toArray
 #align list.nthd List.getD
+-- porting notes: see
+-- https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/List.2Ehead/near/313204716
+-- for the fooI naming convention.
 /-- "inhabited" `get` function: returns `default` instead of `none` in the case
   that the index is out of bounds. -/
 def getI [Inhabited α] (l : List α) (n : Nat) : α :=

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -280,15 +280,15 @@ def permutationsAux.rec {C : List α → List α → Sort v} (H0 : ∀ is, C [] 
            (succ (length ts) + length is, length (t :: ts)) by
         rw [Nat.succ_add] <;> exact Prod.Lex.right _ (lt_succ_self _)
     have h2 : ⟨is, []⟩ ≺ ⟨t :: ts, is⟩ := Prod.Lex.left _ _ (Nat.lt_add_of_pos_left (succ_pos _))
-    H1 t ts is (PermutationsAux.rec H0 H1 ts (t :: is)) (PermutationsAux.rec H0 H1 is [])
+    H1 t ts is (permutationsAux.rec H0 H1 ts (t :: is)) (permutationsAux.rec H0 H1 is [])
     termination_by'
       ⟨(· ≺ ·), @InvImage.wf _ _ _ meas (Prod.instWellFoundedRelationProd lt_wfRel lt_wfRel)⟩
-#align list.permutations_aux.rec List.PermutationsAux.rec
+#align list.permutations_aux.rec List.permutationsAux.rec
 
 /-- An auxiliary function for defining `permutations`. `permutations_aux ts is` is the set of all
 permutations of `is ++ ts` that do not fix `ts`. -/
 def permutationsAux : List α → List α → List (List α) :=
-  @PermutationsAux.rec (fun _ _ => List (List α)) (fun is => []) fun t ts is IH1 IH2 =>
+  @permutationsAux.rec (fun _ _ => List (List α)) (fun is => []) fun t ts is IH1 IH2 =>
     foldr (fun y r => (permutationsAux2 t ts r y id).2) IH1 (is :: IH2)
 #align list.permutations_aux List.permutationsAux
 

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -48,7 +48,7 @@ instance [DecidableEq α] : SDiff (List α) :=
 /-- "inhabited" `get` function: returns `default` instead of `none` in the case
   that the index is out of bounds. -/
 def getI [Inhabited α] (l : List α) (n : Nat) : α :=
-  getD  l n default
+  getD l n default
 #align list.inth List.getI
 
 #align list.modify_nth_tail List.modifyNthTail

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -53,9 +53,9 @@ def nthd (d : α) : ∀ (_ : List α) (_ : ℕ), α
 
 /-- "inhabited" `nth` function: returns `default` instead of `none` in the case
   that the index is out of bounds. -/
-def inth [Inhabited α] (l : List α) (n : Nat) : α :=
+def nthI [Inhabited α] (l : List α) (n : Nat) : α :=
   nthd default l n
-#align list.inth List.inth
+#align list.inth List.nthI
 
 #align list.modify_nth_tail List.modifyNthTail
 #align list.modify_head List.modifyHead

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -616,4 +616,3 @@ def replaceIf : List α → List Bool → List α → List α
 
 
 end List
-#lint

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -568,7 +568,7 @@ def map₂Right (f : Option α → β → γ) (as : List α) (bs : List β) : Li
 -- TODO: naming is awkward...
 /-- Asynchronous version of `List.map`.
 -/
-def map_async_chunked {α β} (f : α → β) (xs : List α) (chunk_size := 1024) : List β :=
+def mapAsyncChunked {α β} (f : α → β) (xs : List α) (chunk_size := 1024) : List β :=
   ((xs.toChunks chunk_size).map fun xs => Task.spawn fun _ => List.map f xs).bind Task.get
 #align list.map_async_chunked List.map_async_chunked
 

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -271,7 +271,7 @@ local infixl:50 " ≺ " => InvImage (Prod.Lex (· < ·) (· < ·)) meas
 /-- A recursor for pairs of lists. To have `C l₁ l₂` for all `l₁`, `l₂`, it suffices to have it for
 `l₂ = []` and to be able to pour the elements of `l₁` into `l₂`. -/
 @[elab_as_elim]
-def PermutationsAux.rec {C : List α → List α → Sort v} (H0 : ∀ is, C [] is)
+def permutationsAux.rec {C : List α → List α → Sort v} (H0 : ∀ is, C [] is)
     (H1 : ∀ t ts is, C ts (t :: is) → C is [] → C (t :: ts) is) : ∀ l₁ l₂, C l₁ l₂
   | [], is => H0 is
   | t :: ts, is =>

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -72,7 +72,7 @@ def prod [Mul α] [One α] : List α → α :=
 -- dependencies.
 /-- Sum of a list.
 
-     sum [a, b, c] = ((0 + a) + b) + c -/
+     `sum [a, b, c] = ((0 + a) + b) + c` -/
 def sum [Add α] [Zero α] : List α → α :=
   foldl (· + ·) 0
 #align list.sum List.sum

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -101,12 +101,6 @@ def alternatingProd {G : Type _} [One G] [Mul G] [Inv G] : List G → G
 #align list.partition_map List.partitionMap
 #align list.find List.find?
 
--- TODO: move
-@[reducible] def Functor.mapConstRev {f : Type u → Type v} [Functor f] {α β : Type u} :
-  f β → α → f α :=
-fun a b => Functor.mapConst b a
-infix:100 " $> " => Functor.mapConstRev
-
 /-- `mfind tac l` returns the first element of `l` on which `tac` succeeds, and
 fails otherwise. -/
 def findM {α} {m : Type u → Type v} [Monad m] [Alternative m] (tac : α → m PUnit) : List α → m α :=

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -452,7 +452,7 @@ def mapDiagM' {m} [Monad m] {α} (f : α → α → m Unit) : List α → m Unit
 /-- Map each element of a `List` to an action, evaluate these actions in order,
     and collect the results.
 -/
-protected def traverse {F : Type u → Type v}[Applicative F] {α β : Type _} (f : α → F β)
+protected def traverse {F : Type u → Type v} [Applicative F] {α β : Type _} (f : α → F β)
     : List α → F (List β)
   | [] => pure []
   | x :: xs => List.cons <$> f x <*> List.traverse f xs

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -45,18 +45,13 @@ instance [DecidableEq α] : SDiff (List α) :=
 /-- "default" `nth` function: returns `d` instead of `none` in the case
   that the index is out of bounds. -/
 @[nolint unusedArguments]
-def nthd (d : α) : ∀ (_ : List α) (_ : ℕ), α
+def getD' (d : α) : ∀ (_ : List α) (_ : ℕ), α
   | [], _ => d
   | x :: _, 0 => x
   | _ :: xs, n + 1 => nthd d xs n
 #align list.nthd List.nthd
 
-/-- "inhabited" `nth` function: returns `default` instead of `none` in the case
-  that the index is out of bounds. -/
-def nthI [Inhabited α] (l : List α) (n : Nat) : α :=
-  nthd default l n
-#align list.inth List.nthI
-
+#align list.inth List.getD
 #align list.modify_nth_tail List.modifyNthTail
 #align list.modify_head List.modifyHead
 #align list.modify_nth List.modifyNth


### PR DESCRIPTION
Port of `data.list.defs`, mostly consists of appropriate `#align`s to map `mathlib` `List` functions to the appropriate definitions in `Std4`

Based on 1fc36cc9c8264e6e81253f88be7fb2cb6c92d76a