### PR TITLE
[Merged by Bors] - feat: add Semigroup.to_isAssociative

### DIFF
--- a/Mathlib/Algebra/Group/Defs.lean
+++ b/Mathlib/Algebra/Group/Defs.lean
@@ -204,6 +204,11 @@ variable [CommSemigroup G]
 theorem mul_comm : ∀ a b : G, a * b = b * a :=
   CommSemigroup.mul_comm
 
+@[to_additive]
+instance CommSemigroup.to_isCommutative : IsCommutative G (· * ·) :=
+  ⟨mul_comm⟩
+#align comm_semigroup.to_is_commutative CommSemigroup.to_isCommutative
+
 /-- Any `CommSemigroup G` that satisfies `IsRightCancelMul G` also satisfies
 `IsLeftCancelMul G`. -/
 @[to_additive AddCommSemigroup.IsRightCancelAdd.to_IsLeftCancelAdd "Any

--- a/Mathlib/Algebra/Group/Defs.lean
+++ b/Mathlib/Algebra/Group/Defs.lean
@@ -175,6 +175,11 @@ variable [Semigroup G]
 theorem mul_assoc : ∀ a b c : G, a * b * c = a * (b * c) :=
   Semigroup.mul_assoc
 
+@[to_additive]
+instance Semigroup.to_isAssociative : IsAssociative G (· * ·) :=
+  ⟨mul_assoc⟩
+#align semigroup.to_is_associative Semigroup.to_isAssociative
+
 end Semigroup
 
 /-- A commutative semigroup is a type with an associative commutative `(*)`. -/


### PR DESCRIPTION
This instance was missing for some reason in Algebra.Group.Defs.