### PR TITLE
[Merged by Bors] - feat: port Algebra.Group.Ext

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -6,6 +6,7 @@ import Mathlib.Algebra.Group.Basic
 import Mathlib.Algebra.Group.Commutator
 import Mathlib.Algebra.Group.Commute
 import Mathlib.Algebra.Group.Defs
+import Mathlib.Algebra.Group.Ext
 import Mathlib.Algebra.Group.InjSurj
 import Mathlib.Algebra.Group.OrderSynonym
 import Mathlib.Algebra.Group.Semiconj

--- a/Mathlib/Algebra/Group/Ext.lean
+++ b/Mathlib/Algebra/Group/Ext.lean
@@ -1,0 +1,140 @@
+/-
+Copyright (c) 2021 Bryan Gin-ge Chen. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Bryan Gin-ge Chen, Yury Kudryashov
+-/
+import Mathlib.Algebra.Hom.Group
+
+/-!
+# Extensionality lemmas for monoid and group structures
+
+In this file we prove extensionality lemmas for `monoid` and higher algebraic structures with one
+binary operation. Extensionality lemmas for structures that are lower in the hierarchy can be found
+in `algebra.group.defs`.
+
+## Implementation details
+
+To get equality of `npow` etc, we define a monoid homomorphism between two monoid structures on the
+same type, then apply lemmas like `monoid_hom.map_div`, `monoid_hom.map_pow` etc.
+
+## Tags
+monoid, group, extensionality
+-/
+
+
+universe u
+
+@[ext, to_additive]
+theorem Monoid.ext {M : Type u} ⦃m₁ m₂ : Monoid M⦄ (h_mul : m₁.mul = m₂.mul) : m₁ = m₂ := by
+  have h₁ : (@Monoid.toMulOneClass _ m₁).one = (@Monoid.toMulOneClass _ m₂).one :=
+    congr_arg (@MulOneClass.one M) (MulOneClass.ext h_mul)
+  set f : @MonoidHom M M (@Monoid.toMulOneClass _ m₁) (@Monoid.toMulOneClass _ m₂) :=
+    { toFun := id, map_one' := h₁, map_mul' := fun x y => congr_fun (congr_fun h_mul x) y }
+  have hpow : m₁.npow = m₂.npow := by
+    ext (n x)
+    exact @MonoidHom.map_pow M M m₁ m₂ f x n
+  cases m₁
+  cases m₂
+  congr <;> assumption
+#align monoid.ext Monoid.ext
+
+@[to_additive]
+theorem CommMonoid.to_monoid_injective {M : Type u} : Function.Injective (@CommMonoid.toMonoid M) :=
+  by
+  rintro ⟨⟩ ⟨⟩ h
+  congr <;> injection h
+#align comm_monoid.to_monoid_injective CommMonoid.to_monoid_injective
+
+@[ext, to_additive]
+theorem CommMonoid.ext {M : Type _} ⦃m₁ m₂ : CommMonoid M⦄ (h_mul : m₁.mul = m₂.mul) : m₁ = m₂ :=
+  CommMonoid.to_monoid_injective <| Monoid.ext h_mul
+#align comm_monoid.ext CommMonoid.ext
+
+@[to_additive]
+theorem LeftCancelMonoid.to_monoid_injective {M : Type u} :
+    Function.Injective (@LeftCancelMonoid.toMonoid M) := by
+  rintro ⟨⟩ ⟨⟩ h
+  congr <;> injection h
+#align left_cancel_monoid.to_monoid_injective LeftCancelMonoid.to_monoid_injective
+
+@[ext, to_additive]
+theorem LeftCancelMonoid.ext {M : Type u} ⦃m₁ m₂ : LeftCancelMonoid M⦄ (h_mul : m₁.mul = m₂.mul) :
+    m₁ = m₂ :=
+  LeftCancelMonoid.to_monoid_injective <| Monoid.ext h_mul
+#align left_cancel_monoid.ext LeftCancelMonoid.ext
+
+@[to_additive]
+theorem RightCancelMonoid.to_monoid_injective {M : Type u} :
+    Function.Injective (@RightCancelMonoid.toMonoid M) := by
+  rintro ⟨⟩ ⟨⟩ h
+  congr <;> injection h
+#align right_cancel_monoid.to_monoid_injective RightCancelMonoid.to_monoid_injective
+
+@[ext, to_additive]
+theorem RightCancelMonoid.ext {M : Type u} ⦃m₁ m₂ : RightCancelMonoid M⦄ (h_mul : m₁.mul = m₂.mul) :
+    m₁ = m₂ :=
+  RightCancelMonoid.to_monoid_injective <| Monoid.ext h_mul
+#align right_cancel_monoid.ext RightCancelMonoid.ext
+
+@[to_additive]
+theorem CancelMonoid.to_left_cancel_monoid_injective {M : Type u} :
+    Function.Injective (@CancelMonoid.toLeftCancelMonoid M) := by
+  rintro ⟨⟩ ⟨⟩ h
+  congr <;> injection h
+#align cancel_monoid.to_left_cancel_monoid_injective CancelMonoid.to_left_cancel_monoid_injective
+
+@[ext, to_additive]
+theorem CancelMonoid.ext {M : Type _} ⦃m₁ m₂ : CancelMonoid M⦄ (h_mul : m₁.mul = m₂.mul) :
+    m₁ = m₂ :=
+  CancelMonoid.to_left_cancel_monoid_injective <| LeftCancelMonoid.ext h_mul
+#align cancel_monoid.ext CancelMonoid.ext
+
+@[to_additive]
+theorem CancelCommMonoid.to_comm_monoid_injective {M : Type u} :
+    Function.Injective (@CancelCommMonoid.toCommMonoid M) := by
+  rintro ⟨⟩ ⟨⟩ h
+  congr <;> injection h
+#align cancel_comm_monoid.to_comm_monoid_injective CancelCommMonoid.to_comm_monoid_injective
+
+@[ext, to_additive]
+theorem CancelCommMonoid.ext {M : Type _} ⦃m₁ m₂ : CancelCommMonoid M⦄ (h_mul : m₁.mul = m₂.mul) :
+    m₁ = m₂ :=
+  CancelCommMonoid.to_comm_monoid_injective <| CommMonoid.ext h_mul
+#align cancel_comm_monoid.ext CancelCommMonoid.ext
+
+@[ext, to_additive]
+theorem DivInvMonoid.ext {M : Type _} ⦃m₁ m₂ : DivInvMonoid M⦄ (h_mul : m₁.mul = m₂.mul)
+    (h_inv : m₁.inv = m₂.inv) : m₁ = m₂ := by
+  have h₁ : (@DivInvMonoid.toMonoid _ m₁).one = (@DivInvMonoid.toMonoid _ m₂).one :=
+    congr_arg (@Monoid.one M) (Monoid.ext h_mul)
+  set f : @MonoidHom M M (by letI := m₁ <;> infer_instance) (by letI := m₂ <;> infer_instance) :=
+    { toFun := id, map_one' := h₁, map_mul' := fun x y => congr_fun (congr_fun h_mul x) y }
+  have hpow : (@DivInvMonoid.toMonoid _ m₁).npow = (@DivInvMonoid.toMonoid _ m₂).npow :=
+    congr_arg (@Monoid.npow M) (Monoid.ext h_mul)
+  have hzpow : m₁.zpow = m₂.zpow := by
+    ext (m x)
+    exact @MonoidHom.map_zpow' M M m₁ m₂ f (congr_fun h_inv) x m
+  have hdiv : m₁.div = m₂.div := by
+    ext (a b)
+    exact @map_div' M M _ m₁ m₂ _ f (congr_fun h_inv) a b
+  cases m₁
+  cases m₂
+  congr
+  exacts[h_mul, h₁, hpow, h_inv, hdiv, hzpow]
+#align div_inv_monoid.ext DivInvMonoid.ext
+
+@[ext, to_additive]
+theorem Group.ext {G : Type _} ⦃g₁ g₂ : Group G⦄ (h_mul : g₁.mul = g₂.mul) : g₁ = g₂ := by
+  set f :=
+    @MonoidHom.mk' G G (by letI := g₁ <;> infer_instance) g₂ id fun a b =>
+      congr_fun (congr_fun h_mul a) b
+  exact
+    Group.to_div_inv_monoid_injective
+      (DivInvMonoid.ext h_mul
+        (funext <| @MonoidHom.map_inv G G g₁ (@Group.toDivisionMonoid _ g₂) f))
+#align group.ext Group.ext
+
+@[ext, to_additive]
+theorem CommGroup.ext {G : Type _} ⦃g₁ g₂ : CommGroup G⦄ (h_mul : g₁.mul = g₂.mul) : g₁ = g₂ :=
+  CommGroup.to_group_injective <| Group.ext h_mul
+#align comm_group.ext CommGroup.ext

--- a/Mathlib/Algebra/Group/Ext.lean
+++ b/Mathlib/Algebra/Group/Ext.lean
@@ -105,8 +105,6 @@ theorem CancelCommMonoid.ext {M : Type _} ⦃m₁ m₂ : CancelCommMonoid M⦄ (
   CancelCommMonoid.toCommMonoid_injective <| CommMonoid.ext h_mul
 #align cancel_comm_monoid.ext CancelCommMonoid.ext
 
--- set_option pp.all true
-
 @[ext, to_additive]
 theorem DivInvMonoid.ext {M : Type _} ⦃m₁ m₂ : DivInvMonoid M⦄ (h_mul : m₁.mul = m₂.mul)
   (h_inv : m₁.inv = m₂.inv) : m₁ = m₂ := by

--- a/Mathlib/Algebra/Group/Ext.lean
+++ b/Mathlib/Algebra/Group/Ext.lean
@@ -110,20 +110,19 @@ theorem CancelCommMonoid.ext {M : Type _} ⦃m₁ m₂ : CancelCommMonoid M⦄ (
 theorem DivInvMonoid.ext {M : Type _} ⦃m₁ m₂ : DivInvMonoid M⦄ (h_mul : m₁.mul = m₂.mul)
   (h_inv : m₁.inv = m₂.inv) : m₁ = m₂ := by
   have := Monoid.ext h_mul
-  have h₁ : m₁.one = m₂.one := by rw [this]
+  have h₁ : m₁.one = m₂.one := congr_arg (·.one) this
   let f : @MonoidHom M M m₁.toMulOneClass m₂.toMulOneClass :=
     @MonoidHom.mk _ _ (_) _ (@OneHom.mk _ _ (_) _ id h₁)
       (fun x y => congr_fun (congr_fun h_mul x) y)
-  have hpow : (@DivInvMonoid.toMonoid _ m₁).npow = (@DivInvMonoid.toMonoid _ m₂).npow :=
-    congr_arg (@Monoid.npow M) (Monoid.ext h_mul)
+  have hpow : m₁.npow = m₂.npow := congr_arg (·.npow) (Monoid.ext h_mul)
   have hzpow : m₁.zpow = m₂.zpow := by
     ext (m x)
     exact @MonoidHom.map_zpow' M M m₁ m₂ f (congr_fun h_inv) x m
   have hdiv : m₁.div = m₂.div := by
     ext (a b)
-    exact @map_div' M M
-      (@MonoidHom M M m₁.toMulOneClass m₂.toMulOneClass) m₁ m₂
-      (@MonoidHom.monoidHomClass M M m₁.toMulOneClass m₂.toMulOneClass) f (congr_fun h_inv) a b
+    exact @map_div' _ _
+      (@MonoidHom _ _ (_) _) (_) _
+      (@MonoidHom.monoidHomClass _ _ (_) _) f (congr_fun h_inv) a b
   rcases m₁ with @⟨_, ⟨inv₁⟩, ⟨div₁⟩, _, zpow₁⟩
   rcases m₂ with @⟨_, ⟨inv₂⟩, ⟨div₂⟩, _, zpow₂⟩
   congr

--- a/Mathlib/Algebra/Group/Ext.lean
+++ b/Mathlib/Algebra/Group/Ext.lean
@@ -105,8 +105,8 @@ theorem CancelCommMonoid.ext {M : Type _} ⦃m₁ m₂ : CancelCommMonoid M⦄ (
 #align cancel_comm_monoid.ext CancelCommMonoid.ext
 
 @[ext, to_additive]
-theorem DivInvMonoid.ext {M : Type _} : ∀ ⦃m₁ m₂ : DivInvMonoid M⦄, m₁.mul = m₂.mul →
-    m₁.inv = m₂.inv → m₁ = m₂ := by
+theorem DivInvMonoid.ext {M : Type _} ⦃m₁ m₂ : DivInvMonoid M⦄ (h_mul : m₁.mul = m₂.mul)
+  (h_inv : m₁.inv = m₂.inv) : m₁ = m₂ := by
   /- have h₁ : (@DivInvMonoid.toMonoid _ m₁).one = (@DivInvMonoid.toMonoid _ m₂).one :=
     congr_arg (@Monoid.one M) (Monoid.ext h_mul)
   let f : @MonoidHom M M (by letI := m₁ <;> infer_instance) (by letI := m₂ <;> infer_instance) :=
@@ -119,26 +119,28 @@ theorem DivInvMonoid.ext {M : Type _} : ∀ ⦃m₁ m₂ : DivInvMonoid M⦄, m�
   have hdiv : m₁.div = m₂.div := by
     ext (a b)
     exact @map_div' M M _ m₁ m₂ _ f (congr_fun h_inv) a b -/
-  rintro
-    @⟨toMonoid₁, ⟨inv₁⟩, ⟨div₁⟩, div_eq_mul_inv₁, zpow₁, zpow_zero₁, zpow_succ₁, zpow_neg₁⟩
-    @⟨toMonoid₂, ⟨inv₂⟩, ⟨div₂⟩, div_eq_mul_inv₂, zpow₂, zpow_zero₂, zpow_succ₂, zpow_neg₂⟩
-    h_mul h_inv
-  have : toMonoid₁ = toMonoid₂ := Monoid.ext h_mul
-  have : toMonoid₁.one = toMonoid₂.one := by rw [this]
-  have : inv₁ = inv₂ := by exact h_inv
-  have : div₁ = div₂ := by
+  have := Monoid.ext h_mul
+  have : m₁.one = m₂.one := by rw [this]
+  have : m₁.div = m₂.div := by
     ext (a b)
-    --rw [div_eq_mul_inv₁, div_eq_mul_inv₂] -- fails
+    --rw [m₁.div_eq_mul_inv, m₂.div_eq_mul_inv] -- fails
     sorry
-  have : zpow₁ = zpow₂ := by
+  have h_zpow : m₁.zpow = m₁.zpow := by
     ext (m x)
-    sorry
+    induction' m with n n
+    · --rw [@zpow_ofNat _ m₁]
+      sorry
+    · sorry
+  rcases m₁ with @⟨_, ⟨inv₁⟩, ⟨div₁⟩, _, zpow₁⟩
+  rcases m₂ with @⟨_, ⟨inv₂⟩, ⟨div₂⟩, _, zpow₂⟩
   congr
+  · show zpow₁ = zpow₂
+    sorry
   --exacts[h_mul, h₁, hpow, h_inv, hdiv, hzpow]
 #align div_inv_monoid.ext DivInvMonoid.ext
 
 @[ext, to_additive]
-theorem Group.ext {G : Type _} : ∀ ⦃g₁ g₂ : Group G⦄, g₁.mul = g₂.mul → g₁ = g₂ := by
+theorem Group.ext {G : Type _} ⦃g₁ g₂ : Group G⦄ (h_mul : g₁.mul = g₂.mul) : g₁ = g₂ := by
   /-let f :=
     @MonoidHom.mk' G G (by letI := g₁ <;> infer_instance) g₂ id fun a b =>
       congr_fun (congr_fun h_mul a) b
@@ -146,10 +148,19 @@ theorem Group.ext {G : Type _} : ∀ ⦃g₁ g₂ : Group G⦄, g₁.mul = g₂.
     Group.to_div_inv_monoid_injective
       (DivInvMonoid.ext h_mul
         (funext <| @MonoidHom.map_inv G G g₁ (@Group.toDivisionMonoid _ g₂) f))-/
-  rintro @⟨toDivInvMonoid₁, mul_left_inv₁⟩ @⟨toDivInvMonoid₂, mul_left_inv₂⟩ h_mul
-  have : toDivInvMonoid₁.inv = toDivInvMonoid₂.inv := by
-    sorry
-  have : toDivInvMonoid₁ = toDivInvMonoid₂ := DivInvMonoid.ext h_mul this
+  --rintro @⟨toDivInvMonoid₁, mul_left_inv₁⟩ @⟨toDivInvMonoid₂, mul_left_inv₂⟩ h_mul
+  --have : toDivInvMonoid₁.inv = toDivInvMonoid₂.inv := by
+  --  sorry
+  --have : toDivInvMonoid₁ = toDivInvMonoid₂ := DivInvMonoid.ext h_mul this
+  have : g₁.inv = g₂.inv := by
+    ext g
+    rw [@inv_eq_iff_mul_eq_one _ g₁]
+    show g₁.mul g (g₂.inv g) = 1 -- lean is using hMul and not mul
+    rw [h_mul]
+    rw [@mul_inv_eq_one _ g₂]
+  have := DivInvMonoid.ext h_mul this
+  cases g₁
+  cases g₂
   congr
 #align group.ext Group.ext
 

--- a/Mathlib/Algebra/Group/Ext.lean
+++ b/Mathlib/Algebra/Group/Ext.lean
@@ -104,13 +104,16 @@ theorem CancelCommMonoid.ext {M : Type _} ⦃m₁ m₂ : CancelCommMonoid M⦄ (
   CancelCommMonoid.toCommMonoid_injective <| CommMonoid.ext h_mul
 #align cancel_comm_monoid.ext CancelCommMonoid.ext
 
+-- set_option pp.all true
+
 @[ext, to_additive]
 theorem DivInvMonoid.ext {M : Type _} ⦃m₁ m₂ : DivInvMonoid M⦄ (h_mul : m₁.mul = m₂.mul)
   (h_inv : m₁.inv = m₂.inv) : m₁ = m₂ := by
-  /- have h₁ : (@DivInvMonoid.toMonoid _ m₁).one = (@DivInvMonoid.toMonoid _ m₂).one :=
-    congr_arg (@Monoid.one M) (Monoid.ext h_mul)
-  let f : @MonoidHom M M (by letI := m₁ <;> infer_instance) (by letI := m₂ <;> infer_instance) :=
-    { toFun := id, map_one' := h₁, map_mul' := fun x y => congr_fun (congr_fun h_mul x) y }
+  have := Monoid.ext h_mul
+  have h₁ : m₁.one = m₂.one := by rw [this]
+  let f : @MonoidHom M M m₁.toMulOneClass m₂.toMulOneClass :=
+    @MonoidHom.mk _ _ (_) _ (@OneHom.mk _ _ (_) _ id h₁)
+      (fun x y => congr_fun (congr_fun h_mul x) y)
   have hpow : (@DivInvMonoid.toMonoid _ m₁).npow = (@DivInvMonoid.toMonoid _ m₂).npow :=
     congr_arg (@Monoid.npow M) (Monoid.ext h_mul)
   have hzpow : m₁.zpow = m₂.zpow := by
@@ -118,25 +121,12 @@ theorem DivInvMonoid.ext {M : Type _} ⦃m₁ m₂ : DivInvMonoid M⦄ (h_mul : 
     exact @MonoidHom.map_zpow' M M m₁ m₂ f (congr_fun h_inv) x m
   have hdiv : m₁.div = m₂.div := by
     ext (a b)
-    exact @map_div' M M _ m₁ m₂ _ f (congr_fun h_inv) a b -/
-  have := Monoid.ext h_mul
-  have : m₁.one = m₂.one := by rw [this]
-  have : m₁.div = m₂.div := by
-    ext (a b)
-    --rw [m₁.div_eq_mul_inv, m₂.div_eq_mul_inv] -- fails
-    sorry
-  have h_zpow : m₁.zpow = m₁.zpow := by
-    ext (m x)
-    induction' m with n n
-    · --rw [@zpow_ofNat _ m₁]
-      sorry
-    · sorry
+    exact @map_div' M M
+      (@MonoidHom M M m₁.toMulOneClass m₂.toMulOneClass) m₁ m₂
+      (@MonoidHom.monoidHomClass M M m₁.toMulOneClass m₂.toMulOneClass) f (congr_fun h_inv) a b
   rcases m₁ with @⟨_, ⟨inv₁⟩, ⟨div₁⟩, _, zpow₁⟩
   rcases m₂ with @⟨_, ⟨inv₂⟩, ⟨div₂⟩, _, zpow₂⟩
   congr
-  · show zpow₁ = zpow₂
-    sorry
-  --exacts[h_mul, h₁, hpow, h_inv, hdiv, hzpow]
 #align div_inv_monoid.ext DivInvMonoid.ext
 
 @[ext, to_additive]

--- a/Mathlib/Algebra/Group/Ext.lean
+++ b/Mathlib/Algebra/Group/Ext.lean
@@ -4,110 +4,112 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bryan Gin-ge Chen, Yury Kudryashov
 -/
 import Mathlib.Algebra.Hom.Group
+import Mathlib.Tactic.Basic
 
 /-!
 # Extensionality lemmas for monoid and group structures
 
-In this file we prove extensionality lemmas for `monoid` and higher algebraic structures with one
+In this file we prove extensionality lemmas for `Monoid` and higher algebraic structures with one
 binary operation. Extensionality lemmas for structures that are lower in the hierarchy can be found
-in `algebra.group.defs`.
+in `Algebra.Group.Defs`.
 
 ## Implementation details
 
 To get equality of `npow` etc, we define a monoid homomorphism between two monoid structures on the
-same type, then apply lemmas like `monoid_hom.map_div`, `monoid_hom.map_pow` etc.
+same type, then apply lemmas like `MonoidHom.map_div`, `MonoidHom.map_pow` etc.
 
 ## Tags
 monoid, group, extensionality
 -/
 
-
 universe u
 
 @[ext, to_additive]
-theorem Monoid.ext {M : Type u} ⦃m₁ m₂ : Monoid M⦄ (h_mul : m₁.mul = m₂.mul) : m₁ = m₂ := by
-  have h₁ : (@Monoid.toMulOneClass _ m₁).one = (@Monoid.toMulOneClass _ m₂).one :=
-    congr_arg (@MulOneClass.one M) (MulOneClass.ext h_mul)
-  set f : @MonoidHom M M (@Monoid.toMulOneClass _ m₁) (@Monoid.toMulOneClass _ m₂) :=
-    { toFun := id, map_one' := h₁, map_mul' := fun x y => congr_fun (congr_fun h_mul x) y }
-  have hpow : m₁.npow = m₂.npow := by
+theorem Monoid.ext {M : Type u} : ∀ ⦃m₁ m₂ : Monoid M⦄, m₁.mul = m₂.mul → m₁ = m₂ := by
+  rintro
+    @⟨@⟨⟨mul₁⟩⟩, ⟨one₁⟩, _, mul_one₁, npow₁, npow_zero₁, npow_succ₁⟩
+    @⟨@⟨⟨mul₂⟩⟩, ⟨one₂⟩, one_mul₂, _, npow₂, npow_zero₂, npow_succ₂⟩ ⟨rfl⟩
+  have : one₁ = one₂ := (one_mul₂ one₁).symm.trans (mul_one₁ one₂)
+  have : npow₁ = npow₂ := by
     ext (n x)
-    exact @MonoidHom.map_pow M M m₁ m₂ f x n
-  cases m₁
-  cases m₂
-  congr <;> assumption
+    induction' n with n IH
+    · rw [npow_zero₁, npow_zero₂, this]
+    · rw [npow_succ₁, npow_succ₂, IH]
+  congr
 #align monoid.ext Monoid.ext
 
 @[to_additive]
-theorem CommMonoid.to_monoid_injective {M : Type u} : Function.Injective (@CommMonoid.toMonoid M) :=
+theorem CommMonoid.toMonoid_injective {M : Type u} : Function.Injective (@CommMonoid.toMonoid M) :=
   by
   rintro ⟨⟩ ⟨⟩ h
-  congr <;> injection h
-#align comm_monoid.to_monoid_injective CommMonoid.to_monoid_injective
+  congr
+#align comm_monoid.to_monoid_injective CommMonoid.toMonoid_injective
 
 @[ext, to_additive]
 theorem CommMonoid.ext {M : Type _} ⦃m₁ m₂ : CommMonoid M⦄ (h_mul : m₁.mul = m₂.mul) : m₁ = m₂ :=
-  CommMonoid.to_monoid_injective <| Monoid.ext h_mul
+  CommMonoid.toMonoid_injective <| Monoid.ext h_mul
 #align comm_monoid.ext CommMonoid.ext
 
 @[to_additive]
-theorem LeftCancelMonoid.to_monoid_injective {M : Type u} :
+theorem LeftCancelMonoid.toMonoid_injective {M : Type u} :
     Function.Injective (@LeftCancelMonoid.toMonoid M) := by
-  rintro ⟨⟩ ⟨⟩ h
+  rintro @⟨@⟨⟩⟩ @⟨@⟨⟩⟩ h
   congr <;> injection h
-#align left_cancel_monoid.to_monoid_injective LeftCancelMonoid.to_monoid_injective
+#align left_cancel_monoid.to_monoid_injective LeftCancelMonoid.toMonoid_injective
 
 @[ext, to_additive]
 theorem LeftCancelMonoid.ext {M : Type u} ⦃m₁ m₂ : LeftCancelMonoid M⦄ (h_mul : m₁.mul = m₂.mul) :
     m₁ = m₂ :=
-  LeftCancelMonoid.to_monoid_injective <| Monoid.ext h_mul
+  LeftCancelMonoid.toMonoid_injective <| Monoid.ext h_mul
 #align left_cancel_monoid.ext LeftCancelMonoid.ext
 
 @[to_additive]
-theorem RightCancelMonoid.to_monoid_injective {M : Type u} :
+theorem RightCancelMonoid.toMonoid_injective {M : Type u} :
     Function.Injective (@RightCancelMonoid.toMonoid M) := by
-  rintro ⟨⟩ ⟨⟩ h
+  rintro @⟨@⟨⟩⟩ @⟨@⟨⟩⟩ h
   congr <;> injection h
-#align right_cancel_monoid.to_monoid_injective RightCancelMonoid.to_monoid_injective
+#align right_cancel_monoid.to_monoid_injective RightCancelMonoid.toMonoid_injective
 
 @[ext, to_additive]
 theorem RightCancelMonoid.ext {M : Type u} ⦃m₁ m₂ : RightCancelMonoid M⦄ (h_mul : m₁.mul = m₂.mul) :
     m₁ = m₂ :=
-  RightCancelMonoid.to_monoid_injective <| Monoid.ext h_mul
+  RightCancelMonoid.toMonoid_injective <| Monoid.ext h_mul
 #align right_cancel_monoid.ext RightCancelMonoid.ext
 
 @[to_additive]
-theorem CancelMonoid.to_left_cancel_monoid_injective {M : Type u} :
+theorem CancelMonoid.toLeftCancelMonoid_injective {M : Type u} :
     Function.Injective (@CancelMonoid.toLeftCancelMonoid M) := by
   rintro ⟨⟩ ⟨⟩ h
-  congr <;> injection h
-#align cancel_monoid.to_left_cancel_monoid_injective CancelMonoid.to_left_cancel_monoid_injective
+  congr
+#align cancel_monoid.to_left_cancel_monoid_injective CancelMonoid.toLeftCancelMonoid_injective
 
 @[ext, to_additive]
 theorem CancelMonoid.ext {M : Type _} ⦃m₁ m₂ : CancelMonoid M⦄ (h_mul : m₁.mul = m₂.mul) :
     m₁ = m₂ :=
-  CancelMonoid.to_left_cancel_monoid_injective <| LeftCancelMonoid.ext h_mul
+  CancelMonoid.toLeftCancelMonoid_injective <| LeftCancelMonoid.ext h_mul
 #align cancel_monoid.ext CancelMonoid.ext
 
 @[to_additive]
-theorem CancelCommMonoid.to_comm_monoid_injective {M : Type u} :
+theorem CancelCommMonoid.toCommMonoid_injective {M : Type u} :
     Function.Injective (@CancelCommMonoid.toCommMonoid M) := by
-  rintro ⟨⟩ ⟨⟩ h
-  congr <;> injection h
-#align cancel_comm_monoid.to_comm_monoid_injective CancelCommMonoid.to_comm_monoid_injective
+  rintro @⟨@⟨@⟨⟩⟩⟩ @⟨@⟨@⟨⟩⟩⟩ h
+  congr <;> {
+    injection h with h'
+    injection h' }
+#align cancel_comm_monoid.to_comm_monoid_injective CancelCommMonoid.toCommMonoid_injective
 
 @[ext, to_additive]
 theorem CancelCommMonoid.ext {M : Type _} ⦃m₁ m₂ : CancelCommMonoid M⦄ (h_mul : m₁.mul = m₂.mul) :
     m₁ = m₂ :=
-  CancelCommMonoid.to_comm_monoid_injective <| CommMonoid.ext h_mul
+  CancelCommMonoid.toCommMonoid_injective <| CommMonoid.ext h_mul
 #align cancel_comm_monoid.ext CancelCommMonoid.ext
 
 @[ext, to_additive]
-theorem DivInvMonoid.ext {M : Type _} ⦃m₁ m₂ : DivInvMonoid M⦄ (h_mul : m₁.mul = m₂.mul)
-    (h_inv : m₁.inv = m₂.inv) : m₁ = m₂ := by
-  have h₁ : (@DivInvMonoid.toMonoid _ m₁).one = (@DivInvMonoid.toMonoid _ m₂).one :=
+theorem DivInvMonoid.ext {M : Type _} : ∀ ⦃m₁ m₂ : DivInvMonoid M⦄, m₁.mul = m₂.mul →
+    m₁.inv = m₂.inv → m₁ = m₂ := by
+  /- have h₁ : (@DivInvMonoid.toMonoid _ m₁).one = (@DivInvMonoid.toMonoid _ m₂).one :=
     congr_arg (@Monoid.one M) (Monoid.ext h_mul)
-  set f : @MonoidHom M M (by letI := m₁ <;> infer_instance) (by letI := m₂ <;> infer_instance) :=
+  let f : @MonoidHom M M (by letI := m₁ <;> infer_instance) (by letI := m₂ <;> infer_instance) :=
     { toFun := id, map_one' := h₁, map_mul' := fun x y => congr_fun (congr_fun h_mul x) y }
   have hpow : (@DivInvMonoid.toMonoid _ m₁).npow = (@DivInvMonoid.toMonoid _ m₂).npow :=
     congr_arg (@Monoid.npow M) (Monoid.ext h_mul)
@@ -116,25 +118,42 @@ theorem DivInvMonoid.ext {M : Type _} ⦃m₁ m₂ : DivInvMonoid M⦄ (h_mul : 
     exact @MonoidHom.map_zpow' M M m₁ m₂ f (congr_fun h_inv) x m
   have hdiv : m₁.div = m₂.div := by
     ext (a b)
-    exact @map_div' M M _ m₁ m₂ _ f (congr_fun h_inv) a b
-  cases m₁
-  cases m₂
+    exact @map_div' M M _ m₁ m₂ _ f (congr_fun h_inv) a b -/
+  rintro
+    @⟨toMonoid₁, ⟨inv₁⟩, ⟨div₁⟩, div_eq_mul_inv₁, zpow₁, zpow_zero₁, zpow_succ₁, zpow_neg₁⟩
+    @⟨toMonoid₂, ⟨inv₂⟩, ⟨div₂⟩, div_eq_mul_inv₂, zpow₂, zpow_zero₂, zpow_succ₂, zpow_neg₂⟩
+    h_mul h_inv
+  have : toMonoid₁ = toMonoid₂ := Monoid.ext h_mul
+  have : toMonoid₁.one = toMonoid₂.one := by rw [this]
+  have : inv₁ = inv₂ := by exact h_inv
+  have : div₁ = div₂ := by
+    ext (a b)
+    --rw [div_eq_mul_inv₁, div_eq_mul_inv₂] -- fails
+    sorry
+  have : zpow₁ = zpow₂ := by
+    ext (m x)
+    sorry
   congr
-  exacts[h_mul, h₁, hpow, h_inv, hdiv, hzpow]
+  --exacts[h_mul, h₁, hpow, h_inv, hdiv, hzpow]
 #align div_inv_monoid.ext DivInvMonoid.ext
 
 @[ext, to_additive]
-theorem Group.ext {G : Type _} ⦃g₁ g₂ : Group G⦄ (h_mul : g₁.mul = g₂.mul) : g₁ = g₂ := by
-  set f :=
+theorem Group.ext {G : Type _} : ∀ ⦃g₁ g₂ : Group G⦄, g₁.mul = g₂.mul → g₁ = g₂ := by
+  /-let f :=
     @MonoidHom.mk' G G (by letI := g₁ <;> infer_instance) g₂ id fun a b =>
       congr_fun (congr_fun h_mul a) b
   exact
     Group.to_div_inv_monoid_injective
       (DivInvMonoid.ext h_mul
-        (funext <| @MonoidHom.map_inv G G g₁ (@Group.toDivisionMonoid _ g₂) f))
+        (funext <| @MonoidHom.map_inv G G g₁ (@Group.toDivisionMonoid _ g₂) f))-/
+  rintro @⟨toDivInvMonoid₁, mul_left_inv₁⟩ @⟨toDivInvMonoid₂, mul_left_inv₂⟩ h_mul
+  have : toDivInvMonoid₁.inv = toDivInvMonoid₂.inv := by
+    sorry
+  have : toDivInvMonoid₁ = toDivInvMonoid₂ := DivInvMonoid.ext h_mul this
+  congr
 #align group.ext Group.ext
 
 @[ext, to_additive]
 theorem CommGroup.ext {G : Type _} ⦃g₁ g₂ : CommGroup G⦄ (h_mul : g₁.mul = g₂.mul) : g₁ = g₂ :=
-  CommGroup.to_group_injective <| Group.ext h_mul
+  CommGroup.toGroup_injective <| Group.ext h_mul
 #align comm_group.ext CommGroup.ext


### PR DESCRIPTION
mathlib SHA: e574b1a4e891376b0ef974b926da39e05da12a06

Porting notes:
1. Constructing a `MonoidHom` (or `OneHom`) with ambiguous instances requires the use of the `mk` constructor and using `(_)` to disable the TC inference on the input type.
2. For the proofs of injectivity, I needed to destructure the instances further for the proofs to work. In the case of `CancelCommMonoid.toCommMonoid_injective`, I needed to nest `injection` tactics. Not sure if `injection` or `congr` should do these automatically.