### PR TITLE
feat: port algebra.order.monoid.with_zero.defs

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -36,6 +36,7 @@ import Mathlib.Algebra.Order.Monoid.Defs
 import Mathlib.Algebra.Order.Monoid.Lemmas
 import Mathlib.Algebra.Order.Monoid.MinMax
 import Mathlib.Algebra.Order.Monoid.OrderDual
+import Mathlib.Algebra.Order.Monoid.WithZero.Defs
 import Mathlib.Algebra.Order.Ring
 import Mathlib.Algebra.Order.Ring.Lemmas
 import Mathlib.Algebra.Order.Sub.Canonical

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -10,6 +10,7 @@ import Mathlib.Algebra.Group.InjSurj
 import Mathlib.Algebra.Group.OrderSynonym
 import Mathlib.Algebra.Group.Semiconj
 import Mathlib.Algebra.Group.Units
+import Mathlib.Algebra.Group.WithOne.Defs
 import Mathlib.Algebra.GroupPower.Basic
 import Mathlib.Algebra.GroupPower.Identities
 import Mathlib.Algebra.GroupPower.Lemmas

--- a/Mathlib/Algebra/Group/WithOne/Defs.lean
+++ b/Mathlib/Algebra/Group/WithOne/Defs.lean
@@ -6,7 +6,6 @@ Authors: Mario Carneiro, Johan Commelin
 import Mathlib.Order.WithBot
 import Mathlib.Algebra.Ring.Defs
 
-set_option autoImplicit true -- *TODO* remove this
 /-!
 # Adjoining a zero/one to semigroups and related algebraic structures
 
@@ -138,7 +137,6 @@ theorem ne_one_iff_exists {x : WithOne α} : x ≠ 1 ↔ ∃ a : α, ↑a = x :=
   Option.ne_none_iff_exists
 #align with_one.ne_one_iff_exists WithOne.ne_one_iff_exists
 
--- **TODO** waiting for `lift` tactic
 -- porting note : waiting for `lift` tactic
 --@[to_additive]
 --instance canLift : CanLift (WithOne α) α coe fun a => a ≠ 1 where prf a := ne_one_iff_exists.1
@@ -159,7 +157,7 @@ protected theorem cases_on {P : WithOne α → Prop} : ∀ x : WithOne α, P 1 �
   Option.casesOn
 #align with_one.cases_on WithOne.cases_on
 
--- **TODO** Is this now incorrect?
+-- porting note: in Lean 3 there was the following comment:
 -- the `show` statements in the proofs are important, because otherwise the generated lemmas
 -- `with_one.mul_one_class._proof_{1,2}` have an ill-typed statement after `with_one` is made
 -- irreducible.
@@ -167,7 +165,6 @@ protected theorem cases_on {P : WithOne α → Prop} : ∀ x : WithOne α, P 1 �
 instance [Mul α] : MulOneClass (WithOne α) where
   mul := (· * ·)
   one := 1
-  -- I can kill those `show`s, right?
   one_mul := show ∀ x : WithOne α, 1 * x = x from (Option.liftOrGet_isLeftId _).1
   mul_one := show ∀ x : WithOne α, x * 1 = x from (Option.liftOrGet_isRightId _).1
 

--- a/Mathlib/Algebra/Group/WithOne/Defs.lean
+++ b/Mathlib/Algebra/Group/WithOne/Defs.lean
@@ -185,10 +185,18 @@ theorem coe_mul [Mul α] (a b : α) : ((a * b : α) : WithOne α) = a * b :=
   rfl
 #align with_one.coe_mul WithOne.coe_mul
 
+-- porting note: in Mathlib3 `[norm_cast, to_additive]` would put the `norm_cast` attribute
+-- on the additivised declaration. At the time of writing I think this isn't true in Mathlib4
+attribute [norm_cast] WithZero.coe_add
+
 @[simp, norm_cast, to_additive]
 theorem coe_inv [Inv α] (a : α) : ((a⁻¹ : α) : WithOne α) = (a : WithOne α)⁻¹ :=
   rfl
 #align with_one.coe_inv WithOne.coe_inv
+
+-- porting note: in Mathlib3 `[norm_cast, to_additive]` would put the `norm_cast` attribute
+-- on the additivised declaration. At the time of writing I think this isn't true in Mathlib4
+attribute [norm_cast] WithZero.coe_neg
 
 end WithOne
 

--- a/Mathlib/Algebra/Group/WithOne/Defs.lean
+++ b/Mathlib/Algebra/Group/WithOne/Defs.lean
@@ -1,0 +1,391 @@
+/-
+Copyright (c) 2018 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro, Johan Commelin
+-/
+import Mathbin.Order.WithBot
+import Mathbin.Algebra.Ring.Defs
+
+/-!
+# Adjoining a zero/one to semigroups and related algebraic structures
+
+This file contains different results about adjoining an element to an algebraic structure which then
+behaves like a zero or a one. An example is adjoining a one to a semigroup to obtain a monoid. That
+this provides an example of an adjunction is proved in `algebra.category.Mon.adjunctions`.
+
+Another result says that adjoining to a group an element `zero` gives a `group_with_zero`. For more
+information about these structures (which are not that standard in informal mathematics, see
+`algebra.group_with_zero.basic`)
+-/
+
+
+universe u v w
+
+variable {α : Type u} {β : Type v} {γ : Type w}
+
+/-- Add an extra element `1` to a type -/
+@[to_additive "Add an extra element `0` to a type"]
+def WithOne (α) :=
+  Option α
+#align with_one WithOne
+
+namespace WithOne
+
+instance [Repr α] : Repr (WithZero α) :=
+  ⟨fun o =>
+    match o with
+    | none => "0"
+    | some a => "↑" ++ repr a⟩
+
+@[to_additive]
+instance [Repr α] : Repr (WithOne α) :=
+  ⟨fun o =>
+    match o with
+    | none => "1"
+    | some a => "↑" ++ repr a⟩
+
+@[to_additive]
+instance : Monad WithOne :=
+  Option.monad
+
+@[to_additive]
+instance : One (WithOne α) :=
+  ⟨none⟩
+
+@[to_additive]
+instance [Mul α] : Mul (WithOne α) :=
+  ⟨Option.liftOrGet (· * ·)⟩
+
+@[to_additive]
+instance [Inv α] : Inv (WithOne α) :=
+  ⟨fun a => Option.map Inv.inv a⟩
+
+@[to_additive]
+instance [HasInvolutiveInv α] : HasInvolutiveInv (WithOne α) :=
+  { WithOne.hasInv with
+    inv_inv := fun a =>
+      (Option.map_map _ _ _).trans <| by simp_rw [inv_comp_inv, Option.map_id, id] }
+
+@[to_additive]
+instance [Inv α] : InvOneClass (WithOne α) :=
+  { WithOne.hasOne, WithOne.hasInv with inv_one := rfl }
+
+@[to_additive]
+instance : Inhabited (WithOne α) :=
+  ⟨1⟩
+
+@[to_additive]
+instance [Nonempty α] : Nontrivial (WithOne α) :=
+  Option.nontrivial
+
+@[to_additive]
+instance : CoeTC α (WithOne α) :=
+  ⟨some⟩
+
+/-- Recursor for `with_one` using the preferred forms `1` and `↑a`. -/
+@[elab_as_elim, to_additive "Recursor for `with_zero` using the preferred forms `0` and `↑a`."]
+def recOneCoe {C : WithOne α → Sort _} (h₁ : C 1) (h₂ : ∀ a : α, C a) : ∀ n : WithOne α, C n :=
+  Option.rec h₁ h₂
+#align with_one.rec_one_coe WithOne.recOneCoe
+
+/-- Deconstruct a `x : with_one α` to the underlying value in `α`, given a proof that `x ≠ 1`. -/
+@[to_additive unzero
+      "Deconstruct a `x : with_zero α` to the underlying value in `α`, given a proof that `x ≠ 0`."]
+def unone {x : WithOne α} (hx : x ≠ 1) : α :=
+  WithBot.unbot x hx
+#align with_one.unone WithOne.unone
+
+@[simp, to_additive unzero_coe]
+theorem unone_coe {x : α} (hx : (x : WithOne α) ≠ 1) : unone hx = x :=
+  rfl
+#align with_one.unone_coe WithOne.unone_coe
+
+@[simp, to_additive coe_unzero]
+theorem coe_unone {x : WithOne α} (hx : x ≠ 1) : ↑(unone hx) = x :=
+  WithBot.coe_unbot x hx
+#align with_one.coe_unone WithOne.coe_unone
+
+@[to_additive]
+theorem some_eq_coe {a : α} : (some a : WithOne α) = ↑a :=
+  rfl
+#align with_one.some_eq_coe WithOne.some_eq_coe
+
+@[simp, to_additive]
+theorem coe_ne_one {a : α} : (a : WithOne α) ≠ (1 : WithOne α) :=
+  Option.some_ne_none a
+#align with_one.coe_ne_one WithOne.coe_ne_one
+
+@[simp, to_additive]
+theorem one_ne_coe {a : α} : (1 : WithOne α) ≠ a :=
+  coe_ne_one.symm
+#align with_one.one_ne_coe WithOne.one_ne_coe
+
+@[to_additive]
+theorem ne_one_iff_exists {x : WithOne α} : x ≠ 1 ↔ ∃ a : α, ↑a = x :=
+  Option.ne_none_iff_exists
+#align with_one.ne_one_iff_exists WithOne.ne_one_iff_exists
+
+@[to_additive]
+instance canLift : CanLift (WithOne α) α coe fun a => a ≠ 1 where prf a := ne_one_iff_exists.1
+#align with_one.can_lift WithOne.canLift
+
+@[simp, norm_cast, to_additive]
+theorem coe_inj {a b : α} : (a : WithOne α) = b ↔ a = b :=
+  Option.some_inj
+#align with_one.coe_inj WithOne.coe_inj
+
+@[elab_as_elim, to_additive]
+protected theorem cases_on {P : WithOne α → Prop} : ∀ x : WithOne α, P 1 → (∀ a : α, P a) → P x :=
+  Option.casesOn
+#align with_one.cases_on WithOne.cases_on
+
+-- the `show` statements in the proofs are important, because otherwise the generated lemmas
+-- `with_one.mul_one_class._proof_{1,2}` have an ill-typed statement after `with_one` is made
+-- irreducible.
+@[to_additive]
+instance [Mul α] : MulOneClass (WithOne
+        α) where 
+  mul := (· * ·)
+  one := 1
+  one_mul := show ∀ x : WithOne α, 1 * x = x from (Option.liftOrGet_isLeftId _).1
+  mul_one := show ∀ x : WithOne α, x * 1 = x from (Option.liftOrGet_isRightId _).1
+
+@[to_additive]
+instance [Semigroup α] : Monoid (WithOne α) :=
+  { WithOne.mulOneClass with mul_assoc := (Option.liftOrGet_isAssociative _).1 }
+
+example [Semigroup α] : @Monoid.toMulOneClass _ (@WithOne.monoid α _) = @WithOne.mulOneClass α _ :=
+  rfl
+
+@[to_additive]
+instance [CommSemigroup α] : CommMonoid (WithOne α) :=
+  { WithOne.monoid with mul_comm := (Option.liftOrGet_isCommutative _).1 }
+
+@[simp, norm_cast, to_additive]
+theorem coe_mul [Mul α] (a b : α) : ((a * b : α) : WithOne α) = a * b :=
+  rfl
+#align with_one.coe_mul WithOne.coe_mul
+
+@[simp, norm_cast, to_additive]
+theorem coe_inv [Inv α] (a : α) : ((a⁻¹ : α) : WithOne α) = a⁻¹ :=
+  rfl
+#align with_one.coe_inv WithOne.coe_inv
+
+end WithOne
+
+namespace WithZero
+
+instance [one : One α] : One (WithZero α) :=
+  { one with }
+
+@[simp, norm_cast]
+theorem coe_one [One α] : ((1 : α) : WithZero α) = 1 :=
+  rfl
+#align with_zero.coe_one WithZero.coe_one
+
+instance [Mul α] : MulZeroClass (WithZero α) :=
+  { WithZero.hasZero with mul := fun o₁ o₂ => o₁.bind fun a => Option.map (fun b => a * b) o₂,
+    zero_mul := fun a => rfl, mul_zero := fun a => by cases a <;> rfl }
+
+@[simp, norm_cast]
+theorem coe_mul {α : Type u} [Mul α] {a b : α} : ((a * b : α) : WithZero α) = a * b :=
+  rfl
+#align with_zero.coe_mul WithZero.coe_mul
+
+@[simp]
+theorem zero_mul {α : Type u} [Mul α] (a : WithZero α) : 0 * a = 0 :=
+  rfl
+#align with_zero.zero_mul WithZero.zero_mul
+
+@[simp]
+theorem mul_zero {α : Type u} [Mul α] (a : WithZero α) : a * 0 = 0 := by cases a <;> rfl
+#align with_zero.mul_zero WithZero.mul_zero
+
+instance [Mul α] : NoZeroDivisors (WithZero α) :=
+  ⟨by 
+    rintro (a | a) (b | b) h
+    exacts[Or.inl rfl, Or.inl rfl, Or.inr rfl, Option.noConfusion h]⟩
+
+instance [Semigroup α] : SemigroupWithZero (WithZero α) :=
+  { WithZero.mulZeroClass with
+    mul_assoc := fun a b c =>
+      match a, b, c with
+      | none, _, _ => rfl
+      | some a, none, _ => rfl
+      | some a, some b, none => rfl
+      | some a, some b, some c => congr_arg some (mul_assoc _ _ _) }
+
+instance [CommSemigroup α] : CommSemigroup (WithZero α) :=
+  { WithZero.semigroupWithZero with
+    mul_comm := fun a b =>
+      match a, b with
+      | none, _ => (mul_zero _).symm
+      | some a, none => rfl
+      | some a, some b => congr_arg some (mul_comm _ _) }
+
+instance [MulOneClass α] : MulZeroOneClass (WithZero α) :=
+  { WithZero.mulZeroClass, WithZero.hasOne with
+    one_mul := fun a =>
+      match a with
+      | none => rfl
+      | some a => congr_arg some <| one_mul _,
+    mul_one := fun a =>
+      match a with
+      | none => rfl
+      | some a => congr_arg some <| mul_one _ }
+
+instance [One α] [Pow α ℕ] : Pow (WithZero α) ℕ :=
+  ⟨fun x n =>
+    match x, n with
+    | none, 0 => 1
+    | none, n + 1 => 0
+    | some x, n => ↑(x ^ n)⟩
+
+@[simp, norm_cast]
+theorem coe_pow [One α] [Pow α ℕ] {a : α} (n : ℕ) : ↑(a ^ n : α) = (↑a ^ n : WithZero α) :=
+  rfl
+#align with_zero.coe_pow WithZero.coe_pow
+
+instance [Monoid α] : MonoidWithZero (WithZero α) :=
+  { WithZero.mulZeroOneClass, WithZero.semigroupWithZero with npow := fun n x => x ^ n,
+    npow_zero' := fun x =>
+      match x with
+      | none => rfl
+      | some x => congr_arg some <| pow_zero _,
+    npow_succ' := fun n x =>
+      match x with
+      | none => rfl
+      | some x => congr_arg some <| pow_succ _ _ }
+
+instance [CommMonoid α] : CommMonoidWithZero (WithZero α) :=
+  { WithZero.monoidWithZero, WithZero.commSemigroup with }
+
+/-- Given an inverse operation on `α` there is an inverse operation
+  on `with_zero α` sending `0` to `0`-/
+instance [Inv α] : Inv (WithZero α) :=
+  ⟨fun a => Option.map Inv.inv a⟩
+
+@[simp, norm_cast]
+theorem coe_inv [Inv α] (a : α) : ((a⁻¹ : α) : WithZero α) = a⁻¹ :=
+  rfl
+#align with_zero.coe_inv WithZero.coe_inv
+
+@[simp]
+theorem inv_zero [Inv α] : (0 : WithZero α)⁻¹ = 0 :=
+  rfl
+#align with_zero.inv_zero WithZero.inv_zero
+
+instance [HasInvolutiveInv α] : HasInvolutiveInv (WithZero α) :=
+  { WithZero.hasInv with
+    inv_inv := fun a =>
+      (Option.map_map _ _ _).trans <| by simp_rw [inv_comp_inv, Option.map_id, id] }
+
+instance [InvOneClass α] : InvOneClass (WithZero α) :=
+  { WithZero.hasOne, WithZero.hasInv with inv_one := show ((1⁻¹ : α) : WithZero α) = 1 by simp }
+
+instance [Div α] : Div (WithZero α) :=
+  ⟨fun o₁ o₂ => o₁.bind fun a => Option.map (fun b => a / b) o₂⟩
+
+@[norm_cast]
+theorem coe_div [Div α] (a b : α) : ↑(a / b : α) = (a / b : WithZero α) :=
+  rfl
+#align with_zero.coe_div WithZero.coe_div
+
+instance [One α] [Pow α ℤ] : Pow (WithZero α) ℤ :=
+  ⟨fun x n =>
+    match x, n with
+    | none, Int.ofNat 0 => 1
+    | none, Int.ofNat (Nat.succ n) => 0
+    | none, Int.negSucc n => 0
+    | some x, n => ↑(x ^ n)⟩
+
+@[simp, norm_cast]
+theorem coe_zpow [DivInvMonoid α] {a : α} (n : ℤ) : ↑(a ^ n : α) = (↑a ^ n : WithZero α) :=
+  rfl
+#align with_zero.coe_zpow WithZero.coe_zpow
+
+instance [DivInvMonoid α] : DivInvMonoid (WithZero α) :=
+  { WithZero.hasDiv, WithZero.hasInv, WithZero.monoidWithZero with
+    div_eq_mul_inv := fun a b =>
+      match a, b with
+      | none, _ => rfl
+      | some a, none => rfl
+      | some a, some b => congr_arg some (div_eq_mul_inv _ _),
+    zpow := fun n x => x ^ n,
+    zpow_zero' := fun x =>
+      match x with
+      | none => rfl
+      | some x => congr_arg some <| zpow_zero _,
+    zpow_succ' := fun n x =>
+      match x with
+      | none => rfl
+      | some x => congr_arg some <| DivInvMonoid.zpow_succ' _ _,
+    zpow_neg' := fun n x =>
+      match x with
+      | none => rfl
+      | some x => congr_arg some <| DivInvMonoid.zpow_neg' _ _ }
+
+instance [DivInvOneMonoid α] : DivInvOneMonoid (WithZero α) :=
+  { WithZero.divInvMonoid, WithZero.invOneClass with }
+
+instance [DivisionMonoid α] : DivisionMonoid (WithZero α) :=
+  { WithZero.divInvMonoid, WithZero.hasInvolutiveInv with
+    mul_inv_rev := fun a b =>
+      match a, b with
+      | none, none => rfl
+      | none, some b => rfl
+      | some a, none => rfl
+      | some a, some b => congr_arg some <| mul_inv_rev _ _,
+    inv_eq_of_mul := fun a b =>
+      match a, b with
+      | none, none => fun _ => rfl
+      | none, some b => by contradiction
+      | some a, none => by contradiction
+      | some a, some b => fun h =>
+        congr_arg some <| inv_eq_of_mul_eq_one_right <| Option.some_injective _ h }
+
+instance [DivisionCommMonoid α] : DivisionCommMonoid (WithZero α) :=
+  { WithZero.divisionMonoid, WithZero.commSemigroup with }
+
+section Group
+
+variable [Group α]
+
+/-- if `G` is a group then `with_zero G` is a group with zero. -/
+instance : GroupWithZero (WithZero α) :=
+  { WithZero.monoidWithZero, WithZero.divInvMonoid, WithZero.nontrivial with inv_zero := inv_zero,
+    mul_inv_cancel := fun a ha => by 
+      lift a to α using ha
+      norm_cast
+      apply mul_right_inv }
+
+end Group
+
+instance [CommGroup α] : CommGroupWithZero (WithZero α) :=
+  { WithZero.groupWithZero, WithZero.commMonoidWithZero with }
+
+instance [AddMonoidWithOne α] : AddMonoidWithOne (WithZero α) :=
+  { WithZero.addMonoid, WithZero.hasOne with natCast := fun n => if n = 0 then 0 else (n.cast : α),
+    nat_cast_zero := rfl,
+    nat_cast_succ := fun n => by 
+      cases n
+      show (((1 : ℕ) : α) : WithZero α) = 0 + 1; · rw [Nat.cast_one, coe_one, zero_add]
+      show (((n + 2 : ℕ) : α) : WithZero α) = ((n + 1 : ℕ) : α) + 1
+      · rw [Nat.cast_succ, coe_add, coe_one] }
+
+instance [Semiring α] : Semiring (WithZero α) :=
+  { WithZero.addMonoidWithOne, WithZero.addCommMonoid, WithZero.mulZeroClass,
+    WithZero.monoidWithZero with
+    left_distrib := fun a b c => by 
+      cases' a with a; · rfl
+      cases' b with b <;> cases' c with c <;> try rfl
+      exact congr_arg some (left_distrib _ _ _),
+    right_distrib := fun a b c => by 
+      cases' c with c
+      · change (a + b) * 0 = a * 0 + b * 0
+        simp
+      cases' a with a <;> cases' b with b <;> try rfl
+      exact congr_arg some (right_distrib _ _ _) }
+
+end WithZero
+

--- a/Mathlib/Algebra/Group/WithOne/Defs.lean
+++ b/Mathlib/Algebra/Group/WithOne/Defs.lean
@@ -78,7 +78,7 @@ instance : Inhabited (WithOne α) :=
 instance [Nonempty α] : Nontrivial (WithOne α) :=
   Option.nontrivial
 
--- porting note: this new declaration is here to make `(a : WithOne α)` have type `WithOne α` ;
+-- porting note: this new declaration is here to make `((a : α): WithOne α)` have type `WithOne α` ;
 -- otherwise the coercion kicks in and it becomes `Option.some a : WithOne α` which
 -- becomes `Option.some a : Option α`.
 /-- The canonical map from `α` into `WithOne α` -/
@@ -86,6 +86,8 @@ instance [Nonempty α] : Nontrivial (WithOne α) :=
 def coe : α → WithOne α :=
   Option.some
 
+-- porting note : `@[coe, to_additive]` doesn't tag the to-additivised declaration
+-- with coe, in contrast to Lean 3, so we have to do it manually.
 attribute [coe] WithZero.coe
 
 @[to_additive]
@@ -222,13 +224,12 @@ theorem coe_mul {α : Type u} [Mul α] {a b : α} : ((a * b : α) : WithZero α)
 #align with_zero.coe_mul WithZero.coe_mul
 
 -- porting note: this used to be `@[simp]` in Lean 3 but in Lean 4 `simp` can already
--- prove it
+-- prove it because we've just proved we're in MulZeroClass.
 theorem zero_mul {α : Type u} [Mul α] (a : WithZero α) : 0 * a = 0 :=
   rfl
 #align with_zero.zero_mul WithZero.zero_mul
 
 -- porting note: in Lean 3 this was `@[simp]` but in Lean 4 `simp` can already prove it.
---@[simp]
 theorem mul_zero {α : Type u} [Mul α] (a : WithZero α) : a * 0 = 0 := by cases a <;> rfl
 #align with_zero.mul_zero WithZero.mul_zero
 

--- a/Mathlib/Algebra/Order/Monoid/WithZero/Defs.lean
+++ b/Mathlib/Algebra/Order/Monoid/WithZero/Defs.lean
@@ -3,8 +3,8 @@ Copyright (c) 2016 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro, Johannes Hölzl
 -/
-import Mathbin.Algebra.Group.WithOne.Defs
-import Mathbin.Algebra.Order.Monoid.Canonical.Defs
+import Mathlib.Algebra.Group.WithOne.Defs
+import Mathlib.Algebra.Order.Monoid.Canonical.Defs
 
 /-!
 # Adjoining a zero element to an ordered monoid.

--- a/Mathlib/Algebra/Order/Monoid/WithZero/Defs.lean
+++ b/Mathlib/Algebra/Order/Monoid/WithZero/Defs.lean
@@ -1,0 +1,225 @@
+/-
+Copyright (c) 2016 Jeremy Avigad. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro, Johannes Hölzl
+-/
+import Mathbin.Algebra.Group.WithOne.Defs
+import Mathbin.Algebra.Order.Monoid.Canonical.Defs
+
+/-!
+# Adjoining a zero element to an ordered monoid.
+-/
+
+
+open Function
+
+universe u
+
+variable {α : Type u}
+
+/-- Typeclass for expressing that the `0` of a type is less or equal to its `1`. -/
+class ZeroLeOneClass (α : Type _) [Zero α] [One α] [LE α] where
+  zero_le_one : (0 : α) ≤ 1
+#align zero_le_one_class ZeroLeOneClass
+
+/-- A linearly ordered commutative monoid with a zero element. -/
+class LinearOrderedCommMonoidWithZero (α : Type _) extends LinearOrderedCommMonoid α,
+  CommMonoidWithZero α where
+  zero_le_one : (0 : α) ≤ 1
+#align linear_ordered_comm_monoid_with_zero LinearOrderedCommMonoidWithZero
+
+instance (priority := 100) LinearOrderedCommMonoidWithZero.toZeroLeOneClass
+    [LinearOrderedCommMonoidWithZero α] : ZeroLeOneClass α :=
+  { ‹LinearOrderedCommMonoidWithZero α› with }
+#align
+  linear_ordered_comm_monoid_with_zero.to_zero_le_one_class LinearOrderedCommMonoidWithZero.toZeroLeOneClass
+
+instance (priority := 100) CanonicallyOrderedAddMonoid.toZeroLeOneClass
+    [CanonicallyOrderedAddMonoid α] [One α] : ZeroLeOneClass α :=
+  ⟨zero_le 1⟩
+#align
+  canonically_ordered_add_monoid.to_zero_le_one_class CanonicallyOrderedAddMonoid.toZeroLeOneClass
+
+/-- `zero_le_one` with the type argument implicit. -/
+@[simp]
+theorem zero_le_one [Zero α] [One α] [LE α] [ZeroLeOneClass α] : (0 : α) ≤ 1 :=
+  ZeroLeOneClass.zero_le_one
+#align zero_le_one zero_le_one
+
+/-- `zero_le_one` with the type argument explicit. -/
+theorem zero_le_one' (α) [Zero α] [One α] [LE α] [ZeroLeOneClass α] : (0 : α) ≤ 1 :=
+  zero_le_one
+#align zero_le_one' zero_le_one'
+
+theorem zero_le_two [Preorder α] [One α] [AddZeroClass α] [ZeroLeOneClass α]
+    [CovariantClass α α (· + ·) (· ≤ ·)] : (0 : α) ≤ 2 :=
+  add_nonneg zero_le_one zero_le_one
+#align zero_le_two zero_le_two
+
+theorem zero_le_three [Preorder α] [One α] [AddZeroClass α] [ZeroLeOneClass α]
+    [CovariantClass α α (· + ·) (· ≤ ·)] : (0 : α) ≤ 3 :=
+  add_nonneg zero_le_two zero_le_one
+#align zero_le_three zero_le_three
+
+theorem zero_le_four [Preorder α] [One α] [AddZeroClass α] [ZeroLeOneClass α]
+    [CovariantClass α α (· + ·) (· ≤ ·)] : (0 : α) ≤ 4 :=
+  add_nonneg zero_le_two zero_le_two
+#align zero_le_four zero_le_four
+
+theorem one_le_two [LE α] [One α] [AddZeroClass α] [ZeroLeOneClass α]
+    [CovariantClass α α (· + ·) (· ≤ ·)] : (1 : α) ≤ 2 :=
+  calc
+    1 = 1 + 0 := (add_zero 1).symm
+    _ ≤ 1 + 1 := add_le_add_left zero_le_one _
+    
+#align one_le_two one_le_two
+
+theorem one_le_two' [LE α] [One α] [AddZeroClass α] [ZeroLeOneClass α]
+    [CovariantClass α α (swap (· + ·)) (· ≤ ·)] : (1 : α) ≤ 2 :=
+  calc
+    1 = 0 + 1 := (zero_add 1).symm
+    _ ≤ 1 + 1 := add_le_add_right zero_le_one _
+    
+#align one_le_two' one_le_two'
+
+namespace WithZero
+
+attribute [local semireducible] WithZero
+
+instance [Preorder α] : Preorder (WithZero α) :=
+  WithBot.preorder
+
+instance [PartialOrder α] : PartialOrder (WithZero α) :=
+  WithBot.partialOrder
+
+instance [Preorder α] : OrderBot (WithZero α) :=
+  WithBot.orderBot
+
+theorem zero_le [Preorder α] (a : WithZero α) : 0 ≤ a :=
+  bot_le
+#align with_zero.zero_le WithZero.zero_le
+
+theorem zero_lt_coe [Preorder α] (a : α) : (0 : WithZero α) < a :=
+  WithBot.bot_lt_coe a
+#align with_zero.zero_lt_coe WithZero.zero_lt_coe
+
+theorem zero_eq_bot [Preorder α] : (0 : WithZero α) = ⊥ :=
+  rfl
+#align with_zero.zero_eq_bot WithZero.zero_eq_bot
+
+@[simp, norm_cast]
+theorem coe_lt_coe [Preorder α] {a b : α} : (a : WithZero α) < b ↔ a < b :=
+  WithBot.coe_lt_coe
+#align with_zero.coe_lt_coe WithZero.coe_lt_coe
+
+@[simp, norm_cast]
+theorem coe_le_coe [Preorder α] {a b : α} : (a : WithZero α) ≤ b ↔ a ≤ b :=
+  WithBot.coe_le_coe
+#align with_zero.coe_le_coe WithZero.coe_le_coe
+
+instance [Lattice α] : Lattice (WithZero α) :=
+  WithBot.lattice
+
+instance [LinearOrder α] : LinearOrder (WithZero α) :=
+  WithBot.linearOrder
+
+instance covariant_class_mul_le {α : Type u} [Mul α] [Preorder α]
+    [CovariantClass α α (· * ·) (· ≤ ·)] :
+    CovariantClass (WithZero α) (WithZero α) (· * ·) (· ≤ ·) := by
+  refine' ⟨fun a b c hbc => _⟩
+  induction a using WithZero.recZeroCoe; · exact zero_le _
+  induction b using WithZero.recZeroCoe; · exact zero_le _
+  rcases WithBot.coe_le_iff.1 hbc with ⟨c, rfl, hbc'⟩
+  rw [← coe_mul, ← coe_mul, coe_le_coe]
+  exact mul_le_mul_left' hbc' a
+#align with_zero.covariant_class_mul_le WithZero.covariant_class_mul_le
+
+@[simp]
+theorem le_max_iff [LinearOrder α] {a b c : α} : (a : WithZero α) ≤ max b c ↔ a ≤ max b c := by
+  simp only [WithZero.coe_le_coe, le_max_iff]
+#align with_zero.le_max_iff WithZero.le_max_iff
+
+@[simp]
+theorem min_le_iff [LinearOrder α] {a b c : α} : min (a : WithZero α) b ≤ c ↔ min a b ≤ c := by
+  simp only [WithZero.coe_le_coe, min_le_iff]
+#align with_zero.min_le_iff WithZero.min_le_iff
+
+instance [OrderedCommMonoid α] : OrderedCommMonoid (WithZero α) :=
+  { WithZero.commMonoidWithZero, WithZero.partialOrder with
+    mul_le_mul_left := fun _ _ => mul_le_mul_left' }
+
+protected theorem covariant_class_add_le [AddZeroClass α] [Preorder α]
+    [CovariantClass α α (· + ·) (· ≤ ·)] (h : ∀ a : α, 0 ≤ a) :
+    CovariantClass (WithZero α) (WithZero α) (· + ·) (· ≤ ·) := by
+  refine' ⟨fun a b c hbc => _⟩
+  induction a using WithZero.recZeroCoe
+  · rwa [zero_add, zero_add]
+  induction b using WithZero.recZeroCoe
+  · rw [add_zero]
+    induction c using WithZero.recZeroCoe
+    · rw [add_zero]
+      exact le_rfl
+    · rw [← coe_add, coe_le_coe]
+      exact le_add_of_nonneg_right (h _)
+  · rcases WithBot.coe_le_iff.1 hbc with ⟨c, rfl, hbc'⟩
+    rw [← coe_add, ← coe_add, coe_le_coe]
+    exact add_le_add_left hbc' a
+#align with_zero.covariant_class_add_le WithZero.covariant_class_add_le
+
+/-
+Note 1 : the below is not an instance because it requires `zero_le`. It seems
+like a rather pathological definition because α already has a zero.
+Note 2 : there is no multiplicative analogue because it does not seem necessary.
+Mathematicians might be more likely to use the order-dual version, where all
+elements are ≤ 1 and then 1 is the top element.
+-/
+/-- If `0` is the least element in `α`, then `with_zero α` is an `ordered_add_comm_monoid`.
+See note [reducible non-instances].
+-/
+@[reducible]
+protected def orderedAddCommMonoid [OrderedAddCommMonoid α] (zero_le : ∀ a : α, 0 ≤ a) :
+    OrderedAddCommMonoid (WithZero α) :=
+  { WithZero.partialOrder, WithZero.addCommMonoid with
+    add_le_add_left := @add_le_add_left _ _ _ (WithZero.covariant_class_add_le zero_le).. }
+#align with_zero.ordered_add_comm_monoid WithZero.orderedAddCommMonoid
+
+end WithZero
+
+section CanonicallyOrderedMonoid
+
+instance WithZero.has_exists_add_of_le {α} [Add α] [Preorder α] [HasExistsAddOfLe α] :
+    HasExistsAddOfLe (WithZero α) :=
+  ⟨fun a b => by 
+    apply WithZero.cases_on a
+    · exact fun _ => ⟨b, (zero_add b).symm⟩
+    apply WithZero.cases_on b
+    · exact fun b' h => (WithBot.not_coe_le_bot _ h).elim
+    rintro a' b' h
+    obtain ⟨c, rfl⟩ := exists_add_of_le (WithZero.coe_le_coe.1 h)
+    exact ⟨c, rfl⟩⟩
+#align with_zero.has_exists_add_of_le WithZero.has_exists_add_of_le
+
+-- This instance looks absurd: a monoid already has a zero
+/-- Adding a new zero to a canonically ordered additive monoid produces another one. -/
+instance WithZero.canonicallyOrderedAddMonoid {α : Type u} [CanonicallyOrderedAddMonoid α] :
+    CanonicallyOrderedAddMonoid (WithZero α) :=
+  { WithZero.orderBot, WithZero.orderedAddCommMonoid zero_le, WithZero.has_exists_add_of_le with
+    le_self_add := fun a b => by 
+      apply WithZero.cases_on a
+      · exact bot_le
+      apply WithZero.cases_on b
+      · exact fun b' => le_rfl
+      · exact fun a' b' => WithZero.coe_le_coe.2 le_self_add }
+#align with_zero.canonically_ordered_add_monoid WithZero.canonicallyOrderedAddMonoid
+
+end CanonicallyOrderedMonoid
+
+section CanonicallyLinearOrderedMonoid
+
+instance WithZero.canonicallyLinearOrderedAddMonoid (α : Type _)
+    [CanonicallyLinearOrderedAddMonoid α] : CanonicallyLinearOrderedAddMonoid (WithZero α) :=
+  { WithZero.canonicallyOrderedAddMonoid, WithZero.linearOrder with }
+#align with_zero.canonically_linear_ordered_add_monoid WithZero.canonicallyLinearOrderedAddMonoid
+
+end CanonicallyLinearOrderedMonoid
+


### PR DESCRIPTION
Tracking mathlib commit: [dad7ecf9a1feae63e6e49f07619b7087403fb8d4](https://github.com/leanprover-community/mathlib/commit/dad7ecf9a1feae63e6e49f07619b7087403fb8d4)

- [x] depends on #841