### PR TITLE
[Merged by Bors] - feat(Combinatorics/Quiver/Basic): Add comp_id and id_comp lemmas for prefunctors

### DIFF
--- a/Mathlib/Combinatorics/Quiver/Basic.lean
+++ b/Mathlib/Combinatorics/Quiver/Basic.lean
@@ -96,6 +96,18 @@ def comp {U : Type _} [Quiver U] {V : Type _} [Quiver V] {W : Type _} [Quiver W]
 #align prefunctor.comp Prefunctor.comp
 
 @[simp]
+theorem comp_id {U V : Type _} [Quiver U] [Quiver V] (F : Prefunctor U V) :
+    F.comp (id _) = F := by
+  cases F; rfl
+#align prefunctor.comp_id Prefunctor.comp_id
+
+@[simp]
+theorem id_comp {U V : Type _} [Quiver U] [Quiver V] (F : Prefunctor U V) :
+    (id _).comp F = F := by
+  cases F; rfl
+#align prefunctor.id_comp Prefunctor.id_comp
+
+@[simp]
 theorem comp_assoc {U V W Z : Type _} [Quiver U] [Quiver V] [Quiver W] [Quiver Z]
     (F : Prefunctor U V) (G : Prefunctor V W) (H : Prefunctor W Z) :
     (F.comp G).comp H = F.comp (G.comp H) :=


### PR DESCRIPTION
In order to synchronize with [mathlib#17617](https://github.com/leanprover-community/mathlib/pull/17617).