### PR TITLE
[Merged by Bors] - chore: refactor is_domain to allow semirings

### DIFF
--- a/Mathlib/Algebra/Ring/Defs.lean
+++ b/Mathlib/Algebra/Ring/Defs.lean
@@ -446,12 +446,12 @@ instance (priority := 100) CommRing.toNonUnitalCommRing [s : CommRing α] : NonU
   { s with }
 #align comm_ring.to_non_unital_comm_ring CommRing.toNonUnitalCommRing
 
-/-- A domain is a nontrivial ring such multiplication by a non zero element is cancellative,
-  on both sides. In other words, a nontrivial ring `R` satisfying
+/-- A domain is a nontrivial semiring such multiplication by a non zero element is cancellative,
+  on both sides. In other words, a nontrivial semiring `R` satisfying
   `∀ {a b c : R}, a ≠ 0 → a * b = a * c → b = c` and
   `∀ {a b c : R}, b ≠ 0 → a * b = c * b → a = c`.
 
-  This is implemented as a mixin for `Ring α`.
+  This is implemented as a mixin for `Semiring α`.
   To obtain an integral domain use `[CommRing α] [IsDomain α]`. -/
-class IsDomain (α : Type u) [Ring α] extends IsCancelMulZero α, Nontrivial α : Prop
+class IsDomain (α : Type u) [Semiring α] extends IsCancelMulZero α, Nontrivial α : Prop
 #align is_domain IsDomain


### PR DESCRIPTION
We refactor `is_domain` to allow semirings.

Corresponding mathlib PR [#17831](https://github.com/leanprover-community/mathlib/pull/17831).