### PR TITLE
[Merged by Bors] - feat: log warning for unused names in `split_ifs with`

### DIFF
--- a/Mathlib/Data/Nat/PSub.lean
+++ b/Mathlib/Data/Nat/PSub.lean
@@ -118,7 +118,7 @@ def psub' (m n : ℕ) : Option ℕ :=
 
 theorem psub'_eq_psub (m n) : psub' m n = psub m n := by
   rw [psub']
-  split_ifs with h h
+  split_ifs with h
   exact (psub_eq_sub h).symm
   exact (psub_eq_none.2 (not_le.1 h)).symm
 #align nat.psub'_eq_psub Nat.psub'_eq_psub

--- a/Mathlib/Order/Heyting/Basic.lean
+++ b/Mathlib/Order/Heyting/Basic.lean
@@ -1187,14 +1187,14 @@ def LinearOrder.toBiheytingAlgebra [LinearOrder α] [BoundedOrder α] : Biheytin
     compl := fun a => if a = ⊥ then ⊤ else ⊥,
     le_himp_iff := fun a b c => by
       change _ ≤ ite _ _ _ ↔ _
-      split_ifs with h h
+      split_ifs with h
       · exact iff_of_true le_top (inf_le_of_right_le h)
       · rw [inf_le_iff, or_iff_left h],
     himp_bot := fun a => if_congr le_bot_iff rfl rfl, sdiff := fun a b => if a ≤ b then ⊥ else a,
     hnot := fun a => if a = ⊤ then ⊥ else ⊤,
     sdiff_le_iff := fun a b c => by
       change ite _ _ _ ≤ _ ↔ _
-      split_ifs with h h
+      split_ifs with h
       · exact iff_of_true bot_le (le_sup_of_le_left h)
       · rw [le_sup_iff, or_iff_right h],
     top_sdiff := fun a => if_congr top_le_iff rfl rfl }

--- a/Mathlib/Tactic/SplitIfs.lean
+++ b/Mathlib/Tactic/SplitIfs.lean
@@ -50,7 +50,7 @@ match loc with
 /-- Finds an if condition to split. If successful, returns the position and the condition.
 -/
 private def findIfCondAt (loc : Location) : TacticM (Option (SplitPosition × Expr)) := do
-  for (pos, e) in  (← getSplitCandidates loc) do
+  for (pos, e) in (← getSplitCandidates loc) do
     if let some cond := SplitIf.findIfToSplit? e
     then return some (pos, cond)
   return none
@@ -88,10 +88,13 @@ private def splitIf1 (cond: Expr) (hName : Name) (loc : Location) : TacticM Unit
 /-- Pops off the front of the list of names, or generates a fresh name if the
 list is empty.
 -/
-private def getNextName (hNames: IO.Ref (List Name)) : MetaM Name := do
+private def getNextName (hNames: IO.Ref (List (TSyntax `Lean.binderIdent))) : MetaM Name := do
   match ←hNames.get with
   | [] => mkFreshUserName `h
-  | n::ns => do hNames.set ns; pure n
+  | n::ns => do hNames.set ns
+                if let `(binderIdent| $x:ident) := n
+                then pure x.getId
+                else pure `_
 
 /-- Returns `true` if the condition or its negation already appears as a hypothesis.
 -/
@@ -104,8 +107,10 @@ private def valueKnown (cond : Expr) : TacticM Bool := do
 /-- Main loop of split_ifs. Pulls names for new hypotheses from `hNames`.
 Stops if it encounters a condition in the passed-in `List Expr`.
 -/
-private partial def splitIfsCore (loc : Location) (hNames : IO.Ref (List Name)) :
-  List Expr → TacticM Unit := fun done ↦ withMainContext do
+private partial def splitIfsCore
+    (loc : Location)
+    (hNames : IO.Ref (List (TSyntax `Lean.binderIdent))) :
+    List Expr → TacticM Unit := fun done ↦ withMainContext do
   let some (_,cond) ← findIfCondAt loc
       | Meta.throwTacticEx `split_ifs (←getMainGoal) "no if-the-else conditions to split"
 
@@ -118,6 +123,7 @@ private partial def splitIfsCore (loc : Location) (hNames : IO.Ref (List Name)) 
     tac_and_then (reduceIfsAt loc) (splitIfsCore loc hNames (cond::done) <|> pure ())
   else do
     let hName ← getNextName hNames
+    dbg_trace "hName = {hName}"
     tac_and_then (splitIf1 cond hName loc) ((splitIfsCore loc hNames (cond::done)) <|> pure ())
 
 /-- Splits all if-then-else-expressions into multiple goals.
@@ -138,9 +144,9 @@ elab_rules : tactic
   | some loc => expandLocation loc
   let names := match withArg with
   | none => []
-  | some args => args.map (λ s => if let `(binderIdent| $x:ident) := s
-                                  then x.getId
-                                  else `_) |>.toList
+  | some args => args.toList
   withMainContext do
     let names ← IO.mkRef names
     splitIfsCore loc names []
+    for name in ← names.get do
+      logWarningAt name m!"unused name: {name}"


### PR DESCRIPTION
When `split_ifs with` splits a single if-then-else, it only consumes a single name (this matches the mathlib3 behavior). I noticed some places where we seem to be assuming that it consumes a separate name for each branch. To avoid that kind of confusion in the future, this PR adds a warning for any unused names.