### PR TITLE
[Merged by Bors] - port: Algebra.Order.Monoid.NatCast

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -43,6 +43,7 @@ import Mathlib.Algebra.Order.Monoid.Canonical.Defs
 import Mathlib.Algebra.Order.Monoid.Defs
 import Mathlib.Algebra.Order.Monoid.Lemmas
 import Mathlib.Algebra.Order.Monoid.MinMax
+import Mathlib.Algebra.Order.Monoid.NatCast
 import Mathlib.Algebra.Order.Monoid.OrderDual
 import Mathlib.Algebra.Order.Monoid.WithZero.Basic
 import Mathlib.Algebra.Order.Monoid.WithZero.Defs
@@ -50,6 +51,7 @@ import Mathlib.Algebra.Order.Ring
 import Mathlib.Algebra.Order.Ring.Lemmas
 import Mathlib.Algebra.Order.Sub.Canonical
 import Mathlib.Algebra.Order.Sub.Defs
+import Mathlib.Algebra.Order.ZeroLEOne
 import Mathlib.Algebra.PEmptyInstances
 import Mathlib.Algebra.Quotient
 import Mathlib.Algebra.Regular.Basic

--- a/Mathlib/Algebra/Order/Monoid/NatCast.lean
+++ b/Mathlib/Algebra/Order/Monoid/NatCast.lean
@@ -1,0 +1,95 @@
+/-
+Copyright (c) 2016 Jeremy Avigad. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro, Johannes Hölzl, Yuyang Zhao
+-/
+import Mathlib.Algebra.Order.Monoid.Lemmas
+import Mathlib.Algebra.Order.ZeroLEOne
+import Mathlib.Data.Nat.Cast.Defs
+
+/-!
+# Order of numerals in an `AddMonoidWithOne`.
+-/
+
+variable {α : Type _}
+
+open Function
+
+lemma lt_add_one [One α] [AddZeroClass α] [PartialOrder α] [ZeroLEOneClass α]
+  [NeZero (1 : α)] [CovariantClass α α (·+·) (·<·)] (a : α) : a < a + 1 :=
+lt_add_of_pos_right _ zero_lt_one
+
+lemma lt_one_add [One α] [AddZeroClass α] [PartialOrder α] [ZeroLEOneClass α]
+  [NeZero (1 : α)] [CovariantClass α α (swap (·+·)) (·<·)] (a : α) : a < 1 + a :=
+lt_add_of_pos_left _ zero_lt_one
+
+variable [AddMonoidWithOne α]
+
+lemma zero_le_two [Preorder α] [ZeroLEOneClass α] [CovariantClass α α (·+·) (·≤·)] :
+    (0 : α) ≤ 2 := by
+  rw [← one_add_one_eq_two]
+  exact add_nonneg zero_le_one zero_le_one
+
+lemma zero_le_three [Preorder α] [ZeroLEOneClass α] [CovariantClass α α (·+·) (·≤·)] :
+  (0 : α) ≤ 3 := by
+  rw [← two_add_one_eq_three]
+  exact add_nonneg zero_le_two zero_le_one
+
+lemma zero_le_four [Preorder α] [ZeroLEOneClass α] [CovariantClass α α (·+·) (·≤·)] :
+    (0 : α) ≤ 4 := by
+  rw [← three_add_one_eq_four]
+  exact add_nonneg zero_le_three zero_le_one
+
+lemma one_le_two [LE α] [ZeroLEOneClass α] [CovariantClass α α (·+·) (·≤·)] :
+  (1 : α) ≤ 2 :=
+calc 1 = 1 + 0 := (add_zero 1).symm
+     _ ≤ 1 + 1 := add_le_add_left zero_le_one _
+     _ = 2 := one_add_one_eq_two
+
+lemma one_le_two' [LE α] [ZeroLEOneClass α] [CovariantClass α α (swap (·+·)) (·≤·)] :
+  (1 : α) ≤ 2 :=
+calc 1 = 0 + 1 := (zero_add 1).symm
+     _ ≤ 1 + 1 := add_le_add_right zero_le_one _
+     _ = 2 := one_add_one_eq_two
+
+section
+variable [PartialOrder α] [ZeroLEOneClass α] [NeZero (1 : α)]
+
+section
+variable [CovariantClass α α (·+·) (·≤·)]
+
+/-- See `zero_lt_two'` for a version with the type explicit. -/
+@[simp] lemma zero_lt_two : (0 : α) < 2 := zero_lt_one.trans_le one_le_two
+/-- See `zero_lt_three'` for a version with the type explicit. -/
+@[simp] lemma zero_lt_three : (0 : α) < 3 := by
+  rw [← two_add_one_eq_three]
+  exact lt_add_of_lt_of_nonneg zero_lt_two zero_le_one
+/-- See `zero_lt_four'` for a version with the type explicit. -/
+@[simp] lemma zero_lt_four : (0 : α) < 4 := by
+  rw [← three_add_one_eq_four]
+  exact lt_add_of_lt_of_nonneg zero_lt_three zero_le_one
+
+variable (α)
+
+/-- See `zero_lt_two` for a version with the type implicit. -/
+lemma zero_lt_two' : (0 : α) < 2 := zero_lt_two
+/-- See `zero_lt_three` for a version with the type implicit. -/
+lemma zero_lt_three' : (0 : α) < 3 := zero_lt_three
+/-- See `zero_lt_four` for a version with the type implicit. -/
+lemma zero_lt_four' : (0 : α) < 4 := zero_lt_four
+
+instance zero_le_one_class.ne_zero.two : NeZero (2 : α) := ⟨zero_lt_two.ne'⟩
+instance zero_le_one_class.ne_zero.three : NeZero (3 : α) := ⟨zero_lt_three.ne'⟩
+instance zero_le_one_class.ne_zero.four : NeZero (4 : α) := ⟨zero_lt_four.ne'⟩
+
+end
+
+lemma one_lt_two [CovariantClass α α (·+·) (·<·)] : (1 : α) < 2 := by
+  rw [← one_add_one_eq_two]
+  exact lt_add_one _
+
+end
+
+alias zero_lt_two ← two_pos
+alias zero_lt_three ← three_pos
+alias zero_lt_four ← four_pos

--- a/Mathlib/Algebra/Order/ZeroLEOne.lean
+++ b/Mathlib/Algebra/Order/ZeroLEOne.lean
@@ -1,0 +1,42 @@
+/-
+Copyright (c) 2016 Jeremy Avigad. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro, Johannes Hölzl
+-/
+import Mathlib.Order.Basic
+import Mathlib.Algebra.NeZero
+
+/-!
+# Typeclass expressing `0 ≤ 1`.
+-/
+
+variable {α : Type _}
+
+open Function
+
+/-- Typeclass for expressing that the `0` of a type is less or equal to its `1`. -/
+class ZeroLEOneClass (α : Type _) [Zero α] [One α] [LE α] where
+  zero_le_one : (0 : α) ≤ 1
+
+/-- `zero_le_one` with the type argument implicit. -/
+@[simp] lemma zero_le_one [Zero α] [One α] [LE α] [ZeroLEOneClass α] : (0 : α) ≤ 1 :=
+ZeroLEOneClass.zero_le_one
+
+/-- `zero_le_one` with the type argument explicit. -/
+lemma zero_le_one' (α) [Zero α] [One α] [LE α] [ZeroLEOneClass α] : (0 : α) ≤ 1 :=
+zero_le_one
+
+section
+variable [Zero α] [One α] [PartialOrder α] [ZeroLEOneClass α] [NeZero (1 : α)]
+
+/-- See `zero_lt_one'` for a version with the type explicit. -/
+@[simp] lemma zero_lt_one : (0 : α) < 1 := zero_le_one.lt_of_ne (NeZero.ne' 1)
+
+variable (α)
+
+/-- See `zero_lt_one` for a version with the type implicit. -/
+lemma zero_lt_one' : (0 : α) < 1 := zero_lt_one
+
+end
+
+alias zero_lt_one ← one_pos

--- a/Mathlib/Algebra/Order/ZeroLEOne.lean
+++ b/Mathlib/Algebra/Order/ZeroLEOne.lean
@@ -16,6 +16,7 @@ open Function
 
 /-- Typeclass for expressing that the `0` of a type is less or equal to its `1`. -/
 class ZeroLEOneClass (α : Type _) [Zero α] [One α] [LE α] where
+  /-- Zero is less than or equal to one. -/
   zero_le_one : (0 : α) ≤ 1
 
 /-- `zero_le_one` with the type argument implicit. -/

--- a/Mathlib/Data/Nat/Cast/Defs.lean
+++ b/Mathlib/Data/Nat/Cast/Defs.lean
@@ -237,3 +237,14 @@ theorem one_add_one_eq_two [AddMonoidWithOne α] : 1 + 1 = (2 : α) := by
   rw [←Nat.cast_one, ←Nat.cast_add]
   apply congrArg
   decide
+
+theorem two_add_one_eq_three [AddMonoidWithOne α] : 2 + 1 = (3 : α) := by
+  rw [←one_add_one_eq_two, ←Nat.cast_one, ←Nat.cast_add, ←Nat.cast_add]
+  apply congrArg
+  decide
+
+theorem three_add_one_eq_four [AddMonoidWithOne α] : 3 + 1 = (4 : α) := by
+  rw [←two_add_one_eq_three, ←one_add_one_eq_two, ←Nat.cast_one,
+    ←Nat.cast_add, ←Nat.cast_add, ←Nat.cast_add]
+  apply congrArg
+  decide

--- a/Mathlib/Tactic/Linarith/Lemmas.lean
+++ b/Mathlib/Tactic/Linarith/Lemmas.lean
@@ -9,6 +9,7 @@ import Std.Tactic.Lint.Basic
 import Mathlib.Algebra.Order.Ring
 import Mathlib.Algebra.Order.Monoid.Lemmas
 import Mathlib.Init.Data.Int.Order
+import Mathlib.Algebra.Order.ZeroLEOne
 
 /-!
 # Lemmas for `linarith`.
@@ -79,7 +80,9 @@ open Function
 -- These lemmas can be removed when their originals are ported.
 
 @[nolint unusedArguments]
-theorem zero_lt_one [OrderedSemiring α] [Nontrivial α] : (0 : α) < 1 := sorry
+theorem zero_lt_one'' [OrderedSemiring α] [Nontrivial α] : (0 : α) < 1 :=
+  -- should be just `zero_lt_one`, but the typeclasses don't work out yet.
+  sorry
 
 theorem lt_zero_of_zero_gt [Zero α] [LT α] {a : α} (h : 0 > a) : a < 0 := h
 

--- a/Mathlib/Tactic/Linarith/Verification.lean
+++ b/Mathlib/Tactic/Linarith/Verification.lean
@@ -138,7 +138,7 @@ def typeOfIneqProof (prf : Expr) : MetaM Expr := do
 where the numerals are natively of type `tp`.
 -/
 def mkNegOneLtZeroProof (tp : Expr) : MetaM Expr := do
-  let zero_lt_one ← mkAppOptM ``zero_lt_one #[tp, none, none]
+  let zero_lt_one ← mkAppOptM ``zero_lt_one'' #[tp, none, none]
   mkAppM `neg_neg_of_pos #[zero_lt_one]
 
 /--


### PR DESCRIPTION
Ported by hand from current mathlib: 07fee0ca54c320250c98bacf31ca5f288b2bcbe2

This is thoroughly ridiculous, but it my fault for merging https://github.com/leanprover-community/mathlib/pull/17820, see discussion on [zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/OfNat).

Rather than proving 1 + 1 = 2 (I feel ridiculous), these lemmas should just happen later in mathlib, with stronger typeclasses. But these files are holding up the port, so its better to get this ported as is, and we can make it more sensible later...