### PR TITLE
[Merged by Bors] - feat: port Algebra.Order.Group.Units

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -36,6 +36,7 @@ import Mathlib.Algebra.NeZero
 import Mathlib.Algebra.Opposites
 import Mathlib.Algebra.Order.Group.Defs
 import Mathlib.Algebra.Order.Group.Instances
+import Mathlib.Algebra.Order.Group.Units
 import Mathlib.Algebra.Order.Hom.Basic
 import Mathlib.Algebra.Order.Monoid.Basic
 import Mathlib.Algebra.Order.Monoid.Cancel.Basic

--- a/Mathlib/Algebra/Group/Units.lean
+++ b/Mathlib/Algebra/Group/Units.lean
@@ -200,6 +200,8 @@ instance {α} [CommMonoid α] : CommGroup αˣ :=
   { (inferInstance : Group αˣ) with
     mul_comm := fun _ _ => ext <| mul_comm _ _ }
 attribute [instance] AddUnits.instAddCommGroupAddUnitsToAddMonoid
+#align units.comm_group Units.instCommGroupUnitsToMonoid
+#align add_units.add_comm_group AddUnits.instAddCommGroupAddUnitsToAddMonoid
 
 /-- Units of a monoid are inhabited because `1` is a unit. -/
 @[to_additive "Additive units of an additive monoid are inhabited because `0` is an additive unit."]

--- a/Mathlib/Algebra/Order/Group/Units.lean
+++ b/Mathlib/Algebra/Order/Group/Units.lean
@@ -1,0 +1,23 @@
+/-
+Copyright (c) 2016 Jeremy Avigad. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro, Johannes Hölzl
+-/
+import Mathlib.Algebra.Order.Group.Defs
+import Mathlib.Algebra.Order.Monoid.Defs
+import Mathlib.Algebra.Order.Monoid.Units
+
+/-!
+# Adjoining a top element to a `linear_ordered_add_comm_group_with_top`.
+-/
+
+
+variable {α : Type _}
+
+/-- The units of an ordered commutative monoid form an ordered commutative group. -/
+@[to_additive
+      "The units of an ordered commutative additive monoid form an ordered commutative\nadditive group."]
+instance Units.orderedCommGroup [OrderedCommMonoid α] : OrderedCommGroup αˣ :=
+  { Units.partialOrder, Units.commGroup with
+    mul_le_mul_left := fun a b h c => (mul_le_mul_left' (h : (a : α) ≤ b) _ : (c : α) * a ≤ c * b) }
+#align units.ordered_comm_group Units.orderedCommGroup

--- a/Mathlib/Algebra/Order/Group/Units.lean
+++ b/Mathlib/Algebra/Order/Group/Units.lean
@@ -8,7 +8,7 @@ import Mathlib.Algebra.Order.Monoid.Defs
 import Mathlib.Algebra.Order.Monoid.Units
 
 /-!
-# Adjoining a top element to a `linear_ordered_add_comm_group_with_top`.
+# The units of an ordered commutative monoid form an ordered commutative group
 -/
 
 
@@ -16,8 +16,14 @@ variable {α : Type _}
 
 /-- The units of an ordered commutative monoid form an ordered commutative group. -/
 @[to_additive
-      "The units of an ordered commutative additive monoid form an ordered commutative\nadditive group."]
+      "The units of an ordered commutative additive monoid form an ordered commutative
+      additive group."]
 instance Units.orderedCommGroup [OrderedCommMonoid α] : OrderedCommGroup αˣ :=
-  { Units.partialOrder, Units.commGroup with
-    mul_le_mul_left := fun a b h c => (mul_le_mul_left' (h : (a : α) ≤ b) _ : (c : α) * a ≤ c * b) }
+  { Units.instPartialOrderUnits, Units.instCommGroupUnitsToMonoid with
+    mul_le_mul_left := fun _ _ h _ => (@mul_le_mul_left' α _ _ _ _ _ h _) }
 #align units.ordered_comm_group Units.orderedCommGroup
+#align add_units.ordered_add_comm_group AddUnits.orderedAddCommGroup
+
+-- porting note: the mathlib3 proof was
+-- mul_le_mul_left := fun a b h c => (mul_le_mul_left' (h : (a : α) ≤ b) _ : (c : α) * a ≤ c * b) }
+-- see https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/elaboration.20failure.20in.20algebra.2Eorder.2Egroup.2Eunits

--- a/Mathlib/Algebra/Order/Monoid/Units.lean
+++ b/Mathlib/Algebra/Order/Monoid/Units.lean
@@ -31,6 +31,8 @@ theorem val_lt_val [Monoid α] [Preorder α] {a b : αˣ} : (a : α) < b ↔ a <
 @[to_additive]
 instance [Monoid α] [PartialOrder α] : PartialOrder αˣ :=
   PartialOrder.lift val Units.ext
+#align units.partial_order Units.instPartialOrderUnits
+#align add_units.partial_order AddUnits.instPartialOrderAddUnits
 
 @[to_additive]
 instance [Monoid α] [LinearOrder α] : LinearOrder αˣ :=


### PR DESCRIPTION
mathlib3 a95b16cbade0f938fc24abd05412bde1e84bab9b

Porting notes:
- the module docstring title in mathlib3 was incorrect (probably a relic of a hasty split), I have changed it here without backporting
- one elaboration issue, see [Zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/elaboration.20failure.20in.20algebra.2Eorder.2Egroup.2Eunits)
- same issue with instance names as in #890, and I made the same choice about how to fix it