### PR TITLE
[Merged by Bors] - chore: naming instances around `WithBot`, `WithTop`, `WithOne` and `WithZero`

### DIFF
--- a/Mathlib/Algebra/Group/WithOne/Defs.lean
+++ b/Mathlib/Algebra/Group/WithOne/Defs.lean
@@ -46,37 +46,40 @@ instance [Repr α] : Repr (WithOne α) :=
     | some a => "↑" ++ repr a⟩
 
 @[to_additive]
-instance : Monad WithOne :=
+instance monad : Monad WithOne :=
   instMonadOption
 
 @[to_additive]
-instance : One (WithOne α) :=
+instance one : One (WithOne α) :=
   ⟨none⟩
+#align with_one.has_one WithOne.one
 
 @[to_additive]
-instance [Mul α] : Mul (WithOne α) :=
+instance mul [Mul α] : Mul (WithOne α) :=
   ⟨Option.liftOrGet (· * ·)⟩
+#align with_one.has_mul WithOne.mul
 
 @[to_additive]
-instance [Inv α] : Inv (WithOne α) :=
+instance inv [Inv α] : Inv (WithOne α) :=
   ⟨fun a => Option.map Inv.inv a⟩
+#align with_one.has_inv WithOne.inv
 
 @[to_additive]
-instance [InvolutiveInv α] : InvolutiveInv (WithOne α) :=
-  { instInvWithOne with
+instance involutiveInv [InvolutiveInv α] : InvolutiveInv (WithOne α) :=
+  { WithOne.inv with
     inv_inv := fun a =>
       (Option.map_map _ _ _).trans <| by simp_rw [inv_comp_inv, Option.map_id, id] }
 
 @[to_additive]
-instance [Inv α] : InvOneClass (WithOne α) :=
-  { instOneWithOne, instInvWithOne with inv_one := rfl }
+instance invOneClass [Inv α] : InvOneClass (WithOne α) :=
+  { WithOne.one, WithOne.inv with inv_one := rfl }
 
 @[to_additive]
-instance : Inhabited (WithOne α) :=
+instance inhabited : Inhabited (WithOne α) :=
   ⟨1⟩
 
 @[to_additive]
-instance [Nonempty α] : Nontrivial (WithOne α) :=
+instance nontrivial [Nonempty α] : Nontrivial (WithOne α) :=
   Option.nontrivial
 
 -- porting note: this new declaration is here to make `((a : α): WithOne α)` have type `WithOne α` ;
@@ -92,7 +95,7 @@ def coe : α → WithOne α :=
 attribute [coe] WithZero.coe
 
 @[to_additive]
-instance : CoeTC α (WithOne α) :=
+instance coeTC : CoeTC α (WithOne α) :=
   ⟨coe⟩
 
 /-- Recursor for `with_one` using the preferred forms `1` and `↑a`. -/
@@ -183,19 +186,19 @@ attribute [elab_as_elim] WithZero.cases_on
 -- irreducible. Maybe one day when mathlib is ported to Lean 4 we can experiment
 -- to see if these `show` comments can be removed.
 @[to_additive]
-instance [Mul α] : MulOneClass (WithOne α) where
+instance mulOneClass [Mul α] : MulOneClass (WithOne α) where
   mul := (· * ·)
   one := 1
   one_mul := show ∀ x : WithOne α, 1 * x = x from (Option.liftOrGet_isLeftId _).1
   mul_one := show ∀ x : WithOne α, x * 1 = x from (Option.liftOrGet_isRightId _).1
 
 @[to_additive]
-instance [Semigroup α] : Monoid (WithOne α) :=
-  { instMulOneClassWithOne with mul_assoc := (Option.liftOrGet_isAssociative _).1 }
+instance monoid [Semigroup α] : Monoid (WithOne α) :=
+  { WithOne.mulOneClass with mul_assoc := (Option.liftOrGet_isAssociative _).1 }
 
 @[to_additive]
-instance [CommSemigroup α] : CommMonoid (WithOne α) :=
-  { instMonoidWithOne with mul_comm := (Option.liftOrGet_isCommutative _).1 }
+instance commMonoid [CommSemigroup α] : CommMonoid (WithOne α) :=
+  { WithOne.monoid with mul_comm := (Option.liftOrGet_isCommutative _).1 }
 
 @[simp, norm_cast, to_additive]
 theorem coe_mul [Mul α] (a b : α) : ((a * b : α) : WithOne α) = a * b :=
@@ -221,7 +224,7 @@ end WithOne
 
 namespace WithZero
 
-instance [one : One α] : One (WithZero α) :=
+instance one [one : One α] : One (WithZero α) :=
   { one with }
 
 @[simp, norm_cast]
@@ -229,8 +232,8 @@ theorem coe_one [One α] : ((1 : α) : WithZero α) = 1 :=
   rfl
 #align with_zero.coe_one WithZero.coe_one
 
-instance [Mul α] : MulZeroClass (WithZero α) :=
-  { instZeroWithZero with
+instance mulZeroClass [Mul α] : MulZeroClass (WithZero α) :=
+  { WithZero.zero with
     mul := fun o₁ o₂ => o₁.bind fun a => Option.map (fun b => a * b) o₂,
     zero_mul := fun a => rfl,
     mul_zero := fun a => by cases a <;> rfl }
@@ -250,13 +253,13 @@ theorem zero_mul {α : Type u} [Mul α] (a : WithZero α) : 0 * a = 0 :=
 theorem mul_zero {α : Type u} [Mul α] (a : WithZero α) : a * 0 = 0 := by cases a <;> rfl
 #align with_zero.mul_zero WithZero.mul_zero
 
-instance [Mul α] : NoZeroDivisors (WithZero α) :=
+instance noZeroDivisors [Mul α] : NoZeroDivisors (WithZero α) :=
   ⟨by
     rintro (a | a) (b | b) h
     exacts[Or.inl rfl, Or.inl rfl, Or.inr rfl, Option.noConfusion h]⟩
 
-instance [Semigroup α] : SemigroupWithZero (WithZero α) :=
-  { instMulZeroClassWithZero with
+instance semigroupWithZero [Semigroup α] : SemigroupWithZero (WithZero α) :=
+  { WithZero.mulZeroClass with
     mul_assoc := fun a b c =>
       match a, b, c with
       | none, _, _ => rfl
@@ -264,16 +267,16 @@ instance [Semigroup α] : SemigroupWithZero (WithZero α) :=
       | some _, some _, none => rfl
       | some a, some b, some c => congr_arg some (mul_assoc a b c) }
 
-instance [CommSemigroup α] : CommSemigroup (WithZero α) :=
-  { instSemigroupWithZeroWithZero with
+instance commSemigroup [CommSemigroup α] : CommSemigroup (WithZero α) :=
+  { WithZero.semigroupWithZero with
     mul_comm := fun a b =>
       match a, b with
       | none, _ => (mul_zero _).symm
       | some _, none => rfl
       | some a, some b => congr_arg some (mul_comm a b) }
 
-instance [MulOneClass α] : MulZeroOneClass (WithZero α) :=
-  { instMulZeroClassWithZero, instOneWithZero with
+instance mulZeroOneClass [MulOneClass α] : MulZeroOneClass (WithZero α) :=
+  { WithZero.mulZeroClass, WithZero.one with
     one_mul := fun a =>
       match a with
       | none => rfl
@@ -283,7 +286,7 @@ instance [MulOneClass α] : MulZeroOneClass (WithZero α) :=
       | none => rfl
       | some a => congr_arg some <| mul_one a }
 
-instance [One α] [Pow α ℕ] : Pow (WithZero α) ℕ :=
+instance pow [One α] [Pow α ℕ] : Pow (WithZero α) ℕ :=
   ⟨fun x n =>
     match x, n with
     | none, 0 => 1
@@ -296,8 +299,8 @@ theorem coe_pow [One α] [Pow α ℕ] {a : α} (n : ℕ) :
   rfl
 #align with_zero.coe_pow WithZero.coe_pow
 
-instance [Monoid α] : MonoidWithZero (WithZero α) :=
-  { instMulZeroOneClassWithZero, instSemigroupWithZeroWithZero with
+instance monoidWithZero [Monoid α] : MonoidWithZero (WithZero α) :=
+  { WithZero.mulZeroOneClass, WithZero.semigroupWithZero with
     npow := fun n x => x ^ n,
     npow_zero := fun x =>
       match x with
@@ -308,12 +311,12 @@ instance [Monoid α] : MonoidWithZero (WithZero α) :=
       | none => rfl
       | some x => congr_arg some <| pow_succ x n }
 
-instance [CommMonoid α] : CommMonoidWithZero (WithZero α) :=
-  { instMonoidWithZeroWithZero, instCommSemigroupWithZero with }
+instance commMonoidWithZero [CommMonoid α] : CommMonoidWithZero (WithZero α) :=
+  { WithZero.monoidWithZero, WithZero.commSemigroup with }
 
 /-- Given an inverse operation on `α` there is an inverse operation
   on `with_zero α` sending `0` to `0`-/
-instance [Inv α] : Inv (WithZero α) :=
+instance inv [Inv α] : Inv (WithZero α) :=
   ⟨fun a => Option.map Inv.inv a⟩
 
 @[simp, norm_cast]
@@ -326,15 +329,15 @@ theorem inv_zero [Inv α] : (0 : WithZero α)⁻¹ = 0 :=
   rfl
 #align with_zero.inv_zero WithZero.inv_zero
 
-instance [InvolutiveInv α] : InvolutiveInv (WithZero α) :=
-  { instInvWithZero with
+instance involutiveInv [InvolutiveInv α] : InvolutiveInv (WithZero α) :=
+  { WithZero.inv with
     inv_inv := fun a =>
       (Option.map_map _ _ _).trans <| by simp_rw [inv_comp_inv, Option.map_id, id] }
 
-instance [InvOneClass α] : InvOneClass (WithZero α) :=
-  { instOneWithZero, instInvWithZero with inv_one := show ((1⁻¹ : α) : WithZero α) = 1 by simp }
+instance invOneClass [InvOneClass α] : InvOneClass (WithZero α) :=
+  { WithZero.one, WithZero.inv with inv_one := show ((1⁻¹ : α) : WithZero α) = 1 by simp }
 
-instance [Div α] : Div (WithZero α) :=
+instance div [Div α] : Div (WithZero α) :=
   ⟨fun o₁ o₂ => o₁.bind fun a => Option.map (fun b => a / b) o₂⟩
 
 @[norm_cast]
@@ -355,8 +358,8 @@ theorem coe_zpow [DivInvMonoid α] {a : α} (n : ℤ) : ↑(a ^ n : α) = ((↑a
   rfl
 #align with_zero.coe_zpow WithZero.coe_zpow
 
-instance [DivInvMonoid α] : DivInvMonoid (WithZero α) :=
-  { instDivWithZero, instInvWithZero, instMonoidWithZeroWithZero with
+instance divInvMonoid [DivInvMonoid α] : DivInvMonoid (WithZero α) :=
+  { WithZero.div, WithZero.inv, WithZero.monoidWithZero with
     div_eq_mul_inv := fun a b =>
       match a, b with
       | none, _ => rfl
@@ -376,11 +379,11 @@ instance [DivInvMonoid α] : DivInvMonoid (WithZero α) :=
       | none => rfl
       | some x => congr_arg some <| DivInvMonoid.zpow_neg' n x }
 
-instance [DivInvOneMonoid α] : DivInvOneMonoid (WithZero α) :=
-  { instDivInvMonoidWithZero, instInvOneClassWithZero with }
+instance divInvOneMonoid [DivInvOneMonoid α] : DivInvOneMonoid (WithZero α) :=
+  { WithZero.divInvMonoid, WithZero.invOneClass with }
 
-instance [DivisionMonoid α] : DivisionMonoid (WithZero α) :=
-  { instDivInvMonoidWithZero, instInvolutiveInvWithZero with
+instance divisionMonoid [DivisionMonoid α] : DivisionMonoid (WithZero α) :=
+  { WithZero.divInvMonoid, WithZero.involutiveInv with
     mul_inv_rev := fun a b =>
       match a, b with
       | none, none => rfl
@@ -395,8 +398,8 @@ instance [DivisionMonoid α] : DivisionMonoid (WithZero α) :=
       | some a, some b => fun h ↦
         congr_arg some <| inv_eq_of_mul_eq_one_right <| Option.some_injective _ h }
 
-instance [DivisionCommMonoid α] : DivisionCommMonoid (WithZero α) :=
-  { instDivisionMonoidWithZero, instCommSemigroupWithZero with }
+instance divisionCommMonoid [DivisionCommMonoid α] : DivisionCommMonoid (WithZero α) :=
+  { WithZero.divisionMonoid, WithZero.commSemigroup with }
 
 section Group
 
@@ -405,8 +408,8 @@ variable [Group α]
 -- porting note: the lean 3 proof of this used the `lift` tactic, which was not
 -- present in mathlib4 at the time of porting; we instead do a case split.
 /-- if `G` is a group then `with_zero G` is a group with zero. -/
-instance : GroupWithZero (WithZero α) :=
-  { instMonoidWithZeroWithZero, instDivInvMonoidWithZero, instNontrivialWithZero with
+instance groupWithZero : GroupWithZero (WithZero α) :=
+  { WithZero.monoidWithZero, WithZero.divInvMonoid, WithZero.nontrivial with
     inv_zero := inv_zero,
     mul_inv_cancel := fun a _ ↦
     match a with
@@ -418,11 +421,11 @@ instance : GroupWithZero (WithZero α) :=
 
 end Group
 
-instance [CommGroup α] : CommGroupWithZero (WithZero α) :=
-  { instGroupWithZeroWithZero, instCommMonoidWithZeroWithZero with }
+instance commGroupWithZero [CommGroup α] : CommGroupWithZero (WithZero α) :=
+  { WithZero.groupWithZero, WithZero.commMonoidWithZero with }
 
-instance [AddMonoidWithOne α] : AddMonoidWithOne (WithZero α) :=
-  { instAddMonoidWithZero, instOneWithZero with
+instance addMonoidWithOne [AddMonoidWithOne α] : AddMonoidWithOne (WithZero α) :=
+  { WithZero.addMonoid, WithZero.one with
     natCast := fun n => if n = 0 then 0 else (n.cast : α),
     natCast_zero := rfl,
     natCast_succ := fun n => by
@@ -433,9 +436,9 @@ instance [AddMonoidWithOne α] : AddMonoidWithOne (WithZero α) :=
           rw [Nat.cast_succ, coe_add, coe_one]
       }
 
-instance [Semiring α] : Semiring (WithZero α) :=
-  { instAddMonoidWithOneWithZero, instAddCommMonoidWithZero, instMulZeroClassWithZero,
-    instMonoidWithZeroWithZero with
+instance semiring [Semiring α] : Semiring (WithZero α) :=
+  { WithZero.addMonoidWithOne, WithZero.addCommMonoid, WithZero.mulZeroClass,
+    WithZero.monoidWithZero with
     left_distrib := fun a b c => by
       cases' a with a; · rfl
       cases' b with b <;> cases' c with c <;> try rfl

--- a/Mathlib/Algebra/Order/Monoid/WithZero/Defs.lean
+++ b/Mathlib/Algebra/Order/Monoid/WithZero/Defs.lean
@@ -24,14 +24,14 @@ class LinearOrderedCommMonoidWithZero (α : Type _) extends LinearOrderedCommMon
 
 namespace WithZero
 
-instance [Preorder α] : Preorder (WithZero α) :=
-  WithBot.instPreorderWithBot
+instance preorder [Preorder α] : Preorder (WithZero α) :=
+  WithBot.preorder
 
-instance [PartialOrder α] : PartialOrder (WithZero α) :=
-  WithBot.instPartialOrderWithBot
+instance partialOrder [PartialOrder α] : PartialOrder (WithZero α) :=
+  WithBot.partialOrder
 
-instance [Preorder α] : OrderBot (WithZero α) :=
-  WithBot.instOrderBotWithBotInstLEWithBot
+instance orderBot [Preorder α] : OrderBot (WithZero α) :=
+  WithBot.orderBot
 
 theorem zero_le [Preorder α] (a : WithZero α) : 0 ≤ a :=
   bot_le
@@ -55,11 +55,11 @@ theorem coe_le_coe [Preorder α] {a b : α} : (a : WithZero α) ≤ b ↔ a ≤ 
   WithBot.coe_le_coe
 #align with_zero.coe_le_coe WithZero.coe_le_coe
 
-instance [Lattice α] : Lattice (WithZero α) :=
-  WithBot.instLatticeWithBot
+instance lattice [Lattice α] : Lattice (WithZero α) :=
+  WithBot.lattice
 
-instance [LinearOrder α] : LinearOrder (WithZero α) :=
-  WithBot.instLinearOrderWithBot
+instance linearOrder [LinearOrder α] : LinearOrder (WithZero α) :=
+  WithBot.linearOrder
 
 instance covariantClass_mul_le [Mul α] [Preorder α]
     [CovariantClass α α (· * ·) (· ≤ ·)] :
@@ -80,8 +80,8 @@ instance covariantClass_mul_le [Mul α] [Preorder α]
 #noalign with_zero.le_max_iff
 #noalign with_zero.min_le_iff
 
-instance [OrderedCommMonoid α] : OrderedCommMonoid (WithZero α) :=
-  { CommMonoidWithZero.toCommMonoid, WithZero.instPartialOrderWithZero with
+instance orderedCommMonoid [OrderedCommMonoid α] : OrderedCommMonoid (WithZero α) :=
+  { WithZero.commMonoidWithZero.toCommMonoid, WithZero.partialOrder with
     mul_le_mul_left := fun _ _ => mul_le_mul_left' }
 
 -- FIXME: `WithOne.coe_mul` and `WithZero.coe_mul` have inconsistent use of implicit parameters
@@ -118,15 +118,13 @@ See note [reducible non-instances].
 @[reducible]
 protected def orderedAddCommMonoid [OrderedAddCommMonoid α] (zero_le : ∀ a : α, 0 ≤ a) :
     OrderedAddCommMonoid (WithZero α) :=
-  { WithZero.instPartialOrderWithZero, instAddCommMonoidWithZero with
+  { WithZero.partialOrder, WithZero.addCommMonoid with
     add_le_add_left := @add_le_add_left _ _ _ (WithZero.covariantClass_add_le zero_le).. }
 #align with_zero.ordered_add_comm_monoid WithZero.orderedAddCommMonoid
 
-end WithZero
-
 section CanonicallyOrderedMonoid
 
-instance WithZero.instExistsAddOfLE [Add α] [Preorder α] [ExistsAddOfLE α] :
+instance existsAddOfLE [Add α] [Preorder α] [ExistsAddOfLE α] :
     ExistsAddOfLE (WithZero α) :=
   ⟨fun {a b} => by
     induction a using WithZero.cases_on
@@ -136,15 +134,15 @@ instance WithZero.instExistsAddOfLE [Add α] [Preorder α] [ExistsAddOfLE α] :
     intro h
     obtain ⟨c, rfl⟩ := exists_add_of_le (WithZero.coe_le_coe.1 h)
     exact ⟨c, rfl⟩⟩
-#align with_zero.has_exists_add_of_le WithZero.instExistsAddOfLE
+#align with_zero.has_exists_add_of_le WithZero.existsAddOfLE
 
 -- This instance looks absurd: a monoid already has a zero
 /-- Adding a new zero to a canonically ordered additive monoid produces another one. -/
-instance WithZero.canonicallyOrderedAddMonoid [CanonicallyOrderedAddMonoid α] :
+instance canonicallyOrderedAddMonoid [CanonicallyOrderedAddMonoid α] :
     CanonicallyOrderedAddMonoid (WithZero α) :=
-  { WithZero.instOrderBotWithZeroToLEInstPreorderWithZero,
+  { WithZero.orderBot,
     WithZero.orderedAddCommMonoid _root_.zero_le,
-    WithZero.instExistsAddOfLE with
+    WithZero.existsAddOfLE with
     le_self_add := fun a b => by
       induction a using WithZero.cases_on
       · exact bot_le
@@ -157,9 +155,11 @@ end CanonicallyOrderedMonoid
 
 section CanonicallyLinearOrderedMonoid
 
-instance WithZero.canonicallyLinearOrderedAddMonoid (α : Type _)
+instance canonicallyLinearOrderedAddMonoid (α : Type _)
     [CanonicallyLinearOrderedAddMonoid α] : CanonicallyLinearOrderedAddMonoid (WithZero α) :=
-  { WithZero.canonicallyOrderedAddMonoid, WithZero.instLinearOrderWithZero with }
+  { WithZero.canonicallyOrderedAddMonoid, WithZero.linearOrder with }
 #align with_zero.canonically_linear_ordered_add_monoid WithZero.canonicallyLinearOrderedAddMonoid
 
 end CanonicallyLinearOrderedMonoid
+
+end WithZero

--- a/Mathlib/Order/WithBot.lean
+++ b/Mathlib/Order/WithBot.lean
@@ -37,13 +37,13 @@ instance [Repr α] : Repr (WithBot α) :=
 @[coe] def some : α → WithBot α :=
   Option.some
 
-instance : CoeTC α (WithBot α) :=
+instance coeTC : CoeTC α (WithBot α) :=
   ⟨some⟩
 
-instance : Bot (WithBot α) :=
+instance bot : Bot (WithBot α) :=
   ⟨none⟩
 
-instance : Inhabited (WithBot α) :=
+instance inhabited : Inhabited (WithBot α) :=
   ⟨⊥⟩
 
 open Function
@@ -172,7 +172,7 @@ section LE
 
 variable [LE α]
 
-instance (priority := 10) : LE (WithBot α) :=
+instance (priority := 10) le : LE (WithBot α) :=
   ⟨fun o₁ o₂ : Option α => ∀ a ∈ o₁, ∃ b ∈ o₂, a ≤ b⟩
 
 @[simp]
@@ -189,16 +189,16 @@ theorem coe_le_coe : (a : WithBot α) ≤ b ↔ a ≤ b :=
 theorem none_le {a : WithBot α} : @LE.le (WithBot α) _ none a := fun _ h => Option.noConfusion h
 #align with_bot.none_le WithBot.none_le
 
-instance : OrderBot (WithBot α) :=
-  { instBotWithBot with bot_le := fun _ => none_le }
+instance orderBot : OrderBot (WithBot α) :=
+  { WithBot.bot with bot_le := fun _ => none_le }
 
 
-instance [OrderTop α] : OrderTop (WithBot α) where
+instance orderTop [OrderTop α] : OrderTop (WithBot α) where
   top := some ⊤
   le_top o a ha := by cases ha ; exact ⟨_, rfl, le_top⟩
 
 instance [OrderTop α] : BoundedOrder (WithBot α) :=
-  { instOrderBotWithBotInstLEWithBot, instOrderTopWithBotInstLEWithBot with }
+  { WithBot.orderBot, WithBot.orderTop with }
 
 theorem not_coe_le_bot (a : α) : ¬(a : WithBot α) ≤ ⊥ := fun h =>
   let ⟨_, hb, _⟩ := h _ rfl
@@ -230,7 +230,7 @@ section LT
 
 variable [LT α]
 
-instance (priority := 10) : LT (WithBot α) :=
+instance (priority := 10) lt : LT (WithBot α) :=
   ⟨fun o₁ o₂ : Option α => ∃ b ∈ o₂, ∀ a ∈ o₁, a < b⟩
 
 @[simp]
@@ -269,7 +269,7 @@ theorem lt_coe_iff : ∀ {x : WithBot α}, x < b ↔ ∀ a, x = ↑a → a < b
 
 end LT
 
-instance [Preorder α] : Preorder (WithBot α) where
+instance preorder [Preorder α] : Preorder (WithBot α) where
   le := (· ≤ ·)
   lt := (· < ·)
   lt_iff_le_not_le := by
@@ -281,8 +281,8 @@ instance [Preorder α] : Preorder (WithBot α) where
     let ⟨c, hc, bc⟩ := h₂ b hb
     ⟨c, hc, le_trans ab bc⟩
 
-instance [PartialOrder α] : PartialOrder (WithBot α) :=
-  { instPreorderWithBot with
+instance partialOrder [PartialOrder α] : PartialOrder (WithBot α) :=
+  { WithBot.preorder with
     le_antisymm := fun o₁ o₂ h₁ h₂ => by
       cases' o₁ with a
       · cases' o₂ with b
@@ -361,8 +361,8 @@ theorem unbot'_lt_iff [LT α] {a : WithBot α} {b c : α} (ha : a ≠ ⊥) : a.u
   . rw [some_eq_coe, unbot'_coe, coe_lt_coe]
 #align with_bot.unbot'_lt_iff WithBot.unbot'_lt_iff
 
-instance [SemilatticeSup α] : SemilatticeSup (WithBot α) :=
-  { instPartialOrderWithBot, @instOrderBotWithBotInstLEWithBot α _ with
+instance semilatticeSup [SemilatticeSup α] : SemilatticeSup (WithBot α) :=
+  { WithBot.partialOrder, @WithBot.orderBot α _ with
     sup := Option.liftOrGet (· ⊔ ·),
     le_sup_left := fun o₁ o₂ a ha => by cases ha ; cases o₂ <;> simp [Option.liftOrGet],
     le_sup_right := fun o₁ o₂ a ha => by cases ha ; cases o₁ <;> simp [Option.liftOrGet],
@@ -381,8 +381,8 @@ theorem coe_sup [SemilatticeSup α] (a b : α) : ((a ⊔ b : α) : WithBot α) =
   rfl
 #align with_bot.coe_sup WithBot.coe_sup
 
-instance [SemilatticeInf α] : SemilatticeInf (WithBot α) :=
-  { instPartialOrderWithBot, @instOrderBotWithBotInstLEWithBot α _ with
+instance semilatticeInf [SemilatticeInf α] : SemilatticeInf (WithBot α) :=
+  { WithBot.partialOrder, @WithBot.orderBot α _ with
     inf := fun o₁ o₂ => o₁.bind fun a => o₂.map fun b => a ⊓ b,
     inf_le_left := fun o₁ o₂ a ha => by
       simp [map] at ha
@@ -402,11 +402,11 @@ theorem coe_inf [SemilatticeInf α] (a b : α) : ((a ⊓ b : α) : WithBot α) =
   rfl
 #align with_bot.coe_inf WithBot.coe_inf
 
-instance [Lattice α] : Lattice (WithBot α) :=
-  { instSemilatticeSupWithBot, instSemilatticeInfWithBot with }
+instance lattice [Lattice α] : Lattice (WithBot α) :=
+  { WithBot.semilatticeSup, WithBot.semilatticeInf with }
 
-instance [DistribLattice α] : DistribLattice (WithBot α) :=
-  { instLatticeWithBot with
+instance instDistribLattice [DistribLattice α] : DistribLattice (WithBot α) :=
+  { WithBot.lattice with
     le_sup_inf := fun o₁ o₂ o₃ =>
       match o₁, o₂, o₃ with
       | ⊥, ⊥, ⊥ => le_rfl
@@ -440,7 +440,7 @@ instance isTotal_le [LE α] [IsTotal α (· ≤ ·)] : IsTotal (WithBot α) (· 
     | Option.some x, Option.some y => (total_of (· ≤ ·) x y).imp some_le_some.2 some_le_some.2⟩
 #align with_bot.is_total_le WithBot.isTotal_le
 
-instance [LinearOrder α] : LinearOrder (WithBot α) :=
+instance linearOrder [LinearOrder α] : LinearOrder (WithBot α) :=
   Lattice.toLinearOrder _
 
 -- this is not marked simp because the corresponding with_top lemmas are used
@@ -475,7 +475,7 @@ theorem wellFounded_lt [Preorder α] (h : @WellFounded α (· < ·)) :
                   (some_lt_some.1 hc) (lt_trans hc hba))⟩
 #align with_bot.well_founded_lt WithBot.wellFounded_lt
 
-instance [LT α] [DenselyOrdered α] [NoMinOrder α] : DenselyOrdered (WithBot α) :=
+instance denselyOrdered [LT α] [DenselyOrdered α] [NoMinOrder α] : DenselyOrdered (WithBot α) :=
   ⟨fun a b =>
     match a, b with
     | a, none => fun h : a < ⊥ => (not_lt_none _ h).elim
@@ -495,7 +495,7 @@ theorem lt_iff_exists_coe_btwn [Preorder α] [DenselyOrdered α] [NoMinOrder α]
     fun ⟨_, hx⟩ => lt_trans hx.1 hx.2⟩
 #align with_bot.lt_iff_exists_coe_btwn WithBot.lt_iff_exists_coe_btwn
 
-instance [LE α] [NoTopOrder α] [Nonempty α] : NoTopOrder (WithBot α) :=
+instance noTopOrder [LE α] [NoTopOrder α] [Nonempty α] : NoTopOrder (WithBot α) :=
   ⟨by
     apply recBotCoe
     · exact ‹Nonempty α›.elim fun a => ⟨a, not_coe_le_bot a⟩
@@ -505,7 +505,7 @@ instance [LE α] [NoTopOrder α] [Nonempty α] : NoTopOrder (WithBot α) :=
       exact ⟨b, by rwa [coe_le_coe]⟩
       ⟩
 
-instance [LT α] [NoMaxOrder α] [Nonempty α] : NoMaxOrder (WithBot α) :=
+instance noMaxOrder [LT α] [NoMaxOrder α] [Nonempty α] : NoMaxOrder (WithBot α) :=
   ⟨by
     apply WithBot.recBotCoe
     · apply ‹Nonempty α›.elim
@@ -538,13 +538,13 @@ instance [Repr α] : Repr (WithTop α) :=
 @[coe] def some : α → WithTop α :=
   Option.some
 
-instance : CoeTC α (WithTop α) :=
+instance coeTC : CoeTC α (WithTop α) :=
   ⟨some⟩
 
-instance : Top (WithTop α) :=
+instance top : Top (WithTop α) :=
   ⟨none⟩
 
-instance : Inhabited (WithTop α) :=
+instance inhabited : Inhabited (WithTop α) :=
   ⟨⊤⟩
 
 protected theorem «forall» {p : WithTop α → Prop} : (∀ x, p x) ↔ p ⊤ ∧ ∀ x : α, p x :=
@@ -735,7 +735,7 @@ section LE
 
 variable [LE α]
 
-instance (priority := 10) : LE (WithTop α) :=
+instance (priority := 10) le : LE (WithTop α) :=
   ⟨fun o₁ o₂ : Option α => ∀ a ∈ o₂, ∃ b ∈ o₁, b ≤ a⟩
 
 theorem toDual_le_iff {a : WithTop α} {b : WithBot αᵒᵈ} :
@@ -784,15 +784,15 @@ theorem le_none {a : WithTop α} : @LE.le (WithTop α) _ a none :=
   toDual_le_toDual_iff.mp (@WithBot.none_le αᵒᵈ _ _)
 #align with_top.le_none WithTop.le_none
 
-instance : OrderTop (WithTop α) :=
-  { instTopWithTop with le_top := fun _ => le_none }
+instance orderTop : OrderTop (WithTop α) :=
+  { WithTop.top with le_top := fun _ => le_none }
 
-instance [OrderBot α] : OrderBot (WithTop α) where
+instance orderBot [OrderBot α] : OrderBot (WithTop α) where
   bot := some ⊥
   bot_le o a ha := by cases ha ; exact ⟨_, rfl, bot_le⟩
 
-instance [OrderBot α] : BoundedOrder (WithTop α) :=
-  { instOrderTopWithTopInstLEWithTop, instOrderBotWithTopInstLEWithTop with }
+instance oundedOrder [OrderBot α] : BoundedOrder (WithTop α) :=
+  { WithTop.orderTop, WithTop.orderBot with }
 
 theorem not_top_le_coe (a : α) : ¬(⊤ : WithTop α) ≤ ↑a :=
   WithBot.not_coe_le_bot (toDual a)
@@ -823,7 +823,7 @@ section LT
 
 variable [LT α]
 
-instance (priority := 10) : LT (WithTop α) :=
+instance (priority := 10) lt : LT (WithTop α) :=
   ⟨fun o₁ o₂ : Option α => ∃ b ∈ o₁, ∀ a ∈ o₂, b < a⟩
 
 theorem toDual_lt_iff {a : WithTop α} {b : WithBot αᵒᵈ} :
@@ -1032,7 +1032,7 @@ theorem coe_lt_iff {x : WithTop α} : ↑a < x ↔ ∀ b, x = ↑b → a < b := 
 
 end LT
 
-instance [Preorder α] : Preorder (WithTop α) where
+instance preorder [Preorder α] : Preorder (WithTop α) where
   le := (· ≤ ·)
   lt := (· < ·)
   lt_iff_le_not_le := by simp [← toDual_lt_toDual_iff, lt_iff_le_not_le]
@@ -1042,7 +1042,7 @@ instance [Preorder α] : Preorder (WithTop α) where
     exact Function.swap le_trans
 
 instance [PartialOrder α] : PartialOrder (WithTop α) :=
-  { instPreorderWithTop with
+  { WithTop.preorder with
     le_antisymm := fun _ _ => by
       simp_rw [← toDual_le_toDual_iff]
       exact Function.swap le_antisymm }
@@ -1096,7 +1096,7 @@ theorem map_le_iff [Preorder α] [Preorder β] (f : α → β) (a b : WithTop α
   simp [mono_iff]
 #align with_top.map_le_iff WithTop.map_le_iff
 
-instance [SemilatticeInf α] : SemilatticeInf (WithTop α) :=
+instance semilatticeInf [SemilatticeInf α] : SemilatticeInf (WithTop α) :=
   { instPartialOrderWithTop with
     inf := Option.liftOrGet (· ⊓ ·),
     inf_le_left := fun o₁ o₂ a ha => by cases ha ; cases o₂ <;> simp [Option.liftOrGet],
@@ -1116,7 +1116,7 @@ theorem coe_inf [SemilatticeInf α] (a b : α) : ((a ⊓ b : α) : WithTop α) =
   rfl
 #align with_top.coe_inf WithTop.coe_inf
 
-instance [SemilatticeSup α] : SemilatticeSup (WithTop α) :=
+instance semilatticeSup [SemilatticeSup α] : SemilatticeSup (WithTop α) :=
   { instPartialOrderWithTop with
     sup := fun o₁ o₂ => o₁.bind fun a => o₂.map fun b => a ⊔ b,
     le_sup_left := fun o₁ o₂ a ha => by
@@ -1137,11 +1137,11 @@ theorem coe_sup [SemilatticeSup α] (a b : α) : ((a ⊔ b : α) : WithTop α) =
   rfl
 #align with_top.coe_sup WithTop.coe_sup
 
-instance [Lattice α] : Lattice (WithTop α) :=
-  { instSemilatticeSupWithTop, instSemilatticeInfWithTop with }
+instance lattice [Lattice α] : Lattice (WithTop α) :=
+  { WithTop.semilatticeSup, WithTop.semilatticeInf with }
 
-instance [DistribLattice α] : DistribLattice (WithTop α) :=
-  { instLatticeWithTop with
+instance distribLattice [DistribLattice α] : DistribLattice (WithTop α) :=
+  { WithTop.lattice with
     le_sup_inf := fun o₁ o₂ o₃ =>
       match o₁, o₂, o₃ with
       | ⊤, _, _ => le_rfl
@@ -1150,15 +1150,15 @@ instance [DistribLattice α] : DistribLattice (WithTop α) :=
       | (a₁ : α), (a₂ : α), ⊤ => le_rfl
       | (a₁ : α), (a₂ : α), (a₃ : α) => coe_le_coe.mpr le_sup_inf }
 
-instance decidableLe [LE α] [@DecidableRel α (· ≤ ·)] :
+instance decidableLE [LE α] [@DecidableRel α (· ≤ ·)] :
     @DecidableRel (WithTop α) (· ≤ ·) := fun _ _ =>
   decidable_of_decidable_of_iff  toDual_le_toDual_iff
-#align with_top.decidable_le WithTop.decidableLe
+#align with_top.decidable_le WithTop.decidableLE
 
-instance decidableLt [LT α] [@DecidableRel α (· < ·)] :
+instance decidableLT [LT α] [@DecidableRel α (· < ·)] :
     @DecidableRel (WithTop α) (· < ·) := fun _ _ =>
   decidable_of_decidable_of_iff toDual_lt_toDual_iff
-#align with_top.decidable_lt WithTop.decidableLt
+#align with_top.decidable_lt WithTop.decidableLT
 
 instance isTotal_le [LE α] [IsTotal α (· ≤ ·)] : IsTotal (WithTop α) (· ≤ ·) :=
   ⟨fun _ _ => by
@@ -1166,7 +1166,7 @@ instance isTotal_le [LE α] [IsTotal α (· ≤ ·)] : IsTotal (WithTop α) (· 
     exact total_of _ _ _⟩
 #align with_top.is_total_le WithTop.isTotal_le
 
-instance [LinearOrder α] : LinearOrder (WithTop α) :=
+instance linearOrder [LinearOrder α] : LinearOrder (WithTop α) :=
   Lattice.toLinearOrder _
 
 @[simp, norm_cast]
@@ -1287,10 +1287,10 @@ theorem lt_iff_exists_coe_btwn [Preorder α] [DenselyOrdered α] [NoMaxOrder α]
     fun ⟨_, hx⟩ => lt_trans hx.1 hx.2⟩
 #align with_top.lt_iff_exists_coe_btwn WithTop.lt_iff_exists_coe_btwn
 
-instance [LE α] [NoBotOrder α] [Nonempty α] : NoBotOrder (WithTop α) :=
+instance noBotOrder [LE α] [NoBotOrder α] [Nonempty α] : NoBotOrder (WithTop α) :=
   @instNoBotOrderOrderDualInstLEOrderDual (WithBot αᵒᵈ) _ _
 
-instance [LT α] [NoMinOrder α] [Nonempty α] : NoMinOrder (WithTop α) :=
+instance noMinOrder [LT α] [NoMinOrder α] [Nonempty α] : NoMinOrder (WithTop α) :=
   @instNoMinOrderOrderDualInstLTOrderDual (WithBot αᵒᵈ) _ _
 
 end WithTop

--- a/Mathlib/Order/WithBot.lean
+++ b/Mathlib/Order/WithBot.lean
@@ -294,6 +294,7 @@ instance partialOrder [PartialOrder α] : PartialOrder (WithBot α) :=
         rcases h₂ b rfl with ⟨_, ⟨⟩, h₂'⟩
         rw [le_antisymm h₁' h₂']
          }
+#align with_bot.partial_order WithBot.partialOrder
 
 theorem coe_strictMono [Preorder α] : StrictMono (fun (a : α) => (a : WithBot α)) :=
   fun _ _ => coe_lt_coe.2
@@ -442,6 +443,7 @@ instance isTotal_le [LE α] [IsTotal α (· ≤ ·)] : IsTotal (WithBot α) (· 
 
 instance linearOrder [LinearOrder α] : LinearOrder (WithBot α) :=
   Lattice.toLinearOrder _
+#align with_bot.linear_order WithBot.linearOrder
 
 -- this is not marked simp because the corresponding with_top lemmas are used
 @[norm_cast]
@@ -790,8 +792,9 @@ instance orderTop : OrderTop (WithTop α) :=
 instance orderBot [OrderBot α] : OrderBot (WithTop α) where
   bot := some ⊥
   bot_le o a ha := by cases ha ; exact ⟨_, rfl, bot_le⟩
+#align with_top.order_bot WithTop.orderBot
 
-instance oundedOrder [OrderBot α] : BoundedOrder (WithTop α) :=
+instance boundedOrder [OrderBot α] : BoundedOrder (WithTop α) :=
   { WithTop.orderTop, WithTop.orderBot with }
 
 theorem not_top_le_coe (a : α) : ¬(⊤ : WithTop α) ≤ ↑a :=
@@ -1168,6 +1171,7 @@ instance isTotal_le [LE α] [IsTotal α (· ≤ ·)] : IsTotal (WithTop α) (· 
 
 instance linearOrder [LinearOrder α] : LinearOrder (WithTop α) :=
   Lattice.toLinearOrder _
+#align with_top.linear_order WithTop.linearOrder
 
 @[simp, norm_cast]
 theorem coe_min [LinearOrder α] (x y : α) : (↑(min x y) : WithTop α) = min (x : WithTop α) y :=

--- a/Mathlib/Order/WithBot.lean
+++ b/Mathlib/Order/WithBot.lean
@@ -406,7 +406,7 @@ theorem coe_inf [SemilatticeInf α] (a b : α) : ((a ⊓ b : α) : WithBot α) =
 instance lattice [Lattice α] : Lattice (WithBot α) :=
   { WithBot.semilatticeSup, WithBot.semilatticeInf with }
 
-instance instDistribLattice [DistribLattice α] : DistribLattice (WithBot α) :=
+instance distribLattice [DistribLattice α] : DistribLattice (WithBot α) :=
   { WithBot.lattice with
     le_sup_inf := fun o₁ o₂ o₃ =>
       match o₁, o₂, o₃ with
@@ -1101,7 +1101,7 @@ theorem map_le_iff [Preorder α] [Preorder β] (f : α → β) (a b : WithTop α
 #align with_top.map_le_iff WithTop.map_le_iff
 
 instance semilatticeInf [SemilatticeInf α] : SemilatticeInf (WithTop α) :=
-  { instPartialOrderWithTop with
+  { WithTop.partialOrder with
     inf := Option.liftOrGet (· ⊓ ·),
     inf_le_left := fun o₁ o₂ a ha => by cases ha ; cases o₂ <;> simp [Option.liftOrGet],
     inf_le_right := fun o₁ o₂ a ha => by cases ha ; cases o₁ <;> simp [Option.liftOrGet],
@@ -1121,7 +1121,7 @@ theorem coe_inf [SemilatticeInf α] (a b : α) : ((a ⊓ b : α) : WithTop α) =
 #align with_top.coe_inf WithTop.coe_inf
 
 instance semilatticeSup [SemilatticeSup α] : SemilatticeSup (WithTop α) :=
-  { instPartialOrderWithTop with
+  { WithTop.partialOrder with
     sup := fun o₁ o₂ => o₁.bind fun a => o₂.map fun b => a ⊔ b,
     le_sup_left := fun o₁ o₂ a ha => by
       simp [map] at ha

--- a/Mathlib/Order/WithBot.lean
+++ b/Mathlib/Order/WithBot.lean
@@ -1044,11 +1044,12 @@ instance preorder [Preorder α] : Preorder (WithTop α) where
     simp_rw [← toDual_le_toDual_iff]
     exact Function.swap le_trans
 
-instance [PartialOrder α] : PartialOrder (WithTop α) :=
+instance partialOrder [PartialOrder α] : PartialOrder (WithTop α) :=
   { WithTop.preorder with
     le_antisymm := fun _ _ => by
       simp_rw [← toDual_le_toDual_iff]
       exact Function.swap le_antisymm }
+#align with_top.partial_order WithTop.partialOrder
 
 theorem coe_strictMono [Preorder α] : StrictMono (fun a : α => (a : WithTop α)) :=
   fun _ _ => some_lt_some.2


### PR DESCRIPTION
`#align`s are missing, I'm having a hard time guessing the lean3 instance names...