### PR TITLE
[Merged by Bors] - feat: port Algebra.Group.WithOne.Basic

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -16,8 +16,8 @@ import Mathlib.Algebra.Group.Semiconj
 import Mathlib.Algebra.Group.TypeTags
 import Mathlib.Algebra.Group.ULift
 import Mathlib.Algebra.Group.Units
-import Mathlib.Algebra.Group.WithOne.Defs
 import Mathlib.Algebra.Group.WithOne.Basic
+import Mathlib.Algebra.Group.WithOne.Defs
 import Mathlib.Algebra.GroupPower.Basic
 import Mathlib.Algebra.GroupPower.Identities
 import Mathlib.Algebra.GroupPower.Lemmas

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -17,6 +17,7 @@ import Mathlib.Algebra.Group.TypeTags
 import Mathlib.Algebra.Group.ULift
 import Mathlib.Algebra.Group.Units
 import Mathlib.Algebra.Group.WithOne.Defs
+import Mathlib.Algebra.Group.WithOne.Basic
 import Mathlib.Algebra.GroupPower.Basic
 import Mathlib.Algebra.GroupPower.Identities
 import Mathlib.Algebra.GroupPower.Lemmas

--- a/Mathlib/Algebra/Group/WithOne/Basic.lean
+++ b/Mathlib/Algebra/Group/WithOne/Basic.lean
@@ -1,0 +1,151 @@
+/-
+Copyright (c) 2018 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro, Johan Commelin
+-/
+import Mathbin.Algebra.Group.WithOne.Defs
+import Mathbin.Algebra.Hom.Equiv.Basic
+
+/-!
+# More operations on `with_one` and `with_zero`
+
+This file defines various bundled morphisms on `with_one` and `with_zero`
+that were not available in `algebra/group/with_one/defs`.
+
+## Main definitions
+
+* `with_one.lift`, `with_zero.lift`
+* `with_one.map`, `with_zero.map`
+-/
+
+
+universe u v w
+
+variable {α : Type u} {β : Type v} {γ : Type w}
+
+namespace WithOne
+
+section
+
+-- workaround: we make `with_one`/`with_zero` irreducible for this definition, otherwise `simps`
+-- will unfold it in the statement of the lemma it generates.
+/-- `coe` as a bundled morphism -/
+@[to_additive "`coe` as a bundled morphism", simps apply]
+def coeMulHom [Mul α] : α →ₙ* WithOne α where 
+  toFun := coe
+  map_mul' x y := rfl
+#align with_one.coe_mul_hom WithOne.coeMulHom
+
+end
+
+section lift
+
+attribute [local semireducible] WithOne WithZero
+
+variable [Mul α] [MulOneClass β]
+
+/-- Lift a semigroup homomorphism `f` to a bundled monoid homorphism. -/
+@[to_additive "Lift an add_semigroup homomorphism `f` to a bundled add_monoid homorphism."]
+def lift :
+    (α →ₙ* β) ≃
+      (WithOne α →*
+        β) where 
+  toFun f :=
+    { toFun := fun x => Option.casesOn x 1 f, map_one' := rfl,
+      map_mul' := fun x y =>
+        (WithOne.cases_on x
+            (by 
+              rw [one_mul]
+              exact (one_mul _).symm))
+          fun x =>
+          (WithOne.cases_on y
+              (by 
+                rw [mul_one]
+                exact (mul_one _).symm))
+            fun y => f.map_mul x y }
+  invFun F := F.toMulHom.comp coeMulHom
+  left_inv f := MulHom.ext fun x => rfl
+  right_inv F := MonoidHom.ext fun x => (WithOne.cases_on x F.map_one.symm) fun x => rfl
+#align with_one.lift WithOne.lift
+
+variable (f : α →ₙ* β)
+
+@[simp, to_additive]
+theorem lift_coe (x : α) : lift f x = f x :=
+  rfl
+#align with_one.lift_coe WithOne.lift_coe
+
+@[simp, to_additive]
+theorem lift_one : lift f 1 = 1 :=
+  rfl
+#align with_one.lift_one WithOne.lift_one
+
+@[to_additive]
+theorem lift_unique (f : WithOne α →* β) : f = lift (f.toMulHom.comp coeMulHom) :=
+  (lift.apply_symm_apply f).symm
+#align with_one.lift_unique WithOne.lift_unique
+
+end lift
+
+section Map
+
+variable [Mul α] [Mul β] [Mul γ]
+
+/-- Given a multiplicative map from `α → β` returns a monoid homomorphism
+  from `with_one α` to `with_one β` -/
+@[to_additive
+      "Given an additive map from `α → β` returns an add_monoid homomorphism\n  from `with_zero α` to `with_zero β`"]
+def map (f : α →ₙ* β) : WithOne α →* WithOne β :=
+  lift (coeMulHom.comp f)
+#align with_one.map WithOne.map
+
+@[simp, to_additive]
+theorem map_coe (f : α →ₙ* β) (a : α) : map f (a : WithOne α) = f a :=
+  lift_coe _ _
+#align with_one.map_coe WithOne.map_coe
+
+@[simp, to_additive]
+theorem map_id : map (MulHom.id α) = MonoidHom.id (WithOne α) := by
+  ext
+  induction x using WithOne.cases_on <;> rfl
+#align with_one.map_id WithOne.map_id
+
+@[to_additive]
+theorem map_map (f : α →ₙ* β) (g : β →ₙ* γ) (x) : map g (map f x) = map (g.comp f) x := by
+  induction x using WithOne.cases_on <;> rfl
+#align with_one.map_map WithOne.map_map
+
+@[simp, to_additive]
+theorem map_comp (f : α →ₙ* β) (g : β →ₙ* γ) : map (g.comp f) = (map g).comp (map f) :=
+  MonoidHom.ext fun x => (map_map f g x).symm
+#align with_one.map_comp WithOne.map_comp
+
+/-- A version of `equiv.option_congr` for `with_one`. -/
+@[to_additive "A version of `equiv.option_congr` for `with_zero`.", simps apply]
+def MulEquiv.withOneCongr (e : α ≃* β) : WithOne α ≃* WithOne β :=
+  { map e.toMulHom with toFun := map e.toMulHom, invFun := map e.symm.toMulHom,
+    left_inv := fun x => (map_map _ _ _).trans <| by induction x using WithOne.cases_on <;> · simp,
+    right_inv := fun x =>
+      (map_map _ _ _).trans <| by induction x using WithOne.cases_on <;> · simp }
+#align mul_equiv.with_one_congr MulEquiv.withOneCongr
+
+@[simp]
+theorem MulEquiv.with_one_congr_refl : (MulEquiv.refl α).withOneCongr = MulEquiv.refl _ :=
+  MulEquiv.to_monoid_hom_injective map_id
+#align mul_equiv.with_one_congr_refl MulEquiv.with_one_congr_refl
+
+@[simp]
+theorem MulEquiv.with_one_congr_symm (e : α ≃* β) : e.withOneCongr.symm = e.symm.withOneCongr :=
+  rfl
+#align mul_equiv.with_one_congr_symm MulEquiv.with_one_congr_symm
+
+@[simp]
+theorem MulEquiv.with_one_congr_trans (e₁ : α ≃* β) (e₂ : β ≃* γ) :
+    e₁.withOneCongr.trans e₂.withOneCongr = (e₁.trans e₂).withOneCongr :=
+  MulEquiv.to_monoid_hom_injective (map_comp _ _).symm
+#align mul_equiv.with_one_congr_trans MulEquiv.with_one_congr_trans
+
+end Map
+
+end WithOne
+

--- a/Mathlib/Algebra/Group/WithOne/Basic.lean
+++ b/Mathlib/Algebra/Group/WithOne/Basic.lean
@@ -62,9 +62,9 @@ def lift :
   invFun F := F.toMulHom.comp coeMulHom
   left_inv f := MulHom.ext fun x => rfl
   right_inv F := MonoidHom.ext fun x => WithOne.cases_on x F.map_one.symm (fun x => rfl)
+-- porting note: the above proofs were broken because they were parenthesized wrong by mathport?
 #align with_one.lift WithOne.lift
 #align with_zero.lift WithZero.lift
--- porting note: the above proofs were broken because they were parenthesized wrong by mathport?
 
 variable (f : α →ₙ* β)
 
@@ -74,7 +74,8 @@ theorem lift_coe (x : α) : lift f x = f x :=
 #align with_one.lift_coe WithOne.lift_coe
 #align with_zero.lift_coe WithZero.lift_coe
 
-@[simp, to_additive]
+-- porting note: removed `simp` attribute to appease `simpNF` linter.
+@[to_additive]
 theorem lift_one : lift f 1 = 1 :=
   rfl
 #align with_one.lift_one WithOne.lift_one
@@ -132,6 +133,7 @@ def _root_.MulEquiv.withOneCongr (e : α ≃* β) : WithOne α ≃* WithOne β :
   { map e.toMulHom with
     toFun := map e.toMulHom, invFun := map e.symm.toMulHom,
     left_inv := fun x => (map_map _ _ _).trans <| by
+      -- porting note: in mathlib3 this worked as: `induction x using WithOne.cases_on <;> simp`
       induction x using WithOne.cases_on
       · simp
       · simp only [map_coe, MulHom.coe_mk, map_comp, MonoidHom.coe_comp, Function.comp_apply,
@@ -140,6 +142,7 @@ def _root_.MulEquiv.withOneCongr (e : α ≃* β) : WithOne α ≃* WithOne β :
       -- porting note: I think because of the way coercions are handled, this doesn't get changed
       -- by `simp` into something where `Equiv.symm_apply_apply` automatically applies.
     right_inv := fun x => (map_map _ _ _).trans <| by
+      -- porting note: in mathlib3 this worked as: `induction x using WithOne.cases_on <;> simp`
       induction x using WithOne.cases_on
       · simp
       · simp only [map_coe, MulHom.coe_mk, MulEquiv.toEquiv_symm, map_comp, MonoidHom.coe_comp,
@@ -149,7 +152,7 @@ def _root_.MulEquiv.withOneCongr (e : α ≃* β) : WithOne α ≃* WithOne β :
 #align add_equiv.with_zero_congr AddEquiv.withZeroCongr
 
 -- porting note: for this declaration and the two below I added the `to_additive` attribute because
--- it seemed to be mising from mathlib3, hence the lack of additive `#align`s.
+-- it seemed to be missing from mathlib3, hence the lack of additive `#align`s.
 @[simp, to_additive]
 theorem _root_.MulEquiv.withOneCongr_refl : (MulEquiv.refl α).withOneCongr = MulEquiv.refl _ :=
   MulEquiv.to_monoidHom_injective map_id

--- a/Mathlib/Algebra/Group/WithOne/Basic.lean
+++ b/Mathlib/Algebra/Group/WithOne/Basic.lean
@@ -7,15 +7,15 @@ import Mathlib.Algebra.Group.WithOne.Defs
 import Mathlib.Algebra.Hom.Equiv.Basic
 
 /-!
-# More operations on `with_one` and `with_zero`
+# More operations on `WithOne` and `WithZero`
 
-This file defines various bundled morphisms on `with_one` and `with_zero`
-that were not available in `algebra/group/with_one/defs`.
+This file defines various bundled morphisms on `WithOne` and `WithZero`
+that were not available in `Algebra/Group/WithOne/Defs`.
 
 ## Main definitions
 
-* `with_one.lift`, `with_zero.lift`
-* `with_one.map`, `with_zero.map`
+* `WithOne.lift`, `WithZero.lift`
+* `WithOne.map`, `WithZero.map`
 -/
 
 
@@ -27,14 +27,17 @@ namespace WithOne
 
 section
 
+-- porting note: the workaround described below doesn't seem to be a problem even with
+-- semireducible transparency
 -- workaround: we make `with_one`/`with_zero` irreducible for this definition, otherwise `simps`
 -- will unfold it in the statement of the lemma it generates.
-/-- `coe` as a bundled morphism -/
-@[to_additive "`coe` as a bundled morphism", simps apply]
+/-- `WithOne.coe` as a bundled morphism -/
+@[to_additive "`WithZero.coe` as a bundled morphism", simps apply]
 def coeMulHom [Mul α] : α →ₙ* WithOne α where
   toFun := coe
   map_mul' _ _ := rfl
 #align with_one.coe_mul_hom WithOne.coeMulHom
+#align with_zero.coe_add_hom WithZero.coeAddHom
 
 end
 
@@ -46,7 +49,7 @@ section lift
 variable [Mul α] [MulOneClass β]
 
 /-- Lift a semigroup homomorphism `f` to a bundled monoid homorphism. -/
-@[to_additive "Lift an add_semigroup homomorphism `f` to a bundled add_monoid homorphism."]
+@[to_additive "Lift an add semigroup homomorphism `f` to a bundled add monoid homorphism."]
 def lift :
     (α →ₙ* β) ≃
       (WithOne α →*
@@ -60,6 +63,7 @@ def lift :
   left_inv f := MulHom.ext fun x => rfl
   right_inv F := MonoidHom.ext fun x => WithOne.cases_on x F.map_one.symm (fun x => rfl)
 #align with_one.lift WithOne.lift
+#align with_zero.lift WithZero.lift
 -- porting note: the above proofs were broken because they were parenthesized wrong by mathport?
 
 variable (f : α →ₙ* β)
@@ -68,16 +72,19 @@ variable (f : α →ₙ* β)
 theorem lift_coe (x : α) : lift f x = f x :=
   rfl
 #align with_one.lift_coe WithOne.lift_coe
+#align with_zero.lift_coe WithZero.lift_coe
 
 @[simp, to_additive]
 theorem lift_one : lift f 1 = 1 :=
   rfl
 #align with_one.lift_one WithOne.lift_one
+#align with_zero.lift_zero WithZero.lift_zero
 
 @[to_additive]
 theorem lift_unique (f : WithOne α →* β) : f = lift (f.toMulHom.comp coeMulHom) :=
   (lift.apply_symm_apply f).symm
 #align with_one.lift_unique WithOne.lift_unique
+#align with_zero.lift_unique WithZero.lift_unique
 
 end lift
 
@@ -86,41 +93,46 @@ section Map
 variable [Mul α] [Mul β] [Mul γ]
 
 /-- Given a multiplicative map from `α → β` returns a monoid homomorphism
-  from `with_one α` to `with_one β` -/
-@[to_additive
-      "Given an additive map from `α → β` returns an add_monoid homomorphism\n  from `with_zero α` to `with_zero β`"]
+  from `WithOne α` to `WithOne β` -/
+@[to_additive "Given an additive map from `α → β` returns an add monoid homomorphism\n  from
+`WithZero α` to `WithZero β`"]
 def map (f : α →ₙ* β) : WithOne α →* WithOne β :=
   lift (coeMulHom.comp f)
 #align with_one.map WithOne.map
+#align with_zero.map WithZero.map
 
 @[simp, to_additive]
 theorem map_coe (f : α →ₙ* β) (a : α) : map f (a : WithOne α) = f a :=
   lift_coe _ _
 #align with_one.map_coe WithOne.map_coe
+#align with_zero.map_coe WithZero.map_coe
 
 @[simp, to_additive]
 theorem map_id : map (MulHom.id α) = MonoidHom.id (WithOne α) := by
   ext x
   induction x using WithOne.cases_on <;> rfl
 #align with_one.map_id WithOne.map_id
+#align with_zero.map_id WithZero.map_id
 
 @[to_additive]
 theorem map_map (f : α →ₙ* β) (g : β →ₙ* γ) (x) : map g (map f x) = map (g.comp f) x := by
   induction x using WithOne.cases_on <;> rfl
 #align with_one.map_map WithOne.map_map
+#align with_zero.map_map WithZero.map_map
 
 @[simp, to_additive]
 theorem map_comp (f : α →ₙ* β) (g : β →ₙ* γ) : map (g.comp f) = (map g).comp (map f) :=
   MonoidHom.ext fun x => (map_map f g x).symm
 #align with_one.map_comp WithOne.map_comp
+#align with_zero.map_comp WithZero.map_comp
 
-/-- A version of `equiv.option_congr` for `with_one`. -/
+/-- A version of `Equiv.optionCongr` for `WithOne`. -/
 @[to_additive "A version of `equiv.option_congr` for `with_zero`.", simps apply]
 def _root_.MulEquiv.withOneCongr (e : α ≃* β) : WithOne α ≃* WithOne β :=
   { map e.toMulHom with
     toFun := map e.toMulHom, invFun := map e.symm.toMulHom,
     left_inv := fun x => (map_map _ _ _).trans <| by
-      induction x using WithOne.cases_on;
+      induction x using WithOne.cases_on
       · simp
       · simp only [map_coe, MulHom.coe_mk, map_comp, MonoidHom.coe_comp, Function.comp_apply,
           MulEquiv.toEquiv_symm, coe_inj]
@@ -128,29 +140,32 @@ def _root_.MulEquiv.withOneCongr (e : α ≃* β) : WithOne α ≃* WithOne β :
       -- porting note: I think because of the way coercions are handled, this doesn't get changed
       -- by `simp` into something where `Equiv.symm_apply_apply` automatically applies.
     right_inv := fun x => (map_map _ _ _).trans <| by
-      induction x using WithOne.cases_on;
+      induction x using WithOne.cases_on
       · simp
       · simp only [map_coe, MulHom.coe_mk, MulEquiv.toEquiv_symm, map_comp, MonoidHom.coe_comp,
           Function.comp_apply, coe_inj]
         apply Equiv.apply_symm_apply }
 #align mul_equiv.with_one_congr MulEquiv.withOneCongr
+#align add_equiv.with_zero_congr AddEquiv.withZeroCongr
 
-@[simp]
-theorem _root_.MulEquiv.with_one_congr_refl : (MulEquiv.refl α).withOneCongr = MulEquiv.refl _ :=
+-- porting note: for this declaration and the two below I added the `to_additive` attribute because
+-- it seemed to be mising from mathlib3, hence the lack of additive `#align`s.
+@[simp, to_additive]
+theorem _root_.MulEquiv.withOneCongr_refl : (MulEquiv.refl α).withOneCongr = MulEquiv.refl _ :=
   MulEquiv.to_monoidHom_injective map_id
-#align mul_equiv.with_one_congr_refl MulEquiv.with_one_congr_refl
+#align mul_equiv.with_one_congr_refl MulEquiv.withOneCongr_refl
 
-@[simp]
-theorem _root_.MulEquiv.with_one_congr_symm (e : α ≃* β) :
+@[simp, to_additive]
+theorem _root_.MulEquiv.withOneCongr_symm (e : α ≃* β) :
     e.withOneCongr.symm = e.symm.withOneCongr :=
   rfl
-#align mul_equiv.with_one_congr_symm MulEquiv.with_one_congr_symm
+#align mul_equiv.with_one_congr_symm MulEquiv.withOneCongr_symm
 
-@[simp]
-theorem _root_.MulEquiv.with_one_congr_trans (e₁ : α ≃* β) (e₂ : β ≃* γ) :
+@[simp, to_additive]
+theorem _root_.MulEquiv.withOneCongr_trans (e₁ : α ≃* β) (e₂ : β ≃* γ) :
     e₁.withOneCongr.trans e₂.withOneCongr = (e₁.trans e₂).withOneCongr :=
   MulEquiv.to_monoidHom_injective (map_comp _ _).symm
-#align mul_equiv.with_one_congr_trans MulEquiv.with_one_congr_trans
+#align mul_equiv.with_one_congr_trans MulEquiv.withOneCongr_trans
 
 end Map
 

--- a/Mathlib/Algebra/Group/WithOne/Basic.lean
+++ b/Mathlib/Algebra/Group/WithOne/Basic.lean
@@ -3,8 +3,8 @@ Copyright (c) 2018 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Johan Commelin
 -/
-import Mathbin.Algebra.Group.WithOne.Defs
-import Mathbin.Algebra.Hom.Equiv.Basic
+import Mathlib.Algebra.Group.WithOne.Defs
+import Mathlib.Algebra.Hom.Equiv.Basic
 
 /-!
 # More operations on `with_one` and `with_zero`
@@ -31,16 +31,17 @@ section
 -- will unfold it in the statement of the lemma it generates.
 /-- `coe` as a bundled morphism -/
 @[to_additive "`coe` as a bundled morphism", simps apply]
-def coeMulHom [Mul α] : α →ₙ* WithOne α where 
+def coeMulHom [Mul α] : α →ₙ* WithOne α where
   toFun := coe
-  map_mul' x y := rfl
+  map_mul' _ _ := rfl
 #align with_one.coe_mul_hom WithOne.coeMulHom
 
 end
 
 section lift
 
-attribute [local semireducible] WithOne WithZero
+-- porting note: these were never marked with `irreducible` when they were defined.
+-- attribute [local semireducible] WithOne WithZero
 
 variable [Mul α] [MulOneClass β]
 
@@ -49,24 +50,17 @@ variable [Mul α] [MulOneClass β]
 def lift :
     (α →ₙ* β) ≃
       (WithOne α →*
-        β) where 
+        β) where
   toFun f :=
     { toFun := fun x => Option.casesOn x 1 f, map_one' := rfl,
-      map_mul' := fun x y =>
-        (WithOne.cases_on x
-            (by 
-              rw [one_mul]
-              exact (one_mul _).symm))
-          fun x =>
-          (WithOne.cases_on y
-              (by 
-                rw [mul_one]
-                exact (mul_one _).symm))
-            fun y => f.map_mul x y }
+      map_mul' := fun x y => WithOne.cases_on x (by rw [one_mul]; exact (one_mul _).symm)
+        (fun x => WithOne.cases_on y (by rw [mul_one]; exact (mul_one _).symm)
+          (fun y => f.map_mul x y)) }
   invFun F := F.toMulHom.comp coeMulHom
   left_inv f := MulHom.ext fun x => rfl
-  right_inv F := MonoidHom.ext fun x => (WithOne.cases_on x F.map_one.symm) fun x => rfl
+  right_inv F := MonoidHom.ext fun x => WithOne.cases_on x F.map_one.symm (fun x => rfl)
 #align with_one.lift WithOne.lift
+-- porting note: the above proofs were broken because they were parenthesized wrong by mathport?
 
 variable (f : α →ₙ* β)
 
@@ -106,7 +100,7 @@ theorem map_coe (f : α →ₙ* β) (a : α) : map f (a : WithOne α) = f a :=
 
 @[simp, to_additive]
 theorem map_id : map (MulHom.id α) = MonoidHom.id (WithOne α) := by
-  ext
+  ext x
   induction x using WithOne.cases_on <;> rfl
 #align with_one.map_id WithOne.map_id
 
@@ -122,30 +116,42 @@ theorem map_comp (f : α →ₙ* β) (g : β →ₙ* γ) : map (g.comp f) = (map
 
 /-- A version of `equiv.option_congr` for `with_one`. -/
 @[to_additive "A version of `equiv.option_congr` for `with_zero`.", simps apply]
-def MulEquiv.withOneCongr (e : α ≃* β) : WithOne α ≃* WithOne β :=
-  { map e.toMulHom with toFun := map e.toMulHom, invFun := map e.symm.toMulHom,
-    left_inv := fun x => (map_map _ _ _).trans <| by induction x using WithOne.cases_on <;> · simp,
-    right_inv := fun x =>
-      (map_map _ _ _).trans <| by induction x using WithOne.cases_on <;> · simp }
+def _root_.MulEquiv.withOneCongr (e : α ≃* β) : WithOne α ≃* WithOne β :=
+  { map e.toMulHom with
+    toFun := map e.toMulHom, invFun := map e.symm.toMulHom,
+    left_inv := fun x => (map_map _ _ _).trans <| by
+      induction x using WithOne.cases_on;
+      · simp
+      · simp only [map_coe, MulHom.coe_mk, map_comp, MonoidHom.coe_comp, Function.comp_apply,
+          MulEquiv.toEquiv_symm, coe_inj]
+        apply Equiv.symm_apply_apply,
+      -- porting note: I think because of the way coercions are handled, this doesn't get changed
+      -- by `simp` into something where `Equiv.symm_apply_apply` automatically applies.
+    right_inv := fun x => (map_map _ _ _).trans <| by
+      induction x using WithOne.cases_on;
+      · simp
+      · simp only [map_coe, MulHom.coe_mk, MulEquiv.toEquiv_symm, map_comp, MonoidHom.coe_comp,
+          Function.comp_apply, coe_inj]
+        apply Equiv.apply_symm_apply }
 #align mul_equiv.with_one_congr MulEquiv.withOneCongr
 
 @[simp]
-theorem MulEquiv.with_one_congr_refl : (MulEquiv.refl α).withOneCongr = MulEquiv.refl _ :=
-  MulEquiv.to_monoid_hom_injective map_id
+theorem _root_.MulEquiv.with_one_congr_refl : (MulEquiv.refl α).withOneCongr = MulEquiv.refl _ :=
+  MulEquiv.to_monoidHom_injective map_id
 #align mul_equiv.with_one_congr_refl MulEquiv.with_one_congr_refl
 
 @[simp]
-theorem MulEquiv.with_one_congr_symm (e : α ≃* β) : e.withOneCongr.symm = e.symm.withOneCongr :=
+theorem _root_.MulEquiv.with_one_congr_symm (e : α ≃* β) :
+    e.withOneCongr.symm = e.symm.withOneCongr :=
   rfl
 #align mul_equiv.with_one_congr_symm MulEquiv.with_one_congr_symm
 
 @[simp]
-theorem MulEquiv.with_one_congr_trans (e₁ : α ≃* β) (e₂ : β ≃* γ) :
+theorem _root_.MulEquiv.with_one_congr_trans (e₁ : α ≃* β) (e₂ : β ≃* γ) :
     e₁.withOneCongr.trans e₂.withOneCongr = (e₁.trans e₂).withOneCongr :=
-  MulEquiv.to_monoid_hom_injective (map_comp _ _).symm
+  MulEquiv.to_monoidHom_injective (map_comp _ _).symm
 #align mul_equiv.with_one_congr_trans MulEquiv.with_one_congr_trans
 
 end Map
 
 end WithOne
-


### PR DESCRIPTION
mathlib3 SHA: 4dc134b97a3de65ef2ed881f3513d56260971562

porting notes:

1. In `WithOne.lift` mathport's output was broken, but I think the only reason was that it was parenthesized wrong (or maybe it was a whitespace / formatting issue?)
2. In `MulEquiv.withOneCongr`, there were some `simp` calls that broke. I think this is a result of the way coercions are handled now. I think the net result is that `simp` doesn't get it into a form where it can apply `Equiv.symm_apply_apply`.
3. I added the `to_additive` attribute to `MulEquiv.withOneCongr_{refl, symm, trans}` because it just seemed to be missing from mathlib3.
4. `WithOne` already has semireducible transparency in mathlib4, so we are just ignoring the changing of transparency settings (this isn't even possible in Lean 4); see [Zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/local.20semireducible)