### PR TITLE
[Merged by Bors] - feat: re-port Algebra.Order.Monoid.WithZero

### DIFF
--- a/Mathlib/Algebra/Order/Monoid/WithZero/Defs.lean
+++ b/Mathlib/Algebra/Order/Monoid/WithZero/Defs.lean
@@ -19,32 +19,31 @@ variable {α : Type u}
 /-- A linearly ordered commutative monoid with a zero element. -/
 class LinearOrderedCommMonoidWithZero (α : Type _) extends LinearOrderedCommMonoid α,
   CommMonoidWithZero α where
+  /-- `0 ≤ 1` in any linearly ordered commutative monoid. -/
   zero_le_one : (0 : α) ≤ 1
 #align linear_ordered_comm_monoid_with_zero LinearOrderedCommMonoidWithZero
 
 instance (priority := 100) LinearOrderedCommMonoidWithZero.toZeroLeOneClass
-    [LinearOrderedCommMonoidWithZero α] : ZeroLeOneClass α :=
+    [LinearOrderedCommMonoidWithZero α] : ZeroLEOneClass α :=
   { ‹LinearOrderedCommMonoidWithZero α› with }
-#align
-  linear_ordered_comm_monoid_with_zero.to_zero_le_one_class LinearOrderedCommMonoidWithZero.toZeroLeOneClass
+#align linear_ordered_comm_monoid_with_zero.to_zero_le_one_class
+  LinearOrderedCommMonoidWithZero.toZeroLeOneClass
 
 instance (priority := 100) CanonicallyOrderedAddMonoid.toZeroLeOneClass
-    [CanonicallyOrderedAddMonoid α] [One α] : ZeroLeOneClass α :=
+    [CanonicallyOrderedAddMonoid α] [One α] : ZeroLEOneClass α :=
   ⟨zero_le 1⟩
 #align
   canonically_ordered_add_monoid.to_zero_le_one_class CanonicallyOrderedAddMonoid.toZeroLeOneClass
 
 namespace WithZero
 
-attribute [local semireducible] WithZero
-
-instance [Preorder α] : Preorder (WithZero α) :=
+instance preorder [Preorder α] : Preorder (WithZero α) :=
   WithBot.preorder
 
-instance [PartialOrder α] : PartialOrder (WithZero α) :=
+instance partialOrder [PartialOrder α] : PartialOrder (WithZero α) :=
   WithBot.partialOrder
 
-instance [Preorder α] : OrderBot (WithZero α) :=
+instance orderBot [Preorder α] : OrderBot (WithZero α) :=
   WithBot.orderBot
 
 theorem zero_le [Preorder α] (a : WithZero α) : 0 ≤ a :=
@@ -69,54 +68,55 @@ theorem coe_le_coe [Preorder α] {a b : α} : (a : WithZero α) ≤ b ↔ a ≤ 
   WithBot.coe_le_coe
 #align with_zero.coe_le_coe WithZero.coe_le_coe
 
-instance [Lattice α] : Lattice (WithZero α) :=
+instance lattice [Lattice α] : Lattice (WithZero α) :=
   WithBot.lattice
 
-instance [LinearOrder α] : LinearOrder (WithZero α) :=
+instance linearOrder [LinearOrder α] : LinearOrder (WithZero α) :=
   WithBot.linearOrder
 
-instance covariant_class_mul_le {α : Type u} [Mul α] [Preorder α]
+instance covariantClass_mul_le [Mul α] [Preorder α]
     [CovariantClass α α (· * ·) (· ≤ ·)] :
     CovariantClass (WithZero α) (WithZero α) (· * ·) (· ≤ ·) := by
-  refine' ⟨fun a b c hbc => _⟩
+  refine ⟨fun a b c hbc => ?_⟩
   induction a using WithZero.recZeroCoe; · exact zero_le _
   induction b using WithZero.recZeroCoe; · exact zero_le _
   rcases WithBot.coe_le_iff.1 hbc with ⟨c, rfl, hbc'⟩
-  rw [← coe_mul, ← coe_mul, coe_le_coe]
-  exact mul_le_mul_left' hbc' a
-#align with_zero.covariant_class_mul_le WithZero.covariant_class_mul_le
+  refine le_trans ?_ (le_of_eq <| coe_mul)
+  -- rw [← coe_mul, ← coe_mul, coe_le_coe]
+  -- Porting note: rewriting `coe_mul` here doesn't work because of some difference between
+  -- `coe` and `WithBot.some`, even though they're definitionally equal as shown by the `refine'`
+  rw [← coe_mul, coe_le_coe]
+  exact mul_le_mul_left' hbc' _
+#align with_zero.covariant_class_mul_le WithZero.covariantClass_mul_le
 
-@[simp]
-theorem le_max_iff [LinearOrder α] {a b c : α} : (a : WithZero α) ≤ max b c ↔ a ≤ max b c := by
-  simp only [WithZero.coe_le_coe, le_max_iff]
-#align with_zero.le_max_iff WithZero.le_max_iff
+-- Porting note: `simp` can prove these mathlib3 lemmas, so they are omitted.
+#noalign with_zero.le_max_iff
+#noalign with_zero.min_le_iff
 
-@[simp]
-theorem min_le_iff [LinearOrder α] {a b c : α} : min (a : WithZero α) b ≤ c ↔ min a b ≤ c := by
-  simp only [WithZero.coe_le_coe, min_le_iff]
-#align with_zero.min_le_iff WithZero.min_le_iff
-
-instance [OrderedCommMonoid α] : OrderedCommMonoid (WithZero α) :=
-  { WithZero.commMonoidWithZero, WithZero.partialOrder with
+instance orderedCommMonoid [OrderedCommMonoid α] : OrderedCommMonoid (WithZero α) :=
+  { WithZero.commMonoidWithZero.toCommMonoid, WithZero.partialOrder with
     mul_le_mul_left := fun _ _ => mul_le_mul_left' }
 
-protected theorem covariant_class_add_le [AddZeroClass α] [Preorder α]
+-- FIXME: `WithOne.coe_mul` and `WithZero.coe_mul` have inconsistent use of implicit parameters
+
+-- Porting note: same issue as `covariantClass_mul_le`
+protected theorem covariantClass_add_le [AddZeroClass α] [Preorder α]
     [CovariantClass α α (· + ·) (· ≤ ·)] (h : ∀ a : α, 0 ≤ a) :
     CovariantClass (WithZero α) (WithZero α) (· + ·) (· ≤ ·) := by
-  refine' ⟨fun a b c hbc => _⟩
+  refine ⟨fun a b c hbc => ?_⟩
   induction a using WithZero.recZeroCoe
   · rwa [zero_add, zero_add]
   induction b using WithZero.recZeroCoe
   · rw [add_zero]
     induction c using WithZero.recZeroCoe
     · rw [add_zero]
-      exact le_rfl
     · rw [← coe_add, coe_le_coe]
       exact le_add_of_nonneg_right (h _)
   · rcases WithBot.coe_le_iff.1 hbc with ⟨c, rfl, hbc'⟩
-    rw [← coe_add, ← coe_add, coe_le_coe]
-    exact add_le_add_left hbc' a
-#align with_zero.covariant_class_add_le WithZero.covariant_class_add_le
+    refine le_trans ?_ (le_of_eq <| coe_add _ _)
+    rw [← coe_add, coe_le_coe]
+    exact add_le_add_left hbc' _
+#align with_zero.covariant_class_add_le WithZero.covariantClass_add_le
 
 /-
 Note 1 : the below is not an instance because it requires `zero_le`. It seems
@@ -125,52 +125,54 @@ Note 2 : there is no multiplicative analogue because it does not seem necessary.
 Mathematicians might be more likely to use the order-dual version, where all
 elements are ≤ 1 and then 1 is the top element.
 -/
-/-- If `0` is the least element in `α`, then `with_zero α` is an `ordered_add_comm_monoid`.
+/-- If `0` is the least element in `α`, then `WithZero α` is an `OrderedAddCommMonoid`.
 See note [reducible non-instances].
 -/
 @[reducible]
 protected def orderedAddCommMonoid [OrderedAddCommMonoid α] (zero_le : ∀ a : α, 0 ≤ a) :
     OrderedAddCommMonoid (WithZero α) :=
   { WithZero.partialOrder, WithZero.addCommMonoid with
-    add_le_add_left := @add_le_add_left _ _ _ (WithZero.covariant_class_add_le zero_le).. }
+    add_le_add_left := @add_le_add_left _ _ _ (WithZero.covariantClass_add_le zero_le).. }
 #align with_zero.ordered_add_comm_monoid WithZero.orderedAddCommMonoid
-
-end WithZero
 
 section CanonicallyOrderedMonoid
 
-instance WithZero.has_exists_add_of_le {α} [Add α] [Preorder α] [HasExistsAddOfLe α] :
-    HasExistsAddOfLe (WithZero α) :=
-  ⟨fun a b => by
-    apply WithZero.cases_on a
+instance existsAddOfLE [Add α] [Preorder α] [ExistsAddOfLE α] :
+    ExistsAddOfLE (WithZero α) :=
+  ⟨fun {a b} => by
+    induction a using WithZero.cases_on
     · exact fun _ => ⟨b, (zero_add b).symm⟩
-    apply WithZero.cases_on b
-    · exact fun b' h => (WithBot.not_coe_le_bot _ h).elim
-    rintro a' b' h
+    induction b using WithZero.cases_on
+    · exact fun h => (WithBot.not_coe_le_bot _ h).elim
+    intro h
     obtain ⟨c, rfl⟩ := exists_add_of_le (WithZero.coe_le_coe.1 h)
     exact ⟨c, rfl⟩⟩
-#align with_zero.has_exists_add_of_le WithZero.has_exists_add_of_le
+#align with_zero.has_exists_add_of_le WithZero.existsAddOfLE
 
 -- This instance looks absurd: a monoid already has a zero
 /-- Adding a new zero to a canonically ordered additive monoid produces another one. -/
-instance WithZero.canonicallyOrderedAddMonoid {α : Type u} [CanonicallyOrderedAddMonoid α] :
+instance canonicallyOrderedAddMonoid [CanonicallyOrderedAddMonoid α] :
     CanonicallyOrderedAddMonoid (WithZero α) :=
-  { WithZero.orderBot, WithZero.orderedAddCommMonoid zero_le, WithZero.has_exists_add_of_le with
+  { WithZero.orderBot,
+    WithZero.orderedAddCommMonoid _root_.zero_le,
+    WithZero.existsAddOfLE with
     le_self_add := fun a b => by
-      apply WithZero.cases_on a
+      induction a using WithZero.cases_on
       · exact bot_le
-      apply WithZero.cases_on b
-      · exact fun b' => le_rfl
-      · exact fun a' b' => WithZero.coe_le_coe.2 le_self_add }
+      induction b using WithZero.cases_on
+      · exact le_rfl
+      · exact WithZero.coe_le_coe.2 le_self_add }
 #align with_zero.canonically_ordered_add_monoid WithZero.canonicallyOrderedAddMonoid
 
 end CanonicallyOrderedMonoid
 
 section CanonicallyLinearOrderedMonoid
 
-instance WithZero.canonicallyLinearOrderedAddMonoid (α : Type _)
+instance canonicallyLinearOrderedAddMonoid (α : Type _)
     [CanonicallyLinearOrderedAddMonoid α] : CanonicallyLinearOrderedAddMonoid (WithZero α) :=
   { WithZero.canonicallyOrderedAddMonoid, WithZero.linearOrder with }
 #align with_zero.canonically_linear_ordered_add_monoid WithZero.canonicallyLinearOrderedAddMonoid
 
 end CanonicallyLinearOrderedMonoid
+
+end WithZero

--- a/Mathlib/Algebra/Order/Monoid/WithZero/Defs.lean
+++ b/Mathlib/Algebra/Order/Monoid/WithZero/Defs.lean
@@ -5,6 +5,7 @@ Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro, Johannes Hölzl
 -/
 import Mathlib.Algebra.Group.WithOne.Defs
 import Mathlib.Algebra.Order.Monoid.Canonical.Defs
+import Mathlib.Algebra.Order.ZeroLeOne
 
 /-!
 # Adjoining a zero element to an ordered monoid.
@@ -18,19 +19,32 @@ variable {α : Type u}
 /-- A linearly ordered commutative monoid with a zero element. -/
 class LinearOrderedCommMonoidWithZero (α : Type _) extends LinearOrderedCommMonoid α,
   CommMonoidWithZero α where
-  /-- `0 ≤ 1` in any linearly ordered commutative monoid. -/
   zero_le_one : (0 : α) ≤ 1
 #align linear_ordered_comm_monoid_with_zero LinearOrderedCommMonoidWithZero
 
+instance (priority := 100) LinearOrderedCommMonoidWithZero.toZeroLeOneClass
+    [LinearOrderedCommMonoidWithZero α] : ZeroLeOneClass α :=
+  { ‹LinearOrderedCommMonoidWithZero α› with }
+#align
+  linear_ordered_comm_monoid_with_zero.to_zero_le_one_class LinearOrderedCommMonoidWithZero.toZeroLeOneClass
+
+instance (priority := 100) CanonicallyOrderedAddMonoid.toZeroLeOneClass
+    [CanonicallyOrderedAddMonoid α] [One α] : ZeroLeOneClass α :=
+  ⟨zero_le 1⟩
+#align
+  canonically_ordered_add_monoid.to_zero_le_one_class CanonicallyOrderedAddMonoid.toZeroLeOneClass
+
 namespace WithZero
 
-instance preorder [Preorder α] : Preorder (WithZero α) :=
+attribute [local semireducible] WithZero
+
+instance [Preorder α] : Preorder (WithZero α) :=
   WithBot.preorder
 
-instance partialOrder [PartialOrder α] : PartialOrder (WithZero α) :=
+instance [PartialOrder α] : PartialOrder (WithZero α) :=
   WithBot.partialOrder
 
-instance orderBot [Preorder α] : OrderBot (WithZero α) :=
+instance [Preorder α] : OrderBot (WithZero α) :=
   WithBot.orderBot
 
 theorem zero_le [Preorder α] (a : WithZero α) : 0 ≤ a :=
@@ -55,55 +69,54 @@ theorem coe_le_coe [Preorder α] {a b : α} : (a : WithZero α) ≤ b ↔ a ≤ 
   WithBot.coe_le_coe
 #align with_zero.coe_le_coe WithZero.coe_le_coe
 
-instance lattice [Lattice α] : Lattice (WithZero α) :=
+instance [Lattice α] : Lattice (WithZero α) :=
   WithBot.lattice
 
-instance linearOrder [LinearOrder α] : LinearOrder (WithZero α) :=
+instance [LinearOrder α] : LinearOrder (WithZero α) :=
   WithBot.linearOrder
 
-instance covariantClass_mul_le [Mul α] [Preorder α]
+instance covariant_class_mul_le {α : Type u} [Mul α] [Preorder α]
     [CovariantClass α α (· * ·) (· ≤ ·)] :
     CovariantClass (WithZero α) (WithZero α) (· * ·) (· ≤ ·) := by
-  refine ⟨fun a b c hbc => ?_⟩
+  refine' ⟨fun a b c hbc => _⟩
   induction a using WithZero.recZeroCoe; · exact zero_le _
   induction b using WithZero.recZeroCoe; · exact zero_le _
   rcases WithBot.coe_le_iff.1 hbc with ⟨c, rfl, hbc'⟩
-  refine le_trans ?_ (le_of_eq <| coe_mul)
-  -- rw [← coe_mul, ← coe_mul, coe_le_coe]
-  -- Porting note: rewriting `coe_mul` here doesn't work because of some difference between
-  -- `coe` and `WithBot.some`, even though they're definitionally equal as shown by the `refine'`
-  rw [← coe_mul, coe_le_coe]
-  exact mul_le_mul_left' hbc' _
-#align with_zero.covariant_class_mul_le WithZero.covariantClass_mul_le
+  rw [← coe_mul, ← coe_mul, coe_le_coe]
+  exact mul_le_mul_left' hbc' a
+#align with_zero.covariant_class_mul_le WithZero.covariant_class_mul_le
 
--- Porting note: `simp` can prove these mathlib3 lemmas, so they are omitted.
-#noalign with_zero.le_max_iff
-#noalign with_zero.min_le_iff
+@[simp]
+theorem le_max_iff [LinearOrder α] {a b c : α} : (a : WithZero α) ≤ max b c ↔ a ≤ max b c := by
+  simp only [WithZero.coe_le_coe, le_max_iff]
+#align with_zero.le_max_iff WithZero.le_max_iff
 
-instance orderedCommMonoid [OrderedCommMonoid α] : OrderedCommMonoid (WithZero α) :=
-  { WithZero.commMonoidWithZero.toCommMonoid, WithZero.partialOrder with
+@[simp]
+theorem min_le_iff [LinearOrder α] {a b c : α} : min (a : WithZero α) b ≤ c ↔ min a b ≤ c := by
+  simp only [WithZero.coe_le_coe, min_le_iff]
+#align with_zero.min_le_iff WithZero.min_le_iff
+
+instance [OrderedCommMonoid α] : OrderedCommMonoid (WithZero α) :=
+  { WithZero.commMonoidWithZero, WithZero.partialOrder with
     mul_le_mul_left := fun _ _ => mul_le_mul_left' }
 
--- FIXME: `WithOne.coe_mul` and `WithZero.coe_mul` have inconsistent use of implicit parameters
-
--- Porting note: same issue as `covariantClass_mul_le`
-protected theorem covariantClass_add_le [AddZeroClass α] [Preorder α]
+protected theorem covariant_class_add_le [AddZeroClass α] [Preorder α]
     [CovariantClass α α (· + ·) (· ≤ ·)] (h : ∀ a : α, 0 ≤ a) :
     CovariantClass (WithZero α) (WithZero α) (· + ·) (· ≤ ·) := by
-  refine ⟨fun a b c hbc => ?_⟩
+  refine' ⟨fun a b c hbc => _⟩
   induction a using WithZero.recZeroCoe
   · rwa [zero_add, zero_add]
   induction b using WithZero.recZeroCoe
   · rw [add_zero]
     induction c using WithZero.recZeroCoe
     · rw [add_zero]
+      exact le_rfl
     · rw [← coe_add, coe_le_coe]
       exact le_add_of_nonneg_right (h _)
   · rcases WithBot.coe_le_iff.1 hbc with ⟨c, rfl, hbc'⟩
-    refine le_trans ?_ (le_of_eq <| coe_add _ _)
-    rw [← coe_add, coe_le_coe]
-    exact add_le_add_left hbc' _
-#align with_zero.covariant_class_add_le WithZero.covariantClass_add_le
+    rw [← coe_add, ← coe_add, coe_le_coe]
+    exact add_le_add_left hbc' a
+#align with_zero.covariant_class_add_le WithZero.covariant_class_add_le
 
 /-
 Note 1 : the below is not an instance because it requires `zero_le`. It seems
@@ -112,54 +125,52 @@ Note 2 : there is no multiplicative analogue because it does not seem necessary.
 Mathematicians might be more likely to use the order-dual version, where all
 elements are ≤ 1 and then 1 is the top element.
 -/
-/-- If `0` is the least element in `α`, then `WithZero α` is an `OrderedAddCommMonoid`.
+/-- If `0` is the least element in `α`, then `with_zero α` is an `ordered_add_comm_monoid`.
 See note [reducible non-instances].
 -/
 @[reducible]
 protected def orderedAddCommMonoid [OrderedAddCommMonoid α] (zero_le : ∀ a : α, 0 ≤ a) :
     OrderedAddCommMonoid (WithZero α) :=
   { WithZero.partialOrder, WithZero.addCommMonoid with
-    add_le_add_left := @add_le_add_left _ _ _ (WithZero.covariantClass_add_le zero_le).. }
+    add_le_add_left := @add_le_add_left _ _ _ (WithZero.covariant_class_add_le zero_le).. }
 #align with_zero.ordered_add_comm_monoid WithZero.orderedAddCommMonoid
+
+end WithZero
 
 section CanonicallyOrderedMonoid
 
-instance existsAddOfLE [Add α] [Preorder α] [ExistsAddOfLE α] :
-    ExistsAddOfLE (WithZero α) :=
-  ⟨fun {a b} => by
-    induction a using WithZero.cases_on
+instance WithZero.has_exists_add_of_le {α} [Add α] [Preorder α] [HasExistsAddOfLe α] :
+    HasExistsAddOfLe (WithZero α) :=
+  ⟨fun a b => by
+    apply WithZero.cases_on a
     · exact fun _ => ⟨b, (zero_add b).symm⟩
-    induction b using WithZero.cases_on
-    · exact fun h => (WithBot.not_coe_le_bot _ h).elim
-    intro h
+    apply WithZero.cases_on b
+    · exact fun b' h => (WithBot.not_coe_le_bot _ h).elim
+    rintro a' b' h
     obtain ⟨c, rfl⟩ := exists_add_of_le (WithZero.coe_le_coe.1 h)
     exact ⟨c, rfl⟩⟩
-#align with_zero.has_exists_add_of_le WithZero.existsAddOfLE
+#align with_zero.has_exists_add_of_le WithZero.has_exists_add_of_le
 
 -- This instance looks absurd: a monoid already has a zero
 /-- Adding a new zero to a canonically ordered additive monoid produces another one. -/
-instance canonicallyOrderedAddMonoid [CanonicallyOrderedAddMonoid α] :
+instance WithZero.canonicallyOrderedAddMonoid {α : Type u} [CanonicallyOrderedAddMonoid α] :
     CanonicallyOrderedAddMonoid (WithZero α) :=
-  { WithZero.orderBot,
-    WithZero.orderedAddCommMonoid _root_.zero_le,
-    WithZero.existsAddOfLE with
+  { WithZero.orderBot, WithZero.orderedAddCommMonoid zero_le, WithZero.has_exists_add_of_le with
     le_self_add := fun a b => by
-      induction a using WithZero.cases_on
+      apply WithZero.cases_on a
       · exact bot_le
-      induction b using WithZero.cases_on
-      · exact le_rfl
-      · exact WithZero.coe_le_coe.2 le_self_add }
+      apply WithZero.cases_on b
+      · exact fun b' => le_rfl
+      · exact fun a' b' => WithZero.coe_le_coe.2 le_self_add }
 #align with_zero.canonically_ordered_add_monoid WithZero.canonicallyOrderedAddMonoid
 
 end CanonicallyOrderedMonoid
 
 section CanonicallyLinearOrderedMonoid
 
-instance canonicallyLinearOrderedAddMonoid (α : Type _)
+instance WithZero.canonicallyLinearOrderedAddMonoid (α : Type _)
     [CanonicallyLinearOrderedAddMonoid α] : CanonicallyLinearOrderedAddMonoid (WithZero α) :=
   { WithZero.canonicallyOrderedAddMonoid, WithZero.linearOrder with }
 #align with_zero.canonically_linear_ordered_add_monoid WithZero.canonicallyLinearOrderedAddMonoid
 
 end CanonicallyLinearOrderedMonoid
-
-end WithZero

--- a/Mathlib/Algebra/Order/Monoid/WithZero/Defs.lean
+++ b/Mathlib/Algebra/Order/Monoid/WithZero/Defs.lean
@@ -5,7 +5,7 @@ Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro, Johannes Hölzl
 -/
 import Mathlib.Algebra.Group.WithOne.Defs
 import Mathlib.Algebra.Order.Monoid.Canonical.Defs
-import Mathlib.Algebra.Order.ZeroLeOne
+import Mathlib.Algebra.Order.ZeroLEOne
 
 /-!
 # Adjoining a zero element to an ordered monoid.


### PR DESCRIPTION
This file had been modified in mathlib3 since the commit that the first port was based on.

Here is the mathlib3 commit that this port is based on:
[4dc134b97a3de65ef2ed881f3513d56260971562](https://github.com/leanprover-community/mathlib/commit/4dc134b97a3de65ef2ed881f3513d56260971562)

The first commit here is the output of mathport on that commit, in case anyone wants to check the diff.