### PR TITLE
[Merged by Bors] - feat port: Algebra.Order.Ring.Cone

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -66,6 +66,7 @@ import Mathlib.Algebra.Order.Monoid.WithZero.Defs
 import Mathlib.Algebra.Order.Positive.Ring
 import Mathlib.Algebra.Order.Ring.Canonical
 import Mathlib.Algebra.Order.Ring.CharZero
+import Mathlib.Algebra.Order.Ring.Cone
 import Mathlib.Algebra.Order.Ring.Defs
 import Mathlib.Algebra.Order.Ring.InjSurj
 import Mathlib.Algebra.Order.Ring.Lemmas

--- a/Mathlib/Algebra/Order/Group/Defs.lean
+++ b/Mathlib/Algebra/Order/Group/Defs.lean
@@ -981,7 +981,9 @@ structure PositiveCone (α : Type _) [AddCommGroup α] where
 for every `a`, either `a` or `-a` is non-negative. -/
 -- Porting note: @[nolint has_nonempty_instance]
 structure TotalPositiveCone (α : Type _) [AddCommGroup α] extends PositiveCone α where
+  /-- For any `a` the proposition `nonneg a` is decidable -/
   nonnegDecidable : DecidablePred nonneg
+  /-- Either `a` or `-a` is `nonneg` -/
   nonneg_total : ∀ a : α, nonneg a ∨ nonneg (-a)
 #align add_comm_group.total_positive_cone AddCommGroup.TotalPositiveCone
 

--- a/Mathlib/Algebra/Order/Ring/Cone.lean
+++ b/Mathlib/Algebra/Order/Ring/Cone.lean
@@ -18,30 +18,29 @@ variable {α : Type _} [Ring α] [Nontrivial α]
 
 namespace Ring
 
-/-- A positive cone in a ring consists of a positive cone in underlying `add_comm_group`,
+/-- A positive cone in a ring consists of a positive cone in underlying `AddCommGroup`,
 which contains `1` and such that the positive elements are closed under multiplication. -/
-@[nolint has_nonempty_instance]
 structure PositiveCone (α : Type _) [Ring α] extends AddCommGroup.PositiveCone α where
   one_nonneg : nonneg 1
-  mul_pos : ∀ a b, Pos a → Pos b → Pos (a * b)
+  mul_pos : ∀ a b, pos a → pos b → pos (a * b)
 #align ring.positive_cone Ring.PositiveCone
 
 /-- Forget that a positive cone in a ring respects the multiplicative structure. -/
-add_decl_doc positive_cone.to_positive_cone
+add_decl_doc PositiveCone.toPositiveCone
 
 /-- A total positive cone in a nontrivial ring induces a linear order. -/
-@[nolint has_nonempty_instance]
 structure TotalPositiveCone (α : Type _) [Ring α] extends PositiveCone α,
   AddCommGroup.TotalPositiveCone α
 #align ring.total_positive_cone Ring.TotalPositiveCone
+#align ring.total_positive_cone.to_positive_cone Ring.TotalPositiveCone.toPositiveCone_1
 
-/-- Forget that a `total_positive_cone` in a ring is total. -/
-add_decl_doc total_positive_cone.to_positive_cone
+/-- Forget that a `TotalPositiveCone` in a ring is total. -/
+add_decl_doc TotalPositiveCone.toPositiveCone_1
 
-/-- Forget that a `total_positive_cone` in a ring respects the multiplicative structure. -/
-add_decl_doc total_positive_cone.to_total_positive_cone
+/-- Forget that a `TotalPositiveCone` in a ring respects the multiplicative structure. -/
+add_decl_doc TotalPositiveCone.toTotalPositiveCone
 
-theorem PositiveCone.one_pos (C : PositiveCone α) : C.Pos 1 :=
+theorem PositiveCone.one_pos (C : PositiveCone α) : C.pos 1 :=
   (C.pos_iff _).2 ⟨C.one_nonneg, fun h => one_ne_zero <| C.nonneg_antisymm C.one_nonneg h⟩
 #align ring.positive_cone.one_pos Ring.PositiveCone.one_pos
 
@@ -49,7 +48,7 @@ end Ring
 
 open Ring
 
-/-- Construct a `strict_ordered_ring` by designating a positive cone in an existing `ring`. -/
+/-- Construct a `StrictOrderedRing` by designating a positive cone in an existing `Ring`. -/
 def StrictOrderedRing.mkOfPositiveCone (C : PositiveCone α) : StrictOrderedRing α :=
   { ‹Ring α›, OrderedAddCommGroup.mkOfPositiveCone C.toPositiveCone with
     exists_pair_ne := ⟨0, 1, fun h => by simpa [← h, C.pos_iff] using C.one_pos⟩,
@@ -70,9 +69,9 @@ def StrictOrderedRing.mkOfPositiveCone (C : PositiveCone α) : StrictOrderedRing
       simp }
 #align strict_ordered_ring.mk_of_positive_cone StrictOrderedRing.mkOfPositiveCone
 
-/-- Construct a `linear_ordered_ring` by
-designating a positive cone in an existing `ring`. -/
+/-- Construct a `LinearOrderedRing` by
+designating a positive cone in an existing `Ring`. -/
 def LinearOrderedRing.mkOfPositiveCone (C : TotalPositiveCone α) : LinearOrderedRing α :=
-  { StrictOrderedRing.mkOfPositiveCone C.toPositiveCone,
-    LinearOrderedAddCommGroup.mkOfPositiveCone C.toTotalPositiveCone with }
+  { LinearOrderedAddCommGroup.mkOfPositiveCone C.toTotalPositiveCone,
+    StrictOrderedRing.mkOfPositiveCone C.toPositiveCone_1 with }
 #align linear_ordered_ring.mk_of_positive_cone LinearOrderedRing.mkOfPositiveCone

--- a/Mathlib/Algebra/Order/Ring/Cone.lean
+++ b/Mathlib/Algebra/Order/Ring/Cone.lean
@@ -60,14 +60,7 @@ def StrictOrderedRing.mkOfPositiveCone (C : PositiveCone α) : StrictOrderedRing
       simp,
     mul_pos := fun x y xp yp => by
       change C.pos (x * y - 0)
-      convert
-        C.mul_pos x y
-          (by
-            convert xp
-            simp)
-          (by
-            convert yp
-            simp)
+      convert C.mul_pos x y (by convert xp; simp) (by convert yp; simp)
       simp }
 #align strict_ordered_ring.mk_of_positive_cone StrictOrderedRing.mkOfPositiveCone
 

--- a/Mathlib/Algebra/Order/Ring/Cone.lean
+++ b/Mathlib/Algebra/Order/Ring/Cone.lean
@@ -21,7 +21,9 @@ namespace Ring
 /-- A positive cone in a ring consists of a positive cone in underlying `AddCommGroup`,
 which contains `1` and such that the positive elements are closed under multiplication. -/
 structure PositiveCone (α : Type _) [Ring α] extends AddCommGroup.PositiveCone α where
+  /-- In a positive cone, `1` is `nonneg` -/
   one_nonneg : nonneg 1
+  /-- In a positive cone, if `a` and `b` are `pos` then so is `a * b` -/
   mul_pos : ∀ a b, pos a → pos b → pos (a * b)
 #align ring.positive_cone Ring.PositiveCone
 

--- a/Mathlib/Algebra/Order/Ring/Cone.lean
+++ b/Mathlib/Algebra/Order/Ring/Cone.lean
@@ -1,0 +1,78 @@
+/-
+Copyright (c) 2016 Jeremy Avigad. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro
+-/
+import Mathlib.Algebra.Order.Ring.Defs
+
+/-!
+# Constructing an ordered ring from a ring with a specified positive cone.
+
+-/
+
+
+/-! ### Positive cones -/
+
+
+variable {α : Type _} [Ring α] [Nontrivial α]
+
+namespace Ring
+
+/-- A positive cone in a ring consists of a positive cone in underlying `add_comm_group`,
+which contains `1` and such that the positive elements are closed under multiplication. -/
+@[nolint has_nonempty_instance]
+structure PositiveCone (α : Type _) [Ring α] extends AddCommGroup.PositiveCone α where
+  one_nonneg : nonneg 1
+  mul_pos : ∀ a b, Pos a → Pos b → Pos (a * b)
+#align ring.positive_cone Ring.PositiveCone
+
+/-- Forget that a positive cone in a ring respects the multiplicative structure. -/
+add_decl_doc positive_cone.to_positive_cone
+
+/-- A total positive cone in a nontrivial ring induces a linear order. -/
+@[nolint has_nonempty_instance]
+structure TotalPositiveCone (α : Type _) [Ring α] extends PositiveCone α,
+  AddCommGroup.TotalPositiveCone α
+#align ring.total_positive_cone Ring.TotalPositiveCone
+
+/-- Forget that a `total_positive_cone` in a ring is total. -/
+add_decl_doc total_positive_cone.to_positive_cone
+
+/-- Forget that a `total_positive_cone` in a ring respects the multiplicative structure. -/
+add_decl_doc total_positive_cone.to_total_positive_cone
+
+theorem PositiveCone.one_pos (C : PositiveCone α) : C.Pos 1 :=
+  (C.pos_iff _).2 ⟨C.one_nonneg, fun h => one_ne_zero <| C.nonneg_antisymm C.one_nonneg h⟩
+#align ring.positive_cone.one_pos Ring.PositiveCone.one_pos
+
+end Ring
+
+open Ring
+
+/-- Construct a `strict_ordered_ring` by designating a positive cone in an existing `ring`. -/
+def StrictOrderedRing.mkOfPositiveCone (C : PositiveCone α) : StrictOrderedRing α :=
+  { ‹Ring α›, OrderedAddCommGroup.mkOfPositiveCone C.toPositiveCone with
+    exists_pair_ne := ⟨0, 1, fun h => by simpa [← h, C.pos_iff] using C.one_pos⟩,
+    zero_le_one := by
+      change C.nonneg (1 - 0)
+      convert C.one_nonneg
+      simp,
+    mul_pos := fun x y xp yp => by
+      change C.pos (x * y - 0)
+      convert
+        C.mul_pos x y
+          (by
+            convert xp
+            simp)
+          (by
+            convert yp
+            simp)
+      simp }
+#align strict_ordered_ring.mk_of_positive_cone StrictOrderedRing.mkOfPositiveCone
+
+/-- Construct a `linear_ordered_ring` by
+designating a positive cone in an existing `ring`. -/
+def LinearOrderedRing.mkOfPositiveCone (C : TotalPositiveCone α) : LinearOrderedRing α :=
+  { StrictOrderedRing.mkOfPositiveCone C.toPositiveCone,
+    LinearOrderedAddCommGroup.mkOfPositiveCone C.toTotalPositiveCone with }
+#align linear_ordered_ring.mk_of_positive_cone LinearOrderedRing.mkOfPositiveCone


### PR DESCRIPTION
10b4e499f43088dd3bb7b5796184ad5216648ab1

No real problems other than the fact that the new autogenerated name for `ring.total_positive_cone.to_positive_cone` is `Ring.TotalPositiveCone.toPositiveCone_1`. No idea why there is a `_1` at the end.