### PR TITLE
[Merged by Bors] - feat: port algebra.order.group.with_top

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -50,6 +50,7 @@ import Mathlib.Algebra.Order.Group.MinMax
 import Mathlib.Algebra.Order.Group.OrderIso
 import Mathlib.Algebra.Order.Group.TypeTags
 import Mathlib.Algebra.Order.Group.Units
+import Mathlib.Algebra.Order.Group.WithTop
 import Mathlib.Algebra.Order.Hom.Basic
 import Mathlib.Algebra.Order.Monoid.Basic
 import Mathlib.Algebra.Order.Monoid.Cancel.Basic

--- a/Mathlib/Algebra/Order/Group/WithTop.lean
+++ b/Mathlib/Algebra/Order/Group/WithTop.lean
@@ -10,6 +10,7 @@ import Mathlib.Algebra.Order.Monoid.WithTop
 # Adjoining a top element to a `linear_ordered_add_comm_group_with_top`.
 -/
 
+namespace WithTop
 
 variable {α : Type _}
 
@@ -17,19 +18,22 @@ section LinearOrderedAddCommGroup
 
 variable [LinearOrderedAddCommGroup α] {a b c d : α}
 
-instance WithTop.linearOrderedAddCommGroupWithTop : LinearOrderedAddCommGroupWithTop (WithTop α) :=
-  { WithTop.linearOrderedAddCommMonoidWithTop, Option.nontrivial with
-    neg := Option.map fun a : α => -a, neg_top := @Option.map_none _ _ fun a : α => -a,
-    add_neg_cancel := by 
-      rintro (a | a) ha
-      · exact (ha rfl).elim
-      · exact with_top.coe_add.symm.trans (WithTop.coe_eq_coe.2 (add_neg_self a)) }
+instance linearOrderedAddCommGroupWithTop : LinearOrderedAddCommGroupWithTop (WithTop α) where
+  __ := WithTop.linearOrderedAddCommMonoidWithTop
+  __ := Option.nontrivial
+  neg := Option.map fun a : α => -a
+  neg_top := Option.map_none
+  add_neg_cancel := by
+    rintro (a | a) ha
+    · exact (ha rfl).elim
+    · exact WithTop.coe_add.symm.trans (WithTop.coe_eq_coe.2 (add_neg_self a))
 #align with_top.linear_ordered_add_comm_group_with_top WithTop.linearOrderedAddCommGroupWithTop
 
 @[simp, norm_cast]
-theorem WithTop.coe_neg (a : α) : ((-a : α) : WithTop α) = -a :=
+theorem coe_neg (a : α) : ((-a : α) : WithTop α) = -a :=
   rfl
 #align with_top.coe_neg WithTop.coe_neg
 
 end LinearOrderedAddCommGroup
 
+end WithTop

--- a/Mathlib/Algebra/Order/Group/WithTop.lean
+++ b/Mathlib/Algebra/Order/Group/WithTop.lean
@@ -3,8 +3,8 @@ Copyright (c) 2016 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro, Johannes Hölzl
 -/
-import Mathbin.Algebra.Order.Group.Instances
-import Mathbin.Algebra.Order.Monoid.WithTop
+import Mathlib.Algebra.Order.Group.Instances
+import Mathlib.Algebra.Order.Monoid.WithTop
 
 /-!
 # Adjoining a top element to a `linear_ordered_add_comm_group_with_top`.

--- a/Mathlib/Algebra/Order/Group/WithTop.lean
+++ b/Mathlib/Algebra/Order/Group/WithTop.lean
@@ -1,0 +1,35 @@
+/-
+Copyright (c) 2016 Jeremy Avigad. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro, Johannes Hölzl
+-/
+import Mathbin.Algebra.Order.Group.Instances
+import Mathbin.Algebra.Order.Monoid.WithTop
+
+/-!
+# Adjoining a top element to a `linear_ordered_add_comm_group_with_top`.
+-/
+
+
+variable {α : Type _}
+
+section LinearOrderedAddCommGroup
+
+variable [LinearOrderedAddCommGroup α] {a b c d : α}
+
+instance WithTop.linearOrderedAddCommGroupWithTop : LinearOrderedAddCommGroupWithTop (WithTop α) :=
+  { WithTop.linearOrderedAddCommMonoidWithTop, Option.nontrivial with
+    neg := Option.map fun a : α => -a, neg_top := @Option.map_none _ _ fun a : α => -a,
+    add_neg_cancel := by 
+      rintro (a | a) ha
+      · exact (ha rfl).elim
+      · exact with_top.coe_add.symm.trans (WithTop.coe_eq_coe.2 (add_neg_self a)) }
+#align with_top.linear_ordered_add_comm_group_with_top WithTop.linearOrderedAddCommGroupWithTop
+
+@[simp, norm_cast]
+theorem WithTop.coe_neg (a : α) : ((-a : α) : WithTop α) = -a :=
+  rfl
+#align with_top.coe_neg WithTop.coe_neg
+
+end LinearOrderedAddCommGroup
+

--- a/Mathlib/Algebra/Order/Group/WithTop.lean
+++ b/Mathlib/Algebra/Order/Group/WithTop.lean
@@ -7,7 +7,7 @@ import Mathlib.Algebra.Order.Group.Instances
 import Mathlib.Algebra.Order.Monoid.WithTop
 
 /-!
-# Adjoining a top element to a `linear_ordered_add_comm_group_with_top`.
+# Adjoining a top element to a `LinearOrderedAddCommGroupWithTop`.
 -/
 
 namespace WithTop

--- a/Mathlib/Algebra/Order/Monoid/WithTop.lean
+++ b/Mathlib/Algebra/Order/Monoid/WithTop.lean
@@ -358,7 +358,8 @@ instance orderedAddCommMonoid [OrderedAddCommMonoid α] : OrderedAddCommMonoid (
       simp only [some_eq_coe, ← coe_add, coe_le_coe] at h⊢
       exact add_le_add_left h c }
 
-instance [LinearOrderedAddCommMonoid α] : LinearOrderedAddCommMonoidWithTop (WithTop α) :=
+instance linearOrderedAddCommMonoidWithTop [LinearOrderedAddCommMonoid α] :
+    LinearOrderedAddCommMonoidWithTop (WithTop α) :=
   { WithTop.orderTop, WithTop.linearOrder, WithTop.orderedAddCommMonoid with
     top_add' := WithTop.top_add }
 


### PR DESCRIPTION
Tracking mathlib commit: [f178c0e25af359f6cbc72a96a243efd3b12423a3](https://github.com/leanprover-community/mathlib/commit/f178c0e25af359f6cbc72a96a243efd3b12423a3)