### PR TITLE
[Merged by Bors] - fix: `@[to_additive, simps]` will now work correctly

### DIFF
--- a/Mathlib/Algebra/Group/Units.lean
+++ b/Mathlib/Algebra/Group/Units.lean
@@ -245,10 +245,12 @@ theorem inv_mk (x y : α) (h₁ h₂) : (mk x y h₁ h₂)⁻¹ = mk y x h₂ h�
 #noalign units.val_eq_coe
 #noalign add_units.val_eq_coe
 
--- Porting note: the lower priority is needed to appease the `simpNF` linter
-@[simp 900, to_additive]
+@[to_additive]
 theorem inv_eq_val_inv : a.inv = ((a⁻¹ : αˣ) : α) :=
   rfl
+-- Porting note: the lower priority is needed to appease the `simpNF` linter
+-- Note that `to_additive` doesn't copy `simp` priorities, so we use this as a workaround
+attribute [simp 900] Units.inv_eq_val_inv AddUnits.neg_eq_val_neg
 #align units.inv_eq_coe_inv Units.inv_eq_val_inv
 #align add_units.neg_eq_coe_neg AddUnits.neg_eq_val_neg
 

--- a/Mathlib/Tactic/Simps/Basic.lean
+++ b/Mathlib/Tactic/Simps/Basic.lean
@@ -1027,4 +1027,5 @@ initialize simpsAttr : ParametricAttribute (Array Name) ←
       let ids := ids.map fun x => (x.getId.eraseMacroScopes.getString, x.raw)
       simpsTac stx nm cfg ids.toList trc.isSome
     | _ => throwUnsupportedSyntax
+    applicationTime := .afterCompilation
   }

--- a/test/Simps.lean
+++ b/test/Simps.lean
@@ -889,10 +889,8 @@ example (x : Bool) {z} (h : id x = z) : myRingHom x = z := by
 
 -- set_option trace.simps.debug true
 
-@[to_additive instAddProd] -- todo: want to write simps here
+@[to_additive instAddProd, simps]
 instance {M N} [Mul M] [Mul N] : Mul (M × N) := ⟨λ p q => ⟨p.1 * q.1, p.2 * q.2⟩⟩
-
-attribute [simps] instMulProd
 
 run_cmd liftTermElabM <| do
   let env ← getEnv
@@ -909,9 +907,8 @@ run_cmd liftTermElabM <| do
 
 /- The names of the generated simp lemmas for the additive version are not great if the definition
   had a custom additive name -/
-@[to_additive my_add_instance] -- todo: want to write simps here
+@[to_additive my_add_instance, simps]
 instance my_instance {M N} [One M] [One N] : One (M × N) := ⟨(1, 1)⟩
-attribute [simps] my_instance
 
 run_cmd liftTermElabM <| do
   let env ← getEnv
@@ -976,10 +973,8 @@ structure MyType :=
 --   rfl
 
 -- test that `to_additive` works with a custom name
-@[to_additive some_test2] -- todo: want to write simps here
+@[to_additive some_test2, simps]
 def some_test1 (M : Type _) [CommMonoid M] : Subtype (λ _ : M => True) := ⟨1, trivial⟩
-
-attribute [simps] some_test1
 
 run_cmd liftTermElabM <| do
   let env ← getEnv


### PR DESCRIPTION
Fixes part 2 of #950. Possible after https://github.com/leanprover/lean4/commit/a999015371adcc5516f2994b95251f312e3c820c