### PR TITLE
[Merged by Bors] - hack: to_additive copies more attributes

### DIFF
--- a/Mathlib/Algebra/Group/WithOne/Defs.lean
+++ b/Mathlib/Algebra/Group/WithOne/Defs.lean
@@ -90,10 +90,6 @@ instance nontrivial [Nonempty α] : Nontrivial (WithOne α) :=
 def coe : α → WithOne α :=
   Option.some
 
--- porting note : `@[coe, to_additive]` doesn't tag the to-additivised declaration
--- with coe, in contrast to Lean 3, so we have to do it manually.
-attribute [coe] WithZero.coe
-
 @[to_additive]
 instance coeTC : CoeTC α (WithOne α) :=
   ⟨coe⟩

--- a/Mathlib/Tactic/ToAdditive.lean
+++ b/Mathlib/Tactic/ToAdditive.lean
@@ -9,12 +9,11 @@ import Mathlib.Data.KVMap
 import Mathlib.Lean.Expr.ReplaceRec
 import Std.Lean.NameMapAttribute
 import Std.Data.Option.Basic
--- extra imports we need just to copy attributes
-import Std.Tactic.NormCast.Ext
-import Std.Tactic.Ext.Attr
-import Mathlib.Tactic.Relation.Rfl
-import Mathlib.Tactic.Relation.Symm
-import Mathlib.Tactic.Relation.Trans
+import Std.Tactic.NormCast.Ext -- just to copy the attribute
+import Std.Tactic.Ext.Attr -- just to copy the attribute
+import Mathlib.Tactic.Relation.Rfl -- just to copy the attribute
+import Mathlib.Tactic.Relation.Symm -- just to copy the attribute
+import Mathlib.Tactic.Relation.Trans -- just to copy the attribute
 
 /-!
 # The `@[to_additive]` attribute.

--- a/Mathlib/Tactic/ToAdditive.lean
+++ b/Mathlib/Tactic/ToAdditive.lean
@@ -535,8 +535,8 @@ def copySimpAttribute (src tgt : Name) (ext : SimpExtension := simpExtension) : 
 [todo] it seems not to work when the `to_additive` is added as an attribute later. -/
 def copyInstanceAttribute (src tgt : Name) : CoreM Unit := do
   if (← isInstance src) then
-    let prio := (← getInstancePriority? src).elim 100 id
-    let attr_kind := (← getInstanceAttrKind? src).elim AttributeKind.global id
+    let prio := (← getInstancePriority? src).getD 100
+    let attr_kind := (← getInstanceAttrKind? src).getD .global
     trace[to_additive_detail] "Making {tgt} an instance with priority {prio}."
     addInstance tgt attr_kind prio |>.run'
 
@@ -556,7 +556,7 @@ def hackyCopyAttr [Inhabited β] (attr : SimpleScopedEnvExtension α β) (f : β
   if f (attr.getState (← getEnv)) src then
     hackyAddAttribute attrName tgt
 
-/-- [todo] add more attributes. -/
+/-- Copy attributes to the additive name. -/
 def copyAttributes (src tgt : Name) : CoreM Unit := do
   -- Copy the standard `simp` attribute
   copySimpAttribute src tgt

--- a/Mathlib/Tactic/ToAdditive.lean
+++ b/Mathlib/Tactic/ToAdditive.lean
@@ -14,6 +14,7 @@ import Std.Tactic.Ext.Attr -- just to copy the attribute
 import Mathlib.Tactic.Relation.Rfl -- just to copy the attribute
 import Mathlib.Tactic.Relation.Symm -- just to copy the attribute
 import Mathlib.Tactic.Relation.Trans -- just to copy the attribute
+import Mathlib.Tactic.RunCmd -- not necessary, but useful for debugging
 
 /-!
 # The `@[to_additive]` attribute.
@@ -548,7 +549,9 @@ def copyInstanceAttribute (src tgt : Name) : CoreM Unit := do
 
 /-- A hack to add an attribute to a declaration.
   We use the `missing` for the syntax, so this only works for certain attributes.
-  It seems to work for `refl`, `symm`, `trans`, `ext` and `coe`. -/
+  It seems to work for `refl`, `symm`, `trans`, `ext` and `coe`.
+  This does not work for most attributes where the syntax has optional arguments.
+  TODO: have a proper implementation once we have the infrastructure for this. -/
 def hackyAddAttribute (attrName declName : Name) (kind : AttributeKind := .global) :
   CoreM Unit := do
   let .ok attr := getAttributeImpl (← getEnv) attrName
@@ -556,7 +559,8 @@ def hackyAddAttribute (attrName declName : Name) (kind : AttributeKind := .globa
   attr.add declName .missing kind
 
 /-- Copy an attribute that stores enough information to test whether a declaration is in it
-  in a hacky way. -/
+  in a hacky way.
+  TODO: have a proper implementation once we have the infrastructure for this. -/
 def hackyCopyAttr [Inhabited β] (attr : SimpleScopedEnvExtension α β) (f : β → Name → Bool)
   (attrName src tgt : Name) : CoreM Unit := do
   if f (attr.getState (← getEnv)) src then

--- a/Mathlib/Tactic/ToAdditive.lean
+++ b/Mathlib/Tactic/ToAdditive.lean
@@ -552,9 +552,9 @@ def hackyAddAttribute (attrName declName : Name) (kind : AttributeKind := .globa
 /-- Copy an attribute that stores enough information to test whether a declaration is in it
   in a hacky way. -/
 def hackyCopyAttr [Inhabited β] (attr : SimpleScopedEnvExtension α β) (f : β → Name → Bool)
-  (src tgt : Name) : CoreM Unit := do
+  (attrName src tgt : Name) : CoreM Unit := do
   if f (attr.getState (← getEnv)) src then
-    hackyAddAttribute `ext tgt
+    hackyAddAttribute attrName tgt
 
 /-- [todo] add more attributes. -/
 def copyAttributes (src tgt : Name) : CoreM Unit := do
@@ -567,11 +567,11 @@ def copyAttributes (src tgt : Name) : CoreM Unit := do
   copySimpAttribute src tgt normCastExt.squash
   -- copy `instance`
   copyInstanceAttribute src tgt
-  hackyCopyAttr Std.Tactic.Ext.extExtension (·.elements.contains ·) src tgt -- copy `@[ext]`
-  hackyCopyAttr Mathlib.Tactic.reflExt (·.elements.contains ·) src tgt -- copy `@[refl]`
-  hackyCopyAttr Mathlib.Tactic.symmExt (·.elements.contains ·) src tgt -- copy `@[symm]`
-  hackyCopyAttr Mathlib.Tactic.transExt (·.elements.contains ·) src tgt -- copy `@[trans]`
-  hackyCopyAttr Std.Tactic.Coe.coeExt (·.contains ·) src tgt -- copy `@[coe]`
+  hackyCopyAttr Std.Tactic.Ext.extExtension (·.elements.contains ·) `ext src tgt -- copy `@[ext]`
+  hackyCopyAttr Mathlib.Tactic.reflExt (·.elements.contains ·) `refl src tgt -- copy `@[refl]`
+  hackyCopyAttr Mathlib.Tactic.symmExt (·.elements.contains ·) `symm src tgt -- copy `@[symm]`
+  hackyCopyAttr Mathlib.Tactic.transExt (·.elements.contains ·) `trans src tgt -- copy `@[trans]`
+  hackyCopyAttr Std.Tactic.Coe.coeExt (·.contains ·) `coe src tgt -- copy `@[coe]`
 
 /--
 Make a new copy of a declaration, replacing fragments of the names of identifiers in the type and

--- a/Mathlib/Tactic/ToAdditive.lean
+++ b/Mathlib/Tactic/ToAdditive.lean
@@ -9,7 +9,12 @@ import Mathlib.Data.KVMap
 import Mathlib.Lean.Expr.ReplaceRec
 import Std.Lean.NameMapAttribute
 import Std.Data.Option.Basic
+-- extra imports we need just to copy attributes
 import Std.Tactic.NormCast.Ext
+import Std.Tactic.Ext.Attr
+import Mathlib.Tactic.Relation.Rfl
+import Mathlib.Tactic.Relation.Symm
+import Mathlib.Tactic.Relation.Trans
 
 /-!
 # The `@[to_additive]` attribute.
@@ -536,6 +541,22 @@ def copyInstanceAttribute (src tgt : Name) : CoreM Unit := do
     trace[to_additive_detail] "Making {tgt} an instance with priority {prio}."
     addInstance tgt attr_kind prio |>.run'
 
+/-- A hack to add an attribute to a declaration.
+  We use the `missing` for the syntax, so this only works for certain attributes.
+  It seems to work for `refl`, `symm`, `trans`, `ext` and `coe`. -/
+def hackyAddAttribute (attrName declName : Name) (kind : AttributeKind := .global) :
+  CoreM Unit := do
+  let .ok attr := getAttributeImpl (← getEnv) attrName
+    | throwError "unknown attribute {attrName}"
+  attr.add declName .missing kind
+
+/-- Copy an attribute that stores enough information to test whether a declaration is in it
+  in a hacky way. -/
+def hackyCopyAttr [Inhabited β] (attr : SimpleScopedEnvExtension α β) (f : β → Name → Bool)
+  (src tgt : Name) : CoreM Unit := do
+  if f (attr.getState (← getEnv)) src then
+    hackyAddAttribute `ext tgt
+
 /-- [todo] add more attributes. -/
 def copyAttributes (src tgt : Name) : CoreM Unit := do
   -- Copy the standard `simp` attribute
@@ -545,7 +566,13 @@ def copyAttributes (src tgt : Name) : CoreM Unit := do
   copySimpAttribute src tgt normCastExt.up
   copySimpAttribute src tgt normCastExt.down
   copySimpAttribute src tgt normCastExt.squash
+  -- copy `instance`
   copyInstanceAttribute src tgt
+  hackyCopyAttr Std.Tactic.Ext.extExtension (·.elements.contains ·) src tgt -- copy `@[ext]`
+  hackyCopyAttr Mathlib.Tactic.reflExt (·.elements.contains ·) src tgt -- copy `@[refl]`
+  hackyCopyAttr Mathlib.Tactic.symmExt (·.elements.contains ·) src tgt -- copy `@[symm]`
+  hackyCopyAttr Mathlib.Tactic.transExt (·.elements.contains ·) src tgt -- copy `@[trans]`
+  hackyCopyAttr Std.Tactic.Coe.coeExt (·.contains ·) src tgt -- copy `@[coe]`
 
 /--
 Make a new copy of a declaration, replacing fragments of the names of identifiers in the type and


### PR DESCRIPTION
* `to_additive` now copies `ext`, `coe`, `refl`, `symm`, `trans`
* Implemented in a hacky way
* This could be used until a proper solution is available.
