### PR TITLE
[Merged by Bors] - feat: port algebra.group.with_one.units

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -18,6 +18,7 @@ import Mathlib.Algebra.Group.ULift
 import Mathlib.Algebra.Group.Units
 import Mathlib.Algebra.Group.WithOne.Basic
 import Mathlib.Algebra.Group.WithOne.Defs
+import Mathlib.Algebra.Group.WithOne.Units
 import Mathlib.Algebra.GroupPower.Basic
 import Mathlib.Algebra.GroupPower.Identities
 import Mathlib.Algebra.GroupPower.Lemmas

--- a/Mathlib/Algebra/Group/WithOne/Units.lean
+++ b/Mathlib/Algebra/Group/WithOne/Units.lean
@@ -1,0 +1,31 @@
+/-
+Copyright (c) 2018 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro, Johan Commelin
+-/
+import Mathbin.Algebra.Group.WithOne.Basic
+import Mathbin.Algebra.GroupWithZero.Units.Basic
+
+/-!
+# Isomorphism between a group and the units of itself adjoined with `0`
+
+## Notes
+This is here to keep `algebra.group_with_zero.units.basic` out of the import requirements of
+`algebra.order.field.defs`.
+-/
+
+
+namespace WithZero
+
+/-- Any group is isomorphic to the units of itself adjoined with `0`. -/
+def unitsWithZeroEquiv {α : Type _} [Group α] :
+    (WithZero α)ˣ ≃* α where 
+  toFun a := unzero a.NeZero
+  invFun a := Units.mk0 a coe_ne_zero
+  left_inv _ := Units.ext <| by simpa only [coe_unzero]
+  right_inv _ := rfl
+  map_mul' _ _ := coe_inj.mp <| by simpa only [coe_unzero, coe_mul]
+#align with_zero.units_with_zero_equiv WithZero.unitsWithZeroEquiv
+
+end WithZero
+

--- a/Mathlib/Algebra/Group/WithOne/Units.lean
+++ b/Mathlib/Algebra/Group/WithOne/Units.lean
@@ -19,12 +19,11 @@ namespace WithZero
 
 /-- Any group is isomorphic to the units of itself adjoined with `0`. -/
 def unitsWithZeroEquiv {α : Type _} [Group α] : (WithZero α)ˣ ≃* α where
-  toFun a := unzero a.NeZero
+  toFun a := unzero a.ne_zero
   invFun a := Units.mk0 a coe_ne_zero
-  left_inv _ := Units.ext <| by simpa only [coe_unzero]
+  left_inv _ := Units.ext <| by simp only [coe_unzero, Units.mk0_val]
   right_inv _ := rfl
-  map_mul' _ _ := coe_inj.mp <| by simpa only [coe_unzero, coe_mul]
+  map_mul' _ _ := coe_inj.mp <| by simp only [Units.val_mul, coe_unzero, coe_mul]
 #align with_zero.units_with_zero_equiv WithZero.unitsWithZeroEquiv
 
 end WithZero
-

--- a/Mathlib/Algebra/Group/WithOne/Units.lean
+++ b/Mathlib/Algebra/Group/WithOne/Units.lean
@@ -3,23 +3,22 @@ Copyright (c) 2018 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Johan Commelin
 -/
-import Mathbin.Algebra.Group.WithOne.Basic
-import Mathbin.Algebra.GroupWithZero.Units.Basic
+import Mathlib.Algebra.Group.WithOne.Basic
+import Mathlib.Algebra.GroupWithZero.Units.Basic
 
 /-!
 # Isomorphism between a group and the units of itself adjoined with `0`
 
 ## Notes
-This is here to keep `algebra.group_with_zero.units.basic` out of the import requirements of
-`algebra.order.field.defs`.
+This is here to keep `Algebra.GroupWithZero.Units.Basic` out of the import requirements of
+`Algebra.Order.Field.Defs`.
 -/
 
 
 namespace WithZero
 
 /-- Any group is isomorphic to the units of itself adjoined with `0`. -/
-def unitsWithZeroEquiv {α : Type _} [Group α] :
-    (WithZero α)ˣ ≃* α where 
+def unitsWithZeroEquiv {α : Type _} [Group α] : (WithZero α)ˣ ≃* α where
   toFun a := unzero a.NeZero
   invFun a := Units.mk0 a coe_ne_zero
   left_inv _ := Units.ext <| by simpa only [coe_unzero]


### PR DESCRIPTION
Tracking mathlib commit: [4e87c8477c6c38b753f050bc9664b94ee859896c](https://github.com/leanprover-community/mathlib/commit/4e87c8477c6c38b753f050bc9664b94ee859896c)