### PR TITLE
[Merged by Bors] - feat: Data.Set.Basic Add mem_setOf_eq

### DIFF
--- a/Mathlib/Data/Set/Basic.lean
+++ b/Mathlib/Data/Set/Basic.lean
@@ -255,6 +255,8 @@ theorem forall_in_swap {p : α → β → Prop} : (∀ a ∈ s, ∀ (b), p a b) 
 
 /-! ### Lemmas about `mem` and `setOf` -/
 
+@[simp] theorem mem_setOf_eq {x : α} {p : α → Prop} : (x ∈ {y | p y}) = p x := rfl
+#align set.mem_set_of_eq Set.mem_setOf_eq
 
 theorem mem_setOf {a : α} {p : α → Prop} : a ∈ { x | p x } ↔ p a :=
   Iff.rfl


### PR DESCRIPTION
Adding a missing lemma from Lean3 core. Alternatively we could just mark `mem_setOf` as a `simp` lemma and align Lean3's `set.mem_set_of_eq`, but the statements are slightly different `Eq` versus `Iff` so this is probably the method that make porting the easiest.