### PR TITLE
[Merged by Bors] - chore: bump to get std4#63 (use Nat.cast in place of Int.ofNat)

### DIFF
--- a/Mathlib/Algebra/Group/Basic.lean
+++ b/Mathlib/Algebra/Group/Basic.lean
@@ -618,7 +618,8 @@ theorem leftInverse_inv_mul_mul_right (c : G) :
 theorem exists_npow_eq_one_of_zpow_eq_one {n : ℤ} (hn : n ≠ 0) {x : G} (h : x ^ n = 1) :
     ∃ n : ℕ, 0 < n ∧ x ^ n = 1 := by
   cases' n with n n
-  · rw [zpow_ofNat] at h
+  · simp only [Int.ofNat_eq_coe] at h
+    rw [zpow_ofNat] at h
     refine' ⟨n, Nat.pos_of_ne_zero fun n0 ↦ hn ?_, h⟩
     rw [n0]
     rfl

--- a/Mathlib/Algebra/Group/Opposite.lean
+++ b/Mathlib/Algebra/Group/Opposite.lean
@@ -136,8 +136,9 @@ instance [DivInvMonoid α] : DivInvMonoid αᵐᵒᵖ :=
   { instMonoidMulOpposite α, instInvMulOpposite α with
     zpow := fun n x => op <| x.unop ^ n,
     zpow_zero' := fun x => unop_injective <| DivInvMonoid.zpow_zero' x.unop,
-    zpow_succ' := fun n x =>
-      unop_injective <| by rw [unop_op, zpow_ofNat, pow_succ', unop_mul, unop_op, zpow_ofNat],
+    zpow_succ' := fun n x => unop_injective <| by
+      simp only [Int.ofNat_eq_coe]
+      rw [unop_op, zpow_ofNat, pow_succ', unop_mul, unop_op, zpow_ofNat],
     zpow_neg' := fun z x => unop_injective <| DivInvMonoid.zpow_neg' z x.unop }
 
 @[to_additive AddOpposite.subtractionMonoid]

--- a/Mathlib/Data/Int/Basic.lean
+++ b/Mathlib/Data/Int/Basic.lean
@@ -45,6 +45,7 @@ instance : CommRing ℤ where
   nsmul_zero := Int.zero_mul
   nsmul_succ n x := by
     show ofNat (Nat.succ n) * x = x + ofNat n * x
+    simp only [ofNat_eq_coe]
     rw [Int.ofNat_succ, Int.add_mul, Int.add_comm, Int.one_mul]
   sub_eq_add_neg _ _ := Int.sub_eq_add_neg
   natCast := (·)

--- a/Mathlib/Data/Int/Basic.lean
+++ b/Mathlib/Data/Int/Basic.lean
@@ -59,7 +59,6 @@ instance : CommRing ℤ where
 
 @[simp] lemma ofNat_eq_cast : Int.ofNat n = n := rfl
 
-@[simp, norm_cast]
 lemma cast_Nat_cast [AddGroupWithOne R] : (Int.cast (Nat.cast n) : R) = Nat.cast n :=
   Int.cast_ofNat _
 
@@ -105,18 +104,15 @@ instance : Distrib ℤ          := by infer_instance
 #align int.neg_succ_mul_coe_nat Int.negSucc_mul_ofNat
 #align int.neg_succ_mul_neg_succ Int.negSucc_mul_negSucc
 
-@[simp, norm_cast] theorem coe_nat_le {m n : ℕ} : (↑m : ℤ) ≤ ↑n ↔ m ≤ n := ofNat_le
-#align int.coe_nat_le Int.coe_nat_le
-
-@[simp, norm_cast] theorem coe_nat_lt {n m : ℕ} : (↑n : ℤ) < ↑m ↔ n < m := ofNat_lt
-#align int.coe_nat_lt Int.coe_nat_lt
+#align int.coe_nat_le Int.ofNat_le
+#align int.coe_nat_lt Int.ofNat_lt
 
 theorem coe_nat_inj' {m n : ℕ} : (↑m : ℤ) = ↑n ↔ m = n := Int.ofNat_inj
 
 theorem coe_nat_strictMono : StrictMono (· : ℕ → ℤ) := fun _ _ ↦ Int.ofNat_lt.2
 #align int.coe_nat_strict_mono Int.coe_nat_strictMono
 
-theorem coe_nat_nonneg (n : ℕ) : 0 ≤ (n : ℤ) := coe_nat_le.2 (Nat.zero_le _)
+theorem coe_nat_nonneg (n : ℕ) : 0 ≤ (n : ℤ) := ofNat_le.2 (Nat.zero_le _)
 
 #align int.neg_of_nat_ne_zero Int.negSucc_ne_zero
 #align int.zero_ne_neg_of_nat Int.zero_ne_negSucc

--- a/Mathlib/Data/Int/Cast/Basic.lean
+++ b/Mathlib/Data/Int/Cast/Basic.lean
@@ -82,7 +82,7 @@ theorem cast_neg : ∀ n, ((-n : ℤ) : R) = -n
 theorem cast_subNatNat (m n) : ((Int.subNatNat m n : ℤ) : R) = m - n := by
   unfold subNatNat
   cases e : n - m
-  · rw [cast_ofNat]
+  · simp only [ofNat_eq_coe]
     simp [e, Nat.le_of_sub_eq_zero e]
   · rw [cast_negSucc, Nat.add_one, ← e, Nat.cast_sub <| _root_.le_of_lt <| Nat.lt_of_sub_eq_succ e,
       neg_sub]

--- a/Mathlib/Data/Nat/Cast/Defs.lean
+++ b/Mathlib/Data/Nat/Cast/Defs.lean
@@ -29,18 +29,9 @@ protected def Nat.unaryCast {R : Type u} [One R] [Zero R] [Add R] : ℕ → R
   | n + 1 => Nat.unaryCast n + 1
 #align nat.unary_cast Nat.unaryCast
 
-/-- Type class for the canonical homomorphism `ℕ → R`. -/
-class NatCast (R : Type u) where
-  /-- The canonical map `ℕ → R`. -/
-  protected natCast : ℕ → R
 #align has_nat_cast NatCast
 #align has_nat_cast.nat_cast NatCast.natCast
 
-/-- Canonical homomorphism from `ℕ` to a additive monoid `R` with a `1`.
-This is just the bare function in order to aid in creating instances of `AddMonoidWithOne`. -/
-@[coe]
-protected def Nat.cast {R : Type u} [NatCast R] : ℕ → R :=
-  NatCast.natCast
 #align nat.cast Nat.cast
 
 -- see note [coercion into rings]

--- a/Mathlib/Init/Data/Int/Basic.lean
+++ b/Mathlib/Init/Data/Int/Basic.lean
@@ -38,8 +38,6 @@ namespace Int
 theorem neg_negSucc (n : ℕ) : - -[n+1] = ofNat (succ n) := rfl
 #align int.neg_neg_of_nat_succ Int.neg_negSucc
 
-@[deprecated, nolint synTaut]
-theorem ofNat_eq_coe (n : ℕ) : ofNat n = ↑n := rfl
 #align int.of_nat_eq_coe Int.ofNat_eq_coe
 
 #align int.neg_succ_of_nat_coe Int.negSucc_coe

--- a/Mathlib/Tactic/ModCases.lean
+++ b/Mathlib/Tactic/ModCases.lean
@@ -13,7 +13,7 @@ subgoals in which `e ≡ 0 [ZMOD n]`, ..., `e ≡ n-1 [ZMOD n]` are assumed.
 
 section MoveMe
 /-- `a ≡ b [ZMOD n]` says that `a` and `b` are congruent mod `n : ℤ`. -/
-def Int.modeq (n a b : ℤ) := a % n = b % n
+def Int.modeq (n a b : ℤ) := a.emod n = b.emod n
 
 @[inherit_doc] notation:50 a " ≡ " b " [ZMOD " n "]" => Int.modeq n a b
 end MoveMe
@@ -23,7 +23,7 @@ open Lean Meta Elab Tactic Term Qq Int
 
 /--
 `OnModCases n a lb p` represents a partial proof by cases that
-there exists `0 ≤ z < n` such that `a ≡ z (mod n)`.
+there exists `0 ≤ z < n`t such that `a ≡ z (mod n)`.
 It asserts that if `∃ z, lb ≤ z < n ∧ a ≡ z (mod n)` holds, then `p`
 (where `p` is the current goal).
 -/
@@ -36,12 +36,12 @@ The actual mathematical content of the proof is here.
 -/
 @[inline] def onModCases_start (p : Sort _) (a : ℤ) (n : ℕ) (hn : Nat.ble 1 n = true)
     (H : OnModCases n a (nat_lit 0) p) : p :=
-  H (a % (ofNat n)).toNat <| by
+  H (a.emod (ofNat n)).toNat <| by
     have := ofNat_pos.2 <| Nat.le_of_ble_eq_true hn
     have nonneg := emod_nonneg a <| Int.ne_of_gt this
     refine ⟨Nat.zero_le _, ?_, ?_⟩
-    · simp only [ofNat_eq_coe]; rw [Int.toNat_lt nonneg]; exact Int.emod_lt_of_pos _ this
-    · simp only [ofNat_eq_coe]; rw [Int.modeq, Int.toNat_of_nonneg nonneg, emod_emod]
+    · rw [Int.toNat_lt nonneg]; exact Int.emod_lt_of_pos _ this
+    · rw [Int.modeq, Int.toNat_of_nonneg nonneg, emod_emod]
 
 /--
 The end point is that once we have reduced to `∃ z, n ≤ z < n ∧ a ≡ z (mod n)`

--- a/Mathlib/Tactic/ModCases.lean
+++ b/Mathlib/Tactic/ModCases.lean
@@ -40,8 +40,8 @@ The actual mathematical content of the proof is here.
     have := ofNat_pos.2 <| Nat.le_of_ble_eq_true hn
     have nonneg := emod_nonneg a <| Int.ne_of_gt this
     refine ⟨Nat.zero_le _, ?_, ?_⟩
-    · rw [Int.toNat_lt nonneg]; exact Int.emod_lt_of_pos _ this
-    · rw [Int.modeq, Int.toNat_of_nonneg nonneg, emod_emod]
+    · simp only [ofNat_eq_coe]; rw [Int.toNat_lt nonneg]; exact Int.emod_lt_of_pos _ this
+    · simp only [ofNat_eq_coe]; rw [Int.modeq, Int.toNat_of_nonneg nonneg, emod_emod]
 
 /--
 The end point is that once we have reduced to `∃ z, n ≤ z < n ∧ a ≡ z (mod n)`

--- a/Mathlib/Tactic/ModCases.lean
+++ b/Mathlib/Tactic/ModCases.lean
@@ -13,7 +13,7 @@ subgoals in which `e ≡ 0 [ZMOD n]`, ..., `e ≡ n-1 [ZMOD n]` are assumed.
 
 section MoveMe
 /-- `a ≡ b [ZMOD n]` says that `a` and `b` are congruent mod `n : ℤ`. -/
-def Int.modeq (n a b : ℤ) := a.emod n = b.emod n
+def Int.modeq (n a b : ℤ) := a % n = b % n
 
 @[inherit_doc] notation:50 a " ≡ " b " [ZMOD " n "]" => Int.modeq n a b
 end MoveMe
@@ -28,7 +28,7 @@ It asserts that if `∃ z, lb ≤ z < n ∧ a ≡ z (mod n)` holds, then `p`
 (where `p` is the current goal).
 -/
 def OnModCases (n : ℕ) (a : ℤ) (lb : ℕ) (p : Sort _) :=
-∀ z, lb ≤ z ∧ z < n ∧ a ≡ ofNat z [ZMOD ofNat n] → p
+∀ z, lb ≤ z ∧ z < n ∧ a ≡ ↑z [ZMOD ↑n] → p
 
 /--
 The first theorem we apply says that `∃ z, 0 ≤ z < n ∧ a ≡ z (mod n)`.
@@ -36,7 +36,7 @@ The actual mathematical content of the proof is here.
 -/
 @[inline] def onModCases_start (p : Sort _) (a : ℤ) (n : ℕ) (hn : Nat.ble 1 n = true)
     (H : OnModCases n a (nat_lit 0) p) : p :=
-  H (a.emod (ofNat n)).toNat <| by
+  H (a % ↑n).toNat <| by
     have := ofNat_pos.2 <| Nat.le_of_ble_eq_true hn
     have nonneg := emod_nonneg a <| Int.ne_of_gt this
     refine ⟨Nat.zero_le _, ?_, ?_⟩

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -2,30 +2,6 @@
  "packagesDir": "./lake-packages",
  "packages":
  [{"git":
-   {"url": "https://github.com/xubaiw/CMark.lean",
-    "subDir?": null,
-    "rev": "2cc7cdeef67184f84db6731450e4c2b258c28fe8",
-    "name": "CMark",
-    "inputRev?": "main"}},
-  {"git":
-   {"url": "https://github.com/leanprover/lake",
-    "subDir?": null,
-    "rev": "235383015cdcb0082777b0347b84dba01843c79c",
-    "name": "lake",
-    "inputRev?": "master"}},
-  {"git":
-   {"url": "https://github.com/leanprover/doc-gen4",
-    "subDir?": null,
-    "rev": "7009910876145a9a1220359f968ba7045dd05290",
-    "name": "doc-gen4",
-    "inputRev?": "main"}},
-  {"git":
-   {"url": "https://github.com/mhuisi/lean4-cli",
-    "subDir?": null,
-    "rev": "5a858c32963b6b19be0d477a30a1f4b6c120be7e",
-    "name": "Cli",
-    "inputRev?": "nightly"}},
-  {"git":
    {"url": "https://github.com/gebner/quote4",
     "subDir?": null,
     "rev": "7ac99aa3fac487bec1d5860e751b99c7418298cf",
@@ -34,24 +10,12 @@
   {"git":
    {"url": "https://github.com/JLimperg/aesop",
     "subDir?": null,
-    "rev": "ddced06b6b76483fe8794f2b516c57980a08fcef",
+    "rev": "6a840e4aa779082167129f790ceb0cda69b10a41",
     "name": "aesop",
     "inputRev?": "master"}},
   {"git":
-   {"url": "https://github.com/hargonix/LeanInk",
-    "subDir?": null,
-    "rev": "9f3101452135964ac9107ec8e9910bfd14022bbc",
-    "name": "leanInk",
-    "inputRev?": "doc-gen"}},
-  {"git":
-   {"url": "https://github.com/xubaiw/Unicode.lean",
-    "subDir?": null,
-    "rev": "6dd6ae3a3839c8350a91876b090eda85cf538d1d",
-    "name": "Unicode",
-    "inputRev?": "main"}},
-  {"git":
    {"url": "https://github.com/leanprover/std4",
     "subDir?": null,
-    "rev": "6196cf930a95664987eba8aee62ae7802d51428c",
+    "rev": "18de5bb2858c645b3916e979280918435378e80c",
     "name": "std",
-    "inputRev?": "main"}}]}
+    "inputRev?": "18de5bb2858c645b3916e979280918435378e80c"}}]}

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -2,6 +2,30 @@
  "packagesDir": "./lake-packages",
  "packages":
  [{"git":
+   {"url": "https://github.com/xubaiw/CMark.lean",
+    "subDir?": null,
+    "rev": "2cc7cdeef67184f84db6731450e4c2b258c28fe8",
+    "name": "CMark",
+    "inputRev?": "main"}},
+  {"git":
+   {"url": "https://github.com/leanprover/lake",
+    "subDir?": null,
+    "rev": "235383015cdcb0082777b0347b84dba01843c79c",
+    "name": "lake",
+    "inputRev?": "master"}},
+  {"git":
+   {"url": "https://github.com/leanprover/doc-gen4",
+    "subDir?": null,
+    "rev": "f221bbdcffe6a17bb310f0e9ee10767812b03e13",
+    "name": "doc-gen4",
+    "inputRev?": "main"}},
+  {"git":
+   {"url": "https://github.com/mhuisi/lean4-cli",
+    "subDir?": null,
+    "rev": "5a858c32963b6b19be0d477a30a1f4b6c120be7e",
+    "name": "Cli",
+    "inputRev?": "nightly"}},
+  {"git":
    {"url": "https://github.com/gebner/quote4",
     "subDir?": null,
     "rev": "7ac99aa3fac487bec1d5860e751b99c7418298cf",
@@ -10,12 +34,24 @@
   {"git":
    {"url": "https://github.com/JLimperg/aesop",
     "subDir?": null,
-    "rev": "6a840e4aa779082167129f790ceb0cda69b10a41",
+    "rev": "ebea1013bc12e73193c5b6148271c1360addd298",
     "name": "aesop",
     "inputRev?": "master"}},
   {"git":
+   {"url": "https://github.com/hargonix/LeanInk",
+    "subDir?": null,
+    "rev": "9f3101452135964ac9107ec8e9910bfd14022bbc",
+    "name": "leanInk",
+    "inputRev?": "doc-gen"}},
+  {"git":
+   {"url": "https://github.com/xubaiw/Unicode.lean",
+    "subDir?": null,
+    "rev": "6dd6ae3a3839c8350a91876b090eda85cf538d1d",
+    "name": "Unicode",
+    "inputRev?": "main"}},
+  {"git":
    {"url": "https://github.com/leanprover/std4",
     "subDir?": null,
-    "rev": "18de5bb2858c645b3916e979280918435378e80c",
+    "rev": "bf3acbb326513731ebb856717731cc1cd6a91d61",
     "name": "std",
-    "inputRev?": "18de5bb2858c645b3916e979280918435378e80c"}}]}
+    "inputRev?": "main"}}]}

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -16,6 +16,6 @@ lean_exe runLinter where
 meta if get_config? doc = some "on" then -- do not download and build doc-gen4 by default
 require «doc-gen4» from git "https://github.com/leanprover/doc-gen4" @ "main"
 
-require std from git "https://github.com/leanprover/std4" @ "main"
+require std from git "https://github.com/leanprover/std4" @ "18de5bb2858c645b3916e979280918435378e80c"
 require Qq from git "https://github.com/gebner/quote4" @ "master"
 require aesop from git "https://github.com/JLimperg/aesop" @ "master"

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -16,6 +16,6 @@ lean_exe runLinter where
 meta if get_config? doc = some "on" then -- do not download and build doc-gen4 by default
 require «doc-gen4» from git "https://github.com/leanprover/doc-gen4" @ "main"
 
-require std from git "https://github.com/leanprover/std4" @ "18de5bb2858c645b3916e979280918435378e80c"
+require std from git "https://github.com/leanprover/std4" @ "main"
 require Qq from git "https://github.com/gebner/quote4" @ "master"
 require aesop from git "https://github.com/JLimperg/aesop" @ "master"


### PR DESCRIPTION
This verifies that https://github.com/leanprover/std4/pull/63 will work in mathlib4.

Before merging this:
* [x] check that https://github.com/leanprover/std4/pull/63 has been merged
* [x] change `lakefile.lean` to point back to "main" for the std4 dependency
* [ ] we may want to golf the proofs where I have added `simp only [Int.ofNat_eq_coe]`, to combine these into the adjacent rw/simp.