### PR TITLE
[Merged by Bors] - feat: port Algebra.Order.Field.Canonical.Defs

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -47,8 +47,8 @@ import Mathlib.Algebra.Homology.ComplexShape
 import Mathlib.Algebra.Invertible
 import Mathlib.Algebra.NeZero
 import Mathlib.Algebra.Opposites
-import Mathlib.Algebra.Order.Field.Defs
 import Mathlib.Algebra.Order.Field.Canonical.Defs
+import Mathlib.Algebra.Order.Field.Defs
 import Mathlib.Algebra.Order.Group.Abs
 import Mathlib.Algebra.Order.Group.Defs
 import Mathlib.Algebra.Order.Group.DenselyOrdered

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -48,6 +48,7 @@ import Mathlib.Algebra.Invertible
 import Mathlib.Algebra.NeZero
 import Mathlib.Algebra.Opposites
 import Mathlib.Algebra.Order.Field.Defs
+import Mathlib.Algebra.Order.Field.Canonical.Defs
 import Mathlib.Algebra.Order.Group.Abs
 import Mathlib.Algebra.Order.Group.Defs
 import Mathlib.Algebra.Order.Group.DenselyOrdered

--- a/Mathlib/Algebra/Order/Field/Canonical/Defs.lean
+++ b/Mathlib/Algebra/Order/Field/Canonical/Defs.lean
@@ -1,0 +1,39 @@
+/-
+Copyright (c) 2014 Robert Lewis. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Lewis, Leonardo de Moura, Mario Carneiro, Floris van Doorn
+Ported by: Rémy Degenne
+-/
+import Mathlib.Algebra.Order.Field.Defs
+import Mathlib.Algebra.Order.Ring.Canonical
+import Mathlib.Algebra.Order.WithZero
+
+/-!
+# Canonically ordered semifields
+-/
+
+
+variable {α : Type _}
+
+/-- A canonically linear ordered field is a linear ordered field in which `a ≤ b` iff there exists
+`c` with `b = a + c`. -/
+class CanonicallyLinearOrderedSemifield (α : Type _) extends CanonicallyOrderedCommSemiring α,
+  LinearOrderedSemifield α
+#align canonically_linear_ordered_semifield CanonicallyLinearOrderedSemifield
+
+-- See note [lower instance priority]
+instance (priority := 100) CanonicallyLinearOrderedSemifield.toLinearOrderedCommGroupWithZero
+    [CanonicallyLinearOrderedSemifield α] : LinearOrderedCommGroupWithZero α :=
+  { ‹CanonicallyLinearOrderedSemifield α› with
+    mul_le_mul_left := fun a b h c => mul_le_mul_of_nonneg_left h <| zero_le _ }
+#align
+  canonically_linear_ordered_semifield.to_linear_ordered_comm_group_with_zero
+  CanonicallyLinearOrderedSemifield.toLinearOrderedCommGroupWithZero
+
+-- See note [lower instance priority]
+instance (priority := 100) CanonicallyLinearOrderedSemifield.toCanonicallyLinearOrderedAddMonoid
+    [CanonicallyLinearOrderedSemifield α] : CanonicallyLinearOrderedAddMonoid α :=
+  { ‹CanonicallyLinearOrderedSemifield α› with }
+#align
+  canonically_linear_ordered_semifield.to_canonically_linear_ordered_add_monoid
+  CanonicallyLinearOrderedSemifield.toCanonicallyLinearOrderedAddMonoid

--- a/Mathlib/Algebra/Order/Field/Canonical/Defs.lean
+++ b/Mathlib/Algebra/Order/Field/Canonical/Defs.lean
@@ -25,7 +25,7 @@ class CanonicallyLinearOrderedSemifield (α : Type _) extends CanonicallyOrdered
 instance (priority := 100) CanonicallyLinearOrderedSemifield.toLinearOrderedCommGroupWithZero
     [CanonicallyLinearOrderedSemifield α] : LinearOrderedCommGroupWithZero α :=
   { ‹CanonicallyLinearOrderedSemifield α› with
-    mul_le_mul_left := fun a b h c => mul_le_mul_of_nonneg_left h <| zero_le _ }
+    mul_le_mul_left := fun a b h c ↦ mul_le_mul_of_nonneg_left h <| zero_le _ }
 #align
   canonically_linear_ordered_semifield.to_linear_ordered_comm_group_with_zero
   CanonicallyLinearOrderedSemifield.toLinearOrderedCommGroupWithZero


### PR DESCRIPTION
Mathlib SHA: fc2ed6f838ce7c9b7c7171e58d78eaf7b438fb0e

Sorry, I forgot to push the mathport version. The only manual changes are:
- breaking two align lines that were above 100 chars.
- the deletion of a `@[protect_proj]` before line 20, which returned an error. I don't know whether that is the right thing to do or not. The wiki says I should protect all fields, but that class only extends two others and does not introduce new fields.
- replace one `=>` by `↦`