### PR TITLE
[Merged by Bors] - fix: ignore aux decls in casesMatching

### DIFF
--- a/Mathlib/Tactic/CasesM.lean
+++ b/Mathlib/Tactic/CasesM.lean
@@ -27,6 +27,7 @@ partial def casesMatching (g : MVarId) (matcher : Expr → MetaM Bool)
   go (g : MVarId) (acc : Array MVarId := #[]) : MetaM (Array MVarId) :=
     g.withContext do
       for ldecl in ← getLCtx do
+        if ldecl.isAuxDecl then continue
         if ← matcher ldecl.type then
           let mut acc := acc
           let subgoals ← if allowSplit then

--- a/test/casesm.lean
+++ b/test/casesm.lean
@@ -77,3 +77,19 @@ example : True ∧ True ∧ True := by
   constructorm _∧_
   · guard_target = True; constructorm True
   · guard_target = True ∧ True; constructorm* True, _∧_
+
+section AuxDecl
+variable {p q r : Prop}
+variable (h : p ∧ q ∨ p ∧ r)
+
+-- Make sure that we don't try to work on auxilliary declarations.
+-- In this case, there will be an auxiliary recursive declaration for
+-- `foo` itself that `casesm (_ ∧ _)` could potentially match.
+theorem foo : p ∧ p :=
+by cases h
+   · casesm (_ ∧ _)
+     constructor <;> assumption
+   · casesm (_ ∧ _)
+     constructor <;> assumption
+
+end AuxDecl

--- a/test/casesm.lean
+++ b/test/casesm.lean
@@ -82,7 +82,7 @@ section AuxDecl
 variable {p q r : Prop}
 variable (h : p ∧ q ∨ p ∧ r)
 
--- Make sure that we don't try to work on auxilliary declarations.
+-- Make sure that we don't try to work on auxiliary declarations.
 -- In this case, there will be an auxiliary recursive declaration for
 -- `foo` itself that `casesm (_ ∧ _)` could potentially match.
 theorem foo : p ∧ p :=


### PR DESCRIPTION
Adds a check so that we ignore auxiliary declarations in `casesMatching`.
Adds a testcase that fails when the fix is not applied.

This prevents errors of the form
```
failed to revert foo, it is an auxiliary declaration created to represent recursive definitions
```

See Zulip discussion here: https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/tactic.20'cases'.20failed.20nested.20error