### PR TITLE
[Merged by Bors] - fix: initialize simps for FunLike structures

### DIFF
--- a/Mathlib/Algebra/Hom/Group.lean
+++ b/Mathlib/Algebra/Hom/Group.lean
@@ -216,6 +216,10 @@ instance OneHom.oneHomClass : OneHomClass (OneHom M N) M N where
 #align one_hom.one_hom_class OneHom.oneHomClass
 #align zero_hom.zero_hom_class ZeroHom.zeroHomClass
 
+/-- See Note [custom simps projection] -/
+@[to_additive "See Note custom simps projection"]
+def OneHom.Simps.apply (f : OneHom M N) : M → N := f
+
 @[simp, to_additive]
 theorem map_one [OneHomClass F M N] (f : F) : f 1 = 1 :=
   OneHomClass.map_one f
@@ -295,6 +299,10 @@ instance MulHom.mulHomClass : MulHomClass (M →ₙ* N) M N where
 #align mul_hom.mul_hom_class MulHom.mulHomClass
 #align add_hom.add_hom_class AddHom.addHomClass
 
+/-- See Note [custom simps projection] -/
+@[to_additive "See Note custom simps projection"]
+def MulHom.Simps.apply (f : M →ₙ* N) : M → N := f
+
 @[simp, to_additive]
 theorem map_mul [MulHomClass F M N] (f : F) (x y : M) : f (x * y) = f x * f y :=
   MulHomClass.map_mul f x y
@@ -359,6 +367,10 @@ instance MonoidHom.monoidHomClass : MonoidHomClass (M →* N) M N where
   map_one f := f.toOneHom.map_one'
 #align monoid_hom.monoid_hom_class MonoidHom.monoidHomClass
 #align add_monoid_hom.add_monoid_hom_class AddMonoidHom.addMonoidHomClass
+
+/-- See Note [custom simps projection] -/
+@[to_additive "See Note custom simps projection"]
+def MonoidHom.Simps.apply (f : M →* N) : M → N := f
 
 -- Porting note: we need to add an extra `to_additive`.
 -- This is waiting on https://github.com/leanprover-community/mathlib4/issues/660
@@ -480,6 +492,9 @@ instance MonoidWithZeroHom.monoidWithZeroHomClass : MonoidWithZeroHomClass (M �
   map_one := MonoidWithZeroHom.map_one'
   map_zero f := f.map_zero'
 #align monoid_with_zero_hom.monoid_with_zero_hom_class MonoidWithZeroHom.monoidWithZeroHomClass
+
+/-- See Note [custom simps projection] -/
+def MonoidWithZeroHom.Simps.apply (f : M →*₀ N) : M → N := f
 
 /-- Any type that is a `MonoidWithZeroHomClass` can be cast into a `MonoidWithZeroHom`. -/
 instance [MonoidWithZeroHomClass F M N] : CoeTC F (M →*₀ N) :=

--- a/Mathlib/Algebra/Hom/Ring.lean
+++ b/Mathlib/Algebra/Hom/Ring.lean
@@ -124,6 +124,12 @@ instance : NonUnitalRingHomClass (α →ₙ+* β) α
 #noalign non_unital_ring_hom.coe_mk
 #noalign non_unital_ring_hom.coe_coe
 
+/-- See Note [custom simps projection] -/
+def Simps.apply {α β : Type _} [NonUnitalNonAssocSemiring α]
+  [NonUnitalNonAssocSemiring β] (f : α →ₙ+* β) : α → β := f
+
+initialize_simps_projections NonUnitalRingHom (toMulHom_toFun → apply, -toMulHom)
+
 @[simp]
 theorem coe_to_mulHom (f : α →ₙ+* β) : ⇑f.toMulHom = f :=
   rfl
@@ -417,8 +423,10 @@ instance : RingHomClass (α →+* β) α β where
 -- instance : CoeFun (α →+* β) fun _ => α → β :=
 --   ⟨RingHom.toFun⟩
 
-initialize_simps_projections RingHom
-  (toMonoidHom_toOneHom_toFun → apply, -toMonoidHom_toOneHom, -toMonoidHom)
+/-- See Note [custom simps projection] -/
+def Simps.apply {α β : Type _} [NonAssocSemiring α] [NonAssocSemiring β] (f : α →+* β) : α → β := f
+
+initialize_simps_projections RingHom (toMonoidHom_toOneHom_toFun → apply, -toMonoidHom)
 
 -- Porting note: is this lemma still needed in Lean4?
 @[simp]

--- a/Mathlib/Order/Hom/Basic.lean
+++ b/Mathlib/Order/Hom/Basic.lean
@@ -220,7 +220,7 @@ instance : OrderHomClass (α →o β) α β where
 
 /-- See Note [custom simps projection]. Note: all other FunLike classes use `apply` instead of `coe`
 for the projection names. Maybe we should change this. -/
-def OrderHom.Simps.coe (f : α →o β) : α → β := f
+def Simps.coe (f : α →o β) : α → β := f
 
 initialize_simps_projections OrderHom (toFun → coe)
 

--- a/Mathlib/Order/Hom/Basic.lean
+++ b/Mathlib/Order/Hom/Basic.lean
@@ -202,8 +202,6 @@ directly. -/
 instance : CoeFun (α →o β) fun _ => α → β :=
   ⟨OrderHom.toFun⟩
 
-initialize_simps_projections OrderHom (toFun → coe)
-
 protected theorem monotone (f : α →o β) : Monotone f :=
   f.monotone'
 #align order_hom.monotone OrderHom.monotone
@@ -219,6 +217,12 @@ instance : OrderHomClass (α →o β) α β where
     cases g
     congr
   map_rel f _ _ h := f.monotone h
+
+/-- See Note [custom simps projection]. Note: all other FunLike classes use `apply` instead of `coe`
+for the projection names. Maybe we should change this. -/
+def OrderHom.Simps.coe (f : α →o β) : α → β := f
+
+initialize_simps_projections OrderHom (toFun → coe)
 
 -- Porting note: dropped `to_fun_eq_coe` as it is a tautology now.
 #noalign order_hom.to_fun_eq_coe

--- a/Mathlib/Order/RelIso/Basic.lean
+++ b/Mathlib/Order/RelIso/Basic.lean
@@ -106,6 +106,9 @@ instance : RelHomClass (r →r s) r s where
     congr
   map_rel := map_rel'
 
+/-- See Note [custom simps projection] -/
+def RelHom.Simps.apply (f : r →r s) : α → β := f
+
 initialize_simps_projections RelHom (toFun → apply)
 
 protected theorem map_rel (f : r →r s) {a b} : r a b → s (f a) (f b) :=
@@ -244,6 +247,8 @@ because it is a composition of multiple projections. -/
 def Simps.apply (h : r ↪r s) : α → β :=
   h
 #align rel_embedding.simps.apply RelEmbedding.Simps.apply
+
+initialize_simps_projections RelEmbedding (toEmbedding_toFun → apply, -toEmbedding)
 
 theorem injective (f : r ↪r s) : Injective f :=
   f.inj'

--- a/Mathlib/Order/RelIso/Basic.lean
+++ b/Mathlib/Order/RelIso/Basic.lean
@@ -107,7 +107,7 @@ instance : RelHomClass (r →r s) r s where
   map_rel := map_rel'
 
 /-- See Note [custom simps projection] -/
-def RelHom.Simps.apply (f : r →r s) : α → β := f
+def Simps.apply (f : r →r s) : α → β := f
 
 initialize_simps_projections RelHom (toFun → apply)
 


### PR DESCRIPTION
Because coercions and bundling has changed, we have to give all simps projections of all `FunLike` structures manually for now (#1013).

Fixes linting issues in #977