### PR TITLE
[Merged by Bors] - feat: initialize_simps_projections has better tracing, hovers and jump-to-definition

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -260,6 +260,7 @@ import Mathlib.Lean.Expr.Basic
 import Mathlib.Lean.Expr.ReplaceRec
 import Mathlib.Lean.Expr.Traverse
 import Mathlib.Lean.LocalContext
+import Mathlib.Lean.Message
 import Mathlib.Lean.Meta
 import Mathlib.Lean.Meta.Simp
 import Mathlib.Logic.Basic

--- a/Mathlib/Lean/Message.lean
+++ b/Mathlib/Lean/Message.lean
@@ -1,0 +1,6 @@
+/-
+Copyright (c) 2022 Floris van Doorn. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Floris van Doorn
+-/
+import Lean.Message

--- a/Mathlib/Lean/Message.lean
+++ b/Mathlib/Lean/Message.lean
@@ -4,3 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn
 -/
 import Lean.Message
+
+open Lean Std Format MessageData
+instance [ToMessageData α] [ToMessageData β] : ToMessageData (α × β) :=
+  ⟨fun x => paren <| toMessageData x.1 ++ ofFormat "," ++ Format.line ++ toMessageData x.2 ⟩

--- a/Mathlib/Lean/Message.lean
+++ b/Mathlib/Lean/Message.lean
@@ -5,6 +5,10 @@ Authors: Floris van Doorn
 -/
 import Lean.Message
 
+/-!
+# Additional operations on MessageData and related types
+-/
+
 open Lean Std Format MessageData
 instance [ToMessageData α] [ToMessageData β] : ToMessageData (α × β) :=
   ⟨fun x => paren <| toMessageData x.1 ++ ofFormat "," ++ Format.line ++ toMessageData x.2 ⟩

--- a/Mathlib/Tactic/Simps/Basic.lean
+++ b/Mathlib/Tactic/Simps/Basic.lean
@@ -539,7 +539,7 @@ def simpsFindCustomProjection (str : Name) (proj : ParsedProjectionData)
   match env.find? customName with
   | some d@(.defnInfo _) =>
     let customProj := d.instantiateValueLevelParams! rawUnivs
-    trace[simps.verbose] "[simps] > found custom projection for {proj.newName}:\n        > {
+    trace[simps.verbose] "[simps] > found custom projection for {proj.newName.1}:\n        > {
       customProj}"
     match (← MetaM.run' $ isDefEq customProj rawExpr) with
     | true =>

--- a/Mathlib/Tactic/Simps/Basic.lean
+++ b/Mathlib/Tactic/Simps/Basic.lean
@@ -413,12 +413,6 @@ instance : ToMessageData ParsedProjectionData where toMessageData
       toMessageData x₅, toMessageData x₆, toMessageData x₇]
     ("," ++ Format.line) ++ "⟩"
 
--- instance : ToMessageData ParsedProjectionData where toMessageData
---   | ⟨x₁, x₂, x₃, x₄, x₅, x₆, x₇, x₈, x₉⟩ => .group <| .nest 1 <|
---     "⟨" ++ .joinSep [toMessageData x₁, toMessageData x₂, toMessageData x₃, toMessageData x₄,
---       toMessageData x₅, toMessageData x₆, toMessageData x₇, toMessageData x₈, toMessageData x₉]
---     ("," ++ Format.line) ++ "⟩"
-
 /-- The type of rules that specify how metadata for projections in changes.
   See `initialize_simps_projections`. -/
 structure ProjectionRule where

--- a/Mathlib/Tactic/Simps/Basic.lean
+++ b/Mathlib/Tactic/Simps/Basic.lean
@@ -419,18 +419,19 @@ abbrev ProjectionRule :=
 -- todo: use `MessageData` properly in the definition
 def projectionsInfo (l : List ProjectionData) (pref : String) (str : Name) : MessageData :=
   let ⟨defaults, nondefaults⟩ := l.partition (·.isDefault)
-  let toPrint : List Format :=
+  let toPrint : List MessageData :=
     defaults.map fun s ↦
       let prefixStr := if s.isPrefix then "(prefix) " else ""
-      f!"Projection {prefixStr}{s.name}: {s.expr}"
-  let print2 :=
+      m!"Projection {prefixStr}{s.name}: {s.expr}"
+  let print2 : MessageData :=
     String.join <| (nondefaults.map fun nm : ProjectionData ↦ toString nm.1).intersperse ", "
   let toPrint :=
-    toPrint.map toString ++
+    toPrint ++
       if nondefaults.isEmpty then [] else
-      ["No lemmas are generated for the projections: " ++ print2 ++ "."]
-  let toPrint := String.join <| toPrint.intersperse "\n        > "
-  f! "[simps] > {pref} {str}:\n        > {toPrint}"
+      [("No lemmas are generated for the projections: " : MessageData) ++ print2 ++ "."]
+  let toPrint := toPrint.intersperse ("\n        > " : MessageData) |>.foldl (fun r s => r ++ s)
+    ("" : MessageData)
+  m! "[simps] > {pref} {str}:\n        > {toPrint}"
 
 /-- Auxiliary function of `getCompositeOfProjections`. -/
 partial def getCompositeOfProjectionsAux (str : Name) (proj : String) (x : Expr)


### PR DESCRIPTION
* `initialize_simps_projections` now prints all tracing messages (with `?` or `trace.simps.debug`) as `MessageData` instead of `Format`, making it much more readable
* Add hovers and jump-to-definition over most arguments to `initialize_simps_projections`
  - They work for the structure name and all custom simps projections
  - other arguments also have hovers, but no jump-to-definition (since in general they are generally compositions of projections, and even if it is a single projection, it's eta-expanded, so it doesn't do jump-to-definition).