### PR TITLE
[Merged by Bors] - fix: ldecl.isAuxDecl -> ldecl.isImplementationDetail in CasesM

### DIFF
--- a/Mathlib/Tactic/CasesM.lean
+++ b/Mathlib/Tactic/CasesM.lean
@@ -27,7 +27,7 @@ partial def casesMatching (g : MVarId) (matcher : Expr → MetaM Bool)
   go (g : MVarId) (acc : Array MVarId := #[]) : MetaM (Array MVarId) :=
     g.withContext do
       for ldecl in ← getLCtx do
-        if ldecl.isAuxDecl then continue
+        if ldecl.isImplementationDetail then continue
         if ← matcher ldecl.type then
           let mut acc := acc
           let subgoals ← if allowSplit then


### PR DESCRIPTION
Followup to https://github.com/leanprover-community/mathlib4/pull/991.
See @JLimperg's comment https://github.com/leanprover-community/mathlib4/pull/991#issuecomment-1350805571