### PR TITLE
[Merged by Bors] - feat: make MulOpposite and AddOpposite structures

### DIFF
--- a/Mathlib/Algebra/Group/Opposite.lean
+++ b/Mathlib/Algebra/Group/Opposite.lean
@@ -176,12 +176,13 @@ theorem semiconj_by_op [Mul α] {a x y : α} : SemiconjBy (op a) (op y) (op x) �
   by simp only [SemiconjBy, ← op_mul, op_inj, eq_comm] ; rfl
 #align mul_opposite.semiconj_by_op MulOpposite.semiconj_by_op
 
-@[simp, to_additive]
+@[simp, nolint simpComm, to_additive]
 theorem semiconj_by_unop [Mul α] {a x y : αᵐᵒᵖ} :
     SemiconjBy (unop a) (unop y) (unop x) ↔ SemiconjBy a x y := by
   conv_rhs => rw [← op_unop a, ← op_unop x, ← op_unop y, semiconj_by_op]
 #align mul_opposite.semiconj_by_unop MulOpposite.semiconj_by_unop
 
+attribute [nolint simpComm] AddOpposite.semiconj_by_unop
 @[to_additive]
 theorem _root_.SemiconjBy.op [Mul α] {a x y : α} (h : SemiconjBy a x y) :
     SemiconjBy (op a) (op y) (op x) :=
@@ -209,10 +210,12 @@ theorem commute_op [Mul α] {x y : α} : Commute (op x) (op y) ↔ Commute x y :
   semiconj_by_op
 #align mul_opposite.commute_op MulOpposite.commute_op
 
-@[simp, to_additive]
+@[simp, nolint simpComm, to_additive]
 theorem commute_unop [Mul α] {x y : αᵐᵒᵖ} : Commute (unop x) (unop y) ↔ Commute x y :=
   semiconj_by_unop
 #align mul_opposite.commute_unop MulOpposite.commute_unop
+
+attribute [nolint simpComm] AddOpposite.commute_unop
 
 /-- The function `mul_opposite.op` is an additive equivalence. -/
 @[simps (config := { fullyApplied := false, simpRhs := true })]

--- a/Mathlib/Algebra/Group/Opposite.lean
+++ b/Mathlib/Algebra/Group/Opposite.lean
@@ -38,10 +38,10 @@ instance [AddCommSemigroup α] : AddCommSemigroup αᵐᵒᵖ :=
   unop_injective.addCommSemigroup _ fun _ _ => rfl
 
 instance [AddZeroClass α] : AddZeroClass αᵐᵒᵖ :=
-  unop_injective.addZeroClass _ rfl fun _ _ => rfl
+  unop_injective.addZeroClass _ (by exact rfl) fun _ _ => rfl
 
 instance [AddMonoid α] : AddMonoid αᵐᵒᵖ :=
-  unop_injective.addMonoid _ rfl (fun _ _ => rfl) fun _ _ => rfl
+  unop_injective.addMonoid _ (by exact rfl) (fun _ _ => rfl) fun _ _ => rfl
 
 instance [AddMonoidWithOne α] : AddMonoidWithOne αᵐᵒᵖ :=
   { instAddMonoidMulOpposite α, instOneMulOpposite α with
@@ -50,25 +50,25 @@ instance [AddMonoidWithOne α] : AddMonoidWithOne αᵐᵒᵖ :=
     natCast_succ := show ∀ n, op ((n + 1 : ℕ) : α) = op ((n : ℕ) : α) + 1 by simp }
 
 instance [AddCommMonoid α] : AddCommMonoid αᵐᵒᵖ :=
-  unop_injective.addCommMonoid _ rfl (fun _ _ => rfl) fun _ _ => rfl
+  unop_injective.addCommMonoid _ (by exact rfl) (fun _ _ => rfl) fun _ _ => rfl
 
 instance [SubNegMonoid α] : SubNegMonoid αᵐᵒᵖ :=
-  unop_injective.subNegMonoid _ rfl (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl)
+  unop_injective.subNegMonoid _ (by exact rfl) (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl)
     (fun _ _ => rfl) fun _ _ => rfl
 
 instance [AddGroup α] : AddGroup αᵐᵒᵖ :=
-  unop_injective.addGroup _ rfl (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl)
-    fun _ _ => rfl
+  unop_injective.addGroup _ (by exact rfl) (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl)
+  (fun _ _ => rfl) fun _ _ => rfl
 
 instance [AddGroupWithOne α] : AddGroupWithOne αᵐᵒᵖ :=
   { instAddMonoidWithOneMulOpposite α, instAddGroupMulOpposite α with
     intCast := fun n => op n,
     intCast_ofNat := fun n => show op ((n : ℤ) : α) = op (n : α) by rw [Int.cast_ofNat],
     intCast_negSucc := fun n =>
-      show op _ = op (-unop (op ((n + 1 : ℕ) : α))) by erw [unop_op, Int.cast_negSucc] }
+      show op _ = op (-unop (op ((n + 1 : ℕ) : α))) by simp }
 
 instance [AddCommGroup α] : AddCommGroup αᵐᵒᵖ :=
-  unop_injective.addCommGroup _ rfl (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl)
+  unop_injective.addCommGroup _ (by exact rfl) (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl)
     (fun _ _ => rfl) fun _ _ => rfl
 
 /-!
@@ -247,7 +247,7 @@ instance [CommSemigroup α] : CommSemigroup αᵃᵒᵖ :=
   unop_injective.commSemigroup _ fun _ _ => rfl
 
 instance [MulOneClass α] : MulOneClass αᵃᵒᵖ :=
-  unop_injective.mulOneClass _ rfl fun _ _ => rfl
+  unop_injective.mulOneClass _ (by exact rfl) fun _ _ => rfl
 
 instance {β} [Pow α β] : Pow αᵃᵒᵖ β where pow a b := op (unop a ^ b)
 
@@ -262,22 +262,22 @@ theorem unop_pow {β} [Pow α β] (a : αᵃᵒᵖ) (b : β) : unop (a ^ b) = un
 #align add_opposite.unop_pow AddOpposite.unop_pow
 
 instance [Monoid α] : Monoid αᵃᵒᵖ :=
-  unop_injective.monoid _ rfl (fun _ _ => rfl) fun _ _ => rfl
+  unop_injective.monoid _ (by exact rfl) (fun _ _ => rfl) fun _ _ => rfl
 
 instance [CommMonoid α] : CommMonoid αᵃᵒᵖ :=
-  unop_injective.commMonoid _ rfl (fun _ _ => rfl) fun _ _ => rfl
+  unop_injective.commMonoid _ (by exact rfl) (fun _ _ => rfl) fun _ _ => rfl
 
 instance [DivInvMonoid α] : DivInvMonoid αᵃᵒᵖ :=
-  unop_injective.divInvMonoid _ rfl (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl)
+  unop_injective.divInvMonoid _ (by exact rfl) (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl)
     (fun _ _ => rfl) fun _ _ => rfl
 
 instance [Group α] : Group αᵃᵒᵖ :=
-  unop_injective.group _ rfl (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl)
-    fun _ _ => rfl
+  unop_injective.group _ (by exact rfl) (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl)
+  (fun _ _ => rfl) fun _ _ => rfl
 
 instance [CommGroup α] : CommGroup αᵃᵒᵖ :=
-  unop_injective.commGroup _ rfl (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl)
-    fun _ _ => rfl
+  unop_injective.commGroup _ (by exact rfl) (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl)
+  (fun _ _ => rfl) fun _ _ => rfl
 
 variable {α}
 
@@ -362,7 +362,7 @@ def MonoidHom.fromOpposite {M N : Type _} [MulOneClass M] [MulOneClass N] (f : M
       of the additive units."]
 def Units.opEquiv {M} [Monoid M] : Mᵐᵒᵖˣ ≃* Mˣᵐᵒᵖ where
   toFun u := op ⟨unop u, unop ↑u⁻¹, op_injective u.4, op_injective u.3⟩
-  invFun := MulOpposite.rec fun u => ⟨op ↑u, op ↑u⁻¹, unop_injective <| u.4, unop_injective u.3⟩
+  invFun := MulOpposite.rec' fun u => ⟨op ↑u, op ↑u⁻¹, unop_injective <| u.4, unop_injective u.3⟩
   map_mul' x y := unop_injective <| Units.ext <| rfl
   left_inv x := Units.ext <| by simp
   right_inv x := unop_injective <| Units.ext <| rfl
@@ -514,7 +514,7 @@ def AddEquiv.mulOp {α β} [Add α] [Add β] : α ≃+ β ≃ (αᵐᵒᵖ ≃+ 
   right_inv f := by
     apply AddEquiv.ext
     intro
-    simp [MulOpposite.op, MulOpposite.unop]
+    rfl
 #align add_equiv.mul_op AddEquiv.mulOp
 
 /-- The 'unopposite' of an iso `αᵐᵒᵖ ≃+ βᵐᵒᵖ`. Inverse to `add_equiv.mul_op`. -/

--- a/Mathlib/Algebra/Opposites.lean
+++ b/Mathlib/Algebra/Opposites.lean
@@ -37,8 +37,6 @@ definitional eta reduction for structures (Lean 3 does not).
 ## Tags
 
 multiplicative opposite, additive opposite
-
-##
 -/
 
 
@@ -91,7 +89,7 @@ theorem op_comp_unop : (op : α → αᵐᵒᵖ) ∘ unop = id :=
 theorem unop_comp_op : (unop : αᵐᵒᵖ → α) ∘ op = id :=
   rfl
 
-/-- A recursor for `MulOpposite`. Use as `induction x using MulOpposite.rec`. -/
+/-- A recursor for `MulOpposite`. Use as `induction x using MulOpposite.rec'`. -/
 @[simp, to_additive "A recursor for `AddOpposite`. Use as `induction x using AddOpposite.rec`."]
 protected def rec' {F : ∀ _ : αᵐᵒᵖ, Sort v} (h : ∀ X, F (op X)) : ∀ X, F X := fun X => h (unop X)
 #align mul_opposite.rec MulOpposite.rec'

--- a/Mathlib/Algebra/Opposites.lean
+++ b/Mathlib/Algebra/Opposites.lean
@@ -27,9 +27,18 @@ from `α` to `αᵃᵒᵖ`.
 * `αᵐᵒᵖ = MulOpposite α`
 * `αᵃᵒᵖ = AddOpposite α`
 
+## Implementation notes
+
+In mathlib3 `αᵐᵒᵖ` was just a type synonym for `α`, marked irreducible after the API
+was developed. In mathlib4 we use a structure with one field, because it is not possible
+to change the reducibility of a declaration after its definition, and because Lean 4 has
+definitional eta reduction for structures (Lean 3 does not).
+
 ## Tags
 
 multiplicative opposite, additive opposite
+
+##
 -/
 
 
@@ -39,11 +48,24 @@ open Function
 
 /-- Multiplicative opposite of a type. This type inherits all additive structures on `α` and
 reverses left and right in multiplication.-/
-@[to_additive
-      "Additive opposite of a type. This type inherits all multiplicative structures on
-      `α` and reverses left and right in addition."]
-def MulOpposite (α : Type u) : Type u :=
-  α
+structure MulOpposite (α : Type u) : Type u where
+  /-- The element of `MulOpposite α` that represents `x : α`. -/ op ::
+  /-- The element of `α` represented by `x : αᵐᵒᵖ`. -/ unop : α
+#align mul_opposite.op MulOpposite.op
+
+-- porting note: the attribute `pp_nodot` does not exist yet; `op` and `unop` were
+-- both tagged with it in mathlib3
+
+/-- Additive opposite of a type. This type inherits all multiplicative structures on
+      `α` and reverses left and right in addition. -/
+structure AddOpposite (α : Type u) : Type u where
+  /-- The element of `αᵃᵒᵖ` that represents `x : α`. -/ op ::
+  /-- The element of `α` represented by `x : αᵃᵒᵖ`. -/ unop : α
+
+-- porting note: the attribute `pp_nodot` does not exist yet; `op` and `unop` were
+-- both tagged with it in mathlib3
+
+attribute [to_additive] MulOpposite
 
 /-- Multiplicative opposite of a type. -/
 postfix:max "ᵐᵒᵖ" => MulOpposite
@@ -52,20 +74,6 @@ postfix:max "ᵐᵒᵖ" => MulOpposite
 postfix:max "ᵃᵒᵖ" => AddOpposite
 
 namespace MulOpposite
-
-/-- The element of `MulOpposite α` that represents `x : α`. -/
--- porting note: the attribute `pp_nodot` does not exist yet
---@[pp_nodot,
-@[to_additive "The element of `αᵃᵒᵖ` that represents `x : α`."]
-def op : α → αᵐᵒᵖ :=
-  id
-#align mul_opposite.op MulOpposite.op
-
-/-- The element of `α` represented by `x : αᵐᵒᵖ`. -/
---@[pp_nodot,
-@[to_additive "The element of `α` represented by `x : αᵃᵒᵖ`."]
-def unop : αᵐᵒᵖ → α :=
-  id
 
 @[simp, to_additive]
 theorem unop_op (x : α) : unop (op x) = x :=
@@ -85,8 +93,8 @@ theorem unop_comp_op : (unop : αᵐᵒᵖ → α) ∘ op = id :=
 
 /-- A recursor for `MulOpposite`. Use as `induction x using MulOpposite.rec`. -/
 @[simp, to_additive "A recursor for `AddOpposite`. Use as `induction x using AddOpposite.rec`."]
-protected def rec {F : ∀ _ : αᵐᵒᵖ, Sort v} (h : ∀ X, F (op X)) : ∀ X, F X := fun X => h (unop X)
-#align mul_opposite.rec MulOpposite.rec
+protected def rec' {F : ∀ _ : αᵐᵒᵖ, Sort v} (h : ∀ X, F (op X)) : ∀ X, F X := fun X => h (unop X)
+#align mul_opposite.rec MulOpposite.rec'
 
 /-- The canonical bijection between `α` and `αᵐᵒᵖ`. -/
 @[to_additive "The canonical bijection between `α` and `αᵃᵒᵖ`.",--]
@@ -344,7 +352,7 @@ theorem op_div [Div α] (a b : α) : op (a / b) = op a / op b :=
 #align add_opposite.op_div AddOpposite.op_div
 
 @[simp]
-theorem unop_div [Div α] (a b : α) : unop (a / b) = unop a / unop b :=
+theorem unop_div [Div α] (a b : αᵃᵒᵖ) : unop (a / b) = unop a / unop b :=
   rfl
 #align add_opposite.unop_div AddOpposite.unop_div
 

--- a/Mathlib/Algebra/Opposites.lean
+++ b/Mathlib/Algebra/Opposites.lean
@@ -73,9 +73,9 @@ postfix:max "ᵃᵒᵖ" => AddOpposite
 
 namespace MulOpposite
 
-@[simp, to_additive]
-theorem unop_op (x : α) : unop (op x) = x :=
-  rfl
+-- porting note: `simp` can prove this in Lean 4
+@[to_additive]
+theorem unop_op (x : α) : unop (op x) = x := rfl
 
 @[simp, to_additive]
 theorem op_unop (x : αᵐᵒᵖ) : op (unop x) = x :=
@@ -125,13 +125,15 @@ theorem unop_injective : Injective (unop : αᵐᵒᵖ → α) :=
 theorem unop_surjective : Surjective (unop : αᵐᵒᵖ → α) :=
   unop_bijective.surjective
 
-@[simp, to_additive]
-theorem op_inj {x y : α} : op x = op y ↔ x = y :=
-  op_injective.eq_iff
+-- porting note: `simp` can prove this
+@[to_additive]
+theorem op_inj {x y : α} : op x = op y ↔ x = y := by simp
 
-@[simp, to_additive]
+@[simp, nolint simpComm, to_additive]
 theorem unop_inj {x y : αᵐᵒᵖ} : unop x = unop y ↔ x = y :=
   unop_injective.eq_iff
+
+attribute [nolint simpComm] AddOpposite.unop_inj
 
 variable (α)
 
@@ -263,7 +265,7 @@ end
 
 variable {α}
 
-@[simp]
+@[simp, nolint simpComm]
 theorem unop_eq_zero_iff [Zero α] (a : αᵐᵒᵖ) : a.unop = (0 : α) ↔ a = (0 : αᵐᵒᵖ) :=
   unop_injective.eq_iff' rfl
 #align mul_opposite.unop_eq_zero_iff MulOpposite.unop_eq_zero_iff
@@ -281,9 +283,11 @@ theorem op_ne_zero_iff [Zero α] (a : α) : op a ≠ (0 : αᵐᵒᵖ) ↔ a ≠
   not_congr $ op_eq_zero_iff a
 #align mul_opposite.op_ne_zero_iff MulOpposite.op_ne_zero_iff
 
-@[simp, to_additive]
+@[simp, nolint simpComm, to_additive]
 theorem unop_eq_one_iff [One α] (a : αᵐᵒᵖ) : a.unop = 1 ↔ a = 1 :=
   unop_injective.eq_iff' rfl
+
+attribute [nolint simpComm] AddOpposite.unop_eq_zero_iff
 
 @[simp, to_additive]
 theorem op_eq_one_iff [One α] (a : α) : op a = 1 ↔ a = 1 :=
@@ -314,6 +318,8 @@ theorem op_eq_one_iff [One α] {a : α} : op a = 1 ↔ a = 1 :=
 theorem unop_eq_one_iff [One α] {a : αᵃᵒᵖ} : unop a = 1 ↔ a = 1 :=
   unop_injective.eq_iff' unop_one
 #align add_opposite.unop_eq_one_iff AddOpposite.unop_eq_one_iff
+
+attribute [nolint simpComm] unop_eq_one_iff
 
 instance [Mul α] : Mul αᵃᵒᵖ where mul a b := op (unop a * unop b)
 
@@ -357,3 +363,4 @@ theorem unop_div [Div α] (a b : αᵃᵒᵖ) : unop (a / b) = unop a / unop b :
 #align add_opposite.unop_div AddOpposite.unop_div
 
 end AddOpposite
+#lint

--- a/Mathlib/Algebra/Opposites.lean
+++ b/Mathlib/Algebra/Opposites.lean
@@ -351,6 +351,8 @@ theorem op_div [Div α] (a b : α) : op (a / b) = op a / op b :=
   rfl
 #align add_opposite.op_div AddOpposite.op_div
 
+-- porting note: this lemma looked wrong to me -- is it wrong in mathlib3?
+-- The types of a and b were α not αᵃᵒᵖ.
 @[simp]
 theorem unop_div [Div α] (a b : αᵃᵒᵖ) : unop (a / b) = unop a / unop b :=
   rfl

--- a/Mathlib/Algebra/Ring/Opposite.lean
+++ b/Mathlib/Algebra/Ring/Opposite.lean
@@ -103,8 +103,8 @@ namespace AddOpposite
 
 instance [Distrib α] : Distrib αᵃᵒᵖ :=
   { AddOpposite.instAddAddOpposite α, @AddOpposite.instMulAddOpposite α _ with
-    left_distrib := fun x y z => unop_injective <| @mul_add α _ _ _ x z y,
-    right_distrib := fun x y z => unop_injective <| @add_mul α _ _ _ y x z }
+    left_distrib := fun x y z => unop_injective <| mul_add (unop x) (unop z) (unop y),
+    right_distrib := fun x y z => unop_injective <| add_mul (unop y) (unop x) (unop z) }
 
 instance [MulZeroClass α] : MulZeroClass αᵃᵒᵖ where
   zero := 0

--- a/Mathlib/GroupTheory/GroupAction/Defs.lean
+++ b/Mathlib/GroupTheory/GroupAction/Defs.lean
@@ -265,11 +265,8 @@ class IsCentralScalar (M α : Type _) [SMul M α] [SMul Mᵐᵒᵖ α] : Prop wh
 
 @[to_additive]
 theorem IsCentralScalar.unop_smul_eq_smul {M α : Type _} [SMul M α] [SMul Mᵐᵒᵖ α]
-    [IsCentralScalar M α] (m : Mᵐᵒᵖ) (a : α) : MulOpposite.unop m • a = m • a := by
-  -- Porting note: was one liner
-  apply MulOpposite.rec _ m
-  intro m
-  apply (IsCentralScalar.op_smul_eq_smul _ _).symm
+    [IsCentralScalar M α] (m : Mᵐᵒᵖ) (a : α) : MulOpposite.unop m • a = m • a :=
+  MulOpposite.rec (fun _ => (IsCentralScalar.op_smul_eq_smul _ _).symm) m
 #align is_central_scalar.unop_smul_eq_smul IsCentralScalar.unop_smul_eq_smul
 
 export IsCentralVAdd (op_vadd_eq_vadd unop_vadd_eq_vadd)


### PR DESCRIPTION
This refactor makes `αᵐᵒᵖ` and `αᵃᵒᵖ` into structures with one field, an idea more appropriate in Lean 4 than the Lean 3 approach of type synonyms.