### PR TITLE
[Merged by Bors] - fix: alias uses type of lemma

### DIFF
--- a/Mathlib/Tactic/Alias.lean
+++ b/Mathlib/Tactic/Alias.lean
@@ -129,8 +129,8 @@ def Target.toString : Target → String
   Given a possibly forall-quantified iff expression `prf`, produce a value for one
   of the implication directions (determined by `mp`).
 -/
-def mkIffMpApp (mp : Bool) (prf : Expr) : MetaM Expr := do
-  Meta.forallTelescope (← Meta.inferType prf) fun xs ty ↦ do
+def mkIffMpApp (mp : Bool) (ty prf : Expr) : MetaM Expr := do
+  Meta.forallTelescope ty fun xs ty ↦ do
     let some (lhs, rhs) := ty.iff?
       | throwError "Target theorem must have the form `∀ x y z, a ↔ b`"
     Meta.mkLambdaFVars xs <|
@@ -144,7 +144,7 @@ def aliasIff (doc : Option (TSyntax `Lean.Parser.Command.docComment)) (ci : Cons
   (ref : Syntax) (al : Name) (isForward : Bool) :
   TermElabM Unit := do
   let ls := ci.levelParams
-  let v ← mkIffMpApp isForward ci.value!
+  let v ← mkIffMpApp isForward ci.type ci.value!
   let t' ← Meta.inferType v
   -- TODO add @alias attribute
   addDeclarationRanges al {

--- a/test/Alias.lean
+++ b/test/Alias.lean
@@ -1,5 +1,8 @@
-import Mathlib
+import Mathlib.Tactic.Alias
+import Mathlib.Tactic.RunCmd
+import Std.Tactic.GuardExpr
 
+open Lean Meta
 namespace Alias
 namespace A
 
@@ -59,5 +62,15 @@ end C
 
 example : True → True ∧ True := B.forward2 True
 example : True ∧ True → True := B.backward2 True
+
+theorem checkType : 1 + 1 = 2 ↔ 2 = 2 := .rfl
+alias checkType ↔ forward backward
+
+example : True := by
+  have h1 := forward
+  have h2 := backward
+  guard_hyp h1 :ₛ 1 + 1 = 2 → 2 = 2
+  guard_hyp h2 :ₛ 2 = 2 → 1 + 1 = 2
+  trivial
 
 end Alias


### PR DESCRIPTION
`#check @Function.Surjective.range_eq` now gives
```lean
@Surjective.range_eq : ∀ {α : Type u_2} {ι : Sort u_1} {f : ι → α}, Surjective f → range f = univ
```
as expected.