### PR TITLE
[Merged by Bors] - feat: port algebra.group.pi

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -16,6 +16,7 @@ import Mathlib.Algebra.Group.Ext
 import Mathlib.Algebra.Group.InjSurj
 import Mathlib.Algebra.Group.Opposite
 import Mathlib.Algebra.Group.OrderSynonym
+import Mathlib.Algebra.Group.Pi
 import Mathlib.Algebra.Group.Prod
 import Mathlib.Algebra.Group.Semiconj
 import Mathlib.Algebra.Group.TypeTags

--- a/Mathlib/Algebra/Group/Pi.lean
+++ b/Mathlib/Algebra/Group/Pi.lean
@@ -243,7 +243,8 @@ section MulHom
 /-- A family of MulHom's `f a : γ →ₙ* β a` defines a MulHom `Pi.mulHom f : γ →ₙ* Π a, β a`
 given by `Pi.mulHom f x b = f b x`. -/
 @[to_additive
-      "A family of AddHom's `f a : γ → β a` defines an AddHom `Pi.addHom\nf : γ → Π a, β a` given by `Pi.addHom f x b = f b x`.",
+      "A family of AddHom's `f a : γ → β a` defines an AddHom `Pi.addHom f : γ → Π a, β a` given by
+      `Pi.addHom f x b = f b x`.",
   simps]
 def Pi.mulHom {γ : Type w} [∀ i, Mul (f i)] [Mul γ] (g : ∀ i, γ →ₙ* f i) : γ →ₙ* ∀ i, f i where
   toFun x i := g i x
@@ -262,7 +263,8 @@ theorem Pi.mulHom_injective {γ : Type w} [Nonempty I] [∀ i, Mul (f i)] [Mul �
 /-- A family of monoid homomorphisms `f a : γ →* β a` defines a monoid homomorphism
 `Pi.monoidHom f : γ →* Π a, β a` given by `Pi.monoidHom f x b = f b x`. -/
 @[to_additive
-      "A family of additive monoid homomorphisms `f a : γ →+ β a` defines a monoid\nhomomorphism `Pi.addMonoidHom f : γ →+ Π a, β a` given by `Pi.addMonoidHom f x b\n= f b x`.",
+      "A family of additive monoid homomorphisms `f a : γ →+ β a` defines a monoid homomorphism
+      `Pi.addMonoidHom f : γ →+ Π a, β a` given by `Pi.addMonoidHom f x b = f b x`.",
   simps]
 def Pi.monoidHom {γ : Type w} [∀ i, MulOneClass (f i)] [MulOneClass γ] (g : ∀ i, γ →* f i) :
     γ →* ∀ i, f i :=
@@ -286,7 +288,8 @@ variable (f) [(i : I) → Mul (f i)]
 homomorphism.
 This is `Function.eval i` as a `MulHom`. -/
 @[to_additive
-      "Evaluation of functions into an indexed collection of additive semigroups at a\npoint is an additive semigroup homomorphism.\nThis is `Function.eval i` as an `AddHom`.",
+      "Evaluation of functions into an indexed collection of additive semigroups at a point is an
+      additive semigroup homomorphism. This is `Function.eval i` as an `AddHom`.",
   simps]
 def Pi.evalMulHom (i : I) : (∀ i, f i) →ₙ* f i where
   toFun g := g i
@@ -304,9 +307,12 @@ def Pi.constMulHom (α β : Type _) [Mul β] :
 #align pi.const_add_hom Pi.constAddHom
 
 /-- Coercion of a `MulHom` into a function is itself a `MulHom`.
+
 See also `MulHom.eval`. -/
 @[to_additive
-      "Coercion of an `AddHom` into a function is itself an `AddHom`.\nSee also `AddHom.eval`. ",
+      "Coercion of an `AddHom` into a function is itself an `AddHom`.
+
+      See also `AddHom.eval`. ",
   simps]
 def MulHom.coeFn (α β : Type _) [Mul α] [CommSemigroup β] :
     (α →ₙ* β) →ₙ* α → β where
@@ -318,7 +324,8 @@ def MulHom.coeFn (α β : Type _) [Mul α] [CommSemigroup β] :
 /-- Semigroup homomorphism between the function spaces `I → α` and `I → β`, induced by a semigroup
 homomorphism `f` between `α` and `β`. -/
 @[to_additive
-      "Additive semigroup homomorphism between the function spaces `I → α` and `I → β`,\ninduced by an additive semigroup homomorphism `f` between `α` and `β`",
+      "Additive semigroup homomorphism between the function spaces `I → α` and `I → β`, induced by
+      an additive semigroup homomorphism `f` between `α` and `β`",
   simps]
 protected def MulHom.compLeft {α β : Type _} [Mul α] [Mul β] (f : α →ₙ* β) (I : Type _) :
     (I → α) →ₙ* I → β where
@@ -337,7 +344,8 @@ variable (f) [(i : I) → MulOneClass (f i)]
 homomorphism.
 This is `Function.eval i` as a `MonoidHom`. -/
 @[to_additive
-      "Evaluation of functions into an indexed collection of additive monoids at a\npoint is an additive monoid homomorphism.\nThis is `Function.eval i` as an `AddMonoidHom`.",
+      "Evaluation of functions into an indexed collection of additive monoids at a point is an
+      additive monoid homomorphism. This is `Function.eval i` as an `AddMonoidHom`.",
   simps]
 def Pi.evalMonoidHom (i : I) :
     (∀ i, f i) →* f i where
@@ -361,7 +369,9 @@ def Pi.constMonoidHom (α β : Type _) [MulOneClass β] :
 
 See also `MonoidHom.eval`. -/
 @[to_additive
-      "Coercion of an `AddMonoidHom` into a function is itself a `AddMonoidHom`.\n\nSee also `AddMonoidHom.eval`. ",
+      "Coercion of an `AddMonoidHom` into a function is itself a `AddMonoidHom`.
+
+      See also `AddMonoidHom.eval`. ",
   simps]
 def MonoidHom.coeFn (α β : Type _) [MulOneClass α] [CommMonoid β] :
     (α →* β) →* α → β where
@@ -374,7 +384,8 @@ def MonoidHom.coeFn (α β : Type _) [MulOneClass α] [CommMonoid β] :
 /-- Monoid homomorphism between the function spaces `I → α` and `I → β`, induced by a monoid
 homomorphism `f` between `α` and `β`. -/
 @[to_additive
-      "Additive monoid homomorphism between the function spaces `I → α` and `I → β`,\ninduced by an additive monoid homomorphism `f` between `α` and `β`",
+      "Additive monoid homomorphism between the function spaces `I → α` and `I → β`, induced by an
+      additive monoid homomorphism `f` between `α` and `β`",
   simps]
 protected def MonoidHom.compLeft {α β : Type _} [MulOneClass α] [MulOneClass β] (f : α →* β)
     (I : Type _) : (I → α) →* I → β where
@@ -399,7 +410,10 @@ into a dependent family of values, as functions supported at a point.
 
 This is the `OneHom` version of `Pi.mulSingle`. -/
 @[to_additive
-      "The zero-preserving homomorphism including a single value\ninto a dependent family of values, as functions supported at a point.\n\nThis is the `ZeroHom` version of `Pi.Single`."]
+      "The zero-preserving homomorphism including a single value into a dependent family of values,
+      as functions supported at a point.
+
+      This is the `ZeroHom` version of `Pi.Single`."]
 def OneHom.single [∀ i, One <| f i] (i : I) :
     OneHom (f i) (∀ i, f i) where
   toFun := mulSingle i
@@ -419,7 +433,10 @@ as functions supported at a point.
 
 This is the `MonoidHom` version of `Pi.mulSingle`. -/
 @[to_additive
-      "The additive monoid homomorphism including a single additive\nmonoid into a dependent family of additive monoids, as functions supported at a point.\n\nThis is the `AddMonoidHom` version of `Pi.Single`."]
+      "The additive monoid homomorphism including a single additive monoid into a dependent family
+      of additive monoids, as functions supported at a point.
+
+      This is the `AddMonoidHom` version of `Pi.Single`."]
 def MonoidHom.single [∀ i, MulOneClass <| f i] (i : I) : f i →* ∀ i, f i :=
   { OneHom.single f i with map_mul' := mulSingle_op₂ (fun _ => (· * ·)) (fun _ => one_mul _) _ }
 #align monoid_hom.single MonoidHom.single
@@ -475,7 +492,9 @@ theorem Pi.single_mul [∀ i, MulZeroClass <| f i] (i : I) (x y : f i) :
 
 For injections of commuting elements at the same index, see `Commute.map` -/
 @[to_additive
-      "The injection into an additive pi group at different indices commutes.\n\nFor injections of commuting elements at the same index, see `AddCommute.map`"]
+      "The injection into an additive pi group at different indices commutes.
+
+      For injections of commuting elements at the same index, see `AddCommute.map`"]
 theorem Pi.mulSingle_commute [∀ i, MulOneClass <| f i] :
     Pairwise fun i j => ∀ (x : f i) (y : f j), Commute (mulSingle i x) (mulSingle j y) := by
   intro i j hij x y; ext k
@@ -542,7 +561,8 @@ theorem Pi.mulSingle_mul_mulSingle_eq_mulSingle_mul_mulSingle {M : Type _} [Comm
     · apply mul_comm
     · simp_rw [← Pi.mulSingle_mul, h, mulSingle_one]
 #align
-  pi.mul_single_mul_mul_single_eq_mul_single_mul_mul_single Pi.mulSingle_mul_mulSingle_eq_mulSingle_mul_mulSingle
+  pi.mul_single_mul_mul_single_eq_mul_single_mul_mul_single
+  Pi.mulSingle_mul_mulSingle_eq_mulSingle_mul_mulSingle
 #align pi.single_add_single_eq_single_add_single Pi.single_add_single_eq_single_add_single
 
 end Single

--- a/Mathlib/Algebra/Group/Pi.lean
+++ b/Mathlib/Algebra/Group/Pi.lean
@@ -1,0 +1,599 @@
+/-
+Copyright (c) 2018 Simon Hudon. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Simon Hudon, Patrick Massot
+
+! This file was ported from Lean 3 source module algebra.group.pi
+! leanprover-community/mathlib commit b3f25363ae62cb169e72cd6b8b1ac97bacf21ca7
+! Please do not edit these lines, except to modify the commit id
+! if you have ported upstream changes.
+-/
+import Mathbin.Logic.Pairwise
+import Mathbin.Algebra.Hom.GroupInstances
+import Mathbin.Data.Pi.Algebra
+import Mathbin.Data.Set.Function
+import Mathbin.Tactic.PiInstances
+
+/-!
+# Pi instances for groups and monoids
+
+This file defines instances for group, monoid, semigroup and related structures on Pi types.
+-/
+
+
+universe u v w
+
+variable {ι α : Type _}
+
+variable {I : Type u}
+
+-- The indexing type
+variable {f : I → Type v}
+
+-- The family of types already equipped with instances
+variable (x y : ∀ i, f i) (i : I)
+
+@[to_additive]
+theorem Set.preimage_one {α β : Type _} [One β] (s : Set β) [Decidable ((1 : β) ∈ s)] :
+    (1 : α → β) ⁻¹' s = if (1 : β) ∈ s then Set.univ else ∅ :=
+  Set.preimage_const 1 s
+#align set.preimage_one Set.preimage_one
+
+namespace Pi
+
+@[to_additive]
+instance semigroup [∀ i, Semigroup <| f i] : Semigroup (∀ i : I, f i) := by
+  refine_struct { mul := (· * ·).. } <;> pi_instance_derive_field
+#align pi.semigroup Pi.semigroup
+
+instance semigroupWithZero [∀ i, SemigroupWithZero <| f i] : SemigroupWithZero (∀ i : I, f i) := by
+  refine_struct
+      { zero := (0 : ∀ i, f i)
+        mul := (· * ·).. } <;>
+    pi_instance_derive_field
+#align pi.semigroup_with_zero Pi.semigroupWithZero
+
+@[to_additive]
+instance commSemigroup [∀ i, CommSemigroup <| f i] : CommSemigroup (∀ i : I, f i) := by
+  refine_struct { mul := (· * ·).. } <;> pi_instance_derive_field
+#align pi.comm_semigroup Pi.commSemigroup
+
+@[to_additive]
+instance mulOneClass [∀ i, MulOneClass <| f i] : MulOneClass (∀ i : I, f i) := by
+  refine_struct
+      { one := (1 : ∀ i, f i)
+        mul := (· * ·).. } <;>
+    pi_instance_derive_field
+#align pi.mul_one_class Pi.mulOneClass
+
+@[to_additive]
+instance monoid [∀ i, Monoid <| f i] : Monoid (∀ i : I, f i) := by
+  refine_struct
+      { one := (1 : ∀ i, f i)
+        mul := (· * ·)
+        npow := fun n x i => x i ^ n } <;>
+    pi_instance_derive_field
+#align pi.monoid Pi.monoid
+
+@[to_additive]
+instance commMonoid [∀ i, CommMonoid <| f i] : CommMonoid (∀ i : I, f i) := by
+  refine_struct
+      { one := (1 : ∀ i, f i)
+        mul := (· * ·)
+        npow := Monoid.npow } <;>
+    pi_instance_derive_field
+#align pi.comm_monoid Pi.commMonoid
+
+@[to_additive Pi.subNegMonoid]
+instance [∀ i, DivInvMonoid <| f i] : DivInvMonoid (∀ i : I, f i) := by
+  refine_struct
+      { one := (1 : ∀ i, f i)
+        mul := (· * ·)
+        inv := Inv.inv
+        div := Div.div
+        npow := Monoid.npow
+        zpow := fun z x i => x i ^ z } <;>
+    pi_instance_derive_field
+
+@[to_additive]
+instance [∀ i, InvolutiveInv <| f i] : InvolutiveInv (∀ i, f i) := by
+  refine_struct { inv := Inv.inv } <;> pi_instance_derive_field
+
+@[to_additive Pi.subtractionMonoid]
+instance [∀ i, DivisionMonoid <| f i] : DivisionMonoid (∀ i, f i) := by
+  refine_struct
+      { one := (1 : ∀ i, f i)
+        mul := (· * ·)
+        inv := Inv.inv
+        div := Div.div
+        npow := Monoid.npow
+        zpow := fun z x i => x i ^ z } <;>
+    pi_instance_derive_field
+
+@[to_additive Pi.subtractionCommMonoid]
+instance [∀ i, DivisionCommMonoid <| f i] : DivisionCommMonoid (∀ i, f i) :=
+  { Pi.divisionMonoid, Pi.commSemigroup with }
+
+@[to_additive]
+instance group [∀ i, Group <| f i] : Group (∀ i : I, f i) := by
+  refine_struct
+      { one := (1 : ∀ i, f i)
+        mul := (· * ·)
+        inv := Inv.inv
+        div := Div.div
+        npow := Monoid.npow
+        zpow := DivInvMonoid.zpow } <;>
+    pi_instance_derive_field
+#align pi.group Pi.group
+
+@[to_additive]
+instance commGroup [∀ i, CommGroup <| f i] : CommGroup (∀ i : I, f i) := by
+  refine_struct
+      { one := (1 : ∀ i, f i)
+        mul := (· * ·)
+        inv := Inv.inv
+        div := Div.div
+        npow := Monoid.npow
+        zpow := DivInvMonoid.zpow } <;>
+    pi_instance_derive_field
+#align pi.comm_group Pi.commGroup
+
+@[to_additive AddLeftCancelSemigroup]
+instance leftCancelSemigroup [∀ i, LeftCancelSemigroup <| f i] :
+    LeftCancelSemigroup (∀ i : I, f i) := by
+  refine_struct { mul := (· * ·) } <;> pi_instance_derive_field
+#align pi.left_cancel_semigroup Pi.leftCancelSemigroup
+
+@[to_additive AddRightCancelSemigroup]
+instance rightCancelSemigroup [∀ i, RightCancelSemigroup <| f i] :
+    RightCancelSemigroup (∀ i : I, f i) := by
+  refine_struct { mul := (· * ·) } <;> pi_instance_derive_field
+#align pi.right_cancel_semigroup Pi.rightCancelSemigroup
+
+@[to_additive AddLeftCancelMonoid]
+instance leftCancelMonoid [∀ i, LeftCancelMonoid <| f i] : LeftCancelMonoid (∀ i : I, f i) := by
+  refine_struct
+      { one := (1 : ∀ i, f i)
+        mul := (· * ·)
+        npow := Monoid.npow } <;>
+    pi_instance_derive_field
+#align pi.left_cancel_monoid Pi.leftCancelMonoid
+
+@[to_additive AddRightCancelMonoid]
+instance rightCancelMonoid [∀ i, RightCancelMonoid <| f i] : RightCancelMonoid (∀ i : I, f i) := by
+  refine_struct
+      { one := (1 : ∀ i, f i)
+        mul := (· * ·)
+        npow := Monoid.npow.. } <;>
+    pi_instance_derive_field
+#align pi.right_cancel_monoid Pi.rightCancelMonoid
+
+@[to_additive AddCancelMonoid]
+instance cancelMonoid [∀ i, CancelMonoid <| f i] : CancelMonoid (∀ i : I, f i) := by
+  refine_struct
+      { one := (1 : ∀ i, f i)
+        mul := (· * ·)
+        npow := Monoid.npow } <;>
+    pi_instance_derive_field
+#align pi.cancel_monoid Pi.cancelMonoid
+
+@[to_additive AddCancelCommMonoid]
+instance cancelCommMonoid [∀ i, CancelCommMonoid <| f i] : CancelCommMonoid (∀ i : I, f i) := by
+  refine_struct
+      { one := (1 : ∀ i, f i)
+        mul := (· * ·)
+        npow := Monoid.npow } <;>
+    pi_instance_derive_field
+#align pi.cancel_comm_monoid Pi.cancelCommMonoid
+
+instance mulZeroClass [∀ i, MulZeroClass <| f i] : MulZeroClass (∀ i : I, f i) := by
+  refine_struct
+      { zero := (0 : ∀ i, f i)
+        mul := (· * ·).. } <;>
+    pi_instance_derive_field
+#align pi.mul_zero_class Pi.mulZeroClass
+
+instance mulZeroOneClass [∀ i, MulZeroOneClass <| f i] : MulZeroOneClass (∀ i : I, f i) := by
+  refine_struct
+      { zero := (0 : ∀ i, f i)
+        one := (1 : ∀ i, f i)
+        mul := (· * ·).. } <;>
+    pi_instance_derive_field
+#align pi.mul_zero_one_class Pi.mulZeroOneClass
+
+instance monoidWithZero [∀ i, MonoidWithZero <| f i] : MonoidWithZero (∀ i : I, f i) := by
+  refine_struct
+      { zero := (0 : ∀ i, f i)
+        one := (1 : ∀ i, f i)
+        mul := (· * ·)
+        npow := Monoid.npow } <;>
+    pi_instance_derive_field
+#align pi.monoid_with_zero Pi.monoidWithZero
+
+instance commMonoidWithZero [∀ i, CommMonoidWithZero <| f i] : CommMonoidWithZero (∀ i : I, f i) :=
+  by
+  refine_struct
+      { zero := (0 : ∀ i, f i)
+        one := (1 : ∀ i, f i)
+        mul := (· * ·)
+        npow := Monoid.npow } <;>
+    pi_instance_derive_field
+#align pi.comm_monoid_with_zero Pi.commMonoidWithZero
+
+end Pi
+
+namespace MulHom
+
+@[to_additive]
+theorem coe_mul {M N} {mM : Mul M} {mN : CommSemigroup N} (f g : M →ₙ* N) :
+    (f * g : M → N) = fun x => f x * g x :=
+  rfl
+#align mul_hom.coe_mul MulHom.coe_mul
+
+end MulHom
+
+section MulHom
+
+/-- A family of mul_hom `f a : γ →ₙ* β a` defines a mul_hom `pi.mul_hom f : γ →ₙ* Π a, β a`
+given by `pi.mul_hom f x b = f b x`. -/
+@[to_additive
+      "A family of add_hom `f a : γ → β a` defines a add_hom `pi.add_hom\nf : γ → Π a, β a` given by `pi.add_hom f x b = f b x`.",
+  simps]
+def Pi.mulHom {γ : Type w} [∀ i, Mul (f i)] [Mul γ] (g : ∀ i, γ →ₙ* f i) :
+    γ →ₙ* ∀ i, f i where 
+  toFun x i := g i x
+  map_mul' x y := funext fun i => (g i).map_mul x y
+#align pi.mul_hom Pi.mulHom
+
+@[to_additive]
+theorem Pi.mul_hom_injective {γ : Type w} [Nonempty I] [∀ i, Mul (f i)] [Mul γ] (g : ∀ i, γ →ₙ* f i)
+    (hg : ∀ i, Function.Injective (g i)) : Function.Injective (Pi.mulHom g) := fun x y h =>
+  let ⟨i⟩ := ‹Nonempty I›
+  hg i ((Function.funext_iff.mp h : _) i)
+#align pi.mul_hom_injective Pi.mul_hom_injective
+
+/-- A family of monoid homomorphisms `f a : γ →* β a` defines a monoid homomorphism
+`pi.monoid_mul_hom f : γ →* Π a, β a` given by `pi.monoid_mul_hom f x b = f b x`. -/
+@[to_additive
+      "A family of additive monoid homomorphisms `f a : γ →+ β a` defines a monoid\nhomomorphism `pi.add_monoid_hom f : γ →+ Π a, β a` given by `pi.add_monoid_hom f x b\n= f b x`.",
+  simps]
+def Pi.monoidHom {γ : Type w} [∀ i, MulOneClass (f i)] [MulOneClass γ] (g : ∀ i, γ →* f i) :
+    γ →* ∀ i, f i :=
+  { Pi.mulHom fun i => (g i).toMulHom with
+    toFun := fun x i => g i x
+    map_one' := funext fun i => (g i).map_one }
+#align pi.monoid_hom Pi.monoidHom
+
+@[to_additive]
+theorem Pi.monoid_hom_injective {γ : Type w} [Nonempty I] [∀ i, MulOneClass (f i)] [MulOneClass γ]
+    (g : ∀ i, γ →* f i) (hg : ∀ i, Function.Injective (g i)) :
+    Function.Injective (Pi.monoidHom g) :=
+  Pi.mul_hom_injective (fun i => (g i).toMulHom) hg
+#align pi.monoid_hom_injective Pi.monoid_hom_injective
+
+variable (f) [∀ i, Mul (f i)]
+
+/-- Evaluation of functions into an indexed collection of semigroups at a point is a semigroup
+homomorphism.
+This is `function.eval i` as a `mul_hom`. -/
+@[to_additive
+      "Evaluation of functions into an indexed collection of additive semigroups at a\npoint is an additive semigroup homomorphism.\nThis is `function.eval i` as an `add_hom`.",
+  simps]
+def Pi.evalMulHom (i : I) : (∀ i, f i) →ₙ*
+      f i where 
+  toFun g := g i
+  map_mul' x y := Pi.mul_apply _ _ i
+#align pi.eval_mul_hom Pi.evalMulHom
+
+/-- `function.const` as a `mul_hom`. -/
+@[to_additive "`function.const` as an `add_hom`.", simps]
+def Pi.constMulHom (α β : Type _) [Mul β] :
+    β →ₙ* α → β where 
+  toFun := Function.const α
+  map_mul' _ _ := rfl
+#align pi.const_mul_hom Pi.constMulHom
+
+/-- Coercion of a `mul_hom` into a function is itself a `mul_hom`.
+See also `mul_hom.eval`. -/
+@[to_additive
+      "Coercion of an `add_hom` into a function is itself a `add_hom`.\nSee also `add_hom.eval`. ",
+  simps]
+def MulHom.coeFn (α β : Type _) [Mul α] [CommSemigroup β] :
+    (α →ₙ* β) →ₙ* α → β where 
+  toFun g := g
+  map_mul' x y := rfl
+#align mul_hom.coe_fn MulHom.coeFn
+
+/-- Semigroup homomorphism between the function spaces `I → α` and `I → β`, induced by a semigroup
+homomorphism `f` between `α` and `β`. -/
+@[to_additive
+      "Additive semigroup homomorphism between the function spaces `I → α` and `I → β`,\ninduced by an additive semigroup homomorphism `f` between `α` and `β`",
+  simps]
+protected def MulHom.compLeft {α β : Type _} [Mul α] [Mul β] (f : α →ₙ* β) (I : Type _) :
+    (I → α) →ₙ* I → β where 
+  toFun h := f ∘ h
+  map_mul' _ _ := by ext <;> simp
+#align mul_hom.comp_left MulHom.compLeft
+
+end MulHom
+
+section MonoidHom
+
+variable (f) [∀ i, MulOneClass (f i)]
+
+/-- Evaluation of functions into an indexed collection of monoids at a point is a monoid
+homomorphism.
+This is `function.eval i` as a `monoid_hom`. -/
+@[to_additive
+      "Evaluation of functions into an indexed collection of additive monoids at a\npoint is an additive monoid homomorphism.\nThis is `function.eval i` as an `add_monoid_hom`.",
+  simps]
+def Pi.evalMonoidHom (i : I) :
+    (∀ i, f i) →* f i where 
+  toFun g := g i
+  map_one' := Pi.one_apply i
+  map_mul' x y := Pi.mul_apply _ _ i
+#align pi.eval_monoid_hom Pi.evalMonoidHom
+
+/-- `function.const` as a `monoid_hom`. -/
+@[to_additive "`function.const` as an `add_monoid_hom`.", simps]
+def Pi.constMonoidHom (α β : Type _) [MulOneClass β] :
+    β →* α → β where 
+  toFun := Function.const α
+  map_one' := rfl
+  map_mul' _ _ := rfl
+#align pi.const_monoid_hom Pi.constMonoidHom
+
+/-- Coercion of a `monoid_hom` into a function is itself a `monoid_hom`.
+
+See also `monoid_hom.eval`. -/
+@[to_additive
+      "Coercion of an `add_monoid_hom` into a function is itself a `add_monoid_hom`.\n\nSee also `add_monoid_hom.eval`. ",
+  simps]
+def MonoidHom.coeFn (α β : Type _) [MulOneClass α] [CommMonoid β] :
+    (α →* β) →* α → β where 
+  toFun g := g
+  map_one' := rfl
+  map_mul' x y := rfl
+#align monoid_hom.coe_fn MonoidHom.coeFn
+
+/-- Monoid homomorphism between the function spaces `I → α` and `I → β`, induced by a monoid
+homomorphism `f` between `α` and `β`. -/
+@[to_additive
+      "Additive monoid homomorphism between the function spaces `I → α` and `I → β`,\ninduced by an additive monoid homomorphism `f` between `α` and `β`",
+  simps]
+protected def MonoidHom.compLeft {α β : Type _} [MulOneClass α] [MulOneClass β] (f : α →* β)
+    (I : Type _) : (I → α) →* I → β where 
+  toFun h := f ∘ h
+  map_one' := by ext <;> simp
+  map_mul' _ _ := by ext <;> simp
+#align monoid_hom.comp_left MonoidHom.compLeft
+
+end MonoidHom
+
+section Single
+
+variable [DecidableEq I]
+
+open Pi
+
+variable (f)
+
+/-- The one-preserving homomorphism including a single value
+into a dependent family of values, as functions supported at a point.
+
+This is the `one_hom` version of `pi.mul_single`. -/
+@[to_additive ZeroHom.single
+      "The zero-preserving homomorphism including a single value\ninto a dependent family of values, as functions supported at a point.\n\nThis is the `zero_hom` version of `pi.single`."]
+def OneHom.single [∀ i, One <| f i] (i : I) :
+    OneHom (f i) (∀ i, f i) where 
+  toFun := mulSingle i
+  map_one' := mulSingle_one i
+#align one_hom.single OneHom.single
+
+@[simp, to_additive]
+theorem OneHom.single_apply [∀ i, One <| f i] (i : I) (x : f i) :
+    OneHom.single f i x = mulSingle i x :=
+  rfl
+#align one_hom.single_apply OneHom.single_apply
+
+/-- The monoid homomorphism including a single monoid into a dependent family of additive monoids,
+as functions supported at a point.
+
+This is the `monoid_hom` version of `pi.mul_single`. -/
+@[to_additive
+      "The additive monoid homomorphism including a single additive\nmonoid into a dependent family of additive monoids, as functions supported at a point.\n\nThis is the `add_monoid_hom` version of `pi.single`."]
+def MonoidHom.single [∀ i, MulOneClass <| f i] (i : I) : f i →* ∀ i, f i :=
+  { OneHom.single f i with map_mul' := mulSingle_op₂ (fun _ => (· * ·)) (fun _ => one_mul _) _ }
+#align monoid_hom.single MonoidHom.single
+
+@[simp, to_additive]
+theorem MonoidHom.single_apply [∀ i, MulOneClass <| f i] (i : I) (x : f i) :
+    MonoidHom.single f i x = mulSingle i x :=
+  rfl
+#align monoid_hom.single_apply MonoidHom.single_apply
+
+/-- The multiplicative homomorphism including a single `mul_zero_class`
+into a dependent family of `mul_zero_class`es, as functions supported at a point.
+
+This is the `mul_hom` version of `pi.single`. -/
+@[simps]
+def MulHom.single [∀ i, MulZeroClass <| f i] (i : I) :
+    f i →ₙ* ∀ i, f i where 
+  toFun := single i
+  map_mul' := Pi.single_op₂ (fun _ => (· * ·)) (fun _ => zero_mul _) _
+#align mul_hom.single MulHom.single
+
+variable {f}
+
+@[to_additive]
+theorem Pi.mul_single_mul [∀ i, MulOneClass <| f i] (i : I) (x y : f i) :
+    mulSingle i (x * y) = mulSingle i x * mulSingle i y :=
+  (MonoidHom.single f i).map_mul x y
+#align pi.mul_single_mul Pi.mul_single_mul
+
+@[to_additive]
+theorem Pi.mul_single_inv [∀ i, Group <| f i] (i : I) (x : f i) :
+    mulSingle i x⁻¹ = (mulSingle i x)⁻¹ :=
+  (MonoidHom.single f i).map_inv x
+#align pi.mul_single_inv Pi.mul_single_inv
+
+@[to_additive]
+theorem Pi.single_div [∀ i, Group <| f i] (i : I) (x y : f i) :
+    mulSingle i (x / y) = mulSingle i x / mulSingle i y :=
+  (MonoidHom.single f i).map_div x y
+#align pi.single_div Pi.single_div
+
+theorem Pi.single_mul [∀ i, MulZeroClass <| f i] (i : I) (x y : f i) :
+    single i (x * y) = single i x * single i y :=
+  (MulHom.single f i).map_mul x y
+#align pi.single_mul Pi.single_mul
+
+/-- The injection into a pi group at different indices commutes.
+
+For injections of commuting elements at the same index, see `commute.map` -/
+@[to_additive
+      "The injection into an additive pi group at different indices commutes.\n\nFor injections of commuting elements at the same index, see `add_commute.map`"]
+theorem Pi.mul_single_commute [∀ i, MulOneClass <| f i] :
+    Pairwise fun i j => ∀ (x : f i) (y : f j), Commute (mulSingle i x) (mulSingle j y) := by
+  intro i j hij x y; ext k
+  by_cases h1 : i = k;
+  · subst h1
+    simp [hij]
+  by_cases h2 : j = k;
+  · subst h2
+    simp [hij]
+  simp [h1, h2]
+#align pi.mul_single_commute Pi.mul_single_commute
+
+/-- The injection into a pi group with the same values commutes. -/
+@[to_additive "The injection into an additive pi group with the same values commutes."]
+theorem Pi.mul_single_apply_commute [∀ i, MulOneClass <| f i] (x : ∀ i, f i) (i j : I) :
+    Commute (mulSingle i (x i)) (mulSingle j (x j)) := by
+  obtain rfl | hij := Decidable.eq_or_ne i j
+  · rfl
+  · exact Pi.mul_single_commute hij _ _
+#align pi.mul_single_apply_commute Pi.mul_single_apply_commute
+
+@[to_additive update_eq_sub_add_single]
+theorem Pi.update_eq_div_mul_single [∀ i, Group <| f i] (g : ∀ i : I, f i) (x : f i) :
+    Function.update g i x = g / mulSingle i (g i) * mulSingle i x := by
+  ext j
+  rcases eq_or_ne i j with (rfl | h)
+  · simp
+  · simp [Function.update_noteq h.symm, h]
+#align pi.update_eq_div_mul_single Pi.update_eq_div_mul_single
+
+@[to_additive Pi.single_add_single_eq_single_add_single]
+theorem Pi.mul_single_mul_mul_single_eq_mul_single_mul_mul_single {M : Type _} [CommMonoid M]
+    {k l m n : I} {u v : M} (hu : u ≠ 1) (hv : v ≠ 1) :
+    mulSingle k u * mulSingle l v = mulSingle m u * mulSingle n v ↔
+      k = m ∧ l = n ∨ u = v ∧ k = n ∧ l = m ∨ u * v = 1 ∧ k = l ∧ m = n :=
+  by 
+  refine' ⟨fun h => _, _⟩
+  · have hk := congr_fun h k
+    have hl := congr_fun h l
+    have hm := (congr_fun h m).symm
+    have hn := (congr_fun h n).symm
+    simp only [mul_apply, mul_single_apply, if_pos rfl] at hk hl hm hn
+    rcases eq_or_ne k m with (rfl | hkm)
+    · refine' Or.inl ⟨rfl, not_ne_iff.mp fun hln => (hv _).elim⟩
+      rcases eq_or_ne k l with (rfl | hkl)
+      · rwa [if_neg hln.symm, if_neg hln.symm, one_mul, one_mul] at hn
+      · rwa [if_neg hkl.symm, if_neg hln, one_mul, one_mul] at hl
+    · rcases eq_or_ne m n with (rfl | hmn)
+      · rcases eq_or_ne k l with (rfl | hkl)
+        · rw [if_neg hkm.symm, if_neg hkm.symm, one_mul, if_pos rfl] at hm
+          exact Or.inr (Or.inr ⟨hm, rfl, rfl⟩)
+        · simpa only [if_neg hkm, if_neg hkl, mul_one] using hk
+      · rw [if_neg hkm.symm, if_neg hmn, one_mul, mul_one] at hm
+        obtain rfl := (ite_ne_right_iff.mp (ne_of_eq_of_ne hm.symm hu)).1
+        rw [if_neg hkm, if_neg hkm, one_mul, mul_one] at hk
+        obtain rfl := (ite_ne_right_iff.mp (ne_of_eq_of_ne hk.symm hu)).1
+        exact Or.inr (Or.inl ⟨hk.trans (if_pos rfl), rfl, rfl⟩)
+  · rintro (⟨rfl, rfl⟩ | ⟨rfl, rfl, rfl⟩ | ⟨h, rfl, rfl⟩)
+    · rfl
+    · apply mul_comm
+    · simp_rw [← Pi.mul_single_mul, h, mul_single_one]
+#align
+  pi.mul_single_mul_mul_single_eq_mul_single_mul_mul_single Pi.mul_single_mul_mul_single_eq_mul_single_mul_mul_single
+
+end Single
+
+namespace Function
+
+@[simp, to_additive]
+theorem update_one [∀ i, One (f i)] [DecidableEq I] (i : I) : update (1 : ∀ i, f i) i 1 = 1 :=
+  update_eq_self i 1
+#align function.update_one Function.update_one
+
+@[to_additive]
+theorem update_mul [∀ i, Mul (f i)] [DecidableEq I] (f₁ f₂ : ∀ i, f i) (i : I) (x₁ : f i)
+    (x₂ : f i) : update (f₁ * f₂) i (x₁ * x₂) = update f₁ i x₁ * update f₂ i x₂ :=
+  funext fun j => (apply_update₂ (fun i => (· * ·)) f₁ f₂ i x₁ x₂ j).symm
+#align function.update_mul Function.update_mul
+
+@[to_additive]
+theorem update_inv [∀ i, Inv (f i)] [DecidableEq I] (f₁ : ∀ i, f i) (i : I) (x₁ : f i) :
+    update f₁⁻¹ i x₁⁻¹ = (update f₁ i x₁)⁻¹ :=
+  funext fun j => (apply_update (fun i => Inv.inv) f₁ i x₁ j).symm
+#align function.update_inv Function.update_inv
+
+@[to_additive]
+theorem update_div [∀ i, Div (f i)] [DecidableEq I] (f₁ f₂ : ∀ i, f i) (i : I) (x₁ : f i)
+    (x₂ : f i) : update (f₁ / f₂) i (x₁ / x₂) = update f₁ i x₁ / update f₂ i x₂ :=
+  funext fun j => (apply_update₂ (fun i => (· / ·)) f₁ f₂ i x₁ x₂ j).symm
+#align function.update_div Function.update_div
+
+variable [One α] [Nonempty ι] {a : α}
+
+@[simp, to_additive]
+theorem const_eq_one : const ι a = 1 ↔ a = 1 :=
+  @const_inj _ _ _ _ 1
+#align function.const_eq_one Function.const_eq_one
+
+@[to_additive]
+theorem const_ne_one : const ι a ≠ 1 ↔ a ≠ 1 :=
+  const_eq_one.Not
+#align function.const_ne_one Function.const_ne_one
+
+end Function
+
+section Piecewise
+
+@[to_additive]
+theorem Set.piecewise_mul [∀ i, Mul (f i)] (s : Set I) [∀ i, Decidable (i ∈ s)]
+    (f₁ f₂ g₁ g₂ : ∀ i, f i) :
+    s.piecewise (f₁ * f₂) (g₁ * g₂) = s.piecewise f₁ g₁ * s.piecewise f₂ g₂ :=
+  s.piecewise_op₂ _ _ _ _ fun _ => (· * ·)
+#align set.piecewise_mul Set.piecewise_mul
+
+@[to_additive]
+theorem Set.piecewise_inv [∀ i, Inv (f i)] (s : Set I) [∀ i, Decidable (i ∈ s)] (f₁ g₁ : ∀ i, f i) :
+    s.piecewise f₁⁻¹ g₁⁻¹ = (s.piecewise f₁ g₁)⁻¹ :=
+  s.piecewise_op f₁ g₁ fun _ x => x⁻¹
+#align set.piecewise_inv Set.piecewise_inv
+
+@[to_additive]
+theorem Set.piecewise_div [∀ i, Div (f i)] (s : Set I) [∀ i, Decidable (i ∈ s)]
+    (f₁ f₂ g₁ g₂ : ∀ i, f i) :
+    s.piecewise (f₁ / f₂) (g₁ / g₂) = s.piecewise f₁ g₁ / s.piecewise f₂ g₂ :=
+  s.piecewise_op₂ _ _ _ _ fun _ => (· / ·)
+#align set.piecewise_div Set.piecewise_div
+
+end Piecewise
+
+section Extend
+
+variable {η : Type v} (R : Type w) (s : ι → η)
+
+/-- `function.extend s f 1` as a bundled hom. -/
+@[to_additive Function.ExtendByZero.hom "`function.extend s f 0` as a bundled hom.", simps]
+noncomputable def Function.ExtendByOne.hom [MulOneClass R] :
+    (ι → R) →* η → R where 
+  toFun f := Function.extend s f 1
+  map_one' := Function.extend_one s
+  map_mul' f g := by simpa using Function.extend_mul s f g 1 1
+#align function.extend_by_one.hom Function.ExtendByOne.hom
+
+end Extend
+

--- a/Mathlib/Algebra/Group/Pi.lean
+++ b/Mathlib/Algebra/Group/Pi.lean
@@ -96,66 +96,60 @@ instance monoid [∀ i, Monoid <| f i] : Monoid (∀ i : I, f i) :=
 #align pi.monoid Pi.monoid
 
 @[to_additive]
-instance commMonoid [∀ i, CommMonoid <| f i] : CommMonoid (∀ i : I, f i) := by
-  refine_struct
-      { one := (1 : ∀ i, f i)
-        mul := (· * ·)
-        npow := Monoid.npow } <;>
-    pi_instance_derive_field
+instance commMonoid [∀ i, CommMonoid <| f i] : CommMonoid (∀ i : I, f i) :=
+  { monoid, commSemigroup with }
 #align pi.comm_monoid Pi.commMonoid
 
 @[to_additive Pi.subNegMonoid]
-instance [∀ i, DivInvMonoid <| f i] : DivInvMonoid (∀ i : I, f i) := by
-  refine_struct
-      { one := (1 : ∀ i, f i)
-        mul := (· * ·)
-        inv := Inv.inv
-        div := Div.div
-        npow := Monoid.npow
-        zpow := fun z x i => x i ^ z } <;>
-    pi_instance_derive_field
+instance divInvMonoid [∀ i, DivInvMonoid <| f i] : DivInvMonoid (∀ i : I, f i) :=
+  { monoid with
+    inv := Inv.inv
+    div := Div.div
+    zpow := fun z x i => x i ^ z
+    --pi_instance
+    div_eq_mul_inv := by rename_i inst _; intros; ext i; exact (inst i).div_eq_mul_inv _ _
+    zpow_zero' := by rename_i inst _; intros; ext i; exact (inst i).zpow_zero' _
+    zpow_succ' := by rename_i inst _; intros; ext i; exact (inst i).zpow_succ' _ _
+    zpow_neg' := by rename_i inst _; intros; ext i; exact (inst i).zpow_neg' _ _
+  }
 
 @[to_additive]
-instance [∀ i, InvolutiveInv <| f i] : InvolutiveInv (∀ i, f i) := by
-  refine_struct { inv := Inv.inv } <;> pi_instance_derive_field
+instance involutiveInv [∀ i, InvolutiveInv <| f i] : InvolutiveInv (∀ i, f i) :=
+  { inv := Inv.inv
+    --pi_instance
+    inv_inv := by rename_i inst; intros; ext i; exact (inst i).inv_inv _
+  }
 
 @[to_additive Pi.subtractionMonoid]
-instance [∀ i, DivisionMonoid <| f i] : DivisionMonoid (∀ i, f i) := by
-  refine_struct
-      { one := (1 : ∀ i, f i)
-        mul := (· * ·)
-        inv := Inv.inv
-        div := Div.div
-        npow := Monoid.npow
-        zpow := fun z x i => x i ^ z } <;>
-    pi_instance_derive_field
+instance divisionMonoid [∀ i, DivisionMonoid <| f i] : DivisionMonoid (∀ i, f i) :=
+  { divInvMonoid, involutiveInv with
+    --pi_instance
+    mul_inv_rev := by rename_i inst _ _; intros; ext i; exact (inst i).mul_inv_rev _ _
+    inv_eq_of_mul := by
+      rename_i inst _ _; intros; ext i; apply (inst i).inv_eq_of_mul _ _ _;
+      rename_i ab1; exact congr_fun ab1 i
+  }
 
 @[to_additive Pi.subtractionCommMonoid]
 instance [∀ i, DivisionCommMonoid <| f i] : DivisionCommMonoid (∀ i, f i) :=
-  { Pi.divisionMonoid, Pi.commSemigroup with }
+  { divisionMonoid, commSemigroup with }
 
 @[to_additive]
-instance group [∀ i, Group <| f i] : Group (∀ i : I, f i) := by
-  refine_struct
-      { one := (1 : ∀ i, f i)
-        mul := (· * ·)
-        inv := Inv.inv
-        div := Div.div
-        npow := Monoid.npow
-        zpow := DivInvMonoid.zpow } <;>
-    pi_instance_derive_field
+instance group [∀ i, Group <| f i] : Group (∀ i : I, f i) :=
+{ divInvMonoid with
+  --pi_instance
+  mul_left_inv := by rename_i inst _; intros; ext i; exact (inst i).mul_left_inv _
+  }
 #align pi.group Pi.group
 
 @[to_additive]
-instance commGroup [∀ i, CommGroup <| f i] : CommGroup (∀ i : I, f i) := by
-  refine_struct
-      { one := (1 : ∀ i, f i)
-        mul := (· * ·)
-        inv := Inv.inv
-        div := Div.div
-        npow := Monoid.npow
-        zpow := DivInvMonoid.zpow } <;>
-    pi_instance_derive_field
+instance commGroup [∀ i, CommGroup <| f i] : CommGroup (∀ i : I, f i) :=
+{ one := (1 : ∀ i, f i)
+  mul := (· * ·)
+  inv := Inv.inv
+  div := Div.div
+  npow := Monoid.npow
+  zpow := DivInvMonoid.zpow }
 #align pi.comm_group Pi.commGroup
 
 @[to_additive AddLeftCancelSemigroup]

--- a/Mathlib/Algebra/Group/Pi.lean
+++ b/Mathlib/Algebra/Group/Pi.lean
@@ -49,6 +49,7 @@ theorem Set.preimage_one {α β : Type _} [One β] (s : Set β) [Decidable ((1 :
     (1 : α → β) ⁻¹' s = if (1 : β) ∈ s then Set.univ else ∅ :=
   Set.preimage_const 1 s
 #align set.preimage_one Set.preimage_one
+#align set.preimage_zero Set.preimage_zero
 
 namespace Pi
 
@@ -58,6 +59,7 @@ instance semigroup [∀ i, Semigroup <| f i] : Semigroup (∀ i : I, f i) :=
     --pi_instance
     mul_assoc := by rename_i inst; intros; ext i; exact (inst i).mul_assoc _ _ _ }
 #align pi.semigroup Pi.semigroup
+#align pi.add_semigroup Pi.addSemigroup
 
 instance semigroupWithZero [∀ i, SemigroupWithZero <| f i] : SemigroupWithZero (∀ i : I, f i) :=
   { semigroup with
@@ -74,6 +76,7 @@ instance commSemigroup [∀ i, CommSemigroup <| f i] : CommSemigroup (∀ i : I,
     mul_comm := by rename_i inst _; intros; ext i; exact (inst i).mul_comm _ _
   }
 #align pi.comm_semigroup Pi.commSemigroup
+#align pi.add_comm_semigroup Pi.addCommSemigroup
 
 @[to_additive]
 instance mulOneClass [∀ i, MulOneClass <| f i] : MulOneClass (∀ i : I, f i) :=
@@ -84,6 +87,7 @@ instance mulOneClass [∀ i, MulOneClass <| f i] : MulOneClass (∀ i : I, f i) 
     mul_one := by rename_i inst; intros; ext i; exact (inst i).mul_one _
   }
 #align pi.mul_one_class Pi.mulOneClass
+#align pi.add_zero_class Pi.addZeroClass
 
 @[to_additive]
 instance monoid [∀ i, Monoid <| f i] : Monoid (∀ i : I, f i) :=
@@ -94,11 +98,13 @@ instance monoid [∀ i, Monoid <| f i] : Monoid (∀ i : I, f i) :=
     npow_succ := by rename_i inst _ _; intros; ext i; exact (inst i).npow_succ _ _
   }
 #align pi.monoid Pi.monoid
+#align pi.add_monoid Pi.addMonoid
 
 @[to_additive]
 instance commMonoid [∀ i, CommMonoid <| f i] : CommMonoid (∀ i : I, f i) :=
   { monoid, commSemigroup with }
 #align pi.comm_monoid Pi.commMonoid
+#align pi.add_comm_monoid Pi.addCommMonoid
 
 @[to_additive Pi.subNegMonoid]
 instance divInvMonoid [∀ i, DivInvMonoid <| f i] : DivInvMonoid (∀ i : I, f i) :=
@@ -141,11 +147,13 @@ instance group [∀ i, Group <| f i] : Group (∀ i : I, f i) :=
     mul_left_inv := by rename_i inst _; intros; ext i; exact (inst i).mul_left_inv _
     }
 #align pi.group Pi.group
+#align pi.add_group Pi.addGroup
 
 @[to_additive]
 instance commGroup [∀ i, CommGroup <| f i] : CommGroup (∀ i : I, f i) :=
   { group, commMonoid with }
 #align pi.comm_group Pi.commGroup
+#align pi.add_comm_group Pi.addCommGroup
 
 @[to_additive]
 instance leftCancelSemigroup [∀ i, LeftCancelSemigroup <| f i] :
@@ -157,6 +165,7 @@ instance leftCancelSemigroup [∀ i, LeftCancelSemigroup <| f i] :
       rename_i h; exact congr_fun h i
   }
 #align pi.left_cancel_semigroup Pi.leftCancelSemigroup
+#align pi.add_left_cancel_semigroup Pi.addLeftCancelSemigroup
 
 @[to_additive]
 instance rightCancelSemigroup [∀ i, RightCancelSemigroup <| f i] :
@@ -168,26 +177,31 @@ instance rightCancelSemigroup [∀ i, RightCancelSemigroup <| f i] :
       rename_i h; exact congr_fun h i
   }
 #align pi.right_cancel_semigroup Pi.rightCancelSemigroup
+#align pi.add_right_cancel_semigroup Pi.addRightCancelSemigroup
 
 @[to_additive]
 instance leftCancelMonoid [∀ i, LeftCancelMonoid <| f i] : LeftCancelMonoid (∀ i : I, f i) :=
   { leftCancelSemigroup, monoid with }
 #align pi.left_cancel_monoid Pi.leftCancelMonoid
+#align pi.add_left_cancel_monoid Pi.addLeftCancelMonoid
 
 @[to_additive]
 instance rightCancelMonoid [∀ i, RightCancelMonoid <| f i] : RightCancelMonoid (∀ i : I, f i) :=
   { rightCancelSemigroup, monoid with }
 #align pi.right_cancel_monoid Pi.rightCancelMonoid
+#align pi.add_right_cancel_monoid Pi.addRightCancelMonoid
 
 @[to_additive]
 instance cancelMonoid [∀ i, CancelMonoid <| f i] : CancelMonoid (∀ i : I, f i) :=
   { leftCancelMonoid, rightCancelMonoid with }
 #align pi.cancel_monoid Pi.cancelMonoid
+#align pi.add_cancel_monoid Pi.addCancelMonoid
 
 @[to_additive]
 instance cancelCommMonoid [∀ i, CancelCommMonoid <| f i] : CancelCommMonoid (∀ i : I, f i) :=
   { leftCancelMonoid, commMonoid with }
 #align pi.cancel_comm_monoid Pi.cancelCommMonoid
+#align pi.add_cancel_comm_monoid Pi.addCancelCommMonoid
 
 instance mulZeroClass [∀ i, MulZeroClass <| f i] : MulZeroClass (∀ i : I, f i) :=
   { zero := (0 : ∀ i, f i)
@@ -224,6 +238,7 @@ namespace MulHom
 theorem coe_mul {M N} {_ : Mul M} {_ : CommSemigroup N} (f g : M →ₙ* N) : (f * g : M → N) =
   fun x => f x * g x := rfl
 #align mul_hom.coe_mul MulHom.coe_mul
+#align add_hom.coe_add AddHom.coe_add
 
 end MulHom
 
@@ -238,6 +253,7 @@ def Pi.mulHom {γ : Type w} [∀ i, Mul (f i)] [Mul γ] (g : ∀ i, γ →ₙ* f
   toFun x i := g i x
   map_mul' x y := funext fun i => (g i).map_mul x y
 #align pi.mul_hom Pi.mulHom
+#align pi.add_hom Pi.addHom
 
 @[to_additive]
 theorem Pi.mulHom_injective {γ : Type w} [Nonempty I] [∀ i, Mul (f i)] [Mul γ] (g : ∀ i, γ →ₙ* f i)
@@ -245,6 +261,7 @@ theorem Pi.mulHom_injective {γ : Type w} [Nonempty I] [∀ i, Mul (f i)] [Mul �
   let ⟨i⟩ := ‹Nonempty I›
   hg i ((Function.funext_iff.mp h : _) i)
 #align pi.mul_hom_injective Pi.mulHom_injective
+#align pi.add_hom_injective Pi.addHom_injective
 
 /-- A family of monoid homomorphisms `f a : γ →* β a` defines a monoid homomorphism
 `Pi.monoidHom f : γ →* Π a, β a` given by `Pi.monoidHom f x b = f b x`. -/
@@ -257,6 +274,7 @@ def Pi.monoidHom {γ : Type w} [∀ i, MulOneClass (f i)] [MulOneClass γ] (g : 
     toFun := fun x i => g i x
     map_one' := funext fun i => (g i).map_one }
 #align pi.monoid_hom Pi.monoidHom
+#align pi.add_monoid_hom Pi.addMonoidHom
 
 @[to_additive]
 theorem Pi.monoidHom_injective {γ : Type w} [Nonempty I] [∀ i, MulOneClass (f i)] [MulOneClass γ]
@@ -264,6 +282,7 @@ theorem Pi.monoidHom_injective {γ : Type w} [Nonempty I] [∀ i, MulOneClass (f
     Function.Injective (Pi.monoidHom g) :=
   Pi.mulHom_injective (fun i => (g i).toMulHom) hg
 #align pi.monoid_hom_injective Pi.monoidHom_injective
+#align pi.add_monoid_hom_injective Pi.addMonoidHom_injective
 
 variable (f) [(i : I) → Mul (f i)]
 
@@ -277,14 +296,16 @@ def Pi.evalMulHom (i : I) : (∀ i, f i) →ₙ* f i where
   toFun g := g i
   map_mul' _ _ := Pi.mul_apply _ _ i
 #align pi.eval_mul_hom Pi.evalMulHom
+#align pi.eval_add_hom Pi.evalAddHom
 
-/-- `function.const` as a `MulHom`. -/
-@[to_additive "`function.const` as an `AddHom`.", simps]
+/-- `Function.const` as a `MulHom`. -/
+@[to_additive "`Function.const` as an `AddHom`.", simps]
 def Pi.constMulHom (α β : Type _) [Mul β] :
     β →ₙ* α → β where
   toFun := Function.const α
   map_mul' _ _ := rfl
 #align pi.const_mul_hom Pi.constMulHom
+#align pi.const_add_hom Pi.constAddHom
 
 /-- Coercion of a `MulHom` into a function is itself a `MulHom`.
 See also `MulHom.eval`. -/
@@ -296,6 +317,7 @@ def MulHom.coeFn (α β : Type _) [Mul α] [CommSemigroup β] :
   toFun g := g
   map_mul' _ _ := rfl
 #align mul_hom.coe_fn MulHom.coeFn
+#align add_hom.coe_fn AddHom.coeFn
 
 /-- Semigroup homomorphism between the function spaces `I → α` and `I → β`, induced by a semigroup
 homomorphism `f` between `α` and `β`. -/
@@ -307,6 +329,7 @@ protected def MulHom.compLeft {α β : Type _} [Mul α] [Mul β] (f : α →ₙ*
   toFun h := f ∘ h
   map_mul' _ _ := by ext; simp
 #align mul_hom.comp_left MulHom.compLeft
+#align add_hom.comp_left AddHom.compLeft
 
 end MulHom
 
@@ -326,6 +349,7 @@ def Pi.evalMonoidHom (i : I) :
   map_one' := Pi.one_apply i
   map_mul' _ _ := Pi.mul_apply _ _ i
 #align pi.eval_monoid_hom Pi.evalMonoidHom
+#align pi.eval_add_monoid_hom Pi.evalAddMonoidHom
 
 /-- `Function.const` as a `MonoidHom`. -/
 @[to_additive "`Function.const` as an `AddMonoidHom`.", simps]
@@ -335,6 +359,7 @@ def Pi.constMonoidHom (α β : Type _) [MulOneClass β] :
   map_one' := rfl
   map_mul' _ _ := rfl
 #align pi.const_monoid_hom Pi.constMonoidHom
+#align pi.const_add_monoid_hom Pi.constAddMonoidHom
 
 /-- Coercion of a `MonoidHom` into a function is itself a `MonoidHom`.
 
@@ -348,6 +373,7 @@ def MonoidHom.coeFn (α β : Type _) [MulOneClass α] [CommMonoid β] :
   map_one' := rfl
   map_mul' _ _ := rfl
 #align monoid_hom.coe_fn MonoidHom.coeFn
+#align add_monoid_hom.coe_fn AddMonoidHom.coeFn
 
 /-- Monoid homomorphism between the function spaces `I → α` and `I → β`, induced by a monoid
 homomorphism `f` between `α` and `β`. -/
@@ -360,6 +386,7 @@ protected def MonoidHom.compLeft {α β : Type _} [MulOneClass α] [MulOneClass 
   map_one' := by ext; dsimp; simp
   map_mul' _ _ := by ext; simp
 #align monoid_hom.comp_left MonoidHom.compLeft
+#align add_monoid_hom.comp_left AddMonoidHom.compLeft
 
 end MonoidHom
 
@@ -382,12 +409,14 @@ def OneHom.single [∀ i, One <| f i] (i : I) :
   toFun := mulSingle i
   map_one' := mulSingle_one i
 #align one_hom.single OneHom.single
+#align zero_hom.single ZeroHom.single
 
 @[simp, to_additive]
 theorem OneHom.single_apply [∀ i, One <| f i] (i : I) (x : f i) :
     OneHom.single f i x = mulSingle i x :=
   rfl
 #align one_hom.single_apply OneHom.single_apply
+#align zero_hom.single_apply ZeroHom.single_apply
 
 /-- The monoid homomorphism including a single monoid into a dependent family of additive monoids,
 as functions supported at a point.
@@ -398,12 +427,14 @@ This is the `MonoidHom` version of `Pi.mulSingle`. -/
 def MonoidHom.single [∀ i, MulOneClass <| f i] (i : I) : f i →* ∀ i, f i :=
   { OneHom.single f i with map_mul' := mulSingle_op₂ (fun _ => (· * ·)) (fun _ => one_mul _) _ }
 #align monoid_hom.single MonoidHom.single
+#align add_monoid_hom.single AddMonoidHom.single
 
 @[simp, to_additive]
 theorem MonoidHom.single_apply [∀ i, MulOneClass <| f i] (i : I) (x : f i) :
     MonoidHom.single f i x = mulSingle i x :=
   rfl
 #align monoid_hom.single_apply MonoidHom.single_apply
+#align add_monoid_hom.single_apply AddMonoidHom.single_apply
 
 /-- The multiplicative homomorphism including a single `MulZeroClass`
 into a dependent family of `MulZeroClass`es, as functions supported at a point.
@@ -423,18 +454,21 @@ theorem Pi.mulSingle_mul [∀ i, MulOneClass <| f i] (i : I) (x y : f i) :
     mulSingle i (x * y) = mulSingle i x * mulSingle i y :=
   (MonoidHom.single f i).map_mul x y
 #align pi.mul_single_mul Pi.mulSingle_mul
+#align pi.single_add Pi.single_add
 
 @[to_additive]
 theorem Pi.mulSingle_inv [∀ i, Group <| f i] (i : I) (x : f i) :
     mulSingle i x⁻¹ = (mulSingle i x)⁻¹ :=
   (MonoidHom.single f i).map_inv x
 #align pi.mul_single_inv Pi.mulSingle_inv
+#align pi.single_neg Pi.single_neg
 
 @[to_additive]
 theorem Pi.single_div [∀ i, Group <| f i] (i : I) (x y : f i) :
     mulSingle i (x / y) = mulSingle i x / mulSingle i y :=
   (MonoidHom.single f i).map_div x y
 #align pi.single_div Pi.single_div
+#align pi.single_sub Pi.single_sub
 
 theorem Pi.single_mul [∀ i, MulZeroClass <| f i] (i : I) (x y : f i) :
     Single i (x * y) = Single i x * Single i y :=
@@ -457,6 +491,7 @@ theorem Pi.mulSingle_commute [∀ i, MulOneClass <| f i] :
     simp [hij]
   simp [h1, h2]
 #align pi.mul_single_commute Pi.mulSingle_commute
+#align pi.single_commute Pi.single_commute
 
 /-- The injection into a pi group with the same values commutes. -/
 @[to_additive "The injection into an additive pi group with the same values commutes."]
@@ -466,15 +501,17 @@ theorem Pi.mulSingle_apply_commute [∀ i, MulOneClass <| f i] (x : ∀ i, f i) 
   · rfl
   · exact Pi.mulSingle_commute hij _ _
 #align pi.mul_single_apply_commute Pi.mulSingle_apply_commute
+#align pi.single_apply_commute Pi.single_apply_commute
 
-@[to_additive update_eq_sub_addSingle]
-theorem Pi.update_eq_div_mulSingle [∀ i, Group <| f i] (g : ∀ i : I, f i) (x : f i) :
+@[to_additive]
+theorem Pi.update_eq_div_mul_mulSingle [∀ i, Group <| f i] (g : ∀ i : I, f i) (x : f i) :
     Function.update g i x = g / mulSingle i (g i) * mulSingle i x := by
   ext j
   rcases eq_or_ne i j with (rfl | h)
   · simp
   · simp [Function.update_noteq h.symm, h]
-#align pi.update_eq_div_mul_single Pi.update_eq_div_mulSingle
+#align pi.update_eq_div_mul_single Pi.update_eq_div_mul_mulSingle
+#align pi.update_eq_sub_add_single Pi.update_eq_div_mul_mulSingle
 
 @[to_additive]
 theorem Pi.mulSingle_mul_mulSingle_eq_mulSingle_mul_mulSingle {M : Type _} [CommMonoid M]
@@ -510,6 +547,7 @@ theorem Pi.mulSingle_mul_mulSingle_eq_mulSingle_mul_mulSingle {M : Type _} [Comm
     · simp_rw [← Pi.mulSingle_mul, h, mulSingle_one]
 #align
   pi.mul_single_mul_mul_single_eq_mul_single_mul_mul_single Pi.mulSingle_mul_mulSingle_eq_mulSingle_mul_mulSingle
+#align pi.single_add_single_eq_single_add_single Pi.single_add_single_eq_single_add_single
 
 end Single
 
@@ -519,24 +557,28 @@ namespace Function
 theorem update_one [∀ i, One (f i)] [DecidableEq I] (i : I) : update (1 : ∀ i, f i) i 1 = 1 :=
   update_eq_self i (1 : (a : I) → f a)
 #align function.update_one Function.update_one
+#align function.update_zero Function.update_zero
 
 @[to_additive]
 theorem update_mul [∀ i, Mul (f i)] [DecidableEq I] (f₁ f₂ : ∀ i, f i) (i : I) (x₁ : f i)
     (x₂ : f i) : update (f₁ * f₂) i (x₁ * x₂) = update f₁ i x₁ * update f₂ i x₂ :=
   funext fun j => (apply_update₂ (fun _ => (· * ·)) f₁ f₂ i x₁ x₂ j).symm
 #align function.update_mul Function.update_mul
+#align function.update_add Function.update_add
 
 @[to_additive]
 theorem update_inv [∀ i, Inv (f i)] [DecidableEq I] (f₁ : ∀ i, f i) (i : I) (x₁ : f i) :
     update f₁⁻¹ i x₁⁻¹ = (update f₁ i x₁)⁻¹ :=
   funext fun j => (apply_update (fun _ => Inv.inv) f₁ i x₁ j).symm
 #align function.update_inv Function.update_inv
+#align function.update_neg Function.update_neg
 
 @[to_additive]
 theorem update_div [∀ i, Div (f i)] [DecidableEq I] (f₁ f₂ : ∀ i, f i) (i : I) (x₁ : f i)
     (x₂ : f i) : update (f₁ / f₂) i (x₁ / x₂) = update f₁ i x₁ / update f₂ i x₂ :=
   funext fun j => (apply_update₂ (fun _ => (· / ·)) f₁ f₂ i x₁ x₂ j).symm
 #align function.update_div Function.update_div
+#align function.update_sub Function.update_sub
 
 variable [One α] [Nonempty ι] {a : α}
 
@@ -544,11 +586,13 @@ variable [One α] [Nonempty ι] {a : α}
 theorem const_eq_one : const ι a = 1 ↔ a = 1 :=
   @const_inj _ _ _ _ 1
 #align function.const_eq_one Function.const_eq_one
+#align function.const_eq_zero Function.const_eq_zero
 
 @[to_additive]
 theorem const_ne_one : const ι a ≠ 1 ↔ a ≠ 1 :=
   Iff.not const_eq_one
 #align function.const_ne_one Function.const_ne_one
+#align function.const_ne_zero Function.const_ne_zero
 
 end Function
 
@@ -560,12 +604,14 @@ theorem Set.piecewise_mul [∀ i, Mul (f i)] (s : Set I) [∀ i, Decidable (i �
     s.piecewise (f₁ * f₂) (g₁ * g₂) = s.piecewise f₁ g₁ * s.piecewise f₂ g₂ :=
   s.piecewise_op₂ _ _ _ _ fun _ => (· * ·)
 #align set.piecewise_mul Set.piecewise_mul
+#align set.piecewise_add Set.piecewise_add
 
 @[to_additive]
 theorem Set.piecewise_inv [∀ i, Inv (f i)] (s : Set I) [∀ i, Decidable (i ∈ s)] (f₁ g₁ : ∀ i, f i) :
     s.piecewise f₁⁻¹ g₁⁻¹ = (s.piecewise f₁ g₁)⁻¹ :=
   s.piecewise_op f₁ g₁ fun _ x => x⁻¹
 #align set.piecewise_inv Set.piecewise_inv
+#align set.piecewise_neg Set.piecewise_neg
 
 @[to_additive]
 theorem Set.piecewise_div [∀ i, Div (f i)] (s : Set I) [∀ i, Decidable (i ∈ s)]
@@ -573,6 +619,7 @@ theorem Set.piecewise_div [∀ i, Div (f i)] (s : Set I) [∀ i, Decidable (i �
     s.piecewise (f₁ / f₂) (g₁ / g₂) = s.piecewise f₁ g₁ / s.piecewise f₂ g₂ :=
   s.piecewise_op₂ _ _ _ _ fun _ => (· / ·)
 #align set.piecewise_div Set.piecewise_div
+#align set.piecewise_sub Set.piecewise_sub
 
 end Piecewise
 
@@ -588,5 +635,6 @@ noncomputable def Function.ExtendByOne.hom [MulOneClass R] :
   map_one' := Function.extend_one s
   map_mul' f g := by simpa using Function.extend_mul s f g 1 1
 #align function.extend_by_one.hom Function.ExtendByOne.hom
+#align function.extend_by_zero.hom Function.ExtendByZero.hom
 
 end Extend

--- a/Mathlib/Algebra/Group/Pi.lean
+++ b/Mathlib/Algebra/Group/Pi.lean
@@ -54,39 +54,45 @@ namespace Pi
 
 @[to_additive]
 instance semigroup [∀ i, Semigroup <| f i] : Semigroup (∀ i : I, f i) :=
-  { mul := (· * ·) --by intros f g i; rename_i inst; exact (inst i).mul (f i) (g i)
-    mul_assoc := by rename_i inst; intros a b c; ext i; dsimp; exact (inst i).mul_assoc _ _ _ }
+  { mul := (· * ·)
+    --pi_instance
+    mul_assoc := by rename_i inst; intros; ext i; exact (inst i).mul_assoc _ _ _ }
 #align pi.semigroup Pi.semigroup
 
 instance semigroupWithZero [∀ i, SemigroupWithZero <| f i] : SemigroupWithZero (∀ i : I, f i) :=
   { semigroup with
     zero := (0 : ∀ i, f i)
     --pi_instance
-    zero_mul := by rename_i inst _; intro; ext i; dsimp; exact (inst i).zero_mul _
-    mul_zero := by rename_i inst _; intro; ext i; dsimp; exact (inst i).mul_zero _
-    }
+    zero_mul := by rename_i inst _; intro; ext i; exact (inst i).zero_mul _
+    mul_zero := by rename_i inst _; intro; ext i; exact (inst i).mul_zero _ }
 #align pi.semigroup_with_zero Pi.semigroupWithZero
 
 @[to_additive]
-instance commSemigroup [∀ i, CommSemigroup <| f i] : CommSemigroup (∀ i : I, f i) := by
-  refine_struct { mul := (· * ·).. } <;> pi_instance_derive_field
+instance commSemigroup [∀ i, CommSemigroup <| f i] : CommSemigroup (∀ i : I, f i) :=
+  { semigroup with
+    --pi_instance
+    mul_comm := by rename_i inst _; intros; ext i; exact (inst i).mul_comm _ _
+  }
 #align pi.comm_semigroup Pi.commSemigroup
 
 @[to_additive]
-instance mulOneClass [∀ i, MulOneClass <| f i] : MulOneClass (∀ i : I, f i) := by
-  refine_struct
-      { one := (1 : ∀ i, f i)
-        mul := (· * ·).. } <;>
-    pi_instance_derive_field
+instance mulOneClass [∀ i, MulOneClass <| f i] : MulOneClass (∀ i : I, f i) :=
+  { one := (1 : ∀ i, f i)
+    mul := (· * ·)
+    --pi_instance
+    one_mul := by rename_i inst; intros; ext i; exact (inst i).one_mul _
+    mul_one := by rename_i inst; intros; ext i; exact (inst i).mul_one _
+  }
 #align pi.mul_one_class Pi.mulOneClass
 
 @[to_additive]
-instance monoid [∀ i, Monoid <| f i] : Monoid (∀ i : I, f i) := by
-  refine_struct
-      { one := (1 : ∀ i, f i)
-        mul := (· * ·)
-        npow := fun n x i => x i ^ n } <;>
-    pi_instance_derive_field
+instance monoid [∀ i, Monoid <| f i] : Monoid (∀ i : I, f i) :=
+  { semigroup, mulOneClass with
+    npow := fun n x i => x i ^ n
+    --pi_instance
+    npow_zero := by rename_i inst _ _; intros; ext i; exact (inst i).npow_zero _
+    npow_succ := by rename_i inst _ _; intros; ext i; exact (inst i).npow_succ _ _
+  }
 #align pi.monoid Pi.monoid
 
 @[to_additive]

--- a/Mathlib/Algebra/Group/Pi.lean
+++ b/Mathlib/Algebra/Group/Pi.lean
@@ -57,7 +57,7 @@ namespace Pi
 instance semigroup [∀ i, Semigroup <| f i] : Semigroup (∀ i : I, f i) :=
   { mul := (· * ·)
     --pi_instance
-    mul_assoc := by rename_i inst; intros; ext i; exact (inst i).mul_assoc _ _ _ }
+    mul_assoc := by intros; ext; exact mul_assoc _ _ _ }
 #align pi.semigroup Pi.semigroup
 #align pi.add_semigroup Pi.addSemigroup
 
@@ -65,7 +65,7 @@ instance semigroup [∀ i, Semigroup <| f i] : Semigroup (∀ i : I, f i) :=
 instance commSemigroup [∀ i, CommSemigroup <| f i] : CommSemigroup (∀ i : I, f i) :=
   { semigroup with
     --pi_instance
-    mul_comm := by rename_i inst _; intros; ext i; exact (inst i).mul_comm _ _
+    mul_comm := by intros; ext; exact mul_comm _ _
   }
 #align pi.comm_semigroup Pi.commSemigroup
 #align pi.add_comm_semigroup Pi.addCommSemigroup
@@ -75,8 +75,8 @@ instance mulOneClass [∀ i, MulOneClass <| f i] : MulOneClass (∀ i : I, f i) 
   { one := (1 : ∀ i, f i)
     mul := (· * ·)
     --pi_instance
-    one_mul := by rename_i inst; intros; ext i; exact (inst i).one_mul _
-    mul_one := by rename_i inst; intros; ext i; exact (inst i).mul_one _
+    one_mul := by intros; ext; exact one_mul _
+    mul_one := by intros; ext; exact mul_one _
   }
 #align pi.mul_one_class Pi.mulOneClass
 #align pi.add_zero_class Pi.addZeroClass
@@ -86,8 +86,8 @@ instance monoid [∀ i, Monoid <| f i] : Monoid (∀ i : I, f i) :=
   { semigroup, mulOneClass with
     npow := fun n x i => x i ^ n
     --pi_instance
-    npow_zero := by rename_i inst _ _; intros; ext i; exact (inst i).npow_zero _
-    npow_succ := by rename_i inst _ _; intros; ext i; exact (inst i).npow_succ _ _
+    npow_zero := by intros; ext; exact Monoid.npow_zero _
+    npow_succ := by intros; ext; exact Monoid.npow_succ _ _
   }
 #align pi.monoid Pi.monoid
 #align pi.add_monoid Pi.addMonoid
@@ -108,27 +108,26 @@ instance divInvMonoid [∀ i, DivInvMonoid <| f i] : DivInvMonoid (∀ i : I, f 
     div := Div.div
     zpow := fun z x i => x i ^ z
     --pi_instance
-    div_eq_mul_inv := by rename_i inst _; intros; ext i; exact (inst i).div_eq_mul_inv _ _
-    zpow_zero' := by rename_i inst _; intros; ext i; exact (inst i).zpow_zero' _
-    zpow_succ' := by rename_i inst _; intros; ext i; exact (inst i).zpow_succ' _ _
-    zpow_neg' := by rename_i inst _; intros; ext i; exact (inst i).zpow_neg' _ _
+    div_eq_mul_inv := by intros; ext; exact div_eq_mul_inv _ _
+    zpow_zero' := by intros; ext; exact DivInvMonoid.zpow_zero' _
+    zpow_succ' := by intros; ext; exact DivInvMonoid.zpow_succ' _ _
+    zpow_neg' := by intros; ext; exact DivInvMonoid.zpow_neg' _ _
   }
 
 @[to_additive]
 instance involutiveInv [∀ i, InvolutiveInv <| f i] : InvolutiveInv (∀ i, f i) :=
   { inv := Inv.inv
     --pi_instance
-    inv_inv := by rename_i inst; intros; ext i; exact (inst i).inv_inv _
+    inv_inv := by intros; ext; exact inv_inv _
   }
 
 @[to_additive Pi.subtractionMonoid]
 instance divisionMonoid [∀ i, DivisionMonoid <| f i] : DivisionMonoid (∀ i, f i) :=
   { divInvMonoid, involutiveInv with
     --pi_instance
-    mul_inv_rev := by rename_i inst _ _; intros; ext i; exact (inst i).mul_inv_rev _ _
+    mul_inv_rev := by intros; ext; exact mul_inv_rev _ _
     inv_eq_of_mul := by
-      rename_i inst _ _; intros; ext i; apply (inst i).inv_eq_of_mul _ _ _;
-      rename_i h; exact congr_fun h i
+      intros _ _ h; ext; exact DivisionMonoid.inv_eq_of_mul _ _ (congrFun h _)
   }
 
 @[to_additive Pi.subtractionCommMonoid]
@@ -139,7 +138,7 @@ instance [∀ i, DivisionCommMonoid <| f i] : DivisionCommMonoid (∀ i, f i) :=
 instance group [∀ i, Group <| f i] : Group (∀ i : I, f i) :=
   { divInvMonoid with
     --pi_instance
-    mul_left_inv := by rename_i inst _; intros; ext i; exact (inst i).mul_left_inv _
+    mul_left_inv := by intros; ext; exact mul_left_inv _
     }
 #align pi.group Pi.group
 #align pi.add_group Pi.addGroup
@@ -159,8 +158,7 @@ instance leftCancelSemigroup [∀ i, LeftCancelSemigroup <| f i] :
   { semigroup with
     --pi_instance
     mul_left_cancel := by
-      rename_i inst _; intros; ext i; apply (inst i).mul_left_cancel _ _ _;
-      rename_i h; exact congr_fun h i
+      intros _ _ _ h; ext; exact LeftCancelSemigroup.mul_left_cancel _ _ _ (congr_fun h _);
   }
 #align pi.left_cancel_semigroup Pi.leftCancelSemigroup
 #align pi.add_left_cancel_semigroup Pi.addLeftCancelSemigroup
@@ -171,8 +169,7 @@ instance rightCancelSemigroup [∀ i, RightCancelSemigroup <| f i] :
   { semigroup with
     --pi_instance
     mul_right_cancel := by
-      rename_i inst _; intros; ext i; apply (inst i).mul_right_cancel _ _ _;
-      rename_i h; exact congr_fun h i
+      intros _ _ _ h; ext; exact RightCancelSemigroup.mul_right_cancel _ _ _ (congr_fun h _)
   }
 #align pi.right_cancel_semigroup Pi.rightCancelSemigroup
 #align pi.add_right_cancel_semigroup Pi.addRightCancelSemigroup
@@ -205,8 +202,8 @@ instance mulZeroClass [∀ i, MulZeroClass <| f i] : MulZeroClass (∀ i : I, f 
   { zero := (0 : ∀ i, f i)
     mul := (· * ·)
     --pi_instance
-    zero_mul := by rename_i inst; intro; ext i; exact (inst i).zero_mul _
-    mul_zero := by rename_i inst; intro; ext i; exact (inst i).mul_zero _
+    zero_mul := by intros; ext; exact zero_mul _
+    mul_zero := by intros; ext; exact mul_zero _
 }
 #align pi.mul_zero_class Pi.mulZeroClass
 

--- a/Mathlib/Algebra/Group/Pi.lean
+++ b/Mathlib/Algebra/Group/Pi.lean
@@ -265,7 +265,7 @@ theorem Pi.monoid_hom_injective {γ : Type w} [Nonempty I] [∀ i, MulOneClass (
   Pi.mul_hom_injective (fun i => (g i).toMulHom) hg
 #align pi.monoid_hom_injective Pi.monoid_hom_injective
 
-variable (f) [∀ i, Mul (f i)]
+variable (f) [(i : I) → Mul (f i)]
 
 /-- Evaluation of functions into an indexed collection of semigroups at a point is a semigroup
 homomorphism.
@@ -312,7 +312,7 @@ end MulHom
 
 section MonoidHom
 
-variable (f) [∀ i, MulOneClass (f i)]
+variable (f) [(i : I) → MulOneClass (f i)]
 
 /-- Evaluation of functions into an indexed collection of monoids at a point is a monoid
 homomorphism.

--- a/Mathlib/Algebra/Group/Pi.lean
+++ b/Mathlib/Algebra/Group/Pi.lean
@@ -223,10 +223,10 @@ end MulHom
 
 section MulHom
 
-/-- A family of mul_hom `f a : γ →ₙ* β a` defines a mul_hom `pi.mul_hom f : γ →ₙ* Π a, β a`
-given by `pi.mul_hom f x b = f b x`. -/
+/-- A family of mul_hom `f a : γ →ₙ* β a` defines a mul_hom `Pi.mul_hom f : γ →ₙ* Π a, β a`
+given by `Pi.mul_hom f x b = f b x`. -/
 @[to_additive
-      "A family of add_hom `f a : γ → β a` defines a add_hom `pi.add_hom\nf : γ → Π a, β a` given by `pi.add_hom f x b = f b x`.",
+      "A family of add_hom `f a : γ → β a` defines a add_hom `Pi.add_hom\nf : γ → Π a, β a` given by `Pi.add_hom f x b = f b x`.",
   simps]
 def Pi.mulHom {γ : Type w} [∀ i, Mul (f i)] [Mul γ] (g : ∀ i, γ →ₙ* f i) : γ →ₙ* ∀ i, f i where
   toFun x i := g i x
@@ -241,9 +241,9 @@ theorem Pi.mul_hom_injective {γ : Type w} [Nonempty I] [∀ i, Mul (f i)] [Mul 
 #align pi.mul_hom_injective Pi.mul_hom_injective
 
 /-- A family of monoid homomorphisms `f a : γ →* β a` defines a monoid homomorphism
-`pi.monoid_mul_hom f : γ →* Π a, β a` given by `pi.monoid_mul_hom f x b = f b x`. -/
+`Pi.monoid_mul_hom f : γ →* Π a, β a` given by `Pi.monoid_mul_hom f x b = f b x`. -/
 @[to_additive
-      "A family of additive monoid homomorphisms `f a : γ →+ β a` defines a monoid\nhomomorphism `pi.add_monoid_hom f : γ →+ Π a, β a` given by `pi.add_monoid_hom f x b\n= f b x`.",
+      "A family of additive monoid homomorphisms `f a : γ →+ β a` defines a monoid\nhomomorphism `Pi.add_monoid_hom f : γ →+ Π a, β a` given by `Pi.add_monoid_hom f x b\n= f b x`.",
   simps]
 def Pi.monoidHom {γ : Type w} [∀ i, MulOneClass (f i)] [MulOneClass γ] (g : ∀ i, γ →* f i) :
     γ →* ∀ i, f i :=
@@ -368,9 +368,9 @@ variable (f)
 /-- The one-preserving homomorphism including a single value
 into a dependent family of values, as functions supported at a point.
 
-This is the `one_hom` version of `pi.mulSingle`. -/
+This is the `one_hom` version of `Pi.mulSingle`. -/
 @[to_additive
-      "The zero-preserving homomorphism including a single value\ninto a dependent family of values, as functions supported at a point.\n\nThis is the `zero_hom` version of `pi.single`."]
+      "The zero-preserving homomorphism including a single value\ninto a dependent family of values, as functions supported at a point.\n\nThis is the `zero_hom` version of `Pi.single`."]
 def OneHom.single [∀ i, One <| f i] (i : I) :
     OneHom (f i) (∀ i, f i) where
   toFun := mulSingle i

--- a/Mathlib/Algebra/Group/Pi.lean
+++ b/Mathlib/Algebra/Group/Pi.lean
@@ -24,7 +24,7 @@ This file defines instances for group, monoid, semigroup and related structures 
 
   See this Zulip discussion: [https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/not.20porting.20pi_instance]
 
-  * This file now includes the pi instance for `AddMonoidWithOne`
+  * This file now includes the pi instances for `AddMonoidWithOne` and `AddGroupWithOne`
   * This file relied on the `pi_instance` tactic, which was not available at the time of porting.
     The comment `--pi_instance` is inserted before all fields which were previously derived by
     `pi_instance`.
@@ -209,6 +209,12 @@ instance monoidWithZero [∀ i, MonoidWithZero <| f i] : MonoidWithZero (∀ i :
 instance commMonoidWithZero [∀ i, CommMonoidWithZero <| f i] : CommMonoidWithZero (∀ i : I, f i) :=
   { monoidWithZero, commMonoid with } --!!trim?
 #align pi.comm_monoid_with_zero Pi.commMonoidWithZero
+
+instance [∀ i, AddMonoidWithOne <| f i] : AddMonoidWithOne (∀ i : I, f i) :=
+  { addMonoid with }
+
+instance [∀ i, AddGroupWithOne <| f i] : AddGroupWithOne (∀ i : I, f i) :=
+  { addGroup with }
 
 end Pi
 

--- a/Mathlib/Algebra/Group/Pi.lean
+++ b/Mathlib/Algebra/Group/Pi.lean
@@ -28,8 +28,8 @@ This file defines instances for group, monoid, semigroup and related structures 
   * This file relied on the `pi_instance` tactic, which was not available at the time of porting.
     The comment `--pi_instance` is inserted before all fields which were previously derived by
     `pi_instance`.
-  * This file previously *over*used `pi_instance`. Now previously-defined instances are used as
-    sources via `with` as much as possible.
+  * This file previously gave data fields explicitly. Now previously-defined instances are sourced
+    via `with` as much as possible.
 -/
 
 universe u v w
@@ -54,12 +54,11 @@ namespace Pi
 
 @[to_additive]
 instance semigroup [∀ i, Semigroup <| f i] : Semigroup (∀ i : I, f i) :=
-  { mul := (· * ·) --!!should this be `Pi.instMul.mul` or is this ok?
+  { mul := (· * ·)
     --pi_instance
     mul_assoc := by rename_i inst; intros; ext i; exact (inst i).mul_assoc _ _ _ }
 #align pi.semigroup Pi.semigroup
 
---!!rewrite to use MulZeroClass?
 instance semigroupWithZero [∀ i, SemigroupWithZero <| f i] : SemigroupWithZero (∀ i : I, f i) :=
   { semigroup with
     zero := (0 : ∀ i, f i)
@@ -148,7 +147,7 @@ instance commGroup [∀ i, CommGroup <| f i] : CommGroup (∀ i : I, f i) :=
   { group, commMonoid with }
 #align pi.comm_group Pi.commGroup
 
-@[to_additive AddLeftCancelSemigroup]
+@[to_additive]
 instance leftCancelSemigroup [∀ i, LeftCancelSemigroup <| f i] :
     LeftCancelSemigroup (∀ i : I, f i) :=
   { semigroup with
@@ -159,34 +158,35 @@ instance leftCancelSemigroup [∀ i, LeftCancelSemigroup <| f i] :
   }
 #align pi.left_cancel_semigroup Pi.leftCancelSemigroup
 
-@[to_additive AddRightCancelSemigroup]
+@[to_additive]
 instance rightCancelSemigroup [∀ i, RightCancelSemigroup <| f i] :
     RightCancelSemigroup (∀ i : I, f i) :=
   { semigroup with
+    --pi_instance
     mul_right_cancel := by
       rename_i inst _; intros; ext i; apply (inst i).mul_right_cancel _ _ _;
       rename_i h; exact congr_fun h i
   }
 #align pi.right_cancel_semigroup Pi.rightCancelSemigroup
 
-@[to_additive AddLeftCancelMonoid]
+@[to_additive]
 instance leftCancelMonoid [∀ i, LeftCancelMonoid <| f i] : LeftCancelMonoid (∀ i : I, f i) :=
   { leftCancelSemigroup, monoid with }
 #align pi.left_cancel_monoid Pi.leftCancelMonoid
 
-@[to_additive AddRightCancelMonoid]
+@[to_additive]
 instance rightCancelMonoid [∀ i, RightCancelMonoid <| f i] : RightCancelMonoid (∀ i : I, f i) :=
   { rightCancelSemigroup, monoid with }
 #align pi.right_cancel_monoid Pi.rightCancelMonoid
 
-@[to_additive AddCancelMonoid]
+@[to_additive]
 instance cancelMonoid [∀ i, CancelMonoid <| f i] : CancelMonoid (∀ i : I, f i) :=
-  { leftCancelMonoid, rightCancelMonoid with } --!!trim?
+  { leftCancelMonoid, rightCancelMonoid with }
 #align pi.cancel_monoid Pi.cancelMonoid
 
-@[to_additive AddCancelCommMonoid]
+@[to_additive]
 instance cancelCommMonoid [∀ i, CancelCommMonoid <| f i] : CancelCommMonoid (∀ i : I, f i) :=
-  { leftCancelMonoid, commMonoid with } --!!trim?
+  { leftCancelMonoid, commMonoid with }
 #align pi.cancel_comm_monoid Pi.cancelCommMonoid
 
 instance mulZeroClass [∀ i, MulZeroClass <| f i] : MulZeroClass (∀ i : I, f i) :=
@@ -203,17 +203,17 @@ instance mulZeroOneClass [∀ i, MulZeroOneClass <| f i] : MulZeroOneClass (∀ 
 #align pi.mul_zero_one_class Pi.mulZeroOneClass
 
 instance monoidWithZero [∀ i, MonoidWithZero <| f i] : MonoidWithZero (∀ i : I, f i) :=
-  { monoid, mulZeroClass with } --!!trim?
+  { monoid, mulZeroClass with }
 #align pi.monoid_with_zero Pi.monoidWithZero
 
 instance commMonoidWithZero [∀ i, CommMonoidWithZero <| f i] : CommMonoidWithZero (∀ i : I, f i) :=
-  { monoidWithZero, commMonoid with } --!!trim?
+  { monoidWithZero, commMonoid with }
 #align pi.comm_monoid_with_zero Pi.commMonoidWithZero
 
-instance [∀ i, AddMonoidWithOne <| f i] : AddMonoidWithOne (∀ i : I, f i) :=
+instance addMonoidWithOne [∀ i, AddMonoidWithOne <| f i] : AddMonoidWithOne (∀ i : I, f i) :=
   { addMonoid with }
 
-instance [∀ i, AddGroupWithOne <| f i] : AddGroupWithOne (∀ i : I, f i) :=
+instance addGroupWithOne [∀ i, AddGroupWithOne <| f i] : AddGroupWithOne (∀ i : I, f i) :=
   { addGroup with }
 
 end Pi
@@ -229,10 +229,10 @@ end MulHom
 
 section MulHom
 
-/-- A family of mul_hom `f a : γ →ₙ* β a` defines a mul_hom `Pi.mul_hom f : γ →ₙ* Π a, β a`
-given by `Pi.mul_hom f x b = f b x`. -/
+/-- A family of MulHom's `f a : γ →ₙ* β a` defines a MulHom `Pi.mulHom f : γ →ₙ* Π a, β a`
+given by `Pi.mulHom f x b = f b x`. -/
 @[to_additive
-      "A family of add_hom `f a : γ → β a` defines a add_hom `Pi.add_hom\nf : γ → Π a, β a` given by `Pi.add_hom f x b = f b x`.",
+      "A family of AddHom's `f a : γ → β a` defines an AddHom `Pi.addHom\nf : γ → Π a, β a` given by `Pi.addHom f x b = f b x`.",
   simps]
 def Pi.mulHom {γ : Type w} [∀ i, Mul (f i)] [Mul γ] (g : ∀ i, γ →ₙ* f i) : γ →ₙ* ∀ i, f i where
   toFun x i := g i x
@@ -240,16 +240,16 @@ def Pi.mulHom {γ : Type w} [∀ i, Mul (f i)] [Mul γ] (g : ∀ i, γ →ₙ* f
 #align pi.mul_hom Pi.mulHom
 
 @[to_additive]
-theorem Pi.mul_hom_injective {γ : Type w} [Nonempty I] [∀ i, Mul (f i)] [Mul γ] (g : ∀ i, γ →ₙ* f i)
+theorem Pi.mulHom_injective {γ : Type w} [Nonempty I] [∀ i, Mul (f i)] [Mul γ] (g : ∀ i, γ →ₙ* f i)
     (hg : ∀ i, Function.Injective (g i)) : Function.Injective (Pi.mulHom g) := fun x y h =>
   let ⟨i⟩ := ‹Nonempty I›
   hg i ((Function.funext_iff.mp h : _) i)
-#align pi.mul_hom_injective Pi.mul_hom_injective
+#align pi.mul_hom_injective Pi.mulHom_injective
 
 /-- A family of monoid homomorphisms `f a : γ →* β a` defines a monoid homomorphism
-`Pi.monoid_mul_hom f : γ →* Π a, β a` given by `Pi.monoid_mul_hom f x b = f b x`. -/
+`Pi.monoidHom f : γ →* Π a, β a` given by `Pi.monoidHom f x b = f b x`. -/
 @[to_additive
-      "A family of additive monoid homomorphisms `f a : γ →+ β a` defines a monoid\nhomomorphism `Pi.add_monoid_hom f : γ →+ Π a, β a` given by `Pi.add_monoid_hom f x b\n= f b x`.",
+      "A family of additive monoid homomorphisms `f a : γ →+ β a` defines a monoid\nhomomorphism `Pi.addMonoidHom f : γ →+ Π a, β a` given by `Pi.addMonoidHom f x b\n= f b x`.",
   simps]
 def Pi.monoidHom {γ : Type w} [∀ i, MulOneClass (f i)] [MulOneClass γ] (g : ∀ i, γ →* f i) :
     γ →* ∀ i, f i :=
@@ -259,37 +259,37 @@ def Pi.monoidHom {γ : Type w} [∀ i, MulOneClass (f i)] [MulOneClass γ] (g : 
 #align pi.monoid_hom Pi.monoidHom
 
 @[to_additive]
-theorem Pi.monoid_hom_injective {γ : Type w} [Nonempty I] [∀ i, MulOneClass (f i)] [MulOneClass γ]
+theorem Pi.monoidHom_injective {γ : Type w} [Nonempty I] [∀ i, MulOneClass (f i)] [MulOneClass γ]
     (g : ∀ i, γ →* f i) (hg : ∀ i, Function.Injective (g i)) :
     Function.Injective (Pi.monoidHom g) :=
-  Pi.mul_hom_injective (fun i => (g i).toMulHom) hg
-#align pi.monoid_hom_injective Pi.monoid_hom_injective
+  Pi.mulHom_injective (fun i => (g i).toMulHom) hg
+#align pi.monoid_hom_injective Pi.monoidHom_injective
 
 variable (f) [(i : I) → Mul (f i)]
 
 /-- Evaluation of functions into an indexed collection of semigroups at a point is a semigroup
 homomorphism.
-This is `function.eval i` as a `mul_hom`. -/
+This is `Function.eval i` as a `MulHom`. -/
 @[to_additive
-      "Evaluation of functions into an indexed collection of additive semigroups at a\npoint is an additive semigroup homomorphism.\nThis is `function.eval i` as an `add_hom`.",
+      "Evaluation of functions into an indexed collection of additive semigroups at a\npoint is an additive semigroup homomorphism.\nThis is `Function.eval i` as an `AddHom`.",
   simps]
 def Pi.evalMulHom (i : I) : (∀ i, f i) →ₙ* f i where
   toFun g := g i
   map_mul' _ _ := Pi.mul_apply _ _ i
 #align pi.eval_mul_hom Pi.evalMulHom
 
-/-- `function.const` as a `mul_hom`. -/
-@[to_additive "`function.const` as an `add_hom`.", simps]
+/-- `function.const` as a `MulHom`. -/
+@[to_additive "`function.const` as an `AddHom`.", simps]
 def Pi.constMulHom (α β : Type _) [Mul β] :
     β →ₙ* α → β where
   toFun := Function.const α
   map_mul' _ _ := rfl
 #align pi.const_mul_hom Pi.constMulHom
 
-/-- Coercion of a `mul_hom` into a function is itself a `mul_hom`.
-See also `mul_hom.eval`. -/
+/-- Coercion of a `MulHom` into a function is itself a `MulHom`.
+See also `MulHom.eval`. -/
 @[to_additive
-      "Coercion of an `add_hom` into a function is itself a `add_hom`.\nSee also `add_hom.eval`. ",
+      "Coercion of an `AddHom` into a function is itself an `AddHom`.\nSee also `AddHom.eval`. ",
   simps]
 def MulHom.coeFn (α β : Type _) [Mul α] [CommSemigroup β] :
     (α →ₙ* β) →ₙ* α → β where
@@ -316,9 +316,9 @@ variable (f) [(i : I) → MulOneClass (f i)]
 
 /-- Evaluation of functions into an indexed collection of monoids at a point is a monoid
 homomorphism.
-This is `function.eval i` as a `monoid_hom`. -/
+This is `Function.eval i` as a `MonoidHom`. -/
 @[to_additive
-      "Evaluation of functions into an indexed collection of additive monoids at a\npoint is an additive monoid homomorphism.\nThis is `function.eval i` as an `add_monoid_hom`.",
+      "Evaluation of functions into an indexed collection of additive monoids at a\npoint is an additive monoid homomorphism.\nThis is `Function.eval i` as an `AddMonoidHom`.",
   simps]
 def Pi.evalMonoidHom (i : I) :
     (∀ i, f i) →* f i where
@@ -327,8 +327,8 @@ def Pi.evalMonoidHom (i : I) :
   map_mul' _ _ := Pi.mul_apply _ _ i
 #align pi.eval_monoid_hom Pi.evalMonoidHom
 
-/-- `function.const` as a `monoid_hom`. -/
-@[to_additive "`function.const` as an `add_monoid_hom`.", simps]
+/-- `Function.const` as a `MonoidHom`. -/
+@[to_additive "`Function.const` as an `AddMonoidHom`.", simps]
 def Pi.constMonoidHom (α β : Type _) [MulOneClass β] :
     β →* α → β where
   toFun := Function.const α
@@ -336,11 +336,11 @@ def Pi.constMonoidHom (α β : Type _) [MulOneClass β] :
   map_mul' _ _ := rfl
 #align pi.const_monoid_hom Pi.constMonoidHom
 
-/-- Coercion of a `monoid_hom` into a function is itself a `monoid_hom`.
+/-- Coercion of a `MonoidHom` into a function is itself a `MonoidHom`.
 
-See also `monoid_hom.eval`. -/
+See also `MonoidHom.eval`. -/
 @[to_additive
-      "Coercion of an `add_monoid_hom` into a function is itself a `add_monoid_hom`.\n\nSee also `add_monoid_hom.eval`. ",
+      "Coercion of an `AddMonoidHom` into a function is itself a `AddMonoidHom`.\n\nSee also `AddMonoidHom.eval`. ",
   simps]
 def MonoidHom.coeFn (α β : Type _) [MulOneClass α] [CommMonoid β] :
     (α →* β) →* α → β where
@@ -357,7 +357,7 @@ homomorphism `f` between `α` and `β`. -/
 protected def MonoidHom.compLeft {α β : Type _} [MulOneClass α] [MulOneClass β] (f : α →* β)
     (I : Type _) : (I → α) →* I → β where
   toFun h := f ∘ h
-  map_one' := by ext; dsimp; simp --!!why? bug?
+  map_one' := by ext; dsimp; simp
   map_mul' _ _ := by ext; simp
 #align monoid_hom.comp_left MonoidHom.compLeft
 
@@ -374,9 +374,9 @@ variable (f)
 /-- The one-preserving homomorphism including a single value
 into a dependent family of values, as functions supported at a point.
 
-This is the `one_hom` version of `Pi.mulSingle`. -/
+This is the `OneHom` version of `Pi.mulSingle`. -/
 @[to_additive
-      "The zero-preserving homomorphism including a single value\ninto a dependent family of values, as functions supported at a point.\n\nThis is the `zero_hom` version of `Pi.single`."]
+      "The zero-preserving homomorphism including a single value\ninto a dependent family of values, as functions supported at a point.\n\nThis is the `ZeroHom` version of `Pi.Single`."]
 def OneHom.single [∀ i, One <| f i] (i : I) :
     OneHom (f i) (∀ i, f i) where
   toFun := mulSingle i
@@ -392,9 +392,9 @@ theorem OneHom.single_apply [∀ i, One <| f i] (i : I) (x : f i) :
 /-- The monoid homomorphism including a single monoid into a dependent family of additive monoids,
 as functions supported at a point.
 
-This is the `monoid_hom` version of `Pi.mulSingle`. -/
+This is the `MonoidHom` version of `Pi.mulSingle`. -/
 @[to_additive
-      "The additive monoid homomorphism including a single additive\nmonoid into a dependent family of additive monoids, as functions supported at a point.\n\nThis is the `add_monoid_hom` version of `Pi.Single`."]
+      "The additive monoid homomorphism including a single additive\nmonoid into a dependent family of additive monoids, as functions supported at a point.\n\nThis is the `AddMonoidHom` version of `Pi.Single`."]
 def MonoidHom.single [∀ i, MulOneClass <| f i] (i : I) : f i →* ∀ i, f i :=
   { OneHom.single f i with map_mul' := mulSingle_op₂ (fun _ => (· * ·)) (fun _ => one_mul _) _ }
 #align monoid_hom.single MonoidHom.single
@@ -405,10 +405,10 @@ theorem MonoidHom.single_apply [∀ i, MulOneClass <| f i] (i : I) (x : f i) :
   rfl
 #align monoid_hom.single_apply MonoidHom.single_apply
 
-/-- The multiplicative homomorphism including a single `mul_zero_class`
-into a dependent family of `mul_zero_class`es, as functions supported at a point.
+/-- The multiplicative homomorphism including a single `MulZeroClass`
+into a dependent family of `MulZeroClass`es, as functions supported at a point.
 
-This is the `mul_hom` version of `Pi.Single`. -/
+This is the `MulHom` version of `Pi.Single`. -/
 @[simps]
 def MulHom.single [∀ i, MulZeroClass <| f i] (i : I) :
     f i →ₙ* ∀ i, f i where
@@ -443,9 +443,9 @@ theorem Pi.single_mul [∀ i, MulZeroClass <| f i] (i : I) (x y : f i) :
 
 /-- The injection into a pi group at different indices commutes.
 
-For injections of commuting elements at the same index, see `commute.map` -/
+For injections of commuting elements at the same index, see `Commute.map` -/
 @[to_additive
-      "The injection into an additive pi group at different indices commutes.\n\nFor injections of commuting elements at the same index, see `add_commute.map`"]
+      "The injection into an additive pi group at different indices commutes.\n\nFor injections of commuting elements at the same index, see `AddCommute.map`"]
 theorem Pi.mulSingle_commute [∀ i, MulOneClass <| f i] :
     Pairwise fun i j => ∀ (x : f i) (y : f j), Commute (mulSingle i x) (mulSingle j y) := by
   intro i j hij x y; ext k
@@ -467,7 +467,7 @@ theorem Pi.mulSingle_apply_commute [∀ i, MulOneClass <| f i] (x : ∀ i, f i) 
   · exact Pi.mulSingle_commute hij _ _
 #align pi.mul_single_apply_commute Pi.mulSingle_apply_commute
 
-@[to_additive update_eq_sub_add_single]
+@[to_additive update_eq_sub_addSingle]
 theorem Pi.update_eq_div_mulSingle [∀ i, Group <| f i] (g : ∀ i : I, f i) (x : f i) :
     Function.update g i x = g / mulSingle i (g i) * mulSingle i x := by
   ext j
@@ -477,11 +477,10 @@ theorem Pi.update_eq_div_mulSingle [∀ i, Group <| f i] (g : ∀ i : I, f i) (x
 #align pi.update_eq_div_mul_single Pi.update_eq_div_mulSingle
 
 @[to_additive]
-theorem Pi.mulSingle_mul_mulSingle_eq_mulSingle_mul_mulSingle {M : Type _} [cm : CommMonoid M]
+theorem Pi.mulSingle_mul_mulSingle_eq_mulSingle_mul_mulSingle {M : Type _} [CommMonoid M]
     {k l m n : I} {u v : M} (hu : u ≠ 1) (hv : v ≠ 1) :
-    (mulSingle k u : (a : I) → M) * mulSingle l v = mulSingle m u * mulSingle n v ↔ --!!correct?
-      k = m ∧ l = n ∨ u = v ∧ k = n ∧ l = m ∨ u * v = 1 ∧ k = l ∧ m = n :=
-  by
+    (mulSingle k u : I → M) * mulSingle l v = mulSingle m u * mulSingle n v ↔
+      k = m ∧ l = n ∨ u = v ∧ k = n ∧ l = m ∨ u * v = 1 ∧ k = l ∧ m = n := by
   refine' ⟨fun h => _, _⟩
   · have hk := congr_fun h k
     have hl := congr_fun h l
@@ -516,7 +515,6 @@ end Single
 
 namespace Function
 
-set_option pp.all true
 @[simp, to_additive]
 theorem update_one [∀ i, One (f i)] [DecidableEq I] (i : I) : update (1 : ∀ i, f i) i 1 = 1 :=
   update_eq_self i (1 : (a : I) → f a)
@@ -582,8 +580,8 @@ section Extend
 
 variable {η : Type v} (R : Type w) (s : ι → η)
 
-/-- `function.extend s f 1` as a bundled hom. -/
-@[to_additive Function.ExtendByZero.hom "`function.extend s f 0` as a bundled hom.", simps]
+/-- `Function.extend s f 1` as a bundled hom. -/
+@[to_additive Function.ExtendByZero.hom "`Function.extend s f 0` as a bundled hom.", simps]
 noncomputable def Function.ExtendByOne.hom [MulOneClass R] :
     (ι → R) →* η → R where
   toFun f := Function.extend s f 1

--- a/Mathlib/Algebra/Group/Pi.lean
+++ b/Mathlib/Algebra/Group/Pi.lean
@@ -413,7 +413,7 @@ This is the `OneHom` version of `Pi.mulSingle`. -/
       "The zero-preserving homomorphism including a single value into a dependent family of values,
       as functions supported at a point.
 
-      This is the `ZeroHom` version of `Pi.Single`."]
+      This is the `ZeroHom` version of `Pi.single`."]
 def OneHom.single [∀ i, One <| f i] (i : I) :
     OneHom (f i) (∀ i, f i) where
   toFun := mulSingle i
@@ -436,7 +436,7 @@ This is the `MonoidHom` version of `Pi.mulSingle`. -/
       "The additive monoid homomorphism including a single additive monoid into a dependent family
       of additive monoids, as functions supported at a point.
 
-      This is the `AddMonoidHom` version of `Pi.Single`."]
+      This is the `AddMonoidHom` version of `Pi.single`."]
 def MonoidHom.single [∀ i, MulOneClass <| f i] (i : I) : f i →* ∀ i, f i :=
   { OneHom.single f i with map_mul' := mulSingle_op₂ (fun _ => (· * ·)) (fun _ => one_mul _) _ }
 #align monoid_hom.single MonoidHom.single
@@ -452,11 +452,11 @@ theorem MonoidHom.single_apply [∀ i, MulOneClass <| f i] (i : I) (x : f i) :
 /-- The multiplicative homomorphism including a single `MulZeroClass`
 into a dependent family of `MulZeroClass`es, as functions supported at a point.
 
-This is the `MulHom` version of `Pi.Single`. -/
+This is the `MulHom` version of `Pi.single`. -/
 @[simps]
 def MulHom.single [∀ i, MulZeroClass <| f i] (i : I) :
     f i →ₙ* ∀ i, f i where
-  toFun := Single i
+  toFun := Pi.single i
   map_mul' := Pi.single_op₂ (fun _ => (· * ·)) (fun _ => zero_mul _) _
 #align mul_hom.single MulHom.single
 
@@ -484,7 +484,7 @@ theorem Pi.single_div [∀ i, Group <| f i] (i : I) (x y : f i) :
 #align pi.single_sub Pi.single_sub
 
 theorem Pi.single_mul [∀ i, MulZeroClass <| f i] (i : I) (x y : f i) :
-    Single i (x * y) = Single i x * Single i y :=
+    single i (x * y) = single i x * single i y :=
   (MulHom.single f i).map_mul x y
 #align pi.single_mul Pi.single_mul
 

--- a/Mathlib/Algebra/Group/Pi.lean
+++ b/Mathlib/Algebra/Group/Pi.lean
@@ -368,7 +368,7 @@ variable (f)
 /-- The one-preserving homomorphism including a single value
 into a dependent family of values, as functions supported at a point.
 
-This is the `one_hom` version of `pi.mul_single`. -/
+This is the `one_hom` version of `pi.mulSingle`. -/
 @[to_additive
       "The zero-preserving homomorphism including a single value\ninto a dependent family of values, as functions supported at a point.\n\nThis is the `zero_hom` version of `pi.single`."]
 def OneHom.single [∀ i, One <| f i] (i : I) :
@@ -386,7 +386,7 @@ theorem OneHom.single_apply [∀ i, One <| f i] (i : I) (x : f i) :
 /-- The monoid homomorphism including a single monoid into a dependent family of additive monoids,
 as functions supported at a point.
 
-This is the `monoid_hom` version of `Pi.mul_single`. -/
+This is the `monoid_hom` version of `Pi.mulSingle`. -/
 @[to_additive
       "The additive monoid homomorphism including a single additive\nmonoid into a dependent family of additive monoids, as functions supported at a point.\n\nThis is the `add_monoid_hom` version of `Pi.Single`."]
 def MonoidHom.single [∀ i, MulOneClass <| f i] (i : I) : f i →* ∀ i, f i :=
@@ -413,16 +413,16 @@ def MulHom.single [∀ i, MulZeroClass <| f i] (i : I) :
 variable {f}
 
 @[to_additive]
-theorem Pi.mul_single_mul [∀ i, MulOneClass <| f i] (i : I) (x y : f i) :
+theorem Pi.mulSingle_mul [∀ i, MulOneClass <| f i] (i : I) (x y : f i) :
     mulSingle i (x * y) = mulSingle i x * mulSingle i y :=
   (MonoidHom.single f i).map_mul x y
-#align pi.mul_single_mul Pi.mul_single_mul
+#align pi.mul_single_mul Pi.mulSingle_mul
 
 @[to_additive]
-theorem Pi.mul_single_inv [∀ i, Group <| f i] (i : I) (x : f i) :
+theorem Pi.mulSingle_inv [∀ i, Group <| f i] (i : I) (x : f i) :
     mulSingle i x⁻¹ = (mulSingle i x)⁻¹ :=
   (MonoidHom.single f i).map_inv x
-#align pi.mul_single_inv Pi.mul_single_inv
+#align pi.mul_single_inv Pi.mulSingle_inv
 
 @[to_additive]
 theorem Pi.single_div [∀ i, Group <| f i] (i : I) (x y : f i) :
@@ -440,7 +440,7 @@ theorem Pi.single_mul [∀ i, MulZeroClass <| f i] (i : I) (x y : f i) :
 For injections of commuting elements at the same index, see `commute.map` -/
 @[to_additive
       "The injection into an additive pi group at different indices commutes.\n\nFor injections of commuting elements at the same index, see `add_commute.map`"]
-theorem Pi.mul_single_commute [∀ i, MulOneClass <| f i] :
+theorem Pi.mulSingle_commute [∀ i, MulOneClass <| f i] :
     Pairwise fun i j => ∀ (x : f i) (y : f j), Commute (mulSingle i x) (mulSingle j y) := by
   intro i j hij x y; ext k
   by_cases h1 : i = k;
@@ -450,28 +450,28 @@ theorem Pi.mul_single_commute [∀ i, MulOneClass <| f i] :
   · subst h2
     simp [hij]
   simp [h1, h2]
-#align pi.mul_single_commute Pi.mul_single_commute
+#align pi.mul_single_commute Pi.mulSingle_commute
 
 /-- The injection into a pi group with the same values commutes. -/
 @[to_additive "The injection into an additive pi group with the same values commutes."]
-theorem Pi.mul_single_apply_commute [∀ i, MulOneClass <| f i] (x : ∀ i, f i) (i j : I) :
+theorem Pi.mulSingle_apply_commute [∀ i, MulOneClass <| f i] (x : ∀ i, f i) (i j : I) :
     Commute (mulSingle i (x i)) (mulSingle j (x j)) := by
   obtain rfl | hij := Decidable.eq_or_ne i j
   · rfl
-  · exact Pi.mul_single_commute hij _ _
-#align pi.mul_single_apply_commute Pi.mul_single_apply_commute
+  · exact Pi.mulSingle_commute hij _ _
+#align pi.mul_single_apply_commute Pi.mulSingle_apply_commute
 
 @[to_additive update_eq_sub_add_single]
-theorem Pi.update_eq_div_mul_single [∀ i, Group <| f i] (g : ∀ i : I, f i) (x : f i) :
+theorem Pi.update_eq_div_mulSingle [∀ i, Group <| f i] (g : ∀ i : I, f i) (x : f i) :
     Function.update g i x = g / mulSingle i (g i) * mulSingle i x := by
   ext j
   rcases eq_or_ne i j with (rfl | h)
   · simp
   · simp [Function.update_noteq h.symm, h]
-#align pi.update_eq_div_mul_single Pi.update_eq_div_mul_single
+#align pi.update_eq_div_mul_single Pi.update_eq_div_mulSingle
 
 @[to_additive]
-theorem Pi.mul_single_mul_mul_single_eq_mul_single_mul_mul_single {M : Type _} [cm : CommMonoid M]
+theorem Pi.mulSingle_mul_mulSingle_eq_mulSingle_mul_mulSingle {M : Type _} [cm : CommMonoid M]
     {k l m n : I} {u v : M} (hu : u ≠ 1) (hv : v ≠ 1) :
     (mulSingle k u : (a : I) → M) * mulSingle l v = mulSingle m u * mulSingle n v ↔ --!!correct?
       k = m ∧ l = n ∨ u = v ∧ k = n ∧ l = m ∨ u * v = 1 ∧ k = l ∧ m = n :=
@@ -502,9 +502,9 @@ theorem Pi.mul_single_mul_mul_single_eq_mul_single_mul_mul_single {M : Type _} [
   · rintro (⟨rfl, rfl⟩ | ⟨rfl, rfl, rfl⟩ | ⟨h, rfl, rfl⟩)
     · rfl
     · apply mul_comm
-    · simp_rw [← Pi.mul_single_mul, h, mulSingle_one]
+    · simp_rw [← Pi.mulSingle_mul, h, mulSingle_one]
 #align
-  pi.mul_single_mul_mul_single_eq_mul_single_mul_mul_single Pi.mul_single_mul_mul_single_eq_mul_single_mul_mul_single
+  pi.mul_single_mul_mul_single_eq_mul_single_mul_mul_single Pi.mulSingle_mul_mulSingle_eq_mulSingle_mul_mulSingle
 
 end Single
 

--- a/Mathlib/Algebra/Group/Pi.lean
+++ b/Mathlib/Algebra/Group/Pi.lean
@@ -61,14 +61,6 @@ instance semigroup [∀ i, Semigroup <| f i] : Semigroup (∀ i : I, f i) :=
 #align pi.semigroup Pi.semigroup
 #align pi.add_semigroup Pi.addSemigroup
 
-instance semigroupWithZero [∀ i, SemigroupWithZero <| f i] : SemigroupWithZero (∀ i : I, f i) :=
-  { semigroup with
-    zero := (0 : ∀ i, f i)
-    --pi_instance
-    zero_mul := by rename_i inst _; intro; ext i; exact (inst i).zero_mul _
-    mul_zero := by rename_i inst _; intro; ext i; exact (inst i).mul_zero _ }
-#align pi.semigroup_with_zero Pi.semigroupWithZero
-
 @[to_additive]
 instance commSemigroup [∀ i, CommSemigroup <| f i] : CommSemigroup (∀ i : I, f i) :=
   { semigroup with
@@ -99,6 +91,9 @@ instance monoid [∀ i, Monoid <| f i] : Monoid (∀ i : I, f i) :=
   }
 #align pi.monoid Pi.monoid
 #align pi.add_monoid Pi.addMonoid
+
+instance addMonoidWithOne [∀ i, AddMonoidWithOne <| f i] : AddMonoidWithOne (∀ i : I, f i) :=
+  { addMonoid with }
 
 @[to_additive]
 instance commMonoid [∀ i, CommMonoid <| f i] : CommMonoid (∀ i : I, f i) :=
@@ -148,6 +143,9 @@ instance group [∀ i, Group <| f i] : Group (∀ i : I, f i) :=
     }
 #align pi.group Pi.group
 #align pi.add_group Pi.addGroup
+
+instance addGroupWithOne [∀ i, AddGroupWithOne <| f i] : AddGroupWithOne (∀ i : I, f i) :=
+  { addGroup with }
 
 @[to_additive]
 instance commGroup [∀ i, CommGroup <| f i] : CommGroup (∀ i : I, f i) :=
@@ -224,11 +222,9 @@ instance commMonoidWithZero [∀ i, CommMonoidWithZero <| f i] : CommMonoidWithZ
   { monoidWithZero, commMonoid with }
 #align pi.comm_monoid_with_zero Pi.commMonoidWithZero
 
-instance addMonoidWithOne [∀ i, AddMonoidWithOne <| f i] : AddMonoidWithOne (∀ i : I, f i) :=
-  { addMonoid with }
-
-instance addGroupWithOne [∀ i, AddGroupWithOne <| f i] : AddGroupWithOne (∀ i : I, f i) :=
-  { addGroup with }
+instance semigroupWithZero [∀ i, SemigroupWithZero <| f i] : SemigroupWithZero (∀ i : I, f i) :=
+  { semigroup, mulZeroClass with }
+#align pi.semigroup_with_zero Pi.semigroupWithZero
 
 end Pi
 

--- a/Mathlib/Algebra/Group/Pi.lean
+++ b/Mathlib/Algebra/Group/Pi.lean
@@ -470,7 +470,7 @@ theorem Pi.update_eq_div_mul_single [∀ i, Group <| f i] (g : ∀ i : I, f i) (
   · simp [Function.update_noteq h.symm, h]
 #align pi.update_eq_div_mul_single Pi.update_eq_div_mul_single
 
-@[to_additive Pi.single_add_single_eq_single_add_single]
+@[to_additive]
 theorem Pi.mul_single_mul_mul_single_eq_mul_single_mul_mul_single {M : Type _} [cm : CommMonoid M]
     {k l m n : I} {u v : M} (hu : u ≠ 1) (hv : v ≠ 1) :
     (mulSingle k u : (a : I) → M) * mulSingle l v = mulSingle m u * mulSingle n v ↔ --!!correct?

--- a/Mathlib/Algebra/Group/Pi.lean
+++ b/Mathlib/Algebra/Group/Pi.lean
@@ -54,7 +54,7 @@ namespace Pi
 
 @[to_additive]
 instance semigroup [∀ i, Semigroup <| f i] : Semigroup (∀ i : I, f i) :=
-  { mul := (· * ·)
+  { mul := (· * ·) --!!should this be `Pi.instMul.mul` or is this ok?
     --pi_instance
     mul_assoc := by rename_i inst; intros; ext i; exact (inst i).mul_assoc _ _ _ }
 #align pi.semigroup Pi.semigroup
@@ -215,9 +215,8 @@ end Pi
 namespace MulHom
 
 @[to_additive]
-theorem coe_mul {M N} {mM : Mul M} {mN : CommSemigroup N} (f g : M →ₙ* N) :
-    (f * g : M → N) = fun x => f x * g x :=
-  rfl
+theorem coe_mul {M N} {_ : Mul M} {_ : CommSemigroup N} (f g : M →ₙ* N) : (f * g : M → N) =
+  fun x => f x * g x := rfl
 #align mul_hom.coe_mul MulHom.coe_mul
 
 end MulHom
@@ -229,8 +228,7 @@ given by `pi.mul_hom f x b = f b x`. -/
 @[to_additive
       "A family of add_hom `f a : γ → β a` defines a add_hom `pi.add_hom\nf : γ → Π a, β a` given by `pi.add_hom f x b = f b x`.",
   simps]
-def Pi.mulHom {γ : Type w} [∀ i, Mul (f i)] [Mul γ] (g : ∀ i, γ →ₙ* f i) :
-    γ →ₙ* ∀ i, f i where
+def Pi.mulHom {γ : Type w} [∀ i, Mul (f i)] [Mul γ] (g : ∀ i, γ →ₙ* f i) : γ →ₙ* ∀ i, f i where
   toFun x i := g i x
   map_mul' x y := funext fun i => (g i).map_mul x y
 #align pi.mul_hom Pi.mulHom
@@ -269,10 +267,9 @@ This is `function.eval i` as a `mul_hom`. -/
 @[to_additive
       "Evaluation of functions into an indexed collection of additive semigroups at a\npoint is an additive semigroup homomorphism.\nThis is `function.eval i` as an `add_hom`.",
   simps]
-def Pi.evalMulHom (i : I) : (∀ i, f i) →ₙ*
-      f i where
+def Pi.evalMulHom (i : I) : (∀ i, f i) →ₙ* f i where
   toFun g := g i
-  map_mul' x y := Pi.mul_apply _ _ i
+  map_mul' _ _ := Pi.mul_apply _ _ i
 #align pi.eval_mul_hom Pi.evalMulHom
 
 /-- `function.const` as a `mul_hom`. -/
@@ -291,7 +288,7 @@ See also `mul_hom.eval`. -/
 def MulHom.coeFn (α β : Type _) [Mul α] [CommSemigroup β] :
     (α →ₙ* β) →ₙ* α → β where
   toFun g := g
-  map_mul' x y := rfl
+  map_mul' _ _ := rfl
 #align mul_hom.coe_fn MulHom.coeFn
 
 /-- Semigroup homomorphism between the function spaces `I → α` and `I → β`, induced by a semigroup
@@ -302,7 +299,7 @@ homomorphism `f` between `α` and `β`. -/
 protected def MulHom.compLeft {α β : Type _} [Mul α] [Mul β] (f : α →ₙ* β) (I : Type _) :
     (I → α) →ₙ* I → β where
   toFun h := f ∘ h
-  map_mul' _ _ := by ext <;> simp
+  map_mul' _ _ := by ext; simp
 #align mul_hom.comp_left MulHom.compLeft
 
 end MulHom
@@ -321,7 +318,7 @@ def Pi.evalMonoidHom (i : I) :
     (∀ i, f i) →* f i where
   toFun g := g i
   map_one' := Pi.one_apply i
-  map_mul' x y := Pi.mul_apply _ _ i
+  map_mul' _ _ := Pi.mul_apply _ _ i
 #align pi.eval_monoid_hom Pi.evalMonoidHom
 
 /-- `function.const` as a `monoid_hom`. -/
@@ -343,7 +340,7 @@ def MonoidHom.coeFn (α β : Type _) [MulOneClass α] [CommMonoid β] :
     (α →* β) →* α → β where
   toFun g := g
   map_one' := rfl
-  map_mul' x y := rfl
+  map_mul' _ _ := rfl
 #align monoid_hom.coe_fn MonoidHom.coeFn
 
 /-- Monoid homomorphism between the function spaces `I → α` and `I → β`, induced by a monoid
@@ -354,8 +351,8 @@ homomorphism `f` between `α` and `β`. -/
 protected def MonoidHom.compLeft {α β : Type _} [MulOneClass α] [MulOneClass β] (f : α →* β)
     (I : Type _) : (I → α) →* I → β where
   toFun h := f ∘ h
-  map_one' := by ext <;> simp
-  map_mul' _ _ := by ext <;> simp
+  map_one' := by ext; dsimp; simp --!!why? bug?
+  map_mul' _ _ := by ext; simp
 #align monoid_hom.comp_left MonoidHom.compLeft
 
 end MonoidHom
@@ -372,7 +369,7 @@ variable (f)
 into a dependent family of values, as functions supported at a point.
 
 This is the `one_hom` version of `pi.mul_single`. -/
-@[to_additive ZeroHom.single
+@[to_additive
       "The zero-preserving homomorphism including a single value\ninto a dependent family of values, as functions supported at a point.\n\nThis is the `zero_hom` version of `pi.single`."]
 def OneHom.single [∀ i, One <| f i] (i : I) :
     OneHom (f i) (∀ i, f i) where
@@ -389,9 +386,9 @@ theorem OneHom.single_apply [∀ i, One <| f i] (i : I) (x : f i) :
 /-- The monoid homomorphism including a single monoid into a dependent family of additive monoids,
 as functions supported at a point.
 
-This is the `monoid_hom` version of `pi.mul_single`. -/
+This is the `monoid_hom` version of `Pi.mul_single`. -/
 @[to_additive
-      "The additive monoid homomorphism including a single additive\nmonoid into a dependent family of additive monoids, as functions supported at a point.\n\nThis is the `add_monoid_hom` version of `pi.single`."]
+      "The additive monoid homomorphism including a single additive\nmonoid into a dependent family of additive monoids, as functions supported at a point.\n\nThis is the `add_monoid_hom` version of `Pi.Single`."]
 def MonoidHom.single [∀ i, MulOneClass <| f i] (i : I) : f i →* ∀ i, f i :=
   { OneHom.single f i with map_mul' := mulSingle_op₂ (fun _ => (· * ·)) (fun _ => one_mul _) _ }
 #align monoid_hom.single MonoidHom.single
@@ -405,11 +402,11 @@ theorem MonoidHom.single_apply [∀ i, MulOneClass <| f i] (i : I) (x : f i) :
 /-- The multiplicative homomorphism including a single `mul_zero_class`
 into a dependent family of `mul_zero_class`es, as functions supported at a point.
 
-This is the `mul_hom` version of `pi.single`. -/
+This is the `mul_hom` version of `Pi.Single`. -/
 @[simps]
 def MulHom.single [∀ i, MulZeroClass <| f i] (i : I) :
     f i →ₙ* ∀ i, f i where
-  toFun := single i
+  toFun := Single i
   map_mul' := Pi.single_op₂ (fun _ => (· * ·)) (fun _ => zero_mul _) _
 #align mul_hom.single MulHom.single
 
@@ -434,7 +431,7 @@ theorem Pi.single_div [∀ i, Group <| f i] (i : I) (x y : f i) :
 #align pi.single_div Pi.single_div
 
 theorem Pi.single_mul [∀ i, MulZeroClass <| f i] (i : I) (x y : f i) :
-    single i (x * y) = single i x * single i y :=
+    Single i (x * y) = Single i x * Single i y :=
   (MulHom.single f i).map_mul x y
 #align pi.single_mul Pi.single_mul
 
@@ -474,9 +471,9 @@ theorem Pi.update_eq_div_mul_single [∀ i, Group <| f i] (g : ∀ i : I, f i) (
 #align pi.update_eq_div_mul_single Pi.update_eq_div_mul_single
 
 @[to_additive Pi.single_add_single_eq_single_add_single]
-theorem Pi.mul_single_mul_mul_single_eq_mul_single_mul_mul_single {M : Type _} [CommMonoid M]
+theorem Pi.mul_single_mul_mul_single_eq_mul_single_mul_mul_single {M : Type _} [cm : CommMonoid M]
     {k l m n : I} {u v : M} (hu : u ≠ 1) (hv : v ≠ 1) :
-    mulSingle k u * mulSingle l v = mulSingle m u * mulSingle n v ↔
+    (mulSingle k u : (a : I) → M) * mulSingle l v = mulSingle m u * mulSingle n v ↔ --!!correct?
       k = m ∧ l = n ∨ u = v ∧ k = n ∧ l = m ∨ u * v = 1 ∧ k = l ∧ m = n :=
   by
   refine' ⟨fun h => _, _⟩
@@ -484,7 +481,7 @@ theorem Pi.mul_single_mul_mul_single_eq_mul_single_mul_mul_single {M : Type _} [
     have hl := congr_fun h l
     have hm := (congr_fun h m).symm
     have hn := (congr_fun h n).symm
-    simp only [mul_apply, mul_single_apply, if_pos rfl] at hk hl hm hn
+    simp only [mul_apply, mulSingle_apply, if_pos rfl] at hk hl hm hn
     rcases eq_or_ne k m with (rfl | hkm)
     · refine' Or.inl ⟨rfl, not_ne_iff.mp fun hln => (hv _).elim⟩
       rcases eq_or_ne k l with (rfl | hkl)
@@ -494,7 +491,9 @@ theorem Pi.mul_single_mul_mul_single_eq_mul_single_mul_mul_single {M : Type _} [
       · rcases eq_or_ne k l with (rfl | hkl)
         · rw [if_neg hkm.symm, if_neg hkm.symm, one_mul, if_pos rfl] at hm
           exact Or.inr (Or.inr ⟨hm, rfl, rfl⟩)
-        · simpa only [if_neg hkm, if_neg hkl, mul_one] using hk
+        · simp only [if_neg hkm, if_neg hkl, mul_one] at hk
+          dsimp at hk
+          contradiction
       · rw [if_neg hkm.symm, if_neg hmn, one_mul, mul_one] at hm
         obtain rfl := (ite_ne_right_iff.mp (ne_of_eq_of_ne hm.symm hu)).1
         rw [if_neg hkm, if_neg hkm, one_mul, mul_one] at hk
@@ -503,7 +502,7 @@ theorem Pi.mul_single_mul_mul_single_eq_mul_single_mul_mul_single {M : Type _} [
   · rintro (⟨rfl, rfl⟩ | ⟨rfl, rfl, rfl⟩ | ⟨h, rfl, rfl⟩)
     · rfl
     · apply mul_comm
-    · simp_rw [← Pi.mul_single_mul, h, mul_single_one]
+    · simp_rw [← Pi.mul_single_mul, h, mulSingle_one]
 #align
   pi.mul_single_mul_mul_single_eq_mul_single_mul_mul_single Pi.mul_single_mul_mul_single_eq_mul_single_mul_mul_single
 
@@ -511,27 +510,28 @@ end Single
 
 namespace Function
 
+set_option pp.all true
 @[simp, to_additive]
 theorem update_one [∀ i, One (f i)] [DecidableEq I] (i : I) : update (1 : ∀ i, f i) i 1 = 1 :=
-  update_eq_self i 1
+  update_eq_self i (1 : (a : I) → f a)
 #align function.update_one Function.update_one
 
 @[to_additive]
 theorem update_mul [∀ i, Mul (f i)] [DecidableEq I] (f₁ f₂ : ∀ i, f i) (i : I) (x₁ : f i)
     (x₂ : f i) : update (f₁ * f₂) i (x₁ * x₂) = update f₁ i x₁ * update f₂ i x₂ :=
-  funext fun j => (apply_update₂ (fun i => (· * ·)) f₁ f₂ i x₁ x₂ j).symm
+  funext fun j => (apply_update₂ (fun _ => (· * ·)) f₁ f₂ i x₁ x₂ j).symm
 #align function.update_mul Function.update_mul
 
 @[to_additive]
 theorem update_inv [∀ i, Inv (f i)] [DecidableEq I] (f₁ : ∀ i, f i) (i : I) (x₁ : f i) :
     update f₁⁻¹ i x₁⁻¹ = (update f₁ i x₁)⁻¹ :=
-  funext fun j => (apply_update (fun i => Inv.inv) f₁ i x₁ j).symm
+  funext fun j => (apply_update (fun _ => Inv.inv) f₁ i x₁ j).symm
 #align function.update_inv Function.update_inv
 
 @[to_additive]
 theorem update_div [∀ i, Div (f i)] [DecidableEq I] (f₁ f₂ : ∀ i, f i) (i : I) (x₁ : f i)
     (x₂ : f i) : update (f₁ / f₂) i (x₁ / x₂) = update f₁ i x₁ / update f₂ i x₂ :=
-  funext fun j => (apply_update₂ (fun i => (· / ·)) f₁ f₂ i x₁ x₂ j).symm
+  funext fun j => (apply_update₂ (fun _ => (· / ·)) f₁ f₂ i x₁ x₂ j).symm
 #align function.update_div Function.update_div
 
 variable [One α] [Nonempty ι] {a : α}
@@ -543,7 +543,7 @@ theorem const_eq_one : const ι a = 1 ↔ a = 1 :=
 
 @[to_additive]
 theorem const_ne_one : const ι a ≠ 1 ↔ a ≠ 1 :=
-  const_eq_one.Not
+  Iff.not const_eq_one
 #align function.const_ne_one Function.const_ne_one
 
 end Function

--- a/Mathlib/Algebra/Group/Pi.lean
+++ b/Mathlib/Algebra/Group/Pi.lean
@@ -59,6 +59,7 @@ instance semigroup [∀ i, Semigroup <| f i] : Semigroup (∀ i : I, f i) :=
     mul_assoc := by rename_i inst; intros; ext i; exact (inst i).mul_assoc _ _ _ }
 #align pi.semigroup Pi.semigroup
 
+--!!rewrite to use MulZeroClass?
 instance semigroupWithZero [∀ i, SemigroupWithZero <| f i] : SemigroupWithZero (∀ i : I, f i) :=
   { semigroup with
     zero := (0 : ∀ i, f i)
@@ -127,7 +128,7 @@ instance divisionMonoid [∀ i, DivisionMonoid <| f i] : DivisionMonoid (∀ i, 
     mul_inv_rev := by rename_i inst _ _; intros; ext i; exact (inst i).mul_inv_rev _ _
     inv_eq_of_mul := by
       rename_i inst _ _; intros; ext i; apply (inst i).inv_eq_of_mul _ _ _;
-      rename_i ab1; exact congr_fun ab1 i
+      rename_i h; exact congr_fun h i
   }
 
 @[to_additive Pi.subtractionCommMonoid]
@@ -136,102 +137,77 @@ instance [∀ i, DivisionCommMonoid <| f i] : DivisionCommMonoid (∀ i, f i) :=
 
 @[to_additive]
 instance group [∀ i, Group <| f i] : Group (∀ i : I, f i) :=
-{ divInvMonoid with
-  --pi_instance
-  mul_left_inv := by rename_i inst _; intros; ext i; exact (inst i).mul_left_inv _
-  }
+  { divInvMonoid with
+    --pi_instance
+    mul_left_inv := by rename_i inst _; intros; ext i; exact (inst i).mul_left_inv _
+    }
 #align pi.group Pi.group
 
 @[to_additive]
 instance commGroup [∀ i, CommGroup <| f i] : CommGroup (∀ i : I, f i) :=
-{ one := (1 : ∀ i, f i)
-  mul := (· * ·)
-  inv := Inv.inv
-  div := Div.div
-  npow := Monoid.npow
-  zpow := DivInvMonoid.zpow }
+  { group, commMonoid with }
 #align pi.comm_group Pi.commGroup
 
 @[to_additive AddLeftCancelSemigroup]
 instance leftCancelSemigroup [∀ i, LeftCancelSemigroup <| f i] :
-    LeftCancelSemigroup (∀ i : I, f i) := by
-  refine_struct { mul := (· * ·) } <;> pi_instance_derive_field
+    LeftCancelSemigroup (∀ i : I, f i) :=
+  { semigroup with
+    --pi_instance
+    mul_left_cancel := by
+      rename_i inst _; intros; ext i; apply (inst i).mul_left_cancel _ _ _;
+      rename_i h; exact congr_fun h i
+  }
 #align pi.left_cancel_semigroup Pi.leftCancelSemigroup
 
 @[to_additive AddRightCancelSemigroup]
 instance rightCancelSemigroup [∀ i, RightCancelSemigroup <| f i] :
-    RightCancelSemigroup (∀ i : I, f i) := by
-  refine_struct { mul := (· * ·) } <;> pi_instance_derive_field
+    RightCancelSemigroup (∀ i : I, f i) :=
+  { semigroup with
+    mul_right_cancel := by
+      rename_i inst _; intros; ext i; apply (inst i).mul_right_cancel _ _ _;
+      rename_i h; exact congr_fun h i
+  }
 #align pi.right_cancel_semigroup Pi.rightCancelSemigroup
 
 @[to_additive AddLeftCancelMonoid]
-instance leftCancelMonoid [∀ i, LeftCancelMonoid <| f i] : LeftCancelMonoid (∀ i : I, f i) := by
-  refine_struct
-      { one := (1 : ∀ i, f i)
-        mul := (· * ·)
-        npow := Monoid.npow } <;>
-    pi_instance_derive_field
+instance leftCancelMonoid [∀ i, LeftCancelMonoid <| f i] : LeftCancelMonoid (∀ i : I, f i) :=
+  { leftCancelSemigroup, monoid with }
 #align pi.left_cancel_monoid Pi.leftCancelMonoid
 
 @[to_additive AddRightCancelMonoid]
-instance rightCancelMonoid [∀ i, RightCancelMonoid <| f i] : RightCancelMonoid (∀ i : I, f i) := by
-  refine_struct
-      { one := (1 : ∀ i, f i)
-        mul := (· * ·)
-        npow := Monoid.npow.. } <;>
-    pi_instance_derive_field
+instance rightCancelMonoid [∀ i, RightCancelMonoid <| f i] : RightCancelMonoid (∀ i : I, f i) :=
+  { rightCancelSemigroup, monoid with }
 #align pi.right_cancel_monoid Pi.rightCancelMonoid
 
 @[to_additive AddCancelMonoid]
-instance cancelMonoid [∀ i, CancelMonoid <| f i] : CancelMonoid (∀ i : I, f i) := by
-  refine_struct
-      { one := (1 : ∀ i, f i)
-        mul := (· * ·)
-        npow := Monoid.npow } <;>
-    pi_instance_derive_field
+instance cancelMonoid [∀ i, CancelMonoid <| f i] : CancelMonoid (∀ i : I, f i) :=
+  { leftCancelMonoid, rightCancelMonoid with } --!!trim?
 #align pi.cancel_monoid Pi.cancelMonoid
 
 @[to_additive AddCancelCommMonoid]
-instance cancelCommMonoid [∀ i, CancelCommMonoid <| f i] : CancelCommMonoid (∀ i : I, f i) := by
-  refine_struct
-      { one := (1 : ∀ i, f i)
-        mul := (· * ·)
-        npow := Monoid.npow } <;>
-    pi_instance_derive_field
+instance cancelCommMonoid [∀ i, CancelCommMonoid <| f i] : CancelCommMonoid (∀ i : I, f i) :=
+  { leftCancelMonoid, commMonoid with } --!!trim?
 #align pi.cancel_comm_monoid Pi.cancelCommMonoid
 
-instance mulZeroClass [∀ i, MulZeroClass <| f i] : MulZeroClass (∀ i : I, f i) := by
-  refine_struct
-      { zero := (0 : ∀ i, f i)
-        mul := (· * ·).. } <;>
-    pi_instance_derive_field
+instance mulZeroClass [∀ i, MulZeroClass <| f i] : MulZeroClass (∀ i : I, f i) :=
+  { zero := (0 : ∀ i, f i)
+    mul := (· * ·)
+    --pi_instance
+    zero_mul := by rename_i inst; intro; ext i; exact (inst i).zero_mul _
+    mul_zero := by rename_i inst; intro; ext i; exact (inst i).mul_zero _
+}
 #align pi.mul_zero_class Pi.mulZeroClass
 
-instance mulZeroOneClass [∀ i, MulZeroOneClass <| f i] : MulZeroOneClass (∀ i : I, f i) := by
-  refine_struct
-      { zero := (0 : ∀ i, f i)
-        one := (1 : ∀ i, f i)
-        mul := (· * ·).. } <;>
-    pi_instance_derive_field
+instance mulZeroOneClass [∀ i, MulZeroOneClass <| f i] : MulZeroOneClass (∀ i : I, f i) :=
+  { mulZeroClass, mulOneClass with }
 #align pi.mul_zero_one_class Pi.mulZeroOneClass
 
-instance monoidWithZero [∀ i, MonoidWithZero <| f i] : MonoidWithZero (∀ i : I, f i) := by
-  refine_struct
-      { zero := (0 : ∀ i, f i)
-        one := (1 : ∀ i, f i)
-        mul := (· * ·)
-        npow := Monoid.npow } <;>
-    pi_instance_derive_field
+instance monoidWithZero [∀ i, MonoidWithZero <| f i] : MonoidWithZero (∀ i : I, f i) :=
+  { monoid, mulZeroClass with } --!!trim?
 #align pi.monoid_with_zero Pi.monoidWithZero
 
 instance commMonoidWithZero [∀ i, CommMonoidWithZero <| f i] : CommMonoidWithZero (∀ i : I, f i) :=
-  by
-  refine_struct
-      { zero := (0 : ∀ i, f i)
-        one := (1 : ∀ i, f i)
-        mul := (· * ·)
-        npow := Monoid.npow } <;>
-    pi_instance_derive_field
+  { monoidWithZero, commMonoid with } --!!trim?
 #align pi.comm_monoid_with_zero Pi.commMonoidWithZero
 
 end Pi

--- a/Mathlib/Data/Int/Cast/Lemmas.lean
+++ b/Mathlib/Data/Int/Cast/Lemmas.lean
@@ -359,30 +359,6 @@ theorem Sum.elim_int_cast_int_cast {α β γ : Type _} [IntCast γ] (n : ℤ) :
   @Sum.elim_lam_const_lam_const α β γ n
 #align sum.elim_int_cast_int_cast Sum.elim_int_cast_int_cast
 
-namespace Pi
-
-variable {π : ι → Type _} [∀ i, AddGroupWithOne (π i)]
-
-/-
-Porting note: was `by refine_struct { .. } <;> pi_instance_derive_field`.
-@fpvandoorn suggests this should be moved to `Algebra.Group.Pi`,
-so that we can extend the `AddGroup` instance.
-
-See discussion at https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/not.20porting.20pi_instance
--/
-instance : AddGroupWithOne (∀ i, π i) :=
-{ add_zero := fun f => funext fun a => by simp,
-  zero_add := fun f => funext fun a => by simp,
-  add_assoc := fun f g h => funext fun a => by simp [add_assoc],
-  add_left_neg := fun f => funext fun a => by simp,
-  sub_eq_add_neg := fun f g => funext fun a => by simp [sub_eq_add_neg],
-  natCast_zero := funext fun a => by simp [natCast],
-  natCast_succ := fun n => funext fun a => by simp [natCast],
-  intCast_ofNat := fun n => funext fun a => by simp [intCast],
-  intCast_negSucc := fun n => funext fun a => by simp [intCast], }
-
-end Pi
-
 namespace MulOpposite
 
 variable [AddGroupWithOne α]

--- a/Mathlib/Data/Nat/Cast/Basic.lean
+++ b/Mathlib/Data/Nat/Cast/Basic.lean
@@ -291,26 +291,6 @@ theorem Sum.elim_natCast_natCast {α β γ : Type _} [NatCast γ] (n : ℕ) :
     Sum.elim (n : α → γ) (n : β → γ) = n :=
   @Sum.elim_lam_const_lam_const α β γ n
 
-namespace Pi
-
-variable {π : α → Type _} [∀ a, AddMonoidWithOne (π a)]
-
-/-
-Porting note: was `by refine_struct { .. } <;> pi_instance_derive_field`.
-@fpvandoorn suggests this should be moved to `Algebra.Group.Pi`,
-so that we can extend the `AddMonoid` instance.
-
-See discussion at https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/not.20porting.20pi_instance
--/
-instance : AddMonoidWithOne (∀ a, π a) :=
-{ add_zero := fun f => funext fun a => by simp,
-  zero_add := fun f => funext fun a => by simp,
-  add_assoc := fun f g h => funext fun a => by simp [add_assoc],
-  natCast_zero := funext fun a => by simp [natCast],
-  natCast_succ := fun n => funext fun a => by simp [natCast] }
-
-end Pi
-
 /-! ### Order dual -/
 
 

--- a/Mathlib/Data/Pi/Algebra.lean
+++ b/Mathlib/Data/Pi/Algebra.lean
@@ -187,7 +187,7 @@ variable [DecidableEq I]
 variable [∀ i, One (f i)] [∀ i, One (g i)] [∀ i, One (h i)]
 
 /-- The function supported at `i`, with value `x` there, and `1` elsewhere. -/
-@[to_additive Pi.Single "The function supported at `i`, with value `x` there, and `0` elsewhere."]
+@[to_additive "The function supported at `i`, with value `x` there, and `0` elsewhere."]
 def mulSingle (i : I) (x : f i) : ∀ (j : I), f j :=
   Function.update 1 i x
 
@@ -196,25 +196,29 @@ theorem mulSingle_eq_same (i : I) (x : f i) : mulSingle i x i = x :=
   Function.update_same i x _
 
 #align pi.mul_single_eq_same Pi.mulSingle_eq_same
+#align pi.single_eq_same Pi.single_eq_same
 
 @[simp, to_additive]
 theorem mulSingle_eq_of_ne {i i' : I} (h : i' ≠ i) (x : f i) : mulSingle i x i' = 1 :=
   Function.update_noteq h x _
 
 #align pi.mul_single_eq_of_ne Pi.mulSingle_eq_of_ne
+#align pi.single_eq_of_ne Pi.single_eq_of_ne
 
 /-- Abbreviation for `mulSingle_eq_of_ne h.symm`, for ease of use by `simp`. -/
-@[simp, to_additive "Abbreviation for `single_eq_of_ne h.symm`, for ease of\nuse by `simp`."]
+@[simp, to_additive "Abbreviation for `single_eq_of_ne h.symm`, for ease of use by `simp`."]
 theorem mulSingle_eq_of_ne' {i i' : I} (h : i ≠ i') (x : f i) : mulSingle i x i' = 1 :=
   mulSingle_eq_of_ne h.symm x
 
 #align pi.mul_single_eq_of_ne' Pi.mulSingle_eq_of_ne'
+#align pi.single_eq_of_ne' Pi.single_eq_of_ne'
 
 @[simp, to_additive]
 theorem mulSingle_one (i : I) : mulSingle i (1 : f i) = 1 :=
   Function.update_eq_self _ _
 
 #align pi.mul_single_one Pi.mulSingle_one
+#align pi.single_zero Pi.single_zero
 
 -- Porting notes:
 -- 1) Why do I have to specify the type of `mulSingle i x` explicitly?
@@ -227,6 +231,7 @@ theorem mulSingle_apply [One β] (i : I) (x : β) (i' : I) :
   Function.update_apply (1 : I → β) i x i'
 
 #align pi.mul_single_apply Pi.mulSingle_apply
+#align pi.single_apply Pi.single_apply
 
 -- Porting notes : Same as above.
 /-- On non-dependent functions, `Pi.mulSingle` is symmetric in the two indices. -/
@@ -236,6 +241,7 @@ theorem mulSingle_comm [One β] (i : I) (x : β) (i' : I) :
   simp [mulSingle_apply, eq_comm]
 
 #align pi.mul_single_comm Pi.mulSingle_comm
+#align pi.single_comm Pi.single_comm
 
 @[to_additive]
 theorem apply_mulSingle (f' : ∀ i, f i → g i) (hf' : ∀ i, f' i 1 = 1) (i : I) (x : f i) (j : I) :
@@ -243,6 +249,7 @@ theorem apply_mulSingle (f' : ∀ i, f i → g i) (hf' : ∀ i, f' i 1 = 1) (i :
   simpa only [Pi.one_apply, hf', mulSingle] using Function.apply_update f' 1 i x j
 
 #align pi.apply_mul_single Pi.apply_mulSingle
+#align pi.apply_single Pi.apply_single
 
 @[to_additive apply_single₂]
 theorem apply_mulSingle₂ (f' : ∀ i, f i → g i → h i) (hf' : ∀ i, f' i 1 1 = 1) (i : I)
@@ -251,10 +258,10 @@ theorem apply_mulSingle₂ (f' : ∀ i, f i → g i → h i) (hf' : ∀ i, f' i 
   by_cases h : j = i
   · subst h
     simp only [mulSingle_eq_same]
-
   · simp only [mulSingle_eq_of_ne h, hf']
 
 #align pi.apply_mul_single₂ Pi.apply_mulSingle₂
+#align pi.apply_single₂ Pi.apply_single₂
 
 @[to_additive]
 theorem mulSingle_op {g : I → Type _} [∀ i, One (g i)] (op : ∀ i, f i → g i)
@@ -263,6 +270,7 @@ theorem mulSingle_op {g : I → Type _} [∀ i, One (g i)] (op : ∀ i, f i → 
   Eq.symm <| funext <| apply_mulSingle op h i x
 
 #align pi.mul_single_op Pi.mulSingle_op
+#align pi.single_op Pi.single_op
 
 @[to_additive]
 theorem mulSingle_op₂ {g₁ g₂ : I → Type _} [∀ i, One (g₁ i)] [∀ i, One (g₂ i)]
@@ -270,21 +278,24 @@ theorem mulSingle_op₂ {g₁ g₂ : I → Type _} [∀ i, One (g₁ i)] [∀ i,
     mulSingle i (op i x₁ x₂) = fun j => op j (mulSingle i x₁ j) (mulSingle i x₂ j) :=
   Eq.symm <| funext <| apply_mulSingle₂ op h i x₁ x₂
 
-variable (f)
-
 #align pi.mul_single_op₂ Pi.mulSingle_op₂
+#align pi.single_op₂ Pi.single_op₂
+
+variable (f)
 
 @[to_additive]
 theorem mulSingle_injective (i : I) : Function.Injective (mulSingle i : f i → ∀ i, f i) :=
   Function.update_injective _ i
 
 #align pi.mul_single_injective Pi.mulSingle_injective
+#align pi.single_injective Pi.single_injective
 
 @[simp, to_additive]
 theorem mulSingle_inj (i : I) {x y : f i} : mulSingle i x = mulSingle i y ↔ x = y :=
   (Pi.mulSingle_injective _ _).eq_iff
 
 #align pi.mul_single_inj Pi.mulSingle_inj
+#align pi.single_inj Pi.single_inj
 
 end
 
@@ -377,6 +388,7 @@ theorem Subsingleton.pi_mulSingle_eq {α : Type _} [DecidableEq I] [Subsingleton
   funext fun j => by rw [Subsingleton.elim j i, Pi.mulSingle_eq_same]
 
 #align subsingleton.pi_mul_single_eq Subsingleton.pi_mulSingle_eq
+#align subsingleton.pi_single_eq Subsingleton.pi_single_eq
 
 namespace Sum
 
@@ -398,6 +410,8 @@ theorem elim_one_mulSingle [DecidableEq α] [DecidableEq β] [One γ] (i : β) (
 
 #align sum.elim_mul_single_one Sum.elim_mulSingle_one
 #align sum.elim_one_mul_single Sum.elim_one_mulSingle
+#align sum.elim_single_zero Sum.elim_single_zero
+#align sum.elim_zero_single Sum.elim_zero_single
 
 @[to_additive]
 theorem elim_inv_inv [Inv γ] : Sum.elim a⁻¹ b⁻¹ = (Sum.elim a b)⁻¹ :=

--- a/Mathlib/Data/Pi/Algebra.lean
+++ b/Mathlib/Data/Pi/Algebra.lean
@@ -191,6 +191,9 @@ variable [∀ i, One (f i)] [∀ i, One (g i)] [∀ i, One (h i)]
 def mulSingle (i : I) (x : f i) : ∀ (j : I), f j :=
   Function.update 1 i x
 
+#align pi.mul_single Pi.mulSingle
+#align pi.single Pi.single
+
 @[simp, to_additive]
 theorem mulSingle_eq_same (i : I) (x : f i) : mulSingle i x i = x :=
   Function.update_same i x _


### PR DESCRIPTION
mathlib3port tracking sha: `b3f25363ae62cb169e72cd6b8b1ac97bacf21ca7`

### Porting notes

* Moved `AddMonoidWithOne` and `AddGroupWithOne` here from their original files.
* Corrected the name of `Pi.Single` to `Pi.single` in `Data.Pi.Algebra`, on which this depends. (Note: this change was only done in the final two commits, which can be split off into a subsequent PR for a good history if need be.)
* Replaced explicit data fields by sourcing previously-defined instances where possible, as per [this zulip discussion](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/not.20porting.20pi_instance)
* Changed a name: `update_eq_div_mulSingle` => `update_eq_div_mul_mulSingle`, as it involves a multiplication of two `mulSingle`s. (Note: the additive version in mathlib is `update_eq_sub_add_single`, and `to_additive` "agrees" that `update_eq_div_mul_mulSingle` is the right name in mathlib4.)

### Review questions

* Are we sure about using instances as sources where possible? Just want to double-check that it won't cause any problems.
* If so, should the "highest-up" or "lowest-down" instances be used for sourcing when diamonds occur? E.g. `Foo` extends `Bar0`, `Bar1`, and both have relevant instances `bar0`, `bar1`. However, `Bar1` extends `Baz`, and we also have a relevant instance `baz` which suffices for everything not in `Bar0`. Should the instance for `Foo` start `{ bar0, bar1 with ... }` or `{ bar0, baz with ... }`? Does it matter?
* Should the data `mul := (· * ·)`, `zero := (0 : ∀ i, f i)` remain explicit or be obtained by sourcing `Pi.instMul`, `Pi.instZero` respectively?