### PR TITLE
[Merged by Bors] - chore: clean up `positivity` stub theory

### DIFF
--- a/Mathlib/Tactic/Positivity/Basic.lean
+++ b/Mathlib/Tactic/Positivity/Basic.lean
@@ -86,11 +86,15 @@ such that `positivity` successfully recognises both `a` and `b`. -/
     have pb' : Q(by clear! «$zα» «$pα»; exact 0 ≤ $b) := pb
     pure (.nonnegative (by clear! zα pα; exact q(mul_nonneg $pa' $pb') : Expr))
   | .positive pa, .nonzero pb =>
-    let _a ← synthInstanceQ (q(NoZeroDivisors $α) : Q(Prop))
-    pure (.nonzero (q(mul_ne_zero_of_pos_of_ne_zero $pa $pb) : Expr))
+    have pa' : Q(by clear! «$zα» «$pα»; exact 0 < $a) := pa
+    have pb' : Q(by clear! «$zα»; exact $b ≠ 0) := pb
+    let _a ← synthInstanceQ (q(by clear! «$zα»; exact NoZeroDivisors $α) : Q(Prop))
+    pure (.nonzero (q(mul_ne_zero_of_pos_of_ne_zero $pa' $pb') : Expr))
   | .nonzero pa, .positive pb =>
-    let _a ← synthInstanceQ (q(NoZeroDivisors $α) : Q(Prop))
-    pure (.nonzero (q(mul_ne_zero_of_ne_zero_of_pos $pa $pb) : Expr))
+    have pa' : Q(by clear! «$zα»; exact $a ≠ 0) := pa
+    have pb' : Q(by clear! «$zα» «$pα»; exact 0 < $b) := pb
+    let _a ← synthInstanceQ (q(by clear! «$zα»; exact NoZeroDivisors $α) : Q(Prop))
+    pure (.nonzero (q(mul_ne_zero_of_ne_zero_of_pos $pa' $pb') : Expr))
   | .nonzero pa, .nonzero pb =>
     let _a ← synthInstanceQ (q(NoZeroDivisors $α) : Q(Prop))
     pure (.nonzero (q(mul_ne_zero $pa $pb) : Expr))

--- a/test/positivity.lean
+++ b/test/positivity.lean
@@ -8,10 +8,6 @@ This tactic proves goals of the form `0 ≤ a` and `0 < a`.
 
 open Function
 
-instance [OrderedSemiring α] : OrderedMonoidWithZero α :=
-  { inferInstanceAs (PartialOrder α), inferInstanceAs (MonoidWithZero α) with
-    zero_le_one := sorry }
-
 instance [LinearOrderedRing α] : OrderedSemiring α := by
   refine' { inferInstanceAs (LinearOrderedRing α) with .. } <;> sorry
 
@@ -210,7 +206,7 @@ example {a b : ℤ} (ha : 3 < a) (hb : b ≥ 4) : 0 < 3 * a ^ 2 * b + b * 7 + 14
 --   0 < max (a / b) c :=
 -- by positivity
 
--- example : 0 ≤ max 3 4 := by positivity
+example : 0 ≤ max 3 4 := by positivity
 
 -- example {b : ℤ} : 0 ≤ max (-3) (b ^ 2) := by positivity
 
@@ -247,7 +243,7 @@ example {a b : ℤ} (ha : 3 < a) (hb : b ≥ 4) : 0 < 3 * a ^ 2 * b + b * 7 + 14
 
 /- ### Canonical orders -/
 
--- example {a : ℕ} : 0 ≤ a := by positivity
+example {a : ℕ} : 0 ≤ a := by positivity
 -- example {a : ℚ≥0} : 0 ≤ a := by positivity
 -- example {a : ℝ≥0} : 0 ≤ a := by positivity
 -- example {a : ℝ≥0∞} : 0 ≤ a := by positivity

--- a/test/positivity.lean
+++ b/test/positivity.lean
@@ -1,3 +1,4 @@
+import Mathlib.Algebra.Abs
 import Mathlib.Data.Rat.Order
 import Mathlib.Tactic.Positivity
 

--- a/test/positivity.lean
+++ b/test/positivity.lean
@@ -1,5 +1,5 @@
+import Mathlib.Data.Rat.Order
 import Mathlib.Tactic.Positivity
-import Mathlib.Algebra.Abs
 
 /-! # Tests for the `positivity` tactic
 
@@ -7,24 +7,6 @@ This tactic proves goals of the form `0 ≤ a` and `0 < a`.
 -/
 
 open Function
-
-instance [LinearOrderedRing α] : OrderedSemiring α := by
-  refine' { inferInstanceAs (LinearOrderedRing α) with .. } <;> sorry
-
-instance [OrderedSemiring α] : CovariantClass α α (·+·) (·<·) := sorry
-
-notation "ℚ" => Rat
-instance : LinearOrder ℚ := by refine' { lt := (·<·), le := (·≤·), .. } <;> sorry
-instance : OrderedSemiring ℕ := by
-  refine' { inferInstanceAs (CommSemiring ℕ), inferInstanceAs (LinearOrder ℕ) with .. } <;> sorry
-instance : NoZeroDivisors ℕ := sorry
-instance : OrderedSemiring ℤ := by
-  refine' { inferInstanceAs (CommRing ℤ), inferInstanceAs (LinearOrder ℤ) with .. } <;> sorry
-instance : NoZeroDivisors ℤ := sorry
-instance : CommRing ℚ := by refine' { zero := 0, one := 1, add := (·+·), mul := (·*·), .. } <;> sorry
-instance : LinearOrderedRing ℚ := by
-  refine' { inferInstanceAs (CommRing ℚ), inferInstanceAs (LinearOrder ℚ) with .. } <;> sorry
-instance : NoZeroDivisors ℚ := sorry
 
 variable {ι α β : Type _}
 


### PR DESCRIPTION
Restore the lemmas for the so-far-implemented `positivity` extensions to their mathlib3 positions, attributes (they were all `private`), and typeclasses.  Also remove nonsense instances of some typeclasses in the test file.

This things are all newly possible now that the underlying theory has been implemented.