### PR TITLE
[Merged by Bors] - fix: Data.List.Defs

### DIFF
--- a/Mathlib/Control/Traversable/Basic.lean
+++ b/Mathlib/Control/Traversable/Basic.lean
@@ -9,6 +9,7 @@ Authors: Simon Hudon
 ! if you have ported upstream changes.
 -/
 import Mathlib.Data.List.Defs
+import Mathlib.Data.List.Basic
 
 /-!
 # Traversable type class

--- a/Mathlib/Control/Traversable/Basic.lean
+++ b/Mathlib/Control/Traversable/Basic.lean
@@ -9,7 +9,7 @@ Authors: Simon Hudon
 ! if you have ported upstream changes.
 -/
 import Mathlib.Data.List.Defs
-import Mathlib.Data.List.Basic
+import Mathlib.Data.Option.Defs
 
 /-!
 # Traversable type class

--- a/Mathlib/Data/List/Chain.lean
+++ b/Mathlib/Data/List/Chain.lean
@@ -5,6 +5,7 @@ Authors: Mario Carneiro, Kenny Lau, Yury Kudryashov
 -/
 import Std.Data.List.Basic
 import Mathlib.Init.Logic
+import Mathlib.Data.List.Defs
 import Mathlib.Data.List.Pairwise
 
 /-!
@@ -18,11 +19,6 @@ sometime soon.
 -/
 
 namespace List
-
-@[simp]
-theorem chain_cons {a b : α} {l : List α} : Chain R a (b :: l) ↔ R a b ∧ Chain R b l :=
-  ⟨fun p ↦ by cases p with | cons n p => exact ⟨n, p⟩,
-   fun ⟨n, p⟩ ↦ p.cons n⟩
 
 theorem Chain.imp' {R S : α → α → Prop} (HRS : ∀ ⦃a b⦄, R a b → S a b) {a b : α}
     (Hab : ∀ ⦃c⦄, R a c → S b c) {l : List α} (p : Chain R a l) : Chain S b l := by

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -50,18 +50,22 @@ instance [DecidableEq α] : SDiff (List α) :=
 -- porting notes: see
 -- https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/List.2Ehead/near/313204716
 -- for the fooI naming convention.
-/-- "inhabited" `get` function: returns `default` instead of `none` in the case
+/-- "Inhabited" `get` function: returns `default` instead of `none` in the case
   that the index is out of bounds. -/
 def getI [Inhabited α] (l : List α) (n : Nat) : α :=
   getD l n default
 #align list.inth List.getI
+
+/-- "Inhabited" `take` function: Take `n` elements from a list `l`. If `l` has less than `n` elements, append `n - length l` elements `default`. -/
+def takeI [Inhabited α] (n : Nat) (l : List α): List α :=
+  takeD n l default
+#align list.take' List.takeI
 
 #align list.modify_nth_tail List.modifyNthTail
 #align list.modify_head List.modifyHead
 #align list.modify_nth List.modifyNth
 #align list.modify_last List.modifyLast
 #align list.insert_nth List.insertNth
-#align list.take' List.takeD
 #align list.take_while List.takeWhile
 #align list.scanl List.scanl
 #align list.scanr List.scanr

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -57,7 +57,7 @@ def getI [Inhabited α] (l : List α) (n : Nat) : α :=
 
 /-- "Inhabited" `take` function: Take `n` elements from a list `l`. If `l` has less than `n`
   elements, append `n - length l` elements `default`. -/
-def takeI [Inhabited α] (n : Nat) (l : List α): List α :=
+def takeI [Inhabited α] (n : Nat) (l : List α) : List α :=
   takeD n l default
 #align list.take' List.takeI
 

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -10,7 +10,6 @@ Authors: Parikshit Khanna, Jeremy Avigad, Leonardo de Moura, Floris van Doorn, M
 -/
 import Mathlib.Algebra.Group.Defs
 import Mathlib.Control.Functor
-import Mathlib.Data.List.Chain
 import Mathlib.Data.Nat.Basic
 import Mathlib.Logic.Basic
 import Std.Tactic.Lint.Basic
@@ -357,9 +356,14 @@ infixr:82 " ×ˢ " => List.product
 #align list.pw_filter List.pwFilter
 #align list.chain List.Chain
 #align list.chain' List.Chain'
-#align list.chain_cons List.chain_cons
 
 section Chain
+
+@[simp]
+theorem chain_cons {a b : α} {l : List α} : Chain R a (b :: l) ↔ R a b ∧ Chain R b l :=
+  ⟨fun p ↦ by cases p with | cons n p => exact ⟨n, p⟩,
+   fun ⟨n, p⟩ ↦ p.cons n⟩
+#align list.chain_cons List.chain_cons
 
 noncomputable instance decidableChain [DecidableRel R] (a : α) (l : List α) :
     Decidable (Chain R a l) := by

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -55,7 +55,8 @@ def getI [Inhabited α] (l : List α) (n : Nat) : α :=
   getD l n default
 #align list.inth List.getI
 
-/-- "Inhabited" `take` function: Take `n` elements from a list `l`. If `l` has less than `n` elements, append `n - length l` elements `default`. -/
+/-- "Inhabited" `take` function: Take `n` elements from a list `l`. If `l` has less than `n`
+  elements, append `n - length l` elements `default`. -/
 def takeI [Inhabited α] (n : Nat) (l : List α): List α :=
   takeD n l default
 #align list.take' List.takeI


### PR DESCRIPTION
Fixes some problems surrounding `Data.List.Defs` that were affecting the ongoing port of `Data.List.Basic`.
* introduces `takeI` as a faithful port of `take'` and fixes the align
  * `take'` was previously erroneously aligned with `takeD`. `takeD` uses an explicitly-provided argument as a default whereas `takeI` uses`Inhabited`'s `default`.
* reverses the dependency `Data.List.Chain` → `Data.List.Defs` to `Data.List.Defs` → `Data.List.Chain`
  * This was causing a circular dependency for `Data.List.Basic` when it attempted to import `Data.List.Defs`.
  * We move `chain_cons` from `Data.List.Chain` into `Data.List.Defs`.
  * All of these changes are in keeping mathlib3's original structure.
  * We have to supplement `Control.Traversable.Basic`'s imports, since it was previously relying on `Data.Option.Defs` via `Data.List.Defs` ← `Data.List.Chain` ← ...

See [this Zulip conversation](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Data.2EList.2EBasic/near/316851513) for more context.