### PR TITLE
[Merged by Bors] - fix: improved transitivity, handles `HEq.trans`

### DIFF
--- a/Mathlib/CategoryTheory/Functor/FullyFaithful.lean
+++ b/Mathlib/CategoryTheory/Functor/FullyFaithful.lean
@@ -327,10 +327,6 @@ protected def Faithful.div (F : C ⥤ E) (G : D ⥤ E) [Faithful G] (obj : C →
       trans F.map (𝟙 X)
       exact h_map
       rw [F.map_id, G.map_id, h_obj X]
-      -- refine G.map_injective <| eq_of_heq <| h_map.trans ?_
-      -- simp only [Functor.map_id]
-      -- convert HEq.refl (𝟙 (F.obj X))
-      -- all_goals { apply h_obj }
     map_comp := by
       intros X Y Z f g
       refine G.map_injective <| eq_of_heq <| h_map.trans ?_

--- a/Mathlib/CategoryTheory/Functor/FullyFaithful.lean
+++ b/Mathlib/CategoryTheory/Functor/FullyFaithful.lean
@@ -322,15 +322,15 @@ protected def Faithful.div (F : C ⥤ E) (G : D ⥤ E) [Faithful G] (obj : C →
       intros X
       -- Porting note: The mathlib3 proof uses the `trans` tactic, which didn't work.
       -- See https://github.com/leanprover-community/mathlib4/issues/1119
-      -- apply G.map_injective
-      -- apply eq_of_heq
-      -- trans F.map (𝟙 X)
-      -- exact h_map
-      -- rw [F.map_id, G.map_id, h_obj X]
-      refine G.map_injective <| eq_of_heq <| h_map.trans ?_
-      simp only [Functor.map_id]
-      convert HEq.refl (𝟙 (F.obj X))
-      all_goals { apply h_obj }
+      apply G.map_injective
+      apply eq_of_heq
+      trans F.map (𝟙 X)
+      exact h_map
+      rw [F.map_id, G.map_id, h_obj X]
+      -- refine G.map_injective <| eq_of_heq <| h_map.trans ?_
+      -- simp only [Functor.map_id]
+      -- convert HEq.refl (𝟙 (F.obj X))
+      -- all_goals { apply h_obj }
     map_comp := by
       intros X Y Z f g
       refine G.map_injective <| eq_of_heq <| h_map.trans ?_

--- a/Mathlib/CategoryTheory/Functor/FullyFaithful.lean
+++ b/Mathlib/CategoryTheory/Functor/FullyFaithful.lean
@@ -320,8 +320,6 @@ protected def Faithful.div (F : C ⥤ E) (G : D ⥤ E) [Faithful G] (obj : C →
   { obj, map := @map,
     map_id := by
       intros X
-      -- Porting note: The mathlib3 proof uses the `trans` tactic, which didn't work.
-      -- See https://github.com/leanprover-community/mathlib4/issues/1119
       apply G.map_injective
       apply eq_of_heq
       trans F.map (𝟙 X)

--- a/Mathlib/Tactic/Relation/Trans.lean
+++ b/Mathlib/Tactic/Relation/Trans.lean
@@ -116,8 +116,6 @@ elab "trans" t?:(ppSpace (colGt term))? : tactic => withMainContext do
       | none => throwError "transitivity lemmas only apply to
         binary relations, not {indentExpr tgt}"
     | _ => throwError "transitivity lemmas only apply to binary relations, not {indentExpr tgt}"
-  -- let .app (.app rel x) z := tgt
-  --   | throwError "transitivity lemmas only apply to binary relations, not {indentExpr tgt}"
   trace[Tactic.trans]"goal decomposed"
   trace[Tactic.trans]"rel: {indentExpr rel}"
   trace[Tactic.trans]"x:{indentExpr x}"

--- a/Mathlib/Tactic/Relation/Trans.lean
+++ b/Mathlib/Tactic/Relation/Trans.lean
@@ -16,6 +16,8 @@ variable argument.
 namespace Mathlib.Tactic
 open Lean Meta Elab
 
+initialize registerTraceClass `Tactic.trans
+
 /-- Environment extension storing transitivity lemmas -/
 initialize transExt :
     SimpleScopedEnvExtension (Name × Array (DiscrTree.Key true)) (DiscrTree Name true) ←
@@ -31,7 +33,7 @@ initialize registerBuiltinAttribute {
     let declTy := (← getConstInfo decl).type
     let (xs, _, targetTy) ← withReducible <| forallMetaTelescopeReducing declTy
     let fail := throwError
-      "@[trans] attribute only applies to lemmas proving x ∼ y → y ∼ z → x ∼ z, got {declTy}"
+      "@[trans] attribute only applies to lemmas proving x ∼ y → y ∼ z → x ∼ z, got {indentExpr declTy} with target {indentExpr targetTy}"
     let .app (.app rel _) _ := targetTy | fail
     let some yzHyp := xs.back? | fail
     let some xyHyp := xs.pop.back? | fail
@@ -55,6 +57,21 @@ def _root_.Trans.het' {a : α}(b : β){c : γ}
 open Lean.Elab.Tactic
 
 /--
+Auxiliary meta definition for `trans` tactic for the homogeneous case.
+-/
+def applyTrans(lem: Name)
+    (rel x z : Expr)(t'? : Option (Expr × List MVarId))(g: MVarId) : MetaM <| List MVarId := do
+      let lemTy ← inferType (← mkConstWithLevelParams lem)
+      let ty ← inferType x
+      let arity ← withReducible <| forallTelescopeReducing lemTy fun es _ ↦ pure es.size
+      let y ← (t'?.map (pure ·.1)).getD (mkFreshExprMVar ty)
+      let g₁ ← mkFreshExprMVar (some <| ← mkAppM' rel #[x, y]) .synthetic
+      let g₂ ← mkFreshExprMVar (some <| ← mkAppM' rel #[y, z]) .synthetic
+      g.assign (← mkAppOptM lem (mkArray (arity - 2) none ++ #[some g₁, some g₂]))
+      pure <| [g₁.mvarId!, g₂.mvarId!] ++ if let some (_, gs') := t'? then gs' else [y.mvarId!]
+
+
+/--
 `trans` applies to a goal whose target has the form `t ~ u` where `~` is a transitive relation,
 that is, a relation which has a transitivity lemma tagged with the attribute [trans].
 
@@ -65,34 +82,48 @@ elab "trans" t?:(ppSpace (colGt term))? : tactic => withMainContext do
   let tgt ← getMainTarget
   let .app (.app rel x) z := tgt
     | throwError "transitivity lemmas only apply to binary relations, not {indentExpr tgt}"
-  let ty ← inferType x
-  let t'? ← t?.mapM (elabTermWithHoles · ty (← getMainTag))
-  let s ← saveState
-  for lem in (← (transExt.getState (← getEnv)).getUnify rel).push ``Trans.simple do
-    try
-      liftMetaTactic fun g ↦ do
-        let lemTy ← inferType (← mkConstWithLevelParams lem)
-        let arity ← withReducible <| forallTelescopeReducing lemTy fun es _ ↦ pure es.size
-        let y ← (t'?.map (pure ·.1)).getD (mkFreshExprMVar ty)
-        let g₁ ← mkFreshExprMVar (some <| .app (.app rel x) y) .synthetic
-        let g₂ ← mkFreshExprMVar (some <| .app (.app rel y) z) .synthetic
-        g.assign (← mkAppOptM lem (mkArray (arity - 2) none ++ #[some g₁, some g₂]))
-        pure <| [g₁.mvarId!, g₂.mvarId!] ++ if let some (_, gs') := t'? then gs' else [y.mvarId!]
-      return
-    catch _ => s.restore
+  trace[Tactic.trans]"goal decomposed"
+  trace[Tactic.trans]"rel: {indentExpr rel}"
+  trace[Tactic.trans]"x:{indentExpr x}"
+  trace[Tactic.trans]"z:  {indentExpr z}"
+  -- first trying the homogeneous case
+  try
+    let ty ← inferType x
+    let t'? ← t?.mapM (elabTermWithHoles · ty (← getMainTag))
+    let s ← saveState
+    trace[Tactic.trans]"trying homogeneous case"
+    for lem in (← (transExt.getState (← getEnv)).getUnify rel).push ``Trans.simple do
+      trace[Tactic.trans]"trying lemma {lem}"
+      try
+        liftMetaTactic fun g ↦ do
+          let lemTy ← inferType (← mkConstWithLevelParams lem)
+          let arity ← withReducible <| forallTelescopeReducing lemTy fun es _ ↦ pure es.size
+          let y ← (t'?.map (pure ·.1)).getD (mkFreshExprMVar ty)
+          let g₁ ← mkFreshExprMVar (some <| ← mkAppM' rel #[x, y]) .synthetic
+          let g₂ ← mkFreshExprMVar (some <| ← mkAppM' rel #[y, z]) .synthetic
+          g.assign (← mkAppOptM lem (mkArray (arity - 2) none ++ #[some g₁, some g₂]))
+          pure <| [g₁.mvarId!, g₂.mvarId!] ++ if let some (_, gs') := t'? then gs' else [y.mvarId!]
+        return
+      catch _ => s.restore
+    pure ()
+  catch _ =>
+  trace[Tactic.trans]"trying heterogeneous case"
   let t'? ← t?.mapM (elabTermWithHoles · none (← getMainTag))
   let s ← saveState
-  for lem in (← (transExt.getState (← getEnv)).getUnify rel).push ``Trans.het do
+  for lem in (← (transExt.getState (← getEnv)).getUnify rel).push
+      ``Trans.het do
     try
       liftMetaTactic fun g ↦ do
+        trace[Tactic.trans]"trying lemma {lem}"
         let lemTy ← inferType (← mkConstWithLevelParams lem)
         let arity ← withReducible <| forallTelescopeReducing lemTy fun es _ ↦ pure es.size
         let y ← (t'?.map (pure ·.1)).getD (mkFreshExprMVar none)
-        let g₁ ← mkFreshExprMVar (some <| .app (.app rel x) y) .synthetic
-        let g₂ ← mkFreshExprMVar (some <| .app (.app rel y) z) .synthetic
+        let g₁ ← mkFreshExprMVar (some <| ← mkAppM' rel #[x, y]) .synthetic
+        let g₂ ← mkFreshExprMVar (some <| ← mkAppM' rel #[y, z]) .synthetic
         g.assign (← mkAppOptM lem (mkArray (arity - 2) none ++ #[some g₁, some g₂]))
         pure <| [g₁.mvarId!, g₂.mvarId!] ++ if let some (_, gs') := t'? then gs' else [y.mvarId!]
       return
     catch _ => s.restore
 
-  throwError "no applicable transitivity lemma found for {indentExpr tgt}"
+  throwError m!"no applicable transitivity lemma found for {indentExpr tgt}
+"

--- a/Mathlib/Tactic/Relation/Trans.lean
+++ b/Mathlib/Tactic/Relation/Trans.lean
@@ -56,7 +56,7 @@ def _root_.Trans.het {a : α}{b : β}{c : γ}
 open Lean.Elab.Tactic
 
 /-- solving `e ← mkAppM' f #[x]` -/
-def getExplicitFuncArg? (e: Expr) : MetaM (Option <| Expr × Expr) := do
+def getExplicitFuncArg? (e : Expr) : MetaM (Option <| Expr × Expr) := do
   match e with
   | Expr.app f a => do
     if ← isDefEq (← mkAppM' f #[a]) e then
@@ -66,7 +66,7 @@ def getExplicitFuncArg? (e: Expr) : MetaM (Option <| Expr × Expr) := do
   | _ => return none
 
 /-- solving `tgt ← mkAppM' rel #[x, z]` given `tgt = f z` -/
-def getExplicitRelArg? (tgt f z: Expr) : MetaM (Option <| Expr × Expr) := do
+def getExplicitRelArg? (tgt f z : Expr) : MetaM (Option <| Expr × Expr) := do
   match f  with
   | Expr.app rel x => do
     let check: Bool ← do
@@ -82,7 +82,7 @@ def getExplicitRelArg? (tgt f z: Expr) : MetaM (Option <| Expr × Expr) := do
   | _ => return none
 
 /-- refining `tgt ← mkAppM' rel #[x, z]` dropping more arguments if possible -/
-def getExplicitRelArgCore(tgt rel x z: Expr) : MetaM (Expr × Expr) := do
+def getExplicitRelArgCore(tgt rel x z : Expr) : MetaM (Expr × Expr) := do
   match rel with
   | Expr.app rel' _ => do
     let check: Bool ← do
@@ -118,8 +118,8 @@ elab "trans" t?:(ppSpace (colGt term))? : tactic => withMainContext do
     | _ => throwError "transitivity lemmas only apply to binary relations, not {indentExpr tgt}"
   trace[Tactic.trans]"goal decomposed"
   trace[Tactic.trans]"rel: {indentExpr rel}"
-  trace[Tactic.trans]"x:{indentExpr x}"
-  trace[Tactic.trans]"z:  {indentExpr z}"
+  trace[Tactic.trans]"x: {indentExpr x}"
+  trace[Tactic.trans]"z: {indentExpr z}"
   -- first trying the homogeneous case
   try
     let ty ← inferType x

--- a/Mathlib/Tactic/Relation/Trans.lean
+++ b/Mathlib/Tactic/Relation/Trans.lean
@@ -82,7 +82,7 @@ def getExplicitRelArg? (tgt f z : Expr) : MetaM (Option <| Expr × Expr) := do
   | _ => return none
 
 /-- refining `tgt ← mkAppM' rel #[x, z]` dropping more arguments if possible -/
-def getExplicitRelArgCore(tgt rel x z : Expr) : MetaM (Expr × Expr) := do
+def getExplicitRelArgCore (tgt rel x z : Expr) : MetaM (Expr × Expr) := do
   match rel with
   | Expr.app rel' _ => do
     let check: Bool ← do

--- a/Mathlib/Tactic/Relation/Trans.lean
+++ b/Mathlib/Tactic/Relation/Trans.lean
@@ -33,7 +33,8 @@ initialize registerBuiltinAttribute {
     let declTy := (← getConstInfo decl).type
     let (xs, _, targetTy) ← withReducible <| forallMetaTelescopeReducing declTy
     let fail := throwError
-      "@[trans] attribute only applies to lemmas proving x ∼ y → y ∼ z → x ∼ z, got {indentExpr declTy} with target {indentExpr targetTy}"
+      "@[trans] attribute only applies to lemmas proving
+      x ∼ y → y ∼ z → x ∼ z, got {indentExpr declTy} with target {indentExpr targetTy}"
     let .app (.app rel _) _ := targetTy | fail
     let some yzHyp := xs.back? | fail
     let some xyHyp := xs.pop.back? | fail
@@ -43,20 +44,18 @@ initialize registerBuiltinAttribute {
     transExt.add (decl, key) kind
 }
 
-/-- Compose two proofs by transitivity, simplified to the homogeneous case. -/
+/-- Composition using the `Trans` class in the homogeneous case. -/
 def _root_.Trans.simple {a b c : α} [Trans r r r] : r a b → r b c → r a c := trans
 
+/-- Composition using the `Trans` class in the general case. -/
 def _root_.Trans.het {a : α}{b : β}{c : γ}
   {r : α → β → Sort u} {s : β → γ → Sort v} {t : outParam (α → γ → Sort w)}
   [Trans r s t]: r a b → s b c → t a c := trans
 
-def _root_.Trans.het' {a : α}(b : β){c : γ}
-  {r : α → β → Sort u} {s : β → γ → Sort v} {t : outParam (α → γ → Sort w)}
-  [Trans r s t]: r a b → s b c → t a c := trans
 
 open Lean.Elab.Tactic
 
-
+/-- solving `e ← mkAppM' f #[x]` -/
 def getExplicitFuncArg? (e: Expr) : MetaM (Option <| Expr × Expr) := do
   match e with
   | Expr.app f a => do
@@ -66,7 +65,7 @@ def getExplicitFuncArg? (e: Expr) : MetaM (Option <| Expr × Expr) := do
       getExplicitFuncArg? f
   | _ => return none
 
-
+/-- solving `tgt ← mkAppM' rel #[x, z]` given `tgt = f z` -/
 def getExplicitRelArg? (tgt f z: Expr) : MetaM (Option <| Expr × Expr) := do
   match f  with
   | Expr.app rel x => do
@@ -82,20 +81,21 @@ def getExplicitRelArg? (tgt f z: Expr) : MetaM (Option <| Expr × Expr) := do
       getExplicitRelArg? tgt rel z
   | _ => return none
 
-def showExplicitRelArg (tgt f z: Expr) : MetaM Unit := do
-  logInfo m!"tgt: {tgt}"
-  logInfo m!"f: {f}"
-  logInfo m!"z: {z}"
-  match f  with
-  | Expr.app rel x => do
-    logInfo m!"rel: {rel}"
-    logInfo m!"x: {x}"
-    if ← isDefEq (← mkAppM' rel #[x, z]) tgt then
-      logInfo "matched"
-      return ()
+/-- refining `tgt ← mkAppM' rel #[x, z]` dropping more arguments if possible -/
+def getExplicitRelArgCore(tgt rel x z: Expr) : MetaM (Expr × Expr) := do
+  match rel with
+  | Expr.app rel' _ => do
+    let check: Bool ← do
+      try
+        let folded ← mkAppM' rel' #[x, z]
+        isDefEq folded tgt
+      catch _ =>
+        pure false
+    if !check then
+      return (rel, x)
     else
-      showExplicitRelArg tgt rel z
-  | _ => return ()
+      getExplicitRelArgCore tgt rel' x z
+  | _ => return (rel ,x)
 
 /--
 `trans` applies to a goal whose target has the form `t ~ u` where `~` is a transitive relation,
@@ -111,8 +111,10 @@ elab "trans" t?:(ppSpace (colGt term))? : tactic => withMainContext do
     | Expr.app f z =>
       match (← getExplicitRelArg? tgt f z) with
       | some (rel, x) =>
+        let (rel, x) ← getExplicitRelArgCore tgt rel x z
         pure (rel, x, z)
-      | none => throwError "transitivity lemmas only apply to binary relations, not {indentExpr tgt}"
+      | none => throwError "transitivity lemmas only apply to
+        binary relations, not {indentExpr tgt}"
     | _ => throwError "transitivity lemmas only apply to binary relations, not {indentExpr tgt}"
   -- let .app (.app rel x) z := tgt
   --   | throwError "transitivity lemmas only apply to binary relations, not {indentExpr tgt}"
@@ -145,19 +147,29 @@ elab "trans" t?:(ppSpace (colGt term))? : tactic => withMainContext do
   let t'? ← t?.mapM (elabTermWithHoles · none (← getMainTag))
   let s ← saveState
   for lem in (← (transExt.getState (← getEnv)).getUnify rel).push
-      ``Trans.het do
+      ``HEq.trans |>.push ``HEq.trans  do
     try
       liftMetaTactic fun g ↦ do
         trace[Tactic.trans]"trying lemma {lem}"
         let lemTy ← inferType (← mkConstWithLevelParams lem)
         let arity ← withReducible <| forallTelescopeReducing lemTy fun es _ ↦ pure es.size
+        trace[Tactic.trans]"arity: {arity}"
+        trace[Tactic.trans]"lemma-type: {lemTy}"
         let y ← (t'?.map (pure ·.1)).getD (mkFreshExprMVar none)
-        let g₁ ← mkFreshExprMVar (some <| ← mkAppM' rel #[x, y]) .synthetic
+        trace[Tactic.trans]"obtained y: {y}"
+        trace[Tactic.trans]"rel: {indentExpr rel}"
+        trace[Tactic.trans]"x:{indentExpr x}"
+        trace[Tactic.trans]"z:  {indentExpr z}"
         let g₂ ← mkFreshExprMVar (some <| ← mkAppM' rel #[y, z]) .synthetic
+        trace[Tactic.trans]"obtained g₂: {g₂}"
+        let g₁ ← mkFreshExprMVar (some <| ← mkAppM' rel #[x, y]) .synthetic
+        trace[Tactic.trans]"obtained g₁: {g₁}"
         g.assign (← mkAppOptM lem (mkArray (arity - 2) none ++ #[some g₁, some g₂]))
         pure <| [g₁.mvarId!, g₂.mvarId!] ++ if let some (_, gs') := t'? then gs' else [y.mvarId!]
       return
-    catch _ => s.restore
+    catch e =>
+      trace[Tactic.trans]"failed: {e.toMessageData}"
+      s.restore
 
   throwError m!"no applicable transitivity lemma found for {indentExpr tgt}
 "

--- a/Mathlib/Tactic/Relation/Trans.lean
+++ b/Mathlib/Tactic/Relation/Trans.lean
@@ -48,9 +48,9 @@ initialize registerBuiltinAttribute {
 def _root_.Trans.simple {a b c : α} [Trans r r r] : r a b → r b c → r a c := trans
 
 /-- Composition using the `Trans` class in the general case. -/
-def _root_.Trans.het {a : α}{b : β}{c : γ}
+def _root_.Trans.het {a : α} {b : β} {c : γ}
   {r : α → β → Sort u} {s : β → γ → Sort v} {t : outParam (α → γ → Sort w)}
-  [Trans r s t]: r a b → s b c → t a c := trans
+  [Trans r s t] : r a b → s b c → t a c := trans
 
 
 open Lean.Elab.Tactic

--- a/test/trans.lean
+++ b/test/trans.lean
@@ -64,7 +64,7 @@ example (x n p : Nat) (h₁ : n * Nat.succ p ≤ x) : n * p ≤ x := by
   · apply Nat.mul_le_mul_left; apply Nat.le_succ
   · apply h₁
 
-example (a : α)(c: γ): ∀ b: β, HEq a b → HEq b c → HEq a c := by
+example (a : α)(c : γ) : ∀ b : β, HEq a b → HEq b c → HEq a c := by
     intro b h₁ h₂
     trans b
     assumption

--- a/test/trans.lean
+++ b/test/trans.lean
@@ -64,17 +64,8 @@ example (x n p : Nat) (h₁ : n * Nat.succ p ≤ x) : n * p ≤ x := by
   · apply Nat.mul_le_mul_left; apply Nat.le_succ
   · apply h₁
 
-attribute [trans] HEq.trans
-
-#check @HEq
-#check @HEq.trans
-
--- Narrowed the bug, commented out for now
-set_option trace.Tactic.trans true in
 example (a : α)(c: γ): ∀ b: β, HEq a b → HEq b c → HEq a c := by
     intro b h₁ h₂
     trans b
-
--- Structurally a special case and deprecated, not testing
--- @[trans] example  {p q r : Prop} (h₁ : p → q) (h₂ : q → r) :
---                   p → r := fun hp ↦ h₂ (h₁ hp)
+    assumption
+    assumption

--- a/test/trans.lean
+++ b/test/trans.lean
@@ -66,6 +66,15 @@ example (x n p : Nat) (h₁ : n * Nat.succ p ≤ x) : n * p ≤ x := by
 
 attribute [trans] HEq.trans
 
-example (a : α)(c: γ): ∀ b: β, HEq a b → HEq b c → HEq a c := by
-    intro b h₁ h₂
-    trans b
+#check @HEq
+#check @HEq.trans
+
+-- Narrowed the bug, commented out for now
+-- set_option trace.Tactic.trans true in
+-- example (a : α)(c: γ): ∀ b: β, HEq a b → HEq b c → HEq a c := by
+--     intro b h₁ h₂
+--     trans b
+
+-- Structurally a special case and deprecated, not testing
+-- @[trans] example  {p q r : Prop} (h₁ : p → q) (h₂ : q → r) :
+--                   p → r := fun hp ↦ h₂ (h₁ hp)

--- a/test/trans.lean
+++ b/test/trans.lean
@@ -70,10 +70,10 @@ attribute [trans] HEq.trans
 #check @HEq.trans
 
 -- Narrowed the bug, commented out for now
--- set_option trace.Tactic.trans true in
--- example (a : α)(c: γ): ∀ b: β, HEq a b → HEq b c → HEq a c := by
---     intro b h₁ h₂
---     trans b
+set_option trace.Tactic.trans true in
+example (a : α)(c: γ): ∀ b: β, HEq a b → HEq b c → HEq a c := by
+    intro b h₁ h₂
+    trans b
 
 -- Structurally a special case and deprecated, not testing
 -- @[trans] example  {p q r : Prop} (h₁ : p → q) (h₂ : q → r) :

--- a/test/trans.lean
+++ b/test/trans.lean
@@ -63,3 +63,9 @@ example (x n p : Nat) (h₁ : n * Nat.succ p ≤ x) : n * p ≤ x := by
   trans
   · apply Nat.mul_le_mul_left; apply Nat.le_succ
   · apply h₁
+
+attribute [trans] HEq.trans
+
+example (a : α)(c: γ): ∀ b: β, HEq a b → HEq b c → HEq a c := by
+    intro b h₁ h₂
+    trans b


### PR DESCRIPTION
Transitivity handles heterogeneous cases and premutations of parameters. Fixes #1119 