### PR TITLE
[Merged by Bors] - chore: add source header to Combinatorics.Quiver.Symmetric

### DIFF
--- a/Mathlib/Combinatorics/Quiver/Symmetric.lean
+++ b/Mathlib/Combinatorics/Quiver/Symmetric.lean
@@ -3,6 +3,11 @@ Copyright (c) 2021 David Wärn. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: David Wärn, Antoine Labelle, Rémi Bottinelli
 Ported by: Joël Riou, Rémi Bottinelli
+
+! This file was ported from Lean 3 source module combinatorics.quiver.connected_component
+! leanprover-community/mathlib commit 32618bfa7cbb01291852c272388d23efdd3a94e9
+! Please do not edit these lines, except to modify the commit id
+! if you have ported upstream changes.
 -/
 import Mathlib.Combinatorics.Quiver.Path
 import Mathlib.Combinatorics.Quiver.Push
@@ -248,4 +253,3 @@ def IsPreconnected (V) [Quiver.{u + 1} V] :=
 #align quiver.is_preconnected Quiver.IsPreconnected
 
 end Quiver
-

--- a/Mathlib/Combinatorics/Quiver/Symmetric.lean
+++ b/Mathlib/Combinatorics/Quiver/Symmetric.lean
@@ -5,7 +5,7 @@ Authors: David Wärn, Antoine Labelle, Rémi Bottinelli
 Ported by: Joël Riou, Rémi Bottinelli
 
 ! This file was ported from Lean 3 source module combinatorics.quiver.connected_component
-! leanprover-community/mathlib commit 32618bfa7cbb01291852c272388d23efdd3a94e9
+! leanprover-community/mathlib commit 706d88f2b8fdfeb0b22796433d7a6c1a010af9f2
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/


### PR DESCRIPTION
This file was refactored in this simultaneous Mathlib3 PR:
https://github.com/leanprover-community/mathlib/commit/706d88f2b8fdfeb0b22796433d7a6c1a010af9f2
so I added the header which matches this PR's SHA. 