### PR TITLE
[Merged by Bors] - feat: port Data.Int.Sqrt

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -196,6 +196,7 @@ import Mathlib.Data.Int.LeastGreatest
 import Mathlib.Data.Int.Order.Basic
 import Mathlib.Data.Int.Order.Lemmas
 import Mathlib.Data.Int.Order.Units
+import Mathlib.Data.Int.Sqrt
 import Mathlib.Data.Int.Units
 import Mathlib.Data.KVMap
 import Mathlib.Data.LazyList

--- a/Mathlib/Data/Int/Sqrt.lean
+++ b/Mathlib/Data/Int/Sqrt.lean
@@ -8,13 +8,13 @@ Authors: Kenny Lau
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
-import Mathbin.Data.Nat.Sqrt
+import Mathlib.Data.Nat.Sqrt
 
 /-!
 # Square root of integers
 
-This file defines the square root function on integers. `int.sqrt z` is the greatest integer `r`
-such that `r * r ≤ z`. If `z ≤ 0`, then `int.sqrt z = 0`.
+This file defines the square root function on integers. `Int.sqrt z` is the greatest integer `r`
+such that `r * r ≤ z`. If `z ≤ 0`, then `Int.sqrt z = 0`.
 -/
 
 
@@ -23,17 +23,17 @@ namespace Int
 /-- `sqrt z` is the square root of an integer `z`. If `z` is positive, it returns the largest
 integer `r` such that `r * r ≤ n`. If it is negative, it returns `0`. For example, `sqrt (-1) = 0`,
 `sqrt 1 = 1`, `sqrt 2 = 1` -/
-@[pp_nodot]
+-- @[pp_nodot] porting note: unknown attribute
 def sqrt (z : ℤ) : ℤ :=
   Nat.sqrt <| Int.toNat z
 #align int.sqrt Int.sqrt
 
 theorem sqrt_eq (n : ℤ) : sqrt (n * n) = n.natAbs := by
-  rw [sqrt, ← nat_abs_mul_self, to_nat_coe_nat, Nat.sqrt_eq]
+  rw [sqrt, ← natAbs_mul_self, toNat_coe_nat, Nat.sqrt_eq]
 #align int.sqrt_eq Int.sqrt_eq
 
 theorem exists_mul_self (x : ℤ) : (∃ n, n * n = x) ↔ sqrt x * sqrt x = x :=
-  ⟨fun ⟨n, hn⟩ => by rw [← hn, sqrt_eq, ← Int.ofNat_mul, nat_abs_mul_self], fun h => ⟨sqrt x, h⟩⟩
+  ⟨fun ⟨n, hn⟩ => by rw [← hn, sqrt_eq, ← Int.ofNat_mul, natAbs_mul_self], fun h => ⟨sqrt x, h⟩⟩
 #align int.exists_mul_self Int.exists_mul_self
 
 theorem sqrt_nonneg (n : ℤ) : 0 ≤ sqrt n :=
@@ -41,4 +41,3 @@ theorem sqrt_nonneg (n : ℤ) : 0 ≤ sqrt n :=
 #align int.sqrt_nonneg Int.sqrt_nonneg
 
 end Int
-

--- a/Mathlib/Data/Int/Sqrt.lean
+++ b/Mathlib/Data/Int/Sqrt.lean
@@ -1,0 +1,44 @@
+/-
+Copyright (c) 2018 Kenny Lau. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kenny Lau
+
+! This file was ported from Lean 3 source module data.int.sqrt
+! leanprover-community/mathlib commit ba2245edf0c8bb155f1569fd9b9492a9b384cde6
+! Please do not edit these lines, except to modify the commit id
+! if you have ported upstream changes.
+-/
+import Mathbin.Data.Nat.Sqrt
+
+/-!
+# Square root of integers
+
+This file defines the square root function on integers. `int.sqrt z` is the greatest integer `r`
+such that `r * r ≤ z`. If `z ≤ 0`, then `int.sqrt z = 0`.
+-/
+
+
+namespace Int
+
+/-- `sqrt z` is the square root of an integer `z`. If `z` is positive, it returns the largest
+integer `r` such that `r * r ≤ n`. If it is negative, it returns `0`. For example, `sqrt (-1) = 0`,
+`sqrt 1 = 1`, `sqrt 2 = 1` -/
+@[pp_nodot]
+def sqrt (z : ℤ) : ℤ :=
+  Nat.sqrt <| Int.toNat z
+#align int.sqrt Int.sqrt
+
+theorem sqrt_eq (n : ℤ) : sqrt (n * n) = n.natAbs := by
+  rw [sqrt, ← nat_abs_mul_self, to_nat_coe_nat, Nat.sqrt_eq]
+#align int.sqrt_eq Int.sqrt_eq
+
+theorem exists_mul_self (x : ℤ) : (∃ n, n * n = x) ↔ sqrt x * sqrt x = x :=
+  ⟨fun ⟨n, hn⟩ => by rw [← hn, sqrt_eq, ← Int.ofNat_mul, nat_abs_mul_self], fun h => ⟨sqrt x, h⟩⟩
+#align int.exists_mul_self Int.exists_mul_self
+
+theorem sqrt_nonneg (n : ℤ) : 0 ≤ sqrt n :=
+  coe_nat_nonneg _
+#align int.sqrt_nonneg Int.sqrt_nonneg
+
+end Int
+


### PR DESCRIPTION
Only notable thing here is that ```@[pp_nodot]``` was commented out since that is currently an unknown attribute. Hope that's the way to do it!