### PR TITLE
[Merged by Bors] - fix: do not track origin/master when creating porting branches

### DIFF
--- a/scripts/start_port.sh
+++ b/scripts/start_port.sh
@@ -46,7 +46,7 @@ mv "$TMP_FILE" "$mathlib4_path"
 
 git fetch
 branch_name=port/${mathlib4_mod#Mathlib.}
-git checkout -b "$branch_name" origin/master
+git checkout --no-track -b "$branch_name" origin/master
 
 git add "$mathlib4_path"
 git commit -m 'Initial file copy from mathport'


### PR DESCRIPTION
This prevents maintainers accidentally pushing to master