### PR TITLE
chore: `Combinatorics.Quiver.*` less manual universe level management, and `Symmetrify` now is a `PSum`

### DIFF
--- a/Mathlib/Combinatorics/Quiver/Arborescence.lean
+++ b/Mathlib/Combinatorics/Quiver/Arborescence.lean
@@ -35,13 +35,11 @@ spanning tree'. This proof avoids the use of Zorn's lemma.
 
 open Opposite
 
-universe v u
-
 namespace Quiver
 
 /-- A quiver is an arborescence when there is a unique path from the default vertex
     to every other vertex. -/
-class Arborescence (V : Type u) [Quiver.{v} V] : Type max u v where
+class Arborescence (V : Type _) [Quiver V] where
   /-- The root of the arborescence. -/
   root : V
   /-- There is a unique path from the root to any other vertex. -/
@@ -96,7 +94,7 @@ noncomputable def arborescenceMk {V : Type u} [Quiver V] (r : V) (height : V →
 #align quiver.arborescence_mk Quiver.arborescenceMk
 
 /-- `RootedConnected r` means that there is a path from `r` to any other vertex. -/
-class RootedConnected {V : Type u} [Quiver V] (r : V) : Prop where
+class RootedConnected {V : Type _} [Quiver V] (r : V) where
   nonempty_path : ∀ b : V, Nonempty (Path r b)
 #align quiver.rooted_connected Quiver.RootedConnected
 
@@ -104,7 +102,7 @@ attribute [instance] RootedConnected.nonempty_path
 
 section GeodesicSubtree
 
-variable {V : Type u} [Quiver.{v + 1} V] (r : V) [RootedConnected r]
+variable {V : Type _} [Quiver.{_+1} V] (r : V) [RootedConnected r]
 
 /-- A path from `r` of minimal length. -/
 noncomputable def shortestPath (b : V) : Path r b :=

--- a/Mathlib/Combinatorics/Quiver/Arborescence.lean
+++ b/Mathlib/Combinatorics/Quiver/Arborescence.lean
@@ -47,11 +47,11 @@ class Arborescence (V : Type _) [Quiver V] where
 #align quiver.arborescence Quiver.Arborescence
 
 /-- The root of an arborescence. -/
-def root (V : Type u) [Quiver V] [Arborescence V] : V :=
+def root (V : Type _) [Quiver V] [Arborescence V] : V :=
   Arborescence.root
 #align quiver.root Quiver.root
 
-instance {V : Type u} [Quiver V] [Arborescence V] (b : V) : Unique (Path (root V) b) :=
+instance {V : Type _} [Quiver V] [Arborescence V] (b : V) : Unique (Path (root V) b) :=
   Arborescence.uniquePath b
 
 /-- To show that `[Quiver V]` is an arborescence with root `r : V`, it suffices to
@@ -59,7 +59,7 @@ instance {V : Type u} [Quiver V] [Arborescence V] (b : V) : Unique (Path (root V
     lower vertex to a higher vertex,
   - show that every vertex has at most one arrow to it, and
   - show that every vertex other than `r` has an arrow to it. -/
-noncomputable def arborescenceMk {V : Type u} [Quiver V] (r : V) (height : V → ℕ)
+noncomputable def arborescenceMk {V : Type _} [Quiver V] (r : V) (height : V → ℕ)
     (height_lt : ∀ ⦃a b⦄, (a ⟶ b) → height a < height b)
     (unique_arrow : ∀ ⦃a b c : V⦄ (e : a ⟶ c) (f : b ⟶ c), a = b ∧ HEq e f)
     (root_or_arrow : ∀ b, b = r ∨ ∃ a, Nonempty (a ⟶ b)) :

--- a/Mathlib/Combinatorics/Quiver/Cast.lean
+++ b/Mathlib/Combinatorics/Quiver/Cast.lean
@@ -21,9 +21,7 @@ rewriting arrows and paths along equalities of their endpoints.
 -/
 
 
-universe v v₁ v₂ u u₁ u₂
-
-variable {U : Type _} [Quiver.{u + 1} U]
+variable {U : Type _} [Quiver U]
 
 
 namespace Quiver

--- a/Mathlib/Combinatorics/Quiver/ConnectedComponent.lean
+++ b/Mathlib/Combinatorics/Quiver/ConnectedComponent.lean
@@ -23,11 +23,9 @@ the relation which identifies `a` with `b` if there is a path from `a` to `b` in
 Strongly connected components have not yet been defined.
 -/
 
-universe v u
-
 namespace Quiver
 
-variable (V : Type _) [Quiver.{u+1} V]
+variable (V : Type _) [Quiver V]
 
 /-- Two vertices are related in the zigzag setoid if there is a
     zigzag of arrows from one to the other. -/
@@ -63,12 +61,9 @@ end WeaklyConnectedComponent
 
 variable {V}
 
--- Without the explicit universe level in `Quiver.{v+1}` Lean comes up with
--- `Quiver.{max u_2 u_3 + 1}`. This causes problems elsewhere, so we write `Quiver.{v+1}`.
 /-- A wide subquiver `H` of `Symmetrify V` determines a wide subquiver of `V`, containing an
     an arrow `e` if either `e` or its reversal is in `H`. -/
 def wideSubquiverSymmetrify (H : WideSubquiver (Symmetrify V)) : WideSubquiver V :=
   fun _ _ ↦ { e | H _ _ (Sum.inl e) ∨ H _ _ (Sum.inr e) }
 
 end Quiver
-

--- a/Mathlib/Combinatorics/Quiver/ConnectedComponent.lean
+++ b/Mathlib/Combinatorics/Quiver/ConnectedComponent.lean
@@ -64,6 +64,6 @@ variable {V}
 /-- A wide subquiver `H` of `Symmetrify V` determines a wide subquiver of `V`, containing an
     an arrow `e` if either `e` or its reversal is in `H`. -/
 def wideSubquiverSymmetrify (H : WideSubquiver (Symmetrify V)) : WideSubquiver V :=
-  fun _ _ ↦ { e | H _ _ (Sum.inl e) ∨ H _ _ (Sum.inr e) }
+  fun _ _ ↦ { e | H _ _ (PSum.inl e) ∨ H _ _ (PSum.inr e) }
 
 end Quiver

--- a/Mathlib/Combinatorics/Quiver/Path.lean
+++ b/Mathlib/Combinatorics/Quiver/Path.lean
@@ -21,12 +21,10 @@ family. We define composition of paths and the action of prefunctors on paths.
 
 open Function
 
-universe v v₁ v₂ u u₁ u₂
-
 namespace Quiver
 
 /-- `Path a b` is the type of paths from `a` to `b` through the arrows of `G`. -/
-inductive Path {V : Type u} [Quiver.{v} V] (a : V) : V → Sort max (u + 1) v
+inductive Path {V : Type _} [Quiver V] (a : V) : V → Sort _
   | nil : Path a a
   | cons : ∀ {b c : V}, Path a b → (b ⟶ c) → Path a c
 
@@ -183,7 +181,7 @@ namespace Prefunctor
 
 open Quiver
 
-variable {V : Type u₁} [Quiver.{v₁} V] {W : Type u₂} [Quiver.{v₂} W] (F : V ⥤q W)
+variable {V : Type _} [Quiver V] {W : Type _} [Quiver W] (F : V ⥤q W)
 
 /-- The image of a path under a prefunctor. -/
 def mapPath {a : V} : ∀ {b : V}, Path a b → Path (F.obj a) (F.obj b)

--- a/Mathlib/Combinatorics/Quiver/Push.lean
+++ b/Mathlib/Combinatorics/Quiver/Push.lean
@@ -21,8 +21,6 @@ on `W` by associating to each arrow `v ⟶ v'` in `V` an arrow `σ v ⟶ σ v'` 
 
 namespace Quiver
 
-universe v v₁ v₂ u u₁ u₂
-
 variable {V : Type _} [Quiver V] {W : Type _} (σ : V → W)
 
 /-- The `Quiver` instance obtained by pushing arrows of `V` along the map `σ : V → W` -/
@@ -35,7 +33,7 @@ instance [h : Nonempty W] : Nonempty (Push σ) :=
   h
 
 /-- The quiver structure obtained by pushing arrows of `V` along the map `σ : V → W` -/
-inductive PushQuiver {V : Type u} [Quiver.{v} V] {W : Type u₂} (σ : V → W) : W → W → Type max u u₂ v
+inductive PushQuiver {V : Type _} [Quiver V] {W : Type _} (σ : V → W) : W → W → Sort _
   | arrow {X Y : V} (f : X ⟶ Y) : PushQuiver σ (σ X) (σ Y)
 #align quiver.push_quiver Quiver.PushQuiver
 

--- a/Mathlib/Combinatorics/Quiver/Subquiver.lean
+++ b/Mathlib/Combinatorics/Quiver/Subquiver.lean
@@ -20,21 +20,16 @@ every pair of vertices `a b : V`. We include 'wide' in the name to emphasize tha
 subquivers by definition contain all vertices.
 -/
 
-universe v u
-
 /-- A wide subquiver `H` of `G` picks out a set `H a b` of arrows from `a` to `b`
-    for every pair of vertices `a b`.
-
-    NB: this does not work for `Prop`-valued quivers. It requires `G : Quiver.{v+1} V`. -/
-def WideSubquiver (V) [Quiver.{v + 1} V] :=
+    for every pair of vertices `a b`. -/
+def WideSubquiver (V) [Quiver V] :=
   ∀ a b : V, Set (a ⟶ b)
 
 /-- A type synonym for `V`, when thought of as a quiver having only the arrows from
 some `WideSubquiver`. -/
 -- Porting note: no hasNonemptyInstance linter yet
 @[nolint unusedArguments]
-def WideSubquiver.toType (V) [Quiver V] (_ : WideSubquiver V) : Type u :=
-  V
+def WideSubquiver.toType (V) [Quiver V] (_ : WideSubquiver V) := V
 #align wide_subquiver.to_Type WideSubquiver.toType
 
 instance wideSubquiverHasCoeToSort {V} [Quiver V] :
@@ -59,7 +54,7 @@ noncomputable instance {V} [Quiver V] : Inhabited (WideSubquiver V) :=
 /-- `Total V` is the type of _all_ arrows of `V`. -/
 -- Porting note: no hasNonemptyInstance linter yet
 @[ext]
-structure Total (V : Type u) [Quiver.{v} V] : Sort max (u + 1) v where
+structure Total (V : Type u) [Quiver V] where
   /-- the source vertex of an arrow -/
   left : V
   /-- the target vertex of an arrow -/
@@ -77,10 +72,10 @@ def wideSubquiverEquivSetTotal {V} [Quiver V] :
   right_inv _ := rfl
 
 /-- An `L`-labelling of a quiver assigns to every arrow an element of `L`. -/
-def Labelling (V : Type u) [Quiver V] (L : Sort _) :=
+def Labelling (V : Type _) [Quiver V] (L : Sort _) :=
   ∀ ⦃a b : V⦄, (a ⟶ b) → L
 
-instance {V : Type u} [Quiver V] (L) [Inhabited L] : Inhabited (Labelling V L) :=
+instance {V : Type _} [Quiver V] (L) [Inhabited L] : Inhabited (Labelling V L) :=
   ⟨fun _ _ _ ↦ default⟩
 
 end Quiver

--- a/Mathlib/Combinatorics/Quiver/Symmetric.lean
+++ b/Mathlib/Combinatorics/Quiver/Symmetric.lean
@@ -27,8 +27,6 @@ This file contains constructions related to symmetric quivers:
   of `Symmetrify`.
 -/
 
-universe v u w v'
-
 namespace Quiver
 
 /-- A type synonym for the symmetrized quiver (with an arrow both ways for each original arrow).
@@ -36,10 +34,10 @@ namespace Quiver
 -- Porting note: no hasNonemptyInstance linter yet
 def Symmetrify (V : Type _) := V
 
-instance symmetrifyQuiver (V : Type u) [Quiver V] : Quiver (Symmetrify V) :=
+instance symmetrifyQuiver (V : Type _) [Quiver V] : Quiver (Symmetrify V) :=
   ⟨fun a b : V ↦ Sum (a ⟶ b) (b ⟶ a)⟩
 
-variable (U V W : Type _) [Quiver.{u + 1} U] [Quiver.{v + 1} V] [Quiver.{w + 1} W]
+variable (U V W : Type _) [Quiver U] [Quiver V] [Quiver W]
 
 /-- A quiver `HasReverse` if we can reverse an arrow `p` from `a` to `b` to get an arrow
     `p.reverse` from `b` to `a`.-/
@@ -48,7 +46,7 @@ class HasReverse where
   reverse' : ∀ {a b : V}, (a ⟶ b) → (b ⟶ a)
 
 /-- Reverse the direction of an arrow. -/
-def reverse {V} [Quiver.{v + 1} V] [HasReverse V] {a b : V} : (a ⟶ b) → (b ⟶ a) :=
+def reverse {V} [Quiver V] [HasReverse V] {a b : V} : (a ⟶ b) → (b ⟶ a) :=
   HasReverse.reverse'
 
 /-- A quiver `HasInvolutiveReverse` if reversing twice is the identity.`-/
@@ -171,7 +169,7 @@ def of : Prefunctor V (Symmetrify V) where
   obj := id
   map := Sum.inl
 
-variable {V' : Type _} [Quiver.{v' + 1} V']
+variable {V' : Type _} [Quiver V']
 
 /-- Given a quiver `V'` with reversible arrows, a prefunctor to `V'` can be lifted to one from
     `Symmetrify V` to `V'` -/
@@ -248,7 +246,7 @@ Note that if `V` doesn't `HasReverse`, then the definition is stronger than
 simply having a preconnected underlying `simple_graph`, since a path in one
 direction doesn't induce one in the other.
 -/
-def IsPreconnected (V) [Quiver.{u + 1} V] :=
+def IsPreconnected (V) [Quiver V] :=
   ∀ X Y : V, Nonempty (Path X Y)
 #align quiver.is_preconnected Quiver.IsPreconnected
 


### PR DESCRIPTION
It seems much of the issues related to universe levels and `Symmetrify` disappeared with lean4; there is only one `Quiver.{_+1}` remaining in `Arborescence.lean`.
Maybe it's not a good idea to change something like this and break the sync with mathlib3?