### PR TITLE
[Merged by Bors] - chore: Fix capitalisation in `algebra.order.hom.basic`

### DIFF
--- a/Mathlib/Algebra/Order/AbsoluteValue.lean
+++ b/Mathlib/Algebra/Order/AbsoluteValue.lean
@@ -68,11 +68,11 @@ instance mulHomClass : MulHomClass (AbsoluteValue R S) R S :=
   { AbsoluteValue.zeroHomClass with map_mul := fun f => f.map_mul' }
 #align absolute_value.mul_hom_class AbsoluteValue.mulHomClass
 
-instance nonnegHomClass : NonNegHomClass (AbsoluteValue R S) R S :=
+instance nonnegHomClass : NonnegHomClass (AbsoluteValue R S) R S :=
   { AbsoluteValue.zeroHomClass with map_nonneg := fun f => f.nonneg' }
 #align absolute_value.nonneg_hom_class AbsoluteValue.nonnegHomClass
 
-instance subadditiveHomClass : SubAdditiveHomClass (AbsoluteValue R S) R S :=
+instance subadditiveHomClass : SubadditiveHomClass (AbsoluteValue R S) R S :=
   { AbsoluteValue.zeroHomClass with map_add_le_add := fun f => f.add_le' }
 #align absolute_value.subadditive_hom_class AbsoluteValue.subadditiveHomClass
 

--- a/Mathlib/Algebra/Order/Hom/Basic.lean
+++ b/Mathlib/Algebra/Order/Hom/Basic.lean
@@ -19,11 +19,11 @@ This file defines hom classes for common properties at the intersection of order
 
 ## Typeclasses
 
-* `NonNegHomClass`: Homs are nonnegative: `∀ f a, 0 ≤ f a`
-* `SubAdditiveHomClass`: Homs are subadditive: `∀ f a b, f (a + b) ≤ f a + f b`
-* `SubMultiplicativeHomClass`: Homs are submultiplicative: `∀ f a b, f (a * b) ≤ f a * f b`
+* `NonnegHomClass`: Homs are nonnegative: `∀ f a, 0 ≤ f a`
+* `SubadditiveHomClass`: Homs are subadditive: `∀ f a b, f (a + b) ≤ f a + f b`
+* `SubmultiplicativeHomClass`: Homs are submultiplicative: `∀ f a b, f (a * b) ≤ f a * f b`
 * `MulLEAddHomClass`: `∀ f a b, f (a * b) ≤ f a + f b`
-* `NonArchimedeanHomClass`: `∀ a b, f (a + b) ≤ max (f a) (f b)`
+* `NonarchimedeanHomClass`: `∀ a b, f (a + b) ≤ max (f a) (f b)`
 
 ## TODO
 
@@ -34,57 +34,57 @@ open Function
 
 variable {ι F α β γ δ : Type _}
 
-/-- `NonNegHomClass F α β` states that `F` is a type of nonnegative morphisms. -/
-class NonNegHomClass (F : Type _) (α β : outParam (Type _)) [Zero β] [LE β] extends
+/-- `NonnegHomClass F α β` states that `F` is a type of nonnegative morphisms. -/
+class NonnegHomClass (F : Type _) (α β : outParam (Type _)) [Zero β] [LE β] extends
   FunLike F α fun _ => β where
   /-- the image of any element is non negative. -/
   map_nonneg (f : F) : ∀ a, 0 ≤ f a
-#align nonneg_hom_class NonNegHomClass
+#align nonneg_hom_class NonnegHomClass
 
-/-- `SubAdditiveHomClass F α β` states that `F` is a type of subadditive morphisms. -/
-class SubAdditiveHomClass (F : Type _) (α β : outParam (Type _)) [Add α] [Add β] [LE β] extends
+/-- `SubadditiveHomClass F α β` states that `F` is a type of subadditive morphisms. -/
+class SubadditiveHomClass (F : Type _) (α β : outParam (Type _)) [Add α] [Add β] [LE β] extends
   FunLike F α fun _ => β where
   /-- the image of a sum is less or equal than the sum of the images. -/
   map_add_le_add (f : F) : ∀ a b, f (a + b) ≤ f a + f b
-#align subadditive_hom_class SubAdditiveHomClass
+#align subadditive_hom_class SubadditiveHomClass
 
-/-- `SubMultiplicativeHomClass F α β` states that `F` is a type of submultiplicative morphisms. -/
-@[to_additive SubAdditiveHomClass]
-class SubMultiplicativeHomClass (F : Type _) (α β : outParam (Type _)) [Mul α] [Mul β] [LE β]
+/-- `SubmultiplicativeHomClass F α β` states that `F` is a type of submultiplicative morphisms. -/
+@[to_additive SubadditiveHomClass]
+class SubmultiplicativeHomClass (F : Type _) (α β : outParam (Type _)) [Mul α] [Mul β] [LE β]
   extends FunLike F α fun _ => β where
   /-- the image of a product is less or equal than the product of the images. -/
   map_mul_le_mul (f : F) : ∀ a b, f (a * b) ≤ f a * f b
-#align submultiplicative_hom_class SubMultiplicativeHomClass
+#align submultiplicative_hom_class SubmultiplicativeHomClass
 
 /-- `MulLEAddHomClass F α β` states that `F` is a type of subadditive morphisms. -/
-@[to_additive SubAdditiveHomClass]
+@[to_additive SubadditiveHomClass]
 class MulLEAddHomClass (F : Type _) (α β : outParam (Type _)) [Mul α] [Add β] [LE β]
   extends FunLike F α fun _ => β where
   /-- the image of a product is less or equal than the sum of the images. -/
   map_mul_le_add (f : F) : ∀ a b, f (a * b) ≤ f a + f b
 #align mul_le_add_hom_class MulLEAddHomClass
 
-/-- `NonArchimedeanHomClass F α β` states that `F` is a type of non-archimedean morphisms. -/
-class NonArchimedeanHomClass (F : Type _) (α β : outParam (Type _)) [Add α] [LinearOrder β]
+/-- `NonarchimedeanHomClass F α β` states that `F` is a type of non-archimedean morphisms. -/
+class NonarchimedeanHomClass (F : Type _) (α β : outParam (Type _)) [Add α] [LinearOrder β]
   extends FunLike F α fun _ => β where
   /-- the image of a sum is less or equal than the maximum of the images. -/
   map_add_le_max (f : F) : ∀ a b, f (a + b) ≤ max (f a) (f b)
-#align nonarchimedean_hom_class NonArchimedeanHomClass
+#align nonarchimedean_hom_class NonarchimedeanHomClass
 
-export NonNegHomClass (map_nonneg)
+export NonnegHomClass (map_nonneg)
 
-export SubAdditiveHomClass (map_add_le_add)
+export SubadditiveHomClass (map_add_le_add)
 
-export SubMultiplicativeHomClass (map_mul_le_mul)
+export SubmultiplicativeHomClass (map_mul_le_mul)
 
 export MulLEAddHomClass (map_mul_le_add)
 
-export NonArchimedeanHomClass (map_add_le_max)
+export NonarchimedeanHomClass (map_add_le_max)
 
 attribute [simp] map_nonneg
 
 @[to_additive]
-theorem le_map_mul_map_div [Group α] [CommSemigroup β] [LE β] [SubMultiplicativeHomClass F α β]
+theorem le_map_mul_map_div [Group α] [CommSemigroup β] [LE β] [SubmultiplicativeHomClass F α β]
     (f : F) (a b : α) : f a ≤ f b * f (a / b) := by
   simpa only [mul_comm, div_mul_cancel'] using map_mul_le_mul f (a / b) b
 #align le_map_mul_map_div le_map_mul_map_div
@@ -96,7 +96,7 @@ theorem le_map_add_map_div [Group α] [AddCommSemigroup β] [LE β] [MulLEAddHom
 #align le_map_add_map_div le_map_add_map_div
 
 @[to_additive]
-theorem le_map_div_mul_map_div [Group α] [CommSemigroup β] [LE β] [SubMultiplicativeHomClass F α β]
+theorem le_map_div_mul_map_div [Group α] [CommSemigroup β] [LE β] [SubmultiplicativeHomClass F α β]
     (f : F) (a b c : α) : f (a / c) ≤ f (a / b) * f (b / c) := by
   simpa only [div_mul_div_cancel'] using map_mul_le_mul f (a / b) (b / c)
 #align le_map_div_mul_map_div le_map_div_mul_map_div


### PR DESCRIPTION
The port introduced more caps than necessary in the names. "nonnegative", "subadditive", "submultiplicative" and "nonarchimedean" are all one word each, so shouldn't get caps in the middle. `SubAdditive` and `SubMultiplicative` are particularly dangerous in my opinion, because they should be interpreted as saying that `Sub` is additive/multiplicative.