### PR TITLE
[Merged by Bors] - feat : port Algebra.Regular.Pow

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -116,6 +116,7 @@ import Mathlib.Algebra.PEmptyInstances
 import Mathlib.Algebra.Parity
 import Mathlib.Algebra.Quotient
 import Mathlib.Algebra.Regular.Basic
+import Mathlib.Algebra.Regular.Pow
 import Mathlib.Algebra.Regular.SMul
 import Mathlib.Algebra.Ring.Basic
 import Mathlib.Algebra.Ring.Commute

--- a/Mathlib/Algebra/Regular/Pow.lean
+++ b/Mathlib/Algebra/Regular/Pow.lean
@@ -8,8 +8,8 @@ Authors: Damiano Testa
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
-import Mathbin.Algebra.Hom.Iterate
-import Mathbin.Algebra.Regular.Basic
+import Mathlib.Algebra.Hom.Iterate
+import Mathlib.Algebra.Regular.Basic
 
 /-!
 # Regular elements
@@ -69,4 +69,3 @@ theorem IsRegular.pow_iff {n : ℕ} (n0 : 0 < n) : IsRegular (a ^ n) ↔ IsRegul
 #align is_regular.pow_iff IsRegular.pow_iff
 
 end Monoid
-

--- a/Mathlib/Algebra/Regular/Pow.lean
+++ b/Mathlib/Algebra/Regular/Pow.lean
@@ -1,0 +1,72 @@
+/-
+Copyright (c) 2021 Damiano Testa. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Damiano Testa
+
+! This file was ported from Lean 3 source module algebra.regular.pow
+! leanprover-community/mathlib commit 46a64b5b4268c594af770c44d9e502afc6a515cb
+! Please do not edit these lines, except to modify the commit id
+! if you have ported upstream changes.
+-/
+import Mathbin.Algebra.Hom.Iterate
+import Mathbin.Algebra.Regular.Basic
+
+/-!
+# Regular elements
+
+## Implementation details
+
+Group powers and other definitions import a lot of the algebra hierarchy.
+Lemmas about them are kept separate to be able to provide `is_regular` early in the
+algebra hierarchy.
+
+-/
+
+
+variable {R : Type _} {a b : R}
+
+section Monoid
+
+variable [Monoid R]
+
+/-- Any power of a left-regular element is left-regular. -/
+theorem IsLeftRegular.pow (n : ℕ) (rla : IsLeftRegular a) : IsLeftRegular (a ^ n) := by
+  simp only [IsLeftRegular, ← mul_left_iterate, rla.iterate n]
+#align is_left_regular.pow IsLeftRegular.pow
+
+/-- Any power of a right-regular element is right-regular. -/
+theorem IsRightRegular.pow (n : ℕ) (rra : IsRightRegular a) : IsRightRegular (a ^ n) :=
+  by
+  rw [IsRightRegular, ← mul_right_iterate]
+  exact rra.iterate n
+#align is_right_regular.pow IsRightRegular.pow
+
+/-- Any power of a regular element is regular. -/
+theorem IsRegular.pow (n : ℕ) (ra : IsRegular a) : IsRegular (a ^ n) :=
+  ⟨IsLeftRegular.pow n ra.left, IsRightRegular.pow n ra.right⟩
+#align is_regular.pow IsRegular.pow
+
+/-- An element `a` is left-regular if and only if a positive power of `a` is left-regular. -/
+theorem IsLeftRegular.pow_iff {n : ℕ} (n0 : 0 < n) : IsLeftRegular (a ^ n) ↔ IsLeftRegular a :=
+  by
+  refine' ⟨_, IsLeftRegular.pow n⟩
+  rw [← Nat.succ_pred_eq_of_pos n0, pow_succ']
+  exact IsLeftRegular.of_mul
+#align is_left_regular.pow_iff IsLeftRegular.pow_iff
+
+/-- An element `a` is right-regular if and only if a positive power of `a` is right-regular. -/
+theorem IsRightRegular.pow_iff {n : ℕ} (n0 : 0 < n) : IsRightRegular (a ^ n) ↔ IsRightRegular a :=
+  by
+  refine' ⟨_, IsRightRegular.pow n⟩
+  rw [← Nat.succ_pred_eq_of_pos n0, pow_succ]
+  exact IsRightRegular.of_mul
+#align is_right_regular.pow_iff IsRightRegular.pow_iff
+
+/-- An element `a` is regular if and only if a positive power of `a` is regular. -/
+theorem IsRegular.pow_iff {n : ℕ} (n0 : 0 < n) : IsRegular (a ^ n) ↔ IsRegular a :=
+  ⟨fun h => ⟨(IsLeftRegular.pow_iff n0).mp h.left, (IsRightRegular.pow_iff n0).mp h.right⟩, fun h =>
+    ⟨IsLeftRegular.pow n h.left, IsRightRegular.pow n h.right⟩⟩
+#align is_regular.pow_iff IsRegular.pow_iff
+
+end Monoid
+

--- a/Mathlib/Algebra/Regular/Pow.lean
+++ b/Mathlib/Algebra/Regular/Pow.lean
@@ -17,7 +17,7 @@ import Mathlib.Algebra.Regular.Basic
 ## Implementation details
 
 Group powers and other definitions import a lot of the algebra hierarchy.
-Lemmas about them are kept separate to be able to provide `is_regular` early in the
+Lemmas about them are kept separate to be able to provide `IsRegular` early in the
 algebra hierarchy.
 
 -/


### PR DESCRIPTION
Maybe I was lucky with my first port to mathlib4 or maybe I missed everything since no changes at all (except replacing `Mathbin` by `Mathlib`) were necessary for this port. 

~~I must have done something wrong though since CI is failing in the check import phase and I don't know how to fix it.~~

Ok, I found out I need to add the file to `Mathlib.lean`....

