### PR TITLE
[Merged by Bors] - feat: Port algebra.order.EuclideanAbsoluteValue

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -61,6 +61,7 @@ import Mathlib.Algebra.Invertible
 import Mathlib.Algebra.NeZero
 import Mathlib.Algebra.Opposites
 import Mathlib.Algebra.Order.AbsoluteValue
+import Mathlib.Algebra.Order.EuclideanAbsoluteValue
 import Mathlib.Algebra.Order.Field.Basic
 import Mathlib.Algebra.Order.Field.Canonical.Basic
 import Mathlib.Algebra.Order.Field.Canonical.Defs

--- a/Mathlib/Algebra/Order/EuclideanAbsoluteValue.lean
+++ b/Mathlib/Algebra/Order/EuclideanAbsoluteValue.lean
@@ -26,7 +26,6 @@ absolute value is compatible with the Euclidean domain structure on its domain.
 -/
 
 
--- mathport name: «expr ≺ »
 @[inherit_doc]
 local infixl:50 " ≺ " => EuclideanDomain.r
 

--- a/Mathlib/Algebra/Order/EuclideanAbsoluteValue.lean
+++ b/Mathlib/Algebra/Order/EuclideanAbsoluteValue.lean
@@ -8,8 +8,8 @@ Authors: Anne Baanen
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
-import Mathbin.Algebra.Order.AbsoluteValue
-import Mathbin.Algebra.EuclideanDomain.Instances
+import Mathlib.Algebra.Order.AbsoluteValue
+import Mathlib.Algebra.EuclideanDomain.Instances
 
 /-!
 # Euclidean absolute values

--- a/Mathlib/Algebra/Order/EuclideanAbsoluteValue.lean
+++ b/Mathlib/Algebra/Order/EuclideanAbsoluteValue.lean
@@ -74,8 +74,8 @@ open Int
 /-- `abs : ℤ → ℤ` is a Euclidean absolute value -/
 protected theorem abs_is_euclidean : IsEuclidean (AbsoluteValue.abs : AbsoluteValue ℤ ℤ) :=
   {
-    map_lt_map_iff' := @fun x y =>
-      show abs x < abs y ↔ natAbs x < natAbs y by rw [abs_eq_natAbs, abs_eq_natAbs, Int.ofNat_lt] }
+    map_lt_map_iff' := fun {x y} =>
+      show abs x < abs y ↔ natAbs x < natAbs y by rw [abs_eq_natAbs, abs_eq_natAbs, ofNat_lt] }
 #align absolute_value.abs_is_euclidean AbsoluteValue.abs_is_euclidean
 
 end Int

--- a/Mathlib/Algebra/Order/EuclideanAbsoluteValue.lean
+++ b/Mathlib/Algebra/Order/EuclideanAbsoluteValue.lean
@@ -69,7 +69,7 @@ section Int
 
 open Int
 
--- TODO: generalize to `linear_ordered_euclidean_domain`s if we ever get a definition of those
+-- TODO: generalize to `LinearOrderedEuclideanDomain`s if we ever get a definition of those
 /-- `abs : ℤ → ℤ` is a Euclidean absolute value -/
 protected theorem abs_isEuclidean : IsEuclidean (AbsoluteValue.abs : AbsoluteValue ℤ ℤ) :=
   {  map_lt_map_iff' := fun {x y} =>

--- a/Mathlib/Algebra/Order/EuclideanAbsoluteValue.lean
+++ b/Mathlib/Algebra/Order/EuclideanAbsoluteValue.lean
@@ -42,6 +42,8 @@ variable (abv : AbsoluteValue R S)
 `euclidean_domain` structure on `R`, namely `abv` is strictly monotone with respect to the well
 founded relation `≺` on `R`. -/
 structure IsEuclidean : Prop where
+  /-- The requirement of a Euclidean absolute value
+  that `abv` is monotone with respect to `≺` -/
   map_lt_map_iff' : ∀ {x y}, abv x < abv y ↔ x ≺ y
 #align absolute_value.is_euclidean AbsoluteValue.IsEuclidean
 
@@ -50,7 +52,6 @@ namespace IsEuclidean
 variable {abv}
 
 -- Rearrange the parameters to `map_lt_map_iff'` so it elaborates better.
-
 theorem map_lt_map_iff {x y : R} (h : abv.IsEuclidean) : abv x < abv y ↔ x ≺ y :=
   map_lt_map_iff' h
 #align absolute_value.is_euclidean.map_lt_map_iff AbsoluteValue.IsEuclidean.map_lt_map_iff
@@ -80,4 +81,3 @@ protected theorem abs_is_euclidean : IsEuclidean (AbsoluteValue.abs : AbsoluteVa
 end Int
 
 end AbsoluteValue
-#lint

--- a/Mathlib/Algebra/Order/EuclideanAbsoluteValue.lean
+++ b/Mathlib/Algebra/Order/EuclideanAbsoluteValue.lean
@@ -71,11 +71,10 @@ open Int
 /-- `abs : ℤ → ℤ` is a Euclidean absolute value -/
 protected theorem abs_is_euclidean : IsEuclidean (AbsoluteValue.abs : AbsoluteValue ℤ ℤ) :=
   {
-    map_lt_map_iff' := fun x y =>
-      show abs x < abs y ↔ natAbs x < natAbs y by rw [abs_eq_nat_abs, abs_eq_nat_abs, coe_nat_lt] }
+    map_lt_map_iff' := @fun x y =>
+      show abs x < abs y ↔ natAbs x < natAbs y by rw [abs_eq_natAbs, abs_eq_natAbs, Int.ofNat_lt] }
 #align absolute_value.abs_is_euclidean AbsoluteValue.abs_is_euclidean
 
 end Int
 
 end AbsoluteValue
-

--- a/Mathlib/Algebra/Order/EuclideanAbsoluteValue.lean
+++ b/Mathlib/Algebra/Order/EuclideanAbsoluteValue.lean
@@ -14,7 +14,7 @@ import Mathlib.Algebra.EuclideanDomain.Instances
 /-!
 # Euclidean absolute values
 
-This file defines a predicate `absolute_value.is_euclidean abv` stating the
+This file defines a predicate `AbsoluteValue.IsEuclidean abv` stating the
 absolute value is compatible with the Euclidean domain structure on its domain.
 
 ## Main definitions

--- a/Mathlib/Algebra/Order/EuclideanAbsoluteValue.lean
+++ b/Mathlib/Algebra/Order/EuclideanAbsoluteValue.lean
@@ -19,9 +19,9 @@ absolute value is compatible with the Euclidean domain structure on its domain.
 
 ## Main definitions
 
- * `absolute_value.is_euclidean abv` is a predicate on absolute values on `R` mapping to `S`
+ * `AbsoluteValue.IsEuclidean abv` is a predicate on absolute values on `R` mapping to `S`
     that preserve the order on `R` arising from the Euclidean domain structure.
- * `absolute_value.abs_is_euclidean` shows the "standard" absolute value on `ℤ`,
+ * `AbsoluteValue.abs_isEuclidean` shows the "standard" absolute value on `ℤ`,
    mapping negative `x` to `-x`, is euclidean.
 -/
 

--- a/Mathlib/Algebra/Order/EuclideanAbsoluteValue.lean
+++ b/Mathlib/Algebra/Order/EuclideanAbsoluteValue.lean
@@ -1,0 +1,81 @@
+/-
+Copyright (c) 2021 Anne Baanen. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Anne Baanen
+
+! This file was ported from Lean 3 source module algebra.order.euclidean_absolute_value
+! leanprover-community/mathlib commit 422e70f7ce183d2900c586a8cda8381e788a0c62
+! Please do not edit these lines, except to modify the commit id
+! if you have ported upstream changes.
+-/
+import Mathbin.Algebra.Order.AbsoluteValue
+import Mathbin.Algebra.EuclideanDomain.Instances
+
+/-!
+# Euclidean absolute values
+
+This file defines a predicate `absolute_value.is_euclidean abv` stating the
+absolute value is compatible with the Euclidean domain structure on its domain.
+
+## Main definitions
+
+ * `absolute_value.is_euclidean abv` is a predicate on absolute values on `R` mapping to `S`
+    that preserve the order on `R` arising from the Euclidean domain structure.
+ * `absolute_value.abs_is_euclidean` shows the "standard" absolute value on `ℤ`,
+   mapping negative `x` to `-x`, is euclidean.
+-/
+
+
+-- mathport name: «expr ≺ »
+local infixl:50 " ≺ " => EuclideanDomain.r
+
+namespace AbsoluteValue
+
+section OrderedSemiring
+
+variable {R S : Type _} [EuclideanDomain R] [OrderedSemiring S]
+
+variable (abv : AbsoluteValue R S)
+
+/-- An absolute value `abv : R → S` is Euclidean if it is compatible with the
+`euclidean_domain` structure on `R`, namely `abv` is strictly monotone with respect to the well
+founded relation `≺` on `R`. -/
+structure IsEuclidean : Prop where
+  map_lt_map_iff' : ∀ {x y}, abv x < abv y ↔ x ≺ y
+#align absolute_value.is_euclidean AbsoluteValue.IsEuclidean
+
+namespace IsEuclidean
+
+variable {abv}
+
+-- Rearrange the parameters to `map_lt_map_iff'` so it elaborates better.
+theorem map_lt_map_iff {x y : R} (h : abv.IsEuclidean) : abv x < abv y ↔ x ≺ y :=
+  map_lt_map_iff' h
+#align absolute_value.is_euclidean.map_lt_map_iff AbsoluteValue.IsEuclidean.map_lt_map_iff
+
+attribute [simp] map_lt_map_iff
+
+theorem sub_mod_lt (h : abv.IsEuclidean) (a : R) {b : R} (hb : b ≠ 0) : abv (a % b) < abv b :=
+  h.map_lt_map_iff.mpr (EuclideanDomain.mod_lt a hb)
+#align absolute_value.is_euclidean.sub_mod_lt AbsoluteValue.IsEuclidean.sub_mod_lt
+
+end IsEuclidean
+
+end OrderedSemiring
+
+section Int
+
+open Int
+
+-- TODO: generalize to `linear_ordered_euclidean_domain`s if we ever get a definition of those
+/-- `abs : ℤ → ℤ` is a Euclidean absolute value -/
+protected theorem abs_is_euclidean : IsEuclidean (AbsoluteValue.abs : AbsoluteValue ℤ ℤ) :=
+  {
+    map_lt_map_iff' := fun x y =>
+      show abs x < abs y ↔ natAbs x < natAbs y by rw [abs_eq_nat_abs, abs_eq_nat_abs, coe_nat_lt] }
+#align absolute_value.abs_is_euclidean AbsoluteValue.abs_is_euclidean
+
+end Int
+
+end AbsoluteValue
+

--- a/Mathlib/Algebra/Order/EuclideanAbsoluteValue.lean
+++ b/Mathlib/Algebra/Order/EuclideanAbsoluteValue.lean
@@ -38,7 +38,7 @@ variable {R S : Type _} [EuclideanDomain R] [OrderedSemiring S]
 variable (abv : AbsoluteValue R S)
 
 /-- An absolute value `abv : R → S` is Euclidean if it is compatible with the
-`euclidean_domain` structure on `R`, namely `abv` is strictly monotone with respect to the well
+`EuclideanDomain` structure on `R`, namely `abv` is strictly monotone with respect to the well
 founded relation `≺` on `R`. -/
 structure IsEuclidean : Prop where
   /-- The requirement of a Euclidean absolute value

--- a/Mathlib/Algebra/Order/EuclideanAbsoluteValue.lean
+++ b/Mathlib/Algebra/Order/EuclideanAbsoluteValue.lean
@@ -71,10 +71,9 @@ open Int
 
 -- TODO: generalize to `linear_ordered_euclidean_domain`s if we ever get a definition of those
 /-- `abs : ℤ → ℤ` is a Euclidean absolute value -/
-protected theorem abs_is_euclidean : IsEuclidean (AbsoluteValue.abs : AbsoluteValue ℤ ℤ) :=
-  {
-    map_lt_map_iff' := fun {x y} =>
-      show abs x < abs y ↔ natAbs x < natAbs y by rw [abs_eq_natAbs, abs_eq_natAbs, ofNat_lt] }
+protected theorem abs_isEuclidean : IsEuclidean (AbsoluteValue.abs : AbsoluteValue ℤ ℤ) :=
+  {  map_lt_map_iff' := fun {x y} =>
+       show abs x < abs y ↔ natAbs x < natAbs y by rw [abs_eq_natAbs, abs_eq_natAbs, ofNat_lt] }
 #align absolute_value.abs_is_euclidean AbsoluteValue.abs_is_euclidean
 
 end Int

--- a/Mathlib/Algebra/Order/EuclideanAbsoluteValue.lean
+++ b/Mathlib/Algebra/Order/EuclideanAbsoluteValue.lean
@@ -27,6 +27,7 @@ absolute value is compatible with the Euclidean domain structure on its domain.
 
 
 -- mathport name: «expr ≺ »
+@[inherit_doc]
 local infixl:50 " ≺ " => EuclideanDomain.r
 
 namespace AbsoluteValue
@@ -49,6 +50,7 @@ namespace IsEuclidean
 variable {abv}
 
 -- Rearrange the parameters to `map_lt_map_iff'` so it elaborates better.
+
 theorem map_lt_map_iff {x y : R} (h : abv.IsEuclidean) : abv x < abv y ↔ x ≺ y :=
   map_lt_map_iff' h
 #align absolute_value.is_euclidean.map_lt_map_iff AbsoluteValue.IsEuclidean.map_lt_map_iff
@@ -78,3 +80,4 @@ protected theorem abs_is_euclidean : IsEuclidean (AbsoluteValue.abs : AbsoluteVa
 end Int
 
 end AbsoluteValue
+#lint

--- a/Mathlib/Algebra/Order/EuclideanAbsoluteValue.lean
+++ b/Mathlib/Algebra/Order/EuclideanAbsoluteValue.lean
@@ -74,7 +74,7 @@ open Int
 protected theorem abs_isEuclidean : IsEuclidean (AbsoluteValue.abs : AbsoluteValue ℤ ℤ) :=
   {  map_lt_map_iff' := fun {x y} =>
        show abs x < abs y ↔ natAbs x < natAbs y by rw [abs_eq_natAbs, abs_eq_natAbs, ofNat_lt] }
-#align absolute_value.abs_is_euclidean AbsoluteValue.abs_is_euclidean
+#align absolute_value.abs_is_euclidean AbsoluteValue.abs_isEuclidean
 
 end Int
 


### PR DESCRIPTION
Small PR. Nothing super special here, although I did have a question. On line 74, is it within style guidelines to use `@` to make the parameters explicit? Thanks!