### PR TITLE
[Merged by Bors] - refactor: move some classes to `Prop`

### DIFF
--- a/Mathlib/GroupTheory/Submonoid/Basic.lean
+++ b/Mathlib/GroupTheory/Submonoid/Basic.lean
@@ -72,7 +72,7 @@ variable [MulOneClass M] {s : Set M}
 variable [AddZeroClass A] {t : Set A}
 
 /-- `OneMemClass S M` says `S` is a type of subsets `s ≤ M`, such that `1 ∈ s` for all `s`. -/
-class OneMemClass (S : Type _) (M : outParam <| Type _) [One M] [SetLike S M] where
+class OneMemClass (S : Type _) (M : outParam <| Type _) [One M] [SetLike S M] : Prop where
   /-- By definition, if we have `OneMemClass S M`, we have `1 ∈ s` for all `s : S`. -/
   one_mem : ∀ s : S, (1 : M) ∈ s
 #align one_mem_class OneMemClass
@@ -80,7 +80,7 @@ class OneMemClass (S : Type _) (M : outParam <| Type _) [One M] [SetLike S M] wh
 export OneMemClass (one_mem)
 
 /-- `ZeroMemClass S M` says `S` is a type of subsets `s ≤ M`, such that `0 ∈ s` for all `s`. -/
-class ZeroMemClass (S : Type _) (M : outParam <| Type _) [Zero M] [SetLike S M] where
+class ZeroMemClass (S : Type _) (M : outParam <| Type _) [Zero M] [SetLike S M] : Prop where
   /-- By definition, if we have `ZeroMemClass S M`, we have `0 ∈ s` for all `s : S`. -/
   zero_mem : ∀ s : S, (0 : M) ∈ s
 #align zero_mem_class ZeroMemClass
@@ -105,9 +105,7 @@ add_decl_doc Submonoid.toSubsemigroup
 /-- `SubmonoidClass S M` says `S` is a type of subsets `s ≤ M` that contain `1`
 and are closed under `(*)` -/
 class SubmonoidClass (S : Type _) (M : outParam <| Type _) [MulOneClass M] [SetLike S M] extends
-  MulMemClass S M where
-  /-- A submonoid contains `1.` -/
-  one_mem : ∀ s : S, (1 : M) ∈ s
+  MulMemClass S M, OneMemClass S M : Prop
 #align submonoid_class SubmonoidClass
 
 section
@@ -128,19 +126,10 @@ add_decl_doc AddSubmonoid.toAddSubsemigroup
 /-- `AddSubmonoidClass S M` says `S` is a type of subsets `s ≤ M` that contain `0`
 and are closed under `(+)` -/
 class AddSubmonoidClass (S : Type _) (M : outParam <| Type _) [AddZeroClass M] [SetLike S M] extends
-  AddMemClass S M where
-  /-- An additive submonoid contains `0`. -/
-  zero_mem : ∀ s : S, (0 : M) ∈ s
+  AddMemClass S M, ZeroMemClass S M : Prop
 #align add_submonoid_class AddSubmonoidClass
 
 attribute [to_additive] Submonoid SubmonoidClass
-
--- See note [lower instance priority]
-@[to_additive]
-instance (priority := 100) SubmonoidClass.toOneMemClass (S : Type _) (M : outParam <| Type _)
-    {_ : MulOneClass M} {_ : SetLike S M} [h : SubmonoidClass S M] : OneMemClass S M :=
-  { h with }
-#align submonoid_class.to_one_mem_class SubmonoidClass.toOneMemClass
 
 @[to_additive]
 theorem pow_mem {M A} [Monoid M] [SetLike A M] [SubmonoidClass A M] {S : A} {x : M}

--- a/Mathlib/GroupTheory/Subsemigroup/Basic.lean
+++ b/Mathlib/GroupTheory/Subsemigroup/Basic.lean
@@ -62,7 +62,7 @@ variable [Mul M] {s : Set M}
 variable [Add A] {t : Set A}
 
 /-- `MulMemClass S M` says `S` is a type of sets `s : Set M` that are closed under `(*)` -/
-class MulMemClass (S : Type _) (M : outParam <| Type _) [Mul M] [SetLike S M] where
+class MulMemClass (S : Type _) (M : outParam <| Type _) [Mul M] [SetLike S M] : Prop where
   /-- A substructure satisfying `MulMemClass` is closed under multiplication. -/
   mul_mem : ∀ {s : S} {a b : M}, a ∈ s → b ∈ s → a * b ∈ s
 #align mul_mem_class MulMemClass
@@ -70,7 +70,7 @@ class MulMemClass (S : Type _) (M : outParam <| Type _) [Mul M] [SetLike S M] wh
 export MulMemClass (mul_mem)
 
 /-- `AddMemClass S M` says `S` is a type of sets `s : Set M` that are closed under `(+)` -/
-class AddMemClass (S : Type _) (M : outParam <| Type _) [Add M] [SetLike S M] where
+class AddMemClass (S : Type _) (M : outParam <| Type _) [Add M] [SetLike S M] : Prop where
   /-- A substructure satisfying `AddMemClass` is closed under addition. -/
   add_mem : ∀ {s : S} {a b : M}, a ∈ s → b ∈ s → a + b ∈ s
 #align add_mem_class AddMemClass


### PR DESCRIPTION
Also make `SubmonoidClass` extend `OneMemClass`.
This is a Lean 4 version of leanprover-community/mathlib#18015