### PR TITLE
[Merged by Bors] - feat: synchronize with mathlib3 #17905

### DIFF
--- a/Mathlib/Order/Directed.lean
+++ b/Mathlib/Order/Directed.lean
@@ -223,16 +223,16 @@ protected theorem IsMax.isTop [IsDirected α (· ≤ ·)] (h : IsMax a) : IsTop 
   h.toDual.isBot
 #align is_max.is_top IsMax.isTop
 
-lemma DirectedOn.isBot_of_isMin {s : Set α} (hd : DirectedOn (· ≥ ·) s)
+lemma DirectedOn.is_bot_of_is_min {s : Set α} (hd : DirectedOn (· ≥ ·) s)
     {m} (hm : m ∈ s) (hmin : ∀ a ∈ s, a ≤ m → m ≤ a) : ∀ a ∈ s, m ≤ a := fun a as =>
   let ⟨x, xs, xm, xa⟩ := hd m hm a as
   (hmin x xs xm).trans xa
-#align directed_on.is_bot_of_is_min DirectedOn.isBot_of_isMin
+#align directed_on.is_bot_of_is_min DirectedOn.is_bot_of_is_min
 
-lemma DirectedOn.isTop_of_isMax {s : Set α} (hd : DirectedOn (· ≤ ·) s)
+lemma DirectedOn.is_top_of_is_max {s : Set α} (hd : DirectedOn (· ≤ ·) s)
     {m} (hm : m ∈ s) (hmax : ∀ a ∈ s, m ≤ a → a ≤ m) : ∀ a ∈ s, a ≤ m :=
-  @DirectedOn.isBot_of_isMin αᵒᵈ _ s hd m hm hmax
-#align directed_on.is_top_of_is_max DirectedOn.isTop_of_isMax
+  @DirectedOn.is_bot_of_is_min αᵒᵈ _ s hd m hm hmax
+#align directed_on.is_top_of_is_max DirectedOn.is_top_of_is_max
 
 theorem isTop_or_exists_gt [IsDirected α (· ≤ ·)] (a : α) : IsTop a ∨ ∃ b, a < b :=
   (em (IsMax a)).imp IsMax.isTop not_isMax_iff.mp

--- a/Mathlib/Order/Directed.lean
+++ b/Mathlib/Order/Directed.lean
@@ -56,6 +56,11 @@ theorem directedOn_iff_directed {s} : @DirectedOn α r s ↔ Directed r (Subtype
 
 alias directedOn_iff_directed ↔ DirectedOn.directed_val _
 
+theorem directedOn_range {f : β → α} :
+  Directed r f ↔ DirectedOn r (Set.range f) :=
+by simp_rw [Directed, DirectedOn, Set.forall_range_iff, Set.exists_range_iff]
+#align directed_on_range directedOn_range
+
 theorem directedOn_image {s : Set β} {f : β → α} :
     DirectedOn r (f '' s) ↔ DirectedOn (f ⁻¹'o r) s := by
   simp only [DirectedOn, Set.mem_image, exists_exists_and_eq_and, forall_exists_index, and_imp,
@@ -218,6 +223,16 @@ protected theorem IsMin.isBot [IsDirected α (· ≥ ·)] (h : IsMin a) : IsBot 
 protected theorem IsMax.isTop [IsDirected α (· ≤ ·)] (h : IsMax a) : IsTop a :=
   h.toDual.isBot
 #align is_max.is_top IsMax.isTop
+
+lemma DirectedOn.isBot_of_isMin {s : Set α} (hd : DirectedOn (· ≥ ·) s)
+  {m} (hm : m ∈ s) (hmin : ∀ a ∈ s, a ≤ m → m ≤ a) : ∀ a ∈ s, m ≤ a :=
+λ a as => let ⟨x, xs, xm, xa⟩ := hd m hm a as; (hmin x xs xm).trans xa
+#align directed_on.is_bot_of_is_min DirectedOn.isBot_of_isMin
+
+lemma DirectedOn.isTop_of_isMax {s : Set α} (hd : DirectedOn (· ≤ ·) s)
+  {m} (hm : m ∈ s) (hmax : ∀ a ∈ s, m ≤ a → a ≤ m) : ∀ a ∈ s, a ≤ m :=
+@DirectedOn.isBot_of_isMin αᵒᵈ _ s hd m hm hmax
+#align directed_on.is_top_of_is_max DirectedOn.isTop_of_isMax
 
 theorem isTop_or_exists_gt [IsDirected α (· ≤ ·)] (a : α) : IsTop a ∨ ∃ b, a < b :=
   (em (IsMax a)).imp IsMax.isTop not_isMax_iff.mp

--- a/Mathlib/Order/Directed.lean
+++ b/Mathlib/Order/Directed.lean
@@ -56,9 +56,8 @@ theorem directedOn_iff_directed {s} : @DirectedOn α r s ↔ Directed r (Subtype
 
 alias directedOn_iff_directed ↔ DirectedOn.directed_val _
 
-theorem directedOn_range {f : β → α} :
-  Directed r f ↔ DirectedOn r (Set.range f) :=
-by simp_rw [Directed, DirectedOn, Set.forall_range_iff, Set.exists_range_iff]
+theorem directedOn_range {f : β → α} : Directed r f ↔ DirectedOn r (Set.range f) := by
+  simp_rw [Directed, DirectedOn, Set.forall_range_iff, Set.exists_range_iff]
 #align directed_on_range directedOn_range
 
 theorem directedOn_image {s : Set β} {f : β → α} :
@@ -225,13 +224,14 @@ protected theorem IsMax.isTop [IsDirected α (· ≤ ·)] (h : IsMax a) : IsTop 
 #align is_max.is_top IsMax.isTop
 
 lemma DirectedOn.isBot_of_isMin {s : Set α} (hd : DirectedOn (· ≥ ·) s)
-  {m} (hm : m ∈ s) (hmin : ∀ a ∈ s, a ≤ m → m ≤ a) : ∀ a ∈ s, m ≤ a :=
-λ a as => let ⟨x, xs, xm, xa⟩ := hd m hm a as; (hmin x xs xm).trans xa
+    {m} (hm : m ∈ s) (hmin : ∀ a ∈ s, a ≤ m → m ≤ a) : ∀ a ∈ s, m ≤ a := fun a as =>
+  let ⟨x, xs, xm, xa⟩ := hd m hm a as
+  (hmin x xs xm).trans xa
 #align directed_on.is_bot_of_is_min DirectedOn.isBot_of_isMin
 
 lemma DirectedOn.isTop_of_isMax {s : Set α} (hd : DirectedOn (· ≤ ·) s)
-  {m} (hm : m ∈ s) (hmax : ∀ a ∈ s, m ≤ a → a ≤ m) : ∀ a ∈ s, a ≤ m :=
-@DirectedOn.isBot_of_isMin αᵒᵈ _ s hd m hm hmax
+    {m} (hm : m ∈ s) (hmax : ∀ a ∈ s, m ≤ a → a ≤ m) : ∀ a ∈ s, a ≤ m :=
+  @DirectedOn.isBot_of_isMin αᵒᵈ _ s hd m hm hmax
 #align directed_on.is_top_of_is_max DirectedOn.isTop_of_isMax
 
 theorem isTop_or_exists_gt [IsDirected α (· ≤ ·)] (a : α) : IsTop a ∨ ∃ b, a < b :=

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -2,56 +2,20 @@
  "packagesDir": "./lake-packages",
  "packages":
  [{"git":
-   {"url": "https://github.com/xubaiw/CMark.lean",
-    "subDir?": null,
-    "rev": "2cc7cdeef67184f84db6731450e4c2b258c28fe8",
-    "name": "CMark",
-    "inputRev?": "main"}},
-  {"git":
-   {"url": "https://github.com/leanprover/lake",
-    "subDir?": null,
-    "rev": "d0b530530f14dde97a547b03abf87eee06360d60",
-    "name": "lake",
-    "inputRev?": "master"}},
-  {"git":
-   {"url": "https://github.com/leanprover/doc-gen4",
-    "subDir?": null,
-    "rev": "bdf803b1002786b87da7b8db8d2746c0002a715f",
-    "name": "doc-gen4",
-    "inputRev?": "main"}},
-  {"git":
-   {"url": "https://github.com/mhuisi/lean4-cli",
-    "subDir?": null,
-    "rev": "5a858c32963b6b19be0d477a30a1f4b6c120be7e",
-    "name": "Cli",
-    "inputRev?": "nightly"}},
-  {"git":
    {"url": "https://github.com/gebner/quote4",
     "subDir?": null,
     "rev": "7ac99aa3fac487bec1d5860e751b99c7418298cf",
     "name": "Qq",
     "inputRev?": "master"}},
   {"git":
-   {"url": "https://github.com/gebner/aesop",
+   {"url": "https://github.com/JLimperg/aesop",
     "subDir?": null,
-    "rev": "6f04ed73886f455a8ec41fbbae21ef6b870c61ff",
+    "rev": "c4477a2a7931e2490339d8087f599a45e89f25e7",
     "name": "aesop",
     "inputRev?": "master"}},
   {"git":
-   {"url": "https://github.com/hargonix/LeanInk",
-    "subDir?": null,
-    "rev": "2447df5cc6e48eb965c3c3fba87e46d353b5e9f1",
-    "name": "leanInk",
-    "inputRev?": "doc-gen"}},
-  {"git":
-   {"url": "https://github.com/xubaiw/Unicode.lean",
-    "subDir?": null,
-    "rev": "6dd6ae3a3839c8350a91876b090eda85cf538d1d",
-    "name": "Unicode",
-    "inputRev?": "main"}},
-  {"git":
    {"url": "https://github.com/leanprover/std4",
     "subDir?": null,
-    "rev": "a109889bf299f0d086f93a228e4c152f40ff5b0d",
+    "rev": "2919713bde15d55e3ea3625a03546531283bcb54",
     "name": "std",
     "inputRev?": "main"}}]}

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -2,6 +2,30 @@
  "packagesDir": "./lake-packages",
  "packages":
  [{"git":
+   {"url": "https://github.com/xubaiw/CMark.lean",
+    "subDir?": null,
+    "rev": "2cc7cdeef67184f84db6731450e4c2b258c28fe8",
+    "name": "CMark",
+    "inputRev?": "main"}},
+  {"git":
+   {"url": "https://github.com/leanprover/lake",
+    "subDir?": null,
+    "rev": "d0b530530f14dde97a547b03abf87eee06360d60",
+    "name": "lake",
+    "inputRev?": "master"}},
+  {"git":
+   {"url": "https://github.com/leanprover/doc-gen4",
+    "subDir?": null,
+    "rev": "bdf803b1002786b87da7b8db8d2746c0002a715f",
+    "name": "doc-gen4",
+    "inputRev?": "main"}},
+  {"git":
+   {"url": "https://github.com/mhuisi/lean4-cli",
+    "subDir?": null,
+    "rev": "5a858c32963b6b19be0d477a30a1f4b6c120be7e",
+    "name": "Cli",
+    "inputRev?": "nightly"}},
+  {"git":
    {"url": "https://github.com/gebner/quote4",
     "subDir?": null,
     "rev": "7ac99aa3fac487bec1d5860e751b99c7418298cf",
@@ -13,6 +37,18 @@
     "rev": "c4477a2a7931e2490339d8087f599a45e89f25e7",
     "name": "aesop",
     "inputRev?": "master"}},
+  {"git":
+   {"url": "https://github.com/hargonix/LeanInk",
+    "subDir?": null,
+    "rev": "2447df5cc6e48eb965c3c3fba87e46d353b5e9f1",
+    "name": "leanInk",
+    "inputRev?": "doc-gen"}},
+  {"git":
+   {"url": "https://github.com/xubaiw/Unicode.lean",
+    "subDir?": null,
+    "rev": "6dd6ae3a3839c8350a91876b090eda85cf538d1d",
+    "name": "Unicode",
+    "inputRev?": "main"}},
   {"git":
    {"url": "https://github.com/leanprover/std4",
     "subDir?": null,


### PR DESCRIPTION
mathlib3 SHA: 6cb77a8eaff0ddd100e87b1591c6d3ad319514ff

________

[mathlib#17905](https://github.com/leanprover-community/mathlib/pull/17905/files#diff-deb01ba12632f4703c3dc29a10a34bd3a7d2a1c02dcf8b44d3e561fe3bde06fe) has been approved, so I think reviewers don't need to check the mathematical content.