### PR TITLE
[Merged by Bors] - fix: better error handling in start_port.sh

### DIFF
--- a/scripts/start_port.sh
+++ b/scripts/start_port.sh
@@ -11,7 +11,13 @@ if [ ! $1 ] ; then
     echo "usage: ./scripts/start_port.sh Mathlib/Foo/Bar/Baz.lean"
     exit 1
 fi
-    
+
+case $1 in
+    Mathlib/*) true ;;
+    *) echo "argument must begin with Mathlib/"
+       exit 1 ;;
+esac
+
 if [ -f $1 ] ; then
     echo "file already exists"
     exit 1
@@ -29,11 +35,11 @@ mathlib4_mod=$(basename $(echo "$mathlib4_path" | tr / .) .lean)
 
 mathlib3port_url=$MATHLIB3PORT_BASE_URL/Mathbin/${1#Mathlib/}
 
-curl --silent --show-error -o "$TMP_FILE" "$mathlib3port_url"
+curl --silent --show-error --fail -o "$TMP_FILE" "$mathlib3port_url"
 
 mathlib3_module=$(grep '^! .*source module ' <"$TMP_FILE" | sed 's/.*source module \(.*\)$/\1/')
 
-if curl --silent --show-error "$PORT_STATUS_YAML" | grep -F "$mathlib3_module: " | grep "mathlib4#" ; then
+if curl --silent --show-error --fail "$PORT_STATUS_YAML" | grep -F "$mathlib3_module: " | grep "mathlib4#" ; then
     set +x
     echo "WARNING: The file is already in the process of being ported."
     echo "(See line above for PR number.)"


### PR DESCRIPTION
* Previously, if the user omitted the `Mathlib/` prefix, start_port.sh would add `Mathbin/` anyways and continue, but produce a file in the wrong location. Now, we exit if the argument doesn't begin with `Mathlib/`.

* Use `curl --fail` so that the script exits on HTTP 404 (for example).