### PR TITLE
[Merged by Bors] - fix: ignore isImplementationDetail ldecls in Tauto.distribNot

### DIFF
--- a/Mathlib/Data/Set/Intervals/UnorderedInterval.lean
+++ b/Mathlib/Data/Set/Intervals/UnorderedInterval.lean
@@ -11,6 +11,7 @@ Authors: Zhouhang Zhou
 import Mathlib.Order.Bounds.Basic
 import Mathlib.Data.Set.Intervals.Basic
 import Mathlib.Tactic.ScopedNS
+import Mathlib.Tactic.Tauto
 
 /-!
 # Intervals without endpoints ordering
@@ -228,8 +229,7 @@ theorem interval_subset_interval_union_interval : [[a, c]] ⊆ [[a, b]] ∪ [[b,
   simp only [mem_interval, mem_union]
   cases' le_total a c with h1 h1 <;>
   cases' le_total x b with h2 h2 <;>
-  -- Porting note: restore `tauto`
-  aesop
+  tauto
 #align set.interval_subset_interval_union_interval Set.interval_subset_interval_union_interval
 
 theorem monotone_or_antitone_iff_interval :
@@ -281,25 +281,8 @@ theorem mem_intervalOC : a ∈ Ι b c ↔ b < a ∧ a ≤ c ∨ c < a ∧ a ≤ 
 #align set.mem_interval_oc Set.mem_intervalOC
 
 theorem not_mem_intervalOC : a ∉ Ι b c ↔ a ≤ b ∧ a ≤ c ∨ c < a ∧ b < a := by
-  -- Porting note: restore `tauto` once it's ported
-  -- simp only [interval_oc_eq_union, mem_union, mem_Ioc, not_lt, ← not_le]
-  -- tauto
-  rw [intervalOC_eq_union, mem_union, mem_Ioc, mem_Ioc]
-  push_neg
-  constructor
-  · rintro ⟨h1, h2⟩
-    by_cases b < a
-    case pos _ =>
-      apply Or.intro_right
-      exact ⟨h1 h, h⟩
-    case neg _ =>
-      rw [not_lt] at h
-      rw [← not_imp_not, not_lt, not_lt] at h2
-      apply Or.intro_left
-      exact ⟨h, h2 h⟩
-  · intro h
-    rw [← iff_def, iff_iff_and_or_not_and_not, and_comm]
-    rwa [← not_lt, ← not_lt, or_comm] at h
+  simp only [intervalOC_eq_union, mem_union, mem_Ioc, not_lt, ← not_le]
+  tauto
 #align set.not_mem_interval_oc Set.not_mem_intervalOC
 
 @[simp]

--- a/Mathlib/Tactic/Tauto.lean
+++ b/Mathlib/Tactic/Tauto.lean
@@ -78,7 +78,8 @@ Always succeeds, regardless of whether any progress was actually made.
 -/
 def distribNot : TacticM Unit := withMainContext do
   for h in ← getLCtx do
-    iterateAtMost 3 $ liftMetaTactic' (distribNotAt h)
+    if !h.isImplementationDetail then
+      iterateAtMost 3 $ liftMetaTactic' (distribNotAt h)
 
 /-- Config for the `tauto` tactic. Currently empty. TODO: add `closer` option. -/
 structure Config

--- a/test/Tauto.lean
+++ b/test/Tauto.lean
@@ -72,6 +72,19 @@ example (p : Prop) (em : p ∨ ¬ p) : ¬ (p ↔ ¬ p) := by tauto
 example (P : Nat → Prop) (n : Nat) : P n → n = 7 ∨ n = 0 ∨ ¬ (n = 7 ∨ n = 0) ∧ P n :=
 by tauto
 
+section implementation_detail_ldecl
+variable (a b c : Nat)
+
+/--
+Mathlib.Tactic.Tauto.distribNot must ignore any LocalDecl where isImplementationDetail
+is true. Otherwise, this example yields an error saying "well-founded recursion cannot
+be used".
+-/
+example : ¬(¬a ≤ b ∧ a ≤ c ∨ ¬a ≤ c ∧ a ≤ b) ↔ a ≤ b ∧ a ≤ c ∨ ¬a ≤ c ∧ ¬a ≤ b :=
+by tauto
+
+end implementation_detail_ldecl
+
 section modulo_symmetry
 variable {p q r : Prop} {α : Type} {x y : α}
 variable (h : x = y)


### PR DESCRIPTION
* Fixes a bug where `tauto` could try to work on a recursive auxiliary `LocalDecl`, potentially causing an error about well-founded recursion.
* Updates Data/Set/Intervals/UnorderedInterval.lean to use tauto, as per TODOs. The `not_mem_intervalOC` theorem is where I noticed the bug.
* Adds a test case isolated from `not_mem_intervalOC`.