### PR TITLE
[Merged by Bors] - chore: remove superfluous imports from `runLinter`

### DIFF
--- a/scripts/runLinter.lean
+++ b/scripts/runLinter.lean
@@ -1,5 +1,4 @@
 import Std.Tactic.Lint
-import Mathlib.Data.Array.Defs
 
 open Lean Core Elab Command Std.Tactic.Lint
 


### PR DESCRIPTION
`Mathlib.Data.Array.Defs` is currently an empty file, because its contents have been upstreamed to Std, but it had `import Std` in it which means that building the linter requires compiling all of `Std`, which is not necessary. This is especially obvious now that builds are being cached since the only part that is not cached is the compilation of the C files.