### PR TITLE
fix: uppercase mathlib package name

### DIFF
--- a/Cache/IO.lean
+++ b/Cache/IO.lean
@@ -49,7 +49,7 @@ def isMathlibRoot : IO Bool :=
   FilePath.mk "Mathlib" |>.pathExists
 
 def mathlibDepPath : FilePath :=
-  LAKEPACKAGESDIR / "Mathlib"
+  LAKEPACKAGESDIR / "mathlib"
 
 def getPackageDirs : IO PackageDirs := return .ofList [
   ("Mathlib", if ← isMathlibRoot then "." else mathlibDepPath),


### PR DESCRIPTION
Lake clones the mathlib4 repo as "mathlib" because that's the package name defined in the `lakefile.lean`