### PR TITLE
[Merged by Bors] - fix: always unpack caches

### DIFF
--- a/Cache/IO.lean
+++ b/Cache/IO.lean
@@ -129,7 +129,7 @@ def getLocalCacheSet : IO $ Lean.RBTree String compare := do
   return .ofList (paths.data.map (·.withoutParent CACHEDIR |>.toString))
 
 /-- Decompresses build files into their respective folders -/
-def setCache (hashMap : HashMap) : IO Unit := do
+def unpackCache (hashMap : HashMap) : IO Unit := do
   let hashMap := hashMap.filter (← getLocalCacheSet) true
   let size := hashMap.size
   if size > 0 then
@@ -146,7 +146,7 @@ def setCache (hashMap : HashMap) : IO Unit := do
       else
         discard $ runCmd "tar" #["-xzf", s!"{CACHEDIR / hash.asTarGz}",
           "-C", mathlibDepPath.toString]
-  else IO.println "No cache do decompress"
+  else IO.println "No cache files to decompress"
 
 instance : Ord FilePath where
   compare x y := compare x.toString y.toString

--- a/Cache/Main.lean
+++ b/Cache/Main.lean
@@ -11,11 +11,11 @@ Usage: cache [COMMAND]
 
 Commands:
   # No priviledge required
-  get       Download and decompress linked files missing on the local cache
-  get!      Download and decompress all linked files
+  get       Download linked files missing on the local cache and decompress
+  get!      Download all linked files and decompress
   mk        Compress non-compressed build files into the local cache
   mk!       Compress build files into the local cache (no skipping)
-  set       Decompress linked files
+  unpack    Decompress linked already downloaded files
   clean     Delete non-linked files
   clean!    Delete everything on the local cache
 
@@ -33,11 +33,11 @@ open Cache IO Hashing Requests in
 def main (args : List String) : IO Unit := do
   let hashMap  ← getHashes
   match args with
-  | ["get"] => getFiles (hashMap.filter (← getLocalCacheSet) false)
-  | ["get!"] => getFiles hashMap
+  | ["get"] => getFiles hashMap false
+  | ["get!"] => getFiles hashMap true
   | ["mk"] => discard $ mkCache hashMap false
   | ["mk!"] => discard $ mkCache hashMap true
-  | ["set"] => setCache hashMap
+  | ["unpack"] => unpackCache hashMap
   | ["clean"] =>
     cleanCache $ hashMap.fold (fun acc _ hash => acc.insert $ CACHEDIR / hash.asTarGz) .empty
   | ["clean!"] => cleanCache


### PR DESCRIPTION
Previously, `lake exe cache get` would only unpack caches that were downloaded in the current command.  (Which makes caching useless if you switch back and forth between branches.)