### PR TITLE
[Merged by Bors] - chore: Order.Closure Update SHA

### DIFF
--- a/Mathlib/Order/Closure.lean
+++ b/Mathlib/Order/Closure.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta, Yaël Dillies
 
 ! This file was ported from Lean 3 source module order.closure
-! leanprover-community/mathlib commit 422e70f7ce183d2900c586a8cda8381e788a0c62
+! leanprover-community/mathlib commit f252872231e87a5db80d9938fc05530e70f23a94
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/


### PR DESCRIPTION
The corresponding mathlib3 PR was made in order to match changes made in mathlib4 to satisfy the linter while porting