### PR TITLE
[Merged by Bors] - chore: update SHA of Data.Nat.Prime

### DIFF
--- a/Mathlib/Data/Nat/Prime.lean
+++ b/Mathlib/Data/Nat/Prime.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura, Jeremy Avigad, Mario Carneiro
 
 ! This file was ported from Lean 3 source module data.nat.prime
-! leanprover-community/mathlib commit 0743cc5d9d86bcd1bba10f480e948a257d65056f
+! leanprover-community/mathlib commit c3291da49cfa65f0d43b094750541c0731edc932
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/


### PR DESCRIPTION
... to the [latest mathlib3 commit](https://github.com/leanprover-community/mathlib/commits/master/src/data/nat/prime.lean) modifying the file. The changes have been ported in 412b151 has been ported in #1156.