### PR TITLE
[Merged by Bors] - chore: remove nondeterminism in `abel`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -606,6 +606,7 @@ import Mathlib.Tactic.Zify.Attr
 import Mathlib.Testing.SlimCheck.Gen
 import Mathlib.Testing.SlimCheck.Sampleable
 import Mathlib.Testing.SlimCheck.Testable
+import Mathlib.Util.AtomM
 import Mathlib.Util.Export
 import Mathlib.Util.IncludeStr
 import Mathlib.Util.MemoFix

--- a/Mathlib/Tactic/Abel.lean
+++ b/Mathlib/Tactic/Abel.lean
@@ -377,7 +377,8 @@ open Lean Elab Meta Tactic
 (or monoids). -/
 elab_rules : tactic | `(tactic| abel1 $[!%$tk]?) => withMainContext do
   let tm := if tk.isSome then .default else .reducible
-  let some (_, e₁, e₂) := (← getMainTarget).eq? | throwError "abel1 requires an equality goal"
+  let some (_, e₁, e₂) := (← whnfR <| ← getMainTarget).eq?
+    | throwError "abel1 requires an equality goal"
   trace[abel] "running on an equality `{e₁} = {e₂}`."
   let c ← mkContext e₁
   closeMainGoal <| ← AtomM.run tm <| ReaderT.run (r := c) do

--- a/Mathlib/Tactic/Abel.lean
+++ b/Mathlib/Tactic/Abel.lean
@@ -375,7 +375,7 @@ open Lean Elab Meta Tactic
 
 /-- The `abel1` tactic, which solves equations in the language of commutative additive groups
 (or monoids). -/
-elab_rules : tactic | `(tactic| abel1 $[!%$tk]?) => do
+elab_rules : tactic | `(tactic| abel1 $[!%$tk]?) => withMainContext do
   let tm := if tk.isSome then .default else .reducible
   let some (_, e₁, e₂) := (← getMainTarget).eq? | throwError "abel1 requires an equality goal"
   trace[abel] "running on an equality `{e₁} = {e₂}`."

--- a/Mathlib/Tactic/Abel.lean
+++ b/Mathlib/Tactic/Abel.lean
@@ -1,9 +1,10 @@
 /-
 Copyright (c) 2018 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Mario Carneiro
+Authors: Mario Carneiro, Scott Morrison
 -/
 import Mathlib.Tactic.NormNum
+import Mathlib.Util.AtomM
 import Mathlib.Data.Int.Basic
 
 /-!
@@ -25,25 +26,19 @@ Stores a few options for this call, and caches some common subexpressions
 such as typeclass instances and `0 : α`.
 -/
 structure Context where
-  /-- TransparencyMode for comparing atoms -/
-  red      : TransparencyMode
   /-- The type of the ambient additive commutative group or monoid. -/
-  α        : Expr
+  α       : Expr
   /-- The universe level for `α`. -/
-  univ     : Level
+  univ    : Level
   /-- The expression representing `0 : α`. -/
-  α0       : Expr
+  α0      : Expr
   /-- Specify whether we are in an additive commutative group or an additive commutative monoid. -/
-  is_group : Bool
+  isGroup : Bool
   /-- The `AddCommGroup α` or `AddCommMonoid α` expression. -/
-  inst     : Expr
-  /-- A simplification to apply to atomic expressions when they are encountered,
-  before operating on them as atoms. -/
-  evalAtom : Expr → MetaM Simp.Result := fun e ↦ pure { expr := e }
+  inst    : Expr
 
-/-- Populate a `context` object for evaluating `e`, up to reducibility level `red`. -/
-def mkContext (red : TransparencyMode) (e : Expr)
-    (evalAtom : Expr → MetaM Simp.Result := fun e ↦ pure { expr := e }) : MetaM Context := do
+/-- Populate a `context` object for evaluating `e`. -/
+def mkContext (e : Expr) : MetaM Context := do
   let α ← inferType e
   let c ← synthInstance (← mkAppM ``AddCommMonoid #[α])
   let cg ← synthInstance? (← mkAppM ``AddCommGroup #[α])
@@ -51,8 +46,13 @@ def mkContext (red : TransparencyMode) (e : Expr)
   _ ← isDefEq (.sort (.succ u)) (← inferType α)
   let α0 ← Expr.ofNat α 0
   match cg with
-  | some cg => return ⟨red, α, u, α0, true, cg, evalAtom⟩
-  | _ => return ⟨red, α, u, α0, false, c, evalAtom⟩
+  | some cg => return ⟨α, u, α0, true, cg⟩
+  | _ => return ⟨α, u, α0, false, c⟩
+
+/-- The monad for `Abel` contains, in addition to the `AtomM` state,
+some information about the current type we are working over, so that we can consistently
+use group lemmas or monoid lemmas as appropriate. -/
+abbrev M := ReaderT Context AtomM
 
 /-- Apply the function `n : ∀ {α} [inst : AddWhatever α], _` to the
 implicit parameters in the context, and the given list of arguments. -/
@@ -73,7 +73,7 @@ def Context.mkApp (c : Context) (n inst : Name) (l : Array Expr) : MetaM Expr :=
 This is used to choose between declarations taking `AddCommMonoid` and those
 taking `AddCommGroup` instances.
 -/
-def add_g : Name → Name
+def addG : Name → Name
   | .str p s => .str p (s ++ "g")
   | n => n
 
@@ -81,8 +81,9 @@ def add_g : Name → Name
 
 Will use the `AddComm{Monoid,Group}` instance that has been cached in the context.
 -/
-def Context.iapp (c : Context) (n : Name) : Array Expr → Expr :=
-  c.app (if c.is_group then add_g n else n) c.inst
+def iapp (n : Name) (xs : Array Expr) : M Expr := do
+  let c ← read
+  return c.app (if c.isGroup then addG n else n) c.inst xs
 
 /-- A type synonym used by `abel` to represent `n • x + a` in an additive commutative monoid. -/
 def term {α} [AddCommMonoid α] (n : ℕ) (x a : α) : α := n • x + a
@@ -90,11 +91,11 @@ def term {α} [AddCommMonoid α] (n : ℕ) (x a : α) : α := n • x + a
 def termg {α} [AddCommGroup α] (n : ℤ) (x a : α) : α := n • x + a
 
 /-- Evaluate a term with coefficient `n`, atom `x` and successor terms `a`. -/
-def Context.mkTerm (c : Context) (n x a : Expr) : Expr := c.iapp ``term #[n, x, a]
+def mkTerm (n x a : Expr) : M Expr := iapp ``term #[n, x, a]
 
 /-- Interpret an integer as a coefficient to a term. -/
-def Context.intToExpr (c : Context) (n : ℤ) : MetaM Expr :=
-  Expr.ofInt (mkConst (if c.is_group then ``Int else ``Nat) []) n
+def intToExpr (n : ℤ) : M Expr := do
+  Expr.ofInt (mkConst (if (← read).isGroup then ``Int else ``Nat) []) n
 
 /-- A normal form for `abel`.
 Expressions are represented as a list of terms of the form `e = n • x`,
@@ -103,7 +104,7 @@ We explicitly track the `Expr` forms of `e` and `n`, even though they could be r
 for efficiency. -/
 inductive NormalExpr : Type
   | zero (e : Expr) : NormalExpr
-  | nterm (e : Expr) (n : Expr × ℤ) (x : Expr) (a : NormalExpr) : NormalExpr
+  | nterm (e : Expr) (n : Expr × ℤ) (x : ℕ × Expr) (a : NormalExpr) : NormalExpr
   deriving Inhabited
 
 /-- Extract the expression from a normal form. -/
@@ -114,11 +115,11 @@ def NormalExpr.e : NormalExpr → Expr
 instance : Coe NormalExpr Expr where coe := NormalExpr.e
 
 /-- Construct the normal form representing a single term. -/
-def NormalExpr.term' (c : Context) (n : Expr × ℤ) (x : Expr) (a : NormalExpr) : NormalExpr :=
-  .nterm (c.mkTerm n.1 x a) n x a
+def NormalExpr.term' (n : Expr × ℤ) (x : ℕ × Expr) (a : NormalExpr) : M NormalExpr :=
+  return .nterm (← mkTerm n.1 x.2 a) n x a
 
 /-- Construct the normal form representing zero. -/
-def NormalExpr.zero' (c : Context) : NormalExpr := NormalExpr.zero c.α0
+def NormalExpr.zero' : M NormalExpr := return NormalExpr.zero (← read).α0
 
 open NormalExpr
 
@@ -157,7 +158,7 @@ theorem zero_termg {α} [AddCommGroup α] (x a) : @termg α _ 0 x a = a := by
 /--
 Intepret the sum of two expressions in `abel`'s normal form.
 -/
-partial def evalAdd (c : Context) : NormalExpr → NormalExpr → MetaM (NormalExpr × Expr)
+partial def evalAdd : NormalExpr → NormalExpr → M (NormalExpr × Expr)
   | zero _, e₂ => do
     let p ← mkAppM ``zero_add #[e₂]
     return (e₂, p)
@@ -165,21 +166,22 @@ partial def evalAdd (c : Context) : NormalExpr → NormalExpr → MetaM (NormalE
     let p ← mkAppM ``add_zero #[e₁]
     return (e₁, p)
   | he₁@(nterm e₁ n₁ x₁ a₁), he₂@(nterm e₂ n₂ x₂ a₂) => do
-    if ← withTransparency c.red <| isDefEq x₁ x₂ then
+    if x₁.1 = x₂.1 then
       let n' ← Mathlib.Meta.NormNum.eval (← mkAppM ``HAdd.hAdd #[n₁.1, n₂.1])
-      let (a', h₂) ← evalAdd c a₁ a₂
+      let (a', h₂) ← evalAdd a₁ a₂
       let k := n₁.2 + n₂.2
-      let p₁ := c.iapp ``term_add_term #[n₁.1, x₁, a₁, n₂.1, a₂, n'.expr, a', ← n'.getProof, h₂]
+      let p₁ ← iapp ``term_add_term
+        #[n₁.1, x₁.2, a₁, n₂.1, a₂, n'.expr, a', ← n'.getProof, h₂]
       if k = 0 then do
-        let p ← mkEqTrans p₁ (c.iapp ``zero_term #[x₁, a'])
+        let p ← mkEqTrans p₁ (← iapp ``zero_term #[x₁.2, a'])
         return (a', p)
-      else return (term' c (n'.expr, k) x₁ a', p₁)
-    else if Expr.quickLt x₁ x₂ then do -- Since we don't care about the ordering, use `Expr.quickLt`
-      let (a', h) ← evalAdd c a₁ he₂
-      return (term' c n₁ x₁ a', c.iapp ``term_add_const #[n₁.1, x₁, a₁, e₂, a', h])
+      else return (← term' (n'.expr, k) x₁ a', p₁)
+    else if x₁.1 < x₂.1 then do
+      let (a', h) ← evalAdd a₁ he₂
+      return (← term' n₁ x₁ a', ← iapp ``term_add_const #[n₁.1, x₁.2, a₁, e₂, a', h])
     else do
-      let (a', h) ← evalAdd c he₁ a₂
-      return (term' c n₂ x₂ a', c.iapp ``const_add_term #[e₁, n₂.1, x₂, a₂, a', h])
+      let (a', h) ← evalAdd he₁ a₂
+      return (← term' n₂ x₂ a', ← iapp ``const_add_term #[e₁, n₂.1, x₂.2, a₂, a', h])
 
 theorem term_neg {α} [AddCommGroup α] (n x a n' a')
     (h₁ : -n = n') (h₂ : -a = a') : -@termg α _ n x a = termg n' x a' := by
@@ -188,15 +190,15 @@ theorem term_neg {α} [AddCommGroup α] (n x a n' a')
 /--
 Interpret a negated expression in `abel`'s normal form.
 -/
-def evalNeg (c : Context) : NormalExpr → MetaM (NormalExpr × Expr)
+def evalNeg : NormalExpr → M (NormalExpr × Expr)
   | (zero _) => do
-    let p ← c.mkApp ``neg_zero ``NegZeroClass #[]
-    return (zero' c, p)
+    let p ← (← read).mkApp ``neg_zero ``NegZeroClass #[]
+    return (← zero', p)
   | (nterm _ n x a) => do
     let n' ← Mathlib.Meta.NormNum.eval (← mkAppM ``Neg.neg #[n.1])
-    let (a', h₂) ← evalNeg c a
-    return (term' c (n'.expr, -n.2) x a',
-      c.app ``term_neg c.inst #[n.1, x, a, n'.expr, a', ← n'.getProof, h₂])
+    let (a', h₂) ← evalNeg a
+    return (← term' (n'.expr, -n.2) x a',
+      (← read).app ``term_neg (← read).inst #[n.1, x.2, a, n'.expr, a', ← n'.getProof, h₂])
 
 /-- A synonym for `•`, used internally in `abel`. -/
 def smul {α} [AddCommMonoid α] (n : ℕ) (x : α) : α := n • x
@@ -222,24 +224,29 @@ theorem term_smulg {α} [AddCommGroup α] (c n x a n' a')
 /--
 Auxiliary function for `evalSMul'`.
 -/
-def evalSMul (c : Context) (k : Expr × ℤ) : NormalExpr → MetaM (NormalExpr × Expr)
-  | zero _ => return (zero' c, c.iapp ``zero_smul #[k.1])
+def evalSMul (k : Expr × ℤ) : NormalExpr → M (NormalExpr × Expr)
+  | zero _ => return (← zero', ← iapp ``zero_smul #[k.1])
   | nterm _ n x a => do
     let n' ← Mathlib.Meta.NormNum.eval (← mkAppM ``HMul.hMul #[k.1, n.1])
-    let (a', h₂) ← evalSMul c k a
-    return (term' c (n'.expr, k.2 * n.2) x a',
-      c.iapp ``term_smul #[k.1, n.1, x, a, n'.expr, a', ← n'.getProof, h₂])
+    let (a', h₂) ← evalSMul k a
+    return (← term' (n'.expr, k.2 * n.2) x a',
+      ← iapp ``term_smul #[k.1, n.1, x.2, a, n'.expr, a', ← n'.getProof, h₂])
 
-theorem term_atom {α} [AddCommMonoid α] (x : α) : x = term 1 x 0 := by
-  simp [term]
-
-theorem term_atomg {α} [AddCommGroup α] (x : α) : x = termg 1 x 0 := by
-  simp [termg]
+theorem term_atom {α} [AddCommMonoid α] (x : α) : x = term 1 x 0 := by simp [term]
+theorem term_atomg {α} [AddCommGroup α] (x : α) : x = termg 1 x 0 := by simp [termg]
+theorem term_atom_pf {α} [AddCommMonoid α] (x x' : α) (h : x = x') : x = term 1 x' 0 := by
+  simp [term, h]
+theorem term_atom_pfg {α} [AddCommGroup α] (x x' : α) (h : x = x') : x = termg 1 x' 0 := by
+  simp [termg, h]
 
 /-- Interpret an expression as an atom for `abel`'s normal form. -/
-def evalAtom (c : Context) (e : Expr) : MetaM (NormalExpr × Expr) := do
-  let n1 ← c.intToExpr 1
-  return (term' c (n1, 1) e (zero' c), c.iapp ``term_atom #[e])
+def evalAtom (e : Expr) : M (NormalExpr × Expr) := do
+  let { expr := e', proof?, .. } ← (← readThe AtomM.Context).evalAtom e
+  let i ← AtomM.addAtom e'
+  let p ← match proof? with
+  | none => iapp ``term_atom #[e]
+  | some p => iapp ``term_atom_pf #[e, e', p]
+  return (← term' (← intToExpr 1, 1) (i, e') (← zero'), p)
 
 theorem unfold_sub {α} [SubtractionMonoid α] (a b c : α) (h : a + -b = c) : a - b = c := by
   rw [sub_eq_add_neg, h]
@@ -287,71 +294,72 @@ lemma subst_into_negg {α} [AddCommGroup α] (a ta t : α)
     then simplifying `smulg ↑a b` using `subst_into_smul_upcast`
   * Using `smulg` in a monoid is impossible (or at least out of scope),
     because you need a group argument to write a `smulg` term -/
-def evalSMul' (c : Context) (eval : Expr → MetaM (NormalExpr × Expr))
-    (is_smulg : Bool) (orig e₁ e₂ : Expr) : MetaM (NormalExpr × Expr) := do
+def evalSMul' (eval : Expr → M (NormalExpr × Expr))
+    (is_smulg : Bool) (orig e₁ e₂ : Expr) : M (NormalExpr × Expr) := do
   trace[abel] "Calling NormNum on {e₁}"
   let ⟨e₁', p₁, _⟩ ← try Meta.NormNum.eval e₁ catch _ => pure { expr := e₁ }
   let p₁ := p₁.getD (← mkEqRefl e₁') -- FIXME does this always run??
   match Meta.NormNum.isIntLit e₁' with
   | some n => do
+    let c ← read
     let (e₂', p₂) ← eval e₂
-    if c.is_group = is_smulg then do
-      let (e', p) ← evalSMul c (e₁', n) e₂'
-      return (e', c.iapp ``subst_into_smul #[e₁, e₂, e₁', e₂', e', p₁, p₂, p])
+    if c.isGroup = is_smulg then do
+      let (e', p) ← evalSMul (e₁', n) e₂'
+      return (e', ← iapp ``subst_into_smul #[e₁, e₂, e₁', e₂', e', p₁, p₂, p])
     else do
-      if ¬ c.is_group then throwError "Doesn't make sense to us `smulg` in a monoid. "
+      if ¬ c.isGroup then throwError "Doesn't make sense to us `smulg` in a monoid. "
       -- We are multiplying by a natural number in an additive group.
       let zl ← Expr.ofInt q(ℤ) n
       let p₁' ← mkEqRefl zl
-      let (e', p) ← evalSMul c (zl, n) e₂'
+      let (e', p) ← evalSMul (zl, n) e₂'
       return (e', c.app ``subst_into_smul_upcast c.inst #[e₁, e₂, e₁', zl, e₂', e', p₁, p₁', p₂, p])
-  | none => evalAtom c orig
+  | none => evalAtom orig
 
 /-- Evaluate an expression into its `abel` normal form, by recursing into subexpressions. -/
-partial def eval (c : Context) (e : Expr) : MetaM (NormalExpr × Expr) := do
+partial def eval (e : Expr) : M (NormalExpr × Expr) := do
   trace[abel.detail] "running eval on {e}"
   trace[abel.detail] "getAppFnArgs: {e.getAppFnArgs}"
   match e.getAppFnArgs with
   | (``HAdd.hAdd, #[_, _, _, _, e₁, e₂]) => do
-    let (e₁', p₁) ← eval c e₁
-    let (e₂', p₂) ← eval c e₂
-    let (e', p') ← evalAdd c e₁' e₂'
-    return (e', c.iapp ``subst_into_add #[e₁, e₂, e₁', e₂', e', p₁, p₂, p'])
+    let (e₁', p₁) ← eval e₁
+    let (e₂', p₂) ← eval e₂
+    let (e', p') ← evalAdd e₁' e₂'
+    return (e', ← iapp ``subst_into_add #[e₁, e₂, e₁', e₂', e', p₁, p₂, p'])
   | (``HSub.hSub, #[_, _, _ ,_, e₁, e₂]) => do
     let e₂' ← mkAppM ``Neg.neg #[e₂]
     let e ← mkAppM ``HAdd.hAdd #[e₁, e₂']
-    let (e', p) ← eval c e
-    let p' ← c.mkApp ``unfold_sub ``SubtractionMonoid #[e₁, e₂, e', p]
+    let (e', p) ← eval e
+    let p' ← (← read).mkApp ``unfold_sub ``SubtractionMonoid #[e₁, e₂, e', p]
     return (e', p')
   | (``Neg.neg, #[_, _, e]) => do
-    let (e₁, p₁) ← eval c e
-    let (e₂, p₂) ← evalNeg c e₁
-    return (e₂, c.iapp `Mathlib.Tactic.Abel.subst_into_neg #[e, e₁, e₂, p₁, p₂])
+    let (e₁, p₁) ← eval e
+    let (e₂, p₂) ← evalNeg e₁
+    return (e₂, ← iapp `Mathlib.Tactic.Abel.subst_into_neg #[e, e₁, e₂, p₁, p₂])
   | (`AddMonoid.nsmul, #[_, _, e₁, e₂]) => do
-    let n ← if c.is_group then mkAppM ``Int.ofNat #[e₁] else pure e₁
-    let (e', p) ← eval c $ c.iapp ``smul #[n, e₂]
-    return (e', c.iapp ``unfold_smul #[e₁, e₂, e', p])
+    let n ← if (← read).isGroup then mkAppM ``Int.ofNat #[e₁] else pure e₁
+    let (e', p) ← eval <| ← iapp ``smul #[n, e₂]
+    return (e', ← iapp ``unfold_smul #[e₁, e₂, e', p])
   | (``SubNegMonoid.zsmul, #[_, _, e₁, e₂]) => do
-      if ¬ c.is_group then failure
-      let (e', p) ← eval c $ c.iapp ``smul #[e₁, e₂]
-      return (e', c.app ``unfold_zsmul c.inst #[e₁, e₂, e', p])
+      if ¬ (← read).isGroup then failure
+      let (e', p) ← eval <| ← iapp ``smul #[e₁, e₂]
+      return (e', (← read).app ``unfold_zsmul (← read).inst #[e₁, e₂, e', p])
   | (``SMul.smul, #[.const ``Int _, _, _, e₁, e₂]) =>
-    evalSMul' c (eval c) true e e₁ e₂
+    evalSMul' eval true e e₁ e₂
   | (``SMul.smul, #[.const ``Nat _, _, _, e₁, e₂]) =>
-    evalSMul' c (eval c) false e e₁ e₂
+    evalSMul' eval false e e₁ e₂
   | (``HSMul.hSMul, #[.const ``Int _, _, _, _, e₁, e₂]) =>
-    evalSMul' c (eval c) true e e₁ e₂
+    evalSMul' eval true e e₁ e₂
   | (``HSMul.hSMul, #[.const ``Nat _, _, _, _, e₁, e₂]) =>
-    evalSMul' c (eval c) false e e₁ e₂
-  | (``smul, #[_, _, e₁, e₂]) => evalSMul' c (eval c) false e e₁ e₂
-  | (``smulg, #[_, _, e₁, e₂]) => evalSMul' c (eval c) true e e₁ e₂
+    evalSMul' eval false e e₁ e₂
+  | (``smul, #[_, _, e₁, e₂]) => evalSMul' eval false e e₁ e₂
+  | (``smulg, #[_, _, e₁, e₂]) => evalSMul' eval true e e₁ e₂
   | (``OfNat.ofNat, #[_, .lit (.natVal 0), _])
   | (``Zero.zero, #[_, _]) =>
-    if ← isDefEq e c.α0 then
-      pure (zero' c, ← mkEqRefl c.α0)
+    if ← isDefEq e (← read).α0 then
+      pure (← zero', ← mkEqRefl (← read).α0)
     else
-      evalAtom c e
-  | _ => evalAtom c e
+      evalAtom e
+  | _ => evalAtom e
 
 /-- Tactic for solving equations in the language of
 *additive*, commutative monoids and groups.
@@ -371,19 +379,18 @@ elab_rules : tactic | `(tactic| abel1 $[!%$tk]?) => do
   let tm := if tk.isSome then .default else .reducible
   let some (_, e₁, e₂) := (← getMainTarget).eq? | throwError "abel1 requires an equality goal"
   trace[abel] "running on an equality `{e₁} = {e₂}`."
-  let c ← mkContext tm e₁
-  let (e₁', p₁) ← eval c e₁
-  trace[abel] "found `{p₁}`, a proof that `{e₁} = {e₁'.e}`"
-  let (e₂', p₂) ← eval c e₂
-  trace[abel] "found `{p₂}`, a proof that `{e₂} = {e₂'.e}`"
-  unless ← isDefEq e₁' e₂' do
-    throwError "abel1 found that the two sides were not equal"
-  trace[abel] "verified that the simplified forms are identical"
-  closeMainGoal (← mkEqTrans p₁ (← mkEqSymm p₂))
+  let c ← mkContext e₁
+  closeMainGoal <| ← AtomM.run tm <| ReaderT.run (r := c) do
+    let (e₁', p₁) ← eval e₁
+    trace[abel] "found `{p₁}`, a proof that `{e₁} = {e₁'.e}`"
+    let (e₂', p₂) ← eval e₂
+    trace[abel] "found `{p₂}`, a proof that `{e₂} = {e₂'.e}`"
+    unless ← isDefEq e₁' e₂' do
+      throwError "abel1 found that the two sides were not equal"
+    trace[abel] "verified that the simplified forms are identical"
+    mkEqTrans p₁ (← mkEqSymm p₂)
 
 @[inherit_doc abel1] macro (name := abel1!) "abel1!" : tactic => `(tactic| abel1 !)
-
--- TODO finish porting `abel`, rather than just `abel1`.
 
 theorem term_eq [AddCommMonoid α] (n : ℕ) (x a : α) : term n x a = n • x + a := rfl
 /-- A type synonym used by `abel` to represent `n • x + a` in an additive commutative group. -/
@@ -444,8 +451,7 @@ partial def abelNFCore (cfg : AbelNF.Config) (e : Expr) : MetaM Simp.Result := d
           guard <| root || parent != e -- recursion guard
           let e ← withReducible <| whnf e
           guard e.isApp -- all interesting group expressions are applications
-          let c ← mkContext cfg.red e (evalAtom := evalAtom)
-          let (a, pa) ← eval c e
+          let (a, pa) ← eval e |>.run (← mkContext e) |>.run cfg.red (evalAtom := evalAtom)
           guard !a.isAtom
           let r ← simp { expr := a, proof? := pa }
           if ← withReducible <| isDefEq r.expr e then return .done { expr := r.expr }

--- a/Mathlib/Tactic/Polyrith.lean
+++ b/Mathlib/Tactic/Polyrith.lean
@@ -57,7 +57,7 @@ remember to force recompilation of any files that call `polyrith`.
 
 namespace Mathlib.Tactic.Polyrith
 open Lean hiding Rat
-open Meta Ring Qq PrettyPrinter
+open Meta Ring Qq PrettyPrinter AtomM
 initialize registerTraceClass `Meta.Tactic.polyrith
 
 /-! # Poly Datatype -/
@@ -125,7 +125,7 @@ def Poly.toSyntax : Poly → Syntax.Term
 
 /-- Reifies a ring expression of type `α` as a `Poly`. -/
 partial def parse {u} {α : Q(Type u)} (sα : Q(CommSemiring $α))
-    (c : Ring.Cache α) (e : Q($α)) : RingM Poly := do
+    (c : Ring.Cache α) (e : Q($α)) : AtomM Poly := do
   let els := do
     try pure <| Poly.const (← NormNum.derive e).toRat
     catch _ => pure <| Poly.var (← addAtom e)
@@ -159,8 +159,8 @@ inductive Source where
 
 /-- The first half of `polyrith` produces a list of arguments to be sent to Sage. -/
 def parseContext (only : Bool) (hyps : Array Expr) (tgt : Expr) :
-    RingM (Expr × Array (Source × Poly) × Poly) := do
-  let fail {α} : RingM α := throwError "polyrith failed: target is not an equality in semirings"
+    AtomM (Expr × Array (Source × Poly) × Poly) := do
+  let fail {α} : AtomM α := throwError "polyrith failed: target is not an equality in semirings"
   let some (α, e₁, e₂) := (← instantiateMVars tgt).eq? | fail
   let .sort (.succ u) ← whnf (← inferType α) | fail
   have α : Q(Type u) := α
@@ -315,7 +315,7 @@ This returns `none` if this was a "dry run" attempt that does not actually invok
 def polyrith (g : MVarId) (only : Bool) (hyps : Array Expr)
     (traceOnly := false) : MetaM (Option MVarId × Syntax) := do
   IO.sleep 10 -- otherwise can lead to weird errors when actively editing code with polyrith calls
-  g.withContext <| RingM.run .reducible do
+  g.withContext <| AtomM.run .reducible do
     let (α, hyps', tgt) ← parseContext only hyps (← g.getType)
     let rec
       /-- Try to prove the goal by `ring` and fail with the given message otherwise. -/

--- a/Mathlib/Tactic/Ring/Basic.lean
+++ b/Mathlib/Tactic/Ring/Basic.lean
@@ -7,6 +7,7 @@ import Lean.Elab.Tactic.Basic
 import Mathlib.Algebra.GroupPower.Basic
 import Mathlib.Algebra.Ring.Basic
 import Mathlib.Tactic.NormNum
+import Mathlib.Util.AtomM
 
 /-!
 # `ring` tactic
@@ -78,38 +79,8 @@ ring, semiring, exponent, power
 
 namespace Mathlib.Tactic
 namespace Ring
-open Mathlib.Meta Qq NormNum Lean.Meta
+open Mathlib.Meta Qq NormNum Lean.Meta AtomM
 open Lean (MetaM Expr mkRawNatLit)
-
-/-- The context (read-only state) of the `RingM` monad. -/
-structure Context :=
-  /-- The reducibility setting for definitional equality of atoms -/
-  red : TransparencyMode
-  /-- A simplification to apply to atomic expressions when they are encountered,
-  before interning them in the atom list. -/
-  evalAtom : Expr → MetaM Simp.Result := fun e ↦ pure { expr := e }
-  deriving Inhabited
-
-/-- The mutable state of the `RingM` monad. -/
-structure State :=
-  /-- The list of atoms-up-to-defeq encountered thus far, used for atom sorting. -/
-  atoms : Array Expr := #[]
-
-/-- The monad that `ring` works in. This is only used for collecting atoms. -/
-abbrev RingM := ReaderT Context <| StateRefT State MetaM
-
-/-- Run a computation in the `RingM` monad. -/
-def RingM.run (red : TransparencyMode) (m : RingM α) : MetaM α := (m { red }).run' {}
-
-/-- Get the index corresponding to an atomic expression, if it has already been encountered, or
-put it in the list of atoms and return the new index, otherwise. -/
-def addAtom (e : Expr) : RingM Nat := do
-  let c ← get
-  for h : i in [:c.atoms.size] do
-    have : i < c.atoms.size := h.2
-    if ← withTransparency (← read).red <| isDefEq e c.atoms[i] then
-      return i
-  modifyGet fun c ↦ (c.atoms.size, { c with atoms := c.atoms.push e })
 
 /-- A shortcut instance for `CommSemiring ℕ` used by ring. -/
 def instCommSemiringNat : CommSemiring ℕ := inferInstance
@@ -477,7 +448,7 @@ mutual
 * An atom `e` causes `↑e` to be allocated as a new atom.
 * A sum delegates to `ExSum.evalNatCast`.
 -/
-partial def ExBase.evalNatCast (va : ExBase sℕ a) : RingM (Result (ExBase sα) q($a)) :=
+partial def ExBase.evalNatCast (va : ExBase sℕ a) : AtomM (Result (ExBase sα) q($a)) :=
   match va with
   | .atom _ => do
     let a' : Q($α) := q($a)
@@ -492,7 +463,7 @@ partial def ExBase.evalNatCast (va : ExBase sℕ a) : RingM (Result (ExBase sα)
 * `↑c = c` if `c` is a numeric literal
 * `↑(a ^ n * b) = ↑a ^ n * ↑b`
 -/
-partial def ExProd.evalNatCast (va : ExProd sℕ a) : RingM (Result (ExProd sα) q($a)) :=
+partial def ExProd.evalNatCast (va : ExProd sℕ a) : AtomM (Result (ExProd sα) q($a)) :=
   match va with
   | .const c =>
     have n : Q(ℕ) := a.appArg!
@@ -507,7 +478,7 @@ partial def ExProd.evalNatCast (va : ExProd sℕ a) : RingM (Result (ExProd sα)
 * `↑0 = 0`
 * `↑(a + b) = ↑a + ↑b`
 -/
-partial def ExSum.evalNatCast (va : ExSum sℕ a) : RingM (Result (ExSum sα) q($a)) :=
+partial def ExSum.evalNatCast (va : ExSum sℕ a) : AtomM (Result (ExSum sα) q($a)) :=
   match va with
   | .zero => pure ⟨_, .zero, q(nat_cast_zero (R := $α))⟩
   | .add va₁ va₂ => do
@@ -527,7 +498,7 @@ polynomial expressions.
 * `a • b = a * b` if `α = ℕ`
 * `a • b = ↑a * b` otherwise
 -/
-def evalNSMul (va : ExSum sℕ a) (vb : ExSum sα b) : RingM (Result (ExSum sα) q($a • $b)) := do
+def evalNSMul (va : ExSum sℕ a) (vb : ExSum sα b) : AtomM (Result (ExSum sα) q($a • $b)) := do
   if ← isDefEq sα sℕ then
     let ⟨_, va'⟩ := va.cast
     have _b : Q(ℕ) := b
@@ -864,7 +835,7 @@ Evaluates an atom, an expression where `ring` can find no additional structure.
 
 * `a = a ^ 1 * 1 + 0`
 -/
-def evalAtom (e : Q($α)) : RingM (Result (ExSum sα) e) := do
+def evalAtom (e : Q($α)) : AtomM (Result (ExSum sα) e) := do
   let r ← (← read).evalAtom e
   have e' : Q($α) := r.expr
   let i ← addAtom e'
@@ -899,7 +870,7 @@ Evaluates expression `e` of type `α` into a normalized representation as a poly
 This is the main driver of `ring`, which calls out to `evalAdd`, `evalMul` etc.
 -/
 partial def eval {u} {α : Q(Type u)} (sα : Q(CommSemiring $α))
-    (c : Cache α) (e : Q($α)) : RingM (Result (ExSum sα) e) := do
+    (c : Cache α) (e : Q($α)) : AtomM (Result (ExSum sα) e) := do
   let els := do
     try evalCast sα (← derive e)
     catch _ => evalAtom sα e
@@ -964,7 +935,7 @@ to apply the `ring_nf` simp set to the goal.
 initialize ringCleanupRef : IO.Ref (Expr → MetaM Expr) ← IO.mkRef pure
 
 /-- Frontend of `ring1`: attempt to close a goal `g`, assuming it is an equation of semirings. -/
-def proveEq (g : MVarId) : RingM Unit := do
+def proveEq (g : MVarId) : AtomM Unit := do
   let some (α, e₁, e₂) := (← instantiateMVars (← g.getType)).eq?
     | throwError "ring failed: not an equality"
   let .sort (.succ u) ← whnf (← inferType α) | throwError "not a type{indentExpr α}"
@@ -990,6 +961,6 @@ allowing variables in the exponent.
   to determine equality of atoms.
 -/
 elab (name := ring1) "ring1" tk:"!"? : tactic => liftMetaMAtMain fun g ↦ do
-  RingM.run (if tk.isSome then .default else .reducible) (proveEq g)
+  AtomM.run (if tk.isSome then .default else .reducible) (proveEq g)
 
 @[inherit_doc ring1] macro "ring1!" : tactic => `(tactic| ring1 !)

--- a/Mathlib/Util/AtomM.lean
+++ b/Mathlib/Util/AtomM.lean
@@ -1,0 +1,52 @@
+/-
+Copyright (c) 2023 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro
+-/
+import Lean.Elab.Tactic.Basic
+import Mathlib.Algebra.GroupPower.Basic
+import Mathlib.Algebra.Ring.Basic
+import Mathlib.Tactic.NormNum
+
+/-!
+# A monad for tracking and deduplicating atoms
+
+This monad is used by tactics like `ring` and `abel` to keep uninterpreted atoms in a consistent
+order, and also to allow unifying atoms up to a specified transparency mode.
+-/
+
+namespace Mathlib.Tactic
+open Lean Meta
+
+/-- The context (read-only state) of the `AtomM` monad. -/
+structure AtomM.Context :=
+  /-- The reducibility setting for definitional equality of atoms -/
+  red : TransparencyMode
+  /-- A simplification to apply to atomic expressions when they are encountered,
+  before interning them in the atom list. -/
+  evalAtom : Expr → MetaM Simp.Result := fun e ↦ pure { expr := e }
+  deriving Inhabited
+
+/-- The mutable state of the `AtomM` monad. -/
+structure AtomM.State :=
+  /-- The list of atoms-up-to-defeq encountered thus far, used for atom sorting. -/
+  atoms : Array Expr := #[]
+
+/-- The monad that `ring` works in. This is only used for collecting atoms. -/
+abbrev AtomM := ReaderT AtomM.Context <| StateRefT AtomM.State MetaM
+
+/-- Run a computation in the `AtomM` monad. -/
+def AtomM.run (red : TransparencyMode) (m : AtomM α)
+    (evalAtom : Expr → MetaM Simp.Result := fun e ↦ pure { expr := e }) :
+    MetaM α :=
+  (m { red, evalAtom }).run' {}
+
+/-- Get the index corresponding to an atomic expression, if it has already been encountered, or
+put it in the list of atoms and return the new index, otherwise. -/
+def AtomM.addAtom (e : Expr) : AtomM Nat := do
+  let c ← get
+  for h : i in [:c.atoms.size] do
+    have : i < c.atoms.size := h.2
+    if ← withTransparency (← read).red <| isDefEq e c.atoms[i] then
+      return i
+  modifyGet fun c ↦ (c.atoms.size, { c with atoms := c.atoms.push e })

--- a/test/abel.lean
+++ b/test/abel.lean
@@ -57,3 +57,15 @@ example [AddCommGroup α] (a b : α) : a + b - b - id' a = 0 := by
   fail_if_success
     abel1
   abel1!
+
+-- https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Interaction.20of.20abel.20with.20casting/near/319895001
+example [AddCommGroup α] : True := by
+  have : ∀ (p q r s : α), s + p - q = s - r - (q - r - p) := by
+    intro p q r s
+    abel
+  trivial
+
+-- https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Interaction.20of.20abel.20with.20casting/near/319897374
+example [AddCommGroup α] (x y z : α) : y = x + z - (x - y + z) := by
+  have : True := trivial
+  abel


### PR DESCRIPTION
As [reported on Zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Non-local.20behaviour.20in.20.60abel.60/near/319724302). The solution is to use the `RingM` monad in Abel as well, so we move this to its own file and rename it to `AtomM`.

Also fixes [two other bugs](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Interaction.20of.20abel.20with.20casting) in `abel`.