### PR TITLE
[Merged by Bors] - feat: port Data.Nat.Bitwise

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -256,6 +256,7 @@ import Mathlib.Data.Multiset.Basic
 import Mathlib.Data.Multiset.Nodup
 import Mathlib.Data.Nat.Basic
 import Mathlib.Data.Nat.Bits
+import Mathlib.Data.Nat.Bitwise
 import Mathlib.Data.Nat.Cast.Basic
 import Mathlib.Data.Nat.Cast.Defs
 import Mathlib.Data.Nat.Cast.Field

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -4950,8 +4950,8 @@ theorem getI_eq_iget_get? (n : ℕ) : l.getI n = (l.get? n).iget := by
   rw [← getD_default_eq_getI, getD_eq_getD_get?, Option.getD_default_eq_iget]
 #align list.inth_eq_iget_nth List.getI_eq_iget_get?
 
-theorem getI_zero_eq_head! : l.getI 0 = l.head! := by cases l <;> rfl
-#align list.inth_zero_eq_head List.getI_zero_eq_head!
+theorem getI_zero_eq_headI : l.getI 0 = l.headI := by cases l <;> rfl
+#align list.inth_zero_eq_head List.getI_zero_eq_headI
 
 end getI
 

--- a/Mathlib/Data/Nat/Bitwise.lean
+++ b/Mathlib/Data/Nat/Bitwise.lean
@@ -10,6 +10,8 @@ Authors: Markus Himmel
 -/
 import Mathlib.Data.List.Basic
 import Mathlib.Data.Nat.Bits
+import Mathlib.Data.Nat.Size
+import Mathlib.Data.Nat.Order.Lemmas
 import Mathlib.Tactic.Linarith
 
 -- TODO REMOVE
@@ -76,8 +78,7 @@ theorem zero_testBit (i : ℕ) : testBit 0 i = false := by simp only [testBit, s
 theorem testBit_eq_inth (n i : ℕ) : n.testBit i = n.bits.getI i :=
   by
   induction' i with i ih generalizing n
-  · simp [testBit, shiftr, bodd_eq_bits_head, List.getI_zero_eq_head!]
-    rfl -- huh?
+  · simp [testBit, shiftr, bodd_eq_bits_head, List.getI_zero_eq_headI]
   conv_lhs => rw [← bit_decomp n]
   rw [testBit_succ, ih n.div2, div2_bits_eq_tail]
   cases n.bits <;> simp
@@ -89,7 +90,7 @@ theorem eq_of_testBit_eq {n m : ℕ} (h : ∀ i, testBit n i = testBit m i) : n 
   induction' n using Nat.binaryRec with b n hn generalizing m
   · simp only [zero_testBit] at h
     exact (zero_of_testBit_eq_ff fun i => (h i).symm).symm
-  induction' m using Nat.binaryRec with b' m hm
+  induction' m using Nat.binaryRec with b' m
   · simp only [zero_testBit] at h
     exact zero_of_testBit_eq_ff h
   suffices h' : n = m
@@ -136,14 +137,14 @@ theorem lt_of_testBit {n m : ℕ} (i : ℕ) (hn : testBit n i = false) (hm : tes
     simp only [testBit_succ] at hn hm
     have :=
       hn' _ hn hm fun j hj => by convert hnm j.succ (succ_lt_succ hj) using 1 <;> rw [testBit_succ]
-    cases b <;> cases b' <;>
-        simp only [bit_ff, bit_tt, bit0_val n, bit1_val n, bit0_val m, bit1_val m] <;>
-      linarith
+    cases b <;> cases b'
+    <;> simp only [bit_ff, bit_tt, bit0_val n, bit1_val n, bit0_val m, bit1_val m]
+    <;> linarith only [this]
 #align nat.lt_of_test_bit Nat.lt_of_testBit
 
 @[simp]
 theorem testBit_two_pow_self (n : ℕ) : testBit (2 ^ n) n = true := by
-  rw [testBit, shiftr_eq_div_pow, Nat.div_self (pow_pos zero_lt_two n), bodd_one]
+  rw [testBit, shiftr_eq_div_pow, Nat.div_self (pow_pos (α := ℕ) zero_lt_two n), bodd_one]
 #align nat.test_bit_two_pow_self Nat.testBit_two_pow_self
 
 theorem testBit_two_pow_of_ne {n m : ℕ} (hm : n ≠ m) : testBit (2 ^ n) m = false :=

--- a/Mathlib/Data/Nat/Bitwise.lean
+++ b/Mathlib/Data/Nat/Bitwise.lean
@@ -312,7 +312,14 @@ theorem lxor'_trichotomy {a b c : ℕ} (h : a ≠ lxor' b c) :
   on_goal 2 => right; left; rw [hac]
   on_goal 3 => right; right; rw [hab]
   all_goals
-    sorry --exact lt_of_testBit i (by simp [h, hi]) h fun j hj => by simp [hi' _ hj]
+    exact lt_of_testBit i (by
+      -- Porting note: this was originally `simp [h, hi]`
+      rw [Nat.testBit_lxor', h, Bool.true_xor,hi]
+      rfl
+    ) h fun j hj => by
+      -- Porting note: this was originally `simp [hi' _ hj]`
+      rw [Nat.testBit_lxor', hi' _ hj, Bool.xor_false_right, eq_self_iff_true]
+      trivial
 #align nat.lxor_trichotomy Nat.lxor'_trichotomy
 
 theorem lt_lxor'_cases {a b c : ℕ} (h : a < lxor' b c) : lxor' a c < b ∨ lxor' a b < c :=

--- a/Mathlib/Data/Nat/Bitwise.lean
+++ b/Mathlib/Data/Nat/Bitwise.lean
@@ -98,13 +98,13 @@ theorem eq_of_testBit_eq {n m : ℕ} (h : ∀ i, testBit n i = testBit m i) : n 
 #align nat.eq_of_test_bit_eq Nat.eq_of_testBit_eq
 
 theorem exists_most_significant_bit {n : ℕ} (h : n ≠ 0) :
-    ∃ i, testBit n i = tt ∧ ∀ j, i < j → testBit n j = false :=
+    ∃ i, testBit n i = true ∧ ∀ j, i < j → testBit n j = false :=
   by
   induction' n using Nat.binaryRec with b n hn
   · exact False.elim (h rfl)
   by_cases h' : n = 0
   · subst h'
-    rw [show b = tt by
+    rw [show b = true by
         revert h
         cases b <;> simp]
     refine' ⟨0, ⟨by rw [testBit_zero], fun j hj => _⟩⟩
@@ -112,11 +112,11 @@ theorem exists_most_significant_bit {n : ℕ} (h : n ≠ 0) :
     rw [testBit_succ, zero_testBit]
   · obtain ⟨k, ⟨hk, hk'⟩⟩ := hn h'
     refine' ⟨k + 1, ⟨by rw [testBit_succ, hk], fun j hj => _⟩⟩
-    obtain ⟨j', rfl⟩ := exists_eq_succ_of_ne_zero (show j ≠ 0 by linarith)
+    obtain ⟨j', rfl⟩ := exists_eq_succ_of_ne_zero (show j ≠ 0 by intro x; subst x; simp at hj)
     exact (testBit_succ _ _ _).trans (hk' _ (lt_of_succ_lt_succ hj))
 #align nat.exists_most_significant_bit Nat.exists_most_significant_bit
 
-theorem lt_of_testBit {n m : ℕ} (i : ℕ) (hn : testBit n i = false) (hm : testBit m i = tt)
+theorem lt_of_testBit {n m : ℕ} (i : ℕ) (hn : testBit n i = false) (hm : testBit m i = true)
     (hnm : ∀ j, i < j → testBit n j = testBit m j) : n < m :=
   by
   induction' n using Nat.binaryRec with b n hn' generalizing i m
@@ -129,7 +129,7 @@ theorem lt_of_testBit {n m : ℕ} (i : ℕ) (hn : testBit n i = false) (hm : tes
   · subst hi
     simp only [testBit_zero] at hn hm
     have : n = m :=
-      eq_of_testBit_eq fun i => by convert hnm (i + 1) (by decide) using 1 <;> rw [testBit_succ]
+      eq_of_testBit_eq fun i => by convert hnm (i + 1) (Nat.zero_lt_succ _) using 1 <;> rw [testBit_succ]
     rw [hn, hm, this, bit_ff, bit_tt, bit0_val, bit1_val]
     exact lt_add_one _
   · obtain ⟨i', rfl⟩ := exists_eq_succ_of_ne_zero hi
@@ -142,7 +142,7 @@ theorem lt_of_testBit {n m : ℕ} (i : ℕ) (hn : testBit n i = false) (hm : tes
 #align nat.lt_of_test_bit Nat.lt_of_testBit
 
 @[simp]
-theorem testBit_two_pow_self (n : ℕ) : testBit (2 ^ n) n = tt := by
+theorem testBit_two_pow_self (n : ℕ) : testBit (2 ^ n) n = true := by
   rw [testBit, shiftr_eq_div_pow, Nat.div_self (pow_pos zero_lt_two n), bodd_one]
 #align nat.test_bit_two_pow_self Nat.testBit_two_pow_self
 
@@ -173,7 +173,7 @@ theorem bitwise_comm {f : Bool → Bool → Bool} (hf : ∀ b b', f b b' = f b' 
   calc
     bitwise f = bitwise (swap f) := congr_arg _ <| funext fun _ => funext <| hf _
     _ = swap (bitwise f) := bitwise'_swap hf'
-    
+
 #align nat.bitwise_comm Nat.bitwise_comm
 
 theorem lor_comm (n m : ℕ) : lor n m = lor m n :=
@@ -276,7 +276,7 @@ theorem lxor_eq_zero {n m : ℕ} : lxor' n m = 0 ↔ n = m := by
 #align nat.lxor_eq_zero Nat.lxor_eq_zero
 
 theorem lxor_ne_zero {n m : ℕ} : lxor' n m ≠ 0 ↔ n ≠ m :=
-  lxor_eq_zero.Not
+  lxor_eq_zero.not
 #align nat.lxor_ne_zero Nat.lxor_ne_zero
 
 theorem lxor_trichotomy {a b c : ℕ} (h : a ≠ lxor' b c) :

--- a/Mathlib/Data/Nat/Bitwise.lean
+++ b/Mathlib/Data/Nat/Bitwise.lean
@@ -22,7 +22,7 @@ set_option autoImplicit false
 
 In the first half of this file, we provide theorems for reasoning about natural numbers from their
 bitwise properties. In the second half of this file, we show properties of the bitwise operations
-`lor`, `land` and `lxor`, which are defined in core.
+`lor'`, `land'` and `lxor'`, which are defined in core.
 
 ## Main results
 * `eq_of_testBit_eq`: two natural numbers are equal if they have equal bits at every position.
@@ -168,50 +168,53 @@ theorem testBit_two_pow (n m : ℕ) : testBit (2 ^ n) m = (n = m) :=
 
 /-- If `f` is a commutative operation on bools such that `f false false = false`, then `bitwise f` is also
     commutative. -/
-theorem bitwise_comm {f : Bool → Bool → Bool} (hf : ∀ b b', f b b' = f b' b)
-    (hf' : f false false = false) (n m : ℕ) : bitwise f n m = bitwise f m n :=
-  suffices bitwise f = swap (bitwise f) by conv_lhs => rw [this]
+theorem bitwise'_comm {f : Bool → Bool → Bool} (hf : ∀ b b', f b b' = f b' b)
+    (hf' : f false false = false) (n m : ℕ) : bitwise' f n m = bitwise' f m n :=
+  suffices bitwise' f = swap (bitwise' f) by conv_lhs => rw [this]
   calc
-    bitwise f = bitwise (swap f) := congr_arg _ <| funext fun _ => funext <| hf _
-    _ = swap (bitwise f) := bitwise'_swap hf'
+    bitwise' f = bitwise' (swap f) := congr_arg _ <| funext fun _ => funext <| hf _
+    _ = swap (bitwise' f) := bitwise'_swap hf'
 
-#align nat.bitwise_comm Nat.bitwise_comm
+#align nat.bitwise_comm Nat.bitwise'_comm
 
-theorem lor_comm (n m : ℕ) : lor n m = lor m n :=
-  bitwise_comm Bool.or_comm rfl n m
-#align nat.lor_comm Nat.lor_comm
+theorem lor'_comm (n m : ℕ) : lor' n m = lor' m n :=
+  bitwise'_comm Bool.or_comm rfl n m
+#align nat.lor_comm Nat.lor'_comm
 
-theorem land_comm (n m : ℕ) : land n m = land m n :=
-  bitwise_comm Bool.and_comm rfl n m
-#align nat.land_comm Nat.land_comm
+theorem land'_comm (n m : ℕ) : land' n m = land' m n :=
+  bitwise'_comm Bool.and_comm rfl n m
+#align nat.land_comm Nat.land'_comm
 
-theorem lxor_comm (n m : ℕ) : lxor' n m = lxor' m n :=
-  bitwise_comm Bool.xor_comm rfl n m
-#align nat.lxor_comm Nat.lxor_comm
-
-@[simp]
-theorem zero_lxor (n : ℕ) : lxor' 0 n = n := by simp [lxor]
-#align nat.zero_lxor Nat.zero_lxor
+theorem lxor'_comm (n m : ℕ) : lxor' n m = lxor' m n :=
+  bitwise'_comm Bool.xor_comm rfl n m
+#align nat.lxor_comm Nat.lxor'_comm
 
 @[simp]
-theorem lxor_zero (n : ℕ) : lxor' n 0 = n := by simp [lxor]
-#align nat.lxor_zero Nat.lxor_zero
+theorem zero_lxor' (n : ℕ) : lxor' 0 n = n := by
+ simp only [Bool.xor_false_left, Nat.bitwise'_zero_left, eq_self_iff_true, Bool.cond_true, lxor']
+#align nat.zero_lxor Nat.zero_lxor'
 
 @[simp]
-theorem zero_land (n : ℕ) : land 0 n = 0 := by simp [land]
-#align nat.zero_land Nat.zero_land
+theorem lxor'_zero (n : ℕ) : lxor' n 0 = n := by simp [lxor']
+#align nat.lxor_zero Nat.lxor'_zero
 
 @[simp]
-theorem land_zero (n : ℕ) : land n 0 = 0 := by simp [land]
-#align nat.land_zero Nat.land_zero
+theorem zero_land' (n : ℕ) : land' 0 n = 0 := by
+  simp only [Nat.bitwise'_zero_left, Bool.cond_false, eq_self_iff_true, land', Bool.false_and]
+#align nat.zero_land Nat.zero_land'
 
 @[simp]
-theorem zero_lor (n : ℕ) : lor 0 n = n := by simp [lor]
-#align nat.zero_lor Nat.zero_lor
+theorem land'_zero (n : ℕ) : land' n 0 = 0 := by simp [land']
+#align nat.land_zero Nat.land'_zero
 
 @[simp]
-theorem lor_zero (n : ℕ) : lor n 0 = n := by simp [lor]
-#align nat.lor_zero Nat.lor_zero
+theorem zero_lor' (n : ℕ) : lor' 0 n = n := by --simp [lor']
+  simp only [Nat.bitwise'_zero_left, Bool.false_or, eq_self_iff_true, Bool.cond_true, Nat.lor']
+#align nat.zero_lor Nat.zero_lor'
+
+@[simp]
+theorem lor'_zero (n : ℕ) : lor' n 0 = n := by simp [lor']
+#align nat.lor_zero Nat.lor'_zero
 
 /- ./././Mathport/Syntax/Translate/Expr.lean:333:4: warning: unsupported (TODO): `[tacs] -/
 /-- Proving associativity of bitwise operations in general essentially boils down to a huge case
@@ -221,90 +224,90 @@ unsafe def bitwise_assoc_tac : tactic Unit :=
 #align nat.bitwise_assoc_tac nat.bitwise_assoc_tac
 
 /- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:72:18: unsupported non-interactive tactic nat.bitwise_assoc_tac -/
-theorem lxor_assoc (n m k : ℕ) : lxor' (lxor' n m) k = lxor' n (lxor' m k) := by
+theorem lxor'_assoc (n m k : ℕ) : lxor' (lxor' n m) k = lxor' n (lxor' m k) := by
   run_tac
     bitwise_assoc_tac
-#align nat.lxor_assoc Nat.lxor_assoc
+#align nat.lxor_assoc Nat.lxor'_assoc
 
 /- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:72:18: unsupported non-interactive tactic nat.bitwise_assoc_tac -/
-theorem land_assoc (n m k : ℕ) : land (land n m) k = land n (land m k) := by
+theorem land'_assoc (n m k : ℕ) : land' (land' n m) k = land' n (land' m k) := by
   run_tac
     bitwise_assoc_tac
-#align nat.land_assoc Nat.land_assoc
+#align nat.land_assoc Nat.land'_assoc
 
 /- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:72:18: unsupported non-interactive tactic nat.bitwise_assoc_tac -/
-theorem lor_assoc (n m k : ℕ) : lor (lor n m) k = lor n (lor m k) := by
+theorem lor'_assoc (n m k : ℕ) : lor' (lor' n m) k = lor' n (lor' m k) := by
   run_tac
     bitwise_assoc_tac
-#align nat.lor_assoc Nat.lor_assoc
+#align nat.lor_assoc Nat.lor'_assoc
 
 @[simp]
-theorem lxor_self (n : ℕ) : lxor' n n = 0 :=
+theorem lxor'_self (n : ℕ) : lxor' n n = 0 :=
   zero_of_testBit_eq_ff fun i => by simp
-#align nat.lxor_self Nat.lxor_self
+#align nat.lxor_self Nat.lxor'_self
 
 -- These lemmas match `mul_inv_cancel_right` and `mul_inv_cancel_left`.
 theorem lxor_cancel_right (n m : ℕ) : lxor' (lxor' m n) n = m := by
-  rw [lxor_assoc, lxor_self, lxor_zero]
-#align nat.lxor_cancel_right Nat.lxor_cancel_right
+  rw [lxor'_assoc, lxor'_self, lxor'_zero]
+#align nat.lxor_cancel_right Nat.lxor'_cancel_right
 
-theorem lxor_cancel_left (n m : ℕ) : lxor' n (lxor' n m) = m := by
-  rw [← lxor_assoc, lxor_self, zero_lxor]
-#align nat.lxor_cancel_left Nat.lxor_cancel_left
+theorem lxor'_cancel_left (n m : ℕ) : lxor' n (lxor' n m) = m := by
+  rw [← lxor'_assoc, lxor'_self, zero_lxor']
+#align nat.lxor_cancel_left Nat.lxor'_cancel_left
 
-theorem lxor_right_injective {n : ℕ} : Function.Injective (lxor' n) := fun m m' h => by
-  rw [← lxor_cancel_left n m, ← lxor_cancel_left n m', h]
-#align nat.lxor_right_injective Nat.lxor_right_injective
+theorem lxor'_right_injective {n : ℕ} : Function.Injective (lxor' n) := fun m m' h => by
+  rw [← lxor_cancel_left n m, ← lxor'_cancel_left n m', h]
+#align nat.lxor_right_injective Nat.lxor'_right_injective
 
-theorem lxor_left_injective {n : ℕ} : Function.Injective fun m => lxor' m n :=
+theorem lxor'_left_injective {n : ℕ} : Function.Injective fun m => lxor' m n :=
   fun m m' (h : lxor' m n = lxor' m' n) => by
-  rw [← lxor_cancel_right n m, ← lxor_cancel_right n m', h]
-#align nat.lxor_left_injective Nat.lxor_left_injective
+  rw [← lxor'_cancel_right n m, ← lxor'_cancel_right n m', h]
+#align nat.lxor'_left_injective Nat.lxor'_left_injective
 
 @[simp]
-theorem lxor_right_inj {n m m' : ℕ} : lxor' n m = lxor' n m' ↔ m = m' :=
-  lxor_right_injective.eq_iff
-#align nat.lxor_right_inj Nat.lxor_right_inj
+theorem lxor'_right_inj {n m m' : ℕ} : lxor' n m = lxor' n m' ↔ m = m' :=
+  lxor'_right_injective.eq_iff
+#align nat.lxor_right_inj Nat.lxor'_right_inj
 
 @[simp]
-theorem lxor_left_inj {n m m' : ℕ} : lxor' m n = lxor' m' n ↔ m = m' :=
-  lxor_left_injective.eq_iff
-#align nat.lxor_left_inj Nat.lxor_left_inj
+theorem lxor'_left_inj {n m m' : ℕ} : lxor' m n = lxor' m' n ↔ m = m' :=
+  lxor'_left_injective.eq_iff
+#align nat.lxor_left_inj Nat.lxor'_left_inj
 
 @[simp]
-theorem lxor_eq_zero {n m : ℕ} : lxor' n m = 0 ↔ n = m := by
-  rw [← lxor_self n, lxor_right_inj, eq_comm]
-#align nat.lxor_eq_zero Nat.lxor_eq_zero
+theorem lxor'_eq_zero {n m : ℕ} : lxor' n m = 0 ↔ n = m := by
+  rw [← lxor'_self n, lxor'_right_inj, eq_comm]
+#align nat.lxor_eq_zero Nat.lxor'_eq_zero
 
-theorem lxor_ne_zero {n m : ℕ} : lxor' n m ≠ 0 ↔ n ≠ m :=
+theorem lxor'_ne_zero {n m : ℕ} : lxor' n m ≠ 0 ↔ n ≠ m :=
   lxor_eq_zero.not
-#align nat.lxor_ne_zero Nat.lxor_ne_zero
+#align nat.lxor_ne_zero Nat.lxor'_ne_zero
 
-theorem lxor_trichotomy {a b c : ℕ} (h : a ≠ lxor' b c) :
+theorem lxor'_trichotomy {a b c : ℕ} (h : a ≠ lxor' b c) :
     lxor' b c < a ∨ lxor' a c < b ∨ lxor' a b < c :=
   by
-  set v := lxor a (lxor b c) with hv
+  set v := lxor' a (lxor b c) with hv
   -- The xor of any two of `a`, `b`, `c` is the xor of `v` and the third.
-  have hab : lxor a b = lxor c v := by
+  have hab : lxor' a b = lxor' c v := by
     rw [hv]
     conv_rhs =>
-      rw [lxor_comm]
-      simp [lxor_assoc]
-  have hac : lxor a c = lxor b v := by
+      rw [lxor'_comm]
+      simp [lxor'_assoc]
+  have hac : lxor' a c = lxor' b v := by
     rw [hv]
     conv_rhs =>
       congr
       skip
-      rw [lxor_comm]
-    rw [← lxor_assoc, ← lxor_assoc, lxor_self, zero_lxor, lxor_comm]
-  have hbc : lxor b c = lxor a v := by simp [hv, ← lxor_assoc]
+      rw [lxor'_comm]
+    rw [← lxor'_assoc, ← lxor'_assoc, lxor'_self, zero_lxor', lxor'_comm]
+  have hbc : lxor' b c = lxor' a v := by simp [hv, ← lxor'_assoc]
   -- If `i` is the position of the most significant bit of `v`, then at least one of `a`, `b`, `c`
   -- has a one bit at position `i`.
-  obtain ⟨i, ⟨hi, hi'⟩⟩ := exists_most_significant_bit (lxor_ne_zero.2 h)
+  obtain ⟨i, ⟨hi, hi'⟩⟩ := exists_most_significant_bit (lxor'_ne_zero.2 h)
   have : testBit a i = tt ∨ testBit b i = tt ∨ testBit c i = tt :=
     by
     contrapose! hi
-    simp only [Bool.eq_false_eq_not_eq_true, Ne, testBit_lxor] at hi⊢
+    simp only [Bool.eq_false_eq_not_eq_true, Ne, testBit_lxor'] at hi⊢
     rw [hi.1, hi.2.1, hi.2.2, Bool.xor_false, Bool.xor_false]
   -- If, say, `a` has a one bit at position `i`, then `a xor v` has a zero bit at position `i`, but
       -- the same bits as `a` in positions greater than `j`, so `a xor v < a`.
@@ -319,10 +322,10 @@ theorem lxor_trichotomy {a b c : ℕ} (h : a ≠ lxor' b c) :
         right
         rw [hab]] <;>
     exact lt_of_testBit i (by simp [h, hi]) h fun j hj => by simp [hi' _ hj]
-#align nat.lxor_trichotomy Nat.lxor_trichotomy
+#align nat.lxor_trichotomy Nat.lxor'_trichotomy
 
-theorem lt_lxor_cases {a b c : ℕ} (h : a < lxor' b c) : lxor' a c < b ∨ lxor' a b < c :=
-  (or_iff_right fun h' => (h.asymm h').elim).1 <| lxor_trichotomy h.Ne
-#align nat.lt_lxor_cases Nat.lt_lxor_cases
+theorem lt_lxor'_cases {a b c : ℕ} (h : a < lxor' b c) : lxor' a c < b ∨ lxor' a b < c :=
+  (or_iff_right fun h' => (h.asymm h').elim).1 <| lxor'_trichotomy h.Ne
+#align nat.lt_lxor_cases Nat.lt_lxor'_cases
 
 end Nat

--- a/Mathlib/Data/Nat/Bitwise.lean
+++ b/Mathlib/Data/Nat/Bitwise.lean
@@ -8,15 +8,14 @@ Authors: Markus Himmel
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
+import Lean.Elab.Tactic
 import Mathlib.Data.List.Basic
 import Mathlib.Data.Nat.Bits
 import Mathlib.Data.Nat.Size
 import Mathlib.Data.Nat.Order.Lemmas
 import Mathlib.Tactic.Linarith
-import Lean.Elab.Tactic
-
--- TODO REMOVE
-set_option autoImplicit false
+import Mathlib.Tactic.Set
+import Mathlib.Tactic.Cases
 
 /-!
 # Bitwise operations on natural numbers
@@ -49,27 +48,27 @@ open Function
 namespace Nat
 
 @[simp]
-theorem bit_ff : bit false = bit0 :=
+theorem bit_false : bit false = bit0 :=
   rfl
-#align nat.bit_ff Nat.bit_ff
+#align nat.bit_ff Nat.bit_false
 
 @[simp]
-theorem bit_tt : bit true = bit1 :=
+theorem bit_true : bit true = bit1 :=
   rfl
-#align nat.bit_tt Nat.bit_tt
+#align nat.bit_tt Nat.bit_true
 
 @[simp]
 theorem bit_eq_zero {n : ℕ} {b : Bool} : n.bit b = 0 ↔ n = 0 ∧ b = false := by
   cases b <;> simp [Nat.bit0_eq_zero, Nat.bit1_ne_zero]
 #align nat.bit_eq_zero Nat.bit_eq_zero
 
-theorem zero_of_testBit_eq_ff {n : ℕ} (h : ∀ i, testBit n i = false) : n = 0 :=
+theorem zero_of_testBit_eq_false {n : ℕ} (h : ∀ i, testBit n i = false) : n = 0 :=
   by
   induction' n using Nat.binaryRec with b n hn
   · rfl
   · have : b = false := by simpa using h 0
-    rw [this, bit_ff, bit0_val, hn fun i => by rw [← h (i + 1), testBit_succ], mul_zero]
-#align nat.zero_of_test_bit_eq_ff Nat.zero_of_testBit_eq_ff
+    rw [this, bit_false, bit0_val, hn fun i => by rw [← h (i + 1), testBit_succ], mul_zero]
+#align nat.zero_of_test_bit_eq_ff Nat.zero_of_testBit_eq_false
 
 @[simp]
 theorem zero_testBit (i : ℕ) : testBit 0 i = false := by simp only [testBit, shiftr_zero, bodd_zero]
@@ -90,10 +89,10 @@ theorem eq_of_testBit_eq {n m : ℕ} (h : ∀ i, testBit n i = testBit m i) : n 
   by
   induction' n using Nat.binaryRec with b n hn generalizing m
   · simp only [zero_testBit] at h
-    exact (zero_of_testBit_eq_ff fun i => (h i).symm).symm
+    exact (zero_of_testBit_eq_false fun i => (h i).symm).symm
   induction' m using Nat.binaryRec with b' m
   · simp only [zero_testBit] at h
-    exact zero_of_testBit_eq_ff h
+    exact zero_of_testBit_eq_false h
   suffices h' : n = m
   · rw [h', show b = b' by simpa using h 0]
   exact hn fun i => by convert h (i + 1) using 1 <;> rw [testBit_succ]
@@ -132,14 +131,14 @@ theorem lt_of_testBit {n m : ℕ} (i : ℕ) (hn : testBit n i = false) (hm : tes
     simp only [testBit_zero] at hn hm
     have : n = m :=
       eq_of_testBit_eq fun i => by convert hnm (i + 1) (Nat.zero_lt_succ _) using 1 <;> rw [testBit_succ]
-    rw [hn, hm, this, bit_ff, bit_tt, bit0_val, bit1_val]
+    rw [hn, hm, this, bit_false, bit_true, bit0_val, bit1_val]
     exact lt_add_one _
   · obtain ⟨i', rfl⟩ := exists_eq_succ_of_ne_zero hi
     simp only [testBit_succ] at hn hm
     have :=
       hn' _ hn hm fun j hj => by convert hnm j.succ (succ_lt_succ hj) using 1 <;> rw [testBit_succ]
     cases b <;> cases b'
-    <;> simp only [bit_ff, bit_tt, bit0_val n, bit1_val n, bit0_val m, bit1_val m]
+    <;> simp only [bit_false, bit_true, bit0_val n, bit1_val n, bit0_val m, bit1_val m]
     <;> linarith only [this]
 #align nat.lt_of_test_bit Nat.lt_of_testBit
 
@@ -156,6 +155,7 @@ theorem testBit_two_pow_of_ne {n m : ℕ} (hm : n ≠ m) : testBit (2 ^ n) m = f
     exact Nat.pow_lt_pow_of_lt_right one_lt_two hm
   · rw [pow_div hm.le zero_lt_two, ← tsub_add_cancel_of_le (succ_le_of_lt <| tsub_pos_of_lt hm)]
     simp [pow_succ]
+    sorry
 #align nat.test_bit_two_pow_of_ne Nat.testBit_two_pow_of_ne
 
 theorem testBit_two_pow (n m : ℕ) : testBit (2 ^ n) m = (n = m) :=
@@ -220,14 +220,15 @@ theorem lor'_zero (n : ℕ) : lor' n 0 = n := by simp [lor']
 
 /-- Proving associativity of bitwise operations in general essentially boils down to a huge case
     distinction, so it is shorter to use this tactic instead of proving it in the general case. -/
-macro "bitwise_assoc_tac" : tactic => set_option hygiene false in `(tactic|
+macro "bitwise_assoc_tac" : tactic => set_option hygiene false in `(tactic| (
   induction' n using Nat.binaryRec with b n hn generalizing m k
-  <;> · simp
-  <;> induction' m using Nat.binaryRec with b' m hm
-  <;> · simp
-  <;> induction' k using Nat.binaryRec with b'' k hk
-  -- Porting note: This is necessary because these are simp lemmas in mathlib
-  <;> simp [hn, Bool.or_assoc, Bool.and_assoc])
+  · simp
+  induction' m using Nat.binaryRec with b' m hm
+  · simp
+  induction' k using Nat.binaryRec with b'' k hk
+  -- Porting note: was `simp [hn]`
+  -- This is necessary because these are simp lemmas in mathlib
+  <;> simp [hn, Bool.or_assoc, Bool.and_assoc]))
 
 theorem lxor'_assoc (n m k : ℕ) : lxor' (lxor' n m) k = lxor' n (lxor' m k) := by bitwise_assoc_tac
 #align nat.lxor_assoc Nat.lxor'_assoc
@@ -240,25 +241,25 @@ theorem lor'_assoc (n m k : ℕ) : lor' (lor' n m) k = lor' n (lor' m k) := by b
 
 @[simp]
 theorem lxor'_self (n : ℕ) : lxor' n n = 0 :=
-  zero_of_testBit_eq_ff fun i => by simp
+  zero_of_testBit_eq_false fun i => by simp
 #align nat.lxor_self Nat.lxor'_self
 
 -- These lemmas match `mul_inv_cancel_right` and `mul_inv_cancel_left`.
 theorem lxor_cancel_right (n m : ℕ) : lxor' (lxor' m n) n = m := by
   rw [lxor'_assoc, lxor'_self, lxor'_zero]
-#align nat.lxor_cancel_right Nat.lxor'_cancel_right
+#align nat.lxor_cancel_right Nat.lxor_cancel_right
 
 theorem lxor'_cancel_left (n m : ℕ) : lxor' n (lxor' n m) = m := by
   rw [← lxor'_assoc, lxor'_self, zero_lxor']
 #align nat.lxor_cancel_left Nat.lxor'_cancel_left
 
 theorem lxor'_right_injective {n : ℕ} : Function.Injective (lxor' n) := fun m m' h => by
-  rw [← lxor_cancel_left n m, ← lxor'_cancel_left n m', h]
+  rw [← lxor'_cancel_left n m, ← lxor'_cancel_left n m', h]
 #align nat.lxor_right_injective Nat.lxor'_right_injective
 
 theorem lxor'_left_injective {n : ℕ} : Function.Injective fun m => lxor' m n :=
   fun m m' (h : lxor' m n = lxor' m' n) => by
-  rw [← lxor'_cancel_right n m, ← lxor'_cancel_right n m', h]
+  rw [← lxor_cancel_right n m, ← lxor_cancel_right n m', h]
 #align nat.lxor'_left_injective Nat.lxor'_left_injective
 
 @[simp]
@@ -277,13 +278,12 @@ theorem lxor'_eq_zero {n m : ℕ} : lxor' n m = 0 ↔ n = m := by
 #align nat.lxor_eq_zero Nat.lxor'_eq_zero
 
 theorem lxor'_ne_zero {n m : ℕ} : lxor' n m ≠ 0 ↔ n ≠ m :=
-  lxor_eq_zero.not
+  lxor'_eq_zero.not
 #align nat.lxor_ne_zero Nat.lxor'_ne_zero
 
 theorem lxor'_trichotomy {a b c : ℕ} (h : a ≠ lxor' b c) :
-    lxor' b c < a ∨ lxor' a c < b ∨ lxor' a b < c :=
-  by
-  set v := lxor' a (lxor b c) with hv
+    lxor' b c < a ∨ lxor' a c < b ∨ lxor' a b < c := by
+  set v := lxor' a (lxor' b c) with hv
   -- The xor of any two of `a`, `b`, `c` is the xor of `v` and the third.
   have hab : lxor' a b = lxor' c v := by
     rw [hv]
@@ -293,36 +293,31 @@ theorem lxor'_trichotomy {a b c : ℕ} (h : a ≠ lxor' b c) :
   have hac : lxor' a c = lxor' b v := by
     rw [hv]
     conv_rhs =>
-      congr
-      skip
-      rw [lxor'_comm]
+      right
+      rw [← lxor'_comm]
     rw [← lxor'_assoc, ← lxor'_assoc, lxor'_self, zero_lxor', lxor'_comm]
   have hbc : lxor' b c = lxor' a v := by simp [hv, ← lxor'_assoc]
   -- If `i` is the position of the most significant bit of `v`, then at least one of `a`, `b`, `c`
   -- has a one bit at position `i`.
   obtain ⟨i, ⟨hi, hi'⟩⟩ := exists_most_significant_bit (lxor'_ne_zero.2 h)
-  have : testBit a i = tt ∨ testBit b i = tt ∨ testBit c i = tt :=
+  have : testBit a i = true ∨ testBit b i = true ∨ testBit c i = true :=
     by
     contrapose! hi
     simp only [Bool.eq_false_eq_not_eq_true, Ne, testBit_lxor'] at hi⊢
     rw [hi.1, hi.2.1, hi.2.2, Bool.xor_false, Bool.xor_false]
   -- If, say, `a` has a one bit at position `i`, then `a xor v` has a zero bit at position `i`, but
-      -- the same bits as `a` in positions greater than `j`, so `a xor v < a`.
-      rcases this with (h | h | h) <;>
-      [·
-        left
-        rw [hbc],
-      · right
-        left
-        rw [hac],
-      · right
-        right
-        rw [hab]] <;>
-    exact lt_of_testBit i (by simp [h, hi]) h fun j hj => by simp [hi' _ hj]
+  -- the same bits as `a` in positions greater than `j`, so `a xor v < a`.
+  rcases this with (h | h | h)
+  on_goal 1 => left ; rw [hbc]
+  on_goal 2 => right; left; rw [hac]
+  on_goal 3 => right; right; rw [hab]
+  all_goals
+    admit --exact lt_of_testBit i (by simp [h, hi]) h fun j hj => by simp [hi' _ hj]
+
 #align nat.lxor_trichotomy Nat.lxor'_trichotomy
 
 theorem lt_lxor'_cases {a b c : ℕ} (h : a < lxor' b c) : lxor' a c < b ∨ lxor' a b < c :=
-  (or_iff_right fun h' => (h.asymm h').elim).1 <| lxor'_trichotomy h.Ne
+  (or_iff_right fun h' => (h.asymm h').elim).1 <| lxor'_trichotomy h.ne
 #align nat.lt_lxor_cases Nat.lt_lxor'_cases
 
 end Nat

--- a/Mathlib/Data/Nat/Bitwise.lean
+++ b/Mathlib/Data/Nat/Bitwise.lean
@@ -46,6 +46,8 @@ open Function
 
 namespace Nat
 
+set_option linter.deprecated false
+
 @[simp]
 theorem bit_false : bit false = bit0 :=
   rfl

--- a/Mathlib/Data/Nat/Bitwise.lean
+++ b/Mathlib/Data/Nat/Bitwise.lean
@@ -8,9 +8,9 @@ Authors: Markus Himmel
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
-import Mathbin.Data.List.Basic
-import Mathbin.Data.Nat.Bits
-import Mathbin.Tactic.Linarith.Default
+import Mathlib.Data.List.Basic
+import Mathlib.Data.Nat.Bits
+import Mathlib.Tactic.Linarith.Default
 
 /-!
 # Bitwise operations on natural numbers

--- a/Mathlib/Data/Nat/Bitwise.lean
+++ b/Mathlib/Data/Nat/Bitwise.lean
@@ -1,0 +1,324 @@
+/-
+Copyright (c) 2020 Markus Himmel. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Markus Himmel
+
+! This file was ported from Lean 3 source module data.nat.bitwise
+! leanprover-community/mathlib commit 6afc9b06856ad973f6a2619e3e8a0a8d537a58f2
+! Please do not edit these lines, except to modify the commit id
+! if you have ported upstream changes.
+-/
+import Mathbin.Data.List.Basic
+import Mathbin.Data.Nat.Bits
+import Mathbin.Tactic.Linarith.Default
+
+/-!
+# Bitwise operations on natural numbers
+
+In the first half of this file, we provide theorems for reasoning about natural numbers from their
+bitwise properties. In the second half of this file, we show properties of the bitwise operations
+`lor`, `land` and `lxor`, which are defined in core.
+
+## Main results
+* `eq_of_test_bit_eq`: two natural numbers are equal if they have equal bits at every position.
+* `exists_most_significant_bit`: if `n ≠ 0`, then there is some position `i` that contains the most
+  significant `1`-bit of `n`.
+* `lt_of_test_bit`: if `n` and `m` are numbers and `i` is a position such that the `i`-th bit of
+  of `n` is zero, the `i`-th bit of `m` is one, and all more significant bits are equal, then
+  `n < m`.
+
+## Future work
+
+There is another way to express bitwise properties of natural number: `digits 2`. The two ways
+should be connected.
+
+## Keywords
+
+bitwise, and, or, xor
+-/
+
+
+open Function
+
+namespace Nat
+
+@[simp]
+theorem bit_ff : bit false = bit0 :=
+  rfl
+#align nat.bit_ff Nat.bit_ff
+
+@[simp]
+theorem bit_tt : bit true = bit1 :=
+  rfl
+#align nat.bit_tt Nat.bit_tt
+
+@[simp]
+theorem bit_eq_zero {n : ℕ} {b : Bool} : n.bit b = 0 ↔ n = 0 ∧ b = ff := by
+  cases b <;> simp [Nat.bit0_eq_zero, Nat.bit1_ne_zero]
+#align nat.bit_eq_zero Nat.bit_eq_zero
+
+theorem zero_of_test_bit_eq_ff {n : ℕ} (h : ∀ i, testBit n i = ff) : n = 0 :=
+  by
+  induction' n using Nat.binaryRec with b n hn
+  · rfl
+  · have : b = ff := by simpa using h 0
+    rw [this, bit_ff, bit0_val, hn fun i => by rw [← h (i + 1), test_bit_succ], mul_zero]
+#align nat.zero_of_test_bit_eq_ff Nat.zero_of_test_bit_eq_ff
+
+@[simp]
+theorem zero_test_bit (i : ℕ) : testBit 0 i = ff := by simp [test_bit]
+#align nat.zero_test_bit Nat.zero_test_bit
+
+/-- The ith bit is the ith element of `n.bits`. -/
+theorem test_bit_eq_inth (n i : ℕ) : n.testBit i = n.bits.inth i :=
+  by
+  induction' i with i ih generalizing n
+  · simp [test_bit, shiftr, bodd_eq_bits_head, List.getI_zero_eq_head!]
+  conv_lhs => rw [← bit_decomp n]
+  rw [test_bit_succ, ih n.div2, div2_bits_eq_tail]
+  cases n.bits <;> simp
+#align nat.test_bit_eq_inth Nat.test_bit_eq_inth
+
+/-- Bitwise extensionality: Two numbers agree if they agree at every bit position. -/
+theorem eq_of_test_bit_eq {n m : ℕ} (h : ∀ i, testBit n i = testBit m i) : n = m :=
+  by
+  induction' n using Nat.binaryRec with b n hn generalizing m
+  · simp only [zero_test_bit] at h
+    exact (zero_of_test_bit_eq_ff fun i => (h i).symm).symm
+  induction' m using Nat.binaryRec with b' m hm
+  · simp only [zero_test_bit] at h
+    exact zero_of_test_bit_eq_ff h
+  suffices h' : n = m
+  · rw [h', show b = b' by simpa using h 0]
+  exact hn fun i => by convert h (i + 1) using 1 <;> rw [test_bit_succ]
+#align nat.eq_of_test_bit_eq Nat.eq_of_test_bit_eq
+
+theorem exists_most_significant_bit {n : ℕ} (h : n ≠ 0) :
+    ∃ i, testBit n i = tt ∧ ∀ j, i < j → testBit n j = ff :=
+  by
+  induction' n using Nat.binaryRec with b n hn
+  · exact False.elim (h rfl)
+  by_cases h' : n = 0
+  · subst h'
+    rw [show b = tt by
+        revert h
+        cases b <;> simp]
+    refine' ⟨0, ⟨by rw [test_bit_zero], fun j hj => _⟩⟩
+    obtain ⟨j', rfl⟩ := exists_eq_succ_of_ne_zero (ne_of_gt hj)
+    rw [test_bit_succ, zero_test_bit]
+  · obtain ⟨k, ⟨hk, hk'⟩⟩ := hn h'
+    refine' ⟨k + 1, ⟨by rw [test_bit_succ, hk], fun j hj => _⟩⟩
+    obtain ⟨j', rfl⟩ := exists_eq_succ_of_ne_zero (show j ≠ 0 by linarith)
+    exact (test_bit_succ _ _ _).trans (hk' _ (lt_of_succ_lt_succ hj))
+#align nat.exists_most_significant_bit Nat.exists_most_significant_bit
+
+theorem lt_of_test_bit {n m : ℕ} (i : ℕ) (hn : testBit n i = ff) (hm : testBit m i = tt)
+    (hnm : ∀ j, i < j → testBit n j = testBit m j) : n < m :=
+  by
+  induction' n using Nat.binaryRec with b n hn' generalizing i m
+  · contrapose! hm
+    rw [le_zero_iff] at hm
+    simp [hm]
+  induction' m using Nat.binaryRec with b' m hm' generalizing i
+  · exact False.elim (Bool.ff_ne_tt ((zero_test_bit i).symm.trans hm))
+  by_cases hi : i = 0
+  · subst hi
+    simp only [test_bit_zero] at hn hm
+    have : n = m :=
+      eq_of_test_bit_eq fun i => by convert hnm (i + 1) (by decide) using 1 <;> rw [test_bit_succ]
+    rw [hn, hm, this, bit_ff, bit_tt, bit0_val, bit1_val]
+    exact lt_add_one _
+  · obtain ⟨i', rfl⟩ := exists_eq_succ_of_ne_zero hi
+    simp only [test_bit_succ] at hn hm
+    have :=
+      hn' _ hn hm fun j hj => by convert hnm j.succ (succ_lt_succ hj) using 1 <;> rw [test_bit_succ]
+    cases b <;> cases b' <;>
+        simp only [bit_ff, bit_tt, bit0_val n, bit1_val n, bit0_val m, bit1_val m] <;>
+      linarith
+#align nat.lt_of_test_bit Nat.lt_of_test_bit
+
+@[simp]
+theorem test_bit_two_pow_self (n : ℕ) : testBit (2 ^ n) n = tt := by
+  rw [test_bit, shiftr_eq_div_pow, Nat.div_self (pow_pos zero_lt_two n), bodd_one]
+#align nat.test_bit_two_pow_self Nat.test_bit_two_pow_self
+
+theorem test_bit_two_pow_of_ne {n m : ℕ} (hm : n ≠ m) : testBit (2 ^ n) m = ff :=
+  by
+  rw [test_bit, shiftr_eq_div_pow]
+  cases' hm.lt_or_lt with hm hm
+  · rw [Nat.div_eq_zero, bodd_zero]
+    exact Nat.pow_lt_pow_of_lt_right one_lt_two hm
+  · rw [pow_div hm.le zero_lt_two, ← tsub_add_cancel_of_le (succ_le_of_lt <| tsub_pos_of_lt hm)]
+    simp [pow_succ]
+#align nat.test_bit_two_pow_of_ne Nat.test_bit_two_pow_of_ne
+
+theorem test_bit_two_pow (n m : ℕ) : testBit (2 ^ n) m = (n = m) :=
+  by
+  by_cases n = m
+  · cases h
+    simp
+  · rw [test_bit_two_pow_of_ne h]
+    simp [h]
+#align nat.test_bit_two_pow Nat.test_bit_two_pow
+
+/-- If `f` is a commutative operation on bools such that `f ff ff = ff`, then `bitwise f` is also
+    commutative. -/
+theorem bitwise_comm {f : Bool → Bool → Bool} (hf : ∀ b b', f b b' = f b' b)
+    (hf' : f false false = ff) (n m : ℕ) : bitwise f n m = bitwise f m n :=
+  suffices bitwise f = swap (bitwise f) by conv_lhs => rw [this]
+  calc
+    bitwise f = bitwise (swap f) := congr_arg _ <| funext fun _ => funext <| hf _
+    _ = swap (bitwise f) := bitwise'_swap hf'
+    
+#align nat.bitwise_comm Nat.bitwise_comm
+
+theorem lor_comm (n m : ℕ) : lor n m = lor m n :=
+  bitwise_comm Bool.or_comm rfl n m
+#align nat.lor_comm Nat.lor_comm
+
+theorem land_comm (n m : ℕ) : land n m = land m n :=
+  bitwise_comm Bool.and_comm rfl n m
+#align nat.land_comm Nat.land_comm
+
+theorem lxor_comm (n m : ℕ) : lxor' n m = lxor' m n :=
+  bitwise_comm Bool.xor_comm rfl n m
+#align nat.lxor_comm Nat.lxor_comm
+
+@[simp]
+theorem zero_lxor (n : ℕ) : lxor' 0 n = n := by simp [lxor]
+#align nat.zero_lxor Nat.zero_lxor
+
+@[simp]
+theorem lxor_zero (n : ℕ) : lxor' n 0 = n := by simp [lxor]
+#align nat.lxor_zero Nat.lxor_zero
+
+@[simp]
+theorem zero_land (n : ℕ) : land 0 n = 0 := by simp [land]
+#align nat.zero_land Nat.zero_land
+
+@[simp]
+theorem land_zero (n : ℕ) : land n 0 = 0 := by simp [land]
+#align nat.land_zero Nat.land_zero
+
+@[simp]
+theorem zero_lor (n : ℕ) : lor 0 n = n := by simp [lor]
+#align nat.zero_lor Nat.zero_lor
+
+@[simp]
+theorem lor_zero (n : ℕ) : lor n 0 = n := by simp [lor]
+#align nat.lor_zero Nat.lor_zero
+
+/- ./././Mathport/Syntax/Translate/Expr.lean:333:4: warning: unsupported (TODO): `[tacs] -/
+/-- Proving associativity of bitwise operations in general essentially boils down to a huge case
+    distinction, so it is shorter to use this tactic instead of proving it in the general case. -/
+unsafe def bitwise_assoc_tac : tactic Unit :=
+  sorry
+#align nat.bitwise_assoc_tac nat.bitwise_assoc_tac
+
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:72:18: unsupported non-interactive tactic nat.bitwise_assoc_tac -/
+theorem lxor_assoc (n m k : ℕ) : lxor' (lxor' n m) k = lxor' n (lxor' m k) := by
+  run_tac
+    bitwise_assoc_tac
+#align nat.lxor_assoc Nat.lxor_assoc
+
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:72:18: unsupported non-interactive tactic nat.bitwise_assoc_tac -/
+theorem land_assoc (n m k : ℕ) : land (land n m) k = land n (land m k) := by
+  run_tac
+    bitwise_assoc_tac
+#align nat.land_assoc Nat.land_assoc
+
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:72:18: unsupported non-interactive tactic nat.bitwise_assoc_tac -/
+theorem lor_assoc (n m k : ℕ) : lor (lor n m) k = lor n (lor m k) := by
+  run_tac
+    bitwise_assoc_tac
+#align nat.lor_assoc Nat.lor_assoc
+
+@[simp]
+theorem lxor_self (n : ℕ) : lxor' n n = 0 :=
+  zero_of_test_bit_eq_ff fun i => by simp
+#align nat.lxor_self Nat.lxor_self
+
+-- These lemmas match `mul_inv_cancel_right` and `mul_inv_cancel_left`.
+theorem lxor_cancel_right (n m : ℕ) : lxor' (lxor' m n) n = m := by
+  rw [lxor_assoc, lxor_self, lxor_zero]
+#align nat.lxor_cancel_right Nat.lxor_cancel_right
+
+theorem lxor_cancel_left (n m : ℕ) : lxor' n (lxor' n m) = m := by
+  rw [← lxor_assoc, lxor_self, zero_lxor]
+#align nat.lxor_cancel_left Nat.lxor_cancel_left
+
+theorem lxor_right_injective {n : ℕ} : Function.Injective (lxor' n) := fun m m' h => by
+  rw [← lxor_cancel_left n m, ← lxor_cancel_left n m', h]
+#align nat.lxor_right_injective Nat.lxor_right_injective
+
+theorem lxor_left_injective {n : ℕ} : Function.Injective fun m => lxor' m n :=
+  fun m m' (h : lxor' m n = lxor' m' n) => by
+  rw [← lxor_cancel_right n m, ← lxor_cancel_right n m', h]
+#align nat.lxor_left_injective Nat.lxor_left_injective
+
+@[simp]
+theorem lxor_right_inj {n m m' : ℕ} : lxor' n m = lxor' n m' ↔ m = m' :=
+  lxor_right_injective.eq_iff
+#align nat.lxor_right_inj Nat.lxor_right_inj
+
+@[simp]
+theorem lxor_left_inj {n m m' : ℕ} : lxor' m n = lxor' m' n ↔ m = m' :=
+  lxor_left_injective.eq_iff
+#align nat.lxor_left_inj Nat.lxor_left_inj
+
+@[simp]
+theorem lxor_eq_zero {n m : ℕ} : lxor' n m = 0 ↔ n = m := by
+  rw [← lxor_self n, lxor_right_inj, eq_comm]
+#align nat.lxor_eq_zero Nat.lxor_eq_zero
+
+theorem lxor_ne_zero {n m : ℕ} : lxor' n m ≠ 0 ↔ n ≠ m :=
+  lxor_eq_zero.Not
+#align nat.lxor_ne_zero Nat.lxor_ne_zero
+
+theorem lxor_trichotomy {a b c : ℕ} (h : a ≠ lxor' b c) :
+    lxor' b c < a ∨ lxor' a c < b ∨ lxor' a b < c :=
+  by
+  set v := lxor a (lxor b c) with hv
+  -- The xor of any two of `a`, `b`, `c` is the xor of `v` and the third.
+  have hab : lxor a b = lxor c v := by
+    rw [hv]
+    conv_rhs =>
+      rw [lxor_comm]
+      simp [lxor_assoc]
+  have hac : lxor a c = lxor b v := by
+    rw [hv]
+    conv_rhs =>
+      congr
+      skip
+      rw [lxor_comm]
+    rw [← lxor_assoc, ← lxor_assoc, lxor_self, zero_lxor, lxor_comm]
+  have hbc : lxor b c = lxor a v := by simp [hv, ← lxor_assoc]
+  -- If `i` is the position of the most significant bit of `v`, then at least one of `a`, `b`, `c`
+  -- has a one bit at position `i`.
+  obtain ⟨i, ⟨hi, hi'⟩⟩ := exists_most_significant_bit (lxor_ne_zero.2 h)
+  have : test_bit a i = tt ∨ test_bit b i = tt ∨ test_bit c i = tt :=
+    by
+    contrapose! hi
+    simp only [Bool.eq_false_eq_not_eq_true, Ne, test_bit_lxor] at hi⊢
+    rw [hi.1, hi.2.1, hi.2.2, Bool.xor_false, Bool.xor_false]
+  -- If, say, `a` has a one bit at position `i`, then `a xor v` has a zero bit at position `i`, but
+      -- the same bits as `a` in positions greater than `j`, so `a xor v < a`.
+      rcases this with (h | h | h) <;>
+      [·
+        left
+        rw [hbc],
+      · right
+        left
+        rw [hac],
+      · right
+        right
+        rw [hab]] <;>
+    exact lt_of_test_bit i (by simp [h, hi]) h fun j hj => by simp [hi' _ hj]
+#align nat.lxor_trichotomy Nat.lxor_trichotomy
+
+theorem lt_lxor_cases {a b c : ℕ} (h : a < lxor' b c) : lxor' a c < b ∨ lxor' a b < c :=
+  (or_iff_right fun h' => (h.asymm h').elim).1 <| lxor_trichotomy h.Ne
+#align nat.lt_lxor_cases Nat.lt_lxor_cases
+
+end Nat
+

--- a/Mathlib/Data/Nat/Bitwise.lean
+++ b/Mathlib/Data/Nat/Bitwise.lean
@@ -13,6 +13,7 @@ import Mathlib.Data.Nat.Bits
 import Mathlib.Data.Nat.Size
 import Mathlib.Data.Nat.Order.Lemmas
 import Mathlib.Tactic.Linarith
+import Lean.Elab.Tactic
 
 -- TODO REMOVE
 set_option autoImplicit false
@@ -216,29 +217,25 @@ theorem zero_lor' (n : ℕ) : lor' 0 n = n := by --simp [lor']
 theorem lor'_zero (n : ℕ) : lor' n 0 = n := by simp [lor']
 #align nat.lor_zero Nat.lor'_zero
 
-/- ./././Mathport/Syntax/Translate/Expr.lean:333:4: warning: unsupported (TODO): `[tacs] -/
+
 /-- Proving associativity of bitwise operations in general essentially boils down to a huge case
     distinction, so it is shorter to use this tactic instead of proving it in the general case. -/
-unsafe def bitwise_assoc_tac : tactic Unit :=
-  sorry
-#align nat.bitwise_assoc_tac nat.bitwise_assoc_tac
+macro "bitwise_assoc_tac" : tactic => set_option hygiene false in `(tactic|
+  induction' n using Nat.binaryRec with b n hn generalizing m k
+  <;> · simp
+  <;> induction' m using Nat.binaryRec with b' m hm
+  <;> · simp
+  <;> induction' k using Nat.binaryRec with b'' k hk
+  -- Porting note: This is necessary because these are simp lemmas in mathlib
+  <;> simp [hn, Bool.or_assoc, Bool.and_assoc])
 
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:72:18: unsupported non-interactive tactic nat.bitwise_assoc_tac -/
-theorem lxor'_assoc (n m k : ℕ) : lxor' (lxor' n m) k = lxor' n (lxor' m k) := by
-  run_tac
-    bitwise_assoc_tac
+theorem lxor'_assoc (n m k : ℕ) : lxor' (lxor' n m) k = lxor' n (lxor' m k) := by bitwise_assoc_tac
 #align nat.lxor_assoc Nat.lxor'_assoc
 
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:72:18: unsupported non-interactive tactic nat.bitwise_assoc_tac -/
-theorem land'_assoc (n m k : ℕ) : land' (land' n m) k = land' n (land' m k) := by
-  run_tac
-    bitwise_assoc_tac
+theorem land'_assoc (n m k : ℕ) : land' (land' n m) k = land' n (land' m k) := by bitwise_assoc_tac
 #align nat.land_assoc Nat.land'_assoc
 
-/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:72:18: unsupported non-interactive tactic nat.bitwise_assoc_tac -/
-theorem lor'_assoc (n m k : ℕ) : lor' (lor' n m) k = lor' n (lor' m k) := by
-  run_tac
-    bitwise_assoc_tac
+theorem lor'_assoc (n m k : ℕ) : lor' (lor' n m) k = lor' n (lor' m k) := by bitwise_assoc_tac
 #align nat.lor_assoc Nat.lor'_assoc
 
 @[simp]

--- a/Mathlib/Init/Data/List/Basic.lean
+++ b/Mathlib/Init/Data/List/Basic.lean
@@ -34,10 +34,13 @@ set_option linter.deprecated false in
 theorem nthLe_eq (l : List α) (n) (h : n < l.length) : nthLe l n h = get l ⟨n, h⟩ := rfl
 
 /-- The head of a list, or the default element of the type is the list is `nil`. -/
-@[simp] def headI [Inhabited α] : List α → α
+def headI [Inhabited α] : List α → α
 | []       => default
 | (a :: _) => a
 #align list.head List.headI
+
+@[simp] theorem headI_nil [Inhabited α] : ([] : List α).headI = default := rfl
+@[simp] theorem headI_cons [Inhabited α] {h : α} {t : List α} : (h :: t).headI = h := rfl
 
 #align list.map₂ List.zipWith
 


### PR DESCRIPTION
depends on
- [x] depends on: #1407
- [x] depends on: #1415 otherwise simp cannot unify past a panic

would be nice:
- [ ] leanprover/lean4#2017 will simplify `bitwise_assoc_tac`