### PR TITLE
[Merged by Bors] - chore: improve UIntN declaration

### DIFF
--- a/Mathlib/Data/UInt.lean
+++ b/Mathlib/Data/UInt.lean
@@ -24,10 +24,10 @@ lemma UInt64.val_eq_of_lt {a : Nat} : a < UInt64.size -> (ofNat a).val = a := Fi
 
 lemma USize.val_eq_of_lt {a : Nat} : a < USize.size -> (ofNat a).val = a := Fin.val_eq_of_lt
 
-set_option hygiene false
-/-- `genIntDeclars UInt8` generates a `CommRing UInt8` instance.  -/
-local macro "genIntDeclars" typeName:ident : command => do
-  `(
+set_option hygiene false in
+run_cmd
+  for typeName in [`UInt8, `UInt16, `UInt32, `UInt64, `USize].map Lean.mkIdent do
+  Lean.Elab.Command.elabCommand (← `(
     namespace $typeName
       instance : Inhabited (Fin size) where
         default := Fin.ofNat' 0 size_positive
@@ -108,13 +108,7 @@ local macro "genIntDeclars" typeName:ident : command => do
           exact mul_comm _ _
 
     end $typeName
-  )
-
-genIntDeclars UInt8
-genIntDeclars UInt16
-genIntDeclars UInt32
-genIntDeclars UInt64
-genIntDeclars USize
+  ))
 
 namespace UInt8
 


### PR DESCRIPTION
This change apparently fixes some error reporting issues stemming from these UInt declarations not being a monolithic command (see https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Data.2EFin.2EBasic.20.28mathlib4.231084.29/near/319933441). 

I have a very slow computer, but for some reason this seems to take long time to elaborate.