### PR TITLE
[Merged by Bors] - feat: specific file names for `cache get` and `cache get!`

### DIFF
--- a/Cache/Hashing.lean
+++ b/Cache/Hashing.lean
@@ -22,12 +22,12 @@ partial def insertDeps (hashMap : HashMap) (path : FilePath) (hashMemo : HashMem
   | (some deps, some hash) => deps.foldl (insertDeps · · hashMemo) (hashMap.insert path hash)
   | _ => hashMap
 
-def HashMemo.filterByPatterns (hashMemo : HashMemo) (patterns : List String) : IO HashMap := do
+def HashMemo.filterByFileNames (hashMemo : HashMemo) (fileNames : List String) : IO HashMap := do
   let mut hashMap := default
-  for pattern in patterns do
-    if hashMemo.hashMap.contains pattern then
-      hashMap := insertDeps hashMap pattern hashMemo
-    else IO.println s!"No match for {pattern}"
+  for fileName in fileNames do
+    if hashMemo.hashMap.contains fileName then
+      hashMap := insertDeps hashMap fileName hashMemo
+    else IO.println s!"No match for {fileName}"
   return hashMap
 
 /-- We cache the hash of each file and their dependencies for later lookup -/

--- a/Cache/Hashing.lean
+++ b/Cache/Hashing.lean
@@ -22,10 +22,13 @@ partial def insertDeps (hashMap : HashMap) (path : FilePath) (hashMemo : HashMem
   | (some deps, some hash) => deps.foldl (insertDeps · · hashMemo) (hashMap.insert path hash)
   | _ => hashMap
 
-def HashMemo.filterByPatterns (hashMemo : HashMemo) (patterns : List String) : IO HashMap :=
-  hashMemo.hashMap.foldM (init := default) fun acc path _ => do
-    if patterns.contains path.toString then pure $ insertDeps acc path hashMemo
-    else pure acc
+def HashMemo.filterByPatterns (hashMemo : HashMemo) (patterns : List String) : IO HashMap := do
+  let mut hashMap := default
+  for pattern in patterns do
+    if hashMemo.hashMap.contains pattern then
+      hashMap := insertDeps hashMap pattern hashMemo
+    else IO.println s!"No match for {pattern}"
+  return hashMap
 
 /-- We cache the hash of each file and their dependencies for later lookup -/
 abbrev HashM := StateT HashMemo IO

--- a/Cache/Hashing.lean
+++ b/Cache/Hashing.lean
@@ -22,6 +22,11 @@ partial def insertDeps (hashMap : HashMap) (path : FilePath) (hashMemo : HashMem
   | (some deps, some hash) => deps.foldl (insertDeps · · hashMemo) (hashMap.insert path hash)
   | _ => hashMap
 
+/--
+Filters the `HashMap` of a `HashMemo` so that it only contains key/value pairs such that every key:
+* Belongs to the given list of file paths or
+* Corresponds to a file that's imported (transitively of not) by some file in the list of file paths
+-/
 def HashMemo.filterByFilePaths (hashMemo : HashMemo) (filePaths : List FilePath) : IO HashMap := do
   let mut hashMap := default
   for filePath in filePaths do

--- a/Cache/Hashing.lean
+++ b/Cache/Hashing.lean
@@ -16,14 +16,6 @@ structure HashMemo where
   hashMap : HashMap
   deriving Inhabited
 
-/-- Tells whether a string matches a pattern with at most one wildcard '*' -/
-def matchesAnyPattern (str : String) : List String → IO Bool
-  | [] => pure false
-  | p :: ps => match p.splitOn "*" with
-    | [pat] => if str.startsWith pat then pure true else matchesAnyPattern str ps
-    | [b, e] => if str.startsWith b && str.endsWith e then pure true else matchesAnyPattern str ps
-    | _ => throw $ IO.userError s!"Invalid pattern: {p}"
-
 partial def insertDeps (hashMap : HashMap) (path : FilePath) (hashMemo : HashMemo) : HashMap :=
   if hashMap.contains path then hashMap else
   match (hashMemo.depsMap.find? path, hashMemo.hashMap.find? path) with
@@ -32,7 +24,7 @@ partial def insertDeps (hashMap : HashMap) (path : FilePath) (hashMemo : HashMem
 
 def HashMemo.filterByPatterns (hashMemo : HashMemo) (patterns : List String) : IO HashMap :=
   hashMemo.hashMap.foldM (init := default) fun acc path _ => do
-    if ← matchesAnyPattern path.toString patterns then pure $ insertDeps acc path hashMemo
+    if patterns.contains path.toString then pure $ insertDeps acc path hashMemo
     else pure acc
 
 /-- We cache the hash of each file and their dependencies for later lookup -/

--- a/Cache/Hashing.lean
+++ b/Cache/Hashing.lean
@@ -19,8 +19,9 @@ structure HashMemo where
 def matchesAnyPattern (str : String) : List String → IO Bool
   | [] => pure false
   | p :: ps => match p.splitOn "*" with
-    | [pat] => return str == pat
-    | [b, e] => return str.startsWith b && str.endsWith e
+    | [pat] => if str == pat then pure true else matchesAnyPattern str ps
+    | [b, e] => if str.startsWith b && str.endsWith e then pure true else matchesAnyPattern str ps
+    | _ => throw $ IO.userError s!"Invalid pattern: {p}"
 
 def HashMemo.filterByPatterns (memo : HashMemo) (patterns : List String) : IO HashMap := do
   let mut res := default

--- a/Cache/Hashing.lean
+++ b/Cache/Hashing.lean
@@ -27,7 +27,7 @@ def HashMemo.filterByFileNames (hashMemo : HashMemo) (fileNames : List String) :
   for fileName in fileNames do
     if hashMemo.hashMap.contains fileName then
       hashMap := insertDeps hashMap fileName hashMemo
-    else IO.println s!"No match for {fileName}"
+    else throw $ IO.userError s!"No match for {fileName}"
   return hashMap
 
 /-- We cache the hash of each file and their dependencies for later lookup -/

--- a/Cache/Hashing.lean
+++ b/Cache/Hashing.lean
@@ -16,6 +16,19 @@ structure HashMemo where
   map : HashMap
   deriving Inhabited
 
+def matchesAnyPattern (str : String) : List String → IO Bool
+  | [] => pure false
+  | p :: ps => match p.splitOn "*" with
+    | [pat] => return str == pat
+    | [b, e] => return str.startsWith b && str.endsWith e
+
+def HashMemo.filterByPatterns (memo : HashMemo) (patterns : List String) : IO HashMap := do
+  let mut res := default
+  for (path, hash) in memo.map.toList do
+    if ← matchesAnyPattern path.toString patterns then
+      sorry
+  pure res
+
 /-- We cache the hash of each file for faster lookup -/
 abbrev HashM := StateT HashMemo IO
 

--- a/Cache/Hashing.lean
+++ b/Cache/Hashing.lean
@@ -22,12 +22,12 @@ partial def insertDeps (hashMap : HashMap) (path : FilePath) (hashMemo : HashMem
   | (some deps, some hash) => deps.foldl (insertDeps · · hashMemo) (hashMap.insert path hash)
   | _ => hashMap
 
-def HashMemo.filterByFileNames (hashMemo : HashMemo) (fileNames : List String) : IO HashMap := do
+def HashMemo.filterByFilePaths (hashMemo : HashMemo) (filePaths : List FilePath) : IO HashMap := do
   let mut hashMap := default
-  for fileName in fileNames do
-    if hashMemo.hashMap.contains fileName then
-      hashMap := insertDeps hashMap fileName hashMemo
-    else throw $ IO.userError s!"No match for {fileName}"
+  for filePath in filePaths do
+    if hashMemo.hashMap.contains filePath then
+      hashMap := insertDeps hashMap filePath hashMemo
+    else throw $ IO.userError s!"No match for {filePath}"
   return hashMap
 
 /-- We cache the hash of each file and their dependencies for later lookup -/

--- a/Cache/IO.lean
+++ b/Cache/IO.lean
@@ -176,7 +176,7 @@ def unpackCache (hashMap : HashMap) : IO Unit := do
           "-C", mathlibDepPath.toString]
   else IO.println "No cache files to decompress"
 
-/-- Retrieves the azure token from the file system -/
+/-- Retrieves the azure token from the environment -/
 def getToken : IO String := do
   let some token ← IO.getEnv "MATHLIB_CACHE_SAS"
     | throw $ IO.userError "environment variable MATHLIB_CACHE_SAS must be set to upload caches"

--- a/Cache/Main.lean
+++ b/Cache/Main.lean
@@ -11,29 +11,41 @@ Usage: cache [COMMAND]
 
 Commands:
   # No priviledge required
-  get  [ARGS]*  Download linked files missing on the local cache and decompress
-  get! [ARGS]*  Download all linked files and decompress
-  mk            Compress non-compressed build files into the local cache
-  mk!           Compress build files into the local cache (no skipping)
-  unpack        Decompress linked already downloaded files
-  clean         Delete non-linked files
-  clean!        Delete everything on the local cache
+  get  [ARGS]  Download linked files missing on the local cache and decompress
+  get! [ARGS]  Download all linked files and decompress
+  mk           Compress non-compressed build files into the local cache
+  mk!          Compress build files into the local cache (no skipping)
+  unpack       Decompress linked already downloaded files
+  clean        Delete non-linked files
+  clean!       Delete everything on the local cache
 
   # Privilege required
-  put           Run 'mk' then upload linked files missing on the server
-  put!          Run 'mk' then upload all linked files
-  commit        Write a commit on the server
-  commit!       Overwrite a commit on the server
-  collect       TODO
+  put          Run 'mk' then upload linked files missing on the server
+  put!         Run 'mk' then upload all linked files
+  commit       Write a commit on the server
+  commit!      Overwrite a commit on the server
+  collect      TODO
 
 * Linked files refer to local cache files with corresponding Lean sources
-* Commands ending with '!' should be used manually, when hot-fixes are needed"
+* Commands ending with '!' should be used manually, when hot-fixes are needed
+
+# The arguments for 'get' and 'get!'
+
+'get' and 'get!' can process list of paths containing at most one wildcard each,
+Allowing the user to be more specific about what should be downloaded. Example:
+
+$ lake exe cache get Mathlib/Algebra/Field/* Mathlib/Data *Conjugate.lean
+
+Will download the cache for:
+* Everything that starts with 'Mathlib/Algebra/Field/'
+* Everything that starts with 'Mathlib/Data'
+* Everything that ends with 'Conjugate.lean'"
 
 open Cache IO Hashing Requests in
 def main (args : List String) : IO Unit := do
   if !(← validateCurl) then return
   let hashMemo ← getHashMemo
-  let hashMap := hashMemo.map
+  let hashMap := hashMemo.hashMap
   match args with
   | "get"  :: args => getFiles (← hashMemo.filterByPatterns args) false
   | "get!" :: args => getFiles (← hashMemo.filterByPatterns args) true

--- a/Cache/Main.lean
+++ b/Cache/Main.lean
@@ -50,8 +50,8 @@ def main (args : List String) : IO Unit := do
   match args with
   | ["get"] => getFiles hashMap false
   | ["get!"] => getFiles hashMap true
-  | "get"  :: args => getFiles (← hashMemo.filterByFileNames args) false
-  | "get!" :: args => getFiles (← hashMemo.filterByFileNames args) true
+  | "get"  :: args => getFiles (← hashMemo.filterByFilePaths (args.map .mk)) false
+  | "get!" :: args => getFiles (← hashMemo.filterByFilePaths (args.map .mk)) true
   | ["mk"] => discard $ mkCache hashMap false
   | ["mk!"] => discard $ mkCache hashMap true
   | ["unpack"] => unpackCache hashMap

--- a/Cache/Main.lean
+++ b/Cache/Main.lean
@@ -32,7 +32,7 @@ Commands:
 # The arguments for 'get' and 'get!'
 
 'get' and 'get!' can process list of paths containing at most one wildcard each,
-Allowing the user to be more specific about what should be downloaded. Example:
+allowing the user to be more specific about what should be downloaded. Example:
 
 $ lake exe cache get Mathlib/Algebra/Field/* Mathlib/Data *Conjugate.lean
 

--- a/Cache/Main.lean
+++ b/Cache/Main.lean
@@ -11,20 +11,20 @@ Usage: cache [COMMAND]
 
 Commands:
   # No priviledge required
-  get       Download linked files missing on the local cache and decompress
-  get!      Download all linked files and decompress
-  mk        Compress non-compressed build files into the local cache
-  mk!       Compress build files into the local cache (no skipping)
-  unpack    Decompress linked already downloaded files
-  clean     Delete non-linked files
-  clean!    Delete everything on the local cache
+  get  [ARGS]*  Download linked files missing on the local cache and decompress
+  get! [ARGS]*  Download all linked files and decompress
+  mk            Compress non-compressed build files into the local cache
+  mk!           Compress build files into the local cache (no skipping)
+  unpack        Decompress linked already downloaded files
+  clean         Delete non-linked files
+  clean!        Delete everything on the local cache
 
   # Privilege required
-  put       Run 'mk' then upload linked files missing on the server
-  put!      Run 'mk' then upload all linked files
-  commit    Write a commit on the server
-  commit!   (Over)write a commit on the server
-  collect   TODO
+  put           Run 'mk' then upload linked files missing on the server
+  put!          Run 'mk' then upload all linked files
+  commit        Write a commit on the server
+  commit!       Overwrite a commit on the server
+  collect       TODO
 
 * Linked files refer to local cache files with corresponding Lean sources
 * Commands ending with '!' should be used manually, when hot-fixes are needed"
@@ -35,8 +35,8 @@ def main (args : List String) : IO Unit := do
   let hashMemo ← getHashMemo
   let hashMap := hashMemo.map
   match args with
-  | ["get"] => getFiles hashMap false
-  | ["get!"] => getFiles hashMap true
+  | "get"  :: args => getFiles (← hashMemo.filterByPatterns args) false
+  | "get!" :: args => getFiles (← hashMemo.filterByPatterns args) true
   | ["mk"] => discard $ mkCache hashMap false
   | ["mk!"] => discard $ mkCache hashMap true
   | ["unpack"] => unpackCache hashMap

--- a/Cache/Main.lean
+++ b/Cache/Main.lean
@@ -50,8 +50,8 @@ def main (args : List String) : IO Unit := do
   match args with
   | ["get"] => getFiles hashMap false
   | ["get!"] => getFiles hashMap true
-  | "get"  :: args => getFiles (← hashMemo.filterByPatterns args) false
-  | "get!" :: args => getFiles (← hashMemo.filterByPatterns args) true
+  | "get"  :: args => getFiles (← hashMemo.filterByFileNames args) false
+  | "get!" :: args => getFiles (← hashMemo.filterByFileNames args) true
   | ["mk"] => discard $ mkCache hashMap false
   | ["mk!"] => discard $ mkCache hashMap true
   | ["unpack"] => unpackCache hashMap

--- a/Cache/Main.lean
+++ b/Cache/Main.lean
@@ -31,15 +31,16 @@ Commands:
 
 # The arguments for 'get' and 'get!'
 
-'get' and 'get!' can process list of paths containing at most one wildcard each,
-allowing the user to be more specific about what should be downloaded. Example:
+'get' and 'get!' can process list of paths, allowing the user to be more
+specific about what should be downloaded. For example, with automatic glob
+expansion in shell, one can call:
 
-$ lake exe cache get Mathlib/Algebra/Field/* Mathlib/Data *Conjugate.lean
+$ lake exe cache get Mathlib/Algebra/Field/* Mathlib/Data/*
 
-Will download the cache for:
+Which will download the cache for:
 * Everything that starts with 'Mathlib/Algebra/Field/'
-* Everything that starts with 'Mathlib/Data'
-* Everything that ends with 'Conjugate.lean'"
+* Everything that starts with 'Mathlib/Data/'
+* Everything that's needed for the above"
 
 open Cache IO Hashing Requests in
 def main (args : List String) : IO Unit := do

--- a/Cache/Main.lean
+++ b/Cache/Main.lean
@@ -32,7 +32,8 @@ Commands:
 open Cache IO Hashing Requests in
 def main (args : List String) : IO Unit := do
   if !(← validateCurl) then return
-  let hashMap  ← getHashes
+  let hashMemo ← getHashMemo
+  let hashMap := hashMemo.map
   match args with
   | ["get"] => getFiles hashMap false
   | ["get!"] => getFiles hashMap true
@@ -45,10 +46,10 @@ def main (args : List String) : IO Unit := do
   | ["put"] => putFiles (← mkCache hashMap false) false (← getToken)
   | ["put!"] => putFiles (← mkCache hashMap false) true (← getToken)
   | ["commit"] =>
-    if !(← isStatusClean) then IO.println "Please commit your changes first" return else
+    if !(← isGitStatusClean) then IO.println "Please commit your changes first" return else
     commit hashMap false (← getToken)
   | ["commit!"] =>
-    if !(← isStatusClean) then IO.println "Please commit your changes first" return else
+    if !(← isGitStatusClean) then IO.println "Please commit your changes first" return else
     commit hashMap true (← getToken)
   | ["collect"] => IO.println "TODO"
   | _ => println help

--- a/Cache/Main.lean
+++ b/Cache/Main.lean
@@ -47,6 +47,8 @@ def main (args : List String) : IO Unit := do
   let hashMemo ← getHashMemo
   let hashMap := hashMemo.hashMap
   match args with
+  | ["get"] => getFiles hashMap false
+  | ["get!"] => getFiles hashMap true
   | "get"  :: args => getFiles (← hashMemo.filterByPatterns args) false
   | "get!" :: args => getFiles (← hashMemo.filterByPatterns args) true
   | ["mk"] => discard $ mkCache hashMap false

--- a/Cache/Requests.lean
+++ b/Cache/Requests.lean
@@ -41,31 +41,18 @@ def mkGetConfigContent (hashMap : IO.HashMap) : IO String := do
     pure $ (s!"url = {← mkFileURL fileName none}\n-o {IO.CACHEDIR / fileName}") :: acc
   return "\n".intercalate l
 
-/--
-Calls `curl` to download files from the server.
-
-It downloads the files to CACHEDIR (.cache).
--/
-def downloadFiles (hashMap : IO.HashMap) : IO Unit := do
+/-- Calls `curl` to download files from the server to `CACHEDIR` (`.cache`) then unpacks them -/
+def getFiles (hashMap : IO.HashMap) (forceDownload : Bool) : IO Unit := do
+  let hashMap := if forceDownload then hashMap else hashMap.filter (← IO.getLocalCacheSet) false
   let size := hashMap.size
   if size > 0 then
     IO.mkDir IO.CACHEDIR
     IO.println s!"Attempting to download {size} file(s)"
     IO.FS.writeFile IO.CURLCFG (← mkGetConfigContent hashMap)
     discard $ IO.runCmd "curl"
-        #["-X", "GET", "--parallel", "-f", "-s", "-K", IO.CURLCFG.toString] false
+      #["-X", "GET", "--parallel", "-f", "-s", "-K", IO.CURLCFG.toString] false
     IO.FS.removeFile IO.CURLCFG
   else IO.println "No files to download"
-
-/--
-Downloads files from the server and unpacks them.
--/
-def getFiles (hashMap : IO.HashMap) (forceDownload : Bool) : IO Unit := do
-  downloadFiles
-    (← if forceDownload then
-      pure hashMap
-    else
-      pure (hashMap.filter (← IO.getLocalCacheSet) false))
   IO.unpackCache hashMap
 
 end Get
@@ -97,10 +84,10 @@ end Put
 
 section Commit
 
-def isStatusClean : IO Bool :=
+def isGitStatusClean : IO Bool :=
   return (← IO.runCmd "git" #["status", "--porcelain"]).isEmpty
 
-def getCommitHash : IO String := do
+def getGitCommitHash : IO String := do
   let ret := (← IO.runCmd "git" #["log", "-1"]).replace "\n" " "
   match ret.splitOn " " with
   | "commit" :: hash :: _ => return hash
@@ -112,7 +99,7 @@ Sends a commit file to the server, containing the hashes of the respective commi
 The file name is the current Git hash and the `c/` prefix means that it's a commit file.
 -/
 def commit (hashMap : IO.HashMap) (overwrite : Bool) (token : String) : IO Unit := do
-  let hash ← getCommitHash
+  let hash ← getGitCommitHash
   let path := IO.CACHEDIR / hash
   IO.mkDir IO.CACHEDIR
   IO.FS.writeFile path $ ("\n".intercalate $ hashMap.hashes.toList.map toString) ++ "\n"

--- a/Cache/Requests.lean
+++ b/Cache/Requests.lean
@@ -6,14 +6,6 @@ Authors: Arthur Paulino
 
 import Cache.Hashing
 
-def ByteArray.startsWith (a b : ByteArray) : Bool := Id.run do
-  let size := b.size
-  let a := a.copySlice 0 .empty 0 size
-  if size != a.size then return false
-  for i in [0 : size] do
-    if a.get! i != b.get! i then return false
-  return true
-
 namespace Cache.Requests
 
 /-- Azure blob URL -/


### PR DESCRIPTION
This PR allows arguments for `cache get` and `cache get!` as explained in the help menu:

```text
'get' and 'get!' can process list of paths, allowing the user to be more
specific about what should be downloaded. For example, with automatic glob
expansion in shell, one can call:

$ lake exe cache get Mathlib/Algebra/Field/* Mathlib/Data/*

Which will download the cache for:
* Everything that starts with 'Mathlib/Algebra/Field/'
* Everything that starts with 'Mathlib/Data/'
* Everything that's needed for the above
```