### PR TITLE
[Merged by Bors] - feat: `Rat`-dependent `norm_num` functionality

### DIFF
--- a/Mathlib/Algebra/Invertible.lean
+++ b/Mathlib/Algebra/Invertible.lean
@@ -202,6 +202,9 @@ def invertibleOne [Monoid α] : Invertible (1 : α) :=
 #align invertible_one invertibleOne
 
 @[simp]
+theorem invOf_one' [Monoid α] {_ : Invertible (1 : α)} : ⅟ (1 : α) = 1 :=
+  invOf_eq_right_inv (mul_one _)
+
 theorem invOf_one [Monoid α] [Invertible (1 : α)] : ⅟ (1 : α) = 1 :=
   invOf_eq_right_inv (mul_one _)
 #align inv_of_one invOf_one

--- a/Mathlib/Algebra/Invertible.lean
+++ b/Mathlib/Algebra/Invertible.lean
@@ -137,6 +137,11 @@ def Invertible.copy [MulOneClass α] {r : α} (hr : Invertible r) (s : α) (hs :
   mul_invOf_self := by rw [hs, mul_invOf_self]
 #align invertible.copy Invertible.copy
 
+/-- If `a` is invertible and `a = b`, then `⅟a = ⅟b`. -/
+@[congr]
+theorem Invertible.cong [Ring α] (a b : α) [Invertible a] (h : a = b) :
+  ⅟a = @Invertible.invOf _ _ _ b (Invertible.copy ‹_› _ h.symm) := by subst h; rfl
+
 /-- An `invertible` element is a unit. -/
 @[simps]
 def unitOfInvertible [Monoid α] (a : α) [Invertible a] :

--- a/Mathlib/Algebra/Order/Floor.lean
+++ b/Mathlib/Algebra/Order/Floor.lean
@@ -1443,8 +1443,12 @@ theorem round_eq (x : α) : round x = ⌊x + 1 / 2⌋ := by
       . -- Porting note: `add_halves` can be removed, and `norm_num at *` can lose the *, after
         -- linarith learns about fractions
         have := add_halves (1:α)
+        -- norm_num at *
+        -- linarith
+        -- Porting note: linarith broke here after the move to ℚ in norm_num.
+        have := add_le_add_right hx (1/2)
         norm_num at *
-        linarith
+        assumption
       · -- Porting note: `norm_num at *` can lose the *, after linarith learns about fractions
         norm_num at *
         linarith [fract_lt_one x]

--- a/Mathlib/Algebra/Order/Floor.lean
+++ b/Mathlib/Algebra/Order/Floor.lean
@@ -1440,10 +1440,7 @@ theorem round_eq (x : α) : round x = ⌊x + 1 / 2⌋ := by
   · have : ⌊fract x + 1 / 2⌋ = 1 := by
       rw [floor_eq_iff]
       constructor
-      . -- Porting note: `add_halves` can be removed, and `norm_num at *` can lose the *, after
-        -- linarith learns about fractions
-        have := add_halves (1:α)
-        -- norm_num at *
+      . -- norm_num at *
         -- linarith
         -- Porting note: linarith broke here after the move to ℚ in norm_num.
         have := add_le_add_right hx (1/2)

--- a/Mathlib/Tactic/NormNum/Basic.lean
+++ b/Mathlib/Tactic/NormNum/Basic.lean
@@ -93,7 +93,7 @@ theorem isInt_add {α} [Ring α] : {a b : α} → {a' b' c : ℤ} →
     IsInt a a' → IsInt b b' → Int.add a' b' = c → IsInt (a + b) c
   | _, _, _, _, _, ⟨rfl⟩, ⟨rfl⟩, rfl => ⟨(Int.cast_add ..).symm⟩
 
-theorem isRat_add {α} [Ring α] : {a b : α} → {an bn cn : ℤ} → {ad bd cd g : ℕ} →
+def isRat_add {α} [Ring α] : {a b : α} → {an bn cn : ℤ} → {ad bd cd g : ℕ} →
     IsRat a an ad → IsRat b bn bd →
     Int.add (Int.mul an bd) (Int.mul bn ad) = Int.mul (Nat.succ g) cn →
     Nat.mul ad bd = Nat.mul (Nat.succ g) cd →
@@ -153,7 +153,7 @@ theorem isInt_neg {α} [Ring α] : {a : α} → {a' b : ℤ} →
     IsInt a a' → Int.neg a' = b → IsInt (-a) b
   | _, _, _, ⟨rfl⟩, rfl => ⟨(Int.cast_neg ..).symm⟩
 
-theorem isRat_neg {α} [Ring α] : {a : α} → {n n' : ℤ} → {d : ℕ} →
+def isRat_neg {α} [Ring α] : {a : α} → {n n' : ℤ} → {d : ℕ} →
     IsRat a n d → Int.neg n = n' → IsRat (-a) n' d
   | _, _, _, _, ⟨_, rfl⟩, rfl => sorry
 
@@ -190,7 +190,7 @@ theorem isInt_sub {α} [Ring α] : {a b : α} → {a' b' c : ℤ} →
     IsInt a a' → IsInt b b' → Int.sub a' b' = c → IsInt (a - b) c
   | _, _, _, _, _, ⟨rfl⟩, ⟨rfl⟩, rfl => ⟨(Int.cast_sub ..).symm⟩
 
-theorem isRat_sub {α} [Ring α] : {a b : α} → {an bn cn : ℤ} → {ad bd cd g : ℕ} →
+def isRat_sub {α} [Ring α] : {a b : α} → {an bn cn : ℤ} → {ad bd cd g : ℕ} →
     IsRat a an ad → IsRat b bn bd →
     Int.sub (Int.mul an bd) (Int.mul bn ad) = Int.mul (Nat.succ g) cn →
     Nat.mul ad bd = Nat.mul (Nat.succ g) cd →
@@ -244,7 +244,7 @@ theorem isInt_mul {α} [Ring α] : {a b : α} → {a' b' c : ℤ} →
     IsInt a a' → IsInt b b' → Int.mul a' b' = c → IsInt (a * b) c
   | _, _, _, _, _, ⟨rfl⟩, ⟨rfl⟩, rfl => ⟨(Int.cast_mul ..).symm⟩
 
-theorem isRat_mul {α} [Ring α] : {a b : α} → {an bn cn : ℤ} → {ad bd cd g : ℕ} →
+def isRat_mul {α} [Ring α] : {a b : α} → {an bn cn : ℤ} → {ad bd cd g : ℕ} →
     IsRat a an ad → IsRat b bn bd →
     Int.mul an bn = Int.mul (Nat.succ g) cn →
     Nat.mul ad bd = Nat.mul (Nat.succ g) cd →
@@ -301,6 +301,7 @@ theorem isInt_pow {α} [Ring α] : {a : α} → {b : ℕ} → {a' : ℤ} → {b'
     IsInt a a' → IsNat b b' → Int.pow a' b' = c → IsInt (a ^ b) c
   | _, _, _, _, _, ⟨rfl⟩, ⟨rfl⟩, rfl => ⟨by simp⟩
 
+@[nolint defLemma] -- FIXME: figure out how to get the linter to work with these
 theorem isRat_pow {α} [Ring α] : {a : α} → {an cn : ℤ} → {ad b b' cd : ℕ} →
     IsRat a an ad → IsNat b b' →
     Int.pow an b' = cn → Nat.pow ad b' = cd →
@@ -341,7 +342,7 @@ def evalPow : NormNumExt where eval {u α} e := do
       return (.isRat dα qc nc dc (q(isRat_pow $pa $pb $r1 $r2) : Expr) : Result q($a ^ $b))
   core
 
-theorem isRat_inv_pos {α} [DivisionRing α] : {a : α} → {n d : ℕ} →
+def isRat_inv_pos {α} [DivisionRing α] : {a : α} → {n d : ℕ} →
     Nat.ble (nat_lit 1) n = true → IsRat a (.ofNat n) d → IsRat a⁻¹ (.ofNat d) n
   | _, _, _, _, ⟨_, rfl⟩ => sorry
 
@@ -349,7 +350,7 @@ theorem isRat_inv_zero {α} [DivisionRing α] : {a : α} →
     IsNat a (nat_lit 0) → IsNat a⁻¹ (nat_lit 0)
   | _, ⟨rfl⟩ => ⟨by simp⟩
 
-theorem isRat_inv_neg {α} [DivisionRing α] : {a : α} → {n d : ℕ} →
+def isRat_inv_neg {α} [DivisionRing α] : {a : α} → {n d : ℕ} →
     Nat.ble 1 n = true → IsRat a (.negOfNat n) d → IsRat a⁻¹ (.negOfNat d) n
   | _, _, _, _, ⟨_, rfl⟩ => sorry
 
@@ -379,7 +380,7 @@ such that `norm_num` successfully recognises `a`. -/
       | failure
     return (.isNat inst _z (q(isRat_inv_zero $pa) : Expr) : Result q($a⁻¹))
 
-theorem isRat_div {α} [DivisionRing α] : {a b : α} → {cn : ℤ} → {cd : ℕ} → IsRat (a * b⁻¹) cn cd →
+def isRat_div {α} [DivisionRing α] : {a b : α} → {cn : ℤ} → {cd : ℕ} → IsRat (a * b⁻¹) cn cd →
     IsRat (a / b) cn cd
   | _, _, _, _, h => by simp [div_eq_mul_inv]; exact h
 
@@ -393,6 +394,3 @@ such that `norm_num` successfully recognises both `a` and `b`. -/
   let ⟨qa, na, da, pa⟩ := rab.toRat'
   let pa : Q(IsRat ($a * $b⁻¹) $na $da) := pa
   return (.isRat' dα qa na da q(isRat_div $pa) : Result q($a / $b))
-
-attribute [nolint defLemma] isRat_add isRat_neg isRat_sub isRat_mul isRat_pow isRat_inv_pos
-  isRat_inv_neg isRat_div -- FIXME: figure out how to get the linter to work with these

--- a/Mathlib/Tactic/NormNum/Basic.lean
+++ b/Mathlib/Tactic/NormNum/Basic.lean
@@ -93,7 +93,7 @@ theorem isInt_add {α} [Ring α] : {a b : α} → {a' b' c : ℤ} →
     IsInt a a' → IsInt b b' → Int.add a' b' = c → IsInt (a + b) c
   | _, _, _, _, _, ⟨rfl⟩, ⟨rfl⟩, rfl => ⟨(Int.cast_add ..).symm⟩
 
-def isRat_add {α} [Ring α] : {a b : α} → {an bn cn : ℤ} → {ad bd cd g : ℕ} →
+theorem isRat_add {α} [Ring α] : {a b : α} → {an bn cn : ℤ} → {ad bd cd g : ℕ} →
     IsRat a an ad → IsRat b bn bd →
     Int.add (Int.mul an bd) (Int.mul bn ad) = Int.mul (Nat.succ g) cn →
     Nat.mul ad bd = Nat.mul (Nat.succ g) cd →
@@ -153,7 +153,7 @@ theorem isInt_neg {α} [Ring α] : {a : α} → {a' b : ℤ} →
     IsInt a a' → Int.neg a' = b → IsInt (-a) b
   | _, _, _, ⟨rfl⟩, rfl => ⟨(Int.cast_neg ..).symm⟩
 
-def isRat_neg {α} [Ring α] : {a : α} → {n n' : ℤ} → {d : ℕ} →
+theorem isRat_neg {α} [Ring α] : {a : α} → {n n' : ℤ} → {d : ℕ} →
     IsRat a n d → Int.neg n = n' → IsRat (-a) n' d
   | _, _, _, _, ⟨_, rfl⟩, rfl => sorry
 
@@ -190,7 +190,7 @@ theorem isInt_sub {α} [Ring α] : {a b : α} → {a' b' c : ℤ} →
     IsInt a a' → IsInt b b' → Int.sub a' b' = c → IsInt (a - b) c
   | _, _, _, _, _, ⟨rfl⟩, ⟨rfl⟩, rfl => ⟨(Int.cast_sub ..).symm⟩
 
-def isRat_sub {α} [Ring α] : {a b : α} → {an bn cn : ℤ} → {ad bd cd g : ℕ} →
+theorem isRat_sub {α} [Ring α] : {a b : α} → {an bn cn : ℤ} → {ad bd cd g : ℕ} →
     IsRat a an ad → IsRat b bn bd →
     Int.sub (Int.mul an bd) (Int.mul bn ad) = Int.mul (Nat.succ g) cn →
     Nat.mul ad bd = Nat.mul (Nat.succ g) cd →
@@ -244,7 +244,7 @@ theorem isInt_mul {α} [Ring α] : {a b : α} → {a' b' c : ℤ} →
     IsInt a a' → IsInt b b' → Int.mul a' b' = c → IsInt (a * b) c
   | _, _, _, _, _, ⟨rfl⟩, ⟨rfl⟩, rfl => ⟨(Int.cast_mul ..).symm⟩
 
-def isRat_mul {α} [Ring α] : {a b : α} → {an bn cn : ℤ} → {ad bd cd g : ℕ} →
+theorem isRat_mul {α} [Ring α] : {a b : α} → {an bn cn : ℤ} → {ad bd cd g : ℕ} →
     IsRat a an ad → IsRat b bn bd →
     Int.mul an bn = Int.mul (Nat.succ g) cn →
     Nat.mul ad bd = Nat.mul (Nat.succ g) cd →
@@ -301,7 +301,6 @@ theorem isInt_pow {α} [Ring α] : {a : α} → {b : ℕ} → {a' : ℤ} → {b'
     IsInt a a' → IsNat b b' → Int.pow a' b' = c → IsInt (a ^ b) c
   | _, _, _, _, _, ⟨rfl⟩, ⟨rfl⟩, rfl => ⟨by simp⟩
 
-@[nolint defLemma] -- FIXME: figure out how to get the linter to work with these
 theorem isRat_pow {α} [Ring α] : {a : α} → {an cn : ℤ} → {ad b b' cd : ℕ} →
     IsRat a an ad → IsNat b b' →
     Int.pow an b' = cn → Nat.pow ad b' = cd →
@@ -342,7 +341,7 @@ def evalPow : NormNumExt where eval {u α} e := do
       return (.isRat dα qc nc dc (q(isRat_pow $pa $pb $r1 $r2) : Expr) : Result q($a ^ $b))
   core
 
-def isRat_inv_pos {α} [DivisionRing α] : {a : α} → {n d : ℕ} →
+theorem isRat_inv_pos {α} [DivisionRing α] : {a : α} → {n d : ℕ} →
     Nat.ble (nat_lit 1) n = true → IsRat a (.ofNat n) d → IsRat a⁻¹ (.ofNat d) n
   | _, _, _, _, ⟨_, rfl⟩ => sorry
 
@@ -350,7 +349,7 @@ theorem isRat_inv_zero {α} [DivisionRing α] : {a : α} →
     IsNat a (nat_lit 0) → IsNat a⁻¹ (nat_lit 0)
   | _, ⟨rfl⟩ => ⟨by simp⟩
 
-def isRat_inv_neg {α} [DivisionRing α] : {a : α} → {n d : ℕ} →
+theorem isRat_inv_neg {α} [DivisionRing α] : {a : α} → {n d : ℕ} →
     Nat.ble 1 n = true → IsRat a (.negOfNat n) d → IsRat a⁻¹ (.negOfNat d) n
   | _, _, _, _, ⟨_, rfl⟩ => sorry
 
@@ -380,7 +379,7 @@ such that `norm_num` successfully recognises `a`. -/
       | failure
     return (.isNat inst _z (q(isRat_inv_zero $pa) : Expr) : Result q($a⁻¹))
 
-def isRat_div {α} [DivisionRing α] : {a b : α} → {cn : ℤ} → {cd : ℕ} → IsRat (a * b⁻¹) cn cd →
+theorem isRat_div {α} [DivisionRing α] : {a b : α} → {cn : ℤ} → {cd : ℕ} → IsRat (a * b⁻¹) cn cd →
     IsRat (a / b) cn cd
   | _, _, _, _, h => by simp [div_eq_mul_inv]; exact h
 

--- a/Mathlib/Tactic/NormNum/Basic.lean
+++ b/Mathlib/Tactic/NormNum/Basic.lean
@@ -353,7 +353,7 @@ theorem isRat_inv_neg {α} [DivisionRing α] : {a : α} → {n d : ℕ} →
     Nat.ble 1 n = true → IsRat a (.negOfNat n) d → IsRat a⁻¹ (.negOfNat d) n
   | _, _, _, _, ⟨_, rfl⟩ => sorry
 
-/-- The `norm_num` extension which identifies expressions of the form `-a`,
+/-- The `norm_num` extension which identifies expressions of the form `a⁻¹`,
 such that `norm_num` successfully recognises `a`. -/
 @[norm_num _⁻¹] def evalInv : NormNumExt where eval {u α} e := do
   let .app f (a : Q($α)) ← withReducible (whnf e) | failure
@@ -383,7 +383,7 @@ theorem isRat_div {α} [DivisionRing α] : {a b : α} → {cn : ℤ} → {cd : �
     IsRat (a / b) cn cd
   | _, _, _, _, h => by simp [div_eq_mul_inv]; exact h
 
-/-- The `norm_num` extension which identifies expressions of the form `a * b`,
+/-- The `norm_num` extension which identifies expressions of the form `a / b`,
 such that `norm_num` successfully recognises both `a` and `b`. -/
 @[norm_num _ / _, Div.div _ _] def evalDiv : NormNumExt where eval {u α} e := do
   let .app (.app f (a : Q($α))) (b : Q($α)) ← withReducible (whnf e) | failure

--- a/Mathlib/Tactic/NormNum/Basic.lean
+++ b/Mathlib/Tactic/NormNum/Basic.lean
@@ -393,3 +393,6 @@ such that `norm_num` successfully recognises both `a` and `b`. -/
   let ⟨qa, na, da, pa⟩ := rab.toRat'
   let pa : Q(IsRat ($a * $b⁻¹) $na $da) := pa
   return (.isRat' dα qa na da q(isRat_div $pa) : Result q($a / $b))
+
+attribute [nolint defLemma] isRat_add isRat_neg isRat_sub isRat_mul isRat_pow isRat_inv_pos
+  isRat_inv_neg isRat_div -- FIXME: figure out how to get the linter to work with these

--- a/Mathlib/Tactic/NormNum/Core.lean
+++ b/Mathlib/Tactic/NormNum/Core.lean
@@ -277,14 +277,26 @@ instance : ToMessageData (Result x) where
   | .isRat _ q _ _ proof => m!"isRat {q} ({proof})"
 
 /--
-Given a `NormNum.Result e` (which uses `IsNat`, `IsInt`, `IsRat` to express equality to an integer
-numeral), converts it to an equality `e = Nat.rawCast n` or `e = Int.rawCast n` to a raw cast
-expression, so it can be used for rewriting.
+Given a `NormNum.Result e` (which uses `IsNat`, `IsInt`, `IsRat` to express equality to a rational
+numeral), converts it to an equality `e = Nat.rawCast n`, `e = Int.rawCast n`, or
+`e = Rat.rawcast n d` to a raw cast expression, so it can be used for rewriting.
 -/
 def Result.toRawEq {α : Q(Type u)} {e : Q($α)} : Result e → (ℚ × (e' : Q($α)) × Q($e = $e'))
   | .isNat _ lit p => ⟨lit.natLit!, q(Nat.rawCast $lit), q(IsNat.to_raw_eq $p)⟩
   | .isNegNat _ lit p => ⟨-lit.natLit!, q(Int.rawCast (.negOfNat $lit)), q(IsInt.to_raw_eq $p)⟩
   | .isRat _ q n d p => ⟨q, q(Rat.rawCast $n $d), q(IsRat.to_raw_eq $p)⟩
+
+/--
+Given a `NormNum.Result e` for something known to be an integer (which uses `IsNat` or `IsInt` to
+express equality to an integer numeral), converts it to an equality `e = Nat.rawCast n` or
+`e = Int.rawCast n` to a raw cast expression, so it can be used for rewriting. Gives `none` if not
+an integer.
+-/
+def Result.toRawIntEq {α : Q(Type u)} {e : Q($α)} : Result e →
+    Option (ℤ × (e' : Q($α)) × Q($e = $e'))
+  | .isNat _ lit p => some ⟨lit.natLit!, q(Nat.rawCast $lit), q(IsNat.to_raw_eq $p)⟩
+  | .isNegNat _ lit p => some ⟨-lit.natLit!, q(Int.rawCast (.negOfNat $lit)), q(IsInt.to_raw_eq $p)⟩
+  | .isRat _ .. => none
 
 /-- Constructs a `Result` out of a raw nat cast. Assumes `e` is a raw nat cast expression. -/
 def Result.ofRawNat {α : Q(Type u)} (e : Q($α)) : Result e := Id.run do

--- a/Mathlib/Tactic/NormNum/Core.lean
+++ b/Mathlib/Tactic/NormNum/Core.lean
@@ -151,6 +151,7 @@ theorem IsRat.nonneg_to_eq {α} [DivisionRing α] {n d} :
     {a n' d' : α} → IsRat a (.ofNat n) d → n = n' → d = d' → a = n' / d'
   | _, _, _, ⟨_, rfl⟩, rfl, rfl => sorry
 
+attribute [nolint defLemma] IsNat.to_isRat IsInt.to_isRat IsRat.of_raw
 end
 
 /-- Represent an integer as a typed expression. -/

--- a/Mathlib/Tactic/NormNum/Core.lean
+++ b/Mathlib/Tactic/NormNum/Core.lean
@@ -105,11 +105,8 @@ Assert that an element of a ring is equal to `num / denom`
 We will usually also have `num` and `denom` coprime,
 although this is not part of the definition.
 -/
-structure IsRat [Ring α] (a : α) (num : ℤ) (denom : ℕ) where
-  /-- The denominator is invertible. -/
-  inv : Invertible (denom : α)
-  /-- The element is equal to the fraction with the specified numerator and denominator. -/
-  eq : a = num * ⅟(denom : α)
+inductive IsRat [Ring α] (a : α) (num : ℤ) (denom : ℕ) : Prop
+  | mk (inv : Invertible (denom : α)) (eq : a = num * ⅟(denom : α))
 
 /--
 A "raw rat cast" is an expression of the form:
@@ -151,8 +148,6 @@ theorem IsRat.nonneg_to_eq {α} [DivisionRing α] {n d} :
     {a n' d' : α} → IsRat a (.ofNat n) d → n = n' → d = d' → a = n' / d'
   | _, _, _, ⟨_, rfl⟩, rfl, rfl => sorry
 
-attribute [nolint defLemma] IsNat.to_isRat IsInt.to_isRat IsRat.of_raw
--- FIXME: get the linter to work here
 end
 
 /-- Represent an integer as a typed expression. -/

--- a/Mathlib/Tactic/NormNum/Core.lean
+++ b/Mathlib/Tactic/NormNum/Core.lean
@@ -265,7 +265,7 @@ def Result.toRat' {α : Q(Type u)} {e : Q($α)}
     have proof : Q(@IsNat _ instAddMonoidWithOne $e $lit) := proof
     ⟨lit.natLit!, q(.ofNat $lit), q(nat_lit 1), q(($proof).to_isRat)⟩
   | .isNegNat _ lit proof =>
-    have proof : Q(@IsInt _ DivisionRing.toRing $e $lit) := proof
+    have proof : Q(@IsInt _ DivisionRing.toRing $e (.negOfNat $lit)) := proof
     ⟨-lit.natLit!, q(.negOfNat $lit), q(nat_lit 1),
       (q(@IsInt.to_isRat _ DivisionRing.toRing _ _ $proof) : Expr)⟩
   | .isRat _ q n d proof => ⟨q, n, d, proof⟩

--- a/Mathlib/Tactic/NormNum/Core.lean
+++ b/Mathlib/Tactic/NormNum/Core.lean
@@ -5,6 +5,7 @@ Authors: Mario Carneiro
 -/
 import Std.Lean.Parser
 import Mathlib.Algebra.Invertible
+import Mathlib.Data.Rat.Cast
 import Mathlib.Data.Nat.Basic
 import Mathlib.Data.Int.Basic
 import Mathlib.Tactic.Conv
@@ -97,60 +98,64 @@ def instAddMonoidWithOneNat : AddMonoidWithOne ℕ := inferInstance
 
 /-- A shortcut (non)instance for `Ring ℤ` to shrink generated proofs. -/
 def instRingInt : Ring ℤ := inferInstance
-
+set_option pp.all true
 /--
 Assert that an element of a ring is equal to `num / denom`
 (and `denom` is invertible so that this makes sense).
 We will usually also have `num` and `denom` coprime,
 although this is not part of the definition.
 -/
-structure IsRat [Ring α] (a : α) (num : ℤ) (denom : ℕ) where
-  /-- The denominator is invertible. -/
-  inv : Invertible denom
-  /-- The element is equal to the fraction with the specified numerator and denominator. -/
-  eq : a = num * ⅟denom
+structure IsRat [DivisionRing α] (a : α) (q : ℚ) where
+  /-- The element is equal to the coercion of therational number. -/
+  out : a = q
 
 --!!/ Translate appropriate parts to `Rat`
 /--
-A "raw int cast" is an expression of the form:
+A "raw rat cast" is an expression of the form:
 
 * `(Nat.rawCast lit : α)` where `lit` is a raw natural number literal
 * `(Int.rawCast (Int.negOfNat lit) : α)` where `lit` is a nonzero raw natural number literal
+* `(Rat.rawCast (la / lb) : α)` where `la` and `lb` are raw natural number literals and `lb ≠ 1`.
 
-(That is, we only actually use this function for negative integers.) This representation is used by
+(That is, we only actually use this function for nonintegral rats.) This representation is used by
 tactics like `ring` to decrease the number of typeclass arguments required in each use of a number
 literal at type `α`.
 -/
-@[simp] def _root_.Int.rawCast [Ring α] (n : ℤ) : α := n
+@[simp] def _root_.Rat.rawCast [DivisionRing α] (q : ℚ) : α := q
 
-theorem IsInt.to_isNat {α} [Ring α] : ∀ {a : α} {n}, IsInt a (.ofNat n) → IsNat a n
+theorem IsRat.to_isNat {α} [DivisionRing α] : ∀ {a : α} {n : ℕ}, IsRat a n → IsNat a n
   | _, _, ⟨rfl⟩ => ⟨by simp⟩
 
-theorem IsNat.to_isInt {α} [Ring α] : ∀ {a : α} {n}, IsNat a n → IsInt a (.ofNat n)
+theorem IsRat.to_isInt {α} [DivisionRing α] : ∀ {a : α} {n : ℤ}, IsRat a n → IsInt a n
   | _, _, ⟨rfl⟩ => ⟨by simp⟩
 
-theorem IsInt.to_raw_eq [Ring α] : IsInt (a : α) n → a = n.rawCast
-  | ⟨e⟩ => e
+theorem IsNat.to_isRat {α} [DivisionRing α] : ∀ {a : α} {n : ℕ}, IsNat a n → IsRat a n
+  | _, _, ⟨rfl⟩ => ⟨by simp⟩
 
-theorem IsInt.of_raw (α) [Ring α] (n : ℤ) : IsInt (n.rawCast : α) n := ⟨rfl⟩
+theorem IsInt.to_isRat {α} [DivisionRing α] : ∀ {a : α} {n : ℤ}, IsInt a n → IsRat a n
+  | _, _, ⟨rfl⟩ => ⟨by simp⟩
 
-theorem IsInt.neg_to_eq {α} [Ring α] {n} :
-    {a a' : α} → IsInt a (.negOfNat n) → n = a' → a = -a'
-  | _, _, ⟨rfl⟩, rfl => by simp [Int.negOfNat_eq, Int.cast_neg]
+theorem IsRat.to_raw_eq [DivisionRing α] : (IsRat (a : α) q) → a = q.rawCast
+| ⟨e⟩ => e
 
-theorem IsInt.nonneg_to_eq {α} [Ring α] {n}
-    {a a' : α} (h : IsInt a (.ofNat n)) (e : n = a') : a = a' := h.to_isNat.to_eq e
+theorem IsRat.of_raw (α) [DivisionRing α] (q : ℚ) : IsRat (q.rawCast : α) q := ⟨rfl⟩
 
-/-- Represent an integer as a typed expression. -/
-def mkRawIntLit (n : ℤ) : Q(ℤ) :=
-  let lit : Q(ℕ) := mkRawNatLit n.natAbs
-  if 0 ≤ n then q(.ofNat $lit) else q(.negOfNat $lit)
+--!! no parallels?
+-- theorem IsInt.neg_to_eq {α} [DivisionRing α] {q} :
+--     {a a' : α} → IsInt a (.negOfNat n) → n = a' → a = -a'
+--   | _, _, ⟨rfl⟩, rfl => by simp [Int.negOfNat_eq, Int.cast_neg]
 
-/-- A shortcut (non)instance for `AddMonoidWithOne ℕ` to shrink generated proofs. -/
-def instAddMonoidWithOneNat : AddMonoidWithOne ℕ := inferInstance
+-- theorem IsInt.nonneg_to_eq {α} [Ring α] {n}
+--     {a a' : α} (h : IsInt a (.ofNat n)) (e : n = a') : a = a' := h.to_isNat.to_eq e
 
-/-- A shortcut (non)instance for `Ring ℤ` to shrink generated proofs. -/
-def instRingInt : Ring ℤ := inferInstance
+/-- Represent a rational as a typed expression. -/
+def mkRawRatLit (q : ℚ) : Q(ℚ) :=
+  let n : Q(ℤ) := mkRawIntLit q.num
+  let d : Q(ℕ) := mkRawNatLit q.den
+  q($n / $d)
+
+/-- A shortcut (non)instance for `DivisionRing ℚ` to shrink generated proofs. -/
+def instDivisionRingRat : DivisionRing ℚ := inferInstance
 --!!\
 
 /-- The result of `norm_num` running on an expression `x` of type `α`.

--- a/Mathlib/Tactic/NormNum/Core.lean
+++ b/Mathlib/Tactic/NormNum/Core.lean
@@ -136,7 +136,7 @@ theorem IsInt.to_isRat {α} [DivisionRing α] : ∀ {a : α} {n : ℤ}, IsInt a 
   | _, _, ⟨rfl⟩ => ⟨by simp⟩
 
 theorem IsRat.to_raw_eq [DivisionRing α] : (IsRat (a : α) q) → a = q.rawCast
-| ⟨e⟩ => e
+  | ⟨e⟩ => e
 
 theorem IsRat.of_raw (α) [DivisionRing α] (q : ℚ) : IsRat (q.rawCast : α) q := ⟨rfl⟩
 
@@ -166,7 +166,7 @@ inductive Result' where
   /-- Untyped version of `Result.isNegNat`. -/
   | isNegNat (inst lit proof : Expr)
   /-- Untyped version of `Result.isRat`. -/
-  | isRat (inst : Expr) (q : Rat) (n d proof : Expr)
+  | isRat (inst lit proof : Expr)
   deriving Inhabited
 
 section
@@ -192,8 +192,8 @@ and `proof : isInt x (.negOfNat lit)`. -/
 with `lit` a raw nat literal and `d` is a raw nat literal (not 0 or 1),
 and `q` is the value of `n / d`. -/
 @[match_pattern, inline] def Result.isRat {α : Q(Type u)} {x : Q($α)} :
-    ∀ (inst : Q(Ring $α) := by assumption) (q : Rat) (n : Q(ℤ)) (d : Q(ℕ))
-      (proof : Q(IsRat $x $n $d)), Result x := Result'.isRat
+    ∀ (inst : Q(DivisionRing $α) := by assumption) (q : Q(ℚ))
+      (proof : Q(IsRat $x $q)), Result x := Result'.isRat
 
 /-- A shortcut (non)instance for `AddMonoidWithOne α` from `Ring α` to shrink generated proofs. -/
 def instAddMonoidWithOne [Ring α] : AddMonoidWithOne α := inferInstance
@@ -214,7 +214,7 @@ def Result.isInt {α : Q(Type u)} {x : Q($α)} {z : Q(ℤ)}
 def Result.toRat : Result e → Rat
   | .isNat _ lit _ => lit.natLit!
   | .isNegNat _ lit _ => -lit.natLit!
-  | .isRat _ q .. => q
+  | .isRat _ q _ => q
 
 end
 

--- a/Mathlib/Tactic/NormNum/Core.lean
+++ b/Mathlib/Tactic/NormNum/Core.lean
@@ -136,7 +136,7 @@ theorem IsInt.to_isRat {α} [DivisionRing α] : ∀ {a : α} {n : ℤ}, IsInt a 
   | _, _, ⟨rfl⟩ => ⟨by simp⟩
 
 theorem IsRat.to_raw_eq [DivisionRing α] : (IsRat (a : α) q) → a = q.rawCast
-  | ⟨e⟩ => e
+| ⟨e⟩ => e
 
 theorem IsRat.of_raw (α) [DivisionRing α] (q : ℚ) : IsRat (q.rawCast : α) q := ⟨rfl⟩
 
@@ -166,7 +166,7 @@ inductive Result' where
   /-- Untyped version of `Result.isNegNat`. -/
   | isNegNat (inst lit proof : Expr)
   /-- Untyped version of `Result.isRat`. -/
-  | isRat (inst lit proof : Expr)
+  | isRat (inst : Expr) (q : Rat) (n d proof : Expr)
   deriving Inhabited
 
 section
@@ -192,8 +192,8 @@ and `proof : isInt x (.negOfNat lit)`. -/
 with `lit` a raw nat literal and `d` is a raw nat literal (not 0 or 1),
 and `q` is the value of `n / d`. -/
 @[match_pattern, inline] def Result.isRat {α : Q(Type u)} {x : Q($α)} :
-    ∀ (inst : Q(DivisionRing $α) := by assumption) (q : Q(ℚ))
-      (proof : Q(IsRat $x $q)), Result x := Result'.isRat
+    ∀ (inst : Q(Ring $α) := by assumption) (q : Rat) (n : Q(ℤ)) (d : Q(ℕ))
+      (proof : Q(IsRat $x $n $d)), Result x := Result'.isRat
 
 /-- A shortcut (non)instance for `AddMonoidWithOne α` from `Ring α` to shrink generated proofs. -/
 def instAddMonoidWithOne [Ring α] : AddMonoidWithOne α := inferInstance
@@ -214,7 +214,7 @@ def Result.isInt {α : Q(Type u)} {x : Q($α)} {z : Q(ℤ)}
 def Result.toRat : Result e → Rat
   | .isNat _ lit _ => lit.natLit!
   | .isNegNat _ lit _ => -lit.natLit!
-  | .isRat _ q _ => q
+  | .isRat _ q .. => q
 
 end
 

--- a/Mathlib/Tactic/Ring/Basic.lean
+++ b/Mathlib/Tactic/Ring/Basic.lean
@@ -285,7 +285,7 @@ def evalAddOverlap (va : ExProd sα a) (vb : ExProd sα b) : Option (Overlap sα
     let res ← NormNum.evalAdd.core q($a + $b) _ _ ra rb
     match res with
     | .isNat _ (.lit (.natVal 0)) p => pure <| .zero p
-    | rc => let ⟨zc, c, pc⟩ := rc.toRawEq; pure <| .nonzero ⟨c, .const zc, pc⟩
+    | rc => let ⟨zc, c, pc⟩ := rc.toRawIntEq.get!; pure <| .nonzero ⟨c, .const zc, pc⟩
   | .mul (x := a₁) (e := a₂) va₁ va₂ va₃, .mul vb₁ vb₂ vb₃ => do
     guard (va₁.eq vb₁ && va₂.eq vb₂)
     match ← evalAddOverlap va₃ vb₃ with
@@ -373,7 +373,7 @@ partial def evalMulProd (va : ExProd sα a) (vb : ExProd sα b) : Result (ExProd
     else
       let ra := Result.ofRawInt za a; let rb := Result.ofRawInt zb b
       let ⟨zc, c, pc⟩ :=
-        (NormNum.evalMul.core q($a * $b) _ _ q(CommSemiring.toSemiring) ra rb).get!.toRawEq
+        (NormNum.evalMul.core q($a * $b) _ _ q(CommSemiring.toSemiring) ra rb).get!.toRawIntEq.get!
       ⟨c, .const zc, pc⟩
   | .mul (x := a₁) (e := a₂) va₁ va₂ va₃, .const _ =>
     let ⟨_, vc, pc⟩ := evalMulProd va₃ vb
@@ -528,7 +528,7 @@ def evalNegProd (rα : Q(Ring $α)) (va : ExProd sα a) : Result (ExProd sα) q(
     let rm := Result.isNegNat rα lit (q(IsInt.of_raw $α (.negOfNat $lit)) : Expr)
     let ra := Result.ofRawInt za a
     let ⟨zb, b, (pb : Q((Int.negOfNat (nat_lit 1)).rawCast * $a = $b))⟩ :=
-      (NormNum.evalMul.core q($m1 * $a) _ _ q(CommSemiring.toSemiring) rm ra).get!.toRawEq
+      (NormNum.evalMul.core q($m1 * $a) _ _ q(CommSemiring.toSemiring) rm ra).get!.toRawIntEq.get!
     ⟨b, .const zb, (q(neg_one_mul (R := $α) $pb) : Expr)⟩
   | .mul (x := a₁) (e := a₂) va₁ va₂ va₃ =>
     let ⟨_, vb, pb⟩ := evalNegProd rα va₃
@@ -698,7 +698,7 @@ def evalPowProd (va : ExProd sα a) (vb : ExProd sℕ b) : Result (ExProd sα) q
       have lit : Q(ℕ) := b.appArg!
       let rb := (q(IsNat.of_raw ℕ $lit) : Expr)
       let ⟨zc, c, pc⟩ :=
-        (← NormNum.evalPow.core q($a ^ $b) _ b lit rb q(CommSemiring.toSemiring) ra).toRawEq
+        (← NormNum.evalPow.core q($a ^ $b) _ b lit rb q(CommSemiring.toSemiring) ra).toRawIntEq.get!
       some ⟨c, .const zc, pc⟩
     | .mul vxa₁ vea₁ va₂, vb => do
       let ⟨_, vc₁, pc₁⟩ := evalMulProd sℕ vea₁ vb

--- a/test/linear_combination.lean
+++ b/test/linear_combination.lean
@@ -40,10 +40,6 @@ example (x y : ℤ) (h1 : 10 = 3 * x + 2 * y) (h2 : 3 = 2 * x + 5 * y) : 11 + 1 
 example (x y : ℤ) (h1 : x + 2 = -3) (h2 : y = 10) : -y + 2 * x + 4 = -16 := by
   linear_combination 2 * h1 - h2
 
-axiom Rat' : Type
-@[instance] axiom instRat : CommRing Rat'
-notation "ℚ" => Rat'
-
 axiom Real' : Type
 @[instance] axiom instReal : CommRing Real'
 notation "ℝ" => Real'

--- a/test/norm_num.lean
+++ b/test/norm_num.lean
@@ -75,8 +75,8 @@ by norm_num at *; exact h
 --   exact n
 
 example (a : ℚ) (h : 3⁻¹ * a = a) : true := by
-  norm_num at h;
-  guard_hyp h : 1 / 3 * a = a;
+  norm_num at h
+  guard_hyp h : 1 / 3 * a = a
   trivial
 
 -- example (h : (5 : ℤ) ∣ 2) : false := by norm_num at h

--- a/test/norm_num.lean
+++ b/test/norm_num.lean
@@ -62,25 +62,22 @@ example : (12321 - 2 : ℤ) = 12319 := by norm_num
 example (x : ℤ) (h : 1000 + 2000 < x) : 100 * 30 < x :=
 by norm_num at *; exact h
 
-example : (1103 : ℤ) ≤ (2102 : ℤ) := by norm_num
-example : (110474 : ℤ) ≤ (210485 : ℤ) := by norm_num
-example : (11047462383473829263 : ℤ) ≤ (21048574677772382462 : ℤ) := by norm_num
-example : (210485742382937847263 : ℤ) ≤ (1104857462382937847262 : ℤ) := by norm_num
-example : (210485987642382937847263 : ℕ) ≤ (11048512347462382937847262 : ℕ) := by norm_num
--- example : (210485987642382937847263 : ℚ) ≤ (11048512347462382937847262 : ℚ) := by norm_num
-example : (2 * 12868 + 25705) * 11621 ^ 2 ≤ 23235 ^ 2 * 12868 := by norm_num
+-- example : (1103 : ℤ) ≤ (2102 : ℤ) := by norm_num1
+-- example : (110474 : ℤ) ≤ (210485 : ℤ) := by norm_num1
+-- example : (11047462383473829263 : ℤ) ≤ (21048574677772382462 : ℤ) := by norm_num1
+-- example : (210485742382937847263 : ℤ) ≤ (1104857462382937847262 : ℤ) := by norm_num1
+-- example : (210485987642382937847263 : ℕ) ≤ (11048512347462382937847262 : ℕ) := by norm_num1
+-- example : (210485987642382937847263 : ℚ) ≤ (11048512347462382937847262 : ℚ) := by norm_num1
+-- example : (2 * 12868 + 25705) * 11621 ^ 2 ≤ 23235 ^ 2 * 12868 := by norm_num1
 
 -- example (x : ℕ) : ℕ := by
---   let n : ℕ, {apply_normed (2^32 - 71)},
+--   let n : ℕ := by apply_normed (2^32 - 71);
 --   exact n
 
-
--- example (a : ℚ) (h : 3⁻¹ * a = a) : true :=
--- begin
---   norm_num at h,
---   guard_hyp h : 1 / 3 * a = a,
---   trivial
--- end
+example (a : ℚ) (h : 3⁻¹ * a = a) : true := by
+  norm_num at h;
+  guard_hyp h : 1 / 3 * a = a;
+  trivial
 
 -- example (h : (5 : ℤ) ∣ 2) : false := by norm_num at h
 -- example (h : false) : false := by norm_num at h
@@ -181,28 +178,28 @@ section
   example : (123456 : α) * 123456 = 15241383936 := by norm_num
 end
 
--- section
---   variable {α : Type}
---   variable [LinearOrderedField α]
---   example : (4 : α) / 2 = 2 := by norm_num
---   example : (4 : α) / 1 = 4 := by norm_num
---   example : (4 : α) / 3 = 4 / 3 := by norm_num
---   example : (50 : α) / 5 = 10 := by norm_num
---   example : (1056 : α) / 1 = 1056 := by norm_num
---   example : (6 : α) / 4 = 3/2 := by norm_num
---   example : (0 : α) / 3 = 0 := by norm_num
---   example : (3 : α) / 0 = 0 := by norm_num
---   example : (9 * 9 * 9) * (12 : α) / 27 = 81 * (2 + 2) := by norm_num
---   example : (-2 : α) * 4 / 3 = -8 / 3 := by norm_num
---   example : - (-4 / 3) = 1 / (3 / (4 : α)) := by norm_num
--- end
+section
+  variable {α : Type}
+  variable [LinearOrderedField α]
+  example : (4 : α) / 2 = 2 := by norm_num
+  example : (4 : α) / 1 = 4 := by norm_num
+  example : (4 : α) / 3 = 4 / 3 := by norm_num
+  example : (50 : α) / 5 = 10 := by norm_num
+  example : (1056 : α) / 1 = 1056 := by norm_num
+  example : (6 : α) / 4 = 3/2 := by norm_num
+  example : (0 : α) / 3 = 0 := by norm_num
+  example : (3 : α) / 0 = 0 := by norm_num
+  example : (9 * 9 * 9) * (12 : α) / 27 = 81 * (2 + 2) := by norm_num
+  example : (-2 : α) * 4 / 3 = -8 / 3 := by norm_num
+  example : - (-4 / 3) = 1 / (3 / (4 : α)) := by norm_num
+end
 
 -- user command
 
--- #norm_num 1 = 1
+#norm_num 1 = 1
 example : 1 = 1 := by norm_num
--- #norm_num 2^4-1 ∣ 2^16-1
--- example : 2^4-1 ∣ 2^16-1 := by norm_num
+#norm_num 2^4-1 ∣ 2^16-1
+example : 2^4-1 ∣ 2^16-1 := by norm_num
 -- #norm_num (3 : real) ^ (-2 : ℤ) = 1/9
 -- example : (3 : real) ^ (-2 : ℤ) = 1/9 := by norm_num
 
@@ -220,93 +217,94 @@ section norm_num_cmd_variable
 end norm_num_cmd_variable
 
 -- auto gen tests
--- example : ((25 * (1 / 1)) + (30 - 16)) = (39 : α) := by norm_num
--- example : ((19 * (- 2 - 3)) / 6) = (-95/6 : α) := by norm_num
--- example : - (3 * 28) = (-84 : α) := by norm_num
--- example : - - (16 / ((11 / (- - (6 * 19) + 12)) * 21)) = (96/11 : α) := by norm_num
--- example : (- (- 21 + 24) - - (- - (28 + (- 21 / - (16 / ((1 * 26) * ((0 * - 11) + 13))))) * 21)) =
---   (79209/8 : α) := by norm_num
--- example : (27 * (((16 + - (12 + 4)) + (22 - - 19)) - 23)) = (486 : α) := by norm_num
--- example : - (13 * (- 30 / ((7 / 24) + - 7))) = (-9360/161 : α) := by norm_num
--- example : - (0 + 20) = (-20 : α) := by norm_num
--- example : (- 2 - (27 + (((2 / 14) - (7 + 21)) + (16 - - - 14)))) = (-22/7 : α) := by norm_num
--- example : (25 + ((8 - 2) + 16)) = (47 : α) := by norm_num
--- example : (- - 26 / 27) = (26/27 : α) := by norm_num
--- example : ((((16 * (22 / 14)) - 18) / 11) + 30) = (2360/77 : α) := by norm_num
--- example : (((- 28 * 28) / (29 - 24)) * 24) = (-18816/5 : α) := by norm_num
--- example : ((- (18 - ((- - (10 + - 2) - - (23 / 5)) / 5)) - (21 * 22)) -
---   (((20 / - ((((19 + 18) + 15) + 3) + - 22)) + 14) / 17)) = (-394571/825 : α) := by norm_num
--- example : ((3 + 25) - - 4) = (32 : α) := by norm_num
--- example : ((1 - 0) - 22) = (-21 : α) := by norm_num
--- example : (((- (8 / 7) / 14) + 20) + 22) = (2054/49 : α) := by norm_num
--- example : ((21 / 20) - 29) = (-559/20 : α) := by norm_num
--- example : - - 20 = (20 : α) := by norm_num
--- example : (24 - (- 9 / 4)) = (105/4 : α) := by norm_num
--- example : (((7 / ((23 * 19) + (27 * 10))) - ((28 - - 15) * 24)) + (9 / - (10 * - 3))) =
---   (-1042007/1010 : α) := by norm_num
--- example : (26 - (- 29 + (12 / 25))) = (1363/25 : α) := by norm_num
--- example : ((11 * 27) / (4 - 5)) = (-297 : α) := by norm_num
--- example : (24 - (9 + 15)) = (0 : α) := by norm_num
--- example : (- 9 - - 0) = (-9 : α) := by norm_num
--- example : (- 10 / (30 + 10)) = (-1/4 : α) := by norm_num
--- example : (22 - (6 * (28 * - 8))) = (1366 : α) := by norm_num
--- example : ((- - 2 * (9 * - 3)) + (22 / 30)) = (-799/15 : α) := by norm_num
--- example : - (26 / ((3 + 7) / - (27 * (12 / - 16)))) = (-1053/20 : α) := by norm_num
--- example : ((- 29 / 1) + 28) = (-1 : α) := by norm_num
--- example : ((21 * ((10 - (((17 + 28) - - 0) + 20)) + 26)) + ((17 + - 16) * 7)) = (-602 : α) :=
--- by norm_num
--- example : (((- 5 - ((24 + - - 8) + 3)) + 20) + - 23) = (-43 : α) := by norm_num
--- example : ((- ((14 - 15) * (14 + 8)) + ((- (18 - 27) - 0) + 12)) - 11) = (32 : α) := by norm_num
--- example : (((15 / 17) * (26 / 27)) + 28) = (4414/153 : α) := by norm_num
--- example : (14 - ((- 16 - 3) * - (20 * 19))) = (-7206 : α) := by norm_num
--- example : (21 - - - (28 - (12 * 11))) = (125 : α) := by norm_num
--- example : ((0 + (7 + (25 + 8))) * - (11 * 27)) = (-11880 : α) := by norm_num
--- example : (19 * - 5) = (-95 : α) := by norm_num
--- example : (29 * - 8) = (-232 : α) := by norm_num
--- example : ((22 / 9) - 29) = (-239/9 : α) := by norm_num
--- example : (3 + (19 / 12)) = (55/12 : α) := by norm_num
--- example : - (13 + 30) = (-43 : α) := by norm_num
--- example : - - - (((21 * - - ((- 25 - (- (30 - 5) / (- 5 - 5))) /
---   (((6 + ((25 * - 13) + 22)) - 3) / 2))) / (- 3 / 10)) * (- 8 - 0)) = (-308/3 : α) := by norm_num
--- example : - (2 * - (- 24 * 22)) = (-1056 : α) := by norm_num
--- example : - - (((28 / - ((- 13 * - 5) / - (((7 - 30) / 16) + 6))) * 0) - 24) = (-24 : α) :=
--- by norm_num
--- example : ((13 + 24) - (27 / (21 * 13))) = (3358/91 : α) := by norm_num
--- example : ((3 / - 21) * 25) = (-25/7 : α) := by norm_num
--- example : (17 - (29 - 18)) = (6 : α) := by norm_num
--- example : ((28 / 20) * 15) = (21 : α) := by norm_num
--- example : ((((26 * (- (23 - 13) - 3)) / 20) / (14 - (10 + 20))) / ((16 / 6) / (16 * - (3 / 28)))) =
--- (-1521/2240 : α) := by norm_num
+variable [Field α]
+example : ((25 * (1 / 1)) + (30 - 16)) = (39 : α) := by norm_num
+example : ((19 * (- 2 - 3)) / 6) = (-95/6 : α) := by norm_num
+example : - (3 * 28) = (-84 : α) := by norm_num
+example : - - (16 / ((11 / (- - (6 * 19) + 12)) * 21)) = (96/11 : α) := by norm_num
+example : (- (- 21 + 24) - - (- - (28 + (- 21 / - (16 / ((1 * 26) * ((0 * - 11) + 13))))) * 21)) =
+  (79209/8 : α) := by norm_num
+example : (27 * (((16 + - (12 + 4)) + (22 - - 19)) - 23)) = (486 : α) := by norm_num
+example : - (13 * (- 30 / ((7 / 24) + - 7))) = (-9360/161 : α) := by norm_num
+example : - (0 + 20) = (-20 : α) := by norm_num
+example : (- 2 - (27 + (((2 / 14) - (7 + 21)) + (16 - - - 14)))) = (-22/7 : α) := by norm_num
+example : (25 + ((8 - 2) + 16)) = (47 : α) := by norm_num
+example : (- - 26 / 27) = (26/27 : α) := by norm_num
+example : ((((16 * (22 / 14)) - 18) / 11) + 30) = (2360/77 : α) := by norm_num
+example : (((- 28 * 28) / (29 - 24)) * 24) = (-18816/5 : α) := by norm_num
+example : ((- (18 - ((- - (10 + - 2) - - (23 / 5)) / 5)) - (21 * 22)) -
+  (((20 / - ((((19 + 18) + 15) + 3) + - 22)) + 14) / 17)) = (-394571/825 : α) := by norm_num
+example : ((3 + 25) - - 4) = (32 : α) := by norm_num
+example : ((1 - 0) - 22) = (-21 : α) := by norm_num
+example : (((- (8 / 7) / 14) + 20) + 22) = (2054/49 : α) := by norm_num
+example : ((21 / 20) - 29) = (-559/20 : α) := by norm_num
+example : - - 20 = (20 : α) := by norm_num
+example : (24 - (- 9 / 4)) = (105/4 : α) := by norm_num
+example : (((7 / ((23 * 19) + (27 * 10))) - ((28 - - 15) * 24)) + (9 / - (10 * - 3))) =
+  (-1042007/1010 : α) := by norm_num
+example : (26 - (- 29 + (12 / 25))) = (1363/25 : α) := by norm_num
+example : ((11 * 27) / (4 - 5)) = (-297 : α) := by norm_num
+example : (24 - (9 + 15)) = (0 : α) := by norm_num
+example : (- 9 - - 0) = (-9 : α) := by norm_num
+example : (- 10 / (30 + 10)) = (-1/4 : α) := by norm_num
+example : (22 - (6 * (28 * - 8))) = (1366 : α) := by norm_num
+example : ((- - 2 * (9 * - 3)) + (22 / 30)) = (-799/15 : α) := by norm_num
+example : - (26 / ((3 + 7) / - (27 * (12 / - 16)))) = (-1053/20 : α) := by norm_num
+example : ((- 29 / 1) + 28) = (-1 : α) := by norm_num
+example : ((21 * ((10 - (((17 + 28) - - 0) + 20)) + 26)) + ((17 + - 16) * 7)) = (-602 : α) :=
+by norm_num
+example : (((- 5 - ((24 + - - 8) + 3)) + 20) + - 23) = (-43 : α) := by norm_num
+example : ((- ((14 - 15) * (14 + 8)) + ((- (18 - 27) - 0) + 12)) - 11) = (32 : α) := by norm_num
+example : (((15 / 17) * (26 / 27)) + 28) = (4414/153 : α) := by norm_num
+example : (14 - ((- 16 - 3) * - (20 * 19))) = (-7206 : α) := by norm_num
+example : (21 - - - (28 - (12 * 11))) = (125 : α) := by norm_num
+example : ((0 + (7 + (25 + 8))) * - (11 * 27)) = (-11880 : α) := by norm_num
+example : (19 * - 5) = (-95 : α) := by norm_num
+example : (29 * - 8) = (-232 : α) := by norm_num
+example : ((22 / 9) - 29) = (-239/9 : α) := by norm_num
+example : (3 + (19 / 12)) = (55/12 : α) := by norm_num
+example : - (13 + 30) = (-43 : α) := by norm_num
+example : - - - (((21 * - - ((- 25 - (- (30 - 5) / (- 5 - 5))) /
+  (((6 + ((25 * - 13) + 22)) - 3) / 2))) / (- 3 / 10)) * (- 8 - 0)) = (-308/3 : α) := by norm_num
+example : - (2 * - (- 24 * 22)) = (-1056 : α) := by norm_num
+example : - - (((28 / - ((- 13 * - 5) / - (((7 - 30) / 16) + 6))) * 0) - 24) = (-24 : α) :=
+by norm_num
+example : ((13 + 24) - (27 / (21 * 13))) = (3358/91 : α) := by norm_num
+example : ((3 / - 21) * 25) = (-25/7 : α) := by norm_num
+example : (17 - (29 - 18)) = (6 : α) := by norm_num
+example : ((28 / 20) * 15) = (21 : α) := by norm_num
+example : ((((26 * (- (23 - 13) - 3)) / 20) / (14 - (10 + 20))) / ((16 / 6) / (16 * - (3 / 28)))) =
+(-1521/2240 : α) := by norm_num
 
--- example : (46 / (- ((- 17 * 28) - 77) + 87)) = (23/320 : α) := by norm_num
--- example : (73 * - (67 - (74 * - - 11))) = (54531 : α) := by norm_num
--- example : ((8 * (25 / 9)) + 59) = (731/9 : α) := by norm_num
--- example : - ((59 + 85) * - 70) = (10080 : α) := by norm_num
--- example : (66 + (70 * 58)) = (4126 : α) := by norm_num
--- example : (- - 49 * 0) = (0 : α) := by norm_num
--- example : ((- 78 - 69) * 9) = (-1323 : α) := by norm_num
--- example : - - (7 - - (50 * 79)) = (3957 : α) := by norm_num
--- example : - (85 * (((4 * 93) * 19) * - 31)) = (18624180 : α) := by norm_num
--- example : (21 + (- 5 / ((74 * 85) / 45))) = (26373/1258 : α) := by norm_num
--- example : (42 - ((27 + 64) + 26)) = (-75 : α) := by norm_num
--- example : (- ((38 - - 17) + 86) - (74 + 58)) = (-273 : α) := by norm_num
--- example : ((29 * - (75 + - 68)) + (- 41 / 28)) = (-5725/28 : α) := by norm_num
--- example : (- - (40 - 11) - (68 * 86)) = (-5819 : α) := by norm_num
--- example : (6 + ((65 - 14) + - 89)) = (-32 : α) := by norm_num
--- example : (97 * - (29 * 35)) = (-98455 : α) := by norm_num
--- example : - (66 / 33) = (-2 : α) := by norm_num
--- example : - ((94 * 89) + (79 - (23 - (((- 1 / 55) + 95) * (28 - (54 / - - - 22)))))) =
--- (-1369070/121 : α) := by norm_num
--- example : (- 23 + 61) = (38 : α) := by norm_num
--- example : - (93 / 69) = (-31/23 : α) := by norm_num
--- example : (- - ((68 / (39 + (((45 * - (59 - (37 + 35))) / (53 - 75)) -
---  - (100 + - (50 / (- 30 - 59)))))) - (69 - (23 * 30))) / (57 + 17)) = (137496481/16368578 : α) :=
--- by norm_num
--- example : (- 19 * - - (75 * - - 41)) = (-58425 : α) := by norm_num
--- example : ((3 / ((- 28 * 45) * (19 + ((- (- 88 - (- (- 1 + 90) + 8)) + 87) * 48)))) + 1) =
---   (1903019/1903020 : α) := by norm_num
--- example : ((- - (28 + 48) / 75) + ((- 59 - 14) - 0)) = (-5399/75 : α) := by norm_num
--- example : (- ((- (((66 - 86) - 36) / 94) - 3) / - - (77 / (56 - - - 79))) + 87) =
---   (312254/3619 : α) := by norm_num
+example : (46 / (- ((- 17 * 28) - 77) + 87)) = (23/320 : α) := by norm_num
+example : (73 * - (67 - (74 * - - 11))) = (54531 : α) := by norm_num
+example : ((8 * (25 / 9)) + 59) = (731/9 : α) := by norm_num
+example : - ((59 + 85) * - 70) = (10080 : α) := by norm_num
+example : (66 + (70 * 58)) = (4126 : α) := by norm_num
+example : (- - 49 * 0) = (0 : α) := by norm_num
+example : ((- 78 - 69) * 9) = (-1323 : α) := by norm_num
+example : - - (7 - - (50 * 79)) = (3957 : α) := by norm_num
+example : - (85 * (((4 * 93) * 19) * - 31)) = (18624180 : α) := by norm_num
+example : (21 + (- 5 / ((74 * 85) / 45))) = (26373/1258 : α) := by norm_num
+example : (42 - ((27 + 64) + 26)) = (-75 : α) := by norm_num
+example : (- ((38 - - 17) + 86) - (74 + 58)) = (-273 : α) := by norm_num
+example : ((29 * - (75 + - 68)) + (- 41 / 28)) = (-5725/28 : α) := by norm_num
+example : (- - (40 - 11) - (68 * 86)) = (-5819 : α) := by norm_num
+example : (6 + ((65 - 14) + - 89)) = (-32 : α) := by norm_num
+example : (97 * - (29 * 35)) = (-98455 : α) := by norm_num
+example : - (66 / 33) = (-2 : α) := by norm_num
+example : - ((94 * 89) + (79 - (23 - (((- 1 / 55) + 95) * (28 - (54 / - - - 22)))))) =
+(-1369070/121 : α) := by norm_num
+example : (- 23 + 61) = (38 : α) := by norm_num
+example : - (93 / 69) = (-31/23 : α) := by norm_num
+example : (- - ((68 / (39 + (((45 * - (59 - (37 + 35))) / (53 - 75)) -
+ - (100 + - (50 / (- 30 - 59)))))) - (69 - (23 * 30))) / (57 + 17)) = (137496481/16368578 : α) :=
+by norm_num
+example : (- 19 * - - (75 * - - 41)) = (-58425 : α) := by norm_num
+example : ((3 / ((- 28 * 45) * (19 + ((- (- 88 - (- (- 1 + 90) + 8)) + 87) * 48)))) + 1) =
+  (1903019/1903020 : α) := by norm_num
+example : ((- - (28 + 48) / 75) + ((- 59 - 14) - 0)) = (-5399/75 : α) := by norm_num
+example : (- ((- (((66 - 86) - 36) / 94) - 3) / - - (77 / (56 - - - 79))) + 87) =
+  (312254/3619 : α) := by norm_num
 
--- example : 2 ^ 13 - 1 = int.of_nat 8191 := by norm_num
+-- example : 2 ^ 13 - 1 = Int.ofNat 8191 := by norm_num


### PR DESCRIPTION
As per #1102, we extend `norm_num` to handle `Rat`s.

We leave most of the theorems sorried, but the evaluation and tests work!