### PR TITLE
[Merged by Bors] - feat: port the positivity_max extension

### DIFF
--- a/test/positivity.lean
+++ b/test/positivity.lean
@@ -79,6 +79,12 @@ example {a b : ℚ} (ha : 0 < a) (hb : b ≠ 0) : min a b ≠ 0 := by positivity
 example {a b : ℚ} (ha : a ≠ 0) (hb : 0 < b) : min a b ≠ 0 := by positivity
 example {a b : ℚ} (ha : a ≠ 0) (hb : b ≠ 0) : min a b ≠ 0 := by positivity
 
+example {a b : ℚ} (ha : 0 < a) : 0 < max a b := by positivity
+example {a b : ℚ} (hb : 0 < b) : 0 < max a b := by positivity
+example {a b : ℚ} (ha : 0 ≤ a) : 0 ≤ max a b := by positivity
+example {a b : ℚ} (hb : 0 ≤ b) : 0 ≤ max a b := by positivity
+example {a b : ℚ} (ha : a ≠ 0) (hb : b ≠ 0) : max a b ≠ 0 := by positivity
+
 example {a b : ℚ} (ha : 0 < a) (hb : 0 < b) : 0 < a * b := by positivity
 example {a b : ℚ} (ha : 0 < a) (hb : 0 ≤ b) : 0 ≤ a * b := by positivity
 example {a b : ℚ} (ha : 0 ≤ a) (hb : 0 < b) : 0 ≤ a * b := by positivity
@@ -200,13 +206,13 @@ example {a b : ℤ} (ha : 3 < a) : 0 ≤ min a (b ^ 2) := by positivity
 
 example : 0 ≤ max 3 4 := by positivity
 
--- example {b : ℤ} : 0 ≤ max (-3) (b ^ 2) := by positivity
+example {b : ℤ} : 0 ≤ max (-3) (b ^ 2) := by positivity
 
--- example {b : ℤ} : 0 ≤ max (b ^ 2) 0 := by positivity
+example {b : ℤ} : 0 ≤ max (b ^ 2) 0 := by positivity
 
--- example : 0 ≤ max (0:ℤ) (-3) := by positivity
+example : 0 ≤ max (0:ℤ) (-3) := by positivity
 
--- example : 0 ≤ max (-3 : ℤ) 5 := by positivity
+example : 0 ≤ max (-3 : ℤ) 5 := by positivity
 
 -- example [OrderedSemiring α] [OrderedAddCommMonoid β] [SMulWithZero α β]
 --   [OrderedSMul α β] {a : α} (ha : 0 < a) {b : β} (hb : 0 < b) : 0 ≤ a • b := by positivity


### PR DESCRIPTION
Ports the `positivity_max` positivity extension from mathlib3: https://github.com/leanprover-community/mathlib/blob/2f7b36ab1dffd22fcc18e8ad84340e7314abc819/src/tactic/positivity.lean#L389-L415