### PR TITLE
[Merged by Bors] - feat port:Algebra.FreeMonoid.Basic

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -12,6 +12,7 @@ import Mathlib.Algebra.Field.Basic
 import Mathlib.Algebra.Field.Defs
 import Mathlib.Algebra.Field.Opposite
 import Mathlib.Algebra.Field.Power
+import Mathlib.Algebra.FreeMonoid.Basic
 import Mathlib.Algebra.GCDMonoid.Basic
 import Mathlib.Algebra.Group.Basic
 import Mathlib.Algebra.Group.Commutator

--- a/Mathlib/Algebra/FreeMonoid/Basic.lean
+++ b/Mathlib/Algebra/FreeMonoid/Basic.lean
@@ -27,8 +27,7 @@ variable {α : Type _} {β : Type _} {γ : Type _} {M : Type _} [Monoid M] {N : 
 
 /-- Free monoid over a given alphabet. -/
 @[to_additive "Free nonabelian additive monoid over a given alphabet"]
-def FreeMonoid (α) :=
-  List α
+def FreeMonoid (α) := List α
 #align free_monoid FreeMonoid
 
 namespace FreeMonoid
@@ -136,15 +135,9 @@ theorem toList_of_mul (x : α) (xs : FreeMonoid α) : toList (of x * xs) = x :: 
 theorem of_injective : Function.Injective (@of α) := List.singleton_injective
 #align free_monoid.of_injective FreeMonoid.of_injective
 
-
---- RESUME HERE
-
-/-- Recursor for `FreeMonoid` using `1` and `FreeMonoid.of x * xs` instead of `[]` and
-`x :: xs`. -/
-@[elab_as_elim,
-  to_additive
-      "Recursor for `FreeAddMonoid` using `0` and `FreeAddMonoid.of x + xs` instead of `[]` and
-      `x :: xs`."]
+/-- Recursor for `FreeMonoid` using `1` and `FreeMonoid.of x * xs` instead of `[]` and `x :: xs`. -/
+@[elab_as_elim, to_additive "Recursor for `FreeAddMonoid` using `0` and `FreeAddMonoid.of x + xs`
+instead of `[]` and `x :: xs`."]
 -- Porting note: added noncomputable
 noncomputable def recOn {C : FreeMonoid α → Sort _} (xs : FreeMonoid α) (h0 : C 1)
     (ih : ∀ x xs, C xs → C (of x * xs)) : C xs := List.recOn xs h0 ih
@@ -163,10 +156,8 @@ theorem recOn_of_mul {C : FreeMonoid α → Sort _} (x : α) (xs : FreeMonoid α
 
 /-- A version of `List.cases_on` for `FreeMonoid` using `1` and `FreeMonoid.of x * xs` instead of
 `[]` and `x :: xs`. -/
-@[elab_as_elim,
-  to_additive
-      "A version of `List.casesOn` for `FreeAddMonoid` using `0` and `FreeAddMonoid.of x + xs`
-      instead of `[]` and `x :: xs`."]
+@[elab_as_elim, to_additive "A version of `List.casesOn` for `FreeAddMonoid` using `0` and
+`FreeAddMonoid.of x + xs` instead of `[]` and `x :: xs`."]
 def casesOn {C : FreeMonoid α → Sort _} (xs : FreeMonoid α) (h0 : C 1)
     (ih : ∀ x xs, C (of x * xs)) : C xs := List.casesOn xs h0 ih
 #align free_monoid.cases_on FreeMonoid.casesOn
@@ -183,48 +174,42 @@ theorem casesOn_of_mul {C : FreeMonoid α → Sort _} (x : α) (xs : FreeMonoid 
 
 @[to_additive (attr := ext)]
 theorem hom_eq ⦃f g : FreeMonoid α →* M⦄ (h : ∀ x, f (of x) = g (of x)) : f = g :=
-  MonoidHom.ext fun l =>
-    (recOn l (f.map_one.trans g.map_one.symm)) fun x xs hxs => by
-      simp only [h, hxs, MonoidHom.map_mul]
+  MonoidHom.ext fun l ↦ recOn l (f.map_one.trans g.map_one.symm)
+    (fun x xs hxs ↦ by  simp only [h, hxs, MonoidHom.map_mul])
 #align free_monoid.hom_eq FreeMonoid.hom_eq
 
 /-- Equivalence between maps `α → M` and monoid homomorphisms `FreeMonoid α →* M`. -/
-@[to_additive
-      "Equivalence between maps `α → A` and additive monoid homomorphisms
-      `FreeAddMonoid α →+ A`."]
+@[to_additive "Equivalence between maps `α → A` and additive monoid homomorphisms
+`FreeAddMonoid α →+ A`."]
 def lift : (α → M) ≃ (FreeMonoid α →* M)
     where
   toFun f :=
-    ⟨fun l => (l.toList.map f).Prod, rfl, fun l₁ l₂ => by
-      simp only [to_list_mul, List.map_append, List.prod_append]⟩
+  { toFun := fun l ↦ ((toList l).map f).prod
+    map_one' := rfl -- sorry
+    map_mul' := fun _ _ ↦ by simp only [toList_mul, List.map_append, List.prod_append] }
   invFun f x := f (of x)
-  left_inv f := funext fun x => one_mul (f x)
-  right_inv f := hom_eq fun x => one_mul (f (of x))
+  left_inv f := funext fun x ↦ one_mul (f x)
+  right_inv f := hom_eq fun x ↦ one_mul (f (of x))
 #align free_monoid.lift FreeMonoid.lift
 
 @[to_additive (attr := simp)]
-theorem lift_symm_apply (f : FreeMonoid α →* M) : lift.symm f = f ∘ of :=
-  rfl
+theorem lift_symm_apply (f : FreeMonoid α →* M) : lift.symm f = f ∘ of := rfl
 #align free_monoid.lift_symm_apply FreeMonoid.lift_symm_apply
 
 @[to_additive]
-theorem lift_apply (f : α → M) (l : FreeMonoid α) : lift f l = (l.toList.map f).Prod :=
-  rfl
+theorem lift_apply (f : α → M) (l : FreeMonoid α) : lift f l = ((toList l).map f).prod := rfl
 #align free_monoid.lift_apply FreeMonoid.lift_apply
 
 @[to_additive]
-theorem lift_comp_of (f : α → M) : lift f ∘ of = f :=
-  lift.symm_apply_apply f
+theorem lift_comp_of (f : α → M) : lift f ∘ of = f := lift.symm_apply_apply f
 #align free_monoid.lift_comp_of FreeMonoid.lift_comp_of
 
 @[to_additive (attr := simp)]
-theorem lift_eval_of (f : α → M) (x : α) : lift f (of x) = f x :=
-  congr_fun (lift_comp_of f) x
+theorem lift_eval_of (f : α → M) (x : α) : lift f (of x) = f x := congr_fun (lift_comp_of f) x
 #align free_monoid.lift_eval_of FreeMonoid.lift_eval_of
 
 @[to_additive (attr := simp)]
-theorem lift_restrict (f : FreeMonoid α →* M) : lift (f ∘ of) = f :=
-  lift.apply_symm_apply f
+theorem lift_restrict (f : FreeMonoid α →* M) : lift (f ∘ of) = f := lift.apply_symm_apply f
 #align free_monoid.lift_restrict FreeMonoid.lift_restrict
 
 @[to_additive]
@@ -250,16 +235,14 @@ def mkMulAction (f : α → β → β) : MulAction (FreeMonoid α) β
 
 @[to_additive]
 theorem smul_def (f : α → β → β) (l : FreeMonoid α) (b : β) :
-    haveI := mk_mul_action f
-    l • b = l.to_list.foldr f b :=
-  rfl
+    haveI := mkMulAction f
+    l • b = l.toList.foldr f b := rfl
 #align free_monoid.smul_def FreeMonoid.smul_def
 
 @[to_additive]
 theorem ofList_smul (f : α → β → β) (l : List α) (b : β) :
-    haveI := mk_mul_action f
-    of_list l • b = l.foldr f b :=
-  rfl
+    haveI := mkMulAction f
+    ofList l • b = l.foldr f b := rfl
 #align free_monoid.of_list_smul FreeMonoid.ofList_smul
 
 @[simp, to_additive]
@@ -272,9 +255,8 @@ theorem of_smul (f : α → β → β) (x : α) (y : β) :
 
 /-- The unique monoid homomorphism `FreeMonoid α →* FreeMonoid β` that sends
 each `of x` to `of (f x)`. -/
-@[to_additive
-      "The unique additive monoid homomorphism `FreeAddMonoid α →+ FreeAddMonoid β`
-      that sends each `of x` to `of (f x)`."]
+@[to_additive "The unique additive monoid homomorphism `FreeAddMonoid α →+ FreeAddMonoid β`
+that sends each `of x` to `of (f x)`."]
 def map (f : α → β) : FreeMonoid α →* FreeMonoid β
     where
   toFun l := ofList <| l.toList.map f
@@ -287,7 +269,7 @@ theorem map_of (f : α → β) (x : α) : map f (of x) = of (f x) := rfl
 #align free_monoid.map_of FreeMonoid.map_of
 
 @[to_additive]
-theorem toList_map (f : α → β) (xs : FreeMonoid α) : (map f xs).toList = xs.toList.map f := rfl
+theorem toList_map (f : α → β) (xs : FreeMonoid α) : toList (map f xs) = xs.toList.map f := rfl
 #align free_monoid.to_list_map FreeMonoid.toList_map
 
 @[to_additive]
@@ -295,18 +277,15 @@ theorem ofList_map (f : α → β) (xs : List α) : ofList (xs.map f) = map f (o
 #align free_monoid.of_list_map FreeMonoid.ofList_map
 
 @[to_additive]
-theorem lift_of_comp_eq_map (f : α → β) : (lift fun x => of (f x)) = map f :=
-  hom_eq fun x => rfl
+theorem lift_of_comp_eq_map (f : α → β) : (lift fun x ↦ of (f x)) = map f := hom_eq fun _ ↦ rfl
 #align free_monoid.lift_of_comp_eq_map FreeMonoid.lift_of_comp_eq_map
 
 @[to_additive]
-theorem map_comp (g : β → γ) (f : α → β) : map (g ∘ f) = (map g).comp (map f) :=
-  hom_eq fun _ => rfl
+theorem map_comp (g : β → γ) (f : α → β) : map (g ∘ f) = (map g).comp (map f) := hom_eq fun _ ↦ rfl
 #align free_monoid.map_comp FreeMonoid.map_comp
 
 @[to_additive (attr := simp)]
-theorem map_id : map (@id α) = MonoidHom.id (FreeMonoid α) :=
-  hom_eq fun _ => rfl
+theorem map_id : map (@id α) = MonoidHom.id (FreeMonoid α) := hom_eq fun _ ↦ rfl
 #align free_monoid.map_id FreeMonoid.map_id
 
 end FreeMonoid

--- a/Mathlib/Algebra/FreeMonoid/Basic.lean
+++ b/Mathlib/Algebra/FreeMonoid/Basic.lean
@@ -1,0 +1,332 @@
+/-
+Copyright (c) 2019 Simon Hudon. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Simon Hudon, Yury Kudryashov
+
+! This file was ported from Lean 3 source module algebra.free_monoid.basic
+! leanprover-community/mathlib commit dd71334db81d0bd444af1ee339a29298bef40734
+! Please do not edit these lines, except to modify the commit id
+! if you have ported upstream changes.
+-/
+import Mathbin.Data.List.BigOperators.Basic
+
+/-!
+# Free monoid over a given alphabet
+
+## Main definitions
+
+* `free_monoid α`: free monoid over alphabet `α`; defined as a synonym for `list α`
+  with multiplication given by `(++)`.
+* `free_monoid.of`: embedding `α → free_monoid α` sending each element `x` to `[x]`;
+* `free_monoid.lift`: natural equivalence between `α → M` and `free_monoid α →* M`
+* `free_monoid.map`: embedding of `α → β` into `free_monoid α →* free_monoid β` given by `list.map`.
+-/
+
+
+variable {α : Type _} {β : Type _} {γ : Type _} {M : Type _} [Monoid M] {N : Type _} [Monoid N]
+
+/-- Free monoid over a given alphabet. -/
+@[to_additive "Free nonabelian additive monoid over a given alphabet"]
+def FreeMonoid (α) :=
+  List α
+#align free_monoid FreeMonoid
+
+namespace FreeMonoid
+
+@[to_additive]
+instance [DecidableEq α] : DecidableEq (FreeMonoid α) :=
+  List.decidableEq
+
+/-- The identity equivalence between `free_monoid α` and `list α`. -/
+@[to_additive "The identity equivalence between `free_add_monoid α` and `list α`."]
+def toList : FreeMonoid α ≃ List α :=
+  Equiv.refl _
+#align free_monoid.to_list FreeMonoid.toList
+
+/-- The identity equivalence between `list α` and `free_monoid α`. -/
+@[to_additive "The identity equivalence between `list α` and `free_add_monoid α`."]
+def ofList : List α ≃ FreeMonoid α :=
+  Equiv.refl _
+#align free_monoid.of_list FreeMonoid.ofList
+
+@[simp, to_additive]
+theorem to_list_symm : (@toList α).symm = of_list :=
+  rfl
+#align free_monoid.to_list_symm FreeMonoid.to_list_symm
+
+@[simp, to_additive]
+theorem of_list_symm : (@ofList α).symm = to_list :=
+  rfl
+#align free_monoid.of_list_symm FreeMonoid.of_list_symm
+
+@[simp, to_additive]
+theorem to_list_of_list (l : List α) : toList (ofList l) = l :=
+  rfl
+#align free_monoid.to_list_of_list FreeMonoid.to_list_of_list
+
+@[simp, to_additive]
+theorem of_list_to_list (xs : FreeMonoid α) : ofList (toList xs) = xs :=
+  rfl
+#align free_monoid.of_list_to_list FreeMonoid.of_list_to_list
+
+@[simp, to_additive]
+theorem to_list_comp_of_list : @toList α ∘ of_list = id :=
+  rfl
+#align free_monoid.to_list_comp_of_list FreeMonoid.to_list_comp_of_list
+
+@[simp, to_additive]
+theorem of_list_comp_to_list : @ofList α ∘ to_list = id :=
+  rfl
+#align free_monoid.of_list_comp_to_list FreeMonoid.of_list_comp_to_list
+
+@[to_additive]
+instance : CancelMonoid (FreeMonoid α)
+    where
+  one := ofList []
+  mul x y := ofList (x.toList ++ y.toList)
+  mul_one := List.append_nil
+  one_mul := List.nil_append
+  mul_assoc := List.append_assoc
+  mul_left_cancel _ _ _ := List.append_left_cancel
+  mul_right_cancel _ _ _ := List.append_right_cancel
+
+@[to_additive]
+instance : Inhabited (FreeMonoid α) :=
+  ⟨1⟩
+
+@[simp, to_additive]
+theorem to_list_one : (1 : FreeMonoid α).toList = [] :=
+  rfl
+#align free_monoid.to_list_one FreeMonoid.to_list_one
+
+@[simp, to_additive]
+theorem of_list_nil : ofList ([] : List α) = 1 :=
+  rfl
+#align free_monoid.of_list_nil FreeMonoid.of_list_nil
+
+@[simp, to_additive]
+theorem to_list_mul (xs ys : FreeMonoid α) : (xs * ys).toList = xs.toList ++ ys.toList :=
+  rfl
+#align free_monoid.to_list_mul FreeMonoid.to_list_mul
+
+@[simp, to_additive]
+theorem of_list_append (xs ys : List α) : ofList (xs ++ ys) = ofList xs * ofList ys :=
+  rfl
+#align free_monoid.of_list_append FreeMonoid.of_list_append
+
+@[simp, to_additive]
+theorem to_list_prod (xs : List (FreeMonoid α)) : toList xs.Prod = (xs.map toList).join := by
+  induction xs <;> simp [*, List.join]
+#align free_monoid.to_list_prod FreeMonoid.to_list_prod
+
+@[simp, to_additive]
+theorem of_list_join (xs : List (List α)) : ofList xs.join = (xs.map ofList).Prod :=
+  toList.Injective <| by simp
+#align free_monoid.of_list_join FreeMonoid.of_list_join
+
+/-- Embeds an element of `α` into `free_monoid α` as a singleton list. -/
+@[to_additive "Embeds an element of `α` into `free_add_monoid α` as a singleton list."]
+def of (x : α) : FreeMonoid α :=
+  ofList [x]
+#align free_monoid.of FreeMonoid.of
+
+@[simp, to_additive]
+theorem to_list_of (x : α) : toList (of x) = [x] :=
+  rfl
+#align free_monoid.to_list_of FreeMonoid.to_list_of
+
+@[to_additive]
+theorem of_list_singleton (x : α) : ofList [x] = of x :=
+  rfl
+#align free_monoid.of_list_singleton FreeMonoid.of_list_singleton
+
+@[simp, to_additive]
+theorem of_list_cons (x : α) (xs : List α) : ofList (x :: xs) = of x * ofList xs :=
+  rfl
+#align free_monoid.of_list_cons FreeMonoid.of_list_cons
+
+@[to_additive]
+theorem to_list_of_mul (x : α) (xs : FreeMonoid α) : toList (of x * xs) = x :: xs.toList :=
+  rfl
+#align free_monoid.to_list_of_mul FreeMonoid.to_list_of_mul
+
+@[to_additive]
+theorem of_injective : Function.Injective (@of α) :=
+  List.singleton_injective
+#align free_monoid.of_injective FreeMonoid.of_injective
+
+/-- Recursor for `free_monoid` using `1` and `free_monoid.of x * xs` instead of `[]` and
+`x :: xs`. -/
+@[elab_as_elim,
+  to_additive
+      "Recursor for `free_add_monoid` using `0` and `free_add_monoid.of x + xs` instead of `[]` and\n  `x :: xs`."]
+def recOn {C : FreeMonoid α → Sort _} (xs : FreeMonoid α) (h0 : C 1)
+    (ih : ∀ x xs, C xs → C (of x * xs)) : C xs :=
+  List.recOn xs h0 ih
+#align free_monoid.rec_on FreeMonoid.recOn
+
+@[simp, to_additive]
+theorem rec_on_one {C : FreeMonoid α → Sort _} (h0 : C 1) (ih : ∀ x xs, C xs → C (of x * xs)) :
+    @recOn α C 1 h0 ih = h0 :=
+  rfl
+#align free_monoid.rec_on_one FreeMonoid.rec_on_one
+
+@[simp, to_additive]
+theorem rec_on_of_mul {C : FreeMonoid α → Sort _} (x : α) (xs : FreeMonoid α) (h0 : C 1)
+    (ih : ∀ x xs, C xs → C (of x * xs)) : @recOn α C (of x * xs) h0 ih = ih x xs (recOn xs h0 ih) :=
+  rfl
+#align free_monoid.rec_on_of_mul FreeMonoid.rec_on_of_mul
+
+/-- A version of `list.cases_on` for `free_monoid` using `1` and `free_monoid.of x * xs` instead of
+`[]` and `x :: xs`. -/
+@[elab_as_elim,
+  to_additive
+      "A version of `list.cases_on` for `free_add_monoid` using `0` and `free_add_monoid.of x + xs`\n  instead of `[]` and `x :: xs`."]
+def casesOn {C : FreeMonoid α → Sort _} (xs : FreeMonoid α) (h0 : C 1)
+    (ih : ∀ x xs, C (of x * xs)) : C xs :=
+  List.casesOn xs h0 ih
+#align free_monoid.cases_on FreeMonoid.casesOn
+
+@[simp, to_additive]
+theorem cases_on_one {C : FreeMonoid α → Sort _} (h0 : C 1) (ih : ∀ x xs, C (of x * xs)) :
+    @casesOn α C 1 h0 ih = h0 :=
+  rfl
+#align free_monoid.cases_on_one FreeMonoid.cases_on_one
+
+@[simp, to_additive]
+theorem cases_on_of_mul {C : FreeMonoid α → Sort _} (x : α) (xs : FreeMonoid α) (h0 : C 1)
+    (ih : ∀ x xs, C (of x * xs)) : @casesOn α C (of x * xs) h0 ih = ih x xs :=
+  rfl
+#align free_monoid.cases_on_of_mul FreeMonoid.cases_on_of_mul
+
+@[ext, to_additive]
+theorem hom_eq ⦃f g : FreeMonoid α →* M⦄ (h : ∀ x, f (of x) = g (of x)) : f = g :=
+  MonoidHom.ext fun l =>
+    (recOn l (f.map_one.trans g.map_one.symm)) fun x xs hxs => by
+      simp only [h, hxs, MonoidHom.map_mul]
+#align free_monoid.hom_eq FreeMonoid.hom_eq
+
+/-- Equivalence between maps `α → M` and monoid homomorphisms `free_monoid α →* M`. -/
+@[to_additive
+      "Equivalence between maps `α → A` and additive monoid homomorphisms\n`free_add_monoid α →+ A`."]
+def lift : (α → M) ≃ (FreeMonoid α →* M)
+    where
+  toFun f :=
+    ⟨fun l => (l.toList.map f).Prod, rfl, fun l₁ l₂ => by
+      simp only [to_list_mul, List.map_append, List.prod_append]⟩
+  invFun f x := f (of x)
+  left_inv f := funext fun x => one_mul (f x)
+  right_inv f := hom_eq fun x => one_mul (f (of x))
+#align free_monoid.lift FreeMonoid.lift
+
+@[simp, to_additive]
+theorem lift_symm_apply (f : FreeMonoid α →* M) : lift.symm f = f ∘ of :=
+  rfl
+#align free_monoid.lift_symm_apply FreeMonoid.lift_symm_apply
+
+@[to_additive]
+theorem lift_apply (f : α → M) (l : FreeMonoid α) : lift f l = (l.toList.map f).Prod :=
+  rfl
+#align free_monoid.lift_apply FreeMonoid.lift_apply
+
+@[to_additive]
+theorem lift_comp_of (f : α → M) : lift f ∘ of = f :=
+  lift.symm_apply_apply f
+#align free_monoid.lift_comp_of FreeMonoid.lift_comp_of
+
+@[simp, to_additive]
+theorem lift_eval_of (f : α → M) (x : α) : lift f (of x) = f x :=
+  congr_fun (lift_comp_of f) x
+#align free_monoid.lift_eval_of FreeMonoid.lift_eval_of
+
+@[simp, to_additive]
+theorem lift_restrict (f : FreeMonoid α →* M) : lift (f ∘ of) = f :=
+  lift.apply_symm_apply f
+#align free_monoid.lift_restrict FreeMonoid.lift_restrict
+
+@[to_additive]
+theorem comp_lift (g : M →* N) (f : α → M) : g.comp (lift f) = lift (g ∘ f) :=
+  by
+  ext
+  simp
+#align free_monoid.comp_lift FreeMonoid.comp_lift
+
+@[to_additive]
+theorem hom_map_lift (g : M →* N) (f : α → M) (x : FreeMonoid α) : g (lift f x) = lift (g ∘ f) x :=
+  MonoidHom.ext_iff.1 (comp_lift g f) x
+#align free_monoid.hom_map_lift FreeMonoid.hom_map_lift
+
+/-- Define a multiplicative action of `free_monoid α` on `β`. -/
+@[to_additive "Define an additive action of `free_add_monoid α` on `β`."]
+def mkMulAction (f : α → β → β) : MulAction (FreeMonoid α) β
+    where
+  smul l b := l.toList.foldr f b
+  one_smul x := rfl
+  mul_smul xs ys b := List.foldr_append _ _ _ _
+#align free_monoid.mk_mul_action FreeMonoid.mkMulAction
+
+@[to_additive]
+theorem smul_def (f : α → β → β) (l : FreeMonoid α) (b : β) :
+    haveI := mk_mul_action f
+    l • b = l.to_list.foldr f b :=
+  rfl
+#align free_monoid.smul_def FreeMonoid.smul_def
+
+@[to_additive]
+theorem of_list_smul (f : α → β → β) (l : List α) (b : β) :
+    haveI := mk_mul_action f
+    of_list l • b = l.foldr f b :=
+  rfl
+#align free_monoid.of_list_smul FreeMonoid.of_list_smul
+
+@[simp, to_additive]
+theorem of_smul (f : α → β → β) (x : α) (y : β) :
+    (haveI := mk_mul_action f
+      of x • y) =
+      f x y :=
+  rfl
+#align free_monoid.of_smul FreeMonoid.of_smul
+
+/-- The unique monoid homomorphism `free_monoid α →* free_monoid β` that sends
+each `of x` to `of (f x)`. -/
+@[to_additive
+      "The unique additive monoid homomorphism `free_add_monoid α →+ free_add_monoid β`\nthat sends each `of x` to `of (f x)`."]
+def map (f : α → β) : FreeMonoid α →* FreeMonoid β
+    where
+  toFun l := of_list <| l.toList.map f
+  map_one' := rfl
+  map_mul' l₁ l₂ := List.map_append _ _ _
+#align free_monoid.map FreeMonoid.map
+
+@[simp, to_additive]
+theorem map_of (f : α → β) (x : α) : map f (of x) = of (f x) :=
+  rfl
+#align free_monoid.map_of FreeMonoid.map_of
+
+@[to_additive]
+theorem to_list_map (f : α → β) (xs : FreeMonoid α) : (map f xs).toList = xs.toList.map f :=
+  rfl
+#align free_monoid.to_list_map FreeMonoid.to_list_map
+
+@[to_additive]
+theorem of_list_map (f : α → β) (xs : List α) : ofList (xs.map f) = map f (ofList xs) :=
+  rfl
+#align free_monoid.of_list_map FreeMonoid.of_list_map
+
+@[to_additive]
+theorem lift_of_comp_eq_map (f : α → β) : (lift fun x => of (f x)) = map f :=
+  hom_eq fun x => rfl
+#align free_monoid.lift_of_comp_eq_map FreeMonoid.lift_of_comp_eq_map
+
+@[to_additive]
+theorem map_comp (g : β → γ) (f : α → β) : map (g ∘ f) = (map g).comp (map f) :=
+  hom_eq fun x => rfl
+#align free_monoid.map_comp FreeMonoid.map_comp
+
+@[simp, to_additive]
+theorem map_id : map (@id α) = MonoidHom.id (FreeMonoid α) :=
+  hom_eq fun x => rfl
+#align free_monoid.map_id FreeMonoid.map_id
+
+end FreeMonoid
+

--- a/Mathlib/Algebra/FreeMonoid/Basic.lean
+++ b/Mathlib/Algebra/FreeMonoid/Basic.lean
@@ -214,20 +214,18 @@ theorem lift_restrict (f : FreeMonoid α →* M) : lift (f ∘ of) = f := lift.a
 
 @[to_additive]
 theorem comp_lift (g : M →* N) (f : α → M) : g.comp (lift f) = lift (g ∘ f) :=
-  by
-  ext
-  simp
+-- Porting note: replace ext by FreeMonoid.hom_eq
+  FreeMonoid.hom_eq (by simp)
 #align free_monoid.comp_lift FreeMonoid.comp_lift
 
 @[to_additive]
 theorem hom_map_lift (g : M →* N) (f : α → M) (x : FreeMonoid α) : g (lift f x) = lift (g ∘ f) x :=
-  MonoidHom.ext_iff.1 (comp_lift g f) x
+  FunLike.ext_iff.1 (comp_lift g f) x
 #align free_monoid.hom_map_lift FreeMonoid.hom_map_lift
 
 /-- Define a multiplicative action of `FreeMonoid α` on `β`. -/
 @[to_additive "Define an additive action of `FreeAddMonoid α` on `β`."]
-def mkMulAction (f : α → β → β) : MulAction (FreeMonoid α) β
-    where
+def mkMulAction (f : α → β → β) : MulAction (FreeMonoid α) β where
   smul l b := l.toList.foldr f b
   one_smul _ := rfl
   mul_smul _ _ _ := List.foldr_append _ _ _ _
@@ -245,12 +243,10 @@ theorem ofList_smul (f : α → β → β) (l : List α) (b : β) :
     ofList l • b = l.foldr f b := rfl
 #align free_monoid.of_list_smul FreeMonoid.ofList_smul
 
-@[simp, to_additive]
+@[to_additive (attr := simp)]
 theorem of_smul (f : α → β → β) (x : α) (y : β) :
-    (haveI := mk_mul_action f
-      of x • y) =
-      f x y :=
-  rfl
+    (haveI := mkMulAction f
+    of x • y) = f x y := rfl
 #align free_monoid.of_smul FreeMonoid.of_smul
 
 /-- The unique monoid homomorphism `FreeMonoid α →* FreeMonoid β` that sends

--- a/Mathlib/Algebra/FreeMonoid/Basic.lean
+++ b/Mathlib/Algebra/FreeMonoid/Basic.lean
@@ -15,11 +15,11 @@ import Mathlib.Data.List.BigOperators.Basic
 
 ## Main definitions
 
-* `free_monoid α`: free monoid over alphabet `α`; defined as a synonym for `list α`
+* `FreeMonoid α`: free monoid over alphabet `α`; defined as a synonym for `List α`
   with multiplication given by `(++)`.
-* `free_monoid.of`: embedding `α → free_monoid α` sending each element `x` to `[x]`;
-* `free_monoid.lift`: natural equivalence between `α → M` and `free_monoid α →* M`
-* `free_monoid.map`: embedding of `α → β` into `free_monoid α →* free_monoid β` given by `list.map`.
+* `FreeMonoid.of`: embedding `α → FreeMonoid α` sending each element `x` to `[x]`;
+* `FreeMonoid.lift`: natural equivalence between `α → M` and `FreeMonoid α →* M`
+* `FreeMonoid.map`: embedding of `α → β` into `FreeMonoid α →* FreeMonoid β` given by `List.map`.
 -/
 
 
@@ -33,57 +33,49 @@ def FreeMonoid (α) :=
 
 namespace FreeMonoid
 
+-- Porting note: TODO. Check this is still needed
 @[to_additive]
-instance [DecidableEq α] : DecidableEq (FreeMonoid α) :=
-  List.decidableEq
+instance [DecidableEq α] : DecidableEq (FreeMonoid α) := instDecidableEqList
 
-/-- The identity equivalence between `free_monoid α` and `list α`. -/
-@[to_additive "The identity equivalence between `free_add_monoid α` and `list α`."]
-def toList : FreeMonoid α ≃ List α :=
-  Equiv.refl _
+/-- The identity equivalence between `FreeMonoid α` and `List α`. -/
+@[to_additive "The identity equivalence between `FreeAddMonoid α` and `List α`."]
+def toList : FreeMonoid α ≃ List α := Equiv.refl _
 #align free_monoid.to_list FreeMonoid.toList
 
-/-- The identity equivalence between `list α` and `free_monoid α`. -/
-@[to_additive "The identity equivalence between `list α` and `free_add_monoid α`."]
-def ofList : List α ≃ FreeMonoid α :=
-  Equiv.refl _
+/-- The identity equivalence between `List α` and `FreeMonoid α`. -/
+@[to_additive "The identity equivalence between `List α` and `FreeAddMonoid α`."]
+def ofList : List α ≃ FreeMonoid α := Equiv.refl _
 #align free_monoid.of_list FreeMonoid.ofList
 
-@[simp, to_additive]
-theorem to_list_symm : (@toList α).symm = of_list :=
-  rfl
-#align free_monoid.to_list_symm FreeMonoid.to_list_symm
+@[to_additive (attr := simp)]
+theorem toList_symm : (@toList α).symm = ofList := rfl
+#align free_monoid.to_list_symm FreeMonoid.toList_symm
 
-@[simp, to_additive]
-theorem of_list_symm : (@ofList α).symm = to_list :=
-  rfl
-#align free_monoid.of_list_symm FreeMonoid.of_list_symm
+@[to_additive (attr := simp)]
+theorem ofList_symm : (@ofList α).symm = toList := rfl
+#align free_monoid.of_list_symm FreeMonoid.ofList_symm
 
-@[simp, to_additive]
-theorem to_list_of_list (l : List α) : toList (ofList l) = l :=
-  rfl
-#align free_monoid.to_list_of_list FreeMonoid.to_list_of_list
+@[to_additive (attr := simp)]
+theorem toList_ofList (l : List α) : toList (ofList l) = l := rfl
+#align free_monoid.to_list_of_list FreeMonoid.toList_ofList
 
-@[simp, to_additive]
-theorem of_list_to_list (xs : FreeMonoid α) : ofList (toList xs) = xs :=
-  rfl
-#align free_monoid.of_list_to_list FreeMonoid.of_list_to_list
+@[to_additive (attr := simp)]
+theorem ofList_toList (xs : FreeMonoid α) : ofList (toList xs) = xs := rfl
+#align free_monoid.of_list_to_list FreeMonoid.ofList_toList
 
-@[simp, to_additive]
-theorem to_list_comp_of_list : @toList α ∘ of_list = id :=
-  rfl
-#align free_monoid.to_list_comp_of_list FreeMonoid.to_list_comp_of_list
+@[to_additive (attr := simp)]
+theorem toList_comp_ofList : @toList α ∘ ofList = id := rfl
+#align free_monoid.to_list_comp_of_list FreeMonoid.toList_comp_ofList
 
-@[simp, to_additive]
-theorem of_list_comp_to_list : @ofList α ∘ to_list = id :=
-  rfl
-#align free_monoid.of_list_comp_to_list FreeMonoid.of_list_comp_to_list
+@[to_additive (attr := simp)]
+theorem ofList_comp_toList : @ofList α ∘ toList = id := rfl
+#align free_monoid.of_list_comp_to_list FreeMonoid.ofList_comp_toList
 
 @[to_additive]
 instance : CancelMonoid (FreeMonoid α)
     where
   one := ofList []
-  mul x y := ofList (x.toList ++ y.toList)
+  mul x y := ofList (toList x ++ toList y)
   mul_one := List.append_nil
   one_mul := List.nil_append
   mul_assoc := List.append_assoc
@@ -91,124 +83,115 @@ instance : CancelMonoid (FreeMonoid α)
   mul_right_cancel _ _ _ := List.append_right_cancel
 
 @[to_additive]
-instance : Inhabited (FreeMonoid α) :=
-  ⟨1⟩
+instance : Inhabited (FreeMonoid α) := ⟨1⟩
 
-@[simp, to_additive]
-theorem to_list_one : (1 : FreeMonoid α).toList = [] :=
-  rfl
-#align free_monoid.to_list_one FreeMonoid.to_list_one
+@[to_additive (attr := simp)]
+theorem toList_one : toList (1 : FreeMonoid α) = [] := rfl
+#align free_monoid.to_list_one FreeMonoid.toList_one
 
-@[simp, to_additive]
-theorem of_list_nil : ofList ([] : List α) = 1 :=
-  rfl
-#align free_monoid.of_list_nil FreeMonoid.of_list_nil
+@[to_additive (attr := simp)]
+theorem ofList_nil : ofList ([] : List α) = 1 := rfl
+#align free_monoid.of_list_nil FreeMonoid.ofList_nil
 
-@[simp, to_additive]
-theorem to_list_mul (xs ys : FreeMonoid α) : (xs * ys).toList = xs.toList ++ ys.toList :=
-  rfl
-#align free_monoid.to_list_mul FreeMonoid.to_list_mul
+@[to_additive (attr := simp)]
+theorem toList_mul (xs ys : FreeMonoid α) : toList (xs * ys) = toList xs ++ toList ys := rfl
+#align free_monoid.to_list_mul FreeMonoid.toList_mul
 
-@[simp, to_additive]
-theorem of_list_append (xs ys : List α) : ofList (xs ++ ys) = ofList xs * ofList ys :=
-  rfl
-#align free_monoid.of_list_append FreeMonoid.of_list_append
+@[to_additive (attr := simp)]
+theorem ofList_append (xs ys : List α) : ofList (xs ++ ys) = ofList xs * ofList ys := rfl
+#align free_monoid.of_list_append FreeMonoid.ofList_append
 
-@[simp, to_additive]
-theorem to_list_prod (xs : List (FreeMonoid α)) : toList xs.Prod = (xs.map toList).join := by
+@[to_additive (attr := simp)]
+theorem toList_prod (xs : List (FreeMonoid α)) : toList xs.prod = (xs.map toList).join := by
   induction xs <;> simp [*, List.join]
-#align free_monoid.to_list_prod FreeMonoid.to_list_prod
+#align free_monoid.to_list_prod FreeMonoid.toList_prod
 
-@[simp, to_additive]
-theorem of_list_join (xs : List (List α)) : ofList xs.join = (xs.map ofList).Prod :=
-  toList.Injective <| by simp
-#align free_monoid.of_list_join FreeMonoid.of_list_join
+@[to_additive (attr := simp)]
+theorem ofList_join (xs : List (List α)) : ofList xs.join = (xs.map ofList).prod :=
+  toList.injective <| by simp
+#align free_monoid.of_list_join FreeMonoid.ofList_join
 
-/-- Embeds an element of `α` into `free_monoid α` as a singleton list. -/
-@[to_additive "Embeds an element of `α` into `free_add_monoid α` as a singleton list."]
-def of (x : α) : FreeMonoid α :=
-  ofList [x]
+/-- Embeds an element of `α` into `FreeMonoid α` as a singleton list. -/
+@[to_additive "Embeds an element of `α` into `FreeAddMonoid α` as a singleton list."]
+def of (x : α) : FreeMonoid α := ofList [x]
 #align free_monoid.of FreeMonoid.of
 
-@[simp, to_additive]
-theorem to_list_of (x : α) : toList (of x) = [x] :=
-  rfl
-#align free_monoid.to_list_of FreeMonoid.to_list_of
+@[to_additive (attr := simp)]
+theorem toList_of (x : α) : toList (of x) = [x] := rfl
+#align free_monoid.to_list_of FreeMonoid.toList_of
 
 @[to_additive]
-theorem of_list_singleton (x : α) : ofList [x] = of x :=
-  rfl
-#align free_monoid.of_list_singleton FreeMonoid.of_list_singleton
+theorem ofList_singleton (x : α) : ofList [x] = of x := rfl
+#align free_monoid.of_list_singleton FreeMonoid.ofList_singleton
 
-@[simp, to_additive]
-theorem of_list_cons (x : α) (xs : List α) : ofList (x :: xs) = of x * ofList xs :=
-  rfl
-#align free_monoid.of_list_cons FreeMonoid.of_list_cons
+@[to_additive (attr := simp)]
+theorem ofList_cons (x : α) (xs : List α) : ofList (x :: xs) = of x * ofList xs := rfl
+#align free_monoid.of_list_cons FreeMonoid.ofList_cons
 
 @[to_additive]
-theorem to_list_of_mul (x : α) (xs : FreeMonoid α) : toList (of x * xs) = x :: xs.toList :=
-  rfl
-#align free_monoid.to_list_of_mul FreeMonoid.to_list_of_mul
+theorem toList_of_mul (x : α) (xs : FreeMonoid α) : toList (of x * xs) = x :: toList xs := rfl
+#align free_monoid.to_list_of_mul FreeMonoid.toList_of_mul
 
 @[to_additive]
-theorem of_injective : Function.Injective (@of α) :=
-  List.singleton_injective
+theorem of_injective : Function.Injective (@of α) := List.singleton_injective
 #align free_monoid.of_injective FreeMonoid.of_injective
 
-/-- Recursor for `free_monoid` using `1` and `free_monoid.of x * xs` instead of `[]` and
+
+--- RESUME HERE
+
+/-- Recursor for `FreeMonoid` using `1` and `FreeMonoid.of x * xs` instead of `[]` and
 `x :: xs`. -/
 @[elab_as_elim,
   to_additive
-      "Recursor for `free_add_monoid` using `0` and `free_add_monoid.of x + xs` instead of `[]` and\n  `x :: xs`."]
-def recOn {C : FreeMonoid α → Sort _} (xs : FreeMonoid α) (h0 : C 1)
-    (ih : ∀ x xs, C xs → C (of x * xs)) : C xs :=
-  List.recOn xs h0 ih
+      "Recursor for `FreeAddMonoid` using `0` and `FreeAddMonoid.of x + xs` instead of `[]` and
+      `x :: xs`."]
+-- Porting note: added noncomputable
+noncomputable def recOn {C : FreeMonoid α → Sort _} (xs : FreeMonoid α) (h0 : C 1)
+    (ih : ∀ x xs, C xs → C (of x * xs)) : C xs := List.recOn xs h0 ih
 #align free_monoid.rec_on FreeMonoid.recOn
 
-@[simp, to_additive]
-theorem rec_on_one {C : FreeMonoid α → Sort _} (h0 : C 1) (ih : ∀ x xs, C xs → C (of x * xs)) :
-    @recOn α C 1 h0 ih = h0 :=
-  rfl
-#align free_monoid.rec_on_one FreeMonoid.rec_on_one
+@[to_additive (attr := simp)]
+theorem recOn_one {C : FreeMonoid α → Sort _} (h0 : C 1) (ih : ∀ x xs, C xs → C (of x * xs)) :
+    @recOn α C 1 h0 ih = h0 := rfl
+#align free_monoid.rec_on_one FreeMonoid.recOn_one
 
-@[simp, to_additive]
-theorem rec_on_of_mul {C : FreeMonoid α → Sort _} (x : α) (xs : FreeMonoid α) (h0 : C 1)
+@[to_additive (attr := simp)]
+theorem recOn_of_mul {C : FreeMonoid α → Sort _} (x : α) (xs : FreeMonoid α) (h0 : C 1)
     (ih : ∀ x xs, C xs → C (of x * xs)) : @recOn α C (of x * xs) h0 ih = ih x xs (recOn xs h0 ih) :=
   rfl
-#align free_monoid.rec_on_of_mul FreeMonoid.rec_on_of_mul
+#align free_monoid.rec_on_of_mul FreeMonoid.recOn_of_mul
 
-/-- A version of `list.cases_on` for `free_monoid` using `1` and `free_monoid.of x * xs` instead of
+/-- A version of `List.cases_on` for `FreeMonoid` using `1` and `FreeMonoid.of x * xs` instead of
 `[]` and `x :: xs`. -/
 @[elab_as_elim,
   to_additive
-      "A version of `list.cases_on` for `free_add_monoid` using `0` and `free_add_monoid.of x + xs`\n  instead of `[]` and `x :: xs`."]
+      "A version of `List.casesOn` for `FreeAddMonoid` using `0` and `FreeAddMonoid.of x + xs`
+      instead of `[]` and `x :: xs`."]
 def casesOn {C : FreeMonoid α → Sort _} (xs : FreeMonoid α) (h0 : C 1)
-    (ih : ∀ x xs, C (of x * xs)) : C xs :=
-  List.casesOn xs h0 ih
+    (ih : ∀ x xs, C (of x * xs)) : C xs := List.casesOn xs h0 ih
 #align free_monoid.cases_on FreeMonoid.casesOn
 
-@[simp, to_additive]
-theorem cases_on_one {C : FreeMonoid α → Sort _} (h0 : C 1) (ih : ∀ x xs, C (of x * xs)) :
-    @casesOn α C 1 h0 ih = h0 :=
-  rfl
-#align free_monoid.cases_on_one FreeMonoid.cases_on_one
+@[to_additive (attr := simp)]
+theorem casesOn_one {C : FreeMonoid α → Sort _} (h0 : C 1) (ih : ∀ x xs, C (of x * xs)) :
+    @casesOn α C 1 h0 ih = h0 := rfl
+#align free_monoid.cases_on_one FreeMonoid.casesOn_one
 
-@[simp, to_additive]
-theorem cases_on_of_mul {C : FreeMonoid α → Sort _} (x : α) (xs : FreeMonoid α) (h0 : C 1)
-    (ih : ∀ x xs, C (of x * xs)) : @casesOn α C (of x * xs) h0 ih = ih x xs :=
-  rfl
-#align free_monoid.cases_on_of_mul FreeMonoid.cases_on_of_mul
+@[to_additive (attr := simp)]
+theorem casesOn_of_mul {C : FreeMonoid α → Sort _} (x : α) (xs : FreeMonoid α) (h0 : C 1)
+    (ih : ∀ x xs, C (of x * xs)) : @casesOn α C (of x * xs) h0 ih = ih x xs := rfl
+#align free_monoid.cases_on_of_mul FreeMonoid.casesOn_of_mul
 
-@[ext, to_additive]
+@[to_additive (attr := ext)]
 theorem hom_eq ⦃f g : FreeMonoid α →* M⦄ (h : ∀ x, f (of x) = g (of x)) : f = g :=
   MonoidHom.ext fun l =>
     (recOn l (f.map_one.trans g.map_one.symm)) fun x xs hxs => by
       simp only [h, hxs, MonoidHom.map_mul]
 #align free_monoid.hom_eq FreeMonoid.hom_eq
 
-/-- Equivalence between maps `α → M` and monoid homomorphisms `free_monoid α →* M`. -/
+/-- Equivalence between maps `α → M` and monoid homomorphisms `FreeMonoid α →* M`. -/
 @[to_additive
-      "Equivalence between maps `α → A` and additive monoid homomorphisms\n`free_add_monoid α →+ A`."]
+      "Equivalence between maps `α → A` and additive monoid homomorphisms
+      `FreeAddMonoid α →+ A`."]
 def lift : (α → M) ≃ (FreeMonoid α →* M)
     where
   toFun f :=
@@ -219,7 +202,7 @@ def lift : (α → M) ≃ (FreeMonoid α →* M)
   right_inv f := hom_eq fun x => one_mul (f (of x))
 #align free_monoid.lift FreeMonoid.lift
 
-@[simp, to_additive]
+@[to_additive (attr := simp)]
 theorem lift_symm_apply (f : FreeMonoid α →* M) : lift.symm f = f ∘ of :=
   rfl
 #align free_monoid.lift_symm_apply FreeMonoid.lift_symm_apply
@@ -234,12 +217,12 @@ theorem lift_comp_of (f : α → M) : lift f ∘ of = f :=
   lift.symm_apply_apply f
 #align free_monoid.lift_comp_of FreeMonoid.lift_comp_of
 
-@[simp, to_additive]
+@[to_additive (attr := simp)]
 theorem lift_eval_of (f : α → M) (x : α) : lift f (of x) = f x :=
   congr_fun (lift_comp_of f) x
 #align free_monoid.lift_eval_of FreeMonoid.lift_eval_of
 
-@[simp, to_additive]
+@[to_additive (attr := simp)]
 theorem lift_restrict (f : FreeMonoid α →* M) : lift (f ∘ of) = f :=
   lift.apply_symm_apply f
 #align free_monoid.lift_restrict FreeMonoid.lift_restrict
@@ -256,13 +239,13 @@ theorem hom_map_lift (g : M →* N) (f : α → M) (x : FreeMonoid α) : g (lift
   MonoidHom.ext_iff.1 (comp_lift g f) x
 #align free_monoid.hom_map_lift FreeMonoid.hom_map_lift
 
-/-- Define a multiplicative action of `free_monoid α` on `β`. -/
-@[to_additive "Define an additive action of `free_add_monoid α` on `β`."]
+/-- Define a multiplicative action of `FreeMonoid α` on `β`. -/
+@[to_additive "Define an additive action of `FreeAddMonoid α` on `β`."]
 def mkMulAction (f : α → β → β) : MulAction (FreeMonoid α) β
     where
   smul l b := l.toList.foldr f b
-  one_smul x := rfl
-  mul_smul xs ys b := List.foldr_append _ _ _ _
+  one_smul _ := rfl
+  mul_smul _ _ _ := List.foldr_append _ _ _ _
 #align free_monoid.mk_mul_action FreeMonoid.mkMulAction
 
 @[to_additive]
@@ -273,11 +256,11 @@ theorem smul_def (f : α → β → β) (l : FreeMonoid α) (b : β) :
 #align free_monoid.smul_def FreeMonoid.smul_def
 
 @[to_additive]
-theorem of_list_smul (f : α → β → β) (l : List α) (b : β) :
+theorem ofList_smul (f : α → β → β) (l : List α) (b : β) :
     haveI := mk_mul_action f
     of_list l • b = l.foldr f b :=
   rfl
-#align free_monoid.of_list_smul FreeMonoid.of_list_smul
+#align free_monoid.of_list_smul FreeMonoid.ofList_smul
 
 @[simp, to_additive]
 theorem of_smul (f : α → β → β) (x : α) (y : β) :
@@ -287,31 +270,29 @@ theorem of_smul (f : α → β → β) (x : α) (y : β) :
   rfl
 #align free_monoid.of_smul FreeMonoid.of_smul
 
-/-- The unique monoid homomorphism `free_monoid α →* free_monoid β` that sends
+/-- The unique monoid homomorphism `FreeMonoid α →* FreeMonoid β` that sends
 each `of x` to `of (f x)`. -/
 @[to_additive
-      "The unique additive monoid homomorphism `free_add_monoid α →+ free_add_monoid β`\nthat sends each `of x` to `of (f x)`."]
+      "The unique additive monoid homomorphism `FreeAddMonoid α →+ FreeAddMonoid β`
+      that sends each `of x` to `of (f x)`."]
 def map (f : α → β) : FreeMonoid α →* FreeMonoid β
     where
-  toFun l := of_list <| l.toList.map f
+  toFun l := ofList <| l.toList.map f
   map_one' := rfl
-  map_mul' l₁ l₂ := List.map_append _ _ _
+  map_mul' _ _ := List.map_append _ _ _
 #align free_monoid.map FreeMonoid.map
 
-@[simp, to_additive]
-theorem map_of (f : α → β) (x : α) : map f (of x) = of (f x) :=
-  rfl
+@[to_additive (attr := simp)]
+theorem map_of (f : α → β) (x : α) : map f (of x) = of (f x) := rfl
 #align free_monoid.map_of FreeMonoid.map_of
 
 @[to_additive]
-theorem to_list_map (f : α → β) (xs : FreeMonoid α) : (map f xs).toList = xs.toList.map f :=
-  rfl
-#align free_monoid.to_list_map FreeMonoid.to_list_map
+theorem toList_map (f : α → β) (xs : FreeMonoid α) : (map f xs).toList = xs.toList.map f := rfl
+#align free_monoid.to_list_map FreeMonoid.toList_map
 
 @[to_additive]
-theorem of_list_map (f : α → β) (xs : List α) : ofList (xs.map f) = map f (ofList xs) :=
-  rfl
-#align free_monoid.of_list_map FreeMonoid.of_list_map
+theorem ofList_map (f : α → β) (xs : List α) : ofList (xs.map f) = map f (ofList xs) := rfl
+#align free_monoid.of_list_map FreeMonoid.ofList_map
 
 @[to_additive]
 theorem lift_of_comp_eq_map (f : α → β) : (lift fun x => of (f x)) = map f :=
@@ -320,13 +301,12 @@ theorem lift_of_comp_eq_map (f : α → β) : (lift fun x => of (f x)) = map f :
 
 @[to_additive]
 theorem map_comp (g : β → γ) (f : α → β) : map (g ∘ f) = (map g).comp (map f) :=
-  hom_eq fun x => rfl
+  hom_eq fun _ => rfl
 #align free_monoid.map_comp FreeMonoid.map_comp
 
-@[simp, to_additive]
+@[to_additive (attr := simp)]
 theorem map_id : map (@id α) = MonoidHom.id (FreeMonoid α) :=
-  hom_eq fun x => rfl
+  hom_eq fun _ => rfl
 #align free_monoid.map_id FreeMonoid.map_id
 
 end FreeMonoid
-

--- a/Mathlib/Algebra/FreeMonoid/Basic.lean
+++ b/Mathlib/Algebra/FreeMonoid/Basic.lean
@@ -8,7 +8,7 @@ Authors: Simon Hudon, Yury Kudryashov
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
-import Mathbin.Data.List.BigOperators.Basic
+import Mathlib.Data.List.BigOperators.Basic
 
 /-!
 # Free monoid over a given alphabet


### PR DESCRIPTION
- Dot notation not working for `toList` so replaced with "normal" notation