### PR TITLE
[Merged by Bors] - fix: help menu for cache CLI

### DIFF
--- a/Cache/Main.lean
+++ b/Cache/Main.lean
@@ -35,11 +35,11 @@ Commands:
 specific about what should be downloaded. For example, with automatic glob
 expansion in shell, one can call:
 
-$ lake exe cache get Mathlib/Algebra/Field/* Mathlib/Data/*
+$ lake exe cache get Mathlib/Algebra/Field/*.lean Mathlib/Data/*.lean
 
 Which will download the cache for:
-* Everything that starts with 'Mathlib/Algebra/Field/'
-* Everything that starts with 'Mathlib/Data/'
+* Every Lean file inside 'Mathlib/Algebra/Field/'
+* Every Lean file inside 'Mathlib/Data/'
 * Everything that's needed for the above"
 
 open Cache IO Hashing Requests in


### PR DESCRIPTION
The help menu for `cache` has some typos for automatic glob expansion. This PR fixes them.