### PR TITLE
[Merged by Bors] - feat port: Algebra.FreeMonoid.Count

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -14,6 +14,7 @@ import Mathlib.Algebra.Field.Defs
 import Mathlib.Algebra.Field.Opposite
 import Mathlib.Algebra.Field.Power
 import Mathlib.Algebra.FreeMonoid.Basic
+import Mathlib.Algebra.FreeMonoid.Count
 import Mathlib.Algebra.GCDMonoid.Basic
 import Mathlib.Algebra.Group.Basic
 import Mathlib.Algebra.Group.Commutator

--- a/Mathlib/Algebra/FreeMonoid/Count.lean
+++ b/Mathlib/Algebra/FreeMonoid/Count.lean
@@ -18,7 +18,7 @@ In this file we define `FreeMonoid.countp`, `FreeMonoid.count`, `FreeAddMonoid.c
 `FreeAddMonoid.count`. These are `List.countp` and `List.count` bundled as multiplicative and
 additive homomorphisms from `FreeMonoid` and `FreeAddMonoid`.
 
-We do not use `to_additive` because it can't map `multiplicative ℕ` to `ℕ`.
+We do not use `to_additive` because it can't map `Multiplicative ℕ` to `ℕ`.
 -/
 
 variable {α : Type _} (p : α → Prop) [DecidablePred p]

--- a/Mathlib/Algebra/FreeMonoid/Count.lean
+++ b/Mathlib/Algebra/FreeMonoid/Count.lean
@@ -1,0 +1,94 @@
+/-
+Copyright (c) 2022 Yury Kudryashov. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yury Kudryashov
+
+! This file was ported from Lean 3 source module algebra.free_monoid.count
+! leanprover-community/mathlib commit a2d2e18906e2b62627646b5d5be856e6a642062f
+! Please do not edit these lines, except to modify the commit id
+! if you have ported upstream changes.
+-/
+import Mathbin.Algebra.FreeMonoid.Basic
+import Mathbin.Data.List.Count
+
+/-!
+# `list.count` as a bundled homomorphism
+
+In this file we define `free_monoid.countp`, `free_monoid.count`, `free_add_monoid.countp`, and
+`free_add_monoid.count`. These are `list.countp` and `list.count` bundled as multiplicative and
+additive homomorphisms from `free_monoid` and `free_add_monoid`.
+
+We do not use `to_additive` because it can't map `multiplicative ℕ` to `ℕ`.
+-/
+
+
+variable {α : Type _} (p : α → Prop) [DecidablePred p]
+
+namespace FreeAddMonoid
+
+/-- `list.countp` as a bundled additive monoid homomorphism. -/
+def countp (p : α → Prop) [DecidablePred p] : FreeAddMonoid α →+ ℕ :=
+  ⟨List.countp p, List.countp_nil p, List.countp_append _⟩
+#align free_add_monoid.countp FreeAddMonoid.countp
+
+theorem countp_of (x : α) : countp p (of x) = if p x then 1 else 0 :=
+  rfl
+#align free_add_monoid.countp_of FreeAddMonoid.countp_of
+
+theorem countp_apply (l : FreeAddMonoid α) : countp p l = List.countp p l :=
+  rfl
+#align free_add_monoid.countp_apply FreeAddMonoid.countp_apply
+
+/-- `list.count` as a bundled additive monoid homomorphism. -/
+def count [DecidableEq α] (x : α) : FreeAddMonoid α →+ ℕ :=
+  countp (Eq x)
+#align free_add_monoid.count FreeAddMonoid.count
+
+theorem count_of [DecidableEq α] (x y : α) : count x (of y) = Pi.single x 1 y := by
+  simp only [count, countp_of, Pi.single_apply, eq_comm]
+#align free_add_monoid.count_of FreeAddMonoid.count_of
+
+theorem count_apply [DecidableEq α] (x : α) (l : FreeAddMonoid α) : count x l = List.count x l :=
+  rfl
+#align free_add_monoid.count_apply FreeAddMonoid.count_apply
+
+end FreeAddMonoid
+
+namespace FreeMonoid
+
+/-- `list.countp` as a bundled multiplicative monoid homomorphism. -/
+def countp (p : α → Prop) [DecidablePred p] : FreeMonoid α →* Multiplicative ℕ :=
+  (FreeAddMonoid.countp p).toMultiplicative
+#align free_monoid.countp FreeMonoid.countp
+
+theorem countp_of' (x : α) :
+    countp p (of x) = if p x then Multiplicative.ofAdd 1 else Multiplicative.ofAdd 0 :=
+  rfl
+#align free_monoid.countp_of' FreeMonoid.countp_of'
+
+theorem countp_of (x : α) : countp p (of x) = if p x then Multiplicative.ofAdd 1 else 1 := by
+  rw [countp_of', ofAdd_zero]
+#align free_monoid.countp_of FreeMonoid.countp_of
+
+-- `rfl` is not transitive
+theorem countp_apply (l : FreeAddMonoid α) : countp p l = Multiplicative.ofAdd (List.countp p l) :=
+  rfl
+#align free_monoid.countp_apply FreeMonoid.countp_apply
+
+/-- `list.count` as a bundled additive monoid homomorphism. -/
+def count [DecidableEq α] (x : α) : FreeMonoid α →* Multiplicative ℕ :=
+  countp (Eq x)
+#align free_monoid.count FreeMonoid.count
+
+theorem count_apply [DecidableEq α] (x : α) (l : FreeAddMonoid α) :
+    count x l = Multiplicative.ofAdd (List.count x l) :=
+  rfl
+#align free_monoid.count_apply FreeMonoid.count_apply
+
+theorem count_of [DecidableEq α] (x y : α) :
+    count x (of y) = @Pi.mulSingle α (fun _ => Multiplicative ℕ) _ _ x (Multiplicative.ofAdd 1) y :=
+  by simp only [count, countp_of, Pi.mulSingle_apply, eq_comm]
+#align free_monoid.count_of FreeMonoid.count_of
+
+end FreeMonoid
+

--- a/Mathlib/Algebra/FreeMonoid/Count.lean
+++ b/Mathlib/Algebra/FreeMonoid/Count.lean
@@ -8,8 +8,8 @@ Authors: Yury Kudryashov
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
-import Mathbin.Algebra.FreeMonoid.Basic
-import Mathbin.Data.List.Count
+import Mathlib.Algebra.FreeMonoid.Basic
+import Mathlib.Data.List.Count
 
 /-!
 # `list.count` as a bundled homomorphism

--- a/Mathlib/Algebra/FreeMonoid/Count.lean
+++ b/Mathlib/Algebra/FreeMonoid/Count.lean
@@ -21,32 +21,35 @@ additive homomorphisms from `FreeMonoid` and `FreeAddMonoid`.
 We do not use `to_additive` because it can't map `multiplicative ℕ` to `ℕ`.
 -/
 
-variable {α : Type _} (p : α → Bool) -- [DecidablePred p]
+variable {α : Type _} (p : α → Prop) [DecidablePred p]
 
 namespace FreeAddMonoid
 
 /-- `List.countp` as a bundled additive monoid homomorphism. -/
--- Porting note: change the type of p : α → Prop to p : α → Bool to match the change in List.countp
+-- Porting note: changed the type of `p : α → Prop` to `p : α → Bool` to match the
+-- change in `List.countp`
 def countp (p : α → Bool): FreeAddMonoid α →+ ℕ where
   toFun := List.countp p
   map_zero' := List.countp_nil p
   map_add' := List.countp_append p
 #align free_add_monoid.countp FreeAddMonoid.countp
 
--- Porting note: TODO: fix this proof (not true by defeq anymore)
-theorem countp_of (x : α): countp p (of x) = if p x then 1 else 0 := sorry -- rfl
+theorem countp_of (x : α): countp p (of x) = if p x = true then 1 else 0 := by
+  simp [countp, List.countp, List.countp.go]
 #align free_add_monoid.countp_of FreeAddMonoid.countp_of
 
 theorem countp_apply (l : FreeAddMonoid α) : countp p l = List.countp p l := rfl
 #align free_add_monoid.countp_apply FreeAddMonoid.countp_apply
 
 /-- `List.count` as a bundled additive monoid homomorphism. -/
-def count [DecidableEq α] (x : α) : FreeAddMonoid α →+ ℕ := countp (Eq x)
+-- Porting note: changed from `countp (Eq x)` to match the definition of `List.count` and thus
+-- we can prove `count_apply` by `rfl`
+def count [DecidableEq α] (x : α) : FreeAddMonoid α →+ ℕ := countp (· == x)
 #align free_add_monoid.count FreeAddMonoid.count
 
 theorem count_of [DecidableEq α] (x y : α) : count x (of y) = (Pi.single x 1 : α → ℕ) y := by
-  simp only [count, countp_of, Pi.single_apply, eq_comm]
-
+  simp [Pi.single, Function.update, count, countp, List.countp, List.countp.go,
+    Bool.beq_eq_decide_eq]
 #align free_add_monoid.count_of FreeAddMonoid.count_of
 
 theorem count_apply [DecidableEq α] (x : α) (l : FreeAddMonoid α) : count x l = List.count x l :=
@@ -58,16 +61,21 @@ end FreeAddMonoid
 namespace FreeMonoid
 
 /-- `list.countp` as a bundled multiplicative monoid homomorphism. -/
-def countp (p : α → Prop) [DecidablePred p] : FreeMonoid α →* Multiplicative ℕ :=
-  (FreeAddMonoid.countp p).toMultiplicative
+-- Porting note: changed the type of `p : α → Prop` to `p : α → Bool` to match the
+-- definition of `FreeAddMonoid.countp`
+def countp (p : α → Bool): FreeMonoid α →* Multiplicative ℕ :=
+    AddMonoidHom.toMultiplicative (FreeAddMonoid.countp p)
 #align free_monoid.countp FreeMonoid.countp
 
-theorem countp_of' (x : α) :
-    countp p (of x) = if p x then Multiplicative.ofAdd 1 else Multiplicative.ofAdd 0 :=
-  rfl
+-- Porting note: changed the type of `p : α → Prop` to `p : α → Bool` and `if` to `bif`
+theorem countp_of' (x : α) (p : α → Bool):
+    countp p (of x) = bif p x then Multiplicative.ofAdd 1 else Multiplicative.ofAdd 0 := by
+    simp [countp]
+    exact AddMonoidHom.toMultiplicative_apply_apply (FreeAddMonoid.countp p) (of x)
 #align free_monoid.countp_of' FreeMonoid.countp_of'
 
-theorem countp_of (x : α) : countp p (of x) = if p x then Multiplicative.ofAdd 1 else 1 := by
+-- Porting note: changed `if` to `bif`
+theorem countp_of (x : α) : countp p (of x) = bif p x then Multiplicative.ofAdd 1 else 1 := by
   rw [countp_of', ofAdd_zero]
 #align free_monoid.countp_of FreeMonoid.countp_of
 
@@ -76,19 +84,17 @@ theorem countp_apply (l : FreeAddMonoid α) : countp p l = Multiplicative.ofAdd 
   rfl
 #align free_monoid.countp_apply FreeMonoid.countp_apply
 
-/-- `list.count` as a bundled additive monoid homomorphism. -/
-def count [DecidableEq α] (x : α) : FreeMonoid α →* Multiplicative ℕ :=
-  countp (Eq x)
+/-- `List.count` as a bundled additive monoid homomorphism. -/
+def count [DecidableEq α] (x : α) : FreeMonoid α →* Multiplicative ℕ := countp (· == x)
 #align free_monoid.count FreeMonoid.count
 
 theorem count_apply [DecidableEq α] (x : α) (l : FreeAddMonoid α) :
-    count x l = Multiplicative.ofAdd (List.count x l) :=
-  rfl
+    count x l = Multiplicative.ofAdd (List.count x l) := rfl
 #align free_monoid.count_apply FreeMonoid.count_apply
 
 theorem count_of [DecidableEq α] (x y : α) :
     count x (of y) = @Pi.mulSingle α (fun _ => Multiplicative ℕ) _ _ x (Multiplicative.ofAdd 1) y :=
-  by simp only [count, countp_of, Pi.mulSingle_apply, eq_comm]
+  by simp [count, countp_of, Pi.mulSingle_apply, eq_comm, Bool.beq_eq_decide_eq]
 #align free_monoid.count_of FreeMonoid.count_of
 
 end FreeMonoid

--- a/Mathlib/Algebra/FreeMonoid/Count.lean
+++ b/Mathlib/Algebra/FreeMonoid/Count.lean
@@ -12,40 +12,41 @@ import Mathlib.Algebra.FreeMonoid.Basic
 import Mathlib.Data.List.Count
 
 /-!
-# `list.count` as a bundled homomorphism
+# `List.count` as a bundled homomorphism
 
-In this file we define `free_monoid.countp`, `free_monoid.count`, `free_add_monoid.countp`, and
-`free_add_monoid.count`. These are `list.countp` and `list.count` bundled as multiplicative and
-additive homomorphisms from `free_monoid` and `free_add_monoid`.
+In this file we define `FreeMonoid.countp`, `FreeMonoid.count`, `FreeAddMonoid.countp`, and
+`FreeAddMonoid.count`. These are `List.countp` and `List.count` bundled as multiplicative and
+additive homomorphisms from `FreeMonoid` and `FreeAddMonoid`.
 
 We do not use `to_additive` because it can't map `multiplicative ℕ` to `ℕ`.
 -/
 
-
-variable {α : Type _} (p : α → Prop) [DecidablePred p]
+variable {α : Type _} (p : α → Bool) -- [DecidablePred p]
 
 namespace FreeAddMonoid
 
-/-- `list.countp` as a bundled additive monoid homomorphism. -/
-def countp (p : α → Prop) [DecidablePred p] : FreeAddMonoid α →+ ℕ :=
-  ⟨List.countp p, List.countp_nil p, List.countp_append _⟩
+/-- `List.countp` as a bundled additive monoid homomorphism. -/
+-- Porting note: change the type of p : α → Prop to p : α → Bool to match the change in List.countp
+def countp (p : α → Bool): FreeAddMonoid α →+ ℕ where
+  toFun := List.countp p
+  map_zero' := List.countp_nil p
+  map_add' := List.countp_append p
 #align free_add_monoid.countp FreeAddMonoid.countp
 
-theorem countp_of (x : α) : countp p (of x) = if p x then 1 else 0 :=
-  rfl
+-- Porting note: TODO: fix this proof (not true by defeq anymore)
+theorem countp_of (x : α): countp p (of x) = if p x then 1 else 0 := sorry -- rfl
 #align free_add_monoid.countp_of FreeAddMonoid.countp_of
 
-theorem countp_apply (l : FreeAddMonoid α) : countp p l = List.countp p l :=
-  rfl
+theorem countp_apply (l : FreeAddMonoid α) : countp p l = List.countp p l := rfl
 #align free_add_monoid.countp_apply FreeAddMonoid.countp_apply
 
-/-- `list.count` as a bundled additive monoid homomorphism. -/
-def count [DecidableEq α] (x : α) : FreeAddMonoid α →+ ℕ :=
-  countp (Eq x)
+/-- `List.count` as a bundled additive monoid homomorphism. -/
+def count [DecidableEq α] (x : α) : FreeAddMonoid α →+ ℕ := countp (Eq x)
 #align free_add_monoid.count FreeAddMonoid.count
 
-theorem count_of [DecidableEq α] (x y : α) : count x (of y) = Pi.single x 1 y := by
+theorem count_of [DecidableEq α] (x y : α) : count x (of y) = (Pi.single x 1 : α → ℕ) y := by
   simp only [count, countp_of, Pi.single_apply, eq_comm]
+
 #align free_add_monoid.count_of FreeAddMonoid.count_of
 
 theorem count_apply [DecidableEq α] (x : α) (l : FreeAddMonoid α) : count x l = List.count x l :=
@@ -91,4 +92,3 @@ theorem count_of [DecidableEq α] (x y : α) :
 #align free_monoid.count_of FreeMonoid.count_of
 
 end FreeMonoid
-


### PR DESCRIPTION
It necessary to use `Bool` instead of `Prop` to match the changes made in `List.countp` so I add to change some `if` to `bif` at  a couple of places. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
