### PR TITLE
[Merged by Bors] - fix: add default_instance attribute to instHSMul and instHVAdd

### DIFF
--- a/Mathlib/Algebra/Group/Defs.lean
+++ b/Mathlib/Algebra/Group/Defs.lean
@@ -79,9 +79,7 @@ class SMul (M : Type _) (α : Type _) where
   smul : M → α → α
 #align has_smul SMul
 
-instance instHVAdd [VAdd α β] : HVAdd α β β where
-  hVAdd := VAdd.vadd
-
+@[to_additive (attr := default_instance)]
 instance instHSMul [SMul α β] : HSMul α β β where
   hSMul := SMul.smul
 
@@ -89,7 +87,7 @@ infixl:65 " +ᵥ " => HVAdd.hVAdd
 infixl:65 " -ᵥ " => VSub.vsub
 infixr:73 " • " => HSMul.hSMul
 
-attribute [to_additive] Mul Div HMul instHMul HDiv instHDiv instHSMul HSMul
+attribute [to_additive] Mul Div HMul instHMul HDiv instHDiv HSMul
 attribute [to_additive (reorder := 1)] Pow instHPow HPow
 attribute [to_additive (reorder := 1 5)] HPow.hPow
 attribute [to_additive (reorder := 1 4)] Pow.pow

--- a/Mathlib/Algebra/Group/Defs.lean
+++ b/Mathlib/Algebra/Group/Defs.lean
@@ -79,18 +79,20 @@ class SMul (M : Type _) (α : Type _) where
   smul : M → α → α
 #align has_smul SMul
 
-@[to_additive (attr := default_instance)]
-instance instHSMul [SMul α β] : HSMul α β β where
-  hSMul := SMul.smul
-
 infixl:65 " +ᵥ " => HVAdd.hVAdd
 infixl:65 " -ᵥ " => VSub.vsub
 infixr:73 " • " => HSMul.hSMul
 
 attribute [to_additive] Mul Div HMul instHMul HDiv instHDiv HSMul
-attribute [to_additive (reorder := 1)] Pow instHPow HPow
+attribute [to_additive (reorder := 1)] Pow HPow
 attribute [to_additive (reorder := 1 5)] HPow.hPow
 attribute [to_additive (reorder := 1 4)] Pow.pow
+
+@[to_additive (attr := default_instance)]
+instance instHSMul [SMul α β] : HSMul α β β where
+  hSMul := SMul.smul
+
+attribute [to_additive (reorder := 1)] instHPow
 
 universe u
 


### PR DESCRIPTION
Fixes issue in https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Heterogeneous.20scalar.20multiplication

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
