### PR TITLE
[Merged by Bors] - Change notation precedence in Quiver/Basic

### DIFF
--- a/Mathlib/Combinatorics/Quiver/Basic.lean
+++ b/Mathlib/Combinatorics/Quiver/Basic.lean
@@ -5,7 +5,7 @@ Authors: David Wärn, Scott Morrison
 Ported by: Scott Morrison
 
 ! This file was ported from Lean 3 source module combinatorics.quiver.basic
-! leanprover-community/mathlib commit 18a5306c091183ac90884daa9373fa3b178e8607
+! leanprover-community/mathlib commit 56adee5b5eef9e734d82272918300fca4f3e7cef
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/

--- a/Mathlib/Combinatorics/Quiver/Basic.lean
+++ b/Mathlib/Combinatorics/Quiver/Basic.lean
@@ -121,7 +121,7 @@ theorem comp_assoc {U V W Z : Type _} [Quiver U] [Quiver V] [Quiver W] [Quiver Z
 infixl:50 " ⥤q " => Prefunctor
 
 /-- Notation for composition of prefunctors. -/
-infixl:50 " ⋙q " => Prefunctor.comp
+infixl:60 " ⋙q " => Prefunctor.comp
 
 /-- Notation for the identity prefunctor on a quiver. -/
 notation "𝟭q" => id


### PR DESCRIPTION
This matches the corresponding change in the mathlib3 PR  #17846

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
