### PR TITLE
[Merged by Bors] - chore: use Nat.cast instead of ofNat when argument is not a literal

### DIFF
--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -2471,7 +2471,7 @@ end PredAbove
 
 /-- `min n m` as an element of `Fin (m + 1)` -/
 def clamp (n m : ℕ) : Fin (m + 1) :=
-  OfNat.ofNat <| min n m
+  Nat.cast <| min n m
 #align fin.clamp Fin.clamp
 
 @[simp]


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
