### PR TITLE
[Merged by Bors] - fix: unremove `Repr (Cauchy abv)`

### DIFF
--- a/Mathlib/Data/Real/CauSeqCompletion.lean
+++ b/Mathlib/Data/Real/CauSeqCompletion.lean
@@ -279,17 +279,16 @@ theorem ofRat_div (x y : β) : ofRat (x / y) = (ofRat x / ofRat y : Cauchy abv) 
   simp only [div_eq_mul_inv, ofRat_inv, ofRat_mul]
 #align cau_seq.completion.of_rat_div CauSeq.Completion.ofRat_div
 
--- Porting note: removed
--- /-- Show the first 10 items of a representative of this equivalence class of cauchy sequences.
+/-- Show the first 10 items of a representative of this equivalence class of cauchy sequences.
 
--- The representative chosen is the one passed in the VM to `quot.mk`, so two cauchy sequences
--- converging to the same number may be printed differently.
--- -/
--- unsafe instance [Repr β] : Repr (Cauchy abv) where
---   reprPrec r _ :=
---     let N := 10
---     let seq := r.unquot
---     "(sorry /- " ++ Std.Format.joinSep ((List.range N).map <| repr ∘ seq) ", " ++ ", ... -/)"
+The representative chosen is the one passed in the VM to `quot.mk`, so two cauchy sequences
+converging to the same number may be printed differently.
+-/
+unsafe instance [Repr β] : Repr (Cauchy abv) where
+  reprPrec r _ :=
+    let N := 10
+    let seq := r.unquot
+    "(sorry /- " ++ Std.Format.joinSep ((List.range N).map <| repr ∘ seq) ", " ++ ", ... -/)"
 
 end
 


### PR DESCRIPTION
This unremoves a working instance from mathlib3

Partially reverts e839638eb69434da4cc84ab0c158f434ab544b7f

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
