### PR TITLE
[Merged by Bors] - refactor: use semi-implicit brackets for Set.HasSubset; dedup instances

### DIFF
--- a/Mathlib/Data/Set/Basic.lean
+++ b/Mathlib/Data/Set/Basic.lean
@@ -81,9 +81,6 @@ namespace Set
 
 variable {α : Type _} {s t : Set α}
 
-instance : LE (Set α) :=
-  ⟨(· ⊆ ·)⟩
-
 instance {α : Type _} : BooleanAlgebra (Set α) :=
   { (inferInstance : BooleanAlgebra (α → Prop)) with
     sup := (· ∪ ·),

--- a/Mathlib/Data/Set/Basic.lean
+++ b/Mathlib/Data/Set/Basic.lean
@@ -82,17 +82,14 @@ namespace Set
 variable {α : Type _} {s t : Set α}
 
 instance : LE (Set α) :=
-  ⟨fun s t => ∀ ⦃x⦄, x ∈ s → x ∈ t⟩
-
-instance : HasSubset (Set α) :=
-  ⟨(· ≤ ·)⟩
+  ⟨(· ⊆ ·)⟩
 
 instance {α : Type _} : BooleanAlgebra (Set α) :=
   { (inferInstance : BooleanAlgebra (α → Prop)) with
-    sup := fun s t => { x | x ∈ s ∨ x ∈ t },
+    sup := (· ∪ ·),
     le := (· ≤ ·),
     lt := fun s t => s ⊆ t ∧ ¬t ⊆ s,
-    inf := fun s t => { x | x ∈ s ∧ x ∈ t },
+    inf := (· ∩ ·),
     bot := ∅,
     compl := fun s => { x | x ∉ s },
     top := univ,
@@ -100,12 +97,6 @@ instance {α : Type _} : BooleanAlgebra (Set α) :=
 
 instance : HasSSubset (Set α) :=
   ⟨(· < ·)⟩
-
-instance : Union (Set α) :=
-  ⟨(· ⊔ ·)⟩
-
-instance : Inter (Set α) :=
-  ⟨(· ⊓ ·)⟩
 
 @[simp]
 theorem top_eq_univ : (⊤ : Set α) = univ :=
@@ -2103,7 +2094,7 @@ theorem powerset_inter (s t : Set α) : 𝒫(s ∩ t) = 𝒫 s ∩ 𝒫 t :=
 
 @[simp]
 theorem powerset_mono : 𝒫 s ⊆ 𝒫 t ↔ s ⊆ t :=
-  ⟨fun h => @h _ (fun h => h), fun h _ hu _ ha => h (hu ha)⟩
+  ⟨fun h => @h _ (fun _ h => h), fun h _ hu _ ha => h (hu ha)⟩
 #align set.powerset_mono Set.powerset_mono
 
 theorem monotone_powerset : Monotone (powerset : Set α → Set (Set α)) := fun _ _ => powerset_mono.2
@@ -2111,7 +2102,7 @@ theorem monotone_powerset : Monotone (powerset : Set α → Set (Set α)) := fun
 
 @[simp]
 theorem powerset_nonempty : (𝒫 s).Nonempty :=
-  ⟨∅, fun h => empty_subset s h⟩
+  ⟨∅, fun _ h => empty_subset s h⟩
 #align set.powerset_nonempty Set.powerset_nonempty
 
 @[simp]

--- a/Mathlib/Init/Set.lean
+++ b/Mathlib/Init/Set.lean
@@ -51,7 +51,7 @@ theorem ext {a b : Set α} (h : ∀ (x : α), x ∈ a ↔ x ∈ b) : a = b :=
 funext (fun x ↦ propext (h x))
 
 protected def Subset (s₁ s₂ : Set α) :=
-∀ {a}, a ∈ s₁ → a ∈ s₂
+∀ ⦃a⦄, a ∈ s₁ → a ∈ s₂
 
 instance : HasSubset (Set α) :=
 ⟨Set.Subset⟩

--- a/Mathlib/Init/Set.lean
+++ b/Mathlib/Init/Set.lean
@@ -53,8 +53,13 @@ funext (fun x ↦ propext (h x))
 protected def Subset (s₁ s₂ : Set α) :=
 ∀ ⦃a⦄, a ∈ s₁ → a ∈ s₂
 
+/-- Porting note: we introduce `≤` before `⊆` to help the unifier when applying lattice theorems
+to subset hypotheses. -/
+instance : LE (Set α) :=
+  ⟨Set.Subset⟩
+
 instance : HasSubset (Set α) :=
-⟨Set.Subset⟩
+  ⟨(· ≤ ·)⟩
 
 instance : EmptyCollection (Set α) :=
 ⟨λ _ => False⟩


### PR DESCRIPTION
Dan Velleman observed that both Mathlib.Init.Set and Mathlib.Data.Set.Basic have definitions of subset, intersection and union, and they are slightly different since in Init.Set the brackets were implicit and in Set.Basic they were semi-implicit. In this PR we make the situation consistent by moving the semi-implicit definition to Init.Set and removing the duplicate definitions from Set.Basic.

~~I don't have much time to do fixes in the coming two days;~~ Feel free to push to this branch!

Closes: #738

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
