### PR TITLE
[Merged by Bors] - Typo in Data.Rat.Sqrt

### DIFF
--- a/Mathlib/Data/Rat/Sqrt.lean
+++ b/Mathlib/Data/Rat/Sqrt.lean
@@ -15,7 +15,7 @@ import Mathlib.Data.Int.Sqrt
 /-!
 # Square root on rational numbers
 
-This file defines the square root function on rational numbers `rat.sqrt`
+This file defines the square root function on rational numbers `Rat.sqrt`
 and proves several theorems about it.
 
 -/


### PR DESCRIPTION
Just noticed a small typo from when I ported `Data.Rat.Sqrt`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
