### PR TITLE
[Merged by Bors] - Refactor: drop `List.repeat`

### DIFF
--- a/Mathlib/Algebra/BigOperators/Multiset/Basic.lean
+++ b/Mathlib/Algebra/BigOperators/Multiset/Basic.lean
@@ -116,11 +116,10 @@ theorem prod_nsmul (m : Multiset α) : ∀ n : ℕ, (n • m).prod = m.prod ^ n
   | n + 1 => by rw [add_nsmul, one_nsmul, pow_add, pow_one, prod_add, prod_nsmul m n]
 #align multiset.prod_nsmul Multiset.prod_nsmul
 
-set_option linter.deprecated false in
 @[to_additive (attr := simp)]
-theorem prod_repeat (a : α) (n : ℕ) : («repeat» a n).prod = a ^ n := by
-  simp [«repeat», replicate, List.prod_replicate]
-#align multiset.prod_repeat Multiset.prod_repeat
+theorem prod_replicate (n : ℕ) (a : α) : (replicate n a).prod = a ^ n := by
+  simp [replicate, List.prod_replicate]
+#align multiset.prod_replicate Multiset.prod_replicate
 
 @[to_additive]
 theorem prod_map_eq_pow_single [DecidableEq ι] (i : ι)
@@ -140,7 +139,7 @@ theorem prod_eq_pow_single [DecidableEq α] (a : α) (h : ∀ (a') (_ : a' ≠ a
 
 @[to_additive]
 theorem pow_count [DecidableEq α] (a : α) : a ^ s.count a = (s.filter (Eq a)).prod := by
-  rw [filter_eq, prod_repeat]
+  rw [filter_eq, prod_replicate]
 #align multiset.pow_count Multiset.pow_count
 
 @[to_additive]
@@ -174,7 +173,8 @@ theorem prod_hom_rel [CommMonoid β] (s : Multiset ι) {r : α → β → Prop} 
 #align multiset.prod_hom_rel Multiset.prod_hom_rel
 
 @[to_additive]
-theorem prod_map_one : prod (m.map fun _ => (1 : α)) = 1 := by rw [map_const', prod_repeat, one_pow]
+theorem prod_map_one : prod (m.map fun _ => (1 : α)) = 1 := by
+  rw [map_const', prod_replicate, one_pow]
 #align multiset.prod_map_one Multiset.prod_map_one
 
 @[to_additive (attr := simp)]
@@ -395,7 +395,7 @@ theorem prod_le_prod_map (f : α → α) (h : ∀ x, x ∈ s → x ≤ f x) : s.
 @[to_additive card_nsmul_le_sum]
 theorem pow_card_le_prod (h : ∀ x ∈ s, a ≤ x) : a ^ card s ≤ s.prod :=
   by
-  rw [← Multiset.prod_repeat, ← Multiset.map_const]
+  rw [← Multiset.prod_replicate, ← Multiset.map_const]
   exact prod_map_le_prod _ h
 #align multiset.pow_card_le_prod Multiset.pow_card_le_prod
 

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -460,8 +460,8 @@ theorem replicate_add (m n) (a : α) : replicate (m + n) a = replicate m a ++ re
   induction m <;> simp [*, zero_add, succ_add, replicate]
 #align list.replicate_add List.replicate_add
 
-theorem replicate_succ' (n) (a : α) : replicate (n + 1) a = replicate n a ++ [a] := by
-  rw [replicate_add, replicate_one]
+theorem replicate_succ' (n) (a : α) : replicate (n + 1) a = replicate n a ++ [a] :=
+  replicate_add n 1 a
 
 theorem replicate_subset_singleton (n) (a : α) : replicate n a ⊆ [a] := fun _ h =>
   mem_singleton.2 (eq_of_mem_replicate h)
@@ -484,7 +484,7 @@ theorem subset_singleton_iff {a : α} {L : List α} : L ⊆ [a] ↔ ∃ n, L = r
   induction n <;> [rfl, simp only [*, replicate, join, append_nil]]
 #align list.join_replicate_nil List.join_replicate_nil
 
-theorem replicate_right_injective {n : ℕ} (hn : n ≠ 0) : Injective (@replicate α n ·) :=
+theorem replicate_right_injective {n : ℕ} (hn : n ≠ 0) : Injective (@replicate α n) :=
   fun _ _ h => (eq_replicate.1 h).2 _ <| mem_replicate.2 ⟨hn, rfl⟩
 #align list.replicate_right_injective List.replicate_right_injective
 
@@ -780,7 +780,7 @@ theorem getLast_mem : ∀ {l : List α} (h : l ≠ []), getLast l h ∈ l
         exact getLast_mem (cons_ne_nil b l)
 #align list.last_mem List.getLast_mem
 
-theorem getLast_replicate_succ (m a : ℕ) :
+theorem getLast_replicate_succ (m : ℕ) (a : α) :
     (replicate (m + 1) a).getLast (ne_nil_of_length_eq_succ (length_replicate _ _)) = a := by
   simp only [replicate_succ']
   exact getLast_append_singleton _

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -439,9 +439,13 @@ fun _ _ ↦ append_right_cancel
 /-! ### replicate -/
 
 attribute [simp] replicate_succ
+#align list.replicate_succ List.replicate_succ
 
 @[simp] lemma replicate_zero (a : α) : replicate 0 a = [] := rfl
+#align list.replicate_zero List.replicate_zero
+
 lemma replicate_one (a : α) : replicate 1 a = [a] := rfl
+#align list.replicate_one List.replicate_one
 
 theorem eq_replicate_length {a : α} : ∀ {l : List α}, l = replicate l.length a ↔ ∀ b ∈ l, b = a
   | [] => by simp
@@ -462,6 +466,7 @@ theorem replicate_add (m n) (a : α) : replicate (m + n) a = replicate m a ++ re
 
 theorem replicate_succ' (n) (a : α) : replicate (n + 1) a = replicate n a ++ [a] :=
   replicate_add n 1 a
+#align list.replicate_succ' List.replicate_succ'
 
 theorem replicate_subset_singleton (n) (a : α) : replicate n a ⊆ [a] := fun _ h =>
   mem_singleton.2 (eq_of_mem_replicate h)
@@ -1941,6 +1946,7 @@ theorem map_eq_replicate_iff {l : List α} {f : α → β} {b : β} :
 
 @[simp] theorem map_const' (l : List α) (b : β) : map (fun _ => b) l = replicate l.length b :=
   map_const l b
+#align list.map_const' List.map_const'
 
 theorem eq_of_mem_map_const {b₁ b₂ : β} {l : List α} (h : b₁ ∈ map (const α b₂) l) :
     b₁ = b₂ := by rw [map_const] at h; exact eq_of_mem_replicate h

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -436,163 +436,76 @@ fun _ _ ↦ append_right_cancel
 
 #align list.map_eq_append_split List.map_eq_append_split
 
--- porting note: TODO: #align list.repeat List.replicate & theorems below?
-/-! ### repeat -/
+/-! ### replicate -/
 
 attribute [simp] replicate_succ
 
-theorem eq_replicate_of_mem {a : α} :
-    ∀ {l : List α}, (∀ b ∈ l, b = a) → l = List.replicate l.length a
-  | [], _ => rfl
-  | b :: l, H => by
-    rw [length_cons, List.replicate]
-    cases' forall_mem_cons.1 H with H₁ H₂
-    conv_lhs => rw [H₁, eq_replicate_of_mem H₂]
+@[simp] lemma replicate_zero (a : α) : replicate 0 a = [] := rfl
+lemma replicate_one (a : α) : replicate 1 a = [a] := rfl
 
-theorem eq_replicate' {a : α} {l : List α} : l = List.replicate l.length a ↔ ∀ b ∈ l, b = a :=
-  ⟨fun h => h.symm ▸ fun _ => eq_of_mem_replicate, eq_replicate_of_mem⟩
+theorem eq_replicate_length {a : α} : ∀ {l : List α}, l = replicate l.length a ↔ ∀ b ∈ l, b = a
+  | [] => by simp
+  | (b :: l) => by simp [eq_replicate_length]
+#align list.eq_replicate_length List.eq_replicate_length
 
-theorem eq_replicate {a : α} {n} {l : List α} :
-    l = List.replicate n a ↔ length l = n ∧ ∀ b ∈ l, b = a :=
+alias eq_replicate_length ↔ _ eq_replicate_of_mem
+#align list.eq_replicate_of_mem List.eq_replicate_of_mem
+
+theorem eq_replicate {a : α} {n} {l} : l = replicate n a ↔ length l = n ∧ ∀ b ∈ l, b = a :=
   ⟨fun h => h.symm ▸ ⟨length_replicate _ _, fun _ => eq_of_mem_replicate⟩, fun ⟨e, al⟩ =>
     e ▸ eq_replicate_of_mem al⟩
+#align list.eq_replicate List.eq_replicate
 
-theorem replicate_add (a : α) (m n) :
-    List.replicate (m + n) a = List.replicate m a ++ List.replicate n a := by
-  induction m <;> simp [*, zero_add, succ_add, List.replicate]
+theorem replicate_add (m n) (a : α) : replicate (m + n) a = replicate m a ++ replicate n a := by
+  induction m <;> simp [*, zero_add, succ_add, replicate]
+#align list.replicate_add List.replicate_add
 
-theorem replicate_subset_singleton (a : α) (n) : List.replicate n a ⊆ [a] := fun _ h =>
+theorem replicate_succ' (n) (a : α) : replicate (n + 1) a = replicate n a ++ [a] := by
+  rw [replicate_add, replicate_one]
+
+theorem replicate_subset_singleton (n) (a : α) : replicate n a ⊆ [a] := fun _ h =>
   mem_singleton.2 (eq_of_mem_replicate h)
+#align list.replicate_subset_singleton List.replicate_subset_singleton
 
-theorem subset_singleton_iff {a : α} : ∀ L : List α, L ⊆ [a] ↔ ∃ n, L = List.replicate n a
-  | [] => ⟨fun _ => ⟨0, by simp⟩, by simp⟩
-  | h :: L => by
-    refine' ⟨fun h => _, fun ⟨k, hk⟩ => by simp [hk, replicate_subset_singleton]⟩
-    rw [cons_subset] at h
-    obtain ⟨n, rfl⟩ := (subset_singleton_iff L).mp h.2
-    exact ⟨n.succ, by simp [mem_singleton.mp h.1]⟩
-
-@[simp] theorem map_replicate (f : α → β) (a : α) (n) :
-    map f (List.replicate n a) = List.replicate n (f a) := by
-  induction n <;> [rfl, simp only [*, List.replicate, map]]
-
-@[simp] theorem tail_replicate (a : α) (n) :
-    tail (List.replicate n a) = List.replicate n.pred a := by cases n <;> rfl
-
-@[simp] theorem join_replicate_nil (n : ℕ) : join (List.replicate n []) = @nil α := by
-  induction n <;> [rfl, simp only [*, List.replicate, join, append_nil]]
-
-theorem replicate_left_injective {n : ℕ} (hn : n ≠ 0) :
-    Function.Injective (@List.replicate α n ·) :=
-  fun _ _ h => (eq_replicate.1 h).2 _ <| mem_replicate.2 ⟨hn, rfl⟩
-
-theorem replicate_left_inj {a b : α} {n : ℕ} (hn : n ≠ 0) :
-    List.replicate n a = List.replicate n b ↔ a = b :=
-  (replicate_left_injective hn).eq_iff
-
-@[simp] theorem replicate_left_inj' {a b : α} : ∀ {n},
-    List.replicate n a = List.replicate n b ↔ n = 0 ∨ a = b
-  | 0 => by simp
-  | n + 1 => (replicate_left_inj n.succ_ne_zero).trans <| by simp [n.succ_ne_zero, false_or_iff]
-
-theorem replicate_right_injective (a : α) : Function.Injective (List.replicate · a) :=
-  Function.LeftInverse.injective (length_replicate · a)
-
-@[simp]
-theorem replicate_right_inj {a : α} {n m : ℕ} :
-    List.replicate n a = List.replicate m a ↔ n = m :=
-  (replicate_right_injective a).eq_iff
-
-section deprecated
-set_option linter.deprecated false
-
--- Porting note: From Lean3 Core
-@[deprecated length_replicate]
-lemma length_repeat (a : α) (n : ℕ) : length (List.repeat a n) = n := length_replicate ..
-#align list.length_repeat List.length_repeat
-
-@[deprecated replicate_succ]
-theorem repeat_succ (a : α) (n) : List.repeat a (n + 1) = a :: List.repeat a n :=
-  rfl
-#align list.repeat_succ List.repeat_succ
-
-@[deprecated mem_replicate]
-theorem mem_repeat {a b : α} {n} : b ∈ List.repeat a n ↔ n ≠ 0 ∧ b = a := mem_replicate
-#align list.mem_repeat List.mem_repeat
-
-@[deprecated eq_of_mem_replicate]
-theorem eq_of_mem_repeat {a b : α} {n} (h : b ∈ List.repeat a n) : b = a := eq_of_mem_replicate h
-#align list.eq_of_mem_repeat List.eq_of_mem_repeat
-
-@[deprecated eq_replicate_of_mem]
-theorem eq_repeat_of_mem {a : α} {l : List α} : (∀ b ∈ l, b = a) → l = List.repeat a l.length :=
-  eq_replicate_of_mem
-#align list.eq_repeat_of_mem List.eq_repeat_of_mem
-
-@[deprecated eq_replicate']
-theorem eq_repeat' {a : α} {l : List α} : l = List.repeat a l.length ↔ ∀ b ∈ l, b = a :=
-  eq_replicate'
-#align list.eq_repeat' List.eq_repeat'
-
-@[deprecated eq_replicate]
-theorem eq_repeat {a : α} {n} {l : List α} : l = List.repeat a n ↔ length l = n ∧ ∀ b ∈ l, b = a :=
-  eq_replicate
-#align list.eq_repeat List.eq_repeat
-
-@[deprecated replicate_add]
-theorem repeat_add (a : α) (m n) : List.repeat a (m + n) = List.repeat a m ++ List.repeat a n :=
-  replicate_add ..
-#align list.repeat_add List.repeat_add
-
-@[deprecated replicate_subset_singleton]
-theorem repeat_subset_singleton (a : α) (n) : List.repeat a n ⊆ [a] :=
-  replicate_subset_singleton ..
-#align list.repeat_subset_singleton List.repeat_subset_singleton
-
+theorem subset_singleton_iff {a : α} {L : List α} : L ⊆ [a] ↔ ∃ n, L = replicate n a := by
+  simp only [eq_replicate, subset_def, mem_singleton, exists_eq_left']
 #align list.subset_singleton_iff List.subset_singleton_iff
 
-@[deprecated map_replicate]
-theorem map_repeat (f : α → β) (a : α) (n) : map f (List.repeat a n) = List.repeat (f a) n :=
-  map_replicate ..
-#align list.map_repeat List.map_repeat
+@[simp] theorem map_replicate (f : α → β) (n) (a : α) :
+    map f (replicate n a) = replicate n (f a) := by
+  induction n <;> [rfl, simp only [*, replicate, map]]
+#align list.map_replicate List.map_replicate
 
-@[deprecated tail_replicate]
-theorem tail_repeat (a : α) (n) : tail (List.repeat a n) = List.repeat a n.pred :=
-  tail_replicate ..
-#align list.tail_repeat List.tail_repeat
+@[simp] theorem tail_replicate (a : α) (n) :
+    tail (replicate n a) = replicate (n - 1) a := by cases n <;> rfl
+#align list.tail_replicate List.tail_replicate
 
-@[deprecated join_replicate_nil]
-theorem join_repeat_nil (n : ℕ) : join (List.repeat [] n) = @nil α :=
-  join_replicate_nil ..
-#align list.join_repeat_nil List.join_repeat_nil
+@[simp] theorem join_replicate_nil (n : ℕ) : join (replicate n []) = @nil α := by
+  induction n <;> [rfl, simp only [*, replicate, join, append_nil]]
+#align list.join_replicate_nil List.join_replicate_nil
 
-@[deprecated replicate_left_injective]
-theorem repeat_left_injective {n : ℕ} (hn : n ≠ 0) :
-    Function.Injective fun a : α => List.repeat a n := replicate_left_injective hn
-#align list.repeat_left_injective List.repeat_left_injective
+theorem replicate_right_injective {n : ℕ} (hn : n ≠ 0) : Injective (@replicate α n ·) :=
+  fun _ _ h => (eq_replicate.1 h).2 _ <| mem_replicate.2 ⟨hn, rfl⟩
+#align list.replicate_right_injective List.replicate_right_injective
 
-@[deprecated replicate_left_inj]
-theorem repeat_left_inj {a b : α} {n : ℕ} (hn : n ≠ 0) :
-    List.repeat a n = List.repeat b n ↔ a = b :=
-  replicate_left_inj hn
-#align list.repeat_left_inj List.repeat_left_inj
+theorem replicate_right_inj {a b : α} {n : ℕ} (hn : n ≠ 0) :
+    replicate n a = replicate n b ↔ a = b :=
+  (replicate_right_injective hn).eq_iff
+#align list.replicate_right_inj List.replicate_right_inj
 
-@[deprecated replicate_left_inj']
-theorem repeat_left_inj' {a b : α} {n} : List.repeat a n = List.repeat b n ↔ n = 0 ∨ a = b :=
-  replicate_left_inj'
-#align list.repeat_left_inj' List.repeat_left_inj'
+@[simp] theorem replicate_right_inj' {a b : α} : ∀ {n},
+    replicate n a = replicate n b ↔ n = 0 ∨ a = b
+  | 0 => by simp
+  | n + 1 => (replicate_right_inj n.succ_ne_zero).trans <| by simp only [n.succ_ne_zero, false_or]
+#align list.replicate_right_inj' List.replicate_right_inj'
 
-@[deprecated replicate_right_injective]
-theorem repeat_right_injective (a : α) : Function.Injective (List.repeat a) :=
-  replicate_right_injective ..
-#align list.repeat_right_injective List.repeat_right_injective
+theorem replicate_left_injective (a : α) : Injective (replicate · a) :=
+  LeftInverse.injective (length_replicate · a)
+#align list.replicate_left_injective List.replicate_left_injective
 
-@[deprecated replicate_right_inj]
-theorem repeat_right_inj {a : α} {n m : ℕ} : List.repeat a n = List.repeat a m ↔ n = m :=
-  replicate_right_inj ..
-#align list.repeat_right_inj List.repeat_right_inj
-
-end deprecated
+@[simp] theorem replicate_left_inj {a : α} {n m : ℕ} : replicate n a = replicate m a ↔ n = m :=
+  (replicate_left_injective a).eq_iff
+#align list.replicate_left_inj List.replicate_left_inj
 
 /-! ### pure -/
 
@@ -769,16 +682,11 @@ theorem mem_reverse' {a : α} {l : List α} : a ∈ reverse l ↔ a ∈ l :=
   List.mem_reverse _ _
 #align list.mem_reverse List.mem_reverse'
 
-@[simp] theorem reverse_replicate (n) (a : α) : reverse (List.replicate n a) = List.replicate n a :=
+@[simp] theorem reverse_replicate (n) (a : α) : reverse (replicate n a) = replicate n a :=
   eq_replicate.2
-    ⟨by simp only [length_reverse, length_replicate],
+    ⟨by rw [length_reverse, length_replicate],
      fun b h => eq_of_mem_replicate (mem_reverse'.1 h)⟩
-
-set_option linter.deprecated false in
-@[deprecated reverse_replicate]
-theorem reverse_repeat (a : α) (n) : reverse (List.repeat a n) = List.repeat a n :=
-  reverse_replicate ..
-#align list.reverse_repeat List.reverse_repeat
+#align list.reverse_replicate List.reverse_replicate
 
 /-! ### empty -/
 
@@ -873,19 +781,10 @@ theorem getLast_mem : ∀ {l : List α} (h : l ≠ []), getLast l h ∈ l
 #align list.last_mem List.getLast_mem
 
 theorem getLast_replicate_succ (m a : ℕ) :
-    (List.replicate m.succ a).getLast (ne_nil_of_length_eq_succ
-      (show (List.replicate m.succ a).length = m.succ by rw [length_replicate])) = a := by
-  induction' m with k IH
-  · simp
-  · simpa only [replicate_succ, getLast]
-
-set_option linter.deprecated false in
-@[deprecated getLast_replicate_succ]
-theorem getLast_repeat_succ (a m : ℕ) :
-    (List.repeat a m.succ).getLast (ne_nil_of_length_eq_succ
-      (show (List.repeat a m.succ).length = m.succ by rw [length_repeat])) = a :=
-  getLast_replicate_succ ..
-#align list.last_repeat_succ List.getLast_repeat_succ
+    (replicate (m + 1) a).getLast (ne_nil_of_length_eq_succ (length_replicate _ _)) = a := by
+  simp only [replicate_succ']
+  exact getLast_append_singleton _
+#align list.last_replicate_succ List.getLast_replicate_succ
 
 /-! ### getLast? -/
 
@@ -1219,28 +1118,18 @@ theorem sublist_nil_iff_eq_nil {l : List α} : l <+ [] ↔ l = [] :=
 
 @[simp]
 theorem replicate_sublist_replicate {m n} (a : α) :
-    List.replicate m a <+ List.replicate n a ↔ m ≤ n :=
+    replicate m a <+ replicate n a ↔ m ≤ n :=
   ⟨fun h => by simpa only [length_replicate] using h.length_le, fun h => by
     induction h <;> [rfl, simp only [*, replicate_succ, Sublist.cons]]⟩
-
-set_option linter.deprecated false in
-@[deprecated replicate_sublist_replicate]
-theorem repeat_sublist_repeat (a : α) {m n} : List.repeat a m <+ List.repeat a n ↔ m ≤ n :=
-  replicate_sublist_replicate _
-#align list.repeat_sublist_repeat List.repeat_sublist_repeat
+#align list.replicate_sublist_replicate List.replicate_sublist_replicate
 
 theorem sublist_replicate_iff {l : List α} {a : α} {n : ℕ} :
-    l <+ List.replicate n a ↔ ∃ k ≤ n, l = List.replicate k a :=
+    l <+ replicate n a ↔ ∃ k ≤ n, l = replicate k a :=
   ⟨fun h =>
-    ⟨l.length, h.length_le.trans (length_replicate _ _).le,
-      eq_replicate.mpr ⟨rfl, fun b hb => List.eq_of_mem_replicate (h.subset hb)⟩⟩,
+    ⟨l.length, h.length_le.trans_eq (length_replicate _ _),
+      eq_replicate_length.mpr fun b hb => eq_of_mem_replicate (h.subset hb)⟩,
     by rintro ⟨k, h, rfl⟩; exact (replicate_sublist_replicate _).mpr h⟩
-
-set_option linter.deprecated false in
-@[deprecated sublist_replicate_iff]
-theorem sublist_repeat_iff {l : List α} {a : α} {n : ℕ} :
-    l <+ List.repeat a n ↔ ∃ k ≤ n, l = List.repeat a k := sublist_replicate_iff
-#align list.sublist_repeat_iff List.sublist_repeat_iff
+#align list.sublist_replicate_iff List.sublist_replicate_iff
 
 theorem Sublist.eq_of_length : ∀ {l₁ l₂ : List α}, l₁ <+ l₂ → length l₁ = length l₂ → l₁ = l₂
   | _, _, Sublist.slnil, _ => rfl
@@ -1502,9 +1391,9 @@ theorem nthLe_append_right {l₁ l₂ : List α} {n : ℕ} (h₁ : l₁.length �
 #align list.nth_le_append_right List.nthLe_append_right
 
 @[deprecated get_replicate]
-theorem nthLe_repeat (a : α) {n m : ℕ} (h : m < (List.repeat a n).length) :
-    (List.repeat a n).nthLe m h = a := get_replicate ..
-#align list.nth_le_repeat List.nthLe_repeat
+theorem nthLe_replicate (a : α) {n m : ℕ} (h : m < (replicate n a).length) :
+    (replicate n a).nthLe m h = a := get_replicate ..
+#align list.nth_le_replicate List.nthLe_replicate
 
 #align list.nth_append List.get?_append
 #align list.nth_append_right List.get?_append_right
@@ -2042,32 +1931,18 @@ theorem getLast_map (f : α → β) {l : List α} (hl : l ≠ []) :
 #align list.last_map List.getLast_map
 
 theorem map_eq_replicate_iff {l : List α} {f : α → β} {b : β} :
-    l.map f = List.replicate l.length b ↔ ∀ x ∈ l, f x = b := by
-  induction' l with x l' ih
-  · simp only [List.replicate, length, not_mem_nil, IsEmpty.forall_iff, imp_true_iff, map_nil,
-      eq_self_iff_true]
-  · simp only [map, List.replicate, add_eq, add_zero, cons.injEq, mem_cons,
-      forall_eq_or_imp, and_congr_right_iff]
-    exact fun _ => ih
+    l.map f = replicate l.length b ↔ ∀ x ∈ l, f x = b := by
+  simp [eq_replicate]
+#align list.map_eq_replicate_iff List.map_eq_replicate_iff
 
-set_option linter.deprecated false in
-@[deprecated map_eq_replicate_iff]
-theorem map_eq_repeat_iff {l : List α} {f : α → β} {b : β} :
-    l.map f = List.repeat b l.length ↔ ∀ x ∈ l, f x = b :=
-  map_eq_replicate_iff
-#align list.map_eq_repeat_iff List.map_eq_repeat_iff
-
-@[simp]
-theorem map_const (l : List α) (b : β) : map (Function.const α b) l = List.replicate l.length b :=
+@[simp] theorem map_const (l : List α) (b : β) : map (const α b) l = replicate l.length b :=
   map_eq_replicate_iff.mpr fun _ _ => rfl
+#align list.map_const List.map_const
 
-set_option linter.deprecated false in
-@[deprecated map_const]
-theorem map_const' (l : List α) (b : β) : map (Function.const α b) l = List.repeat b l.length :=
-  map_eq_replicate_iff.mpr fun _ _ => rfl
-#align list.map_const List.map_const'
+@[simp] theorem map_const' (l : List α) (b : β) : map (fun _ => b) l = replicate l.length b :=
+  map_const l b
 
-theorem eq_of_mem_map_const {b₁ b₂ : β} {l : List α} (h : b₁ ∈ map (Function.const α b₂) l) :
+theorem eq_of_mem_map_const {b₁ b₂ : β} {l : List α} (h : b₁ ∈ map (const α b₂) l) :
     b₁ = b₂ := by rw [map_const] at h; exact eq_of_mem_replicate h
 #align list.eq_of_mem_map_const List.eq_of_mem_map_const
 
@@ -2134,16 +2009,11 @@ theorem take_take : ∀ (n m) (l : List α), take n (take m l) = take (min n m) 
     simp only [take, min_succ_succ, take_take n m l]
 #align list.take_take List.take_take
 
-theorem take_replicate (a : α) : ∀ n m : ℕ, take n (List.replicate m a) = List.replicate (min n m) a
+theorem take_replicate (a : α) : ∀ n m : ℕ, take n (replicate m a) = replicate (min n m) a
   | n, 0 => by simp
   | 0, m => by simp
   | succ n, succ m => by simp [min_succ_succ, take_replicate]
-
-set_option linter.deprecated false in
-@[deprecated take_replicate]
-theorem take_repeat (a : α) (n m : ℕ) : take n (List.repeat a m) = List.repeat a (min n m) :=
-  take_replicate ..
-#align list.take_repeat List.take_repeat
+#align list.take_replicate List.take_replicate
 
 theorem map_take {α β : Type _} (f : α → β) :
     ∀ (L : List α) (i : ℕ), (L.take i).map f = (L.map f).take i
@@ -4874,7 +4744,7 @@ theorem getD_replicate_default_eq (r n : ℕ) : (replicate r d).getD n d = d := 
   induction' r with r IH generalizing n
   · simp
   · cases n <;> simp [IH]
-#align list.nthd_repeat_default_eq List.getD_replicate_default_eqₓ -- argument order
+#align list.nthd_replicate_default_eq List.getD_replicate_default_eqₓ -- argument order
 
 theorem getD_append (l l' : List α) (d : α) (n : ℕ) (h : n < l.length)
     (h' : n < (l ++ l').length := h.trans_le ((length_append l l').symm ▸ le_self_add)) :

--- a/Mathlib/Data/List/BigOperators/Basic.lean
+++ b/Mathlib/Data/List/BigOperators/Basic.lean
@@ -71,17 +71,12 @@ theorem prod_eq_foldr : ∀ {l : List M}, l.prod = foldr (· * ·) 1 l
 #align list.prod_eq_foldr List.prod_eq_foldr
 
 @[to_additive (attr := simp)]
-theorem prod_replicate (a : M) (n : ℕ) : (List.replicate n a).prod = a ^ n := by
+theorem prod_replicate (n : ℕ) (a : M) : (replicate n a).prod = a ^ n := by
   induction' n with n ih
   · rw [pow_zero]
     rfl
-  · rw [List.replicate_succ, List.prod_cons, ih, pow_succ]
-
-set_option linter.deprecated false in
-/-- Deprecated: use `List.prod_replicate` instead. -/
-@[to_additive (attr := deprecated) "Deprecated: use `List.sum_replicate` instead."]
-theorem prod_repeat (a : M) (n : ℕ) : (List.repeat a n).prod = a ^ n := by simp
-#align list.prod_repeat List.prod_repeat
+  · rw [replicate_succ, prod_cons, ih, pow_succ]
+#align list.prod_replicate List.prod_replicate
 
 @[to_additive sum_eq_card_nsmul]
 theorem prod_eq_pow_card (l : List M) (m : M) (h : ∀ x ∈ l, x = m) : l.prod = m ^ l.length := by
@@ -125,23 +120,9 @@ theorem prod_map_mul {α : Type _} [CommMonoid α] {l : List ι} {f g : ι → �
 
 @[simp]
 theorem prod_map_neg {α} [CommMonoid α] [HasDistribNeg α] (l : List α) :
-    (l.map Neg.neg).prod = (-1) ^ l.length * l.prod :=
-  by
-  convert @prod_map_mul α α _ l (fun _ => -1) id
-  · ext
-    rw [neg_one_mul]
-    rfl
-  · -- Porting note: proof used to be
-    -- convert (prod_repeat _ _).symm
-    -- rw [eq_repeat]
-    -- use l.length_map _
-    -- intro
-    -- rw [mem_map]
-    -- rintro ⟨_, _, rfl⟩
-    -- rfl
-    rw [prod_eq_pow_card _ (-1:α) _, length_map]
-    simp
-  · rw [map_id]
+    (l.map Neg.neg).prod = (-1) ^ l.length * l.prod := by
+  simpa only [id_eq, neg_mul, one_mul, map_const', prod_replicate, map_id]
+    using @prod_map_mul α α _ l (fun _ => -1) id
 #align list.prod_map_neg List.prod_map_neg
 
 @[to_additive]
@@ -326,16 +307,11 @@ theorem prod_lt_prod_of_ne_nil [Preorder M] [CovariantClass M M (· * ·) (· < 
     (exists_mem_of_ne_nil l hl).imp fun i hi => ⟨hi, hlt i hi⟩
 #align list.prod_lt_prod_of_ne_nil List.prod_lt_prod_of_ne_nil
 
-set_option linter.deprecated false in
 @[to_additive sum_le_card_nsmul]
 theorem prod_le_pow_card [Preorder M] [CovariantClass M M (Function.swap (· * ·)) (· ≤ ·)]
     [CovariantClass M M (· * ·) (· ≤ ·)] (l : List M) (n : M) (h : ∀ x ∈ l, x ≤ n) :
     l.prod ≤ n ^ l.length := by
-      -- Porting note: proof used to be
-      -- simpa only [map_id'', map_const, prod_repeat] using prod_le_prod' h
-      have := prod_le_prod' h
-      erw [map_id'', map_const', prod_repeat] at this
-      exact this
+      simpa only [map_id'', map_const', prod_replicate] using prod_le_prod' h
 #align list.prod_le_pow_card List.prod_le_pow_card
 
 @[to_additive exists_lt_of_sum_lt]
@@ -561,9 +537,9 @@ theorem prod_map_erase [DecidableEq ι] [CommMonoid M] (f : ι → M) {a} :
 #align list.prod_map_erase List.prod_map_erase
 
 -- Porting note: Should this not be `to_additive` of a multiplicative statement?
--- @[simp] -- Porting note: simp can prove this up to commutativity
-theorem sum_const_nat (m n : ℕ) : sum (List.replicate n m) = m * n := by
-  simp only [sum_replicate, smul_eq_mul, mul_comm]
+-- @[simp] -- Porting note: simp can prove this
+theorem sum_const_nat (m n : ℕ) : sum (replicate m n) = m * n :=
+  sum_replicate m n
 #align list.sum_const_nat List.sum_const_nat
 
 /-- The product of a list of positive natural numbers is positive,
@@ -584,8 +560,7 @@ If desired, we could add a class stating that `default = 0`.
 
 
 /-- This relies on `default ℕ = 0`. -/
-theorem headI_add_tail_sum (L : List ℕ) : L.headI + L.tail.sum = L.sum :=
-  by
+theorem headI_add_tail_sum (L : List ℕ) : L.headI + L.tail.sum = L.sum := by
   cases L
   · simp
   · simp

--- a/Mathlib/Data/List/BigOperators/Basic.lean
+++ b/Mathlib/Data/List/BigOperators/Basic.lean
@@ -536,8 +536,6 @@ theorem prod_map_erase [DecidableEq ι] [CommMonoid M] (f : ι → M) {a} :
         mul_left_comm (f a) (f b)]
 #align list.prod_map_erase List.prod_map_erase
 
--- Porting note: Should this not be `to_additive` of a multiplicative statement?
--- @[simp] -- Porting note: simp can prove this
 theorem sum_const_nat (m n : ℕ) : sum (replicate m n) = m * n :=
   sum_replicate m n
 #align list.sum_const_nat List.sum_const_nat

--- a/Mathlib/Data/List/Count.lean
+++ b/Mathlib/Data/List/Count.lean
@@ -167,7 +167,6 @@ end Countp
 
 /-! ### count -/
 
-
 section Count
 
 variable [DecidableEq α]
@@ -268,66 +267,42 @@ theorem count_eq_zero : count a l = 0 ↔ a ∉ l :=
 
 @[simp]
 theorem count_eq_length : count a l = l.length ↔ ∀ b ∈ l, a = b := by
-  rw [count, countp_eq_length]
-  refine ⟨fun h b hb => ?h₁, fun h b hb => ?h₂⟩
-  · refine' Eq.symm _
-    simpa using h b hb
-  · rw [h b hb, beq_self_eq_true]
+  simp_rw [count, countp_eq_length, beq_iff_eq, eq_comm]
 #align list.count_eq_length List.count_eq_length
 
 @[simp]
 theorem count_replicate_self (a : α) (n : ℕ) : count a (replicate n a) = n :=
   (count_eq_length.2 <| fun _ h => (eq_of_mem_replicate h).symm).trans (length_replicate _ _)
+#align list.count_replicate_self List.count_replicate_self
 
 theorem count_replicate (a b : α) (n : ℕ) : count a (replicate n b) = if a = b then n else 0 := by
   split
   exacts [‹a = b› ▸ count_replicate_self _ _, count_eq_zero.2 <| mt eq_of_mem_replicate ‹a ≠ b›]
+#align list.count_replicate List.count_replicate
+
+theorem filter_beq' (l : List α) (a : α) : l.filter (· == a) = replicate (count a l) a := by
+  simp only [count, countp_eq_length_filter, eq_replicate, mem_filter, beq_iff_eq]
+  exact ⟨trivial, fun _ h => h.2⟩
+
+theorem filter_eq' (l : List α) (a : α) : l.filter (· = a) = replicate (count a l) a :=
+  filter_beq' l a
+
+theorem filter_eq (l : List α) (a : α) : l.filter (a = ·) = replicate (count a l) a := by
+  simpa only [eq_comm] using filter_eq' l a
+
+theorem filter_beq (l : List α) (a : α) : l.filter (a == ·) = replicate (count a l) a :=
+  filter_eq l a
 
 theorem le_count_iff_replicate_sublist : n ≤ count a l ↔ replicate n a <+ l :=
-  ⟨fun h =>
-    ((replicate_sublist_replicate a).2 h).trans <| by
-      have : filter (Eq a) l = replicate (count a l) a := eq_replicate.2 ⟨?h₁, ?h₂⟩
-      rw [← this]
-      apply filter_sublist
-      · simp [count, countp_eq_length_filter, ← Bool.beq_eq_decide_eq, Bool.beq_comm]
-      · intro b hb
-        simpa [decide_eq_true_eq, eq_comm] using of_mem_filter hb,
+  ⟨fun h => ((replicate_sublist_replicate a).2 h).trans <| filter_eq l a ▸ filter_sublist _,
     fun h => by simpa only [count_replicate_self] using h.count_le a⟩
+#align list.le_count_iff_replicate_sublist List.le_count_iff_replicate_sublist
 
 theorem replicate_count_eq_of_count_eq_length (h : count a l = length l) :
     replicate (count a l) a = l :=
   (le_count_iff_replicate_sublist.mp le_rfl).eq_of_length <|
     (length_replicate (count a l) a).trans h
-
-section deprecated
-
-set_option linter.deprecated false
-
---Porting note: removed `simp`, `simp` can prove it using corresponding lemma about replicate
-@[deprecated count_replicate_self]
-theorem count_repeat_self (a : α) (n : ℕ) : count a (List.repeat a n) = n :=
-  count_replicate_self _ _
-#align list.count_repeat_self List.count_repeat_self
-
---Porting note: removed `simp`, `simp` can prove it using corresponding lemma about replicate
-@[deprecated count_replicate]
-theorem count_repeat (a b : α) (n : ℕ) : count a (List.repeat b n) = if a = b then n else 0 :=
-  count_replicate _ _ _
-#align list.count_repeat List.count_repeat
-
-@[deprecated le_count_iff_replicate_sublist]
-theorem le_count_iff_repeat_sublist {a : α} {l : List α} {n : ℕ} :
-    n ≤ count a l ↔ List.repeat a n <+ l :=
-  le_count_iff_replicate_sublist
-#align list.le_count_iff_repeat_sublist List.le_count_iff_repeat_sublist
-
-@[deprecated replicate_count_eq_of_count_eq_length]
-theorem repeat_count_eq_of_count_eq_length {a : α} {l : List α} (h : count a l = length l) :
-    List.repeat a (count a l) = l :=
-  replicate_count_eq_of_count_eq_length h
-#align list.repeat_count_eq_of_count_eq_length List.repeat_count_eq_of_count_eq_length
-
-end deprecated
+#align list.replicate_count_eq_of_count_eq_length List.replicate_count_eq_of_count_eq_length
 
 @[simp]
 theorem count_filter (h : p a) : count a (filter p l) = count a l := by

--- a/Mathlib/Data/List/Count.lean
+++ b/Mathlib/Data/List/Count.lean
@@ -280,16 +280,20 @@ theorem count_replicate (a b : α) (n : ℕ) : count a (replicate n b) = if a = 
   exacts [‹a = b› ▸ count_replicate_self _ _, count_eq_zero.2 <| mt eq_of_mem_replicate ‹a ≠ b›]
 #align list.count_replicate List.count_replicate
 
+-- porting note: new lemma
 theorem filter_beq' (l : List α) (a : α) : l.filter (· == a) = replicate (count a l) a := by
   simp only [count, countp_eq_length_filter, eq_replicate, mem_filter, beq_iff_eq]
   exact ⟨trivial, fun _ h => h.2⟩
 
 theorem filter_eq' (l : List α) (a : α) : l.filter (· = a) = replicate (count a l) a :=
   filter_beq' l a
+#align list.filter_eq' List.filter_eq'
 
 theorem filter_eq (l : List α) (a : α) : l.filter (a = ·) = replicate (count a l) a := by
   simpa only [eq_comm] using filter_eq' l a
+#align list.filter_eq List.filter_eq
 
+-- porting note: new lemma
 theorem filter_beq (l : List α) (a : α) : l.filter (a == ·) = replicate (count a l) a :=
   filter_eq l a
 

--- a/Mathlib/Data/List/Dedup.lean
+++ b/Mathlib/Data/List/Dedup.lean
@@ -106,12 +106,7 @@ theorem replicate_dedup {x : α} : ∀ {k}, k ≠ 0 → (replicate k x).dedup = 
   | n + 2, _ => by
     rw [replicate_succ, dedup_cons_of_mem (mem_replicate.2 ⟨n.succ_ne_zero, rfl⟩),
       replicate_dedup n.succ_ne_zero]
-
-set_option linter.deprecated false in
-@[deprecated replicate_dedup]
-theorem repeat_dedup {x : α} : ∀ {k}, k ≠ 0 → (List.repeat x k).dedup = [x] :=
-  replicate_dedup
-#align list.repeat_dedup List.repeat_dedup
+#align list.replicate_dedup List.replicate_dedup
 
 theorem count_dedup (l : List α) (a : α) : l.dedup.count a = if a ∈ l then 1 else 0 := by
   simp_rw [count_eq_of_nodup <| nodup_dedup l, mem_dedup]

--- a/Mathlib/Data/List/Nodup.lean
+++ b/Mathlib/Data/List/Nodup.lean
@@ -193,11 +193,7 @@ theorem nodup_replicate (a : α) : ∀ {n : ℕ}, Nodup (replicate n a) ↔ n �
     iff_of_false
       (fun H => nodup_iff_sublist.1 H a ((replicate_sublist_replicate _).2 (Nat.le_add_left 2 n)))
       (not_le_of_lt <| Nat.le_add_left 2 n)
-
-set_option linter.deprecated false in
-theorem nodup_repeat (a : α) : ∀ {n : ℕ}, Nodup (List.repeat a n) ↔ n ≤ 1 :=
-  nodup_replicate a
-#align list.nodup_repeat List.nodup_repeat
+#align list.nodup_replicate List.nodup_replicate
 
 @[simp]
 theorem count_eq_one_of_mem [DecidableEq α] {a : α} {l : List α} (d : Nodup l) (h : a ∈ l) :

--- a/Mathlib/Data/List/Pairwise.lean
+++ b/Mathlib/Data/List/Pairwise.lean
@@ -350,13 +350,7 @@ theorem pairwise_replicate {α : Type _} {r : α → α → Prop} {x : α} (hx :
   | 0 => by simp
   | n + 1 => by simp only [replicate, add_eq, add_zero, pairwise_cons, mem_replicate, ne_eq,
     and_imp, forall_eq_apply_imp_iff', hx, implies_true, pairwise_replicate hx n, and_self]
-
-set_option linter.deprecated false in
-@[deprecated pairwise_replicate]
-theorem pairwise_repeat {α : Type _} {r : α → α → Prop} {x : α} (hx : r x x) :
-    ∀ n : ℕ, Pairwise r (List.repeat x n) :=
-  List.pairwise_replicate hx
-#align list.pairwise_repeat List.pairwise_repeat
+#align list.pairwise_replicate List.pairwise_replicate
 
 /-! ### Pairwise filtering -/
 

--- a/Mathlib/Data/List/Perm.lean
+++ b/Mathlib/Data/List/Perm.lean
@@ -201,23 +201,13 @@ theorem perm_replicate {a : α} {n : ℕ} {l : List α} :
   ⟨fun p => eq_replicate.2
     ⟨p.length_eq.trans <| length_replicate _ _, fun _b m => eq_of_mem_replicate <| p.subset m⟩,
     fun h => h ▸ Perm.refl _⟩
-
-set_option linter.deprecated false in
-@[deprecated perm_replicate]
-theorem perm_repeat {a : α} {n : ℕ} {l : List α} : l ~ List.repeat a n ↔ l = List.repeat a n :=
-  perm_replicate
-#align list.perm_repeat List.perm_repeat
+#align list.perm_replicate List.perm_replicate
 
 @[simp]
 theorem replicate_perm {a : α} {n : ℕ} {l : List α} :
     List.replicate n a ~ l ↔ List.replicate n a = l :=
   (perm_comm.trans perm_replicate).trans eq_comm
-
-set_option linter.deprecated false in
-@[deprecated replicate_perm]
-theorem repeat_perm {a : α} {n : ℕ} {l : List α} : List.repeat a n ~ l ↔ List.repeat a n = l :=
-  replicate_perm
-#align list.repeat_perm List.repeat_perm
+#align list.replicate_perm List.replicate_perm
 
 @[simp]
 theorem perm_singleton {a : α} {l : List α} : l ~ [a] ↔ l = [a] :=

--- a/Mathlib/Data/List/Perm.lean
+++ b/Mathlib/Data/List/Perm.lean
@@ -196,27 +196,27 @@ theorem perm_cons_append_cons {l l₁ l₂ : List α} (a : α) (p : l ~ l₁ ++ 
 #align list.perm_cons_append_cons List.perm_cons_append_cons
 
 @[simp]
-theorem perm_replicate {a : α} {n : ℕ} {l : List α} :
-    l ~ List.replicate n a ↔ l = List.replicate n a :=
+theorem perm_replicate {n : ℕ} {a : α} {l : List α} :
+    l ~ replicate n a ↔ l = replicate n a :=
   ⟨fun p => eq_replicate.2
     ⟨p.length_eq.trans <| length_replicate _ _, fun _b m => eq_of_mem_replicate <| p.subset m⟩,
     fun h => h ▸ Perm.refl _⟩
 #align list.perm_replicate List.perm_replicate
 
 @[simp]
-theorem replicate_perm {a : α} {n : ℕ} {l : List α} :
-    List.replicate n a ~ l ↔ List.replicate n a = l :=
+theorem replicate_perm {n : ℕ} {a : α} {l : List α} :
+    replicate n a ~ l ↔ replicate n a = l :=
   (perm_comm.trans perm_replicate).trans eq_comm
 #align list.replicate_perm List.replicate_perm
 
 @[simp]
 theorem perm_singleton {a : α} {l : List α} : l ~ [a] ↔ l = [a] :=
-  @perm_replicate α a 1 l
+  @perm_replicate α 1 a l
 #align list.perm_singleton List.perm_singleton
 
 @[simp]
 theorem singleton_perm {a : α} {l : List α} : [a] ~ l ↔ [a] = l :=
-  @replicate_perm α a 1 l
+  @replicate_perm α 1 a l
 #align list.singleton_perm List.singleton_perm
 
 theorem Perm.eq_singleton {a : α} {l : List α} (p : l ~ [a]) : l = [a] :=

--- a/Mathlib/Data/Multiset/Basic.lean
+++ b/Mathlib/Data/Multiset/Basic.lean
@@ -1294,6 +1294,7 @@ theorem map_const (s : Multiset α) (b : β) : map (const α b) s = replicate (c
 
 @[simp] theorem map_const' (s : Multiset α) (b : β) : map (fun _ ↦ b) s = replicate (card s) b :=
   map_const _ _
+#align multiset.map_const' Multiset.map_const'
 
 theorem eq_of_mem_map_const {b₁ b₂ : β} {l : List α} (h : b₁ ∈ map (Function.const α b₂) l) :
     b₁ = b₂ :=

--- a/Mathlib/Data/Multiset/Basic.lean
+++ b/Mathlib/Data/Multiset/Basic.lean
@@ -881,7 +881,7 @@ instance is_wellFounded_lt : WellFoundedLT (Multiset α) :=
 def replicate (n : ℕ) (a : α) : Multiset α :=
   List.replicate n a
 
-theorem coe_replicate (a : α) (n : ℕ) : (List.replicate n a : Multiset α) = replicate n a := rfl
+theorem coe_replicate (n : ℕ) (a : α) : (List.replicate n a : Multiset α) = replicate n a := rfl
 #align multiset.coe_replicate Multiset.coe_replicate
 
 @[simp] theorem replicate_zero (a : α) : replicate 0 a = 0 := rfl
@@ -899,7 +899,7 @@ theorem replicate_add (m n : ℕ) (a : α) : replicate (m + n) a = replicate m a
 def replicateAddMonoidHom (a : α) : ℕ →+ Multiset α where
   toFun := fun n => replicate n a
   map_zero' := replicate_zero a
-  map_add' := fun _ _ =>replicate_add _ _ a
+  map_add' := fun _ _ => replicate_add _ _ a
 #align multiset.replicate_add_monoid_hom Multiset.replicateAddMonoidHom
 
 -- @[simp] -- Porting note: simp can prove this
@@ -919,7 +919,7 @@ theorem eq_of_mem_replicate {a b : α} {n} : b ∈ replicate n a → b = a :=
 #align multiset.eq_of_mem_replicate Multiset.eq_of_mem_replicate
 
 theorem eq_replicate_card {a : α} {s : Multiset α} : s = replicate (card s) a ↔ ∀ b ∈ s, b = a :=
-  Quot.inductionOn s fun _l => coe_eq_coe.trans <| perm_replicate.trans <| eq_replicate_length
+  Quot.inductionOn s fun _l => coe_eq_coe.trans <| perm_replicate.trans eq_replicate_length
 #align multiset.eq_replicate_card Multiset.eq_replicate_card
 
 alias eq_replicate_card ↔ _ eq_replicate_of_mem
@@ -927,8 +927,8 @@ alias eq_replicate_card ↔ _ eq_replicate_of_mem
 
 theorem eq_replicate {a : α} {n} {s : Multiset α} :
     s = replicate n a ↔ card s = n ∧ ∀ b ∈ s, b = a :=
-  ⟨fun h => h.symm ▸ ⟨card_replicate _ _, fun _b => eq_of_mem_replicate⟩, fun ⟨e, al⟩ =>
-    e ▸ eq_replicate_of_mem al⟩
+  ⟨fun h => h.symm ▸ ⟨card_replicate _ _, fun _b => eq_of_mem_replicate⟩,
+    fun ⟨e, al⟩ => e ▸ eq_replicate_of_mem al⟩
 #align multiset.eq_replicate Multiset.eq_replicate
 
 theorem replicate_right_injective {n : ℕ} (hn : n ≠ 0) : Injective (@replicate α n) :=
@@ -2459,7 +2459,7 @@ theorem count_sub (a : α) (s t : Multiset α) : count a (s - t) = count a s - c
   by
   revert s; refine' Multiset.induction_on t (by simp) fun b t IH s => _
   rw [sub_cons, IH]
-  rcases eq_or_ne a b with rfl | ab
+  rcases Decidable.eq_or_ne a b with rfl | ab
   · rw [count_erase_self, count_cons_self, Nat.sub_sub, add_comm]
   · rw [count_erase_of_ne ab, count_cons_of_ne ab]
 #align multiset.count_sub Multiset.count_sub
@@ -2578,7 +2578,7 @@ theorem filter_eq (s : Multiset α) (b : α) : s.filter (Eq b) = replicate (coun
 #align multiset.filter_eq Multiset.filter_eq
 
 @[simp]
-theorem replicate_inter (x : α) (n : ℕ) (s : Multiset α) :
+theorem replicate_inter (n : ℕ) (x : α) (s : Multiset α) :
     replicate n x ∩ s = replicate (min n (s.count x)) x := by
   ext y
   rw [count_inter, count_replicate, count_replicate]
@@ -2588,7 +2588,7 @@ theorem replicate_inter (x : α) (n : ℕ) (s : Multiset α) :
 #align multiset.replicate_inter Multiset.replicate_inter
 
 @[simp]
-theorem inter_replicate (s : Multiset α) (x : α) (n : ℕ) :
+theorem inter_replicate (s : Multiset α) (n : ℕ) (x : α) :
     s ∩ replicate n x = replicate (min (s.count x) n) x := by
   rw [inter_comm, replicate_inter, min_comm]
 #align multiset.inter_replicate Multiset.inter_replicate

--- a/Mathlib/Data/Multiset/Basic.lean
+++ b/Mathlib/Data/Multiset/Basic.lean
@@ -19,7 +19,7 @@ These are implemented as the quotient of a list by permutations.
 We define the global infix notation `::ₘ` for `Multiset.cons`.
 -/
 
-open List Subtype Nat
+open List Subtype Nat Function
 
 variable {α : Type _} {β : Type _} {γ : Type _}
 
@@ -118,7 +118,6 @@ theorem coe_eq_zero_iff_isEmpty (l : List α) : (l : Multiset α) = 0 ↔ l.isEm
 #align multiset.coe_eq_zero_iff_empty Multiset.coe_eq_zero_iff_isEmpty
 
 /-! ### `Multiset.cons` -/
-
 
 /-- `cons a s` is the multiset which contains `s` plus one more instance of `a`. -/
 def cons (a : α) (s : Multiset α) : Multiset α :=
@@ -876,145 +875,115 @@ instance is_wellFounded_lt : WellFoundedLT (Multiset α) :=
   ⟨wellFounded_lt⟩
 #align multiset.is_well_founded_lt Multiset.is_wellFounded_lt
 
-/-! ### `Multiset.replicate` and `Multiset.repeat` -/
+/-! ### `Multiset.replicate` -/
 
 /-- `replicate n a` is the multiset containing only `a` with multiplicity `n`. -/
 def replicate (n : ℕ) (a : α) : Multiset α :=
   List.replicate n a
 
-section deprecated
-set_option linter.deprecated false
+theorem coe_replicate (a : α) (n : ℕ) : (List.replicate n a : Multiset α) = replicate n a := rfl
+#align multiset.coe_replicate Multiset.coe_replicate
 
-/- TODO: all these lemmas should be in terms of `replicate` -/
+@[simp] theorem replicate_zero (a : α) : replicate 0 a = 0 := rfl
+#align multiset.replicate_zero Multiset.replicate_zero
 
-/-- `repeat a n` is the multiset containing only `a` with multiplicity `n`. -/
-@[deprecated replicate]
-def «repeat» (a : α) (n : ℕ) : Multiset α :=
-  replicate n a
-#align multiset.repeat Multiset.repeat
+@[simp] theorem replicate_succ (a : α) (n) : replicate (n + 1) a = a ::ₘ replicate n a := rfl
+#align multiset.replicate_succ Multiset.replicate_succ
 
-theorem coe_repeat (a : α) (n : ℕ) : (List.repeat a n : Multiset α) = «repeat» a n :=
-  rfl
-#align multiset.coe_repeat Multiset.coe_repeat
+theorem replicate_add (m n : ℕ) (a : α) : replicate (m + n) a = replicate m a + replicate n a :=
+  congr_arg _ <| List.replicate_add ..
+#align multiset.replicate_add Multiset.replicate_add
 
-@[simp]
-theorem repeat_zero (a : α) : «repeat» a 0 = 0 :=
-  rfl
-#align multiset.repeat_zero Multiset.repeat_zero
-
-@[simp]
-theorem repeat_succ (a : α) (n) : «repeat» a (n + 1) = a ::ₘ «repeat» a n := by
-  simp [«repeat», replicate]
-#align multiset.repeat_succ Multiset.repeat_succ
-
-theorem repeat_add (a : α) (m n : ℕ) : «repeat» a (m + n) = «repeat» a m + «repeat» a n :=
-  congr_arg _ <| List.repeat_add _ _ _
-#align multiset.repeat_add Multiset.repeat_add
-
-/-- `Multiset.repeat` as an `addMonoidHom`. -/
+/-- `Multiset.replicate` as an `addMonoidHom`. -/
 @[simps]
-def repeatAddMonoidHom (a : α) : ℕ →+ Multiset α where
-  toFun := «repeat» a
-  map_zero' := repeat_zero a
-  map_add' := repeat_add a
-#align multiset.repeat_add_monoid_hom Multiset.repeatAddMonoidHom
+def replicateAddMonoidHom (a : α) : ℕ →+ Multiset α where
+  toFun := fun n => replicate n a
+  map_zero' := replicate_zero a
+  map_add' := fun _ _ =>replicate_add _ _ a
+#align multiset.replicate_add_monoid_hom Multiset.replicateAddMonoidHom
 
 -- @[simp] -- Porting note: simp can prove this
-theorem repeat_one (a : α) : «repeat» a 1 = {a} := by
-  simp only [repeat_succ, ← cons_zero, eq_self_iff_true, repeat_zero, cons_inj_right]
-#align multiset.repeat_one Multiset.repeat_one
+theorem replicate_one (a : α) : replicate 1 a = {a} := rfl
+#align multiset.replicate_one Multiset.replicate_one
 
-@[simp]
-theorem card_repeat : ∀ (a : α) (n), card («repeat» a n) = n :=
-  length_repeat
-#align multiset.card_repeat Multiset.card_repeat
+@[simp] theorem card_replicate (n) (a : α) : card (replicate n a) = n :=
+  length_replicate n a
+#align multiset.card_replicate Multiset.card_replicate
 
-theorem mem_repeat {a b : α} {n : ℕ} : b ∈ «repeat» a n ↔ n ≠ 0 ∧ b = a :=
-  List.mem_repeat
-#align multiset.mem_repeat Multiset.mem_repeat
+theorem mem_replicate {a b : α} {n : ℕ} : b ∈ replicate n a ↔ n ≠ 0 ∧ b = a :=
+  List.mem_replicate
+#align multiset.mem_replicate Multiset.mem_replicate
 
-theorem eq_of_mem_repeat {a b : α} {n} : b ∈ «repeat» a n → b = a :=
-  List.eq_of_mem_repeat
-#align multiset.eq_of_mem_repeat Multiset.eq_of_mem_repeat
+theorem eq_of_mem_replicate {a b : α} {n} : b ∈ replicate n a → b = a :=
+  List.eq_of_mem_replicate
+#align multiset.eq_of_mem_replicate Multiset.eq_of_mem_replicate
 
-theorem eq_repeat' {a : α} {s : Multiset α} : s = «repeat» a (card s) ↔ ∀ b ∈ s, b = a :=
-  Quot.inductionOn s fun _l =>
-    Iff.trans ⟨fun h => perm_repeat.1 <| Quotient.exact h, congr_arg _⟩ List.eq_repeat'
-#align multiset.eq_repeat' Multiset.eq_repeat'
+theorem eq_replicate_card {a : α} {s : Multiset α} : s = replicate (card s) a ↔ ∀ b ∈ s, b = a :=
+  Quot.inductionOn s fun _l => coe_eq_coe.trans <| perm_replicate.trans <| eq_replicate_length
+#align multiset.eq_replicate_card Multiset.eq_replicate_card
 
-theorem eq_repeat_of_mem {a : α} {s : Multiset α} : (∀ b ∈ s, b = a) → s = «repeat» a (card s) :=
-  eq_repeat'.2
-#align multiset.eq_repeat_of_mem Multiset.eq_repeat_of_mem
+alias eq_replicate_card ↔ _ eq_replicate_of_mem
+#align multiset.eq_replicate_of_mem Multiset.eq_replicate_of_mem
 
-theorem eq_repeat {a : α} {n} {s : Multiset α} : s = «repeat» a n ↔ card s = n ∧ ∀ b ∈ s, b = a :=
-  ⟨fun h => h.symm ▸ ⟨card_repeat _ _, fun _b => eq_of_mem_repeat⟩, fun ⟨e, al⟩ =>
-    e ▸ eq_repeat_of_mem al⟩
-#align multiset.eq_repeat Multiset.eq_repeat
+theorem eq_replicate {a : α} {n} {s : Multiset α} :
+    s = replicate n a ↔ card s = n ∧ ∀ b ∈ s, b = a :=
+  ⟨fun h => h.symm ▸ ⟨card_replicate _ _, fun _b => eq_of_mem_replicate⟩, fun ⟨e, al⟩ =>
+    e ▸ eq_replicate_of_mem al⟩
+#align multiset.eq_replicate Multiset.eq_replicate
 
-theorem repeat_left_injective {n : ℕ} (hn : n ≠ 0) : Function.Injective fun a : α => «repeat» a n :=
-  fun _a _b h => (eq_repeat.1 h).2 _ <| mem_repeat.2 ⟨hn, rfl⟩
-#align multiset.repeat_left_injective Multiset.repeat_left_injective
+theorem replicate_right_injective {n : ℕ} (hn : n ≠ 0) : Injective (@replicate α n) :=
+  fun _ _ h => (eq_replicate.1 h).2 _ <| mem_replicate.2 ⟨hn, rfl⟩
+#align multiset.replicate_right_injective Multiset.replicate_right_injective
 
-@[simp]
-theorem repeat_left_inj {a b : α} {n : ℕ} (h : n ≠ 0) : «repeat» a n = «repeat» b n ↔ a = b :=
-  (repeat_left_injective h).eq_iff
-#align multiset.repeat_left_inj Multiset.repeat_left_inj
+@[simp] theorem replicate_right_inj {a b : α} {n : ℕ} (h : n ≠ 0) :
+    replicate n a = replicate n b ↔ a = b :=
+  (replicate_right_injective h).eq_iff
+#align multiset.replicate_right_inj Multiset.replicate_right_inj
 
-theorem repeat_injective (a : α) : Function.Injective («repeat» a) := fun m n h => by
-  rw [← (eq_repeat.1 h).1, card_repeat]
-#align multiset.repeat_injective Multiset.repeat_injective
+theorem replicate_left_injective (a : α) : Injective (replicate · a) :=
+  LeftInverse.injective (card_replicate · a)
+#align multiset.replicate_left_injective Multiset.replicate_left_injective
 
-theorem repeat_subset_singleton : ∀ (a : α) (n), «repeat» a n ⊆ {a} :=
-  List.repeat_subset_singleton
-#align multiset.repeat_subset_singleton Multiset.repeat_subset_singleton
+theorem replicate_subset_singleton (n : ℕ) (a : α) : replicate n a ⊆ {a} :=
+  List.replicate_subset_singleton n a
+#align multiset.replicate_subset_singleton Multiset.replicate_subset_singleton
 
-theorem repeat_le_coe {a : α} {n} {l : List α} : «repeat» a n ≤ l ↔ List.repeat a n <+ l :=
-  ⟨fun ⟨_l', p, s⟩ => perm_repeat.1 p ▸ s, Sublist.subperm⟩
-#align multiset.repeat_le_coe Multiset.repeat_le_coe
+theorem replicate_le_coe {a : α} {n} {l : List α} : replicate n a ≤ l ↔ List.replicate n a <+ l :=
+  ⟨fun ⟨_l', p, s⟩ => perm_replicate.1 p ▸ s, Sublist.subperm⟩
+#align multiset.replicate_le_coe Multiset.replicate_le_coe
 
-theorem nsmul_singleton (a : α) (n) : n • ({a} : Multiset α) = «repeat» a n :=
-  by
-  refine' eq_repeat.mpr ⟨_, fun b hb => mem_singleton.mp (mem_of_mem_nsmul hb)⟩
-  rw [card_nsmul, card_singleton, mul_one]
+theorem nsmul_replicate {a : α} (n m : ℕ) : n • replicate m a = replicate (n * m) a :=
+  ((replicateAddMonoidHom a).map_nsmul _ _).symm
+#align multiset.nsmul_replicate Multiset.nsmul_replicate
+
+theorem nsmul_singleton (a : α) (n) : n • ({a} : Multiset α) = replicate n a := by
+  rw [← replicate_one, nsmul_replicate, mul_one]
 #align multiset.nsmul_singleton Multiset.nsmul_singleton
 
-theorem nsmul_repeat {a : α} (n m : ℕ) : n • «repeat» a m = «repeat» a (n * m) :=
-  ((repeatAddMonoidHom a).map_nsmul _ _).symm
-#align multiset.nsmul_repeat Multiset.nsmul_repeat
+theorem replicate_le_replicate (a : α) {k n : ℕ} : replicate k a ≤ replicate n a ↔ k ≤ n :=
+  _root_.trans (by rw [← replicate_le_coe, coe_replicate]) (List.replicate_sublist_replicate a)
+#align multiset.replicate_le_replicate Multiset.replicate_le_replicate
 
-theorem repeat_le_repeat (a : α) {k n : ℕ} : «repeat» a k ≤ «repeat» a n ↔ k ≤ n :=
-  _root_.trans (by rw [← repeat_le_coe, coe_repeat]) (List.repeat_sublist_repeat a)
-#align multiset.repeat_le_repeat Multiset.repeat_le_repeat
+theorem le_replicate_iff {m : Multiset α} {a : α} {n : ℕ} :
+    m ≤ replicate n a ↔ ∃ k ≤ n, m = replicate k a :=
+  ⟨fun h => ⟨card m, (card_mono h).trans_eq (card_replicate _ _),
+      eq_replicate_card.2 <| fun _ hb => eq_of_mem_replicate <| subset_of_le h hb⟩,
+    fun ⟨_, hkn, hm⟩ => hm.symm ▸ (replicate_le_replicate _).2 hkn⟩
+#align multiset.le_replicate_iff Multiset.le_replicate_iff
 
-theorem le_repeat_iff {m : Multiset α} {a : α} {n : ℕ} :
-    m ≤ «repeat» a n ↔ ∃ k ≤ n, m = «repeat» a k :=
-  Quot.inductionOn m fun l =>
-    show (l : Multiset α) ≤ «repeat» a n ↔ ∃ k ≤ n, ↑l = «repeat» a k by
-      simp only [← coe_repeat, coe_le, Subperm, sublist_repeat_iff, coe_eq_coe, perm_repeat]
-      constructor
-      · rintro ⟨l, hl, k, h, rfl⟩
-        rw [perm_comm, perm_repeat] at hl
-        exact ⟨k, h, hl⟩
-      · rintro ⟨k, h, hl⟩
-        exact ⟨l, Perm.refl _, k, h, hl⟩
-#align multiset.le_repeat_iff Multiset.le_repeat_iff
-
-theorem lt_repeat_succ {m : Multiset α} {x : α} {n : ℕ} :
-    m < «repeat» x (n + 1) ↔ m ≤ «repeat» x n := by
+theorem lt_replicate_succ {m : Multiset α} {x : α} {n : ℕ} :
+    m < replicate (n + 1) x ↔ m ≤ replicate n x := by
   rw [lt_iff_cons_le]
   constructor
   · rintro ⟨x', hx'⟩
-    have := eq_of_mem_repeat (mem_of_le hx' (mem_cons_self _ _))
-    rwa [this, repeat_succ, cons_le_cons_iff] at hx'
+    have := eq_of_mem_replicate (mem_of_le hx' (mem_cons_self _ _))
+    rwa [this, replicate_succ, cons_le_cons_iff] at hx'
   · intro h
-    rw [repeat_succ]
+    rw [replicate_succ]
     exact ⟨x, cons_le_cons _ h⟩
-#align multiset.lt_repeat_succ Multiset.lt_repeat_succ
-
-end deprecated
+#align multiset.lt_replicate_succ Multiset.lt_replicate_succ
 
 /-! ### Erasing one copy of an element -/
-
 
 section Erase
 
@@ -1216,13 +1185,9 @@ theorem map_singleton (f : α → β) (a : α) : ({a} : Multiset α).map f = {f 
   rfl
 #align multiset.map_singleton Multiset.map_singleton
 
-set_option linter.deprecated false in
-theorem map_repeat (f : α → β) (a : α) (k : ℕ) : («repeat» a k).map f = «repeat» (f a) k :=
-  by
-  induction k
-  simp
-  simpa
-#align multiset.map_repeat Multiset.map_repeat
+theorem map_replicate (f : α → β) (k : ℕ) (a : α) : (replicate k a).map f = replicate k (f a) := by
+  simp only [← coe_replicate, coe_map, List.map_replicate]
+#align multiset.map_replicate Multiset.map_replicate
 
 @[simp]
 theorem map_add (f : α → β) (s t) : map f (s + t) = map f s + map f t :=
@@ -1323,20 +1288,16 @@ theorem map_id' (s : Multiset α) : map (fun x => x) s = s :=
   map_id s
 #align multiset.map_id' Multiset.map_id'
 
-set_option linter.deprecated false in
-theorem map_const (s : Multiset α) (b : β) : map (Function.const α b) s = «repeat» b (card s) :=
+theorem map_const (s : Multiset α) (b : β) : map (const α b) s = replicate (card s) b :=
   Quot.inductionOn s fun _ => congr_arg _ <| List.map_const' _ _
 #align multiset.map_const Multiset.map_const
 
--- Porting note: new, added as simp lemma, because the LHS of `map_const` is not in SNF
-set_option linter.deprecated false in
-@[simp]
-theorem map_const' (s : Multiset α) (b : β) : map (fun _ ↦ b) s = «repeat» b (card s) :=
+@[simp] theorem map_const' (s : Multiset α) (b : β) : map (fun _ ↦ b) s = replicate (card s) b :=
   map_const _ _
 
 theorem eq_of_mem_map_const {b₁ b₂ : β} {l : List α} (h : b₁ ∈ map (Function.const α b₂) l) :
     b₁ = b₂ :=
-  eq_of_mem_repeat <| by rwa [map_const] at h
+  eq_of_mem_replicate <| by rwa [map_const] at h
 #align multiset.eq_of_mem_map_const Multiset.eq_of_mem_map_const
 
 @[simp]
@@ -2392,7 +2353,7 @@ theorem count_zero [BEq α] (a : α) : count a 0 = 0 :=
 variable [DecidableEq α]
 
 @[simp]
-theorem count_cons_self (a : α) (s : Multiset α) : count a (a ::ₘ s) = succ (count a s) :=
+theorem count_cons_self (a : α) (s : Multiset α) : count a (a ::ₘ s) = count a s + 1 :=
   countp_cons_of_pos _ $ beq_self_eq_true _
 #align multiset.count_cons_self Multiset.count_cons_self
 
@@ -2473,35 +2434,24 @@ theorem count_eq_card {a : α} {s} : count a s = card s ↔ ∀ x ∈ s, a = x :
   simp [countp_eq_card, count, @eq_comm _ a]
 #align multiset.count_eq_card Multiset.count_eq_card
 
-set_option linter.deprecated false in
 @[simp]
-theorem count_repeat_self (a : α) (n : ℕ) : count a («repeat» a n) = n := by
-  simp [«repeat», replicate]
-#align multiset.count_repeat_self Multiset.count_repeat_self
+theorem count_replicate_self (a : α) (n : ℕ) : count a (replicate n a) = n :=
+  List.count_replicate_self ..
+#align multiset.count_replicate_self Multiset.count_replicate_self
 
-set_option linter.deprecated false in
-theorem count_repeat (a b : α) (n : ℕ) : count a («repeat» b n) = if a = b then n else 0 :=
-  by
-  split_ifs with h₁
-  · rw [h₁, count_repeat_self]
-  · rw [count_eq_zero]
-    apply mt eq_of_mem_repeat h₁
-#align multiset.count_repeat Multiset.count_repeat
+theorem count_replicate (a b : α) (n : ℕ) : count a (replicate n b) = if a = b then n else 0 :=
+  List.count_replicate ..
+#align multiset.count_replicate Multiset.count_replicate
 
 @[simp]
-theorem count_erase_self (a : α) (s : Multiset α) : count a (erase s a) = pred (count a s) :=
-  by
-  by_cases a ∈ s
-  · rw [(by rw [cons_erase h] : count a s = count a (a ::ₘ erase s a)), count_cons_self]; rfl
-  · rw [erase_of_not_mem h, count_eq_zero.2 h]; rfl
+theorem count_erase_self (a : α) (s : Multiset α) : count a (erase s a) = count a s - 1 :=
+  Quotient.inductionOn s <| List.count_erase_self a
 #align multiset.count_erase_self Multiset.count_erase_self
 
 @[simp]
 theorem count_erase_of_ne {a b : α} (ab : a ≠ b) (s : Multiset α) :
-    count a (erase s b) = count a s := by
-  by_cases b ∈ s
-  · rw [← count_cons_of_ne ab, cons_erase h]
-  · rw [erase_of_not_mem h]
+    count a (erase s b) = count a s :=
+  Quotient.inductionOn s <| List.count_erase_of_ne ab
 #align multiset.count_erase_of_ne Multiset.count_erase_of_ne
 
 @[simp]
@@ -2509,9 +2459,8 @@ theorem count_sub (a : α) (s t : Multiset α) : count a (s - t) = count a s - c
   by
   revert s; refine' Multiset.induction_on t (by simp) fun b t IH s => _
   rw [sub_cons, IH]
-  by_cases ab : a = b
-  · subst b
-    rw [count_erase_self, count_cons_self, sub_succ, pred_sub]
+  rcases eq_or_ne a b with rfl | ab
+  · rw [count_erase_self, count_cons_self, Nat.sub_sub, add_comm]
   · rw [count_erase_of_ne ab, count_cons_of_ne ab]
 #align multiset.count_sub Multiset.count_sub
 
@@ -2527,11 +2476,10 @@ theorem count_inter (a : α) (s t : Multiset α) : count a (s ∩ t) = min (coun
   rw [← count_add, sub_add_inter, count_sub, tsub_add_min]
 #align multiset.count_inter Multiset.count_inter
 
-set_option linter.deprecated false in
-theorem le_count_iff_repeat_le {a : α} {s : Multiset α} {n : ℕ} :
-    n ≤ count a s ↔ «repeat» a n ≤ s :=
-  Quot.inductionOn s fun _l => le_count_iff_repeat_sublist.trans repeat_le_coe.symm
-#align multiset.le_count_iff_repeat_le Multiset.le_count_iff_repeat_le
+theorem le_count_iff_replicate_le {a : α} {s : Multiset α} {n : ℕ} :
+    n ≤ count a s ↔ replicate n a ≤ s :=
+  Quot.inductionOn s fun _l => le_count_iff_replicate_sublist.trans replicate_le_coe.symm
+#align multiset.le_count_iff_replicate_le Multiset.le_count_iff_replicate_le
 
 @[simp]
 theorem count_filter_of_pos {p} {a} {s : Multiset α} (h : p a) :
@@ -2579,17 +2527,6 @@ instance : DistribLattice (Multiset α) :=
             simp only [max_min_distrib_left, Multiset.count_inter, Multiset.sup_eq_union,
               Multiset.count_union, Multiset.inf_eq_inter] }
 
-set_option linter.deprecated false in
-theorem repeat_inf (s : Multiset α) (a : α) (n : ℕ) :
-    «repeat» a n ⊓ s = «repeat» a (min (s.count a) n) :=
-  by
-  ext x
-  rw [inf_eq_inter, count_inter, count_repeat, count_repeat]
-  by_cases x = a
-  simp only [min_comm, h, if_true, eq_self_iff_true]
-  simp only [h, if_false, zero_min]
-#align multiset.repeat_inf Multiset.repeat_inf
-
 theorem count_map {α β : Type _} (f : α → β) (s : Multiset α) [DecidableEq β] (b : β) :
     count b (map f s) = card (s.filter fun a => b = f a) := by
   simp [Bool.beq_eq_decide_eq, eq_comm, count, countp_map]
@@ -2606,9 +2543,8 @@ theorem count_map_eq_count [DecidableEq β] (f : α → β) (s : Multiset α)
     by
     rw [count, countp_map, ← this]
     exact count_filter_of_pos $ beq_self_eq_true _
-  · rw [eq_repeat.2
-        ⟨rfl, fun b hb => eq_comm.1 ((hf H (mem_filter.1 hb).left) _)⟩]
-    · simp only [count_repeat, eq_self_iff_true, if_true, card_repeat]
+  · rw [eq_replicate_card.2 fun b hb => (hf H (mem_filter.1 hb).left _).symm]
+    · simp only [count_replicate, eq_self_iff_true, if_true, card_replicate]
     · simp only [mem_filter, beq_iff_eq, and_imp, @eq_comm _ (f x), imp_self, implies_true]
 #align multiset.count_map_eq_count Multiset.count_map_eq_count
 
@@ -2633,38 +2569,29 @@ theorem attach_count_eq_count_coe (m : Multiset α) (a) : m.attach.count a = m.c
 
 #align multiset.attach_count_eq_count_coe Multiset.attach_count_eq_count_coe
 
-set_option linter.deprecated false in
-theorem filter_eq' (s : Multiset α) (b : α) : s.filter (· = b) = «repeat» b (count b s) :=
-  by
-  ext a
-  rw [count_repeat, count_filter]
-  exact if_ctx_congr (by simp) (by rw [·]) fun _h => rfl
+theorem filter_eq' (s : Multiset α) (b : α) : s.filter (· = b) = replicate (count b s) b :=
+  Quotient.inductionOn s <| fun l => congr_arg _ <| List.filter_eq' l b
 #align multiset.filter_eq' Multiset.filter_eq'
 
-set_option linter.deprecated false in
-theorem filter_eq (s : Multiset α) (b : α) : s.filter (Eq b) = «repeat» b (count b s) := by
+theorem filter_eq (s : Multiset α) (b : α) : s.filter (Eq b) = replicate (count b s) b := by
   simp_rw [← filter_eq', eq_comm]
 #align multiset.filter_eq Multiset.filter_eq
 
-set_option linter.deprecated false in
 @[simp]
-theorem repeat_inter (x : α) (n : ℕ) (s : Multiset α) :
-    «repeat» x n ∩ s = «repeat» x (min n (s.count x)) := by
-  refine' le_antisymm _ _
-  · simp only [le_iff_count, count_inter, count_repeat]
-    intro a
-    split_ifs with h
-    · rw [h]
-    · rw [Nat.zero_min]
-  simp only [le_inter_iff, ← le_count_iff_repeat_le, count_inter, count_repeat_self,
-    min_le_left, min_le_right]
-#align multiset.repeat_inter Multiset.repeat_inter
+theorem replicate_inter (x : α) (n : ℕ) (s : Multiset α) :
+    replicate n x ∩ s = replicate (min n (s.count x)) x := by
+  ext y
+  rw [count_inter, count_replicate, count_replicate]
+  by_cases y = x
+  · simp only [h, if_true]
+  · simp only [h, if_false, zero_min]
+#align multiset.replicate_inter Multiset.replicate_inter
 
-set_option linter.deprecated false in
 @[simp]
-theorem inter_repeat (s : Multiset α) (x : α) (n : ℕ) :
-    s ∩ «repeat» x n = «repeat» x (min (s.count x) n) := by rw [inter_comm, repeat_inter, min_comm]
-#align multiset.inter_repeat Multiset.inter_repeat
+theorem inter_replicate (s : Multiset α) (x : α) (n : ℕ) :
+    s ∩ replicate n x = replicate (min (s.count x) n) x := by
+  rw [inter_comm, replicate_inter, min_comm]
+#align multiset.inter_replicate Multiset.inter_replicate
 
 end
 
@@ -2888,26 +2815,24 @@ theorem rel_of_forall {m1 m2 : Multiset α} {r : α → α → Prop} (h : ∀ a 
     · simpa using hc
 #align multiset.rel_of_forall Multiset.rel_of_forall
 
-set_option linter.deprecated false in
-theorem rel_repeat_left {m : Multiset α} {a : α} {r : α → α → Prop} {n : ℕ} :
-    («repeat» a n).Rel r m ↔ card m = n ∧ ∀ x, x ∈ m → r a x :=
+theorem rel_replicate_left {m : Multiset α} {a : α} {r : α → α → Prop} {n : ℕ} :
+    (replicate n a).Rel r m ↔ card m = n ∧ ∀ x, x ∈ m → r a x :=
   ⟨fun h =>
-    ⟨(card_eq_card_of_rel h).symm.trans (card_repeat _ _), fun x hx =>
+    ⟨(card_eq_card_of_rel h).symm.trans (card_replicate _ _), fun x hx =>
       by
       obtain ⟨b, hb1, hb2⟩ := exists_mem_of_rel_of_mem (rel_flip.2 h) hx
-      rwa [eq_of_mem_repeat hb1] at hb2⟩,
+      rwa [eq_of_mem_replicate hb1] at hb2⟩,
     fun h =>
-    rel_of_forall (fun x y hx hy => (eq_of_mem_repeat hx).symm ▸ h.2 _ hy)
-      (Eq.trans (card_repeat _ _) h.1.symm)⟩
-#align multiset.rel_repeat_left Multiset.rel_repeat_left
+    rel_of_forall (fun x y hx hy => (eq_of_mem_replicate hx).symm ▸ h.2 _ hy)
+      (Eq.trans (card_replicate _ _) h.1.symm)⟩
+#align multiset.rel_replicate_left Multiset.rel_replicate_left
 
-set_option linter.deprecated false in
-theorem rel_repeat_right {m : Multiset α} {a : α} {r : α → α → Prop} {n : ℕ} :
-    m.Rel r («repeat» a n) ↔ card m = n ∧ ∀ x, x ∈ m → r x a :=
+theorem rel_replicate_right {m : Multiset α} {a : α} {r : α → α → Prop} {n : ℕ} :
+    m.Rel r (replicate n a) ↔ card m = n ∧ ∀ x, x ∈ m → r x a :=
   by
   rw [← rel_flip]
-  exact rel_repeat_left
-#align multiset.rel_repeat_right Multiset.rel_repeat_right
+  exact rel_replicate_left
+#align multiset.rel_replicate_right Multiset.rel_replicate_right
 
 protected nonrec -- Porting note: added
 theorem Rel.trans (r : α → α → Prop) [IsTrans α r] {s t u : Multiset α} (r1 : Rel r s t)

--- a/Mathlib/Data/Multiset/Nodup.lean
+++ b/Mathlib/Data/Multiset/Nodup.lean
@@ -72,7 +72,7 @@ theorem not_nodup_pair : ∀ a : α, ¬Nodup (a ::ₘ a ::ₘ 0) :=
 
 theorem nodup_iff_le {s : Multiset α} : Nodup s ↔ ∀ a : α, ¬a ::ₘ a ::ₘ 0 ≤ s :=
   Quot.induction_on s fun _ =>
-    nodup_iff_sublist.trans <| forall_congr' fun a => not_congr (@repeat_le_coe _ a 2 _).symm
+    nodup_iff_sublist.trans <| forall_congr' fun a => not_congr (@replicate_le_coe _ a 2 _).symm
 #align multiset.nodup_iff_le Multiset.nodup_iff_le
 
 theorem nodup_iff_ne_cons_cons {s : Multiset α} : s.Nodup ↔ ∀ a t, s ≠ a ::ₘ a ::ₘ t :=

--- a/Mathlib/Data/Vector.lean
+++ b/Mathlib/Data/Vector.lean
@@ -147,9 +147,9 @@ def map₂ (f : α → β → φ) : Vector α n → Vector β n → Vector φ n
 #align vector.map₂ Vector.map₂
 
 /-- Vector obtained by repeating an element. -/
-def «repeat» (a : α) (n : ℕ) : Vector α n :=
+def replicate (n : ℕ) (a : α) : Vector α n :=
   ⟨List.replicate n a, List.length_replicate n a⟩
-#align vector.repeat Vector.repeat
+#align vector.replicate Vector.replicate
 
 /-- Drop `i` elements from a vector of length `n`; we can have `i > n`. -/
 def drop (i : ℕ) : Vector α n → Vector α (n - i)

--- a/Mathlib/Init/Data/List/Basic.lean
+++ b/Mathlib/Init/Data/List/Basic.lean
@@ -59,11 +59,6 @@ def findIndex (p : α → Prop) [DecidablePred p] : List α → ℕ := List.find
 
 #align list.band List.and
 
-/-- List consisting of an element `a` repeated a specified number of times. -/
-@[deprecated replicate, simp]
-def «repeat» (a : α) (n : Nat) : List α := List.replicate n a
-#align list.repeat List.repeat
-
 #align list.last List.getLast
 
 /-- The last element of a list, with the default if list empty -/


### PR DESCRIPTION
Mathlib 3 migrated to `list.replicate` in leanprover-community/mathlib#18127 (merged) and leanprover-community/mathlib#18181 (awaiting review).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
