### PR TITLE
[Merged by Bors] - chore: adjust Nat.le_induction for compatibility with `induction` tactic

### DIFF
--- a/Mathlib/Data/Nat/Basic.lean
+++ b/Mathlib/Data/Nat/Basic.lean
@@ -491,8 +491,8 @@ theorem le_induction {m} {P : ∀ (n : Nat) (_ : m ≤ n), Prop} (base : P m le_
     (succ : ∀ (n : Nat) (hn : m ≤ n), P n hn → P (n + 1) (hn.trans <| Nat.le_succ _)) :
     ∀ (n : Nat) (hn : m ≤ n), P n hn := by
   apply Nat.le.rec
-  . exact base
-  . intros n hn
+  · exact base
+  · intros n hn
     apply succ n hn
 #align nat.le_induction Nat.le_induction
 

--- a/Mathlib/Data/Nat/Basic.lean
+++ b/Mathlib/Data/Nat/Basic.lean
@@ -483,14 +483,17 @@ theorem strongRecOn'_beta {P : ℕ → Sort _} {h} {n : ℕ} :
   rw [Nat.strongRec']
 #align nat.strong_rec_on_beta' Nat.strongRecOn'_beta
 
-/-- Induction principle starting at a non-zero number. For maps to a `Sort*` see `le_rec_on`. -/
+/-- Induction principle starting at a non-zero number. For maps to a `Sort*` see `le_rec_on`.
+To use in an induction proof, the syntax is `induction n, hn using Nat.le_induction` (or the same
+for `induction'`). -/
 @[elab_as_elim]
-theorem le_induction {P : Nat → Prop} {m} (h0 : P m) (h1 : ∀ n, m ≤ n → P n → P (n + 1)) :
-    ∀ n, m ≤ n → P n := by
+theorem le_induction {m} {P : ∀ (n : Nat) (_ : m ≤ n), Prop} (base : P m le_rfl)
+    (succ : ∀ (n : Nat) (hn : m ≤ n), P n hn → P (n + 1) (hn.trans <| Nat.le_succ _)) :
+    ∀ (n : Nat) (hn : m ≤ n), P n hn := by
   apply Nat.le.rec
-  · exact h0
-  · intros n hn
-    apply h1 n hn
+  . exact base
+  . intros n hn
+    apply succ n hn
 #align nat.le_induction Nat.le_induction
 
 /-- Decreasing induction: if `P (k+1)` implies `P k`, then `P n` implies `P m` for all `m ≤ n`.

--- a/Mathlib/Data/Set/Pointwise/Basic.lean
+++ b/Mathlib/Data/Set/Pointwise/Basic.lean
@@ -819,9 +819,10 @@ theorem pow_subset_pow (hst : s ⊆ t) : ∀ n : ℕ, s ^ n ⊆ t ^ n
 #align set.pow_subset_pow Set.pow_subset_pow
 
 @[to_additive nsmul_subset_nsmul_of_zero_mem]
-theorem pow_subset_pow_of_one_mem (hs : (1 : α) ∈ s) : m ≤ n → s ^ m ⊆ s ^ n := by
-  -- Porting note: made `P` explicit
-  refine Nat.le_induction (P := fun M => s ^ m ⊆ s ^ M) ?_ (fun n _ ih => ?_) _
+theorem pow_subset_pow_of_one_mem (hs : (1 : α) ∈ s) (hn : m ≤ n) : s ^ m ⊆ s ^ n := by
+  -- Porting note: `Nat.le_induction` didn't work as an induction principle in mathlib3, this was
+  -- `refine nat.le_induction ...`
+  induction' n, hn using Nat.le_induction with _ _ ih
   · exact Subset.rfl
   · dsimp only
     rw [pow_succ]


### PR DESCRIPTION
See [Zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Correct.20formulation.20of.20induction.20principles/near/321255637).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
