### PR TITLE
[Merged by Bors] - chore: try 'XDG_CACHE_HOME' to download cache files

### DIFF
--- a/Cache/IO.lean
+++ b/Cache/IO.lean
@@ -34,8 +34,10 @@ def IRDIR : FilePath :=
 /-- Target directory for caching -/
 initialize CACHEDIR : FilePath ← do
   match ← IO.getEnv "XDG_CACHE_HOME" with
-  | some path => return path / "mathlib"
-  | none => pure ⟨".cache"⟩
+  | some path => return path / "mathlib_cache"
+  | none => match ← IO.getEnv "HOME" with
+    | some path => return path / "mathlib_cache"
+    | none => pure ⟨".cache"⟩
 
 /-- Target file path for `curl` configurations -/
 def CURLCFG :=

--- a/Cache/IO.lean
+++ b/Cache/IO.lean
@@ -32,8 +32,10 @@ def IRDIR : FilePath :=
   "build" / "ir"
 
 /-- Target directory for caching -/
-def CACHEDIR : FilePath :=
-  ⟨".cache"⟩
+initialize CACHEDIR : FilePath ← do
+  match ← IO.getEnv "XDG_CACHE_HOME" with
+  | some path => return path / "mathlib"
+  | none => pure ⟨".cache"⟩
 
 /-- Target file path for `curl` configurations -/
 def CURLCFG :=

--- a/Cache/IO.lean
+++ b/Cache/IO.lean
@@ -34,9 +34,9 @@ def IRDIR : FilePath :=
 /-- Target directory for caching -/
 initialize CACHEDIR : FilePath ← do
   match ← IO.getEnv "XDG_CACHE_HOME" with
-  | some path => return path / "mathlib_cache"
+  | some path => return path / "mathlib"
   | none => match ← IO.getEnv "HOME" with
-    | some path => return path / "mathlib_cache"
+    | some path => return path / ".cache" / "mathlib"
     | none => pure ⟨".cache"⟩
 
 /-- Target file path for `curl` configurations -/


### PR DESCRIPTION
Searches for a `XDG_CACHE_HOME` env variable. If it's defined, use `$XDG_CACHE_HOME/mathlib` as the repository of cache files. Fallback to `.cache`.

Zulip thread fro context: https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/lake.20get-cache/near/321773418