### PR TITLE
feat: Make Fin.induction computable

### DIFF
--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -1661,17 +1661,17 @@ theorem succRecOn_succ {C : ∀ n, Fin n → Sort _} {H0 Hs} {n} (i : Fin n) :
 def inductionImpl {C : Fin (n + 1) → Sort _} (h0 : C 0)
     (hs : ∀ i : Fin n, C (castSucc i) → C i.succ) :
     ∀ i : Fin (n + 1), C i :=
-  fun ⟨i, hi⟩ => by cases i with
-  | zero => rwa [Fin.mk_zero]
-  | succ i => exact hs ⟨i, lt_of_succ_lt_succ hi⟩ (Fin.inductionImpl h0 hs ⟨i, lt_of_succ_lt hi⟩)
+  fun ⟨i, hi⟩ => match i with
+  | zero => h0
+  | Nat.succ i => hs ⟨i, lt_of_succ_lt_succ hi⟩ (Fin.inductionImpl h0 hs ⟨i, lt_of_succ_lt hi⟩)
 
 --porting note: see `Fin.inductionImpl` above for added `implemented_by`
 /-- Define `C i` by induction on `i : Fin (n + 1)` via induction on the underlying `Nat` value.
 This function has two arguments: `h0` handles the base case on `C 0`,
 and `hs` defines the inductive step using `C i.castSucc`.
 -/
-@[elab_as_elim, implemented_by Fin.inductionImpl]
-def induction {C : Fin (n + 1) → Sort _} (h0 : C 0)
+@[elab_as_elim]
+noncomputable def induction {C : Fin (n + 1) → Sort _} (h0 : C 0)
     (hs : ∀ i : Fin n, C (castSucc i) → C i.succ) :
     ∀ i : Fin (n + 1), C i := by
   rintro ⟨i, hi⟩

--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -1682,11 +1682,11 @@ def induction {C : Fin (n + 1) → Sort _} (h0 : C 0)
 #align fin.induction Fin.induction
 
 -- porting note: verification of equality and csimp for compiler
-@[csimp] theorem induction_eq_inductionImpl_csimp : @induction = @inductionImpl := by
+@[csimp]
+theorem induction_eq_inductionImpl_csimp : @induction = @inductionImpl := by
   funext n C h0 hs ⟨i, hi⟩
   induction' i with i IH
-  · rw [Fin.mk_zero]
-    rfl
+  · rw [Fin.mk_zero] ; rfl
   · rw [inductionImpl]
     simp only
     rw [← IH (lt_of_succ_lt hi), induction, induction]

--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -1682,14 +1682,14 @@ def induction {C : Fin (n + 1) → Sort _} (h0 : C 0)
 #align fin.induction Fin.induction
 
 -- porting note: verification of equality and csimp for compiler
-@[csimp] theorem inductionImpl_eq_induction_csimp : @inductionImpl = @induction := by
+@[csimp] theorem induction_eq_inductionImpl_csimp : @induction = @inductionImpl := by
   funext n C h0 hs ⟨i, hi⟩
   induction' i with i IH
   · rw [Fin.mk_zero]
     rfl
   · rw [inductionImpl]
     simp only
-    rw [IH (lt_of_succ_lt hi), induction, induction]
+    rw [← IH (lt_of_succ_lt hi), induction, induction]
 
 @[simp]
 theorem induction_zero {C : Fin (n + 1) → Sort _} : ∀ (h0 : C 0)

--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -1681,21 +1681,15 @@ def induction {C : Fin (n + 1) → Sort _} (h0 : C 0)
     exact IH (lt_of_succ_lt hi)
 #align fin.induction Fin.induction
 
--- porting note: verifying the implementation
-theorem inductionImpl_eq_induction {C : Fin (n+1) → Sort _} (h0 : C 0)
-    (hs : ∀ i : Fin n, C (castSucc i) → C i.succ): inductionImpl h0 hs = induction h0 hs := by
-  ext ⟨k, hk⟩
-  induction' k with k IH
+-- porting note: verification of equality and csimp for compiler
+@[csimp] theorem inductionImpl_eq_induction_csimp : @inductionImpl = @induction := by
+  funext n C h0 hs ⟨i, hi⟩
+  induction' i with i IH
   · rw [Fin.mk_zero]
     rfl
   · rw [inductionImpl]
     simp only
-    rw [IH (lt_of_succ_lt hk), induction, induction]
-
--- porting note: csimp for the compiler
-@[csimp] theorem induction_Impl_eq_induction_csimp : @inductionImpl = @induction := by
-  funext
-  rw [inductionImpl_eq_induction]
+    rw [IH (lt_of_succ_lt hi), induction, induction]
 
 @[simp]
 theorem induction_zero {C : Fin (n + 1) → Sort _} : ∀ (h0 : C 0)

--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -1656,6 +1656,8 @@ theorem succRecOn_succ {C : ∀ n, Fin n → Sort _} {H0 Hs} {n} (i : Fin n) :
 
 -- porting note: This is a bandaid solution to make Fin.induction computable
 -- This can (and probably should) be removed once the code generator supports `Nat.rec`
+
+/-- A computable definition for `Fin.induction`-/
 def inductionImpl {C : Fin (n + 1) → Sort _} (h0 : C 0)
     (hs : ∀ i : Fin n, C (castSucc i) → C i.succ) :
     ∀ i : Fin (n + 1), C i :=
@@ -1663,6 +1665,7 @@ def inductionImpl {C : Fin (n + 1) → Sort _} (h0 : C 0)
   | zero => rwa [Fin.mk_zero]
   | succ i => exact hs ⟨i, lt_of_succ_lt_succ hi⟩ (Fin.inductionImpl h0 hs ⟨i, lt_of_succ_lt hi⟩)
 
+--porting note: see `Fin.inductionImpl` above for added `implemented_by`
 /-- Define `C i` by induction on `i : Fin (n + 1)` via induction on the underlying `Nat` value.
 This function has two arguments: `h0` handles the base case on `C 0`,
 and `hs` defines the inductive step using `C i.castSucc`.

--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -1681,6 +1681,22 @@ def induction {C : Fin (n + 1) → Sort _} (h0 : C 0)
     exact IH (lt_of_succ_lt hi)
 #align fin.induction Fin.induction
 
+-- porting note: verifying the implementation
+theorem inductionImpl_eq_induction {C : Fin (n+1) → Sort _} (h0 : C 0)
+    (hs : ∀ i : Fin n, C (castSucc i) → C i.succ): inductionImpl h0 hs = induction h0 hs := by
+  ext ⟨k, hk⟩
+  induction' k with k IH
+  · rw [Fin.mk_zero]
+    rfl
+  · rw [inductionImpl]
+    simp only
+    rw [IH (lt_of_succ_lt hk), induction, induction]
+
+-- porting note: csimp for the compiler
+@[csimp] theorem induction_Impl_eq_induction_csimp : @inductionImpl = @induction := by
+  funext
+  rw [inductionImpl_eq_induction]
+
 @[simp]
 theorem induction_zero {C : Fin (n + 1) → Sort _} : ∀ (h0 : C 0)
     (hs : ∀ i : Fin n, C (castSucc i) → C i.succ),

--- a/Mathlib/Data/Fin/Tuple/Basic.lean
+++ b/Mathlib/Data/Fin/Tuple/Basic.lean
@@ -63,9 +63,8 @@ theorem tail_def {n : ℕ} {α : Fin (n + 1) → Type _} {q : ∀ i, α i} :
   rfl
 #align fin.tail_def Fin.tail_def
 
--- Porting note: I made this noncomputable because Lean seemed to think it should be
 /-- Adding an element at the beginning of an `n`-tuple, to get an `n+1`-tuple. -/
-noncomputable def cons (x : α 0) (p : ∀ i : Fin n, α i.succ) : ∀ i, α i := fun j ↦ Fin.cases x p j
+def cons (x : α 0) (p : ∀ i : Fin n, α i.succ) : ∀ i, α i := fun j ↦ Fin.cases x p j
 #align fin.cons Fin.cons
 
 @[simp]
@@ -305,8 +304,8 @@ end Tuple
 section TupleRight
 
 /-! In the previous section, we have discussed inserting or removing elements on the left of a
-tuple. In this section, we do the same on the right. A difference is that `fin (n+1)` is constructed
-inductively from `fin n` starting from the left, not from the right. This implies that Lean needs
+tuple. In this section, we do the same on the right. A difference is that `Fin (n+1)` is constructed
+inductively from `Fin n` starting from the left, not from the right. This implies that Lean needs
 more help to realize that elements belong to the right types, i.e., we need to insert casts at
 several places. -/
 


### PR DESCRIPTION
This is a small change with a temporary solution to make `Fin.induction` computable. It also shortens some proofs and removes now extraneous `noncomputable` tags.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
