### PR TITLE
[Merged by Bors] - feat: port Data.Finite.Set

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -238,6 +238,7 @@ import Mathlib.Data.Fin.SuccPred
 import Mathlib.Data.Fin.Tuple.Basic
 import Mathlib.Data.FinEnum
 import Mathlib.Data.Finite.Defs
+import Mathlib.Data.Finite.Set
 import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Finset.Card
 import Mathlib.Data.Finset.Fin

--- a/Mathlib/Data/Finite/Set.lean
+++ b/Mathlib/Data/Finite/Set.lean
@@ -23,7 +23,7 @@ finiteness, finite sets
 
 open Set
 
-universe u v w x
+universe u v w
 
 variable {α : Type u} {β : Type v} {ι : Sort w}
 

--- a/Mathlib/Data/Finite/Set.lean
+++ b/Mathlib/Data/Finite/Set.lean
@@ -9,7 +9,8 @@ Authors: Kyle Miller
 ! if you have ported upstream changes.
 -/
 import Mathlib.Data.Fintype.Card
- -- TODO: remove
+
+set_option autoImplicit false-- TODO: remove
 /-!
 # Lemmas about `Finite` and `Set`s
 

--- a/Mathlib/Data/Finite/Set.lean
+++ b/Mathlib/Data/Finite/Set.lean
@@ -9,7 +9,7 @@ Authors: Kyle Miller
 ! if you have ported upstream changes.
 -/
 import Mathlib.Data.Fintype.Card
-set_option autoImplicit false
+set_option autoImplicit false -- TODO: remove
 /-!
 # Lemmas about `Finite` and `Set`s
 

--- a/Mathlib/Data/Finite/Set.lean
+++ b/Mathlib/Data/Finite/Set.lean
@@ -8,7 +8,7 @@ Authors: Kyle Miller
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
-import Mathbin.Data.Fintype.Card
+import Mathlib.Data.Fintype.Card
 
 /-!
 # Lemmas about `finite` and `set`s

--- a/Mathlib/Data/Finite/Set.lean
+++ b/Mathlib/Data/Finite/Set.lean
@@ -1,0 +1,39 @@
+/-
+Copyright (c) 2022 Kyle Miller. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kyle Miller
+
+! This file was ported from Lean 3 source module data.finite.set
+! leanprover-community/mathlib commit 509de852e1de55e1efa8eacfa11df0823f26f226
+! Please do not edit these lines, except to modify the commit id
+! if you have ported upstream changes.
+-/
+import Mathbin.Data.Fintype.Card
+
+/-!
+# Lemmas about `finite` and `set`s
+
+In this file we prove two lemmas about `finite` and `set`s.
+
+## Tags
+
+finiteness, finite sets
+-/
+
+
+open Set
+
+universe u v w x
+
+variable {α : Type u} {β : Type v} {ι : Sort w}
+
+theorem Finite.Set.finite_of_finite_image (s : Set α) {f : α → β} (h : s.InjOn f)
+    [Finite (f '' s)] : Finite s :=
+  Finite.of_equiv _ (Equiv.ofBijective _ h.bij_on_image.Bijective).symm
+#align finite.set.finite_of_finite_image Finite.Set.finite_of_finite_image
+
+theorem Finite.of_injective_finite_range {f : ι → α} (hf : Function.Injective f)
+    [Finite (range f)] : Finite ι :=
+  Finite.of_injective (Set.rangeFactorization f) (hf.codRestrict _)
+#align finite.of_injective_finite_range Finite.of_injective_finite_range
+

--- a/Mathlib/Data/Finite/Set.lean
+++ b/Mathlib/Data/Finite/Set.lean
@@ -9,11 +9,11 @@ Authors: Kyle Miller
 ! if you have ported upstream changes.
 -/
 import Mathlib.Data.Fintype.Card
-
+set_option autoImplicit false
 /-!
-# Lemmas about `finite` and `set`s
+# Lemmas about `Finite` and `Set`s
 
-In this file we prove two lemmas about `finite` and `set`s.
+In this file we prove two lemmas about `Finite` and `Set`s.
 
 ## Tags
 
@@ -29,11 +29,10 @@ variable {α : Type u} {β : Type v} {ι : Sort w}
 
 theorem Finite.Set.finite_of_finite_image (s : Set α) {f : α → β} (h : s.InjOn f)
     [Finite (f '' s)] : Finite s :=
-  Finite.of_equiv _ (Equiv.ofBijective _ h.bij_on_image.Bijective).symm
+  Finite.of_equiv _ (Equiv.ofBijective _ h.bijOn_image.bijective).symm
 #align finite.set.finite_of_finite_image Finite.Set.finite_of_finite_image
 
 theorem Finite.of_injective_finite_range {f : ι → α} (hf : Function.Injective f)
     [Finite (range f)] : Finite ι :=
   Finite.of_injective (Set.rangeFactorization f) (hf.codRestrict _)
 #align finite.of_injective_finite_range Finite.of_injective_finite_range
-

--- a/Mathlib/Data/Finite/Set.lean
+++ b/Mathlib/Data/Finite/Set.lean
@@ -10,7 +10,6 @@ Authors: Kyle Miller
 -/
 import Mathlib.Data.Fintype.Card
 
-set_option autoImplicit false-- TODO: remove
 /-!
 # Lemmas about `Finite` and `Set`s
 

--- a/Mathlib/Data/Finite/Set.lean
+++ b/Mathlib/Data/Finite/Set.lean
@@ -9,7 +9,7 @@ Authors: Kyle Miller
 ! if you have ported upstream changes.
 -/
 import Mathlib.Data.Fintype.Card
-set_option autoImplicit false
+
 /-!
 # Lemmas about `Finite` and `Set`s
 

--- a/Mathlib/Data/Set/Function.lean
+++ b/Mathlib/Data/Set/Function.lean
@@ -36,7 +36,7 @@ import Mathlib.Logic.Function.Conjugate
   and the codomain to `t`.
 -/
 
-variable {α β γ ι : Type _} {π : α → Type _}
+variable {α β γ : Type _} {ι : Sort _} {π : α → Type _}
 
 open Equiv Equiv.Perm Function
 


### PR DESCRIPTION
Port of data.finite.set

Also fixed a blocking variable declaration bug in Data.Set.Function

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
