### PR TITLE
chore: improve cache error message when an imported file can't be found

### DIFF
--- a/Cache/Hashing.lean
+++ b/Cache/Hashing.lean
@@ -76,6 +76,7 @@ partial def getFileHash (filePath : FilePath) : HashM UInt64 := do
     let content ← IO.FS.readFile fixedPath
     let fileImports := getFileImports content pkgDirs
     for fileImport in fileImports do
+      let fileImport := (← IO.getPackageDir fileImport) / fileImport
       if !(← fileImport.pathExists) then
         throw $ .userError s!"Couldn't find {fileImport} (imported from {fixedPath})"
     let importHashes ← fileImports.mapM getFileHash


### PR DESCRIPTION
Print a better error message if an imported file can't be found.

Zulip thread: https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/.5BCI.5D.20error.20getting.20cache/near/322396937

Close #1698 if this is accepted