### PR TITLE
[Merged by Bors] - fix: make :: notation for Sym.cons' scoped

### DIFF
--- a/Mathlib/Data/Sym/Basic.lean
+++ b/Mathlib/Data/Sym/Basic.lean
@@ -243,7 +243,7 @@ def cons' {α : Type _} {n : ℕ} : α → Sym' α n → Sym' α (Nat.succ n) :=
 #align sym.cons' Sym.cons'
 
 @[inherit_doc]
-notation a "::" b => cons' a b
+scoped notation a " :: " b => cons' a b
 
 /-- Multisets of cardinality n are equivalent to length-n vectors up to permutations.
 -/


### PR DESCRIPTION
This breaks pattern-matching on `::`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
