### PR TITLE
[Merged by Bors] - Bug fix: Bool.not_ne_self missing "()"

### DIFF
--- a/Mathlib/Data/Bool/Basic.lean
+++ b/Mathlib/Data/Bool/Basic.lean
@@ -220,7 +220,7 @@ theorem ne_not {a b : Bool} : a ≠ !b ↔ a = b :=
 theorem not_ne : ∀ {a b : Bool}, (!a) ≠ b ↔ a = b := not_not_eq
 #align bool.bnot_ne Bool.not_ne
 
-lemma not_ne_self : ∀ b : Bool, !b ≠ b := by decide
+lemma not_ne_self : ∀ b : Bool, (!b) ≠ b := by decide
 #align bool.bnot_ne_self Bool.not_ne_self
 
 lemma self_ne_not : ∀ b : Bool, b ≠ !b := by decide


### PR DESCRIPTION
where `!b ≠ b` is interpreted as `(!decide (b ≠ b))`, but meant to be `(!b) ≠ b`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
