### PR TITLE
[Merged by Bors] - fix: workaround for inferInstance bug in nontriviality

### DIFF
--- a/Mathlib/Tactic/Nontriviality/Core.lean
+++ b/Mathlib/Tactic/Nontriviality/Core.lean
@@ -33,14 +33,16 @@ def nontrivialityByElim (α : Q(Type u)) (g : MVarId) (simpArgs : Array Syntax) 
   let g₁ ← mkFreshExprMVarQ q(Subsingleton $α → $p)
   let (_, g₁') ← g₁.mvarId!.intro1
   g₁'.withContext try
-    g₁'.inferInstance <|> do
+    -- FIXME: restore after lean4#2054 is fixed
+    -- g₁'.inferInstance <|> do
+    (do g₁'.assign (← synthInstance (← g₁'.getType))) <|> do
       let simpArgs := simpArgs.push (Unhygienic.run `(Parser.Tactic.simpLemma| nontriviality))
       let stx := open TSyntax.Compat in Unhygienic.run `(tactic| simp [$simpArgs,*])
       let ([], _) ← runTactic g₁' stx | failure
   catch _ => throwError
     "Could not prove goal assuming `{q(Subsingleton $α)}`\n{MessageData.ofGoal g₁'}"
   let g₂ : Q(Nontrivial $α → $p) ← mkFreshExprMVarQ q(Nontrivial $α → $p)
-  g.assign q(@subsingleton_or_nontrivial_elim $p $α $g₁ $g₂)
+  g.assign q(subsingleton_or_nontrivial_elim $g₁ $g₂)
   pure g₂.mvarId!
 
 /--

--- a/Mathlib/Tactic/PrintPrefix.lean
+++ b/Mathlib/Tactic/PrintPrefix.lean
@@ -10,8 +10,6 @@ open Lean Meta Elab Command
 namespace Lean
 namespace Meta
 
-deriving instance Inhabited for ConstantInfo -- required for Array.qsort
-
 structure FindOptions where
   stage1       : Bool := true
   checkPrivate : Bool := false

--- a/test/nontriviality.lean
+++ b/test/nontriviality.lean
@@ -85,3 +85,8 @@ example (α : ℕ → Type) (a b : α 0) (h : a = b) : a = b := by
   nontriviality α 0 using Nat.zero_lt_one
   rename_i inst; guard_hyp inst : Nontrivial (α 0)
   exact h
+
+class Foo (α : Type) : Prop
+instance : Foo α := {}
+
+example (α : Type) : Foo α := by nontriviality α; infer_instance


### PR DESCRIPTION
As [reported on Zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/nontriviality.20leaves.20metavars/near/322890502).