### PR TITLE
[Merged by Bors] - fix: instantiate mvars before pattern matching on Type

### DIFF
--- a/Mathlib/Tactic/Linarith/Frontend.lean
+++ b/Mathlib/Tactic/Linarith/Frontend.lean
@@ -165,13 +165,28 @@ def applyContrLemma (g : MVarId) : MetaM (Option (Expr × Expr) × MVarId) := do
       return (some (tp, .fvar f), g)
   | none => return (none, g)
 
+abbrev ExprMultiMap α := Array (Expr × List α)
+
+def ExprMultiMap.find (self : ExprMultiMap α) (k : Expr) : MetaM (Nat × List α) := do
+  for h : i in [:self.size] do
+    let (k', vs) := self[i]'h.2
+    if ← isDefEq k' k then
+      return (i, vs)
+  return (self.size, [])
+
+def ExprMultiMap.insert (self : ExprMultiMap α) (k : Expr) (v : α) : MetaM (ExprMultiMap α) := do
+  for h : i in [:self.size] do
+    if ← isDefEq (self[i]'h.2).1 k then
+      return self.modify i fun (k, vs) => (k, v::vs)
+  return self.push (k, [v])
+
 /--
 `partitionByType l` takes a list `l` of proofs of comparisons. It sorts these proofs by
 the type of the variables in the comparison, e.g. `(a : ℚ) < 1` and `(b : ℤ) > c` will be separated.
 Returns a map from a type to a list of comparisons over that type.
 -/
-def partitionByType (l : List Expr) : MetaM (Std.HashMap Expr (List Expr)) :=
-l.foldlM (fun m h => do return m.consVal (← typeOfIneqProof h) h) HashMap.empty
+def partitionByType (l : List Expr) : MetaM (ExprMultiMap Expr) :=
+  l.foldlM (fun m h => do m.insert (← typeOfIneqProof h) h) #[]
 
 /--
 Given a list `ls` of lists of proofs of comparisons, `findLinarithContradiction cfg ls` will try to
@@ -203,10 +218,11 @@ let single_process : MVarId → List Expr → MetaM Expr :=
      ("after preprocessing, linarith has " ++ toString hyps.length ++ " facts:") hyps
    let hyp_set ← partitionByType hyps
    trace[linarith] m!"hypotheses appear in {hyp_set.size} different types"
-   match pref_type with
-   | some t => proveFalseByLinarith cfg g (hyp_set.findD t []) <|>
-               findLinarithContradiction cfg g ((hyp_set.erase t).values)
-   | none => findLinarithContradiction cfg g hyp_set.values
+    if let some t := pref_type then
+      let (i, vs) ← hyp_set.find t
+      proveFalseByLinarith cfg g vs <|>
+      findLinarithContradiction cfg g ((hyp_set.eraseIdx i).toList.map (·.2))
+    else findLinarithContradiction cfg g (hyp_set.toList.map (·.2))
 let preprocessors :=
   (if cfg.split_hypotheses then [Linarith.splitConjunctions.globalize.branching] else []) ++
   cfg.preprocessors.getD defaultPreprocessors

--- a/Mathlib/Tactic/Linarith/Frontend.lean
+++ b/Mathlib/Tactic/Linarith/Frontend.lean
@@ -165,8 +165,12 @@ def applyContrLemma (g : MVarId) : MetaM (Option (Expr × Expr) × MVarId) := do
       return (some (tp, .fvar f), g)
   | none => return (none, g)
 
+/-- A map of keys to values, where the keys are `Expr` up to defeq and one key can be
+associated to multiple values. -/
 abbrev ExprMultiMap α := Array (Expr × List α)
 
+/-- Retrieves the list of values at a key, as well as the index of the key for later modification.
+(If the key is not in the map it returns `self.size` as the index.) -/
 def ExprMultiMap.find (self : ExprMultiMap α) (k : Expr) : MetaM (Nat × List α) := do
   for h : i in [:self.size] do
     let (k', vs) := self[i]'h.2
@@ -174,6 +178,8 @@ def ExprMultiMap.find (self : ExprMultiMap α) (k : Expr) : MetaM (Nat × List �
       return (i, vs)
   return (self.size, [])
 
+/-- Insert a new value into the map at key `k`. This does a defeq check with all other keys
+in the map. -/
 def ExprMultiMap.insert (self : ExprMultiMap α) (k : Expr) (v : α) : MetaM (ExprMultiMap α) := do
   for h : i in [:self.size] do
     if ← isDefEq (self[i]'h.2).1 k then

--- a/Mathlib/Tactic/Linarith/Verification.lean
+++ b/Mathlib/Tactic/Linarith/Verification.lean
@@ -36,7 +36,8 @@ def ofNatQ (α : Q(Type $u)) (_ : Q(Semiring $α)) (n : ℕ) : Q($α) :=
 -- See https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Using.20.60QQ.60.20when.20you.20only.20have.20an.20.60Expr.60/near/303349037
 def inferTypeQ' (e : Expr) : MetaM ((u : Level) × (α : Q(Type $u)) × Q($α)) := do
   let α ← inferType e
-  let .sort (.succ u) ← whnf (← inferType α) | throwError "not a type{indentExpr α}"
+  let .sort (.succ u) ← instantiateMVars (← whnf (← inferType α))
+    | throwError "not a type{indentExpr α}"
   pure ⟨u, α, e⟩
 
 end Qq

--- a/test/linarith.lean
+++ b/test/linarith.lean
@@ -475,3 +475,8 @@ lemma bar (x y: Int) (h : 0 ≤ y ∧ 1 ≤ x) : 1 ≤ y + x * x := by linarith 
 
 -- -- issue #9822
 -- lemma mytest (j : ℕ) (h : 0 < j) : j-1 < j:= by linarith
+
+example [LinearOrderedCommRing α] (h : ∃ x : α, 0 ≤ x) : True := by
+  cases' h with x h
+  have : 0 ≤ x := by linarith
+  trivial

--- a/test/linarith.lean
+++ b/test/linarith.lean
@@ -478,5 +478,5 @@ lemma bar (x y: Int) (h : 0 ≤ y ∧ 1 ≤ x) : 1 ≤ y + x * x := by linarith 
 
 example [LinearOrderedCommRing α] (h : ∃ x : α, 0 ≤ x) : True := by
   cases' h with x h
-  have : 0 ≤ x := by linarith
+  have : 0 ≤ x; · linarith
   trivial


### PR DESCRIPTION
As [reported on Zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/linarith.20error.20in.20structured.20proof/near/322937531).