### PR TITLE
[Merged by Bors] - fix: to_additive translates constructors of inductive types

### DIFF
--- a/Mathlib/GroupTheory/Congruence.lean
+++ b/Mathlib/GroupTheory/Congruence.lean
@@ -102,9 +102,6 @@ inductive ConGen.Rel [Mul M] (r : M → M → Prop) : M → M → Prop
   | mul : ∀ {w x y z}, ConGen.Rel r w x → ConGen.Rel r y z → ConGen.Rel r (w * y) (x * z)
 #align con_gen.rel ConGen.Rel
 
-attribute [to_additive] ConGen.Rel.of ConGen.Rel.refl ConGen.Rel.symm ConGen.Rel.trans
-  ConGen.Rel.mul
-
 /-- The inductively defined smallest multiplicative congruence relation containing a given binary
     relation. -/
 @[to_additive addConGen "The inductively defined smallest additive congruence relation containing


### PR DESCRIPTION
[Zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/.60to_additive.60.20with.20.60inductive.60)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
