### PR TITLE
feat: add `#compile` command

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -806,6 +806,7 @@ import Mathlib.Testing.SlimCheck.Gen
 import Mathlib.Testing.SlimCheck.Sampleable
 import Mathlib.Testing.SlimCheck.Testable
 import Mathlib.Util.AtomM
+import Mathlib.Util.CompileInductive
 import Mathlib.Util.Export
 import Mathlib.Util.IncludeStr
 import Mathlib.Util.MemoFix

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -12,6 +12,7 @@ import Mathlib.Algebra.Group.Defs
 import Mathlib.Control.Functor
 import Mathlib.Data.Nat.Basic
 import Mathlib.Logic.Basic
+import Mathlib.Util.CompileInductive
 import Std.Tactic.Lint.Basic
 import Std.Data.RBMap.Basic
 
@@ -32,31 +33,9 @@ namespace List
 
 open Function Nat
 
-section recursor_workarounds
-/-- A computable version of `List.rec`. Workaround until Lean has native support for this. -/
-def recC.{u_1, u} {α : Type u} {motive : List α → Sort u_1} (nil : motive [])
-  (cons : (head : α) → (tail : List α) → motive tail → motive (head :: tail)) :
-    (l : List α) → motive l
-| [] => nil
-| (x :: xs) => cons x xs (List.recC nil cons xs)
-
-@[csimp]
-lemma rec_eq_recC : @List.rec = @List.recC := by
-  ext α motive nil cons l
-  induction l with
-  | nil => rfl
-  | cons x xs ih =>
-    rw [List.recC, ←ih]
-
-/-- A computable version of `List._sizeOf_inst`. -/
-def _sizeOf_instC.{u} (α : Type u) [SizeOf α] : SizeOf (List α) where
-  sizeOf t := List.rec 1 (fun head _ tail_ih => 1 + SizeOf.sizeOf head + tail_ih) t
-
-@[csimp]
-lemma _sizeOfinst_eq_sizeOfinstC : @List._sizeOf_inst = @List._sizeOf_instC := by
-  simp [List._sizeOf_1, List._sizeOf_instC, _sizeOf_inst]
-
-end recursor_workarounds
+#compile inductive List
+#compile def _sizeOf_1
+#compile def _sizeOf_inst
 
 universe u v w x
 

--- a/Mathlib/Data/W/Basic.lean
+++ b/Mathlib/Data/W/Basic.lean
@@ -183,7 +183,7 @@ private def encodable_succ (n : Nat) (h : Encodable (WType' β n)) : Encodable (
 /-- `WType` is encodable when `α` is an encodable fintype and for every `a : α`, `β a` is
 encodable. -/
 instance : Encodable (WType β) := by
-  haveI h' : ∀ n, Encodable (WType' β n) := fun n => Nat.recC encodable_zero encodable_succ n
+  haveI h' : ∀ n, Encodable (WType' β n) := fun n => Nat.rec encodable_zero encodable_succ n
   let f : WType β → Σn, WType' β n := fun t => ⟨t.depth, ⟨t, le_rfl⟩⟩
   let finv : (Σn, WType' β n) → WType β := fun p => p.2.1
   have : ∀ t, finv (f t) = t := fun t => rfl

--- a/Mathlib/Init/Data/Nat/Basic.lean
+++ b/Mathlib/Init/Data/Nat/Basic.lean
@@ -5,27 +5,11 @@ Authors: Floris van Doorn, Leonardo de Moura
 -/
 import Mathlib.Init.ZeroOne
 import Mathlib.Init.Data.Nat.Notation
+import Mathlib.Util.CompileInductive
 
 namespace Nat
 
-
-section recursor_workarounds
-
-/-- A computable version of `Nat.rec`. Workaround until Lean has native support for this. -/
-def recC.{u} {motive : ℕ → Sort u} (zero : motive zero)
-  (succ : (n : ℕ) → motive n → motive (succ n)) :
-  (t : ℕ) → motive t
-| 0 => zero
-| (n + 1) => succ n (recC zero succ n)
-
-@[csimp]
-theorem rec_eq_recC : @Nat.rec = @Nat.recC := by
-  funext motive zero succ n
-  induction n with
-  | zero => rfl
-  | succ n ih => rw [Nat.recC, ←ih]
-
-end recursor_workarounds
+#compile inductive Nat
 
 set_option linter.deprecated false
 

--- a/Mathlib/Util/CompileInductive.lean
+++ b/Mathlib/Util/CompileInductive.lean
@@ -127,7 +127,7 @@ def compileInductive (iv : InductiveVal) : TermElabM Unit := do
     return
   let levels := rv.levelParams.map .param
   let name ← mkFreshUserName rv.name
-  addAndCompile <| .mutualDefnDecl  [{ rv with
+  addAndCompile <| .mutualDefnDecl [{ rv with
     name
     value := ← forallTelescope rv.type λ xs body => do
       let val := .const (mkCasesOnName iv.name) levels
@@ -137,13 +137,13 @@ def compileInductive (iv : InductiveVal) : TermElabM Unit := do
       let val := mkAppN val <| rv.rules.toArray.map λ rule =>
         .beta (replaceConst rv.name name rule.rhs) xs[:rv.getFirstIndexIdx]
       mkLambdaFVars xs val
-    hints := .abbrev
+    hints := .opaque
     safety := .partial
   }]
   let old := .const rv.name levels
   let new := .const name levels
   let name ← mkFreshUserName <| rv.name.str "eq"
-  addDecl <| .thmDecl {
+  addDecl <| .mutualDefnDecl [{
     name
     levelParams := rv.levelParams
     type := ← mkEq rv.type old new
@@ -162,7 +162,9 @@ def compileInductive (iv : InductiveVal) : TermElabM Unit := do
           mkLambdaFVars ys pf'
       let pf := mkAppN pf xs[rv.getFirstIndexIdx:]
       mkFunExts' xs pf (body, old, new)
-  }
+    hints := .opaque
+    safety := .partial
+  }]
   Compiler.CSimp.add name .global
   for aux in [mkRecOnName iv.name, mkBRecOnName iv.name] do
     if let some (.defnInfo dv) := (← getEnv).find? aux then

--- a/Mathlib/Util/CompileInductive.lean
+++ b/Mathlib/Util/CompileInductive.lean
@@ -1,0 +1,184 @@
+/-
+Copyright (c) 2023 Parth Shastri. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Parth Shastri
+-/
+import Lean.Compiler.CSimpAttr
+import Lean.Elab.Predefinition
+
+/-!
+# Define the `#compile inductive` command.
+-/
+
+namespace Mathlib.Util
+
+open Lean
+
+private def replaceConst (old new : Name) (e : Expr) : Expr :=
+  e.replace λ | .const n us => if n == old then some (.const new us) else none | _ => none
+
+open Meta
+
+private def mkFunExts' (xs : Array Expr) (e : Expr) (βfg : Expr × Expr × Expr) : MetaM Expr :=
+  Prod.fst <$> xs.foldrM (init := (e, βfg)) λ x (e, β, f, g) => do
+    let α ← inferType x
+    let f ← mkLambdaFVars #[x] f
+    let g ← mkLambdaFVars #[x] g
+    return (
+      mkApp5
+        (.const ``funext [(← inferType α).sortLevel!, (← inferType β).sortLevel!])
+        α
+        (← mkLambdaFVars #[x] β)
+        f
+        g
+        (← mkLambdaFVars #[x] e),
+      ← mkForallFVars #[x] β,
+      f,
+      g
+    )
+
+private def mkFunExts (e : Expr) : MetaM Expr := do
+  forallTelescope (← inferType e) λ xs body => do
+    let some βfg := (← whnf body).eq?
+      | throwError "expected equality"
+    mkFunExts' xs (mkAppN e xs) βfg
+
+private def mkEq (α a b : Expr) : MetaM Expr := do
+  return mkApp3 (.const ``Eq [(← inferType α).sortLevel!]) α a b
+
+open Elab
+
+/--
+Compile the definition `dv`.
+-/
+def compileDefn (dv : DefinitionVal) : TermElabM Unit := do
+  let name ← mkFreshUserName dv.name
+  addAndCompile <| .defnDecl { dv with name }
+  let levels := dv.levelParams.map .param
+  let old := .const dv.name levels
+  let new := .const name levels
+  let name ← mkFreshUserName <| dv.name.str "eq"
+  addDecl <| .thmDecl {
+    name
+    levelParams := dv.levelParams
+    type := ← mkEq dv.type old new
+    value := ← mkEqRefl old
+  }
+  Compiler.CSimp.add name .global
+
+/--
+`#compile def i` compiles the definition `i`.
+-/
+elab tk:"#compile " "def " i:ident : command => Command.liftTermElabM do
+  let n ← resolveGlobalConstNoOverload i
+  let dv ← withRef i <| getConstInfoDefn n
+  withRef tk <| compileDefn dv
+
+private def compilePropStructure (iv : InductiveVal) (rv : RecursorVal) : TermElabM Unit := do
+  let name ← mkFreshUserName rv.name
+  addAndCompile <| .defnDecl {
+    name
+    levelParams := rv.levelParams
+    type := rv.type
+    value := ← forallTelescope rv.type λ xs _ => do
+      let val := xs[rv.getFirstMinorIdx]!
+      let val := mkAppN val <| .mk <| .map (.proj iv.name · xs[rv.getMajorIdx]!) <| .range rv.rules[0]!.nfields
+      mkLambdaFVars xs val
+    hints := .abbrev
+    safety := .safe
+  }
+  let levels := rv.levelParams.map .param
+  let old := .const rv.name levels
+  let new := .const name levels
+  let name ← mkFreshUserName <| rv.name.str "eq"
+  addDecl <| .thmDecl {
+    name
+    levelParams := rv.levelParams
+    type := ← mkEq rv.type old new
+    value := ← forallTelescope rv.type λ xs body => do
+      let pf := .const rv.name (.zero :: levels.tail!)
+      let pf := mkAppN pf xs[:rv.numParams]
+      let old := mkAppN old xs
+      let new := mkAppN new xs
+      let pf := .app pf <| ← mkLambdaFVars xs[rv.getFirstIndexIdx:] <| ← mkEq body old new
+      let minor := xs[rv.getFirstMinorIdx]!
+      let pf := .app pf <| ← forallTelescope (← inferType minor) λ ys _ => do
+        let pf' ← mkEqRefl <| mkAppN minor ys[:rv.rules[0]!.nfields]
+        mkLambdaFVars ys pf'
+      let pf := .app pf xs[rv.getMajorIdx]!
+      mkFunExts' xs pf (body, old, new)
+    }
+  Compiler.CSimp.add name .global
+  compileDefn <| ← getConstInfoDefn <| mkRecOnName iv.name
+
+/--
+Compile the recursor for `iv`.
+-/
+def compileInductive (iv : InductiveVal) : TermElabM Unit := do
+  let rv ← getConstInfoRec <| mkRecName iv.name
+  if ← isProp rv.type then
+    logWarning m!"not compiling {rv.name}"
+    return
+  unless rv.numMotives == 1 do
+    throwError "mutual/nested inductives unsupported"
+  if iv.type.getForallBody.isProp && !iv.isRec && iv.numCtors == 1 && iv.numIndices == 0 then
+    compilePropStructure iv rv
+    return
+  let levels := rv.levelParams.map .param
+  let name ← mkFreshUserName rv.name
+  addPreDefinitions #[{
+    ref := ← getRef
+    kind := .def
+    levelParams := rv.levelParams
+    modifiers := {}
+    declName := name
+    type := rv.type
+    value := ← forallTelescope rv.type λ xs body => do
+      let val := .const (mkCasesOnName iv.name) levels
+      let val := mkAppN val xs[:rv.numParams]
+      let val := .app val <| ← mkLambdaFVars xs[rv.getFirstIndexIdx:] body
+      let val := mkAppN val xs[rv.getFirstIndexIdx:]
+      let val := mkAppN val <| rv.rules.toArray.map λ rule =>
+        .beta (replaceConst rv.name name rule.rhs) xs[:rv.getFirstIndexIdx]
+      mkLambdaFVars xs val
+  }] {}
+  let some eqn ← getUnfoldEqnFor? name true
+    | throwError "no unfold equation found"
+  let old := .const rv.name levels
+  let new := .const name levels
+  let name ← mkFreshUserName <| rv.name.str "eq"
+  addDecl <| .thmDecl {
+    name
+    levelParams := rv.levelParams
+    type := ← mkEq rv.type old new
+    value := ← forallTelescope rv.type λ xs body => do
+      let pf := .const rv.name (.zero :: levels.tail!)
+      let pf := mkAppN pf xs[:rv.numParams]
+      let old := mkAppN old xs
+      let new := mkAppN new xs
+      let motive ← mkLambdaFVars xs[rv.getFirstIndexIdx:] <| ← mkEq body old new
+      let pf := .app pf motive
+      let eqn := mkAppN (.const eqn levels) xs[:rv.getFirstIndexIdx]
+      let pf := mkAppN pf <| ← rv.rules.toArray.zip xs[rv.getFirstMinorIdx:] |>.mapM λ (rule, minor) => do
+        forallTelescope ((← inferType minor).replaceFVar xs[rv.numParams]! motive) λ ys body' => do
+          let pf' ← mkEqRefl <| mkAppN minor ys[:rule.nfields]
+          let pf' ← ys[rule.nfields:].foldlM (λ pf' y => do mkCongr pf' (← mkFunExts y)) pf'
+          let eqn := mkAppN eqn body'.getAppArgs
+          let eqn ← mkEqSymm eqn
+          let pf' ← mkEqTrans pf' eqn
+          mkLambdaFVars ys pf'
+      let pf := mkAppN pf xs[rv.getFirstIndexIdx:]
+      mkFunExts' xs pf (body, old, new)
+  }
+  Compiler.CSimp.add name .global
+  for aux in [mkRecOnName iv.name, mkBRecOnName iv.name] do
+    if let some (.defnInfo dv) := (← getEnv).find? aux then
+      compileDefn dv
+
+/--
+`#compile inductive i` compiles the recursor for `i`.
+-/
+elab tk:"#compile " "inductive " i:ident : command => Command.liftTermElabM do
+  let n ← resolveGlobalConstNoOverload i
+  let iv ← withRef i <| getConstInfoInduct n
+  withRef tk <| compileInductive iv

--- a/test/CompileInductive.lean
+++ b/test/CompileInductive.lean
@@ -36,17 +36,13 @@ example := @List._sizeOf_1
 open Lean
 
 #eval Elab.Command.liftTermElabM do
-  let ivs := (← getEnv).constants.toList |>.filterMap λ | (_, .inductInfo iv) => some iv | _ => none
+  let ivs := (← getEnv).constants.toList.filterMap λ | (_, .inductInfo iv) => some iv | _ => none
   let mut success := 0
-  let mut skipped := 0
   for iv in ivs do
     try
-      unless (← getConstInfoRec <| mkRecName iv.name).numMotives == 1 do
-        skipped := skipped + 1
-        continue
       withCurrHeartbeats <| Mathlib.Util.compileInductive iv
       success := success + 1
     catch | e => logError m!"[{iv.name}] {e.toMessageData}"
   modifyThe Core.State λ s => { s with messages.msgs := s.messages.msgs.filter (·.severity != .warning) }
   modifyThe Core.State λ s => { s with messages := s.messages.errorsToWarnings }
-  logInfo m!"{success} / {ivs.length - skipped}"
+  logInfo m!"{success} / {ivs.length}"

--- a/test/CompileInductive.lean
+++ b/test/CompileInductive.lean
@@ -1,0 +1,52 @@
+import Mathlib
+
+#compile inductive Nat
+#compile inductive List
+#compile inductive Fin2
+#compile inductive PUnit
+#compile inductive PEmpty
+#compile inductive And
+#compile inductive Or
+#compile inductive False
+#compile inductive Empty
+
+example := @Nat.rec
+example := @List.rec
+example := @Fin2.rec
+example := @PUnit.rec
+example := @PEmpty.rec
+
+example := @Nat.recOn
+example := @List.recOn
+example := @Fin2.recOn
+example := @PUnit.recOn
+example := @PEmpty.recOn
+example := @And.recOn
+example := @False.recOn
+example := @Empty.recOn
+
+example := @Nat.brecOn
+example := @List.brecOn
+example := @Fin2.brecOn
+
+#compile def List._sizeOf_1
+
+example := @List._sizeOf_1
+
+open Lean
+
+#eval Elab.Command.liftTermElabM do
+  let ivs := (← getEnv).constants.toList |>.filterMap λ | (_, .inductInfo iv) => some iv | _ => none
+  let mut success := 0
+  let mut skipped := 0
+  for iv in ivs do
+    try
+      unless (← getConstInfoRec <| mkRecName iv.name).numMotives == 1 do
+        skipped := skipped + 1
+        continue
+      withCurrHeartbeats <| Mathlib.Util.compileInductive iv
+      success := success + 1
+    catch | e => logError m!"[{iv.name}] {e.toMessageData}"
+  modifyThe Core.State λ s => { s with messages.msgs := s.messages.msgs.filter (·.severity != .warning) }
+  modifyThe Core.State λ s => { s with messages := s.messages.errorsToWarnings }
+  logInfo m!"{success} / {ivs.length - skipped}"


### PR DESCRIPTION
---
Add a `#compile inductive` command to compile the recursors of an inductive type, which works by creating a recursive definition and using `@[csimp]`.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)