### PR TITLE
[Merged by Bors] - feat: port GroupTheory.Subgroup.MulOpposite

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -562,6 +562,7 @@ import Mathlib.GroupTheory.Perm.Support
 import Mathlib.GroupTheory.Perm.ViaEmbedding
 import Mathlib.GroupTheory.Subgroup.Actions
 import Mathlib.GroupTheory.Subgroup.Basic
+import Mathlib.GroupTheory.Subgroup.MulOpposite
 import Mathlib.GroupTheory.Subgroup.Zpowers
 import Mathlib.GroupTheory.Submonoid.Basic
 import Mathlib.GroupTheory.Submonoid.Center

--- a/Mathlib/GroupTheory/Subgroup/MulOpposite.lean
+++ b/Mathlib/GroupTheory/Subgroup/MulOpposite.lean
@@ -24,47 +24,45 @@ variable {G : Type _} [Group G]
 namespace Subgroup
 
 /-- A subgroup `H` of `G` determines a subgroup `H.opposite` of the opposite group `Gᵐᵒᵖ`. -/
-@[to_additive
-      "An additive subgroup `H` of `G` determines an additive subgroup `H.opposite` of the\n  opposite additive group `Gᵃᵒᵖ`."]
+@[to_additive "An additive subgroup `H` of `G` determines an additive subgroup `H.opposite` of the
+ opposite additive group `Gᵃᵒᵖ`."]
 def opposite : Subgroup G ≃ Subgroup Gᵐᵒᵖ
     where
   toFun H :=
     { carrier := MulOpposite.unop ⁻¹' (H : Set G)
       one_mem' := H.one_mem
-      mul_mem' := fun a b ha hb => H.mul_mem hb ha
-      inv_mem' := fun a => H.inv_mem }
+      mul_mem' := fun ha hb => H.mul_mem hb ha
+      inv_mem' := H.inv_mem }
   invFun H :=
     { carrier := MulOpposite.op ⁻¹' (H : Set Gᵐᵒᵖ)
       one_mem' := H.one_mem
-      mul_mem' := fun a b ha hb => H.mul_mem hb ha
-      inv_mem' := fun a => H.inv_mem }
-  left_inv H := SetLike.coe_injective rfl
-  right_inv H := SetLike.coe_injective rfl
+      mul_mem' := fun ha hb => H.mul_mem hb ha
+      inv_mem' := H.inv_mem }
+  left_inv _ := SetLike.coe_injective rfl
+  right_inv _ := SetLike.coe_injective rfl
 #align subgroup.opposite Subgroup.opposite
 #align add_subgroup.opposite AddSubgroup.opposite
 
 /-- Bijection between a subgroup `H` and its opposite. -/
 @[to_additive "Bijection between an additive subgroup `H` and its opposite.", simps]
-def oppositeEquiv (H : Subgroup G) : H ≃ H.opposite :=
+def oppositeEquiv (H : Subgroup G) : H ≃ opposite H :=
   MulOpposite.opEquiv.subtypeEquiv fun _ => Iff.rfl
 #align subgroup.opposite_equiv Subgroup.oppositeEquiv
 #align add_subgroup.opposite_equiv AddSubgroup.oppositeEquiv
 
 @[to_additive]
-instance (H : Subgroup G) [Encodable H] : Encodable H.opposite :=
+instance (H : Subgroup G) [Encodable H] : Encodable (opposite H) :=
   Encodable.ofEquiv H H.oppositeEquiv.symm
 
 @[to_additive]
-instance (H : Subgroup G) [Countable H] : Countable H.opposite :=
+instance (H : Subgroup G) [Countable H] : Countable (opposite H) :=
   Countable.of_equiv H H.oppositeEquiv
 
 @[to_additive]
-theorem smul_opposite_mul {H : Subgroup G} (x g : G) (h : H.opposite) : h • (g * x) = g * h • x :=
-  by
-  cases h
-  simp [(· • ·), mul_assoc]
+theorem smul_opposite_mul {H : Subgroup G} (x g : G) (h : opposite H) :
+    h • (g * x) = g * h • x :=
+  mul_assoc _ _ _
 #align subgroup.smul_opposite_mul Subgroup.smul_opposite_mul
 #align add_subgroup.vadd_opposite_add AddSubgroup.vadd_opposite_add
 
 end Subgroup
-

--- a/Mathlib/GroupTheory/Subgroup/MulOpposite.lean
+++ b/Mathlib/GroupTheory/Subgroup/MulOpposite.lean
@@ -8,7 +8,7 @@ Authors: Alex Kontorovich
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
-import Mathbin.GroupTheory.Subgroup.Actions
+import Mathlib.GroupTheory.Subgroup.Actions
 
 /-!
 # Mul-opposite subgroups

--- a/Mathlib/GroupTheory/Subgroup/MulOpposite.lean
+++ b/Mathlib/GroupTheory/Subgroup/MulOpposite.lean
@@ -1,0 +1,70 @@
+/-
+Copyright (c) 2022 Alex Kontorovich. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Alex Kontorovich
+
+! This file was ported from Lean 3 source module group_theory.subgroup.mul_opposite
+! leanprover-community/mathlib commit f93c11933efbc3c2f0299e47b8ff83e9b539cbf6
+! Please do not edit these lines, except to modify the commit id
+! if you have ported upstream changes.
+-/
+import Mathbin.GroupTheory.Subgroup.Actions
+
+/-!
+# Mul-opposite subgroups
+
+## Tags
+subgroup, subgroups
+
+-/
+
+
+variable {G : Type _} [Group G]
+
+namespace Subgroup
+
+/-- A subgroup `H` of `G` determines a subgroup `H.opposite` of the opposite group `Gᵐᵒᵖ`. -/
+@[to_additive
+      "An additive subgroup `H` of `G` determines an additive subgroup `H.opposite` of the\n  opposite additive group `Gᵃᵒᵖ`."]
+def opposite : Subgroup G ≃ Subgroup Gᵐᵒᵖ
+    where
+  toFun H :=
+    { carrier := MulOpposite.unop ⁻¹' (H : Set G)
+      one_mem' := H.one_mem
+      mul_mem' := fun a b ha hb => H.mul_mem hb ha
+      inv_mem' := fun a => H.inv_mem }
+  invFun H :=
+    { carrier := MulOpposite.op ⁻¹' (H : Set Gᵐᵒᵖ)
+      one_mem' := H.one_mem
+      mul_mem' := fun a b ha hb => H.mul_mem hb ha
+      inv_mem' := fun a => H.inv_mem }
+  left_inv H := SetLike.coe_injective rfl
+  right_inv H := SetLike.coe_injective rfl
+#align subgroup.opposite Subgroup.opposite
+#align add_subgroup.opposite AddSubgroup.opposite
+
+/-- Bijection between a subgroup `H` and its opposite. -/
+@[to_additive "Bijection between an additive subgroup `H` and its opposite.", simps]
+def oppositeEquiv (H : Subgroup G) : H ≃ H.opposite :=
+  MulOpposite.opEquiv.subtypeEquiv fun _ => Iff.rfl
+#align subgroup.opposite_equiv Subgroup.oppositeEquiv
+#align add_subgroup.opposite_equiv AddSubgroup.oppositeEquiv
+
+@[to_additive]
+instance (H : Subgroup G) [Encodable H] : Encodable H.opposite :=
+  Encodable.ofEquiv H H.oppositeEquiv.symm
+
+@[to_additive]
+instance (H : Subgroup G) [Countable H] : Countable H.opposite :=
+  Countable.of_equiv H H.oppositeEquiv
+
+@[to_additive]
+theorem smul_opposite_mul {H : Subgroup G} (x g : G) (h : H.opposite) : h • (g * x) = g * h • x :=
+  by
+  cases h
+  simp [(· • ·), mul_assoc]
+#align subgroup.smul_opposite_mul Subgroup.smul_opposite_mul
+#align add_subgroup.vadd_opposite_add AddSubgroup.vadd_opposite_add
+
+end Subgroup
+


### PR DESCRIPTION
porting notes:

1. the `H.opposite` notation isn't working, which I think is due to the fact that `subgroup.opposite` is an equiv and Lean doesn't find the `CoeFun` instance. I think I saw something on Zulip about this, but I can't find it. I'm not sure if there is a resolution; to get it working I just wrote `opposite H` instead of `H.opposite`
2. the `simp` call at the end was broken, I think because it didn't rewrite the scalar multiplication by the opposite element as multiplication on the right, so I just golfed it.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
