### PR TITLE
fix: fin bug in to_additive

### DIFF
--- a/Mathlib/Lean/Expr/Basic.lean
+++ b/Mathlib/Lean/Expr/Basic.lean
@@ -164,6 +164,17 @@ def fvarId? : Expr → Option FVarId
   | .fvar n => n
   | _ => none
 
+/-- `isConstantApplication e` checks whether `e` is syntactically an application of the form
+  `(fun x₁ ⋯ xₙ => H) y₁ ⋯ yₙ` where `H` does not depend on `xₙ`. In other words,
+  it does a syntactic check that the expression does not depend on `yₙ`. -/
+def isConstantApplication (e : Expr) :=
+e.isApp && aux e.getAppNumArgs'.pred e.getAppFn' e.getAppNumArgs'
+where
+  aux (depth : Nat) : Expr → Nat → Bool
+  | .lam _ _ b _, n + 1  => aux depth b n
+  | e, 0  => !e.hasLooseBVar (depth - 1)
+  | _, _ => false
+
 open Meta
 
 /-- Check that an expression contains no metavariables (after instantiation). -/

--- a/Mathlib/Lean/Expr/Basic.lean
+++ b/Mathlib/Lean/Expr/Basic.lean
@@ -165,7 +165,7 @@ def fvarId? : Expr → Option FVarId
   | _ => none
 
 /-- `isConstantApplication e` checks whether `e` is syntactically an application of the form
-  `(fun x₁ ⋯ xₙ => H) y₁ ⋯ yₙ` where `H` does not depend on `xₙ`. In other words,
+  `(fun x₁ ⋯ xₙ => H) y₁ ⋯ yₙ` where `H` does not contain the variable `xₙ`. In other words,
   it does a syntactic check that the expression does not depend on `yₙ`. -/
 def isConstantApplication (e : Expr) :=
 e.isApp && aux e.getAppNumArgs'.pred e.getAppFn' e.getAppNumArgs'

--- a/Mathlib/Lean/Expr/Basic.lean
+++ b/Mathlib/Lean/Expr/Basic.lean
@@ -170,6 +170,8 @@ def fvarId? : Expr → Option FVarId
 def isConstantApplication (e : Expr) :=
 e.isApp && aux e.getAppNumArgs'.pred e.getAppFn' e.getAppNumArgs'
 where
+  /-- `aux depth e n` checks whether the body of the `n`-th lambda of `e` has loose bvar
+    `depth - 1`. -/
   aux (depth : Nat) : Expr → Nat → Bool
   | .lam _ _ b _, n + 1  => aux depth b n
   | e, 0  => !e.hasLooseBVar (depth - 1)

--- a/Mathlib/Tactic/ToAdditive.lean
+++ b/Mathlib/Tactic/ToAdditive.lean
@@ -251,7 +251,7 @@ private def additiveTestAux (findTranslation? : Name → Option Name)
   | _, x@(.app e a)       => Id.run do
       if !visit true e then
         return false
-      -- take care of constant functions, like `(fun x => α) (n + 1)`
+      -- make sure that we don't treat `(fun x => α) (n + 1)` as a type that depends on `Nat`
       if x.isConstantApplication then
         return true
       if let some n := e.getAppFn.constName? then
@@ -362,13 +362,14 @@ where /-- Implementation of `applyReplacementFun`. -/
         let firstArg := if h : gArgs.size > 0 then gArgs[0] else x
         if !shouldTranslateNumeral findTranslation? ignore fixedNumeral nm firstArg then
           if trace then
-            dbg_trace s!""
+            dbg_trace s!"applyReplacementFun: Do not change numeral {g.app x}"
           return some <| g.app x
       return e.updateApp! (← r g) (← r x)
     | .proj n₀ idx e => do
       let n₁ := n₀.mapPrefix findTranslation?
       if trace then
-        dbg_trace s!""
+        dbg_trace s!"applyReplacementFun: in projection {e}.{idx} of type {n₀}, {""
+          }replace type with {n₁}"
       return some <| .proj n₁ idx <| ← r e
     | _ => return none
 

--- a/Mathlib/Tactic/ToAdditive.lean
+++ b/Mathlib/Tactic/ToAdditive.lean
@@ -342,16 +342,14 @@ where /-- Implementation of `applyReplacementFun`. -/
             let ga := r g.appArg!
             let e₂ := mkApp2 gf x ga
             if trace then
-              dbg_trace
-                s!"reordering {nm}: {x} ↔ {ga}\nBefore: {e}\nAfter: {e₂}"
+              dbg_trace s!"reordering {nm}: {x} ↔ {ga}\nBefore: {e}\nAfter: {e₂}"
             return some e₂
         /- Test if the head should not be replaced. -/
         let c1 := isRelevant nm gArgs.size
         let c2 := gf.isConst
         let c3 := additiveTest findTranslation? ignore x
         if trace && c1 && c2 && c3 then
-          dbg_trace
-            s!"{x} doesn't contain a fixed type, so we will change {nm}"
+          dbg_trace s!"{x} doesn't contain a fixed type, so we will change {nm}"
         if c1 && c2 && not c3 then
           if trace then
             dbg_trace s!"{x} contains a fixed type, so {nm} is not changed"

--- a/test/toAdditive.lean
+++ b/test/toAdditive.lean
@@ -283,6 +283,13 @@ run_cmd do
   let e : Expr := Ones 300
   let _ ← Elab.Command.liftCoreM <| MetaM.run' <| ToAdditive.applyReplacementFun e
 
+-- testing `isConstantApplication`
+run_cmd do
+  unless !(q((fun _ y => y) 3 4) : Q(Nat)).isConstantApplication do throwError "1"
+  unless (q((fun x _ => x) 3 4) : Q(Nat)).isConstantApplication do throwError "2"
+  unless !(q((fun x => x) 3) : Q(Nat)).isConstantApplication do throwError "3"
+  unless (q((fun _ => 5) 3) : Q(Nat)).isConstantApplication do throwError "4"
+
 
 
 

--- a/test/toAdditive.lean
+++ b/test/toAdditive.lean
@@ -167,6 +167,14 @@ def some_def.in_namespace : Bool := false
 def some_def {α : Type u} [Mul α] (x : α) : α :=
 if some_def.in_namespace then x * x else x
 
+def myFin (_ : ℕ) := ℕ
+
+instance : One (myFin n) := ⟨(1 : ℕ)⟩
+
+@[to_additive bar]
+def myFin.foo : myFin (n+1) := 1
+
+
 
 -- cannot apply `@[to_additive]` to `some_def` if `some_def.in_namespace` doesn't have the attribute
 run_cmd Elab.Command.liftCoreM <| successIfFail <|
@@ -268,10 +276,11 @@ def Ones : ℕ → Q(Nat)
 | 0     => q(1)
 | (n+1) => q($(Ones n) + $(Ones n))
 
+
 -- this test just exists to see if this finishes in finite time. It should take <100ms.
 -- #time
 run_cmd do
-  let e : Expr := Ones 400
+  let e : Expr := Ones 300
   let _ ← Elab.Command.liftCoreM <| MetaM.run' <| ToAdditive.applyReplacementFun e
 
 


### PR DESCRIPTION
* The `to_additive` heuristic was ported wrong (a conjunction in Lean 3 was ported to a disjunction in Lean 4)
  * I had to add a check to take care that heuristic doesn't treat `(fun x => α) (n + 1)` as a type that depends on `Nat`. This was causing at least one error.
* Also re-add some simple debug tracing in `applyReplacementFun` (with `dbg_trace`, since it's a pure function).
* In a future PR I will speed-up `additiveTestAux`, since it's currently still exponentially slower than necessary (though usually applied to only small terms).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
