### PR TITLE
[Merged by Bors] - fix: set the local context in mod_cases

### DIFF
--- a/Mathlib/Tactic/ModCases.lean
+++ b/Mathlib/Tactic/ModCases.lean
@@ -79,7 +79,7 @@ partial def proveOnModCases (n : Q(ℕ)) (a : Q(ℤ)) (b : Q(ℕ)) (p : Q(Sort u
 syntax "mod_cases " (atomic(binderIdent ":"))? term:71 " % " num : tactic
 
 elab_rules : tactic
-  | `(tactic| mod_cases $[$h :]? $e % $n) => do
+  | `(tactic| mod_cases $[$h :]? $e % $n) => withMainContext do
     let n := n.getNat
     if n == 0 then Elab.throwUnsupportedSyntax
     let g ← getMainGoal

--- a/Mathlib/Tactic/ModCases.lean
+++ b/Mathlib/Tactic/ModCases.lean
@@ -79,10 +79,11 @@ partial def proveOnModCases (n : Q(ℕ)) (a : Q(ℤ)) (b : Q(ℕ)) (p : Q(Sort u
 syntax "mod_cases " (atomic(binderIdent ":"))? term:71 " % " num : tactic
 
 elab_rules : tactic
-  | `(tactic| mod_cases $[$h :]? $e % $n) => withMainContext do
+  | `(tactic| mod_cases $[$h :]? $e % $n) => do
     let n := n.getNat
     if n == 0 then Elab.throwUnsupportedSyntax
     let g ← getMainGoal
+    g.withContext do
     let ⟨u, p, g⟩ ← inferTypeQ (.mvar g)
     let e : Q(ℤ) ← Tactic.elabTermEnsuringType e q(ℤ)
     let h := h.getD (← `(binderIdent| _))

--- a/test/mod_cases.lean
+++ b/test/mod_cases.lean
@@ -5,3 +5,12 @@ example (n : ℤ) : 3 ∣ n ^ 3 - n := by
   · guard_hyp H :ₛ n ≡ 0 [ZMOD 3]; guard_target = 3 ∣ n ^ 3 - n; sorry
   · guard_hyp H :ₛ n ≡ 1 [ZMOD 3]; guard_target = 3 ∣ n ^ 3 - n; sorry
   · guard_hyp H :ₛ n ≡ 2 [ZMOD 3]; guard_target = 3 ∣ n ^ 3 - n; sorry
+
+-- test case for https://github.com/leanprover-community/mathlib4/issues/1851
+example (n : ℕ) (z : ℤ) : n = n := by
+  induction n with
+  | zero => rfl
+  | succ n ih =>
+     mod_cases h : z % 2
+     · sorry
+     · sorry


### PR DESCRIPTION
Wraps the main part of the `mod_cases` elaboration function in `g.withContext`, so that when the subgoal mvars are created their fvars can be properly resolved.

Fixes #1851.
