### PR TITLE
[Merged by Bors] - feat: port GroupTheory.GroupAction.ConjAct

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -549,6 +549,7 @@ import Mathlib.GroupTheory.Congruence
 import Mathlib.GroupTheory.EckmannHilton
 import Mathlib.GroupTheory.GroupAction.Basic
 import Mathlib.GroupTheory.GroupAction.BigOperators
+import Mathlib.GroupTheory.GroupAction.ConjAct
 import Mathlib.GroupTheory.GroupAction.Defs
 import Mathlib.GroupTheory.GroupAction.Embedding
 import Mathlib.GroupTheory.GroupAction.Group

--- a/Mathlib/GroupTheory/GroupAction/ConjAct.lean
+++ b/Mathlib/GroupTheory/GroupAction/ConjAct.lean
@@ -8,9 +8,9 @@ Authors: Chris Hughes
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
-import Mathbin.GroupTheory.GroupAction.Basic
-import Mathbin.GroupTheory.Subgroup.Zpowers
-import Mathbin.Algebra.GroupRingAction.Basic
+import Mathlib.GroupTheory.GroupAction.Basic
+import Mathlib.GroupTheory.Subgroup.Zpowers
+import Mathlib.Algebra.GroupRingAction.Basic
 
 /-!
 # Conjugation action of a group on itself
@@ -275,8 +275,7 @@ theorem smul_eq_mulAut_conj (g : ConjAct G) (h : G) : g • h = MulAut.conj (ofC
 #align conj_act.smul_eq_mul_aut_conj ConjAct.smul_eq_mulAut_conj
 
 /-- The set of fixed points of the conjugation action of `G` on itself is the center of `G`. -/
-theorem fixedPoints_eq_center : fixedPoints (ConjAct G) G = center G :=
-  by
+theorem fixedPoints_eq_center : fixedPoints (ConjAct G) G = center G := by
   ext x
   simp [mem_center_iff, smul_def, mul_inv_eq_iff_eq_mul]
 #align conj_act.fixed_points_eq_center ConjAct.fixedPoints_eq_center
@@ -315,8 +314,7 @@ theorem MulAut.conjNormal_apply {H : Subgroup G} [H.Normal] (g : G) (h : H) :
 
 @[simp]
 theorem MulAut.conjNormal_symm_apply {H : Subgroup G} [H.Normal] (g : G) (h : H) :
-    ↑((MulAut.conjNormal g).symm h) = g⁻¹ * h * g :=
-  by
+    ↑((MulAut.conjNormal g).symm h) = g⁻¹ * h * g := by
   change _ * _⁻¹⁻¹ = _
   rw [inv_inv]
   rfl

--- a/Mathlib/GroupTheory/GroupAction/ConjAct.lean
+++ b/Mathlib/GroupTheory/GroupAction/ConjAct.lean
@@ -1,0 +1,346 @@
+/-
+Copyright (c) 2021 . All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Hughes
+
+! This file was ported from Lean 3 source module group_theory.group_action.conj_act
+! leanprover-community/mathlib commit f93c11933efbc3c2f0299e47b8ff83e9b539cbf6
+! Please do not edit these lines, except to modify the commit id
+! if you have ported upstream changes.
+-/
+import Mathbin.GroupTheory.GroupAction.Basic
+import Mathbin.GroupTheory.Subgroup.Zpowers
+import Mathbin.Algebra.GroupRingAction.Basic
+
+/-!
+# Conjugation action of a group on itself
+
+This file defines the conjugation action of a group on itself. See also `mul_aut.conj` for
+the definition of conjugation as a homomorphism into the automorphism group.
+
+## Main definitions
+
+A type alias `conj_act G` is introduced for a group `G`. The group `conj_act G` acts on `G`
+by conjugation. The group `conj_act G` also acts on any normal subgroup of `G` by conjugation.
+
+As a generalization, this also allows:
+* `conj_act Mˣ` to act on `M`, when `M` is a `monoid`
+* `conj_act G₀` to act on `G₀`, when `G₀` is a `group_with_zero`
+
+## Implementation Notes
+
+The scalar action in defined in this file can also be written using `mul_aut.conj g • h`. This
+has the advantage of not using the type alias `conj_act`, but the downside of this approach
+is that some theorems about the group actions will not apply when since this
+`mul_aut.conj g • h` describes an action of `mul_aut G` on `G`, and not an action of `G`.
+
+-/
+
+
+variable (α M G G₀ R K : Type _)
+
+/-- A type alias for a group `G`. `conj_act G` acts on `G` by conjugation -/
+def ConjAct : Type _ :=
+  G
+#align conj_act ConjAct
+
+namespace ConjAct
+
+open MulAction Subgroup
+
+variable {M G G₀ R K}
+
+instance : ∀ [Group G], Group (ConjAct G) :=
+  id
+
+instance : ∀ [DivInvMonoid G], DivInvMonoid (ConjAct G) :=
+  id
+
+instance : ∀ [GroupWithZero G], GroupWithZero (ConjAct G) :=
+  id
+
+instance : ∀ [Fintype G], Fintype (ConjAct G) :=
+  id
+
+@[simp]
+theorem card [Fintype G] : Fintype.card (ConjAct G) = Fintype.card G :=
+  rfl
+#align conj_act.card ConjAct.card
+
+section DivInvMonoid
+
+variable [DivInvMonoid G]
+
+instance : Inhabited (ConjAct G) :=
+  ⟨1⟩
+
+/-- Reinterpret `g : conj_act G` as an element of `G`. -/
+def ofConjAct : ConjAct G ≃* G :=
+  ⟨id, id, fun _ => rfl, fun _ => rfl, fun _ _ => rfl⟩
+#align conj_act.of_conj_act ConjAct.ofConjAct
+
+/-- Reinterpret `g : G` as an element of `conj_act G`. -/
+def toConjAct : G ≃* ConjAct G :=
+  ofConjAct.symm
+#align conj_act.to_conj_act ConjAct.toConjAct
+
+/-- A recursor for `conj_act`, for use as `induction x using conj_act.rec` when `x : conj_act G`. -/
+protected def rec {C : ConjAct G → Sort _} (h : ∀ g, C (toConjAct g)) : ∀ g, C g :=
+  h
+#align conj_act.rec ConjAct.rec
+
+@[simp]
+theorem forall (p : ConjAct G → Prop) : (∀ x : ConjAct G, p x) ↔ ∀ x : G, p (toConjAct x) :=
+  Iff.rfl
+#align conj_act.forall ConjAct.forall
+
+@[simp]
+theorem of_mul_symm_eq : (@ofConjAct G _).symm = to_conj_act :=
+  rfl
+#align conj_act.of_mul_symm_eq ConjAct.of_mul_symm_eq
+
+@[simp]
+theorem to_mul_symm_eq : (@toConjAct G _).symm = of_conj_act :=
+  rfl
+#align conj_act.to_mul_symm_eq ConjAct.to_mul_symm_eq
+
+@[simp]
+theorem toConjAct_ofConjAct (x : ConjAct G) : toConjAct (ofConjAct x) = x :=
+  rfl
+#align conj_act.to_conj_act_of_conj_act ConjAct.toConjAct_ofConjAct
+
+@[simp]
+theorem ofConjAct_toConjAct (x : G) : ofConjAct (toConjAct x) = x :=
+  rfl
+#align conj_act.of_conj_act_to_conj_act ConjAct.ofConjAct_toConjAct
+
+@[simp]
+theorem ofConjAct_one : ofConjAct (1 : ConjAct G) = 1 :=
+  rfl
+#align conj_act.of_conj_act_one ConjAct.ofConjAct_one
+
+@[simp]
+theorem toConjAct_one : toConjAct (1 : G) = 1 :=
+  rfl
+#align conj_act.to_conj_act_one ConjAct.toConjAct_one
+
+@[simp]
+theorem ofConjAct_inv (x : ConjAct G) : ofConjAct x⁻¹ = (ofConjAct x)⁻¹ :=
+  rfl
+#align conj_act.of_conj_act_inv ConjAct.ofConjAct_inv
+
+@[simp]
+theorem toConjAct_inv (x : G) : toConjAct x⁻¹ = (toConjAct x)⁻¹ :=
+  rfl
+#align conj_act.to_conj_act_inv ConjAct.toConjAct_inv
+
+@[simp]
+theorem ofConjAct_mul (x y : ConjAct G) : ofConjAct (x * y) = ofConjAct x * ofConjAct y :=
+  rfl
+#align conj_act.of_conj_act_mul ConjAct.ofConjAct_mul
+
+@[simp]
+theorem toConjAct_mul (x y : G) : toConjAct (x * y) = toConjAct x * toConjAct y :=
+  rfl
+#align conj_act.to_conj_act_mul ConjAct.toConjAct_mul
+
+instance : SMul (ConjAct G) G where smul g h := ofConjAct g * h * (ofConjAct g)⁻¹
+
+theorem smul_def (g : ConjAct G) (h : G) : g • h = ofConjAct g * h * (ofConjAct g)⁻¹ :=
+  rfl
+#align conj_act.smul_def ConjAct.smul_def
+
+end DivInvMonoid
+
+section Units
+
+section Monoid
+
+variable [Monoid M]
+
+instance hasUnitsScalar : SMul (ConjAct Mˣ) M where smul g h := ofConjAct g * h * ↑(ofConjAct g)⁻¹
+#align conj_act.has_units_scalar ConjAct.hasUnitsScalar
+
+theorem units_smul_def (g : ConjAct Mˣ) (h : M) : g • h = ofConjAct g * h * ↑(ofConjAct g)⁻¹ :=
+  rfl
+#align conj_act.units_smul_def ConjAct.units_smul_def
+
+instance unitsMulDistribMulAction : MulDistribMulAction (ConjAct Mˣ) M
+    where
+  smul := (· • ·)
+  one_smul := by simp [units_smul_def]
+  mul_smul := by simp [units_smul_def, mul_assoc, mul_inv_rev]
+  smul_mul := by simp [units_smul_def, mul_assoc]
+  smul_one := by simp [units_smul_def]
+#align conj_act.units_mul_distrib_mul_action ConjAct.unitsMulDistribMulAction
+
+instance units_sMulCommClass [SMul α M] [SMulCommClass α M M] [IsScalarTower α M M] :
+    SMulCommClass α (ConjAct Mˣ) M
+    where smul_comm a um m := by rw [units_smul_def, units_smul_def, mul_smul_comm, smul_mul_assoc]
+#align conj_act.units_smul_comm_class ConjAct.units_sMulCommClass
+
+instance units_smul_comm_class' [SMul α M] [SMulCommClass M α M] [IsScalarTower α M M] :
+    SMulCommClass (ConjAct Mˣ) α M :=
+  haveI : SMulCommClass α M M := SMulCommClass.symm _ _ _
+  SMulCommClass.symm _ _ _
+#align conj_act.units_smul_comm_class' ConjAct.units_smul_comm_class'
+
+end Monoid
+
+section Semiring
+
+variable [Semiring R]
+
+instance unitsMulSemiringAction : MulSemiringAction (ConjAct Rˣ) R :=
+  { ConjAct.unitsMulDistribMulAction with
+    smul := (· • ·)
+    smul_zero := by simp [units_smul_def]
+    smul_add := by simp [units_smul_def, mul_add, add_mul] }
+#align conj_act.units_mul_semiring_action ConjAct.unitsMulSemiringAction
+
+end Semiring
+
+end Units
+
+section GroupWithZero
+
+variable [GroupWithZero G₀]
+
+@[simp]
+theorem ofConjAct_zero : ofConjAct (0 : ConjAct G₀) = 0 :=
+  rfl
+#align conj_act.of_conj_act_zero ConjAct.ofConjAct_zero
+
+@[simp]
+theorem toConjAct_zero : toConjAct (0 : G₀) = 0 :=
+  rfl
+#align conj_act.to_conj_act_zero ConjAct.toConjAct_zero
+
+instance mulAction₀ : MulAction (ConjAct G₀) G₀
+    where
+  smul := (· • ·)
+  one_smul := by simp [smul_def]
+  mul_smul := by simp [smul_def, mul_assoc, mul_inv_rev]
+#align conj_act.mul_action₀ ConjAct.mulAction₀
+
+instance smul_comm_class₀ [SMul α G₀] [SMulCommClass α G₀ G₀] [IsScalarTower α G₀ G₀] :
+    SMulCommClass α (ConjAct G₀) G₀
+    where smul_comm a ug g := by rw [smul_def, smul_def, mul_smul_comm, smul_mul_assoc]
+#align conj_act.smul_comm_class₀ ConjAct.smul_comm_class₀
+
+instance smul_comm_class₀' [SMul α G₀] [SMulCommClass G₀ α G₀] [IsScalarTower α G₀ G₀] :
+    SMulCommClass (ConjAct G₀) α G₀ :=
+  haveI := SMulCommClass.symm G₀ α G₀
+  SMulCommClass.symm _ _ _
+#align conj_act.smul_comm_class₀' ConjAct.smul_comm_class₀'
+
+end GroupWithZero
+
+section DivisionRing
+
+variable [DivisionRing K]
+
+instance distribMulAction₀ : DistribMulAction (ConjAct K) K :=
+  { ConjAct.mulAction₀ with
+    smul := (· • ·)
+    smul_zero := by simp [smul_def]
+    smul_add := by simp [smul_def, mul_add, add_mul] }
+#align conj_act.distrib_mul_action₀ ConjAct.distribMulAction₀
+
+end DivisionRing
+
+variable [Group G]
+
+instance : MulDistribMulAction (ConjAct G) G
+    where
+  smul := (· • ·)
+  smul_mul := by simp [smul_def, mul_assoc]
+  smul_one := by simp [smul_def]
+  one_smul := by simp [smul_def]
+  mul_smul := by simp [smul_def, mul_assoc]
+
+instance sMulCommClass [SMul α G] [SMulCommClass α G G] [IsScalarTower α G G] :
+    SMulCommClass α (ConjAct G) G
+    where smul_comm a ug g := by rw [smul_def, smul_def, mul_smul_comm, smul_mul_assoc]
+#align conj_act.smul_comm_class ConjAct.sMulCommClass
+
+instance smul_comm_class' [SMul α G] [SMulCommClass G α G] [IsScalarTower α G G] :
+    SMulCommClass (ConjAct G) α G :=
+  haveI := SMulCommClass.symm G α G
+  SMulCommClass.symm _ _ _
+#align conj_act.smul_comm_class' ConjAct.smul_comm_class'
+
+theorem smul_eq_mulAut_conj (g : ConjAct G) (h : G) : g • h = MulAut.conj (ofConjAct g) h :=
+  rfl
+#align conj_act.smul_eq_mul_aut_conj ConjAct.smul_eq_mulAut_conj
+
+/-- The set of fixed points of the conjugation action of `G` on itself is the center of `G`. -/
+theorem fixedPoints_eq_center : fixedPoints (ConjAct G) G = center G :=
+  by
+  ext x
+  simp [mem_center_iff, smul_def, mul_inv_eq_iff_eq_mul]
+#align conj_act.fixed_points_eq_center ConjAct.fixedPoints_eq_center
+
+theorem stabilizer_eq_centralizer (g : G) : stabilizer (ConjAct G) g = (zpowers g).centralizer :=
+  le_antisymm (le_centralizer_iff.mp (zpowers_le.mpr fun x => mul_inv_eq_iff_eq_mul.mp)) fun x h =>
+    mul_inv_eq_of_eq_mul (h g (mem_zpowers g)).symm
+#align conj_act.stabilizer_eq_centralizer ConjAct.stabilizer_eq_centralizer
+
+/-- As normal subgroups are closed under conjugation, they inherit the conjugation action
+  of the underlying group. -/
+instance Subgroup.conjAction {H : Subgroup G} [hH : H.Normal] : SMul (ConjAct G) H :=
+  ⟨fun g h => ⟨g • h, hH.conj_mem h.1 h.2 (ofConjAct g)⟩⟩
+#align conj_act.subgroup.conj_action ConjAct.Subgroup.conjAction
+
+theorem Subgroup.coe_conj_smul {H : Subgroup G} [hH : H.Normal] (g : ConjAct G) (h : H) :
+    ↑(g • h) = g • (h : G) :=
+  rfl
+#align conj_act.subgroup.coe_conj_smul ConjAct.Subgroup.coe_conj_smul
+
+instance Subgroup.conjMulDistribMulAction {H : Subgroup G} [hH : H.Normal] :
+    MulDistribMulAction (ConjAct G) H :=
+  Subtype.coe_injective.MulDistribMulAction H.Subtype Subgroup.coe_conj_smul
+#align conj_act.subgroup.conj_mul_distrib_mul_action ConjAct.Subgroup.conjMulDistribMulAction
+
+/-- Group conjugation on a normal subgroup. Analogous to `mul_aut.conj`. -/
+def MulAut.conjNormal {H : Subgroup G} [hH : H.Normal] : G →* MulAut H :=
+  (MulDistribMulAction.toMulAut (ConjAct G) H).comp toConjAct.toMonoidHom
+#align mul_aut.conj_normal MulAut.conjNormal
+
+@[simp]
+theorem MulAut.conjNormal_apply {H : Subgroup G} [H.Normal] (g : G) (h : H) :
+    ↑(MulAut.conjNormal g h) = g * h * g⁻¹ :=
+  rfl
+#align mul_aut.conj_normal_apply MulAut.conjNormal_apply
+
+@[simp]
+theorem MulAut.conjNormal_symm_apply {H : Subgroup G} [H.Normal] (g : G) (h : H) :
+    ↑((MulAut.conjNormal g).symm h) = g⁻¹ * h * g :=
+  by
+  change _ * _⁻¹⁻¹ = _
+  rw [inv_inv]
+  rfl
+#align mul_aut.conj_normal_symm_apply MulAut.conjNormal_symm_apply
+
+@[simp]
+theorem MulAut.conjNormal_inv_apply {H : Subgroup G} [H.Normal] (g : G) (h : H) :
+    ↑((MulAut.conjNormal g)⁻¹ h) = g⁻¹ * h * g :=
+  MulAut.conjNormal_symm_apply g h
+#align mul_aut.conj_normal_inv_apply MulAut.conjNormal_inv_apply
+
+theorem MulAut.conjNormal_coe {H : Subgroup G} [H.Normal] {h : H} :
+    MulAut.conjNormal ↑h = MulAut.conj h :=
+  MulEquiv.ext fun x => rfl
+#align mul_aut.conj_normal_coe MulAut.conjNormal_coe
+
+instance normal_of_characteristic_of_normal {H : Subgroup G} [hH : H.Normal] {K : Subgroup H}
+    [h : K.Characteristic] : (K.map H.Subtype).Normal :=
+  ⟨fun a ha b => by
+    obtain ⟨a, ha, rfl⟩ := ha
+    exact
+      K.apply_coe_mem_map H.subtype
+        ⟨_, (set_like.ext_iff.mp (h.fixed (MulAut.conjNormal b)) a).mpr ha⟩⟩
+#align conj_act.normal_of_characteristic_of_normal ConjAct.normal_of_characteristic_of_normal
+
+end ConjAct
+

--- a/Mathlib/GroupTheory/GroupAction/ConjAct.lean
+++ b/Mathlib/GroupTheory/GroupAction/ConjAct.lean
@@ -118,12 +118,12 @@ theorem ofConjAct_toConjAct (x : G) : ofConjAct (toConjAct x) = x :=
   rfl
 #align conj_act.of_conj_act_to_conj_act ConjAct.ofConjAct_toConjAct
 
-@[simp]
+-- porting note: removed `simp` attribute because `simpNF` says it can prove it
 theorem ofConjAct_one : ofConjAct (1 : ConjAct G) = 1 :=
   rfl
 #align conj_act.of_conj_act_one ConjAct.ofConjAct_one
 
-@[simp]
+-- porting note: removed `simp` attribute because `simpNF` says it can prove it
 theorem toConjAct_one : toConjAct (1 : G) = 1 :=
   rfl
 #align conj_act.to_conj_act_one ConjAct.toConjAct_one
@@ -138,12 +138,12 @@ theorem toConjAct_inv (x : G) : toConjAct x⁻¹ = (toConjAct x)⁻¹ :=
   rfl
 #align conj_act.to_conj_act_inv ConjAct.toConjAct_inv
 
-@[simp]
+-- porting note: removed `simp` attribute because `simpNF` says it can prove it
 theorem ofConjAct_mul (x y : ConjAct G) : ofConjAct (x * y) = ofConjAct x * ofConjAct y :=
   rfl
 #align conj_act.of_conj_act_mul ConjAct.ofConjAct_mul
 
-@[simp]
+-- porting note: removed `simp` attribute because `simpNF` says it can prove it
 theorem toConjAct_mul (x y : G) : toConjAct (x * y) = toConjAct x * toConjAct y :=
   rfl
 #align conj_act.to_conj_act_mul ConjAct.toConjAct_mul
@@ -219,12 +219,12 @@ section GroupWithZero
 
 variable [GroupWithZero G₀]
 
-@[simp]
+-- porting note: removed `simp` attribute because `simpNF` says it can prove it
 theorem ofConjAct_zero : ofConjAct (0 : ConjAct G₀) = 0 :=
   rfl
 #align conj_act.of_conj_act_zero ConjAct.ofConjAct_zero
 
-@[simp]
+-- porting note: removed `simp` attribute because `simpNF` says it can prove it
 theorem toConjAct_zero : toConjAct (0 : G₀) = 0 :=
   rfl
 #align conj_act.to_conj_act_zero ConjAct.toConjAct_zero

--- a/Mathlib/GroupTheory/GroupAction/ConjAct.lean
+++ b/Mathlib/GroupTheory/GroupAction/ConjAct.lean
@@ -15,31 +15,31 @@ import Mathlib.Algebra.GroupRingAction.Basic
 /-!
 # Conjugation action of a group on itself
 
-This file defines the conjugation action of a group on itself. See also `mul_aut.conj` for
+This file defines the conjugation action of a group on itself. See also `MulAut.conj` for
 the definition of conjugation as a homomorphism into the automorphism group.
 
 ## Main definitions
 
-A type alias `conj_act G` is introduced for a group `G`. The group `conj_act G` acts on `G`
-by conjugation. The group `conj_act G` also acts on any normal subgroup of `G` by conjugation.
+A type alias `ConjAct G` is introduced for a group `G`. The group `ConjAct G` acts on `G`
+by conjugation. The group `ConjAct G` also acts on any normal subgroup of `G` by conjugation.
 
 As a generalization, this also allows:
-* `conj_act Mˣ` to act on `M`, when `M` is a `monoid`
-* `conj_act G₀` to act on `G₀`, when `G₀` is a `group_with_zero`
+* `ConjAct Mˣ` to act on `M`, when `M` is a `Monoid`
+* `ConjAct G₀` to act on `G₀`, when `G₀` is a `GroupWithZero`
 
 ## Implementation Notes
 
-The scalar action in defined in this file can also be written using `mul_aut.conj g • h`. This
-has the advantage of not using the type alias `conj_act`, but the downside of this approach
+The scalar action in defined in this file can also be written using `MulAut.conj g • h`. This
+has the advantage of not using the type alias `ConjAct`, but the downside of this approach
 is that some theorems about the group actions will not apply when since this
-`mul_aut.conj g • h` describes an action of `mul_aut G` on `G`, and not an action of `G`.
+`MulAut.conj g • h` describes an action of `MulAut G` on `G`, and not an action of `G`.
 
 -/
 
 
 variable (α M G G₀ R K : Type _)
 
-/-- A type alias for a group `G`. `conj_act G` acts on `G` by conjugation -/
+/-- A type alias for a group `G`. `ConjAct G` acts on `G` by conjugation -/
 def ConjAct : Type _ :=
   G
 #align conj_act ConjAct
@@ -74,7 +74,7 @@ variable [DivInvMonoid G]
 instance : Inhabited (ConjAct G) :=
   ⟨1⟩
 
-/-- Reinterpret `g : conj_act G` as an element of `G`. -/
+/-- Reinterpret `g : ConjAct G` as an element of `G`. -/
 def ofConjAct : ConjAct G ≃* G where
   toFun := id
   invFun := id
@@ -83,12 +83,12 @@ def ofConjAct : ConjAct G ≃* G where
   map_mul' := fun _ _ => rfl
 #align conj_act.of_conj_act ConjAct.ofConjAct
 
-/-- Reinterpret `g : G` as an element of `conj_act G`. -/
+/-- Reinterpret `g : G` as an element of `ConjAct G`. -/
 def toConjAct : G ≃* ConjAct G :=
   ofConjAct.symm
 #align conj_act.to_conj_act ConjAct.toConjAct
 
-/-- A recursor for `conj_act`, for use as `induction x using conj_act.rec` when `x : conj_act G`. -/
+/-- A recursor for `ConjAct`, for use as `induction x using ConjAct.rec` when `x : ConjAct G`. -/
 protected def rec {C : ConjAct G → Sort _} (h : ∀ g, C (toConjAct g)) : ∀ g, C g :=
   h
 #align conj_act.rec ConjAct.rec
@@ -330,7 +330,7 @@ instance Subgroup.conjMulDistribMulAction {H : Subgroup G} [H.Normal] :
   Subtype.coe_injective.mulDistribMulAction H.subtype Subgroup.val_conj_smul
 #align conj_act.subgroup.conj_mul_distrib_mul_action ConjAct.Subgroup.conjMulDistribMulAction
 
-/-- Group conjugation on a normal subgroup. Analogous to `mul_aut.conj`. -/
+/-- Group conjugation on a normal subgroup. Analogous to `MulAut.conj`. -/
 def _root_.MulAut.conjNormal {H : Subgroup G} [H.Normal] : G →* MulAut H :=
   (MulDistribMulAction.toMulAut (ConjAct G) H).comp toConjAct.toMonoidHom
 #align mul_aut.conj_normal MulAut.conjNormal

--- a/Mathlib/GroupTheory/GroupAction/ConjAct.lean
+++ b/Mathlib/GroupTheory/GroupAction/ConjAct.lean
@@ -169,6 +169,8 @@ theorem units_smul_def (g : ConjAct Mˣ) (h : M) : g • h = ofConjAct g * h * �
   rfl
 #align conj_act.units_smul_def ConjAct.units_smul_def
 
+-- porting note: very slow without `simp only` and need to separate `units_smul_def`
+-- so that things trigger appropriately
 instance unitsMulDistribMulAction : MulDistribMulAction (ConjAct Mˣ) M
     where
   smul := (· • ·)
@@ -201,6 +203,8 @@ section Semiring
 
 variable [Semiring R]
 
+-- porting note: very slow without `simp only` and need to separate `units_smul_def`
+-- so that things trigger appropriately
 instance unitsMulSemiringAction : MulSemiringAction (ConjAct Rˣ) R :=
   { ConjAct.unitsMulDistribMulAction with
     smul := (· • ·)
@@ -229,6 +233,8 @@ theorem toConjAct_zero : toConjAct (0 : G₀) = 0 :=
   rfl
 #align conj_act.to_conj_act_zero ConjAct.toConjAct_zero
 
+-- porting note: very slow without `simp only` and need to separate `smul_def`
+-- so that things trigger appropriately
 instance mulAction₀ : MulAction (ConjAct G₀) G₀
     where
   smul := (· • ·)
@@ -257,6 +263,8 @@ section DivisionRing
 
 variable [DivisionRing K]
 
+-- porting note: very slow without `simp only` and need to separate `smul_def`
+-- so that things trigger appropriately
 instance distribMulAction₀ : DistribMulAction (ConjAct K) K :=
   { ConjAct.mulAction₀ with
     smul := (· • ·)
@@ -272,6 +280,8 @@ end DivisionRing
 
 variable [Group G]
 
+-- porting note: very slow without `simp only` and need to separate `smul_def`
+-- so that things trigger appropriately
 instance : MulDistribMulAction (ConjAct G) G
     where
   smul := (· • ·)

--- a/Mathlib/GroupTheory/GroupAction/ConjAct.lean
+++ b/Mathlib/GroupTheory/GroupAction/ConjAct.lean
@@ -184,16 +184,16 @@ instance unitsMulDistribMulAction : MulDistribMulAction (ConjAct Mˣ) M
 #align conj_act.units_mul_distrib_mul_action ConjAct.unitsMulDistribMulAction
 
 
-instance units_sMulCommClass [SMul α M] [SMulCommClass α M M] [IsScalarTower α M M] :
+instance unitsSMulCommClass [SMul α M] [SMulCommClass α M M] [IsScalarTower α M M] :
     SMulCommClass α (ConjAct Mˣ) M
     where smul_comm a um m := by rw [units_smul_def, units_smul_def, mul_smul_comm, smul_mul_assoc]
-#align conj_act.units_smul_comm_class ConjAct.units_sMulCommClass
+#align conj_act.units_smul_comm_class ConjAct.unitsSMulCommClass
 
-instance units_smul_comm_class' [SMul α M] [SMulCommClass M α M] [IsScalarTower α M M] :
+instance unitsSMulCommClass' [SMul α M] [SMulCommClass M α M] [IsScalarTower α M M] :
     SMulCommClass (ConjAct Mˣ) α M :=
   haveI : SMulCommClass α M M := SMulCommClass.symm _ _ _
   SMulCommClass.symm _ _ _
-#align conj_act.units_smul_comm_class' ConjAct.units_smul_comm_class'
+#align conj_act.units_smul_comm_class' ConjAct.unitsSMulCommClass'
 
 end Monoid
 
@@ -240,16 +240,16 @@ instance mulAction₀ : MulAction (ConjAct G₀) G₀
     simp only [map_mul, mul_assoc, mul_inv_rev, forall_const, «forall»]
 #align conj_act.mul_action₀ ConjAct.mulAction₀
 
-instance smul_comm_class₀ [SMul α G₀] [SMulCommClass α G₀ G₀] [IsScalarTower α G₀ G₀] :
+instance smulCommClass₀ [SMul α G₀] [SMulCommClass α G₀ G₀] [IsScalarTower α G₀ G₀] :
     SMulCommClass α (ConjAct G₀) G₀
     where smul_comm a ug g := by rw [smul_def, smul_def, mul_smul_comm, smul_mul_assoc]
-#align conj_act.smul_comm_class₀ ConjAct.smul_comm_class₀
+#align conj_act.smul_comm_class₀ ConjAct.smulCommClass₀
 
-instance smul_comm_class₀' [SMul α G₀] [SMulCommClass G₀ α G₀] [IsScalarTower α G₀ G₀] :
+instance smulCommClass₀' [SMul α G₀] [SMulCommClass G₀ α G₀] [IsScalarTower α G₀ G₀] :
     SMulCommClass (ConjAct G₀) α G₀ :=
   haveI := SMulCommClass.symm G₀ α G₀
   SMulCommClass.symm _ _ _
-#align conj_act.smul_comm_class₀' ConjAct.smul_comm_class₀'
+#align conj_act.smul_comm_class₀' ConjAct.smulCommClass₀'
 
 end GroupWithZero
 
@@ -288,16 +288,16 @@ instance : MulDistribMulAction (ConjAct G) G
 -- shortcut instance
 instance : MulAction (ConjAct G) G := MulDistribMulAction.toMulAction
 
-instance sMulCommClass [SMul α G] [SMulCommClass α G G] [IsScalarTower α G G] :
+instance smulCommClass [SMul α G] [SMulCommClass α G G] [IsScalarTower α G G] :
     SMulCommClass α (ConjAct G) G
     where smul_comm a ug g := by rw [smul_def, smul_def, mul_smul_comm, smul_mul_assoc]
-#align conj_act.smul_comm_class ConjAct.sMulCommClass
+#align conj_act.smul_comm_class ConjAct.smulCommClass
 
-instance smul_comm_class' [SMul α G] [SMulCommClass G α G] [IsScalarTower α G G] :
+instance smulCommClass' [SMul α G] [SMulCommClass G α G] [IsScalarTower α G G] :
     SMulCommClass (ConjAct G) α G :=
   haveI := SMulCommClass.symm G α G
   SMulCommClass.symm _ _ _
-#align conj_act.smul_comm_class' ConjAct.smul_comm_class'
+#align conj_act.smul_comm_class' ConjAct.smulCommClass'
 
 theorem smul_eq_mulAut_conj (g : ConjAct G) (h : G) : g • h = MulAut.conj (ofConjAct g) h :=
   rfl
@@ -320,14 +320,14 @@ instance Subgroup.conjAction {H : Subgroup G} [hH : H.Normal] : SMul (ConjAct G)
   ⟨fun g h => ⟨g • (h : G), hH.conj_mem h.1 h.2 (ofConjAct g)⟩⟩
 #align conj_act.subgroup.conj_action ConjAct.Subgroup.conjAction
 
-theorem Subgroup.coe_conj_smul {H : Subgroup G} [H.Normal] (g : ConjAct G) (h : H) :
+theorem Subgroup.val_conj_smul {H : Subgroup G} [H.Normal] (g : ConjAct G) (h : H) :
     ↑(g • h) = g • (h : G) :=
   rfl
-#align conj_act.subgroup.coe_conj_smul ConjAct.Subgroup.coe_conj_smul
+#align conj_act.subgroup.coe_conj_smul ConjAct.Subgroup.val_conj_smul
 
 instance Subgroup.conjMulDistribMulAction {H : Subgroup G} [H.Normal] :
     MulDistribMulAction (ConjAct G) H :=
-  Subtype.coe_injective.mulDistribMulAction H.subtype Subgroup.coe_conj_smul
+  Subtype.coe_injective.mulDistribMulAction H.subtype Subgroup.val_conj_smul
 #align conj_act.subgroup.conj_mul_distrib_mul_action ConjAct.Subgroup.conjMulDistribMulAction
 
 /-- Group conjugation on a normal subgroup. Analogous to `mul_aut.conj`. -/
@@ -355,10 +355,10 @@ theorem _root_.MulAut.conjNormal_inv_apply {H : Subgroup G} [H.Normal] (g : G) (
   MulAut.conjNormal_symm_apply g h
 #align mul_aut.conj_normal_inv_apply MulAut.conjNormal_inv_apply
 
-theorem _root_.MulAut.conjNormal_coe {H : Subgroup G} [H.Normal] {h : H} :
+theorem _root_.MulAut.conjNormal_val {H : Subgroup G} [H.Normal] {h : H} :
     MulAut.conjNormal ↑h = MulAut.conj h :=
   MulEquiv.ext fun _ => rfl
-#align mul_aut.conj_normal_coe MulAut.conjNormal_coe
+#align mul_aut.conj_normal_coe MulAut.conjNormal_val
 
 instance normal_of_characteristic_of_normal {H : Subgroup G} [hH : H.Normal] {K : Subgroup H}
     [h : K.Characteristic] : (K.map H.subtype).Normal :=

--- a/Mathlib/GroupTheory/GroupAction/ConjAct.lean
+++ b/Mathlib/GroupTheory/GroupAction/ConjAct.lean
@@ -50,17 +50,17 @@ open MulAction Subgroup
 
 variable {M G G₀ R K}
 
-instance : ∀ [Group G], Group (ConjAct G) :=
-  @id _
+instance [Group G] : Group (ConjAct G) :=
+  by delta ConjAct; infer_instance
 
-instance : ∀ [DivInvMonoid G], DivInvMonoid (ConjAct G) :=
-  @id _
+instance [DivInvMonoid G] : DivInvMonoid (ConjAct G) :=
+  by delta ConjAct; infer_instance
 
-instance : ∀ [GroupWithZero G], GroupWithZero (ConjAct G) :=
-  @id _
+instance [GroupWithZero G] : GroupWithZero (ConjAct G) :=
+  by delta ConjAct; infer_instance
 
-instance : ∀ [Fintype G], Fintype (ConjAct G) :=
-  @id _
+instance [Fintype G] : Fintype (ConjAct G) :=
+  by delta ConjAct; infer_instance
 
 @[simp]
 theorem card [Fintype G] : Fintype.card (ConjAct G) = Fintype.card G :=
@@ -95,7 +95,7 @@ protected def rec {C : ConjAct G → Sort _} (h : ∀ g, C (toConjAct g)) : ∀ 
 
 @[simp]
 theorem «forall» (p : ConjAct G → Prop) : (∀ x : ConjAct G, p x) ↔ ∀ x : G, p (toConjAct x) :=
-  Iff.rfl
+  id Iff.rfl
 #align conj_act.forall ConjAct.forall
 
 @[simp]
@@ -171,9 +171,7 @@ theorem units_smul_def (g : ConjAct Mˣ) (h : M) : g • h = ofConjAct g * h * �
 
 -- porting note: very slow without `simp only` and need to separate `units_smul_def`
 -- so that things trigger appropriately
-instance unitsMulDistribMulAction : MulDistribMulAction (ConjAct Mˣ) M
-    where
-  smul := (· • ·)
+instance unitsMulDistribMulAction : MulDistribMulAction (ConjAct Mˣ) M where
   one_smul := by simp only [units_smul_def, ofConjAct_one, Units.val_one, one_mul, inv_one,
     mul_one, forall_const]
   mul_smul := by
@@ -182,7 +180,7 @@ instance unitsMulDistribMulAction : MulDistribMulAction (ConjAct Mˣ) M
   smul_mul := by
     simp only [units_smul_def]
     simp only [mul_assoc, Units.inv_mul_cancel_left, forall_const, «forall»]
-  smul_one := by simp only [units_smul_def, mul_one, Units.mul_inv, «forall», forall_const]
+  smul_one := by simp [units_smul_def, mul_one, Units.mul_inv, «forall», forall_const]
 #align conj_act.units_mul_distrib_mul_action ConjAct.unitsMulDistribMulAction
 
 
@@ -207,7 +205,6 @@ variable [Semiring R]
 -- so that things trigger appropriately
 instance unitsMulSemiringAction : MulSemiringAction (ConjAct Rˣ) R :=
   { ConjAct.unitsMulDistribMulAction with
-    smul := (· • ·)
     smul_zero := by
       simp only [units_smul_def, mul_zero, zero_mul, «forall», forall_const]
     smul_add := by
@@ -235,9 +232,7 @@ theorem toConjAct_zero : toConjAct (0 : G₀) = 0 :=
 
 -- porting note: very slow without `simp only` and need to separate `smul_def`
 -- so that things trigger appropriately
-instance mulAction₀ : MulAction (ConjAct G₀) G₀
-    where
-  smul := (· • ·)
+instance mulAction₀ : MulAction (ConjAct G₀) G₀ where
   one_smul := by
     simp only [smul_def]
     simp only [map_one, one_mul, inv_one, mul_one, forall_const]
@@ -267,7 +262,6 @@ variable [DivisionRing K]
 -- so that things trigger appropriately
 instance distribMulAction₀ : DistribMulAction (ConjAct K) K :=
   { ConjAct.mulAction₀ with
-    smul := (· • ·)
     smul_zero := by
       simp only [smul_def]
       simp only [mul_zero, zero_mul, «forall», forall_const]
@@ -282,9 +276,7 @@ variable [Group G]
 
 -- porting note: very slow without `simp only` and need to separate `smul_def`
 -- so that things trigger appropriately
-instance : MulDistribMulAction (ConjAct G) G
-    where
-  smul := (· • ·)
+instance : MulDistribMulAction (ConjAct G) G where
   smul_mul := by
     simp only [smul_def]
     simp only [mul_assoc, inv_mul_cancel_left, forall_const, «forall»]

--- a/Mathlib/GroupTheory/GroupAction/ConjAct.lean
+++ b/Mathlib/GroupTheory/GroupAction/ConjAct.lean
@@ -51,16 +51,16 @@ open MulAction Subgroup
 variable {M G G₀ R K}
 
 instance : ∀ [Group G], Group (ConjAct G) :=
-  id
+  @id _
 
 instance : ∀ [DivInvMonoid G], DivInvMonoid (ConjAct G) :=
-  id
+  @id _
 
 instance : ∀ [GroupWithZero G], GroupWithZero (ConjAct G) :=
-  id
+  @id _
 
 instance : ∀ [Fintype G], Fintype (ConjAct G) :=
-  id
+  @id _
 
 @[simp]
 theorem card [Fintype G] : Fintype.card (ConjAct G) = Fintype.card G :=
@@ -75,8 +75,12 @@ instance : Inhabited (ConjAct G) :=
   ⟨1⟩
 
 /-- Reinterpret `g : conj_act G` as an element of `G`. -/
-def ofConjAct : ConjAct G ≃* G :=
-  ⟨id, id, fun _ => rfl, fun _ => rfl, fun _ _ => rfl⟩
+def ofConjAct : ConjAct G ≃* G where
+  toFun := id
+  invFun := id
+  left_inv := fun _ => rfl
+  right_inv := fun _ => rfl
+  map_mul' := fun _ _ => rfl
 #align conj_act.of_conj_act ConjAct.ofConjAct
 
 /-- Reinterpret `g : G` as an element of `conj_act G`. -/
@@ -90,17 +94,17 @@ protected def rec {C : ConjAct G → Sort _} (h : ∀ g, C (toConjAct g)) : ∀ 
 #align conj_act.rec ConjAct.rec
 
 @[simp]
-theorem forall (p : ConjAct G → Prop) : (∀ x : ConjAct G, p x) ↔ ∀ x : G, p (toConjAct x) :=
+theorem «forall» (p : ConjAct G → Prop) : (∀ x : ConjAct G, p x) ↔ ∀ x : G, p (toConjAct x) :=
   Iff.rfl
 #align conj_act.forall ConjAct.forall
 
 @[simp]
-theorem of_mul_symm_eq : (@ofConjAct G _).symm = to_conj_act :=
+theorem of_mul_symm_eq : (@ofConjAct G _).symm = toConjAct :=
   rfl
 #align conj_act.of_mul_symm_eq ConjAct.of_mul_symm_eq
 
 @[simp]
-theorem to_mul_symm_eq : (@toConjAct G _).symm = of_conj_act :=
+theorem to_mul_symm_eq : (@toConjAct G _).symm = ofConjAct :=
   rfl
 #align conj_act.to_mul_symm_eq ConjAct.to_mul_symm_eq
 
@@ -158,8 +162,8 @@ section Monoid
 
 variable [Monoid M]
 
-instance hasUnitsScalar : SMul (ConjAct Mˣ) M where smul g h := ofConjAct g * h * ↑(ofConjAct g)⁻¹
-#align conj_act.has_units_scalar ConjAct.hasUnitsScalar
+instance unitsScalar : SMul (ConjAct Mˣ) M where smul g h := ofConjAct g * h * ↑(ofConjAct g)⁻¹
+#align conj_act.has_units_scalar ConjAct.unitsScalar
 
 theorem units_smul_def (g : ConjAct Mˣ) (h : M) : g • h = ofConjAct g * h * ↑(ofConjAct g)⁻¹ :=
   rfl
@@ -168,11 +172,17 @@ theorem units_smul_def (g : ConjAct Mˣ) (h : M) : g • h = ofConjAct g * h * �
 instance unitsMulDistribMulAction : MulDistribMulAction (ConjAct Mˣ) M
     where
   smul := (· • ·)
-  one_smul := by simp [units_smul_def]
-  mul_smul := by simp [units_smul_def, mul_assoc, mul_inv_rev]
-  smul_mul := by simp [units_smul_def, mul_assoc]
-  smul_one := by simp [units_smul_def]
+  one_smul := by simp only [units_smul_def, ofConjAct_one, Units.val_one, one_mul, inv_one,
+    mul_one, forall_const]
+  mul_smul := by
+    simp only [units_smul_def]
+    simp only [map_mul, Units.val_mul, mul_assoc, mul_inv_rev, forall_const, «forall»]
+  smul_mul := by
+    simp only [units_smul_def]
+    simp only [mul_assoc, Units.inv_mul_cancel_left, forall_const, «forall»]
+  smul_one := by simp only [units_smul_def, mul_one, Units.mul_inv, «forall», forall_const]
 #align conj_act.units_mul_distrib_mul_action ConjAct.unitsMulDistribMulAction
+
 
 instance units_sMulCommClass [SMul α M] [SMulCommClass α M M] [IsScalarTower α M M] :
     SMulCommClass α (ConjAct Mˣ) M
@@ -194,8 +204,11 @@ variable [Semiring R]
 instance unitsMulSemiringAction : MulSemiringAction (ConjAct Rˣ) R :=
   { ConjAct.unitsMulDistribMulAction with
     smul := (· • ·)
-    smul_zero := by simp [units_smul_def]
-    smul_add := by simp [units_smul_def, mul_add, add_mul] }
+    smul_zero := by
+      simp only [units_smul_def, mul_zero, zero_mul, «forall», forall_const]
+    smul_add := by
+      simp only [units_smul_def]
+      simp only [mul_add, add_mul, forall_const, «forall»] }
 #align conj_act.units_mul_semiring_action ConjAct.unitsMulSemiringAction
 
 end Semiring
@@ -219,8 +232,12 @@ theorem toConjAct_zero : toConjAct (0 : G₀) = 0 :=
 instance mulAction₀ : MulAction (ConjAct G₀) G₀
     where
   smul := (· • ·)
-  one_smul := by simp [smul_def]
-  mul_smul := by simp [smul_def, mul_assoc, mul_inv_rev]
+  one_smul := by
+    simp only [smul_def]
+    simp only [map_one, one_mul, inv_one, mul_one, forall_const]
+  mul_smul := by
+    simp only [smul_def]
+    simp only [map_mul, mul_assoc, mul_inv_rev, forall_const, «forall»]
 #align conj_act.mul_action₀ ConjAct.mulAction₀
 
 instance smul_comm_class₀ [SMul α G₀] [SMulCommClass α G₀ G₀] [IsScalarTower α G₀ G₀] :
@@ -243,8 +260,12 @@ variable [DivisionRing K]
 instance distribMulAction₀ : DistribMulAction (ConjAct K) K :=
   { ConjAct.mulAction₀ with
     smul := (· • ·)
-    smul_zero := by simp [smul_def]
-    smul_add := by simp [smul_def, mul_add, add_mul] }
+    smul_zero := by
+      simp only [smul_def]
+      simp only [mul_zero, zero_mul, «forall», forall_const]
+    smul_add := by
+      simp only [smul_def]
+      simp only [mul_add, add_mul, forall_const, «forall»] }
 #align conj_act.distrib_mul_action₀ ConjAct.distribMulAction₀
 
 end DivisionRing
@@ -254,10 +275,18 @@ variable [Group G]
 instance : MulDistribMulAction (ConjAct G) G
     where
   smul := (· • ·)
-  smul_mul := by simp [smul_def, mul_assoc]
-  smul_one := by simp [smul_def]
-  one_smul := by simp [smul_def]
-  mul_smul := by simp [smul_def, mul_assoc]
+  smul_mul := by
+    simp only [smul_def]
+    simp only [mul_assoc, inv_mul_cancel_left, forall_const, «forall»]
+  smul_one := by simp only [smul_def, mul_one, mul_right_inv, «forall», forall_const]
+  one_smul := by simp only [smul_def, ofConjAct_one, one_mul, inv_one, mul_one, forall_const]
+  mul_smul := by
+    simp only [smul_def]
+    simp only [map_mul, mul_assoc, mul_inv_rev, forall_const, «forall»]
+
+-- porting note: type class inference fails on `stabilizer_eq_centralizer` below without this
+-- shortcut instance
+instance : MulAction (ConjAct G) G := MulDistribMulAction.toMulAction
 
 instance sMulCommClass [SMul α G] [SMulCommClass α G G] [IsScalarTower α G G] :
     SMulCommClass α (ConjAct G) G
@@ -281,39 +310,39 @@ theorem fixedPoints_eq_center : fixedPoints (ConjAct G) G = center G := by
 #align conj_act.fixed_points_eq_center ConjAct.fixedPoints_eq_center
 
 theorem stabilizer_eq_centralizer (g : G) : stabilizer (ConjAct G) g = (zpowers g).centralizer :=
-  le_antisymm (le_centralizer_iff.mp (zpowers_le.mpr fun x => mul_inv_eq_iff_eq_mul.mp)) fun x h =>
+  le_antisymm (le_centralizer_iff.mp (zpowers_le.mpr fun _ => mul_inv_eq_iff_eq_mul.mp)) fun _ h =>
     mul_inv_eq_of_eq_mul (h g (mem_zpowers g)).symm
 #align conj_act.stabilizer_eq_centralizer ConjAct.stabilizer_eq_centralizer
 
 /-- As normal subgroups are closed under conjugation, they inherit the conjugation action
   of the underlying group. -/
 instance Subgroup.conjAction {H : Subgroup G} [hH : H.Normal] : SMul (ConjAct G) H :=
-  ⟨fun g h => ⟨g • h, hH.conj_mem h.1 h.2 (ofConjAct g)⟩⟩
+  ⟨fun g h => ⟨g • (h : G), hH.conj_mem h.1 h.2 (ofConjAct g)⟩⟩
 #align conj_act.subgroup.conj_action ConjAct.Subgroup.conjAction
 
-theorem Subgroup.coe_conj_smul {H : Subgroup G} [hH : H.Normal] (g : ConjAct G) (h : H) :
+theorem Subgroup.coe_conj_smul {H : Subgroup G} [H.Normal] (g : ConjAct G) (h : H) :
     ↑(g • h) = g • (h : G) :=
   rfl
 #align conj_act.subgroup.coe_conj_smul ConjAct.Subgroup.coe_conj_smul
 
-instance Subgroup.conjMulDistribMulAction {H : Subgroup G} [hH : H.Normal] :
+instance Subgroup.conjMulDistribMulAction {H : Subgroup G} [H.Normal] :
     MulDistribMulAction (ConjAct G) H :=
-  Subtype.coe_injective.MulDistribMulAction H.Subtype Subgroup.coe_conj_smul
+  Subtype.coe_injective.mulDistribMulAction H.subtype Subgroup.coe_conj_smul
 #align conj_act.subgroup.conj_mul_distrib_mul_action ConjAct.Subgroup.conjMulDistribMulAction
 
 /-- Group conjugation on a normal subgroup. Analogous to `mul_aut.conj`. -/
-def MulAut.conjNormal {H : Subgroup G} [hH : H.Normal] : G →* MulAut H :=
+def _root_.MulAut.conjNormal {H : Subgroup G} [H.Normal] : G →* MulAut H :=
   (MulDistribMulAction.toMulAut (ConjAct G) H).comp toConjAct.toMonoidHom
 #align mul_aut.conj_normal MulAut.conjNormal
 
 @[simp]
-theorem MulAut.conjNormal_apply {H : Subgroup G} [H.Normal] (g : G) (h : H) :
+theorem _root_.MulAut.conjNormal_apply {H : Subgroup G} [H.Normal] (g : G) (h : H) :
     ↑(MulAut.conjNormal g h) = g * h * g⁻¹ :=
   rfl
 #align mul_aut.conj_normal_apply MulAut.conjNormal_apply
 
 @[simp]
-theorem MulAut.conjNormal_symm_apply {H : Subgroup G} [H.Normal] (g : G) (h : H) :
+theorem _root_.MulAut.conjNormal_symm_apply {H : Subgroup G} [H.Normal] (g : G) (h : H) :
     ↑((MulAut.conjNormal g).symm h) = g⁻¹ * h * g := by
   change _ * _⁻¹⁻¹ = _
   rw [inv_inv]
@@ -321,24 +350,22 @@ theorem MulAut.conjNormal_symm_apply {H : Subgroup G} [H.Normal] (g : G) (h : H)
 #align mul_aut.conj_normal_symm_apply MulAut.conjNormal_symm_apply
 
 @[simp]
-theorem MulAut.conjNormal_inv_apply {H : Subgroup G} [H.Normal] (g : G) (h : H) :
+theorem _root_.MulAut.conjNormal_inv_apply {H : Subgroup G} [H.Normal] (g : G) (h : H) :
     ↑((MulAut.conjNormal g)⁻¹ h) = g⁻¹ * h * g :=
   MulAut.conjNormal_symm_apply g h
 #align mul_aut.conj_normal_inv_apply MulAut.conjNormal_inv_apply
 
-theorem MulAut.conjNormal_coe {H : Subgroup G} [H.Normal] {h : H} :
+theorem _root_.MulAut.conjNormal_coe {H : Subgroup G} [H.Normal] {h : H} :
     MulAut.conjNormal ↑h = MulAut.conj h :=
-  MulEquiv.ext fun x => rfl
+  MulEquiv.ext fun _ => rfl
 #align mul_aut.conj_normal_coe MulAut.conjNormal_coe
 
 instance normal_of_characteristic_of_normal {H : Subgroup G} [hH : H.Normal] {K : Subgroup H}
-    [h : K.Characteristic] : (K.map H.Subtype).Normal :=
+    [h : K.Characteristic] : (K.map H.subtype).Normal :=
   ⟨fun a ha b => by
     obtain ⟨a, ha, rfl⟩ := ha
-    exact
-      K.apply_coe_mem_map H.subtype
-        ⟨_, (set_like.ext_iff.mp (h.fixed (MulAut.conjNormal b)) a).mpr ha⟩⟩
+    exact K.apply_coe_mem_map H.subtype
+      ⟨_, (SetLike.ext_iff.mp (h.fixed (MulAut.conjNormal b)) a).mpr ha⟩⟩
 #align conj_act.normal_of_characteristic_of_normal ConjAct.normal_of_characteristic_of_normal
 
 end ConjAct
-


### PR DESCRIPTION
This compiles and lints now, BUT...

1. There were some very slow `simp`s here, that I had to massage with `simp only` and more. I didn't expect these to be so slow.
2. I had to add a shortcut instance for `MulAction (ConjAct G) G` in order for TC inference to find it in the declaration `stabilizer_eq_centralizer`.
3. There were several `simp` lemmas that `simpNF` said it could prove for which I just removed the `simp` attribute.

I think we may at least want to consider addressing the first two problems before merging.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
