### PR TITLE
[Merged by Bors] - feat: port Data.Num.Bitwise

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -456,6 +456,7 @@ import Mathlib.Data.Nat.Units
 import Mathlib.Data.Nat.Upto
 import Mathlib.Data.Nat.WithBot
 import Mathlib.Data.Num.Basic
+import Mathlib.Data.Num.Bitwise
 import Mathlib.Data.Opposite
 import Mathlib.Data.Option.Basic
 import Mathlib.Data.Option.Defs

--- a/Mathlib/Data/Num/Basic.lean
+++ b/Mathlib/Data/Num/Basic.lean
@@ -220,10 +220,10 @@ set_option linter.deprecated false
 end deprecated
 
 instance : Repr PosNum :=
-  ⟨fun _ n => repr (n : ℕ)⟩
+  ⟨fun n _ => repr (n : ℕ)⟩
 
 instance : Repr Num :=
-  ⟨fun _ n => repr (n : ℕ)⟩
+  ⟨fun n _ => repr (n : ℕ)⟩
 
 end
 
@@ -688,6 +688,6 @@ variable {α : Type _} [Zero α] [One α] [Add α] [Neg α]
 #align znum_coe znumCoe
 
 instance : Repr ZNum :=
-  ⟨fun _ n => repr (n : ℤ)⟩
+  ⟨fun n _ => repr (n : ℤ)⟩
 
 end

--- a/Mathlib/Data/Num/Bitwise.lean
+++ b/Mathlib/Data/Num/Bitwise.lean
@@ -293,8 +293,9 @@ def not : SNum → SNum
   | nz p => ~p
 #align snum.not SNum.not
 
+-- Porting note: Defined `priority` so that `~1 : SNum` is unambiguous.
 -- mathport name: snum.not
-prefix:0 "~" => not
+prefix:100 (priority := default + 1) "~" => not
 
 /-- Add a bit at the end of a `SNum`. This mimics `NzsNum.bit`. -/
 @[match_pattern]
@@ -328,7 +329,6 @@ namespace NzsNum
 
 open SNum
 
-/- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
 /-- A dependent induction principle for `NzsNum`, with base cases
       `0 : SNum` and `(-1) : SNum`. -/
 def drec' {C : SNum → Sort _} (z : ∀ b, C (SNum.zero b)) (s : ∀ b p, C p → C (b :: p)) :
@@ -356,7 +356,6 @@ def tail : SNum → SNum
   | nz p => p.tail
 #align snum.tail SNum.tail
 
-/- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
 /-- A dependent induction principle for `SNum` which avoids relying on `NzsNum`. -/
 def drec' {C : SNum → Sort _} (z : ∀ b, C (SNum.zero b)) (s : ∀ b p, C p → C (b :: p)) : ∀ p, C p
   | zero b => z b
@@ -380,16 +379,11 @@ def succ : SNum → SNum :=
   rec' (fun b => cond b 0 1) fun b p succp => cond b (false :: succp) (true :: p)
 #align snum.succ SNum.succ
 
-/- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
-/- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
-/- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
-/- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
 /-- The predecessor of a `SNum` (i.e. the operation of removing one). -/
 def pred : SNum → SNum :=
   rec' (fun b => cond b (~1) (~0)) fun b p predp => cond b (false :: p) (true :: predp)
 #align snum.pred SNum.pred
 
-/- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
 /-- The opposite of a `SNum`. -/
 protected def neg (n : SNum) : SNum :=
   succ (~n)
@@ -398,14 +392,14 @@ protected def neg (n : SNum) : SNum :=
 instance : Neg SNum :=
   ⟨SNum.neg⟩
 
-/-- `SNum.czadd a b n` is `n + a - b` (where `a` and `b` should be read as either 0 or 1).
-      This is useful to implement the carry system in `cadd`. -/
-def czadd : Bool → Bool → SNum → SNum
+/-- `SNum.czAdd a b n` is `n + a - b` (where `a` and `b` should be read as either 0 or 1).
+      This is useful to implement the carry system in `cAdd`. -/
+def czAdd : Bool → Bool → SNum → SNum
   | false, false, p => p
   | false, true, p => pred p
   | true, false, p => succ p
   | true, true, p => p
-#align snum.czadd SNum.czadd
+#align snum.czadd SNum.czAdd
 
 end SNum
 
@@ -417,23 +411,21 @@ def bits : SNum → ∀ n, Vector Bool n
   | p, n + 1 => head p ::ᵥ bits (tail p) n
 #align snum.bits SNum.bits
 
-/- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
-/- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
-def cadd : SNum → SNum → Bool → SNum :=
-  rec' (fun a p c => czadd c a p) fun a p IH =>
-    rec' (fun b c => czadd c b (a :: p)) fun b q _ c =>
+def cAdd : SNum → SNum → Bool → SNum :=
+  rec' (fun a p c => czAdd c a p) fun a p IH =>
+    rec' (fun b c => czAdd c b (a :: p)) fun b q _ c =>
       Bitvec.xor3 a b c :: IH q (Bitvec.carry a b c)
-#align snum.cadd SNum.cadd
+#align snum.cadd SNum.cAdd
 
 /-- Add two `SNum`s. -/
 protected def add (a b : SNum) : SNum :=
-  cadd a b false
+  cAdd a b false
 #align snum.add SNum.add
 
 instance : Add SNum :=
   ⟨SNum.add⟩
 
-/-- subtract two `SNum`s. -/
+/-- Subtract two `SNum`s. -/
 protected def sub (a b : SNum) : SNum :=
   a + -b
 #align snum.sub SNum.sub

--- a/Mathlib/Data/Num/Bitwise.lean
+++ b/Mathlib/Data/Num/Bitwise.lean
@@ -38,9 +38,9 @@ def lor : PosNum → PosNum → PosNum
 
 /-- Bitwise "and" for `pos_num`. -/
 def land : PosNum → PosNum → Num
-  | 1, bit0 q => 0
+  | 1, bit0 _ => 0
   | 1, _ => 1
-  | bit0 p, 1 => 0
+  | bit0 _, 1 => 0
   | _, 1 => 1
   | bit0 p, bit0 q => Num.bit0 (land p q)
   | bit0 p, bit1 q => Num.bit0 (land p q)
@@ -57,7 +57,7 @@ def land : PosNum → PosNum → Num
 
   -/
 def ldiff : PosNum → PosNum → Num
-  | 1, bit0 q => 1
+  | 1, bit0 _ => 1
   | 1, _ => 0
   | bit0 p, 1 => Num.pos (bit0 p)
   | bit1 p, 1 => Num.pos (bit0 p)
@@ -84,30 +84,30 @@ def lxor : PosNum → PosNum → Num
       of `a` is active. If the size of `a` is less than `n`, this evaluates to `ff`. -/
 def testBit : PosNum → Nat → Bool
   | 1, 0 => true
-  | 1, n + 1 => false
-  | bit0 p, 0 => false
-  | bit0 p, n + 1 => test_bit p n
-  | bit1 p, 0 => true
-  | bit1 p, n + 1 => test_bit p n
+  | 1, _ => false
+  | bit0 _, 0 => false
+  | bit0 p, n + 1 => testBit p n
+  | bit1 _, 0 => true
+  | bit1 p, n + 1 => testBit p n
 #align pos_num.test_bit PosNum.testBit
 
 /-- `n.one_bits 0` is the list of indices of active bits in the binary representation of `n`. -/
 def oneBits : PosNum → Nat → List Nat
   | 1, d => [d]
-  | bit0 p, d => one_bits p (d + 1)
-  | bit1 p, d => d :: one_bits p (d + 1)
+  | bit0 p, d => oneBits p (d + 1)
+  | bit1 p, d => d :: oneBits p (d + 1)
 #align pos_num.one_bits PosNum.oneBits
 
 /-- Left-shift the binary representation of a `pos_num`. -/
 def shiftl (p : PosNum) : Nat → PosNum
   | 0 => p
-  | n + 1 => bit0 (shiftl n)
+  | n + 1 => bit0 (p.shiftl n)
 #align pos_num.shiftl PosNum.shiftl
 
 /-- Right-shift the binary representation of a `pos_num`. -/
 def shiftr : PosNum → Nat → Num
   | p, 0 => Num.pos p
-  | 1, n + 1 => 0
+  | 1, _ => 0
   | bit0 p, n + 1 => shiftr p n
   | bit1 p, n + 1 => shiftr p n
 #align pos_num.shiftr PosNum.shiftr
@@ -120,14 +120,14 @@ namespace Num
 def lor : Num → Num → Num
   | 0, q => q
   | p, 0 => p
-  | Pos p, Pos q => pos (p.lor q)
+  | pos p, pos q => pos (p.lor q)
 #align num.lor Num.lor
 
 /-- Bitwise "and" for `num`. -/
 def land : Num → Num → Num
-  | 0, q => 0
-  | p, 0 => 0
-  | Pos p, Pos q => p.land q
+  | 0, _ => 0
+  | _, 0 => 0
+  | pos p, pos q => p.land q
 #align num.land Num.land
 
 /-- Bitwise `λ a b, a && !b` for `num`. For example, `ldiff 5 9 = 4`:
@@ -139,52 +139,53 @@ def land : Num → Num → Num
 
   -/
 def ldiff : Num → Num → Num
-  | 0, q => 0
+  | 0, _ => 0
   | p, 0 => p
-  | Pos p, Pos q => p.ldiff q
+  | pos p, pos q => p.ldiff q
 #align num.ldiff Num.ldiff
 
 /-- Bitwise "xor" for `num`. -/
 def lxor : Num → Num → Num
   | 0, q => q
   | p, 0 => p
-  | Pos p, Pos q => p.lxor q
+  | pos p, pos q => p.lxor q
 #align num.lxor Num.lxor
 
 /-- Left-shift the binary representation of a `num`. -/
 def shiftl : Num → Nat → Num
-  | 0, n => 0
-  | Pos p, n => pos (p.shiftl n)
+  | 0, _ => 0
+  | pos p, n => pos (p.shiftl n)
 #align num.shiftl Num.shiftl
 
 /-- Right-shift the binary representation of a `pos_num`. -/
 def shiftr : Num → Nat → Num
-  | 0, n => 0
-  | Pos p, n => p.shiftr n
+  | 0, _ => 0
+  | pos p, n => p.shiftr n
 #align num.shiftr Num.shiftr
 
 /-- `a.test_bit n` is `tt` iff the `n`-th bit (starting from the LSB) in the binary representation
       of `a` is active. If the size of `a` is less than `n`, this evaluates to `ff`. -/
 def testBit : Num → Nat → Bool
-  | 0, n => false
-  | Pos p, n => p.testBit n
+  | 0, _ => false
+  | pos p, n => p.testBit n
 #align num.test_bit Num.testBit
 
 /-- `n.one_bits` is the list of indices of active bits in the binary representation of `n`. -/
 def oneBits : Num → List Nat
   | 0 => []
-  | Pos p => p.oneBits 0
+  | pos p => p.oneBits 0
 #align num.one_bits Num.oneBits
 
 end Num
 
 /-- This is a nonzero (and "non minus one") version of `snum`.
     See the documentation of `snum` for more details. -/
-inductive Nzsnum : Type
-  | msb : Bool → Nzsnum
-  | bit : Bool → Nzsnum → Nzsnum
-  deriving has_reflect, DecidableEq
-#align nzsnum Nzsnum
+inductive NzsNum : Type
+  | msb : Bool → NzsNum
+  | bit : Bool → NzsNum → NzsNum
+  -- Porting note: Original version is `deriving has_reflect, DecidableEq`.
+  deriving DecidableEq
+#align nzsnum NzsNum
 
 /-- Alternative representation of integers using a sign bit at the end.
   The convention on sign here is to have the argument to `msb` denote
@@ -200,28 +201,29 @@ inductive Nzsnum : Type
 
      0  = ..0000000(base 2) = zero ff
      -1 = ..1111111(base 2) = zero tt -/
-inductive Snum : Type
-  | zero : Bool → Snum
-  | nz : Nzsnum → Snum
-  deriving has_reflect, DecidableEq
-#align snum Snum
+inductive SNum : Type
+  | zero : Bool → SNum
+  | nz : NzsNum → SNum
+  -- Porting note: Original version is `deriving has_reflect, DecidableEq`.
+  deriving DecidableEq
+#align snum SNum
 
-instance : Coe Nzsnum Snum :=
-  ⟨Snum.nz⟩
+instance : Coe NzsNum SNum :=
+  ⟨SNum.nz⟩
 
-instance : Zero Snum :=
-  ⟨Snum.zero false⟩
+instance : Zero SNum :=
+  ⟨SNum.zero false⟩
 
-instance : One Nzsnum :=
-  ⟨Nzsnum.msb true⟩
+instance : One NzsNum :=
+  ⟨NzsNum.msb true⟩
 
-instance : One Snum :=
-  ⟨Snum.nz 1⟩
+instance : One SNum :=
+  ⟨SNum.nz 1⟩
 
-instance : Inhabited Nzsnum :=
+instance : Inhabited NzsNum :=
   ⟨1⟩
 
-instance : Inhabited Snum :=
+instance : Inhabited SNum :=
   ⟨0⟩
 
 /-!
@@ -230,232 +232,231 @@ and the negation of the MSB is sign-extended to all higher bits.
 -/
 
 
-namespace Nzsnum
+namespace NzsNum
 
 -- mathport name: nznum.bit
 notation a "::" b => bit a b
 
 /- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
 /-- Sign of a `nzsnum`. -/
-def sign : Nzsnum → Bool
+def sign : NzsNum → Bool
   | msb b => not b
-  | b::p => sign p
-#align nzsnum.sign Nzsnum.sign
+  | _::p => sign p
+#align nzsnum.sign NzsNum.sign
 
 /- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
 /- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
 /-- Bitwise `not` for `nzsnum`. -/
 @[match_pattern]
-def not : Nzsnum → Nzsnum
-  | msb b => msb (not b)
-  | b::p => not b::Not p
-#align nzsnum.not Nzsnum.not
+def not : NzsNum → NzsNum
+  | msb b => msb (Not b)
+  | b::p => Not b::not p
+#align nzsnum.not NzsNum.not
 
 -- mathport name: «expr~ »
 prefix:100 "~" => not
 
 /-- Add an inactive bit at the end of a `nzsnum`. This mimics `pos_num.bit0`. -/
-def bit0 : Nzsnum → Nzsnum :=
+def bit0 : NzsNum → NzsNum :=
   bit false
-#align nzsnum.bit0 Nzsnum.bit0
+#align nzsnum.bit0 NzsNum.bit0
 
 /-- Add an active bit at the end of a `nzsnum`. This mimics `pos_num.bit1`. -/
-def bit1 : Nzsnum → Nzsnum :=
+def bit1 : NzsNum → NzsNum :=
   bit true
-#align nzsnum.bit1 Nzsnum.bit1
+#align nzsnum.bit1 NzsNum.bit1
 
 /- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
 /-- The `head` of a `nzsnum` is the boolean value of its LSB. -/
-def head : Nzsnum → Bool
+def head : NzsNum → Bool
   | msb b => b
-  | b::p => b
-#align nzsnum.head Nzsnum.head
+  | b::_ => b
+#align nzsnum.head NzsNum.head
 
 /- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
 /-- The `tail` of a `nzsnum` is the `snum` obtained by removing the LSB.
       Edge cases: `tail 1 = 0` and `tail (-2) = -1`. -/
-def tail : Nzsnum → Snum
-  | msb b => Snum.zero (not b)
-  | b::p => p
-#align nzsnum.tail Nzsnum.tail
+def tail : NzsNum → SNum
+  | msb b => SNum.zero (Not b)
+  | _::p => p
+#align nzsnum.tail NzsNum.tail
 
-end Nzsnum
+end NzsNum
 
-namespace Snum
+namespace SNum
 
-open Nzsnum
+open NzsNum
 
 /-- Sign of a `snum`. -/
-def sign : Snum → Bool
+def sign : SNum → Bool
   | zero z => z
   | nz p => p.sign
-#align snum.sign Snum.sign
+#align snum.sign SNum.sign
 
 /-- Bitwise `not` for `snum`. -/
 @[match_pattern]
-def not : Snum → Snum
-  | zero z => zero (not z)
+def not : SNum → SNum
+  | zero z => zero (Not z)
   | nz p => ~p
-#align snum.not Snum.not
+#align snum.not SNum.not
 
 -- mathport name: snum.not
 prefix:0 "~" => not
 
 /-- Add a bit at the end of a `snum`. This mimics `nzsnum.bit`. -/
 @[match_pattern]
-def bit : Bool → Snum → Snum
+def bit : Bool → SNum → SNum
   | b, zero z => if b = z then zero b else msb b
   | b, nz p => p.bit b
-#align snum.bit Snum.bit
+#align snum.bit SNum.bit
 
 -- mathport name: snum.bit
 notation a "::" b => bit a b
 
 /-- Add an inactive bit at the end of a `snum`. This mimics `znum.bit0`. -/
-def bit0 : Snum → Snum :=
+def bit0 : SNum → SNum :=
   bit false
-#align snum.bit0 Snum.bit0
+#align snum.bit0 SNum.bit0
 
 /-- Add an active bit at the end of a `snum`. This mimics `znum.bit1`. -/
-def bit1 : Snum → Snum :=
+def bit1 : SNum → SNum :=
   bit true
-#align snum.bit1 Snum.bit1
+#align snum.bit1 SNum.bit1
 
 /- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
 theorem bit_zero (b) : (b::zero b) = zero b := by cases b <;> rfl
-#align snum.bit_zero Snum.bit_zero
+#align snum.bit_zero SNum.bit_zero
 
 /- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
-theorem bit_one (b) : (b::zero (not b)) = msb b := by cases b <;> rfl
-#align snum.bit_one Snum.bit_one
+theorem bit_one (b) : (b::zero (Not b)) = msb b := by cases b <;> rfl
+#align snum.bit_one SNum.bit_one
 
-end Snum
+end SNum
 
-namespace Nzsnum
+namespace NzsNum
 
-open Snum
+open SNum
 
 /- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
 /-- A dependent induction principle for `nzsnum`, with base cases
       `0 : snum` and `(-1) : snum`. -/
-def drec' {C : Snum → Sort _} (z : ∀ b, C (Snum.zero b)) (s : ∀ b p, C p → C (b::p)) :
-    ∀ p : Nzsnum, C p
-  | msb b => by rw [← bit_one] <;> exact s b (Snum.zero (not b)) (z (not b))
+def drec' {C : SNum → Sort _} (z : ∀ b, C (SNum.zero b)) (s : ∀ b p, C p → C (b::p)) :
+    ∀ p : NzsNum, C p
+  | msb b => by rw [← bit_one] ; exact s b (SNum.zero (Not b)) (z (Not b))
   | bit b p => s b p (drec' p)
-#align nzsnum.drec' Nzsnum.drec'
+#align nzsnum.drec' NzsNum.drec'
 
-end Nzsnum
+end NzsNum
 
-namespace Snum
+namespace SNum
 
-open Nzsnum
+open NzsNum
 
 /-- The `head` of a `snum` is the boolean value of its LSB. -/
-def head : Snum → Bool
+def head : SNum → Bool
   | zero z => z
   | nz p => p.head
-#align snum.head Snum.head
+#align snum.head SNum.head
 
 /-- The `tail` of a `snum` is obtained by removing the LSB.
       Edge cases: `tail 1 = 0`, `tail (-2) = -1`, `tail 0 = 0` and `tail (-1) = -1`. -/
-def tail : Snum → Snum
+def tail : SNum → SNum
   | zero z => zero z
   | nz p => p.tail
-#align snum.tail Snum.tail
+#align snum.tail SNum.tail
 
 /- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
 /-- A dependent induction principle for `snum` which avoids relying on `nzsnum`. -/
-def drec' {C : Snum → Sort _} (z : ∀ b, C (Snum.zero b)) (s : ∀ b p, C p → C (b::p)) : ∀ p, C p
+def drec' {C : SNum → Sort _} (z : ∀ b, C (SNum.zero b)) (s : ∀ b p, C p → C (b::p)) : ∀ p, C p
   | zero b => z b
   | nz p => p.drec' z s
-#align snum.drec' Snum.drec'
+#align snum.drec' SNum.drec'
 
 /-- An induction principle for `snum` which avoids relying on `nzsnum`. -/
-def rec' {α} (z : Bool → α) (s : Bool → Snum → α → α) : Snum → α :=
+def rec' {α} (z : Bool → α) (s : Bool → SNum → α → α) : SNum → α :=
   drec' z s
-#align snum.rec' Snum.rec'
+#align snum.rec' SNum.rec'
 
 /-- `snum.test_bit n a` is `tt` iff the `n`-th bit (starting from the LSB) of `a` is active.
       If the size of `a` is less than `n`, this evaluates to `ff`. -/
-def testBit : Nat → Snum → Bool
+def testBit : Nat → SNum → Bool
   | 0, p => head p
-  | n + 1, p => test_bit n (tail p)
-#align snum.test_bit Snum.testBit
+  | n + 1, p => testBit n (tail p)
+#align snum.test_bit SNum.testBit
 
 /- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
 /- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
 /-- The successor of a `snum` (i.e. the operation adding one). -/
-def succ : Snum → Snum :=
-  rec' (fun b => cond b 0 1) fun b p succp => cond b (ff::succp) (tt::p)
-#align snum.succ Snum.succ
+def succ : SNum → SNum :=
+  rec' (fun b => cond b 0 1) fun b p succp => cond b (false::succp) (true::p)
+#align snum.succ SNum.succ
 
 /- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
 /- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
 /- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
 /- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
 /-- The predecessor of a `snum` (i.e. the operation of removing one). -/
-def pred : Snum → Snum :=
-  rec' (fun b => cond b (~1) (~0)) fun b p predp => cond b (ff::p) (tt::predp)
-#align snum.pred Snum.pred
+def pred : SNum → SNum :=
+  rec' (fun b => cond b (~1) (~0)) fun b p predp => cond b (false::p) (true::predp)
+#align snum.pred SNum.pred
 
 /- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
 /-- The opposite of a `snum`. -/
-protected def neg (n : Snum) : Snum :=
+protected def neg (n : SNum) : SNum :=
   succ (~n)
-#align snum.neg Snum.neg
+#align snum.neg SNum.neg
 
-instance : Neg Snum :=
-  ⟨Snum.neg⟩
+instance : Neg SNum :=
+  ⟨SNum.neg⟩
 
 /-- `snum.czadd a b n` is `n + a - b` (where `a` and `b` should be read as either 0 or 1).
       This is useful to implement the carry system in `cadd`. -/
-def czadd : Bool → Bool → Snum → Snum
-  | ff, ff, p => p
-  | ff, tt, p => pred p
-  | tt, ff, p => succ p
-  | tt, tt, p => p
-#align snum.czadd Snum.czadd
+def czadd : Bool → Bool → SNum → SNum
+  | false, false, p => p
+  | false, true, p => pred p
+  | true, false, p => succ p
+  | true, true, p => p
+#align snum.czadd SNum.czadd
 
-end Snum
+end SNum
 
-namespace Snum
+namespace SNum
 
 /-- `a.bits n` is the vector of the `n` first bits of `a` (starting from the LSB). -/
-def bits : Snum → ∀ n, Vector Bool n
-  | p, 0 => Vector.nil
+def bits : SNum → ∀ n, Vector Bool n
+  | _, 0 => Vector.nil
   | p, n + 1 => head p ::ᵥ bits (tail p) n
-#align snum.bits Snum.bits
+#align snum.bits SNum.bits
 
 /- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
 /- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
-def cadd : Snum → Snum → Bool → Snum :=
+def cadd : SNum → SNum → Bool → SNum :=
   rec' (fun a p c => czadd c a p) fun a p IH =>
     rec' (fun b c => czadd c b (a::p)) fun b q _ c => Bitvec.xor3 a b c::IH q (Bitvec.carry a b c)
-#align snum.cadd Snum.cadd
+#align snum.cadd SNum.cadd
 
 /-- Add two `snum`s. -/
-protected def add (a b : Snum) : Snum :=
+protected def add (a b : SNum) : SNum :=
   cadd a b false
-#align snum.add Snum.add
+#align snum.add SNum.add
 
-instance : Add Snum :=
-  ⟨Snum.add⟩
+instance : Add SNum :=
+  ⟨SNum.add⟩
 
 /-- subtract two `snum`s. -/
-protected def sub (a b : Snum) : Snum :=
+protected def sub (a b : SNum) : SNum :=
   a + -b
-#align snum.sub Snum.sub
+#align snum.sub SNum.sub
 
-instance : Sub Snum :=
-  ⟨Snum.sub⟩
+instance : Sub SNum :=
+  ⟨SNum.sub⟩
 
 /-- Multiply two `snum`s. -/
-protected def mul (a : Snum) : Snum → Snum :=
-  rec' (fun b => cond b (-a) 0) fun b q IH => cond b (bit0 IH + a) (bit0 IH)
-#align snum.mul Snum.mul
+protected def mul (a : SNum) : SNum → SNum :=
+  rec' (fun b => cond b (-a) 0) fun b _ IH => cond b (bit0 IH + a) (bit0 IH)
+#align snum.mul SNum.mul
 
-instance : Mul Snum :=
-  ⟨Snum.mul⟩
+instance : Mul SNum :=
+  ⟨SNum.mul⟩
 
-end Snum
-
+end SNum

--- a/Mathlib/Data/Num/Bitwise.lean
+++ b/Mathlib/Data/Num/Bitwise.lean
@@ -182,6 +182,7 @@ end Num
     See the documentation of `SNum` for more details. -/
 inductive NzsNum : Type
   | msb : Bool → NzsNum
+  /-- Add a bit at the end of a `NzsNum`. -/
   | bit : Bool → NzsNum → NzsNum
   deriving DecidableEq  -- Porting note: Removed `deriving has_reflect`.
 #align nzsnum NzsNum
@@ -233,6 +234,7 @@ and the negation of the MSB is sign-extended to all higher bits.
 namespace NzsNum
 
 -- mathport name: nznum.bit
+@[inherit_doc]
 notation a "::" b => bit a b
 
 /-- Sign of a `NzsNum`. -/
@@ -249,6 +251,7 @@ def not : NzsNum → NzsNum
 #align nzsnum.not NzsNum.not
 
 -- mathport name: «expr~ »
+@[inherit_doc]
 prefix:100 "~" => not
 
 /-- Add an inactive bit at the end of a `NzsNum`. This mimics `PosNum.bit0`. -/
@@ -295,6 +298,7 @@ def not : SNum → SNum
 
 -- Porting note: Defined `priority` so that `~1 : SNum` is unambiguous.
 -- mathport name: snum.not
+@[inherit_doc]
 prefix:100 (priority := default + 1) "~" => not
 
 /-- Add a bit at the end of a `SNum`. This mimics `NzsNum.bit`. -/
@@ -305,6 +309,7 @@ def bit : Bool → SNum → SNum
 #align snum.bit SNum.bit
 
 -- mathport name: snum.bit
+@[inherit_doc]
 notation a "::" b => bit a b
 
 /-- Add an inactive bit at the end of a `SNum`. This mimics `ZNum.bit0`. -/
@@ -411,6 +416,8 @@ def bits : SNum → ∀ n, Vector Bool n
   | p, n + 1 => head p ::ᵥ bits (tail p) n
 #align snum.bits SNum.bits
 
+/-- `SNum.cAdd n m a` is `n + m + a` (where `a` should be read as either 0 or 1).
+      `a` represents a carry bit. -/
 def cAdd : SNum → SNum → Bool → SNum :=
   rec' (fun a p c ↦ czAdd c a p) fun a p IH ↦
     rec' (fun b c ↦ czAdd c b (a :: p)) fun b q _ c ↦ Bitvec.xor3 a b c :: IH q (Bitvec.carry a b c)

--- a/Mathlib/Data/Num/Bitwise.lean
+++ b/Mathlib/Data/Num/Bitwise.lean
@@ -376,12 +376,12 @@ def testBit : Nat → SNum → Bool
 
 /-- The successor of a `SNum` (i.e. the operation adding one). -/
 def succ : SNum → SNum :=
-  rec' (fun b => cond b 0 1) fun b p succp => cond b (false :: succp) (true :: p)
+  rec' (fun b ↦ cond b 0 1) fun b p succp ↦ cond b (false :: succp) (true :: p)
 #align snum.succ SNum.succ
 
 /-- The predecessor of a `SNum` (i.e. the operation of removing one). -/
 def pred : SNum → SNum :=
-  rec' (fun b => cond b (~1) (~0)) fun b p predp => cond b (false :: p) (true :: predp)
+  rec' (fun b ↦ cond b (~1) (~0)) fun b p predp ↦ cond b (false :: p) (true :: predp)
 #align snum.pred SNum.pred
 
 /-- The opposite of a `SNum`. -/
@@ -412,9 +412,8 @@ def bits : SNum → ∀ n, Vector Bool n
 #align snum.bits SNum.bits
 
 def cAdd : SNum → SNum → Bool → SNum :=
-  rec' (fun a p c => czAdd c a p) fun a p IH =>
-    rec' (fun b c => czAdd c b (a :: p)) fun b q _ c =>
-      Bitvec.xor3 a b c :: IH q (Bitvec.carry a b c)
+  rec' (fun a p c ↦ czAdd c a p) fun a p IH ↦
+    rec' (fun b c ↦ czAdd c b (a :: p)) fun b q _ c ↦ Bitvec.xor3 a b c :: IH q (Bitvec.carry a b c)
 #align snum.cadd SNum.cAdd
 
 /-- Add two `SNum`s. -/
@@ -435,7 +434,7 @@ instance : Sub SNum :=
 
 /-- Multiply two `SNum`s. -/
 protected def mul (a : SNum) : SNum → SNum :=
-  rec' (fun b => cond b (-a) 0) fun b _ IH => cond b (bit0 IH + a) (bit0 IH)
+  rec' (fun b ↦ cond b (-a) 0) fun b _ IH ↦ cond b (bit0 IH + a) (bit0 IH)
 #align snum.mul SNum.mul
 
 instance : Mul SNum :=

--- a/Mathlib/Data/Num/Bitwise.lean
+++ b/Mathlib/Data/Num/Bitwise.lean
@@ -16,15 +16,15 @@ import Mathlib.Data.Bitvec.Core
 
 ## Definitions
 
-* bitwise operations for `pos_num` and `num`,
-* `snum`, a type that represents integers as a bit string with a sign bit at the end,
-* arithmetic operations for `snum`.
+* bitwise operations for `PosNum` and `Num`,
+* `SNum`, a type that represents integers as a bit string with a sign bit at the end,
+* arithmetic operations for `SNum`.
 -/
 
 
 namespace PosNum
 
-/-- Bitwise "or" for `pos_num`. -/
+/-- Bitwise "or" for `PosNum`. -/
 def lor : PosNum → PosNum → PosNum
   | 1, bit0 q => bit1 q
   | 1, q => q
@@ -36,7 +36,7 @@ def lor : PosNum → PosNum → PosNum
   | bit1 p, bit1 q => bit1 (lor p q)
 #align pos_num.lor PosNum.lor
 
-/-- Bitwise "and" for `pos_num`. -/
+/-- Bitwise "and" for `PosNum`. -/
 def land : PosNum → PosNum → Num
   | 1, bit0 _ => 0
   | 1, _ => 1
@@ -48,14 +48,14 @@ def land : PosNum → PosNum → Num
   | bit1 p, bit1 q => Num.bit1 (land p q)
 #align pos_num.land PosNum.land
 
-/-- Bitwise `λ a b, a && !b` for `pos_num`. For example, `ldiff 5 9 = 4`:
-
-     101
-    1001
-    ----
-     100
-
-  -/
+/-- Bitwise `fun a b ↦ a && !b` for `PosNum`. For example, `ldiff 5 9 = 4`:
+```
+ 101
+1001
+----
+ 100
+```
+-/
 def ldiff : PosNum → PosNum → Num
   | 1, bit0 _ => 1
   | 1, _ => 0
@@ -67,7 +67,7 @@ def ldiff : PosNum → PosNum → Num
   | bit1 p, bit1 q => Num.bit0 (ldiff p q)
 #align pos_num.ldiff PosNum.ldiff
 
-/-- Bitwise "xor" for `pos_num`. -/
+/-- Bitwise "xor" for `PosNum`. -/
 def lxor : PosNum → PosNum → Num
   | 1, 1 => 0
   | 1, bit0 q => Num.pos (bit1 q)
@@ -80,8 +80,8 @@ def lxor : PosNum → PosNum → Num
   | bit1 p, bit1 q => Num.bit0 (lxor p q)
 #align pos_num.lxor PosNum.lxor
 
-/-- `a.test_bit n` is `tt` iff the `n`-th bit (starting from the LSB) in the binary representation
-      of `a` is active. If the size of `a` is less than `n`, this evaluates to `ff`. -/
+/-- `a.testBit n` is `true` iff the `n`-th bit (starting from the LSB) in the binary representation
+      of `a` is active. If the size of `a` is less than `n`, this evaluates to `false`. -/
 def testBit : PosNum → Nat → Bool
   | 1, 0 => true
   | 1, _ => false
@@ -91,20 +91,20 @@ def testBit : PosNum → Nat → Bool
   | bit1 p, n + 1 => testBit p n
 #align pos_num.test_bit PosNum.testBit
 
-/-- `n.one_bits 0` is the list of indices of active bits in the binary representation of `n`. -/
+/-- `n.oneBits 0` is the list of indices of active bits in the binary representation of `n`. -/
 def oneBits : PosNum → Nat → List Nat
   | 1, d => [d]
   | bit0 p, d => oneBits p (d + 1)
   | bit1 p, d => d :: oneBits p (d + 1)
 #align pos_num.one_bits PosNum.oneBits
 
-/-- Left-shift the binary representation of a `pos_num`. -/
+/-- Left-shift the binary representation of a `PosNum`. -/
 def shiftl (p : PosNum) : Nat → PosNum
   | 0 => p
   | n + 1 => bit0 (p.shiftl n)
 #align pos_num.shiftl PosNum.shiftl
 
-/-- Right-shift the binary representation of a `pos_num`. -/
+/-- Right-shift the binary representation of a `PosNum`. -/
 def shiftr : PosNum → Nat → Num
   | p, 0 => Num.pos p
   | 1, _ => 0
@@ -116,61 +116,61 @@ end PosNum
 
 namespace Num
 
-/-- Bitwise "or" for `num`. -/
+/-- Bitwise "or" for `Num`. -/
 def lor : Num → Num → Num
   | 0, q => q
   | p, 0 => p
   | pos p, pos q => pos (p.lor q)
 #align num.lor Num.lor
 
-/-- Bitwise "and" for `num`. -/
+/-- Bitwise "and" for `Num`. -/
 def land : Num → Num → Num
   | 0, _ => 0
   | _, 0 => 0
   | pos p, pos q => p.land q
 #align num.land Num.land
 
-/-- Bitwise `λ a b, a && !b` for `num`. For example, `ldiff 5 9 = 4`:
-
-     101
-    1001
-    ----
-     100
-
-  -/
+/-- Bitwise `fun a b ↦ a && !b` for `Num`. For example, `ldiff 5 9 = 4`:
+```
+ 101
+1001
+----
+ 100
+```
+-/
 def ldiff : Num → Num → Num
   | 0, _ => 0
   | p, 0 => p
   | pos p, pos q => p.ldiff q
 #align num.ldiff Num.ldiff
 
-/-- Bitwise "xor" for `num`. -/
+/-- Bitwise "xor" for `Num`. -/
 def lxor : Num → Num → Num
   | 0, q => q
   | p, 0 => p
   | pos p, pos q => p.lxor q
 #align num.lxor Num.lxor
 
-/-- Left-shift the binary representation of a `num`. -/
+/-- Left-shift the binary representation of a `Num`. -/
 def shiftl : Num → Nat → Num
   | 0, _ => 0
   | pos p, n => pos (p.shiftl n)
 #align num.shiftl Num.shiftl
 
-/-- Right-shift the binary representation of a `pos_num`. -/
+/-- Right-shift the binary representation of a `Num`. -/
 def shiftr : Num → Nat → Num
   | 0, _ => 0
   | pos p, n => p.shiftr n
 #align num.shiftr Num.shiftr
 
-/-- `a.test_bit n` is `tt` iff the `n`-th bit (starting from the LSB) in the binary representation
-      of `a` is active. If the size of `a` is less than `n`, this evaluates to `ff`. -/
+/-- `a.testBit n` is `true` iff the `n`-th bit (starting from the LSB) in the binary representation
+      of `a` is active. If the size of `a` is less than `n`, this evaluates to `false`. -/
 def testBit : Num → Nat → Bool
   | 0, _ => false
   | pos p, n => p.testBit n
 #align num.test_bit Num.testBit
 
-/-- `n.one_bits` is the list of indices of active bits in the binary representation of `n`. -/
+/-- `n.oneBits` is the list of indices of active bits in the binary representation of `n`. -/
 def oneBits : Num → List Nat
   | 0 => []
   | pos p => p.oneBits 0
@@ -178,8 +178,8 @@ def oneBits : Num → List Nat
 
 end Num
 
-/-- This is a nonzero (and "non minus one") version of `snum`.
-    See the documentation of `snum` for more details. -/
+/-- This is a nonzero (and "non minus one") version of `SNum`.
+    See the documentation of `SNum` for more details. -/
 inductive NzsNum : Type
   | msb : Bool → NzsNum
   | bit : Bool → NzsNum → NzsNum
@@ -192,15 +192,15 @@ inductive NzsNum : Type
   the sign of the MSB itself, with all higher bits set to the negation
   of this sign. The result is interpreted in two's complement.
 
-     13  = ..0001101(base 2) = nz (bit1 (bit0 (bit1 (msb tt))))
-     -13 = ..1110011(base 2) = nz (bit1 (bit1 (bit0 (msb ff))))
+     13  = ..0001101(base 2) = nz (bit1 (bit0 (bit1 (msb true))))
+     -13 = ..1110011(base 2) = nz (bit1 (bit1 (bit0 (msb false))))
 
-  As with `num`, a special case must be added for zero, which has no msb,
+  As with `Num`, a special case must be added for zero, which has no msb,
   but by two's complement symmetry there is a second special case for -1.
-  Here the `bool` field indicates the sign of the number.
+  Here the `Bool` field indicates the sign of the number.
 
-     0  = ..0000000(base 2) = zero ff
-     -1 = ..1111111(base 2) = zero tt -/
+     0  = ..0000000(base 2) = zero false
+     -1 = ..1111111(base 2) = zero true -/
 inductive SNum : Type
   | zero : Bool → SNum
   | nz : NzsNum → SNum
@@ -227,7 +227,7 @@ instance : Inhabited SNum :=
   ⟨0⟩
 
 /-!
-The `snum` representation uses a bit string, essentially a list of 0 (`ff`) and 1 (`tt`) bits,
+The `SNum` representation uses a bit string, essentially a list of 0 (`false`) and 1 (`true`) bits,
 and the negation of the MSB is sign-extended to all higher bits.
 -/
 
@@ -237,16 +237,13 @@ namespace NzsNum
 -- mathport name: nznum.bit
 notation a "::" b => bit a b
 
-/- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
-/-- Sign of a `nzsnum`. -/
+/-- Sign of a `NzsNum`. -/
 def sign : NzsNum → Bool
   | msb b => not b
   | _::p => sign p
 #align nzsnum.sign NzsNum.sign
 
-/- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
-/- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
-/-- Bitwise `not` for `nzsnum`. -/
+/-- Bitwise `not` for `NzsNum`. -/
 @[match_pattern]
 def not : NzsNum → NzsNum
   | msb b => msb (Not b)
@@ -256,25 +253,23 @@ def not : NzsNum → NzsNum
 -- mathport name: «expr~ »
 prefix:100 "~" => not
 
-/-- Add an inactive bit at the end of a `nzsnum`. This mimics `pos_num.bit0`. -/
+/-- Add an inactive bit at the end of a `NzsNum`. This mimics `PosNum.bit0`. -/
 def bit0 : NzsNum → NzsNum :=
   bit false
 #align nzsnum.bit0 NzsNum.bit0
 
-/-- Add an active bit at the end of a `nzsnum`. This mimics `pos_num.bit1`. -/
+/-- Add an active bit at the end of a `NzsNum`. This mimics `PosNum.bit1`. -/
 def bit1 : NzsNum → NzsNum :=
   bit true
 #align nzsnum.bit1 NzsNum.bit1
 
-/- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
-/-- The `head` of a `nzsnum` is the boolean value of its LSB. -/
+/-- The `head` of a `NzsNum` is the boolean value of its LSB. -/
 def head : NzsNum → Bool
   | msb b => b
   | b::_ => b
 #align nzsnum.head NzsNum.head
 
-/- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
-/-- The `tail` of a `nzsnum` is the `snum` obtained by removing the LSB.
+/-- The `tail` of a `NzsNum` is the `SNum` obtained by removing the LSB.
       Edge cases: `tail 1 = 0` and `tail (-2) = -1`. -/
 def tail : NzsNum → SNum
   | msb b => SNum.zero (Not b)
@@ -287,13 +282,13 @@ namespace SNum
 
 open NzsNum
 
-/-- Sign of a `snum`. -/
+/-- Sign of a `SNum`. -/
 def sign : SNum → Bool
   | zero z => z
   | nz p => p.sign
 #align snum.sign SNum.sign
 
-/-- Bitwise `not` for `snum`. -/
+/-- Bitwise `not` for `SNum`. -/
 @[match_pattern]
 def not : SNum → SNum
   | zero z => zero (Not z)
@@ -303,7 +298,7 @@ def not : SNum → SNum
 -- mathport name: snum.not
 prefix:0 "~" => not
 
-/-- Add a bit at the end of a `snum`. This mimics `nzsnum.bit`. -/
+/-- Add a bit at the end of a `SNum`. This mimics `NzsNum.bit`. -/
 @[match_pattern]
 def bit : Bool → SNum → SNum
   | b, zero z => if b = z then zero b else msb b
@@ -313,12 +308,12 @@ def bit : Bool → SNum → SNum
 -- mathport name: snum.bit
 notation a "::" b => bit a b
 
-/-- Add an inactive bit at the end of a `snum`. This mimics `znum.bit0`. -/
+/-- Add an inactive bit at the end of a `SNum`. This mimics `ZNum.bit0`. -/
 def bit0 : SNum → SNum :=
   bit false
 #align snum.bit0 SNum.bit0
 
-/-- Add an active bit at the end of a `snum`. This mimics `znum.bit1`. -/
+/-- Add an active bit at the end of a `SNum`. This mimics `ZNum.bit1`. -/
 def bit1 : SNum → SNum :=
   bit true
 #align snum.bit1 SNum.bit1
@@ -338,12 +333,12 @@ namespace NzsNum
 open SNum
 
 /- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
-/-- A dependent induction principle for `nzsnum`, with base cases
-      `0 : snum` and `(-1) : snum`. -/
+/-- A dependent induction principle for `NzsNum`, with base cases
+      `0 : SNum` and `(-1) : SNum`. -/
 def drec' {C : SNum → Sort _} (z : ∀ b, C (SNum.zero b)) (s : ∀ b p, C p → C (b::p)) :
     ∀ p : NzsNum, C p
   | msb b => by rw [← bit_one] ; exact s b (SNum.zero (Not b)) (z (Not b))
-  | bit b p => s b p (drec' p)
+  | bit b p => s b p (drec' z s p)
 #align nzsnum.drec' NzsNum.drec'
 
 end NzsNum
@@ -352,13 +347,13 @@ namespace SNum
 
 open NzsNum
 
-/-- The `head` of a `snum` is the boolean value of its LSB. -/
+/-- The `head` of a `SNum` is the boolean value of its LSB. -/
 def head : SNum → Bool
   | zero z => z
   | nz p => p.head
 #align snum.head SNum.head
 
-/-- The `tail` of a `snum` is obtained by removing the LSB.
+/-- The `tail` of a `SNum` is obtained by removing the LSB.
       Edge cases: `tail 1 = 0`, `tail (-2) = -1`, `tail 0 = 0` and `tail (-1) = -1`. -/
 def tail : SNum → SNum
   | zero z => zero z
@@ -366,27 +361,25 @@ def tail : SNum → SNum
 #align snum.tail SNum.tail
 
 /- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
-/-- A dependent induction principle for `snum` which avoids relying on `nzsnum`. -/
+/-- A dependent induction principle for `SNum` which avoids relying on `NzsNum`. -/
 def drec' {C : SNum → Sort _} (z : ∀ b, C (SNum.zero b)) (s : ∀ b p, C p → C (b::p)) : ∀ p, C p
   | zero b => z b
   | nz p => p.drec' z s
 #align snum.drec' SNum.drec'
 
-/-- An induction principle for `snum` which avoids relying on `nzsnum`. -/
+/-- An induction principle for `SNum` which avoids relying on `NzsNum`. -/
 def rec' {α} (z : Bool → α) (s : Bool → SNum → α → α) : SNum → α :=
   drec' z s
 #align snum.rec' SNum.rec'
 
-/-- `snum.test_bit n a` is `tt` iff the `n`-th bit (starting from the LSB) of `a` is active.
-      If the size of `a` is less than `n`, this evaluates to `ff`. -/
+/-- `SNum.testBit n a` is `true` iff the `n`-th bit (starting from the LSB) of `a` is active.
+      If the size of `a` is less than `n`, this evaluates to `false`. -/
 def testBit : Nat → SNum → Bool
   | 0, p => head p
   | n + 1, p => testBit n (tail p)
 #align snum.test_bit SNum.testBit
 
-/- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
-/- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
-/-- The successor of a `snum` (i.e. the operation adding one). -/
+/-- The successor of a `SNum` (i.e. the operation adding one). -/
 def succ : SNum → SNum :=
   rec' (fun b => cond b 0 1) fun b p succp => cond b (false::succp) (true::p)
 #align snum.succ SNum.succ
@@ -395,13 +388,13 @@ def succ : SNum → SNum :=
 /- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
 /- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
 /- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
-/-- The predecessor of a `snum` (i.e. the operation of removing one). -/
+/-- The predecessor of a `SNum` (i.e. the operation of removing one). -/
 def pred : SNum → SNum :=
   rec' (fun b => cond b (~1) (~0)) fun b p predp => cond b (false::p) (true::predp)
 #align snum.pred SNum.pred
 
 /- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
-/-- The opposite of a `snum`. -/
+/-- The opposite of a `SNum`. -/
 protected def neg (n : SNum) : SNum :=
   succ (~n)
 #align snum.neg SNum.neg
@@ -409,7 +402,7 @@ protected def neg (n : SNum) : SNum :=
 instance : Neg SNum :=
   ⟨SNum.neg⟩
 
-/-- `snum.czadd a b n` is `n + a - b` (where `a` and `b` should be read as either 0 or 1).
+/-- `SNum.czadd a b n` is `n + a - b` (where `a` and `b` should be read as either 0 or 1).
       This is useful to implement the carry system in `cadd`. -/
 def czadd : Bool → Bool → SNum → SNum
   | false, false, p => p
@@ -435,7 +428,7 @@ def cadd : SNum → SNum → Bool → SNum :=
     rec' (fun b c => czadd c b (a::p)) fun b q _ c => Bitvec.xor3 a b c::IH q (Bitvec.carry a b c)
 #align snum.cadd SNum.cadd
 
-/-- Add two `snum`s. -/
+/-- Add two `SNum`s. -/
 protected def add (a b : SNum) : SNum :=
   cadd a b false
 #align snum.add SNum.add
@@ -443,7 +436,7 @@ protected def add (a b : SNum) : SNum :=
 instance : Add SNum :=
   ⟨SNum.add⟩
 
-/-- subtract two `snum`s. -/
+/-- subtract two `SNum`s. -/
 protected def sub (a b : SNum) : SNum :=
   a + -b
 #align snum.sub SNum.sub
@@ -451,7 +444,7 @@ protected def sub (a b : SNum) : SNum :=
 instance : Sub SNum :=
   ⟨SNum.sub⟩
 
-/-- Multiply two `snum`s. -/
+/-- Multiply two `SNum`s. -/
 protected def mul (a : SNum) : SNum → SNum :=
   rec' (fun b => cond b (-a) 0) fun b _ IH => cond b (bit0 IH + a) (bit0 IH)
 #align snum.mul SNum.mul

--- a/Mathlib/Data/Num/Bitwise.lean
+++ b/Mathlib/Data/Num/Bitwise.lean
@@ -8,8 +8,8 @@ Authors: Mario Carneiro
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
-import Mathbin.Data.Num.Basic
-import Mathbin.Data.Bitvec.Core
+import Mathlib.Data.Num.Basic
+import Mathlib.Data.Bitvec.Core
 
 /-!
 # Bitwise operations using binary representation of integers

--- a/Mathlib/Data/Num/Bitwise.lean
+++ b/Mathlib/Data/Num/Bitwise.lean
@@ -1,0 +1,461 @@
+/-
+Copyright (c) 2014 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro
+
+! This file was ported from Lean 3 source module data.num.bitwise
+! leanprover-community/mathlib commit f7fc89d5d5ff1db2d1242c7bb0e9062ce47ef47c
+! Please do not edit these lines, except to modify the commit id
+! if you have ported upstream changes.
+-/
+import Mathbin.Data.Num.Basic
+import Mathbin.Data.Bitvec.Core
+
+/-!
+# Bitwise operations using binary representation of integers
+
+## Definitions
+
+* bitwise operations for `pos_num` and `num`,
+* `snum`, a type that represents integers as a bit string with a sign bit at the end,
+* arithmetic operations for `snum`.
+-/
+
+
+namespace PosNum
+
+/-- Bitwise "or" for `pos_num`. -/
+def lor : PosNum → PosNum → PosNum
+  | 1, bit0 q => bit1 q
+  | 1, q => q
+  | bit0 p, 1 => bit1 p
+  | p, 1 => p
+  | bit0 p, bit0 q => bit0 (lor p q)
+  | bit0 p, bit1 q => bit1 (lor p q)
+  | bit1 p, bit0 q => bit1 (lor p q)
+  | bit1 p, bit1 q => bit1 (lor p q)
+#align pos_num.lor PosNum.lor
+
+/-- Bitwise "and" for `pos_num`. -/
+def land : PosNum → PosNum → Num
+  | 1, bit0 q => 0
+  | 1, _ => 1
+  | bit0 p, 1 => 0
+  | _, 1 => 1
+  | bit0 p, bit0 q => Num.bit0 (land p q)
+  | bit0 p, bit1 q => Num.bit0 (land p q)
+  | bit1 p, bit0 q => Num.bit0 (land p q)
+  | bit1 p, bit1 q => Num.bit1 (land p q)
+#align pos_num.land PosNum.land
+
+/-- Bitwise `λ a b, a && !b` for `pos_num`. For example, `ldiff 5 9 = 4`:
+
+     101
+    1001
+    ----
+     100
+
+  -/
+def ldiff : PosNum → PosNum → Num
+  | 1, bit0 q => 1
+  | 1, _ => 0
+  | bit0 p, 1 => Num.pos (bit0 p)
+  | bit1 p, 1 => Num.pos (bit0 p)
+  | bit0 p, bit0 q => Num.bit0 (ldiff p q)
+  | bit0 p, bit1 q => Num.bit0 (ldiff p q)
+  | bit1 p, bit0 q => Num.bit1 (ldiff p q)
+  | bit1 p, bit1 q => Num.bit0 (ldiff p q)
+#align pos_num.ldiff PosNum.ldiff
+
+/-- Bitwise "xor" for `pos_num`. -/
+def lxor : PosNum → PosNum → Num
+  | 1, 1 => 0
+  | 1, bit0 q => Num.pos (bit1 q)
+  | 1, bit1 q => Num.pos (bit0 q)
+  | bit0 p, 1 => Num.pos (bit1 p)
+  | bit1 p, 1 => Num.pos (bit0 p)
+  | bit0 p, bit0 q => Num.bit0 (lxor p q)
+  | bit0 p, bit1 q => Num.bit1 (lxor p q)
+  | bit1 p, bit0 q => Num.bit1 (lxor p q)
+  | bit1 p, bit1 q => Num.bit0 (lxor p q)
+#align pos_num.lxor PosNum.lxor
+
+/-- `a.test_bit n` is `tt` iff the `n`-th bit (starting from the LSB) in the binary representation
+      of `a` is active. If the size of `a` is less than `n`, this evaluates to `ff`. -/
+def testBit : PosNum → Nat → Bool
+  | 1, 0 => true
+  | 1, n + 1 => false
+  | bit0 p, 0 => false
+  | bit0 p, n + 1 => test_bit p n
+  | bit1 p, 0 => true
+  | bit1 p, n + 1 => test_bit p n
+#align pos_num.test_bit PosNum.testBit
+
+/-- `n.one_bits 0` is the list of indices of active bits in the binary representation of `n`. -/
+def oneBits : PosNum → Nat → List Nat
+  | 1, d => [d]
+  | bit0 p, d => one_bits p (d + 1)
+  | bit1 p, d => d :: one_bits p (d + 1)
+#align pos_num.one_bits PosNum.oneBits
+
+/-- Left-shift the binary representation of a `pos_num`. -/
+def shiftl (p : PosNum) : Nat → PosNum
+  | 0 => p
+  | n + 1 => bit0 (shiftl n)
+#align pos_num.shiftl PosNum.shiftl
+
+/-- Right-shift the binary representation of a `pos_num`. -/
+def shiftr : PosNum → Nat → Num
+  | p, 0 => Num.pos p
+  | 1, n + 1 => 0
+  | bit0 p, n + 1 => shiftr p n
+  | bit1 p, n + 1 => shiftr p n
+#align pos_num.shiftr PosNum.shiftr
+
+end PosNum
+
+namespace Num
+
+/-- Bitwise "or" for `num`. -/
+def lor : Num → Num → Num
+  | 0, q => q
+  | p, 0 => p
+  | Pos p, Pos q => pos (p.lor q)
+#align num.lor Num.lor
+
+/-- Bitwise "and" for `num`. -/
+def land : Num → Num → Num
+  | 0, q => 0
+  | p, 0 => 0
+  | Pos p, Pos q => p.land q
+#align num.land Num.land
+
+/-- Bitwise `λ a b, a && !b` for `num`. For example, `ldiff 5 9 = 4`:
+
+     101
+    1001
+    ----
+     100
+
+  -/
+def ldiff : Num → Num → Num
+  | 0, q => 0
+  | p, 0 => p
+  | Pos p, Pos q => p.ldiff q
+#align num.ldiff Num.ldiff
+
+/-- Bitwise "xor" for `num`. -/
+def lxor : Num → Num → Num
+  | 0, q => q
+  | p, 0 => p
+  | Pos p, Pos q => p.lxor q
+#align num.lxor Num.lxor
+
+/-- Left-shift the binary representation of a `num`. -/
+def shiftl : Num → Nat → Num
+  | 0, n => 0
+  | Pos p, n => pos (p.shiftl n)
+#align num.shiftl Num.shiftl
+
+/-- Right-shift the binary representation of a `pos_num`. -/
+def shiftr : Num → Nat → Num
+  | 0, n => 0
+  | Pos p, n => p.shiftr n
+#align num.shiftr Num.shiftr
+
+/-- `a.test_bit n` is `tt` iff the `n`-th bit (starting from the LSB) in the binary representation
+      of `a` is active. If the size of `a` is less than `n`, this evaluates to `ff`. -/
+def testBit : Num → Nat → Bool
+  | 0, n => false
+  | Pos p, n => p.testBit n
+#align num.test_bit Num.testBit
+
+/-- `n.one_bits` is the list of indices of active bits in the binary representation of `n`. -/
+def oneBits : Num → List Nat
+  | 0 => []
+  | Pos p => p.oneBits 0
+#align num.one_bits Num.oneBits
+
+end Num
+
+/-- This is a nonzero (and "non minus one") version of `snum`.
+    See the documentation of `snum` for more details. -/
+inductive Nzsnum : Type
+  | msb : Bool → Nzsnum
+  | bit : Bool → Nzsnum → Nzsnum
+  deriving has_reflect, DecidableEq
+#align nzsnum Nzsnum
+
+/-- Alternative representation of integers using a sign bit at the end.
+  The convention on sign here is to have the argument to `msb` denote
+  the sign of the MSB itself, with all higher bits set to the negation
+  of this sign. The result is interpreted in two's complement.
+
+     13  = ..0001101(base 2) = nz (bit1 (bit0 (bit1 (msb tt))))
+     -13 = ..1110011(base 2) = nz (bit1 (bit1 (bit0 (msb ff))))
+
+  As with `num`, a special case must be added for zero, which has no msb,
+  but by two's complement symmetry there is a second special case for -1.
+  Here the `bool` field indicates the sign of the number.
+
+     0  = ..0000000(base 2) = zero ff
+     -1 = ..1111111(base 2) = zero tt -/
+inductive Snum : Type
+  | zero : Bool → Snum
+  | nz : Nzsnum → Snum
+  deriving has_reflect, DecidableEq
+#align snum Snum
+
+instance : Coe Nzsnum Snum :=
+  ⟨Snum.nz⟩
+
+instance : Zero Snum :=
+  ⟨Snum.zero false⟩
+
+instance : One Nzsnum :=
+  ⟨Nzsnum.msb true⟩
+
+instance : One Snum :=
+  ⟨Snum.nz 1⟩
+
+instance : Inhabited Nzsnum :=
+  ⟨1⟩
+
+instance : Inhabited Snum :=
+  ⟨0⟩
+
+/-!
+The `snum` representation uses a bit string, essentially a list of 0 (`ff`) and 1 (`tt`) bits,
+and the negation of the MSB is sign-extended to all higher bits.
+-/
+
+
+namespace Nzsnum
+
+-- mathport name: nznum.bit
+notation a "::" b => bit a b
+
+/- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
+/-- Sign of a `nzsnum`. -/
+def sign : Nzsnum → Bool
+  | msb b => not b
+  | b::p => sign p
+#align nzsnum.sign Nzsnum.sign
+
+/- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
+/- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
+/-- Bitwise `not` for `nzsnum`. -/
+@[match_pattern]
+def not : Nzsnum → Nzsnum
+  | msb b => msb (not b)
+  | b::p => not b::Not p
+#align nzsnum.not Nzsnum.not
+
+-- mathport name: «expr~ »
+prefix:100 "~" => not
+
+/-- Add an inactive bit at the end of a `nzsnum`. This mimics `pos_num.bit0`. -/
+def bit0 : Nzsnum → Nzsnum :=
+  bit false
+#align nzsnum.bit0 Nzsnum.bit0
+
+/-- Add an active bit at the end of a `nzsnum`. This mimics `pos_num.bit1`. -/
+def bit1 : Nzsnum → Nzsnum :=
+  bit true
+#align nzsnum.bit1 Nzsnum.bit1
+
+/- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
+/-- The `head` of a `nzsnum` is the boolean value of its LSB. -/
+def head : Nzsnum → Bool
+  | msb b => b
+  | b::p => b
+#align nzsnum.head Nzsnum.head
+
+/- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
+/-- The `tail` of a `nzsnum` is the `snum` obtained by removing the LSB.
+      Edge cases: `tail 1 = 0` and `tail (-2) = -1`. -/
+def tail : Nzsnum → Snum
+  | msb b => Snum.zero (not b)
+  | b::p => p
+#align nzsnum.tail Nzsnum.tail
+
+end Nzsnum
+
+namespace Snum
+
+open Nzsnum
+
+/-- Sign of a `snum`. -/
+def sign : Snum → Bool
+  | zero z => z
+  | nz p => p.sign
+#align snum.sign Snum.sign
+
+/-- Bitwise `not` for `snum`. -/
+@[match_pattern]
+def not : Snum → Snum
+  | zero z => zero (not z)
+  | nz p => ~p
+#align snum.not Snum.not
+
+-- mathport name: snum.not
+prefix:0 "~" => not
+
+/-- Add a bit at the end of a `snum`. This mimics `nzsnum.bit`. -/
+@[match_pattern]
+def bit : Bool → Snum → Snum
+  | b, zero z => if b = z then zero b else msb b
+  | b, nz p => p.bit b
+#align snum.bit Snum.bit
+
+-- mathport name: snum.bit
+notation a "::" b => bit a b
+
+/-- Add an inactive bit at the end of a `snum`. This mimics `znum.bit0`. -/
+def bit0 : Snum → Snum :=
+  bit false
+#align snum.bit0 Snum.bit0
+
+/-- Add an active bit at the end of a `snum`. This mimics `znum.bit1`. -/
+def bit1 : Snum → Snum :=
+  bit true
+#align snum.bit1 Snum.bit1
+
+/- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
+theorem bit_zero (b) : (b::zero b) = zero b := by cases b <;> rfl
+#align snum.bit_zero Snum.bit_zero
+
+/- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
+theorem bit_one (b) : (b::zero (not b)) = msb b := by cases b <;> rfl
+#align snum.bit_one Snum.bit_one
+
+end Snum
+
+namespace Nzsnum
+
+open Snum
+
+/- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
+/-- A dependent induction principle for `nzsnum`, with base cases
+      `0 : snum` and `(-1) : snum`. -/
+def drec' {C : Snum → Sort _} (z : ∀ b, C (Snum.zero b)) (s : ∀ b p, C p → C (b::p)) :
+    ∀ p : Nzsnum, C p
+  | msb b => by rw [← bit_one] <;> exact s b (Snum.zero (not b)) (z (not b))
+  | bit b p => s b p (drec' p)
+#align nzsnum.drec' Nzsnum.drec'
+
+end Nzsnum
+
+namespace Snum
+
+open Nzsnum
+
+/-- The `head` of a `snum` is the boolean value of its LSB. -/
+def head : Snum → Bool
+  | zero z => z
+  | nz p => p.head
+#align snum.head Snum.head
+
+/-- The `tail` of a `snum` is obtained by removing the LSB.
+      Edge cases: `tail 1 = 0`, `tail (-2) = -1`, `tail 0 = 0` and `tail (-1) = -1`. -/
+def tail : Snum → Snum
+  | zero z => zero z
+  | nz p => p.tail
+#align snum.tail Snum.tail
+
+/- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
+/-- A dependent induction principle for `snum` which avoids relying on `nzsnum`. -/
+def drec' {C : Snum → Sort _} (z : ∀ b, C (Snum.zero b)) (s : ∀ b p, C p → C (b::p)) : ∀ p, C p
+  | zero b => z b
+  | nz p => p.drec' z s
+#align snum.drec' Snum.drec'
+
+/-- An induction principle for `snum` which avoids relying on `nzsnum`. -/
+def rec' {α} (z : Bool → α) (s : Bool → Snum → α → α) : Snum → α :=
+  drec' z s
+#align snum.rec' Snum.rec'
+
+/-- `snum.test_bit n a` is `tt` iff the `n`-th bit (starting from the LSB) of `a` is active.
+      If the size of `a` is less than `n`, this evaluates to `ff`. -/
+def testBit : Nat → Snum → Bool
+  | 0, p => head p
+  | n + 1, p => test_bit n (tail p)
+#align snum.test_bit Snum.testBit
+
+/- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
+/- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
+/-- The successor of a `snum` (i.e. the operation adding one). -/
+def succ : Snum → Snum :=
+  rec' (fun b => cond b 0 1) fun b p succp => cond b (ff::succp) (tt::p)
+#align snum.succ Snum.succ
+
+/- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
+/- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
+/- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
+/- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
+/-- The predecessor of a `snum` (i.e. the operation of removing one). -/
+def pred : Snum → Snum :=
+  rec' (fun b => cond b (~1) (~0)) fun b p predp => cond b (ff::p) (tt::predp)
+#align snum.pred Snum.pred
+
+/- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
+/-- The opposite of a `snum`. -/
+protected def neg (n : Snum) : Snum :=
+  succ (~n)
+#align snum.neg Snum.neg
+
+instance : Neg Snum :=
+  ⟨Snum.neg⟩
+
+/-- `snum.czadd a b n` is `n + a - b` (where `a` and `b` should be read as either 0 or 1).
+      This is useful to implement the carry system in `cadd`. -/
+def czadd : Bool → Bool → Snum → Snum
+  | ff, ff, p => p
+  | ff, tt, p => pred p
+  | tt, ff, p => succ p
+  | tt, tt, p => p
+#align snum.czadd Snum.czadd
+
+end Snum
+
+namespace Snum
+
+/-- `a.bits n` is the vector of the `n` first bits of `a` (starting from the LSB). -/
+def bits : Snum → ∀ n, Vector Bool n
+  | p, 0 => Vector.nil
+  | p, n + 1 => head p ::ᵥ bits (tail p) n
+#align snum.bits Snum.bits
+
+/- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
+/- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
+def cadd : Snum → Snum → Bool → Snum :=
+  rec' (fun a p c => czadd c a p) fun a p IH =>
+    rec' (fun b c => czadd c b (a::p)) fun b q _ c => Bitvec.xor3 a b c::IH q (Bitvec.carry a b c)
+#align snum.cadd Snum.cadd
+
+/-- Add two `snum`s. -/
+protected def add (a b : Snum) : Snum :=
+  cadd a b false
+#align snum.add Snum.add
+
+instance : Add Snum :=
+  ⟨Snum.add⟩
+
+/-- subtract two `snum`s. -/
+protected def sub (a b : Snum) : Snum :=
+  a + -b
+#align snum.sub Snum.sub
+
+instance : Sub Snum :=
+  ⟨Snum.sub⟩
+
+/-- Multiply two `snum`s. -/
+protected def mul (a : Snum) : Snum → Snum :=
+  rec' (fun b => cond b (-a) 0) fun b q IH => cond b (bit0 IH + a) (bit0 IH)
+#align snum.mul Snum.mul
+
+instance : Mul Snum :=
+  ⟨Snum.mul⟩
+
+end Snum
+

--- a/Mathlib/Data/Num/Bitwise.lean
+++ b/Mathlib/Data/Num/Bitwise.lean
@@ -99,9 +99,9 @@ def oneBits : PosNum → Nat → List Nat
 #align pos_num.one_bits PosNum.oneBits
 
 /-- Left-shift the binary representation of a `PosNum`. -/
-def shiftl (p : PosNum) : Nat → PosNum
-  | 0 => p
-  | n + 1 => bit0 (p.shiftl n)
+def shiftl : PosNum → Nat → PosNum
+  | p, 0 => p
+  | p, n + 1 => shiftl p.bit0 n
 #align pos_num.shiftl PosNum.shiftl
 
 /-- Right-shift the binary representation of a `PosNum`. -/


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

A few notes:

* Fixed a repr bug in `Data.Num.Basic`. After the fix, `#eval PosNum.one.bit1.bit0` prints 6.
* `~` could mean `SNum.not` or `NzsNum.not`. I gave a higher priority to `SNum.not`.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
