### PR TITLE
[Merged by Bors] - fix: add missing whnfR in linarith

### DIFF
--- a/Mathlib/Tactic/Linarith/Frontend.lean
+++ b/Mathlib/Tactic/Linarith/Frontend.lean
@@ -266,7 +266,7 @@ if it does not succeed at doing this.
 partial def linarith (only_on : Bool) (hyps : List Expr) (cfg : LinarithConfig := {})
     (g : MVarId) : MetaM Unit := do
   -- if the target is an equality, we run `linarith` twice, to prove ≤ and ≥.
-  if (← instantiateMVars (← g.getType)).isEq then do
+  if (← whnfR (← instantiateMVars (← g.getType))).isEq then do
     trace[linarith] "target is an equality: splitting"
     let [g₁, g₂] ← g.apply (← mkConst' ``eq_of_not_lt_of_not_gt) | failure
     linarith only_on hyps cfg g₁

--- a/test/linarith.lean
+++ b/test/linarith.lean
@@ -479,3 +479,8 @@ example [LinearOrderedCommRing α] (h : ∃ x : α, 0 ≤ x) : True := by
   cases' h with x h
   have : 0 ≤ x; · linarith
   trivial
+
+-- At one point, this failed, due to `mdata` interfering with `Expr.isEq`.
+example (a : Int) : a = a := by
+  have h : True := True.intro
+  linarith


### PR DESCRIPTION
Fixes a bug where `mdata` could prevent `linarith` from working on an equality goal.

A similar bug was recently found in abel and fixed in https://github.com/leanprover-community/mathlib4/pull/1394.

Zulip discussion: https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/linarith.20failure/near/324493802