### PR TITLE
[Merged by Bors] - fix: misaligned to_additive in Data/Set/Pointwise/ListOfFn

### DIFF
--- a/Mathlib/Data/Set/Pointwise/ListOfFn.lean
+++ b/Mathlib/Data/Set/Pointwise/ListOfFn.lean
@@ -55,10 +55,11 @@ theorem mem_list_prod {l : List (Set α)} {a : α} :
 #align set.mem_list_prod Set.mem_list_prod
 #align set.mem_list_sum Set.mem_list_sum
 
-@[to_additive mem_mul]
-theorem mem_pow {a : α} {n : ℕ} :
+@[to_additive]
+theorem mem_npow {a : α} {n : ℕ} :
     a ∈ s ^ n ↔ ∃ f : Fin n → s, (List.ofFn fun i ↦ (f i : α)).prod = a := by
   rw [← mem_prod_list_ofFn, List.ofFn_const, List.prod_replicate]
-#align set.mem_pow Set.mem_pow
+#align set.mem_pow Set.mem_npow
+#align set.mem_nsmul Set.mem_nsmul
 
 end Set

--- a/Mathlib/Data/Set/Pointwise/ListOfFn.lean
+++ b/Mathlib/Data/Set/Pointwise/ListOfFn.lean
@@ -56,10 +56,10 @@ theorem mem_list_prod {l : List (Set α)} {a : α} :
 #align set.mem_list_sum Set.mem_list_sum
 
 @[to_additive]
-theorem mem_npow {a : α} {n : ℕ} :
+theorem mem_pow {a : α} {n : ℕ} :
     a ∈ s ^ n ↔ ∃ f : Fin n → s, (List.ofFn fun i ↦ (f i : α)).prod = a := by
   rw [← mem_prod_list_ofFn, List.ofFn_const, List.prod_replicate]
-#align set.mem_pow Set.mem_npow
+#align set.mem_pow Set.mem_pow
 #align set.mem_nsmul Set.mem_nsmul
 
 end Set


### PR DESCRIPTION
A misaligned `to_additive` causes some proofs to fail in #1911. No backport needed, the misalign happened due to a mathlib4 exclusive mistake as I understand.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
