### PR TITLE
[Merged by Bors] - fix: avoid global notation overloading

### DIFF
--- a/Mathlib/Data/Num/Bitwise.lean
+++ b/Mathlib/Data/Num/Bitwise.lean
@@ -235,7 +235,7 @@ namespace NzsNum
 
 -- mathport name: nznum.bit
 @[inherit_doc]
-notation a "::" b => bit a b
+scoped notation a "::" b => bit a b
 
 /-- Sign of a `NzsNum`. -/
 def sign : NzsNum → Bool
@@ -252,7 +252,7 @@ def not : NzsNum → NzsNum
 
 -- mathport name: «expr~ »
 @[inherit_doc]
-prefix:100 "~" => not
+scoped prefix:100 "~" => not
 
 /-- Add an inactive bit at the end of a `NzsNum`. This mimics `PosNum.bit0`. -/
 def bit0 : NzsNum → NzsNum :=
@@ -299,7 +299,7 @@ def not : SNum → SNum
 -- Porting note: Defined `priority` so that `~1 : SNum` is unambiguous.
 -- mathport name: snum.not
 @[inherit_doc]
-prefix:100 (priority := default + 1) "~" => not
+scoped prefix:100 (priority := default + 1) "~" => not
 
 /-- Add a bit at the end of a `SNum`. This mimics `NzsNum.bit`. -/
 @[match_pattern]
@@ -310,7 +310,7 @@ def bit : Bool → SNum → SNum
 
 -- mathport name: snum.bit
 @[inherit_doc]
-notation a "::" b => bit a b
+scoped notation a "::" b => bit a b
 
 /-- Add an inactive bit at the end of a `SNum`. This mimics `ZNum.bit0`. -/
 def bit0 : SNum → SNum :=

--- a/Mathlib/Data/Seq/Computation.lean
+++ b/Mathlib/Data/Seq/Computation.lean
@@ -436,7 +436,7 @@ def Promises (s : Computation α) (a : α) : Prop :=
 -- mathport name: «expr ~> »
 /-- `Promises s a`, or `s ~> a`, asserts that although the computation `s`
   may not terminate, if it does, then the result is `a`. -/
-infixl:50 " ~> " => Promises
+scoped infixl:50 " ~> " => Promises
 
 theorem mem_promises {s : Computation α} {a : α} : a ∈ s → s ~> a := fun h _ => mem_unique h
 #align computation.mem_promises Computation.mem_promises
@@ -983,7 +983,7 @@ def Equiv (c₁ c₂ : Computation α) : Prop :=
 
 -- mathport name: «expr ~ »
 /-- equivalence relation for computations-/
-infixl:50 " ~ " => Equiv
+scoped infixl:50 " ~ " => Equiv
 
 @[refl]
 theorem Equiv.refl (s : Computation α) : s ~ s := fun _ => Iff.rfl


### PR DESCRIPTION
This is currently breaking mathport. See also leanprover/lean4#2076.