### PR TITLE
[Merged by Bors] - Chore: drop `_root_.not_not`, export it from `Classical`

### DIFF
--- a/Mathlib/Control/Fix.lean
+++ b/Mathlib/Control/Fix.lean
@@ -96,7 +96,7 @@ protected theorem fix_def {x : α} (h' : ∃ i, (Fix.approx f i x).Dom) :
     rw [assert_neg]
     rfl
     rw [Nat.zero_add] at _this
-    simpa only [_root_.not_not, Coe]
+    simpa only [not_not, Coe]
   | succ n n_ih =>
     intro x'
     rw [Fix.approx, WellFounded.fix_eq, fixAux]

--- a/Mathlib/Logic/Basic.lean
+++ b/Mathlib/Logic/Basic.lean
@@ -247,8 +247,11 @@ classical ones, as these may cause instance mismatch errors later.
 /-- The Double Negation Theorem: `¬ ¬ P` is equivalent to `P`.
 The left-to-right direction, double negation elimination (DNE),
 is classically true but not constructively. -/
-@[simp] theorem not_not : ¬¬a ↔ a := Decidable.not_not
-#align not_not not_not
+add_decl_doc Classical.not_not
+
+export Classical (not_not)
+attribute [simp] not_not
+#align not_not Classical.not_not
 
 theorem of_not_not : ¬¬a → a := by_contra
 #align of_not_not of_not_not

--- a/Mathlib/Logic/Basic.lean
+++ b/Mathlib/Logic/Basic.lean
@@ -247,7 +247,7 @@ classical ones, as these may cause instance mismatch errors later.
 /-- The Double Negation Theorem: `¬ ¬ P` is equivalent to `P`.
 The left-to-right direction, double negation elimination (DNE),
 is classically true but not constructively. -/
-add_decl_doc Classical.not_not
+add_decl_doc Classical.not_not -- TODO: move to Std
 
 export Classical (not_not)
 attribute [simp] not_not

--- a/Mathlib/Logic/Nontrivial.lean
+++ b/Mathlib/Logic/Nontrivial.lean
@@ -116,7 +116,7 @@ theorem subsingleton_iff : Subsingleton α ↔ ∀ x y : α, x = y :=
 #align subsingleton_iff subsingleton_iff
 
 theorem not_nontrivial_iff_subsingleton : ¬Nontrivial α ↔ Subsingleton α := by
-  simp only [nontrivial_iff, subsingleton_iff, not_exists, Ne.def, _root_.not_not]
+  simp only [nontrivial_iff, subsingleton_iff, not_exists, Ne.def, not_not]
 #align not_nontrivial_iff_subsingleton not_nontrivial_iff_subsingleton
 
 theorem not_nontrivial (α) [Subsingleton α] : ¬Nontrivial α :=

--- a/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
+++ b/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
@@ -1523,7 +1523,7 @@ theorem WithTop.supr_coe_eq_top {ι : Sort _} {α : Type _} [ConditionallyComple
 
 theorem WithTop.supr_coe_lt_top {ι : Sort _} {α : Type _} [ConditionallyCompleteLinearOrderBot α]
     (f : ι → α) : (⨆ x, (f x : WithTop α)) < ⊤ ↔ BddAbove (Set.range f) :=
-  lt_top_iff_ne_top.trans <| (WithTop.supr_coe_eq_top f).not.trans _root_.not_not
+  lt_top_iff_ne_top.trans <| (WithTop.supr_coe_eq_top f).not.trans not_not
 #align with_top.supr_coe_lt_top WithTop.supr_coe_lt_top
 
 end WithTopBot

--- a/Mathlib/Order/Filter/Ultrafilter.lean
+++ b/Mathlib/Order/Filter/Ultrafilter.lean
@@ -115,7 +115,7 @@ theorem inf_neBot_iff {f : Ultrafilter α} {g : Filter α} : NeBot (↑f ⊓ g) 
 #align ultrafilter.inf_ne_bot_iff Ultrafilter.inf_neBot_iff
 
 theorem disjoint_iff_not_le {f : Ultrafilter α} {g : Filter α} : Disjoint (↑f) g ↔ ¬↑f ≤ g := by
-  rw [← inf_neBot_iff, neBot_iff, Ne.def, _root_.not_not, disjoint_iff]
+  rw [← inf_neBot_iff, neBot_iff, Ne.def, not_not, disjoint_iff]
 #align ultrafilter.disjoint_iff_not_le Ultrafilter.disjoint_iff_not_le
 
 @[simp]


### PR DESCRIPTION
This way we don't get a name clash when we `open Classical`.

---

The docstring should be moved to `std`.
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
