### PR TITLE
[Merged by Bors] - Feat: add `Bool.compl_singleton_*` and `Set.range_in{l,r}`

### DIFF
--- a/Mathlib/Data/Bool/Set.lean
+++ b/Mathlib/Data/Bool/Set.lean
@@ -32,10 +32,7 @@ theorem range_eq {α : Type _} (f : Bool → α) : range f = {f false, f true} :
   rw [← image_univ, univ_eq, image_pair]
 #align bool.range_eq Bool.range_eq
 
-@[simp] theorem compl_singleton_true : ({true}ᶜ : Set Bool) = {false} :=
-  Set.ext fun _ => iff_of_eq (not_eq_true _)
-
-@[simp] theorem compl_singleton_false : ({false}ᶜ : Set Bool) = {true} :=
-  Set.ext fun _ => iff_of_eq (not_eq_false _)
+@[simp] theorem compl_singleton (b : Bool) : ({b}ᶜ : Set Bool) = {!b} :=
+  Set.ext fun _ => eq_not_iff.symm
 
 end Bool

--- a/Mathlib/Data/Bool/Set.lean
+++ b/Mathlib/Data/Bool/Set.lean
@@ -32,4 +32,10 @@ theorem range_eq {α : Type _} (f : Bool → α) : range f = {f false, f true} :
   rw [← image_univ, univ_eq, image_pair]
 #align bool.range_eq Bool.range_eq
 
+@[simp] theorem compl_singleton_true : ({true}ᶜ : Set Bool) = {false} :=
+  Set.ext fun _ => iff_of_eq (not_eq_true _)
+
+@[simp] theorem compl_singleton_false : ({false}ᶜ : Set Bool) = {true} :=
+  Set.ext fun _ => iff_of_eq (not_eq_false _)
+
 end Bool

--- a/Mathlib/Data/Set/Image.lean
+++ b/Mathlib/Data/Set/Image.lean
@@ -857,6 +857,9 @@ theorem range_eval {ι : Type _} {α : ι → Sort _} [∀ i, Nonempty (α i)] (
   -- Porting note: should be `(surjective_eval i).range_eq` if dot notation works
 #align set.range_eval Set.range_eval
 
+theorem range_inl : range (@Sum.inl α β) = {x | Sum.isLeft x} := by ext (_|_) <;> simp
+theorem range_inr : range (@Sum.inr α β) = {x | Sum.isRight x} := by ext (_|_) <;> simp
+
 theorem isCompl_range_inl_range_inr : IsCompl (range <| @Sum.inl α β) (range Sum.inr) :=
   IsCompl.of_le
     (by


### PR DESCRIPTION
Backported in leanprover-community/mathlib#18332

---
I had to rewrite a proof about `Sum`s because I failed to quickly fix it, and I used these lemmas in the new proof.
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
