### PR TITLE
[Merged by Bors] - fix: curl is not needed for all commands

### DIFF
--- a/Cache/IO.lean
+++ b/Cache/IO.lean
@@ -135,7 +135,7 @@ def allExist (paths : Array FilePath) : IO Bool := do
   pure true
 
 /-- Compresses build files into the local cache and returns an array with the compressed files -/
-def mkCache (hashMap : HashMap) (overwrite : Bool) : IO $ Array String := do
+def packCache (hashMap : HashMap) (overwrite : Bool) : IO $ Array String := do
   mkDir CACHEDIR
   IO.println "Compressing cache"
   let mut acc := default


### PR DESCRIPTION
`curl` is not needed for all `cache` commands, as mentioned [here](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/New.20Project.20that.20uses.20MathLib4/near/324783543)

This PR also changes `mk` to `pack` so it's consistent with `unpack`