### PR TITLE
[Merged by Bors] - fix: remove custom applicationTime from `simps`

### DIFF
--- a/Mathlib/Tactic/Simps/Basic.lean
+++ b/Mathlib/Tactic/Simps/Basic.lean
@@ -1047,6 +1047,4 @@ initialize simpsAttr : ParametricAttribute (Array Name) ←
   registerParametricAttribute {
     name := `simps
     descr := "Automatically derive lemmas specifying the projections of this declaration.",
-    getParam := simpsTacFromSyntax
-    applicationTime := .afterCompilation
-  }
+    getParam := simpsTacFromSyntax }

--- a/Mathlib/Tactic/ToAdditive.lean
+++ b/Mathlib/Tactic/ToAdditive.lean
@@ -1066,6 +1066,9 @@ initialize registerBuiltinAttribute {
       if (kind != AttributeKind.global) then
         throwError "`to_additive` can only be used as a global attribute"
       let cfg ← elabToAdditive stx
-      addToAdditiveAttr src cfg }
+      addToAdditiveAttr src cfg
+    -- we (presumably) need to run after compilation to properly add the `simp` attribute
+    applicationTime := .afterCompilation
+  }
 
 end ToAdditive

--- a/Mathlib/Tactic/ToAdditive.lean
+++ b/Mathlib/Tactic/ToAdditive.lean
@@ -1066,9 +1066,6 @@ initialize registerBuiltinAttribute {
       if (kind != AttributeKind.global) then
         throwError "`to_additive` can only be used as a global attribute"
       let cfg ← elabToAdditive stx
-      addToAdditiveAttr src cfg
-    -- we (presumably) need to run after compilation to properly add the `simp` attribute
-    applicationTime := .afterCompilation
-  }
+      addToAdditiveAttr src cfg }
 
 end ToAdditive


### PR DESCRIPTION
This should not matter anymore after #1314 

* I tried removing it from `to_additive`, but that fails, presumably because `to_additive` has to be able to add other attributes, like `simp`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
