### PR TITLE
[Merged by Bors] - chore: correct Int.eq_zero_or_eq_zero_of_mul_eq_zero

### DIFF
--- a/Mathlib/Init/Data/Int/Order.lean
+++ b/Mathlib/Init/Data/Int/Order.lean
@@ -73,4 +73,31 @@ theorem mul_neg_eq_neg_mul_symm (a b : ℤ) : a * -b = -(a * b) := (Int.neg_mul_
 #align int.nat_abs_of_nonneg Int.natAbs_of_nonneg
 #align int.of_nat_nat_abs_of_nonpos Int.ofNat_natAbs_of_nonpos
 
-alias mul_eq_zero ↔ eq_zero_or_eq_zero_of_mul_eq_zero _
+protected theorem eq_zero_or_eq_zero_of_mul_eq_zero {a b : ℤ} (h : a * b = 0) : a = 0 ∨ b = 0 :=
+  match lt_trichotomy 0 a with
+  | Or.inl hlt₁ =>
+    match lt_trichotomy 0 b with
+    | Or.inl hlt₂ => by
+      have : 0 < a * b := Int.mul_pos hlt₁ hlt₂
+      rw [h] at this
+      exact absurd this (lt_irrefl _)
+    | Or.inr (Or.inl heq₂) => Or.inr heq₂.symm
+    | Or.inr (Or.inr hgt₂) =>
+      by
+      have : 0 > a * b := Int.mul_neg_of_pos_of_neg hlt₁ hgt₂
+      rw [h] at this
+      exact absurd this (lt_irrefl _)
+  | Or.inr (Or.inl heq₁) => Or.inl heq₁.symm
+  | Or.inr (Or.inr hgt₁) =>
+    match lt_trichotomy 0 b with
+    | Or.inl hlt₂ => by
+      have : 0 > a * b := Int.mul_neg_of_neg_of_pos hgt₁ hlt₂
+      rw [h] at this
+      exact absurd this (lt_irrefl _)
+    | Or.inr (Or.inl heq₂) => Or.inr heq₂.symm
+    | Or.inr (Or.inr hgt₂) =>
+      by
+      have : 0 < a * b := Int.mul_pos_of_neg_of_neg hgt₁ hgt₂
+      rw [h] at this
+      exact absurd this (lt_irrefl _)
+#align int.eq_zero_or_eq_zero_of_mul_eq_zero Int.eq_zero_or_eq_zero_of_mul_eq_zero


### PR DESCRIPTION
The lemma `Int.eq_zero_or_eq_zero_of_mul_eq_zero` was accidentally stated for `Nat`.  Fix by copying in mathport output.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
