### PR TITLE
[Merged by Bors] - chore: forward-port comment on trueSetoid

### DIFF
--- a/Mathlib/Data/Quot.lean
+++ b/Mathlib/Data/Quot.lean
@@ -444,7 +444,9 @@ theorem true_equivalence : @Equivalence α fun _ _ ↦ True :=
   ⟨fun _ ↦ trivial, fun _ ↦ trivial, fun _ _ ↦ trivial⟩
 #align true_equivalence true_equivalence
 
-/-- Always-true relation as a `Setoid`. -/
+/-- Always-true relation as a `Setoid`.
+
+Note that in later files the preferred spelling is `⊤ : Setoid α`. -/
 def trueSetoid : Setoid α :=
   ⟨_, true_equivalence⟩
 #align true_setoid trueSetoid


### PR DESCRIPTION
This forward-ports the last commits in https://github.com/leanprover-community/mathlib/pull/18320, which was prematurely forward-ported as https://github.com/leanprover-community/mathlib4/pull/1924 before it was merged in mathlib3.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
