### PR TITLE
[Merged by Bors] - feat: forward-port leanprover-community/mathlib#18356

### DIFF
--- a/Mathlib/Data/Set/Basic.lean
+++ b/Mathlib/Data/Set/Basic.lean
@@ -1154,6 +1154,21 @@ theorem insert_subset_insert_iff (ha : a ∉ s) : insert a s ⊆ insert a t ↔ 
   exacts[(ha hx).elim, hxt]
 #align set.insert_subset_insert_iff Set.insert_subset_insert_iff
 
+theorem subset_insert_iff_of_not_mem {s t : Set α} {a : α} (h : a ∉ s) : s ⊆ insert a t ↔ s ⊆ t :=
+  by
+  constructor
+  · intro g y hy
+    specialize g hy
+    rw [mem_insert_iff] at g
+    rcases g with (g | g)
+    · rw [g] at hy
+      contradiction
+    · assumption
+  · intro g y hy
+    specialize g hy
+    exact mem_insert_of_mem _ g
+#align set.subset_insert_iff_of_not_mem Set.subset_insert_iff_of_not_mem
+
 theorem ssubset_iff_insert {s t : Set α} : s ⊂ t ↔ ∃ (a : α) (_ : a ∉ s), insert a s ⊆ t := by
   simp only [insert_subset, exists_and_right, ssubset_def, not_subset]
   simp only [exists_prop, and_comm]
@@ -2124,6 +2139,13 @@ theorem powerset_empty : 𝒫(∅ : Set α) = {∅} :=
 theorem powerset_univ : 𝒫(univ : Set α) = univ :=
   eq_univ_of_forall subset_univ
 #align set.powerset_univ Set.powerset_univ
+
+/-- The powerset of a singleton contains only `∅` and the singleton itself. -/
+theorem powerset_singleton (x : α) : 𝒫({x} : Set α) = {∅, {x}} :=
+  by
+  ext y
+  rw [mem_powerset_iff, subset_singleton_iff_eq, mem_insert_iff, mem_singleton_iff]
+#align set.powerset_singleton Set.powerset_singleton
 
 /-! ### Sets defined as an if-then-else -/
 

--- a/Mathlib/Data/Set/Basic.lean
+++ b/Mathlib/Data/Set/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura
 
 ! This file was ported from Lean 3 source module data.set.basic
-! leanprover-community/mathlib commit b875cbb7f2aa2b4c685aaa2f99705689c95322ad
+! leanprover-community/mathlib commit 75608affb24b4f48699fbcd38f227827f7793771
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -2130,8 +2130,7 @@ theorem powerset_univ : 𝒫(univ : Set α) = univ :=
 #align set.powerset_univ Set.powerset_univ
 
 /-- The powerset of a singleton contains only `∅` and the singleton itself. -/
-theorem powerset_singleton (x : α) : 𝒫({x} : Set α) = {∅, {x}} :=
-  by
+theorem powerset_singleton (x : α) : 𝒫({x} : Set α) = {∅, {x}} := by
   ext y
   rw [mem_powerset_iff, subset_singleton_iff_eq, mem_insert_iff, mem_singleton_iff]
 #align set.powerset_singleton Set.powerset_singleton

--- a/Mathlib/Data/Set/Basic.lean
+++ b/Mathlib/Data/Set/Basic.lean
@@ -1154,19 +1154,8 @@ theorem insert_subset_insert_iff (ha : a ∉ s) : insert a s ⊆ insert a t ↔ 
   exacts[(ha hx).elim, hxt]
 #align set.insert_subset_insert_iff Set.insert_subset_insert_iff
 
-theorem subset_insert_iff_of_not_mem {s t : Set α} {a : α} (h : a ∉ s) : s ⊆ insert a t ↔ s ⊆ t :=
-  by
-  constructor
-  · intro g y hy
-    specialize g hy
-    rw [mem_insert_iff] at g
-    rcases g with (g | g)
-    · rw [g] at hy
-      contradiction
-    · assumption
-  · intro g y hy
-    specialize g hy
-    exact mem_insert_of_mem _ g
+theorem subset_insert_iff_of_not_mem (ha : a ∉ s) : s ⊆ insert a t ↔ s ⊆ t :=
+  forall₂_congr <| fun _ hb => or_iff_right <| ne_of_mem_of_not_mem hb ha
 #align set.subset_insert_iff_of_not_mem Set.subset_insert_iff_of_not_mem
 
 theorem ssubset_iff_insert {s t : Set α} : s ⊂ t ↔ ∃ (a : α) (_ : a ∉ s), insert a s ⊆ t := by

--- a/Mathlib/Data/Set/Image.lean
+++ b/Mathlib/Data/Set/Image.lean
@@ -610,6 +610,28 @@ theorem image_perm {s : Set α} {σ : Equiv.Perm α} (hs : { a : α | σ a ≠ a
 
 end Image
 
+/-! ### Lemmas about the powerset and image. -/
+
+/-- The powerset of `{a} ∪ s` is `𝒫 s` together with `{a} ∪ t` for each `t ∈ 𝒫 s`. -/
+theorem powerset_insert (s : Set α) (a : α) : 𝒫 insert a s = 𝒫 s ∪ insert a '' 𝒫 s :=
+  by
+  ext t
+  simp_rw [mem_union, mem_image, mem_powerset_iff]
+  constructor
+  · intro h
+    by_cases hs : a ∈ t
+    · right
+      refine' ⟨t \ {a}, _, _⟩
+      · rw [diff_singleton_subset_iff]
+        assumption
+      · rw [insert_diff_singleton, insert_eq_of_mem hs]
+    · left
+      exact (subset_insert_iff_of_not_mem hs).mp h
+  · rintro (h | ⟨s', h₁, rfl⟩)
+    · exact subset_trans h (subset_insert a s)
+    · exact insert_subset_insert h₁
+#align set.powerset_insert Set.powerset_insert
+
 /-! ### Lemmas about range of a function. -/
 
 

--- a/Mathlib/Data/Set/Image.lean
+++ b/Mathlib/Data/Set/Image.lean
@@ -613,8 +613,7 @@ end Image
 /-! ### Lemmas about the powerset and image. -/
 
 /-- The powerset of `{a} ∪ s` is `𝒫 s` together with `{a} ∪ t` for each `t ∈ 𝒫 s`. -/
-theorem powerset_insert (s : Set α) (a : α) : 𝒫 insert a s = 𝒫 s ∪ insert a '' 𝒫 s :=
-  by
+theorem powerset_insert (s : Set α) (a : α) : 𝒫 insert a s = 𝒫 s ∪ insert a '' 𝒫 s := by
   ext t
   simp_rw [mem_union, mem_image, mem_powerset_iff]
   constructor

--- a/Mathlib/Data/Set/Image.lean
+++ b/Mathlib/Data/Set/Image.lean
@@ -5,7 +5,7 @@ Authors: Jeremy Avigad, Leonardo de Moura
 Ported by: Winston Yin
 
 ! This file was ported from Lean 3 source module data.set.image
-! leanprover-community/mathlib commit 2f4cdce0c2f2f3b8cd58f05d556d03b468e1eb2e
+! leanprover-community/mathlib commit 4550138052d0a416b700c27056d492e2ef53214e
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/


### PR DESCRIPTION
This is the corresponding forward porting PR to https://github.com/leanprover-community/mathlib/pull/18356 and https://github.com/leanprover-community/mathlib/pull/18491

---

* [`data.set.basic`@`b875cbb7f2aa2b4c685aaa2f99705689c95322ad`..`75608affb24b4f48699fbcd38f227827f7793771`](https://leanprover-community.github.io/mathlib-port-status/file/data/set/basic?range=b875cbb7f2aa2b4c685aaa2f99705689c95322ad..75608affb24b4f48699fbcd38f227827f7793771)
* [`data.set.image`@`2f4cdce0c2f2f3b8cd58f05d556d03b468e1eb2e`..`4550138052d0a416b700c27056d492e2ef53214e`](https://leanprover-community.github.io/mathlib-port-status/file/data/set/image?range=2f4cdce0c2f2f3b8cd58f05d556d03b468e1eb2e..4550138052d0a416b700c27056d492e2ef53214e)

~**Note:** #1616 updated `Data.Set.Image` to commit [`2f4cdce0c2f2f3b8cd58f05d556d03b468e1eb2e`](https://github.com/leanprover-community/mathlib/commit/2f4cdce0c2f2f3b8cd58f05d556d03b468e1eb2e) but used the wrong SHA for it (it used [`b875cbb7f2aa2b4c685aaa2f99705689c95322ad`](https://github.com/leanprover-community/mathlib/commit/b875cbb7f2aa2b4c685aaa2f99705689c95322ad) which is newer, but the tools don't like that), see~

* ~[`data.set.image`@`3d95492390dc90e34184b13e865f50bc67f30fbb`..`42f4cdce0c2f2f3b8cd58f05d556d03b468e1eb2e`](https://leanprover-community.github.io/mathlib-port-status/file/data/set/image?range=3d95492390dc90e34184b13e865f50bc67f30fbb..2f4cdce0c2f2f3b8cd58f05d556d03b468e1eb2e)~

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
-->
- [x] depends on: #2517

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
