### PR TITLE
[Merged by Bors] - fix: use focus in `cases'` and `induction'`

### DIFF
--- a/Mathlib/Tactic/Cases.lean
+++ b/Mathlib/Tactic/Cases.lean
@@ -63,7 +63,7 @@ elab (name := induction') "induction' " tgts:(casesTarget,+)
     withArg:((" with " (colGt binderIdent)+)?)
     genArg:((" generalizing " (colGt ident)+)?) : tactic => do
   let targets ← elabCasesTargets tgts.1.getSepArgs
-  let g ← getMainGoal
+  let g :: gs ← getUnsolvedGoals | throwNoGoalsToBeSolved
   g.withContext do
     let elimInfo ← getElimNameInfo usingArg targets (induction := true)
     let targets ← addImplicitTargets elimInfo targets
@@ -88,13 +88,13 @@ elab (name := induction') "induction' " tgts:(casesTarget,+)
       g.assign result.elimApp
       let subgoals ← ElimApp.evalNames elimInfo result.alts withArg
         (numGeneralized := fvarIds.size) (toClear := targetFVarIds)
-      setGoals (subgoals ++ result.others).toList
+      setGoals <| (subgoals ++ result.others).toList ++ gs
 
 open private getElimNameInfo in evalCases in
 elab (name := cases') "cases' " tgts:(casesTarget,+) usingArg:((" using " ident)?)
   withArg:((" with " (colGt binderIdent)+)?) : tactic => do
   let targets ← elabCasesTargets tgts.1.getSepArgs
-  let g ← getMainGoal
+  let g :: gs ← getUnsolvedGoals | throwNoGoalsToBeSolved
   g.withContext do
     let elimInfo ← getElimNameInfo usingArg targets (induction := false)
     let targets ← addImplicitTargets elimInfo targets
@@ -109,4 +109,4 @@ elab (name := cases') "cases' " tgts:(casesTarget,+) usingArg:((" using " ident)
       g.assign result.elimApp
       let subgoals ← ElimApp.evalNames elimInfo result.alts withArg
          (numEqs := targets.size) (toClear := targetsNew)
-      setGoals subgoals.toList
+      setGoals <| subgoals.toList ++ gs

--- a/test/cases.lean
+++ b/test/cases.lean
@@ -97,3 +97,10 @@ example (x : Bar n) : x = x := by
   case A => guard_target = Bar.A a b = Bar.A a b; rfl
   case B => guard_hyp h : Bar (c + 1); guard_hyp ih : h = h
             guard_target = Bar.B c d h = Bar.B c d h; rfl
+
+example (p q : Prop) : (p → ¬ q) → ¬ (p ∧ q) := by
+  intro hpnq hpq
+  apply hpnq
+  cases' hpq with hp hq
+  assumption
+  exact hpq.2


### PR DESCRIPTION
As [reported on Zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/bug.20in.20cases'.20goal.20management/near/325426211). Fixes #2016.