### PR TITLE
fix initialize_simp_projection occurrences

### DIFF
--- a/Mathlib/Algebra/Module/Equiv.lean
+++ b/Mathlib/Algebra/Module/Equiv.lean
@@ -278,6 +278,13 @@ def symm (e : M ≃ₛₗ[σ] M₂) : M₂ ≃ₛₗ[σ'] M :=
 #align linear_equiv.symm LinearEquiv.symm
 
 /-- See Note [custom simps projection] -/
+def Simps.apply {R : Type _} {S : Type _} [Semiring R] [Semiring S]
+    {σ : R →+* S} {σ' : S →+* R} [RingHomInvPair σ σ'] [RingHomInvPair σ' σ]
+    {M : Type _} {M₂ : Type _} [AddCommMonoid M] [AddCommMonoid M₂] [Module R M] [Module S M₂]
+    (e : M ≃ₛₗ[σ] M₂) : M → M₂ :=
+  e
+
+/-- See Note [custom simps projection] -/
 def Simps.symmApply {R : Type _} {S : Type _} [Semiring R] [Semiring S]
     {σ : R →+* S} {σ' : S →+* R} [RingHomInvPair σ σ'] [RingHomInvPair σ' σ]
     {M : Type _} {M₂ : Type _} [AddCommMonoid M] [AddCommMonoid M₂] [Module R M] [Module S M₂]
@@ -285,7 +292,8 @@ def Simps.symmApply {R : Type _} {S : Type _} [Semiring R] [Semiring S]
   e.symm
 #align linear_equiv.simps.symm_apply LinearEquiv.Simps.symmApply
 
-initialize_simps_projections LinearEquiv (toLinearMap → apply, invFun → symmApply)
+initialize_simps_projections LinearEquiv (toLinearMap_toAddHom_toFun → apply, -toLinearMap,
+  invFun → symmApply)
 
 @[simp]
 theorem invFun_eq_symm : e.invFun = e.symm :=

--- a/Mathlib/Algebra/Module/LinearMap.lean
+++ b/Mathlib/Algebra/Module/LinearMap.lean
@@ -264,7 +264,7 @@ protected def Simps.apply {R S : Type _} [Semiring R] [Semiring S] (σ : R →+*
   f
 #align linear_map.simps.apply LinearMap.Simps.apply
 
-initialize_simps_projections LinearMap (toAddHom_toFun → apply)
+initialize_simps_projections LinearMap (toAddHom_toFun → apply, -toAddHom)
 
 @[simp]
 theorem coe_mk {σ : R →+* S} (f : M →+ M₃) (h) :

--- a/Mathlib/Algebra/Order/AbsoluteValue.lean
+++ b/Mathlib/Algebra/Order/AbsoluteValue.lean
@@ -47,7 +47,7 @@ namespace AbsoluteValue
 -- Porting note: Removing nolints.
 -- attribute [nolint doc_blame] AbsoluteValue.toMulHom
 
--- initialize_simps_projections AbsoluteValue (to_mul_hom_to_fun → apply)
+initialize_simps_projections AbsoluteValue (toMulHom_toFun → apply, -toMulHom)
 
 section OrderedSemiring
 

--- a/Mathlib/GroupTheory/Subgroup/Basic.lean
+++ b/Mathlib/GroupTheory/Subgroup/Basic.lean
@@ -437,9 +437,10 @@ def Simps.coe (S : Subgroup G) : Set G :=
 #align subgroup.simps.coe Subgroup.Simps.coe
 #align add_subgroup.simps.coe AddSubgroup.Simps.coe
 
-initialize_simps_projections Subgroup (toSubmonoid_toSubsemigroup_carrier → coe)
+initialize_simps_projections Subgroup (toSubmonoid_toSubsemigroup_carrier → coe, -toSubmonoid)
 
-initialize_simps_projections AddSubgroup (toAddSubmonoid_toAddSubsemigroup_carrier → coe)
+initialize_simps_projections AddSubgroup (toAddSubmonoid_toAddSubsemigroup_carrier → coe,
+  -toAddSubmonoid)
 
 @[to_additive (attr := simp)]
 theorem coe_toSubmonoid (K : Subgroup G) : (K.toSubmonoid : Set G) = K :=

--- a/Mathlib/GroupTheory/Submonoid/Basic.lean
+++ b/Mathlib/GroupTheory/Submonoid/Basic.lean
@@ -167,9 +167,9 @@ def Simps.coe (S : Submonoid M) : Set M :=
 /-- See Note [custom simps projection] -/
 add_decl_doc AddSubmonoid.Simps.coe
 
-initialize_simps_projections Submonoid (toSubsemigroup_carrier → coe)
+initialize_simps_projections Submonoid (toSubsemigroup_carrier → coe, -toSubsemigroup)
 
-initialize_simps_projections AddSubmonoid (toAddSubsemigroup_carrier → coe)
+initialize_simps_projections AddSubmonoid (toAddSubsemigroup_carrier → coe, -toAddSubsemigroup)
 
 @[to_additive (attr := simp)]
 theorem mem_toSubsemigroup {s : Submonoid M} {x : M} : x ∈ s.toSubsemigroup ↔ x ∈ s :=


### PR DESCRIPTION
I'm going to change the default behavior of `initialize_simp_projection`, but until then, this might be useful to fix wrongly configured ones.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
