### PR TITLE
[Merged by Bors] - fix: use withMainContext in `linear_combination`

### DIFF
--- a/Mathlib/Tactic/LinearCombination.lean
+++ b/Mathlib/Tactic/LinearCombination.lean
@@ -126,7 +126,7 @@ theorem eq_of_add [AddGroup α] (p : (a:α) = b) (H : (a' - b') - (a - b) = 0) :
 /-- Implementation of `linear_combination` and `linear_combination2`. -/
 def elabLinearCombination
     (norm? : Option Syntax.Tactic) (input : Option Syntax.Term)
-    (twoGoals := false) : Tactic.TacticM Unit := do
+    (twoGoals := false) : Tactic.TacticM Unit := Tactic.withMainContext do
   let p ← match input with
   | none => `(Eq.refl 0)
   | some e => withSynthesize do

--- a/test/linear_combination.lean
+++ b/test/linear_combination.lean
@@ -1,5 +1,9 @@
-import Mathlib.Data.Real.Basic
 import Mathlib.Tactic.LinearCombination
+
+-- We deliberately mock R here so that we don't have to import the deps
+axiom Real : Type
+notation "ℝ" => Real
+@[instance] axiom Real.linearOrderedRing : LinearOrderedField ℝ
 
 /-! ### Simple Cases with ℤ and two or less equations -/
 
@@ -188,3 +192,11 @@ example (a _b : ℕ) (h1 : a = 3) : a = 3 := by
 example (a b : ℤ) (x y : ℝ) (hab : a = b) (hxy : x = y) : 2 * x = 2 * y := by
   fail_if_success linear_combination 2 * hab
   linear_combination 2 * hxy
+
+/-! ### Regression tests -/
+
+def g (a : ℤ) : ℤ := a ^ 2
+
+example (h : g a = g b) : a ^ 4 = b ^ 4 := by
+  dsimp [g] at h
+  linear_combination (a ^ 2 + b ^ 2) * h

--- a/test/linear_combination.lean
+++ b/test/linear_combination.lean
@@ -3,7 +3,7 @@ import Mathlib.Tactic.LinearCombination
 -- We deliberately mock R here so that we don't have to import the deps
 axiom Real : Type
 notation "ℝ" => Real
-@[instance] axiom Real.linearOrderedRing : LinearOrderedField ℝ
+@[instance] axiom Real.linearOrderedField : LinearOrderedField ℝ
 
 /-! ### Simple Cases with ℤ and two or less equations -/
 


### PR DESCRIPTION
As [reported on Zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/linear_combination.20bug.3F/near/325925737).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
