### PR TITLE
[Merged by Bors] - fix: make push_neg try to synthesize LinearOrder before using it

### DIFF
--- a/test/push_neg.lean
+++ b/test/push_neg.lean
@@ -97,6 +97,16 @@ example (a : β) : ¬ ∀ x : β, x < a → ∃ y : β, (y < a) ∧ ∀ z : β, 
   guard_target = ∃ x, x < a ∧ ∀ (y : β), y < a → ∃ z, x ≠ z
   sorry
 
+example {α} [Preorder α] (m n : α) (h : ¬(∃ k : α, m ≤ k)) (h₂ : m ≤ n) : m ≤ n := by
+  push_neg at h
+  guard_hyp h : ∀ k, ¬(m ≤ k)
+  exact h₂
+
+example {α} [Preorder α] (m n : α) (h : ¬(∃ k : α, m < k)) (h₂ : m ≤ n) : m ≤ n := by
+  push_neg at h
+  guard_hyp h : ∀ k, ¬(m < k)
+  exact h₂
+
 set_option push_neg.use_distrib true
 
 example (h : ¬ p ∨ ¬ q): ¬ (p ∧ q) := by


### PR DESCRIPTION
This fixes a bug in `push_neg` that occurs on expressions such as `¬(x ≤ y)` or `¬(x < y)`. Currently, it tries to transform these into `y < x` and `y ≤ x` even when `LinearOrder` is not present (and crashes if e.g. we only have a `Preorder`). This is fixed by making sure that we try to synthesize a `LinearOrder` before attempting the transformation.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
