### PR TITLE
[Merged by Bors] - feat Port/Topology.Algebra.Order.ExtrClosure

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -976,6 +976,7 @@ import Mathlib.Testing.SlimCheck.Testable
 import Mathlib.Topology.Algebra.ConstMulAction
 import Mathlib.Topology.Algebra.Constructions
 import Mathlib.Topology.Algebra.Order.Archimedean
+import Mathlib.Topology.Algebra.Order.ExtrClosure
 import Mathlib.Topology.Algebra.Order.LeftRight
 import Mathlib.Topology.Bases
 import Mathlib.Topology.Basic

--- a/Mathlib/Topology/Algebra/Order/ExtrClosure.lean
+++ b/Mathlib/Topology/Algebra/Order/ExtrClosure.lean
@@ -1,0 +1,67 @@
+/-
+Copyright (c) 2022 Yury G. Kudryashov. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yury G. Kudryashov
+
+! This file was ported from Lean 3 source module topology.algebra.order.extr_closure
+! leanprover-community/mathlib commit 4c19a16e4b705bf135cf9a80ac18fcc99c438514
+! Please do not edit these lines, except to modify the commit id
+! if you have ported upstream changes.
+-/
+import Mathbin.Topology.LocalExtr
+import Mathbin.Topology.Order.Basic
+
+/-!
+# Maximum/minimum on the closure of a set
+
+In this file we prove several versions of the following statement: if `f : X → Y` has a (local or
+not) maximum (or minimum) on a set `s` at a point `a` and is continuous on the closure of `s`, then
+`f` has an extremum of the same type on `closure s` at `a`.
+-/
+
+
+open Filter Set
+
+open Topology
+
+variable {X Y : Type _} [TopologicalSpace X] [TopologicalSpace Y] [Preorder Y]
+  [OrderClosedTopology Y] {f g : X → Y} {s : Set X} {a : X}
+
+protected theorem IsMaxOn.closure (h : IsMaxOn f s a) (hc : ContinuousOn f (closure s)) :
+    IsMaxOn f (closure s) a := fun x hx =>
+  ContinuousWithinAt.closure_le hx ((hc x hx).mono subset_closure) continuousWithinAt_const h
+#align is_max_on.closure IsMaxOn.closure
+
+protected theorem IsMinOn.closure (h : IsMinOn f s a) (hc : ContinuousOn f (closure s)) :
+    IsMinOn f (closure s) a :=
+  h.dual.closure hc
+#align is_min_on.closure IsMinOn.closure
+
+protected theorem IsExtrOn.closure (h : IsExtrOn f s a) (hc : ContinuousOn f (closure s)) :
+    IsExtrOn f (closure s) a :=
+  h.elim (fun h => Or.inl <| h.closure hc) fun h => Or.inr <| h.closure hc
+#align is_extr_on.closure IsExtrOn.closure
+
+protected theorem IsLocalMaxOn.closure (h : IsLocalMaxOn f s a) (hc : ContinuousOn f (closure s)) :
+    IsLocalMaxOn f (closure s) a :=
+  by
+  rcases mem_nhdsWithin.1 h with ⟨U, Uo, aU, hU⟩
+  refine' mem_nhdsWithin.2 ⟨U, Uo, aU, _⟩
+  rintro x ⟨hxU, hxs⟩
+  refine' ContinuousWithinAt.closure_le _ _ continuousWithinAt_const hU
+  · rwa [mem_closure_iff_nhdsWithin_neBot, nhdsWithin_inter_of_mem, ←
+      mem_closure_iff_nhdsWithin_neBot]
+    exact nhdsWithin_le_nhds (Uo.mem_nhds hxU)
+  · exact (hc _ hxs).mono ((inter_subset_right _ _).trans subset_closure)
+#align is_local_max_on.closure IsLocalMaxOn.closure
+
+protected theorem IsLocalMinOn.closure (h : IsLocalMinOn f s a) (hc : ContinuousOn f (closure s)) :
+    IsLocalMinOn f (closure s) a :=
+  IsLocalMaxOn.closure h.dual hc
+#align is_local_min_on.closure IsLocalMinOn.closure
+
+protected theorem IsLocalExtrOn.closure (h : IsLocalExtrOn f s a)
+    (hc : ContinuousOn f (closure s)) : IsLocalExtrOn f (closure s) a :=
+  h.elim (fun h => Or.inl <| h.closure hc) fun h => Or.inr <| h.closure hc
+#align is_local_extr_on.closure IsLocalExtrOn.closure
+

--- a/Mathlib/Topology/Algebra/Order/ExtrClosure.lean
+++ b/Mathlib/Topology/Algebra/Order/ExtrClosure.lean
@@ -8,8 +8,8 @@ Authors: Yury G. Kudryashov
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
-import Mathbin.Topology.LocalExtr
-import Mathbin.Topology.Order.Basic
+import Mathlib.Topology.LocalExtr
+import Mathlib.Topology.Order.Basic
 
 /-!
 # Maximum/minimum on the closure of a set
@@ -43,8 +43,7 @@ protected theorem IsExtrOn.closure (h : IsExtrOn f s a) (hc : ContinuousOn f (cl
 #align is_extr_on.closure IsExtrOn.closure
 
 protected theorem IsLocalMaxOn.closure (h : IsLocalMaxOn f s a) (hc : ContinuousOn f (closure s)) :
-    IsLocalMaxOn f (closure s) a :=
-  by
+    IsLocalMaxOn f (closure s) a := by
   rcases mem_nhdsWithin.1 h with ⟨U, Uo, aU, hU⟩
   refine' mem_nhdsWithin.2 ⟨U, Uo, aU, _⟩
   rintro x ⟨hxU, hxs⟩

--- a/Mathlib/Topology/Algebra/Order/ExtrClosure.lean
+++ b/Mathlib/Topology/Algebra/Order/ExtrClosure.lean
@@ -16,7 +16,7 @@ import Mathlib.Topology.Order.Basic
 
 In this file we prove several versions of the following statement: if `f : X → Y` has a (local or
 not) maximum (or minimum) on a set `s` at a point `a` and is continuous on the closure of `s`, then
-`f` has an extremum of the same type on `closure s` at `a`.
+`f` has an extremum of the same type on `Closure s` at `a`.
 -/
 
 
@@ -63,4 +63,3 @@ protected theorem IsLocalExtrOn.closure (h : IsLocalExtrOn f s a)
     (hc : ContinuousOn f (closure s)) : IsLocalExtrOn f (closure s) a :=
   h.elim (fun h => Or.inl <| h.closure hc) fun h => Or.inr <| h.closure hc
 #align is_local_extr_on.closure IsLocalExtrOn.closure
-


### PR DESCRIPTION
port of topology.algebra.order.extr_closure

no changes other than one docu fix

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
