### PR TITLE
[Merged by Bors] - feat: better yaml output format for port status shas

### DIFF
--- a/scripts/make_port_status.py
+++ b/scripts/make_port_status.py
@@ -185,7 +185,7 @@ for node in sorted(graph.nodes):
                 assert(False)
             new_status.update(mathlib4_pr=pr_info['pr'], source=dict(repo=pr_info['repo'], commit=pr_info['commit']))
             sha = pr_info['commit'] if pr_info['repo'] == 'leanprover-community/mathlib' else "_"
-            status += f' mathlib4#{pr_info['pr']} {sha}'
+            status += f" mathlib4#{pr_info['pr']} {sha}"
     try:
         comment_data = comments_dict[node]
     except KeyError:


### PR DESCRIPTION
This makes them easier to process downstream

This doesn't impact the old-style status yaml, only the new one. The change is not backwards compatible, but the one consumer is already able to process the new format.

This also removes a bunch of dead code from this file.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
