### PR TITLE
[Merged by Bors] - fix: use whnfR in linarith preprocessor

### DIFF
--- a/test/linarith.lean
+++ b/test/linarith.lean
@@ -484,3 +484,14 @@ example [LinearOrderedCommRing α] (h : ∃ x : α, 0 ≤ x) : True := by
 example (a : Int) : a = a := by
   have h : True := True.intro
   linarith
+
+example (n : Nat) (h1 : ¬n = 1) (h2 : n ≥ 1) : n ≥ 2 := by
+  by_contra h3
+  suffices n = 1 by exact h1 this
+  linarith
+
+example (n : Nat) (h1 : ¬n = 1) (h2 : n ≥ 1) : n ≥ 2 := by
+  have h4 : n ≥ 1 := h2
+  by_contra h3
+  suffices n = 1 by exact h1 this
+  linarith


### PR DESCRIPTION
As [reported on Zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/linarith/near/326705462).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
