### PR TITLE
[Merged by Bors] - feat: port Data.Pi.Interval

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -530,6 +530,7 @@ import Mathlib.Data.PNat.Xgcd
 import Mathlib.Data.PSigma.Order
 import Mathlib.Data.Part
 import Mathlib.Data.Pi.Algebra
+import Mathlib.Data.Pi.Interval
 import Mathlib.Data.Pi.Lex
 import Mathlib.Data.Prod.Basic
 import Mathlib.Data.Prod.Lex

--- a/Mathlib/Data/Fintype/BigOperators.lean
+++ b/Mathlib/Data/Fintype/BigOperators.lean
@@ -136,17 +136,13 @@ theorem Finset.card_pi [DecidableEq α] {δ : α → Type _} (s : Finset α) (t 
 
 @[simp]
 theorem Fintype.card_piFinset [DecidableEq α] [Fintype α] {δ : α → Type _} (t : ∀ a, Finset (δ a)) :
-    (Fintype.piFinset t).card = ∏ a, card (t a) := by simp [Fintype.piFinset, card_map]
+    (Fintype.piFinset t).card = ∏ a, Finset.card (t a) := by simp [Fintype.piFinset, card_map]
 #align fintype.card_pi_finset Fintype.card_piFinset
 
 @[simp]
-theorem Fintype.card_pi {β : α → Type _} [DecidableEq α] [Fintype α] [f : ∀ a, Fintype (β a)] :
-    Fintype.card (∀ a, β a) = ∏ a, Fintype.card (β a) := by
-  -- Porting note: term mode proof `Fintype.card_piFinset _` no longer works
-  unfold Fintype.card
-  erw [Fintype.card_piFinset]
-  apply Finset.prod_congr rfl
-  simp [Fintype.card]
+theorem Fintype.card_pi {β : α → Type _} [DecidableEq α] [Fintype α] [∀ a, Fintype (β a)] :
+    Fintype.card (∀ a, β a) = ∏ a, Fintype.card (β a) :=
+  Fintype.card_piFinset _
 #align fintype.card_pi Fintype.card_pi
 
 -- FIXME ouch, this should be in the main file.

--- a/Mathlib/Data/Pi/Interval.lean
+++ b/Mathlib/Data/Pi/Interval.lean
@@ -8,8 +8,8 @@ Authors: Yaël Dillies
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
-import Mathbin.Data.Finset.LocallyFinite
-import Mathbin.Data.Fintype.BigOperators
+import Mathlib.Data.Finset.LocallyFinite
+import Mathlib.Data.Fintype.BigOperators
 
 /-!
 # Intervals in a pi type

--- a/Mathlib/Data/Pi/Interval.lean
+++ b/Mathlib/Data/Pi/Interval.lean
@@ -34,7 +34,7 @@ variable [DecidableEq ι] [Fintype ι] [∀ i, DecidableEq (α i)] [∀ i, Parti
 
 instance : LocallyFiniteOrder (∀ i, α i) :=
   LocallyFiniteOrder.ofIcc _ (fun a b => piFinset fun i => Icc (a i) (b i)) fun a b x => by
-    simp_rw [mem_pi_finset, mem_Icc, le_def, forall_and]
+    simp_rw [mem_piFinset, mem_Icc, le_def, forall_and]
 
 variable (a b : ∀ i, α i)
 
@@ -42,8 +42,11 @@ theorem Icc_eq : Icc a b = piFinset fun i => Icc (a i) (b i) :=
   rfl
 #align pi.Icc_eq Pi.Icc_eq
 
-theorem card_Icc : (Icc a b).card = ∏ i, (Icc (a i) (b i)).card :=
-  card_piFinset _
+theorem card_Icc : (Icc a b).card = ∏ i, (Icc (a i) (b i)).card := by
+  -- Porting note: term mode proof `card_piFinset _` no longer works
+  erw [card_piFinset]
+  apply Finset.prod_congr rfl
+  simp [Fintype.card]
 #align pi.card_Icc Pi.card_Icc
 
 theorem card_Ico : (Ico a b).card = (∏ i, (Icc (a i) (b i)).card) - 1 := by
@@ -70,10 +73,13 @@ variable [∀ i, LocallyFiniteOrderBot (α i)] (b : ∀ i, α i)
 
 instance : LocallyFiniteOrderBot (∀ i, α i) :=
   LocallyFiniteOrderTop.ofIic _ (fun b => piFinset fun i => Iic (b i)) fun b x => by
-    simp_rw [mem_pi_finset, mem_Iic, le_def]
+    simp_rw [mem_piFinset, mem_Iic, le_def]
 
-theorem card_Iic : (Iic b).card = ∏ i, (Iic (b i)).card :=
-  card_piFinset _
+theorem card_Iic : (Iic b).card = ∏ i, (Iic (b i)).card := by
+  -- Porting note: term mode proof `card_piFinset _` no longer works
+  erw [card_piFinset]
+  apply Finset.prod_congr rfl
+  simp [Fintype.card]
 #align pi.card_Iic Pi.card_Iic
 
 theorem card_Iio : (Iio b).card = (∏ i, (Iic (b i)).card) - 1 := by
@@ -88,10 +94,13 @@ variable [∀ i, LocallyFiniteOrderTop (α i)] (a : ∀ i, α i)
 
 instance : LocallyFiniteOrderTop (∀ i, α i) :=
   LocallyFiniteOrderTop.ofIci _ (fun a => piFinset fun i => Ici (a i)) fun a x => by
-    simp_rw [mem_pi_finset, mem_Ici, le_def]
+    simp_rw [mem_piFinset, mem_Ici, le_def]
 
-theorem card_Ici : (Ici a).card = ∏ i, (Ici (a i)).card :=
-  card_piFinset _
+theorem card_Ici : (Ici a).card = ∏ i, (Ici (a i)).card := by
+  -- Porting note: term mode proof `card_piFinset _` no longer works
+  erw [card_piFinset]
+  apply Finset.prod_congr rfl
+  simp [Fintype.card]
 #align pi.card_Ici Pi.card_Ici
 
 theorem card_Ioi : (Ioi a).card = (∏ i, (Ici (a i)).card) - 1 := by
@@ -103,4 +112,3 @@ end Top
 end Bounded
 
 end Pi
-

--- a/Mathlib/Data/Pi/Interval.lean
+++ b/Mathlib/Data/Pi/Interval.lean
@@ -1,0 +1,106 @@
+/-
+Copyright (c) 2021 Yaël Dillies. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies
+
+! This file was ported from Lean 3 source module data.pi.interval
+! leanprover-community/mathlib commit d101e93197bb5f6ea89bd7ba386b7f7dff1f3903
+! Please do not edit these lines, except to modify the commit id
+! if you have ported upstream changes.
+-/
+import Mathbin.Data.Finset.LocallyFinite
+import Mathbin.Data.Fintype.BigOperators
+
+/-!
+# Intervals in a pi type
+
+This file shows that (dependent) functions to locally finite orders equipped with the pointwise
+order are locally finite and calculates the cardinality of their intervals.
+-/
+
+
+open Finset Fintype
+
+open BigOperators
+
+variable {ι : Type _} {α : ι → Type _}
+
+namespace Pi
+
+section LocallyFinite
+
+variable [DecidableEq ι] [Fintype ι] [∀ i, DecidableEq (α i)] [∀ i, PartialOrder (α i)]
+  [∀ i, LocallyFiniteOrder (α i)]
+
+instance : LocallyFiniteOrder (∀ i, α i) :=
+  LocallyFiniteOrder.ofIcc _ (fun a b => piFinset fun i => Icc (a i) (b i)) fun a b x => by
+    simp_rw [mem_pi_finset, mem_Icc, le_def, forall_and]
+
+variable (a b : ∀ i, α i)
+
+theorem Icc_eq : Icc a b = piFinset fun i => Icc (a i) (b i) :=
+  rfl
+#align pi.Icc_eq Pi.Icc_eq
+
+theorem card_Icc : (Icc a b).card = ∏ i, (Icc (a i) (b i)).card :=
+  card_piFinset _
+#align pi.card_Icc Pi.card_Icc
+
+theorem card_Ico : (Ico a b).card = (∏ i, (Icc (a i) (b i)).card) - 1 := by
+  rw [card_Ico_eq_card_Icc_sub_one, card_Icc]
+#align pi.card_Ico Pi.card_Ico
+
+theorem card_Ioc : (Ioc a b).card = (∏ i, (Icc (a i) (b i)).card) - 1 := by
+  rw [card_Ioc_eq_card_Icc_sub_one, card_Icc]
+#align pi.card_Ioc Pi.card_Ioc
+
+theorem card_Ioo : (Ioo a b).card = (∏ i, (Icc (a i) (b i)).card) - 2 := by
+  rw [card_Ioo_eq_card_Icc_sub_two, card_Icc]
+#align pi.card_Ioo Pi.card_Ioo
+
+end LocallyFinite
+
+section Bounded
+
+variable [DecidableEq ι] [Fintype ι] [∀ i, DecidableEq (α i)] [∀ i, PartialOrder (α i)]
+
+section Bot
+
+variable [∀ i, LocallyFiniteOrderBot (α i)] (b : ∀ i, α i)
+
+instance : LocallyFiniteOrderBot (∀ i, α i) :=
+  LocallyFiniteOrderTop.ofIic _ (fun b => piFinset fun i => Iic (b i)) fun b x => by
+    simp_rw [mem_pi_finset, mem_Iic, le_def]
+
+theorem card_Iic : (Iic b).card = ∏ i, (Iic (b i)).card :=
+  card_piFinset _
+#align pi.card_Iic Pi.card_Iic
+
+theorem card_Iio : (Iio b).card = (∏ i, (Iic (b i)).card) - 1 := by
+  rw [card_Iio_eq_card_Iic_sub_one, card_Iic]
+#align pi.card_Iio Pi.card_Iio
+
+end Bot
+
+section Top
+
+variable [∀ i, LocallyFiniteOrderTop (α i)] (a : ∀ i, α i)
+
+instance : LocallyFiniteOrderTop (∀ i, α i) :=
+  LocallyFiniteOrderTop.ofIci _ (fun a => piFinset fun i => Ici (a i)) fun a x => by
+    simp_rw [mem_pi_finset, mem_Ici, le_def]
+
+theorem card_Ici : (Ici a).card = ∏ i, (Ici (a i)).card :=
+  card_piFinset _
+#align pi.card_Ici Pi.card_Ici
+
+theorem card_Ioi : (Ioi a).card = (∏ i, (Ici (a i)).card) - 1 := by
+  rw [card_Ioi_eq_card_Ici_sub_one, card_Ici]
+#align pi.card_Ioi Pi.card_Ioi
+
+end Top
+
+end Bounded
+
+end Pi
+

--- a/Mathlib/Data/Pi/Interval.lean
+++ b/Mathlib/Data/Pi/Interval.lean
@@ -42,11 +42,8 @@ theorem Icc_eq : Icc a b = piFinset fun i => Icc (a i) (b i) :=
   rfl
 #align pi.Icc_eq Pi.Icc_eq
 
-theorem card_Icc : (Icc a b).card = ∏ i, (Icc (a i) (b i)).card := by
-  -- Porting note: term mode proof `card_piFinset _` no longer works
-  erw [card_piFinset]
-  apply Finset.prod_congr rfl
-  simp [Fintype.card]
+theorem card_Icc : (Icc a b).card = ∏ i, (Icc (a i) (b i)).card :=
+  card_piFinset _
 #align pi.card_Icc Pi.card_Icc
 
 theorem card_Ico : (Ico a b).card = (∏ i, (Icc (a i) (b i)).card) - 1 := by
@@ -75,11 +72,8 @@ instance : LocallyFiniteOrderBot (∀ i, α i) :=
   LocallyFiniteOrderTop.ofIic _ (fun b => piFinset fun i => Iic (b i)) fun b x => by
     simp_rw [mem_piFinset, mem_Iic, le_def]
 
-theorem card_Iic : (Iic b).card = ∏ i, (Iic (b i)).card := by
-  -- Porting note: term mode proof `card_piFinset _` no longer works
-  erw [card_piFinset]
-  apply Finset.prod_congr rfl
-  simp [Fintype.card]
+theorem card_Iic : (Iic b).card = ∏ i, (Iic (b i)).card :=
+  card_piFinset _
 #align pi.card_Iic Pi.card_Iic
 
 theorem card_Iio : (Iio b).card = (∏ i, (Iic (b i)).card) - 1 := by
@@ -96,11 +90,8 @@ instance : LocallyFiniteOrderTop (∀ i, α i) :=
   LocallyFiniteOrderTop.ofIci _ (fun a => piFinset fun i => Ici (a i)) fun a x => by
     simp_rw [mem_piFinset, mem_Ici, le_def]
 
-theorem card_Ici : (Ici a).card = ∏ i, (Ici (a i)).card := by
-  -- Porting note: term mode proof `card_piFinset _` no longer works
-  erw [card_piFinset]
-  apply Finset.prod_congr rfl
-  simp [Fintype.card]
+theorem card_Ici : (Ici a).card = ∏ i, (Ici (a i)).card :=
+  card_piFinset _
 #align pi.card_Ici Pi.card_Ici
 
 theorem card_Ioi : (Ioi a).card = (∏ i, (Ici (a i)).card) - 1 := by


### PR DESCRIPTION
This also fixes a mis-port of `card_piFinset` from #1742, which used `Fintype.card` instead of the correct `Finset.card`.

After this change the port is just a single name fix.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
