### PR TITLE
[Merged by Bors] - chore: update bors to change base of existing prs

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -3,4 +3,5 @@ use_squash_merge = true
 timeout_sec = 28800
 block_labels = ["not-ready-to-merge", "WIP", "blocked-by-other-PR", "merge-conflict"]
 delete_merged_branches = true
+update_base_for_deletes = true
 cut_body_after = "---"


### PR DESCRIPTION
After merging a PR from branch X to Y, bors will now redirect
any existing PRs whose target is X to have target Y.


---
[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
