### PR TITLE
[Merged by Bors] - feat: add norm_num extension for the modulo operation for `ℕ`

### DIFF
--- a/Mathlib/Tactic/NormNum/Basic.lean
+++ b/Mathlib/Tactic/NormNum/Basic.lean
@@ -783,3 +783,22 @@ such that `norm_num` successfully recognises both `a` and `b`. -/
   have nc : Q(ℕ) := mkRawNatLit (na.natLit! - nb.natLit!)
   let r : Q(Nat.sub $na $nb = $nc) := (q(Eq.refl $nc) : Expr)
   return (.isNat sℕ nc q(isNat_natSub $pa $pb $r) : Result q($a - $b))
+
+theorem isNat_natMod : {a b : ℕ} → {a' b' c : ℕ} →
+    IsNat a a' → IsNat b b' → Nat.mod a' b' = c → IsNat (a % b) c
+  | _, _, _, _, _, ⟨rfl⟩, ⟨rfl⟩, rfl => ⟨by aesop⟩
+
+/-- The `norm_num` extension which identifies expressions of the form `Nat.mod a b`,
+such that `norm_num` successfully recognises both `a` and `b`. -/
+@[norm_num (_ : ℕ) % _, Mod.mod (_ : ℕ) _, Nat.mod _ _] def evalNatMod :
+    NormNumExt where eval {u α} e := do
+  let .app (.app f (a : Q(ℕ))) (b : Q(ℕ)) ← whnfR e | failure
+  -- We trust that the default instance for `HMod` is `Nat.mod` when the first parameter is `ℕ`.
+  guard <|← withNewMCtxDepth <| isDefEq f q(HMod.hMod (α := ℕ))
+  let sℕ : Q(AddMonoidWithOne ℕ) := q(instAddMonoidWithOneNat)
+  let ⟨na, pa⟩ ← deriveNat a sℕ; let ⟨nb, pb⟩ ← deriveNat b sℕ
+  have pa : Q(IsNat $a $na) := pa
+  have pb : Q(IsNat $b $nb) := pb
+  have nc : Q(ℕ) := mkRawNatLit (na.natLit! % nb.natLit!)
+  let r : Q(Nat.mod $na $nb = $nc) := (q(Eq.refl $nc) : Expr)
+  return (.isNat sℕ nc q(isNat_natMod $pa $pb $r) : Result q($a % $b))

--- a/test/norm_num.lean
+++ b/test/norm_num.lean
@@ -339,6 +339,10 @@ example (h : False) : False := by norm_num1 at h
 example : True := by norm_num1
 -- example : True ∧ True := by norm_num1
 
+/-!
+# Nat operations
+-/
+
 section Nat.sub
 
 example : 10 - 1 = 9 := by norm_num1
@@ -352,6 +356,21 @@ example : 5 * (2 - 3) = 0 := by norm_num1
 example : 10 - 5 * 5 + (7 - 3) * 6 = 27 - 3 := by norm_num1
 
 end Nat.sub
+
+section Nat.mod
+
+example : 10 % 1 = 0 := by norm_num1
+example : 5 % 4 = 1 := by norm_num1
+example : (9 % 4) % (12 % 8) = 1 := by norm_num1
+example : 0 % 10 = 0 := by norm_num1
+example : 10 % 0 = 10 := by norm_num1
+example : 1 % 1 = 0 := by norm_num1
+
+end Nat.mod
+
+/-!
+# Numbers in algebraic structures
+-/
 
 -- noncomputable def foo : ℝ := 1
 
@@ -454,6 +473,7 @@ section Transparency
 
 example : Add.add 10 2 = 12 := by norm_num1
 example : Nat.sub 10 1 = 9 := by norm_num1
+example : Nat.mod 10 5 = 0 := by norm_num1
 example : Sub.sub 10 1 = 9 := by norm_num1
 example : Sub.sub 10 (-2) = 12 := by norm_num1
 example : Mul.mul 10 1 = 10 := by norm_num1


### PR DESCRIPTION
This PR adds a `norm_num` extension for computing the modulo operation (i.e. `%`) over `ℕ`. This is a straightforward modification of the corresponding extension for nat subtraction.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
