### PR TITLE
[Merged by Bors] - fix: restore continuity attributes

### DIFF
--- a/Mathlib/Topology/UniformSpace/AbstractCompletion.lean
+++ b/Mathlib/Topology/UniformSpace/AbstractCompletion.lean
@@ -194,7 +194,7 @@ theorem uniformContinuous_map : UniformContinuous (map f) :=
   pkg.uniformContinuous_extend
 #align abstract_completion.uniform_continuous_map AbstractCompletion.uniformContinuous_map
 
--- @[continuity] -- Porting note: Add tag once implemented
+@[continuity]
 theorem continuous_map : Continuous (map f) :=
   pkg.continuous_extend
 #align abstract_completion.continuous_map AbstractCompletion.continuous_map

--- a/Mathlib/Topology/UniformSpace/Equiv.lean
+++ b/Mathlib/Topology/UniformSpace/Equiv.lean
@@ -141,7 +141,7 @@ protected theorem uniformContinuous (h : α ≃ᵤ β) : UniformContinuous h :=
   h.uniformContinuous_toFun
 #align uniform_equiv.uniform_continuous UniformEquiv.uniformContinuous
 
---@[continuity] -- Porting note: missing attribute
+@[continuity]
 protected theorem continuous (h : α ≃ᵤ β) : Continuous h :=
   h.uniformContinuous.continuous
 #align uniform_equiv.continuous UniformEquiv.continuous
@@ -151,7 +151,7 @@ protected theorem uniformContinuous_symm (h : α ≃ᵤ β) : UniformContinuous 
 #align uniform_equiv.uniform_continuous_symm UniformEquiv.uniformContinuous_symm
 
 -- otherwise `by continuity` can't prove continuity of `h.to_equiv.symm`
---@[continuity] -- Porting note: missing attribute
+@[continuity]
 protected theorem continuous_symm (h : α ≃ᵤ β) : Continuous h.symm :=
   h.uniformContinuous_symm.continuous
 #align uniform_equiv.continuous_symm UniformEquiv.continuous_symm


### PR DESCRIPTION
Restore the remaining `@[continuity]` attributes that were ported while the `continuity` tactic was in the works.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
