### PR TITLE
[Merged by Bors] - fix: Add back LinearEquiv.coe_mk

### DIFF
--- a/Mathlib/Algebra/Module/Equiv.lean
+++ b/Mathlib/Algebra/Module/Equiv.lean
@@ -185,9 +185,13 @@ instance : SemilinearEquivClass (M ≃ₛₗ[σ] M₂) σ M M₂
   map_add := (·.map_add') --map_add' Porting note: TODO why did I need to change this?
   map_smulₛₗ := (·.map_smul') --map_smul' Porting note: TODO why did I need to change this?
 
+-- Porting note: Because coercions from `LinearEquiv`s to functions is generally implemented by
+--               `FunLike` and coercions are elaborated directly in Lean 4,
+--               This is on different line from Mathlib 3.
 @[simp]
 theorem coe_mk {to_fun inv_fun map_add map_smul left_inv right_inv} :
     (⟨⟨⟨to_fun, map_add⟩, map_smul⟩, inv_fun, left_inv, right_inv⟩ : M ≃ₛₗ[σ] M₂) = to_fun := rfl
+#align linear_equiv.coe_mk LinearEquiv.coe_mk
 
 theorem coe_injective : @Injective (M ≃ₛₗ[σ] M₂) (M → M₂) CoeFun.coe :=
   FunLike.coe_injective

--- a/Mathlib/Algebra/Module/Equiv.lean
+++ b/Mathlib/Algebra/Module/Equiv.lean
@@ -185,9 +185,7 @@ instance : SemilinearEquivClass (M ≃ₛₗ[σ] M₂) σ M M₂
   map_add := (·.map_add') --map_add' Porting note: TODO why did I need to change this?
   map_smulₛₗ := (·.map_smul') --map_smul' Porting note: TODO why did I need to change this?
 
--- Porting note: Because coercions from `LinearEquiv`s to functions is generally implemented by
---               `FunLike` and coercions are elaborated directly in Lean 4,
---               This is on different line from Mathlib 3.
+-- Porting note: moved to a lower line since there is no shortcut `CoeFun` instance any more
 @[simp]
 theorem coe_mk {to_fun inv_fun map_add map_smul left_inv right_inv} :
     (⟨⟨⟨to_fun, map_add⟩, map_smul⟩, inv_fun, left_inv, right_inv⟩ : M ≃ₛₗ[σ] M₂) = to_fun := rfl

--- a/Mathlib/Algebra/Module/Equiv.lean
+++ b/Mathlib/Algebra/Module/Equiv.lean
@@ -185,6 +185,10 @@ instance : SemilinearEquivClass (M ≃ₛₗ[σ] M₂) σ M M₂
   map_add := (·.map_add') --map_add' Porting note: TODO why did I need to change this?
   map_smulₛₗ := (·.map_smul') --map_smul' Porting note: TODO why did I need to change this?
 
+@[simp]
+theorem coe_mk {to_fun inv_fun map_add map_smul left_inv right_inv} :
+    (⟨⟨⟨to_fun, map_add⟩, map_smul⟩, inv_fun, left_inv, right_inv⟩ : M ≃ₛₗ[σ] M₂) = to_fun := rfl
+
 theorem coe_injective : @Injective (M ≃ₛₗ[σ] M₂) (M → M₂) CoeFun.coe :=
   FunLike.coe_injective
 #align linear_equiv.coe_injective LinearEquiv.coe_injective


### PR DESCRIPTION
This lemma was incorrectly deleted in #1732, after [a mis-port](https://github.com/leanprover-community/mathlib4/pull/1732/commits/fad407bf539b071eb1286dfee0a79cb72d884312) caused it to be rejected as a tautology.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
