### PR TITLE
[Merged by Bors] - feat(algebra/order): unions of Ioc intervals

### DIFF
--- a/Mathlib/Data/Set/Intervals/Group.lean
+++ b/Mathlib/Data/Set/Intervals/Group.lean
@@ -5,12 +5,14 @@ Authors: Johannes Hölzl, Mario Carneiro, Patrick Massot, Yury Kudryashov, Rémy
 Ported by: Winston Yin
 
 ! This file was ported from Lean 3 source module data.set.intervals.group
-! leanprover-community/mathlib commit 18a5306c091183ac90884daa9373fa3b178e8607
+! leanprover-community/mathlib commit 207cfac9fcd06138865b5d04f7091e46d9320432
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
 import Mathlib.Data.Set.Intervals.Basic
 import Mathlib.Algebra.Order.Group.Abs
+import Mathlib.Data.Set.Pairwise
+import Mathlib.Algebra.GroupPower.Lemmas
 
 /-! ### Lemmas about arithmetic operations and intervals. -/
 
@@ -157,5 +159,117 @@ theorem nonempty_Ico_sdiff {x dx y dy : α} (h : dy < dx) (hx : 0 < dx) :
 #align set.nonempty_Ico_sdiff Set.nonempty_Ico_sdiff
 
 end LinearOrderedAddCommGroup
+
+/-! ### Lemmas about disjointness of translates of intervals -/
+
+section PairwiseDisjoint
+
+section OrderedCommGroup
+
+variable [OrderedCommGroup α] (a b : α)
+
+@[to_additive]
+theorem pairwise_disjoint_Ioc_mul_zpow :
+    Pairwise (Disjoint on fun n : ℤ => Ioc (a * b ^ n) (a * b ^ (n + 1))) := by
+  simp_rw [Function.onFun, Set.disjoint_iff]
+  intro m n hmn x hx
+  apply hmn
+  have hb : 1 < b := by
+    have : a * b ^ m < a * b ^ (m + 1) := hx.1.1.trans_le hx.1.2
+    rwa [mul_lt_mul_iff_left, ← mul_one (b ^ m), zpow_add_one, mul_lt_mul_iff_left] at this
+  have i1 := hx.1.1.trans_le hx.2.2
+  have i2 := hx.2.1.trans_le hx.1.2
+  rw [mul_lt_mul_iff_left, zpow_lt_zpow_iff hb, Int.lt_add_one_iff] at i1 i2
+  exact le_antisymm i1 i2
+#align set.pairwise_disjoint_Ioc_mul_zpow Set.pairwise_disjoint_Ioc_mul_zpow
+#align set.pairwise_disjoint_Ioc_add_zsmul Set.pairwise_disjoint_Ioc_add_zsmul
+
+@[to_additive]
+theorem pairwise_disjoint_Ico_mul_zpow :
+    Pairwise (Disjoint on fun n : ℤ => Ico (a * b ^ n) (a * b ^ (n + 1))) :=
+  by
+  simp_rw [Function.onFun, Set.disjoint_iff]
+  intro m n hmn x hx
+  apply hmn
+  have hb : 1 < b :=
+    by
+    have : a * b ^ m < a * b ^ (m + 1) := hx.1.1.trans_lt hx.1.2
+    rwa [mul_lt_mul_iff_left, ← mul_one (b ^ m), zpow_add_one, mul_lt_mul_iff_left] at this
+  have i1 := hx.1.1.trans_lt hx.2.2
+  have i2 := hx.2.1.trans_lt hx.1.2
+  rw [mul_lt_mul_iff_left, zpow_lt_zpow_iff hb, Int.lt_add_one_iff] at i1 i2
+  exact le_antisymm i1 i2
+#align set.pairwise_disjoint_Ico_mul_zpow Set.pairwise_disjoint_Ico_mul_zpow
+#align set.pairwise_disjoint_Ico_add_zsmul Set.pairwise_disjoint_Ico_add_zsmul
+
+@[to_additive]
+theorem pairwise_disjoint_Ioo_mul_zpow :
+    Pairwise (Disjoint on fun n : ℤ => Ioo (a * b ^ n) (a * b ^ (n + 1))) := fun _ _ hmn =>
+  (pairwise_disjoint_Ioc_mul_zpow a b hmn).mono Ioo_subset_Ioc_self Ioo_subset_Ioc_self
+#align set.pairwise_disjoint_Ioo_mul_zpow Set.pairwise_disjoint_Ioo_mul_zpow
+#align set.pairwise_disjoint_Ioo_add_zsmul Set.pairwise_disjoint_Ioo_add_zsmul
+
+@[to_additive]
+theorem pairwise_disjoint_Ioc_zpow :
+    Pairwise (Disjoint on fun n : ℤ => Ioc (b ^ n) (b ^ (n + 1))) := by
+  simpa only [one_mul] using pairwise_disjoint_Ioc_mul_zpow 1 b
+#align set.pairwise_disjoint_Ioc_zpow Set.pairwise_disjoint_Ioc_zpow
+#align set.pairwise_disjoint_Ioc_zsmul Set.pairwise_disjoint_Ioc_zsmul
+
+@[to_additive]
+theorem pairwise_disjoint_Ico_zpow :
+    Pairwise (Disjoint on fun n : ℤ => Ico (b ^ n) (b ^ (n + 1))) := by
+  simpa only [one_mul] using pairwise_disjoint_Ico_mul_zpow 1 b
+#align set.pairwise_disjoint_Ico_zpow Set.pairwise_disjoint_Ico_zpow
+#align set.pairwise_disjoint_Ico_zsmul Set.pairwise_disjoint_Ico_zsmul
+
+@[to_additive]
+theorem pairwise_disjoint_Ioo_zpow :
+    Pairwise (Disjoint on fun n : ℤ => Ioo (b ^ n) (b ^ (n + 1))) := by
+  simpa only [one_mul] using pairwise_disjoint_Ioo_mul_zpow 1 b
+#align set.pairwise_disjoint_Ioo_zpow Set.pairwise_disjoint_Ioo_zpow
+#align set.pairwise_disjoint_Ioo_zsmul Set.pairwise_disjoint_Ioo_zsmul
+
+end OrderedCommGroup
+
+section OrderedRing
+
+variable [OrderedRing α] (a : α)
+
+theorem pairwise_disjoint_Ioc_add_int_cast :
+    Pairwise (Disjoint on fun n : ℤ => Ioc (a + n) (a + n + 1)) := by
+  simpa only [zsmul_one, Int.cast_add, Int.cast_one, ← add_assoc] using
+    pairwise_disjoint_Ioc_add_zsmul a (1 : α)
+#align set.pairwise_disjoint_Ioc_add_int_cast Set.pairwise_disjoint_Ioc_add_int_cast
+
+theorem pairwise_disjoint_Ico_add_int_cast :
+    Pairwise (Disjoint on fun n : ℤ => Ico (a + n) (a + n + 1)) := by
+  simpa only [zsmul_one, Int.cast_add, Int.cast_one, ← add_assoc] using
+    pairwise_disjoint_Ico_add_zsmul a (1 : α)
+#align set.pairwise_disjoint_Ico_add_int_cast Set.pairwise_disjoint_Ico_add_int_cast
+
+theorem pairwise_disjoint_Ioo_add_int_cast :
+    Pairwise (Disjoint on fun n : ℤ => Ioo (a + n) (a + n + 1)) := by
+  simpa only [zsmul_one, Int.cast_add, Int.cast_one, ← add_assoc] using
+    pairwise_disjoint_Ioo_add_zsmul a (1 : α)
+#align set.pairwise_disjoint_Ioo_add_int_cast Set.pairwise_disjoint_Ioo_add_int_cast
+
+variable (α)
+
+theorem pairwise_disjoint_Ico_int_cast : Pairwise (Disjoint on fun n : ℤ => Ico (n : α) (n + 1)) :=
+  by simpa only [zero_add] using pairwise_disjoint_Ico_add_int_cast (0 : α)
+#align set.pairwise_disjoint_Ico_int_cast Set.pairwise_disjoint_Ico_int_cast
+
+theorem pairwise_disjoint_Ioo_int_cast : Pairwise (Disjoint on fun n : ℤ => Ioo (n : α) (n + 1)) :=
+  by simpa only [zero_add] using pairwise_disjoint_Ioo_add_int_cast (0 : α)
+#align set.pairwise_disjoint_Ioo_int_cast Set.pairwise_disjoint_Ioo_int_cast
+
+theorem pairwise_disjoint_Ioc_int_cast : Pairwise (Disjoint on fun n : ℤ => Ioc (n : α) (n + 1)) :=
+  by simpa only [zero_add] using pairwise_disjoint_Ioc_add_int_cast (0 : α)
+#align set.pairwise_disjoint_Ioc_int_cast Set.pairwise_disjoint_Ioc_int_cast
+
+end OrderedRing
+
+end PairwiseDisjoint
 
 end Set

--- a/Mathlib/Data/Set/Intervals/Group.lean
+++ b/Mathlib/Data/Set/Intervals/Group.lean
@@ -5,7 +5,7 @@ Authors: Johannes Hölzl, Mario Carneiro, Patrick Massot, Yury Kudryashov, Rémy
 Ported by: Winston Yin
 
 ! This file was ported from Lean 3 source module data.set.intervals.group
-! leanprover-community/mathlib commit 207cfac9fcd06138865b5d04f7091e46d9320432
+! leanprover-community/mathlib commit 740acc0e6f9adf4423f92a485d0456fc271482da
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/

--- a/Mathlib/Data/Set/Intervals/Group.lean
+++ b/Mathlib/Data/Set/Intervals/Group.lean
@@ -10,8 +10,8 @@ Ported by: Winston Yin
 ! if you have ported upstream changes.
 -/
 import Mathlib.Data.Set.Intervals.Basic
-import Mathlib.Algebra.Order.Group.Abs
 import Mathlib.Data.Set.Pairwise
+import Mathlib.Algebra.Order.Group.Abs
 import Mathlib.Algebra.GroupPower.Lemmas
 
 /-! ### Lemmas about arithmetic operations and intervals. -/


### PR DESCRIPTION
Forward-port lemmas in `Data.Set.Intervals.Group` about disjointness of intervals, from mathlib3 PR [#18427](https://github.com/leanprover-community/mathlib/pull/18427)

---


<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
