### PR TITLE
[Merged by Bors] - fix: remove stray LibrarySearch imports

### DIFF
--- a/Mathlib/Data/Set/Pointwise/SMul.lean
+++ b/Mathlib/Data/Set/Pointwise/SMul.lean
@@ -12,7 +12,6 @@ import Mathlib.Algebra.Module.Basic
 import Mathlib.Data.Set.Pairwise
 import Mathlib.Data.Set.Pointwise.Basic
 import Mathlib.Tactic.ByContra
-import Mathlib.Tactic.LibrarySearch
 
 /-!
 # Pointwise operations of sets

--- a/Mathlib/Topology/Algebra/Order/MonotoneConvergence.lean
+++ b/Mathlib/Topology/Algebra/Order/MonotoneConvergence.lean
@@ -9,7 +9,6 @@ Authors: Heather Macbeth, Yury Kudryashov
 ! if you have ported upstream changes.
 -/
 import Mathlib.Topology.Order.Basic
-import Mathlib.Tactic.LibrarySearch
 
 /-!
 # Bounded monotone sequences converge


### PR DESCRIPTION
`import Mathlib.Tactic.LibrarySearch` is often useful to include while porting a theory file, but should be deleted before committing.
This PR cleans up some cases where it did not get deleted:
  * Mathlib/Data/Set/Pointwise/SMul.lean in https://github.com/leanprover-community/mathlib4/pull/1473
  * Mathlib/Topology/Algebra/Order/MonotoneConvergence.lean in https://github.com/leanprover-community/mathlib4/pull/2097
