### PR TITLE
[Merged by Bors] - fix: use rfl instead of namedPattern rfl rfl rfl

### DIFF
--- a/Mathlib/Data/Finsupp/Fin.lean
+++ b/Mathlib/Data/Finsupp/Fin.lean
@@ -51,7 +51,7 @@ theorem cons_zero : cons y s 0 = y :=
 @[simp]
 theorem cons_succ : cons y s i.succ = s i :=
   -- porting notes: was Fin.cons_succ _ _ _
-  namedPattern rfl rfl rfl
+  rfl
 #align finsupp.cons_succ Finsupp.cons_succ
 
 @[simp]


### PR DESCRIPTION
`library_search` currently has a bug where it sometimes unnecessarily wraps its output in `namedPattern`.

This PR removes a usage of `namedPattern` that got introduced in https://github.com/leanprover-community/mathlib4/pull/1895, presumably due to the `library_search` bug.
