### PR TITLE
[Merged by Bors] - fix: missing instantiateMVars in apply_fun

### DIFF
--- a/Mathlib/Tactic/ApplyFun.lean
+++ b/Mathlib/Tactic/ApplyFun.lean
@@ -36,7 +36,7 @@ partial def fillImplicitArgumentsWithFreshMVars (e : Expr) : MetaM Expr := do
 def applyFunHyp (f : Expr) (using? : Option Expr) (h : FVarId) (g : MVarId) :
     MetaM (List MVarId) := do
   let d ← h.getDecl
-  let (prf, newGoals) ← match d.type.getAppFnArgs with
+  let (prf, newGoals) ← match (← whnfR (← instantiateMVars d.type)).getAppFnArgs with
   | (``Eq, #[α, _, _]) => do
     -- We have to jump through a hoop here!
     -- At this point Lean may think `f` is a dependently-typed function,

--- a/test/apply_fun.lean
+++ b/test/apply_fun.lean
@@ -99,3 +99,13 @@ example (a b : List α) (P : a = b) : True := by
 --   apply_fun f,
 --   assumption,
 -- end
+
+example : ∀ m n : ℕ, m = n → (m < 2) = (n < 2) := by
+  refine fun m n h => ?_
+  apply_fun (· < 2) at h
+  exact h
+
+example : ∀ m n : ℕ, m = n → (m < 2) = (n < 2) := by
+  intro m n h
+  apply_fun (· < 2) at h
+  exact h


### PR DESCRIPTION
As [reported on Zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/bug.20in.20refine.20or.20apply_fun/near/327894671).