### PR TITLE
[Merged by Bors] - fix: return early in library_search if initial solveByElim succeeds

### DIFF
--- a/Mathlib/Tactic/LibrarySearch.lean
+++ b/Mathlib/Tactic/LibrarySearch.lean
@@ -86,6 +86,7 @@ def librarySearch (goal : MVarId) (lemmas : DiscrTree Name s) (required : List E
 
   try
     solveByElim [goal] required solveByElimDepth
+    return none
   catch _ =>
     set state0
 


### PR DESCRIPTION
Fixes a bug introduced in #856.
If `solveByElim` succeeds, then we should return early. Otherwise, we look through all lemmas in the environment and find something like `namedPattern` or `Eq.mp` and unnecessarily wrap the result in that.

See https://github.com/leanprover-community/mathlib4/pull/2276 for an example bad output caused by this bug.

Another example is this test: https://github.com/leanprover-community/mathlib4/blob/4ed65899eca4909e9b8f23a113b52ff8cb3f5d41/test/librarySearch.lean#L15
On master, it emits `exact namedPattern p p rfl`, and after this PR it correctly emits `exact p`.