### PR TITLE
[Merged by Bors] - fix: avoid sorryAx in library_search

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1149,6 +1149,7 @@ import Mathlib.Topology.UniformSpace.Pi
 import Mathlib.Topology.UniformSpace.Separation
 import Mathlib.Topology.UniformSpace.UniformConvergence
 import Mathlib.Topology.UniformSpace.UniformEmbedding
+import Mathlib.Util.AssertNoSorry
 import Mathlib.Util.AtomM
 import Mathlib.Util.Export
 import Mathlib.Util.IncludeStr

--- a/Mathlib/Tactic/LibrarySearch.lean
+++ b/Mathlib/Tactic/LibrarySearch.lean
@@ -31,7 +31,7 @@ initialize registerTraceClass `Tactic.librarySearch
 
 -- from Lean.Server.Completion
 private def isBlackListed (declName : Name) : MetaM Bool := do
-  if declName == ``sorryAx then return false
+  if declName == ``sorryAx then return true
   if declName matches .str _ "inj" then return false
   if declName matches .str _ "noConfusionType" then return false
   let env ← getEnv

--- a/Mathlib/Tactic/LibrarySearch.lean
+++ b/Mathlib/Tactic/LibrarySearch.lean
@@ -32,8 +32,8 @@ initialize registerTraceClass `Tactic.librarySearch
 -- from Lean.Server.Completion
 private def isBlackListed (declName : Name) : MetaM Bool := do
   if declName == ``sorryAx then return true
-  if declName matches .str _ "inj" then return false
-  if declName matches .str _ "noConfusionType" then return false
+  if declName matches .str _ "inj" then return true
+  if declName matches .str _ "noConfusionType" then return true
   let env ← getEnv
   pure $ declName.isInternal
    || isAuxRecursor env declName

--- a/Mathlib/Util/AssertNoSorry.lean
+++ b/Mathlib/Util/AssertNoSorry.lean
@@ -16,6 +16,7 @@ Throws an error if the given identifier uses sorryAx.
 /-- Throws an error if the given identifier uses sorryAx. -/
 elab "assert_no_sorry " n:ident : command => do
   let env ← Lean.getEnv
-  let (_, s) := ((Lean.Elab.Command.CollectAxioms.collect n.getId).run env).run {}
+  let (_, s) := ((Lean.Elab.Command.CollectAxioms.collect
+    (← Lean.Elab.resolveGlobalConstNoOverloadWithInfo n)).run env).run {}
   if s.axioms.contains ``sorryAx
   then throwError "{n} contains sorry"

--- a/Mathlib/Util/AssertNoSorry.lean
+++ b/Mathlib/Util/AssertNoSorry.lean
@@ -1,0 +1,21 @@
+/-
+Copyright (c) 2023 David Renshaw. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: David Renshaw
+-/
+
+import Lean.Elab.Print
+import Lean.Environment
+
+/-!
+# Defines `assert_no_sorry` command.
+
+Throws an error if the given identifier uses sorryAx.
+-/
+
+/-- Throws an error if the given identifier uses sorryAx. -/
+elab "assert_no_sorry " n:ident : command => do
+  let env ← Lean.getEnv
+  let (_, s) := ((Lean.Elab.Command.CollectAxioms.collect n.getId).run env).run {}
+  if s.axioms.contains ``sorryAx
+  then throwError "{n} contains sorry"

--- a/Mathlib/Util/AssertNoSorry.lean
+++ b/Mathlib/Util/AssertNoSorry.lean
@@ -8,7 +8,7 @@ import Lean.Elab.Print
 import Lean.Environment
 
 /-!
-# Defines `assert_no_sorry` command.
+# Defines the `assert_no_sorry` command.
 
 Throws an error if the given identifier uses sorryAx.
 -/

--- a/test/librarySearch.lean
+++ b/test/librarySearch.lean
@@ -106,8 +106,8 @@ by library_search using n, r -- exact nsmulRec n r
 -- Check that we don't use sorryAx:
 -- (see https://github.com/leanprover-community/mathlib4/issues/226)
 
-theorem Bool_eq_iff {A B: Bool} : (A = B) = (A ↔ B)
-  := by (cases A <;> cases B <;> simp)
+theorem Bool_eq_iff {A B: Bool} : (A = B) = (A ↔ B) :=
+  by (cases A <;> cases B <;> simp)
 
-theorem Bool_eq_iff2 {A B: Bool} : (A = B) = (A ↔ B)
-  := by library_search -- exact Bool_eq_iff
+theorem Bool_eq_iff2 {A B: Bool} : (A = B) = (A ↔ B) :=
+  by library_search -- exact Bool_eq_iff

--- a/test/librarySearch.lean
+++ b/test/librarySearch.lean
@@ -111,3 +111,5 @@ theorem Bool_eq_iff {A B: Bool} : (A = B) = (A ↔ B) :=
 
 theorem Bool_eq_iff2 {A B: Bool} : (A = B) = (A ↔ B) :=
   by library_search -- exact Bool_eq_iff
+
+assert_no_sorry Bool_eq_iff2

--- a/test/librarySearch.lean
+++ b/test/librarySearch.lean
@@ -102,3 +102,12 @@ by library_search using P, Q -- exact P ∩ Q
 
 example (n : ℕ) (r : ℚ) : ℚ :=
 by library_search using n, r -- exact nsmulRec n r
+
+-- Check that we don't use sorryAx:
+-- (see https://github.com/leanprover-community/mathlib4/issues/226)
+
+theorem Bool_eq_iff {A B: Bool} : (A = B) = (A ↔ B)
+  := by (cases A <;> cases B <;> simp)
+
+theorem Bool_eq_iff2 {A B: Bool} : (A = B) = (A ↔ B)
+  := by library_search -- exact Bool_eq_iff


### PR DESCRIPTION
Fixes #226, which is still reproducible. #239 was intended to fix it, but apparently plugged in the wrong bool value.

Adds a new `assert_no_sorry` command and uses it in a new testcase.

Also fixes up the "inj" and "noConfusionType" cases, which have the same bug.