### PR TITLE
[Merged by Bors] - refactor: fix LinearMap.coe_mk

### DIFF
--- a/Mathlib/Algebra/Module/LinearMap.lean
+++ b/Mathlib/Algebra/Module/LinearMap.lean
@@ -269,10 +269,16 @@ protected def Simps.apply {R S : Type _} [Semiring R] [Semiring S] (σ : R →+*
 initialize_simps_projections LinearMap (toAddHom_toFun → apply)
 
 @[simp]
-theorem coe_mk {σ : R →+* S} (f : M → M₃) (h₁ h₂) :
-    ((LinearMap.mk (AddHom.mk f h₁) h₂ : M →ₛₗ[σ] M₃) : M → M₃) = f :=
+theorem coe_mk {σ : R →+* S} (f : AddHom M M₃) (h) :
+    ((LinearMap.mk f h : M →ₛₗ[σ] M₃) : M → M₃) = f :=
   rfl
 #align linear_map.coe_mk LinearMap.coe_mk
+
+-- Porting note: This theorem is added.
+@[simp]
+theorem coe_mk' {σ : R →+* S} (f : AddHom M M₃) (h) :
+    ((LinearMap.mk f h : M →ₛₗ[σ] M₃) : AddHom M M₃) = f :=
+  rfl
 
 /-- Identity map as a `LinearMap` -/
 def id : M →ₗ[R] M :=

--- a/Mathlib/Algebra/Module/LinearMap.lean
+++ b/Mathlib/Algebra/Module/LinearMap.lean
@@ -269,8 +269,8 @@ protected def Simps.apply {R S : Type _} [Semiring R] [Semiring S] (σ : R →+*
 initialize_simps_projections LinearMap (toAddHom_toFun → apply)
 
 @[simp]
-theorem coe_mk {σ : R →+* S} (f : M →+ M₃) (h) :
-    ((LinearMap.mk f h : M →ₛₗ[σ] M₃) : M → M₃) = f :=
+theorem coe_mk {σ : R →+* S} (f : M → M₃) (h₁ h₂) :
+    ((LinearMap.mk (AddHom.mk f h₁) h₂ : M →ₛₗ[σ] M₃) : M → M₃) = f :=
   rfl
 #align linear_map.coe_mk LinearMap.coe_mk
 

--- a/Mathlib/Algebra/Module/LinearMap.lean
+++ b/Mathlib/Algebra/Module/LinearMap.lean
@@ -276,7 +276,7 @@ theorem coe_mk {σ : R →+* S} (f : AddHom M M₃) (h) :
 
 -- Porting note: This theorem is added.
 @[simp]
-theorem coe_mk' {σ : R →+* S} (f : AddHom M M₃) (h) :
+theorem coe_addHom_mk {σ : R →+* S} (f : AddHom M M₃) (h) :
     ((LinearMap.mk f h : M →ₛₗ[σ] M₃) : AddHom M M₃) = f :=
   rfl
 

--- a/Mathlib/Algebra/Module/LinearMap.lean
+++ b/Mathlib/Algebra/Module/LinearMap.lean
@@ -274,7 +274,7 @@ theorem coe_mk {σ : R →+* S} (f : AddHom M M₃) (h) :
   rfl
 #align linear_map.coe_mk LinearMap.coe_mk
 
--- Porting note: This theorem is added.
+-- Porting note: This theorem is new.
 @[simp]
 theorem coe_addHom_mk {σ : R →+* S} (f : AddHom M M₃) (h) :
     ((LinearMap.mk f h : M →ₛₗ[σ] M₃) : AddHom M M₃) = f :=


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

This PR fix `LinearMap.coe_mk`.
```
@[simp]
theorem coe_mk {σ : R →+* S} (f : M →+ M₃) (h) :
    ((LinearMap.mk f h : M →ₛₗ[σ] M₃) : M → M₃) = f
```
to
```
@[simp]
theorem coe_mk {σ : R →+* S} (f : M → M₃) (h₁ h₂) :
    ((LinearMap.mk (AddHom.mk f h₁) h₂ : M →ₛₗ[σ] M₃) : M → M₃) = f
```

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
