### PR TITLE
[Merged by Bors] - feat(topology/continuous_map): forward-port #18465

### DIFF
--- a/Mathlib/Topology/Algebra/Monoid.lean
+++ b/Mathlib/Topology/Algebra/Monoid.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro
 
 ! This file was ported from Lean 3 source module topology.algebra.monoid
-! leanprover-community/mathlib commit dc6c365e751e34d100e80fe6e314c3c3e0fd2988
+! leanprover-community/mathlib commit 6efec6bb9fcaed3cf1baaddb2eaadd8a2a06679c
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -12,6 +12,7 @@ import Mathlib.Algebra.BigOperators.Finprod
 import Mathlib.Order.Filter.Pointwise
 import Mathlib.Topology.Algebra.MulAction
 import Mathlib.Algebra.BigOperators.Pi
+import Mathlib.Topology.ContinuousFunction.Basic
 
 /-!
 # Theory of topological monoids
@@ -865,3 +866,29 @@ theorem continuousMul_inf {t₁ t₂ : TopologicalSpace M} (h₁ : @ContinuousMu
 #align has_continuous_add_inf continuousAdd_inf
 
 end LatticeOps
+
+namespace ContinuousMap
+
+variable [Mul X] [ContinuousMul X]
+
+/-- The continuous map `λ y, y * x` -/
+@[to_additive "The continuous map `λ y, y + x"]
+protected def mulRight (x : X) : C(X, X) := mk _ (continuous_mul_right x)
+#align continuous_map.mul_right ContinuousMap.mulRight
+#align continuous_map.add_right ContinuousMap.addRight
+
+@[to_additive, simp]
+lemma coe_mulRight (x : X) : ⇑(ContinuousMap.mulRight x) = λ y => y * x := rfl
+#align continuous_map.coe_mul_right ContinuousMap.coe_mulRight
+
+/-- The continuous map `λ y, x * y` -/
+@[to_additive "The continuous map `λ y, x + y"]
+protected def mulLeft (x : X) : C(X, X) := mk _ (continuous_mul_left x)
+#align continuous_map.mul_left ContinuousMap.mulLeft
+#align continuous_map.add_left ContinuousMap.addLeft
+
+@[to_additive, simp]
+lemma coe_mulLeft (x : X) : ⇑(ContinuousMap.mulLeft x) = λ y => x * y := rfl
+#align continuous_map.coe_mul_left ContinuousMap.coe_mulLeft
+
+end ContinuousMap

--- a/Mathlib/Topology/Algebra/Monoid.lean
+++ b/Mathlib/Topology/Algebra/Monoid.lean
@@ -871,24 +871,30 @@ namespace ContinuousMap
 
 variable [Mul X] [ContinuousMul X]
 
-/-- The continuous map `λ y, y * x` -/
-@[to_additive "The continuous map `λ y, y + x"]
-protected def mulRight (x : X) : C(X, X) := mk _ (continuous_mul_right x)
+/-- The continuous map `fun y => y * x` -/
+@[to_additive "The continuous map `fun y => y + x"]
+protected def mulRight (x : X) : C(X, X) :=
+  mk _ (continuous_mul_right x)
 #align continuous_map.mul_right ContinuousMap.mulRight
 #align continuous_map.add_right ContinuousMap.addRight
 
 @[to_additive, simp]
-lemma coe_mulRight (x : X) : ⇑(ContinuousMap.mulRight x) = λ y => y * x := rfl
+theorem coe_mulRight (x : X) : ⇑(ContinuousMap.mulRight x) = fun y => y * x :=
+  rfl
 #align continuous_map.coe_mul_right ContinuousMap.coe_mulRight
+#align continuous_map.coe_add_right ContinuousMap.coe_addRight
 
-/-- The continuous map `λ y, x * y` -/
-@[to_additive "The continuous map `λ y, x + y"]
-protected def mulLeft (x : X) : C(X, X) := mk _ (continuous_mul_left x)
+/-- The continuous map `fun y => x * y` -/
+@[to_additive "The continuous map `fun y => x + y"]
+protected def mulLeft (x : X) : C(X, X) :=
+  mk _ (continuous_mul_left x)
 #align continuous_map.mul_left ContinuousMap.mulLeft
 #align continuous_map.add_left ContinuousMap.addLeft
 
 @[to_additive, simp]
-lemma coe_mulLeft (x : X) : ⇑(ContinuousMap.mulLeft x) = λ y => x * y := rfl
+theorem coe_mulLeft (x : X) : ⇑(ContinuousMap.mulLeft x) = fun y => x * y :=
+  rfl
 #align continuous_map.coe_mul_left ContinuousMap.coe_mulLeft
+#align continuous_map.coe_add_left ContinuousMap.coe_addLeft
 
 end ContinuousMap

--- a/Mathlib/Topology/ContinuousFunction/Basic.lean
+++ b/Mathlib/Topology/ContinuousFunction/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Nicolò Cavalleri
 
 ! This file was ported from Lean 3 source module topology.continuous_function.basic
-! leanprover-community/mathlib commit b363547b3113d350d053abdf2884e9850a56b205
+! leanprover-community/mathlib commit 6efec6bb9fcaed3cf1baaddb2eaadd8a2a06679c
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -331,12 +331,18 @@ def restrict (f : C(α, β)) : C(s, β) where
   toFun := f ∘ ((↑) : s → α)
 #align continuous_map.restrict ContinuousMap.restrict
 
-@[simp]
-theorem coe_restrict (f : C(α, β)) : ⇑(f.restrict s) = f ∘ ((↑) : s → α) :=
-  rfl
+@[simp] theorem coe_restrict (f : C(α, β)) : ⇑(f.restrict s) = f ∘ ((↑) : s → α) := rfl
 #align continuous_map.coe_restrict ContinuousMap.coe_restrict
 
-/-- The restriction of a continuous map onto the preimage of a set. -/
+@[simp] lemma restrict_apply (f : C(α, β)) (s : Set α) (x : s) : f.restrict s x = f x := rfl
+#align continuous_map.restrict_apply ContinuousMap.restrict_apply
+
+@[simp] lemma restrict_apply_mk (f : C(α, β)) (s : Set α) (x : α) (hx : x ∈ s) :
+  f.restrict s ⟨x, hx⟩ = f x :=
+rfl
+#align continuous_map.restrict_apply_mk ContinuousMap.restrict_apply_mk
+
+/-- The restriction of a continuous map to the preimage of a set. -/
 @[simps]
 def restrictPreimage (f : C(α, β)) (s : Set β) : C(f ⁻¹' s, s) :=
   ⟨s.restrictPreimage f, continuous_iff_continuousAt.mpr fun _ => f.2.continuousAt.restrictPreimage⟩

--- a/Mathlib/Topology/ContinuousFunction/Basic.lean
+++ b/Mathlib/Topology/ContinuousFunction/Basic.lean
@@ -331,15 +331,20 @@ def restrict (f : C(α, β)) : C(s, β) where
   toFun := f ∘ ((↑) : s → α)
 #align continuous_map.restrict ContinuousMap.restrict
 
-@[simp] theorem coe_restrict (f : C(α, β)) : ⇑(f.restrict s) = f ∘ ((↑) : s → α) := rfl
+@[simp]
+theorem coe_restrict (f : C(α, β)) : ⇑(f.restrict s) = f ∘ ((↑) : s → α) :=
+  rfl
 #align continuous_map.coe_restrict ContinuousMap.coe_restrict
 
-@[simp] lemma restrict_apply (f : C(α, β)) (s : Set α) (x : s) : f.restrict s x = f x := rfl
+@[simp]
+theorem restrict_apply (f : C(α, β)) (s : Set α) (x : s) : f.restrict s x = f x :=
+  rfl
 #align continuous_map.restrict_apply ContinuousMap.restrict_apply
 
-@[simp] lemma restrict_apply_mk (f : C(α, β)) (s : Set α) (x : α) (hx : x ∈ s) :
-  f.restrict s ⟨x, hx⟩ = f x :=
-rfl
+@[simp]
+theorem restrict_apply_mk (f : C(α, β)) (s : Set α) (x : α) (hx : x ∈ s) :
+    f.restrict s ⟨x, hx⟩ = f x :=
+  rfl
 #align continuous_map.restrict_apply_mk ContinuousMap.restrict_apply_mk
 
 /-- The restriction of a continuous map to the preimage of a set. -/


### PR DESCRIPTION
Forward-port of changes to already-ported files `topology.algebra.monoid` and `topology.continuous_map.basic` made in mathlib3 PR [#18465](https://github.com/leanprover-community/mathlib/pull/18465)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
