### PR TITLE
[Merged by Bors] - forward port changes to Algebra.Order.Hom.Basic

### DIFF
--- a/Mathlib/Algebra/Order/Hom/Basic.lean
+++ b/Mathlib/Algebra/Order/Hom/Basic.lean
@@ -51,7 +51,7 @@ Finitary versions of the current lemmas.
 -/
 
 
-library_note "outParam inheritance"/--
+library_note "out-param inheritance"/--
 Diamond inheritance cannot depend on `outParam`s in the following circumstances:
  * there are three classes `Top`, `Middle`, `Bottom`
  * all of these classes have a parameter `(α : outParam _)`
@@ -176,7 +176,9 @@ group `α`.
 You should extend this class when you extend `AddGroupSeminorm`. -/
 class AddGroupSeminormClass (F : Type _) (α β : outParam <| Type _) [AddGroup α]
   [OrderedAddCommMonoid β] extends SubadditiveHomClass F α β where
+  /-- The image of zero is zero. -/
   map_zero (f : F) : f 0 = 0
+  /-- The map is invariant under negation of its argument. -/
   map_neg_eq_map (f : F) (a : α) : f (-a) = f a
 #align add_group_seminorm_class AddGroupSeminormClass
 
@@ -186,7 +188,9 @@ You should extend this class when you extend `GroupSeminorm`. -/
 @[to_additive]
 class GroupSeminormClass (F : Type _) (α β : outParam <| Type _) [Group α]
   [OrderedAddCommMonoid β] extends MulLEAddHomClass F α β where
+  /-- The image of one is zero. -/
   map_one_eq_zero (f : F) : f 1 = 0
+  /-- The map is invariant under inversion of its argument. -/
   map_inv_eq_map (f : F) (a : α) : f a⁻¹ = f a
 #align group_seminorm_class GroupSeminormClass
 
@@ -196,6 +200,7 @@ class GroupSeminormClass (F : Type _) (α β : outParam <| Type _) [Group α]
 You should extend this class when you extend `AddGroupNorm`. -/
 class AddGroupNormClass (F : Type _) (α β : outParam <| Type _) [AddGroup α]
   [OrderedAddCommMonoid β] extends AddGroupSeminormClass F α β where
+  /-- The argument is zero if its image under the map is zero. -/
   eq_zero_of_map_eq_zero (f : F) {a : α} : f a = 0 → a = 0
 #align add_group_norm_class AddGroupNormClass
 
@@ -205,6 +210,7 @@ You should extend this class when you extend `GroupNorm`. -/
 @[to_additive]
 class GroupNormClass (F : Type _) (α β : outParam <| Type _) [Group α]
   [OrderedAddCommMonoid β] extends GroupSeminormClass F α β where
+  /-- The argument is one if its image under the map is zero. -/
   eq_one_of_map_eq_zero (f : F) {a : α} : f a = 0 → a = 1
 #align group_norm_class GroupNormClass
 
@@ -225,8 +231,8 @@ attribute [simp] map_inv_eq_map -- porting note: `to_additive` translation alrea
 attribute [to_additive] GroupSeminormClass.toMulLEAddHomClass
 
 -- See note [lower instance priority]
-instance (priority := 100) AddGroupSeminormClass.toZeroHomClass [AddGroup α]
-    [OrderedAddCommMonoid β] [AddGroupSeminormClass F α β] : ZeroHomClass F α β :=
+instance (priority := 100) AddGroupSeminormClass.toZeroHomClass {_ : AddGroup α}
+    {_ : OrderedAddCommMonoid β} [AddGroupSeminormClass F α β] : ZeroHomClass F α β :=
   { ‹AddGroupSeminormClass F α β› with }
 #align add_group_seminorm_class.to_zero_hom_class AddGroupSeminormClass.toZeroHomClass
 
@@ -269,8 +275,8 @@ theorem abs_sub_map_le_div [Group α] [LinearOrderedAddCommGroup β] [GroupSemin
 
 -- See note [lower instance priority]
 @[to_additive]
-instance (priority := 100) GroupSeminormClass.toNonnegHomClass [Group α]
-    [LinearOrderedAddCommMonoid β] [GroupSeminormClass F α β] : NonnegHomClass F α β :=
+instance (priority := 100) GroupSeminormClass.toNonnegHomClass {_ : Group α}
+    {_ : LinearOrderedAddCommMonoid β} [GroupSeminormClass F α β] : NonnegHomClass F α β :=
   { ‹GroupSeminormClass F α β› with
     map_nonneg := fun f a =>
       (nsmul_nonneg_iff two_ne_zero).1 <|
@@ -303,10 +309,7 @@ end GroupNormClass
 @[to_additive]
 theorem map_pos_of_ne_one [Group α] [LinearOrderedAddCommMonoid β] [GroupNormClass F α β] (f : F)
     {x : α} (hx : x ≠ 1) : 0 < f x :=
-  (@map_nonneg _ _ _ _ _ GroupSeminormClass.toNonnegHomClass f x).lt_of_ne <|
-    ((map_ne_zero_iff_ne_one _).2 hx).symm
-  -- porting note: I think this is lean4#2074 biting us again because I had to provide that
-  -- instance explicitly.
+  (map_nonneg _ _).lt_of_ne <| ((map_ne_zero_iff_ne_one _).2 hx).symm
 #align map_pos_of_ne_one map_pos_of_ne_one
 #align map_pos_of_ne_zero map_pos_of_ne_zero
 
@@ -345,19 +348,19 @@ class MulRingNormClass (F : Type _) (α β : outParam <| Type _) [NonAssocRing �
 
 -- See note [out-param inheritance]
 -- See note [lower instance priority]
-instance (priority := 100) RingSeminormClass.toNonnegHomClass [NonUnitalNonAssocRing α]
-    [LinearOrderedSemiring β] [RingSeminormClass F α β] : NonnegHomClass F α β :=
+instance (priority := 100) RingSeminormClass.toNonnegHomClass {_ : NonUnitalNonAssocRing α}
+    {_ : LinearOrderedSemiring β} [RingSeminormClass F α β] : NonnegHomClass F α β :=
   AddGroupSeminormClass.toNonnegHomClass
 #align ring_seminorm_class.to_nonneg_hom_class RingSeminormClass.toNonnegHomClass
 
 -- See note [lower instance priority]
-instance (priority := 100) MulRingSeminormClass.toRingSeminormClass [NonAssocRing α]
-    [OrderedSemiring β] [MulRingSeminormClass F α β] : RingSeminormClass F α β :=
+instance (priority := 100) MulRingSeminormClass.toRingSeminormClass {_ : NonAssocRing α}
+    {_ : OrderedSemiring β} [MulRingSeminormClass F α β] : RingSeminormClass F α β :=
   { ‹MulRingSeminormClass F α β› with map_mul_le_mul := fun f a b => (map_mul _ _ _).le }
 #align mul_ring_seminorm_class.to_ring_seminorm_class MulRingSeminormClass.toRingSeminormClass
 
 -- See note [lower instance priority]
-instance (priority := 100) MulRingNormClass.toRingNormClass [NonAssocRing α] [OrderedSemiring β]
-    [MulRingNormClass F α β] : RingNormClass F α β :=
+instance (priority := 100) MulRingNormClass.toRingNormClass {_ : NonAssocRing α}
+    {_ : OrderedSemiring β} [MulRingNormClass F α β] : RingNormClass F α β :=
   { ‹MulRingNormClass F α β›, MulRingSeminormClass.toRingSeminormClass with }
 #align mul_ring_norm_class.to_ring_norm_class MulRingNormClass.toRingNormClass

--- a/Mathlib/Algebra/Order/Hom/Basic.lean
+++ b/Mathlib/Algebra/Order/Hom/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 
 ! This file was ported from Lean 3 source module algebra.order.hom.basic
-! leanprover-community/mathlib commit 70d50ecfd4900dd6d328da39ab7ebd516abe4025
+! leanprover-community/mathlib commit 28aa996fc6fb4317f0083c4e6daf79878d81be33
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -19,20 +19,64 @@ This file defines hom classes for common properties at the intersection of order
 
 ## Typeclasses
 
+Basic typeclasses
 * `NonnegHomClass`: Homs are nonnegative: `∀ f a, 0 ≤ f a`
 * `SubadditiveHomClass`: Homs are subadditive: `∀ f a b, f (a + b) ≤ f a + f b`
 * `SubmultiplicativeHomClass`: Homs are submultiplicative: `∀ f a b, f (a * b) ≤ f a * f b`
 * `MulLEAddHomClass`: `∀ f a b, f (a * b) ≤ f a + f b`
 * `NonarchimedeanHomClass`: `∀ a b, f (a + b) ≤ max (f a) (f b)`
 
+Group norms
+* `AddGroupSeminormClass`: Homs are nonnegative, subadditive, even and preserve zero.
+* `GroupSeminormClass`: Homs are nonnegative, respect `f (a * b) ≤ f a + f b`, `f a⁻¹ = f a` and
+  preserve zero.
+* `AddGroupNormClass`: Homs are seminorms such that `f x = 0 → x = 0` for all `x`.
+* `GroupNormClass`: Homs are seminorms such that `f x = 0 → x = 1` for all `x`.
+
+Ring norms
+* `RingSeminormClass`: Homs are submultiplicative group norms.
+* `RingNormClass`: Homs are ring seminorms that are also additive group norms.
+* `MulRingSeminormClass`: Homs are ring seminorms that are multiplicative.
+* `MulRingNormClass`: Homs are ring norms that are multiplicative.
+
+## Notes
+
+Typeclasses for seminorms are defined here while types of seminorms are defined in
+`Analysis.Normed.Group.Seminorm` and `Analysis.Normed.Ring.Seminorm` because absolute values are
+multiplicative ring norms but outside of this use we only consider real-valued seminorms.
+
 ## TODO
 
 Finitary versions of the current lemmas.
 -/
 
+
+library_note "outParam inheritance"/--
+Diamond inheritance cannot depend on `outParam`s in the following circumstances:
+ * there are three classes `Top`, `Middle`, `Bottom`
+ * all of these classes have a parameter `(α : outParam _)`
+ * all of these classes have an instance parameter `[Root α]` that depends on this `outParam`
+ * the `Root` class has two child classes: `Left` and `Right`, these are siblings in the hierarchy
+ * the instance `Bottom.toMiddle` takes a `[Left α]` parameter
+ * the instance `Middle.toTop` takes a `[Right α]` parameter
+ * there is a `Leaf` class that inherits from both `Left` and `Right`.
+In that case, given instances `Bottom α` and `Leaf α`, Lean cannot synthesize a `Top α` instance,
+even though the hypotheses of the instances `Bottom.toMiddle` and `Middle.toTop` are satisfied.
+
+There are two workarounds:
+* You could replace the bundled inheritance implemented by the instance `Middle.toTop` with
+  unbundled inheritance implemented by adding a `[Top α]` parameter to the `Middle` class. This is
+  the preferred option since it is also more compatible with Lean 4, at the cost of being more work
+  to implement and more verbose to use.
+* You could weaken the `Bottom.toMiddle` instance by making it depend on a subclass of
+  `Middle.toTop`'s parameter, in this example replacing `[Left α]` with `[Leaf α]`.
+-/
+
 open Function
 
 variable {ι F α β γ δ : Type _}
+
+/-! ### Basics -/
 
 /-- `NonnegHomClass F α β` states that `F` is a type of nonnegative morphisms. -/
 class NonnegHomClass (F : Type _) (α β : outParam (Type _)) [Zero β] [LE β] extends
@@ -122,3 +166,198 @@ theorem le_map_div_add_map_div [Group α] [AddCommSemigroup β] [LE β] [MulLEAd
 -- #align tactic.positivity_map tactic.positivity_map
 
 --end Mathlib.Meta.Positivity
+
+/-! ### Group (semi)norms -/
+
+
+/-- `AddGroupSeminormClass F α` states that `F` is a type of `β`-valued seminorms on the additive
+group `α`.
+
+You should extend this class when you extend `AddGroupSeminorm`. -/
+class AddGroupSeminormClass (F : Type _) (α β : outParam <| Type _) [AddGroup α]
+  [OrderedAddCommMonoid β] extends SubadditiveHomClass F α β where
+  map_zero (f : F) : f 0 = 0
+  map_neg_eq_map (f : F) (a : α) : f (-a) = f a
+#align add_group_seminorm_class AddGroupSeminormClass
+
+/-- `GroupSeminormClass F α` states that `F` is a type of `β`-valued seminorms on the group `α`.
+
+You should extend this class when you extend `GroupSeminorm`. -/
+@[to_additive]
+class GroupSeminormClass (F : Type _) (α β : outParam <| Type _) [Group α]
+  [OrderedAddCommMonoid β] extends MulLEAddHomClass F α β where
+  map_one_eq_zero (f : F) : f 1 = 0
+  map_inv_eq_map (f : F) (a : α) : f a⁻¹ = f a
+#align group_seminorm_class GroupSeminormClass
+
+/-- `AddGroupNormClass F α` states that `F` is a type of `β`-valued norms on the additive group
+`α`.
+
+You should extend this class when you extend `AddGroupNorm`. -/
+class AddGroupNormClass (F : Type _) (α β : outParam <| Type _) [AddGroup α]
+  [OrderedAddCommMonoid β] extends AddGroupSeminormClass F α β where
+  eq_zero_of_map_eq_zero (f : F) {a : α} : f a = 0 → a = 0
+#align add_group_norm_class AddGroupNormClass
+
+/-- `GroupNormClass F α` states that `F` is a type of `β`-valued norms on the group `α`.
+
+You should extend this class when you extend `GroupNorm`. -/
+@[to_additive]
+class GroupNormClass (F : Type _) (α β : outParam <| Type _) [Group α]
+  [OrderedAddCommMonoid β] extends GroupSeminormClass F α β where
+  eq_one_of_map_eq_zero (f : F) {a : α} : f a = 0 → a = 1
+#align group_norm_class GroupNormClass
+
+export AddGroupSeminormClass (map_neg_eq_map)
+
+export GroupSeminormClass (map_one_eq_zero map_inv_eq_map)
+
+export AddGroupNormClass (eq_zero_of_map_eq_zero)
+
+export GroupNormClass (eq_one_of_map_eq_zero)
+
+attribute [simp] map_one_eq_zero -- porting note: `to_additive` translation already exists
+
+attribute [simp] map_neg_eq_map
+
+attribute [simp] map_inv_eq_map -- porting note: `to_additive` translation already exists
+
+attribute [to_additive] GroupSeminormClass.toMulLEAddHomClass
+
+-- See note [lower instance priority]
+instance (priority := 100) AddGroupSeminormClass.toZeroHomClass [AddGroup α]
+    [OrderedAddCommMonoid β] [AddGroupSeminormClass F α β] : ZeroHomClass F α β :=
+  { ‹AddGroupSeminormClass F α β› with }
+#align add_group_seminorm_class.to_zero_hom_class AddGroupSeminormClass.toZeroHomClass
+
+section GroupSeminormClass
+
+variable [Group α] [OrderedAddCommMonoid β] [GroupSeminormClass F α β] (f : F) (x y : α)
+
+@[to_additive]
+theorem map_div_le_add : f (x / y) ≤ f x + f y :=
+  by
+  rw [div_eq_mul_inv, ← map_inv_eq_map f y]
+  exact map_mul_le_add _ _ _
+#align map_div_le_add map_div_le_add
+#align map_sub_le_add map_sub_le_add
+
+@[to_additive]
+theorem map_div_rev : f (x / y) = f (y / x) := by rw [← inv_div, map_inv_eq_map]
+#align map_div_rev map_div_rev
+#align map_sub_rev map_sub_rev
+
+@[to_additive]
+theorem le_map_add_map_div' : f x ≤ f y + f (y / x) := by
+  simpa only [add_comm, map_div_rev, div_mul_cancel'] using map_mul_le_add f (x / y) y
+#align le_map_add_map_div' le_map_add_map_div'
+#align le_map_add_map_sub' le_map_add_map_sub'
+
+end GroupSeminormClass
+
+example [OrderedAddCommGroup β] : OrderedAddCommMonoid β :=
+  inferInstance
+
+@[to_additive]
+theorem abs_sub_map_le_div [Group α] [LinearOrderedAddCommGroup β] [GroupSeminormClass F α β]
+    (f : F) (x y : α) : |f x - f y| ≤ f (x / y) :=
+  by
+  rw [abs_sub_le_iff, sub_le_iff_le_add', sub_le_iff_le_add']
+  exact ⟨le_map_add_map_div _ _ _, le_map_add_map_div' _ _ _⟩
+#align abs_sub_map_le_div abs_sub_map_le_div
+#align abs_sub_map_le_sub abs_sub_map_le_sub
+
+-- See note [lower instance priority]
+@[to_additive]
+instance (priority := 100) GroupSeminormClass.toNonnegHomClass [Group α]
+    [LinearOrderedAddCommMonoid β] [GroupSeminormClass F α β] : NonnegHomClass F α β :=
+  { ‹GroupSeminormClass F α β› with
+    map_nonneg := fun f a =>
+      (nsmul_nonneg_iff two_ne_zero).1 <|
+        by
+        rw [two_nsmul, ← map_one_eq_zero f, ← div_self' a]
+        exact map_div_le_add _ _ _ }
+#align group_seminorm_class.to_nonneg_hom_class GroupSeminormClass.toNonnegHomClass
+#align add_group_seminorm_class.to_nonneg_hom_class AddGroupSeminormClass.toNonnegHomClass
+
+section GroupNormClass
+
+variable [Group α] [OrderedAddCommMonoid β] [GroupNormClass F α β] (f : F) {x : α}
+
+@[to_additive (attr := simp)]
+theorem map_eq_zero_iff_eq_one : f x = 0 ↔ x = 1 :=
+  ⟨eq_one_of_map_eq_zero _, by
+    rintro rfl
+    exact map_one_eq_zero _⟩
+#align map_eq_zero_iff_eq_one map_eq_zero_iff_eq_one
+#align map_eq_zero_iff_eq_zero map_eq_zero_iff_eq_zero
+
+@[to_additive]
+theorem map_ne_zero_iff_ne_one : f x ≠ 0 ↔ x ≠ 1 :=
+  (map_eq_zero_iff_eq_one _).not
+#align map_ne_zero_iff_ne_one map_ne_zero_iff_ne_one
+#align map_ne_zero_iff_ne_zero map_ne_zero_iff_ne_zero
+
+end GroupNormClass
+
+@[to_additive]
+theorem map_pos_of_ne_one [Group α] [LinearOrderedAddCommMonoid β] [GroupNormClass F α β] (f : F)
+    {x : α} (hx : x ≠ 1) : 0 < f x :=
+  (@map_nonneg _ _ _ _ _ GroupSeminormClass.toNonnegHomClass f x).lt_of_ne <|
+    ((map_ne_zero_iff_ne_one _).2 hx).symm
+  -- porting note: I think this is lean4#2074 biting us again because I had to provide that
+  -- instance explicitly.
+#align map_pos_of_ne_one map_pos_of_ne_one
+#align map_pos_of_ne_zero map_pos_of_ne_zero
+
+/-! ### Ring (semi)norms -/
+
+
+/-- `RingSeminormClass F α` states that `F` is a type of `β`-valued seminorms on the ring `α`.
+
+You should extend this class when you extend `RingSeminorm`. -/
+class RingSeminormClass (F : Type _) (α β : outParam <| Type _) [NonUnitalNonAssocRing α]
+  [OrderedSemiring β] extends AddGroupSeminormClass F α β, SubmultiplicativeHomClass F α β
+#align ring_seminorm_class RingSeminormClass
+
+/-- `RingNormClass F α` states that `F` is a type of `β`-valued norms on the ring `α`.
+
+You should extend this class when you extend `RingNorm`. -/
+class RingNormClass (F : Type _) (α β : outParam <| Type _) [NonUnitalNonAssocRing α]
+  [OrderedSemiring β] extends RingSeminormClass F α β, AddGroupNormClass F α β
+#align ring_norm_class RingNormClass
+
+/-- `MulRingSeminormClass F α` states that `F` is a type of `β`-valued multiplicative seminorms
+on the ring `α`.
+
+You should extend this class when you extend `MulRingSeminorm`. -/
+class MulRingSeminormClass (F : Type _) (α β : outParam <| Type _) [NonAssocRing α]
+  [OrderedSemiring β] extends AddGroupSeminormClass F α β, MonoidWithZeroHomClass F α β
+#align mul_ring_seminorm_class MulRingSeminormClass
+
+/-- `MulRingNormClass F α` states that `F` is a type of `β`-valued multiplicative norms on the
+ring `α`.
+
+You should extend this class when you extend `MulRingNorm`. -/
+class MulRingNormClass (F : Type _) (α β : outParam <| Type _) [NonAssocRing α]
+  [OrderedSemiring β] extends MulRingSeminormClass F α β, AddGroupNormClass F α β
+#align mul_ring_norm_class MulRingNormClass
+
+-- See note [out-param inheritance]
+-- See note [lower instance priority]
+instance (priority := 100) RingSeminormClass.toNonnegHomClass [NonUnitalNonAssocRing α]
+    [LinearOrderedSemiring β] [RingSeminormClass F α β] : NonnegHomClass F α β :=
+  AddGroupSeminormClass.toNonnegHomClass
+#align ring_seminorm_class.to_nonneg_hom_class RingSeminormClass.toNonnegHomClass
+
+-- See note [lower instance priority]
+instance (priority := 100) MulRingSeminormClass.toRingSeminormClass [NonAssocRing α]
+    [OrderedSemiring β] [MulRingSeminormClass F α β] : RingSeminormClass F α β :=
+  { ‹MulRingSeminormClass F α β› with map_mul_le_mul := fun f a b => (map_mul _ _ _).le }
+#align mul_ring_seminorm_class.to_ring_seminorm_class MulRingSeminormClass.toRingSeminormClass
+
+-- See note [lower instance priority]
+instance (priority := 100) MulRingNormClass.toRingNormClass [NonAssocRing α] [OrderedSemiring β]
+    [MulRingNormClass F α β] : RingNormClass F α β :=
+  { ‹MulRingNormClass F α β›, MulRingSeminormClass.toRingSeminormClass with }
+#align mul_ring_norm_class.to_ring_norm_class MulRingNormClass.toRingNormClass


### PR DESCRIPTION
This forward ports changes to this file from [mathlib3#16919](https://github.com/leanprover-community/mathlib/pull/16919). This does not address the other files in that PR, but #1238 is open to address those. This is being PR'ed separately so that work on `Analysis.Normed.Group.Seminorm` can continue (#2400).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
