### PR TITLE
[Merged by Bors] - feat: add NatCast, IntCast, and NatSucc positivity extensions

### DIFF
--- a/Mathlib/Algebra/Order/Floor.lean
+++ b/Mathlib/Algebra/Order/Floor.lean
@@ -1042,9 +1042,7 @@ theorem fract_div_natCast_eq_div_natCast_mod {m n : ℕ} : fract ((m : k) / n) =
   have hn' : 0 < (n : k) := by
     norm_cast
   refine fract_eq_iff.mpr ⟨?_, ?_, m / n, ?_⟩
-  · -- porting note: eliminate `have` after we have positivity extension for casts of Nat
-    have : (0:k) ≤ m % n := Nat.cast_nonneg _
-    positivity
+  · positivity
   · simpa only [div_lt_one hn', Nat.cast_lt] using m.mod_lt hn
   · rw [sub_eq_iff_eq_add', ← mul_right_inj' hn'.ne.symm, mul_div_cancel' _ hn'.ne.symm, mul_add,
       mul_div_cancel' _ hn'.ne.symm]

--- a/Mathlib/Tactic/Positivity/Basic.lean
+++ b/Mathlib/Tactic/Positivity/Basic.lean
@@ -345,3 +345,50 @@ def evalNatAbs : PositivityExt where eval {_u _α} _zα _pα e := do
     pure .none
   | .none =>
     pure .none
+
+@[positivity Nat.cast _]
+def evalNatCast : PositivityExt where eval {u α} _zα _pα e := do
+  let (.app _ (a : Q(Nat))) ← withReducible (whnf e) | throwError "not Nat.cast"
+  let zα' ← synthInstanceQ (q(Zero Nat) : Q(Type))
+  let pα' ← synthInstanceQ (q(PartialOrder Nat) : Q(Type))
+  let ra ← core zα' pα' a
+  match ra with
+  | .positive pa =>
+    have pa' : Q(0 < $a) := pa
+    let oα ← synthInstanceQ (q(OrderedSemiring $α) : Q(Type $u))
+    let nt ← synthInstanceQ (q(Nontrivial $α) : Q(Prop))
+    pure (.positive (q((@Nat.cast_pos $α $oα $nt).mpr $pa') : Expr))
+  | _ =>
+    let oα ← synthInstanceQ (q(OrderedSemiring $α) : Q(Type $u))
+    pure (.nonnegative (q(@Nat.cast_nonneg $α $oα $a) : Expr))
+
+@[positivity Int.cast _]
+def evalIntCast : PositivityExt where eval {u α} _zα _pα e := do
+  let (.app _ (a : Q(Int))) ← withReducible (whnf e) | throwError "not Int.cast"
+  let zα' ← synthInstanceQ (q(Zero Int) : Q(Type))
+  let pα' ← synthInstanceQ (q(PartialOrder Int) : Q(Type))
+  let ra ← core zα' pα' a
+  match ra with
+  | .positive pa =>
+    have pa' : Q(0 < $a) := pa
+    let oα ← synthInstanceQ (q(OrderedRing $α) : Q(Type $u))
+    let nt ← synthInstanceQ (q(Nontrivial $α) : Q(Prop))
+    pure (.positive (q((@Int.cast_pos $α $oα $nt).mpr $pa') : Expr))
+  | .nonnegative pa =>
+    have pa' : Q(0 ≤ $a) := pa
+    let oα ← synthInstanceQ (q(OrderedRing $α) : Q(Type $u))
+    let nt ← synthInstanceQ (q(Nontrivial $α) : Q(Prop))
+    pure (.nonnegative (q((@Int.cast_nonneg $α $oα $nt).mpr $pa') : Expr))
+  | .nonzero pa =>
+    have pa' : Q($a ≠ 0) := pa
+    let oα ← synthInstanceQ (q(AddGroupWithOne $α) : Q(Type $u))
+    let nt ← synthInstanceQ (q(CharZero $α) : Q(Prop))
+    pure (.nonzero (q((@Int.cast_ne_zero $α $oα $nt).mpr $pa') : Expr))
+  | .none =>
+    pure .none
+
+/-- Extension for Nat.succ. -/
+@[positivity Nat.succ _]
+def evalNatSucc : PositivityExt where eval {_u _α} _zα _pα e := do
+  let (.app _ (a : Q(Nat))) ← withReducible (whnf e) | throwError "not Nat.succ"
+  pure (.positive (q(Nat.succ_pos $a) : Expr))

--- a/test/positivity.lean
+++ b/test/positivity.lean
@@ -217,7 +217,7 @@ example : 0 ≤ max (-3 : ℤ) 5 := by positivity
 -- example [OrderedSemiring α] [OrderedAddCommMonoid β] [SMulWithZero α β]
 --   [OrderedSMul α β] {a : α} (ha : 0 < a) {b : β} (hb : 0 < b) : 0 ≤ a • b := by positivity
 
--- example (n : ℕ) : 0 < n.succ := by positivity
+example (n : ℕ) : 0 < n.succ := by positivity
 -- example (n : ℕ) : 0 < n! := by positivity
 -- example (n k : ℕ) : 0 < n.asc_factorial k := by positivity
 
@@ -248,13 +248,13 @@ example {a : ℕ} : 0 ≤ a := by positivity
 
 /- ### Coercions -/
 
--- example {a : ℕ} : (0 : ℤ) ≤ a := by positivity
--- example {a : ℕ} : (0 : ℚ) ≤ a := by positivity
--- example {a : ℕ} (ha : 0 < a) : (0 : ℤ) < a := by positivity
--- example {a : ℕ} (ha : 0 < a) : (0 : ℚ) < a := by positivity
--- example {a : ℤ} (ha : a ≠ 0) : (a : ℚ) ≠ 0 := by positivity
--- example {a : ℤ} (ha : 0 ≤ a) : (0 : ℚ) ≤ a := by positivity
--- example {a : ℤ} (ha : 0 < a) : (0 : ℚ) < a := by positivity
+example {a : ℕ} : (0 : ℤ) ≤ a := by positivity
+example {a : ℕ} : (0 : ℚ) ≤ a := by positivity
+example {a : ℕ} (ha : 0 < a) : (0 : ℤ) < a := by positivity
+example {a : ℕ} (ha : 0 < a) : (0 : ℚ) < a := by positivity
+example {a : ℤ} (ha : a ≠ 0) : (a : ℚ) ≠ 0 := by positivity
+example {a : ℤ} (ha : 0 ≤ a) : (0 : ℚ) ≤ a := by positivity
+example {a : ℤ} (ha : 0 < a) : (0 : ℚ) < a := by positivity
 -- example {a : ℚ} (ha : a ≠ 0) : (a : ℝ) ≠ 0 := by positivity
 -- example {a : ℚ} (ha : 0 ≤ a) : (0 : ℝ) ≤ a := by positivity
 -- example {a : ℚ} (ha : 0 < a) : (0 : ℝ) < a := by positivity


### PR DESCRIPTION
* Adds positivity extensions for casting from nats and ints, corresponding to [this mathlib3 code](https://github.com/leanprover-community/mathlib/blob/bd9851ca476957ea4549eb19b40e7b5ade9428cc/src/tactic/positivity.lean#L680-L690).
* Adds positivity extension for Nat.succ, corresponding to [this mathlib3 code](https://github.com/leanprover-community/mathlib/blob/bd9851ca476957ea4549eb19b40e7b5ade9428cc/src/tactic/positivity.lean#L704-L708).
