### PR TITLE
[Merged by Bors] - feat: add/generalize lemmas about `WithTop`/`WithBot`

### DIFF
--- a/Mathlib/Algebra/BigOperators/Multiset/Lemmas.lean
+++ b/Mathlib/Algebra/BigOperators/Multiset/Lemmas.lean
@@ -31,6 +31,13 @@ theorem prod_eq_one_iff [CanonicallyOrderedMonoid α] {m : Multiset α} :
 
 end Multiset
 
+@[simp]
+lemma CanonicallyOrderedCommSemiring.multiset_prod_pos {R} [CanonicallyOrderedCommSemiring R]
+    [Nontrivial R] {m : Multiset R} : 0 < m.prod ↔ (∀ x ∈ m, (0 : R) < x) := by
+  rcases m with ⟨l⟩
+  rw [Multiset.quot_mk_to_coe'', Multiset.coe_prod]
+  exact CanonicallyOrderedCommSemiring.list_prod_pos
+
 open Multiset
 
 namespace Commute

--- a/Mathlib/Algebra/BigOperators/Order.lean
+++ b/Mathlib/Algebra/BigOperators/Order.lean
@@ -696,35 +696,29 @@ namespace WithTop
 open Finset
 
 /-- A product of finite numbers is still finite -/
-theorem prod_lt_top [CanonicallyOrderedCommSemiring R] [Nontrivial R] [DecidableEq R] {s : Finset ι}
-    {f : ι → WithTop R} (h : ∀ i ∈ s, f i ≠ ⊤) : (∏ i in s, f i) < ⊤ :=
-  prod_induction f (fun a ↦ a < ⊤) (fun _ _ h₁ h₂ ↦ mul_lt_top h₁.ne h₂.ne) (coe_lt_top 1)
-    fun a ha ↦ lt_top_iff_ne_top.2 (h a ha)
+theorem prod_lt_top [CommMonoidWithZero R] [NoZeroDivisors R] [Nontrivial R] [DecidableEq R] [LT R]
+    {s : Finset ι} {f : ι → WithTop R} (h : ∀ i ∈ s, f i ≠ ⊤) : (∏ i in s, f i) < ⊤ :=
+  prod_induction f (fun a ↦ a < ⊤) (fun _ _ h₁ h₂ ↦ mul_lt_top' h₁ h₂) (coe_lt_top 1)
+    fun a ha ↦ WithTop.lt_top_iff_ne_top.2 (h a ha)
 #align with_top.prod_lt_top WithTop.prod_lt_top
 
-/-- A sum of finite numbers is still finite -/
-theorem sum_lt_top [OrderedAddCommMonoid M] {s : Finset ι} {f : ι → WithTop M}
-    (h : ∀ i ∈ s, f i ≠ ⊤) : (∑ i in s, f i) < ⊤ :=
-  sum_induction f (fun a ↦ a < ⊤) (fun _ _ h₁ h₂ ↦ add_lt_top.2 ⟨h₁, h₂⟩) zero_lt_top fun i hi ↦
-    lt_top_iff_ne_top.2 (h i hi)
-#align with_top.sum_lt_top WithTop.sum_lt_top
-
 /-- A sum of numbers is infinite iff one of them is infinite -/
-theorem sum_eq_top_iff [OrderedAddCommMonoid M] {s : Finset ι} {f : ι → WithTop M} :
+theorem sum_eq_top_iff [AddCommMonoid M] {s : Finset ι} {f : ι → WithTop M} :
     (∑ i in s, f i) = ⊤ ↔ ∃ i ∈ s, f i = ⊤ := by
-  classical
-    constructor
-    · contrapose!
-      exact fun h ↦ (sum_lt_top fun i hi ↦ h i hi).ne
-    · rintro ⟨i, his, hi⟩
-      rw [sum_eq_add_sum_diff_singleton his, hi, top_add]
+  induction s using Finset.cons_induction <;> simp [*]
 #align with_top.sum_eq_top_iff WithTop.sum_eq_top_iff
 
 /-- A sum of finite numbers is still finite -/
-theorem sum_lt_top_iff [OrderedAddCommMonoid M] {s : Finset ι} {f : ι → WithTop M} :
+theorem sum_lt_top_iff [AddCommMonoid M] [LT M] {s : Finset ι} {f : ι → WithTop M} :
     (∑ i in s, f i) < ⊤ ↔ ∀ i ∈ s, f i < ⊤ := by
-  simp only [lt_top_iff_ne_top, ne_eq, sum_eq_top_iff, not_exists, not_and]
+  simp only [WithTop.lt_top_iff_ne_top, ne_eq, sum_eq_top_iff, not_exists, not_and]
 #align with_top.sum_lt_top_iff WithTop.sum_lt_top_iff
+
+/-- A sum of finite numbers is still finite -/
+theorem sum_lt_top [AddCommMonoid M] [LT M] {s : Finset ι} {f : ι → WithTop M}
+    (h : ∀ i ∈ s, f i ≠ ⊤) : (∑ i in s, f i) < ⊤ :=
+  sum_lt_top_iff.2 fun i hi => WithTop.lt_top_iff_ne_top.2 (h i hi)
+#align with_top.sum_lt_top WithTop.sum_lt_top
 
 end WithTop
 
@@ -734,11 +728,10 @@ variable {S : Type _}
 
 theorem AbsoluteValue.sum_le [Semiring R] [OrderedSemiring S] (abv : AbsoluteValue R S)
     (s : Finset ι) (f : ι → R) : abv (∑ i in s, f i) ≤ ∑ i in s, abv (f i) := by
-  letI := Classical.decEq ι
-  refine' Finset.induction_on s _ fun i s hi ih ↦ _
+  induction' s using Finset.cons_induction
   · simp
-  · simp only [Finset.sum_insert hi]
-    exact (abv.add_le _ _).trans (add_le_add le_rfl ih)
+  · simp only [Finset.sum_cons]
+    exact (abv.add_le _ _).trans (add_le_add le_rfl ‹_›)
 #align absolute_value.sum_le AbsoluteValue.sum_le
 
 theorem IsAbsoluteValue.abv_sum [Semiring R] [OrderedSemiring S] (abv : R → S) [IsAbsoluteValue abv]

--- a/Mathlib/Algebra/BigOperators/Order.lean
+++ b/Mathlib/Algebra/BigOperators/Order.lean
@@ -637,14 +637,14 @@ section CanonicallyOrderedCommSemiring
 
 variable [CanonicallyOrderedCommSemiring R] {f g h : ι → R} {s : Finset ι} {i : ι}
 
-theorem prod_le_prod' (h : ∀ i ∈ s, f i ≤ g i) : (∏ i in s, f i) ≤ ∏ i in s, g i := by
-  classical
-    induction' s using Finset.induction with a s has ih h
-    · simp
-    · rw [Finset.prod_insert has, Finset.prod_insert has]
-      apply mul_le_mul'
-      · exact h _ (Finset.mem_insert_self a s)
-      · exact ih fun i hi ↦ h _ (Finset.mem_insert_of_mem hi)
+/-- Note that the name is to match `CanonicallyOrderedCommSemiring.mul_pos`. -/
+@[simp] lemma _root_.CanonicallyOrderedCommSemiring.prod_pos [Nontrivial R] :
+    0 < ∏ i in s, f i ↔ (∀ i ∈ s, (0 : R) < f i) :=
+  CanonicallyOrderedCommSemiring.multiset_prod_pos.trans Multiset.forall_mem_map_iff
+#align canonically_ordered_comm_semiring.prod_pos CanonicallyOrderedCommSemiring.prod_pos
+
+theorem prod_le_prod' (h : ∀ i ∈ s, f i ≤ g i) : (∏ i in s, f i) ≤ ∏ i in s, g i :=
+  prod_le_prod'' h
 #align finset.prod_le_prod' Finset.prod_le_prod'
 
 /-- If `g, h ≤ f` and `g i + h i ≤ f i`, then the product of `f` over `s` is at least the

--- a/Mathlib/Algebra/BigOperators/Order.lean
+++ b/Mathlib/Algebra/BigOperators/Order.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl
 
 ! This file was ported from Lean 3 source module algebra.big_operators.order
-! leanprover-community/mathlib commit 509de852e1de55e1efa8eacfa11df0823f26f226
+! leanprover-community/mathlib commit afdb4fa3b32d41106a4a09b371ce549ad7958abd
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -733,11 +733,8 @@ section AbsoluteValue
 variable {S : Type _}
 
 theorem AbsoluteValue.sum_le [Semiring R] [OrderedSemiring S] (abv : AbsoluteValue R S)
-    (s : Finset ι) (f : ι → R) : abv (∑ i in s, f i) ≤ ∑ i in s, abv (f i) := by
-  induction' s using Finset.cons_induction
-  · simp
-  · simp only [Finset.sum_cons]
-    exact (abv.add_le _ _).trans (add_le_add le_rfl ‹_›)
+    (s : Finset ι) (f : ι → R) : abv (∑ i in s, f i) ≤ ∑ i in s, abv (f i) :=
+  Finset.le_sum_of_subadditive abv (map_zero _) abv.add_le _ _
 #align absolute_value.sum_le AbsoluteValue.sum_le
 
 theorem IsAbsoluteValue.abv_sum [Semiring R] [OrderedSemiring S] (abv : R → S) [IsAbsoluteValue abv]

--- a/Mathlib/Algebra/BigOperators/Order.lean
+++ b/Mathlib/Algebra/BigOperators/Order.lean
@@ -643,8 +643,14 @@ variable [CanonicallyOrderedCommSemiring R] {f g h : ι → R} {s : Finset ι} {
   CanonicallyOrderedCommSemiring.multiset_prod_pos.trans Multiset.forall_mem_map_iff
 #align canonically_ordered_comm_semiring.prod_pos CanonicallyOrderedCommSemiring.prod_pos
 
-theorem prod_le_prod' (h : ∀ i ∈ s, f i ≤ g i) : (∏ i in s, f i) ≤ ∏ i in s, g i :=
-  prod_le_prod'' h
+theorem prod_le_prod' (h : ∀ i ∈ s, f i ≤ g i) : (∏ i in s, f i) ≤ ∏ i in s, g i := by
+  classical
+    induction' s using Finset.induction with a s has ih h
+    · simp
+    · rw [Finset.prod_insert has, Finset.prod_insert has]
+      apply mul_le_mul'
+      · exact h _ (Finset.mem_insert_self a s)
+      · exact ih fun i hi ↦ h _ (Finset.mem_insert_of_mem hi)
 #align finset.prod_le_prod' Finset.prod_le_prod'
 
 /-- If `g, h ≤ f` and `g i + h i ≤ f i`, then the product of `f` over `s` is at least the

--- a/Mathlib/Algebra/Order/Monoid/WithTop.lean
+++ b/Mathlib/Algebra/Order/Monoid/WithTop.lean
@@ -146,8 +146,8 @@ theorem add_ne_top : a + b ≠ ⊤ ↔ a ≠ ⊤ ∧ b ≠ ⊤ :=
   add_eq_top.not.trans not_or
 #align with_top.add_ne_top WithTop.add_ne_top
 
-theorem add_lt_top [PartialOrder α] {a b : WithTop α} : a + b < ⊤ ↔ a < ⊤ ∧ b < ⊤ := by
-  simp_rw [lt_top_iff_ne_top, add_ne_top]
+theorem add_lt_top [LT α] {a b : WithTop α} : a + b < ⊤ ↔ a < ⊤ ∧ b < ⊤ := by
+  simp_rw [WithTop.lt_top_iff_ne_top, add_ne_top]
 #align with_top.add_lt_top WithTop.add_lt_top
 
 theorem add_eq_coe :

--- a/Mathlib/Algebra/Order/Monoid/WithTop.lean
+++ b/Mathlib/Algebra/Order/Monoid/WithTop.lean
@@ -5,7 +5,7 @@ Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro, Johannes Hölzl
 Ported by: Jon Eugster
 
 ! This file was ported from Lean 3 source module algebra.order.monoid.with_top
-! leanprover-community/mathlib commit e7e2ba8aa216a5833b5ed85a93317263711a36b5
+! leanprover-community/mathlib commit afdb4fa3b32d41106a4a09b371ce549ad7958abd
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -569,7 +569,7 @@ theorem add_ne_bot : a + b ≠ ⊥ ↔ a ≠ ⊥ ∧ b ≠ ⊥ :=
   WithTop.add_ne_top
 #align with_bot.add_ne_bot WithBot.add_ne_bot
 
-theorem bot_lt_add [PartialOrder α] {a b : WithBot α} : ⊥ < a + b ↔ ⊥ < a ∧ ⊥ < b :=
+theorem bot_lt_add [LT α] {a b : WithBot α} : ⊥ < a + b ↔ ⊥ < a ∧ ⊥ < b :=
   @WithTop.add_lt_top αᵒᵈ _ _ _ _
 #align with_bot.bot_lt_add WithBot.bot_lt_add
 

--- a/Mathlib/Algebra/Order/Ring/Canonical.lean
+++ b/Mathlib/Algebra/Order/Ring/Canonical.lean
@@ -103,10 +103,6 @@ instance (priority := 100) toCovariantClassMulLE : CovariantClass α α (· * ·
 #align canonically_ordered_comm_semiring.to_covariant_mul_le CanonicallyOrderedCommSemiring.toCovariantClassMulLE
 
 -- see Note [lower instance priority]
-instance (priority := 100) toOrderedCommMonoid : OrderedCommMonoid α where
-  mul_le_mul_left := fun _ _ => mul_le_mul_left'
-
--- see Note [lower instance priority]
 instance (priority := 100) toOrderedCommSemiring : OrderedCommSemiring α :=
   { ‹CanonicallyOrderedCommSemiring α› with
     zero_le_one := zero_le _,

--- a/Mathlib/Algebra/Order/Ring/Canonical.lean
+++ b/Mathlib/Algebra/Order/Ring/Canonical.lean
@@ -103,6 +103,10 @@ instance (priority := 100) toCovariantClassMulLE : CovariantClass α α (· * ·
 #align canonically_ordered_comm_semiring.to_covariant_mul_le CanonicallyOrderedCommSemiring.toCovariantClassMulLE
 
 -- see Note [lower instance priority]
+instance (priority := 100) toOrderedCommMonoid : OrderedCommMonoid α where
+  mul_le_mul_left := fun _ _ => mul_le_mul_left'
+
+-- see Note [lower instance priority]
 instance (priority := 100) toOrderedCommSemiring : OrderedCommSemiring α :=
   { ‹CanonicallyOrderedCommSemiring α› with
     zero_le_one := zero_le _,

--- a/Mathlib/Algebra/Order/Ring/WithTop.lean
+++ b/Mathlib/Algebra/Order/Ring/WithTop.lean
@@ -48,13 +48,32 @@ theorem mul_def {a b : WithTop α} :
 theorem top_mul_top : (⊤ * ⊤ : WithTop α) = ⊤ := by simp [mul_def]; rfl
 #align with_top.top_mul_top WithTop.top_mul_top
 
-@[simp]
-theorem mul_top {a : WithTop α} (h : a ≠ 0) : a * ⊤ = ⊤ := by cases a <;> simp [mul_def, h] <;> rfl
+theorem mul_top' (a : WithTop α) : a * ⊤ = if a = 0 then 0 else ⊤ := by
+  induction a using recTopCoe <;> simp [mul_def] <;> rfl
+
+@[simp] theorem mul_top {a : WithTop α} (h : a ≠ 0) : a * ⊤ = ⊤ := by rw [mul_top', if_neg h]
 #align with_top.mul_top WithTop.mul_top
 
-@[simp]
-theorem top_mul {a : WithTop α} (h : a ≠ 0) : ⊤ * a = ⊤ := by cases a <;> simp [mul_def, h] <;> rfl
+theorem top_mul' (a : WithTop α) : ⊤ * a = if a = 0 then 0 else ⊤ := by
+  induction a using recTopCoe <;> simp [mul_def] <;> rfl
+
+@[simp] theorem top_mul {a : WithTop α} (h : a ≠ 0) : ⊤ * a = ⊤ := by rw [top_mul', if_neg h]
 #align with_top.top_mul WithTop.top_mul
+
+theorem mul_eq_top_iff {a b : WithTop α} : a * b = ⊤ ↔ a ≠ 0 ∧ b = ⊤ ∨ a = ⊤ ∧ b ≠ 0 := by
+  rw [mul_def, ite_eq_iff, ← none_eq_top, Option.map₂_eq_none_iff]
+  have ha : a = 0 → a ≠ none := fun h => h.symm ▸ zero_ne_top
+  have hb : b = 0 → b ≠ none := fun h => h.symm ▸ zero_ne_top
+  tauto
+#align with_top.mul_eq_top_iff WithTop.mul_eq_top_iff
+
+theorem mul_lt_top' [LT α] {a b : WithTop α} (ha : a < ⊤) (hb : b < ⊤) : a * b < ⊤ := by
+  rw [WithTop.lt_top_iff_ne_top] at *
+  simp only [Ne.def, mul_eq_top_iff, *, and_false, false_and, false_or]
+
+theorem mul_lt_top [LT α] {a b : WithTop α} (ha : a ≠ ⊤) (hb : b ≠ ⊤) : a * b < ⊤ :=
+  mul_lt_top' (WithTop.lt_top_iff_ne_top.2 ha) (WithTop.lt_top_iff_ne_top.2 hb)
+#align with_top.mul_lt_top WithTop.mul_lt_top
 
 instance noZeroDivisors [NoZeroDivisors α] : NoZeroDivisors (WithTop α) := by
   refine ⟨fun h₁ => Decidable.by_contradiction <| fun h₂ => ?_⟩
@@ -68,7 +87,7 @@ section MulZeroClass
 
 variable [MulZeroClass α]
 
-@[norm_cast]
+@[simp, norm_cast] -- porting note: added `simp`
 theorem coe_mul {a b : α} : (↑(a * b) : WithTop α) = a * b := by
   by_cases ha : a = 0
   · simp [ha]
@@ -86,23 +105,6 @@ theorem mul_coe {b : α} (hb : b ≠ 0) : ∀ {a : WithTop α},
     rw [some_eq_coe, ← coe_mul]
     rfl
 #align with_top.mul_coe WithTop.mul_coe
-
-@[simp]
-theorem mul_eq_top_iff {a b : WithTop α} : a * b = ⊤ ↔ a ≠ 0 ∧ b = ⊤ ∨ a = ⊤ ∧ b ≠ 0 := by
-  match a with
-  | none => match b with
-    | none => simp [none_eq_top]
-    | Option.some b => by_cases hb : b = 0 <;> simp [none_eq_top, some_eq_coe, hb]
-  | Option.some a => match b with
-    | none => by_cases ha : a = 0 <;> simp [none_eq_top, some_eq_coe, ha]
-    | Option.some b => simp [some_eq_coe, ← coe_mul]
-#align with_top.mul_eq_top_iff WithTop.mul_eq_top_iff
-
-theorem mul_lt_top [Preorder α] {a b : WithTop α} (ha : a ≠ ⊤) (hb : b ≠ ⊤) : a * b < ⊤ := by
-  lift a to α using ha
-  lift b to α using hb
-  simp only [← coe_mul, coe_lt_top]
-#align with_top.mul_lt_top WithTop.mul_lt_top
 
 @[simp]
 theorem untop'_zero_mul (a b : WithTop α) : (a * b).untop' 0 = a.untop' 0 * b.untop' 0 := by
@@ -148,7 +150,7 @@ protected def MonoidWithZeroHom.withTopMap {R S : Type _} [MulZeroOneClass R] [D
       induction' y using WithTop.recTopCoe with y
       · have : (f x : WithTop S) ≠ 0 := by simpa [hf.eq_iff' (map_zero f)] using hx
         simp [mul_top hx, mul_top this]
-      · simp [← coe_mul, map_coe] }
+      · simp only [map_coe, ← coe_mul, map_mul] } -- porting note: todo: `simp [← coe_mul]` fails
 #align monoid_with_zero_hom.with_top_map WithTop.MonoidWithZeroHom.withTopMap
 
 instance [SemigroupWithZero α] [NoZeroDivisors α] : SemigroupWithZero (WithTop α) :=
@@ -250,13 +252,25 @@ theorem bot_mul_bot : (⊥ * ⊥ : WithBot α) = ⊥ :=
   WithTop.top_mul_top
 #align with_bot.bot_mul_bot WithBot.bot_mul_bot
 
+@[simp]
+theorem mul_eq_bot_iff {a b : WithBot α} : a * b = ⊥ ↔ a ≠ 0 ∧ b = ⊥ ∨ a = ⊥ ∧ b ≠ 0 :=
+  WithTop.mul_eq_top_iff
+#align with_bot.mul_eq_bot_iff WithBot.mul_eq_bot_iff
+
+theorem bot_lt_mul' [LT α] {a b : WithBot α} (ha : ⊥ < a) (hb : ⊥ < b) : ⊥ < a * b :=
+  WithTop.mul_lt_top' (α := αᵒᵈ) ha hb
+#align with_bot.bot_lt_mul WithBot.bot_lt_mul'
+
+theorem bot_lt_mul [LT α] {a b : WithBot α} (ha : a ≠ ⊥) (hb : b ≠ ⊥) : ⊥ < a * b :=
+  WithTop.mul_lt_top (α := αᵒᵈ) ha hb
+
 end Mul
 
 section MulZeroClass
 
 variable [MulZeroClass α]
 
-@[norm_cast]
+@[simp, norm_cast] -- porting note: added `simp`
 theorem coe_mul {a b : α} : (↑(a * b) : WithBot α) = a * b :=
   WithTop.coe_mul
 #align with_bot.coe_mul WithBot.coe_mul
@@ -265,17 +279,6 @@ theorem mul_coe {b : α} (hb : b ≠ 0) {a : WithBot α} :
     a * (b : WithBot α) = a.bind fun a : α => ↑(a * b) :=
   WithTop.mul_coe hb
 #align with_bot.mul_coe WithBot.mul_coe
-
-@[simp]
-theorem mul_eq_bot_iff {a b : WithBot α} : a * b = ⊥ ↔ a ≠ 0 ∧ b = ⊥ ∨ a = ⊥ ∧ b ≠ 0 :=
-  WithTop.mul_eq_top_iff
-#align with_bot.mul_eq_bot_iff WithBot.mul_eq_bot_iff
-
-theorem bot_lt_mul [Preorder α] {a b : WithBot α} (ha : ⊥ < a) (hb : ⊥ < b) : ⊥ < a * b := by
-  lift a to α using ne_bot_of_gt ha
-  lift b to α using ne_bot_of_gt hb
-  simp only [← coe_mul, bot_lt_coe]
-#align with_bot.bot_lt_mul WithBot.bot_lt_mul
 
 end MulZeroClass
 

--- a/Mathlib/Algebra/Order/Ring/WithTop.lean
+++ b/Mathlib/Algebra/Order/Ring/WithTop.lean
@@ -3,7 +3,7 @@ Copyright (c) 2016 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro
 ! This file was ported from Lean 3 source module algebra.order.ring.with_top
-! leanprover-community/mathlib commit e7e2ba8aa216a5833b5ed85a93317263711a36b5
+! leanprover-community/mathlib commit afdb4fa3b32d41106a4a09b371ce549ad7958abd
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -50,12 +50,14 @@ theorem top_mul_top : (⊤ * ⊤ : WithTop α) = ⊤ := by simp [mul_def]; rfl
 
 theorem mul_top' (a : WithTop α) : a * ⊤ = if a = 0 then 0 else ⊤ := by
   induction a using recTopCoe <;> simp [mul_def] <;> rfl
+#align with_top.mul_top' WithTop.mul_top'
 
 @[simp] theorem mul_top {a : WithTop α} (h : a ≠ 0) : a * ⊤ = ⊤ := by rw [mul_top', if_neg h]
 #align with_top.mul_top WithTop.mul_top
 
 theorem top_mul' (a : WithTop α) : ⊤ * a = if a = 0 then 0 else ⊤ := by
   induction a using recTopCoe <;> simp [mul_def] <;> rfl
+#align with_top.top_mul' WithTop.top_mul'
 
 @[simp] theorem top_mul {a : WithTop α} (h : a ≠ 0) : ⊤ * a = ⊤ := by rw [top_mul', if_neg h]
 #align with_top.top_mul WithTop.top_mul
@@ -70,6 +72,7 @@ theorem mul_eq_top_iff {a b : WithTop α} : a * b = ⊤ ↔ a ≠ 0 ∧ b = ⊤ 
 theorem mul_lt_top' [LT α] {a b : WithTop α} (ha : a < ⊤) (hb : b < ⊤) : a * b < ⊤ := by
   rw [WithTop.lt_top_iff_ne_top] at *
   simp only [Ne.def, mul_eq_top_iff, *, and_false, false_and, false_or]
+#align with_top.mul_lt_top' WithTop.mul_lt_top'
 
 theorem mul_lt_top [LT α] {a b : WithTop α} (ha : a ≠ ⊤) (hb : b ≠ ⊤) : a * b < ⊤ :=
   mul_lt_top' (WithTop.lt_top_iff_ne_top.2 ha) (WithTop.lt_top_iff_ne_top.2 hb)
@@ -87,7 +90,7 @@ section MulZeroClass
 
 variable [MulZeroClass α]
 
-@[simp, norm_cast] -- porting note: added `simp`
+@[simp, norm_cast]
 theorem coe_mul {a b : α} : (↑(a * b) : WithTop α) = a * b := by
   by_cases ha : a = 0
   · simp [ha]
@@ -258,10 +261,11 @@ theorem mul_eq_bot_iff {a b : WithBot α} : a * b = ⊥ ↔ a ≠ 0 ∧ b = ⊥ 
 
 theorem bot_lt_mul' [LT α] {a b : WithBot α} (ha : ⊥ < a) (hb : ⊥ < b) : ⊥ < a * b :=
   WithTop.mul_lt_top' (α := αᵒᵈ) ha hb
-#align with_bot.bot_lt_mul WithBot.bot_lt_mul'
+#align with_bot.bot_lt_mul' WithBot.bot_lt_mul'
 
 theorem bot_lt_mul [LT α] {a b : WithBot α} (ha : a ≠ ⊥) (hb : b ≠ ⊥) : ⊥ < a * b :=
   WithTop.mul_lt_top (α := αᵒᵈ) ha hb
+#align with_bot.bot_lt_mul WithBot.bot_lt_mul
 
 end Mul
 

--- a/Mathlib/Algebra/Order/Ring/WithTop.lean
+++ b/Mathlib/Algebra/Order/Ring/WithTop.lean
@@ -252,7 +252,6 @@ theorem bot_mul_bot : (⊥ * ⊥ : WithBot α) = ⊥ :=
   WithTop.top_mul_top
 #align with_bot.bot_mul_bot WithBot.bot_mul_bot
 
-@[simp]
 theorem mul_eq_bot_iff {a b : WithBot α} : a * b = ⊥ ↔ a ≠ 0 ∧ b = ⊥ ∨ a = ⊥ ∧ b ≠ 0 :=
   WithTop.mul_eq_top_iff
 #align with_bot.mul_eq_bot_iff WithBot.mul_eq_bot_iff

--- a/Mathlib/Algebra/Order/Sub/WithTop.lean
+++ b/Mathlib/Algebra/Order/Sub/WithTop.lean
@@ -48,6 +48,11 @@ theorem top_sub_coe {a : α} : (⊤ : WithTop α) - a = ⊤ :=
 theorem sub_top {a : WithTop α} : a - ⊤ = 0 := by cases a <;> rfl
 #align with_top.sub_top WithTop.sub_top
 
+@[simp] theorem sub_eq_top_iff {a b : WithTop α} : a - b = ⊤ ↔ a = ⊤ ∧ b ≠ ⊤ := by
+  induction a using recTopCoe <;> induction b using recTopCoe <;>
+    simp only [← coe_sub, coe_ne_top, sub_top, zero_ne_top, coe_ne_top, top_sub_coe, false_and,
+      Ne.def]
+
 theorem map_sub [Sub β] [Zero β] {f : α → β} (h : ∀ x y, f (x - y) = f x - f y) (h₀ : f 0 = 0) :
     ∀ x y : WithTop α, (x - y).map f = x.map f - y.map f
   | _, ⊤ => by simp only [h₀, sub_top, WithTop.map_zero, coe_zero, map_top]

--- a/Mathlib/Algebra/Order/Sub/WithTop.lean
+++ b/Mathlib/Algebra/Order/Sub/WithTop.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn
 
 ! This file was ported from Lean 3 source module algebra.order.sub.with_top
-! leanprover-community/mathlib commit 10b4e499f43088dd3bb7b5796184ad5216648ab1
+! leanprover-community/mathlib commit afdb4fa3b32d41106a4a09b371ce549ad7958abd
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -52,6 +52,7 @@ theorem sub_top {a : WithTop α} : a - ⊤ = 0 := by cases a <;> rfl
   induction a using recTopCoe <;> induction b using recTopCoe <;>
     simp only [← coe_sub, coe_ne_top, sub_top, zero_ne_top, coe_ne_top, top_sub_coe, false_and,
       Ne.def]
+#align with_top.sub_eq_top_iff WithTop.sub_eq_top_iff
 
 theorem map_sub [Sub β] [Zero β] {f : α → β} (h : ∀ x y, f (x - y) = f x - f y) (h₀ : f 0 = 0) :
     ∀ x y : WithTop α, (x - y).map f = x.map f - y.map f

--- a/Mathlib/Data/List/BigOperators/Basic.lean
+++ b/Mathlib/Data/List/BigOperators/Basic.lean
@@ -4,10 +4,11 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Floris van Doorn, Sébastien Gouëzel, Alex J. Best
 
 ! This file was ported from Lean 3 source module data.list.big_operators.basic
-! leanprover-community/mathlib commit 47adfab39a11a072db552f47594bf8ed2cf8a722
+! leanprover-community/mathlib commit 6c5f73fd6f6cc83122788a80a27cdd54663609f4
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
+import Mathlib.Data.Int.Order.Basic
 import Mathlib.Data.List.Forall2
 
 /-!
@@ -586,18 +587,24 @@ theorem prod_pos [StrictOrderedSemiring R] (l : List R) (h : ∀ a ∈ l, (0 : R
     exact mul_pos (h _ <| mem_cons_self _ _) (ih fun a ha => h a <| mem_cons_of_mem _ ha)
 #align list.prod_pos List.prod_pos
 
+/-- A variant of `List.prod_pos` for `CanonicallyOrderedCommSemiring`. -/
+@[simp] lemma _root_.CanonicallyOrderedCommSemiring.list_prod_pos
+    {α : Type _} [CanonicallyOrderedCommSemiring α] [Nontrivial α] :
+    ∀ {l : List α}, 0 < l.prod ↔ (∀ x ∈ l, (0 : α) < x)
+  | [] => by simp
+  | (x :: xs) => by simp_rw [prod_cons, forall_mem_cons, CanonicallyOrderedCommSemiring.mul_pos,
+    list_prod_pos]
+#align canonically_ordered_comm_semiring.list_prod_pos CanonicallyOrderedCommSemiring.list_prod_pos
+
 /-!
 Several lemmas about sum/head/tail for `List ℕ`.
 These are hard to generalize well, as they rely on the fact that `default ℕ = 0`.
 If desired, we could add a class stating that `default = 0`.
 -/
 
-
 /-- This relies on `default ℕ = 0`. -/
 theorem headI_add_tail_sum (L : List ℕ) : L.headI + L.tail.sum = L.sum := by
-  cases L
-  · simp
-  · simp
+  cases L <;> simp
 #align list.head_add_tail_sum List.headI_add_tail_sum
 
 /-- This relies on `default ℕ = 0`. -/
@@ -663,6 +670,22 @@ theorem alternatingProd_cons (a : α) (l : List α) :
 #align list.alternating_sum_cons List.alternatingSum_cons
 
 end Alternating
+
+lemma sum_nat_mod (l : List ℕ) (n : ℕ) : l.sum % n = (l.map (· % n)).sum % n := by
+  induction l <;> simp [Nat.add_mod, *]
+#align list.sum_nat_mod List.sum_nat_mod
+
+lemma prod_nat_mod (l : List ℕ) (n : ℕ) : l.prod % n = (l.map (· % n)).prod % n := by
+  induction l <;> simp [Nat.mul_mod, *]
+#align list.prod_nat_mod List.prod_nat_mod
+
+lemma sum_int_mod (l : List ℤ) (n : ℤ) : l.sum % n = (l.map (· % n)).sum % n := by
+  induction l <;> simp [Int.add_emod, *]
+#align list.sum_int_mod List.sum_int_mod
+
+lemma prod_int_mod (l : List ℤ) (n : ℤ) : l.prod % n = (l.map (· % n)).prod % n := by
+  induction l <;> simp [Int.mul_emod, *]
+#align list.prod_int_mod List.prod_int_mod
 
 end List
 

--- a/Mathlib/Order/WithBot.lean
+++ b/Mathlib/Order/WithBot.lean
@@ -130,6 +130,19 @@ theorem unbot'_coe {α} (d x : α) : unbot' d x = x :=
 theorem coe_eq_coe : (a : WithBot α) = b ↔ a = b := coe_inj
 #align with_bot.coe_eq_coe WithBot.coe_eq_coe
 
+-- porting note: new theorem
+theorem unbot'_eq_iff {d y : α} {x : WithBot α} : unbot' d x = y ↔ x = y ∨ x = ⊥ ∧ y = d := by
+  induction x using recBotCoe <;> simp [@eq_comm _ d]
+
+@[simp] -- porting note: new theorem
+theorem unbot'_eq_d_iff {d : α} {x : WithBot α} : unbot' d x = d ↔ x = d ∨ x = ⊥ := by
+  simp [unbot'_eq_iff]
+
+-- porting note: new theorem
+theorem unbot'_eq_unbot'_iff {d : α} {x y : WithBot α} :
+    unbot' d x = unbot' d y ↔ x = y ∨ x = d ∧ y = ⊥ ∨ x = ⊥ ∧ y = d := by
+ induction y using recBotCoe <;> simp [unbot'_eq_iff, or_comm]
+
 /-- Lift a map `f : α → β` to `WithBot α → WithBot β`. Implemented using `Option.map`. -/
 def map (f : α → β) : WithBot α → WithBot β :=
   Option.map f
@@ -275,6 +288,12 @@ theorem lt_coe_iff : ∀ {x : WithBot α}, x < b ↔ ∀ a, x = ↑a → a < b
   | Option.some b => by simp [some_eq_coe, coe_eq_coe, coe_lt_coe]
   | none => by simp [none_eq_bot, bot_lt_coe]
 #align with_bot.lt_coe_iff WithBot.lt_coe_iff
+
+/-- A version of `bot_lt_iff_ne_bot` for `WithBot` that only requires `LT α`, not
+`PartialOrder α`. -/
+protected theorem bot_lt_iff_ne_bot : ∀ {x : WithBot α}, ⊥ < x ↔ x ≠ ⊥
+  | ⊥ => by simpa using not_lt_none ⊥
+  | (x : α) => by simp [bot_lt_coe]
 
 end LT
 
@@ -680,6 +699,19 @@ theorem coe_eq_coe : (a : WithTop α) = b ↔ a = b :=
   Option.some_inj
 #align with_top.coe_eq_coe WithTop.coe_eq_coe
 
+-- porting note: new theorem
+theorem untop'_eq_iff {d y : α} {x : WithTop α} : untop' d x = y ↔ x = y ∨ x = ⊤ ∧ y = d :=
+  WithBot.unbot'_eq_iff
+
+@[simp] -- porting note: new theorem
+theorem untop'_eq_d_iff {d : α} {x : WithTop α} : untop' d x = d ↔ x = d ∨ x = ⊤ :=
+  WithBot.unbot'_eq_d_iff
+
+-- porting note: new theorem
+theorem untop'_eq_untop'_iff {d : α} {x y : WithTop α} :
+    untop' d x = untop' d y ↔ x = y ∨ x = d ∧ y = ⊤ ∨ x = ⊤ ∧ y = d :=
+  WithBot.unbot'_eq_unbot'_iff
+
 /-- Lift a map `f : α → β` to `WithTop α → WithTop β`. Implemented using `Option.map`. -/
 def map (f : α → β) : WithTop α → WithTop β :=
   Option.map f
@@ -1039,6 +1071,11 @@ theorem lt_iff_exists_coe {a b : WithTop α} : a < b ↔ ∃ p : α, a = p ∧ �
 
 theorem coe_lt_iff {x : WithTop α} : ↑a < x ↔ ∀ b, x = ↑b → a < b := by simp
 #align with_top.coe_lt_iff WithTop.coe_lt_iff
+
+/-- A version of `lt_top_iff_ne_top` for `WithTop` that only requires `LT α`, not
+`PartialOrder α`. -/
+protected theorem lt_top_iff_ne_top {x : WithTop α} : x < ⊤ ↔ x ≠ ⊤ :=
+  @WithBot.bot_lt_iff_ne_bot αᵒᵈ _ x
 
 end LT
 

--- a/Mathlib/Order/WithBot.lean
+++ b/Mathlib/Order/WithBot.lean
@@ -135,7 +135,7 @@ theorem unbot'_eq_iff {d y : α} {x : WithBot α} : unbot' d x = y ↔ x = y ∨
   induction x using recBotCoe <;> simp [@eq_comm _ d]
 
 @[simp] -- porting note: new theorem
-theorem unbot'_eq_d_iff {d : α} {x : WithBot α} : unbot' d x = d ↔ x = d ∨ x = ⊥ := by
+theorem unbot'_eq_self_iff {d : α} {x : WithBot α} : unbot' d x = d ↔ x = d ∨ x = ⊥ := by
   simp [unbot'_eq_iff]
 
 -- porting note: new theorem
@@ -704,8 +704,8 @@ theorem untop'_eq_iff {d y : α} {x : WithTop α} : untop' d x = y ↔ x = y ∨
   WithBot.unbot'_eq_iff
 
 @[simp] -- porting note: new theorem
-theorem untop'_eq_d_iff {d : α} {x : WithTop α} : untop' d x = d ↔ x = d ∨ x = ⊤ :=
-  WithBot.unbot'_eq_d_iff
+theorem untop'_eq_self_iff {d : α} {x : WithTop α} : untop' d x = d ↔ x = d ∨ x = ⊤ :=
+  WithBot.unbot'_eq_self_iff
 
 -- porting note: new theorem
 theorem untop'_eq_untop'_iff {d : α} {x y : WithTop α} :

--- a/Mathlib/Order/WithBot.lean
+++ b/Mathlib/Order/WithBot.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl
 
 ! This file was ported from Lean 3 source module order.with_bot
-! leanprover-community/mathlib commit 995b47e555f1b6297c7cf16855f1023e355219fb
+! leanprover-community/mathlib commit afdb4fa3b32d41106a4a09b371ce549ad7958abd
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -130,18 +130,18 @@ theorem unbot'_coe {α} (d x : α) : unbot' d x = x :=
 theorem coe_eq_coe : (a : WithBot α) = b ↔ a = b := coe_inj
 #align with_bot.coe_eq_coe WithBot.coe_eq_coe
 
--- porting note: new theorem
 theorem unbot'_eq_iff {d y : α} {x : WithBot α} : unbot' d x = y ↔ x = y ∨ x = ⊥ ∧ y = d := by
   induction x using recBotCoe <;> simp [@eq_comm _ d]
+#align with_bot.unbot'_eq_iff WithBot.unbot'_eq_iff
 
-@[simp] -- porting note: new theorem
-theorem unbot'_eq_self_iff {d : α} {x : WithBot α} : unbot' d x = d ↔ x = d ∨ x = ⊥ := by
+@[simp] theorem unbot'_eq_self_iff {d : α} {x : WithBot α} : unbot' d x = d ↔ x = d ∨ x = ⊥ := by
   simp [unbot'_eq_iff]
+#align with_bot.unbot'_eq_self_iff WithBot.unbot'_eq_self_iff
 
--- porting note: new theorem
 theorem unbot'_eq_unbot'_iff {d : α} {x y : WithBot α} :
     unbot' d x = unbot' d y ↔ x = y ∨ x = d ∧ y = ⊥ ∨ x = ⊥ ∧ y = d := by
  induction y using recBotCoe <;> simp [unbot'_eq_iff, or_comm]
+#align with_bot.unbot'_eq_unbot'_iff WithBot.unbot'_eq_unbot'_iff
 
 /-- Lift a map `f : α → β` to `WithBot α → WithBot β`. Implemented using `Option.map`. -/
 def map (f : α → β) : WithBot α → WithBot β :=
@@ -294,6 +294,7 @@ theorem lt_coe_iff : ∀ {x : WithBot α}, x < b ↔ ∀ a, x = ↑a → a < b
 protected theorem bot_lt_iff_ne_bot : ∀ {x : WithBot α}, ⊥ < x ↔ x ≠ ⊥
   | ⊥ => by simpa using not_lt_none ⊥
   | (x : α) => by simp [bot_lt_coe]
+#align with_bot.bot_lt_iff_ne_bot WithBot.bot_lt_iff_ne_bot
 
 end LT
 
@@ -699,18 +700,18 @@ theorem coe_eq_coe : (a : WithTop α) = b ↔ a = b :=
   Option.some_inj
 #align with_top.coe_eq_coe WithTop.coe_eq_coe
 
--- porting note: new theorem
 theorem untop'_eq_iff {d y : α} {x : WithTop α} : untop' d x = y ↔ x = y ∨ x = ⊤ ∧ y = d :=
   WithBot.unbot'_eq_iff
+#align with_top.untop'_eq_iff WithTop.untop'_eq_iff
 
-@[simp] -- porting note: new theorem
-theorem untop'_eq_self_iff {d : α} {x : WithTop α} : untop' d x = d ↔ x = d ∨ x = ⊤ :=
+@[simp] theorem untop'_eq_self_iff {d : α} {x : WithTop α} : untop' d x = d ↔ x = d ∨ x = ⊤ :=
   WithBot.unbot'_eq_self_iff
+#align with_top.untop'_eq_self_iff WithTop.untop'_eq_self_iff
 
--- porting note: new theorem
 theorem untop'_eq_untop'_iff {d : α} {x y : WithTop α} :
     untop' d x = untop' d y ↔ x = y ∨ x = d ∧ y = ⊤ ∨ x = ⊤ ∧ y = d :=
   WithBot.unbot'_eq_unbot'_iff
+#align with_top.untop'_eq_untop'_iff WithTop.untop'_eq_untop'_iff
 
 /-- Lift a map `f : α → β` to `WithTop α → WithTop β`. Implemented using `Option.map`. -/
 def map (f : α → β) : WithTop α → WithTop β :=
@@ -1076,6 +1077,7 @@ theorem coe_lt_iff {x : WithTop α} : ↑a < x ↔ ∀ b, x = ↑b → a < b := 
 `PartialOrder α`. -/
 protected theorem lt_top_iff_ne_top {x : WithTop α} : x < ⊤ ↔ x ≠ ⊤ :=
   @WithBot.bot_lt_iff_ne_bot αᵒᵈ _ x
+#align with_top.lt_top_iff_ne_top WithTop.lt_top_iff_ne_top
 
 end LT
 


### PR DESCRIPTION
Some of these lemmas are generalized from `ENNReal` while porting `Data.Real.ENNReal`. Backported to Mathlib 3 in leanprover-community/mathlib#18487, now forward-porting back to Mathlib 4. Also forward-porting leanprover-community/mathlib#18391

* [`order.with_bot`@`995b47e555f1b6297c7cf16855f1023e355219fb`..`afdb4fa3b32d41106a4a09b371ce549ad7958abd`](https://leanprover-community.github.io/mathlib-port-status/file/order/with_bot?range=995b47e555f1b6297c7cf16855f1023e355219fb..afdb4fa3b32d41106a4a09b371ce549ad7958abd)
* [`algebra.order.monoid.with_top`@`e7e2ba8aa216a5833b5ed85a93317263711a36b5`..`afdb4fa3b32d41106a4a09b371ce549ad7958abd`](https://leanprover-community.github.io/mathlib-port-status/file/algebra/order/monoid/with_top?range=e7e2ba8aa216a5833b5ed85a93317263711a36b5..afdb4fa3b32d41106a4a09b371ce549ad7958abd)
* [`algebra.order.sub.with_top`@`10b4e499f43088dd3bb7b5796184ad5216648ab1`..`afdb4fa3b32d41106a4a09b371ce549ad7958abd`](https://leanprover-community.github.io/mathlib-port-status/file/algebra/order/sub/with_top?range=10b4e499f43088dd3bb7b5796184ad5216648ab1..afdb4fa3b32d41106a4a09b371ce549ad7958abd)
* [`algebra.order.ring.with_top`@`e7e2ba8aa216a5833b5ed85a93317263711a36b5`..`afdb4fa3b32d41106a4a09b371ce549ad7958abd`](https://leanprover-community.github.io/mathlib-port-status/file/algebra/order/ring/with_top?range=e7e2ba8aa216a5833b5ed85a93317263711a36b5..afdb4fa3b32d41106a4a09b371ce549ad7958abd)
* [`data.list.big_operators.basic`@`47adfab39a11a072db552f47594bf8ed2cf8a722`..`6c5f73fd6f6cc83122788a80a27cdd54663609f4`](https://leanprover-community.github.io/mathlib-port-status/file/data/list/big_operators/basic?range=47adfab39a11a072db552f47594bf8ed2cf8a722..6c5f73fd6f6cc83122788a80a27cdd54663609f4)
* [`algebra.big_operators.order`@`509de852e1de55e1efa8eacfa11df0823f26f226`..`afdb4fa3b32d41106a4a09b371ce549ad7958abd`](https://leanprover-community.github.io/mathlib-port-status/file/algebra/big_operators/order?range=509de852e1de55e1efa8eacfa11df0823f26f226..afdb4fa3b32d41106a4a09b371ce549ad7958abd)

---

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
