### PR TITLE
[Merged by Bors] - feat: port CategoryTheory.Adjunction.FullyFaithful

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -223,6 +223,7 @@ import Mathlib.Algebra.Tropical.Basic
 import Mathlib.Algebra.Tropical.BigOperators
 import Mathlib.Algebra.Tropical.Lattice
 import Mathlib.CategoryTheory.Adjunction.Basic
+import Mathlib.CategoryTheory.Adjunction.FullyFaithful
 import Mathlib.CategoryTheory.Arrow
 import Mathlib.CategoryTheory.Balanced
 import Mathlib.CategoryTheory.Bicategory.Basic

--- a/Mathlib/CategoryTheory/Adjunction/Basic.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Basic.lean
@@ -177,14 +177,14 @@ theorem homEquiv_naturality_right_symm (f : X ⟶ G.obj Y) (g : Y ⟶ Y') :
 #align category_theory.adjunction.hom_equiv_naturality_right_symm CategoryTheory.Adjunction.homEquiv_naturality_right_symm
 
 @[simp]
-theorem left_triangle : whiskerRight adj.unit F ≫ whiskerLeft F adj.counit = NatTrans.id _ := by
+theorem left_triangle : whiskerRight adj.unit F ≫ whiskerLeft F adj.counit = 𝟙 _ := by
   ext; dsimp
   erw [← adj.homEquiv_counit, Equiv.symm_apply_eq, adj.homEquiv_unit]
   simp
 #align category_theory.adjunction.left_triangle CategoryTheory.Adjunction.left_triangle
 
 @[simp]
-theorem right_triangle : whiskerLeft G adj.unit ≫ whiskerRight adj.counit G = NatTrans.id _ := by
+theorem right_triangle : whiskerLeft G adj.unit ≫ whiskerRight adj.counit G = 𝟙 _ := by
   ext; dsimp
   erw [← adj.homEquiv_unit, ← Equiv.eq_symm_apply, adj.homEquiv_counit]
   simp
@@ -387,10 +387,10 @@ def mkOfUnitCounit (adj : CoreUnitCounit F G) : F ⊣ G :=
           exact t } }
 #align category_theory.adjunction.mk_of_unit_counit CategoryTheory.Adjunction.mkOfUnitCounit
 
-/- Porting note: simpNF linter claims these are solved by simp but that 
+/- Porting note: simpNF linter claims these are solved by simp but that
 is not true -/
-attribute [nolint simpNF] CategoryTheory.Adjunction.mkOfUnitCounit_homEquiv_symm_apply 
-attribute [nolint simpNF] CategoryTheory.Adjunction.mkOfUnitCounit_homEquiv_apply 
+attribute [nolint simpNF] CategoryTheory.Adjunction.mkOfUnitCounit_homEquiv_symm_apply
+attribute [nolint simpNF] CategoryTheory.Adjunction.mkOfUnitCounit_homEquiv_apply
 
 /-- The adjunction between the identity functor on a category and itself. -/
 def id : 𝟭 C ⊣ 𝟭 C where

--- a/Mathlib/CategoryTheory/Adjunction/FullyFaithful.lean
+++ b/Mathlib/CategoryTheory/Adjunction/FullyFaithful.lean
@@ -8,9 +8,9 @@ Authors: Scott Morrison
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
-import Mathbin.CategoryTheory.Adjunction.Basic
-import Mathbin.CategoryTheory.Conj
-import Mathbin.CategoryTheory.Yoneda
+import Mathlib.CategoryTheory.Adjunction.Basic
+import Mathlib.CategoryTheory.Conj
+import Mathlib.CategoryTheory.Yoneda
 
 /-!
 # Adjoints of fully faithful functors
@@ -148,8 +148,7 @@ instance whiskerLeft_counit_iso_of_L_fully_faithful [Full L] [Faithful L] :
 #align category_theory.whisker_left_counit_iso_of_L_fully_faithful CategoryTheory.whiskerLeft_counit_iso_of_L_fully_faithful
 
 instance whiskerRight_counit_iso_of_L_fully_faithful [Full L] [Faithful L] :
-    IsIso (whiskerRight h.counit R) :=
-  by
+    IsIso (whiskerRight h.counit R) := by
   have := h.right_triangle
   rw [← is_iso.eq_inv_comp] at this
   rw [this]

--- a/Mathlib/CategoryTheory/Adjunction/FullyFaithful.lean
+++ b/Mathlib/CategoryTheory/Adjunction/FullyFaithful.lean
@@ -1,0 +1,215 @@
+/-
+Copyright (c) 2019 Scott Morrison. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Scott Morrison
+
+! This file was ported from Lean 3 source module category_theory.adjunction.fully_faithful
+! leanprover-community/mathlib commit 9e7c80f638149bfb3504ba8ff48dfdbfc949fb1a
+! Please do not edit these lines, except to modify the commit id
+! if you have ported upstream changes.
+-/
+import Mathbin.CategoryTheory.Adjunction.Basic
+import Mathbin.CategoryTheory.Conj
+import Mathbin.CategoryTheory.Yoneda
+
+/-!
+# Adjoints of fully faithful functors
+
+A left adjoint is fully faithful, if and only if the unit is an isomorphism
+(and similarly for right adjoints and the counit).
+
+`adjunction.restrict_fully_faithful` shows that an adjunction can be restricted along fully faithful
+inclusions.
+
+## Future work
+
+The statements from Riehl 4.5.13 for adjoints which are either full, or faithful.
+-/
+
+
+open CategoryTheory
+
+namespace CategoryTheory
+
+universe v₁ v₂ u₁ u₂
+
+open Category
+
+open Opposite
+
+variable {C : Type u₁} [Category.{v₁} C]
+
+variable {D : Type u₂} [Category.{v₂} D]
+
+variable {L : C ⥤ D} {R : D ⥤ C} (h : L ⊣ R)
+
+/-- If the left adjoint is fully faithful, then the unit is an isomorphism.
+
+See
+* Lemma 4.5.13 from [Riehl][riehl2017]
+* https://math.stackexchange.com/a/2727177
+* https://stacks.math.columbia.edu/tag/07RB (we only prove the forward direction!)
+-/
+instance unit_isIso_of_L_fully_faithful [Full L] [Faithful L] : IsIso (Adjunction.unit h) :=
+  @NatIso.isIso_of_isIso_app _ _ _ _ _ _ (Adjunction.unit h) fun X =>
+    @Yoneda.isIso _ _ _ _ ((Adjunction.unit h).app X)
+      ⟨⟨{ app := fun Y f => L.preimage ((h.homEquiv (unop Y) (L.obj X)).symm f) },
+          ⟨by
+            ext (x f); dsimp
+            apply L.map_injective
+            simp, by
+            ext (x f); dsimp
+            simp only [adjunction.hom_equiv_counit, preimage_comp, preimage_map, category.assoc]
+            rw [← h.unit_naturality]
+            simp⟩⟩⟩
+#align category_theory.unit_is_iso_of_L_fully_faithful CategoryTheory.unit_isIso_of_L_fully_faithful
+
+/-- If the right adjoint is fully faithful, then the counit is an isomorphism.
+
+See <https://stacks.math.columbia.edu/tag/07RB> (we only prove the forward direction!)
+-/
+instance counit_isIso_of_R_fully_faithful [Full R] [Faithful R] : IsIso (Adjunction.counit h) :=
+  @NatIso.isIso_of_isIso_app _ _ _ _ _ _ (Adjunction.counit h) fun X =>
+    @isIso_of_op _ _ _ _ _ <|
+      @Coyoneda.isIso _ _ _ _ ((Adjunction.counit h).app X).op
+        ⟨⟨{ app := fun Y f => R.preimage ((h.homEquiv (R.obj X) Y) f) },
+            ⟨by
+              ext (x f); dsimp
+              apply R.map_injective
+              simp, by
+              ext (x f); dsimp
+              simp only [adjunction.hom_equiv_unit, preimage_comp, preimage_map]
+              rw [← h.counit_naturality]
+              simp⟩⟩⟩
+#align category_theory.counit_is_iso_of_R_fully_faithful CategoryTheory.counit_isIso_of_R_fully_faithful
+
+/-- If the unit of an adjunction is an isomorphism, then its inverse on the image of L is given
+by L whiskered with the counit. -/
+@[simp]
+theorem inv_map_unit {X : C} [IsIso (h.Unit.app X)] :
+    inv (L.map (h.Unit.app X)) = h.counit.app (L.obj X) :=
+  IsIso.inv_eq_of_hom_inv_id h.left_triangle_components
+#align category_theory.inv_map_unit CategoryTheory.inv_map_unit
+
+/-- If the unit is an isomorphism, bundle one has an isomorphism `L ⋙ R ⋙ L ≅ L`. -/
+@[simps]
+noncomputable def whiskerLeftLCounitIsoOfIsIsoUnit [IsIso h.Unit] : L ⋙ R ⋙ L ≅ L :=
+  (L.associator R L).symm ≪≫ isoWhiskerRight (asIso h.Unit).symm L ≪≫ Functor.leftUnitor _
+#align category_theory.whisker_left_L_counit_iso_of_is_iso_unit CategoryTheory.whiskerLeftLCounitIsoOfIsIsoUnit
+
+/-- If the counit of an adjunction is an isomorphism, then its inverse on the image of R is given
+by R whiskered with the unit. -/
+@[simp]
+theorem inv_counit_map {X : D} [IsIso (h.counit.app X)] :
+    inv (R.map (h.counit.app X)) = h.Unit.app (R.obj X) :=
+  IsIso.inv_eq_of_inv_hom_id h.right_triangle_components
+#align category_theory.inv_counit_map CategoryTheory.inv_counit_map
+
+/-- If the counit of an is an isomorphism, one has an isomorphism `(R ⋙ L ⋙ R) ≅ R`. -/
+@[simps]
+noncomputable def whiskerLeftRUnitIsoOfIsIsoCounit [IsIso h.counit] : R ⋙ L ⋙ R ≅ R :=
+  (R.associator L R).symm ≪≫ isoWhiskerRight (asIso h.counit) R ≪≫ Functor.leftUnitor _
+#align category_theory.whisker_left_R_unit_iso_of_is_iso_counit CategoryTheory.whiskerLeftRUnitIsoOfIsIsoCounit
+
+/-- If the unit is an isomorphism, then the left adjoint is full-/
+noncomputable def lFullOfUnitIsIso [IsIso h.Unit] : Full L
+    where preimage X Y f := h.homEquiv X (L.obj Y) f ≫ inv (h.Unit.app Y)
+#align category_theory.L_full_of_unit_is_iso CategoryTheory.lFullOfUnitIsIso
+
+/-- If the unit is an isomorphism, then the left adjoint is faithful-/
+theorem L_faithful_of_unit_isIso [IsIso h.Unit] : Faithful L :=
+  {
+    map_injective' := fun X Y f g H =>
+      by
+      rw [← (h.hom_equiv X (L.obj Y)).apply_eq_iff_eq] at H
+      simpa using H =≫ inv (h.unit.app Y) }
+#align category_theory.L_faithful_of_unit_is_iso CategoryTheory.L_faithful_of_unit_isIso
+
+/-- If the counit is an isomorphism, then the right adjoint is full-/
+noncomputable def rFullOfCounitIsIso [IsIso h.counit] : Full R
+    where preimage X Y f := inv (h.counit.app X) ≫ (h.homEquiv (R.obj X) Y).symm f
+#align category_theory.R_full_of_counit_is_iso CategoryTheory.rFullOfCounitIsIso
+
+/-- If the counit is an isomorphism, then the right adjoint is faithful-/
+theorem R_faithful_of_counit_isIso [IsIso h.counit] : Faithful R :=
+  {
+    map_injective' := fun X Y f g H =>
+      by
+      rw [← (h.hom_equiv (R.obj X) Y).symm.apply_eq_iff_eq] at H
+      simpa using inv (h.counit.app X) ≫= H }
+#align category_theory.R_faithful_of_counit_is_iso CategoryTheory.R_faithful_of_counit_isIso
+
+instance whiskerLeft_counit_iso_of_L_fully_faithful [Full L] [Faithful L] :
+    IsIso (whiskerLeft L h.counit) := by
+  have := h.left_triangle
+  rw [← is_iso.eq_inv_comp] at this
+  rw [this]
+  infer_instance
+#align category_theory.whisker_left_counit_iso_of_L_fully_faithful CategoryTheory.whiskerLeft_counit_iso_of_L_fully_faithful
+
+instance whiskerRight_counit_iso_of_L_fully_faithful [Full L] [Faithful L] :
+    IsIso (whiskerRight h.counit R) :=
+  by
+  have := h.right_triangle
+  rw [← is_iso.eq_inv_comp] at this
+  rw [this]
+  infer_instance
+#align category_theory.whisker_right_counit_iso_of_L_fully_faithful CategoryTheory.whiskerRight_counit_iso_of_L_fully_faithful
+
+instance whiskerLeft_unit_iso_of_R_fully_faithful [Full R] [Faithful R] :
+    IsIso (whiskerLeft R h.Unit) := by
+  have := h.right_triangle
+  rw [← is_iso.eq_comp_inv] at this
+  rw [this]
+  infer_instance
+#align category_theory.whisker_left_unit_iso_of_R_fully_faithful CategoryTheory.whiskerLeft_unit_iso_of_R_fully_faithful
+
+instance whiskerRight_unit_iso_of_R_fully_faithful [Full R] [Faithful R] :
+    IsIso (whiskerRight h.Unit L) := by
+  have := h.left_triangle
+  rw [← is_iso.eq_comp_inv] at this
+  rw [this]
+  infer_instance
+#align category_theory.whisker_right_unit_iso_of_R_fully_faithful CategoryTheory.whiskerRight_unit_iso_of_R_fully_faithful
+
+-- TODO also do the statements from Riehl 4.5.13 for full and faithful separately?
+universe v₃ v₄ u₃ u₄
+
+variable {C' : Type u₃} [Category.{v₃} C']
+
+variable {D' : Type u₄} [Category.{v₄} D']
+
+-- TODO: This needs some lemmas describing the produced adjunction, probably in terms of `adj`,
+-- `iC` and `iD`.
+/-- If `C` is a full subcategory of `C'` and `D` is a full subcategory of `D'`, then we can restrict
+an adjunction `L' ⊣ R'` where `L' : C' ⥤ D'` and `R' : D' ⥤ C'` to `C` and `D`.
+The construction here is slightly more general, in that `C` is required only to have a full and
+faithful "inclusion" functor `iC : C ⥤ C'` (and similarly `iD : D ⥤ D'`) which commute (up to
+natural isomorphism) with the proposed restrictions.
+-/
+def Adjunction.restrictFullyFaithful (iC : C ⥤ C') (iD : D ⥤ D') {L' : C' ⥤ D'} {R' : D' ⥤ C'}
+    (adj : L' ⊣ R') {L : C ⥤ D} {R : D ⥤ C} (comm1 : iC ⋙ L' ≅ L ⋙ iD) (comm2 : iD ⋙ R' ≅ R ⋙ iC)
+    [Full iC] [Faithful iC] [Full iD] [Faithful iD] : L ⊣ R :=
+  Adjunction.mkOfHomEquiv
+    { homEquiv := fun X Y =>
+        calc
+          (L.obj X ⟶ Y) ≃ (iD.obj (L.obj X) ⟶ iD.obj Y) := equivOfFullyFaithful iD
+          _ ≃ (L'.obj (iC.obj X) ⟶ iD.obj Y) := Iso.homCongr (comm1.symm.app X) (Iso.refl _)
+          _ ≃ (iC.obj X ⟶ R'.obj (iD.obj Y)) := adj.homEquiv _ _
+          _ ≃ (iC.obj X ⟶ iC.obj (R.obj Y)) := Iso.homCongr (Iso.refl _) (comm2.app Y)
+          _ ≃ (X ⟶ R.obj Y) := (equivOfFullyFaithful iC).symm
+          
+      homEquiv_naturality_left_symm := fun X' X Y f g =>
+        by
+        apply iD.map_injective
+        simpa using (comm1.inv.naturality_assoc f _).symm
+      homEquiv_naturality_right := fun X Y' Y f g =>
+        by
+        apply iC.map_injective
+        suffices : R'.map (iD.map g) ≫ comm2.hom.app Y = comm2.hom.app Y' ≫ iC.map (R.map g)
+        simp [this]
+        apply comm2.hom.naturality g }
+#align category_theory.adjunction.restrict_fully_faithful CategoryTheory.Adjunction.restrictFullyFaithful
+
+end CategoryTheory
+

--- a/Mathlib/CategoryTheory/Adjunction/FullyFaithful.lean
+++ b/Mathlib/CategoryTheory/Adjunction/FullyFaithful.lean
@@ -221,13 +221,12 @@ def Adjunction.restrictFullyFaithful (iC : C ⥤ C') (iD : D ⥤ D') {L' : C' �
 
       homEquiv_naturality_left_symm := fun {X' X Y} f g => by
         apply iD.map_injective
-        sorry --simpa using (comm1.inv.naturality_assoc f _).symm
+        simpa [Trans.trans] using (comm1.inv.naturality_assoc f _).symm
       homEquiv_naturality_right := fun {X Y' Y} f g => by
         apply iC.map_injective
         suffices : R'.map (iD.map g) ≫ comm2.hom.app Y = comm2.hom.app Y' ≫ iC.map (R.map g)
-        . sorry -- simp [this]
-        . apply comm2.hom.naturality g
-         }
+        . simp [Trans.trans, this]
+        . apply comm2.hom.naturality g }
 #align category_theory.adjunction.restrict_fully_faithful CategoryTheory.Adjunction.restrictFullyFaithful
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Adjunction/FullyFaithful.lean
+++ b/Mathlib/CategoryTheory/Adjunction/FullyFaithful.lean
@@ -18,7 +18,7 @@ import Mathlib.CategoryTheory.Yoneda
 A left adjoint is fully faithful, if and only if the unit is an isomorphism
 (and similarly for right adjoints and the counit).
 
-`adjunction.restrict_fully_faithful` shows that an adjunction can be restricted along fully faithful
+`Adjunction.restrictFullyFaithful` shows that an adjunction can be restricted along fully faithful
 inclusions.
 
 ## Future work
@@ -53,15 +53,22 @@ See
 instance unit_isIso_of_L_fully_faithful [Full L] [Faithful L] : IsIso (Adjunction.unit h) :=
   @NatIso.isIso_of_isIso_app _ _ _ _ _ _ (Adjunction.unit h) fun X =>
     @Yoneda.isIso _ _ _ _ ((Adjunction.unit h).app X)
-      ⟨⟨{ app := fun Y f => L.preimage ((h.homEquiv (unop Y) (L.obj X)).symm f) },
+      ⟨⟨{ app := fun Y f => L.preimage ((h.homEquiv (unop Y) (L.obj X)).symm f),
+          naturality := fun X Y f => by
+            funext x -- porting note: `aesop_cat` is not able to do `funext` automatically
+            aesop_cat },
           ⟨by
-            ext (x f); dsimp
+            ext x
+            funext f
             apply L.map_injective
-            simp, by
-            ext (x f); dsimp
-            simp only [adjunction.hom_equiv_counit, preimage_comp, preimage_map, category.assoc]
+            aesop_cat, by
+            ext x
+            funext f
+            dsimp
+            simp only [Adjunction.homEquiv_counit, preimage_comp, preimage_map, Category.assoc]
             rw [← h.unit_naturality]
             simp⟩⟩⟩
+set_option linter.uppercaseLean3 false in
 #align category_theory.unit_is_iso_of_L_fully_faithful CategoryTheory.unit_isIso_of_L_fully_faithful
 
 /-- If the right adjoint is fully faithful, then the counit is an isomorphism.
@@ -72,103 +79,117 @@ instance counit_isIso_of_R_fully_faithful [Full R] [Faithful R] : IsIso (Adjunct
   @NatIso.isIso_of_isIso_app _ _ _ _ _ _ (Adjunction.counit h) fun X =>
     @isIso_of_op _ _ _ _ _ <|
       @Coyoneda.isIso _ _ _ _ ((Adjunction.counit h).app X).op
-        ⟨⟨{ app := fun Y f => R.preimage ((h.homEquiv (R.obj X) Y) f) },
+        ⟨⟨{ app := fun Y f => R.preimage ((h.homEquiv (R.obj X) Y) f),
+            naturality := fun X Y f => by
+              funext x
+              aesop_cat },
             ⟨by
-              ext (x f); dsimp
+              ext x
+              funext f
               apply R.map_injective
               simp, by
-              ext (x f); dsimp
-              simp only [adjunction.hom_equiv_unit, preimage_comp, preimage_map]
+              ext x
+              funext f
+              dsimp
+              simp only [Adjunction.homEquiv_unit, preimage_comp, preimage_map]
               rw [← h.counit_naturality]
               simp⟩⟩⟩
+set_option linter.uppercaseLean3 false in
 #align category_theory.counit_is_iso_of_R_fully_faithful CategoryTheory.counit_isIso_of_R_fully_faithful
 
 /-- If the unit of an adjunction is an isomorphism, then its inverse on the image of L is given
 by L whiskered with the counit. -/
 @[simp]
-theorem inv_map_unit {X : C} [IsIso (h.Unit.app X)] :
-    inv (L.map (h.Unit.app X)) = h.counit.app (L.obj X) :=
+theorem inv_map_unit {X : C} [IsIso (h.unit.app X)] :
+    inv (L.map (h.unit.app X)) = h.counit.app (L.obj X) :=
   IsIso.inv_eq_of_hom_inv_id h.left_triangle_components
 #align category_theory.inv_map_unit CategoryTheory.inv_map_unit
 
 /-- If the unit is an isomorphism, bundle one has an isomorphism `L ⋙ R ⋙ L ≅ L`. -/
-@[simps]
-noncomputable def whiskerLeftLCounitIsoOfIsIsoUnit [IsIso h.Unit] : L ⋙ R ⋙ L ≅ L :=
-  (L.associator R L).symm ≪≫ isoWhiskerRight (asIso h.Unit).symm L ≪≫ Functor.leftUnitor _
+@[simps!]
+noncomputable def whiskerLeftLCounitIsoOfIsIsoUnit [IsIso h.unit] : L ⋙ R ⋙ L ≅ L :=
+  (L.associator R L).symm ≪≫ isoWhiskerRight (asIso h.unit).symm L ≪≫ Functor.leftUnitor _
+set_option linter.uppercaseLean3 false in
 #align category_theory.whisker_left_L_counit_iso_of_is_iso_unit CategoryTheory.whiskerLeftLCounitIsoOfIsIsoUnit
 
 /-- If the counit of an adjunction is an isomorphism, then its inverse on the image of R is given
 by R whiskered with the unit. -/
 @[simp]
 theorem inv_counit_map {X : D} [IsIso (h.counit.app X)] :
-    inv (R.map (h.counit.app X)) = h.Unit.app (R.obj X) :=
+    inv (R.map (h.counit.app X)) = h.unit.app (R.obj X) :=
   IsIso.inv_eq_of_inv_hom_id h.right_triangle_components
 #align category_theory.inv_counit_map CategoryTheory.inv_counit_map
 
 /-- If the counit of an is an isomorphism, one has an isomorphism `(R ⋙ L ⋙ R) ≅ R`. -/
-@[simps]
+@[simps!]
 noncomputable def whiskerLeftRUnitIsoOfIsIsoCounit [IsIso h.counit] : R ⋙ L ⋙ R ≅ R :=
   (R.associator L R).symm ≪≫ isoWhiskerRight (asIso h.counit) R ≪≫ Functor.leftUnitor _
+set_option linter.uppercaseLean3 false in
 #align category_theory.whisker_left_R_unit_iso_of_is_iso_counit CategoryTheory.whiskerLeftRUnitIsoOfIsIsoCounit
 
 /-- If the unit is an isomorphism, then the left adjoint is full-/
-noncomputable def lFullOfUnitIsIso [IsIso h.Unit] : Full L
-    where preimage X Y f := h.homEquiv X (L.obj Y) f ≫ inv (h.Unit.app Y)
+noncomputable def lFullOfUnitIsIso [IsIso h.unit] : Full L
+    where preimage {X Y} f := h.homEquiv _ (L.obj Y) f ≫ inv (h.unit.app Y)
+set_option linter.uppercaseLean3 false in
 #align category_theory.L_full_of_unit_is_iso CategoryTheory.lFullOfUnitIsIso
 
 /-- If the unit is an isomorphism, then the left adjoint is faithful-/
-theorem L_faithful_of_unit_isIso [IsIso h.Unit] : Faithful L :=
-  {
-    map_injective' := fun X Y f g H =>
-      by
-      rw [← (h.hom_equiv X (L.obj Y)).apply_eq_iff_eq] at H
-      simpa using H =≫ inv (h.unit.app Y) }
+theorem L_faithful_of_unit_isIso [IsIso h.unit] : Faithful L :=
+  ⟨fun {X Y f g} H => by
+    rw [← (h.homEquiv X (L.obj Y)).apply_eq_iff_eq] at H
+    simpa using H =≫ inv (h.unit.app Y)⟩
+set_option linter.uppercaseLean3 false in
 #align category_theory.L_faithful_of_unit_is_iso CategoryTheory.L_faithful_of_unit_isIso
 
 /-- If the counit is an isomorphism, then the right adjoint is full-/
 noncomputable def rFullOfCounitIsIso [IsIso h.counit] : Full R
-    where preimage X Y f := inv (h.counit.app X) ≫ (h.homEquiv (R.obj X) Y).symm f
+    where preimage {X Y} f := inv (h.counit.app X) ≫ (h.homEquiv (R.obj X) Y).symm f
+set_option linter.uppercaseLean3 false in
 #align category_theory.R_full_of_counit_is_iso CategoryTheory.rFullOfCounitIsIso
 
 /-- If the counit is an isomorphism, then the right adjoint is faithful-/
 theorem R_faithful_of_counit_isIso [IsIso h.counit] : Faithful R :=
-  {
-    map_injective' := fun X Y f g H =>
+  ⟨fun {X Y f g} H =>
       by
-      rw [← (h.hom_equiv (R.obj X) Y).symm.apply_eq_iff_eq] at H
-      simpa using inv (h.counit.app X) ≫= H }
+      rw [← (h.homEquiv (R.obj X) Y).symm.apply_eq_iff_eq] at H
+      simpa using inv (h.counit.app X) ≫= H⟩
+set_option linter.uppercaseLean3 false in
 #align category_theory.R_faithful_of_counit_is_iso CategoryTheory.R_faithful_of_counit_isIso
 
 instance whiskerLeft_counit_iso_of_L_fully_faithful [Full L] [Faithful L] :
     IsIso (whiskerLeft L h.counit) := by
   have := h.left_triangle
-  rw [← is_iso.eq_inv_comp] at this
+  rw [← IsIso.eq_inv_comp] at this
   rw [this]
   infer_instance
+set_option linter.uppercaseLean3 false in
 #align category_theory.whisker_left_counit_iso_of_L_fully_faithful CategoryTheory.whiskerLeft_counit_iso_of_L_fully_faithful
 
 instance whiskerRight_counit_iso_of_L_fully_faithful [Full L] [Faithful L] :
     IsIso (whiskerRight h.counit R) := by
   have := h.right_triangle
-  rw [← is_iso.eq_inv_comp] at this
+  rw [← IsIso.eq_inv_comp] at this
   rw [this]
   infer_instance
+set_option linter.uppercaseLean3 false in
 #align category_theory.whisker_right_counit_iso_of_L_fully_faithful CategoryTheory.whiskerRight_counit_iso_of_L_fully_faithful
 
 instance whiskerLeft_unit_iso_of_R_fully_faithful [Full R] [Faithful R] :
-    IsIso (whiskerLeft R h.Unit) := by
+    IsIso (whiskerLeft R h.unit) := by
   have := h.right_triangle
-  rw [← is_iso.eq_comp_inv] at this
+  rw [← IsIso.eq_comp_inv] at this
   rw [this]
   infer_instance
+set_option linter.uppercaseLean3 false in
 #align category_theory.whisker_left_unit_iso_of_R_fully_faithful CategoryTheory.whiskerLeft_unit_iso_of_R_fully_faithful
 
 instance whiskerRight_unit_iso_of_R_fully_faithful [Full R] [Faithful R] :
-    IsIso (whiskerRight h.Unit L) := by
+    IsIso (whiskerRight h.unit L) := by
   have := h.left_triangle
-  rw [← is_iso.eq_comp_inv] at this
+  rw [← IsIso.eq_comp_inv] at this
   rw [this]
   infer_instance
+set_option linter.uppercaseLean3 false in
 #align category_theory.whisker_right_unit_iso_of_R_fully_faithful CategoryTheory.whiskerRight_unit_iso_of_R_fully_faithful
 
 -- TODO also do the statements from Riehl 4.5.13 for full and faithful separately?
@@ -197,18 +218,16 @@ def Adjunction.restrictFullyFaithful (iC : C ⥤ C') (iD : D ⥤ D') {L' : C' �
           _ ≃ (iC.obj X ⟶ R'.obj (iD.obj Y)) := adj.homEquiv _ _
           _ ≃ (iC.obj X ⟶ iC.obj (R.obj Y)) := Iso.homCongr (Iso.refl _) (comm2.app Y)
           _ ≃ (X ⟶ R.obj Y) := (equivOfFullyFaithful iC).symm
-          
-      homEquiv_naturality_left_symm := fun X' X Y f g =>
-        by
+
+      homEquiv_naturality_left_symm := fun {X' X Y} f g => by
         apply iD.map_injective
-        simpa using (comm1.inv.naturality_assoc f _).symm
-      homEquiv_naturality_right := fun X Y' Y f g =>
-        by
+        sorry --simpa using (comm1.inv.naturality_assoc f _).symm
+      homEquiv_naturality_right := fun {X Y' Y} f g => by
         apply iC.map_injective
         suffices : R'.map (iD.map g) ≫ comm2.hom.app Y = comm2.hom.app Y' ≫ iC.map (R.map g)
-        simp [this]
-        apply comm2.hom.naturality g }
+        . sorry -- simp [this]
+        . apply comm2.hom.naturality g
+         }
 #align category_theory.adjunction.restrict_fully_faithful CategoryTheory.Adjunction.restrictFullyFaithful
 
 end CategoryTheory
-


### PR DESCRIPTION
---
Some automation failed for the `naturality` field of a natural transformation defined in `unit_isIso_of_L_fully_faithful`: `aesop_cat` fails, but `funext; aesop_cat` succeeds. Should the tactic `funext` be added to `aesop_cat`?
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
