### PR TITLE
[Merged by Bors] - feat(lint-style): add file name and line number to plaintext Github messages

### DIFF
--- a/Mathlib/Init/Data/Nat/Notation.lean
+++ b/Mathlib/Init/Data/Nat/Notation.lean
@@ -1,3 +1,4 @@
+/- This comment will trip up at least one, but probably multiple style linters by being long and at the start of the file -/
 /-
 Copyright (c) 2014 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.

--- a/Mathlib/Init/Data/Nat/Notation.lean
+++ b/Mathlib/Init/Data/Nat/Notation.lean
@@ -1,4 +1,3 @@
-/- This comment will trip up at least one, but probably multiple style linters by being long and at the start of the file -/
 /-
 Copyright (c) 2014 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.

--- a/scripts/lint-style.py
+++ b/scripts/lint-style.py
@@ -238,8 +238,8 @@ def output_message(path, line_nr, code, msg):
             msg_type = "error"
         if code.startswith("WRN"):
             msg_type = "warning"
-        # We are outputting for github. It doesn't appear to surface code, so show it in the message too
-        print(f"::{msg_type} file={path},line={line_nr},code={code}::{code}: {msg}")
+        # We are outputting for github. We duplicate path, line_nr and code, so that they are also visible in the plaintext output.
+        print(f"::{msg_type} file={path},line={line_nr},code={code}::{path}#{line_nr}: {code}: {msg}")
 
 def format_errors(errors):
     global new_exceptions

--- a/scripts/lint-style.py
+++ b/scripts/lint-style.py
@@ -238,8 +238,9 @@ def output_message(path, line_nr, code, msg):
             msg_type = "error"
         if code.startswith("WRN"):
             msg_type = "warning"
-        # We are outputting for github. We duplicate path, line_nr and code, so that they are also visible in the plaintext output.
-        print(f"::{msg_type} file={path},line={line_nr},code={code}::{path}#{line_nr}: {code}: {msg}")
+        # We are outputting for github. We duplicate path, line_nr and code,
+        # so that they are also visible in the plaintext output.
+        print(f"::{msg_type} file={path},line={line_nr},code={code}::{path}#L{line_nr}: {code}: {msg}")
 
 def format_errors(errors):
     global new_exceptions


### PR DESCRIPTION
New output example: https://github.com/leanprover-community/mathlib4/actions/runs/4252111790/jobs/7395295146

![image](https://user-images.githubusercontent.com/7376012/220894355-3268d167-ac3b-4ac1-867a-637f108b991b.png)


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
