### PR TITLE
[Merged by Bors] - feat: Port Combinatorics.SimpleGraph.StronglyRegular

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -317,6 +317,7 @@ import Mathlib.Combinatorics.SetFamily.LYM
 import Mathlib.Combinatorics.SetFamily.Shadow
 import Mathlib.Combinatorics.SimpleGraph.Basic
 import Mathlib.Combinatorics.SimpleGraph.Regularity.Equitabilise
+import Mathlib.Combinatorics.SimpleGraph.StronglyRegular
 import Mathlib.Combinatorics.Young.SemistandardTableau
 import Mathlib.Combinatorics.Young.YoungDiagram
 import Mathlib.Computability.DFA

--- a/Mathlib/Combinatorics/SimpleGraph/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Basic.lean
@@ -1286,6 +1286,13 @@ def degree : ℕ :=
   (G.neighborFinset v).card
 #align simple_graph.degree SimpleGraph.degree
 
+-- Porting note: in Lean 3 we could do `simp [← degree]`, but that gives
+-- "invalid '←' modifier, 'SimpleGraph.degree' is a declaration name to be unfolded".
+-- In any case, having this lemma is good since there's no guarantee we won't still change
+-- the definition of `degree`.
+@[simp]
+theorem card_neighborFinset_eq_degree : (G.neighborFinset v).card = G.degree v := rfl
+
 @[simp]
 theorem card_neighborSet_eq_degree : Fintype.card (G.neighborSet v) = G.degree v :=
   (Set.toFinset_card _).symm

--- a/Mathlib/Combinatorics/SimpleGraph/StronglyRegular.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/StronglyRegular.lean
@@ -86,7 +86,9 @@ theorem IsSRGWith.card_neighborFinset_union_eq {v w : V} (h : G.IsSRGWith n k �
       2 * k - Fintype.card (G.commonNeighbors v w) := by
   apply Nat.add_right_cancel (m := Fintype.card (G.commonNeighbors v w))
   rw [Nat.sub_add_cancel, ← Set.toFinset_card]
-  · simp [commonNeighbors, @Set.toFinset_inter _ _ _ _ (_) (_) (_),
+  -- porting note: Set.toFinset_inter needs workaround to use unification to solve for one of the
+  -- instance arguments:
+  · simp [commonNeighbors, @Set.toFinset_inter _ _ _ _ _ _ (_),
       ← neighborFinset_def, Finset.card_union_add_card_inter, card_neighborFinset_eq_degree,
       h.regular.degree_eq, two_mul]
   · apply le_trans (card_commonNeighbors_le_degree_left _ _ _)

--- a/Mathlib/Combinatorics/SimpleGraph/StronglyRegular.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/StronglyRegular.lean
@@ -1,0 +1,182 @@
+/-
+Copyright (c) 2021 Alena Gusakov. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Alena Gusakov
+
+! This file was ported from Lean 3 source module combinatorics.simple_graph.strongly_regular
+! leanprover-community/mathlib commit 2b35fc7bea4640cb75e477e83f32fbd538920822
+! Please do not edit these lines, except to modify the commit id
+! if you have ported upstream changes.
+-/
+import Mathbin.Combinatorics.SimpleGraph.Basic
+import Mathbin.Data.Set.Finite
+
+/-!
+# Strongly regular graphs
+
+## Main definitions
+
+* `G.is_SRG_with n k ℓ μ` (see `simple_graph.is_SRG_with`) is a structure for
+  a `simple_graph` satisfying the following conditions:
+  * The cardinality of the vertex set is `n`
+  * `G` is a regular graph with degree `k`
+  * The number of common neighbors between any two adjacent vertices in `G` is `ℓ`
+  * The number of common neighbors between any two nonadjacent vertices in `G` is `μ`
+
+## TODO
+- Prove that the parameters of a strongly regular graph
+  obey the relation `(n - k - 1) * μ = k * (k - ℓ - 1)`
+- Prove that if `I` is the identity matrix and `J` is the all-one matrix,
+  then the adj matrix `A` of SRG obeys relation `A^2 = kI + ℓA + μ(J - I - A)`
+-/
+
+
+open Finset
+
+universe u
+
+namespace SimpleGraph
+
+variable {V : Type u}
+
+variable [Fintype V] [DecidableEq V]
+
+variable (G : SimpleGraph V) [DecidableRel G.Adj]
+
+/-- A graph is strongly regular with parameters `n k ℓ μ` if
+ * its vertex set has cardinality `n`
+ * it is regular with degree `k`
+ * every pair of adjacent vertices has `ℓ` common neighbors
+ * every pair of nonadjacent vertices has `μ` common neighbors
+-/
+structure IsSRGWith (n k ℓ μ : ℕ) : Prop where
+  card : Fintype.card V = n
+  regular : G.IsRegularOfDegree k
+  of_adj : ∀ v w : V, G.Adj v w → Fintype.card (G.commonNeighbors v w) = ℓ
+  of_not_adj : ∀ v w : V, v ≠ w → ¬G.Adj v w → Fintype.card (G.commonNeighbors v w) = μ
+#align simple_graph.is_SRG_with SimpleGraph.IsSRGWith
+
+variable {G} {n k ℓ μ : ℕ}
+
+/-- Empty graphs are strongly regular. Note that `ℓ` can take any value
+  for empty graphs, since there are no pairs of adjacent vertices. -/
+theorem bot_strongly_regular : (⊥ : SimpleGraph V).IsSRGWith (Fintype.card V) 0 ℓ 0 :=
+  { card := rfl
+    regular := bot_degree
+    of_adj := fun v w h => h.elim
+    of_not_adj := fun v w h =>
+      by
+      simp only [card_eq_zero, filter_congr_decidable, Fintype.card_ofFinset, forall_true_left,
+        not_false_iff, bot_adj]
+      ext
+      simp [mem_common_neighbors] }
+#align simple_graph.bot_strongly_regular SimpleGraph.bot_strongly_regular
+
+/-- Complete graphs are strongly regular. Note that `μ` can take any value
+  for complete graphs, since there are no distinct pairs of non-adjacent vertices. -/
+theorem IsSRGWith.top :
+    (⊤ : SimpleGraph V).IsSRGWith (Fintype.card V) (Fintype.card V - 1) (Fintype.card V - 2) μ :=
+  { card := rfl
+    regular := IsRegularOfDegree.top
+    of_adj := fun v w h => by
+      rw [card_common_neighbors_top]
+      exact h
+    of_not_adj := fun v w h h' => False.elim <| by simpa using h }
+#align simple_graph.is_SRG_with.top SimpleGraph.IsSRGWith.top
+
+theorem IsSRGWith.card_neighborFinset_union_eq {v w : V} (h : G.IsSRGWith n k ℓ μ) :
+    (G.neighborFinset v ∪ G.neighborFinset w).card = 2 * k - Fintype.card (G.commonNeighbors v w) :=
+  by
+  apply @Nat.add_right_cancel _ (Fintype.card (G.common_neighbors v w))
+  rw [Nat.sub_add_cancel, ← Set.toFinset_card]
+  ·
+    simp [neighbor_finset, common_neighbors, Set.toFinset_inter, Finset.card_union_add_card_inter,
+      h.regular.degree_eq, two_mul]
+  · apply le_trans (card_common_neighbors_le_degree_left _ _ _)
+    simp [h.regular.degree_eq, two_mul]
+#align simple_graph.is_SRG_with.card_neighbor_finset_union_eq SimpleGraph.IsSRGWith.card_neighborFinset_union_eq
+
+/-- Assuming `G` is strongly regular, `2*(k + 1) - m` in `G` is the number of vertices that are
+  adjacent to either `v` or `w` when `¬G.adj v w`. So it's the cardinality of
+  `G.neighbor_set v ∪ G.neighbor_set w`. -/
+theorem IsSRGWith.card_neighborFinset_union_of_not_adj {v w : V} (h : G.IsSRGWith n k ℓ μ)
+    (hne : v ≠ w) (ha : ¬G.Adj v w) : (G.neighborFinset v ∪ G.neighborFinset w).card = 2 * k - μ :=
+  by
+  rw [← h.of_not_adj v w hne ha]
+  apply h.card_neighbor_finset_union_eq
+#align simple_graph.is_SRG_with.card_neighbor_finset_union_of_not_adj SimpleGraph.IsSRGWith.card_neighborFinset_union_of_not_adj
+
+theorem IsSRGWith.card_neighborFinset_union_of_adj {v w : V} (h : G.IsSRGWith n k ℓ μ)
+    (ha : G.Adj v w) : (G.neighborFinset v ∪ G.neighborFinset w).card = 2 * k - ℓ :=
+  by
+  rw [← h.of_adj v w ha]
+  apply h.card_neighbor_finset_union_eq
+#align simple_graph.is_SRG_with.card_neighbor_finset_union_of_adj SimpleGraph.IsSRGWith.card_neighborFinset_union_of_adj
+
+theorem compl_neighborFinset_sdiff_inter_eq {v w : V} :
+    G.neighborFinset vᶜ \ {v} ∩ (G.neighborFinset wᶜ \ {w}) =
+      (G.neighborFinset vᶜ ∩ G.neighborFinset wᶜ) \ ({w} ∪ {v}) :=
+  by
+  ext
+  rw [← not_iff_not]
+  simp [imp_iff_not_or, or_assoc', or_comm', or_left_comm]
+#align simple_graph.compl_neighbor_finset_sdiff_inter_eq SimpleGraph.compl_neighborFinset_sdiff_inter_eq
+
+theorem sdiff_compl_neighborFinset_inter_eq {v w : V} (h : G.Adj v w) :
+    (G.neighborFinset vᶜ ∩ G.neighborFinset wᶜ) \ ({w} ∪ {v}) =
+      G.neighborFinset vᶜ ∩ G.neighborFinset wᶜ :=
+  by
+  ext
+  simp only [and_imp, mem_union, mem_sdiff, mem_compl, and_iff_left_iff_imp, mem_neighbor_finset,
+    mem_inter, mem_singleton]
+  rintro hnv hnw (rfl | rfl)
+  · exact hnv h
+  · apply hnw
+    rwa [adj_comm]
+#align simple_graph.sdiff_compl_neighbor_finset_inter_eq SimpleGraph.sdiff_compl_neighborFinset_inter_eq
+
+theorem IsSRGWith.compl_is_regular (h : G.IsSRGWith n k ℓ μ) : Gᶜ.IsRegularOfDegree (n - k - 1) :=
+  by
+  rw [← h.card, Nat.sub_sub, add_comm, ← Nat.sub_sub]
+  exact h.regular.compl
+#align simple_graph.is_SRG_with.compl_is_regular SimpleGraph.IsSRGWith.compl_is_regular
+
+theorem IsSRGWith.card_commonNeighbors_eq_of_adj_compl (h : G.IsSRGWith n k ℓ μ) {v w : V}
+    (ha : Gᶜ.Adj v w) : Fintype.card ↥(Gᶜ.commonNeighbors v w) = n - (2 * k - μ) - 2 :=
+  by
+  simp only [← Set.toFinset_card, common_neighbors, Set.toFinset_inter, neighbor_set_compl,
+    Set.toFinset_diff, Set.toFinset_singleton, Set.toFinset_compl, ← neighbor_finset_def]
+  simp_rw [compl_neighbor_finset_sdiff_inter_eq]
+  have hne : v ≠ w := ne_of_adj _ ha
+  rw [compl_adj] at ha
+  rw [card_sdiff, ← insert_eq, card_insert_of_not_mem, card_singleton, ← Finset.compl_union]
+  · change 1 + 1 with 2
+    rw [card_compl, h.card_neighbor_finset_union_of_not_adj hne ha.2, ← h.card]
+  · simp only [hne.symm, not_false_iff, mem_singleton]
+  · intro u
+    simp only [mem_union, mem_compl, mem_neighbor_finset, mem_inter, mem_singleton]
+    rintro (rfl | rfl) <;> simpa [adj_comm] using ha.2
+#align simple_graph.is_SRG_with.card_common_neighbors_eq_of_adj_compl SimpleGraph.IsSRGWith.card_commonNeighbors_eq_of_adj_compl
+
+theorem IsSRGWith.card_commonNeighbors_eq_of_not_adj_compl (h : G.IsSRGWith n k ℓ μ) {v w : V}
+    (hn : v ≠ w) (hna : ¬Gᶜ.Adj v w) : Fintype.card ↥(Gᶜ.commonNeighbors v w) = n - (2 * k - ℓ) :=
+  by
+  simp only [← Set.toFinset_card, common_neighbors, Set.toFinset_inter, neighbor_set_compl,
+    Set.toFinset_diff, Set.toFinset_singleton, Set.toFinset_compl, ← neighbor_finset_def]
+  simp only [not_and, Classical.not_not, compl_adj] at hna
+  have h2' := hna hn
+  simp_rw [compl_neighbor_finset_sdiff_inter_eq, sdiff_compl_neighbor_finset_inter_eq h2']
+  rwa [← Finset.compl_union, card_compl, h.card_neighbor_finset_union_of_adj, ← h.card]
+#align simple_graph.is_SRG_with.card_common_neighbors_eq_of_not_adj_compl SimpleGraph.IsSRGWith.card_commonNeighbors_eq_of_not_adj_compl
+
+/-- The complement of a strongly regular graph is strongly regular. -/
+theorem IsSRGWith.compl (h : G.IsSRGWith n k ℓ μ) :
+    Gᶜ.IsSRGWith n (n - k - 1) (n - (2 * k - μ) - 2) (n - (2 * k - ℓ)) :=
+  { card := h.card
+    regular := h.compl_is_regular
+    of_adj := fun v w ha => h.card_commonNeighbors_eq_of_adj_compl ha
+    of_not_adj := fun v w hn hna => h.card_commonNeighbors_eq_of_not_adj_compl hn hna }
+#align simple_graph.is_SRG_with.compl SimpleGraph.IsSRGWith.compl
+
+end SimpleGraph
+

--- a/Mathlib/Combinatorics/SimpleGraph/StronglyRegular.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/StronglyRegular.lean
@@ -16,8 +16,8 @@ import Mathlib.Data.Set.Finite
 
 ## Main definitions
 
-* `G.is_SRG_with n k ℓ μ` (see `simple_graph.is_SRG_with`) is a structure for
-  a `simple_graph` satisfying the following conditions:
+* `G.IsSRGWith n k ℓ μ` (see `SimpleGraph.IsSRGWith`) is a structure for
+  a `SimpleGraph` satisfying the following conditions:
   * The cardinality of the vertex set is `n`
   * `G` is a regular graph with degree `k`
   * The number of common neighbors between any two adjacent vertices in `G` is `ℓ`
@@ -54,6 +54,7 @@ structure IsSRGWith (n k ℓ μ : ℕ) : Prop where
   regular : G.IsRegularOfDegree k
   of_adj : ∀ v w : V, G.Adj v w → Fintype.card (G.commonNeighbors v w) = ℓ
   of_not_adj : ∀ v w : V, v ≠ w → ¬G.Adj v w → Fintype.card (G.commonNeighbors v w) = μ
+set_option linter.uppercaseLean3 false in
 #align simple_graph.is_SRG_with SimpleGraph.IsSRGWith
 
 variable {G} {n k ℓ μ : ℕ}
@@ -64,12 +65,10 @@ theorem bot_strongly_regular : (⊥ : SimpleGraph V).IsSRGWith (Fintype.card V) 
   { card := rfl
     regular := bot_degree
     of_adj := fun v w h => h.elim
-    of_not_adj := fun v w h =>
-      by
-      simp only [card_eq_zero, filter_congr_decidable, Fintype.card_ofFinset, forall_true_left,
-        not_false_iff, bot_adj]
+    of_not_adj := fun v w _h => by
+      simp only [card_eq_zero, Fintype.card_ofFinset, forall_true_left, not_false_iff, bot_adj]
       ext
-      simp [mem_common_neighbors] }
+      simp [mem_commonNeighbors] }
 #align simple_graph.bot_strongly_regular SimpleGraph.bot_strongly_regular
 
 /-- Complete graphs are strongly regular. Note that `μ` can take any value
@@ -79,21 +78,22 @@ theorem IsSRGWith.top :
   { card := rfl
     regular := IsRegularOfDegree.top
     of_adj := fun v w h => by
-      rw [card_common_neighbors_top]
+      rw [card_commonNeighbors_top]
       exact h
-    of_not_adj := fun v w h h' => False.elim <| by simpa using h }
+    of_not_adj := fun v w h h' => False.elim (h' ((top_adj v w).2 h)) }
+set_option linter.uppercaseLean3 false in
 #align simple_graph.is_SRG_with.top SimpleGraph.IsSRGWith.top
 
 theorem IsSRGWith.card_neighborFinset_union_eq {v w : V} (h : G.IsSRGWith n k ℓ μ) :
     (G.neighborFinset v ∪ G.neighborFinset w).card = 2 * k - Fintype.card (G.commonNeighbors v w) :=
   by
-  apply @Nat.add_right_cancel _ (Fintype.card (G.common_neighbors v w))
+  apply @Nat.add_right_cancel _ (Fintype.card (G.commonNeighbors v w))
   rw [Nat.sub_add_cancel, ← Set.toFinset_card]
-  ·
-    simp [neighbor_finset, common_neighbors, Set.toFinset_inter, Finset.card_union_add_card_inter,
-      h.regular.degree_eq, two_mul]
-  · apply le_trans (card_common_neighbors_le_degree_left _ _ _)
+  · sorry
+    -- simp [neighborFinset, commonNeighbors, Set.toFinset_inter, Finset.card_union_add_card_inter, h.regular.degree_eq, two_mul]
+  · apply le_trans (card_commonNeighbors_le_degree_left _ _ _)
     simp [h.regular.degree_eq, two_mul]
+set_option linter.uppercaseLean3 false in
 #align simple_graph.is_SRG_with.card_neighbor_finset_union_eq SimpleGraph.IsSRGWith.card_neighborFinset_union_eq
 
 /-- Assuming `G` is strongly regular, `2*(k + 1) - m` in `G` is the number of vertices that are
@@ -103,13 +103,15 @@ theorem IsSRGWith.card_neighborFinset_union_of_not_adj {v w : V} (h : G.IsSRGWit
     (hne : v ≠ w) (ha : ¬G.Adj v w) : (G.neighborFinset v ∪ G.neighborFinset w).card = 2 * k - μ :=
   by
   rw [← h.of_not_adj v w hne ha]
-  apply h.card_neighbor_finset_union_eq
+  apply h.card_neighborFinset_union_eq
+set_option linter.uppercaseLean3 false in
 #align simple_graph.is_SRG_with.card_neighbor_finset_union_of_not_adj SimpleGraph.IsSRGWith.card_neighborFinset_union_of_not_adj
 
 theorem IsSRGWith.card_neighborFinset_union_of_adj {v w : V} (h : G.IsSRGWith n k ℓ μ)
     (ha : G.Adj v w) : (G.neighborFinset v ∪ G.neighborFinset w).card = 2 * k - ℓ := by
   rw [← h.of_adj v w ha]
-  apply h.card_neighbor_finset_union_eq
+  apply h.card_neighborFinset_union_eq
+set_option linter.uppercaseLean3 false in
 #align simple_graph.is_SRG_with.card_neighbor_finset_union_of_adj SimpleGraph.IsSRGWith.card_neighborFinset_union_of_adj
 
 theorem compl_neighborFinset_sdiff_inter_eq {v w : V} :
@@ -117,14 +119,14 @@ theorem compl_neighborFinset_sdiff_inter_eq {v w : V} :
       (G.neighborFinset vᶜ ∩ G.neighborFinset wᶜ) \ ({w} ∪ {v}) := by
   ext
   rw [← not_iff_not]
-  simp [imp_iff_not_or, or_assoc', or_comm', or_left_comm]
+  simp [imp_iff_not_or, or_assoc, or_comm, or_left_comm]
 #align simple_graph.compl_neighbor_finset_sdiff_inter_eq SimpleGraph.compl_neighborFinset_sdiff_inter_eq
 
 theorem sdiff_compl_neighborFinset_inter_eq {v w : V} (h : G.Adj v w) :
     (G.neighborFinset vᶜ ∩ G.neighborFinset wᶜ) \ ({w} ∪ {v}) =
       G.neighborFinset vᶜ ∩ G.neighborFinset wᶜ := by
   ext
-  simp only [and_imp, mem_union, mem_sdiff, mem_compl, and_iff_left_iff_imp, mem_neighbor_finset,
+  simp only [and_imp, mem_union, mem_sdiff, mem_compl, and_iff_left_iff_imp, mem_neighborFinset,
     mem_inter, mem_singleton]
   rintro hnv hnw (rfl | rfl)
   · exact hnv h
@@ -136,33 +138,35 @@ theorem IsSRGWith.compl_is_regular (h : G.IsSRGWith n k ℓ μ) : Gᶜ.IsRegular
   by
   rw [← h.card, Nat.sub_sub, add_comm, ← Nat.sub_sub]
   exact h.regular.compl
+set_option linter.uppercaseLean3 false in
 #align simple_graph.is_SRG_with.compl_is_regular SimpleGraph.IsSRGWith.compl_is_regular
 
 theorem IsSRGWith.card_commonNeighbors_eq_of_adj_compl (h : G.IsSRGWith n k ℓ μ) {v w : V}
-    (ha : Gᶜ.Adj v w) : Fintype.card ↥(Gᶜ.commonNeighbors v w) = n - (2 * k - μ) - 2 := by
-  simp only [← Set.toFinset_card, common_neighbors, Set.toFinset_inter, neighbor_set_compl,
-    Set.toFinset_diff, Set.toFinset_singleton, Set.toFinset_compl, ← neighbor_finset_def]
-  simp_rw [compl_neighbor_finset_sdiff_inter_eq]
+    (ha : Gᶜ.Adj v w) : Fintype.card (↥(Gᶜ.commonNeighbors v w)) = n - (2 * k - μ) - 2 := by
+  simp only [← Set.toFinset_card, commonNeighbors, Set.toFinset_inter, neighborSet_compl,
+    Set.toFinset_diff, Set.toFinset_singleton, Set.toFinset_compl, ← neighborFinset_def]
+  simp_rw [compl_neighborFinset_sdiff_inter_eq]
   have hne : v ≠ w := ne_of_adj _ ha
   rw [compl_adj] at ha
   rw [card_sdiff, ← insert_eq, card_insert_of_not_mem, card_singleton, ← Finset.compl_union]
-  · change 1 + 1 with 2
-    rw [card_compl, h.card_neighbor_finset_union_of_not_adj hne ha.2, ← h.card]
+  · rw [card_compl, h.card_neighborFinset_union_of_not_adj hne ha.2, ← h.card]
   · simp only [hne.symm, not_false_iff, mem_singleton]
   · intro u
-    simp only [mem_union, mem_compl, mem_neighbor_finset, mem_inter, mem_singleton]
+    simp only [mem_union, mem_compl, mem_neighborFinset, mem_inter, mem_singleton]
     rintro (rfl | rfl) <;> simpa [adj_comm] using ha.2
+set_option linter.uppercaseLean3 false in
 #align simple_graph.is_SRG_with.card_common_neighbors_eq_of_adj_compl SimpleGraph.IsSRGWith.card_commonNeighbors_eq_of_adj_compl
 
 theorem IsSRGWith.card_commonNeighbors_eq_of_not_adj_compl (h : G.IsSRGWith n k ℓ μ) {v w : V}
-    (hn : v ≠ w) (hna : ¬Gᶜ.Adj v w) : Fintype.card ↥(Gᶜ.commonNeighbors v w) = n - (2 * k - ℓ) :=
+    (hn : v ≠ w) (hna : ¬Gᶜ.Adj v w) : Fintype.card (↥(Gᶜ.commonNeighbors v w)) = n - (2 * k - ℓ) :=
   by
-  simp only [← Set.toFinset_card, common_neighbors, Set.toFinset_inter, neighbor_set_compl,
-    Set.toFinset_diff, Set.toFinset_singleton, Set.toFinset_compl, ← neighbor_finset_def]
+  simp only [← Set.toFinset_card, commonNeighbors, Set.toFinset_inter, neighborSet_compl,
+    Set.toFinset_diff, Set.toFinset_singleton, Set.toFinset_compl, ← neighborFinset_def]
   simp only [not_and, Classical.not_not, compl_adj] at hna
   have h2' := hna hn
-  simp_rw [compl_neighbor_finset_sdiff_inter_eq, sdiff_compl_neighbor_finset_inter_eq h2']
-  rwa [← Finset.compl_union, card_compl, h.card_neighbor_finset_union_of_adj, ← h.card]
+  simp_rw [compl_neighborFinset_sdiff_inter_eq, sdiff_compl_neighborFinset_inter_eq h2']
+  rwa [← Finset.compl_union, card_compl, h.card_neighborFinset_union_of_adj, ← h.card]
+set_option linter.uppercaseLean3 false in
 #align simple_graph.is_SRG_with.card_common_neighbors_eq_of_not_adj_compl SimpleGraph.IsSRGWith.card_commonNeighbors_eq_of_not_adj_compl
 
 /-- The complement of a strongly regular graph is strongly regular. -/
@@ -170,8 +174,9 @@ theorem IsSRGWith.compl (h : G.IsSRGWith n k ℓ μ) :
     Gᶜ.IsSRGWith n (n - k - 1) (n - (2 * k - μ) - 2) (n - (2 * k - ℓ)) :=
   { card := h.card
     regular := h.compl_is_regular
-    of_adj := fun v w ha => h.card_commonNeighbors_eq_of_adj_compl ha
-    of_not_adj := fun v w hn hna => h.card_commonNeighbors_eq_of_not_adj_compl hn hna }
+    of_adj := fun _v _w ha => h.card_commonNeighbors_eq_of_adj_compl ha
+    of_not_adj := fun _v _w hn hna => h.card_commonNeighbors_eq_of_not_adj_compl hn hna }
+set_option linter.uppercaseLean3 false in
 #align simple_graph.is_SRG_with.compl SimpleGraph.IsSRGWith.compl
 
 end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/StronglyRegular.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/StronglyRegular.lean
@@ -8,8 +8,8 @@ Authors: Alena Gusakov
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
-import Mathbin.Combinatorics.SimpleGraph.Basic
-import Mathbin.Data.Set.Finite
+import Mathlib.Combinatorics.SimpleGraph.Basic
+import Mathlib.Data.Set.Finite
 
 /-!
 # Strongly regular graphs
@@ -107,16 +107,14 @@ theorem IsSRGWith.card_neighborFinset_union_of_not_adj {v w : V} (h : G.IsSRGWit
 #align simple_graph.is_SRG_with.card_neighbor_finset_union_of_not_adj SimpleGraph.IsSRGWith.card_neighborFinset_union_of_not_adj
 
 theorem IsSRGWith.card_neighborFinset_union_of_adj {v w : V} (h : G.IsSRGWith n k ℓ μ)
-    (ha : G.Adj v w) : (G.neighborFinset v ∪ G.neighborFinset w).card = 2 * k - ℓ :=
-  by
+    (ha : G.Adj v w) : (G.neighborFinset v ∪ G.neighborFinset w).card = 2 * k - ℓ := by
   rw [← h.of_adj v w ha]
   apply h.card_neighbor_finset_union_eq
 #align simple_graph.is_SRG_with.card_neighbor_finset_union_of_adj SimpleGraph.IsSRGWith.card_neighborFinset_union_of_adj
 
 theorem compl_neighborFinset_sdiff_inter_eq {v w : V} :
     G.neighborFinset vᶜ \ {v} ∩ (G.neighborFinset wᶜ \ {w}) =
-      (G.neighborFinset vᶜ ∩ G.neighborFinset wᶜ) \ ({w} ∪ {v}) :=
-  by
+      (G.neighborFinset vᶜ ∩ G.neighborFinset wᶜ) \ ({w} ∪ {v}) := by
   ext
   rw [← not_iff_not]
   simp [imp_iff_not_or, or_assoc', or_comm', or_left_comm]
@@ -124,8 +122,7 @@ theorem compl_neighborFinset_sdiff_inter_eq {v w : V} :
 
 theorem sdiff_compl_neighborFinset_inter_eq {v w : V} (h : G.Adj v w) :
     (G.neighborFinset vᶜ ∩ G.neighborFinset wᶜ) \ ({w} ∪ {v}) =
-      G.neighborFinset vᶜ ∩ G.neighborFinset wᶜ :=
-  by
+      G.neighborFinset vᶜ ∩ G.neighborFinset wᶜ := by
   ext
   simp only [and_imp, mem_union, mem_sdiff, mem_compl, and_iff_left_iff_imp, mem_neighbor_finset,
     mem_inter, mem_singleton]
@@ -142,8 +139,7 @@ theorem IsSRGWith.compl_is_regular (h : G.IsSRGWith n k ℓ μ) : Gᶜ.IsRegular
 #align simple_graph.is_SRG_with.compl_is_regular SimpleGraph.IsSRGWith.compl_is_regular
 
 theorem IsSRGWith.card_commonNeighbors_eq_of_adj_compl (h : G.IsSRGWith n k ℓ μ) {v w : V}
-    (ha : Gᶜ.Adj v w) : Fintype.card ↥(Gᶜ.commonNeighbors v w) = n - (2 * k - μ) - 2 :=
-  by
+    (ha : Gᶜ.Adj v w) : Fintype.card ↥(Gᶜ.commonNeighbors v w) = n - (2 * k - μ) - 2 := by
   simp only [← Set.toFinset_card, common_neighbors, Set.toFinset_inter, neighbor_set_compl,
     Set.toFinset_diff, Set.toFinset_singleton, Set.toFinset_compl, ← neighbor_finset_def]
   simp_rw [compl_neighbor_finset_sdiff_inter_eq]

--- a/Mathlib/Combinatorics/SimpleGraph/StronglyRegular.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/StronglyRegular.lean
@@ -37,10 +37,7 @@ universe u
 
 namespace SimpleGraph
 
-variable {V : Type u}
-
-variable [Fintype V] [DecidableEq V]
-
+variable {V : Type u} [Fintype V] [DecidableEq V]
 variable (G : SimpleGraph V) [DecidableRel G.Adj]
 
 /-- A graph is strongly regular with parameters `n k ℓ μ` if
@@ -60,48 +57,49 @@ set_option linter.uppercaseLean3 false in
 variable {G} {n k ℓ μ : ℕ}
 
 /-- Empty graphs are strongly regular. Note that `ℓ` can take any value
-  for empty graphs, since there are no pairs of adjacent vertices. -/
-theorem bot_strongly_regular : (⊥ : SimpleGraph V).IsSRGWith (Fintype.card V) 0 ℓ 0 :=
-  { card := rfl
-    regular := bot_degree
-    of_adj := fun v w h => h.elim
-    of_not_adj := fun v w _h => by
-      simp only [card_eq_zero, Fintype.card_ofFinset, forall_true_left, not_false_iff, bot_adj]
-      ext
-      simp [mem_commonNeighbors] }
+for empty graphs, since there are no pairs of adjacent vertices. -/
+theorem bot_strongly_regular : (⊥ : SimpleGraph V).IsSRGWith (Fintype.card V) 0 ℓ 0 where
+  card := rfl
+  regular := bot_degree
+  of_adj := fun v w h => h.elim
+  of_not_adj := fun v w _h => by
+    simp only [card_eq_zero, Fintype.card_ofFinset, forall_true_left, not_false_iff, bot_adj]
+    ext
+    simp [mem_commonNeighbors]
 #align simple_graph.bot_strongly_regular SimpleGraph.bot_strongly_regular
 
 /-- Complete graphs are strongly regular. Note that `μ` can take any value
-  for complete graphs, since there are no distinct pairs of non-adjacent vertices. -/
+for complete graphs, since there are no distinct pairs of non-adjacent vertices. -/
 theorem IsSRGWith.top :
-    (⊤ : SimpleGraph V).IsSRGWith (Fintype.card V) (Fintype.card V - 1) (Fintype.card V - 2) μ :=
-  { card := rfl
-    regular := IsRegularOfDegree.top
-    of_adj := fun v w h => by
-      rw [card_commonNeighbors_top]
-      exact h
-    of_not_adj := fun v w h h' => False.elim (h' ((top_adj v w).2 h)) }
+    (⊤ : SimpleGraph V).IsSRGWith (Fintype.card V) (Fintype.card V - 1) (Fintype.card V - 2) μ where
+  card := rfl
+  regular := IsRegularOfDegree.top
+  of_adj := fun v w h => by
+    rw [card_commonNeighbors_top]
+    exact h
+  of_not_adj := fun v w h h' => False.elim (h' ((top_adj v w).2 h))
 set_option linter.uppercaseLean3 false in
 #align simple_graph.is_SRG_with.top SimpleGraph.IsSRGWith.top
 
 theorem IsSRGWith.card_neighborFinset_union_eq {v w : V} (h : G.IsSRGWith n k ℓ μ) :
-    (G.neighborFinset v ∪ G.neighborFinset w).card = 2 * k - Fintype.card (G.commonNeighbors v w) :=
-  by
-  apply @Nat.add_right_cancel _ (Fintype.card (G.commonNeighbors v w))
+    (G.neighborFinset v ∪ G.neighborFinset w).card =
+      2 * k - Fintype.card (G.commonNeighbors v w) := by
+  apply Nat.add_right_cancel (m := Fintype.card (G.commonNeighbors v w))
   rw [Nat.sub_add_cancel, ← Set.toFinset_card]
-  · sorry
-    -- simp [neighborFinset, commonNeighbors, Set.toFinset_inter, Finset.card_union_add_card_inter, h.regular.degree_eq, two_mul]
+  · simp [commonNeighbors, @Set.toFinset_inter _ _ _ _ (_) (_) (_),
+      ← neighborFinset_def, Finset.card_union_add_card_inter, card_neighborFinset_eq_degree,
+      h.regular.degree_eq, two_mul]
   · apply le_trans (card_commonNeighbors_le_degree_left _ _ _)
     simp [h.regular.degree_eq, two_mul]
 set_option linter.uppercaseLean3 false in
 #align simple_graph.is_SRG_with.card_neighbor_finset_union_eq SimpleGraph.IsSRGWith.card_neighborFinset_union_eq
 
 /-- Assuming `G` is strongly regular, `2*(k + 1) - m` in `G` is the number of vertices that are
-  adjacent to either `v` or `w` when `¬G.adj v w`. So it's the cardinality of
-  `G.neighbor_set v ∪ G.neighbor_set w`. -/
+adjacent to either `v` or `w` when `¬G.Adj v w`. So it's the cardinality of
+`G.neighborSet v ∪ G.neighborSet w`. -/
 theorem IsSRGWith.card_neighborFinset_union_of_not_adj {v w : V} (h : G.IsSRGWith n k ℓ μ)
-    (hne : v ≠ w) (ha : ¬G.Adj v w) : (G.neighborFinset v ∪ G.neighborFinset w).card = 2 * k - μ :=
-  by
+    (hne : v ≠ w) (ha : ¬G.Adj v w) :
+    (G.neighborFinset v ∪ G.neighborFinset w).card = 2 * k - μ := by
   rw [← h.of_not_adj v w hne ha]
   apply h.card_neighborFinset_union_eq
 set_option linter.uppercaseLean3 false in
@@ -134,8 +132,8 @@ theorem sdiff_compl_neighborFinset_inter_eq {v w : V} (h : G.Adj v w) :
     rwa [adj_comm]
 #align simple_graph.sdiff_compl_neighbor_finset_inter_eq SimpleGraph.sdiff_compl_neighborFinset_inter_eq
 
-theorem IsSRGWith.compl_is_regular (h : G.IsSRGWith n k ℓ μ) : Gᶜ.IsRegularOfDegree (n - k - 1) :=
-  by
+theorem IsSRGWith.compl_is_regular (h : G.IsSRGWith n k ℓ μ) :
+  Gᶜ.IsRegularOfDegree (n - k - 1) := by
   rw [← h.card, Nat.sub_sub, add_comm, ← Nat.sub_sub]
   exact h.regular.compl
 set_option linter.uppercaseLean3 false in
@@ -158,8 +156,8 @@ set_option linter.uppercaseLean3 false in
 #align simple_graph.is_SRG_with.card_common_neighbors_eq_of_adj_compl SimpleGraph.IsSRGWith.card_commonNeighbors_eq_of_adj_compl
 
 theorem IsSRGWith.card_commonNeighbors_eq_of_not_adj_compl (h : G.IsSRGWith n k ℓ μ) {v w : V}
-    (hn : v ≠ w) (hna : ¬Gᶜ.Adj v w) : Fintype.card (↥(Gᶜ.commonNeighbors v w)) = n - (2 * k - ℓ) :=
-  by
+    (hn : v ≠ w) (hna : ¬Gᶜ.Adj v w) :
+    Fintype.card (↥Gᶜ.commonNeighbors v w) = n - (2 * k - ℓ) := by
   simp only [← Set.toFinset_card, commonNeighbors, Set.toFinset_inter, neighborSet_compl,
     Set.toFinset_diff, Set.toFinset_singleton, Set.toFinset_compl, ← neighborFinset_def]
   simp only [not_and, Classical.not_not, compl_adj] at hna
@@ -171,13 +169,12 @@ set_option linter.uppercaseLean3 false in
 
 /-- The complement of a strongly regular graph is strongly regular. -/
 theorem IsSRGWith.compl (h : G.IsSRGWith n k ℓ μ) :
-    Gᶜ.IsSRGWith n (n - k - 1) (n - (2 * k - μ) - 2) (n - (2 * k - ℓ)) :=
-  { card := h.card
-    regular := h.compl_is_regular
-    of_adj := fun _v _w ha => h.card_commonNeighbors_eq_of_adj_compl ha
-    of_not_adj := fun _v _w hn hna => h.card_commonNeighbors_eq_of_not_adj_compl hn hna }
+    Gᶜ.IsSRGWith n (n - k - 1) (n - (2 * k - μ) - 2) (n - (2 * k - ℓ)) where
+  card := h.card
+  regular := h.compl_is_regular
+  of_adj := fun _v _w ha => h.card_commonNeighbors_eq_of_adj_compl ha
+  of_not_adj := fun _v _w hn hna => h.card_commonNeighbors_eq_of_not_adj_compl hn hna
 set_option linter.uppercaseLean3 false in
 #align simple_graph.is_SRG_with.compl SimpleGraph.IsSRGWith.compl
 
 end SimpleGraph
-


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

- [x] depends on: #1883 

Help wanted: One error left: This `simp` doesn't work. It's weird because if you guide lean, `rw` doesn't work, even if it looks the same. I guess it has something to do with `Quot.liftOn` which hide behind `dsimp [Finset.card, Multiset.card]`?

```lean
theorem h : card (Set.toFinset (neighborSet G v ∩ neighborSet G w)) = k := sorry
example : Fintype.card (G.commonNeighbors v w) = k := by
  rw [←Set.toFinset_card]
  unfold commonNeighbors
  have hh := @h V _ G _ k v w
  rw [←hh] --- Here 1
  congr    --- Here 2
  simp [Set.fintypeInterOfRight]
```

at Here 1: look the same but it's not.
```lean
⊢ card (Set.toFinset (neighborSet G v ∩ neighborSet G w)) =
  card (Set.toFinset (neighborSet G v ∩ neighborSet G w))
```
at Here 2:
```lean
⊢ (Subtype.fintype fun x => x ∈ neighborSet G v ∩ neighborSet G w) =
    Set.fintypeInterOfRight (neighborSet G v) (neighborSet G w)
```
[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
