### PR TITLE
[Merged by Bors] - feat(Data/Int/Units): If `z * w = 1`, then `z = w`

### DIFF
--- a/Mathlib/Data/Int/Units.lean
+++ b/Mathlib/Data/Int/Units.lean
@@ -62,6 +62,10 @@ theorem eq_one_or_neg_one_of_mul_eq_one' {z w : ℤ} (h : z * w = 1) :
       rcases eq_one_or_neg_one_of_mul_eq_one h' with (rfl | rfl) <;> tauto
 #align int.eq_one_or_neg_one_of_mul_eq_one' Int.eq_one_or_neg_one_of_mul_eq_one'
 
+theorem eq_of_mul_eq_one {z w : ℤ} (h : z * w = 1) : z = w :=
+(eq_one_or_neg_one_of_mul_eq_one' h).elim (and_imp.2 (·.trans ·.symm)) (and_imp.2 (·.trans ·.symm))
+#align int.eq_of_mul_eq_one Int.eq_of_mul_eq_one
+
 theorem mul_eq_one_iff_eq_one_or_neg_one {z w : ℤ} :
     z * w = 1 ↔ z = 1 ∧ w = 1 ∨ z = -1 ∧ w = -1 := by
   refine' ⟨eq_one_or_neg_one_of_mul_eq_one', fun h => Or.elim h (fun H => _) fun H => _⟩ <;>

--- a/Mathlib/Data/Int/Units.lean
+++ b/Mathlib/Data/Int/Units.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad
 
 ! This file was ported from Lean 3 source module data.int.units
-! leanprover-community/mathlib commit 70d50ecfd4900dd6d328da39ab7ebd516abe4025
+! leanprover-community/mathlib commit 641b6a82006416ec431b2987b354af9311fed4f2
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/

--- a/Mathlib/Data/Int/Units.lean
+++ b/Mathlib/Data/Int/Units.lean
@@ -63,7 +63,8 @@ theorem eq_one_or_neg_one_of_mul_eq_one' {z w : ℤ} (h : z * w = 1) :
 #align int.eq_one_or_neg_one_of_mul_eq_one' Int.eq_one_or_neg_one_of_mul_eq_one'
 
 theorem eq_of_mul_eq_one {z w : ℤ} (h : z * w = 1) : z = w :=
-  (eq_one_or_neg_one_of_mul_eq_one' h).elim (and_imp.2 (·.trans ·.symm)) (and_imp.2 (·.trans ·.symm))
+  (eq_one_or_neg_one_of_mul_eq_one' h).elim 
+    (and_imp.2 (·.trans ·.symm)) (and_imp.2 (·.trans ·.symm))
 #align int.eq_of_mul_eq_one Int.eq_of_mul_eq_one
 
 theorem mul_eq_one_iff_eq_one_or_neg_one {z w : ℤ} :

--- a/Mathlib/Data/Int/Units.lean
+++ b/Mathlib/Data/Int/Units.lean
@@ -63,7 +63,7 @@ theorem eq_one_or_neg_one_of_mul_eq_one' {z w : ℤ} (h : z * w = 1) :
 #align int.eq_one_or_neg_one_of_mul_eq_one' Int.eq_one_or_neg_one_of_mul_eq_one'
 
 theorem eq_of_mul_eq_one {z w : ℤ} (h : z * w = 1) : z = w :=
-(eq_one_or_neg_one_of_mul_eq_one' h).elim (and_imp.2 (·.trans ·.symm)) (and_imp.2 (·.trans ·.symm))
+  (eq_one_or_neg_one_of_mul_eq_one' h).elim (and_imp.2 (·.trans ·.symm)) (and_imp.2 (·.trans ·.symm))
 #align int.eq_of_mul_eq_one Int.eq_of_mul_eq_one
 
 theorem mul_eq_one_iff_eq_one_or_neg_one {z w : ℤ} :


### PR DESCRIPTION
This PR adds a lemma stating that if `z * w = 1`, then `z = w`.

mathlib PR: https://github.com/leanprover-community/mathlib/pull/18499

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
