### PR TITLE
[Merged by Bors] - chore: update SHAs, forward-port

### DIFF
--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Parikshit Khanna, Jeremy Avigad, Leonardo de Moura, Floris van Doorn, Mario Carneiro
 
 ! This file was ported from Lean 3 source module data.list.basic
-! leanprover-community/mathlib commit cf9386b56953fb40904843af98b7a80757bbe7f9
+! leanprover-community/mathlib commit 1447cae870f372074e480de1acbeb51de0077698
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/

--- a/Mathlib/Data/List/Infix.lean
+++ b/Mathlib/Data/List/Infix.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 
 ! This file was ported from Lean 3 source module data.list.infix
-! leanprover-community/mathlib commit 6d0adfa76594f304b4650d098273d4366edeb61b
+! leanprover-community/mathlib commit 26f081a2fb920140ed5bc5cc5344e84bcc7cb2b2
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -342,6 +342,20 @@ theorem mem_of_mem_take (h : a ∈ l.take n) : a ∈ l :=
 #align list.mem_of_mem_take List.mem_of_mem_take
 
 #align list.mem_of_mem_drop List.mem_of_mem_drop
+
+lemma dropSlice_sublist (n m : ℕ) (l : List α) : l.dropSlice n m <+ l :=
+  calc l.dropSlice n m = take n l ++ drop m (drop n l) := by rw [dropSlice_eq, drop_drop, add_comm]
+  _ <+ take n l ++ drop n l := (Sublist.refl _).append (drop_sublist _ _)
+  _ = _ := take_append_drop _ _
+#align list.slice_sublist List.dropSlice_sublist
+
+lemma dropSlice_subset (n m : ℕ) (l : List α) : l.dropSlice n m ⊆ l :=
+  (dropSlice_sublist n m l).subset
+#align list.slice_subset List.dropSlice_subset
+
+lemma mem_of_mem_dropSlice {n m : ℕ} {l : List α} {a : α} (h : a ∈ l.dropSlice n m) : a ∈ l :=
+  dropSlice_subset n m l h
+#align list.mem_of_mem_slice List.mem_of_mem_dropSlice
 
 theorem takeWhile_prefix (p : α → Bool) : l.takeWhile p <+: l :=
   ⟨l.dropWhile p, takeWhile_append_drop p l⟩

--- a/Mathlib/Data/List/OfFn.lean
+++ b/Mathlib/Data/List/OfFn.lean
@@ -4,13 +4,13 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 
 ! This file was ported from Lean 3 source module data.list.of_fn
-! leanprover-community/mathlib commit fd838fdf07a83ca89fb66d30bebf6f0e02908c3f
+! leanprover-community/mathlib commit bf27744463e9620ca4e4ebe951fe83530ae6949b
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
 import Mathlib.Data.Fin.Tuple.Basic
-import Mathlib.Data.List.Basic
 import Mathlib.Data.List.Join
+import Mathlib.Data.List.Pairwise
 
 /-!
 # Lists from functions
@@ -20,12 +20,11 @@ of length `n`.
 
 ## Main Statements
 
-The main statements pertain to lists generated using `of_fn`
+The main statements pertain to lists generated using `List.ofFn`
 
 - `List.length_ofFn`, which tells us the length of such a list
-- `List.nth_ofFn`, which tells us the nth element of such a list
-- `List.array_eq_ofFn`, which interprets the list form of an array as such a list.
-- `List.equiv_sigma_tuple`, which is an `Equiv` between lists and the functions that generate them
+- `List.get?_ofFn`, which tells us the nth element of such a list
+- `List.equivSigmaTuple`, which is an `Equiv` between lists and the functions that generate them
   via `List.ofFn`.
 -/
 
@@ -242,10 +241,16 @@ theorem ofFn_fin_repeat {m} (a : Fin m → α) (n : ℕ) :
     Nat.add_mul_mod_self_right, Nat.mod_eq_of_lt (Fin.is_lt _)]
 #align list.of_fn_fin_repeat List.ofFn_fin_repeat
 
+@[simp]
+theorem pairwise_ofFn {R : α → α → Prop} {n} {f : Fin n → α} :
+    (ofFn f).Pairwise R ↔ ∀ ⦃i j⦄, i < j → R (f i) (f j) := by
+  simp only [pairwise_iff_get, (Fin.cast (length_ofFn f)).surjective.forall, get_ofFn,
+    OrderIso.lt_iff_lt]
+#align list.pairwise_of_fn List.pairwise_ofFn
+
 /-- Lists are equivalent to the sigma type of tuples of a given length. -/
 @[simps]
-def equivSigmaTuple : List α ≃ Σn, Fin n → α
-    where
+def equivSigmaTuple : List α ≃ Σn, Fin n → α where
   toFun l := ⟨l.length, l.get⟩
   invFun f := List.ofFn f.2
   left_inv := List.ofFn_get

--- a/Mathlib/Data/Nat/Choose/Dvd.lean
+++ b/Mathlib/Data/Nat/Choose/Dvd.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes, Patrick Stevens
 
 ! This file was ported from Lean 3 source module data.nat.choose.dvd
-! leanprover-community/mathlib commit 207cfac9fcd06138865b5d04f7091e46d9320432
+! leanprover-community/mathlib commit 966e0cf0685c9cedf8a3283ac69eef4d5f2eaca2
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/

--- a/Mathlib/Data/Part.lean
+++ b/Mathlib/Data/Part.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Jeremy Avigad, Simon Hudon
 
 ! This file was ported from Lean 3 source module data.part
-! leanprover-community/mathlib commit ee0c179cd3c8a45aa5bffbf1b41d8dbede452865
+! leanprover-community/mathlib commit 80c43012d26f63026d362c3aba28f3c3bafb07e6
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -14,7 +14,7 @@ import Mathlib.Logic.Equiv.Defs
 /-!
 # Partial values of a type
 This file defines `Part α`, the partial values of a type.
-`o : Part α` carries a proposition `o.dom`, its domain, along with a function `get : o.dom → α`, its
+`o : Part α` carries a proposition `o.Dom`, its domain, along with a function `get : o.Dom → α`, its
 value. The rule is then that every partial value has a value but, to access it, you need to provide
 a proof of the domain.
 `Part α` behaves the same as `Option α` except that `o : Option α` is decidably `none` or `some a`
@@ -38,7 +38,7 @@ Monadic structure:
 * `Part.map`: Maps the value and keeps the same domain.
 Other:
 * `Part.restrict`: `Part.restrict p o` replaces the domain of `o : Part α` by `p : Prop` so long as
-  `p → o.dom`.
+  `p → o.Dom`.
 * `Part.assert`: `assert p f` appends `p` to the domains of the values of a partial function.
 * `Part.unwrap`: Gets the value of a partial value regardless of its domain. Unsound.
 ## Notation

--- a/Mathlib/Data/Set/Finite.lean
+++ b/Mathlib/Data/Set/Finite.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro, Kyle Miller
 
 ! This file was ported from Lean 3 source module data.set.finite
-! leanprover-community/mathlib commit 1126441d6bccf98c81214a0780c73d499f6721fe
+! leanprover-community/mathlib commit 1f0096e6caa61e9c849ec2adbd227e960e9dff58
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/

--- a/Mathlib/GroupTheory/GroupAction/Opposite.lean
+++ b/Mathlib/GroupTheory/GroupAction/Opposite.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Eric Wieser
 
 ! This file was ported from Lean 3 source module group_theory.group_action.opposite
-! leanprover-community/mathlib commit fc2ed6f838ce7c9b7c7171e58d78eaf7b438fb0e
+! leanprover-community/mathlib commit 4330aae21f538b862f8aead371cfb6ee556398f1
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -126,6 +126,7 @@ instance Semigroup.opposite_smulCommClass' [Semigroup α] : SMulCommClass α α�
 #align semigroup.opposite_smul_comm_class' Semigroup.opposite_smulCommClass'
 #align add_semigroup.opposite_vadd_comm_class' AddSemigroup.opposite_vaddCommClass'
 
+@[to_additive]
 instance CommSemigroup.isCentralScalar [CommSemigroup α] : IsCentralScalar α α :=
   ⟨fun _ _ => mul_comm _ _⟩
 #align comm_semigroup.is_central_scalar CommSemigroup.isCentralScalar

--- a/Mathlib/Order/Bounds/Basic.lean
+++ b/Mathlib/Order/Bounds/Basic.lean
@@ -3,7 +3,7 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Yury Kudryashov
 ! This file was ported from Lean 3 source module order.bounds.basic
-! leanprover-community/mathlib commit aba57d4d3dae35460225919dcd82fe91355162f9
+! leanprover-community/mathlib commit 3310acfa9787aa171db6d4cba3945f6f275fe9f2
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/

--- a/Mathlib/SetTheory/Lists.lean
+++ b/Mathlib/SetTheory/Lists.lean
@@ -39,7 +39,8 @@ This calls for a two-steps definition of ZFA lists:
 * `Lists' α true`: Proper ZFA prelists. Defined inductively from the empty ZFA prelist
   (`Lists'.nil`) and from appending a ZFA prelist to a proper ZFA prelist (`Lists'.cons a l`).
 * `Lists α`: ZFA lists. Sum of the atoms and proper ZFA prelists.
-* `Finsets α`: ZFA sets. Defined as `Lists` quotiented by `Lists.Equiv`, the extensional equivalence.
+* `Finsets α`: ZFA sets. Defined as `Lists` quotiented by `Lists.Equiv`, the extensional
+  equivalence.
 -/
 
 

--- a/Mathlib/SetTheory/Lists.lean
+++ b/Mathlib/SetTheory/Lists.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 
 ! This file was ported from Lean 3 source module set_theory.lists
-! leanprover-community/mathlib commit 9003f28797c0664a49e4179487267c494477d853
+! leanprover-community/mathlib commit 497d1e06409995dd8ec95301fa8d8f3480187f4c
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -39,11 +39,8 @@ This calls for a two-steps definition of ZFA lists:
 * `Lists' α true`: Proper ZFA prelists. Defined inductively from the empty ZFA prelist
   (`Lists'.nil`) and from appending a ZFA prelist to a proper ZFA prelist (`Lists'.cons a l`).
 * `Lists α`: ZFA lists. Sum of the atoms and proper ZFA prelists.
-
-## TODO
-
-The next step is to define ZFA sets as lists quotiented by `Lists.Equiv`.
-(-/
+* `Finsets α`: ZFA sets. Defined as `Lists` quotiented by `Lists.Equiv`, the extensional equivalence.
+-/
 
 
 variable {α : Type _}


### PR DESCRIPTION
Also fix some module docstrings.

* [`data.part`@`ee0c179cd3c8a45aa5bffbf1b41d8dbede452865`..`80c43012d26f63026d362c3aba28f3c3bafb07e6`](https://leanprover-community.github.io/mathlib-port-status/file/data/part?range=ee0c179cd3c8a45aa5bffbf1b41d8dbede452865..80c43012d26f63026d362c3aba28f3c3bafb07e6)
* [`order.bounds.basic`@`aba57d4d3dae35460225919dcd82fe91355162f9`..`3310acfa9787aa171db6d4cba3945f6f275fe9f2`](https://leanprover-community.github.io/mathlib-port-status/file/order/bounds/basic?range=aba57d4d3dae35460225919dcd82fe91355162f9..3310acfa9787aa171db6d4cba3945f6f275fe9f2)
* [`data.list.of_fn`@`fd838fdf07a83ca89fb66d30bebf6f0e02908c3f`..`bf27744463e9620ca4e4ebe951fe83530ae6949b`](https://leanprover-community.github.io/mathlib-port-status/file/data/list/of_fn?range=fd838fdf07a83ca89fb66d30bebf6f0e02908c3f..bf27744463e9620ca4e4ebe951fe83530ae6949b)
* [`data.set.finite`@`1126441d6bccf98c81214a0780c73d499f6721fe`..`1f0096e6caa61e9c849ec2adbd227e960e9dff58`](https://leanprover-community.github.io/mathlib-port-status/file/data/set/finite?range=1126441d6bccf98c81214a0780c73d499f6721fe..1f0096e6caa61e9c849ec2adbd227e960e9dff58)
* [`group_theory.group_action.opposite`@`fc2ed6f838ce7c9b7c7171e58d78eaf7b438fb0e`..`4330aae21f538b862f8aead371cfb6ee556398f1`](https://leanprover-community.github.io/mathlib-port-status/file/group_theory/group_action/opposite?range=fc2ed6f838ce7c9b7c7171e58d78eaf7b438fb0e..4330aae21f538b862f8aead371cfb6ee556398f1)
* [`data.list.basic`@`cf9386b56953fb40904843af98b7a80757bbe7f9`..`1447cae870f372074e480de1acbeb51de0077698`](https://leanprover-community.github.io/mathlib-port-status/file/data/list/basic?range=cf9386b56953fb40904843af98b7a80757bbe7f9..1447cae870f372074e480de1acbeb51de0077698)
* [`data.list.infix`@`6d0adfa76594f304b4650d098273d4366edeb61b`..`26f081a2fb920140ed5bc5cc5344e84bcc7cb2b2`](https://leanprover-community.github.io/mathlib-port-status/file/data/list/infix?range=6d0adfa76594f304b4650d098273d4366edeb61b..26f081a2fb920140ed5bc5cc5344e84bcc7cb2b2)
* [`set_theory.lists`@`9003f28797c0664a49e4179487267c494477d853`..`497d1e06409995dd8ec95301fa8d8f3480187f4c`](https://leanprover-community.github.io/mathlib-port-status/file/set_theory/lists?range=9003f28797c0664a49e4179487267c494477d853..497d1e06409995dd8ec95301fa8d8f3480187f4c)
* [`data.nat.choose.dvd`@`207cfac9fcd06138865b5d04f7091e46d9320432`..`966e0cf0685c9cedf8a3283ac69eef4d5f2eaca2`](https://leanprover-community.github.io/mathlib-port-status/file/data/nat/choose/dvd?range=207cfac9fcd06138865b5d04f7091e46d9320432..966e0cf0685c9cedf8a3283ac69eef4d5f2eaca2)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)