### PR TITLE
chore: Switch to more succinct sigma notation

### DIFF
--- a/Mathlib/Data/QPF/Multivariate/Constructions/Sigma.lean
+++ b/Mathlib/Data/QPF/Multivariate/Constructions/Sigma.lean
@@ -29,8 +29,7 @@ variable (F : A → TypeVec.{u} n → Type u)
 /-- Dependent sum of of an `n`-ary functor. The sum can range over
 data types like `ℕ` or over `Type.{u-1}` -/
 def Sigma (v : TypeVec.{u} n) : Type u :=
-  -- Porting note: replaced Σα : A, F α v with_root_.Sigma fun α : A => F α v
-  _root_.Sigma fun α : A => F α v
+  Σα : A, F α v
 #align mvqpf.sigma MvQPF.Sigma
 
 /-- Dependent product of of an `n`-ary functor. The sum can range over
@@ -57,8 +56,7 @@ variable [∀ α, MvQPF <| F α]
 
 /-- polynomial functor representation of a dependent sum -/
 protected def P : MvPFunctor n :=
-  -- Porting note, replaced Σ with _root_.Sigma
-  ⟨_root_.Sigma fun a => (P (F a)).A, fun x => (P (F x.1)).B x.2⟩
+  ⟨Σ a, (P (F a)).A, fun x => (P (F x.1)).B x.2⟩
 set_option linter.uppercaseLean3 false in
 #align mvqpf.sigma.P MvQPF.Sigma.P
 
@@ -92,8 +90,7 @@ variable [∀ α, MvQPF <| F α]
 
 /-- polynomial functor representation of a dependent product -/
 protected def P : MvPFunctor n :=
-  -- Porting note: _root_.Sigma
-  ⟨∀ a, (P (F a)).A, fun x i => _root_.Sigma fun a : A => (P (F a)).B (x a) i⟩
+  ⟨∀ a, (P (F a)).A, fun x i => Σ a : A, (P (F a)).B (x a) i⟩
 set_option linter.uppercaseLean3 false in
 #align mvqpf.pi.P MvQPF.Pi.P
 


### PR DESCRIPTION
With the Sigma hygiene problem fixed, we can switch back to using the notation, instead of `_root_.Sigma`

https://github.com/leanprover/lean4/commit/3f6c5f17db30c2a2dcaca1b9e9faec4e2cf04b95 
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
