### PR TITLE
chore: generalize cache

### DIFF
--- a/Cache/Config.lean
+++ b/Cache/Config.lean
@@ -1,0 +1,37 @@
+import Lean.Data.RBMap
+import Lean.Data.Json
+
+open System (FilePath mkFilePath)
+open Lean (Json RBMap)
+
+namespace Cache.Config
+
+def FILE : FilePath :=
+  ⟨"cache-config.json"⟩
+
+structure Config where
+  url : String
+  head : FilePath
+  builds: RBMap String FilePath compare
+
+def load : IO $ Except String Config := do
+  if !(← FILE.pathExists) then return .error s!"{FILE} not found"
+  let json ← match Json.parse (← IO.FS.readFile FILE) with
+    | .ok json => pure json
+    | .error e => return .error s!"Error when parsing {FILE}: {e}"
+  match json with
+  | .obj x =>
+    let some $ .str url := x.find compare "url"
+      | return .error s!"{FILE} is missing the \"url\" (string) field"
+    let some $ .str head := x.find compare "head"
+      | return .error s!"{FILE} is missing the \"head\" (string) field"
+    let some $ .obj builds := x.find compare "builds"
+      | return .error s!"{FILE} is missing the \"builds\" (object) field"
+    let mut builds' := default
+    for pair in builds.toArray do
+      let .str path := pair.2 | return .error s!"Error when reading the build path for {pair.1}"
+      builds' := builds'.insert pair.1 (mkFilePath $ path.splitOn "/")
+    return .ok ⟨url, ⟨head⟩, builds'⟩
+  | _ => return .error s!"Invalid formatting for {FILE}"
+
+end Cache.Config

--- a/Cache/Config.lean
+++ b/Cache/Config.lean
@@ -4,19 +4,24 @@ import Lean.Data.Json
 open System (FilePath mkFilePath)
 open Lean (Json RBMap)
 
-namespace Cache.Config
+namespace Cache
 
-def FILE : FilePath :=
-  ⟨"cache-config.json"⟩
+abbrev PkgDirs := Lean.RBMap String FilePath compare
 
 structure Config where
   url : String
   head : FilePath
   rootRef : FilePath
-  buildDirs: RBMap String FilePath compare
+  tokenEnvVar : String
+  pkgDirs: PkgDirs
+
+namespace Config
+
+def FILE : FilePath :=
+  ⟨"cache-config.json"⟩
 
 @[inline] def Config.getBuildDir (cfg : Config) (k : String) : Option FilePath :=
-  cfg.buildDirs.find? k
+  cfg.pkgDirs.find? k
 
 def load : IO $ Except String Config := do
   if !(← FILE.pathExists) then return .error s!"{FILE} not found"
@@ -31,13 +36,15 @@ def load : IO $ Except String Config := do
       | return .error s!"{FILE} is missing the \"head\" (string) field"
     let some $ .str rootRef := x.find compare "rootRef"
       | return .error s!"{FILE} is missing the \"rootRef\" (string) field"
-    let some $ .obj buildDirs := x.find compare "buildDirs"
-      | return .error s!"{FILE} is missing the \"buildDirs\" (object) field"
-    let mut buildDirs' := default
-    for pair in buildDirs.toArray do
+    let some $ .str tokenEnvVar := x.find compare "tokenEnvVar"
+      | return .error s!"{FILE} is missing the \"tokenEnvVar\" (string) field"
+    let some $ .obj pkgDirs := x.find compare "pkgDirs"
+      | return .error s!"{FILE} is missing the \"pkgDirs\" (object) field"
+    let mut pkgDirs' := default
+    for pair in pkgDirs.toArray do
       let .str path := pair.2 | return .error s!"Error when reading the build path for {pair.1}"
-      buildDirs' := buildDirs'.insert pair.1 (mkFilePath $ path.splitOn "/")
-    return .ok ⟨url, ⟨head⟩, mkFilePath $ rootRef.splitOn "/", buildDirs'⟩
+      pkgDirs' := pkgDirs'.insert pair.1 (mkFilePath $ path.splitOn "/")
+    return .ok ⟨url, ⟨head⟩, mkFilePath $ rootRef.splitOn "/", tokenEnvVar, pkgDirs'⟩
   | _ => return .error s!"Invalid formatting for {FILE}"
 
 end Cache.Config

--- a/Cache/Config.lean
+++ b/Cache/Config.lean
@@ -11,20 +11,54 @@ abbrev PkgDirs := Lean.RBMap String FilePath compare
 structure Config where
   url : String
   head : FilePath
-  rootRef : FilePath
+  rootDir : FilePath
   tokenEnvVar : String
   pkgDirs: PkgDirs
 
 namespace Config
 
+@[inline] def getBuildDir (cfg : Config) (k : String) : Option FilePath :=
+  cfg.pkgDirs.find? k
+
 def FILE : FilePath :=
   ⟨"cache-config.json"⟩
 
-@[inline] def Config.getBuildDir (cfg : Config) (k : String) : Option FilePath :=
-  cfg.pkgDirs.find? k
+def stdTemplate : String :=
+"{
+  \"url\":\"https://lakecache.blob.core.windows.net/std4\",
+  \"head\":\"Std.lean\",
+  \"rootDir\":\"lake-packages/std\",
+  \"tokenEnvVar\":\"STD_CACHE_SAS\",
+  \"pkgDirs\":
+  {
+    \"Std\":\"lake-packages/std\"
+  }
+}\n"
+
+def mathlibTemplate : String :=
+"{
+  \"url\":\"https://lakecache.blob.core.windows.net/mathlib4\",
+  \"head\":\"Mathlib.lean\",
+  \"rootDir\":\"lake-packages/mathlib\",
+  \"tokenEnvVar\":\"MATHLIB_CACHE_SAS\",
+  \"pkgDirs\":
+  {
+    \"Mathlib\":\"lake-packages/mathlib\",
+    \"Aesop\":\"lake-packages/aesop\",
+    \"Qq\":\"lake-packages/Qq\",
+    \"Std\":\"lake-packages/std\"
+  }
+}\n"
+
+def check : IO Bool := do
+  if ← FILE.pathExists then return true else
+  IO.println s!"Which cache config template to use?\n(0) Std\n(1) Mathlib"
+  match (← (← IO.getStdin).getLine).trim with
+  | "0" => IO.FS.writeFile FILE stdTemplate; return true
+  | "1" => IO.FS.writeFile FILE mathlibTemplate; return true
+  | _ => IO.println "Invalid template"; return false
 
 def load : IO $ Except String Config := do
-  if !(← FILE.pathExists) then return .error s!"{FILE} not found"
   let json ← match Json.parse (← IO.FS.readFile FILE) with
     | .ok json => pure json
     | .error e => return .error s!"Error when parsing {FILE}: {e}"
@@ -34,8 +68,8 @@ def load : IO $ Except String Config := do
       | return .error s!"{FILE} is missing the \"url\" (string) field"
     let some $ .str head := x.find compare "head"
       | return .error s!"{FILE} is missing the \"head\" (string) field"
-    let some $ .str rootRef := x.find compare "rootRef"
-      | return .error s!"{FILE} is missing the \"rootRef\" (string) field"
+    let some $ .str rootDir := x.find compare "rootDir"
+      | return .error s!"{FILE} is missing the \"rootDir\" (string) field"
     let some $ .str tokenEnvVar := x.find compare "tokenEnvVar"
       | return .error s!"{FILE} is missing the \"tokenEnvVar\" (string) field"
     let some $ .obj pkgDirs := x.find compare "pkgDirs"
@@ -44,7 +78,7 @@ def load : IO $ Except String Config := do
     for pair in pkgDirs.toArray do
       let .str path := pair.2 | return .error s!"Error when reading the build path for {pair.1}"
       pkgDirs' := pkgDirs'.insert pair.1 (mkFilePath $ path.splitOn "/")
-    return .ok ⟨url, ⟨head⟩, mkFilePath $ rootRef.splitOn "/", tokenEnvVar, pkgDirs'⟩
+    return .ok ⟨url, ⟨head⟩, mkFilePath $ rootDir.splitOn "/", tokenEnvVar, pkgDirs'⟩
   | _ => return .error s!"Invalid formatting for {FILE}"
 
 end Cache.Config

--- a/Cache/Hashing.lean
+++ b/Cache/Hashing.lean
@@ -36,7 +36,7 @@ def HashMemo.filterByFilePaths (hashMemo : HashMemo) (filePaths : List FilePath)
     else throw $ IO.userError s!"No match for {filePath}"
   return hashMap
 
-/-- Gets the file paths to Mathlib files imported on a Lean source -/
+/-- Gets the file paths to files imported on a Lean source -/
 def getFileImports (source : String) (pkgDirs : PkgDirs) : Array FilePath :=
   let s := Lean.ParseImports.main source (Lean.ParseImports.whitespace source {})
   let imps := s.imports.map (·.module.components |> .map toString)
@@ -68,7 +68,7 @@ Computes the hash of a file, which mixes:
 * The root hash
 * The hash of its relative path (inside its package directory)
 * The hash of its content
-* The hashes of the imported files that are part of `Mathlib`
+* The hashes of the imported files that mapped `pkgDirs` in the config file
 -/
 partial def getFileHash (filePath : FilePath) : HashM $ Option UInt64 := do
   let stt ← get

--- a/Cache/Hashing.lean
+++ b/Cache/Hashing.lean
@@ -58,10 +58,9 @@ Computes the root hash, which mixes the hashes of the content of:
 * `lean-toolchain`
 * `lake-manifest.json`
 -/
-def getRootHash (rootRef : FilePath) : IO UInt64 := do
+def getRootHash (rootDir : FilePath) : IO UInt64 := do
   let rootFiles : List FilePath := ["lakefile.lean", "lean-toolchain", "lake-manifest.json"]
-  return hash $ ← rootFiles.mapM fun path => do
-    pure $ ← IO.FS.readFile $ rootRef / path
+  return hash $ ← rootFiles.mapM (do pure $ ← IO.FS.readFile $ rootDir / ·)
 
 /--
 Computes the hash of a file, which mixes:
@@ -100,7 +99,7 @@ partial def getFileHash (filePath : FilePath) : HashM $ Option UInt64 := do
 
 /-- Main API to retrieve the hashes of the Lean files -/
 def getHashMemo (cfg : Config) : IO HashMemo := do
-  let rootHash ← getRootHash cfg.rootRef
+  let rootHash ← getRootHash cfg.rootDir
   return (← StateT.run (ReaderT.run (getFileHash cfg.head) ⟨cfg.pkgDirs, rootHash⟩) default).2
 
 end Cache.Hashing

--- a/Cache/IO.lean
+++ b/Cache/IO.lean
@@ -139,20 +139,20 @@ def getLocalCacheSet : IO $ Lean.RBTree String compare := do
 def unpackCache (cfg : Config) (hashMap : HashMap) : IO Unit := do
   let hashMap := hashMap.filter (← getLocalCacheSet) true
   let size := hashMap.size
-  if size > 0 then
+  if size == 0 then IO.println "No cache files to decompress"
+  else
     IO.println s!"Decompressing {size} file(s)"
-    let rootRefStr := cfg.rootRef.toString
+    let rootDirStr := cfg.rootDir.toString
     hashMap.forM fun path hash => do
       match path.parent with
       | none | some path => do
         let pkgDir ← getPackageDir cfg.pkgDirs path
         mkDir $ pkgDir / LIBDIR / path
         mkDir $ pkgDir / IRDIR / path
-        if rootRefStr != "." && cfg.rootRef == pkgDir then
-          discard $ runCmd "tar" #["-xzf", s!"{CACHEDIR / hash.asTarGz}", "-C", rootRefStr]
+        if rootDirStr != "." && cfg.rootDir == pkgDir then
+          discard $ runCmd "tar" #["-xzf", s!"{CACHEDIR / hash.asTarGz}", "-C", rootDirStr]
         else
           discard $ runCmd "tar" #["-xzf", s!"{CACHEDIR / hash.asTarGz}"]
-  else IO.println "No cache files to decompress"
 
 /-- Retrieves the azure token from the environment -/
 def getToken (tokenEnvVar : String) : IO String := do

--- a/Cache/Main.lean
+++ b/Cache/Main.lean
@@ -5,9 +5,8 @@ Authors: Arthur Paulino
 -/
 
 import Cache.Requests
-import Cache.Config
 
-def help : String := "Mathlib4 caching CLI
+def help : String := "Caching CLI
 Usage: cache [COMMAND]
 
 Commands:
@@ -55,6 +54,7 @@ def curlArgs : List String :=
 
 open Cache IO Hashing Requests in
 def main (args : List String) : IO Unit := do
+  if !(← Config.check) then IO.println "Cache config file not found"; return
   let config ← match ← Config.load with
     | .ok config => pure config
     | .error err => IO.println err; return

--- a/Cache/Requests.lean
+++ b/Cache/Requests.lean
@@ -8,10 +8,6 @@ import Cache.Hashing
 
 namespace Cache.Requests
 
-/-- Azure blob URL -/
-def URL : String :=
-  "https://lakecache.blob.core.windows.net/mathlib4"
-
 open System (FilePath)
 
 /--
@@ -19,53 +15,54 @@ Given a file name like `"1234.tar.gz"`, makes the URL to that file on the server
 
 The `f/` prefix means that it's a common file for caching.
 -/
-def mkFileURL (fileName : String) (token : Option String) : IO String :=
+def mkFileURL (url fileName : String) (token : Option String) : IO String :=
   return match token with
-  | some token => s!"{URL}/f/{fileName}?{token}"
-  | none => s!"{URL}/f/{fileName}"
+  | some token => s!"{url}/f/{fileName}?{token}"
+  | none => s!"{url}/f/{fileName}"
 
 section Get
 
 /-- Formats the config file for `curl`, containing the list of files to be downloaded -/
-def mkGetConfigContent (hashMap : IO.HashMap) : IO String := do
+def mkGetConfigContent (url : String) (hashMap : IO.HashMap) : IO String := do
   let l ← hashMap.foldM (init := []) fun acc _ hash => do
     let fileName := hash.asTarGz
-    pure $ (s!"url = {← mkFileURL fileName none}\n-o {IO.CACHEDIR / fileName}") :: acc
+    pure $ (s!"url = {← mkFileURL url fileName none}\n-o {IO.CACHEDIR / fileName}") :: acc
   return "\n".intercalate l
 
 /-- Calls `curl` to download files from the server to `CACHEDIR` (`.cache`) -/
-def downloadFiles (hashMap : IO.HashMap) (forceDownload : Bool) : IO Unit := do
+def downloadFiles (url : String) (hashMap : IO.HashMap) (forceDownload : Bool) : IO Unit := do
   let hashMap := if forceDownload then hashMap else hashMap.filter (← IO.getLocalCacheSet) false
   let size := hashMap.size
   if size > 0 then
     IO.mkDir IO.CACHEDIR
     IO.println s!"Attempting to download {size} file(s)"
-    IO.FS.writeFile IO.CURLCFG (← mkGetConfigContent hashMap)
+    IO.FS.writeFile IO.CURLCFG (← mkGetConfigContent url hashMap)
     discard $ IO.runCmd "curl"
       #["-X", "GET", "--parallel", "-f", "-s", "-K", IO.CURLCFG.toString] false
     IO.FS.removeFile IO.CURLCFG
   else IO.println "No files to download"
 
 /-- Downloads missing files, and unpacks files. -/
-def getFiles (hashMap : IO.HashMap) (forceDownload : Bool) : IO Unit := do
-  downloadFiles hashMap forceDownload
-  IO.unpackCache hashMap
+def getFiles (cfg : Config) (hashMap : IO.HashMap) (forceDownload : Bool) : IO Unit := do
+  downloadFiles cfg.url hashMap forceDownload
+  IO.unpackCache cfg hashMap
 
 end Get
 
 section Put
 
 /-- Formats the config file for `curl`, containing the list of files to be uploades -/
-def mkPutConfigContent (fileNames : Array String) (token : String) : IO String := do
+def mkPutConfigContent (url : String) (fileNames : Array String) (token : String) : IO String := do
   let l ← fileNames.data.mapM fun fileName : String => do
-    pure s!"-T {(IO.CACHEDIR / fileName).toString}\nurl = {← mkFileURL fileName (some token)}"
+    pure s!"-T {(IO.CACHEDIR / fileName).toString}\nurl = {← mkFileURL url fileName (some token)}"
   return "\n".intercalate l
 
 /-- Calls `curl` to send a set of cached files to the server -/
-def putFiles (fileNames : Array String) (overwrite : Bool) (token : String) : IO Unit := do
+def putFiles (url : String) (fileNames : Array String) (overwrite : Bool) (token : String) :
+    IO Unit := do
   let size := fileNames.size
   if size > 0 then
-    IO.FS.writeFile IO.CURLCFG (← mkPutConfigContent fileNames token)
+    IO.FS.writeFile IO.CURLCFG (← mkPutConfigContent url fileNames token)
     IO.println s!"Attempting to upload {size} file(s)"
     if overwrite then
       discard $ IO.runCmd "curl" #["-X", "PUT", "-H", "x-ms-blob-type: BlockBlob", "--parallel",
@@ -94,7 +91,7 @@ Sends a commit file to the server, containing the hashes of the respective commi
 
 The file name is the current Git hash and the `c/` prefix means that it's a commit file.
 -/
-def commit (hashMap : IO.HashMap) (overwrite : Bool) (token : String) : IO Unit := do
+def commit (url : String) (hashMap : IO.HashMap) (overwrite : Bool) (token : String) : IO Unit := do
   let hash ← getGitCommitHash
   let path := IO.CACHEDIR / hash
   IO.mkDir IO.CACHEDIR
@@ -102,7 +99,7 @@ def commit (hashMap : IO.HashMap) (overwrite : Bool) (token : String) : IO Unit 
   let params := if overwrite
     then #["-X", "PUT", "-H", "x-ms-blob-type: BlockBlob"]
     else #["-X", "PUT", "-H", "x-ms-blob-type: BlockBlob", "-H", "If-None-Match: *"]
-  discard $ IO.runCmd "curl" $ params ++ #["-T", path.toString, s!"{URL}/c/{hash}?{token}"]
+  discard $ IO.runCmd "curl" $ params ++ #["-T", path.toString, s!"{url}/c/{hash}?{token}"]
   IO.FS.removeFile path
 
 end Commit
@@ -130,9 +127,9 @@ Retrieves metadata about hosted files: their names and the timestamps of last mo
 
 Example: `["f/39476538726384726.tar.gz", "Sat, 24 Dec 2022 17:33:01 GMT"]`
 -/
-def getFilesInfo (q : QueryType) : IO $ List (String × String) := do
+def getFilesInfo (url : String) (q : QueryType) : IO $ List (String × String) := do
   IO.println s!"Downloading info list of {q.desc}"
-  let ret ← IO.runCmd "curl" #["-X", "GET", s!"{URL}?comp=list&restype=container{q.prefix}"]
+  let ret ← IO.runCmd "curl" #["-X", "GET", s!"{url}?comp=list&restype=container{q.prefix}"]
   match ret.splitOn "<Name>" with
   | [] => formatError
   | [_] => return default

--- a/cache-config.json
+++ b/cache-config.json
@@ -1,7 +1,8 @@
 {
   "url":"https://lakecache.blob.core.windows.net/mathlib4",
   "head":"Mathlib.lean",
-  "builds":
+  "rootRef":".",
+  "buildDirs":
   {
     "Mathlib":"build",
     "Aesop":"lake-packages/aesop/build",

--- a/cache-config.json
+++ b/cache-config.json
@@ -1,7 +1,7 @@
 {
   "url":"https://lakecache.blob.core.windows.net/mathlib4",
   "head":"Mathlib.lean",
-  "rootRef":".",
+  "rootDir":".",
   "tokenEnvVar":"MATHLIB_CACHE_SAS",
   "pkgDirs":
   {

--- a/cache-config.json
+++ b/cache-config.json
@@ -2,11 +2,12 @@
   "url":"https://lakecache.blob.core.windows.net/mathlib4",
   "head":"Mathlib.lean",
   "rootRef":".",
-  "buildDirs":
+  "tokenEnvVar":"MATHLIB_CACHE_SAS",
+  "pkgDirs":
   {
-    "Mathlib":"build",
-    "Aesop":"lake-packages/aesop/build",
-    "Qq":"lake-packages/Qq/build",
-    "Std":"lake-packages/std/build"
+    "Mathlib":".",
+    "Aesop":"lake-packages/aesop",
+    "Qq":"lake-packages/Qq",
+    "Std":"lake-packages/std"
   }
 }

--- a/cache-config.json
+++ b/cache-config.json
@@ -1,0 +1,11 @@
+{
+  "url":"https://lakecache.blob.core.windows.net/mathlib4",
+  "head":"Mathlib.lean",
+  "builds":
+  {
+    "Mathlib":"build",
+    "Aesop":"lake-packages/aesop/build",
+    "Qq":"lake-packages/Qq/build",
+    "Std":"lake-packages/std/build"
+  }
+}


### PR DESCRIPTION
This PR removes hardcoded values that are specific to mathlib4 from `Cache`, using a JSON for config purposes instead.