### PR TITLE
[Merged by Bors] - feat: forward-port leanprover-community/mathlib#18449

### DIFF
--- a/Mathlib/Data/Set/Semiring.lean
+++ b/Mathlib/Data/Set/Semiring.lean
@@ -8,8 +8,8 @@ Authors: Floris van Doorn
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
-import Mathlib.Data.Set.Pointwise.SMul
 import Mathlib.Algebra.Order.Kleene
+import Mathlib.Data.Set.Pointwise.SMul
 
 /-!
 # Sets as a semiring under union

--- a/Mathlib/Data/Set/Semiring.lean
+++ b/Mathlib/Data/Set/Semiring.lean
@@ -206,7 +206,6 @@ theorem _root_.Set.up_one : up (1 : Set α) = 1 :=
 
 end One
 
--- Porting note: this was `one := 1`
 instance [MulOneClass α] : NonAssocSemiring (SetSemiring α) :=
   { (inferInstance : NonUnitalNonAssocSemiring (SetSemiring α)),
     Set.mulOneClass with

--- a/Mathlib/Data/Set/Semiring.lean
+++ b/Mathlib/Data/Set/Semiring.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn
 
 ! This file was ported from Lean 3 source module data.set.semiring
-! leanprover-community/mathlib commit 9003f28797c0664a49e4179487267c494477d853
+! leanprover-community/mathlib commit 27b54c47c3137250a521aa64e9f1db90be5f6a26
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/

--- a/Mathlib/Data/Set/Semiring.lean
+++ b/Mathlib/Data/Set/Semiring.lean
@@ -9,6 +9,7 @@ Authors: Floris van Doorn
 ! if you have ported upstream changes.
 -/
 import Mathlib.Data.Set.Pointwise.SMul
+import Mathlib.Algebra.Order.Kleene
 
 /-!
 # Sets as a semiring under union
@@ -97,6 +98,8 @@ instance : AddCommMonoid (SetSemiring α) where
   add_zero := union_empty
   add_comm := union_comm
 
+-- TODO: port
+
 /- Since addition on `SetSemiring` is commutative (it is set union), there is no need
 to also have the instance `CovariantClass (SetSemiring α) (SetSemiring α) (swap (+)) (≤)`. -/
 instance covariantClass_add : CovariantClass (SetSemiring α) (SetSemiring α) (· + ·) (· ≤ ·) :=
@@ -116,6 +119,8 @@ instance : NonUnitalNonAssocSemiring (SetSemiring α) :=
     left_distrib := fun _ _ _ => mul_union
     right_distrib := fun _ _ _ => union_mul }
 
+-- TODO: port
+
 instance : NoZeroDivisors (SetSemiring α) :=
   ⟨fun {a b} ab =>
     a.eq_empty_or_nonempty.imp_right fun ha =>
@@ -134,6 +139,9 @@ instance covariantClass_mul_right :
 
 end Mul
 
+
+-- TODO: port
+
 -- Porting note: this was `one := 1`
 instance [MulOneClass α] : NonAssocSemiring (SetSemiring α) :=
   { (inferInstance : NonUnitalNonAssocSemiring (SetSemiring α)),
@@ -144,12 +152,14 @@ instance [MulOneClass α] : NonAssocSemiring (SetSemiring α) :=
 instance [Semigroup α] : NonUnitalSemiring (SetSemiring α) :=
   { (inferInstance : NonUnitalNonAssocSemiring (SetSemiring α)), Set.semigroup with }
 
-instance [Monoid α] : Semiring (SetSemiring α) :=
+instance [Monoid α] : IdemSemiring (SetSemiring α) :=
   { (inferInstance : NonAssocSemiring (SetSemiring α)),
     (inferInstance : NonUnitalSemiring (SetSemiring α)) with }
 
 instance [CommSemigroup α] : NonUnitalCommSemiring (SetSemiring α) :=
   { (inferInstance : NonUnitalSemiring (SetSemiring α)), Set.commSemigroup with }
+
+-- TODO: port
 
 instance [CommMonoid α] : CommMonoid (SetSemiring α) :=
   { (inferInstance : Monoid (SetSemiring α)), Set.commSemigroup with }

--- a/Mathlib/Data/Set/Semiring.lean
+++ b/Mathlib/Data/Set/Semiring.lean
@@ -251,15 +251,21 @@ def imageHom [MulOneClass α] [MulOneClass β] (f : α →* β) : SetSemiring α
   map_mul' _ _ := image_mul f
 #align set_semiring.image_hom SetSemiring.imageHom
 
--- TODO; copy formatting from mathport
+lemma imageHom_def [MulOneClass α] [MulOneClass β] (f : α →* β) (s : SetSemiring α) :
+    imageHom f s = up (image f (down s)) :=
+  rfl
+#align set_semiring.image_hom_def SetSemiring.imageHom_def
+
 @[simp]
 lemma down_imageHom [MulOneClass α] [MulOneClass β] (f : α →* β) (s : SetSemiring α) :
-  down (imageHom f s) = f '' down s := rfl
+    down (imageHom f s) = f '' down s :=
+  rfl
 #align set_semiring.down_image_hom SetSemiring.down_imageHom
 
 @[simp]
-lemma imageHom_up [MulOneClass α] [MulOneClass β] (f : α →* β) (s : Set α) :
-  imageHom f (up s) = up (f '' s) := rfl
-#align set_semiring.image_hom_up SetSemiring.imageHom_up
+lemma _root_.Set.up_image [MulOneClass α] [MulOneClass β] (f : α →* β) (s : Set α) :
+    up (f '' s) = imageHom f (up s) :=
+  rfl
+#align set.up_image Set.up_image
 
 end SetSemiring


### PR DESCRIPTION
The diff being ported is https://github.com/leanprover-community/mathlib3port/commit/d034837787b3e04cf65ce061952078a6e75b66da#diff-968496f13ddf1f2e9b559f374e46c52125a2ada4f449bbce0989bc8ef4965e67.

This also includes a fix from leanprover-community/mathlib#18539

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
