### PR TITLE
[Merged by Bors] - feat: update make_port_status.py to include information for port-dashboard

### DIFF
--- a/scripts/make_port_status.py
+++ b/scripts/make_port_status.py
@@ -126,8 +126,6 @@ for pr in mathlib4repo.get_pulls(state='open'):
     if 'mathlib3-pair' in (l.name for l in pr.labels):
         for file in (f.filename for f in pr.get_files()):
             sync_prs[file] = sync_prs.get(file, set()).union([pr.number])
-    if 'mathlib-port' in (l.name for l in pr.labels):
-        labels[pr.number] = [dict(name=l.name, color=l.color) for l in pr.labels]
     num = pr.number
     nums.append(num)
     prs[num] = pr
@@ -183,9 +181,17 @@ for node in sorted(graph.nodes):
             new_status.update(
                 mathlib4_pr=pr_info['pr'],
                 mathlib4_file=pr_info['fname'],
-                source=dict(repo=pr_info['repo'], commit=pr_info['commit']),
-                labels=labels.get(pr_info['pr'], [])
-                )
+                source=dict(repo=pr_info['repo'], commit=pr_info['commit']))
+
+            try:
+                pr = prs[pr_info['pr']]
+            except KeyError:
+                pass
+            else:
+                lab = [{'name': l.name, 'color': l.color} for l in pr.labels]
+                if lab:
+                    new_status.update(labels=lab)
+
             sha = pr_info['commit'] if pr_info['repo'] == 'leanprover-community/mathlib' else "_"
             status += f" mathlib4#{pr_info['pr']} {sha}"
     try:

--- a/scripts/make_port_status.py
+++ b/scripts/make_port_status.py
@@ -114,9 +114,7 @@ for path4 in Path(mathlib4_root).glob('**/*.lean'):
 prs = {}
 fetch_args = ['git', 'fetch', 'origin']
 nums = []
-
 sync_prs = defaultdict(set)
-
 mathlib4repo = github.Github(github_token).get_repo("leanprover-community/mathlib4")
 for pr in mathlib4repo.get_pulls(state='open'):
     if pr.created_at < datetime.datetime(2022, 12, 1, 0, 0, 0):
@@ -160,12 +158,9 @@ for node in sorted(graph.nodes):
             mathlib4_pr=data[node]['mathlib4_pr'],
             source=data[node]['source']
         )
-
-        # This is separate from the `dict()` above to prevent tons of `sync_prs: []` in the yaml.
-        _sync_prs = list(sync_prs.get(data[node]['mathlib4_file'], set()))
+        _sync_prs = list(sync_prs[data[node]['mathlib4_file']])
         if _sync_prs:
             new_status.update(mathlib4_sync_prs=_sync_prs)
-
         pr_status = f"mathlib4#{data[node]['mathlib4_pr']}" if data[node]['mathlib4_pr'] is not None else "_"
         sha = data[node]['source']['commit'] if data[node]['source']['repo'] == 'leanprover-community/mathlib' else "_"
 
@@ -182,7 +177,6 @@ for node in sorted(graph.nodes):
                 mathlib4_pr=pr_info['pr'],
                 mathlib4_file=pr_info['fname'],
                 source=dict(repo=pr_info['repo'], commit=pr_info['commit']))
-
             labels = [{'name': l.name, 'color': l.color} for l in prs[pr_info['pr']].labels]
             if labels:
                 new_status.update(labels=labels)

--- a/scripts/make_port_status.py
+++ b/scripts/make_port_status.py
@@ -183,8 +183,7 @@ for node in sorted(graph.nodes):
             new_status.update(
                 mathlib4_pr=pr_info['pr'],
                 mathlib4_file=pr_info['fname'],
-                source=dict(repo=pr_info['repo'],
-                commit=pr_info['commit']),
+                source=dict(repo=pr_info['repo'], commit=pr_info['commit']),
                 labels=labels.get(pr_info['pr'], [])
                 )
             sha = pr_info['commit'] if pr_info['repo'] == 'leanprover-community/mathlib' else "_"

--- a/scripts/make_port_status.py
+++ b/scripts/make_port_status.py
@@ -115,7 +115,6 @@ fetch_args = ['git', 'fetch', 'origin']
 nums = []
 
 sync_prs = dict()
-labels = dict()
 
 mathlib4repo = github.Github(github_token).get_repo("leanprover-community/mathlib4")
 for pr in mathlib4repo.get_pulls(state='open'):
@@ -188,9 +187,9 @@ for node in sorted(graph.nodes):
             except KeyError:
                 pass
             else:
-                lab = [{'name': l.name, 'color': l.color} for l in pr.labels]
-                if lab:
-                    new_status.update(labels=lab)
+                labels = [{'name': l.name, 'color': l.color} for l in pr.labels]
+                if labels:
+                    new_status.update(labels=labels)
 
             sha = pr_info['commit'] if pr_info['repo'] == 'leanprover-community/mathlib' else "_"
             status += f" mathlib4#{pr_info['pr']} {sha}"

--- a/scripts/make_port_status.py
+++ b/scripts/make_port_status.py
@@ -124,7 +124,7 @@ for pr in mathlib4repo.get_pulls(state='open'):
         continue
     if 'mathlib3-pair' in (l.name for l in pr.labels):
         for file in (f.filename for f in pr.get_files()):
-            sync_prs[file] = sync_prs.get(file, set()).add(pr.number)
+            sync_prs[file] = sync_prs.get(file, set()).union([pr.number])
     num = pr.number
     nums.append(num)
     prs[num] = pr

--- a/scripts/make_port_status.py
+++ b/scripts/make_port_status.py
@@ -158,7 +158,13 @@ for node in sorted(graph.nodes):
             mathlib4_pr=data[node]['mathlib4_pr'],
             source=data[node]['source']
         )
-        _sync_prs = list(sync_prs[data[node]['mathlib4_file']])
+        _sync_prs = [
+            dict(
+                num=sync_pr_num,
+                labels=[dict(name=l.name, color=l.color) for l in prs[sync_pr_num].labels]
+            )
+            for sync_pr_num in sync_prs[data[node]['mathlib4_file']]
+        ]
         if _sync_prs:
             new_status.update(mathlib4_sync_prs=_sync_prs)
         pr_status = f"mathlib4#{data[node]['mathlib4_pr']}" if data[node]['mathlib4_pr'] is not None else "_"

--- a/scripts/make_port_status.py
+++ b/scripts/make_port_status.py
@@ -127,7 +127,7 @@ for pr in mathlib4repo.get_pulls(state='open'):
         for file in (f.filename for f in pr.get_files()):
             sync_prs[file] = sync_prs.get(file, set()).union([pr.number])
     if 'mathlib-port' in (l.name for l in pr.labels):
-        labels[pr.number] = [[l.name, l.color] for l in pr.labels]
+        labels[pr.number] = [dict(name=l.name, color=l.color) for l in pr.labels]
     num = pr.number
     nums.append(num)
     prs[num] = pr

--- a/scripts/make_port_status.py
+++ b/scripts/make_port_status.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 import yaml
 import networkx as nx
+from collections import defaultdict
 from pathlib import Path
 
 # Must run from root of mathlib4 directory.
@@ -114,7 +115,7 @@ prs = {}
 fetch_args = ['git', 'fetch', 'origin']
 nums = []
 
-sync_prs = dict()
+sync_prs = defaultdict(set)
 
 mathlib4repo = github.Github(github_token).get_repo("leanprover-community/mathlib4")
 for pr in mathlib4repo.get_pulls(state='open'):
@@ -124,7 +125,7 @@ for pr in mathlib4repo.get_pulls(state='open'):
         continue
     if 'mathlib3-pair' in (l.name for l in pr.labels):
         for file in (f.filename for f in pr.get_files()):
-            sync_prs[file] = sync_prs.get(file, set()).union([pr.number])
+            sync_prs[file].add(pr.number)
     num = pr.number
     nums.append(num)
     prs[num] = pr

--- a/scripts/make_port_status.py
+++ b/scripts/make_port_status.py
@@ -183,14 +183,9 @@ for node in sorted(graph.nodes):
                 mathlib4_file=pr_info['fname'],
                 source=dict(repo=pr_info['repo'], commit=pr_info['commit']))
 
-            try:
-                pr = prs[pr_info['pr']]
-            except KeyError:
-                pass
-            else:
-                labels = [{'name': l.name, 'color': l.color} for l in pr.labels]
-                if labels:
-                    new_status.update(labels=labels)
+            labels = [{'name': l.name, 'color': l.color} for l in prs[pr_info['pr']].labels]
+            if labels:
+                new_status.update(labels=labels)
 
             sha = pr_info['commit'] if pr_info['repo'] == 'leanprover-community/mathlib' else "_"
             status += f" mathlib4#{pr_info['pr']} {sha}"

--- a/scripts/make_port_status.py
+++ b/scripts/make_port_status.py
@@ -180,7 +180,6 @@ for node in sorted(graph.nodes):
             labels = [{'name': l.name, 'color': l.color} for l in prs[pr_info['pr']].labels]
             if labels:
                 new_status.update(labels=labels)
-
             sha = pr_info['commit'] if pr_info['repo'] == 'leanprover-community/mathlib' else "_"
             status += f" mathlib4#{pr_info['pr']} {sha}"
     try:

--- a/scripts/make_port_status.py
+++ b/scripts/make_port_status.py
@@ -125,7 +125,7 @@ for pr in mathlib4repo.get_pulls(state='open'):
         continue
     if 'mathlib3-pair' in (l.name for l in pr.labels):
         for file in (f.filename for f in pr.get_files()):
-            sync_prs[file] = sync_prs.get(file, set()).union([pr.number])
+            sync_prs[file] = sync_prs.get(file, set()).add(pr.number)
     num = pr.number
     nums.append(num)
     prs[num] = pr

--- a/scripts/make_port_status.py
+++ b/scripts/make_port_status.py
@@ -164,7 +164,7 @@ for node in sorted(graph.nodes):
         # This is separate from the `dict()` above to prevent tons of `sync_prs: []` in the yaml.
         _sync_prs = list(sync_prs.get(data[node]['mathlib4_file'], set()))
         if _sync_prs:
-            new_status.update(sync_prs=_sync_prs)
+            new_status.update(mathlib4_sync_prs=_sync_prs)
 
         pr_status = f"mathlib4#{data[node]['mathlib4_pr']}" if data[node]['mathlib4_pr'] is not None else "_"
         sha = data[node]['source']['commit'] if data[node]['source']['repo'] == 'leanprover-community/mathlib' else "_"


### PR DESCRIPTION
Include the information needed for the [port-dashboard](https://leanprover-community.github.io/mathlib-port-status/) that requires github API calls into this script.

---

The new fields in the yaml file are:

- `sync_pr`: list of PR numbers of all open mathlib4-PRs with label `mathlib3-pair` that modify the port of this file. (This is for a new column in [Out Of Sync](https://leanprover-community.github.io/mathlib-port-status/out-of-sync), new feature)
- `labels`: list of lists `[label name, label color]`. If the porting-PR has label `mathlib-port`, then this lists all labels of the porting PR. (This is for the [Port-Dashboard](https://leanprover-community.github.io/mathlib-port-status/), existing feature)

PR using these changes:
leanprover-community/mathlib-port-status#16

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
