### PR TITLE
[Merged by Bors] - chore: update some SHAs

### DIFF
--- a/Mathlib/Topology/Constructions.lean
+++ b/Mathlib/Topology/Constructions.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro, Patrick Massot
 
 ! This file was ported from Lean 3 source module topology.constructions
-! leanprover-community/mathlib commit dc6c365e751e34d100e80fe6e314c3c3e0fd2988
+! leanprover-community/mathlib commit 0c1f285a9f6e608ae2bdffa3f993eafb01eba829
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -843,6 +843,7 @@ theorem continuous_sum_dom {f : α ⊕ β → γ} :
   (continuous_sup_dom (t₁ := TopologicalSpace.coinduced Sum.inl _)
     (t₂ := TopologicalSpace.coinduced Sum.inr _)).trans <|
     continuous_coinduced_dom.and continuous_coinduced_dom
+#align continuous_sum_dom continuous_sum_dom
 
 theorem continuous_sum_elim {f : α → γ} {g : β → γ} :
     Continuous (Sum.elim f g) ↔ Continuous f ∧ Continuous g :=

--- a/Mathlib/Topology/UniformSpace/Separation.lean
+++ b/Mathlib/Topology/UniformSpace/Separation.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Patrick Massot
 
 ! This file was ported from Lean 3 source module topology.uniform_space.separation
-! leanprover-community/mathlib commit d90e4e186f1d18e375dcd4e5b5f6364b01cb3e46
+! leanprover-community/mathlib commit 0c1f285a9f6e608ae2bdffa3f993eafb01eba829
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -113,14 +113,14 @@ theorem Filter.HasBasis.mem_separationRel {ι : Sort _} {p : ι → Prop} {s : �
   h.forall_mem_mem
 #align filter.has_basis.mem_separation_rel Filter.HasBasis.mem_separationRel
 
--- porting note: new lemma
 theorem separationRel_iff_specializes {a b : α} : (a, b) ∈ 𝓢 α ↔ a ⤳ b := by
   simp only [(𝓤 α).basis_sets.mem_separationRel, id, mem_setOf_eq,
     (nhds_basis_uniformity (𝓤 α).basis_sets).specializes_iff]
+#align separation_rel_iff_specializes separationRel_iff_specializes
 
--- porting note: new lemma
 theorem separationRel_iff_inseparable {a b : α} : (a, b) ∈ 𝓢 α ↔ Inseparable a b :=
   separationRel_iff_specializes.trans specializes_iff_inseparable
+#align separation_rel_iff_inseparable separationRel_iff_inseparable
 
 /-- A uniform space is separated if its separation relation is trivial (each point
 is related only to itself). -/
@@ -365,6 +365,10 @@ instance : SeparatedSpace (SeparationQuotient α) :=
 
 instance [Inhabited α] : Inhabited (SeparationQuotient α) :=
   inferInstanceAs (Inhabited (Quotient (separationSetoid α)))
+
+lemma mk_eq_mk {x y : α} : (⟦x⟧ : SeparationQuotient α) = ⟦y⟧ ↔ Inseparable x y :=
+Quotient.eq'.trans separationRel_iff_inseparable
+#align uniform_space.separation_quotient.mk_eq_mk UniformSpace.SeparationQuotient.mk_eq_mk
 
 /-- Factoring functions to a separated space through the separation quotient. -/
 def lift [SeparatedSpace β] (f : α → β) : SeparationQuotient α → β :=


### PR DESCRIPTION
Some Mathlib 4 lemmas were backported to Mathlib 3 in leanprover-community/mathlib#18502, sync SHAs

* [`topology.uniform_space.separation`@`d90e4e186f1d18e375dcd4e5b5f6364b01cb3e46`..`0c1f285a9f6e608ae2bdffa3f993eafb01eba829`](https://leanprover-community.github.io/mathlib-port-status/file/topology/uniform_space/separation?range=d90e4e186f1d18e375dcd4e5b5f6364b01cb3e46..0c1f285a9f6e608ae2bdffa3f993eafb01eba829)
* [`topology.constructions`@`dc6c365e751e34d100e80fe6e314c3c3e0fd2988`..`0c1f285a9f6e608ae2bdffa3f993eafb01eba829`](https://leanprover-community.github.io/mathlib-port-status/file/topology/constructions?range=dc6c365e751e34d100e80fe6e314c3c3e0fd2988..0c1f285a9f6e608ae2bdffa3f993eafb01eba829)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)