### PR TITLE
[Merged by Bors] - feat: forward-port leanprover-community/mathlib#18517

### DIFF
--- a/Mathlib/Order/Directed.lean
+++ b/Mathlib/Order/Directed.lean
@@ -25,8 +25,8 @@ directed iff each pair of elements has a shared upper bound.
 * `DirectedOn r s`: Predicate stating that the set `s` is `r`-directed.
 * `IsDirected α r`: Prop-valued mixin stating that `α` is `r`-directed. Follows the style of the
   unbundled relation classes such as `IsTotal`.
-* `scott_continuous`: Predicate stating that a function between preorders preserves
-  `is_lub` on directed sets.
+* `ScottContinuous`: Predicate stating that a function between preorders preserves `IsLUB` on
+  directed sets.
 
 ## References
 * [Gierz et al, *A Compendium of Continuous Lattices*][GierzEtAl1980]
@@ -330,14 +330,14 @@ section ScottContinuous
 
 variable [Preorder α] {a : α}
 
-/-- A function between preorders is said to be Scott continuous if it preserves `is_lub` on directed
+/-- A function between preorders is said to be Scott continuous if it preserves `IsLUB` on directed
 sets. It can be shown that a function is Scott continuous if and only if it is continuous wrt the
 Scott topology.
 
 The dual notion
 
 ```lean
-∀ ⦃d : set α⦄, d.nonempty → directed_on (≥) d → ∀ ⦃a⦄, is_glb d a → is_glb (f '' d) (f a)
+∀ ⦃d : Set α⦄, d.Nonempty → DirectedOn (· ≥ ·) d → ∀ ⦃a⦄, IsGLB d a → IsGLB (f '' d) (f a)
 ```
 
 does not appear to play a significant role in the literature, so is omitted here.

--- a/Mathlib/Order/Directed.lean
+++ b/Mathlib/Order/Directed.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl
 
 ! This file was ported from Lean 3 source module order.directed
-! leanprover-community/mathlib commit e8cf0cfec5fcab9baf46dc17d30c5e22048468be
+! leanprover-community/mathlib commit 485b24ed47b1b7978d38a1e445158c6224c3f42c
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -63,7 +63,7 @@ theorem directedOn_iff_directed {s} : @DirectedOn α r s ↔ Directed r (Subtype
 alias directedOn_iff_directed ↔ DirectedOn.directed_val _
 #align directed_on.directed_coe DirectedOn.directed_val
 
-theorem directedOn_range {f : ι → α} : Directed r f ↔ DirectedOn r (Set.range f) := by
+theorem directedOn_range {f : β → α} : Directed r f ↔ DirectedOn r (Set.range f) := by
   simp_rw [Directed, DirectedOn, Set.forall_range_iff, Set.exists_range_iff]
 #align directed_on_range directedOn_range
 

--- a/Mathlib/Order/Directed.lean
+++ b/Mathlib/Order/Directed.lean
@@ -221,8 +221,7 @@ instance OrderDual.isDirected_le [LE α] [IsDirected α (· ≥ ·)] : IsDirecte
 section Reflexive
 
 theorem DirectedOn.insert (h : Reflexive r) (a : α) {s : Set α} (hd : DirectedOn r s)
-    (ha : ∀ b ∈ s, ∃ c ∈ s, a ≼ c ∧ b ≼ c) : DirectedOn r (insert a s) :=
-  by
+    (ha : ∀ b ∈ s, ∃ c ∈ s, a ≼ c ∧ b ≼ c) : DirectedOn r (insert a s) := by
   rintro x (rfl | hx) y (rfl | hy)
   · exact ⟨y, Set.mem_insert _ _, h _, h _⟩
   · obtain ⟨w, hws, hwr⟩ := ha y hy

--- a/Mathlib/Order/Directed.lean
+++ b/Mathlib/Order/Directed.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl
 
 ! This file was ported from Lean 3 source module order.directed
-! leanprover-community/mathlib commit 485b24ed47b1b7978d38a1e445158c6224c3f42c
+! leanprover-community/mathlib commit e8cf0cfec5fcab9baf46dc17d30c5e22048468be
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -63,7 +63,7 @@ theorem directedOn_iff_directed {s} : @DirectedOn α r s ↔ Directed r (Subtype
 alias directedOn_iff_directed ↔ DirectedOn.directed_val _
 #align directed_on.directed_coe DirectedOn.directed_val
 
-theorem directedOn_range {f : β → α} : Directed r f ↔ DirectedOn r (Set.range f) := by
+theorem directedOn_range {f : ι → α} : Directed r f ↔ DirectedOn r (Set.range f) := by
   simp_rw [Directed, DirectedOn, Set.forall_range_iff, Set.exists_range_iff]
 #align directed_on_range directedOn_range
 

--- a/Mathlib/Order/Directed.lean
+++ b/Mathlib/Order/Directed.lean
@@ -11,7 +11,7 @@ Authors: Johannes Hölzl
 import Mathlib.Data.Set.Image
 import Mathlib.Order.Lattice
 import Mathlib.Order.Max
-import Mathbin.Order.Bounds.Basic
+import Mathlib.Order.Bounds.Basic
 
 /-!
 # Directed indexed families and sets
@@ -234,7 +234,7 @@ theorem DirectedOn.insert (h : Reflexive r) (a : α) {s : Set α} (hd : Directed
 #align directed_on.insert DirectedOn.insert
 
 theorem directedOn_singleton (h : Reflexive r) (a : α) : DirectedOn r ({a} : Set α) :=
-  fun x hx y hy => ⟨x, hx, h _, hx.symm ▸ hy.symm ▸ h _⟩
+  fun x hx _ hy => ⟨x, hx, h _, hx.symm ▸ hy.symm ▸ h _⟩
 #align directed_on_singleton directedOn_singleton
 
 theorem directedOn_pair (h : Reflexive r) {a b : α} (hab : a ≼ b) : DirectedOn r ({a, b} : Set α) :=
@@ -354,7 +354,7 @@ protected theorem ScottContinuous.monotone [Preorder β] {f : α → β} (h : Sc
     · exact Set.insert_nonempty _ _
     · exact directedOn_pair le_refl hab
     · rw [IsLUB, upperBounds_insert, upperBounds_singleton,
-        Set.inter_eq_self_of_subset_right (set.Ici_subset_Ici.mpr hab)]
+        Set.inter_eq_self_of_subset_right (Set.Ici_subset_Ici.mpr hab)]
       exact isLeast_Ici
   apply e1.1
   rw [Set.image_pair]

--- a/Mathlib/Order/Directed.lean
+++ b/Mathlib/Order/Directed.lean
@@ -4,13 +4,14 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl
 
 ! This file was ported from Lean 3 source module order.directed
-! leanprover-community/mathlib commit 18a5306c091183ac90884daa9373fa3b178e8607
+! leanprover-community/mathlib commit 485b24ed47b1b7978d38a1e445158c6224c3f42c
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
 import Mathlib.Data.Set.Image
 import Mathlib.Order.Lattice
 import Mathlib.Order.Max
+import Mathbin.Order.Bounds.Basic
 
 /-!
 # Directed indexed families and sets
@@ -24,6 +25,11 @@ directed iff each pair of elements has a shared upper bound.
 * `DirectedOn r s`: Predicate stating that the set `s` is `r`-directed.
 * `IsDirected α r`: Prop-valued mixin stating that `α` is `r`-directed. Follows the style of the
   unbundled relation classes such as `IsTotal`.
+* `scott_continuous`: Predicate stating that a function between preorders preserves
+  `is_lub` on directed sets.
+
+## References
+* [Gierz et al, *A Compendium of Continuous Lattices*][GierzEtAl1980]
 -/
 
 
@@ -212,6 +218,37 @@ instance OrderDual.isDirected_le [LE α] [IsDirected α (· ≥ ·)] : IsDirecte
   assumption
 #align order_dual.is_directed_le OrderDual.isDirected_le
 
+section Reflexive
+
+theorem DirectedOn.insert (h : Reflexive r) (a : α) {s : Set α} (hd : DirectedOn r s)
+    (ha : ∀ b ∈ s, ∃ c ∈ s, a ≼ c ∧ b ≼ c) : DirectedOn r (insert a s) :=
+  by
+  rintro x (rfl | hx) y (rfl | hy)
+  · exact ⟨y, Set.mem_insert _ _, h _, h _⟩
+  · obtain ⟨w, hws, hwr⟩ := ha y hy
+    exact ⟨w, Set.mem_insert_of_mem _ hws, hwr⟩
+  · obtain ⟨w, hws, hwr⟩ := ha x hx
+    exact ⟨w, Set.mem_insert_of_mem _ hws, hwr.symm⟩
+  · obtain ⟨w, hws, hwr⟩ := hd x hx y hy
+    exact ⟨w, Set.mem_insert_of_mem _ hws, hwr⟩
+#align directed_on.insert DirectedOn.insert
+
+theorem directedOn_singleton (h : Reflexive r) (a : α) : DirectedOn r ({a} : Set α) :=
+  fun x hx y hy => ⟨x, hx, h _, hx.symm ▸ hy.symm ▸ h _⟩
+#align directed_on_singleton directedOn_singleton
+
+theorem directedOn_pair (h : Reflexive r) {a b : α} (hab : a ≼ b) : DirectedOn r ({a, b} : Set α) :=
+  (directedOn_singleton h _).insert h _ fun c hc => ⟨c, hc, hc.symm ▸ hab, h _⟩
+#align directed_on_pair directedOn_pair
+
+theorem directedOn_pair' (h : Reflexive r) {a b : α} (hab : a ≼ b) :
+    DirectedOn r ({b, a} : Set α) := by
+  rw [Set.pair_comm]
+  apply directedOn_pair h hab
+#align directed_on_pair' directedOn_pair'
+
+end Reflexive
+
 section Preorder
 
 variable [Preorder α] {a : α}
@@ -288,3 +325,40 @@ instance (priority := 100) OrderTop.to_isDirected_le [LE α] [OrderTop α] : IsD
 instance (priority := 100) OrderBot.to_isDirected_ge [LE α] [OrderBot α] : IsDirected α (· ≥ ·) :=
   ⟨fun _ _ => ⟨⊥, bot_le _, bot_le _⟩⟩
 #align order_bot.to_is_directed_ge OrderBot.to_isDirected_ge
+
+section ScottContinuous
+
+variable [Preorder α] {a : α}
+
+/-- A function between preorders is said to be Scott continuous if it preserves `is_lub` on directed
+sets. It can be shown that a function is Scott continuous if and only if it is continuous wrt the
+Scott topology.
+
+The dual notion
+
+```lean
+∀ ⦃d : set α⦄, d.nonempty → directed_on (≥) d → ∀ ⦃a⦄, is_glb d a → is_glb (f '' d) (f a)
+```
+
+does not appear to play a significant role in the literature, so is omitted here.
+-/
+def ScottContinuous [Preorder β] (f : α → β) : Prop :=
+  ∀ ⦃d : Set α⦄, d.Nonempty → DirectedOn (· ≤ ·) d → ∀ ⦃a⦄, IsLUB d a → IsLUB (f '' d) (f a)
+#align scott_continuous ScottContinuous
+
+protected theorem ScottContinuous.monotone [Preorder β] {f : α → β} (h : ScottContinuous f) :
+    Monotone f := by
+  intro a b hab
+  have e1 : IsLUB (f '' {a, b}) (f b) := by
+    apply h
+    · exact Set.insert_nonempty _ _
+    · exact directedOn_pair le_refl hab
+    · rw [IsLUB, upperBounds_insert, upperBounds_singleton,
+        Set.inter_eq_self_of_subset_right (set.Ici_subset_Ici.mpr hab)]
+      exact isLeast_Ici
+  apply e1.1
+  rw [Set.image_pair]
+  exact Set.mem_insert _ _
+#align scott_continuous.monotone ScottContinuous.monotone
+
+end ScottContinuous


### PR DESCRIPTION
Matches https://github.com/leanprover-community/mathlib/pull/18517

This result is required in #2508.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)


We prove an insert result for directed sets when the relation is reflexive. This is then used to show that a Scott continuous function is monotone.
