### PR TITLE
[Merged by Bors] - chore: update SHAs

### DIFF
--- a/Mathlib/Data/Fintype/Basic.lean
+++ b/Mathlib/Data/Fintype/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 
 ! This file was ported from Lean 3 source module data.fintype.basic
-! leanprover-community/mathlib commit 9003f28797c0664a49e4179487267c494477d853
+! leanprover-community/mathlib commit d78597269638367c3863d40d45108f52207e03cf
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/


### PR DESCRIPTION
This forward-ports:

* leanprover-community/mathlib#18277. No action is needed as the proof was already fixed during porting.
* leanprover-community/mathlib#18337. This was forward-ported in #1970 but the SHA was not updated.

See the diff here:

* [`data.fintype.basic`@`9003f28797c0664a49e4179487267c494477d853`..`d78597269638367c3863d40d45108f52207e03cf`](https://leanprover-community.github.io/mathlib-port-status/file/data/fintype/basic?range=9003f28797c0664a49e4179487267c494477d853..d78597269638367c3863d40d45108f52207e03cf)


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
