### PR TITLE
[Merged by Bors] - feat: port Algebra.Algebra.Operations

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4,6 +4,7 @@ import Mathlib.Algebra.Algebra.Basic
 import Mathlib.Algebra.Algebra.Bilinear
 import Mathlib.Algebra.Algebra.Equiv
 import Mathlib.Algebra.Algebra.Hom
+import Mathlib.Algebra.Algebra.Operators
 import Mathlib.Algebra.Algebra.Pi
 import Mathlib.Algebra.Algebra.Prod
 import Mathlib.Algebra.Algebra.RestrictScalars

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4,6 +4,7 @@ import Mathlib.Algebra.Algebra.Basic
 import Mathlib.Algebra.Algebra.Bilinear
 import Mathlib.Algebra.Algebra.Equiv
 import Mathlib.Algebra.Algebra.Hom
+import Mathlib.Algebra.Algebra.Operations
 import Mathlib.Algebra.Algebra.Pi
 import Mathlib.Algebra.Algebra.Prod
 import Mathlib.Algebra.Algebra.RestrictScalars

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4,7 +4,7 @@ import Mathlib.Algebra.Algebra.Basic
 import Mathlib.Algebra.Algebra.Bilinear
 import Mathlib.Algebra.Algebra.Equiv
 import Mathlib.Algebra.Algebra.Hom
-import Mathlib.Algebra.Algebra.Operators
+import Mathlib.Algebra.Algebra.Operations
 import Mathlib.Algebra.Algebra.Pi
 import Mathlib.Algebra.Algebra.Prod
 import Mathlib.Algebra.Algebra.RestrictScalars

--- a/Mathlib/Algebra/Algebra/Operations.lean
+++ b/Mathlib/Algebra/Algebra/Operations.lean
@@ -389,10 +389,9 @@ theorem mem_mul_span_singleton {x y : A} : x ∈ P * span R {y} ↔ ∃ z ∈ P,
 #align submodule.mem_mul_span_singleton Submodule.mem_mul_span_singleton
 
 /-- Sub-R-modules of an R-algebra form an idempotent semiring. -/
-instance : IdemSemiring (Submodule R A) :=
+instance idemSemiring : IdemSemiring (Submodule R A) :=
   { toAddSubmonoid_injective.semigroup _ fun m n : Submodule R A => mul_toAddSubmonoid m n,
-    AddMonoidWithOne.unary, Submodule.pointwiseAddCommMonoid, Submodule.one, Submodule.mul,
-    (by infer_instance : OrderBot (Submodule R A)),
+    AddMonoidWithOne.unary, Submodule.pointwiseAddCommMonoid,
     (by infer_instance :
       Lattice (Submodule R A)) with
     one_mul := Submodule.one_mul
@@ -400,13 +399,15 @@ instance : IdemSemiring (Submodule R A) :=
     zero_mul := bot_mul
     mul_zero := mul_bot
     left_distrib := mul_sup
-    right_distrib := sup_mul }
+    right_distrib := sup_mul,
+    -- porting note: removed `(by infer_instance : OrderBot (Submodule R A))`
+    bot_le := fun _ => bot_le }
 
 variable (M)
 
 theorem span_pow (s : Set A) : ∀ n : ℕ, span R s ^ n = span R (s ^ n)
   | 0 => by rw [pow_zero, pow_zero, one_eq_span_one_set]
-  | n + 1 => by rw [pow_succ, pow_succ, span_pow, span_mul_span]
+  | n + 1 => by rw [pow_succ, pow_succ, span_pow s n, span_mul_span]
 #align submodule.span_pow Submodule.span_pow
 
 theorem pow_eq_span_pow_set (n : ℕ) : M ^ n = span R ((M : Set A) ^ n) := by
@@ -426,9 +427,9 @@ theorem pow_toAddSubmonoid {n : ℕ} (h : n ≠ 0) : (M ^ n).toAddSubmonoid = M.
   induction' n with n ih
   · exact (h rfl).elim
   · rw [pow_succ, pow_succ, mul_toAddSubmonoid]
-    cases n
-    · rw [pow_zero, pow_zero, mul_one, ← mul_toAddSubmonoid, mul_one]
-    · rw [ih n.succ_ne_zero]
+    cases n with
+    | zero => rw [pow_zero, pow_zero, mul_one, ← mul_toAddSubmonoid, mul_one]
+    | succ n => rw [ih n.succ_ne_zero]
 #align submodule.pow_to_add_submonoid Submodule.pow_toAddSubmonoid
 
 theorem le_pow_toAddSubmonoid {n : ℕ} : M.toAddSubmonoid ^ n ≤ (M ^ n).toAddSubmonoid := by
@@ -443,7 +444,8 @@ theorem le_pow_toAddSubmonoid {n : ℕ} : M.toAddSubmonoid ^ n ≤ (M ^ n).toAdd
 protected theorem pow_induction_on_left' {C : ∀ (n : ℕ) (x), x ∈ M ^ n → Prop}
     (hr : ∀ r : R, C 0 (algebraMap _ _ r) (algebraMap_mem r))
     (hadd : ∀ x y i hx hy, C i x hx → C i y hy → C i (x + y) (add_mem ‹_› ‹_›))
-    (hmul : ∀ m ∈ M, ∀ (i x hx), C i x hx → C i.succ (m * x) (mul_mem_mul H hx)) {x : A} {n : ℕ}
+    (hmul : ∀ m (hm : m ∈ M), ∀ (i x hx), C i x hx → C i.succ (m * x) (mul_mem_mul hm hx))
+    {x : A} {n : ℕ}
     (hx : x ∈ M ^ n) : C n x hx := by
   induction' n with n n_ih generalizing x
   · rw [pow_zero] at hx
@@ -460,14 +462,15 @@ protected theorem pow_induction_on_right' {C : ∀ (n : ℕ) (x), x ∈ M ^ n �
     (hr : ∀ r : R, C 0 (algebraMap _ _ r) (algebraMap_mem r))
     (hadd : ∀ x y i hx hy, C i x hx → C i y hy → C i (x + y) (add_mem ‹_› ‹_›))
     (hmul :
-      ∀ i x hx, C i x hx → ∀ m ∈ M, C i.succ (x * m) ((pow_succ' M i).symm ▸ mul_mem_mul hx H))
+      ∀ i x hx, C i x hx →
+        ∀ m (hm : m ∈ M), C i.succ (x * m) ((pow_succ' M i).symm ▸ mul_mem_mul hx hm))
     {x : A} {n : ℕ} (hx : x ∈ M ^ n) : C n x hx := by
   induction' n with n n_ih generalizing x
   · rw [pow_zero] at hx
     obtain ⟨r, rfl⟩ := hx
     exact hr r
   revert hx
-  simp_rw [pow_succ']
+  simp_rw [pow_succ']  -- porting note: no longer rewrites
   intro hx
   exact
     Submodule.mul_induction_on' (fun m hm x ih => hmul _ _ hm (n_ih _) _ ih)
@@ -670,7 +673,7 @@ instance : Div (Submodule R A) :=
       zero_mem' := fun y hy => by
         rw [zero_mul]
         apply Submodule.zero_mem
-      add_mem' := fun a b ha hb y hy => by
+      add_mem' := fun ha hb y hy => by
         rw [add_mul]
         exact Submodule.add_mem _ (ha _ hy) (hb _ hy)
       smul_mem' := fun r x hx y hy => by

--- a/Mathlib/Algebra/Algebra/Operations.lean
+++ b/Mathlib/Algebra/Algebra/Operations.lean
@@ -328,13 +328,21 @@ section
 
 open Pointwise
 
--- TODO: lean4#2074
-set_option synthInstance.etaExperiment true in
+/-
+Porting note: the following def ought to be
+```
+protected def hasDistribPointwiseNeg {A} [Ring A] [Algebra R A] : HasDistribNeg (Submodule R A) :=
+  toAddSubmonoid_injective.hasDistribNeg _ neg_toAddSubmonoid mul_toAddSubmonoid
+```
+but this is not possible due to η-for-classes issues. See lean4#2074
+-/
 /-- `Submodule.pointwiseNeg` distributes over multiplication.
 
 This is available as an instance in the `pointwise` locale. -/
-protected def hasDistribPointwiseNeg {A} [Ring A] [Algebra R A] : HasDistribNeg (Submodule R A) :=
-  toAddSubmonoid_injective.hasDistribNeg _ neg_toAddSubmonoid mul_toAddSubmonoid
+protected def hasDistribPointwiseNeg {A} [Ring A] [Algebra R A] :
+    HasDistribNeg (@Submodule R A _ _ Algebra.toModule) :=
+  @Function.Injective.hasDistribNeg _ _ _ _ (id _) _ _ toAddSubmonoid_injective
+    (@neg_toAddSubmonoid R A _ _ Algebra.toModule) mul_toAddSubmonoid
 #align submodule.has_distrib_pointwise_neg Submodule.hasDistribPointwiseNeg
 
 scoped[Pointwise] attribute [instance] Submodule.hasDistribPointwiseNeg

--- a/Mathlib/Algebra/Algebra/Operations.lean
+++ b/Mathlib/Algebra/Algebra/Operations.lean
@@ -328,6 +328,8 @@ section
 
 open Pointwise
 
+-- TODO: lean4#2074
+set_option synthInstance.etaExperiment true in
 /-- `Submodule.pointwiseNeg` distributes over multiplication.
 
 This is available as an instance in the `pointwise` locale. -/

--- a/Mathlib/Algebra/Algebra/Operations.lean
+++ b/Mathlib/Algebra/Algebra/Operations.lean
@@ -220,13 +220,13 @@ theorem bot_mul : ⊥ * M = ⊥ :=
   map₂_bot_left _ _
 #align submodule.bot_mul Submodule.bot_mul
 
-@[simp, nolint simpNF] -- Porting note: simp can't prove this
+-- @[simp] -- Porting note: simp can prove this once we have a monoid structure
 protected theorem one_mul : (1 : Submodule R A) * M = M := by
   conv_lhs => rw [one_eq_span, ← span_eq M]
   erw [span_mul_span, one_mul, span_eq]
 #align submodule.one_mul Submodule.one_mul
 
-@[simp, nolint simpNF] -- Porting note: simp can't prove this
+-- @[simp] -- Porting note: simp can prove this once we have a monoid structure
 protected theorem mul_one : M * 1 = M := by
   conv_lhs => rw [one_eq_span, ← span_eq M]
   erw [span_mul_span, mul_one, span_eq]

--- a/Mathlib/Algebra/Algebra/Operations.lean
+++ b/Mathlib/Algebra/Algebra/Operations.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau
 
 ! This file was ported from Lean 3 source module algebra.algebra.operations
-! leanprover-community/mathlib commit 2bbc7e3884ba234309d2a43b19144105a753292e
+! leanprover-community/mathlib commit 2bbc7e3884ba234309d2a43b19144105a753292e TODO: update
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -105,7 +105,7 @@ theorem mem_one {x : A} : x ∈ (1 : Submodule R A) ↔ ∃ y, algebraMap R A y 
 
 @[simp]
 theorem toSubMulAction_one : (1 : Submodule R A).toSubMulAction = 1 :=
-  SetLike.ext fun x => mem_one.trans SubMulAction.mem_one'.symm
+  SetLike.ext fun _ => mem_one.trans SubMulAction.mem_one'.symm
 #align submodule.to_sub_mul_action_one Submodule.toSubMulAction_one
 
 theorem one_eq_span : (1 : Submodule R A) = R ∙ 1 := by

--- a/Mathlib/Algebra/Algebra/Operations.lean
+++ b/Mathlib/Algebra/Algebra/Operations.lean
@@ -1,0 +1,753 @@
+/-
+Copyright (c) 2019 Kenny Lau. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kenny Lau
+
+! This file was ported from Lean 3 source module algebra.algebra.operations
+! leanprover-community/mathlib commit 27b54c47c3137250a521aa64e9f1db90be5f6a26
+! Please do not edit these lines, except to modify the commit id
+! if you have ported upstream changes.
+-/
+import Mathbin.Algebra.Algebra.Bilinear
+import Mathbin.Algebra.Algebra.Equiv
+import Mathbin.Algebra.Module.Submodule.Pointwise
+import Mathbin.Algebra.Module.Submodule.Bilinear
+import Mathbin.Algebra.Module.Opposites
+import Mathbin.Algebra.Order.Kleene
+import Mathbin.Data.Finset.Pointwise
+import Mathbin.Data.Set.Semiring
+import Mathbin.Data.Set.Pointwise.BigOperators
+import Mathbin.GroupTheory.GroupAction.SubMulAction.Pointwise
+
+/-!
+# Multiplication and division of submodules of an algebra.
+
+An interface for multiplication and division of sub-R-modules of an R-algebra A is developed.
+
+## Main definitions
+
+Let `R` be a commutative ring (or semiring) and let `A` be an `R`-algebra.
+
+* `1 : submodule R A`       : the R-submodule R of the R-algebra A
+* `has_mul (submodule R A)` : multiplication of two sub-R-modules M and N of A is defined to be
+                              the smallest submodule containing all the products `m * n`.
+* `has_div (submodule R A)` : `I / J` is defined to be the submodule consisting of all `a : A` such
+                              that `a • J ⊆ I`
+
+It is proved that `submodule R A` is a semiring, and also an algebra over `set A`.
+
+Additionally, in the `pointwise` locale we promote `submodule.pointwise_distrib_mul_action` to a
+`mul_semiring_action` as `submodule.pointwise_mul_semiring_action`.
+
+## Tags
+
+multiplication of submodules, division of submodules, submodule semiring
+-/
+
+
+universe uι u v
+
+open Algebra Set MulOpposite
+
+open BigOperators
+
+open Pointwise
+
+namespace SubMulAction
+
+variable {R : Type u} {A : Type v} [CommSemiring R] [Semiring A] [Algebra R A]
+
+theorem algebraMap_mem (r : R) : algebraMap R A r ∈ (1 : SubMulAction R A) :=
+  ⟨r, (algebraMap_eq_smul_one r).symm⟩
+#align sub_mul_action.algebra_map_mem SubMulAction.algebraMap_mem
+
+theorem mem_one' {x : A} : x ∈ (1 : SubMulAction R A) ↔ ∃ y, algebraMap R A y = x :=
+  exists_congr fun r => by rw [algebra_map_eq_smul_one]
+#align sub_mul_action.mem_one' SubMulAction.mem_one'
+
+end SubMulAction
+
+namespace Submodule
+
+variable {ι : Sort uι}
+
+variable {R : Type u} [CommSemiring R]
+
+section Ring
+
+variable {A : Type v} [Semiring A] [Algebra R A]
+
+variable (S T : Set A) {M N P Q : Submodule R A} {m n : A}
+
+/-- `1 : submodule R A` is the submodule R of A. -/
+instance : One (Submodule R A) :=
+  ⟨(Algebra.linearMap R A).range⟩
+
+theorem one_eq_range : (1 : Submodule R A) = (Algebra.linearMap R A).range :=
+  rfl
+#align submodule.one_eq_range Submodule.one_eq_range
+
+theorem le_one_toAddSubmonoid : 1 ≤ (1 : Submodule R A).toAddSubmonoid :=
+  by
+  rintro x ⟨n, rfl⟩
+  exact ⟨n, map_natCast (algebraMap R A) n⟩
+#align submodule.le_one_to_add_submonoid Submodule.le_one_toAddSubmonoid
+
+theorem algebraMap_mem (r : R) : algebraMap R A r ∈ (1 : Submodule R A) :=
+  LinearMap.mem_range_self _ _
+#align submodule.algebra_map_mem Submodule.algebraMap_mem
+
+@[simp]
+theorem mem_one {x : A} : x ∈ (1 : Submodule R A) ↔ ∃ y, algebraMap R A y = x :=
+  Iff.rfl
+#align submodule.mem_one Submodule.mem_one
+
+@[simp]
+theorem toSubMulAction_one : (1 : Submodule R A).toSubMulAction = 1 :=
+  SetLike.ext fun x => mem_one.trans SubMulAction.mem_one'.symm
+#align submodule.to_sub_mul_action_one Submodule.toSubMulAction_one
+
+theorem one_eq_span : (1 : Submodule R A) = R ∙ 1 :=
+  by
+  apply Submodule.ext
+  intro a
+  simp only [mem_one, mem_span_singleton, Algebra.smul_def, mul_one]
+#align submodule.one_eq_span Submodule.one_eq_span
+
+theorem one_eq_span_one_set : (1 : Submodule R A) = span R 1 :=
+  one_eq_span
+#align submodule.one_eq_span_one_set Submodule.one_eq_span_one_set
+
+theorem one_le : (1 : Submodule R A) ≤ P ↔ (1 : A) ∈ P := by
+  simpa only [one_eq_span, span_le, Set.singleton_subset_iff]
+#align submodule.one_le Submodule.one_le
+
+protected theorem map_one {A'} [Semiring A'] [Algebra R A'] (f : A →ₐ[R] A') :
+    map f.toLinearMap (1 : Submodule R A) = 1 :=
+  by
+  ext
+  simp
+#align submodule.map_one Submodule.map_one
+
+@[simp]
+theorem map_op_one :
+    map (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ) : A →ₗ[R] Aᵐᵒᵖ) (1 : Submodule R A) = 1 :=
+  by
+  ext
+  induction x using MulOpposite.rec'
+  simp
+#align submodule.map_op_one Submodule.map_op_one
+
+@[simp]
+theorem comap_op_one :
+    comap (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ) : A →ₗ[R] Aᵐᵒᵖ) (1 : Submodule R Aᵐᵒᵖ) = 1 :=
+  by
+  ext
+  simp
+#align submodule.comap_op_one Submodule.comap_op_one
+
+@[simp]
+theorem map_unop_one :
+    map (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ).symm : Aᵐᵒᵖ →ₗ[R] A) (1 : Submodule R Aᵐᵒᵖ) = 1 := by
+  rw [← comap_equiv_eq_map_symm, comap_op_one]
+#align submodule.map_unop_one Submodule.map_unop_one
+
+@[simp]
+theorem comap_unop_one :
+    comap (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ).symm : Aᵐᵒᵖ →ₗ[R] A) (1 : Submodule R A) = 1 := by
+  rw [← map_equiv_eq_comap_symm, map_op_one]
+#align submodule.comap_unop_one Submodule.comap_unop_one
+
+/-- Multiplication of sub-R-modules of an R-algebra A. The submodule `M * N` is the
+smallest R-submodule of `A` containing the elements `m * n` for `m ∈ M` and `n ∈ N`. -/
+instance : Mul (Submodule R A) :=
+  ⟨Submodule.map₂ <| LinearMap.mul R A⟩
+
+theorem mul_mem_mul (hm : m ∈ M) (hn : n ∈ N) : m * n ∈ M * N :=
+  apply_mem_map₂ _ hm hn
+#align submodule.mul_mem_mul Submodule.mul_mem_mul
+
+theorem mul_le : M * N ≤ P ↔ ∀ m ∈ M, ∀ n ∈ N, m * n ∈ P :=
+  map₂_le
+#align submodule.mul_le Submodule.mul_le
+
+theorem mul_toAddSubmonoid (M N : Submodule R A) :
+    (M * N).toAddSubmonoid = M.toAddSubmonoid * N.toAddSubmonoid :=
+  by
+  dsimp [Mul.mul]
+  simp_rw [← LinearMap.mulLeft_toAddMonoid_hom R, LinearMap.mulLeft, ← map_to_add_submonoid _ N,
+    map₂]
+  rw [supr_to_add_submonoid]
+  rfl
+#align submodule.mul_to_add_submonoid Submodule.mul_toAddSubmonoid
+
+@[elab_as_elim]
+protected theorem mul_induction_on {C : A → Prop} {r : A} (hr : r ∈ M * N)
+    (hm : ∀ m ∈ M, ∀ n ∈ N, C (m * n)) (ha : ∀ x y, C x → C y → C (x + y)) : C r :=
+  by
+  rw [← mem_to_add_submonoid, mul_to_add_submonoid] at hr
+  exact AddSubmonoid.mul_induction_on hr hm ha
+#align submodule.mul_induction_on Submodule.mul_induction_on
+
+/-- A dependent version of `mul_induction_on`. -/
+@[elab_as_elim]
+protected theorem mul_induction_on' {C : ∀ r, r ∈ M * N → Prop}
+    (hm : ∀ m ∈ M, ∀ n ∈ N, C (m * n) (mul_mem_mul ‹_› ‹_›))
+    (ha : ∀ x hx y hy, C x hx → C y hy → C (x + y) (add_mem ‹_› ‹_›)) {r : A} (hr : r ∈ M * N) :
+    C r hr := by
+  refine' Exists.elim _ fun (hr : r ∈ M * N) (hc : C r hr) => hc
+  exact
+    Submodule.mul_induction_on hr (fun x hx y hy => ⟨_, hm _ hx _ hy⟩) fun x y ⟨_, hx⟩ ⟨_, hy⟩ =>
+      ⟨_, ha _ _ _ _ hx hy⟩
+#align submodule.mul_induction_on' Submodule.mul_induction_on'
+
+variable (R)
+
+theorem span_mul_span : span R S * span R T = span R (S * T) :=
+  map₂_span_span _ _ _ _
+#align submodule.span_mul_span Submodule.span_mul_span
+
+variable {R}
+
+variable (M N P Q)
+
+@[simp]
+theorem mul_bot : M * ⊥ = ⊥ :=
+  map₂_bot_right _ _
+#align submodule.mul_bot Submodule.mul_bot
+
+@[simp]
+theorem bot_mul : ⊥ * M = ⊥ :=
+  map₂_bot_left _ _
+#align submodule.bot_mul Submodule.bot_mul
+
+@[simp]
+protected theorem one_mul : (1 : Submodule R A) * M = M :=
+  by
+  conv_lhs => rw [one_eq_span, ← span_eq M]
+  erw [span_mul_span, one_mul, span_eq]
+#align submodule.one_mul Submodule.one_mul
+
+@[simp]
+protected theorem mul_one : M * 1 = M :=
+  by
+  conv_lhs => rw [one_eq_span, ← span_eq M]
+  erw [span_mul_span, mul_one, span_eq]
+#align submodule.mul_one Submodule.mul_one
+
+variable {M N P Q}
+
+@[mono]
+theorem mul_le_mul (hmp : M ≤ P) (hnq : N ≤ Q) : M * N ≤ P * Q :=
+  map₂_le_map₂ hmp hnq
+#align submodule.mul_le_mul Submodule.mul_le_mul
+
+theorem mul_le_mul_left (h : M ≤ N) : M * P ≤ N * P :=
+  map₂_le_map₂_left h
+#align submodule.mul_le_mul_left Submodule.mul_le_mul_left
+
+theorem mul_le_mul_right (h : N ≤ P) : M * N ≤ M * P :=
+  map₂_le_map₂_right h
+#align submodule.mul_le_mul_right Submodule.mul_le_mul_right
+
+variable (M N P)
+
+theorem mul_sup : M * (N ⊔ P) = M * N ⊔ M * P :=
+  map₂_sup_right _ _ _ _
+#align submodule.mul_sup Submodule.mul_sup
+
+theorem sup_mul : (M ⊔ N) * P = M * P ⊔ N * P :=
+  map₂_sup_left _ _ _ _
+#align submodule.sup_mul Submodule.sup_mul
+
+theorem mul_subset_mul : (↑M : Set A) * (↑N : Set A) ⊆ (↑(M * N) : Set A) :=
+  image2_subset_map₂ (LinearMap.Algebra.lmul R A).toLinearMap M N
+#align submodule.mul_subset_mul Submodule.mul_subset_mul
+
+protected theorem map_mul {A'} [Semiring A'] [Algebra R A'] (f : A →ₐ[R] A') :
+    map f.toLinearMap (M * N) = map f.toLinearMap M * map f.toLinearMap N :=
+  calc
+    map f.toLinearMap (M * N) = ⨆ i : M, (N.map (LinearMap.mul R A i)).map f.toLinearMap :=
+      map_supᵢ _ _
+    _ = map f.toLinearMap M * map f.toLinearMap N :=
+      by
+      apply congr_arg Sup
+      ext S
+      constructor <;> rintro ⟨y, hy⟩
+      · use f y, mem_map.mpr ⟨y.1, y.2, rfl⟩
+        refine' trans _ hy
+        ext
+        simp
+      · obtain ⟨y', hy', fy_eq⟩ := mem_map.mp y.2
+        use y', hy'
+        refine' trans _ hy
+        rw [f.to_linear_map_apply] at fy_eq
+        ext
+        simp [fy_eq]
+    
+#align submodule.map_mul Submodule.map_mul
+
+theorem map_op_mul :
+    map (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ) : A →ₗ[R] Aᵐᵒᵖ) (M * N) =
+      map (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ) : A →ₗ[R] Aᵐᵒᵖ) N *
+        map (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ) : A →ₗ[R] Aᵐᵒᵖ) M :=
+  by
+  apply le_antisymm
+  · simp_rw [map_le_iff_le_comap]
+    refine' mul_le.2 fun m hm n hn => _
+    rw [mem_comap, map_equiv_eq_comap_symm, map_equiv_eq_comap_symm]
+    show op n * op m ∈ _
+    exact mul_mem_mul hn hm
+  · refine' mul_le.2 (MulOpposite.rec' fun m hm => MulOpposite.rec' fun n hn => _)
+    rw [Submodule.mem_map_equiv] at hm hn⊢
+    exact mul_mem_mul hn hm
+#align submodule.map_op_mul Submodule.map_op_mul
+
+theorem comap_unop_mul :
+    comap (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ).symm : Aᵐᵒᵖ →ₗ[R] A) (M * N) =
+      comap (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ).symm : Aᵐᵒᵖ →ₗ[R] A) N *
+        comap (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ).symm : Aᵐᵒᵖ →ₗ[R] A) M :=
+  by simp_rw [← map_equiv_eq_comap_symm, map_op_mul]
+#align submodule.comap_unop_mul Submodule.comap_unop_mul
+
+theorem map_unop_mul (M N : Submodule R Aᵐᵒᵖ) :
+    map (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ).symm : Aᵐᵒᵖ →ₗ[R] A) (M * N) =
+      map (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ).symm : Aᵐᵒᵖ →ₗ[R] A) N *
+        map (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ).symm : Aᵐᵒᵖ →ₗ[R] A) M :=
+  have : Function.Injective (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ) : A →ₗ[R] Aᵐᵒᵖ) :=
+    LinearEquiv.injective _
+  map_injective_of_injective this <| by
+    rw [← map_comp, map_op_mul, ← map_comp, ← map_comp, LinearEquiv.comp_coe,
+      LinearEquiv.symm_trans_self, LinearEquiv.refl_toLinearMap, map_id, map_id, map_id]
+#align submodule.map_unop_mul Submodule.map_unop_mul
+
+theorem comap_op_mul (M N : Submodule R Aᵐᵒᵖ) :
+    comap (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ) : A →ₗ[R] Aᵐᵒᵖ) (M * N) =
+      comap (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ) : A →ₗ[R] Aᵐᵒᵖ) N *
+        comap (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ) : A →ₗ[R] Aᵐᵒᵖ) M :=
+  by simp_rw [comap_equiv_eq_map_symm, map_unop_mul]
+#align submodule.comap_op_mul Submodule.comap_op_mul
+
+section
+
+open Pointwise
+
+/-- `submodule.has_pointwise_neg` distributes over multiplication.
+
+This is available as an instance in the `pointwise` locale. -/
+protected def hasDistribPointwiseNeg {A} [Ring A] [Algebra R A] : HasDistribNeg (Submodule R A) :=
+  toAddSubmonoid_injective.HasDistribNeg _ neg_toAddSubmonoid mul_toAddSubmonoid
+#align submodule.has_distrib_pointwise_neg Submodule.hasDistribPointwiseNeg
+
+scoped[Pointwise] attribute [instance] Submodule.hasDistribPointwiseNeg
+
+end
+
+section DecidableEq
+
+open Classical
+
+theorem mem_span_mul_finite_of_mem_span_mul {R A} [Semiring R] [AddCommMonoid A] [Mul A]
+    [Module R A] {S : Set A} {S' : Set A} {x : A} (hx : x ∈ span R (S * S')) :
+    ∃ T T' : Finset A, ↑T ⊆ S ∧ ↑T' ⊆ S' ∧ x ∈ span R (T * T' : Set A) :=
+  by
+  obtain ⟨U, h, hU⟩ := mem_span_finite_of_mem_span hx
+  obtain ⟨T, T', hS, hS', h⟩ := Finset.subset_mul h
+  use T, T', hS, hS'
+  have h' : (U : Set A) ⊆ T * T' := by assumption_mod_cast
+  have h'' := span_mono h' hU
+  assumption
+#align submodule.mem_span_mul_finite_of_mem_span_mul Submodule.mem_span_mul_finite_of_mem_span_mul
+
+end DecidableEq
+
+theorem mul_eq_span_mul_set (s t : Submodule R A) : s * t = span R ((s : Set A) * (t : Set A)) :=
+  map₂_eq_span_image2 _ s t
+#align submodule.mul_eq_span_mul_set Submodule.mul_eq_span_mul_set
+
+theorem supᵢ_mul (s : ι → Submodule R A) (t : Submodule R A) : (⨆ i, s i) * t = ⨆ i, s i * t :=
+  map₂_supᵢ_left _ s t
+#align submodule.supr_mul Submodule.supᵢ_mul
+
+theorem mul_supᵢ (t : Submodule R A) (s : ι → Submodule R A) : (t * ⨆ i, s i) = ⨆ i, t * s i :=
+  map₂_supᵢ_right _ t s
+#align submodule.mul_supr Submodule.mul_supᵢ
+
+theorem mem_span_mul_finite_of_mem_mul {P Q : Submodule R A} {x : A} (hx : x ∈ P * Q) :
+    ∃ T T' : Finset A, (T : Set A) ⊆ P ∧ (T' : Set A) ⊆ Q ∧ x ∈ span R (T * T' : Set A) :=
+  Submodule.mem_span_mul_finite_of_mem_span_mul
+    (by rwa [← Submodule.span_eq P, ← Submodule.span_eq Q, Submodule.span_mul_span] at hx)
+#align submodule.mem_span_mul_finite_of_mem_mul Submodule.mem_span_mul_finite_of_mem_mul
+
+variable {M N P}
+
+theorem mem_span_singleton_mul {x y : A} : x ∈ span R {y} * P ↔ ∃ z ∈ P, y * z = x :=
+  by
+  simp_rw [(· * ·), map₂_span_singleton_eq_map, exists_prop]
+  rfl
+#align submodule.mem_span_singleton_mul Submodule.mem_span_singleton_mul
+
+theorem mem_mul_span_singleton {x y : A} : x ∈ P * span R {y} ↔ ∃ z ∈ P, z * y = x :=
+  by
+  simp_rw [(· * ·), map₂_span_singleton_eq_map_flip, exists_prop]
+  rfl
+#align submodule.mem_mul_span_singleton Submodule.mem_mul_span_singleton
+
+/-- Sub-R-modules of an R-algebra form an idempotent semiring. -/
+instance : IdemSemiring (Submodule R A) :=
+  { toAddSubmonoid_injective.Semigroup _ fun m n : Submodule R A => mul_toAddSubmonoid m n,
+    AddMonoidWithOne.unary, Submodule.pointwiseAddCommMonoid, Submodule.hasOne, Submodule.hasMul,
+    (by infer_instance : OrderBot (Submodule R A)),
+    (by infer_instance :
+      Lattice (Submodule R A)) with
+    one_mul := Submodule.one_mul
+    mul_one := Submodule.mul_one
+    zero_mul := bot_mul
+    mul_zero := mul_bot
+    left_distrib := mul_sup
+    right_distrib := sup_mul }
+
+variable (M)
+
+theorem span_pow (s : Set A) : ∀ n : ℕ, span R s ^ n = span R (s ^ n)
+  | 0 => by rw [pow_zero, pow_zero, one_eq_span_one_set]
+  | n + 1 => by rw [pow_succ, pow_succ, span_pow, span_mul_span]
+#align submodule.span_pow Submodule.span_pow
+
+theorem pow_eq_span_pow_set (n : ℕ) : M ^ n = span R ((M : Set A) ^ n) := by
+  rw [← span_pow, span_eq]
+#align submodule.pow_eq_span_pow_set Submodule.pow_eq_span_pow_set
+
+theorem pow_subset_pow {n : ℕ} : (↑M : Set A) ^ n ⊆ ↑(M ^ n : Submodule R A) :=
+  (pow_eq_span_pow_set M n).symm ▸ subset_span
+#align submodule.pow_subset_pow Submodule.pow_subset_pow
+
+theorem pow_mem_pow {x : A} (hx : x ∈ M) (n : ℕ) : x ^ n ∈ M ^ n :=
+  pow_subset_pow _ <| Set.pow_mem_pow hx _
+#align submodule.pow_mem_pow Submodule.pow_mem_pow
+
+theorem pow_toAddSubmonoid {n : ℕ} (h : n ≠ 0) : (M ^ n).toAddSubmonoid = M.toAddSubmonoid ^ n :=
+  by
+  induction' n with n ih
+  · exact (h rfl).elim
+  · rw [pow_succ, pow_succ, mul_to_add_submonoid]
+    cases n
+    · rw [pow_zero, pow_zero, mul_one, ← mul_to_add_submonoid, mul_one]
+    · rw [ih n.succ_ne_zero]
+#align submodule.pow_to_add_submonoid Submodule.pow_toAddSubmonoid
+
+theorem le_pow_toAddSubmonoid {n : ℕ} : M.toAddSubmonoid ^ n ≤ (M ^ n).toAddSubmonoid :=
+  by
+  obtain rfl | hn := Decidable.eq_or_ne n 0
+  · rw [pow_zero, pow_zero]
+    exact le_one_to_add_submonoid
+  · exact (pow_to_add_submonoid M hn).ge
+#align submodule.le_pow_to_add_submonoid Submodule.le_pow_toAddSubmonoid
+
+/-- Dependent version of `submodule.pow_induction_on_left`. -/
+@[elab_as_elim]
+protected theorem pow_induction_on_left' {C : ∀ (n : ℕ) (x), x ∈ M ^ n → Prop}
+    (hr : ∀ r : R, C 0 (algebraMap _ _ r) (algebraMap_mem r))
+    (hadd : ∀ x y i hx hy, C i x hx → C i y hy → C i (x + y) (add_mem ‹_› ‹_›))
+    (hmul : ∀ m ∈ M, ∀ (i x hx), C i x hx → C i.succ (m * x) (mul_mem_mul H hx)) {x : A} {n : ℕ}
+    (hx : x ∈ M ^ n) : C n x hx :=
+  by
+  induction' n with n n_ih generalizing x
+  · rw [pow_zero] at hx
+    obtain ⟨r, rfl⟩ := hx
+    exact hr r
+  exact
+    Submodule.mul_induction_on' (fun m hm x ih => hmul _ hm _ _ _ (n_ih ih))
+      (fun x hx y hy Cx Cy => hadd _ _ _ _ _ Cx Cy) hx
+#align submodule.pow_induction_on_left' Submodule.pow_induction_on_left'
+
+/-- Dependent version of `submodule.pow_induction_on_right`. -/
+@[elab_as_elim]
+protected theorem pow_induction_on_right' {C : ∀ (n : ℕ) (x), x ∈ M ^ n → Prop}
+    (hr : ∀ r : R, C 0 (algebraMap _ _ r) (algebraMap_mem r))
+    (hadd : ∀ x y i hx hy, C i x hx → C i y hy → C i (x + y) (add_mem ‹_› ‹_›))
+    (hmul :
+      ∀ i x hx, C i x hx → ∀ m ∈ M, C i.succ (x * m) ((pow_succ' M i).symm ▸ mul_mem_mul hx H))
+    {x : A} {n : ℕ} (hx : x ∈ M ^ n) : C n x hx :=
+  by
+  induction' n with n n_ih generalizing x
+  · rw [pow_zero] at hx
+    obtain ⟨r, rfl⟩ := hx
+    exact hr r
+  revert hx
+  simp_rw [pow_succ']
+  intro hx
+  exact
+    Submodule.mul_induction_on' (fun m hm x ih => hmul _ _ hm (n_ih _) _ ih)
+      (fun x hx y hy Cx Cy => hadd _ _ _ _ _ Cx Cy) hx
+#align submodule.pow_induction_on_right' Submodule.pow_induction_on_right'
+
+/-- To show a property on elements of `M ^ n` holds, it suffices to show that it holds for scalars,
+is closed under addition, and holds for `m * x` where `m ∈ M` and it holds for `x` -/
+@[elab_as_elim]
+protected theorem pow_induction_on_left {C : A → Prop} (hr : ∀ r : R, C (algebraMap _ _ r))
+    (hadd : ∀ x y, C x → C y → C (x + y)) (hmul : ∀ m ∈ M, ∀ (x), C x → C (m * x)) {x : A} {n : ℕ}
+    (hx : x ∈ M ^ n) : C x :=
+  Submodule.pow_induction_on_left' M hr (fun x y i hx hy => hadd x y)
+    (fun m hm i x hx => hmul _ hm _) hx
+#align submodule.pow_induction_on_left Submodule.pow_induction_on_left
+
+/-- To show a property on elements of `M ^ n` holds, it suffices to show that it holds for scalars,
+is closed under addition, and holds for `x * m` where `m ∈ M` and it holds for `x` -/
+@[elab_as_elim]
+protected theorem pow_induction_on_right {C : A → Prop} (hr : ∀ r : R, C (algebraMap _ _ r))
+    (hadd : ∀ x y, C x → C y → C (x + y)) (hmul : ∀ x, C x → ∀ m ∈ M, C (x * m)) {x : A} {n : ℕ}
+    (hx : x ∈ M ^ n) : C x :=
+  Submodule.pow_induction_on_right' M hr (fun x y i hx hy => hadd x y) (fun i x hx => hmul _) hx
+#align submodule.pow_induction_on_right Submodule.pow_induction_on_right
+
+/-- `submonoid.map` as a `monoid_with_zero_hom`, when applied to `alg_hom`s. -/
+@[simps]
+def mapHom {A'} [Semiring A'] [Algebra R A'] (f : A →ₐ[R] A') : Submodule R A →*₀ Submodule R A'
+    where
+  toFun := map f.toLinearMap
+  map_zero' := Submodule.map_bot _
+  map_one' := Submodule.map_one _
+  map_mul' _ _ := Submodule.map_mul _ _ _
+#align submodule.map_hom Submodule.mapHom
+
+/-- The ring of submodules of the opposite algebra is isomorphic to the opposite ring of
+submodules. -/
+@[simps apply symm_apply]
+def equivOpposite : Submodule R Aᵐᵒᵖ ≃+* (Submodule R A)ᵐᵒᵖ
+    where
+  toFun p := op <| p.comap (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ) : A →ₗ[R] Aᵐᵒᵖ)
+  invFun p := p.unop.comap (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ).symm : Aᵐᵒᵖ →ₗ[R] A)
+  left_inv p := SetLike.coe_injective <| rfl
+  right_inv p := unop_injective <| SetLike.coe_injective rfl
+  map_add' p q := by simp [comap_equiv_eq_map_symm, ← op_add]
+  map_mul' p q := congr_arg op <| comap_op_mul _ _
+#align submodule.equiv_opposite Submodule.equivOpposite
+
+protected theorem map_pow {A'} [Semiring A'] [Algebra R A'] (f : A →ₐ[R] A') (n : ℕ) :
+    map f.toLinearMap (M ^ n) = map f.toLinearMap M ^ n :=
+  map_pow (mapHom f) M n
+#align submodule.map_pow Submodule.map_pow
+
+theorem comap_unop_pow (n : ℕ) :
+    comap (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ).symm : Aᵐᵒᵖ →ₗ[R] A) (M ^ n) =
+      comap (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ).symm : Aᵐᵒᵖ →ₗ[R] A) M ^ n :=
+  (equivOpposite : Submodule R Aᵐᵒᵖ ≃+* _).symm.map_pow (op M) n
+#align submodule.comap_unop_pow Submodule.comap_unop_pow
+
+theorem comap_op_pow (n : ℕ) (M : Submodule R Aᵐᵒᵖ) :
+    comap (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ) : A →ₗ[R] Aᵐᵒᵖ) (M ^ n) =
+      comap (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ) : A →ₗ[R] Aᵐᵒᵖ) M ^ n :=
+  op_injective <| (equivOpposite : Submodule R Aᵐᵒᵖ ≃+* _).map_pow M n
+#align submodule.comap_op_pow Submodule.comap_op_pow
+
+theorem map_op_pow (n : ℕ) :
+    map (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ) : A →ₗ[R] Aᵐᵒᵖ) (M ^ n) =
+      map (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ) : A →ₗ[R] Aᵐᵒᵖ) M ^ n :=
+  by rw [map_equiv_eq_comap_symm, map_equiv_eq_comap_symm, comap_unop_pow]
+#align submodule.map_op_pow Submodule.map_op_pow
+
+theorem map_unop_pow (n : ℕ) (M : Submodule R Aᵐᵒᵖ) :
+    map (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ).symm : Aᵐᵒᵖ →ₗ[R] A) (M ^ n) =
+      map (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ).symm : Aᵐᵒᵖ →ₗ[R] A) M ^ n :=
+  by rw [← comap_equiv_eq_map_symm, ← comap_equiv_eq_map_symm, comap_op_pow]
+#align submodule.map_unop_pow Submodule.map_unop_pow
+
+/-- `span` is a semiring homomorphism (recall multiplication is pointwise multiplication of subsets
+on either side). -/
+@[simps]
+def span.ringHom : SetSemiring A →+* Submodule R A
+    where
+  toFun s := Submodule.span R s.down
+  map_zero' := span_empty
+  map_one' := one_eq_span.symm
+  map_add' := span_union
+  map_mul' s t := by rw [SetSemiring.down_mul, span_mul_span, ← image_mul_prod]
+#align submodule.span.ring_hom Submodule.span.ringHom
+
+section
+
+variable {α : Type _} [Monoid α] [MulSemiringAction α A] [SMulCommClass α R A]
+
+/-- The action on a submodule corresponding to applying the action to every element.
+
+This is available as an instance in the `pointwise` locale.
+
+This is a stronger version of `submodule.pointwise_distrib_mul_action`. -/
+protected def pointwiseMulSemiringAction : MulSemiringAction α (Submodule R A) :=
+  {
+    Submodule.pointwiseDistribMulAction with
+    smul_mul := fun r x y => Submodule.map_mul x y <| MulSemiringAction.toAlgHom R A r
+    smul_one := fun r => Submodule.map_one <| MulSemiringAction.toAlgHom R A r }
+#align submodule.pointwise_mul_semiring_action Submodule.pointwiseMulSemiringAction
+
+scoped[Pointwise] attribute [instance] Submodule.pointwiseMulSemiringAction
+
+end
+
+end Ring
+
+section CommRing
+
+variable {A : Type v} [CommSemiring A] [Algebra R A]
+
+variable {M N : Submodule R A} {m n : A}
+
+theorem mul_mem_mul_rev (hm : m ∈ M) (hn : n ∈ N) : n * m ∈ M * N :=
+  mul_comm m n ▸ mul_mem_mul hm hn
+#align submodule.mul_mem_mul_rev Submodule.mul_mem_mul_rev
+
+variable (M N)
+
+protected theorem mul_comm : M * N = N * M :=
+  le_antisymm (mul_le.2 fun r hrm s hsn => mul_mem_mul_rev hsn hrm)
+    (mul_le.2 fun r hrn s hsm => mul_mem_mul_rev hsm hrn)
+#align submodule.mul_comm Submodule.mul_comm
+
+/-- Sub-R-modules of an R-algebra A form a semiring. -/
+instance : IdemCommSemiring (Submodule R A) :=
+  { Submodule.idemSemiring with mul_comm := Submodule.mul_comm }
+
+theorem prod_span {ι : Type _} (s : Finset ι) (M : ι → Set A) :
+    (∏ i in s, Submodule.span R (M i)) = Submodule.span R (∏ i in s, M i) :=
+  by
+  letI := Classical.decEq ι
+  refine' Finset.induction_on s _ _
+  · simp [one_eq_span, Set.singleton_one]
+  · intro _ _ H ih
+    rw [Finset.prod_insert H, Finset.prod_insert H, ih, span_mul_span]
+#align submodule.prod_span Submodule.prod_span
+
+theorem prod_span_singleton {ι : Type _} (s : Finset ι) (x : ι → A) :
+    (∏ i in s, span R ({x i} : Set A)) = span R {∏ i in s, x i} := by
+  rw [prod_span, Set.finset_prod_singleton]
+#align submodule.prod_span_singleton Submodule.prod_span_singleton
+
+variable (R A)
+
+/-- R-submodules of the R-algebra A are a module over `set A`. -/
+instance moduleSet : Module (SetSemiring A) (Submodule R A)
+    where
+  smul s P := span R s.down * P
+  smul_add _ _ _ := mul_add _ _ _
+  add_smul s t P := by simp_rw [SMul.smul, SetSemiring.down_add, span_union, sup_mul, add_eq_sup]
+  mul_smul s t P := by simp_rw [SMul.smul, SetSemiring.down_mul, ← mul_assoc, span_mul_span]
+  one_smul P := by simp_rw [SMul.smul, SetSemiring.down_one, ← one_eq_span_one_set, one_mul]
+  zero_smul P := by simp_rw [SMul.smul, SetSemiring.down_zero, span_empty, bot_mul, bot_eq_zero]
+  smul_zero _ := mul_bot _
+#align submodule.module_set Submodule.moduleSet
+
+variable {R A}
+
+theorem smul_def (s : SetSemiring A) (P : Submodule R A) : s • P = span R s.down * P :=
+  rfl
+#align submodule.smul_def Submodule.smul_def
+
+theorem smul_le_smul {s t : SetSemiring A} {M N : Submodule R A} (h₁ : s.down ⊆ t.down)
+    (h₂ : M ≤ N) : s • M ≤ t • N :=
+  mul_le_mul (span_mono h₁) h₂
+#align submodule.smul_le_smul Submodule.smul_le_smul
+
+theorem smul_singleton (a : A) (M : Submodule R A) :
+    ({a} : Set A).up • M = M.map (LinearMap.mulLeft R a) :=
+  by
+  conv_lhs => rw [← span_eq M]
+  change span _ _ * span _ _ = _
+  rw [span_mul_span]
+  apply le_antisymm
+  · rw [span_le]
+    rintro _ ⟨b, m, hb, hm, rfl⟩
+    rw [SetLike.mem_coe, mem_map, set.mem_singleton_iff.mp hb]
+    exact ⟨m, hm, rfl⟩
+  · rintro _ ⟨m, hm, rfl⟩
+    exact subset_span ⟨a, m, Set.mem_singleton a, hm, rfl⟩
+#align submodule.smul_singleton Submodule.smul_singleton
+
+section Quotient
+
+/-- The elements of `I / J` are the `x` such that `x • J ⊆ I`.
+
+In fact, we define `x ∈ I / J` to be `∀ y ∈ J, x * y ∈ I` (see `mem_div_iff_forall_mul_mem`),
+which is equivalent to `x • J ⊆ I` (see `mem_div_iff_smul_subset`), but nicer to use in proofs.
+
+This is the general form of the ideal quotient, traditionally written $I : J$.
+-/
+instance : Div (Submodule R A) :=
+  ⟨fun I J =>
+    { carrier := { x | ∀ y ∈ J, x * y ∈ I }
+      zero_mem' := fun y hy => by
+        rw [zero_mul]
+        apply Submodule.zero_mem
+      add_mem' := fun a b ha hb y hy => by
+        rw [add_mul]
+        exact Submodule.add_mem _ (ha _ hy) (hb _ hy)
+      smul_mem' := fun r x hx y hy => by
+        rw [Algebra.smul_mul_assoc]
+        exact Submodule.smul_mem _ _ (hx _ hy) }⟩
+
+theorem mem_div_iff_forall_mul_mem {x : A} {I J : Submodule R A} : x ∈ I / J ↔ ∀ y ∈ J, x * y ∈ I :=
+  Iff.refl _
+#align submodule.mem_div_iff_forall_mul_mem Submodule.mem_div_iff_forall_mul_mem
+
+theorem mem_div_iff_smul_subset {x : A} {I J : Submodule R A} : x ∈ I / J ↔ x • (J : Set A) ⊆ I :=
+  ⟨fun h y ⟨y', hy', xy'_eq_y⟩ => by
+    rw [← xy'_eq_y]
+    apply h
+    assumption, fun h y hy => h (Set.smul_mem_smul_set hy)⟩
+#align submodule.mem_div_iff_smul_subset Submodule.mem_div_iff_smul_subset
+
+theorem le_div_iff {I J K : Submodule R A} : I ≤ J / K ↔ ∀ x ∈ I, ∀ z ∈ K, x * z ∈ J :=
+  Iff.refl _
+#align submodule.le_div_iff Submodule.le_div_iff
+
+theorem le_div_iff_mul_le {I J K : Submodule R A} : I ≤ J / K ↔ I * K ≤ J := by
+  rw [le_div_iff, mul_le]
+#align submodule.le_div_iff_mul_le Submodule.le_div_iff_mul_le
+
+@[simp]
+theorem one_le_one_div {I : Submodule R A} : 1 ≤ 1 / I ↔ I ≤ 1 :=
+  by
+  constructor; all_goals intro hI
+  · rwa [le_div_iff_mul_le, one_mul] at hI
+  · rwa [le_div_iff_mul_le, one_mul]
+#align submodule.one_le_one_div Submodule.one_le_one_div
+
+/- ./././Mathport/Syntax/Translate/Tactic/Lean3.lean:132:4: warning: unsupported: rw with cfg: { occs := occurrences.pos[occurrences.pos] «expr[ ,]»([1]) } -/
+theorem le_self_mul_one_div {I : Submodule R A} (hI : I ≤ 1) : I ≤ I * (1 / I) :=
+  by
+  rw [← mul_one I]
+  apply mul_le_mul_right (one_le_one_div.mpr hI)
+#align submodule.le_self_mul_one_div Submodule.le_self_mul_one_div
+
+theorem mul_one_div_le_one {I : Submodule R A} : I * (1 / I) ≤ 1 :=
+  by
+  rw [Submodule.mul_le]
+  intro m hm n hn
+  rw [Submodule.mem_div_iff_forall_mul_mem] at hn
+  rw [mul_comm]
+  exact hn m hm
+#align submodule.mul_one_div_le_one Submodule.mul_one_div_le_one
+
+@[simp]
+protected theorem map_div {B : Type _} [CommSemiring B] [Algebra R B] (I J : Submodule R A)
+    (h : A ≃ₐ[R] B) : (I / J).map h.toLinearMap = I.map h.toLinearMap / J.map h.toLinearMap :=
+  by
+  ext x
+  simp only [mem_map, mem_div_iff_forall_mul_mem]
+  constructor
+  · rintro ⟨x, hx, rfl⟩ _ ⟨y, hy, rfl⟩
+    exact ⟨x * y, hx _ hy, h.map_mul x y⟩
+  · rintro hx
+    refine' ⟨h.symm x, fun z hz => _, h.apply_symm_apply x⟩
+    obtain ⟨xz, xz_mem, hxz⟩ := hx (h z) ⟨z, hz, rfl⟩
+    convert xz_mem
+    apply h.injective
+    erw [h.map_mul, h.apply_symm_apply, hxz]
+#align submodule.map_div Submodule.map_div
+
+end Quotient
+
+end CommRing
+
+end Submodule
+

--- a/Mathlib/Algebra/Algebra/Operations.lean
+++ b/Mathlib/Algebra/Algebra/Operations.lean
@@ -220,13 +220,13 @@ theorem bot_mul : ⊥ * M = ⊥ :=
   map₂_bot_left _ _
 #align submodule.bot_mul Submodule.bot_mul
 
-@[simp]
+@[simp, nolint simpNF] -- Porting note: simp can't prove this
 protected theorem one_mul : (1 : Submodule R A) * M = M := by
   conv_lhs => rw [one_eq_span, ← span_eq M]
   erw [span_mul_span, one_mul, span_eq]
 #align submodule.one_mul Submodule.one_mul
 
-@[simp]
+@[simp, nolint simpNF] -- Porting note: simp can't prove this
 protected theorem mul_one : M * 1 = M := by
   conv_lhs => rw [one_eq_span, ← span_eq M]
   erw [span_mul_span, mul_one, span_eq]
@@ -756,3 +756,5 @@ end Quotient
 end CommRing
 
 end Submodule
+
+#lint

--- a/Mathlib/Algebra/Algebra/Operations.lean
+++ b/Mathlib/Algebra/Algebra/Operations.lean
@@ -81,9 +81,10 @@ variable (S T : Set A) {M N P Q : Submodule R A} {m n : A}
 
 /-- `1 : Submodule R A` is the submodule R of A. -/
 instance : One (Submodule R A) :=
-  ⟨(Algebra.linearMap R A).range⟩
+-- porting note: `f.range` notation doesn't work
+  ⟨LinearMap.range (Algebra.linearMap R A)⟩
 
-theorem one_eq_range : (1 : Submodule R A) = (Algebra.linearMap R A).range :=
+theorem one_eq_range : (1 : Submodule R A) = LinearMap.range (Algebra.linearMap R A) :=
   rfl
 #align submodule.one_eq_range Submodule.one_eq_range
 
@@ -117,7 +118,8 @@ theorem one_eq_span_one_set : (1 : Submodule R A) = span R 1 :=
 #align submodule.one_eq_span_one_set Submodule.one_eq_span_one_set
 
 theorem one_le : (1 : Submodule R A) ≤ P ↔ (1 : A) ∈ P := by
-  simpa only [one_eq_span, span_le, Set.singleton_subset_iff]
+  -- porting note: simpa no longer closes refl goals, so added `SetLike.mem_coe`
+  simp only [one_eq_span, span_le, Set.singleton_subset_iff, SetLike.mem_coe]
 #align submodule.one_le Submodule.one_le
 
 protected theorem map_one {A'} [Semiring A'] [Algebra R A'] (f : A →ₐ[R] A') :
@@ -130,7 +132,7 @@ protected theorem map_one {A'} [Semiring A'] [Algebra R A'] (f : A →ₐ[R] A')
 theorem map_op_one :
     map (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ) : A →ₗ[R] Aᵐᵒᵖ) (1 : Submodule R A) = 1 :=
   by
-  ext
+  ext x
   induction x using MulOpposite.rec'
   simp
 #align submodule.map_op_one Submodule.map_op_one
@@ -170,7 +172,7 @@ theorem mul_le : M * N ≤ P ↔ ∀ m ∈ M, ∀ n ∈ N, m * n ∈ P :=
 
 theorem mul_toAddSubmonoid (M N : Submodule R A) :
     (M * N).toAddSubmonoid = M.toAddSubmonoid * N.toAddSubmonoid := by
-  dsimp [Mul.mul]
+  dsimp [HMul.hMul, Mul.mul]  --porting note: added `hMul`
   simp_rw [← LinearMap.mulLeft_toAddMonoid_hom R, LinearMap.mulLeft, ← map_toAddSubmonoid _ N,
     map₂]
   rw [supᵢ_toAddSubmonoid]
@@ -187,7 +189,7 @@ protected theorem mul_induction_on {C : A → Prop} {r : A} (hr : r ∈ M * N)
 /-- A dependent version of `mul_induction_on`. -/
 @[elab_as_elim]
 protected theorem mul_induction_on' {C : ∀ r, r ∈ M * N → Prop}
-    (hm : ∀ m ∈ M, ∀ n ∈ N, C (m * n) (mul_mem_mul ‹_› ‹_›))
+    (hm : ∀ m (_ : m ∈ M), ∀ n (_ : n ∈ N), C (m * n) (mul_mem_mul ‹_› ‹_›))
     (ha : ∀ x hx y hy, C x hx → C y hy → C (x + y) (add_mem ‹_› ‹_›)) {r : A} (hr : r ∈ M * N) :
     C r hr := by
   refine' Exists.elim _ fun (hr : r ∈ M * N) (hc : C r hr) => hc

--- a/Mathlib/Algebra/Algebra/Operations.lean
+++ b/Mathlib/Algebra/Algebra/Operations.lean
@@ -756,5 +756,3 @@ end Quotient
 end CommRing
 
 end Submodule
-
-#lint

--- a/Mathlib/Algebra/Algebra/Operations.lean
+++ b/Mathlib/Algebra/Algebra/Operations.lean
@@ -472,7 +472,7 @@ protected theorem pow_induction_on_right' {C : ∀ (n : ℕ) (x), x ∈ M ^ n �
     obtain ⟨r, rfl⟩ := hx
     exact hr r
   revert hx
-  simp_rw [pow_succ']  -- porting note: no longer rewrites
+  simp_rw [pow_succ']  -- porting note: TODO: no longer rewrites
   intro hx
   exact
     Submodule.mul_induction_on' (fun m hm x ih => hmul _ _ hm (n_ih _) _ ih)
@@ -485,8 +485,9 @@ is closed under addition, and holds for `m * x` where `m ∈ M` and it holds for
 protected theorem pow_induction_on_left {C : A → Prop} (hr : ∀ r : R, C (algebraMap _ _ r))
     (hadd : ∀ x y, C x → C y → C (x + y)) (hmul : ∀ m ∈ M, ∀ (x), C x → C (m * x)) {x : A} {n : ℕ}
     (hx : x ∈ M ^ n) : C x :=
-  Submodule.pow_induction_on_left' M hr (fun x y i hx hy => hadd x y)
-    (fun m hm i x hx => hmul _ hm _) hx
+  -- porting note: `M` is explicit yet can't be passed positionally!
+  Submodule.pow_induction_on_left' (M := M) (C := fun _ a _ => C a) hr (fun x y _ _ _ => hadd x y)
+    (fun _ hm _ _ _ => hmul _ hm _) hx
 #align submodule.pow_induction_on_left Submodule.pow_induction_on_left
 
 /-- To show a property on elements of `M ^ n` holds, it suffices to show that it holds for scalars,
@@ -495,7 +496,7 @@ is closed under addition, and holds for `x * m` where `m ∈ M` and it holds for
 protected theorem pow_induction_on_right {C : A → Prop} (hr : ∀ r : R, C (algebraMap _ _ r))
     (hadd : ∀ x y, C x → C y → C (x + y)) (hmul : ∀ x, C x → ∀ m ∈ M, C (x * m)) {x : A} {n : ℕ}
     (hx : x ∈ M ^ n) : C x :=
-  Submodule.pow_induction_on_right' M hr (fun x y i hx hy => hadd x y) (fun i x hx => hmul _) hx
+  Submodule.pow_induction_on_right' M hr (fun x y _ _ _ => hadd x y) (fun _ _ _ => hmul _) hx
 #align submodule.pow_induction_on_right Submodule.pow_induction_on_right
 
 /-- `Submonoid.map` as a `MonoidWithZeroHom`, when applied to `AlgHom`s. -/

--- a/Mathlib/Algebra/Algebra/Operations.lean
+++ b/Mathlib/Algebra/Algebra/Operations.lean
@@ -8,16 +8,16 @@ Authors: Kenny Lau
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
-import Mathbin.Algebra.Algebra.Bilinear
-import Mathbin.Algebra.Algebra.Equiv
-import Mathbin.Algebra.Module.Submodule.Pointwise
-import Mathbin.Algebra.Module.Submodule.Bilinear
-import Mathbin.Algebra.Module.Opposites
-import Mathbin.Algebra.Order.Kleene
-import Mathbin.Data.Finset.Pointwise
-import Mathbin.Data.Set.Semiring
-import Mathbin.Data.Set.Pointwise.BigOperators
-import Mathbin.GroupTheory.GroupAction.SubMulAction.Pointwise
+import Mathlib.Algebra.Algebra.Bilinear
+import Mathlib.Algebra.Algebra.Equiv
+import Mathlib.Algebra.Module.Submodule.Pointwise
+import Mathlib.Algebra.Module.Submodule.Bilinear
+import Mathlib.Algebra.Module.Opposites
+import Mathlib.Algebra.Order.Kleene
+import Mathlib.Data.Finset.Pointwise
+import Mathlib.Data.Set.Semiring
+import Mathlib.Data.Set.Pointwise.BigOperators
+import Mathlib.GroupTheory.GroupAction.SubMulAction.Pointwise
 
 /-!
 # Multiplication and division of submodules of an algebra.
@@ -87,8 +87,7 @@ theorem one_eq_range : (1 : Submodule R A) = (Algebra.linearMap R A).range :=
   rfl
 #align submodule.one_eq_range Submodule.one_eq_range
 
-theorem le_one_toAddSubmonoid : 1 ≤ (1 : Submodule R A).toAddSubmonoid :=
-  by
+theorem le_one_toAddSubmonoid : 1 ≤ (1 : Submodule R A).toAddSubmonoid := by
   rintro x ⟨n, rfl⟩
   exact ⟨n, map_natCast (algebraMap R A) n⟩
 #align submodule.le_one_to_add_submonoid Submodule.le_one_toAddSubmonoid
@@ -107,8 +106,7 @@ theorem toSubMulAction_one : (1 : Submodule R A).toSubMulAction = 1 :=
   SetLike.ext fun x => mem_one.trans SubMulAction.mem_one'.symm
 #align submodule.to_sub_mul_action_one Submodule.toSubMulAction_one
 
-theorem one_eq_span : (1 : Submodule R A) = R ∙ 1 :=
-  by
+theorem one_eq_span : (1 : Submodule R A) = R ∙ 1 := by
   apply Submodule.ext
   intro a
   simp only [mem_one, mem_span_singleton, Algebra.smul_def, mul_one]
@@ -123,8 +121,7 @@ theorem one_le : (1 : Submodule R A) ≤ P ↔ (1 : A) ∈ P := by
 #align submodule.one_le Submodule.one_le
 
 protected theorem map_one {A'} [Semiring A'] [Algebra R A'] (f : A →ₐ[R] A') :
-    map f.toLinearMap (1 : Submodule R A) = 1 :=
-  by
+    map f.toLinearMap (1 : Submodule R A) = 1 := by
   ext
   simp
 #align submodule.map_one Submodule.map_one
@@ -172,8 +169,7 @@ theorem mul_le : M * N ≤ P ↔ ∀ m ∈ M, ∀ n ∈ N, m * n ∈ P :=
 #align submodule.mul_le Submodule.mul_le
 
 theorem mul_toAddSubmonoid (M N : Submodule R A) :
-    (M * N).toAddSubmonoid = M.toAddSubmonoid * N.toAddSubmonoid :=
-  by
+    (M * N).toAddSubmonoid = M.toAddSubmonoid * N.toAddSubmonoid := by
   dsimp [Mul.mul]
   simp_rw [← LinearMap.mulLeft_toAddMonoid_hom R, LinearMap.mulLeft, ← map_to_add_submonoid _ N,
     map₂]
@@ -183,8 +179,7 @@ theorem mul_toAddSubmonoid (M N : Submodule R A) :
 
 @[elab_as_elim]
 protected theorem mul_induction_on {C : A → Prop} {r : A} (hr : r ∈ M * N)
-    (hm : ∀ m ∈ M, ∀ n ∈ N, C (m * n)) (ha : ∀ x y, C x → C y → C (x + y)) : C r :=
-  by
+    (hm : ∀ m ∈ M, ∀ n ∈ N, C (m * n)) (ha : ∀ x y, C x → C y → C (x + y)) : C r := by
   rw [← mem_to_add_submonoid, mul_to_add_submonoid] at hr
   exact AddSubmonoid.mul_induction_on hr hm ha
 #align submodule.mul_induction_on Submodule.mul_induction_on
@@ -222,15 +217,13 @@ theorem bot_mul : ⊥ * M = ⊥ :=
 #align submodule.bot_mul Submodule.bot_mul
 
 @[simp]
-protected theorem one_mul : (1 : Submodule R A) * M = M :=
-  by
+protected theorem one_mul : (1 : Submodule R A) * M = M := by
   conv_lhs => rw [one_eq_span, ← span_eq M]
   erw [span_mul_span, one_mul, span_eq]
 #align submodule.one_mul Submodule.one_mul
 
 @[simp]
-protected theorem mul_one : M * 1 = M :=
-  by
+protected theorem mul_one : M * 1 = M := by
   conv_lhs => rw [one_eq_span, ← span_eq M]
   erw [span_mul_span, mul_one, span_eq]
 #align submodule.mul_one Submodule.mul_one
@@ -290,8 +283,7 @@ protected theorem map_mul {A'} [Semiring A'] [Algebra R A'] (f : A →ₐ[R] A')
 theorem map_op_mul :
     map (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ) : A →ₗ[R] Aᵐᵒᵖ) (M * N) =
       map (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ) : A →ₗ[R] Aᵐᵒᵖ) N *
-        map (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ) : A →ₗ[R] Aᵐᵒᵖ) M :=
-  by
+        map (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ) : A →ₗ[R] Aᵐᵒᵖ) M := by
   apply le_antisymm
   · simp_rw [map_le_iff_le_comap]
     refine' mul_le.2 fun m hm n hn => _
@@ -349,8 +341,7 @@ open Classical
 
 theorem mem_span_mul_finite_of_mem_span_mul {R A} [Semiring R] [AddCommMonoid A] [Mul A]
     [Module R A] {S : Set A} {S' : Set A} {x : A} (hx : x ∈ span R (S * S')) :
-    ∃ T T' : Finset A, ↑T ⊆ S ∧ ↑T' ⊆ S' ∧ x ∈ span R (T * T' : Set A) :=
-  by
+    ∃ T T' : Finset A, ↑T ⊆ S ∧ ↑T' ⊆ S' ∧ x ∈ span R (T * T' : Set A) := by
   obtain ⟨U, h, hU⟩ := mem_span_finite_of_mem_span hx
   obtain ⟨T, T', hS, hS', h⟩ := Finset.subset_mul h
   use T, T', hS, hS'
@@ -381,14 +372,12 @@ theorem mem_span_mul_finite_of_mem_mul {P Q : Submodule R A} {x : A} (hx : x ∈
 
 variable {M N P}
 
-theorem mem_span_singleton_mul {x y : A} : x ∈ span R {y} * P ↔ ∃ z ∈ P, y * z = x :=
-  by
+theorem mem_span_singleton_mul {x y : A} : x ∈ span R {y} * P ↔ ∃ z ∈ P, y * z = x := by
   simp_rw [(· * ·), map₂_span_singleton_eq_map, exists_prop]
   rfl
 #align submodule.mem_span_singleton_mul Submodule.mem_span_singleton_mul
 
-theorem mem_mul_span_singleton {x y : A} : x ∈ P * span R {y} ↔ ∃ z ∈ P, z * y = x :=
-  by
+theorem mem_mul_span_singleton {x y : A} : x ∈ P * span R {y} ↔ ∃ z ∈ P, z * y = x := by
   simp_rw [(· * ·), map₂_span_singleton_eq_map_flip, exists_prop]
   rfl
 #align submodule.mem_mul_span_singleton Submodule.mem_mul_span_singleton
@@ -436,8 +425,7 @@ theorem pow_toAddSubmonoid {n : ℕ} (h : n ≠ 0) : (M ^ n).toAddSubmonoid = M.
     · rw [ih n.succ_ne_zero]
 #align submodule.pow_to_add_submonoid Submodule.pow_toAddSubmonoid
 
-theorem le_pow_toAddSubmonoid {n : ℕ} : M.toAddSubmonoid ^ n ≤ (M ^ n).toAddSubmonoid :=
-  by
+theorem le_pow_toAddSubmonoid {n : ℕ} : M.toAddSubmonoid ^ n ≤ (M ^ n).toAddSubmonoid := by
   obtain rfl | hn := Decidable.eq_or_ne n 0
   · rw [pow_zero, pow_zero]
     exact le_one_to_add_submonoid
@@ -450,8 +438,7 @@ protected theorem pow_induction_on_left' {C : ∀ (n : ℕ) (x), x ∈ M ^ n →
     (hr : ∀ r : R, C 0 (algebraMap _ _ r) (algebraMap_mem r))
     (hadd : ∀ x y i hx hy, C i x hx → C i y hy → C i (x + y) (add_mem ‹_› ‹_›))
     (hmul : ∀ m ∈ M, ∀ (i x hx), C i x hx → C i.succ (m * x) (mul_mem_mul H hx)) {x : A} {n : ℕ}
-    (hx : x ∈ M ^ n) : C n x hx :=
-  by
+    (hx : x ∈ M ^ n) : C n x hx := by
   induction' n with n n_ih generalizing x
   · rw [pow_zero] at hx
     obtain ⟨r, rfl⟩ := hx
@@ -468,8 +455,7 @@ protected theorem pow_induction_on_right' {C : ∀ (n : ℕ) (x), x ∈ M ^ n �
     (hadd : ∀ x y i hx hy, C i x hx → C i y hy → C i (x + y) (add_mem ‹_› ‹_›))
     (hmul :
       ∀ i x hx, C i x hx → ∀ m ∈ M, C i.succ (x * m) ((pow_succ' M i).symm ▸ mul_mem_mul hx H))
-    {x : A} {n : ℕ} (hx : x ∈ M ^ n) : C n x hx :=
-  by
+    {x : A} {n : ℕ} (hx : x ∈ M ^ n) : C n x hx := by
   induction' n with n n_ih generalizing x
   · rw [pow_zero] at hx
     obtain ⟨r, rfl⟩ := hx
@@ -609,8 +595,7 @@ instance : IdemCommSemiring (Submodule R A) :=
   { Submodule.idemSemiring with mul_comm := Submodule.mul_comm }
 
 theorem prod_span {ι : Type _} (s : Finset ι) (M : ι → Set A) :
-    (∏ i in s, Submodule.span R (M i)) = Submodule.span R (∏ i in s, M i) :=
-  by
+    (∏ i in s, Submodule.span R (M i)) = Submodule.span R (∏ i in s, M i) := by
   letI := Classical.decEq ι
   refine' Finset.induction_on s _ _
   · simp [one_eq_span, Set.singleton_one]
@@ -649,8 +634,7 @@ theorem smul_le_smul {s t : SetSemiring A} {M N : Submodule R A} (h₁ : s.down 
 #align submodule.smul_le_smul Submodule.smul_le_smul
 
 theorem smul_singleton (a : A) (M : Submodule R A) :
-    ({a} : Set A).up • M = M.map (LinearMap.mulLeft R a) :=
-  by
+    ({a} : Set A).up • M = M.map (LinearMap.mulLeft R a) := by
   conv_lhs => rw [← span_eq M]
   change span _ _ * span _ _ = _
   rw [span_mul_span]
@@ -705,22 +689,19 @@ theorem le_div_iff_mul_le {I J K : Submodule R A} : I ≤ J / K ↔ I * K ≤ J 
 #align submodule.le_div_iff_mul_le Submodule.le_div_iff_mul_le
 
 @[simp]
-theorem one_le_one_div {I : Submodule R A} : 1 ≤ 1 / I ↔ I ≤ 1 :=
-  by
+theorem one_le_one_div {I : Submodule R A} : 1 ≤ 1 / I ↔ I ≤ 1 := by
   constructor; all_goals intro hI
   · rwa [le_div_iff_mul_le, one_mul] at hI
   · rwa [le_div_iff_mul_le, one_mul]
 #align submodule.one_le_one_div Submodule.one_le_one_div
 
 /- ./././Mathport/Syntax/Translate/Tactic/Lean3.lean:132:4: warning: unsupported: rw with cfg: { occs := occurrences.pos[occurrences.pos] «expr[ ,]»([1]) } -/
-theorem le_self_mul_one_div {I : Submodule R A} (hI : I ≤ 1) : I ≤ I * (1 / I) :=
-  by
+theorem le_self_mul_one_div {I : Submodule R A} (hI : I ≤ 1) : I ≤ I * (1 / I) := by
   rw [← mul_one I]
   apply mul_le_mul_right (one_le_one_div.mpr hI)
 #align submodule.le_self_mul_one_div Submodule.le_self_mul_one_div
 
-theorem mul_one_div_le_one {I : Submodule R A} : I * (1 / I) ≤ 1 :=
-  by
+theorem mul_one_div_le_one {I : Submodule R A} : I * (1 / I) ≤ 1 := by
   rw [Submodule.mul_le]
   intro m hm n hn
   rw [Submodule.mem_div_iff_forall_mul_mem] at hn

--- a/Mathlib/Algebra/Algebra/Operations.lean
+++ b/Mathlib/Algebra/Algebra/Operations.lean
@@ -507,7 +507,8 @@ is closed under addition, and holds for `x * m` where `m ∈ M` and it holds for
 protected theorem pow_induction_on_right {C : A → Prop} (hr : ∀ r : R, C (algebraMap _ _ r))
     (hadd : ∀ x y, C x → C y → C (x + y)) (hmul : ∀ x, C x → ∀ m ∈ M, C (x * m)) {x : A} {n : ℕ}
     (hx : x ∈ M ^ n) : C x :=
-  Submodule.pow_induction_on_right' M hr (fun x y _ _ _ => hadd x y) (fun _ _ _ => hmul _) hx
+  Submodule.pow_induction_on_right' (M := M) (C := fun _ a _ => C a) hr (fun x y _ _ _ => hadd x y)
+    (fun _ _ _ => hmul _) hx
 #align submodule.pow_induction_on_right Submodule.pow_induction_on_right
 
 /-- `Submonoid.map` as a `MonoidWithZeroHom`, when applied to `AlgHom`s. -/

--- a/Mathlib/Algebra/Algebra/Operations.lean
+++ b/Mathlib/Algebra/Algebra/Operations.lean
@@ -608,8 +608,8 @@ theorem mul_mem_mul_rev (hm : m ∈ M) (hn : n ∈ N) : n * m ∈ M * N :=
 variable (M N)
 
 protected theorem mul_comm : M * N = N * M :=
-  le_antisymm (mul_le.2 fun r hrm s hsn => mul_mem_mul_rev hsn hrm)
-    (mul_le.2 fun r hrn s hsm => mul_mem_mul_rev hsm hrn)
+  le_antisymm (mul_le.2 fun _r hrm _s hsn => mul_mem_mul_rev hsn hrm)
+    (mul_le.2 fun _r hrn _s hsm => mul_mem_mul_rev hsm hrn)
 #align submodule.mul_comm Submodule.mul_comm
 
 /-- Sub-R-modules of an R-algebra A form a semiring. -/

--- a/Mathlib/Algebra/Algebra/Operations.lean
+++ b/Mathlib/Algebra/Algebra/Operations.lean
@@ -271,14 +271,14 @@ protected theorem map_mul {A'} [Semiring A'] [Algebra R A'] (f : A →ₐ[R] A')
       apply congr_arg supₛ
       ext S
       constructor <;> rintro ⟨y, hy⟩
-      · use f y, mem_map.mpr ⟨y.1, y.2, rfl⟩
-        refine' trans _ hy
+      · use ⟨f y, mem_map.mpr ⟨y.1, y.2, rfl⟩⟩  -- porting note: added `⟨⟩`
+        refine' Eq.trans _ hy
         ext
         simp
       · obtain ⟨y', hy', fy_eq⟩ := mem_map.mp y.2
-        use y', hy'
-        refine' trans _ hy
-        rw [f.to_linear_map_apply] at fy_eq
+        use ⟨y', hy'⟩  -- porting note: added `⟨⟩`
+        refine' Eq.trans _ hy
+        rw [f.toLinearMap_apply] at fy_eq
         ext
         simp [fy_eq]
 

--- a/Mathlib/Algebra/Algebra/Operations.lean
+++ b/Mathlib/Algebra/Algebra/Operations.lean
@@ -28,16 +28,16 @@ An interface for multiplication and division of sub-R-modules of an R-algebra A 
 
 Let `R` be a commutative ring (or semiring) and let `A` be an `R`-algebra.
 
-* `1 : submodule R A`       : the R-submodule R of the R-algebra A
-* `has_mul (submodule R A)` : multiplication of two sub-R-modules M and N of A is defined to be
+* `1 : Submodule R A`       : the R-submodule R of the R-algebra A
+* `Mul (Submodule R A)` : multiplication of two sub-R-modules M and N of A is defined to be
                               the smallest submodule containing all the products `m * n`.
-* `has_div (submodule R A)` : `I / J` is defined to be the submodule consisting of all `a : A` such
+* `Div (Submodule R A)` : `I / J` is defined to be the submodule consisting of all `a : A` such
                               that `a • J ⊆ I`
 
-It is proved that `submodule R A` is a semiring, and also an algebra over `set A`.
+It is proved that `Submodule R A` is a semiring, and also an algebra over `Set A`.
 
-Additionally, in the `pointwise` locale we promote `submodule.pointwise_distrib_mul_action` to a
-`mul_semiring_action` as `submodule.pointwise_mul_semiring_action`.
+Additionally, in the `pointwise` locale we promote `Submodule.pointwiseDistribMulAction` to a
+`MulSemiringAction` as `Submodule.pointwiseMulSemiringAction`.
 
 ## Tags
 
@@ -79,7 +79,7 @@ variable {A : Type v} [Semiring A] [Algebra R A]
 
 variable (S T : Set A) {M N P Q : Submodule R A} {m n : A}
 
-/-- `1 : submodule R A` is the submodule R of A. -/
+/-- `1 : Submodule R A` is the submodule R of A. -/
 instance : One (Submodule R A) :=
   ⟨(Algebra.linearMap R A).range⟩
 
@@ -324,7 +324,7 @@ section
 
 open Pointwise
 
-/-- `submodule.has_pointwise_neg` distributes over multiplication.
+/-- `Submodule.pointwiseNeg` distributes over multiplication.
 
 This is available as an instance in the `pointwise` locale. -/
 protected def hasDistribPointwiseNeg {A} [Ring A] [Algebra R A] : HasDistribNeg (Submodule R A) :=
@@ -432,7 +432,7 @@ theorem le_pow_toAddSubmonoid {n : ℕ} : M.toAddSubmonoid ^ n ≤ (M ^ n).toAdd
   · exact (pow_to_add_submonoid M hn).ge
 #align submodule.le_pow_to_add_submonoid Submodule.le_pow_toAddSubmonoid
 
-/-- Dependent version of `submodule.pow_induction_on_left`. -/
+/-- Dependent version of `Submodule.pow_induction_on_left`. -/
 @[elab_as_elim]
 protected theorem pow_induction_on_left' {C : ∀ (n : ℕ) (x), x ∈ M ^ n → Prop}
     (hr : ∀ r : R, C 0 (algebraMap _ _ r) (algebraMap_mem r))
@@ -448,7 +448,7 @@ protected theorem pow_induction_on_left' {C : ∀ (n : ℕ) (x), x ∈ M ^ n →
       (fun x hx y hy Cx Cy => hadd _ _ _ _ _ Cx Cy) hx
 #align submodule.pow_induction_on_left' Submodule.pow_induction_on_left'
 
-/-- Dependent version of `submodule.pow_induction_on_right`. -/
+/-- Dependent version of `Submodule.pow_induction_on_right`. -/
 @[elab_as_elim]
 protected theorem pow_induction_on_right' {C : ∀ (n : ℕ) (x), x ∈ M ^ n → Prop}
     (hr : ∀ r : R, C 0 (algebraMap _ _ r) (algebraMap_mem r))
@@ -487,7 +487,7 @@ protected theorem pow_induction_on_right {C : A → Prop} (hr : ∀ r : R, C (al
   Submodule.pow_induction_on_right' M hr (fun x y i hx hy => hadd x y) (fun i x hx => hmul _) hx
 #align submodule.pow_induction_on_right Submodule.pow_induction_on_right
 
-/-- `submonoid.map` as a `monoid_with_zero_hom`, when applied to `alg_hom`s. -/
+/-- `Submonoid.map` as a `MonoidWithZeroHom`, when applied to `AlgHom`s. -/
 @[simps]
 def mapHom {A'} [Semiring A'] [Algebra R A'] (f : A →ₐ[R] A') : Submodule R A →*₀ Submodule R A'
     where
@@ -558,7 +558,7 @@ variable {α : Type _} [Monoid α] [MulSemiringAction α A] [SMulCommClass α R 
 
 This is available as an instance in the `pointwise` locale.
 
-This is a stronger version of `submodule.pointwise_distrib_mul_action`. -/
+This is a stronger version of `Submodule.pointwiseDistribMulAction`. -/
 protected def pointwiseMulSemiringAction : MulSemiringAction α (Submodule R A) :=
   {
     Submodule.pointwiseDistribMulAction with
@@ -609,7 +609,7 @@ theorem prod_span_singleton {ι : Type _} (s : Finset ι) (x : ι → A) :
 
 variable (R A)
 
-/-- R-submodules of the R-algebra A are a module over `set A`. -/
+/-- R-submodules of the R-algebra A are a module over `Set A`. -/
 instance moduleSet : Module (SetSemiring A) (Submodule R A)
     where
   smul s P := span R s * P

--- a/Mathlib/Algebra/Algebra/Operations.lean
+++ b/Mathlib/Algebra/Algebra/Operations.lean
@@ -472,7 +472,11 @@ protected theorem pow_induction_on_right' {C : ∀ (n : ℕ) (x), x ∈ M ^ n �
     obtain ⟨r, rfl⟩ := hx
     exact hr r
   revert hx
-  simp_rw [pow_succ' M n]  -- porting note: TODO: no longer rewrites
+  -- porting note: workaround for lean4#1926, was `simp_rw [pow_succ']`
+  have h_lean4_1926_aux : x ∈ M ^ Nat.succ n ↔ x ∈ M ^ n * M := by rw [pow_succ']
+  suffices h_lean4_1926 : ∀ (hx' : x ∈ M ^ n * M), C (Nat.succ n) x (h_lean4_1926_aux.mpr hx') from
+    fun hx => h_lean4_1926 (h_lean4_1926_aux.mp hx)
+  -- porting note: end workaround
   intro hx
   exact
     Submodule.mul_induction_on' (fun m hm x ih => hmul _ _ hm (n_ih _) _ ih)

--- a/Mathlib/Algebra/Algebra/Operations.lean
+++ b/Mathlib/Algebra/Algebra/Operations.lean
@@ -472,7 +472,7 @@ protected theorem pow_induction_on_right' {C : ∀ (n : ℕ) (x), x ∈ M ^ n �
     obtain ⟨r, rfl⟩ := hx
     exact hr r
   revert hx
-  simp_rw [pow_succ']  -- porting note: TODO: no longer rewrites
+  simp_rw [pow_succ' M n]  -- porting note: TODO: no longer rewrites
   intro hx
   exact
     Submodule.mul_induction_on' (fun m hm x ih => hmul _ _ hm (n_ih _) _ ih)
@@ -553,8 +553,7 @@ theorem map_unop_pow (n : ℕ) (M : Submodule R Aᵐᵒᵖ) :
 
 /-- `span` is a semiring homomorphism (recall multiplication is pointwise multiplication of subsets
 on either side). -/
-def span.ringHom : SetSemiring A →+* Submodule R A
-    where
+def span.ringHom : SetSemiring A →+* Submodule R A where
   toFun := Submodule.span R
   map_zero' := span_empty
   map_one' := one_eq_span.symm
@@ -622,17 +621,18 @@ theorem prod_span_singleton {ι : Type _} (s : Finset ι) (x : ι → A) :
 variable (R A)
 
 /-- R-submodules of the R-algebra A are a module over `Set A`. -/
-instance moduleSet : Module (SetSemiring A) (Submodule R A)
-    where
-  smul s P := span R s * P
+instance moduleSet : Module (SetSemiring A) (Submodule R A) where
+  -- porting note: have to unfold both `HSMul.hSMul` and `SMul.smul`
+  smul s P := span R (SetSemiring.down s) * P
   smul_add _ _ _ := mul_add _ _ _
-  add_smul s t P := show span R (s ⊔ t) * P = _ by erw [span_union, right_distrib]
-  mul_smul s t P := show _ = _ * (_ * _) by rw [← mul_assoc, span_mul_span, ← image_mul_prod]
-  one_smul P :=
-    show span R {(1 : A)} * P = _ by
-      conv_lhs => erw [← span_eq P]
-      erw [span_mul_span, one_mul, span_eq]
-  zero_smul P := show span R ∅ * P = ⊥ by erw [span_empty, bot_mul]
+  add_smul s t P := by
+    simp_rw [HSMul.hSMul, SMul.smul, SetSemiring.down_add, span_union, sup_mul, add_eq_sup]
+  mul_smul s t P := by
+    simp_rw [HSMul.hSMul, SMul.smul, SetSemiring.down_mul, ← mul_assoc, span_mul_span]
+  one_smul P := by
+    simp_rw [HSMul.hSMul, SMul.smul, SetSemiring.down_one, ←one_eq_span_one_set, one_mul]
+  zero_smul P := by
+    simp_rw [HSMul.hSMul, SMul.smul, SetSemiring.down_zero, span_empty, bot_mul, bot_eq_zero]
   smul_zero _ := mul_bot _
 #align submodule.module_set Submodule.moduleSet
 
@@ -643,7 +643,7 @@ theorem smul_def {s : SetSemiring A} {P : Submodule R A} : s • P = span R s * 
 #align submodule.smul_def Submodule.smul_def
 
 theorem smul_le_smul {s t : SetSemiring A} {M N : Submodule R A}
-    (h₁ : SetSemiring.down s ≤ SetSemiring.down t)
+    (h₁ : SetSemiring.down s ⊆ SetSemiring.down t)
     (h₂ : M ≤ N) : s • M ≤ t • N :=
   mul_le_mul (span_mono h₁) h₂
 #align submodule.smul_le_smul Submodule.smul_le_smul
@@ -656,7 +656,7 @@ theorem smul_singleton (a : A) (M : Submodule R A) :
   apply le_antisymm
   · rw [span_le]
     rintro _ ⟨b, m, hb, hm, rfl⟩
-    rw [SetLike.mem_coe, mem_map, set.mem_singleton_iff.mp hb]
+    rw [SetLike.mem_coe, mem_map, Set.mem_singleton_iff.mp hb]
     exact ⟨m, hm, rfl⟩
   · rintro _ ⟨m, hm, rfl⟩
     exact subset_span ⟨a, m, Set.mem_singleton a, hm, rfl⟩

--- a/Mathlib/Algebra/Algebra/Operations.lean
+++ b/Mathlib/Algebra/Algebra/Operations.lean
@@ -8,16 +8,16 @@ Authors: Kenny Lau
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
-import Mathbin.Algebra.Algebra.Bilinear
-import Mathbin.Algebra.Algebra.Equiv
-import Mathbin.Algebra.Module.Submodule.Pointwise
-import Mathbin.Algebra.Module.Submodule.Bilinear
-import Mathbin.Algebra.Module.Opposites
-import Mathbin.Algebra.Order.Kleene
-import Mathbin.Data.Finset.Pointwise
-import Mathbin.Data.Set.Semiring
-import Mathbin.Data.Set.Pointwise.BigOperators
-import Mathbin.GroupTheory.GroupAction.SubMulAction.Pointwise
+import Mathlib.Algebra.Algebra.Bilinear
+import Mathlib.Algebra.Algebra.Equiv
+import Mathlib.Algebra.Module.Submodule.Pointwise
+import Mathlib.Algebra.Module.Submodule.Bilinear
+import Mathlib.Algebra.Module.Opposites
+import Mathlib.Algebra.Order.Kleene
+import Mathlib.Data.Finset.Pointwise
+import Mathlib.Data.Set.Semiring
+import Mathlib.Data.Set.Pointwise.BigOperators
+import Mathlib.GroupTheory.GroupAction.SubMulAction.Pointwise
 
 /-!
 # Multiplication and division of submodules of an algebra.
@@ -87,8 +87,7 @@ theorem one_eq_range : (1 : Submodule R A) = (Algebra.linearMap R A).range :=
   rfl
 #align submodule.one_eq_range Submodule.one_eq_range
 
-theorem le_one_toAddSubmonoid : 1 ≤ (1 : Submodule R A).toAddSubmonoid :=
-  by
+theorem le_one_toAddSubmonoid : 1 ≤ (1 : Submodule R A).toAddSubmonoid := by
   rintro x ⟨n, rfl⟩
   exact ⟨n, map_natCast (algebraMap R A) n⟩
 #align submodule.le_one_to_add_submonoid Submodule.le_one_toAddSubmonoid
@@ -107,8 +106,7 @@ theorem toSubMulAction_one : (1 : Submodule R A).toSubMulAction = 1 :=
   SetLike.ext fun x => mem_one.trans SubMulAction.mem_one'.symm
 #align submodule.to_sub_mul_action_one Submodule.toSubMulAction_one
 
-theorem one_eq_span : (1 : Submodule R A) = R ∙ 1 :=
-  by
+theorem one_eq_span : (1 : Submodule R A) = R ∙ 1 := by
   apply Submodule.ext
   intro a
   simp only [mem_one, mem_span_singleton, Algebra.smul_def, mul_one]
@@ -123,8 +121,7 @@ theorem one_le : (1 : Submodule R A) ≤ P ↔ (1 : A) ∈ P := by
 #align submodule.one_le Submodule.one_le
 
 protected theorem map_one {A'} [Semiring A'] [Algebra R A'] (f : A →ₐ[R] A') :
-    map f.toLinearMap (1 : Submodule R A) = 1 :=
-  by
+    map f.toLinearMap (1 : Submodule R A) = 1 := by
   ext
   simp
 #align submodule.map_one Submodule.map_one
@@ -172,8 +169,7 @@ theorem mul_le : M * N ≤ P ↔ ∀ m ∈ M, ∀ n ∈ N, m * n ∈ P :=
 #align submodule.mul_le Submodule.mul_le
 
 theorem mul_toAddSubmonoid (M N : Submodule R A) :
-    (M * N).toAddSubmonoid = M.toAddSubmonoid * N.toAddSubmonoid :=
-  by
+    (M * N).toAddSubmonoid = M.toAddSubmonoid * N.toAddSubmonoid := by
   dsimp [Mul.mul]
   simp_rw [← LinearMap.mulLeft_toAddMonoid_hom R, LinearMap.mulLeft, ← map_to_add_submonoid _ N,
     map₂]
@@ -183,8 +179,7 @@ theorem mul_toAddSubmonoid (M N : Submodule R A) :
 
 @[elab_as_elim]
 protected theorem mul_induction_on {C : A → Prop} {r : A} (hr : r ∈ M * N)
-    (hm : ∀ m ∈ M, ∀ n ∈ N, C (m * n)) (ha : ∀ x y, C x → C y → C (x + y)) : C r :=
-  by
+    (hm : ∀ m ∈ M, ∀ n ∈ N, C (m * n)) (ha : ∀ x y, C x → C y → C (x + y)) : C r := by
   rw [← mem_to_add_submonoid, mul_to_add_submonoid] at hr
   exact AddSubmonoid.mul_induction_on hr hm ha
 #align submodule.mul_induction_on Submodule.mul_induction_on
@@ -222,15 +217,13 @@ theorem bot_mul : ⊥ * M = ⊥ :=
 #align submodule.bot_mul Submodule.bot_mul
 
 @[simp]
-protected theorem one_mul : (1 : Submodule R A) * M = M :=
-  by
+protected theorem one_mul : (1 : Submodule R A) * M = M := by
   conv_lhs => rw [one_eq_span, ← span_eq M]
   erw [span_mul_span, one_mul, span_eq]
 #align submodule.one_mul Submodule.one_mul
 
 @[simp]
-protected theorem mul_one : M * 1 = M :=
-  by
+protected theorem mul_one : M * 1 = M := by
   conv_lhs => rw [one_eq_span, ← span_eq M]
   erw [span_mul_span, mul_one, span_eq]
 #align submodule.mul_one Submodule.mul_one
@@ -290,8 +283,7 @@ protected theorem map_mul {A'} [Semiring A'] [Algebra R A'] (f : A →ₐ[R] A')
 theorem map_op_mul :
     map (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ) : A →ₗ[R] Aᵐᵒᵖ) (M * N) =
       map (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ) : A →ₗ[R] Aᵐᵒᵖ) N *
-        map (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ) : A →ₗ[R] Aᵐᵒᵖ) M :=
-  by
+        map (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ) : A →ₗ[R] Aᵐᵒᵖ) M := by
   apply le_antisymm
   · simp_rw [map_le_iff_le_comap]
     refine' mul_le.2 fun m hm n hn => _
@@ -349,8 +341,7 @@ open Classical
 
 theorem mem_span_mul_finite_of_mem_span_mul {R A} [Semiring R] [AddCommMonoid A] [Mul A]
     [Module R A] {S : Set A} {S' : Set A} {x : A} (hx : x ∈ span R (S * S')) :
-    ∃ T T' : Finset A, ↑T ⊆ S ∧ ↑T' ⊆ S' ∧ x ∈ span R (T * T' : Set A) :=
-  by
+    ∃ T T' : Finset A, ↑T ⊆ S ∧ ↑T' ⊆ S' ∧ x ∈ span R (T * T' : Set A) := by
   obtain ⟨U, h, hU⟩ := mem_span_finite_of_mem_span hx
   obtain ⟨T, T', hS, hS', h⟩ := Finset.subset_mul h
   use T, T', hS, hS'
@@ -381,14 +372,12 @@ theorem mem_span_mul_finite_of_mem_mul {P Q : Submodule R A} {x : A} (hx : x ∈
 
 variable {M N P}
 
-theorem mem_span_singleton_mul {x y : A} : x ∈ span R {y} * P ↔ ∃ z ∈ P, y * z = x :=
-  by
+theorem mem_span_singleton_mul {x y : A} : x ∈ span R {y} * P ↔ ∃ z ∈ P, y * z = x := by
   simp_rw [(· * ·), map₂_span_singleton_eq_map, exists_prop]
   rfl
 #align submodule.mem_span_singleton_mul Submodule.mem_span_singleton_mul
 
-theorem mem_mul_span_singleton {x y : A} : x ∈ P * span R {y} ↔ ∃ z ∈ P, z * y = x :=
-  by
+theorem mem_mul_span_singleton {x y : A} : x ∈ P * span R {y} ↔ ∃ z ∈ P, z * y = x := by
   simp_rw [(· * ·), map₂_span_singleton_eq_map_flip, exists_prop]
   rfl
 #align submodule.mem_mul_span_singleton Submodule.mem_mul_span_singleton
@@ -436,8 +425,7 @@ theorem pow_toAddSubmonoid {n : ℕ} (h : n ≠ 0) : (M ^ n).toAddSubmonoid = M.
     · rw [ih n.succ_ne_zero]
 #align submodule.pow_to_add_submonoid Submodule.pow_toAddSubmonoid
 
-theorem le_pow_toAddSubmonoid {n : ℕ} : M.toAddSubmonoid ^ n ≤ (M ^ n).toAddSubmonoid :=
-  by
+theorem le_pow_toAddSubmonoid {n : ℕ} : M.toAddSubmonoid ^ n ≤ (M ^ n).toAddSubmonoid := by
   obtain rfl | hn := Decidable.eq_or_ne n 0
   · rw [pow_zero, pow_zero]
     exact le_one_to_add_submonoid
@@ -450,8 +438,7 @@ protected theorem pow_induction_on_left' {C : ∀ (n : ℕ) (x), x ∈ M ^ n →
     (hr : ∀ r : R, C 0 (algebraMap _ _ r) (algebraMap_mem r))
     (hadd : ∀ x y i hx hy, C i x hx → C i y hy → C i (x + y) (add_mem ‹_› ‹_›))
     (hmul : ∀ m ∈ M, ∀ (i x hx), C i x hx → C i.succ (m * x) (mul_mem_mul H hx)) {x : A} {n : ℕ}
-    (hx : x ∈ M ^ n) : C n x hx :=
-  by
+    (hx : x ∈ M ^ n) : C n x hx := by
   induction' n with n n_ih generalizing x
   · rw [pow_zero] at hx
     obtain ⟨r, rfl⟩ := hx
@@ -468,8 +455,7 @@ protected theorem pow_induction_on_right' {C : ∀ (n : ℕ) (x), x ∈ M ^ n �
     (hadd : ∀ x y i hx hy, C i x hx → C i y hy → C i (x + y) (add_mem ‹_› ‹_›))
     (hmul :
       ∀ i x hx, C i x hx → ∀ m ∈ M, C i.succ (x * m) ((pow_succ' M i).symm ▸ mul_mem_mul hx H))
-    {x : A} {n : ℕ} (hx : x ∈ M ^ n) : C n x hx :=
-  by
+    {x : A} {n : ℕ} (hx : x ∈ M ^ n) : C n x hx := by
   induction' n with n n_ih generalizing x
   · rw [pow_zero] at hx
     obtain ⟨r, rfl⟩ := hx
@@ -608,8 +594,7 @@ instance : IdemCommSemiring (Submodule R A) :=
   { Submodule.idemSemiring with mul_comm := Submodule.mul_comm }
 
 theorem prod_span {ι : Type _} (s : Finset ι) (M : ι → Set A) :
-    (∏ i in s, Submodule.span R (M i)) = Submodule.span R (∏ i in s, M i) :=
-  by
+    (∏ i in s, Submodule.span R (M i)) = Submodule.span R (∏ i in s, M i) := by
   letI := Classical.decEq ι
   refine' Finset.induction_on s _ _
   · simp [one_eq_span, Set.singleton_one]
@@ -651,8 +636,7 @@ theorem smul_le_smul {s t : SetSemiring A} {M N : Submodule R A} (h₁ : s.down 
 #align submodule.smul_le_smul Submodule.smul_le_smul
 
 theorem smul_singleton (a : A) (M : Submodule R A) :
-    ({a} : Set A).up • M = M.map (LinearMap.mulLeft R a) :=
-  by
+    ({a} : Set A).up • M = M.map (LinearMap.mulLeft R a) := by
   conv_lhs => rw [← span_eq M]
   change span _ _ * span _ _ = _
   rw [span_mul_span]
@@ -707,22 +691,19 @@ theorem le_div_iff_mul_le {I J K : Submodule R A} : I ≤ J / K ↔ I * K ≤ J 
 #align submodule.le_div_iff_mul_le Submodule.le_div_iff_mul_le
 
 @[simp]
-theorem one_le_one_div {I : Submodule R A} : 1 ≤ 1 / I ↔ I ≤ 1 :=
-  by
+theorem one_le_one_div {I : Submodule R A} : 1 ≤ 1 / I ↔ I ≤ 1 := by
   constructor; all_goals intro hI
   · rwa [le_div_iff_mul_le, one_mul] at hI
   · rwa [le_div_iff_mul_le, one_mul]
 #align submodule.one_le_one_div Submodule.one_le_one_div
 
 /- ./././Mathport/Syntax/Translate/Tactic/Lean3.lean:132:4: warning: unsupported: rw with cfg: { occs := occurrences.pos[occurrences.pos] «expr[ ,]»([1]) } -/
-theorem le_self_mul_one_div {I : Submodule R A} (hI : I ≤ 1) : I ≤ I * (1 / I) :=
-  by
+theorem le_self_mul_one_div {I : Submodule R A} (hI : I ≤ 1) : I ≤ I * (1 / I) := by
   rw [← mul_one I]
   apply mul_le_mul_right (one_le_one_div.mpr hI)
 #align submodule.le_self_mul_one_div Submodule.le_self_mul_one_div
 
-theorem mul_one_div_le_one {I : Submodule R A} : I * (1 / I) ≤ 1 :=
-  by
+theorem mul_one_div_le_one {I : Submodule R A} : I * (1 / I) ≤ 1 := by
   rw [Submodule.mul_le]
   intro m hm n hn
   rw [Submodule.mem_div_iff_forall_mul_mem] at hn

--- a/Mathlib/Algebra/Algebra/Operations.lean
+++ b/Mathlib/Algebra/Algebra/Operations.lean
@@ -642,13 +642,14 @@ theorem smul_def {s : SetSemiring A} {P : Submodule R A} : s • P = span R s * 
   rfl
 #align submodule.smul_def Submodule.smul_def
 
-theorem smul_le_smul {s t : SetSemiring A} {M N : Submodule R A} (h₁ : s.down ≤ t.down)
+theorem smul_le_smul {s t : SetSemiring A} {M N : Submodule R A}
+    (h₁ : SetSemiring.down s ≤ SetSemiring.down t)
     (h₂ : M ≤ N) : s • M ≤ t • N :=
   mul_le_mul (span_mono h₁) h₂
 #align submodule.smul_le_smul Submodule.smul_le_smul
 
 theorem smul_singleton (a : A) (M : Submodule R A) :
-    ({a} : Set A).up • M = M.map (LinearMap.mulLeft R a) := by
+    Set.up ({a} : Set A) • M = M.map (LinearMap.mulLeft R a) := by
   conv_lhs => rw [← span_eq M]
   change span _ _ * span _ _ = _
   rw [span_mul_span]
@@ -673,7 +674,7 @@ This is the general form of the ideal quotient, traditionally written $I : J$.
 instance : Div (Submodule R A) :=
   ⟨fun I J =>
     { carrier := { x | ∀ y ∈ J, x * y ∈ I }
-      zero_mem' := fun y hy => by
+      zero_mem' := fun y _ => by
         rw [zero_mul]
         apply Submodule.zero_mem
       add_mem' := fun ha hb y hy => by
@@ -709,9 +710,8 @@ theorem one_le_one_div {I : Submodule R A} : 1 ≤ 1 / I ↔ I ≤ 1 := by
   · rwa [le_div_iff_mul_le, one_mul]
 #align submodule.one_le_one_div Submodule.one_le_one_div
 
-/- ./././Mathport/Syntax/Translate/Tactic/Lean3.lean:132:4: warning: unsupported: rw with cfg: { occs := occurrences.pos[occurrences.pos] «expr[ ,]»([1]) } -/
 theorem le_self_mul_one_div {I : Submodule R A} (hI : I ≤ 1) : I ≤ I * (1 / I) := by
-  rw [← mul_one I]
+  refine (mul_one I).symm.trans_le ?_  -- porting note: drop `rw {occs := _}` in favor of `refine`
   apply mul_le_mul_right (one_le_one_div.mpr hI)
 #align submodule.le_self_mul_one_div Submodule.le_self_mul_one_div
 

--- a/Mathlib/Algebra/Algebra/Operations.lean
+++ b/Mathlib/Algebra/Algebra/Operations.lean
@@ -481,9 +481,8 @@ protected theorem pow_induction_on_right' {C : ∀ (n : ℕ) (x), x ∈ M ^ n �
     exact hr r
   revert hx
   -- porting note: workaround for lean4#1926, was `simp_rw [pow_succ']`
-  have h_lean4_1926_aux : x ∈ M ^ Nat.succ n ↔ x ∈ M ^ n * M := by rw [pow_succ']
-  suffices h_lean4_1926 : ∀ (hx' : x ∈ M ^ n * M), C (Nat.succ n) x (h_lean4_1926_aux.mpr hx') from
-    fun hx => h_lean4_1926 (h_lean4_1926_aux.mp hx)
+  suffices h_lean4_1926 : ∀ (hx' : x ∈ M ^ n * M), C (Nat.succ n) x (by rwa [pow_succ']) from
+    fun hx => h_lean4_1926 (by rwa [← pow_succ'])
   -- porting note: end workaround
   intro hx
   exact

--- a/Mathlib/Algebra/Algebra/Operations.lean
+++ b/Mathlib/Algebra/Algebra/Operations.lean
@@ -497,8 +497,9 @@ protected theorem pow_induction_on_left {C : A → Prop} (hr : ∀ r : R, C (alg
     (hadd : ∀ x y, C x → C y → C (x + y)) (hmul : ∀ m ∈ M, ∀ (x), C x → C (m * x)) {x : A} {n : ℕ}
     (hx : x ∈ M ^ n) : C x :=
   -- porting note: `M` is explicit yet can't be passed positionally!
-  Submodule.pow_induction_on_left' (M := M) (C := fun _ a _ => C a) hr (fun x y _ _ _ => hadd x y)
-    (fun _ hm _ _ _ => hmul _ hm _) hx
+  Submodule.pow_induction_on_left' (M := M) (C := fun _ a _ => C a) hr
+    (fun x y _i _hx _hy => hadd x y)
+    (fun _m hm _i _x _hx => hmul _ hm _) hx
 #align submodule.pow_induction_on_left Submodule.pow_induction_on_left
 
 /-- To show a property on elements of `M ^ n` holds, it suffices to show that it holds for scalars,
@@ -507,8 +508,9 @@ is closed under addition, and holds for `x * m` where `m ∈ M` and it holds for
 protected theorem pow_induction_on_right {C : A → Prop} (hr : ∀ r : R, C (algebraMap _ _ r))
     (hadd : ∀ x y, C x → C y → C (x + y)) (hmul : ∀ x, C x → ∀ m ∈ M, C (x * m)) {x : A} {n : ℕ}
     (hx : x ∈ M ^ n) : C x :=
-  Submodule.pow_induction_on_right' (M := M) (C := fun _ a _ => C a) hr (fun x y _ _ _ => hadd x y)
-    (fun _ _ _ => hmul _) hx
+  Submodule.pow_induction_on_right' (M := M) (C := fun _ a _ => C a) hr
+    (fun x y _i _hx _hy => hadd x y)
+    (fun _i _x _hx => hmul _) hx
 #align submodule.pow_induction_on_right Submodule.pow_induction_on_right
 
 /-- `Submonoid.map` as a `MonoidWithZeroHom`, when applied to `AlgHom`s. -/

--- a/Mathlib/Algebra/Algebra/Operations.lean
+++ b/Mathlib/Algebra/Algebra/Operations.lean
@@ -1,0 +1,755 @@
+/-
+Copyright (c) 2019 Kenny Lau. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kenny Lau
+
+! This file was ported from Lean 3 source module algebra.algebra.operations
+! leanprover-community/mathlib commit 2bbc7e3884ba234309d2a43b19144105a753292e
+! Please do not edit these lines, except to modify the commit id
+! if you have ported upstream changes.
+-/
+import Mathbin.Algebra.Algebra.Bilinear
+import Mathbin.Algebra.Algebra.Equiv
+import Mathbin.Algebra.Module.Submodule.Pointwise
+import Mathbin.Algebra.Module.Submodule.Bilinear
+import Mathbin.Algebra.Module.Opposites
+import Mathbin.Algebra.Order.Kleene
+import Mathbin.Data.Finset.Pointwise
+import Mathbin.Data.Set.Semiring
+import Mathbin.Data.Set.Pointwise.BigOperators
+import Mathbin.GroupTheory.GroupAction.SubMulAction.Pointwise
+
+/-!
+# Multiplication and division of submodules of an algebra.
+
+An interface for multiplication and division of sub-R-modules of an R-algebra A is developed.
+
+## Main definitions
+
+Let `R` be a commutative ring (or semiring) and let `A` be an `R`-algebra.
+
+* `1 : submodule R A`       : the R-submodule R of the R-algebra A
+* `has_mul (submodule R A)` : multiplication of two sub-R-modules M and N of A is defined to be
+                              the smallest submodule containing all the products `m * n`.
+* `has_div (submodule R A)` : `I / J` is defined to be the submodule consisting of all `a : A` such
+                              that `a • J ⊆ I`
+
+It is proved that `submodule R A` is a semiring, and also an algebra over `set A`.
+
+Additionally, in the `pointwise` locale we promote `submodule.pointwise_distrib_mul_action` to a
+`mul_semiring_action` as `submodule.pointwise_mul_semiring_action`.
+
+## Tags
+
+multiplication of submodules, division of submodules, submodule semiring
+-/
+
+
+universe uι u v
+
+open Algebra Set MulOpposite
+
+open BigOperators
+
+open Pointwise
+
+namespace SubMulAction
+
+variable {R : Type u} {A : Type v} [CommSemiring R] [Semiring A] [Algebra R A]
+
+theorem algebraMap_mem (r : R) : algebraMap R A r ∈ (1 : SubMulAction R A) :=
+  ⟨r, (algebraMap_eq_smul_one r).symm⟩
+#align sub_mul_action.algebra_map_mem SubMulAction.algebraMap_mem
+
+theorem mem_one' {x : A} : x ∈ (1 : SubMulAction R A) ↔ ∃ y, algebraMap R A y = x :=
+  exists_congr fun r => by rw [algebra_map_eq_smul_one]
+#align sub_mul_action.mem_one' SubMulAction.mem_one'
+
+end SubMulAction
+
+namespace Submodule
+
+variable {ι : Sort uι}
+
+variable {R : Type u} [CommSemiring R]
+
+section Ring
+
+variable {A : Type v} [Semiring A] [Algebra R A]
+
+variable (S T : Set A) {M N P Q : Submodule R A} {m n : A}
+
+/-- `1 : submodule R A` is the submodule R of A. -/
+instance : One (Submodule R A) :=
+  ⟨(Algebra.linearMap R A).range⟩
+
+theorem one_eq_range : (1 : Submodule R A) = (Algebra.linearMap R A).range :=
+  rfl
+#align submodule.one_eq_range Submodule.one_eq_range
+
+theorem le_one_toAddSubmonoid : 1 ≤ (1 : Submodule R A).toAddSubmonoid :=
+  by
+  rintro x ⟨n, rfl⟩
+  exact ⟨n, map_natCast (algebraMap R A) n⟩
+#align submodule.le_one_to_add_submonoid Submodule.le_one_toAddSubmonoid
+
+theorem algebraMap_mem (r : R) : algebraMap R A r ∈ (1 : Submodule R A) :=
+  LinearMap.mem_range_self _ _
+#align submodule.algebra_map_mem Submodule.algebraMap_mem
+
+@[simp]
+theorem mem_one {x : A} : x ∈ (1 : Submodule R A) ↔ ∃ y, algebraMap R A y = x :=
+  Iff.rfl
+#align submodule.mem_one Submodule.mem_one
+
+@[simp]
+theorem toSubMulAction_one : (1 : Submodule R A).toSubMulAction = 1 :=
+  SetLike.ext fun x => mem_one.trans SubMulAction.mem_one'.symm
+#align submodule.to_sub_mul_action_one Submodule.toSubMulAction_one
+
+theorem one_eq_span : (1 : Submodule R A) = R ∙ 1 :=
+  by
+  apply Submodule.ext
+  intro a
+  simp only [mem_one, mem_span_singleton, Algebra.smul_def, mul_one]
+#align submodule.one_eq_span Submodule.one_eq_span
+
+theorem one_eq_span_one_set : (1 : Submodule R A) = span R 1 :=
+  one_eq_span
+#align submodule.one_eq_span_one_set Submodule.one_eq_span_one_set
+
+theorem one_le : (1 : Submodule R A) ≤ P ↔ (1 : A) ∈ P := by
+  simpa only [one_eq_span, span_le, Set.singleton_subset_iff]
+#align submodule.one_le Submodule.one_le
+
+protected theorem map_one {A'} [Semiring A'] [Algebra R A'] (f : A →ₐ[R] A') :
+    map f.toLinearMap (1 : Submodule R A) = 1 :=
+  by
+  ext
+  simp
+#align submodule.map_one Submodule.map_one
+
+@[simp]
+theorem map_op_one :
+    map (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ) : A →ₗ[R] Aᵐᵒᵖ) (1 : Submodule R A) = 1 :=
+  by
+  ext
+  induction x using MulOpposite.rec'
+  simp
+#align submodule.map_op_one Submodule.map_op_one
+
+@[simp]
+theorem comap_op_one :
+    comap (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ) : A →ₗ[R] Aᵐᵒᵖ) (1 : Submodule R Aᵐᵒᵖ) = 1 :=
+  by
+  ext
+  simp
+#align submodule.comap_op_one Submodule.comap_op_one
+
+@[simp]
+theorem map_unop_one :
+    map (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ).symm : Aᵐᵒᵖ →ₗ[R] A) (1 : Submodule R Aᵐᵒᵖ) = 1 := by
+  rw [← comap_equiv_eq_map_symm, comap_op_one]
+#align submodule.map_unop_one Submodule.map_unop_one
+
+@[simp]
+theorem comap_unop_one :
+    comap (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ).symm : Aᵐᵒᵖ →ₗ[R] A) (1 : Submodule R A) = 1 := by
+  rw [← map_equiv_eq_comap_symm, map_op_one]
+#align submodule.comap_unop_one Submodule.comap_unop_one
+
+/-- Multiplication of sub-R-modules of an R-algebra A. The submodule `M * N` is the
+smallest R-submodule of `A` containing the elements `m * n` for `m ∈ M` and `n ∈ N`. -/
+instance : Mul (Submodule R A) :=
+  ⟨Submodule.map₂ <| LinearMap.mul R A⟩
+
+theorem mul_mem_mul (hm : m ∈ M) (hn : n ∈ N) : m * n ∈ M * N :=
+  apply_mem_map₂ _ hm hn
+#align submodule.mul_mem_mul Submodule.mul_mem_mul
+
+theorem mul_le : M * N ≤ P ↔ ∀ m ∈ M, ∀ n ∈ N, m * n ∈ P :=
+  map₂_le
+#align submodule.mul_le Submodule.mul_le
+
+theorem mul_toAddSubmonoid (M N : Submodule R A) :
+    (M * N).toAddSubmonoid = M.toAddSubmonoid * N.toAddSubmonoid :=
+  by
+  dsimp [Mul.mul]
+  simp_rw [← LinearMap.mulLeft_toAddMonoid_hom R, LinearMap.mulLeft, ← map_to_add_submonoid _ N,
+    map₂]
+  rw [supr_to_add_submonoid]
+  rfl
+#align submodule.mul_to_add_submonoid Submodule.mul_toAddSubmonoid
+
+@[elab_as_elim]
+protected theorem mul_induction_on {C : A → Prop} {r : A} (hr : r ∈ M * N)
+    (hm : ∀ m ∈ M, ∀ n ∈ N, C (m * n)) (ha : ∀ x y, C x → C y → C (x + y)) : C r :=
+  by
+  rw [← mem_to_add_submonoid, mul_to_add_submonoid] at hr
+  exact AddSubmonoid.mul_induction_on hr hm ha
+#align submodule.mul_induction_on Submodule.mul_induction_on
+
+/-- A dependent version of `mul_induction_on`. -/
+@[elab_as_elim]
+protected theorem mul_induction_on' {C : ∀ r, r ∈ M * N → Prop}
+    (hm : ∀ m ∈ M, ∀ n ∈ N, C (m * n) (mul_mem_mul ‹_› ‹_›))
+    (ha : ∀ x hx y hy, C x hx → C y hy → C (x + y) (add_mem ‹_› ‹_›)) {r : A} (hr : r ∈ M * N) :
+    C r hr := by
+  refine' Exists.elim _ fun (hr : r ∈ M * N) (hc : C r hr) => hc
+  exact
+    Submodule.mul_induction_on hr (fun x hx y hy => ⟨_, hm _ hx _ hy⟩) fun x y ⟨_, hx⟩ ⟨_, hy⟩ =>
+      ⟨_, ha _ _ _ _ hx hy⟩
+#align submodule.mul_induction_on' Submodule.mul_induction_on'
+
+variable (R)
+
+theorem span_mul_span : span R S * span R T = span R (S * T) :=
+  map₂_span_span _ _ _ _
+#align submodule.span_mul_span Submodule.span_mul_span
+
+variable {R}
+
+variable (M N P Q)
+
+@[simp]
+theorem mul_bot : M * ⊥ = ⊥ :=
+  map₂_bot_right _ _
+#align submodule.mul_bot Submodule.mul_bot
+
+@[simp]
+theorem bot_mul : ⊥ * M = ⊥ :=
+  map₂_bot_left _ _
+#align submodule.bot_mul Submodule.bot_mul
+
+@[simp]
+protected theorem one_mul : (1 : Submodule R A) * M = M :=
+  by
+  conv_lhs => rw [one_eq_span, ← span_eq M]
+  erw [span_mul_span, one_mul, span_eq]
+#align submodule.one_mul Submodule.one_mul
+
+@[simp]
+protected theorem mul_one : M * 1 = M :=
+  by
+  conv_lhs => rw [one_eq_span, ← span_eq M]
+  erw [span_mul_span, mul_one, span_eq]
+#align submodule.mul_one Submodule.mul_one
+
+variable {M N P Q}
+
+@[mono]
+theorem mul_le_mul (hmp : M ≤ P) (hnq : N ≤ Q) : M * N ≤ P * Q :=
+  map₂_le_map₂ hmp hnq
+#align submodule.mul_le_mul Submodule.mul_le_mul
+
+theorem mul_le_mul_left (h : M ≤ N) : M * P ≤ N * P :=
+  map₂_le_map₂_left h
+#align submodule.mul_le_mul_left Submodule.mul_le_mul_left
+
+theorem mul_le_mul_right (h : N ≤ P) : M * N ≤ M * P :=
+  map₂_le_map₂_right h
+#align submodule.mul_le_mul_right Submodule.mul_le_mul_right
+
+variable (M N P)
+
+theorem mul_sup : M * (N ⊔ P) = M * N ⊔ M * P :=
+  map₂_sup_right _ _ _ _
+#align submodule.mul_sup Submodule.mul_sup
+
+theorem sup_mul : (M ⊔ N) * P = M * P ⊔ N * P :=
+  map₂_sup_left _ _ _ _
+#align submodule.sup_mul Submodule.sup_mul
+
+theorem mul_subset_mul : (↑M : Set A) * (↑N : Set A) ⊆ (↑(M * N) : Set A) :=
+  image2_subset_map₂ (LinearMap.Algebra.lmul R A).toLinearMap M N
+#align submodule.mul_subset_mul Submodule.mul_subset_mul
+
+protected theorem map_mul {A'} [Semiring A'] [Algebra R A'] (f : A →ₐ[R] A') :
+    map f.toLinearMap (M * N) = map f.toLinearMap M * map f.toLinearMap N :=
+  calc
+    map f.toLinearMap (M * N) = ⨆ i : M, (N.map (LinearMap.mul R A i)).map f.toLinearMap :=
+      map_supᵢ _ _
+    _ = map f.toLinearMap M * map f.toLinearMap N :=
+      by
+      apply congr_arg Sup
+      ext S
+      constructor <;> rintro ⟨y, hy⟩
+      · use f y, mem_map.mpr ⟨y.1, y.2, rfl⟩
+        refine' trans _ hy
+        ext
+        simp
+      · obtain ⟨y', hy', fy_eq⟩ := mem_map.mp y.2
+        use y', hy'
+        refine' trans _ hy
+        rw [f.to_linear_map_apply] at fy_eq
+        ext
+        simp [fy_eq]
+    
+#align submodule.map_mul Submodule.map_mul
+
+theorem map_op_mul :
+    map (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ) : A →ₗ[R] Aᵐᵒᵖ) (M * N) =
+      map (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ) : A →ₗ[R] Aᵐᵒᵖ) N *
+        map (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ) : A →ₗ[R] Aᵐᵒᵖ) M :=
+  by
+  apply le_antisymm
+  · simp_rw [map_le_iff_le_comap]
+    refine' mul_le.2 fun m hm n hn => _
+    rw [mem_comap, map_equiv_eq_comap_symm, map_equiv_eq_comap_symm]
+    show op n * op m ∈ _
+    exact mul_mem_mul hn hm
+  · refine' mul_le.2 (MulOpposite.rec' fun m hm => MulOpposite.rec' fun n hn => _)
+    rw [Submodule.mem_map_equiv] at hm hn⊢
+    exact mul_mem_mul hn hm
+#align submodule.map_op_mul Submodule.map_op_mul
+
+theorem comap_unop_mul :
+    comap (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ).symm : Aᵐᵒᵖ →ₗ[R] A) (M * N) =
+      comap (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ).symm : Aᵐᵒᵖ →ₗ[R] A) N *
+        comap (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ).symm : Aᵐᵒᵖ →ₗ[R] A) M :=
+  by simp_rw [← map_equiv_eq_comap_symm, map_op_mul]
+#align submodule.comap_unop_mul Submodule.comap_unop_mul
+
+theorem map_unop_mul (M N : Submodule R Aᵐᵒᵖ) :
+    map (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ).symm : Aᵐᵒᵖ →ₗ[R] A) (M * N) =
+      map (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ).symm : Aᵐᵒᵖ →ₗ[R] A) N *
+        map (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ).symm : Aᵐᵒᵖ →ₗ[R] A) M :=
+  have : Function.Injective (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ) : A →ₗ[R] Aᵐᵒᵖ) :=
+    LinearEquiv.injective _
+  map_injective_of_injective this <| by
+    rw [← map_comp, map_op_mul, ← map_comp, ← map_comp, LinearEquiv.comp_coe,
+      LinearEquiv.symm_trans_self, LinearEquiv.refl_toLinearMap, map_id, map_id, map_id]
+#align submodule.map_unop_mul Submodule.map_unop_mul
+
+theorem comap_op_mul (M N : Submodule R Aᵐᵒᵖ) :
+    comap (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ) : A →ₗ[R] Aᵐᵒᵖ) (M * N) =
+      comap (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ) : A →ₗ[R] Aᵐᵒᵖ) N *
+        comap (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ) : A →ₗ[R] Aᵐᵒᵖ) M :=
+  by simp_rw [comap_equiv_eq_map_symm, map_unop_mul]
+#align submodule.comap_op_mul Submodule.comap_op_mul
+
+section
+
+open Pointwise
+
+/-- `submodule.has_pointwise_neg` distributes over multiplication.
+
+This is available as an instance in the `pointwise` locale. -/
+protected def hasDistribPointwiseNeg {A} [Ring A] [Algebra R A] : HasDistribNeg (Submodule R A) :=
+  toAddSubmonoid_injective.HasDistribNeg _ neg_toAddSubmonoid mul_toAddSubmonoid
+#align submodule.has_distrib_pointwise_neg Submodule.hasDistribPointwiseNeg
+
+scoped[Pointwise] attribute [instance] Submodule.hasDistribPointwiseNeg
+
+end
+
+section DecidableEq
+
+open Classical
+
+theorem mem_span_mul_finite_of_mem_span_mul {R A} [Semiring R] [AddCommMonoid A] [Mul A]
+    [Module R A] {S : Set A} {S' : Set A} {x : A} (hx : x ∈ span R (S * S')) :
+    ∃ T T' : Finset A, ↑T ⊆ S ∧ ↑T' ⊆ S' ∧ x ∈ span R (T * T' : Set A) :=
+  by
+  obtain ⟨U, h, hU⟩ := mem_span_finite_of_mem_span hx
+  obtain ⟨T, T', hS, hS', h⟩ := Finset.subset_mul h
+  use T, T', hS, hS'
+  have h' : (U : Set A) ⊆ T * T' := by assumption_mod_cast
+  have h'' := span_mono h' hU
+  assumption
+#align submodule.mem_span_mul_finite_of_mem_span_mul Submodule.mem_span_mul_finite_of_mem_span_mul
+
+end DecidableEq
+
+theorem mul_eq_span_mul_set (s t : Submodule R A) : s * t = span R ((s : Set A) * (t : Set A)) :=
+  map₂_eq_span_image2 _ s t
+#align submodule.mul_eq_span_mul_set Submodule.mul_eq_span_mul_set
+
+theorem supᵢ_mul (s : ι → Submodule R A) (t : Submodule R A) : (⨆ i, s i) * t = ⨆ i, s i * t :=
+  map₂_supᵢ_left _ s t
+#align submodule.supr_mul Submodule.supᵢ_mul
+
+theorem mul_supᵢ (t : Submodule R A) (s : ι → Submodule R A) : (t * ⨆ i, s i) = ⨆ i, t * s i :=
+  map₂_supᵢ_right _ t s
+#align submodule.mul_supr Submodule.mul_supᵢ
+
+theorem mem_span_mul_finite_of_mem_mul {P Q : Submodule R A} {x : A} (hx : x ∈ P * Q) :
+    ∃ T T' : Finset A, (T : Set A) ⊆ P ∧ (T' : Set A) ⊆ Q ∧ x ∈ span R (T * T' : Set A) :=
+  Submodule.mem_span_mul_finite_of_mem_span_mul
+    (by rwa [← Submodule.span_eq P, ← Submodule.span_eq Q, Submodule.span_mul_span] at hx)
+#align submodule.mem_span_mul_finite_of_mem_mul Submodule.mem_span_mul_finite_of_mem_mul
+
+variable {M N P}
+
+theorem mem_span_singleton_mul {x y : A} : x ∈ span R {y} * P ↔ ∃ z ∈ P, y * z = x :=
+  by
+  simp_rw [(· * ·), map₂_span_singleton_eq_map, exists_prop]
+  rfl
+#align submodule.mem_span_singleton_mul Submodule.mem_span_singleton_mul
+
+theorem mem_mul_span_singleton {x y : A} : x ∈ P * span R {y} ↔ ∃ z ∈ P, z * y = x :=
+  by
+  simp_rw [(· * ·), map₂_span_singleton_eq_map_flip, exists_prop]
+  rfl
+#align submodule.mem_mul_span_singleton Submodule.mem_mul_span_singleton
+
+/-- Sub-R-modules of an R-algebra form an idempotent semiring. -/
+instance : IdemSemiring (Submodule R A) :=
+  { toAddSubmonoid_injective.Semigroup _ fun m n : Submodule R A => mul_toAddSubmonoid m n,
+    AddMonoidWithOne.unary, Submodule.pointwiseAddCommMonoid, Submodule.hasOne, Submodule.hasMul,
+    (by infer_instance : OrderBot (Submodule R A)),
+    (by infer_instance :
+      Lattice (Submodule R A)) with
+    one_mul := Submodule.one_mul
+    mul_one := Submodule.mul_one
+    zero_mul := bot_mul
+    mul_zero := mul_bot
+    left_distrib := mul_sup
+    right_distrib := sup_mul }
+
+variable (M)
+
+theorem span_pow (s : Set A) : ∀ n : ℕ, span R s ^ n = span R (s ^ n)
+  | 0 => by rw [pow_zero, pow_zero, one_eq_span_one_set]
+  | n + 1 => by rw [pow_succ, pow_succ, span_pow, span_mul_span]
+#align submodule.span_pow Submodule.span_pow
+
+theorem pow_eq_span_pow_set (n : ℕ) : M ^ n = span R ((M : Set A) ^ n) := by
+  rw [← span_pow, span_eq]
+#align submodule.pow_eq_span_pow_set Submodule.pow_eq_span_pow_set
+
+theorem pow_subset_pow {n : ℕ} : (↑M : Set A) ^ n ⊆ ↑(M ^ n : Submodule R A) :=
+  (pow_eq_span_pow_set M n).symm ▸ subset_span
+#align submodule.pow_subset_pow Submodule.pow_subset_pow
+
+theorem pow_mem_pow {x : A} (hx : x ∈ M) (n : ℕ) : x ^ n ∈ M ^ n :=
+  pow_subset_pow _ <| Set.pow_mem_pow hx _
+#align submodule.pow_mem_pow Submodule.pow_mem_pow
+
+theorem pow_toAddSubmonoid {n : ℕ} (h : n ≠ 0) : (M ^ n).toAddSubmonoid = M.toAddSubmonoid ^ n :=
+  by
+  induction' n with n ih
+  · exact (h rfl).elim
+  · rw [pow_succ, pow_succ, mul_to_add_submonoid]
+    cases n
+    · rw [pow_zero, pow_zero, mul_one, ← mul_to_add_submonoid, mul_one]
+    · rw [ih n.succ_ne_zero]
+#align submodule.pow_to_add_submonoid Submodule.pow_toAddSubmonoid
+
+theorem le_pow_toAddSubmonoid {n : ℕ} : M.toAddSubmonoid ^ n ≤ (M ^ n).toAddSubmonoid :=
+  by
+  obtain rfl | hn := Decidable.eq_or_ne n 0
+  · rw [pow_zero, pow_zero]
+    exact le_one_to_add_submonoid
+  · exact (pow_to_add_submonoid M hn).ge
+#align submodule.le_pow_to_add_submonoid Submodule.le_pow_toAddSubmonoid
+
+/-- Dependent version of `submodule.pow_induction_on_left`. -/
+@[elab_as_elim]
+protected theorem pow_induction_on_left' {C : ∀ (n : ℕ) (x), x ∈ M ^ n → Prop}
+    (hr : ∀ r : R, C 0 (algebraMap _ _ r) (algebraMap_mem r))
+    (hadd : ∀ x y i hx hy, C i x hx → C i y hy → C i (x + y) (add_mem ‹_› ‹_›))
+    (hmul : ∀ m ∈ M, ∀ (i x hx), C i x hx → C i.succ (m * x) (mul_mem_mul H hx)) {x : A} {n : ℕ}
+    (hx : x ∈ M ^ n) : C n x hx :=
+  by
+  induction' n with n n_ih generalizing x
+  · rw [pow_zero] at hx
+    obtain ⟨r, rfl⟩ := hx
+    exact hr r
+  exact
+    Submodule.mul_induction_on' (fun m hm x ih => hmul _ hm _ _ _ (n_ih ih))
+      (fun x hx y hy Cx Cy => hadd _ _ _ _ _ Cx Cy) hx
+#align submodule.pow_induction_on_left' Submodule.pow_induction_on_left'
+
+/-- Dependent version of `submodule.pow_induction_on_right`. -/
+@[elab_as_elim]
+protected theorem pow_induction_on_right' {C : ∀ (n : ℕ) (x), x ∈ M ^ n → Prop}
+    (hr : ∀ r : R, C 0 (algebraMap _ _ r) (algebraMap_mem r))
+    (hadd : ∀ x y i hx hy, C i x hx → C i y hy → C i (x + y) (add_mem ‹_› ‹_›))
+    (hmul :
+      ∀ i x hx, C i x hx → ∀ m ∈ M, C i.succ (x * m) ((pow_succ' M i).symm ▸ mul_mem_mul hx H))
+    {x : A} {n : ℕ} (hx : x ∈ M ^ n) : C n x hx :=
+  by
+  induction' n with n n_ih generalizing x
+  · rw [pow_zero] at hx
+    obtain ⟨r, rfl⟩ := hx
+    exact hr r
+  revert hx
+  simp_rw [pow_succ']
+  intro hx
+  exact
+    Submodule.mul_induction_on' (fun m hm x ih => hmul _ _ hm (n_ih _) _ ih)
+      (fun x hx y hy Cx Cy => hadd _ _ _ _ _ Cx Cy) hx
+#align submodule.pow_induction_on_right' Submodule.pow_induction_on_right'
+
+/-- To show a property on elements of `M ^ n` holds, it suffices to show that it holds for scalars,
+is closed under addition, and holds for `m * x` where `m ∈ M` and it holds for `x` -/
+@[elab_as_elim]
+protected theorem pow_induction_on_left {C : A → Prop} (hr : ∀ r : R, C (algebraMap _ _ r))
+    (hadd : ∀ x y, C x → C y → C (x + y)) (hmul : ∀ m ∈ M, ∀ (x), C x → C (m * x)) {x : A} {n : ℕ}
+    (hx : x ∈ M ^ n) : C x :=
+  Submodule.pow_induction_on_left' M hr (fun x y i hx hy => hadd x y)
+    (fun m hm i x hx => hmul _ hm _) hx
+#align submodule.pow_induction_on_left Submodule.pow_induction_on_left
+
+/-- To show a property on elements of `M ^ n` holds, it suffices to show that it holds for scalars,
+is closed under addition, and holds for `x * m` where `m ∈ M` and it holds for `x` -/
+@[elab_as_elim]
+protected theorem pow_induction_on_right {C : A → Prop} (hr : ∀ r : R, C (algebraMap _ _ r))
+    (hadd : ∀ x y, C x → C y → C (x + y)) (hmul : ∀ x, C x → ∀ m ∈ M, C (x * m)) {x : A} {n : ℕ}
+    (hx : x ∈ M ^ n) : C x :=
+  Submodule.pow_induction_on_right' M hr (fun x y i hx hy => hadd x y) (fun i x hx => hmul _) hx
+#align submodule.pow_induction_on_right Submodule.pow_induction_on_right
+
+/-- `submonoid.map` as a `monoid_with_zero_hom`, when applied to `alg_hom`s. -/
+@[simps]
+def mapHom {A'} [Semiring A'] [Algebra R A'] (f : A →ₐ[R] A') : Submodule R A →*₀ Submodule R A'
+    where
+  toFun := map f.toLinearMap
+  map_zero' := Submodule.map_bot _
+  map_one' := Submodule.map_one _
+  map_mul' _ _ := Submodule.map_mul _ _ _
+#align submodule.map_hom Submodule.mapHom
+
+/-- The ring of submodules of the opposite algebra is isomorphic to the opposite ring of
+submodules. -/
+@[simps apply symm_apply]
+def equivOpposite : Submodule R Aᵐᵒᵖ ≃+* (Submodule R A)ᵐᵒᵖ
+    where
+  toFun p := op <| p.comap (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ) : A →ₗ[R] Aᵐᵒᵖ)
+  invFun p := p.unop.comap (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ).symm : Aᵐᵒᵖ →ₗ[R] A)
+  left_inv p := SetLike.coe_injective <| rfl
+  right_inv p := unop_injective <| SetLike.coe_injective rfl
+  map_add' p q := by simp [comap_equiv_eq_map_symm, ← op_add]
+  map_mul' p q := congr_arg op <| comap_op_mul _ _
+#align submodule.equiv_opposite Submodule.equivOpposite
+
+protected theorem map_pow {A'} [Semiring A'] [Algebra R A'] (f : A →ₐ[R] A') (n : ℕ) :
+    map f.toLinearMap (M ^ n) = map f.toLinearMap M ^ n :=
+  map_pow (mapHom f) M n
+#align submodule.map_pow Submodule.map_pow
+
+theorem comap_unop_pow (n : ℕ) :
+    comap (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ).symm : Aᵐᵒᵖ →ₗ[R] A) (M ^ n) =
+      comap (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ).symm : Aᵐᵒᵖ →ₗ[R] A) M ^ n :=
+  (equivOpposite : Submodule R Aᵐᵒᵖ ≃+* _).symm.map_pow (op M) n
+#align submodule.comap_unop_pow Submodule.comap_unop_pow
+
+theorem comap_op_pow (n : ℕ) (M : Submodule R Aᵐᵒᵖ) :
+    comap (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ) : A →ₗ[R] Aᵐᵒᵖ) (M ^ n) =
+      comap (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ) : A →ₗ[R] Aᵐᵒᵖ) M ^ n :=
+  op_injective <| (equivOpposite : Submodule R Aᵐᵒᵖ ≃+* _).map_pow M n
+#align submodule.comap_op_pow Submodule.comap_op_pow
+
+theorem map_op_pow (n : ℕ) :
+    map (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ) : A →ₗ[R] Aᵐᵒᵖ) (M ^ n) =
+      map (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ) : A →ₗ[R] Aᵐᵒᵖ) M ^ n :=
+  by rw [map_equiv_eq_comap_symm, map_equiv_eq_comap_symm, comap_unop_pow]
+#align submodule.map_op_pow Submodule.map_op_pow
+
+theorem map_unop_pow (n : ℕ) (M : Submodule R Aᵐᵒᵖ) :
+    map (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ).symm : Aᵐᵒᵖ →ₗ[R] A) (M ^ n) =
+      map (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ).symm : Aᵐᵒᵖ →ₗ[R] A) M ^ n :=
+  by rw [← comap_equiv_eq_map_symm, ← comap_equiv_eq_map_symm, comap_op_pow]
+#align submodule.map_unop_pow Submodule.map_unop_pow
+
+/-- `span` is a semiring homomorphism (recall multiplication is pointwise multiplication of subsets
+on either side). -/
+def span.ringHom : SetSemiring A →+* Submodule R A
+    where
+  toFun := Submodule.span R
+  map_zero' := span_empty
+  map_one' := one_eq_span.symm
+  map_add' := span_union
+  map_mul' s t := by erw [span_mul_span, ← image_mul_prod]
+#align submodule.span.ring_hom Submodule.span.ringHom
+
+section
+
+variable {α : Type _} [Monoid α] [MulSemiringAction α A] [SMulCommClass α R A]
+
+/-- The action on a submodule corresponding to applying the action to every element.
+
+This is available as an instance in the `pointwise` locale.
+
+This is a stronger version of `submodule.pointwise_distrib_mul_action`. -/
+protected def pointwiseMulSemiringAction : MulSemiringAction α (Submodule R A) :=
+  {
+    Submodule.pointwiseDistribMulAction with
+    smul_mul := fun r x y => Submodule.map_mul x y <| MulSemiringAction.toAlgHom R A r
+    smul_one := fun r => Submodule.map_one <| MulSemiringAction.toAlgHom R A r }
+#align submodule.pointwise_mul_semiring_action Submodule.pointwiseMulSemiringAction
+
+scoped[Pointwise] attribute [instance] Submodule.pointwiseMulSemiringAction
+
+end
+
+end Ring
+
+section CommRing
+
+variable {A : Type v} [CommSemiring A] [Algebra R A]
+
+variable {M N : Submodule R A} {m n : A}
+
+theorem mul_mem_mul_rev (hm : m ∈ M) (hn : n ∈ N) : n * m ∈ M * N :=
+  mul_comm m n ▸ mul_mem_mul hm hn
+#align submodule.mul_mem_mul_rev Submodule.mul_mem_mul_rev
+
+variable (M N)
+
+protected theorem mul_comm : M * N = N * M :=
+  le_antisymm (mul_le.2 fun r hrm s hsn => mul_mem_mul_rev hsn hrm)
+    (mul_le.2 fun r hrn s hsm => mul_mem_mul_rev hsm hrn)
+#align submodule.mul_comm Submodule.mul_comm
+
+/-- Sub-R-modules of an R-algebra A form a semiring. -/
+instance : IdemCommSemiring (Submodule R A) :=
+  { Submodule.idemSemiring with mul_comm := Submodule.mul_comm }
+
+theorem prod_span {ι : Type _} (s : Finset ι) (M : ι → Set A) :
+    (∏ i in s, Submodule.span R (M i)) = Submodule.span R (∏ i in s, M i) :=
+  by
+  letI := Classical.decEq ι
+  refine' Finset.induction_on s _ _
+  · simp [one_eq_span, Set.singleton_one]
+  · intro _ _ H ih
+    rw [Finset.prod_insert H, Finset.prod_insert H, ih, span_mul_span]
+#align submodule.prod_span Submodule.prod_span
+
+theorem prod_span_singleton {ι : Type _} (s : Finset ι) (x : ι → A) :
+    (∏ i in s, span R ({x i} : Set A)) = span R {∏ i in s, x i} := by
+  rw [prod_span, Set.finset_prod_singleton]
+#align submodule.prod_span_singleton Submodule.prod_span_singleton
+
+variable (R A)
+
+/-- R-submodules of the R-algebra A are a module over `set A`. -/
+instance moduleSet : Module (SetSemiring A) (Submodule R A)
+    where
+  smul s P := span R s * P
+  smul_add _ _ _ := mul_add _ _ _
+  add_smul s t P := show span R (s ⊔ t) * P = _ by erw [span_union, right_distrib]
+  mul_smul s t P := show _ = _ * (_ * _) by rw [← mul_assoc, span_mul_span, ← image_mul_prod]
+  one_smul P :=
+    show span R {(1 : A)} * P = _ by
+      conv_lhs => erw [← span_eq P]
+      erw [span_mul_span, one_mul, span_eq]
+  zero_smul P := show span R ∅ * P = ⊥ by erw [span_empty, bot_mul]
+  smul_zero _ := mul_bot _
+#align submodule.module_set Submodule.moduleSet
+
+variable {R A}
+
+theorem smul_def {s : SetSemiring A} {P : Submodule R A} : s • P = span R s * P :=
+  rfl
+#align submodule.smul_def Submodule.smul_def
+
+theorem smul_le_smul {s t : SetSemiring A} {M N : Submodule R A} (h₁ : s.down ≤ t.down)
+    (h₂ : M ≤ N) : s • M ≤ t • N :=
+  mul_le_mul (span_mono h₁) h₂
+#align submodule.smul_le_smul Submodule.smul_le_smul
+
+theorem smul_singleton (a : A) (M : Submodule R A) :
+    ({a} : Set A).up • M = M.map (LinearMap.mulLeft R a) :=
+  by
+  conv_lhs => rw [← span_eq M]
+  change span _ _ * span _ _ = _
+  rw [span_mul_span]
+  apply le_antisymm
+  · rw [span_le]
+    rintro _ ⟨b, m, hb, hm, rfl⟩
+    rw [SetLike.mem_coe, mem_map, set.mem_singleton_iff.mp hb]
+    exact ⟨m, hm, rfl⟩
+  · rintro _ ⟨m, hm, rfl⟩
+    exact subset_span ⟨a, m, Set.mem_singleton a, hm, rfl⟩
+#align submodule.smul_singleton Submodule.smul_singleton
+
+section Quotient
+
+/-- The elements of `I / J` are the `x` such that `x • J ⊆ I`.
+
+In fact, we define `x ∈ I / J` to be `∀ y ∈ J, x * y ∈ I` (see `mem_div_iff_forall_mul_mem`),
+which is equivalent to `x • J ⊆ I` (see `mem_div_iff_smul_subset`), but nicer to use in proofs.
+
+This is the general form of the ideal quotient, traditionally written $I : J$.
+-/
+instance : Div (Submodule R A) :=
+  ⟨fun I J =>
+    { carrier := { x | ∀ y ∈ J, x * y ∈ I }
+      zero_mem' := fun y hy => by
+        rw [zero_mul]
+        apply Submodule.zero_mem
+      add_mem' := fun a b ha hb y hy => by
+        rw [add_mul]
+        exact Submodule.add_mem _ (ha _ hy) (hb _ hy)
+      smul_mem' := fun r x hx y hy => by
+        rw [Algebra.smul_mul_assoc]
+        exact Submodule.smul_mem _ _ (hx _ hy) }⟩
+
+theorem mem_div_iff_forall_mul_mem {x : A} {I J : Submodule R A} : x ∈ I / J ↔ ∀ y ∈ J, x * y ∈ I :=
+  Iff.refl _
+#align submodule.mem_div_iff_forall_mul_mem Submodule.mem_div_iff_forall_mul_mem
+
+theorem mem_div_iff_smul_subset {x : A} {I J : Submodule R A} : x ∈ I / J ↔ x • (J : Set A) ⊆ I :=
+  ⟨fun h y ⟨y', hy', xy'_eq_y⟩ => by
+    rw [← xy'_eq_y]
+    apply h
+    assumption, fun h y hy => h (Set.smul_mem_smul_set hy)⟩
+#align submodule.mem_div_iff_smul_subset Submodule.mem_div_iff_smul_subset
+
+theorem le_div_iff {I J K : Submodule R A} : I ≤ J / K ↔ ∀ x ∈ I, ∀ z ∈ K, x * z ∈ J :=
+  Iff.refl _
+#align submodule.le_div_iff Submodule.le_div_iff
+
+theorem le_div_iff_mul_le {I J K : Submodule R A} : I ≤ J / K ↔ I * K ≤ J := by
+  rw [le_div_iff, mul_le]
+#align submodule.le_div_iff_mul_le Submodule.le_div_iff_mul_le
+
+@[simp]
+theorem one_le_one_div {I : Submodule R A} : 1 ≤ 1 / I ↔ I ≤ 1 :=
+  by
+  constructor; all_goals intro hI
+  · rwa [le_div_iff_mul_le, one_mul] at hI
+  · rwa [le_div_iff_mul_le, one_mul]
+#align submodule.one_le_one_div Submodule.one_le_one_div
+
+/- ./././Mathport/Syntax/Translate/Tactic/Lean3.lean:132:4: warning: unsupported: rw with cfg: { occs := occurrences.pos[occurrences.pos] «expr[ ,]»([1]) } -/
+theorem le_self_mul_one_div {I : Submodule R A} (hI : I ≤ 1) : I ≤ I * (1 / I) :=
+  by
+  rw [← mul_one I]
+  apply mul_le_mul_right (one_le_one_div.mpr hI)
+#align submodule.le_self_mul_one_div Submodule.le_self_mul_one_div
+
+theorem mul_one_div_le_one {I : Submodule R A} : I * (1 / I) ≤ 1 :=
+  by
+  rw [Submodule.mul_le]
+  intro m hm n hn
+  rw [Submodule.mem_div_iff_forall_mul_mem] at hn
+  rw [mul_comm]
+  exact hn m hm
+#align submodule.mul_one_div_le_one Submodule.mul_one_div_le_one
+
+@[simp]
+protected theorem map_div {B : Type _} [CommSemiring B] [Algebra R B] (I J : Submodule R A)
+    (h : A ≃ₐ[R] B) : (I / J).map h.toLinearMap = I.map h.toLinearMap / J.map h.toLinearMap :=
+  by
+  ext x
+  simp only [mem_map, mem_div_iff_forall_mul_mem]
+  constructor
+  · rintro ⟨x, hx, rfl⟩ _ ⟨y, hy, rfl⟩
+    exact ⟨x * y, hx _ hy, h.map_mul x y⟩
+  · rintro hx
+    refine' ⟨h.symm x, fun z hz => _, h.apply_symm_apply x⟩
+    obtain ⟨xz, xz_mem, hxz⟩ := hx (h z) ⟨z, hz, rfl⟩
+    convert xz_mem
+    apply h.injective
+    erw [h.map_mul, h.apply_symm_apply, hxz]
+#align submodule.map_div Submodule.map_div
+
+end Quotient
+
+end CommRing
+
+end Submodule
+

--- a/Mathlib/Algebra/Algebra/Operations.lean
+++ b/Mathlib/Algebra/Algebra/Operations.lean
@@ -80,9 +80,10 @@ variable {A : Type v} [Semiring A] [Algebra R A]
 variable (S T : Set A) {M N P Q : Submodule R A} {m n : A}
 
 /-- `1 : Submodule R A` is the submodule R of A. -/
-instance : One (Submodule R A) :=
+instance one : One (Submodule R A) :=
 -- porting note: `f.range` notation doesn't work
   ⟨LinearMap.range (Algebra.linearMap R A)⟩
+#align submodule.has_one Submodule.one
 
 theorem one_eq_range : (1 : Submodule R A) = LinearMap.range (Algebra.linearMap R A) :=
   rfl
@@ -159,8 +160,9 @@ theorem comap_unop_one :
 
 /-- Multiplication of sub-R-modules of an R-algebra A. The submodule `M * N` is the
 smallest R-submodule of `A` containing the elements `m * n` for `m ∈ M` and `n ∈ N`. -/
-instance : Mul (Submodule R A) :=
+instance mul : Mul (Submodule R A) :=
   ⟨Submodule.map₂ <| LinearMap.mul R A⟩
+#align submodule.has_mul Submodule.mul
 
 theorem mul_mem_mul (hm : m ∈ M) (hn : n ∈ N) : m * n ∈ M * N :=
   apply_mem_map₂ _ hm hn
@@ -375,19 +377,21 @@ theorem mem_span_mul_finite_of_mem_mul {P Q : Submodule R A} {x : A} (hx : x ∈
 variable {M N P}
 
 theorem mem_span_singleton_mul {x y : A} : x ∈ span R {y} * P ↔ ∃ z ∈ P, y * z = x := by
-  simp_rw [(· * ·), map₂_span_singleton_eq_map, exists_prop]
+  --porting note: need both `*` and `Mul.mul`
+  simp_rw [(· * ·), Mul.mul, map₂_span_singleton_eq_map, exists_prop]
   rfl
 #align submodule.mem_span_singleton_mul Submodule.mem_span_singleton_mul
 
 theorem mem_mul_span_singleton {x y : A} : x ∈ P * span R {y} ↔ ∃ z ∈ P, z * y = x := by
-  simp_rw [(· * ·), map₂_span_singleton_eq_map_flip, exists_prop]
+  --porting note: need both `*` and `Mul.mul`
+  simp_rw [(· * ·), Mul.mul, map₂_span_singleton_eq_map_flip, exists_prop]
   rfl
 #align submodule.mem_mul_span_singleton Submodule.mem_mul_span_singleton
 
 /-- Sub-R-modules of an R-algebra form an idempotent semiring. -/
 instance : IdemSemiring (Submodule R A) :=
-  { toAddSubmonoid_injective.Semigroup _ fun m n : Submodule R A => mul_toAddSubmonoid m n,
-    AddMonoidWithOne.unary, Submodule.pointwiseAddCommMonoid, Submodule.hasOne, Submodule.hasMul,
+  { toAddSubmonoid_injective.semigroup _ fun m n : Submodule R A => mul_toAddSubmonoid m n,
+    AddMonoidWithOne.unary, Submodule.pointwiseAddCommMonoid, Submodule.one, Submodule.mul,
     (by infer_instance : OrderBot (Submodule R A)),
     (by infer_instance :
       Lattice (Submodule R A)) with

--- a/Mathlib/Algebra/Algebra/Operations.lean
+++ b/Mathlib/Algebra/Algebra/Operations.lean
@@ -62,7 +62,7 @@ theorem algebraMap_mem (r : R) : algebraMap R A r ∈ (1 : SubMulAction R A) :=
 #align sub_mul_action.algebra_map_mem SubMulAction.algebraMap_mem
 
 theorem mem_one' {x : A} : x ∈ (1 : SubMulAction R A) ↔ ∃ y, algebraMap R A y = x :=
-  exists_congr fun r => by rw [algebra_map_eq_smul_one]
+  exists_congr fun r => by rw [algebraMap_eq_smul_one]
 #align sub_mul_action.mem_one' SubMulAction.mem_one'
 
 end SubMulAction
@@ -171,16 +171,16 @@ theorem mul_le : M * N ≤ P ↔ ∀ m ∈ M, ∀ n ∈ N, m * n ∈ P :=
 theorem mul_toAddSubmonoid (M N : Submodule R A) :
     (M * N).toAddSubmonoid = M.toAddSubmonoid * N.toAddSubmonoid := by
   dsimp [Mul.mul]
-  simp_rw [← LinearMap.mulLeft_toAddMonoid_hom R, LinearMap.mulLeft, ← map_to_add_submonoid _ N,
+  simp_rw [← LinearMap.mulLeft_toAddMonoid_hom R, LinearMap.mulLeft, ← map_toAddSubmonoid _ N,
     map₂]
-  rw [supr_to_add_submonoid]
+  rw [supᵢ_toAddSubmonoid]
   rfl
 #align submodule.mul_to_add_submonoid Submodule.mul_toAddSubmonoid
 
 @[elab_as_elim]
 protected theorem mul_induction_on {C : A → Prop} {r : A} (hr : r ∈ M * N)
     (hm : ∀ m ∈ M, ∀ n ∈ N, C (m * n)) (ha : ∀ x y, C x → C y → C (x + y)) : C r := by
-  rw [← mem_to_add_submonoid, mul_to_add_submonoid] at hr
+  rw [← mem_toAddSubmonoid, mul_toAddSubmonoid] at hr
   exact AddSubmonoid.mul_induction_on hr hm ha
 #align submodule.mul_induction_on Submodule.mul_induction_on
 
@@ -264,7 +264,7 @@ protected theorem map_mul {A'} [Semiring A'] [Algebra R A'] (f : A →ₐ[R] A')
       map_supᵢ _ _
     _ = map f.toLinearMap M * map f.toLinearMap N :=
       by
-      apply congr_arg Sup
+      apply congr_arg supₛ
       ext S
       constructor <;> rintro ⟨y, hy⟩
       · use f y, mem_map.mpr ⟨y.1, y.2, rfl⟩
@@ -277,7 +277,7 @@ protected theorem map_mul {A'} [Semiring A'] [Algebra R A'] (f : A →ₐ[R] A')
         rw [f.to_linear_map_apply] at fy_eq
         ext
         simp [fy_eq]
-    
+
 #align submodule.map_mul Submodule.map_mul
 
 theorem map_op_mul :
@@ -328,7 +328,7 @@ open Pointwise
 
 This is available as an instance in the `pointwise` locale. -/
 protected def hasDistribPointwiseNeg {A} [Ring A] [Algebra R A] : HasDistribNeg (Submodule R A) :=
-  toAddSubmonoid_injective.HasDistribNeg _ neg_toAddSubmonoid mul_toAddSubmonoid
+  toAddSubmonoid_injective.hasDistribNeg _ neg_toAddSubmonoid mul_toAddSubmonoid
 #align submodule.has_distrib_pointwise_neg Submodule.hasDistribPointwiseNeg
 
 scoped[Pointwise] attribute [instance] Submodule.hasDistribPointwiseNeg
@@ -419,17 +419,17 @@ theorem pow_toAddSubmonoid {n : ℕ} (h : n ≠ 0) : (M ^ n).toAddSubmonoid = M.
   by
   induction' n with n ih
   · exact (h rfl).elim
-  · rw [pow_succ, pow_succ, mul_to_add_submonoid]
+  · rw [pow_succ, pow_succ, mul_toAddSubmonoid]
     cases n
-    · rw [pow_zero, pow_zero, mul_one, ← mul_to_add_submonoid, mul_one]
+    · rw [pow_zero, pow_zero, mul_one, ← mul_toAddSubmonoid, mul_one]
     · rw [ih n.succ_ne_zero]
 #align submodule.pow_to_add_submonoid Submodule.pow_toAddSubmonoid
 
 theorem le_pow_toAddSubmonoid {n : ℕ} : M.toAddSubmonoid ^ n ≤ (M ^ n).toAddSubmonoid := by
   obtain rfl | hn := Decidable.eq_or_ne n 0
   · rw [pow_zero, pow_zero]
-    exact le_one_to_add_submonoid
-  · exact (pow_to_add_submonoid M hn).ge
+    exact le_one_toAddSubmonoid
+  · exact (pow_toAddSubmonoid M hn).ge
 #align submodule.le_pow_to_add_submonoid Submodule.le_pow_toAddSubmonoid
 
 /-- Dependent version of `Submodule.pow_induction_on_left`. -/
@@ -713,8 +713,7 @@ theorem mul_one_div_le_one {I : Submodule R A} : I * (1 / I) ≤ 1 := by
 
 @[simp]
 protected theorem map_div {B : Type _} [CommSemiring B] [Algebra R B] (I J : Submodule R A)
-    (h : A ≃ₐ[R] B) : (I / J).map h.toLinearMap = I.map h.toLinearMap / J.map h.toLinearMap :=
-  by
+    (h : A ≃ₐ[R] B) : (I / J).map h.toLinearMap = I.map h.toLinearMap / J.map h.toLinearMap := by
   ext x
   simp only [mem_map, mem_div_iff_forall_mul_mem]
   constructor
@@ -733,4 +732,3 @@ end Quotient
 end CommRing
 
 end Submodule
-

--- a/Mathlib/Algebra/Module/Submodule/Bilinear.lean
+++ b/Mathlib/Algebra/Module/Submodule/Bilinear.lean
@@ -62,6 +62,7 @@ theorem map₂_le {f : M →ₗ[R] N →ₗ[R] P} {p : Submodule R M} {q : Submo
     supᵢ_le fun ⟨m, hm⟩ => map_le_iff_le_comap.2 fun n hn => H m hm n hn⟩
 #align submodule.map₂_le Submodule.map₂_le
 
+variable (R)
 theorem map₂_span_span (f : M →ₗ[R] N →ₗ[R] P) (s : Set M) (t : Set N) :
     map₂ f (span R s) (span R t) = span R (Set.image2 (fun m n => f m n) s t) := by
   apply le_antisymm
@@ -78,6 +79,7 @@ theorem map₂_span_span (f : M →ₗ[R] N →ₗ[R] P) (s : Set M) (t : Set N)
     rintro _ ⟨a, b, ha, hb, rfl⟩
     exact apply_mem_map₂ _ (subset_span ha) (subset_span hb)
 #align submodule.map₂_span_span Submodule.map₂_span_span
+variable {R}
 
 @[simp]
 theorem map₂_bot_right (f : M →ₗ[R] N →ₗ[R] P) (p : Submodule R M) : map₂ f p ⊥ = ⊥ :=


### PR DESCRIPTION
This had some trouble with leanprover/lean4#2074 and leanprover/lean4#1926.
There are also quite a few places where extra unfolding is needed in initializers for new-style structures.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
-->
- [x] depends on: leanprover-community/mathlib#18539
- [x] depends on: #2518


[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

Note that this includes a second forward-port; so when diffing, choose the first merge commit as the base.
