### PR TITLE
[Merged by Bors] - fix: make continuity a terminal tactic

### DIFF
--- a/Mathlib/Tactic/Continuity.lean
+++ b/Mathlib/Tactic/Continuity.lean
@@ -24,7 +24,7 @@ macro "continuity" : attr =>
 The tactic `continuity` solves goals of the form `Continuous f` by applying lemmas tagged with the
 `continuity` user attribute. -/
 macro "continuity" : tactic =>
-  `(tactic|aesop options := { terminal := true } (rule_sets [$(Lean.mkIdent `Continuous):ident]))
+  `(tactic|aesop (options := { terminal := true }) (rule_sets [$(Lean.mkIdent `Continuous):ident]))
 
 -- Todo: implement `continuity?`, `continuity!` and `continuity!?` and add configuration, original
 -- syntax was (same for the missing `continuity` variants):

--- a/Mathlib/Tactic/Continuity.lean
+++ b/Mathlib/Tactic/Continuity.lean
@@ -24,7 +24,7 @@ macro "continuity" : attr =>
 The tactic `continuity` solves goals of the form `Continuous f` by applying lemmas tagged with the
 `continuity` user attribute. -/
 macro "continuity" : tactic =>
-  `(tactic|aesop (rule_sets [$(Lean.mkIdent `Continuous):ident]))
+  `(tactic|aesop options := { terminal := true } (rule_sets [$(Lean.mkIdent `Continuous):ident]))
 
 -- Todo: implement `continuity?`, `continuity!` and `continuity!?` and add configuration, original
 -- syntax was (same for the missing `continuity` variants):


### PR DESCRIPTION
As mentioned on zulip, nonterminal `aesop`s are bad, especially for auto-params.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
