### PR TITLE
[Merged by Bors] - refactor: review API of `UniformEmbedding`

### DIFF
--- a/Mathlib/Logic/Equiv/Basic.lean
+++ b/Mathlib/Logic/Equiv/Basic.lean
@@ -5,7 +5,7 @@ Authors: Leonardo de Moura, Mario Carneiro
 Ported by: Kevin Buzzard, Ruben Vorster, Scott Morrison, Eric Rodriguez
 
 ! This file was ported from Lean 3 source module logic.equiv.basic
-! leanprover-community/mathlib commit d6aae1bcbd04b8de2022b9b83a5b5b10e10c777d
+! leanprover-community/mathlib commit 195fcd60ff2bfe392543bceb0ec2adcdb472db4c
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -105,7 +105,7 @@ def pprodEquivProdPLift : PProd α β ≃ PLift α × PLift β :=
 /-- Product of two equivalences. If `α₁ ≃ α₂` and `β₁ ≃ β₂`, then `α₁ × β₁ ≃ α₂ × β₂`. This is
 `Prod.map` as an equivalence. -/
 -- porting note: in Lean 3 there was also a @[congr] tag
-@[simps apply]
+@[simps (config := .asFn) apply]
 def prodCongr (e₁ : α₁ ≃ α₂) (e₂ : β₁ ≃ β₂) : α₁ × β₁ ≃ α₂ × β₂ :=
   ⟨Prod.map e₁ e₂, Prod.map e₁.symm e₂.symm, fun ⟨a, b⟩ => by simp, fun ⟨a, b⟩ => by simp⟩
 #align equiv.prod_congr Equiv.prodCongr

--- a/Mathlib/Topology/Separation.lean
+++ b/Mathlib/Topology/Separation.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro
 
 ! This file was ported from Lean 3 source module topology.separation
-! leanprover-community/mathlib commit 92ca63f0fb391a9ca5f22d2409a6080e786d99f7
+! leanprover-community/mathlib commit 195fcd60ff2bfe392543bceb0ec2adcdb472db4c
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -192,16 +192,22 @@ theorem Inseparable.eq [T0Space α] {x y : α} (h : Inseparable x y) : x = y :=
   T0Space.t0 h
 #align inseparable.eq Inseparable.eq
 
--- porting note: 2 new lemmas
 /-- A topology `Inducing` map from a T₀ space is injective. -/
-protected theorem Inducing.injective [T0Space α] [TopologicalSpace β] {f : α → β}
+protected theorem Inducing.injective [TopologicalSpace β] [T0Space α] {f : α → β}
     (hf : Inducing f) : Injective f := fun _ _ h =>
   (hf.inseparable_iff.1 <| .of_eq h).eq
+#align inducing.injective Inducing.injective
 
-/-- A topology `Inducing` map from a T₀ space is an embedding. -/
-protected theorem Inducing.embedding [T0Space α] [TopologicalSpace β] {f : α → β}
+/-- A topology `Inducing` map from a T₀ space is a topological embedding. -/
+protected theorem Inducing.embedding [TopologicalSpace β] [T0Space α] {f : α → β}
     (hf : Inducing f) : Embedding f :=
   ⟨hf, hf.injective⟩
+#align inducing.embedding Inducing.embedding
+
+lemma embedding_iff_inducing [TopologicalSpace β] [T0Space α] {f : α → β} :
+    Embedding f ↔ Inducing f :=
+  ⟨Embedding.toInducing, Inducing.embedding⟩
+#align embedding_iff_inducing embedding_iff_inducing
 
 theorem t0Space_iff_nhds_injective (α : Type u) [TopologicalSpace α] :
     T0Space α ↔ Injective (𝓝 : α → Filter α) :=

--- a/Mathlib/Topology/UniformSpace/Basic.lean
+++ b/Mathlib/Topology/UniformSpace/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro, Patrick Massot
 
 ! This file was ported from Lean 3 source module topology.uniform_space.basic
-! leanprover-community/mathlib commit e1a7bdeb4fd826b7e71d130d34988f0a2d26a177
+! leanprover-community/mathlib commit 195fcd60ff2bfe392543bceb0ec2adcdb472db4c
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -1136,15 +1136,15 @@ nonrec theorem UniformContinuous.comp [UniformSpace β] [UniformSpace γ] {g : �
   hg.comp hf
 #align uniform_continuous.comp UniformContinuous.comp
 
-theorem Filter.HasBasis.uniformContinuous_iff [UniformSpace β] {p : γ → Prop} {s : γ → Set (α × α)}
-    (ha : (𝓤 α).HasBasis p s) {q : δ → Prop} {t : δ → Set (β × β)} (hb : (𝓤 β).HasBasis q t)
-    {f : α → β} :
+theorem Filter.HasBasis.uniformContinuous_iff {ι'} [UniformSpace β] {p : ι → Prop}
+    {s : ι → Set (α × α)} (ha : (𝓤 α).HasBasis p s) {q : ι' → Prop} {t : ι' → Set (β × β)}
+    (hb : (𝓤 β).HasBasis q t) {f : α → β} :
     UniformContinuous f ↔ ∀ i, q i → ∃ j, p j ∧ ∀ x y, (x, y) ∈ s j → (f x, f y) ∈ t i :=
   (ha.tendsto_iff hb).trans <| by simp only [Prod.forall]
 #align filter.has_basis.uniform_continuous_iff Filter.HasBasis.uniformContinuous_iff
 
-theorem Filter.HasBasis.uniformContinuousOn_iff [UniformSpace β] {p : γ → Prop}
-    {s : γ → Set (α × α)} (ha : (𝓤 α).HasBasis p s) {q : δ → Prop} {t : δ → Set (β × β)}
+theorem Filter.HasBasis.uniformContinuousOn_iff {ι'} [UniformSpace β] {p : ι → Prop}
+    {s : ι → Set (α × α)} (ha : (𝓤 α).HasBasis p s) {q : ι' → Prop} {t : ι' → Set (β × β)}
     (hb : (𝓤 β).HasBasis q t) {f : α → β} {S : Set α} :
     UniformContinuousOn f S ↔
       ∀ i, q i → ∃ j, p j ∧ ∀ x, x ∈ S → ∀ y, y ∈ S → (x, y) ∈ s j → (f x, f y) ∈ t i :=

--- a/Mathlib/Topology/UniformSpace/UniformEmbedding.lean
+++ b/Mathlib/Topology/UniformSpace/UniformEmbedding.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Sébastien Gouëzel, Patrick Massot
 
 ! This file was ported from Lean 3 source module topology.uniform_space.uniform_embedding
-! leanprover-community/mathlib commit 2705404e701abc6b3127da906f40bae062a169c9
+! leanprover-community/mathlib commit 195fcd60ff2bfe392543bceb0ec2adcdb472db4c
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -26,25 +26,43 @@ section
 universe u v w
 variable {α : Type u} {β : Type v} {γ : Type w} [UniformSpace α] [UniformSpace β] [UniformSpace γ]
 
+/-!
+### Uniform inducing maps
+-/
+
 /-- A map `f : α → β` between uniform spaces is called *uniform inducing* if the uniformity filter
 on `α` is the pullback of the uniformity filter on `β` under `Prod.map f f`. If `α` is a separated
 space, then this implies that `f` is injective, hence it is a `UniformEmbedding`. -/
+@[mk_iff uniformInducing_iff]
 structure UniformInducing (f : α → β) : Prop where
   /-- The uniformity filter on the domain is the pullback of the uniformity filter on the codomain
   under `Prod.map f f`. -/
   comap_uniformity : comap (fun x : α × α => (f x.1, f x.2)) (𝓤 β) = 𝓤 α
 #align uniform_inducing UniformInducing
+#align uniform_inducing_iff uniformInducing_iff
+
+protected lemma UniformInducing.comap_uniformSpace {f : α → β} (hf : UniformInducing f) :
+    ‹UniformSpace β›.comap f = ‹UniformSpace α› :=
+  uniformSpace_eq hf.1
+#align uniform_inducing.comap_uniform_space UniformInducing.comap_uniformSpace
+
+lemma uniformInducing_iff' {f : α → β} :
+    UniformInducing f ↔ UniformContinuous f ∧ comap (Prod.map f f) (𝓤 β) ≤ 𝓤 α := by
+  rw [uniformInducing_iff, UniformContinuous, tendsto_iff_comap, le_antisymm_iff, and_comm]; rfl
+#align uniform_inducing_iff' uniformInducing_iff'
+
+protected lemma Filter.HasBasis.uniformInducing_iff {ι ι'} {p : ι → Prop} {p' : ι' → Prop} {s s'}
+    (h : (𝓤 α).HasBasis p s) (h' : (𝓤 β).HasBasis p' s') {f : α → β} :
+    UniformInducing f ↔
+      (∀ i, p' i → ∃ j, p j ∧ ∀ x y, (x, y) ∈ s j → (f x, f y) ∈ s' i) ∧
+        (∀ j, p j → ∃ i, p' i ∧ ∀ x y, (f x, f y) ∈ s' i → (x, y) ∈ s j) := by
+  simp [uniformInducing_iff', h.uniformContinuous_iff h', (h'.comap _).le_basis_iff h, subset_def]
+#align filter.has_basis.uniform_inducing_iff Filter.HasBasis.uniformInducing_iff
 
 theorem UniformInducing.mk' {f : α → β}
     (h : ∀ s, s ∈ 𝓤 α ↔ ∃ t ∈ 𝓤 β, ∀ x y : α, (f x, f y) ∈ t → (x, y) ∈ s) : UniformInducing f :=
   ⟨by simp [eq_comm, Filter.ext_iff, subset_def, h]⟩
 #align uniform_inducing.mk' UniformInducing.mk'
-
-theorem UniformInducing.inducing {f : α → β} (h : UniformInducing f) : Inducing f :=
-  inducing_iff_nhds.2 fun a => by
-    simp only [nhds_eq_comap_uniformity, ← h.comap_uniformity, comap_comap]
-    rfl
-#align uniform_inducing.inducing UniformInducing.inducing
 
 theorem uniformInducing_id : UniformInducing (@id α) :=
   ⟨by rw [← Prod.map_def, Prod.map_id, comap_id]⟩
@@ -73,12 +91,69 @@ theorem uniformInducing_of_compose {f : α → β} {g : β → γ} (hf : Uniform
   exact comap_mono hg.le_comap
 #align uniform_inducing_of_compose uniformInducing_of_compose
 
+theorem UniformInducing.uniformContinuous {f : α → β} (hf : UniformInducing f) :
+    UniformContinuous f := (uniformInducing_iff'.1 hf).1
+#align uniform_inducing.uniform_continuous UniformInducing.uniformContinuous
+
+theorem UniformInducing.uniformContinuous_iff {f : α → β} {g : β → γ} (hg : UniformInducing g) :
+    UniformContinuous f ↔ UniformContinuous (g ∘ f) := by
+  dsimp only [UniformContinuous, Tendsto]
+  rw [← hg.comap_uniformity, ← map_le_iff_le_comap, Filter.map_map]; rfl
+#align uniform_inducing.uniform_continuous_iff UniformInducing.uniformContinuous_iff
+
+theorem UniformInducing.inducing {f : α → β} (h : UniformInducing f) : Inducing f := by
+  obtain rfl := h.comap_uniformSpace
+  exact inducing_induced f
+#align uniform_inducing.inducing UniformInducing.inducing
+
+theorem UniformInducing.prod {α' : Type _} {β' : Type _} [UniformSpace α'] [UniformSpace β']
+    {e₁ : α → α'} {e₂ : β → β'} (h₁ : UniformInducing e₁) (h₂ : UniformInducing e₂) :
+    UniformInducing fun p : α × β => (e₁ p.1, e₂ p.2) :=
+  ⟨by simp [(· ∘ ·), uniformity_prod, ← h₁.1, ← h₂.1, comap_inf, comap_comap]⟩
+#align uniform_inducing.prod UniformInducing.prod
+
+theorem UniformInducing.denseInducing {f : α → β} (h : UniformInducing f) (hd : DenseRange f) :
+    DenseInducing f :=
+  { dense := hd
+    induced := h.inducing.induced }
+#align uniform_inducing.dense_inducing UniformInducing.denseInducing
+
+protected theorem UniformInducing.injective [T0Space α] {f : α → β} (h : UniformInducing f) :
+    Injective f :=
+  h.inducing.injective
+
+/-!
+### Uniform embeddings
+-/
+
 /-- A map `f : α → β` between uniform spaces is a *uniform embedding* if it is uniform inducing and
 injective. If `α` is a separated space, then the latter assumption follows from the former. -/
+@[mk_iff uniformEmbedding_iff]
 structure UniformEmbedding (f : α → β) extends UniformInducing f : Prop where
   /-- A uniform embedding is injective. -/
   inj : Function.Injective f
 #align uniform_embedding UniformEmbedding
+#align uniform_embedding_iff uniformEmbedding_iff
+
+theorem uniformEmbedding_iff' {f : α → β} :
+    UniformEmbedding f ↔ Injective f ∧ UniformContinuous f ∧ comap (Prod.map f f) (𝓤 β) ≤ 𝓤 α := by
+  rw [uniformEmbedding_iff, and_comm, uniformInducing_iff']
+#align uniform_embedding_iff' uniformEmbedding_iff'
+
+theorem Filter.HasBasis.uniformEmbedding_iff' {ι ι'} {p : ι → Prop} {p' : ι' → Prop} {s s'}
+    (h : (𝓤 α).HasBasis p s) (h' : (𝓤 β).HasBasis p' s') {f : α → β} :
+    UniformEmbedding f ↔ Injective f ∧
+      (∀ i, p' i → ∃ j, p j ∧ ∀ x y, (x, y) ∈ s j → (f x, f y) ∈ s' i) ∧
+        (∀ j, p j → ∃ i, p' i ∧ ∀ x y, (f x, f y) ∈ s' i → (x, y) ∈ s j) := by
+  rw [uniformEmbedding_iff, and_comm, h.uniformInducing_iff h']
+#align filter.has_basis.uniform_embedding_iff' Filter.HasBasis.uniformEmbedding_iff'
+
+theorem Filter.HasBasis.uniformEmbedding_iff {ι ι'} {p : ι → Prop} {p' : ι' → Prop} {s s'}
+    (h : (𝓤 α).HasBasis p s) (h' : (𝓤 β).HasBasis p' s') {f : α → β} :
+    UniformEmbedding f ↔ Injective f ∧ UniformContinuous f ∧
+      (∀ j, p j → ∃ i, p' i ∧ ∀ x y, (f x, f y) ∈ s' i → (x, y) ∈ s j) := by
+  simp only [h.uniformEmbedding_iff' h', h.uniformContinuous_iff h']
+#align filter.has_basis.uniform_embedding_iff Filter.HasBasis.uniformEmbedding_iff
 
 theorem uniformEmbedding_subtype_val {p : α → Prop} :
     UniformEmbedding (Subtype.val : Subtype p → α) :=
@@ -98,46 +173,21 @@ theorem UniformEmbedding.comp {g : β → γ} (hg : UniformEmbedding g) {f : α 
   { hg.toUniformInducing.comp hf.toUniformInducing with inj := hg.inj.comp hf.inj }
 #align uniform_embedding.comp UniformEmbedding.comp
 
-theorem uniformEmbedding_def {f : α → β} :
-    UniformEmbedding f ↔
-      Function.Injective f ∧ ∀ s, s ∈ 𝓤 α ↔ ∃ t ∈ 𝓤 β, ∀ x y : α, (f x, f y) ∈ t → (x, y) ∈ s := by
-  constructor
-  · rintro ⟨⟨h⟩, h'⟩
-    rw [eq_comm, Filter.ext_iff] at h
-    simp [*, subset_def]
-  · rintro ⟨h, h'⟩
-    refine' UniformEmbedding.mk ⟨_⟩ h
-    rw [eq_comm, Filter.ext_iff]
-    simp [*, subset_def]
-#align uniform_embedding_def uniformEmbedding_def
-
-theorem uniformEmbedding_def' {f : α → β} :
-    UniformEmbedding f ↔
-      Function.Injective f ∧
-        UniformContinuous f ∧ ∀ s, s ∈ 𝓤 α → ∃ t ∈ 𝓤 β, ∀ x y : α, (f x, f y) ∈ t → (x, y) ∈ s := by
-  simp only [uniformEmbedding_def, uniformContinuous_def]
-  exact ⟨fun ⟨I, H⟩ => ⟨I, fun s su => (H _).2 ⟨s, su, fun x y => id⟩, fun s => (H s).1⟩,
-    fun ⟨I, H₁, H₂⟩ => ⟨I, fun s =>
-      ⟨H₂ s, fun ⟨t, tu, h⟩ => mem_of_superset (H₁ t tu) fun ⟨a, b⟩ => h a b⟩⟩⟩
-#align uniform_embedding_def' uniformEmbedding_def'
-
 theorem Equiv.uniformEmbedding {α β : Type _} [UniformSpace α] [UniformSpace β] (f : α ≃ β)
     (h₁ : UniformContinuous f) (h₂ : UniformContinuous f.symm) : UniformEmbedding f :=
-  { toUniformInducing := uniformInducing_of_compose h₁ h₂ <| by
-      rw [f.symm_comp_self]; exact uniformInducing_id
-    inj := f.injective }
+  uniformEmbedding_iff'.2 ⟨f.injective, h₁, by rwa [← Equiv.prodCongr_apply, ← map_equiv_symm]⟩
 #align equiv.uniform_embedding Equiv.uniformEmbedding
 
 theorem uniformEmbedding_inl : UniformEmbedding (Sum.inl : α → α ⊕ β) :=
-  uniformEmbedding_def'.2 ⟨Sum.inl_injective, uniformContinuous_inl, fun s hs =>
+  uniformEmbedding_iff'.2 ⟨Sum.inl_injective, uniformContinuous_inl, fun s hs =>
     ⟨Prod.map Sum.inl Sum.inl '' s ∪ range (Prod.map Sum.inr Sum.inr),
-      union_mem_sup (image_mem_map hs) range_mem_map, fun x y h => by simpa using h⟩⟩
+      union_mem_sup (image_mem_map hs) range_mem_map, fun x h => by simpa using h⟩⟩
 #align uniform_embedding_inl uniformEmbedding_inl
 
 theorem uniformEmbedding_inr : UniformEmbedding (Sum.inr : β → α ⊕ β) :=
-  uniformEmbedding_def'.2 ⟨Sum.inr_injective, uniformContinuous_inr, fun s hs =>
+  uniformEmbedding_iff'.2 ⟨Sum.inr_injective, uniformContinuous_inr, fun s hs =>
     ⟨range (Prod.map Sum.inl Sum.inl) ∪ Prod.map Sum.inr Sum.inr '' s,
-      union_mem_sup range_mem_map (image_mem_map hs), fun x y h => by simpa using h⟩⟩
+      union_mem_sup range_mem_map (image_mem_map hs), fun x h => by simpa using h⟩⟩
 #align uniform_embedding_inr uniformEmbedding_inr
 
 /-- If the domain of a `UniformInducing` map `f` is a T₀ space, then `f` is injective,
@@ -146,6 +196,11 @@ protected theorem UniformInducing.uniformEmbedding [T0Space α] {f : α → β}
     (hf : UniformInducing f) : UniformEmbedding f :=
   ⟨hf, hf.inducing.injective⟩
 #align uniform_inducing.uniform_embedding UniformInducing.uniformEmbedding
+
+theorem uniformEmbedding_iff_uniformInducing [T0Space α] {f : α → β} :
+    UniformEmbedding f ↔ UniformInducing f :=
+  ⟨UniformEmbedding.toUniformInducing, UniformInducing.uniformEmbedding⟩
+#align uniform_embedding_iff_uniform_inducing uniformEmbedding_iff_uniformInducing
 
 /-- If a map `f : α → β` sends any two distinct points to point that are **not** related by a fixed
 `s ∈ 𝓤 β`, then `f` is uniform inducing with respect to the discrete uniformity on `α`:
@@ -169,29 +224,7 @@ theorem uniformEmbedding_of_spaced_out {α} {f : α → β} {s : Set (β × β)}
   exact UniformInducing.uniformEmbedding ⟨comap_uniformity_of_spaced_out hs hf⟩
 #align uniform_embedding_of_spaced_out uniformEmbedding_of_spaced_out
 
-theorem UniformInducing.uniformContinuous {f : α → β} (hf : UniformInducing f) :
-    UniformContinuous f := by simp [UniformContinuous, hf.comap_uniformity.symm, tendsto_comap]
-#align uniform_inducing.uniform_continuous UniformInducing.uniformContinuous
-
-theorem UniformInducing.uniformContinuous_iff {f : α → β} {g : β → γ} (hg : UniformInducing g) :
-    UniformContinuous f ↔ UniformContinuous (g ∘ f) := by
-  dsimp only [UniformContinuous, Tendsto]
-  rw [← hg.comap_uniformity, ← map_le_iff_le_comap, Filter.map_map]; rfl
-#align uniform_inducing.uniform_continuous_iff UniformInducing.uniformContinuous_iff
-
-theorem UniformInducing.prod {α' : Type _} {β' : Type _} [UniformSpace α'] [UniformSpace β']
-    {e₁ : α → α'} {e₂ : β → β'} (h₁ : UniformInducing e₁) (h₂ : UniformInducing e₂) :
-    UniformInducing fun p : α × β => (e₁ p.1, e₂ p.2) :=
-  ⟨by simp [(· ∘ ·), uniformity_prod, ← h₁.1, ← h₂.1, comap_inf, comap_comap]⟩
-#align uniform_inducing.prod UniformInducing.prod
-
-theorem UniformInducing.denseInducing {f : α → β} (h : UniformInducing f) (hd : DenseRange f) :
-    DenseInducing f :=
-  { dense := hd
-    induced := h.inducing.induced }
-#align uniform_inducing.dense_inducing UniformInducing.denseInducing
-
-theorem UniformEmbedding.embedding {f : α → β} (h : UniformEmbedding f) : Embedding f :=
+protected theorem UniformEmbedding.embedding {f : α → β} (h : UniformEmbedding f) : Embedding f :=
   { toInducing := h.toUniformInducing.inducing
     inj := h.inj }
 #align uniform_embedding.embedding UniformEmbedding.embedding


### PR DESCRIPTION
Forward-port leanprover-community/mathlib#18516

* [`logic.equiv.basic`@`d6aae1bcbd04b8de2022b9b83a5b5b10e10c777d`..`195fcd60ff2bfe392543bceb0ec2adcdb472db4c`](https://leanprover-community.github.io/mathlib-port-status/file/logic/equiv/basic?range=d6aae1bcbd04b8de2022b9b83a5b5b10e10c777d..195fcd60ff2bfe392543bceb0ec2adcdb472db4c)
* [`topology.separation`@`92ca63f0fb391a9ca5f22d2409a6080e786d99f7`..`195fcd60ff2bfe392543bceb0ec2adcdb472db4c`](https://leanprover-community.github.io/mathlib-port-status/file/topology/separation?range=92ca63f0fb391a9ca5f22d2409a6080e786d99f7..195fcd60ff2bfe392543bceb0ec2adcdb472db4c)
* [`topology.uniform_space.basic`@`e1a7bdeb4fd826b7e71d130d34988f0a2d26a177`..`195fcd60ff2bfe392543bceb0ec2adcdb472db4c`](https://leanprover-community.github.io/mathlib-port-status/file/topology/uniform_space/basic?range=e1a7bdeb4fd826b7e71d130d34988f0a2d26a177..195fcd60ff2bfe392543bceb0ec2adcdb472db4c)
* [`topology.uniform_space.uniform_embedding`@`2705404e701abc6b3127da906f40bae062a169c9`..`195fcd60ff2bfe392543bceb0ec2adcdb472db4c`](https://leanprover-community.github.io/mathlib-port-status/file/topology/uniform_space/uniform_embedding?range=2705404e701abc6b3127da906f40bae062a169c9..195fcd60ff2bfe392543bceb0ec2adcdb472db4c)

-------

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)