### PR TITLE
[Merged by Bors] - feat: do not modify the working tree when running start_port.sh

### DIFF
--- a/scripts/start_port.sh
+++ b/scripts/start_port.sh
@@ -93,7 +93,7 @@ echo ""
 
 mathlib3_module=$(grep '^! .*source module ' <"$GIT_WORK_TREE/$mathlib4_path" | sed 's/.*source module \(.*\)$/\1/')
 
-if git cat-file -q -e origin/master:$mathlib4_path 2> /dev/null; then
+if git cat-file -e origin/master:$mathlib4_path 2> /dev/null; then
     echo "WARNING: this file has already been ported!"
     echo "To continue anyway with a fresh port, you can run"
     echo ""

--- a/scripts/start_port.sh
+++ b/scripts/start_port.sh
@@ -93,7 +93,7 @@ echo ""
 
 mathlib3_module=$(grep '^! .*source module ' <"$GIT_WORK_TREE/$mathlib4_path" | sed 's/.*source module \(.*\)$/\1/')
 
-if git cat-file -e origin/master:$mathlib4_path; then
+if git cat-file -q -e origin/master:$mathlib4_path 2> /dev/null; then
     echo "WARNING: this file has already been ported!"
     echo "To continue anyway with a fresh port, you can run"
     echo ""
@@ -102,7 +102,7 @@ if git cat-file -e origin/master:$mathlib4_path; then
     exit 1
 fi
 
-if PR=$(curl --silent --show-error --fail "$PORT_STATUS_YAML" | grep -F "$mathlib3_module: " | grep "mathlib4#"); then
+if PR=$(curl --silent --show-error --fail "$PORT_STATUS_YAML" | grep -F "$mathlib3_module: " | grep -o -E "mathlib4#[0-9]+"); then
     set +x
     echo "WARNING: The file is already in the process of being ported in $PR."
     echo "To continue anyway with a fresh port, you can run"

--- a/scripts/start_port.sh
+++ b/scripts/start_port.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -e
+set -o pipefail
 
 if [ ! -d Mathlib ] ; then
     echo "No Mathlib/ directory; are you at the root of the mathlib4 repo?"
@@ -12,75 +13,108 @@ if [ ! $1 ] ; then
     exit 1
 fi
 
-case $1 in
+# arguments
+mathlib4_path="$1"
+
+case $mathlib4_path in
     Mathlib/*) true ;;
     *) echo "argument must begin with Mathlib/"
        exit 1 ;;
 esac
 
-if [ -f $1 ] ; then
-    echo "file already exists"
-    exit 1
-fi
-
-set -x
-set -o pipefail
-
 MATHLIB3PORT_BASE_URL=https://raw.githubusercontent.com/leanprover-community/mathlib3port/master
 PORT_STATUS_YAML=https://raw.githubusercontent.com/wiki/leanprover-community/mathlib/mathlib4-port-status.md
-TMP_FILE=start_port_tmp.lean
 
-mathlib4_path=$1
+# process path name
 mathlib4_mod=$(basename $(echo "$mathlib4_path" | tr / .) .lean)
-
+mathlib4_mod_tail=${mathlib4_mod#Mathlib.}
 mathlib3port_url=$MATHLIB3PORT_BASE_URL/Mathbin/${1#Mathlib/}
 
-curl --silent --show-error --fail -o "$TMP_FILE" "$mathlib3port_url"
+# start the port from the latest master
+git fetch
+BASE_COMMIT=$(git rev-parse origin/master)
 
-mathlib3_module=$(grep '^! .*source module ' <"$TMP_FILE" | sed 's/.*source module \(.*\)$/\1/')
+TMP_DIR=$(mktemp -d)
+trap 'rm -fr "$TMP_DIR"' 0 1 2 13 15
 
-if curl --silent --show-error --fail "$PORT_STATUS_YAML" | grep -F "$mathlib3_module: " | grep "mathlib4#" ; then
-    set +x
-    echo "WARNING: The file is already in the process of being ported."
-    echo "(See line above for PR number.)"
-    rm "$TMP_FILE"
+export GIT_WORK_TREE=$TMP_DIR/working_tree
+export GIT_INDEX_FILE=$TMP_DIR/index
+mkdir -p "$GIT_WORK_TREE"
+
+echo "Checking out a new branch in a temporary working tree"
+git ls-tree -z -r --full-name "$BASE_COMMIT" | git update-index -z --index-info
+git checkout-index -a
+
+echo "Downloading latest version from mathlib3port"
+(
+    cd $GIT_WORK_TREE;
+    # download the file, but don't commit it yet
+    mkdir -p "$(dirname "$mathlib4_path")"
+    curl --silent --show-error --fail -o "$mathlib4_path" "$mathlib3port_url"
+)
+
+# Empty commit with nice title. Used by gh and hub to suggest PR title.
+BASE_COMMIT="$(echo "feat: port $mathlib4_mod_tail" | git commit-tree "$(git write-tree)" -p "$BASE_COMMIT")"
+
+# Add the mathport file
+git update-index --add "$mathlib4_path"
+BASE_COMMIT="$(echo "Initial file copy from mathport" | git commit-tree "$(git write-tree)" -p "$BASE_COMMIT")"
+
+echo "Applying automated fixes"
+# Apply automated fixes
+(
+    cd $GIT_WORK_TREE;
+    sed -i 's/Mathbin\./Mathlib\./g' "$mathlib4_path"
+    sed -i '/^import/{s/[.]Gcd/.GCD/g; s/[.]Modeq/.ModEq/g; s/[.]Nary/.NAry/g; s/[.]Peq/.PEq/g; s/[.]Pfun/.PFun/g; s/[.]Pnat/.PNat/g; s/[.]Smul/.SMul/g; s/[.]Zmod/.ZMod/g}' "$mathlib4_path"
+
+    # awk script taken from https://github.com/leanprover-community/mathlib4/pull/1523
+    awk '{do {{if (match($0, "^  by$") && length(p) < 98 && (!(match(p, "^[ \t]*--.*$")))) {p=p " by";} else {if (NR!=1) {print p}; p=$0}}} while (getline == 1) if (getline==0) print p}' "$mathlib4_path" > "$mathlib4_path.tmp"
+    mv "$mathlib4_path.tmp" "$mathlib4_path"
+
+    (echo "import $mathlib4_mod" ; cat Mathlib.lean) | LC_ALL=C sort | uniq > Mathlib.lean.tmp
+    mv -f Mathlib.lean.tmp Mathlib.lean
+)
+
+# Commit them
+git update-index --add "$mathlib4_path"
+BASE_COMMIT="$(git commit-tree "$(git write-tree)" -p "$BASE_COMMIT" << EOF
+automated fixes
+
+Mathbin -> Mathlib
+fix certain import statements
+move "by" to end of line
+add import to Mathlib.lean
+EOF
+)"
+
+echo "Successfully created initial commits:"
+git log -n3 $BASE_COMMIT --graph --oneline
+echo ""
+
+mathlib3_module=$(grep '^! .*source module ' <"$GIT_WORK_TREE/$mathlib4_path" | sed 's/.*source module \(.*\)$/\1/')
+
+if git cat-file -e origin/master:$mathlib4_path; then
+    echo "WARNING: this file has already been ported!"
+    echo "To continue anyway with a fresh port, you can run"
+    echo ""
+    echo "    git checkout $BASE_COMMIT -b port/${mathlib4_mod_tail}-again"
+    echo ""
     exit 1
 fi
 
-mkdir -p $(dirname "$mathlib4_path")
-mv "$TMP_FILE" "$mathlib4_path"
+if PR=$(curl --silent --show-error --fail "$PORT_STATUS_YAML" | grep -F "$mathlib3_module: " | grep "mathlib4#"); then
+    set +x
+    echo "WARNING: The file is already in the process of being ported in $PR."
+    echo "To continue anyway with a fresh port, you can run"
+    echo ""
+    echo "    git checkout $BASE_COMMIT -b port/${mathlib4_mod_tail}-<some-suffix>"
+    echo ""
+    exit 1
+fi
 
-git fetch
-mathlib4_mod_tail=${mathlib4_mod#Mathlib.}
 branch_name=port/${mathlib4_mod_tail}
-git checkout --no-track -b "$branch_name" origin/master
-
-# Empty commit with nice title. Used by gh and hub to suggest PR title.
-git commit -m "feat: port $mathlib4_mod_tail" --allow-empty
-
-git add "$mathlib4_path"
-git commit -m 'Initial file copy from mathport'
-
-sed -i 's/Mathbin\./Mathlib\./g' "$mathlib4_path"
-sed -i '/^import/{s/[.]Gcd/.GCD/g; s/[.]Modeq/.ModEq/g; s/[.]Nary/.NAry/g; s/[.]Peq/.PEq/g; s/[.]Pfun/.PFun/g; s/[.]Pnat/.PNat/g; s/[.]Smul/.SMul/g; s/[.]Zmod/.ZMod/g}' "$mathlib4_path"
-
-# awk script taken from https://github.com/leanprover-community/mathlib4/pull/1523
-awk '{do {{if (match($0, "^  by$") && length(p) < 98 && (!(match(p, "^[ \t]*--.*$")))) {p=p " by";} else {if (NR!=1) {print p}; p=$0}}} while (getline == 1) if (getline==0) print p}' "$mathlib4_path" > "$mathlib4_path.tmp"
-mv "$mathlib4_path.tmp" "$mathlib4_path"
-
-(echo "import $mathlib4_mod" ; cat Mathlib.lean) | LC_ALL=C sort | uniq > Mathlib.lean.tmp
-mv -f Mathlib.lean.tmp Mathlib.lean
-
-git add Mathlib.lean "$mathlib4_path"
-git commit \
-	-m 'automated fixes' \
-	-m '' \
-	-m 'Mathbin -> Mathlib' \
-	-m 'fix certain import statements' \
-	-m 'move "by" to end of line' \
-	-m 'add import to Mathlib.lean'
-
-set +x
+echo "Checking out a new $branch_name branch from $BASE_COMMIT"
+git checkout --no-track -b "$branch_name" "$BASE_COMMIT"
 
 echo "After pushing, you can open a PR at:"
 echo "https://github.com/leanprover-community/mathlib4/compare/$branch_name?expand=1&title=feat:+port+$mathlib4_mod_tail&labels=mathlib-port"


### PR DESCRIPTION
This means that it always succeeds, even if a port has already happened. It also prevents it from clobbering local changes.
The new behavior is:
```sh
# this file is ported
$ scripts/start_port.sh Mathlib/Algebra/Algebra/Basic.lean
Checking out a new branch in a temporary working tree
Downloading latest version from mathlib3port
Applying automated fixes
Successfully created initial commits:
* 865bcb6d automated fixes
* 72c365f7 Initial file copy from mathport
* 43748fcf feat: port Algebra.Algebra.Basic

WARNING: this file has already been ported!
To continue anyway with a fresh port, you can run

    git checkout 865bcb6d548e990a7214a3a168389f731a975aa8 -b port/Algebra.Algebra.Basic-again
```
```sh
# this file is in progress
$ scripts/start_port.sh Mathlib/Algebra/Algebra/Operations.lean
Checking out a new branch in a temporary working tree
Downloading latest version from mathlib3port
Applying automated fixes
Successfully created initial commits:
* 66beceb7 automated fixes
* 209e1206 Initial file copy from mathport
* 250226b3 feat: port Algebra.Algebra.Operations

WARNING: The file is already in the process of being ported in mathlib4#2568.
To continue anyway with a fresh port, you can run

    git checkout 66beceb792782206d6fdf60822bffcb14779c2b0 -b port/Algebra.Algebra.Operations-<some-suffix>

```
```sh
# this file is not ported
$ scripts/start_port.sh Mathlib/Algebra/Algebra/Subalgebra/Basic.lean
Checking out a new branch in a temporary working tree
Downloading latest version from mathlib3port
Applying automated fixes
Successfully created initial commits:
* 93e0eb94 automated fixes
* d57e8e8f Initial file copy from mathport
* 6716afb6 feat: port Algebra.Algebra.Subalgebra.Basic

Checking out a new port/Algebra.Algebra.Subalgebra.Basic branch from 93e0eb94e59146036141385b0a94cef93dd9ffc7
M       Mathlib.lean
Switched to a new branch 'port/Algebra.Algebra.Subalgebra.Basic'
After pushing, you can open a PR at:
https://github.com/leanprover-community/mathlib4/compare/port/Algebra.Algebra.Subalgebra.Basic?expand=1&title=feat:+port+Algebra.Algebra.Subalgebra.Basic&labels=mathlib-port
```

The approach here is taken from https://github.com/ion1/git-plumbing-create-commit/blob/master/git-plumbing-create-commit

This mostly makes #2249 obsolete.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
