### PR TITLE
[Merged by Bors] - feat: port Topology.Algebra.Order.Field

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1248,6 +1248,7 @@ import Mathlib.Topology.Algebra.Order.Archimedean
 import Mathlib.Topology.Algebra.Order.Compact
 import Mathlib.Topology.Algebra.Order.ExtendFrom
 import Mathlib.Topology.Algebra.Order.ExtrClosure
+import Mathlib.Topology.Algebra.Order.Field
 import Mathlib.Topology.Algebra.Order.Filter
 import Mathlib.Topology.Algebra.Order.Floor
 import Mathlib.Topology.Algebra.Order.Group

--- a/Mathlib/Order/Filter/Pointwise.lean
+++ b/Mathlib/Order/Filter/Pointwise.lean
@@ -825,7 +825,6 @@ Note that `Filter α` is not a `Distrib` because `f * g + f * h` has cross terms
 lacks.
 -/
 
-
 theorem mul_add_subset : f * (g + h) ≤ f * g + f * h :=
   map₂_distrib_le_left mul_add
 #align filter.mul_add_subset Filter.mul_add_subset
@@ -908,7 +907,7 @@ theorem map_inv' : f⁻¹.map m = (f.map m)⁻¹ :=
 #align filter.map_neg' Filter.map_neg'
 
 @[to_additive]
-theorem Tendsto.inv_inv : Tendsto m f₁ f₂ → Tendsto m f₁⁻¹ f₂⁻¹ := fun hf =>
+protected theorem Tendsto.inv_inv : Tendsto m f₁ f₂ → Tendsto m f₁⁻¹ f₂⁻¹ := fun hf =>
   (Filter.map_inv' m).trans_le <| Filter.inv_le_inv hf
 #align filter.tendsto.inv_inv Filter.Tendsto.inv_inv
 #align filter.tendsto.neg_neg Filter.Tendsto.neg_neg
@@ -920,8 +919,9 @@ protected theorem map_div : (f / g).map m = f.map m / g.map m :=
 #align filter.map_sub Filter.map_sub
 
 @[to_additive]
-theorem Tendsto.div_div : Tendsto m f₁ f₂ → Tendsto m g₁ g₂ → Tendsto m (f₁ / g₁) (f₂ / g₂) :=
-  fun hf hg => (Filter.map_div m).trans_le <| Filter.div_le_div hf hg
+protected theorem Tendsto.div_div (hf : Tendsto m f₁ f₂) (hg : Tendsto m g₁ g₂) :
+    Tendsto m (f₁ / g₁) (f₂ / g₂) :=
+  (Filter.map_div m).trans_le <| Filter.div_le_div hf hg
 #align filter.tendsto.div_div Filter.Tendsto.div_div
 #align filter.tendsto.sub_sub Filter.Tendsto.sub_sub
 

--- a/Mathlib/Topology/Algebra/Group/Basic.lean
+++ b/Mathlib/Topology/Algebra/Group/Basic.lean
@@ -37,9 +37,7 @@ topological space, group, topological group
 -/
 
 
-open Classical Set Filter TopologicalSpace Function
-
-open Classical Topology Filter Pointwise
+open Classical Set Filter TopologicalSpace Function Topology Pointwise
 
 universe u v w x
 

--- a/Mathlib/Topology/Algebra/GroupWithZero.lean
+++ b/Mathlib/Topology/Algebra/GroupWithZero.lean
@@ -255,28 +255,59 @@ protected def mulRight₀ (c : α) (hc : c ≠ 0) : α ≃ₜ α :=
 #align homeomorph.mul_right₀ Homeomorph.mulRight₀
 
 @[simp]
-theorem coe_mulLeft₀ (c : α) (hc : c ≠ 0) : ⇑(Homeomorph.mulLeft₀ c hc) = (· * ·) c :=
+theorem coe_mulLeft₀ (c : α) (hc : c ≠ 0) : ⇑(Homeomorph.mulLeft₀ c hc) = (c * ·) :=
   rfl
 #align homeomorph.coe_mul_left₀ Homeomorph.coe_mulLeft₀
 
 @[simp]
 theorem mulLeft₀_symm_apply (c : α) (hc : c ≠ 0) :
-    ((Homeomorph.mulLeft₀ c hc).symm : α → α) = (· * ·) c⁻¹ :=
+    ((Homeomorph.mulLeft₀ c hc).symm : α → α) = (c⁻¹ * ·) :=
   rfl
 #align homeomorph.mul_left₀_symm_apply Homeomorph.mulLeft₀_symm_apply
 
 @[simp]
-theorem coe_mulRight₀ (c : α) (hc : c ≠ 0) : ⇑(Homeomorph.mulRight₀ c hc) = fun x => x * c :=
+theorem coe_mulRight₀ (c : α) (hc : c ≠ 0) : ⇑(Homeomorph.mulRight₀ c hc) = (· * c) :=
   rfl
 #align homeomorph.coe_mul_right₀ Homeomorph.coe_mulRight₀
 
 @[simp]
 theorem mulRight₀_symm_apply (c : α) (hc : c ≠ 0) :
-    ((Homeomorph.mulRight₀ c hc).symm : α → α) = fun x => x * c⁻¹ :=
+    ((Homeomorph.mulRight₀ c hc).symm : α → α) = (· * c⁻¹) :=
   rfl
 #align homeomorph.mul_right₀_symm_apply Homeomorph.mulRight₀_symm_apply
 
 end Homeomorph
+
+section map_comap
+
+variable [TopologicalSpace G₀] [GroupWithZero G₀] [ContinuousMul G₀] {a : G₀}
+
+theorem map_mul_left_nhds₀ (ha : a ≠ 0) (b : G₀) : map (a * ·) (𝓝 b) = 𝓝 (a * b) :=
+  (Homeomorph.mulLeft₀ a ha).map_nhds_eq b
+
+theorem map_mul_left_nhds_one₀ (ha : a ≠ 0) : map (a * ·) (𝓝 1) = 𝓝 (a) := by
+  rw [map_mul_left_nhds₀ ha, mul_one]
+
+theorem map_mul_right_nhds₀ (ha : a ≠ 0) (b : G₀) : map (· * a) (𝓝 b) = 𝓝 (b * a) :=
+  (Homeomorph.mulRight₀ a ha).map_nhds_eq b
+
+theorem map_mul_right_nhds_one₀ (ha : a ≠ 0) : map (· * a) (𝓝 1) = 𝓝 (a) := by
+  rw [map_mul_right_nhds₀ ha, one_mul]
+
+theorem nhds_translation_mul_inv₀ (ha : a ≠ 0) : comap (· * a⁻¹) (𝓝 1) = 𝓝 a :=
+  ((Homeomorph.mulRight₀ a ha).symm.comap_nhds_eq 1).trans <| by simp
+
+/-- If a group with zero has continuous multiplication and `fun x ↦ x⁻¹` is continuous at one,
+then it is continuous at any unit. -/
+theorem HasContinuousInv₀.of_nhds_one (h : Tendsto Inv.inv (𝓝 (1 : G₀)) (𝓝 1)) :
+    HasContinuousInv₀ G₀ where
+  continuousAt_inv₀ x hx := by
+    have hx' := inv_ne_zero hx
+    rw [ContinuousAt, ← map_mul_left_nhds_one₀ hx, ← nhds_translation_mul_inv₀ hx',
+      tendsto_map'_iff, tendsto_comap_iff]
+    simpa only [(· ∘ ·), mul_inv_rev, mul_inv_cancel_right₀ hx']
+
+end map_comap
 
 section Zpow
 

--- a/Mathlib/Topology/Algebra/Order/Field.lean
+++ b/Mathlib/Topology/Algebra/Order/Field.lean
@@ -218,7 +218,7 @@ instance (priority := 100) LinearOrderedSemifield.toHasContinuousInv₀ {𝕜}
     exact hxx'.trans_lt <| inv_inv x' ▸ inv_lt_inv_of_lt hy.1 hy.2
   · filter_upwards [Ioi_mem_nhds (inv_lt_one hx)] with y hy
     simpa only [inv_inv] using inv_lt_inv_of_lt (inv_pos.2 <| one_pos.trans hx) hy
-    
+
 instance (priority := 100) LinearOrderedField.toTopologicalDivisionRing :
     TopologicalDivisionRing 𝕜 := ⟨⟩
 #align linear_ordered_field.to_topological_division_ring LinearOrderedField.toTopologicalDivisionRing

--- a/Mathlib/Topology/Algebra/Order/Field.lean
+++ b/Mathlib/Topology/Algebra/Order/Field.lean
@@ -9,258 +9,141 @@ Authors: Benjamin Davidson, Devon Tuma, Eric Rodriguez, Oliver Nash
 ! if you have ported upstream changes.
 -/
 import Mathlib.Tactic.Positivity
-import Mathlib.Tactic.Linarith.Default
 import Mathlib.Topology.Algebra.Order.Group
 import Mathlib.Topology.Algebra.Field
 
 /-!
 # Topologies on linear ordered fields
 
+In this file we prove that a linear ordered field with order topology has continuous multiplication
+and division (apart from zero in the denominator). We also prove theorems like
+`Filter.Tendsto.mul_atTop`: if `f` tends to a positive number and `g` tends to positive infinity,
+then `f * g` tends to positive infinity.
 -/
 
 
-open Set Filter TopologicalSpace
-
-open Function
-
+open Set Filter TopologicalSpace Function Topology Classical
 open OrderDual (toDual ofDual)
 
-open Topology Classical Filter
+/-- If a (possibly non-unital and/or non-associative) ring `R` admits a submultiplicative
+nonnegative norm `norm : R → 𝕜`, where `𝕜` is a linear ordered field, and the open balls
+`{ x | norm x < ε }`, `ε > 0`, form a basis of neighborhoods of zero, then `R` is a topological
+ring. -/
+theorem TopologicalRing.of_norm {R 𝕜 : Type _} [NonUnitalNonAssocRing R] [LinearOrderedField 𝕜]
+    [TopologicalSpace R] [TopologicalAddGroup R] (norm : R → 𝕜)
+    (norm_nonneg : ∀ x, 0 ≤ norm x) (norm_mul_le : ∀ x y, norm (x * y) ≤ norm x * norm y)
+    (nhds_basis : (𝓝 (0 : R)).HasBasis ((0 : 𝕜) < ·) (fun ε ↦ { x | norm x < ε })) :
+    TopologicalRing R := by
+  have h0 : ∀ f : R → R, ∀ c ≥ (0 : 𝕜), (∀ x, norm (f x) ≤ c * norm x) → Tendsto f (𝓝 0) (𝓝 0)
+  · refine fun f c c0 hf ↦ (nhds_basis.tendsto_iff nhds_basis).2 fun ε ε0 ↦ ?_
+    rcases exists_pos_mul_lt ε0 c with ⟨δ, δ0, hδ⟩
+    refine ⟨δ, δ0, fun x hx ↦ (hf _).trans_lt ?_⟩
+    exact (mul_le_mul_of_nonneg_left (le_of_lt hx) c0).trans_lt hδ
+  apply TopologicalRing.of_add_group_of_nhds_zero
+  case hmul =>
+    refine ((nhds_basis.prod nhds_basis).tendsto_iff nhds_basis).2 fun ε ε0 ↦ ?_
+    refine ⟨(1, ε), ⟨one_pos, ε0⟩, fun (x, y) ⟨hx, hy⟩ => ?_⟩
+    simp only [sub_zero] at *
+    calc norm (x * y) ≤ norm x * norm y := norm_mul_le _ _
+    _ < ε := mul_lt_of_le_one_of_lt_of_nonneg hx.le hy (norm_nonneg _)
+  case hmul_left => exact fun x => h0 _ (norm x) (norm_nonneg _) (norm_mul_le x)
+  case hmul_right =>
+    exact fun y => h0 (· * y) (norm y) (norm_nonneg y) fun x =>
+      (norm_mul_le x y).trans_eq (mul_comm _ _)
 
-variable {α β : Type _}
-
-variable [LinearOrderedField α] [TopologicalSpace α] [OrderTopology α]
-
-variable {l : Filter β} {f g : β → α}
-
-section continuous_mul
-
-theorem mul_tendsto_nhds_zero_right (x : α) :
-    Tendsto (uncurry ((· * ·) : α → α → α)) (𝓝 0 ×ᶠ 𝓝 x) <| 𝓝 0 := by
-  have hx : 0 < 2 * (1 + |x|) := by positivity
-  rw [((nhds_basis_zero_abs_sub_lt α).Prod <| nhds_basis_abs_sub_lt x).tendsto_iffₓ
-      (nhds_basis_zero_abs_sub_lt α)]
-  refine' fun ε ε_pos => ⟨(ε / (2 * (1 + |x|)), 1), ⟨div_pos ε_pos hx, zero_lt_one⟩, _⟩
-  suffices ∀ a b : α, |a| < ε / (2 * (1 + |x|)) → |b - x| < 1 → |a| * |b| < ε by
-    simpa only [and_imp, Prod.forall, mem_prod, ← abs_mul]
-  intro a b h h'
-  refine' lt_of_le_of_lt (mul_le_mul_of_nonneg_left _ (abs_nonneg a)) ((lt_div_iff hx).1 h)
-  calc
-    |b| = |b - x + x| := by rw [sub_add_cancel b x]
-    _ ≤ |b - x| + |x| := (abs_add (b - x) x)
-    _ ≤ 2 * (1 + |x|) := by linarith
-    
-#align mul_tendsto_nhds_zero_right mul_tendsto_nhds_zero_right
-
-/- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
-theorem mul_tendsto_nhds_zero_left (x : α) :
-    Tendsto (uncurry ((· * ·) : α → α → α)) (𝓝 x ×ᶠ 𝓝 0) <| 𝓝 0 := by
-  intro s hs
-  have := mul_tendsto_nhds_zero_right x hs
-  rw [Filter.mem_map, mem_prod_iff] at this⊢
-  obtain ⟨U, hU, V, hV, h⟩ := this
-  exact
-    ⟨V, hV, U, hU, fun y hy =>
-      (mul_comm y.2 y.1 ▸ h (⟨hy.2, hy.1⟩ : Prod.mk y.2 y.1 ∈ U ×ˢ V) : y.1 * y.2 ∈ s)⟩
-#align mul_tendsto_nhds_zero_left mul_tendsto_nhds_zero_left
-
-theorem nhds_eq_map_mul_left_nhds_one {x₀ : α} (hx₀ : x₀ ≠ 0) :
-    𝓝 x₀ = map (fun x => x₀ * x) (𝓝 1) := by
-  have hx₀' : 0 < |x₀| := abs_pos.2 hx₀
-  refine' Filter.ext fun t => _
-  simp only [exists_prop, set_of_subset_set_of, (nhds_basis_abs_sub_lt x₀).mem_iff,
-    (nhds_basis_abs_sub_lt (1 : α)).mem_iff, Filter.mem_map']
-  refine' ⟨fun h => _, fun h => _⟩
-  · obtain ⟨i, hi, hit⟩ := h
-    refine' ⟨i / |x₀|, div_pos hi (abs_pos.2 hx₀), fun x hx => hit _⟩
-    calc
-      |x₀ * x - x₀| = |x₀ * (x - 1)| := congr_arg abs (by ring_nf)
-      _ = |x₀| * |x - 1| := (abs_mul x₀ (x - 1))
-      _ < |x₀| * (i / |x₀|) := (mul_lt_mul' le_rfl hx (by positivity) (abs_pos.2 hx₀))
-      _ = |x₀| * i / |x₀| := by ring
-      _ = i := mul_div_cancel_left i fun h => hx₀ (abs_eq_zero.1 h)
-      
-  · obtain ⟨i, hi, hit⟩ := h
-    refine' ⟨i * |x₀|, mul_pos hi (abs_pos.2 hx₀), fun x hx => _⟩
-    have : |x / x₀ - 1| < i
-    calc
-      |x / x₀ - 1| = |x / x₀ - x₀ / x₀| := by rw [div_self hx₀]
-      _ = |(x - x₀) / x₀| := (congr_arg abs (sub_div x x₀ x₀).symm)
-      _ = |x - x₀| / |x₀| := (abs_div (x - x₀) x₀)
-      _ < i * |x₀| / |x₀| := (div_lt_div_of_lt (abs_pos.2 hx₀) hx)
-      _ = i := by rw [← mul_div_assoc', div_self (ne_of_lt <| abs_pos.2 hx₀).symm, mul_one]
-      
-    specialize hit (x / x₀) this
-    rwa [mul_div_assoc', mul_div_cancel_left x hx₀] at hit
-#align nhds_eq_map_mul_left_nhds_one nhds_eq_map_mul_left_nhds_one
-
-theorem nhds_eq_map_mul_right_nhds_one {x₀ : α} (hx₀ : x₀ ≠ 0) :
-    𝓝 x₀ = map (fun x => x * x₀) (𝓝 1) := by
-  simp_rw [mul_comm _ x₀, nhds_eq_map_mul_left_nhds_one hx₀]
-#align nhds_eq_map_mul_right_nhds_one nhds_eq_map_mul_right_nhds_one
-
-theorem mul_tendsto_nhds_one_nhds_one :
-    Tendsto (uncurry ((· * ·) : α → α → α)) (𝓝 1 ×ᶠ 𝓝 1) <| 𝓝 1 := by
-  rw [((nhds_basis_Ioo_pos (1 : α)).Prod <| nhds_basis_Ioo_pos (1 : α)).tendsto_iffₓ
-      (nhds_basis_Ioo_pos_of_pos (zero_lt_one : (0 : α) < 1))]
-  intro ε hε
-  have hε' : 0 ≤ 1 - ε / 4 := by linarith
-  have ε_pos : 0 < ε / 4 := by linarith
-  have ε_pos' : 0 < ε / 2 := by linarith
-  simp only [and_imp, Prod.forall, mem_Ioo, Function.uncurry_apply_pair, mem_prod, Prod.exists]
-  refine' ⟨ε / 4, ε / 4, ⟨ε_pos, ε_pos⟩, fun a b ha ha' hb hb' => _⟩
-  have ha0 : 0 ≤ a := le_trans hε' (le_of_lt ha)
-  have hb0 : 0 ≤ b := le_trans hε' (le_of_lt hb)
-  refine'
-    ⟨lt_of_le_of_lt _ (mul_lt_mul'' ha hb hε' hε'), lt_of_lt_of_le (mul_lt_mul'' ha' hb' ha0 hb0) _⟩
-  ·
-    calc
-      1 - ε = 1 - ε / 2 - ε / 2 := by ring_nf
-      _ ≤ 1 - ε / 2 - ε / 2 + ε / 2 * (ε / 2) := (le_add_of_nonneg_right (by positivity))
-      _ = (1 - ε / 2) * (1 - ε / 2) := by ring_nf
-      _ ≤ (1 - ε / 4) * (1 - ε / 4) := mul_le_mul (by linarith) (by linarith) (by linarith) hε'
-      
-  ·
-    calc
-      (1 + ε / 4) * (1 + ε / 4) = 1 + ε / 2 + ε / 4 * (ε / 4) := by ring_nf
-      _ = 1 + ε / 2 + ε * ε / 16 := by ring_nf
-      _ ≤ 1 + ε / 2 + ε / 2 :=
-        (add_le_add_left
-          (div_le_div (le_of_lt hε.1)
-            (le_trans ((mul_le_mul_left hε.1).2 hε.2) (le_of_eq <| mul_one ε)) zero_lt_two
-            (by linarith))
-          (1 + ε / 2))
-      _ ≤ 1 + ε := by ring_nf
-      
-#align mul_tendsto_nhds_one_nhds_one mul_tendsto_nhds_one_nhds_one
+variable {𝕜 α : Type _} [LinearOrderedField 𝕜] [TopologicalSpace 𝕜] [OrderTopology 𝕜]
+  {l : Filter α} {f g : α → 𝕜}
 
 -- see Note [lower instance priority]
-instance (priority := 100) LinearOrderedField.continuousMul : ContinuousMul α :=
-  ⟨by
-    rw [continuous_iff_continuousAt]
-    rintro ⟨x₀, y₀⟩
-    by_cases hx₀ : x₀ = 0
-    · rw [hx₀, ContinuousAt, zero_mul, nhds_prod_eq]
-      exact mul_tendsto_nhds_zero_right y₀
-    by_cases hy₀ : y₀ = 0
-    · rw [hy₀, ContinuousAt, mul_zero, nhds_prod_eq]
-      exact mul_tendsto_nhds_zero_left x₀
-    have hxy : x₀ * y₀ ≠ 0 := mul_ne_zero hx₀ hy₀
-    have key :
-      (fun p : α × α => x₀ * p.1 * (p.2 * y₀)) =
-        ((fun x => x₀ * x) ∘ fun x => x * y₀) ∘ uncurry (· * ·) :=
-      by
-      ext p
-      simp [uncurry, mul_assoc]
-    have key₂ : ((fun x => x₀ * x) ∘ fun x => y₀ * x) = fun x => x₀ * y₀ * x :=
-      by
-      ext x
-      simp
-    calc
-      map (uncurry (· * ·)) (𝓝 (x₀, y₀)) = map (uncurry (· * ·)) (𝓝 x₀ ×ᶠ 𝓝 y₀) := by
-        rw [nhds_prod_eq]
-      _ = map (fun p : α × α => x₀ * p.1 * (p.2 * y₀)) (𝓝 1 ×ᶠ 𝓝 1) := by
-        rw [uncurry, nhds_eq_map_mul_left_nhds_one hx₀, nhds_eq_map_mul_right_nhds_one hy₀,
-          prod_map_map_eq, Filter.map_map]
-      _ = map ((fun x => x₀ * x) ∘ fun x => x * y₀) (map (uncurry (· * ·)) (𝓝 1 ×ᶠ 𝓝 1)) := by
-        rw [key, ← Filter.map_map]
-      _ ≤ map ((fun x : α => x₀ * x) ∘ fun x => x * y₀) (𝓝 1) :=
-        (map_mono mul_tendsto_nhds_one_nhds_one)
-      _ = 𝓝 (x₀ * y₀) := by
-        rw [← Filter.map_map, ← nhds_eq_map_mul_right_nhds_one hy₀,
-          nhds_eq_map_mul_left_nhds_one hy₀, Filter.map_map, key₂, ←
-          nhds_eq_map_mul_left_nhds_one hxy]
-      ⟩
-#align linear_ordered_field.has_continuous_mul LinearOrderedField.continuousMul
+instance (priority := 100) LinearOrderedField.topologicalRing : TopologicalRing 𝕜 :=
+  .of_norm abs abs_nonneg (fun _ _ ↦ (abs_mul _ _).le) <| by
+    simpa using nhds_basis_abs_sub_lt (0 : 𝕜)
 
-end continuous_mul
-
-/-- In a linearly ordered field with the order topology, if `f` tends to `at_top` and `g` tends to
-a positive constant `C` then `f * g` tends to `at_top`. -/
-theorem Filter.Tendsto.atTop_mul {C : α} (hC : 0 < C) (hf : Tendsto f l atTop)
+/-- In a linearly ordered field with the order topology, if `f` tends to `Filter.atTop` and `g`
+tends to a positive constant `C` then `f * g` tends to `Filter.atTop`. -/
+theorem Filter.Tendsto.atTop_mul {C : 𝕜} (hC : 0 < C) (hf : Tendsto f l atTop)
     (hg : Tendsto g l (𝓝 C)) : Tendsto (fun x => f x * g x) l atTop := by
-  refine' tendsto_at_top_mono' _ _ (hf.at_top_mul_const (half_pos hC))
-  filter_upwards [hg.eventually (lt_mem_nhds (half_lt_self hC)),
-    hf.eventually (eventually_ge_at_top 0)]with x hg hf using mul_le_mul_of_nonneg_left hg.le hf
+  refine' tendsto_atTop_mono' _ _ (hf.atTop_mul_const (half_pos hC))
+  filter_upwards [hg.eventually (lt_mem_nhds (half_lt_self hC)), hf.eventually_ge_atTop 0]
+    with x hg hf using mul_le_mul_of_nonneg_left hg.le hf
 #align filter.tendsto.at_top_mul Filter.Tendsto.atTop_mul
 
 /-- In a linearly ordered field with the order topology, if `f` tends to a positive constant `C` and
-`g` tends to `at_top` then `f * g` tends to `at_top`. -/
-theorem Filter.Tendsto.mul_atTop {C : α} (hC : 0 < C) (hf : Tendsto f l (𝓝 C))
+`g` tends to `Filter.atTop` then `f * g` tends to `Filter.atTop`. -/
+theorem Filter.Tendsto.mul_atTop {C : 𝕜} (hC : 0 < C) (hf : Tendsto f l (𝓝 C))
     (hg : Tendsto g l atTop) : Tendsto (fun x => f x * g x) l atTop := by
-  simpa only [mul_comm] using hg.at_top_mul hC hf
+  simpa only [mul_comm] using hg.atTop_mul hC hf
 #align filter.tendsto.mul_at_top Filter.Tendsto.mul_atTop
 
-/-- In a linearly ordered field with the order topology, if `f` tends to `at_top` and `g` tends to
-a negative constant `C` then `f * g` tends to `at_bot`. -/
-theorem Filter.Tendsto.atTop_mul_neg {C : α} (hC : C < 0) (hf : Tendsto f l atTop)
+/-- In a linearly ordered field with the order topology, if `f` tends to `Filter.atTop` and `g`
+tends to a negative constant `C` then `f * g` tends to `Filter.atBot`. -/
+theorem Filter.Tendsto.atTop_mul_neg {C : 𝕜} (hC : C < 0) (hf : Tendsto f l atTop)
     (hg : Tendsto g l (𝓝 C)) : Tendsto (fun x => f x * g x) l atBot := by
-  simpa only [(· ∘ ·), neg_mul_eq_mul_neg, neg_neg] using
-    tendsto_neg_at_top_at_bot.comp (hf.at_top_mul (neg_pos.2 hC) hg.neg)
+  have := hf.atTop_mul (neg_pos.2 hC) hg.neg
+  simpa only [(· ∘ ·), neg_mul_eq_mul_neg, neg_neg] using tendsto_neg_atTop_atBot.comp this
 #align filter.tendsto.at_top_mul_neg Filter.Tendsto.atTop_mul_neg
 
 /-- In a linearly ordered field with the order topology, if `f` tends to a negative constant `C` and
-`g` tends to `at_top` then `f * g` tends to `at_bot`. -/
-theorem Filter.Tendsto.neg_mul_atTop {C : α} (hC : C < 0) (hf : Tendsto f l (𝓝 C))
+`g` tends to `Filter.atTop` then `f * g` tends to `Filter.atBot`. -/
+theorem Filter.Tendsto.neg_mul_atTop {C : 𝕜} (hC : C < 0) (hf : Tendsto f l (𝓝 C))
     (hg : Tendsto g l atTop) : Tendsto (fun x => f x * g x) l atBot := by
-  simpa only [mul_comm] using hg.at_top_mul_neg hC hf
+  simpa only [mul_comm] using hg.atTop_mul_neg hC hf
 #align filter.tendsto.neg_mul_at_top Filter.Tendsto.neg_mul_atTop
 
-/-- In a linearly ordered field with the order topology, if `f` tends to `at_bot` and `g` tends to
-a positive constant `C` then `f * g` tends to `at_bot`. -/
-theorem Filter.Tendsto.atBot_mul {C : α} (hC : 0 < C) (hf : Tendsto f l atBot)
+/-- In a linearly ordered field with the order topology, if `f` tends to `Filter.atBot` and `g`
+tends to a positive constant `C` then `f * g` tends to `Filter.atBot`. -/
+theorem Filter.Tendsto.atBot_mul {C : 𝕜} (hC : 0 < C) (hf : Tendsto f l atBot)
     (hg : Tendsto g l (𝓝 C)) : Tendsto (fun x => f x * g x) l atBot := by
-  simpa [(· ∘ ·)] using
-    tendsto_neg_at_top_at_bot.comp ((tendsto_neg_at_bot_at_top.comp hf).atTop_mul hC hg)
+  have := (tendsto_neg_atBot_atTop.comp hf).atTop_mul hC hg
+  simpa [(· ∘ ·)] using tendsto_neg_atTop_atBot.comp this
 #align filter.tendsto.at_bot_mul Filter.Tendsto.atBot_mul
 
-/-- In a linearly ordered field with the order topology, if `f` tends to `at_bot` and `g` tends to
-a negative constant `C` then `f * g` tends to `at_top`. -/
-theorem Filter.Tendsto.atBot_mul_neg {C : α} (hC : C < 0) (hf : Tendsto f l atBot)
+/-- In a linearly ordered field with the order topology, if `f` tends to `Filter.atBot` and `g`
+tends to a negative constant `C` then `f * g` tends to `Filter.atTop`. -/
+theorem Filter.Tendsto.atBot_mul_neg {C : 𝕜} (hC : C < 0) (hf : Tendsto f l atBot)
     (hg : Tendsto g l (𝓝 C)) : Tendsto (fun x => f x * g x) l atTop := by
-  simpa [(· ∘ ·)] using
-    tendsto_neg_at_bot_at_top.comp ((tendsto_neg_at_bot_at_top.comp hf).atTop_mul_neg hC hg)
+  have := (tendsto_neg_atBot_atTop.comp hf).atTop_mul_neg hC hg
+  simpa [(· ∘ ·)] using tendsto_neg_atBot_atTop.comp this
 #align filter.tendsto.at_bot_mul_neg Filter.Tendsto.atBot_mul_neg
 
 /-- In a linearly ordered field with the order topology, if `f` tends to a positive constant `C` and
-`g` tends to `at_bot` then `f * g` tends to `at_bot`. -/
-theorem Filter.Tendsto.mul_atBot {C : α} (hC : 0 < C) (hf : Tendsto f l (𝓝 C))
+`g` tends to `Filter.atBot` then `f * g` tends to `Filter.atBot`. -/
+theorem Filter.Tendsto.mul_atBot {C : 𝕜} (hC : 0 < C) (hf : Tendsto f l (𝓝 C))
     (hg : Tendsto g l atBot) : Tendsto (fun x => f x * g x) l atBot := by
-  simpa only [mul_comm] using hg.at_bot_mul hC hf
+  simpa only [mul_comm] using hg.atBot_mul hC hf
 #align filter.tendsto.mul_at_bot Filter.Tendsto.mul_atBot
 
 /-- In a linearly ordered field with the order topology, if `f` tends to a negative constant `C` and
-`g` tends to `at_bot` then `f * g` tends to `at_top`. -/
-theorem Filter.Tendsto.neg_mul_atBot {C : α} (hC : C < 0) (hf : Tendsto f l (𝓝 C))
+`g` tends to `Filter.atBot` then `f * g` tends to `Filter.atTop`. -/
+theorem Filter.Tendsto.neg_mul_atBot {C : 𝕜} (hC : C < 0) (hf : Tendsto f l (𝓝 C))
     (hg : Tendsto g l atBot) : Tendsto (fun x => f x * g x) l atTop := by
-  simpa only [mul_comm] using hg.at_bot_mul_neg hC hf
+  simpa only [mul_comm] using hg.atBot_mul_neg hC hf
 #align filter.tendsto.neg_mul_at_bot Filter.Tendsto.neg_mul_atBot
 
 /-- The function `x ↦ x⁻¹` tends to `+∞` on the right of `0`. -/
-theorem tendsto_inv_zero_atTop : Tendsto (fun x : α => x⁻¹) (𝓝[>] (0 : α)) atTop := by
-  refine' (at_top_basis' 1).tendsto_right_iff.2 fun b hb => _
+theorem tendsto_inv_zero_atTop : Tendsto (fun x : 𝕜 => x⁻¹) (𝓝[>] (0 : 𝕜)) atTop := by
+  refine' (atTop_basis' 1).tendsto_right_iff.2 fun b hb => _
   have hb' : 0 < b := by positivity
   filter_upwards [Ioc_mem_nhdsWithin_Ioi
       ⟨le_rfl, inv_pos.2 hb'⟩]with x hx using(le_inv hx.1 hb').1 hx.2
 #align tendsto_inv_zero_at_top tendsto_inv_zero_atTop
 
 /-- The function `r ↦ r⁻¹` tends to `0` on the right as `r → +∞`. -/
-theorem tendsto_inv_atTop_zero' : Tendsto (fun r : α => r⁻¹) atTop (𝓝[>] (0 : α)) := by
-  refine'
-    (has_basis.tendsto_iff at_top_basis ⟨fun s => mem_nhdsWithin_Ioi_iff_exists_Ioc_subset⟩).2 _
-  refine' fun b hb => ⟨b⁻¹, trivial, fun x hx => _⟩
+theorem tendsto_inv_atTop_zero' : Tendsto (fun r : 𝕜 => r⁻¹) atTop (𝓝[>] (0 : 𝕜)) := by
+  refine (atTop_basis.tendsto_iff ⟨fun s => mem_nhdsWithin_Ioi_iff_exists_Ioc_subset⟩).2 ?_
+  refine fun b hb => ⟨b⁻¹, trivial, fun x hx => ?_⟩
   have : 0 < x := lt_of_lt_of_le (inv_pos.2 hb) hx
   exact ⟨inv_pos.2 this, (inv_le this hb).2 hx⟩
 #align tendsto_inv_at_top_zero' tendsto_inv_atTop_zero'
 
-theorem tendsto_inv_atTop_zero : Tendsto (fun r : α => r⁻¹) atTop (𝓝 0) :=
+theorem tendsto_inv_atTop_zero : Tendsto (fun r : 𝕜 => r⁻¹) atTop (𝓝 0) :=
   tendsto_inv_atTop_zero'.mono_right inf_le_left
 #align tendsto_inv_at_top_zero tendsto_inv_atTop_zero
 
-theorem Filter.Tendsto.div_atTop [ContinuousMul α] {f g : β → α} {l : Filter β} {a : α}
-    (h : Tendsto f l (𝓝 a)) (hg : Tendsto g l atTop) : Tendsto (fun x => f x / g x) l (𝓝 0) := by
+theorem Filter.Tendsto.div_atTop {a : 𝕜} (h : Tendsto f l (𝓝 a)) (hg : Tendsto g l atTop) :
+    Tendsto (fun x => f x / g x) l (𝓝 0) := by
   simp only [div_eq_mul_inv]
-  exact mul_zero a ▸ h.mul (tendsto_inv_at_top_zero.comp hg)
+  exact mul_zero a ▸ h.mul (tendsto_inv_atTop_zero.comp hg)
 #align filter.tendsto.div_at_top Filter.Tendsto.div_atTop
 
 theorem Filter.Tendsto.inv_tendsto_atTop (h : Tendsto f l atTop) : Tendsto f⁻¹ l (𝓝 0) :=
@@ -272,116 +155,85 @@ theorem Filter.Tendsto.inv_tendsto_zero (h : Tendsto f l (𝓝[>] 0)) : Tendsto 
 #align filter.tendsto.inv_tendsto_zero Filter.Tendsto.inv_tendsto_zero
 
 /-- The function `x^(-n)` tends to `0` at `+∞` for any positive natural `n`.
-A version for positive real powers exists as `tendsto_rpow_neg_at_top`. -/
+A version for positive real powers exists as `tendsto_rpow_neg_atTop`. -/
 theorem tendsto_pow_neg_atTop {n : ℕ} (hn : n ≠ 0) :
-    Tendsto (fun x : α => x ^ (-(n : ℤ))) atTop (𝓝 0) := by
-  simpa only [zpow_neg, zpow_ofNat] using (@tendsto_pow_at_top α _ _ hn).inv_tendsto_atTop
+    Tendsto (fun x : 𝕜 => x ^ (-(n : ℤ))) atTop (𝓝 0) := by
+  simpa only [zpow_neg, zpow_ofNat] using (@tendsto_pow_atTop 𝕜 _ _ hn).inv_tendsto_atTop
 #align tendsto_pow_neg_at_top tendsto_pow_neg_atTop
 
-theorem tendsto_zpow_atTop_zero {n : ℤ} (hn : n < 0) : Tendsto (fun x : α => x ^ n) atTop (𝓝 0) :=
-  by
-  lift -n to ℕ using le_of_lt (neg_pos.mpr hn) with N
+theorem tendsto_zpow_atTop_zero {n : ℤ} (hn : n < 0) :
+    Tendsto (fun x : 𝕜 => x ^ n) atTop (𝓝 0) := by
+  lift -n to ℕ using le_of_lt (neg_pos.mpr hn) with N h
   rw [← neg_pos, ← h, Nat.cast_pos] at hn
   simpa only [h, neg_neg] using tendsto_pow_neg_atTop hn.ne'
 #align tendsto_zpow_at_top_zero tendsto_zpow_atTop_zero
 
-theorem tendsto_const_mul_zpow_atTop_zero {n : ℤ} {c : α} (hn : n < 0) :
+theorem tendsto_const_mul_zpow_atTop_zero {n : ℤ} {c : 𝕜} (hn : n < 0) :
     Tendsto (fun x => c * x ^ n) atTop (𝓝 0) :=
   mul_zero c ▸ Filter.Tendsto.const_mul c (tendsto_zpow_atTop_zero hn)
 #align tendsto_const_mul_zpow_at_top_zero tendsto_const_mul_zpow_atTop_zero
 
-theorem tendsto_const_mul_pow_nhds_iff' {n : ℕ} {c d : α} :
-    Tendsto (fun x : α => c * x ^ n) atTop (𝓝 d) ↔ (c = 0 ∨ n = 0) ∧ c = d := by
+theorem tendsto_const_mul_pow_nhds_iff' {n : ℕ} {c d : 𝕜} :
+    Tendsto (fun x : 𝕜 => c * x ^ n) atTop (𝓝 d) ↔ (c = 0 ∨ n = 0) ∧ c = d := by
   rcases eq_or_ne n 0 with (rfl | hn)
   · simp [tendsto_const_nhds_iff]
   rcases lt_trichotomy c 0 with (hc | rfl | hc)
-  · have := tendsto_const_mul_pow_at_bot_iff.2 ⟨hn, hc⟩
+  · have := tendsto_const_mul_pow_atBot_iff.2 ⟨hn, hc⟩
     simp [not_tendsto_nhds_of_tendsto_atBot this, hc.ne, hn]
   · simp [tendsto_const_nhds_iff]
-  · have := tendsto_const_mul_pow_at_top_iff.2 ⟨hn, hc⟩
+  · have := tendsto_const_mul_pow_atTop_iff.2 ⟨hn, hc⟩
     simp [not_tendsto_nhds_of_tendsto_atTop this, hc.ne', hn]
 #align tendsto_const_mul_pow_nhds_iff' tendsto_const_mul_pow_nhds_iff'
 
-theorem tendsto_const_mul_pow_nhds_iff {n : ℕ} {c d : α} (hc : c ≠ 0) :
-    Tendsto (fun x : α => c * x ^ n) atTop (𝓝 d) ↔ n = 0 ∧ c = d := by
+theorem tendsto_const_mul_pow_nhds_iff {n : ℕ} {c d : 𝕜} (hc : c ≠ 0) :
+    Tendsto (fun x : 𝕜 => c * x ^ n) atTop (𝓝 d) ↔ n = 0 ∧ c = d := by
   simp [tendsto_const_mul_pow_nhds_iff', hc]
 #align tendsto_const_mul_pow_nhds_iff tendsto_const_mul_pow_nhds_iff
 
-theorem tendsto_const_mul_zpow_atTop_nhds_iff {n : ℤ} {c d : α} (hc : c ≠ 0) :
-    Tendsto (fun x : α => c * x ^ n) atTop (𝓝 d) ↔ n = 0 ∧ c = d ∨ n < 0 ∧ d = 0 := by
+theorem tendsto_const_mul_zpow_atTop_nhds_iff {n : ℤ} {c d : 𝕜} (hc : c ≠ 0) :
+    Tendsto (fun x : 𝕜 => c * x ^ n) atTop (𝓝 d) ↔ n = 0 ∧ c = d ∨ n < 0 ∧ d = 0 := by
   refine' ⟨fun h => _, fun h => _⟩
-  · by_cases hn : 0 ≤ n
-    · lift n to ℕ using hn
-      simp only [zpow_ofNat] at h
-      rw [tendsto_const_mul_pow_nhds_iff hc, ← Int.coe_nat_eq_zero] at h
-      exact Or.inl h
-    · rw [not_le] at hn
-      refine' Or.inr ⟨hn, tendsto_nhds_unique h (tendsto_const_mul_zpow_atTop_zero hn)⟩
-  · cases h
+  · cases n with -- porting note: Lean 3 proof used `by_cases`, then `lift` but `lift` failed
+    | ofNat n =>
+      left
+      simpa [tendsto_const_mul_pow_nhds_iff hc] using h
+    | negSucc n =>
+      have hn := Int.negSucc_lt_zero n
+      exact Or.inr ⟨hn, tendsto_nhds_unique h (tendsto_const_mul_zpow_atTop_zero hn)⟩
+  · cases' h with h h
     · simp only [h.left, h.right, zpow_zero, mul_one]
       exact tendsto_const_nhds
     · exact h.2.symm ▸ tendsto_const_mul_zpow_atTop_zero h.1
 #align tendsto_const_mul_zpow_at_top_nhds_iff tendsto_const_mul_zpow_atTop_nhds_iff
 
--- TODO: With a different proof, this could be possibly generalised to only require a
--- `linear_ordered_semifield` instance, which would also remove the need for the
--- `nnreal` instance of `has_continuous_inv₀`.
 -- see Note [lower instance priority]
-instance (priority := 100) LinearOrderedField.to_topologicalDivisionRing : TopologicalDivisionRing α
-    where continuousAt_inv₀ :=
-    by
-    suffices ∀ {x : α}, 0 < x → ContinuousAt Inv.inv x
-      by
-      intro x hx
-      cases hx.symm.lt_or_lt
-      · exact this h
-      convert (this <| neg_pos.mpr h).neg.comp continuous_neg.continuous_at
-      ext
-      simp [neg_inv]
-    intro t ht
-    rw [ContinuousAt,
-      (nhds_basis_Ioo_pos t).tendsto_iffₓ <| nhds_basis_Ioo_pos_of_pos <| inv_pos.2 ht]
-    rintro ε ⟨hε : ε > 0, hεt : ε ≤ t⁻¹⟩
-    refine' ⟨min (t ^ 2 * ε / 2) (t / 2), by positivity, fun x h => _⟩
-    have hx : t / 2 < x := by
-      rw [Set.mem_Ioo, sub_lt_comm, lt_min_iff] at h
-      nlinarith
-    have hx' : 0 < x := (half_pos ht).trans hx
-    have aux : 0 < 2 / t ^ 2 := by positivity
-    rw [Set.mem_Ioo, ← sub_lt_iff_lt_add', sub_lt_comm, ← abs_sub_lt_iff] at h⊢
-    rw [inv_sub_inv ht.ne' hx'.ne', abs_div, div_eq_mul_inv]
-    suffices (|t * x|)⁻¹ < 2 / t ^ 2 by
-      rw [← abs_neg, neg_sub]
-      refine' (mul_lt_mul'' h this (by positivity) (by positivity)).trans_le _
-      rw [mul_comm, mul_min_of_nonneg _ _ aux.le]
-      apply min_le_of_left_le
-      rw [← mul_div, ← mul_assoc, div_mul_cancel _ (sq_pos_of_pos ht).ne',
-        mul_div_cancel' ε two_ne_zero]
-    refine' inv_lt_of_inv_lt aux _
-    rw [inv_div, abs_of_pos <| mul_pos ht hx', sq, ← mul_div_assoc']
-    exact mul_lt_mul_of_pos_left hx ht
-#align linear_ordered_field.to_topological_division_ring LinearOrderedField.to_topologicalDivisionRing
+instance (priority := 100) LinearOrderedSemifield.toHasContinuousInv₀ {𝕜}
+    [LinearOrderedSemifield 𝕜] [TopologicalSpace 𝕜] [OrderTopology 𝕜] [ContinuousMul 𝕜] :
+    HasContinuousInv₀ 𝕜 := .of_nhds_one <| tendsto_order.2 <| by
+  refine ⟨fun x hx => ?_, fun x hx => ?_⟩
+  · obtain ⟨x', h₀, hxx', h₁⟩ : ∃ x', 0 < x' ∧ x ≤ x' ∧ x' < 1 :=
+      ⟨max x (1 / 2), one_half_pos.trans_le (le_max_right _ _), le_max_left _ _,
+        max_lt hx one_half_lt_one⟩
+    filter_upwards [Ioo_mem_nhds one_pos (one_lt_inv h₀ h₁)] with y hy
+    exact hxx'.trans_lt <| inv_inv x' ▸ inv_lt_inv_of_lt hy.1 hy.2
+  · filter_upwards [Ioi_mem_nhds (inv_lt_one hx)] with y hy
+    simpa only [inv_inv] using inv_lt_inv_of_lt (inv_pos.2 <| one_pos.trans hx) hy
+    
+instance (priority := 100) LinearOrderedField.toTopologicalDivisionRing :
+    TopologicalDivisionRing 𝕜 := ⟨⟩
+#align linear_ordered_field.to_topological_division_ring LinearOrderedField.toTopologicalDivisionRing
 
-theorem nhdsWithin_pos_comap_mul_left {x : α} (hx : 0 < x) :
-    comap (fun ε => x * ε) (𝓝[>] 0) = 𝓝[>] 0 := by
-  suffices ∀ {x : α} (hx : 0 < x), 𝓝[>] 0 ≤ comap (fun ε => x * ε) (𝓝[>] 0)
-    by
-    refine' le_antisymm _ (this hx)
-    have hr : 𝓝[>] (0 : α) = ((𝓝[>] (0 : α)).comap fun ε => x⁻¹ * ε).comap fun ε => x * ε := by
-      simp [comap_comap, inv_mul_cancel hx.ne.symm, comap_id, one_mul_eq_id]
-    conv_rhs => rw [hr]
-    rw [comap_le_comap_iff
-        (by convert univ_mem <;> exact (mul_left_surjective₀ hx.ne.symm).range_eq)]
-    exact this (inv_pos.mpr hx)
-  intro x hx
-  convert nhdsWithin_le_comap (continuous_mul_left x).ContinuousWithinAt
-  · exact (mul_zero _).symm
-  · rw [image_const_mul_Ioi_zero hx]
+-- porting note: todo: generalize to a `GroupWithzero`
+theorem nhdsWithin_pos_comap_mul_left {x : 𝕜} (hx : 0 < x) :
+    comap (x * ·) (𝓝[>] 0) = 𝓝[>] 0 := by
+  rw [nhdsWithin, comap_inf, comap_principal, preimage_const_mul_Ioi _ hx, zero_div]
+  congr 1
+  refine ((Homeomorph.mulLeft₀ x hx.ne').comap_nhds_eq _).trans ?_
+  simp
 #align nhds_within_pos_comap_mul_left nhdsWithin_pos_comap_mul_left
 
-theorem eventually_nhdsWithin_pos_mul_left {x : α} (hx : 0 < x) {p : α → Prop}
+theorem eventually_nhdsWithin_pos_mul_left {x : 𝕜} (hx : 0 < x) {p : 𝕜 → Prop}
     (h : ∀ᶠ ε in 𝓝[>] 0, p ε) : ∀ᶠ ε in 𝓝[>] 0, p (x * ε) := by
-  convert h.comap fun ε => x * ε
-  exact (nhdsWithin_pos_comap_mul_left hx).symm
+  rw [← nhdsWithin_pos_comap_mul_left hx]
+  exact h.comap fun ε => x * ε
 #align eventually_nhds_within_pos_mul_left eventually_nhdsWithin_pos_mul_left
-

--- a/Mathlib/Topology/Algebra/Order/Field.lean
+++ b/Mathlib/Topology/Algebra/Order/Field.lean
@@ -8,10 +8,10 @@ Authors: Benjamin Davidson, Devon Tuma, Eric Rodriguez, Oliver Nash
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
-import Mathbin.Tactic.Positivity
-import Mathbin.Tactic.Linarith.Default
-import Mathbin.Topology.Algebra.Order.Group
-import Mathbin.Topology.Algebra.Field
+import Mathlib.Tactic.Positivity
+import Mathlib.Tactic.Linarith.Default
+import Mathlib.Topology.Algebra.Order.Group
+import Mathlib.Topology.Algebra.Field
 
 /-!
 # Topologies on linear ordered fields
@@ -36,8 +36,7 @@ variable {l : Filter β} {f g : β → α}
 section continuous_mul
 
 theorem mul_tendsto_nhds_zero_right (x : α) :
-    Tendsto (uncurry ((· * ·) : α → α → α)) (𝓝 0 ×ᶠ 𝓝 x) <| 𝓝 0 :=
-  by
+    Tendsto (uncurry ((· * ·) : α → α → α)) (𝓝 0 ×ᶠ 𝓝 x) <| 𝓝 0 := by
   have hx : 0 < 2 * (1 + |x|) := by positivity
   rw [((nhds_basis_zero_abs_sub_lt α).Prod <| nhds_basis_abs_sub_lt x).tendsto_iffₓ
       (nhds_basis_zero_abs_sub_lt α)]
@@ -55,8 +54,7 @@ theorem mul_tendsto_nhds_zero_right (x : α) :
 
 /- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
 theorem mul_tendsto_nhds_zero_left (x : α) :
-    Tendsto (uncurry ((· * ·) : α → α → α)) (𝓝 x ×ᶠ 𝓝 0) <| 𝓝 0 :=
-  by
+    Tendsto (uncurry ((· * ·) : α → α → α)) (𝓝 x ×ᶠ 𝓝 0) <| 𝓝 0 := by
   intro s hs
   have := mul_tendsto_nhds_zero_right x hs
   rw [Filter.mem_map, mem_prod_iff] at this⊢
@@ -67,8 +65,7 @@ theorem mul_tendsto_nhds_zero_left (x : α) :
 #align mul_tendsto_nhds_zero_left mul_tendsto_nhds_zero_left
 
 theorem nhds_eq_map_mul_left_nhds_one {x₀ : α} (hx₀ : x₀ ≠ 0) :
-    𝓝 x₀ = map (fun x => x₀ * x) (𝓝 1) :=
-  by
+    𝓝 x₀ = map (fun x => x₀ * x) (𝓝 1) := by
   have hx₀' : 0 < |x₀| := abs_pos.2 hx₀
   refine' Filter.ext fun t => _
   simp only [exists_prop, set_of_subset_set_of, (nhds_basis_abs_sub_lt x₀).mem_iff,
@@ -103,8 +100,7 @@ theorem nhds_eq_map_mul_right_nhds_one {x₀ : α} (hx₀ : x₀ ≠ 0) :
 #align nhds_eq_map_mul_right_nhds_one nhds_eq_map_mul_right_nhds_one
 
 theorem mul_tendsto_nhds_one_nhds_one :
-    Tendsto (uncurry ((· * ·) : α → α → α)) (𝓝 1 ×ᶠ 𝓝 1) <| 𝓝 1 :=
-  by
+    Tendsto (uncurry ((· * ·) : α → α → α)) (𝓝 1 ×ᶠ 𝓝 1) <| 𝓝 1 := by
   rw [((nhds_basis_Ioo_pos (1 : α)).Prod <| nhds_basis_Ioo_pos (1 : α)).tendsto_iffₓ
       (nhds_basis_Ioo_pos_of_pos (zero_lt_one : (0 : α) < 1))]
   intro ε hε
@@ -182,8 +178,7 @@ end continuous_mul
 /-- In a linearly ordered field with the order topology, if `f` tends to `at_top` and `g` tends to
 a positive constant `C` then `f * g` tends to `at_top`. -/
 theorem Filter.Tendsto.atTop_mul {C : α} (hC : 0 < C) (hf : Tendsto f l atTop)
-    (hg : Tendsto g l (𝓝 C)) : Tendsto (fun x => f x * g x) l atTop :=
-  by
+    (hg : Tendsto g l (𝓝 C)) : Tendsto (fun x => f x * g x) l atTop := by
   refine' tendsto_at_top_mono' _ _ (hf.at_top_mul_const (half_pos hC))
   filter_upwards [hg.eventually (lt_mem_nhds (half_lt_self hC)),
     hf.eventually (eventually_ge_at_top 0)]with x hg hf using mul_le_mul_of_nonneg_left hg.le hf
@@ -242,8 +237,7 @@ theorem Filter.Tendsto.neg_mul_atBot {C : α} (hC : C < 0) (hf : Tendsto f l (�
 #align filter.tendsto.neg_mul_at_bot Filter.Tendsto.neg_mul_atBot
 
 /-- The function `x ↦ x⁻¹` tends to `+∞` on the right of `0`. -/
-theorem tendsto_inv_zero_atTop : Tendsto (fun x : α => x⁻¹) (𝓝[>] (0 : α)) atTop :=
-  by
+theorem tendsto_inv_zero_atTop : Tendsto (fun x : α => x⁻¹) (𝓝[>] (0 : α)) atTop := by
   refine' (at_top_basis' 1).tendsto_right_iff.2 fun b hb => _
   have hb' : 0 < b := by positivity
   filter_upwards [Ioc_mem_nhdsWithin_Ioi
@@ -251,8 +245,7 @@ theorem tendsto_inv_zero_atTop : Tendsto (fun x : α => x⁻¹) (𝓝[>] (0 : α
 #align tendsto_inv_zero_at_top tendsto_inv_zero_atTop
 
 /-- The function `r ↦ r⁻¹` tends to `0` on the right as `r → +∞`. -/
-theorem tendsto_inv_atTop_zero' : Tendsto (fun r : α => r⁻¹) atTop (𝓝[>] (0 : α)) :=
-  by
+theorem tendsto_inv_atTop_zero' : Tendsto (fun r : α => r⁻¹) atTop (𝓝[>] (0 : α)) := by
   refine'
     (has_basis.tendsto_iff at_top_basis ⟨fun s => mem_nhdsWithin_Ioi_iff_exists_Ioc_subset⟩).2 _
   refine' fun b hb => ⟨b⁻¹, trivial, fun x hx => _⟩
@@ -265,8 +258,7 @@ theorem tendsto_inv_atTop_zero : Tendsto (fun r : α => r⁻¹) atTop (𝓝 0) :
 #align tendsto_inv_at_top_zero tendsto_inv_atTop_zero
 
 theorem Filter.Tendsto.div_atTop [ContinuousMul α] {f g : β → α} {l : Filter β} {a : α}
-    (h : Tendsto f l (𝓝 a)) (hg : Tendsto g l atTop) : Tendsto (fun x => f x / g x) l (𝓝 0) :=
-  by
+    (h : Tendsto f l (𝓝 a)) (hg : Tendsto g l atTop) : Tendsto (fun x => f x / g x) l (𝓝 0) := by
   simp only [div_eq_mul_inv]
   exact mul_zero a ▸ h.mul (tendsto_inv_at_top_zero.comp hg)
 #align filter.tendsto.div_at_top Filter.Tendsto.div_atTop
@@ -299,8 +291,7 @@ theorem tendsto_const_mul_zpow_atTop_zero {n : ℤ} {c : α} (hn : n < 0) :
 #align tendsto_const_mul_zpow_at_top_zero tendsto_const_mul_zpow_atTop_zero
 
 theorem tendsto_const_mul_pow_nhds_iff' {n : ℕ} {c d : α} :
-    Tendsto (fun x : α => c * x ^ n) atTop (𝓝 d) ↔ (c = 0 ∨ n = 0) ∧ c = d :=
-  by
+    Tendsto (fun x : α => c * x ^ n) atTop (𝓝 d) ↔ (c = 0 ∨ n = 0) ∧ c = d := by
   rcases eq_or_ne n 0 with (rfl | hn)
   · simp [tendsto_const_nhds_iff]
   rcases lt_trichotomy c 0 with (hc | rfl | hc)
@@ -317,8 +308,7 @@ theorem tendsto_const_mul_pow_nhds_iff {n : ℕ} {c d : α} (hc : c ≠ 0) :
 #align tendsto_const_mul_pow_nhds_iff tendsto_const_mul_pow_nhds_iff
 
 theorem tendsto_const_mul_zpow_atTop_nhds_iff {n : ℤ} {c d : α} (hc : c ≠ 0) :
-    Tendsto (fun x : α => c * x ^ n) atTop (𝓝 d) ↔ n = 0 ∧ c = d ∨ n < 0 ∧ d = 0 :=
-  by
+    Tendsto (fun x : α => c * x ^ n) atTop (𝓝 d) ↔ n = 0 ∧ c = d ∨ n < 0 ∧ d = 0 := by
   refine' ⟨fun h => _, fun h => _⟩
   · by_cases hn : 0 ≤ n
     · lift n to ℕ using hn
@@ -373,8 +363,7 @@ instance (priority := 100) LinearOrderedField.to_topologicalDivisionRing : Topol
 #align linear_ordered_field.to_topological_division_ring LinearOrderedField.to_topologicalDivisionRing
 
 theorem nhdsWithin_pos_comap_mul_left {x : α} (hx : 0 < x) :
-    comap (fun ε => x * ε) (𝓝[>] 0) = 𝓝[>] 0 :=
-  by
+    comap (fun ε => x * ε) (𝓝[>] 0) = 𝓝[>] 0 := by
   suffices ∀ {x : α} (hx : 0 < x), 𝓝[>] 0 ≤ comap (fun ε => x * ε) (𝓝[>] 0)
     by
     refine' le_antisymm _ (this hx)
@@ -391,8 +380,7 @@ theorem nhdsWithin_pos_comap_mul_left {x : α} (hx : 0 < x) :
 #align nhds_within_pos_comap_mul_left nhdsWithin_pos_comap_mul_left
 
 theorem eventually_nhdsWithin_pos_mul_left {x : α} (hx : 0 < x) {p : α → Prop}
-    (h : ∀ᶠ ε in 𝓝[>] 0, p ε) : ∀ᶠ ε in 𝓝[>] 0, p (x * ε) :=
-  by
+    (h : ∀ᶠ ε in 𝓝[>] 0, p ε) : ∀ᶠ ε in 𝓝[>] 0, p (x * ε) := by
   convert h.comap fun ε => x * ε
   exact (nhdsWithin_pos_comap_mul_left hx).symm
 #align eventually_nhds_within_pos_mul_left eventually_nhdsWithin_pos_mul_left

--- a/Mathlib/Topology/Algebra/Order/Field.lean
+++ b/Mathlib/Topology/Algebra/Order/Field.lean
@@ -1,0 +1,399 @@
+/-
+Copyright (c) 2022 Benjamin Davidson. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Benjamin Davidson, Devon Tuma, Eric Rodriguez, Oliver Nash
+
+! This file was ported from Lean 3 source module topology.algebra.order.field
+! leanprover-community/mathlib commit 9a59dcb7a2d06bf55da57b9030169219980660cd
+! Please do not edit these lines, except to modify the commit id
+! if you have ported upstream changes.
+-/
+import Mathbin.Tactic.Positivity
+import Mathbin.Tactic.Linarith.Default
+import Mathbin.Topology.Algebra.Order.Group
+import Mathbin.Topology.Algebra.Field
+
+/-!
+# Topologies on linear ordered fields
+
+-/
+
+
+open Set Filter TopologicalSpace
+
+open Function
+
+open OrderDual (toDual ofDual)
+
+open Topology Classical Filter
+
+variable {α β : Type _}
+
+variable [LinearOrderedField α] [TopologicalSpace α] [OrderTopology α]
+
+variable {l : Filter β} {f g : β → α}
+
+section continuous_mul
+
+theorem mul_tendsto_nhds_zero_right (x : α) :
+    Tendsto (uncurry ((· * ·) : α → α → α)) (𝓝 0 ×ᶠ 𝓝 x) <| 𝓝 0 :=
+  by
+  have hx : 0 < 2 * (1 + |x|) := by positivity
+  rw [((nhds_basis_zero_abs_sub_lt α).Prod <| nhds_basis_abs_sub_lt x).tendsto_iffₓ
+      (nhds_basis_zero_abs_sub_lt α)]
+  refine' fun ε ε_pos => ⟨(ε / (2 * (1 + |x|)), 1), ⟨div_pos ε_pos hx, zero_lt_one⟩, _⟩
+  suffices ∀ a b : α, |a| < ε / (2 * (1 + |x|)) → |b - x| < 1 → |a| * |b| < ε by
+    simpa only [and_imp, Prod.forall, mem_prod, ← abs_mul]
+  intro a b h h'
+  refine' lt_of_le_of_lt (mul_le_mul_of_nonneg_left _ (abs_nonneg a)) ((lt_div_iff hx).1 h)
+  calc
+    |b| = |b - x + x| := by rw [sub_add_cancel b x]
+    _ ≤ |b - x| + |x| := (abs_add (b - x) x)
+    _ ≤ 2 * (1 + |x|) := by linarith
+    
+#align mul_tendsto_nhds_zero_right mul_tendsto_nhds_zero_right
+
+/- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
+theorem mul_tendsto_nhds_zero_left (x : α) :
+    Tendsto (uncurry ((· * ·) : α → α → α)) (𝓝 x ×ᶠ 𝓝 0) <| 𝓝 0 :=
+  by
+  intro s hs
+  have := mul_tendsto_nhds_zero_right x hs
+  rw [Filter.mem_map, mem_prod_iff] at this⊢
+  obtain ⟨U, hU, V, hV, h⟩ := this
+  exact
+    ⟨V, hV, U, hU, fun y hy =>
+      (mul_comm y.2 y.1 ▸ h (⟨hy.2, hy.1⟩ : Prod.mk y.2 y.1 ∈ U ×ˢ V) : y.1 * y.2 ∈ s)⟩
+#align mul_tendsto_nhds_zero_left mul_tendsto_nhds_zero_left
+
+theorem nhds_eq_map_mul_left_nhds_one {x₀ : α} (hx₀ : x₀ ≠ 0) :
+    𝓝 x₀ = map (fun x => x₀ * x) (𝓝 1) :=
+  by
+  have hx₀' : 0 < |x₀| := abs_pos.2 hx₀
+  refine' Filter.ext fun t => _
+  simp only [exists_prop, set_of_subset_set_of, (nhds_basis_abs_sub_lt x₀).mem_iff,
+    (nhds_basis_abs_sub_lt (1 : α)).mem_iff, Filter.mem_map']
+  refine' ⟨fun h => _, fun h => _⟩
+  · obtain ⟨i, hi, hit⟩ := h
+    refine' ⟨i / |x₀|, div_pos hi (abs_pos.2 hx₀), fun x hx => hit _⟩
+    calc
+      |x₀ * x - x₀| = |x₀ * (x - 1)| := congr_arg abs (by ring_nf)
+      _ = |x₀| * |x - 1| := (abs_mul x₀ (x - 1))
+      _ < |x₀| * (i / |x₀|) := (mul_lt_mul' le_rfl hx (by positivity) (abs_pos.2 hx₀))
+      _ = |x₀| * i / |x₀| := by ring
+      _ = i := mul_div_cancel_left i fun h => hx₀ (abs_eq_zero.1 h)
+      
+  · obtain ⟨i, hi, hit⟩ := h
+    refine' ⟨i * |x₀|, mul_pos hi (abs_pos.2 hx₀), fun x hx => _⟩
+    have : |x / x₀ - 1| < i
+    calc
+      |x / x₀ - 1| = |x / x₀ - x₀ / x₀| := by rw [div_self hx₀]
+      _ = |(x - x₀) / x₀| := (congr_arg abs (sub_div x x₀ x₀).symm)
+      _ = |x - x₀| / |x₀| := (abs_div (x - x₀) x₀)
+      _ < i * |x₀| / |x₀| := (div_lt_div_of_lt (abs_pos.2 hx₀) hx)
+      _ = i := by rw [← mul_div_assoc', div_self (ne_of_lt <| abs_pos.2 hx₀).symm, mul_one]
+      
+    specialize hit (x / x₀) this
+    rwa [mul_div_assoc', mul_div_cancel_left x hx₀] at hit
+#align nhds_eq_map_mul_left_nhds_one nhds_eq_map_mul_left_nhds_one
+
+theorem nhds_eq_map_mul_right_nhds_one {x₀ : α} (hx₀ : x₀ ≠ 0) :
+    𝓝 x₀ = map (fun x => x * x₀) (𝓝 1) := by
+  simp_rw [mul_comm _ x₀, nhds_eq_map_mul_left_nhds_one hx₀]
+#align nhds_eq_map_mul_right_nhds_one nhds_eq_map_mul_right_nhds_one
+
+theorem mul_tendsto_nhds_one_nhds_one :
+    Tendsto (uncurry ((· * ·) : α → α → α)) (𝓝 1 ×ᶠ 𝓝 1) <| 𝓝 1 :=
+  by
+  rw [((nhds_basis_Ioo_pos (1 : α)).Prod <| nhds_basis_Ioo_pos (1 : α)).tendsto_iffₓ
+      (nhds_basis_Ioo_pos_of_pos (zero_lt_one : (0 : α) < 1))]
+  intro ε hε
+  have hε' : 0 ≤ 1 - ε / 4 := by linarith
+  have ε_pos : 0 < ε / 4 := by linarith
+  have ε_pos' : 0 < ε / 2 := by linarith
+  simp only [and_imp, Prod.forall, mem_Ioo, Function.uncurry_apply_pair, mem_prod, Prod.exists]
+  refine' ⟨ε / 4, ε / 4, ⟨ε_pos, ε_pos⟩, fun a b ha ha' hb hb' => _⟩
+  have ha0 : 0 ≤ a := le_trans hε' (le_of_lt ha)
+  have hb0 : 0 ≤ b := le_trans hε' (le_of_lt hb)
+  refine'
+    ⟨lt_of_le_of_lt _ (mul_lt_mul'' ha hb hε' hε'), lt_of_lt_of_le (mul_lt_mul'' ha' hb' ha0 hb0) _⟩
+  ·
+    calc
+      1 - ε = 1 - ε / 2 - ε / 2 := by ring_nf
+      _ ≤ 1 - ε / 2 - ε / 2 + ε / 2 * (ε / 2) := (le_add_of_nonneg_right (by positivity))
+      _ = (1 - ε / 2) * (1 - ε / 2) := by ring_nf
+      _ ≤ (1 - ε / 4) * (1 - ε / 4) := mul_le_mul (by linarith) (by linarith) (by linarith) hε'
+      
+  ·
+    calc
+      (1 + ε / 4) * (1 + ε / 4) = 1 + ε / 2 + ε / 4 * (ε / 4) := by ring_nf
+      _ = 1 + ε / 2 + ε * ε / 16 := by ring_nf
+      _ ≤ 1 + ε / 2 + ε / 2 :=
+        (add_le_add_left
+          (div_le_div (le_of_lt hε.1)
+            (le_trans ((mul_le_mul_left hε.1).2 hε.2) (le_of_eq <| mul_one ε)) zero_lt_two
+            (by linarith))
+          (1 + ε / 2))
+      _ ≤ 1 + ε := by ring_nf
+      
+#align mul_tendsto_nhds_one_nhds_one mul_tendsto_nhds_one_nhds_one
+
+-- see Note [lower instance priority]
+instance (priority := 100) LinearOrderedField.continuousMul : ContinuousMul α :=
+  ⟨by
+    rw [continuous_iff_continuousAt]
+    rintro ⟨x₀, y₀⟩
+    by_cases hx₀ : x₀ = 0
+    · rw [hx₀, ContinuousAt, zero_mul, nhds_prod_eq]
+      exact mul_tendsto_nhds_zero_right y₀
+    by_cases hy₀ : y₀ = 0
+    · rw [hy₀, ContinuousAt, mul_zero, nhds_prod_eq]
+      exact mul_tendsto_nhds_zero_left x₀
+    have hxy : x₀ * y₀ ≠ 0 := mul_ne_zero hx₀ hy₀
+    have key :
+      (fun p : α × α => x₀ * p.1 * (p.2 * y₀)) =
+        ((fun x => x₀ * x) ∘ fun x => x * y₀) ∘ uncurry (· * ·) :=
+      by
+      ext p
+      simp [uncurry, mul_assoc]
+    have key₂ : ((fun x => x₀ * x) ∘ fun x => y₀ * x) = fun x => x₀ * y₀ * x :=
+      by
+      ext x
+      simp
+    calc
+      map (uncurry (· * ·)) (𝓝 (x₀, y₀)) = map (uncurry (· * ·)) (𝓝 x₀ ×ᶠ 𝓝 y₀) := by
+        rw [nhds_prod_eq]
+      _ = map (fun p : α × α => x₀ * p.1 * (p.2 * y₀)) (𝓝 1 ×ᶠ 𝓝 1) := by
+        rw [uncurry, nhds_eq_map_mul_left_nhds_one hx₀, nhds_eq_map_mul_right_nhds_one hy₀,
+          prod_map_map_eq, Filter.map_map]
+      _ = map ((fun x => x₀ * x) ∘ fun x => x * y₀) (map (uncurry (· * ·)) (𝓝 1 ×ᶠ 𝓝 1)) := by
+        rw [key, ← Filter.map_map]
+      _ ≤ map ((fun x : α => x₀ * x) ∘ fun x => x * y₀) (𝓝 1) :=
+        (map_mono mul_tendsto_nhds_one_nhds_one)
+      _ = 𝓝 (x₀ * y₀) := by
+        rw [← Filter.map_map, ← nhds_eq_map_mul_right_nhds_one hy₀,
+          nhds_eq_map_mul_left_nhds_one hy₀, Filter.map_map, key₂, ←
+          nhds_eq_map_mul_left_nhds_one hxy]
+      ⟩
+#align linear_ordered_field.has_continuous_mul LinearOrderedField.continuousMul
+
+end continuous_mul
+
+/-- In a linearly ordered field with the order topology, if `f` tends to `at_top` and `g` tends to
+a positive constant `C` then `f * g` tends to `at_top`. -/
+theorem Filter.Tendsto.atTop_mul {C : α} (hC : 0 < C) (hf : Tendsto f l atTop)
+    (hg : Tendsto g l (𝓝 C)) : Tendsto (fun x => f x * g x) l atTop :=
+  by
+  refine' tendsto_at_top_mono' _ _ (hf.at_top_mul_const (half_pos hC))
+  filter_upwards [hg.eventually (lt_mem_nhds (half_lt_self hC)),
+    hf.eventually (eventually_ge_at_top 0)]with x hg hf using mul_le_mul_of_nonneg_left hg.le hf
+#align filter.tendsto.at_top_mul Filter.Tendsto.atTop_mul
+
+/-- In a linearly ordered field with the order topology, if `f` tends to a positive constant `C` and
+`g` tends to `at_top` then `f * g` tends to `at_top`. -/
+theorem Filter.Tendsto.mul_atTop {C : α} (hC : 0 < C) (hf : Tendsto f l (𝓝 C))
+    (hg : Tendsto g l atTop) : Tendsto (fun x => f x * g x) l atTop := by
+  simpa only [mul_comm] using hg.at_top_mul hC hf
+#align filter.tendsto.mul_at_top Filter.Tendsto.mul_atTop
+
+/-- In a linearly ordered field with the order topology, if `f` tends to `at_top` and `g` tends to
+a negative constant `C` then `f * g` tends to `at_bot`. -/
+theorem Filter.Tendsto.atTop_mul_neg {C : α} (hC : C < 0) (hf : Tendsto f l atTop)
+    (hg : Tendsto g l (𝓝 C)) : Tendsto (fun x => f x * g x) l atBot := by
+  simpa only [(· ∘ ·), neg_mul_eq_mul_neg, neg_neg] using
+    tendsto_neg_at_top_at_bot.comp (hf.at_top_mul (neg_pos.2 hC) hg.neg)
+#align filter.tendsto.at_top_mul_neg Filter.Tendsto.atTop_mul_neg
+
+/-- In a linearly ordered field with the order topology, if `f` tends to a negative constant `C` and
+`g` tends to `at_top` then `f * g` tends to `at_bot`. -/
+theorem Filter.Tendsto.neg_mul_atTop {C : α} (hC : C < 0) (hf : Tendsto f l (𝓝 C))
+    (hg : Tendsto g l atTop) : Tendsto (fun x => f x * g x) l atBot := by
+  simpa only [mul_comm] using hg.at_top_mul_neg hC hf
+#align filter.tendsto.neg_mul_at_top Filter.Tendsto.neg_mul_atTop
+
+/-- In a linearly ordered field with the order topology, if `f` tends to `at_bot` and `g` tends to
+a positive constant `C` then `f * g` tends to `at_bot`. -/
+theorem Filter.Tendsto.atBot_mul {C : α} (hC : 0 < C) (hf : Tendsto f l atBot)
+    (hg : Tendsto g l (𝓝 C)) : Tendsto (fun x => f x * g x) l atBot := by
+  simpa [(· ∘ ·)] using
+    tendsto_neg_at_top_at_bot.comp ((tendsto_neg_at_bot_at_top.comp hf).atTop_mul hC hg)
+#align filter.tendsto.at_bot_mul Filter.Tendsto.atBot_mul
+
+/-- In a linearly ordered field with the order topology, if `f` tends to `at_bot` and `g` tends to
+a negative constant `C` then `f * g` tends to `at_top`. -/
+theorem Filter.Tendsto.atBot_mul_neg {C : α} (hC : C < 0) (hf : Tendsto f l atBot)
+    (hg : Tendsto g l (𝓝 C)) : Tendsto (fun x => f x * g x) l atTop := by
+  simpa [(· ∘ ·)] using
+    tendsto_neg_at_bot_at_top.comp ((tendsto_neg_at_bot_at_top.comp hf).atTop_mul_neg hC hg)
+#align filter.tendsto.at_bot_mul_neg Filter.Tendsto.atBot_mul_neg
+
+/-- In a linearly ordered field with the order topology, if `f` tends to a positive constant `C` and
+`g` tends to `at_bot` then `f * g` tends to `at_bot`. -/
+theorem Filter.Tendsto.mul_atBot {C : α} (hC : 0 < C) (hf : Tendsto f l (𝓝 C))
+    (hg : Tendsto g l atBot) : Tendsto (fun x => f x * g x) l atBot := by
+  simpa only [mul_comm] using hg.at_bot_mul hC hf
+#align filter.tendsto.mul_at_bot Filter.Tendsto.mul_atBot
+
+/-- In a linearly ordered field with the order topology, if `f` tends to a negative constant `C` and
+`g` tends to `at_bot` then `f * g` tends to `at_top`. -/
+theorem Filter.Tendsto.neg_mul_atBot {C : α} (hC : C < 0) (hf : Tendsto f l (𝓝 C))
+    (hg : Tendsto g l atBot) : Tendsto (fun x => f x * g x) l atTop := by
+  simpa only [mul_comm] using hg.at_bot_mul_neg hC hf
+#align filter.tendsto.neg_mul_at_bot Filter.Tendsto.neg_mul_atBot
+
+/-- The function `x ↦ x⁻¹` tends to `+∞` on the right of `0`. -/
+theorem tendsto_inv_zero_atTop : Tendsto (fun x : α => x⁻¹) (𝓝[>] (0 : α)) atTop :=
+  by
+  refine' (at_top_basis' 1).tendsto_right_iff.2 fun b hb => _
+  have hb' : 0 < b := by positivity
+  filter_upwards [Ioc_mem_nhdsWithin_Ioi
+      ⟨le_rfl, inv_pos.2 hb'⟩]with x hx using(le_inv hx.1 hb').1 hx.2
+#align tendsto_inv_zero_at_top tendsto_inv_zero_atTop
+
+/-- The function `r ↦ r⁻¹` tends to `0` on the right as `r → +∞`. -/
+theorem tendsto_inv_atTop_zero' : Tendsto (fun r : α => r⁻¹) atTop (𝓝[>] (0 : α)) :=
+  by
+  refine'
+    (has_basis.tendsto_iff at_top_basis ⟨fun s => mem_nhdsWithin_Ioi_iff_exists_Ioc_subset⟩).2 _
+  refine' fun b hb => ⟨b⁻¹, trivial, fun x hx => _⟩
+  have : 0 < x := lt_of_lt_of_le (inv_pos.2 hb) hx
+  exact ⟨inv_pos.2 this, (inv_le this hb).2 hx⟩
+#align tendsto_inv_at_top_zero' tendsto_inv_atTop_zero'
+
+theorem tendsto_inv_atTop_zero : Tendsto (fun r : α => r⁻¹) atTop (𝓝 0) :=
+  tendsto_inv_atTop_zero'.mono_right inf_le_left
+#align tendsto_inv_at_top_zero tendsto_inv_atTop_zero
+
+theorem Filter.Tendsto.div_atTop [ContinuousMul α] {f g : β → α} {l : Filter β} {a : α}
+    (h : Tendsto f l (𝓝 a)) (hg : Tendsto g l atTop) : Tendsto (fun x => f x / g x) l (𝓝 0) :=
+  by
+  simp only [div_eq_mul_inv]
+  exact mul_zero a ▸ h.mul (tendsto_inv_at_top_zero.comp hg)
+#align filter.tendsto.div_at_top Filter.Tendsto.div_atTop
+
+theorem Filter.Tendsto.inv_tendsto_atTop (h : Tendsto f l atTop) : Tendsto f⁻¹ l (𝓝 0) :=
+  tendsto_inv_atTop_zero.comp h
+#align filter.tendsto.inv_tendsto_at_top Filter.Tendsto.inv_tendsto_atTop
+
+theorem Filter.Tendsto.inv_tendsto_zero (h : Tendsto f l (𝓝[>] 0)) : Tendsto f⁻¹ l atTop :=
+  tendsto_inv_zero_atTop.comp h
+#align filter.tendsto.inv_tendsto_zero Filter.Tendsto.inv_tendsto_zero
+
+/-- The function `x^(-n)` tends to `0` at `+∞` for any positive natural `n`.
+A version for positive real powers exists as `tendsto_rpow_neg_at_top`. -/
+theorem tendsto_pow_neg_atTop {n : ℕ} (hn : n ≠ 0) :
+    Tendsto (fun x : α => x ^ (-(n : ℤ))) atTop (𝓝 0) := by
+  simpa only [zpow_neg, zpow_ofNat] using (@tendsto_pow_at_top α _ _ hn).inv_tendsto_atTop
+#align tendsto_pow_neg_at_top tendsto_pow_neg_atTop
+
+theorem tendsto_zpow_atTop_zero {n : ℤ} (hn : n < 0) : Tendsto (fun x : α => x ^ n) atTop (𝓝 0) :=
+  by
+  lift -n to ℕ using le_of_lt (neg_pos.mpr hn) with N
+  rw [← neg_pos, ← h, Nat.cast_pos] at hn
+  simpa only [h, neg_neg] using tendsto_pow_neg_atTop hn.ne'
+#align tendsto_zpow_at_top_zero tendsto_zpow_atTop_zero
+
+theorem tendsto_const_mul_zpow_atTop_zero {n : ℤ} {c : α} (hn : n < 0) :
+    Tendsto (fun x => c * x ^ n) atTop (𝓝 0) :=
+  mul_zero c ▸ Filter.Tendsto.const_mul c (tendsto_zpow_atTop_zero hn)
+#align tendsto_const_mul_zpow_at_top_zero tendsto_const_mul_zpow_atTop_zero
+
+theorem tendsto_const_mul_pow_nhds_iff' {n : ℕ} {c d : α} :
+    Tendsto (fun x : α => c * x ^ n) atTop (𝓝 d) ↔ (c = 0 ∨ n = 0) ∧ c = d :=
+  by
+  rcases eq_or_ne n 0 with (rfl | hn)
+  · simp [tendsto_const_nhds_iff]
+  rcases lt_trichotomy c 0 with (hc | rfl | hc)
+  · have := tendsto_const_mul_pow_at_bot_iff.2 ⟨hn, hc⟩
+    simp [not_tendsto_nhds_of_tendsto_atBot this, hc.ne, hn]
+  · simp [tendsto_const_nhds_iff]
+  · have := tendsto_const_mul_pow_at_top_iff.2 ⟨hn, hc⟩
+    simp [not_tendsto_nhds_of_tendsto_atTop this, hc.ne', hn]
+#align tendsto_const_mul_pow_nhds_iff' tendsto_const_mul_pow_nhds_iff'
+
+theorem tendsto_const_mul_pow_nhds_iff {n : ℕ} {c d : α} (hc : c ≠ 0) :
+    Tendsto (fun x : α => c * x ^ n) atTop (𝓝 d) ↔ n = 0 ∧ c = d := by
+  simp [tendsto_const_mul_pow_nhds_iff', hc]
+#align tendsto_const_mul_pow_nhds_iff tendsto_const_mul_pow_nhds_iff
+
+theorem tendsto_const_mul_zpow_atTop_nhds_iff {n : ℤ} {c d : α} (hc : c ≠ 0) :
+    Tendsto (fun x : α => c * x ^ n) atTop (𝓝 d) ↔ n = 0 ∧ c = d ∨ n < 0 ∧ d = 0 :=
+  by
+  refine' ⟨fun h => _, fun h => _⟩
+  · by_cases hn : 0 ≤ n
+    · lift n to ℕ using hn
+      simp only [zpow_ofNat] at h
+      rw [tendsto_const_mul_pow_nhds_iff hc, ← Int.coe_nat_eq_zero] at h
+      exact Or.inl h
+    · rw [not_le] at hn
+      refine' Or.inr ⟨hn, tendsto_nhds_unique h (tendsto_const_mul_zpow_atTop_zero hn)⟩
+  · cases h
+    · simp only [h.left, h.right, zpow_zero, mul_one]
+      exact tendsto_const_nhds
+    · exact h.2.symm ▸ tendsto_const_mul_zpow_atTop_zero h.1
+#align tendsto_const_mul_zpow_at_top_nhds_iff tendsto_const_mul_zpow_atTop_nhds_iff
+
+-- TODO: With a different proof, this could be possibly generalised to only require a
+-- `linear_ordered_semifield` instance, which would also remove the need for the
+-- `nnreal` instance of `has_continuous_inv₀`.
+-- see Note [lower instance priority]
+instance (priority := 100) LinearOrderedField.to_topologicalDivisionRing : TopologicalDivisionRing α
+    where continuousAt_inv₀ :=
+    by
+    suffices ∀ {x : α}, 0 < x → ContinuousAt Inv.inv x
+      by
+      intro x hx
+      cases hx.symm.lt_or_lt
+      · exact this h
+      convert (this <| neg_pos.mpr h).neg.comp continuous_neg.continuous_at
+      ext
+      simp [neg_inv]
+    intro t ht
+    rw [ContinuousAt,
+      (nhds_basis_Ioo_pos t).tendsto_iffₓ <| nhds_basis_Ioo_pos_of_pos <| inv_pos.2 ht]
+    rintro ε ⟨hε : ε > 0, hεt : ε ≤ t⁻¹⟩
+    refine' ⟨min (t ^ 2 * ε / 2) (t / 2), by positivity, fun x h => _⟩
+    have hx : t / 2 < x := by
+      rw [Set.mem_Ioo, sub_lt_comm, lt_min_iff] at h
+      nlinarith
+    have hx' : 0 < x := (half_pos ht).trans hx
+    have aux : 0 < 2 / t ^ 2 := by positivity
+    rw [Set.mem_Ioo, ← sub_lt_iff_lt_add', sub_lt_comm, ← abs_sub_lt_iff] at h⊢
+    rw [inv_sub_inv ht.ne' hx'.ne', abs_div, div_eq_mul_inv]
+    suffices (|t * x|)⁻¹ < 2 / t ^ 2 by
+      rw [← abs_neg, neg_sub]
+      refine' (mul_lt_mul'' h this (by positivity) (by positivity)).trans_le _
+      rw [mul_comm, mul_min_of_nonneg _ _ aux.le]
+      apply min_le_of_left_le
+      rw [← mul_div, ← mul_assoc, div_mul_cancel _ (sq_pos_of_pos ht).ne',
+        mul_div_cancel' ε two_ne_zero]
+    refine' inv_lt_of_inv_lt aux _
+    rw [inv_div, abs_of_pos <| mul_pos ht hx', sq, ← mul_div_assoc']
+    exact mul_lt_mul_of_pos_left hx ht
+#align linear_ordered_field.to_topological_division_ring LinearOrderedField.to_topologicalDivisionRing
+
+theorem nhdsWithin_pos_comap_mul_left {x : α} (hx : 0 < x) :
+    comap (fun ε => x * ε) (𝓝[>] 0) = 𝓝[>] 0 :=
+  by
+  suffices ∀ {x : α} (hx : 0 < x), 𝓝[>] 0 ≤ comap (fun ε => x * ε) (𝓝[>] 0)
+    by
+    refine' le_antisymm _ (this hx)
+    have hr : 𝓝[>] (0 : α) = ((𝓝[>] (0 : α)).comap fun ε => x⁻¹ * ε).comap fun ε => x * ε := by
+      simp [comap_comap, inv_mul_cancel hx.ne.symm, comap_id, one_mul_eq_id]
+    conv_rhs => rw [hr]
+    rw [comap_le_comap_iff
+        (by convert univ_mem <;> exact (mul_left_surjective₀ hx.ne.symm).range_eq)]
+    exact this (inv_pos.mpr hx)
+  intro x hx
+  convert nhdsWithin_le_comap (continuous_mul_left x).ContinuousWithinAt
+  · exact (mul_zero _).symm
+  · rw [image_const_mul_Ioi_zero hx]
+#align nhds_within_pos_comap_mul_left nhdsWithin_pos_comap_mul_left
+
+theorem eventually_nhdsWithin_pos_mul_left {x : α} (hx : 0 < x) {p : α → Prop}
+    (h : ∀ᶠ ε in 𝓝[>] 0, p ε) : ∀ᶠ ε in 𝓝[>] 0, p (x * ε) :=
+  by
+  convert h.comap fun ε => x * ε
+  exact (nhdsWithin_pos_comap_mul_left hx).symm
+#align eventually_nhds_within_pos_mul_left eventually_nhdsWithin_pos_mul_left
+

--- a/Mathlib/Topology/Homeomorph.lean
+++ b/Mathlib/Topology/Homeomorph.lean
@@ -78,6 +78,7 @@ protected def symm (h : α ≃ₜ β) : β ≃ₜ α where
 #align homeomorph.symm Homeomorph.symm
 
 @[simp] theorem symm_symm (h : α ≃ₜ β) : h.symm.symm = h := rfl
+#align homeomorph.symm_symm Homeomorph.symm_symm
 
 /-- See Note [custom simps projection]. We need to specify this projection explicitly in this case,
   because it is a composition of multiple projections. -/

--- a/Mathlib/Topology/Homeomorph.lean
+++ b/Mathlib/Topology/Homeomorph.lean
@@ -77,6 +77,8 @@ protected def symm (h : α ≃ₜ β) : β ≃ₜ α where
   toEquiv := h.toEquiv.symm
 #align homeomorph.symm Homeomorph.symm
 
+@[simp] theorem symm_symm (h : α ≃ₜ β) : h.symm.symm = h := rfl
+
 /-- See Note [custom simps projection]. We need to specify this projection explicitly in this case,
   because it is a composition of multiple projections. -/
 def Simps.apply (h : α ≃ₜ β) : α → β :=

--- a/Mathlib/Topology/Homeomorph.lean
+++ b/Mathlib/Topology/Homeomorph.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Patrick Massot, Sébastien Gouëzel, Zhouhang Zhou, Reid Barton
 
 ! This file was ported from Lean 3 source module topology.homeomorph
-! leanprover-community/mathlib commit d90e4e186f1d18e375dcd4e5b5f6364b01cb3e46
+! leanprover-community/mathlib commit 3b267e70a936eebb21ab546f49a8df34dd300b25
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/


### PR DESCRIPTION
I made substantial changes to the proofs. To avoid backporting most of them, in leanprover-community/mathlib#18552 I add `private` to lemmas that are deleted in this PR. Also, I backport `Homeomorph.symm_symm` in leanprover-community/mathlib#18551

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)