### PR TITLE
[Merged by Bors] - fix: actually commit Mathlib.lean in the port script

### DIFF
--- a/scripts/start_port.sh
+++ b/scripts/start_port.sh
@@ -76,6 +76,7 @@ echo "Applying automated fixes"
 )
 
 # Commit them
+git update-index --add Mathlib.lean
 git update-index --add "$mathlib4_path"
 BASE_COMMIT="$(git commit-tree "$(git write-tree)" -p "$BASE_COMMIT" << EOF
 automated fixes


### PR DESCRIPTION
Tested locally and confirmed that this file is now added correctly.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
