### PR TITLE
[Merged by Bors] - feat: update SHA

### DIFF
--- a/Mathlib/Logic/Basic.lean
+++ b/Mathlib/Logic/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura
 
 ! This file was ported from Lean 3 source module logic.basic
-! leanprover-community/mathlib commit 13cd3e89b30352d5b1b7349f5537ea18ba878e40
+! leanprover-community/mathlib commit d2d8742b0c21426362a9dacebc6005db895ca963
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/

--- a/Mathlib/Logic/Equiv/Basic.lean
+++ b/Mathlib/Logic/Equiv/Basic.lean
@@ -5,7 +5,7 @@ Authors: Leonardo de Moura, Mario Carneiro
 Ported by: Kevin Buzzard, Ruben Vorster, Scott Morrison, Eric Rodriguez
 
 ! This file was ported from Lean 3 source module logic.equiv.basic
-! leanprover-community/mathlib commit 195fcd60ff2bfe392543bceb0ec2adcdb472db4c
+! leanprover-community/mathlib commit d2d8742b0c21426362a9dacebc6005db895ca963
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/

--- a/Mathlib/Logic/Nonempty.lean
+++ b/Mathlib/Logic/Nonempty.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl
 
 ! This file was ported from Lean 3 source module logic.nonempty
-! leanprover-community/mathlib commit c4658a649d216f57e99621708b09dcb3dcccbd23
+! leanprover-community/mathlib commit d2d8742b0c21426362a9dacebc6005db895ca963
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/


### PR DESCRIPTION
The diffs of these files are solely generalising Types `α` from `Type` to `Sort`, but they are already `Sort` in mathlib4.

These SHA just need updating from backport leanprover-community/mathlib#18543

---

* [`logic.basic`@`13cd3e89b30352d5b1b7349f5537ea18ba878e40`..`d2d8742b0c21426362a9dacebc6005db895ca963`](https://leanprover-community.github.io/mathlib-port-status/file/logic/basic?range=13cd3e89b30352d5b1b7349f5537ea18ba878e40..d2d8742b0c21426362a9dacebc6005db895ca963)
* [`logic.nonempty`@`c4658a649d216f57e99621708b09dcb3dcccbd23`..`d2d8742b0c21426362a9dacebc6005db895ca963`](https://leanprover-community.github.io/mathlib-port-status/file/logic/nonempty?range=c4658a649d216f57e99621708b09dcb3dcccbd23..d2d8742b0c21426362a9dacebc6005db895ca963)
* [`logic.equiv.basic`@`195fcd60ff2bfe392543bceb0ec2adcdb472db4c`..`d2d8742b0c21426362a9dacebc6005db895ca963`](https://leanprover-community.github.io/mathlib-port-status/file/logic/equiv/basic?range=195fcd60ff2bfe392543bceb0ec2adcdb472db4c..d2d8742b0c21426362a9dacebc6005db895ca963)

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
