### PR TITLE
[Merged by Bors] - feat: update SHA from  #18277

### DIFF
--- a/Mathlib/Data/Dfinsupp/Basic.lean
+++ b/Mathlib/Data/Dfinsupp/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Kenny Lau
 
 ! This file was ported from Lean 3 source module data.dfinsupp.basic
-! leanprover-community/mathlib commit e3d9ab8faa9dea8f78155c6c27d62a621f4c152d
+! leanprover-community/mathlib commit 6623e6af705e97002a9054c1c05a980180276fc1
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/

--- a/Mathlib/Data/Finsupp/Defs.lean
+++ b/Mathlib/Data/Finsupp/Defs.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Scott Morrison
 
 ! This file was ported from Lean 3 source module data.finsupp.defs
-! leanprover-community/mathlib commit 842328d9df7e96fd90fc424e115679c15fb23a71
+! leanprover-community/mathlib commit 6623e6af705e97002a9054c1c05a980180276fc1
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/

--- a/Mathlib/Data/Finsupp/Defs.lean
+++ b/Mathlib/Data/Finsupp/Defs.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Scott Morrison
 
 ! This file was ported from Lean 3 source module data.finsupp.defs
-! leanprover-community/mathlib commit 8631e2d5ea77f6c13054d9151d82b83069680cb1
+! leanprover-community/mathlib commit 842328d9df7e96fd90fc424e115679c15fb23a71
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/

--- a/Mathlib/Data/Fintype/Sum.lean
+++ b/Mathlib/Data/Fintype/Sum.lean
@@ -47,8 +47,7 @@ def fintypeOfFintypeNe (a : α) (h : Fintype { b // b ≠ a }) : Fintype α :=
     classical exact (Equiv.sumCompl (· = a)).bijective
 #align fintype_of_fintype_ne fintypeOfFintypeNe
 
-open Classical in
-theorem image_subtype_ne_univ_eq_image_erase [Fintype α] (k : β) (b : α → β) :
+theorem image_subtype_ne_univ_eq_image_erase [Fintype α] [DecidableEq β] (k : β) (b : α → β) :
     image (fun i : { a // b a ≠ k } => b ↑i) univ = (image b univ).erase k := by
   apply subset_antisymm
   · rw [image_subset_iff]
@@ -61,8 +60,7 @@ theorem image_subtype_ne_univ_eq_image_erase [Fintype α] (k : β) (b : α → �
     exact ⟨⟨a, ne_of_mem_erase hi⟩, mem_univ _, rfl⟩
 #align image_subtype_ne_univ_eq_image_erase image_subtype_ne_univ_eq_image_erase
 
-open Classical in
-theorem image_subtype_univ_ssubset_image_univ [Fintype α] (k : β) (b : α → β)
+theorem image_subtype_univ_ssubset_image_univ [Fintype α] [DecidableEq β] (k : β) (b : α → β)
     (hk : k ∈ Finset.image b univ) (p : β → Prop) [DecidablePred p] (hp : ¬p k) :
     image (fun i : { a // p (b a) } => b ↑i) univ ⊂ image b univ := by
   constructor
@@ -79,10 +77,9 @@ theorem image_subtype_univ_ssubset_image_univ [Fintype α] (k : β) (b : α → 
     exact hp (hj' ▸ j.2)
 #align image_subtype_univ_ssubset_image_univ image_subtype_univ_ssubset_image_univ
 
-open Classical in
 /-- Any injection from a finset `s` in a fintype `α` to a finset `t` of the same cardinality as `α`
 can be extended to a bijection between `α` and `t`. -/
-theorem Finset.exists_equiv_extend_of_card_eq [Fintype α] {t : Finset β}
+theorem Finset.exists_equiv_extend_of_card_eq [Fintype α] [DecidableEq β] {t : Finset β}
     (hαt : Fintype.card α = t.card) {s : Finset α} {f : α → β} (hfst : Finset.image f s ⊆ t)
     (hfs : Set.InjOn f s) : ∃ g : α ≃ t, ∀ i ∈ s, (g i : β) = f i := by
   classical

--- a/Mathlib/Data/Fintype/Sum.lean
+++ b/Mathlib/Data/Fintype/Sum.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 
 ! This file was ported from Lean 3 source module data.fintype.sum
-! leanprover-community/mathlib commit 509de852e1de55e1efa8eacfa11df0823f26f226
+! leanprover-community/mathlib commit 6623e6af705e97002a9054c1c05a980180276fc1
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/

--- a/Mathlib/Data/Pi/Lex.lean
+++ b/Mathlib/Data/Pi/Lex.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes
 
 ! This file was ported from Lean 3 source module data.pi.lex
-! leanprover-community/mathlib commit d4f69d96f3532729da8ebb763f4bc26fcf640f06
+! leanprover-community/mathlib commit 6623e6af705e97002a9054c1c05a980180276fc1
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/

--- a/Mathlib/Order/OrderIsoNat.lean
+++ b/Mathlib/Order/OrderIsoNat.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 
 ! This file was ported from Lean 3 source module order.order_iso_nat
-! leanprover-community/mathlib commit 2445c98ae4b87eabebdde552593519b9b6dc350c
+! leanprover-community/mathlib commit 6623e6af705e97002a9054c1c05a980180276fc1
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/

--- a/Mathlib/Order/OrderIsoNat.lean
+++ b/Mathlib/Order/OrderIsoNat.lean
@@ -128,30 +128,34 @@ noncomputable def Subtype.orderIsoOfNat : ℕ ≃o s := by
       Nat.Subtype.ofNat_surjective
 #align nat.subtype.order_iso_of_nat Nat.Subtype.orderIsoOfNat
 
---porting note: Added the decidability requirement, I'm not sure how it worked in lean3 without it
-variable {s} [dP : DecidablePred (· ∈ s)]
+variable {s}
 
 @[simp]
-theorem coe_orderEmbeddingOfSet : ⇑(orderEmbeddingOfSet s) = (↑) ∘ Subtype.ofNat s :=
+theorem coe_orderEmbeddingOfSet [DecidablePred (· ∈ s)] :
+    ⇑(orderEmbeddingOfSet s) = (↑) ∘ Subtype.ofNat s :=
   rfl
 #align nat.coe_order_embedding_of_set Nat.coe_orderEmbeddingOfSet
 
-theorem orderEmbeddingOfSet_apply {n : ℕ} : orderEmbeddingOfSet s n = Subtype.ofNat s n :=
+theorem orderEmbeddingOfSet_apply [DecidablePred (· ∈ s)] {n : ℕ} :
+    orderEmbeddingOfSet s n = Subtype.ofNat s n :=
   rfl
 #align nat.order_embedding_of_set_apply Nat.orderEmbeddingOfSet_apply
 
 @[simp]
-theorem Subtype.orderIsoOfNat_apply {n : ℕ} : Subtype.orderIsoOfNat s n = Subtype.ofNat s n := by
+theorem Subtype.orderIsoOfNat_apply [dP : DecidablePred (· ∈ s)] {n : ℕ} :
+    Subtype.orderIsoOfNat s n = Subtype.ofNat s n := by
   simp only [orderIsoOfNat, RelIso.ofSurjective_apply,
     RelEmbedding.orderEmbeddingOfLTEmbedding_apply, RelEmbedding.coe_natLt]
   suffices (fun a => Classical.propDecidable (a ∈ s)) = (fun a => dP a) by
     rw [this]
   simp
+  -- Porting note: This proof was simply `by simp [orderIsoOfNat]; congr`
 #align nat.subtype.order_iso_of_nat_apply Nat.Subtype.orderIsoOfNat_apply
 
 variable (s)
 
-theorem orderEmbeddingOfSet_range : Set.range (Nat.orderEmbeddingOfSet s) = s :=
+theorem orderEmbeddingOfSet_range [DecidablePred (· ∈ s)] :
+    Set.range (Nat.orderEmbeddingOfSet s) = s :=
   Subtype.coe_comp_ofNat_range
 #align nat.order_embedding_of_set_range Nat.orderEmbeddingOfSet_range
 


### PR DESCRIPTION
leanprover-community/mathlib#18277 backported a bug about classical which is already fixed in mathlib4, so these diffs simpy need a SHA update.

(Comment: This might not be the full PR #18277 yet, as I worked on a file-by-file base)

---

* [`data.dfinsupp.basic`@`e3d9ab8faa9dea8f78155c6c27d62a621f4c152d`..`6623e6af705e97002a9054c1c05a980180276fc1`](https://leanprover-community.github.io/mathlib-port-status/file/data/dfinsupp/basic?range=e3d9ab8faa9dea8f78155c6c27d62a621f4c152d..6623e6af705e97002a9054c1c05a980180276fc1)
* [`data.finsupp.defs`@`8631e2d5ea77f6c13054d9151d82b83069680cb1`..`6623e6af705e97002a9054c1c05a980180276fc1`](https://leanprover-community.github.io/mathlib-port-status/file/data/finsupp/defs?range=8631e2d5ea77f6c13054d9151d82b83069680cb1..6623e6af705e97002a9054c1c05a980180276fc1)
* [`data.pi.lex`@`d4f69d96f3532729da8ebb763f4bc26fcf640f06`..`6623e6af705e97002a9054c1c05a980180276fc1`](https://leanprover-community.github.io/mathlib-port-status/file/data/pi/lex?range=d4f69d96f3532729da8ebb763f4bc26fcf640f06..6623e6af705e97002a9054c1c05a980180276fc1)
* [`data.fintype.sum`@`509de852e1de55e1efa8eacfa11df0823f26f226`..`6623e6af705e97002a9054c1c05a980180276fc1`](https://leanprover-community.github.io/mathlib-port-status/file/data/fintype/sum?range=509de852e1de55e1efa8eacfa11df0823f26f226..6623e6af705e97002a9054c1c05a980180276fc1)
* [`order.order_iso_nat`@`2445c98ae4b87eabebdde552593519b9b6dc350c`..`6623e6af705e97002a9054c1c05a980180276fc1`](https://leanprover-community.github.io/mathlib-port-status/file/order/order_iso_nat?range=2445c98ae4b87eabebdde552593519b9b6dc350c..6623e6af705e97002a9054c1c05a980180276fc1)

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
