### PR TITLE
[Merged by Bors] - feat: sync Data.Vector.Basic

### DIFF
--- a/Mathlib/Data/Vector/Basic.lean
+++ b/Mathlib/Data/Vector/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 
 ! This file was ported from Lean 3 source module data.vector.basic
-! leanprover-community/mathlib commit 9003f28797c0664a49e4179487267c494477d853
+! leanprover-community/mathlib commit f694c7dead66f5d4c80f446c796a5aad14707f0e
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/


### PR DESCRIPTION
---

* [`data.vector.basic`@`9003f28797c0664a49e4179487267c494477d853`..`f694c7dead66f5d4c80f446c796a5aad14707f0e`](https://leanprover-community.github.io/mathlib-port-status/file/data/vector/basic?range=9003f28797c0664a49e4179487267c494477d853..f694c7dead66f5d4c80f446c796a5aad14707f0e)

This has two changes:

- addition of `Vector.replicate`: In Mathlib4 this definition is in `Data/Vector.lean`: [docs4#Vector.replicate](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Data/Vector.html#Vector.replicate)
- Rename `nth_repeat` to `nth_replicate`: This has the name `get_replicate` in mathlib4, see [docs4#Vector.get_replicate](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Data/Vector/Basic.html#Vector.get_replicate)

I don't know the background behind this diverge, but it seems that this diff might be marked as synced.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
