### PR TITLE
[Merged by Bors] - chore: update SHA for Data.Int.Cast.Lemmas

### DIFF
--- a/Mathlib/Data/Int/Cast/Lemmas.lean
+++ b/Mathlib/Data/Int/Cast/Lemmas.lean
@@ -5,7 +5,7 @@ Authors: Mario Carneiro
 Ported by: Scott Morrison
 
 ! This file was ported from Lean 3 source module data.int.cast.lemmas
-! leanprover-community/mathlib commit fc2ed6f838ce7c9b7c7171e58d78eaf7b438fb0e
+! leanprover-community/mathlib commit 7a89b1aed52bcacbcc4a8ad515e72c5c07268940
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/


### PR DESCRIPTION
This has been synced in #1340 which forgot to update the SHA.

* [`data.int.cast.lemmas`@`fc2ed6f838ce7c9b7c7171e58d78eaf7b438fb0e`..`7a89b1aed52bcacbcc4a8ad515e72c5c07268940`](https://leanprover-community.github.io/mathlib-port-status/file/data/int/cast/lemmas?range=fc2ed6f838ce7c9b7c7171e58d78eaf7b438fb0e..7a89b1aed52bcacbcc4a8ad515e72c5c07268940)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
