### PR TITLE
[Merged by Bors] - chore: update SHA for Algebra.GroupPower.Lemmas

### DIFF
--- a/Mathlib/Algebra/GroupPower/Lemmas.lean
+++ b/Mathlib/Algebra/GroupPower/Lemmas.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Robert Y. Lewis
 
 ! This file was ported from Lean 3 source module algebra.group_power.lemmas
-! leanprover-community/mathlib commit 02c4026cbe3cd2122eb8ff196c80f24441037002
+! leanprover-community/mathlib commit e1bccd6e40ae78370f01659715d3c948716e3b7e
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/


### PR DESCRIPTION
---

* [`algebra.group_power.lemmas`@`02c4026cbe3cd2122eb8ff196c80f24441037002`..`e1bccd6e40ae78370f01659715d3c948716e3b7e`](https://leanprover-community.github.io/mathlib-port-status/file/algebra/group_power/lemmas?range=02c4026cbe3cd2122eb8ff196c80f24441037002..e1bccd6e40ae78370f01659715d3c948716e3b7e)

This file has two diffs that are both irrelevant:

1. The first is just a name change of a lemma used in the proof. This has anyways a new name in mathlib4.
2. The second change (`nat_abs_sq` / `natAbs_sq`) matches what's in Mathlib4.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
