### PR TITLE
feat: forward-port mathlib#18551

### DIFF
--- a/Mathlib/Topology/Homeomorph.lean
+++ b/Mathlib/Topology/Homeomorph.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Patrick Massot, Sébastien Gouëzel, Zhouhang Zhou, Reid Barton
 
 ! This file was ported from Lean 3 source module topology.homeomorph
-! leanprover-community/mathlib commit d90e4e186f1d18e375dcd4e5b5f6364b01cb3e46
+! leanprover-community/mathlib commit 3b267e70a936eebb21ab546f49a8df34dd300b25
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -104,6 +104,11 @@ theorem coe_symm_toEquiv (h : α ≃ₜ β) : ⇑h.toEquiv.symm = h.symm :=
 theorem ext {h h' : α ≃ₜ β} (H : ∀ x, h x = h' x) : h = h' :=
   FunLike.ext _ _ H
 #align homeomorph.ext Homeomorph.ext
+
+@[simp]
+lemma symm_symm (h : α ≃ₜ β) : h.symm.symm = h := by
+  ext
+  rfl
 
 /-- Identity map as a homeomorphism. -/
 @[simps! (config := { fullyApplied := false }) apply]


### PR DESCRIPTION
forward-port of leanprover-community/mathlib#18551.

---

* [`topology.homeomorph`@`d90e4e186f1d18e375dcd4e5b5f6364b01cb3e46`..`3b267e70a936eebb21ab546f49a8df34dd300b25`](https://leanprover-community.github.io/mathlib-port-status/file/topology/homeomorph?range=d90e4e186f1d18e375dcd4e5b5f6364b01cb3e46..3b267e70a936eebb21ab546f49a8df34dd300b25)

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
