### PR TITLE
[Merged by Bors] - feat: sync Data.Nat.PartENat

### DIFF
--- a/Mathlib/Data/Nat/PartENat.lean
+++ b/Mathlib/Data/Nat/PartENat.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes
 
 ! This file was ported from Lean 3 source module data.nat.part_enat
-! leanprover-community/mathlib commit f7fc89d5d5ff1db2d1242c7bb0e9062ce47ef47c
+! leanprover-community/mathlib commit 114ff8a4a7935cb7531062200bff375e7b1d6d85
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -120,6 +120,9 @@ theorem natCast_inj {x y : ℕ} : (x : PartENat) = y ↔ x = y :=
 theorem dom_natCast (x : ℕ) : (x : PartENat).Dom :=
   trivial
 #align part_enat.dom_coe PartENat.dom_natCast
+
+instance : CanLift PartENat ℕ (↑) Dom :=
+  ⟨fun n hn => ⟨n.get hn, Part.some_get _⟩⟩
 
 instance : LE PartENat :=
   ⟨fun x y => ∃ h : y.Dom → x.Dom, ∀ hy : y.Dom, x.get (h hy) ≤ y.get hy⟩
@@ -446,6 +449,14 @@ noncomputable instance : CanonicallyOrderedAddMonoid PartENat :=
         PartENat.casesOn a (fun h => ((natCast_lt_top _).not_le h).elim) fun a h =>
           ⟨(b - a : ℕ), by
             rw [← Nat.cast_add, natCast_inj, add_comm, tsub_add_cancel_of_le (coe_le_coe.1 h)]⟩ }
+
+theorem eq_natCast_sub_of_add_eq_natCast {x y : PartENat} {n : ℕ} (h : x + y = n) :
+    x = ↑(n - y.get (dom_of_le_natCast ((le_add_left le_rfl).trans_eq h))) := by
+  lift x to ℕ using dom_of_le_natCast ((le_add_right le_rfl).trans_eq h)
+  lift y to ℕ using dom_of_le_natCast ((le_add_left le_rfl).trans_eq h)
+  rw [← Nat.cast_add, natCast_inj] at h
+  rw [get_natCast, natCast_inj, eq_tsub_of_add_eq h]
+#align part_enat.eq_coe_sub_of_add_eq_coe PartENat.eq_natCast_sub_of_add_eq_natCast
 
 protected theorem add_lt_add_right {x y z : PartENat} (h : x < y) (hz : z ≠ ⊤) : x + z < y + z := by
   rcases ne_top_iff.mp (ne_top_of_lt h) with ⟨m, rfl⟩


### PR DESCRIPTION
---

* [`data.nat.part_enat`@`f7fc89d5d5ff1db2d1242c7bb0e9062ce47ef47c`..`114ff8a4a7935cb7531062200bff375e7b1d6d85`](https://leanprover-community.github.io/mathlib-port-status/file/data/nat/part_enat?range=f7fc89d5d5ff1db2d1242c7bb0e9062ce47ef47c..114ff8a4a7935cb7531062200bff375e7b1d6d85)

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
