### PR TITLE
[Merged by Bors] - feat: add decidable instance to  ∈ singleton

### DIFF
--- a/Mathlib/Data/Set/Basic.lean
+++ b/Mathlib/Data/Set/Basic.lean
@@ -2834,6 +2834,10 @@ instance decidableSetOf (p : α → Prop) [Decidable (p a)] : Decidable (a ∈ {
   assumption
 #align set.decidable_set_of Set.decidableSetOf
 
+-- porting note: Lean 3 unfolded `{a}` before finding instances but Lean 4 needs additional help
+instance singletonDecidableMem {α: Type _} {a j: α} [DecidableEq α] :
+    Decidable (j ∈ ({a} : Set α)) := decidableSetOf j (fun (b : α) => b = a)
+
 end Set
 
 /-! ### Monotone lemmas for sets -/


### PR DESCRIPTION
Adds `Decidable (j ∈ ({a} : Set α))` to help Lean 4 infer instances that Lean 3 automatically found

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
