### PR TITLE
[Merged by Bors] - fix: `ring`: use `whnfR` when obtaining goal

### DIFF
--- a/Mathlib/Tactic/Ring/Basic.lean
+++ b/Mathlib/Tactic/Ring/Basic.lean
@@ -1065,7 +1065,7 @@ initialize ringCleanupRef : IO.Ref (Expr → MetaM Expr) ← IO.mkRef pure
 
 /-- Frontend of `ring1`: attempt to close a goal `g`, assuming it is an equation of semirings. -/
 def proveEq (g : MVarId) : AtomM Unit := do
-  let some (α, e₁, e₂) := (← instantiateMVars (← g.getType)).eq?
+  let some (α, e₁, e₂) := (← whnfR <|← instantiateMVars <|← g.getType).eq?
     | throwError "ring failed: not an equality"
   let .sort (.succ u) ← whnf (← inferType α) | throwError "not a type{indentExpr α}"
   have α : Q(Type u) := α

--- a/test/ring.lean
+++ b/test/ring.lean
@@ -108,3 +108,11 @@ example (x : ℕ) : (22 + 7 * x + 3 * 8 = 0 + 7 * x + 46 + 1)
                     = (7 * x + 46 = 7 * x + 47) := by
   conv => ring
   trivial
+
+-- check that mdata is consumed
+def f : Nat → Nat := sorry
+
+example (a : Nat) : 1 * f a * 1 = f (a + 0) := by
+  have ha : a + 0 = a := by ring
+  rw [ha] -- goal has mdata
+  ring1


### PR DESCRIPTION
Adds `whnfR` so that goals which are e.g. equalities with metadata are recognized by `ring`. See [zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Bug.20in.20.60ring1.60.3F).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
