### PR TITLE
[Merged by Bors] - fix: remove stray LibrarySearch import in Combinatorics.SimpleGraph.Coloring

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Coloring.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Coloring.lean
@@ -12,7 +12,6 @@ import Mathlib.Combinatorics.SimpleGraph.Clique
 import Mathlib.Data.Nat.Lattice
 import Mathlib.Data.Setoid.Partition
 import Mathlib.Order.Antichain
-import Mathlib.Tactic.LibrarySearch -- porting notes: TODO REMOVE
 
 /-!
 # Graph Coloring


### PR DESCRIPTION
Removes unneeded import left behind from https://github.com/leanprover-community/mathlib4/pull/2526.