### PR TITLE
[Merged by Bors] - chore: update quote4

### DIFF
--- a/Mathlib/Tactic/FieldSimp.lean
+++ b/Mathlib/Tactic/FieldSimp.lean
@@ -9,7 +9,7 @@ import Lean.Meta.Tactic.Simp.Main
 import Std.Lean.Parser
 import Mathlib.Algebra.Group.Units
 import Mathlib.Tactic.NormNum.Core
-import Qq.Match
+import Qq
 
 /-!
 # `field_simp` tactic

--- a/Mathlib/Tactic/NormNum/Basic.lean
+++ b/Mathlib/Tactic/NormNum/Basic.lean
@@ -190,7 +190,7 @@ such that `norm_num` successfully recognises `a`. -/
   have _e_eq : $e =Q $f $a := ⟨⟩
   let ra ← derive a
   let rα ← inferRing α
-  let ⟨(_f_eq : $f =Q Neg.neg)⟩ ← withNewMCtxDepth do assertDefEqQ _ _
+  let ⟨(_f_eq : $f =Q Neg.neg)⟩ ← withNewMCtxDepth <| assertDefEqQ _ _
   let rec
   /-- Main part of `evalNeg`. -/
   core : Option (Result e) := do
@@ -234,7 +234,7 @@ such that `norm_num` successfully recognises both `a` and `b`. -/
   have _e_eq : $e =Q $f $a $b := ⟨⟩
   let rα ← inferRing α
   assertInstancesCommute
-  let ⟨(_f_eq : $f =Q HSub.hSub)⟩ ← withNewMCtxDepth do assertDefEqQ _ _
+  let ⟨(_f_eq : $f =Q HSub.hSub)⟩ ← withNewMCtxDepth <| assertDefEqQ _ _
   let ra ← derive a; let rb ← derive b
   let rec
   /-- Main part of `evalAdd`. -/

--- a/Mathlib/Tactic/NormNum/Basic.lean
+++ b/Mathlib/Tactic/NormNum/Basic.lean
@@ -233,7 +233,6 @@ such that `norm_num` successfully recognises both `a` and `b`. -/
   let .app (.app (f : Q($α → $α → $α)) (a : Q($α))) (b : Q($α)) ← whnfR e | failure
   have _e_eq : $e =Q $f $a $b := ⟨⟩
   let rα ← inferRing α
-  assertInstancesCommute
   let ⟨(_f_eq : $f =Q HSub.hSub)⟩ ← withNewMCtxDepth <| assertDefEqQ _ _
   let ra ← derive a; let rb ← derive b
   let rec

--- a/Mathlib/Tactic/Positivity/Basic.lean
+++ b/Mathlib/Tactic/Positivity/Basic.lean
@@ -8,7 +8,7 @@ import Mathlib.Data.Int.Order.Basic
 import Mathlib.Tactic.Positivity.Core
 import Mathlib.Algebra.GroupPower.Order
 import Mathlib.Algebra.Order.Field.Basic
-import Qq.Match
+import Qq
 
 /-!
 ## `positivity` core extensions
@@ -38,104 +38,74 @@ end LinearOrder
 /-- The `positivity` extension which identifies expressions of the form `min a b`,
 such that `positivity` successfully recognises both `a` and `b`. -/
 @[positivity min _ _] def evalMin : PositivityExt where eval {u α} zα pα e := do
-  let .app (.app f (a : Q($α))) (b : Q($α)) ← withReducible (whnf e) | throwError "not min"
-  let ra ← core zα pα a; let rb ← core zα pα b
+  let .app (.app (f : Q($α → $α → $α)) (a : Q($α))) (b : Q($α)) ← withReducible (whnf e)
+    | throwError "not min"
+  let _e_eq : $e =Q $f $a $b := ⟨⟩
   let _a ← synthInstanceQ (q(LinearOrder $α) : Q(Type u))
-  guard <|← withDefault <| withNewMCtxDepth <| isDefEq f q(min (α := $α))
-  match ra, rb with
-  | .positive pa, .positive pb =>
-    have pa' : Q(by clear! «$pα»; exact 0 < $a) := pa
-    have pb' : Q(by clear! «$pα»; exact 0 < $b) := pb
-    pure (.positive (q(lt_min $pa' $pb') : Expr))
-  | .positive pa, .nonnegative pb =>
-    have pa' : Q(by clear! «$pα»; exact 0 < $a) := pa
-    have pb' : Q(by clear! «$pα»; exact 0 ≤ $b) := pb
-    pure (.nonnegative (q(le_min_of_lt_of_le $pa' $pb') : Expr))
-  | .nonnegative pa, .positive pb =>
-    have pa' : Q(by clear! «$pα»; exact 0 ≤ $a) := pa
-    have pb' : Q(by clear! «$pα»; exact 0 < $b) := pb
-    pure (.nonnegative (q(le_min_of_le_of_lt $pa' $pb') : Expr))
-  | .nonnegative pa, .nonnegative pb =>
-    have pa' : Q(by clear! «$pα»; exact 0 ≤ $a) := pa
-    have pb' : Q(by clear! «$pα»; exact 0 ≤ $b) := pb
-    pure (.nonnegative (q(le_min $pa' $pb') : Expr))
-  | .positive pa, .nonzero pb =>
-    have pa' : Q(by clear! «$pα»; exact 0 < $a) := pa
-    have pb' : Q(by clear! «$pα»; exact $b ≠ 0) := pb
-    pure (.nonzero (q(min_ne_of_lt_of_ne $pa' $pb') : Expr))
-  | .nonzero pa, .positive pb =>
-    have pa' : Q(by clear! «$pα»; exact $a ≠ 0) := pa
-    have pb' : Q(by clear! «$pα»; exact 0 < $b) := pb
-    pure (.nonzero (q(min_ne_of_ne_of_lt $pa' $pb') : Expr))
-  | .nonzero pa, .nonzero pb =>
-    have pa' : Q(by clear! «$pα»; exact $a ≠ 0) := pa
-    have pb' : Q(by clear! «$pα»; exact $b ≠ 0) := pb
-    pure (.nonzero (q(min_ne $pa' $pb') : Expr))
-  | _, _ => pure .none
+  assertInstancesCommute
+  let ⟨_f_eq⟩ ← withDefault do withNewMCtxDepth do assertDefEqQ (u := u.succ) f q(min)
+  match ← core zα pα a, ← core zα pα b with
+  | .positive pa, .positive pb => return .positive q(lt_min $pa $pb)
+  | .positive pa, .nonnegative pb => return .nonnegative q(le_min_of_lt_of_le $pa $pb)
+  | .nonnegative pa, .positive pb => return .nonnegative q(le_min_of_le_of_lt $pa $pb)
+  | .nonnegative pa, .nonnegative pb => return .nonnegative q(le_min $pa $pb)
+  | .positive pa, .nonzero pb => return .nonzero q(min_ne_of_lt_of_ne $pa $pb)
+  | .nonzero pa, .positive pb => return .nonzero q(min_ne_of_ne_of_lt $pa $pb)
+  | .nonzero pa, .nonzero pb => return .nonzero q(min_ne $pa $pb)
+  | _, _ => return .none
 
 /-- Extension for the `max` operator. The `max` of two numbers is nonnegative if at least one
 is nonnegative, strictly positive if at least one is positive, and nonzero if both are nonzero. -/
 @[positivity max _ _] def evalMax : PositivityExt where eval {u α} zα pα e := do
-  let .app (.app f (a : Q($α))) (b : Q($α)) ← withReducible (whnf e) | throwError "not max"
-  let result ← catchNone do
-    let _a ← synthInstanceQ (q(LinearOrder $α) : Q(Type u))
-    guard <|← withDefault <| withNewMCtxDepth <| isDefEq f q(max (α := $α))
+  let .app (.app (f : Q($α → $α → $α)) (a : Q($α))) (b : Q($α)) ← withReducible (whnf e)
+    | throwError "not max"
+  let _e_eq : $e =Q $f $a $b := ⟨⟩
+  let _a ← synthInstanceQ (q(LinearOrder $α) : Q(Type u))
+  assertInstancesCommute
+  let ⟨_f_eq⟩ ← withDefault do withNewMCtxDepth do assertDefEqQ (u := u.succ) f q(max)
+  let result : Strictness zα pα e ← catchNone do
     let ra ← core zα pα a
     match ra with
-    | .positive pa =>
-      have pa' : Q(by clear! «$pα»; exact 0 < $a) := pa
-      pure (.positive (q(@lt_max_of_lt_left $α _ _ _ $b $pa') : Expr))
-    | .nonnegative pa =>
-      have pa' : Q(by clear! «$pα»; exact 0 ≤ $a) := pa
-      pure (.nonnegative (q(@le_max_of_le_left $α _ _ _ $b $pa') : Expr))
+    | .positive pa => return .positive q(lt_max_of_lt_left $pa)
+    | .nonnegative pa => return .nonnegative q(le_max_of_le_left $pa)
     -- If `a ≠ 0`, we might prove `max a b ≠ 0` if `b ≠ 0` but we don't want to evaluate
     -- `b` before having ruled out `0 < a`, for performance. So we do that in the second branch
     -- of the `orElse'`.
-    | _ => pure .none
+    | _ => return .none
   orElse result do
-    let _a ← synthInstanceQ (q(LinearOrder $α) : Q(Type u))
-    guard <|← withDefault <| withNewMCtxDepth <| isDefEq f q(max (α := $α))
     let rb ← core zα pα b
     match rb with
-    | .positive pb =>
-      have pb' : Q(by clear! «$pα»; exact 0 < $b) := pb
-      pure (.positive (q(@lt_max_of_lt_right $α _ _ $a $b $pb') : Expr))
-    | .nonnegative pb =>
-      have pb' : Q(by clear! «$pα»; exact 0 ≤ $b) := pb
-      pure (.nonnegative (q(@le_max_of_le_right $α _ _ $a $b $pb') : Expr))
+    | .positive pb => return .positive q(lt_max_of_lt_right $pb)
+    | .nonnegative pb => return .nonnegative q(le_max_of_le_right $pb)
     | .nonzero pb => do
-      have pb' : Q(by clear! «$pα»; exact $b ≠ 0) := pb
       match ← core zα pα a with
-      | .nonzero pa =>
-        have pa' : Q(by clear! «$pα»; exact $a ≠ 0) := pa
-        pure ( .nonzero (q(max_ne $pa' $pb') : Expr))
-      | _ => pure .none
-    | _ => pure .none
+      | .nonzero pa => return .nonzero q(max_ne $pa $pb)
+      | _ => return .none
+    | _ => return .none
 
 /-- The `positivity` extension which identifies expressions of the form `a + b`,
 such that `positivity` successfully recognises both `a` and `b`. -/
 @[positivity _ + _, Add.add _ _] def evalAdd : PositivityExt where eval {u α} zα pα e := do
-  let .app (.app f (a : Q($α))) (b : Q($α)) ← withReducible (whnf e) | throwError "not +"
-  let ra ← core zα pα a; let rb ← core zα pα b
+  let .app (.app (f : Q($α → $α → $α)) (a : Q($α))) (b : Q($α)) ← withReducible (whnf e)
+    | throwError "not +"
+  let _e_eq : $e =Q $f $a $b := ⟨⟩
   let _a ← synthInstanceQ (q(AddZeroClass $α) : Q(Type u))
-  guard <|← withDefault <| withNewMCtxDepth <| isDefEq f q(HAdd.hAdd (α := $α))
+  assertInstancesCommute
+  let ⟨_f_eq⟩ ← withDefault do withNewMCtxDepth do assertDefEqQ (u := u.succ) f q(HAdd.hAdd)
+  let ra ← core zα pα a; let rb ← core zα pα b
   match ra, rb with
-  | .positive (pa : Q(@Zero.zero _ AddZeroClass.toZero < $a)),
-    .positive (pb : Q(@Zero.zero _ AddZeroClass.toZero < $b)) =>
+  | .positive pa, .positive pb =>
     let _a ← synthInstanceQ (q(CovariantClass $α $α (·+·) (·<·)) : Q(Prop))
-    pure (.positive (q(add_pos $pa $pb) : Expr))
-  | .positive (pa : Q(@Zero.zero _ AddZeroClass.toZero < $a)),
-    .nonnegative (pb : Q(@Zero.zero _ AddZeroClass.toZero ≤ $b)) =>
+    return .positive q(add_pos $pa $pb)
+  | .positive pa, .nonnegative pb =>
     let _a ← synthInstanceQ (q(CovariantClass $α $α (swap (·+·)) (·<·)) : Q(Prop))
-    pure (.positive (q(lt_add_of_pos_of_le $pa $pb) : Expr))
-  | .nonnegative (pa : Q(@Zero.zero _ AddZeroClass.toZero ≤ $a)),
-    .positive (pb : Q(@Zero.zero _ AddZeroClass.toZero < $b)) =>
+    return .positive q(lt_add_of_pos_of_le $pa $pb)
+  | .nonnegative pa, .positive pb =>
     let _a ← synthInstanceQ (q(CovariantClass $α $α (·+·) (·<·)) : Q(Prop))
-    pure (.positive (q(lt_add_of_le_of_pos $pa $pb) : Expr))
-  | .nonnegative (pa : Q(@Zero.zero _ AddZeroClass.toZero ≤ $a)),
-    .nonnegative (pb : Q(@Zero.zero _ AddZeroClass.toZero ≤ $b)) =>
+    return .positive q(lt_add_of_le_of_pos $pa $pb)
+  | .nonnegative pa, .nonnegative pb =>
     let _a ← synthInstanceQ (q(CovariantClass $α $α (·+·) (·≤·)) : Q(Prop))
-    pure (.nonnegative (q(add_nonneg $pa $pb) : Expr))
+    return .nonnegative q(add_nonneg $pa $pb)
   | _, _ => failure
 
 private theorem mul_nonneg_of_pos_of_nonneg [OrderedSemiring α] {a b : α}
@@ -157,42 +127,28 @@ private theorem mul_ne_zero_of_pos_of_ne_zero [OrderedSemiring α] [NoZeroDiviso
 /-- The `positivity` extension which identifies expressions of the form `a * b`,
 such that `positivity` successfully recognises both `a` and `b`. -/
 @[positivity _ * _, Mul.mul _ _] def evalMul : PositivityExt where eval {u α} zα pα e := do
-  let .app (.app f (a : Q($α))) (b : Q($α)) ← withReducible (whnf e) | throwError "not *"
-  let ra ← core zα pα a; let rb ← core zα pα b
+  let .app (.app (f : Q($α → $α → $α)) (a : Q($α))) (b : Q($α)) ← withReducible (whnf e)
+    | throwError "not *"
+  let _e_eq : $e =Q $f $a $b := ⟨⟩
   let _a ← synthInstanceQ (q(StrictOrderedSemiring $α) : Q(Type u))
-  guard <|← withDefault <| withNewMCtxDepth <| isDefEq f q(HMul.hMul (α := $α))
-  -- FIXME: this code is pretty horrible, we should improve Qq or something
+  assertInstancesCommute
+  let ⟨_f_eq⟩ ← withDefault do withNewMCtxDepth do assertDefEqQ (u := u.succ) f q(HMul.hMul)
+  let ra ← core zα pα a; let rb ← core zα pα b
   match ra, rb with
-  | .positive pa, .positive pb =>
-    have pa' : Q(by clear! «$zα» «$pα»; exact 0 < $a) := pa
-    have pb' : Q(by clear! «$zα» «$pα»; exact 0 < $b) := pb
-    pure (.positive (by clear! zα pα; exact q(@mul_pos $α _ _ _ _ _ $pa' $pb') : Expr))
-  | .positive pa, .nonnegative pb =>
-    have pa' : Q(by clear! «$zα» «$pα»; exact 0 < $a) := pa
-    have pb' : Q(by clear! «$zα» «$pα»; exact 0 ≤ $b) := pb
-    pure (.nonnegative (q(mul_nonneg_of_pos_of_nonneg $pa' $pb') : Expr))
-  | .nonnegative pa, .positive pb =>
-    have pa' : Q(by clear! «$zα» «$pα»; exact 0 ≤ $a) := pa
-    have pb' : Q(by clear! «$zα» «$pα»; exact 0 < $b) := pb
-    pure (.nonnegative (q(mul_nonneg_of_nonneg_of_pos $pa' $pb') : Expr))
-  | .nonnegative pa, .nonnegative pb =>
-    have pa' : Q(by clear! «$zα» «$pα»; exact 0 ≤ $a) := pa
-    have pb' : Q(by clear! «$zα» «$pα»; exact 0 ≤ $b) := pb
-    pure (.nonnegative (by clear! zα pα; exact q(mul_nonneg $pa' $pb') : Expr))
+  | .positive pa, .positive pb => return .positive q(mul_pos $pa $pb)
+  | .positive pa, .nonnegative pb => return .nonnegative q(mul_nonneg_of_pos_of_nonneg $pa $pb)
+  | .nonnegative pa, .positive pb => return .nonnegative q(mul_nonneg_of_nonneg_of_pos $pa $pb)
+  | .nonnegative pa, .nonnegative pb => return .nonnegative q(mul_nonneg $pa $pb)
   | .positive pa, .nonzero pb =>
-    have pa' : Q(by clear! «$zα» «$pα»; exact 0 < $a) := pa
-    have pb' : Q(by clear! «$zα»; exact $b ≠ 0) := pb
-    let _a ← synthInstanceQ (q(by clear! «$zα»; exact NoZeroDivisors $α) : Q(Prop))
-    pure (.nonzero (q(mul_ne_zero_of_pos_of_ne_zero $pa' $pb') : Expr))
+    let _a ← synthInstanceQ (q(NoZeroDivisors $α) : Q(Prop))
+    return .nonzero q(mul_ne_zero_of_pos_of_ne_zero $pa $pb)
   | .nonzero pa, .positive pb =>
-    have pa' : Q(by clear! «$zα»; exact $a ≠ 0) := pa
-    have pb' : Q(by clear! «$zα» «$pα»; exact 0 < $b) := pb
-    let _a ← synthInstanceQ (q(by clear! «$zα»; exact NoZeroDivisors $α) : Q(Prop))
-    pure (.nonzero (q(mul_ne_zero_of_ne_zero_of_pos $pa' $pb') : Expr))
+    let _a ← synthInstanceQ (q(NoZeroDivisors $α) : Q(Prop))
+    return .nonzero q(mul_ne_zero_of_ne_zero_of_pos $pa $pb)
   | .nonzero pa, .nonzero pb =>
     let _a ← synthInstanceQ (q(NoZeroDivisors $α) : Q(Prop))
-    pure (.nonzero (q(mul_ne_zero $pa $pb) : Expr))
-  | _, _ => pure .none
+    return .nonzero (q(mul_ne_zero $pa $pb))
+  | _, _ => return .none
 
 
 private lemma int_div_self_pos {a : ℤ} (ha : 0 < a) : 0 < a / a :=
@@ -255,59 +211,38 @@ end LinearOrderedSemifield
 /-- The `positivity` extension which identifies expressions of the form `a / b`,
 such that `positivity` successfully recognises both `a` and `b`. -/
 @[positivity _ / _] def evalDiv : PositivityExt where eval {u α} zα pα e := do
-  let .app (.app f (a : Q($α))) (b : Q($α)) ← withReducible (whnf e) | throwError "not /"
-  let ra ← core zα pα a; let rb ← core zα pα b
+  let .app (.app (f : Q($α → $α → $α)) (a : Q($α))) (b : Q($α)) ← withReducible (whnf e)
+    | throwError "not /"
+  let _e_eq : $e =Q $f $a $b := ⟨⟩
   let _a ← synthInstanceQ (q(LinearOrderedSemifield $α) : Q(Type u))
-  guard <|← withDefault <| withNewMCtxDepth <| isDefEq f q(HDiv.hDiv (α := $α))
+  assertInstancesCommute
+  let ⟨_f_eq⟩ ← withDefault do withNewMCtxDepth do assertDefEqQ (u := u.succ) f q(HDiv.hDiv)
+  let ra ← core zα pα a; let rb ← core zα pα b
   match ra, rb with
-  | .positive pa, .positive pb =>
-    have pa' : Q(by clear! «$zα» «$pα»; exact 0 < $a) := pa
-    have pb' : Q(by clear! «$zα» «$pα»; exact 0 < $b) := pb
-    pure (.positive (q(@div_pos $α _ _ _ $pa' $pb') : Expr))
-  | .positive pa, .nonnegative pb =>
-    have pa' : Q(by clear! «$zα» «$pα»; exact 0 < $a) := pa
-    have pb' : Q(by clear! «$zα» «$pα»; exact 0 ≤ $b) := pb
-    pure (.nonnegative (q(@div_nonneg_of_pos_of_nonneg $α _ _ _ $pa' $pb') : Expr))
-  | .nonnegative pa, .positive pb =>
-    have pa' : Q(by clear! «$zα» «$pα»; exact 0 ≤ $a) := pa
-    have pb' : Q(by clear! «$zα» «$pα»; exact 0 < $b) := pb
-    pure (.nonnegative (q(@div_nonneg_of_nonneg_of_pos $α _ _ _ $pa' $pb') : Expr))
-  | .nonnegative pa, .nonnegative pb =>
-    have pa' : Q(by clear! «$zα» «$pα»; exact 0 ≤ $a) := pa
-    have pb' : Q(by clear! «$zα» «$pα»; exact 0 ≤ $b) := pb
-    pure (.nonnegative (q(@div_nonneg $α _ _ _ $pa' $pb') : Expr))
-  | .positive pa, .nonzero pb =>
-    have pa' : Q(by clear! «$zα» «$pα»; exact 0 < $a) := pa
-    have pb' : Q(by clear! «$zα» «$pα»; exact $b ≠ 0) := pb
-    pure (.nonzero (q(@div_ne_zero_of_pos_of_ne_zero $α _ _ _ $pa' $pb') : Expr))
-  | .nonzero pa, .positive pb =>
-    have pa' : Q(by clear! «$zα» «$pα»; exact $a ≠ 0) := pa
-    have pb' : Q(by clear! «$zα» «$pα»; exact 0 < $b) := pb
-    pure (.nonzero (q(@div_ne_zero_of_ne_zero_of_pos $α _ _ _ $pa' $pb') : Expr))
-  | .nonzero pa, .nonzero pb =>
-    have pa' : Q(by clear! «$zα» «$pα»; exact $a ≠ 0) := pa
-    have pb' : Q(by clear! «$zα» «$pα»; exact $b ≠ 0) := pb
-    pure (.nonzero (q(@div_ne_zero $α _ _ _ $pa' $pb') : Expr))
-  | _, _ => pure .none
+  | .positive pa, .positive pb => return .positive q(div_pos $pa $pb)
+  | .positive pa, .nonnegative pb => return .nonnegative q(div_nonneg_of_pos_of_nonneg $pa $pb)
+  | .nonnegative pa, .positive pb => return .nonnegative q(div_nonneg_of_nonneg_of_pos $pa $pb)
+  | .nonnegative pa, .nonnegative pb => return .nonnegative q(div_nonneg $pa $pb)
+  | .positive pa, .nonzero pb => return .nonzero q(div_ne_zero_of_pos_of_ne_zero $pa $pb)
+  | .nonzero pa, .positive pb => return .nonzero q(div_ne_zero_of_ne_zero_of_pos $pa $pb)
+  | .nonzero pa, .nonzero pb => return .nonzero q(div_ne_zero $pa $pb)
+  | _, _ => return .none
 
 /-- The `positivity` extension which identifies expressions of the form `a⁻¹`,
 such that `positivity` successfully recognises `a`. -/
 @[positivity (_ : α)⁻¹]
 def evalInv : PositivityExt where eval {u α} zα pα e := do
-  let (.app _ (a : Q($α))) ← withReducible (whnf e) | throwError "not ·⁻¹"
+  let .app (f : Q($α → $α)) (a : Q($α)) ← withReducible (whnf e) | throwError "not ⁻¹"
+  let _e_eq : $e =Q $f $a := ⟨⟩
   let _a ← synthInstanceQ (q(LinearOrderedSemifield $α) : Q(Type u))
+  assertInstancesCommute
+  let ⟨_f_eq⟩ ← withDefault do withNewMCtxDepth do assertDefEqQ (u := u.succ) f q(Inv.inv)
   let ra ← core zα pα a
   match ra with
-  | .positive pa =>
-    have pa' : Q(by clear! «$zα» «$pα»; exact 0 < $a) := pa
-    pure (.positive (q(@inv_pos_of_pos $α _ _ $pa') : Expr))
-  | .nonnegative pa =>
-    have pa' : Q(by clear! «$zα» «$pα»; exact 0 ≤ $a) := pa
-    pure (.nonnegative (q(@inv_nonneg_of_nonneg $α _ _ $pa') : Expr))
-  | .nonzero pa =>
-    have pa' : Q(by clear! «$zα» «$pα»; exact $a ≠ 0) := pa
-    pure (.nonzero (q(@inv_ne_zero $α _ _ $pa') : Expr))
-  | .none => pure .none
+  | .positive pa => return .positive q(inv_pos_of_pos $pa)
+  | .nonnegative pa => return .nonnegative q(inv_nonneg_of_nonneg $pa)
+  | .nonzero pa => return .nonzero q(inv_ne_zero $pa)
+  | .none => return .none
 
 private theorem pow_zero_pos [OrderedSemiring α] [Nontrivial α] (a : α) : 0 < a ^ 0 :=
   zero_lt_one.trans_le (pow_zero a).ge

--- a/Mathlib/Tactic/Positivity/Basic.lean
+++ b/Mathlib/Tactic/Positivity/Basic.lean
@@ -43,16 +43,16 @@ such that `positivity` successfully recognises both `a` and `b`. -/
   let _e_eq : $e =Q $f $a $b := ⟨⟩
   let _a ← synthInstanceQ (q(LinearOrder $α) : Q(Type u))
   assertInstancesCommute
-  let ⟨_f_eq⟩ ← withDefault do withNewMCtxDepth do assertDefEqQ (u := u.succ) f q(min)
+  let ⟨_f_eq⟩ ← withDefault <| withNewMCtxDepth <| assertDefEqQ (u := u.succ) f q(min)
   match ← core zα pα a, ← core zα pα b with
-  | .positive pa, .positive pb => return .positive q(lt_min $pa $pb)
-  | .positive pa, .nonnegative pb => return .nonnegative q(le_min_of_lt_of_le $pa $pb)
-  | .nonnegative pa, .positive pb => return .nonnegative q(le_min_of_le_of_lt $pa $pb)
-  | .nonnegative pa, .nonnegative pb => return .nonnegative q(le_min $pa $pb)
-  | .positive pa, .nonzero pb => return .nonzero q(min_ne_of_lt_of_ne $pa $pb)
-  | .nonzero pa, .positive pb => return .nonzero q(min_ne_of_ne_of_lt $pa $pb)
-  | .nonzero pa, .nonzero pb => return .nonzero q(min_ne $pa $pb)
-  | _, _ => return .none
+  | .positive pa, .positive pb => pure (.positive q(lt_min $pa $pb))
+  | .positive pa, .nonnegative pb => pure (.nonnegative q(le_min_of_lt_of_le $pa $pb))
+  | .nonnegative pa, .positive pb => pure (.nonnegative q(le_min_of_le_of_lt $pa $pb))
+  | .nonnegative pa, .nonnegative pb => pure (.nonnegative q(le_min $pa $pb))
+  | .positive pa, .nonzero pb => pure (.nonzero q(min_ne_of_lt_of_ne $pa $pb))
+  | .nonzero pa, .positive pb => pure (.nonzero q(min_ne_of_ne_of_lt $pa $pb))
+  | .nonzero pa, .nonzero pb => pure (.nonzero q(min_ne $pa $pb))
+  | _, _ => pure .none
 
 /-- Extension for the `max` operator. The `max` of two numbers is nonnegative if at least one
 is nonnegative, strictly positive if at least one is positive, and nonzero if both are nonzero. -/
@@ -62,26 +62,26 @@ is nonnegative, strictly positive if at least one is positive, and nonzero if bo
   let _e_eq : $e =Q $f $a $b := ⟨⟩
   let _a ← synthInstanceQ (q(LinearOrder $α) : Q(Type u))
   assertInstancesCommute
-  let ⟨_f_eq⟩ ← withDefault do withNewMCtxDepth do assertDefEqQ (u := u.succ) f q(max)
+  let ⟨_f_eq⟩ ← withDefault <| withNewMCtxDepth <| assertDefEqQ (u := u.succ) f q(max)
   let result : Strictness zα pα e ← catchNone do
     let ra ← core zα pα a
     match ra with
-    | .positive pa => return .positive q(lt_max_of_lt_left $pa)
-    | .nonnegative pa => return .nonnegative q(le_max_of_le_left $pa)
+    | .positive pa => pure (.positive q(lt_max_of_lt_left $pa))
+    | .nonnegative pa => pure (.nonnegative q(le_max_of_le_left $pa))
     -- If `a ≠ 0`, we might prove `max a b ≠ 0` if `b ≠ 0` but we don't want to evaluate
     -- `b` before having ruled out `0 < a`, for performance. So we do that in the second branch
     -- of the `orElse'`.
-    | _ => return .none
+    | _ => pure .none
   orElse result do
     let rb ← core zα pα b
     match rb with
-    | .positive pb => return .positive q(lt_max_of_lt_right $pb)
-    | .nonnegative pb => return .nonnegative q(le_max_of_le_right $pb)
+    | .positive pb => pure (.positive q(lt_max_of_lt_right $pb))
+    | .nonnegative pb => pure (.nonnegative q(le_max_of_le_right $pb))
     | .nonzero pb => do
       match ← core zα pα a with
-      | .nonzero pa => return .nonzero q(max_ne $pa $pb)
-      | _ => return .none
-    | _ => return .none
+      | .nonzero pa => pure (.nonzero q(max_ne $pa $pb))
+      | _ => pure .none
+    | _ => pure .none
 
 /-- The `positivity` extension which identifies expressions of the form `a + b`,
 such that `positivity` successfully recognises both `a` and `b`. -/
@@ -91,21 +91,21 @@ such that `positivity` successfully recognises both `a` and `b`. -/
   let _e_eq : $e =Q $f $a $b := ⟨⟩
   let _a ← synthInstanceQ (q(AddZeroClass $α) : Q(Type u))
   assertInstancesCommute
-  let ⟨_f_eq⟩ ← withDefault do withNewMCtxDepth do assertDefEqQ (u := u.succ) f q(HAdd.hAdd)
+  let ⟨_f_eq⟩ ← withDefault <| withNewMCtxDepth <| assertDefEqQ (u := u.succ) f q(HAdd.hAdd)
   let ra ← core zα pα a; let rb ← core zα pα b
   match ra, rb with
   | .positive pa, .positive pb =>
     let _a ← synthInstanceQ (q(CovariantClass $α $α (·+·) (·<·)) : Q(Prop))
-    return .positive q(add_pos $pa $pb)
+    pure (.positive q(add_pos $pa $pb))
   | .positive pa, .nonnegative pb =>
     let _a ← synthInstanceQ (q(CovariantClass $α $α (swap (·+·)) (·<·)) : Q(Prop))
-    return .positive q(lt_add_of_pos_of_le $pa $pb)
+    pure (.positive q(lt_add_of_pos_of_le $pa $pb))
   | .nonnegative pa, .positive pb =>
     let _a ← synthInstanceQ (q(CovariantClass $α $α (·+·) (·<·)) : Q(Prop))
-    return .positive q(lt_add_of_le_of_pos $pa $pb)
+    pure (.positive q(lt_add_of_le_of_pos $pa $pb))
   | .nonnegative pa, .nonnegative pb =>
     let _a ← synthInstanceQ (q(CovariantClass $α $α (·+·) (·≤·)) : Q(Prop))
-    return .nonnegative q(add_nonneg $pa $pb)
+    pure (.nonnegative q(add_nonneg $pa $pb))
   | _, _ => failure
 
 private theorem mul_nonneg_of_pos_of_nonneg [OrderedSemiring α] {a b : α}
@@ -132,23 +132,23 @@ such that `positivity` successfully recognises both `a` and `b`. -/
   let _e_eq : $e =Q $f $a $b := ⟨⟩
   let _a ← synthInstanceQ (q(StrictOrderedSemiring $α) : Q(Type u))
   assertInstancesCommute
-  let ⟨_f_eq⟩ ← withDefault do withNewMCtxDepth do assertDefEqQ (u := u.succ) f q(HMul.hMul)
+  let ⟨_f_eq⟩ ← withDefault <| withNewMCtxDepth <| assertDefEqQ (u := u.succ) f q(HMul.hMul)
   let ra ← core zα pα a; let rb ← core zα pα b
   match ra, rb with
-  | .positive pa, .positive pb => return .positive q(mul_pos $pa $pb)
-  | .positive pa, .nonnegative pb => return .nonnegative q(mul_nonneg_of_pos_of_nonneg $pa $pb)
-  | .nonnegative pa, .positive pb => return .nonnegative q(mul_nonneg_of_nonneg_of_pos $pa $pb)
-  | .nonnegative pa, .nonnegative pb => return .nonnegative q(mul_nonneg $pa $pb)
+  | .positive pa, .positive pb => pure (.positive q(mul_pos $pa $pb))
+  | .positive pa, .nonnegative pb => pure (.nonnegative q(mul_nonneg_of_pos_of_nonneg $pa $pb))
+  | .nonnegative pa, .positive pb => pure (.nonnegative q(mul_nonneg_of_nonneg_of_pos $pa $pb))
+  | .nonnegative pa, .nonnegative pb => pure (.nonnegative q(mul_nonneg $pa $pb))
   | .positive pa, .nonzero pb =>
     let _a ← synthInstanceQ (q(NoZeroDivisors $α) : Q(Prop))
-    return .nonzero q(mul_ne_zero_of_pos_of_ne_zero $pa $pb)
+    pure (.nonzero q(mul_ne_zero_of_pos_of_ne_zero $pa $pb))
   | .nonzero pa, .positive pb =>
     let _a ← synthInstanceQ (q(NoZeroDivisors $α) : Q(Prop))
-    return .nonzero q(mul_ne_zero_of_ne_zero_of_pos $pa $pb)
+    pure (.nonzero q(mul_ne_zero_of_ne_zero_of_pos $pa $pb))
   | .nonzero pa, .nonzero pb =>
     let _a ← synthInstanceQ (q(NoZeroDivisors $α) : Q(Prop))
-    return .nonzero (q(mul_ne_zero $pa $pb))
-  | _, _ => return .none
+    pure (.nonzero (q(mul_ne_zero $pa $pb)))
+  | _, _ => pure .none
 
 
 private lemma int_div_self_pos {a : ℤ} (ha : 0 < a) : 0 < a / a :=
@@ -216,17 +216,17 @@ such that `positivity` successfully recognises both `a` and `b`. -/
   let _e_eq : $e =Q $f $a $b := ⟨⟩
   let _a ← synthInstanceQ (q(LinearOrderedSemifield $α) : Q(Type u))
   assertInstancesCommute
-  let ⟨_f_eq⟩ ← withDefault do withNewMCtxDepth do assertDefEqQ (u := u.succ) f q(HDiv.hDiv)
+  let ⟨_f_eq⟩ ← withDefault <| withNewMCtxDepth <| assertDefEqQ (u := u.succ) f q(HDiv.hDiv)
   let ra ← core zα pα a; let rb ← core zα pα b
   match ra, rb with
-  | .positive pa, .positive pb => return .positive q(div_pos $pa $pb)
-  | .positive pa, .nonnegative pb => return .nonnegative q(div_nonneg_of_pos_of_nonneg $pa $pb)
-  | .nonnegative pa, .positive pb => return .nonnegative q(div_nonneg_of_nonneg_of_pos $pa $pb)
-  | .nonnegative pa, .nonnegative pb => return .nonnegative q(div_nonneg $pa $pb)
-  | .positive pa, .nonzero pb => return .nonzero q(div_ne_zero_of_pos_of_ne_zero $pa $pb)
-  | .nonzero pa, .positive pb => return .nonzero q(div_ne_zero_of_ne_zero_of_pos $pa $pb)
-  | .nonzero pa, .nonzero pb => return .nonzero q(div_ne_zero $pa $pb)
-  | _, _ => return .none
+  | .positive pa, .positive pb => pure (.positive q(div_pos $pa $pb))
+  | .positive pa, .nonnegative pb => pure (.nonnegative q(div_nonneg_of_pos_of_nonneg $pa $pb))
+  | .nonnegative pa, .positive pb => pure (.nonnegative q(div_nonneg_of_nonneg_of_pos $pa $pb))
+  | .nonnegative pa, .nonnegative pb => pure (.nonnegative q(div_nonneg $pa $pb))
+  | .positive pa, .nonzero pb => pure (.nonzero q(div_ne_zero_of_pos_of_ne_zero $pa $pb))
+  | .nonzero pa, .positive pb => pure (.nonzero q(div_ne_zero_of_ne_zero_of_pos $pa $pb))
+  | .nonzero pa, .nonzero pb => pure (.nonzero q(div_ne_zero $pa $pb))
+  | _, _ => pure .none
 
 /-- The `positivity` extension which identifies expressions of the form `a⁻¹`,
 such that `positivity` successfully recognises `a`. -/
@@ -236,13 +236,13 @@ def evalInv : PositivityExt where eval {u α} zα pα e := do
   let _e_eq : $e =Q $f $a := ⟨⟩
   let _a ← synthInstanceQ (q(LinearOrderedSemifield $α) : Q(Type u))
   assertInstancesCommute
-  let ⟨_f_eq⟩ ← withDefault do withNewMCtxDepth do assertDefEqQ (u := u.succ) f q(Inv.inv)
+  let ⟨_f_eq⟩ ← withDefault <| withNewMCtxDepth <| assertDefEqQ (u := u.succ) f q(Inv.inv)
   let ra ← core zα pα a
   match ra with
-  | .positive pa => return .positive q(inv_pos_of_pos $pa)
-  | .nonnegative pa => return .nonnegative q(inv_nonneg_of_nonneg $pa)
-  | .nonzero pa => return .nonzero q(inv_ne_zero $pa)
-  | .none => return .none
+  | .positive pa => pure (.positive q(inv_pos_of_pos $pa))
+  | .nonnegative pa => pure (.nonnegative q(inv_nonneg_of_nonneg $pa))
+  | .nonzero pa => pure (.nonzero q(inv_ne_zero $pa))
+  | .none => pure .none
 
 private theorem pow_zero_pos [OrderedSemiring α] [Nontrivial α] (a : α) : 0 < a ^ 0 :=
   zero_lt_one.trans_le (pow_zero a).ge

--- a/Mathlib/Tactic/Positivity/Core.lean
+++ b/Mathlib/Tactic/Positivity/Core.lean
@@ -9,7 +9,7 @@ import Mathlib.Tactic.Clear!
 import Mathlib.Order.Basic
 import Mathlib.Algebra.Order.Ring.Defs
 import Mathlib.Data.Nat.Cast.Basic
-import Qq.Match
+import Qq
 
 /-!
 ## `positivity` core functionality
@@ -145,19 +145,22 @@ def throwNone [Monad m] [Alternative m]
 def normNumPositivity (e : Q($α)) : MetaM (Strictness zα pα e) := catchNone do
   match ← NormNum.derive e with
   | .isBool .. => failure
-  | .isNat i lit p =>
+  | .isNat _ lit p =>
     if 0 < lit.natLit! then
       let _a ← synthInstanceQ (q(StrictOrderedSemiring $α) : Q(Type u))
-      have p : Q(by clear! «$i»; exact NormNum.IsNat $e $lit) := p
+      assertInstancesCommute
+      have p : Q(NormNum.IsNat $e $lit) := p
       let p' : Q(Nat.ble 1 $lit = true) := (q(Eq.refl true) : Expr)
       pure (.positive (q(@pos_of_isNat $α _ _ _ $p $p') : Expr))
     else
       let _a ← synthInstanceQ (q(OrderedSemiring $α) : Q(Type u))
-      have p : Q(by clear! «$i»; exact NormNum.IsNat $e $lit) := p
+      assertInstancesCommute
+      have p : Q(NormNum.IsNat $e $lit) := p
       pure (.nonnegative (q(nonneg_of_isNat $p) : Expr))
-  | .isNegNat i lit p =>
+  | .isNegNat _ lit p =>
     let _a ← synthInstanceQ (q(StrictOrderedRing $α) : Q(Type u))
-    have p : Q(by clear! «$i»; exact NormNum.IsInt $e (Int.negOfNat $lit)) := p
+    assertInstancesCommute
+    have p : Q(NormNum.IsInt $e (Int.negOfNat $lit)) := p
     let p' : Q(Nat.ble 1 $lit = true) := (q(Eq.refl true) : Expr)
     pure (.nonzero (q(nz_of_isNegNat $p $p') : Expr))
   | .isRat _ .. => throwError "isRat" -- TODO

--- a/Mathlib/Tactic/Ring/Basic.lean
+++ b/Mathlib/Tactic/Ring/Basic.lean
@@ -850,12 +850,12 @@ theorem cast_rat {R} [DivisionRing R] {a : R} : IsRat a n d → a = Rat.rawCast 
 * `e = Rat.rawCast n d + 0` if `norm_num` returns `IsRat e n d`
 -/
 def evalCast : NormNum.Result e → Option (Result (ExSum sα) e)
-  | .isNat _sα (.lit (.natVal 0)) (p : Expr) => clear% _sα
-    let p : Q(IsNat $e (nat_lit 0)) := p
-    pure ⟨_, .zero, (q(cast_zero $p) : Expr)⟩
-  | .isNat _sα lit (p : Expr) => clear% _sα
-    let p : Q(IsNat $e $lit) := p
-    pure ⟨_, (ExProd.mkNat sα lit.natLit!).2.toSum, (q(cast_pos $p) : Expr)⟩
+  | .isNat sα' (.lit (.natVal 0)) p =>
+    have _assume_defeq : QE (u := u.succ) sα' q(AddCommMonoidWithOne.toAddMonoidWithOne) := ⟨⟩
+    pure ⟨_, .zero, q(cast_zero $p)⟩
+  | .isNat sα' lit p =>
+    have _assume_defeq : QE (u := u.succ) sα' q(AddCommMonoidWithOne.toAddMonoidWithOne) := ⟨⟩
+    pure ⟨_, (ExProd.mkNat sα lit.natLit!).2.toSum, (q(cast_pos $p) :)⟩
   | .isNegNat rα lit p =>
     pure ⟨_, (ExProd.mkNegNat _ rα lit.natLit!).2.toSum, (q(cast_neg $p) : Expr)⟩
   | .isRat dα q n d p =>

--- a/Mathlib/Tactic/TFAE.lean
+++ b/Mathlib/Tactic/TFAE.lean
@@ -7,7 +7,7 @@ import Lean
 import Mathlib.Tactic.Have
 import Mathlib.Tactic.SolveByElim
 import Mathlib.Data.List.TFAE
-import Qq.Match
+import Qq
 
 /-!
 # The Following Are Equivalent (TFAE)
@@ -152,9 +152,9 @@ def proveTFAE (l : Q(List Prop)) : TacticM Q(TFAE $l) := do
   match l with
   | ~q([]) => return q(tfae_nil)
   | ~q([$P]) => return q(tfae_singleton $P)
-  | ~q($P :: $P' :: $l) =>
-    let c ← proveChain P q($P' :: $l)
-    let il ← proveILast'Impl P P' l
+  | ~q($P :: $P' :: $l') =>
+    let c ← proveChain P q($P' :: $l')
+    let il ← proveILast'Impl P P' l'
     return q(tfae_of_cycle $c $il)
 
 /-! # `tfae_have` components -/

--- a/Mathlib/Tactic/Tauto.lean
+++ b/Mathlib/Tactic/Tauto.lean
@@ -12,7 +12,7 @@ import Mathlib.Tactic.CasesM
 import Mathlib.Tactic.Classical
 import Mathlib.Tactic.Core
 import Mathlib.Tactic.SolveByElim
-import Qq.Match
+import Qq
 
 /-!
 The `tauto` tactic.

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -4,7 +4,7 @@
  [{"git":
    {"url": "https://github.com/gebner/quote4",
     "subDir?": null,
-    "rev": "7ac99aa3fac487bec1d5860e751b99c7418298cf",
+    "rev": "2412c4fdf4a8b689f4467618e5e7b371ae5014aa",
     "name": "Qq",
     "inputRev?": "master"}},
   {"git":


### PR DESCRIPTION
The latest version of `quote4` adds a new `=Q` type, which allows you to state that two quoted terms are definitionally equal.  When unquoting (i.e., going inside the `q()`), it will try to turn this assumption into a let-binding to make the two sides defeq.

You'd typically use this for type class instances:
```lean
u : Level
R : Q(Type $u)
inst1 : Q(Ring $R)
inst2 : Q(DivisionRing $R)
heq : $inst1 =Q DivisionRing.toRing
```
Turns into the following after unquoting:
```lean
R : Type u
inst2 : DivisionRing R
inst1 : Ring R := DivisionRing.toRing
heq : inst1 = DivisionRing.toRing
```

As a goodie, there is also a `assertInstancesCommute` macro that automatically adds all of these `=Q` assumptions (requires `MetaM`).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
