### PR TITLE
[Merged by Bors] - chore: fix some bad names generated by to_additive

### DIFF
--- a/Mathlib/GroupTheory/Subgroup/Finite.lean
+++ b/Mathlib/GroupTheory/Subgroup/Finite.lean
@@ -158,20 +158,20 @@ theorem eq_bot_of_card_eq [Fintype H] (h : Fintype.card H = 1) : H = ⊥ :=
 #align subgroup.eq_bot_of_card_eq Subgroup.eq_bot_of_card_eq
 #align add_subgroup.eq_bot_of_card_eq AddSubgroup.eq_bot_of_card_eq
 
-@[to_additive]
+@[to_additive card_le_one_iff_eq_bot]
 theorem card_le_one_iff_eq_bot [Fintype H] : Fintype.card H ≤ 1 ↔ H = ⊥ :=
   ⟨fun h =>
     (eq_bot_iff_forall _).2 fun x hx => by
       simpa [Subtype.ext_iff] using Fintype.card_le_one_iff.1 h ⟨x, hx⟩ 1,
     fun h => by simp [h]⟩
 #align subgroup.card_le_one_iff_eq_bot Subgroup.card_le_one_iff_eq_bot
-#align add_subgroup.card_nonpos_iff_eq_bot AddSubgroup.card_nonpos_iff_eq_bot
+#align add_subgroup.card_nonpos_iff_eq_bot AddSubgroup.card_le_one_iff_eq_bot
 
-@[to_additive]
+@[to_additive one_lt_card_iff_ne_bot]
 theorem one_lt_card_iff_ne_bot [Fintype H] : 1 < Fintype.card H ↔ H ≠ ⊥ :=
   lt_iff_not_le.trans H.card_le_one_iff_eq_bot.not
 #align subgroup.one_lt_card_iff_ne_bot Subgroup.one_lt_card_iff_ne_bot
-#align add_subgroup.pos_card_iff_ne_bot AddSubgroup.pos_card_iff_ne_bot
+#align add_subgroup.pos_card_iff_ne_bot AddSubgroup.one_lt_card_iff_ne_bot
 
 end Subgroup
 


### PR DESCRIPTION
These were noticed back in https://github.com/leanprover-community/mathlib/issues/9945 but never fixed. It seems unlikely that we're ever going to make `to_additive` smart enough to cope here by itself.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
