### PR TITLE
[Merged by Bors] - fix: `fix-comments.py` uses wrong encoding on Windows

### DIFF
--- a/scripts/fix-comments.py
+++ b/scripts/fix-comments.py
@@ -41,7 +41,7 @@ align_files = subprocess.run(
 
 name_map = dict()
 for f in align_files.stdout.splitlines():
-    with open(os.path.join(root_dir, f)) as fh:
+    with open(os.path.join(root_dir, f), encoding="utf-8", newline='\n') as fh:
         contents = fh.read()
         for p in contents.split(sep='\n#align')[1:]:
             n3, n4, *_ = p.split(maxsplit=2)
@@ -84,7 +84,7 @@ def finish_comment():
         in_line_comment = False
         comment_so_far = None
 
-with open(leanfile) as F:
+with open(leanfile, encoding="utf-8", newline='\n') as F:
     while 1:
         char = F.read(1)
         if not char:

--- a/scripts/fix-comments.py
+++ b/scripts/fix-comments.py
@@ -41,7 +41,7 @@ align_files = subprocess.run(
 
 name_map = dict()
 for f in align_files.stdout.splitlines():
-    with open(os.path.join(root_dir, f), encoding="utf-8", newline='\n') as fh:
+    with open(os.path.join(root_dir, f), encoding="utf-8") as fh:
         contents = fh.read()
         for p in contents.split(sep='\n#align')[1:]:
             n3, n4, *_ = p.split(maxsplit=2)
@@ -84,7 +84,7 @@ def finish_comment():
         in_line_comment = False
         comment_so_far = None
 
-with open(leanfile, encoding="utf-8", newline='\n') as F:
+with open(leanfile, encoding="utf-8") as F:
     while 1:
         char = F.read(1)
         if not char:


### PR DESCRIPTION
Another issue is that it writes the output with CRLF newlines. I tried to fix it but failed.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
