### PR TITLE
[Merged by Bors] - feat: reassoc_of term elaborator

### DIFF
--- a/Mathlib/Tactic/Reassoc.lean
+++ b/Mathlib/Tactic/Reassoc.lean
@@ -81,8 +81,8 @@ initialize registerBuiltinAttribute {
     _ ← Term.TermElabM.run' <| ToAdditive.applyAttributes ref stx `reassoc src tgt
   | _ => throwUnsupportedSyntax }
 
-open Elab Term in
-elab "reassoc_of% " t:term : term <= _expectedType => do
+open Term in
+elab "reassoc_of% " t:term : term => do
   reassocExpr (← elabTerm t none)
 
 end CategoryTheory

--- a/Mathlib/Tactic/Reassoc.lean
+++ b/Mathlib/Tactic/Reassoc.lean
@@ -81,4 +81,8 @@ initialize registerBuiltinAttribute {
     _ ← Term.TermElabM.run' <| ToAdditive.applyAttributes ref stx `reassoc src tgt
   | _ => throwUnsupportedSyntax }
 
+open Elab Term in
+elab "reassoc_of% " t:term : term <= _expectedType => do
+  reassocExpr (← elabTerm t none)
+
 end CategoryTheory

--- a/Mathlib/Tactic/Reassoc.lean
+++ b/Mathlib/Tactic/Reassoc.lean
@@ -18,6 +18,8 @@ but with the conclusions simplified used the axioms for a category
 
 This is useful for generating lemmas which the simplifier can use even on expressions
 that are already right associated.
+
+There is also a term elaborator `reassoc_of% t` for use within proofs.
 -/
 
 open Lean Meta Elab Tactic
@@ -82,6 +84,12 @@ initialize registerBuiltinAttribute {
   | _ => throwUnsupportedSyntax }
 
 open Term in
+/--
+`reassoc_of% t`, where `t` is
+an equation `f = g` between morphisms `X ⟶ Y` in a category (possibly after a `∀` binder),
+produce the equation `∀ {Z} (h : Y ⟶ Z), f ≫ h = g ≫ h`,
+but with compositions fully right associated and identities removed.
+-/
 elab "reassoc_of% " t:term : term => do
   reassocExpr (← elabTerm t none)
 


### PR DESCRIPTION
As requested on [zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/reassoc_of).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
