### PR TITLE
chore: make `awk` optional in the start-port script.

### DIFF
--- a/scripts/start_port.sh
+++ b/scripts/start_port.sh
@@ -68,8 +68,10 @@ echo "Applying automated fixes"
     sed -i '/^import/{s/[.]Gcd/.GCD/g; s/[.]Modeq/.ModEq/g; s/[.]Nary/.NAry/g; s/[.]Peq/.PEq/g; s/[.]Pfun/.PFun/g; s/[.]Pnat/.PNat/g; s/[.]Smul/.SMul/g; s/[.]Zmod/.ZMod/g}' "$mathlib4_path"
 
     # awk script taken from https://github.com/leanprover-community/mathlib4/pull/1523
-    awk '{do {{if (match($0, "^  by$") && length(p) < 98 && (!(match(p, "^[ \t]*--.*$")))) {p=p " by";} else {if (NR!=1) {print p}; p=$0}}} while (getline == 1) if (getline==0) print p}' "$mathlib4_path" > "$mathlib4_path.tmp"
-    mv "$mathlib4_path.tmp" "$mathlib4_path"
+    (
+        awk '{do {{if (match($0, "^  by$") && length(p) < 98 && (!(match(p, "^[ \t]*--.*$")))) {p=p " by";} else {if (NR!=1) {print p}; p=$0}}} while (getline == 1) if (getline==0) print p}' "$mathlib4_path" > "$mathlib4_path.tmp" &&
+        mv "$mathlib4_path.tmp" "$mathlib4_path"
+    ) || (echo "Warning: You have the wrong 'awk' version! Could not search for line-breaks in ':= by'.")
 
     (echo "import $mathlib4_mod" ; cat Mathlib.lean) | LC_ALL=C sort | uniq > Mathlib.lean.tmp
     mv -f Mathlib.lean.tmp Mathlib.lean


### PR DESCRIPTION
The only use of `awk` in `scripts/start_port.sh` is to remove newlines between `:= by`.

Since this can always be fixed manually or using the script  at any later point, having the wrong version of `awk` should not prevent a user from using the start-port script.

### Current behaviour:
I have mawk installed and get 

```
awk: line 1: syntax error at or near if
awk: line 1: syntax error at or near }
```

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
