### PR TITLE
[Merged by Bors] - refactor: Change the definition of `Num.ofNat'`

### DIFF
--- a/Mathlib/Data/Num/Basic.lean
+++ b/Mathlib/Data/Num/Basic.lean
@@ -9,7 +9,7 @@ Authors: Leonardo de Moura, Mario Carneiro
 ! if you have ported upstream changes.
 -/
 import Mathlib.Mathport.Rename
-import Mathlib.Init.Data.Nat.Lemmas
+import Mathlib.Init.Data.Nat.Bitwise
 import Mathlib.Init.Data.Int.Basic
 import Lean.Linter.Deprecated
 /-!
@@ -328,12 +328,8 @@ def toZNumNeg : Num → ZNum
 #align num.to_znum_neg Num.toZNumNeg
 
 /-- Converts a `Nat` to a `Num`. -/
-def ofNat' : ℕ → Num
-  | 0 => 0
-  | n + 1 => if (n + 1) % 2 = 0
-    then Num.bit0 (ofNat' ((n + 1) / 2))
-    else Num.bit1 (ofNat' ((n + 1) / 2))
-decreasing_by (exact Nat.div_lt_self (Nat.succ_pos n) (Nat.le_refl 2))
+def ofNat' : ℕ → Num :=
+  Nat.binaryRec 0 (fun b _ => cond b Num.bit1 Num.bit0)
 #align num.of_nat' Num.ofNat'
 
 end Num


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

This PR changes the definition of `Num.ofNat'`. This definition was different from Lean3's one because `Nat.binaryRec` had not ported yet.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
