### PR TITLE
[Merged by Bors] - refactor: Add a new theorem for `PosNum.shiftl`

### DIFF
--- a/Mathlib/Data/Num/Bitwise.lean
+++ b/Mathlib/Data/Num/Bitwise.lean
@@ -101,7 +101,7 @@ def oneBits : PosNum → Nat → List Nat
 /-- Left-shift the binary representation of a `PosNum`. -/
 def shiftl : PosNum → Nat → PosNum
   | p, 0 => p
-  | p, n + 1 => shiftl p.bit0 n
+  | p, n + 1 => bit0 (shiftl p n)
 #align pos_num.shiftl PosNum.shiftl
 
 /-- Right-shift the binary representation of a `PosNum`. -/

--- a/Mathlib/Data/Num/Bitwise.lean
+++ b/Mathlib/Data/Num/Bitwise.lean
@@ -101,8 +101,14 @@ def oneBits : PosNum → Nat → List Nat
 /-- Left-shift the binary representation of a `PosNum`. -/
 def shiftl : PosNum → Nat → PosNum
   | p, 0 => p
-  | p, n + 1 => bit0 (shiftl p n)
+  | p, n + 1 => shiftl p.bit0 n
 #align pos_num.shiftl PosNum.shiftl
+
+-- Porting note: `PosNum.shiftl` is defined as tail-recursive in Lean4.
+--               This theorem ensures the definition is same to one in Lean3.
+theorem shiftl_succ_eq_bit0_shiftl : ∀ (p : PosNum) (n : Nat), shiftl p n.succ = bit0 (shiftl p n)
+  | _, 0       => rfl
+  | p, .succ n => shiftl_succ_eq_bit0_shiftl p.bit0 n
 
 /-- Right-shift the binary representation of a `PosNum`. -/
 def shiftr : PosNum → Nat → Num


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

This PR adds an new theorem which ensures the old definition of `PosNum.shiftl` and the new one is the same.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
