### PR TITLE
fix: make `awk` script posix-compatible

### DIFF
--- a/scripts/start_port.sh
+++ b/scripts/start_port.sh
@@ -68,7 +68,20 @@ echo "Applying automated fixes"
     sed -i '/^import/{s/[.]Gcd/.GCD/g; s/[.]Modeq/.ModEq/g; s/[.]Nary/.NAry/g; s/[.]Peq/.PEq/g; s/[.]Pfun/.PFun/g; s/[.]Pnat/.PNat/g; s/[.]Smul/.SMul/g; s/[.]Zmod/.ZMod/g}' "$mathlib4_path"
 
     # awk script taken from https://github.com/leanprover-community/mathlib4/pull/1523
-    awk '{do {{if (match($0, "^  by$") && length(p) < 98 && (!(match(p, "^[ \t]*--.*$")))) {p=p " by";} else {if (NR!=1) {print p}; p=$0}}} while (getline == 1); if (getline==0) print p}' "$mathlib4_path" > "$mathlib4_path.tmp"
+    # unicode locale and 'gawk' are necessary to calculate line-length correctly.
+    LC_ALL=en_US.UTF-8 gawk '
+{
+    do {
+        if (match($0, "^  by$") && length(p) < 98 && (!(match(p, "^[ \t]*--.*$")))) {
+            p=p " by";
+        } else {
+            if (NR!=1) {print p};
+            p=$0
+        }
+    } while (getline == 1);
+    if (getline==0) print p
+}' "$mathlib4_path" > "$mathlib4_path.tmp"
+
     mv "$mathlib4_path.tmp" "$mathlib4_path"
 
     (echo "import $mathlib4_mod" ; cat Mathlib.lean) | LC_ALL=C sort | uniq > Mathlib.lean.tmp

--- a/scripts/start_port.sh
+++ b/scripts/start_port.sh
@@ -68,7 +68,7 @@ echo "Applying automated fixes"
     sed -i '/^import/{s/[.]Gcd/.GCD/g; s/[.]Modeq/.ModEq/g; s/[.]Nary/.NAry/g; s/[.]Peq/.PEq/g; s/[.]Pfun/.PFun/g; s/[.]Pnat/.PNat/g; s/[.]Smul/.SMul/g; s/[.]Zmod/.ZMod/g}' "$mathlib4_path"
 
     # awk script taken from https://github.com/leanprover-community/mathlib4/pull/1523
-    awk '{do {{if (match($0, "^  by$") && length(p) < 98 && (!(match(p, "^[ \t]*--.*$")))) {p=p " by";} else {if (NR!=1) {print p}; p=$0}}} while (getline == 1) if (getline==0) print p}' "$mathlib4_path" > "$mathlib4_path.tmp"
+    awk '{do {{if (match($0, "^  by$") && length(p) < 98 && (!(match(p, "^[ \t]*--.*$")))) {p=p " by";} else {if (NR!=1) {print p}; p=$0}}} while (getline == 1); if (getline==0) print p}' "$mathlib4_path" > "$mathlib4_path.tmp"
     mv "$mathlib4_path.tmp" "$mathlib4_path"
 
     (echo "import $mathlib4_mod" ; cat Mathlib.lean) | LC_ALL=C sort | uniq > Mathlib.lean.tmp


### PR DESCRIPTION
## test plan
The following command is run for every test:
```
$ ./scripts/start_port.sh Mathlib/Algebra/Module/LocalizedModule.lean
Checking out a new branch in a temporary working tree
Downloading latest version from mathlib3port
Applying automated fixes
Successfully created initial commits:
* 95066ca4 automated fixes
* 1deb6079 Initial file copy from mathport
* 99dc7f4a feat: port Algebra.Module.LocalizedModule

Checking out a new port/Algebra.Module.LocalizedModule branch from 95066ca4bf3b59b4fcbbf466f938d7ffc23eeec0
branchless: processing 1 update: branch port/Algebra.Module.LocalizedModule
Switched to a new branch 'port/Algebra.Module.LocalizedModule'
branchless: processing checkout
After pushing, you can open a PR at:
https://github.com/leanprover-community/mathlib4/compare/port/Algebra.Module.LocalizedModule?expand=1&title=feat:+port+Algebra.Module.LocalizedModule&labels=mathlib-port
```

### default behaviour:
using `gawk`:
```
$ sha256sum Mathlib/Algebra/Module/LocalizedModule.lean
ed1bc9d4a48c344d38117fdd470ac216abf4bd6dab6445f224a70b9662b560ee  Mathlib/Algebra/Module/LocalizedModule.lean
```
fails for others.

### Including these changes
 using `gawk`:
```
$ sha256sum Mathlib/Algebra/Module/LocalizedModule.lean
ed1bc9d4a48c344d38117fdd470ac216abf4bd6dab6445f224a70b9662b560ee  Mathlib/Algebra/Module/LocalizedModule.lean
```

using `mawk`
```
$ sha256sum Mathlib/Algebra/Module/LocalizedModule.lean
b99df47cfc1872c278d7f5ce9fdd0e3ac30d5f7c791edb4ac33d16a4edc8189a  Mathlib/Algebra/Module/LocalizedModule.lean
````
uh-oh... this appears to be because `mawk` does not support unicode, in particular it calculates line-length slightly too conservatively:
```
git diff changes_with_gawk..changes_with_mawk Mathlib/Algebra/Module/LocalizedModule.lean
diff --git a/Mathlib/Algebra/Module/LocalizedModule.lean b/Mathlib/Algebra/Module/LocalizedModule.lean
index b4c5d7b1..c8054848 100644
--- a/Mathlib/Algebra/Module/LocalizedModule.lean
+++ b/Mathlib/Algebra/Module/LocalizedModule.lean
@@ -976,13 +976,15 @@ theorem mk'_cancel' (m : M) (s : S) : s • mk' f m s = f m := by
 #align is_localized_module.mk'_cancel' IsLocalizedModule.mk'_cancel'
 
 @[simp]
-theorem mk'_cancel_left (m : M) (s₁ s₂ : S) : mk' f (s₁ • m) (s₁ * s₂) = mk' f m s₂ := by
+theorem mk'_cancel_left (m : M) (s₁ s₂ : S) : mk' f (s₁ • m) (s₁ * s₂) = mk' f m s₂ :=
+  by
   delta mk'
   rw [LocalizedModule.mk_cancel_common_left]
 #align is_localized_module.mk'_cancel_left IsLocalizedModule.mk'_cancel_left
 
 @[simp]
-theorem mk'_cancel_right (m : M) (s₁ s₂ : S) : mk' f (s₂ • m) (s₁ * s₂) = mk' f m s₁ := by
+theorem mk'_cancel_right (m : M) (s₁ s₂ : S) : mk' f (s₂ • m) (s₁ * s₂) = mk' f m s₁ :=
+  by
   delta mk'
   rw [LocalizedModule.mk_cancel_common_right]
 #align is_localized_module.mk'_cancel_right IsLocalizedModule.mk'_cancel_right
```
there isn't too much of a change though, so I think this is better than failure.

macOS awk has the same behaviour as mawk, except this script doesn't even work on macOS because its `sed` fails.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
