### PR TITLE
[Merged by Bors] - feat: port CategoryTheory.Limits.Opposites

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -324,6 +324,7 @@ import Mathlib.CategoryTheory.Limits.FunctorCategory
 import Mathlib.CategoryTheory.Limits.HasLimits
 import Mathlib.CategoryTheory.Limits.IsLimit
 import Mathlib.CategoryTheory.Limits.KanExtension
+import Mathlib.CategoryTheory.Limits.Opposites
 import Mathlib.CategoryTheory.Limits.Preserves.Basic
 import Mathlib.CategoryTheory.Limits.Preserves.Filtered
 import Mathlib.CategoryTheory.Limits.Preserves.Finite

--- a/Mathlib/CategoryTheory/Limits/Constructions/FiniteProductsOfBinaryProducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Constructions/FiniteProductsOfBinaryProducts.lean
@@ -42,7 +42,7 @@ variable {C : Type u} [Category.{v} C]
 variable {D : Type u'} [Category.{v'} D]
 
 /--
-Given `n+1` objects of `C`, a fan for the last `n` with point `c₁.pt` and 
+Given `n+1` objects of `C`, a fan for the last `n` with point `c₁.pt` and
 a binary fan on `c₁.pt` and `f 0`, we can build a fan for all `n+1`.
 
 In `extendFanIsLimit` we show that if the two given fans are limits, then this fan is also a
@@ -63,7 +63,7 @@ def extendFan {n : ℕ} {f : Fin (n + 1) → C} (c₁ : Fan fun i : Fin n => f i
 limit.
 -/
 def extendFanIsLimit {n : ℕ} (f : Fin (n + 1) → C) {c₁ : Fan fun i : Fin n => f i.succ}
-    {c₂ : BinaryFan (f 0) c₁.pt} (t₁ : IsLimit c₁) (t₂ : IsLimit c₂) : IsLimit (extendFan c₁ c₂) 
+    {c₂ : BinaryFan (f 0) c₁.pt} (t₁ : IsLimit c₁) (t₂ : IsLimit c₂) : IsLimit (extendFan c₁ c₂)
     where
   lift s := by
     apply (BinaryFan.IsLimit.lift' t₂ (s.π.app ⟨0⟩) _).1
@@ -101,7 +101,7 @@ than this.
 private theorem hasProduct_fin : ∀ (n : ℕ) (f : Fin n → C), HasProduct f
   | 0 => fun f => by
     letI : HasLimitsOfShape (Discrete (Fin 0)) C :=
-      hasLimitsOfShapeOfEquivalence (Discrete.equivalence.{0} finZeroEquiv'.symm)
+      hasLimitsOfShape_of_equivalence (Discrete.equivalence.{0} finZeroEquiv'.symm)
     infer_instance
   | n + 1 => fun f => by
     haveI := hasProduct_fin n
@@ -152,10 +152,10 @@ noncomputable def preservesFinOfPreservesBinaryAndTerminal :
     rintro ⟨j⟩
     refine' Fin.inductionOn j ?_ ?_
     · apply (Category.id_comp _).symm
-    · rintro i _ 
+    · rintro i _
       dsimp [extendFan_π_app, Iso.refl_hom, Fan.mk_π]
       rw [Fin.cases_succ, Fin.cases_succ]
-      change F.map _ ≫ _ = 𝟙 _ ≫ _ 
+      change F.map _ ≫ _ = 𝟙 _ ≫ _
       simp only [id_comp, ← F.map_comp]
       rfl
 #align category_theory.preserves_fin_of_preserves_binary_and_terminal CategoryTheory.preservesFinOfPreservesBinaryAndTerminalₓ -- Porting note: order of universes changed
@@ -164,7 +164,7 @@ noncomputable def preservesFinOfPreservesBinaryAndTerminal :
 `Discrete (Fin n)`.
 -/
 def preservesShapeFinOfPreservesBinaryAndTerminal (n : ℕ) :
-    PreservesLimitsOfShape (Discrete (Fin n)) F where 
+    PreservesLimitsOfShape (Discrete (Fin n)) F where
   preservesLimit {K} := by
     let that : (Discrete.functor fun n => K.obj ⟨n⟩) ≅ K := Discrete.natIso fun ⟨i⟩ => Iso.refl _
     haveI := preservesFinOfPreservesBinaryAndTerminal F n fun n => K.obj ⟨n⟩
@@ -306,7 +306,7 @@ noncomputable def preservesFinOfPreservesBinaryAndInitial :
 `Discrete (Fin n)`.
 -/
 def preservesShapeFinOfPreservesBinaryAndInitial (n : ℕ) :
-    PreservesColimitsOfShape (Discrete (Fin n)) F where 
+    PreservesColimitsOfShape (Discrete (Fin n)) F where
   preservesColimit {K} := by
     let that : (Discrete.functor fun n => K.obj ⟨n⟩) ≅ K := Discrete.natIso fun ⟨i⟩ => Iso.refl _
     haveI := preservesFinOfPreservesBinaryAndInitial F n fun n => K.obj ⟨n⟩
@@ -325,4 +325,3 @@ def preservesFiniteCoproductsOfPreservesBinaryAndInitial (J : Type) [Fintype J] 
 end Preserves
 
 end CategoryTheory
-

--- a/Mathlib/CategoryTheory/Limits/EssentiallySmall.lean
+++ b/Mathlib/CategoryTheory/Limits/EssentiallySmall.lean
@@ -31,7 +31,7 @@ variable (J : Type u₂) [Category.{v₂} J] (C : Type u₁) [Category.{v₁} C]
 
 theorem hasLimitsOfShape_of_essentiallySmall [EssentiallySmall.{w₁} J]
     [HasLimitsOfSize.{w₁, w₁} C] : HasLimitsOfShape J C :=
-  hasLimitsOfShapeOfEquivalence <| Equivalence.symm <| equivSmallModel.{w₁} J
+  hasLimitsOfShape_of_equivalence <| Equivalence.symm <| equivSmallModel.{w₁} J
 #align category_theory.limits.has_limits_of_shape_of_essentially_small CategoryTheory.Limits.hasLimitsOfShape_of_essentiallySmall
 
 theorem hasColimitsOfShape_of_essentiallySmall [EssentiallySmall.{w₁} J]
@@ -41,7 +41,7 @@ theorem hasColimitsOfShape_of_essentiallySmall [EssentiallySmall.{w₁} J]
 
 theorem hasProductsOfShape_of_small (β : Type w₂) [Small.{w₁} β] [HasProducts.{w₁} C] :
     HasProductsOfShape β C :=
-  hasLimitsOfShapeOfEquivalence <| Discrete.equivalence <| Equiv.symm <| equivShrink β
+  hasLimitsOfShape_of_equivalence <| Discrete.equivalence <| Equiv.symm <| equivShrink β
 #align category_theory.limits.has_products_of_shape_of_small CategoryTheory.Limits.hasProductsOfShape_of_small
 
 theorem hasCoproductsOfShape_of_small (β : Type w₂) [Small.{w₁} β] [HasCoproducts.{w₁} C] :
@@ -50,4 +50,3 @@ theorem hasCoproductsOfShape_of_small (β : Type w₂) [Small.{w₁} β] [HasCop
 #align category_theory.limits.has_coproducts_of_shape_of_small CategoryTheory.Limits.hasCoproductsOfShape_of_small
 
 end CategoryTheory.Limits
-

--- a/Mathlib/CategoryTheory/Limits/HasLimits.lean
+++ b/Mathlib/CategoryTheory/Limits/HasLimits.lean
@@ -477,11 +477,11 @@ theorem limit.lift_post (c : Cone F) :
 
 @[simp]
 theorem limit.post_post {E : Type u''} [Category.{v''} E] (H : D ⥤ E) [h : HasLimit ((F ⋙ G) ⋙ H)] :
-    -- H G (limit F) ⟶ H (limit (F ⋙ G)) ⟶ limit ((F ⋙ G) ⋙ H) equals 
+    -- H G (limit F) ⟶ H (limit (F ⋙ G)) ⟶ limit ((F ⋙ G) ⋙ H) equals
     -- H G (limit F) ⟶ limit (F ⋙ (G ⋙ H))
-    haveI : HasLimit (F ⋙  G ⋙  H) := h 
-    H.map (limit.post F G) ≫ limit.post (F ⋙ G) H = limit.post F (G ⋙ H) := by 
-  haveI : HasLimit (F ⋙  G ⋙  H) := h 
+    haveI : HasLimit (F ⋙  G ⋙  H) := h
+    H.map (limit.post F G) ≫ limit.post (F ⋙ G) H = limit.post F (G ⋙ H) := by
+  haveI : HasLimit (F ⋙  G ⋙  H) := h
   ext; erw [assoc, limit.post_π, ← H.map_comp, limit.post_π, limit.post_π]; rfl
 #align category_theory.limits.limit.post_post CategoryTheory.Limits.limit.post_post
 
@@ -489,11 +489,11 @@ end Post
 
 theorem limit.pre_post {D : Type u'} [Category.{v'} D] (E : K ⥤ J) (F : J ⥤ C) (G : C ⥤ D)
     [HasLimit F] [HasLimit (E ⋙ F)] [HasLimit (F ⋙ G)]
-    [h : HasLimit ((E ⋙ F) ⋙ G)] :-- G (limit F) ⟶ G (limit (E ⋙ F)) ⟶ limit ((E ⋙ F) ⋙ G) vs 
+    [h : HasLimit ((E ⋙ F) ⋙ G)] :-- G (limit F) ⟶ G (limit (E ⋙ F)) ⟶ limit ((E ⋙ F) ⋙ G) vs
             -- G (limit F) ⟶ limit F ⋙ G ⟶ limit (E ⋙ (F ⋙ G)) or
-    haveI : HasLimit (E ⋙  F ⋙  G) := h 
+    haveI : HasLimit (E ⋙  F ⋙  G) := h
     G.map (limit.pre F E) ≫ limit.post (E ⋙ F) G = limit.post F G ≫ limit.pre (F ⋙ G) E := by
-  haveI : HasLimit (E ⋙  F ⋙  G) := h 
+  haveI : HasLimit (E ⋙  F ⋙  G) := h
   ext ; erw [assoc, limit.post_π, ← G.map_comp, limit.pre_π, assoc, limit.pre_π, limit.post_π]
 #align category_theory.limits.limit.pre_post CategoryTheory.Limits.limit.pre_post
 
@@ -505,7 +505,7 @@ instance hasLimitEquivalenceComp (e : K ≌ J) [HasLimit F] : HasLimit (e.functo
       isLimit := IsLimit.whiskerEquivalence (limit.isLimit F) e }
 #align category_theory.limits.has_limit_equivalence_comp CategoryTheory.Limits.hasLimitEquivalenceComp
 
--- Porting note: testing whether this still needed 
+-- Porting note: testing whether this still needed
 -- attribute [local elab_without_expected_type] inv_fun_id_assoc
 
 -- not entirely sure why this is needed
@@ -558,7 +558,7 @@ theorem limit.map_pre' [HasLimitsOfShape K C] (F : J ⥤ C) {E₁ E₂ : K ⥤ J
   ext1; simp [← category.assoc]
 #align category_theory.limits.limit.map_pre' CategoryTheory.Limits.limit.map_pre'
 
-theorem limit.id_pre (F : J ⥤ C) : limit.pre F (𝟭 _) = lim.map (Functor.leftUnitor F).inv := by 
+theorem limit.id_pre (F : J ⥤ C) : limit.pre F (𝟭 _) = lim.map (Functor.leftUnitor F).inv := by
   aesop_cat
 #align category_theory.limits.limit.id_pre CategoryTheory.Limits.limit.id_pre
 
@@ -619,12 +619,12 @@ instance limMap_mono {F G : J ⥤ C} [HasLimit F] [HasLimit G] (α : F ⟶ G) [�
 
 /-- We can transport limits of shape `J` along an equivalence `J ≌ J'`.
 -/
-theorem hasLimitsOfShapeOfEquivalence {J' : Type u₂} [Category.{v₂} J'] (e : J ≌ J')
+theorem hasLimitsOfShape_of_equivalence {J' : Type u₂} [Category.{v₂} J'] (e : J ≌ J')
     [HasLimitsOfShape J C] : HasLimitsOfShape J' C := by
   constructor
   intro F
   apply hasLimitOfEquivalenceComp e
-#align category_theory.limits.has_limits_of_shape_of_equivalence CategoryTheory.Limits.hasLimitsOfShapeOfEquivalence
+#align category_theory.limits.has_limits_of_shape_of_equivalence CategoryTheory.Limits.hasLimitsOfShape_of_equivalence
 
 variable (C)
 
@@ -633,7 +633,7 @@ from some other `HasLimitsOfSize C`.
 -/
 theorem hasLimitsOfSizeShrink [HasLimitsOfSize.{max v₁ v₂, max u₁ u₂} C] :
     HasLimitsOfSize.{v₁, u₁} C :=
-  ⟨fun J _ => hasLimitsOfShapeOfEquivalence (ULiftHomULiftCategory.equiv.{v₂, u₂} J).symm⟩
+  ⟨fun J _ => hasLimitsOfShape_of_equivalence (ULiftHomULiftCategory.equiv.{v₂, u₂} J).symm⟩
 #align category_theory.limits.has_limits_of_size_shrink CategoryTheory.Limits.hasLimitsOfSizeShrink
 
 instance (priority := 100) hasSmallestLimitsOfHasLimits [HasLimits C] : HasLimitsOfSize.{0, 0} C :=
@@ -1057,14 +1057,14 @@ theorem colimit.post_desc (c : Cocone F) :
 #align category_theory.limits.colimit.post_desc CategoryTheory.Limits.colimit.post_desc
 
 @[simp]
-theorem colimit.post_post {E : Type u''} [Category.{v''} E] (H : D ⥤ E) 
-    -- H G (colimit F) ⟶ H (colimit (F ⋙ G)) ⟶ colimit ((F ⋙ G) ⋙ H) equals 
+theorem colimit.post_post {E : Type u''} [Category.{v''} E] (H : D ⥤ E)
+    -- H G (colimit F) ⟶ H (colimit (F ⋙ G)) ⟶ colimit ((F ⋙ G) ⋙ H) equals
     -- H G (colimit F) ⟶ colimit (F ⋙ (G ⋙ H))
-    [h : HasColimit ((F ⋙ G) ⋙ H)] : haveI : HasColimit (F ⋙  G ⋙  H) := h 
+    [h : HasColimit ((F ⋙ G) ⋙ H)] : haveI : HasColimit (F ⋙  G ⋙  H) := h
     colimit.post (F ⋙ G) H ≫ H.map (colimit.post F G) = colimit.post F (G ⋙ H) := by
   ext j
   rw [← assoc, colimit.ι_post, ← H.map_comp, colimit.ι_post]
-  haveI : HasColimit (F ⋙  G ⋙  H) := h 
+  haveI : HasColimit (F ⋙  G ⋙  H) := h
   exact (colimit.ι_post F (G ⋙ H) j).symm
 #align category_theory.limits.colimit.post_post CategoryTheory.Limits.colimit.post_post
 
@@ -1072,10 +1072,10 @@ end Post
 
 theorem colimit.pre_post {D : Type u'} [Category.{v'} D] (E : K ⥤ J) (F : J ⥤ C) (G : C ⥤ D)
     [HasColimit F] [HasColimit (E ⋙ F)] [HasColimit (F ⋙ G)] [h : HasColimit ((E ⋙ F) ⋙ G)] :
-    -- G (colimit F) ⟶ G (colimit (E ⋙ F)) ⟶ colimit ((E ⋙ F) ⋙ G) vs 
+    -- G (colimit F) ⟶ G (colimit (E ⋙ F)) ⟶ colimit ((E ⋙ F) ⋙ G) vs
     -- G (colimit F) ⟶ colimit F ⋙ G ⟶ colimit (E ⋙ (F ⋙ G)) or
-    haveI : HasColimit (E ⋙  F ⋙  G) := h 
-    colimit.post (E ⋙ F) G ≫ G.map (colimit.pre F E) = 
+    haveI : HasColimit (E ⋙  F ⋙  G) := h
+    colimit.post (E ⋙ F) G ≫ G.map (colimit.pre F E) =
       colimit.pre (F ⋙ G) E ≫ colimit.post F G := by
   ext j
   rw [← assoc, colimit.ι_post, ← G.map_comp, colimit.ι_pre, ← assoc]
@@ -1124,7 +1124,7 @@ variable {G : J ⥤ C} (α : F ⟶ G)
 theorem colimit.ι_map (j : J) : colimit.ι F j ≫ colim.map α = α.app j ≫ colimit.ι G j := by simp
 #align category_theory.limits.colimit.ι_map CategoryTheory.Limits.colimit.ι_map
 
-@[simp] -- Porting note: proof adjusted to account for @[simps] on all fields of colim 
+@[simp] -- Porting note: proof adjusted to account for @[simps] on all fields of colim
 theorem colimit.map_desc (c : Cocone G) :
     colimMap α ≫ colimit.desc G c = colimit.desc F ((Cocones.precompose α).obj c) := by
   apply Limits.colimit.hom_ext; intro j
@@ -1165,9 +1165,9 @@ morphisms from the cone point of the colimit cocone for `F` to `W`
 and cocones over `F` with cone point `W`
 is natural in `F`.
 -/
-def colimCoyoneda : colim.op ⋙ coyoneda ⋙ (whiskeringRight _ _ _).obj uliftFunctor.{u₁} 
-    ≅ CategoryTheory.cocones J C := 
-  NatIso.ofComponents (fun F => NatIso.ofComponents (fun W => colimit.homIso (unop F) (op W)) 
+def colimCoyoneda : colim.op ⋙ coyoneda ⋙ (whiskeringRight _ _ _).obj uliftFunctor.{u₁}
+    ≅ CategoryTheory.cocones J C :=
+  NatIso.ofComponents (fun F => NatIso.ofComponents (fun W => colimit.homIso (unop F) (op W))
     <| by intros ; funext ; aesop_cat) <| by intros ; ext ; funext ; aesop_cat
 #align category_theory.limits.colim_coyoneda CategoryTheory.Limits.colimCoyoneda
 
@@ -1245,7 +1245,7 @@ def IsLimit.op {t : Cone F} (P : IsLimit t) : IsColimit t.op where
   uniq s m w := by
     dsimp
     rw [← P.uniq s.unop m.unop]
-    · rfl 
+    · rfl
     · dsimp
       intro j
       rw [← w]

--- a/Mathlib/CategoryTheory/Limits/Opposites.lean
+++ b/Mathlib/CategoryTheory/Limits/Opposites.lean
@@ -687,14 +687,16 @@ noncomputable def pushoutIsoUnopPullback {X Y Z : C} (f : X ⟶ Z) (g : X ⟶ Y)
 @[reassoc (attr := simp)]
 theorem pushoutIsoUnopPullback_inl_hom {X Y Z : C} (f : X ⟶ Z) (g : X ⟶ Y) [HasPushout f g]
     [HasPullback f.op g.op] :
-    pushout.inl ≫ (pushoutIsoUnopPullback f g).hom = (pullback.fst : pullback f.op g.op ⟶ _).unop :=
+    pushout.inl ≫ (pushoutIsoUnopPullback f g).hom =
+      (pullback.fst : pullback f.op g.op ⟶ _).unop :=
   (IsColimit.comp_coconePointUniqueUpToIso_hom _ _ _).trans (by simp)
 #align category_theory.limits.pushout_iso_unop_pullback_inl_hom CategoryTheory.Limits.pushoutIsoUnopPullback_inl_hom
 
 @[reassoc (attr := simp)]
 theorem pushoutIsoUnopPullback_inr_hom {X Y Z : C} (f : X ⟶ Z) (g : X ⟶ Y) [HasPushout f g]
     [HasPullback f.op g.op] :
-    pushout.inr ≫ (pushoutIsoUnopPullback f g).hom = (pullback.snd : pullback f.op g.op ⟶ _).unop :=
+    pushout.inr ≫ (pushoutIsoUnopPullback f g).hom =
+      (pullback.snd : pullback f.op g.op ⟶ _).unop :=
   (IsColimit.comp_coconePointUniqueUpToIso_hom _ _ _).trans (by simp)
 #align category_theory.limits.pushout_iso_unop_pullback_inr_hom CategoryTheory.Limits.pushoutIsoUnopPullback_inr_hom
 

--- a/Mathlib/CategoryTheory/Limits/Opposites.lean
+++ b/Mathlib/CategoryTheory/Limits/Opposites.lean
@@ -8,10 +8,10 @@ Authors: Scott Morrison, Floris van Doorn
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
-import Mathbin.CategoryTheory.Limits.Filtered
-import Mathbin.CategoryTheory.Limits.Shapes.FiniteProducts
-import Mathbin.CategoryTheory.DiscreteCategory
-import Mathbin.Tactic.EquivRw
+import Mathlib.CategoryTheory.Limits.Filtered
+import Mathlib.CategoryTheory.Limits.Shapes.FiniteProducts
+import Mathlib.CategoryTheory.DiscreteCategory
+import Mathlib.Tactic.EquivRw
 
 /-!
 # Limits in `C` give colimits in `Cᵒᵖ`.
@@ -334,8 +334,7 @@ variable (X : Type v₂)
 
 /-- If `C` has products indexed by `X`, then `Cᵒᵖ` has coproducts indexed by `X`.
 -/
-instance hasCoproductsOfShape_opposite [HasProductsOfShape X C] : HasCoproductsOfShape X Cᵒᵖ :=
-  by
+instance hasCoproductsOfShape_opposite [HasProductsOfShape X C] : HasCoproductsOfShape X Cᵒᵖ := by
   haveI : has_limits_of_shape (discrete X)ᵒᵖ C :=
     has_limits_of_shape_of_equivalence (discrete.opposite X).symm
   infer_instance
@@ -349,8 +348,7 @@ theorem hasCoproductsOfShape_of_opposite [HasProductsOfShape X Cᵒᵖ] : HasCop
 
 /-- If `C` has coproducts indexed by `X`, then `Cᵒᵖ` has products indexed by `X`.
 -/
-instance hasProductsOfShape_opposite [HasCoproductsOfShape X C] : HasProductsOfShape X Cᵒᵖ :=
-  by
+instance hasProductsOfShape_opposite [HasCoproductsOfShape X C] : HasProductsOfShape X Cᵒᵖ := by
   haveI : has_colimits_of_shape (discrete X)ᵒᵖ C :=
     has_colimits_of_shape_of_equivalence (discrete.opposite X).symm
   infer_instance
@@ -394,15 +392,13 @@ theorem hasFiniteProducts_of_opposite [HasFiniteCoproducts Cᵒᵖ] : HasFiniteP
   { out := fun n => hasProductsOfShape_of_opposite _ }
 #align category_theory.limits.has_finite_products_of_opposite CategoryTheory.Limits.hasFiniteProducts_of_opposite
 
-instance hasEqualizers_opposite [HasCoequalizers C] : HasEqualizers Cᵒᵖ :=
-  by
+instance hasEqualizers_opposite [HasCoequalizers C] : HasEqualizers Cᵒᵖ := by
   haveI : has_colimits_of_shape walking_parallel_pairᵒᵖ C :=
     has_colimits_of_shape_of_equivalence walking_parallel_pair_op_equiv
   infer_instance
 #align category_theory.limits.has_equalizers_opposite CategoryTheory.Limits.hasEqualizers_opposite
 
-instance hasCoequalizers_opposite [HasEqualizers C] : HasCoequalizers Cᵒᵖ :=
-  by
+instance hasCoequalizers_opposite [HasEqualizers C] : HasCoequalizers Cᵒᵖ := by
   haveI : has_limits_of_shape walking_parallel_pairᵒᵖ C :=
     has_limits_of_shape_of_equivalence walking_parallel_pair_op_equiv
   infer_instance
@@ -420,15 +416,13 @@ instance hasFiniteLimits_opposite [HasFiniteColimits C] : HasFiniteLimits Cᵒ�
     infer_instance
 #align category_theory.limits.has_finite_limits_opposite CategoryTheory.Limits.hasFiniteLimits_opposite
 
-instance hasPullbacks_opposite [HasPushouts C] : HasPullbacks Cᵒᵖ :=
-  by
+instance hasPullbacks_opposite [HasPushouts C] : HasPullbacks Cᵒᵖ := by
   haveI : has_colimits_of_shape walking_cospanᵒᵖ C :=
     has_colimits_of_shape_of_equivalence walking_cospan_op_equiv.symm
   apply has_limits_of_shape_op_of_has_colimits_of_shape
 #align category_theory.limits.has_pullbacks_opposite CategoryTheory.Limits.hasPullbacks_opposite
 
-instance hasPushouts_opposite [HasPullbacks C] : HasPushouts Cᵒᵖ :=
-  by
+instance hasPushouts_opposite [HasPullbacks C] : HasPushouts Cᵒᵖ := by
   haveI : has_limits_of_shape walking_spanᵒᵖ C :=
     has_limits_of_shape_of_equivalence walking_span_op_equiv.symm
   infer_instance
@@ -491,8 +485,7 @@ def unop {X Y Z : Cᵒᵖ} {f : X ⟶ Y} {g : X ⟶ Z} (c : PushoutCocone f g) :
 
 @[simp]
 theorem unop_fst {X Y Z : Cᵒᵖ} {f : X ⟶ Y} {g : X ⟶ Z} (c : PushoutCocone f g) :
-    c.unop.fst = c.inl.unop :=
-  by
+    c.unop.fst = c.inl.unop := by
   change (_ : limits.cone _).π.app _ = _
   simp only [pushout_cocone.ι_app_left, pushout_cocone.unop_π_app]
   tidy
@@ -500,8 +493,7 @@ theorem unop_fst {X Y Z : Cᵒᵖ} {f : X ⟶ Y} {g : X ⟶ Z} (c : PushoutCocon
 
 @[simp]
 theorem unop_snd {X Y Z : Cᵒᵖ} {f : X ⟶ Y} {g : X ⟶ Z} (c : PushoutCocone f g) :
-    c.unop.snd = c.inr.unop :=
-  by
+    c.unop.snd = c.inr.unop := by
   change (_ : limits.cone _).π.app _ = _
   simp only [pushout_cocone.unop_π_app, pushout_cocone.ι_app_right]
   tidy
@@ -543,8 +535,7 @@ def unop {X Y Z : Cᵒᵖ} {f : X ⟶ Z} {g : Y ⟶ Z} (c : PullbackCone f g) :
 
 @[simp]
 theorem unop_inl {X Y Z : Cᵒᵖ} {f : X ⟶ Z} {g : Y ⟶ Z} (c : PullbackCone f g) :
-    c.unop.inl = c.fst.unop :=
-  by
+    c.unop.inl = c.fst.unop := by
   change (_ : limits.cocone _).ι.app _ = _
   dsimp only [unop, op_span]
   simp; dsimp; simp; dsimp; simp
@@ -552,8 +543,7 @@ theorem unop_inl {X Y Z : Cᵒᵖ} {f : X ⟶ Z} {g : Y ⟶ Z} (c : PullbackCone
 
 @[simp]
 theorem unop_inr {X Y Z : Cᵒᵖ} {f : X ⟶ Z} {g : Y ⟶ Z} (c : PullbackCone f g) :
-    c.unop.inr = c.snd.unop :=
-  by
+    c.unop.inr = c.snd.unop := by
   change (_ : limits.cocone _).ι.app _ = _
   apply Quiver.Hom.op_inj
   simp [unop_ι_app]; dsimp; simp
@@ -608,8 +598,7 @@ def unopOp {X Y Z : Cᵒᵖ} {f : X ⟶ Y} {g : X ⟶ Z} (c : PushoutCocone f g)
 /-- A pushout cone is a colimit cocone if and only if the corresponding pullback cone
 in the opposite category is a limit cone. -/
 def isColimitEquivIsLimitOp {X Y Z : C} {f : X ⟶ Y} {g : X ⟶ Z} (c : PushoutCocone f g) :
-    IsColimit c ≃ IsLimit c.op :=
-  by
+    IsColimit c ≃ IsLimit c.op := by
   apply equivOfSubsingletonOfSubsingleton
   · intro h
     equiv_rw is_limit.postcompose_hom_equiv _ _
@@ -626,8 +615,7 @@ def isColimitEquivIsLimitOp {X Y Z : C} {f : X ⟶ Y} {g : X ⟶ Z} (c : Pushout
 /-- A pushout cone is a colimit cocone in `Cᵒᵖ` if and only if the corresponding pullback cone
 in `C` is a limit cone. -/
 def isColimitEquivIsLimitUnop {X Y Z : Cᵒᵖ} {f : X ⟶ Y} {g : X ⟶ Z} (c : PushoutCocone f g) :
-    IsColimit c ≃ IsLimit c.unop :=
-  by
+    IsColimit c ≃ IsLimit c.unop := by
   apply equivOfSubsingletonOfSubsingleton
   · intro h
     apply is_limit_cocone_unop

--- a/Mathlib/CategoryTheory/Limits/Opposites.lean
+++ b/Mathlib/CategoryTheory/Limits/Opposites.lean
@@ -701,7 +701,8 @@ theorem pushoutIsoUnopPullback_inr_hom {X Y Z : C} (f : X ⟶ Z) (g : X ⟶ Y) [
 
 @[simp]
 theorem pushoutIsoUnopPullback_inv_fst {X Y Z : C} (f : X ⟶ Z) (g : X ⟶ Y) [HasPushout f g]
-    [HasPullback f.op g.op] : (pushoutIsoUnopPullback f g).inv.op ≫ pullback.fst = pushout.inl.op :=
+    [HasPullback f.op g.op] :
+      (pushoutIsoUnopPullback f g).inv.op ≫ pullback.fst = pushout.inl.op :=
   by
   apply Quiver.Hom.unop_inj
   dsimp
@@ -710,7 +711,8 @@ theorem pushoutIsoUnopPullback_inv_fst {X Y Z : C} (f : X ⟶ Z) (g : X ⟶ Y) [
 
 @[simp]
 theorem pushoutIsoUnopPullback_inv_snd {X Y Z : C} (f : X ⟶ Z) (g : X ⟶ Y) [HasPushout f g]
-    [HasPullback f.op g.op] : (pushoutIsoUnopPullback f g).inv.op ≫ pullback.snd = pushout.inr.op :=
+    [HasPullback f.op g.op] :
+      (pushoutIsoUnopPullback f g).inv.op ≫ pullback.snd = pushout.inr.op :=
   by
   apply Quiver.Hom.unop_inj
   dsimp

--- a/Mathlib/CategoryTheory/Limits/Opposites.lean
+++ b/Mathlib/CategoryTheory/Limits/Opposites.lean
@@ -11,7 +11,7 @@ Authors: Scott Morrison, Floris van Doorn
 import Mathlib.CategoryTheory.Limits.Filtered
 import Mathlib.CategoryTheory.Limits.Shapes.FiniteProducts
 import Mathlib.CategoryTheory.DiscreteCategory
-import Mathlib.Tactic.EquivRw
+--import Mathlib.Tactic.EquivRw
 
 /-!
 # Limits in `C` give colimits in `Cᵒᵖ`.
@@ -43,10 +43,10 @@ variable {J : Type u₂} [Category.{v₂} J]
 def isLimitCoconeOp (F : J ⥤ C) {c : Cocone F} (hc : IsColimit c) : IsLimit c.op
     where
   lift s := (hc.desc s.unop).op
-  fac s j := Quiver.Hom.unop_inj (by simpa)
+  fac s j := Quiver.Hom.unop_inj (by simp)
   uniq s m w := by
     refine' Quiver.Hom.unop_inj (hc.hom_ext fun j => Quiver.Hom.op_inj _)
-    simpa only [Quiver.Hom.unop_op, is_colimit.fac] using w (op j)
+    simpa only [Quiver.Hom.unop_op, IsColimit.fac] using w (op j)
 #align category_theory.limits.is_limit_cocone_op CategoryTheory.Limits.isLimitCoconeOp
 
 /-- Turn a limit for `F : J ⥤ C` into a colimit for `F.op : Jᵒᵖ ⥤ Cᵒᵖ`. -/
@@ -54,13 +54,13 @@ def isLimitCoconeOp (F : J ⥤ C) {c : Cocone F} (hc : IsColimit c) : IsLimit c.
 def isColimitConeOp (F : J ⥤ C) {c : Cone F} (hc : IsLimit c) : IsColimit c.op
     where
   desc s := (hc.lift s.unop).op
-  fac s j := Quiver.Hom.unop_inj (by simpa)
+  fac s j := Quiver.Hom.unop_inj (by simp)
   uniq s m w := by
     refine' Quiver.Hom.unop_inj (hc.hom_ext fun j => Quiver.Hom.op_inj _)
-    simpa only [Quiver.Hom.unop_op, is_limit.fac] using w (op j)
+    simpa only [Quiver.Hom.unop_op, IsLimit.fac] using w (op j)
 #align category_theory.limits.is_colimit_cone_op CategoryTheory.Limits.isColimitConeOp
 
-/-- Turn a colimit for `F : J ⥤ Cᵒᵖ` into a limit for `F.left_op : Jᵒᵖ ⥤ C`. -/
+/-- Turn a colimit for `F : J ⥤ Cᵒᵖ` into a limit for `F.leftOp : Jᵒᵖ ⥤ C`. -/
 @[simps]
 def isLimitConeLeftOpOfCocone (F : J ⥤ Cᵒᵖ) {c : Cocone F} (hc : IsColimit c) :
     IsLimit (coneLeftOpOfCocone c)
@@ -68,14 +68,14 @@ def isLimitConeLeftOpOfCocone (F : J ⥤ Cᵒᵖ) {c : Cocone F} (hc : IsColimit
   lift s := (hc.desc (coconeOfConeLeftOp s)).unop
   fac s j :=
     Quiver.Hom.op_inj <| by
-      simpa only [cone_left_op_of_cocone_π_app, op_comp, Quiver.Hom.op_unop, is_colimit.fac,
-        cocone_of_cone_left_op_ι_app]
+      simp only [coneLeftOpOfCocone_π_app, op_comp, Quiver.Hom.op_unop, IsColimit.fac,
+        coconeOfConeLeftOp_ι_app, op_unop]
   uniq s m w := by
     refine' Quiver.Hom.op_inj (hc.hom_ext fun j => Quiver.Hom.unop_inj _)
-    simpa only [Quiver.Hom.op_unop, is_colimit.fac, cocone_of_cone_left_op_ι_app] using w (op j)
+    simpa only [Quiver.Hom.op_unop, IsColimit.fac, coconeOfConeLeftOp_ι_app] using w (op j)
 #align category_theory.limits.is_limit_cone_left_op_of_cocone CategoryTheory.Limits.isLimitConeLeftOpOfCocone
 
-/-- Turn a limit of `F : J ⥤ Cᵒᵖ` into a colimit of `F.left_op : Jᵒᵖ ⥤ C`. -/
+/-- Turn a limit of `F : J ⥤ Cᵒᵖ` into a colimit of `F.leftOp : Jᵒᵖ ⥤ C`. -/
 @[simps]
 def isColimitCoconeLeftOpOfCone (F : J ⥤ Cᵒᵖ) {c : Cone F} (hc : IsLimit c) :
     IsColimit (coconeLeftOpOfCone c)
@@ -83,35 +83,35 @@ def isColimitCoconeLeftOpOfCone (F : J ⥤ Cᵒᵖ) {c : Cone F} (hc : IsLimit c
   desc s := (hc.lift (coneOfCoconeLeftOp s)).unop
   fac s j :=
     Quiver.Hom.op_inj <| by
-      simpa only [cocone_left_op_of_cone_ι_app, op_comp, Quiver.Hom.op_unop, is_limit.fac,
-        cone_of_cocone_left_op_π_app]
+      simp only [coconeLeftOpOfCone_ι_app, op_comp, Quiver.Hom.op_unop, IsLimit.fac,
+        coneOfCoconeLeftOp_π_app, op_unop]
   uniq s m w := by
     refine' Quiver.Hom.op_inj (hc.hom_ext fun j => Quiver.Hom.unop_inj _)
-    simpa only [Quiver.Hom.op_unop, is_limit.fac, cone_of_cocone_left_op_π_app] using w (op j)
+    simpa only [Quiver.Hom.op_unop, IsLimit.fac, coneOfCoconeLeftOp_π_app] using w (op j)
 #align category_theory.limits.is_colimit_cocone_left_op_of_cone CategoryTheory.Limits.isColimitCoconeLeftOpOfCone
 
-/-- Turn a colimit for `F : Jᵒᵖ ⥤ C` into a limit for `F.right_op : J ⥤ Cᵒᵖ`. -/
+/-- Turn a colimit for `F : Jᵒᵖ ⥤ C` into a limit for `F.rightOp : J ⥤ Cᵒᵖ`. -/
 @[simps]
 def isLimitConeRightOpOfCocone (F : Jᵒᵖ ⥤ C) {c : Cocone F} (hc : IsColimit c) :
     IsLimit (coneRightOpOfCocone c)
     where
   lift s := (hc.desc (coconeOfConeRightOp s)).op
-  fac s j := Quiver.Hom.unop_inj (by simpa)
+  fac s j := Quiver.Hom.unop_inj (by simp)
   uniq s m w := by
     refine' Quiver.Hom.unop_inj (hc.hom_ext fun j => Quiver.Hom.op_inj _)
-    simpa only [Quiver.Hom.unop_op, is_colimit.fac] using w (unop j)
+    simpa only [Quiver.Hom.unop_op, IsColimit.fac] using w (unop j)
 #align category_theory.limits.is_limit_cone_right_op_of_cocone CategoryTheory.Limits.isLimitConeRightOpOfCocone
 
-/-- Turn a limit for `F : Jᵒᵖ ⥤ C` into a colimit for `F.right_op : J ⥤ Cᵒᵖ`. -/
+/-- Turn a limit for `F : Jᵒᵖ ⥤ C` into a colimit for `F.rightOp : J ⥤ Cᵒᵖ`. -/
 @[simps]
 def isColimitCoconeRightOpOfCone (F : Jᵒᵖ ⥤ C) {c : Cone F} (hc : IsLimit c) :
     IsColimit (coconeRightOpOfCone c)
     where
   desc s := (hc.lift (coneOfCoconeRightOp s)).op
-  fac s j := Quiver.Hom.unop_inj (by simpa)
+  fac s j := Quiver.Hom.unop_inj (by simp)
   uniq s m w := by
     refine' Quiver.Hom.unop_inj (hc.hom_ext fun j => Quiver.Hom.op_inj _)
-    simpa only [Quiver.Hom.unop_op, is_limit.fac] using w (unop j)
+    simpa only [Quiver.Hom.unop_op, IsLimit.fac] using w (unop j)
 #align category_theory.limits.is_colimit_cocone_right_op_of_cone CategoryTheory.Limits.isColimitCoconeRightOpOfCone
 
 /-- Turn a colimit for `F : Jᵒᵖ ⥤ Cᵒᵖ` into a limit for `F.unop : J ⥤ C`. -/
@@ -120,10 +120,10 @@ def isLimitConeUnopOfCocone (F : Jᵒᵖ ⥤ Cᵒᵖ) {c : Cocone F} (hc : IsCol
     IsLimit (coneUnopOfCocone c)
     where
   lift s := (hc.desc (coconeOfConeUnop s)).unop
-  fac s j := Quiver.Hom.op_inj (by simpa)
+  fac s j := Quiver.Hom.op_inj (by simp)
   uniq s m w := by
     refine' Quiver.Hom.op_inj (hc.hom_ext fun j => Quiver.Hom.unop_inj _)
-    simpa only [Quiver.Hom.op_unop, is_colimit.fac] using w (unop j)
+    simpa only [Quiver.Hom.op_unop, IsColimit.fac] using w (unop j)
 #align category_theory.limits.is_limit_cone_unop_of_cocone CategoryTheory.Limits.isLimitConeUnopOfCocone
 
 /-- Turn a limit of `F : Jᵒᵖ ⥤ Cᵒᵖ` into a colimit of `F.unop : J ⥤ C`. -/
@@ -132,10 +132,10 @@ def isColimitCoconeUnopOfCone (F : Jᵒᵖ ⥤ Cᵒᵖ) {c : Cone F} (hc : IsLim
     IsColimit (coconeUnopOfCone c)
     where
   desc s := (hc.lift (coneOfCoconeUnop s)).unop
-  fac s j := Quiver.Hom.op_inj (by simpa)
+  fac s j := Quiver.Hom.op_inj (by simp)
   uniq s m w := by
     refine' Quiver.Hom.op_inj (hc.hom_ext fun j => Quiver.Hom.unop_inj _)
-    simpa only [Quiver.Hom.op_unop, is_limit.fac] using w (unop j)
+    simpa only [Quiver.Hom.op_unop, IsLimit.fac] using w (unop j)
 #align category_theory.limits.is_colimit_cocone_unop_of_cone CategoryTheory.Limits.isColimitCoconeUnopOfCone
 
 /-- Turn a colimit for `F.op : Jᵒᵖ ⥤ Cᵒᵖ` into a limit for `F : J ⥤ C`. -/
@@ -143,10 +143,10 @@ def isColimitCoconeUnopOfCone (F : Jᵒᵖ ⥤ Cᵒᵖ) {c : Cone F} (hc : IsLim
 def isLimitCoconeUnop (F : J ⥤ C) {c : Cocone F.op} (hc : IsColimit c) : IsLimit c.unop
     where
   lift s := (hc.desc s.op).unop
-  fac s j := Quiver.Hom.op_inj (by simpa)
+  fac s j := Quiver.Hom.op_inj (by simp)
   uniq s m w := by
     refine' Quiver.Hom.op_inj (hc.hom_ext fun j => Quiver.Hom.unop_inj _)
-    simpa only [Quiver.Hom.op_unop, is_colimit.fac] using w (unop j)
+    simpa only [Quiver.Hom.op_unop, IsColimit.fac] using w (unop j)
 #align category_theory.limits.is_limit_cocone_unop CategoryTheory.Limits.isLimitCoconeUnop
 
 /-- Turn a limit for `F.op : Jᵒᵖ ⥤ Cᵒᵖ` into a colimit for `F : J ⥤ C`. -/
@@ -154,13 +154,13 @@ def isLimitCoconeUnop (F : J ⥤ C) {c : Cocone F.op} (hc : IsColimit c) : IsLim
 def isColimitConeUnop (F : J ⥤ C) {c : Cone F.op} (hc : IsLimit c) : IsColimit c.unop
     where
   desc s := (hc.lift s.op).unop
-  fac s j := Quiver.Hom.op_inj (by simpa)
+  fac s j := Quiver.Hom.op_inj (by simp)
   uniq s m w := by
     refine' Quiver.Hom.op_inj (hc.hom_ext fun j => Quiver.Hom.unop_inj _)
-    simpa only [Quiver.Hom.op_unop, is_limit.fac] using w (unop j)
+    simpa only [Quiver.Hom.op_unop, IsLimit.fac] using w (unop j)
 #align category_theory.limits.is_colimit_cone_unop CategoryTheory.Limits.isColimitConeUnop
 
-/-- Turn a colimit for `F.left_op : Jᵒᵖ ⥤ C` into a limit for `F : J ⥤ Cᵒᵖ`. -/
+/-- Turn a colimit for `F.leftOp : Jᵒᵖ ⥤ C` into a limit for `F : J ⥤ Cᵒᵖ`. -/
 @[simps]
 def isLimitConeOfCoconeLeftOp (F : J ⥤ Cᵒᵖ) {c : Cocone F.leftOp} (hc : IsColimit c) :
     IsLimit (coneOfCoconeLeftOp c)
@@ -168,14 +168,14 @@ def isLimitConeOfCoconeLeftOp (F : J ⥤ Cᵒᵖ) {c : Cocone F.leftOp} (hc : Is
   lift s := (hc.desc (coconeLeftOpOfCone s)).op
   fac s j :=
     Quiver.Hom.unop_inj <| by
-      simpa only [cone_of_cocone_left_op_π_app, unop_comp, Quiver.Hom.unop_op, is_colimit.fac,
-        cocone_left_op_of_cone_ι_app]
+      simp only [coneOfCoconeLeftOp_π_app, unop_comp, Quiver.Hom.unop_op, IsColimit.fac,
+        coconeLeftOpOfCone_ι_app, unop_op]
   uniq s m w := by
     refine' Quiver.Hom.unop_inj (hc.hom_ext fun j => Quiver.Hom.op_inj _)
-    simpa only [Quiver.Hom.unop_op, is_colimit.fac, cone_of_cocone_left_op_π_app] using w (unop j)
+    simpa only [Quiver.Hom.unop_op, IsColimit.fac, coneOfCoconeLeftOp_π_app] using w (unop j)
 #align category_theory.limits.is_limit_cone_of_cocone_left_op CategoryTheory.Limits.isLimitConeOfCoconeLeftOp
 
-/-- Turn a limit of `F.left_op : Jᵒᵖ ⥤ C` into a colimit of `F : J ⥤ Cᵒᵖ`. -/
+/-- Turn a limit of `F.leftOp : Jᵒᵖ ⥤ C` into a colimit of `F : J ⥤ Cᵒᵖ`. -/
 @[simps]
 def isColimitCoconeOfConeLeftOp (F : J ⥤ Cᵒᵖ) {c : Cone F.leftOp} (hc : IsLimit c) :
     IsColimit (coconeOfConeLeftOp c)
@@ -183,35 +183,35 @@ def isColimitCoconeOfConeLeftOp (F : J ⥤ Cᵒᵖ) {c : Cone F.leftOp} (hc : Is
   desc s := (hc.lift (coneLeftOpOfCocone s)).op
   fac s j :=
     Quiver.Hom.unop_inj <| by
-      simpa only [cocone_of_cone_left_op_ι_app, unop_comp, Quiver.Hom.unop_op, is_limit.fac,
-        cone_left_op_of_cocone_π_app]
+      simp only [coconeOfConeLeftOp_ι_app, unop_comp, Quiver.Hom.unop_op, IsLimit.fac,
+        coneLeftOpOfCocone_π_app, unop_op]
   uniq s m w := by
     refine' Quiver.Hom.unop_inj (hc.hom_ext fun j => Quiver.Hom.op_inj _)
-    simpa only [Quiver.Hom.unop_op, is_limit.fac, cocone_of_cone_left_op_ι_app] using w (unop j)
+    simpa only [Quiver.Hom.unop_op, IsLimit.fac, coconeOfConeLeftOp_ι_app] using w (unop j)
 #align category_theory.limits.is_colimit_cocone_of_cone_left_op CategoryTheory.Limits.isColimitCoconeOfConeLeftOp
 
-/-- Turn a colimit for `F.right_op : J ⥤ Cᵒᵖ` into a limit for `F : Jᵒᵖ ⥤ C`. -/
+/-- Turn a colimit for `F.rightOp : J ⥤ Cᵒᵖ` into a limit for `F : Jᵒᵖ ⥤ C`. -/
 @[simps]
 def isLimitConeOfCoconeRightOp (F : Jᵒᵖ ⥤ C) {c : Cocone F.rightOp} (hc : IsColimit c) :
     IsLimit (coneOfCoconeRightOp c)
     where
   lift s := (hc.desc (coconeRightOpOfCone s)).unop
-  fac s j := Quiver.Hom.op_inj (by simpa)
+  fac s j := Quiver.Hom.op_inj (by simp)
   uniq s m w := by
     refine' Quiver.Hom.op_inj (hc.hom_ext fun j => Quiver.Hom.unop_inj _)
-    simpa only [Quiver.Hom.op_unop, is_colimit.fac] using w (op j)
+    simpa only [Quiver.Hom.op_unop, IsColimit.fac] using w (op j)
 #align category_theory.limits.is_limit_cone_of_cocone_right_op CategoryTheory.Limits.isLimitConeOfCoconeRightOp
 
-/-- Turn a limit for `F.right_op : J ⥤ Cᵒᵖ` into a limit for `F : Jᵒᵖ ⥤ C`. -/
+/-- Turn a limit for `F.rightOp : J ⥤ Cᵒᵖ` into a limit for `F : Jᵒᵖ ⥤ C`. -/
 @[simps]
 def isColimitCoconeOfConeRightOp (F : Jᵒᵖ ⥤ C) {c : Cone F.rightOp} (hc : IsLimit c) :
     IsColimit (coconeOfConeRightOp c)
     where
   desc s := (hc.lift (coneRightOpOfCocone s)).unop
-  fac s j := Quiver.Hom.op_inj (by simpa)
+  fac s j := Quiver.Hom.op_inj (by simp)
   uniq s m w := by
     refine' Quiver.Hom.op_inj (hc.hom_ext fun j => Quiver.Hom.unop_inj _)
-    simpa only [Quiver.Hom.op_unop, is_limit.fac] using w (op j)
+    simpa only [Quiver.Hom.op_unop, IsLimit.fac] using w (op j)
 #align category_theory.limits.is_colimit_cocone_of_cone_right_op CategoryTheory.Limits.isColimitCoconeOfConeRightOp
 
 /-- Turn a colimit for `F.unop : J ⥤ C` into a limit for `F : Jᵒᵖ ⥤ Cᵒᵖ`. -/
@@ -220,10 +220,10 @@ def isLimitConeOfCoconeUnop (F : Jᵒᵖ ⥤ Cᵒᵖ) {c : Cocone F.unop} (hc : 
     IsLimit (coneOfCoconeUnop c)
     where
   lift s := (hc.desc (coconeUnopOfCone s)).op
-  fac s j := Quiver.Hom.unop_inj (by simpa)
+  fac s j := Quiver.Hom.unop_inj (by simp)
   uniq s m w := by
     refine' Quiver.Hom.unop_inj (hc.hom_ext fun j => Quiver.Hom.op_inj _)
-    simpa only [Quiver.Hom.unop_op, is_colimit.fac] using w (op j)
+    simpa only [Quiver.Hom.unop_op, IsColimit.fac] using w (op j)
 #align category_theory.limits.is_limit_cone_of_cocone_unop CategoryTheory.Limits.isLimitConeOfCoconeUnop
 
 /-- Turn a limit for `F.unop : J ⥤ C` into a colimit for `F : Jᵒᵖ ⥤ Cᵒᵖ`. -/
@@ -232,102 +232,102 @@ def isColimitConeOfCoconeUnop (F : Jᵒᵖ ⥤ Cᵒᵖ) {c : Cone F.unop} (hc : 
     IsColimit (coconeOfConeUnop c)
     where
   desc s := (hc.lift (coneUnopOfCocone s)).op
-  fac s j := Quiver.Hom.unop_inj (by simpa)
+  fac s j := Quiver.Hom.unop_inj (by simp)
   uniq s m w := by
     refine' Quiver.Hom.unop_inj (hc.hom_ext fun j => Quiver.Hom.op_inj _)
-    simpa only [Quiver.Hom.unop_op, is_limit.fac] using w (op j)
+    simpa only [Quiver.Hom.unop_op, IsLimit.fac] using w (op j)
 #align category_theory.limits.is_colimit_cone_of_cocone_unop CategoryTheory.Limits.isColimitConeOfCoconeUnop
 
-/-- If `F.left_op : Jᵒᵖ ⥤ C` has a colimit, we can construct a limit for `F : J ⥤ Cᵒᵖ`.
+/-- If `F.leftOp : Jᵒᵖ ⥤ C` has a colimit, we can construct a limit for `F : J ⥤ Cᵒᵖ`.
 -/
 theorem hasLimit_of_hasColimit_leftOp (F : J ⥤ Cᵒᵖ) [HasColimit F.leftOp] : HasLimit F :=
   HasLimit.mk
-    { Cone := coneOfCoconeLeftOp (colimit.cocone F.leftOp)
-      IsLimit := isLimitConeOfCoconeLeftOp _ (colimit.isColimit _) }
+    { cone := coneOfCoconeLeftOp (colimit.cocone F.leftOp)
+      isLimit := isLimitConeOfCoconeLeftOp _ (colimit.isColimit _) }
 #align category_theory.limits.has_limit_of_has_colimit_left_op CategoryTheory.Limits.hasLimit_of_hasColimit_leftOp
 
 theorem hasLimit_of_hasColimit_op (F : J ⥤ C) [HasColimit F.op] : HasLimit F :=
   HasLimit.mk
-    { Cone := (colimit.cocone F.op).unop
-      IsLimit := isLimitCoconeUnop _ (colimit.isColimit _) }
+    { cone := (colimit.cocone F.op).unop
+      isLimit := isLimitCoconeUnop _ (colimit.isColimit _) }
 #align category_theory.limits.has_limit_of_has_colimit_op CategoryTheory.Limits.hasLimit_of_hasColimit_op
 
 /-- If `C` has colimits of shape `Jᵒᵖ`, we can construct limits in `Cᵒᵖ` of shape `J`.
 -/
 theorem hasLimitsOfShape_op_of_hasColimitsOfShape [HasColimitsOfShape Jᵒᵖ C] :
     HasLimitsOfShape J Cᵒᵖ :=
-  { HasLimit := fun F => hasLimit_of_hasColimit_leftOp F }
+  { has_limit := fun F => hasLimit_of_hasColimit_leftOp F }
 #align category_theory.limits.has_limits_of_shape_op_of_has_colimits_of_shape CategoryTheory.Limits.hasLimitsOfShape_op_of_hasColimitsOfShape
 
 theorem hasLimitsOfShape_of_hasColimitsOfShape_op [HasColimitsOfShape Jᵒᵖ Cᵒᵖ] :
     HasLimitsOfShape J C :=
-  { HasLimit := fun F => hasLimit_of_hasColimit_op F }
+  { has_limit := fun F => hasLimit_of_hasColimit_op F }
 #align category_theory.limits.has_limits_of_shape_of_has_colimits_of_shape_op CategoryTheory.Limits.hasLimitsOfShape_of_hasColimitsOfShape_op
 
-attribute [local instance] has_limits_of_shape_op_of_has_colimits_of_shape
+attribute [local instance] hasLimitsOfShape_op_of_hasColimitsOfShape
 
 /-- If `C` has colimits, we can construct limits for `Cᵒᵖ`.
 -/
 instance hasLimits_op_of_hasColimits [HasColimits C] : HasLimits Cᵒᵖ :=
-  ⟨inferInstance⟩
+  ⟨fun _ => inferInstance⟩
 #align category_theory.limits.has_limits_op_of_has_colimits CategoryTheory.Limits.hasLimits_op_of_hasColimits
 
 theorem hasLimits_of_hasColimits_op [HasColimits Cᵒᵖ] : HasLimits C :=
-  { HasLimitsOfShape := fun J hJ => has_limits_of_shape_of_has_colimits_of_shape_op }
+  { has_limits_of_shape := fun _ _ => hasLimitsOfShape_of_hasColimitsOfShape_op }
 #align category_theory.limits.has_limits_of_has_colimits_op CategoryTheory.Limits.hasLimits_of_hasColimits_op
 
 instance has_cofiltered_limits_op_of_has_filtered_colimits [HasFilteredColimitsOfSize.{v₂, u₂} C] :
     HasCofilteredLimitsOfSize.{v₂, u₂} Cᵒᵖ
-    where HasLimitsOfShape I hI₁ hI₂ := has_limits_of_shape_op_of_has_colimits_of_shape
+    where HasLimitsOfShape _ _ _ := hasLimitsOfShape_op_of_hasColimitsOfShape
 #align category_theory.limits.has_cofiltered_limits_op_of_has_filtered_colimits CategoryTheory.Limits.has_cofiltered_limits_op_of_has_filtered_colimits
 
 theorem has_cofiltered_limits_of_has_filtered_colimits_op [HasFilteredColimitsOfSize.{v₂, u₂} Cᵒᵖ] :
     HasCofilteredLimitsOfSize.{v₂, u₂} C :=
-  { HasLimitsOfShape := fun I hI₂ hI₂ => has_limits_of_shape_of_has_colimits_of_shape_op }
+  { HasLimitsOfShape := fun _ _ _ => hasLimitsOfShape_of_hasColimitsOfShape_op }
 #align category_theory.limits.has_cofiltered_limits_of_has_filtered_colimits_op CategoryTheory.Limits.has_cofiltered_limits_of_has_filtered_colimits_op
 
-/-- If `F.left_op : Jᵒᵖ ⥤ C` has a limit, we can construct a colimit for `F : J ⥤ Cᵒᵖ`.
+/-- If `F.leftOp : Jᵒᵖ ⥤ C` has a limit, we can construct a colimit for `F : J ⥤ Cᵒᵖ`.
 -/
 theorem hasColimit_of_hasLimit_leftOp (F : J ⥤ Cᵒᵖ) [HasLimit F.leftOp] : HasColimit F :=
   HasColimit.mk
-    { Cocone := coconeOfConeLeftOp (limit.cone F.leftOp)
-      IsColimit := isColimitCoconeOfConeLeftOp _ (limit.isLimit _) }
+    { cocone := coconeOfConeLeftOp (limit.cone F.leftOp)
+      isColimit := isColimitCoconeOfConeLeftOp _ (limit.isLimit _) }
 #align category_theory.limits.has_colimit_of_has_limit_left_op CategoryTheory.Limits.hasColimit_of_hasLimit_leftOp
 
 theorem hasColimit_of_hasLimit_op (F : J ⥤ C) [HasLimit F.op] : HasColimit F :=
   HasColimit.mk
-    { Cocone := (limit.cone F.op).unop
-      IsColimit := isColimitConeUnop _ (limit.isLimit _) }
+    { cocone := (limit.cone F.op).unop
+      isColimit := isColimitConeUnop _ (limit.isLimit _) }
 #align category_theory.limits.has_colimit_of_has_limit_op CategoryTheory.Limits.hasColimit_of_hasLimit_op
 
 /-- If `C` has colimits of shape `Jᵒᵖ`, we can construct limits in `Cᵒᵖ` of shape `J`.
 -/
 instance hasColimitsOfShape_op_of_hasLimitsOfShape [HasLimitsOfShape Jᵒᵖ C] :
-    HasColimitsOfShape J Cᵒᵖ where HasColimit F := hasColimit_of_hasLimit_leftOp F
+    HasColimitsOfShape J Cᵒᵖ where has_colimit F := hasColimit_of_hasLimit_leftOp F
 #align category_theory.limits.has_colimits_of_shape_op_of_has_limits_of_shape CategoryTheory.Limits.hasColimitsOfShape_op_of_hasLimitsOfShape
 
 theorem hasColimitsOfShape_of_hasLimitsOfShape_op [HasLimitsOfShape Jᵒᵖ Cᵒᵖ] :
     HasColimitsOfShape J C :=
-  { HasColimit := fun F => hasColimit_of_hasLimit_op F }
+  { has_colimit := fun F => hasColimit_of_hasLimit_op F }
 #align category_theory.limits.has_colimits_of_shape_of_has_limits_of_shape_op CategoryTheory.Limits.hasColimitsOfShape_of_hasLimitsOfShape_op
 
 /-- If `C` has limits, we can construct colimits for `Cᵒᵖ`.
 -/
 instance hasColimits_op_of_hasLimits [HasLimits C] : HasColimits Cᵒᵖ :=
-  ⟨inferInstance⟩
+  ⟨fun _ => inferInstance⟩
 #align category_theory.limits.has_colimits_op_of_has_limits CategoryTheory.Limits.hasColimits_op_of_hasLimits
 
 theorem hasColimits_of_hasLimits_op [HasLimits Cᵒᵖ] : HasColimits C :=
-  { HasColimitsOfShape := fun J hJ => has_colimits_of_shape_of_has_limits_of_shape_op }
+  { has_colimits_of_shape := fun _ _ => hasColimitsOfShape_of_hasLimitsOfShape_op }
 #align category_theory.limits.has_colimits_of_has_limits_op CategoryTheory.Limits.hasColimits_of_hasLimits_op
 
 instance has_filtered_colimits_op_of_has_cofiltered_limits [HasCofilteredLimitsOfSize.{v₂, u₂} C] :
-    HasFilteredColimitsOfSize.{v₂, u₂} Cᵒᵖ where HasColimitsOfShape I hI₁ hI₂ := inferInstance
+    HasFilteredColimitsOfSize.{v₂, u₂} Cᵒᵖ where HasColimitsOfShape _ _ _ := inferInstance
 #align category_theory.limits.has_filtered_colimits_op_of_has_cofiltered_limits CategoryTheory.Limits.has_filtered_colimits_op_of_has_cofiltered_limits
 
 theorem has_filtered_colimits_of_has_cofiltered_limits_op [HasCofilteredLimitsOfSize.{v₂, u₂} Cᵒᵖ] :
     HasFilteredColimitsOfSize.{v₂, u₂} C :=
-  { HasColimitsOfShape := fun I hI₁ hI₂ => has_colimits_of_shape_of_has_limits_of_shape_op }
+  { HasColimitsOfShape := fun _ _ _ => hasColimitsOfShape_of_hasLimitsOfShape_op }
 #align category_theory.limits.has_filtered_colimits_of_has_cofiltered_limits_op CategoryTheory.Limits.has_filtered_colimits_of_has_cofiltered_limits_op
 
 variable (X : Type v₂)
@@ -335,32 +335,32 @@ variable (X : Type v₂)
 /-- If `C` has products indexed by `X`, then `Cᵒᵖ` has coproducts indexed by `X`.
 -/
 instance hasCoproductsOfShape_opposite [HasProductsOfShape X C] : HasCoproductsOfShape X Cᵒᵖ := by
-  haveI : has_limits_of_shape (discrete X)ᵒᵖ C :=
-    has_limits_of_shape_of_equivalence (discrete.opposite X).symm
+  haveI : HasLimitsOfShape (Discrete X)ᵒᵖ C :=
+    hasLimitsOfShape_of_equivalence (Discrete.opposite X).symm
   infer_instance
 #align category_theory.limits.has_coproducts_of_shape_opposite CategoryTheory.Limits.hasCoproductsOfShape_opposite
 
 theorem hasCoproductsOfShape_of_opposite [HasProductsOfShape X Cᵒᵖ] : HasCoproductsOfShape X C :=
-  haveI : has_limits_of_shape (discrete X)ᵒᵖ Cᵒᵖ :=
-    has_limits_of_shape_of_equivalence (discrete.opposite X).symm
-  has_colimits_of_shape_of_has_limits_of_shape_op
+  haveI : HasLimitsOfShape (Discrete X)ᵒᵖ Cᵒᵖ :=
+    hasLimitsOfShape_of_equivalence (Discrete.opposite X).symm
+  hasColimitsOfShape_of_hasLimitsOfShape_op
 #align category_theory.limits.has_coproducts_of_shape_of_opposite CategoryTheory.Limits.hasCoproductsOfShape_of_opposite
 
 /-- If `C` has coproducts indexed by `X`, then `Cᵒᵖ` has products indexed by `X`.
 -/
 instance hasProductsOfShape_opposite [HasCoproductsOfShape X C] : HasProductsOfShape X Cᵒᵖ := by
-  haveI : has_colimits_of_shape (discrete X)ᵒᵖ C :=
-    has_colimits_of_shape_of_equivalence (discrete.opposite X).symm
+  haveI : HasColimitsOfShape (Discrete X)ᵒᵖ C :=
+    hasColimitsOfShape_of_equivalence (Discrete.opposite X).symm
   infer_instance
 #align category_theory.limits.has_products_of_shape_opposite CategoryTheory.Limits.hasProductsOfShape_opposite
 
 theorem hasProductsOfShape_of_opposite [HasCoproductsOfShape X Cᵒᵖ] : HasProductsOfShape X C :=
-  haveI : has_colimits_of_shape (discrete X)ᵒᵖ Cᵒᵖ :=
-    has_colimits_of_shape_of_equivalence (discrete.opposite X).symm
-  has_limits_of_shape_of_has_colimits_of_shape_op
+  haveI : HasColimitsOfShape (Discrete X)ᵒᵖ Cᵒᵖ :=
+    hasColimitsOfShape_of_equivalence (Discrete.opposite X).symm
+  hasLimitsOfShape_of_hasColimitsOfShape_op
 #align category_theory.limits.has_products_of_shape_of_opposite CategoryTheory.Limits.hasProductsOfShape_of_opposite
 
-instance hasProducts_opposite [HasCoproducts.{v₂} C] : HasProducts.{v₂} Cᵒᵖ := fun X =>
+instance hasProducts_opposite [HasCoproducts.{v₂} C] : HasProducts.{v₂} Cᵒᵖ := fun _ =>
   inferInstance
 #align category_theory.limits.has_products_opposite CategoryTheory.Limits.hasProducts_opposite
 
@@ -368,7 +368,7 @@ theorem hasProducts_of_opposite [HasCoproducts.{v₂} Cᵒᵖ] : HasProducts.{v�
   hasProductsOfShape_of_opposite X
 #align category_theory.limits.has_products_of_opposite CategoryTheory.Limits.hasProducts_of_opposite
 
-instance hasCoproducts_opposite [HasProducts.{v₂} C] : HasCoproducts.{v₂} Cᵒᵖ := fun X =>
+instance hasCoproducts_opposite [HasProducts.{v₂} C] : HasCoproducts.{v₂} Cᵒᵖ := fun _ =>
   inferInstance
 #align category_theory.limits.has_coproducts_opposite CategoryTheory.Limits.hasCoproducts_opposite
 
@@ -377,130 +377,121 @@ theorem hasCoproducts_of_opposite [HasProducts.{v₂} Cᵒᵖ] : HasCoproducts.{
 #align category_theory.limits.has_coproducts_of_opposite CategoryTheory.Limits.hasCoproducts_of_opposite
 
 instance hasFiniteCoproducts_opposite [HasFiniteProducts C] : HasFiniteCoproducts Cᵒᵖ
-    where out n := Limits.hasCoproductsOfShape_opposite _
+    where out _ := Limits.hasCoproductsOfShape_opposite _
 #align category_theory.limits.has_finite_coproducts_opposite CategoryTheory.Limits.hasFiniteCoproducts_opposite
 
 theorem hasFiniteCoproducts_of_opposite [HasFiniteProducts Cᵒᵖ] : HasFiniteCoproducts C :=
-  { out := fun n => hasCoproductsOfShape_of_opposite _ }
+  { out := fun _ => hasCoproductsOfShape_of_opposite _ }
 #align category_theory.limits.has_finite_coproducts_of_opposite CategoryTheory.Limits.hasFiniteCoproducts_of_opposite
 
 instance hasFiniteProducts_opposite [HasFiniteCoproducts C] : HasFiniteProducts Cᵒᵖ
-    where out n := inferInstance
+    where out _ := inferInstance
 #align category_theory.limits.has_finite_products_opposite CategoryTheory.Limits.hasFiniteProducts_opposite
 
 theorem hasFiniteProducts_of_opposite [HasFiniteCoproducts Cᵒᵖ] : HasFiniteProducts C :=
-  { out := fun n => hasProductsOfShape_of_opposite _ }
+  { out := fun _ => hasProductsOfShape_of_opposite _ }
 #align category_theory.limits.has_finite_products_of_opposite CategoryTheory.Limits.hasFiniteProducts_of_opposite
 
 instance hasEqualizers_opposite [HasCoequalizers C] : HasEqualizers Cᵒᵖ := by
-  haveI : has_colimits_of_shape walking_parallel_pairᵒᵖ C :=
-    has_colimits_of_shape_of_equivalence walking_parallel_pair_op_equiv
+  haveI : HasColimitsOfShape WalkingParallelPairᵒᵖ C :=
+    hasColimitsOfShape_of_equivalence walkingParallelPairOpEquiv
   infer_instance
 #align category_theory.limits.has_equalizers_opposite CategoryTheory.Limits.hasEqualizers_opposite
 
 instance hasCoequalizers_opposite [HasEqualizers C] : HasCoequalizers Cᵒᵖ := by
-  haveI : has_limits_of_shape walking_parallel_pairᵒᵖ C :=
-    has_limits_of_shape_of_equivalence walking_parallel_pair_op_equiv
+  haveI : HasLimitsOfShape WalkingParallelPairᵒᵖ C :=
+    hasLimitsOfShape_of_equivalence walkingParallelPairOpEquiv
   infer_instance
 #align category_theory.limits.has_coequalizers_opposite CategoryTheory.Limits.hasCoequalizers_opposite
 
-instance hasFiniteColimits_opposite [HasFiniteLimits C] : HasFiniteColimits Cᵒᵖ
-    where out J 𝒟 𝒥 := by
-    skip
-    infer_instance
+instance hasFiniteColimits_opposite [HasFiniteLimits C] : HasFiniteColimits Cᵒᵖ :=
+  ⟨fun _ _ _ => inferInstance⟩
 #align category_theory.limits.has_finite_colimits_opposite CategoryTheory.Limits.hasFiniteColimits_opposite
 
-instance hasFiniteLimits_opposite [HasFiniteColimits C] : HasFiniteLimits Cᵒᵖ
-    where out J 𝒟 𝒥 := by
-    skip
-    infer_instance
+instance hasFiniteLimits_opposite [HasFiniteColimits C] : HasFiniteLimits Cᵒᵖ :=
+  ⟨fun _ _ _ => inferInstance⟩
 #align category_theory.limits.has_finite_limits_opposite CategoryTheory.Limits.hasFiniteLimits_opposite
 
 instance hasPullbacks_opposite [HasPushouts C] : HasPullbacks Cᵒᵖ := by
-  haveI : has_colimits_of_shape walking_cospanᵒᵖ C :=
-    has_colimits_of_shape_of_equivalence walking_cospan_op_equiv.symm
-  apply has_limits_of_shape_op_of_has_colimits_of_shape
+  haveI : HasColimitsOfShape WalkingCospanᵒᵖ C :=
+    hasColimitsOfShape_of_equivalence walkingCospanOpEquiv.symm
+  apply hasLimitsOfShape_op_of_hasColimitsOfShape
 #align category_theory.limits.has_pullbacks_opposite CategoryTheory.Limits.hasPullbacks_opposite
 
 instance hasPushouts_opposite [HasPullbacks C] : HasPushouts Cᵒᵖ := by
-  haveI : has_limits_of_shape walking_spanᵒᵖ C :=
-    has_limits_of_shape_of_equivalence walking_span_op_equiv.symm
+  haveI : HasLimitsOfShape WalkingSpanᵒᵖ C :=
+    hasLimitsOfShape_of_equivalence walkingSpanOpEquiv.symm
   infer_instance
 #align category_theory.limits.has_pushouts_opposite CategoryTheory.Limits.hasPushouts_opposite
 
-/-- The canonical isomorphism relating `span f.op g.op` and `(cospan f g).op` -/
-@[simps]
+/-- The canonical isomorphism relating `Span f.op g.op` and `(Cospan f g).op` -/
+@[simps!]
 def spanOp {X Y Z : C} (f : X ⟶ Z) (g : Y ⟶ Z) :
     span f.op g.op ≅ walkingCospanOpEquiv.inverse ⋙ (cospan f g).op :=
   NatIso.ofComponents (by rintro (_ | _ | _) <;> rfl)
-    (by rintro (_ | _ | _) (_ | _ | _) f <;> cases f <;> tidy)
+    (by rintro (_ | _ | _) (_ | _ | _) f <;> cases f <;> aesop_cat)
 #align category_theory.limits.span_op CategoryTheory.Limits.spanOp
 
-/-- The canonical isomorphism relating `(cospan f g).op` and `span f.op g.op` -/
-@[simps]
+/-- The canonical isomorphism relating `(Cospan f g).op` and `Span f.op g.op` -/
+@[simps!]
 def opCospan {X Y Z : C} (f : X ⟶ Z) (g : Y ⟶ Z) :
-    (cospan f g).op ≅ walkingCospanOpEquiv.Functor ⋙ span f.op g.op :=
+    (cospan f g).op ≅ walkingCospanOpEquiv.functor ⋙ span f.op g.op :=
   calc
     (cospan f g).op ≅ 𝟭 _ ⋙ (cospan f g).op := by rfl
-    _ ≅ (walkingCospanOpEquiv.Functor ⋙ walkingCospanOpEquiv.inverse) ⋙ (cospan f g).op :=
+    _ ≅ (walkingCospanOpEquiv.functor ⋙ walkingCospanOpEquiv.inverse) ⋙ (cospan f g).op :=
       (isoWhiskerRight walkingCospanOpEquiv.unitIso _)
-    _ ≅ walkingCospanOpEquiv.Functor ⋙ walkingCospanOpEquiv.inverse ⋙ (cospan f g).op :=
+    _ ≅ walkingCospanOpEquiv.functor ⋙ walkingCospanOpEquiv.inverse ⋙ (cospan f g).op :=
       (Functor.associator _ _ _)
-    _ ≅ walkingCospanOpEquiv.Functor ⋙ span f.op g.op := isoWhiskerLeft _ (spanOp f g).symm
-    
+    _ ≅ walkingCospanOpEquiv.functor ⋙ span f.op g.op := isoWhiskerLeft _ (spanOp f g).symm
 #align category_theory.limits.op_cospan CategoryTheory.Limits.opCospan
 
-/-- The canonical isomorphism relating `cospan f.op g.op` and `(span f g).op` -/
-@[simps]
+/-- The canonical isomorphism relating `Cospan f.op g.op` and `(Span f g).op` -/
+@[simps!]
 def cospanOp {X Y Z : C} (f : X ⟶ Y) (g : X ⟶ Z) :
     cospan f.op g.op ≅ walkingSpanOpEquiv.inverse ⋙ (span f g).op :=
   NatIso.ofComponents (by rintro (_ | _ | _) <;> rfl)
-    (by rintro (_ | _ | _) (_ | _ | _) f <;> cases f <;> tidy)
+    (by rintro (_ | _ | _) (_ | _ | _) f <;> cases f <;> aesop_cat)
 #align category_theory.limits.cospan_op CategoryTheory.Limits.cospanOp
 
-/-- The canonical isomorphism relating `(span f g).op` and `cospan f.op g.op` -/
-@[simps]
+/-- The canonical isomorphism relating `(Span f g).op` and `Cospan f.op g.op` -/
+@[simps!]
 def opSpan {X Y Z : C} (f : X ⟶ Y) (g : X ⟶ Z) :
-    (span f g).op ≅ walkingSpanOpEquiv.Functor ⋙ cospan f.op g.op :=
+    (span f g).op ≅ walkingSpanOpEquiv.functor ⋙ cospan f.op g.op :=
   calc
     (span f g).op ≅ 𝟭 _ ⋙ (span f g).op := by rfl
-    _ ≅ (walkingSpanOpEquiv.Functor ⋙ walkingSpanOpEquiv.inverse) ⋙ (span f g).op :=
+    _ ≅ (walkingSpanOpEquiv.functor ⋙ walkingSpanOpEquiv.inverse) ⋙ (span f g).op :=
       (isoWhiskerRight walkingSpanOpEquiv.unitIso _)
-    _ ≅ walkingSpanOpEquiv.Functor ⋙ walkingSpanOpEquiv.inverse ⋙ (span f g).op :=
+    _ ≅ walkingSpanOpEquiv.functor ⋙ walkingSpanOpEquiv.inverse ⋙ (span f g).op :=
       (Functor.associator _ _ _)
-    _ ≅ walkingSpanOpEquiv.Functor ⋙ cospan f.op g.op := isoWhiskerLeft _ (cospanOp f g).symm
-    
+    _ ≅ walkingSpanOpEquiv.functor ⋙ cospan f.op g.op := isoWhiskerLeft _ (cospanOp f g).symm
+
 #align category_theory.limits.op_span CategoryTheory.Limits.opSpan
 
 namespace PushoutCocone
 
-/-- The obvious map `pushout_cocone f g → pullback_cone f.unop g.unop` -/
-@[simps (config := lemmasOnly)]
+-- porting note: it was originally @[simps (config := lemmasOnly)]
+/-- The obvious map `PushoutCocone f g → PullbackCone f.unop g.unop` -/
+@[simps!]
 def unop {X Y Z : Cᵒᵖ} {f : X ⟶ Y} {g : X ⟶ Z} (c : PushoutCocone f g) :
     PullbackCone f.unop g.unop :=
   Cocone.unop
     ((Cocones.precompose (opCospan f.unop g.unop).hom).obj
-      (Cocone.whisker walkingCospanOpEquiv.Functor c))
+      (Cocone.whisker walkingCospanOpEquiv.functor c))
 #align category_theory.limits.pushout_cocone.unop CategoryTheory.Limits.PushoutCocone.unop
 
 @[simp]
 theorem unop_fst {X Y Z : Cᵒᵖ} {f : X ⟶ Y} {g : X ⟶ Z} (c : PushoutCocone f g) :
-    c.unop.fst = c.inl.unop := by
-  change (_ : limits.cone _).π.app _ = _
-  simp only [pushout_cocone.ι_app_left, pushout_cocone.unop_π_app]
-  tidy
+    c.unop.fst = c.inl.unop := by aesop_cat
 #align category_theory.limits.pushout_cocone.unop_fst CategoryTheory.Limits.PushoutCocone.unop_fst
 
 @[simp]
 theorem unop_snd {X Y Z : Cᵒᵖ} {f : X ⟶ Y} {g : X ⟶ Z} (c : PushoutCocone f g) :
-    c.unop.snd = c.inr.unop := by
-  change (_ : limits.cone _).π.app _ = _
-  simp only [pushout_cocone.unop_π_app, pushout_cocone.ι_app_right]
-  tidy
+    c.unop.snd = c.inr.unop := by aesop_cat
 #align category_theory.limits.pushout_cocone.unop_snd CategoryTheory.Limits.PushoutCocone.unop_snd
 
-/-- The obvious map `pushout_cocone f.op g.op → pullback_cone f g` -/
-@[simps (config := lemmasOnly)]
+-- porting note: it was originally @[simps (config := lemmasOnly)]
+/-- The obvious map `PushoutCocone f.op g.op → PullbackCone f g` -/
+@[simps!]
 def op {X Y Z : C} {f : X ⟶ Y} {g : X ⟶ Z} (c : PushoutCocone f g) : PullbackCone f.op g.op :=
   (Cones.postcompose (cospanOp f g).symm.hom).obj
     (Cone.whisker walkingSpanOpEquiv.inverse (Cocone.op c))
@@ -508,50 +499,40 @@ def op {X Y Z : C} {f : X ⟶ Y} {g : X ⟶ Z} (c : PushoutCocone f g) : Pullbac
 
 @[simp]
 theorem op_fst {X Y Z : C} {f : X ⟶ Y} {g : X ⟶ Z} (c : PushoutCocone f g) : c.op.fst = c.inl.op :=
-  by
-  change (_ : limits.cone _).π.app _ = _
-  apply category.comp_id
+  by aesop_cat
 #align category_theory.limits.pushout_cocone.op_fst CategoryTheory.Limits.PushoutCocone.op_fst
 
 @[simp]
 theorem op_snd {X Y Z : C} {f : X ⟶ Y} {g : X ⟶ Z} (c : PushoutCocone f g) : c.op.snd = c.inr.op :=
-  by
-  change (_ : limits.cone _).π.app _ = _
-  apply category.comp_id
+  by aesop_cat
 #align category_theory.limits.pushout_cocone.op_snd CategoryTheory.Limits.PushoutCocone.op_snd
 
 end PushoutCocone
 
 namespace PullbackCone
 
-/-- The obvious map `pullback_cone f g → pushout_cocone f.unop g.unop` -/
-@[simps (config := lemmasOnly)]
+-- porting note: it was originally @[simps (config := lemmasOnly)]
+/-- The obvious map `PullbackCone f g → PushoutCocone f.unop g.unop` -/
+@[simps!]
 def unop {X Y Z : Cᵒᵖ} {f : X ⟶ Z} {g : Y ⟶ Z} (c : PullbackCone f g) :
     PushoutCocone f.unop g.unop :=
   Cone.unop
     ((Cones.postcompose (opSpan f.unop g.unop).symm.hom).obj
-      (Cone.whisker walkingSpanOpEquiv.Functor c))
+      (Cone.whisker walkingSpanOpEquiv.functor c))
 #align category_theory.limits.pullback_cone.unop CategoryTheory.Limits.PullbackCone.unop
 
 @[simp]
 theorem unop_inl {X Y Z : Cᵒᵖ} {f : X ⟶ Z} {g : Y ⟶ Z} (c : PullbackCone f g) :
-    c.unop.inl = c.fst.unop := by
-  change (_ : limits.cocone _).ι.app _ = _
-  dsimp only [unop, op_span]
-  simp; dsimp; simp; dsimp; simp
+    c.unop.inl = c.fst.unop := by aesop_cat
 #align category_theory.limits.pullback_cone.unop_inl CategoryTheory.Limits.PullbackCone.unop_inl
 
 @[simp]
 theorem unop_inr {X Y Z : Cᵒᵖ} {f : X ⟶ Z} {g : Y ⟶ Z} (c : PullbackCone f g) :
-    c.unop.inr = c.snd.unop := by
-  change (_ : limits.cocone _).ι.app _ = _
-  apply Quiver.Hom.op_inj
-  simp [unop_ι_app]; dsimp; simp
-  apply category.comp_id
+    c.unop.inr = c.snd.unop := by aesop_cat
 #align category_theory.limits.pullback_cone.unop_inr CategoryTheory.Limits.PullbackCone.unop_inr
 
-/-- The obvious map `pullback_cone f g → pushout_cocone f.op g.op` -/
-@[simps (config := lemmasOnly)]
+/-- The obvious map `PullbackCone f g → PushoutCocone f.op g.op` -/
+@[simps!]
 def op {X Y Z : C} {f : X ⟶ Z} {g : Y ⟶ Z} (c : PullbackCone f g) : PushoutCocone f.op g.op :=
   (Cocones.precompose (spanOp f g).hom).obj
     (Cocone.whisker walkingCospanOpEquiv.inverse (Cone.op c))
@@ -559,16 +540,12 @@ def op {X Y Z : C} {f : X ⟶ Z} {g : Y ⟶ Z} (c : PullbackCone f g) : PushoutC
 
 @[simp]
 theorem op_inl {X Y Z : C} {f : X ⟶ Z} {g : Y ⟶ Z} (c : PullbackCone f g) : c.op.inl = c.fst.op :=
-  by
-  change (_ : limits.cocone _).ι.app _ = _
-  apply category.id_comp
+  by aesop_cat
 #align category_theory.limits.pullback_cone.op_inl CategoryTheory.Limits.PullbackCone.op_inl
 
 @[simp]
 theorem op_inr {X Y Z : C} {f : X ⟶ Z} {g : Y ⟶ Z} (c : PullbackCone f g) : c.op.inr = c.snd.op :=
-  by
-  change (_ : limits.cocone _).ι.app _ = _
-  apply category.id_comp
+  by aesop_cat
 #align category_theory.limits.pullback_cone.op_inr CategoryTheory.Limits.PullbackCone.op_inr
 
 /-- If `c` is a pullback cone, then `c.op.unop` is isomorphic to `c`. -/
@@ -599,34 +576,36 @@ def unopOp {X Y Z : Cᵒᵖ} {f : X ⟶ Y} {g : X ⟶ Z} (c : PushoutCocone f g)
 in the opposite category is a limit cone. -/
 def isColimitEquivIsLimitOp {X Y Z : C} {f : X ⟶ Y} {g : X ⟶ Z} (c : PushoutCocone f g) :
     IsColimit c ≃ IsLimit c.op := by
-  apply equivOfSubsingletonOfSubsingleton
-  · intro h
-    equiv_rw is_limit.postcompose_hom_equiv _ _
-    equiv_rw(is_limit.whisker_equivalence_equiv walking_span_op_equiv.symm).symm
-    exact is_limit_cocone_op _ h
-  · intro h
-    equiv_rw is_colimit.equiv_iso_colimit c.op_unop.symm
-    apply is_colimit_cone_unop
-    equiv_rw is_limit.postcompose_hom_equiv _ _
-    equiv_rw(is_limit.whisker_equivalence_equiv _).symm
-    exact h
+  sorry
+  --apply equivOfSubsingletonOfSubsingleton
+  --· intro h
+  --  equiv_rw is_limit.postcompose_hom_equiv _ _
+  --  equiv_rw(is_limit.whisker_equivalence_equiv walking_span_op_equiv.symm).symm
+  --  exact is_limit_cocone_op _ h
+  --· intro h
+  --  equiv_rw is_colimit.equiv_iso_colimit c.op_unop.symm
+  --  apply is_colimit_cone_unop
+  --  equiv_rw is_limit.postcompose_hom_equiv _ _
+  --  equiv_rw(is_limit.whisker_equivalence_equiv _).symm
+  --  exact h
 #align category_theory.limits.pushout_cocone.is_colimit_equiv_is_limit_op CategoryTheory.Limits.PushoutCocone.isColimitEquivIsLimitOp
 
 /-- A pushout cone is a colimit cocone in `Cᵒᵖ` if and only if the corresponding pullback cone
 in `C` is a limit cone. -/
 def isColimitEquivIsLimitUnop {X Y Z : Cᵒᵖ} {f : X ⟶ Y} {g : X ⟶ Z} (c : PushoutCocone f g) :
     IsColimit c ≃ IsLimit c.unop := by
-  apply equivOfSubsingletonOfSubsingleton
-  · intro h
-    apply is_limit_cocone_unop
-    equiv_rw is_colimit.precompose_hom_equiv _ _
-    equiv_rw(is_colimit.whisker_equivalence_equiv _).symm
-    exact h
-  · intro h
-    equiv_rw is_colimit.equiv_iso_colimit c.unop_op.symm
-    equiv_rw is_colimit.precompose_hom_equiv _ _
-    equiv_rw(is_colimit.whisker_equivalence_equiv walking_cospan_op_equiv.symm).symm
-    exact is_colimit_cone_op _ h
+  sorry
+  --apply equivOfSubsingletonOfSubsingleton
+  --· intro h
+  --  apply is_limit_cocone_unop
+  --  equiv_rw is_colimit.precompose_hom_equiv _ _
+  --  equiv_rw(is_colimit.whisker_equivalence_equiv _).symm
+  --  exact h
+  --· intro h
+  --  equiv_rw is_colimit.equiv_iso_colimit c.unop_op.symm
+  --  equiv_rw is_colimit.precompose_hom_equiv _ _
+  --  equiv_rw(is_colimit.whisker_equivalence_equiv walking_cospan_op_equiv.symm).symm
+  --  exact is_colimit_cone_op _ h
 #align category_theory.limits.pushout_cocone.is_colimit_equiv_is_limit_unop CategoryTheory.Limits.PushoutCocone.isColimitEquivIsLimitUnop
 
 end PushoutCocone
@@ -637,14 +616,14 @@ namespace PullbackCone
 in the opposite category is a colimit cocone. -/
 def isLimitEquivIsColimitOp {X Y Z : C} {f : X ⟶ Z} {g : Y ⟶ Z} (c : PullbackCone f g) :
     IsLimit c ≃ IsColimit c.op :=
-  (IsLimit.equivIsoLimit c.op_unop).symm.trans c.op.isColimitEquivIsLimitUnop.symm
+  (IsLimit.equivIsoLimit c.opUnop).symm.trans c.op.isColimitEquivIsLimitUnop.symm
 #align category_theory.limits.pullback_cone.is_limit_equiv_is_colimit_op CategoryTheory.Limits.PullbackCone.isLimitEquivIsColimitOp
 
 /-- A pullback cone is a limit cone in `Cᵒᵖ` if and only if the corresponding pushout cocone
 in `C` is a colimit cocone. -/
 def isLimitEquivIsColimitUnop {X Y Z : Cᵒᵖ} {f : X ⟶ Z} {g : Y ⟶ Z} (c : PullbackCone f g) :
     IsLimit c ≃ IsColimit c.unop :=
-  (IsLimit.equivIsoLimit c.unop_op).symm.trans c.unop.isColimitEquivIsLimitOp.symm
+  (IsLimit.equivIsoLimit c.unopOp).symm.trans c.unop.isColimitEquivIsLimitOp.symm
 #align category_theory.limits.pullback_cone.is_limit_equiv_is_colimit_unop CategoryTheory.Limits.PullbackCone.isLimitEquivIsColimitUnop
 
 end PullbackCone
@@ -655,42 +634,42 @@ open Opposite
 
 /-- The pullback of `f` and `g` in `C` is isomorphic to the pushout of
 `f.op` and `g.op` in `Cᵒᵖ`. -/
-noncomputable def pullbackIsoUnopPushout {X Y Z : C} (f : X ⟶ Z) (g : Y ⟶ Z) [HasPullback f g]
+noncomputable def pullbackIsoUnopPushout {X Y Z : C} (f : X ⟶ Z) (g : Y ⟶ Z) [h : HasPullback f g]
     [HasPushout f.op g.op] : pullback f g ≅ unop (pushout f.op g.op) :=
-  IsLimit.conePointUniqueUpToIso (limit.isLimit _)
+  IsLimit.conePointUniqueUpToIso (@limit.isLimit _ _ _ _ _ h)
     ((PushoutCocone.isColimitEquivIsLimitUnop _) (colimit.isColimit (span f.op g.op)))
 #align category_theory.limits.pullback_iso_unop_pushout CategoryTheory.Limits.pullbackIsoUnopPushout
 
-@[simp, reassoc.1]
+@[reassoc (attr := simp)]
 theorem pullbackIsoUnopPushout_inv_fst {X Y Z : C} (f : X ⟶ Z) (g : Y ⟶ Z) [HasPullback f g]
     [HasPushout f.op g.op] :
     (pullbackIsoUnopPushout f g).inv ≫ pullback.fst = (pushout.inl : _ ⟶ pushout f.op g.op).unop :=
   (IsLimit.conePointUniqueUpToIso_inv_comp _ _ _).trans (by simp)
 #align category_theory.limits.pullback_iso_unop_pushout_inv_fst CategoryTheory.Limits.pullbackIsoUnopPushout_inv_fst
 
-@[simp, reassoc.1]
+@[reassoc (attr := simp)]
 theorem pullbackIsoUnopPushout_inv_snd {X Y Z : C} (f : X ⟶ Z) (g : Y ⟶ Z) [HasPullback f g]
     [HasPushout f.op g.op] :
     (pullbackIsoUnopPushout f g).inv ≫ pullback.snd = (pushout.inr : _ ⟶ pushout f.op g.op).unop :=
   (IsLimit.conePointUniqueUpToIso_inv_comp _ _ _).trans (by simp)
 #align category_theory.limits.pullback_iso_unop_pushout_inv_snd CategoryTheory.Limits.pullbackIsoUnopPushout_inv_snd
 
-@[simp, reassoc.1]
+@[reassoc (attr := simp)]
 theorem pullbackIsoUnopPushout_hom_inl {X Y Z : C} (f : X ⟶ Z) (g : Y ⟶ Z) [HasPullback f g]
     [HasPushout f.op g.op] : pushout.inl ≫ (pullbackIsoUnopPushout f g).hom.op = pullback.fst.op :=
   by
   apply Quiver.Hom.unop_inj
   dsimp
-  rw [← pullback_iso_unop_pushout_inv_fst, iso.hom_inv_id_assoc]
+  rw [← pullbackIsoUnopPushout_inv_fst, Iso.hom_inv_id_assoc]
 #align category_theory.limits.pullback_iso_unop_pushout_hom_inl CategoryTheory.Limits.pullbackIsoUnopPushout_hom_inl
 
-@[simp, reassoc.1]
+@[reassoc (attr := simp)]
 theorem pullbackIsoUnopPushout_hom_inr {X Y Z : C} (f : X ⟶ Z) (g : Y ⟶ Z) [HasPullback f g]
     [HasPushout f.op g.op] : pushout.inr ≫ (pullbackIsoUnopPushout f g).hom.op = pullback.snd.op :=
   by
   apply Quiver.Hom.unop_inj
   dsimp
-  rw [← pullback_iso_unop_pushout_inv_snd, iso.hom_inv_id_assoc]
+  rw [← pullbackIsoUnopPushout_inv_snd, Iso.hom_inv_id_assoc]
 #align category_theory.limits.pullback_iso_unop_pushout_hom_inr CategoryTheory.Limits.pullbackIsoUnopPushout_hom_inr
 
 end Pullback
@@ -699,20 +678,20 @@ section Pushout
 
 /-- The pushout of `f` and `g` in `C` is isomorphic to the pullback of
  `f.op` and `g.op` in `Cᵒᵖ`. -/
-noncomputable def pushoutIsoUnopPullback {X Y Z : C} (f : X ⟶ Z) (g : X ⟶ Y) [HasPushout f g]
+noncomputable def pushoutIsoUnopPullback {X Y Z : C} (f : X ⟶ Z) (g : X ⟶ Y) [h : HasPushout f g]
     [HasPullback f.op g.op] : pushout f g ≅ unop (pullback f.op g.op) :=
-  IsColimit.coconePointUniqueUpToIso (colimit.isColimit _)
+  IsColimit.coconePointUniqueUpToIso (@colimit.isColimit _ _ _ _ _ h)
     ((PullbackCone.isLimitEquivIsColimitUnop _) (limit.isLimit (cospan f.op g.op)))
 #align category_theory.limits.pushout_iso_unop_pullback CategoryTheory.Limits.pushoutIsoUnopPullback
 
-@[simp, reassoc.1]
+@[reassoc (attr := simp)]
 theorem pushoutIsoUnopPullback_inl_hom {X Y Z : C} (f : X ⟶ Z) (g : X ⟶ Y) [HasPushout f g]
     [HasPullback f.op g.op] :
     pushout.inl ≫ (pushoutIsoUnopPullback f g).hom = (pullback.fst : pullback f.op g.op ⟶ _).unop :=
   (IsColimit.comp_coconePointUniqueUpToIso_hom _ _ _).trans (by simp)
 #align category_theory.limits.pushout_iso_unop_pullback_inl_hom CategoryTheory.Limits.pushoutIsoUnopPullback_inl_hom
 
-@[simp, reassoc.1]
+@[reassoc (attr := simp)]
 theorem pushoutIsoUnopPullback_inr_hom {X Y Z : C} (f : X ⟶ Z) (g : X ⟶ Y) [HasPushout f g]
     [HasPullback f.op g.op] :
     pushout.inr ≫ (pushoutIsoUnopPullback f g).hom = (pullback.snd : pullback f.op g.op ⟶ _).unop :=
@@ -725,7 +704,7 @@ theorem pushoutIsoUnopPullback_inv_fst {X Y Z : C} (f : X ⟶ Z) (g : X ⟶ Y) [
   by
   apply Quiver.Hom.unop_inj
   dsimp
-  rw [← pushout_iso_unop_pullback_inl_hom, category.assoc, iso.hom_inv_id, category.comp_id]
+  rw [← pushoutIsoUnopPullback_inl_hom, Category.assoc, Iso.hom_inv_id, Category.comp_id]
 #align category_theory.limits.pushout_iso_unop_pullback_inv_fst CategoryTheory.Limits.pushoutIsoUnopPullback_inv_fst
 
 @[simp]
@@ -734,10 +713,9 @@ theorem pushoutIsoUnopPullback_inv_snd {X Y Z : C} (f : X ⟶ Z) (g : X ⟶ Y) [
   by
   apply Quiver.Hom.unop_inj
   dsimp
-  rw [← pushout_iso_unop_pullback_inr_hom, category.assoc, iso.hom_inv_id, category.comp_id]
+  rw [← pushoutIsoUnopPullback_inr_hom, Category.assoc, Iso.hom_inv_id, Category.comp_id]
 #align category_theory.limits.pushout_iso_unop_pullback_inv_snd CategoryTheory.Limits.pushoutIsoUnopPullback_inv_snd
 
 end Pushout
 
 end CategoryTheory.Limits
-

--- a/Mathlib/CategoryTheory/Limits/Opposites.lean
+++ b/Mathlib/CategoryTheory/Limits/Opposites.lean
@@ -478,12 +478,12 @@ def unop {X Y Z : Cᵒᵖ} {f : X ⟶ Y} {g : X ⟶ Z} (c : PushoutCocone f g) :
       (Cocone.whisker walkingCospanOpEquiv.functor c))
 #align category_theory.limits.pushout_cocone.unop CategoryTheory.Limits.PushoutCocone.unop
 
-@[simp]
+-- porting note: removed simp attribute as the equality can already be obtained by simp
 theorem unop_fst {X Y Z : Cᵒᵖ} {f : X ⟶ Y} {g : X ⟶ Z} (c : PushoutCocone f g) :
-    c.unop.fst = c.inl.unop := by aesop_cat
+    c.unop.fst = c.inl.unop := by simp
 #align category_theory.limits.pushout_cocone.unop_fst CategoryTheory.Limits.PushoutCocone.unop_fst
 
-@[simp]
+-- porting note: removed simp attribute as the equality can already be obtained by simp
 theorem unop_snd {X Y Z : Cᵒᵖ} {f : X ⟶ Y} {g : X ⟶ Z} (c : PushoutCocone f g) :
     c.unop.snd = c.inr.unop := by aesop_cat
 #align category_theory.limits.pushout_cocone.unop_snd CategoryTheory.Limits.PushoutCocone.unop_snd
@@ -496,12 +496,12 @@ def op {X Y Z : C} {f : X ⟶ Y} {g : X ⟶ Z} (c : PushoutCocone f g) : Pullbac
     (Cone.whisker walkingSpanOpEquiv.inverse (Cocone.op c))
 #align category_theory.limits.pushout_cocone.op CategoryTheory.Limits.PushoutCocone.op
 
-@[simp]
+-- porting note: removed simp attribute as the equality can already be obtained by simp
 theorem op_fst {X Y Z : C} {f : X ⟶ Y} {g : X ⟶ Z} (c : PushoutCocone f g) : c.op.fst = c.inl.op :=
   by aesop_cat
 #align category_theory.limits.pushout_cocone.op_fst CategoryTheory.Limits.PushoutCocone.op_fst
 
-@[simp]
+-- porting note: removed simp attribute as the equality can already be obtained by simp
 theorem op_snd {X Y Z : C} {f : X ⟶ Y} {g : X ⟶ Z} (c : PushoutCocone f g) : c.op.snd = c.inr.op :=
   by aesop_cat
 #align category_theory.limits.pushout_cocone.op_snd CategoryTheory.Limits.PushoutCocone.op_snd
@@ -520,12 +520,12 @@ def unop {X Y Z : Cᵒᵖ} {f : X ⟶ Z} {g : Y ⟶ Z} (c : PullbackCone f g) :
       (Cone.whisker walkingSpanOpEquiv.functor c))
 #align category_theory.limits.pullback_cone.unop CategoryTheory.Limits.PullbackCone.unop
 
-@[simp]
+-- porting note: removed simp attribute as the equality can already be obtained by simp
 theorem unop_inl {X Y Z : Cᵒᵖ} {f : X ⟶ Z} {g : Y ⟶ Z} (c : PullbackCone f g) :
     c.unop.inl = c.fst.unop := by aesop_cat
 #align category_theory.limits.pullback_cone.unop_inl CategoryTheory.Limits.PullbackCone.unop_inl
 
-@[simp]
+-- porting note: removed simp attribute as the equality can already be obtained by simp
 theorem unop_inr {X Y Z : Cᵒᵖ} {f : X ⟶ Z} {g : Y ⟶ Z} (c : PullbackCone f g) :
     c.unop.inr = c.snd.unop := by aesop_cat
 #align category_theory.limits.pullback_cone.unop_inr CategoryTheory.Limits.PullbackCone.unop_inr
@@ -537,12 +537,12 @@ def op {X Y Z : C} {f : X ⟶ Z} {g : Y ⟶ Z} (c : PullbackCone f g) : PushoutC
     (Cocone.whisker walkingCospanOpEquiv.inverse (Cone.op c))
 #align category_theory.limits.pullback_cone.op CategoryTheory.Limits.PullbackCone.op
 
-@[simp]
+-- porting note: removed simp attribute as the equality can already be obtained by simp
 theorem op_inl {X Y Z : C} {f : X ⟶ Z} {g : Y ⟶ Z} (c : PullbackCone f g) : c.op.inl = c.fst.op :=
   by aesop_cat
 #align category_theory.limits.pullback_cone.op_inl CategoryTheory.Limits.PullbackCone.op_inl
 
-@[simp]
+-- porting note: removed simp attribute as the equality can already be obtained by simp
 theorem op_inr {X Y Z : C} {f : X ⟶ Z} {g : Y ⟶ Z} (c : PullbackCone f g) : c.op.inr = c.snd.op :=
   by aesop_cat
 #align category_theory.limits.pullback_cone.op_inr CategoryTheory.Limits.PullbackCone.op_inr
@@ -575,36 +575,28 @@ def unopOp {X Y Z : Cᵒᵖ} {f : X ⟶ Y} {g : X ⟶ Z} (c : PushoutCocone f g)
 in the opposite category is a limit cone. -/
 def isColimitEquivIsLimitOp {X Y Z : C} {f : X ⟶ Y} {g : X ⟶ Z} (c : PushoutCocone f g) :
     IsColimit c ≃ IsLimit c.op := by
-  sorry
-  --apply equivOfSubsingletonOfSubsingleton
-  --· intro h
-  --  equiv_rw is_limit.postcompose_hom_equiv _ _
-  --  equiv_rw(is_limit.whisker_equivalence_equiv walking_span_op_equiv.symm).symm
-  --  exact is_limit_cocone_op _ h
-  --· intro h
-  --  equiv_rw is_colimit.equiv_iso_colimit c.op_unop.symm
-  --  apply is_colimit_cone_unop
-  --  equiv_rw is_limit.postcompose_hom_equiv _ _
-  --  equiv_rw(is_limit.whisker_equivalence_equiv _).symm
-  --  exact h
+  apply equivOfSubsingletonOfSubsingleton
+  . intro h
+    exact (IsLimit.postcomposeHomEquiv _ _).invFun
+      ((IsLimit.whiskerEquivalenceEquiv walkingSpanOpEquiv.symm).toFun (isLimitCoconeOp _ h))
+  . intro h
+    exact (IsColimit.equivIsoColimit c.opUnop).toFun
+      (isColimitConeUnop _ ((IsLimit.postcomposeHomEquiv _ _).invFun
+        ((IsLimit.whiskerEquivalenceEquiv _).toFun h)))
 #align category_theory.limits.pushout_cocone.is_colimit_equiv_is_limit_op CategoryTheory.Limits.PushoutCocone.isColimitEquivIsLimitOp
 
 /-- A pushout cone is a colimit cocone in `Cᵒᵖ` if and only if the corresponding pullback cone
 in `C` is a limit cone. -/
 def isColimitEquivIsLimitUnop {X Y Z : Cᵒᵖ} {f : X ⟶ Y} {g : X ⟶ Z} (c : PushoutCocone f g) :
     IsColimit c ≃ IsLimit c.unop := by
-  sorry
-  --apply equivOfSubsingletonOfSubsingleton
-  --· intro h
-  --  apply is_limit_cocone_unop
-  --  equiv_rw is_colimit.precompose_hom_equiv _ _
-  --  equiv_rw(is_colimit.whisker_equivalence_equiv _).symm
-  --  exact h
-  --· intro h
-  --  equiv_rw is_colimit.equiv_iso_colimit c.unop_op.symm
-  --  equiv_rw is_colimit.precompose_hom_equiv _ _
-  --  equiv_rw(is_colimit.whisker_equivalence_equiv walking_cospan_op_equiv.symm).symm
-  --  exact is_colimit_cone_op _ h
+  apply equivOfSubsingletonOfSubsingleton
+  . intro h
+    exact isLimitCoconeOp _ ((IsColimit.precomposeHomEquiv _ _).invFun
+      ((IsColimit.whiskerEquivalenceEquiv _).toFun h))
+  . intro h
+    exact (IsColimit.equivIsoColimit c.unopOp).toFun
+      ((IsColimit.precomposeHomEquiv _ _).invFun
+      ((IsColimit.whiskerEquivalenceEquiv walkingCospanOpEquiv.symm).toFun (isColimitConeOp _ h)))
 #align category_theory.limits.pushout_cocone.is_colimit_equiv_is_limit_unop CategoryTheory.Limits.PushoutCocone.isColimitEquivIsLimitUnop
 
 end PushoutCocone

--- a/Mathlib/CategoryTheory/Limits/Opposites.lean
+++ b/Mathlib/CategoryTheory/Limits/Opposites.lean
@@ -11,7 +11,6 @@ Authors: Scott Morrison, Floris van Doorn
 import Mathlib.CategoryTheory.Limits.Filtered
 import Mathlib.CategoryTheory.Limits.Shapes.FiniteProducts
 import Mathlib.CategoryTheory.DiscreteCategory
---import Mathlib.Tactic.EquivRw
 
 /-!
 # Limits in `C` give colimits in `Cᵒᵖ`.

--- a/Mathlib/CategoryTheory/Limits/Opposites.lean
+++ b/Mathlib/CategoryTheory/Limits/Opposites.lean
@@ -1,0 +1,755 @@
+/-
+Copyright (c) 2019 Scott Morrison. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Scott Morrison, Floris van Doorn
+
+! This file was ported from Lean 3 source module category_theory.limits.opposites
+! leanprover-community/mathlib commit ac3ae212f394f508df43e37aa093722fa9b65d31
+! Please do not edit these lines, except to modify the commit id
+! if you have ported upstream changes.
+-/
+import Mathbin.CategoryTheory.Limits.Filtered
+import Mathbin.CategoryTheory.Limits.Shapes.FiniteProducts
+import Mathbin.CategoryTheory.DiscreteCategory
+import Mathbin.Tactic.EquivRw
+
+/-!
+# Limits in `C` give colimits in `Cᵒᵖ`.
+
+We also give special cases for (co)products,
+(co)equalizers, and pullbacks / pushouts.
+
+-/
+
+
+universe v₁ v₂ u₁ u₂
+
+noncomputable section
+
+open CategoryTheory
+
+open CategoryTheory.Functor
+
+open Opposite
+
+namespace CategoryTheory.Limits
+
+variable {C : Type u₁} [Category.{v₁} C]
+
+variable {J : Type u₂} [Category.{v₂} J]
+
+/-- Turn a colimit for `F : J ⥤ C` into a limit for `F.op : Jᵒᵖ ⥤ Cᵒᵖ`. -/
+@[simps]
+def isLimitCoconeOp (F : J ⥤ C) {c : Cocone F} (hc : IsColimit c) : IsLimit c.op
+    where
+  lift s := (hc.desc s.unop).op
+  fac s j := Quiver.Hom.unop_inj (by simpa)
+  uniq s m w := by
+    refine' Quiver.Hom.unop_inj (hc.hom_ext fun j => Quiver.Hom.op_inj _)
+    simpa only [Quiver.Hom.unop_op, is_colimit.fac] using w (op j)
+#align category_theory.limits.is_limit_cocone_op CategoryTheory.Limits.isLimitCoconeOp
+
+/-- Turn a limit for `F : J ⥤ C` into a colimit for `F.op : Jᵒᵖ ⥤ Cᵒᵖ`. -/
+@[simps]
+def isColimitConeOp (F : J ⥤ C) {c : Cone F} (hc : IsLimit c) : IsColimit c.op
+    where
+  desc s := (hc.lift s.unop).op
+  fac s j := Quiver.Hom.unop_inj (by simpa)
+  uniq s m w := by
+    refine' Quiver.Hom.unop_inj (hc.hom_ext fun j => Quiver.Hom.op_inj _)
+    simpa only [Quiver.Hom.unop_op, is_limit.fac] using w (op j)
+#align category_theory.limits.is_colimit_cone_op CategoryTheory.Limits.isColimitConeOp
+
+/-- Turn a colimit for `F : J ⥤ Cᵒᵖ` into a limit for `F.left_op : Jᵒᵖ ⥤ C`. -/
+@[simps]
+def isLimitConeLeftOpOfCocone (F : J ⥤ Cᵒᵖ) {c : Cocone F} (hc : IsColimit c) :
+    IsLimit (coneLeftOpOfCocone c)
+    where
+  lift s := (hc.desc (coconeOfConeLeftOp s)).unop
+  fac s j :=
+    Quiver.Hom.op_inj <| by
+      simpa only [cone_left_op_of_cocone_π_app, op_comp, Quiver.Hom.op_unop, is_colimit.fac,
+        cocone_of_cone_left_op_ι_app]
+  uniq s m w := by
+    refine' Quiver.Hom.op_inj (hc.hom_ext fun j => Quiver.Hom.unop_inj _)
+    simpa only [Quiver.Hom.op_unop, is_colimit.fac, cocone_of_cone_left_op_ι_app] using w (op j)
+#align category_theory.limits.is_limit_cone_left_op_of_cocone CategoryTheory.Limits.isLimitConeLeftOpOfCocone
+
+/-- Turn a limit of `F : J ⥤ Cᵒᵖ` into a colimit of `F.left_op : Jᵒᵖ ⥤ C`. -/
+@[simps]
+def isColimitCoconeLeftOpOfCone (F : J ⥤ Cᵒᵖ) {c : Cone F} (hc : IsLimit c) :
+    IsColimit (coconeLeftOpOfCone c)
+    where
+  desc s := (hc.lift (coneOfCoconeLeftOp s)).unop
+  fac s j :=
+    Quiver.Hom.op_inj <| by
+      simpa only [cocone_left_op_of_cone_ι_app, op_comp, Quiver.Hom.op_unop, is_limit.fac,
+        cone_of_cocone_left_op_π_app]
+  uniq s m w := by
+    refine' Quiver.Hom.op_inj (hc.hom_ext fun j => Quiver.Hom.unop_inj _)
+    simpa only [Quiver.Hom.op_unop, is_limit.fac, cone_of_cocone_left_op_π_app] using w (op j)
+#align category_theory.limits.is_colimit_cocone_left_op_of_cone CategoryTheory.Limits.isColimitCoconeLeftOpOfCone
+
+/-- Turn a colimit for `F : Jᵒᵖ ⥤ C` into a limit for `F.right_op : J ⥤ Cᵒᵖ`. -/
+@[simps]
+def isLimitConeRightOpOfCocone (F : Jᵒᵖ ⥤ C) {c : Cocone F} (hc : IsColimit c) :
+    IsLimit (coneRightOpOfCocone c)
+    where
+  lift s := (hc.desc (coconeOfConeRightOp s)).op
+  fac s j := Quiver.Hom.unop_inj (by simpa)
+  uniq s m w := by
+    refine' Quiver.Hom.unop_inj (hc.hom_ext fun j => Quiver.Hom.op_inj _)
+    simpa only [Quiver.Hom.unop_op, is_colimit.fac] using w (unop j)
+#align category_theory.limits.is_limit_cone_right_op_of_cocone CategoryTheory.Limits.isLimitConeRightOpOfCocone
+
+/-- Turn a limit for `F : Jᵒᵖ ⥤ C` into a colimit for `F.right_op : J ⥤ Cᵒᵖ`. -/
+@[simps]
+def isColimitCoconeRightOpOfCone (F : Jᵒᵖ ⥤ C) {c : Cone F} (hc : IsLimit c) :
+    IsColimit (coconeRightOpOfCone c)
+    where
+  desc s := (hc.lift (coneOfCoconeRightOp s)).op
+  fac s j := Quiver.Hom.unop_inj (by simpa)
+  uniq s m w := by
+    refine' Quiver.Hom.unop_inj (hc.hom_ext fun j => Quiver.Hom.op_inj _)
+    simpa only [Quiver.Hom.unop_op, is_limit.fac] using w (unop j)
+#align category_theory.limits.is_colimit_cocone_right_op_of_cone CategoryTheory.Limits.isColimitCoconeRightOpOfCone
+
+/-- Turn a colimit for `F : Jᵒᵖ ⥤ Cᵒᵖ` into a limit for `F.unop : J ⥤ C`. -/
+@[simps]
+def isLimitConeUnopOfCocone (F : Jᵒᵖ ⥤ Cᵒᵖ) {c : Cocone F} (hc : IsColimit c) :
+    IsLimit (coneUnopOfCocone c)
+    where
+  lift s := (hc.desc (coconeOfConeUnop s)).unop
+  fac s j := Quiver.Hom.op_inj (by simpa)
+  uniq s m w := by
+    refine' Quiver.Hom.op_inj (hc.hom_ext fun j => Quiver.Hom.unop_inj _)
+    simpa only [Quiver.Hom.op_unop, is_colimit.fac] using w (unop j)
+#align category_theory.limits.is_limit_cone_unop_of_cocone CategoryTheory.Limits.isLimitConeUnopOfCocone
+
+/-- Turn a limit of `F : Jᵒᵖ ⥤ Cᵒᵖ` into a colimit of `F.unop : J ⥤ C`. -/
+@[simps]
+def isColimitCoconeUnopOfCone (F : Jᵒᵖ ⥤ Cᵒᵖ) {c : Cone F} (hc : IsLimit c) :
+    IsColimit (coconeUnopOfCone c)
+    where
+  desc s := (hc.lift (coneOfCoconeUnop s)).unop
+  fac s j := Quiver.Hom.op_inj (by simpa)
+  uniq s m w := by
+    refine' Quiver.Hom.op_inj (hc.hom_ext fun j => Quiver.Hom.unop_inj _)
+    simpa only [Quiver.Hom.op_unop, is_limit.fac] using w (unop j)
+#align category_theory.limits.is_colimit_cocone_unop_of_cone CategoryTheory.Limits.isColimitCoconeUnopOfCone
+
+/-- Turn a colimit for `F.op : Jᵒᵖ ⥤ Cᵒᵖ` into a limit for `F : J ⥤ C`. -/
+@[simps]
+def isLimitCoconeUnop (F : J ⥤ C) {c : Cocone F.op} (hc : IsColimit c) : IsLimit c.unop
+    where
+  lift s := (hc.desc s.op).unop
+  fac s j := Quiver.Hom.op_inj (by simpa)
+  uniq s m w := by
+    refine' Quiver.Hom.op_inj (hc.hom_ext fun j => Quiver.Hom.unop_inj _)
+    simpa only [Quiver.Hom.op_unop, is_colimit.fac] using w (unop j)
+#align category_theory.limits.is_limit_cocone_unop CategoryTheory.Limits.isLimitCoconeUnop
+
+/-- Turn a limit for `F.op : Jᵒᵖ ⥤ Cᵒᵖ` into a colimit for `F : J ⥤ C`. -/
+@[simps]
+def isColimitConeUnop (F : J ⥤ C) {c : Cone F.op} (hc : IsLimit c) : IsColimit c.unop
+    where
+  desc s := (hc.lift s.op).unop
+  fac s j := Quiver.Hom.op_inj (by simpa)
+  uniq s m w := by
+    refine' Quiver.Hom.op_inj (hc.hom_ext fun j => Quiver.Hom.unop_inj _)
+    simpa only [Quiver.Hom.op_unop, is_limit.fac] using w (unop j)
+#align category_theory.limits.is_colimit_cone_unop CategoryTheory.Limits.isColimitConeUnop
+
+/-- Turn a colimit for `F.left_op : Jᵒᵖ ⥤ C` into a limit for `F : J ⥤ Cᵒᵖ`. -/
+@[simps]
+def isLimitConeOfCoconeLeftOp (F : J ⥤ Cᵒᵖ) {c : Cocone F.leftOp} (hc : IsColimit c) :
+    IsLimit (coneOfCoconeLeftOp c)
+    where
+  lift s := (hc.desc (coconeLeftOpOfCone s)).op
+  fac s j :=
+    Quiver.Hom.unop_inj <| by
+      simpa only [cone_of_cocone_left_op_π_app, unop_comp, Quiver.Hom.unop_op, is_colimit.fac,
+        cocone_left_op_of_cone_ι_app]
+  uniq s m w := by
+    refine' Quiver.Hom.unop_inj (hc.hom_ext fun j => Quiver.Hom.op_inj _)
+    simpa only [Quiver.Hom.unop_op, is_colimit.fac, cone_of_cocone_left_op_π_app] using w (unop j)
+#align category_theory.limits.is_limit_cone_of_cocone_left_op CategoryTheory.Limits.isLimitConeOfCoconeLeftOp
+
+/-- Turn a limit of `F.left_op : Jᵒᵖ ⥤ C` into a colimit of `F : J ⥤ Cᵒᵖ`. -/
+@[simps]
+def isColimitCoconeOfConeLeftOp (F : J ⥤ Cᵒᵖ) {c : Cone F.leftOp} (hc : IsLimit c) :
+    IsColimit (coconeOfConeLeftOp c)
+    where
+  desc s := (hc.lift (coneLeftOpOfCocone s)).op
+  fac s j :=
+    Quiver.Hom.unop_inj <| by
+      simpa only [cocone_of_cone_left_op_ι_app, unop_comp, Quiver.Hom.unop_op, is_limit.fac,
+        cone_left_op_of_cocone_π_app]
+  uniq s m w := by
+    refine' Quiver.Hom.unop_inj (hc.hom_ext fun j => Quiver.Hom.op_inj _)
+    simpa only [Quiver.Hom.unop_op, is_limit.fac, cocone_of_cone_left_op_ι_app] using w (unop j)
+#align category_theory.limits.is_colimit_cocone_of_cone_left_op CategoryTheory.Limits.isColimitCoconeOfConeLeftOp
+
+/-- Turn a colimit for `F.right_op : J ⥤ Cᵒᵖ` into a limit for `F : Jᵒᵖ ⥤ C`. -/
+@[simps]
+def isLimitConeOfCoconeRightOp (F : Jᵒᵖ ⥤ C) {c : Cocone F.rightOp} (hc : IsColimit c) :
+    IsLimit (coneOfCoconeRightOp c)
+    where
+  lift s := (hc.desc (coconeRightOpOfCone s)).unop
+  fac s j := Quiver.Hom.op_inj (by simpa)
+  uniq s m w := by
+    refine' Quiver.Hom.op_inj (hc.hom_ext fun j => Quiver.Hom.unop_inj _)
+    simpa only [Quiver.Hom.op_unop, is_colimit.fac] using w (op j)
+#align category_theory.limits.is_limit_cone_of_cocone_right_op CategoryTheory.Limits.isLimitConeOfCoconeRightOp
+
+/-- Turn a limit for `F.right_op : J ⥤ Cᵒᵖ` into a limit for `F : Jᵒᵖ ⥤ C`. -/
+@[simps]
+def isColimitCoconeOfConeRightOp (F : Jᵒᵖ ⥤ C) {c : Cone F.rightOp} (hc : IsLimit c) :
+    IsColimit (coconeOfConeRightOp c)
+    where
+  desc s := (hc.lift (coneRightOpOfCocone s)).unop
+  fac s j := Quiver.Hom.op_inj (by simpa)
+  uniq s m w := by
+    refine' Quiver.Hom.op_inj (hc.hom_ext fun j => Quiver.Hom.unop_inj _)
+    simpa only [Quiver.Hom.op_unop, is_limit.fac] using w (op j)
+#align category_theory.limits.is_colimit_cocone_of_cone_right_op CategoryTheory.Limits.isColimitCoconeOfConeRightOp
+
+/-- Turn a colimit for `F.unop : J ⥤ C` into a limit for `F : Jᵒᵖ ⥤ Cᵒᵖ`. -/
+@[simps]
+def isLimitConeOfCoconeUnop (F : Jᵒᵖ ⥤ Cᵒᵖ) {c : Cocone F.unop} (hc : IsColimit c) :
+    IsLimit (coneOfCoconeUnop c)
+    where
+  lift s := (hc.desc (coconeUnopOfCone s)).op
+  fac s j := Quiver.Hom.unop_inj (by simpa)
+  uniq s m w := by
+    refine' Quiver.Hom.unop_inj (hc.hom_ext fun j => Quiver.Hom.op_inj _)
+    simpa only [Quiver.Hom.unop_op, is_colimit.fac] using w (op j)
+#align category_theory.limits.is_limit_cone_of_cocone_unop CategoryTheory.Limits.isLimitConeOfCoconeUnop
+
+/-- Turn a limit for `F.unop : J ⥤ C` into a colimit for `F : Jᵒᵖ ⥤ Cᵒᵖ`. -/
+@[simps]
+def isColimitConeOfCoconeUnop (F : Jᵒᵖ ⥤ Cᵒᵖ) {c : Cone F.unop} (hc : IsLimit c) :
+    IsColimit (coconeOfConeUnop c)
+    where
+  desc s := (hc.lift (coneUnopOfCocone s)).op
+  fac s j := Quiver.Hom.unop_inj (by simpa)
+  uniq s m w := by
+    refine' Quiver.Hom.unop_inj (hc.hom_ext fun j => Quiver.Hom.op_inj _)
+    simpa only [Quiver.Hom.unop_op, is_limit.fac] using w (op j)
+#align category_theory.limits.is_colimit_cone_of_cocone_unop CategoryTheory.Limits.isColimitConeOfCoconeUnop
+
+/-- If `F.left_op : Jᵒᵖ ⥤ C` has a colimit, we can construct a limit for `F : J ⥤ Cᵒᵖ`.
+-/
+theorem hasLimit_of_hasColimit_leftOp (F : J ⥤ Cᵒᵖ) [HasColimit F.leftOp] : HasLimit F :=
+  HasLimit.mk
+    { Cone := coneOfCoconeLeftOp (colimit.cocone F.leftOp)
+      IsLimit := isLimitConeOfCoconeLeftOp _ (colimit.isColimit _) }
+#align category_theory.limits.has_limit_of_has_colimit_left_op CategoryTheory.Limits.hasLimit_of_hasColimit_leftOp
+
+theorem hasLimit_of_hasColimit_op (F : J ⥤ C) [HasColimit F.op] : HasLimit F :=
+  HasLimit.mk
+    { Cone := (colimit.cocone F.op).unop
+      IsLimit := isLimitCoconeUnop _ (colimit.isColimit _) }
+#align category_theory.limits.has_limit_of_has_colimit_op CategoryTheory.Limits.hasLimit_of_hasColimit_op
+
+/-- If `C` has colimits of shape `Jᵒᵖ`, we can construct limits in `Cᵒᵖ` of shape `J`.
+-/
+theorem hasLimitsOfShape_op_of_hasColimitsOfShape [HasColimitsOfShape Jᵒᵖ C] :
+    HasLimitsOfShape J Cᵒᵖ :=
+  { HasLimit := fun F => hasLimit_of_hasColimit_leftOp F }
+#align category_theory.limits.has_limits_of_shape_op_of_has_colimits_of_shape CategoryTheory.Limits.hasLimitsOfShape_op_of_hasColimitsOfShape
+
+theorem hasLimitsOfShape_of_hasColimitsOfShape_op [HasColimitsOfShape Jᵒᵖ Cᵒᵖ] :
+    HasLimitsOfShape J C :=
+  { HasLimit := fun F => hasLimit_of_hasColimit_op F }
+#align category_theory.limits.has_limits_of_shape_of_has_colimits_of_shape_op CategoryTheory.Limits.hasLimitsOfShape_of_hasColimitsOfShape_op
+
+attribute [local instance] has_limits_of_shape_op_of_has_colimits_of_shape
+
+/-- If `C` has colimits, we can construct limits for `Cᵒᵖ`.
+-/
+instance hasLimits_op_of_hasColimits [HasColimits C] : HasLimits Cᵒᵖ :=
+  ⟨inferInstance⟩
+#align category_theory.limits.has_limits_op_of_has_colimits CategoryTheory.Limits.hasLimits_op_of_hasColimits
+
+theorem hasLimits_of_hasColimits_op [HasColimits Cᵒᵖ] : HasLimits C :=
+  { HasLimitsOfShape := fun J hJ => has_limits_of_shape_of_has_colimits_of_shape_op }
+#align category_theory.limits.has_limits_of_has_colimits_op CategoryTheory.Limits.hasLimits_of_hasColimits_op
+
+instance has_cofiltered_limits_op_of_has_filtered_colimits [HasFilteredColimitsOfSize.{v₂, u₂} C] :
+    HasCofilteredLimitsOfSize.{v₂, u₂} Cᵒᵖ
+    where HasLimitsOfShape I hI₁ hI₂ := has_limits_of_shape_op_of_has_colimits_of_shape
+#align category_theory.limits.has_cofiltered_limits_op_of_has_filtered_colimits CategoryTheory.Limits.has_cofiltered_limits_op_of_has_filtered_colimits
+
+theorem has_cofiltered_limits_of_has_filtered_colimits_op [HasFilteredColimitsOfSize.{v₂, u₂} Cᵒᵖ] :
+    HasCofilteredLimitsOfSize.{v₂, u₂} C :=
+  { HasLimitsOfShape := fun I hI₂ hI₂ => has_limits_of_shape_of_has_colimits_of_shape_op }
+#align category_theory.limits.has_cofiltered_limits_of_has_filtered_colimits_op CategoryTheory.Limits.has_cofiltered_limits_of_has_filtered_colimits_op
+
+/-- If `F.left_op : Jᵒᵖ ⥤ C` has a limit, we can construct a colimit for `F : J ⥤ Cᵒᵖ`.
+-/
+theorem hasColimit_of_hasLimit_leftOp (F : J ⥤ Cᵒᵖ) [HasLimit F.leftOp] : HasColimit F :=
+  HasColimit.mk
+    { Cocone := coconeOfConeLeftOp (limit.cone F.leftOp)
+      IsColimit := isColimitCoconeOfConeLeftOp _ (limit.isLimit _) }
+#align category_theory.limits.has_colimit_of_has_limit_left_op CategoryTheory.Limits.hasColimit_of_hasLimit_leftOp
+
+theorem hasColimit_of_hasLimit_op (F : J ⥤ C) [HasLimit F.op] : HasColimit F :=
+  HasColimit.mk
+    { Cocone := (limit.cone F.op).unop
+      IsColimit := isColimitConeUnop _ (limit.isLimit _) }
+#align category_theory.limits.has_colimit_of_has_limit_op CategoryTheory.Limits.hasColimit_of_hasLimit_op
+
+/-- If `C` has colimits of shape `Jᵒᵖ`, we can construct limits in `Cᵒᵖ` of shape `J`.
+-/
+instance hasColimitsOfShape_op_of_hasLimitsOfShape [HasLimitsOfShape Jᵒᵖ C] :
+    HasColimitsOfShape J Cᵒᵖ where HasColimit F := hasColimit_of_hasLimit_leftOp F
+#align category_theory.limits.has_colimits_of_shape_op_of_has_limits_of_shape CategoryTheory.Limits.hasColimitsOfShape_op_of_hasLimitsOfShape
+
+theorem hasColimitsOfShape_of_hasLimitsOfShape_op [HasLimitsOfShape Jᵒᵖ Cᵒᵖ] :
+    HasColimitsOfShape J C :=
+  { HasColimit := fun F => hasColimit_of_hasLimit_op F }
+#align category_theory.limits.has_colimits_of_shape_of_has_limits_of_shape_op CategoryTheory.Limits.hasColimitsOfShape_of_hasLimitsOfShape_op
+
+/-- If `C` has limits, we can construct colimits for `Cᵒᵖ`.
+-/
+instance hasColimits_op_of_hasLimits [HasLimits C] : HasColimits Cᵒᵖ :=
+  ⟨inferInstance⟩
+#align category_theory.limits.has_colimits_op_of_has_limits CategoryTheory.Limits.hasColimits_op_of_hasLimits
+
+theorem hasColimits_of_hasLimits_op [HasLimits Cᵒᵖ] : HasColimits C :=
+  { HasColimitsOfShape := fun J hJ => has_colimits_of_shape_of_has_limits_of_shape_op }
+#align category_theory.limits.has_colimits_of_has_limits_op CategoryTheory.Limits.hasColimits_of_hasLimits_op
+
+instance has_filtered_colimits_op_of_has_cofiltered_limits [HasCofilteredLimitsOfSize.{v₂, u₂} C] :
+    HasFilteredColimitsOfSize.{v₂, u₂} Cᵒᵖ where HasColimitsOfShape I hI₁ hI₂ := inferInstance
+#align category_theory.limits.has_filtered_colimits_op_of_has_cofiltered_limits CategoryTheory.Limits.has_filtered_colimits_op_of_has_cofiltered_limits
+
+theorem has_filtered_colimits_of_has_cofiltered_limits_op [HasCofilteredLimitsOfSize.{v₂, u₂} Cᵒᵖ] :
+    HasFilteredColimitsOfSize.{v₂, u₂} C :=
+  { HasColimitsOfShape := fun I hI₁ hI₂ => has_colimits_of_shape_of_has_limits_of_shape_op }
+#align category_theory.limits.has_filtered_colimits_of_has_cofiltered_limits_op CategoryTheory.Limits.has_filtered_colimits_of_has_cofiltered_limits_op
+
+variable (X : Type v₂)
+
+/-- If `C` has products indexed by `X`, then `Cᵒᵖ` has coproducts indexed by `X`.
+-/
+instance hasCoproductsOfShape_opposite [HasProductsOfShape X C] : HasCoproductsOfShape X Cᵒᵖ :=
+  by
+  haveI : has_limits_of_shape (discrete X)ᵒᵖ C :=
+    has_limits_of_shape_of_equivalence (discrete.opposite X).symm
+  infer_instance
+#align category_theory.limits.has_coproducts_of_shape_opposite CategoryTheory.Limits.hasCoproductsOfShape_opposite
+
+theorem hasCoproductsOfShape_of_opposite [HasProductsOfShape X Cᵒᵖ] : HasCoproductsOfShape X C :=
+  haveI : has_limits_of_shape (discrete X)ᵒᵖ Cᵒᵖ :=
+    has_limits_of_shape_of_equivalence (discrete.opposite X).symm
+  has_colimits_of_shape_of_has_limits_of_shape_op
+#align category_theory.limits.has_coproducts_of_shape_of_opposite CategoryTheory.Limits.hasCoproductsOfShape_of_opposite
+
+/-- If `C` has coproducts indexed by `X`, then `Cᵒᵖ` has products indexed by `X`.
+-/
+instance hasProductsOfShape_opposite [HasCoproductsOfShape X C] : HasProductsOfShape X Cᵒᵖ :=
+  by
+  haveI : has_colimits_of_shape (discrete X)ᵒᵖ C :=
+    has_colimits_of_shape_of_equivalence (discrete.opposite X).symm
+  infer_instance
+#align category_theory.limits.has_products_of_shape_opposite CategoryTheory.Limits.hasProductsOfShape_opposite
+
+theorem hasProductsOfShape_of_opposite [HasCoproductsOfShape X Cᵒᵖ] : HasProductsOfShape X C :=
+  haveI : has_colimits_of_shape (discrete X)ᵒᵖ Cᵒᵖ :=
+    has_colimits_of_shape_of_equivalence (discrete.opposite X).symm
+  has_limits_of_shape_of_has_colimits_of_shape_op
+#align category_theory.limits.has_products_of_shape_of_opposite CategoryTheory.Limits.hasProductsOfShape_of_opposite
+
+instance hasProducts_opposite [HasCoproducts.{v₂} C] : HasProducts.{v₂} Cᵒᵖ := fun X =>
+  inferInstance
+#align category_theory.limits.has_products_opposite CategoryTheory.Limits.hasProducts_opposite
+
+theorem hasProducts_of_opposite [HasCoproducts.{v₂} Cᵒᵖ] : HasProducts.{v₂} C := fun X =>
+  hasProductsOfShape_of_opposite X
+#align category_theory.limits.has_products_of_opposite CategoryTheory.Limits.hasProducts_of_opposite
+
+instance hasCoproducts_opposite [HasProducts.{v₂} C] : HasCoproducts.{v₂} Cᵒᵖ := fun X =>
+  inferInstance
+#align category_theory.limits.has_coproducts_opposite CategoryTheory.Limits.hasCoproducts_opposite
+
+theorem hasCoproducts_of_opposite [HasProducts.{v₂} Cᵒᵖ] : HasCoproducts.{v₂} C := fun X =>
+  hasCoproductsOfShape_of_opposite X
+#align category_theory.limits.has_coproducts_of_opposite CategoryTheory.Limits.hasCoproducts_of_opposite
+
+instance hasFiniteCoproducts_opposite [HasFiniteProducts C] : HasFiniteCoproducts Cᵒᵖ
+    where out n := Limits.hasCoproductsOfShape_opposite _
+#align category_theory.limits.has_finite_coproducts_opposite CategoryTheory.Limits.hasFiniteCoproducts_opposite
+
+theorem hasFiniteCoproducts_of_opposite [HasFiniteProducts Cᵒᵖ] : HasFiniteCoproducts C :=
+  { out := fun n => hasCoproductsOfShape_of_opposite _ }
+#align category_theory.limits.has_finite_coproducts_of_opposite CategoryTheory.Limits.hasFiniteCoproducts_of_opposite
+
+instance hasFiniteProducts_opposite [HasFiniteCoproducts C] : HasFiniteProducts Cᵒᵖ
+    where out n := inferInstance
+#align category_theory.limits.has_finite_products_opposite CategoryTheory.Limits.hasFiniteProducts_opposite
+
+theorem hasFiniteProducts_of_opposite [HasFiniteCoproducts Cᵒᵖ] : HasFiniteProducts C :=
+  { out := fun n => hasProductsOfShape_of_opposite _ }
+#align category_theory.limits.has_finite_products_of_opposite CategoryTheory.Limits.hasFiniteProducts_of_opposite
+
+instance hasEqualizers_opposite [HasCoequalizers C] : HasEqualizers Cᵒᵖ :=
+  by
+  haveI : has_colimits_of_shape walking_parallel_pairᵒᵖ C :=
+    has_colimits_of_shape_of_equivalence walking_parallel_pair_op_equiv
+  infer_instance
+#align category_theory.limits.has_equalizers_opposite CategoryTheory.Limits.hasEqualizers_opposite
+
+instance hasCoequalizers_opposite [HasEqualizers C] : HasCoequalizers Cᵒᵖ :=
+  by
+  haveI : has_limits_of_shape walking_parallel_pairᵒᵖ C :=
+    has_limits_of_shape_of_equivalence walking_parallel_pair_op_equiv
+  infer_instance
+#align category_theory.limits.has_coequalizers_opposite CategoryTheory.Limits.hasCoequalizers_opposite
+
+instance hasFiniteColimits_opposite [HasFiniteLimits C] : HasFiniteColimits Cᵒᵖ
+    where out J 𝒟 𝒥 := by
+    skip
+    infer_instance
+#align category_theory.limits.has_finite_colimits_opposite CategoryTheory.Limits.hasFiniteColimits_opposite
+
+instance hasFiniteLimits_opposite [HasFiniteColimits C] : HasFiniteLimits Cᵒᵖ
+    where out J 𝒟 𝒥 := by
+    skip
+    infer_instance
+#align category_theory.limits.has_finite_limits_opposite CategoryTheory.Limits.hasFiniteLimits_opposite
+
+instance hasPullbacks_opposite [HasPushouts C] : HasPullbacks Cᵒᵖ :=
+  by
+  haveI : has_colimits_of_shape walking_cospanᵒᵖ C :=
+    has_colimits_of_shape_of_equivalence walking_cospan_op_equiv.symm
+  apply has_limits_of_shape_op_of_has_colimits_of_shape
+#align category_theory.limits.has_pullbacks_opposite CategoryTheory.Limits.hasPullbacks_opposite
+
+instance hasPushouts_opposite [HasPullbacks C] : HasPushouts Cᵒᵖ :=
+  by
+  haveI : has_limits_of_shape walking_spanᵒᵖ C :=
+    has_limits_of_shape_of_equivalence walking_span_op_equiv.symm
+  infer_instance
+#align category_theory.limits.has_pushouts_opposite CategoryTheory.Limits.hasPushouts_opposite
+
+/-- The canonical isomorphism relating `span f.op g.op` and `(cospan f g).op` -/
+@[simps]
+def spanOp {X Y Z : C} (f : X ⟶ Z) (g : Y ⟶ Z) :
+    span f.op g.op ≅ walkingCospanOpEquiv.inverse ⋙ (cospan f g).op :=
+  NatIso.ofComponents (by rintro (_ | _ | _) <;> rfl)
+    (by rintro (_ | _ | _) (_ | _ | _) f <;> cases f <;> tidy)
+#align category_theory.limits.span_op CategoryTheory.Limits.spanOp
+
+/-- The canonical isomorphism relating `(cospan f g).op` and `span f.op g.op` -/
+@[simps]
+def opCospan {X Y Z : C} (f : X ⟶ Z) (g : Y ⟶ Z) :
+    (cospan f g).op ≅ walkingCospanOpEquiv.Functor ⋙ span f.op g.op :=
+  calc
+    (cospan f g).op ≅ 𝟭 _ ⋙ (cospan f g).op := by rfl
+    _ ≅ (walkingCospanOpEquiv.Functor ⋙ walkingCospanOpEquiv.inverse) ⋙ (cospan f g).op :=
+      (isoWhiskerRight walkingCospanOpEquiv.unitIso _)
+    _ ≅ walkingCospanOpEquiv.Functor ⋙ walkingCospanOpEquiv.inverse ⋙ (cospan f g).op :=
+      (Functor.associator _ _ _)
+    _ ≅ walkingCospanOpEquiv.Functor ⋙ span f.op g.op := isoWhiskerLeft _ (spanOp f g).symm
+    
+#align category_theory.limits.op_cospan CategoryTheory.Limits.opCospan
+
+/-- The canonical isomorphism relating `cospan f.op g.op` and `(span f g).op` -/
+@[simps]
+def cospanOp {X Y Z : C} (f : X ⟶ Y) (g : X ⟶ Z) :
+    cospan f.op g.op ≅ walkingSpanOpEquiv.inverse ⋙ (span f g).op :=
+  NatIso.ofComponents (by rintro (_ | _ | _) <;> rfl)
+    (by rintro (_ | _ | _) (_ | _ | _) f <;> cases f <;> tidy)
+#align category_theory.limits.cospan_op CategoryTheory.Limits.cospanOp
+
+/-- The canonical isomorphism relating `(span f g).op` and `cospan f.op g.op` -/
+@[simps]
+def opSpan {X Y Z : C} (f : X ⟶ Y) (g : X ⟶ Z) :
+    (span f g).op ≅ walkingSpanOpEquiv.Functor ⋙ cospan f.op g.op :=
+  calc
+    (span f g).op ≅ 𝟭 _ ⋙ (span f g).op := by rfl
+    _ ≅ (walkingSpanOpEquiv.Functor ⋙ walkingSpanOpEquiv.inverse) ⋙ (span f g).op :=
+      (isoWhiskerRight walkingSpanOpEquiv.unitIso _)
+    _ ≅ walkingSpanOpEquiv.Functor ⋙ walkingSpanOpEquiv.inverse ⋙ (span f g).op :=
+      (Functor.associator _ _ _)
+    _ ≅ walkingSpanOpEquiv.Functor ⋙ cospan f.op g.op := isoWhiskerLeft _ (cospanOp f g).symm
+    
+#align category_theory.limits.op_span CategoryTheory.Limits.opSpan
+
+namespace PushoutCocone
+
+/-- The obvious map `pushout_cocone f g → pullback_cone f.unop g.unop` -/
+@[simps (config := lemmasOnly)]
+def unop {X Y Z : Cᵒᵖ} {f : X ⟶ Y} {g : X ⟶ Z} (c : PushoutCocone f g) :
+    PullbackCone f.unop g.unop :=
+  Cocone.unop
+    ((Cocones.precompose (opCospan f.unop g.unop).hom).obj
+      (Cocone.whisker walkingCospanOpEquiv.Functor c))
+#align category_theory.limits.pushout_cocone.unop CategoryTheory.Limits.PushoutCocone.unop
+
+@[simp]
+theorem unop_fst {X Y Z : Cᵒᵖ} {f : X ⟶ Y} {g : X ⟶ Z} (c : PushoutCocone f g) :
+    c.unop.fst = c.inl.unop :=
+  by
+  change (_ : limits.cone _).π.app _ = _
+  simp only [pushout_cocone.ι_app_left, pushout_cocone.unop_π_app]
+  tidy
+#align category_theory.limits.pushout_cocone.unop_fst CategoryTheory.Limits.PushoutCocone.unop_fst
+
+@[simp]
+theorem unop_snd {X Y Z : Cᵒᵖ} {f : X ⟶ Y} {g : X ⟶ Z} (c : PushoutCocone f g) :
+    c.unop.snd = c.inr.unop :=
+  by
+  change (_ : limits.cone _).π.app _ = _
+  simp only [pushout_cocone.unop_π_app, pushout_cocone.ι_app_right]
+  tidy
+#align category_theory.limits.pushout_cocone.unop_snd CategoryTheory.Limits.PushoutCocone.unop_snd
+
+/-- The obvious map `pushout_cocone f.op g.op → pullback_cone f g` -/
+@[simps (config := lemmasOnly)]
+def op {X Y Z : C} {f : X ⟶ Y} {g : X ⟶ Z} (c : PushoutCocone f g) : PullbackCone f.op g.op :=
+  (Cones.postcompose (cospanOp f g).symm.hom).obj
+    (Cone.whisker walkingSpanOpEquiv.inverse (Cocone.op c))
+#align category_theory.limits.pushout_cocone.op CategoryTheory.Limits.PushoutCocone.op
+
+@[simp]
+theorem op_fst {X Y Z : C} {f : X ⟶ Y} {g : X ⟶ Z} (c : PushoutCocone f g) : c.op.fst = c.inl.op :=
+  by
+  change (_ : limits.cone _).π.app _ = _
+  apply category.comp_id
+#align category_theory.limits.pushout_cocone.op_fst CategoryTheory.Limits.PushoutCocone.op_fst
+
+@[simp]
+theorem op_snd {X Y Z : C} {f : X ⟶ Y} {g : X ⟶ Z} (c : PushoutCocone f g) : c.op.snd = c.inr.op :=
+  by
+  change (_ : limits.cone _).π.app _ = _
+  apply category.comp_id
+#align category_theory.limits.pushout_cocone.op_snd CategoryTheory.Limits.PushoutCocone.op_snd
+
+end PushoutCocone
+
+namespace PullbackCone
+
+/-- The obvious map `pullback_cone f g → pushout_cocone f.unop g.unop` -/
+@[simps (config := lemmasOnly)]
+def unop {X Y Z : Cᵒᵖ} {f : X ⟶ Z} {g : Y ⟶ Z} (c : PullbackCone f g) :
+    PushoutCocone f.unop g.unop :=
+  Cone.unop
+    ((Cones.postcompose (opSpan f.unop g.unop).symm.hom).obj
+      (Cone.whisker walkingSpanOpEquiv.Functor c))
+#align category_theory.limits.pullback_cone.unop CategoryTheory.Limits.PullbackCone.unop
+
+@[simp]
+theorem unop_inl {X Y Z : Cᵒᵖ} {f : X ⟶ Z} {g : Y ⟶ Z} (c : PullbackCone f g) :
+    c.unop.inl = c.fst.unop :=
+  by
+  change (_ : limits.cocone _).ι.app _ = _
+  dsimp only [unop, op_span]
+  simp; dsimp; simp; dsimp; simp
+#align category_theory.limits.pullback_cone.unop_inl CategoryTheory.Limits.PullbackCone.unop_inl
+
+@[simp]
+theorem unop_inr {X Y Z : Cᵒᵖ} {f : X ⟶ Z} {g : Y ⟶ Z} (c : PullbackCone f g) :
+    c.unop.inr = c.snd.unop :=
+  by
+  change (_ : limits.cocone _).ι.app _ = _
+  apply Quiver.Hom.op_inj
+  simp [unop_ι_app]; dsimp; simp
+  apply category.comp_id
+#align category_theory.limits.pullback_cone.unop_inr CategoryTheory.Limits.PullbackCone.unop_inr
+
+/-- The obvious map `pullback_cone f g → pushout_cocone f.op g.op` -/
+@[simps (config := lemmasOnly)]
+def op {X Y Z : C} {f : X ⟶ Z} {g : Y ⟶ Z} (c : PullbackCone f g) : PushoutCocone f.op g.op :=
+  (Cocones.precompose (spanOp f g).hom).obj
+    (Cocone.whisker walkingCospanOpEquiv.inverse (Cone.op c))
+#align category_theory.limits.pullback_cone.op CategoryTheory.Limits.PullbackCone.op
+
+@[simp]
+theorem op_inl {X Y Z : C} {f : X ⟶ Z} {g : Y ⟶ Z} (c : PullbackCone f g) : c.op.inl = c.fst.op :=
+  by
+  change (_ : limits.cocone _).ι.app _ = _
+  apply category.id_comp
+#align category_theory.limits.pullback_cone.op_inl CategoryTheory.Limits.PullbackCone.op_inl
+
+@[simp]
+theorem op_inr {X Y Z : C} {f : X ⟶ Z} {g : Y ⟶ Z} (c : PullbackCone f g) : c.op.inr = c.snd.op :=
+  by
+  change (_ : limits.cocone _).ι.app _ = _
+  apply category.id_comp
+#align category_theory.limits.pullback_cone.op_inr CategoryTheory.Limits.PullbackCone.op_inr
+
+/-- If `c` is a pullback cone, then `c.op.unop` is isomorphic to `c`. -/
+def opUnop {X Y Z : C} {f : X ⟶ Z} {g : Y ⟶ Z} (c : PullbackCone f g) : c.op.unop ≅ c :=
+  PullbackCone.ext (Iso.refl _) (by simp) (by simp)
+#align category_theory.limits.pullback_cone.op_unop CategoryTheory.Limits.PullbackCone.opUnop
+
+/-- If `c` is a pullback cone in `Cᵒᵖ`, then `c.unop.op` is isomorphic to `c`. -/
+def unopOp {X Y Z : Cᵒᵖ} {f : X ⟶ Z} {g : Y ⟶ Z} (c : PullbackCone f g) : c.unop.op ≅ c :=
+  PullbackCone.ext (Iso.refl _) (by simp) (by simp)
+#align category_theory.limits.pullback_cone.unop_op CategoryTheory.Limits.PullbackCone.unopOp
+
+end PullbackCone
+
+namespace PushoutCocone
+
+/-- If `c` is a pushout cocone, then `c.op.unop` is isomorphic to `c`. -/
+def opUnop {X Y Z : C} {f : X ⟶ Y} {g : X ⟶ Z} (c : PushoutCocone f g) : c.op.unop ≅ c :=
+  PushoutCocone.ext (Iso.refl _) (by simp) (by simp)
+#align category_theory.limits.pushout_cocone.op_unop CategoryTheory.Limits.PushoutCocone.opUnop
+
+/-- If `c` is a pushout cocone in `Cᵒᵖ`, then `c.unop.op` is isomorphic to `c`. -/
+def unopOp {X Y Z : Cᵒᵖ} {f : X ⟶ Y} {g : X ⟶ Z} (c : PushoutCocone f g) : c.unop.op ≅ c :=
+  PushoutCocone.ext (Iso.refl _) (by simp) (by simp)
+#align category_theory.limits.pushout_cocone.unop_op CategoryTheory.Limits.PushoutCocone.unopOp
+
+/-- A pushout cone is a colimit cocone if and only if the corresponding pullback cone
+in the opposite category is a limit cone. -/
+def isColimitEquivIsLimitOp {X Y Z : C} {f : X ⟶ Y} {g : X ⟶ Z} (c : PushoutCocone f g) :
+    IsColimit c ≃ IsLimit c.op :=
+  by
+  apply equivOfSubsingletonOfSubsingleton
+  · intro h
+    equiv_rw is_limit.postcompose_hom_equiv _ _
+    equiv_rw(is_limit.whisker_equivalence_equiv walking_span_op_equiv.symm).symm
+    exact is_limit_cocone_op _ h
+  · intro h
+    equiv_rw is_colimit.equiv_iso_colimit c.op_unop.symm
+    apply is_colimit_cone_unop
+    equiv_rw is_limit.postcompose_hom_equiv _ _
+    equiv_rw(is_limit.whisker_equivalence_equiv _).symm
+    exact h
+#align category_theory.limits.pushout_cocone.is_colimit_equiv_is_limit_op CategoryTheory.Limits.PushoutCocone.isColimitEquivIsLimitOp
+
+/-- A pushout cone is a colimit cocone in `Cᵒᵖ` if and only if the corresponding pullback cone
+in `C` is a limit cone. -/
+def isColimitEquivIsLimitUnop {X Y Z : Cᵒᵖ} {f : X ⟶ Y} {g : X ⟶ Z} (c : PushoutCocone f g) :
+    IsColimit c ≃ IsLimit c.unop :=
+  by
+  apply equivOfSubsingletonOfSubsingleton
+  · intro h
+    apply is_limit_cocone_unop
+    equiv_rw is_colimit.precompose_hom_equiv _ _
+    equiv_rw(is_colimit.whisker_equivalence_equiv _).symm
+    exact h
+  · intro h
+    equiv_rw is_colimit.equiv_iso_colimit c.unop_op.symm
+    equiv_rw is_colimit.precompose_hom_equiv _ _
+    equiv_rw(is_colimit.whisker_equivalence_equiv walking_cospan_op_equiv.symm).symm
+    exact is_colimit_cone_op _ h
+#align category_theory.limits.pushout_cocone.is_colimit_equiv_is_limit_unop CategoryTheory.Limits.PushoutCocone.isColimitEquivIsLimitUnop
+
+end PushoutCocone
+
+namespace PullbackCone
+
+/-- A pullback cone is a limit cone if and only if the corresponding pushout cocone
+in the opposite category is a colimit cocone. -/
+def isLimitEquivIsColimitOp {X Y Z : C} {f : X ⟶ Z} {g : Y ⟶ Z} (c : PullbackCone f g) :
+    IsLimit c ≃ IsColimit c.op :=
+  (IsLimit.equivIsoLimit c.op_unop).symm.trans c.op.isColimitEquivIsLimitUnop.symm
+#align category_theory.limits.pullback_cone.is_limit_equiv_is_colimit_op CategoryTheory.Limits.PullbackCone.isLimitEquivIsColimitOp
+
+/-- A pullback cone is a limit cone in `Cᵒᵖ` if and only if the corresponding pushout cocone
+in `C` is a colimit cocone. -/
+def isLimitEquivIsColimitUnop {X Y Z : Cᵒᵖ} {f : X ⟶ Z} {g : Y ⟶ Z} (c : PullbackCone f g) :
+    IsLimit c ≃ IsColimit c.unop :=
+  (IsLimit.equivIsoLimit c.unop_op).symm.trans c.unop.isColimitEquivIsLimitOp.symm
+#align category_theory.limits.pullback_cone.is_limit_equiv_is_colimit_unop CategoryTheory.Limits.PullbackCone.isLimitEquivIsColimitUnop
+
+end PullbackCone
+
+section Pullback
+
+open Opposite
+
+/-- The pullback of `f` and `g` in `C` is isomorphic to the pushout of
+`f.op` and `g.op` in `Cᵒᵖ`. -/
+noncomputable def pullbackIsoUnopPushout {X Y Z : C} (f : X ⟶ Z) (g : Y ⟶ Z) [HasPullback f g]
+    [HasPushout f.op g.op] : pullback f g ≅ unop (pushout f.op g.op) :=
+  IsLimit.conePointUniqueUpToIso (limit.isLimit _)
+    ((PushoutCocone.isColimitEquivIsLimitUnop _) (colimit.isColimit (span f.op g.op)))
+#align category_theory.limits.pullback_iso_unop_pushout CategoryTheory.Limits.pullbackIsoUnopPushout
+
+@[simp, reassoc.1]
+theorem pullbackIsoUnopPushout_inv_fst {X Y Z : C} (f : X ⟶ Z) (g : Y ⟶ Z) [HasPullback f g]
+    [HasPushout f.op g.op] :
+    (pullbackIsoUnopPushout f g).inv ≫ pullback.fst = (pushout.inl : _ ⟶ pushout f.op g.op).unop :=
+  (IsLimit.conePointUniqueUpToIso_inv_comp _ _ _).trans (by simp)
+#align category_theory.limits.pullback_iso_unop_pushout_inv_fst CategoryTheory.Limits.pullbackIsoUnopPushout_inv_fst
+
+@[simp, reassoc.1]
+theorem pullbackIsoUnopPushout_inv_snd {X Y Z : C} (f : X ⟶ Z) (g : Y ⟶ Z) [HasPullback f g]
+    [HasPushout f.op g.op] :
+    (pullbackIsoUnopPushout f g).inv ≫ pullback.snd = (pushout.inr : _ ⟶ pushout f.op g.op).unop :=
+  (IsLimit.conePointUniqueUpToIso_inv_comp _ _ _).trans (by simp)
+#align category_theory.limits.pullback_iso_unop_pushout_inv_snd CategoryTheory.Limits.pullbackIsoUnopPushout_inv_snd
+
+@[simp, reassoc.1]
+theorem pullbackIsoUnopPushout_hom_inl {X Y Z : C} (f : X ⟶ Z) (g : Y ⟶ Z) [HasPullback f g]
+    [HasPushout f.op g.op] : pushout.inl ≫ (pullbackIsoUnopPushout f g).hom.op = pullback.fst.op :=
+  by
+  apply Quiver.Hom.unop_inj
+  dsimp
+  rw [← pullback_iso_unop_pushout_inv_fst, iso.hom_inv_id_assoc]
+#align category_theory.limits.pullback_iso_unop_pushout_hom_inl CategoryTheory.Limits.pullbackIsoUnopPushout_hom_inl
+
+@[simp, reassoc.1]
+theorem pullbackIsoUnopPushout_hom_inr {X Y Z : C} (f : X ⟶ Z) (g : Y ⟶ Z) [HasPullback f g]
+    [HasPushout f.op g.op] : pushout.inr ≫ (pullbackIsoUnopPushout f g).hom.op = pullback.snd.op :=
+  by
+  apply Quiver.Hom.unop_inj
+  dsimp
+  rw [← pullback_iso_unop_pushout_inv_snd, iso.hom_inv_id_assoc]
+#align category_theory.limits.pullback_iso_unop_pushout_hom_inr CategoryTheory.Limits.pullbackIsoUnopPushout_hom_inr
+
+end Pullback
+
+section Pushout
+
+/-- The pushout of `f` and `g` in `C` is isomorphic to the pullback of
+ `f.op` and `g.op` in `Cᵒᵖ`. -/
+noncomputable def pushoutIsoUnopPullback {X Y Z : C} (f : X ⟶ Z) (g : X ⟶ Y) [HasPushout f g]
+    [HasPullback f.op g.op] : pushout f g ≅ unop (pullback f.op g.op) :=
+  IsColimit.coconePointUniqueUpToIso (colimit.isColimit _)
+    ((PullbackCone.isLimitEquivIsColimitUnop _) (limit.isLimit (cospan f.op g.op)))
+#align category_theory.limits.pushout_iso_unop_pullback CategoryTheory.Limits.pushoutIsoUnopPullback
+
+@[simp, reassoc.1]
+theorem pushoutIsoUnopPullback_inl_hom {X Y Z : C} (f : X ⟶ Z) (g : X ⟶ Y) [HasPushout f g]
+    [HasPullback f.op g.op] :
+    pushout.inl ≫ (pushoutIsoUnopPullback f g).hom = (pullback.fst : pullback f.op g.op ⟶ _).unop :=
+  (IsColimit.comp_coconePointUniqueUpToIso_hom _ _ _).trans (by simp)
+#align category_theory.limits.pushout_iso_unop_pullback_inl_hom CategoryTheory.Limits.pushoutIsoUnopPullback_inl_hom
+
+@[simp, reassoc.1]
+theorem pushoutIsoUnopPullback_inr_hom {X Y Z : C} (f : X ⟶ Z) (g : X ⟶ Y) [HasPushout f g]
+    [HasPullback f.op g.op] :
+    pushout.inr ≫ (pushoutIsoUnopPullback f g).hom = (pullback.snd : pullback f.op g.op ⟶ _).unop :=
+  (IsColimit.comp_coconePointUniqueUpToIso_hom _ _ _).trans (by simp)
+#align category_theory.limits.pushout_iso_unop_pullback_inr_hom CategoryTheory.Limits.pushoutIsoUnopPullback_inr_hom
+
+@[simp]
+theorem pushoutIsoUnopPullback_inv_fst {X Y Z : C} (f : X ⟶ Z) (g : X ⟶ Y) [HasPushout f g]
+    [HasPullback f.op g.op] : (pushoutIsoUnopPullback f g).inv.op ≫ pullback.fst = pushout.inl.op :=
+  by
+  apply Quiver.Hom.unop_inj
+  dsimp
+  rw [← pushout_iso_unop_pullback_inl_hom, category.assoc, iso.hom_inv_id, category.comp_id]
+#align category_theory.limits.pushout_iso_unop_pullback_inv_fst CategoryTheory.Limits.pushoutIsoUnopPullback_inv_fst
+
+@[simp]
+theorem pushoutIsoUnopPullback_inv_snd {X Y Z : C} (f : X ⟶ Z) (g : X ⟶ Y) [HasPushout f g]
+    [HasPullback f.op g.op] : (pushoutIsoUnopPullback f g).inv.op ≫ pullback.snd = pushout.inr.op :=
+  by
+  apply Quiver.Hom.unop_inj
+  dsimp
+  rw [← pushout_iso_unop_pullback_inr_hom, category.assoc, iso.hom_inv_id, category.comp_id]
+#align category_theory.limits.pushout_iso_unop_pullback_inv_snd CategoryTheory.Limits.pushoutIsoUnopPullback_inv_snd
+
+end Pushout
+
+end CategoryTheory.Limits
+

--- a/Mathlib/CategoryTheory/Limits/Shapes/FiniteLimits.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/FiniteLimits.lean
@@ -40,23 +40,23 @@ instance and `J : Type` has a limit.
 This is often called 'finitely complete'.
 -/
 class HasFiniteLimits : Prop where
-  /-- `C` has all limits over any type `J` whose objects and morphisms lie in the same universe 
+  /-- `C` has all limits over any type `J` whose objects and morphisms lie in the same universe
   and which has `FinType` objects and morphisms-/
   out (J : Type) [𝒥 : SmallCategory J] [@FinCategory J 𝒥] : @HasLimitsOfShape J 𝒥 C _
 #align category_theory.limits.has_finite_limits CategoryTheory.Limits.HasFiniteLimits
 
 instance (priority := 100) hasLimitsOfShape_of_hasFiniteLimits (J : Type w) [SmallCategory J]
     [FinCategory J] [HasFiniteLimits C] : HasLimitsOfShape J C := by
-  apply @hasLimitsOfShapeOfEquivalence _ _ _ _ _ _ (FinCategory.equivAsType J) ?_
+  apply @hasLimitsOfShape_of_equivalence _ _ _ _ _ _ (FinCategory.equivAsType J) ?_
   apply HasFiniteLimits.out
 #align category_theory.limits.has_limits_of_shape_of_has_finite_limits CategoryTheory.Limits.hasLimitsOfShape_of_hasFiniteLimits
 
 instance (priority := 100) hasFiniteLimits_of_hasLimitsOfSize [HasLimitsOfSize.{v', u'} C] :
-    HasFiniteLimits C where 
-  out := fun J hJ hJ' => 
+    HasFiniteLimits C where
+  out := fun J hJ hJ' =>
     haveI := hasLimitsOfSizeShrink.{0, 0} C
     let F := @FinCategory.equivAsType J (@FinCategory.fintypeObj J hJ hJ') hJ hJ'
-    @hasLimitsOfShapeOfEquivalence (@FinCategory.AsType J (@FinCategory.fintypeObj J hJ hJ')) 
+    @hasLimitsOfShape_of_equivalence (@FinCategory.AsType J (@FinCategory.fintypeObj J hJ hJ'))
     (@FinCategory.categoryAsType J (@FinCategory.fintypeObj J hJ hJ') hJ hJ') _ _ J hJ F _
 #align category_theory.limits.has_finite_limits_of_has_limits_of_size CategoryTheory.Limits.hasFiniteLimits_of_hasLimitsOfSize
 
@@ -69,18 +69,18 @@ instance (priority := 100) hasFiniteLimits_of_hasLimits [HasLimits C] : HasFinit
 arbitrary universe. -/
 theorem hasFiniteLimits_of_hasFiniteLimits_of_size
     (h : ∀ (J : Type w) {𝒥 : SmallCategory J} (_ : @FinCategory J 𝒥), HasLimitsOfShape J C) :
-    HasFiniteLimits C where 
+    HasFiniteLimits C where
   out := fun J hJ hhJ => by
     haveI := h (ULiftHom.{w} (ULift.{w} J)) <| @CategoryTheory.finCategoryUlift J hJ hhJ
-    have l : 
+    have l :
       @Equivalence J (ULiftHom (ULift J)) hJ (@ULiftHom.category (ULift J) (@uliftCategory J hJ))
       := @ULiftHomULiftCategory.equiv J hJ
-    apply @hasLimitsOfShapeOfEquivalence (ULiftHom (ULift J)) 
-      (@ULiftHom.category (ULift J) (@uliftCategory J hJ)) C _ J hJ 
-      (@Equivalence.symm J hJ (ULiftHom (ULift J)) 
+    apply @hasLimitsOfShape_of_equivalence (ULiftHom (ULift J))
+      (@ULiftHom.category (ULift J) (@uliftCategory J hJ)) C _ J hJ
+      (@Equivalence.symm J hJ (ULiftHom (ULift J))
       (@ULiftHom.category (ULift J) (@uliftCategory J hJ)) l) _
-    /- Porting note: tried to factor out (@instCategoryULiftHom (ULift J) (@uliftCategory J hJ) 
-    but when doing that would then find the instance and say it was not definitionally equal to 
+    /- Porting note: tried to factor out (@instCategoryULiftHom (ULift J) (@uliftCategory J hJ)
+    but when doing that would then find the instance and say it was not definitionally equal to
     to the provide one (the same thing factored out) -/
 #align category_theory.limits.has_finite_limits_of_has_finite_limits_of_size CategoryTheory.Limits.hasFiniteLimits_of_hasFiniteLimits_of_size
 
@@ -90,7 +90,7 @@ instance and `J : Type` has a colimit.
 This is often called 'finitely cocomplete'.
 -/
 class HasFiniteColimits : Prop where
-  /-- `C` has all colimits over any type `J` whose objects and morphisms lie in the same universe 
+  /-- `C` has all colimits over any type `J` whose objects and morphisms lie in the same universe
   and which has `FinType` objects and morphisms-/
   out (J : Type) [𝒥 : SmallCategory J] [@FinCategory J 𝒥] : @HasColimitsOfShape J 𝒥 C _
 #align category_theory.limits.has_finite_colimits CategoryTheory.Limits.HasFiniteColimits
@@ -106,7 +106,7 @@ instance (priority := 100) hasFiniteColimits_of_hasColimitsOfSize [HasColimitsOf
   out := fun J hJ hJ' =>
     haveI := hasColimitsOfSize_shrink.{0, 0} C
     let F := @FinCategory.equivAsType J (@FinCategory.fintypeObj J hJ hJ') hJ hJ'
-    @hasColimitsOfShape_of_equivalence (@FinCategory.AsType J (@FinCategory.fintypeObj J hJ hJ')) 
+    @hasColimitsOfShape_of_equivalence (@FinCategory.AsType J (@FinCategory.fintypeObj J hJ hJ'))
     (@FinCategory.categoryAsType J (@FinCategory.fintypeObj J hJ hJ') hJ hJ') _ _ J hJ F _
 #align category_theory.limits.has_finite_colimits_of_has_colimits_of_size CategoryTheory.Limits.hasFiniteColimits_of_hasColimitsOfSize
 
@@ -114,15 +114,15 @@ instance (priority := 100) hasFiniteColimits_of_hasColimitsOfSize [HasColimitsOf
 arbitrary universe. -/
 theorem hasFiniteColimits_of_hasFiniteColimits_of_size
     (h : ∀ (J : Type w) {𝒥 : SmallCategory J} (_ : @FinCategory J 𝒥), HasColimitsOfShape J C) :
-    HasFiniteColimits C where 
+    HasFiniteColimits C where
   out := fun J hJ hhJ => by
     haveI := h (ULiftHom.{w} (ULift.{w} J)) <| @CategoryTheory.finCategoryUlift J hJ hhJ
-    have l : 
+    have l :
       @Equivalence J (ULiftHom (ULift J)) hJ (@ULiftHom.category (ULift J) (@uliftCategory J hJ))
       := @ULiftHomULiftCategory.equiv J hJ
-    apply @hasColimitsOfShape_of_equivalence (ULiftHom (ULift J)) 
-      (@ULiftHom.category (ULift J) (@uliftCategory J hJ)) C _ J hJ 
-      (@Equivalence.symm J hJ (ULiftHom (ULift J)) 
+    apply @hasColimitsOfShape_of_equivalence (ULiftHom (ULift J))
+      (@ULiftHom.category (ULift J) (@uliftCategory J hJ)) C _ J hJ
+      (@Equivalence.symm J hJ (ULiftHom (ULift J))
       (@ULiftHom.category (ULift J) (@uliftCategory J hJ)) l) _
 #align category_theory.limits.has_finite_colimits_of_has_finite_colimits_of_size CategoryTheory.Limits.hasFiniteColimits_of_hasFiniteColimits_of_size
 
@@ -143,14 +143,14 @@ instance (j j' : WalkingParallelPair) : Fintype (WalkingParallelPairHom j j') wh
       (WalkingParallelPair.recOn j' [WalkingParallelPairHom.id zero].toFinset
         [left, right].toFinset)
       (WalkingParallelPair.recOn j' ∅ [WalkingParallelPairHom.id one].toFinset)
-  complete := by 
+  complete := by
     rintro (_|_) <;> simp
     · cases j <;> simp
 end
 
 instance : FinCategory WalkingParallelPair where
   fintypeObj := fintypeWalkingParallelPair
-  fintypeHom := instFintypeWalkingParallelPairHom -- Porting note: could not be inferred 
+  fintypeHom := instFintypeWalkingParallelPairHom -- Porting note: could not be inferred
 
 /-- Equalizers are finite limits, so if `C` has all finite limits, it also has all equalizers -/
 example [HasFiniteLimits C] : HasEqualizers C := by infer_instance
@@ -181,9 +181,9 @@ instance fintypeHom (j j' : WidePullbackShape J) : Fintype (j ⟶ j')
       · rw [h]
         exact {Hom.id j}
       · exact ∅
-  complete := by 
+  complete := by
     rintro (_|_)
-    · cases j <;> simp 
+    · cases j <;> simp
     · simp
 #align category_theory.limits.wide_pullback_shape.fintype_hom CategoryTheory.Limits.WidePullbackShape.fintypeHom
 
@@ -205,10 +205,10 @@ instance fintypeHom (j j' : WidePushoutShape J) : Fintype (j ⟶ j') where
       · rw [h]
         exact {Hom.id j'}
       · exact ∅
-  complete := by 
-    rintro (_|_) 
-    · cases j <;> simp 
-    · simp 
+  complete := by
+    rintro (_|_)
+    · cases j <;> simp
+    · simp
 #align category_theory.limits.wide_pushout_shape.fintype_hom CategoryTheory.Limits.WidePushoutShape.fintypeHom
 
 end WidePushoutShape
@@ -280,4 +280,3 @@ example [HasFiniteWidePullbacks C] : HasPullbacks C := by infer_instance
 example [HasFiniteWidePushouts C] : HasPushouts C := by infer_instance
 
 end CategoryTheory.Limits
-

--- a/Mathlib/CategoryTheory/Limits/Shapes/FiniteProducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/FiniteProducts.lean
@@ -49,7 +49,7 @@ instance hasLimitsOfShape_discrete [HasFiniteProducts C] (ι : Type w) [Finite �
     HasLimitsOfShape (Discrete ι) C := by
   rcases Finite.exists_equiv_fin ι with ⟨n, ⟨e⟩⟩
   haveI : HasLimitsOfShape (Discrete (Fin n)) C := HasFiniteProducts.out n
-  exact hasLimitsOfShapeOfEquivalence (Discrete.equivalence e.symm)
+  exact hasLimitsOfShape_of_equivalence (Discrete.equivalence e.symm)
 #align category_theory.limits.has_limits_of_shape_discrete CategoryTheory.Limits.hasLimitsOfShape_discrete
 
 /-- We can now write this for powers. -/
@@ -59,7 +59,7 @@ noncomputable example [HasFiniteProducts C] (X : C) : C :=
 /-- If a category has all products then in particular it has finite products.
 -/
 theorem hasFiniteProducts_of_hasProducts [HasProducts.{w} C] : HasFiniteProducts C :=
-  ⟨fun _ => hasLimitsOfShapeOfEquivalence (Discrete.equivalence Equiv.ulift.{w})⟩
+  ⟨fun _ => hasLimitsOfShape_of_equivalence (Discrete.equivalence Equiv.ulift.{w})⟩
 #align category_theory.limits.has_finite_products_of_has_products CategoryTheory.Limits.hasFiniteProducts_of_hasProducts
 
 /-- A category has finite coproducts if there is a chosen colimit for every diagram

--- a/Mathlib/CategoryTheory/Limits/Shapes/Products.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Products.lean
@@ -285,7 +285,7 @@ abbrev HasCoproducts :=
 variable {C}
 
 theorem has_smallest_products_of_hasProducts [HasProducts.{w} C] : HasProducts.{0} C := fun J =>
-  hasLimitsOfShapeOfEquivalence (Discrete.equivalence Equiv.ulift : Discrete (ULift.{w} J) ≌ _)
+  hasLimitsOfShape_of_equivalence (Discrete.equivalence Equiv.ulift : Discrete (ULift.{w} J) ≌ _)
 #align category_theory.limits.has_smallest_products_of_has_products CategoryTheory.Limits.has_smallest_products_of_hasProducts
 
 theorem has_smallest_coproducts_of_hasCoproducts [HasCoproducts.{w} C] : HasCoproducts.{0} C :=

--- a/Mathlib/CategoryTheory/Limits/Shapes/WidePullbacks.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/WidePullbacks.lean
@@ -39,18 +39,18 @@ namespace CategoryTheory.Limits
 variable (J : Type w)
 
 /-- A wide pullback shape for any type `J` can be written simply as `Option J`. -/
-def WidePullbackShape := Option J 
+def WidePullbackShape := Option J
 #align category_theory.limits.wide_pullback_shape CategoryTheory.Limits.WidePullbackShape
 
 -- Porting note: strangely this could be synthesized
-instance : Inhabited (WidePullbackShape J) where 
+instance : Inhabited (WidePullbackShape J) where
   default := none
 
 /-- A wide pushout shape for any type `J` can be written simply as `Option J`. -/
-def WidePushoutShape := Option J 
+def WidePushoutShape := Option J
 #align category_theory.limits.wide_pushout_shape CategoryTheory.Limits.WidePushoutShape
 
-instance : Inhabited (WidePushoutShape J) where 
+instance : Inhabited (WidePushoutShape J) where
   default := none
 
 namespace WidePullbackShape
@@ -61,7 +61,7 @@ variable {J}
 inductive Hom : WidePullbackShape J → WidePullbackShape J → Type w
   | id : ∀ X, Hom X X
   | term : ∀ j : J, Hom (some j) none
-  deriving DecidableEq 
+  deriving DecidableEq
 #align category_theory.limits.wide_pullback_shape.hom CategoryTheory.Limits.WidePullbackShape.Hom
 
 attribute [nolint unusedArguments] instDecidableEqHom
@@ -81,20 +81,20 @@ instance Hom.inhabited : Inhabited (Hom (none : WidePullbackShape J) none) :=
 #align category_theory.limits.wide_pullback_shape.hom.inhabited CategoryTheory.Limits.WidePullbackShape.Hom.inhabited
 
 open Lean Elab Tactic
-/- Pointing note: experimenting with manual scoping of aesop tactics. Attempted to define 
+/- Pointing note: experimenting with manual scoping of aesop tactics. Attempted to define
 aesop rule directing on `WidePushoutOut` and it didn't take for some reason -/
 /-- An aesop tactic for bulk cases on morphisms in `WidePushoutShape` -/
-def evalCasesBash : TacticM Unit := do 
-  evalTactic 
-    (← `(tactic| casesm* WidePullbackShape _, 
+def evalCasesBash : TacticM Unit := do
+  evalTactic
+    (← `(tactic| casesm* WidePullbackShape _,
       (_: WidePullbackShape _) ⟶  (_ : WidePullbackShape _) ))
 
 attribute [local aesop safe tactic (rule_sets [CategoryTheory])] evalCasesBash
 
-instance subsingleton_hom : Quiver.IsThin (WidePullbackShape J) := fun _ _ => by 
+instance subsingleton_hom : Quiver.IsThin (WidePullbackShape J) := fun _ _ => by
   constructor
-  intro a b 
-  casesm* WidePullbackShape _, (_: WidePullbackShape _) ⟶  (_ : WidePullbackShape _) 
+  intro a b
+  casesm* WidePullbackShape _, (_: WidePullbackShape _) ⟶  (_ : WidePullbackShape _)
   rfl; rfl; rfl
 #align category_theory.limits.wide_pullback_shape.subsingleton_hom CategoryTheory.Limits.WidePullbackShape.subsingleton_hom
 
@@ -107,8 +107,8 @@ theorem hom_id (X : WidePullbackShape J) : Hom.id X = 𝟙 X :=
   rfl
 #align category_theory.limits.wide_pullback_shape.hom_id CategoryTheory.Limits.WidePullbackShape.hom_id
 
-/- Porting note: we get a warning that we should change LHS to `sizeOf (𝟙 X)` but Lean cannot 
-find the category instance on `WidePullbackShape J` in that case. Once supplied in the proof, 
+/- Porting note: we get a warning that we should change LHS to `sizeOf (𝟙 X)` but Lean cannot
+find the category instance on `WidePullbackShape J` in that case. Once supplied in the proof,
 the proposed proof of `simp [only WidePullbackShape.hom_id]` does not work -/
 attribute [nolint simpNF] Hom.id.sizeOf_spec
 
@@ -198,18 +198,18 @@ instance Hom.inhabited : Inhabited (Hom (none : WidePushoutShape J) none) :=
 open Lean Elab Tactic
 -- Pointing note: experimenting with manual scoping of aesop tactics; only this worked
 /-- An aesop tactic for bulk cases on morphisms in `WidePushoutShape` -/
-def evalCasesBash' : TacticM Unit := do 
-  evalTactic 
-    (← `(tactic| casesm* WidePushoutShape _,  
+def evalCasesBash' : TacticM Unit := do
+  evalTactic
+    (← `(tactic| casesm* WidePushoutShape _,
       (_: WidePushoutShape _) ⟶  (_ : WidePushoutShape _) ))
 
 attribute [local aesop safe tactic (rule_sets [CategoryTheory])] evalCasesBash'
 
-instance subsingleton_hom : Quiver.IsThin (WidePushoutShape J) := fun _ _ => by 
+instance subsingleton_hom : Quiver.IsThin (WidePushoutShape J) := fun _ _ => by
   constructor
   intro a b
   casesm* WidePushoutShape _, (_: WidePushoutShape _) ⟶  (_ : WidePushoutShape _)
-  repeat rfl 
+  repeat rfl
 #align category_theory.limits.wide_pushout_shape.subsingleton_hom CategoryTheory.Limits.WidePushoutShape.subsingleton_hom
 
 instance category : SmallCategory (WidePushoutShape J) :=
@@ -221,8 +221,8 @@ theorem hom_id (X : WidePushoutShape J) : Hom.id X = 𝟙 X :=
   rfl
 #align category_theory.limits.wide_pushout_shape.hom_id CategoryTheory.Limits.WidePushoutShape.hom_id
 
-/- Porting note: we get a warning that we should change LHS to `sizeOf (𝟙 X)` but Lean cannot 
-find the category instance on `WidePushoutShape J` in that case. Once supplied in the proof, 
+/- Porting note: we get a warning that we should change LHS to `sizeOf (𝟙 X)` but Lean cannot
+find the category instance on `WidePushoutShape J` in that case. Once supplied in the proof,
 the proposed proof of `simp [only WidePushoutShape.hom_id]` does not work -/
 attribute [nolint simpNF] Hom.id.sizeOf_spec
 variable {C : Type u} [Category.{v} C]
@@ -237,10 +237,10 @@ def wideSpan (B : C) (objs : J → C) (arrows : ∀ j : J, B ⟶ objs j) : WideP
     cases' f with _ j
     · apply 𝟙 _
     · exact arrows j
-  map_comp := fun f g => by 
+  map_comp := fun f g => by
     cases f
-    · simp only [Eq.ndrec, hom_id, eq_rec_constant, Category.id_comp]; congr 
-    · cases g 
+    · simp only [Eq.ndrec, hom_id, eq_rec_constant, Category.id_comp]; congr
+    · cases g
       · simp only [Eq.ndrec, hom_id, eq_rec_constant, Category.comp_id]; congr
 #align category_theory.limits.wide_pushout_shape.wide_span CategoryTheory.Limits.WidePushoutShape.wideSpan
 
@@ -325,7 +325,7 @@ noncomputable abbrev base : widePullback _ _ arrows ⟶ B :=
 theorem π_arrow (j : J) : π arrows j ≫ arrows _ = base arrows := by
   apply limit.w (WidePullbackShape.wideCospan _ _ _) (WidePullbackShape.Hom.term j)
 #align category_theory.limits.wide_pullback.π_arrow CategoryTheory.Limits.WidePullback.π_arrow
- 
+
 variable {arrows}
 
 /-- Lift a collection of morphisms to a morphism to the pullback. -/
@@ -403,7 +403,7 @@ theorem arrow_ι (j : J) : arrows j ≫ ι arrows j = head arrows := by
 #align category_theory.limits.wide_pushout.arrow_ι CategoryTheory.Limits.WidePushout.arrow_ι
 
 -- Porting note: this can simplify itself
-attribute [nolint simpNF] WidePushout.arrow_ι WidePushout.arrow_ι_assoc 
+attribute [nolint simpNF] WidePushout.arrow_ι WidePushout.arrow_ι_assoc
 
 variable {arrows}
 
@@ -448,7 +448,7 @@ theorem hom_eq_desc (g : widePushout _ _ arrows ⟶ X) :
         simp := by
   apply eq_desc_of_comp_eq
   aesop_cat
-  rfl -- Porting note: another missing rfl 
+  rfl -- Porting note: another missing rfl
 #align category_theory.limits.wide_pushout.hom_eq_desc CategoryTheory.Limits.WidePushout.hom_eq_desc
 
 @[ext]
@@ -479,7 +479,7 @@ def widePullbackShapeOpMap :
 @[simps]
 def widePullbackShapeOp : WidePullbackShape J ⥤ (WidePushoutShape J)ᵒᵖ where
   obj X := op X
-  map {X₁} {X₂} := widePullbackShapeOpMap J X₁ X₂ 
+  map {X₁} {X₂} := widePullbackShapeOpMap J X₁ X₂
 #align category_theory.limits.wide_pullback_shape_op CategoryTheory.Limits.widePullbackShapeOp
 
 /-- The action on morphisms of the obvious functor
@@ -495,7 +495,7 @@ def widePushoutShapeOpMap :
 @[simps]
 def widePushoutShapeOp : WidePushoutShape J ⥤ (WidePullbackShape J)ᵒᵖ where
   obj X := op X
-  map := fun {X} {Y} => widePushoutShapeOpMap J X Y 
+  map := fun {X} {Y} => widePushoutShapeOpMap J X Y
 #align category_theory.limits.wide_pushout_shape_op CategoryTheory.Limits.widePushoutShapeOp
 
 /-- The obvious functor `(WidePullbackShape J)ᵒᵖ ⥤ WidePushoutShape J`-/
@@ -555,8 +555,7 @@ def widePullbackShapeOpEquiv : (WidePullbackShape J)ᵒᵖ ≌ WidePushoutShape 
 /-- If a category has wide pullbacks on a higher universe level it also has wide pullbacks
 on a lower universe level. -/
 theorem hasWidePullbacks_shrink [HasWidePullbacks.{max w w'} C] : HasWidePullbacks.{w} C := fun _ =>
-  hasLimitsOfShapeOfEquivalence (WidePullbackShape.equivalenceOfEquiv _ Equiv.ulift.{w'})
+  hasLimitsOfShape_of_equivalence (WidePullbackShape.equivalenceOfEquiv _ Equiv.ulift.{w'})
 #align category_theory.limits.has_wide_pullbacks_shrink CategoryTheory.Limits.hasWidePullbacks_shrink
 
 end CategoryTheory.Limits
-


### PR DESCRIPTION
---
There was an inconsistency in the naming of `hasColimitsOfShape_of_equivalence` and `hasLimitsOfShapeOfEquivalence`. I have changed the latter to `hasLimitsOfShape_of_equivalence`: this is why this PR changes several files.
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
