### PR TITLE
[Merged by Bors] - chore: strip trailing spaces in lean files

### DIFF
--- a/Mathlib/CategoryTheory/Abelian/NonPreadditive.lean
+++ b/Mathlib/CategoryTheory/Abelian/NonPreadditive.lean
@@ -162,7 +162,7 @@ instance : Mono (Abelian.factorThruCoimage f) :=
     calc
       h ≫ f = h ≫ p ≫ i := (Abelian.coimage.fac f).symm ▸ rfl
       _ = h ≫ p ≫ cokernel.π g ≫ t := (ht ▸ rfl)
-      _ = h ≫ u ≫ t := by simp only [Category.assoc] 
+      _ = h ≫ u ≫ t := by simp only [Category.assoc]
       _ = 0 ≫ t := by rw [← Category.assoc, hu.w]
       _ = 0 := zero_comp
     -- h factors through the kernel of f via some l.
@@ -283,7 +283,7 @@ abbrev σ {A : C} : A ⨯ A ⟶ A :=
 
 end
 
--- Porting note: simp can prove these 
+-- Porting note: simp can prove these
 @[reassoc]
 theorem diag_σ {X : C} : diag X ≫ σ = 0 := by rw [cokernel.condition_assoc, zero_comp]
 #align category_theory.non_preadditive_abelian.diag_σ CategoryTheory.NonPreadditiveAbelian.diag_σ
@@ -296,7 +296,7 @@ theorem lift_σ {X : C} : prod.lift (𝟙 X) 0 ≫ σ = 𝟙 X := by rw [← Cat
 theorem lift_map {X Y : C} (f : X ⟶ Y) :
     prod.lift (𝟙 X) 0 ≫ Limits.prod.map f f = f ≫ prod.lift (𝟙 Y) 0 := by simp
 #align category_theory.non_preadditive_abelian.lift_map CategoryTheory.NonPreadditiveAbelian.lift_map
- 
+
 /-- σ is a cokernel of Δ X. -/
 def isColimitσ {X : C} : IsColimit (CokernelCofork.ofπ (σ : X ⨯ X ⟶  X) diag_σ) :=
   cokernel.cokernelIso _ σ (asIso (r X)).symm (by rw [Iso.symm_hom, asIso_inv])
@@ -305,7 +305,7 @@ def isColimitσ {X : C} : IsColimit (CokernelCofork.ofπ (σ : X ⨯ X ⟶  X) d
 /-- This is the key identity satisfied by `σ`. -/
 theorem σ_comp {X Y : C} (f : X ⟶ Y) : σ ≫ f = Limits.prod.map f f ≫ σ := by
   obtain ⟨g, hg⟩ :=
-    CokernelCofork.IsColimit.desc' isColimitσ (Limits.prod.map f f ≫ σ) (by 
+    CokernelCofork.IsColimit.desc' isColimitσ (Limits.prod.map f f ≫ σ) (by
       rw [prod.diag_map_assoc, diag_σ, comp_zero])
   suffices hfg : f = g
   · rw [← hg, Cofork.π_ofπ, hfg]
@@ -314,7 +314,7 @@ theorem σ_comp {X Y : C} (f : X ⟶ Y) : σ ≫ f = Limits.prod.map f f ≫ σ 
     _ = prod.lift (𝟙 X) 0 ≫ Limits.prod.map f f ≫ σ := by rw [lift_map_assoc]
     _ = prod.lift (𝟙 X) 0 ≫ σ ≫ g := by rw [← hg, CokernelCofork.π_ofπ]
     _ = g := by rw [← Category.assoc, lift_σ, Category.id_comp]
-    
+
 #align category_theory.non_preadditive_abelian.σ_comp CategoryTheory.NonPreadditiveAbelian.σ_comp
 
 section
@@ -329,7 +329,7 @@ attribute [local instance] hasSub
 
 -- We write `-f` for `0 - f`.
 /-- Negation of morphisms in a `NonPreadditiveAbelian` category. -/
-def hasNeg {X Y : C} : Neg (X ⟶ Y) where 
+def hasNeg {X Y : C} : Neg (X ⟶ Y) where
   neg := fun f => 0 - f
 #align category_theory.non_preadditive_abelian.has_neg CategoryTheory.NonPreadditiveAbelian.hasNeg
 
@@ -367,7 +367,7 @@ theorem sub_self {X Y : C} (a : X ⟶ Y) : a - a = 0 := by
 theorem lift_sub_lift {X Y : C} (a b c d : X ⟶ Y) :
     prod.lift a b - prod.lift c d = prod.lift (a - c) (b - d) := by
   simp only [sub_def]
-  apply prod.hom_ext 
+  apply prod.hom_ext
   · rw [Category.assoc, σ_comp, prod.lift_map_assoc, prod.lift_fst, prod.lift_fst, prod.lift_fst]
   · rw [Category.assoc, σ_comp, prod.lift_map_assoc, prod.lift_snd, prod.lift_snd, prod.lift_snd]
 #align category_theory.non_preadditive_abelian.lift_sub_lift CategoryTheory.NonPreadditiveAbelian.lift_sub_lift
@@ -393,7 +393,7 @@ theorem add_comm {X Y : C} (a b : X ⟶ Y) : a + b = b + a := by
   rw [neg_def, neg_def, neg_def, sub_sub_sub]
   conv_lhs =>
     congr
-    next => skip 
+    next => skip
     rw [← neg_def, neg_sub]
   rw [sub_sub_sub, add_def, ← neg_def, neg_neg b, neg_def]
 #align category_theory.non_preadditive_abelian.add_comm CategoryTheory.NonPreadditiveAbelian.add_comm
@@ -448,7 +448,7 @@ theorem add_comp (X Y Z : C) (f g : X ⟶ Y) (h : Y ⟶ Z) : (f + g) ≫ h = f �
 /-- Every `NonPreadditiveAbelian` category is preadditive. -/
 def preadditive : Preadditive C where
   homGroup X Y :=
-    { add := (· + ·) 
+    { add := (· + ·)
       add_assoc := add_assoc
       zero := 0
       zero_add := neg_neg
@@ -464,4 +464,3 @@ def preadditive : Preadditive C where
 end
 
 end CategoryTheory.NonPreadditiveAbelian
-

--- a/Mathlib/CategoryTheory/Bicategory/Basic.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Basic.lean
@@ -73,7 +73,7 @@ class Bicategory (B : Type u) extends CategoryStruct.{v} B where
   -- right unitor:
   rightUnitor {a b : B} (f : a ⟶ b) : f ≫ 𝟙 b ≅ f
   -- axioms for left whiskering:
-  whiskerLeft_id : ∀ {a b c} (f : a ⟶ b) (g : b ⟶ c), whiskerLeft f (𝟙 g) = 𝟙 (f ≫ g) := 
+  whiskerLeft_id : ∀ {a b c} (f : a ⟶ b) (g : b ⟶ c), whiskerLeft f (𝟙 g) = 𝟙 (f ≫ g) :=
     by aesop_cat
   whiskerLeft_comp :
     ∀ {a b c} (f : a ⟶ b) {g h i : b ⟶ c} (η : g ⟶ h) (θ : h ⟶ i),
@@ -125,7 +125,7 @@ class Bicategory (B : Type u) extends CategoryStruct.{v} B where
   -- triangle identity:
   triangle :
     ∀ {a b c} (f : a ⟶ b) (g : b ⟶ c),
-      (associator f (𝟙 b) g).hom ≫ whiskerLeft f (leftUnitor g).hom 
+      (associator f (𝟙 b) g).hom ≫ whiskerLeft f (leftUnitor g).hom
       = whiskerRight (rightUnitor f).hom g := by
     aesop_cat
 #align category_theory.bicategory CategoryTheory.Bicategory
@@ -178,14 +178,14 @@ Note that `f₁ ◁ f₂ ◁ f₃ ◁ η ▷ f₄ ▷ f₅` is actually `f₁ �
 attribute [instance] homCategory
 
 attribute [reassoc]
-  whiskerLeft_comp id_whiskerLeft comp_whiskerLeft comp_whiskerRight whiskerRight_id 
-  whiskerRight_comp whisker_assoc whisker_exchange 
+  whiskerLeft_comp id_whiskerLeft comp_whiskerLeft comp_whiskerRight whiskerRight_id
+  whiskerRight_comp whisker_assoc whisker_exchange
 
 attribute [reassoc (attr := simp)] pentagon triangle
 /-
 The following simp attributes are put in order to rewrite any 2-morphisms into normal forms. There
 are associators and unitors in the RHS in the several simp lemmas here (e.g. `id_whiskerLeft`),
-which at first glance look more complicated than the LHS, but they will be eventually reduced by 
+which at first glance look more complicated than the LHS, but they will be eventually reduced by
 the pentagon or the triangle identities, and more generally, (forthcoming) `coherence` tactic.
 -/
 attribute [simp]
@@ -203,7 +203,7 @@ theorem hom_inv_whiskerLeft (f : a ⟶ b) {g h : b ⟶ c} (η : g ≅ h) :
 @[reassoc (attr := simp)]
 theorem hom_inv_whiskerRight {f g : a ⟶ b} (η : f ≅ g) (h : b ⟶ c) :
     η.hom ▷ h ≫ η.inv ▷ h = 𝟙 (f ≫ h) := by rw [← comp_whiskerRight, hom_inv_id, id_whiskerRight]
-#align category_theory.bicategory.hom_inv_whisker_right 
+#align category_theory.bicategory.hom_inv_whisker_right
   CategoryTheory.Bicategory.hom_inv_whiskerRight
 
 @[reassoc (attr := simp)]
@@ -214,7 +214,7 @@ theorem inv_hom_whiskerLeft (f : a ⟶ b) {g h : b ⟶ c} (η : g ≅ h) :
 @[reassoc (attr := simp)]
 theorem inv_hom_whiskerRight {f g : a ⟶ b} (η : f ≅ g) (h : b ⟶ c) :
     η.inv ▷ h ≫ η.hom ▷ h = 𝟙 (g ≫ h) := by rw [← comp_whiskerRight, inv_hom_id, id_whiskerRight]
-#align category_theory.bicategory.inv_hom_whisker_right 
+#align category_theory.bicategory.inv_hom_whisker_right
   CategoryTheory.Bicategory.inv_hom_whiskerRight
 
 /-- The left whiskering of a 2-isomorphism is a 2-isomorphism. -/
@@ -230,9 +230,9 @@ instance whiskerLeft_isIso (f : a ⟶ b) {g h : b ⟶ c} (η : g ⟶ h) [IsIso �
 #align category_theory.bicategory.whisker_left_is_iso CategoryTheory.Bicategory.whiskerLeft_isIso
 
 @[simp]
-theorem inv_whiskerLeft (f : a ⟶ b) {g h : b ⟶ c} (η : g ⟶ h) [IsIso η] : 
+theorem inv_whiskerLeft (f : a ⟶ b) {g h : b ⟶ c} (η : g ⟶ h) [IsIso η] :
   inv (f ◁ η) = f ◁ inv η := by
-  aesop_cat 
+  aesop_cat
   simp only [← whiskerLeft_comp, whiskerLeft_id, IsIso.hom_inv_id]
 #align category_theory.bicategory.inv_whisker_left CategoryTheory.Bicategory.inv_whiskerLeft
 
@@ -246,13 +246,13 @@ def whiskerRightIso {f g : a ⟶ b} (η : f ≅ g) (h : b ⟶ c) : f ≫ h ≅ g
 
 instance whiskerRight_isIso {f g : a ⟶ b} (η : f ⟶ g) (h : b ⟶ c) [IsIso η] : IsIso (η ▷ h) :=
   IsIso.of_iso (whiskerRightIso (asIso η) h)
-#align category_theory.bicategory.whisker_right_is_iso 
+#align category_theory.bicategory.whisker_right_is_iso
   CategoryTheory.Bicategory.whiskerRight_isIso
 
 @[simp]
 theorem inv_whiskerRight {f g : a ⟶ b} (η : f ⟶ g) (h : b ⟶ c) [IsIso η] :
     inv (η ▷ h) = inv η ▷ h := by
-  aesop_cat 
+  aesop_cat
   simp only [← comp_whiskerRight, id_whiskerRight, IsIso.hom_inv_id]
 #align category_theory.bicategory.inv_whisker_right CategoryTheory.Bicategory.inv_whiskerRight
 
@@ -270,7 +270,7 @@ theorem pentagon_inv_inv_hom_hom_inv (f : a ⟶ b) (g : b ⟶ c) (h : c ⟶ d) (
   by
   rw [← cancel_epi (f ◁ (α_ g h i).inv), ← cancel_mono (α_ (f ≫ g) h i).inv]
   simp
-#align category_theory.bicategory.pentagon_inv_inv_hom_hom_inv 
+#align category_theory.bicategory.pentagon_inv_inv_hom_hom_inv
   CategoryTheory.Bicategory.pentagon_inv_inv_hom_hom_inv
 
 @[reassoc (attr := simp)]
@@ -278,7 +278,7 @@ theorem pentagon_inv_hom_hom_hom_inv (f : a ⟶ b) (g : b ⟶ c) (h : c ⟶ d) (
     (α_ (f ≫ g) h i).inv ≫ (α_ f g h).hom ▷ i ≫ (α_ f (g ≫ h) i).hom =
       (α_ f g (h ≫ i)).hom ≫ f ◁ (α_ g h i).inv :=
   eq_of_inv_eq_inv (by simp)
-#align category_theory.bicategory.pentagon_inv_hom_hom_hom_inv 
+#align category_theory.bicategory.pentagon_inv_hom_hom_hom_inv
   CategoryTheory.Bicategory.pentagon_inv_hom_hom_hom_inv
 
 @[reassoc (attr := simp)]
@@ -286,7 +286,7 @@ theorem pentagon_hom_inv_inv_inv_inv (f : a ⟶ b) (g : b ⟶ c) (h : c ⟶ d) (
     f ◁ (α_ g h i).hom ≫ (α_ f g (h ≫ i)).inv ≫ (α_ (f ≫ g) h i).inv =
       (α_ f (g ≫ h) i).inv ≫ (α_ f g h).inv ▷ i :=
   by simp [← cancel_epi (f ◁ (α_ g h i).inv)]
-#align category_theory.bicategory.pentagon_hom_inv_inv_inv_inv 
+#align category_theory.bicategory.pentagon_hom_inv_inv_inv_inv
   CategoryTheory.Bicategory.pentagon_hom_inv_inv_inv_inv
 
 @[reassoc (attr := simp)]
@@ -294,7 +294,7 @@ theorem pentagon_hom_hom_inv_hom_hom (f : a ⟶ b) (g : b ⟶ c) (h : c ⟶ d) (
     (α_ (f ≫ g) h i).hom ≫ (α_ f g (h ≫ i)).hom ≫ f ◁ (α_ g h i).inv =
       (α_ f g h).hom ▷ i ≫ (α_ f (g ≫ h) i).hom :=
   eq_of_inv_eq_inv (by simp)
-#align category_theory.bicategory.pentagon_hom_hom_inv_hom_hom 
+#align category_theory.bicategory.pentagon_hom_hom_inv_hom_hom
   CategoryTheory.Bicategory.pentagon_hom_hom_inv_hom_hom
 
 @[reassoc (attr := simp)]
@@ -304,7 +304,7 @@ theorem pentagon_hom_inv_inv_inv_hom (f : a ⟶ b) (g : b ⟶ c) (h : c ⟶ d) (
   by
   rw [← cancel_epi (α_ f g (h ≫ i)).inv, ← cancel_mono ((α_ f g h).inv ▷ i)]
   simp
-#align category_theory.bicategory.pentagon_hom_inv_inv_inv_hom 
+#align category_theory.bicategory.pentagon_hom_inv_inv_inv_hom
   CategoryTheory.Bicategory.pentagon_hom_inv_inv_inv_hom
 
 @[reassoc (attr := simp)]
@@ -312,7 +312,7 @@ theorem pentagon_hom_hom_inv_inv_hom (f : a ⟶ b) (g : b ⟶ c) (h : c ⟶ d) (
     (α_ f (g ≫ h) i).hom ≫ f ◁ (α_ g h i).hom ≫ (α_ f g (h ≫ i)).inv =
       (α_ f g h).inv ▷ i ≫ (α_ (f ≫ g) h i).hom :=
   eq_of_inv_eq_inv (by simp)
-#align category_theory.bicategory.pentagon_hom_hom_inv_inv_hom 
+#align category_theory.bicategory.pentagon_hom_hom_inv_inv_hom
   CategoryTheory.Bicategory.pentagon_hom_hom_inv_inv_hom
 
 @[reassoc (attr := simp)]
@@ -320,7 +320,7 @@ theorem pentagon_inv_hom_hom_hom_hom (f : a ⟶ b) (g : b ⟶ c) (h : c ⟶ d) (
     (α_ f g h).inv ▷ i ≫ (α_ (f ≫ g) h i).hom ≫ (α_ f g (h ≫ i)).hom =
       (α_ f (g ≫ h) i).hom ≫ f ◁ (α_ g h i).hom :=
   by simp [← cancel_epi ((α_ f g h).hom ▷ i)]
-#align category_theory.bicategory.pentagon_inv_hom_hom_hom_hom 
+#align category_theory.bicategory.pentagon_inv_hom_hom_hom_hom
   CategoryTheory.Bicategory.pentagon_inv_hom_hom_hom_hom
 
 @[reassoc (attr := simp)]
@@ -328,94 +328,94 @@ theorem pentagon_inv_inv_hom_inv_inv (f : a ⟶ b) (g : b ⟶ c) (h : c ⟶ d) (
     (α_ f g (h ≫ i)).inv ≫ (α_ (f ≫ g) h i).inv ≫ (α_ f g h).hom ▷ i =
       f ◁ (α_ g h i).inv ≫ (α_ f (g ≫ h) i).inv :=
   eq_of_inv_eq_inv (by simp)
-#align category_theory.bicategory.pentagon_inv_inv_hom_inv_inv 
+#align category_theory.bicategory.pentagon_inv_inv_hom_inv_inv
   CategoryTheory.Bicategory.pentagon_inv_inv_hom_inv_inv
 
 theorem triangle_assoc_comp_left (f : a ⟶ b) (g : b ⟶ c) :
     (α_ f (𝟙 b) g).hom ≫ f ◁ (λ_ g).hom = (ρ_ f).hom ▷ g :=
   triangle f g
-#align category_theory.bicategory.triangle_assoc_comp_left 
+#align category_theory.bicategory.triangle_assoc_comp_left
   CategoryTheory.Bicategory.triangle_assoc_comp_left
 
 @[reassoc (attr := simp)]
 theorem triangle_assoc_comp_right (f : a ⟶ b) (g : b ⟶ c) :
     (α_ f (𝟙 b) g).inv ≫ (ρ_ f).hom ▷ g = f ◁ (λ_ g).hom := by rw [← triangle, inv_hom_id_assoc]
-#align category_theory.bicategory.triangle_assoc_comp_right 
+#align category_theory.bicategory.triangle_assoc_comp_right
   CategoryTheory.Bicategory.triangle_assoc_comp_right
 
 @[reassoc (attr := simp)]
 theorem triangle_assoc_comp_right_inv (f : a ⟶ b) (g : b ⟶ c) :
-    (ρ_ f).inv ▷ g ≫ (α_ f (𝟙 b) g).hom = f ◁ (λ_ g).inv := by 
+    (ρ_ f).inv ▷ g ≫ (α_ f (𝟙 b) g).hom = f ◁ (λ_ g).inv := by
   simp [← cancel_mono (f ◁ (λ_ g).hom)]
-#align category_theory.bicategory.triangle_assoc_comp_right_inv 
+#align category_theory.bicategory.triangle_assoc_comp_right_inv
   CategoryTheory.Bicategory.triangle_assoc_comp_right_inv
 
 @[reassoc (attr := simp)]
 theorem triangle_assoc_comp_left_inv (f : a ⟶ b) (g : b ⟶ c) :
-    f ◁ (λ_ g).inv ≫ (α_ f (𝟙 b) g).inv = (ρ_ f).inv ▷ g := by 
+    f ◁ (λ_ g).inv ≫ (α_ f (𝟙 b) g).inv = (ρ_ f).inv ▷ g := by
   simp [← cancel_mono ((ρ_ f).hom ▷ g)]
-#align category_theory.bicategory.triangle_assoc_comp_left_inv 
+#align category_theory.bicategory.triangle_assoc_comp_left_inv
   CategoryTheory.Bicategory.triangle_assoc_comp_left_inv
 
 @[reassoc]
 theorem associator_naturality_left {f f' : a ⟶ b} (η : f ⟶ f') (g : b ⟶ c) (h : c ⟶ d) :
     η ▷ g ▷ h ≫ (α_ f' g h).hom = (α_ f g h).hom ≫ η ▷ (g ≫ h) := by simp
-#align category_theory.bicategory.associator_naturality_left 
+#align category_theory.bicategory.associator_naturality_left
   CategoryTheory.Bicategory.associator_naturality_left
 
 @[reassoc]
 theorem associator_inv_naturality_left {f f' : a ⟶ b} (η : f ⟶ f') (g : b ⟶ c) (h : c ⟶ d) :
     η ▷ (g ≫ h) ≫ (α_ f' g h).inv = (α_ f g h).inv ≫ η ▷ g ▷ h := by simp
-#align category_theory.bicategory.associator_inv_naturality_left 
+#align category_theory.bicategory.associator_inv_naturality_left
   CategoryTheory.Bicategory.associator_inv_naturality_left
 
 @[reassoc]
 theorem whiskerRight_comp_symm {f f' : a ⟶ b} (η : f ⟶ f') (g : b ⟶ c) (h : c ⟶ d) :
     η ▷ g ▷ h = (α_ f g h).hom ≫ η ▷ (g ≫ h) ≫ (α_ f' g h).inv := by simp
-#align category_theory.bicategory.whisker_right_comp_symm 
+#align category_theory.bicategory.whisker_right_comp_symm
   CategoryTheory.Bicategory.whiskerRight_comp_symm
 
 @[reassoc]
 theorem associator_naturality_middle (f : a ⟶ b) {g g' : b ⟶ c} (η : g ⟶ g') (h : c ⟶ d) :
     (f ◁ η) ▷ h ≫ (α_ f g' h).hom = (α_ f g h).hom ≫ f ◁ η ▷ h := by simp
-#align category_theory.bicategory.associator_naturality_middle 
+#align category_theory.bicategory.associator_naturality_middle
   CategoryTheory.Bicategory.associator_naturality_middle
 
 @[reassoc]
 theorem associator_inv_naturality_middle (f : a ⟶ b) {g g' : b ⟶ c} (η : g ⟶ g') (h : c ⟶ d) :
     f ◁ η ▷ h ≫ (α_ f g' h).inv = (α_ f g h).inv ≫ (f ◁ η) ▷ h := by simp
-#align category_theory.bicategory.associator_inv_naturality_middle 
+#align category_theory.bicategory.associator_inv_naturality_middle
   CategoryTheory.Bicategory.associator_inv_naturality_middle
 
 @[reassoc]
 theorem whisker_assoc_symm (f : a ⟶ b) {g g' : b ⟶ c} (η : g ⟶ g') (h : c ⟶ d) :
     f ◁ η ▷ h = (α_ f g h).inv ≫ (f ◁ η) ▷ h ≫ (α_ f g' h).hom := by simp
-#align category_theory.bicategory.whisker_assoc_symm 
+#align category_theory.bicategory.whisker_assoc_symm
   CategoryTheory.Bicategory.whisker_assoc_symm
 
 @[reassoc]
 theorem associator_naturality_right (f : a ⟶ b) (g : b ⟶ c) {h h' : c ⟶ d} (η : h ⟶ h') :
     (f ≫ g) ◁ η ≫ (α_ f g h').hom = (α_ f g h).hom ≫ f ◁ g ◁ η := by simp
-#align category_theory.bicategory.associator_naturality_right 
+#align category_theory.bicategory.associator_naturality_right
   CategoryTheory.Bicategory.associator_naturality_right
 
 @[reassoc]
 theorem associator_inv_naturality_right (f : a ⟶ b) (g : b ⟶ c) {h h' : c ⟶ d} (η : h ⟶ h') :
     f ◁ g ◁ η ≫ (α_ f g h').inv = (α_ f g h).inv ≫ (f ≫ g) ◁ η := by simp
-#align category_theory.bicategory.associator_inv_naturality_right 
+#align category_theory.bicategory.associator_inv_naturality_right
   CategoryTheory.Bicategory.associator_inv_naturality_right
 
 @[reassoc]
 theorem comp_whiskerLeft_symm (f : a ⟶ b) (g : b ⟶ c) {h h' : c ⟶ d} (η : h ⟶ h') :
     f ◁ g ◁ η = (α_ f g h).inv ≫ (f ≫ g) ◁ η ≫ (α_ f g h').hom := by simp
-#align category_theory.bicategory.comp_whisker_left_symm 
+#align category_theory.bicategory.comp_whisker_left_symm
   CategoryTheory.Bicategory.comp_whiskerLeft_symm
 
 @[reassoc]
-theorem leftUnitor_naturality {f g : a ⟶ b} (η : f ⟶ g) : 
+theorem leftUnitor_naturality {f g : a ⟶ b} (η : f ⟶ g) :
     𝟙 a ◁ η ≫ (λ_ g).hom = (λ_ f).hom ≫ η :=
   by simp
-#align category_theory.bicategory.left_unitor_naturality 
+#align category_theory.bicategory.left_unitor_naturality
   CategoryTheory.Bicategory.leftUnitor_naturality
 
 @[reassoc]
@@ -470,7 +470,7 @@ theorem whiskerLeft_rightUnitor (f : a ⟶ b) (g : b ⟶ c) :
   rw [← whiskerRight_iff, comp_whiskerRight, ← cancel_epi (α_ _ _ _).inv, ←
       cancel_epi (f ◁ (α_ _ _ _).inv), pentagon_inv_assoc, triangle_assoc_comp_right, ←
       associator_inv_naturality_middle, ← whiskerLeft_comp_assoc, triangle_assoc_comp_right,
-      associator_inv_naturality_right] 
+      associator_inv_naturality_right]
 #align category_theory.bicategory.whisker_left_right_unitor CategoryTheory.Bicategory.whiskerLeft_rightUnitor
 
 @[reassoc, simp]
@@ -510,7 +510,7 @@ theorem rightUnitor_comp_inv (f : a ⟶ b) (g : b ⟶ c) :
 @[simp]
 theorem unitors_equal : (λ_ (𝟙 a)).hom = (ρ_ (𝟙 a)).hom := by
   rw [← whiskerLeft_iff, ← cancel_epi (α_ _ _ _).hom, ← cancel_mono (ρ_ _).hom, triangle, ←
-      rightUnitor_comp, rightUnitor_naturality] 
+      rightUnitor_comp, rightUnitor_naturality]
 #align category_theory.bicategory.unitors_equal CategoryTheory.Bicategory.unitors_equal
 
 @[simp]

--- a/Mathlib/CategoryTheory/Category/Basic.lean
+++ b/Mathlib/CategoryTheory/Category/Basic.lean
@@ -120,7 +120,7 @@ which adds the `CategoryTheory` rule set,
 and allows `aesop` look through semireducible definitions when calling `intros`. -/
 macro (name := aesop_cat) "aesop_cat" c:Aesop.tactic_clause*: tactic =>
   `(tactic|
-    aesop $c* (options := { introsTransparency? := some .default, warnOnNonterminal := false }) 
+    aesop $c* (options := { introsTransparency? := some .default, warnOnNonterminal := false })
     (rule_sets [$(Lean.mkIdent `CategoryTheory):ident]))
 
 -- We turn on `ext` inside `aesop_cat`.

--- a/Mathlib/CategoryTheory/Category/Cat.lean
+++ b/Mathlib/CategoryTheory/Category/Cat.lean
@@ -141,22 +141,22 @@ This ought to be modelled as a 2-functor!
 @[simps]
 def typeToCat : Type u ⥤ Cat where
   obj X := Cat.of (Discrete X)
-  map := fun {X} {Y} f => by 
-    dsimp 
+  map := fun {X} {Y} f => by
+    dsimp
     exact Discrete.functor (Discrete.mk ∘ f)
-  map_id X := by 
+  map_id X := by
     apply Functor.ext
     · intro X Y f
       cases f
       simp only [id_eq, eqToHom_refl, Cat.id_map, Category.comp_id, Category.id_comp]
       apply ULift.ext
       aesop_cat
-    · aesop_cat 
+    · aesop_cat
   map_comp f g := by apply Functor.ext; aesop_cat
 set_option linter.uppercaseLean3 false in
 #align category_theory.Type_to_Cat CategoryTheory.typeToCat
 
-instance : Faithful typeToCat.{u} where 
+instance : Faithful typeToCat.{u} where
   map_injective {_X} {_Y} _f _g h :=
     funext fun x => congr_arg Discrete.as (Functor.congr_obj h ⟨x⟩)
 
@@ -168,11 +168,10 @@ instance : Full typeToCat.{u}
     apply Functor.ext
     · intro x y f
       dsimp
-      apply ULift.ext 
+      apply ULift.ext
       aesop_cat
     · rintro ⟨x⟩
       apply Discrete.ext
       rfl
 
 end CategoryTheory
-

--- a/Mathlib/CategoryTheory/ConcreteCategory/Basic.lean
+++ b/Mathlib/CategoryTheory/ConcreteCategory/Basic.lean
@@ -71,7 +71,7 @@ def forget (C : Type v) [Category C] [ConcreteCategory.{u} C] : C ⥤ Type u :=
   ConcreteCategory.Forget
 #align category_theory.forget CategoryTheory.forget
 
-instance ConcreteCategory.types : ConcreteCategory (Type u) where 
+instance ConcreteCategory.types : ConcreteCategory (Type u) where
   Forget := 𝟭 _
 #align category_theory.concrete_category.types CategoryTheory.ConcreteCategory.types
 
@@ -108,9 +108,9 @@ attribute [local instance] ConcreteCategory.hasCoeToFun
 
 /-- In any concrete category, we can test equality of morphisms by pointwise evaluations.-/
 theorem ConcreteCategory.hom_ext {X Y : C} (f g : X ⟶ Y) (w : ∀ x : X, f x = g x) : f = g := by
-  apply @Faithful.map_injective C _ (Type w) _ (forget C) _ X Y 
+  apply @Faithful.map_injective C _ (Type w) _ (forget C) _ X Y
   dsimp [forget]
-  funext x 
+  funext x
   exact w x
 #align category_theory.concrete_category.hom_ext CategoryTheory.ConcreteCategory.hom_ext
 
@@ -133,12 +133,12 @@ theorem coe_comp {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) : (f ≫ g : X → Z) =
   (forget _).map_comp f g
 #align category_theory.coe_comp CategoryTheory.coe_comp
 
--- Porting note: removed @[simp] since simp can prove this 
+-- Porting note: removed @[simp] since simp can prove this
 theorem id_apply {X : C} (x : X) : (𝟙 X : X → X) x = x :=
   congr_fun ((forget _).map_id X) x
 #align category_theory.id_apply CategoryTheory.id_apply
 
--- Porting note: removed @[simp] since simp can prove this 
+-- Porting note: removed @[simp] since simp can prove this
 theorem comp_apply {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) (x : X) : (f ≫ g) x = g (f x) :=
   congr_fun ((forget _).map_comp _ _) x
 #align category_theory.comp_apply CategoryTheory.comp_apply
@@ -238,7 +238,7 @@ instance forget₂_preservesEpimorphisms (C : Type v) (D : Type v') [Category C]
 #align category_theory.forget₂_preserves_epimorphisms CategoryTheory.forget₂_preservesEpimorphisms
 
 instance InducedCategory.concreteCategory {C : Type v} {D : Type v'} [Category D]
-    [ConcreteCategory D] (f : C → D) : ConcreteCategory (InducedCategory D f) where 
+    [ConcreteCategory D] (f : C → D) : ConcreteCategory (InducedCategory D f) where
   Forget := inducedFunctor f ⋙ forget D
 #align category_theory.induced_category.concrete_category CategoryTheory.InducedCategory.concreteCategory
 
@@ -249,7 +249,7 @@ instance InducedCategory.hasForget₂ {C : Type v} {D : Type v'} [Category D] [C
 #align category_theory.induced_category.has_forget₂ CategoryTheory.InducedCategory.hasForget₂
 
 instance FullSubcategory.concreteCategory {C : Type v} [Category C] [ConcreteCategory C]
-    (Z : C → Prop) : ConcreteCategory (FullSubcategory Z) where 
+    (Z : C → Prop) : ConcreteCategory (FullSubcategory Z) where
   Forget := fullSubcategoryInclusion Z ⋙ forget C
 #align category_theory.full_subcategory.concrete_category CategoryTheory.FullSubcategoryₓ.concreteCategory
 
@@ -279,4 +279,3 @@ def hasForgetToType (C : Type v) [Category C] [ConcreteCategory C] : HasForget�
 #align category_theory.has_forget_to_Type CategoryTheory.hasForgetToType
 
 end CategoryTheory
-

--- a/Mathlib/CategoryTheory/EpiMono.lean
+++ b/Mathlib/CategoryTheory/EpiMono.lean
@@ -60,7 +60,7 @@ attribute [reassoc (attr := simp)] SplitMono.id
 
 /-- `IsSplitMono f` is the assertion that `f` admits a retraction -/
 class IsSplitMono {X Y : C} (f : X ⟶ Y) : Prop where
-  /-- There is a splitting -/ 
+  /-- There is a splitting -/
   exists_splitMono : Nonempty (SplitMono f)
 #align category_theory.is_split_mono CategoryTheory.IsSplitMono
 #align category_theory.is_split_mono.exists_split_mono CategoryTheory.IsSplitMono.exists_splitMono
@@ -111,7 +111,7 @@ theorem IsSplitMono.id {X Y : C} (f : X ⟶ Y) [hf : IsSplitMono f] : f ≫ retr
 #align category_theory.is_split_mono.id CategoryTheory.IsSplitMono.id
 
 /-- The retraction of a split monomorphism has an obvious section. -/
-def SplitMono.splitEpi {X Y : C} {f : X ⟶ Y} (sm : SplitMono f) : SplitEpi sm.retraction 
+def SplitMono.splitEpi {X Y : C} {f : X ⟶ Y} (sm : SplitMono f) : SplitEpi sm.retraction
     where section_ := f
 #align category_theory.split_mono.split_epi CategoryTheory.SplitMono.splitEpi
 

--- a/Mathlib/CategoryTheory/Functor/Currying.lean
+++ b/Mathlib/CategoryTheory/Functor/Currying.lean
@@ -58,14 +58,14 @@ def curryObj (F : C × D ⥤ E) : C ⥤ D ⥤ E
     where
   obj X :=
     { obj := fun Y => F.obj (X, Y)
-      map := fun g => F.map (𝟙 X, g) 
+      map := fun g => F.map (𝟙 X, g)
       map_id := fun Y => by simp only [F.map_id]; rw [←prod_id]; exact F.map_id ⟨X,Y⟩
-      map_comp := fun f g => by simp [←F.map_comp]} 
-  map f := 
-    { app := fun Y => F.map (f, 𝟙 Y) 
+      map_comp := fun f g => by simp [←F.map_comp]}
+  map f :=
+    { app := fun Y => F.map (f, 𝟙 Y)
       naturality := fun {Y} {Y'} g => by simp [←F.map_comp]  }
-  map_id := fun X => by ext Y; exact F.map_id _  
-  map_comp := fun f g => by ext Y; dsimp; simp [←F.map_comp] 
+  map_id := fun X => by ext Y; exact F.map_id _
+  map_comp := fun f g => by ext Y; dsimp; simp [←F.map_comp]
 #align category_theory.curry_obj CategoryTheory.curryObj
 
 /-- The currying functor, taking a functor `(C × D) ⥤ E` and producing a functor `C ⥤ (D ⥤ E)`.
@@ -95,7 +95,7 @@ def currying : C ⥤ D ⥤ E ≌ C × D ⥤ E :=
         NatIso.ofComponents (fun X => NatIso.ofComponents (fun Y => Iso.refl _) (by aesop_cat))
           (by aesop_cat))
       (by aesop_cat))
-    (NatIso.ofComponents (fun F => NatIso.ofComponents (fun X => eqToIso (by simp)) 
+    (NatIso.ofComponents (fun F => NatIso.ofComponents (fun X => eqToIso (by simp))
       (by intros X Y f; cases X; cases Y; cases f; dsimp at *; rw [←F.map_comp]; simp ))
       (by aesop_cat))
 #align category_theory.currying CategoryTheory.currying
@@ -103,7 +103,7 @@ def currying : C ⥤ D ⥤ E ≌ C × D ⥤ E :=
 /-- `F.flip` is isomorphic to uncurrying `F`, swapping the variables, and currying. -/
 @[simps!]
 def flipIsoCurrySwapUncurry (F : C ⥤ D ⥤ E) : F.flip ≅ curry.obj (Prod.swap _ _ ⋙ uncurry.obj F) :=
-  NatIso.ofComponents (fun d => NatIso.ofComponents (fun c => Iso.refl _) 
+  NatIso.ofComponents (fun d => NatIso.ofComponents (fun c => Iso.refl _)
     (by aesop_cat)) (by aesop_cat)
 #align category_theory.flip_iso_curry_swap_uncurry CategoryTheory.flipIsoCurrySwapUncurry
 

--- a/Mathlib/CategoryTheory/Functor/EpiMono.lean
+++ b/Mathlib/CategoryTheory/Functor/EpiMono.lean
@@ -55,7 +55,7 @@ instance map_epi (F : C ⥤ D) [PreservesEpimorphisms F] {X Y : C} (f : X ⟶ Y)
     monomorphisms. -/
 class ReflectsMonomorphisms (F : C ⥤ D) : Prop where
    /-- A functor reflects monomorphisms if morphisms that are mapped to monomorphisms are themselves
-    monomorphisms. -/ 
+    monomorphisms. -/
   reflects : ∀ {X Y : C} (f : X ⟶ Y), Mono (F.map f) → Mono f
 #align category_theory.functor.reflects_monomorphisms CategoryTheory.Functor.ReflectsMonomorphisms
 
@@ -78,26 +78,26 @@ theorem epi_of_epi_map (F : C ⥤ D) [ReflectsEpimorphisms F] {X Y : C} {f : X �
 #align category_theory.functor.epi_of_epi_map CategoryTheory.Functor.epi_of_epi_map
 
 instance preservesMonomorphisms_comp (F : C ⥤ D) (G : D ⥤ E) [PreservesMonomorphisms F]
-    [PreservesMonomorphisms G] : PreservesMonomorphisms (F ⋙ G) where 
+    [PreservesMonomorphisms G] : PreservesMonomorphisms (F ⋙ G) where
   preserves f h := by
     rw [comp_map]
     exact inferInstance
 #align category_theory.functor.preserves_monomorphisms_comp CategoryTheory.Functor.preservesMonomorphisms_comp
 
 instance preservesEpimorphisms_comp (F : C ⥤ D) (G : D ⥤ E) [PreservesEpimorphisms F]
-    [PreservesEpimorphisms G] : PreservesEpimorphisms (F ⋙ G) where 
+    [PreservesEpimorphisms G] : PreservesEpimorphisms (F ⋙ G) where
   preserves f h := by
     rw [comp_map]
     exact inferInstance
 #align category_theory.functor.preserves_epimorphisms_comp CategoryTheory.Functor.preservesEpimorphisms_comp
 
 instance reflectsMonomorphisms_comp (F : C ⥤ D) (G : D ⥤ E) [ReflectsMonomorphisms F]
-    [ReflectsMonomorphisms G] : ReflectsMonomorphisms (F ⋙ G) where 
+    [ReflectsMonomorphisms G] : ReflectsMonomorphisms (F ⋙ G) where
   reflects _ h := F.mono_of_mono_map (G.mono_of_mono_map h)
 #align category_theory.functor.reflects_monomorphisms_comp CategoryTheory.Functor.reflectsMonomorphisms_comp
 
 instance reflectsEpimorphisms_comp (F : C ⥤ D) (G : D ⥤ E) [ReflectsEpimorphisms F]
-    [ReflectsEpimorphisms G] : ReflectsEpimorphisms (F ⋙ G) where 
+    [ReflectsEpimorphisms G] : ReflectsEpimorphisms (F ⋙ G) where
   reflects _ h := F.epi_of_epi_map (G.epi_of_epi_map h)
 #align category_theory.functor.reflects_epimorphisms_comp CategoryTheory.Functor.reflectsEpimorphisms_comp
 
@@ -241,11 +241,11 @@ def splitEpiEquiv [Full F] [Faithful F] : SplitEpi f ≃ SplitEpi (F.map f)
     simp only [map_comp, image_preimage, map_id]
     apply SplitEpi.id
   left_inv := by aesop_cat
-  right_inv := by 
+  right_inv := by
       simp only [Function.RightInverse,Function.LeftInverse]
-      intro x 
+      intro x
       simp only [SplitEpi.map, preimage]
-      aesop_cat 
+      aesop_cat
 #align category_theory.functor.split_epi_equiv CategoryTheory.Functor.splitEpiEquiv
 
 @[simp]
@@ -267,7 +267,7 @@ def splitMonoEquiv [Full F] [Faithful F] : SplitMono f ≃ SplitMono (F.map f)
     simp only [map_comp, image_preimage, map_id]
     apply SplitMono.id
   left_inv := by aesop_cat
-  right_inv := by 
+  right_inv := by
     simp only [Function.RightInverse, Function.LeftInverse]
     intro x
     simp only [SplitMono.map,preimage]
@@ -353,4 +353,3 @@ theorem strongEpi_map_iff_strongEpi_of_isEquivalence [IsEquivalence F] :
 #align category_theory.functor.strong_epi_map_iff_strong_epi_of_is_equivalence CategoryTheory.Functor.strongEpi_map_iff_strongEpi_of_isEquivalence
 
 end CategoryTheory.Functor
-

--- a/Mathlib/CategoryTheory/Functor/Hom.lean
+++ b/Mathlib/CategoryTheory/Functor/Hom.lean
@@ -32,7 +32,7 @@ covariant in `Y`. -/
 def hom : Cᵒᵖ × C ⥤ Type v where
   obj p := unop p.1 ⟶ p.2
   map f h := f.1.unop ≫ h ≫ f.2
-  map_id := by aesop_cat 
+  map_id := by aesop_cat
   map_comp := fun {X} {Y} {Z} f g => by funext b; simp
 #align category_theory.functor.hom CategoryTheory.Functor.hom
 

--- a/Mathlib/CategoryTheory/Functor/ReflectsIso.lean
+++ b/Mathlib/CategoryTheory/Functor/ReflectsIso.lean
@@ -67,7 +67,7 @@ instance (F : C ⥤ D) (G : D ⥤ E) [ReflectsIsomorphisms F] [ReflectsIsomorphi
 
 instance (priority := 100) reflectsIsomorphisms_of_reflectsMonomorphisms_of_reflectsEpimorphisms
     [Balanced C] (F : C ⥤ D) [ReflectsMonomorphisms F] [ReflectsEpimorphisms F] :
-    ReflectsIsomorphisms F where 
+    ReflectsIsomorphisms F where
   reflects f hf := by
     skip
     haveI : Epi f := epi_of_epi_map F inferInstance
@@ -78,4 +78,3 @@ instance (priority := 100) reflectsIsomorphisms_of_reflectsMonomorphisms_of_refl
 end ReflectsIso
 
 end CategoryTheory
-

--- a/Mathlib/CategoryTheory/Groupoid.lean
+++ b/Mathlib/CategoryTheory/Groupoid.lean
@@ -42,7 +42,7 @@ universe v v₂ u u₂
 -- morphism levels before object levels. See note [CategoryTheory universes].
 /-- A `Groupoid` is a category such that all morphisms are isomorphisms. -/
 class Groupoid (obj : Type u) extends Category.{v} obj : Type max u (v + 1) where
-  /-- The inverse morphism -/ 
+  /-- The inverse morphism -/
   inv : ∀ {X Y : obj}, (X ⟶ Y) → (Y ⟶ X)
   /-- `inv f` composed `f` is the identity -/
   inv_comp : ∀ {X Y : obj} (f : X ⟶ Y), comp (inv f) f = id Y := by aesop_cat
@@ -98,7 +98,7 @@ theorem Groupoid.reverse_eq_inv (f : X ⟶ Y) : Quiver.reverse f = Groupoid.inv 
 #align category_theory.groupoid.reverse_eq_inv CategoryTheory.Groupoid.reverse_eq_inv
 
 instance functorMapReverse {D : Type _} [Groupoid D] (F : C ⥤ D) : F.toPrefunctor.MapReverse
-    where 
+    where
       map_reverse' f := by
         simp only [Quiver.reverse, Quiver.HasReverse.reverse', Groupoid.inv_eq_inv,
           Functor.map_inv]
@@ -133,10 +133,10 @@ variable {C : Type u} [Category.{v} C]
 
 /-- A category where every morphism `IsIso` is a groupoid. -/
 noncomputable def Groupoid.ofIsIso (all_is_iso : ∀ {X Y : C} (f : X ⟶ Y), IsIso f) : Groupoid.{v} C
-    where 
+    where
       inv := fun f => CategoryTheory.inv f
-      comp_inv := by aesop_cat 
-      inv_comp := fun f => Classical.choose_spec (all_is_iso f).out|>.right  
+      comp_inv := by aesop_cat
+      inv_comp := fun f => Classical.choose_spec (all_is_iso f).out|>.right
 #align category_theory.groupoid.of_is_iso CategoryTheory.Groupoid.ofIsIso
 
 /-- A category with a unique morphism between any two objects is a groupoid -/
@@ -158,10 +158,10 @@ section
 
 instance groupoidPi {I : Type u} {J : I → Type u₂} [∀ i, Groupoid.{v} (J i)] :
     Groupoid.{max u v} (∀ i : I, J i)
-    where 
+    where
       inv f := fun i : I => Groupoid.inv (f i)
-      comp_inv := fun f => by funext i; apply Groupoid.comp_inv  
-      inv_comp := fun f => by funext i; apply Groupoid.inv_comp  
+      comp_inv := fun f => by funext i; apply Groupoid.comp_inv
+      inv_comp := fun f => by funext i; apply Groupoid.inv_comp
 #align category_theory.groupoid_pi CategoryTheory.groupoidPi
 
 instance groupoidProd {α : Type u} {β : Type v} [Groupoid.{u₂} α] [Groupoid.{v₂} β] :

--- a/Mathlib/CategoryTheory/IsConnected.lean
+++ b/Mathlib/CategoryTheory/IsConnected.lean
@@ -153,7 +153,7 @@ The converse is given in `is_connected.of_induct`.
 -/
 theorem induct_on_objects [IsPreconnected J] (p : Set J) {j₀ : J} (h0 : j₀ ∈ p)
     (h1 : ∀ {j₁ j₂ : J} (_ : j₁ ⟶ j₂), j₁ ∈ p ↔ j₂ ∈ p) (j : J) : j ∈ p := by
-  let aux (j₁ j₂ : J) (f : j₁ ⟶  j₂) := congrArg ULift.up <| (h1 f).to_eq 
+  let aux (j₁ j₂ : J) (f : j₁ ⟶  j₂) := congrArg ULift.up <| (h1 f).to_eq
   injection constant_of_preserves_morphisms (fun k => ULift.up (k ∈ p)) aux j j₀ with i
   rwa [i]
 #align category_theory.induct_on_objects CategoryTheory.induct_on_objects
@@ -167,8 +167,8 @@ theorem IsConnected.of_induct [Nonempty J] {j₀ : J}
     (h : ∀ p : Set J, j₀ ∈ p → (∀ {j₁ j₂ : J} (_ : j₁ ⟶ j₂), j₁ ∈ p ↔ j₂ ∈ p) → ∀ j : J, j ∈ p) :
     IsConnected J :=
   IsConnected.of_constant_of_preserves_morphisms fun {α} F a => by
-    have w := h { j | F j = F j₀ } rfl (fun {j₁} {j₂} f => by 
-      change F j₁ = F j₀ ↔ F j₂ = F j₀ 
+    have w := h { j | F j = F j₀ } rfl (fun {j₁} {j₂} f => by
+      change F j₁ = F j₀ ↔ F j₂ = F j₀
       simp [a f];)
     dsimp at w
     intro j j'
@@ -276,7 +276,7 @@ theorem zigzag_symmetric : Symmetric (@Zigzag J _) :=
 #align category_theory.zigzag_symmetric CategoryTheory.zigzag_symmetric
 
 theorem zigzag_equivalence : _root_.Equivalence (@Zigzag J _) :=
-  _root_.Equivalence.mk Relation.reflexive_reflTransGen (fun h => zigzag_symmetric h) 
+  _root_.Equivalence.mk Relation.reflexive_reflTransGen (fun h => zigzag_symmetric h)
   (fun h g => Relation.transitive_reflTransGen h g)
 #align category_theory.zigzag_equivalence CategoryTheory.zigzag_equivalence
 
@@ -392,4 +392,3 @@ instance nonempty_hom_of_connected_groupoid {G} [Groupoid G] [IsConnected G] :
 #align category_theory.nonempty_hom_of_connected_groupoid CategoryTheory.nonempty_hom_of_connected_groupoid
 
 end CategoryTheory
-

--- a/Mathlib/CategoryTheory/Limits/Constructions/EpiMono.lean
+++ b/Mathlib/CategoryTheory/Limits/Constructions/EpiMono.lean
@@ -41,7 +41,7 @@ theorem preserves_mono_of_preservesLimit {X Y : C} (f : X ⟶ Y) [PreservesLimit
 #align category_theory.preserves_mono_of_preserves_limit CategoryTheory.preserves_mono_of_preservesLimit
 
 instance (priority := 100) preservesMonomorphisms_of_preservesLimitsOfShape
-    [PreservesLimitsOfShape WalkingCospan F] : F.PreservesMonomorphisms where 
+    [PreservesLimitsOfShape WalkingCospan F] : F.PreservesMonomorphisms where
   preserves f _ := preserves_mono_of_preservesLimit F f
 #align category_theory.preserves_monomorphisms_of_preserves_limits_of_shape CategoryTheory.preservesMonomorphisms_of_preservesLimitsOfShape
 
@@ -54,7 +54,7 @@ theorem reflects_mono_of_reflectsLimit {X Y : C} (f : X ⟶ Y) [ReflectsLimit (c
 #align category_theory.reflects_mono_of_reflects_limit CategoryTheory.reflects_mono_of_reflectsLimit
 
 instance (priority := 100) reflectsMonomorphisms_of_reflectsLimitsOfShape
-    [ReflectsLimitsOfShape WalkingCospan F] : F.ReflectsMonomorphisms where 
+    [ReflectsLimitsOfShape WalkingCospan F] : F.ReflectsMonomorphisms where
   reflects f _ := reflects_mono_of_reflectsLimit F f
 #align category_theory.reflects_monomorphisms_of_reflects_limits_of_shape CategoryTheory.reflectsMonomorphisms_of_reflectsLimitsOfShape
 
@@ -67,7 +67,7 @@ theorem preserves_epi_of_preservesColimit {X Y : C} (f : X ⟶ Y) [PreservesColi
 #align category_theory.preserves_epi_of_preserves_colimit CategoryTheory.preserves_epi_of_preservesColimit
 
 instance (priority := 100) preservesEpimorphisms_of_preservesColimitsOfShape
-    [PreservesColimitsOfShape WalkingSpan F] : F.PreservesEpimorphisms where 
+    [PreservesColimitsOfShape WalkingSpan F] : F.PreservesEpimorphisms where
   preserves f _ := preserves_epi_of_preservesColimit F f
 #align category_theory.preserves_epimorphisms_of_preserves_colimits_of_shape CategoryTheory.preservesEpimorphisms_of_preservesColimitsOfShape
 
@@ -82,9 +82,8 @@ theorem reflects_epi_of_reflectsColimit {X Y : C} (f : X ⟶ Y) [ReflectsColimit
 #align category_theory.reflects_epi_of_reflects_colimit CategoryTheory.reflects_epi_of_reflectsColimit
 
 instance (priority := 100) reflectsEpimorphisms_of_reflectsColimitsOfShape
-    [ReflectsColimitsOfShape WalkingSpan F] : F.ReflectsEpimorphisms where 
+    [ReflectsColimitsOfShape WalkingSpan F] : F.ReflectsEpimorphisms where
   reflects f _ := reflects_epi_of_reflectsColimit F f
 #align category_theory.reflects_epimorphisms_of_reflects_colimits_of_shape CategoryTheory.reflectsEpimorphisms_of_reflectsColimitsOfShape
 
 end CategoryTheory
-

--- a/Mathlib/CategoryTheory/Limits/Constructions/Equalizers.lean
+++ b/Mathlib/CategoryTheory/Limits/Constructions/Equalizers.lean
@@ -54,7 +54,7 @@ abbrev pullbackFst (F : WalkingParallelPair ⥤ C) :
 #align category_theory.limits.has_equalizers_of_has_pullbacks_and_binary_products.pullback_fst CategoryTheory.Limits.HasEqualizersOfHasPullbacksAndBinaryProducts.pullbackFst
 
 theorem pullbackFst_eq_pullback_snd (F : WalkingParallelPair ⥤ C) : pullbackFst F = pullback.snd :=
-  by convert (eq_whisker pullback.condition Limits.prod.fst : 
+  by convert (eq_whisker pullback.condition Limits.prod.fst :
       (_ : constructEqualizer F ⟶  F.obj WalkingParallelPair.zero) = _) <;> simp
 #align category_theory.limits.has_equalizers_of_has_pullbacks_and_binary_products.pullback_fst_eq_pullback_snd CategoryTheory.Limits.HasEqualizersOfHasPullbacksAndBinaryProducts.pullbackFst_eq_pullback_snd
 
@@ -65,7 +65,7 @@ def equalizerCone (F : WalkingParallelPair ⥤ C) : Cone F :=
     (Fork.ofι (pullbackFst F)
       (by
         conv_rhs => rw [pullbackFst_eq_pullback_snd]
-        convert (eq_whisker pullback.condition Limits.prod.snd : 
+        convert (eq_whisker pullback.condition Limits.prod.snd :
           (_ : constructEqualizer F ⟶  F.obj WalkingParallelPair.one) = _) using 1 <;> simp))
 #align category_theory.limits.has_equalizers_of_has_pullbacks_and_binary_products.equalizer_cone CategoryTheory.Limits.HasEqualizersOfHasPullbacksAndBinaryProducts.equalizerCone
 
@@ -155,8 +155,8 @@ abbrev pushoutInl (F : WalkingParallelPair ⥤ C) :
 #align category_theory.limits.has_coequalizers_of_has_pushouts_and_binary_coproducts.pushout_inl CategoryTheory.Limits.HasCoequalizersOfHasPushoutsAndBinaryCoproducts.pushoutInl
 
 theorem pushoutInl_eq_pushout_inr (F : WalkingParallelPair ⥤ C) : pushoutInl F = pushout.inr := by
-  convert (whisker_eq Limits.coprod.inl pushout.condition : 
-    (_ : F.obj _ ⟶  constructCoequalizer _) = _) <;> simp 
+  convert (whisker_eq Limits.coprod.inl pushout.condition :
+    (_ : F.obj _ ⟶  constructCoequalizer _) = _) <;> simp
 #align category_theory.limits.has_coequalizers_of_has_pushouts_and_binary_coproducts.pushout_inl_eq_pushout_inr CategoryTheory.Limits.HasCoequalizersOfHasPushoutsAndBinaryCoproducts.pushoutInl_eq_pushout_inr
 
 /-- Define the equalizing cocone -/
@@ -165,7 +165,7 @@ def coequalizerCocone (F : WalkingParallelPair ⥤ C) : Cocone F :=
   Cocone.ofCofork
     (Cofork.ofπ (pushoutInl F) (by
         conv_rhs => rw [pushoutInl_eq_pushout_inr]
-        convert (whisker_eq Limits.coprod.inr pushout.condition 
+        convert (whisker_eq Limits.coprod.inr pushout.condition
           : (_ : F.obj _ ⟶  constructCoequalizer _) = _) using 1 <;> simp))
 #align category_theory.limits.has_coequalizers_of_has_pushouts_and_binary_coproducts.coequalizer_cocone CategoryTheory.Limits.HasCoequalizersOfHasPushoutsAndBinaryCoproducts.coequalizerCocone
 
@@ -242,4 +242,3 @@ def preservesCoequalizersOfPreservesPushoutsAndBinaryCoproducts [HasBinaryCoprod
 #align category_theory.limits.preserves_coequalizers_of_preserves_pushouts_and_binary_coproducts CategoryTheory.Limits.preservesCoequalizersOfPreservesPushoutsAndBinaryCoproducts
 
 end CategoryTheory.Limits
-

--- a/Mathlib/CategoryTheory/Limits/Constructions/LimitsOfProductsAndEqualizers.lean
+++ b/Mathlib/CategoryTheory/Limits/Constructions/LimitsOfProductsAndEqualizers.lean
@@ -90,7 +90,7 @@ def buildIsLimit (t₁ : IsLimit c₁) (t₂ : IsLimit c₂) (hi : IsLimit i) :
         (t₁.hom_ext fun j => by
           cases' j with j
           simpa using w j))
-  fac s j := by simp 
+  fac s j := by simp
 #align category_theory.limits.has_limit_of_has_products_of_has_equalizers.build_is_limit CategoryTheory.Limits.HasLimitOfHasProductsOfHasEqualizers.buildIsLimit
 
 end HasLimitOfHasProductsOfHasEqualizers
@@ -139,7 +139,7 @@ See <https://stacks.math.columbia.edu/tag/002N>.
 -/
 theorem has_limits_of_hasEqualizers_and_products [HasProducts.{w} C] [HasEqualizers C] :
     HasLimitsOfSize.{w, w} C :=
-  { has_limits_of_shape := 
+  { has_limits_of_shape :=
     fun _ _ => { has_limit := fun F => hasLimit_of_equalizer_and_product F } }
 #align category_theory.limits.has_limits_of_has_equalizers_and_products CategoryTheory.Limits.has_limits_of_hasEqualizers_and_products
 
@@ -148,13 +148,13 @@ theorem has_limits_of_hasEqualizers_and_products [HasProducts.{w} C] [HasEqualiz
 See <https://stacks.math.columbia.edu/tag/002O>.
 -/
 theorem hasFiniteLimits_of_hasEqualizers_and_finite_products [HasFiniteProducts C]
-    [HasEqualizers C] : HasFiniteLimits C where 
+    [HasEqualizers C] : HasFiniteLimits C where
   out _ := { has_limit := fun F => hasLimit_of_equalizer_and_product F }
 #align category_theory.limits.has_finite_limits_of_has_equalizers_and_finite_products CategoryTheory.Limits.hasFiniteLimits_of_hasEqualizers_and_finite_products
 
 variable {D : Type u₂} [Category.{v₂} D]
 
-/- Porting note: original file have noncomputable theory which made everything after 
+/- Porting note: original file have noncomputable theory which made everything after
 noncomputable. Removed this and made whatever necessary noncomputable -/
 -- noncomputable section
 
@@ -189,19 +189,19 @@ noncomputable def preservesLimitOfPreservesEqualizersAndProduct : PreservesLimit
     · intro f
       dsimp [Fan.mk]
       simp only [← G.map_comp, limit.lift_π]
-      congr 
+      congr
     · intro f
       dsimp [Fan.mk]
       simp only [← G.map_comp, limit.lift_π]
-      apply congrArg G.map 
+      apply congrArg G.map
       dsimp
     · apply Fork.ofι (G.map i)
       rw [← G.map_comp, ← G.map_comp]
       apply congrArg G.map
-      exact equalizer.condition s t 
+      exact equalizer.condition s t
     · apply isLimitOfHasProductOfPreservesLimit
     · apply isLimitOfHasProductOfPreservesLimit
-    · apply isLimitForkMapOfIsLimit   
+    · apply isLimitForkMapOfIsLimit
       apply equalizerIsEqualizer
     · refine Cones.ext (Iso.refl _) ?_
       intro j; dsimp; simp
@@ -210,30 +210,30 @@ noncomputable def preservesLimitOfPreservesEqualizersAndProduct : PreservesLimit
 
 end
 
-/- Porting note: the original parameter [∀ (J) [Fintype J], PreservesColimitsOfShape 
-(Discrete.{0} J) G] triggered the error "invalid parametric local instance, parameter 
-with type Fintype J does not have forward dependencies, type class resolution cannot 
-use this kind of local instance because it will not be able to infer a value for this 
+/- Porting note: the original parameter [∀ (J) [Fintype J], PreservesColimitsOfShape
+(Discrete.{0} J) G] triggered the error "invalid parametric local instance, parameter
+with type Fintype J does not have forward dependencies, type class resolution cannot
+use this kind of local instance because it will not be able to infer a value for this
 parameter." Factored out this as new class in `CategoryTheory.Limits.Preserves.Finite` -/
 /-- If G preserves equalizers and finite products, it preserves finite limits. -/
 noncomputable def preservesFiniteLimitsOfPreservesEqualizersAndFiniteProducts [HasEqualizers C]
     [HasFiniteProducts C] (G : C ⥤ D) [PreservesLimitsOfShape WalkingParallelPair G]
     [PreservesFiniteProducts G] : PreservesFiniteLimits G where
-  PreservesFiniteLimits := by 
-    intro J sJ fJ 
-    haveI : Fintype J := inferInstance   
-    haveI : Fintype ((p : J × J) × (p.fst ⟶  p.snd)) := inferInstance 
+  PreservesFiniteLimits := by
+    intro J sJ fJ
+    haveI : Fintype J := inferInstance
+    haveI : Fintype ((p : J × J) × (p.fst ⟶  p.snd)) := inferInstance
     apply @preservesLimitOfPreservesEqualizersAndProduct _ _ _ sJ _ _ ?_ ?_ _ G _ ?_ ?_
     · apply hasLimitsOfShape_discrete _ _
     · apply hasLimitsOfShape_discrete _
-    · apply PreservesFiniteProducts.preserves _ 
-    · apply PreservesFiniteProducts.preserves _ 
+    · apply PreservesFiniteProducts.preserves _
+    · apply PreservesFiniteProducts.preserves _
 #align category_theory.limits.preserves_finite_limits_of_preserves_equalizers_and_finite_products CategoryTheory.Limits.preservesFiniteLimitsOfPreservesEqualizersAndFiniteProducts
 
 /-- If G preserves equalizers and products, it preserves all limits. -/
-noncomputable def preservesLimitsOfPreservesEqualizersAndProducts [HasEqualizers C] 
+noncomputable def preservesLimitsOfPreservesEqualizersAndProducts [HasEqualizers C]
     [HasProducts.{w} C] (G : C ⥤ D) [PreservesLimitsOfShape WalkingParallelPair G]
-    [∀ J, PreservesLimitsOfShape (Discrete.{w} J) G] : PreservesLimitsOfSize.{w, w} G where 
+    [∀ J, PreservesLimitsOfShape (Discrete.{w} J) G] : PreservesLimitsOfSize.{w, w} G where
   preservesLimitsOfShape := preservesLimitOfPreservesEqualizersAndProduct G
 #align category_theory.limits.preserves_limits_of_preserves_equalizers_and_products CategoryTheory.Limits.preservesLimitsOfPreservesEqualizersAndProducts
 
@@ -247,17 +247,17 @@ theorem hasFiniteLimits_of_hasTerminal_and_pullbacks [HasTerminal C] [HasPullbac
 #align category_theory.limits.has_finite_limits_of_has_terminal_and_pullbacks CategoryTheory.Limits.hasFiniteLimits_of_hasTerminal_and_pullbacks
 
 /-- If G preserves terminal objects and pullbacks, it preserves all finite limits. -/
-noncomputable def preservesFiniteLimitsOfPreservesTerminalAndPullbacks [HasTerminal C] 
+noncomputable def preservesFiniteLimitsOfPreservesTerminalAndPullbacks [HasTerminal C]
     [HasPullbacks C] (G : C ⥤ D) [PreservesLimitsOfShape (Discrete.{0} PEmpty) G]
     [PreservesLimitsOfShape WalkingCospan G] : PreservesFiniteLimits G := by
   haveI : HasFiniteLimits C := hasFiniteLimits_of_hasTerminal_and_pullbacks
   haveI : PreservesLimitsOfShape (Discrete WalkingPair) G :=
     preservesBinaryProductsOfPreservesTerminalAndPullbacks G
-  haveI : PreservesLimitsOfShape WalkingParallelPair G := 
+  haveI : PreservesLimitsOfShape WalkingParallelPair G :=
       preservesEqualizersOfPreservesPullbacksAndBinaryProducts G
-  apply 
+  apply
     @preservesFiniteLimitsOfPreservesEqualizersAndFiniteProducts _ _ _ _ _ _ G _ ?_
-  apply PreservesFiniteProducts.mk 
+  apply PreservesFiniteProducts.mk
   apply preservesFiniteProductsOfPreservesBinaryAndTerminal G
 #align category_theory.limits.preserves_finite_limits_of_preserves_terminal_and_pullbacks CategoryTheory.Limits.preservesFiniteLimitsOfPreservesTerminalAndPullbacks
 
@@ -284,8 +284,8 @@ def buildColimit : Cocone F where
     { app := fun j => c₂.ι.app ⟨_⟩ ≫ i.π
       naturality := fun j₁ j₂ f => by
         dsimp
-        have reassoced (f : (p : J × J) × (p.fst ⟶  p.snd)) {W : C} {h : _ ⟶  W} : 
-          c₁.ι.app ⟨f⟩ ≫ s ≫ h = F.map f.snd ≫ c₂.ι.app ⟨f.fst.snd⟩ ≫ h := by 
+        have reassoced (f : (p : J × J) × (p.fst ⟶  p.snd)) {W : C} {h : _ ⟶  W} :
+          c₁.ι.app ⟨f⟩ ≫ s ≫ h = F.map f.snd ≫ c₂.ι.app ⟨f.fst.snd⟩ ≫ h := by
             simp only [← Category.assoc, eq_whisker (hs f)]
         rw [Category.comp_id, ← reassoced ⟨⟨_, _⟩, f⟩, i.condition, ← Category.assoc, ht] }
 #align category_theory.limits.has_colimit_of_has_coproducts_of_has_coequalizers.build_colimit CategoryTheory.Limits.HasColimitOfHasCoproductsOfHasCoequalizers.buildColimit
@@ -305,11 +305,11 @@ def buildIsColimit (t₁ : IsColimit c₁) (t₂ : IsColimit c₂) (hi : IsColim
       intro j
       cases' j with j
       have reassoced_s (f : (p : J ×  J) × (p.fst ⟶  p.snd)) {W : C} (h : _ ⟶  W) :
-        c₁.ι.app ⟨f⟩ ≫ s ≫ h = F.map f.snd ≫ c₂.ι.app ⟨f.fst.snd⟩ ≫ h := by  
+        c₁.ι.app ⟨f⟩ ≫ s ≫ h = F.map f.snd ≫ c₂.ι.app ⟨f.fst.snd⟩ ≫ h := by
           simp only [← Category.assoc]
           apply eq_whisker (hs f)
       have reassoced_t (f : (p : J ×  J) × (p.fst ⟶  p.snd)) {W : C} (h : _ ⟶  W) :
-        c₁.ι.app ⟨f⟩ ≫ t ≫ h = c₂.ι.app ⟨f.fst.fst⟩ ≫ h := by  
+        c₁.ι.app ⟨f⟩ ≫ t ≫ h = c₂.ι.app ⟨f.fst.fst⟩ ≫ h := by
           simp only [← Category.assoc]
           apply eq_whisker (ht f)
       simp [reassoced_s, reassoced_t]
@@ -319,7 +319,7 @@ def buildIsColimit (t₁ : IsColimit c₁) (t₂ : IsColimit c₂) (hi : IsColim
         (t₂.hom_ext fun j => by
           cases' j with j
           simpa using w j))
-  fac s j := by simp 
+  fac s j := by simp
 #align category_theory.limits.has_colimit_of_has_coproducts_of_has_coequalizers.build_is_colimit CategoryTheory.Limits.HasColimitOfHasCoproductsOfHasCoequalizers.buildIsColimit
 
 end HasColimitOfHasCoproductsOfHasCoequalizers
@@ -377,7 +377,7 @@ theorem has_colimits_of_hasCoequalizers_and_coproducts [HasCoproducts.{w} C] [Ha
 See <https://stacks.math.columbia.edu/tag/002Q>.
 -/
 theorem hasFiniteColimits_of_hasCoequalizers_and_finite_coproducts [HasFiniteCoproducts C]
-    [HasCoequalizers C] : HasFiniteColimits C where 
+    [HasCoequalizers C] : HasFiniteColimits C where
   out _ := { has_colimit := fun F => hasColimit_of_coequalizer_and_coproduct F }
 #align category_theory.limits.has_finite_colimits_of_has_coequalizers_and_finite_coproducts CategoryTheory.Limits.hasFiniteColimits_of_hasCoequalizers_and_finite_coproducts
 
@@ -393,7 +393,7 @@ variable (G : C ⥤ D) [PreservesColimitsOfShape WalkingParallelPair G]
   [PreservesColimitsOfShape (Discrete.{w} (Σp : J × J, p.1 ⟶ p.2)) G]
 
 /-- If a functor preserves coequalizers and the appropriate coproducts, it preserves colimits. -/
-noncomputable def preservesColimitOfPreservesCoequalizersAndCoproduct : 
+noncomputable def preservesColimitOfPreservesCoequalizersAndCoproduct :
     PreservesColimitsOfShape J G where
   preservesColimit {K} := by
     let P := ∐ K.obj
@@ -407,8 +407,8 @@ noncomputable def preservesColimitOfPreservesCoequalizersAndCoproduct :
         (buildIsColimit s t (by simp) (by simp) (colimit.isColimit _) (colimit.isColimit _)
           (colimit.isColimit _))
     refine' IsColimit.ofIsoColimit (buildIsColimit _ _ _ _ _ _ _) _
-    · refine Cofan.mk (G.obj Q) fun j => G.map ?_ 
-      apply Sigma.ι _ j  
+    · refine Cofan.mk (G.obj Q) fun j => G.map ?_
+      apply Sigma.ι _ j
     -- fun j => G.map (Sigma.ι _ j)
     · exact Cofan.mk _ fun f => G.map (Sigma.ι _ f)
     · apply G.map s
@@ -416,15 +416,15 @@ noncomputable def preservesColimitOfPreservesCoequalizersAndCoproduct :
     · intro f
       dsimp [Cofan.mk]
       simp only [← G.map_comp, colimit.ι_desc]
-      congr 
+      congr
     · intro f
       dsimp [Cofan.mk]
       simp only [← G.map_comp, colimit.ι_desc]
       dsimp
     · refine Cofork.ofπ (G.map i) ?_
       rw [← G.map_comp, ← G.map_comp]
-      apply congrArg G.map 
-      apply coequalizer.condition 
+      apply congrArg G.map
+      apply coequalizer.condition
     · apply isColimitOfHasCoproductOfPreservesColimit
     · apply isColimitOfHasCoproductOfPreservesColimit
     · apply isColimitCoforkMapOfIsColimit
@@ -438,16 +438,16 @@ noncomputable def preservesColimitOfPreservesCoequalizersAndCoproduct :
 
 end
 
-/- Porting note: the original parameter [∀ (J) [Fintype J], PreservesColimitsOfShape 
-(Discrete.{0} J) G]  triggered the error "invalid parametric local instance, parameter 
-with type Fintype J does not have forward dependencies, type class resolution cannot use 
-this kind of local instance because it will not be able to infer a value for this parameter." 
+/- Porting note: the original parameter [∀ (J) [Fintype J], PreservesColimitsOfShape
+(Discrete.{0} J) G]  triggered the error "invalid parametric local instance, parameter
+with type Fintype J does not have forward dependencies, type class resolution cannot use
+this kind of local instance because it will not be able to infer a value for this parameter."
 Factored out this as new class in `CategoryTheory.Limits.Preserves.Finite` -/
 /-- If G preserves coequalizers and finite coproducts, it preserves finite colimits. -/
-noncomputable def preservesFiniteColimitsOfPreservesCoequalizersAndFiniteCoproducts 
-    [HasCoequalizers C] [HasFiniteCoproducts C] (G : C ⥤ D) 
+noncomputable def preservesFiniteColimitsOfPreservesCoequalizersAndFiniteCoproducts
+    [HasCoequalizers C] [HasFiniteCoproducts C] (G : C ⥤ D)
     [PreservesColimitsOfShape WalkingParallelPair G]
-    [PreservesFiniteCoproducts G] : PreservesFiniteColimits G where 
+    [PreservesFiniteCoproducts G] : PreservesFiniteColimits G where
   PreservesFiniteColimits := by
     intro J sJ fJ
     haveI : Fintype J := inferInstance
@@ -456,11 +456,11 @@ noncomputable def preservesFiniteColimitsOfPreservesCoequalizersAndFiniteCoprodu
     · apply hasColimitsOfShape_discrete _ _
     · apply hasColimitsOfShape_discrete _
     · apply PreservesFiniteCoproducts.preserves _
-    · apply PreservesFiniteCoproducts.preserves _ 
+    · apply PreservesFiniteCoproducts.preserves _
 #align category_theory.limits.preserves_finite_colimits_of_preserves_coequalizers_and_finite_coproducts CategoryTheory.Limits.preservesFiniteColimitsOfPreservesCoequalizersAndFiniteCoproducts
 
 /-- If G preserves coequalizers and coproducts, it preserves all colimits. -/
-noncomputable def preservesColimitsOfPreservesCoequalizersAndCoproducts [HasCoequalizers C] 
+noncomputable def preservesColimitsOfPreservesCoequalizersAndCoproducts [HasCoequalizers C]
     [HasCoproducts.{w} C] (G : C ⥤ D) [PreservesColimitsOfShape WalkingParallelPair G]
     [∀ J, PreservesColimitsOfShape (Discrete.{w} J) G] : PreservesColimitsOfSize.{w} G where
   preservesColimitsOfShape := preservesColimitOfPreservesCoequalizersAndCoproduct G
@@ -477,19 +477,18 @@ theorem hasFiniteColimits_of_hasInitial_and_pushouts [HasInitial C] [HasPushouts
 
 /-- If G preserves initial objects and pushouts, it preserves all finite colimits. -/
 noncomputable def preservesFiniteColimitsOfPreservesInitialAndPushouts [HasInitial C]
-    [HasPushouts C] (G : C ⥤ D) [PreservesColimitsOfShape (Discrete.{0} PEmpty) G] 
+    [HasPushouts C] (G : C ⥤ D) [PreservesColimitsOfShape (Discrete.{0} PEmpty) G]
     [PreservesColimitsOfShape WalkingSpan G] : PreservesFiniteColimits G := by
   haveI : HasFiniteColimits C := hasFiniteColimits_of_hasInitial_and_pushouts
   haveI : PreservesColimitsOfShape (Discrete WalkingPair) G :=
     preservesBinaryCoproductsOfPreservesInitialAndPushouts G
-  haveI : PreservesColimitsOfShape (WalkingParallelPair) G :=  
+  haveI : PreservesColimitsOfShape (WalkingParallelPair) G :=
       (preservesCoequalizersOfPreservesPushoutsAndBinaryCoproducts G)
   refine
     @preservesFiniteColimitsOfPreservesCoequalizersAndFiniteCoproducts _ _ _ _ _ _ G _ ?_
-  apply PreservesFiniteCoproducts.mk 
+  apply PreservesFiniteCoproducts.mk
   apply preservesFiniteCoproductsOfPreservesBinaryAndInitial G
 
 #align category_theory.limits.preserves_finite_colimits_of_preserves_initial_and_pushouts CategoryTheory.Limits.preservesFiniteColimitsOfPreservesInitialAndPushouts
 
 end CategoryTheory.Limits
-

--- a/Mathlib/CategoryTheory/Limits/Constructions/Pullbacks.lean
+++ b/Mathlib/CategoryTheory/Limits/Constructions/Pullbacks.lean
@@ -38,12 +38,12 @@ theorem hasLimit_cospan_of_hasLimit_pair_of_hasLimit_parallelPair {C : Type u} [
     { cone :=
         PullbackCone.mk (e ≫ π₁) (e ≫ π₂) <| by rw [Category.assoc, equalizer.condition]; simp
       isLimit :=
-        PullbackCone.IsLimit.mk _ (fun s => equalizer.lift 
+        PullbackCone.IsLimit.mk _ (fun s => equalizer.lift
           (prod.lift (s.π.app WalkingCospan.left) (s.π.app WalkingCospan.right)) <| by
               rw [← Category.assoc, limit.lift_π, ← Category.assoc, limit.lift_π];
                 exact PullbackCone.condition _)
           (by simp) (by simp) fun s m h₁ h₂ => by
-          apply equalizer.hom_ext 
+          apply equalizer.hom_ext
           apply prod.hom_ext
           · dsimp; simpa using h₁
           · simpa using h₂ }
@@ -104,4 +104,3 @@ theorem hasPushouts_of_hasBinaryCoproducts_of_hasCoequalizers (C : Type u) [Cate
 end
 
 end CategoryTheory.Limits
-

--- a/Mathlib/CategoryTheory/Limits/FunctorCategory.lean
+++ b/Mathlib/CategoryTheory/Limits/FunctorCategory.lean
@@ -168,7 +168,7 @@ def combinedIsColimit (F : J ⥤ K ⥤ C) (c : ∀ k : K, ColimitCocone (F.flip.
 
 noncomputable section
 
-instance functorCategoryHasLimitsOfShape [HasLimitsOfShape J C] : HasLimitsOfShape J (K ⥤ C) where 
+instance functorCategoryHasLimitsOfShape [HasLimitsOfShape J C] : HasLimitsOfShape J (K ⥤ C) where
   has_limit F :=
     HasLimit.mk
       { cone := combineCones F fun _ => getLimitCone _
@@ -176,7 +176,7 @@ instance functorCategoryHasLimitsOfShape [HasLimitsOfShape J C] : HasLimitsOfSha
 #align category_theory.limits.functor_category_has_limits_of_shape CategoryTheory.Limits.functorCategoryHasLimitsOfShape
 
 instance functorCategoryHasColimitsOfShape [HasColimitsOfShape J C] : HasColimitsOfShape J (K ⥤ C)
-    where 
+    where
   has_colimit _ :=
     HasColimit.mk
       { cocone := combineCocones _ fun _ => getColimitCocone _
@@ -184,22 +184,22 @@ instance functorCategoryHasColimitsOfShape [HasColimitsOfShape J C] : HasColimit
 #align category_theory.limits.functor_category_has_colimits_of_shape CategoryTheory.Limits.functorCategoryHasColimitsOfShape
 
 -- Porting note: previously Lean could see through the binders and infer_instance sufficed
-instance functorCategoryHasLimitsOfSize [HasLimitsOfSize.{v₁, u₁} C] : 
-    HasLimitsOfSize.{v₁, u₁} (K ⥤ C) where  
-  has_limits_of_shape := fun _ _ => inferInstance 
+instance functorCategoryHasLimitsOfSize [HasLimitsOfSize.{v₁, u₁} C] :
+    HasLimitsOfSize.{v₁, u₁} (K ⥤ C) where
+  has_limits_of_shape := fun _ _ => inferInstance
 #align category_theory.limits.functor_category_has_limits_of_size CategoryTheory.Limits.functorCategoryHasLimitsOfSize
 
 -- Porting note: previously Lean could see through the binders and infer_instance sufficed
 instance functorCategoryHasColimitsOfSize [HasColimitsOfSize.{v₁, u₁} C] :
-    HasColimitsOfSize.{v₁, u₁} (K ⥤ C) where 
-  has_colimits_of_shape := fun _ _ => inferInstance 
+    HasColimitsOfSize.{v₁, u₁} (K ⥤ C) where
+  has_colimits_of_shape := fun _ _ => inferInstance
 #align category_theory.limits.functor_category_has_colimits_of_size CategoryTheory.Limits.functorCategoryHasColimitsOfSize
 
 instance evaluationPreservesLimitsOfShape [HasLimitsOfShape J C] (k : K) :
-    PreservesLimitsOfShape J ((evaluation K C).obj k) where 
-  preservesLimit {F} := by 
-    -- Porting note: added a let because X was not inferred  
-    let X : (k:K)  → LimitCone (Prefunctor.obj (Functor.flip F).toPrefunctor k) := 
+    PreservesLimitsOfShape J ((evaluation K C).obj k) where
+  preservesLimit {F} := by
+    -- Porting note: added a let because X was not inferred
+    let X : (k:K)  → LimitCone (Prefunctor.obj (Functor.flip F).toPrefunctor k) :=
       fun k => getLimitCone (Prefunctor.obj (Functor.flip F).toPrefunctor k)
     exact preservesLimitOfPreservesLimitCone (combinedIsLimit _ _) <|
       IsLimit.ofIsoLimit (limit.isLimit _) (evaluateCombinedCones F X k).symm
@@ -263,10 +263,10 @@ theorem limit_obj_ext {H : J ⥤ K ⥤ C} [HasLimitsOfShape J C] {k : K} {W : C}
 #align category_theory.limits.limit_obj_ext CategoryTheory.Limits.limit_obj_ext
 
 instance evaluationPreservesColimitsOfShape [HasColimitsOfShape J C] (k : K) :
-    PreservesColimitsOfShape J ((evaluation K C).obj k) where 
+    PreservesColimitsOfShape J ((evaluation K C).obj k) where
   preservesColimit {F} := by
-    -- Porting note: added a let because X was not inferred 
-    let X : (k:K)  → ColimitCocone (Prefunctor.obj (Functor.flip F).toPrefunctor k) := 
+    -- Porting note: added a let because X was not inferred
+    let X : (k:K)  → ColimitCocone (Prefunctor.obj (Functor.flip F).toPrefunctor k) :=
       fun k => getColimitCocone (Prefunctor.obj (Functor.flip F).toPrefunctor k)
     refine preservesColimitOfPreservesColimitCocone (combinedIsColimit _ _) <|
       IsColimit.ofIsoColimit (colimit.isColimit _) (evaluateCombinedCocones F X k).symm
@@ -366,7 +366,7 @@ instance preservesLimitsConst : PreservesLimitsOfSize.{w', w} (const D : C ⥤ _
 #align category_theory.limits.preserves_limits_const CategoryTheory.Limits.preservesLimitsConst
 
 instance evaluationPreservesColimits [HasColimits C] (k : K) :
-    PreservesColimits ((evaluation K C).obj k) where 
+    PreservesColimits ((evaluation K C).obj k) where
   preservesColimitsOfShape := by skip; infer_instance
 #align category_theory.limits.evaluation_preserves_colimits CategoryTheory.Limits.evaluationPreservesColimits
 
@@ -414,8 +414,8 @@ def limitIsoFlipCompLim [HasLimitsOfShape J C] (F : J ⥤ K ⥤ C) : limit F ≅
 
 /-- A variant of `limitIsoFlipCompLim` where the arguemnts of `F` are flipped. -/
 @[simps!]
-def limitFlipIsoCompLim [HasLimitsOfShape J C] (F : K ⥤ J ⥤ C) : limit F.flip ≅ F ⋙ lim := 
-  let f := fun k => 
+def limitFlipIsoCompLim [HasLimitsOfShape J C] (F : K ⥤ J ⥤ C) : limit F.flip ≅ F ⋙ lim :=
+  let f := fun k =>
     limitObjIsoLimitCompEvaluation F.flip k ≪≫ HasLimit.isoOfNatIso (flipCompEvaluation _ _)
   NatIso.ofComponents f <| by aesop_cat
 #align category_theory.limits.limit_flip_iso_comp_lim CategoryTheory.Limits.limitFlipIsoCompLim
@@ -439,8 +439,8 @@ def colimitIsoFlipCompColim [HasColimitsOfShape J C] (F : J ⥤ K ⥤ C) : colim
 /-- A variant of `colimit_iso_flip_comp_colim` where the arguemnts of `F` are flipped. -/
 @[simps!]
 def colimitFlipIsoCompColim [HasColimitsOfShape J C] (F : K ⥤ J ⥤ C) : colimit F.flip ≅ F ⋙ colim :=
-  let f := fun k => 
-      colimitObjIsoColimitCompEvaluation _ _ ≪≫ HasColimit.isoOfNatIso (flipCompEvaluation _ _) 
+  let f := fun k =>
+      colimitObjIsoColimitCompEvaluation _ _ ≪≫ HasColimit.isoOfNatIso (flipCompEvaluation _ _)
   NatIso.ofComponents f <| by aesop_cat
 #align category_theory.limits.colimit_flip_iso_comp_colim CategoryTheory.Limits.colimitFlipIsoCompColim
 
@@ -453,5 +453,4 @@ def colimitIsoSwapCompColim [HasColimitsOfShape J C] (G : J ⥤ K ⥤ C) :
   colimitIsoFlipCompColim G ≪≫ isoWhiskerRight (flipIsoCurrySwapUncurry _) _
 #align category_theory.limits.colimit_iso_swap_comp_colim CategoryTheory.Limits.colimitIsoSwapCompColim
 
-end 
-
+end

--- a/Mathlib/CategoryTheory/Limits/IsLimit.lean
+++ b/Mathlib/CategoryTheory/Limits/IsLimit.lean
@@ -103,7 +103,7 @@ def liftConeMorphism {t : Cone F} (h : IsLimit t) (s : Cone F) : s ⟶ t where H
 #align category_theory.limits.is_limit.lift_cone_morphism CategoryTheory.Limits.IsLimit.liftConeMorphism
 
 theorem uniq_cone_morphism {s t : Cone F} (h : IsLimit t) {f f' : s ⟶ t} : f = f' :=
-  have : ∀ {g : s ⟶ t}, g = h.liftConeMorphism s := by 
+  have : ∀ {g : s ⟶ t}, g = h.liftConeMorphism s := by
     intro g; apply ConeMorphism.ext; exact h.uniq _ _ g.w
   this.trans this.symm
 #align category_theory.limits.is_limit.uniq_cone_morphism CategoryTheory.Limits.IsLimit.uniq_cone_morphism
@@ -233,7 +233,7 @@ theorem hom_lift (h : IsLimit t) {W : C} (m : W ⟶ t.pt) :
 
 /-- Two morphisms into a limit are equal if their compositions with
   each cone morphism are equal. -/
-theorem hom_ext (h : IsLimit t) {W : C} {f f' : W ⟶ t.pt} 
+theorem hom_ext (h : IsLimit t) {W : C} {f f' : W ⟶ t.pt}
     (w : ∀ j, f ≫ t.π.app j = f' ≫ t.π.app j) :
     f = f' := by rw [h.hom_lift f, h.hom_lift f']; congr; exact funext w
 #align category_theory.limits.is_limit.hom_ext CategoryTheory.Limits.IsLimit.hom_ext
@@ -382,7 +382,7 @@ def conePointsIsoOfEquivalence {F : J ⥤ C} {s : Cone F} {G : K ⥤ C} {t : Con
       simp only [Limits.Cone.whisker_π, Limits.Cones.postcompose_obj_π, fac, whiskerLeft_app,
         assoc, id_comp, invFunIdAssoc_hom_app, fac_assoc, NatTrans.comp_app]
       rw [counit_app_functor, ←Functor.comp_map]
-      have l : 
+      have l :
         NatTrans.app w.hom j = NatTrans.app w.hom (Prefunctor.obj (𝟭 J).toPrefunctor j) := by dsimp
       rw [l,w.hom.naturality]
       simp
@@ -398,10 +398,10 @@ end Equivalence
 def homIso (h : IsLimit t) (W : C) : ULift.{u₁} (W ⟶ t.pt : Type v₃) ≅ (const J).obj W ⟶ F where
   hom f := (t.extend f.down).π
   inv π := ⟨h.lift { pt := W, π }⟩
-  hom_inv_id := by 
+  hom_inv_id := by
     funext f; apply ULift.ext
     apply h.hom_ext; intro j; simp
-  inv_hom_id := by 
+  inv_hom_id := by
     funext f; dsimp [const]; aesop_cat
 #align category_theory.limits.is_limit.hom_iso CategoryTheory.Limits.IsLimit.homIso
 
@@ -415,9 +415,9 @@ theorem homIso_hom (h : IsLimit t) {W : C} (f : ULift.{u₁} (W ⟶ t.pt)) :
   the set of cones on `F` with cone point `W`. -/
 def natIso (h : IsLimit t) : yoneda.obj t.pt ⋙ uliftFunctor.{u₁} ≅ F.cones := by
   refine NatIso.ofComponents (fun W => IsLimit.homIso h (unop W)) ?_
-  intro X Y f 
+  intro X Y f
   dsimp [yoneda,homIso,const,uliftFunctor,cones]
-  funext g 
+  funext g
   aesop_cat
 #align category_theory.limits.is_limit.nat_iso CategoryTheory.Limits.IsLimit.natIso
 
@@ -490,8 +490,8 @@ def homOfCone (s : Cone F) : s.pt ⟶ X :=
 @[simp]
 theorem coneOfHom_homOfCone (s : Cone F) : coneOfHom h (homOfCone h s) = s := by
   dsimp [coneOfHom, homOfCone]
-  match s with 
-  | .mk s_pt s_π => 
+  match s with
+  | .mk s_pt s_π =>
     congr ; dsimp
     convert congrFun (congrFun (congrArg NatTrans.app h.inv_hom_id) (op s_pt)) s_π
 #align category_theory.limits.is_limit.of_nat_iso.cone_of_hom_of_cone CategoryTheory.Limits.IsLimit.OfNatIso.coneOfHom_homOfCone
@@ -919,10 +919,10 @@ def homIso (h : IsColimit t) (W : C) : ULift.{u₁} (t.pt ⟶ W : Type v₃) ≅
     ⟨h.desc
         { pt := W
           ι }⟩
-  hom_inv_id := by 
+  hom_inv_id := by
     funext f; apply ULift.ext
     apply h.hom_ext; intro j; simp
-  inv_hom_id := by 
+  inv_hom_id := by
     funext f; dsimp [const]; aesop_cat
 #align category_theory.limits.is_colimit.hom_iso CategoryTheory.Limits.IsColimit.homIso
 
@@ -1007,7 +1007,7 @@ def homOfCocone (s : Cocone F) : X ⟶ s.pt:=
 
 @[simp]
 theorem coconeOfHom_homOfCocone (s : Cocone F) : coconeOfHom h (homOfCocone h s) = s := by
-  dsimp [coconeOfHom, homOfCocone]; 
+  dsimp [coconeOfHom, homOfCocone];
   have ⟨s_pt,s_ι⟩ := s
   congr ; dsimp
   convert congrFun (congrFun (congrArg NatTrans.app h.inv_hom_id) s_pt) s_ι

--- a/Mathlib/CategoryTheory/Limits/Preserves/Finite.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Finite.lean
@@ -94,11 +94,11 @@ def compPreservesFiniteLimits (F : C ⥤ D) (G : D ⥤ E) [PreservesFiniteLimits
   ⟨fun _ _ _ => by infer_instance⟩
 #align category_theory.limits.comp_preserves_finite_limits CategoryTheory.Limits.compPreservesFiniteLimits
 
-/- Porting note: adding this class because quantified classes don't behave well 
+/- Porting note: adding this class because quantified classes don't behave well
 [#2764](https://github.com/leanprover-community/mathlib4/pull/2764) -/
-/-- A functor `F` preserves finite products if it preserves all from `Discrete J` 
+/-- A functor `F` preserves finite products if it preserves all from `Discrete J`
 for `Fintype J` -/
-class PreservesFiniteProducts (F : C ⥤  D) where 
+class PreservesFiniteProducts (F : C ⥤  D) where
   preserves : ∀ (J : Type) [Fintype J], PreservesLimitsOfShape (Discrete J) F
 
 /-- A functor is said to preserve finite colimits, if it preserves all colimits of
@@ -152,11 +152,11 @@ def compPreservesFiniteColimits (F : C ⥤ D) (G : D ⥤ E) [PreservesFiniteColi
   ⟨fun _ _ _ => by infer_instance⟩
 #align category_theory.limits.comp_preserves_finite_colimits CategoryTheory.Limits.compPreservesFiniteColimits
 
-/- Porting note: adding this class because quantified classes don't behave well 
+/- Porting note: adding this class because quantified classes don't behave well
 [#2764](https://github.com/leanprover-community/mathlib4/pull/2764) -/
-/-- A functor `F` preserves finite products if it preserves all from `Discrete J` 
+/-- A functor `F` preserves finite products if it preserves all from `Discrete J`
 for `Fintype J` -/
-class PreservesFiniteCoproducts (F : C ⥤  D) where 
+class PreservesFiniteCoproducts (F : C ⥤  D) where
   preserves : ∀ (J : Type) [Fintype J], PreservesColimitsOfShape (Discrete J) F
 
 end CategoryTheory.Limits

--- a/Mathlib/CategoryTheory/Limits/Preserves/Limits.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Limits.lean
@@ -74,7 +74,7 @@ theorem preservesLimitsIso_inv_π (j) :
 
 @[reassoc (attr := simp)]
 theorem lift_comp_preservesLimitsIso_hom (t : Cone F) :
-    G.map (limit.lift _ t) ≫ (preservesLimitIso G F).hom = 
+    G.map (limit.lift _ t) ≫ (preservesLimitIso G F).hom =
     limit.lift (F ⋙ G) (G.mapCone _) := by
   ext
   simp [← G.map_comp]
@@ -103,7 +103,7 @@ variable [PreservesColimit F G]
 
 @[simp]
 theorem preserves_desc_mapCocone (c₁ c₂ : Cocone F) (t : IsColimit c₁) :
-    (PreservesColimit.preserves t).desc (G.mapCocone _) = G.map (t.desc c₂) := 
+    (PreservesColimit.preserves t).desc (G.mapCocone _) = G.map (t.desc c₂) :=
   ((PreservesColimit.preserves t).uniq (G.mapCocone _) _ (by simp [← G.map_comp])).symm
 #align category_theory.preserves_desc_map_cocone CategoryTheory.preserves_desc_mapCocone
 
@@ -131,7 +131,7 @@ theorem ι_preservesColimitsIso_hom (j : J) :
 
 @[reassoc (attr := simp)]
 theorem preservesColimitsIso_inv_comp_desc (t : Cocone F) :
-    (preservesColimitIso G F).inv ≫ G.map (colimit.desc _ t) = 
+    (preservesColimitIso G F).inv ≫ G.map (colimit.desc _ t) =
     colimit.desc _ (G.mapCocone t) := by
   ext
   simp [← G.map_comp]
@@ -158,4 +158,3 @@ def preservesColimitNatIso : colim ⋙ G ≅ (whiskeringRight J C D).obj G ⋙ c
 end
 
 end CategoryTheory
-

--- a/Mathlib/CategoryTheory/Limits/Preserves/Shapes/BinaryProducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Shapes/BinaryProducts.lean
@@ -116,8 +116,8 @@ the cofork consisting of the mapped morphisms is a colimit.
 This essentially lets us commute `BinaryCofan.mk` with `Functor.mapCocone`.
 -/
 def isColimitMapCoconeBinaryCofanEquiv :
-    IsColimit (Functor.mapCocone G (BinaryCofan.mk f g)) 
-    ≃ IsColimit (BinaryCofan.mk (G.map f) (G.map g)) := 
+    IsColimit (Functor.mapCocone G (BinaryCofan.mk f g))
+    ≃ IsColimit (BinaryCofan.mk (G.map f) (G.map g)) :=
   (IsColimit.precomposeHomEquiv (diagramIsoPair _).symm _).symm.trans
     (IsColimit.equivIsoColimit
       (Cocones.ext (Iso.refl _)
@@ -183,4 +183,3 @@ instance : IsIso (coprodComparison G X Y) := by
 end
 
 end CategoryTheory.Limits
-

--- a/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Biproducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Biproducts.lean
@@ -161,7 +161,7 @@ def preservesBiproductsShrink (F : C ⥤ D) [PreservesZeroMorphisms F]
 #align category_theory.limits.preserves_biproducts_shrink CategoryTheory.Limits.preservesBiproductsShrink
 
 instance (priority := 100) preservesFiniteBiproductsOfPreservesBiproducts (F : C ⥤ D)
-    [PreservesZeroMorphisms F] [PreservesBiproducts.{w₁} F] : PreservesFiniteBiproducts F where 
+    [PreservesZeroMorphisms F] [PreservesBiproducts.{w₁} F] : PreservesFiniteBiproducts F where
   preserves {J} _ := by letI := preservesBiproductsShrink.{0} F; infer_instance
 #align category_theory.limits.preserves_finite_biproducts_of_preserves_biproducts CategoryTheory.Limits.preservesFiniteBiproductsOfPreservesBiproducts
 
@@ -171,7 +171,7 @@ class PreservesBinaryBiproduct (X Y : C) (F : C ⥤ D) [PreservesZeroMorphisms F
   preserves : ∀ {b : BinaryBicone X Y}, b.IsBilimit → (F.mapBinaryBicone b).IsBilimit
 #align category_theory.limits.preserves_binary_biproduct CategoryTheory.Limits.PreservesBinaryBiproduct
 
-attribute [inherit_doc PreservesBinaryBiproduct] PreservesBinaryBiproduct.preserves 
+attribute [inherit_doc PreservesBinaryBiproduct] PreservesBinaryBiproduct.preserves
 
 /-- A functor `F` preserves binary biproducts of `X` and `Y` if `F` maps every bilimit bicone over
     `X` and `Y` to a bilimit bicone over `F.obj X` and `F.obj Y`. -/
@@ -187,7 +187,7 @@ class PreservesBinaryBiproducts (F : C ⥤ D) [PreservesZeroMorphisms F] where
   preserves : ∀ {X Y : C}, PreservesBinaryBiproduct X Y F := by infer_instance
 #align category_theory.limits.preserves_binary_biproducts CategoryTheory.Limits.PreservesBinaryBiproducts
 
-attribute [inherit_doc PreservesBinaryBiproducts] PreservesBinaryBiproducts.preserves 
+attribute [inherit_doc PreservesBinaryBiproducts] PreservesBinaryBiproducts.preserves
 
 /-- A functor that preserves biproducts of a pair preserves binary biproducts. -/
 def preservesBinaryBiproductOfPreservesBiproduct (F : C ⥤ D) [PreservesZeroMorphisms F] (X Y : C)
@@ -209,7 +209,7 @@ def preservesBinaryBiproductOfPreservesBiproduct (F : C ⥤ D) [PreservesZeroMor
 
 /-- A functor that preserves biproducts of a pair preserves binary biproducts. -/
 def preservesBinaryBiproductsOfPreservesBiproducts (F : C ⥤ D) [PreservesZeroMorphisms F]
-    [PreservesBiproductsOfShape WalkingPair F] : PreservesBinaryBiproducts F where 
+    [PreservesBiproductsOfShape WalkingPair F] : PreservesBinaryBiproducts F where
   preserves {X} Y := preservesBinaryBiproductOfPreservesBiproduct F X Y
 #align category_theory.limits.preserves_binary_biproducts_of_preserves_biproducts CategoryTheory.Limits.preservesBinaryBiproductsOfPreservesBiproducts
 
@@ -267,7 +267,7 @@ theorem biproductComparison'_comp_biproductComparison :
 
 /-- `biproduct_comparison F f` is a split epimorphism. -/
 @[simps]
-def splitEpiBiproductComparison : SplitEpi (biproductComparison F f) where 
+def splitEpiBiproductComparison : SplitEpi (biproductComparison F f) where
   section_ := biproductComparison' F f
   id := by aesop
 #align category_theory.functor.split_epi_biproduct_comparison CategoryTheory.Functor.splitEpiBiproductComparison
@@ -277,7 +277,7 @@ instance : IsSplitEpi (biproductComparison F f) :=
 
 /-- `biproduct_comparison' F f` is a split monomorphism. -/
 @[simps]
-def splitMonoBiproductComparison' : SplitMono (biproductComparison' F f) where 
+def splitMonoBiproductComparison' : SplitMono (biproductComparison' F f) where
   retraction := biproductComparison F f
   id := by aesop
 #align category_theory.functor.split_mono_biproduct_comparison' CategoryTheory.Functor.splitMonoBiproductComparison'
@@ -303,12 +303,12 @@ def mapBiproduct : F.obj (⨁ f) ≅ ⨁ F.obj ∘ f :=
 #align category_theory.functor.map_biproduct CategoryTheory.Functor.mapBiproduct
 
 theorem mapBiproduct_hom :
-    haveI : HasBiproduct fun j => F.obj (f j) := hasBiproduct_of_preserves F f 
+    haveI : HasBiproduct fun j => F.obj (f j) := hasBiproduct_of_preserves F f
     (mapBiproduct F f).hom = biproduct.lift fun j => F.map (biproduct.π f j) := rfl
 #align category_theory.functor.map_biproduct_hom CategoryTheory.Functor.mapBiproduct_hom
 
 theorem mapBiproduct_inv :
-    haveI : HasBiproduct fun j => F.obj (f j) := hasBiproduct_of_preserves F f 
+    haveI : HasBiproduct fun j => F.obj (f j) := hasBiproduct_of_preserves F f
     (mapBiproduct F f).inv = biproduct.desc fun j => F.map (biproduct.ι f j) := rfl
 #align category_theory.functor.map_biproduct_inv CategoryTheory.Functor.mapBiproduct_inv
 
@@ -366,7 +366,7 @@ theorem biprodComparison'_comp_biprodComparison :
 @[simps]
 def splitEpiBiprodComparison : SplitEpi (biprodComparison F X Y) where
   section_ := biprodComparison' F X Y
-  id := by aesop 
+  id := by aesop
 #align category_theory.functor.split_epi_biprod_comparison CategoryTheory.Functor.splitEpiBiprodComparison
 
 instance : IsSplitEpi (biprodComparison F X Y) :=
@@ -421,10 +421,10 @@ theorem biproduct.map_lift_mapBiprod (g : ∀ j, W ⟶ f j) :
     -- Porting note: twice we need haveI to tell Lean about hasBiproduct_of_preserves F f
     haveI : HasBiproduct fun j => F.obj (f j) := hasBiproduct_of_preserves F f
     F.map (biproduct.lift g) ≫ (F.mapBiproduct f).hom = biproduct.lift fun j => F.map (g j) := by
-  apply biproduct.hom_ext; intro j' 
+  apply biproduct.hom_ext; intro j'
   dsimp [Function.comp]
   haveI : HasBiproduct fun j => F.obj (f j) := hasBiproduct_of_preserves F f
-  simp only [mapBiproduct_hom, Category.assoc, biproduct.lift_π, ← F.map_comp] 
+  simp only [mapBiproduct_hom, Category.assoc, biproduct.lift_π, ← F.map_comp]
 #align category_theory.limits.biproduct.map_lift_map_biprod CategoryTheory.Limits.biproduct.map_lift_mapBiprod
 
 theorem biproduct.mapBiproduct_inv_map_desc (g : ∀ j, f j ⟶ W) :
@@ -475,4 +475,3 @@ end Limits
 end HasZeroMorphisms
 
 end CategoryTheory
-

--- a/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Equalizers.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Equalizers.lean
@@ -70,8 +70,8 @@ If `G` preserves equalizers and `C` has them, then the fork constructed of the m
 a fork is a limit.
 -/
 def isLimitOfHasEqualizerOfPreservesLimit [PreservesLimit (parallelPair f g) G] :
-    IsLimit (Fork.ofι 
-      (G.map (equalizer.ι f g)) (by simp only [← G.map_comp]; rw [equalizer.condition]) : 
+    IsLimit (Fork.ofι
+      (G.map (equalizer.ι f g)) (by simp only [← G.map_comp]; rw [equalizer.condition]) :
       Fork (G.map f) (G.map g)) :=
   isLimitForkMapOfIsLimit G _ (equalizerIsEqualizer f g)
 #align category_theory.limits.is_limit_of_has_equalizer_of_preserves_limit CategoryTheory.Limits.isLimitOfHasEqualizerOfPreservesLimit
@@ -154,7 +154,7 @@ If `G` preserves coequalizers and `C` has them, then the cofork constructed of t
 of a cofork is a colimit.
 -/
 def isColimitOfHasCoequalizerOfPreservesColimit [PreservesColimit (parallelPair f g) G] :
-    IsColimit (Cofork.ofπ (G.map (coequalizer.π f g)) (by 
+    IsColimit (Cofork.ofπ (G.map (coequalizer.π f g)) (by
       simp only [← G.map_comp]; rw [coequalizer.condition]) : Cofork (G.map f) (G.map g)) :=
   isColimitCoforkMapOfIsColimit G _ (coequalizerIsCoequalizer f g)
 #align category_theory.limits.is_colimit_of_has_coequalizer_of_preserves_colimit CategoryTheory.Limits.isColimitOfHasCoequalizerOfPreservesColimit
@@ -168,7 +168,7 @@ def ofIsoComparison [i : IsIso (coequalizerComparison f g G)] :
     PreservesColimit (parallelPair f g) G := by
   apply preservesColimitOfPreservesColimitCocone (coequalizerIsCoequalizer f g)
   apply (isColimitMapCoconeCoforkEquiv _ _).symm _
-  refine 
+  refine
     @IsColimit.ofPointIso _ _ _ _ _ _ _ (colimit.isColimit (parallelPair (G.map f) (G.map g))) ?_
   apply i
 #align category_theory.limits.of_iso_comparison CategoryTheory.Limits.ofIsoComparison
@@ -197,9 +197,9 @@ instance : IsIso (coequalizerComparison f g G) := by
 instance map_π_epi : Epi (G.map (coequalizer.π f g)) :=
   ⟨fun {W} h k => by
     rw [← ι_comp_coequalizerComparison]
-    haveI : Epi (coequalizer.π (G.map f) (G.map g) ≫ coequalizerComparison f g G) := by 
+    haveI : Epi (coequalizer.π (G.map f) (G.map g) ≫ coequalizerComparison f g G) := by
       apply epi_comp
-    apply (cancel_epi _).1⟩ 
+    apply (cancel_epi _).1⟩
 #align category_theory.limits.map_π_epi CategoryTheory.Limits.map_π_epi
 
 @[reassoc]
@@ -254,4 +254,3 @@ instance (priority := 1) preservesSplitCoequalizers (f g : X ⟶ Y) [HasSplitCoe
 end Coequalizers
 
 end CategoryTheory.Limits
-

--- a/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Products.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Products.lean
@@ -84,7 +84,7 @@ def PreservesProduct.ofIsoComparison [i : IsIso (piComparison G f)] :
     PreservesLimit (Discrete.functor f) G := by
   apply preservesLimitOfPreservesLimitCone (productIsProduct f)
   apply (isLimitMapConeFanMkEquiv _ _ _).symm _
-  refine @IsLimit.ofPointIso _ _ _ _ _ _ _ 
+  refine @IsLimit.ofPointIso _ _ _ _ _ _ _
     (limit.isLimit (Discrete.functor fun j : J => G.obj (f j))) ?_
   apply i
 #align category_theory.limits.preserves_product.of_iso_comparison CategoryTheory.Limits.PreservesProduct.ofIsoComparison
@@ -155,7 +155,7 @@ def PreservesCoproduct.ofIsoComparison [i : IsIso (sigmaComparison G f)] :
     PreservesColimit (Discrete.functor f) G := by
   apply preservesColimitOfPreservesColimitCocone (coproductIsCoproduct f)
   apply (isColimitMapCoconeCofanMkEquiv _ _ _).symm _
-  refine @IsColimit.ofPointIso _ _ _ _ _ _ _ 
+  refine @IsColimit.ofPointIso _ _ _ _ _ _ _
     (colimit.isColimit (Discrete.functor fun j : J => G.obj (f j))) ?_
   apply i
 #align category_theory.limits.preserves_coproduct.of_iso_comparison CategoryTheory.Limits.PreservesCoproduct.ofIsoComparison
@@ -181,4 +181,3 @@ instance : IsIso (sigmaComparison G f) := by
 end
 
 end CategoryTheory.Limits
-

--- a/Mathlib/CategoryTheory/Limits/Shapes/BinaryProducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/BinaryProducts.lean
@@ -57,7 +57,7 @@ def WalkingPair.swap : WalkingPair ≃ WalkingPair
     where
   toFun j := WalkingPair.recOn j right left
   invFun j := WalkingPair.recOn j right left
-  left_inv j := by cases j; repeat rfl 
+  left_inv j := by cases j; repeat rfl
   right_inv j := by cases j; repeat rfl
 #align category_theory.limits.walking_pair.swap CategoryTheory.Limits.WalkingPair.swap
 
@@ -154,7 +154,7 @@ variable {F G : Discrete WalkingPair ⥤ C} (f : F.obj ⟨left⟩ ⟶ G.obj ⟨l
 
 /-- The natural transformation between two functors out of the
  walking pair, specified by its components. -/
-def mapPair : F ⟶ G where 
+def mapPair : F ⟶ G where
   app j := Discrete.recOn j fun j => WalkingPair.casesOn j f g
   naturality := fun ⟨X⟩ ⟨Y⟩ ⟨⟨u⟩⟩ => by dsimp at u; cases u; simp
 #align category_theory.limits.map_pair CategoryTheory.Limits.mapPair
@@ -173,7 +173,7 @@ theorem mapPair_right : (mapPair f g).app ⟨right⟩ = g :=
 components. -/
 @[simps!]
 def mapPairIso (f : F.obj ⟨left⟩ ≅ G.obj ⟨left⟩) (g : F.obj ⟨right⟩ ≅ G.obj ⟨right⟩) : F ≅ G :=
-  NatIso.ofComponents (fun j => Discrete.recOn j fun j => WalkingPair.casesOn j f g) 
+  NatIso.ofComponents (fun j => Discrete.recOn j fun j => WalkingPair.casesOn j f g)
     (fun {X} {Y} ⟨⟨u⟩⟩ => by dsimp; cases X; cases Y; cases u; simp)
 #align category_theory.limits.map_pair_iso CategoryTheory.Limits.mapPairIso
 
@@ -299,8 +299,8 @@ section
 def BinaryFan.mk {P : C} (π₁ : P ⟶ X) (π₂ : P ⟶ Y) : BinaryFan X Y where
   pt := P
   π :=
-    -- Porting removed use of casesOn to preserve computability 
-    { app := fun ⟨j⟩ => by cases j <;> simpa 
+    -- Porting removed use of casesOn to preserve computability
+    { app := fun ⟨j⟩ => by cases j <;> simpa
       naturality := fun ⟨X⟩ ⟨Y⟩ ⟨⟨u⟩⟩ => by cases u; simp }
 #align category_theory.limits.binary_fan.mk CategoryTheory.Limits.BinaryFan.mk
 
@@ -308,9 +308,9 @@ def BinaryFan.mk {P : C} (π₁ : P ⟶ X) (π₂ : P ⟶ Y) : BinaryFan X Y whe
 @[simps pt]
 def BinaryCofan.mk {P : C} (ι₁ : X ⟶ P) (ι₂ : Y ⟶ P) : BinaryCofan X Y where
   pt := P
-  ι := 
-    -- Porting removed use of casesOn to preserve computability 
-    { app := fun ⟨j⟩ => by cases j <;> simpa 
+  ι :=
+    -- Porting removed use of casesOn to preserve computability
+    { app := fun ⟨j⟩ => by cases j <;> simpa
       naturality := fun ⟨X⟩ ⟨Y⟩ ⟨⟨u⟩⟩ => by cases u; simp }
 #align category_theory.limits.binary_cofan.mk CategoryTheory.Limits.BinaryCofan.mk
 
@@ -356,7 +356,7 @@ def BinaryFan.isLimitMk {W : C} {fst : W ⟶ X} {snd : W ⟶ Y} (lift : ∀ s : 
       ∀ (s : BinaryFan X Y) (m : s.pt ⟶ W) (_ : m ≫ fst = s.fst) (_ : m ≫ snd = s.snd),
         m = lift s) :
     IsLimit (BinaryFan.mk fst snd) :=
-  { lift := lift 
+  { lift := lift
     fac := fun s j => by
       rcases j with ⟨⟨⟩⟩
       exacts[fac_left s, fac_right s]
@@ -367,7 +367,7 @@ def BinaryFan.isLimitMk {W : C} {fst : W ⟶ X} {snd : W ⟶ Y} (lift : ∀ s : 
 `BinaryCofan.mk` is a colimit cocone.
 -/
 def BinaryCofan.isColimitMk {W : C} {inl : X ⟶ W} {inr : Y ⟶ W}
-    (desc : ∀ s : BinaryCofan X Y, W ⟶ s.pt) 
+    (desc : ∀ s : BinaryCofan X Y, W ⟶ s.pt)
     (fac_left : ∀ s : BinaryCofan X Y, inl ≫ desc s = s.inl)
     (fac_right : ∀ s : BinaryCofan X Y, inr ≫ desc s = s.inr)
     (uniq :
@@ -420,7 +420,7 @@ theorem BinaryFan.isLimit_iff_isIso_fst {X Y : C} (h : IsTerminal Y) (c : Binary
             (h.hom_ext _ _),
           hl⟩⟩
   · intro
-    exact 
+    exact
       ⟨BinaryFan.IsLimit.mk _ (fun f _ => f ≫ inv c.fst) (fun _ _ => by simp)
           (fun _ _ => h.hom_ext _ _) fun _ _ _ e _ => by simp [← e]⟩
 #align category_theory.limits.binary_fan.is_limit_iff_is_iso_fst CategoryTheory.Limits.BinaryFan.isLimit_iff_isIso_fst
@@ -438,15 +438,15 @@ noncomputable def BinaryFan.isLimitCompLeftIso {X Y X' : C} (c : BinaryFan X Y) 
     [IsIso f] (h : IsLimit c) : IsLimit (BinaryFan.mk (c.fst ≫ f) c.snd) := by
   fapply BinaryFan.isLimitMk
   · exact fun s => h.lift (BinaryFan.mk (s.fst ≫ inv f) s.snd)
-  · intro s -- Porting note: simp timed out here 
+  · intro s -- Porting note: simp timed out here
     simp only [Category.comp_id,BinaryFan.π_app_left,IsIso.inv_hom_id,
       BinaryFan.mk_fst,IsLimit.fac_assoc,eq_self_iff_true,Category.assoc]
-  · intro s -- Porting note: simp timed out here 
+  · intro s -- Porting note: simp timed out here
     simp only [BinaryFan.π_app_right,BinaryFan.mk_snd,eq_self_iff_true,IsLimit.fac]
   · intro s m e₁ e₂
-     -- Porting note: simpa timed out here also 
-    apply BinaryFan.IsLimit.hom_ext h 
-    · simpa only 
+     -- Porting note: simpa timed out here also
+    apply BinaryFan.IsLimit.hom_ext h
+    · simpa only
       [BinaryFan.π_app_left,BinaryFan.mk_fst,Category.assoc,IsLimit.fac,IsIso.eq_comp_inv]
     · simpa only [BinaryFan.π_app_right,BinaryFan.mk_snd,IsLimit.fac]
 #align category_theory.limits.binary_fan.is_limit_comp_left_iso CategoryTheory.Limits.BinaryFan.isLimitCompLeftIso
@@ -474,7 +474,7 @@ theorem BinaryCofan.isColimit_iff_isIso_inl {X Y : C} (h : IsInitial Y) (c : Bin
     obtain ⟨l, hl, -⟩ := BinaryCofan.IsColimit.desc' H (𝟙 X) (h.to X)
     refine ⟨⟨l, hl, BinaryCofan.IsColimit.hom_ext H (?_) (h.hom_ext _ _)⟩⟩
     rw [Category.comp_id]
-    have e : (inl c ≫ l) ≫ inl c = 𝟙 X ≫ inl c := congrArg (·≫inl c) hl 
+    have e : (inl c ≫ l) ≫ inl c = 𝟙 X ≫ inl c := congrArg (·≫inl c) hl
     rwa [Category.assoc,Category.id_comp] at e
   · intro
     exact
@@ -570,10 +570,10 @@ abbrev coprod.inr {X Y : C} [HasBinaryCoproduct X Y] : Y ⟶ X ⨿ Y :=
 /-- The binary fan constructed from the projection maps is a limit. -/
 def prodIsProd (X Y : C) [HasBinaryProduct X Y] :
     IsLimit (BinaryFan.mk (prod.fst : X ⨯ Y ⟶ X) prod.snd) :=
-  (limit.isLimit _).ofIsoLimit (Cones.ext (Iso.refl _) (fun ⟨u⟩ => by 
+  (limit.isLimit _).ofIsoLimit (Cones.ext (Iso.refl _) (fun ⟨u⟩ => by
     cases u
-    · dsimp; simp only [Category.id_comp]; rfl 
-    · dsimp; simp only [Category.id_comp]; rfl 
+    · dsimp; simp only [Category.id_comp]; rfl
+    · dsimp; simp only [Category.id_comp]; rfl
   ))
 #align category_theory.limits.prod_is_prod CategoryTheory.Limits.prodIsProd
 
@@ -583,7 +583,7 @@ def coprodIsCoprod (X Y : C) [HasBinaryCoproduct X Y] :
   (colimit.isColimit _).ofIsoColimit (Cocones.ext (Iso.refl _) (fun ⟨u⟩ => by
     cases u
     · dsimp; simp only [Category.comp_id]
-    · dsimp; simp only [Category.comp_id] 
+    · dsimp; simp only [Category.comp_id]
   ))
 #align category_theory.limits.coprod_is_coprod CategoryTheory.Limits.coprodIsCoprod
 
@@ -799,7 +799,7 @@ instance prod.map_mono {C : Type _} [Category C] {W X Y Z : C} (f : W ⟶ Y) (g 
       simpa using congr_arg (fun f => f ≫ prod.snd) h⟩
 #align category_theory.limits.prod.map_mono CategoryTheory.Limits.prod.map_mono
 
-@[reassoc] -- Porting note: simp can prove these 
+@[reassoc] -- Porting note: simp can prove these
 theorem prod.diag_map {X Y : C} (f : X ⟶ Y) [HasBinaryProduct X X] [HasBinaryProduct Y Y] :
     diag X ≫ prod.map f f = f ≫ diag Y := by simp
 #align category_theory.limits.prod.diag_map CategoryTheory.Limits.prod.diag_map
@@ -823,9 +823,9 @@ end ProdLemmas
 section CoprodLemmas
 
 -- @[reassoc (attr := simp)]
-@[simp] -- Porting note: removing reassoc tag since result is not hygenic (two h's) 
+@[simp] -- Porting note: removing reassoc tag since result is not hygenic (two h's)
 theorem coprod.desc_comp {V W X Y : C} [HasBinaryCoproduct X Y] (f : V ⟶ W) (g : X ⟶ V)
-    (h : Y ⟶ V) : coprod.desc g h ≫ f = coprod.desc (g ≫ f) (h ≫ f) := by 
+    (h : Y ⟶ V) : coprod.desc g h ≫ f = coprod.desc (g ≫ f) (h ≫ f) := by
   apply coprod.hom_ext; simp; simp
 #align category_theory.limits.coprod.desc_comp CategoryTheory.Limits.coprod.desc_comp
 
@@ -864,7 +864,7 @@ theorem coprod.desc_inl_inr {X Y : C} [HasBinaryCoproduct X Y] :
 @[reassoc, simp]
 theorem coprod.map_desc {S T U V W : C} [HasBinaryCoproduct U W] [HasBinaryCoproduct T V]
     (f : U ⟶ S) (g : W ⟶ S) (h : T ⟶ U) (k : V ⟶ W) :
-    coprod.map h k ≫ coprod.desc f g = coprod.desc (h ≫ f) (k ≫ g) := by 
+    coprod.map h k ≫ coprod.desc f g = coprod.desc (h ≫ f) (k ≫ g) := by
   apply coprod.hom_ext; simp; simp
 #align category_theory.limits.coprod.map_desc CategoryTheory.Limits.coprod.map_desc
 
@@ -881,7 +881,7 @@ theorem coprod.desc_comp_inl_comp_inr {W X Y Z : C} [HasBinaryCoproduct W Y]
 @[reassoc (attr := simp)]
 theorem coprod.map_map {A₁ A₂ A₃ B₁ B₂ B₃ : C} [HasBinaryCoproduct A₁ B₁] [HasBinaryCoproduct A₂ B₂]
     [HasBinaryCoproduct A₃ B₃] (f : A₁ ⟶ A₂) (g : B₁ ⟶ B₂) (h : A₂ ⟶ A₃) (k : B₂ ⟶ B₃) :
-    coprod.map f g ≫ coprod.map h k = coprod.map (f ≫ h) (g ≫ k) := by 
+    coprod.map f g ≫ coprod.map h k = coprod.map (f ≫ h) (g ≫ k) := by
   apply coprod.hom_ext; simp; simp
 #align category_theory.limits.coprod.map_map CategoryTheory.Limits.coprod.map_map
 
@@ -1019,10 +1019,10 @@ theorem prod.symmetry (P Q : C) [HasBinaryProduct P Q] [HasBinaryProduct Q P] :
 def prod.associator [HasBinaryProducts C] (P Q R : C) : (P ⨯ Q) ⨯ R ≅ P ⨯ Q ⨯ R where
   hom := prod.lift (prod.fst ≫ prod.fst) (prod.lift (prod.fst ≫ prod.snd) prod.snd)
   inv := prod.lift (prod.lift prod.fst (prod.snd ≫ prod.fst)) (prod.snd ≫ prod.snd)
-  hom_inv_id := by 
-    apply prod.hom_ext 
-    · apply prod.hom_ext; simp; simp 
-    · simp 
+  hom_inv_id := by
+    apply prod.hom_ext
+    · apply prod.hom_ext; simp; simp
+    · simp
   inv_hom_id := by
     apply prod.hom_ext
     · simp
@@ -1052,10 +1052,10 @@ variable [HasTerminal C]
 def prod.leftUnitor (P : C) [HasBinaryProduct (⊤_ C) P] : (⊤_ C) ⨯ P ≅ P where
   hom := prod.snd
   inv := prod.lift (terminal.from P) (𝟙 _)
-  hom_inv_id := by 
-    apply prod.hom_ext 
-    · simp 
-    · simp 
+  hom_inv_id := by
+    apply prod.hom_ext
+    · simp
+    · simp
   inv_hom_id := by simp
 #align category_theory.limits.prod.left_unitor CategoryTheory.Limits.prod.leftUnitor
 
@@ -1064,10 +1064,10 @@ def prod.leftUnitor (P : C) [HasBinaryProduct (⊤_ C) P] : (⊤_ C) ⨯ P ≅ P
 def prod.rightUnitor (P : C) [HasBinaryProduct P (⊤_ C)] : P ⨯ ⊤_ C ≅ P where
   hom := prod.fst
   inv := prod.lift (𝟙 _) (terminal.from P)
-  hom_inv_id := by 
-    apply prod.hom_ext 
-    · simp 
-    · simp 
+  hom_inv_id := by
+    apply prod.hom_ext
+    · simp
+    · simp
   inv_hom_id := by simp
 #align category_theory.limits.prod.right_unitor CategoryTheory.Limits.prod.rightUnitor
 
@@ -1098,7 +1098,7 @@ theorem prod_rightUnitor_inv_naturality [HasBinaryProducts C] (f : X ⟶ Y) :
 theorem prod.triangle [HasBinaryProducts C] (X Y : C) :
     (prod.associator X (⊤_ C) Y).hom ≫ prod.map (𝟙 X) (prod.leftUnitor Y).hom =
       prod.map (prod.rightUnitor X).hom (𝟙 Y) :=
-  by dsimp; apply prod.hom_ext; simp; simp; 
+  by dsimp; apply prod.hom_ext; simp; simp;
 #align category_theory.limits.prod.triangle CategoryTheory.Limits.prod.triangle
 
 end
@@ -1131,10 +1131,10 @@ theorem coprod.symmetry (P Q : C) : (coprod.braiding P Q).hom ≫ (coprod.braidi
 def coprod.associator (P Q R : C) : (P ⨿ Q) ⨿ R ≅ P ⨿ Q ⨿ R where
   hom := coprod.desc (coprod.desc coprod.inl (coprod.inl ≫ coprod.inr)) (coprod.inr ≫ coprod.inr)
   inv := coprod.desc (coprod.inl ≫ coprod.inl) (coprod.desc (coprod.inr ≫ coprod.inl) coprod.inr)
-  hom_inv_id := by 
-    apply coprod.hom_ext 
-    · apply coprod.hom_ext; simp; simp 
-    · simp 
+  hom_inv_id := by
+    apply coprod.hom_ext
+    · apply coprod.hom_ext; simp; simp
+    · simp
   inv_hom_id := by
     apply coprod.hom_ext
     · simp
@@ -1162,9 +1162,9 @@ variable [HasInitial C]
 def coprod.leftUnitor (P : C) : (⊥_ C) ⨿ P ≅ P where
   hom := coprod.desc (initial.to P) (𝟙 _)
   inv := coprod.inr
-  hom_inv_id := by 
-    apply coprod.hom_ext 
-    · simp 
+  hom_inv_id := by
+    apply coprod.hom_ext
+    · simp
     · simp
   inv_hom_id := by simp
 #align category_theory.limits.coprod.left_unitor CategoryTheory.Limits.coprod.leftUnitor
@@ -1174,9 +1174,9 @@ def coprod.leftUnitor (P : C) : (⊥_ C) ⨿ P ≅ P where
 def coprod.rightUnitor (P : C) : P ⨿ ⊥_ C ≅ P where
   hom := coprod.desc (𝟙 _) (initial.to P)
   inv := coprod.inl
-  hom_inv_id := by 
-    apply coprod.hom_ext 
-    · simp 
+  hom_inv_id := by
+    apply coprod.hom_ext
+    · simp
     · simp
   inv_hom_id := by simp
 #align category_theory.limits.coprod.right_unitor CategoryTheory.Limits.coprod.rightUnitor
@@ -1200,7 +1200,7 @@ def prod.functor : C ⥤ C ⥤ C where
   obj X :=
     { obj := fun Y => X ⨯ Y
       map := fun {Y Z} => prod.map (𝟙 X) }
-  map f := 
+  map f :=
     { app := fun T => prod.map f (𝟙 T) }
 #align category_theory.limits.prod.functor CategoryTheory.Limits.prod.functor
 
@@ -1310,7 +1310,7 @@ isomorphism (as `B` changes).
 -- @[simps (config := { rhsMd := semireducible })] -- Porting note: no config for semireducible
 @[simps]
 def prodComparisonNatIso [HasBinaryProducts C] [HasBinaryProducts D] (A : C)
-    [∀ B, IsIso (prodComparison F A B)] : 
+    [∀ B, IsIso (prodComparison F A B)] :
     prod.functor.obj A ⋙ F ≅ F ⋙ prod.functor.obj (F.obj A) := by
   refine { @asIso _ _ _ _ _ (?_) with hom := prodComparisonNatTrans F A }
   apply NatIso.isIso_of_isIso_app
@@ -1395,7 +1395,7 @@ isomorphism (as `B` changes).
 @[simps]
 def coprodComparisonNatIso [HasBinaryCoproducts C] [HasBinaryCoproducts D] (A : C)
     [∀ B, IsIso (coprodComparison F A B)] :
-    F ⋙ coprod.functor.obj (F.obj A) ≅ coprod.functor.obj A ⋙ F := by 
+    F ⋙ coprod.functor.obj (F.obj A) ≅ coprod.functor.obj A ⋙ F := by
   refine { @asIso _ _ _ _ _ (?_) with hom := coprodComparisonNatTrans F A }
   apply NatIso.isIso_of_isIso_app -- Porting note: this did not work inside { }
 #align category_theory.limits.coprod_comparison_nat_iso CategoryTheory.Limits.coprodComparisonNatIso
@@ -1428,7 +1428,7 @@ def Over.coprod [HasBinaryCoproducts C] {A : C} : Over A ⥤ Over A ⥤ Over A w
         ext;
           · dsimp; simp }
   map_id X := by
-    ext  
+    ext
     · dsimp; simp
   map_comp f g := by
     ext
@@ -1436,4 +1436,3 @@ def Over.coprod [HasBinaryCoproducts C] {A : C} : Over A ⥤ Over A ⥤ Over A w
 #align category_theory.over.coprod CategoryTheory.Over.coprod
 
 end CategoryTheory
- 

--- a/Mathlib/CategoryTheory/Limits/Shapes/Biproducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Biproducts.lean
@@ -75,13 +75,13 @@ structure Bicone (F : J → C) where
   pt : C
   π : ∀ j, pt ⟶ F j
   ι : ∀ j, F j ⟶  pt
-  ι_π : ∀ j j', ι j ≫ π j' = 
+  ι_π : ∀ j j', ι j ≫ π j' =
     if h : j = j' then eqToHom (congrArg F h) else 0 := by aesop
 #align category_theory.limits.bicone CategoryTheory.Limits.Bicone
 set_option linter.uppercaseLean3 false in
 #align category_theory.limits.bicone_X CategoryTheory.Limits.Bicone.pt
 
-attribute [inherit_doc Bicone] Bicone.pt Bicone.π Bicone.ι Bicone.ι_π 
+attribute [inherit_doc Bicone] Bicone.pt Bicone.π Bicone.ι Bicone.ι_π
 
 @[reassoc (attr := simp)]
 theorem bicone_ι_π_self {F : J → C} (B : Bicone F) (j : J) : B.ι j ≫ B.π j = 𝟙 (F j) := by
@@ -102,7 +102,7 @@ namespace Bicone
 /-- Extract the cone from a bicone. -/
 def toCone (B : Bicone F) : Cone (Discrete.functor F) where
   pt := B.pt
-  π := { app := fun j => B.π j.as 
+  π := { app := fun j => B.π j.as
          naturality := by intro ⟨j⟩ ⟨j'⟩ ⟨⟨f⟩⟩; cases f; simp}
 #align category_theory.limits.bicone.to_cone CategoryTheory.Limits.Bicone.toCone
 
@@ -121,7 +121,7 @@ theorem toCone_π_app_mk (B : Bicone F) (j : J) : B.toCone.π.app ⟨j⟩ = B.π
 /-- Extract the cocone from a bicone. -/
 def toCocone (B : Bicone F) : Cocone (Discrete.functor F) where
   pt := B.pt
-  ι := { app := fun j => B.ι j.as 
+  ι := { app := fun j => B.ι j.as
          naturality := by intro ⟨j⟩ ⟨j'⟩ ⟨⟨f⟩⟩; cases f; simp}
 #align category_theory.limits.bicone.to_cocone CategoryTheory.Limits.Bicone.toCocone
 
@@ -349,12 +349,12 @@ instance (priority := 100) hasBiproductsOfShape_finite [HasFiniteBiproducts C] [
 #align category_theory.limits.has_biproducts_of_shape_finite CategoryTheory.Limits.hasBiproductsOfShape_finite
 
 instance (priority := 100) hasFiniteProducts_of_hasFiniteBiproducts [HasFiniteBiproducts C] :
-    HasFiniteProducts C where 
+    HasFiniteProducts C where
   out _ := ⟨fun _ => hasLimitOfIso Discrete.natIsoFunctor.symm⟩
 #align category_theory.limits.has_finite_products_of_has_finite_biproducts CategoryTheory.Limits.hasFiniteProducts_of_hasFiniteBiproducts
 
 instance (priority := 100) hasFiniteCoproducts_of_hasFiniteBiproducts [HasFiniteBiproducts C] :
-    HasFiniteCoproducts C where 
+    HasFiniteCoproducts C where
   out _ := ⟨fun _ => hasColimitOfIso Discrete.natIsoFunctor⟩
 #align category_theory.limits.has_finite_coproducts_of_has_finite_biproducts CategoryTheory.Limits.hasFiniteCoproducts_of_hasFiniteBiproducts
 
@@ -448,8 +448,8 @@ theorem biproduct.ι_desc {f : J → C} [HasBiproduct f] {P : C} (p : ∀ b, f b
 indexed by the same type, we obtain a map between the biproducts. -/
 abbrev biproduct.map {f g : J → C} [HasBiproduct f] [HasBiproduct g] (p : ∀ b, f b ⟶ g b) :
     ⨁ f ⟶ ⨁ g :=
-  IsLimit.map (biproduct.bicone f).toCone (biproduct.isLimit g) 
-    (Discrete.natTrans (fun j => p j.as))   
+  IsLimit.map (biproduct.bicone f).toCone (biproduct.isLimit g)
+    (Discrete.natTrans (fun j => p j.as))
 #align category_theory.limits.biproduct.map CategoryTheory.Limits.biproduct.map
 
 /-- An alternative to `biproduct.map` constructed via colimits.
@@ -517,7 +517,7 @@ theorem biproduct.map_eq_map' {f g : J → C} [HasBiproduct f] [HasBiproduct g] 
   dsimp
   rw [biproduct.ι_π_assoc, biproduct.ι_π]
   split_ifs with h
-  · subst h; rw [eqToHom_refl, Category.id_comp]; erw [Category.comp_id] 
+  · subst h; rw [eqToHom_refl, Category.id_comp]; erw [Category.comp_id]
   · simp
 #align category_theory.limits.biproduct.map_eq_map' CategoryTheory.Limits.biproduct.map_eq_map'
 
@@ -531,7 +531,7 @@ theorem biproduct.map_π {f g : J → C} [HasBiproduct f] [HasBiproduct g] (p : 
 theorem biproduct.ι_map {f g : J → C} [HasBiproduct f] [HasBiproduct g] (p : ∀ j, f j ⟶ g j)
     (j : J) : biproduct.ι f j ≫ biproduct.map p = p j ≫ biproduct.ι g j := by
   rw [biproduct.map_eq_map']
-  apply 
+  apply
     Limits.IsColimit.ι_map (biproduct.isColimit f) (biproduct.bicone g).toCocone
     (Discrete.natTrans fun j => p j.as) (Discrete.mk j)
 #align category_theory.limits.biproduct.ι_map CategoryTheory.Limits.biproduct.ι_map
@@ -632,7 +632,7 @@ theorem biproduct.toSubtype_eq_desc [DecidablePred p] :
   biproduct.hom_ext' _ _ (by simp)
 #align category_theory.limits.biproduct.to_subtype_eq_desc CategoryTheory.Limits.biproduct.toSubtype_eq_desc
 
-@[reassoc] -- Porting note: simp can prove both versions 
+@[reassoc] -- Porting note: simp can prove both versions
 theorem biproduct.ι_toSubtype_subtype (j : Subtype p) :
     biproduct.ι f j ≫ biproduct.toSubtype f p = biproduct.ι (Subtype.restrict p f) j := by
   apply biproduct.hom_ext; intro i
@@ -925,8 +925,8 @@ variable (C)
 instance (priority := 100) hasZeroObject_of_hasFiniteBiproducts [HasFiniteBiproducts C] :
     HasZeroObject C := by
   refine' ⟨⟨biproduct Empty.elim, fun X => ⟨⟨⟨0⟩, _⟩⟩, fun X => ⟨⟨⟨0⟩, _⟩⟩⟩⟩
-  · intro a; apply biproduct.hom_ext'; simp 
-  · intro a; apply biproduct.hom_ext; simp 
+  · intro a; apply biproduct.hom_ext'; simp
+  · intro a; apply biproduct.hom_ext; simp
 #align category_theory.limits.has_zero_object_of_has_finite_biproducts CategoryTheory.Limits.hasZeroObject_of_hasFiniteBiproducts
 
 section
@@ -980,8 +980,8 @@ structure BinaryBicone (P Q : C) where
 #align category_theory.limits.binary_bicone.inr_fst' CategoryTheory.Limits.BinaryBicone.inr_fst
 #align category_theory.limits.binary_bicone.inr_snd' CategoryTheory.Limits.BinaryBicone.inr_snd
 
-attribute [inherit_doc BinaryBicone] BinaryBicone.pt BinaryBicone.fst BinaryBicone.snd 
-  BinaryBicone.inl BinaryBicone.inr BinaryBicone.inl_fst BinaryBicone.inl_snd 
+attribute [inherit_doc BinaryBicone] BinaryBicone.pt BinaryBicone.fst BinaryBicone.snd
+  BinaryBicone.inl BinaryBicone.inr BinaryBicone.inl_fst BinaryBicone.inl_snd
   BinaryBicone.inr_fst BinaryBicone.inr_snd
 
 attribute [reassoc (attr := simp)]
@@ -1138,7 +1138,7 @@ structure BinaryBicone.IsBilimit {P Q : C} (b : BinaryBicone P Q) where
 #align category_theory.limits.binary_bicone.is_bilimit.is_limit CategoryTheory.Limits.BinaryBicone.IsBilimit.isLimit
 #align category_theory.limits.binary_bicone.is_bilimit.is_colimit CategoryTheory.Limits.BinaryBicone.IsBilimit.isColimit
 
-attribute [inherit_doc BinaryBicone.IsBilimit] BinaryBicone.IsBilimit.isLimit 
+attribute [inherit_doc BinaryBicone.IsBilimit] BinaryBicone.IsBilimit.isLimit
   BinaryBicone.IsBilimit.isColimit
 
 /-- A binary bicone is a bilimit bicone if and only if the corresponding bicone is a bilimit. -/
@@ -1170,7 +1170,7 @@ structure BinaryBiproductData (P Q : C) where
 #align category_theory.limits.binary_biproduct_data CategoryTheory.Limits.BinaryBiproductData
 #align category_theory.limits.binary_biproduct_data.is_bilimit CategoryTheory.Limits.BinaryBiproductData.isBilimit
 
-attribute [inherit_doc BinaryBiproductData] BinaryBiproductData.bicone 
+attribute [inherit_doc BinaryBiproductData] BinaryBiproductData.bicone
   BinaryBiproductData.isBilimit
 
 /-- `HasBinaryBiproduct P Q` expresses the mere existence of a bicone which is
@@ -1255,12 +1255,12 @@ instance HasBinaryBiproduct.hasColimit_pair [HasBinaryBiproduct P Q] : HasColimi
 #align category_theory.limits.has_binary_biproduct.has_colimit_pair CategoryTheory.Limits.HasBinaryBiproduct.hasColimit_pair
 
 instance (priority := 100) hasBinaryProducts_of_hasBinaryBiproducts [HasBinaryBiproducts C] :
-    HasBinaryProducts C where 
+    HasBinaryProducts C where
   has_limit F := hasLimitOfIso (diagramIsoPair F).symm
 #align category_theory.limits.has_binary_products_of_has_binary_biproducts CategoryTheory.Limits.hasBinaryProducts_of_hasBinaryBiproducts
 
 instance (priority := 100) hasBinaryCoproducts_of_hasBinaryBiproducts [HasBinaryBiproducts C] :
-    HasBinaryCoproducts C where 
+    HasBinaryCoproducts C where
   has_colimit F := hasColimitOfIso (diagramIsoPair F)
 #align category_theory.limits.has_binary_coproducts_of_has_binary_biproducts CategoryTheory.Limits.hasBinaryCoproducts_of_hasBinaryBiproducts
 
@@ -1441,7 +1441,7 @@ def biprod.isoProd (X Y : C) [HasBinaryBiproduct X Y] : X ⊞ Y ≅ X ⨯ Y :=
 
 @[simp]
 theorem biprod.isoProd_hom {X Y : C} [HasBinaryBiproduct X Y] :
-    (biprod.isoProd X Y).hom = prod.lift biprod.fst biprod.snd := by 
+    (biprod.isoProd X Y).hom = prod.lift biprod.fst biprod.snd := by
       apply biprod.hom_ext' <;> apply prod.hom_ext <;> simp [biprod.isoProd]
 #align category_theory.limits.biprod.iso_prod_hom CategoryTheory.Limits.biprod.isoProd_hom
 
@@ -1473,7 +1473,7 @@ theorem biprod.map_eq_map' {W X Y Z : C} [HasBinaryBiproduct W X] [HasBinaryBipr
   apply biprod.hom_ext' <;> apply biprod.hom_ext
   · simp only [mapPair_left, IsColimit.ι_map, IsLimit.map_π, biprod.inl_fst_assoc,
       Category.assoc, ← BinaryBicone.toCone_π_app_left, ← BinaryBiproduct.bicone_fst, ←
-      BinaryBicone.toCocone_ι_app_left, ← BinaryBiproduct.bicone_inl];  
+      BinaryBicone.toCocone_ι_app_left, ← BinaryBiproduct.bicone_inl];
     dsimp; simp
   · simp only [mapPair_left, IsColimit.ι_map, IsLimit.map_π, zero_comp, biprod.inl_snd_assoc,
       Category.assoc, ← BinaryBicone.toCone_π_app_right, ← BinaryBiproduct.bicone_snd, ←
@@ -1613,7 +1613,7 @@ theorem BinaryBicone.fstKernelFork_ι : (BinaryBicone.fstKernelFork c).ι = c.in
 
 /-- A kernel fork for the kernel of `BinaryBicone.snd`. It consists of the morphism
 `BinaryBicone.inl`. -/
-def BinaryBicone.sndKernelFork : KernelFork c.snd := 
+def BinaryBicone.sndKernelFork : KernelFork c.snd :=
   KernelFork.ofι c.inl c.inl_snd
 #align category_theory.limits.binary_bicone.snd_kernel_fork CategoryTheory.Limits.BinaryBicone.sndKernelFork
 
@@ -1682,7 +1682,7 @@ def biprod.fstKernelFork : KernelFork (biprod.fst : X ⊞ Y ⟶ X) :=
 #align category_theory.limits.biprod.fst_kernel_fork CategoryTheory.Limits.biprod.fstKernelFork
 
 @[simp]
-theorem biprod.fstKernelFork_ι : Fork.ι (biprod.fstKernelFork X Y) = (biprod.inr : Y ⟶  X ⊞ Y) := 
+theorem biprod.fstKernelFork_ι : Fork.ι (biprod.fstKernelFork X Y) = (biprod.inr : Y ⟶  X ⊞ Y) :=
   rfl
 #align category_theory.limits.biprod.fst_kernel_fork_ι CategoryTheory.Limits.biprod.fstKernelFork_ι
 
@@ -1849,7 +1849,7 @@ theorem biprod.braiding_map_braiding {W X Y Z : C} (f : W ⟶ Y) (g : X ⟶ Z) :
 
 @[reassoc (attr := simp)]
 theorem biprod.symmetry' (P Q : C) :
-    biprod.lift biprod.snd biprod.fst ≫ biprod.lift biprod.snd biprod.fst = 𝟙 (P ⊞ Q) := by 
+    biprod.lift biprod.snd biprod.fst ≫ biprod.lift biprod.snd biprod.fst = 𝟙 (P ⊞ Q) := by
   aesop_cat
 #align category_theory.limits.biprod.symmetry' CategoryTheory.Limits.biprod.symmetry'
 
@@ -1912,8 +1912,7 @@ theorem isIso_right_of_isIso_biprod_map {W X Y Z : C} (f : W ⟶ Y) (g : X ⟶ Z
   letI : IsIso (biprod.map g f) := by
     rw [← biprod.braiding_map_braiding]
     infer_instance
-  isIso_left_of_isIso_biprod_map g f 
+  isIso_left_of_isIso_biprod_map g f
 #align category_theory.is_iso_right_of_is_iso_biprod_map CategoryTheory.isIso_right_of_isIso_biprod_map
 
 end CategoryTheory
-

--- a/Mathlib/CategoryTheory/Limits/Shapes/Equalizers.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Equalizers.lean
@@ -48,7 +48,7 @@ general limits can be used.
 * [F. Borceux, *Handbook of Categorical Algebra 1*][borceux-vol1]
 -/
 
-/- Porting note: removed global noncomputable since there are things that might be 
+/- Porting note: removed global noncomputable since there are things that might be
 computable value like WalkingPair -/
 section
 
@@ -77,9 +77,9 @@ inductive WalkingParallelPairHom : WalkingParallelPair → WalkingParallelPair �
   deriving DecidableEq
 #align category_theory.limits.walking_parallel_pair_hom CategoryTheory.Limits.WalkingParallelPairHom
 
-/- Porting note: this simplifies using walkingParallelPairHom_id; replacement is below; 
+/- Porting note: this simplifies using walkingParallelPairHom_id; replacement is below;
 simpNF still complains of striking this from the simp list -/
-attribute [-simp, nolint simpNF] WalkingParallelPairHom.id.sizeOf_spec 
+attribute [-simp, nolint simpNF] WalkingParallelPairHom.id.sizeOf_spec
 
 /-- Satisfying the inhabited linter -/
 instance : Inhabited (WalkingParallelPairHom zero one) where default := WalkingParallelPairHom.left
@@ -89,7 +89,7 @@ open WalkingParallelPairHom
 /-- Composition of morphisms in the indexing diagram for (co)equalizers. -/
 def WalkingParallelPairHom.comp :
   -- Porting note: changed X Y Z to implicit to match comp fields in precategory
-    ∀ { X Y Z : WalkingParallelPair } (_ : WalkingParallelPairHom X Y) 
+    ∀ { X Y Z : WalkingParallelPair } (_ : WalkingParallelPairHom X Y)
       (_ : WalkingParallelPairHom Y Z), WalkingParallelPairHom X Z
   | _, _, _, id _, h => h
   | _, _, _, left, id one => left
@@ -98,15 +98,15 @@ def WalkingParallelPairHom.comp :
 
 -- Porting note: adding these since they are simple and aesop couldn't directly prove them
 theorem WalkingParallelPairHom.id_comp {X Y : WalkingParallelPair} (g : WalkingParallelPairHom X Y):
-    comp (id X) g = g := rfl 
+    comp (id X) g = g := rfl
 
 theorem WalkingParallelPairHom.comp_id {X Y : WalkingParallelPair} (f : WalkingParallelPairHom X Y):
-    comp f (id Y) = f := by cases f <;> rfl  
+    comp f (id Y) = f := by cases f <;> rfl
 
-theorem WalkingParallelPairHom.assoc {X Y Z W : WalkingParallelPair} 
-    (f : WalkingParallelPairHom X Y) (g: WalkingParallelPairHom Y Z) 
-    (h : WalkingParallelPairHom Z W) : comp (comp f g) h = comp f (comp g h) := by 
-    cases f <;> cases g <;> cases h <;> rfl 
+theorem WalkingParallelPairHom.assoc {X Y Z W : WalkingParallelPair}
+    (f : WalkingParallelPairHom X Y) (g: WalkingParallelPairHom Y Z)
+    (h : WalkingParallelPairHom Z W) : comp (comp f g) h = comp f (comp g h) := by
+    cases f <;> cases g <;> cases h <;> rfl
 
 instance walkingParallelPairHomCategory : SmallCategory WalkingParallelPair where
   Hom := WalkingParallelPairHom
@@ -123,9 +123,9 @@ theorem walkingParallelPairHom_id (X : WalkingParallelPair) : WalkingParallelPai
 #align category_theory.limits.walking_parallel_pair_hom_id CategoryTheory.Limits.walkingParallelPairHom_id
 
 -- Porting note: simpNF asked me to do this becasue the LHS of the non-primed version reduced
-@[simp] 
-theorem WalkingParallelPairHom.id.sizeOf_spec' (X : WalkingParallelPair) : 
-    (WalkingParallelPairHom._sizeOf_inst X X).sizeOf (𝟙 X) = 1 + sizeOf X := by cases X <;> rfl 
+@[simp]
+theorem WalkingParallelPairHom.id.sizeOf_spec' (X : WalkingParallelPair) :
+    (WalkingParallelPairHom._sizeOf_inst X X).sizeOf (𝟙 X) = 1 + sizeOf X := by cases X <;> rfl
 
 /-- The functor `WalkingParallelPair ⥤ WalkingParallelPairᵒᵖ` sending left to left and right to
 right.
@@ -168,9 +168,9 @@ def walkingParallelPairOpEquiv : WalkingParallelPair ≌ WalkingParallelPairᵒ�
     NatIso.ofComponents (fun j => eqToIso (by cases j <;> rfl))
       (by rintro _ _ (_ | _ | _) <;> simp)
   counitIso :=
-    NatIso.ofComponents (fun j => eqToIso (by 
-            induction' j using Opposite.rec with X 
-            cases X <;> rfl )) 
+    NatIso.ofComponents (fun j => eqToIso (by
+            induction' j using Opposite.rec with X
+            cases X <;> rfl ))
       (fun {i} {j} f => by
       induction' i using Opposite.rec with i
       induction' j using Opposite.rec with j
@@ -178,7 +178,7 @@ def walkingParallelPairOpEquiv : WalkingParallelPair ≌ WalkingParallelPairᵒ�
       have : f = g.op := rfl
       rw [this]
       cases i <;> cases j <;> cases g <;> rfl)
-  functor_unitIso_comp := fun j => by cases j <;> rfl  
+  functor_unitIso_comp := fun j => by cases j <;> rfl
 #align category_theory.limits.walking_parallel_pair_op_equiv CategoryTheory.Limits.walkingParallelPairOpEquiv
 
 @[simp]
@@ -213,7 +213,7 @@ def parallelPair (f g : X ⟶ Y) : WalkingParallelPair ⥤ C where
     match x with
     | zero => X
     | one => Y
-  map h := 
+  map h :=
     match h with
     | WalkingParallelPairHom.id _ => 𝟙 _
     | left => f
@@ -249,7 +249,7 @@ theorem parallelPair_functor_obj {F : WalkingParallelPair ⥤ C} (j : WalkingPar
 @[simps!]
 def diagramIsoParallelPair (F : WalkingParallelPair ⥤ C) :
     F ≅ parallelPair (F.map left) (F.map right) :=
-  (NatIso.ofComponents fun j => eqToIso <| by cases j <;> rfl) <| by rintro _ _ (_|_|_) <;> simp 
+  (NatIso.ofComponents fun j => eqToIso <| by cases j <;> rfl) <| by rintro _ _ (_|_|_) <;> simp
 #align category_theory.limits.diagram_iso_parallel_pair CategoryTheory.Limits.diagramIsoParallelPair
 
 /-- Construct a morphism between parallel pairs. -/
@@ -311,7 +311,7 @@ abbrev Cofork (f g : X ⟶ Y) :=
 
 variable {f g : X ⟶ Y}
 
-/-- A fork `t` on the parallel pair `f g : X ⟶ Y` consists of two morphisms 
+/-- A fork `t` on the parallel pair `f g : X ⟶ Y` consists of two morphisms
     `t.π.app zero : t.pt ⟶ X`
     and `t.π.app one : t.pt ⟶ Y`. Of these, only the first one is interesting, and we give it the
     shorter name `fork.ι t`. -/
@@ -405,9 +405,9 @@ theorem Cofork.condition (t : Cofork f g) : f ≫ t.π = g ≫ t.π := by
 theorem Fork.equalizer_ext (s : Fork f g) {W : C} {k l : W ⟶ s.pt} (h : k ≫ s.ι = l ≫ s.ι) :
     ∀ j : WalkingParallelPair, k ≫ s.π.app j = l ≫ s.π.app j
   | zero => h
-  | one => by 
-    have : k ≫ ι s ≫ f = l ≫ ι s ≫  f := by 
-      simp only [← Category.assoc]; exact congrArg (· ≫ f) h 
+  | one => by
+    have : k ≫ ι s ≫ f = l ≫ ι s ≫  f := by
+      simp only [← Category.assoc]; exact congrArg (· ≫ f) h
     rw [s.app_one_eq_ι_comp_left, this]
 #align category_theory.limits.fork.equalizer_ext CategoryTheory.Limits.Fork.equalizer_ext
 
@@ -613,7 +613,7 @@ theorem Cocone.ofCofork_ι {F : WalkingParallelPair ⥤ C} (t : Cofork (F.map le
 def Fork.ofCone {F : WalkingParallelPair ⥤ C} (t : Cone F) : Fork (F.map left) (F.map right)
     where
   pt := t.pt
-  π := { app := fun X => t.π.app X ≫ eqToHom (by aesop) 
+  π := { app := fun X => t.π.app X ≫ eqToHom (by aesop)
          naturality := by rintro _ _ (_|_|_) <;> {dsimp; simp}}
 #align category_theory.limits.fork.of_cone CategoryTheory.Limits.Fork.ofCone
 
@@ -658,7 +658,7 @@ def Fork.mkHom {s t : Fork f g} (k : s.pt ⟶ t.pt) (w : k ≫ t.ι = s.ι) : s 
     rintro ⟨_ | _⟩
     · exact w
     · simp only [Fork.app_one_eq_ι_comp_left,← Category.assoc]
-      congr 
+      congr
 #align category_theory.limits.fork.mk_hom CategoryTheory.Limits.Fork.mkHom
 
 /-- To construct an isomorphism between forks,
@@ -689,12 +689,12 @@ def Cofork.mkHom {s t : Cofork f g} (k : s.pt ⟶ t.pt) (w : s.π ≫ k = t.π) 
 
 @[reassoc (attr := simp)]
 theorem Fork.hom_comp_ι {s t : Fork f g} (f : s ⟶ t) : f.Hom ≫ t.ι = s.ι := by
-  cases s; cases t; cases f; aesop 
+  cases s; cases t; cases f; aesop
 #align category_theory.limits.fork.hom_comp_ι CategoryTheory.Limits.Fork.hom_comp_ι
 
 @[reassoc (attr := simp)]
-theorem Fork.π_comp_hom {s t : Cofork f g} (f : s ⟶ t) : s.π ≫ f.Hom = t.π := by 
-  cases s; cases t; cases f; aesop 
+theorem Fork.π_comp_hom {s t : Cofork f g} (f : s ⟶ t) : s.π ≫ f.Hom = t.π := by
+  cases s; cases t; cases f; aesop
 #align category_theory.limits.fork.π_comp_hom CategoryTheory.Limits.Fork.π_comp_hom
 
 /-- To construct an isomorphism between coforks,
@@ -759,7 +759,7 @@ theorem equalizer.condition : equalizer.ι f g ≫ f = equalizer.ι f g ≫ g :=
 #align category_theory.limits.equalizer.condition CategoryTheory.Limits.equalizer.condition
 
 /-- The equalizer built from `equalizer.ι f g` is limiting. -/
-noncomputable def equalizerIsEqualizer : IsLimit (Fork.ofι (equalizer.ι f g) 
+noncomputable def equalizerIsEqualizer : IsLimit (Fork.ofι (equalizer.ι f g)
     (equalizer.condition f g)) :=
   IsLimit.ofIsoLimit (limit.isLimit _) (Fork.ext (Iso.refl _) (by aesop))
 #align category_theory.limits.equalizer_is_equalizer CategoryTheory.Limits.equalizerIsEqualizer
@@ -800,7 +800,7 @@ theorem equalizer.existsUnique {W : C} (k : W ⟶ X) (h : k ≫ f = k ≫ g) :
 #align category_theory.limits.equalizer.exists_unique CategoryTheory.Limits.equalizer.existsUnique
 
 /-- An equalizer morphism is a monomorphism -/
-instance equalizer.ι_mono : Mono (equalizer.ι f g) where 
+instance equalizer.ι_mono : Mono (equalizer.ι f g) where
   right_cancellation _ _ w := equalizer.hom_ext w
 #align category_theory.limits.equalizer.ι_mono CategoryTheory.Limits.equalizer.ι_mono
 
@@ -949,7 +949,7 @@ variable {f g}
 
 /-- Any morphism `k : Y ⟶ W` satisfying `f ≫ k = g ≫ k` factors through the coequalizer of `f`
     and `g` via `coequalizer.desc : coequalizer f g ⟶ W`. -/
-noncomputable abbrev coequalizer.desc {W : C} (k : Y ⟶ W) (h : f ≫ k = g ≫ k) : 
+noncomputable abbrev coequalizer.desc {W : C} (k : Y ⟶ W) (h : f ≫ k = g ≫ k) :
     coequalizer f g ⟶ W :=
   colimit.desc (parallelPair f g) (Cofork.ofπ k h)
 #align category_theory.limits.coequalizer.desc CategoryTheory.Limits.coequalizer.desc
@@ -990,7 +990,7 @@ theorem coequalizer.existsUnique {W : C} (k : Y ⟶ W) (h : f ≫ k = g ≫ k) :
 #align category_theory.limits.coequalizer.exists_unique CategoryTheory.Limits.coequalizer.existsUnique
 
 /-- A coequalizer morphism is an epimorphism -/
-instance coequalizer.π_epi : Epi (coequalizer.π f g) where 
+instance coequalizer.π_epi : Epi (coequalizer.π f g) where
   left_cancellation _ _ w := coequalizer.hom_ext w
 #align category_theory.limits.coequalizer.π_epi CategoryTheory.Limits.coequalizer.π_epi
 
@@ -1096,7 +1096,7 @@ This is an isomorphism iff `G` preserves the equalizer of `f,g`; see
 -/
 noncomputable def equalizerComparison [HasEqualizer f g] [HasEqualizer (G.map f) (G.map g)] :
     G.obj (equalizer f g) ⟶ equalizer (G.map f) (G.map g) :=
-  equalizer.lift (G.map (equalizer.ι _ _)) 
+  equalizer.lift (G.map (equalizer.ι _ _))
     (by simp only [← G.map_comp]; rw[equalizer.condition])
 #align category_theory.limits.equalizer_comparison CategoryTheory.Limits.equalizerComparison
 
@@ -1118,7 +1118,7 @@ theorem map_lift_equalizerComparison [HasEqualizer f g] [HasEqualizer (G.map f) 
 /-- The comparison morphism for the coequalizer of `f,g`. -/
 noncomputable def coequalizerComparison [HasCoequalizer f g] [HasCoequalizer (G.map f) (G.map g)] :
     coequalizer (G.map f) (G.map g) ⟶ G.obj (coequalizer f g) :=
-  coequalizer.desc (G.map (coequalizer.π _ _)) 
+  coequalizer.desc (G.map (coequalizer.π _ _))
     (by simp only [← G.map_comp]; rw [coequalizer.condition])
 #align category_theory.limits.coequalizer_comparison CategoryTheory.Limits.coequalizerComparison
 
@@ -1171,7 +1171,7 @@ variable {C} [IsSplitMono f]
 /-- A split mono `f` equalizes `(retraction f ≫ f)` and `(𝟙 Y)`.
 Here we build the cone, and show in `isSplitMonoEqualizes` that it is a limit cone.
 -/
--- @[simps (config := { rhsMd := semireducible })] Porting note: no semireducible 
+-- @[simps (config := { rhsMd := semireducible })] Porting note: no semireducible
 @[simps!]
 noncomputable def coneOfIsSplitMono : Fork (𝟙 Y) (retraction f ≫ f) :=
   Fork.ofι f (by simp)
@@ -1184,7 +1184,7 @@ theorem coneOfIsSplitMono_ι : (coneOfIsSplitMono f).ι = f :=
 
 /-- A split mono `f` equalizes `(retraction f ≫ f)` and `(𝟙 Y)`.
 -/
-noncomputable def isSplitMonoEqualizes {X Y : C} (f : X ⟶ Y) [IsSplitMono f] : 
+noncomputable def isSplitMonoEqualizes {X Y : C} (f : X ⟶ Y) [IsSplitMono f] :
     IsLimit (coneOfIsSplitMono f) :=
   Fork.IsLimit.mk' _ fun s =>
     ⟨s.ι ≫ retraction f, by
@@ -1208,9 +1208,9 @@ variable {C f g}
 
 /-- The fork obtained by postcomposing an equalizer fork with a monomorphism is an equalizer. -/
 def isEqualizerCompMono {c : Fork f g} (i : IsLimit c) {Z : C} (h : Y ⟶ Z) [hm : Mono h] :
-    have : Fork.ι c ≫ f ≫ h = Fork.ι c ≫ g ≫ h := by 
-      simp only [←Category.assoc] 
-      exact congrArg (· ≫ h) c.condition; 
+    have : Fork.ι c ≫ f ≫ h = Fork.ι c ≫ g ≫ h := by
+      simp only [←Category.assoc]
+      exact congrArg (· ≫ h) c.condition;
     IsLimit (Fork.ofι c.ι (by simp [this]) : Fork (f ≫ h) (g ≫ h)) :=
   Fork.IsLimit.mk' _ fun s =>
     let s' : Fork f g := Fork.ofι s.ι (by apply hm.right_cancellation; simp [s.condition])
@@ -1240,7 +1240,7 @@ def splitMonoOfIdempotentOfIsLimitFork {X : C} {f : X ⟶ X} (hf : f ≫ f = f) 
 #align category_theory.limits.split_mono_of_idempotent_of_is_limit_fork CategoryTheory.Limits.splitMonoOfIdempotentOfIsLimitFork
 
 /-- The equalizer of an idempotent morphism and the identity is split mono. -/
-noncomputable def splitMonoOfIdempotentEqualizer {X : C} {f : X ⟶ X} (hf : f ≫ f = f) 
+noncomputable def splitMonoOfIdempotentEqualizer {X : C} {f : X ⟶ X} (hf : f ≫ f = f)
     [HasEqualizer (𝟙 X) f] : SplitMono (equalizer.ι (𝟙 X) f) :=
   splitMonoOfIdempotentOfIsLimitFork _ hf (limit.isLimit _)
 #align category_theory.limits.split_mono_of_idempotent_equalizer CategoryTheory.Limits.splitMonoOfIdempotentEqualizer
@@ -1266,7 +1266,7 @@ theorem coconeOfIsSplitEpi_π : (coconeOfIsSplitEpi f).π = f :=
 
 /-- A split epi `f` coequalizes `(f ≫ section_ f)` and `(𝟙 X)`.
 -/
-noncomputable def isSplitEpiCoequalizes {X Y : C} (f : X ⟶ Y) [IsSplitEpi f] : 
+noncomputable def isSplitEpiCoequalizes {X Y : C} (f : X ⟶ Y) [IsSplitEpi f] :
     IsColimit (coconeOfIsSplitEpi f) :=
   Cofork.IsColimit.mk' _ fun s =>
     ⟨section_ f ≫ s.π, by
@@ -1294,9 +1294,9 @@ variable {C f g}
 /-- The cofork obtained by precomposing a coequalizer cofork with an epimorphism is
 a coequalizer. -/
 def isCoequalizerEpiComp {c : Cofork f g} (i : IsColimit c) {W : C} (h : W ⟶ X) [hm : Epi h] :
-    have : (h ≫ f) ≫ Cofork.π c = (h ≫ g) ≫ Cofork.π c := by 
+    have : (h ≫ f) ≫ Cofork.π c = (h ≫ g) ≫ Cofork.π c := by
       simp only [Category.assoc]
-      exact congrArg (h ≫ ·) c.condition 
+      exact congrArg (h ≫ ·) c.condition
     IsColimit (Cofork.ofπ c.π (this) : Cofork (h ≫ f) (h ≫ g)) :=
   Cofork.IsColimit.mk' _ fun s =>
     let s' : Cofork f g :=
@@ -1327,10 +1327,9 @@ def splitEpiOfIdempotentOfIsColimitCofork {X : C} {f : X ⟶ X} (hf : f ≫ f = 
 #align category_theory.limits.split_epi_of_idempotent_of_is_colimit_cofork CategoryTheory.Limits.splitEpiOfIdempotentOfIsColimitCofork
 
 /-- The coequalizer of an idempotent morphism and the identity is split epi. -/
-noncomputable def splitEpiOfIdempotentCoequalizer {X : C} {f : X ⟶ X} (hf : f ≫ f = f) 
+noncomputable def splitEpiOfIdempotentCoequalizer {X : C} {f : X ⟶ X} (hf : f ≫ f = f)
     [HasCoequalizer (𝟙 X) f] : SplitEpi (coequalizer.π (𝟙 X) f) :=
   splitEpiOfIdempotentOfIsColimitCofork _ hf (colimit.isColimit _)
 #align category_theory.limits.split_epi_of_idempotent_coequalizer CategoryTheory.Limits.splitEpiOfIdempotentCoequalizer
 
 end CategoryTheory.Limits
- 

--- a/Mathlib/CategoryTheory/Limits/Shapes/Kernels.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Kernels.lean
@@ -92,7 +92,7 @@ theorem KernelFork.condition (s : KernelFork f) : Fork.ι s ≫ f = 0 := by
 #align category_theory.limits.kernel_fork.condition CategoryTheory.Limits.KernelFork.condition
 
 -- Porting note: simp can prove this, removed simp tag
-theorem KernelFork.app_one (s : KernelFork f) : s.π.app one = 0 := by 
+theorem KernelFork.app_one (s : KernelFork f) : s.π.app one = 0 := by
   simp [Fork.app_one_eq_ι_comp_right]
 #align category_theory.limits.kernel_fork.app_one CategoryTheory.Limits.KernelFork.app_one
 
@@ -112,23 +112,23 @@ section
 
 /-- Every kernel fork `s` is isomorphic (actually, equal) to `fork.ofι (fork.ι s) _`. -/
 def isoOfι (s : Fork f 0) : s ≅ Fork.ofι (Fork.ι s) (Fork.condition s) :=
-  Cones.ext (Iso.refl _) <| by rintro ⟨j⟩ <;> simp 
+  Cones.ext (Iso.refl _) <| by rintro ⟨j⟩ <;> simp
 #align category_theory.limits.iso_of_ι CategoryTheory.Limits.isoOfι
 
 /-- If `ι = ι'`, then `fork.ofι ι _` and `fork.ofι ι' _` are isomorphic. -/
 def ofιCongr {P : C} {ι ι' : P ⟶ X} {w : ι ≫ f = 0} (h : ι = ι') :
     KernelFork.ofι ι w ≅ KernelFork.ofι ι' (by rw [← h, w]) :=
-  Cones.ext (Iso.refl _) <| by rintro ⟨j⟩ <;> aesop_cat 
+  Cones.ext (Iso.refl _) <| by rintro ⟨j⟩ <;> aesop_cat
 #align category_theory.limits.of_ι_congr CategoryTheory.Limits.ofιCongr
 
 /-- If `F` is an equivalence, then applying `F` to a diagram indexing a (co)kernel of `f` yields
     the diagram indexing the (co)kernel of `F.map f`. -/
 def compNatIso {D : Type u'} [Category.{v} D] [HasZeroMorphisms D] (F : C ⥤ D) [IsEquivalence F] :
     parallelPair f 0 ⋙ F ≅ parallelPair (F.map f) 0 :=
-  let app (j :WalkingParallelPair) : 
-      (parallelPair f 0 ⋙ F).obj j ≅ (parallelPair (F.map f) 0).obj j:=  
-    match j with 
-    | zero => Iso.refl _ 
+  let app (j :WalkingParallelPair) :
+      (parallelPair f 0 ⋙ F).obj j ≅ (parallelPair (F.map f) 0).obj j:=
+    match j with
+    | zero => Iso.refl _
     | one => Iso.refl _
   NatIso.ofComponents app <| by rintro ⟨i⟩ ⟨j⟩ <;> intro g <;> cases g <;> simp
 #align category_theory.limits.comp_nat_iso CategoryTheory.Limits.compNatIso
@@ -290,8 +290,8 @@ def kernel.mapIso {X' Y' : C} (f' : X' ⟶ Y') [HasKernel f'] (p : X ≅ X') (q 
       (by
         refine' (cancel_mono q.hom).1 _
         simp [w])
-  hom_inv_id := by apply equalizer.hom_ext; simp 
-  inv_hom_id := by apply equalizer.hom_ext; simp  
+  hom_inv_id := by apply equalizer.hom_ext; simp
+  inv_hom_id := by apply equalizer.hom_ext; simp
 #align category_theory.limits.kernel.map_iso CategoryTheory.Limits.kernel.mapIso
 
 /-- Every kernel of the zero morphism is an isomorphism -/
@@ -332,9 +332,9 @@ theorem kernelIsoOfEq_refl {h : f = f} : kernelIsoOfEq h = Iso.refl (kernel f) :
 
 /- Porting note: induction on Eq is trying instantiate another g...-/
 @[reassoc (attr := simp)]
-theorem kernelIsoOfEq_hom_comp_ι {f g : X ⟶ Y} [HasKernel f] [HasKernel g] (h : f = g) : 
-    (kernelIsoOfEq h).hom ≫ kernel.ι g = kernel.ι f := by 
-  cases h; simp 
+theorem kernelIsoOfEq_hom_comp_ι {f g : X ⟶ Y} [HasKernel f] [HasKernel g] (h : f = g) :
+    (kernelIsoOfEq h).hom ≫ kernel.ι g = kernel.ι f := by
+  cases h; simp
 #align category_theory.limits.kernel_iso_of_eq_hom_comp_ι CategoryTheory.Limits.kernelIsoOfEq_hom_comp_ι
 
 @[reassoc (attr := simp)]
@@ -392,8 +392,8 @@ def kernelCompMono {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) [HasKernel f] [Mono g
         rw [← cancel_mono g]
         simp)
   inv := kernel.lift _ (kernel.ι _) (by simp)
-  hom_inv_id := by apply equalizer.hom_ext; simp 
-  inv_hom_id := by apply equalizer.hom_ext; simp  
+  hom_inv_id := by apply equalizer.hom_ext; simp
+  inv_hom_id := by apply equalizer.hom_ext; simp
 #align category_theory.limits.kernel_comp_mono CategoryTheory.Limits.kernelCompMono
 
 instance hasKernel_iso_comp {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) [IsIso f] [HasKernel g] :
@@ -415,8 +415,8 @@ def kernelIsIsoComp {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) [IsIso f] [HasKernel
     kernel (f ≫ g) ≅ kernel g where
   hom := kernel.lift _ (kernel.ι _ ≫ f) (by simp)
   inv := kernel.lift _ (kernel.ι _ ≫ inv f) (by simp)
-  hom_inv_id := equalizer.hom_ext (by simp) 
-  inv_hom_id := equalizer.hom_ext (by simp) 
+  hom_inv_id := equalizer.hom_ext (by simp)
+  inv_hom_id := equalizer.hom_ext (by simp)
 #align category_theory.limits.kernel_is_iso_comp CategoryTheory.Limits.kernelIsIsoComp
 
 end
@@ -459,7 +459,7 @@ def zeroKernelOfCancelZero {X Y : C} (f : X ⟶ Y)
     (hf : ∀ (Z : C) (g : Z ⟶ X) (_ : g ≫ f = 0), g = 0) :
     IsLimit (KernelFork.ofι (0 : 0 ⟶ X) (show 0 ≫ f = 0 by simp)) :=
   Fork.IsLimit.mk _ (fun s => 0) (fun s => by rw [hf _ _ (KernelFork.condition s), zero_comp])
-    fun s m _ => by dsimp; apply HasZeroObject.to_zero_ext 
+    fun s m _ => by dsimp; apply HasZeroObject.to_zero_ext
 #align category_theory.limits.zero_kernel_of_cancel_zero CategoryTheory.Limits.zeroKernelOfCancelZero
 
 end HasZeroObject
@@ -498,7 +498,7 @@ def IsKernel.isoKernel {Z : C} (l : Z ⟶ X) {s : KernelFork f} (hs : IsLimit s)
 
 /-- If `i` is an isomorphism such that `i.hom ≫ kernel.ι f = l`, then `l` is a kernel of `f`. -/
 def kernel.isoKernel [HasKernel f] {Z : C} (l : Z ⟶ X) (i : Z ≅ kernel f)
-    (h : i.hom ≫ kernel.ι f = l) : 
+    (h : i.hom ≫ kernel.ι f = l) :
     IsLimit (@KernelFork.ofι _ _ _ _ _ f _ l <| by simp [← h]) :=
   IsKernel.isoKernel f l (limit.isLimit _) i h
 #align category_theory.limits.kernel.iso_kernel CategoryTheory.Limits.kernel.isoKernel
@@ -696,10 +696,10 @@ def cokernel.desc' {W : C} (k : Y ⟶ W) (h : f ≫ k = 0) :
 /-- A commuting square induces a morphism of cokernels. -/
 abbrev cokernel.map {X' Y' : C} (f' : X' ⟶ Y') [HasCokernel f'] (p : X ⟶ X') (q : Y ⟶ Y')
     (w : f ≫ q = p ≫ f') : cokernel f ⟶ cokernel f' :=
-  cokernel.desc f (q ≫ cokernel.π f') (by 
-    have : f ≫ q ≫ π f' = p ≫ f' ≫ π f' := by 
+  cokernel.desc f (q ≫ cokernel.π f') (by
+    have : f ≫ q ≫ π f' = p ≫ f' ≫ π f' := by
       simp only [←Category.assoc]
-      apply congrArg (· ≫ π f') w 
+      apply congrArg (· ≫ π f') w
     simp [this])
 #align category_theory.limits.cokernel.map CategoryTheory.Limits.cokernel.map
 
@@ -733,8 +733,8 @@ def cokernel.mapIso {X' Y' : C} (f' : X' ⟶ Y') [HasCokernel f'] (p : X ≅ X')
   inv := cokernel.map f' f p.inv q.inv (by
           refine' (cancel_mono q.hom).1 _
           simp [w])
-  hom_inv_id := by apply coequalizer.hom_ext; simp 
-  inv_hom_id := by apply coequalizer.hom_ext; simp 
+  hom_inv_id := by apply coequalizer.hom_ext; simp
+  inv_hom_id := by apply coequalizer.hom_ext; simp
 #align category_theory.limits.cokernel.map_iso CategoryTheory.Limits.cokernel.mapIso
 
 /-- The cokernel of the zero morphism is an isomorphism -/
@@ -820,7 +820,7 @@ theorem cokernel_not_iso_of_nonzero (w : f ≠ 0) : IsIso (cokernel.π f) → Fa
 
 -- TODO the remainder of this section has obvious generalizations to `HasCoequalizer f g`.
 instance hasCokernel_comp_iso {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) [HasCokernel f] [IsIso g] :
-    HasCokernel (f ≫ g) where 
+    HasCokernel (f ≫ g) where
   exists_colimit :=
     ⟨{  cocone := CokernelCofork.ofπ (inv g ≫ cokernel.π f) (by simp)
         isColimit :=
@@ -841,7 +841,7 @@ def cokernelCompIsIso {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) [HasCokernel f] [I
   hom := cokernel.desc _ (inv g ≫ cokernel.π f) (by simp)
   inv := cokernel.desc _ (g ≫ cokernel.π (f ≫ g)) (by rw [← Category.assoc, cokernel.condition])
   hom_inv_id := by apply coequalizer.hom_ext; simp
-  inv_hom_id := by apply coequalizer.hom_ext; simp 
+  inv_hom_id := by apply coequalizer.hom_ext; simp
 #align category_theory.limits.cokernel_comp_is_iso CategoryTheory.Limits.cokernelCompIsIso
 
 instance hasCokernel_epi_comp {X Y : C} (f : X ⟶ Y) [HasCokernel f] {W} (g : W ⟶ X) [Epi g] :
@@ -862,7 +862,7 @@ def cokernelEpiComp {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) [Epi f] [HasCokernel
         rw [← cancel_epi f, ← Category.assoc]
         simp)
   hom_inv_id := by apply coequalizer.hom_ext; simp
-  inv_hom_id := by apply coequalizer.hom_ext; simp 
+  inv_hom_id := by apply coequalizer.hom_ext; simp
 #align category_theory.limits.cokernel_epi_comp CategoryTheory.Limits.cokernelEpiComp
 
 end
@@ -946,7 +946,7 @@ def cokernelImageι {X Y : C} (f : X ⟶ Y) [HasImage f] [HasCokernel (image.ι 
           rw [← image.fac f]
         rw [Category.assoc, cokernel.condition, HasZeroMorphisms.comp_zero])
   hom_inv_id := by apply coequalizer.hom_ext; simp
-  inv_hom_id := by apply coequalizer.hom_ext; simp 
+  inv_hom_id := by apply coequalizer.hom_ext; simp
 #align category_theory.limits.cokernel_image_ι CategoryTheory.Limits.cokernelImageι
 
 end HasImage
@@ -985,7 +985,7 @@ def zeroCokernelOfZeroCancel {X Y : C} (f : X ⟶ Y)
     (hf : ∀ (Z : C) (g : Y ⟶ Z) (_ : f ≫ g = 0), g = 0) :
     IsColimit (CokernelCofork.ofπ (0 : Y ⟶ 0) (show f ≫ 0 = 0 by simp)) :=
   Cofork.IsColimit.mk _ (fun s => 0)
-    (fun s => by rw [hf _ _ (CokernelCofork.condition s), comp_zero]) fun s m _ => by 
+    (fun s => by rw [hf _ _ (CokernelCofork.condition s), comp_zero]) fun s m _ => by
       apply HasZeroObject.from_zero_ext
 #align category_theory.limits.zero_cokernel_of_zero_cancel CategoryTheory.Limits.zeroCokernelOfZeroCancel
 
@@ -1029,7 +1029,7 @@ def IsCokernel.cokernelIso {Z : C} (l : Y ⟶ Z) {s : CokernelCofork f} (hs : Is
 
 /-- If `i` is an isomorphism such that `cokernel.π f ≫ i.hom = l`, then `l` is a cokernel of `f`. -/
 def cokernel.cokernelIso [HasCokernel f] {Z : C} (l : Y ⟶ Z) (i : cokernel f ≅ Z)
-    (h : cokernel.π f ≫ i.hom = l) : 
+    (h : cokernel.π f ≫ i.hom = l) :
     IsColimit (@CokernelCofork.ofπ _ _ _ _ _ f _ l <| by simp [← h]) :=
   IsCokernel.cokernelIso f l (colimit.isColimit _) i h
 #align category_theory.limits.cokernel.cokernel_iso CategoryTheory.Limits.cokernel.cokernelIso
@@ -1140,4 +1140,3 @@ instance (priority := 100) hasCokernels_of_hasCoequalizers [HasCoequalizers C] :
 #align category_theory.limits.has_cokernels_of_has_coequalizers CategoryTheory.Limits.hasCokernels_of_hasCoequalizers
 
 end CategoryTheory.Limits
-

--- a/Mathlib/CategoryTheory/Limits/Shapes/NormalMono/Basic.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/NormalMono/Basic.lean
@@ -67,20 +67,20 @@ def equivalenceReflectsNormalMono {D : Type u₂} [Category.{v₁} D] [HasZeroMo
     [IsEquivalence F] {X Y : C} {f : X ⟶ Y} (hf : NormalMono (F.map f)) : NormalMono f where
   Z := F.objPreimage hf.Z
   g := Full.preimage (hf.g ≫ (F.objObjPreimageIso hf.Z).inv)
-  w := F.map_injective <| by 
-    have reassoc' {W : D} (h : hf.Z ⟶  W) : F.map f ≫ hf.g ≫ h = 0 ≫ h := by 
+  w := F.map_injective <| by
+    have reassoc' {W : D} (h : hf.Z ⟶  W) : F.map f ≫ hf.g ≫ h = 0 ≫ h := by
       rw [← Category.assoc, eq_whisker hf.w]
     simp [reassoc']
-  isLimit := 
+  isLimit :=
     @ReflectsLimit.reflects C _ D _ _ _ _ F _ _ <|
       IsLimit.ofConeEquiv (Cones.postcomposeEquivalence (@compNatIso C _ _ _ _ _ D _ _ F _)) <|
-        IsLimit.ofIsoLimit 
-          (IsLimit.ofIsoLimit  
-            (IsKernel.ofCompIso _ _ (F.objObjPreimageIso hf.Z) (by 
-              simp only [Full.witness, Category.assoc, Iso.inv_hom_id, Category.comp_id]) 
+        IsLimit.ofIsoLimit
+          (IsLimit.ofIsoLimit
+            (IsKernel.ofCompIso _ _ (F.objObjPreimageIso hf.Z) (by
+              simp only [Full.witness, Category.assoc, Iso.inv_hom_id, Category.comp_id])
             hf.isLimit)
             (ofιCongr (Category.comp_id _).symm))
-        <| by apply Iso.symm; apply isoOfι  -- Porting note: very fiddly unification here 
+        <| by apply Iso.symm; apply isoOfι  -- Porting note: very fiddly unification here
 #align category_theory.equivalence_reflects_normal_mono CategoryTheory.equivalenceReflectsNormalMono
 
 end
@@ -110,8 +110,8 @@ def normalOfIsPullbackSndOfNormal {P Q R S : C} {f : P ⟶ Q} {g : P ⟶ R} {h :
     NormalMono g where
   Z := hn.Z
   g := k ≫ hn.g
-  w := by 
-    have reassoc' {W : C} (h' : S ⟶  W) : f ≫ h ≫ h' = g ≫ k ≫ h' := by 
+  w := by
+    have reassoc' {W : C} (h' : S ⟶  W) : f ≫ h ≫ h' = g ≫ k ≫ h' := by
       simp only [← Category.assoc, eq_whisker comm]
     rw [← reassoc', hn.w, HasZeroMorphisms.comp_zero]
   isLimit := by
@@ -154,7 +154,7 @@ def normalMonoOfMono [NormalMonoCategory C] (f : X ⟶ Y) [Mono f] : NormalMono 
 #align category_theory.normal_mono_of_mono CategoryTheory.normalMonoOfMono
 
 instance (priority := 100) regularMonoCategoryOfNormalMonoCategory [NormalMonoCategory C] :
-    RegularMonoCategory C where 
+    RegularMonoCategory C where
   regularMonoOfMono f _ := by
     haveI := normalMonoOfMono f
     infer_instance
@@ -196,7 +196,7 @@ def equivalenceReflectsNormalEpi {D : Type u₂} [Category.{v₁} D] [HasZeroMor
           (IsColimit.ofIsoColimit
             (IsCokernel.ofIsoComp _ _ (F.objObjPreimageIso hf.W).symm (by simp) hf.isColimit)
             (ofπCongr (Category.id_comp _).symm))
-          <| by apply Iso.symm; apply isoOfπ  
+          <| by apply Iso.symm; apply isoOfπ
 #align category_theory.equivalence_reflects_normal_epi CategoryTheory.equivalenceReflectsNormalEpi
 
 end
@@ -226,8 +226,8 @@ def normalOfIsPushoutSndOfNormal {P Q R S : C} {f : P ⟶ Q} {g : P ⟶ R} {h : 
     NormalEpi h where
   W := gn.W
   g := gn.g ≫ f
-  w := by 
-    have reassoc' {W : C} (h' : R ⟶  W) :  gn.g ≫ g ≫ h' = 0 ≫ h' := by 
+  w := by
+    have reassoc' {W : C} (h' : R ⟶  W) :  gn.g ≫ g ≫ h' = 0 ≫ h' := by
       rw [← Category.assoc, eq_whisker gn.w]
     rw [Category.assoc, comm, reassoc', zero_comp]
   isColimit := by
@@ -316,11 +316,10 @@ def normalEpiOfEpi [NormalEpiCategory C] (f : X ⟶ Y) [Epi f] : NormalEpi f :=
 #align category_theory.normal_epi_of_epi CategoryTheory.normalEpiOfEpi
 
 instance (priority := 100) regularEpiCategoryOfNormalEpiCategory [NormalEpiCategory C] :
-    RegularEpiCategory C where 
+    RegularEpiCategory C where
   regularEpiOfEpi f _ := by
     haveI := normalEpiOfEpi f
     infer_instance
 #align category_theory.regular_epi_category_of_normal_epi_category CategoryTheory.regularEpiCategoryOfNormalEpiCategory
 
 end CategoryTheory
-

--- a/Mathlib/CategoryTheory/Limits/Shapes/NormalMono/Equalizers.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/NormalMono/Equalizers.lean
@@ -31,7 +31,7 @@ namespace CategoryTheory.NormalMonoCategory
 variable [HasFiniteProducts C] [HasKernels C] [NormalMonoCategory C]
 
 /-- The pullback of two monomorphisms exists. -/
-@[irreducible, nolint defLemma] -- Porting note: changed to irreducible and a def 
+@[irreducible, nolint defLemma] -- Porting note: changed to irreducible and a def
 def pullback_of_mono {X Y Z : C} (a : X ⟶ Z) (b : Y ⟶ Z) [Mono a] [Mono b] :
   HasLimit (cospan a b) :=
   let ⟨P, f, haf, i⟩ := normalMonoOfMono a
@@ -43,7 +43,7 @@ def pullback_of_mono {X Y Z : C} (a : X ⟶ Z) (b : Y ⟶ Z) [Mono a] [Mono b] :
           by rw [prod.lift_fst]
         _ = (0 : kernel (prod.lift f g) ⟶ P ⨯ Q) ≫ Limits.prod.fst := by rw [kernel.condition_assoc]
         _ = 0 := zero_comp
-        
+
   let ⟨b', hb'⟩ :=
     KernelFork.IsLimit.lift' i' (kernel.ι (prod.lift f g)) <|
       calc
@@ -51,7 +51,7 @@ def pullback_of_mono {X Y Z : C} (a : X ⟶ Z) (b : Y ⟶ Z) [Mono a] [Mono b] :
           by rw [prod.lift_snd]
         _ = (0 : kernel (prod.lift f g) ⟶ P ⨯ Q) ≫ Limits.prod.snd := by rw [kernel.condition_assoc]
         _ = 0 := zero_comp
-        
+
   HasLimit.mk
     { cone :=
         PullbackCone.mk a' b' <| by
@@ -120,14 +120,14 @@ def hasLimit_parallelPair {X Y : C} (f g : X ⟶ Y) : HasLimit (parallelPair f g
       _ = pullback.fst ≫ prod.lift (𝟙 X) f ≫ Limits.prod.fst := by rw [prod.lift_fst]
       _ = pullback.snd ≫ prod.lift (𝟙 X) g ≫ Limits.prod.fst := by rw [pullback.condition_assoc]
       _ = pullback.snd := by rw [prod.lift_fst, Category.comp_id]
-      
+
   have hvu : (pullback.fst : P f g ⟶ X) ≫ f = pullback.snd ≫ g :=
     calc
       (pullback.fst : P f g ⟶ X) ≫ f = pullback.fst ≫ prod.lift (𝟙 X) f ≫ Limits.prod.snd := by
         rw [prod.lift_snd]
       _ = pullback.snd ≫ prod.lift (𝟙 X) g ≫ Limits.prod.snd := by rw [pullback.condition_assoc]
       _ = pullback.snd ≫ g := by rw [prod.lift_snd]
-      
+
   have huu : (pullback.fst : P f g ⟶ X) ≫ f = pullback.fst ≫ g := by rw [hvu, ← huv]
   HasLimit.mk
     { cone := Fork.ofι pullback.fst huu
@@ -190,7 +190,7 @@ namespace CategoryTheory.NormalEpiCategory
 variable [HasFiniteCoproducts C] [HasCokernels C] [NormalEpiCategory C]
 
 /-- The pushout of two epimorphisms exists. -/
-@[irreducible, nolint defLemma] -- Porting note: made a def and re-added irreducible 
+@[irreducible, nolint defLemma] -- Porting note: made a def and re-added irreducible
 def pushout_of_epi {X Y Z : C} (a : X ⟶ Y) (b : X ⟶ Z) [Epi a] [Epi b] :
   HasColimit (span a b) :=
   let ⟨P, f, hfa, i⟩ := normalEpiOfEpi a
@@ -203,7 +203,7 @@ def pushout_of_epi {X Y Z : C} (a : X ⟶ Y) (b : X ⟶ Z) [Epi a] [Epi b] :
           by rw [coprod.inl_desc_assoc]
         _ = coprod.inl ≫ (0 : P ⨿ Q ⟶ cokernel (coprod.desc f g)) := by rw [cokernel.condition]
         _ = 0 := HasZeroMorphisms.comp_zero _ _
-        
+
   let ⟨b', hb'⟩ :=
     CokernelCofork.IsColimit.desc' i' (cokernel.π (coprod.desc f g)) <|
       calc
@@ -212,7 +212,7 @@ def pushout_of_epi {X Y Z : C} (a : X ⟶ Y) (b : X ⟶ Z) [Epi a] [Epi b] :
           by rw [coprod.inr_desc_assoc]
         _ = coprod.inr ≫ (0 : P ⨿ Q ⟶ cokernel (coprod.desc f g)) := by rw [cokernel.condition]
         _ = 0 := HasZeroMorphisms.comp_zero _ _
-        
+
   HasColimit.mk
     { cocone :=
         PushoutCocone.mk a' b' <| by
@@ -241,8 +241,8 @@ def pushout_of_epi {X Y Z : C} (a : X ⟶ Y) (b : X ⟶ Z) [Epi a] [Epi b] :
           (fun s =>
             (cancel_epi a).1 <| by
               rw [CokernelCofork.π_ofπ] at ha'
-              have reassoced {W : C} (h : cokernel (coprod.desc f g) ⟶  W) : a ≫ a' ≫ h 
-                = cokernel.π (coprod.desc f g) ≫ h := by rw [← Category.assoc, eq_whisker ha']  
+              have reassoced {W : C} (h : cokernel (coprod.desc f g) ⟶  W) : a ≫ a' ≫ h
+                = cokernel.π (coprod.desc f g) ≫ h := by rw [← Category.assoc, eq_whisker ha']
               simp [reassoced , PushoutCocone.condition s])
           (fun s =>
             (cancel_epi b).1 <| by
@@ -284,7 +284,7 @@ def hasColimit_parallelPair {X Y : C} (f g : X ⟶ Y) : HasColimit (parallelPair
       _ = (coprod.inl ≫ coprod.desc (𝟙 Y) g) ≫ pushout.inr := by
         simp only [Category.assoc, pushout.condition]
       _ = pushout.inr := by rw [coprod.inl_desc, Category.id_comp]
-      
+
   have hvu : f ≫ (pushout.inl : Y ⟶ Q f g) = g ≫ pushout.inr :=
     calc
       f ≫ (pushout.inl : Y ⟶ Q f g) = (coprod.inr ≫ coprod.desc (𝟙 Y) f) ≫ pushout.inl := by
@@ -292,7 +292,7 @@ def hasColimit_parallelPair {X Y : C} (f g : X ⟶ Y) : HasColimit (parallelPair
       _ = (coprod.inr ≫ coprod.desc (𝟙 Y) g) ≫ pushout.inr := by
         simp only [Category.assoc, pushout.condition]
       _ = g ≫ pushout.inr := by rw [coprod.inr_desc]
-      
+
   have huu : f ≫ (pushout.inl : Y ⟶ Q f g) = g ≫ pushout.inl := by rw [hvu, huv]
   HasColimit.mk
     { cocone := Cofork.ofπ pushout.inl huu
@@ -327,7 +327,7 @@ theorem mono_of_zero_kernel {X Y : C} (f : X ⟶ Y) (Z : C)
     by
     obtain ⟨W, w, hw, hl⟩ := normalEpiOfEpi (coequalizer.π u v)
     obtain ⟨m, hm⟩ := coequalizer.desc' f huv
-    have reassoced {W : C} (h : coequalizer u v ⟶  W) : w ≫ coequalizer.π u v ≫ h = 0 ≫ h := by 
+    have reassoced {W : C} (h : coequalizer u v ⟶  W) : w ≫ coequalizer.π u v ≫ h = 0 ≫ h := by
       rw [← Category.assoc, eq_whisker hw]
     have hwf : w ≫ f = 0 := by rw [← hm, reassoced, zero_comp]
     obtain ⟨n, hn⟩ := KernelFork.IsLimit.lift' l _ hwf
@@ -353,4 +353,3 @@ theorem mono_of_cancel_zero {X Y : C} (f : X ⟶ Y)
 end
 
 end CategoryTheory.NormalEpiCategory
-

--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullbacks.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullbacks.lean
@@ -1681,7 +1681,7 @@ theorem pullbackConeOfRightIso_π_app_left : (pullbackConeOfRightIso f g).π.app
 #align category_theory.limits.pullback_cone_of_right_iso_π_app_left CategoryTheory.Limits.pullbackConeOfRightIso_π_app_left
 
 @[simp]
-theorem pullbackConeOfRightIso_π_app_right : (pullbackConeOfRightIso f g).π.app right = f ≫ inv g 
+theorem pullbackConeOfRightIso_π_app_right : (pullbackConeOfRightIso f g).π.app right = f ≫ inv g
   := rfl
 #align category_theory.limits.pullback_cone_of_right_iso_π_app_right CategoryTheory.Limits.pullbackConeOfRightIso_π_app_right
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/RegularMono.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/RegularMono.lean
@@ -106,8 +106,8 @@ def regularOfIsPullbackSndOfRegular {P Q R S : C} {f : P ⟶ Q} {g : P ⟶ R} {h
   Z := hr.Z
   left := k ≫ hr.left
   right := k ≫ hr.right
-  w := by 
-    repeat (rw [← Category.assoc, ← eq_whisker comm]) 
+  w := by
+    repeat (rw [← Category.assoc, ← eq_whisker comm])
     simp only [Category.assoc, hr.w]
   isLimit := by
     apply Fork.IsLimit.mk' _ _
@@ -173,14 +173,14 @@ def regularMonoOfMono [RegularMonoCategory C] (f : X ⟶ Y) [Mono f] : RegularMo
 #align category_theory.regular_mono_of_mono CategoryTheory.regularMonoOfMono
 
 instance (priority := 100) regularMonoCategoryOfSplitMonoCategory [SplitMonoCategory C] :
-    RegularMonoCategory C where 
+    RegularMonoCategory C where
   regularMonoOfMono f _ := by
     haveI := isSplitMono_of_mono f
     infer_instance
 #align category_theory.regular_mono_category_of_split_mono_category CategoryTheory.regularMonoCategoryOfSplitMonoCategory
 
 instance (priority := 100) strongMonoCategory_of_regularMonoCategory [RegularMonoCategory C] :
-    StrongMonoCategory C where 
+    StrongMonoCategory C where
   strongMono_of_mono f _ := by
     haveI := regularMonoOfMono f
     infer_instance
@@ -315,7 +315,7 @@ def regularEpiOfEpi [RegularEpiCategory C] (f : X ⟶ Y) [Epi f] : RegularEpi f 
 #align category_theory.regular_epi_of_epi CategoryTheory.regularEpiOfEpi
 
 instance (priority := 100) regularEpiCategoryOfSplitEpiCategory [SplitEpiCategory C] :
-    RegularEpiCategory C where 
+    RegularEpiCategory C where
   regularEpiOfEpi f _ :=
     by
     haveI := isSplitEpi_of_epi f
@@ -330,4 +330,3 @@ instance (priority := 100) strongEpiCategory_of_regularEpiCategory [RegularEpiCa
 #align category_theory.strong_epi_category_of_regular_epi_category CategoryTheory.strongEpiCategory_of_regularEpiCategory
 
 end CategoryTheory
-

--- a/Mathlib/CategoryTheory/Limits/Shapes/SplitCoequalizer.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/SplitCoequalizer.lean
@@ -112,7 +112,7 @@ open Limits
 
 /-- A split coequalizer clearly induces a cofork. -/
 @[simps! pt]
-def IsSplitCoequalizer.asCofork {Z : C} {h : Y ⟶ Z} (t : IsSplitCoequalizer f g h) : 
+def IsSplitCoequalizer.asCofork {Z : C} {h : Y ⟶ Z} (t : IsSplitCoequalizer f g h) :
     Cofork f g := Cofork.ofπ h t.condition
 #align category_theory.is_split_coequalizer.as_cofork CategoryTheory.IsSplitCoequalizer.asCofork
 
@@ -189,4 +189,3 @@ instance (priority := 1) hasCoequalizer_of_hasSplitCoequalizer [HasSplitCoequali
 end Limits
 
 end CategoryTheory
-

--- a/Mathlib/CategoryTheory/Limits/Shapes/Terminal.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Terminal.lean
@@ -32,8 +32,8 @@ namespace CategoryTheory.Limits
 variable {C : Type u₁} [Category.{v₁} C]
 
 -- attribute [local tidy] tactic.discrete_cases -- Porting note: no tidy
-open Lean Elab Meta Tactic in 
-/- Porting note: adding a lightweight macro intended to serve the narrow use case of casing on 
+open Lean Elab Meta Tactic in
+/- Porting note: adding a lightweight macro intended to serve the narrow use case of casing on
 `Discrete PEmpty`. -/
 /-- A local tactic replacing the use of discrete cases on `PEmpty` in Lean 3.
 `dee` is short for `discrete_empty_elim`. -/
@@ -44,7 +44,7 @@ scoped elab (name := discrete_empty_elim) "dee" : tactic => withMainContext do
 @[simps]
 def asEmptyCone (X : C) : Cone (Functor.empty.{0} C) :=
   { pt := X
-    π := 
+    π :=
     { app := by dee
       naturality := by dee } }
 #align category_theory.limits.as_empty_cone CategoryTheory.Limits.asEmptyCone
@@ -53,7 +53,7 @@ def asEmptyCone (X : C) : Cone (Functor.empty.{0} C) :=
 @[simps]
 def asEmptyCocone (X : C) : Cocone (Functor.empty.{0} C) :=
   { pt := X
-    ι := 
+    ι :=
     { app := by dee
       naturality := by dee } }
 #align category_theory.limits.as_empty_cocone CategoryTheory.Limits.asEmptyCocone
@@ -70,27 +70,27 @@ abbrev IsInitial (X : C) :=
 
 /-- An object `Y` is terminal iff for every `X` there is a unique morphism `X ⟶ Y`. -/
 def isTerminalEquivUnique (F : Discrete.{0} PEmpty.{1} ⥤ C) (Y : C) :
-    IsLimit (⟨Y, (by dee), (by dee)⟩ : 
+    IsLimit (⟨Y, (by dee), (by dee)⟩ :
     Cone F) ≃ ∀ X : C, Unique (X ⟶ Y) where
   toFun t X :=
-    { default := t.lift ⟨X, ⟨(by dee),(by dee)⟩⟩ 
-      uniq := fun f => 
+    { default := t.lift ⟨X, ⟨(by dee),(by dee)⟩⟩
+      uniq := fun f =>
         t.uniq ⟨X, ⟨by dee, by dee⟩⟩ f (by dee) }
   invFun u :=
     { lift := fun s => (u s.pt).default
       fac := by dee
       uniq := fun s _ _ => (u s.pt).2 _ }
   left_inv := by dsimp [Function.LeftInverse]; intro x; simp only [eq_iff_true_of_subsingleton]
-  right_inv := by 
+  right_inv := by
     dsimp [Function.RightInverse,Function.LeftInverse]
     intro u; funext X; simp only
 #align category_theory.limits.is_terminal_equiv_unique CategoryTheory.Limits.isTerminalEquivUnique
 
 /-- An object `Y` is terminal if for every `X` there is a unique morphism `X ⟶ Y`
     (as an instance). -/
-def IsTerminal.ofUnique (Y : C) [h : ∀ X : C, Unique (X ⟶ Y)] : IsTerminal Y where 
-  lift s := (h s.pt).default 
-  fac := fun _ ⟨j⟩ => j.elim  
+def IsTerminal.ofUnique (Y : C) [h : ∀ X : C, Unique (X ⟶ Y)] : IsTerminal Y where
+  lift s := (h s.pt).default
+  fac := fun _ ⟨j⟩ => j.elim
 #align category_theory.limits.is_terminal.of_unique CategoryTheory.Limits.IsTerminal.ofUnique
 
 /-- If `α` is a preorder with top, then `⊤` is a terminal object. -/
@@ -113,19 +113,19 @@ def isInitialEquivUnique (F : Discrete.{0} PEmpty.{1} ⥤ C) (X : C) :
       uniq := fun f => t.uniq ⟨X, ⟨by dee, by dee⟩⟩ f (by dee) }
   invFun u :=
     { desc := fun s => (u s.pt).default
-      fac := by dee  
+      fac := by dee
       uniq := fun s _ _ => (u s.pt).2 _ }
   left_inv := by dsimp [Function.LeftInverse]; intro; simp only [eq_iff_true_of_subsingleton]
-  right_inv := by 
+  right_inv := by
     dsimp [Function.RightInverse,Function.LeftInverse]
-    intro; funext; simp only 
+    intro; funext; simp only
 #align category_theory.limits.is_initial_equiv_unique CategoryTheory.Limits.isInitialEquivUnique
 
 /-- An object `X` is initial if for every `Y` there is a unique morphism `X ⟶ Y`
     (as an instance). -/
-def IsInitial.ofUnique (X : C) [h : ∀ Y : C, Unique (X ⟶ Y)] : IsInitial X where 
+def IsInitial.ofUnique (X : C) [h : ∀ Y : C, Unique (X ⟶ Y)] : IsInitial X where
   desc s := (h s.pt).default
-  fac := fun _ ⟨j⟩ => j.elim 
+  fac := fun _ ⟨j⟩ => j.elim
 #align category_theory.limits.is_initial.of_unique CategoryTheory.Limits.IsInitial.ofUnique
 
 /-- If `α` is a preorder with bot, then `⊥` is an initial object. -/
@@ -241,8 +241,8 @@ def isLimitChangeEmptyCone {c₁ : Cone F₁} (hl : IsLimit c₁) (c₂ : Cone F
     IsLimit c₂ where
   lift c := hl.lift ⟨c.pt, by dee, by dee⟩ ≫ hi.hom
   fac _ j := j.as.elim
-  uniq c f _ := by 
-    dsimp 
+  uniq c f _ := by
+    dsimp
     rw [← hl.uniq _ (f ≫ hi.inv) _]
     · simp only [Category.assoc, Iso.inv_hom_id, Category.comp_id]
     · dee
@@ -250,14 +250,14 @@ def isLimitChangeEmptyCone {c₁ : Cone F₁} (hl : IsLimit c₁) (c₂ : Cone F
 
 /-- Replacing an empty cone in `IsLimit` by another with the same cone point
     is an equivalence. -/
-def isLimitEmptyConeEquiv (c₁ : Cone F₁) (c₂ : Cone F₂) (h : c₁.pt ≅ c₂.pt) : 
+def isLimitEmptyConeEquiv (c₁ : Cone F₁) (c₂ : Cone F₂) (h : c₁.pt ≅ c₂.pt) :
     IsLimit c₁ ≃ IsLimit c₂ where
   toFun hl := isLimitChangeEmptyCone C hl c₂ h
   invFun hl := isLimitChangeEmptyCone C hl c₁ h.symm
-  left_inv := by dsimp [Function.LeftInverse]; intro; simp only [eq_iff_true_of_subsingleton] 
-  right_inv := by 
+  left_inv := by dsimp [Function.LeftInverse]; intro; simp only [eq_iff_true_of_subsingleton]
+  right_inv := by
     dsimp [Function.LeftInverse,Function.RightInverse]; intro; funext
-    simp only [eq_iff_true_of_subsingleton] 
+    simp only [eq_iff_true_of_subsingleton]
 #align category_theory.limits.is_limit_empty_cone_equiv CategoryTheory.Limits.isLimitEmptyConeEquiv
 
 theorem hasTerminalChangeDiagram (h : HasLimit F₁) : HasLimit F₂ :=
@@ -281,8 +281,8 @@ def isColimitChangeEmptyCocone {c₁ : Cocone F₁} (hl : IsColimit c₁) (c₂ 
   fac _ j := j.as.elim
   uniq c f _ := by
     dsimp
-    rw [← hl.uniq _ (hi.hom ≫ f) _] 
-    · simp only [Iso.inv_hom_id_assoc] 
+    rw [← hl.uniq _ (hi.hom ≫ f) _]
+    · simp only [Iso.inv_hom_id_assoc]
     · dee
 #align category_theory.limits.is_colimit_change_empty_cocone CategoryTheory.Limits.isColimitChangeEmptyCocone
 
@@ -292,14 +292,14 @@ def isColimitEmptyCoconeEquiv (c₁ : Cocone F₁) (c₂ : Cocone F₂) (h : c�
     IsColimit c₁ ≃ IsColimit c₂ where
   toFun hl := isColimitChangeEmptyCocone C hl c₂ h
   invFun hl := isColimitChangeEmptyCocone C hl c₁ h.symm
-  left_inv := by dsimp [Function.LeftInverse]; intro; simp only [eq_iff_true_of_subsingleton] 
-  right_inv := by 
+  left_inv := by dsimp [Function.LeftInverse]; intro; simp only [eq_iff_true_of_subsingleton]
+  right_inv := by
     dsimp [Function.LeftInverse,Function.RightInverse]; intro; funext
     simp only [eq_iff_true_of_subsingleton]
 #align category_theory.limits.is_colimit_empty_cocone_equiv CategoryTheory.Limits.isColimitEmptyCoconeEquiv
 
 theorem hasInitialChangeDiagram (h : HasColimit F₁) : HasColimit F₂ :=
-  ⟨⟨⟨⟨colimit F₁, by dee, by dee⟩, 
+  ⟨⟨⟨⟨colimit F₁, by dee, by dee⟩,
     isColimitChangeEmptyCocone C (colimit.isColimit F₁) _ (eqToIso rfl)⟩⟩⟩
 #align category_theory.limits.has_initial_change_diagram CategoryTheory.Limits.hasInitialChangeDiagram
 
@@ -347,7 +347,7 @@ theorem hasTerminal_of_unique (X : C) [h : ∀ Y : C, Unique (Y ⟶ X)] : HasTer
 #align category_theory.limits.has_terminal_of_unique CategoryTheory.Limits.hasTerminal_of_unique
 
 theorem IsTerminal.hasTerminal {X : C} (h : IsTerminal X) : HasTerminal C :=
-  { has_limit := fun F => HasLimit.mk ⟨⟨X, by dee, by dee⟩, 
+  { has_limit := fun F => HasLimit.mk ⟨⟨X, by dee, by dee⟩,
     isLimitChangeEmptyCone _ h _ (Iso.refl _)⟩ }
 #align category_theory.limits.is_terminal.has_terminal CategoryTheory.Limits.IsTerminal.hasTerminal
 
@@ -374,16 +374,16 @@ abbrev initial.to [HasInitial C] (P : C) : ⊥_ C ⟶ P :=
 #align category_theory.limits.initial.to CategoryTheory.Limits.initial.to
 
 /-- A terminal object is terminal. -/
-def terminalIsTerminal [HasTerminal C] : IsTerminal (⊤_ C) where 
+def terminalIsTerminal [HasTerminal C] : IsTerminal (⊤_ C) where
   lift s := terminal.from _
-  fac := by dee 
+  fac := by dee
   uniq := by intro _ _ _; dsimp; ext ⟨j⟩; dsimp; cases j
 #align category_theory.limits.terminal_is_terminal CategoryTheory.Limits.terminalIsTerminal
 
 /-- An initial object is initial. -/
-def initialIsInitial [HasInitial C] : IsInitial (⊥_ C) where 
+def initialIsInitial [HasInitial C] : IsInitial (⊥_ C) where
   desc s := initial.to _
-  fac := by dee 
+  fac := by dee
   uniq := by intro _ _ _; dsimp; ext ⟨j⟩; dsimp; cases j
 #align category_theory.limits.initial_is_initial CategoryTheory.Limits.initialIsInitial
 
@@ -494,7 +494,7 @@ def limitConstTerminal {J : Type _} [Category J] {C : Type _} [Category C] [HasT
 theorem limitConstTerminal_inv_π {J : Type _} [Category J] {C : Type _} [Category C] [HasTerminal C]
     {j : J} :
     limitConstTerminal.inv ≫ limit.π ((CategoryTheory.Functor.const J).obj (⊤_ C)) j =
-      terminal.from _ := by 
+      terminal.from _ := by
         apply Limits.limit.hom_ext; dee
 #align category_theory.limits.limit_const_terminal_inv_π CategoryTheory.Limits.limitConstTerminal_inv_π
 
@@ -533,7 +533,7 @@ to terminal is a monomorphism, which is the second of Freyd's axioms for an AT c
 TODO: This is a condition satisfied by categories with zero objects and morphisms.
 -/
 class InitialMonoClass (C : Type u₁) [Category.{v₁} C] : Prop where
-  /-- The map from the (any as stated) initial object to any other object is a 
+  /-- The map from the (any as stated) initial object to any other object is a
     monomorphism -/
   isInitial_mono_from : ∀ {I} (X : C) (hI : IsInitial I), Mono (hI.to X)
 #align category_theory.limits.initial_mono_class CategoryTheory.Limits.InitialMonoClass
@@ -625,7 +625,7 @@ def limitOfDiagramInitial {X : J} (tX : IsInitial X) (F : J ⥤ C) :
     IsLimit (coneOfDiagramInitial tX F) where
   lift s := s.π.app X
   uniq s m w := by
-    conv_lhs => dsimp  
+    conv_lhs => dsimp
     simp_rw [← w X, coneOfDiagramInitial_π_app, tX.hom_ext (tX.to X) (𝟙 _)]
     dsimp; simp
 #align category_theory.limits.limit_of_diagram_initial CategoryTheory.Limits.limitOfDiagramInitial
@@ -658,7 +658,7 @@ def coneOfDiagramTerminal {X : J} (hX : IsTerminal X) (F : J ⥤ C)
 /-- From a functor `F : J ⥤ C`, given a terminal object of `J` and that the morphisms in the
 diagram are isomorphisms, show the cone `cone_of_diagram_terminal` is a limit. -/
 def limitOfDiagramTerminal {X : J} (hX : IsTerminal X) (F : J ⥤ C)
-    [∀ (i j : J) (f : i ⟶ j), IsIso (F.map f)] : IsLimit (coneOfDiagramTerminal hX F) where 
+    [∀ (i j : J) (f : i ⟶ j), IsIso (F.map f)] : IsLimit (coneOfDiagramTerminal hX F) where
   lift S := S.π.app _
 #align category_theory.limits.limit_of_diagram_terminal CategoryTheory.Limits.limitOfDiagramTerminal
 
@@ -722,7 +722,7 @@ def coconeOfDiagramInitial {X : J} (hX : IsInitial X) (F : J ⥤ C)
 /-- From a functor `F : J ⥤ C`, given an initial object of `J` and that the morphisms in the
 diagram are isomorphisms, show the cone `cocone_of_diagram_initial` is a colimit. -/
 def colimitOfDiagramInitial {X : J} (hX : IsInitial X) (F : J ⥤ C)
-    [∀ (i j : J) (f : i ⟶ j), IsIso (F.map f)] : IsColimit (coconeOfDiagramInitial hX F) where 
+    [∀ (i j : J) (f : i ⟶ j), IsIso (F.map f)] : IsColimit (coconeOfDiagramInitial hX F) where
   desc S := S.ι.app _
 #align category_theory.limits.colimit_of_diagram_initial CategoryTheory.Limits.colimitOfDiagramInitial
 
@@ -778,11 +778,11 @@ instance isIso_ι_terminal [HasTerminal J] (F : J ⥤ C) [HasColimit F] : IsIso 
 
 theorem isIso_ι_of_isInitial {j : J} (I : IsInitial j) (F : J ⥤ C) [HasColimit F]
     [∀ (i j : J) (f : i ⟶ j), IsIso (F.map f)] : IsIso (colimit.ι F j) :=
-  ⟨⟨colimit.desc _ (coconeOfDiagramInitial I F), by 
+  ⟨⟨colimit.desc _ (coconeOfDiagramInitial I F), by
     refine ⟨?_, by ext; simp⟩
-    dsimp; simp only [colimit.ι_desc, coconeOfDiagramInitial_pt, coconeOfDiagramInitial_ι_app, 
+    dsimp; simp only [colimit.ι_desc, coconeOfDiagramInitial_pt, coconeOfDiagramInitial_ι_app,
       Functor.const_obj_obj, IsInitial.to_self, Functor.map_id]
-    dsimp [inv]; simp only [Category.id_comp, Category.comp_id, and_self] 
+    dsimp [inv]; simp only [Category.id_comp, Category.comp_id, and_self]
     apply @Classical.choose_spec _ (fun x => x = 𝟙 F.obj j) _
   ⟩⟩
 #align category_theory.limits.is_iso_ι_of_is_initial CategoryTheory.Limits.isIso_ι_of_isInitial
@@ -795,4 +795,3 @@ instance isIso_ι_initial [HasInitial J] (F : J ⥤ C) [HasColimit F]
 end
 
 end CategoryTheory.Limits
-

--- a/Mathlib/CategoryTheory/Limits/Shapes/ZeroMorphisms.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/ZeroMorphisms.lean
@@ -81,7 +81,7 @@ theorem zero_comp [HasZeroMorphisms C] {X : C} {Y Z : C} {f : Y ⟶ Z} :
 instance hasZeroMorphismsPempty : HasZeroMorphisms (Discrete PEmpty) where Zero := by dee
 #align category_theory.limits.has_zero_morphisms_pempty CategoryTheory.Limits.hasZeroMorphismsPempty
 
-instance hasZeroMorphismsPunit : HasZeroMorphisms (Discrete PUnit) where 
+instance hasZeroMorphismsPunit : HasZeroMorphisms (Discrete PUnit) where
   Zero := fun X Y => by repeat (constructor)
 #align category_theory.limits.has_zero_morphisms_punit CategoryTheory.Limits.hasZeroMorphismsPunit
 
@@ -90,12 +90,12 @@ namespace HasZeroMorphisms
 /-- This lemma will be immediately superseded by `ext`, below. -/
 private theorem ext_aux (I J : HasZeroMorphisms C)
     (w : ∀ X Y : C, (I.Zero X Y).zero = (J.Zero X Y).zero) : I = J := by
-  have : I.Zero = J.Zero := by 
+  have : I.Zero = J.Zero := by
     funext X Y
-    specialize w X Y 
+    specialize w X Y
     apply congrArg Zero.mk w
   cases I; cases J
-  congr 
+  congr
   · apply proof_irrel_heq
   · apply proof_irrel_heq
 -- Porting note: private def; no align
@@ -109,10 +109,10 @@ See, particularly, the note on `zeroMorphismsOfZeroObject` below.
 theorem ext (I J : HasZeroMorphisms C) : I = J := by
   apply ext_aux
   intro X Y
-  have : (I.Zero X Y).zero ≫ (J.Zero Y Y).zero = (I.Zero X Y).zero := by 
+  have : (I.Zero X Y).zero ≫ (J.Zero Y Y).zero = (I.Zero X Y).zero := by
     apply I.zero_comp X (J.Zero Y Y).zero
-  have that : (I.Zero X Y).zero ≫ (J.Zero Y Y).zero = (J.Zero X Y).zero := by 
-    apply J.comp_zero (I.Zero X Y).zero Y 
+  have that : (I.Zero X Y).zero ≫ (J.Zero Y Y).zero = (J.Zero X Y).zero := by
+    apply J.comp_zero (I.Zero X Y).zero Y
   rw[←this,←that]
 #align category_theory.limits.has_zero_morphisms.ext CategoryTheory.Limits.HasZeroMorphisms.ext
 
@@ -126,7 +126,7 @@ open Opposite HasZeroMorphisms
 instance hasZeroMorphismsOpposite [HasZeroMorphisms C] : HasZeroMorphisms Cᵒᵖ where
   Zero X Y := ⟨(0 : unop Y ⟶ unop X).op⟩
   comp_zero f Z := congr_arg Quiver.Hom.op (HasZeroMorphisms.zero_comp (unop Z) f.unop)
-  zero_comp X {Y Z} (f : Y ⟶  Z) := 
+  zero_comp X {Y Z} (f : Y ⟶  Z) :=
     congrArg Quiver.Hom.op (HasZeroMorphisms.comp_zero f.unop (unop X))
 #align category_theory.limits.has_zero_morphisms_opposite CategoryTheory.Limits.hasZeroMorphismsOpposite
 
@@ -158,12 +158,12 @@ section
 
 variable [HasZeroMorphisms D]
 
-instance : HasZeroMorphisms (C ⥤ D) where 
+instance : HasZeroMorphisms (C ⥤ D) where
   Zero F G := ⟨{ app := fun X => 0 }⟩
-  comp_zero := fun η H => by 
-    ext X; dsimp; apply comp_zero 
-  zero_comp := fun F {G H} η => by 
-    ext X; dsimp; apply zero_comp 
+  comp_zero := fun η H => by
+    ext X; dsimp; apply comp_zero
+  zero_comp := fun F {G H} η => by
+    ext X; dsimp; apply zero_comp
 
 @[simp]
 theorem zero_app (F G : C ⥤ D) (j : C) : (0 : F ⟶ G).app j = 0 := rfl
@@ -185,9 +185,9 @@ theorem eq_zero_of_tgt {X Y : C} (o : IsZero Y) (f : X ⟶ Y) : f = 0 :=
 
 theorem iff_id_eq_zero (X : C) : IsZero X ↔ 𝟙 X = 0 :=
   ⟨fun h => h.eq_of_src _ _, fun h =>
-    ⟨fun Y => ⟨⟨⟨0⟩, fun f => by 
+    ⟨fun Y => ⟨⟨⟨0⟩, fun f => by
         rw [← id_comp f, ← id_comp (0: X ⟶ Y), h, zero_comp, zero_comp]; simp only⟩⟩,
-    fun Y => ⟨⟨⟨0⟩, fun f => by 
+    fun Y => ⟨⟨⟨0⟩, fun f => by
         rw [← comp_id f, ← comp_id (0 : Y ⟶  X), h, comp_zero, comp_zero]; simp only ⟩⟩⟩⟩
 #align category_theory.limits.is_zero.iff_id_eq_zero CategoryTheory.Limits.IsZero.iff_id_eq_zero
 
@@ -253,7 +253,7 @@ end IsZero
     asks for an instance of `HasZeroObjects`. -/
 def IsZero.hasZeroMorphisms {O : C} (hO : IsZero O) : HasZeroMorphisms C where
   Zero X Y := { zero := hO.from_ X ≫ hO.to_ Y }
-  zero_comp X {Y Z} f := by 
+  zero_comp X {Y Z} f := by
     change (hO.from_ X ≫ hO.to_ Y) ≫ f = hO.from_ X ≫ hO.to_ Z
     rw [Category.assoc]
     congr
@@ -282,12 +282,12 @@ open ZeroObject
 def zeroMorphismsOfZeroObject : HasZeroMorphisms C where
   Zero X Y := { zero := (default : X ⟶ 0) ≫ default }
   zero_comp X {Y Z} f := by
-    change ( (default : X ⟶  0)  ≫ default) ≫ f = (default : X ⟶  0) ≫ default 
+    change ( (default : X ⟶  0)  ≫ default) ≫ f = (default : X ⟶  0) ≫ default
     rw [Category.assoc]
     congr
     simp only [eq_iff_true_of_subsingleton]
   comp_zero {X Y} f Z := by
-    change f ≫ (default : Y ⟶  0)  ≫ default = (default : X ⟶  0) ≫ default 
+    change f ≫ (default : Y ⟶  0)  ≫ default = (default : X ⟶  0) ≫ default
     rw [← Category.assoc]
     congr
     simp only [eq_iff_true_of_subsingleton]
@@ -349,13 +349,13 @@ theorem IsZero.map [HasZeroObject D] [HasZeroMorphisms D] {F : C ⥤ D} (hF : Is
 #align category_theory.limits.is_zero.map CategoryTheory.Limits.IsZero.map
 
 @[simp]
-theorem _root_.CategoryTheory.Functor.zero_obj [HasZeroObject D] (X : C) : 
+theorem _root_.CategoryTheory.Functor.zero_obj [HasZeroObject D] (X : C) :
     IsZero ((0 : C ⥤ D).obj X) :=
   (isZero_zero _).obj _
 #align category_theory.functor.zero_obj CategoryTheory.Functor.zero_obj
 
 @[simp]
-theorem _root_.CategoryTheory.zero_map [HasZeroObject D] [HasZeroMorphisms D] {X Y : C} 
+theorem _root_.CategoryTheory.zero_map [HasZeroObject D] [HasZeroMorphisms D] {X Y : C}
     (f : X ⟶ Y) : (0 : C ⥤ D).map f = 0 :=
   (isZero_zero _).map _
 #align category_theory.zero_map CategoryTheory.zero_map
@@ -377,7 +377,7 @@ theorem zero_of_to_zero {X : C} (f : X ⟶ 0) : f = 0 := by ext
 
 theorem zero_of_target_iso_zero {X Y : C} (f : X ⟶ Y) (i : Y ≅ 0) : f = 0 := by
   have h : f = f ≫ i.hom ≫ 𝟙 0 ≫ i.inv := by simp only [Iso.hom_inv_id, id_comp, comp_id]
-  simpa using h 
+  simpa using h
 #align category_theory.limits.zero_of_target_iso_zero CategoryTheory.Limits.zero_of_target_iso_zero
 
 /-- An arrow starting at the zero object is zero -/
@@ -464,9 +464,9 @@ def isoOfIsIsomorphicZero {X : C} (P : IsIsomorphic X 0) : X ≅ 0 where
   hom_inv_id := by
     cases' P with P
     rw [←P.hom_inv_id,←Category.id_comp P.inv]
-    apply Eq.symm 
+    apply Eq.symm
     simp only [id_comp, Iso.hom_inv_id, comp_zero]
-    apply (idZeroEquivIsoZero X).invFun P 
+    apply (idZeroEquivIsoZero X).invFun P
   inv_hom_id := by simp
 #align category_theory.limits.iso_of_is_isomorphic_zero CategoryTheory.Limits.isoOfIsIsomorphicZero
 
@@ -491,8 +491,8 @@ def isIsoZeroEquiv (X Y : C) : IsIso (0 : X ⟶ Y) ≃ 𝟙 X = 0 ∧ 𝟙 Y = 0
   right_inv := by aesop_cat
 #align category_theory.limits.is_iso_zero_equiv CategoryTheory.Limits.isIsoZeroEquiv
 
--- Porting note: simp solves these 
-attribute [-simp, nolint simpNF] isIsoZeroEquiv_apply isIsoZeroEquiv_symm_apply 
+-- Porting note: simp solves these
+attribute [-simp, nolint simpNF] isIsoZeroEquiv_apply isIsoZeroEquiv_symm_apply
 
 /-- A zero morphism `0 : X ⟶ X` is an isomorphism if and only if
 the identity on `X` is zero.
@@ -547,7 +547,7 @@ theorem hasZeroObject_of_hasInitial_object [HasZeroMorphisms C] [HasInitial C] :
     f = f ≫ 𝟙 _ := (Category.comp_id _).symm
     _ = f ≫ 0 := by congr!
     _ = 0 := HasZeroMorphisms.comp_zero _ _
-    
+
 #align category_theory.limits.has_zero_object_of_has_initial_object CategoryTheory.Limits.hasZeroObject_of_hasInitial_object
 
 /-- If there are zero morphisms, any terminal object is a zero object. -/
@@ -558,7 +558,7 @@ theorem hasZeroObject_of_hasTerminal_object [HasZeroMorphisms C] [HasTerminal C]
     f = 𝟙 _ ≫ f := (Category.id_comp _).symm
     _ = 0 ≫ f := by congr!
     _ = 0 := zero_comp
-    
+
 #align category_theory.limits.has_zero_object_of_has_terminal_object CategoryTheory.Limits.hasZeroObject_of_hasTerminal_object
 
 section Image
@@ -666,4 +666,3 @@ instance isSplitEpi_prod_snd [HasZeroMorphisms C] {X Y : C} [HasLimit (pair X Y)
 #align category_theory.limits.is_split_epi_prod_snd CategoryTheory.Limits.isSplitEpi_prod_snd
 
 end CategoryTheory.Limits
-

--- a/Mathlib/CategoryTheory/Limits/Yoneda.lean
+++ b/Mathlib/CategoryTheory/Limits/Yoneda.lean
@@ -55,7 +55,7 @@ def colimitCoconeIsColimit (X : Cᵒᵖ) : IsColimit (colimitCocone X)
     convert congr_fun (s.w f).symm (𝟙 (unop X))
     simp
   uniq s m w := by
-    apply funext; rintro ⟨⟩ 
+    apply funext; rintro ⟨⟩
     dsimp
     rw [← w]
     simp
@@ -130,7 +130,7 @@ def yonedaJointlyReflectsLimits (J : Type w) [SmallCategory J] (K : J ⥤ Cᵒ�
       suffices (fun _ : PUnit => m.unop) = (t s.pt.unop).lift (s' s) by
         apply congr_fun this PUnit.unit
       apply (t _).uniq (s' s) _ fun j => _
-      intro j 
+      intro j
       funext
       exact Quiver.Hom.op_inj (w j) }
 #align category_theory.yoneda_jointly_reflects_limits CategoryTheory.yonedaJointlyReflectsLimits
@@ -182,4 +182,3 @@ end CategoryTheory
 -- assert_not_exists Set.range
 
 -- assert_not_exists AddCommMonoid
-

--- a/Mathlib/CategoryTheory/Over.lean
+++ b/Mathlib/CategoryTheory/Over.lean
@@ -41,10 +41,10 @@ triangles.
 See <https://stacks.math.columbia.edu/tag/001G>.
 -/
 def Over (X : T) :=
-  CostructuredArrow (𝟭 T) X 
+  CostructuredArrow (𝟭 T) X
 #align category_theory.over CategoryTheory.Over
 
-instance (X : T) : Category (Over X) := commaCategory 
+instance (X : T) : Category (Over X) := commaCategory
 
 -- Satisfying the inhabited linter
 instance Over.inhabited [Inhabited T] : Inhabited (Over (default : T))
@@ -61,14 +61,14 @@ variable {X : T}
 @[ext]
 theorem OverMorphism.ext {X : T} {U V : Over X} {f g : U ⟶ V} (h : f.left = g.left) : f = g := by
   let ⟨_,b,_⟩ := f
-  let ⟨_,e,_⟩ := g 
+  let ⟨_,e,_⟩ := g
   congr
   simp only [eq_iff_true_of_subsingleton]
 
 #align category_theory.over.over_morphism.ext CategoryTheory.Over.OverMorphism.ext
 
--- @[simp] : Porting note : simp can prove this 
-theorem over_right (U : Over X) : U.right = ⟨⟨⟩⟩ := by simp only 
+-- @[simp] : Porting note : simp can prove this
+theorem over_right (U : Over X) : U.right = ⟨⟨⟩⟩ := by simp only
 #align category_theory.over.over_right CategoryTheory.Over.over_right
 
 @[simp]
@@ -199,9 +199,9 @@ def mapComp {Y Z : T} (f : X ⟶ Y) (g : Y ⟶ Z) : map (f ≫ g) ≅ map f ⋙ 
 
 end
 
-instance forget_reflects_iso : ReflectsIsomorphisms (forget X) where 
-  reflects {Y Z} f t := by 
-    let g :Z ⟶  Y := Over.homMk (inv ((forget X).map f)) 
+instance forget_reflects_iso : ReflectsIsomorphisms (forget X) where
+  reflects {Y Z} f t := by
+    let g :Z ⟶  Y := Over.homMk (inv ((forget X).map f))
       ((asIso ((forget X).map f)).inv_comp_eq.2 (Over.w f).symm)
     dsimp [forget] at t
     refine ⟨⟨g, ⟨?_,?_⟩⟩⟩
@@ -275,7 +275,7 @@ def iteratedSliceEquiv : Over f ≌ Over f.left
   functor := iteratedSliceForward f
   inverse := iteratedSliceBackward f
   unitIso :=
-    NatIso.ofComponents (fun g => Over.isoMk (Over.isoMk (Iso.refl _) 
+    NatIso.ofComponents (fun g => Over.isoMk (Over.isoMk (Iso.refl _)
       (by aesop_cat)) (by aesop_cat)) fun g => by ext; dsimp; simp
   counitIso :=
     NatIso.ofComponents (fun g => Over.isoMk (Iso.refl _) (by aesop_cat)) fun g =>
@@ -332,13 +332,13 @@ variable {X : T}
 
 @[ext]
 theorem UnderMorphism.ext {X : T} {U V : Under X} {f g : U ⟶ V} (h : f.right = g.right) : f = g :=
-  by 
+  by
   let ⟨_,b,_⟩ := f; let ⟨_,e,_⟩ := g
   congr; simp only [eq_iff_true_of_subsingleton]
 #align category_theory.under.under_morphism.ext CategoryTheory.Under.UnderMorphism.ext
 
 -- @[simp] Porting note: simp can prove this
-theorem under_left (U : Under X) : U.left = ⟨⟨⟩⟩ := by simp only 
+theorem under_left (U : Under X) : U.left = ⟨⟨⟩⟩ := by simp only
 #align category_theory.under.under_left CategoryTheory.Under.under_left
 
 @[simp]
@@ -454,9 +454,9 @@ def mapComp {Y Z : T} (f : X ⟶ Y) (g : Y ⟶ Z) : map (f ≫ g) ≅ map g ⋙ 
 
 end
 
-instance forget_reflects_iso : ReflectsIsomorphisms (forget X) where 
-  reflects {Y Z} f t := by 
-    let g : Z ⟶  Y := Under.homMk (inv ((Under.forget X).map f)) 
+instance forget_reflects_iso : ReflectsIsomorphisms (forget X) where
+  reflects {Y Z} f t := by
+    let g : Z ⟶  Y := Under.homMk (inv ((Under.forget X).map f))
       ((IsIso.comp_inv_eq _).2 (Under.w f).symm)
     dsimp [forget] at t
     refine ⟨⟨g, ⟨?_,?_⟩⟩⟩
@@ -495,7 +495,7 @@ The converse of `CategoryTheory.under.epi_of_epi_right`.
 instance epi_right_of_epi {f g : Under X} (k : f ⟶ g) [Epi k] : Epi k.right := by
   refine' ⟨fun { Y : T } l m a => _⟩
   let l' : g ⟶ mk (g.hom ≫ m) := homMk l (by
-    dsimp; rw [← Under.w k, Category.assoc, a, Category.assoc]) 
+    dsimp; rw [← Under.w k, Category.assoc, a, Category.assoc])
   -- Porting note: add type ascription here to `homMk m`
   suffices l' = (homMk m  : g ⟶  mk (g.hom ≫ m)) by apply congrArg CommaMorphism.right this
   rw [← cancel_epi k]; ext; apply a
@@ -517,4 +517,3 @@ end
 end Under
 
 end CategoryTheory
-

--- a/Mathlib/CategoryTheory/PEmpty.lean
+++ b/Mathlib/CategoryTheory/PEmpty.lean
@@ -25,33 +25,33 @@ namespace CategoryTheory
 namespace Functor
 
 variable (C : Type u) [Category.{v} C]
-/- Porting note: `aesop_cat` could not close any of the goals `tidy` did. 
+/- Porting note: `aesop_cat` could not close any of the goals `tidy` did.
 Switched to more explict construction -/
 /-- Equivalence between two empty categories. -/
-def emptyEquivalence : Discrete.{w} PEmpty ≌ Discrete.{v} PEmpty where 
-  functor := 
+def emptyEquivalence : Discrete.{w} PEmpty ≌ Discrete.{v} PEmpty where
+  functor :=
     { obj := PEmpty.elim ∘ Discrete.as
-      map := fun {X} _ _ => X.as.elim 
+      map := fun {X} _ _ => X.as.elim
       map_comp := fun {X} _ _ _ _ => X.as.elim }
-  inverse := 
+  inverse :=
     { obj := PEmpty.elim ∘ Discrete.as
-      map := fun {X} _ _ => X.as.elim  
+      map := fun {X} _ _ => X.as.elim
       map_comp := fun {X} _ _ _ _ => X.as.elim }
-  unitIso := 
-    { hom := 
-        { app := fun X => X.as.elim 
+  unitIso :=
+    { hom :=
+        { app := fun X => X.as.elim
           naturality := fun {X} _ _ => X.as.elim }
-      inv := 
-        { app := fun X => X.as.elim 
+      inv :=
+        { app := fun X => X.as.elim
           naturality := fun {X} _ _ => X.as.elim } }
-  counitIso := 
-    { hom := 
-        { app := fun X => X.as.elim 
+  counitIso :=
+    { hom :=
+        { app := fun X => X.as.elim
           naturality := fun {X} _ _ => X.as.elim }
-      inv := 
-        { app := fun X => X.as.elim 
+      inv :=
+        { app := fun X => X.as.elim
           naturality := fun {X} _ _ => X.as.elim } }
-  functor_unitIso_comp := fun X => X.as.elim  
+  functor_unitIso_comp := fun X => X.as.elim
 #align category_theory.functor.empty_equivalence CategoryTheory.Functor.emptyEquivalence
 
 /-- The canonical functor out of the empty category. -/
@@ -83,4 +83,3 @@ theorem empty_ext' (F G : Discrete.{w} PEmpty ⥤ C) : F = G :=
 end Functor
 
 end CategoryTheory
-

--- a/Mathlib/CategoryTheory/PUnit.lean
+++ b/Mathlib/CategoryTheory/PUnit.lean
@@ -30,28 +30,28 @@ variable (C : Type u) [Category.{v} C]
 namespace Functor
 
 /-- The constant functor sending everything to `PUnit.star`. -/
-@[simps!] 
+@[simps!]
 def star : C ⥤ Discrete PUnit :=
   (Functor.const _).obj ⟨⟨⟩⟩
 #align category_theory.functor.star CategoryTheory.Functor.star
--- Porting note: simp can simplify this 
+-- Porting note: simp can simplify this
 attribute [nolint simpNF] star_map_down_down
 variable {C}
 
 /-- Any two functors to `Discrete PUnit` are isomorphic. -/
-@[simps!] 
+@[simps!]
 def pUnitExt (F G : C ⥤ Discrete PUnit) : F ≅ G := by
   refine NatIso.ofComponents (fun X => eqToIso ?_) fun {X} {Y} f => ?_
   · simp only [eq_iff_true_of_subsingleton]
-  · aesop_cat 
+  · aesop_cat
 #align category_theory.functor.punit_ext CategoryTheory.Functor.pUnitExt
--- Porting note: simp does indeed fire for these despite the linter warning 
-attribute [nolint simpNF] pUnitExt_hom_app_down_down pUnitExt_inv_app_down_down 
+-- Porting note: simp does indeed fire for these despite the linter warning
+attribute [nolint simpNF] pUnitExt_hom_app_down_down pUnitExt_inv_app_down_down
 
 /-- Any two functors to `Discrete PUnit` are *equal*.
 You probably want to use `pUnitExt` instead of this. -/
-theorem pUnit_ext' (F G : C ⥤ Discrete PUnit) : F = G := by 
-  refine Functor.ext (fun X => ?_) fun {X} {Y} f => ?_ 
+theorem pUnit_ext' (F G : C ⥤ Discrete PUnit) : F = G := by
+  refine Functor.ext (fun X => ?_) fun {X} {Y} f => ?_
   · simp only [eq_iff_true_of_subsingleton]
   · aesop_cat
 #align category_theory.functor.punit_ext' CategoryTheory.Functor.pUnit_ext'
@@ -87,7 +87,7 @@ def equiv : Discrete PUnit ⥤ C ≌ C where
 end Functor
 
 /-- A category being equivalent to `PUnit` is equivalent to it having a unique morphism between
-  any two objects. (In fact, such a category is also a groupoid; 
+  any two objects. (In fact, such a category is also a groupoid;
   see `CategoryTheory.Groupoid.ofHomUnique`) -/
 theorem equiv_pUnit_iff_unique :
     Nonempty (C ≌ Discrete PUnit) ↔ Nonempty C ∧ ∀ x y : C, Nonempty <| Unique (x ⟶ y) := by
@@ -113,7 +113,7 @@ theorem equiv_pUnit_iff_unique :
     haveI := fun x y => (h x y).some
     refine'
       Nonempty.intro
-        (CategoryTheory.Equivalence.mk ((Functor.const _).obj ⟨⟨⟩⟩) 
+        (CategoryTheory.Equivalence.mk ((Functor.const _).obj ⟨⟨⟩⟩)
           ((@Functor.const <| Discrete PUnit).obj p) ?_ (by apply Functor.pUnitExt))
     exact
       NatIso.ofComponents
@@ -124,4 +124,3 @@ theorem equiv_pUnit_iff_unique :
 #align category_theory.equiv_punit_iff_unique CategoryTheory.equiv_pUnit_iff_unique
 
 end CategoryTheory
-

--- a/Mathlib/CategoryTheory/Preadditive/Basic.lean
+++ b/Mathlib/CategoryTheory/Preadditive/Basic.lean
@@ -74,7 +74,7 @@ attribute [inherit_doc Preadditive] Preadditive.homGroup Preadditive.add_comp Pr
 
 attribute [instance] Preadditive.homGroup
 
--- Porting note: simp can prove reassoc version 
+-- Porting note: simp can prove reassoc version
 attribute [reassoc, simp] Preadditive.add_comp
 
 attribute [reassoc] Preadditive.comp_add
@@ -206,19 +206,19 @@ instance (priority := 100) preadditiveHasZeroMorphisms : HasZeroMorphisms C wher
   zero_comp P _ _ f := show rightComp P f 0 = 0 from map_zero _
 #align category_theory.preadditive.preadditive_has_zero_morphisms CategoryTheory.Preadditive.preadditiveHasZeroMorphisms
 
-/--Porting note: adding this before the ring instance allowed moduleEndRight to find 
-the correct Monoid structure on End. Moved both down after preadditiveHasZeroMorphisms 
+/--Porting note: adding this before the ring instance allowed moduleEndRight to find
+the correct Monoid structure on End. Moved both down after preadditiveHasZeroMorphisms
 to make use of them -/
-instance {X : C} : Semiring (End X) := 
-  { End.monoid with 
-    zero_mul := fun f => by dsimp [mul]; exact HasZeroMorphisms.comp_zero f _ 
+instance {X : C} : Semiring (End X) :=
+  { End.monoid with
+    zero_mul := fun f => by dsimp [mul]; exact HasZeroMorphisms.comp_zero f _
     mul_zero := fun f => by dsimp [mul]; exact HasZeroMorphisms.zero_comp _ f
     left_distrib := fun f g h => Preadditive.add_comp X X X g h f
     right_distrib := fun f g h => Preadditive.comp_add X X X h f g }
 
-/-- Porting note: It looks like Ring's parent classes changed in 
+/-- Porting note: It looks like Ring's parent classes changed in
 Lean 4 so the previous instance needed modification. Was following my nose here. -/
-instance {X : C} : Ring (End X) := 
+instance {X : C} : Ring (End X) :=
   { (inferInstance : Semiring (End X)),
     (inferInstance : AddCommGroup (End X)) with
     add_left_neg := add_left_neg }
@@ -231,7 +231,7 @@ instance moduleEndRight {X Y : C} : Module (End Y) (X ⟶ Y) where
 #align category_theory.preadditive.module_End_right CategoryTheory.Preadditive.moduleEndRight
 
 theorem mono_of_cancel_zero {Q R : C} (f : Q ⟶ R) (h : ∀ {P : C} (g : P ⟶ Q), g ≫ f = 0 → g = 0) :
-    Mono f where 
+    Mono f where
   right_cancellation := fun {Z} g₁ g₂ hg =>
     sub_eq_zero.1 <| h _ <| (map_sub (rightComp Z f) g₁ g₂).trans <| sub_eq_zero.2 hg
 #align category_theory.preadditive.mono_of_cancel_zero CategoryTheory.Preadditive.mono_of_cancel_zero
@@ -248,7 +248,7 @@ theorem mono_of_kernel_zero {X Y : C} {f : X ⟶ Y} [HasLimit (parallelPair f 0)
 
 theorem epi_of_cancel_zero {P Q : C} (f : P ⟶ Q) (h : ∀ {R : C} (g : Q ⟶ R), f ≫ g = 0 → g = 0) :
     Epi f :=
-  ⟨fun {Z} g g' hg => 
+  ⟨fun {Z} g g' hg =>
     sub_eq_zero.1 <| h _ <| (map_sub (leftComp Z f) g g').trans <| sub_eq_zero.2 hg⟩
 #align category_theory.preadditive.epi_of_cancel_zero CategoryTheory.Preadditive.epi_of_cancel_zero
 
@@ -440,7 +440,7 @@ theorem hasEqualizers_of_hasKernels [HasKernels C] : HasEqualizers C :=
 
 /-- If a preadditive category has all cokernels, then it also has all coequalizers. -/
 theorem hasCoequalizers_of_hasCokernels [HasCokernels C] : HasCoequalizers C :=
-  @hasCoequalizers_of_hasColimit_parallelPair _ _ fun {_} {_} f g => 
+  @hasCoequalizers_of_hasColimit_parallelPair _ _ fun {_} {_} f g =>
     hasCoequalizer_of_hasCokernel f g
 #align category_theory.preadditive.has_coequalizers_of_has_cokernels CategoryTheory.Preadditive.hasCoequalizers_of_hasCokernels
 
@@ -449,4 +449,3 @@ end Equalizers
 end Preadditive
 
 end CategoryTheory
-

--- a/Mathlib/CategoryTheory/Preadditive/Biproducts.lean
+++ b/Mathlib/CategoryTheory/Preadditive/Biproducts.lean
@@ -90,7 +90,7 @@ def isBilimitOfTotal {f : J → C} (b : Bicone f) (total : (∑ j : J, b.π j �
         erw [← Category.comp_id m, ← total, comp_sum]
         apply Finset.sum_congr rfl
         intro j _
-        have reassoced : m ≫ Bicone.π b j ≫ Bicone.ι b j = s.π.app ⟨j⟩ ≫ Bicone.ι b j := by 
+        have reassoced : m ≫ Bicone.π b j ≫ Bicone.ι b j = s.π.app ⟨j⟩ ≫ Bicone.ι b j := by
           erw [← Category.assoc, eq_whisker (h ⟨j⟩)]
         rw [reassoced]
       fac := fun s j => by
@@ -174,7 +174,7 @@ def isBilimitOfIsColimit {f : J → C} (t : Bicone f) (ht : IsColimit t.toCocone
 /-- We can turn any limit cone over a pair into a bilimit bicone. -/
 def biconeIsBilimitOfColimitCoconeOfIsColimit {f : J → C} {t : Cocone (Discrete.functor f)}
     (ht : IsColimit t) : (Bicone.ofColimitCocone ht).IsBilimit :=
-  isBilimitOfIsColimit _ <| IsColimit.ofIsoColimit ht <| Cocones.ext (Iso.refl _) <| by 
+  isBilimitOfIsColimit _ <| IsColimit.ofIsoColimit ht <| Cocones.ext (Iso.refl _) <| by
     rintro ⟨j⟩; simp
 #align category_theory.limits.bicone_is_bilimit_of_colimit_cocone_of_is_colimit CategoryTheory.Limits.biconeIsBilimitOfColimitCoconeOfIsColimit
 
@@ -284,7 +284,7 @@ def biproduct.reindex {β γ : Type} [Fintype β] [DecidableEq β] [DecidableEq 
     by_cases h : b' = b
     · subst h; simp
     · have : ε b' ≠ ε b := by simp [h]
-      simp [biproduct.ι_π_ne _ h, biproduct.ι_π_ne _ this]  
+      simp [biproduct.ι_π_ne _ h, biproduct.ι_π_ne _ this]
   inv_hom_id := by
     apply biproduct.hom_ext; intro g; apply biproduct.hom_ext'; intro g'
     by_cases h : g' = g <;>
@@ -302,9 +302,9 @@ def isBinaryBilimitOfTotal {X Y : C} (b : BinaryBicone X Y)
     (total : b.fst ≫ b.inl + b.snd ≫ b.inr = 𝟙 b.pt) : b.IsBilimit where
   isLimit :=
     { lift := fun s =>
-      (BinaryFan.fst s ≫ b.inl : s.pt ⟶  b.pt) + (BinaryFan.snd s ≫ b.inr : s.pt ⟶ b.pt) 
+      (BinaryFan.fst s ≫ b.inl : s.pt ⟶  b.pt) + (BinaryFan.snd s ≫ b.inr : s.pt ⟶ b.pt)
       uniq := fun s m h => by
-        have reassoced (j : WalkingPair) {W : C} (h' : _ ⟶  W) : 
+        have reassoced (j : WalkingPair) {W : C} (h' : _ ⟶  W) :
           m ≫ b.toCone.π.app ⟨j⟩ ≫ h' = s.π.app ⟨j⟩ ≫ h' := by
             rw [← Category.assoc, eq_whisker (h ⟨j⟩)]
         erw [← Category.comp_id m, ← total, comp_add, reassoced WalkingPair.left,
@@ -315,7 +315,7 @@ def isBinaryBilimitOfTotal {X Y : C} (b : BinaryBicone X Y)
         (b.fst ≫ BinaryCofan.inl s : b.pt ⟶  s.pt) + (b.snd ≫ BinaryCofan.inr s : b.pt ⟶  s.pt)
       uniq := fun s m h => by
         erw [← Category.id_comp m, ← total, add_comp, Category.assoc, Category.assoc,
-          h ⟨WalkingPair.left⟩, h ⟨WalkingPair.right⟩] 
+          h ⟨WalkingPair.left⟩, h ⟨WalkingPair.right⟩]
       fac := fun s j => by rcases j with ⟨⟨⟩⟩ <;> simp }
 #align category_theory.limits.is_binary_bilimit_of_total CategoryTheory.Limits.isBinaryBilimitOfTotal
 
@@ -411,7 +411,7 @@ theorem snd_of_isColimit {X Y : C} {t : BinaryBicone X Y} (ht : IsColimit t.toCo
     bilimit bicone. -/
 def isBinaryBilimitOfIsColimit {X Y : C} (t : BinaryBicone X Y) (ht : IsColimit t.toCocone) :
     t.IsBilimit :=
-  isBinaryBilimitOfTotal _ <| by 
+  isBinaryBilimitOfTotal _ <| by
     refine' BinaryCofan.IsColimit.hom_ext ht _ _ <;> simp
 #align category_theory.limits.is_binary_bilimit_of_is_colimit CategoryTheory.Limits.isBinaryBilimitOfIsColimit
 
@@ -525,8 +525,8 @@ def BinaryBicone.isBilimitOfKernelInl {X Y : C} (b : BinaryBicone X Y)
   isBinaryBilimitOfIsLimit _ <|
     BinaryFan.IsLimit.mk _ (fun f g => f ≫ b.inl + g ≫ b.inr) (fun f g => by simp)
       (fun f g => by simp) fun {T} f g m h₁ h₂ => by
-      dsimp at m 
-      have h₁' : ((m : T ⟶  b.pt) - (f ≫ b.inl + g ≫ b.inr)) ≫ b.fst = 0 := by 
+      dsimp at m
+      have h₁' : ((m : T ⟶  b.pt) - (f ≫ b.inl + g ≫ b.inr)) ≫ b.fst = 0 := by
         simpa using sub_eq_zero.2 h₁
       have h₂' : (m - (f ≫ b.inl + g ≫ b.inr)) ≫ b.snd = 0 := by simpa using sub_eq_zero.2 h₂
       obtain ⟨q : T ⟶ X, hq : q ≫ b.inl = m - (f ≫ b.inl + g ≫ b.inr)⟩ :=
@@ -559,7 +559,7 @@ def BinaryBicone.isBilimitOfCokernelFst {X Y : C} (b : BinaryBicone X Y)
   isBinaryBilimitOfIsColimit _ <|
     BinaryCofan.IsColimit.mk _ (fun f g => b.fst ≫ f + b.snd ≫ g) (fun f g => by simp)
       (fun f g => by simp) fun {T} f g m h₁ h₂ => by
-      dsimp at m 
+      dsimp at m
       have h₁' : b.inl ≫ (m - (b.fst ≫ f + b.snd ≫ g)) = 0 := by simpa using sub_eq_zero.2 h₁
       have h₂' : b.inr ≫ (m - (b.fst ≫ f + b.snd ≫ g)) = 0 := by simpa using sub_eq_zero.2 h₂
       obtain ⟨q : X ⟶ T, hq : b.fst ≫ q = m - (b.fst ≫ f + b.snd ≫ g)⟩ :=
@@ -591,7 +591,7 @@ already a biproduct. -/
 @[simps]
 def binaryBiconeOfIsSplitEpiOfKernel {X Y : C} {f : X ⟶ Y} [IsSplitEpi f] {c : KernelFork f}
     (i : IsLimit c) : BinaryBicone c.pt Y :=
-  { pt := X 
+  { pt := X
     fst :=
       let c' : KernelFork (𝟙 X - (𝟙 X - f ≫ section_ f)) := KernelFork.ofι (Fork.ι c) (by simp)
       let i' : IsLimit c' := isKernelCompMono i (section_ f) (by simp)
@@ -651,7 +651,7 @@ attribute [local ext] Preadditive
 instance subsingleton_preadditive_of_hasBinaryBiproducts {C : Type u} [Category.{v} C]
     [HasZeroMorphisms C] [HasBinaryBiproducts C] : Subsingleton (Preadditive C) where
   allEq := fun a b => by
-    apply Preadditive.ext; funext X Y; apply AddCommGroup.ext; funext f g 
+    apply Preadditive.ext; funext X Y; apply AddCommGroup.ext; funext f g
     have h₁ := @biprod.add_eq_lift_id_desc _ _ a _ _ f g
       (by convert (inferInstance : HasBinaryBiproduct X X))
     have h₂ := @biprod.add_eq_lift_id_desc _ _ b _ _ f g
@@ -777,7 +777,7 @@ def Biprod.gaussian (f : X₁ ⊞ X₂ ⟶ Y₁ ⊞ Y₂) [IsIso (biprod.inl ≫
   let this :=
     Biprod.gaussian' (biprod.inl ≫ f ≫ biprod.fst) (biprod.inl ≫ f ≫ biprod.snd)
       (biprod.inr ≫ f ≫ biprod.fst) (biprod.inr ≫ f ≫ biprod.snd)
-  rwa [Biprod.ofComponents_eq] at this 
+  rwa [Biprod.ofComponents_eq] at this
 #align category_theory.biprod.gaussian CategoryTheory.Biprod.gaussian
 
 /-- If `X₁ ⊞ X₂ ≅ Y₁ ⊞ Y₂` via a two-by-two matrix whose `X₁ ⟶ Y₁` entry is an isomorphism,
@@ -842,8 +842,8 @@ theorem Biproduct.column_nonzero_of_iso' {σ τ : Type} [Finite τ] {S : σ → 
   intro z
   have reassoced {t : τ} {W : C} (h : _ ⟶  W) :
     biproduct.ι S s ≫ f ≫ biproduct.π T t ≫ h =  0 ≫ h := by
-    simp only [← Category.assoc] 
-    apply eq_whisker 
+    simp only [← Category.assoc]
+    apply eq_whisker
     simp only [Category.assoc]
     apply z
   set x := biproduct.ι S s ≫ f ≫ inv f ≫ biproduct.π S s
@@ -890,7 +890,7 @@ variable {J : Type} [Fintype J]
 /-- A functor between preadditive categories that preserves (zero morphisms and) finite biproducts
     preserves finite products. -/
 def preservesProductOfPreservesBiproduct {f : J → C} [PreservesBiproduct f F] :
-    PreservesLimit (Discrete.functor f) F where 
+    PreservesLimit (Discrete.functor f) F where
   preserves hc :=
     IsLimit.ofIsoLimit
         ((IsLimit.postcomposeInvEquiv (Discrete.compNatIsoDiscrete _ _) _).symm
@@ -905,7 +905,7 @@ attribute [local instance] preservesProductOfPreservesBiproduct
 /-- A functor between preadditive categories that preserves (zero morphisms and) finite biproducts
     preserves finite products. -/
 def preservesProductsOfShapeOfPreservesBiproductsOfShape [PreservesBiproductsOfShape J F] :
-    PreservesLimitsOfShape (Discrete J) F where 
+    PreservesLimitsOfShape (Discrete J) F where
   preservesLimit {_} := preservesLimitOfIsoDiagram _ Discrete.natIsoFunctor.symm
 #align category_theory.limits.preserves_products_of_shape_of_preserves_biproducts_of_shape CategoryTheory.Limits.preservesProductsOfShapeOfPreservesBiproductsOfShape
 
@@ -927,7 +927,7 @@ def preservesBiproductOfPreservesProduct {f : J → C} [PreservesLimit (Discrete
     preserves the biproduct of `f`. For the converse, see `mapBiproduct`. -/
 def preservesBiproductOfMonoBiproductComparison {f : J → C} [HasBiproduct f]
     [HasBiproduct (F.obj ∘ f)] [Mono (biproductComparison F f)] : PreservesBiproduct f F := by
-  haveI : HasProduct fun b => F.obj (f b) := by 
+  haveI : HasProduct fun b => F.obj (f b) := by
     change HasProduct (F.obj ∘ f)
     infer_instance
   have that : piComparison F f =
@@ -956,14 +956,14 @@ def preservesBiproductOfEpiBiproductComparison' {f : J → C} [HasBiproduct f]
 /-- A functor between preadditive categories that preserves (zero morphisms and) finite products
     preserves finite biproducts. -/
 def preservesBiproductsOfShapeOfPreservesProductsOfShape [PreservesLimitsOfShape (Discrete J) F] :
-    PreservesBiproductsOfShape J F where 
+    PreservesBiproductsOfShape J F where
   preserves {_} := preservesBiproductOfPreservesProduct F
 #align category_theory.limits.preserves_biproducts_of_shape_of_preserves_products_of_shape CategoryTheory.Limits.preservesBiproductsOfShapeOfPreservesProductsOfShape
 
 /-- A functor between preadditive categories that preserves (zero morphisms and) finite biproducts
     preserves finite coproducts. -/
 def preservesCoproductOfPreservesBiproduct {f : J → C} [PreservesBiproduct f F] :
-    PreservesColimit (Discrete.functor f) F where 
+    PreservesColimit (Discrete.functor f) F where
   preserves {c} hc :=
     IsColimit.ofIsoColimit
         ((IsColimit.precomposeHomEquiv (Discrete.compNatIsoDiscrete _ _) _).symm
@@ -978,7 +978,7 @@ attribute [local instance] preservesCoproductOfPreservesBiproduct
 /-- A functor between preadditive categories that preserves (zero morphisms and) finite biproducts
     preserves finite coproducts. -/
 def preservesCoproductsOfShapeOfPreservesBiproductsOfShape [PreservesBiproductsOfShape J F] :
-    PreservesColimitsOfShape (Discrete J) F where 
+    PreservesColimitsOfShape (Discrete J) F where
   preservesColimit {_} := preservesColimitOfIsoDiagram _ Discrete.natIsoFunctor.symm
 #align category_theory.limits.preserves_coproducts_of_shape_of_preserves_biproducts_of_shape CategoryTheory.Limits.preservesCoproductsOfShapeOfPreservesBiproductsOfShape
 
@@ -987,7 +987,7 @@ end
 /-- A functor between preadditive categories that preserves (zero morphisms and) finite coproducts
     preserves finite biproducts. -/
 def preservesBiproductOfPreservesCoproduct {f : J → C} [PreservesColimit (Discrete.functor f) F] :
-    PreservesBiproduct f F where 
+    PreservesBiproduct f F where
   preserves {b} hb :=
     isBilimitOfIsColimit _ <|
       IsColimit.ofIsoColimit
@@ -1009,12 +1009,12 @@ end Fintype
 /-- A functor between preadditive categories that preserves (zero morphisms and) binary biproducts
     preserves binary products. -/
 def preservesBinaryProductOfPreservesBinaryBiproduct {X Y : C} [PreservesBinaryBiproduct X Y F] :
-    PreservesLimit (pair X Y) F where 
+    PreservesLimit (pair X Y) F where
   preserves {c} hc := IsLimit.ofIsoLimit
         ((IsLimit.postcomposeInvEquiv (diagramIsoPair _) _).symm
           (isBinaryBilimitOfPreserves F (binaryBiconeIsBilimitOfLimitConeOfIsLimit hc)).isLimit) <|
       Cones.ext (by dsimp; rfl) fun j => by
-        rcases j with ⟨⟨⟩⟩ <;> simp 
+        rcases j with ⟨⟨⟩⟩ <;> simp
 #align category_theory.limits.preserves_binary_product_of_preserves_binary_biproduct CategoryTheory.Limits.preservesBinaryProductOfPreservesBinaryBiproduct
 
 section
@@ -1024,7 +1024,7 @@ attribute [local instance] preservesBinaryProductOfPreservesBinaryBiproduct
 /-- A functor between preadditive categories that preserves (zero morphisms and) binary biproducts
     preserves binary products. -/
 def preservesBinaryProductsOfPreservesBinaryBiproducts [PreservesBinaryBiproducts F] :
-    PreservesLimitsOfShape (Discrete WalkingPair) F where 
+    PreservesLimitsOfShape (Discrete WalkingPair) F where
   preservesLimit {_} := preservesLimitOfIsoDiagram _ (diagramIsoPair _).symm
 #align category_theory.limits.preserves_binary_products_of_preserves_binary_biproducts CategoryTheory.Limits.preservesBinaryProductsOfPreservesBinaryBiproducts
 
@@ -1033,12 +1033,12 @@ end
 /-- A functor between preadditive categories that preserves (zero morphisms and) binary products
     preserves binary biproducts. -/
 def preservesBinaryBiproductOfPreservesBinaryProduct {X Y : C} [PreservesLimit (pair X Y) F] :
-    PreservesBinaryBiproduct X Y F where 
-  preserves {b} hb := isBinaryBilimitOfIsLimit _ <| IsLimit.ofIsoLimit  
+    PreservesBinaryBiproduct X Y F where
+  preserves {b} hb := isBinaryBilimitOfIsLimit _ <| IsLimit.ofIsoLimit
           ((IsLimit.postcomposeHomEquiv (diagramIsoPair _) (F.mapCone b.toCone)).symm
             (isLimitOfPreserves F hb.isLimit)) <|
         Cones.ext (by dsimp; rfl) fun j => by
-          rcases j with ⟨⟨⟩⟩ <;> simp 
+          rcases j with ⟨⟨⟩⟩ <;> simp
 #align category_theory.limits.preserves_binary_biproduct_of_preserves_binary_product CategoryTheory.Limits.preservesBinaryBiproductOfPreservesBinaryProduct
 
 /-- If the (product-like) biproduct comparison for `F`, `X` and `Y` is a monomorphism, then
@@ -1086,7 +1086,7 @@ def preservesBinaryCoproductOfPreservesBinaryBiproduct {X Y : C} [PreservesBinar
           (isBinaryBilimitOfPreserves F
               (binaryBiconeIsBilimitOfColimitCoconeOfIsColimit hc)).isColimit) <|
       Cocones.ext (by dsimp; rfl) fun j => by
-        rcases j with ⟨⟨⟩⟩ <;> simp 
+        rcases j with ⟨⟨⟩⟩ <;> simp
 #align category_theory.limits.preserves_binary_coproduct_of_preserves_binary_biproduct CategoryTheory.Limits.preservesBinaryCoproductOfPreservesBinaryBiproduct
 
 section
@@ -1112,7 +1112,7 @@ def preservesBinaryBiproductOfPreservesBinaryCoproduct {X Y : C} [PreservesColim
           ((IsColimit.precomposeInvEquiv (diagramIsoPair _) (F.mapCocone b.toCocone)).symm
             (isColimitOfPreserves F hb.isColimit)) <|
         Cocones.ext (Iso.refl _) fun j => by
-          rcases j with ⟨⟨⟩⟩ <;> simp 
+          rcases j with ⟨⟨⟩⟩ <;> simp
 #align category_theory.limits.preserves_binary_biproduct_of_preserves_binary_coproduct CategoryTheory.Limits.preservesBinaryBiproductOfPreservesBinaryCoproduct
 
 /-- A functor between preadditive categories that preserves (zero morphisms and) binary coproducts
@@ -1127,4 +1127,3 @@ end Limits
 end Preadditive
 
 end CategoryTheory
-

--- a/Mathlib/CategoryTheory/Products/Basic.lean
+++ b/Mathlib/CategoryTheory/Products/Basic.lean
@@ -172,7 +172,7 @@ def symmetry : swap C D ⋙ swap D C ≅ 𝟭 (C × D)
 -/
 @[simps!]
 def braiding : C × D ≌ D × C :=
-  Equivalence.mk (swap C D) (swap D C) 
+  Equivalence.mk (swap C D) (swap D C)
     (NatIso.ofComponents (fun X => eqToIso (by simp)) (by aesop_cat))
     (NatIso.ofComponents (fun X => eqToIso (by simp)) (by aesop_cat))
 #align category_theory.prod.braiding CategoryTheory.Prod.braiding
@@ -294,9 +294,9 @@ def prod {F G : A ⥤ B} {H I : C ⥤ D} (α : F ⟶ G) (β : H ⟶ I) : F.prod 
   app X := (α.app X.1, β.app X.2)
   naturality {X} {Y} f := by
     cases X; cases Y
-    simp only [Functor.prod_map, prod_comp] 
-    rw [Prod.mk.inj_iff] 
-    constructor 
+    simp only [Functor.prod_map, prod_comp]
+    rw [Prod.mk.inj_iff]
+    constructor
     repeat {rw [naturality]}
 #align category_theory.nat_trans.prod CategoryTheory.NatTrans.prod
 
@@ -338,11 +338,11 @@ def functorProdToProdFunctor : (A ⥤ B × C) ⥤ (A ⥤ B) × (A ⥤ C)
 @[simps!]
 def functorProdFunctorEquivUnitIso :
     𝟭 _ ≅ prodFunctorToFunctorProd A B C ⋙ functorProdToProdFunctor A B C :=
-  NatIso.ofComponents 
-    (fun F => 
-      (((Functor.prod'CompFst F.fst F.snd).prod (Functor.prod'CompSnd F.fst F.snd)).trans 
-        (prod.etaIso F)).symm) 
-      (fun α => by aesop_cat) 
+  NatIso.ofComponents
+    (fun F =>
+      (((Functor.prod'CompFst F.fst F.snd).prod (Functor.prod'CompSnd F.fst F.snd)).trans
+        (prod.etaIso F)).symm)
+      (fun α => by aesop_cat)
 #align category_theory.functor_prod_functor_equiv_unit_iso CategoryTheory.functorProdFunctorEquivUnitIso
 
 /-- The counit isomorphism for `functorProdFunctorEquiv` -/
@@ -354,12 +354,12 @@ def functorProdFunctorEquivCounitIso :
 #align category_theory.functor_prod_functor_equiv_counit_iso CategoryTheory.functorProdFunctorEquivCounitIso
 
 /- Porting note: unlike with Lean 3, we needed to provide `functor_unitIso_comp` because
-Lean 4 could not see through `functorProdFunctorEquivUnitIso` (or the co-unit version) 
+Lean 4 could not see through `functorProdFunctorEquivUnitIso` (or the co-unit version)
 to run the auto tactic `by aesop_cat` -/
 
 /-- The equivalence of categories between `(A ⥤ B) × (A ⥤ C)` and `A ⥤ (B × C)` -/
 @[simps]
-def functorProdFunctorEquiv : (A ⥤ B) × (A ⥤ C) ≌ A ⥤ B × C := 
+def functorProdFunctorEquiv : (A ⥤ B) × (A ⥤ C) ≌ A ⥤ B × C :=
   { functor := prodFunctorToFunctorProd A B C,
     inverse := functorProdToProdFunctor A B C,
     unitIso := functorProdFunctorEquivUnitIso A B C,

--- a/Mathlib/CategoryTheory/Skeletal.lean
+++ b/Mathlib/CategoryTheory/Skeletal.lean
@@ -78,26 +78,26 @@ variable (C D)
 /-- Construct the skeleton category as the induced category on the isomorphism classes, and derive
 its category structure.
 -/
-def Skeleton : Type u₁ := InducedCategory C Quotient.out 
+def Skeleton : Type u₁ := InducedCategory C Quotient.out
 #align category_theory.skeleton CategoryTheory.Skeleton
 
 instance [Inhabited C] : Inhabited (Skeleton C) :=
   ⟨⟦default⟧⟩
 
--- Porting note: previously `Skeleton` used `deriving Category` 
-noncomputable instance : Category (Skeleton C) := by 
-  apply InducedCategory.category 
+-- Porting note: previously `Skeleton` used `deriving Category`
+noncomputable instance : Category (Skeleton C) := by
+  apply InducedCategory.category
 
 /-- The functor from the skeleton of `C` to `C`. -/
 @[simps!]
 noncomputable def fromSkeleton : Skeleton C ⥤ C :=
-  inducedFunctor _ 
+  inducedFunctor _
 #align category_theory.from_skeleton CategoryTheory.fromSkeleton
 
--- Porting note: previously `fromSkeleton` used `deriving Faithful, Full` 
-noncomputable instance : Full <| fromSkeleton C := by 
+-- Porting note: previously `fromSkeleton` used `deriving Faithful, Full`
+noncomputable instance : Full <| fromSkeleton C := by
   apply InducedCategory.full
-noncomputable instance : Faithful <| fromSkeleton C := by 
+noncomputable instance : Faithful <| fromSkeleton C := by
   apply InducedCategory.faithful
 
 instance : EssSurj (fromSkeleton C) where mem_essImage X := ⟨Quotient.mk' X, Quotient.mk_out X⟩
@@ -154,20 +154,20 @@ instance inhabitedThinSkeleton [Inhabited C] : Inhabited (ThinSkeleton C) :=
 instance ThinSkeleton.preorder : Preorder (ThinSkeleton C)
     where
   le :=
-    @Quotient.lift₂ C C _ (isIsomorphicSetoid C) (isIsomorphicSetoid C) 
+    @Quotient.lift₂ C C _ (isIsomorphicSetoid C) (isIsomorphicSetoid C)
       (fun X Y => Nonempty (X ⟶ Y))
         (by
           rintro _ _ _ _ ⟨i₁⟩ ⟨i₂⟩
           exact
             propext
-              ⟨Nonempty.map fun f => i₁.inv ≫ f ≫ i₂.hom, 
+              ⟨Nonempty.map fun f => i₁.inv ≫ f ≫ i₂.hom,
                 Nonempty.map fun f => i₁.hom ≫ f ≫ i₂.inv⟩)
   le_refl := by
     refine' Quotient.ind fun a => _
     exact ⟨𝟙 _⟩
   le_trans a b c := Quotient.inductionOn₃ a b c fun A B C => Nonempty.map2 (· ≫ ·)
 #align category_theory.thin_skeleton.preorder CategoryTheory.ThinSkeleton.preorder
- 
+
 /-- The functor from a category to its thin skeleton. -/
 @[simps]
 def toThinSkeleton : C ⥤ ThinSkeleton C where
@@ -208,49 +208,49 @@ def mapNatTrans {F₁ F₂ : C ⥤ D} (k : F₁ ⟶ F₂) : map F₁ ⟶ map F�
     where app X := Quotient.recOnSubsingleton X fun x => ⟨⟨⟨k.app x⟩⟩⟩
 #align category_theory.thin_skeleton.map_nat_trans CategoryTheory.ThinSkeleton.mapNatTrans
 
-/- Porting note: `map₂ObjMap`, `map₂Functor`, and `map₂NatTrans` were all extracted 
-from the original `map₂` proof. Lean needed an extensive amount explicit type 
-annotations to figure things out. This also translated into repeated deterministic 
-timeouts. The extracted defs allow for explicit motives for the multiple 
+/- Porting note: `map₂ObjMap`, `map₂Functor`, and `map₂NatTrans` were all extracted
+from the original `map₂` proof. Lean needed an extensive amount explicit type
+annotations to figure things out. This also translated into repeated deterministic
+timeouts. The extracted defs allow for explicit motives for the multiple
 descents to the quotients.
 
-It would be better to prove that 
-`ThinSkeleton (C × D) ≌ ThinSkeleton C × ThinSkeleton D` 
-which is more immediate from comparing the preorders. Then one could get 
+It would be better to prove that
+`ThinSkeleton (C × D) ≌ ThinSkeleton C × ThinSkeleton D`
+which is more immediate from comparing the preorders. Then one could get
 `map₂` by currying.
 -/
 /-- Given a bifunctor, we descend to a function on objects of `ThinSkeleton` -/
-def map₂ObjMap (F : C ⥤ D ⥤ E) : ThinSkeleton C → ThinSkeleton D → ThinSkeleton E := 
+def map₂ObjMap (F : C ⥤ D ⥤ E) : ThinSkeleton C → ThinSkeleton D → ThinSkeleton E :=
   fun x y =>
-    @Quotient.map₂ C D (isIsomorphicSetoid C) (isIsomorphicSetoid D) E (isIsomorphicSetoid E) 
+    @Quotient.map₂ C D (isIsomorphicSetoid C) (isIsomorphicSetoid D) E (isIsomorphicSetoid E)
       (fun X Y => (F.obj X).obj Y)
           (fun X₁ _ ⟨hX⟩ _ Y₂ ⟨hY⟩ => ⟨(F.obj X₁).mapIso hY ≪≫ (F.mapIso hX).app Y₂⟩) x y
 
 /-- For each `x : ThinSkeleton C`, we promote `map₂ObjMap F x` to a functor -/
-def map₂Functor (F : C ⥤ D ⥤ E) : ThinSkeleton C → ThinSkeleton D ⥤ ThinSkeleton E := 
-  fun x => 
+def map₂Functor (F : C ⥤ D ⥤ E) : ThinSkeleton C → ThinSkeleton D ⥤ ThinSkeleton E :=
+  fun x =>
     { obj := fun y => map₂ObjMap F x y
-      map := fun {y₁} {y₂} => @Quotient.recOnSubsingleton C (isIsomorphicSetoid C) 
-        (fun x => (y₁ ⟶  y₂) → (map₂ObjMap F x y₁ ⟶  map₂ObjMap F x y₂)) _ x fun X 
+      map := fun {y₁} {y₂} => @Quotient.recOnSubsingleton C (isIsomorphicSetoid C)
+        (fun x => (y₁ ⟶  y₂) → (map₂ObjMap F x y₁ ⟶  map₂ObjMap F x y₂)) _ x fun X
           => Quotient.recOnSubsingleton₂ y₁ y₂ fun Y₁ Y₂ hY =>
             homOfLE (hY.le.elim fun g => ⟨(F.obj X).map g⟩) }
 
-/-- This provides natural transformations `map₂Functor F x₁ ⟶  map₂Functor F x₂` given 
+/-- This provides natural transformations `map₂Functor F x₁ ⟶  map₂Functor F x₂` given
 `x₁ ⟶  x₂` -/
-def map₂NatTrans (F : C ⥤ D ⥤ E) : {x₁ x₂ : ThinSkeleton C} → (x₁ ⟶  x₂) →  
-    (map₂Functor F x₁ ⟶  map₂Functor F x₂) := fun {x₁} {x₂} => 
-  @Quotient.recOnSubsingleton₂ C C (isIsomorphicSetoid C) (isIsomorphicSetoid C) 
-    (fun x x' : ThinSkeleton C => (x ⟶  x') → (map₂Functor F x ⟶  map₂Functor F x')) _ x₁ x₂ 
-    (fun X₁ X₂ f => { app := fun y =>   
-      Quotient.recOnSubsingleton y fun Y => homOfLE (f.le.elim fun f' => ⟨(F.map f').app Y⟩) }) 
+def map₂NatTrans (F : C ⥤ D ⥤ E) : {x₁ x₂ : ThinSkeleton C} → (x₁ ⟶  x₂) →
+    (map₂Functor F x₁ ⟶  map₂Functor F x₂) := fun {x₁} {x₂} =>
+  @Quotient.recOnSubsingleton₂ C C (isIsomorphicSetoid C) (isIsomorphicSetoid C)
+    (fun x x' : ThinSkeleton C => (x ⟶  x') → (map₂Functor F x ⟶  map₂Functor F x')) _ x₁ x₂
+    (fun X₁ X₂ f => { app := fun y =>
+      Quotient.recOnSubsingleton y fun Y => homOfLE (f.le.elim fun f' => ⟨(F.map f').app Y⟩) })
 
 -- TODO: state the lemmas about what happens when you compose with `toThinSkeleton`
 /-- A functor `C ⥤ D ⥤ E` computably lowers to a functor
 `ThinSkeleton C ⥤ ThinSkeleton D ⥤ ThinSkeleton E` -/
 @[simps]
-def map₂ (F : C ⥤ D ⥤ E) : ThinSkeleton C ⥤ ThinSkeleton D ⥤ ThinSkeleton E where 
+def map₂ (F : C ⥤ D ⥤ E) : ThinSkeleton C ⥤ ThinSkeleton D ⥤ ThinSkeleton E where
   obj := map₂Functor F
-  map := map₂NatTrans F 
+  map := map₂NatTrans F
 #align category_theory.thin_skeleton.map₂ CategoryTheory.ThinSkeleton.map₂
 
 variable (C)
@@ -370,4 +370,3 @@ noncomputable def Equivalence.thinSkeletonOrderIso [Quiver.IsThin C] (e : C ≌ 
 end
 
 end CategoryTheory
-

--- a/Mathlib/CategoryTheory/Sums/Basic.lean
+++ b/Mathlib/CategoryTheory/Sums/Basic.lean
@@ -56,9 +56,9 @@ instance sum : Category.{v₁} (Sum C D)
     match X, Y, Z, f, g with
     | inl X, inl Y, inl Z, f, g => f ≫ g
     | inr X, inr Y, inr Z, f, g => f ≫ g
-  assoc := @fun W X Y Z f g h => 
-    match X, Y, Z, W with 
-    | inl X, inl Y, inl Z, inl W => Category.assoc f g h  
+  assoc := @fun W X Y Z f g h =>
+    match X, Y, Z, W with
+    | inl X, inl Y, inl Z, inl W => Category.assoc f g h
     | inr X, inr Y, inr Z, inr W => Category.assoc f g h
 #align category_theory.sum CategoryTheory.sum
 
@@ -113,10 +113,10 @@ def swap : Sum C D ⥤ Sum D C
     match X, Y, f with
     | inl _, inl _, f => f
     | inr _, inr _, f => f
-  map_comp := fun {X} {Y} {Z} _ _ => 
-    match X, Y, Z with 
-    | inl X, inl Y, inl Z => by rfl 
-    | inr X, inr Y, inr Z => by rfl 
+  map_comp := fun {X} {Y} {Z} _ _ =>
+    match X, Y, Z with
+    | inl X, inl Y, inl Z => by rfl
+    | inr X, inr Y, inr Z => by rfl
 #align category_theory.sum.swap CategoryTheory.Sum.swap
 
 @[simp]
@@ -146,7 +146,7 @@ namespace Swap
 /-- `swap` gives an equivalence between `C ⊕ D` and `D ⊕ C`. -/
 def equivalence : Sum C D ≌ Sum D C :=
   Equivalence.mk (swap C D) (swap D C)
-    (NatIso.ofComponents (fun X => eqToIso (by cases X <;> rfl)) 
+    (NatIso.ofComponents (fun X => eqToIso (by cases X <;> rfl))
     (by simp only [swap]; aesop_cat; cases f; cases f))
     (NatIso.ofComponents (fun X => eqToIso (by cases X <;> rfl))
     (by simp only [swap]; aesop_cat; cases f; cases f))

--- a/Mathlib/CategoryTheory/Yoneda.lean
+++ b/Mathlib/CategoryTheory/Yoneda.lean
@@ -46,11 +46,11 @@ def yoneda : C ⥤ Cᵒᵖ ⥤ Type v₁
       map := fun f g => f.unop ≫ g
       map_comp := fun f g => by funext; dsimp; erw [Category.assoc]
       map_id := fun Y => by funext; dsimp; erw [Category.id_comp] }
-  map f := 
-    { app := fun Y g => g ≫ f 
+  map f :=
+    { app := fun Y g => g ≫ f
       naturality := fun Y Y' g => by funext Z; aesop_cat }
-  map_id := by aesop_cat 
-  map_comp := fun f g => by ext Y; dsimp; funext f; simp 
+  map_id := by aesop_cat
+  map_comp := fun f g => by ext Y; dsimp; funext f; simp
 #align category_theory.yoneda CategoryTheory.yoneda
 
 /-- The co-Yoneda embedding, as a functor from `Cᵒᵖ` into co-presheaves on `C`.
@@ -60,11 +60,11 @@ def coyoneda : Cᵒᵖ ⥤ C ⥤ Type v₁
     where
   obj X :=
     { obj := fun Y => unop X ⟶ Y
-      map := fun f g => g ≫ f 
-      map_comp := fun f g => by funext; dsimp; erw [Category.assoc]  
+      map := fun f g => g ≫ f
+      map_comp := fun f g => by funext; dsimp; erw [Category.assoc]
       map_id := fun Y => by funext; dsimp; erw [Category.comp_id] }
-  map f := 
-    { app := fun Y g => f.unop ≫ g 
+  map f :=
+    { app := fun Y g => f.unop ≫ g
       naturality := fun Y Y' g => by funext Z; aesop_cat }
 #align category_theory.coyoneda CategoryTheory.coyoneda
 
@@ -86,9 +86,9 @@ theorem naturality {X Y : C} (α : yoneda.obj X ⟶ yoneda.obj Y) {Z Z' : C} (f 
 
 See <https://stacks.math.columbia.edu/tag/001P>.
 -/
-instance yonedaFull : Full (yoneda : C ⥤ Cᵒᵖ ⥤ Type v₁) where 
+instance yonedaFull : Full (yoneda : C ⥤ Cᵒᵖ ⥤ Type v₁) where
   preimage {X} {Y} f := f.app (op X) (𝟙 X)
-  witness {X} {Y} f := by simp only [yoneda]; aesop_cat 
+  witness {X} {Y} f := by simp only [yoneda]; aesop_cat
 #align category_theory.yoneda.yoneda_full CategoryTheory.Yoneda.yonedaFull
 
 /-- The Yoneda embedding is faithful.
@@ -96,7 +96,7 @@ instance yonedaFull : Full (yoneda : C ⥤ Cᵒᵖ ⥤ Type v₁) where
 See <https://stacks.math.columbia.edu/tag/001P>.
 -/
 instance yoneda_faithful : Faithful (yoneda : C ⥤ Cᵒᵖ ⥤ Type v₁)
-    where 
+    where
       map_injective {X} {Y} f g p := by
         convert congr_fun (congr_app p (op X)) (𝟙 X) <;> dsimp <;> simp
 #align category_theory.yoneda.yoneda_faithful CategoryTheory.Yoneda.yoneda_faithful
@@ -117,8 +117,8 @@ def ext (X Y : C) (p : ∀ {Z : C}, (Z ⟶ X) → (Z ⟶ Y)) (q : ∀ {Z : C}, (
       (fun Z =>
         { hom := p
           inv := q
-          hom_inv_id := by simp only [yoneda]; funext; apply h₁ 
-          inv_hom_id := by simp only [yoneda]; funext; apply h₂ }) 
+          hom_inv_id := by simp only [yoneda]; funext; apply h₁
+          inv_hom_id := by simp only [yoneda]; funext; apply h₂ })
       (fun f => by simp only [yoneda]; funext; apply n))
 #align category_theory.yoneda.ext CategoryTheory.Yoneda.ext
 
@@ -139,12 +139,12 @@ theorem naturality {X Y : Cᵒᵖ} (α : coyoneda.obj X ⟶ coyoneda.obj Y) {Z Z
 #align category_theory.coyoneda.naturality CategoryTheory.Coyoneda.naturality
 
 instance coyonedaFull : Full (coyoneda : Cᵒᵖ ⥤ C ⥤ Type v₁)
-    where 
+    where
       preimage {X} _ f := (f.app _ (𝟙 X.unop)).op
       witness {X} {Y} f := by simp only [coyoneda]; aesop_cat
 #align category_theory.coyoneda.coyoneda_full CategoryTheory.Coyoneda.coyonedaFull
 
-instance coyoneda_faithful : Faithful (coyoneda : Cᵒᵖ ⥤ C ⥤ Type v₁) where 
+instance coyoneda_faithful : Faithful (coyoneda : Cᵒᵖ ⥤ C ⥤ Type v₁) where
   map_injective {X} _ _ _ p := by
     have t := congr_fun (congr_app p X.unop) (𝟙 _)
     simpa using congr_arg Quiver.Hom.op t
@@ -209,7 +209,7 @@ variable [F.Representable]
 /-- The representing object for the representable functor `F`. -/
 noncomputable def reprX : C :=
   (Representable.has_representation : ∃ (_ : _)(_ : _ ⟶ F), _).choose
-set_option linter.uppercaseLean3 false 
+set_option linter.uppercaseLean3 false
 #align category_theory.functor.repr_X CategoryTheory.Functor.reprX
 
 /-- The (forward direction of the) isomorphism witnessing `F` is representable. -/
@@ -258,7 +258,7 @@ variable [F.Corepresentable]
 /-- The representing object for the corepresentable functor `F`. -/
 noncomputable def coreprX : C :=
   (Corepresentable.has_corepresentation : ∃ (_ : _)(_ : _ ⟶ F), _).choose.unop
-set_option linter.uppercaseLean3 false 
+set_option linter.uppercaseLean3 false
 #align category_theory.functor.corepr_X CategoryTheory.Functor.coreprX
 
 /-- The (forward direction of the) isomorphism witnessing `F` is corepresentable. -/
@@ -361,7 +361,7 @@ def yonedaLemma : yonedaPairing C ≅ yonedaEvaluation C
   hom :=
     { app := fun F x => ULift.up ((x.app F.1) (𝟙 (unop F.1)))
       naturality := by
-        intro X Y f; simp only [yonedaEvaluation]; funext; dsimp 
+        intro X Y f; simp only [yonedaEvaluation]; funext; dsimp
         erw [Category.id_comp, ←FunctorToTypes.naturality]
         simp only [Category.comp_id, yoneda_obj_map] }
   inv :=
@@ -374,7 +374,7 @@ def yonedaLemma : yonedaPairing C ≅ yonedaEvaluation C
         intro X Y f; simp only [yoneda]; funext; apply NatTrans.ext; funext; funext; dsimp
         rw [←FunctorToTypes.naturality X.snd Y.snd f.snd, FunctorToTypes.map_comp_apply] }
   hom_inv_id := by
-    apply NatTrans.ext; funext; funext; 
+    apply NatTrans.ext; funext; funext;
     apply NatTrans.ext; funext; funext; dsimp
     erw [← FunctorToTypes.naturality, obj_map_id]
     simp only [yoneda_map_app, Quiver.Hom.unop_op]
@@ -448,50 +448,49 @@ attribute [local ext] Functor.ext
 /- Porting note: this used to be two calls to `tidy` -/
 /-- The curried version of yoneda lemma when `C` is small. -/
 def curriedYonedaLemma {C : Type u₁} [SmallCategory C] :
-    (yoneda.op ⋙ coyoneda : Cᵒᵖ ⥤ (Cᵒᵖ ⥤ Type u₁) ⥤ Type u₁) ≅ evaluation Cᵒᵖ (Type u₁) := by 
-  refine eqToIso ?_ ≪≫ curry.mapIso 
+    (yoneda.op ⋙ coyoneda : Cᵒᵖ ⥤ (Cᵒᵖ ⥤ Type u₁) ⥤ Type u₁) ≅ evaluation Cᵒᵖ (Type u₁) := by
+  refine eqToIso ?_ ≪≫ curry.mapIso
     (yonedaLemma C ≪≫ isoWhiskerLeft (evaluationUncurried Cᵒᵖ (Type u₁)) uliftFunctorTrivial) ≪≫
     eqToIso ?_
-  · apply Functor.ext 
-    · intro X Y f 
+  · apply Functor.ext
+    · intro X Y f
       simp only [curry, yoneda, coyoneda, curryObj, yonedaPairing]
-      dsimp 
-      apply NatTrans.ext 
+      dsimp
+      apply NatTrans.ext
       dsimp at *
-      funext F g 
-      apply NatTrans.ext 
-      simp 
-    · intro X 
+      funext F g
+      apply NatTrans.ext
+      simp
+    · intro X
       simp only [curry, yoneda, coyoneda, curryObj, yonedaPairing]
       aesop_cat
   · apply Functor.ext
-    · intro X Y f 
+    · intro X Y f
       simp only [curry, yoneda, coyoneda, curryObj, yonedaPairing]
-      dsimp 
-      apply NatTrans.ext 
+      dsimp
+      apply NatTrans.ext
       dsimp at *
-      funext F g 
-      simp 
-    · intro X 
+      funext F g
+      simp
+    · intro X
       simp only [curry, yoneda, coyoneda, curryObj, yonedaPairing]
-      aesop_cat 
+      aesop_cat
 #align category_theory.curried_yoneda_lemma CategoryTheory.curriedYonedaLemma
 
 /-- The curried version of yoneda lemma when `C` is small. -/
 def curriedYonedaLemma' {C : Type u₁} [SmallCategory C] :
-    yoneda ⋙ (whiskeringLeft Cᵒᵖ (Cᵒᵖ ⥤ Type u₁)ᵒᵖ (Type u₁)).obj yoneda.op ≅ 𝟭 (Cᵒᵖ ⥤ Type u₁) 
-    := by 
+    yoneda ⋙ (whiskeringLeft Cᵒᵖ (Cᵒᵖ ⥤ Type u₁)ᵒᵖ (Type u₁)).obj yoneda.op ≅ 𝟭 (Cᵒᵖ ⥤ Type u₁)
+    := by
   refine eqToIso ?_ ≪≫ curry.mapIso (isoWhiskerLeft (Prod.swap _ _)
-    (yonedaLemma C ≪≫ isoWhiskerLeft (evaluationUncurried Cᵒᵖ (Type u₁)) uliftFunctorTrivial :_)) 
+    (yonedaLemma C ≪≫ isoWhiskerLeft (evaluationUncurried Cᵒᵖ (Type u₁)) uliftFunctorTrivial :_))
     ≪≫ eqToIso ?_
-  · apply Functor.ext 
-    · intro X Y f 
+  · apply Functor.ext
+    · intro X Y f
       simp only [curry, yoneda, coyoneda, curryObj, yonedaPairing]
       aesop_cat
   · apply Functor.ext
-    · intro X Y f 
+    · intro X Y f
       aesop_cat
 #align category_theory.curried_yoneda_lemma' CategoryTheory.curriedYonedaLemma'
 
 end CategoryTheory
-

--- a/Mathlib/Data/Analysis/Topology.lean
+++ b/Mathlib/Data/Analysis/Topology.lean
@@ -174,7 +174,7 @@ theorem ext [T : TopologicalSpace α] {σ : Type _} {F : Ctop α σ} (H₁ : ∀
 
 variable [TopologicalSpace α]
 
--- Porting note: add non-computable : because 
+-- Porting note: add non-computable : because
 -- > ... it depends on `Inter.inter`, and it does not have executable code.
 /-- The topological space realizer made of the open sets. -/
 protected noncomputable def id : Realizer α :=

--- a/Mathlib/Data/Int/Units.lean
+++ b/Mathlib/Data/Int/Units.lean
@@ -63,7 +63,7 @@ theorem eq_one_or_neg_one_of_mul_eq_one' {z w : ℤ} (h : z * w = 1) :
 #align int.eq_one_or_neg_one_of_mul_eq_one' Int.eq_one_or_neg_one_of_mul_eq_one'
 
 theorem eq_of_mul_eq_one {z w : ℤ} (h : z * w = 1) : z = w :=
-  (eq_one_or_neg_one_of_mul_eq_one' h).elim 
+  (eq_one_or_neg_one_of_mul_eq_one' h).elim
     (and_imp.2 (·.trans ·.symm)) (and_imp.2 (·.trans ·.symm))
 #align int.eq_of_mul_eq_one Int.eq_of_mul_eq_one
 

--- a/Mathlib/Data/Real/EReal.lean
+++ b/Mathlib/Data/Real/EReal.lean
@@ -993,7 +993,7 @@ infinite. This version eliminates some cases by assuming that `P` is symmetric a
 `P (-x) y` for all `x`, `y`. -/
 @[elab_as_elim]
 theorem induction₂_symm_neg {P : EReal → EReal → Prop}
-    (symm : Symmetric P) (neg_left : ∀ {x y}, P x y → P (-x) y) (top_top : P ⊤ ⊤) 
+    (symm : Symmetric P) (neg_left : ∀ {x y}, P x y → P (-x) y) (top_top : P ⊤ ⊤)
     (top_pos : ∀ x : ℝ, 0 < x → P ⊤ x) (top_zero : P ⊤ 0) (coe_coe : ∀ x y : ℝ, P x y) :
     ∀ x y, P x y :=
   have neg_right : ∀ {x y}, P x y → P x (-y) := fun h => symm <| neg_left <| symm h

--- a/Mathlib/Data/Set/Enumerate.lean
+++ b/Mathlib/Data/Set/Enumerate.lean
@@ -76,7 +76,7 @@ theorem enumerate_mem (h_sel : ∀ s a, sel s = some a → a ∈ s) :
 
 theorem enumerate_inj {n₁ n₂ : ℕ} {a : α} {s : Set α} (h_sel : ∀ s a, sel s = some a → a ∈ s)
     (h₁ : enumerate sel s n₁ = some a) (h₂ : enumerate sel s n₂ = some a) : n₁ = n₂ := by
-  /- porting note : The `rcase, on_goal, all_goals` has been used instead of 
+  /- porting note : The `rcase, on_goal, all_goals` has been used instead of
      the not-yet-ported `wlog` -/
   rcases le_total n₁ n₂ with (hn|hn)
   on_goal 2 => swap_var n₁ ↔ n₂, h₁ ↔ h₂

--- a/Mathlib/Data/Set/Intervals/Pi.lean
+++ b/Mathlib/Data/Set/Intervals/Pi.lean
@@ -110,7 +110,7 @@ theorem pi_univ_Ioc_update_right {x y : ∀ i, α i} {i₀ : ι} {m : α i₀} (
 theorem disjoint_pi_univ_Ioc_update_left_right {x y : ∀ i, α i} {i₀ : ι} {m : α i₀} :
     Disjoint (pi univ fun i ↦ Ioc (x i) (update y i₀ m i))
       (pi univ fun i ↦ Ioc (update x i₀ m i) (y i)) :=
-  by 
+  by
   rw [disjoint_left]
   rintro z h₁ h₂
   refine' (h₁ i₀ (mem_univ _)).2.not_lt _
@@ -142,7 +142,7 @@ of the faces of `[x, y]`. -/
 theorem Icc_diff_pi_univ_Ioo_subset (x y x' y' : ∀ i, α i) :
     (Icc x y \ pi univ fun i ↦ Ioo (x' i) (y' i)) ⊆
       (⋃ i : ι, Icc x (update y i (x' i))) ∪ ⋃ i : ι, Icc (update x i (y' i)) y :=
-  by 
+  by
   rintro a ⟨⟨hxa, hay⟩, ha'⟩
   simp at ha'
   simp [le_update_iff, update_le_iff, hxa, hay, hxa _, hay _, ← exists_or]

--- a/Mathlib/Dynamics/OmegaLimit.lean
+++ b/Mathlib/Dynamics/OmegaLimit.lean
@@ -105,7 +105,7 @@ theorem mapsTo_omega_limit' {α' β' : Type _} [TopologicalSpace β'] {f : Filte
   calc
     gb (ϕ t x) = ϕ' t (ga x) := ht.2 hx
     _ ∈ image2 ϕ' u s' := mem_image2_of_mem ht.1 (hs hx)
-    
+
 #align maps_to_omega_limit' mapsTo_omega_limit'
 
 theorem mapsTo_omegaLimit {α' β' : Type _} [TopologicalSpace β'] {f : Filter τ} {ϕ : τ → α → β}
@@ -325,7 +325,7 @@ theorem nonempty_omegaLimit_of_isCompact_absorbing [NeBot f] {c : Set β} (hc₁
     calc
       _ ⊆ closure (image2 ϕ v s) := closure_mono (image2_subset (inter_subset_right _ _) Subset.rfl)
       _ ⊆ c := hv₂
-      
+
   · exact fun _ ↦ isClosed_closure
 #align nonempty_omega_limit_of_is_compact_absorbing nonempty_omegaLimit_of_isCompact_absorbing
 
@@ -381,7 +381,7 @@ theorem omegaLimit_image_eq (hf : ∀ t, Tendsto (· + t) f f) (t : τ) : ω f �
     calc
       ω f ϕ s = ω f ϕ (ϕ (-t) '' (ϕ t '' s)) := by simp [image_image, ← map_add]
       _ ⊆ ω f ϕ (ϕ t '' s) := omegaLimit_image_subset _ _ _ _ (hf _)
-      
+
 #align flow.omega_limit_image_eq Flow.omegaLimit_image_eq
 
 theorem omegaLimit_omegaLimit (hf : ∀ t, Tendsto ((· + ·) t) f f) : ω f ϕ (ω f ϕ s) ⊆ ω f ϕ s := by

--- a/Mathlib/GroupTheory/Archimedean.lean
+++ b/Mathlib/GroupTheory/Archimedean.lean
@@ -99,6 +99,6 @@ theorem AddSubgroup.cyclic_of_isolated_zero {H : AddSubgroup G} {a : G} (h₀ : 
 /-- Every subgroup of `ℤ` is cyclic. -/
 theorem Int.subgroup_cyclic (H : AddSubgroup ℤ) : ∃ a, H = AddSubgroup.closure {a} :=
   have : Ioo (0 : ℤ) 1 = ∅ := eq_empty_of_forall_not_mem fun m hm =>
-    hm.1.not_le (lt_add_one_iff.1 hm.2) 
+    hm.1.not_le (lt_add_one_iff.1 hm.2)
   AddSubgroup.cyclic_of_isolated_zero one_pos <| by simp [this]
 #align int.subgroup_cyclic Int.subgroup_cyclic

--- a/Mathlib/Order/Filter/Lift.lean
+++ b/Mathlib/Order/Filter/Lift.lean
@@ -165,7 +165,7 @@ theorem lift_lift_same_eq_lift {g : Set α → Set α → Filter β} (hg₁ : �
       calc
         g (s ∩ t) (s ∩ t) ≤ g s (s ∩ t) := hg₂ (s ∩ t) (inter_subset_left _ _)
         _ ≤ g s t := hg₁ s (inter_subset_right _ _)
-            
+
 #align filter.lift_lift_same_eq_lift Filter.lift_lift_same_eq_lift
 
 theorem lift_principal {s : Set α} (hg : Monotone g) : (𝓟 s).lift g = g s :=
@@ -299,7 +299,7 @@ theorem map_lift'_eq {m : β → γ} (hh : Monotone h) : map m (f.lift' h) = f.l
   calc
     map m (f.lift' h) = f.lift (map m ∘ 𝓟 ∘ h) := map_lift_eq <| monotone_principal.comp hh
     _ = f.lift' (image m ∘ h) := by simp only [comp, Filter.lift', map_principal]
-    
+
 #align filter.map_lift'_eq Filter.map_lift'_eq
 
 theorem lift'_map_le {g : Set β → Set γ} {m : α → β} : (map m f).lift' g ≤ f.lift' (g ∘ image m) :=
@@ -350,7 +350,7 @@ theorem lift_lift'_assoc {g : Set α → Set β} {h : Set β → Filter γ} (hg 
   calc
     (f.lift' g).lift h = f.lift fun s => (𝓟 (g s)).lift h := lift_assoc (monotone_principal.comp hg)
     _ = f.lift fun s => h (g s) := by simp only [lift_principal, hh, eq_self_iff_true]
-    
+
 #align filter.lift_lift'_assoc Filter.lift_lift'_assoc
 
 theorem lift'_lift'_assoc {g : Set α → Set β} {h : Set β → Set γ} (hg : Monotone g)

--- a/Mathlib/Order/Filter/SmallSets.lean
+++ b/Mathlib/Order/Filter/SmallSets.lean
@@ -159,7 +159,7 @@ theorem eventually_smallSets_eventually {p : α → Prop} :
       eventually_small_sets' fun s t hst ht => ht.mono fun x hx hs => hx (hst hs)
     _ ↔ ∃ s ∈ l, ∃ t ∈ l', ∀ x, x ∈ t → x ∈ s → p x := by simp only [eventually_iff_exists_mem]
     _ ↔ ∀ᶠ x in l ⊓ l', p x := by simp only [eventually_inf, and_comm, mem_inter_iff, ← and_imp]
-    
+
 #align filter.eventually_small_sets_eventually Filter.eventually_smallSets_eventually
 
 @[simp]

--- a/Mathlib/SetTheory/Cardinal/Divisibility.lean
+++ b/Mathlib/SetTheory/Cardinal/Divisibility.lean
@@ -132,7 +132,7 @@ theorem nat_is_prime_iff : Prime (n : Cardinal) ↔ n.Prime := by
   wlog hℵ₀b : ℵ₀ ≤ b
   refine' (this h c b _ _ hc hb hℵ₀.symm hn (hℵ₀.resolve_left hℵ₀b)).symm <;> try assumption
   rwa [mul_comm] at hbc
-  rwa [mul_comm] at h' 
+  rwa [mul_comm] at h'
   exact Or.inl (dvd_of_le_of_aleph0_le hn ((nat_lt_aleph0 n).le.trans hℵ₀b) hℵ₀b)
 #align cardinal.nat_is_prime_iff Cardinal.nat_is_prime_iff
 
@@ -160,4 +160,3 @@ theorem isPrimePow_iff {a : Cardinal} : IsPrimePow a ↔ ℵ₀ ≤ a ∨ ∃ n 
 #align cardinal.is_prime_pow_iff Cardinal.isPrimePow_iff
 
 end Cardinal
-

--- a/Mathlib/SetTheory/Cardinal/SchroederBernstein.lean
+++ b/Mathlib/SetTheory/Cardinal/SchroederBernstein.lean
@@ -99,7 +99,7 @@ private def sets :=
   { s : Set (∀ i, β i) | ∀ x ∈ s, ∀ y ∈ s, ∀ (i), (x : ∀ i, β i) i = y i → x = y }
 
 /-- The cardinals are well-ordered. We express it here by the fact that in any set of cardinals
-there is an element that injects into the others. 
+there is an element that injects into the others.
 See `Cardinal.conditionallyCompleteLinearOrderBot` for (one of) the lattice instances. -/
 theorem min_injective [I : Nonempty ι] : ∃ i, Nonempty (∀ j, β i ↪ β j) :=
   let ⟨s, hs, ms⟩ :=

--- a/Mathlib/Topology/Algebra/Order/Group.lean
+++ b/Mathlib/Topology/Algebra/Order/Group.lean
@@ -45,7 +45,7 @@ instance (priority := 100) LinearOrderedAddCommGroup.topologicalAddGroup : Topol
         |x - a + (y - b)| ≤ |x - a| + |y - b| := abs_add _ _
         _ < δ + (ε - δ) := add_lt_add hx hy
         _ = ε := add_sub_cancel'_right _ _
-        
+
     · -- Otherwise `ε`-nhd of each point `a` is `{a}`
       have hε : ∀ {x y}, |x - y| < ε → x = y :=
         by

--- a/Mathlib/Topology/Connected.lean
+++ b/Mathlib/Topology/Connected.lean
@@ -673,7 +673,7 @@ theorem connectedComponent_eq {x y : α} (h : y ∈ connectedComponent x) :
 theorem connectedComponent_eq_iff_mem {x y : α} :
     connectedComponent x = connectedComponent y ↔ x ∈ connectedComponent y :=
   ⟨fun h => h ▸ mem_connectedComponent, fun h => (connectedComponent_eq h).symm⟩
-#align connected_component_eq_iff_mem connectedComponent_eq_iff_mem 
+#align connected_component_eq_iff_mem connectedComponent_eq_iff_mem
 
 theorem connectedComponentIn_eq {x y : α} {F : Set α} (h : y ∈ connectedComponentIn F x) :
     connectedComponentIn F x = connectedComponentIn F y := by

--- a/Mathlib/Topology/DenseEmbedding.lean
+++ b/Mathlib/Topology/DenseEmbedding.lean
@@ -75,7 +75,7 @@ theorem closure_image_mem_nhds {s : Set α} {a : α} (di : DenseInducing i) (hs 
   calc
     U ⊆ closure (i '' (i ⁻¹' U)) := di.dense.subset_closure_image_preimage_of_isOpen hUo
     _ ⊆ closure (i '' s) := closure_mono (image_subset i sub)
-    
+
 #align dense_inducing.closure_image_mem_nhds DenseInducing.closure_image_mem_nhds
 
 theorem dense_image (di : DenseInducing i) {s : Set α} : Dense (i '' s) ↔ Dense s := by
@@ -315,7 +315,7 @@ theorem isClosed_property [TopologicalSpace β] {e : α → β} {p : β → Prop
       univ = closure (range e) := he.closure_range.symm
       _ ⊆ closure { b | p b } := closure_mono <| range_subset_iff.mpr h
       _ = _ := hp.closure_eq
-      
+
   fun _ => this trivial
 #align is_closed_property isClosed_property
 
@@ -388,4 +388,3 @@ theorem Filter.HasBasis.hasBasis_of_denseInducing [TopologicalSpace α] [Topolog
     replace h := (h (s i)).mpr ⟨i, hi, Subset.rfl⟩
     exact hf.closure_image_mem_nhds h
 #align filter.has_basis.has_basis_of_dense_inducing Filter.HasBasis.hasBasis_of_denseInducing
-

--- a/Mathlib/Topology/LocallyConstant/Basic.lean
+++ b/Mathlib/Topology/LocallyConstant/Basic.lean
@@ -288,7 +288,7 @@ theorem congr_fun {f g : LocallyConstant X Y} (h : f = g) (x : X) : f x = g x :=
 #align locally_constant.congr_fun LocallyConstant.congr_fun
 
 theorem congr_arg (f : LocallyConstant X Y) {x y : X} (h : x = y) : f x = f y :=
-  FunLike.congr_arg f h 
+  FunLike.congr_arg f h
 #align locally_constant.congr_arg LocallyConstant.congr_arg
 
 theorem coe_injective : @Function.Injective (LocallyConstant X Y) (X → Y) (↑) := fun _ _ =>
@@ -567,7 +567,7 @@ theorem mulIndicator_apply_eq_if (hU : IsClopen U) :
 variable {a}
 
 @[to_additive]
-theorem mulIndicator_of_mem (hU : IsClopen U) (h : a ∈ U) : f.mulIndicator hU a = f a := 
+theorem mulIndicator_of_mem (hU : IsClopen U) (h : a ∈ U) : f.mulIndicator hU a = f a :=
   Set.mulIndicator_of_mem h _
 #align locally_constant.mul_indicator_of_mem LocallyConstant.mulIndicator_of_mem
 #align locally_constant.indicator_of_mem LocallyConstant.indicator_of_mem

--- a/Mathlib/Topology/MetricSpace/Basic.lean
+++ b/Mathlib/Topology/MetricSpace/Basic.lean
@@ -2161,7 +2161,7 @@ theorem properSpace_of_compact_closedBall_of_le (R : ℝ)
     (closedBall_subset_closedBall <| le_max_left _ _)⟩
 #align proper_space_of_compact_closed_ball_of_le properSpace_of_compact_closedBall_of_le
 
--- A compact pseudometric space is proper 
+-- A compact pseudometric space is proper
 -- see Note [lower instance priority]
 instance (priority := 100) proper_of_compact [CompactSpace α] : ProperSpace α :=
   ⟨fun _ _ => isClosed_ball.isCompact⟩

--- a/Mathlib/Topology/MetricSpace/Lipschitz.lean
+++ b/Mathlib/Topology/MetricSpace/Lipschitz.lean
@@ -182,7 +182,7 @@ theorem edist_lt_of_edist_lt_div (hf : LipschitzWith K f) {x y : α} {d : ℝ≥
   calc
     edist (f x) (f y) ≤ K * edist x y := hf x y
     _ < d := ENNReal.mul_lt_of_lt_div' h
-    
+
 #align lipschitz_with.edist_lt_of_edist_lt_div LipschitzWith.edist_lt_of_edist_lt_div
 
 /-- A Lipschitz function is uniformly continuous -/
@@ -229,7 +229,7 @@ protected theorem comp {Kf Kg : ℝ≥0} {f : β → γ} {g : α → β} (hf : L
     edist (f (g x)) (f (g y)) ≤ Kf * edist (g x) (g y) := hf _ _
     _ ≤ Kf * (Kg * edist x y) := (ENNReal.mul_left_mono (hg _ _))
     _ = (Kf * Kg : ℝ≥0) * edist x y := by rw [← mul_assoc, ENNReal.coe_mul]
-    
+
 #align lipschitz_with.comp LipschitzWith.comp
 
 theorem comp_lipschitzOnWith {Kf Kg : ℝ≥0} {f : β → γ} {g : α → β} {s : Set α}
@@ -604,7 +604,7 @@ theorem continuousOn_prod_of_continuousOn_lipschitz_on [PseudoEMetricSpace α] [
       edist_triangle _ _ _
     _ < ε / 2 + ε / 2 := (ENNReal.add_lt_add ((hb _ hbt).edist_lt_of_edist_lt_div has hx hax) hby)
     _ = ε := ENNReal.add_halves ε
-    
+
 #align continuous_on_prod_of_continuous_on_lipschitz_on continuousOn_prod_of_continuousOn_lipschitz_on
 
 /-- Consider a function `f : α × β → γ`. Suppose that it is continuous on each “vertical section”

--- a/Mathlib/Topology/Separation.lean
+++ b/Mathlib/Topology/Separation.lean
@@ -1220,7 +1220,7 @@ theorem Function.LeftInverse.closed_range [T2Space α] {f : α → β} {g : β �
   have : EqOn (g ∘ f) id (closure <| range g) :=
     h.rightInvOn_range.eqOn.closure (hg.comp hf) continuous_id
   isClosed_of_closure_subset fun x hx => ⟨f x, this hx⟩
-      
+
 #align function.left_inverse.closed_range Function.LeftInverse.closed_range
 
 theorem Function.LeftInverse.closedEmbedding [T2Space α] {f : α → β} {g : β → α}

--- a/test/classical.lean
+++ b/test/classical.lean
@@ -21,7 +21,7 @@ def bar : Bool := by
 def bar' : Bool := by
   fail_if_success have := ∀ p, decide p -- no classical in scope
   exact decide (0 < 1) -- uses the decidable instance
-  
+
 -- check that classical respects tactic blocks
 def bar'' : Bool := by
   fail_if_success have := ∀ p, decide p -- no classical in scope

--- a/test/triv.lean
+++ b/test/triv.lean
@@ -5,8 +5,8 @@ example : True := by
 
 example : 2 + 2 = 4 := by
   triv
-  
+
 -- Verify the difference in behaviour between `triv` and `trivial`.
 example (P : Prop) (h1 : P) (h2 : ¬ P) : False := by
   fail_if_success triv -- fails
-  trivial -- succeeds  
+  trivial -- succeeds


### PR DESCRIPTION
vscode is already configured by `.vscode/settings.json` to trim these on save. It's not clear how they've managed to stick around.

By doing this all in one PR now, it avoids getting random whitespace diffs in PRs later.

This was done with a regex search in vscode,

![image](https://user-images.githubusercontent.com/425260/224557938-4e763925-d69c-411b-89be-4c3141cb4bd7.png)


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
