### PR TITLE
[Merged by Bors] - feat: 'lake exe cache get' decompresses in parallel

### DIFF
--- a/Cache/IO.lean
+++ b/Cache/IO.lean
@@ -169,6 +169,7 @@ def unpackCache (hashMap : HashMap) : IO Unit := do
     IO.println s!"Decompressing {size} file(s)"
     let isMathlibRoot ← isMathlibRoot
     hashMap.forM fun path hash => do
+      let _ ← IO.asTask do
       match path.parent with
       | none | some path => do
         let packageDir ← getPackageDir path


### PR DESCRIPTION
This speeds up the decompression step from 16s to 9.5s on my computer.

(That said, this is getting to be too slow, in either case. Ideally `lake exe cache get`, run twice, would return very quickly on the second run, without doing any decompression work at all.)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
