### PR TITLE
[Merged by Bors] - feat: `LinearOrder α` extends `Ord α`

### DIFF
--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -300,9 +300,9 @@ theorem val_fin_le {n : ℕ} {a b : Fin n} : (a : ℕ) ≤ (b : ℕ) ↔ a ≤ b
 #align fin.coe_fin_le Fin.val_fin_le
 
 instance {n : ℕ} : LinearOrder (Fin n) :=
-  @LinearOrder.lift (Fin n) _ _ ⟨fun x y => ⟨max x y, max_rec' (· < n) x.2 y.2⟩⟩
-    ⟨fun x y => ⟨min x y, min_rec' (· < n) x.2 y.2⟩⟩ Fin.val Fin.val_injective (fun _ _ => rfl)
-    fun _ _ => rfl
+  @LinearOrder.liftWithOrd (Fin n) _ _ ⟨fun x y => ⟨max x y, max_rec' (· < n) x.2 y.2⟩⟩
+    ⟨fun x y => ⟨min x y, min_rec' (· < n) x.2 y.2⟩⟩ _ Fin.val Fin.val_injective (fun _ _ => rfl)
+    (fun _ _ => rfl) (fun _ _ => rfl)
 
 @[simp]
 theorem mk_le_mk {x y : Nat} {hx} {hy} : (⟨x, hx⟩ : Fin n) ≤ ⟨y, hy⟩ ↔ x ≤ y :=

--- a/Mathlib/Init/Algebra/Order.lean
+++ b/Mathlib/Init/Algebra/Order.lean
@@ -376,13 +376,6 @@ theorem compare_eq_iff_eq {a b : α} : (compare a b = .eq) ↔ a = b := by
   case _ _ h => exact true_iff_iff.2 h
   case _ _ h => exact false_iff_iff.2 h
 
-theorem compare_trichotomy {a b : α} :
-    (compare a b = .lt) ∨ (compare a b = .eq) ∨ (compare a b = .gt) :=
-  lt_by_cases a b
-    (fun h ↦ Or.inl (compare_lt_iff_lt.2 h))
-    (fun h ↦ Or.inr <| Or.inl (compare_eq_iff_eq.2 h))
-    (fun h ↦ Or.inr <| Or.inr (compare_gt_iff_gt.2 h))
-
 -- TODO: generalize to instance of LE, Eq (and upstream?)
 -- Move?
 /-- The `Prop` corresponding to each `Ordering` constructor (e.g. `.lt.toProp a b` is `a < b`). -/

--- a/Mathlib/Init/Algebra/Order.lean
+++ b/Mathlib/Init/Algebra/Order.lean
@@ -402,21 +402,15 @@ theorem compare_iff (a b : α) {o : Ordering} : compare a b = o ↔ o.toRel a b 
   · exact compare_eq_iff_eq
   · exact compare_gt_iff_gt
 
--- These are `private` because the user-facing lemmas are the fields of the `TransCmp` instance.
-private theorem compare_symm (a b : α) : Ordering.swap (compare a b) = compare b a := by
-  cases h : compare a b <;>
-  simp only [Ordering.swap] <;> symm
-  · exact compare_gt_iff_gt.2 <| compare_lt_iff_lt.1 h
-  · exact compare_eq_iff_eq.2 <| compare_eq_iff_eq.1 h |>.symm
-  · exact compare_lt_iff_lt.2 <| compare_gt_iff_gt.1 h
-
-private theorem compare_le_trans {a b c : α} : compare a b ≠ Ordering.gt →
-    compare b c ≠ Ordering.gt → compare a c ≠ Ordering.gt
-  | h₁, h₂ => compare_le_iff_le.2 <| le_trans (compare_le_iff_le.1 h₁) (compare_le_iff_le.1 h₂)
-
 instance : Std.TransCmp (compare (α := α)) where
-  symm a b := compare_symm a b
-  le_trans := compare_le_trans
+  symm a b := by
+    cases h : compare a b <;>
+    simp only [Ordering.swap] <;> symm
+    · exact compare_gt_iff_gt.2 <| compare_lt_iff_lt.1 h
+    · exact compare_eq_iff_eq.2 <| compare_eq_iff_eq.1 h |>.symm
+    · exact compare_lt_iff_lt.2 <| compare_gt_iff_gt.1 h
+  le_trans := fun h₁ h₂ ↦
+    compare_le_iff_le.2 <| le_trans (compare_le_iff_le.1 h₁) (compare_le_iff_le.1 h₂)
 
 end Ord
 

--- a/Mathlib/Init/Algebra/Order.lean
+++ b/Mathlib/Init/Algebra/Order.lean
@@ -388,16 +388,16 @@ theorem compare_ge_iff_ge {a b : α} : (compare a b ≠ .lt) ↔ a ≥ b := by
   · exact true_iff_iff.2 <| le_of_eq <| (·.symm) <| compare_eq_iff_eq.1 h
   · exact true_iff_iff.2 <| le_of_lt <| compare_gt_iff_gt.1 h
 
--- TODO: generalize to instance of LE, Eq (and upstream?)
+-- TODO: generalize to instance of LT/GT/Eq (and upstream?)
 -- Move?
-/-- The `Prop` corresponding to each `Ordering` constructor (e.g. `.lt.toProp a b` is `a < b`). -/
-def Ordering.toProp (o : Ordering) (a b : α) : Prop := match o with
-| .lt => a < b
-| .eq => a = b
-| .gt => a > b
+/-- The relation corresponding to each `Ordering` constructor (e.g. `.lt.toProp a b` is `a < b`). -/
+def Ordering.toRel : Ordering → α → α → Prop
+| .lt => (· < ·)
+| .eq => Eq
+| .gt => (· > ·)
 
-theorem compare_iff (a b : α) {o : Ordering} : compare a b = o ↔ Ordering.toProp o a b := by
-  cases o <;> simp only [Ordering.toProp]
+theorem compare_iff (a b : α) {o : Ordering} : compare a b = o ↔ o.toRel a b := by
+  cases o <;> simp only [Ordering.toRel]
   · exact compare_lt_iff_lt
   · exact compare_eq_iff_eq
   · exact compare_gt_iff_gt

--- a/Mathlib/Init/Algebra/Order.lean
+++ b/Mathlib/Init/Algebra/Order.lean
@@ -356,4 +356,26 @@ theorem le_imp_le_of_lt_imp_lt {β} [Preorder α] [LinearOrder β]
   {a b : α} {c d : β} (H : d < c → b < a) (h : a ≤ b) : c ≤ d :=
 le_of_not_lt $ λ h' => not_le_of_gt (H h') h
 
+section Ord
+
+theorem compare_lt_iff_lt (a b : α) : (compare a b = .lt) ↔ a < b := by
+  rw [LinearOrder.compare_eq_compareOfLessAndEq, compareOfLessAndEq]
+  split_ifs <;> simp only [*, lt_irrefl]
+
+theorem compare_gt_iff_gt (a b : α) : (compare a b = .gt) ↔ a > b := by
+  rw [LinearOrder.compare_eq_compareOfLessAndEq, compareOfLessAndEq]
+  split_ifs <;> simp only [*, lt_irrefl, not_lt_of_gt]
+  case _ h₁ h₂ =>
+    have h : b < a := lt_trichotomy a b |>.resolve_left h₁ |>.resolve_left h₂
+    exact true_iff_iff.2 h
+
+theorem compare_eq_iff_eq (a b : α) : (compare a b = .eq) ↔ a = b := by
+  rw [LinearOrder.compare_eq_compareOfLessAndEq, compareOfLessAndEq]
+  split_ifs <;> simp only []
+  case _ h   => exact false_iff_iff.2 <| ne_iff_lt_or_gt.2 <| .inl h
+  case _ _ h => exact true_iff_iff.2 h
+  case _ _ h => exact false_iff_iff.2 h
+
+end Ord
+
 end LinearOrder

--- a/Mathlib/Init/Algebra/Order.lean
+++ b/Mathlib/Init/Algebra/Order.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura, Deniz Aydin
 -/
 import Mathlib.Init.Logic
+import Mathlib.Init.Data.Ordering.Basic
 import Mathlib.Tactic.Relation.Rfl
 import Mathlib.Tactic.SplitIfs
 

--- a/Mathlib/Init/Algebra/Order.lean
+++ b/Mathlib/Init/Algebra/Order.lean
@@ -402,6 +402,21 @@ theorem compare_iff (a b : α) {o : Ordering} : compare a b = o ↔ Ordering.toP
   · exact compare_eq_iff_eq
   · exact compare_gt_iff_gt
 
+theorem compare_symm (a b : α) : Ordering.swap (compare a b) = compare b a := by
+  cases h : compare a b <;>
+  simp only [Ordering.swap] <;> symm
+  · exact compare_gt_iff_gt.2 <| compare_lt_iff_lt.1 h
+  · exact compare_eq_iff_eq.2 <| compare_eq_iff_eq.1 h |>.symm
+  · exact compare_lt_iff_lt.2 <| compare_gt_iff_gt.1 h
+
+theorem compare_le_trans {a b c : α} : compare a b ≠ Ordering.gt → compare b c ≠ Ordering.gt →
+    compare a c ≠ Ordering.gt := fun h₁ h₂ ↦
+  compare_le_iff_le.2 <| le_trans (compare_le_iff_le.1 h₁) (compare_le_iff_le.1 h₂)
+
+instance : Std.TransCmp (compare (α := α)) where
+  symm a b := compare_symm a b
+  le_trans := compare_le_trans
+
 end Ord
 
 end LinearOrder

--- a/Mathlib/Init/Algebra/Order.lean
+++ b/Mathlib/Init/Algebra/Order.lean
@@ -376,6 +376,13 @@ theorem compare_eq_iff_eq {a b : α} : (compare a b = .eq) ↔ a = b := by
   case _ _ h => exact true_iff_iff.2 h
   case _ _ h => exact false_iff_iff.2 h
 
+theorem compare_trichotomy {a b : α} :
+    (compare a b = .lt) ∨ (compare a b = .eq) ∨ (compare a b = .gt) :=
+  lt_by_cases a b
+    (fun h ↦ Or.inl (compare_lt_iff_lt.2 h))
+    (fun h ↦ Or.inr <| Or.inl (compare_eq_iff_eq.2 h))
+    (fun h ↦ Or.inr <| Or.inr (compare_gt_iff_gt.2 h))
+
 end Ord
 
 end LinearOrder

--- a/Mathlib/Init/Algebra/Order.lean
+++ b/Mathlib/Init/Algebra/Order.lean
@@ -410,8 +410,8 @@ theorem compare_symm (a b : α) : Ordering.swap (compare a b) = compare b a := b
   · exact compare_lt_iff_lt.2 <| compare_gt_iff_gt.1 h
 
 theorem compare_le_trans {a b c : α} : compare a b ≠ Ordering.gt → compare b c ≠ Ordering.gt →
-    compare a c ≠ Ordering.gt := fun h₁ h₂ ↦
-  compare_le_iff_le.2 <| le_trans (compare_le_iff_le.1 h₁) (compare_le_iff_le.1 h₂)
+    compare a c ≠ Ordering.gt
+  | h₁, h₂ => compare_le_iff_le.2 <| le_trans (compare_le_iff_le.1 h₁) (compare_le_iff_le.1 h₂)
 
 instance : Std.TransCmp (compare (α := α)) where
   symm a b := compare_symm a b

--- a/Mathlib/Init/Algebra/Order.lean
+++ b/Mathlib/Init/Algebra/Order.lean
@@ -216,7 +216,7 @@ if a ≤ b then a else b
 
 /-- A linear order is reflexive, transitive, antisymmetric and total relation `≤`.
 We assume that every linear ordered type has decidable `(≤)`, `(<)`, and `(=)`. -/
-class LinearOrder (α : Type u) extends PartialOrder α, Min α, Max α :=
+class LinearOrder (α : Type u) extends PartialOrder α, Min α, Max α, Ord α :=
   /-- A linear order is total. -/
   le_total (a b : α) : a ≤ b ∨ b ≤ a
   /-- In a linearly ordered type, we assume the order relations are all decidable. -/
@@ -232,6 +232,9 @@ class LinearOrder (α : Type u) extends PartialOrder α, Min α, Max α :=
   min_def : ∀ a b, min a b = if a ≤ b then a else b := by intros; rfl
   /-- The minimum function is equivalent to the one you get from `maxOfLe`. -/
   max_def : ∀ a b, max a b = if a ≤ b then b else a := by intros; rfl
+  compare a b := compareOfLessAndEq a b
+  /-- Comparison via `compare` is equal to the canonical comparison given decidable `<` and `=`. -/
+  compare_eq_compareOfLessAndEq : ∀ a b, compare a b = compareOfLessAndEq a b := by intros; rfl
 
 variable [LinearOrder α]
 

--- a/Mathlib/Init/Algebra/Order.lean
+++ b/Mathlib/Init/Algebra/Order.lean
@@ -388,14 +388,6 @@ theorem compare_ge_iff_ge {a b : α} : (compare a b ≠ .lt) ↔ a ≥ b := by
   · exact true_iff_iff.2 <| le_of_eq <| (·.symm) <| compare_eq_iff_eq.1 h
   · exact true_iff_iff.2 <| le_of_lt <| compare_gt_iff_gt.1 h
 
--- TODO: generalize to instance of LT/GT/Eq (and upstream?)
--- Move?
-/-- The relation corresponding to each `Ordering` constructor (e.g. `.lt.toProp a b` is `a < b`). -/
-def Ordering.toRel : Ordering → α → α → Prop
-| .lt => (· < ·)
-| .eq => Eq
-| .gt => (· > ·)
-
 theorem compare_iff (a b : α) {o : Ordering} : compare a b = o ↔ o.toRel a b := by
   cases o <;> simp only [Ordering.toRel]
   · exact compare_lt_iff_lt

--- a/Mathlib/Init/Algebra/Order.lean
+++ b/Mathlib/Init/Algebra/Order.lean
@@ -376,6 +376,18 @@ theorem compare_eq_iff_eq {a b : α} : (compare a b = .eq) ↔ a = b := by
   case _ _ h => exact true_iff_iff.2 h
   case _ _ h => exact false_iff_iff.2 h
 
+theorem compare_le_iff_le {a b : α} : (compare a b ≠ .gt) ↔ a ≤ b := by
+  cases h : compare a b <;> simp only []
+  · exact true_iff_iff.2 <| le_of_lt <| compare_lt_iff_lt.1 h
+  · exact true_iff_iff.2 <| le_of_eq <| compare_eq_iff_eq.1 h
+  · exact false_iff_iff.2 <| not_le_of_gt <| compare_gt_iff_gt.1 h
+
+theorem compare_ge_iff_ge {a b : α} : (compare a b ≠ .lt) ↔ a ≥ b := by
+  cases h : compare a b <;> simp only []
+  · exact false_iff_iff.2 <| (lt_iff_not_ge a b).1 <| compare_lt_iff_lt.1 h
+  · exact true_iff_iff.2 <| le_of_eq <| (·.symm) <| compare_eq_iff_eq.1 h
+  · exact true_iff_iff.2 <| le_of_lt <| compare_gt_iff_gt.1 h
+
 -- TODO: generalize to instance of LE, Eq (and upstream?)
 -- Move?
 /-- The `Prop` corresponding to each `Ordering` constructor (e.g. `.lt.toProp a b` is `a < b`). -/

--- a/Mathlib/Init/Algebra/Order.lean
+++ b/Mathlib/Init/Algebra/Order.lean
@@ -358,18 +358,18 @@ le_of_not_lt $ λ h' => not_le_of_gt (H h') h
 
 section Ord
 
-theorem compare_lt_iff_lt (a b : α) : (compare a b = .lt) ↔ a < b := by
+theorem compare_lt_iff_lt {a b : α} : (compare a b = .lt) ↔ a < b := by
   rw [LinearOrder.compare_eq_compareOfLessAndEq, compareOfLessAndEq]
   split_ifs <;> simp only [*, lt_irrefl]
 
-theorem compare_gt_iff_gt (a b : α) : (compare a b = .gt) ↔ a > b := by
+theorem compare_gt_iff_gt {a b : α} : (compare a b = .gt) ↔ a > b := by
   rw [LinearOrder.compare_eq_compareOfLessAndEq, compareOfLessAndEq]
   split_ifs <;> simp only [*, lt_irrefl, not_lt_of_gt]
   case _ h₁ h₂ =>
     have h : b < a := lt_trichotomy a b |>.resolve_left h₁ |>.resolve_left h₂
     exact true_iff_iff.2 h
 
-theorem compare_eq_iff_eq (a b : α) : (compare a b = .eq) ↔ a = b := by
+theorem compare_eq_iff_eq {a b : α} : (compare a b = .eq) ↔ a = b := by
   rw [LinearOrder.compare_eq_compareOfLessAndEq, compareOfLessAndEq]
   split_ifs <;> simp only []
   case _ h   => exact false_iff_iff.2 <| ne_iff_lt_or_gt.2 <| .inl h

--- a/Mathlib/Init/Algebra/Order.lean
+++ b/Mathlib/Init/Algebra/Order.lean
@@ -215,6 +215,15 @@ if a ≤ b then b else a
 def minDefault {α : Type u} [LE α] [DecidableRel ((· ≤ ·) : α → α → Prop)] (a b : α) :=
 if a ≤ b then a else b
 
+/-- This attempts to prove that a given instance of `compare` is equal to `compareOfLessAndEq` by
+introducing the arguments and trying the following approaches in order:
+
+1. seeing if `rfl` works
+2. seeing if the `compare` at hand is nonetheless essentially `compareOfLessAndEq`, but, because of
+implicit arguments, requires us to unfold the defs and split the `if`s in the definition of
+`compareOfLessAndEq`
+3. seeing if we can split by cases on the arguments, then see if the defs work themselves out
+  (useful when `compare` is defined via a `match` statement, as it is for `Bool`) -/
 macro "compareOfLessAndEq_rfl" : tactic =>
   `(tactic| (intros a b; first | rfl |
     (simp only [compare, compareOfLessAndEq]; split_ifs <;> rfl) |

--- a/Mathlib/Init/Algebra/Order.lean
+++ b/Mathlib/Init/Algebra/Order.lean
@@ -383,6 +383,20 @@ theorem compare_trichotomy {a b : α} :
     (fun h ↦ Or.inr <| Or.inl (compare_eq_iff_eq.2 h))
     (fun h ↦ Or.inr <| Or.inr (compare_gt_iff_gt.2 h))
 
+-- TODO: generalize to instance of LE, Eq (and upstream?)
+-- Move?
+/-- The `Prop` corresponding to each `Ordering` constructor (e.g. `.lt.toProp a b` is `a < b`). -/
+def Ordering.toProp (o : Ordering) (a b : α) : Prop := match o with
+| .lt => a < b
+| .eq => a = b
+| .gt => a > b
+
+theorem compare_iff (a b : α) {o : Ordering} : compare a b = o ↔ Ordering.toProp o a b := by
+  cases o <;> simp only [Ordering.toProp]
+  · exact compare_lt_iff_lt
+  · exact compare_eq_iff_eq
+  · exact compare_gt_iff_gt
+
 end Ord
 
 end LinearOrder

--- a/Mathlib/Init/Algebra/Order.lean
+++ b/Mathlib/Init/Algebra/Order.lean
@@ -402,15 +402,16 @@ theorem compare_iff (a b : α) {o : Ordering} : compare a b = o ↔ o.toRel a b 
   · exact compare_eq_iff_eq
   · exact compare_gt_iff_gt
 
-theorem compare_symm (a b : α) : Ordering.swap (compare a b) = compare b a := by
+-- These are `private` because the user-facing lemmas are the fields of the `TransCmp` instance.
+private theorem compare_symm (a b : α) : Ordering.swap (compare a b) = compare b a := by
   cases h : compare a b <;>
   simp only [Ordering.swap] <;> symm
   · exact compare_gt_iff_gt.2 <| compare_lt_iff_lt.1 h
   · exact compare_eq_iff_eq.2 <| compare_eq_iff_eq.1 h |>.symm
   · exact compare_lt_iff_lt.2 <| compare_gt_iff_gt.1 h
 
-theorem compare_le_trans {a b c : α} : compare a b ≠ Ordering.gt → compare b c ≠ Ordering.gt →
-    compare a c ≠ Ordering.gt
+private theorem compare_le_trans {a b c : α} : compare a b ≠ Ordering.gt →
+    compare b c ≠ Ordering.gt → compare a c ≠ Ordering.gt
   | h₁, h₂ => compare_le_iff_le.2 <| le_trans (compare_le_iff_le.1 h₁) (compare_le_iff_le.1 h₂)
 
 instance : Std.TransCmp (compare (α := α)) where

--- a/Mathlib/Init/Algebra/Order.lean
+++ b/Mathlib/Init/Algebra/Order.lean
@@ -5,6 +5,7 @@ Authors: Leonardo de Moura, Deniz Aydin
 -/
 import Mathlib.Init.Logic
 import Mathlib.Tactic.Relation.Rfl
+import Mathlib.Tactic.SplitIfs
 
 /-!
 # Orders
@@ -214,6 +215,11 @@ if a ≤ b then b else a
 def minDefault {α : Type u} [LE α] [DecidableRel ((· ≤ ·) : α → α → Prop)] (a b : α) :=
 if a ≤ b then a else b
 
+macro "compareOfLessAndEq_rfl" : tactic =>
+  `(tactic| (intros a b; first | rfl |
+    (simp only [compare, compareOfLessAndEq]; split_ifs <;> rfl) |
+    (induction a <;> induction b <;> simp only [])))
+
 /-- A linear order is reflexive, transitive, antisymmetric and total relation `≤`.
 We assume that every linear ordered type has decidable `(≤)`, `(<)`, and `(=)`. -/
 class LinearOrder (α : Type u) extends PartialOrder α, Min α, Max α, Ord α :=
@@ -234,7 +240,8 @@ class LinearOrder (α : Type u) extends PartialOrder α, Min α, Max α, Ord α 
   max_def : ∀ a b, max a b = if a ≤ b then b else a := by intros; rfl
   compare a b := compareOfLessAndEq a b
   /-- Comparison via `compare` is equal to the canonical comparison given decidable `<` and `=`. -/
-  compare_eq_compareOfLessAndEq : ∀ a b, compare a b = compareOfLessAndEq a b := by intros; rfl
+  compare_eq_compareOfLessAndEq : ∀ a b, compare a b = compareOfLessAndEq a b := by
+    compareOfLessAndEq_rfl
 
 variable [LinearOrder α]
 

--- a/Mathlib/Init/Data/Ordering/Basic.lean
+++ b/Mathlib/Init/Data/Ordering/Basic.lean
@@ -19,6 +19,12 @@ def orElse : Ordering → Ordering → Ordering
   | eq, o => o
   | gt, _ => gt
 
+/-- The relation corresponding to each `Ordering` constructor (e.g. `.lt.toProp a b` is `a < b`). -/
+def toRel [LT α] : Ordering → α → α → Prop
+| .lt => (· < ·)
+| .eq => Eq
+| .gt => (· > ·)
+
 end Ordering
 
 /--

--- a/Mathlib/Order/Basic.lean
+++ b/Mathlib/Order/Basic.lean
@@ -616,12 +616,18 @@ theorem PartialOrder.toPreorder_injective {α : Type _} :
 theorem LinearOrder.toPartialOrder_injective {α : Type _} :
     Function.Injective (@LinearOrder.toPartialOrder α) :=
   fun A B h ↦ match A, B with
-  | { le := A_le, lt := A_lt, decidable_le := A_decidable_le,
-      min := A_min, max := A_max, min_def := A_min_def, max_def := A_max_def, .. },
-    { le := B_le, lt := B_lt, decidable_le := B_decidable_le,
-      min := B_min, max := B_max, min_def := B_min_def, max_def := B_max_def, .. } => by
+  | { le := A_le, lt := A_lt,
+      decidable_le := A_decidable_le, decidable_eq := A_decidable_eq, decidable_lt := A_decidable_lt
+      min := A_min, max := A_max, min_def := A_min_def, max_def := A_max_def,
+      compare := A_compare, compare_eq_compareOfLessAndEq := A_compare_canonical,  .. },
+    { le := B_le, lt := B_lt,
+      decidable_le := B_decidable_le, decidable_eq := B_decidable_eq, decidable_lt := B_decidable_lt
+      min := B_min, max := B_max, min_def := B_min_def, max_def := B_max_def,
+      compare := B_compare, compare_eq_compareOfLessAndEq := B_compare_canonical, .. } => by
     cases h
     obtain rfl : A_decidable_le = B_decidable_le := Subsingleton.elim _ _
+    obtain rfl : A_decidable_eq = B_decidable_eq := Subsingleton.elim _ _
+    obtain rfl : A_decidable_lt = B_decidable_lt := Subsingleton.elim _ _
     have : A_min = B_min := by
       funext a b
       exact (A_min_def _ _).trans (B_min_def _ _).symm
@@ -630,7 +636,10 @@ theorem LinearOrder.toPartialOrder_injective {α : Type _} :
       funext a b
       exact (A_max_def _ _).trans (B_max_def _ _).symm
     cases this
-    congr <;> exact Subsingleton.elim _ _
+    have : A_compare = B_compare := by
+      funext a b
+      exact (A_compare_canonical _ _).trans (B_compare_canonical _ _).symm
+    congr
 #align linear_order.to_partial_order_injective LinearOrder.toPartialOrder_injective
 
 theorem Preorder.ext {α} {A B : Preorder α}

--- a/Mathlib/Order/Basic.lean
+++ b/Mathlib/Order/Basic.lean
@@ -1017,10 +1017,10 @@ fields. See note [reducible non-instances]. -/
 def LinearOrder.lift {α β} [LinearOrder β] [Sup α] [Inf α] (f : α → β) (inj : Injective f)
     (hsup : ∀ x y, f (x ⊔ y) = max (f x) (f y)) (hinf : ∀ x y, f (x ⊓ y) = min (f x) (f y)) :
     LinearOrder α :=
-  let instOrdα : Ord α := ⟨fun a b ↦ compare (f a) (f b)⟩
-  let decidable_le := fun x y ↦ (inferInstance : Decidable (f x ≤ f y))
-  let decidable_lt := fun x y ↦ (inferInstance : Decidable (f x < f y))
-  let decidable_eq := fun x y ↦ decidable_of_iff (f x = f y) inj.eq_iff
+  letI instOrdα : Ord α := ⟨fun a b ↦ compare (f a) (f b)⟩
+  letI decidable_le := fun x y ↦ (inferInstance : Decidable (f x ≤ f y))
+  letI decidable_lt := fun x y ↦ (inferInstance : Decidable (f x < f y))
+  letI decidable_eq := fun x y ↦ decidable_of_iff (f x = f y) inj.eq_iff
   { PartialOrder.lift f inj, instOrdα with
     le_total := fun x y ↦ le_total (f x) (f y)
     decidable_le := decidable_le
@@ -1065,9 +1065,9 @@ def LinearOrder.liftWithOrd {α β} [LinearOrder β] [Sup α] [Inf α] [Ord α] 
     (inj : Injective f) (hsup : ∀ x y, f (x ⊔ y) = max (f x) (f y))
     (hinf : ∀ x y, f (x ⊓ y) = min (f x) (f y))
     (compare_f : ∀ a b : α, compare a b = compare (f a) (f b)) : LinearOrder α :=
-  let decidable_le := fun x y ↦ (inferInstance : Decidable (f x ≤ f y))
-  let decidable_lt := fun x y ↦ (inferInstance : Decidable (f x < f y))
-  let decidable_eq := fun x y ↦ decidable_of_iff (f x = f y) inj.eq_iff
+  letI decidable_le := fun x y ↦ (inferInstance : Decidable (f x ≤ f y))
+  letI decidable_lt := fun x y ↦ (inferInstance : Decidable (f x < f y))
+  letI decidable_eq := fun x y ↦ decidable_of_iff (f x = f y) inj.eq_iff
   { PartialOrder.lift f inj with
     le_total := fun x y ↦ le_total (f x) (f y)
     decidable_le := decidable_le

--- a/Mathlib/Order/Basic.lean
+++ b/Mathlib/Order/Basic.lean
@@ -995,7 +995,7 @@ def PartialOrder.lift {α β} [PartialOrder β] (f : α → β) (inj : Injective
   { Preorder.lift f with le_antisymm := fun _ _ h₁ h₂ ↦ inj (h₁.antisymm h₂) }
 #align partial_order.lift PartialOrder.lift
 
-theorem compareOfLessAndEq_of_injective_eq_compareOfLessAndEq (a b : α) [LinearOrder β]
+theorem compare_of_injective_eq_compareOfLessAndEq (a b : α) [LinearOrder β]
     [DecidableEq α] (f : α → β) (inj : Injective f)
     [Decidable (LT.lt (self := PartialOrder.lift f inj |>.toLT) a b)] :
     compare (f a) (f b) =
@@ -1039,7 +1039,7 @@ def LinearOrder.lift {α β} [LinearOrder β] [Sup α] [Inf α] (f : α → β) 
       rw [apply_ite f]
       exact (hsup _ _).trans (max_def _ _)
     compare_eq_compareOfLessAndEq := fun a b ↦
-      compareOfLessAndEq_of_injective_eq_compareOfLessAndEq a b f inj }
+      compare_of_injective_eq_compareOfLessAndEq a b f inj }
 
 /-- Transfer a `LinearOrder` on `β` to a `LinearOrder` on `α` using an injective
 function `f : α → β`. This version autogenerates `min` and `max` fields. See `LinearOrder.lift`
@@ -1086,7 +1086,7 @@ def LinearOrder.liftWithOrd {α β} [LinearOrder β] [Sup α] [Inf α] [Ord α] 
       rw [apply_ite f]
       exact (hsup _ _).trans (max_def _ _)
     compare_eq_compareOfLessAndEq := fun a b ↦
-      (compare_f a b).trans <| compareOfLessAndEq_of_injective_eq_compareOfLessAndEq a b f inj }
+      (compare_f a b).trans <| compare_of_injective_eq_compareOfLessAndEq a b f inj }
 
 /-- Transfer a `LinearOrder` on `β` to a `LinearOrder` on `α` using an injective
 function `f : α → β`. This version auto-generates `min` and `max` fields. It also takes `[Ord α]`

--- a/Mathlib/Order/Basic.lean
+++ b/Mathlib/Order/Basic.lean
@@ -995,7 +995,7 @@ def PartialOrder.lift {α β} [PartialOrder β] (f : α → β) (inj : Injective
   { Preorder.lift f with le_antisymm := fun _ _ h₁ h₂ ↦ inj (h₁.antisymm h₂) }
 #align partial_order.lift PartialOrder.lift
 
-theorem compareOfLessAndEq_of_injective_eq_compareOfLessAndEq (a b : α) [Ord α] [LinearOrder β]
+theorem compareOfLessAndEq_of_injective_eq_compareOfLessAndEq (a b : α) [LinearOrder β]
     [DecidableEq α] (f : α → β) (inj : Injective f)
     [Decidable (LT.lt (self := PartialOrder.lift f inj |>.toLT) a b)] :
     compare (f a) (f b) =

--- a/Mathlib/Tactic/Ring/Basic.lean
+++ b/Mathlib/Tactic/Ring/Basic.lean
@@ -77,10 +77,6 @@ This feature wasn't needed yet, so it's not implemented yet.
 ring, semiring, exponent, power
 -/
 
--- TODO: move somewhere else
-instance : Ord ℚ where
-  compare x y := compareOfLessAndEq x y
-
 namespace Mathlib.Tactic
 namespace Ring
 open Mathlib.Meta Qq NormNum Lean.Meta AtomM


### PR DESCRIPTION
This PR makes `LinearOrder` lawfully extend `Ord`.

Since `LinearOrder` has decidable order relations, we take `compare` to be `compareOfLessAndEq` by default for a linear order.

Since typeclass synthesis is preferred by structure instances to optparams, this does not create non-defeq diamonds for types which already have a different implementation of `Ord`.

We also add a field `compare_eq_compareOfLessAndEq` which encodes the lawful quality by demanding equality to the canonical comparison.

Motivation: `Array` functions like `min` largely use `Ord`, so this lets us seamlessly use these array functions when we only have a linear order.

See [zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Ord.20.C9.91.20from.20LinearOrder.20.C9.91.3F).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
