### PR TITLE
[Merged by Bors] - fix: prevent `Int.ofNat` being used instead of `Nat.cast`

### DIFF
--- a/Mathlib/Data/Nat/Cast/Defs.lean
+++ b/Mathlib/Data/Nat/Cast/Defs.lean
@@ -45,6 +45,9 @@ instance [NatCast R] : CoeTail ℕ R where coe := Nat.cast
 -- see note [coercion into rings]
 instance [NatCast R] : CoeHTCT ℕ R where coe := Nat.cast
 
+/-- This instance is needed to ensure that `instCoeNatInt` is not used. -/
+instance : Coe ℕ ℤ where coe := Nat.cast
+
 -- the following four declarations are not in mathlib3 and are relevant to the way numeric
 -- literals are handled in Lean 4.
 

--- a/Mathlib/Data/PNat/Defs.lean
+++ b/Mathlib/Data/PNat/Defs.lean
@@ -10,6 +10,7 @@ Authors: Mario Carneiro, Neil Strickland
 -/
 
 import Mathlib.Algebra.NeZero
+import Mathlib.Data.Nat.Cast.Defs
 import Mathlib.Order.Basic
 import Mathlib.Tactic.Coe
 import Mathlib.Tactic.Lift
@@ -299,7 +300,7 @@ instance Nat.canLiftPNat : CanLift ℕ ℕ+ (↑) (fun n => 0 < n) :=
 instance Int.canLiftPNat : CanLift ℤ ℕ+ (↑) ((0 < ·)) :=
   ⟨fun n hn =>
     ⟨Nat.toPNat' (Int.natAbs n), by
-      rw [Nat.toPNat'_coe, if_pos (Int.natAbs_pos.2 hn.ne'), Int.ofNat_eq_coe,
+      rw [Nat.toPNat'_coe, if_pos (Int.natAbs_pos.2 hn.ne'),
         Int.natAbs_of_nonneg hn.le]⟩⟩
 #align int.can_lift_pnat Int.canLiftPNat
 


### PR DESCRIPTION
Without this override, the coercion is found as `instCoeNatInt : Coe ℕ ℤ` which unfolds to `Int.ofNat`. This only happened when searching for `Coe ℕ ℤ`; `CoeHTCT ℕ ℤ` would already find the correct instance.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
