### PR TITLE
[Merged by Bors] - feat: support and improve notation_class in simps

### DIFF
--- a/Mathlib/Algebra/Group/Defs.lean
+++ b/Mathlib/Algebra/Group/Defs.lean
@@ -1175,3 +1175,10 @@ instance (priority := 100) CommGroup.toDivisionCommMonoid : DivisionCommMonoid G
   { ‹CommGroup G›, Group.toDivisionMonoid with }
 
 end CommGroup
+
+initialize_simps_projections Neg
+initialize_simps_projections Semigroup
+initialize_simps_projections AddSemigroup
+initialize_simps_projections Monoid
+initialize_simps_projections Group
+initialize_simps_projections AddMonoid

--- a/Mathlib/Algebra/Group/Defs.lean
+++ b/Mathlib/Algebra/Group/Defs.lean
@@ -63,6 +63,10 @@ class HSMul (α : Type u) (β : Type v) (γ : outParam (Type w)) where
   The meaning of this notation is type-dependent. -/
   hSMul : α → β → γ
 
+attribute [notation_class  smul Simps.copySecond] HSMul
+attribute [notation_class nsmul Simps.nsmulArgs]  HSMul
+attribute [notation_class zsmul Simps.zsmulArgs]  HSMul
+
 /-- Type class for the `+ᵥ` notation. -/
 class VAdd (G : Type _) (P : Type _) where
   vadd : G → P → P
@@ -100,7 +104,7 @@ universe u
 variable {G : Type _}
 
 /-- Class of types that have an inversion operation. -/
-@[to_additive]
+@[to_additive, notation_class]
 class Inv (α : Type u) where
   /-- Invert an element of α. -/
   inv : α → α
@@ -1176,9 +1180,41 @@ instance (priority := 100) CommGroup.toDivisionCommMonoid : DivisionCommMonoid G
 
 end CommGroup
 
-initialize_simps_projections Neg
+/-! We initialize all projections for `@[simps]` here, so that we don't have to do it in later
+files.
+
+Note: the lemmas generated for the `npow`/`zpow` projections will *not* apply to `x ^ y`, since the
+argument order of these projections doesn't match the argument order of `^`.
+The `nsmul`/`zsmul` lemmas will be correct. -/
 initialize_simps_projections Semigroup
 initialize_simps_projections AddSemigroup
+initialize_simps_projections CommSemigroup
+initialize_simps_projections AddCommSemigroup
+initialize_simps_projections LeftCancelSemigroup
+initialize_simps_projections AddLeftCancelSemigroup
+initialize_simps_projections RightCancelSemigroup
+initialize_simps_projections AddRightCancelSemigroup
 initialize_simps_projections Monoid
-initialize_simps_projections Group
 initialize_simps_projections AddMonoid
+initialize_simps_projections CommMonoid
+initialize_simps_projections AddCommMonoid
+initialize_simps_projections LeftCancelMonoid
+initialize_simps_projections AddLeftCancelMonoid
+initialize_simps_projections RightCancelMonoid
+initialize_simps_projections AddRightCancelMonoid
+initialize_simps_projections CancelMonoid
+initialize_simps_projections AddCancelMonoid
+initialize_simps_projections CancelCommMonoid
+initialize_simps_projections AddCancelCommMonoid
+initialize_simps_projections DivInvMonoid
+initialize_simps_projections SubNegMonoid
+initialize_simps_projections DivInvOneMonoid
+initialize_simps_projections SubNegZeroMonoid
+initialize_simps_projections DivisionMonoid
+initialize_simps_projections SubtractionMonoid
+initialize_simps_projections DivisionCommMonoid
+initialize_simps_projections SubtractionCommMonoid
+initialize_simps_projections Group
+initialize_simps_projections AddGroup
+initialize_simps_projections CommGroup
+initialize_simps_projections AddCommGroup

--- a/Mathlib/Data/FunLike/Basic.lean
+++ b/Mathlib/Data/FunLike/Basic.lean
@@ -128,7 +128,7 @@ injective coercion to functions from `α` to `β`.
 This typeclass is used in the definition of the homomorphism typeclasses,
 such as `ZeroHomClass`, `MulHomClass`, `MonoidHomClass`, ....
 -/
-@[notation_class* toFun]
+@[notation_class * toFun Simps.findCoercionArgs]
 class FunLike (F : Sort _) (α : outParam (Sort _)) (β : outParam <| α → Sort _) where
   /-- The coercion from `F` to a function. -/
   coe : F → ∀ a : α, β a

--- a/Mathlib/Data/FunLike/Basic.lean
+++ b/Mathlib/Data/FunLike/Basic.lean
@@ -128,6 +128,7 @@ injective coercion to functions from `α` to `β`.
 This typeclass is used in the definition of the homomorphism typeclasses,
 such as `ZeroHomClass`, `MulHomClass`, `MonoidHomClass`, ....
 -/
+@[notation_class* toFun]
 class FunLike (F : Sort _) (α : outParam (Sort _)) (β : outParam <| α → Sort _) where
   /-- The coercion from `F` to a function. -/
   coe : F → ∀ a : α, β a

--- a/Mathlib/Data/SetLike/Basic.lean
+++ b/Mathlib/Data/SetLike/Basic.lean
@@ -95,6 +95,7 @@ Then you should *not* repeat the `outParam` declaration so `SetLike` will supply
 This ensures your subclass will not have issues with synthesis of the `[Mul M]` parameter starting
 before the value of `M` is known.
 -/
+@[notation_class* carrier]
 class SetLike (A : Type _) (B : outParam <| Type _) where
   /-- The coercion from a term of a `SetLike` to its corresponding `Set`. -/
   protected coe : A → Set B

--- a/Mathlib/Data/SetLike/Basic.lean
+++ b/Mathlib/Data/SetLike/Basic.lean
@@ -95,7 +95,7 @@ Then you should *not* repeat the `outParam` declaration so `SetLike` will supply
 This ensures your subclass will not have issues with synthesis of the `[Mul M]` parameter starting
 before the value of `M` is known.
 -/
-@[notation_class* carrier]
+@[notation_class * carrier Simps.findCoercionArgs]
 class SetLike (A : Type _) (B : outParam <| Type _) where
   /-- The coercion from a term of a `SetLike` to its corresponding `Set`. -/
   protected coe : A → Set B

--- a/Mathlib/Lean/Expr/Basic.lean
+++ b/Mathlib/Lean/Expr/Basic.lean
@@ -179,11 +179,6 @@ def bvarIdx? : Expr → Option Nat
 def getAppFnArgs (e : Expr) : Name × Array Expr :=
   withApp e λ e a => (e.constName, a)
 
-/-- Get the arity of a type, i.e. the number of forall binders -/
-def getNumForallBinders : Expr → Nat
-  | .forallE _ _ b _ => b.getNumForallBinders + 1
-  | _ => 0
-
 /-- Turn an expression that is a natural number literal into a natural number. -/
 def natLit! : Expr → Nat
   | lit (Literal.natVal v) => v

--- a/Mathlib/Lean/Expr/Basic.lean
+++ b/Mathlib/Lean/Expr/Basic.lean
@@ -179,6 +179,11 @@ def bvarIdx? : Expr → Option Nat
 def getAppFnArgs (e : Expr) : Name × Array Expr :=
   withApp e λ e a => (e.constName, a)
 
+/-- Get the arity of a type, i.e. the number of forall binders -/
+def getNumForallBinders : Expr → Nat
+  | .forallE _ _ b _ => b.getNumForallBinders + 1
+  | _ => 0
+
 /-- Turn an expression that is a natural number literal into a natural number. -/
 def natLit! : Expr → Nat
   | lit (Literal.natVal v) => v

--- a/Mathlib/Tactic/Simps/Basic.lean
+++ b/Mathlib/Tactic/Simps/Basic.lean
@@ -648,8 +648,7 @@ def findAutomaticProjectionsAux (str : Name) (proj : ParsedProjectionData) (args
   TermElabM <| Option (Expr × Name)  := do
   if let some ⟨className, isNotation, findArgs⟩ :=
     notationClassAttr.find? (← getEnv) proj.strName then
-    let findArgs ← unsafe evalConst (Name → Name → Array Expr → MetaM (Array (Option Expr)))
-      findArgs
+    let findArgs ← unsafe evalConst findArgType findArgs
     let classArgs ← try findArgs str className args
     catch ex =>
       trace[simps.debug] "Projection {proj.strName} is likely unrelated to the projection of {

--- a/Mathlib/Tactic/Simps/Basic.lean
+++ b/Mathlib/Tactic/Simps/Basic.lean
@@ -38,15 +38,9 @@ There are three attributes being defined here
   will be `fun α hα ↦ @Mul.mul α (@Semigroup.toMul α hα)` instead of `@Semigroup.mul`.
   [this is not correctly implemented in Lean 4 yet]
 
-## Unimplemented Features
-
-* Correct interaction with heterogenous operations like `HAdd` and `HMul`
-* Adding custom simp-attributes / other attributes
-
-### Improvements
+### Possible Future Improvements
 * If multiple declarations are generated from a `simps` without explicit projection names, then
   only the first one is shown when mousing over `simps`.
-* Double check output of simps (especially in combination with `to_additive`).
 
 ## Changes w.r.t. Lean 3
 
@@ -161,9 +155,8 @@ derives two `simp` lemmas:
 * It will automatically reduce newly created beta-redexes, but will not unfold any definitions.
 * If the structure has a coercion to either sorts or functions, and this is defined to be one
   of the projections, then this coercion will be used instead of the projection.
-* If the structure is a class that has an instance to a notation class, like `Neg`, then this
-  notation is used instead of the corresponding projection.
-  [TODO: not yet implemented for heterogenous operations like `HMul` and `HAdd`]
+* If the structure is a class that has an instance to a notation class, like `Neg` or `Mul`,
+  then this notation is used instead of the corresponding projection.
 * You can specify custom projections, by giving a declaration with name
   `{StructureName}.Simps.{projectionName}`. See Note [custom simps projection].
 
@@ -219,7 +212,7 @@ derives two `simp` lemmas:
   @[simp] lemma foo_fst_fst : foo.fst.fst = 1
   @[simp] lemma foo_snd : foo.snd = {fst := 3, snd := 4}
   ```
-* [TODO] If one of the values is an eta-expanded structure, we will eta-reduce this structure.
+* If one of the values is an eta-expanded structure, we will eta-reduce this structure.
 
   Example:
   ```lean
@@ -285,7 +278,7 @@ This command specifies custom names and custom projections for the simp attribut
   `initialize_simps_projections Equiv (toFun → apply, invFun → symm_apply)`.
 * See Note [custom simps projection] and the examples below for information how to declare custom
   projections.
-* TODO in Lean 4: For algebraic structures, we will automatically use the notation (like `Mul`)
+* For algebraic structures, we will automatically use the notation (like `Mul`)
   for the projections if such an instance is available.
 * By default, the projections to parent structures are not default projections,
   but all the data-carrying fields are (including those in parent structures).
@@ -689,8 +682,7 @@ def findAutomaticProjectionsAux (str : Name) (proj : ParsedProjectionData) (args
 
 /-- Auxilliary function for `getRawProjections`.
 Find custom projections, automatically found by simps.
-These come from `FunLike` and `SetLike` instances.
-Todo: also support algebraic operations and notation classes, like `+`. -/
+These come from `FunLike` and `SetLike` instances. -/
 def findAutomaticProjections (str : Name) (projs : Array ParsedProjectionData) :
   CoreM (Array ParsedProjectionData) := do
   let strDecl ← getConstInfo str

--- a/Mathlib/Tactic/Simps/Basic.lean
+++ b/Mathlib/Tactic/Simps/Basic.lean
@@ -662,11 +662,12 @@ def findAutomaticProjectionsAux (str : Name) (proj : ParsedProjectionData) (args
     let projName := (getStructureFields (← getEnv) className)[0]!
     let projName := className ++ projName
     let eStr := mkAppN (← mkConstWithLevelParams str) args
-    let eInstType ← try elabAppArgs (← Term.mkConst className) #[] classArgs none true false
-    catch ex =>
-      trace[simps.debug] "Projection doesn't have the right type for the automatic projection:\n{
-        ex.toMessageData}"
-      return none
+    let eInstType ←
+      try withoutErrToSorry (elabAppArgs (← Term.mkConst className) #[] classArgs none true false)
+      catch ex =>
+        trace[simps.debug] "Projection doesn't have the right type for the automatic projection:\n{
+          ex.toMessageData}"
+        return none
     return ← withLocalDeclD `self eStr fun instStr ↦ do
       trace[simps.debug] "found projection {proj.strName}. Trying to synthesize {eInstType}."
       let eInst ← try synthInstance eInstType <| some 10

--- a/Mathlib/Tactic/Simps/Basic.lean
+++ b/Mathlib/Tactic/Simps/Basic.lean
@@ -645,7 +645,7 @@ an applicable name. (e.g. `Iso.inv`)
 Implementation note: getting rid of TermElabM is tricky, since `Expr.mkAppOptM` doesn't allow to
 keep metavariables around, which are necessary for `OutParam`. -/
 def findAutomaticProjectionsAux (str : Name) (proj : ParsedProjectionData) (args : Array Expr) :
-  TermElabM <| Option (Expr × Name)  := do
+  TermElabM <| Option (Expr × Name) := do
   if let some ⟨className, isNotation, findArgs⟩ :=
     notationClassAttr.find? (← getEnv) proj.strName then
     let findArgs ← unsafe evalConst findArgType findArgs
@@ -669,7 +669,7 @@ def findAutomaticProjectionsAux (str : Name) (proj : ParsedProjectionData) (args
         return none
     return ← withLocalDeclD `self eStr fun instStr ↦ do
       trace[simps.debug] "found projection {proj.strName}. Trying to synthesize {eInstType}."
-      let eInst ← try synthInstance eInstType <| some 10
+      let eInst ← try synthInstance eInstType
       catch ex =>
         trace[simps.debug] "Didn't find instance:\n{ex.toMessageData}"
         return none

--- a/Mathlib/Tactic/Simps/NotationClass.lean
+++ b/Mathlib/Tactic/Simps/NotationClass.lean
@@ -48,7 +48,7 @@ def findArgType : Type := Name → Name → Array Expr → MetaM (Array (Option 
 /-- Find arguments for a notation class -/
 def defaultfindArgs : findArgType := λ _ className args =>  do
   let some classExpr := (← getEnv).find? className | throwError "no such class {className}"
-  let arity := classExpr.type.getNumForallBinders
+  let arity := classExpr.type.forallArity
   if arity == args.size then
     return args.map some
   else if args.size == 1 then
@@ -67,7 +67,7 @@ def copySecond : findArgType := λ _ _ args => return (args.push <| args[1]?.get
 def nsmulArgs: findArgType := λ _ _ args =>
   return #[Expr.const `Nat [], args[0]?.getD default] ++ args |>.map some
 
-/-- Find arguments by prepending `ℤ ` and duplicating the first argument. Used for `zsmul`. -/
+/-- Find arguments by prepending `ℤ` and duplicating the first argument. Used for `zsmul`. -/
 def zsmulArgs : findArgType := λ _ _ args =>
   return #[Expr.const `Int [], args[0]?.getD default] ++ args |>.map some
 
@@ -82,7 +82,7 @@ def findOneArgs : findArgType := λ _ _ args =>
 /-- Find arguments of a coercion class (`FunLike` or `SetLike`) -/
 def findCoercionArgs : findArgType := λ str className args =>  do
   let some classExpr := (← getEnv).find? className | throwError "no such class {className}"
-  let arity := classExpr.type.getNumForallBinders
+  let arity := classExpr.type.forallArity
   let eStr := mkAppN (← mkConstWithLevelParams str) args
   let classArgs := mkArray (arity - 1) none
   return #[some eStr] ++ classArgs

--- a/Mathlib/Tactic/Simps/NotationClass.lean
+++ b/Mathlib/Tactic/Simps/NotationClass.lean
@@ -51,27 +51,29 @@ def defaultfindArgs (_str className : Name) (args : Array Expr) :
 
 /-- Find arguments by duplicating the first argument. Used for `pow`. -/
 def copyFirst (_str _className : Name) (args : Array Expr) :
-  MetaM (Array (Option Expr)) := return (args.push args[0]!).map some
+  MetaM (Array (Option Expr)) := return (args.push <| args[0]?.getD default).map some
 
 /-- Find arguments by duplicating the first argument. Used for `smul`. -/
 def copySecond (_str _className : Name) (args : Array Expr) :
-  MetaM (Array (Option Expr)) := return (args.push args[1]!).map some
+  MetaM (Array (Option Expr)) := return (args.push <| args[1]?.getD default).map some
 
 /-- Find arguments by prepending `ℕ` and duplicating the first argument. Used for `nsmul`. -/
 def nsmulArgs (_str _className : Name) (args : Array Expr) :
-  MetaM (Array (Option Expr)) := return (#[.const `Nat [], args[0]!] ++ args).map some
+  MetaM (Array (Option Expr)) :=
+  return #[Expr.const `Nat [], args[0]?.getD default] ++ args |>.map some
 
 /-- Find arguments by prepending `ℤ ` and duplicating the first argument. Used for `zsmul`. -/
 def zsmulArgs (_str _className : Name) (args : Array Expr) :
-  MetaM (Array (Option Expr)) := return (#[.const `Int [], args[0]!] ++ args).map some
+  MetaM (Array (Option Expr)) :=
+  return #[Expr.const `Int [], args[0]?.getD default] ++ args |>.map some
 
 /-- Find arguments for the `Zero` class. -/
 def findZeroArgs (_str _className : Name) (args : Array Expr) :
-  MetaM (Array (Option Expr)) := return (args.push <| mkRawNatLit 0).map some
+  MetaM (Array (Option Expr)) := return #[some <| args[0]?.getD default, some <| mkRawNatLit 0]
 
-/-- Find arguments for the `Zero` class. -/
+/-- Find arguments for the `One` class. -/
 def findOneArgs (_str _className : Name) (args : Array Expr) :
-  MetaM (Array (Option Expr)) := return (args.push <| mkRawNatLit 1).map some
+  MetaM (Array (Option Expr)) := return #[some <| args[0]?.getD default, some <| mkRawNatLit 1]
 
 /-- Find arguments of a coercion class (`FunLike` or `SetLike`) -/
 def findCoercionArgs (str className : Name) (args : Array Expr) :

--- a/Mathlib/Tactic/Simps/NotationClass.lean
+++ b/Mathlib/Tactic/Simps/NotationClass.lean
@@ -5,7 +5,9 @@ Authors: Floris van Doorn
 -/
 
 import Std.Lean.NameMapAttribute
-import Lean.Structure
+import Mathlib.Lean.Expr.Basic
+-- import Lean.Elab.Exception
+import Qq.MetaM
 
 /-!
 # `@[notation_class]` attribute for `@[simps]`
@@ -15,22 +17,87 @@ in the file where we declare `@[simps]`. For further documentation, see `Tactic.
 -/
 
 /-- The `@[notation_class]` attribute specifies that this is a notation class,
-  and this notation should be used instead of projections by @[simps].
+  and this notation should be used instead of projections by `@[simps]`.
+  Adding a `*` indicates that this is a coercion class instead of a notation class.
+  The name argument is the projection name we use as the key to search for this class
+  (default: name of first projection of the class).
+  The optional term is a term of type
+  `Name → Name → Array Expr → MetaM (Array (Option Expr))` that specifies how to generate the
+  arguments of the class. Specifying this is experimental. -/
+syntax (name := notation_class) "notation_class" "*"? (ppSpace ident)? (ppSpace term)? : attr
 
-  Note: this does *not* work yet for heterogenous operations like `HAdd`.
--/
-syntax (name := notation_class) "notation_class" : attr
+open Lean Meta Elab Term Qq
 
-open Lean
+namespace Simps
 
-/- todo: should this be TagAttribute? Can we "initialize" TagAttribute with a certain cache? -/
-/-- `@[notation_class]` attribute -/
-initialize notationClassAttr : NameMapExtension Unit ←
-  registerNameMapAttribute {
-    name  := `notation_class
+/-- Find arguments for a notation class -/
+def defaultfindArgs (_str className : Name) (args : Array Expr) :
+  MetaM (Array (Option Expr)) := do
+  let some classExpr := (← getEnv).find? className | throwError "no such class {className}"
+  let arity := classExpr.type.getNumForallBinders
+  if arity == args.size then
+    return args.map some
+  else if args.size == 1 then
+    return mkArray arity args[0]!
+  else
+    throwError "initialize_simps_projections cannot automatically find arguments for class {
+      className}"
+
+/-- Find arguments of a coercion class (`FunLike` or `SetLike`) -/
+def findCoercionArgs (str className : Name) (args : Array Expr) :
+  MetaM (Array (Option Expr)) := do
+  let some classExpr := (← getEnv).find? className | throwError "no such class {className}"
+  let arity := classExpr.type.getNumForallBinders
+  let eStr := mkAppN (← mkConstWithLevelParams str) args
+  let classArgs := mkArray (arity - 1) none
+  return #[some eStr] ++ classArgs
+
+/-- Data needed to generate automatic projections. This data is associated to a name of a projection
+  in a structure that must be used to trigger the search. -/
+structure AutomaticProjectionData where
+  /-- `className` is the name of the class we are looking for. -/
+  className : Name
+  /-- `isNotation` is a boolean that specifies whether this is notation
+    (false for the coercions `FunLike` and SetLike`). If this is set to true, we add the current
+    class as hypothesis during type-class synthesis. -/
+  isNotation := true
+  /-- The method to find the arguments of the class. -/
+  findArgs : Name → Name → Array Expr → MetaM (Array (Option Expr)) := defaultfindArgs
+deriving Inhabited
+
+-- /-- todo: replace by attribute. -/
+-- def defaultCoercions : NameMap AutomaticProjectionData :=
+-- .ofList [
+--   (`toFun, { className := `FunLike, isNotation := false, findArgs := findCoercionArgs }),
+--   (`carrier, { className := `SetLike, isNotation := false, findArgs := findCoercionArgs }),
+--   (`neg, { className := `Neg }),
+--   (`mul, { className := `HMul }),
+--   (`npow, { className := `Pow,
+--             findArgs  := fun _ _ xs => return xs.push (.const `Nat []) |>.map some })]
+
+/-- `@[notation_class]` attribute. Note: this is *not* a `NameMapAttribute` because we key on the
+  argument of the attribute, not the declaration name. -/
+initialize notationClassAttr : NameMapExtension AutomaticProjectionData ← do
+  let ext ← registerNameMapExtension AutomaticProjectionData
+  registerBuiltinAttribute {
+    name := `notation_class
     descr := "An attribute specifying that this is a notation class. Used by @[simps]."
-    add   := fun
-    | nm, `(attr|notation_class) => do
-      if (getStructureInfo? (← getEnv) nm).isNone then
+    add := fun src stx _kind => do
+      unless isStructure (← getEnv) src do
         throwError "@[notation_class] attribute can only be added to classes."
-    | _, stx => throwError "unexpected notation_class syntax {stx}" }
+      match stx with
+      | `(attr|notation_class $[*%$coercion]? $[$projName?]? $[$findArgs?]?) => do
+        let projName ← match projName? with
+          | none => pure (getStructureFields (← getEnv) src)[0]!
+          | some projName => pure projName.getId
+        let findArgs ← MetaM.run' <| TermElabM.run' <|
+          match findArgs? with
+          | none => pure defaultfindArgs
+          | some findArgs =>
+            unsafe evalTerm (Name → Name → Array Expr → MetaM (Array (Option Expr)))
+                           q(Name → Name → Array Expr → MetaM (Array (Option Expr))) findArgs
+        ext.add projName ⟨src, coercion.isNone, findArgs⟩
+      | _ => throwUnsupportedSyntax }
+  return ext
+
+end Simps

--- a/test/Simps.lean
+++ b/test/Simps.lean
@@ -12,20 +12,21 @@ import Mathlib.Data.Prod.Basic
 open Lean Meta Elab Term Command Simps
 
 structure Foo1 : Type where
-  one : Nat
+  Projone : Nat
   two : Bool
   three : Nat → Bool
   four : 1 = 1
   five : 2 = 1
 
-initialize_simps_projections Foo1 (one → toNat, two → toBool, three → coe, as_prefix coe, -toBool)
+initialize_simps_projections Foo1 (Projone → toNat, two → toBool, three → coe, as_prefix coe,
+  -toBool)
 
 run_cmd liftTermElabM <| do
   let env ← getEnv
   let state := ((Simps.structureExt.getState env).find? `Foo1).get!
   guard <| state.1 == []
   guard <| state.2.map (·.1) == #[`toNat, `toBool, `coe, `four, `five]
-  liftMetaM <| guard (← isDefEq (state.2[0]!.2) (← elabTerm (← `(Foo1.one)) none))
+  liftMetaM <| guard (← isDefEq (state.2[0]!.2) (← elabTerm (← `(Foo1.Projone)) none))
   liftMetaM <| guard (← isDefEq (state.2[1]!.2) (← elabTerm (← `(Foo1.two)) none))
   guard <| state.2.map (·.3) == (Array.range 5).map ([·])
   guard <| state.2.map (·.4) == #[true, false, true, false, false]
@@ -509,9 +510,8 @@ class Semigroup (G : Type u) extends Mul G where
 { mul := λ x y => (x.1 * y.1, x.2 * y.2)
   mul_assoc := λ _ _ _ => Prod.ext (Semigroup.mul_assoc ..) (Semigroup.mul_assoc ..) }
 
--- todo: heterogenous notation_class
--- example {α β} [Semigroup α] [Semigroup β] (x y : α × β) : x * y = (x.1 * y.1, x.2 * y.2) := by simp
--- example {α β} [Semigroup α] [Semigroup β] (x y : α × β) : (x * y).1 = x.1 * y.1 := by simp
+example {α β} [Semigroup α] [Semigroup β] (x y : α × β) : x * y = (x.1 * y.1, x.2 * y.2) := by simp
+example {α β} [Semigroup α] [Semigroup β] (x y : α × β) : (x * y).1 = x.1 * y.1 := by simp
 
 structure BSemigroup :=
   (G : Type _)
@@ -904,9 +904,8 @@ run_cmd liftTermElabM <| do
   guard <| hasSimpAttribute env `instMulProd_mul
   guard <| hasSimpAttribute env `instAddProd_add
 
--- todo: heterogenous notation_class
--- example {M N} [Mul M] [Mul N] (p q : M × N) : p * q = ⟨p.1 * q.1, p.2 * q.2⟩ := by simp
--- example {M N} [Add M] [Add N] (p q : M × N) : p + q = ⟨p.1 + q.1, p.2 + q.2⟩ := by simp
+example {M N} [Mul M] [Mul N] (p q : M × N) : p * q = ⟨p.1 * q.1, p.2 * q.2⟩ := by simp
+example {M N} [Add M] [Add N] (p q : M × N) : p + q = ⟨p.1 + q.1, p.2 + q.2⟩ := by simp
 
 /- The names of the generated simp lemmas for the additive version are not great if the definition
   had a custom additive name -/
@@ -922,9 +921,8 @@ run_cmd liftTermElabM <| do
   guard <| hasSimpAttribute env `my_instance_one
   guard <| hasSimpAttribute env `my_add_instance_zero
 
--- todo: heterogenous notation_class
--- example {M N} [One M] [One N] : (1 : M × N) = ⟨1, 1⟩ := by simp
--- example {M N} [Zero M] [Zero N] : (0 : M × N) = ⟨0, 0⟩ := by simp
+example {M N} [One M] [One N] : (1 : M × N) = ⟨1, 1⟩ := by simp
+example {M N} [Zero M] [Zero N] : (0 : M × N) = ⟨0, 0⟩ := by simp
 
 section
 /-! Test `dsimp, simp` with the option `simpRhs` -/
@@ -938,42 +936,21 @@ structure MyType :=
 ⟨{ _x : Fin (Nat.add 3 0) // 1 + 1 = 2 }⟩
 
 -- todo: this fails in Lean 4, not sure what is going on
--- example (h : false) (x y : { x : Fin (Nat.add 3 0) // 1 + 1 = 2 }) : myTypeDef.A = Unit := by
---   simp only [myTypeDef_A]
---   guard_target = { _x : Fin 3 // true } = Unit
---   /- note: calling only one of `simp` or `dsimp` does not produce the current target
---   as the following tests show. -/
---   -- successIfFail { guard_hyp x : { x : Fin 3 // true } }
---   dsimp at x
---   -- successIfFail { guard_hyp x : { x : Fin 3 // true } }
---   simp at y
---   -- successIfFail { guard_hyp y : { x : Fin 3 // true } }
---   simp at x
---   dsimp at y
---   guard_hyp x : { x : Fin 3 // true }
---   guard_hyp y : { x : Fin 3 // true }
---   contradiction
-
--- this test might not apply to Lean 4
--- /- Test that `to_additive` copies the `@[_rfl_lemma]` attribute correctly -/
--- @[to_additive (attr := simps)]
--- def monoid_hom.my_comp {M N P : Type _} [mul_one_class M] [mul_one_class N] [mul_one_class P]
---   (hnp : N →* P) (hmn : M →* N) : M →* P :=
--- { toFun := hnp ∘ hmn, map_one' := by simp, map_mul' := by simp }
-
--- -- `simps` adds the `_rfl_lemma` attribute to `monoid_hom.my_comp_apply`
--- example {M N P : Type _} [mul_one_class M] [mul_one_class N] [mul_one_class P]
---   (hnp : N →* P) (hmn : M →* N) (m : M) : hnp.my_comp hmn m = hnp (hmn m) := by
---   dsimp
---   guard_target = hnp (hmn m) = hnp (hmn m)
---   rfl
-
--- -- `to_additive` adds the `_rfl_lemma` attribute to `AddMonoidHom.my_comp_apply`
--- example {M N P : Type _} [add_zero_class M] [add_zero_class N] [add_zero_class P]
---   (hnp : N →+ P) (hmn : M →+ N) (m : M) : hnp.my_comp hmn m = hnp (hmn m) := by
---   dsimp
---   guard_target = hnp (hmn m) = hnp (hmn m)
---   rfl
+example (h : false) (x y : { x : Fin (Nat.add 3 0) // 1 + 1 = 2 }) : myTypeDef.A = Unit := by
+  simp only [myTypeDef_A]
+  guard_target = { _x : Fin 3 // True } = Unit
+  /- note: calling only one of `simp` or `dsimp` does not produce the current target
+  as the following tests show. -/
+  -- successIfFail { guard_hyp x : { x : Fin 3 // true } }
+  dsimp at x
+  -- successIfFail { guard_hyp x : { x : Fin 3 // true } }
+  simp at y
+  -- successIfFail { guard_hyp y : { x : Fin 3 // true } }
+  simp at x
+  dsimp at y
+  guard_hyp x : { _x : Fin 3 // True }
+  guard_hyp y : { _x : Fin 3 // True }
+  contradiction
 
 -- test that `to_additive` works with a custom name
 @[to_additive (attr := simps) some_test2]
@@ -1135,28 +1112,28 @@ infixr:25 " →+ " => AddMonoidHom
 instance (M N : Type _) [AddMonoid M] [AddMonoid N] : CoeFun (M →+ N) (λ _ => M → N) := ⟨(·.toFun)⟩
 
 class AddHomPlus [Add ι] [∀ i, AddCommMonoid (A i)] :=
-(mul {i} : A i →+ A i)
+(myMul {i} : A i →+ A i)
 
 def AddHomPlus.Simps.apply [Add ι] [∀ i, AddCommMonoid (A i)] [AddHomPlus A] {i : ι} (x : A i) :
   A i :=
-AddHomPlus.mul x
+AddHomPlus.myMul x
 
-initialize_simps_projections AddHomPlus (mul_toFun → apply, -mul)
+initialize_simps_projections AddHomPlus (myMul_toFun → apply, -myMul)
 
 class AddHomPlus2 [Add ι] :=
-(mul {i j} : A i ≃ (A j ≃ A (i + j)))
+(myMul {i j} : A i ≃ (A j ≃ A (i + j)))
 
 def AddHomPlus2.Simps.mul [Add ι] [AddHomPlus2 A] {i j : ι}
   (x : A i) (y : A j) : A (i + j) :=
-AddHomPlus2.mul x y
+AddHomPlus2.myMul x y
 
-initialize_simps_projections AddHomPlus2 (mul → mul', mul_toFun_toFun → mul, -mul')
+initialize_simps_projections AddHomPlus2 (-myMul, myMul_toFun_toFun → mul)
 
 attribute [ext] Equiv'
 
 @[simps]
 def thing (h : Bool ≃ (Bool ≃ Bool)) : AddHomPlus2 (λ _ : ℕ => Bool) :=
-{ mul :=
+{ myMul :=
   { toFun := λ b =>
     { toFun := h b
       invFun := (h b).symm
@@ -1167,7 +1144,7 @@ def thing (h : Bool ≃ (Bool ≃ Bool)) : AddHomPlus2 (λ _ : ℕ => Bool) :=
     right_inv := h.right_inv } } -- definitional eta
 
 example (h : Bool ≃ (Bool ≃ Bool)) (i j : ℕ) (b1 b2 : Bool) {x} (h2 : h b1 b2 = x) :
-  @AddHomPlus2.mul _ _ _ (thing h) i j b1 b2 = x := by
+  @AddHomPlus2.myMul _ _ _ (thing h) i j b1 b2 = x := by
   simp only [thing_mul]
   rw [h2]
 

--- a/test/Simps.lean
+++ b/test/Simps.lean
@@ -1186,3 +1186,10 @@ noncomputable def fooSum {I J : Type _} (C : I → Type _) {D : J → Type _} :
 { obj := λ f => { obj := λ g s => Sum.rec f g s }}
 
 end
+
+/- Test that we deal with classes whose names are prefixes of other classes -/
+
+class MyDiv (α : Type _) extends Div α
+class MyDivInv (α : Type _) extends MyDiv α
+class MyGroup (α : Type _) extends MyDivInv α
+initialize_simps_projections MyGroup

--- a/test/Simps.lean
+++ b/test/Simps.lean
@@ -1164,9 +1164,24 @@ noncomputable def fooSum {I J : Type _} (C : I → Type _) {D : J → Type _} :
 
 end
 
-/- Test that we deal with classes whose names are prefixes of other classes -/
+/-! Test that we deal with classes whose names are prefixes of other classes -/
 
 class MyDiv (α : Type _) extends Div α
 class MyDivInv (α : Type _) extends MyDiv α
 class MyGroup (α : Type _) extends MyDivInv α
 initialize_simps_projections MyGroup
+
+/-! Test that the automatic projection module doesn't throw an error if we have a projection name
+unrelated to one of the classes. -/
+
+class MyGOne {ι} [Zero ι] (A : ι → Type _)  where
+  /-- The term `one` of grade 0 -/
+  one : A 0
+
+initialize_simps_projections MyGOne
+
+class Artificial (n : Nat)  where
+  /-- The term `one` of grade 0 -/
+  one : Nat
+
+initialize_simps_projections Artificial


### PR DESCRIPTION
* If you write `@[simps]` for the definition of an `AddGroup`, it will now generate the correct lemmas for `0`, `+`, `nsmul` and `zsmul` using `OfNat` and heterogenous operations. This is needed for #2609.
  * This is a lot more flexible than the Lean 3 implementation, in order to handle `nsmul`, `zsmul` and numerals.
  * It doesn't handle the `zpow` and `npow` projections, since their argument order is different than that of `HPow.pow` (that was likely done for the sake of `to_additive`, but we can consider to revisit that choice).
* Also fixes the `nvMonoid` bug encountered in #2609 
  * There was an issue where the wrong projection was chosen, since `toDiv` is a prefix of `toDivInvMonoid`
  * Before we were checking if `_toDiv` is a prefix of your projection with `_` prepended (e.g. `_toDivInvMonoid`), now we are checking whether `toDiv_` is a prefix of your projection with `_` appended (which doesn't match `toDivInvMonoid_`).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

A potential better implementation to this is to have a custom simp-set that simplifies standard projections to the desired custom projections (suggested by Kyle).

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
