### PR TITLE
[Merged by Bors] - feat: let `apply_fun` use `CoeFun` and dependent functions

### DIFF
--- a/Mathlib/Tactic/ApplyFun.lean
+++ b/Mathlib/Tactic/ApplyFun.lean
@@ -76,8 +76,7 @@ def applyFunHyp (f : Expr) (using? : Option Expr) (h : FVarId) (g : MVarId) :
     for mvarId in mvars do
       let d ← mvarId.getDecl
       if let .synthetic := d.kind then
-        let mvarVal ← synthInstance (← mvarId.getType)
-        mvarId.assign mvarVal
+        mvarId.assign (← synthInstance (← mvarId.getType))
     let eq' ← instantiateMVars (← mkEq lhs' rhs')
     let mvar ← mkFreshExprMVar eq'
     let [] ← mvar.mvarId!.congrN | throwError "`apply_fun` could not construct congruence"

--- a/test/apply_fun.lean
+++ b/test/apply_fun.lean
@@ -17,9 +17,9 @@ example (x : Int) (h : x = 1) : 1 = 1 := by
 
 example (a b : Int) (h : a = b) : a + 1 = b + 1 := by
   -- Make sure that we infer the type of the function only after we see the hypothesis:
-  apply_fun (fun n => n+1) at h
-  -- check that `h` was β-reduced (in Lean3 this required additional work)
-  guard_hyp h : a + 1 = b + 1
+  apply_fun (fun n => n + 1) at h
+  -- check that `h` was β-reduced
+  guard_hyp h :ₛ a + 1 = b + 1
   exact h
 
 -- Verify failure when applying a dependently typed function.
@@ -132,7 +132,14 @@ example (f : (p : Prop) → [Decidable p] → Nat) (p q : Prop) (h : p = q)
   apply h'
   exact h
 
+example (f : (p : Prop) → [Decidable p] → Nat) (p q : Prop) (h : p = q)
+    (h' : {n m : Nat} → n = m → True) : True := by
+  classical
+  apply_fun (fun x [Decidable x] => f x) at h
+  apply h'
+  exact h
+
 example (a b : ℕ) (h : a = b) : True := by
-  apply_fun (fun {j} i => i + j) at h
+  apply_fun (fun i => i + ?_) at h
   · trivial
   · exact 37

--- a/test/apply_fun.lean
+++ b/test/apply_fun.lean
@@ -115,6 +115,15 @@ example (f : ℕ ≃ ℕ) (a b : ℕ) (h : a = b) : True := by
   guard_hyp h : f a = f b
   trivial
 
+example (f : ℤ ≃ ℤ) (a b : ℕ) (h : a = b) : True := by
+  apply_fun f at h
+  guard_hyp h : f a = f b
+  trivial
+
+example (f : ℤ ≃ ℤ) (a b : α) (h : a = b) : True := by
+  fail_if_success apply_fun f at h
+  trivial
+
 example (f : ℕ → ℕ) (a b : ℕ) (h : a = b) : True := by
   apply_fun f at h
   guard_hyp h : f a = f b

--- a/test/apply_fun.lean
+++ b/test/apply_fun.lean
@@ -109,3 +109,30 @@ example : ∀ m n : ℕ, m = n → (m < 2) = (n < 2) := by
   intro m n h
   apply_fun (· < 2) at h
   exact h
+
+example (f : ℕ ≃ ℕ) (a b : ℕ) (h : a = b) : True := by
+  apply_fun f at h
+  guard_hyp h : f a = f b
+  trivial
+
+example (f : ℕ → ℕ) (a b : ℕ) (h : a = b) : True := by
+  apply_fun f at h
+  guard_hyp h : f a = f b
+  trivial
+
+example (f : {i : Nat} → Fin i → ℕ) (a b : Fin 37) (h : a = b) : True := by
+  apply_fun f at h
+  guard_hyp h : f a = f b
+  trivial
+
+example (f : (p : Prop) → [Decidable p] → Nat) (p q : Prop) (h : p = q)
+    (h' : {n m : Nat} → n = m → True) : True := by
+  classical
+  apply_fun f at h
+  apply h'
+  exact h
+
+example (a b : ℕ) (h : a = b) : True := by
+  apply_fun (fun {j} i => i + j) at h
+  · trivial
+  · exact 37


### PR DESCRIPTION
Changes `apply_fun` to use the main function application elaborator, then uses `Lean.MVarId.congrN` to solve for a congruence proof. This means that `apply_fun f at h` should work whenever `f` applies to both sides of the equation `h` (even when coercions need to be involved).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
