### PR TITLE
[Merged by Bors] - chore: forward port leanprover-community/mathlib#18575

### DIFF
--- a/Mathlib/LinearAlgebra/AffineSpace/AffineMap.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/AffineMap.lean
@@ -500,7 +500,7 @@ theorem image_vsub_image {s t : Set P1} (f : P1 →ᵃ[k] P2) :
     f '' s -ᵥ f '' t = f.linear '' (s -ᵥ t) := by
   ext v
   -- porting note: `simp` needs a placeholder for the `β` argument to `Set.mem_vsub`
-  simp only [Set.mem_vsub (β := P2), Set.mem_vsub (β := _), Set.mem_image,
+  simp only [Set.mem_vsub (β := _), Set.mem_image,
     exists_exists_and_eq_and, exists_and_left, ← f.linearMap_vsub]
   constructor
   · rintro ⟨x, hx, y, hy, hv⟩

--- a/Mathlib/LinearAlgebra/AffineSpace/AffineMap.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/AffineMap.lean
@@ -46,11 +46,10 @@ topology are defined elsewhere; see `Analysis.NormedSpace.AddTorsor` and
 * https://en.wikipedia.org/wiki/Principal_homogeneous_space
 -/
 
+-- Porting note: Workaround for lean4#2074
+attribute [-instance] Ring.toNonAssocRing
 
 open Affine
-
--- Porting note: Workaround for lean4#2074
-attribute [-instance] Ring.toNonAssocRing in
 
 /-- An `AffineMap k P1 P2` (notation: `P1 →ᵃ[k] P2`) is a map from `P1` to `P2` that
 induces a corresponding linear map from `V1` to `V2`. -/
@@ -88,9 +87,6 @@ namespace LinearMap
 
 variable {k : Type _} {V₁ : Type _} {V₂ : Type _} [Ring k] [AddCommGroup V₁] [Module k V₁]
   [AddCommGroup V₂] [Module k V₂] (f : V₁ →ₗ[k] V₂)
-
--- Porting note: Workaround for lean4#2074
-attribute [-instance] Ring.toNonAssocRing
 
 /-- Reinterpret a linear map as an affine map. -/
 def toAffineMap : V₁ →ᵃ[k] V₂ where
@@ -172,8 +168,7 @@ protected theorem congr_fun {f g : P1 →ᵃ[k] P2} (h : f = g) (x : P1) : f x =
 variable (k P1)
 
 /-- The constant function as an `AffineMap`. -/
-def const (p : P2) : P1 →ᵃ[k] P2
-    where
+def const (p : P2) : P1 →ᵃ[k] P2 where
   toFun := Function.const P1 p
   linear := 0
   map_vadd' _ _ := by simp
@@ -210,8 +205,6 @@ instance nonempty : Nonempty (P1 →ᵃ[k] P2) :=
   (AddTorsor.Nonempty : Nonempty P2).elim fun p => ⟨const k P1 p⟩
 #align affine_map.nonempty AffineMap.nonempty
 
--- Porting note: Workaround for lean4#2074
-attribute [-instance] Ring.toNonAssocRing in
 /-- Construct an affine map by verifying the relation between the map and its linear part at one
 base point. Namely, this function takes a map `f : P₁ → P₂`, a linear map `f' : V₁ →ₗ[k] V₂`, and
 a point `p` such that for any other point `p'` we have `f p' = f' (p' -ᵥ p) +ᵥ f p`. -/
@@ -235,7 +228,6 @@ theorem mk'_linear (f : P1 → P2) (f' : V1 →ₗ[k] V2) (p h) : (mk' f f' p h)
 section SMul
 
 variable {R : Type _} [Monoid R] [DistribMulAction R V2] [SMulCommClass k R V2]
-
 /-- The space of affine maps to a module inherits an `R`-action from the action on its codomain. -/
 instance mulAction : MulAction R (P1 →ᵃ[k] V2) where
   -- porting note: `map_vadd` is `simp`, but we still have to pass it explicitly
@@ -253,20 +245,30 @@ theorem smul_linear (t : R) (f : P1 →ᵃ[k] V2) : (t • f).linear = t • f.l
   rfl
 #align affine_map.smul_linear AffineMap.smul_linear
 
-instance [DistribMulAction Rᵐᵒᵖ V2] [IsCentralScalar R V2] : IsCentralScalar R (P1 →ᵃ[k] V2)
-    where op_smul_eq_smul r x := ext fun _ => op_smul_eq_smul _ _
+-- Porting note: Workaround for lean4#2074
+instance [DistribMulAction Rᵐᵒᵖ V2] [IsCentralScalar R V2] : SMulCommClass k Rᵐᵒᵖ V2 :=
+SMulCommClass.op_right
+
+instance isCentralScalar [DistribMulAction Rᵐᵒᵖ V2] [IsCentralScalar R V2] :
+  IsCentralScalar R (P1 →ᵃ[k] V2) where
+    op_smul_eq_smul _r _x := ext fun _ => op_smul_eq_smul _ _
 
 end SMul
 
-instance : Zero (P1 →ᵃ[k] V2) where zero := ⟨0, 0, fun p v => (zero_vadd _ _).symm⟩
+instance : Zero (P1 →ᵃ[k] V2) where zero := ⟨0, 0, fun _ _ => (zero_vadd _ _).symm⟩
 
 instance : Add (P1 →ᵃ[k] V2)
-    where add f g := ⟨f + g, f.linear + g.linear, fun p v => by simp [add_add_add_comm]⟩
+    where add f g := ⟨f + g, f.linear + g.linear,
+      -- porting note: `simp` can't infer `P1` in `map_vadd`
+      fun p v => by simp [add_add_add_comm, map_vadd _ (_ : P1)]⟩
 
 instance : Sub (P1 →ᵃ[k] V2)
-    where sub f g := ⟨f - g, f.linear - g.linear, fun p v => by simp [sub_add_sub_comm]⟩
+    where sub f g := ⟨f - g, f.linear - g.linear,
+      -- porting note: `simp` can't infer `P1` in `map_vadd`
+      fun p v => by simp [sub_add_sub_comm, map_vadd _ (_ : P1)]⟩
 
-instance : Neg (P1 →ᵃ[k] V2) where neg f := ⟨-f, -f.linear, fun p v => by simp [add_comm]⟩
+instance : Neg (P1 →ᵃ[k] V2)
+    where neg f := ⟨-f, -f.linear, fun p v => by simp [add_comm, map_vadd f]⟩
 
 @[simp, norm_cast]
 theorem coe_zero : ⇑(0 : P1 →ᵃ[k] V2) = 0 :=
@@ -310,20 +312,23 @@ theorem neg_linear (f : P1 →ᵃ[k] V2) : (-f).linear = -f.linear :=
 
 /-- The set of affine maps to a vector space is an additive commutative group. -/
 instance : AddCommGroup (P1 →ᵃ[k] V2) :=
-  coeFn_injective.AddCommGroup _ coe_zero coe_add coe_neg coe_sub (fun _ _ => coe_smul _ _)
+  coeFn_injective.addCommGroup _ coe_zero coe_add coe_neg coe_sub (fun _ _ => coe_smul _ _)
     fun _ _ => coe_smul _ _
 
 /-- The space of affine maps from `P1` to `P2` is an affine space over the space of affine maps
 from `P1` to the vector space `V2` corresponding to `P2`. -/
-instance : AffineSpace (P1 →ᵃ[k] V2) (P1 →ᵃ[k] P2)
-    where
+instance : AffineSpace (P1 →ᵃ[k] V2) (P1 →ᵃ[k] P2) where
   vadd f g :=
-    ⟨fun p => f p +ᵥ g p, f.linear + g.linear, fun p v => by simp [vadd_vadd, add_right_comm]⟩
+    ⟨fun p => f p +ᵥ g p, f.linear + g.linear,
+      -- porting note: `simp` can't infer `P1` in `map_vadd`
+      fun p v => by simp [vadd_vadd, add_right_comm, map_vadd _ (_ : P1)]⟩
   zero_vadd f := ext fun p => zero_vadd _ (f p)
   add_vadd f₁ f₂ f₃ := ext fun p => add_vadd (f₁ p) (f₂ p) (f₃ p)
   vsub f g :=
     ⟨fun p => f p -ᵥ g p, f.linear - g.linear, fun p v => by
-      simp [vsub_vadd_eq_vsub_sub, vadd_vsub_assoc, add_sub, sub_add_eq_add_sub]⟩
+      -- porting note: `simp` can't infer `P1` in `map_vadd` or `P2` in the others
+      simp [map_vadd _ (_ : P1), vsub_vadd_eq_vsub_sub (_ : P2), vadd_vsub_assoc _ (_ : P2),
+        add_sub, sub_add_eq_add_sub]⟩
   vsub_vadd' f g := ext fun p => vsub_vadd (f p) (g p)
   vadd_vsub' f g := ext fun p => vadd_vsub (f p) (g p)
 
@@ -372,19 +377,16 @@ theorem snd_linear : (snd : P1 × P2 →ᵃ[k] P2).linear = LinearMap.snd k V1 V
 #align affine_map.snd_linear AffineMap.snd_linear
 
 variable (k P1)
-
-omit V2
-
 /-- Identity map as an affine map. -/
-def id : P1 →ᵃ[k] P1 where
+nonrec def id : P1 →ᵃ[k] P1 where
   toFun := id
   linear := LinearMap.id
-  map_vadd' p v := rfl
+  map_vadd' _ _ := rfl
 #align affine_map.id AffineMap.id
 
 /-- The identity affine map acts as the identity. -/
 @[simp]
-theorem coe_id : ⇑(id k P1) = id :=
+theorem coe_id : ⇑(id k P1) = _root_.id :=
   rfl
 #align affine_map.coe_id AffineMap.coe_id
 
@@ -400,16 +402,13 @@ theorem id_apply (p : P1) : id k P1 p = p :=
   rfl
 #align affine_map.id_apply AffineMap.id_apply
 
-variable {k P1}
+variable {k}
 
 instance : Inhabited (P1 →ᵃ[k] P1) :=
   ⟨id k P1⟩
 
-include V2 V3
-
 /-- Composition of affine maps. -/
-def comp (f : P2 →ᵃ[k] P3) (g : P1 →ᵃ[k] P2) : P1 →ᵃ[k] P3
-    where
+def comp (f : P2 →ᵃ[k] P3) (g : P1 →ᵃ[k] P2) : P1 →ᵃ[k] P3 where
   toFun := f ∘ g
   linear := f.linear.comp g.linear
   map_vadd' := by
@@ -429,26 +428,20 @@ theorem comp_apply (f : P2 →ᵃ[k] P3) (g : P1 →ᵃ[k] P2) (p : P1) : f.comp
   rfl
 #align affine_map.comp_apply AffineMap.comp_apply
 
-omit V3
-
 @[simp]
 theorem comp_id (f : P1 →ᵃ[k] P2) : f.comp (id k P1) = f :=
-  ext fun p => rfl
+  ext fun _ => rfl
 #align affine_map.comp_id AffineMap.comp_id
 
 @[simp]
 theorem id_comp (f : P1 →ᵃ[k] P2) : (id k P2).comp f = f :=
-  ext fun p => rfl
+  ext fun _ => rfl
 #align affine_map.id_comp AffineMap.id_comp
-
-include V3 V4
 
 theorem comp_assoc (f₃₄ : P3 →ᵃ[k] P4) (f₂₃ : P2 →ᵃ[k] P3) (f₁₂ : P1 →ᵃ[k] P2) :
     (f₃₄.comp f₂₃).comp f₁₂ = f₃₄.comp (f₂₃.comp f₁₂) :=
   rfl
 #align affine_map.comp_assoc AffineMap.comp_assoc
-
-omit V2 V3 V4
 
 instance : Monoid (P1 →ᵃ[k] P1) where
   one := id k P1
@@ -463,20 +456,17 @@ theorem coe_mul (f g : P1 →ᵃ[k] P1) : ⇑(f * g) = f ∘ g :=
 #align affine_map.coe_mul AffineMap.coe_mul
 
 @[simp]
-theorem coe_one : ⇑(1 : P1 →ᵃ[k] P1) = id :=
+theorem coe_one : ⇑(1 : P1 →ᵃ[k] P1) = _root_.id :=
   rfl
 #align affine_map.coe_one AffineMap.coe_one
 
 /-- `affine_map.linear` on endomorphisms is a `MonoidHom`. -/
 @[simps]
-def linearHom : (P1 →ᵃ[k] P1) →* V1 →ₗ[k] V1
-    where
+def linearHom : (P1 →ᵃ[k] P1) →* V1 →ₗ[k] V1 where
   toFun := linear
   map_one' := rfl
   map_mul' _ _ := rfl
 #align affine_map.linear_hom AffineMap.linearHom
-
-include V2
 
 @[simp]
 theorem linear_injective_iff (f : P1 →ᵃ[k] P2) :
@@ -509,8 +499,9 @@ theorem linear_bijective_iff (f : P1 →ᵃ[k] P2) :
 theorem image_vsub_image {s t : Set P1} (f : P1 →ᵃ[k] P2) :
     f '' s -ᵥ f '' t = f.linear '' (s -ᵥ t) := by
   ext v
-  simp only [Set.mem_vsub, Set.mem_image, exists_exists_and_eq_and, exists_and_left, ←
-    f.linear_map_vsub]
+  -- porting note: `simp` can't infer the `β` argument to `Set.mem_vsub`
+  simp only [Set.mem_vsub (β := P2), Set.mem_vsub (β := P1), Set.mem_image,
+    exists_exists_and_eq_and, exists_and_left, ← f.linearMap_vsub]
   constructor
   · rintro ⟨x, hx, y, hy, hv⟩
     exact ⟨x -ᵥ y, ⟨x, hx, y, hy, rfl⟩, hv⟩
@@ -518,13 +509,14 @@ theorem image_vsub_image {s t : Set P1} (f : P1 →ᵃ[k] P2) :
     exact ⟨x, hx, y, hy, rfl⟩
 #align affine_map.image_vsub_image AffineMap.image_vsub_image
 
-omit V2
-
 /-! ### Definition of `AffineMap.lineMap` and lemmas about it -/
+
+-- Porting note: Workaround for lean4#2074
+instance : Module k k := Semiring.toModule
 
 /-- The affine map from `k` to `P1` sending `0` to `p₀` and `1` to `p₁`. -/
 def lineMap (p₀ p₁ : P1) : k →ᵃ[k] P1 :=
-  ((LinearMap.id : k →ₗ[k] k).smul_right (p₁ -ᵥ p₀)).toAffineMap +ᵥ const k k p₀
+  ((LinearMap.id : k →ₗ[k] k).smulRight (p₁ -ᵥ p₀)).toAffineMap +ᵥ const k k p₀
 #align affine_map.line_map AffineMap.lineMap
 
 theorem coe_lineMap (p₀ p₁ : P1) : (lineMap p₀ p₁ : k → P1) = fun c => c • (p₁ -ᵥ p₀) +ᵥ p₀ :=
@@ -540,10 +532,8 @@ theorem lineMap_apply_module' (p₀ p₁ : V1) (c : k) : lineMap p₀ p₁ c = c
 #align affine_map.line_map_apply_module' AffineMap.lineMap_apply_module'
 
 theorem lineMap_apply_module (p₀ p₁ : V1) (c : k) : lineMap p₀ p₁ c = (1 - c) • p₀ + c • p₁ := by
-  simp [line_map_apply_module', smul_sub, sub_smul] <;> abel
+  simp [lineMap_apply_module', smul_sub, sub_smul]; abel
 #align affine_map.line_map_apply_module AffineMap.lineMap_apply_module
-
-omit V1
 
 theorem lineMap_apply_ring' (a b c : k) : lineMap a b c = c * (b - a) + a :=
   rfl
@@ -553,19 +543,19 @@ theorem lineMap_apply_ring (a b c : k) : lineMap a b c = (1 - c) * a + c * b :=
   lineMap_apply_module a b c
 #align affine_map.line_map_apply_ring AffineMap.lineMap_apply_ring
 
-include V1
-
 theorem lineMap_vadd_apply (p : P1) (v : V1) (c : k) : lineMap p (v +ᵥ p) c = c • v +ᵥ p := by
-  rw [line_map_apply, vadd_vsub]
+  rw [lineMap_apply, vadd_vsub]
 #align affine_map.line_map_vadd_apply AffineMap.lineMap_vadd_apply
 
 @[simp]
 theorem lineMap_linear (p₀ p₁ : P1) :
-    (lineMap p₀ p₁ : k →ᵃ[k] P1).linear = LinearMap.id.smul_right (p₁ -ᵥ p₀) :=
+    (lineMap p₀ p₁ : k →ᵃ[k] P1).linear = LinearMap.id.smulRight (p₁ -ᵥ p₀) :=
   add_zero _
 #align affine_map.line_map_linear AffineMap.lineMap_linear
 
-theorem lineMap_same_apply (p : P1) (c : k) : lineMap p p c = p := by simp [line_map_apply]
+theorem lineMap_same_apply (p : P1) (c : k) : lineMap p p c = p := by
+  -- porting note: `simp` can't infer `P1`
+  simp [lineMap_apply (_ : P1), vsub_self (_ : P1)]
 #align affine_map.line_map_same_apply AffineMap.lineMap_same_apply
 
 @[simp]
@@ -574,46 +564,51 @@ theorem lineMap_same (p : P1) : lineMap p p = const k k p :=
 #align affine_map.line_map_same AffineMap.lineMap_same
 
 @[simp]
-theorem lineMap_apply_zero (p₀ p₁ : P1) : lineMap p₀ p₁ (0 : k) = p₀ := by simp [line_map_apply]
+theorem lineMap_apply_zero (p₀ p₁ : P1) : lineMap p₀ p₁ (0 : k) = p₀ := by
+  -- porting note: `simp` can't infer `P1`
+  simp [lineMap_apply (_ : P1)]
 #align affine_map.line_map_apply_zero AffineMap.lineMap_apply_zero
 
 @[simp]
-theorem lineMap_apply_one (p₀ p₁ : P1) : lineMap p₀ p₁ (1 : k) = p₁ := by simp [line_map_apply]
+theorem lineMap_apply_one (p₀ p₁ : P1) : lineMap p₀ p₁ (1 : k) = p₁ := by
+  -- porting note: `simp` can't infer `P1`
+  simp [lineMap_apply (_ : P1), vsub_vadd (_ : P1)]
 #align affine_map.line_map_apply_one AffineMap.lineMap_apply_one
 
 @[simp]
 theorem lineMap_eq_lineMap_iff [NoZeroSMulDivisors k V1] {p₀ p₁ : P1} {c₁ c₂ : k} :
     lineMap p₀ p₁ c₁ = lineMap p₀ p₁ c₂ ↔ p₀ = p₁ ∨ c₁ = c₂ := by
-  rw [line_map_apply, line_map_apply, ← @vsub_eq_zero_iff_eq V1, vadd_vsub_vadd_cancel_right, ←
-    sub_smul, smul_eq_zero, sub_eq_zero, vsub_eq_zero_iff_eq, or_comm', eq_comm]
+  rw [lineMap_apply, lineMap_apply, ← @vsub_eq_zero_iff_eq V1, vadd_vsub_vadd_cancel_right, ←
+    sub_smul, smul_eq_zero, sub_eq_zero, vsub_eq_zero_iff_eq, or_comm, eq_comm]
 #align affine_map.line_map_eq_line_map_iff AffineMap.lineMap_eq_lineMap_iff
 
 @[simp]
 theorem lineMap_eq_left_iff [NoZeroSMulDivisors k V1] {p₀ p₁ : P1} {c : k} :
     lineMap p₀ p₁ c = p₀ ↔ p₀ = p₁ ∨ c = 0 := by
-  rw [← @line_map_eq_line_map_iff k V1, line_map_apply_zero]
+  rw [← @lineMap_eq_lineMap_iff k V1, lineMap_apply_zero]
 #align affine_map.line_map_eq_left_iff AffineMap.lineMap_eq_left_iff
 
 @[simp]
 theorem lineMap_eq_right_iff [NoZeroSMulDivisors k V1] {p₀ p₁ : P1} {c : k} :
     lineMap p₀ p₁ c = p₁ ↔ p₀ = p₁ ∨ c = 1 := by
-  rw [← @line_map_eq_line_map_iff k V1, line_map_apply_one]
+  rw [← @lineMap_eq_lineMap_iff k V1, lineMap_apply_one]
 #align affine_map.line_map_eq_right_iff AffineMap.lineMap_eq_right_iff
 
 variable (k)
 
 theorem lineMap_injective [NoZeroSMulDivisors k V1] {p₀ p₁ : P1} (h : p₀ ≠ p₁) :
-    Function.Injective (lineMap p₀ p₁ : k → P1) := fun c₁ c₂ hc =>
+    Function.Injective (lineMap p₀ p₁ : k → P1) := fun _c₁ _c₂ hc =>
   (lineMap_eq_lineMap_iff.mp hc).resolve_left h
 #align affine_map.line_map_injective AffineMap.lineMap_injective
 
 variable {k}
 
-include V2
-
 @[simp]
 theorem apply_lineMap (f : P1 →ᵃ[k] P2) (p₀ p₁ : P1) (c : k) :
-    f (lineMap p₀ p₁ c) = lineMap (f p₀) (f p₁) c := by simp [line_map_apply]
+    f (lineMap p₀ p₁ c) = lineMap (f p₀) (f p₁) c := by
+  -- porting note: `simp` can't infer `P1` or `P2`
+  simp [lineMap_apply (_ : P1), lineMap_apply (_ : P2), map_vadd _ (_ : P1),
+    linearMap_vsub _ (_ : P1)]
 #align affine_map.apply_line_map AffineMap.apply_lineMap
 
 @[simp]
@@ -632,16 +627,13 @@ theorem snd_lineMap (p₀ p₁ : P1 × P2) (c : k) : (lineMap p₀ p₁ c).2 = l
   snd.apply_lineMap p₀ p₁ c
 #align affine_map.snd_line_map AffineMap.snd_lineMap
 
-omit V2
-
 theorem lineMap_symm (p₀ p₁ : P1) :
     lineMap p₀ p₁ = (lineMap p₁ p₀).comp (lineMap (1 : k) (0 : k)) := by
   rw [comp_line_map]
   simp
 #align affine_map.line_map_symm AffineMap.lineMap_symm
 
-theorem lineMap_apply_one_sub (p₀ p₁ : P1) (c : k) : lineMap p₀ p₁ (1 - c) = lineMap p₁ p₀ c :=
-  by
+theorem lineMap_apply_one_sub (p₀ p₁ : P1) (c : k) : lineMap p₀ p₁ (1 - c) = lineMap p₁ p₀ c := by
   rw [line_map_symm p₀, comp_apply]
   congr
   simp [line_map_apply]
@@ -699,11 +691,10 @@ omit V1
 
 theorem image_uIcc {k : Type _} [LinearOrderedField k] (f : k →ᵃ[k] k) (a b : k) :
     f '' Set.uIcc a b = Set.uIcc (f a) (f b) := by
-  have : ⇑f = (fun x => x + f 0) ∘ fun x => x * (f 1 - f 0) :=
-    by
+  have : ⇑f = (fun x => x + f 0) ∘ fun x => x * (f 1 - f 0) := by
     ext x
     change f x = x • (f 1 -ᵥ f 0) +ᵥ f 0
-    rw [← f.linear_map_vsub, ← f.linear.map_smul, ← f.map_vadd]
+    rw [← f.linearMap_vsub, ← f.linear.map_smul, ← f.map_vadd]
     simp only [vsub_eq_sub, add_zero, mul_one, vadd_eq_add, sub_zero, smul_eq_mul]
   rw [this, Set.image_comp]
   simp only [Set.image_add_const_uIcc, Set.image_mul_const_uIcc]
@@ -717,8 +708,7 @@ variable {ι : Type _} {V : ∀ i : ι, Type _} {P : ∀ i : ι, Type _} [∀ i,
 include V
 
 /-- Evaluation at a point as an affine map. -/
-def proj (i : ι) : (∀ i : ι, P i) →ᵃ[k] P i
-    where
+def proj (i : ι) : (∀ i : ι, P i) →ᵃ[k] P i where
   toFun f := f i
   linear := @LinearMap.proj k ι _ V _ _ i
   map_vadd' p v := rfl
@@ -760,8 +750,7 @@ section DistribMulAction
 variable [Monoid R] [DistribMulAction R V2] [SMulCommClass k R V2]
 
 /-- The space of affine maps to a module inherits an `R`-action from the action on its codomain. -/
-instance : DistribMulAction R (P1 →ᵃ[k] V2)
-    where
+instance : DistribMulAction R (P1 →ᵃ[k] V2) where
   smul_add c f g := ext fun p => smul_add _ _ _
   smul_zero c := ext fun p => smul_zero _
 
@@ -785,8 +774,7 @@ instance : AddCommMonoid (V1 →ₗ[k] V2) := LinearMap.addCommMonoid
 instance : AddCommMonoid (V2 × (V1 →ₗ[k] V2)) := Prod.instAddCommMonoidSum
 instance : Module R (V1 →ₗ[k] V2) := LinearMap.instModuleLinearMapAddCommMonoid
 instance : Module R (V2 × (V1 →ₗ[k] V2)) := Prod.module
--- Porting note: Workaround for lean4#2074
-attribute [-instance] Ring.toNonAssocRing
+
 
 /-- The space of affine maps between two modules is linearly equivalent to the product of the
 domain with the space of linear maps, by taking the value of the affine map at `(0 : V1)` and the
@@ -794,8 +782,7 @@ linear part.
 
 See note [bundled maps over different rings]-/
 @[simps]
-def toConstProdLinearMap : (V1 →ᵃ[k] V2) ≃ₗ[R] V2 × (V1 →ₗ[k] V2)
-    where
+def toConstProdLinearMap : (V1 →ᵃ[k] V2) ≃ₗ[R] V2 × (V1 →ₗ[k] V2) where
   toFun f := ⟨f 0, f.linear⟩
   invFun p := p.2.toAffineMap + const k V1 p.1
   left_inv f := by

--- a/Mathlib/LinearAlgebra/AffineSpace/AffineMap.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/AffineMap.lean
@@ -259,13 +259,13 @@ instance : Zero (P1 →ᵃ[k] V2) where zero := ⟨0, 0, fun _ _ => (zero_vadd _
 
 instance : Add (P1 →ᵃ[k] V2)
     where add f g := ⟨f + g, f.linear + g.linear,
-      -- porting note: `simp` needs `map_vadd _` to use `map_vadd`
-      fun p v => by simp [add_add_add_comm, map_vadd _]⟩
+      -- porting note: `simp` needs lemmas to be expressions
+      fun p v => by simp [add_add_add_comm, (map_vadd)]⟩
 
 instance : Sub (P1 →ᵃ[k] V2)
     where sub f g := ⟨f - g, f.linear - g.linear,
-      -- porting note: `simp` needs `map_vadd _` to use `map_vadd`
-      fun p v => by simp [sub_add_sub_comm, map_vadd _]⟩
+      -- porting note: `simp` needs lemmas to be expressions
+      fun p v => by simp [sub_add_sub_comm, (map_vadd)]⟩
 
 instance : Neg (P1 →ᵃ[k] V2)
     where neg f := ⟨-f, -f.linear, fun p v => by simp [add_comm, map_vadd f]⟩
@@ -320,14 +320,14 @@ from `P1` to the vector space `V2` corresponding to `P2`. -/
 instance : AffineSpace (P1 →ᵃ[k] V2) (P1 →ᵃ[k] P2) where
   vadd f g :=
     ⟨fun p => f p +ᵥ g p, f.linear + g.linear,
-      -- porting note: `simp` needs `map_vadd _` to use `map_vadd`
-      fun p v => by simp [vadd_vadd, add_right_comm, map_vadd _]⟩
+      -- porting note: `simp` needs lemmas to be expressions
+      fun p v => by simp [vadd_vadd, add_right_comm, (map_vadd)]⟩
   zero_vadd f := ext fun p => zero_vadd _ (f p)
   add_vadd f₁ f₂ f₃ := ext fun p => add_vadd (f₁ p) (f₂ p) (f₃ p)
   vsub f g :=
     ⟨fun p => f p -ᵥ g p, f.linear - g.linear, fun p v => by
-      -- porting note: `simp` needs `_` to use these lemmas
-      simp [map_vadd _, vsub_vadd_eq_vsub_sub _, vadd_vsub_assoc _,
+      -- porting note: `simp` needs lemmas to be expressions
+      simp [(map_vadd), (vsub_vadd_eq_vsub_sub), (vadd_vsub_assoc),
         add_sub, sub_add_eq_add_sub]⟩
   vsub_vadd' f g := ext fun p => vsub_vadd (f p) (g p)
   vadd_vsub' f g := ext fun p => vadd_vsub (f p) (g p)
@@ -499,8 +499,8 @@ theorem linear_bijective_iff (f : P1 →ᵃ[k] P2) :
 theorem image_vsub_image {s t : Set P1} (f : P1 →ᵃ[k] P2) :
     f '' s -ᵥ f '' t = f.linear '' (s -ᵥ t) := by
   ext v
-  -- porting note: `simp` needs a placeholder for the `β` argument to `Set.mem_vsub`
-  simp only [Set.mem_vsub (β := _), Set.mem_image,
+  -- porting note: `simp` needs `Set.mem_vsub` to be an expression
+  simp only [(Set.mem_vsub), Set.mem_image,
     exists_exists_and_eq_and, exists_and_left, ← f.linearMap_vsub]
   constructor
   · rintro ⟨x, hx, y, hy, hv⟩
@@ -554,8 +554,8 @@ theorem lineMap_linear (p₀ p₁ : P1) :
 #align affine_map.line_map_linear AffineMap.lineMap_linear
 
 theorem lineMap_same_apply (p : P1) (c : k) : lineMap p p c = p := by
-  -- porting note: `simp` needs a `_` to use these lemmas
-  simp [lineMap_apply _, vsub_self _]
+  -- porting note: `simp` needs lemmas to be expressions
+  simp [(lineMap_apply), (vsub_self)]
 #align affine_map.line_map_same_apply AffineMap.lineMap_same_apply
 
 @[simp]
@@ -565,14 +565,14 @@ theorem lineMap_same (p : P1) : lineMap p p = const k k p :=
 
 @[simp]
 theorem lineMap_apply_zero (p₀ p₁ : P1) : lineMap p₀ p₁ (0 : k) = p₀ := by
-  -- porting note: `simp` needs a `_` to use these lemmas
-  simp [lineMap_apply _]
+  -- porting note: `simp` needs lemmas to be expressions
+  simp [(lineMap_apply)]
 #align affine_map.line_map_apply_zero AffineMap.lineMap_apply_zero
 
 @[simp]
 theorem lineMap_apply_one (p₀ p₁ : P1) : lineMap p₀ p₁ (1 : k) = p₁ := by
-  -- porting note: `simp` needs a `_` to use these lemmas
-  simp [lineMap_apply _, vsub_vadd _]
+  -- porting note: `simp` needs lemmas to be expressions
+  simp [(lineMap_apply), (vsub_vadd)]
 #align affine_map.line_map_apply_one AffineMap.lineMap_apply_one
 
 @[simp]
@@ -606,8 +606,8 @@ variable {k}
 @[simp]
 theorem apply_lineMap (f : P1 →ᵃ[k] P2) (p₀ p₁ : P1) (c : k) :
     f (lineMap p₀ p₁ c) = lineMap (f p₀) (f p₁) c := by
-  -- porting note: `simp` needs a `_` to use these lemmas
-  simp [lineMap_apply _, lineMap_apply _, map_vadd _, linearMap_vsub _]
+  -- porting note: `simp` needs lemmas to be expressions
+  simp [(lineMap_apply), (map_vadd), (linearMap_vsub)]
 #align affine_map.apply_line_map AffineMap.apply_lineMap
 
 @[simp]
@@ -782,7 +782,7 @@ def toConstProdLinearMap : (V1 →ᵃ[k] V2) ≃ₗ[R] V2 × (V1 →ₗ[k] V2) w
   left_inv f := by
     ext
     rw [f.decomp]
-    simp [const_apply _ _]  -- porting note: `simp` needs `_`s to use these lemmas
+    simp [const_apply _ _]  -- porting note: `simp` needs `_`s to use this lemma
   right_inv := by
     rintro ⟨v, f⟩
     ext <;> simp [const_apply _ _, const_linear _ _]  -- porting note: `simp` needs `_`s

--- a/Mathlib/LinearAlgebra/AffineSpace/AffineMap.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/AffineMap.lean
@@ -460,7 +460,7 @@ theorem coe_one : ⇑(1 : P1 →ᵃ[k] P1) = _root_.id :=
   rfl
 #align affine_map.coe_one AffineMap.coe_one
 
-/-- `affine_map.linear` on endomorphisms is a `MonoidHom`. -/
+/-- `AffineMap.linear` on endomorphisms is a `MonoidHom`. -/
 @[simps]
 def linearHom : (P1 →ᵃ[k] P1) →* V1 →ₗ[k] V1 where
   toFun := linear

--- a/Mathlib/LinearAlgebra/AffineSpace/AffineMap.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/AffineMap.lean
@@ -3,7 +3,7 @@ Copyright (c) 2020 Joseph Myers. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joseph Myers
 
-! This file was ported from Lean 3 source module linear_algebra.AffineSpace.affine_map
+! This file was ported from Lean 3 source module linear_algebra.affine_space.affine_map
 ! leanprover-community/mathlib commit bd1fc183335ea95a9519a1630bcf901fe9326d83
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
@@ -42,7 +42,7 @@ topology are defined elsewhere; see `Analysis.NormedSpace.AddTorsor` and
 
 ## References
 
-* https://en.wikipedia.org/wiki/AffineSpace
+* https://en.wikipedia.org/wiki/Affine_space
 * https://en.wikipedia.org/wiki/Principal_homogeneous_space
 -/
 

--- a/Mathlib/LinearAlgebra/AffineSpace/AffineMap.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/AffineMap.lean
@@ -259,13 +259,13 @@ instance : Zero (P1 →ᵃ[k] V2) where zero := ⟨0, 0, fun _ _ => (zero_vadd _
 
 instance : Add (P1 →ᵃ[k] V2)
     where add f g := ⟨f + g, f.linear + g.linear,
-      -- porting note: `simp` can't infer `P1` in `map_vadd`
-      fun p v => by simp [add_add_add_comm, map_vadd _ (_ : P1)]⟩
+      -- porting note: `simp` needs `map_vadd _` to use `map_vadd`
+      fun p v => by simp [add_add_add_comm, map_vadd _]⟩
 
 instance : Sub (P1 →ᵃ[k] V2)
     where sub f g := ⟨f - g, f.linear - g.linear,
-      -- porting note: `simp` can't infer `P1` in `map_vadd`
-      fun p v => by simp [sub_add_sub_comm, map_vadd _ (_ : P1)]⟩
+      -- porting note: `simp` needs `map_vadd _` to use `map_vadd`
+      fun p v => by simp [sub_add_sub_comm, map_vadd _]⟩
 
 instance : Neg (P1 →ᵃ[k] V2)
     where neg f := ⟨-f, -f.linear, fun p v => by simp [add_comm, map_vadd f]⟩
@@ -320,14 +320,14 @@ from `P1` to the vector space `V2` corresponding to `P2`. -/
 instance : AffineSpace (P1 →ᵃ[k] V2) (P1 →ᵃ[k] P2) where
   vadd f g :=
     ⟨fun p => f p +ᵥ g p, f.linear + g.linear,
-      -- porting note: `simp` can't infer `P1` in `map_vadd`
-      fun p v => by simp [vadd_vadd, add_right_comm, map_vadd _ (_ : P1)]⟩
+      -- porting note: `simp` needs `map_vadd _` to use `map_vadd`
+      fun p v => by simp [vadd_vadd, add_right_comm, map_vadd _]⟩
   zero_vadd f := ext fun p => zero_vadd _ (f p)
   add_vadd f₁ f₂ f₃ := ext fun p => add_vadd (f₁ p) (f₂ p) (f₃ p)
   vsub f g :=
     ⟨fun p => f p -ᵥ g p, f.linear - g.linear, fun p v => by
-      -- porting note: `simp` can't infer `P1` in `map_vadd` or `P2` in the others
-      simp [map_vadd _ (_ : P1), vsub_vadd_eq_vsub_sub (_ : P2), vadd_vsub_assoc _ (_ : P2),
+      -- porting note: `simp` needs `_` to use these lemmas
+      simp [map_vadd _, vsub_vadd_eq_vsub_sub _, vadd_vsub_assoc _,
         add_sub, sub_add_eq_add_sub]⟩
   vsub_vadd' f g := ext fun p => vsub_vadd (f p) (g p)
   vadd_vsub' f g := ext fun p => vadd_vsub (f p) (g p)
@@ -499,8 +499,8 @@ theorem linear_bijective_iff (f : P1 →ᵃ[k] P2) :
 theorem image_vsub_image {s t : Set P1} (f : P1 →ᵃ[k] P2) :
     f '' s -ᵥ f '' t = f.linear '' (s -ᵥ t) := by
   ext v
-  -- porting note: `simp` can't infer the `β` argument to `Set.mem_vsub`
-  simp only [Set.mem_vsub (β := P2), Set.mem_vsub (β := P1), Set.mem_image,
+  -- porting note: `simp` needs a placeholder for the `β` argument to `Set.mem_vsub`
+  simp only [Set.mem_vsub (β := P2), Set.mem_vsub (β := _), Set.mem_image,
     exists_exists_and_eq_and, exists_and_left, ← f.linearMap_vsub]
   constructor
   · rintro ⟨x, hx, y, hy, hv⟩
@@ -554,8 +554,8 @@ theorem lineMap_linear (p₀ p₁ : P1) :
 #align affine_map.line_map_linear AffineMap.lineMap_linear
 
 theorem lineMap_same_apply (p : P1) (c : k) : lineMap p p c = p := by
-  -- porting note: `simp` can't infer `P1`
-  simp [lineMap_apply (_ : P1), vsub_self (_ : P1)]
+  -- porting note: `simp` needs a `_` to use these lemmas
+  simp [lineMap_apply _, vsub_self _]
 #align affine_map.line_map_same_apply AffineMap.lineMap_same_apply
 
 @[simp]
@@ -565,14 +565,14 @@ theorem lineMap_same (p : P1) : lineMap p p = const k k p :=
 
 @[simp]
 theorem lineMap_apply_zero (p₀ p₁ : P1) : lineMap p₀ p₁ (0 : k) = p₀ := by
-  -- porting note: `simp` can't infer `P1`
-  simp [lineMap_apply (_ : P1)]
+  -- porting note: `simp` needs a `_` to use these lemmas
+  simp [lineMap_apply _]
 #align affine_map.line_map_apply_zero AffineMap.lineMap_apply_zero
 
 @[simp]
 theorem lineMap_apply_one (p₀ p₁ : P1) : lineMap p₀ p₁ (1 : k) = p₁ := by
-  -- porting note: `simp` can't infer `P1`
-  simp [lineMap_apply (_ : P1), vsub_vadd (_ : P1)]
+  -- porting note: `simp` needs a `_` to use these lemmas
+  simp [lineMap_apply _, vsub_vadd _]
 #align affine_map.line_map_apply_one AffineMap.lineMap_apply_one
 
 @[simp]
@@ -606,9 +606,8 @@ variable {k}
 @[simp]
 theorem apply_lineMap (f : P1 →ᵃ[k] P2) (p₀ p₁ : P1) (c : k) :
     f (lineMap p₀ p₁ c) = lineMap (f p₀) (f p₁) c := by
-  -- porting note: `simp` can't infer `P1` or `P2`
-  simp [lineMap_apply (_ : P1), lineMap_apply (_ : P2), map_vadd _ (_ : P1),
-    linearMap_vsub _ (_ : P1)]
+  -- porting note: `simp` needs a `_` to use these lemmas
+  simp [lineMap_apply _, lineMap_apply _, map_vadd _, linearMap_vsub _]
 #align affine_map.apply_line_map AffineMap.apply_lineMap
 
 @[simp]
@@ -783,10 +782,10 @@ def toConstProdLinearMap : (V1 →ᵃ[k] V2) ≃ₗ[R] V2 × (V1 →ₗ[k] V2) w
   left_inv f := by
     ext
     rw [f.decomp]
-    simp
+    simp [const_apply _ _]  -- porting note: `simp` needs `_`s to use these lemmas
   right_inv := by
     rintro ⟨v, f⟩
-    ext <;> simp
+    ext <;> simp [const_apply _ _, const_linear _ _]  -- porting note: `simp` needs `_`s
   map_add' := by simp
   map_smul' := by simp
 #align affine_map.to_const_prod_linear_map AffineMap.toConstProdLinearMap
@@ -800,8 +799,6 @@ section CommRing
 variable [CommRing k] [AddCommGroup V1] [AffineSpace V1 P1] [AddCommGroup V2]
 
 variable [Module k V1] [Module k V2]
-
-include V1
 
 /-- `homothety c r` is the homothety (also known as dilation) about `c` with scale factor `r`. -/
 def homothety (c : P1) (r : k) : P1 →ᵃ[k] P1 :=
@@ -834,7 +831,7 @@ theorem homothety_apply_same (c : P1) (r : k) : homothety c r c = c :=
 
 theorem homothety_mul_apply (c : P1) (r₁ r₂ : k) (p : P1) :
     homothety c (r₁ * r₂) p = homothety c r₁ (homothety c r₂ p) := by
-  simp [homothety_apply, mul_smul]
+  simp only [homothety_apply, mul_smul, vadd_vsub]
 #align affine_map.homothety_mul_apply AffineMap.homothety_mul_apply
 
 theorem homothety_mul (c : P1) (r₁ r₂ : k) :
@@ -855,8 +852,10 @@ theorem homothety_add (c : P1) (r₁ r₂ : k) :
 #align affine_map.homothety_add AffineMap.homothety_add
 
 /-- `homothety` as a multiplicative monoid homomorphism. -/
-def homothetyHom (c : P1) : k →* P1 →ᵃ[k] P1 :=
-  ⟨homothety c, homothety_one c, homothety_mul c⟩
+def homothetyHom (c : P1) : k →* P1 →ᵃ[k] P1 where
+  toFun := homothety c
+  map_one' := homothety_one c
+  map_mul' := homothety_mul c
 #align affine_map.homothety_hom AffineMap.homothetyHom
 
 @[simp]
@@ -888,7 +887,7 @@ the images. -/
 theorem Convex.combo_affine_apply {x y : E} {a b : 𝕜} {f : E →ᵃ[𝕜] F} (h : a + b = 1) :
     f (a • x + b • y) = a • f x + b • f y := by
   simp only [Convex.combo_eq_smul_sub_add h, ← vsub_eq_sub]
-  exact f.apply_line_map _ _ _
+  exact f.apply_lineMap _ _ _
 #align convex.combo_affine_apply Convex.combo_affine_apply
 
 end

--- a/Mathlib/LinearAlgebra/AffineSpace/AffineMap.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/AffineMap.lean
@@ -629,14 +629,14 @@ theorem snd_lineMap (p₀ p₁ : P1 × P2) (c : k) : (lineMap p₀ p₁ c).2 = l
 
 theorem lineMap_symm (p₀ p₁ : P1) :
     lineMap p₀ p₁ = (lineMap p₁ p₀).comp (lineMap (1 : k) (0 : k)) := by
-  rw [comp_line_map]
+  rw [comp_lineMap]
   simp
 #align affine_map.line_map_symm AffineMap.lineMap_symm
 
 theorem lineMap_apply_one_sub (p₀ p₁ : P1) (c : k) : lineMap p₀ p₁ (1 - c) = lineMap p₁ p₀ c := by
-  rw [line_map_symm p₀, comp_apply]
+  rw [lineMap_symm p₀, comp_apply]
   congr
-  simp [line_map_apply]
+  simp [lineMap_apply]
 #align affine_map.line_map_apply_one_sub AffineMap.lineMap_apply_one_sub
 
 @[simp]
@@ -646,48 +646,45 @@ theorem lineMap_vsub_left (p₀ p₁ : P1) (c : k) : lineMap p₀ p₁ c -ᵥ p�
 
 @[simp]
 theorem left_vsub_lineMap (p₀ p₁ : P1) (c : k) : p₀ -ᵥ lineMap p₀ p₁ c = c • (p₀ -ᵥ p₁) := by
-  rw [← neg_vsub_eq_vsub_rev, line_map_vsub_left, ← smul_neg, neg_vsub_eq_vsub_rev]
+  rw [← neg_vsub_eq_vsub_rev, lineMap_vsub_left, ← smul_neg, neg_vsub_eq_vsub_rev]
 #align affine_map.left_vsub_line_map AffineMap.left_vsub_lineMap
 
 @[simp]
 theorem lineMap_vsub_right (p₀ p₁ : P1) (c : k) : lineMap p₀ p₁ c -ᵥ p₁ = (1 - c) • (p₀ -ᵥ p₁) := by
-  rw [← line_map_apply_one_sub, line_map_vsub_left]
+  rw [← lineMap_apply_one_sub, lineMap_vsub_left]
 #align affine_map.line_map_vsub_right AffineMap.lineMap_vsub_right
 
 @[simp]
 theorem right_vsub_lineMap (p₀ p₁ : P1) (c : k) : p₁ -ᵥ lineMap p₀ p₁ c = (1 - c) • (p₁ -ᵥ p₀) := by
-  rw [← line_map_apply_one_sub, left_vsub_line_map]
+  rw [← lineMap_apply_one_sub, left_vsub_lineMap]
 #align affine_map.right_vsub_line_map AffineMap.right_vsub_lineMap
 
 theorem lineMap_vadd_lineMap (v₁ v₂ : V1) (p₁ p₂ : P1) (c : k) :
     lineMap v₁ v₂ c +ᵥ lineMap p₁ p₂ c = lineMap (v₁ +ᵥ p₁) (v₂ +ᵥ p₂) c :=
-  ((fst : V1 × P1 →ᵃ[k] V1) +ᵥ snd).apply_lineMap (v₁, p₁) (v₂, p₂) c
+  ((fst : V1 × P1 →ᵃ[k] V1) +ᵥ (snd : V1 × P1 →ᵃ[k] P1)).apply_lineMap (v₁, p₁) (v₂, p₂) c
 #align affine_map.line_map_vadd_line_map AffineMap.lineMap_vadd_lineMap
 
 theorem lineMap_vsub_lineMap (p₁ p₂ p₃ p₄ : P1) (c : k) :
     lineMap p₁ p₂ c -ᵥ lineMap p₃ p₄ c = lineMap (p₁ -ᵥ p₃) (p₂ -ᵥ p₄) c :=
-  letI-- Why Lean fails to find this instance without a hint?
-   : AffineSpace (V1 × V1) (P1 × P1) := Prod.addTorsor
   ((fst : P1 × P1 →ᵃ[k] P1) -ᵥ (snd : P1 × P1 →ᵃ[k] P1)).apply_lineMap (_, _) (_, _) c
 #align affine_map.line_map_vsub_line_map AffineMap.lineMap_vsub_lineMap
 
 /-- Decomposition of an affine map in the special case when the point space and vector space
 are the same. -/
-theorem decomp (f : V1 →ᵃ[k] V2) : (f : V1 → V2) = f.linear + fun z => f 0 := by
+theorem decomp (f : V1 →ᵃ[k] V2) : (f : V1 → V2) = ⇑f.linear + fun _ => f 0 := by
   ext x
   calc
-    f x = f.linear x +ᵥ f 0 := by simp [← f.map_vadd]
-    _ = (f.linear.to_fun + fun z : V1 => f 0) x := by simp
+    f x = f.linear x +ᵥ f 0 := by rw [← f.map_vadd, vadd_eq_add, add_zero]
+    _ = (f.linear + fun _ : V1 => f 0) x := rfl
 
 #align affine_map.decomp AffineMap.decomp
 
 /-- Decomposition of an affine map in the special case when the point space and vector space
 are the same. -/
-theorem decomp' (f : V1 →ᵃ[k] V2) : (f.linear : V1 → V2) = f - fun z => f 0 := by
-  rw [decomp] <;> simp only [LinearMap.map_zero, Pi.add_apply, add_sub_cancel, zero_add]
+theorem decomp' (f : V1 →ᵃ[k] V2) : (f.linear : V1 → V2) = ⇑f - fun _ => f 0 := by
+  rw [decomp]
+  simp only [LinearMap.map_zero, Pi.add_apply, add_sub_cancel, zero_add]
 #align affine_map.decomp' AffineMap.decomp'
-
-omit V1
 
 theorem image_uIcc {k : Type _} [LinearOrderedField k] (f : k →ᵃ[k] k) (a b : k) :
     f '' Set.uIcc a b = Set.uIcc (f a) (f b) := by
@@ -697,21 +694,22 @@ theorem image_uIcc {k : Type _} [LinearOrderedField k] (f : k →ᵃ[k] k) (a b 
     rw [← f.linearMap_vsub, ← f.linear.map_smul, ← f.map_vadd]
     simp only [vsub_eq_sub, add_zero, mul_one, vadd_eq_add, sub_zero, smul_eq_mul]
   rw [this, Set.image_comp]
-  simp only [Set.image_add_const_uIcc, Set.image_mul_const_uIcc]
+  simp only [Set.image_add_const_uIcc, Set.image_mul_const_uIcc, Function.comp_apply]
 #align affine_map.image_uIcc AffineMap.image_uIcc
 
 section
 
-variable {ι : Type _} {V : ∀ i : ι, Type _} {P : ∀ i : ι, Type _} [∀ i, AddCommGroup (V i)]
+variable {ι : Type _} {V : ∀ _ : ι, Type _} {P : ∀ _ : ι, Type _} [∀ i, AddCommGroup (V i)]
   [∀ i, Module k (V i)] [∀ i, AddTorsor (V i) (P i)]
 
-include V
+-- Workaround for lean4#2074
+instance : AffineSpace (∀ i : ι, (V i)) (∀ i : ι, P i) := Pi.instAddTorsorForAllForAllAddGroup
 
 /-- Evaluation at a point as an affine map. -/
 def proj (i : ι) : (∀ i : ι, P i) →ᵃ[k] P i where
   toFun f := f i
   linear := @LinearMap.proj k ι _ V _ _ i
-  map_vadd' p v := rfl
+  map_vadd' _ _ := rfl
 #align affine_map.proj AffineMap.proj
 
 @[simp]
@@ -743,16 +741,14 @@ variable [Ring k] [AddCommGroup V1] [AffineSpace V1 P1] [AddCommGroup V2]
 
 variable [Module k V1] [Module k V2]
 
-include V1
-
 section DistribMulAction
 
 variable [Monoid R] [DistribMulAction R V2] [SMulCommClass k R V2]
 
 /-- The space of affine maps to a module inherits an `R`-action from the action on its codomain. -/
-instance : DistribMulAction R (P1 →ᵃ[k] V2) where
-  smul_add c f g := ext fun p => smul_add _ _ _
-  smul_zero c := ext fun p => smul_zero _
+instance distribMulAction : DistribMulAction R (P1 →ᵃ[k] V2) where
+  smul_add _c _f _g := ext fun _p => smul_add _ _ _
+  smul_zero _c := ext fun _p => smul_zero _
 
 end DistribMulAction
 
@@ -774,7 +770,6 @@ instance : AddCommMonoid (V1 →ₗ[k] V2) := LinearMap.addCommMonoid
 instance : AddCommMonoid (V2 × (V1 →ₗ[k] V2)) := Prod.instAddCommMonoidSum
 instance : Module R (V1 →ₗ[k] V2) := LinearMap.instModuleLinearMapAddCommMonoid
 instance : Module R (V2 × (V1 →ₗ[k] V2)) := Prod.module
-
 
 /-- The space of affine maps between two modules is linearly equivalent to the product of the
 domain with the space of linear maps, by taking the value of the affine map at `(0 : V1)` and the

--- a/Mathlib/LinearAlgebra/AffineSpace/AffineMap.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/AffineMap.lean
@@ -3,7 +3,7 @@ Copyright (c) 2020 Joseph Myers. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joseph Myers
 
-! This file was ported from Lean 3 source module linear_algebra.affine_space.affine_map
+! This file was ported from Lean 3 source module linear_algebra.AffineSpace.affine_map
 ! leanprover-community/mathlib commit bd1fc183335ea95a9519a1630bcf901fe9326d83
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
@@ -42,45 +42,45 @@ topology are defined elsewhere; see `Analysis.NormedSpace.AddTorsor` and
 
 ## References
 
-* https://en.wikipedia.org/wiki/Affine_space
+* https://en.wikipedia.org/wiki/AffineSpace
 * https://en.wikipedia.org/wiki/Principal_homogeneous_space
 -/
 
 
 open Affine
 
+-- Porting note: Workaround for lean4#2074
+attribute [-instance] Ring.toNonAssocRing in
+
 /-- An `AffineMap k P1 P2` (notation: `P1 →ᵃ[k] P2`) is a map from `P1` to `P2` that
 induces a corresponding linear map from `V1` to `V2`. -/
 structure AffineMap (k : Type _) {V1 : Type _} (P1 : Type _) {V2 : Type _} (P2 : Type _) [Ring k]
-  [AddCommGroup V1] [Module k V1] [affine_space V1 P1] [AddCommGroup V2] [Module k V2]
-  [affine_space V2 P2] where
+  [AddCommGroup V1] [Module k V1] [AffineSpace V1 P1] [AddCommGroup V2] [Module k V2]
+  [AffineSpace V2 P2] where
   toFun : P1 → P2
   linear : V1 →ₗ[k] V2
   map_vadd' : ∀ (p : P1) (v : V1), toFun (v +ᵥ p) = linear v +ᵥ toFun p
 #align affine_map AffineMap
-
-end defn
 
 /-- An `AffineMap k P1 P2` (notation: `P1 →ᵃ[k] P2`) is a map from `P1` to `P2` that
 induces a corresponding linear map from `V1` to `V2`. -/
 notation:25 P1 " →ᵃ[" k:25 "] " P2:0 => AffineMap k P1 P2
 
 instance AffineMap.funLike (k : Type _) {V1 : Type _} (P1 : Type _) {V2 : Type _} (P2 : Type _)
-    [Ring k] [AddCommGroup V1] [Module k V1] [affine_space V1 P1] [AddCommGroup V2] [Module k V2]
-    [affine_space V2 P2] : FunLike (P1 →ᵃ[k] P2) P1 fun _ => P2
+    [Ring k] [AddCommGroup V1] [Module k V1] [AffineSpace V1 P1] [AddCommGroup V2] [Module k V2]
+    [AffineSpace V2 P2] : FunLike (P1 →ᵃ[k] P2) P1 fun _ => P2
     where
   coe := AffineMap.toFun
-  coe_injective' := fun ⟨f, f_linear, f_add⟩ ⟨g, g_linear, g_add⟩ (h : f = g) =>
-    by
-    cases' (AddTorsor.nonempty : Nonempty P1) with p
+  coe_injective' := fun ⟨f, f_linear, f_add⟩ ⟨g, g_linear, g_add⟩ => fun (h : f = g) => by
+    cases' (AddTorsor.Nonempty : Nonempty P1) with p
     congr with v
     apply vadd_right_cancel (f p)
     erw [← f_add, h, ← g_add]
 #align affine_map.fun_like AffineMap.funLike
 
 instance AffineMap.hasCoeToFun (k : Type _) {V1 : Type _} (P1 : Type _) {V2 : Type _} (P2 : Type _)
-    [Ring k] [AddCommGroup V1] [Module k V1] [affine_space V1 P1] [AddCommGroup V2] [Module k V2]
-    [affine_space V2 P2] : CoeFun (P1 →ᵃ[k] P2) fun _ => P1 → P2 :=
+    [Ring k] [AddCommGroup V1] [Module k V1] [AffineSpace V1 P1] [AddCommGroup V2] [Module k V2]
+    [AffineSpace V2 P2] : CoeFun (P1 →ᵃ[k] P2) fun _ => P1 → P2 :=
   FunLike.hasCoeToFun
 #align affine_map.has_coe_to_fun AffineMap.hasCoeToFun
 
@@ -115,10 +115,8 @@ namespace AffineMap
 
 variable {k : Type _} {V1 : Type _} {P1 : Type _} {V2 : Type _} {P2 : Type _} {V3 : Type _}
   {P3 : Type _} {V4 : Type _} {P4 : Type _} [Ring k] [AddCommGroup V1] [Module k V1]
-  [affine_space V1 P1] [AddCommGroup V2] [Module k V2] [affine_space V2 P2] [AddCommGroup V3]
-  [Module k V3] [affine_space V3 P3] [AddCommGroup V4] [Module k V4] [affine_space V4 P4]
-
-include V1 V2
+  [AffineSpace V1 P1] [AddCommGroup V2] [Module k V2] [AffineSpace V2 P2] [AddCommGroup V3]
+  [Module k V3] [AffineSpace V3 P3] [AddCommGroup V4] [Module k V4] [AffineSpace V4 P4]
 
 /-- Constructing an affine map and coercing back to a function
 produces the same map. -/
@@ -156,10 +154,10 @@ theorem ext {f g : P1 →ᵃ[k] P2} (h : ∀ p, f p = g p) : f = g :=
 #align affine_map.ext AffineMap.ext
 
 theorem ext_iff {f g : P1 →ᵃ[k] P2} : f = g ↔ ∀ p, f p = g p :=
-  ⟨fun h p => h ▸ rfl, ext⟩
+  ⟨fun h _ => h ▸ rfl, ext⟩
 #align affine_map.ext_iff AffineMap.ext_iff
 
-theorem coeFn_injective : @Function.Injective (P1 →ᵃ[k] P2) (P1 → P2) coeFn :=
+theorem coeFn_injective : @Function.Injective (P1 →ᵃ[k] P2) (P1 → P2) (⇑) :=
   FunLike.coe_injective
 #align affine_map.coe_fn_injective AffineMap.coeFn_injective
 
@@ -212,6 +210,8 @@ instance nonempty : Nonempty (P1 →ᵃ[k] P2) :=
   (AddTorsor.Nonempty : Nonempty P2).elim fun p => ⟨const k P1 p⟩
 #align affine_map.nonempty AffineMap.nonempty
 
+-- Porting note: Workaround for lean4#2074
+attribute [-instance] Ring.toNonAssocRing in
 /-- Construct an affine map by verifying the relation between the map and its linear part at one
 base point. Namely, this function takes a map `f : P₁ → P₂`, a linear map `f' : V₁ →ₗ[k] V₂`, and
 a point `p` such that for any other point `p'` we have `f p' = f' (p' -ᵥ p) +ᵥ f p`. -/
@@ -237,14 +237,14 @@ section SMul
 variable {R : Type _} [Monoid R] [DistribMulAction R V2] [SMulCommClass k R V2]
 
 /-- The space of affine maps to a module inherits an `R`-action from the action on its codomain. -/
-instance : MulAction R (P1 →ᵃ[k] V2)
-    where
-  smul c f := ⟨c • f, c • f.linear, fun p v => by simp [smul_add]⟩
+instance mulAction : MulAction R (P1 →ᵃ[k] V2) where
+  -- porting note: `map_vadd` is `simp`, but we still have to pass it explicitly
+  smul c f := ⟨c • ⇑f, c • f.linear, fun p v => by simp [smul_add, map_vadd f]⟩
   one_smul f := ext fun p => one_smul _ _
   mul_smul c₁ c₂ f := ext fun p => mul_smul _ _ _
 
 @[simp, norm_cast]
-theorem coe_smul (c : R) (f : P1 →ᵃ[k] V2) : ⇑(c • f) = c • f :=
+theorem coe_smul (c : R) (f : P1 →ᵃ[k] V2) : ⇑(c • f) = c • ⇑f :=
   rfl
 #align affine_map.coe_smul AffineMap.coe_smul
 
@@ -315,7 +315,7 @@ instance : AddCommGroup (P1 →ᵃ[k] V2) :=
 
 /-- The space of affine maps from `P1` to `P2` is an affine space over the space of affine maps
 from `P1` to the vector space `V2` corresponding to `P2`. -/
-instance : affine_space (P1 →ᵃ[k] V2) (P1 →ᵃ[k] P2)
+instance : AffineSpace (P1 →ᵃ[k] V2) (P1 →ᵃ[k] P2)
     where
   vadd f g :=
     ⟨fun p => f p +ᵥ g p, f.linear + g.linear, fun p v => by simp [vadd_vadd, add_right_comm]⟩
@@ -675,7 +675,7 @@ theorem lineMap_vadd_lineMap (v₁ v₂ : V1) (p₁ p₂ : P1) (c : k) :
 theorem lineMap_vsub_lineMap (p₁ p₂ p₃ p₄ : P1) (c : k) :
     lineMap p₁ p₂ c -ᵥ lineMap p₃ p₄ c = lineMap (p₁ -ᵥ p₃) (p₂ -ᵥ p₄) c :=
   letI-- Why Lean fails to find this instance without a hint?
-   : affine_space (V1 × V1) (P1 × P1) := Prod.addTorsor
+   : AffineSpace (V1 × V1) (P1 × P1) := Prod.addTorsor
   ((fst : P1 × P1 →ᵃ[k] P1) -ᵥ (snd : P1 × P1 →ᵃ[k] P1)).apply_lineMap (_, _) (_, _) c
 #align affine_map.line_map_vsub_line_map AffineMap.lineMap_vsub_lineMap
 
@@ -749,7 +749,7 @@ variable {R k V1 P1 V2 : Type _}
 
 section Ring
 
-variable [Ring k] [AddCommGroup V1] [affine_space V1 P1] [AddCommGroup V2]
+variable [Ring k] [AddCommGroup V1] [AffineSpace V1 P1] [AddCommGroup V2]
 
 variable [Module k V1] [Module k V2]
 
@@ -815,7 +815,7 @@ end Ring
 
 section CommRing
 
-variable [CommRing k] [AddCommGroup V1] [affine_space V1 P1] [AddCommGroup V2]
+variable [CommRing k] [AddCommGroup V1] [AffineSpace V1 P1] [AddCommGroup V2]
 
 variable [Module k V1] [Module k V2]
 


### PR DESCRIPTION
This somewhat re-ports the file from scratch (by manually cleaning up the mathport output to remove all the meta comments), as lots of workarounds were added in #2570 to deal with coercion issues.

All proof changes are restoring the mathport proofs, except for small modifications to use `simp [(foo)]` instead of `simp [foo]` or `simp` (where `foo` was already a `simp` lemma).

leanprover-community/mathlib#18575

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
