### PR TITLE
[Merged by Bors] - fix a typo in `Topology.Homotopy.Basic`

### DIFF
--- a/Mathlib/Topology/Homotopy/Basic.lean
+++ b/Mathlib/Topology/Homotopy/Basic.lean
@@ -360,12 +360,10 @@ The type of homotopies between `f₀ f₁ : C(X, Y)`, where the intermediate map
 `P : C(X, Y) → Prop`
 -/
 structure HomotopyWith (f₀ f₁ : C(X, Y)) (P : C(X, Y) → Prop) extends Homotopy f₀ f₁ where
+  -- porting note: todo: use `toHomotopy.curry t`
   /-- the intermediate maps of the homotopy satisfy the proprerty -/
-  prop' :
-    ∀ t,
-      P
-        ⟨fun x => toFun (t, x),
-          Continuous.comp continuous_to_fun (continuous_const.prod_mk continuous_id')⟩
+  prop' : ∀ t, P ⟨fun x => toFun (t, x),
+    Continuous.comp continuous_toFun (continuous_const.prod_mk continuous_id')⟩
 #align continuous_map.homotopy_with ContinuousMap.HomotopyWith
 
 namespace HomotopyWith
@@ -427,8 +425,7 @@ theorem coe_toHomotopy (F : HomotopyWith f₀ f₁ P) : ⇑F.toHomotopy = F :=
   rfl
 #align continuous_map.homotopy_with.coe_to_homotopy ContinuousMap.HomotopyWith.coe_toHomotopy
 
-theorem prop (F : HomotopyWith f₀ f₁ P) (t : I) : P (F.toHomotopy.curry t) :=
-  @HomotopyWith.prop' _ _ _ _ _ _ _ F (ContinuousMap.continuous_toFun _) _
+theorem prop (F : HomotopyWith f₀ f₁ P) (t : I) : P (F.toHomotopy.curry t) := F.prop' t
 #align continuous_map.homotopy_with.prop ContinuousMap.HomotopyWith.prop
 
 theorem extendProp (F : HomotopyWith f₀ f₁ P) (t : ℝ) : P (F.toHomotopy.extend t) := by
@@ -454,10 +451,7 @@ variable {P : C(X, Y) → Prop}
 @[simps!]
 def refl (f : C(X, Y)) (hf : P f) : HomotopyWith f f P :=
   { Homotopy.refl f with
-    prop' := fun t => by
-      refine' Eq.subst _ hf
-      cases f
-      rfl }
+    prop' := fun _ => hf }
 #align continuous_map.homotopy_with.refl ContinuousMap.HomotopyWith.refl
 
 instance : Inhabited (HomotopyWith (ContinuousMap.id X) (ContinuousMap.id X) fun _ => True) :=

--- a/Mathlib/Topology/Homotopy/Basic.lean
+++ b/Mathlib/Topology/Homotopy/Basic.lean
@@ -361,7 +361,7 @@ The type of homotopies between `f₀ f₁ : C(X, Y)`, where the intermediate map
 -/
 structure HomotopyWith (f₀ f₁ : C(X, Y)) (P : C(X, Y) → Prop) extends Homotopy f₀ f₁ where
   -- porting note: todo: use `toHomotopy.curry t`
-  /-- the intermediate maps of the homotopy satisfy the proprerty -/
+  /-- the intermediate maps of the homotopy satisfy the property -/
   prop' : ∀ t, P ⟨fun x => toFun (t, x),
     Continuous.comp continuous_toFun (continuous_const.prod_mk continuous_id')⟩
 #align continuous_map.homotopy_with ContinuousMap.HomotopyWith


### PR DESCRIPTION
The `prop'` field used `continuous_to_fun` instead of `continuous_toFun`. Lean 4 silently introduced an implicit argument `continuous_to_fun`, so one had to specify it in the `.prop` theorem below.

Also golf a proof using new Lean 4 `rfl` for structures.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
