### PR TITLE
[Merged by Bors] - chore: remove notation for combine

### DIFF
--- a/Mathlib/Init/Function.lean
+++ b/Mathlib/Init/Function.lean
@@ -43,9 +43,6 @@ f x
 @[inherit_doc onFun]
 infixl:2 " on " => onFun
 
-@[inherit_doc combine]
-notation f " -[" op "]- " g => combine f op g
-
 theorem left_id (f : α → β) : id ∘ f = f := rfl
 
 theorem right_id (f : α → β) : f ∘ id = f := rfl


### PR DESCRIPTION
This clashes with the notation in `Analysis.Convex.Segment` and is not used at all in mathlib.

[Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Removing.20notation.20for.20.60Function.2Ecombine.60)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
