### PR TITLE
[Merged by Bors] - fix: Restore `apply_fun` to the Taylor polynomial file

### DIFF
--- a/Mathlib/Data/Polynomial/Taylor.lean
+++ b/Mathlib/Data/Polynomial/Taylor.lean
@@ -132,8 +132,7 @@ theorem taylor_eval_sub {R} [CommRing R] (r : R) (f : R[X]) (s : R) :
 
 theorem taylor_injective {R} [CommRing R] (r : R) : Function.Injective (taylor r) := by
   intro f g h
-  -- porting note: `apply_fun taylor (-r) at h` fails
-  replace h := FunLike.congr_arg (taylor (-r)) h
+  apply_fun taylor (-r) at h
   simpa only [taylor_apply, comp_assoc, add_comp, X_comp, C_comp, C_neg, neg_add_cancel_right,
     comp_X] using h
 #align polynomial.taylor_injective Polynomial.taylor_injective


### PR DESCRIPTION
Now that #2890 is merged, we can restore the line of code in #2850 that had to be changed because of the corresponding bug.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
