### PR TITLE
[Merged by Bors] - chore: forward-port leanprover-community/mathlib#18597

### DIFF
--- a/Mathlib/Algebra/Module/Basic.lean
+++ b/Mathlib/Algebra/Module/Basic.lean
@@ -465,32 +465,32 @@ theorem map_nat_cast_smul [AddCommMonoid M] [AddCommMonoid M₂] {F : Type _}
   simp only [← nsmul_eq_smul_cast, AddMonoidHom.map_nsmul, map_nsmul]
 #align map_nat_cast_smul map_nat_cast_smul
 
-theorem map_inv_int_cast_smul [AddCommGroup M] [AddCommGroup M₂] {F : Type _}
-    [AddMonoidHomClass F M M₂] (f : F) (R S : Type _) [DivisionRing R] [DivisionRing S] [Module R M]
-    [Module S M₂] (n : ℤ) (x : M) : f ((n⁻¹ : R) • x) = (n⁻¹ : S) • f x := by
+theorem map_inv_nat_cast_smul [AddCommMonoid M] [AddCommMonoid M₂] {F : Type _}
+    [AddMonoidHomClass F M M₂] (f : F) (R S : Type _)
+    [DivisionSemiring R] [DivisionSemiring S] [Module R M]
+    [Module S M₂] (n : ℕ) (x : M) : f ((n⁻¹ : R) • x) = (n⁻¹ : S) • f x := by
   by_cases hR : (n : R) = 0 <;> by_cases hS : (n : S) = 0
   · simp [hR, hS, map_zero f]
   · suffices ∀ y, f y = 0 by rw [this, this, smul_zero]
     clear x
     intro x
-    rw [← inv_smul_smul₀ hS (f x), ← map_int_cast_smul f R S]
+    rw [← inv_smul_smul₀ hS (f x), ← map_nat_cast_smul f R S]
     simp [hR, map_zero f]
   · suffices ∀ y, f y = 0 by simp [this]
     clear x
     intro x
-    rw [← smul_inv_smul₀ hR x, map_int_cast_smul f R S, hS, zero_smul]
-  · rw [← inv_smul_smul₀ hS (f _), ← map_int_cast_smul f R S, smul_inv_smul₀ hR]
-#align map_inv_int_cast_smul map_inv_int_cast_smul
-
-theorem map_inv_nat_cast_smul [AddCommGroup M] [AddCommGroup M₂] {F : Type _}
-    [AddMonoidHomClass F M M₂] (f : F) (R S : Type _) [DivisionRing R] [DivisionRing S] [Module R M]
-    [Module S M₂] (n : ℕ) (x : M) : f ((n⁻¹ : R) • x) = (n⁻¹ : S) • f x := by
-  -- Porting note: old proof was:
-  --exact_mod_cast map_inv_int_cast_smul f R S n x
-  convert map_inv_int_cast_smul f R S n x
-  · rw [Int.cast_Nat_cast]
-  · rw [Int.cast_Nat_cast]
+    rw [← smul_inv_smul₀ hR x, map_nat_cast_smul f R S, hS, zero_smul]
+  · rw [← inv_smul_smul₀ hS (f _), ← map_nat_cast_smul f R S, smul_inv_smul₀ hR]
 #align map_inv_nat_cast_smul map_inv_nat_cast_smul
+
+theorem map_inv_int_cast_smul [AddCommGroup M] [AddCommGroup M₂] {F : Type _}
+    [AddMonoidHomClass F M M₂] (f : F) (R S : Type _) [DivisionRing R] [DivisionRing S] [Module R M]
+    [Module S M₂] (z : ℤ) (x : M) : f ((z⁻¹ : R) • x) = (z⁻¹ : S) • f x := by
+  obtain ⟨n, rfl | rfl⟩ := z.eq_nat_or_neg
+  · rw [Int.cast_Nat_cast, Int.cast_Nat_cast, map_inv_nat_cast_smul _ R S]
+  · simp_rw [Int.cast_neg, Int.cast_Nat_cast, inv_neg, neg_smul, map_neg,
+      map_inv_nat_cast_smul _ R S]
+#align map_inv_int_cast_smul map_inv_int_cast_smul
 
 theorem map_rat_cast_smul [AddCommGroup M] [AddCommGroup M₂] {F : Type _} [AddMonoidHomClass F M M₂]
     (f : F) (R S : Type _) [DivisionRing R] [DivisionRing S] [Module R M] [Module S M₂] (c : ℚ)
@@ -510,18 +510,26 @@ instance subsingleton_rat_module (E : Type _) [AddCommGroup E] : Subsingleton (M
 #align subsingleton_rat_module subsingleton_rat_module
 
 /-- If `E` is a vector space over two division rings `R` and `S`, then scalar multiplications
+agree on inverses of natural numbers in `R` and `S`. -/
+theorem inv_nat_cast_smul_eq {E : Type _} (R S : Type _) [AddCommMonoid E] [DivisionSemiring R]
+    [DivisionRing S] [Module R E] [Module S E] (n : ℕ) (x : E) : (n⁻¹ : R) • x = (n⁻¹ : S) • x :=
+  map_inv_nat_cast_smul (AddMonoidHom.id E) R S n x
+#align inv_nat_cast_smul_eq inv_nat_cast_smul_eq
+
+/-- If `E` is a vector space over two division rings `R` and `S`, then scalar multiplications
 agree on inverses of integer numbers in `R` and `S`. -/
 theorem inv_int_cast_smul_eq {E : Type _} (R S : Type _) [AddCommGroup E] [DivisionRing R]
     [DivisionRing S] [Module R E] [Module S E] (n : ℤ) (x : E) : (n⁻¹ : R) • x = (n⁻¹ : S) • x :=
   map_inv_int_cast_smul (AddMonoidHom.id E) R S n x
 #align inv_int_cast_smul_eq inv_int_cast_smul_eq
 
-/-- If `E` is a vector space over two division rings `R` and `S`, then scalar multiplications
-agree on inverses of natural numbers in `R` and `S`. -/
-theorem inv_nat_cast_smul_eq {E : Type _} (R S : Type _) [AddCommGroup E] [DivisionRing R]
-    [DivisionRing S] [Module R E] [Module S E] (n : ℕ) (x : E) : (n⁻¹ : R) • x = (n⁻¹ : S) • x :=
-  map_inv_nat_cast_smul (AddMonoidHom.id E) R S n x
-#align inv_nat_cast_smul_eq inv_nat_cast_smul_eq
+/-- If `E` is a vector space over a division rings `R` and has a monoid action by `α`, then that
+action commutes by scalar multiplication of inverses of natural numbers in `R`. -/
+theorem inv_nat_cast_smul_comm {α E : Type _} (R : Type _) [AddCommMonoid E] [DivisionSemiring R]
+    [Monoid α] [Module R E] [DistribMulAction α E] (n : ℕ) (s : α) (x : E) :
+    (n⁻¹ : R) • s • x = s • (n⁻¹ : R) • x :=
+  (map_inv_nat_cast_smul (DistribMulAction.toAddMonoidHom E s) R R n x).symm
+#align inv_nat_cast_smul_comm inv_nat_cast_smul_comm
 
 /-- If `E` is a vector space over a division rings `R` and has a monoid action by `α`, then that
 action commutes by scalar multiplication of inverses of integers in `R` -/
@@ -530,14 +538,6 @@ theorem inv_int_cast_smul_comm {α E : Type _} (R : Type _) [AddCommGroup E] [Di
     (n⁻¹ : R) • s • x = s • (n⁻¹ : R) • x :=
   (map_inv_int_cast_smul (DistribMulAction.toAddMonoidHom E s) R R n x).symm
 #align inv_int_cast_smul_comm inv_int_cast_smul_comm
-
-/-- If `E` is a vector space over a division rings `R` and has a monoid action by `α`, then that
-action commutes by scalar multiplication of inverses of natural numbers in `R`. -/
-theorem inv_nat_cast_smul_comm {α E : Type _} (R : Type _) [AddCommGroup E] [DivisionRing R]
-    [Monoid α] [Module R E] [DistribMulAction α E] (n : ℕ) (s : α) (x : E) :
-    (n⁻¹ : R) • s • x = s • (n⁻¹ : R) • x :=
-  (map_inv_nat_cast_smul (DistribMulAction.toAddMonoidHom E s) R R n x).symm
-#align inv_nat_cast_smul_comm inv_nat_cast_smul_comm
 
 /-- If `E` is a vector space over two division rings `R` and `S`, then scalar multiplications
 agree on rational numbers in `R` and `S`. -/

--- a/Mathlib/Algebra/Module/Basic.lean
+++ b/Mathlib/Algebra/Module/Basic.lean
@@ -512,7 +512,8 @@ instance subsingleton_rat_module (E : Type _) [AddCommGroup E] : Subsingleton (M
 /-- If `E` is a vector space over two division semirings `R` and `S`, then scalar multiplications
 agree on inverses of natural numbers in `R` and `S`. -/
 theorem inv_nat_cast_smul_eq {E : Type _} (R S : Type _) [AddCommMonoid E] [DivisionSemiring R]
-    [DivisionSemiring S] [Module R E] [Module S E] (n : ℕ) (x : E) : (n⁻¹ : R) • x = (n⁻¹ : S) • x :=
+    [DivisionSemiring S] [Module R E] [Module S E] (n : ℕ) (x : E) :
+    (n⁻¹ : R) • x = (n⁻¹ : S) • x :=
   map_inv_nat_cast_smul (AddMonoidHom.id E) R S n x
 #align inv_nat_cast_smul_eq inv_nat_cast_smul_eq
 

--- a/Mathlib/Algebra/Module/Basic.lean
+++ b/Mathlib/Algebra/Module/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Nathaniel Thomas, Jeremy Avigad, Johannes Hölzl, Mario Carneiro
 
 ! This file was ported from Lean 3 source module algebra.module.basic
-! leanprover-community/mathlib commit 966e0cf0685c9cedf8a3283ac69eef4d5f2eaca2
+! leanprover-community/mathlib commit 30413fc89f202a090a54d78e540963ed3de0056e
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/

--- a/Mathlib/Algebra/Module/Basic.lean
+++ b/Mathlib/Algebra/Module/Basic.lean
@@ -509,10 +509,10 @@ instance subsingleton_rat_module (E : Type _) [AddCommGroup E] : Subsingleton (M
   ⟨fun P Q => (Module.ext' P Q) fun r x => @map_rat_smul _ _ _ _ P Q _ _ (AddMonoidHom.id E) r x⟩
 #align subsingleton_rat_module subsingleton_rat_module
 
-/-- If `E` is a vector space over two division rings `R` and `S`, then scalar multiplications
+/-- If `E` is a vector space over two division semirings `R` and `S`, then scalar multiplications
 agree on inverses of natural numbers in `R` and `S`. -/
 theorem inv_nat_cast_smul_eq {E : Type _} (R S : Type _) [AddCommMonoid E] [DivisionSemiring R]
-    [DivisionRing S] [Module R E] [Module S E] (n : ℕ) (x : E) : (n⁻¹ : R) • x = (n⁻¹ : S) • x :=
+    [DivisionSemiring S] [Module R E] [Module S E] (n : ℕ) (x : E) : (n⁻¹ : R) • x = (n⁻¹ : S) • x :=
   map_inv_nat_cast_smul (AddMonoidHom.id E) R S n x
 #align inv_nat_cast_smul_eq inv_nat_cast_smul_eq
 
@@ -523,7 +523,7 @@ theorem inv_int_cast_smul_eq {E : Type _} (R S : Type _) [AddCommGroup E] [Divis
   map_inv_int_cast_smul (AddMonoidHom.id E) R S n x
 #align inv_int_cast_smul_eq inv_int_cast_smul_eq
 
-/-- If `E` is a vector space over a division rings `R` and has a monoid action by `α`, then that
+/-- If `E` is a vector space over a division semiring `R` and has a monoid action by `α`, then that
 action commutes by scalar multiplication of inverses of natural numbers in `R`. -/
 theorem inv_nat_cast_smul_comm {α E : Type _} (R : Type _) [AddCommMonoid E] [DivisionSemiring R]
     [Monoid α] [Module R E] [DistribMulAction α E] (n : ℕ) (s : α) (x : E) :
@@ -531,7 +531,7 @@ theorem inv_nat_cast_smul_comm {α E : Type _} (R : Type _) [AddCommMonoid E] [D
   (map_inv_nat_cast_smul (DistribMulAction.toAddMonoidHom E s) R R n x).symm
 #align inv_nat_cast_smul_comm inv_nat_cast_smul_comm
 
-/-- If `E` is a vector space over a division rings `R` and has a monoid action by `α`, then that
+/-- If `E` is a vector space over a division ring `R` and has a monoid action by `α`, then that
 action commutes by scalar multiplication of inverses of integers in `R` -/
 theorem inv_int_cast_smul_comm {α E : Type _} (R : Type _) [AddCommGroup E] [DivisionRing R]
     [Monoid α] [Module R E] [DistribMulAction α E] (n : ℤ) (s : α) (x : E) :

--- a/Mathlib/Algebra/Periodic.lean
+++ b/Mathlib/Algebra/Periodic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Benjamin Davidson
 
 ! This file was ported from Lean 3 source module algebra.periodic
-! leanprover-community/mathlib commit 2196ab363eb097c008d4497125e0dde23fb36db2
+! leanprover-community/mathlib commit 30413fc89f202a090a54d78e540963ed3de0056e
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/

--- a/Mathlib/Algebra/Star/Basic.lean
+++ b/Mathlib/Algebra/Star/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 
 ! This file was ported from Lean 3 source module algebra.star.basic
-! leanprover-community/mathlib commit 44b58b42794e5abe2bf86397c38e26b587e07e59
+! leanprover-community/mathlib commit 30413fc89f202a090a54d78e540963ed3de0056e
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/

--- a/Mathlib/Algebra/Star/Basic.lean
+++ b/Mathlib/Algebra/Star/Basic.lean
@@ -398,18 +398,18 @@ set_option linter.uppercaseLean3 false in
 #align is_R_or_C.conj_conj IsROrC.conj_conj
 
 @[simp]
-theorem star_inv' [DivisionRing R] [StarRing R] (x : R) : star x⁻¹ = (star x)⁻¹ :=
+theorem star_inv' [DivisionSemiring R] [StarRing R] (x : R) : star x⁻¹ = (star x)⁻¹ :=
   op_injective <| (map_inv₀ (starRingEquiv : R ≃+* Rᵐᵒᵖ) x).trans (op_inv (star x)).symm
 #align star_inv' star_inv'
 
 @[simp]
-theorem star_zpow₀ [DivisionRing R] [StarRing R] (x : R) (z : ℤ) : star (x ^ z) = star x ^ z :=
+theorem star_zpow₀ [DivisionSemiring R] [StarRing R] (x : R) (z : ℤ) : star (x ^ z) = star x ^ z :=
   op_injective <| (map_zpow₀ (starRingEquiv : R ≃+* Rᵐᵒᵖ) x z).trans (op_zpow (star x) z).symm
 #align star_zpow₀ star_zpow₀
 
 /-- When multiplication is commutative, `star` preserves division. -/
 @[simp]
-theorem star_div' [Field R] [StarRing R] (x y : R) : star (x / y) = star x / star y := by
+theorem star_div' [Semifield R] [StarRing R] (x y : R) : star (x / y) = star x / star y := by
   apply op_injective
   rw [division_def, op_div, mul_comm, star_mul, star_inv', op_mul, op_inv]
 #align star_div' star_div'

--- a/Mathlib/Algebra/Star/Module.lean
+++ b/Mathlib/Algebra/Star/Module.lean
@@ -38,28 +38,28 @@ section SmulLemmas
 variable {R M : Type _}
 
 @[simp]
-theorem star_int_cast_smul [Ring R] [AddCommGroup M] [Module R M] [StarAddMonoid M] (n : ℤ)
-    (x : M) : star ((n : R) • x) = (n : R) • star x :=
-  map_int_cast_smul (starAddEquiv : M ≃+ M) R R n x
-#align star_int_cast_smul star_int_cast_smul
-
-@[simp]
 theorem star_nat_cast_smul [Semiring R] [AddCommMonoid M] [Module R M] [StarAddMonoid M] (n : ℕ)
     (x : M) : star ((n : R) • x) = (n : R) • star x :=
   map_nat_cast_smul (starAddEquiv : M ≃+ M) R R n x
 #align star_nat_cast_smul star_nat_cast_smul
 
 @[simp]
+theorem star_int_cast_smul [Ring R] [AddCommGroup M] [Module R M] [StarAddMonoid M] (n : ℤ)
+    (x : M) : star ((n : R) • x) = (n : R) • star x :=
+  map_int_cast_smul (starAddEquiv : M ≃+ M) R R n x
+#align star_int_cast_smul star_int_cast_smul
+
+@[simp]
+theorem star_inv_nat_cast_smul [DivisionSemiring R] [AddCommMonoid M] [Module R M] [StarAddMonoid M]
+    (n : ℕ) (x : M) : star ((n⁻¹ : R) • x) = (n⁻¹ : R) • star x :=
+  map_inv_nat_cast_smul (starAddEquiv : M ≃+ M) R R n x
+#align star_inv_nat_cast_smul star_inv_nat_cast_smul
+
+@[simp]
 theorem star_inv_int_cast_smul [DivisionRing R] [AddCommGroup M] [Module R M] [StarAddMonoid M]
     (n : ℤ) (x : M) : star ((n⁻¹ : R) • x) = (n⁻¹ : R) • star x :=
   map_inv_int_cast_smul (starAddEquiv : M ≃+ M) R R n x
 #align star_inv_int_cast_smul star_inv_int_cast_smul
-
-@[simp]
-theorem star_inv_nat_cast_smul [DivisionRing R] [AddCommGroup M] [Module R M] [StarAddMonoid M]
-    (n : ℕ) (x : M) : star ((n⁻¹ : R) • x) = (n⁻¹ : R) • star x :=
-  map_inv_nat_cast_smul (starAddEquiv : M ≃+ M) R R n x
-#align star_inv_nat_cast_smul star_inv_nat_cast_smul
 
 @[simp]
 theorem star_rat_cast_smul [DivisionRing R] [AddCommGroup M] [Module R M] [StarAddMonoid M] (n : ℚ)

--- a/Mathlib/Algebra/Star/Module.lean
+++ b/Mathlib/Algebra/Star/Module.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Eric Wieser, Frédéric Dupuis
 
 ! This file was ported from Lean 3 source module algebra.star.module
-! leanprover-community/mathlib commit 09d7fe375d1f63d17cf6b2aa4b413ab3e6ec49df
+! leanprover-community/mathlib commit 30413fc89f202a090a54d78e540963ed3de0056e
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/

--- a/Mathlib/Algebra/Star/Pointwise.lean
+++ b/Mathlib/Algebra/Star/Pointwise.lean
@@ -144,7 +144,7 @@ protected theorem star_inv [Group α] [StarSemigroup α] (s : Set α) : s⁻¹�
   simp only [mem_star, mem_inv, star_inv]
 #align set.star_inv Set.star_inv
 
-protected theorem star_inv' [DivisionRing α] [StarRing α] (s : Set α) : s⁻¹⋆ = s⋆⁻¹ := by
+protected theorem star_inv' [DivisionSemiring α] [StarRing α] (s : Set α) : s⁻¹⋆ = s⋆⁻¹ := by
   ext
   simp only [mem_star, mem_inv, star_inv']
 #align set.star_inv' Set.star_inv'

--- a/Mathlib/Algebra/Star/Pointwise.lean
+++ b/Mathlib/Algebra/Star/Pointwise.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jireh Loreaux
 
 ! This file was ported from Lean 3 source module algebra.star.pointwise
-! leanprover-community/mathlib commit 2445c98ae4b87eabebdde552593519b9b6dc350c
+! leanprover-community/mathlib commit 30413fc89f202a090a54d78e540963ed3de0056e
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/

--- a/Mathlib/Algebra/Star/SelfAdjoint.lean
+++ b/Mathlib/Algebra/Star/SelfAdjoint.lean
@@ -182,16 +182,22 @@ section Field
 
 variable [Field R] [StarRing R]
 
-theorem inv {x : R} (hx : IsSelfAdjoint x) : IsSelfAdjoint x⁻¹ := by
-  simp only [isSelfAdjoint_iff, star_inv', hx.star_eq]
+theorem inv {x : R} (hx : IsSelfAdjoint x) : IsSelfAdjoint x⁻¹ :=
+  -- porting note: hack for lean4#2074, remove after forward-porting other changes to this file
+  set_option synthInstance.etaExperiment true in by
+    simp only [isSelfAdjoint_iff, star_inv', hx.star_eq]
 #align is_self_adjoint.inv IsSelfAdjoint.inv
 
-theorem div {x y : R} (hx : IsSelfAdjoint x) (hy : IsSelfAdjoint y) : IsSelfAdjoint (x / y) := by
-  simp only [isSelfAdjoint_iff, star_div', hx.star_eq, hy.star_eq]
+theorem div {x y : R} (hx : IsSelfAdjoint x) (hy : IsSelfAdjoint y) : IsSelfAdjoint (x / y) :=
+  -- porting note: hack for lean4#2074, remove after forward-porting other changes to this file
+  set_option synthInstance.etaExperiment true in by
+    simp only [isSelfAdjoint_iff, star_div', hx.star_eq, hy.star_eq]
 #align is_self_adjoint.div IsSelfAdjoint.div
 
-theorem zpow {x : R} (hx : IsSelfAdjoint x) (n : ℤ) : IsSelfAdjoint (x ^ n) := by
-  simp only [isSelfAdjoint_iff, star_zpow₀, hx.star_eq]
+theorem zpow {x : R} (hx : IsSelfAdjoint x) (n : ℤ) : IsSelfAdjoint (x ^ n) :=
+  -- porting note: hack for lean4#2074, remove after forward-porting other changes to this file
+  set_option synthInstance.etaExperiment true in by
+    simp only [isSelfAdjoint_iff, star_zpow₀, hx.star_eq]
 #align is_self_adjoint.zpow IsSelfAdjoint.zpow
 
 end Field
@@ -341,12 +347,10 @@ theorem val_zpow (x : selfAdjoint R) (z : ℤ) : (x ^ z : R) = (x : R) ^ z :=
 #align self_adjoint.coe_zpow selfAdjoint.val_zpow
 
 theorem ratCast_mem : ∀ x : ℚ, IsSelfAdjoint (x : R)
-  | ⟨a, b, h1, h2⟩ => by
-    -- Porting note: added
-    let inst : StarRing R := ‹_›
-    rw [IsSelfAdjoint, Rat.cast_mk', star_mul', star_inv']
-    rw [@star_natCast _ _ inst]
-    rw [star_intCast]
+  | ⟨a, b, h1, h2⟩ =>
+    -- porting note: hack for lean4#2074, remove after forward-porting other changes to this file
+    set_option synthInstance.etaExperiment true in by
+      rw [IsSelfAdjoint, Rat.cast_mk', star_mul', star_inv', star_natCast, star_intCast]
 #align self_adjoint.rat_cast_mem selfAdjoint.ratCast_mem
 
 instance : RatCast (selfAdjoint R) :=


### PR DESCRIPTION
This is a forward-port of https://github.com/leanprover-community/mathlib/pull/18597

Some notes:

* This doesn't forward-port the changes to [`algebra/star/self_adjoint`](https://leanprover-community.github.io/mathlib-port-status/file/algebra/star/self_adjoint); I plan to re-port this file from scratch after https://github.com/leanprover-community/mathlib/pull/18565 lands. For now, I just add some hacks to keep it compiling.
* It seems that the changes to `algebra/periodic` were made during porting, see https://github.com/leanprover-community/mathlib4/pull/1963/files/2a6b385f555c37f3eb5e4dd9c113e0a1b5f6b958..578a6252973bcdbd1a6ce4fc0fe2791295cf80e4#r1140354814. So there is nothing to do other than update the SHA.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

Diff links (from CI output):

* https://leanprover-community.github.io/mathlib-port-status/file/algebra/module/basic?range=966e0cf0685c9cedf8a3283ac69eef4d5f2eaca2..30413fc89f202a090a54d78e540963ed3de0056e
* https://leanprover-community.github.io/mathlib-port-status/file/algebra/periodic?range=2196ab363eb097c008d4497125e0dde23fb36db2..30413fc89f202a090a54d78e540963ed3de0056e
* https://leanprover-community.github.io/mathlib-port-status/file/algebra/star/basic?range=44b58b42794e5abe2bf86397c38e26b587e07e59..30413fc89f202a090a54d78e540963ed3de0056e
* https://leanprover-community.github.io/mathlib-port-status/file/algebra/star/module?range=09d7fe375d1f63d17cf6b2aa4b413ab3e6ec49df..30413fc89f202a090a54d78e540963ed3de0056e
* https://leanprover-community.github.io/mathlib-port-status/file/algebra/star/pointwise?range=2445c98ae4b87eabebdde552593519b9b6dc350c..30413fc89f202a090a54d78e540963ed3de0056e
* https://leanprover-community.github.io/mathlib-port-status/file/linear_algebra/affine_space/affine_map?range=9003f28797c0664a49e4179487267c494477d853..bd1fc183335ea95a9519a1630bcf901fe9326d83
