### PR TITLE
[Merged by Bors] - feat: strengthen `apply_fun` capabilities

### DIFF
--- a/Mathlib/Tactic/ApplyFun.lean
+++ b/Mathlib/Tactic/ApplyFun.lean
@@ -40,7 +40,7 @@ def applyFunHyp (f : TSyntax `term) (using? : Option Expr) (h : FVarId) (g : MVa
         Term.synthesizeSyntheticMVarsUsingDefault
         instantiateMVars eq
     let mvar ← mkFreshExprMVar eq'
-    let [] ← mvar.mvarId!.congrN! none | throwError "`apply_fun` could not construct congruence"
+    let [] ← mvar.mvarId!.congrN! | throwError "`apply_fun` could not construct congruence"
     pure (mvar, gs)
   | (``LE.le, _) =>
     let (monotone_f, newGoals) ← match using? with

--- a/Mathlib/Tactic/ApplyFun.lean
+++ b/Mathlib/Tactic/ApplyFun.lean
@@ -40,7 +40,7 @@ def applyFunHyp (f : TSyntax `term) (using? : Option Expr) (h : FVarId) (g : MVa
         Term.synthesizeSyntheticMVarsUsingDefault
         instantiateMVars eq
     let mvar ← mkFreshExprMVar eq'
-    let [] ← mvar.mvarId!.congrN | throwError "`apply_fun` could not construct congruence"
+    let [] ← mvar.mvarId!.congrN! none | throwError "`apply_fun` could not construct congruence"
     pure (mvar, gs)
   | (``LE.le, _) =>
     let (monotone_f, newGoals) ← match using? with

--- a/Mathlib/Tactic/Congr!.lean
+++ b/Mathlib/Tactic/Congr!.lean
@@ -792,8 +792,8 @@ See the documentation on the `congr!` syntax.
 
 The `depth?` argument controls the depth of the recursion. If `none`, then it uses a reasonably
 large bound that is linear in the expression depth. -/
-def Lean.MVarId.congrN! (mvarId : MVarId) (depth? : Option Nat) (config : Congr!.Config := {}) :
-    MetaM (List MVarId) := do
+def Lean.MVarId.congrN! (mvarId : MVarId)
+    (depth? : Option Nat := none) (config : Congr!.Config := {}) : MetaM (List MVarId) := do
   let ty ← withReducible <| mvarId.getType'
   -- A reasonably large yet practically bounded default recursion depth.
   let defaultDepth := max 1000000 (8 * (1 + ty.approxDepth.toNat))

--- a/test/apply_fun.lean
+++ b/test/apply_fun.lean
@@ -154,7 +154,7 @@ example (a b : ℕ) (h : a = b) : True := by
   · trivial
   · exact 37
 
--- Check that it can solve congruence and use Subsingleton.elim on the fintype instances
+-- Check that it can solve congruence (needs Subsingleton.elim for the fintype instances)
 example (α β : Type u) [Fintype α] [Fintype β] (h : α = β) : True := by
   apply_fun Fintype.card at h
   guard_hyp h : Fintype.card α = Fintype.card β

--- a/test/apply_fun.lean
+++ b/test/apply_fun.lean
@@ -2,6 +2,7 @@ import Mathlib.Init.Data.Nat.Notation
 import Mathlib.Tactic.Basic
 import Mathlib.Tactic.ApplyFun
 import Mathlib.Init.Function
+import Mathlib.Data.Fintype.Card
 -- import Mathlib.Data.Matrix.Basic
 
 open Function
@@ -152,3 +153,9 @@ example (a b : ℕ) (h : a = b) : True := by
   apply_fun (fun i => i + ?_) at h
   · trivial
   · exact 37
+
+-- Check that it can solve congruence and use Subsingleton.elim on the fintype instances
+example (α β : Type u) [Fintype α] [Fintype β] (h : α = β) : True := by
+  apply_fun Fintype.card at h
+  guard_hyp h : Fintype.card α = Fintype.card β
+  trivial


### PR DESCRIPTION
Use `Lean.MVarId.congrN!` rather than `Lean.MVarId.congrN` when proving congruence. This lets `apply_fun Fintype.card at h` work (note that there are `Fintype` instances involved, so it needs to apply `Subsingleton.elim`).


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
