### PR TITLE
chore: add manual instance names to prod instances

### DIFF
--- a/Mathlib/Algebra/Algebra/Unitization.lean
+++ b/Mathlib/Algebra/Algebra/Unitization.lean
@@ -153,35 +153,35 @@ instance inhabited [Inhabited R] [Inhabited A] : Inhabited (Unitization R A) :=
   instInhabitedProd
 
 instance zero [Zero R] [Zero A] : Zero (Unitization R A) :=
-  Prod.instZeroSum
+  Prod.zero
 
 instance add [Add R] [Add A] : Add (Unitization R A) :=
-  Prod.instAddSum
+  Prod.add
 
 instance neg [Neg R] [Neg A] : Neg (Unitization R A) :=
-  Prod.instNegSum
+  Prod.neg
 
 instance addSemigroup [AddSemigroup R] [AddSemigroup A] : AddSemigroup (Unitization R A) :=
-  Prod.instAddSemigroupSum
+  Prod.addSemigroup
 
 instance addZeroClass [AddZeroClass R] [AddZeroClass A] : AddZeroClass (Unitization R A) :=
-  Prod.instAddZeroClassSum
+  Prod.addZeroClass
 
 instance addMonoid [AddMonoid R] [AddMonoid A] : AddMonoid (Unitization R A) :=
-  Prod.instAddMonoidSum
+  Prod.addMonoid
 
 instance addGroup [AddGroup R] [AddGroup A] : AddGroup (Unitization R A) :=
-  Prod.instAddGroupSum
+  Prod.addGroup
 
 instance addCommSemigroup [AddCommSemigroup R] [AddCommSemigroup A] :
     AddCommSemigroup (Unitization R A) :=
-  Prod.instAddCommSemigroupSum
+  Prod.addCommSemigroup
 
 instance addCommMonoid [AddCommMonoid R] [AddCommMonoid A] : AddCommMonoid (Unitization R A) :=
-  Prod.instAddCommMonoidSum
+  Prod.addCommMonoid
 
 instance addCommGroup [AddCommGroup R] [AddCommGroup A] : AddCommGroup (Unitization R A) :=
-  Prod.instAddCommGroupSum
+  Prod.addCommGroup
 
 instance smul [SMul S R] [SMul S A] : SMul S (Unitization R A) :=
   Prod.smul

--- a/Mathlib/Algebra/Group/Prod.lean
+++ b/Mathlib/Algebra/Group/Prod.lean
@@ -292,7 +292,8 @@ instance leftCancelMonoid [LeftCancelMonoid M] [LeftCancelMonoid N] : LeftCancel
 #align prod.add_left_cancel_monoid Prod.addLeftCancelMonoid
 
 @[to_additive]
-instance rightCancelMonoid [RightCancelMonoid M] [RightCancelMonoid N] : RightCancelMonoid (M × N) :=
+instance rightCancelMonoid [RightCancelMonoid M] [RightCancelMonoid N] :
+    RightCancelMonoid (M × N) :=
   { mul_one := by simp,
     one_mul := by simp }
 #align prod.right_cancel_monoid Prod.rightCancelMonoid

--- a/Mathlib/Algebra/Group/Prod.lean
+++ b/Mathlib/Algebra/Group/Prod.lean
@@ -94,6 +94,7 @@ theorem mk_one_mul_mk_one [Mul M] [Monoid N] (a₁ a₂ : M) :
 instance one [One M] [One N] : One (M × N) :=
   ⟨(1, 1)⟩
 #align prod.has_one Prod.one
+#align prod.has_zero Prod.zero
 
 @[to_additive (attr := simp)]
 theorem fst_one [One M] [One N] : (1 : M × N).1 = 1 :=
@@ -135,6 +136,7 @@ theorem fst_mul_snd [MulOneClass M] [MulOneClass N] (p : M × N) : (p.fst, 1) * 
 instance inv [Inv M] [Inv N] : Inv (M × N) :=
   ⟨fun p => (p.1⁻¹, p.2⁻¹)⟩
 #align prod.has_inv Prod.inv
+#align prod.has_neg Prod.neg
 
 @[to_additive (attr := simp)]
 theorem fst_inv [Inv G] [Inv H] (p : G × H) : p⁻¹.1 = p.1⁻¹ :=
@@ -201,14 +203,16 @@ instance mulZeroClass [MulZeroClass M] [MulZeroClass N] : MulZeroClass (M × N) 
 #align prod.mul_zero_class Prod.mulZeroClass
 
 @[to_additive]
-instance semiGroup [Semigroup M] [Semigroup N] : Semigroup (M × N) :=
+instance semigroup [Semigroup M] [Semigroup N] : Semigroup (M × N) :=
   { mul_assoc := fun _ _ _ => mk.inj_iff.mpr ⟨mul_assoc _ _ _, mul_assoc _ _ _⟩ }
-#align prod.semi_group Prod.semiGroup
+#align prod.semigroup Prod.semigroup
+#align prod.add_semigroup Prod.addSemigroup
 
 @[to_additive]
 instance commSemigroup [CommSemigroup G] [CommSemigroup H] : CommSemigroup (G × H) :=
   { mul_comm := fun _ _ => mk.inj_iff.mpr ⟨mul_comm _ _, mul_comm _ _⟩ }
 #align prod.comm_semigroup Prod.commSemigroup
+#align prod.add_comm_semigroup Prod.addCommSemigroup
 
 instance semigroupWithZero [SemigroupWithZero M] [SemigroupWithZero N] :
     SemigroupWithZero (M × N) :=
@@ -221,6 +225,7 @@ instance mulOneClass [MulOneClass M] [MulOneClass N] : MulOneClass (M × N) :=
   { one_mul := fun a => Prod.recOn a fun _ _ => mk.inj_iff.mpr ⟨one_mul _, one_mul _⟩,
     mul_one := fun a => Prod.recOn a fun _ _ => mk.inj_iff.mpr ⟨mul_one _, mul_one _⟩ }
 #align prod.mul_one_class Prod.mulOneClass
+#align prod.add_zero_class Prod.addZeroClass
 
 @[to_additive]
 instance monoid [Monoid M] [Monoid N] : Monoid (M × N) :=
@@ -230,6 +235,7 @@ instance monoid [Monoid M] [Monoid N] : Monoid (M × N) :=
     one_mul := by simp,
     mul_one := by simp }
 #align prod.monoid Prod.monoid
+#align prod.add_monoid Prod.addMonoid
 
 @[to_additive Prod.subNegMonoid]
 instance divInvMonoid [DivInvMonoid G] [DivInvMonoid H] : DivInvMonoid (G × H) :=
@@ -239,8 +245,9 @@ instance divInvMonoid [DivInvMonoid G] [DivInvMonoid H] : DivInvMonoid (G × H) 
     zpow_succ' := fun _ _ => ext (DivInvMonoid.zpow_succ' _ _) (DivInvMonoid.zpow_succ' _ _),
     zpow_neg' := fun _ _ => ext (DivInvMonoid.zpow_neg' _ _) (DivInvMonoid.zpow_neg' _ _) }
 #align prod.div_inv_monoid Prod.divInvMonoid
+#align prod.sub_neg_inv_monoid Prod.subNegMonoid
 
-@[to_additive]
+@[to_additive subtractionMonoid]
 instance divisionMonoid [DivisionMonoid G] [DivisionMonoid H] : DivisionMonoid (G × H) :=
   { mul_inv_rev := fun a b => ext (mul_inv_rev _ _) (mul_inv_rev _ _),
     inv_eq_of_mul := fun a b h =>
@@ -248,17 +255,20 @@ instance divisionMonoid [DivisionMonoid G] [DivisionMonoid H] : DivisionMonoid (
         (inv_eq_of_mul_eq_one_right <| congr_arg snd h),
     inv_inv := by simp }
 #align prod.division_monoid Prod.divisionMonoid
+#align prod.subtraction_monoid Prod.subtractionMonoid
 
-@[to_additive SubtractionCommMonoid]
+@[to_additive subtractionCommMonoid]
 instance divisionCommMonoid [DivisionCommMonoid G] [DivisionCommMonoid H] :
     DivisionCommMonoid (G × H) :=
   { mul_comm := fun ⟨g₁ , h₁⟩ ⟨_, _⟩ => by rw [mk_mul_mk, mul_comm g₁, mul_comm h₁]; rfl }
 #align prod.division_comm_monoid Prod.divisionCommMonoid
+#align prod.subtraction_comm_monoid Prod.subtractionCommMonoid
 
 @[to_additive]
 instance group [Group G] [Group H] : Group (G × H) :=
   { mul_left_inv := fun _ => mk.inj_iff.mpr ⟨mul_left_inv _, mul_left_inv _⟩ }
 #align prod.group Prod.group
+#align prod.add_group Prod.addGroup
 
 @[to_additive]
 instance leftCancelSemigroup [LeftCancelSemigroup G] [LeftCancelSemigroup H] :
@@ -279,27 +289,32 @@ instance leftCancelMonoid [LeftCancelMonoid M] [LeftCancelMonoid N] : LeftCancel
   { mul_one := by simp,
     one_mul := by simp }
 #align prod.left_cancel_monoid Prod.leftCancelMonoid
+#align prod.add_left_cancel_monoid Prod.addLeftCancelMonoid
 
 @[to_additive]
 instance rightCancelMonoid [RightCancelMonoid M] [RightCancelMonoid N] : RightCancelMonoid (M × N) :=
   { mul_one := by simp,
     one_mul := by simp }
 #align prod.right_cancel_monoid Prod.rightCancelMonoid
+#align prod.add_right_cancel_monoid Prod.addRightCancelMonoid
 
 @[to_additive]
 instance cancelMonoid [CancelMonoid M] [CancelMonoid N] : CancelMonoid (M × N) :=
   { mul_right_cancel := by simp only [mul_left_inj, imp_self, forall_const] }
 #align prod.cancel_monoid Prod.cancelMonoid
+#align prod.add_cancel_monoid Prod.addCancelMonoid
 
 @[to_additive]
 instance commMonoid [CommMonoid M] [CommMonoid N] : CommMonoid (M × N) :=
   { mul_comm := fun ⟨m₁, n₁⟩ ⟨_, _⟩ => by rw [mk_mul_mk, mk_mul_mk, mul_comm m₁, mul_comm n₁] }
 #align prod.comm_monoid Prod.commMonoid
+#align prod.add_comm_monoid Prod.addCommMonoid
 
 @[to_additive]
 instance cancelCommMonoid [CancelCommMonoid M] [CancelCommMonoid N] : CancelCommMonoid (M × N) :=
   { mul_comm := fun ⟨m₁, n₁⟩ ⟨_, _⟩ => by rw [mk_mul_mk, mk_mul_mk, mul_comm m₁, mul_comm n₁] }
 #align prod.cancel_comm_monoid Prod.cancelCommMonoid
+#align prod.add_cancel_comm_monoid Prod.addCancelCommMonoid
 
 instance mulZeroOneClass [MulZeroOneClass M] [MulZeroOneClass N] : MulZeroOneClass (M × N) :=
   { zero_mul := by simp,
@@ -321,6 +336,7 @@ instance commMonoidWithZero [CommMonoidWithZero M] [CommMonoidWithZero N] :
 instance commGroup [CommGroup G] [CommGroup H] : CommGroup (G × H) :=
   { mul_comm := fun ⟨g₁, h₁⟩ ⟨_, _⟩ => by rw [mk_mul_mk, mk_mul_mk, mul_comm g₁, mul_comm h₁] }
 #align prod.comm_group Prod.commGroup
+#align prod.add_comm_group Prod.addCommGroup
 
 end Prod
 

--- a/Mathlib/Algebra/Group/Prod.lean
+++ b/Mathlib/Algebra/Group/Prod.lean
@@ -41,8 +41,9 @@ variable {A : Type _} {B : Type _} {G : Type _} {H : Type _} {M : Type _} {N : T
 namespace Prod
 
 @[to_additive]
-instance [Mul M] [Mul N] : Mul (M × N) :=
+instance mul [Mul M] [Mul N] : Mul (M × N) :=
   ⟨fun p q => ⟨p.1 * q.1, p.2 * q.2⟩⟩
+#align prod.has_mul Prod.mul
 
 @[to_additive (attr := simp)]
 theorem fst_mul [Mul M] [Mul N] (p q : M × N) : (p * q).1 = p.1 * q.1 :=
@@ -90,8 +91,9 @@ theorem mk_one_mul_mk_one [Mul M] [Monoid N] (a₁ a₂ : M) :
 #align prod.mk_zero_add_mk_zero Prod.mk_zero_add_mk_zero
 
 @[to_additive]
-instance [One M] [One N] : One (M × N) :=
+instance one [One M] [One N] : One (M × N) :=
   ⟨(1, 1)⟩
+#align prod.has_one Prod.one
 
 @[to_additive (attr := simp)]
 theorem fst_one [One M] [One N] : (1 : M × N).1 = 1 :=
@@ -130,8 +132,9 @@ theorem fst_mul_snd [MulOneClass M] [MulOneClass N] (p : M × N) : (p.fst, 1) * 
 #align prod.fst_add_snd Prod.fst_add_snd
 
 @[to_additive]
-instance [Inv M] [Inv N] : Inv (M × N) :=
+instance inv [Inv M] [Inv N] : Inv (M × N) :=
   ⟨fun p => (p.1⁻¹, p.2⁻¹)⟩
+#align prod.has_inv Prod.inv
 
 @[to_additive (attr := simp)]
 theorem fst_inv [Inv G] [Inv H] (p : G × H) : p⁻¹.1 = p.1⁻¹ :=
@@ -158,12 +161,14 @@ theorem swap_inv [Inv G] [Inv H] (p : G × H) : p⁻¹.swap = p.swap⁻¹ :=
 #align prod.swap_neg Prod.swap_neg
 
 @[to_additive]
-instance [InvolutiveInv M] [InvolutiveInv N] : InvolutiveInv (M × N) :=
+instance involutiveInv [InvolutiveInv M] [InvolutiveInv N] : InvolutiveInv (M × N) :=
   { inv_inv := fun _ => ext (inv_inv _) (inv_inv _) }
+#align prod.has_involutive_inv Prod.involutiveInv
 
 @[to_additive]
-instance [Div M] [Div N] : Div (M × N) :=
+instance div [Div M] [Div N] : Div (M × N) :=
   ⟨fun p q => ⟨p.1 / q.1, p.2 / q.2⟩⟩
+#align prod.has_div Prod.div
 
 @[to_additive (attr := simp)]
 theorem fst_div [Div G] [Div H] (a b : G × H) : (a / b).1 = a.1 / b.1 :=
@@ -190,106 +195,132 @@ theorem swap_div [Div G] [Div H] (a b : G × H) : (a / b).swap = a.swap / b.swap
 #align prod.swap_div Prod.swap_div
 #align prod.swap_sub Prod.swap_sub
 
-instance [MulZeroClass M] [MulZeroClass N] : MulZeroClass (M × N) :=
+instance mulZeroClass [MulZeroClass M] [MulZeroClass N] : MulZeroClass (M × N) :=
   { zero_mul := fun a => Prod.recOn a fun _ _ => mk.inj_iff.mpr ⟨zero_mul _, zero_mul _⟩,
     mul_zero := fun a => Prod.recOn a fun _ _ => mk.inj_iff.mpr ⟨mul_zero _, mul_zero _⟩ }
+#align prod.mul_zero_class Prod.mulZeroClass
 
 @[to_additive]
-instance [Semigroup M] [Semigroup N] : Semigroup (M × N) :=
+instance semiGroup [Semigroup M] [Semigroup N] : Semigroup (M × N) :=
   { mul_assoc := fun _ _ _ => mk.inj_iff.mpr ⟨mul_assoc _ _ _, mul_assoc _ _ _⟩ }
+#align prod.semi_group Prod.semiGroup
 
 @[to_additive]
-instance [CommSemigroup G] [CommSemigroup H] : CommSemigroup (G × H) :=
+instance commSemigroup [CommSemigroup G] [CommSemigroup H] : CommSemigroup (G × H) :=
   { mul_comm := fun _ _ => mk.inj_iff.mpr ⟨mul_comm _ _, mul_comm _ _⟩ }
+#align prod.comm_semigroup Prod.commSemigroup
 
-instance [SemigroupWithZero M] [SemigroupWithZero N] : SemigroupWithZero (M × N) :=
+instance semigroupWithZero [SemigroupWithZero M] [SemigroupWithZero N] :
+    SemigroupWithZero (M × N) :=
   { zero_mul := by simp,
     mul_zero := by simp }
+#align prod.semigroup_with_zero Prod.semigroupWithZero
 
 @[to_additive]
-instance [MulOneClass M] [MulOneClass N] : MulOneClass (M × N) :=
+instance mulOneClass [MulOneClass M] [MulOneClass N] : MulOneClass (M × N) :=
   { one_mul := fun a => Prod.recOn a fun _ _ => mk.inj_iff.mpr ⟨one_mul _, one_mul _⟩,
     mul_one := fun a => Prod.recOn a fun _ _ => mk.inj_iff.mpr ⟨mul_one _, mul_one _⟩ }
+#align prod.mul_one_class Prod.mulOneClass
 
 @[to_additive]
-instance [Monoid M] [Monoid N] : Monoid (M × N) :=
+instance monoid [Monoid M] [Monoid N] : Monoid (M × N) :=
   { npow := fun z a => ⟨Monoid.npow z a.1, Monoid.npow z a.2⟩,
     npow_zero := fun z => ext (Monoid.npow_zero _) (Monoid.npow_zero _),
     npow_succ := fun z a => ext (Monoid.npow_succ _ _) (Monoid.npow_succ _ _),
     one_mul := by simp,
     mul_one := by simp }
+#align prod.monoid Prod.monoid
 
 @[to_additive Prod.subNegMonoid]
-instance [DivInvMonoid G] [DivInvMonoid H] : DivInvMonoid (G × H) :=
+instance divInvMonoid [DivInvMonoid G] [DivInvMonoid H] : DivInvMonoid (G × H) :=
   { div_eq_mul_inv := fun _ _ => mk.inj_iff.mpr ⟨div_eq_mul_inv _ _, div_eq_mul_inv _ _⟩,
     zpow := fun z a => ⟨DivInvMonoid.zpow z a.1, DivInvMonoid.zpow z a.2⟩,
     zpow_zero' := fun _ => ext (DivInvMonoid.zpow_zero' _) (DivInvMonoid.zpow_zero' _),
     zpow_succ' := fun _ _ => ext (DivInvMonoid.zpow_succ' _ _) (DivInvMonoid.zpow_succ' _ _),
     zpow_neg' := fun _ _ => ext (DivInvMonoid.zpow_neg' _ _) (DivInvMonoid.zpow_neg' _ _) }
+#align prod.div_inv_monoid Prod.divInvMonoid
 
 @[to_additive]
-instance [DivisionMonoid G] [DivisionMonoid H] : DivisionMonoid (G × H) :=
+instance divisionMonoid [DivisionMonoid G] [DivisionMonoid H] : DivisionMonoid (G × H) :=
   { mul_inv_rev := fun a b => ext (mul_inv_rev _ _) (mul_inv_rev _ _),
     inv_eq_of_mul := fun a b h =>
       ext (inv_eq_of_mul_eq_one_right <| congr_arg fst h)
         (inv_eq_of_mul_eq_one_right <| congr_arg snd h),
     inv_inv := by simp }
+#align prod.division_monoid Prod.divisionMonoid
 
 @[to_additive SubtractionCommMonoid]
-instance [DivisionCommMonoid G] [DivisionCommMonoid H] : DivisionCommMonoid (G × H) :=
+instance divisionCommMonoid [DivisionCommMonoid G] [DivisionCommMonoid H] :
+    DivisionCommMonoid (G × H) :=
   { mul_comm := fun ⟨g₁ , h₁⟩ ⟨_, _⟩ => by rw [mk_mul_mk, mul_comm g₁, mul_comm h₁]; rfl }
+#align prod.division_comm_monoid Prod.divisionCommMonoid
 
 @[to_additive]
-instance [Group G] [Group H] : Group (G × H) :=
+instance group [Group G] [Group H] : Group (G × H) :=
   { mul_left_inv := fun _ => mk.inj_iff.mpr ⟨mul_left_inv _, mul_left_inv _⟩ }
+#align prod.group Prod.group
 
 @[to_additive]
-instance [LeftCancelSemigroup G] [LeftCancelSemigroup H] : LeftCancelSemigroup (G × H) :=
+instance leftCancelSemigroup [LeftCancelSemigroup G] [LeftCancelSemigroup H] :
+    LeftCancelSemigroup (G × H) :=
   { mul_left_cancel := fun _ _ _ h =>
       Prod.ext (mul_left_cancel (Prod.ext_iff.1 h).1) (mul_left_cancel (Prod.ext_iff.1 h).2) }
+#align prod.left_cancel_semigroup Prod.leftCancelSemigroup
 
 @[to_additive]
-instance [RightCancelSemigroup G] [RightCancelSemigroup H] : RightCancelSemigroup (G × H) :=
+instance rightCancelSemigroup [RightCancelSemigroup G] [RightCancelSemigroup H] :
+    RightCancelSemigroup (G × H) :=
   { mul_right_cancel := fun _ _ _ h =>
       Prod.ext (mul_right_cancel (Prod.ext_iff.1 h).1) (mul_right_cancel (Prod.ext_iff.1 h).2) }
+#align prod.right_cancel_semigroup Prod.rightCancelSemigroup
 
 @[to_additive]
-instance [LeftCancelMonoid M] [LeftCancelMonoid N] : LeftCancelMonoid (M × N) :=
+instance leftCancelMonoid [LeftCancelMonoid M] [LeftCancelMonoid N] : LeftCancelMonoid (M × N) :=
   { mul_one := by simp,
     one_mul := by simp }
+#align prod.left_cancel_monoid Prod.leftCancelMonoid
 
 @[to_additive]
-instance [RightCancelMonoid M] [RightCancelMonoid N] : RightCancelMonoid (M × N) :=
+instance rightCancelMonoid [RightCancelMonoid M] [RightCancelMonoid N] : RightCancelMonoid (M × N) :=
   { mul_one := by simp,
     one_mul := by simp }
+#align prod.right_cancel_monoid Prod.rightCancelMonoid
 
 @[to_additive]
-instance [CancelMonoid M] [CancelMonoid N] : CancelMonoid (M × N) :=
+instance cancelMonoid [CancelMonoid M] [CancelMonoid N] : CancelMonoid (M × N) :=
   { mul_right_cancel := by simp only [mul_left_inj, imp_self, forall_const] }
+#align prod.cancel_monoid Prod.cancelMonoid
 
 @[to_additive]
-instance [CommMonoid M] [CommMonoid N] : CommMonoid (M × N) :=
+instance commMonoid [CommMonoid M] [CommMonoid N] : CommMonoid (M × N) :=
   { mul_comm := fun ⟨m₁, n₁⟩ ⟨_, _⟩ => by rw [mk_mul_mk, mk_mul_mk, mul_comm m₁, mul_comm n₁] }
+#align prod.comm_monoid Prod.commMonoid
 
 @[to_additive]
-instance [CancelCommMonoid M] [CancelCommMonoid N] : CancelCommMonoid (M × N) :=
+instance cancelCommMonoid [CancelCommMonoid M] [CancelCommMonoid N] : CancelCommMonoid (M × N) :=
   { mul_comm := fun ⟨m₁, n₁⟩ ⟨_, _⟩ => by rw [mk_mul_mk, mk_mul_mk, mul_comm m₁, mul_comm n₁] }
+#align prod.cancel_comm_monoid Prod.cancelCommMonoid
 
-instance [MulZeroOneClass M] [MulZeroOneClass N] : MulZeroOneClass (M × N) :=
+instance mulZeroOneClass [MulZeroOneClass M] [MulZeroOneClass N] : MulZeroOneClass (M × N) :=
   { zero_mul := by simp,
     mul_zero := by simp }
+#align prod.mul_zero_one_class Prod.mulZeroOneClass
 
-instance [MonoidWithZero M] [MonoidWithZero N] : MonoidWithZero (M × N) :=
+instance monoidWithZero [MonoidWithZero M] [MonoidWithZero N] : MonoidWithZero (M × N) :=
   { zero_mul := by simp,
     mul_zero := by simp }
+#align prod.monoid_with_zero Prod.monoidWithZero
 
-instance [CommMonoidWithZero M] [CommMonoidWithZero N] : CommMonoidWithZero (M × N) :=
+instance commMonoidWithZero [CommMonoidWithZero M] [CommMonoidWithZero N] :
+    CommMonoidWithZero (M × N) :=
   { zero_mul := by simp,
     mul_zero := by simp }
+#align prod.comm_monoid_with_zero Prod.commMonoidWithZero
 
 @[to_additive]
-instance [CommGroup G] [CommGroup H] : CommGroup (G × H) :=
+instance commGroup [CommGroup G] [CommGroup H] : CommGroup (G × H) :=
   { mul_comm := fun ⟨g₁, h₁⟩ ⟨_, _⟩ => by rw [mk_mul_mk, mk_mul_mk, mul_comm g₁, mul_comm h₁] }
+#align prod.comm_group Prod.commGroup
 
 end Prod
 

--- a/Mathlib/Data/Nat/Cast/Prod.lean
+++ b/Mathlib/Data/Nat/Cast/Prod.lean
@@ -22,11 +22,12 @@ namespace Prod
 
 variable [AddMonoidWithOne α] [AddMonoidWithOne β]
 
-instance : AddMonoidWithOne (α × β) :=
-  { Prod.instAddMonoidSum, @instOneProd α β _ _ with
+instance addMonoidWithOne : AddMonoidWithOne (α × β) :=
+  { Prod.addMonoid, Prod.one with
     natCast := fun n => (n, n)
     natCast_zero := congr_arg₂ Prod.mk Nat.cast_zero Nat.cast_zero
     natCast_succ := fun _ => congr_arg₂ Prod.mk (Nat.cast_succ _) (Nat.cast_succ _) }
+#align prod.add_monoid_with_one Prod.addMonoidWithOne
 
 @[simp]
 theorem fst_natCast (n : ℕ) : (n : α × β).fst = n := by induction n <;> simp [*]


### PR DESCRIPTION
The defaults generate nonsense like `Prod.instAddSum`, where `Sum` has been incorrectly additivized from `Prod`.

Also adds `#align`s for good measure.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
