### PR TITLE
[Merged by Bors] - perf: Data.Sign

### DIFF
--- a/Mathlib/Data/Sign.lean
+++ b/Mathlib/Data/Sign.lean
@@ -90,9 +90,10 @@ instance Le.decidableRel : DecidableRel Le := fun a b => by
 instance decidableEq : DecidableEq SignType := fun a b => by
   cases a <;> cases b <;> first | exact isTrue (by constructor)| exact isFalse (by rintro ⟨_⟩)
 
+private lemma mul_comm : ∀ (a b : SignType), a * b = b * a := by rintro ⟨⟩ ⟨⟩ <;> rfl
+private lemma mul_assoc : ∀ (a b c : SignType), (a * b) * c = a * (b * c) := by
+  rintro ⟨⟩ ⟨⟩ ⟨⟩ <;> rfl
 
-set_option maxHeartbeats 0
--- Porting note: This takes too long, likely fixed by lean4#2003
 /- We can define a `Field` instance on `SignType`, but it's not mathematically sensible,
 so we only define the `CommGroupWithZero`. -/
 instance : CommGroupWithZero SignType where
@@ -105,17 +106,23 @@ instance : CommGroupWithZero SignType where
   mul_one a := by cases a <;> rfl
   one_mul a := by cases a <;> rfl
   mul_inv_cancel a ha := by cases a <;> trivial
-  mul_comm a b := by cases a <;> cases b <;> rfl
-  mul_assoc a b c := by cases a <;> cases b <;> cases c <;> rfl
+  mul_comm := mul_comm
+  mul_assoc := mul_assoc
   exists_pair_ne := ⟨0, 1, by rintro ⟨_⟩⟩
   inv_zero := rfl
+
+private lemma le_antisymm (a b : SignType) (_ : a ≤ b) (_: b ≤ a) : a = b := by
+  cases a <;> cases b <;> trivial
+
+private lemma le_trans (a b c : SignType) (_ : a ≤ b) (_: b ≤ c) : a ≤ c := by
+  cases a <;> cases b <;> cases c <;> first | tauto | constructor
 
 instance : LinearOrder SignType where
   le := (· ≤ ·)
   le_refl a := by cases a <;> constructor
   le_total a b := by cases a <;> cases b <;> first | left; constructor | right; constructor
-  le_antisymm a b ha hb := by cases a <;> cases b <;> trivial
-  le_trans a b c hab hbc := by cases a <;> cases b <;> cases c <;> first | tauto | constructor
+  le_antisymm := le_antisymm
+  le_trans := le_trans
   decidable_le := Le.decidableRel
   decidable_eq := SignType.decidableEq
 


### PR DESCRIPTION
This single file uses more than twice as much RAM as the next largest file in mathlib, see https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/mathlib4.20speedcenter/near/342595677. A simple out-lining fixes the issue.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
