### PR TITLE
[Merged by Bors] - fix: port script crash on python 3.8

### DIFF
--- a/scripts/fix-line-breaks.py
+++ b/scripts/fix-line-breaks.py
@@ -3,8 +3,8 @@ import sys
 from collections import deque
 
 lns = deque([], 2)
-with (open(sys.argv[1], "r", encoding="utf-8", newline="\n") as f,
-      open(sys.argv[2], "w", encoding="utf-8", newline="\n") as g):
+with open(sys.argv[1], "r", encoding="utf-8", newline="\n") as f, \
+      open(sys.argv[2], "w", encoding="utf-8", newline="\n") as g:
     for ln_raw in f:
         ln = ln_raw.strip("\n")
         lns.append(ln)


### PR DESCRIPTION
The previous syntax was only valid in Python 3.10 and onwards.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
