### PR TITLE
[Merged by Bors] - fix: add incorrectly-deleted lemmas

### DIFF
--- a/Mathlib/Algebra/Ring/Equiv.lean
+++ b/Mathlib/Algebra/Ring/Equiv.lean
@@ -136,8 +136,11 @@ instance : RingEquivClass (R ≃+* S) R S where
 #noalign ring_equiv.to_equiv_eq_coe
 -- Porting note: `toFun_eq_coe` no longer needed in Lean4
 #noalign ring_equiv.to_fun_eq_coe
--- Porting note: `coe_toEquiv` no longer needed in Lean4
-#noalign ring_equiv.coe_to_equiv
+
+@[simp]
+theorem coe_toEquiv (f : R ≃+* S) : ⇑(f : R ≃ S) = f :=
+  rfl
+#align ring_equiv.coe_to_equiv RingEquiv.coe_toEquiv
 
 /-- A ring isomorphism preserves multiplication. -/
 protected theorem map_mul (e : R ≃+* S) (x y : R) : e (x * y) = e x * e y :=
@@ -156,8 +159,11 @@ theorem ext {f g : R ≃+* S} (h : ∀ x, f x = g x) : f = g :=
   FunLike.ext f g h
 #align ring_equiv.ext RingEquiv.ext
 
--- Porting note: `coe_mk` no longer needed in Lean4
-#noalign ring_equiv.coe_mk
+@[simp]
+theorem coe_mk (e h₃ h₄) : ⇑(⟨e, h₃, h₄⟩ : R ≃+* S) = e :=
+  rfl
+#align ring_equiv.coe_mk RingEquiv.coe_mkₓ
+
 -- Porting note: `toEquiv_mk` no longer needed in Lean4
 #noalign ring_equiv.to_equiv_mk
 


### PR DESCRIPTION
These lemmas are still needed in Lean 4, despite claims in #1077 that they are not.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
