### PR TITLE
[Merged by Bors] - chore: remove noncomputable in Algebra.FreeAlgebra

### DIFF
--- a/Mathlib/Algebra/FreeAlgebra.lean
+++ b/Mathlib/Algebra/FreeAlgebra.lean
@@ -110,9 +110,12 @@ attribute [local instance] Pre.hasCoeGenerator Pre.hasCoeSemiring Pre.hasMul Pre
 /-- Given a function from `X` to an `R`-algebra `A`, `lift_fun` provides a lift of `f` to a function
 from `Pre R X` to `A`. This is mainly used in the construction of `FreeAlgebra.lift`.
 -/
--- Porting note: added noncomputable for recOn to work
-noncomputable def liftFun {A : Type _} [Semiring A] [Algebra R A] (f : X → A) :
-  Pre R X → A := fun t ↦ Pre.recOn t f (algebraMap _ _) (fun _ _ ↦ (· + ·)) (fun _ _ ↦ (· * ·))
+def liftFun {A : Type _} [Semiring A] [Algebra R A] (f : X → A) :
+    Pre R X → A
+  | .of t => f t
+  | .add a b => liftFun f a + liftFun f b
+  | .mul a b => liftFun f a * liftFun f b
+  | .of_scalar c => algebraMap _ _ c
 #align free_algebra.lift_fun FreeAlgebra.liftFun
 
 /-- An inductively defined relation on `Pre R X` used to force the initial algebra structure on
@@ -234,8 +237,7 @@ theorem quot_mk_eq_ι (m : X) : Quot.mk (FreeAlgebra.Rel R X) m = ι R m := by r
 variable {A : Type _} [Semiring A] [Algebra R A]
 
 /-- Internal definition used to define `lift` -/
--- Porting note: add noncomputable since liftFun is also noncomputable
-private noncomputable def liftAux (f : X → A) : FreeAlgebra R X →ₐ[R] A
+private def liftAux (f : X → A) : FreeAlgebra R X →ₐ[R] A
     where
   toFun a :=
     Quot.liftOn a (liftFun _ _ f) fun a b h ↦
@@ -291,9 +293,8 @@ private noncomputable def liftAux (f : X → A) : FreeAlgebra R X →ₐ[R] A
 /-- Given a function `f : X → A` where `A` is an `R`-algebra, `lift R f` is the unique lift
 of `f` to a morphism of `R`-algebras `FreeAlgebra R X → A`.
 -/
--- Porting note: add noncomputable since liftFun is also noncomputable and changed
--- irreducible_def to def since it does not work with noncomputable
-noncomputable def lift : (X → A) ≃ (FreeAlgebra R X →ₐ[R] A) :=
+@[irreducible]
+def lift : (X → A) ≃ (FreeAlgebra R X →ₐ[R] A) :=
   { toFun := liftAux R
     invFun := fun F ↦ F ∘ ι R
     left_inv := fun f ↦ by
@@ -312,7 +313,7 @@ noncomputable def lift : (X → A) ≃ (FreeAlgebra R X →ₐ[R] A) :=
         rw [AlgHom.commutes F _]
       case add a b ha hb =>
         -- Porting note: it is necessary to declare fa and fb explicitely otherwise Lean refuses
-        -- to consider Quot.mk (Rel R X) * as element of FreeAlgebra R X
+        -- to consider `Quot.mk (Rel R X) ·` as element of FreeAlgebra R X
         let fa : FreeAlgebra R X := Quot.mk (Rel R X) a
         let fb : FreeAlgebra R X := Quot.mk (Rel R X) b
         change liftAux R (F ∘ ι R) (fa + fb) = F (fa + fb)
@@ -410,8 +411,7 @@ instance [Nontrivial R] : Nontrivial (FreeAlgebra R X) :=
 section
 
 /-- The left-inverse of `algebraMap`. -/
--- Porting note: add noncomputable since liftFun is also noncomputable
-noncomputable def algebraMapInv : FreeAlgebra R X →ₐ[R] R :=
+def algebraMapInv : FreeAlgebra R X →ₐ[R] R :=
   lift R (0 : X → R)
 #align free_algebra.algebra_map_inv FreeAlgebra.algebraMapInv
 

--- a/Mathlib/Algebra/FreeAlgebra.lean
+++ b/Mathlib/Algebra/FreeAlgebra.lean
@@ -110,6 +110,8 @@ attribute [local instance] Pre.hasCoeGenerator Pre.hasCoeSemiring Pre.hasMul Pre
 /-- Given a function from `X` to an `R`-algebra `A`, `lift_fun` provides a lift of `f` to a function
 from `Pre R X` to `A`. This is mainly used in the construction of `FreeAlgebra.lift`.
 -/
+-- Porting note: recOn was replaced by an inductive definition to preserve computability,
+-- see https://github.com/leanprover/lean4/issues/2049
 def liftFun {A : Type _} [Semiring A] [Algebra R A] (f : X → A) :
     Pre R X → A
   | .of t => f t

--- a/Mathlib/Algebra/FreeAlgebra.lean
+++ b/Mathlib/Algebra/FreeAlgebra.lean
@@ -110,8 +110,7 @@ attribute [local instance] Pre.hasCoeGenerator Pre.hasCoeSemiring Pre.hasMul Pre
 /-- Given a function from `X` to an `R`-algebra `A`, `lift_fun` provides a lift of `f` to a function
 from `Pre R X` to `A`. This is mainly used in the construction of `FreeAlgebra.lift`.
 -/
--- Porting note: recOn was replaced by an inductive definition to preserve computability,
--- see https://github.com/leanprover/lean4/issues/2049
+-- Porting note: recOn was replaced to preserve computability, see lean4#2049
 def liftFun {A : Type _} [Semiring A] [Algebra R A] (f : X → A) :
     Pre R X → A
   | .of t => f t


### PR DESCRIPTION

See the Zulip [thread](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Noncomputable.20definitions.20in.20!4.233007)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
