### PR TITLE
[Merged by Bors] - chore: add explicit instance names for MulOpposite

### DIFF
--- a/Mathlib/Algebra/Field/Opposite.lean
+++ b/Mathlib/Algebra/Field/Opposite.lean
@@ -19,32 +19,32 @@ namespace MulOpposite
 
 variable (α : Type _)
 
-instance [DivisionSemiring α] : DivisionSemiring αᵐᵒᵖ :=
+instance divisionSemiring [DivisionSemiring α] : DivisionSemiring αᵐᵒᵖ :=
   { instGroupWithZeroMulOpposite α, instSemiringMulOpposite α with }
 
-instance [DivisionRing α] : DivisionRing αᵐᵒᵖ :=
+instance divisionRing [DivisionRing α] : DivisionRing αᵐᵒᵖ :=
   { instGroupWithZeroMulOpposite α, instRingMulOpposite α with }
 
-instance [Semifield α] : Semifield αᵐᵒᵖ :=
-  { instDivisionSemiringMulOpposite α, MulOpposite.instCommSemiringMulOpposite α with }
+instance semifield [Semifield α] : Semifield αᵐᵒᵖ :=
+  { MulOpposite.divisionSemiring α, MulOpposite.commSemiring α with }
 
-instance [Field α] : Field αᵐᵒᵖ :=
-  { instDivisionRingMulOpposite α, instCommRingMulOpposite α with }
+instance field [Field α] : Field αᵐᵒᵖ :=
+  { MulOpposite.divisionRing α, MulOpposite.commRing α with }
 
 end MulOpposite
 
 namespace AddOpposite
 
-instance [DivisionSemiring α] : DivisionSemiring αᵃᵒᵖ :=
-  { instGroupWithZeroAddOpposite α, instSemiringAddOpposite α with }
+instance divisionSemiring [DivisionSemiring α] : DivisionSemiring αᵃᵒᵖ :=
+  { AddOpposite.groupWithZero α, AddOpposite.semiring α with }
 
-instance [DivisionRing α] : DivisionRing αᵃᵒᵖ :=
-  { instGroupWithZeroAddOpposite α, instRingAddOpposite α with }
+instance divisionRing [DivisionRing α] : DivisionRing αᵃᵒᵖ :=
+  { AddOpposite.groupWithZero α, AddOpposite.ring α with }
 
-instance [Semifield α] : Semifield αᵃᵒᵖ :=
-  { instDivisionSemiringAddOpposite, instCommSemiringAddOpposite α with }
+instance semifield [Semifield α] : Semifield αᵃᵒᵖ :=
+  { AddOpposite.divisionSemiring, AddOpposite.commSemiring α with }
 
-instance [Field α] : Field αᵃᵒᵖ :=
-  { instDivisionRingAddOpposite, instCommRingAddOpposite α with }
+instance field [Field α] : Field αᵃᵒᵖ :=
+  { AddOpposite.divisionRing, AddOpposite.commRing α with }
 
 end AddOpposite

--- a/Mathlib/Algebra/Field/Opposite.lean
+++ b/Mathlib/Algebra/Field/Opposite.lean
@@ -20,10 +20,10 @@ namespace MulOpposite
 variable (α : Type _)
 
 instance divisionSemiring [DivisionSemiring α] : DivisionSemiring αᵐᵒᵖ :=
-  { instGroupWithZeroMulOpposite α, instSemiringMulOpposite α with }
+  { MulOpposite.groupWithZero α, MulOpposite.semiring α with }
 
 instance divisionRing [DivisionRing α] : DivisionRing αᵐᵒᵖ :=
-  { instGroupWithZeroMulOpposite α, instRingMulOpposite α with }
+  { MulOpposite.groupWithZero α, MulOpposite.ring α with }
 
 instance semifield [Semifield α] : Semifield αᵐᵒᵖ :=
   { MulOpposite.divisionSemiring α, MulOpposite.commSemiring α with }

--- a/Mathlib/Algebra/Group/Opposite.lean
+++ b/Mathlib/Algebra/Group/Opposite.lean
@@ -30,49 +30,49 @@ namespace MulOpposite
 -/
 
 
-instance [AddSemigroup α] : AddSemigroup αᵐᵒᵖ :=
+instance addSemigroup [AddSemigroup α] : AddSemigroup αᵐᵒᵖ :=
   unop_injective.addSemigroup _ fun _ _ => rfl
 
-instance [AddLeftCancelSemigroup α] : AddLeftCancelSemigroup αᵐᵒᵖ :=
+instance addLeftCancelSemigroup [AddLeftCancelSemigroup α] : AddLeftCancelSemigroup αᵐᵒᵖ :=
   unop_injective.addLeftCancelSemigroup _ fun _ _ => rfl
 
-instance [AddRightCancelSemigroup α] : AddRightCancelSemigroup αᵐᵒᵖ :=
+instance addRightCancelSemigroup [AddRightCancelSemigroup α] : AddRightCancelSemigroup αᵐᵒᵖ :=
   unop_injective.addRightCancelSemigroup _ fun _ _ => rfl
 
-instance [AddCommSemigroup α] : AddCommSemigroup αᵐᵒᵖ :=
+instance addCommSemigroup [AddCommSemigroup α] : AddCommSemigroup αᵐᵒᵖ :=
   unop_injective.addCommSemigroup _ fun _ _ => rfl
 
-instance [AddZeroClass α] : AddZeroClass αᵐᵒᵖ :=
+instance addZeroClass [AddZeroClass α] : AddZeroClass αᵐᵒᵖ :=
   unop_injective.addZeroClass _ (by exact rfl) fun _ _ => rfl
 
-instance [AddMonoid α] : AddMonoid αᵐᵒᵖ :=
+instance addMonoid [AddMonoid α] : AddMonoid αᵐᵒᵖ :=
   unop_injective.addMonoid _ (by exact rfl) (fun _ _ => rfl) fun _ _ => rfl
 
-instance [AddMonoidWithOne α] : AddMonoidWithOne αᵐᵒᵖ :=
+instance addMonoidWithOne [AddMonoidWithOne α] : AddMonoidWithOne αᵐᵒᵖ :=
   { instAddMonoidMulOpposite α, instOneMulOpposite α with
     natCast := fun n => op n,
     natCast_zero := show op ((0 : ℕ) : α) = 0 by simp,
     natCast_succ := show ∀ n, op ((n + 1 : ℕ) : α) = op ((n : ℕ) : α) + 1 by simp }
 
-instance [AddCommMonoid α] : AddCommMonoid αᵐᵒᵖ :=
+instance addCommMonoid [AddCommMonoid α] : AddCommMonoid αᵐᵒᵖ :=
   unop_injective.addCommMonoid _ (by exact rfl) (fun _ _ => rfl) fun _ _ => rfl
 
-instance [SubNegMonoid α] : SubNegMonoid αᵐᵒᵖ :=
+instance subNegMonoid [SubNegMonoid α] : SubNegMonoid αᵐᵒᵖ :=
   unop_injective.subNegMonoid _ (by exact rfl) (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl)
     (fun _ _ => rfl) fun _ _ => rfl
 
-instance [AddGroup α] : AddGroup αᵐᵒᵖ :=
+instance addGroup [AddGroup α] : AddGroup αᵐᵒᵖ :=
   unop_injective.addGroup _ (by exact rfl) (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl)
   (fun _ _ => rfl) fun _ _ => rfl
 
-instance [AddGroupWithOne α] : AddGroupWithOne αᵐᵒᵖ :=
+instance addGroupWithOne [AddGroupWithOne α] : AddGroupWithOne αᵐᵒᵖ :=
   { instAddMonoidWithOneMulOpposite α, instAddGroupMulOpposite α with
     intCast := fun n => op n,
     intCast_ofNat := fun n => show op ((n : ℤ) : α) = op (n : α) by rw [Int.cast_ofNat],
     intCast_negSucc := fun n =>
       show op _ = op (-unop (op ((n + 1 : ℕ) : α))) by simp }
 
-instance [AddCommGroup α] : AddCommGroup αᵐᵒᵖ :=
+instance addCommGroup [AddCommGroup α] : AddCommGroup αᵐᵒᵖ :=
   unop_injective.addCommGroup _ (by exact rfl) (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl)
     (fun _ _ => rfl) fun _ _ => rfl
 
@@ -84,61 +84,61 @@ We also generate additive structures on `αᵃᵒᵖ` using `to_additive`
 
 
 @[to_additive]
-instance [Semigroup α] : Semigroup αᵐᵒᵖ :=
-  { instMulMulOpposite α with
+instance semigroup [Semigroup α] : Semigroup αᵐᵒᵖ :=
+  { MulOpposite.mul α with
     mul_assoc := fun x y z => unop_injective <| Eq.symm <| mul_assoc (unop z) (unop y) (unop x) }
 
 @[to_additive]
-instance [RightCancelSemigroup α] : LeftCancelSemigroup αᵐᵒᵖ :=
-  { instSemigroupMulOpposite α with
+instance leftCancelSemigroup [RightCancelSemigroup α] : LeftCancelSemigroup αᵐᵒᵖ :=
+  { MulOpposite.semigroup α with
     mul_left_cancel := fun _ _ _ H => unop_injective <| mul_right_cancel <| op_injective H }
 
 @[to_additive]
-instance [LeftCancelSemigroup α] : RightCancelSemigroup αᵐᵒᵖ :=
-  { instSemigroupMulOpposite α with
+instance rightCancelSemigroup [LeftCancelSemigroup α] : RightCancelSemigroup αᵐᵒᵖ :=
+  { MulOpposite.semigroup α with
     mul_right_cancel := fun _ _ _ H => unop_injective <| mul_left_cancel <| op_injective H }
 
 @[to_additive]
-instance [CommSemigroup α] : CommSemigroup αᵐᵒᵖ :=
-  { instSemigroupMulOpposite α with
+instance commSemigroup [CommSemigroup α] : CommSemigroup αᵐᵒᵖ :=
+  { MulOpposite.semigroup α with
     mul_comm := fun x y => unop_injective <| mul_comm (unop y) (unop x) }
 
 @[to_additive]
-instance [MulOneClass α] : MulOneClass αᵐᵒᵖ :=
-  { instMulMulOpposite α, instOneMulOpposite α with
+instance mulOneClass [MulOneClass α] : MulOneClass αᵐᵒᵖ :=
+  { MulOpposite.mul α, MulOpposite.one α with
     one_mul := fun x => unop_injective <| mul_one <| unop x,
     mul_one := fun x => unop_injective <| one_mul <| unop x }
 
 @[to_additive]
-instance [Monoid α] : Monoid αᵐᵒᵖ :=
-  { instSemigroupMulOpposite α, instMulOneClassMulOpposite α with
+instance monoid [Monoid α] : Monoid αᵐᵒᵖ :=
+  { MulOpposite.semigroup α, MulOpposite.mulOneClass α with
     npow := fun n x => op <| x.unop ^ n,
     npow_zero := fun x => unop_injective <| Monoid.npow_zero x.unop,
     npow_succ := fun n x => unop_injective <| pow_succ' x.unop n }
 
 @[to_additive]
-instance [RightCancelMonoid α] : LeftCancelMonoid αᵐᵒᵖ :=
-  { instLeftCancelSemigroupMulOpposite α, instMonoidMulOpposite α with }
+instance leftCancelMonoid [RightCancelMonoid α] : LeftCancelMonoid αᵐᵒᵖ :=
+  { MulOpposite.leftCancelSemigroup α, MulOpposite.monoid α with }
 
 @[to_additive]
-instance [LeftCancelMonoid α] : RightCancelMonoid αᵐᵒᵖ :=
-  { instRightCancelSemigroupMulOpposite α, instMonoidMulOpposite α with }
+instance rightCancelMonoid [LeftCancelMonoid α] : RightCancelMonoid αᵐᵒᵖ :=
+  { MulOpposite.rightCancelSemigroup α, MulOpposite.monoid α with }
 
 @[to_additive]
-instance [CancelMonoid α] : CancelMonoid αᵐᵒᵖ :=
-  { instRightCancelMonoidMulOpposite α, instLeftCancelMonoidMulOpposite α with }
+instance cancelMonoid [CancelMonoid α] : CancelMonoid αᵐᵒᵖ :=
+  { MulOpposite.rightCancelMonoid α, MulOpposite.leftCancelMonoid α with }
 
 @[to_additive]
-instance [CommMonoid α] : CommMonoid αᵐᵒᵖ :=
-  { instMonoidMulOpposite α, instCommSemigroupMulOpposite α with }
+instance commMonoid [CommMonoid α] : CommMonoid αᵐᵒᵖ :=
+  { MulOpposite.monoid α, MulOpposite.commSemigroup α with }
 
 @[to_additive]
-instance [CancelCommMonoid α] : CancelCommMonoid αᵐᵒᵖ :=
-  { instCancelMonoidMulOpposite α, instCommMonoidMulOpposite α with }
+instance cancelCommMonoid [CancelCommMonoid α] : CancelCommMonoid αᵐᵒᵖ :=
+  { MulOpposite.cancelMonoid α, MulOpposite.commMonoid α with }
 
 @[to_additive AddOpposite.subNegMonoid]
-instance [DivInvMonoid α] : DivInvMonoid αᵐᵒᵖ :=
-  { instMonoidMulOpposite α, instInvMulOpposite α with
+instance divInvMonoid [DivInvMonoid α] : DivInvMonoid αᵐᵒᵖ :=
+  { MulOpposite.monoid α, MulOpposite.inv α with
     zpow := fun n x => op <| x.unop ^ n,
     zpow_zero' := fun x => unop_injective <| DivInvMonoid.zpow_zero' x.unop,
     zpow_succ' := fun n x => unop_injective <| by
@@ -147,23 +147,23 @@ instance [DivInvMonoid α] : DivInvMonoid αᵐᵒᵖ :=
     zpow_neg' := fun z x => unop_injective <| DivInvMonoid.zpow_neg' z x.unop }
 
 @[to_additive AddOpposite.subtractionMonoid]
-instance [DivisionMonoid α] : DivisionMonoid αᵐᵒᵖ :=
-  { instDivInvMonoidMulOpposite α, instInvolutiveInvMulOpposite α with
+instance divisionMonoid [DivisionMonoid α] : DivisionMonoid αᵐᵒᵖ :=
+  { MulOpposite.divInvMonoid α, MulOpposite.involutiveInv α with
     mul_inv_rev := fun _ _ => unop_injective <| mul_inv_rev _ _,
     inv_eq_of_mul := fun _ _ h => unop_injective <| inv_eq_of_mul_eq_one_left <| congr_arg unop h }
 
 @[to_additive AddOpposite.subtractionCommMonoid]
-instance [DivisionCommMonoid α] : DivisionCommMonoid αᵐᵒᵖ :=
-  { instDivisionMonoidMulOpposite α, instCommSemigroupMulOpposite α with }
+instance divisionCommMonoid [DivisionCommMonoid α] : DivisionCommMonoid αᵐᵒᵖ :=
+  { MulOpposite.divisionMonoid α, MulOpposite.commSemigroup α with }
 
 @[to_additive]
-instance [Group α] : Group αᵐᵒᵖ :=
-  { instDivInvMonoidMulOpposite α with
+instance group [Group α] : Group αᵐᵒᵖ :=
+  { MulOpposite.divInvMonoid α with
     mul_left_inv := fun x => unop_injective <| mul_inv_self <| unop x }
 
 @[to_additive]
-instance [CommGroup α] : CommGroup αᵐᵒᵖ :=
-  { instGroupMulOpposite α, instCommMonoidMulOpposite α with }
+instance commGroup [CommGroup α] : CommGroup αᵐᵒᵖ :=
+  { MulOpposite.group α, MulOpposite.commMonoid α with }
 
 variable {α}
 
@@ -255,22 +255,22 @@ end MulOpposite
 
 namespace AddOpposite
 
-instance [Semigroup α] : Semigroup αᵃᵒᵖ :=
+instance semigroup [Semigroup α] : Semigroup αᵃᵒᵖ :=
   unop_injective.semigroup _ fun _ _ => rfl
 
-instance [LeftCancelSemigroup α] : LeftCancelSemigroup αᵃᵒᵖ :=
+instance leftCancelSemigroup [LeftCancelSemigroup α] : LeftCancelSemigroup αᵃᵒᵖ :=
   unop_injective.leftCancelSemigroup _ fun _ _ => rfl
 
-instance [RightCancelSemigroup α] : RightCancelSemigroup αᵃᵒᵖ :=
+instance rightCancelSemigroup [RightCancelSemigroup α] : RightCancelSemigroup αᵃᵒᵖ :=
   unop_injective.rightCancelSemigroup _ fun _ _ => rfl
 
-instance [CommSemigroup α] : CommSemigroup αᵃᵒᵖ :=
+instance commSemigroup [CommSemigroup α] : CommSemigroup αᵃᵒᵖ :=
   unop_injective.commSemigroup _ fun _ _ => rfl
 
-instance [MulOneClass α] : MulOneClass αᵃᵒᵖ :=
+instance mulOneClass [MulOneClass α] : MulOneClass αᵃᵒᵖ :=
   unop_injective.mulOneClass _ (by exact rfl) fun _ _ => rfl
 
-instance {β} [Pow α β] : Pow αᵃᵒᵖ β where pow a b := op (unop a ^ b)
+instance pow {β} [Pow α β] : Pow αᵃᵒᵖ β where pow a b := op (unop a ^ b)
 
 @[simp]
 theorem op_pow {β} [Pow α β] (a : α) (b : β) : op (a ^ b) = op a ^ b :=
@@ -282,23 +282,23 @@ theorem unop_pow {β} [Pow α β] (a : αᵃᵒᵖ) (b : β) : unop (a ^ b) = un
   rfl
 #align add_opposite.unop_pow AddOpposite.unop_pow
 
-instance [Monoid α] : Monoid αᵃᵒᵖ :=
+instance monoid [Monoid α] : Monoid αᵃᵒᵖ :=
   unop_injective.monoid _ (by exact rfl) (fun _ _ => rfl) fun _ _ => rfl
 
-instance [CommMonoid α] : CommMonoid αᵃᵒᵖ :=
+instance commMonoid [CommMonoid α] : CommMonoid αᵃᵒᵖ :=
   unop_injective.commMonoid _ (by exact rfl) (fun _ _ => rfl) fun _ _ => rfl
 
-instance [DivInvMonoid α] : DivInvMonoid αᵃᵒᵖ :=
+instance divInvMonoid [DivInvMonoid α] : DivInvMonoid αᵃᵒᵖ :=
   unop_injective.divInvMonoid _ (by exact rfl) (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl)
     (fun _ _ => rfl) fun _ _ => rfl
 
-instance [Group α] : Group αᵃᵒᵖ :=
+instance group [Group α] : Group αᵃᵒᵖ :=
   unop_injective.group _ (by exact rfl) (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl)
-  (fun _ _ => rfl) fun _ _ => rfl
+    (fun _ _ => rfl) fun _ _ => rfl
 
-instance [CommGroup α] : CommGroup αᵃᵒᵖ :=
+instance commGroup [CommGroup α] : CommGroup αᵃᵒᵖ :=
   unop_injective.commGroup _ (by exact rfl) (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl)
-  (fun _ _ => rfl) fun _ _ => rfl
+    (fun _ _ => rfl) fun _ _ => rfl
 
 variable {α}
 

--- a/Mathlib/Algebra/Group/Opposite.lean
+++ b/Mathlib/Algebra/Group/Opposite.lean
@@ -49,7 +49,7 @@ instance addMonoid [AddMonoid α] : AddMonoid αᵐᵒᵖ :=
   unop_injective.addMonoid _ (by exact rfl) (fun _ _ => rfl) fun _ _ => rfl
 
 instance addMonoidWithOne [AddMonoidWithOne α] : AddMonoidWithOne αᵐᵒᵖ :=
-  { instAddMonoidMulOpposite α, instOneMulOpposite α with
+  { MulOpposite.addMonoid α, MulOpposite.one α with
     natCast := fun n => op n,
     natCast_zero := show op ((0 : ℕ) : α) = 0 by simp,
     natCast_succ := show ∀ n, op ((n + 1 : ℕ) : α) = op ((n : ℕ) : α) + 1 by simp }
@@ -66,7 +66,7 @@ instance addGroup [AddGroup α] : AddGroup αᵐᵒᵖ :=
   (fun _ _ => rfl) fun _ _ => rfl
 
 instance addGroupWithOne [AddGroupWithOne α] : AddGroupWithOne αᵐᵒᵖ :=
-  { instAddMonoidWithOneMulOpposite α, instAddGroupMulOpposite α with
+  { MulOpposite.addMonoidWithOne α, MulOpposite.addGroup α with
     intCast := fun n => op n,
     intCast_ofNat := fun n => show op ((n : ℤ) : α) = op (n : α) by rw [Int.cast_ofNat],
     intCast_negSucc := fun n =>

--- a/Mathlib/Algebra/Opposites.lean
+++ b/Mathlib/Algebra/Opposites.lean
@@ -177,51 +177,51 @@ attribute [nolint simpComm] AddOpposite.unop_inj
 variable (α)
 
 @[to_additive]
-instance [Nontrivial α] : Nontrivial αᵐᵒᵖ :=
+instance nontrivial [Nontrivial α] : Nontrivial αᵐᵒᵖ :=
   op_injective.nontrivial
 
 @[to_additive]
-instance [Inhabited α] : Inhabited αᵐᵒᵖ :=
+instance inhabited [Inhabited α] : Inhabited αᵐᵒᵖ :=
   ⟨op default⟩
 
 @[to_additive]
-instance [Subsingleton α] : Subsingleton αᵐᵒᵖ :=
+instance subsingleton [Subsingleton α] : Subsingleton αᵐᵒᵖ :=
   unop_injective.subsingleton
 
 @[to_additive]
-instance [Unique α] : Unique αᵐᵒᵖ :=
+instance unique [Unique α] : Unique αᵐᵒᵖ :=
   Unique.mk' _
 
 @[to_additive]
-instance [IsEmpty α] : IsEmpty αᵐᵒᵖ :=
+instance isEmpty [IsEmpty α] : IsEmpty αᵐᵒᵖ :=
   Function.isEmpty unop
 
-instance [Zero α] : Zero αᵐᵒᵖ where zero := op 0
+instance zero [Zero α] : Zero αᵐᵒᵖ where zero := op 0
 
 @[to_additive]
-instance [One α] : One αᵐᵒᵖ where one := op 1
+instance one [One α] : One αᵐᵒᵖ where one := op 1
 
-instance [Add α] : Add αᵐᵒᵖ where add x y := op (unop x + unop y)
+instance add [Add α] : Add αᵐᵒᵖ where add x y := op (unop x + unop y)
 
-instance [Sub α] : Sub αᵐᵒᵖ where sub x y := op (unop x - unop y)
+instance sub [Sub α] : Sub αᵐᵒᵖ where sub x y := op (unop x - unop y)
 
-instance [Neg α] : Neg αᵐᵒᵖ where neg x := op $ -unop x
+instance neg [Neg α] : Neg αᵐᵒᵖ where neg x := op $ -unop x
 
-instance [InvolutiveNeg α] : InvolutiveNeg αᵐᵒᵖ :=
-  { MulOpposite.instNegMulOpposite α with neg_neg := fun _ => unop_injective $ neg_neg _ }
-
-@[to_additive]
-instance [Mul α] : Mul αᵐᵒᵖ where mul x y := op (unop y * unop x)
+instance involutiveNeg [InvolutiveNeg α] : InvolutiveNeg αᵐᵒᵖ :=
+  { MulOpposite.neg α with neg_neg := fun _ => unop_injective $ neg_neg _ }
 
 @[to_additive]
-instance [Inv α] : Inv αᵐᵒᵖ where inv x := op $ (unop x)⁻¹
+instance mul [Mul α] : Mul αᵐᵒᵖ where mul x y := op (unop y * unop x)
 
 @[to_additive]
-instance [InvolutiveInv α] : InvolutiveInv αᵐᵒᵖ :=
-  { MulOpposite.instInvMulOpposite α with inv_inv := fun _ => unop_injective $ inv_inv _ }
+instance inv [Inv α] : Inv αᵐᵒᵖ where inv x := op $ (unop x)⁻¹
 
 @[to_additive]
-instance (R : Type _) [SMul R α] : SMul R αᵐᵒᵖ where smul c x := op (c • unop x)
+instance involutiveInv [InvolutiveInv α] : InvolutiveInv αᵐᵒᵖ :=
+  { MulOpposite.inv α with inv_inv := fun _ => unop_injective $ inv_inv _ }
+
+@[to_additive]
+instance smul (R : Type _) [SMul R α] : SMul R αᵐᵒᵖ where smul c x := op (c • unop x)
 
 section
 
@@ -355,7 +355,7 @@ end MulOpposite
 
 namespace AddOpposite
 
-instance [One α] : One αᵃᵒᵖ where one := op 1
+instance one [One α] : One αᵃᵒᵖ where one := op 1
 
 @[simp]
 theorem op_one [One α] : op (1 : α) = 1 :=
@@ -379,7 +379,7 @@ theorem unop_eq_one_iff [One α] {a : αᵃᵒᵖ} : unop a = 1 ↔ a = 1 :=
 
 attribute [nolint simpComm] unop_eq_one_iff
 
-instance [Mul α] : Mul αᵃᵒᵖ where mul a b := op (unop a * unop b)
+instance mul [Mul α] : Mul αᵃᵒᵖ where mul a b := op (unop a * unop b)
 
 @[simp]
 theorem op_mul [Mul α] (a b : α) : op (a * b) = op a * op b :=
@@ -391,10 +391,10 @@ theorem unop_mul [Mul α] (a b : αᵃᵒᵖ) : unop (a * b) = unop a * unop b :
   rfl
 #align add_opposite.unop_mul AddOpposite.unop_mul
 
-instance [Inv α] : Inv αᵃᵒᵖ where inv a := op (unop a)⁻¹
+instance inv [Inv α] : Inv αᵃᵒᵖ where inv a := op (unop a)⁻¹
 
-instance [InvolutiveInv α] : InvolutiveInv αᵃᵒᵖ :=
-  { AddOpposite.instInvAddOpposite with inv_inv := fun _ => unop_injective $ inv_inv _ }
+instance involutiveInv [InvolutiveInv α] : InvolutiveInv αᵃᵒᵖ :=
+  { AddOpposite.inv with inv_inv := fun _ => unop_injective $ inv_inv _ }
 
 @[simp]
 theorem op_inv [Inv α] (a : α) : op a⁻¹ = (op a)⁻¹ :=
@@ -406,7 +406,7 @@ theorem unop_inv [Inv α] (a : αᵃᵒᵖ) : unop a⁻¹ = (unop a)⁻¹ :=
   rfl
 #align add_opposite.unop_inv AddOpposite.unop_inv
 
-instance [Div α] : Div αᵃᵒᵖ where div a b := op (unop a / unop b)
+instance div [Div α] : Div αᵃᵒᵖ where div a b := op (unop a / unop b)
 
 @[simp]
 theorem op_div [Div α] (a b : α) : op (a / b) = op a / op b :=

--- a/Mathlib/Algebra/Quandle.lean
+++ b/Mathlib/Algebra/Quandle.lean
@@ -712,10 +712,10 @@ See `toEnvelGroup.map`.
 -/
 def toEnvelGroup.mapAux {R : Type _} [Rack R] {G : Type _} [Group G] (f : R →◃ Quandle.Conj G) :
     PreEnvelGroup R → G
-  | unit => 1
-  | incl x => f x
-  | mul a b => toEnvelGroup.mapAux f a * toEnvelGroup.mapAux f b
-  | inv a => (toEnvelGroup.mapAux f a)⁻¹
+  | .unit => 1
+  | .incl x => f x
+  | .mul a b => toEnvelGroup.mapAux f a * toEnvelGroup.mapAux f b
+  | .inv a => (toEnvelGroup.mapAux f a)⁻¹
 #align rack.to_envel_group.map_aux Rack.toEnvelGroup.mapAux
 
 namespace toEnvelGroup.mapAux

--- a/Mathlib/Algebra/Ring/Basic.lean
+++ b/Mathlib/Algebra/Ring/Basic.lean
@@ -102,8 +102,8 @@ variable [Mul α] [HasDistribNeg α]
 
 open MulOpposite
 
-instance : HasDistribNeg αᵐᵒᵖ :=
-  { MulOpposite.instInvolutiveNegMulOpposite _ with
+instance hasDistribNeg : HasDistribNeg αᵐᵒᵖ :=
+  { MulOpposite.involutiveNeg _ with
     neg_mul := fun _ _ => unop_injective <| mul_neg _ _,
     mul_neg := fun _ _ => unop_injective <| neg_mul _ _ }
 

--- a/Mathlib/Algebra/Ring/Basic.lean
+++ b/Mathlib/Algebra/Ring/Basic.lean
@@ -103,7 +103,7 @@ variable [Mul α] [HasDistribNeg α]
 open MulOpposite
 
 instance : HasDistribNeg αᵐᵒᵖ :=
-  { MulOpposite.instInvolutiveNegMulOpposite _ with
+  { MulOpposite.involutiveNeg _ with
     neg_mul := fun _ _ => unop_injective <| mul_neg _ _,
     mul_neg := fun _ _ => unop_injective <| neg_mul _ _ }
 

--- a/Mathlib/Algebra/Ring/Basic.lean
+++ b/Mathlib/Algebra/Ring/Basic.lean
@@ -103,7 +103,7 @@ variable [Mul α] [HasDistribNeg α]
 open MulOpposite
 
 instance : HasDistribNeg αᵐᵒᵖ :=
-  { MulOpposite.involutiveNeg _ with
+  { MulOpposite.instInvolutiveNegMulOpposite _ with
     neg_mul := fun _ _ => unop_injective <| mul_neg _ _,
     mul_neg := fun _ _ => unop_injective <| neg_mul _ _ }
 

--- a/Mathlib/Algebra/Ring/Defs.lean
+++ b/Mathlib/Algebra/Ring/Defs.lean
@@ -333,7 +333,7 @@ class NonUnitalRing (α : Type _) extends NonUnitalNonAssocRing α, NonUnitalSem
 
 /-- A unital but not-necessarily-associative ring. -/
 class NonAssocRing (α : Type _) extends NonUnitalNonAssocRing α, NonAssocSemiring α,
-    AddGroupWithOne α
+    AddCommGroupWithOne α
 #align non_assoc_ring NonAssocRing
 
 class Ring (R : Type u) extends Semiring R, AddCommGroup R, AddGroupWithOne R

--- a/Mathlib/Algebra/Ring/Defs.lean
+++ b/Mathlib/Algebra/Ring/Defs.lean
@@ -333,7 +333,7 @@ class NonUnitalRing (α : Type _) extends NonUnitalNonAssocRing α, NonUnitalSem
 
 /-- A unital but not-necessarily-associative ring. -/
 class NonAssocRing (α : Type _) extends NonUnitalNonAssocRing α, NonAssocSemiring α,
-    AddCommGroupWithOne α
+    AddGroupWithOne α
 #align non_assoc_ring NonAssocRing
 
 class Ring (R : Type u) extends Semiring R, AddCommGroup R, AddGroupWithOne R

--- a/Mathlib/Algebra/Ring/Opposite.lean
+++ b/Mathlib/Algebra/Ring/Opposite.lean
@@ -150,10 +150,10 @@ instance nonUnitalRing [NonUnitalRing α] : NonUnitalRing αᵃᵒᵖ :=
   { AddOpposite.addCommGroup α, AddOpposite.semigroupWithZero α, AddOpposite.distrib α with }
 
 instance nonAssocRing [NonAssocRing α] : NonAssocRing αᵃᵒᵖ :=
-  { AddOpposite.addCommGroupWithOne α, AddOpposite.mulZeroOneClass α, AddOpposite.distrib α with }
+  { AddOpposite.addCommGroup α, AddOpposite.mulZeroOneClass α, AddOpposite.distrib α with }
 
 instance ring [Ring α] : Ring αᵃᵒᵖ :=
-  { AddOpposite.addCommGroupWithOne α, AddOpposite.monoid α, AddOpposite.semiring α with }
+  { AddOpposite.addCommGroup α, AddOpposite.monoid α, AddOpposite.semiring α with }
 
 instance nonUnitalCommRing [NonUnitalCommRing α] : NonUnitalCommRing αᵃᵒᵖ :=
   { AddOpposite.nonUnitalRing α, AddOpposite.nonUnitalCommSemiring α with }

--- a/Mathlib/Algebra/Ring/Opposite.lean
+++ b/Mathlib/Algebra/Ring/Opposite.lean
@@ -23,82 +23,79 @@ variable (α : Type u)
 
 namespace MulOpposite
 
-instance [Distrib α] : Distrib αᵐᵒᵖ :=
-  { MulOpposite.instAddMulOpposite α, MulOpposite.instMulMulOpposite α with
+instance distrib [Distrib α] : Distrib αᵐᵒᵖ :=
+  { MulOpposite.add α, MulOpposite.mul α with
     left_distrib := fun x y z => unop_injective <| add_mul (unop y) (unop z) (unop x),
     right_distrib := fun x y z => unop_injective <| mul_add (unop z) (unop x) (unop y) }
 
-instance [MulZeroClass α] : MulZeroClass αᵐᵒᵖ where
+instance mulZeroClass [MulZeroClass α] : MulZeroClass αᵐᵒᵖ where
   zero := 0
   mul := (· * ·)
   zero_mul x := unop_injective <| mul_zero <| unop x
   mul_zero x := unop_injective <| zero_mul <| unop x
 
-instance [MulZeroOneClass α] : MulZeroOneClass αᵐᵒᵖ :=
-  { MulOpposite.instMulZeroClassMulOpposite α, MulOpposite.instMulOneClassMulOpposite α with }
+instance mulZeroOneClass [MulZeroOneClass α] : MulZeroOneClass αᵐᵒᵖ :=
+  { MulOpposite.mulZeroClass α, MulOpposite.mulOneClass α with }
 
-instance [SemigroupWithZero α] : SemigroupWithZero αᵐᵒᵖ :=
-  { MulOpposite.instSemigroupMulOpposite α, MulOpposite.instMulZeroClassMulOpposite α with }
+instance semigroupWithZero [SemigroupWithZero α] : SemigroupWithZero αᵐᵒᵖ :=
+  { MulOpposite.semigroup α, MulOpposite.mulZeroClass α with }
 
-instance [MonoidWithZero α] : MonoidWithZero αᵐᵒᵖ :=
-  { MulOpposite.instMonoidMulOpposite α, MulOpposite.instMulZeroOneClassMulOpposite α with }
+instance monoidWithZero [MonoidWithZero α] : MonoidWithZero αᵐᵒᵖ :=
+  { MulOpposite.monoid α, MulOpposite.mulZeroOneClass α with }
 
-instance [NonUnitalNonAssocSemiring α] : NonUnitalNonAssocSemiring αᵐᵒᵖ :=
-  { MulOpposite.instAddCommMonoidMulOpposite α, MulOpposite.instMulZeroClassMulOpposite α,
-    MulOpposite.instDistribMulOpposite α with }
+instance nonUnitalNonAssocSemiring [NonUnitalNonAssocSemiring α] : NonUnitalNonAssocSemiring αᵐᵒᵖ :=
+  { MulOpposite.addCommMonoid α, MulOpposite.mulZeroClass α, MulOpposite.distrib α with }
 
-instance [NonUnitalSemiring α] : NonUnitalSemiring αᵐᵒᵖ :=
-  { MulOpposite.instSemigroupWithZeroMulOpposite α,
-    MulOpposite.instNonUnitalNonAssocSemiringMulOpposite α with }
+instance nonUnitalSemiring [NonUnitalSemiring α] : NonUnitalSemiring αᵐᵒᵖ :=
+  { MulOpposite.semigroupWithZero α, MulOpposite.nonUnitalNonAssocSemiring α with }
 
-instance [NonAssocSemiring α] : NonAssocSemiring αᵐᵒᵖ :=
-  { MulOpposite.instAddMonoidWithOneMulOpposite α, MulOpposite.instMulZeroOneClassMulOpposite α,
-    MulOpposite.instNonUnitalNonAssocSemiringMulOpposite α with }
+instance nonAssocSemiring [NonAssocSemiring α] : NonAssocSemiring αᵐᵒᵖ :=
+  { MulOpposite.addMonoidWithOne α, MulOpposite.mulZeroOneClass α,
+    MulOpposite.nonUnitalNonAssocSemiring α with }
 
-instance [Semiring α] : Semiring αᵐᵒᵖ :=
-  { MulOpposite.instNonUnitalSemiringMulOpposite α, MulOpposite.instNonAssocSemiringMulOpposite α,
-    MulOpposite.instMonoidWithZeroMulOpposite α with }
+instance semiring [Semiring α] : Semiring αᵐᵒᵖ :=
+  { MulOpposite.nonUnitalSemiring α, MulOpposite.nonAssocSemiring α,
+    MulOpposite.monoidWithZero α with }
 
-instance [NonUnitalCommSemiring α] : NonUnitalCommSemiring αᵐᵒᵖ :=
-  { MulOpposite.instNonUnitalSemiringMulOpposite α,
-    MulOpposite.instCommSemigroupMulOpposite α with }
+instance nonUnitalCommSemiring [NonUnitalCommSemiring α] : NonUnitalCommSemiring αᵐᵒᵖ :=
+  { MulOpposite.nonUnitalSemiring α, MulOpposite.commSemigroup α with }
 
-instance [CommSemiring α] : CommSemiring αᵐᵒᵖ :=
-  { MulOpposite.instSemiringMulOpposite α, MulOpposite.instCommSemigroupMulOpposite α with }
+instance commSemiring [CommSemiring α] : CommSemiring αᵐᵒᵖ :=
+  { MulOpposite.semiring α, MulOpposite.commSemigroup α with }
 
-instance [NonUnitalNonAssocRing α] : NonUnitalNonAssocRing αᵐᵒᵖ :=
-  { MulOpposite.instAddCommGroupMulOpposite α, MulOpposite.instMulZeroClassMulOpposite α,
-    MulOpposite.instDistribMulOpposite α with }
+instance nonUnitalNonAssocRing [NonUnitalNonAssocRing α] : NonUnitalNonAssocRing αᵐᵒᵖ :=
+  { MulOpposite.addCommGroup α, MulOpposite.mulZeroClass α,
+    MulOpposite.distrib α with }
 
-instance [NonUnitalRing α] : NonUnitalRing αᵐᵒᵖ :=
-  { MulOpposite.instAddCommGroupMulOpposite α, MulOpposite.instSemigroupWithZeroMulOpposite α,
-    MulOpposite.instDistribMulOpposite α with }
+instance nonUnitalRing [NonUnitalRing α] : NonUnitalRing αᵐᵒᵖ :=
+  { MulOpposite.addCommGroup α, MulOpposite.semigroupWithZero α,
+    MulOpposite.distrib α with }
 
-instance [NonAssocRing α] : NonAssocRing αᵐᵒᵖ :=
-  { MulOpposite.instAddCommGroupMulOpposite α, MulOpposite.instMulZeroOneClassMulOpposite α,
-    MulOpposite.instDistribMulOpposite α, MulOpposite.instAddGroupWithOneMulOpposite α with }
+instance nonAssocRing [NonAssocRing α] : NonAssocRing αᵐᵒᵖ :=
+  { MulOpposite.addCommGroup α, MulOpposite.mulZeroOneClass α,
+    MulOpposite.distrib α, MulOpposite.addGroupWithOne α with }
 
-instance [Ring α] : Ring αᵐᵒᵖ :=
-  { MulOpposite.instMonoidMulOpposite α, MulOpposite.instNonAssocRingMulOpposite α with }
+instance ring [Ring α] : Ring αᵐᵒᵖ :=
+  { MulOpposite.monoid α, MulOpposite.nonAssocRing α with }
 
-instance [NonUnitalCommRing α] : NonUnitalCommRing αᵐᵒᵖ :=
-  { MulOpposite.instNonUnitalRingMulOpposite α,
-    MulOpposite.instNonUnitalCommSemiringMulOpposite α with }
+instance nonUnitalCommRing [NonUnitalCommRing α] : NonUnitalCommRing αᵐᵒᵖ :=
+  { MulOpposite.nonUnitalRing α,
+    MulOpposite.nonUnitalCommSemiring α with }
 
-instance [CommRing α] : CommRing αᵐᵒᵖ :=
-  { MulOpposite.instRingMulOpposite α, MulOpposite.instCommSemiringMulOpposite α with }
+instance commRing [CommRing α] : CommRing αᵐᵒᵖ :=
+  { MulOpposite.ring α, MulOpposite.commSemiring α with }
 
-instance [Zero α] [Mul α] [NoZeroDivisors α] : NoZeroDivisors αᵐᵒᵖ where
+instance noZeroDivisors [Zero α] [Mul α] [NoZeroDivisors α] : NoZeroDivisors αᵐᵒᵖ where
 eq_zero_or_eq_zero_of_mul_eq_zero (H : op (_ * _) = op (0 : α)) :=
     Or.casesOn (eq_zero_or_eq_zero_of_mul_eq_zero <| op_injective H)
       (fun hy => Or.inr <| unop_injective <| hy) fun hx => Or.inl <| unop_injective <| hx
 
-instance [Ring α] [IsDomain α] : IsDomain αᵐᵒᵖ :=
+instance isDomain [Ring α] [IsDomain α] : IsDomain αᵐᵒᵖ :=
   NoZeroDivisors.to_isDomain _
 
-instance [GroupWithZero α] : GroupWithZero αᵐᵒᵖ :=
-  { MulOpposite.instMonoidWithZeroMulOpposite α, MulOpposite.instDivInvMonoidMulOpposite α,
-    MulOpposite.instNontrivialMulOpposite α with
+instance groupWithZero [GroupWithZero α] : GroupWithZero αᵐᵒᵖ :=
+  { MulOpposite.monoidWithZero α, MulOpposite.divInvMonoid α,
+    MulOpposite.nontrivial α with
     mul_inv_cancel := fun _ hx => unop_injective <| inv_mul_cancel <| unop_injective.ne hx,
     inv_zero := unop_injective inv_zero }
 
@@ -106,83 +103,75 @@ end MulOpposite
 
 namespace AddOpposite
 
-instance [Distrib α] : Distrib αᵃᵒᵖ :=
-  { AddOpposite.instAddAddOpposite α, @AddOpposite.instMulAddOpposite α _ with
+instance distrib [Distrib α] : Distrib αᵃᵒᵖ :=
+  { AddOpposite.add α, @AddOpposite.mul α _ with
     left_distrib := fun x y z => unop_injective <| mul_add (unop x) (unop z) (unop y),
     right_distrib := fun x y z => unop_injective <| add_mul (unop y) (unop x) (unop z) }
 
-instance [MulZeroClass α] : MulZeroClass αᵃᵒᵖ where
+instance mulZeroClass [MulZeroClass α] : MulZeroClass αᵃᵒᵖ where
   zero := 0
   mul := (· * ·)
   zero_mul x := unop_injective <| zero_mul <| unop x
   mul_zero x := unop_injective <| mul_zero <| unop x
 
-instance [MulZeroOneClass α] : MulZeroOneClass αᵃᵒᵖ :=
-  { AddOpposite.instMulZeroClassAddOpposite α, AddOpposite.instMulOneClassAddOpposite α with }
+instance mulZeroOneClass [MulZeroOneClass α] : MulZeroOneClass αᵃᵒᵖ :=
+  { AddOpposite.mulZeroClass α, AddOpposite.mulOneClass α with }
 
-instance [SemigroupWithZero α] : SemigroupWithZero αᵃᵒᵖ :=
-  { AddOpposite.instSemigroupAddOpposite α, AddOpposite.instMulZeroClassAddOpposite α with }
+instance semigroupWithZero [SemigroupWithZero α] : SemigroupWithZero αᵃᵒᵖ :=
+  { AddOpposite.semigroup α, AddOpposite.mulZeroClass α with }
 
-instance [MonoidWithZero α] : MonoidWithZero αᵃᵒᵖ :=
-  { AddOpposite.instMonoidAddOpposite α, AddOpposite.instMulZeroOneClassAddOpposite α with }
+instance monoidWithZero [MonoidWithZero α] : MonoidWithZero αᵃᵒᵖ :=
+  { AddOpposite.monoid α, AddOpposite.mulZeroOneClass α with }
 
-instance [NonUnitalNonAssocSemiring α] : NonUnitalNonAssocSemiring αᵃᵒᵖ :=
-  { AddOpposite.instAddCommMonoidAddOpposite α, AddOpposite.instMulZeroClassAddOpposite α,
-    AddOpposite.instDistribAddOpposite α with }
+instance nonUnitalNonAssocSemiring [NonUnitalNonAssocSemiring α] : NonUnitalNonAssocSemiring αᵃᵒᵖ :=
+  { AddOpposite.addCommMonoid α, AddOpposite.mulZeroClass α, AddOpposite.distrib α with }
 
-instance [NonUnitalSemiring α] : NonUnitalSemiring αᵃᵒᵖ :=
-  { AddOpposite.instSemigroupWithZeroAddOpposite α,
-    AddOpposite.instNonUnitalNonAssocSemiringAddOpposite α with }
+instance nonUnitalSemiring [NonUnitalSemiring α] : NonUnitalSemiring αᵃᵒᵖ :=
+  { AddOpposite.semigroupWithZero α, AddOpposite.nonUnitalNonAssocSemiring α with }
 
-instance [NonAssocSemiring α] : NonAssocSemiring αᵃᵒᵖ :=
+instance nonAssocSemiring [NonAssocSemiring α] : NonAssocSemiring αᵃᵒᵖ :=
   { AddOpposite.instMulZeroOneClassAddOpposite α,
     AddOpposite.instNonUnitalNonAssocSemiringAddOpposite α with }
 
-instance [Semiring α] : Semiring αᵃᵒᵖ :=
-  { AddOpposite.instNonUnitalSemiringAddOpposite α, AddOpposite.instNonAssocSemiringAddOpposite α,
-    AddOpposite.instMonoidWithZeroAddOpposite α with }
+instance semiring [Semiring α] : Semiring αᵃᵒᵖ :=
+  { AddOpposite.nonUnitalSemiring α, AddOpposite.nonAssocSemiring α,
+    AddOpposite.monoidWithZero α with }
 
-instance [NonUnitalCommSemiring α] : NonUnitalCommSemiring αᵃᵒᵖ :=
-  { AddOpposite.instNonUnitalSemiringAddOpposite α,
-    AddOpposite.instCommSemigroupAddOpposite α with }
+instance nonUnitalCommSemiring [NonUnitalCommSemiring α] : NonUnitalCommSemiring αᵃᵒᵖ :=
+  { AddOpposite.nonUnitalSemiring α, AddOpposite.commSemigroup α with }
 
-instance [CommSemiring α] : CommSemiring αᵃᵒᵖ :=
-  { AddOpposite.instSemiringAddOpposite α, AddOpposite.instCommSemigroupAddOpposite α with }
+instance commSemiring [CommSemiring α] : CommSemiring αᵃᵒᵖ :=
+  { AddOpposite.semiring α, AddOpposite.commSemigroup α with }
 
-instance [NonUnitalNonAssocRing α] : NonUnitalNonAssocRing αᵃᵒᵖ :=
-  { AddOpposite.instAddCommGroupAddOpposite α, AddOpposite.instMulZeroClassAddOpposite α,
-    AddOpposite.instDistribAddOpposite α with }
+instance nonUnitalNonAssocRing [NonUnitalNonAssocRing α] : NonUnitalNonAssocRing αᵃᵒᵖ :=
+  { AddOpposite.addCommGroup α, AddOpposite.mulZeroClass α, AddOpposite.distrib α with }
 
-instance [NonUnitalRing α] : NonUnitalRing αᵃᵒᵖ :=
-  { AddOpposite.instAddCommGroupAddOpposite α, AddOpposite.instSemigroupWithZeroAddOpposite α,
-    AddOpposite.instDistribAddOpposite α with }
+instance nonUnitalRing [NonUnitalRing α] : NonUnitalRing αᵃᵒᵖ :=
+  { AddOpposite.addCommGroup α, AddOpposite.semigroupWithZero α, AddOpposite.distrib α with }
 
-instance [NonAssocRing α] : NonAssocRing αᵃᵒᵖ :=
-  { AddOpposite.instAddCommGroupAddOpposite α, AddOpposite.instMulZeroOneClassAddOpposite α,
-    AddOpposite.instDistribAddOpposite α with }
+instance nonAssocRing [NonAssocRing α] : NonAssocRing αᵃᵒᵖ :=
+  { AddOpposite.addCommGroupWithOne α, AddOpposite.mulZeroOneClass α, AddOpposite.distrib α with }
 
-instance [Ring α] : Ring αᵃᵒᵖ :=
-  { AddOpposite.instAddCommGroupAddOpposite α, AddOpposite.instMonoidAddOpposite α,
-    AddOpposite.instSemiringAddOpposite α with }
+instance ring [Ring α] : Ring αᵃᵒᵖ :=
+  { AddOpposite.addCommGroupWithOne α, AddOpposite.monoid α, AddOpposite.semiring α with }
 
-instance [NonUnitalCommRing α] : NonUnitalCommRing αᵃᵒᵖ :=
-  { AddOpposite.instNonUnitalRingAddOpposite α,
-    AddOpposite.instNonUnitalCommSemiringAddOpposite α with }
+instance nonUnitalCommRing [NonUnitalCommRing α] : NonUnitalCommRing αᵃᵒᵖ :=
+  { AddOpposite.nonUnitalRing α, AddOpposite.nonUnitalCommSemiring α with }
 
-instance [CommRing α] : CommRing αᵃᵒᵖ :=
-  { AddOpposite.instRingAddOpposite α, AddOpposite.instCommSemiringAddOpposite α with }
+instance commRing [CommRing α] : CommRing αᵃᵒᵖ :=
+  { AddOpposite.ring α, AddOpposite.commSemiring α with }
 
-instance [Zero α] [Mul α] [NoZeroDivisors α] : NoZeroDivisors αᵃᵒᵖ where
+instance noZeroDivisors [Zero α] [Mul α] [NoZeroDivisors α] : NoZeroDivisors αᵃᵒᵖ where
 eq_zero_or_eq_zero_of_mul_eq_zero (H : op (_ * _) = op (0 : α)) :=
   Or.imp (fun hx => unop_injective hx) (fun hy => unop_injective hy)
   (@eq_zero_or_eq_zero_of_mul_eq_zero α _ _ _ _ _ <| op_injective H)
 
-instance [Ring α] [IsDomain α] : IsDomain αᵃᵒᵖ :=
+instance isDomain [Ring α] [IsDomain α] : IsDomain αᵃᵒᵖ :=
   NoZeroDivisors.to_isDomain _
 
-instance [GroupWithZero α] : GroupWithZero αᵃᵒᵖ :=
-  { AddOpposite.instMonoidWithZeroAddOpposite α, AddOpposite.instDivInvMonoidAddOpposite α,
-    AddOpposite.instNontrivialAddOpposite α with
+instance groupWithZero [GroupWithZero α] : GroupWithZero αᵃᵒᵖ :=
+  { AddOpposite.monoidWithZero α, AddOpposite.divInvMonoid α,
+    AddOpposite.nontrivial α with
     mul_inv_cancel := fun _ hx => unop_injective <| mul_inv_cancel <| unop_injective.ne hx,
     inv_zero := unop_injective inv_zero }
 

--- a/Mathlib/Algebra/Ring/Opposite.lean
+++ b/Mathlib/Algebra/Ring/Opposite.lean
@@ -130,8 +130,8 @@ instance nonUnitalSemiring [NonUnitalSemiring α] : NonUnitalSemiring αᵃᵒ�
   { AddOpposite.semigroupWithZero α, AddOpposite.nonUnitalNonAssocSemiring α with }
 
 instance nonAssocSemiring [NonAssocSemiring α] : NonAssocSemiring αᵃᵒᵖ :=
-  { AddOpposite.instMulZeroOneClassAddOpposite α,
-    AddOpposite.instNonUnitalNonAssocSemiringAddOpposite α with }
+  { AddOpposite.mulZeroOneClass α,
+    AddOpposite.nonUnitalNonAssocSemiring α with }
 
 instance semiring [Semiring α] : Semiring αᵃᵒᵖ :=
   { AddOpposite.nonUnitalSemiring α, AddOpposite.nonAssocSemiring α,

--- a/Mathlib/Analysis/Normed/Field/Basic.lean
+++ b/Mathlib/Analysis/Normed/Field/Basic.lean
@@ -274,7 +274,7 @@ instance Pi.nonUnitalSeminormedRing {π : ι → Type _} [Fintype ι]
 #align pi.non_unital_semi_normed_ring Pi.nonUnitalSeminormedRing
 
 instance MulOpposite.nonUnitalSeminormedRing : NonUnitalSeminormedRing αᵐᵒᵖ :=
-  { MulOpposite.seminormedAddCommGroup, MulOpposite.instNonUnitalRingMulOpposite α with
+  { MulOpposite.seminormedAddCommGroup, MulOpposite.nonUnitalRing α with
     norm_mul :=
       MulOpposite.rec' fun x =>
         MulOpposite.rec' fun y => (norm_mul_le y x).trans_eq (mul_comm _ _) }
@@ -404,7 +404,7 @@ instance Pi.seminormedRing {π : ι → Type _} [Fintype ι] [∀ i, SeminormedR
 #align pi.semi_normed_ring Pi.seminormedRing
 
 instance MulOpposite.seminormedRing : SeminormedRing αᵐᵒᵖ :=
-  { MulOpposite.nonUnitalSeminormedRing, MulOpposite.instRingMulOpposite α with }
+  { MulOpposite.nonUnitalSeminormedRing, MulOpposite.ring α with }
 #align mul_opposite.semi_normed_ring MulOpposite.seminormedRing
 
 end SeminormedRing

--- a/Mathlib/GroupTheory/GroupAction/Opposite.lean
+++ b/Mathlib/GroupTheory/GroupAction/Opposite.lean
@@ -17,7 +17,7 @@ import Mathlib.GroupTheory.GroupAction.Defs
 This file defines the actions on the opposite type `SMul R Mᵐᵒᵖ`, and actions by the opposite
 type, `SMul Rᵐᵒᵖ M`.
 
-Note that `MulOpposite.instSMulMulOpposite` is provided in an earlier file as it is needed to
+Note that `MulOpposite.smul` is provided in an earlier file as it is needed to
 provide the `AddMonoid.nsmul` and `AddCommGroup.zsmul` fields.
 -/
 


### PR DESCRIPTION
Using explicit names makes it easier to refer to instances from docstrings and Zulip.

This probably isn't exhaustive, but does most of the algebra hierarchy.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

Split from #2940