### PR TITLE
[Merged by Bors] - feat: sync Data.Set.Intervals.OrdConnected

### DIFF
--- a/Mathlib/Data/Set/Intervals/OrdConnected.lean
+++ b/Mathlib/Data/Set/Intervals/OrdConnected.lean
@@ -4,12 +4,13 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury G. Kudryashov
 
 ! This file was ported from Lean 3 source module data.set.intervals.ord_connected
-! leanprover-community/mathlib commit 9003f28797c0664a49e4179487267c494477d853
+! leanprover-community/mathlib commit b19481deb571022990f1baa9cbf9172e6757a479
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
 import Mathlib.Data.Set.Intervals.UnorderedInterval
 import Mathlib.Data.Set.Lattice
+import Mathlib.Order.Antichain
 
 /-!
 # Order-connected sets
@@ -225,6 +226,19 @@ theorem dual_ordConnected {s : Set α} [OrdConnected s] : OrdConnected (ofDual �
 #align set.dual_ord_connected Set.dual_ordConnected
 
 end Preorder
+
+section PartialOrder
+
+variable {α : Type _} [PartialOrder α] {s : Set α}
+
+protected theorem IsAntichain.ordConnected (hs : IsAntichain (· ≤ ·) s) : s.OrdConnected :=
+  ⟨fun x hx y hy z hz => by
+    obtain rfl := hs.eq hx hy (hz.1.trans hz.2)
+    rw [Icc_self, mem_singleton_iff] at hz
+    rwa [hz]⟩
+#align set.is_antichain.ord_connected Set.IsAntichain.ordConnected
+
+end PartialOrder
 
 section LinearOrder
 

--- a/Mathlib/Data/Set/Intervals/OrdConnected.lean
+++ b/Mathlib/Data/Set/Intervals/OrdConnected.lean
@@ -231,12 +231,12 @@ section PartialOrder
 
 variable {α : Type _} [PartialOrder α] {s : Set α}
 
-protected theorem IsAntichain.ordConnected (hs : IsAntichain (· ≤ ·) s) : s.OrdConnected :=
+protected theorem _root_.IsAntichain.ordConnected (hs : IsAntichain (· ≤ ·) s) : s.OrdConnected :=
   ⟨fun x hx y hy z hz => by
     obtain rfl := hs.eq hx hy (hz.1.trans hz.2)
     rw [Icc_self, mem_singleton_iff] at hz
     rwa [hz]⟩
-#align set.is_antichain.ord_connected Set.IsAntichain.ordConnected
+#align is_antichain.ord_connected IsAntichain.ordConnected
 
 end PartialOrder
 


### PR DESCRIPTION
---

* [`data.set.intervals.ord_connected`@`9003f28797c0664a49e4179487267c494477d853`..`b19481deb571022990f1baa9cbf9172e6757a479`](https://leanprover-community.github.io/mathlib-port-status/file/data/set/intervals/ord_connected?range=9003f28797c0664a49e4179487267c494477d853..b19481deb571022990f1baa9cbf9172e6757a479)

This matches the way it is in mathlib3, but is it correct that the new statement is `Set.IsAntichain.ordConnected` instead of `IsAntichain.ordConnected`?

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
