### PR TITLE
[Merged by Bors] - feat: add regression test from leanprover-community/mathlib#18645

### DIFF
--- a/test/ring.lean
+++ b/test/ring.lean
@@ -122,3 +122,6 @@ example (a : Nat) : 1 * f a * 1 = f (a + 0) := by
   have ha : a + 0 = a := by ring
   rw [ha] -- goal has mdata
   ring1
+
+-- Powers in the exponent get evaluated correctly
+example (X : ℤ) : (X^5 + 1) * (X^2^3 + X) = X^13 + X^8 + X^6 + X := by ring


### PR DESCRIPTION
The bug is not present in the lean 4 version of the `ring` tactic, but we port the regression test anyway.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
