### PR TITLE
[Merged by Bors] - chore: fix align linebreaks

### DIFF
--- a/Mathlib/Algebra/CharZero/Quotient.lean
+++ b/Mathlib/Algebra/CharZero/Quotient.lean
@@ -50,8 +50,7 @@ theorem nsmul_mem_zmultiples_iff_exists_sub_div {r : R} {n : ℕ} (hn : n ≠ 0)
   rw [← coe_nat_zsmul r, zsmul_mem_zmultiples_iff_exists_sub_div (Int.coe_nat_ne_zero.mpr hn),
     Int.cast_ofNat]
   rfl
-#align add_subgroup.nsmul_mem_zmultiples_iff_exists_sub_div
-    AddSubgroup.nsmul_mem_zmultiples_iff_exists_sub_div
+#align add_subgroup.nsmul_mem_zmultiples_iff_exists_sub_div AddSubgroup.nsmul_mem_zmultiples_iff_exists_sub_div
 
 end AddSubgroup
 

--- a/Mathlib/CategoryTheory/Bicategory/Basic.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Basic.lean
@@ -214,8 +214,7 @@ theorem inv_hom_whiskerLeft (f : a ⟶ b) {g h : b ⟶ c} (η : g ≅ h) :
 @[reassoc (attr := simp)]
 theorem inv_hom_whiskerRight {f g : a ⟶ b} (η : f ≅ g) (h : b ⟶ c) :
     η.inv ▷ h ≫ η.hom ▷ h = 𝟙 (g ≫ h) := by rw [← comp_whiskerRight, inv_hom_id, id_whiskerRight]
-#align category_theory.bicategory.inv_hom_whisker_right
-  CategoryTheory.Bicategory.inv_hom_whiskerRight
+#align category_theory.bicategory.inv_hom_whisker_right CategoryTheory.Bicategory.inv_hom_whiskerRight
 
 /-- The left whiskering of a 2-isomorphism is a 2-isomorphism. -/
 @[simps]
@@ -246,8 +245,7 @@ def whiskerRightIso {f g : a ⟶ b} (η : f ≅ g) (h : b ⟶ c) : f ≫ h ≅ g
 
 instance whiskerRight_isIso {f g : a ⟶ b} (η : f ⟶ g) (h : b ⟶ c) [IsIso η] : IsIso (η ▷ h) :=
   IsIso.of_iso (whiskerRightIso (asIso η) h)
-#align category_theory.bicategory.whisker_right_is_iso
-  CategoryTheory.Bicategory.whiskerRight_isIso
+#align category_theory.bicategory.whisker_right_is_iso CategoryTheory.Bicategory.whiskerRight_isIso
 
 @[simp]
 theorem inv_whiskerRight {f g : a ⟶ b} (η : f ⟶ g) (h : b ⟶ c) [IsIso η] :
@@ -270,32 +268,28 @@ theorem pentagon_inv_inv_hom_hom_inv (f : a ⟶ b) (g : b ⟶ c) (h : c ⟶ d) (
   by
   rw [← cancel_epi (f ◁ (α_ g h i).inv), ← cancel_mono (α_ (f ≫ g) h i).inv]
   simp
-#align category_theory.bicategory.pentagon_inv_inv_hom_hom_inv
-  CategoryTheory.Bicategory.pentagon_inv_inv_hom_hom_inv
+#align category_theory.bicategory.pentagon_inv_inv_hom_hom_inv CategoryTheory.Bicategory.pentagon_inv_inv_hom_hom_inv
 
 @[reassoc (attr := simp)]
 theorem pentagon_inv_hom_hom_hom_inv (f : a ⟶ b) (g : b ⟶ c) (h : c ⟶ d) (i : d ⟶ e) :
     (α_ (f ≫ g) h i).inv ≫ (α_ f g h).hom ▷ i ≫ (α_ f (g ≫ h) i).hom =
       (α_ f g (h ≫ i)).hom ≫ f ◁ (α_ g h i).inv :=
   eq_of_inv_eq_inv (by simp)
-#align category_theory.bicategory.pentagon_inv_hom_hom_hom_inv
-  CategoryTheory.Bicategory.pentagon_inv_hom_hom_hom_inv
+#align category_theory.bicategory.pentagon_inv_hom_hom_hom_inv CategoryTheory.Bicategory.pentagon_inv_hom_hom_hom_inv
 
 @[reassoc (attr := simp)]
 theorem pentagon_hom_inv_inv_inv_inv (f : a ⟶ b) (g : b ⟶ c) (h : c ⟶ d) (i : d ⟶ e) :
     f ◁ (α_ g h i).hom ≫ (α_ f g (h ≫ i)).inv ≫ (α_ (f ≫ g) h i).inv =
       (α_ f (g ≫ h) i).inv ≫ (α_ f g h).inv ▷ i :=
   by simp [← cancel_epi (f ◁ (α_ g h i).inv)]
-#align category_theory.bicategory.pentagon_hom_inv_inv_inv_inv
-  CategoryTheory.Bicategory.pentagon_hom_inv_inv_inv_inv
+#align category_theory.bicategory.pentagon_hom_inv_inv_inv_inv CategoryTheory.Bicategory.pentagon_hom_inv_inv_inv_inv
 
 @[reassoc (attr := simp)]
 theorem pentagon_hom_hom_inv_hom_hom (f : a ⟶ b) (g : b ⟶ c) (h : c ⟶ d) (i : d ⟶ e) :
     (α_ (f ≫ g) h i).hom ≫ (α_ f g (h ≫ i)).hom ≫ f ◁ (α_ g h i).inv =
       (α_ f g h).hom ▷ i ≫ (α_ f (g ≫ h) i).hom :=
   eq_of_inv_eq_inv (by simp)
-#align category_theory.bicategory.pentagon_hom_hom_inv_hom_hom
-  CategoryTheory.Bicategory.pentagon_hom_hom_inv_hom_hom
+#align category_theory.bicategory.pentagon_hom_hom_inv_hom_hom CategoryTheory.Bicategory.pentagon_hom_hom_inv_hom_hom
 
 @[reassoc (attr := simp)]
 theorem pentagon_hom_inv_inv_inv_hom (f : a ⟶ b) (g : b ⟶ c) (h : c ⟶ d) (i : d ⟶ e) :
@@ -304,44 +298,38 @@ theorem pentagon_hom_inv_inv_inv_hom (f : a ⟶ b) (g : b ⟶ c) (h : c ⟶ d) (
   by
   rw [← cancel_epi (α_ f g (h ≫ i)).inv, ← cancel_mono ((α_ f g h).inv ▷ i)]
   simp
-#align category_theory.bicategory.pentagon_hom_inv_inv_inv_hom
-  CategoryTheory.Bicategory.pentagon_hom_inv_inv_inv_hom
+#align category_theory.bicategory.pentagon_hom_inv_inv_inv_hom CategoryTheory.Bicategory.pentagon_hom_inv_inv_inv_hom
 
 @[reassoc (attr := simp)]
 theorem pentagon_hom_hom_inv_inv_hom (f : a ⟶ b) (g : b ⟶ c) (h : c ⟶ d) (i : d ⟶ e) :
     (α_ f (g ≫ h) i).hom ≫ f ◁ (α_ g h i).hom ≫ (α_ f g (h ≫ i)).inv =
       (α_ f g h).inv ▷ i ≫ (α_ (f ≫ g) h i).hom :=
   eq_of_inv_eq_inv (by simp)
-#align category_theory.bicategory.pentagon_hom_hom_inv_inv_hom
-  CategoryTheory.Bicategory.pentagon_hom_hom_inv_inv_hom
+#align category_theory.bicategory.pentagon_hom_hom_inv_inv_hom CategoryTheory.Bicategory.pentagon_hom_hom_inv_inv_hom
 
 @[reassoc (attr := simp)]
 theorem pentagon_inv_hom_hom_hom_hom (f : a ⟶ b) (g : b ⟶ c) (h : c ⟶ d) (i : d ⟶ e) :
     (α_ f g h).inv ▷ i ≫ (α_ (f ≫ g) h i).hom ≫ (α_ f g (h ≫ i)).hom =
       (α_ f (g ≫ h) i).hom ≫ f ◁ (α_ g h i).hom :=
   by simp [← cancel_epi ((α_ f g h).hom ▷ i)]
-#align category_theory.bicategory.pentagon_inv_hom_hom_hom_hom
-  CategoryTheory.Bicategory.pentagon_inv_hom_hom_hom_hom
+#align category_theory.bicategory.pentagon_inv_hom_hom_hom_hom CategoryTheory.Bicategory.pentagon_inv_hom_hom_hom_hom
 
 @[reassoc (attr := simp)]
 theorem pentagon_inv_inv_hom_inv_inv (f : a ⟶ b) (g : b ⟶ c) (h : c ⟶ d) (i : d ⟶ e) :
     (α_ f g (h ≫ i)).inv ≫ (α_ (f ≫ g) h i).inv ≫ (α_ f g h).hom ▷ i =
       f ◁ (α_ g h i).inv ≫ (α_ f (g ≫ h) i).inv :=
   eq_of_inv_eq_inv (by simp)
-#align category_theory.bicategory.pentagon_inv_inv_hom_inv_inv
-  CategoryTheory.Bicategory.pentagon_inv_inv_hom_inv_inv
+#align category_theory.bicategory.pentagon_inv_inv_hom_inv_inv CategoryTheory.Bicategory.pentagon_inv_inv_hom_inv_inv
 
 theorem triangle_assoc_comp_left (f : a ⟶ b) (g : b ⟶ c) :
     (α_ f (𝟙 b) g).hom ≫ f ◁ (λ_ g).hom = (ρ_ f).hom ▷ g :=
   triangle f g
-#align category_theory.bicategory.triangle_assoc_comp_left
-  CategoryTheory.Bicategory.triangle_assoc_comp_left
+#align category_theory.bicategory.triangle_assoc_comp_left CategoryTheory.Bicategory.triangle_assoc_comp_left
 
 @[reassoc (attr := simp)]
 theorem triangle_assoc_comp_right (f : a ⟶ b) (g : b ⟶ c) :
     (α_ f (𝟙 b) g).inv ≫ (ρ_ f).hom ▷ g = f ◁ (λ_ g).hom := by rw [← triangle, inv_hom_id_assoc]
-#align category_theory.bicategory.triangle_assoc_comp_right
-  CategoryTheory.Bicategory.triangle_assoc_comp_right
+#align category_theory.bicategory.triangle_assoc_comp_right CategoryTheory.Bicategory.triangle_assoc_comp_right
 
 @[reassoc (attr := simp)]
 theorem triangle_assoc_comp_right_inv (f : a ⟶ b) (g : b ⟶ c) :
@@ -354,62 +342,52 @@ theorem triangle_assoc_comp_right_inv (f : a ⟶ b) (g : b ⟶ c) :
 theorem triangle_assoc_comp_left_inv (f : a ⟶ b) (g : b ⟶ c) :
     f ◁ (λ_ g).inv ≫ (α_ f (𝟙 b) g).inv = (ρ_ f).inv ▷ g := by
   simp [← cancel_mono ((ρ_ f).hom ▷ g)]
-#align category_theory.bicategory.triangle_assoc_comp_left_inv
-  CategoryTheory.Bicategory.triangle_assoc_comp_left_inv
+#align category_theory.bicategory.triangle_assoc_comp_left_inv CategoryTheory.Bicategory.triangle_assoc_comp_left_inv
 
 @[reassoc]
 theorem associator_naturality_left {f f' : a ⟶ b} (η : f ⟶ f') (g : b ⟶ c) (h : c ⟶ d) :
     η ▷ g ▷ h ≫ (α_ f' g h).hom = (α_ f g h).hom ≫ η ▷ (g ≫ h) := by simp
-#align category_theory.bicategory.associator_naturality_left
-  CategoryTheory.Bicategory.associator_naturality_left
+#align category_theory.bicategory.associator_naturality_left CategoryTheory.Bicategory.associator_naturality_left
 
 @[reassoc]
 theorem associator_inv_naturality_left {f f' : a ⟶ b} (η : f ⟶ f') (g : b ⟶ c) (h : c ⟶ d) :
     η ▷ (g ≫ h) ≫ (α_ f' g h).inv = (α_ f g h).inv ≫ η ▷ g ▷ h := by simp
-#align category_theory.bicategory.associator_inv_naturality_left
-  CategoryTheory.Bicategory.associator_inv_naturality_left
+#align category_theory.bicategory.associator_inv_naturality_left CategoryTheory.Bicategory.associator_inv_naturality_left
 
 @[reassoc]
 theorem whiskerRight_comp_symm {f f' : a ⟶ b} (η : f ⟶ f') (g : b ⟶ c) (h : c ⟶ d) :
     η ▷ g ▷ h = (α_ f g h).hom ≫ η ▷ (g ≫ h) ≫ (α_ f' g h).inv := by simp
-#align category_theory.bicategory.whisker_right_comp_symm
-  CategoryTheory.Bicategory.whiskerRight_comp_symm
+#align category_theory.bicategory.whisker_right_comp_symm CategoryTheory.Bicategory.whiskerRight_comp_symm
 
 @[reassoc]
 theorem associator_naturality_middle (f : a ⟶ b) {g g' : b ⟶ c} (η : g ⟶ g') (h : c ⟶ d) :
     (f ◁ η) ▷ h ≫ (α_ f g' h).hom = (α_ f g h).hom ≫ f ◁ η ▷ h := by simp
-#align category_theory.bicategory.associator_naturality_middle
-  CategoryTheory.Bicategory.associator_naturality_middle
+#align category_theory.bicategory.associator_naturality_middle CategoryTheory.Bicategory.associator_naturality_middle
 
 @[reassoc]
 theorem associator_inv_naturality_middle (f : a ⟶ b) {g g' : b ⟶ c} (η : g ⟶ g') (h : c ⟶ d) :
     f ◁ η ▷ h ≫ (α_ f g' h).inv = (α_ f g h).inv ≫ (f ◁ η) ▷ h := by simp
-#align category_theory.bicategory.associator_inv_naturality_middle
-  CategoryTheory.Bicategory.associator_inv_naturality_middle
+#align category_theory.bicategory.associator_inv_naturality_middle CategoryTheory.Bicategory.associator_inv_naturality_middle
 
 @[reassoc]
 theorem whisker_assoc_symm (f : a ⟶ b) {g g' : b ⟶ c} (η : g ⟶ g') (h : c ⟶ d) :
     f ◁ η ▷ h = (α_ f g h).inv ≫ (f ◁ η) ▷ h ≫ (α_ f g' h).hom := by simp
-#align category_theory.bicategory.whisker_assoc_symm
-  CategoryTheory.Bicategory.whisker_assoc_symm
+#align category_theory.bicategory.whisker_assoc_symm CategoryTheory.Bicategory.whisker_assoc_symm
 
 @[reassoc]
 theorem associator_naturality_right (f : a ⟶ b) (g : b ⟶ c) {h h' : c ⟶ d} (η : h ⟶ h') :
     (f ≫ g) ◁ η ≫ (α_ f g h').hom = (α_ f g h).hom ≫ f ◁ g ◁ η := by simp
-#align category_theory.bicategory.associator_naturality_right
-  CategoryTheory.Bicategory.associator_naturality_right
+#align category_theory.bicategory.associator_naturality_right CategoryTheory.Bicategory.associator_naturality_right
 
 @[reassoc]
 theorem associator_inv_naturality_right (f : a ⟶ b) (g : b ⟶ c) {h h' : c ⟶ d} (η : h ⟶ h') :
     f ◁ g ◁ η ≫ (α_ f g h').inv = (α_ f g h).inv ≫ (f ≫ g) ◁ η := by simp
-#align category_theory.bicategory.associator_inv_naturality_right
-  CategoryTheory.Bicategory.associator_inv_naturality_right
+#align category_theory.bicategory.associator_inv_naturality_right CategoryTheory.Bicategory.associator_inv_naturality_right
 
 @[reassoc]
 theorem comp_whiskerLeft_symm (f : a ⟶ b) (g : b ⟶ c) {h h' : c ⟶ d} (η : h ⟶ h') :
     f ◁ g ◁ η = (α_ f g h).inv ≫ (f ≫ g) ◁ η ≫ (α_ f g h').hom := by simp
-#align category_theory.bicategory.comp_whisker_left_symm
-  CategoryTheory.Bicategory.comp_whiskerLeft_symm
+#align category_theory.bicategory.comp_whisker_left_symm CategoryTheory.Bicategory.comp_whiskerLeft_symm
 
 @[reassoc]
 theorem leftUnitor_naturality {f g : a ⟶ b} (η : f ⟶ g) :

--- a/Mathlib/CategoryTheory/Bicategory/Functor.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Functor.lean
@@ -198,14 +198,10 @@ structure OplaxFunctor (B : Type u₁) [Bicategory.{w₁, v₁} B] (C : Type u�
 #align category_theory.oplax_functor CategoryTheory.OplaxFunctor
 #align category_theory.oplax_functor.map_id CategoryTheory.OplaxFunctor.mapId
 #align category_theory.oplax_functor.map_comp CategoryTheory.OplaxFunctor.mapComp
-#align category_theory.oplax_functor.map_comp_naturality_left'
-  CategoryTheory.OplaxFunctor.mapComp_naturality_left
-#align category_theory.oplax_functor.map_comp_naturality_left
-  CategoryTheory.OplaxFunctor.mapComp_naturality_left
-#align category_theory.oplax_functor.map_comp_naturality_right'
-  CategoryTheory.OplaxFunctor.mapComp_naturality_right
-#align category_theory.oplax_functor.map_comp_naturality_right
-  CategoryTheory.OplaxFunctor.mapComp_naturality_right
+#align category_theory.oplax_functor.map_comp_naturality_left' CategoryTheory.OplaxFunctor.mapComp_naturality_left
+#align category_theory.oplax_functor.map_comp_naturality_left CategoryTheory.OplaxFunctor.mapComp_naturality_left
+#align category_theory.oplax_functor.map_comp_naturality_right' CategoryTheory.OplaxFunctor.mapComp_naturality_right
+#align category_theory.oplax_functor.map_comp_naturality_right CategoryTheory.OplaxFunctor.mapComp_naturality_right
 #align category_theory.oplax_functor.map₂_id' CategoryTheory.OplaxFunctor.map₂_id
 #align category_theory.oplax_functor.map₂_comp' CategoryTheory.OplaxFunctor.map₂_comp
 #align category_theory.oplax_functor.map₂_associator' CategoryTheory.OplaxFunctor.map₂_associator
@@ -438,8 +434,7 @@ attribute [nolint docBlame] CategoryTheory.Pseudofunctor.mapId
 
 instance hasCoeToPrelaxFunctor : Coe (Pseudofunctor B C) (PrelaxFunctor B C) :=
   ⟨toPrelaxFunctor⟩
-#align category_theory.pseudofunctor.has_coe_to_prelax_functor
-  CategoryTheory.Pseudofunctor.hasCoeToPrelaxFunctor
+#align category_theory.pseudofunctor.has_coe_to_prelax_functor CategoryTheory.Pseudofunctor.hasCoeToPrelaxFunctor
 
 variable (F : Pseudofunctor B C)
 

--- a/Mathlib/CategoryTheory/EssentiallySmall.lean
+++ b/Mathlib/CategoryTheory/EssentiallySmall.lean
@@ -82,8 +82,7 @@ theorem essentiallySmall_congr {C : Type u} [Category.{v} C] {D : Type u'} [Cate
 theorem Discrete.essentiallySmallOfSmall {α : Type u} [Small.{w} α] :
     EssentiallySmall.{w} (Discrete α) :=
   ⟨⟨Discrete (Shrink α), ⟨inferInstance, ⟨Discrete.equivalence (equivShrink _)⟩⟩⟩⟩
-#align category_theory.discrete.essentially_small_of_small
-  CategoryTheory.Discrete.essentiallySmallOfSmall
+#align category_theory.discrete.essentially_small_of_small CategoryTheory.Discrete.essentiallySmallOfSmall
 
 theorem essentiallySmallSelf : EssentiallySmall.{max w v u} C :=
   EssentiallySmall.mk' (AsSmall.equiv : C ≌ AsSmall.{w} C)

--- a/Mathlib/CategoryTheory/Limits/ConeCategory.lean
+++ b/Mathlib/CategoryTheory/Limits/ConeCategory.lean
@@ -48,8 +48,7 @@ def Cone.toCostructuredArrow (F : J ⥤ C) : Cone F ⥤ CostructuredArrow (const
     CostructuredArrow.homMk f.Hom <| by
       ext
       simp
-#align category_theory.limits.cone.to_costructured_arrow
-  CategoryTheory.Limits.Cone.toCostructuredArrow
+#align category_theory.limits.cone.to_costructured_arrow CategoryTheory.Limits.Cone.toCostructuredArrow
 
 /-- Construct a cone on `F` from an object of the category `(Δ ↓ F)`. This is part of an
     equivalence, see `Cone.equivCostructuredArrow`. -/
@@ -98,8 +97,7 @@ theorem hasLimit_iff_hasTerminal_cone (F : J ⥤ C) : HasLimit F ↔ HasTerminal
   ⟨fun _ => (Cone.isLimitEquivIsTerminal _ (limit.isLimit F)).hasTerminal, fun h =>
     haveI : HasTerminal (Cone F) := h
     ⟨⟨⟨⊤_ _, (Cone.isLimitEquivIsTerminal _).symm terminalIsTerminal⟩⟩⟩⟩
-#align category_theory.limits.has_limit_iff_has_terminal_cone
-  CategoryTheory.Limits.hasLimit_iff_hasTerminal_cone
+#align category_theory.limits.has_limit_iff_has_terminal_cone CategoryTheory.Limits.hasLimit_iff_hasTerminal_cone
 
 theorem hasLimitsOfShape_iff_isLeftAdjoint_const :
     HasLimitsOfShape J C ↔ Nonempty (IsLeftAdjoint (const J : C ⥤ _)) :=
@@ -112,14 +110,12 @@ theorem hasLimitsOfShape_iff_isLeftAdjoint_const :
     _ ↔ Nonempty (IsLeftAdjoint (const J : C ⥤ _)) :=
       nonempty_isLeftAdjoint_iff_hasTerminal_costructuredArrow.symm
 
-#align category_theory.limits.has_limits_of_shape_iff_is_left_adjoint_const
-  CategoryTheory.Limits.hasLimitsOfShape_iff_isLeftAdjoint_const
+#align category_theory.limits.has_limits_of_shape_iff_is_left_adjoint_const CategoryTheory.Limits.hasLimitsOfShape_iff_isLeftAdjoint_const
 
 theorem IsLimit.liftConeMorphism_eq_isTerminal_from {F : J ⥤ C} {c : Cone F} (hc : IsLimit c)
     (s : Cone F) : hc.liftConeMorphism s = IsTerminal.from (Cone.isLimitEquivIsTerminal _ hc) _ :=
   rfl
-#align category_theory.limits.is_limit.lift_cone_morphism_eq_is_terminal_from
-  CategoryTheory.Limits.IsLimit.liftConeMorphism_eq_isTerminal_from
+#align category_theory.limits.is_limit.lift_cone_morphism_eq_is_terminal_from CategoryTheory.Limits.IsLimit.liftConeMorphism_eq_isTerminal_from
 
 theorem IsTerminal.from_eq_liftConeMorphism {F : J ⥤ C} {c : Cone F} (hc : IsTerminal c)
     (s : Cone F) :
@@ -132,8 +128,7 @@ theorem IsTerminal.from_eq_liftConeMorphism {F : J ⥤ C} {c : Cone F} (hc : IsT
 def IsLimit.ofPreservesConeTerminal {F : J ⥤ C} {F' : K ⥤ D} (G : Cone F ⥤ Cone F')
     [PreservesLimit (Functor.empty.{0} _) G] {c : Cone F} (hc : IsLimit c) : IsLimit (G.obj c) :=
   (Cone.isLimitEquivIsTerminal _).symm <| (Cone.isLimitEquivIsTerminal _ hc).isTerminalObj _ _
-#align category_theory.limits.is_limit.of_preserves_cone_terminal
-  CategoryTheory.Limits.IsLimit.ofPreservesConeTerminal
+#align category_theory.limits.is_limit.of_preserves_cone_terminal CategoryTheory.Limits.IsLimit.ofPreservesConeTerminal
 
 /-- If `G : Cone F ⥤ Cone F'` reflects terminal objects, it reflects limit cones. -/
 def IsLimit.ofReflectsConeTerminal {F : J ⥤ C} {F' : K ⥤ D} (G : Cone F ⥤ Cone F')
@@ -152,8 +147,7 @@ def Cocone.toStructuredArrow (F : J ⥤ C) : Cocone F ⥤ StructuredArrow F (con
     StructuredArrow.homMk f.Hom <| by
       ext
       simp
-#align category_theory.limits.cocone.to_structured_arrow
-  CategoryTheory.Limits.Cocone.toStructuredArrow
+#align category_theory.limits.cocone.to_structured_arrow CategoryTheory.Limits.Cocone.toStructuredArrow
 
 /-- Construct a cocone on `F` from an object of the category `(F ↓ Δ)`. This is part of an
     equivalence, see `Cocone.equivStructuredArrow`. -/
@@ -178,8 +172,7 @@ def Cocone.equivStructuredArrow (F : J ⥤ C) : Cocone F ≌ StructuredArrow F (
     (NatIso.ofComponents Cocones.eta (by aesop_cat))
     (NatIso.ofComponents (fun c => (StructuredArrow.eta _).symm)
       (by intros ; apply StructuredArrow.ext ; aesop_cat))
-#align category_theory.limits.cocone.equiv_structured_arrow
-  CategoryTheory.Limits.Cocone.equivStructuredArrow
+#align category_theory.limits.cocone.equiv_structured_arrow CategoryTheory.Limits.Cocone.equivStructuredArrow
 
 /-- A cocone is a colimit cocone iff it is initial. -/
 def Cocone.isColimitEquivIsInitial {F : J ⥤ C} (c : Cocone F) : IsColimit c ≃ IsInitial c :=
@@ -188,8 +181,7 @@ def Cocone.isColimitEquivIsInitial {F : J ⥤ C} (c : Cocone F) : IsColimit c �
       invFun := fun h s => ⟨⟨IsInitial.to h s⟩, fun a => IsInitial.hom_ext h a _⟩
       left_inv := by aesop_cat
       right_inv := by aesop_cat }
-#align category_theory.limits.cocone.is_colimit_equiv_is_initial
-  CategoryTheory.Limits.Cocone.isColimitEquivIsInitial
+#align category_theory.limits.cocone.is_colimit_equiv_is_initial CategoryTheory.Limits.Cocone.isColimitEquivIsInitial
 
 theorem hasColimit_iff_hasInitial_cocone (F : J ⥤ C) : HasColimit F ↔ HasInitial (Cocone F) :=
   ⟨fun _ => (Cocone.isColimitEquivIsInitial _ (colimit.isColimit F)).hasInitial, fun h =>
@@ -216,8 +208,7 @@ theorem IsColimit.descCoconeMorphism_eq_isInitial_to {F : J ⥤ C} {c : Cocone F
     (s : Cocone F) :
     hc.descCoconeMorphism s = IsInitial.to (Cocone.isColimitEquivIsInitial _ hc) _ :=
   rfl
-#align category_theory.limits.is_colimit.desc_cocone_morphism_eq_is_initial_to
-  CategoryTheory.Limits.IsColimit.descCoconeMorphism_eq_isInitial_to
+#align category_theory.limits.is_colimit.desc_cocone_morphism_eq_is_initial_to CategoryTheory.Limits.IsColimit.descCoconeMorphism_eq_isInitial_to
 
 theorem IsInitial.to_eq_descCoconeMorphism {F : J ⥤ C} {c : Cocone F} (hc : IsInitial c)
     (s : Cocone F) :
@@ -240,7 +231,6 @@ def IsColimit.ofReflectsCoconeInitial {F : J ⥤ C} {F' : K ⥤ D} (G : Cocone F
     IsColimit c :=
   (Cocone.isColimitEquivIsInitial _).symm <|
     (Cocone.isColimitEquivIsInitial _ hc).isInitialOfObj _ _
-#align category_theory.limits.is_colimit.of_reflects_cocone_initial
-  CategoryTheory.Limits.IsColimit.ofReflectsCoconeInitial
+#align category_theory.limits.is_colimit.of_reflects_cocone_initial CategoryTheory.Limits.IsColimit.ofReflectsCoconeInitial
 
 end CategoryTheory.Limits

--- a/Mathlib/Combinatorics/Composition.lean
+++ b/Mathlib/Combinatorics/Composition.lean
@@ -896,8 +896,7 @@ def length : ℕ :=
 
 theorem card_boundaries_eq_succ_length : c.boundaries.card = c.length + 1 :=
   (tsub_eq_iff_eq_add_of_le (Nat.succ_le_of_lt c.card_boundaries_pos)).mp rfl
-#align composition_as_set.card_boundaries_eq_succ_length
-  CompositionAsSet.card_boundaries_eq_succ_length
+#align composition_as_set.card_boundaries_eq_succ_length CompositionAsSet.card_boundaries_eq_succ_length
 
 theorem length_lt_card_boundaries : c.length < c.boundaries.card := by
   rw [c.card_boundaries_eq_succ_length]

--- a/Mathlib/Combinatorics/DoubleCounting.lean
+++ b/Mathlib/Combinatorics/DoubleCounting.lean
@@ -84,8 +84,7 @@ theorem sum_card_bipartiteAbove_eq_sum_card_bipartiteBelow [∀ a b, Decidable (
     (∑ a in s, (t.bipartiteAbove r a).card) = ∑ b in t, (s.bipartiteBelow r b).card := by
   simp_rw [card_eq_sum_ones, bipartiteAbove, bipartiteBelow, sum_filter]
   exact sum_comm
-#align finset.sum_card_bipartite_above_eq_sum_card_bipartite_below
-  Finset.sum_card_bipartiteAbove_eq_sum_card_bipartiteBelow
+#align finset.sum_card_bipartite_above_eq_sum_card_bipartite_below Finset.sum_card_bipartiteAbove_eq_sum_card_bipartiteBelow
 
 /-- Double counting argument. Considering `r` as a bipartite graph, the LHS is a lower bound on the
 number of edges while the RHS is an upper bound. -/

--- a/Mathlib/Combinatorics/SetFamily/LYM.lean
+++ b/Mathlib/Combinatorics/SetFamily/LYM.lean
@@ -180,8 +180,7 @@ theorem IsAntichain.disjoint_slice_shadow_falling {m n : ℕ}
     refine' h𝒜 (slice_subset h₂) ht _ ((erase_subset _ _).trans hst)
     rintro rfl
     exact not_mem_erase _ _ (hst ha)
-#align finset.is_antichain.disjoint_slice_shadow_falling
-    Finset.IsAntichain.disjoint_slice_shadow_falling
+#align finset.is_antichain.disjoint_slice_shadow_falling Finset.IsAntichain.disjoint_slice_shadow_falling
 
 /-- A bound on any top part of the sum in LYM in terms of the size of `falling k 𝒜`. -/
 theorem le_card_falling_div_choose [Fintype α] (hk : k ≤ Fintype.card α)

--- a/Mathlib/GroupTheory/Coset.lean
+++ b/Mathlib/GroupTheory/Coset.lean
@@ -400,8 +400,7 @@ theorem rightRel_r_eq_rightCosetEquivalence :
   ext
   rw [rightRel_eq]
   exact (rightCoset_eq_iff s).symm
-#align quotient_group.right_rel_r_eq_right_coset_equivalence
-  QuotientGroup.rightRel_r_eq_rightCosetEquivalence
+#align quotient_group.right_rel_r_eq_right_coset_equivalence QuotientGroup.rightRel_r_eq_rightCosetEquivalence
 
 @[to_additive]
 instance rightRelDecidable [DecidablePred (· ∈ s)] : DecidableRel (rightRel s).r := fun x y => by
@@ -438,10 +437,8 @@ def quotientRightRelEquivQuotientLeftRel : Quotient (QuotientGroup.rightRel s) �
         (by
           simp only [inv_inv]
           exact Quotient.exact' rfl)
-#align quotient_group.quotient_right_rel_equiv_quotient_left_rel
-  QuotientGroup.quotientRightRelEquivQuotientLeftRel
-#align quotient_add_group.quotient_right_rel_equiv_quotient_left_rel
-  QuotientAddGroup.quotientRightRelEquivQuotientLeftRel
+#align quotient_group.quotient_right_rel_equiv_quotient_left_rel QuotientGroup.quotientRightRelEquivQuotientLeftRel
+#align quotient_add_group.quotient_right_rel_equiv_quotient_left_rel QuotientAddGroup.quotientRightRelEquivQuotientLeftRel
 
 @[to_additive]
 instance fintypeQuotientRightRel [Fintype (α ⧸ s)] :
@@ -702,8 +699,7 @@ def quotientSubgroupOfEmbeddingOfLe (H : Subgroup α) (h : s ≤ t) :
       intro a b h
       simpa only [Quotient.map'_mk'', eq'] using h
 #align subgroup.quotient_subgroup_of_embedding_of_le Subgroup.quotientSubgroupOfEmbeddingOfLe
-#align add_subgroup.quotient_add_subgroup_of_embedding_of_le
-  AddSubgroup.quotientAddSubgroupOfEmbeddingOfLe
+#align add_subgroup.quotient_add_subgroup_of_embedding_of_le AddSubgroup.quotientAddSubgroupOfEmbeddingOfLe
 
 -- porting note: I had to add the type ascription to the right-hand side or else Lean times out.
 @[to_additive (attr := simp)]
@@ -712,10 +708,8 @@ theorem quotientSubgroupOfEmbeddingOfLe_apply_mk (H : Subgroup α) (h : s ≤ t)
       (QuotientGroup.mk (inclusion h g) : (fun _ => { x // x ∈ t } ⧸ subgroupOf H t) ↑g) :=
   rfl
 
-#align subgroup.quotient_subgroup_of_embedding_of_le_apply_mk
-  Subgroup.quotientSubgroupOfEmbeddingOfLe_apply_mk
-#align add_subgroup.quotient_add_subgroup_of_embedding_of_le_apply_mk
-  AddSubgroup.quotientAddSubgroupOfEmbeddingOfLe_apply_mk
+#align subgroup.quotient_subgroup_of_embedding_of_le_apply_mk Subgroup.quotientSubgroupOfEmbeddingOfLe_apply_mk
+#align add_subgroup.quotient_add_subgroup_of_embedding_of_le_apply_mk AddSubgroup.quotientAddSubgroupOfEmbeddingOfLe_apply_mk
 
 /-- If `s ≤ t`, then there is a map `H ⧸ s.subgroupOf H → H ⧸ t.subgroupOf H`. -/
 @[to_additive "If `s ≤ t`, then there is an map `H ⧸ s.addSubgroupOf H → H ⧸ t.addSubgroupOf H`."]
@@ -766,8 +760,7 @@ def quotientInfᵢSubgroupOfEmbedding {ι : Type _} (f : ι → Subgroup α) (H 
       simp_rw [funext_iff, quotientSubgroupOfMapOfLe_apply_mk, eq', mem_subgroupOf, mem_infᵢ,
         imp_self, forall_const]
 #align subgroup.quotient_infi_subgroup_of_embedding Subgroup.quotientInfᵢSubgroupOfEmbedding
-#align add_subgroup.quotient_infi_add_subgroup_of_embedding
-  AddSubgroup.quotientInfᵢAddSubgroupOfEmbedding
+#align add_subgroup.quotient_infi_add_subgroup_of_embedding AddSubgroup.quotientInfᵢAddSubgroupOfEmbedding
 
 -- porting note: I had to add the type ascription to the right-hand side or else Lean times out.
 @[to_additive (attr := simp)]
@@ -776,10 +769,8 @@ theorem quotientInfᵢSubgroupOfEmbedding_apply_mk {ι : Type _} (f : ι → Sub
     quotientInfᵢSubgroupOfEmbedding f H (QuotientGroup.mk g) i =
       (QuotientGroup.mk g : { x // x ∈ H } ⧸ subgroupOf (f i) H) :=
   rfl
-#align subgroup.quotient_infi_subgroup_of_embedding_apply_mk
-  Subgroup.quotientInfᵢSubgroupOfEmbedding_apply_mk
-#align add_subgroup.quotient_infi_add_subgroup_of_embedding_apply_mk
-  AddSubgroup.quotientInfᵢAddSubgroupOfEmbedding_apply_mk
+#align subgroup.quotient_infi_subgroup_of_embedding_apply_mk Subgroup.quotientInfᵢSubgroupOfEmbedding_apply_mk
+#align add_subgroup.quotient_infi_add_subgroup_of_embedding_apply_mk AddSubgroup.quotientInfᵢAddSubgroupOfEmbedding_apply_mk
 
 /-- The natural embedding `α ⧸ (⨅ i, f i) ↪ Π i, α ⧸ f i`. -/
 @[to_additive (attr := simps) "The natural embedding `α ⧸ (⨅ i, f i) ↪ Π i, α ⧸ f i`."]

--- a/Mathlib/GroupTheory/MonoidLocalization.lean
+++ b/Mathlib/GroupTheory/MonoidLocalization.lean
@@ -746,8 +746,7 @@ theorem eq_mk'_iff_mul_eq {x} {y : S} {z} : z = f.mk' x y ↔ z * f.toMap y = f.
 theorem mk'_eq_iff_eq_mul {x} {y : S} {z} : f.mk' x y = z ↔ f.toMap x = z * f.toMap y := by
   rw [eq_comm, eq_mk'_iff_mul_eq, eq_comm]
 #align submonoid.localization_map.mk'_eq_iff_eq_mul Submonoid.LocalizationMap.mk'_eq_iff_eq_mul
-#align add_submonoid.localization_map.mk'_eq_iff_eq_add
-  AddSubmonoid.LocalizationMap.mk'_eq_iff_eq_add
+#align add_submonoid.localization_map.mk'_eq_iff_eq_add AddSubmonoid.LocalizationMap.mk'_eq_iff_eq_add
 
 @[to_additive]
 theorem mk'_eq_iff_eq {x₁ x₂} {y₁ y₂ : S} :
@@ -794,8 +793,7 @@ theorem mk'_eq_iff_mk'_eq (g : LocalizationMap S P) {x₁ x₂} {y₁ y₂ : S} 
     f.mk' x₁ y₁ = f.mk' x₂ y₂ ↔ g.mk' x₁ y₁ = g.mk' x₂ y₂ :=
   f.eq'.trans g.eq'.symm
 #align submonoid.localization_map.mk'_eq_iff_mk'_eq Submonoid.LocalizationMap.mk'_eq_iff_mk'_eq
-#align add_submonoid.localization_map.mk'_eq_iff_mk'_eq
-  AddSubmonoid.LocalizationMap.mk'_eq_iff_mk'_eq
+#align add_submonoid.localization_map.mk'_eq_iff_mk'_eq AddSubmonoid.LocalizationMap.mk'_eq_iff_mk'_eq
 
 /-- Given a Localization map `f : M →* N` for a Submonoid `S ⊆ M`, for all `x₁ : M` and `y₁ ∈ S`,
 if `x₂ : M, y₂ ∈ S` are such that `f x₁ * (f y₁)⁻¹ * f y₂ = f x₂`, then there exists `c ∈ S`
@@ -808,8 +806,7 @@ theorem exists_of_sec_mk' (x) (y : S) :
     ∃ c : S, ↑c * (↑(f.sec <| f.mk' x y).2 * x) = c * (y * (f.sec <| f.mk' x y).1) :=
   f.eq_iff_exists.1 <| f.mk'_eq_iff_eq.1 <| (mk'_sec _ _).symm
 #align submonoid.localization_map.exists_of_sec_mk' Submonoid.LocalizationMap.exists_of_sec_mk'
-#align add_submonoid.localization_map.exists_of_sec_mk'
-  AddSubmonoid.LocalizationMap.exists_of_sec_mk'
+#align add_submonoid.localization_map.exists_of_sec_mk' AddSubmonoid.LocalizationMap.exists_of_sec_mk'
 
 @[to_additive]
 theorem mk'_eq_of_eq {a₁ b₁ : M} {a₂ b₂ : S} (H : ↑a₂ * b₁ = ↑b₂ * a₁) :
@@ -856,16 +853,13 @@ theorem mk'_mul_eq_mk'_of_mul (x₁ x₂) (y : S) : f.mk' x₂ y * f.toMap x₁ 
 theorem mul_mk'_one_eq_mk' (x) (y : S) : f.toMap x * f.mk' 1 y = f.mk' x y := by
   rw [mul_mk'_eq_mk'_of_mul, mul_one]
 #align submonoid.localization_map.mul_mk'_one_eq_mk' Submonoid.LocalizationMap.mul_mk'_one_eq_mk'
-#align add_submonoid.localization_map.add_mk'_zero_eq_mk'
-  AddSubmonoid.LocalizationMap.add_mk'_zero_eq_mk'
+#align add_submonoid.localization_map.add_mk'_zero_eq_mk' AddSubmonoid.LocalizationMap.add_mk'_zero_eq_mk'
 
 @[to_additive (attr := simp)]
 theorem mk'_mul_cancel_right (x : M) (y : S) : f.mk' (x * y) y = f.toMap x := by
   rw [← mul_mk'_one_eq_mk', f.toMap.map_mul, mul_assoc, mul_mk'_one_eq_mk', mk'_self', mul_one]
-#align submonoid.localization_map.mk'_mul_cancel_right
-  Submonoid.LocalizationMap.mk'_mul_cancel_right
-#align add_submonoid.localization_map.mk'_add_cancel_right
-  AddSubmonoid.LocalizationMap.mk'_add_cancel_right
+#align submonoid.localization_map.mk'_mul_cancel_right Submonoid.LocalizationMap.mk'_mul_cancel_right
+#align add_submonoid.localization_map.mk'_add_cancel_right AddSubmonoid.LocalizationMap.mk'_add_cancel_right
 
 @[to_additive]
 theorem mk'_mul_cancel_left (x) (y : S) : f.mk' ((y : M) * x) y = f.toMap x := by
@@ -1116,8 +1110,7 @@ theorem lift_injective_iff :
     rw [← f.mk'_sec z, ← f.mk'_sec w]
     exact (mul_inv f.map_units).2 ((H _ _).2 <| (mul_inv hg).1 h)
 #align submonoid.localization_map.lift_injective_iff Submonoid.LocalizationMap.lift_injective_iff
-#align add_submonoid.localization_map.lift_injective_iff
-  AddSubmonoid.LocalizationMap.lift_injective_iff
+#align add_submonoid.localization_map.lift_injective_iff AddSubmonoid.LocalizationMap.lift_injective_iff
 
 variable {T : Submonoid P} (hy : ∀ y : S, g y ∈ T) {Q : Type _} [CommMonoid Q]
   (k : LocalizationMap T Q)
@@ -1374,34 +1367,26 @@ noncomputable def mulEquivOfLocalizations (k : LocalizationMap S P) : N ≃* P :
   left_inv := f.lift_left_inverse
   right_inv := k.lift_left_inverse
   map_mul' :=  MonoidHom.map_mul _ }
-#align submonoid.localization_map.mul_equiv_of_localizations
-  Submonoid.LocalizationMap.mulEquivOfLocalizations
-#align add_submonoid.localization_map.add_equiv_of_localizations
-  AddSubmonoid.LocalizationMap.addEquivOfLocalizations
+#align submonoid.localization_map.mul_equiv_of_localizations Submonoid.LocalizationMap.mulEquivOfLocalizations
+#align add_submonoid.localization_map.add_equiv_of_localizations AddSubmonoid.LocalizationMap.addEquivOfLocalizations
 
 @[to_additive (attr := simp)]
 theorem mulEquivOfLocalizations_apply {k : LocalizationMap S P} {x} :
     f.mulEquivOfLocalizations k x = f.lift k.map_units x := rfl
-#align submonoid.localization_map.mul_equiv_of_localizations_apply
-  Submonoid.LocalizationMap.mulEquivOfLocalizations_apply
-#align add_submonoid.localization_map.add_equiv_of_localizations_apply
-  AddSubmonoid.LocalizationMap.addEquivOfLocalizations_apply
+#align submonoid.localization_map.mul_equiv_of_localizations_apply Submonoid.LocalizationMap.mulEquivOfLocalizations_apply
+#align add_submonoid.localization_map.add_equiv_of_localizations_apply AddSubmonoid.LocalizationMap.addEquivOfLocalizations_apply
 
 @[to_additive (attr := simp)]
 theorem mulEquivOfLocalizations_symm_apply {k : LocalizationMap S P} {x} :
     (f.mulEquivOfLocalizations k).symm x = k.lift f.map_units x := rfl
-#align submonoid.localization_map.mul_equiv_of_localizations_symm_apply
-  Submonoid.LocalizationMap.mulEquivOfLocalizations_symm_apply
-#align add_submonoid.localization_map.add_equiv_of_localizations_symm_apply
-  AddSubmonoid.LocalizationMap.addEquivOfLocalizations_symm_apply
+#align submonoid.localization_map.mul_equiv_of_localizations_symm_apply Submonoid.LocalizationMap.mulEquivOfLocalizations_symm_apply
+#align add_submonoid.localization_map.add_equiv_of_localizations_symm_apply AddSubmonoid.LocalizationMap.addEquivOfLocalizations_symm_apply
 
 @[to_additive]
 theorem mulEquivOfLocalizations_symm_eq_mulEquivOfLocalizations {k : LocalizationMap S P} :
     (k.mulEquivOfLocalizations f).symm = f.mulEquivOfLocalizations k := rfl
-#align submonoid.localization_map.mul_equiv_of_localizations_symm_eq_mul_equiv_of_localizations
-  Submonoid.LocalizationMap.mulEquivOfLocalizations_symm_eq_mulEquivOfLocalizations
-#align add_submonoid.localization_map.add_equiv_of_localizations_symm_eq_add_equiv_of_localizations
-  AddSubmonoid.LocalizationMap.addEquivOfLocalizations_symm_eq_addEquivOfLocalizations
+#align submonoid.localization_map.mul_equiv_of_localizations_symm_eq_mul_equiv_of_localizations Submonoid.LocalizationMap.mulEquivOfLocalizations_symm_eq_mulEquivOfLocalizations
+#align add_submonoid.localization_map.add_equiv_of_localizations_symm_eq_add_equiv_of_localizations AddSubmonoid.LocalizationMap.addEquivOfLocalizations_symm_eq_addEquivOfLocalizations
 
 /-- If `f : M →* N` is a Localization map for a Submonoid `S` and `k : N ≃* P` is an isomorphism
 of `CommMonoid`s, `k ∘ f` is a Localization map for `M` at `S`. -/
@@ -1456,10 +1441,8 @@ theorem symm_comp_ofMulEquivOfLocalizations_apply' {k : P ≃* N} (x) :
 theorem ofMulEquivOfLocalizations_eq_iff_eq {k : N ≃* P} {x y} :
     (f.ofMulEquivOfLocalizations k).toMap x = y ↔ f.toMap x = k.symm y :=
   k.toEquiv.eq_symm_apply.symm
-#align submonoid.localization_map.of_mul_equiv_of_localizations_eq_iff_eq
-  Submonoid.LocalizationMap.ofMulEquivOfLocalizations_eq_iff_eq
-#align add_submonoid.localization_map.of_add_equiv_of_localizations_eq_iff_eq
-  AddSubmonoid.LocalizationMap.ofAddEquivOfLocalizations_eq_iff_eq
+#align submonoid.localization_map.of_mul_equiv_of_localizations_eq_iff_eq Submonoid.LocalizationMap.ofMulEquivOfLocalizations_eq_iff_eq
+#align add_submonoid.localization_map.of_add_equiv_of_localizations_eq_iff_eq AddSubmonoid.LocalizationMap.ofAddEquivOfLocalizations_eq_iff_eq
 
 @[to_additive addEquivOfLocalizations_right_inv]
 theorem mulEquivOfLocalizations_right_inv (k : LocalizationMap S P) :
@@ -1474,10 +1457,8 @@ theorem mulEquivOfLocalizations_right_inv (k : LocalizationMap S P) :
 @[to_additive addEquivOfLocalizations_right_inv_apply]
 theorem mulEquivOfLocalizations_right_inv_apply {k : LocalizationMap S P} {x} :
     (f.ofMulEquivOfLocalizations (f.mulEquivOfLocalizations k)).toMap x = k.toMap x := by simp
-#align submonoid.localization_map.mul_equiv_of_localizations_right_inv_apply
-  Submonoid.LocalizationMap.mulEquivOfLocalizations_right_inv_apply
-#align add_submonoid.localization_map.add_equiv_of_localizations_right_inv_apply
-  AddSubmonoid.LocalizationMap.addEquivOfLocalizations_right_inv_apply
+#align submonoid.localization_map.mul_equiv_of_localizations_right_inv_apply Submonoid.LocalizationMap.mulEquivOfLocalizations_right_inv_apply
+#align add_submonoid.localization_map.add_equiv_of_localizations_right_inv_apply AddSubmonoid.LocalizationMap.addEquivOfLocalizations_right_inv_apply
 
 @[to_additive]
 theorem mulEquivOfLocalizations_left_inv (k : N ≃* P) :
@@ -1492,28 +1473,22 @@ theorem mulEquivOfLocalizations_left_inv (k : N ≃* P) :
 @[to_additive]
 theorem mulEquivOfLocalizations_left_inv_apply {k : N ≃* P} (x) :
     f.mulEquivOfLocalizations (f.ofMulEquivOfLocalizations k) x = k x := by simp
-#align submonoid.localization_map.mul_equiv_of_localizations_left_inv_apply
-  Submonoid.LocalizationMap.mulEquivOfLocalizations_left_inv_apply
-#align add_submonoid.localization_map.add_equiv_of_localizations_left_neg_apply
-  AddSubmonoid.LocalizationMap.addEquivOfLocalizations_left_neg_apply
+#align submonoid.localization_map.mul_equiv_of_localizations_left_inv_apply Submonoid.LocalizationMap.mulEquivOfLocalizations_left_inv_apply
+#align add_submonoid.localization_map.add_equiv_of_localizations_left_neg_apply AddSubmonoid.LocalizationMap.addEquivOfLocalizations_left_neg_apply
 
 @[to_additive (attr := simp)]
 theorem ofMulEquivOfLocalizations_id : f.ofMulEquivOfLocalizations (MulEquiv.refl N) = f := by
   ext ; rfl
-#align submonoid.localization_map.of_mul_equiv_of_localizations_id
-  Submonoid.LocalizationMap.ofMulEquivOfLocalizations_id
-#align add_submonoid.localization_map.of_add_equiv_of_localizations_id
-  AddSubmonoid.LocalizationMap.ofAddEquivOfLocalizations_id
+#align submonoid.localization_map.of_mul_equiv_of_localizations_id Submonoid.LocalizationMap.ofMulEquivOfLocalizations_id
+#align add_submonoid.localization_map.of_add_equiv_of_localizations_id AddSubmonoid.LocalizationMap.ofAddEquivOfLocalizations_id
 
 @[to_additive]
 theorem ofMulEquivOfLocalizations_comp {k : N ≃* P} {j : P ≃* Q} :
     (f.ofMulEquivOfLocalizations (k.trans j)).toMap =
       j.toMonoidHom.comp (f.ofMulEquivOfLocalizations k).toMap :=
   by ext ; rfl
-#align submonoid.localization_map.of_mul_equiv_of_localizations_comp
-  Submonoid.LocalizationMap.ofMulEquivOfLocalizations_comp
-#align add_submonoid.localization_map.of_add_equiv_of_localizations_comp
-  AddSubmonoid.LocalizationMap.ofAddEquivOfLocalizations_comp
+#align submonoid.localization_map.of_mul_equiv_of_localizations_comp Submonoid.LocalizationMap.ofMulEquivOfLocalizations_comp
+#align add_submonoid.localization_map.of_add_equiv_of_localizations_comp AddSubmonoid.LocalizationMap.ofAddEquivOfLocalizations_comp
 
 /-- Given `CommMonoid`s `M, P` and Submonoids `S ⊆ M, T ⊆ P`, if `f : M →* N` is a Localization
 map for `S` and `k : P ≃* M` is an isomorphism of `CommMonoid`s such that `k(T) = S`, `f ∘ k`
@@ -1570,18 +1545,14 @@ theorem ofMulEquivOfDom_eq {k : P ≃* M} (H : T.map k.toMonoidHom = S) :
 theorem ofMulEquivOfDom_comp_symm {k : P ≃* M} (H : T.map k.toMonoidHom = S) (x) :
     (f.ofMulEquivOfDom H).toMap (k.symm x) = f.toMap x :=
   congr_arg f.toMap <| k.apply_symm_apply x
-#align submonoid.localization_map.of_mul_equiv_of_dom_comp_symm
-  Submonoid.LocalizationMap.ofMulEquivOfDom_comp_symm
-#align add_submonoid.localization_map.of_add_equiv_of_dom_comp_symm
-  AddSubmonoid.LocalizationMap.ofAddEquivOfDom_comp_symm
+#align submonoid.localization_map.of_mul_equiv_of_dom_comp_symm Submonoid.LocalizationMap.ofMulEquivOfDom_comp_symm
+#align add_submonoid.localization_map.of_add_equiv_of_dom_comp_symm AddSubmonoid.LocalizationMap.ofAddEquivOfDom_comp_symm
 
 @[to_additive]
 theorem ofMulEquivOfDom_comp {k : M ≃* P} (H : T.map k.symm.toMonoidHom = S) (x) :
     (f.ofMulEquivOfDom H).toMap (k x) = f.toMap x := congr_arg f.toMap <| k.symm_apply_apply x
-#align submonoid.localization_map.of_mul_equiv_of_dom_comp
-  Submonoid.LocalizationMap.ofMulEquivOfDom_comp
-#align add_submonoid.localization_map.of_add_equiv_of_dom_comp
-  AddSubmonoid.LocalizationMap.ofAddEquivOfDom_comp
+#align submonoid.localization_map.of_mul_equiv_of_dom_comp Submonoid.LocalizationMap.ofMulEquivOfDom_comp
+#align add_submonoid.localization_map.of_add_equiv_of_dom_comp AddSubmonoid.LocalizationMap.ofAddEquivOfDom_comp
 
 /-- A special case of `f ∘ id = f`, `f` a Localization map. -/
 @[to_additive (attr := simp) "A special case of `f ∘ id = f`, `f` a Localization map."]
@@ -1590,10 +1561,8 @@ theorem ofMulEquivOfDom_id :
         (show S.map (MulEquiv.refl M).toMonoidHom = S from
           Submonoid.ext fun x ↦ ⟨fun ⟨_, hy, h⟩ ↦ h ▸ hy, fun h ↦ ⟨x, h, rfl⟩⟩) = f :=
   by ext ; rfl
-#align submonoid.localization_map.of_mul_equiv_of_dom_id
-  Submonoid.LocalizationMap.ofMulEquivOfDom_id
-#align add_submonoid.localization_map.of_add_equiv_of_dom_id
-  AddSubmonoid.LocalizationMap.ofAddEquivOfDom_id
+#align submonoid.localization_map.of_mul_equiv_of_dom_id Submonoid.LocalizationMap.ofMulEquivOfDom_id
+#align add_submonoid.localization_map.of_add_equiv_of_dom_id AddSubmonoid.LocalizationMap.ofAddEquivOfDom_id
 
 /-- Given Localization maps `f : M →* N, k : P →* U` for Submonoids `S, T` respectively, an
 isomorphism `j : M ≃* P` such that `j(S) = T` induces an isomorphism of localizations `N ≃* U`. -/
@@ -1662,10 +1631,8 @@ theorem of_mulEquivOfMulEquiv_apply {k : LocalizationMap T Q} {j : M ≃* P}
 theorem of_mulEquivOfMulEquiv {k : LocalizationMap T Q} {j : M ≃* P} (H : S.map j.toMonoidHom = T) :
     (f.ofMulEquivOfLocalizations (f.mulEquivOfMulEquiv k H)).toMap = k.toMap.comp j.toMonoidHom :=
   MonoidHom.ext <| f.of_mulEquivOfMulEquiv_apply H
-#align submonoid.localization_map.of_mul_equiv_of_mul_equiv
-  Submonoid.LocalizationMap.of_mulEquivOfMulEquiv
-#align add_submonoid.localization_map.of_add_equiv_of_add_equiv
-  AddSubmonoid.LocalizationMap.of_addEquivOfAddEquiv
+#align submonoid.localization_map.of_mul_equiv_of_mul_equiv Submonoid.LocalizationMap.of_mulEquivOfMulEquiv
+#align add_submonoid.localization_map.of_add_equiv_of_add_equiv AddSubmonoid.LocalizationMap.of_addEquivOfAddEquiv
 
 end LocalizationMap
 
@@ -1796,10 +1763,8 @@ theorem mulEquivOfQuotient_symm_mk (x y) : (mulEquivOfQuotient f).symm (f.mk' x 
 theorem mulEquivOfQuotient_symm_monoidOf (x) :
     (mulEquivOfQuotient f).symm (f.toMap x) = (monoidOf S).toMap x :=
   f.lift_eq (monoidOf S).map_units _
-#align localization.mul_equiv_of_quotient_symm_monoid_of
-  Localization.mulEquivOfQuotient_symm_monoidOf
-#align add_localization.add_equiv_of_quotient_symm_add_monoid_of
-  addLocalization.addEquivOfQuotient_symm_addMonoidOf
+#align localization.mul_equiv_of_quotient_symm_monoid_of Localization.mulEquivOfQuotient_symm_monoidOf
+#align add_localization.add_equiv_of_quotient_symm_add_monoid_of addLocalization.addEquivOfQuotient_symm_addMonoidOf
 
 section Away
 

--- a/Mathlib/GroupTheory/Perm/Subgroup.lean
+++ b/Mathlib/GroupTheory/Perm/Subgroup.lean
@@ -46,8 +46,7 @@ theorem sumCongrHom.card_range {α β : Type _} [Fintype (sumCongrHom α β).ran
 instance sigmaCongrRightHom.decidableMemRange {α : Type _} {β : α → Type _} [DecidableEq α]
     [∀ a, DecidableEq (β a)] [Fintype α] [∀ a, Fintype (β a)] :
     DecidablePred (· ∈ (sigmaCongrRightHom β).range) := fun _ => inferInstance
-#align equiv.perm.sigma_congr_right_hom.decidable_mem_range
-    Equiv.Perm.sigmaCongrRightHom.decidableMemRange
+#align equiv.perm.sigma_congr_right_hom.decidable_mem_range Equiv.Perm.sigmaCongrRightHom.decidableMemRange
 
 @[simp]
 theorem sigmaCongrRightHom.card_range {α : Type _} {β : α → Type _}

--- a/Mathlib/Order/Filter/Bases.lean
+++ b/Mathlib/Order/Filter/Bases.lean
@@ -1012,8 +1012,7 @@ instance Nat.inhabitedCountableFilterBasis : Inhabited (CountableFilterBasis ℕ
 theorem HasCountableBasis.isCountablyGenerated {f : Filter α} {p : ι → Prop} {s : ι → Set α}
     (h : f.HasCountableBasis p s) : f.IsCountablyGenerated :=
   ⟨⟨{ t | ∃ i, p i ∧ s i = t }, h.countable.image s, h.toHasBasis.eq_generate⟩⟩
-#align filter.has_countable_basis.is_countably_generated
-  Filter.HasCountableBasis.isCountablyGenerated
+#align filter.has_countable_basis.is_countably_generated Filter.HasCountableBasis.isCountablyGenerated
 
 theorem antitone_seq_of_seq (s : ℕ → Set α) :
     ∃ t : ℕ → Set α, Antitone t ∧ (⨅ i, 𝓟 <| s i) = ⨅ i, 𝓟 (t i) := by
@@ -1172,8 +1171,7 @@ theorem isCountablyGenerated_iff_exists_antitone_basis {f : Filter α} :
   · rintro ⟨x, h⟩
     rw [h.1.eq_infᵢ]
     exact isCountablyGenerated_seq x
-#align filter.is_countably_generated_iff_exists_antitone_basis
-  Filter.isCountablyGenerated_iff_exists_antitone_basis
+#align filter.is_countably_generated_iff_exists_antitone_basis Filter.isCountablyGenerated_iff_exists_antitone_basis
 
 @[instance]
 theorem isCountablyGenerated_principal (s : Set α) : IsCountablyGenerated (𝓟 s) :=

--- a/Mathlib/Order/LocallyFinite.lean
+++ b/Mathlib/Order/LocallyFinite.lean
@@ -448,8 +448,7 @@ instance (priority := 100) LocallyFiniteOrder.toLocallyFiniteOrderTop : LocallyF
   finsetIoi b := Ioc b ⊤
   finset_mem_Ici a x := by rw [mem_Icc, and_iff_left le_top]
   finset_mem_Ioi a x := by rw [mem_Ioc, and_iff_left le_top]
-#align locally_finite_order.to_locally_finite_order_top
-  Finset.LocallyFiniteOrder.toLocallyFiniteOrderTop
+#align locally_finite_order.to_locally_finite_order_top Finset.LocallyFiniteOrder.toLocallyFiniteOrderTop
 
 theorem Ici_eq_Icc (a : α) : Ici a = Icc a ⊤ :=
   rfl
@@ -472,8 +471,7 @@ instance (priority := 100) LocallyFiniteOrder.toLocallyFiniteOrderBot : LocallyF
   finsetIio := Ico ⊥
   finset_mem_Iic a x := by rw [mem_Icc, and_iff_right bot_le]
   finset_mem_Iio a x := by rw [mem_Ico, and_iff_right bot_le]
-#align finset.locally_finite_order.to_locally_finite_order_bot
-  Finset.LocallyFiniteOrder.toLocallyFiniteOrderBot
+#align finset.locally_finite_order.to_locally_finite_order_bot Finset.LocallyFiniteOrder.toLocallyFiniteOrderBot
 
 theorem Iic_eq_Icc : Iic = Icc (⊥ : α) :=
   rfl

--- a/Mathlib/Order/Partition/Equipartition.lean
+++ b/Mathlib/Order/Partition/Equipartition.lean
@@ -52,8 +52,7 @@ theorem Set.Subsingleton.isEquipartition (h : (P.parts : Set (Finset α)).Subsin
 theorem IsEquipartition.card_parts_eq_average (hP : P.IsEquipartition) (ht : t ∈ P.parts) :
     t.card = s.card / P.parts.card ∨ t.card = s.card / P.parts.card + 1 :=
   P.isEquipartition_iff_card_parts_eq_average.1 hP _ ht
-#align finpartition.is_equipartition.card_parts_eq_average
-    Finpartition.IsEquipartition.card_parts_eq_average
+#align finpartition.is_equipartition.card_parts_eq_average Finpartition.IsEquipartition.card_parts_eq_average
 
 theorem IsEquipartition.average_le_card_part (hP : P.IsEquipartition) (ht : t ∈ P.parts) :
     s.card / P.parts.card ≤ t.card := by
@@ -66,8 +65,7 @@ theorem IsEquipartition.card_part_le_average_add_one (hP : P.IsEquipartition) (h
     t.card ≤ s.card / P.parts.card + 1 := by
   rw [← P.sum_card_parts]
   exact Finset.EquitableOn.le_add_one hP ht
-#align finpartition.is_equipartition.card_part_le_average_add_one
-    Finpartition.IsEquipartition.card_part_le_average_add_one
+#align finpartition.is_equipartition.card_part_le_average_add_one Finpartition.IsEquipartition.card_part_le_average_add_one
 
 /-! ### Discrete and indiscrete finpartition -/
 


### PR DESCRIPTION
Apparently we have CI scripts that assume those fall on a single line.
The command line used to fix the aligns was:
```bash
find . -type f -name "*.lean" -exec sed -i -E 'N;s/^#align ([^[:space:]]+)\n *([^[:space:]]+)$/#align \1 \2/' {} \;
```
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
