### PR TITLE
[Merged by Bors] - chore: bump Std

### DIFF
--- a/Mathlib/Algebra/TrivSqZeroExt.lean
+++ b/Mathlib/Algebra/TrivSqZeroExt.lean
@@ -622,7 +622,7 @@ theorem snd_pow_of_smul_comm [Monoid R] [AddMonoid M] [DistribMulAction R M]
     simp_rw [Nat.pred_succ]
     refine' (List.sum_eq_card_nsmul _ (x.fst ^ n • x.snd) _).trans _
     · rintro m hm
-      simp_rw [List.mem_map', List.mem_range] at hm
+      simp_rw [List.mem_map, List.mem_range] at hm
       obtain ⟨i, hi, rfl⟩ := hm
       rw [tsub_add_cancel_of_le (Nat.lt_succ_iff.mp hi)]
     · rw [List.length_map, List.length_range]

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity.lean
@@ -798,7 +798,7 @@ theorem dart_snd_mem_support_of_mem_darts {u v : V} (p : G.Walk u v) {d : G.Dart
 theorem fst_mem_support_of_mem_edges {t u v w : V} (p : G.Walk v w) (he : ⟦(t, u)⟧ ∈ p.edges) :
     t ∈ p.support := by
   obtain ⟨d, hd, he⟩ := List.mem_map.mp he
-  rw [eq_comm, dart_edge_eq_mk'_iff'] at he
+  rw [dart_edge_eq_mk'_iff'] at he
   rcases he with (⟨rfl, rfl⟩ | ⟨rfl, rfl⟩)
   · exact dart_fst_mem_support_of_mem_darts _ hd
   · exact dart_snd_mem_support_of_mem_darts _ hd

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity.lean
@@ -2338,7 +2338,7 @@ theorem reachable_delete_edges_iff_exists_walk {v w : V} :
   constructor
   · rintro ⟨p⟩
     use p.map (Hom.mapSpanningSubgraphs (by simp))
-    simp_rw [Walk.edges_map, List.mem_map', Hom.mapSpanningSubgraphs_apply, Sym2.map_id', id.def]
+    simp_rw [Walk.edges_map, List.mem_map, Hom.mapSpanningSubgraphs_apply, Sym2.map_id', id.def]
     rintro ⟨e, h, rfl⟩
     simpa using p.edges_subset_edgeSet h
   · rintro ⟨p, h⟩

--- a/Mathlib/Combinatorics/Young/YoungDiagram.lean
+++ b/Mathlib/Combinatorics/Young/YoungDiagram.lean
@@ -431,7 +431,7 @@ theorem rowLens_sorted (μ : YoungDiagram) : μ.rowLens.Sorted (· ≥ ·) :=
 #align young_diagram.row_lens_sorted YoungDiagram.rowLens_sorted
 
 theorem pos_of_mem_rowLens (μ : YoungDiagram) (x : ℕ) (hx : x ∈ μ.rowLens) : 0 < x := by
-  rw [rowLens, List.mem_map'] at hx
+  rw [rowLens, List.mem_map] at hx
   obtain ⟨i, hi, rfl : μ.rowLen i = x⟩ := hx
   rwa [List.mem_range, ← mem_iff_lt_colLen, mem_iff_lt_rowLen] at hi
 #align young_diagram.pos_of_mem_row_lens YoungDiagram.pos_of_mem_rowLens

--- a/Mathlib/Data/Fin/Tuple/NatAntidiagonal.lean
+++ b/Mathlib/Data/Fin/Tuple/NatAntidiagonal.lean
@@ -91,7 +91,7 @@ theorem mem_antidiagonalTuple {n : ℕ} {k : ℕ} {x : Fin k → ℕ} :
   | h x₀ x ih =>
     simp_rw [Fin.sum_cons]
     rw [antidiagonalTuple]  -- porting note: simp_rw doesn't use the equation lemma properly
-    simp_rw [List.mem_bind, List.mem_map',
+    simp_rw [List.mem_bind, List.mem_map,
       List.Nat.mem_antidiagonal, Fin.cons_eq_cons, exists_eq_right_right, ih,
       @eq_comm _ _ (Prod.snd _), and_comm (a := Prod.snd _ = _),
       ←Prod.mk.inj_iff (a₁ := Prod.fst _), Prod.mk.eta, exists_eq_right]
@@ -111,11 +111,11 @@ theorem nodup_antidiagonalTuple (k n : ℕ) : List.Nodup (antidiagonalTuple k n)
   · exact List.pairwise_singleton _ _
   · rw [List.Nat.antidiagonal_succ]
     refine' List.Pairwise.cons (fun a ha x hx₁ hx₂ => _) (n_ih.map _ fun a b h x hx₁ hx₂ => _)
-    · rw [List.mem_map'] at hx₁ hx₂ ha
+    · rw [List.mem_map] at hx₁ hx₂ ha
       obtain ⟨⟨a, -, rfl⟩, ⟨x₁, -, rfl⟩, ⟨x₂, -, h⟩⟩ := ha, hx₁, hx₂
       rw [Fin.cons_eq_cons] at h
       injection h.1
-    · rw [List.mem_map'] at hx₁ hx₂
+    · rw [List.mem_map] at hx₁ hx₂
       obtain ⟨⟨x₁, hx₁, rfl⟩, ⟨x₂, hx₂, h₁₂⟩⟩ := hx₁, hx₂
       dsimp at h₁₂
       rw [Fin.cons_eq_cons, Nat.succ_inj'] at h₁₂
@@ -160,7 +160,7 @@ theorem antidiagonalTuple_pairwise_pi_lex :
   | 0, _ + 1 => List.Pairwise.nil
   | k + 1, n =>
     by
-    simp_rw [antidiagonalTuple, List.pairwise_bind, List.pairwise_map, List.mem_map',
+    simp_rw [antidiagonalTuple, List.pairwise_bind, List.pairwise_map, List.mem_map,
       forall_exists_index, and_imp, forall_apply_eq_imp_iff₂]
     simp only [mem_antidiagonal, Prod.forall, and_imp, forall_apply_eq_imp_iff₂]
     simp only [Fin.pi_lex_lt_cons_cons, eq_self_iff_true, true_and_iff, lt_self_iff_false,
@@ -171,7 +171,7 @@ theorem antidiagonalTuple_pairwise_pi_lex :
       exact List.pairwise_singleton _ _
     · rw [antidiagonal_succ, List.pairwise_cons, List.pairwise_map]
       refine' ⟨fun p hp x hx y hy => _, _⟩
-      · rw [List.mem_map', Prod.exists] at hp
+      · rw [List.mem_map, Prod.exists] at hp
         obtain ⟨a, b, _, rfl : (Nat.succ a, b) = p⟩ := hp
         exact Or.inl (Nat.zero_lt_succ _)
       dsimp

--- a/Mathlib/Data/Finsupp/BigOperators.lean
+++ b/Mathlib/Data/Finsupp/BigOperators.lean
@@ -93,7 +93,7 @@ theorem List.support_sum_eq [AddMonoid M] (l : List (ι →₀ M))
     · rw [← List.foldr_map, ← Finset.bot_eq_empty, List.foldr_sup_eq_sup_toFinset,
         Finset.disjoint_sup_right]
       intro f hf
-      simp only [List.mem_toFinset, List.mem_map'] at hf
+      simp only [List.mem_toFinset, List.mem_map] at hf
       obtain ⟨f, hf, rfl⟩ := hf
       exact hl.left _ hf
 #align list.support_sum_eq List.support_sum_eq

--- a/Mathlib/Data/Fintype/Perm.lean
+++ b/Mathlib/Data/Fintype/Perm.lean
@@ -76,7 +76,7 @@ theorem mem_permsOfList_of_mem {l : List α} {f : Perm α} (h : ∀ x, f x ≠ x
     split_ifs at hx with h_1
     exacts[hxa (h.symm.trans h_1), hx h]
   suffices f ∈ permsOfList l ∨ ∃ b ∈ l, ∃ g ∈ permsOfList l, Equiv.swap a b * g = f by
-    simpa only [permsOfList, exists_prop, List.mem_map', mem_append, List.mem_bind]
+    simpa only [permsOfList, exists_prop, List.mem_map, mem_append, List.mem_bind]
   refine' or_iff_not_imp_left.2 fun _hfl => ⟨f a, _, Equiv.swap a (f a) * f, IH this, _⟩
   · exact mem_of_ne_of_mem hfa (h _ hfa')
   · rw [← mul_assoc, mul_def (swap a (f a)) (swap a (f a)), swap_swap, ← Perm.one_def, one_mul]
@@ -92,7 +92,7 @@ theorem mem_of_mem_permsOfList :
     (mem_append.1 h).elim (fun h hx => mem_cons_of_mem _ (mem_of_mem_permsOfList h x hx))
       fun h hx =>
       let ⟨y, hy, hy'⟩ := List.mem_bind.1 h
-      let ⟨g, hg₁, hg₂⟩ := List.mem_map'.1 hy'
+      let ⟨g, hg₁, hg₂⟩ := List.mem_map.1 hy'
       -- Porting note: Seems like the implicit variable `x` of type `α` is needed.
       if hxa : x = a then by simp [hxa]
       else
@@ -119,8 +119,8 @@ theorem nodup_permsOfList : ∀ {l : List α} (_ : l.Nodup), (permsOfList l).Nod
     · exact hln'
     · exact fun _ _ => hln'.map fun _ _ => mul_left_cancel
     · intros i j hij x hx₁ hx₂
-      let ⟨f, hf⟩ := List.mem_map'.1 hx₁
-      let ⟨g, hg⟩ := List.mem_map'.1 hx₂
+      let ⟨f, hf⟩ := List.mem_map.1 hx₁
+      let ⟨g, hg⟩ := List.mem_map.1 hx₂
       have hix : x a = List.get l i := by
         rw [← hf.2, mul_apply, hmeml hf.1, swap_apply_left]
       have hiy : x a = List.get l j := by
@@ -129,7 +129,7 @@ theorem nodup_permsOfList : ∀ {l : List α} (_ : l.Nodup), (permsOfList l).Nod
       exact absurd hieqj (_root_.ne_of_lt hij)
     · intros f hf₁ hf₂
       let ⟨x, hx, hx'⟩ := List.mem_bind.1 hf₂
-      let ⟨g, hg⟩ := List.mem_map'.1 hx'
+      let ⟨g, hg⟩ := List.mem_map.1 hx'
       have hgxa : g⁻¹ x = a := f.injective <| by rw [hmeml hf₁, ← hg.2]; simp
       have hxa : x ≠ a := fun h => (List.nodup_cons.1 hl).1 (h ▸ hx)
       exact  (List.nodup_cons.1 hl).1 <|

--- a/Mathlib/Data/Int/Range.lean
+++ b/Mathlib/Data/Int/Range.lean
@@ -31,7 +31,7 @@ def range (m n : ℤ) : List ℤ :=
 #align int.range Int.range
 
 theorem mem_range_iff {m n r : ℤ} : r ∈ range m n ↔ m ≤ r ∧ r < n := by
-  simp only [range, List.mem_map', List.mem_range, lt_toNat, lt_sub_iff_add_lt, add_comm]
+  simp only [range, List.mem_map, List.mem_range, lt_toNat, lt_sub_iff_add_lt, add_comm]
   exact ⟨fun ⟨a, ha⟩ => ha.2 ▸ ⟨le_add_of_nonneg_right (Int.coe_nat_nonneg _), ha.1⟩,
     fun h => ⟨toNat (r - m), by simp [toNat_of_nonneg (sub_nonneg.2 h.1), h.2] ⟩⟩
 

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -3623,9 +3623,9 @@ theorem monotone_filter_left (p : α → Bool) ⦃l l' : List α⦄ (h : l ⊆ l
 
 variable (p)
 
--- Porting note: The lemma `Sublist.filter` accidentally had its argument `p` change from explicit to
--- implicit when it was moved from Mathlib to Std.  This is a temporary copy providing the explicit
--- version, to be removed after `Std` is corrected.
+-- Porting note: The lemma `Sublist.filter` accidentally had its argument `p` change from explicit
+-- to implicit when it was moved from Mathlib to Std.  This is a temporary copy providing the
+-- explicit version, to be removed after `Std` is corrected.
 theorem Sublist.filter' {l₁ l₂} (s : l₁ <+ l₂) : l₁.filter p <+ l₂.filter p := by
   have := filterMap_eq_filter (fun a => p a)
   simp only [Bool.decide_coe] at this

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -121,14 +121,9 @@ theorem mem_split {a : α} {l : List α} (h : a ∈ l) : ∃ s t : List α, l = 
 
 #align list.ne_and_not_mem_of_not_mem_cons List.ne_and_not_mem_of_not_mem_cons
 
--- Porting TODO: fix `List.mem_map` in Std to this statement.
-@[simp]
-theorem mem_map' {f : α → β} {b : β} {l : List α} : b ∈ map f l ↔ ∃ a, a ∈ l ∧ f a = b := by
-  simp only [List.mem_map, eq_comm]
-#align list.mem_map List.mem_map'
+#align list.mem_map List.mem_map
 
-alias mem_map' ↔ exists_of_mem_map' _
-#align list.exists_of_mem_map List.exists_of_mem_map'
+#align list.exists_of_mem_map List.exists_of_mem_map
 
 #align list.mem_map_of_mem List.mem_map_of_memₓ -- implicits order
 
@@ -144,7 +139,7 @@ theorem _root_.Function.Involutive.exists_mem_and_apply_eq_iff {f : α → α}
 #align function.involutive.exists_mem_and_apply_eq_iff Function.Involutive.exists_mem_and_apply_eq_iff
 
 theorem mem_map_of_involutive {f : α → α} (hf : Involutive f) {a : α} {l : List α} :
-    a ∈ map f l ↔ f a ∈ l := by rw [mem_map', hf.exists_mem_and_apply_eq_iff]
+    a ∈ map f l ↔ f a ∈ l := by rw [mem_map, hf.exists_mem_and_apply_eq_iff]
 #align list.mem_map_of_involutive List.mem_map_of_involutive
 
 #align list.forall_mem_map_iff List.forall_mem_map_iffₓ -- universe order

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -100,8 +100,6 @@ theorem _root_.Decidable.List.eq_or_ne_mem_of_mem [DecidableEq α]
 alias mem_cons ↔ eq_or_mem_of_mem_cons _
 #align list.eq_or_mem_of_mem_cons List.eq_or_mem_of_mem_cons
 
-theorem not_mem_append {a : α} {s t : List α} (h₁ : a ∉ s) (h₂ : a ∉ t) : a ∉ s ++ t :=
-mt mem_append.1 $ not_or.mpr ⟨h₁, h₂⟩
 #align list.not_mem_append List.not_mem_append
 
 #align list.ne_nil_of_mem List.ne_nil_of_mem
@@ -113,24 +111,14 @@ theorem mem_split {a : α} {l : List α} (h : a ∈ l) : ∃ s t : List α, l = 
     exact ⟨b :: s, t, rfl⟩
 #align list.mem_split List.mem_split
 
-theorem mem_of_ne_of_mem {a y : α} {l : List α} (h₁ : a ≠ y) (h₂ : a ∈ y :: l) : a ∈ l :=
-Or.elim (eq_or_mem_of_mem_cons h₂) (fun e ↦ absurd e h₁) (fun r ↦ r)
 #align list.mem_of_ne_of_mem List.mem_of_ne_of_mem
 
-theorem ne_of_not_mem_cons {a b : α} {l : List α} : (a ∉ b::l) → a ≠ b :=
-fun nin aeqb ↦ absurd (aeqb ▸ Mem.head ..) nin
 #align list.ne_of_not_mem_cons List.ne_of_not_mem_cons
 
-theorem not_mem_of_not_mem_cons {a b : α} {l : List α} : (a ∉ b::l) → a ∉ l :=
-fun nin nainl ↦ absurd (Mem.tail _ nainl) nin
 #align list.not_mem_of_not_mem_cons List.not_mem_of_not_mem_cons
 
-theorem not_mem_cons_of_ne_of_not_mem {a y : α} {l : List α} : a ≠ y → (a ∉ l) → (a ∉ y::l) :=
-fun p1 p2 Pain ↦ absurd (eq_or_mem_of_mem_cons Pain) (not_or.mpr ⟨p1, p2⟩)
 #align list.not_mem_cons_of_ne_of_not_mem List.not_mem_cons_of_ne_of_not_mem
 
-theorem ne_and_not_mem_of_not_mem_cons {a y : α} {l : List α} : (a ∉ y::l) → a ≠ y ∧ a ∉ l :=
-fun p ↦ ⟨ne_of_not_mem_cons p, not_mem_of_not_mem_cons p⟩
 #align list.ne_and_not_mem_of_not_mem_cons List.ne_and_not_mem_of_not_mem_cons
 
 -- Porting TODO: fix `List.mem_map` in Std to this statement.
@@ -451,12 +439,8 @@ theorem eq_replicate_length {a : α} : ∀ {l : List α}, l = replicate l.length
   | (b :: l) => by simp [eq_replicate_length]
 #align list.eq_replicate_length List.eq_replicate_length
 
-alias eq_replicate_length ↔ _ eq_replicate_of_mem
 #align list.eq_replicate_of_mem List.eq_replicate_of_mem
 
-theorem eq_replicate {a : α} {n} {l} : l = replicate n a ↔ length l = n ∧ ∀ b ∈ l, b = a :=
-  ⟨fun h => h.symm ▸ ⟨length_replicate _ _, fun _ => eq_of_mem_replicate⟩, fun ⟨e, al⟩ =>
-    e ▸ eq_replicate_of_mem al⟩
 #align list.eq_replicate List.eq_replicate
 
 theorem replicate_add (m n) (a : α) : replicate (m + n) a = replicate m a ++ replicate n a := by
@@ -1094,11 +1078,6 @@ theorem cons_sublist_cons_iff {l₁ l₂ : List α} {a : α} : a :: l₁ <+ a ::
 #align list.sublist.append List.Sublist.append
 #align list.sublist.subset List.Sublist.subset
 
-@[simp]
-theorem singleton_sublist {a : α} {l} : [a] <+ l ↔ a ∈ l :=
-  ⟨fun h => h.subset (mem_singleton_self _), fun h =>
-    let ⟨_, _, e⟩ := mem_split h
-    e.symm ▸ ((nil_sublist _).cons_cons _).trans (sublist_append_right _ _)⟩
 #align list.singleton_sublist List.singleton_sublist
 
 theorem eq_nil_of_sublist_nil {l : List α} (s : l <+ []) : l = [] :=
@@ -1110,11 +1089,6 @@ theorem sublist_nil_iff_eq_nil {l : List α} : l <+ [] ↔ l = [] :=
   ⟨eq_nil_of_sublist_nil, fun H => H ▸ Sublist.refl _⟩
 #align list.sublist_nil_iff_eq_nil List.sublist_nil_iff_eq_nil
 
-@[simp]
-theorem replicate_sublist_replicate {m n} (a : α) :
-    replicate m a <+ replicate n a ↔ m ≤ n :=
-  ⟨fun h => by simpa only [length_replicate] using h.length_le, fun h => by
-    induction h <;> [rfl, simp only [*, replicate_succ, Sublist.cons]]⟩
 #align list.replicate_sublist_replicate List.replicate_sublist_replicate
 
 theorem sublist_replicate_iff {l : List α} {a : α} {n : ℕ} :
@@ -1125,16 +1099,8 @@ theorem sublist_replicate_iff {l : List α} {a : α} {n : ℕ} :
     by rintro ⟨k, h, rfl⟩; exact (replicate_sublist_replicate _).mpr h⟩
 #align list.sublist_replicate_iff List.sublist_replicate_iff
 
-theorem Sublist.eq_of_length : ∀ {l₁ l₂ : List α}, l₁ <+ l₂ → length l₁ = length l₂ → l₁ = l₂
-  | _, _, Sublist.slnil, _ => rfl
-  | _, _, Sublist.cons a s, h => by
-    cases s.length_le.not_lt (by rw [h]; apply lt_succ_self)
-  | _, _, Sublist.cons₂ a s, h => by
-    rw [length, length] at h; injection h with h; rw [s.eq_of_length h]
 #align list.sublist.eq_of_length List.Sublist.eq_of_length
 
-theorem Sublist.eq_of_length_le (s : l₁ <+ l₂) (h : length l₂ ≤ length l₁) : l₁ = l₂ :=
-  s.eq_of_length <| s.length_le.antisymm h
 #align list.sublist.eq_of_length_le List.Sublist.eq_of_length_le
 
 theorem Sublist.antisymm (s₁ : l₁ <+ l₂) (s₂ : l₂ <+ l₁) : l₁ = l₂ :=
@@ -3330,35 +3296,19 @@ theorem find?_nil (p : α → Bool) : find? p [] = none :=
 
 -- Porting note: List.find? is given @[simp] in Std.Data.List.Init.Lemmas
 -- @[simp]
-@[simp 1100, nolint simpNF]
-theorem find?_cons_of_pos (l) (h : p a) : find? p (a :: l) = some a :=
-  by simp [find?, h]
+-- Later porting note (at time of this lemma moving to Std): removing attribute `nolint simpNF`
+attribute [simp 1100] find?_cons_of_pos
 #align list.find_cons_of_pos List.find?_cons_of_pos
 
 -- Porting note: List.find? is given @[simp] in Std.Data.List.Init.Lemmas
 -- @[simp]
-@[simp 1100, nolint simpNF]
-theorem find?_cons_of_neg (l) (h : ¬p a) : find? p (a :: l) = find? p l :=
-  by simp [find?, h]
+-- Later porting note (at time of this lemma moving to Std): removing attribute `nolint simpNF`
+attribute [simp 1100] find?_cons_of_neg
 #align list.find_cons_of_neg List.find?_cons_of_neg
 
-@[simp]
-theorem find?_eq_none : find? p l = none ↔ ∀ x ∈ l, ¬p x := by
-  induction' l with a l IH
-  · exact iff_of_true rfl (forall_mem_nil _)
-  rw [forall_mem_cons]; by_cases h : p a
-  · simp only [find?_cons_of_pos _ h, h, not_true, false_and_iff]
-  · rwa [find?_cons_of_neg _ h, iff_true_intro h, true_and_iff]
+attribute [simp] find?_eq_none
 #align list.find_eq_none List.find?_eq_none
 
-theorem find?_some (H : find? p l = some a) : p a := by
-  induction' l with b l IH; · contradiction
-  by_cases h : p b
-  · rw [find?_cons_of_pos _ h] at H
-    cases H
-    exact h
-  · rw [find?_cons_of_neg _ h] at H
-    exact IH H
 #align list.find_some List.find?_some
 
 @[simp]
@@ -3456,191 +3406,63 @@ end Lookmap
 /-! ### filter -/
 -- Porting note: These lemmas are from Lean3 core
 
-@[simp] theorem filter_nil (p : α → Bool) : filter p [] = [] := rfl
 #align list.filter_nil List.filter_nil
 
-@[simp] theorem filter_cons_of_pos {p : α → Bool} {a : α} :
-   ∀ l, p a → filter p (a::l) = a :: filter p l :=
-fun l pa => by rw [filter, pa]
 #align list.filter_cons_of_pos List.filter_cons_of_pos
 
-@[simp] theorem filter_cons_of_neg {p : α → Bool} {a : α} :
-  ∀ l, ¬ p a → filter p (a::l) = filter p l :=
-fun l pa => by rw [filter, eq_false_of_ne_true pa]
 #align list.filter_cons_of_neg List.filter_cons_of_neg
 
-@[simp] theorem filter_append {p : α → Bool} :
-  ∀ (l₁ l₂ : List α), filter p (l₁++l₂) = filter p l₁ ++ filter p l₂
-| [],    l₂ => rfl
-| a::l₁, l₂ => by rw [cons_append, filter, filter]; cases p a <;> dsimp <;> rw [filter_append l₁]
 #align list.filter_append List.filter_append
 
-@[simp] theorem filter_sublist {p : α → Bool} :
-    ∀ (l : List α), filter p l <+ l
-| []     => Sublist.slnil
-| (a::l) => by
-  rw [filter]
-  cases p a
-  . exact Sublist.cons _ (filter_sublist l)
-  . exact Sublist.cons₂ _ (filter_sublist l)
 #align list.filter_sublist List.filter_sublist
 
 /-! ### filterMap -/
 
-@[simp]
-theorem filterMap_nil (f : α → Option β) : filterMap f [] = [] :=
-  rfl
 #align list.filter_map_nil List.filterMap_nil
 
 -- Porting note: List.filterMap is given @[simp] in Std.Data.List.Init.Lemmas
 -- @[simp]
-@[simp 1100, nolint simpNF]
-theorem filterMap_cons_none {f : α → Option β} (a : α) (l : List α) (h : f a = none) :
-    filterMap f (a :: l) = filterMap f l := by simp only [filterMap, h]
+-- Later porting note (at time of this lemma moving to Std): removing attribute `nolint simpNF`
+attribute [simp 1100] filterMap_cons_none
 #align list.filter_map_cons_none List.filterMap_cons_none
 
 -- @[simp]
-@[simp 1100, nolint simpNF]
-theorem filterMap_cons_some (f : α → Option β) (a : α) (l : List α) {b : β} (h : f a = some b) :
-    filterMap f (a :: l) = b :: filterMap f l := by
-  simp only [filterMap, h]
+-- Later porting note (at time of this lemma moving to Std): removing attribute `nolint simpNF`
+attribute [simp 1100] filterMap_cons_some
 #align list.filter_map_cons_some List.filterMap_cons_some
 
-theorem filterMap_cons (f : α → Option β) (a : α) (l : List α) :
-    filterMap f (a :: l) = Option.casesOn (f a) (filterMap f l) fun b => b :: filterMap f l := by
-  generalize eq : f a = b
-  cases b
-  · rw [filterMap_cons_none _ _ eq]
-  · rw [filterMap_cons_some _ _ _ eq]
 #align list.filter_map_cons List.filterMap_cons
 
-theorem filterMap_append {α β : Type _} (l l' : List α) (f : α → Option β) :
-    filterMap f (l ++ l') = filterMap f l ++ filterMap f l' := by
-  induction' l with hd tl hl generalizing l'
-  · simp
-  · rw [cons_append, filterMap, filterMap]
-    cases f hd <;> simp only [filterMap, hl, cons_append, eq_self_iff_true, and_self_iff]
 #align list.filter_map_append List.filterMap_append
 
-theorem filterMap_eq_map (f : α → β) : filterMap (some ∘ f) = map f := by
-  funext l
-  induction' l with a l IH; · rfl
-  simp only [filterMap_cons_some (some ∘ f) _ _ rfl, IH, map_cons]
 #align list.filter_map_eq_map List.filterMap_eq_map
 
-theorem filterMap_eq_filter (p : α → Bool) :
-    filterMap (Option.guard (p ·)) = filter p := by
-  funext l
-  induction' l with a l IH; · rfl
-  by_cases pa : p a
-  · simp only [filterMap, Option.guard, pa, ite_true, filter, decide_True, ← IH]
-  · simp only [filterMap, Option.guard, pa, ite_false, filter, decide_False, ← IH]
 #align list.filter_map_eq_filter List.filterMap_eq_filter
 
-theorem filterMap_filterMap (f : α → Option β) (g : β → Option γ) (l : List α) :
-    filterMap g (filterMap f l) = filterMap (fun x => (f x).bind g) l := by
-  induction' l with a l IH; · rfl
-  cases' h : f a with b
-  · rw [filterMap_cons_none _ _ h, filterMap_cons_none, IH]
-    simp only [h, Option.none_bind']
-  rw [filterMap_cons_some _ _ _ h]
-  cases' h' : g b with c <;> [rw [filterMap_cons_none _ _ h', filterMap_cons_none, IH],
-      rw [filterMap_cons_some _ _ _ h', filterMap_cons_some, IH]] <;>
-    simp only [h, h', Option.some_bind']
 #align list.filter_map_filter_map List.filterMap_filterMap
 
-theorem map_filterMap (f : α → Option β) (g : β → γ) (l : List α) :
-    map g (filterMap f l) = filterMap (fun x => (f x).map g) l := by
-  simp only [← filterMap_eq_map, filterMap_filterMap, Option.map_eq_bind]
 #align list.map_filter_map List.map_filterMap
 
-theorem filterMap_map (f : α → β) (g : β → Option γ) (l : List α) :
-    filterMap g (map f l) = filterMap (g ∘ f) l := by
-  rw [← filterMap_eq_map, filterMap_filterMap]; rfl
 #align list.filter_map_map List.filterMap_map
 
-theorem filter_filterMap (f : α → Option β) (p : β → Bool) (l : List α) :
-    filter p (filterMap f l) = filterMap (fun x => (f x).filter p) l := by
-  rw [← filterMap_eq_filter, filterMap_filterMap]
-  congr
-  funext x
-  cases f x <;> simp [Option.filter, Option.guard]
 #align list.filter_filter_map List.filter_filterMap
 
-theorem filterMap_filter (p : α → Bool) (f : α → Option β) (l : List α) :
-    filterMap f (filter p l) = filterMap (fun x => if p x then f x else none) l := by
-  rw [← filterMap_eq_filter, filterMap_filterMap]; congr
-  funext x
-  by_cases h : p x <;> simp [Option.guard, h]
 #align list.filter_map_filter List.filterMap_filter
 
-@[simp]
-theorem filterMap_some (l : List α) : filterMap some l = l := by
-  erw [filterMap_eq_map]; apply map_id
 #align list.filter_map_some List.filterMap_some
 
-theorem map_filterMap_some_eq_filter_map_is_some (f : α → Option β) (l : List α) :
-    (l.filterMap f).map some = (l.map f).filter fun b => b.isSome := by
-  induction' l with x xs ih
-  · rfl
-  · cases h : f x <;> rw [List.filterMap_cons, h] <;> simp [h, ih]
 #align list.map_filter_map_some_eq_filter_map_is_some List.map_filterMap_some_eq_filter_map_is_some
 
-@[simp]
-theorem mem_filterMap (f : α → Option β) (l : List α) {b : β} :
-    b ∈ filterMap f l ↔ ∃ a, a ∈ l ∧ f a = some b := by
-  induction' l with a l IH
-  · constructor
-    · intro H
-      cases H
-    · rintro ⟨_, H, _⟩
-      cases H
-  cases' h : f a with b'
-  · have : f a ≠ some b := by
-      rw [h]
-      intro
-      contradiction
-    simp only [filterMap_cons_none _ _ h, IH, mem_cons, or_and_right, exists_or,
-      exists_eq_left, this, false_or_iff]
-  · have : f a = some b ↔ b = b' := by
-      constructor <;> intro t
-      · rw [t] at h; injection h
-      · exact t.symm ▸ h
-    simp only [filterMap_cons_some _ _ _ h, IH, mem_cons, or_and_right, exists_or, this,
-      exists_eq_left]
 #align list.mem_filter_map List.mem_filterMap
 
-@[simp]
-theorem filterMap_join (f : α → Option β) (L : List (List α)) :
-    filterMap f (join L) = join (map (filterMap f) L) := by
-  induction' L with hd tl ih
-  · rfl
-  · rw [map, join, join, filterMap_append, ih]
 #align list.filter_map_join List.filterMap_join
 
-theorem map_filterMap_of_inv (f : α → Option β) (g : β → α) (H : ∀ x : α, (f x).map g = some x)
-    (l : List α) : map g (filterMap f l) = l := by simp only [map_filterMap, H, filterMap_some]
 #align list.map_filter_map_of_inv List.map_filterMap_of_inv
 
-theorem length_filter_le (p : α → Bool) (l : List α) :
-    (l.filter p).length ≤ l.length :=
-  (List.filter_sublist _).length_le
 #align list.length_filter_le List.length_filter_leₓ
 
-theorem length_filterMap_le (f : α → Option β) (l : List α) :
-    (List.filterMap f l).length ≤ l.length := by
-  rw [←List.length_map _ some, List.map_filterMap_some_eq_filter_map_is_some, ←List.length_map _ f]
-  apply List.length_filter_le
 #align list.length_filter_map_le List.length_filterMap_le
 
-theorem Sublist.filterMap (f : α → Option β) {l₁ l₂ : List α} (s : l₁ <+ l₂) :
-    filterMap f l₁ <+ filterMap f l₂ := by
-  induction' s with l₁ l₂ a s IH l₁ l₂ a s IH
-  . simp
-  . rw [filterMap]
-    cases f a <;> simp [IH, Sublist.cons]
-  . rw [filterMap, filterMap]
-    cases f a <;> simp [IH, Sublist.cons₂]
 #align list.sublist.filter_map List.Sublist.filterMap
 
 theorem Sublist.map (f : α → β) {l₁ l₂ : List α} (s : l₁ <+ l₂) : map f l₁ <+ map f l₂ :=
@@ -3755,14 +3577,6 @@ theorem filter_eq_foldr (p : α → Bool) (l : List α) :
   induction l <;> simp [*, filter]; rfl
 #align list.filter_eq_foldr List.filter_eq_foldr
 
-theorem filter_congr' {p q : α → Bool} :
-    ∀ {l : List α}, (∀ x ∈ l, p x ↔ q x) → filter p l = filter q l
-  | [], _ => rfl
-  | a :: l, h => by
-    rw [forall_mem_cons] at h; by_cases pa : p a <;>
-      [simp only [filter_cons_of_pos _ pa, filter_cons_of_pos _ (h.1.1 pa), filter_congr' h.2],
-      simp only [filter_cons_of_neg _ pa, filter_cons_of_neg _ (mt h.1.2 pa),
-        filter_congr' h.2]]
 #align list.filter_congr' List.filter_congr'
 
 @[simp]
@@ -3801,32 +3615,14 @@ theorem monotone_filter_left (p : α → Bool) ⦃l l' : List α⦄ (h : l ⊆ l
   exact ⟨h hx.left, hx.right⟩
 #align list.monotone_filter_left List.monotone_filter_left
 
-theorem filter_eq_self {l} : filter p l = l ↔ ∀ a ∈ l, p a := by
-  induction' l with a l ih
-  · exact iff_of_true rfl (forall_mem_nil _)
-  rw [forall_mem_cons]
-  by_cases h : p a
-  · rw [filter_cons_of_pos _ h, cons_inj, ih, and_iff_right h]
-  · refine' iff_of_false (fun hl => h <| of_mem_filter (_ : a ∈ filter p (a :: l))) (mt And.left h)
-    rw [hl]
-    exact mem_cons_self _ _
 #align list.filter_eq_self List.filter_eq_self
 
-theorem filter_length_eq_length {l} : (filter p l).length = l.length ↔ ∀ a ∈ l, p a :=
-  Iff.trans ⟨l.filter_sublist.eq_of_length, congr_arg List.length⟩ filter_eq_self
 #align list.filter_length_eq_length List.filter_length_eq_length
 
-theorem filter_eq_nil {l} : filter p l = [] ↔ ∀ a ∈ l, ¬p a := by
-  simp only [eq_nil_iff_forall_not_mem, mem_filter, not_and]
 #align list.filter_eq_nil List.filter_eq_nil
 
 variable (p)
 
-theorem Sublist.filter {l₁ l₂} (s : l₁ <+ l₂) : filter p l₁ <+ filter p l₂ := by
-  have := filterMap_eq_filter (fun a => p a)
-  simp only [Bool.decide_coe] at this
-  rw [← this]
-  apply s.filterMap
 #align list.sublist.filter List.Sublist.filter
 
 theorem monotone_filter_right (l : List α) ⦃p q : α → Bool⦄
@@ -3844,18 +3640,8 @@ theorem monotone_filter_right (l : List α) ⦃p q : α → Bool⦄
         exact IH
 #align list.monotone_filter_right List.monotone_filter_right
 
-theorem map_filter (f : β → α) (l : List β) : filter p (map f l) = map f (filter (p ∘ f) l) := by
-  rw [← filterMap_eq_map, filter_filterMap, filterMap_filter]; rfl
 #align list.map_filter List.map_filter
 
-@[simp]
-theorem filter_filter (q) :
-    ∀ l, filter p (filter q l) = filter (fun a => p a ∧ q a) l
-  | [] => rfl
-  | a :: l => by
-    by_cases hp : p a <;> by_cases hq : q a <;>
-      simp only [hp, hq, filter, if_true, if_false, true_and_iff, false_and_iff, filter_filter _ l,
-        eq_self_iff_true, decide_True, decide_False]
 #align list.filter_filter List.filter_filter
 
 @[simp]
@@ -4013,8 +3799,6 @@ variable [DecidableEq α]
 #align list.erase_sublist List.erase_sublistₓ -- DecidableEq -> BEq
 #align list.erase_subset List.erase_subsetₓ -- DecidableEq -> BEq
 
-theorem Sublist.erase (a : α) {l₁ l₂ : List α} (h : l₁ <+ l₂) : l₁.erase a <+ l₂.erase a := by
-  simp [erase_eq_eraseP]; exact Sublist.eraseP h
 #align list.sublist.erase List.Sublist.eraseₓ -- DecidableEq -> BEq
 
 #align list.mem_of_mem_erase List.mem_of_mem_eraseₓ -- DecidableEq -> BEq
@@ -4040,57 +3824,24 @@ section Diff
 
 variable [DecidableEq α]
 
-@[simp]
-theorem diff_nil (l : List α) : l.diff [] = l :=
-  rfl
 #align list.diff_nil List.diff_nil
 
-@[simp]
-theorem diff_cons (l₁ l₂ : List α) (a : α) : l₁.diff (a :: l₂) = (l₁.erase a).diff l₂ :=
-  if h : elem a l₁ then by simp only [List.diff, if_pos h]
-  else by simp only [List.diff, if_neg h, erase_of_not_mem (mt elem_eq_true_of_mem h)]
 #align list.diff_cons List.diff_cons
 
-theorem diff_cons_right (l₁ l₂ : List α) (a : α) : l₁.diff (a :: l₂) = (l₁.diff l₂).erase a := by
-  induction' l₂ with b l₂ ih generalizing l₁ a
-  · simp_rw [diff_cons, diff_nil]
-  · rw [diff_cons, diff_cons, erase_comm, ← diff_cons, ih, ← diff_cons]
 #align list.diff_cons_right List.diff_cons_right
 
-theorem diff_erase (l₁ l₂ : List α) (a : α) : (l₁.diff l₂).erase a = (l₁.erase a).diff l₂ := by
-  rw [← diff_cons_right, diff_cons]
 #align list.diff_erase List.diff_erase
 
-@[simp]
-theorem nil_diff (l : List α) : [].diff l = [] := by
-  induction l <;> [rfl, simp only [*, diff_cons, erase_of_not_mem (not_mem_nil _)]]
 #align list.nil_diff List.nil_diff
 
-theorem cons_diff (a : α) (l₁ l₂ : List α) :
-    (a :: l₁).diff l₂ = if a ∈ l₂ then l₁.diff (l₂.erase a) else a :: l₁.diff l₂ := by
-  induction' l₂ with b l₂ ih; · rfl
-  rcases eq_or_ne a b with (rfl | hne)
-  · simp
-  · simp only [mem_cons, *, false_or_iff, diff_cons_right]
-    split_ifs with h₂ <;> simp [diff_erase, List.erase, mt eq_of_beq hne, mt eq_of_beq hne.symm]
 #align list.cons_diff List.cons_diff
 
-theorem cons_diff_of_mem {a : α} {l₂ : List α} (h : a ∈ l₂) (l₁ : List α) :
-    (a :: l₁).diff l₂ = l₁.diff (l₂.erase a) := by rw [cons_diff, if_pos h]
 #align list.cons_diff_of_mem List.cons_diff_of_mem
 
-theorem cons_diff_of_not_mem {a : α} {l₂ : List α} (h : a ∉ l₂) (l₁ : List α) :
-    (a :: l₁).diff l₂ = a :: l₁.diff l₂ := by rw [cons_diff, if_neg h]
 #align list.cons_diff_of_not_mem List.cons_diff_of_not_mem
 
-theorem diff_eq_foldl : ∀ l₁ l₂ : List α, l₁.diff l₂ = foldl List.erase l₁ l₂
-  | _, [] => rfl
-  | l₁, a :: l₂ => (diff_cons l₁ l₂ a).trans (diff_eq_foldl _ _)
 #align list.diff_eq_foldl List.diff_eq_foldl
 
-@[simp]
-theorem diff_append (l₁ l₂ l₃ : List α) : l₁.diff (l₂ ++ l₃) = (l₁.diff l₂).diff l₃ := by
-  simp only [diff_eq_foldl, foldl_append]
 #align list.diff_append List.diff_append
 
 @[simp]
@@ -4099,31 +3850,12 @@ theorem map_diff [DecidableEq β] {f : α → β} (finj : Injective f) {l₁ l�
   simp only [diff_eq_foldl, foldl_map, map_foldl_erase finj]
 #align list.map_diff List.map_diff
 
-theorem diff_sublist : ∀ l₁ l₂ : List α, l₁.diff l₂ <+ l₁
-  | _, [] => Sublist.refl _
-  | l₁, a :: l₂ =>
-    calc
-      l₁.diff (a :: l₂) = (l₁.erase a).diff l₂ := diff_cons _ _ _
-      _ <+ l₁.erase a := diff_sublist _ _
-      _ <+ l₁ := List.erase_sublist _ _
 #align list.diff_sublist List.diff_sublist
 
-theorem diff_subset (l₁ l₂ : List α) : l₁.diff l₂ ⊆ l₁ :=
-  (diff_sublist _ _).subset
 #align list.diff_subset List.diff_subset
 
-theorem mem_diff_of_mem {a : α} : ∀ {l₁ l₂ : List α}, a ∈ l₁ → a ∉ l₂ → a ∈ l₁.diff l₂
-  | _, [], h₁, _ => h₁
-  | l₁, b :: l₂, h₁, h₂ => by
-    rw [diff_cons] ;
-      exact
-        mem_diff_of_mem ((mem_erase_of_ne (ne_of_not_mem_cons h₂)).2 h₁)
-          (not_mem_of_not_mem_cons h₂)
 #align list.mem_diff_of_mem List.mem_diff_of_mem
 
-theorem Sublist.diff_right : ∀ {l₁ l₂ l₃ : List α}, l₁ <+ l₂ → l₁.diff l₃ <+ l₂.diff l₃
-  | _,  _, [], h => h
-  | l₁, l₂, a :: l₃, h => by simp only [diff_cons, (h.erase _).diff_right]
 #align list.sublist.diff_right List.Sublist.diff_right
 
 theorem erase_diff_erase_sublist_of_sublist {a : α} :

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -3618,15 +3618,6 @@ theorem monotone_filter_left (p : α → Bool) ⦃l l' : List α⦄ (h : l ⊆ l
 
 variable (p)
 
--- Porting note: The lemma `Sublist.filter` accidentally had its argument `p` change from explicit
--- to implicit when it was moved from Mathlib to Std.  This is a temporary copy providing the
--- explicit version, to be removed after `Std` is corrected.
-theorem Sublist.filter' {l₁ l₂} (s : l₁ <+ l₂) : l₁.filter p <+ l₂.filter p := by
-  have := filterMap_eq_filter (fun a => p a)
-  simp only [Bool.decide_coe] at this
-  rw [← this]
-  apply s.filterMap
-
 #align list.sublist.filter List.Sublist.filter
 
 theorem monotone_filter_right (l : List α) ⦃p q : α → Bool⦄

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -3623,6 +3623,15 @@ theorem monotone_filter_left (p : α → Bool) ⦃l l' : List α⦄ (h : l ⊆ l
 
 variable (p)
 
+-- Porting note: The lemma `Sublist.filter` accidentally had its argument `p` change from explicit to
+-- implicit when it was moved from Mathlib to Std.  This is a temporary copy providing the explicit
+-- version, to be removed after `Std` is corrected.
+theorem Sublist.filter' {l₁ l₂} (s : l₁ <+ l₂) : l₁.filter p <+ l₂.filter p := by
+  have := filterMap_eq_filter (fun a => p a)
+  simp only [Bool.decide_coe] at this
+  rw [← this]
+  apply s.filterMap
+
 #align list.sublist.filter List.Sublist.filter
 
 theorem monotone_filter_right (l : List α) ⦃p q : α → Bool⦄

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -1079,9 +1079,8 @@ theorem eq_nil_of_sublist_nil {l : List α} (s : l <+ []) : l = [] :=
   eq_nil_of_subset_nil <| s.subset
 #align list.eq_nil_of_sublist_nil List.eq_nil_of_sublist_nil
 
-@[simp]
-theorem sublist_nil_iff_eq_nil {l : List α} : l <+ [] ↔ l = [] :=
-  ⟨eq_nil_of_sublist_nil, fun H => H ▸ Sublist.refl _⟩
+-- Porting note: this lemma seems to have been renamed on the occasion of its move to Std4
+alias sublist_nil ← sublist_nil_iff_eq_nil
 #align list.sublist_nil_iff_eq_nil List.sublist_nil_iff_eq_nil
 
 #align list.replicate_sublist_replicate List.replicate_sublist_replicate

--- a/Mathlib/Data/List/Card.lean
+++ b/Mathlib/Data/List/Card.lean
@@ -158,7 +158,7 @@ theorem card_map_eq_of_inj_on {f : α → β} {as : List α} :
       intro inj_on'
       cases (exists_of_mem_map h) with
       | intro x hx =>
-        have : a = x := inj_on' (mem_cons_self ..) (mem_cons_of_mem _ hx.1) hx.2
+        have : x = a := inj_on' (mem_cons_of_mem _ hx.1) (mem_cons_self ..) hx.2
         have h1 : a ∈ as := this ▸ hx.1
         have h2 : inj_on f as := inj_on_of_subset inj_on' (subset_cons _ _)
         rw [map, card_cons_of_mem h, ih h2, card_cons_of_mem h1]

--- a/Mathlib/Data/List/Count.lean
+++ b/Mathlib/Data/List/Count.lean
@@ -121,7 +121,7 @@ theorem length_filter_lt_length_iff_exists (l) :
 #align list.length_filter_lt_length_iff_exists List.length_filter_lt_length_iff_exists
 
 theorem Sublist.countp_le (s : l₁ <+ l₂) : countp p l₁ ≤ countp p l₂ := by
-  simpa only [countp_eq_length_filter] using length_le_of_sublist (s.filter p)
+  simpa only [countp_eq_length_filter] using length_le_of_sublist (s.filter' p)
 #align list.sublist.countp_le List.Sublist.countp_le
 
 @[simp]

--- a/Mathlib/Data/List/Count.lean
+++ b/Mathlib/Data/List/Count.lean
@@ -121,7 +121,7 @@ theorem length_filter_lt_length_iff_exists (l) :
 #align list.length_filter_lt_length_iff_exists List.length_filter_lt_length_iff_exists
 
 theorem Sublist.countp_le (s : l₁ <+ l₂) : countp p l₁ ≤ countp p l₂ := by
-  simpa only [countp_eq_length_filter] using length_le_of_sublist (s.filter' p)
+  simpa only [countp_eq_length_filter] using length_le_of_sublist (s.filter p)
 #align list.sublist.countp_le List.Sublist.countp_le
 
 @[simp]

--- a/Mathlib/Data/List/Dedup.lean
+++ b/Mathlib/Data/List/Dedup.lean
@@ -129,7 +129,7 @@ theorem sum_map_count_dedup_filter_eq_countp (p : α → Bool) (l : List α) :
       · refine' _root_.trans (sum_map_eq_nsmul_single a _ fun _ h _ => by simp [h]) _
         simp [hp, count_dedup]
       · refine' _root_.trans (List.sum_eq_zero fun n hn => _) (by simp [hp])
-        obtain ⟨a', ha'⟩ := List.mem_map'.1 hn
+        obtain ⟨a', ha'⟩ := List.mem_map.1 hn
         split_ifs at ha' with ha
         · simp only [ha, mem_filter, mem_dedup, find?, mem_cons, true_or, hp,
             and_false, false_and] at ha'

--- a/Mathlib/Data/List/FinRange.lean
+++ b/Mathlib/Data/List/FinRange.lean
@@ -78,7 +78,7 @@ open List
 theorem Equiv.Perm.map_finRange_perm {n : ℕ} (σ : Equiv.Perm (Fin n)) :
     map σ (finRange n) ~ finRange n := by
   rw [perm_ext ((nodup_finRange n).map σ.injective) <| nodup_finRange n]
-  simpa [mem_map', mem_finRange, true_and_iff, iff_true_iff] using σ.surjective
+  simpa [mem_map, mem_finRange, true_and_iff, iff_true_iff] using σ.surjective
 #align equiv.perm.map_fin_range_perm Equiv.Perm.map_finRange_perm
 
 /-- The list obtained from a permutation of a tuple `f` is permutation equivalent to

--- a/Mathlib/Data/List/Join.lean
+++ b/Mathlib/Data/List/Join.lean
@@ -82,7 +82,7 @@ theorem length_bind (l : List α) (f : α → List β) :
 @[simp]
 theorem bind_eq_nil {l : List α} {f : α → List β} : List.bind l f = [] ↔ ∀ x ∈ l, f x = [] :=
   join_eq_nil.trans <| by
-    simp only [mem_map', forall_exists_index, and_imp, forall_apply_eq_imp_iff₂]
+    simp only [mem_map, forall_exists_index, and_imp, forall_apply_eq_imp_iff₂]
 #align list.bind_eq_nil List.bind_eq_nil
 
 /-- In a join, taking the first elements up to an index which is the sum of the lengths of the

--- a/Mathlib/Data/List/Nodup.lean
+++ b/Mathlib/Data/List/Nodup.lean
@@ -255,8 +255,8 @@ theorem inj_on_of_nodup_map {f : α → β} {l : List α} (d : Nodup (map f l)) 
     simp only [mem_cons]
     rintro _ (rfl | h₁) _ (rfl | h₂) h₃
     · rfl
-    · apply (d.1 _ h₂ h₃).elim
-    · apply (d.1 _ h₁ h₃.symm).elim
+    · apply (d.1 _ h₂ h₃.symm).elim
+    · apply (d.1 _ h₁ h₃).elim
     · apply ih d.2 h₁ h₂ h₃
 #align list.inj_on_of_nodup_map List.inj_on_of_nodup_map
 
@@ -340,8 +340,8 @@ theorem nodup_bind {l₁ : List α} {f : α → List β} :
       (∀ x ∈ l₁, Nodup (f x)) ∧ Pairwise (fun a b : α => Disjoint (f a) (f b)) l₁ := by
   simp only [List.bind, nodup_join, pairwise_map, and_comm, and_left_comm, mem_map, exists_imp,
       and_imp]
-  rw [show (∀ (l : List β) (x : α), l = f x → x ∈ l₁ → Nodup l) ↔ ∀ x : α, x ∈ l₁ → Nodup (f x)
-      from forall_swap.trans <| forall_congr' fun _ => forall_eq]
+  rw [show (∀ (l : List β) (x : α), f x = l → x ∈ l₁ → Nodup l) ↔ ∀ x : α, x ∈ l₁ → Nodup (f x)
+      from forall_swap.trans <| forall_congr' fun _ => forall_eq']
 #align list.nodup_bind List.nodup_bind
 
 protected theorem Nodup.product {l₂ : List β} (d₁ : l₁.Nodup) (d₂ : l₂.Nodup) :

--- a/Mathlib/Data/List/Pairwise.lean
+++ b/Mathlib/Data/List/Pairwise.lean
@@ -267,7 +267,7 @@ theorem pairwise_join {L : List (List α)} :
 theorem pairwise_bind {R : β → β → Prop} {l : List α} {f : α → List β} :
     List.Pairwise R (l.bind f) ↔
       (∀ a ∈ l, Pairwise R (f a)) ∧ Pairwise (fun a₁ a₂ => ∀ x ∈ f a₁, ∀ y ∈ f a₂, R x y) l :=
-  by simp [List.bind, List.pairwise_join, List.mem_map', List.pairwise_map]
+  by simp [List.bind, List.pairwise_join, List.mem_map, List.pairwise_map]
 #align list.pairwise_bind List.pairwise_bind
 
 #align list.pairwise_reverse List.pairwise_reverse

--- a/Mathlib/Data/List/Pairwise.lean
+++ b/Mathlib/Data/List/Pairwise.lean
@@ -182,7 +182,7 @@ theorem pairwise_middle (s : Symmetric R) {a : α} {l₁ l₂ : List α} :
     ∀ {l : List β}, Pairwise R (map f l) ↔ Pairwise (fun a b : β => R (f a) (f b)) l
   | [] => by simp only [map, Pairwise.nil]
   | b :: l => by
-    simp only [map, pairwise_cons, mem_map', forall_exists_index, and_imp,
+    simp only [map, pairwise_cons, mem_map, forall_exists_index, and_imp,
       forall_apply_eq_imp_iff₂, pairwise_map]
 #align list.pairwise_map List.pairwise_map'
 

--- a/Mathlib/Data/List/Perm.lean
+++ b/Mathlib/Data/List/Perm.lean
@@ -459,7 +459,7 @@ theorem Subperm.subset {l₁ l₂ : List α} : l₁ <+~ l₂ → l₁ ⊆ l₂
 theorem Subperm.filter (p : α → Bool) ⦃l l' : List α⦄ (h : l <+~ l') :
     filter p l <+~ filter p l' := by
   obtain ⟨xs, hp, h⟩ := h
-  exact ⟨_, hp.filter p, h.filter p⟩
+  exact ⟨_, hp.filter p, h.filter' p⟩
 #align list.subperm.filter List.Subperm.filter
 
 end Subperm

--- a/Mathlib/Data/List/Perm.lean
+++ b/Mathlib/Data/List/Perm.lean
@@ -459,7 +459,7 @@ theorem Subperm.subset {l₁ l₂ : List α} : l₁ <+~ l₂ → l₁ ⊆ l₂
 theorem Subperm.filter (p : α → Bool) ⦃l l' : List α⦄ (h : l <+~ l') :
     filter p l <+~ filter p l' := by
   obtain ⟨xs, hp, h⟩ := h
-  exact ⟨_, hp.filter p, h.filter' p⟩
+  exact ⟨_, hp.filter p, h.filter p⟩
 #align list.subperm.filter List.Subperm.filter
 
 end Subperm

--- a/Mathlib/Data/List/Perm.lean
+++ b/Mathlib/Data/List/Perm.lean
@@ -1378,7 +1378,7 @@ theorem count_permutations'Aux_self [DecidableEq α] (l : List α) (x : α) :
     · subst hx
       simpa [takeWhile, Nat.succ_inj', DecEq_eq] using IH _
     · rw [takeWhile]
-      simp only [mem_map', cons.injEq, Ne.symm hx, false_and, and_false, exists_false,
+      simp only [mem_map, cons.injEq, Ne.symm hx, false_and, and_false, exists_false,
         not_false_iff, count_eq_zero_of_not_mem, zero_add, hx, decide_False, length_nil]
 #align list.count_permutations'_aux_self List.count_permutations'Aux_self
 
@@ -1411,7 +1411,7 @@ theorem nodup_permutations'Aux_of_not_mem (s : List α) (x : α) (hx : x ∉ s) 
   induction' s with y s IH
   · simp
   · simp only [not_or, mem_cons] at hx
-    simp only [permutations'Aux, nodup_cons, mem_map', cons.injEq, exists_eq_right_right, not_and]
+    simp only [permutations'Aux, nodup_cons, mem_map, cons.injEq, exists_eq_right_right, not_and]
     refine' ⟨fun _ => Ne.symm hx.left, _⟩
     rw [nodup_map_iff]
     · exact IH hx.right

--- a/Mathlib/Data/List/Rotate.lean
+++ b/Mathlib/Data/List/Rotate.lean
@@ -501,8 +501,8 @@ theorem isRotated_iff_mod : l ~r l' ↔ ∃ n ≤ l.length, l.rotate n = l' := b
 theorem isRotated_iff_mem_map_range : l ~r l' ↔ l' ∈ (List.range (l.length + 1)).map l.rotate := by
   simp_rw [mem_map, mem_range, isRotated_iff_mod]
   exact
-    ⟨fun ⟨n, hn, h⟩ => ⟨n, Nat.lt_succ_of_le hn, h.symm⟩,
-      fun ⟨n, hn, h⟩ => ⟨n, Nat.le_of_lt_succ hn, h.symm⟩⟩
+    ⟨fun ⟨n, hn, h⟩ => ⟨n, Nat.lt_succ_of_le hn, h⟩,
+      fun ⟨n, hn, h⟩ => ⟨n, Nat.le_of_lt_succ hn, h⟩⟩
 #align list.is_rotated_iff_mem_map_range List.isRotated_iff_mem_map_range
 
 -- Porting note: @[congr] only works for equality.

--- a/Mathlib/Data/List/Sections.lean
+++ b/Mathlib/Data/List/Sections.lean
@@ -34,9 +34,7 @@ theorem mem_sections {L : List (List α)} {f} : f ∈ sections L ↔ Forall₂ (
   · induction' h with a l f L al fL fs
     · simp only [sections, mem_singleton]
     simp only [sections, bind_eq_bind, mem_bind, mem_map]
-    use f
-    simp only [cons.injEq, and_true, exists_eq_right']
-    exact ⟨fs, al⟩
+    exact ⟨f, fs, a, al, rfl⟩
 #align list.mem_sections List.mem_sections
 
 theorem mem_sections_length {L : List (List α)} {f} (h : f ∈ sections L) : length f = length L :=

--- a/Mathlib/Data/List/Sigma.lean
+++ b/Mathlib/Data/List/Sigma.lean
@@ -62,7 +62,7 @@ theorem mem_keys_of_mem {s : Sigma β} {l : List (Sigma β)} : s ∈ l → s.1 �
 
 theorem exists_of_mem_keys {a} {l : List (Sigma β)} (h : a ∈ l.keys) :
     ∃ b : β a, Sigma.mk a b ∈ l :=
-  let ⟨⟨_, b'⟩, m, e⟩ := exists_of_mem_map' h
+  let ⟨⟨_, b'⟩, m, e⟩ := exists_of_mem_map h
   Eq.recOn e (Exists.intro b' m)
 #align list.exists_of_mem_keys List.exists_of_mem_keys
 

--- a/Mathlib/Data/Multiset/Antidiagonal.lean
+++ b/Mathlib/Data/Multiset/Antidiagonal.lean
@@ -52,8 +52,8 @@ theorem mem_antidiagonal {s : Multiset α} {x : Multiset α × Multiset α} :
     dsimp only [quot_mk_to_coe, antidiagonal_coe]
     refine' ⟨fun h => revzip_powersetAux h, fun h ↦ _⟩
     haveI := Classical.decEq α
-    simp only [revzip_powersetAux_lemma l revzip_powersetAux, h.symm, ge_iff_le, mem_coe, mem_map',
-      mem_powersetAux]
+    simp only [revzip_powersetAux_lemma l revzip_powersetAux, h.symm, ge_iff_le, mem_coe,
+      List.mem_map, mem_powersetAux]
     cases' x with x₁ x₂
     exact ⟨x₁, le_add_right _ _, by rw [add_tsub_cancel_left x₁ x₂]⟩
 #align multiset.mem_antidiagonal Multiset.mem_antidiagonal

--- a/Mathlib/Data/Multiset/Basic.lean
+++ b/Mathlib/Data/Multiset/Basic.lean
@@ -1968,7 +1968,7 @@ theorem filter_subset (s : Multiset α) : filter p s ⊆ s :=
 #align multiset.filter_subset Multiset.filter_subset
 
 theorem filter_le_filter {s t} (h : s ≤ t) : filter p s ≤ filter p t :=
-  leInductionOn h fun h => (h.filter (p ·)).subperm
+  leInductionOn h fun h => (h.filter' (p ·)).subperm
 #align multiset.filter_le_filter Multiset.filter_le_filter
 
 theorem monotone_filter_left : Monotone (filter p) := fun _s _t => filter_le_filter p

--- a/Mathlib/Data/Multiset/Basic.lean
+++ b/Mathlib/Data/Multiset/Basic.lean
@@ -1236,7 +1236,7 @@ theorem map_nsmul (f : α → β) (n : ℕ) (s) : map f (n • s) = n • map f 
 
 @[simp]
 theorem mem_map {f : α → β} {b : β} {s : Multiset α} : b ∈ map f s ↔ ∃ a, a ∈ s ∧ f a = b :=
-  Quot.inductionOn s fun _l => mem_map'
+  Quot.inductionOn s fun _l => List.mem_map
 #align multiset.mem_map Multiset.mem_map
 
 @[simp]

--- a/Mathlib/Data/Multiset/Basic.lean
+++ b/Mathlib/Data/Multiset/Basic.lean
@@ -1968,7 +1968,7 @@ theorem filter_subset (s : Multiset α) : filter p s ⊆ s :=
 #align multiset.filter_subset Multiset.filter_subset
 
 theorem filter_le_filter {s t} (h : s ≤ t) : filter p s ≤ filter p t :=
-  leInductionOn h fun h => (h.filter' (p ·)).subperm
+  leInductionOn h fun h => (h.filter (p ·)).subperm
 #align multiset.filter_le_filter Multiset.filter_le_filter
 
 theorem monotone_filter_left : Monotone (filter p) := fun _s _t => filter_le_filter p

--- a/Mathlib/Data/Multiset/Powerset.lean
+++ b/Mathlib/Data/Multiset/Powerset.lean
@@ -125,7 +125,7 @@ theorem card_powerset (s : Multiset α) : card (powerset s) = 2 ^ card s :=
 #align multiset.card_powerset Multiset.card_powerset
 
 theorem revzip_powersetAux {l : List α} ⦃x⦄ (h : x ∈ revzip (powersetAux l)) : x.1 + x.2 = ↑l := by
-  rw [revzip, powersetAux_eq_map_coe, ← map_reverse, zip_map, ← revzip, mem_map'] at h
+  rw [revzip, powersetAux_eq_map_coe, ← map_reverse, zip_map, ← revzip, List.mem_map] at h
   simp only [Prod_map, Prod.exists] at h
   rcases h with ⟨l₁, l₂, h, rfl, rfl⟩
   exact Quot.sound (revzip_sublists _ _ _ h)
@@ -133,7 +133,7 @@ theorem revzip_powersetAux {l : List α} ⦃x⦄ (h : x ∈ revzip (powersetAux 
 
 theorem revzip_powersetAux' {l : List α} ⦃x⦄ (h : x ∈ revzip (powersetAux' l)) :
     x.1 + x.2 = ↑l := by
-  rw [revzip, powersetAux', ← map_reverse, zip_map, ← revzip, mem_map'] at h
+  rw [revzip, powersetAux', ← map_reverse, zip_map, ← revzip, List.mem_map] at h
   simp only [Prod_map, Prod.exists] at h
   rcases h with ⟨l₁, l₂, h, rfl, rfl⟩
   exact Quot.sound (revzip_sublists' _ _ _ h)

--- a/Mathlib/Data/Vector/Mem.lean
+++ b/Mathlib/Data/Vector/Mem.lean
@@ -78,7 +78,7 @@ theorem mem_of_mem_tail (v : Vector α n) (ha : a ∈ v.tail.toList) : a ∈ v.t
 
 theorem mem_map_iff (b : β) (v : Vector α n) (f : α → β) :
     b ∈ (v.map f).toList ↔ ∃ a : α, a ∈ v.toList ∧ f a = b := by
-  rw [Vector.toList_map, List.mem_map']
+  rw [Vector.toList_map, List.mem_map]
 #align vector.mem_map_iff Vector.mem_map_iff
 
 theorem not_mem_map_zero (b : β) (v : Vector α 0) (f : α → β) : b ∉ (v.map f).toList := by

--- a/Mathlib/Deprecated/Subgroup.lean
+++ b/Mathlib/Deprecated/Subgroup.lean
@@ -575,7 +575,7 @@ theorem exists_list_of_mem_closure {s : Set G} {a : G} (h : a ∈ closure s) :
     ⟨[], List.forall_mem_nil _, rfl⟩
     (fun {x} _ ⟨L, HL1, HL2⟩ =>
       ⟨L.reverse.map Inv.inv, fun x hx =>
-        let ⟨y, hy1, hy2⟩ := List.exists_of_mem_map' hx
+        let ⟨y, hy1, hy2⟩ := List.exists_of_mem_map hx
         hy2 ▸ Or.imp id (by rw [inv_inv]; exact id) (HL1 _ <| List.mem_reverse'.1 hy1).symm,
         HL2 ▸
           List.recOn L inv_one.symm fun hd tl ih => by

--- a/Mathlib/Deprecated/Subring.lean
+++ b/Mathlib/Deprecated/Subring.lean
@@ -116,7 +116,7 @@ theorem exists_list_of_mem_closure {a : R} (h : a ∈ closure s) :
     fun {b} _ ih ↦ match b, ih with
     | _, ⟨L1, h1, rfl⟩ =>
       ⟨L1.map (List.cons (-1)),
-        fun L2 h2 ↦ match L2, List.mem_map'.1 h2 with
+        fun L2 h2 ↦ match L2, List.mem_map.1 h2 with
         | _, ⟨L3, h3, rfl⟩ => List.forall_mem_cons.2 ⟨Or.inr rfl, h1 L3 h3⟩, by
         simp only [List.map_map, (· ∘ ·), List.prod_cons, neg_one_mul]
         refine' List.recOn L1 neg_zero.symm fun hd tl ih ↦ _

--- a/Mathlib/Dynamics/PeriodicPts.lean
+++ b/Mathlib/Dynamics/PeriodicPts.lean
@@ -518,7 +518,7 @@ theorem periodicOrbit_eq_nil_of_not_periodic_pt (h : x ∉ periodicPts f) :
 @[simp]
 theorem mem_periodicOrbit_iff (hx : x ∈ periodicPts f) :
     y ∈ periodicOrbit f x ↔ ∃ n, (f^[n]) x = y := by
-  simp only [periodicOrbit, Cycle.mem_coe_iff, List.mem_map', List.mem_range]
+  simp only [periodicOrbit, Cycle.mem_coe_iff, List.mem_map, List.mem_range]
   use fun ⟨a, _, ha'⟩ => ⟨a, ha'⟩
   rintro ⟨n, rfl⟩
   use n % minimalPeriod f x, mod_lt _ (minimalPeriod_pos_of_mem_periodicPts hx)

--- a/Mathlib/GroupTheory/Perm/Sign.lean
+++ b/Mathlib/GroupTheory/Perm/Sign.lean
@@ -632,7 +632,7 @@ theorem sign_prod_list_swap {l : List (Perm α)} (hl : ∀ g ∈ l, IsSwap g) :
   have h₁ : l.map sign = List.replicate l.length (-1) :=
     List.eq_replicate.2
       ⟨by simp, fun u hu =>
-        let ⟨g, hg⟩ := List.mem_map'.1 hu
+        let ⟨g, hg⟩ := List.mem_map.1 hu
         hg.2 ▸ (hl _ hg.1).sign_eq⟩
   rw [← List.prod_replicate, ← h₁, List.prod_hom _ (@sign α _ _)]
 #align equiv.perm.sign_prod_list_swap Equiv.Perm.sign_prod_list_swap
@@ -659,7 +659,7 @@ theorem eq_sign_of_surjective_hom {s : Perm α →* ℤˣ} (hs : Surjective s) :
         let ⟨g, hg⟩ := hs (-1)
         let ⟨l, hl⟩ := (truncSwapFactors g).out
         have : ∀ a ∈ l.map s, a = (1 : ℤˣ) := fun a ha =>
-          let ⟨g, hg⟩ := List.mem_map'.1 ha
+          let ⟨g, hg⟩ := List.mem_map.1 ha
           hg.2 ▸ this _ (hl.2 _ hg.1)
         have : s l.prod = 1 := by
           rw [← l.prod_hom s, List.eq_replicate_length.2 this, List.prod_replicate, one_pow]
@@ -668,7 +668,7 @@ theorem eq_sign_of_surjective_hom {s : Perm α →* ℤˣ} (hs : Surjective s) :
   MonoidHom.ext fun f => by
     let ⟨l, hl₁, hl₂⟩ := (truncSwapFactors f).out
     have hsl : ∀ a ∈ l.map s, a = (-1 : ℤˣ) := fun a ha =>
-      let ⟨g, hg⟩ := List.mem_map'.1 ha
+      let ⟨g, hg⟩ := List.mem_map.1 ha
       hg.2 ▸ this (hl₂ _ hg.1)
     rw [← hl₁, ← l.prod_hom s, List.eq_replicate_length.2 hsl, List.length_map, List.prod_replicate,
       sign_prod_list_swap hl₂]
@@ -678,7 +678,7 @@ theorem sign_subtypePerm (f : Perm α) {p : α → Prop} [DecidablePred p] (h₁
     (h₂ : ∀ x, f x ≠ x → p x) : sign (subtypePerm f h₁) = sign f := by
   let l := (truncSwapFactors (subtypePerm f h₁)).out
   have hl' : ∀ g' ∈ l.1.map ofSubtype, IsSwap g' := fun g' hg' =>
-    let ⟨g, hg⟩ := List.mem_map'.1 hg'
+    let ⟨g, hg⟩ := List.mem_map.1 hg'
     hg.2 ▸ (l.2.2 _ hg.1).of_subtype_isSwap
   have hl'₂ : (l.1.map ofSubtype).prod = f := by
     rw [l.1.prod_hom ofSubtype, l.2.1, ofSubtype_subtypePerm _ h₂]

--- a/Mathlib/RingTheory/Subsemiring/Basic.lean
+++ b/Mathlib/RingTheory/Subsemiring/Basic.lean
@@ -954,7 +954,7 @@ theorem mem_closure_iff_exists_list {R} [Semiring R] {s : Set R} {x} :
   · rintro ⟨L, HL1, HL2⟩
     exact HL2 ▸
       list_sum_mem fun r hr =>
-        let ⟨t, ht1, ht2⟩ := List.mem_map'.1 hr
+        let ⟨t, ht1, ht2⟩ := List.mem_map.1 hr
         ht2 ▸ list_prod_mem _ fun y hy => subset_closure <| HL1 t ht1 y hy
 #align subsemiring.mem_closure_iff_exists_list Subsemiring.mem_closure_iff_exists_list
 

--- a/Mathlib/SetTheory/Ordinal/CantorNormalForm.lean
+++ b/Mathlib/SetTheory/Ordinal/CantorNormalForm.lean
@@ -180,7 +180,7 @@ theorem CNF_sorted (b o : Ordinal) : ((CNF b o).map Prod.fst).Sorted (· > ·) :
       · simp only [CNF_of_lt ho hob, List.map]
       · rw [CNF_ne_zero ho, List.map_cons, List.sorted_cons]
         refine' ⟨fun a H ↦ _, IH⟩
-        rw [List.mem_map'] at H
+        rw [List.mem_map] at H
         rcases H with ⟨⟨a, a'⟩, H, rfl⟩
         exact (CNF_fst_le_log H).trans_lt (log_mod_opow_log_lt_log_self hb ho hbo)
 set_option linter.uppercaseLean3 false in

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -16,6 +16,6 @@
   {"git":
    {"url": "https://github.com/leanprover/std4",
     "subDir?": null,
-    "rev": "a5c5aec12dcb9f770d6cd1e0f9f896e45fab58c6",
+    "rev": "5507f9d8409f93b984ce04eccf4914d534e6fca2",
     "name": "std",
     "inputRev?": "main"}}]}

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -16,6 +16,6 @@
   {"git":
    {"url": "https://github.com/leanprover/std4",
     "subDir?": null,
-    "rev": "d4107bc2bd28bc70e8327578c16acb904d2bcfd0",
+    "rev": "a5c5aec12dcb9f770d6cd1e0f9f896e45fab58c6",
     "name": "std",
     "inputRev?": "main"}}]}


### PR DESCRIPTION
Notably incorporates https://github.com/leanprover/std4/pull/98 and https://github.com/leanprover/std4/pull/109.

https://github.com/leanprover/std4/pull/98 moves a number of lemmas from Mathlib to Std, so the bump requires deleting them in Mathlib.  I did check on each lemma whether its attributes were kept in the move (and gave attribute markings in Mathlib if they were not present in Std), but a reviewer may wish to re-check.

`List.mem_map` changed statement from `b ∈ l.map f ↔ ∃ a, a ∈ l ∧ b = f a` to `b ∈ l.map f ↔ ∃ a, a ∈ l ∧ f a = b`.  Similarly for `List.exists_of_mem_map`.  This was a deliberate change, so I have simply adjusted proofs (many become simpler, which supports the change).  I also deleted `List.mem_map'`, `List.exists_of_mem_map'`, which were temporary versions in Mathlib while waiting for this change (replacing their uses with the unprimed versions).

Also, the lemma `sublist_nil_iff_eq_nil` seems to have been renamed to `sublist_nil` during the move, so I added an alias for the old name.

(another issue fixed during review by @digama0) ~~`List.Sublist.filter` had an argument change from explicit to implicit.  This appears to have been an oversight (cc @JamesGallicchio).  I have temporarily introduced `List.Sublist.filter'` with the argument explicit, and replaced Mathlib uses of `Sublist.filter` with `Sublist.filter'`.  Later we can fix the argument in Std, and then delete `List.Sublist.filter'`.~~

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
