### PR TITLE
[Merged by Bors] - feat: forward-port #15990

### DIFF
--- a/Mathlib/SetTheory/Ordinal/Arithmetic.lean
+++ b/Mathlib/SetTheory/Ordinal/Arithmetic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Floris van Doorn, Violeta Hernández Palacios
 
 ! This file was ported from Lean 3 source module set_theory.ordinal.arithmetic
-! leanprover-community/mathlib commit 8da9e30545433fdd8fe55a0d3da208e5d9263f03
+! leanprover-community/mathlib commit b67044ba53af18680e1dd246861d9584e968495d
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -606,6 +606,7 @@ theorem sub_sub (a b c : Ordinal) : a - b - c = a - (b + c) :=
   eq_of_forall_ge_iff fun d => by rw [sub_le, sub_le, sub_le, add_assoc]
 #align ordinal.sub_sub Ordinal.sub_sub
 
+@[simp]
 theorem add_sub_add_cancel (a b c : Ordinal) : a + b - (a + c) = b - c := by
   rw [← sub_sub, add_sub_cancel]
 #align ordinal.add_sub_add_cancel Ordinal.add_sub_add_cancel
@@ -1031,6 +1032,10 @@ theorem mod_def (a b : Ordinal) : a % b = a - b * (a / b) :=
   rfl
 #align ordinal.mod_def Ordinal.mod_def
 
+theorem mod_le (a b : Ordinal) : a % b ≤ a :=
+  sub_le_self a _
+#align ordinal.mod_le Ordinal.mod_le
+
 @[simp]
 theorem mod_zero (a : Ordinal) : a % 0 = a := by simp only [mod_def, div_zero, zero_mul, sub_zero]
 #align ordinal.mod_zero Ordinal.mod_zero
@@ -1075,6 +1080,30 @@ theorem mod_eq_zero_of_dvd {a b : Ordinal} (H : b ∣ a) : a % b = 0 := by
 theorem dvd_iff_mod_eq_zero {a b : Ordinal} : b ∣ a ↔ a % b = 0 :=
   ⟨mod_eq_zero_of_dvd, dvd_of_mod_eq_zero⟩
 #align ordinal.dvd_iff_mod_eq_zero Ordinal.dvd_iff_mod_eq_zero
+
+@[simp]
+theorem mul_add_mod_self (x y z : Ordinal) : (x * y + z) % x = z % x :=  by
+  rcases eq_or_ne x 0 with rfl | hx
+  · simp
+  · rwa [mod_def, mul_add_div, mul_add, ← sub_sub, add_sub_cancel, mod_def]
+#align ordinal.mul_add_mod_self Ordinal.mul_add_mod_self
+
+@[simp]
+theorem mul_mod (x y : Ordinal) : x * y % x = 0 := by
+  simpa using mul_add_mod_self x y 0
+#align ordinal.mul_mod Ordinal.mul_mod
+
+theorem mod_mod_of_dvd (a : Ordinal) {b c : Ordinal} (h : c ∣ b) : a % b % c = a % c := by
+  nth_rw 2 [← div_add_mod a b]
+  rcases h with ⟨d, rfl⟩
+  rw [mul_assoc, mul_add_mod_self]
+
+#align ordinal.mod_mod_of_dvd Ordinal.mod_mod_of_dvd
+
+@[simp]
+theorem mod_mod (a b : Ordinal) : a % b % b = a % b :=
+  mod_mod_of_dvd a dvd_rfl
+#align ordinal.mod_mod Ordinal.mod_mod
 
 /-! ### Families of ordinals
 

--- a/Mathlib/SetTheory/Ordinal/Exponential.lean
+++ b/Mathlib/SetTheory/Ordinal/Exponential.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Floris van Doorn, Violeta Hernández Palacios
 
 ! This file was ported from Lean 3 source module set_theory.ordinal.exponential
-! leanprover-community/mathlib commit 8ee653c07a9ddb27ae466d045a3f0c2151b076cf
+! leanprover-community/mathlib commit b67044ba53af18680e1dd246861d9584e968495d
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -13,7 +13,7 @@ import Mathlib.SetTheory.Ordinal.Arithmetic
 /-! # Ordinal exponential
 
 In this file we define the power function and the logarithm function on ordinals. The two are
-related by the lemma `Ordinal.opow_le_iff_le_log : (b^c) ≤ x ↔ c ≤ log b x` for nontrivial inputs 
+related by the lemma `Ordinal.opow_le_iff_le_log : (b^c) ≤ x ↔ c ≤ log b x` for nontrivial inputs
 `b`, `c`.
 -/
 
@@ -211,9 +211,8 @@ theorem opow_add (a b c : Ordinal) : a^(b + c) = (a^b) * (a^c) := by
 theorem opow_one_add (a b : Ordinal) : a^(1 + b) = a * (a^b) := by rw [opow_add, opow_one]
 #align ordinal.opow_one_add Ordinal.opow_one_add
 
-theorem opow_dvd_opow (a) {b c : Ordinal} (h : b ≤ c) : (a^b) ∣ (a^c) := by
-  rw [← Ordinal.add_sub_cancel_of_le h, opow_add]
-  apply dvd_mul_right
+theorem opow_dvd_opow (a) {b c : Ordinal} (h : b ≤ c) : (a^b) ∣ (a^c) :=
+  ⟨a^(c - b), by rw [← opow_add, Ordinal.add_sub_cancel_of_le h]⟩
 #align ordinal.opow_dvd_opow Ordinal.opow_dvd_opow
 
 theorem opow_dvd_opow_iff {a b c : Ordinal} (a1 : 1 < a) : (a^b) ∣ (a^c) ↔ b ≤ c :=
@@ -428,6 +427,14 @@ theorem log_opow {b : Ordinal} (hb : 1 < b) (x : Ordinal) : log b (b^x) = x := b
     using 1
   rw [add_zero, mul_one]
 #align ordinal.log_opow Ordinal.log_opow
+
+theorem div_opow_log_pos (b : Ordinal) {o : Ordinal} (ho : o ≠ 0) : 0 < o / (b^log b o) :=
+  by
+  rcases eq_zero_or_pos b with (rfl | hb)
+  · simpa using Ordinal.pos_iff_ne_zero.2 ho
+  · rw [div_pos (opow_ne_zero _ hb.ne')]
+    exact opow_log_le_self b ho
+#align ordinal.div_opow_log_pos Ordinal.div_opow_log_pos
 
 theorem div_opow_log_lt {b : Ordinal} (o : Ordinal) (hb : 1 < b) : o / (b^log b o) < b := by
   rw [div_lt (opow_pos _ (zero_lt_one.trans hb)).ne', ← opow_succ]


### PR DESCRIPTION
---

leanprover-community/mathlib#15990

The 3rd file `set-theory.ordinal.notation` is currently being ported at #2470

 * [`set_theory.ordinal.exponential`@`8ee653c07a9ddb27ae466d045a3f0c2151b076cf`..`b67044ba53af18680e1dd246861d9584e968495d`](https://leanprover-community.github.io/mathlib-port-status/file/set_theory/ordinal/exponential?range=8ee653c07a9ddb27ae466d045a3f0c2151b076cf..b67044ba53af18680e1dd246861d9584e968495d)
* [`set_theory.ordinal.arithmetic`@`8da9e30545433fdd8fe55a0d3da208e5d9263f03`..`b67044ba53af18680e1dd246861d9584e968495d`](https://leanprover-community.github.io/mathlib-port-status/file/set_theory/ordinal/arithmetic?range=8da9e30545433fdd8fe55a0d3da208e5d9263f03..b67044ba53af18680e1dd246861d9584e968495d)


<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
