### PR TITLE
[Merged by Bors] - chore: forward-port leanprover-community/mathlib#18644

### DIFF
--- a/Mathlib/Analysis/NormedSpace/MStructure.lean
+++ b/Mathlib/Analysis/NormedSpace/MStructure.lean
@@ -64,7 +64,7 @@ M-summand, M-projection, L-summand, L-projection, M-ideal, M-structure
 
 variable (X : Type _) [NormedAddCommGroup X]
 
-variable {M : Type} [Ring M] [Module M X]
+variable {M : Type _} [Ring M] [Module M X]
 
 --porting note: Mathlib3 uses names with uppercase 'L' for L-projections
 set_option linter.uppercaseLean3 false

--- a/Mathlib/Data/List/Func.lean
+++ b/Mathlib/Data/List/Func.lean
@@ -382,14 +382,14 @@ theorem length_sub [Zero α] [Sub α] {xs ys : List α} :
 #align list.func.length_sub List.Func.length_sub
 
 @[simp]
-theorem nil_sub {α : Type} [AddGroup α] (as : List α) : sub [] as = neg as := by
+theorem nil_sub {α : Type _} [AddGroup α] (as : List α) : sub [] as = neg as := by
   rw [sub, @nil_pointwise _ _ _ ⟨0⟩ ⟨0⟩]
   congr with x
   exact zero_sub x
 #align list.func.nil_sub List.Func.nil_sub
 
 @[simp]
-theorem sub_nil {α : Type} [AddGroup α] (as : List α) : sub as [] = as := by
+theorem sub_nil {α : Type _} [AddGroup α] (as : List α) : sub as [] = as := by
   rw [sub, @pointwise_nil _ _ _ ⟨0⟩ ⟨0⟩]
   apply Eq.trans _ (map_id as)
   congr with x

--- a/Mathlib/Logic/Equiv/List.lean
+++ b/Mathlib/Logic/Equiv/List.lean
@@ -423,7 +423,7 @@ def listNatEquivNat : List ℕ ≃ ℕ :=
 #align equiv.list_nat_equiv_nat Equiv.listNatEquivNat
 
 /-- If `α` is equivalent to `ℕ`, then `List α` is equivalent to `α`. -/
-def listEquivSelfOfEquivNat {α : Type} (e : α ≃ ℕ) : List α ≃ α :=
+def listEquivSelfOfEquivNat {α : Type _} (e : α ≃ ℕ) : List α ≃ α :=
   calc
     List α ≃ List ℕ := listEquivOfEquiv e
     _ ≃ ℕ := listNatEquivNat


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

* [`logic.equiv.list`@`1126441d6bccf98c81214a0780c73d499f6721fe`..`d11893b411025250c8e61ff2f12ccbd7ee35ab15`](https://leanprover-community.github.io/mathlib-port-status/file/logic/equiv/list?range=1126441d6bccf98c81214a0780c73d499f6721fe..d11893b411025250c8e61ff2f12ccbd7ee35ab15)
* [`data.list.func`@`aba57d4d3dae35460225919dcd82fe91355162f9`..`d11893b411025250c8e61ff2f12ccbd7ee35ab15`](https://leanprover-community.github.io/mathlib-port-status/file/data/list/func?range=aba57d4d3dae35460225919dcd82fe91355162f9..d11893b411025250c8e61ff2f12ccbd7ee35ab15)
* [`analysis.normed_space.M_structure`@`17ef379e997badd73e5eabb4d38f11919ab3c4b3`..`d11893b411025250c8e61ff2f12ccbd7ee35ab15`](https://leanprover-community.github.io/mathlib-port-status/file/analysis/normed_space/M_structure?range=17ef379e997badd73e5eabb4d38f11919ab3c4b3..d11893b411025250c8e61ff2f12ccbd7ee35ab15)