### PR TITLE
[Merged by Bors] - feat: command to list declarations with long names

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1146,6 +1146,8 @@ import Mathlib.Lean.LocalContext
 import Mathlib.Lean.Message
 import Mathlib.Lean.Meta
 import Mathlib.Lean.Meta.Simp
+import Mathlib.Lean.Name
+import Mathlib.Lean.SMap
 import Mathlib.LinearAlgebra.AffineSpace.AffineEquiv
 import Mathlib.LinearAlgebra.AffineSpace.AffineMap
 import Mathlib.LinearAlgebra.AffineSpace.AffineSubspace

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1670,6 +1670,7 @@ import Mathlib.Util.AssertNoSorry
 import Mathlib.Util.AtomM
 import Mathlib.Util.Export
 import Mathlib.Util.IncludeStr
+import Mathlib.Util.LongNames
 import Mathlib.Util.MemoFix
 import Mathlib.Util.Syntax
 import Mathlib.Util.SynthesizeUsing

--- a/Mathlib/Lean/Name.lean
+++ b/Mathlib/Lean/Name.lean
@@ -1,0 +1,53 @@
+/-
+Copyright (c) 2023 Scott Morrison. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Scott Morrison
+-/
+import Std.Data.HashMap
+import Mathlib.Lean.SMap
+import Mathlib.Lean.Expr.Basic
+
+open Lean Meta Elab
+
+private def isBlackListed (declName : Name) : CoreM Bool := do
+  if declName.toString.startsWith "Lean" then return true
+  let env ← getEnv
+  pure $ declName.isInternal'
+   || isAuxRecursor env declName
+   || isNoConfusion env declName
+  <||> isRec declName <||> isMatcher declName
+
+/--
+Retrieve all names in the environment satisfying a predicate.
+-/
+def allNames (p : Name → Bool) : CoreM (Array Name) := do
+  (← getEnv).constants.foldM (init := #[]) fun names n _ => do
+    if p n && !(← isBlackListed n) then
+      return names.push n
+    else
+      return names
+
+/--
+Find the module a name was declared in.
+-/
+def Lean.Name.getModule (n : Name) : CoreM (Option Name) := do
+  let env ← getEnv
+  let modules := env.header.moduleNames
+  match env.const2ModIdx[n] with
+  | none => pure none
+  | some (idx : Nat) => pure modules[idx]?
+
+/--
+Retrieve all names in the environment satisfying a predicate,
+gathered together into a `HashMap` according to the module they are defined in.
+-/
+def allNamesByModule (p : Name → Bool) : CoreM (Std.HashMap Name (Array Name)) := do
+  (← getEnv).constants.foldM (init := Std.HashMap.empty) fun names n _ => do
+    if p n && !(← isBlackListed n) then
+      let some m ← n.getModule | return names
+      -- TODO use `Std.HashMap.modify` when we bump Std4 (or `alter` if that is written).
+      match names.find? m with
+      | some others => return names.insert m (others.push n)
+      | none => return names.insert m #[n]
+    else
+      return names

--- a/Mathlib/Lean/Name.lean
+++ b/Mathlib/Lean/Name.lean
@@ -7,6 +7,13 @@ import Std.Data.HashMap
 import Mathlib.Lean.SMap
 import Mathlib.Lean.Expr.Basic
 
+/-!
+# Additional functions on `Lean.Name`.
+
+We provide `Name.getModule : Name → CoreM (Option Name)`,
+and `allNames` and `allNamesByModule`.
+-/
+
 open Lean Meta Elab
 
 private def isBlackListed (declName : Name) : CoreM Bool := do

--- a/Mathlib/Lean/SMap.lean
+++ b/Mathlib/Lean/SMap.lean
@@ -1,0 +1,15 @@
+/-
+Copyright (c) 2023 Scott Morrison. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Scott Morrison
+-/
+import Lean.Data.SMap
+
+/-!
+# Extra functions on Lean.SMap
+-/
+
+/-- Monadic fold over a staged map. -/
+def Lean.SMap.foldM {m : Type w → Type w} [Monad m] [BEq α] [Hashable α]
+    (f : σ → α → β → m σ) (init : σ) (map : SMap α β) : m σ := do
+  map.map₂.foldlM f (← map.map₁.foldM f init)

--- a/Mathlib/Util/LongNames.lean
+++ b/Mathlib/Util/LongNames.lean
@@ -3,7 +3,7 @@ Copyright (c) 2023 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import Std.Data.HashMap
+import Mathlib.Lean.Name
 import Mathlib.Lean.Expr.Basic
 
 /-!
@@ -13,50 +13,6 @@ For finding declarations with excessively long names.
 -/
 
 open Lean Meta Elab
-
-private def isBlackListed (declName : Name) : CoreM Bool := do
-  if declName.toString.startsWith "Lean" then return true
-  let env ← getEnv
-  pure $ declName.isInternal'
-   || isAuxRecursor env declName
-   || isNoConfusion env declName
-  <||> isRec declName <||> isMatcher declName
-
-/--
-Retrieve all names in the environment satisfying a predicate.
--/
-def allNames (p : Name → Bool) : CoreM (Array Name) := do
-  let mut names := #[]
-  for (n, _) in (← getEnv).constants.map₁.toList ++ (← getEnv).constants.map₂.toList do
-    if p n && !(← isBlackListed n) then
-      names := names.push n
-  pure names
-
-def Lean.Name.getModule (n : Name) : CoreM (Option Name) := do
-  let env ← getEnv
-  let modules := env.header.moduleNames
-  match env.const2ModIdx[n] with
-  | none => pure none
-  | some (idx : Nat) => pure modules[idx]?
-
-/--
-Collect the values in an `Array` into a `HashMap`, according to their values under a function.
--/
-def gatherBy [BEq β] [Hashable β] (x : Array α) (f : α → β) : Std.HashMap β (Array α) := Id.run do
-  let mut h := Std.HashMap.empty
-  for a in x do
-    let b := f a
-    h := h.insert b (match h.find? b with
-    | none => #[a]
-    | some l => l.push a)
-  pure h
-
-/--
-Retrieve all names in the environment satisfying a predicate,
-gathered together into a `HashMap` according to the module they are defined in. -/
-def allNamesByModule (p : Name → Bool) : CoreM (Std.HashMap Name (Array Name)) := do
-  let names ← (← allNames p) |>.filterMapM fun n => do pure <| (n, ·) <$> (← n.getModule)
-  pure <| gatherBy names (·.2) |>.mapVal fun _ n => n.map (·.1)
 
 /-- Helper function for `#long_names` and `#long_instances`. -/
 def printNameHashMap (h : Std.HashMap Name (Array Name)) : IO Unit :=

--- a/Mathlib/Util/LongNames.lean
+++ b/Mathlib/Util/LongNames.lean
@@ -1,0 +1,93 @@
+/-
+Copyright (c) 2023 Scott Morrison. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Scott Morrison
+-/
+import Std.Data.HashMap
+import Mathlib.Lean.Expr.Basic
+
+/-!
+# Commands `#long_names` and `#long_instances`
+
+For finding declarations with excessively long names.
+-/
+
+open Lean Meta Elab
+
+private def isBlackListed (declName : Name) : CoreM Bool := do
+  if declName.toString.startsWith "Lean" then return true
+  let env ← getEnv
+  pure $ declName.isInternal'
+   || isAuxRecursor env declName
+   || isNoConfusion env declName
+  <||> isRec declName <||> isMatcher declName
+
+/--
+Retrieve all names in the environment satisfying a predicate.
+-/
+def allNames (p : Name → Bool) : CoreM (Array Name) := do
+  let mut names := #[]
+  for (n, _) in (← getEnv).constants.map₁.toList ++ (← getEnv).constants.map₂.toList do
+    if p n && !(← isBlackListed n) then
+      names := names.push n
+  pure names
+
+def Lean.Name.getModule (n : Name) : CoreM (Option Name) := do
+  let env ← getEnv
+  let modules := env.header.moduleNames
+  match env.const2ModIdx[n] with
+  | none => pure none
+  | some (idx : Nat) => pure modules[idx]?
+
+/--
+Collect the values in an `Array` into a `HashMap`, according to their values under a function.
+-/
+def gatherBy [BEq β] [Hashable β] (x : Array α) (f : α → β) : Std.HashMap β (Array α) := Id.run do
+  let mut h := Std.HashMap.empty
+  for a in x do
+    let b := f a
+    h := h.insert b (match h.find? b with
+    | none => #[a]
+    | some l => l.push a)
+  pure h
+
+/--
+Retrieve all names in the environment satisfying a predicate,
+gathered together into a `HashMap` according to the module they are defined in. -/
+def allNamesByModule (p : Name → Bool) : CoreM (Std.HashMap Name (Array Name)) := do
+  let names ← (← allNames p) |>.filterMapM fun n => do pure <| (n, ·) <$> (← n.getModule)
+  pure <| gatherBy names (·.2) |>.mapVal fun _ n => n.map (·.1)
+
+/-- Helper function for `#long_names` and `#long_instances`. -/
+def printNameHashMap (h : Std.HashMap Name (Array Name)) : IO Unit :=
+  for (m, names) in h.toList do
+    IO.println "----"
+    IO.println $ m.toString ++ ":"
+    for n in names do
+      IO.println n
+
+/--
+Lists all declarations with a long name, gathered according to the module they are defined in.
+Use as `#long_names` or `#long_names 100` to specify the length.
+-/
+elab "#long_names " N:(num)? : command =>
+  Command.runTermElabM fun _ => do
+    let N := N.map TSyntax.getNat |>.getD 50
+    let namesByModule ← allNamesByModule (fun n => n.toString.length > N)
+    let namesByModule := namesByModule.filter fun m _ => m.getRoot.toString = "Mathlib"
+    printNameHashMap namesByModule
+
+/--
+Lists all instances with a long name beginning with `inst`,
+gathered according to the module they are defined in.
+This is useful for finding automatically named instances with absurd names.
+
+Use as `#long_names` or `#long_names 100` to specify the length.
+-/
+elab "#long_instances " N:(num)?: command =>
+  Command.runTermElabM fun _ => do
+    let N := N.map TSyntax.getNat |>.getD 50
+    let namesByModule ← allNamesByModule
+      (fun n => n.getString.startsWith "inst" && n.getString.length > N)
+    let namesByModule := namesByModule.filter fun m _ => m.getRoot.toString = "Mathlib"
+    printNameHashMap namesByModule


### PR DESCRIPTION
This adds commands `#long_names` and `#long_instances`, useful for finding declarations with excessively long names.

~~I also add explicit names to some of the files that produce instances with names over 80 characters; can do more later.~~

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
