### PR TITLE
[Merged by Bors] - chore: forward-port leanprover-community/mathlib#18636

### DIFF
--- a/Mathlib/Data/Set/Intervals/OrdConnected.lean
+++ b/Mathlib/Data/Set/Intervals/OrdConnected.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury G. Kudryashov
 
 ! This file was ported from Lean 3 source module data.set.intervals.ord_connected
-! leanprover-community/mathlib commit b19481deb571022990f1baa9cbf9172e6757a479
+! leanprover-community/mathlib commit 76de8ae01554c3b37d66544866659ff174e66e1f
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/

--- a/Mathlib/Order/Antichain.lean
+++ b/Mathlib/Order/Antichain.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 
 ! This file was ported from Lean 3 source module order.antichain
-! leanprover-community/mathlib commit 207cfac9fcd06138865b5d04f7091e46d9320432
+! leanprover-community/mathlib commit c227d107bbada5d0d9d20287e3282c0a7f1651a0
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -30,7 +30,7 @@ open Function Set
 
 section General
 
-variable {α β : Type _} {r r₁ r₂ : α → α → Prop} {r' : β → β → Prop} {s t : Set α} {a : α}
+variable {α β : Type _} {r r₁ r₂ : α → α → Prop} {r' : β → β → Prop} {s t : Set α} {a b : α}
 
 protected theorem Symmetric.compl (h : Symmetric r) : Symmetric (rᶜ) := fun _ _ hr hr' =>
   hr <| h hr'
@@ -214,6 +214,10 @@ section Preorder
 
 variable [Preorder α]
 
+theorem IsAntichain.not_lt (hs : IsAntichain (· ≤ ·) s) (ha : a ∈ s) (hb : b ∈ s) : ¬a < b :=
+  fun h => hs ha hb h.ne h.le
+#align is_antichain.not_lt IsAntichain.not_lt
+
 theorem isAntichain_and_least_iff : IsAntichain (· ≤ ·) s ∧ IsLeast s a ↔ s = {a} :=
   ⟨fun h => eq_singleton_iff_unique_mem.2 ⟨h.2.1, fun b hb => h.1.eq' hb h.2.1 (h.2.2 hb)⟩, by
     rintro rfl
@@ -251,6 +255,17 @@ theorem IsAntichain.top_mem_iff [OrderTop α] (hs : IsAntichain (· ≤ ·) s) :
 #align is_antichain.top_mem_iff IsAntichain.top_mem_iff
 
 end Preorder
+
+section PartialOrder
+
+variable [PartialOrder α]
+
+theorem isAntichain_iff_forall_not_lt :
+    IsAntichain (· ≤ ·) s ↔ ∀ ⦃a⦄, a ∈ s → ∀ ⦃b⦄, b ∈ s → ¬a < b :=
+  ⟨fun hs _ ha _ => hs.not_lt ha, fun hs _ ha _ hb h h' => hs ha hb <| h'.lt_of_ne h⟩
+#align is_antichain_iff_forall_not_lt isAntichain_iff_forall_not_lt
+
+end PartialOrder
 
 /-! ### Strong antichains -/
 

--- a/Mathlib/Order/Antichain.lean
+++ b/Mathlib/Order/Antichain.lean
@@ -15,7 +15,7 @@ import Mathlib.Data.Set.Pairwise
 
 This file defines antichains. An antichain is a set where any two distinct elements are not related.
 If the relation is `(≤)`, this corresponds to incomparability and usual order antichains. If the
-relation is `G.adj` for `G : simple_graph α`, this corresponds to independent sets of `G`.
+relation is `G.adj` for `G : SimpleGraph α`, this corresponds to independent sets of `G`.
 
 ## Definitions
 

--- a/Mathlib/Order/Antichain.lean
+++ b/Mathlib/Order/Antichain.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 
 ! This file was ported from Lean 3 source module order.antichain
-! leanprover-community/mathlib commit c227d107bbada5d0d9d20287e3282c0a7f1651a0
+! leanprover-community/mathlib commit b19481deb571022990f1baa9cbf9172e6757a479
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/


### PR DESCRIPTION

The change to `Mathlib/Data/Set/Intervals/OrdConnected.lean` was already forward-ported in #3077.

Also fixes a remaining `simple_graph` in the comments of one of the files.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
