### PR TITLE
[Merged by Bors] - feat: The upper closure is bounded below

### DIFF
--- a/Mathlib/Order/UpperLower/Basic.lean
+++ b/Mathlib/Order/UpperLower/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies, Sara Rousta
 
 ! This file was ported from Lean 3 source module order.upper_lower.basic
-! leanprover-community/mathlib commit 59694bd07f0a39c5beccba34bd9f413a160782bf
+! leanprover-community/mathlib commit e9ce88cd0d54891c714c604076084f763dd480ed
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -1473,6 +1473,36 @@ theorem ordConnected_iff_upperClosure_inter_lowerClosure :
   rw [← h]
   exact (UpperSet.upper _).ordConnected.inter (LowerSet.lower _).ordConnected
 #align ord_connected_iff_upper_closure_inter_lower_closure ordConnected_iff_upperClosure_inter_lowerClosure
+
+@[simp]
+theorem upperBounds_lowerClosure : upperBounds (lowerClosure s : Set α) = upperBounds s :=
+  (upperBounds_mono_set subset_lowerClosure).antisymm fun a ha b ⟨c, hc, hcb⟩ => hcb.trans <| ha hc
+#align upper_bounds_lower_closure upperBounds_lowerClosure
+
+@[simp]
+theorem lowerBounds_upperClosure : lowerBounds (upperClosure s : Set α) = lowerBounds s :=
+  (lowerBounds_mono_set subset_upperClosure).antisymm fun a ha b ⟨c, hc, hcb⟩ => (ha hc).trans hcb
+#align lower_bounds_upper_closure lowerBounds_upperClosure
+
+@[simp]
+theorem bddAbove_lowerClosure : BddAbove (lowerClosure s : Set α) ↔ BddAbove s := by
+  simp_rw [BddAbove, upperBounds_lowerClosure]
+#align bdd_above_lower_closure bddAbove_lowerClosure
+
+@[simp]
+theorem bddBelow_upperClosure : BddBelow (upperClosure s : Set α) ↔ BddBelow s := by
+  simp_rw [BddBelow, lowerBounds_upperClosure]
+#align bdd_below_upper_closure bddBelow_upperClosure
+
+alias bddAbove_lowerClosure ↔ BddAbove.of_lowerClosure BddAbove.lowerClosure
+#align bdd_above.of_lower_closure BddAbove.of_lowerClosure
+#align bdd_above.lower_closure BddAbove.lowerClosure
+
+alias bddBelow_upperClosure ↔ BddBelow.of_upperClosure BddBelow.upperClosure
+#align bdd_below.of_upper_closure BddBelow.of_upperClosure
+#align bdd_below.upper_closure BddBelow.upperClosure
+
+attribute [protected] BddAbove.lowerClosure BddBelow.upperClosure
 
 end closure
 

--- a/Mathlib/Order/UpperLower/Basic.lean
+++ b/Mathlib/Order/UpperLower/Basic.lean
@@ -1476,12 +1476,12 @@ theorem ordConnected_iff_upperClosure_inter_lowerClosure :
 
 @[simp]
 theorem upperBounds_lowerClosure : upperBounds (lowerClosure s : Set α) = upperBounds s :=
-  (upperBounds_mono_set subset_lowerClosure).antisymm fun a ha b ⟨c, hc, hcb⟩ => hcb.trans <| ha hc
+  (upperBounds_mono_set subset_lowerClosure).antisymm λ _a ha _b ⟨_c, hc, hcb⟩ => hcb.trans <| ha hc
 #align upper_bounds_lower_closure upperBounds_lowerClosure
 
 @[simp]
 theorem lowerBounds_upperClosure : lowerBounds (upperClosure s : Set α) = lowerBounds s :=
-  (lowerBounds_mono_set subset_upperClosure).antisymm fun a ha b ⟨c, hc, hcb⟩ => (ha hc).trans hcb
+  (lowerBounds_mono_set subset_upperClosure).antisymm λ _a ha _b ⟨_c, hc, hcb⟩ => (ha hc).trans hcb
 #align lower_bounds_upper_closure lowerBounds_upperClosure
 
 @[simp]
@@ -1502,7 +1502,8 @@ alias bddBelow_upperClosure ↔ BddBelow.of_upperClosure BddBelow.upperClosure
 #align bdd_below.of_upper_closure BddBelow.of_upperClosure
 #align bdd_below.upper_closure BddBelow.upperClosure
 
-attribute [protected] BddAbove.lowerClosure BddBelow.upperClosure
+-- Porting note: attribute [protected] doesn't work
+-- attribute protected BddAbove.lowerClosure BddBelow.upperClosure
 
 end closure
 


### PR DESCRIPTION
Match https://github.com/leanprover-community/mathlib/pull/18637

[`order.upper_lower.basic`@`59694bd07f0a39c5beccba34bd9f413a160782bf`..`e9ce88cd0d54891c714c604076084f763dd480ed`](https://leanprover-community.github.io/mathlib-port-status/file/order/upper_lower/basic?range=59694bd07f0a39c5beccba34bd9f413a160782bf..e9ce88cd0d54891c714c604076084f763dd480ed)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
