### PR TITLE
[Merged by Bors] - chore: Update `RingTheory.RingInvo` SHA

### DIFF
--- a/Mathlib/RingTheory/RingInvo.lean
+++ b/Mathlib/RingTheory/RingInvo.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Andreas Swerdlow, Kenny Lau
 
 ! This file was ported from Lean 3 source module ring_theory.ring_invo
-! leanprover-community/mathlib commit 09597669f02422ed388036273d8848119699c22f
+! leanprover-community/mathlib commit ec2dfcae3677bcdc0d8e906831b1d251dfcbc0f1
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/


### PR DESCRIPTION
Match https://github.com/leanprover-community/mathlib/pull/18175. This made it to the original port, but the SHA was wrong.

[`ring_theory.ring_invo`@`09597669f02422ed388036273d8848119699c22f`..`ec2dfcae3677bcdc0d8e906831b1d251dfcbc0f1`](https://leanprover-community.github.io/mathlib-port-status/file/ring_theory/ring_invo?range=09597669f02422ed388036273d8848119699c22f..ec2dfcae3677bcdc0d8e906831b1d251dfcbc0f1)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
