### PR TITLE
[Merged by Bors] - chore: Fix `cast` mistakes

### DIFF
--- a/Mathlib/Algebra/Field/Opposite.lean
+++ b/Mathlib/Algebra/Field/Opposite.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau
 
 ! This file was ported from Lean 3 source module algebra.field.opposite
-! leanprover-community/mathlib commit acebd8d49928f6ed8920e502a6c90674e75bd441
+! leanprover-community/mathlib commit 76de8ae01554c3b37d66544866659ff174e66e1f
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -63,8 +63,7 @@ instance divisionSemiring [DivisionSemiring α] : DivisionSemiring αᵃᵒᵖ :
   { AddOpposite.groupWithZero α, AddOpposite.semiring α with }
 
 instance divisionRing [DivisionRing α] : DivisionRing αᵃᵒᵖ :=
-  { -- porting note: added `ratCast` override
-    AddOpposite.groupWithZero α, AddOpposite.ring α, AddOpposite.ratCast α with
+  { AddOpposite.ring α, AddOpposite.groupWithZero α, AddOpposite.ratCast α with
     ratCast_mk := fun a b hb h => unop_injective $ by
       rw [unop_ratCast, Rat.cast_def, unop_mul, unop_inv, unop_natCast, unop_intCast,
         div_eq_mul_inv] }

--- a/Mathlib/Algebra/Group/Opposite.lean
+++ b/Mathlib/Algebra/Group/Opposite.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau
 
 ! This file was ported from Lean 3 source module algebra.group.opposite
-! leanprover-community/mathlib commit acebd8d49928f6ed8920e502a6c90674e75bd441
+! leanprover-community/mathlib commit 76de8ae01554c3b37d66544866659ff174e66e1f
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/

--- a/Mathlib/Algebra/Ring/Defs.lean
+++ b/Mathlib/Algebra/Ring/Defs.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura, Floris van Doorn, Yury Kudryashov, Neil Strickland
 
 ! This file was ported from Lean 3 source module algebra.ring.defs
-! leanprover-community/mathlib commit 314d3a578607dbd2eb2481ab15fceeb62b36cbdb
+! leanprover-community/mathlib commit 76de8ae01554c3b37d66544866659ff174e66e1f
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/

--- a/Mathlib/Algebra/Ring/Opposite.lean
+++ b/Mathlib/Algebra/Ring/Opposite.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau
 
 ! This file was ported from Lean 3 source module algebra.ring.opposite
-! leanprover-community/mathlib commit acebd8d49928f6ed8920e502a6c90674e75bd441
+! leanprover-community/mathlib commit 76de8ae01554c3b37d66544866659ff174e66e1f
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -149,13 +149,11 @@ instance nonUnitalNonAssocRing [NonUnitalNonAssocRing α] : NonUnitalNonAssocRin
 instance nonUnitalRing [NonUnitalRing α] : NonUnitalRing αᵃᵒᵖ :=
   { AddOpposite.addCommGroup α, AddOpposite.semigroupWithZero α, AddOpposite.distrib α with }
 
--- porting note: added missing `addCommGroupWithOne` inheritance
 instance nonAssocRing [NonAssocRing α] : NonAssocRing αᵃᵒᵖ :=
   { AddOpposite.addCommGroupWithOne α, AddOpposite.mulZeroOneClass α, AddOpposite.distrib α with }
 
--- porting note: added missing `addCommGroupWithOne` inheritance
 instance ring [Ring α] : Ring αᵃᵒᵖ :=
-  { AddOpposite.addCommGroupWithOne α, AddOpposite.monoid α, AddOpposite.semiring α with }
+  { AddOpposite.nonAssocRing α, AddOpposite.semiring α with }
 
 instance nonUnitalCommRing [NonUnitalCommRing α] : NonUnitalCommRing αᵃᵒᵖ :=
   { AddOpposite.nonUnitalRing α, AddOpposite.nonUnitalCommSemiring α with }


### PR DESCRIPTION
Match https://github.com/leanprover-community/mathlib/pull/18654

* [`algebra.group.opposite`@`acebd8d49928f6ed8920e502a6c90674e75bd441`..`76de8ae01554c3b37d66544866659ff174e66e1f`](https://leanprover-community.github.io/mathlib-port-status/file/algebra/group/opposite?range=acebd8d49928f6ed8920e502a6c90674e75bd441..76de8ae01554c3b37d66544866659ff174e66e1f)
* [`algebra.ring.defs`@`314d3a578607dbd2eb2481ab15fceeb62b36cbdb`..`76de8ae01554c3b37d66544866659ff174e66e1f`](https://leanprover-community.github.io/mathlib-port-status/file/algebra/ring/defs?range=314d3a578607dbd2eb2481ab15fceeb62b36cbdb..76de8ae01554c3b37d66544866659ff174e66e1f)
* [`algebra.ring.opposite`@`acebd8d49928f6ed8920e502a6c90674e75bd441`..`76de8ae01554c3b37d66544866659ff174e66e1f`](https://leanprover-community.github.io/mathlib-port-status/file/algebra/ring/opposite?range=acebd8d49928f6ed8920e502a6c90674e75bd441..76de8ae01554c3b37d66544866659ff174e66e1f)
* [`algebra.field.opposite`@`acebd8d49928f6ed8920e502a6c90674e75bd441`..`76de8ae01554c3b37d66544866659ff174e66e1f`](https://leanprover-community.github.io/mathlib-port-status/file/algebra/field/opposite?range=acebd8d49928f6ed8920e502a6c90674e75bd441..76de8ae01554c3b37d66544866659ff174e66e1f)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
Part of the PR was ported in #3077.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
