### PR TITLE
[Merged by Bors] - chore: factor out MVarId.casesType from casesm tactic

### DIFF
--- a/Mathlib/Tactic/CasesM.lean
+++ b/Mathlib/Tactic/CasesM.lean
@@ -11,8 +11,7 @@ import Lean
 These tactics implement repeated `cases` / `constructor` on anything satisfying a predicate.
 -/
 
-namespace Mathlib.Tactic
-open Lean Meta Elab Tactic
+namespace Lean.MVarId
 
 /--
 Core tactic for `casesm` and `cases_type`. Calls `cases` on all fvars in `g` for which
@@ -21,9 +20,8 @@ Core tactic for `casesm` and `cases_type`. Calls `cases` on all fvars in `g` for
 * `allowSplit`: if false, it will skip any hypotheses where `cases` returns more than one subgoal.
 * `throwOnNoMatch`: if true, then throws an error if no match is found
 -/
-partial def casesMatching (g : MVarId) (matcher : Expr → MetaM Bool)
-    (recursive := false) (allowSplit := true) (throwOnNoMatch := !recursive) :
-    MetaM (List MVarId) := do
+partial def casesMatching (matcher : Expr → MetaM Bool) (recursive := false) (allowSplit := true)
+    (throwOnNoMatch := !recursive) (g : MVarId) : MetaM (List MVarId) := do
   let result := (← go g).toList
   if throwOnNoMatch && result == [g] then
     throwError "no match"
@@ -55,6 +53,17 @@ partial def casesMatching (g : MVarId) (matcher : Expr → MetaM Bool)
           return acc
       return (acc.push g)
 
+def casesType (heads : Array Name) (recursive := false) (allowSplit := true) :
+     MVarId → MetaM (List MVarId) :=
+  let matcher ty := pure <|
+    if let .const n .. := ty.headBeta.getAppFn then heads.contains n else false
+  casesMatching matcher recursive allowSplit
+
+end Lean.MVarId
+
+namespace Mathlib.Tactic
+open Lean Meta Elab Tactic MVarId
+
 /-- Elaborate a list of terms with holes into a list of patterns. -/
 def elabPatterns (pats : Array Term) : TermElabM (Array AbstractMVarsResult) :=
   withTheReader Term.Context (fun ctx ↦ { ctx with ignoreTCFailures := true }) <|
@@ -82,15 +91,13 @@ casesm* _ ∨ _, _ ∧ _
 -/
 elab (name := casesM) "casesm" recursive:"*"? ppSpace pats:term,+ : tactic => do
   let pats ← elabPatterns pats.getElems
-  liftMetaTactic (casesMatching · (matchPatterns pats) recursive.isSome)
+  liftMetaTactic (MVarId.casesMatching (matchPatterns pats) recursive.isSome)
 
 /-- Common implementation of `cases_type` and `cases_type!`. -/
 def elabCasesType (heads : Array Ident)
     (recursive := false) (allowSplit := true) : TacticM Unit := do
   let heads ← heads.mapM resolveGlobalConstNoOverloadWithInfo
-  let matcher ty := pure <|
-    if let .const n .. := ty.headBeta.getAppFn then heads.contains n else false
-  liftMetaTactic (casesMatching · matcher recursive allowSplit)
+  liftMetaTactic (casesType heads recursive allowSplit)
 
 /--
 * `cases_type I` applies the `cases` tactic to a hypothesis `h : (I ...)`

--- a/Mathlib/Tactic/CasesM.lean
+++ b/Mathlib/Tactic/CasesM.lean
@@ -91,7 +91,7 @@ casesm* _ ∨ _, _ ∧ _
 -/
 elab (name := casesM) "casesm" recursive:"*"? ppSpace pats:term,+ : tactic => do
   let pats ← elabPatterns pats.getElems
-  liftMetaTactic (MVarId.casesMatching (matchPatterns pats) recursive.isSome)
+  liftMetaTactic (casesMatching (matchPatterns pats) recursive.isSome)
 
 /-- Common implementation of `cases_type` and `cases_type!`. -/
 def elabCasesType (heads : Array Ident)

--- a/Mathlib/Tactic/Tauto.lean
+++ b/Mathlib/Tactic/Tauto.lean
@@ -20,7 +20,7 @@ The `tauto` tactic.
 
 namespace Mathlib.Tactic.Tauto
 
-open Lean Elab.Tactic Parser.Tactic Lean.Meta
+open Lean Elab.Tactic Parser.Tactic Lean.Meta MVarId
 open Qq
 
 initialize registerTraceClass `tauto
@@ -166,7 +166,7 @@ def tautoCore : TacticM Unit := do
     allGoals (
       liftMetaTactic (fun m => do pure [(← m.intros!).2]) <;>
       distribNot <;>
-      liftMetaTactic (casesMatching · casesMatcher (recursive := true)) <;>
+      liftMetaTactic (casesMatching casesMatcher (recursive := true)) <;>
       (do _ ← tryTactic (evalTactic (← `(tactic| contradiction)))) <;>
       (do _ ← tryTactic (evalTactic (←`(tactic| refine or_iff_not_imp_left.mpr ?_)))) <;>
       liftMetaTactic (fun m => do pure [(← m.intros!).2]) <;>


### PR DESCRIPTION
Very minor refactor, to enable access to `casesType` from `MetaM` rather than just syntactical tactics.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
