### PR TITLE
[Merged by Bors] - chore: update sha in CategoryTheory.Adjunction.Opposites

### DIFF
--- a/Mathlib/CategoryTheory/Adjunction/Opposites.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Opposites.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta, Thomas Read, Andrew Yang
 
 ! This file was ported from Lean 3 source module category_theory.adjunction.opposites
-! leanprover-community/mathlib commit f3ee4628e2dc737653af924c41fa681abc2a4f4a
+! leanprover-community/mathlib commit 0148d455199ed64bf8eb2f493a1e7eb9211ce170
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/


### PR DESCRIPTION
* [`category_theory.adjunction.opposites`@`f3ee4628e2dc737653af924c41fa681abc2a4f4a`..`0148d455199ed64bf8eb2f493a1e7eb9211ce170`](https://leanprover-community.github.io/mathlib-port-status/file/category_theory/adjunction/opposites?range=f3ee4628e2dc737653af924c41fa681abc2a4f4a..0148d455199ed64bf8eb2f493a1e7eb9211ce170)

The changes in https://github.com/leanprover-community/mathlib/pull/18680 were already part of https://github.com/leanprover-community/mathlib4/pull/2424, so we just need to update the SHA.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
