### PR TITLE
[Merged by Bors] - chore: bump SHA in Data.TypeVec

### DIFF
--- a/Mathlib/Data/TypeVec.lean
+++ b/Mathlib/Data/TypeVec.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Mario Carneiro, Simon Hudon
 
 ! This file was ported from Lean 3 source module data.typevec
-! leanprover-community/mathlib commit 39af7d3bf61a98e928812dbc3e16f4ea8b795ca3
+! leanprover-community/mathlib commit 4fcbc82dc2257986c03e113f87bc5ce021243a44
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/


### PR DESCRIPTION
Only whitespace changes in

* [`data.typevec`@`39af7d3bf61a98e928812dbc3e16f4ea8b795ca3`..`4fcbc82dc2257986c03e113f87bc5ce021243a44`](https://leanprover-community.github.io/mathlib-port-status/file/data/typevec?range=39af7d3bf61a98e928812dbc3e16f4ea8b795ca3..4fcbc82dc2257986c03e113f87bc5ce021243a44)

so just bumping the SHA.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
