### PR TITLE
[Merged by Bors] - chore: forward-port leanprover-community/mathlib#18687

### DIFF
--- a/Mathlib/Algebra/Star/SelfAdjoint.lean
+++ b/Mathlib/Algebra/Star/SelfAdjoint.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Frédéric Dupuis
 
 ! This file was ported from Lean 3 source module algebra.star.self_adjoint
-! leanprover-community/mathlib commit 9abfa6f0727d5adc99067e325e15d1a9de17fd8e
+! leanprover-community/mathlib commit a6ece35404f60597c651689c1b46ead86de5ac1b
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -252,7 +252,6 @@ end DivisionRing
 
 section Semifield
 
--- porting note: generalize to `Semifield` to fix lean4#2074-related errors
 variable [Semifield R] [StarRing R]
 
 theorem div {x y : R} (hx : IsSelfAdjoint x) (hy : IsSelfAdjoint y) : IsSelfAdjoint (x / y) := by


### PR DESCRIPTION
This change was already applied in a previous forward-port in order to fix compilation. The porting note can now be removed, since mathlib3 now contains the same generalization.

* [`algebra.star.self_adjoint`@`9abfa6f0727d5adc99067e325e15d1a9de17fd8e`..`a6ece35404f60597c651689c1b46ead86de5ac1b`](https://leanprover-community.github.io/mathlib-port-status/file/algebra/star/self_adjoint?range=9abfa6f0727d5adc99067e325e15d1a9de17fd8e..a6ece35404f60597c651689c1b46ead86de5ac1b)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
