### PR TITLE
feat: MonadLift (StateT α m) (StateT α n) given MonadLiftT m n

### DIFF
--- a/Mathlib/Lean/Control/State.lean
+++ b/Mathlib/Lean/Control/State.lean
@@ -1,0 +1,15 @@
+/-
+Copyright (c) 2023 Scott Morrison. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Scott Morrison
+-/
+
+/-!
+# Missing `MonadLift (StateT α m) (StateT α n)` instance given `MonadLiftT m n`.
+
+Perhaps there is some generalization beyond `StateT` to some class of lawful monad transformers
+that I'm missing?
+-/
+
+instance [MonadLiftT m n] : MonadLift (StateT α m) (StateT α n) where
+  monadLift := fun f s => f s


### PR DESCRIPTION
This instance seems to be missing, but it very useful when carrying around additional state and working with IO/CoreM/MetaM simultaneously.

I've left a note in the module doc in case someone wants to point out this is a special case of some sort of burrito.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
