### PR TITLE
[Merged by Bors] - fix: polynomial powers must be numerals

### DIFF
--- a/Mathlib/Tactic/Polyrith.lean
+++ b/Mathlib/Tactic/Polyrith.lean
@@ -141,7 +141,9 @@ partial def parse {u} {α : Q(Type u)} (sα : Q(CommSemiring $α))
     | ~q(($a : ℕ) • ($b : «$α»)) => pure <| (← parse sℕ .nat a).mul (← parse sα c b)
     | _ => els
   | ``HPow.hPow, _ | ``Pow.pow, _ => match e with
-    | ~q($a ^ $b) => pure <| (← parse sα c a).pow (← parse sℕ .nat b)
+    | ~q($a ^ $b) =>
+      try pure <| (← parse sα c a).pow (.const (← (← NormNum.derive (u := .zero) b).toRat))
+      catch _ => els
     | _ => els
   | ``Neg.neg, some _ => match e with
     | ~q(-$a) => pure <| (← parse sα c a).neg

--- a/test/polyrith.lean
+++ b/test/polyrith.lean
@@ -711,3 +711,6 @@ by create_polyrith_test
 -- example (a : ℕ) : a = 0 := by
 --   have := True.intro
 --   polyrith -- polyrith did not find any relevant hypotheses and the goal is not provable by ring
+
+-- example (y a : ℤ) (k : ℕ) (h : a ^ k = 0) : a ^ k * y = 0 := by
+--   polyrith


### PR DESCRIPTION
As [reported on Zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Bug.20in.20.60polyrith.60.3F/near/346281922).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
