### PR TITLE
[Merged by Bors] - chore: refactor of library_search, and don't timeout

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -769,6 +769,7 @@ import Mathlib.Data.List.Sublists
 import Mathlib.Data.List.TFAE
 import Mathlib.Data.List.Zip
 import Mathlib.Data.ListM
+import Mathlib.Data.ListM.Heartbeats
 import Mathlib.Data.Matrix.DMatrix
 import Mathlib.Data.Multiset.Antidiagonal
 import Mathlib.Data.Multiset.Basic
@@ -1158,6 +1159,7 @@ import Mathlib.Init.Propext
 import Mathlib.Init.Quot
 import Mathlib.Init.Set
 import Mathlib.Init.ZeroOne
+import Mathlib.Lean.CoreM
 import Mathlib.Lean.EnvExtension
 import Mathlib.Lean.Exception
 import Mathlib.Lean.Expr

--- a/Mathlib/Data/ListM.lean
+++ b/Mathlib/Data/ListM.lean
@@ -107,7 +107,7 @@ unsafe def ofList {α : Type u} : List α → ListM m α
 /-- The empty `ListM`. -/
 unsafe def empty {α : Type u} : ListM m α := ofList []
 
-/-- Convert a `list` of values inside the monad into a `ListM`. -/
+/-- Convert a `List` of values inside the monad into a `ListM`. -/
 unsafe def ofListM {α : Type u} : List (m α) → ListM m α
   | [] => nil
   | h :: t => cons ((fun x => (x, ofListM t)) <$> some <$> h)
@@ -119,6 +119,13 @@ unsafe def force {α} (L : ListM m α) : m (List α) := do
   | none => pure []
   | some (x, xs) => (x :: ·) <$> force xs
 #align tactic.mllist.force ListM.force
+
+/-- Extract an array inside the monad from a `ListM`. -/
+unsafe def asArray (L : ListM m α) : m (Array α) := do
+  let mut r := #[]
+  for a in L do
+    r := r.push a
+  return r
 
 /-- Gives the monadic lazy list consisting all of folds of a function on a given initial element.
 Thus `[a₀, a₁, ...].foldsM f b` will give `[b, ← f b a₀, ← f (← f b a₀) a₁, ...]`. -/
@@ -174,7 +181,7 @@ unsafe def map {α β : Type u} (f : α → β) (L : ListM m α) : ListM m β :=
 /-- Filter a `ListM` using a monadic function. -/
 unsafe def filterM {α : Type u} (p : α → m (ULift Bool)) (L : ListM m α) : ListM m α :=
   cons do match ← uncons L with
-  | some (x, xs) => return (if (← p x).down then some x else x, filterM p xs)
+  | some (x, xs) => return (if (← p x).down then some x else none, filterM p xs)
   | none => return (none, empty)
 #align tactic.mllist.mfilter ListM.filterM
 
@@ -200,13 +207,13 @@ unsafe def filterMap {α β : Type u} (f : α → Option β) : ListM m α → Li
 #align tactic.mllist.filter_map ListM.filterMap
 
 /-- Take the initial segment of the lazy list, until the function `f` first returns `false`. -/
-unsafe def takeWhileM [Alternative m] (f : α → m (ULift Bool)) (L : ListM m α) : ListM m α :=
+unsafe def takeWhileM (f : α → m (ULift Bool)) (L : ListM m α) : ListM m α :=
   cons do match ← uncons L with
   | none => return (none, empty)
-  | some (x, xs) => return if (← f x).down then (some x, xs) else (none, empty)
+  | some (x, xs) => return if (← f x).down then (some x, xs.takeWhileM f) else (none, empty)
 
 /-- Take the initial segment of the lazy list, until the function `f` first returns `false`. -/
-unsafe def takeWhile [Alternative m] (f : α → Bool) : ListM m α → ListM m α :=
+unsafe def takeWhile (f : α → Bool) : ListM m α → ListM m α :=
   takeWhileM fun a => pure (.up (f a))
 
 /-- Concatenate two monadic lazy lists. -/

--- a/Mathlib/Data/ListM/Heartbeats.lean
+++ b/Mathlib/Data/ListM/Heartbeats.lean
@@ -1,12 +1,21 @@
+/-
+Copyright (c) 2023 Scott Morrison. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Scott Morrison
+-/
 import Mathlib.Data.ListM
 import Mathlib.Lean.CoreM
 
-open Lean
+/-!
+# Truncate a `ListM` when running out of available heartbeats.
+-/
+
+open Lean.Core (CoreM)
 
 /-- Take an initial segment of a `MetaM` lazy list,
 using at most `percent` of the remaining allowed heartbeats. -/
-unsafe def ListM.whileAtLeastHeartbeatsPercent
-    [Monad m] [MonadLiftT CoreM m] (L : ListM m α) (percent : Nat) : ListM m α :=
+unsafe def ListM.whileAtLeastHeartbeatsPercent [Monad m] [MonadLiftT CoreM m]
+    (L : ListM m α) (percent : Nat) : ListM m α :=
 ListM.squash do
   let initialHeartbeats ← getRemainingHeartbeats
   pure <| L.takeWhileM fun _ => do

--- a/Mathlib/Data/ListM/Heartbeats.lean
+++ b/Mathlib/Data/ListM/Heartbeats.lean
@@ -13,7 +13,7 @@ import Mathlib.Lean.CoreM
 open Lean.Core (CoreM)
 
 /-- Take an initial segment of a `MetaM` lazy list,
-using at most `percent` of the remaining allowed heartbeats. -/
+trying to leave at least `percent` of the remaining allowed heartbeats. -/
 unsafe def ListM.whileAtLeastHeartbeatsPercent [Monad m] [MonadLiftT CoreM m]
     (L : ListM m α) (percent : Nat) : ListM m α :=
 ListM.squash do

--- a/Mathlib/Data/ListM/Heartbeats.lean
+++ b/Mathlib/Data/ListM/Heartbeats.lean
@@ -1,0 +1,13 @@
+import Mathlib.Data.ListM
+import Mathlib.Lean.CoreM
+
+open Lean
+
+/-- Take an initial segment of a `MetaM` lazy list,
+using at most `percent` of the remaining allowed heartbeats. -/
+unsafe def ListM.whileAtLeastHeartbeatsPercent
+    [Monad m] [MonadLiftT CoreM m] (L : ListM m α) (percent : Nat) : ListM m α :=
+ListM.squash do
+  let initialHeartbeats ← getRemainingHeartbeats
+  pure <| L.takeWhileM fun _ => do
+    return .up <| (← getRemainingHeartbeats) * 100 / initialHeartbeats > percent

--- a/Mathlib/Lean/CoreM.lean
+++ b/Mathlib/Lean/CoreM.lean
@@ -1,0 +1,24 @@
+/-
+Copyright (c) 2023 Scott Morrison. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Scott Morrison
+-/
+import Lean.CoreM
+
+/-!
+# Additional functions using `CoreM` state.
+-/
+
+open Lean
+
+/-- Return the current `maxHeartbeats`. -/
+def getMaxHeartbeats : CoreM Nat := do pure (← read).maxHeartbeats
+
+/-- Return the remaining heartbeats available in this computation. -/
+def getRemainingHeartbeats : CoreM Nat := do pure <| (← getMaxHeartbeats) - (← IO.getNumHeartbeats)
+
+/--
+Return the percentage of the max heartbeats allowed
+that have been consumed so far in this computation.
+-/
+def heartbeatsPercent : CoreM Nat := do pure <| (← IO.getNumHeartbeats) * 100 / (← getMaxHeartbeats)

--- a/Mathlib/Tactic/LibrarySearch.lean
+++ b/Mathlib/Tactic/LibrarySearch.lean
@@ -8,6 +8,8 @@ import Mathlib.Lean.Expr.Basic
 import Mathlib.Tactic.Cache
 import Mathlib.Tactic.Core
 import Mathlib.Tactic.SolveByElim
+import Mathlib.Data.ListM.Heartbeats
+import Mathlib.Control.Basic
 
 /-!
 # Library search
@@ -97,6 +99,46 @@ def solveByElim (goals : List MVarId) (required : List Expr) (depth) := do
   _ ← SolveByElim.solveByElim.processSyntax cfg false false [] [] #[] goals
 
 /--
+Try applying the given lemma (with symmetry modifer) to the goal,
+then try to close subsequent goals using `solveByElim`.
+If `solveByElim` succeeds, we return `[]` as the list of new subgoals,
+otherwise the full list of subgoals.
+
+We do not allow the `MetavarContext` to be modified.
+Instead, if the lemma application succeeds we collect the resulting `MetavarContext`
+and return it explicitly.
+-/
+def librarySearchLemma (lem : Name) (mod : DeclMod) (required : List Expr) (solveByElimDepth := 6)
+    (goal : MVarId) : MetaM (MetavarContext × List MVarId) :=
+  withTraceNode `Tactic.librarySearch (return m!"{exceptEmoji ·} trying {lem}") do
+  withoutModifyingState do
+    let lem ← mkConstWithFreshMVarLevels lem
+    let lem ← match mod with
+    | .none => pure lem
+    | .symm => mapForallTelescope (fun e => mkAppM ``Eq.symm #[e]) lem
+    | .mp => mapForallTelescope (fun e => mkAppM ``Iff.mp #[e]) lem
+    | .mpr => mapForallTelescope (fun e => mkAppM ``Iff.mpr #[e]) lem
+    let newGoals ← goal.apply lem
+    try
+      solveByElim newGoals required solveByElimDepth
+      pure (← getMCtx, [])
+    catch _ =>
+      pure (← getMCtx, newGoals)
+
+/--
+Returns a lazy list of the results of applying a library lemma,
+then calling `solveByElim` on the resulting goals.
+-/
+unsafe def librarySearchCore (goal : MVarId) (lemmas : DiscrTree (Name × DeclMod) s)
+    (required : List Expr) (solveByElimDepth := 6) : ListM MetaM (MetavarContext × List MVarId) :=
+  .squash do
+    let ty ← goal.getType
+    withTraceNode `Tactic.librarySearch (return m!"{exceptEmoji ·} {ty}") do
+      let lemmas := ListM.ofList ((← lemmas.getMatch ty).toList)
+      return lemmas.filterMapM fun (lem, mod) =>
+        try? <| librarySearchLemma lem mod required solveByElimDepth goal
+
+/--
 Try to solve the goal either by:
 * calling `solveByElim`
 * or applying a library lemma then calling `solveByElim` on the resulting goals.
@@ -113,50 +155,23 @@ unless the goal was completely solved.)
 this is not currently tracked.)
 -/
 def librarySearch (goal : MVarId) (lemmas : DiscrTree (Name × DeclMod) s) (required : List Expr)
-    (solveByElimDepth := 6) : MetaM <| Option (Array <| MetavarContext × List MVarId) := do
+    (solveByElimDepth := 6) : MetaM (Option (Array (MetavarContext × List MVarId))) := do
   profileitM Exception "librarySearch" (← getOptions) do
-  let ty ← goal.getType
-  withTraceNode `Tactic.librarySearch (return m!"{exceptOptionEmoji ·} {ty}") do
-
-  let mut suggestions := #[]
-
-  let state0 ← get
-
-  try
+  (do
     solveByElim [goal] required solveByElimDepth
-    return none
-  catch _ =>
-    set state0
-
-  for (lem, mod) in ← lemmas.getMatch ty do
-    trace[Tactic.librarySearch] "{lem}"
-    let result ← withTraceNode `Tactic.librarySearch (return m!"{exceptOptionEmoji ·} trying {lem}")
-      try
-        let lem ← mkConstWithFreshMVarLevels lem
-        let lem ← match mod with
-        | .none => pure lem
-        | .symm => mapForallTelescope (fun e => mkAppM ``Eq.symm #[e]) lem
-        | .mp => mapForallTelescope (fun e => mkAppM ``Iff.mp #[e]) lem
-        | .mpr => mapForallTelescope (fun e => mkAppM ``Iff.mpr #[e]) lem
-        let newGoals ← goal.apply lem
-        (try
-          for newGoal in newGoals do
-            trace[Tactic.librarySearch] "proving {← addMessageContextFull (mkMVar newGoal)}"
-          solveByElim newGoals required solveByElimDepth
-          pure $ some $ Sum.inr ()
-        catch _ =>
-          let res := some $ Sum.inl (← getMCtx, newGoals)
-          set state0
-          return res)
-    catch _ =>
-      set state0
-      pure none
-    match result with
-    | none => pure ()
-    | some (Sum.inr ()) => return none
-    | some (Sum.inl suggestion) => suggestions := suggestions.push suggestion
-
-  pure $ some suggestions
+    return none) <|>
+  unsafe (do
+    let results ← librarySearchCore goal lemmas required solveByElimDepth
+      -- Don't use too many heartbeats.
+      |>.whileAtLeastHeartbeatsPercent 10
+      -- Stop if we find something that closes the goal
+      |>.takeUpToFirst (·.2.isEmpty)
+      |>.asArray
+    match results.find? (·.2.isEmpty) with
+    | none => return results
+    | some (ctx, _) => do
+      setMCtx ctx
+      return none)
 
 def lines (ls : List MessageData) :=
   MessageData.joinSep ls (MessageData.ofFormat Format.line)

--- a/Mathlib/Tactic/LibrarySearch.lean
+++ b/Mathlib/Tactic/LibrarySearch.lean
@@ -110,7 +110,7 @@ and return it explicitly.
 -/
 def librarySearchLemma (lem : Name) (mod : DeclMod) (required : List Expr) (solveByElimDepth := 6)
     (goal : MVarId) : MetaM (MetavarContext × List MVarId) :=
-  withTraceNode `Tactic.librarySearch (return m!"{exceptEmoji ·} trying {lem}") do
+  withTraceNode `Tactic.librarySearch (return m!"{·.emoji} trying {lem}") do
   withoutModifyingState do
     let lem ← mkConstWithFreshMVarLevels lem
     let lem ← match mod with
@@ -133,7 +133,7 @@ unsafe def librarySearchCore (goal : MVarId) (lemmas : DiscrTree (Name × DeclMo
     (required : List Expr) (solveByElimDepth := 6) : ListM MetaM (MetavarContext × List MVarId) :=
   .squash do
     let ty ← goal.getType
-    withTraceNode `Tactic.librarySearch (return m!"{exceptEmoji ·} {ty}") do
+    withTraceNode `Tactic.librarySearch (return m!"{·.emoji} {ty}") do
       let lemmas := ListM.ofList ((← lemmas.getMatch ty).toList)
       return lemmas.filterMapM fun (lem, mod) =>
         try? <| librarySearchLemma lem mod required solveByElimDepth goal


### PR DESCRIPTION
This is a refactor of `library_search`, separating the logic of applying lemmas and flow control (i.e. stopping if we find a good one).

This version has an intermediate function that returns a lazy list of candidate results, using the new `ListM` API.

As an easy add-on, we make sure `library_search` never times out --- it watches the clock, and if it reaches 90% of available time it returns what it has so far.

After this refactor it will also be somewhat easier to improve the way results are returned when `library_search` doesn't close the goal. e.g. we should do some basic sorting to put more promising answers first.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
