### PR TITLE
[Merged by Bors] - Feat: Add computable rec for Option via rec_eq_recC pattern

### DIFF
--- a/Mathlib/Data/Option/Basic.lean
+++ b/Mathlib/Data/Option/Basic.lean
@@ -362,10 +362,10 @@ theorem casesOn'_none_coe (f : Option α → β) (o : Option α) :
     casesOn' o (f none) (f ∘ (fun a ↦ ↑a)) = f o := by cases o <;> rfl
 #align option.cases_on'_none_coe Option.casesOn'_none_coe
 
-
+-- porting note: workaround for leanprover/lean4#2049
 section recursor_workarounds
-/-- A computable version of `Option.rec`. Workaround until Lean has native support for this.
-    (issue lean4#2049) -/
+
+/-- A computable version of `Option.rec`. Workaround until Lean has native support for this. -/
 def recC.{u_1, u} {α : Type u} {motive : Option α → Sort u_1} (none : motive none)
   (some : (val : α) →  motive (some val)) :
     (t : Option α) → motive t
@@ -379,8 +379,8 @@ lemma rec_eq_recC : @Option.rec = @Option.recC := by
   | none => rfl
   | some a =>
     rw [Option.recC]
+    
 end recursor_workarounds
-
 
 theorem orElse_eq_some (o o' : Option α) (x : α) :
     (o <|> o') = some x ↔ o = some x ∨ o = none ∧ o' = some x := by

--- a/Mathlib/Data/Option/Basic.lean
+++ b/Mathlib/Data/Option/Basic.lean
@@ -364,7 +364,8 @@ theorem casesOn'_none_coe (f : Option α → β) (o : Option α) :
 
 
 section recursor_workarounds
-/-- A computable version of `Option.rec`. Workaround until Lean has native support for this. -/
+/-- A computable version of `Option.rec`. Workaround until Lean has native support for this.
+    (issue lean4#2049) -/
 def recC.{u_1, u} {α : Type u} {motive : Option α → Sort u_1} (none : motive none)
   (some : (val : α) →  motive (some val)) :
     (t : Option α) → motive t

--- a/Mathlib/Data/Option/Basic.lean
+++ b/Mathlib/Data/Option/Basic.lean
@@ -366,8 +366,8 @@ theorem casesOn'_none_coe (f : Option α → β) (o : Option α) :
 section recursor_workarounds
 /-- A computable version of `Option.rec`. Workaround until Lean has native support for this. -/
 def recC.{u_1, u} {α : Type u} {motive : Option α → Sort u_1} (none : motive none)
-  (some : (a : α) → motive (some a)) :
-    (o : Option α) → motive o
+  (some : (val : α) →  motive (some val)) :
+    (t : Option α) → motive t
 | Option.none => none
 | Option.some a => some a
 

--- a/Mathlib/Data/Option/Basic.lean
+++ b/Mathlib/Data/Option/Basic.lean
@@ -362,6 +362,25 @@ theorem casesOn'_none_coe (f : Option α → β) (o : Option α) :
     casesOn' o (f none) (f ∘ (fun a ↦ ↑a)) = f o := by cases o <;> rfl
 #align option.cases_on'_none_coe Option.casesOn'_none_coe
 
+
+section recursor_workarounds
+/-- A computable version of `Option.rec`. Workaround until Lean has native support for this. -/
+def recC.{u_1, u} {α : Type u} {motive : Option α → Sort u_1} (none : motive none)
+  (some : (a : α) → motive (some a)) :
+    (o : Option α) → motive o
+| Option.none => none
+| Option.some a => some a
+
+@[simp]
+lemma rec_eq_recC : @Option.rec = @Option.recC := by
+  ext α motive none some o
+  induction o with
+  | none => rfl
+  | some a =>
+    rw [Option.recC]
+end recursor_workarounds
+
+
 theorem orElse_eq_some (o o' : Option α) (x : α) :
     (o <|> o') = some x ↔ o = some x ∨ o = none ∧ o' = some x := by
   cases o

--- a/Mathlib/Data/Option/Basic.lean
+++ b/Mathlib/Data/Option/Basic.lean
@@ -371,7 +371,7 @@ def recC.{u_1, u} {α : Type u} {motive : Option α → Sort u_1} (none : motive
 | Option.none => none
 | Option.some a => some a
 
-@[simp]
+@[csimp]
 lemma rec_eq_recC : @Option.rec = @Option.recC := by
   ext α motive none some o
   induction o with


### PR DESCRIPTION
Adds a computable recursor for `Option`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
