### PR TITLE
[Merged by Bors] - chore: have linarith print the goal when it fails

### DIFF
--- a/Mathlib/Tactic/Linarith/Frontend.lean
+++ b/Mathlib/Tactic/Linarith/Frontend.lean
@@ -202,7 +202,7 @@ prove `false` by calling `linarith` on each list in succession. It will stop at 
 def findLinarithContradiction (cfg : LinarithConfig) (g : MVarId) (ls : List (List Expr)) :
     MetaM Expr :=
   ls.firstM (fun L => proveFalseByLinarith cfg g L)
-    <|> throwError "linarith failed to find a contradiction"
+    <|> throwError "linarith failed to find a contradiction\n{g}"
 
 
 /--


### PR DESCRIPTION
This makes `linarith` print the goal (including hypotheses) when it fails, as many other tactics do.

This was motivated by watching the `sagredo` tactic trying to use `linarith`, but failing to see that it didn't quite have the correct hypotheses yet. Once it gave up on using `linarith`, it tried `contradiction`, which printed a more helpful error message (in which a human, although not quite GPT, could easily see the inequalities weren't quite right).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
