### PR TITLE
[Merged by Bors] - chore: fix align linebreaks

### DIFF
--- a/Mathlib/CategoryTheory/Elements.lean
+++ b/Mathlib/CategoryTheory/Elements.lean
@@ -162,14 +162,12 @@ theorem to_comma_map_right {X Y} (f : X ⟶ Y) : ((toStructuredArrow F).map f).r
 def fromStructuredArrow : StructuredArrow PUnit F ⥤ F.Elements where
   obj X := ⟨X.right, X.hom PUnit.unit⟩
   map f := ⟨f.right, congr_fun f.w.symm PUnit.unit⟩
-#align category_theory.category_of_elements.from_structured_arrow
-  CategoryTheory.CategoryOfElements.fromStructuredArrow
+#align category_theory.category_of_elements.from_structured_arrow CategoryTheory.CategoryOfElements.fromStructuredArrow
 
 @[simp]
 theorem fromStructuredArrow_obj (X) : (fromStructuredArrow F).obj X = ⟨X.right, X.hom PUnit.unit⟩ :=
   rfl
-#align category_theory.category_of_elements.from_structured_arrow_obj
-  CategoryTheory.CategoryOfElements.fromStructuredArrow_obj
+#align category_theory.category_of_elements.from_structured_arrow_obj CategoryTheory.CategoryOfElements.fromStructuredArrow_obj
 
 @[simp]
 theorem fromStructuredArrow_map {X Y} (f : X ⟶ Y) :
@@ -206,8 +204,7 @@ def toCostructuredArrow (F : Cᵒᵖ ⥤ Type v) : F.Elementsᵒᵖ ⥤ Costruct
       funext y
       dsimp
       simp only [FunctorToTypes.map_comp_apply, ← f.unop.2]
-#align category_theory.category_of_elements.to_costructured_arrow
-  CategoryTheory.CategoryOfElements.toCostructuredArrow
+#align category_theory.category_of_elements.to_costructured_arrow CategoryTheory.CategoryOfElements.toCostructuredArrow
 
 /-- The reverse direction of the equivalence `F.Elementsᵒᵖ ≅ (yoneda, F)`,
 given by `CategoryTheory.yonedaEquiv`.
@@ -232,8 +229,7 @@ def fromCostructuredArrow (F : Cᵒᵖ ⥤ Type v) : (CostructuredArrow yoneda F
 theorem fromCostructuredArrow_obj_mk (F : Cᵒᵖ ⥤ Type v) {X : C} (f : yoneda.obj X ⟶ F) :
     (fromCostructuredArrow F).obj (op (CostructuredArrow.mk f)) = ⟨op X, yonedaEquiv.1 f⟩ :=
   rfl
-#align category_theory.category_of_elements.from_costructured_arrow_obj_mk
-  CategoryTheory.CategoryOfElements.fromCostructuredArrow_obj_mk
+#align category_theory.category_of_elements.from_costructured_arrow_obj_mk CategoryTheory.CategoryOfElements.fromCostructuredArrow_obj_mk
 
 /-- The unit of the equivalence `F.Elementsᵒᵖ ≅ (yoneda, F)` is indeed iso. -/
 theorem from_toCostructuredArrow_eq (F : Cᵒᵖ ⥤ Type v) :
@@ -248,8 +244,7 @@ theorem from_toCostructuredArrow_eq (F : Cᵒᵖ ⥤ Type v) :
       simp
     ext
     simp [this]
-#align category_theory.category_of_elements.from_to_costructured_arrow_eq
-  CategoryTheory.CategoryOfElements.from_toCostructuredArrow_eq
+#align category_theory.category_of_elements.from_to_costructured_arrow_eq CategoryTheory.CategoryOfElements.from_toCostructuredArrow_eq
 
 /-- The counit of the equivalence `F.Elementsᵒᵖ ≅ (yoneda, F)` is indeed iso. -/
 theorem to_fromCostructuredArrow_eq (F : Cᵒᵖ ⥤ Type v) :
@@ -268,8 +263,7 @@ theorem to_fromCostructuredArrow_eq (F : Cᵒᵖ ⥤ Type v) :
   · intro X Y f
     ext
     simp [CostructuredArrow.eqToHom_left]
-#align category_theory.category_of_elements.to_from_costructured_arrow_eq
-  CategoryTheory.CategoryOfElements.to_fromCostructuredArrow_eq
+#align category_theory.category_of_elements.to_from_costructured_arrow_eq CategoryTheory.CategoryOfElements.to_fromCostructuredArrow_eq
 
 set_option maxHeartbeats 400000 in
 /-- The equivalence `F.Elementsᵒᵖ ≅ (yoneda, F)` given by yoneda lemma. -/

--- a/Mathlib/CategoryTheory/Limits/ConeCategory.lean
+++ b/Mathlib/CategoryTheory/Limits/ConeCategory.lean
@@ -156,8 +156,7 @@ def Cocone.fromStructuredArrow (F : J ⥤ C) : StructuredArrow F (const J) ⥤ C
         convert (congr_fun (congr_arg NatTrans.app f.w) j).symm
         dsimp
         simp }
-#align category_theory.limits.cocone.from_structured_arrow
-  CategoryTheory.Limits.Cocone.fromStructuredArrow
+#align category_theory.limits.cocone.from_structured_arrow CategoryTheory.Limits.Cocone.fromStructuredArrow
 
 /-- The category of cocones on `F` is just the comma category `(F ↓ Δ)`, where `Δ` is the constant
     functor. -/
@@ -182,8 +181,7 @@ theorem hasColimit_iff_hasInitial_cocone (F : J ⥤ C) : HasColimit F ↔ HasIni
   ⟨fun _ => (Cocone.isColimitEquivIsInitial _ (colimit.isColimit F)).hasInitial, fun h =>
     haveI : HasInitial (Cocone F) := h
     ⟨⟨⟨⊥_ _, (Cocone.isColimitEquivIsInitial _).symm initialIsInitial⟩⟩⟩⟩
-#align category_theory.limits.has_colimit_iff_has_initial_cocone
-  CategoryTheory.Limits.hasColimit_iff_hasInitial_cocone
+#align category_theory.limits.has_colimit_iff_has_initial_cocone CategoryTheory.Limits.hasColimit_iff_hasInitial_cocone
 
 theorem hasColimitsOfShape_iff_isRightAdjoint_const :
     HasColimitsOfShape J C ↔ Nonempty (IsRightAdjoint (const J : C ⥤ _)) :=
@@ -196,8 +194,7 @@ theorem hasColimitsOfShape_iff_isRightAdjoint_const :
     _ ↔ Nonempty (IsRightAdjoint (const J : C ⥤ _)) :=
       nonempty_isRightAdjoint_iff_hasInitial_structuredArrow.symm
 
-#align category_theory.limits.has_colimits_of_shape_iff_is_right_adjoint_const
-  CategoryTheory.Limits.hasColimitsOfShape_iff_isRightAdjoint_const
+#align category_theory.limits.has_colimits_of_shape_iff_is_right_adjoint_const CategoryTheory.Limits.hasColimitsOfShape_iff_isRightAdjoint_const
 
 theorem IsColimit.descCoconeMorphism_eq_isInitial_to {F : J ⥤ C} {c : Cocone F} (hc : IsColimit c)
     (s : Cocone F) :


### PR DESCRIPTION
Result of running
```
find . -type f -name "*.lean" -exec sed -i -E 'N;s/^#align ([^[:space:]]+)\n *([^[:space:]]+)$/#align \1 \2/' {} \;
```

Some scripts depend on those statements being on one line. I think it is not important enough to have a special linter or github workflow for that, especially considering this is only needed during the port. I plan to just run this once in a while.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
