### PR TITLE
[Merged by Bors] - feat: Dot notation aliases

### DIFF
--- a/Mathlib/Algebra/CharP/Basic.lean
+++ b/Mathlib/Algebra/CharP/Basic.lean
@@ -531,11 +531,11 @@ theorem char_is_prime_of_two_le (p : ℕ) [hc : CharP R p] (hp : 2 ≤ p) : Nat.
   Or.elim (eq_zero_or_eq_zero_of_mul_eq_zero this)
     (fun hd : (d : R) = 0 =>
       have : p ∣ d := (cast_eq_zero_iff R p d).mp hd
-      show d = 1 ∨ d = p from Or.inr (dvd_antisymm ⟨e, hmul⟩ this))
+      show d = 1 ∨ d = p from Or.inr (this.antisymm' ⟨e, hmul⟩))
     fun he : (e : R) = 0 =>
     have : p ∣ e := (cast_eq_zero_iff R p e).mp he
     have : e ∣ p := dvd_of_mul_left_eq d (Eq.symm hmul)
-    have : e = p := dvd_antisymm ‹e ∣ p› ‹p ∣ e›
+    have : e = p := ‹e ∣ p›.antisymm ‹p ∣ e›
     have h₀ : 0 < p := two_pos.trans_le hp
     have : d * p = 1 * p := by rw [‹e = p›] at hmul; rw [one_mul]; exact Eq.symm hmul
     show d = 1 ∨ d = p from Or.inl (mul_right_cancel₀ h₀.ne' this)

--- a/Mathlib/Algebra/Divisibility/Basic.lean
+++ b/Mathlib/Algebra/Divisibility/Basic.lean
@@ -6,7 +6,7 @@ Neil Strickland, Aaron Anderson
 Ported by: Matej Penciak
 
 ! This file was ported from Lean 3 source module algebra.divisibility.basic
-! leanprover-community/mathlib commit 70d50ecfd4900dd6d328da39ab7ebd516abe4025
+! leanprover-community/mathlib commit e8638a0fcaf73e4500469f368ef9494e495099b3
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -107,13 +107,13 @@ theorem MonoidHom.map_dvd (f : M →* N) {a b} : a ∣ b → f a ∣ f b :=
   _root_.map_dvd f
 #align monoid_hom.map_dvd MonoidHom.map_dvd
 
-end map_dvd
+end map_dvdpeucd
 
 end Semigroup
 
 section Monoid
 
-variable [Monoid α]
+variable [Monoid α] {a b : α}
 
 @[refl, simp]
 theorem dvd_refl (a : α) : a ∣ a :=
@@ -129,6 +129,12 @@ instance : IsRefl α (· ∣ ·) :=
 theorem one_dvd (a : α) : 1 ∣ a :=
   Dvd.intro a (one_mul a)
 #align one_dvd one_dvd
+
+theorem dvd_of_eq (h : a = b) : a ∣ b := by rw [h]
+#align dvd_of_eq dvd_of_eq
+
+alias dvd_of_eq ← Eq.dvd
+#align eq.dvd Eq.dvd
 
 end Monoid
 

--- a/Mathlib/Algebra/Divisibility/Basic.lean
+++ b/Mathlib/Algebra/Divisibility/Basic.lean
@@ -107,7 +107,7 @@ theorem MonoidHom.map_dvd (f : M →* N) {a b} : a ∣ b → f a ∣ f b :=
   _root_.map_dvd f
 #align monoid_hom.map_dvd MonoidHom.map_dvd
 
-end map_dvdpeucd
+end map_dvd
 
 end Semigroup
 

--- a/Mathlib/Algebra/EuclideanDomain/Basic.lean
+++ b/Mathlib/Algebra/EuclideanDomain/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Louis Carlin, Mario Carneiro
 
 ! This file was ported from Lean 3 source module algebra.euclidean_domain.basic
-! leanprover-community/mathlib commit 655994e298904d7e5bbd1e18c95defd7b543eb94
+! leanprover-community/mathlib commit e8638a0fcaf73e4500469f368ef9494e495099b3
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -68,7 +68,7 @@ theorem mod_self (a : R) : a % a = 0 :=
 #align euclidean_domain.mod_self EuclideanDomain.mod_self
 
 theorem dvd_mod_iff {a b c : R} (h : c ∣ b) : c ∣ a % b ↔ c ∣ a := by
-  rw [dvd_add_iff_right (h.mul_right _), div_add_mod]
+  rw [← dvd_add_right (h.mul_right _), div_add_mod]
 #align euclidean_domain.dvd_mod_iff EuclideanDomain.dvd_mod_iff
 
 @[simp]

--- a/Mathlib/Algebra/Group/Units.lean
+++ b/Mathlib/Algebra/Group/Units.lean
@@ -568,8 +568,7 @@ theorem eq_one_of_mul_left (h : a * b = 1) : b = 1 :=
 
 @[to_additive (attr := simp)]
 theorem mul_eq_one : a * b = 1 ↔ a = 1 ∧ b = 1 :=
-  ⟨fun h => ⟨eq_one_of_mul_right h, eq_one_of_mul_left h⟩,
-    by
+  ⟨fun h => ⟨eq_one_of_mul_right h, eq_one_of_mul_left h⟩, by
     rintro ⟨rfl, rfl⟩
     exact mul_one _⟩
 #align mul_eq_one mul_eq_one

--- a/Mathlib/Algebra/Group/Units.lean
+++ b/Mathlib/Algebra/Group/Units.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau, Mario Carneiro, Johannes Hölzl, Chris Hughes, Jens Wagemaker, Jon Eugster
 
 ! This file was ported from Lean 3 source module algebra.group.units
-! leanprover-community/mathlib commit 369525b73f229ccd76a6ec0e0e0bf2be57599768
+! leanprover-community/mathlib commit e8638a0fcaf73e4500469f368ef9494e495099b3
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -551,6 +551,29 @@ theorem divp_eq_divp_iff {x y : α} {ux uy : αˣ} : x /ₚ ux = y /ₚ uy ↔ x
 theorem divp_mul_divp (x y : α) (ux uy : αˣ) : x /ₚ ux * (y /ₚ uy) = x * y /ₚ (ux * uy) := by
   rw [divp_mul_eq_mul_divp, divp_assoc', divp_divp_eq_divp_mul]
 #align divp_mul_divp divp_mul_divp
+
+variable [Subsingleton αˣ] {a b : α}
+
+@[to_additive]
+theorem eq_one_of_mul_right (h : a * b = 1) : a = 1 :=
+  congr_arg Units.inv <| Subsingleton.elim (Units.mk _ _ (by rwa [mul_comm]) h) 1
+#align eq_one_of_mul_right eq_one_of_mul_right
+#align eq_zero_of_add_right eq_zero_of_add_right
+
+@[to_additive]
+theorem eq_one_of_mul_left (h : a * b = 1) : b = 1 :=
+  congr_arg Units.inv <| Subsingleton.elim (Units.mk _ _ h <| by rwa [mul_comm]) 1
+#align eq_one_of_mul_left eq_one_of_mul_left
+#align eq_zero_of_add_left eq_zero_of_add_left
+
+@[simp, to_additive]
+theorem mul_eq_one : a * b = 1 ↔ a = 1 ∧ b = 1 :=
+  ⟨fun h => ⟨eq_one_of_mul_right h, eq_one_of_mul_left h⟩,
+    by
+    rintro ⟨rfl, rfl⟩
+    exact mul_one _⟩
+#align mul_eq_one mul_eq_one
+#align add_eq_zero add_eq_zero
 
 end CommMonoid
 

--- a/Mathlib/Algebra/Group/Units.lean
+++ b/Mathlib/Algebra/Group/Units.lean
@@ -566,7 +566,7 @@ theorem eq_one_of_mul_left (h : a * b = 1) : b = 1 :=
 #align eq_one_of_mul_left eq_one_of_mul_left
 #align eq_zero_of_add_left eq_zero_of_add_left
 
-@[simp, to_additive]
+@[to_additive (attr := simp)]
 theorem mul_eq_one : a * b = 1 ↔ a = 1 ∧ b = 1 :=
   ⟨fun h => ⟨eq_one_of_mul_right h, eq_one_of_mul_left h⟩,
     by

--- a/Mathlib/Algebra/GroupWithZero/Basic.lean
+++ b/Mathlib/Algebra/GroupWithZero/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin
 
 ! This file was ported from Lean 3 source module algebra.group_with_zero.basic
-! leanprover-community/mathlib commit 2196ab363eb097c008d4497125e0dde23fb36db2
+! leanprover-community/mathlib commit e8638a0fcaf73e4500469f368ef9494e495099b3
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -199,6 +199,23 @@ theorem mul_left_eq_self₀ : a * b = b ↔ a = 1 ∨ b = 0 :=
     _ ↔ a = 1 ∨ b = 0 := mul_eq_mul_right_iff
 #align mul_left_eq_self₀ mul_left_eq_self₀
 
+@[simp]
+theorem mul_eq_left₀ (ha : a ≠ 0) : a * b = a ↔ b = 1 := by
+  rw [Iff.comm, ← mul_right_inj' ha, mul_one]
+#align mul_eq_left₀ mul_eq_left₀
+
+@[simp]
+theorem mul_eq_right₀ (hb : b ≠ 0) : a * b = b ↔ a = 1 := by
+  rw [Iff.comm, ← mul_left_inj' hb, one_mul]
+#align mul_eq_right₀ mul_eq_right₀
+
+@[simp]
+theorem left_eq_mul₀ (ha : a ≠ 0) : a = a * b ↔ b = 1 := by rw [eq_comm, mul_eq_left₀ ha]
+#align left_eq_mul₀ left_eq_mul₀
+
+@[simp]
+theorem right_eq_mul₀ (hb : b ≠ 0) : b = a * b ↔ a = 1 := by rw [eq_comm, mul_eq_right₀ hb]
+#align right_eq_mul₀ right_eq_mul₀
 
 /-- An element of a `CancelMonoidWithZero` fixed by right multiplication by an element other
 than one must be zero. -/
@@ -299,6 +316,15 @@ instance (priority := 100) GroupWithZero.toDivisionMonoid : DivisionMonoid G₀ 
       simp [mul_assoc, ha, hb],
     inv_eq_of_mul := fun a b => inv_eq_of_mul }
 #align group_with_zero.to_division_monoid GroupWithZero.toDivisionMonoid
+
+-- see Note [lower instance priority]
+instance (priority := 10) GroupWithZero.toCancelMonoidWithZero : CancelMonoidWithZero G₀ :=
+  { (‹_› : GroupWithZero G₀) with
+    mul_left_cancel_of_ne_zero := @fun x y z hx h => by
+      rw [← inv_mul_cancel_left₀ hx y, h, inv_mul_cancel_left₀ hx z],
+    mul_right_cancel_of_ne_zero := @fun x y z hy h => by
+      rw [← mul_inv_cancel_right₀ hy x, h, mul_inv_cancel_right₀ hy z] }
+#align group_with_zero.to_cancel_monoid_with_zero GroupWithZero.toCancelMonoidWithZero
 
 end GroupWithZero
 

--- a/Mathlib/Algebra/GroupWithZero/Divisibility.lean
+++ b/Mathlib/Algebra/GroupWithZero/Divisibility.lean
@@ -113,8 +113,7 @@ section CancelCommMonoidWithZero
 
 variable [CancelCommMonoidWithZero α] [Subsingleton αˣ] {a b : α}
 
-theorem dvd_antisymm : a ∣ b → b ∣ a → a = b :=
-  by
+theorem dvd_antisymm : a ∣ b → b ∣ a → a = b := by
   rintro ⟨c, rfl⟩ ⟨d, hcd⟩
   rw [mul_assoc, eq_comm, mul_right_eq_self₀, mul_eq_one] at hcd
   obtain ⟨rfl, -⟩ | rfl := hcd <;> simp

--- a/Mathlib/Algebra/GroupWithZero/Divisibility.lean
+++ b/Mathlib/Algebra/GroupWithZero/Divisibility.lean
@@ -127,11 +127,11 @@ theorem dvd_antisymm' : a ∣ b → b ∣ a → b = a :=
   flip dvd_antisymm
 #align dvd_antisymm' dvd_antisymm'
 
-alias dvd_antisymm ← Dvd.Dvd.antisymm
-#align has_dvd.dvd.antisymm Dvd.Dvd.antisymm
+alias dvd_antisymm ← Dvd.dvd.antisymm
+#align has_dvd.dvd.antisymm Dvd.dvd.antisymm
 
-alias dvd_antisymm' ← Dvd.Dvd.antisymm'
-#align has_dvd.dvd.antisymm' Dvd.Dvd.antisymm'
+alias dvd_antisymm' ← Dvd.dvd.antisymm'
+#align has_dvd.dvd.antisymm' Dvd.dvd.antisymm'
 
 theorem eq_of_forall_dvd (h : ∀ c, a ∣ c ↔ b ∣ c) : a = b :=
   ((h _).2 dvd_rfl).antisymm <| (h _).1 dvd_rfl

--- a/Mathlib/Algebra/GroupWithZero/Divisibility.lean
+++ b/Mathlib/Algebra/GroupWithZero/Divisibility.lean
@@ -5,7 +5,7 @@ Authors: Jeremy Avigad, Leonardo de Moura, Floris van Doorn, Amelia Livingston, 
 Neil Strickland, Aaron Anderson
 
 ! This file was ported from Lean 3 source module algebra.group_with_zero.divisibility
-! leanprover-community/mathlib commit f1a2caaf51ef593799107fe9a8d5e411599f3996
+! leanprover-community/mathlib commit e8638a0fcaf73e4500469f368ef9494e495099b3
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -108,3 +108,37 @@ theorem ne_zero_of_dvd_ne_zero {p q : α} (h₁ : q ≠ 0) (h₂ : p ∣ q) : p 
 #align ne_zero_of_dvd_ne_zero ne_zero_of_dvd_ne_zero
 
 end MonoidWithZero
+
+section CancelCommMonoidWithZero
+
+variable [CancelCommMonoidWithZero α] [Subsingleton αˣ] {a b : α}
+
+theorem dvd_antisymm : a ∣ b → b ∣ a → a = b :=
+  by
+  rintro ⟨c, rfl⟩ ⟨d, hcd⟩
+  rw [mul_assoc, eq_comm, mul_right_eq_self₀, mul_eq_one] at hcd
+  obtain ⟨rfl, -⟩ | rfl := hcd <;> simp
+#align dvd_antisymm dvd_antisymm
+
+-- porting note: `attribute [protected]` is currently unsupported
+-- attribute [protected] Nat.dvd_antisymm --This lemma is in core, so we protect it here
+
+theorem dvd_antisymm' : a ∣ b → b ∣ a → b = a :=
+  flip dvd_antisymm
+#align dvd_antisymm' dvd_antisymm'
+
+alias dvd_antisymm ← Dvd.Dvd.antisymm
+#align has_dvd.dvd.antisymm Dvd.Dvd.antisymm
+
+alias dvd_antisymm' ← Dvd.Dvd.antisymm'
+#align has_dvd.dvd.antisymm' Dvd.Dvd.antisymm'
+
+theorem eq_of_forall_dvd (h : ∀ c, a ∣ c ↔ b ∣ c) : a = b :=
+  ((h _).2 dvd_rfl).antisymm <| (h _).1 dvd_rfl
+#align eq_of_forall_dvd eq_of_forall_dvd
+
+theorem eq_of_forall_dvd' (h : ∀ c, c ∣ a ↔ c ∣ b) : a = b :=
+  ((h _).1 dvd_rfl).antisymm <| (h _).2 dvd_rfl
+#align eq_of_forall_dvd' eq_of_forall_dvd'
+
+end CancelCommMonoidWithZero

--- a/Mathlib/Algebra/GroupWithZero/Units/Basic.lean
+++ b/Mathlib/Algebra/GroupWithZero/Units/Basic.lean
@@ -316,11 +316,11 @@ section CommGroupWithZero
 variable [CommGroupWithZero G₀] {a b c d : G₀}
 
 -- see Note [lower instance priority]
-instance (priority := 10) CommGroupWithZero.cancelCommMonoidWithZero :
+instance (priority := 10) CommGroupWithZero.toCancelCommMonoidWithZero :
     CancelCommMonoidWithZero G₀ :=
   { GroupWithZero.toCancelMonoidWithZero,
     CommGroupWithZero.toCommMonoidWithZero with }
-#align comm_group_with_zero.cancel_comm_monoid_with_zero CommGroupWithZero.cancelCommMonoidWithZero
+#align comm_group_with_zero.to_cancel_comm_monoid_with_zero CommGroupWithZero.toCancelCommMonoidWithZero
 
 -- See note [lower instance priority]
 instance (priority := 100) CommGroupWithZero.toDivisionCommMonoid : DivisionCommMonoid G₀ :=

--- a/Mathlib/Algebra/GroupWithZero/Units/Basic.lean
+++ b/Mathlib/Algebra/GroupWithZero/Units/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin
 
 ! This file was ported from Lean 3 source module algebra.group_with_zero.units.basic
-! leanprover-community/mathlib commit 70d50ecfd4900dd6d328da39ab7ebd516abe4025
+! leanprover-community/mathlib commit df5e9937a06fdd349fc60106f54b84d47b1434f0
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/

--- a/Mathlib/Algebra/GroupWithZero/Units/Basic.lean
+++ b/Mathlib/Algebra/GroupWithZero/Units/Basic.lean
@@ -318,7 +318,7 @@ variable [CommGroupWithZero G₀] {a b c d : G₀}
 -- see Note [lower instance priority]
 instance (priority := 10) CommGroupWithZero.cancelCommMonoidWithZero :
     CancelCommMonoidWithZero G₀ :=
-  { GroupWithZero.cancelMonoidWithZero,
+  { GroupWithZero.toCancelMonoidWithZero,
     CommGroupWithZero.toCommMonoidWithZero with }
 #align comm_group_with_zero.cancel_comm_monoid_with_zero CommGroupWithZero.cancelCommMonoidWithZero
 

--- a/Mathlib/Algebra/GroupWithZero/Units/Basic.lean
+++ b/Mathlib/Algebra/GroupWithZero/Units/Basic.lean
@@ -275,15 +275,6 @@ instance (priority := 10) GroupWithZero.noZeroDivisors : NoZeroDivisors G₀ :=
       exact (Units.mk0 a h.1 * Units.mk0 b h.2).ne_zero }
 #align group_with_zero.no_zero_divisors GroupWithZero.noZeroDivisors
 
--- see Note [lower instance priority]
-instance (priority := 10) GroupWithZero.cancelMonoidWithZero : CancelMonoidWithZero G₀ :=
-  { (‹_› : GroupWithZero G₀) with
-    mul_left_cancel_of_ne_zero := @fun x y z hx h => by
-      rw [← inv_mul_cancel_left₀ hx y, h, inv_mul_cancel_left₀ hx z],
-    mul_right_cancel_of_ne_zero := @fun x y z hy h => by
-      rw [← mul_inv_cancel_right₀ hy x, h, mul_inv_cancel_right₀ hy z] }
-#align group_with_zero.cancel_monoid_with_zero GroupWithZero.cancelMonoidWithZero
-
 -- Can't be put next to the other `mk0` lemmas because it depends on the
 -- `NoZeroDivisors` instance, which depends on `mk0`.
 @[simp]

--- a/Mathlib/Algebra/Order/Monoid/Canonical/Defs.lean
+++ b/Mathlib/Algebra/Order/Monoid/Canonical/Defs.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro, Johannes Hölzl
 
 ! This file was ported from Lean 3 source module algebra.order.monoid.canonical.defs
-! leanprover-community/mathlib commit de87d5053a9fe5cbde723172c0fb7e27e7436473
+! leanprover-community/mathlib commit e8638a0fcaf73e4500469f368ef9494e495099b3
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -227,6 +227,8 @@ theorem bot_eq_one : (⊥ : α) = 1 :=
 #align bot_eq_one bot_eq_one
 #align bot_eq_zero bot_eq_zero
 
+--TODO: This is a special case of `mul_eq_one`. We need the instance
+-- `CanonicallyOrderedMonoid α → Unique αˣ`
 @[to_additive (attr := simp)]
 theorem mul_eq_one_iff : a * b = 1 ↔ a = 1 ∧ b = 1 :=
   mul_eq_one_iff' (one_le _) (one_le _)

--- a/Mathlib/Algebra/Ring/Divisibility.lean
+++ b/Mathlib/Algebra/Ring/Divisibility.lean
@@ -55,7 +55,7 @@ section Semigroup
 variable [Semigroup α] [HasDistribNeg α] {a b c : α}
 
 /-- An element `a` of a semigroup with a distributive negation divides the negation of an element
-+`b` iff `a` divides `b`. -/
+`b` iff `a` divides `b`. -/
 @[simp]
 theorem dvd_neg : a ∣ -b ↔ a ∣ b :=
 -- porting note: `simpa` doesn't close the goal with `rfl` anymore
@@ -63,7 +63,7 @@ theorem dvd_neg : a ∣ -b ↔ a ∣ b :=
 #align dvd_neg dvd_neg
 
 /-- The negation of an element `a` of a semigroup with a distributive negation divides another
-+element `b` iff `a` divides `b`. -/
+element `b` iff `a` divides `b`. -/
 @[simp]
 theorem neg_dvd : -a ∣ b ↔ a ∣ b :=
 -- porting note: `simpa` doesn't close the goal with `rfl` anymore
@@ -92,7 +92,7 @@ alias dvd_sub ← Dvd.dvd.sub
 #align has_dvd.dvd.sub Dvd.dvd.sub
 
 /-- If an element `a` divides another element `c` in a ring, `a` divides the sum of another element
-+`b` with `c` iff `a` divides `b`. -/
+`b` with `c` iff `a` divides `b`. -/
 theorem dvd_add_left (h : a ∣ c) : a ∣ b + c ↔ a ∣ b :=
   ⟨fun H => by simpa only [add_sub_cancel] using dvd_sub H h, fun h₂ => dvd_add h₂ h⟩
 #align dvd_add_left dvd_add_left

--- a/Mathlib/Algebra/Ring/Divisibility.lean
+++ b/Mathlib/Algebra/Ring/Divisibility.lean
@@ -5,11 +5,12 @@ Authors: Jeremy Avigad, Leonardo de Moura, Floris van Doorn, Yury Kudryashov, Ne
 Ported by: Matej Penciak
 
 ! This file was ported from Lean 3 source module algebra.ring.divisibility
-! leanprover-community/mathlib commit f1a2caaf51ef593799107fe9a8d5e411599f3996
+! leanprover-community/mathlib commit e8638a0fcaf73e4500469f368ef9494e495099b3
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
 import Mathlib.Algebra.Divisibility.Basic
+import Mathlib.Algebra.Hom.Equiv.Basic
 import Mathlib.Algebra.Ring.Defs
 import Mathlib.Tactic.Convert
 
@@ -27,6 +28,9 @@ variable [Add α] [Semigroup α]
 theorem dvd_add [LeftDistribClass α] {a b c : α} (h₁ : a ∣ b) (h₂ : a ∣ c) : a ∣ b + c :=
   Dvd.elim h₁ fun d hd => Dvd.elim h₂ fun e he => Dvd.intro (d + e) (by simp [left_distrib, hd, he])
 #align dvd_add dvd_add
+
+alias dvd_add ← Dvd.dvd.add
+#align has_dvd.dvd.add Dvd.dvd.add
 
 end DistribSemigroup
 
@@ -50,39 +54,29 @@ section Semigroup
 
 variable [Semigroup α] [HasDistribNeg α] {a b c : α}
 
-theorem dvd_neg_of_dvd (h : a ∣ b) : a ∣ -b :=
-  let ⟨c, hc⟩ := h
-  ⟨-c, by simp [hc]⟩
-#align dvd_neg_of_dvd dvd_neg_of_dvd
-
-theorem dvd_of_dvd_neg (h : a ∣ -b) : a ∣ b := by
-  let t := dvd_neg_of_dvd h
-  rwa [neg_neg] at t
-#align dvd_of_dvd_neg dvd_of_dvd_neg
-
-/-- An element a of a semigroup with a distributive negation divides the negation of an element b
-iff a divides b. -/
+/-- An element `a` of a semigroup with a distributive negation divides the negation of an element
++`b` iff `a` divides `b`. -/
 @[simp]
-theorem dvd_neg (a b : α) : a ∣ -b ↔ a ∣ b :=
-  ⟨dvd_of_dvd_neg, dvd_neg_of_dvd⟩
+theorem dvd_neg : a ∣ -b ↔ a ∣ b :=
+-- porting note: `simpa` doesn't close the goal with `rfl` anymore
+  (Equiv.neg _).exists_congr_left.trans <| by simp; rfl
 #align dvd_neg dvd_neg
 
-theorem neg_dvd_of_dvd (h : a ∣ b) : -a ∣ b :=
-  let ⟨c, hc⟩ := h
-  ⟨-c, by simp [hc]⟩
-#align neg_dvd_of_dvd neg_dvd_of_dvd
-
-theorem dvd_of_neg_dvd (h : -a ∣ b) : a ∣ b := by
-  let t := neg_dvd_of_dvd h
-  rwa [neg_neg] at t
-#align dvd_of_neg_dvd dvd_of_neg_dvd
-
-/-- The negation of an element a of a semigroup with a distributive negation divides
-another element b iff a divides b. -/
+/-- The negation of an element `a` of a semigroup with a distributive negation divides another
++element `b` iff `a` divides `b`. -/
 @[simp]
-theorem neg_dvd (a b : α) : -a ∣ b ↔ a ∣ b :=
-  ⟨dvd_of_neg_dvd, neg_dvd_of_dvd⟩
+theorem neg_dvd : -a ∣ b ↔ a ∣ b :=
+-- porting note: `simpa` doesn't close the goal with `rfl` anymore
+  (Equiv.neg _).exists_congr_left.trans <| by simp; rfl
 #align neg_dvd neg_dvd
+
+alias neg_dvd ↔ Dvd.dvd.of_neg_left Dvd.dvd.neg_left
+#align has_dvd.dvd.of_neg_left Dvd.dvd.of_neg_left
+#align has_dvd.dvd.neg_left Dvd.dvd.neg_left
+
+alias dvd_neg ↔ Dvd.dvd.of_neg_right Dvd.dvd.neg_right
+#align has_dvd.dvd.of_neg_right Dvd.dvd.of_neg_right
+#align has_dvd.dvd.neg_right Dvd.dvd.neg_right
 
 end Semigroup
 
@@ -91,39 +85,44 @@ section NonUnitalRing
 variable [NonUnitalRing α] {a b c : α}
 
 theorem dvd_sub (h₁ : a ∣ b) (h₂ : a ∣ c) : a ∣ b - c := by
-  rw [sub_eq_add_neg]
-  exact dvd_add h₁ (dvd_neg_of_dvd h₂)
+  simpa only [← sub_eq_add_neg] using h₁.add h₂.neg_right
 #align dvd_sub dvd_sub
 
-theorem dvd_add_iff_left (h : a ∣ c) : a ∣ b ↔ a ∣ b + c :=
-  ⟨fun h₂ => dvd_add h₂ h, fun H => by have t := dvd_sub H h ; rwa [add_sub_cancel] at t⟩
-#align dvd_add_iff_left dvd_add_iff_left
+alias dvd_sub ← Dvd.dvd.sub
+#align has_dvd.dvd.sub Dvd.dvd.sub
 
-theorem dvd_add_iff_right (h : a ∣ b) : a ∣ c ↔ a ∣ b + c := by
-  rw [add_comm] ; exact dvd_add_iff_left h
-#align dvd_add_iff_right dvd_add_iff_right
-
-/-- If an element a divides another element c in a commutative ring, a divides the sum of another
-  element b with c iff a divides b. -/
+/-- If an element `a` divides another element `c` in a ring, `a` divides the sum of another element
++`b` with `c` iff `a` divides `b`. -/
 theorem dvd_add_left (h : a ∣ c) : a ∣ b + c ↔ a ∣ b :=
-  (dvd_add_iff_left h).symm
+  ⟨fun H => by simpa only [add_sub_cancel] using dvd_sub H h, fun h₂ => dvd_add h₂ h⟩
 #align dvd_add_left dvd_add_left
 
-/-- If an element a divides another element b in a commutative ring, a divides the sum of b and
-  another element c iff a divides c. -/
-theorem dvd_add_right (h : a ∣ b) : a ∣ b + c ↔ a ∣ c :=
-  (dvd_add_iff_right h).symm
+/-- If an element `a` divides another element `b` in a ring, `a` divides the sum of `b` and another
+element `c` iff `a` divides `c`. -/
+theorem dvd_add_right (h : a ∣ b) : a ∣ b + c ↔ a ∣ c := by rw [add_comm]; exact dvd_add_left h
 #align dvd_add_right dvd_add_right
 
-theorem dvd_iff_dvd_of_dvd_sub {a b c : α} (h : a ∣ b - c) : a ∣ b ↔ a ∣ c := by
-  constructor
-  · intro h'
-    convert dvd_sub h' h
-    exact Eq.symm (sub_sub_self b c)
-  · intro h'
-    convert dvd_add h h'
-    exact eq_add_of_sub_eq rfl
+/-- If an element `a` divides another element `c` in a ring, `a` divides the difference of another
+element `b` with `c` iff `a` divides `b`. -/
+theorem dvd_sub_left (h : a ∣ c) : a ∣ b - c ↔ a ∣ b := by
+--porting note: Needed to give `α` explicitly
+  simpa only [← sub_eq_add_neg] using dvd_add_left ((dvd_neg (α := α)).2 h)
+#align dvd_sub_left dvd_sub_left
+
+/-- If an element `a` divides another element `b` in a ring, `a` divides the difference of `b` and
+another element `c` iff `a` divides `c`. -/
+theorem dvd_sub_right (h : a ∣ b) : a ∣ b - c ↔ a ∣ c := by
+--porting note: Needed to give `α` explicitly
+  rw [sub_eq_add_neg, dvd_add_right h, dvd_neg (α := α)]
+#align dvd_sub_right dvd_sub_right
+
+theorem dvd_iff_dvd_of_dvd_sub (h : a ∣ b - c) : a ∣ b ↔ a ∣ c := by
+  rw [← sub_add_cancel b c, dvd_add_right h]
 #align dvd_iff_dvd_of_dvd_sub dvd_iff_dvd_of_dvd_sub
+
+--porting note: Needed to give `α` explicitly
+theorem dvd_sub_comm : a ∣ b - c ↔ a ∣ c - b := by rw [← dvd_neg (α := α), neg_sub]
+#align dvd_sub_comm dvd_sub_comm
 
 end NonUnitalRing
 
@@ -133,7 +132,7 @@ variable [Ring α] {a b c : α}
 
 set_option linter.deprecated false in
 theorem two_dvd_bit1 : 2 ∣ bit1 a ↔ (2 : α) ∣ 1 :=
-  (dvd_add_iff_right (@two_dvd_bit0 _ _ a)).symm
+  dvd_add_right two_dvd_bit0
 #align two_dvd_bit1 two_dvd_bit1
 
 /-- An element a divides the sum a + b if and only if a divides b.-/
@@ -147,6 +146,18 @@ theorem dvd_add_self_left {a b : α} : a ∣ a + b ↔ a ∣ b :=
 theorem dvd_add_self_right {a b : α} : a ∣ b + a ↔ a ∣ b :=
   dvd_add_left (dvd_refl a)
 #align dvd_add_self_right dvd_add_self_right
+
+/-- An element `a` divides the difference `a - b` if and only if `a` divides `b`. -/
+@[simp]
+theorem dvd_sub_self_left : a ∣ a - b ↔ a ∣ b :=
+  dvd_sub_right dvd_rfl
+#align dvd_sub_self_left dvd_sub_self_left
+
+/-- An element `a` divides the difference `b - a` if and only if `a` divides `b`. -/
+@[simp]
+theorem dvd_sub_self_right : a ∣ b - a ↔ a ∣ b :=
+  dvd_sub_left dvd_rfl
+#align dvd_sub_self_right dvd_sub_self_right
 
 end Ring
 

--- a/Mathlib/Data/Int/Dvd/Basic.lean
+++ b/Mathlib/Data/Int/Dvd/Basic.lean
@@ -5,7 +5,7 @@ Authors: Jeremy Avigad
 Ported by: Scott Morrison
 
 ! This file was ported from Lean 3 source module data.int.dvd.basic
-! leanprover-community/mathlib commit e1bccd6e40ae78370f01659715d3c948716e3b7e
+! leanprover-community/mathlib commit e8638a0fcaf73e4500469f368ef9494e495099b3
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -49,22 +49,6 @@ theorem coe_nat_dvd_right {n : ℕ} {z : ℤ} : z ∣ (↑n : ℤ) ↔ z.natAbs 
 #align int.eq_one_of_mul_eq_one_right Int.eq_one_of_mul_eq_one_right
 
 #align int.eq_one_of_mul_eq_one_left Int.eq_one_of_mul_eq_one_left
-
-theorem ofNat_dvd_of_dvd_natAbs {a : ℕ} : ∀ {z : ℤ} (_ : a ∣ z.natAbs), ↑a ∣ z
-  | Int.ofNat _, haz => Int.coe_nat_dvd.2 haz
-  | -[k+1], haz => by
-    change ↑a ∣ -(k + 1 : ℤ)
-    apply dvd_neg_of_dvd
-    apply Int.coe_nat_dvd.2
-    exact haz
-#align int.of_nat_dvd_of_dvd_nat_abs Int.ofNat_dvd_of_dvd_natAbs
-
-theorem dvd_natAbs_of_ofNat_dvd {a : ℕ} : ∀ {z : ℤ} (_ : ↑a ∣ z), a ∣ z.natAbs
-  | Int.ofNat _, haz => Int.coe_nat_dvd.1 (Int.dvd_natAbs.2 haz)
-  | -[k+1], haz =>
-    have haz' : (↑a : ℤ) ∣ (↑(k + 1) : ℤ) := dvd_of_dvd_neg haz
-    Int.coe_nat_dvd.1 haz'
-#align int.dvd_nat_abs_of_of_nat_dvd Int.dvd_natAbs_of_ofNat_dvd
 
 #align int.dvd_antisymm Int.dvd_antisymm
 

--- a/Mathlib/Data/Int/Dvd/Pow.lean
+++ b/Mathlib/Data/Int/Dvd/Pow.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad
 
 ! This file was ported from Lean 3 source module data.int.dvd.pow
-! leanprover-community/mathlib commit b3f25363ae62cb169e72cd6b8b1ac97bacf21ca7
+! leanprover-community/mathlib commit e8638a0fcaf73e4500469f368ef9494e495099b3
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -28,25 +28,14 @@ theorem sign_pow_bit1 (k : ℕ) : ∀ n : ℤ, n.sign ^ bit1 k = n.sign
   | -[_+1] => (neg_pow_bit1 1 k).trans (congr_arg (fun x => -x) (one_pow (bit1 k)))
 #align int.sign_pow_bit1 Int.sign_pow_bit1
 
+--TODO: Do we really need this lemma?
 theorem pow_dvd_of_le_of_pow_dvd {p m n : ℕ} {k : ℤ} (hmn : m ≤ n) (hdiv : ↑(p ^ n) ∣ k) :
-    ↑(p ^ m) ∣ k := by
-  induction k with
-  | ofNat k =>
-    apply Int.coe_nat_dvd.2
-    apply Nat.pow_dvd_of_le_of_pow_dvd hmn
-    apply Int.coe_nat_dvd.1 hdiv
-  | negSucc k =>
-    show ↑(p ^ m) ∣ -(↑(k + 1) : ℤ)
-    apply dvd_neg_of_dvd
-    apply Int.coe_nat_dvd.2
-    apply Nat.pow_dvd_of_le_of_pow_dvd hmn
-    apply Int.coe_nat_dvd.1
-    apply dvd_of_dvd_neg
-    exact hdiv
+    ↑(p ^ m) ∣ k :=
+  (pow_dvd_pow _ hmn).natCast.trans hdiv
 #align int.pow_dvd_of_le_of_pow_dvd Int.pow_dvd_of_le_of_pow_dvd
 
-theorem dvd_of_pow_dvd {p k : ℕ} {m : ℤ} (hk : 1 ≤ k) (hpk : ↑(p ^ k) ∣ m) : ↑p ∣ m := by
-  rw [← pow_one p] ; exact pow_dvd_of_le_of_pow_dvd hk hpk
+theorem dvd_of_pow_dvd {p k : ℕ} {m : ℤ} (hk : 1 ≤ k) (hpk : ↑(p ^ k) ∣ m) : ↑p ∣ m :=
+  (dvd_pow_self _ <| pos_iff_ne_zero.1 hk).natCast.trans hpk
 #align int.dvd_of_pow_dvd Int.dvd_of_pow_dvd
 
 end Int

--- a/Mathlib/Data/Int/Order/Basic.lean
+++ b/Mathlib/Data/Int/Order/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad
 
 ! This file was ported from Lean 3 source module data.int.order.basic
-! leanprover-community/mathlib commit 728baa2f54e6062c5879a3e397ac6bac323e506f
+! leanprover-community/mathlib commit e8638a0fcaf73e4500469f368ef9494e495099b3
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/

--- a/Mathlib/Data/Nat/GCD/Basic.lean
+++ b/Mathlib/Data/Nat/GCD/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura
 
 ! This file was ported from Lean 3 source module data.nat.gcd.basic
-! leanprover-community/mathlib commit a47cda9662ff3925c6df271090b5808adbca5b46
+! leanprover-community/mathlib commit e8638a0fcaf73e4500469f368ef9494e495099b3
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -100,6 +100,11 @@ theorem lcm_dvd_mul (m n : ℕ) : lcm m n ∣ m * n :=
 theorem lcm_dvd_iff {m n k : ℕ} : lcm m n ∣ k ↔ m ∣ k ∧ n ∣ k :=
   ⟨fun h => ⟨(dvd_lcm_left _ _).trans h, (dvd_lcm_right _ _).trans h⟩, and_imp.2 lcm_dvd⟩
 #align nat.lcm_dvd_iff Nat.lcm_dvd_iff
+
+theorem lcm_pos {m n : ℕ} : 0 < m → 0 < n → 0 < m.lcm n := by
+  simp_rw [pos_iff_ne_zero]
+  exact lcm_ne_zero
+#align nat.lcm_pos Nat.lcm_pos
 
 /-!
 ### `coprime`

--- a/Mathlib/Data/Nat/Order/Basic.lean
+++ b/Mathlib/Data/Nat/Order/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn, Leonardo de Moura, Jeremy Avigad, Mario Carneiro
 
 ! This file was ported from Lean 3 source module data.nat.order.basic
-! leanprover-community/mathlib commit 26f081a2fb920140ed5bc5cc5344e84bcc7cb2b2
+! leanprover-community/mathlib commit e8638a0fcaf73e4500469f368ef9494e495099b3
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -288,21 +288,6 @@ theorem sub_succ' (m n : ℕ) : m - n.succ = m - n - 1 :=
 #align nat.sub_succ' Nat.sub_succ'
 
 /-! ### `mul` -/
-
-
-theorem mul_eq_one_iff : ∀ {m n : ℕ}, m * n = 1 ↔ m = 1 ∧ n = 1
-  | 0, 0 => by decide
-  | 0, 1 => by decide
-  | 1, 0 => by decide
-  | m + 2, 0 => by simp
-  | 0, n + 2 => by simp
-  | m + 1, n + 1 =>
-    ⟨fun h => by
-      simp only [succ_mul, mul_succ, add_succ, one_mul, mul_one, (add_assoc _ _ _).symm,
-          ← succ_eq_add_one, add_eq_zero_iff, (show 1 = succ 0 from rfl), succ_inj'] at h
-      simp [h],
-      fun h => by simp only [h, mul_one]⟩
-#align nat.mul_eq_one_iff Nat.mul_eq_one_iff
 
 theorem succ_mul_pos (m : ℕ) (hn : 0 < n) : 0 < succ m * n :=
   mul_pos (succ_pos m) hn

--- a/Mathlib/Data/Nat/Order/Lemmas.lean
+++ b/Mathlib/Data/Nat/Order/Lemmas.lean
@@ -4,11 +4,12 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn, Leonardo de Moura, Jeremy Avigad, Mario Carneiro
 
 ! This file was ported from Lean 3 source module data.nat.order.lemmas
-! leanprover-community/mathlib commit 2258b40dacd2942571c8ce136215350c702dc78f
+! leanprover-community/mathlib commit e8638a0fcaf73e4500469f368ef9494e495099b3
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
 import Mathlib.Data.Nat.Order.Basic
+import Mathlib.Data.Nat.Units
 import Mathlib.Data.Set.Basic
 import Mathlib.Algebra.Ring.Divisibility
 import Mathlib.Algebra.GroupWithZero.Divisibility
@@ -25,7 +26,7 @@ please feel free to reorganize these two files.
 
 universe u v
 
-variable {m n k : ℕ}
+variable {a b m n k : ℕ}
 
 namespace Nat
 
@@ -204,6 +205,12 @@ theorem eq_zero_of_dvd_of_lt {a b : ℕ} (w : a ∣ b) (h : b < a) : b = 0 :=
   Nat.eq_zero_of_dvd_of_div_eq_zero w
     ((Nat.div_eq_zero_iff (lt_of_le_of_lt (zero_le b) h)).mpr h)
 #align nat.eq_zero_of_dvd_of_lt Nat.eq_zero_of_dvd_of_lt
+
+theorem le_of_lt_add_of_dvd (h : a < b + n) : n ∣ a → n ∣ b → a ≤ b := by
+  rintro ⟨a, rfl⟩ ⟨b, rfl⟩
+  rw [← mul_add_one] at h
+  exact mul_le_mul_left' (lt_succ_iff.1 <| lt_of_mul_lt_mul_left h bot_le) _
+#align nat.le_of_lt_add_of_dvd Nat.le_of_lt_add_of_dvd
 
 @[simp]
 theorem mod_div_self (m n : ℕ) : m % n / n = 0 := by

--- a/Mathlib/Data/Nat/Order/Lemmas.lean
+++ b/Mathlib/Data/Nat/Order/Lemmas.lean
@@ -208,7 +208,8 @@ theorem eq_zero_of_dvd_of_lt {a b : ℕ} (w : a ∣ b) (h : b < a) : b = 0 :=
 
 theorem le_of_lt_add_of_dvd (h : a < b + n) : n ∣ a → n ∣ b → a ≤ b := by
   rintro ⟨a, rfl⟩ ⟨b, rfl⟩
-  rw [← mul_add_one] at h
+  --porting note: Had to give an explicit argument to `mul_add_one`
+  rw [← mul_add_one n] at h
   exact mul_le_mul_left' (lt_succ_iff.1 <| lt_of_mul_lt_mul_left h bot_le) _
 #align nat.le_of_lt_add_of_dvd Nat.le_of_lt_add_of_dvd
 

--- a/Mathlib/Dynamics/PeriodicPts.lean
+++ b/Mathlib/Dynamics/PeriodicPts.lean
@@ -439,7 +439,7 @@ theorem Commute.minimalPeriod_of_comp_dvd_mul {g : α → α} (h : Function.Comm
 theorem Commute.minimalPeriod_of_comp_eq_mul_of_coprime {g : α → α} (h : Function.Commute f g)
     (hco : coprime (minimalPeriod f x) (minimalPeriod g x)) :
     minimalPeriod (f ∘ g) x = minimalPeriod f x * minimalPeriod g x := by
-  apply h.minimalPeriod_of_comp_dvd_mul.antisymmm
+  apply h.minimalPeriod_of_comp_dvd_mul.antisymm
   suffices :
     ∀ {f g : α → α},
       Commute f g →

--- a/Mathlib/Dynamics/PeriodicPts.lean
+++ b/Mathlib/Dynamics/PeriodicPts.lean
@@ -439,7 +439,7 @@ theorem Commute.minimalPeriod_of_comp_dvd_mul {g : α → α} (h : Function.Comm
 theorem Commute.minimalPeriod_of_comp_eq_mul_of_coprime {g : α → α} (h : Function.Commute f g)
     (hco : coprime (minimalPeriod f x) (minimalPeriod g x)) :
     minimalPeriod (f ∘ g) x = minimalPeriod f x * minimalPeriod g x := by
-  apply dvd_antisymm h.minimalPeriod_of_comp_dvd_mul
+  apply h.minimalPeriod_of_comp_dvd_mul.antisymmm
   suffices :
     ∀ {f g : α → α},
       Commute f g →

--- a/Mathlib/GroupTheory/Perm/Cycle/Basic.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes, Yaël Dillies
 
 ! This file was ported from Lean 3 source module group_theory.perm.cycle.basic
-! leanprover-community/mathlib commit 92ca63f0fb391a9ca5f22d2409a6080e786d99f7
+! leanprover-community/mathlib commit e8638a0fcaf73e4500469f368ef9494e495099b3
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -888,7 +888,7 @@ theorem IsCycleOn.zpow_apply_eq {s : Finset α} (hf : f.IsCycleOn s) (ha : a ∈
   | Int.ofNat n => (hf.pow_apply_eq ha).trans Int.coe_nat_dvd.symm
   | Int.negSucc n => by
     rw [zpow_negSucc, ← inv_pow]
-    exact (hf.inv.pow_apply_eq ha).trans ((dvd_neg _ _).trans Int.coe_nat_dvd).symm
+    exact (hf.inv.pow_apply_eq ha).trans (dvd_neg.trans Int.coe_nat_dvd).symm
 #align equiv.perm.is_cycle_on.zpow_apply_eq Equiv.Perm.IsCycleOn.zpow_apply_eq
 
 theorem IsCycleOn.pow_apply_eq_pow_apply {s : Finset α} (hf : f.IsCycleOn s) (ha : a ∈ s)

--- a/Mathlib/NumberTheory/Divisors.lean
+++ b/Mathlib/NumberTheory/Divisors.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Aaron Anderson
 
 ! This file was ported from Lean 3 source module number_theory.divisors
-! leanprover-community/mathlib commit f7fc89d5d5ff1db2d1242c7bb0e9062ce47ef47c
+! leanprover-community/mathlib commit e8638a0fcaf73e4500469f368ef9494e495099b3
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -207,7 +207,7 @@ theorem divisorsAntidiagonal_zero : divisorsAntidiagonal 0 = ∅ := by
 @[simp]
 theorem divisorsAntidiagonal_one : divisorsAntidiagonal 1 = {(1, 1)} := by
   ext
-  simp [Nat.mul_eq_one_iff, Prod.ext_iff]
+  simp [mul_eq_one, Prod.ext_iff]
 #align nat.divisors_antidiagonal_one Nat.divisorsAntidiagonal_one
 
 /- Porting note: simpnf linter; added aux lemma below

--- a/Mathlib/NumberTheory/PythagoreanTriples.lean
+++ b/Mathlib/NumberTheory/PythagoreanTriples.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Paul van Wamelen
 
 ! This file was ported from Lean 3 source module number_theory.pythagorean_triples
-! leanprover-community/mathlib commit 70fd9563a21e7b963887c9360bd29b2393e6225a
+! leanprover-community/mathlib commit e8638a0fcaf73e4500469f368ef9494e495099b3
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -138,9 +138,9 @@ theorem even_odd_of_coprime (hc : Int.gcd x y = 1) :
   -- x even, y even
   · exfalso
     apply Nat.not_coprime_of_dvd_of_dvd (by decide : 1 < 2) _ _ hc
-    · apply Int.dvd_natAbs_of_ofNat_dvd
+    · apply Int.coe_nat_dvd_left.1
       apply Int.dvd_of_emod_eq_zero hx
-    · apply Int.dvd_natAbs_of_ofNat_dvd
+    · apply Int.coe_nat_dvd_left.1
       apply Int.dvd_of_emod_eq_zero hy
   -- x even, y odd
   · left
@@ -381,8 +381,7 @@ private theorem coprime_sq_sub_mul_of_even_odd {m n : ℤ} (h : Int.gcd m n = 1)
     apply (or_self_iff _).mp
     apply Int.Prime.dvd_mul' hp
     rw [(by ring : n * n = -(m ^ 2 - n ^ 2) + m * m)]
-    apply dvd_add (dvd_neg_of_dvd hp1)
-    exact dvd_mul_of_dvd_left (Int.coe_nat_dvd_left.mpr hpm) m
+    exact hp1.neg_right.add ((Int.coe_nat_dvd_left.2 hpm).mul_right _)
   rw [Int.gcd_comm] at hnp
   apply mt (Int.dvd_gcd (Int.coe_nat_dvd_left.mpr hpn)) hnp
   apply (or_self_iff _).mp

--- a/Mathlib/NumberTheory/Zsqrtd/Basic.lean
+++ b/Mathlib/NumberTheory/Zsqrtd/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 
 ! This file was ported from Lean 3 source module number_theory.zsqrtd.basic
-! leanprover-community/mathlib commit 7ec294687917cbc5c73620b4414ae9b5dd9ae1b4
+! leanprover-community/mathlib commit e8638a0fcaf73e4500469f368ef9494e495099b3
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -596,7 +596,7 @@ theorem norm_eq_one_iff {x : ℤ√d} : x.norm.natAbs = 1 ↔ IsUnit x :=
     let ⟨y, hy⟩ := isUnit_iff_dvd_one.1 h
     have := congr_arg (Int.natAbs ∘ norm) hy
     rw [Function.comp_apply, Function.comp_apply, norm_mul, Int.natAbs_mul, norm_one,
-      Int.natAbs_one, eq_comm, Nat.mul_eq_one_iff] at this
+      Int.natAbs_one, eq_comm, mul_eq_one] at this
     exact this.1⟩
 #align zsqrtd.norm_eq_one_iff Zsqrtd.norm_eq_one_iff
 

--- a/Mathlib/RingTheory/Multiplicity.lean
+++ b/Mathlib/RingTheory/Multiplicity.lean
@@ -427,7 +427,7 @@ protected theorem neg (a b : α) : multiplicity a (-b) = multiplicity a b :=
     PartENat.natCast_inj.1 (by
       rw [PartENat.natCast_get]
       exact Eq.symm
-              (Unique (pow_multiplicity_dvd _).neg_right
+              (unique (pow_multiplicity_dvd _).neg_right
                 (mt dvd_neg.1 (is_greatest' _ (lt_succ_self _)))))
 #align multiplicity.neg multiplicity.neg
 

--- a/Mathlib/RingTheory/Multiplicity.lean
+++ b/Mathlib/RingTheory/Multiplicity.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Y. Lewis, Chris Hughes
 
 ! This file was ported from Lean 3 source module ring_theory.multiplicity
-! leanprover-community/mathlib commit ceb887ddf3344dab425292e497fa2af91498437c
+! leanprover-community/mathlib commit e8638a0fcaf73e4500469f368ef9494e495099b3
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -427,8 +427,8 @@ protected theorem neg (a b : α) : multiplicity a (-b) = multiplicity a b :=
     PartENat.natCast_inj.1 (by
       rw [PartENat.natCast_get]
       exact Eq.symm
-        (unique ((dvd_neg _ _).2 (pow_multiplicity_dvd _))
-          (mt (dvd_neg _ _).1 (is_greatest' _ (lt_succ_self _)))))
+              (Unique (pow_multiplicity_dvd _).neg_right
+                (mt dvd_neg.1 (is_greatest' _ (lt_succ_self _)))))
 #align multiplicity.neg multiplicity.neg
 
 theorem Int.natAbs (a : ℕ) (b : ℤ) : multiplicity a b.natAbs = multiplicity (a : ℤ) b := by
@@ -443,9 +443,8 @@ theorem multiplicity_add_of_gt {p a b : α} (h : multiplicity p b < multiplicity
   · apply PartENat.le_of_lt_add_one
     cases' PartENat.ne_top_iff.mp (PartENat.ne_top_of_lt h) with k hk
     rw [hk]
-    rw_mod_cast [multiplicity_lt_iff_neg_dvd]
+    rw_mod_cast [multiplicity_lt_iff_neg_dvd, dvd_add_right]
     intro h_dvd
-    rw [← dvd_add_iff_right] at h_dvd
     · apply multiplicity.is_greatest _ h_dvd
       rw [hk, ←Nat.succ_eq_add_one]
       norm_cast


### PR DESCRIPTION
Match https://github.com/leanprover-community/mathlib/pull/18698 and a bit of https://github.com/leanprover-community/mathlib/pull/18785.

* [`algebra.divisibility.basic`@`70d50ecfd4900dd6d328da39ab7ebd516abe4025`..`e8638a0fcaf73e4500469f368ef9494e495099b3`](https://leanprover-community.github.io/mathlib-port-status/file/algebra/divisibility/basic?range=70d50ecfd4900dd6d328da39ab7ebd516abe4025..e8638a0fcaf73e4500469f368ef9494e495099b3)
* [`algebra.euclidean_domain.basic`@`655994e298904d7e5bbd1e18c95defd7b543eb94`..`e8638a0fcaf73e4500469f368ef9494e495099b3`](https://leanprover-community.github.io/mathlib-port-status/file/algebra/euclidean_domain/basic?range=655994e298904d7e5bbd1e18c95defd7b543eb94..e8638a0fcaf73e4500469f368ef9494e495099b3)
* [`algebra.group.units`@`369525b73f229ccd76a6ec0e0e0bf2be57599768`..`e8638a0fcaf73e4500469f368ef9494e495099b3`](https://leanprover-community.github.io/mathlib-port-status/file/algebra/group/units?range=369525b73f229ccd76a6ec0e0e0bf2be57599768..e8638a0fcaf73e4500469f368ef9494e495099b3)
* [`algebra.group_with_zero.basic`@`2196ab363eb097c008d4497125e0dde23fb36db2`..`e8638a0fcaf73e4500469f368ef9494e495099b3`](https://leanprover-community.github.io/mathlib-port-status/file/algebra/group_with_zero/basic?range=2196ab363eb097c008d4497125e0dde23fb36db2..e8638a0fcaf73e4500469f368ef9494e495099b3)
* [`algebra.group_with_zero.divisibility`@`f1a2caaf51ef593799107fe9a8d5e411599f3996`..`e8638a0fcaf73e4500469f368ef9494e495099b3`](https://leanprover-community.github.io/mathlib-port-status/file/algebra/group_with_zero/divisibility?range=f1a2caaf51ef593799107fe9a8d5e411599f3996..e8638a0fcaf73e4500469f368ef9494e495099b3)
* [`algebra.group_with_zero.units.basic`@`70d50ecfd4900dd6d328da39ab7ebd516abe4025`..`df5e9937a06fdd349fc60106f54b84d47b1434f0`](https://leanprover-community.github.io/mathlib-port-status/file/algebra/group_with_zero/units/basic?range=70d50ecfd4900dd6d328da39ab7ebd516abe4025..df5e9937a06fdd349fc60106f54b84d47b1434f0)
* [`algebra.order.monoid.canonical.defs`@`de87d5053a9fe5cbde723172c0fb7e27e7436473`..`e8638a0fcaf73e4500469f368ef9494e495099b3`](https://leanprover-community.github.io/mathlib-port-status/file/algebra/order/monoid/canonical/defs?range=de87d5053a9fe5cbde723172c0fb7e27e7436473..e8638a0fcaf73e4500469f368ef9494e495099b3)
* [`algebra.ring.divisibility`@`f1a2caaf51ef593799107fe9a8d5e411599f3996`..`e8638a0fcaf73e4500469f368ef9494e495099b3`](https://leanprover-community.github.io/mathlib-port-status/file/algebra/ring/divisibility?range=f1a2caaf51ef593799107fe9a8d5e411599f3996..e8638a0fcaf73e4500469f368ef9494e495099b3)
* [`data.int.dvd.basic`@`e1bccd6e40ae78370f01659715d3c948716e3b7e`..`e8638a0fcaf73e4500469f368ef9494e495099b3`](https://leanprover-community.github.io/mathlib-port-status/file/data/int/dvd/basic?range=e1bccd6e40ae78370f01659715d3c948716e3b7e..e8638a0fcaf73e4500469f368ef9494e495099b3)
* [`data.int.dvd.pow`@`b3f25363ae62cb169e72cd6b8b1ac97bacf21ca7`..`e8638a0fcaf73e4500469f368ef9494e495099b3`](https://leanprover-community.github.io/mathlib-port-status/file/data/int/dvd/pow?range=b3f25363ae62cb169e72cd6b8b1ac97bacf21ca7..e8638a0fcaf73e4500469f368ef9494e495099b3)
* [`data.int.order.basic`@`728baa2f54e6062c5879a3e397ac6bac323e506f`..`e8638a0fcaf73e4500469f368ef9494e495099b3`](https://leanprover-community.github.io/mathlib-port-status/file/data/int/order/basic?range=728baa2f54e6062c5879a3e397ac6bac323e506f..e8638a0fcaf73e4500469f368ef9494e495099b3)
* [`data.nat.gcd.basic`@`a47cda9662ff3925c6df271090b5808adbca5b46`..`e8638a0fcaf73e4500469f368ef9494e495099b3`](https://leanprover-community.github.io/mathlib-port-status/file/data/nat/gcd/basic?range=a47cda9662ff3925c6df271090b5808adbca5b46..e8638a0fcaf73e4500469f368ef9494e495099b3)
* [`data.nat.order.basic`@`26f081a2fb920140ed5bc5cc5344e84bcc7cb2b2`..`e8638a0fcaf73e4500469f368ef9494e495099b3`](https://leanprover-community.github.io/mathlib-port-status/file/data/nat/order/basic?range=26f081a2fb920140ed5bc5cc5344e84bcc7cb2b2..e8638a0fcaf73e4500469f368ef9494e495099b3)
* [`data.nat.order.lemmas`@`2258b40dacd2942571c8ce136215350c702dc78f`..`e8638a0fcaf73e4500469f368ef9494e495099b3`](https://leanprover-community.github.io/mathlib-port-status/file/data/nat/order/lemmas?range=2258b40dacd2942571c8ce136215350c702dc78f..e8638a0fcaf73e4500469f368ef9494e495099b3)
* [`group_theory.perm.cycle.basic`@`92ca63f0fb391a9ca5f22d2409a6080e786d99f7`..`e8638a0fcaf73e4500469f368ef9494e495099b3`](https://leanprover-community.github.io/mathlib-port-status/file/group_theory/perm/cycle/basic?range=92ca63f0fb391a9ca5f22d2409a6080e786d99f7..e8638a0fcaf73e4500469f368ef9494e495099b3)
* [`number_theory.divisors`@`f7fc89d5d5ff1db2d1242c7bb0e9062ce47ef47c`..`e8638a0fcaf73e4500469f368ef9494e495099b3`](https://leanprover-community.github.io/mathlib-port-status/file/number_theory/divisors?range=f7fc89d5d5ff1db2d1242c7bb0e9062ce47ef47c..e8638a0fcaf73e4500469f368ef9494e495099b3)
* [`number_theory.pythagorean_triples`@`70fd9563a21e7b963887c9360bd29b2393e6225a`..`e8638a0fcaf73e4500469f368ef9494e495099b3`](https://leanprover-community.github.io/mathlib-port-status/file/number_theory/pythagorean_triples?range=70fd9563a21e7b963887c9360bd29b2393e6225a..e8638a0fcaf73e4500469f368ef9494e495099b3)
* [`number_theory.zsqrtd.basic`@`7ec294687917cbc5c73620b4414ae9b5dd9ae1b4`..`e8638a0fcaf73e4500469f368ef9494e495099b3`](https://leanprover-community.github.io/mathlib-port-status/file/number_theory/zsqrtd/basic?range=7ec294687917cbc5c73620b4414ae9b5dd9ae1b4..e8638a0fcaf73e4500469f368ef9494e495099b3)
* [`ring_theory.multiplicity`@`ceb887ddf3344dab425292e497fa2af91498437c`..`e8638a0fcaf73e4500469f368ef9494e495099b3`](https://leanprover-community.github.io/mathlib-port-status/file/ring_theory/multiplicity?range=ceb887ddf3344dab425292e497fa2af91498437c..e8638a0fcaf73e4500469f368ef9494e495099b3)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
