### PR TITLE
[Merged by Bors] - fix: make convert tactic use `convert` suffix for goals from anonymous placeholders

### DIFF
--- a/Mathlib/Tactic/Convert.lean
+++ b/Mathlib/Tactic/Convert.lean
@@ -97,7 +97,7 @@ elab_rules : tactic
 | `(tactic| convert $[$cfg:config]? $[←%$sym]? $term $[using $n]?) => withMainContext do
   let config ← Congr!.elabConfig (mkOptionalNode cfg)
   let (e, gs) ← elabTermWithHoles (allowNaturalHoles := true) term
-    (← mkFreshExprMVar (mkSort (← getLevel (← getMainTarget)))) (← getMainTag)
+    (← mkFreshExprMVar (mkSort (← getLevel (← getMainTarget)))) `convert
   liftMetaTactic fun g ↦ return (← g.convert e sym.isSome (n.map (·.getNat)) config) ++ gs
 
 -- FIXME restore when `add_tactic_doc` is ported.


### PR DESCRIPTION
The `convert` tactic mistakenly calls `elabTermWithHoles` using the main goal's tag for the suffix. For example, if the main goal tag was `inl` this would produce tags like `inl.inl_1` for goals associated to anonymous placeholders. We change convert to use the suffix `convert` instead, yielding subgoals like `inl.convert_1` for these.

The previous behavior caused a panic in #3312 due to macro scopes in goal tags, which this fix happily sidesteps.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
