### PR TITLE
[Merged by Bors] - feat: port changes to `Cardinal` files

### DIFF
--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -32,7 +32,7 @@ We define cardinal numbers as a quotient of types under the equivalence relation
 * Multiplication `c₁ * c₂` is defined by `Cardinal.mul_def : #α * #β = #(α × β)`.
 * The order `c₁ ≤ c₂` is defined by `Cardinal.le_def α β : #α ≤ #β ↔ Nonempty (α ↪ β)`.
 * Exponentiation `c₁ ^ c₂` is defined by `Cardinal.power_def α β : #α ^ #β = #(β → α)`.
-* `cardinal.is_limit c` means that `c` is a (weak) limit cardinal: `c ≠ 0 ∧ ∀ x < c, succ x < c`.
+* `cardinal.isLimit c` means that `c` is a (weak) limit cardinal: `c ≠ 0 ∧ ∀ x < c, succ x < c`.
 * `Cardinal.aleph0` or `ℵ₀` is the cardinality of `ℕ`. This definition is universe polymorphic:
   `Cardinal.aleph0.{u} : Cardinal.{u}` (contrast with `ℕ : Type`, which lives in a specific
   universe). In some cases the universe level has to be given explicitly.

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -697,6 +697,9 @@ instance : LinearOrderedCommMonoidWithZero Cardinal.{u} :=
     mul_le_mul_left := @mul_le_mul_left' _ _ _ _
     zero_le_one := zero_le _ }
 
+-- We repeat this instance to steer Lean away from unnecessarily using noncomputable instances.
+instance commMonoid : CommMonoid Cardinal.{u} := CommSemiring.toCommMonoid
+
 theorem zero_power_le (c : Cardinal.{u}) : ((0 : Cardinal.{u})^c) ≤ 1 := by
   by_cases h : c = 0
   · rw [h, power_zero]

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -703,9 +703,6 @@ instance : LinearOrderedCommMonoidWithZero Cardinal.{u} :=
     mul_le_mul_left := @mul_le_mul_left' _ _ _ _
     zero_le_one := zero_le _ }
 
--- We repeat this instance to steer Lean away from unnecessarily using noncomputable instances.
-instance commMonoid : CommMonoid Cardinal.{u} := CommSemiring.toCommMonoid
-
 theorem zero_power_le (c : Cardinal.{u}) : ((0 : Cardinal.{u})^c) ≤ 1 := by
   by_cases h : c = 0
   · rw [h, power_zero]

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro, Floris van Doorn
 
 ! This file was ported from Lean 3 source module set_theory.cardinal.basic
-! leanprover-community/mathlib commit 7c2ce0c2da15516b4e65d0c9e254bb6dc93abd1f
+! leanprover-community/mathlib commit 9dba31df156d9d65b9d78db449542ca73d147c68
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -1270,6 +1270,16 @@ theorem lift_le_aleph0 {c : Cardinal.{u}} : lift.{v} c ≤ ℵ₀ ↔ c ≤ ℵ�
   rw [← lift_aleph0.{u,v}, lift_le]
 #align cardinal.lift_le_aleph_0 Cardinal.lift_le_aleph0
 
+@[simp]
+theorem aleph0_lt_lift {c : Cardinal.{u}} : ℵ₀ < lift.{v} c ↔ ℵ₀ < c := by
+  rw [← lift_aleph0.{u,v}, lift_lt]
+#align cardinal.aleph_0_lt_lift Cardinal.aleph0_lt_lift
+
+@[simp]
+theorem lift_lt_aleph0 {c : Cardinal.{u}} : lift.{v} c < ℵ₀ ↔ c < ℵ₀ := by
+  rw [← lift_aleph0.{u,v}, lift_lt]
+#align cardinal.lift_lt_aleph_0 Cardinal.lift_lt_aleph0
+
 /-! ### Properties about the cast from `ℕ` -/
 
 -- Porting note : simp can prove this
@@ -1291,6 +1301,26 @@ theorem nat_eq_lift_iff {n : ℕ} {a : Cardinal.{u}} :
     (n : Cardinal) = lift.{v} a ↔ (n : Cardinal) = a := by
   rw [← lift_natCast.{v,u} n, lift_inj]
 #align cardinal.nat_eq_lift_iff Cardinal.nat_eq_lift_iff
+
+@[simp]
+theorem lift_le_nat_iff {a : Cardinal.{u}} {n : ℕ} : lift.{v} a ≤ n ↔ a ≤ n := by
+  rw [← lift_natCast.{v,u}, lift_le]
+#align cardinal.lift_le_nat_iff Cardinal.lift_le_nat_iff
+
+@[simp]
+theorem nat_le_lift_iff {n : ℕ} {a : Cardinal.{u}} : n ≤ lift.{v} a ↔ n ≤ a := by
+  rw [← lift_natCast.{v,u}, lift_le]
+#align cardinal.nat_le_lift_iff Cardinal.nat_le_lift_iff
+
+@[simp]
+theorem lift_lt_nat_iff {a : Cardinal.{u}} {n : ℕ} : lift.{v} a < n ↔ a < n := by
+  rw [← lift_natCast.{v,u}, lift_lt]
+#align cardinal.lift_lt_nat_iff Cardinal.lift_lt_nat_iff
+
+@[simp]
+theorem nat_lt_lift_iff {n : ℕ} {a : Cardinal.{u}} : n < lift.{v} a ↔ n < a := by
+  rw [← lift_natCast.{v,u}, lift_lt]
+#align cardinal.nat_lt_lift_iff Cardinal.nat_lt_lift_iff
 
 theorem lift_mk_fin (n : ℕ) : lift (#Fin n) = n := by simp
 #align cardinal.lift_mk_fin Cardinal.lift_mk_fin
@@ -1766,9 +1796,9 @@ theorem toNat_lift (c : Cardinal.{v}) : toNat (lift.{u, v} c) = toNat c :=
   apply natCast_injective
   cases' lt_or_ge c ℵ₀ with hc hc
   · rw [cast_toNat_of_lt_aleph0, ← lift_natCast.{u,v}, cast_toNat_of_lt_aleph0 hc]
-    rwa [← lift_aleph0.{v,u}, lift_lt]
+    rwa [lift_lt_aleph0]
   · rw [cast_toNat_of_aleph0_le, ← lift_natCast.{u,v}, cast_toNat_of_aleph0_le hc, lift_zero]
-    rwa [← lift_aleph0.{v,u}, lift_le]
+    rwa [aleph0_le_lift]
 #align cardinal.to_nat_lift Cardinal.toNat_lift
 
 theorem toNat_congr {β : Type v} (e : α ≃ β) : toNat (#α) = toNat (#β) := by
@@ -1813,12 +1843,8 @@ theorem toNat_add_of_lt_aleph0 {a : Cardinal.{u}} {b : Cardinal.{v}} (ha : a < �
     toNat (lift.{v, u} a + lift.{u, v} b) = toNat a + toNat b :=
   by
   apply Cardinal.natCast_injective
-  replace ha : lift.{v, u} a < ℵ₀ := by
-    rw [← lift_aleph0.{u,v}]
-    exact lift_lt.2 ha
-  replace hb : lift.{u, v} b < ℵ₀ := by
-    rw [← lift_aleph0.{v,u}]
-    exact lift_lt.2 hb
+  replace ha : lift.{v, u} a < ℵ₀ := by rwa [lift_lt_aleph0]
+  replace hb : lift.{u, v} b < ℵ₀ := by rwa [lift_lt_aleph0]
   rw [Nat.cast_add, ← toNat_lift.{v, u} a, ← toNat_lift.{u, v} b, cast_toNat_of_lt_aleph0 ha,
     cast_toNat_of_lt_aleph0 hb, cast_toNat_of_lt_aleph0 (add_lt_aleph0 ha hb)]
 #align cardinal.to_nat_add_of_lt_aleph_0 Cardinal.toNat_add_of_lt_aleph0

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -248,7 +248,7 @@ instance : LE Cardinal.{u} :=
     Quotient.liftOn₂ q₁ q₂ (fun α β => Nonempty <| α ↪ β) fun _ _ _ _ ⟨e₁⟩ ⟨e₂⟩ =>
       propext ⟨fun ⟨e⟩ => ⟨e.congr e₁ e₂⟩, fun ⟨e⟩ => ⟨e.congr e₁.symm e₂.symm⟩⟩⟩
 
-instance linearOrder : LinearOrder Cardinal.{u} where
+instance partialOrder : PartialOrder Cardinal.{u} where
   le := (· ≤ ·)
   le_refl := by
     rintro ⟨α⟩
@@ -259,10 +259,13 @@ instance linearOrder : LinearOrder Cardinal.{u} where
   le_antisymm := by
     rintro ⟨α⟩ ⟨β⟩ ⟨e₁⟩ ⟨e₂⟩
     exact Quotient.sound (e₁.antisymm e₂)
-  le_total := by
-    rintro ⟨α⟩ ⟨β⟩
-    apply Embedding.total
-  decidable_le := Classical.decRel _
+
+instance linearOrder : LinearOrder Cardinal.{u} :=
+  { Cardinal.partialOrder with
+    le_total := by
+      rintro ⟨α⟩ ⟨β⟩
+      apply Embedding.total
+    decidable_le := Classical.decRel _ }
 
 theorem le_def (α β : Type u) : (#α) ≤ (#β) ↔ Nonempty (α ↪ β) :=
   Iff.rfl
@@ -539,6 +542,9 @@ instance commSemiring : CommSemiring Cardinal.{u} where
   npow_zero := @power_zero
   npow_succ n c := show (c ^ (n + 1)) = c * (c ^ n) by rw [power_add, power_one, mul_comm']
 
+-- Porting note: this ensures a computable instance.
+instance commMonoid : CommMonoid Cardinal.{u} := CommSemiring.toCommMonoid
+
 /-! Porting note: Deprecated section. Remove. -/
 section deprecated
 set_option linter.deprecated false
@@ -671,7 +677,7 @@ instance add_swap_covariantClass : CovariantClass Cardinal Cardinal (swap (· + 
 
 instance canonicallyOrderedCommSemiring : CanonicallyOrderedCommSemiring Cardinal.{u} :=
   { Cardinal.commSemiring,
-    Cardinal.linearOrder with
+    Cardinal.partialOrder with
     bot := 0
     bot_le := Cardinal.zero_le
     add_le_add_left := fun a b => add_le_add_left

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -32,7 +32,7 @@ We define cardinal numbers as a quotient of types under the equivalence relation
 * Multiplication `c₁ * c₂` is defined by `Cardinal.mul_def : #α * #β = #(α × β)`.
 * The order `c₁ ≤ c₂` is defined by `Cardinal.le_def α β : #α ≤ #β ↔ Nonempty (α ↪ β)`.
 * Exponentiation `c₁ ^ c₂` is defined by `Cardinal.power_def α β : #α ^ #β = #(β → α)`.
-* `cardinal.isLimit c` means that `c` is a (weak) limit cardinal: `c ≠ 0 ∧ ∀ x < c, succ x < c`.
+* `Cardinal.isLimit c` means that `c` is a (weak) limit cardinal: `c ≠ 0 ∧ ∀ x < c, succ x < c`.
 * `Cardinal.aleph0` or `ℵ₀` is the cardinality of `ℕ`. This definition is universe polymorphic:
   `Cardinal.aleph0.{u} : Cardinal.{u}` (contrast with `ℕ : Type`, which lives in a specific
   universe). In some cases the universe level has to be given explicitly.

--- a/Mathlib/SetTheory/Cardinal/Cofinality.lean
+++ b/Mathlib/SetTheory/Cardinal/Cofinality.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Floris van Doorn, Violeta Hernández Palacios
 
 ! This file was ported from Lean 3 source module set_theory.cardinal.cofinality
-! leanprover-community/mathlib commit bb168510ef455e9280a152e7f31673cabd3d7496
+! leanprover-community/mathlib commit 7c2ce0c2da15516b4e65d0c9e254bb6dc93abd1f
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -21,7 +21,6 @@ This file contains the definition of cofinality of an ordinal number and regular
 * `Ordinal.cof o` is the cofinality of the ordinal `o`.
   If `o` is the order type of the relation `<` on `α`, then `o.cof` is the smallest cardinality of a
   subset `s` of α that is *cofinal* in `α`, i.e. `∀ x : α, ∃ y ∈ s, ¬ y < x`.
-* `Cardinal.IsLimit c` means that `c` is a (weak) limit cardinal: `c ≠ 0 ∧ ∀ x < c, succ x < c`.
 * `Cardinal.IsStrongLimit c` means that `c` is a strong limit cardinal:
   `c ≠ 0 ∧ ∀ x < c, 2 ^ x < c`.
 * `Cardinal.IsRegular c` means that `c` is a regular cardinal: `ℵ₀ ≤ c ∧ c.ord.cof = c`.
@@ -860,27 +859,6 @@ open Ordinal
 -- mathport name: cardinal.pow
 --local infixr:0 "^" => @HPow.hPow Cardinal Cardinal Cardinal instHPow
 
-/-- A cardinal is a limit if it is not zero or a successor
-  cardinal. Note that `ℵ₀` is a limit cardinal by this definition. -/
-def IsLimit (c : Cardinal) : Prop :=
-  c ≠ 0 ∧ ∀ x < c, succ x < c
-#align cardinal.is_limit Cardinal.IsLimit
-
-theorem IsLimit.ne_zero {c} (h : IsLimit c) : c ≠ 0 :=
-  h.1
-#align cardinal.is_limit.ne_zero Cardinal.IsLimit.ne_zero
-
-theorem IsLimit.succ_lt {x c} (h : IsLimit c) : x < c → succ x < c :=
-  h.2 x
-#align cardinal.is_limit.succ_lt Cardinal.IsLimit.succ_lt
-
-theorem IsLimit.aleph0_le {c} (h : IsLimit c) : ℵ₀ ≤ c := by
-  by_contra' h'
-  rcases lt_aleph0.1 h' with ⟨_ | n, rfl⟩
-  · exact h.1.irrefl
-  · simpa using h.2 n
-#align cardinal.is_limit.aleph_0_le Cardinal.IsLimit.aleph0_le
-
 /-- A cardinal is a strong limit if it is not zero and it is
   closed under powersets. Note that `ℵ₀` is a strong limit by this definition. -/
 def IsStrongLimit (c : Cardinal) : Prop :=
@@ -901,24 +879,24 @@ theorem isStrongLimit_aleph0 : IsStrongLimit ℵ₀ :=
     exact_mod_cast nat_lt_aleph0 (2 ^ n)⟩
 #align cardinal.is_strong_limit_aleph_0 Cardinal.isStrongLimit_aleph0
 
+protected theorem IsStrongLimit.isSuccLimit {c} (H : IsStrongLimit c) : IsSuccLimit c :=
+  isSuccLimit_of_succ_lt fun x h => (succ_le_of_lt <| cantor x).trans_lt (H.two_power_lt h)
+#align cardinal.is_strong_limit.is_succ_limit Cardinal.IsStrongLimit.isSuccLimit
+
 theorem IsStrongLimit.isLimit {c} (H : IsStrongLimit c) : IsLimit c :=
-  ⟨H.1, fun x h => (succ_le_of_lt <| cantor x).trans_lt (H.2 _ h)⟩
+  ⟨H.NeZero, H.IsSuccLimit⟩
 #align cardinal.is_strong_limit.is_limit Cardinal.IsStrongLimit.isLimit
 
-theorem isLimit_aleph0 : IsLimit ℵ₀ :=
-  isStrongLimit_aleph0.isLimit
-#align cardinal.is_limit_aleph_0 Cardinal.isLimit_aleph0
-
-theorem isStrongLimit_beth {o : Ordinal} (H : ∀ a < o, succ a < o) : IsStrongLimit (beth o) := by
+theorem isStrongLimit_beth {o : Ordinal} (H : IsSuccLimit o) : IsStrongLimit (beth o) :=
   rcases eq_or_ne o 0 with (rfl | h)
   · rw [beth_zero]
     exact isStrongLimit_aleph0
   · refine' ⟨beth_ne_zero o, fun a ha => _⟩
-    rw [beth_limit ⟨h, H⟩] at ha
+    rw [beth_limit ⟨h, is_succ_limit_iff_succ_lt.1 H⟩] at ha
     rcases exists_lt_of_lt_csupᵢ' ha with ⟨⟨i, hi⟩, ha⟩
     have := power_le_power_left two_ne_zero ha.le
     rw [← beth_succ] at this
-    exact this.trans_lt (beth_lt.2 (H i hi))
+    exact this.trans_lt (beth_lt.2 (H.succ_lt hi))
 #align cardinal.is_strong_limit_beth Cardinal.isStrongLimit_beth
 
 theorem mk_bounded_subset {α : Type _} (h : ∀ x < #α, (2^x) < (#α)) {r : α → α → Prop}

--- a/Mathlib/SetTheory/Cardinal/Cofinality.lean
+++ b/Mathlib/SetTheory/Cardinal/Cofinality.lean
@@ -884,15 +884,15 @@ protected theorem IsStrongLimit.isSuccLimit {c} (H : IsStrongLimit c) : IsSuccLi
 #align cardinal.is_strong_limit.is_succ_limit Cardinal.IsStrongLimit.isSuccLimit
 
 theorem IsStrongLimit.isLimit {c} (H : IsStrongLimit c) : IsLimit c :=
-  ⟨H.NeZero, H.IsSuccLimit⟩
+  ⟨H.ne_zero, H.isSuccLimit⟩
 #align cardinal.is_strong_limit.is_limit Cardinal.IsStrongLimit.isLimit
 
-theorem isStrongLimit_beth {o : Ordinal} (H : IsSuccLimit o) : IsStrongLimit (beth o) :=
+theorem isStrongLimit_beth {o : Ordinal} (H : IsSuccLimit o) : IsStrongLimit (beth o) := by
   rcases eq_or_ne o 0 with (rfl | h)
   · rw [beth_zero]
     exact isStrongLimit_aleph0
   · refine' ⟨beth_ne_zero o, fun a ha => _⟩
-    rw [beth_limit ⟨h, is_succ_limit_iff_succ_lt.1 H⟩] at ha
+    rw [beth_limit ⟨h, isSuccLimit_iff_succ_lt.1 H⟩] at ha
     rcases exists_lt_of_lt_csupᵢ' ha with ⟨⟨i, hi⟩, ha⟩
     have := power_le_power_left two_ne_zero ha.le
     rw [← beth_succ] at this

--- a/Mathlib/SetTheory/Cardinal/Continuum.lean
+++ b/Mathlib/SetTheory/Cardinal/Continuum.lean
@@ -48,22 +48,26 @@ theorem lift_continuum : lift.{v} 𝔠 = 𝔠 := by
 
 @[simp]
 theorem continuum_le_lift {c : Cardinal.{u}} : 𝔠 ≤ lift.{v} c ↔ 𝔠 ≤ c := by
-  rw [← lift_continuum, lift_le]
+  -- porting note: added explicit universes
+  rw [← lift_continuum.{u,v}, lift_le]
 #align cardinal.continuum_le_lift Cardinal.continuum_le_lift
 
 @[simp]
 theorem lift_le_continuum {c : Cardinal.{u}} : lift.{v} c ≤ 𝔠 ↔ c ≤ 𝔠 := by
-  rw [← lift_continuum, lift_le]
+  -- porting note: added explicit universes
+  rw [← lift_continuum.{u,v}, lift_le]
 #align cardinal.lift_le_continuum Cardinal.lift_le_continuum
 
 @[simp]
 theorem continuum_lt_lift {c : Cardinal.{u}} : 𝔠 < lift.{v} c ↔ 𝔠 < c := by
-  rw [← lift_continuum, lift_lt]
+  -- porting note: added explicit universes
+  rw [← lift_continuum.{u,v}, lift_lt]
 #align cardinal.continuum_lt_lift Cardinal.continuum_lt_lift
 
 @[simp]
 theorem lift_lt_continuum {c : Cardinal.{u}} : lift.{v} c < 𝔠 ↔ c < 𝔠 := by
-  rw [← lift_continuum, lift_lt]
+  -- porting note: added explicit universes
+  rw [← lift_continuum.{u,v}, lift_lt]
 #align cardinal.lift_lt_continuum Cardinal.lift_lt_continuum
 
 /-!

--- a/Mathlib/SetTheory/Cardinal/Continuum.lean
+++ b/Mathlib/SetTheory/Cardinal/Continuum.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 
 ! This file was ported from Lean 3 source module set_theory.cardinal.continuum
-! leanprover-community/mathlib commit 3d7987cda72abc473c7cdbbb075170e9ac620042
+! leanprover-community/mathlib commit e08a42b2dd544cf11eba72e5fc7bf199d4349925
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -45,6 +45,26 @@ theorem two_power_aleph0 : 2 ^ aleph0.{u} = continuum.{u} :=
 theorem lift_continuum : lift.{v} 𝔠 = 𝔠 := by
   rw [← two_power_aleph0, lift_two_power, lift_aleph0, two_power_aleph0]
 #align cardinal.lift_continuum Cardinal.lift_continuum
+
+@[simp]
+theorem continuum_le_lift {c : Cardinal.{u}} : 𝔠 ≤ lift.{v} c ↔ 𝔠 ≤ c := by
+  rw [← lift_continuum, lift_le]
+#align cardinal.continuum_le_lift Cardinal.continuum_le_lift
+
+@[simp]
+theorem lift_le_continuum {c : Cardinal.{u}} : lift.{v} c ≤ 𝔠 ↔ c ≤ 𝔠 := by
+  rw [← lift_continuum, lift_le]
+#align cardinal.lift_le_continuum Cardinal.lift_le_continuum
+
+@[simp]
+theorem continuum_lt_lift {c : Cardinal.{u}} : 𝔠 < lift.{v} c ↔ 𝔠 < c := by
+  rw [← lift_continuum, lift_lt]
+#align cardinal.continuum_lt_lift Cardinal.continuum_lt_lift
+
+@[simp]
+theorem lift_lt_continuum {c : Cardinal.{u}} : lift.{v} c < 𝔠 ↔ c < 𝔠 := by
+  rw [← lift_continuum, lift_lt]
+#align cardinal.lift_lt_continuum Cardinal.lift_lt_continuum
 
 /-!
 ### Inequalities

--- a/Mathlib/SetTheory/Cardinal/Continuum.lean
+++ b/Mathlib/SetTheory/Cardinal/Continuum.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 
 ! This file was ported from Lean 3 source module set_theory.cardinal.continuum
-! leanprover-community/mathlib commit 3d7987cda72abc473c7cdbbb075170e9ac620042
+! leanprover-community/mathlib commit e08a42b2dd544cf11eba72e5fc7bf199d4349925
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -45,6 +45,26 @@ theorem two_power_aleph0 : 2 ^ aleph0.{u} = continuum.{u} :=
 theorem lift_continuum : lift.{v} 𝔠 = 𝔠 := by
   rw [← two_power_aleph0, lift_two_power, lift_aleph0, two_power_aleph0]
 #align cardinal.lift_continuum Cardinal.lift_continuum
+
+@[simp]
+theorem continuum_le_lift {c : Cardinal.{u}} : 𝔠 ≤ lift.{v} c ↔ 𝔠 ≤ c := by
+  rw [← lift_continuum.{u,v}, lift_le]
+#align cardinal.continuum_le_lift Cardinal.continuum_le_lift
+
+@[simp]
+theorem lift_le_continuum {c : Cardinal.{u}} : lift.{v} c ≤ 𝔠 ↔ c ≤ 𝔠 := by
+  rw [← lift_continuum.{u,v}, lift_le]
+#align cardinal.lift_le_continuum Cardinal.lift_le_continuum
+
+@[simp]
+theorem continuum_lt_lift {c : Cardinal.{u}} : 𝔠 < lift.{v} c ↔ 𝔠 < c := by
+  rw [← lift_continuum.{u,v}, lift_lt]
+#align cardinal.continuum_lt_lift Cardinal.continuum_lt_lift
+
+@[simp]
+theorem lift_lt_continuum {c : Cardinal.{u}} : lift.{v} c < 𝔠 ↔ c < 𝔠 := by
+  rw [← lift_continuum.{u,v}, lift_lt]
+#align cardinal.lift_lt_continuum Cardinal.lift_lt_continuum
 
 /-!
 ### Inequalities

--- a/Mathlib/SetTheory/Cardinal/Divisibility.lean
+++ b/Mathlib/SetTheory/Cardinal/Divisibility.lean
@@ -61,7 +61,7 @@ theorem isUnit_iff : IsUnit a ↔ a = 1 := by
     exact zero_ne_one ht
 #align cardinal.is_unit_iff Cardinal.isUnit_iff
 
-noncomputable instance : Unique Cardinal.{u}ˣ where
+instance : Unique Cardinal.{u}ˣ where
   default := 1
   uniq a := Units.val_eq_one.mp <| isUnit_iff.mp a.isUnit
 

--- a/Mathlib/SetTheory/Cardinal/Divisibility.lean
+++ b/Mathlib/SetTheory/Cardinal/Divisibility.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Eric Rodriguez
 
 ! This file was ported from Lean 3 source module set_theory.cardinal.divisibility
-! leanprover-community/mathlib commit 92ca63f0fb391a9ca5f22d2409a6080e786d99f7
+! leanprover-community/mathlib commit ea050b44c0f9aba9d16a948c7cc7d2e7c8493567
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -61,7 +61,7 @@ theorem isUnit_iff : IsUnit a ↔ a = 1 := by
     exact zero_ne_one ht
 #align cardinal.is_unit_iff Cardinal.isUnit_iff
 
-instance : Unique Cardinal.{u}ˣ where
+noncomputable instance : Unique Cardinal.{u}ˣ where
   default := 1
   uniq a := Units.val_eq_one.mp <| isUnit_iff.mp a.isUnit
 

--- a/Mathlib/SetTheory/Cardinal/Ordinal.lean
+++ b/Mathlib/SetTheory/Cardinal/Ordinal.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro, Floris van Doorn
 
 ! This file was ported from Lean 3 source module set_theory.cardinal.ordinal
-! leanprover-community/mathlib commit 8da9e30545433fdd8fe55a0d3da208e5d9263f03
+! leanprover-community/mathlib commit 7c2ce0c2da15516b4e65d0c9e254bb6dc93abd1f
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -223,7 +223,7 @@ theorem aleph'_le_of_limit {o : Ordinal} (l : o.IsLimit) {c} :
     exact h _ h'⟩
 #align cardinal.aleph'_le_of_limit Cardinal.aleph'_le_of_limit
 
-theorem aleph'_limit {o : Ordinal} (ho : IsLimit o) : aleph' o = ⨆ a : Iio o, aleph' a := by
+theorem aleph'_limit {o : Ordinal} (ho : o.IsLimit) : aleph' o = ⨆ a : Iio o, aleph' a := by
   refine' le_antisymm _ (csupᵢ_le' fun i => aleph'_le.2 (le_of_lt i.2))
   rw [aleph'_le_of_limit ho]
   exact fun a ha => le_csupᵢ (bddAbove_of_small _) (⟨a, ha⟩ : Iio o)
@@ -276,7 +276,7 @@ theorem aleph_succ {o : Ordinal} : aleph (succ o) = succ (aleph o) := by
 theorem aleph_zero : aleph 0 = ℵ₀ := by rw [aleph, add_zero, aleph'_omega]
 #align cardinal.aleph_zero Cardinal.aleph_zero
 
-theorem aleph_limit {o : Ordinal} (ho : IsLimit o) : aleph o = ⨆ a : Iio o, aleph a := by
+theorem aleph_limit {o : Ordinal} (ho : o.IsLimit) : aleph o = ⨆ a : Iio o, aleph a := by
   apply le_antisymm _ (csupᵢ_le' _)
   · rw [aleph, aleph'_limit (ho.add _)]
     refine' csupᵢ_mono' (bddAbove_of_small _) _
@@ -319,7 +319,7 @@ instance nonempty_out_aleph (o : Ordinal) : Nonempty (aleph o).ord.out.α := by
   exact fun h => (ord_injective h).not_gt (aleph_pos o)
 #align cardinal.nonempty_out_aleph Cardinal.nonempty_out_aleph
 
-theorem ord_aleph_isLimit (o : Ordinal) : IsLimit (aleph o).ord :=
+theorem ord_aleph_isLimit (o : Ordinal) : (aleph o).ord.IsLimit :=
   ord_isLimit <| aleph0_le_aleph _
 #align cardinal.ord_aleph_is_limit Cardinal.ord_aleph_isLimit
 
@@ -426,7 +426,7 @@ theorem beth_succ (o : Ordinal) : beth (succ o) = 2 ^ beth o :=
   limitRecOn_succ _ _ _ _
 #align cardinal.beth_succ Cardinal.beth_succ
 
-theorem beth_limit {o : Ordinal} : IsLimit o → beth o = ⨆ a : Iio o, beth a :=
+theorem beth_limit {o : Ordinal} : o.IsLimit → beth o = ⨆ a : Iio o, beth a :=
   limitRecOn_limit _ _ _ _
 #align cardinal.beth_limit Cardinal.beth_limit
 

--- a/Mathlib/SetTheory/Ordinal/Arithmetic.lean
+++ b/Mathlib/SetTheory/Ordinal/Arithmetic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Floris van Doorn, Violeta Hernández Palacios
 
 ! This file was ported from Lean 3 source module set_theory.ordinal.arithmetic
-! leanprover-community/mathlib commit b67044ba53af18680e1dd246861d9584e968495d
+! leanprover-community/mathlib commit e08a42b2dd544cf11eba72e5fc7bf199d4349925
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -2386,7 +2386,7 @@ theorem ord_aleph0 : ord.{u} ℵ₀ = ω :=
     le_of_forall_lt fun o h =>
       by
       rcases Ordinal.lt_lift_iff.1 h with ⟨o, rfl, h'⟩
-      rw [lt_ord, ← lift_card, ← lift_aleph0.{0, u}, lift_lt, ← typein_enum (· < ·) h']
+      rw [lt_ord, ← lift_card, lift_lt_aleph0, ← typein_enum (· < ·) h']
       exact lt_aleph0_iff_fintype.2 ⟨Set.fintypeLTNat _⟩
 #align cardinal.ord_aleph_0 Cardinal.ord_aleph0
 


### PR DESCRIPTION
My bad for letting these pile up.

* [`set_theory.cardinal.basic`@`4c19a16e4b705bf135cf9a80ac18fcc99c438514`..`e05ead7993520a432bec94ac504842d90707ad63`](https://leanprover-community.github.io/mathlib-port-status/file/set_theory/cardinal/basic?range=4c19a16e4b705bf135cf9a80ac18fcc99c438514..e05ead7993520a432bec94ac504842d90707ad63)
* [`set_theory.cardinal.continuum`@`3d7987cda72abc473c7cdbbb075170e9ac620042`..`e08a42b2dd544cf11eba72e5fc7bf199d4349925`](https://leanprover-community.github.io/mathlib-port-status/file/set_theory/cardinal/continuum?range=3d7987cda72abc473c7cdbbb075170e9ac620042..e08a42b2dd544cf11eba72e5fc7bf199d4349925)
* [`set_theory.cardinal.cofinality`@`bb168510ef455e9280a152e7f31673cabd3d7496`..`7c2ce0c2da15516b4e65d0c9e254bb6dc93abd1f`](https://leanprover-community.github.io/mathlib-port-status/file/set_theory/cardinal/cofinality?range=bb168510ef455e9280a152e7f31673cabd3d7496..7c2ce0c2da15516b4e65d0c9e254bb6dc93abd1f)
* [`set_theory.cardinal.ordinal`@`8da9e30545433fdd8fe55a0d3da208e5d9263f03`..`7c2ce0c2da15516b4e65d0c9e254bb6dc93abd1f`](https://leanprover-community.github.io/mathlib-port-status/file/set_theory/cardinal/ordinal?range=8da9e30545433fdd8fe55a0d3da208e5d9263f03..7c2ce0c2da15516b4e65d0c9e254bb6dc93abd1f)
* [`set_theory.ordinal.arithmetic`@`b67044ba53af18680e1dd246861d9584e968495d`..`e08a42b2dd544cf11eba72e5fc7bf199d4349925`](https://leanprover-community.github.io/mathlib-port-status/file/set_theory/ordinal/arithmetic?range=b67044ba53af18680e1dd246861d9584e968495d..e08a42b2dd544cf11eba72e5fc7bf199d4349925)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
- [x] depends on: https://github.com/leanprover-community/mathlib/pull/18771
- [x] depends on: #3247

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
