### PR TITLE
[Merged by Bors] - fix: remove unneeded LibrarySearch imports

### DIFF
--- a/Mathlib/CategoryTheory/ConnectedComponents.lean
+++ b/Mathlib/CategoryTheory/ConnectedComponents.lean
@@ -12,7 +12,6 @@ import Mathlib.Data.List.Chain
 import Mathlib.CategoryTheory.IsConnected
 import Mathlib.CategoryTheory.Sigma.Basic
 import Mathlib.CategoryTheory.FullSubcategory
-import Mathlib.Tactic.LibrarySearch
 
 /-!
 # Connected components of a category

--- a/Mathlib/Data/Nat/Choose/Multinomial.lean
+++ b/Mathlib/Data/Nat/Choose/Multinomial.lean
@@ -15,8 +15,6 @@ import Mathlib.Data.Fin.VecNotation
 import Mathlib.Data.Finset.Sym
 import Mathlib.Data.Finsupp.Multiset
 
-import Mathlib.Tactic.LibrarySearch
-
 /-!
 # Multinomial
 


### PR DESCRIPTION
Removes `LibrarySearch` imports that were accidentally included in #2843 and #2361.