### PR TITLE
[Merged by Bors] - feat: port LinearAlgebra.Dimension

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1228,6 +1228,7 @@ import Mathlib.LinearAlgebra.Basis
 import Mathlib.LinearAlgebra.Basis.Bilinear
 import Mathlib.LinearAlgebra.BilinearMap
 import Mathlib.LinearAlgebra.Dfinsupp
+import Mathlib.LinearAlgebra.Dimension
 import Mathlib.LinearAlgebra.DirectSum.Finsupp
 import Mathlib.LinearAlgebra.DirectSum.TensorProduct
 import Mathlib.LinearAlgebra.Finsupp

--- a/Mathlib/LinearAlgebra/Dimension.lean
+++ b/Mathlib/LinearAlgebra/Dimension.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Johannes Hölzl, Sander Dahmen, Scott Morrison
 
 ! This file was ported from Lean 3 source module linear_algebra.dimension
-! leanprover-community/mathlib commit 3a2039ad20626aebbece10cddb18ef010f7d912d
+! leanprover-community/mathlib commit 45ce3929e3bf9a086a216feea3b1ab6c14bf0e67
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/

--- a/Mathlib/LinearAlgebra/Dimension.lean
+++ b/Mathlib/LinearAlgebra/Dimension.lean
@@ -1123,6 +1123,7 @@ variable [AddCommGroup V₃] [Module K V₃]
 
 open LinearMap
 
+set_option synthInstance.etaExperiment true in -- Porting note: gets around lean4#2074
 /-- This is mostly an auxiliary lemma for `Submodule.rank_sup_add_rank_inf_eq`. -/
 theorem rank_add_rank_split (db : V₂ →ₗ[K] V) (eb : V₃ →ₗ[K] V) (cd : V₁ →ₗ[K] V₂)
     (ce : V₁ →ₗ[K] V₃) (hde : ⊤ ≤ LinearMap.range db ⊔ LinearMap.range eb) (hgd : ker cd = ⊥)

--- a/Mathlib/LinearAlgebra/Dimension.lean
+++ b/Mathlib/LinearAlgebra/Dimension.lean
@@ -640,8 +640,7 @@ theorem Basis.le_span {J : Set M} (v : Basis ι R M) (hJ : span R J = ⊤) : (#r
   · rw [← Cardinal.lift_le, Cardinal.mk_range_eq_of_injective v.injective, Cardinal.mk_fintype J]
     convert Cardinal.lift_le.{w, v}.2 (basis_le_span' v hJ)
     simp
-  · -- Porting note: `have` in this line is unnecessary.
-    let S : J → Set ι := fun j => ↑(v.repr j).support
+  · let S : J → Set ι := fun j => ↑(v.repr j).support
     let S' : J → Set M := fun j => v '' S j
     have hs : range v ⊆ ⋃ j, S' j := by
       intro b hb

--- a/Mathlib/LinearAlgebra/Dimension.lean
+++ b/Mathlib/LinearAlgebra/Dimension.lean
@@ -739,7 +739,7 @@ theorem linearIndependent_le_infinite_basis {ι : Type _} (b : Basis ι R M) [In
   by_contra h
   rw [not_le, ← Cardinal.mk_finset_of_infinite ι] at h
   let Φ := fun k : κ => (b.repr (v k)).support
-  obtain ⟨s, w : Infinite coe_sort (Φ ⁻¹' {s})⟩ := Cardinal.exists_infinite_fiber Φ h (by infer_instance)
+  obtain ⟨s, w : Infinite ↑(Φ ⁻¹' {s})⟩ := Cardinal.exists_infinite_fiber Φ h (by infer_instance)
   let v' := fun k : Φ ⁻¹' {s} => v k
   have i' : LinearIndependent R v' := i.comp _ Subtype.val_injective
   have w' : Fintype (Φ ⁻¹' {s}) := by
@@ -869,14 +869,14 @@ theorem Basis.finite_index_of_rank_lt_aleph0 {ι : Type _} {s : Set ι} (b : Bas
 #align basis.finite_index_of_rank_lt_aleph_0 Basis.finite_index_of_rank_lt_aleph0
 
 theorem rank_span {v : ι → M} (hv : LinearIndependent R v) :
-    Module.rank R coe_sort (span R (range v)) = (#range v) := by
+    Module.rank R ↑(span R (range v)) = (#range v) := by
   haveI := nontrivial_of_invariantBasisNumber R
   rw [← Cardinal.lift_inj, ← (Basis.span hv).mk_eq_rank,
     Cardinal.mk_range_eq_of_injective (@LinearIndependent.injective ι R M v _ _ _ _ hv)]
 #align rank_span rank_span
 
 theorem rank_span_set {s : Set M} (hs : LinearIndependent R (fun x => x : s → M)) :
-    Module.rank R coe_Sort (span R s) = (#s) := by
+    Module.rank R ↑(span R s) = (#s) := by
   rw [← @setOf_mem_eq _ s, ← Subtype.range_coe_subtype]
   exact rank_span hs
 #align rank_span_set rank_span_set

--- a/Mathlib/LinearAlgebra/Dimension.lean
+++ b/Mathlib/LinearAlgebra/Dimension.lean
@@ -21,7 +21,7 @@ import Mathlib.SetTheory.Cardinal.Cofinality
 
 ## Main definitions
 
-* The rank of a module is defined as `module.rank : cardinal`.
+* The rank of a module is defined as `Module.rank : Cardinal`.
   This is defined as the supremum of the cardinalities of linearly independent subsets.
 
 * The rank of a linear map is defined as the rank of its range.
@@ -32,25 +32,25 @@ import Mathlib.SetTheory.Cardinal.Cofinality
   at most that of the target.
 * `LinearMap.rank_le_of_surjective`: the target of a surjective linear map has dimension
   at most that of that source.
-* `basis_fintype_of_finite_spans`:
+* `basisFintypeOfFiniteSpans`:
   the existence of a finite spanning set implies that any basis is finite.
-* `infinite_basis_le_maximal_linear_independent`:
+* `infinite_basis_le_maximal_linearIndependent`:
   if `b` is an infinite basis for a module `M`,
   and `s` is a maximal linearly independent set,
   then the cardinality of `b` is bounded by the cardinality of `s`.
 
 For modules over rings satisfying the rank condition
 
-* `basis.le_span`:
+* `Basis.le_span`:
   the cardinality of a basis is bounded by the cardinality of any spanning set
 
 For modules over rings satisfying the strong rank condition
 
-* `linear_independent_le_span`:
+* `linearIndependent_le_span`:
   For any linearly independent family `v : ι → M`
   and any finite spanning set `w : set M`,
   the cardinality of `ι` is bounded by the cardinality of `w`.
-* `linear_independent_le_basis`:
+* `linearIndependent_le_basis`:
   If `b` is a basis for a module `M`,
   and `s` is a linearly independent set,
   then the cardinality of `s` is bounded by the cardinality of `b`.
@@ -96,7 +96,7 @@ variable [Semiring K] [AddCommMonoid V] [Module K V]
 
 variable (K V)
 
-/-- The rank of a module, defined as a term of type `cardinal`.
+/-- The rank of a module, defined as a term of type `Cardinal`.
 
 We define this as the supremum of the cardinalities of linearly independent subsets.
 
@@ -214,7 +214,7 @@ theorem rank_eq_of_injective (f : M →ₗ[R] M₁) (h : Injective f) :
 #align rank_eq_of_injective rank_eq_of_injective
 
 set_option synthInstance.etaExperiment true in -- Porting note: gets around lean4#2074
-/-- Pushforwards of submodules along a `linear_equiv` have the same dimension. -/
+/-- Pushforwards of submodules along a `LinearEquiv` have the same dimension. -/
 theorem LinearEquiv.rank_map_eq (f : M ≃ₗ[R] M₁) (p : Submodule R M) :
     Module.rank R (p.map (f : M →ₗ[R] M₁)) = Module.rank R p :=
   (f.submoduleMap p).rank_eq.symm
@@ -267,20 +267,20 @@ theorem cardinal_lift_le_rank_of_linearIndependent.{m} {ι : Type w} {v : ι →
     exact le_rfl
 #align cardinal_lift_le_rank_of_linear_independent cardinal_lift_le_rank_of_linearIndependent
 
-theorem cardinal_lift_le_rank_of_linear_independent' {ι : Type w} {v : ι → M}
+theorem cardinal_lift_le_rank_of_linearIndependent' {ι : Type w} {v : ι → M}
     (hv : LinearIndependent R v) : Cardinal.lift.{v} (#ι) ≤ Cardinal.lift.{w} (Module.rank R M) :=
   cardinal_lift_le_rank_of_linearIndependent.{u, v, w, 0} hv
-#align cardinal_lift_le_rank_of_linear_independent' cardinal_lift_le_rank_of_linear_independent'
+#align cardinal_lift_le_rank_of_linear_independent' cardinal_lift_le_rank_of_linearIndependent'
 
 theorem cardinal_le_rank_of_linearIndependent {ι : Type v} {v : ι → M}
     (hv : LinearIndependent R v) : (#ι) ≤ Module.rank R M := by
   simpa using cardinal_lift_le_rank_of_linearIndependent hv
 #align cardinal_le_rank_of_linear_independent cardinal_le_rank_of_linearIndependent
 
-theorem cardinal_le_rank_of_linear_independent' {s : Set M}
+theorem cardinal_le_rank_of_linearIndependent' {s : Set M}
     (hs : LinearIndependent R (fun x => x : s → M)) : (#s) ≤ Module.rank R M :=
   cardinal_le_rank_of_linearIndependent hs
-#align cardinal_le_rank_of_linear_independent' cardinal_le_rank_of_linear_independent'
+#align cardinal_le_rank_of_linear_independent' cardinal_le_rank_of_linearIndependent'
 
 variable (R M)
 
@@ -309,7 +309,7 @@ variable {R M}
 
 theorem exists_mem_ne_zero_of_rank_pos {s : Submodule R M} (h : 0 < Module.rank R s) :
     ∃ b : M, b ∈ s ∧ b ≠ 0 :=
-  exists_mem_ne_zero_of_ne_bot fun eq => by rw [Eq, rank_bot] at h <;> exact lt_irrefl _ h
+  exists_mem_ne_zero_of_ne_bot fun eq => by rw [eq, rank_bot] at h; exact lt_irrefl _ h
 #align exists_mem_ne_zero_of_rank_pos exists_mem_ne_zero_of_rank_pos
 
 /-- A linearly-independent family of vectors in a module over a non-trivial ring must be finite if
@@ -444,7 +444,7 @@ theorem union_support_maximal_linearIndependent_eq_range_basis {ι : Type w} (b 
 and `s` is a maximal linearly independent set,
 then the cardinality of `b` is bounded by the cardinality of `s`.
 -/
-theorem infinite_basis_le_maximal_linear_independent' {ι : Type w} (b : Basis ι R M) [Infinite ι]
+theorem infinite_basis_le_maximal_linearIndependent' {ι : Type w} (b : Basis ι R M) [Infinite ι]
     {κ : Type w'} (v : κ → M) (i : LinearIndependent R v) (m : i.Maximal) :
     Cardinal.lift.{w'} (#ι) ≤ Cardinal.lift.{w} (#κ) := by
   let Φ := fun k : κ => (b.repr (v k)).support
@@ -453,9 +453,9 @@ theorem infinite_basis_le_maximal_linear_independent' {ι : Type w} (b : Basis �
     exact union_support_maximal_linearIndependent_eq_range_basis b v i m
   have w₂ : Cardinal.lift.{w'} (#Set.range Φ) ≤ Cardinal.lift.{w} (#κ) := Cardinal.mk_range_le_lift
   exact (Cardinal.lift_le.mpr w₁).trans w₂
-#align infinite_basis_le_maximal_linear_independent' infinite_basis_le_maximal_linear_independent'
+#align infinite_basis_le_maximal_linear_independent' infinite_basis_le_maximal_linearIndependent'
 
--- (See `infinite_basis_le_maximal_linear_independent'` for the more general version
+-- (See `infinite_basis_le_maximal_linearIndependent'` for the more general version
 -- where the index types can live in different universes.)
 /-- Over any ring `R`, if `b` is an infinite basis for a module `M`,
 and `s` is a maximal linearly independent set,
@@ -463,7 +463,7 @@ then the cardinality of `b` is bounded by the cardinality of `s`.
 -/
 theorem infinite_basis_le_maximal_linearIndependent {ι : Type w} (b : Basis ι R M) [Infinite ι]
     {κ : Type w} (v : κ → M) (i : LinearIndependent R v) (m : i.Maximal) : (#ι) ≤ (#κ) :=
-  Cardinal.lift_le.mp (infinite_basis_le_maximal_linear_independent' b v i m)
+  Cardinal.lift_le.mp (infinite_basis_le_maximal_linearIndependent' b v i m)
 #align infinite_basis_le_maximal_linear_independent infinite_basis_le_maximal_linearIndependent
 
 theorem CompleteLattice.Independent.subtype_ne_bot_le_rank [NoZeroSMulDivisors R M]
@@ -476,7 +476,7 @@ theorem CompleteLattice.Independent.subtype_ne_bot_le_rank [NoZeroSMulDivisors R
     exact i.prop
   choose v hvV hv using hI
   have : LinearIndependent R v := (hV.comp Subtype.coe_injective).linearIndependent _ hvV hv
-  exact cardinal_lift_le_rank_of_linear_independent' this
+  exact cardinal_lift_le_rank_of_linearIndependent' this
 #align complete_lattice.independent.subtype_ne_bot_le_rank CompleteLattice.Independent.subtype_ne_bot_le_rank
 
 end
@@ -529,7 +529,7 @@ theorem rank_zero_iff_forall_zero : Module.rank R M = 0 ↔ ∀ x : M, x = 0 := 
     rw [← rank_top, this, rank_bot]
 #align rank_zero_iff_forall_zero rank_zero_iff_forall_zero
 
-/-- See `rank_subsingleton` for the reason that `nontrivial R` is needed. -/
+/-- See `rank_subsingleton` for the reason that `Nontrivial R` is needed. -/
 theorem rank_zero_iff : Module.rank R M = 0 ↔ Subsingleton M :=
   rank_zero_iff_forall_zero.trans (subsingleton_iff_forall_eq 0).symm
 #align rank_zero_iff rank_zero_iff
@@ -557,7 +557,7 @@ theorem mk_eq_mk_of_basis (v : Basis ι R M) (v' : Basis ι' R M) :
     Cardinal.lift.{w'} (#ι) = Cardinal.lift.{w} (#ι') := by
   haveI := nontrivial_of_invariantBasisNumber R
   cases fintypeOrInfinite ι
-  · -- `v` is a finite basis, so by `basis_fintype_of_finite_spans` so is `v'`.
+  · -- `v` is a finite basis, so by `basisFintypeOfFiniteSpans` so is `v'`.
     haveI : Fintype (range v) := Set.fintypeRange v
     haveI := basisFintypeOfFiniteSpans _ v.span_eq v'
     -- We clean up a little:
@@ -569,13 +569,13 @@ theorem mk_eq_mk_of_basis (v : Basis ι R M) (v' : Basis ι' R M) :
       (Finsupp.linearEquivFunOnFinite R R ι).symm.trans v.repr.symm ≪≫ₗ v'.repr ≪≫ₗ
         Finsupp.linearEquivFunOnFinite R R ι'
   · -- `v` is an infinite basis,
-    -- so by `infinite_basis_le_maximal_linear_independent`, `v'` is at least as big,
-    -- and then applying `infinite_basis_le_maximal_linear_independent` again
+    -- so by `infinite_basis_le_maximal_linearIndependent`, `v'` is at least as big,
+    -- and then applying `infinite_basis_le_maximal_linearIndependent` again
     -- we see they have the same cardinality.
-    have w₁ := infinite_basis_le_maximal_linear_independent' v _ v'.linearIndependent v'.maximal
+    have w₁ := infinite_basis_le_maximal_linearIndependent' v _ v'.linearIndependent v'.maximal
     rcases Cardinal.lift_mk_le'.mp w₁ with ⟨f⟩
     haveI : Infinite ι' := Infinite.of_injective f f.2
-    have w₂ := infinite_basis_le_maximal_linear_independent' v' _ v.linearIndependent v.maximal
+    have w₂ := infinite_basis_le_maximal_linearIndependent' v' _ v.linearIndependent v.maximal
     exact le_antisymm w₁ w₂
 #align mk_eq_mk_of_basis mk_eq_mk_of_basis
 
@@ -597,11 +597,11 @@ variable {R : Type u} [Ring R] [RankCondition R]
 
 variable {M : Type v} [AddCommGroup M] [Module R M]
 
-/-- An auxiliary lemma for `basis.le_span`.
+/-- An auxiliary lemma for `Basis.le_span`.
 
 If `R` satisfies the rank condition,
-then for any finite basis `b : basis ι R M`,
-and any finite spanning set `w : set M`,
+then for any finite basis `b : Basis ι R M`,
+and any finite spanning set `w : Set M`,
 the cardinality of `ι` is bounded by the cardinality of `w`.
 -/
 theorem Basis.le_span'' {ι : Type _} [Fintype ι] (b : Basis ι R M) {w : Set M} [Fintype w]
@@ -617,7 +617,7 @@ theorem Basis.le_span'' {ι : Type _} [Fintype ι] (b : Basis ι R M) {w : Set M
 #align basis.le_span'' Basis.le_span''
 
 /--
-Another auxiliary lemma for `basis.le_span`, which does not require assuming the basis is finite,
+Another auxiliary lemma for `Basis.le_span`, which does not require assuming the basis is finite,
 but still assumes we have a finite spanning set.
 -/
 theorem basis_le_span' {ι : Type _} (b : Basis ι R M) {w : Set M} [Fintype w] (s : span R w = ⊤) :
@@ -630,7 +630,7 @@ theorem basis_le_span' {ι : Type _} (b : Basis ι R M) {w : Set M} [Fintype w] 
 #align basis_le_span' basis_le_span'
 
 -- Note that if `R` satisfies the strong rank condition,
--- this also follows from `linear_independent_le_span` below.
+-- this also follows from `linearIndependent_le_span` below.
 /-- If `R` satisfies the rank condition,
 then the cardinality of any basis is bounded by the cardinality of any spanning set.
 -/
@@ -673,7 +673,7 @@ variable {M : Type v} [AddCommGroup M] [Module R M]
 
 open Submodule
 
--- An auxiliary lemma for `linear_independent_le_span'`,
+-- An auxiliary lemma for `linearIndependent_le_span'`,
 -- with the additional assumption that the linearly independent family is finite.
 theorem linearIndependent_le_span_aux' {ι : Type _} [Fintype ι] (v : ι → M)
     (i : LinearIndependent R v) (w : Set M) [Fintype w] (s : range v ≤ span R w) :
@@ -694,7 +694,7 @@ theorem linearIndependent_le_span_aux' {ι : Type _} [Fintype ι] (v : ι → M)
 
 /-- If `R` satisfies the strong rank condition,
 then any linearly independent family `v : ι → M`
-contained in the span of some finite `w : set M`,
+contained in the span of some finite `w : Set M`,
 is itself finite.
 -/
 def linearIndependentFintypeOfLeSpanFintype {ι : Type _} (v : ι → M) (i : LinearIndependent R v)
@@ -708,7 +708,7 @@ def linearIndependentFintypeOfLeSpanFintype {ι : Type _} (v : ι → M) (i : Li
 
 /-- If `R` satisfies the strong rank condition,
 then for any linearly independent family `v : ι → M`
-contained in the span of some finite `w : set M`,
+contained in the span of some finite `w : Set M`,
 the cardinality of `ι` is bounded by the cardinality of `w`.
 -/
 theorem linearIndependent_le_span' {ι : Type _} (v : ι → M) (i : LinearIndependent R v) (w : Set M)
@@ -721,7 +721,7 @@ theorem linearIndependent_le_span' {ι : Type _} (v : ι → M) (i : LinearIndep
 
 /-- If `R` satisfies the strong rank condition,
 then for any linearly independent family `v : ι → M`
-and any finite spanning set `w : set M`,
+and any finite spanning set `w : Set M`,
 the cardinality of `ι` is bounded by the cardinality of `w`.
 -/
 theorem linearIndependent_le_span {ι : Type _} (v : ι → M) (i : LinearIndependent R v) (w : Set M)
@@ -731,7 +731,7 @@ theorem linearIndependent_le_span {ι : Type _} (v : ι → M) (i : LinearIndepe
   exact le_top
 #align linear_independent_le_span linearIndependent_le_span
 
-/-- An auxiliary lemma for `linear_independent_le_basis`:
+/-- An auxiliary lemma for `linearIndependent_le_basis`:
 we handle the case where the basis `b` is infinite.
 -/
 theorem linearIndependent_le_infinite_basis {ι : Type _} (b : Basis ι R M) [Infinite ι] {κ : Type _}
@@ -759,11 +759,11 @@ theorem linearIndependent_le_basis {ι : Type _} (b : Basis ι R M) {κ : Type _
     (i : LinearIndependent R v) : (#κ) ≤ (#ι) := by
   -- We split into cases depending on whether `ι` is infinite.
   cases fintypeOrInfinite ι
-  · rw [Cardinal.mk_fintype ι] -- When `ι` is finite, we have `linear_independent_le_span`,
+  · rw [Cardinal.mk_fintype ι] -- When `ι` is finite, we have `linearIndependent_le_span`,
     haveI : Nontrivial R := nontrivial_of_invariantBasisNumber R
     rw [Fintype.card_congr (Equiv.ofInjective b b.injective)]
     exact linearIndependent_le_span v i (range b) b.span_eq
-  · -- and otherwise we have `linear_indepedent_le_infinite_basis`.
+  · -- and otherwise we have `linearIndepedent_le_infinite_basis`.
     exact linearIndependent_le_infinite_basis b v i
 #align linear_independent_le_basis linearIndependent_le_basis
 
@@ -798,7 +798,7 @@ theorem Basis.mk_eq_rank'' {ι : Type v} (v : Basis ι R M) : (#ι) = Module.ran
     apply le_csupᵢ (Cardinal.bddAbove_range.{v, v} _)
     exact
       ⟨Set.range v, by
-        convert v.reindex_range.linear_independent
+        convert v.reindex_range.linearIndependent
         ext
         simp⟩
     exact (Cardinal.mk_range_eq v v.injective).ge
@@ -824,7 +824,7 @@ theorem Basis.card_le_card_of_linearIndependent {ι : Type _} [Fintype ι] (b : 
     Fintype.card ι' ≤ Fintype.card ι := by
   letI := nontrivial_of_invariantBasisNumber R
   simpa [rank_eq_card_basis b, Cardinal.mk_fintype] using
-    cardinal_lift_le_rank_of_linear_independent' hv
+    cardinal_lift_le_rank_of_linearIndependent' hv
 #align basis.card_le_card_of_linear_independent Basis.card_le_card_of_linearIndependent
 
 theorem Basis.card_le_card_of_submodule (N : Submodule R M) [Fintype ι] (b : Basis ι R M)
@@ -939,7 +939,7 @@ namespace Module.Free
 
 variable (K V)
 
-/-- The rank of a free module `M` over `R` is the cardinality of `choose_basis_index R M`. -/
+/-- The rank of a free module `M` over `R` is the cardinality of `ChooseBasisIndex R M`. -/
 theorem rank_eq_card_chooseBasisIndex : Module.rank K V = (#ChooseBasisIndex K V) :=
   (chooseBasis K V).mk_eq_rank''.symm
 #align module.free.rank_eq_card_choose_basis_index Module.Free.rank_eq_card_chooseBasisIndex
@@ -1004,7 +1004,7 @@ theorem LinearEquiv.nonempty_equiv_iff_rank_eq :
   ⟨fun ⟨h⟩ => LinearEquiv.rank_eq h, fun h => nonempty_linearEquiv_of_rank_eq h⟩
 #align linear_equiv.nonempty_equiv_iff_rank_eq LinearEquiv.nonempty_equiv_iff_rank_eq
 
-/-- The rank of `M × N` is `(module.rank R M).lift + (module.rank R N).lift`. -/
+/-- The rank of `M × N` is `(Module.rank R M).lift + (Module.rank R N).lift`. -/
 @[simp]
 theorem rank_prod :
     Module.rank K (V × V') =
@@ -1014,7 +1014,7 @@ theorem rank_prod :
 #align rank_prod rank_prod
 
 /-- If `M` and `N` lie in the same universe, the rank of `M × N` is
-  `(module.rank R M) + (module.rank R N)`. -/
+  `(Module.rank R M) + (Module.rank R N)`. -/
 theorem rank_prod' : Module.rank K (V × V₁) = Module.rank K V + Module.rank K V₁ := by simp
 #align rank_prod' rank_prod'
 
@@ -1058,8 +1058,8 @@ theorem rank_fin_fun (n : ℕ) : Module.rank K (Fin n → K) = n := by simp [ran
 end Fintype
 
 set_option synthInstance.etaExperiment true in -- Porting note: gets around lean4#2074
--- TODO: merge with the `finrank` content
-/-- An `n`-dimensional `K`-vector space is equivalent to `fin n → K`. -/
+-- TODO: merge with the `Finrank` content
+/-- An `n`-dimensional `K`-vector space is equivalent to `Fin n → K`. -/
 def finDimVectorspaceEquiv (n : ℕ) (hn : Module.rank K V = n) : V ≃ₗ[K] Fin n → K := by
   haveI := nontrivial_of_invariantBasisNumber K
   have : Cardinal.lift.{u} (n : Cardinal.{v}) = Cardinal.lift.{v} (n : Cardinal.{u}) := by simp
@@ -1082,7 +1082,7 @@ variable [AddCommGroup V'] [Module K V']
 
 variable [AddCommGroup V₁] [Module K V₁]
 
-/-- If a vector space has a finite dimension, the index set of `basis.of_vector_space` is finite. -/
+/-- If a vector space has a finite dimension, the index set of `Basis.ofVectorSpace` is finite. -/
 theorem Basis.finite_ofVectorSpaceIndex_of_rank_lt_aleph0 (h : Module.rank K V < ℵ₀) :
     (Basis.ofVectorSpaceIndex K V).Finite :=
   finite_def.2 <| (Basis.ofVectorSpace K V).nonempty_fintype_index_of_rank_lt_aleph0 h
@@ -1090,7 +1090,7 @@ theorem Basis.finite_ofVectorSpaceIndex_of_rank_lt_aleph0 (h : Module.rank K V <
 
 -- TODO how far can we generalise this?
 -- When `s` is finite, we could prove this for any ring satisfying the strong rank condition
--- using `linear_independent_le_span'`
+-- using `linearIndependent_le_span'`
 theorem rank_span_le (s : Set V) : Module.rank K (span K s) ≤ (#s) := by
   obtain ⟨b, hb, hsab, hlib⟩ := exists_linearIndependent K s
   convert Cardinal.mk_le_mk_of_subset hb
@@ -1135,7 +1135,7 @@ variable [AddCommGroup V₃] [Module K V₃]
 open LinearMap
 
 set_option synthInstance.etaExperiment true in -- Porting note: gets around lean4#2074
-/-- This is mostly an auxiliary lemma for `submodule.rank_sup_add_rank_inf_eq`. -/
+/-- This is mostly an auxiliary lemma for `Submodule.rank_sup_add_rank_inf_eq`. -/
 theorem rank_add_rank_split (db : V₂ →ₗ[K] V) (eb : V₃ →ₗ[K] V) (cd : V₁ →ₗ[K] V₂)
     (ce : V₁ →ₗ[K] V₃) (hde : ⊤ ≤ LinearMap.range db ⊔ LinearMap.range eb) (hgd : ker cd = ⊥)
     (eq : db.comp cd = eb.comp ce) (eq₂ : ∀ d e, db d = eb e → ∃ c, cd c = d ∧ ce c = e) :
@@ -1199,7 +1199,7 @@ variable [AddCommGroup V'] [Module K V']
 
 /-- The `ι` indexed basis on `V`, where `ι` is an empty type and `V` is zero-dimensional.
 
-See also `finite_dimensional.fin_basis`.
+See also `FiniteDimensional.finBasis`.
 -/
 def Basis.ofRankEqZero {ι : Type _} [IsEmpty ι] (hV : Module.rank K V = 0) : Basis ι K V :=
   haveI : Subsingleton V := rank_zero_iff.1 hV

--- a/Mathlib/LinearAlgebra/Dimension.lean
+++ b/Mathlib/LinearAlgebra/Dimension.lean
@@ -128,12 +128,12 @@ variable {M₁ : Type v} [AddCommGroup M₁] [Module R M₁]
 set_option synthInstance.etaExperiment true in -- Porting note: gets around lean4#2074
 theorem LinearMap.lift_rank_le_of_injective (f : M →ₗ[R] M') (i : Injective f) :
     Cardinal.lift.{v'} (Module.rank R M) ≤ Cardinal.lift.{v} (Module.rank R M') := by
-  dsimp [Module.rank]
+  simp [Module.rank_def]
   rw [Cardinal.lift_supᵢ (Cardinal.bddAbove_range.{v', v'} _),
     Cardinal.lift_supᵢ (Cardinal.bddAbove_range.{v, v} _)]
   apply csupᵢ_mono' (Cardinal.bddAbove_range.{v', v} _)
   rintro ⟨s, li⟩
-  refine' ⟨⟨f '' s, _⟩, cardinal.lift_mk_le'.mpr ⟨(Equiv.Set.image f s i).toEmbedding⟩⟩
+  refine' ⟨⟨f '' s, _⟩, Cardinal.lift_mk_le'.mpr ⟨(Equiv.Set.image f s i).toEmbedding⟩⟩
   exact (li.map' _ <| LinearMap.ker_eq_bot.mpr i).image
 #align linear_map.lift_rank_le_of_injective LinearMap.lift_rank_le_of_injective
 
@@ -146,7 +146,7 @@ theorem LinearMap.rank_le_of_injective (f : M →ₗ[R] M₁) (i : Injective f) 
 theorem rank_le {n : ℕ}
     (H : ∀ s : Finset M, (LinearIndependent R fun i : s => (i : M)) → s.card ≤ n) :
     Module.rank R M ≤ n := by
-  rw [Module.rank]
+  rw [Module.rank_def]
   apply csupᵢ_le'
   rintro ⟨s, li⟩
   exact linearIndependent_bounded_of_finset_linearIndependent_bounded H _ li
@@ -155,17 +155,17 @@ theorem rank_le {n : ℕ}
 set_option synthInstance.etaExperiment true in -- Porting note: gets around lean4#2074
 theorem lift_rank_range_le (f : M →ₗ[R] M') : Cardinal.lift.{v}
     (Module.rank R (LinearMap.range f)) ≤ Cardinal.lift.{v'} (Module.rank R M) := by
-  dsimp [Module.rank]
+  simp [Module.rank_def]
   rw [Cardinal.lift_supᵢ (Cardinal.bddAbove_range.{v', v'} _)]
   apply csupᵢ_le'
   rintro ⟨s, li⟩
   apply le_trans
   swap
-  apply cardinal.lift_le.mpr
-  refine' le_csupᵢ (Cardinal.bddAbove_range.{v, v} _) ⟨range_splitting f '' s, _⟩
-  · apply LinearIndependent.of_comp f.range_restrict
+  apply Cardinal.lift_le.mpr
+  refine' le_csupᵢ (Cardinal.bddAbove_range.{v, v} _) ⟨rangeSplitting f '' s, _⟩
+  · apply LinearIndependent.of_comp f.rangeRestrict
     convert li.comp (Equiv.Set.rangeSplittingImageEquiv f s) (Equiv.injective _) using 1
-  · exact (cardinal.lift_mk_eq'.mpr ⟨Equiv.Set.rangeSplittingImageEquiv f s⟩).ge
+  · exact (Cardinal.lift_mk_eq'.mpr ⟨Equiv.Set.rangeSplittingImageEquiv f s⟩).ge
 #align lift_rank_range_le lift_rank_range_le
 
 set_option synthInstance.etaExperiment true in -- Porting note: gets around lean4#2074
@@ -260,7 +260,7 @@ theorem cardinal_lift_le_rank_of_linearIndependent {ι : Type w} {v : ι → M}
     Cardinal.lift.{v} (#ι) ≤ Cardinal.lift.{w} (Module.rank R M) := by
   apply le_trans
   · exact Cardinal.lift_mk_le'.mpr ⟨(Equiv.ofInjective _ hv.injective).toEmbedding⟩
-  · simp only [Cardinal.lift_le, Module.rank]
+  · simp only [Cardinal.lift_le, Module.rank_def]
     apply le_trans
     swap
     exact le_csupᵢ (Cardinal.bddAbove_range.{v, v} _) ⟨range v, hv.coe_range⟩
@@ -285,24 +285,24 @@ theorem cardinal_le_rank_of_linearIndependent' {s : Set M}
 variable (R M)
 
 @[simp]
-theorem rank_pUnit : Module.rank R PUnit = 0 := by
+theorem rank_punit : Module.rank R PUnit = 0 := by
   apply le_bot_iff.mp
-  rw [Module.rank]
+  rw [Module.rank_def]
   apply csupᵢ_le'
   rintro ⟨s, li⟩
   apply le_bot_iff.mpr
-  apply cardinal.mk_emptyc_iff.mpr
+  apply Cardinal.mk_emptyCollection_iff.mpr
   simp only [Subtype.coe_mk]
   by_contra h
   obtain ⟨a, ha⟩ := nonempty_iff_ne_empty.2 h
   simpa using LinearIndependent.ne_zero (⟨a, ha⟩ : s) li
-#align rank_punit rank_pUnit
+#align rank_punit rank_punit
 
 set_option synthInstance.etaExperiment true in -- Porting note: gets around lean4#2074
 @[simp]
 theorem rank_bot : Module.rank R (⊥ : Submodule R M) = 0 := by
   have : (⊥ : Submodule R M) ≃ₗ[R] PUnit := botEquivPUnit
-  rw [this.rank_eq, rank_pUnit]
+  rw [this.rank_eq, rank_punit]
 #align rank_bot rank_bot
 
 variable {R M}
@@ -352,7 +352,7 @@ def basisFintypeOfFiniteSpans (w : Set M) [Fintype w] (s : span R w = ⊤) {ι :
     use b.repr x
     simp only [and_true_iff, eq_self_iff_true, Finsupp.mem_supported]
     change (b.repr x).support ≤ S
-    convert Finset.le_sup (by simp : (⟨x, m⟩ : w) ∈ Finset.univ)
+    convert Finset.le_sup (α := Finset ι) (by simp : (⟨x, m⟩ : w) ∈ Finset.univ)
     rfl
   -- Thus this finite subset of the basis elements spans the entire module.
   have k : span R bS = ⊤ := eq_top_iff.2 (le_trans s.ge (span_le.2 h))
@@ -492,7 +492,7 @@ theorem rank_subsingleton [Subsingleton R] : Module.rank R M = 1 := by
   haveI := Module.subsingleton R M
   have : Nonempty { s : Set M // LinearIndependent R ((↑) : s → M) } :=
     ⟨⟨∅, linearIndependent_empty _ _⟩⟩
-  rw [Module.rank, csupᵢ_eq_of_forall_le_of_forall_lt_exists_gt]
+  rw [Module.rank_def, csupᵢ_eq_of_forall_le_of_forall_lt_exists_gt]
   · rintro ⟨s, hs⟩
     rw [Cardinal.mk_le_one_iff_set_subsingleton]
     apply subsingleton_of_subsingleton
@@ -510,7 +510,7 @@ theorem rank_pos [Nontrivial M] : 0 < Module.rank R M := by
   obtain ⟨x, hx⟩ := exists_ne (0 : M)
   suffices 1 ≤ Module.rank R M by exact zero_lt_one.trans_le this
   letI := Module.nontrivial R M
-  suffices LinearIndependent R fun y : ({x} : Set M) => ↑y by
+  suffices LinearIndependent R fun y : ({x} : Set M) => (y : M) by
     simpa using cardinal_le_rank_of_linearIndependent this
   exact linearIndependent_singleton hx
 #align rank_pos rank_pos
@@ -610,7 +610,7 @@ theorem Basis.le_span'' {ι : Type _} [Fintype ι] (b : Basis ι R M) {w : Set M
   -- by expressing a linear combination in `w` as a linear combination in `ι`.
   fapply card_le_of_surjective' R
   · exact b.repr.toLinearMap.comp (Finsupp.total w M R (↑))
-  · apply Surjective.comp
+  · apply Surjective.comp (g := b.repr.toLinearMap)
     apply LinearEquiv.surjective
     rw [← LinearMap.range_eq_top, Finsupp.range_total]
     simpa using s
@@ -640,7 +640,7 @@ theorem Basis.le_span {J : Set M} (v : Basis ι R M) (hJ : span R J = ⊤) : (#r
   · rw [← Cardinal.lift_le, Cardinal.mk_range_eq_of_injective v.injective, Cardinal.mk_fintype J]
     convert Cardinal.lift_le.{w, v}.2 (basis_le_span' v hJ)
     simp
-  · have := Cardinal.mk_range_eq_of_injective v.injective
+  · -- Porting note: `have` in this line is unnecessary.
     let S : J → Set ι := fun j => ↑(v.repr j).support
     let S' : J → Set M := fun j => v '' S j
     have hs : range v ⊆ ⋃ j, S' j := by
@@ -791,14 +791,14 @@ theorem maximal_linearIndependent_eq_infinite_basis {ι : Type _} (b : Basis ι 
 
 theorem Basis.mk_eq_rank'' {ι : Type v} (v : Basis ι R M) : (#ι) = Module.rank R M := by
   haveI := nontrivial_of_invariantBasisNumber R
-  rw [Module.rank]
+  rw [Module.rank_def]
   apply le_antisymm
   · trans
     swap
     apply le_csupᵢ (Cardinal.bddAbove_range.{v, v} _)
     exact
       ⟨Set.range v, by
-        convert v.reindex_range.linearIndependent
+        convert v.reindexRange.linearIndependent
         ext
         simp⟩
     exact (Cardinal.mk_range_eq v v.injective).ge
@@ -845,8 +845,8 @@ theorem Basis.mk_eq_rank (v : Basis ι R M) :
 #align basis.mk_eq_rank Basis.mk_eq_rank
 
 theorem Basis.mk_eq_rank'.{m} (v : Basis ι R M) :
-    Cardinal.lift.{max v m} (#ι) = Cardinal.lift.{max w m} (Module.rank R M) := by
-  simpa using v.mk_eq_rank
+    Cardinal.lift.{max v m} (#ι) = Cardinal.lift.{max w m} (Module.rank R M) :=
+  Cardinal.lift_umax_eq.{_, _, m}.mpr v.mk_eq_rank
 #align basis.mk_eq_rank' Basis.mk_eq_rank'
 
 /-- If a module has a finite dimension, all bases are indexed by a finite type. -/
@@ -912,7 +912,8 @@ theorem Ideal.rank_eq {R S : Type _} [CommRing R] [StrongRankCondition R] [Ring 
     le_antisymm
       (b.card_le_card_of_linearIndependent
         (c.linearIndependent.map' (Submodule.subtype I)
-          (LinearMap.ker_eq_bot.mpr Subtype.coe_injective)))
+          ((LinearMap.ker_eq_bot (f := (Submodule.subtype I : I →ₗ[R] S))).mpr
+            Subtype.coe_injective)))
       (c.card_le_card_of_linearIndependent this)
 #align ideal.rank_eq Ideal.rank_eq
 
@@ -953,12 +954,12 @@ open Cardinal
 set_option synthInstance.etaExperiment true in -- Porting note: gets around lean4#2074
 /-- Two vector spaces are isomorphic if they have the same dimension. -/
 theorem nonempty_linearEquiv_of_lift_rank_eq
-    (cond : Cardinal.lift.{v'} (Module.rank K V) = Cardinal.lift.{v} (Module.rank K V')) :
+    (cnd : Cardinal.lift.{v'} (Module.rank K V) = Cardinal.lift.{v} (Module.rank K V')) :
     Nonempty (V ≃ₗ[K] V') := by
-  obtain ⟨⟨_, B⟩⟩ := Module.Free.exists_basis K V
-  obtain ⟨⟨_, B'⟩⟩ := Module.Free.exists_basis K V'
+  obtain ⟨⟨_, B⟩⟩ := Module.Free.exists_basis (R := K) (M := V)
+  obtain ⟨⟨_, B'⟩⟩ := Module.Free.exists_basis (R := K) (M := V')
   have : Cardinal.lift.{v', v} (#_) = Cardinal.lift.{v, v'} (#_) := by
-    rw [B.mk_eq_rank'', cond, B'.mk_eq_rank'']
+    rw [B.mk_eq_rank'', cnd, B'.mk_eq_rank'']
   exact (Cardinal.lift_mk_eq.{v, v', 0}.1 this).map (B.equiv B')
 #align nonempty_linear_equiv_of_lift_rank_eq nonempty_linearEquiv_of_lift_rank_eq
 
@@ -1099,7 +1100,7 @@ theorem rank_span_le (s : Set V) : Module.rank K (span K s) ≤ (#s) := by
 
 theorem rank_span_of_finset (s : Finset V) : Module.rank K (span K (↑s : Set V)) < ℵ₀ :=
   calc
-    Module.rank K (span K (↑s : Set V)) ≤ (#(↑s : Set V)) := rank_span_le ↑s
+    Module.rank K (span K (↑s : Set V)) ≤ (#(↑s : Set V)) := rank_span_le (s : Set V)
     _ = s.card := by rw [Finset.coe_sort_coe, Cardinal.mk_coe_finset]
     _ < ℵ₀ := Cardinal.nat_lt_aleph0 _
 
@@ -1134,6 +1135,8 @@ variable [AddCommGroup V₃] [Module K V₃]
 
 open LinearMap
 
+#eval "TODO: Erase this."
+set_option maxHeartbeats 270000 in
 set_option synthInstance.etaExperiment true in -- Porting note: gets around lean4#2074
 /-- This is mostly an auxiliary lemma for `Submodule.rank_sup_add_rank_inf_eq`. -/
 theorem rank_add_rank_split (db : V₂ →ₗ[K] V) (eb : V₃ →ₗ[K] V) (cd : V₁ →ₗ[K] V₂)
@@ -1226,7 +1229,7 @@ theorem le_rank_iff_exists_linearIndependent {c : Cardinal} :
 
 theorem le_rank_iff_exists_linearIndependent_finset {n : ℕ} :
     ↑n ≤ Module.rank K V ↔
-      ∃ s : Finset V, s.card = n ∧ LinearIndependent K ((↑) : (s : Set V) → V) := by
+      ∃ s : Finset V, s.card = n ∧ LinearIndependent K ((↑) : ↥(s : Set V) → V) := by
   simp only [le_rank_iff_exists_linearIndependent, Cardinal.mk_set_eq_nat_iff_finset]
   constructor
   · rintro ⟨s, ⟨t, rfl, rfl⟩, si⟩
@@ -1309,12 +1312,12 @@ theorem rank_submodule_le_one_iff' (s : Submodule K V) : Module.rank K s ≤ 1 �
 
 theorem Submodule.rank_le_one_iff_isPrincipal (W : Submodule K V) :
     Module.rank K W ≤ 1 ↔ W.IsPrincipal := by
-  simp only [rank_le_one_iff, Submodule.isPrincipal_iff, le_antisymm_iff, le_span_singleton_iff,
+  simp only [rank_le_one_iff, Submodule.IsPrincipal_iff, le_antisymm_iff, le_span_singleton_iff,
     span_singleton_le_iff_mem]
   constructor
   · rintro ⟨⟨m, hm⟩, hm'⟩
     choose f hf using hm'
-    exact ⟨m, ⟨fun v hv => ⟨f ⟨v, hv⟩, congr_arg (↑) (hf ⟨v, hv⟩)⟩, hm⟩⟩
+    exact ⟨m, ⟨fun v hv => ⟨f ⟨v, hv⟩, congr_arg ((↑) : W → V) (hf ⟨v, hv⟩)⟩, hm⟩⟩
   · rintro ⟨a, ⟨h, ha⟩⟩
     choose f hf using h
     exact ⟨⟨a, ha⟩, fun v => ⟨f v.1 v.2, Subtype.ext (hf v.1 v.2)⟩⟩
@@ -1413,7 +1416,7 @@ theorem le_rank_iff_exists_linearIndependent {c : Cardinal} {f : V →ₗ[K] V'}
   rcases f.rangeRestrict.exists_rightInverse_of_surjective f.range_rangeRestrict with ⟨g, hg⟩
   have fg : LeftInverse f.rangeRestrict g := LinearMap.congr_fun hg
   refine' ⟨fun h => _, _⟩
-  · rcases le_rank_iff_exists_linearIndependent.1 h with ⟨s, rfl, si⟩
+  · rcases _root_.le_rank_iff_exists_linearIndependent.1 h with ⟨s, rfl, si⟩
     refine' ⟨g '' s, Cardinal.mk_image_eq_lift _ _ fg.injective, _⟩
     replace fg : ∀ x, f (g x) = x
     · intro x

--- a/Mathlib/LinearAlgebra/Dimension.lean
+++ b/Mathlib/LinearAlgebra/Dimension.lean
@@ -1135,9 +1135,7 @@ theorem rank_add_rank_split (db : V₂ →ₗ[K] V) (eb : V₃ →ₗ[K] V) (cd 
     rw [← rank_prod', rank_eq_of_surjective _ hf]
   congr 1
   apply LinearEquiv.rank_eq
-  -- Porting note: `L` was originally a place holder which is used at next `refine'`.
-  --               This is required to prevent timeout.
-  let L : V₁ →ₗ[K] ker (coprod db eb) := by
+  let L : V₁ →ₗ[K] ker (coprod db eb) := by -- Porting note: this is needed to avoid a timeout
     refine' LinearMap.codRestrict _ (prod cd (-ce)) _
     · intro c
       simp only [add_eq_zero_iff_eq_neg, LinearMap.prod_apply, mem_ker, Pi.prod, coprod_apply,

--- a/Mathlib/LinearAlgebra/Dimension.lean
+++ b/Mathlib/LinearAlgebra/Dimension.lean
@@ -28,9 +28,9 @@ import Mathlib.SetTheory.Cardinal.Cofinality
 
 ## Main statements
 
-* `linear_map.rank_le_of_injective`: the source of an injective linear map has dimension
+* `LinearMap.rank_le_of_injective`: the source of an injective linear map has dimension
   at most that of the target.
-* `linear_map.rank_le_of_surjective`: the target of a surjective linear map has dimension
+* `LinearMap.rank_le_of_surjective`: the target of a surjective linear map has dimension
   at most that of that source.
 * `basis_fintype_of_finite_spans`:
   the existence of a finite spanning set implies that any basis is finite.
@@ -94,8 +94,6 @@ section
 
 variable [Semiring K] [AddCommMonoid V] [Module K V]
 
-include K
-
 variable (K V)
 
 /-- The rank of a module, defined as a term of type `cardinal`.
@@ -112,7 +110,7 @@ The definition is marked as protected to avoid conflicts with `_root_.rank`,
 the rank of a linear map.
 -/
 protected irreducible_def Module.rank : Cardinal :=
-  ⨆ ι : { s : Set V // LinearIndependent K (coe : s → V) }, #ι.1
+  ⨆ ι : { s : Set V // LinearIndependent K ((↑) : s → V) }, #ι.1
 #align module.rank Module.rank
 
 end
@@ -127,6 +125,7 @@ variable {M' : Type v'} [AddCommGroup M'] [Module R M']
 
 variable {M₁ : Type v} [AddCommGroup M₁] [Module R M₁]
 
+set_option synthInstance.etaExperiment true in -- Porting note: gets around lean4#2074
 theorem LinearMap.lift_rank_le_of_injective (f : M →ₗ[R] M') (i : Injective f) :
     Cardinal.lift.{v'} (Module.rank R M) ≤ Cardinal.lift.{v} (Module.rank R M') := by
   dsimp [Module.rank]
@@ -135,9 +134,10 @@ theorem LinearMap.lift_rank_le_of_injective (f : M →ₗ[R] M') (i : Injective 
   apply csupᵢ_mono' (Cardinal.bddAbove_range.{v', v} _)
   rintro ⟨s, li⟩
   refine' ⟨⟨f '' s, _⟩, cardinal.lift_mk_le'.mpr ⟨(Equiv.Set.image f s i).toEmbedding⟩⟩
-  exact (li.map' _ <| linear_map.ker_eq_bot.mpr i).image
+  exact (li.map' _ <| LinearMap.ker_eq_bot.mpr i).image
 #align linear_map.lift_rank_le_of_injective LinearMap.lift_rank_le_of_injective
 
+set_option synthInstance.etaExperiment true in -- Porting note: gets around lean4#2074
 theorem LinearMap.rank_le_of_injective (f : M →ₗ[R] M₁) (i : Injective f) :
     Module.rank R M ≤ Module.rank R M₁ :=
   Cardinal.lift_le.1 (f.lift_rank_le_of_injective i)
@@ -152,8 +152,9 @@ theorem rank_le {n : ℕ}
   exact linearIndependent_bounded_of_finset_linearIndependent_bounded H _ li
 #align rank_le rank_le
 
-theorem lift_rank_range_le (f : M →ₗ[R] M') :
-    Cardinal.lift.{v} (Module.rank R f.range) ≤ Cardinal.lift.{v'} (Module.rank R M) := by
+set_option synthInstance.etaExperiment true in -- Porting note: gets around lean4#2074
+theorem lift_rank_range_le (f : M →ₗ[R] M') : Cardinal.lift.{v}
+    (Module.rank R (LinearMap.range f)) ≤ Cardinal.lift.{v'} (Module.rank R M) := by
   dsimp [Module.rank]
   rw [Cardinal.lift_supᵢ (Cardinal.bddAbove_range.{v', v'} _)]
   apply csupᵢ_le'
@@ -167,45 +168,52 @@ theorem lift_rank_range_le (f : M →ₗ[R] M') :
   · exact (cardinal.lift_mk_eq'.mpr ⟨Equiv.Set.rangeSplittingImageEquiv f s⟩).ge
 #align lift_rank_range_le lift_rank_range_le
 
-theorem rank_range_le (f : M →ₗ[R] M₁) : Module.rank R f.range ≤ Module.rank R M := by
+set_option synthInstance.etaExperiment true in -- Porting note: gets around lean4#2074
+theorem rank_range_le (f : M →ₗ[R] M₁) : Module.rank R (LinearMap.range f) ≤ Module.rank R M := by
   simpa using lift_rank_range_le f
 #align rank_range_le rank_range_le
 
+set_option synthInstance.etaExperiment true in -- Porting note: gets around lean4#2074
 theorem lift_rank_map_le (f : M →ₗ[R] M') (p : Submodule R M) :
     Cardinal.lift.{v} (Module.rank R (p.map f)) ≤ Cardinal.lift.{v'} (Module.rank R p) := by
   have h := lift_rank_range_le (f.comp (Submodule.subtype p))
   rwa [LinearMap.range_comp, range_subtype] at h
 #align lift_rank_map_le lift_rank_map_le
 
+set_option synthInstance.etaExperiment true in -- Porting note: gets around lean4#2074
 theorem rank_map_le (f : M →ₗ[R] M₁) (p : Submodule R M) :
     Module.rank R (p.map f) ≤ Module.rank R p := by simpa using lift_rank_map_le f p
 #align rank_map_le rank_map_le
 
 theorem rank_le_of_submodule (s t : Submodule R M) (h : s ≤ t) :
     Module.rank R s ≤ Module.rank R t :=
-  (ofLe h).rank_le_of_injective fun ⟨x, hx⟩ ⟨y, hy⟩ eq =>
-    Subtype.eq <| show x = y from Subtype.ext_iff_val.1 Eq
+  (ofLe h).rank_le_of_injective fun ⟨x, _⟩ ⟨y, _⟩ eq =>
+    Subtype.eq <| show x = y from Subtype.ext_iff_val.1 eq
 #align rank_le_of_submodule rank_le_of_submodule
 
+set_option synthInstance.etaExperiment true in -- Porting note: gets around lean4#2074
 /-- Two linearly equivalent vector spaces have the same dimension, a version with different
 universes. -/
 theorem LinearEquiv.lift_rank_eq (f : M ≃ₗ[R] M') :
     Cardinal.lift.{v'} (Module.rank R M) = Cardinal.lift.{v} (Module.rank R M') := by
   apply le_antisymm
-  · exact f.to_linear_map.lift_rank_le_of_injective f.injective
-  · exact f.symm.to_linear_map.lift_rank_le_of_injective f.symm.injective
+  · exact f.toLinearMap.lift_rank_le_of_injective f.injective
+  · exact f.symm.toLinearMap.lift_rank_le_of_injective f.symm.injective
 #align linear_equiv.lift_rank_eq LinearEquiv.lift_rank_eq
 
+set_option synthInstance.etaExperiment true in -- Porting note: gets around lean4#2074
 /-- Two linearly equivalent vector spaces have the same dimension. -/
 theorem LinearEquiv.rank_eq (f : M ≃ₗ[R] M₁) : Module.rank R M = Module.rank R M₁ :=
   Cardinal.lift_inj.1 f.lift_rank_eq
 #align linear_equiv.rank_eq LinearEquiv.rank_eq
 
+set_option synthInstance.etaExperiment true in -- Porting note: gets around lean4#2074
 theorem rank_eq_of_injective (f : M →ₗ[R] M₁) (h : Injective f) :
-    Module.rank R M = Module.rank R f.range :=
+    Module.rank R M = Module.rank R (LinearMap.range f) :=
   (LinearEquiv.ofInjective f h).rank_eq
 #align rank_eq_of_injective rank_eq_of_injective
 
+set_option synthInstance.etaExperiment true in -- Porting note: gets around lean4#2074
 /-- Pushforwards of submodules along a `linear_equiv` have the same dimension. -/
 theorem LinearEquiv.rank_map_eq (f : M ≃ₗ[R] M₁) (p : Submodule R M) :
     Module.rank R (p.map (f : M →ₗ[R] M₁)) = Module.rank R p :=
@@ -214,6 +222,7 @@ theorem LinearEquiv.rank_map_eq (f : M ≃ₗ[R] M₁) (p : Submodule R M) :
 
 variable (R M)
 
+set_option synthInstance.etaExperiment true in -- Porting note: gets around lean4#2074
 @[simp]
 theorem rank_top : Module.rank R (⊤ : Submodule R M) = Module.rank R M := by
   have : (⊤ : Submodule R M) ≃ₗ[R] M := LinearEquiv.ofTop ⊤ rfl
@@ -222,8 +231,10 @@ theorem rank_top : Module.rank R (⊤ : Submodule R M) = Module.rank R M := by
 
 variable {R M}
 
+set_option synthInstance.etaExperiment true in -- Porting note: gets around lean4#2074
 theorem rank_range_of_surjective (f : M →ₗ[R] M') (h : Surjective f) :
-    Module.rank R f.range = Module.rank R M' := by rw [LinearMap.range_eq_top.2 h, rank_top]
+    Module.rank R (LinearMap.range f) = Module.rank R M' :=
+  by rw [LinearMap.range_eq_top.2 h, rank_top]
 #align rank_range_of_surjective rank_range_of_surjective
 
 theorem rank_submodule_le (s : Submodule R M) : Module.rank R s ≤ Module.rank R M := by
@@ -231,6 +242,7 @@ theorem rank_submodule_le (s : Submodule R M) : Module.rank R s ≤ Module.rank 
   exact rank_le_of_submodule _ _ le_top
 #align rank_submodule_le rank_submodule_le
 
+set_option synthInstance.etaExperiment true in -- Porting note: gets around lean4#2074
 theorem LinearMap.rank_le_of_surjective (f : M →ₗ[R] M₁) (h : Surjective f) :
     Module.rank R M₁ ≤ Module.rank R M := by
   rw [← rank_range_of_surjective f h]
@@ -247,7 +259,7 @@ theorem cardinal_lift_le_rank_of_linearIndependent.{m} {ι : Type w} {v : ι →
     (hv : LinearIndependent R v) :
     Cardinal.lift.{max v m} (#ι) ≤ Cardinal.lift.{max w m} (Module.rank R M) := by
   apply le_trans
-  · exact cardinal.lift_mk_le.mpr ⟨(Equiv.ofInjective _ hv.injective).toEmbedding⟩
+  · exact Cardinal.lift_mk_le.mpr ⟨(Equiv.ofInjective _ hv.injective).toEmbedding⟩
   · simp only [Cardinal.lift_le, Module.rank]
     apply le_trans
     swap
@@ -286,9 +298,10 @@ theorem rank_pUnit : Module.rank R PUnit = 0 := by
   simpa using LinearIndependent.ne_zero (⟨a, ha⟩ : s) li
 #align rank_punit rank_pUnit
 
+set_option synthInstance.etaExperiment true in -- Porting note: gets around lean4#2074
 @[simp]
 theorem rank_bot : Module.rank R (⊥ : Submodule R M) = 0 := by
-  have : (⊥ : Submodule R M) ≃ₗ[R] PUnit := bot_equiv_punit
+  have : (⊥ : Submodule R M) ≃ₗ[R] PUnit := botEquivPUnit
   rw [this.rank_eq, rank_pUnit]
 #align rank_bot rank_bot
 
@@ -303,7 +316,7 @@ theorem exists_mem_ne_zero_of_rank_pos {s : Submodule R M} (h : 0 < Module.rank 
 the module is Noetherian. -/
 theorem LinearIndependent.finite_of_isNoetherian [IsNoetherian R M] {v : ι → M}
     (hv : LinearIndependent R v) : Finite ι := by
-  have hwf := is_noetherian_iff_well_founded.mp (by infer_instance : IsNoetherian R M)
+  have hwf := isNoetherian_iff_wellFounded.mp (by infer_instance : IsNoetherian R M)
   refine'
     CompleteLattice.WellFounded.finite_of_independent hwf hv.independent_span_singleton
       fun i contra => _
@@ -313,7 +326,7 @@ theorem LinearIndependent.finite_of_isNoetherian [IsNoetherian R M] {v : ι → 
 #align linear_independent.finite_of_is_noetherian LinearIndependent.finite_of_isNoetherian
 
 theorem LinearIndependent.set_finite_of_isNoetherian [IsNoetherian R M] {s : Set M}
-    (hi : LinearIndependent R (coe : s → M)) : s.Finite :=
+    (hi : LinearIndependent R ((↑) : s → M)) : s.Finite :=
   @Set.toFinite _ _ hi.finite_of_isNoetherian
 #align linear_independent.set_finite_of_is_noetherian LinearIndependent.set_finite_of_isNoetherian
 
@@ -331,7 +344,7 @@ def basisFintypeOfFiniteSpans (w : Set M) [Fintype w] (s : span R w = ⊤) {ι :
   intro i
   -- Let `S` be the union of the supports of `x ∈ w` expressed as linear combinations of `b`.
   -- This is a finite set since `w` is finite.
-  let S : Finset ι := finset.univ.sup fun x : w => (b.repr x).support
+  let S : Finset ι := Finset.univ.sup fun x : w => (b.repr x).support
   let bS : Set M := b '' S
   have h : ∀ x ∈ w, x ∈ span R bS := by
     intro x m
@@ -350,10 +363,11 @@ def basisFintypeOfFiniteSpans (w : Set M) [Fintype w] (s : span R w = ⊤) {ι :
     rw [k]
     exact mem_top
   -- giving the desire contradiction.
-  refine' b.linear_independent.not_mem_span_image _ k'
+  refine' b.linearIndependent.not_mem_span_image _ k'
   exact nm
 #align basis_fintype_of_finite_spans basisFintypeOfFiniteSpans
 
+set_option synthInstance.etaExperiment true in -- Porting note: gets around lean4#2074
 -- From [Les familles libres maximales d'un module ont-elles le meme cardinal?][lazarus1973]
 /-- Over any ring `R`, if `b` is a basis for a module `M`,
 and `s` is a maximal linearly independent set,
@@ -361,10 +375,10 @@ then the union of the supports of `x ∈ s` (when written out in the basis `b`) 
 -/
 theorem union_support_maximal_linearIndependent_eq_range_basis {ι : Type w} (b : Basis ι R M)
     {κ : Type w'} (v : κ → M) (i : LinearIndependent R v) (m : i.Maximal) :
-    (⋃ k, ((b.repr (v k)).support : Set ι)) = univ := by
+    (⋃ k, ((b.repr (v k)).support : Set ι)) = Set.univ := by
   -- If that's not the case,
   by_contra h
-  simp only [← Ne.def, ne_univ_iff_exists_not_mem, mem_Union, not_exists_not,
+  simp only [← Ne.def, ne_univ_iff_exists_not_mem, mem_unionᵢ, not_exists_not,
     Finsupp.mem_support_iff, Finset.mem_coe] at h
   -- We have some basis element `b b'` which is not in the support of any of the `v i`.
   obtain ⟨b', w⟩ := h
@@ -385,7 +399,7 @@ theorem union_support_maximal_linearIndependent_eq_range_basis {ι : Type w} (b 
       rfl
     rw [← e] at p
     exact r' p
-  have inj' : injective v' := by
+  have inj' : Injective v' := by
     rintro (_ | k) (_ | k) z
     · rfl
     · exfalso
@@ -395,11 +409,11 @@ theorem union_support_maximal_linearIndependent_eq_range_basis {ι : Type w} (b 
     · congr
       exact i.injective z
   -- The key step in the proof is checking that this strictly larger family is linearly independent.
-  have i' : LinearIndependent R (coe : range v' → M) := by
+  have i' : LinearIndependent R ((↑) : range v' → M) := by
     rw [linearIndependent_subtype_range inj', linearIndependent_iff]
     intro l z
     rw [Finsupp.total_option] at z
-    simp only [v', Option.elim'] at z
+    simp only [Option.elim'] at z
     change _ + Finsupp.total κ M R v l.some = 0 at z
     -- We have some linear combination of `b b'` and the `v i`, which we want to show is trivial.
     -- We'll first show the coefficient of `b b'` is zero,
@@ -410,16 +424,16 @@ theorem union_support_maximal_linearIndependent_eq_range_basis {ι : Type w} (b 
       apply_fun fun x => b.repr x b'  at z
       simp only [repr_self, LinearEquiv.map_smul, mul_one, Finsupp.single_eq_same, Pi.neg_apply,
         Finsupp.smul_single', LinearEquiv.map_neg, Finsupp.coe_neg] at z
-      erw [Finsupp.congr_fun (Finsupp.apply_total R (b.repr : M →ₗ[R] ι →₀ R) v l.some) b'] at z
+      erw [FunLike.congr_fun (Finsupp.apply_total R (b.repr : M →ₗ[R] ι →₀ R) v l.some) b'] at z
       simpa [Finsupp.total_apply, w] using z
     -- Then all the other coefficients are zero, because `v` is linear independent.
     have l₁ : l.some = 0 := by
       rw [l₀, zero_smul, zero_add] at z
-      exact linear_independent_iff.mp i _ z
+      exact linearIndependent_iff.mp i _ z
     -- Finally we put those facts together to show the linear combination is trivial.
     ext (_ | a)
     · simp only [l₀, Finsupp.coe_zero, Pi.zero_apply]
-    · erw [Finsupp.congr_fun l₁ a]
+    · erw [FunLike.congr_fun l₁ a]
       simp only [Finsupp.coe_zero, Pi.zero_apply]
   dsimp [LinearIndependent.Maximal] at m
   specialize m (range v') i' r
@@ -438,7 +452,7 @@ theorem infinite_basis_le_maximal_linear_independent' {ι : Type w} (b : Basis �
     apply Cardinal.le_range_of_union_finset_eq_top
     exact union_support_maximal_linearIndependent_eq_range_basis b v i m
   have w₂ : Cardinal.lift.{w'} (#Set.range Φ) ≤ Cardinal.lift.{w} (#κ) := Cardinal.mk_range_le_lift
-  exact (cardinal.lift_le.mpr w₁).trans w₂
+  exact (Cardinal.lift_le.mpr w₁).trans w₂
 #align infinite_basis_le_maximal_linear_independent' infinite_basis_le_maximal_linear_independent'
 
 -- (See `infinite_basis_le_maximal_linear_independent'` for the more general version
@@ -461,7 +475,7 @@ theorem CompleteLattice.Independent.subtype_ne_bot_le_rank [NoZeroSMulDivisors R
     rw [← Submodule.ne_bot_iff]
     exact i.prop
   choose v hvV hv using hI
-  have : LinearIndependent R v := (hV.comp Subtype.coe_injective).LinearIndependent _ hvV hv
+  have : LinearIndependent R v := (hV.comp Subtype.coe_injective).linearIndependent _ hvV hv
   exact cardinal_lift_le_rank_of_linear_independent' this
 #align complete_lattice.independent.subtype_ne_bot_le_rank CompleteLattice.Independent.subtype_ne_bot_le_rank
 
@@ -476,7 +490,7 @@ variable [Ring R] [AddCommGroup M] [Module R M]
 @[simp]
 theorem rank_subsingleton [Subsingleton R] : Module.rank R M = 1 := by
   haveI := Module.subsingleton R M
-  have : Nonempty { s : Set M // LinearIndependent R (coe : s → M) } :=
+  have : Nonempty { s : Set M // LinearIndependent R ((↑) : s → M) } :=
     ⟨⟨∅, linearIndependent_empty _ _⟩⟩
   rw [Module.rank, csupᵢ_eq_of_forall_le_of_forall_lt_exists_gt]
   · rintro ⟨s, hs⟩
@@ -558,10 +572,10 @@ theorem mk_eq_mk_of_basis (v : Basis ι R M) (v' : Basis ι' R M) :
     -- so by `infinite_basis_le_maximal_linear_independent`, `v'` is at least as big,
     -- and then applying `infinite_basis_le_maximal_linear_independent` again
     -- we see they have the same cardinality.
-    have w₁ := infinite_basis_le_maximal_linear_independent' v _ v'.linear_independent v'.maximal
-    rcases cardinal.lift_mk_le'.mp w₁ with ⟨f⟩
+    have w₁ := infinite_basis_le_maximal_linear_independent' v _ v'.linearIndependent v'.maximal
+    rcases Cardinal.lift_mk_le'.mp w₁ with ⟨f⟩
     haveI : Infinite ι' := Infinite.of_injective f f.2
-    have w₂ := infinite_basis_le_maximal_linear_independent' v' _ v.linear_independent v.maximal
+    have w₂ := infinite_basis_le_maximal_linear_independent' v' _ v.linearIndependent v.maximal
     exact le_antisymm w₁ w₂
 #align mk_eq_mk_of_basis mk_eq_mk_of_basis
 
@@ -595,8 +609,8 @@ theorem Basis.le_span'' {ι : Type _} [Fintype ι] (b : Basis ι R M) {w : Set M
   -- We construct an surjective linear map `(w → R) →ₗ[R] (ι → R)`,
   -- by expressing a linear combination in `w` as a linear combination in `ι`.
   fapply card_le_of_surjective' R
-  · exact b.repr.to_linear_map.comp (Finsupp.total w M R coe)
-  · apply surjective.comp
+  · exact b.repr.toLinearMap.comp (Finsupp.total w M R (↑))
+  · apply Surjective.comp
     apply LinearEquiv.surjective
     rw [← LinearMap.range_eq_top, Finsupp.range_total]
     simpa using s
@@ -632,15 +646,14 @@ theorem Basis.le_span {J : Set M} (v : Basis ι R M) (hJ : span R J = ⊤) : (#r
     have hs : range v ⊆ ⋃ j, S' j := by
       intro b hb
       rcases mem_range.1 hb with ⟨i, hi⟩
-      have : span R J ≤ comap v.repr.to_linear_map (Finsupp.supported R R (⋃ j, S j)) :=
+      have : span R J ≤ comap v.repr.toLinearMap (Finsupp.supported R R (⋃ j, S j)) :=
         span_le.2 fun j hj x hx => ⟨_, ⟨⟨j, hj⟩, rfl⟩, hx⟩
       rw [hJ] at this
       replace : v.repr (v i) ∈ Finsupp.supported R R (⋃ j, S j) := this trivial
       rw [v.repr_self, Finsupp.mem_supported, Finsupp.support_single_ne_zero _ one_ne_zero] at this
       · subst b
-        rcases mem_Union.1 (this (Finset.mem_singleton_self _)) with ⟨j, hj⟩
-        exact mem_Union.2 ⟨j, (mem_image _ _ _).2 ⟨i, hj, rfl⟩⟩
-      · infer_instance
+        rcases mem_unionᵢ.1 (this (Finset.mem_singleton_self _)) with ⟨j, hj⟩
+        exact mem_unionᵢ.2 ⟨j, (mem_image _ _ _).2 ⟨i, hj, rfl⟩⟩
     refine' le_of_not_lt fun IJ => _
     suffices (#⋃ j, S' j) < (#range v) by exact not_le_of_lt this ⟨Set.embeddingOfSubset _ _ hs⟩
     refine'
@@ -673,10 +686,10 @@ theorem linearIndependent_le_span_aux' {ι : Type _} [Fintype ι] (v : ι → M)
   · apply Finsupp.total
     exact fun i => Span.repr R w ⟨v i, s (mem_range_self i)⟩
   · intro f g h
-    apply_fun Finsupp.total w M R coe  at h
+    apply_fun Finsupp.total w M R (↑) at h
     simp only [Finsupp.total_total, Submodule.coe_mk, Span.finsupp_total_repr] at h
     rw [← sub_eq_zero, ← LinearMap.map_sub] at h
-    exact sub_eq_zero.mp (linear_independent_iff.mp i _ h)
+    exact sub_eq_zero.mp (linearIndependent_iff.mp i _ h)
 #align linear_independent_le_span_aux' linearIndependent_le_span_aux'
 
 /-- If `R` satisfies the strong rank condition,
@@ -723,10 +736,10 @@ we handle the case where the basis `b` is infinite.
 -/
 theorem linearIndependent_le_infinite_basis {ι : Type _} (b : Basis ι R M) [Infinite ι] {κ : Type _}
     (v : κ → M) (i : LinearIndependent R v) : (#κ) ≤ (#ι) := by
-  by_contra
+  by_contra h
   rw [not_le, ← Cardinal.mk_finset_of_infinite ι] at h
   let Φ := fun k : κ => (b.repr (v k)).support
-  obtain ⟨s, w : Infinite ↥(Φ ⁻¹' {s})⟩ := Cardinal.exists_infinite_fiber Φ h (by infer_instance)
+  obtain ⟨s, w : Infinite coe_sort (Φ ⁻¹' {s})⟩ := Cardinal.exists_infinite_fiber Φ h (by infer_instance)
   let v' := fun k : Φ ⁻¹' {s} => v k
   have i' : LinearIndependent R v' := i.comp _ Subtype.val_injective
   have w' : Fintype (Φ ⁻¹' {s}) := by
@@ -745,14 +758,12 @@ then the cardinality of `s` is bounded by the cardinality of `b`.
 theorem linearIndependent_le_basis {ι : Type _} (b : Basis ι R M) {κ : Type _} (v : κ → M)
     (i : LinearIndependent R v) : (#κ) ≤ (#ι) := by
   -- We split into cases depending on whether `ι` is infinite.
-    cases fintypeOrInfinite ι <;>
-    skip
-  · -- When `ι` is finite, we have `linear_independent_le_span`,
-    rw [Cardinal.mk_fintype ι]
+  cases fintypeOrInfinite ι
+  · rw [Cardinal.mk_fintype ι] -- When `ι` is finite, we have `linear_independent_le_span`,
     haveI : Nontrivial R := nontrivial_of_invariantBasisNumber R
     rw [Fintype.card_congr (Equiv.ofInjective b b.injective)]
     exact linearIndependent_le_span v i (range b) b.span_eq
-  ·-- and otherwise we have `linear_indepedent_le_infinite_basis`.
+  · -- and otherwise we have `linear_indepedent_le_infinite_basis`.
     exact linearIndependent_le_infinite_basis b v i
 #align linear_independent_le_basis linearIndependent_le_basis
 
@@ -818,13 +829,13 @@ theorem Basis.card_le_card_of_linearIndependent {ι : Type _} [Fintype ι] (b : 
 
 theorem Basis.card_le_card_of_submodule (N : Submodule R M) [Fintype ι] (b : Basis ι R M)
     [Fintype ι'] (b' : Basis ι' R N) : Fintype.card ι' ≤ Fintype.card ι :=
-  b.card_le_card_of_linearIndependent (b'.LinearIndependent.map' N.Subtype N.ker_subtype)
+  b.card_le_card_of_linearIndependent (b'.linearIndependent.map' N.subtype N.ker_subtype)
 #align basis.card_le_card_of_submodule Basis.card_le_card_of_submodule
 
 theorem Basis.card_le_card_of_le {N O : Submodule R M} (hNO : N ≤ O) [Fintype ι] (b : Basis ι R O)
     [Fintype ι'] (b' : Basis ι' R N) : Fintype.card ι' ≤ Fintype.card ι :=
   b.card_le_card_of_linearIndependent
-    (b'.LinearIndependent.map' (Submodule.ofLe hNO) (N.ker_ofLe O _))
+    (b'.linearIndependent.map' (Submodule.ofLe hNO) (N.ker_ofLe O _))
 #align basis.card_le_card_of_le Basis.card_le_card_of_le
 
 theorem Basis.mk_eq_rank (v : Basis ι R M) :
@@ -858,15 +869,15 @@ theorem Basis.finite_index_of_rank_lt_aleph0 {ι : Type _} {s : Set ι} (b : Bas
 #align basis.finite_index_of_rank_lt_aleph_0 Basis.finite_index_of_rank_lt_aleph0
 
 theorem rank_span {v : ι → M} (hv : LinearIndependent R v) :
-    Module.rank R ↥(span R (range v)) = (#range v) := by
+    Module.rank R coe_sort (span R (range v)) = (#range v) := by
   haveI := nontrivial_of_invariantBasisNumber R
   rw [← Cardinal.lift_inj, ← (Basis.span hv).mk_eq_rank,
     Cardinal.mk_range_eq_of_injective (@LinearIndependent.injective ι R M v _ _ _ _ hv)]
 #align rank_span rank_span
 
 theorem rank_span_set {s : Set M} (hs : LinearIndependent R (fun x => x : s → M)) :
-    Module.rank R ↥(span R s) = (#s) := by
-  rw [← @set_of_mem_eq _ s, ← Subtype.range_coe_subtype]
+    Module.rank R coe_Sort (span R s) = (#s) := by
+  rw [← @setOf_mem_eq _ s, ← Subtype.range_coe_subtype]
   exact rank_span hs
 #align rank_span_set rank_span_set
 
@@ -878,10 +889,11 @@ def Submodule.inductionOnRank [IsDomain R] [Fintype ι] (b : Basis ι R M)
       ∀ N : Submodule R M,
         (∀ N' ≤ N, ∀ x ∈ N, (∀ (c : R), ∀ y ∈ N', c • x + y = (0 : M) → c = 0) → P N') → P N)
     (N : Submodule R M) : P N :=
-  Submodule.inductionOnRankAux b P ih (Fintype.card ι) N fun s hs hli => by
-    simpa using b.card_le_card_of_linear_independent hli
+  Submodule.inductionOnRankAux b P ih (Fintype.card ι) N fun hs hli => by
+    simpa using b.card_le_card_of_linearIndependent hli
 #align submodule.induction_on_rank Submodule.inductionOnRank
 
+set_option synthInstance.etaExperiment true in -- Porting note: gets around lean4#2074
 /-- If `S` a finite-dimensional ring extension of `R` which is free as an `R`-module,
 then the rank of an ideal `I` of `S` over `R` is the same as the rank of `S`.
 -/
@@ -890,7 +902,7 @@ theorem Ideal.rank_eq {R S : Type _} [CommRing R] [StrongRankCondition R] [Ring 
     (hI : I ≠ ⊥) (c : Basis m R I) : Fintype.card m = Fintype.card n := by
   obtain ⟨a, ha⟩ := Submodule.nonzero_mem_of_bot_lt (bot_lt_iff_ne_bot.mpr hI)
   have : LinearIndependent R fun i => b i • a := by
-    have hb := b.linear_independent
+    have hb := b.linearIndependent
     rw [Fintype.linearIndependent_iff] at hb⊢
     intro g hg
     apply hb g
@@ -898,10 +910,10 @@ theorem Ideal.rank_eq {R S : Type _} [CommRing R] [StrongRankCondition R] [Ring 
     exact hg.resolve_right ha
   exact
     le_antisymm
-      (b.card_le_card_of_linear_independent
-        (c.linear_independent.map' (Submodule.subtype I)
-          (linear_map.ker_eq_bot.mpr Subtype.coe_injective)))
-      (c.card_le_card_of_linear_independent this)
+      (b.card_le_card_of_linearIndependent
+        (c.linearIndependent.map' (Submodule.subtype I)
+          (LinearMap.ker_eq_bot.mpr Subtype.coe_injective)))
+      (c.card_le_card_of_linearIndependent this)
 #align ideal.rank_eq Ideal.rank_eq
 
 variable (R)
@@ -923,8 +935,6 @@ variable [AddCommGroup V'] [Module K V'] [Module.Free K V']
 
 variable [AddCommGroup V₁] [Module K V₁] [Module.Free K V₁]
 
-variable {K V}
-
 namespace Module.Free
 
 variable (K V)
@@ -940,6 +950,7 @@ open Module.Free
 
 open Cardinal
 
+set_option synthInstance.etaExperiment true in -- Porting note: gets around lean4#2074
 /-- Two vector spaces are isomorphic if they have the same dimension. -/
 theorem nonempty_linearEquiv_of_lift_rank_eq
     (cond : Cardinal.lift.{v'} (Module.rank K V) = Cardinal.lift.{v} (Module.rank K V')) :
@@ -951,6 +962,7 @@ theorem nonempty_linearEquiv_of_lift_rank_eq
   exact (Cardinal.lift_mk_eq.{v, v', 0}.1 this).map (B.equiv B')
 #align nonempty_linear_equiv_of_lift_rank_eq nonempty_linearEquiv_of_lift_rank_eq
 
+set_option synthInstance.etaExperiment true in -- Porting note: gets around lean4#2074
 /-- Two vector spaces are isomorphic if they have the same dimension. -/
 theorem nonempty_linearEquiv_of_rank_eq (cond : Module.rank K V = Module.rank K V₁) :
     Nonempty (V ≃ₗ[K] V₁) :=
@@ -961,6 +973,7 @@ section
 
 variable (V V' V₁)
 
+set_option synthInstance.etaExperiment true in -- Porting note: gets around lean4#2074
 /-- Two vector spaces are isomorphic if they have the same dimension. -/
 def LinearEquiv.ofLiftRankEq
     (cond : Cardinal.lift.{v'} (Module.rank K V) = Cardinal.lift.{v} (Module.rank K V')) :
@@ -968,6 +981,7 @@ def LinearEquiv.ofLiftRankEq
   Classical.choice (nonempty_linearEquiv_of_lift_rank_eq cond)
 #align linear_equiv.of_lift_rank_eq LinearEquiv.ofLiftRankEq
 
+set_option synthInstance.etaExperiment true in -- Porting note: gets around lean4#2074
 /-- Two vector spaces are isomorphic if they have the same dimension. -/
 def LinearEquiv.ofRankEq (cond : Module.rank K V = Module.rank K V₁) : V ≃ₗ[K] V₁ :=
   Classical.choice (nonempty_linearEquiv_of_rank_eq cond)
@@ -975,6 +989,7 @@ def LinearEquiv.ofRankEq (cond : Module.rank K V = Module.rank K V₁) : V ≃�
 
 end
 
+set_option synthInstance.etaExperiment true in -- Porting note: gets around lean4#2074
 /-- Two vector spaces are isomorphic if and only if they have the same dimension. -/
 theorem LinearEquiv.nonempty_equiv_iff_lift_rank_eq :
     Nonempty (V ≃ₗ[K] V') ↔
@@ -982,6 +997,7 @@ theorem LinearEquiv.nonempty_equiv_iff_lift_rank_eq :
   ⟨fun ⟨h⟩ => LinearEquiv.lift_rank_eq h, fun h => nonempty_linearEquiv_of_lift_rank_eq h⟩
 #align linear_equiv.nonempty_equiv_iff_lift_rank_eq LinearEquiv.nonempty_equiv_iff_lift_rank_eq
 
+set_option synthInstance.etaExperiment true in -- Porting note: gets around lean4#2074
 /-- Two vector spaces are isomorphic if and only if they have the same dimension. -/
 theorem LinearEquiv.nonempty_equiv_iff_rank_eq :
     Nonempty (V ≃ₗ[K] V₁) ↔ Module.rank K V = Module.rank K V₁ :=
@@ -993,8 +1009,8 @@ theorem LinearEquiv.nonempty_equiv_iff_rank_eq :
 theorem rank_prod :
     Module.rank K (V × V') =
       Cardinal.lift.{v'} (Module.rank K V) + Cardinal.lift.{v, v'} (Module.rank K V') := by
-  simpa [rank_eq_card_choose_basis_index K V, rank_eq_card_choose_basis_index K V', lift_umax,
-    lift_umax'] using ((choose_basis K V).Prod (choose_basis K V')).mk_eq_rank.symm
+  simpa [rank_eq_card_chooseBasisIndex K V, rank_eq_card_chooseBasisIndex K V', lift_umax,
+    lift_umax'] using ((chooseBasis K V).prod (chooseBasis K V')).mk_eq_rank.symm
 #align rank_prod rank_prod
 
 /-- If `M` and `N` lie in the same universe, the rank of `M × N` is
@@ -1013,7 +1029,7 @@ open LinearMap
 theorem rank_pi [Finite η] : Module.rank K (∀ i, φ i) = Cardinal.sum fun i => Module.rank K (φ i) :=
   by
   cases nonempty_fintype η
-  let B i := choose_basis K (φ i)
+  let B i := chooseBasis K (φ i)
   let b : Basis _ K (∀ i, φ i) := Pi.basis fun i => B i
   simp [← b.mk_eq_rank'', fun i => (B i).mk_eq_rank'']
 #align rank_pi rank_pi
@@ -1031,6 +1047,7 @@ theorem rank_fun_eq_lift_mul :
   by rw [rank_pi, Cardinal.sum_const, Cardinal.mk_fintype, Cardinal.lift_natCast]
 #align rank_fun_eq_lift_mul rank_fun_eq_lift_mul
 
+set_option synthInstance.etaExperiment true in -- Porting note: gets around lean4#2074
 theorem rank_fun' : Module.rank K (η → K) = Fintype.card η := by
   rw [rank_fun_eq_lift_mul, rank_self, Cardinal.lift_one, mul_one, Cardinal.natCast_inj]
 #align rank_fun' rank_fun'
@@ -1040,6 +1057,7 @@ theorem rank_fin_fun (n : ℕ) : Module.rank K (Fin n → K) = n := by simp [ran
 
 end Fintype
 
+set_option synthInstance.etaExperiment true in -- Porting note: gets around lean4#2074
 -- TODO: merge with the `finrank` content
 /-- An `n`-dimensional `K`-vector space is equivalent to `fin n → K`. -/
 def finDimVectorspaceEquiv (n : ℕ) (hn : Module.rank K V = n) : V ≃ₗ[K] Fin n → K := by
@@ -1064,8 +1082,6 @@ variable [AddCommGroup V'] [Module K V']
 
 variable [AddCommGroup V₁] [Module K V₁]
 
-variable {K V}
-
 /-- If a vector space has a finite dimension, the index set of `basis.of_vector_space` is finite. -/
 theorem Basis.finite_ofVectorSpaceIndex_of_rank_lt_aleph0 (h : Module.rank K V < ℵ₀) :
     (Basis.ofVectorSpaceIndex K V).Finite :=
@@ -1086,7 +1102,7 @@ theorem rank_span_of_finset (s : Finset V) : Module.rank K (span K (↑s : Set V
     Module.rank K (span K (↑s : Set V)) ≤ (#(↑s : Set V)) := rank_span_le ↑s
     _ = s.card := by rw [Finset.coe_sort_coe, Cardinal.mk_coe_finset]
     _ < ℵ₀ := Cardinal.nat_lt_aleph0 _
-    
+
 #align rank_span_of_finset rank_span_of_finset
 
 theorem rank_quotient_add_rank (p : Submodule K V) :
@@ -1096,15 +1112,17 @@ theorem rank_quotient_add_rank (p : Submodule K V) :
       rank_prod'.symm.trans f.rank_eq
 #align rank_quotient_add_rank rank_quotient_add_rank
 
+set_option synthInstance.etaExperiment true in -- Porting note: gets around lean4#2074
 /-- rank-nullity theorem -/
 theorem rank_range_add_rank_ker (f : V →ₗ[K] V₁) :
-    Module.rank K f.range + Module.rank K f.ker = Module.rank K V := by
+    Module.rank K (LinearMap.range f) + Module.rank K (LinearMap.ker f) = Module.rank K V := by
   haveI := fun p : Submodule K V => Classical.decEq (V ⧸ p)
-  rw [← f.quot_ker_equiv_range.rank_eq, rank_quotient_add_rank]
+  rw [← f.quotKerEquivRange.rank_eq, rank_quotient_add_rank]
 #align rank_range_add_rank_ker rank_range_add_rank_ker
 
+set_option synthInstance.etaExperiment true in -- Porting note: gets around lean4#2074
 theorem rank_eq_of_surjective (f : V →ₗ[K] V₁) (h : Surjective f) :
-    Module.rank K V = Module.rank K V₁ + Module.rank K f.ker := by
+    Module.rank K V = Module.rank K V₁ + Module.rank K (LinearMap.ker f) := by
   rw [← rank_range_add_rank_ker f, ← rank_range_of_surjective f h]
 #align rank_eq_of_surjective rank_eq_of_surjective
 
@@ -1116,9 +1134,10 @@ variable [AddCommGroup V₃] [Module K V₃]
 
 open LinearMap
 
+set_option synthInstance.etaExperiment true in -- Porting note: gets around lean4#2074
 /-- This is mostly an auxiliary lemma for `submodule.rank_sup_add_rank_inf_eq`. -/
 theorem rank_add_rank_split (db : V₂ →ₗ[K] V) (eb : V₃ →ₗ[K] V) (cd : V₁ →ₗ[K] V₂)
-    (ce : V₁ →ₗ[K] V₃) (hde : ⊤ ≤ db.range ⊔ eb.range) (hgd : ker cd = ⊥)
+    (ce : V₁ →ₗ[K] V₃) (hde : ⊤ ≤ LinearMap.range db ⊔ LinearMap.range eb) (hgd : ker cd = ⊥)
     (eq : db.comp cd = eb.comp ce) (eq₂ : ∀ d e, db d = eb e → ∃ c, cd c = d ∧ ce c = e) :
     Module.rank K V + Module.rank K V₁ = Module.rank K V₂ + Module.rank K V₃ := by
   have hf : Surjective (coprod db eb) := by rwa [← range_eq_top, range_coprod, eq_top_iff]
@@ -1128,13 +1147,13 @@ theorem rank_add_rank_split (db : V₂ →ₗ[K] V) (eb : V₃ →ₗ[K] V) (cd 
   congr 1
   apply LinearEquiv.rank_eq
   refine' LinearEquiv.ofBijective _ ⟨_, _⟩
-  · refine' cod_restrict _ (Prod cd (-ce)) _
+  · refine' LinearMap.codRestrict _ (Prod cd (-ce)) _
     · intro c
       simp only [add_eq_zero_iff_eq_neg, LinearMap.prod_apply, mem_ker, Pi.prod, coprod_apply,
         neg_neg, map_neg, neg_apply]
       exact LinearMap.ext_iff.1 Eq c
-  · rw [← ker_eq_bot, ker_cod_restrict, ker_prod, hgd, bot_inf_eq]
-  · rw [← range_eq_top, eq_top_iff, range_cod_restrict, ← map_le_iff_le_comap, Submodule.map_top,
+  · rw [← ker_eq_bot, ker_codRestrict, ker_prod, hgd, bot_inf_eq]
+  · rw [← range_eq_top, eq_top_iff, range_codRestrict, ← map_le_iff_le_comap, Submodule.map_top,
       range_subtype]
     rintro ⟨d, e⟩
     have h := eq₂ d (-e)
@@ -1146,19 +1165,19 @@ theorem rank_add_rank_split (db : V₂ →ₗ[K] V) (eb : V₃ →ₗ[K] V) (cd 
     rw [h₂, _root_.neg_neg]
 #align rank_add_rank_split rank_add_rank_split
 
+set_option synthInstance.etaExperiment true in -- Porting note: gets around lean4#2074
 theorem Submodule.rank_sup_add_rank_inf_eq (s t : Submodule K V) :
     Module.rank K (s ⊔ t : Submodule K V) + Module.rank K (s ⊓ t : Submodule K V) =
       Module.rank K s + Module.rank K t :=
   rank_add_rank_split (ofLe le_sup_left) (ofLe le_sup_right) (ofLe inf_le_left) (ofLe inf_le_right)
     (by
       rw [← map_le_map_iff' (ker_subtype <| s ⊔ t), Submodule.map_sup, Submodule.map_top, ←
-        LinearMap.range_comp, ← LinearMap.range_comp, subtype_comp_of_le, subtype_comp_of_le,
-        range_subtype, range_subtype, range_subtype]
-      exact le_rfl)
+        LinearMap.range_comp, ← LinearMap.range_comp, subtype_comp_ofLe, subtype_comp_ofLe,
+        range_subtype, range_subtype, range_subtype])
     (ker_ofLe _ _ _) (by ext ⟨x, hx⟩; rfl)
     (by
       rintro ⟨b₁, hb₁⟩ ⟨b₂, hb₂⟩ eq
-      obtain rfl : b₁ = b₂ := congr_arg Subtype.val Eq
+      obtain rfl : b₁ = b₂ := congr_arg Subtype.val eq
       exact ⟨⟨b₁, hb₁, hb₂⟩, rfl, rfl⟩)
 #align submodule.rank_sup_add_rank_inf_eq Submodule.rank_sup_add_rank_inf_eq
 
@@ -1194,20 +1213,20 @@ theorem Basis.ofRankEqZero_apply {ι : Type _} [IsEmpty ι] (hV : Module.rank K 
 #align basis.of_rank_eq_zero_apply Basis.ofRankEqZero_apply
 
 theorem le_rank_iff_exists_linearIndependent {c : Cardinal} :
-    c ≤ Module.rank K V ↔ ∃ s : Set V, (#s) = c ∧ LinearIndependent K (coe : s → V) := by
+    c ≤ Module.rank K V ↔ ∃ s : Set V, (#s) = c ∧ LinearIndependent K ((↑) : s → V) := by
   constructor
   · intro h
     let t := Basis.ofVectorSpace K V
     rw [← t.mk_eq_rank'', Cardinal.le_mk_iff_exists_subset] at h
     rcases h with ⟨s, hst, hsc⟩
-    exact ⟨s, hsc, (of_vector_space_index.linear_independent K V).mono hst⟩
+    exact ⟨s, hsc, (ofVectorSpaceIndex.linearIndependent K V).mono hst⟩
   · rintro ⟨s, rfl, si⟩
     exact cardinal_le_rank_of_linearIndependent si
 #align le_rank_iff_exists_linear_independent le_rank_iff_exists_linearIndependent
 
 theorem le_rank_iff_exists_linearIndependent_finset {n : ℕ} :
     ↑n ≤ Module.rank K V ↔
-      ∃ s : Finset V, s.card = n ∧ LinearIndependent K (coe : (s : Set V) → V) := by
+      ∃ s : Finset V, s.card = n ∧ LinearIndependent K ((↑) : (s : Set V) → V) := by
   simp only [le_rank_iff_exists_linearIndependent, Cardinal.mk_set_eq_nat_iff_finset]
   constructor
   · rintro ⟨s, ⟨t, rfl, rfl⟩, si⟩
@@ -1223,7 +1242,7 @@ theorem rank_le_one_iff : Module.rank K V ≤ 1 ↔ ∃ v₀ : V, ∀ v, ∃ r :
   constructor
   · intro hd
     rw [← b.mk_eq_rank'', Cardinal.le_one_iff_subsingleton, subsingleton_coe] at hd
-    rcases eq_empty_or_nonempty (of_vector_space_index K V) with (hb | ⟨⟨v₀, hv₀⟩⟩)
+    rcases eq_empty_or_nonempty (ofVectorSpaceIndex K V) with (hb | ⟨⟨v₀, hv₀⟩⟩)
     · use 0
       have h' : ∀ v : V, v = 0 := by simpa [hb, Submodule.eq_bot_iff] using b.span_eq.symm
       intro v
@@ -1272,7 +1291,7 @@ theorem rank_submodule_le_one_iff' (s : Submodule K V) : Module.rank K s ≤ 1 �
   by
   rw [rank_submodule_le_one_iff]
   constructor
-  · rintro ⟨v₀, hv₀, h⟩
+  · rintro ⟨v₀, _, h⟩
     exact ⟨v₀, h⟩
   · rintro ⟨v₀, h⟩
     by_cases hw : ∃ w : V, w ∈ s ∧ w ≠ 0
@@ -1281,7 +1300,7 @@ theorem rank_submodule_le_one_iff' (s : Submodule K V) : Module.rank K s ≤ 1 �
       rcases mem_span_singleton.1 (h hw) with ⟨r', rfl⟩
       have h0 : r' ≠ 0 := by
         rintro rfl
-        simpa using hw0
+        simp at hw0
       rwa [span_singleton_smul_eq (IsUnit.mk0 _ h0) _]
     · push_neg  at hw
       rw [← Submodule.eq_bot_iff] at hw
@@ -1295,7 +1314,7 @@ theorem Submodule.rank_le_one_iff_isPrincipal (W : Submodule K V) :
   constructor
   · rintro ⟨⟨m, hm⟩, hm'⟩
     choose f hf using hm'
-    exact ⟨m, ⟨fun v hv => ⟨f ⟨v, hv⟩, congr_arg coe (hf ⟨v, hv⟩)⟩, hm⟩⟩
+    exact ⟨m, ⟨fun v hv => ⟨f ⟨v, hv⟩, congr_arg (↑) (hf ⟨v, hv⟩)⟩, hm⟩⟩
   · rintro ⟨a, ⟨h, ha⟩⟩
     choose f hf using h
     exact ⟨⟨a, ha⟩, fun v => ⟨f v.1 v.2, Subtype.ext (hf v.1 v.2)⟩⟩
@@ -1321,15 +1340,17 @@ variable [Ring K] [AddCommGroup V] [Module K V] [AddCommGroup V₁] [Module K V�
 
 variable [AddCommGroup V'] [Module K V']
 
-/-- `rank f` is the rank of a `linear_map` `f`, defined as the dimension of `f.range`. -/
+set_option synthInstance.etaExperiment true in -- Porting note: gets around lean4#2074
+/-- `rank f` is the rank of a `LinearMap` `f`, defined as the dimension of `f.range`. -/
 def rank (f : V →ₗ[K] V') : Cardinal :=
-  Module.rank K f.range
+  Module.rank K (LinearMap.range f)
 #align linear_map.rank LinearMap.rank
 
 theorem rank_le_range (f : V →ₗ[K] V₁) : rank f ≤ Module.rank K V₁ :=
   rank_submodule_le _
 #align linear_map.rank_le_range LinearMap.rank_le_range
 
+set_option synthInstance.etaExperiment true in -- Porting note: gets around lean4#2074
 @[simp]
 theorem rank_zero [Nontrivial K] : rank (0 : V →ₗ[K] V') = 0 := by
   rw [rank, LinearMap.range_zero, rank_bot]
@@ -1337,6 +1358,7 @@ theorem rank_zero [Nontrivial K] : rank (0 : V →ₗ[K] V') = 0 := by
 
 variable [AddCommGroup V''] [Module K V'']
 
+set_option synthInstance.etaExperiment true in -- Porting note: gets around lean4#2074
 theorem rank_comp_le1 (g : V →ₗ[K] V') (f : V' →ₗ[K] V'') : rank (f.comp g) ≤ rank f := by
   refine' rank_le_of_submodule _ _ _
   rw [LinearMap.range_comp]
@@ -1345,8 +1367,9 @@ theorem rank_comp_le1 (g : V →ₗ[K] V') (f : V' →ₗ[K] V'') : rank (f.comp
 
 variable [AddCommGroup V'₁] [Module K V'₁]
 
+set_option synthInstance.etaExperiment true in -- Porting note: gets around lean4#2074
 theorem rank_comp_le2 (g : V →ₗ[K] V') (f : V' →ₗ[K] V'₁) : rank (f.comp g) ≤ rank g := by
-  rw [rank, rank, LinearMap.range_comp] <;> exact rank_map_le _ _
+  rw [rank, rank, LinearMap.range_comp]; exact rank_map_le _ _
 #align linear_map.rank_comp_le2 LinearMap.rank_comp_le2
 
 end Ring
@@ -1362,31 +1385,34 @@ theorem rank_le_domain (f : V →ₗ[K] V₁) : rank f ≤ Module.rank K V := by
   exact self_le_add_right _ _
 #align linear_map.rank_le_domain LinearMap.rank_le_domain
 
+set_option synthInstance.etaExperiment true in -- Porting note: gets around lean4#2074
 theorem rank_add_le (f g : V →ₗ[K] V') : rank (f + g) ≤ rank f + rank g :=
   calc
-    rank (f + g) ≤ Module.rank K (f.range ⊔ g.range : Submodule K V') := by
+    rank (f + g) ≤ Module.rank K (LinearMap.range f ⊔ LinearMap.range g : Submodule K V') := by
       refine' rank_le_of_submodule _ _ _
       exact
         LinearMap.range_le_iff_comap.2 <|
           eq_top_iff'.2 fun x =>
-            show f x + g x ∈ (f.range ⊔ g.range : Submodule K V') from
+            show f x + g x ∈ (LinearMap.range f ⊔ LinearMap.range g : Submodule K V') from
               mem_sup.2 ⟨_, ⟨x, rfl⟩, _, ⟨x, rfl⟩, rfl⟩
     _ ≤ rank f + rank g := Submodule.rank_add_le_rank_add_rank _ _
-    
+
 #align linear_map.rank_add_le LinearMap.rank_add_le
 
+set_option synthInstance.etaExperiment true in -- Porting note: gets around lean4#2074
 theorem rank_finset_sum_le {η} (s : Finset η) (f : η → V →ₗ[K] V') :
     rank (∑ d in s, f d) ≤ ∑ d in s, rank (f d) :=
   @Finset.sum_hom_rel _ _ _ _ _ (fun a b => rank a ≤ b) f (fun d => rank (f d)) s
-    (le_of_eq rank_zero) fun i g c h => le_trans (rank_add_le _ _) (add_le_add_left h _)
+    (le_of_eq rank_zero) fun _ _ _ h => le_trans (rank_add_le _ _) (add_le_add_left h _)
 #align linear_map.rank_finset_sum_le LinearMap.rank_finset_sum_le
 
+set_option synthInstance.etaExperiment true in -- Porting note: gets around lean4#2074
 theorem le_rank_iff_exists_linearIndependent {c : Cardinal} {f : V →ₗ[K] V'} :
     c ≤ rank f ↔
       ∃ s : Set V,
         Cardinal.lift.{v'} (#s) = Cardinal.lift.{v} c ∧ LinearIndependent K fun x : s => f x := by
-  rcases f.range_restrict.exists_right_inverse_of_surjective f.range_range_restrict with ⟨g, hg⟩
-  have fg : left_inverse f.range_restrict g := LinearMap.congr_fun hg
+  rcases f.rangeRestrict.exists_rightInverse_of_surjective f.range_rangeRestrict with ⟨g, hg⟩
+  have fg : LeftInverse f.rangeRestrict g := LinearMap.congr_fun hg
   refine' ⟨fun h => _, _⟩
   · rcases le_rank_iff_exists_linearIndependent.1 h with ⟨s, rfl, si⟩
     refine' ⟨g '' s, Cardinal.mk_image_eq_lift _ _ fg.injective, _⟩
@@ -1397,13 +1423,14 @@ theorem le_rank_iff_exists_linearIndependent {c : Cardinal} {f : V →ₗ[K] V'}
     · simpa only [fg] using si.map' _ (ker_subtype _)
     exact si.image_of_comp s g f
   · rintro ⟨s, hsc, si⟩
-    have : LinearIndependent K fun x : s => f.range_restrict x :=
+    have : LinearIndependent K fun x : s => f.rangeRestrict x :=
       LinearIndependent.of_comp f.range.subtype (by convert si)
     convert cardinal_le_rank_of_linearIndependent this.image
     rw [← Cardinal.lift_inj, ← hsc, Cardinal.mk_image_eq_of_injOn_lift]
     exact inj_on_iff_injective.2 this.injective
 #align linear_map.le_rank_iff_exists_linear_independent LinearMap.le_rank_iff_exists_linearIndependent
 
+set_option synthInstance.etaExperiment true in -- Porting note: gets around lean4#2074
 theorem le_rank_iff_exists_linearIndependent_finset {n : ℕ} {f : V →ₗ[K] V'} :
     ↑n ≤ rank f ↔ ∃ s : Finset V, s.card = n ∧ LinearIndependent K fun x : (s : Set V) => f x := by
   simp only [le_rank_iff_exists_linearIndependent, Cardinal.lift_natCast, Cardinal.lift_eq_nat_iff,
@@ -1418,4 +1445,3 @@ theorem le_rank_iff_exists_linearIndependent_finset {n : ℕ} {f : V →ₗ[K] V
 end DivisionRing
 
 end LinearMap
-

--- a/Mathlib/LinearAlgebra/Dimension.lean
+++ b/Mathlib/LinearAlgebra/Dimension.lean
@@ -8,13 +8,13 @@ Authors: Mario Carneiro, Johannes Hölzl, Sander Dahmen, Scott Morrison
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
-import Mathbin.Algebra.Module.BigOperators
-import Mathbin.LinearAlgebra.Dfinsupp
-import Mathbin.LinearAlgebra.FreeModule.Basic
-import Mathbin.LinearAlgebra.InvariantBasisNumber
-import Mathbin.LinearAlgebra.Isomorphisms
-import Mathbin.LinearAlgebra.StdBasis
-import Mathbin.SetTheory.Cardinal.Cofinality
+import Mathlib.Algebra.Module.BigOperators
+import Mathlib.LinearAlgebra.Dfinsupp
+import Mathlib.LinearAlgebra.FreeModule.Basic
+import Mathlib.LinearAlgebra.InvariantBasisNumber
+import Mathlib.LinearAlgebra.Isomorphisms
+import Mathlib.LinearAlgebra.StdBasis
+import Mathlib.SetTheory.Cardinal.Cofinality
 
 /-!
 # Dimension of modules and vector spaces
@@ -128,8 +128,7 @@ variable {M' : Type v'} [AddCommGroup M'] [Module R M']
 variable {M₁ : Type v} [AddCommGroup M₁] [Module R M₁]
 
 theorem LinearMap.lift_rank_le_of_injective (f : M →ₗ[R] M') (i : Injective f) :
-    Cardinal.lift.{v'} (Module.rank R M) ≤ Cardinal.lift.{v} (Module.rank R M') :=
-  by
+    Cardinal.lift.{v'} (Module.rank R M) ≤ Cardinal.lift.{v} (Module.rank R M') := by
   dsimp [Module.rank]
   rw [Cardinal.lift_supᵢ (Cardinal.bddAbove_range.{v', v'} _),
     Cardinal.lift_supᵢ (Cardinal.bddAbove_range.{v, v} _)]
@@ -154,8 +153,7 @@ theorem rank_le {n : ℕ}
 #align rank_le rank_le
 
 theorem lift_rank_range_le (f : M →ₗ[R] M') :
-    Cardinal.lift.{v} (Module.rank R f.range) ≤ Cardinal.lift.{v'} (Module.rank R M) :=
-  by
+    Cardinal.lift.{v} (Module.rank R f.range) ≤ Cardinal.lift.{v'} (Module.rank R M) := by
   dsimp [Module.rank]
   rw [Cardinal.lift_supᵢ (Cardinal.bddAbove_range.{v', v'} _)]
   apply csupᵢ_le'
@@ -174,8 +172,7 @@ theorem rank_range_le (f : M →ₗ[R] M₁) : Module.rank R f.range ≤ Module.
 #align rank_range_le rank_range_le
 
 theorem lift_rank_map_le (f : M →ₗ[R] M') (p : Submodule R M) :
-    Cardinal.lift.{v} (Module.rank R (p.map f)) ≤ Cardinal.lift.{v'} (Module.rank R p) :=
-  by
+    Cardinal.lift.{v} (Module.rank R (p.map f)) ≤ Cardinal.lift.{v'} (Module.rank R p) := by
   have h := lift_rank_range_le (f.comp (Submodule.subtype p))
   rwa [LinearMap.range_comp, range_subtype] at h
 #align lift_rank_map_le lift_rank_map_le
@@ -193,8 +190,7 @@ theorem rank_le_of_submodule (s t : Submodule R M) (h : s ≤ t) :
 /-- Two linearly equivalent vector spaces have the same dimension, a version with different
 universes. -/
 theorem LinearEquiv.lift_rank_eq (f : M ≃ₗ[R] M') :
-    Cardinal.lift.{v'} (Module.rank R M) = Cardinal.lift.{v} (Module.rank R M') :=
-  by
+    Cardinal.lift.{v'} (Module.rank R M) = Cardinal.lift.{v} (Module.rank R M') := by
   apply le_antisymm
   · exact f.to_linear_map.lift_rank_le_of_injective f.injective
   · exact f.symm.to_linear_map.lift_rank_le_of_injective f.symm.injective
@@ -219,8 +215,7 @@ theorem LinearEquiv.rank_map_eq (f : M ≃ₗ[R] M₁) (p : Submodule R M) :
 variable (R M)
 
 @[simp]
-theorem rank_top : Module.rank R (⊤ : Submodule R M) = Module.rank R M :=
-  by
+theorem rank_top : Module.rank R (⊤ : Submodule R M) = Module.rank R M := by
   have : (⊤ : Submodule R M) ≃ₗ[R] M := LinearEquiv.ofTop ⊤ rfl
   rw [this.rank_eq]
 #align rank_top rank_top
@@ -231,15 +226,13 @@ theorem rank_range_of_surjective (f : M →ₗ[R] M') (h : Surjective f) :
     Module.rank R f.range = Module.rank R M' := by rw [LinearMap.range_eq_top.2 h, rank_top]
 #align rank_range_of_surjective rank_range_of_surjective
 
-theorem rank_submodule_le (s : Submodule R M) : Module.rank R s ≤ Module.rank R M :=
-  by
+theorem rank_submodule_le (s : Submodule R M) : Module.rank R s ≤ Module.rank R M := by
   rw [← rank_top R M]
   exact rank_le_of_submodule _ _ le_top
 #align rank_submodule_le rank_submodule_le
 
 theorem LinearMap.rank_le_of_surjective (f : M →ₗ[R] M₁) (h : Surjective f) :
-    Module.rank R M₁ ≤ Module.rank R M :=
-  by
+    Module.rank R M₁ ≤ Module.rank R M := by
   rw [← rank_range_of_surjective f h]
   apply rank_range_le
 #align linear_map.rank_le_of_surjective LinearMap.rank_le_of_surjective
@@ -252,8 +245,7 @@ variable [Nontrivial R]
 
 theorem cardinal_lift_le_rank_of_linearIndependent.{m} {ι : Type w} {v : ι → M}
     (hv : LinearIndependent R v) :
-    Cardinal.lift.{max v m} (#ι) ≤ Cardinal.lift.{max w m} (Module.rank R M) :=
-  by
+    Cardinal.lift.{max v m} (#ι) ≤ Cardinal.lift.{max w m} (Module.rank R M) := by
   apply le_trans
   · exact cardinal.lift_mk_le.mpr ⟨(Equiv.ofInjective _ hv.injective).toEmbedding⟩
   · simp only [Cardinal.lift_le, Module.rank]
@@ -281,8 +273,7 @@ theorem cardinal_le_rank_of_linear_independent' {s : Set M}
 variable (R M)
 
 @[simp]
-theorem rank_pUnit : Module.rank R PUnit = 0 :=
-  by
+theorem rank_pUnit : Module.rank R PUnit = 0 := by
   apply le_bot_iff.mp
   rw [Module.rank]
   apply csupᵢ_le'
@@ -296,8 +287,7 @@ theorem rank_pUnit : Module.rank R PUnit = 0 :=
 #align rank_punit rank_pUnit
 
 @[simp]
-theorem rank_bot : Module.rank R (⊥ : Submodule R M) = 0 :=
-  by
+theorem rank_bot : Module.rank R (⊥ : Submodule R M) = 0 := by
   have : (⊥ : Submodule R M) ≃ₗ[R] PUnit := bot_equiv_punit
   rw [this.rank_eq, rank_pUnit]
 #align rank_bot rank_bot
@@ -312,8 +302,7 @@ theorem exists_mem_ne_zero_of_rank_pos {s : Submodule R M} (h : 0 < Module.rank 
 /-- A linearly-independent family of vectors in a module over a non-trivial ring must be finite if
 the module is Noetherian. -/
 theorem LinearIndependent.finite_of_isNoetherian [IsNoetherian R M] {v : ι → M}
-    (hv : LinearIndependent R v) : Finite ι :=
-  by
+    (hv : LinearIndependent R v) : Finite ι := by
   have hwf := is_noetherian_iff_well_founded.mp (by infer_instance : IsNoetherian R M)
   refine'
     CompleteLattice.WellFounded.finite_of_independent hwf hv.independent_span_singleton
@@ -336,8 +325,7 @@ theorem LinearIndependent.set_finite_of_isNoetherian [IsNoetherian R M] {s : Set
 Over any nontrivial ring, the existence of a finite spanning set implies that any basis is finite.
 -/
 def basisFintypeOfFiniteSpans (w : Set M) [Fintype w] (s : span R w = ⊤) {ι : Type w}
-    (b : Basis ι R M) : Fintype ι :=
-  by
+    (b : Basis ι R M) : Fintype ι := by
   -- We'll work by contradiction, assuming `ι` is infinite.
   apply fintypeOfNotInfinite _
   intro i
@@ -373,8 +361,7 @@ then the union of the supports of `x ∈ s` (when written out in the basis `b`) 
 -/
 theorem union_support_maximal_linearIndependent_eq_range_basis {ι : Type w} (b : Basis ι R M)
     {κ : Type w'} (v : κ → M) (i : LinearIndependent R v) (m : i.Maximal) :
-    (⋃ k, ((b.repr (v k)).support : Set ι)) = univ :=
-  by
+    (⋃ k, ((b.repr (v k)).support : Set ι)) = univ := by
   -- If that's not the case,
   by_contra h
   simp only [← Ne.def, ne_univ_iff_exists_not_mem, mem_Union, not_exists_not,
@@ -408,8 +395,7 @@ theorem union_support_maximal_linearIndependent_eq_range_basis {ι : Type w} (b 
     · congr
       exact i.injective z
   -- The key step in the proof is checking that this strictly larger family is linearly independent.
-  have i' : LinearIndependent R (coe : range v' → M) :=
-    by
+  have i' : LinearIndependent R (coe : range v' → M) := by
     rw [linearIndependent_subtype_range inj', linearIndependent_iff]
     intro l z
     rw [Finsupp.total_option] at z
@@ -446,11 +432,9 @@ then the cardinality of `b` is bounded by the cardinality of `s`.
 -/
 theorem infinite_basis_le_maximal_linear_independent' {ι : Type w} (b : Basis ι R M) [Infinite ι]
     {κ : Type w'} (v : κ → M) (i : LinearIndependent R v) (m : i.Maximal) :
-    Cardinal.lift.{w'} (#ι) ≤ Cardinal.lift.{w} (#κ) :=
-  by
+    Cardinal.lift.{w'} (#ι) ≤ Cardinal.lift.{w} (#κ) := by
   let Φ := fun k : κ => (b.repr (v k)).support
-  have w₁ : (#ι) ≤ (#Set.range Φ) :=
-    by
+  have w₁ : (#ι) ≤ (#Set.range Φ) := by
     apply Cardinal.le_range_of_union_finset_eq_top
     exact union_support_maximal_linearIndependent_eq_range_basis b v i m
   have w₂ : Cardinal.lift.{w'} (#Set.range Φ) ≤ Cardinal.lift.{w} (#κ) := Cardinal.mk_range_le_lift
@@ -470,8 +454,7 @@ theorem infinite_basis_le_maximal_linearIndependent {ι : Type w} (b : Basis ι 
 
 theorem CompleteLattice.Independent.subtype_ne_bot_le_rank [NoZeroSMulDivisors R M]
     {V : ι → Submodule R M} (hV : CompleteLattice.Independent V) :
-    Cardinal.lift.{v} (#{ i : ι // V i ≠ ⊥ }) ≤ Cardinal.lift.{w} (Module.rank R M) :=
-  by
+    Cardinal.lift.{v} (#{ i : ι // V i ≠ ⊥ }) ≤ Cardinal.lift.{w} (Module.rank R M) := by
   set I := { i : ι // V i ≠ ⊥ }
   have hI : ∀ i : I, ∃ v ∈ V i, v ≠ (0 : M) := by
     intro i
@@ -491,8 +474,7 @@ variable {R : Type u} {M : Type v}
 variable [Ring R] [AddCommGroup M] [Module R M]
 
 @[simp]
-theorem rank_subsingleton [Subsingleton R] : Module.rank R M = 1 :=
-  by
+theorem rank_subsingleton [Subsingleton R] : Module.rank R M = 1 := by
   haveI := Module.subsingleton R M
   have : Nonempty { s : Set M // LinearIndependent R (coe : s → M) } :=
     ⟨⟨∅, linearIndependent_empty _ _⟩⟩
@@ -510,8 +492,7 @@ theorem rank_subsingleton [Subsingleton R] : Module.rank R M = 1 :=
 
 variable [NoZeroSMulDivisors R M]
 
-theorem rank_pos [Nontrivial M] : 0 < Module.rank R M :=
-  by
+theorem rank_pos [Nontrivial M] : 0 < Module.rank R M := by
   obtain ⟨x, hx⟩ := exists_ne (0 : M)
   suffices 1 ≤ Module.rank R M by exact zero_lt_one.trans_le this
   letI := Module.nontrivial R M
@@ -522,8 +503,7 @@ theorem rank_pos [Nontrivial M] : 0 < Module.rank R M :=
 
 variable [Nontrivial R]
 
-theorem rank_zero_iff_forall_zero : Module.rank R M = 0 ↔ ∀ x : M, x = 0 :=
-  by
+theorem rank_zero_iff_forall_zero : Module.rank R M = 0 ↔ ∀ x : M, x = 0 := by
   refine' ⟨fun h => _, fun h => _⟩
   · contrapose! h
     obtain ⟨x, hx⟩ := h
@@ -540,8 +520,7 @@ theorem rank_zero_iff : Module.rank R M = 0 ↔ Subsingleton M :=
   rank_zero_iff_forall_zero.trans (subsingleton_iff_forall_eq 0).symm
 #align rank_zero_iff rank_zero_iff
 
-theorem rank_pos_iff_exists_ne_zero : 0 < Module.rank R M ↔ ∃ x : M, x ≠ 0 :=
-  by
+theorem rank_pos_iff_exists_ne_zero : 0 < Module.rank R M ↔ ∃ x : M, x ≠ 0 := by
   rw [← not_iff_not]
   simpa using rank_zero_iff_forall_zero
 #align rank_pos_iff_exists_ne_zero rank_pos_iff_exists_ne_zero
@@ -561,8 +540,7 @@ variable {M : Type v} [AddCommGroup M] [Module R M]
 /-- The dimension theorem: if `v` and `v'` are two bases, their index types
 have the same cardinalities. -/
 theorem mk_eq_mk_of_basis (v : Basis ι R M) (v' : Basis ι' R M) :
-    Cardinal.lift.{w'} (#ι) = Cardinal.lift.{w} (#ι') :=
-  by
+    Cardinal.lift.{w'} (#ι) = Cardinal.lift.{w} (#ι') := by
   haveI := nontrivial_of_invariantBasisNumber R
   cases fintypeOrInfinite ι
   · -- `v` is a finite basis, so by `basis_fintype_of_finite_spans` so is `v'`.
@@ -613,8 +591,7 @@ and any finite spanning set `w : set M`,
 the cardinality of `ι` is bounded by the cardinality of `w`.
 -/
 theorem Basis.le_span'' {ι : Type _} [Fintype ι] (b : Basis ι R M) {w : Set M} [Fintype w]
-    (s : span R w = ⊤) : Fintype.card ι ≤ Fintype.card w :=
-  by
+    (s : span R w = ⊤) : Fintype.card ι ≤ Fintype.card w := by
   -- We construct an surjective linear map `(w → R) →ₗ[R] (ι → R)`,
   -- by expressing a linear combination in `w` as a linear combination in `ι`.
   fapply card_le_of_surjective' R
@@ -630,8 +607,7 @@ Another auxiliary lemma for `basis.le_span`, which does not require assuming the
 but still assumes we have a finite spanning set.
 -/
 theorem basis_le_span' {ι : Type _} (b : Basis ι R M) {w : Set M} [Fintype w] (s : span R w = ⊤) :
-    (#ι) ≤ Fintype.card w :=
-  by
+    (#ι) ≤ Fintype.card w := by
   haveI := nontrivial_of_invariantBasisNumber R
   haveI := basisFintypeOfFiniteSpans w s b
   rw [Cardinal.mk_fintype ι]
@@ -644,8 +620,7 @@ theorem basis_le_span' {ι : Type _} (b : Basis ι R M) {w : Set M} [Fintype w] 
 /-- If `R` satisfies the rank condition,
 then the cardinality of any basis is bounded by the cardinality of any spanning set.
 -/
-theorem Basis.le_span {J : Set M} (v : Basis ι R M) (hJ : span R J = ⊤) : (#range v) ≤ (#J) :=
-  by
+theorem Basis.le_span {J : Set M} (v : Basis ι R M) (hJ : span R J = ⊤) : (#range v) ≤ (#J) := by
   haveI := nontrivial_of_invariantBasisNumber R
   cases fintypeOrInfinite J
   · rw [← Cardinal.lift_le, Cardinal.mk_range_eq_of_injective v.injective, Cardinal.mk_fintype J]
@@ -689,8 +664,7 @@ open Submodule
 -- with the additional assumption that the linearly independent family is finite.
 theorem linearIndependent_le_span_aux' {ι : Type _} [Fintype ι] (v : ι → M)
     (i : LinearIndependent R v) (w : Set M) [Fintype w] (s : range v ≤ span R w) :
-    Fintype.card ι ≤ Fintype.card w :=
-  by
+    Fintype.card ι ≤ Fintype.card w := by
   -- We construct an injective linear map `(ι → R) →ₗ[R] (w → R)`,
   -- by thinking of `f : ι → R` as a linear combination of the finite family `v`,
   -- and expressing that (using the axiom of choice) as a linear combination over `w`.
@@ -712,8 +686,7 @@ is itself finite.
 -/
 def linearIndependentFintypeOfLeSpanFintype {ι : Type _} (v : ι → M) (i : LinearIndependent R v)
     (w : Set M) [Fintype w] (s : range v ≤ span R w) : Fintype ι :=
-  fintypeOfFinsetCardLe (Fintype.card w) fun t =>
-    by
+  fintypeOfFinsetCardLe (Fintype.card w) fun t => by
     let v' := fun x : (t : Set ι) => v x
     have i' : LinearIndependent R v' := i.comp _ Subtype.val_injective
     have s' : range v' ≤ span R w := (range_comp_subset_range _ _).trans s
@@ -726,8 +699,7 @@ contained in the span of some finite `w : set M`,
 the cardinality of `ι` is bounded by the cardinality of `w`.
 -/
 theorem linearIndependent_le_span' {ι : Type _} (v : ι → M) (i : LinearIndependent R v) (w : Set M)
-    [Fintype w] (s : range v ≤ span R w) : (#ι) ≤ Fintype.card w :=
-  by
+    [Fintype w] (s : range v ≤ span R w) : (#ι) ≤ Fintype.card w := by
   haveI : Fintype ι := linearIndependentFintypeOfLeSpanFintype v i w s
   rw [Cardinal.mk_fintype]
   simp only [Cardinal.natCast_le]
@@ -740,8 +712,7 @@ and any finite spanning set `w : set M`,
 the cardinality of `ι` is bounded by the cardinality of `w`.
 -/
 theorem linearIndependent_le_span {ι : Type _} (v : ι → M) (i : LinearIndependent R v) (w : Set M)
-    [Fintype w] (s : span R w = ⊤) : (#ι) ≤ Fintype.card w :=
-  by
+    [Fintype w] (s : span R w = ⊤) : (#ι) ≤ Fintype.card w := by
   apply linearIndependent_le_span' v i w
   rw [s]
   exact le_top
@@ -751,16 +722,14 @@ theorem linearIndependent_le_span {ι : Type _} (v : ι → M) (i : LinearIndepe
 we handle the case where the basis `b` is infinite.
 -/
 theorem linearIndependent_le_infinite_basis {ι : Type _} (b : Basis ι R M) [Infinite ι] {κ : Type _}
-    (v : κ → M) (i : LinearIndependent R v) : (#κ) ≤ (#ι) :=
-  by
+    (v : κ → M) (i : LinearIndependent R v) : (#κ) ≤ (#ι) := by
   by_contra
   rw [not_le, ← Cardinal.mk_finset_of_infinite ι] at h
   let Φ := fun k : κ => (b.repr (v k)).support
   obtain ⟨s, w : Infinite ↥(Φ ⁻¹' {s})⟩ := Cardinal.exists_infinite_fiber Φ h (by infer_instance)
   let v' := fun k : Φ ⁻¹' {s} => v k
   have i' : LinearIndependent R v' := i.comp _ Subtype.val_injective
-  have w' : Fintype (Φ ⁻¹' {s}) :=
-    by
+  have w' : Fintype (Φ ⁻¹' {s}) := by
     apply linearIndependentFintypeOfLeSpanFintype v' i' (s.image b)
     rintro m ⟨⟨p, ⟨rfl⟩⟩, rfl⟩
     simp only [SetLike.mem_coe, Subtype.coe_mk, Finset.coe_image]
@@ -774,8 +743,7 @@ and `s` is a linearly independent set,
 then the cardinality of `s` is bounded by the cardinality of `b`.
 -/
 theorem linearIndependent_le_basis {ι : Type _} (b : Basis ι R M) {κ : Type _} (v : κ → M)
-    (i : LinearIndependent R v) : (#κ) ≤ (#ι) :=
-  by
+    (i : LinearIndependent R v) : (#κ) ≤ (#ι) := by
   -- We split into cases depending on whether `ι` is infinite.
     cases fintypeOrInfinite ι <;>
     skip
@@ -803,16 +771,14 @@ This proof (along with some of the lemmas above) comes from
 [Les familles libres maximales d'un module ont-elles le meme cardinal?][lazarus1973]
 -/
 theorem maximal_linearIndependent_eq_infinite_basis {ι : Type _} (b : Basis ι R M) [Infinite ι]
-    {κ : Type _} (v : κ → M) (i : LinearIndependent R v) (m : i.Maximal) : (#κ) = (#ι) :=
-  by
+    {κ : Type _} (v : κ → M) (i : LinearIndependent R v) (m : i.Maximal) : (#κ) = (#ι) := by
   apply le_antisymm
   · exact linearIndependent_le_basis b v i
   · haveI : Nontrivial R := nontrivial_of_invariantBasisNumber R
     exact infinite_basis_le_maximal_linearIndependent b v i m
 #align maximal_linear_independent_eq_infinite_basis maximal_linearIndependent_eq_infinite_basis
 
-theorem Basis.mk_eq_rank'' {ι : Type v} (v : Basis ι R M) : (#ι) = Module.rank R M :=
-  by
+theorem Basis.mk_eq_rank'' {ι : Type v} (v : Basis ι R M) : (#ι) = Module.rank R M := by
   haveI := nontrivial_of_invariantBasisNumber R
   rw [Module.rank]
   apply le_antisymm
@@ -837,16 +803,14 @@ theorem Basis.mk_range_eq_rank (v : Basis ι R M) : (#range v) = Module.rank R M
 /-- If a vector space has a finite basis, then its dimension (seen as a cardinal) is equal to the
 cardinality of the basis. -/
 theorem rank_eq_card_basis {ι : Type w} [Fintype ι] (h : Basis ι R M) :
-    Module.rank R M = Fintype.card ι :=
-  by
+    Module.rank R M = Fintype.card ι := by
   haveI := nontrivial_of_invariantBasisNumber R
   rw [← h.mk_range_eq_rank, Cardinal.mk_fintype, Set.card_range_of_injective h.injective]
 #align rank_eq_card_basis rank_eq_card_basis
 
 theorem Basis.card_le_card_of_linearIndependent {ι : Type _} [Fintype ι] (b : Basis ι R M)
     {ι' : Type _} [Fintype ι'] {v : ι' → M} (hv : LinearIndependent R v) :
-    Fintype.card ι' ≤ Fintype.card ι :=
-  by
+    Fintype.card ι' ≤ Fintype.card ι := by
   letI := nontrivial_of_invariantBasisNumber R
   simpa [rank_eq_card_basis b, Cardinal.mk_fintype] using
     cardinal_lift_le_rank_of_linear_independent' hv
@@ -864,8 +828,7 @@ theorem Basis.card_le_card_of_le {N O : Submodule R M} (hNO : N ≤ O) [Fintype 
 #align basis.card_le_card_of_le Basis.card_le_card_of_le
 
 theorem Basis.mk_eq_rank (v : Basis ι R M) :
-    Cardinal.lift.{v} (#ι) = Cardinal.lift.{w} (Module.rank R M) :=
-  by
+    Cardinal.lift.{v} (#ι) = Cardinal.lift.{w} (Module.rank R M) := by
   haveI := nontrivial_of_invariantBasisNumber R
   rw [← v.mk_range_eq_rank, Cardinal.mk_range_eq_of_injective v.injective]
 #align basis.mk_eq_rank Basis.mk_eq_rank
@@ -895,16 +858,14 @@ theorem Basis.finite_index_of_rank_lt_aleph0 {ι : Type _} {s : Set ι} (b : Bas
 #align basis.finite_index_of_rank_lt_aleph_0 Basis.finite_index_of_rank_lt_aleph0
 
 theorem rank_span {v : ι → M} (hv : LinearIndependent R v) :
-    Module.rank R ↥(span R (range v)) = (#range v) :=
-  by
+    Module.rank R ↥(span R (range v)) = (#range v) := by
   haveI := nontrivial_of_invariantBasisNumber R
   rw [← Cardinal.lift_inj, ← (Basis.span hv).mk_eq_rank,
     Cardinal.mk_range_eq_of_injective (@LinearIndependent.injective ι R M v _ _ _ _ hv)]
 #align rank_span rank_span
 
 theorem rank_span_set {s : Set M} (hs : LinearIndependent R (fun x => x : s → M)) :
-    Module.rank R ↥(span R s) = (#s) :=
-  by
+    Module.rank R ↥(span R s) = (#s) := by
   rw [← @set_of_mem_eq _ s, ← Subtype.range_coe_subtype]
   exact rank_span hs
 #align rank_span_set rank_span_set
@@ -926,11 +887,9 @@ then the rank of an ideal `I` of `S` over `R` is the same as the rank of `S`.
 -/
 theorem Ideal.rank_eq {R S : Type _} [CommRing R] [StrongRankCondition R] [Ring S] [IsDomain S]
     [Algebra R S] {n m : Type _} [Fintype n] [Fintype m] (b : Basis n R S) {I : Ideal S}
-    (hI : I ≠ ⊥) (c : Basis m R I) : Fintype.card m = Fintype.card n :=
-  by
+    (hI : I ≠ ⊥) (c : Basis m R I) : Fintype.card m = Fintype.card n := by
   obtain ⟨a, ha⟩ := Submodule.nonzero_mem_of_bot_lt (bot_lt_iff_ne_bot.mpr hI)
-  have : LinearIndependent R fun i => b i • a :=
-    by
+  have : LinearIndependent R fun i => b i • a := by
     have hb := b.linear_independent
     rw [Fintype.linearIndependent_iff] at hb⊢
     intro g hg
@@ -984,8 +943,7 @@ open Cardinal
 /-- Two vector spaces are isomorphic if they have the same dimension. -/
 theorem nonempty_linearEquiv_of_lift_rank_eq
     (cond : Cardinal.lift.{v'} (Module.rank K V) = Cardinal.lift.{v} (Module.rank K V')) :
-    Nonempty (V ≃ₗ[K] V') :=
-  by
+    Nonempty (V ≃ₗ[K] V') := by
   obtain ⟨⟨_, B⟩⟩ := Module.Free.exists_basis K V
   obtain ⟨⟨_, B'⟩⟩ := Module.Free.exists_basis K V'
   have : Cardinal.lift.{v', v} (#_) = Cardinal.lift.{v, v'} (#_) := by
@@ -1034,8 +992,7 @@ theorem LinearEquiv.nonempty_equiv_iff_rank_eq :
 @[simp]
 theorem rank_prod :
     Module.rank K (V × V') =
-      Cardinal.lift.{v'} (Module.rank K V) + Cardinal.lift.{v, v'} (Module.rank K V') :=
-  by
+      Cardinal.lift.{v'} (Module.rank K V) + Cardinal.lift.{v, v'} (Module.rank K V') := by
   simpa [rank_eq_card_choose_basis_index K V, rank_eq_card_choose_basis_index K V', lift_umax,
     lift_umax'] using ((choose_basis K V).Prod (choose_basis K V')).mk_eq_rank.symm
 #align rank_prod rank_prod
@@ -1085,8 +1042,7 @@ end Fintype
 
 -- TODO: merge with the `finrank` content
 /-- An `n`-dimensional `K`-vector space is equivalent to `fin n → K`. -/
-def finDimVectorspaceEquiv (n : ℕ) (hn : Module.rank K V = n) : V ≃ₗ[K] Fin n → K :=
-  by
+def finDimVectorspaceEquiv (n : ℕ) (hn : Module.rank K V = n) : V ≃ₗ[K] Fin n → K := by
   haveI := nontrivial_of_invariantBasisNumber K
   have : Cardinal.lift.{u} (n : Cardinal.{v}) = Cardinal.lift.{v} (n : Cardinal.{u}) := by simp
   have hn := Cardinal.lift_inj.{v, u}.2 hn
@@ -1119,8 +1075,7 @@ theorem Basis.finite_ofVectorSpaceIndex_of_rank_lt_aleph0 (h : Module.rank K V <
 -- TODO how far can we generalise this?
 -- When `s` is finite, we could prove this for any ring satisfying the strong rank condition
 -- using `linear_independent_le_span'`
-theorem rank_span_le (s : Set V) : Module.rank K (span K s) ≤ (#s) :=
-  by
+theorem rank_span_le (s : Set V) : Module.rank K (span K s) ≤ (#s) := by
   obtain ⟨b, hb, hsab, hlib⟩ := exists_linearIndependent K s
   convert Cardinal.mk_le_mk_of_subset hb
   rw [← hsab, rank_span_set hlib]
@@ -1143,8 +1098,7 @@ theorem rank_quotient_add_rank (p : Submodule K V) :
 
 /-- rank-nullity theorem -/
 theorem rank_range_add_rank_ker (f : V →ₗ[K] V₁) :
-    Module.rank K f.range + Module.rank K f.ker = Module.rank K V :=
-  by
+    Module.rank K f.range + Module.rank K f.ker = Module.rank K V := by
   haveI := fun p : Submodule K V => Classical.decEq (V ⧸ p)
   rw [← f.quot_ker_equiv_range.rank_eq, rank_quotient_add_rank]
 #align rank_range_add_rank_ker rank_range_add_rank_ker
@@ -1166,8 +1120,7 @@ open LinearMap
 theorem rank_add_rank_split (db : V₂ →ₗ[K] V) (eb : V₃ →ₗ[K] V) (cd : V₁ →ₗ[K] V₂)
     (ce : V₁ →ₗ[K] V₃) (hde : ⊤ ≤ db.range ⊔ eb.range) (hgd : ker cd = ⊥)
     (eq : db.comp cd = eb.comp ce) (eq₂ : ∀ d e, db d = eb e → ∃ c, cd c = d ∧ ce c = e) :
-    Module.rank K V + Module.rank K V₁ = Module.rank K V₂ + Module.rank K V₃ :=
-  by
+    Module.rank K V + Module.rank K V₁ = Module.rank K V₂ + Module.rank K V₃ := by
   have hf : Surjective (coprod db eb) := by rwa [← range_eq_top, range_coprod, eq_top_iff]
   conv =>
     rhs
@@ -1210,8 +1163,7 @@ theorem Submodule.rank_sup_add_rank_inf_eq (s t : Submodule K V) :
 #align submodule.rank_sup_add_rank_inf_eq Submodule.rank_sup_add_rank_inf_eq
 
 theorem Submodule.rank_add_le_rank_add_rank (s t : Submodule K V) :
-    Module.rank K (s ⊔ t : Submodule K V) ≤ Module.rank K s + Module.rank K t :=
-  by
+    Module.rank K (s ⊔ t : Submodule K V) ≤ Module.rank K s + Module.rank K t := by
   rw [← Submodule.rank_sup_add_rank_inf_eq]
   exact self_le_add_right _ _
 #align submodule.rank_add_le_rank_add_rank Submodule.rank_add_le_rank_add_rank
@@ -1242,8 +1194,7 @@ theorem Basis.ofRankEqZero_apply {ι : Type _} [IsEmpty ι] (hV : Module.rank K 
 #align basis.of_rank_eq_zero_apply Basis.ofRankEqZero_apply
 
 theorem le_rank_iff_exists_linearIndependent {c : Cardinal} :
-    c ≤ Module.rank K V ↔ ∃ s : Set V, (#s) = c ∧ LinearIndependent K (coe : s → V) :=
-  by
+    c ≤ Module.rank K V ↔ ∃ s : Set V, (#s) = c ∧ LinearIndependent K (coe : s → V) := by
   constructor
   · intro h
     let t := Basis.ofVectorSpace K V
@@ -1256,8 +1207,7 @@ theorem le_rank_iff_exists_linearIndependent {c : Cardinal} :
 
 theorem le_rank_iff_exists_linearIndependent_finset {n : ℕ} :
     ↑n ≤ Module.rank K V ↔
-      ∃ s : Finset V, s.card = n ∧ LinearIndependent K (coe : (s : Set V) → V) :=
-  by
+      ∃ s : Finset V, s.card = n ∧ LinearIndependent K (coe : (s : Set V) → V) := by
   simp only [le_rank_iff_exists_linearIndependent, Cardinal.mk_set_eq_nat_iff_finset]
   constructor
   · rintro ⟨s, ⟨t, rfl, rfl⟩, si⟩
@@ -1268,8 +1218,7 @@ theorem le_rank_iff_exists_linearIndependent_finset {n : ℕ} :
 
 /-- A vector space has dimension at most `1` if and only if there is a
 single vector of which all vectors are multiples. -/
-theorem rank_le_one_iff : Module.rank K V ≤ 1 ↔ ∃ v₀ : V, ∀ v, ∃ r : K, r • v₀ = v :=
-  by
+theorem rank_le_one_iff : Module.rank K V ≤ 1 ↔ ∃ v₀ : V, ∀ v, ∃ r : K, r • v₀ = v := by
   let b := Basis.ofVectorSpace K V
   constructor
   · intro hd
@@ -1297,8 +1246,7 @@ theorem rank_le_one_iff : Module.rank K V ≤ 1 ↔ ∃ v₀ : V, ∀ v, ∃ r :
 single vector in the submodule such that the submodule is contained in
 its span. -/
 theorem rank_submodule_le_one_iff (s : Submodule K V) :
-    Module.rank K s ≤ 1 ↔ ∃ v₀ ∈ s, s ≤ K ∙ v₀ :=
-  by
+    Module.rank K s ≤ 1 ↔ ∃ v₀ ∈ s, s ≤ K ∙ v₀ := by
   simp_rw [rank_le_one_iff, le_span_singleton_iff]
   constructor
   · rintro ⟨⟨v₀, hv₀⟩, h⟩
@@ -1341,8 +1289,7 @@ theorem rank_submodule_le_one_iff' (s : Submodule K V) : Module.rank K s ≤ 1 �
 #align rank_submodule_le_one_iff' rank_submodule_le_one_iff'
 
 theorem Submodule.rank_le_one_iff_isPrincipal (W : Submodule K V) :
-    Module.rank K W ≤ 1 ↔ W.IsPrincipal :=
-  by
+    Module.rank K W ≤ 1 ↔ W.IsPrincipal := by
   simp only [rank_le_one_iff, Submodule.isPrincipal_iff, le_antisymm_iff, le_span_singleton_iff,
     span_singleton_le_iff_mem]
   constructor
@@ -1390,8 +1337,7 @@ theorem rank_zero [Nontrivial K] : rank (0 : V →ₗ[K] V') = 0 := by
 
 variable [AddCommGroup V''] [Module K V'']
 
-theorem rank_comp_le1 (g : V →ₗ[K] V') (f : V' →ₗ[K] V'') : rank (f.comp g) ≤ rank f :=
-  by
+theorem rank_comp_le1 (g : V →ₗ[K] V') (f : V' →ₗ[K] V'') : rank (f.comp g) ≤ rank f := by
   refine' rank_le_of_submodule _ _ _
   rw [LinearMap.range_comp]
   exact LinearMap.map_le_range
@@ -1411,16 +1357,14 @@ variable [DivisionRing K] [AddCommGroup V] [Module K V] [AddCommGroup V₁] [Mod
 
 variable [AddCommGroup V'] [Module K V']
 
-theorem rank_le_domain (f : V →ₗ[K] V₁) : rank f ≤ Module.rank K V :=
-  by
+theorem rank_le_domain (f : V →ₗ[K] V₁) : rank f ≤ Module.rank K V := by
   rw [← rank_range_add_rank_ker f]
   exact self_le_add_right _ _
 #align linear_map.rank_le_domain LinearMap.rank_le_domain
 
 theorem rank_add_le (f g : V →ₗ[K] V') : rank (f + g) ≤ rank f + rank g :=
   calc
-    rank (f + g) ≤ Module.rank K (f.range ⊔ g.range : Submodule K V') :=
-      by
+    rank (f + g) ≤ Module.rank K (f.range ⊔ g.range : Submodule K V') := by
       refine' rank_le_of_submodule _ _ _
       exact
         LinearMap.range_le_iff_comap.2 <|
@@ -1440,8 +1384,7 @@ theorem rank_finset_sum_le {η} (s : Finset η) (f : η → V →ₗ[K] V') :
 theorem le_rank_iff_exists_linearIndependent {c : Cardinal} {f : V →ₗ[K] V'} :
     c ≤ rank f ↔
       ∃ s : Set V,
-        Cardinal.lift.{v'} (#s) = Cardinal.lift.{v} c ∧ LinearIndependent K fun x : s => f x :=
-  by
+        Cardinal.lift.{v'} (#s) = Cardinal.lift.{v} c ∧ LinearIndependent K fun x : s => f x := by
   rcases f.range_restrict.exists_right_inverse_of_surjective f.range_range_restrict with ⟨g, hg⟩
   have fg : left_inverse f.range_restrict g := LinearMap.congr_fun hg
   refine' ⟨fun h => _, _⟩
@@ -1462,8 +1405,7 @@ theorem le_rank_iff_exists_linearIndependent {c : Cardinal} {f : V →ₗ[K] V'}
 #align linear_map.le_rank_iff_exists_linear_independent LinearMap.le_rank_iff_exists_linearIndependent
 
 theorem le_rank_iff_exists_linearIndependent_finset {n : ℕ} {f : V →ₗ[K] V'} :
-    ↑n ≤ rank f ↔ ∃ s : Finset V, s.card = n ∧ LinearIndependent K fun x : (s : Set V) => f x :=
-  by
+    ↑n ≤ rank f ↔ ∃ s : Finset V, s.card = n ∧ LinearIndependent K fun x : (s : Set V) => f x := by
   simp only [le_rank_iff_exists_linearIndependent, Cardinal.lift_natCast, Cardinal.lift_eq_nat_iff,
     Cardinal.mk_set_eq_nat_iff_finset]
   constructor

--- a/Mathlib/LinearAlgebra/Dimension.lean
+++ b/Mathlib/LinearAlgebra/Dimension.lean
@@ -255,11 +255,11 @@ theorem rank_quotient_le (p : Submodule R M) : Module.rank R (M ⧸ p) ≤ Modul
 
 variable [Nontrivial R]
 
-theorem cardinal_lift_le_rank_of_linearIndependent.{m} {ι : Type w} {v : ι → M}
+theorem cardinal_lift_le_rank_of_linearIndependent {ι : Type w} {v : ι → M}
     (hv : LinearIndependent R v) :
-    Cardinal.lift.{max v m} (#ι) ≤ Cardinal.lift.{max w m} (Module.rank R M) := by
+    Cardinal.lift.{v} (#ι) ≤ Cardinal.lift.{w} (Module.rank R M) := by
   apply le_trans
-  · exact Cardinal.lift_mk_le.mpr ⟨(Equiv.ofInjective _ hv.injective).toEmbedding⟩
+  · exact Cardinal.lift_mk_le'.mpr ⟨(Equiv.ofInjective _ hv.injective).toEmbedding⟩
   · simp only [Cardinal.lift_le, Module.rank]
     apply le_trans
     swap
@@ -269,7 +269,7 @@ theorem cardinal_lift_le_rank_of_linearIndependent.{m} {ι : Type w} {v : ι →
 
 theorem cardinal_lift_le_rank_of_linearIndependent' {ι : Type w} {v : ι → M}
     (hv : LinearIndependent R v) : Cardinal.lift.{v} (#ι) ≤ Cardinal.lift.{w} (Module.rank R M) :=
-  cardinal_lift_le_rank_of_linearIndependent.{u, v, w, 0} hv
+  cardinal_lift_le_rank_of_linearIndependent hv
 #align cardinal_lift_le_rank_of_linear_independent' cardinal_lift_le_rank_of_linearIndependent'
 
 theorem cardinal_le_rank_of_linearIndependent {ι : Type v} {v : ι → M}
@@ -582,7 +582,7 @@ theorem mk_eq_mk_of_basis (v : Basis ι R M) (v' : Basis ι' R M) :
 /-- Given two bases indexed by `ι` and `ι'` of an `R`-module, where `R` satisfies the invariant
 basis number property, an equiv `ι ≃ ι' `. -/
 def Basis.indexEquiv (v : Basis ι R M) (v' : Basis ι' R M) : ι ≃ ι' :=
-  Nonempty.some (Cardinal.lift_mk_eq.1 (Cardinal.lift_umax_eq.2 (mk_eq_mk_of_basis v v')))
+  (Cardinal.lift_mk_eq'.1 <| mk_eq_mk_of_basis v v').some
 #align basis.index_equiv Basis.indexEquiv
 
 theorem mk_eq_mk_of_basis' {ι' : Type w} (v : Basis ι R M) (v' : Basis ι' R M) : (#ι) = (#ι') :=
@@ -1147,11 +1147,11 @@ theorem rank_add_rank_split (db : V₂ →ₗ[K] V) (eb : V₃ →ₗ[K] V) (cd 
   congr 1
   apply LinearEquiv.rank_eq
   refine' LinearEquiv.ofBijective _ ⟨_, _⟩
-  · refine' LinearMap.codRestrict _ (Prod cd (-ce)) _
+  · refine' LinearMap.codRestrict _ (prod cd (-ce)) _
     · intro c
       simp only [add_eq_zero_iff_eq_neg, LinearMap.prod_apply, mem_ker, Pi.prod, coprod_apply,
         neg_neg, map_neg, neg_apply]
-      exact LinearMap.ext_iff.1 Eq c
+      exact LinearMap.ext_iff.1 eq c
   · rw [← ker_eq_bot, ker_codRestrict, ker_prod, hgd, bot_inf_eq]
   · rw [← range_eq_top, eq_top_iff, range_codRestrict, ← map_le_iff_le_comap, Submodule.map_top,
       range_subtype]
@@ -1427,7 +1427,7 @@ theorem le_rank_iff_exists_linearIndependent {c : Cardinal} {f : V →ₗ[K] V'}
       LinearIndependent.of_comp f.range.subtype (by convert si)
     convert cardinal_le_rank_of_linearIndependent this.image
     rw [← Cardinal.lift_inj, ← hsc, Cardinal.mk_image_eq_of_injOn_lift]
-    exact inj_on_iff_injective.2 this.injective
+    exact injOn_iff_injective.2 this.injective
 #align linear_map.le_rank_iff_exists_linear_independent LinearMap.le_rank_iff_exists_linearIndependent
 
 set_option synthInstance.etaExperiment true in -- Porting note: gets around lean4#2074

--- a/Mathlib/LinearAlgebra/Dimension.lean
+++ b/Mathlib/LinearAlgebra/Dimension.lean
@@ -1,0 +1,1479 @@
+/-
+Copyright (c) 2018 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro, Johannes Hölzl, Sander Dahmen, Scott Morrison
+
+! This file was ported from Lean 3 source module linear_algebra.dimension
+! leanprover-community/mathlib commit 3a2039ad20626aebbece10cddb18ef010f7d912d
+! Please do not edit these lines, except to modify the commit id
+! if you have ported upstream changes.
+-/
+import Mathbin.Algebra.Module.BigOperators
+import Mathbin.LinearAlgebra.Dfinsupp
+import Mathbin.LinearAlgebra.FreeModule.Basic
+import Mathbin.LinearAlgebra.InvariantBasisNumber
+import Mathbin.LinearAlgebra.Isomorphisms
+import Mathbin.LinearAlgebra.StdBasis
+import Mathbin.SetTheory.Cardinal.Cofinality
+
+/-!
+# Dimension of modules and vector spaces
+
+## Main definitions
+
+* The rank of a module is defined as `module.rank : cardinal`.
+  This is defined as the supremum of the cardinalities of linearly independent subsets.
+
+* The rank of a linear map is defined as the rank of its range.
+
+## Main statements
+
+* `linear_map.rank_le_of_injective`: the source of an injective linear map has dimension
+  at most that of the target.
+* `linear_map.rank_le_of_surjective`: the target of a surjective linear map has dimension
+  at most that of that source.
+* `basis_fintype_of_finite_spans`:
+  the existence of a finite spanning set implies that any basis is finite.
+* `infinite_basis_le_maximal_linear_independent`:
+  if `b` is an infinite basis for a module `M`,
+  and `s` is a maximal linearly independent set,
+  then the cardinality of `b` is bounded by the cardinality of `s`.
+
+For modules over rings satisfying the rank condition
+
+* `basis.le_span`:
+  the cardinality of a basis is bounded by the cardinality of any spanning set
+
+For modules over rings satisfying the strong rank condition
+
+* `linear_independent_le_span`:
+  For any linearly independent family `v : ι → M`
+  and any finite spanning set `w : set M`,
+  the cardinality of `ι` is bounded by the cardinality of `w`.
+* `linear_independent_le_basis`:
+  If `b` is a basis for a module `M`,
+  and `s` is a linearly independent set,
+  then the cardinality of `s` is bounded by the cardinality of `b`.
+
+For modules over rings with invariant basis number
+(including all commutative rings and all noetherian rings)
+
+* `mk_eq_mk_of_basis`: the dimension theorem, any two bases of the same vector space have the same
+  cardinality.
+
+For vector spaces (i.e. modules over a field), we have
+
+* `rank_quotient_add_rank`: if `V₁` is a submodule of `V`, then
+  `module.rank (V/V₁) + module.rank V₁ = module.rank V`.
+* `rank_range_add_rank_ker`: the rank-nullity theorem.
+
+## Implementation notes
+
+Many theorems in this file are not universe-generic when they relate dimensions
+in different universes. They should be as general as they can be without
+inserting `lift`s. The types `V`, `V'`, ... all live in different universes,
+and `V₁`, `V₂`, ... all live in the same universe.
+-/
+
+
+noncomputable section
+
+universe u v v' v'' u₁' w w'
+
+variable {K : Type u} {V V₁ V₂ V₃ : Type v} {V' V'₁ : Type v'} {V'' : Type v''}
+
+variable {ι : Type w} {ι' : Type w'} {η : Type u₁'} {φ : η → Type _}
+
+open Classical BigOperators Cardinal
+
+open Basis Submodule Function Set
+
+section Module
+
+section
+
+variable [Semiring K] [AddCommMonoid V] [Module K V]
+
+include K
+
+variable (K V)
+
+/-- The rank of a module, defined as a term of type `cardinal`.
+
+We define this as the supremum of the cardinalities of linearly independent subsets.
+
+For a free module over any ring satisfying the strong rank condition
+(e.g. left-noetherian rings, commutative rings, and in particular division rings and fields),
+this is the same as the dimension of the space (i.e. the cardinality of any basis).
+
+In particular this agrees with the usual notion of the dimension of a vector space.
+
+The definition is marked as protected to avoid conflicts with `_root_.rank`,
+the rank of a linear map.
+-/
+protected irreducible_def Module.rank : Cardinal :=
+  ⨆ ι : { s : Set V // LinearIndependent K (coe : s → V) }, #ι.1
+#align module.rank Module.rank
+
+end
+
+section
+
+variable {R : Type u} [Ring R]
+
+variable {M : Type v} [AddCommGroup M] [Module R M]
+
+variable {M' : Type v'} [AddCommGroup M'] [Module R M']
+
+variable {M₁ : Type v} [AddCommGroup M₁] [Module R M₁]
+
+theorem LinearMap.lift_rank_le_of_injective (f : M →ₗ[R] M') (i : Injective f) :
+    Cardinal.lift.{v'} (Module.rank R M) ≤ Cardinal.lift.{v} (Module.rank R M') :=
+  by
+  dsimp [Module.rank]
+  rw [Cardinal.lift_supᵢ (Cardinal.bddAbove_range.{v', v'} _),
+    Cardinal.lift_supᵢ (Cardinal.bddAbove_range.{v, v} _)]
+  apply csupᵢ_mono' (Cardinal.bddAbove_range.{v', v} _)
+  rintro ⟨s, li⟩
+  refine' ⟨⟨f '' s, _⟩, cardinal.lift_mk_le'.mpr ⟨(Equiv.Set.image f s i).toEmbedding⟩⟩
+  exact (li.map' _ <| linear_map.ker_eq_bot.mpr i).image
+#align linear_map.lift_rank_le_of_injective LinearMap.lift_rank_le_of_injective
+
+theorem LinearMap.rank_le_of_injective (f : M →ₗ[R] M₁) (i : Injective f) :
+    Module.rank R M ≤ Module.rank R M₁ :=
+  Cardinal.lift_le.1 (f.lift_rank_le_of_injective i)
+#align linear_map.rank_le_of_injective LinearMap.rank_le_of_injective
+
+theorem rank_le {n : ℕ}
+    (H : ∀ s : Finset M, (LinearIndependent R fun i : s => (i : M)) → s.card ≤ n) :
+    Module.rank R M ≤ n := by
+  rw [Module.rank]
+  apply csupᵢ_le'
+  rintro ⟨s, li⟩
+  exact linearIndependent_bounded_of_finset_linearIndependent_bounded H _ li
+#align rank_le rank_le
+
+theorem lift_rank_range_le (f : M →ₗ[R] M') :
+    Cardinal.lift.{v} (Module.rank R f.range) ≤ Cardinal.lift.{v'} (Module.rank R M) :=
+  by
+  dsimp [Module.rank]
+  rw [Cardinal.lift_supᵢ (Cardinal.bddAbove_range.{v', v'} _)]
+  apply csupᵢ_le'
+  rintro ⟨s, li⟩
+  apply le_trans
+  swap
+  apply cardinal.lift_le.mpr
+  refine' le_csupᵢ (Cardinal.bddAbove_range.{v, v} _) ⟨range_splitting f '' s, _⟩
+  · apply LinearIndependent.of_comp f.range_restrict
+    convert li.comp (Equiv.Set.rangeSplittingImageEquiv f s) (Equiv.injective _) using 1
+  · exact (cardinal.lift_mk_eq'.mpr ⟨Equiv.Set.rangeSplittingImageEquiv f s⟩).ge
+#align lift_rank_range_le lift_rank_range_le
+
+theorem rank_range_le (f : M →ₗ[R] M₁) : Module.rank R f.range ≤ Module.rank R M := by
+  simpa using lift_rank_range_le f
+#align rank_range_le rank_range_le
+
+theorem lift_rank_map_le (f : M →ₗ[R] M') (p : Submodule R M) :
+    Cardinal.lift.{v} (Module.rank R (p.map f)) ≤ Cardinal.lift.{v'} (Module.rank R p) :=
+  by
+  have h := lift_rank_range_le (f.comp (Submodule.subtype p))
+  rwa [LinearMap.range_comp, range_subtype] at h
+#align lift_rank_map_le lift_rank_map_le
+
+theorem rank_map_le (f : M →ₗ[R] M₁) (p : Submodule R M) :
+    Module.rank R (p.map f) ≤ Module.rank R p := by simpa using lift_rank_map_le f p
+#align rank_map_le rank_map_le
+
+theorem rank_le_of_submodule (s t : Submodule R M) (h : s ≤ t) :
+    Module.rank R s ≤ Module.rank R t :=
+  (ofLe h).rank_le_of_injective fun ⟨x, hx⟩ ⟨y, hy⟩ eq =>
+    Subtype.eq <| show x = y from Subtype.ext_iff_val.1 Eq
+#align rank_le_of_submodule rank_le_of_submodule
+
+/-- Two linearly equivalent vector spaces have the same dimension, a version with different
+universes. -/
+theorem LinearEquiv.lift_rank_eq (f : M ≃ₗ[R] M') :
+    Cardinal.lift.{v'} (Module.rank R M) = Cardinal.lift.{v} (Module.rank R M') :=
+  by
+  apply le_antisymm
+  · exact f.to_linear_map.lift_rank_le_of_injective f.injective
+  · exact f.symm.to_linear_map.lift_rank_le_of_injective f.symm.injective
+#align linear_equiv.lift_rank_eq LinearEquiv.lift_rank_eq
+
+/-- Two linearly equivalent vector spaces have the same dimension. -/
+theorem LinearEquiv.rank_eq (f : M ≃ₗ[R] M₁) : Module.rank R M = Module.rank R M₁ :=
+  Cardinal.lift_inj.1 f.lift_rank_eq
+#align linear_equiv.rank_eq LinearEquiv.rank_eq
+
+theorem rank_eq_of_injective (f : M →ₗ[R] M₁) (h : Injective f) :
+    Module.rank R M = Module.rank R f.range :=
+  (LinearEquiv.ofInjective f h).rank_eq
+#align rank_eq_of_injective rank_eq_of_injective
+
+/-- Pushforwards of submodules along a `linear_equiv` have the same dimension. -/
+theorem LinearEquiv.rank_map_eq (f : M ≃ₗ[R] M₁) (p : Submodule R M) :
+    Module.rank R (p.map (f : M →ₗ[R] M₁)) = Module.rank R p :=
+  (f.submoduleMap p).rank_eq.symm
+#align linear_equiv.rank_map_eq LinearEquiv.rank_map_eq
+
+variable (R M)
+
+@[simp]
+theorem rank_top : Module.rank R (⊤ : Submodule R M) = Module.rank R M :=
+  by
+  have : (⊤ : Submodule R M) ≃ₗ[R] M := LinearEquiv.ofTop ⊤ rfl
+  rw [this.rank_eq]
+#align rank_top rank_top
+
+variable {R M}
+
+theorem rank_range_of_surjective (f : M →ₗ[R] M') (h : Surjective f) :
+    Module.rank R f.range = Module.rank R M' := by rw [LinearMap.range_eq_top.2 h, rank_top]
+#align rank_range_of_surjective rank_range_of_surjective
+
+theorem rank_submodule_le (s : Submodule R M) : Module.rank R s ≤ Module.rank R M :=
+  by
+  rw [← rank_top R M]
+  exact rank_le_of_submodule _ _ le_top
+#align rank_submodule_le rank_submodule_le
+
+theorem LinearMap.rank_le_of_surjective (f : M →ₗ[R] M₁) (h : Surjective f) :
+    Module.rank R M₁ ≤ Module.rank R M :=
+  by
+  rw [← rank_range_of_surjective f h]
+  apply rank_range_le
+#align linear_map.rank_le_of_surjective LinearMap.rank_le_of_surjective
+
+theorem rank_quotient_le (p : Submodule R M) : Module.rank R (M ⧸ p) ≤ Module.rank R M :=
+  (mkQ p).rank_le_of_surjective (surjective_quot_mk _)
+#align rank_quotient_le rank_quotient_le
+
+variable [Nontrivial R]
+
+theorem cardinal_lift_le_rank_of_linearIndependent.{m} {ι : Type w} {v : ι → M}
+    (hv : LinearIndependent R v) :
+    Cardinal.lift.{max v m} (#ι) ≤ Cardinal.lift.{max w m} (Module.rank R M) :=
+  by
+  apply le_trans
+  · exact cardinal.lift_mk_le.mpr ⟨(Equiv.ofInjective _ hv.injective).toEmbedding⟩
+  · simp only [Cardinal.lift_le, Module.rank]
+    apply le_trans
+    swap
+    exact le_csupᵢ (Cardinal.bddAbove_range.{v, v} _) ⟨range v, hv.coe_range⟩
+    exact le_rfl
+#align cardinal_lift_le_rank_of_linear_independent cardinal_lift_le_rank_of_linearIndependent
+
+theorem cardinal_lift_le_rank_of_linear_independent' {ι : Type w} {v : ι → M}
+    (hv : LinearIndependent R v) : Cardinal.lift.{v} (#ι) ≤ Cardinal.lift.{w} (Module.rank R M) :=
+  cardinal_lift_le_rank_of_linearIndependent.{u, v, w, 0} hv
+#align cardinal_lift_le_rank_of_linear_independent' cardinal_lift_le_rank_of_linear_independent'
+
+theorem cardinal_le_rank_of_linearIndependent {ι : Type v} {v : ι → M}
+    (hv : LinearIndependent R v) : (#ι) ≤ Module.rank R M := by
+  simpa using cardinal_lift_le_rank_of_linearIndependent hv
+#align cardinal_le_rank_of_linear_independent cardinal_le_rank_of_linearIndependent
+
+theorem cardinal_le_rank_of_linear_independent' {s : Set M}
+    (hs : LinearIndependent R (fun x => x : s → M)) : (#s) ≤ Module.rank R M :=
+  cardinal_le_rank_of_linearIndependent hs
+#align cardinal_le_rank_of_linear_independent' cardinal_le_rank_of_linear_independent'
+
+variable (R M)
+
+@[simp]
+theorem rank_pUnit : Module.rank R PUnit = 0 :=
+  by
+  apply le_bot_iff.mp
+  rw [Module.rank]
+  apply csupᵢ_le'
+  rintro ⟨s, li⟩
+  apply le_bot_iff.mpr
+  apply cardinal.mk_emptyc_iff.mpr
+  simp only [Subtype.coe_mk]
+  by_contra h
+  obtain ⟨a, ha⟩ := nonempty_iff_ne_empty.2 h
+  simpa using LinearIndependent.ne_zero (⟨a, ha⟩ : s) li
+#align rank_punit rank_pUnit
+
+@[simp]
+theorem rank_bot : Module.rank R (⊥ : Submodule R M) = 0 :=
+  by
+  have : (⊥ : Submodule R M) ≃ₗ[R] PUnit := bot_equiv_punit
+  rw [this.rank_eq, rank_pUnit]
+#align rank_bot rank_bot
+
+variable {R M}
+
+theorem exists_mem_ne_zero_of_rank_pos {s : Submodule R M} (h : 0 < Module.rank R s) :
+    ∃ b : M, b ∈ s ∧ b ≠ 0 :=
+  exists_mem_ne_zero_of_ne_bot fun eq => by rw [Eq, rank_bot] at h <;> exact lt_irrefl _ h
+#align exists_mem_ne_zero_of_rank_pos exists_mem_ne_zero_of_rank_pos
+
+/-- A linearly-independent family of vectors in a module over a non-trivial ring must be finite if
+the module is Noetherian. -/
+theorem LinearIndependent.finite_of_isNoetherian [IsNoetherian R M] {v : ι → M}
+    (hv : LinearIndependent R v) : Finite ι :=
+  by
+  have hwf := is_noetherian_iff_well_founded.mp (by infer_instance : IsNoetherian R M)
+  refine'
+    CompleteLattice.WellFounded.finite_of_independent hwf hv.independent_span_singleton
+      fun i contra => _
+  apply hv.ne_zero i
+  have : v i ∈ R ∙ v i := Submodule.mem_span_singleton_self (v i)
+  rwa [contra, Submodule.mem_bot] at this
+#align linear_independent.finite_of_is_noetherian LinearIndependent.finite_of_isNoetherian
+
+theorem LinearIndependent.set_finite_of_isNoetherian [IsNoetherian R M] {s : Set M}
+    (hi : LinearIndependent R (coe : s → M)) : s.Finite :=
+  @Set.toFinite _ _ hi.finite_of_isNoetherian
+#align linear_independent.set_finite_of_is_noetherian LinearIndependent.set_finite_of_isNoetherian
+
+-- One might hope that a finite spanning set implies that any linearly independent set is finite.
+-- While this is true over a division ring
+-- (simply because any linearly independent set can be extended to a basis),
+-- I'm not certain what more general statements are possible.
+/--
+Over any nontrivial ring, the existence of a finite spanning set implies that any basis is finite.
+-/
+def basisFintypeOfFiniteSpans (w : Set M) [Fintype w] (s : span R w = ⊤) {ι : Type w}
+    (b : Basis ι R M) : Fintype ι :=
+  by
+  -- We'll work by contradiction, assuming `ι` is infinite.
+  apply fintypeOfNotInfinite _
+  intro i
+  -- Let `S` be the union of the supports of `x ∈ w` expressed as linear combinations of `b`.
+  -- This is a finite set since `w` is finite.
+  let S : Finset ι := finset.univ.sup fun x : w => (b.repr x).support
+  let bS : Set M := b '' S
+  have h : ∀ x ∈ w, x ∈ span R bS := by
+    intro x m
+    rw [← b.total_repr x, Finsupp.span_image_eq_map_total, Submodule.mem_map]
+    use b.repr x
+    simp only [and_true_iff, eq_self_iff_true, Finsupp.mem_supported]
+    change (b.repr x).support ≤ S
+    convert Finset.le_sup (by simp : (⟨x, m⟩ : w) ∈ Finset.univ)
+    rfl
+  -- Thus this finite subset of the basis elements spans the entire module.
+  have k : span R bS = ⊤ := eq_top_iff.2 (le_trans s.ge (span_le.2 h))
+  -- Now there is some `x : ι` not in `S`, since `ι` is infinite.
+  obtain ⟨x, nm⟩ := Infinite.exists_not_mem_finset S
+  -- However it must be in the span of the finite subset,
+  have k' : b x ∈ span R bS := by
+    rw [k]
+    exact mem_top
+  -- giving the desire contradiction.
+  refine' b.linear_independent.not_mem_span_image _ k'
+  exact nm
+#align basis_fintype_of_finite_spans basisFintypeOfFiniteSpans
+
+-- From [Les familles libres maximales d'un module ont-elles le meme cardinal?][lazarus1973]
+/-- Over any ring `R`, if `b` is a basis for a module `M`,
+and `s` is a maximal linearly independent set,
+then the union of the supports of `x ∈ s` (when written out in the basis `b`) is all of `b`.
+-/
+theorem union_support_maximal_linearIndependent_eq_range_basis {ι : Type w} (b : Basis ι R M)
+    {κ : Type w'} (v : κ → M) (i : LinearIndependent R v) (m : i.Maximal) :
+    (⋃ k, ((b.repr (v k)).support : Set ι)) = univ :=
+  by
+  -- If that's not the case,
+  by_contra h
+  simp only [← Ne.def, ne_univ_iff_exists_not_mem, mem_Union, not_exists_not,
+    Finsupp.mem_support_iff, Finset.mem_coe] at h
+  -- We have some basis element `b b'` which is not in the support of any of the `v i`.
+  obtain ⟨b', w⟩ := h
+  -- Using this, we'll construct a linearly independent family strictly larger than `v`,
+  -- by also using this `b b'`.
+  let v' : Option κ → M := fun o => o.elim (b b') v
+  have r : range v ⊆ range v' := by
+    rintro - ⟨k, rfl⟩
+    use some k
+    rfl
+  have r' : b b' ∉ range v := by
+    rintro ⟨k, p⟩
+    simpa [w] using congr_arg (fun m => (b.repr m) b') p
+  have r'' : range v ≠ range v' := by
+    intro e
+    have p : b b' ∈ range v' := by
+      use none
+      rfl
+    rw [← e] at p
+    exact r' p
+  have inj' : injective v' := by
+    rintro (_ | k) (_ | k) z
+    · rfl
+    · exfalso
+      exact r' ⟨k, z.symm⟩
+    · exfalso
+      exact r' ⟨k, z⟩
+    · congr
+      exact i.injective z
+  -- The key step in the proof is checking that this strictly larger family is linearly independent.
+  have i' : LinearIndependent R (coe : range v' → M) :=
+    by
+    rw [linearIndependent_subtype_range inj', linearIndependent_iff]
+    intro l z
+    rw [Finsupp.total_option] at z
+    simp only [v', Option.elim'] at z
+    change _ + Finsupp.total κ M R v l.some = 0 at z
+    -- We have some linear combination of `b b'` and the `v i`, which we want to show is trivial.
+    -- We'll first show the coefficient of `b b'` is zero,
+    -- by expressing the `v i` in the basis `b`, and using that the `v i` have no `b b'` term.
+    have l₀ : l none = 0 := by
+      rw [← eq_neg_iff_add_eq_zero] at z
+      replace z := neg_eq_iff_eq_neg.mpr z
+      apply_fun fun x => b.repr x b'  at z
+      simp only [repr_self, LinearEquiv.map_smul, mul_one, Finsupp.single_eq_same, Pi.neg_apply,
+        Finsupp.smul_single', LinearEquiv.map_neg, Finsupp.coe_neg] at z
+      erw [Finsupp.congr_fun (Finsupp.apply_total R (b.repr : M →ₗ[R] ι →₀ R) v l.some) b'] at z
+      simpa [Finsupp.total_apply, w] using z
+    -- Then all the other coefficients are zero, because `v` is linear independent.
+    have l₁ : l.some = 0 := by
+      rw [l₀, zero_smul, zero_add] at z
+      exact linear_independent_iff.mp i _ z
+    -- Finally we put those facts together to show the linear combination is trivial.
+    ext (_ | a)
+    · simp only [l₀, Finsupp.coe_zero, Pi.zero_apply]
+    · erw [Finsupp.congr_fun l₁ a]
+      simp only [Finsupp.coe_zero, Pi.zero_apply]
+  dsimp [LinearIndependent.Maximal] at m
+  specialize m (range v') i' r
+  exact r'' m
+#align union_support_maximal_linear_independent_eq_range_basis union_support_maximal_linearIndependent_eq_range_basis
+
+/-- Over any ring `R`, if `b` is an infinite basis for a module `M`,
+and `s` is a maximal linearly independent set,
+then the cardinality of `b` is bounded by the cardinality of `s`.
+-/
+theorem infinite_basis_le_maximal_linear_independent' {ι : Type w} (b : Basis ι R M) [Infinite ι]
+    {κ : Type w'} (v : κ → M) (i : LinearIndependent R v) (m : i.Maximal) :
+    Cardinal.lift.{w'} (#ι) ≤ Cardinal.lift.{w} (#κ) :=
+  by
+  let Φ := fun k : κ => (b.repr (v k)).support
+  have w₁ : (#ι) ≤ (#Set.range Φ) :=
+    by
+    apply Cardinal.le_range_of_union_finset_eq_top
+    exact union_support_maximal_linearIndependent_eq_range_basis b v i m
+  have w₂ : Cardinal.lift.{w'} (#Set.range Φ) ≤ Cardinal.lift.{w} (#κ) := Cardinal.mk_range_le_lift
+  exact (cardinal.lift_le.mpr w₁).trans w₂
+#align infinite_basis_le_maximal_linear_independent' infinite_basis_le_maximal_linear_independent'
+
+-- (See `infinite_basis_le_maximal_linear_independent'` for the more general version
+-- where the index types can live in different universes.)
+/-- Over any ring `R`, if `b` is an infinite basis for a module `M`,
+and `s` is a maximal linearly independent set,
+then the cardinality of `b` is bounded by the cardinality of `s`.
+-/
+theorem infinite_basis_le_maximal_linearIndependent {ι : Type w} (b : Basis ι R M) [Infinite ι]
+    {κ : Type w} (v : κ → M) (i : LinearIndependent R v) (m : i.Maximal) : (#ι) ≤ (#κ) :=
+  Cardinal.lift_le.mp (infinite_basis_le_maximal_linear_independent' b v i m)
+#align infinite_basis_le_maximal_linear_independent infinite_basis_le_maximal_linearIndependent
+
+theorem CompleteLattice.Independent.subtype_ne_bot_le_rank [NoZeroSMulDivisors R M]
+    {V : ι → Submodule R M} (hV : CompleteLattice.Independent V) :
+    Cardinal.lift.{v} (#{ i : ι // V i ≠ ⊥ }) ≤ Cardinal.lift.{w} (Module.rank R M) :=
+  by
+  set I := { i : ι // V i ≠ ⊥ }
+  have hI : ∀ i : I, ∃ v ∈ V i, v ≠ (0 : M) := by
+    intro i
+    rw [← Submodule.ne_bot_iff]
+    exact i.prop
+  choose v hvV hv using hI
+  have : LinearIndependent R v := (hV.comp Subtype.coe_injective).LinearIndependent _ hvV hv
+  exact cardinal_lift_le_rank_of_linear_independent' this
+#align complete_lattice.independent.subtype_ne_bot_le_rank CompleteLattice.Independent.subtype_ne_bot_le_rank
+
+end
+
+section RankZero
+
+variable {R : Type u} {M : Type v}
+
+variable [Ring R] [AddCommGroup M] [Module R M]
+
+@[simp]
+theorem rank_subsingleton [Subsingleton R] : Module.rank R M = 1 :=
+  by
+  haveI := Module.subsingleton R M
+  have : Nonempty { s : Set M // LinearIndependent R (coe : s → M) } :=
+    ⟨⟨∅, linearIndependent_empty _ _⟩⟩
+  rw [Module.rank, csupᵢ_eq_of_forall_le_of_forall_lt_exists_gt]
+  · rintro ⟨s, hs⟩
+    rw [Cardinal.mk_le_one_iff_set_subsingleton]
+    apply subsingleton_of_subsingleton
+  intro w hw
+  refine' ⟨⟨{0}, _⟩, _⟩
+  · rw [linearIndependent_iff']
+    intros
+    exact Subsingleton.elim _ _
+  · exact hw.trans_eq (Cardinal.mk_singleton _).symm
+#align rank_subsingleton rank_subsingleton
+
+variable [NoZeroSMulDivisors R M]
+
+theorem rank_pos [Nontrivial M] : 0 < Module.rank R M :=
+  by
+  obtain ⟨x, hx⟩ := exists_ne (0 : M)
+  suffices 1 ≤ Module.rank R M by exact zero_lt_one.trans_le this
+  letI := Module.nontrivial R M
+  suffices LinearIndependent R fun y : ({x} : Set M) => ↑y by
+    simpa using cardinal_le_rank_of_linearIndependent this
+  exact linearIndependent_singleton hx
+#align rank_pos rank_pos
+
+variable [Nontrivial R]
+
+theorem rank_zero_iff_forall_zero : Module.rank R M = 0 ↔ ∀ x : M, x = 0 :=
+  by
+  refine' ⟨fun h => _, fun h => _⟩
+  · contrapose! h
+    obtain ⟨x, hx⟩ := h
+    letI : Nontrivial M := nontrivial_of_ne _ _ hx
+    exact rank_pos.ne'
+  · have : (⊤ : Submodule R M) = ⊥ := by
+      ext x
+      simp [h x]
+    rw [← rank_top, this, rank_bot]
+#align rank_zero_iff_forall_zero rank_zero_iff_forall_zero
+
+/-- See `rank_subsingleton` for the reason that `nontrivial R` is needed. -/
+theorem rank_zero_iff : Module.rank R M = 0 ↔ Subsingleton M :=
+  rank_zero_iff_forall_zero.trans (subsingleton_iff_forall_eq 0).symm
+#align rank_zero_iff rank_zero_iff
+
+theorem rank_pos_iff_exists_ne_zero : 0 < Module.rank R M ↔ ∃ x : M, x ≠ 0 :=
+  by
+  rw [← not_iff_not]
+  simpa using rank_zero_iff_forall_zero
+#align rank_pos_iff_exists_ne_zero rank_pos_iff_exists_ne_zero
+
+theorem rank_pos_iff_nontrivial : 0 < Module.rank R M ↔ Nontrivial M :=
+  rank_pos_iff_exists_ne_zero.trans (nontrivial_iff_exists_ne 0).symm
+#align rank_pos_iff_nontrivial rank_pos_iff_nontrivial
+
+end RankZero
+
+section InvariantBasisNumber
+
+variable {R : Type u} [Ring R] [InvariantBasisNumber R]
+
+variable {M : Type v} [AddCommGroup M] [Module R M]
+
+/-- The dimension theorem: if `v` and `v'` are two bases, their index types
+have the same cardinalities. -/
+theorem mk_eq_mk_of_basis (v : Basis ι R M) (v' : Basis ι' R M) :
+    Cardinal.lift.{w'} (#ι) = Cardinal.lift.{w} (#ι') :=
+  by
+  haveI := nontrivial_of_invariantBasisNumber R
+  cases fintypeOrInfinite ι
+  · -- `v` is a finite basis, so by `basis_fintype_of_finite_spans` so is `v'`.
+    haveI : Fintype (range v) := Set.fintypeRange v
+    haveI := basisFintypeOfFiniteSpans _ v.span_eq v'
+    -- We clean up a little:
+    rw [Cardinal.mk_fintype, Cardinal.mk_fintype]
+    simp only [Cardinal.lift_natCast, Cardinal.natCast_inj]
+    -- Now we can use invariant basis number to show they have the same cardinality.
+    apply card_eq_of_linearEquiv R
+    exact
+      (Finsupp.linearEquivFunOnFinite R R ι).symm.trans v.repr.symm ≪≫ₗ v'.repr ≪≫ₗ
+        Finsupp.linearEquivFunOnFinite R R ι'
+  · -- `v` is an infinite basis,
+    -- so by `infinite_basis_le_maximal_linear_independent`, `v'` is at least as big,
+    -- and then applying `infinite_basis_le_maximal_linear_independent` again
+    -- we see they have the same cardinality.
+    have w₁ := infinite_basis_le_maximal_linear_independent' v _ v'.linear_independent v'.maximal
+    rcases cardinal.lift_mk_le'.mp w₁ with ⟨f⟩
+    haveI : Infinite ι' := Infinite.of_injective f f.2
+    have w₂ := infinite_basis_le_maximal_linear_independent' v' _ v.linear_independent v.maximal
+    exact le_antisymm w₁ w₂
+#align mk_eq_mk_of_basis mk_eq_mk_of_basis
+
+/-- Given two bases indexed by `ι` and `ι'` of an `R`-module, where `R` satisfies the invariant
+basis number property, an equiv `ι ≃ ι' `. -/
+def Basis.indexEquiv (v : Basis ι R M) (v' : Basis ι' R M) : ι ≃ ι' :=
+  Nonempty.some (Cardinal.lift_mk_eq.1 (Cardinal.lift_umax_eq.2 (mk_eq_mk_of_basis v v')))
+#align basis.index_equiv Basis.indexEquiv
+
+theorem mk_eq_mk_of_basis' {ι' : Type w} (v : Basis ι R M) (v' : Basis ι' R M) : (#ι) = (#ι') :=
+  Cardinal.lift_inj.1 <| mk_eq_mk_of_basis v v'
+#align mk_eq_mk_of_basis' mk_eq_mk_of_basis'
+
+end InvariantBasisNumber
+
+section RankCondition
+
+variable {R : Type u} [Ring R] [RankCondition R]
+
+variable {M : Type v} [AddCommGroup M] [Module R M]
+
+/-- An auxiliary lemma for `basis.le_span`.
+
+If `R` satisfies the rank condition,
+then for any finite basis `b : basis ι R M`,
+and any finite spanning set `w : set M`,
+the cardinality of `ι` is bounded by the cardinality of `w`.
+-/
+theorem Basis.le_span'' {ι : Type _} [Fintype ι] (b : Basis ι R M) {w : Set M} [Fintype w]
+    (s : span R w = ⊤) : Fintype.card ι ≤ Fintype.card w :=
+  by
+  -- We construct an surjective linear map `(w → R) →ₗ[R] (ι → R)`,
+  -- by expressing a linear combination in `w` as a linear combination in `ι`.
+  fapply card_le_of_surjective' R
+  · exact b.repr.to_linear_map.comp (Finsupp.total w M R coe)
+  · apply surjective.comp
+    apply LinearEquiv.surjective
+    rw [← LinearMap.range_eq_top, Finsupp.range_total]
+    simpa using s
+#align basis.le_span'' Basis.le_span''
+
+/--
+Another auxiliary lemma for `basis.le_span`, which does not require assuming the basis is finite,
+but still assumes we have a finite spanning set.
+-/
+theorem basis_le_span' {ι : Type _} (b : Basis ι R M) {w : Set M} [Fintype w] (s : span R w = ⊤) :
+    (#ι) ≤ Fintype.card w :=
+  by
+  haveI := nontrivial_of_invariantBasisNumber R
+  haveI := basisFintypeOfFiniteSpans w s b
+  rw [Cardinal.mk_fintype ι]
+  simp only [Cardinal.natCast_le]
+  exact Basis.le_span'' b s
+#align basis_le_span' basis_le_span'
+
+-- Note that if `R` satisfies the strong rank condition,
+-- this also follows from `linear_independent_le_span` below.
+/-- If `R` satisfies the rank condition,
+then the cardinality of any basis is bounded by the cardinality of any spanning set.
+-/
+theorem Basis.le_span {J : Set M} (v : Basis ι R M) (hJ : span R J = ⊤) : (#range v) ≤ (#J) :=
+  by
+  haveI := nontrivial_of_invariantBasisNumber R
+  cases fintypeOrInfinite J
+  · rw [← Cardinal.lift_le, Cardinal.mk_range_eq_of_injective v.injective, Cardinal.mk_fintype J]
+    convert Cardinal.lift_le.{w, v}.2 (basis_le_span' v hJ)
+    simp
+  · have := Cardinal.mk_range_eq_of_injective v.injective
+    let S : J → Set ι := fun j => ↑(v.repr j).support
+    let S' : J → Set M := fun j => v '' S j
+    have hs : range v ⊆ ⋃ j, S' j := by
+      intro b hb
+      rcases mem_range.1 hb with ⟨i, hi⟩
+      have : span R J ≤ comap v.repr.to_linear_map (Finsupp.supported R R (⋃ j, S j)) :=
+        span_le.2 fun j hj x hx => ⟨_, ⟨⟨j, hj⟩, rfl⟩, hx⟩
+      rw [hJ] at this
+      replace : v.repr (v i) ∈ Finsupp.supported R R (⋃ j, S j) := this trivial
+      rw [v.repr_self, Finsupp.mem_supported, Finsupp.support_single_ne_zero _ one_ne_zero] at this
+      · subst b
+        rcases mem_Union.1 (this (Finset.mem_singleton_self _)) with ⟨j, hj⟩
+        exact mem_Union.2 ⟨j, (mem_image _ _ _).2 ⟨i, hj, rfl⟩⟩
+      · infer_instance
+    refine' le_of_not_lt fun IJ => _
+    suffices (#⋃ j, S' j) < (#range v) by exact not_le_of_lt this ⟨Set.embeddingOfSubset _ _ hs⟩
+    refine'
+      lt_of_le_of_lt (le_trans Cardinal.mk_unionᵢ_le_sum_mk (Cardinal.sum_le_sum _ (fun _ => ℵ₀) _))
+        _
+    · exact fun j => (Cardinal.lt_aleph0_of_finite _).le
+    · simpa
+#align basis.le_span Basis.le_span
+
+end RankCondition
+
+section StrongRankCondition
+
+variable {R : Type u} [Ring R] [StrongRankCondition R]
+
+variable {M : Type v} [AddCommGroup M] [Module R M]
+
+open Submodule
+
+-- An auxiliary lemma for `linear_independent_le_span'`,
+-- with the additional assumption that the linearly independent family is finite.
+theorem linearIndependent_le_span_aux' {ι : Type _} [Fintype ι] (v : ι → M)
+    (i : LinearIndependent R v) (w : Set M) [Fintype w] (s : range v ≤ span R w) :
+    Fintype.card ι ≤ Fintype.card w :=
+  by
+  -- We construct an injective linear map `(ι → R) →ₗ[R] (w → R)`,
+  -- by thinking of `f : ι → R` as a linear combination of the finite family `v`,
+  -- and expressing that (using the axiom of choice) as a linear combination over `w`.
+  -- We can do this linearly by constructing the map on a basis.
+  fapply card_le_of_injective' R
+  · apply Finsupp.total
+    exact fun i => Span.repr R w ⟨v i, s (mem_range_self i)⟩
+  · intro f g h
+    apply_fun Finsupp.total w M R coe  at h
+    simp only [Finsupp.total_total, Submodule.coe_mk, Span.finsupp_total_repr] at h
+    rw [← sub_eq_zero, ← LinearMap.map_sub] at h
+    exact sub_eq_zero.mp (linear_independent_iff.mp i _ h)
+#align linear_independent_le_span_aux' linearIndependent_le_span_aux'
+
+/-- If `R` satisfies the strong rank condition,
+then any linearly independent family `v : ι → M`
+contained in the span of some finite `w : set M`,
+is itself finite.
+-/
+def linearIndependentFintypeOfLeSpanFintype {ι : Type _} (v : ι → M) (i : LinearIndependent R v)
+    (w : Set M) [Fintype w] (s : range v ≤ span R w) : Fintype ι :=
+  fintypeOfFinsetCardLe (Fintype.card w) fun t =>
+    by
+    let v' := fun x : (t : Set ι) => v x
+    have i' : LinearIndependent R v' := i.comp _ Subtype.val_injective
+    have s' : range v' ≤ span R w := (range_comp_subset_range _ _).trans s
+    simpa using linearIndependent_le_span_aux' v' i' w s'
+#align linear_independent_fintype_of_le_span_fintype linearIndependentFintypeOfLeSpanFintype
+
+/-- If `R` satisfies the strong rank condition,
+then for any linearly independent family `v : ι → M`
+contained in the span of some finite `w : set M`,
+the cardinality of `ι` is bounded by the cardinality of `w`.
+-/
+theorem linearIndependent_le_span' {ι : Type _} (v : ι → M) (i : LinearIndependent R v) (w : Set M)
+    [Fintype w] (s : range v ≤ span R w) : (#ι) ≤ Fintype.card w :=
+  by
+  haveI : Fintype ι := linearIndependentFintypeOfLeSpanFintype v i w s
+  rw [Cardinal.mk_fintype]
+  simp only [Cardinal.natCast_le]
+  exact linearIndependent_le_span_aux' v i w s
+#align linear_independent_le_span' linearIndependent_le_span'
+
+/-- If `R` satisfies the strong rank condition,
+then for any linearly independent family `v : ι → M`
+and any finite spanning set `w : set M`,
+the cardinality of `ι` is bounded by the cardinality of `w`.
+-/
+theorem linearIndependent_le_span {ι : Type _} (v : ι → M) (i : LinearIndependent R v) (w : Set M)
+    [Fintype w] (s : span R w = ⊤) : (#ι) ≤ Fintype.card w :=
+  by
+  apply linearIndependent_le_span' v i w
+  rw [s]
+  exact le_top
+#align linear_independent_le_span linearIndependent_le_span
+
+/-- An auxiliary lemma for `linear_independent_le_basis`:
+we handle the case where the basis `b` is infinite.
+-/
+theorem linearIndependent_le_infinite_basis {ι : Type _} (b : Basis ι R M) [Infinite ι] {κ : Type _}
+    (v : κ → M) (i : LinearIndependent R v) : (#κ) ≤ (#ι) :=
+  by
+  by_contra
+  rw [not_le, ← Cardinal.mk_finset_of_infinite ι] at h
+  let Φ := fun k : κ => (b.repr (v k)).support
+  obtain ⟨s, w : Infinite ↥(Φ ⁻¹' {s})⟩ := Cardinal.exists_infinite_fiber Φ h (by infer_instance)
+  let v' := fun k : Φ ⁻¹' {s} => v k
+  have i' : LinearIndependent R v' := i.comp _ Subtype.val_injective
+  have w' : Fintype (Φ ⁻¹' {s}) :=
+    by
+    apply linearIndependentFintypeOfLeSpanFintype v' i' (s.image b)
+    rintro m ⟨⟨p, ⟨rfl⟩⟩, rfl⟩
+    simp only [SetLike.mem_coe, Subtype.coe_mk, Finset.coe_image]
+    apply Basis.mem_span_repr_support
+  exact w.false
+#align linear_independent_le_infinite_basis linearIndependent_le_infinite_basis
+
+/-- Over any ring `R` satisfying the strong rank condition,
+if `b` is a basis for a module `M`,
+and `s` is a linearly independent set,
+then the cardinality of `s` is bounded by the cardinality of `b`.
+-/
+theorem linearIndependent_le_basis {ι : Type _} (b : Basis ι R M) {κ : Type _} (v : κ → M)
+    (i : LinearIndependent R v) : (#κ) ≤ (#ι) :=
+  by
+  -- We split into cases depending on whether `ι` is infinite.
+    cases fintypeOrInfinite ι <;>
+    skip
+  · -- When `ι` is finite, we have `linear_independent_le_span`,
+    rw [Cardinal.mk_fintype ι]
+    haveI : Nontrivial R := nontrivial_of_invariantBasisNumber R
+    rw [Fintype.card_congr (Equiv.ofInjective b b.injective)]
+    exact linearIndependent_le_span v i (range b) b.span_eq
+  ·-- and otherwise we have `linear_indepedent_le_infinite_basis`.
+    exact linearIndependent_le_infinite_basis b v i
+#align linear_independent_le_basis linearIndependent_le_basis
+
+/-- In an `n`-dimensional space, the rank is at most `m`. -/
+theorem Basis.card_le_card_of_linearIndependent_aux {R : Type _} [Ring R] [StrongRankCondition R]
+    (n : ℕ) {m : ℕ} (v : Fin m → Fin n → R) : LinearIndependent R v → m ≤ n := fun h => by
+  simpa using linearIndependent_le_basis (Pi.basisFun R (Fin n)) v h
+#align basis.card_le_card_of_linear_independent_aux Basis.card_le_card_of_linearIndependent_aux
+
+-- When the basis is not infinite this need not be true!
+/-- Over any ring `R` satisfying the strong rank condition,
+if `b` is an infinite basis for a module `M`,
+then every maximal linearly independent set has the same cardinality as `b`.
+
+This proof (along with some of the lemmas above) comes from
+[Les familles libres maximales d'un module ont-elles le meme cardinal?][lazarus1973]
+-/
+theorem maximal_linearIndependent_eq_infinite_basis {ι : Type _} (b : Basis ι R M) [Infinite ι]
+    {κ : Type _} (v : κ → M) (i : LinearIndependent R v) (m : i.Maximal) : (#κ) = (#ι) :=
+  by
+  apply le_antisymm
+  · exact linearIndependent_le_basis b v i
+  · haveI : Nontrivial R := nontrivial_of_invariantBasisNumber R
+    exact infinite_basis_le_maximal_linearIndependent b v i m
+#align maximal_linear_independent_eq_infinite_basis maximal_linearIndependent_eq_infinite_basis
+
+theorem Basis.mk_eq_rank'' {ι : Type v} (v : Basis ι R M) : (#ι) = Module.rank R M :=
+  by
+  haveI := nontrivial_of_invariantBasisNumber R
+  rw [Module.rank]
+  apply le_antisymm
+  · trans
+    swap
+    apply le_csupᵢ (Cardinal.bddAbove_range.{v, v} _)
+    exact
+      ⟨Set.range v, by
+        convert v.reindex_range.linear_independent
+        ext
+        simp⟩
+    exact (Cardinal.mk_range_eq v v.injective).ge
+  · apply csupᵢ_le'
+    rintro ⟨s, li⟩
+    apply linearIndependent_le_basis v _ li
+#align basis.mk_eq_rank'' Basis.mk_eq_rank''
+
+theorem Basis.mk_range_eq_rank (v : Basis ι R M) : (#range v) = Module.rank R M :=
+  v.reindexRange.mk_eq_rank''
+#align basis.mk_range_eq_rank Basis.mk_range_eq_rank
+
+/-- If a vector space has a finite basis, then its dimension (seen as a cardinal) is equal to the
+cardinality of the basis. -/
+theorem rank_eq_card_basis {ι : Type w} [Fintype ι] (h : Basis ι R M) :
+    Module.rank R M = Fintype.card ι :=
+  by
+  haveI := nontrivial_of_invariantBasisNumber R
+  rw [← h.mk_range_eq_rank, Cardinal.mk_fintype, Set.card_range_of_injective h.injective]
+#align rank_eq_card_basis rank_eq_card_basis
+
+theorem Basis.card_le_card_of_linearIndependent {ι : Type _} [Fintype ι] (b : Basis ι R M)
+    {ι' : Type _} [Fintype ι'] {v : ι' → M} (hv : LinearIndependent R v) :
+    Fintype.card ι' ≤ Fintype.card ι :=
+  by
+  letI := nontrivial_of_invariantBasisNumber R
+  simpa [rank_eq_card_basis b, Cardinal.mk_fintype] using
+    cardinal_lift_le_rank_of_linear_independent' hv
+#align basis.card_le_card_of_linear_independent Basis.card_le_card_of_linearIndependent
+
+theorem Basis.card_le_card_of_submodule (N : Submodule R M) [Fintype ι] (b : Basis ι R M)
+    [Fintype ι'] (b' : Basis ι' R N) : Fintype.card ι' ≤ Fintype.card ι :=
+  b.card_le_card_of_linearIndependent (b'.LinearIndependent.map' N.Subtype N.ker_subtype)
+#align basis.card_le_card_of_submodule Basis.card_le_card_of_submodule
+
+theorem Basis.card_le_card_of_le {N O : Submodule R M} (hNO : N ≤ O) [Fintype ι] (b : Basis ι R O)
+    [Fintype ι'] (b' : Basis ι' R N) : Fintype.card ι' ≤ Fintype.card ι :=
+  b.card_le_card_of_linearIndependent
+    (b'.LinearIndependent.map' (Submodule.ofLe hNO) (N.ker_ofLe O _))
+#align basis.card_le_card_of_le Basis.card_le_card_of_le
+
+theorem Basis.mk_eq_rank (v : Basis ι R M) :
+    Cardinal.lift.{v} (#ι) = Cardinal.lift.{w} (Module.rank R M) :=
+  by
+  haveI := nontrivial_of_invariantBasisNumber R
+  rw [← v.mk_range_eq_rank, Cardinal.mk_range_eq_of_injective v.injective]
+#align basis.mk_eq_rank Basis.mk_eq_rank
+
+theorem Basis.mk_eq_rank'.{m} (v : Basis ι R M) :
+    Cardinal.lift.{max v m} (#ι) = Cardinal.lift.{max w m} (Module.rank R M) := by
+  simpa using v.mk_eq_rank
+#align basis.mk_eq_rank' Basis.mk_eq_rank'
+
+/-- If a module has a finite dimension, all bases are indexed by a finite type. -/
+theorem Basis.nonempty_fintype_index_of_rank_lt_aleph0 {ι : Type _} (b : Basis ι R M)
+    (h : Module.rank R M < ℵ₀) : Nonempty (Fintype ι) := by
+  rwa [← Cardinal.lift_lt, ← b.mk_eq_rank, Cardinal.lift_aleph0, Cardinal.lift_lt_aleph0,
+    Cardinal.lt_aleph0_iff_fintype] at h
+#align basis.nonempty_fintype_index_of_rank_lt_aleph_0 Basis.nonempty_fintype_index_of_rank_lt_aleph0
+
+/-- If a module has a finite dimension, all bases are indexed by a finite type. -/
+noncomputable def Basis.fintypeIndexOfRankLtAleph0 {ι : Type _} (b : Basis ι R M)
+    (h : Module.rank R M < ℵ₀) : Fintype ι :=
+  Classical.choice (b.nonempty_fintype_index_of_rank_lt_aleph0 h)
+#align basis.fintype_index_of_rank_lt_aleph_0 Basis.fintypeIndexOfRankLtAleph0
+
+/-- If a module has a finite dimension, all bases are indexed by a finite set. -/
+theorem Basis.finite_index_of_rank_lt_aleph0 {ι : Type _} {s : Set ι} (b : Basis s R M)
+    (h : Module.rank R M < ℵ₀) : s.Finite :=
+  finite_def.2 (b.nonempty_fintype_index_of_rank_lt_aleph0 h)
+#align basis.finite_index_of_rank_lt_aleph_0 Basis.finite_index_of_rank_lt_aleph0
+
+theorem rank_span {v : ι → M} (hv : LinearIndependent R v) :
+    Module.rank R ↥(span R (range v)) = (#range v) :=
+  by
+  haveI := nontrivial_of_invariantBasisNumber R
+  rw [← Cardinal.lift_inj, ← (Basis.span hv).mk_eq_rank,
+    Cardinal.mk_range_eq_of_injective (@LinearIndependent.injective ι R M v _ _ _ _ hv)]
+#align rank_span rank_span
+
+theorem rank_span_set {s : Set M} (hs : LinearIndependent R (fun x => x : s → M)) :
+    Module.rank R ↥(span R s) = (#s) :=
+  by
+  rw [← @set_of_mem_eq _ s, ← Subtype.range_coe_subtype]
+  exact rank_span hs
+#align rank_span_set rank_span_set
+
+/-- If `N` is a submodule in a free, finitely generated module,
+do induction on adjoining a linear independent element to a submodule. -/
+def Submodule.inductionOnRank [IsDomain R] [Fintype ι] (b : Basis ι R M)
+    (P : Submodule R M → Sort _)
+    (ih :
+      ∀ N : Submodule R M,
+        (∀ N' ≤ N, ∀ x ∈ N, (∀ (c : R), ∀ y ∈ N', c • x + y = (0 : M) → c = 0) → P N') → P N)
+    (N : Submodule R M) : P N :=
+  Submodule.inductionOnRankAux b P ih (Fintype.card ι) N fun s hs hli => by
+    simpa using b.card_le_card_of_linear_independent hli
+#align submodule.induction_on_rank Submodule.inductionOnRank
+
+/-- If `S` a finite-dimensional ring extension of `R` which is free as an `R`-module,
+then the rank of an ideal `I` of `S` over `R` is the same as the rank of `S`.
+-/
+theorem Ideal.rank_eq {R S : Type _} [CommRing R] [StrongRankCondition R] [Ring S] [IsDomain S]
+    [Algebra R S] {n m : Type _} [Fintype n] [Fintype m] (b : Basis n R S) {I : Ideal S}
+    (hI : I ≠ ⊥) (c : Basis m R I) : Fintype.card m = Fintype.card n :=
+  by
+  obtain ⟨a, ha⟩ := Submodule.nonzero_mem_of_bot_lt (bot_lt_iff_ne_bot.mpr hI)
+  have : LinearIndependent R fun i => b i • a :=
+    by
+    have hb := b.linear_independent
+    rw [Fintype.linearIndependent_iff] at hb⊢
+    intro g hg
+    apply hb g
+    simp only [← smul_assoc, ← Finset.sum_smul, smul_eq_zero] at hg
+    exact hg.resolve_right ha
+  exact
+    le_antisymm
+      (b.card_le_card_of_linear_independent
+        (c.linear_independent.map' (Submodule.subtype I)
+          (linear_map.ker_eq_bot.mpr Subtype.coe_injective)))
+      (c.card_le_card_of_linear_independent this)
+#align ideal.rank_eq Ideal.rank_eq
+
+variable (R)
+
+@[simp]
+theorem rank_self : Module.rank R R = 1 := by
+  rw [← Cardinal.lift_inj, ← (Basis.singleton PUnit R).mk_eq_rank, Cardinal.mk_pUnit]
+#align rank_self rank_self
+
+end StrongRankCondition
+
+section Free
+
+variable [Ring K] [StrongRankCondition K]
+
+variable [AddCommGroup V] [Module K V] [Module.Free K V]
+
+variable [AddCommGroup V'] [Module K V'] [Module.Free K V']
+
+variable [AddCommGroup V₁] [Module K V₁] [Module.Free K V₁]
+
+variable {K V}
+
+namespace Module.Free
+
+variable (K V)
+
+/-- The rank of a free module `M` over `R` is the cardinality of `choose_basis_index R M`. -/
+theorem rank_eq_card_chooseBasisIndex : Module.rank K V = (#ChooseBasisIndex K V) :=
+  (chooseBasis K V).mk_eq_rank''.symm
+#align module.free.rank_eq_card_choose_basis_index Module.Free.rank_eq_card_chooseBasisIndex
+
+end Module.Free
+
+open Module.Free
+
+open Cardinal
+
+/-- Two vector spaces are isomorphic if they have the same dimension. -/
+theorem nonempty_linearEquiv_of_lift_rank_eq
+    (cond : Cardinal.lift.{v'} (Module.rank K V) = Cardinal.lift.{v} (Module.rank K V')) :
+    Nonempty (V ≃ₗ[K] V') :=
+  by
+  obtain ⟨⟨_, B⟩⟩ := Module.Free.exists_basis K V
+  obtain ⟨⟨_, B'⟩⟩ := Module.Free.exists_basis K V'
+  have : Cardinal.lift.{v', v} (#_) = Cardinal.lift.{v, v'} (#_) := by
+    rw [B.mk_eq_rank'', cond, B'.mk_eq_rank'']
+  exact (Cardinal.lift_mk_eq.{v, v', 0}.1 this).map (B.equiv B')
+#align nonempty_linear_equiv_of_lift_rank_eq nonempty_linearEquiv_of_lift_rank_eq
+
+/-- Two vector spaces are isomorphic if they have the same dimension. -/
+theorem nonempty_linearEquiv_of_rank_eq (cond : Module.rank K V = Module.rank K V₁) :
+    Nonempty (V ≃ₗ[K] V₁) :=
+  nonempty_linearEquiv_of_lift_rank_eq <| congr_arg _ cond
+#align nonempty_linear_equiv_of_rank_eq nonempty_linearEquiv_of_rank_eq
+
+section
+
+variable (V V' V₁)
+
+/-- Two vector spaces are isomorphic if they have the same dimension. -/
+def LinearEquiv.ofLiftRankEq
+    (cond : Cardinal.lift.{v'} (Module.rank K V) = Cardinal.lift.{v} (Module.rank K V')) :
+    V ≃ₗ[K] V' :=
+  Classical.choice (nonempty_linearEquiv_of_lift_rank_eq cond)
+#align linear_equiv.of_lift_rank_eq LinearEquiv.ofLiftRankEq
+
+/-- Two vector spaces are isomorphic if they have the same dimension. -/
+def LinearEquiv.ofRankEq (cond : Module.rank K V = Module.rank K V₁) : V ≃ₗ[K] V₁ :=
+  Classical.choice (nonempty_linearEquiv_of_rank_eq cond)
+#align linear_equiv.of_rank_eq LinearEquiv.ofRankEq
+
+end
+
+/-- Two vector spaces are isomorphic if and only if they have the same dimension. -/
+theorem LinearEquiv.nonempty_equiv_iff_lift_rank_eq :
+    Nonempty (V ≃ₗ[K] V') ↔
+      Cardinal.lift.{v'} (Module.rank K V) = Cardinal.lift.{v} (Module.rank K V') :=
+  ⟨fun ⟨h⟩ => LinearEquiv.lift_rank_eq h, fun h => nonempty_linearEquiv_of_lift_rank_eq h⟩
+#align linear_equiv.nonempty_equiv_iff_lift_rank_eq LinearEquiv.nonempty_equiv_iff_lift_rank_eq
+
+/-- Two vector spaces are isomorphic if and only if they have the same dimension. -/
+theorem LinearEquiv.nonempty_equiv_iff_rank_eq :
+    Nonempty (V ≃ₗ[K] V₁) ↔ Module.rank K V = Module.rank K V₁ :=
+  ⟨fun ⟨h⟩ => LinearEquiv.rank_eq h, fun h => nonempty_linearEquiv_of_rank_eq h⟩
+#align linear_equiv.nonempty_equiv_iff_rank_eq LinearEquiv.nonempty_equiv_iff_rank_eq
+
+/-- The rank of `M × N` is `(module.rank R M).lift + (module.rank R N).lift`. -/
+@[simp]
+theorem rank_prod :
+    Module.rank K (V × V') =
+      Cardinal.lift.{v'} (Module.rank K V) + Cardinal.lift.{v, v'} (Module.rank K V') :=
+  by
+  simpa [rank_eq_card_choose_basis_index K V, rank_eq_card_choose_basis_index K V', lift_umax,
+    lift_umax'] using ((choose_basis K V).Prod (choose_basis K V')).mk_eq_rank.symm
+#align rank_prod rank_prod
+
+/-- If `M` and `N` lie in the same universe, the rank of `M × N` is
+  `(module.rank R M) + (module.rank R N)`. -/
+theorem rank_prod' : Module.rank K (V × V₁) = Module.rank K V + Module.rank K V₁ := by simp
+#align rank_prod' rank_prod'
+
+section Fintype
+
+variable [∀ i, AddCommGroup (φ i)] [∀ i, Module K (φ i)] [∀ i, Module.Free K (φ i)]
+
+open LinearMap
+
+/-- The rank of a finite product is the sum of the ranks. -/
+@[simp]
+theorem rank_pi [Finite η] : Module.rank K (∀ i, φ i) = Cardinal.sum fun i => Module.rank K (φ i) :=
+  by
+  cases nonempty_fintype η
+  let B i := choose_basis K (φ i)
+  let b : Basis _ K (∀ i, φ i) := Pi.basis fun i => B i
+  simp [← b.mk_eq_rank'', fun i => (B i).mk_eq_rank'']
+#align rank_pi rank_pi
+
+variable [Fintype η]
+
+theorem rank_fun {V η : Type u} [Fintype η] [AddCommGroup V] [Module K V] [Module.Free K V] :
+    Module.rank K (η → V) = Fintype.card η * Module.rank K V := by
+  rw [rank_pi, Cardinal.sum_const', Cardinal.mk_fintype]
+#align rank_fun rank_fun
+
+theorem rank_fun_eq_lift_mul :
+    Module.rank K (η → V) =
+      (Fintype.card η : Cardinal.{max u₁' v}) * Cardinal.lift.{u₁'} (Module.rank K V) :=
+  by rw [rank_pi, Cardinal.sum_const, Cardinal.mk_fintype, Cardinal.lift_natCast]
+#align rank_fun_eq_lift_mul rank_fun_eq_lift_mul
+
+theorem rank_fun' : Module.rank K (η → K) = Fintype.card η := by
+  rw [rank_fun_eq_lift_mul, rank_self, Cardinal.lift_one, mul_one, Cardinal.natCast_inj]
+#align rank_fun' rank_fun'
+
+theorem rank_fin_fun (n : ℕ) : Module.rank K (Fin n → K) = n := by simp [rank_fun']
+#align rank_fin_fun rank_fin_fun
+
+end Fintype
+
+-- TODO: merge with the `finrank` content
+/-- An `n`-dimensional `K`-vector space is equivalent to `fin n → K`. -/
+def finDimVectorspaceEquiv (n : ℕ) (hn : Module.rank K V = n) : V ≃ₗ[K] Fin n → K :=
+  by
+  haveI := nontrivial_of_invariantBasisNumber K
+  have : Cardinal.lift.{u} (n : Cardinal.{v}) = Cardinal.lift.{v} (n : Cardinal.{u}) := by simp
+  have hn := Cardinal.lift_inj.{v, u}.2 hn
+  rw [this] at hn
+  rw [← @rank_fin_fun K _ _ n] at hn
+  haveI : Module.Free K (Fin n → K) := Module.Free.pi _ _
+  exact Classical.choice (nonempty_linearEquiv_of_lift_rank_eq hn)
+#align fin_dim_vectorspace_equiv finDimVectorspaceEquiv
+
+end Free
+
+section DivisionRing
+
+variable [DivisionRing K]
+
+variable [AddCommGroup V] [Module K V]
+
+variable [AddCommGroup V'] [Module K V']
+
+variable [AddCommGroup V₁] [Module K V₁]
+
+variable {K V}
+
+/-- If a vector space has a finite dimension, the index set of `basis.of_vector_space` is finite. -/
+theorem Basis.finite_ofVectorSpaceIndex_of_rank_lt_aleph0 (h : Module.rank K V < ℵ₀) :
+    (Basis.ofVectorSpaceIndex K V).Finite :=
+  finite_def.2 <| (Basis.ofVectorSpace K V).nonempty_fintype_index_of_rank_lt_aleph0 h
+#align basis.finite_of_vector_space_index_of_rank_lt_aleph_0 Basis.finite_ofVectorSpaceIndex_of_rank_lt_aleph0
+
+-- TODO how far can we generalise this?
+-- When `s` is finite, we could prove this for any ring satisfying the strong rank condition
+-- using `linear_independent_le_span'`
+theorem rank_span_le (s : Set V) : Module.rank K (span K s) ≤ (#s) :=
+  by
+  obtain ⟨b, hb, hsab, hlib⟩ := exists_linearIndependent K s
+  convert Cardinal.mk_le_mk_of_subset hb
+  rw [← hsab, rank_span_set hlib]
+#align rank_span_le rank_span_le
+
+theorem rank_span_of_finset (s : Finset V) : Module.rank K (span K (↑s : Set V)) < ℵ₀ :=
+  calc
+    Module.rank K (span K (↑s : Set V)) ≤ (#(↑s : Set V)) := rank_span_le ↑s
+    _ = s.card := by rw [Finset.coe_sort_coe, Cardinal.mk_coe_finset]
+    _ < ℵ₀ := Cardinal.nat_lt_aleph0 _
+    
+#align rank_span_of_finset rank_span_of_finset
+
+theorem rank_quotient_add_rank (p : Submodule K V) :
+    Module.rank K (V ⧸ p) + Module.rank K p = Module.rank K V := by
+  classical exact
+      let ⟨f⟩ := quotient_prod_linearEquiv p
+      rank_prod'.symm.trans f.rank_eq
+#align rank_quotient_add_rank rank_quotient_add_rank
+
+/-- rank-nullity theorem -/
+theorem rank_range_add_rank_ker (f : V →ₗ[K] V₁) :
+    Module.rank K f.range + Module.rank K f.ker = Module.rank K V :=
+  by
+  haveI := fun p : Submodule K V => Classical.decEq (V ⧸ p)
+  rw [← f.quot_ker_equiv_range.rank_eq, rank_quotient_add_rank]
+#align rank_range_add_rank_ker rank_range_add_rank_ker
+
+theorem rank_eq_of_surjective (f : V →ₗ[K] V₁) (h : Surjective f) :
+    Module.rank K V = Module.rank K V₁ + Module.rank K f.ker := by
+  rw [← rank_range_add_rank_ker f, ← rank_range_of_surjective f h]
+#align rank_eq_of_surjective rank_eq_of_surjective
+
+section
+
+variable [AddCommGroup V₂] [Module K V₂]
+
+variable [AddCommGroup V₃] [Module K V₃]
+
+open LinearMap
+
+/-- This is mostly an auxiliary lemma for `submodule.rank_sup_add_rank_inf_eq`. -/
+theorem rank_add_rank_split (db : V₂ →ₗ[K] V) (eb : V₃ →ₗ[K] V) (cd : V₁ →ₗ[K] V₂)
+    (ce : V₁ →ₗ[K] V₃) (hde : ⊤ ≤ db.range ⊔ eb.range) (hgd : ker cd = ⊥)
+    (eq : db.comp cd = eb.comp ce) (eq₂ : ∀ d e, db d = eb e → ∃ c, cd c = d ∧ ce c = e) :
+    Module.rank K V + Module.rank K V₁ = Module.rank K V₂ + Module.rank K V₃ :=
+  by
+  have hf : Surjective (coprod db eb) := by rwa [← range_eq_top, range_coprod, eq_top_iff]
+  conv =>
+    rhs
+    rw [← rank_prod', rank_eq_of_surjective _ hf]
+  congr 1
+  apply LinearEquiv.rank_eq
+  refine' LinearEquiv.ofBijective _ ⟨_, _⟩
+  · refine' cod_restrict _ (Prod cd (-ce)) _
+    · intro c
+      simp only [add_eq_zero_iff_eq_neg, LinearMap.prod_apply, mem_ker, Pi.prod, coprod_apply,
+        neg_neg, map_neg, neg_apply]
+      exact LinearMap.ext_iff.1 Eq c
+  · rw [← ker_eq_bot, ker_cod_restrict, ker_prod, hgd, bot_inf_eq]
+  · rw [← range_eq_top, eq_top_iff, range_cod_restrict, ← map_le_iff_le_comap, Submodule.map_top,
+      range_subtype]
+    rintro ⟨d, e⟩
+    have h := eq₂ d (-e)
+    simp only [add_eq_zero_iff_eq_neg, LinearMap.prod_apply, mem_ker, SetLike.mem_coe,
+      Prod.mk.inj_iff, coprod_apply, map_neg, neg_apply, LinearMap.mem_range, Pi.prod] at h⊢
+    intro hde
+    rcases h hde with ⟨c, h₁, h₂⟩
+    refine' ⟨c, h₁, _⟩
+    rw [h₂, _root_.neg_neg]
+#align rank_add_rank_split rank_add_rank_split
+
+theorem Submodule.rank_sup_add_rank_inf_eq (s t : Submodule K V) :
+    Module.rank K (s ⊔ t : Submodule K V) + Module.rank K (s ⊓ t : Submodule K V) =
+      Module.rank K s + Module.rank K t :=
+  rank_add_rank_split (ofLe le_sup_left) (ofLe le_sup_right) (ofLe inf_le_left) (ofLe inf_le_right)
+    (by
+      rw [← map_le_map_iff' (ker_subtype <| s ⊔ t), Submodule.map_sup, Submodule.map_top, ←
+        LinearMap.range_comp, ← LinearMap.range_comp, subtype_comp_of_le, subtype_comp_of_le,
+        range_subtype, range_subtype, range_subtype]
+      exact le_rfl)
+    (ker_ofLe _ _ _) (by ext ⟨x, hx⟩; rfl)
+    (by
+      rintro ⟨b₁, hb₁⟩ ⟨b₂, hb₂⟩ eq
+      obtain rfl : b₁ = b₂ := congr_arg Subtype.val Eq
+      exact ⟨⟨b₁, hb₁, hb₂⟩, rfl, rfl⟩)
+#align submodule.rank_sup_add_rank_inf_eq Submodule.rank_sup_add_rank_inf_eq
+
+theorem Submodule.rank_add_le_rank_add_rank (s t : Submodule K V) :
+    Module.rank K (s ⊔ t : Submodule K V) ≤ Module.rank K s + Module.rank K t :=
+  by
+  rw [← Submodule.rank_sup_add_rank_inf_eq]
+  exact self_le_add_right _ _
+#align submodule.rank_add_le_rank_add_rank Submodule.rank_add_le_rank_add_rank
+
+end
+
+end DivisionRing
+
+section DivisionRing
+
+variable [DivisionRing K] [AddCommGroup V] [Module K V] [AddCommGroup V₁] [Module K V₁]
+
+variable [AddCommGroup V'] [Module K V']
+
+/-- The `ι` indexed basis on `V`, where `ι` is an empty type and `V` is zero-dimensional.
+
+See also `finite_dimensional.fin_basis`.
+-/
+def Basis.ofRankEqZero {ι : Type _} [IsEmpty ι] (hV : Module.rank K V = 0) : Basis ι K V :=
+  haveI : Subsingleton V := rank_zero_iff.1 hV
+  Basis.empty _
+#align basis.of_rank_eq_zero Basis.ofRankEqZero
+
+@[simp]
+theorem Basis.ofRankEqZero_apply {ι : Type _} [IsEmpty ι] (hV : Module.rank K V = 0) (i : ι) :
+    Basis.ofRankEqZero hV i = 0 :=
+  rfl
+#align basis.of_rank_eq_zero_apply Basis.ofRankEqZero_apply
+
+theorem le_rank_iff_exists_linearIndependent {c : Cardinal} :
+    c ≤ Module.rank K V ↔ ∃ s : Set V, (#s) = c ∧ LinearIndependent K (coe : s → V) :=
+  by
+  constructor
+  · intro h
+    let t := Basis.ofVectorSpace K V
+    rw [← t.mk_eq_rank'', Cardinal.le_mk_iff_exists_subset] at h
+    rcases h with ⟨s, hst, hsc⟩
+    exact ⟨s, hsc, (of_vector_space_index.linear_independent K V).mono hst⟩
+  · rintro ⟨s, rfl, si⟩
+    exact cardinal_le_rank_of_linearIndependent si
+#align le_rank_iff_exists_linear_independent le_rank_iff_exists_linearIndependent
+
+theorem le_rank_iff_exists_linearIndependent_finset {n : ℕ} :
+    ↑n ≤ Module.rank K V ↔
+      ∃ s : Finset V, s.card = n ∧ LinearIndependent K (coe : (s : Set V) → V) :=
+  by
+  simp only [le_rank_iff_exists_linearIndependent, Cardinal.mk_set_eq_nat_iff_finset]
+  constructor
+  · rintro ⟨s, ⟨t, rfl, rfl⟩, si⟩
+    exact ⟨t, rfl, si⟩
+  · rintro ⟨s, rfl, si⟩
+    exact ⟨s, ⟨s, rfl, rfl⟩, si⟩
+#align le_rank_iff_exists_linear_independent_finset le_rank_iff_exists_linearIndependent_finset
+
+/-- A vector space has dimension at most `1` if and only if there is a
+single vector of which all vectors are multiples. -/
+theorem rank_le_one_iff : Module.rank K V ≤ 1 ↔ ∃ v₀ : V, ∀ v, ∃ r : K, r • v₀ = v :=
+  by
+  let b := Basis.ofVectorSpace K V
+  constructor
+  · intro hd
+    rw [← b.mk_eq_rank'', Cardinal.le_one_iff_subsingleton, subsingleton_coe] at hd
+    rcases eq_empty_or_nonempty (of_vector_space_index K V) with (hb | ⟨⟨v₀, hv₀⟩⟩)
+    · use 0
+      have h' : ∀ v : V, v = 0 := by simpa [hb, Submodule.eq_bot_iff] using b.span_eq.symm
+      intro v
+      simp [h' v]
+    · use v₀
+      have h' : (K ∙ v₀) = ⊤ := by simpa [hd.eq_singleton_of_mem hv₀] using b.span_eq
+      intro v
+      have hv : v ∈ (⊤ : Submodule K V) := mem_top
+      rwa [← h', mem_span_singleton] at hv
+  · rintro ⟨v₀, hv₀⟩
+    have h : (K ∙ v₀) = ⊤ := by
+      ext
+      simp [mem_span_singleton, hv₀]
+    rw [← rank_top, ← h]
+    refine' (rank_span_le _).trans_eq _
+    simp
+#align rank_le_one_iff rank_le_one_iff
+
+/-- A submodule has dimension at most `1` if and only if there is a
+single vector in the submodule such that the submodule is contained in
+its span. -/
+theorem rank_submodule_le_one_iff (s : Submodule K V) :
+    Module.rank K s ≤ 1 ↔ ∃ v₀ ∈ s, s ≤ K ∙ v₀ :=
+  by
+  simp_rw [rank_le_one_iff, le_span_singleton_iff]
+  constructor
+  · rintro ⟨⟨v₀, hv₀⟩, h⟩
+    use v₀, hv₀
+    intro v hv
+    obtain ⟨r, hr⟩ := h ⟨v, hv⟩
+    use r
+    simp_rw [Subtype.ext_iff, coe_smul, Submodule.coe_mk] at hr
+    exact hr
+  · rintro ⟨v₀, hv₀, h⟩
+    use ⟨v₀, hv₀⟩
+    rintro ⟨v, hv⟩
+    obtain ⟨r, hr⟩ := h v hv
+    use r
+    simp_rw [Subtype.ext_iff, coe_smul, Submodule.coe_mk]
+    exact hr
+#align rank_submodule_le_one_iff rank_submodule_le_one_iff
+
+/-- A submodule has dimension at most `1` if and only if there is a
+single vector, not necessarily in the submodule, such that the
+submodule is contained in its span. -/
+theorem rank_submodule_le_one_iff' (s : Submodule K V) : Module.rank K s ≤ 1 ↔ ∃ v₀, s ≤ K ∙ v₀ :=
+  by
+  rw [rank_submodule_le_one_iff]
+  constructor
+  · rintro ⟨v₀, hv₀, h⟩
+    exact ⟨v₀, h⟩
+  · rintro ⟨v₀, h⟩
+    by_cases hw : ∃ w : V, w ∈ s ∧ w ≠ 0
+    · rcases hw with ⟨w, hw, hw0⟩
+      use w, hw
+      rcases mem_span_singleton.1 (h hw) with ⟨r', rfl⟩
+      have h0 : r' ≠ 0 := by
+        rintro rfl
+        simpa using hw0
+      rwa [span_singleton_smul_eq (IsUnit.mk0 _ h0) _]
+    · push_neg  at hw
+      rw [← Submodule.eq_bot_iff] at hw
+      simp [hw]
+#align rank_submodule_le_one_iff' rank_submodule_le_one_iff'
+
+theorem Submodule.rank_le_one_iff_isPrincipal (W : Submodule K V) :
+    Module.rank K W ≤ 1 ↔ W.IsPrincipal :=
+  by
+  simp only [rank_le_one_iff, Submodule.isPrincipal_iff, le_antisymm_iff, le_span_singleton_iff,
+    span_singleton_le_iff_mem]
+  constructor
+  · rintro ⟨⟨m, hm⟩, hm'⟩
+    choose f hf using hm'
+    exact ⟨m, ⟨fun v hv => ⟨f ⟨v, hv⟩, congr_arg coe (hf ⟨v, hv⟩)⟩, hm⟩⟩
+  · rintro ⟨a, ⟨h, ha⟩⟩
+    choose f hf using h
+    exact ⟨⟨a, ha⟩, fun v => ⟨f v.1 v.2, Subtype.ext (hf v.1 v.2)⟩⟩
+#align submodule.rank_le_one_iff_is_principal Submodule.rank_le_one_iff_isPrincipal
+
+theorem Module.rank_le_one_iff_top_isPrincipal :
+    Module.rank K V ≤ 1 ↔ (⊤ : Submodule K V).IsPrincipal := by
+  rw [← Submodule.rank_le_one_iff_isPrincipal, rank_top]
+#align module.rank_le_one_iff_top_is_principal Module.rank_le_one_iff_top_isPrincipal
+
+end DivisionRing
+
+end Module
+
+/-! ### The rank of a linear map -/
+
+
+namespace LinearMap
+
+section Ring
+
+variable [Ring K] [AddCommGroup V] [Module K V] [AddCommGroup V₁] [Module K V₁]
+
+variable [AddCommGroup V'] [Module K V']
+
+/-- `rank f` is the rank of a `linear_map` `f`, defined as the dimension of `f.range`. -/
+def rank (f : V →ₗ[K] V') : Cardinal :=
+  Module.rank K f.range
+#align linear_map.rank LinearMap.rank
+
+theorem rank_le_range (f : V →ₗ[K] V₁) : rank f ≤ Module.rank K V₁ :=
+  rank_submodule_le _
+#align linear_map.rank_le_range LinearMap.rank_le_range
+
+@[simp]
+theorem rank_zero [Nontrivial K] : rank (0 : V →ₗ[K] V') = 0 := by
+  rw [rank, LinearMap.range_zero, rank_bot]
+#align linear_map.rank_zero LinearMap.rank_zero
+
+variable [AddCommGroup V''] [Module K V'']
+
+theorem rank_comp_le1 (g : V →ₗ[K] V') (f : V' →ₗ[K] V'') : rank (f.comp g) ≤ rank f :=
+  by
+  refine' rank_le_of_submodule _ _ _
+  rw [LinearMap.range_comp]
+  exact LinearMap.map_le_range
+#align linear_map.rank_comp_le1 LinearMap.rank_comp_le1
+
+variable [AddCommGroup V'₁] [Module K V'₁]
+
+theorem rank_comp_le2 (g : V →ₗ[K] V') (f : V' →ₗ[K] V'₁) : rank (f.comp g) ≤ rank g := by
+  rw [rank, rank, LinearMap.range_comp] <;> exact rank_map_le _ _
+#align linear_map.rank_comp_le2 LinearMap.rank_comp_le2
+
+end Ring
+
+section DivisionRing
+
+variable [DivisionRing K] [AddCommGroup V] [Module K V] [AddCommGroup V₁] [Module K V₁]
+
+variable [AddCommGroup V'] [Module K V']
+
+theorem rank_le_domain (f : V →ₗ[K] V₁) : rank f ≤ Module.rank K V :=
+  by
+  rw [← rank_range_add_rank_ker f]
+  exact self_le_add_right _ _
+#align linear_map.rank_le_domain LinearMap.rank_le_domain
+
+theorem rank_add_le (f g : V →ₗ[K] V') : rank (f + g) ≤ rank f + rank g :=
+  calc
+    rank (f + g) ≤ Module.rank K (f.range ⊔ g.range : Submodule K V') :=
+      by
+      refine' rank_le_of_submodule _ _ _
+      exact
+        LinearMap.range_le_iff_comap.2 <|
+          eq_top_iff'.2 fun x =>
+            show f x + g x ∈ (f.range ⊔ g.range : Submodule K V') from
+              mem_sup.2 ⟨_, ⟨x, rfl⟩, _, ⟨x, rfl⟩, rfl⟩
+    _ ≤ rank f + rank g := Submodule.rank_add_le_rank_add_rank _ _
+    
+#align linear_map.rank_add_le LinearMap.rank_add_le
+
+theorem rank_finset_sum_le {η} (s : Finset η) (f : η → V →ₗ[K] V') :
+    rank (∑ d in s, f d) ≤ ∑ d in s, rank (f d) :=
+  @Finset.sum_hom_rel _ _ _ _ _ (fun a b => rank a ≤ b) f (fun d => rank (f d)) s
+    (le_of_eq rank_zero) fun i g c h => le_trans (rank_add_le _ _) (add_le_add_left h _)
+#align linear_map.rank_finset_sum_le LinearMap.rank_finset_sum_le
+
+theorem le_rank_iff_exists_linearIndependent {c : Cardinal} {f : V →ₗ[K] V'} :
+    c ≤ rank f ↔
+      ∃ s : Set V,
+        Cardinal.lift.{v'} (#s) = Cardinal.lift.{v} c ∧ LinearIndependent K fun x : s => f x :=
+  by
+  rcases f.range_restrict.exists_right_inverse_of_surjective f.range_range_restrict with ⟨g, hg⟩
+  have fg : left_inverse f.range_restrict g := LinearMap.congr_fun hg
+  refine' ⟨fun h => _, _⟩
+  · rcases le_rank_iff_exists_linearIndependent.1 h with ⟨s, rfl, si⟩
+    refine' ⟨g '' s, Cardinal.mk_image_eq_lift _ _ fg.injective, _⟩
+    replace fg : ∀ x, f (g x) = x
+    · intro x
+      convert congr_arg Subtype.val (fg x)
+    replace si : LinearIndependent K fun x : s => f (g x)
+    · simpa only [fg] using si.map' _ (ker_subtype _)
+    exact si.image_of_comp s g f
+  · rintro ⟨s, hsc, si⟩
+    have : LinearIndependent K fun x : s => f.range_restrict x :=
+      LinearIndependent.of_comp f.range.subtype (by convert si)
+    convert cardinal_le_rank_of_linearIndependent this.image
+    rw [← Cardinal.lift_inj, ← hsc, Cardinal.mk_image_eq_of_injOn_lift]
+    exact inj_on_iff_injective.2 this.injective
+#align linear_map.le_rank_iff_exists_linear_independent LinearMap.le_rank_iff_exists_linearIndependent
+
+theorem le_rank_iff_exists_linearIndependent_finset {n : ℕ} {f : V →ₗ[K] V'} :
+    ↑n ≤ rank f ↔ ∃ s : Finset V, s.card = n ∧ LinearIndependent K fun x : (s : Set V) => f x :=
+  by
+  simp only [le_rank_iff_exists_linearIndependent, Cardinal.lift_natCast, Cardinal.lift_eq_nat_iff,
+    Cardinal.mk_set_eq_nat_iff_finset]
+  constructor
+  · rintro ⟨s, ⟨t, rfl, rfl⟩, si⟩
+    exact ⟨t, rfl, si⟩
+  · rintro ⟨s, rfl, si⟩
+    exact ⟨s, ⟨s, rfl, rfl⟩, si⟩
+#align linear_map.le_rank_iff_exists_linear_independent_finset LinearMap.le_rank_iff_exists_linearIndependent_finset
+
+end DivisionRing
+
+end LinearMap
+

--- a/Mathlib/LinearAlgebra/Dimension.lean
+++ b/Mathlib/LinearAlgebra/Dimension.lean
@@ -1346,9 +1346,13 @@ def rank (f : V →ₗ[K] V') : Cardinal :=
   Module.rank K (LinearMap.range f)
 #align linear_map.rank LinearMap.rank
 
-theorem rank_le_range (f : V →ₗ[K] V₁) : rank f ≤ Module.rank K V₁ :=
+theorem rank_le_range (f : V →ₗ[K] V') : rank f ≤ Module.rank K V' :=
   rank_submodule_le _
 #align linear_map.rank_le_range LinearMap.rank_le_range
+
+theorem rank_le_domain (f : V →ₗ[K] V₁) : rank f ≤ Module.rank K V :=
+  rank_range_le _
+#align linear_map.rank_le_domain LinearMap.rank_le_domain
 
 set_option synthInstance.etaExperiment true in -- Porting note: gets around lean4#2074
 @[simp]
@@ -1359,18 +1363,18 @@ theorem rank_zero [Nontrivial K] : rank (0 : V →ₗ[K] V') = 0 := by
 variable [AddCommGroup V''] [Module K V'']
 
 set_option synthInstance.etaExperiment true in -- Porting note: gets around lean4#2074
-theorem rank_comp_le1 (g : V →ₗ[K] V') (f : V' →ₗ[K] V'') : rank (f.comp g) ≤ rank f := by
+theorem rank_comp_le_left (g : V →ₗ[K] V') (f : V' →ₗ[K] V'') : rank (f.comp g) ≤ rank f := by
   refine' rank_le_of_submodule _ _ _
   rw [LinearMap.range_comp]
   exact LinearMap.map_le_range
-#align linear_map.rank_comp_le1 LinearMap.rank_comp_le1
+#align linear_map.rank_comp_le_left LinearMap.rank_comp_le_left
 
 variable [AddCommGroup V'₁] [Module K V'₁]
 
 set_option synthInstance.etaExperiment true in -- Porting note: gets around lean4#2074
-theorem rank_comp_le2 (g : V →ₗ[K] V') (f : V' →ₗ[K] V'₁) : rank (f.comp g) ≤ rank g := by
+theorem rank_comp_le_right (g : V →ₗ[K] V') (f : V' →ₗ[K] V'₁) : rank (f.comp g) ≤ rank g := by
   rw [rank, rank, LinearMap.range_comp]; exact rank_map_le _ _
-#align linear_map.rank_comp_le2 LinearMap.rank_comp_le2
+#align linear_map.rank_comp_le_right LinearMap.rank_comp_le_right
 
 end Ring
 
@@ -1379,11 +1383,6 @@ section DivisionRing
 variable [DivisionRing K] [AddCommGroup V] [Module K V] [AddCommGroup V₁] [Module K V₁]
 
 variable [AddCommGroup V'] [Module K V']
-
-theorem rank_le_domain (f : V →ₗ[K] V₁) : rank f ≤ Module.rank K V := by
-  rw [← rank_range_add_rank_ker f]
-  exact self_le_add_right _ _
-#align linear_map.rank_le_domain LinearMap.rank_le_domain
 
 set_option synthInstance.etaExperiment true in -- Porting note: gets around lean4#2074
 theorem rank_add_le (f g : V →ₗ[K] V') : rank (f + g) ≤ rank f + rank g :=

--- a/Mathlib/LinearAlgebra/Dimension.lean
+++ b/Mathlib/LinearAlgebra/Dimension.lean
@@ -128,7 +128,7 @@ variable {M₁ : Type v} [AddCommGroup M₁] [Module R M₁]
 set_option synthInstance.etaExperiment true in -- Porting note: gets around lean4#2074
 theorem LinearMap.lift_rank_le_of_injective (f : M →ₗ[R] M') (i : Injective f) :
     Cardinal.lift.{v'} (Module.rank R M) ≤ Cardinal.lift.{v} (Module.rank R M') := by
-  simp [Module.rank_def]
+  simp only [Module.rank_def]
   rw [Cardinal.lift_supᵢ (Cardinal.bddAbove_range.{v', v'} _),
     Cardinal.lift_supᵢ (Cardinal.bddAbove_range.{v, v} _)]
   apply csupᵢ_mono' (Cardinal.bddAbove_range.{v', v} _)
@@ -155,7 +155,7 @@ theorem rank_le {n : ℕ}
 set_option synthInstance.etaExperiment true in -- Porting note: gets around lean4#2074
 theorem lift_rank_range_le (f : M →ₗ[R] M') : Cardinal.lift.{v}
     (Module.rank R (LinearMap.range f)) ≤ Cardinal.lift.{v'} (Module.rank R M) := by
-  simp [Module.rank_def]
+  simp only [Module.rank_def]
   rw [Cardinal.lift_supᵢ (Cardinal.bddAbove_range.{v', v'} _)]
   apply csupᵢ_le'
   rintro ⟨s, li⟩
@@ -317,9 +317,8 @@ the module is Noetherian. -/
 theorem LinearIndependent.finite_of_isNoetherian [IsNoetherian R M] {v : ι → M}
     (hv : LinearIndependent R v) : Finite ι := by
   have hwf := isNoetherian_iff_wellFounded.mp (by infer_instance : IsNoetherian R M)
-  refine'
-    CompleteLattice.WellFounded.finite_of_independent hwf hv.independent_span_singleton
-      fun i contra => _
+  refine' CompleteLattice.WellFounded.finite_of_independent hwf hv.independent_span_singleton
+    fun i contra => _
   apply hv.ne_zero i
   have : v i ∈ R ∙ v i := Submodule.mem_span_singleton_self (v i)
   rwa [contra, Submodule.mem_bot] at this
@@ -655,9 +654,8 @@ theorem Basis.le_span {J : Set M} (v : Basis ι R M) (hJ : span R J = ⊤) : (#r
         exact mem_unionᵢ.2 ⟨j, (mem_image _ _ _).2 ⟨i, hj, rfl⟩⟩
     refine' le_of_not_lt fun IJ => _
     suffices (#⋃ j, S' j) < (#range v) by exact not_le_of_lt this ⟨Set.embeddingOfSubset _ _ hs⟩
-    refine'
-      lt_of_le_of_lt (le_trans Cardinal.mk_unionᵢ_le_sum_mk (Cardinal.sum_le_sum _ (fun _ => ℵ₀) _))
-        _
+    refine' lt_of_le_of_lt (le_trans Cardinal.mk_unionᵢ_le_sum_mk
+      (Cardinal.sum_le_sum _ (fun _ => ℵ₀) _)) _
     · exact fun j => (Cardinal.lt_aleph0_of_finite _).le
     · simpa
 #align basis.le_span Basis.le_span
@@ -845,7 +843,7 @@ theorem Basis.mk_eq_rank (v : Basis ι R M) :
 
 theorem Basis.mk_eq_rank'.{m} (v : Basis ι R M) :
     Cardinal.lift.{max v m} (#ι) = Cardinal.lift.{max w m} (Module.rank R M) :=
-  Cardinal.lift_umax_eq.{_, _, m}.mpr v.mk_eq_rank
+  Cardinal.lift_umax_eq.{w, v, m}.mpr v.mk_eq_rank
 #align basis.mk_eq_rank' Basis.mk_eq_rank'
 
 /-- If a module has a finite dimension, all bases are indexed by a finite type. -/
@@ -883,10 +881,8 @@ theorem rank_span_set {s : Set M} (hs : LinearIndependent R (fun x => x : s → 
 /-- If `N` is a submodule in a free, finitely generated module,
 do induction on adjoining a linear independent element to a submodule. -/
 def Submodule.inductionOnRank [IsDomain R] [Fintype ι] (b : Basis ι R M)
-    (P : Submodule R M → Sort _)
-    (ih :
-      ∀ N : Submodule R M,
-        (∀ N' ≤ N, ∀ x ∈ N, (∀ (c : R), ∀ y ∈ N', c • x + y = (0 : M) → c = 0) → P N') → P N)
+    (P : Submodule R M → Sort _) (ih : ∀ N : Submodule R M,
+    (∀ N' ≤ N, ∀ x ∈ N, (∀ (c : R), ∀ y ∈ N', c • x + y = (0 : M) → c = 0) → P N') → P N)
     (N : Submodule R M) : P N :=
   Submodule.inductionOnRankAux b P ih (Fintype.card ι) N fun hs hli => by
     simpa using b.card_le_card_of_linearIndependent hli
@@ -908,12 +904,9 @@ theorem Ideal.rank_eq {R S : Type _} [CommRing R] [StrongRankCondition R] [Ring 
     simp only [← smul_assoc, ← Finset.sum_smul, smul_eq_zero] at hg
     exact hg.resolve_right ha
   exact
-    le_antisymm
-      (b.card_le_card_of_linearIndependent
-        (c.linearIndependent.map' (Submodule.subtype I)
-          ((LinearMap.ker_eq_bot (f := (Submodule.subtype I : I →ₗ[R] S))).mpr
-            Subtype.coe_injective)))
-      (c.card_le_card_of_linearIndependent this)
+    le_antisymm (b.card_le_card_of_linearIndependent (c.linearIndependent.map' (Submodule.subtype I)
+    ((LinearMap.ker_eq_bot (f := (Submodule.subtype I : I →ₗ[R] S))).mpr Subtype.coe_injective)))
+    (c.card_le_card_of_linearIndependent this)
 #align ideal.rank_eq Ideal.rank_eq
 
 variable (R)
@@ -991,9 +984,8 @@ end
 
 set_option synthInstance.etaExperiment true in -- Porting note: gets around lean4#2074
 /-- Two vector spaces are isomorphic if and only if they have the same dimension. -/
-theorem LinearEquiv.nonempty_equiv_iff_lift_rank_eq :
-    Nonempty (V ≃ₗ[K] V') ↔
-      Cardinal.lift.{v'} (Module.rank K V) = Cardinal.lift.{v} (Module.rank K V') :=
+theorem LinearEquiv.nonempty_equiv_iff_lift_rank_eq : Nonempty (V ≃ₗ[K] V') ↔
+    Cardinal.lift.{v'} (Module.rank K V) = Cardinal.lift.{v} (Module.rank K V') :=
   ⟨fun ⟨h⟩ => LinearEquiv.lift_rank_eq h, fun h => nonempty_linearEquiv_of_lift_rank_eq h⟩
 #align linear_equiv.nonempty_equiv_iff_lift_rank_eq LinearEquiv.nonempty_equiv_iff_lift_rank_eq
 
@@ -1006,9 +998,8 @@ theorem LinearEquiv.nonempty_equiv_iff_rank_eq :
 
 /-- The rank of `M × N` is `(Module.rank R M).lift + (Module.rank R N).lift`. -/
 @[simp]
-theorem rank_prod :
-    Module.rank K (V × V') =
-      Cardinal.lift.{v'} (Module.rank K V) + Cardinal.lift.{v, v'} (Module.rank K V') := by
+theorem rank_prod : Module.rank K (V × V') =
+    Cardinal.lift.{v'} (Module.rank K V) + Cardinal.lift.{v, v'} (Module.rank K V') := by
   simpa [rank_eq_card_chooseBasisIndex K V, rank_eq_card_chooseBasisIndex K V', lift_umax,
     lift_umax'] using ((chooseBasis K V).prod (chooseBasis K V')).mk_eq_rank.symm
 #align rank_prod rank_prod
@@ -1026,8 +1017,8 @@ open LinearMap
 
 /-- The rank of a finite product is the sum of the ranks. -/
 @[simp]
-theorem rank_pi [Finite η] : Module.rank K (∀ i, φ i) = Cardinal.sum fun i => Module.rank K (φ i) :=
-  by
+theorem rank_pi [Finite η] : Module.rank K (∀ i, φ i) =
+    Cardinal.sum fun i => Module.rank K (φ i) := by
   cases nonempty_fintype η
   let B i := chooseBasis K (φ i)
   let b : Basis _ K (∀ i, φ i) := Pi.basis fun i => B i
@@ -1041,9 +1032,8 @@ theorem rank_fun {V η : Type u} [Fintype η] [AddCommGroup V] [Module K V] [Mod
   rw [rank_pi, Cardinal.sum_const', Cardinal.mk_fintype]
 #align rank_fun rank_fun
 
-theorem rank_fun_eq_lift_mul :
-    Module.rank K (η → V) =
-      (Fintype.card η : Cardinal.{max u₁' v}) * Cardinal.lift.{u₁'} (Module.rank K V) :=
+theorem rank_fun_eq_lift_mul : Module.rank K (η → V) =
+    (Fintype.card η : Cardinal.{max u₁' v}) * Cardinal.lift.{u₁'} (Module.rank K V) :=
   by rw [rank_pi, Cardinal.sum_const, Cardinal.mk_fintype, Cardinal.lift_natCast]
 #align rank_fun_eq_lift_mul rank_fun_eq_lift_mul
 
@@ -1102,14 +1092,13 @@ theorem rank_span_of_finset (s : Finset V) : Module.rank K (span K (↑s : Set V
     Module.rank K (span K (↑s : Set V)) ≤ (#(↑s : Set V)) := rank_span_le (s : Set V)
     _ = s.card := by rw [Finset.coe_sort_coe, Cardinal.mk_coe_finset]
     _ < ℵ₀ := Cardinal.nat_lt_aleph0 _
-
 #align rank_span_of_finset rank_span_of_finset
 
 theorem rank_quotient_add_rank (p : Submodule K V) :
     Module.rank K (V ⧸ p) + Module.rank K p = Module.rank K V := by
   classical exact
-      let ⟨f⟩ := quotient_prod_linearEquiv p
-      rank_prod'.symm.trans f.rank_eq
+    let ⟨f⟩ := quotient_prod_linearEquiv p
+    rank_prod'.symm.trans f.rank_eq
 #align rank_quotient_add_rank rank_quotient_add_rank
 
 set_option synthInstance.etaExperiment true in -- Porting note: gets around lean4#2074
@@ -1134,7 +1123,9 @@ variable [AddCommGroup V₃] [Module K V₃]
 
 open LinearMap
 
-#eval "TODO: Erase this."
+-- Porting note: this proof goes over the default maxHeartbeats.
+-- Not seeing anything to do here except making an arbitrary split into subconstructions,
+-- as this is on the critical path for porting we will live in the larger maxHeartbeats limit.
 set_option maxHeartbeats 270000 in
 set_option synthInstance.etaExperiment true in -- Porting note: gets around lean4#2074
 /-- This is mostly an auxiliary lemma for `Submodule.rank_sup_add_rank_inf_eq`. -/
@@ -1170,7 +1161,7 @@ theorem rank_add_rank_split (db : V₂ →ₗ[K] V) (eb : V₃ →ₗ[K] V) (cd 
 set_option synthInstance.etaExperiment true in -- Porting note: gets around lean4#2074
 theorem Submodule.rank_sup_add_rank_inf_eq (s t : Submodule K V) :
     Module.rank K (s ⊔ t : Submodule K V) + Module.rank K (s ⊓ t : Submodule K V) =
-      Module.rank K s + Module.rank K t :=
+    Module.rank K s + Module.rank K t :=
   rank_add_rank_split (ofLe le_sup_left) (ofLe le_sup_right) (ofLe inf_le_left) (ofLe inf_le_right)
     (by
       rw [← map_le_map_iff' (ker_subtype <| s ⊔ t), Submodule.map_sup, Submodule.map_top, ←
@@ -1226,9 +1217,8 @@ theorem le_rank_iff_exists_linearIndependent {c : Cardinal} :
     exact cardinal_le_rank_of_linearIndependent si
 #align le_rank_iff_exists_linear_independent le_rank_iff_exists_linearIndependent
 
-theorem le_rank_iff_exists_linearIndependent_finset {n : ℕ} :
-    ↑n ≤ Module.rank K V ↔
-      ∃ s : Finset V, s.card = n ∧ LinearIndependent K ((↑) : ↥(s : Set V) → V) := by
+theorem le_rank_iff_exists_linearIndependent_finset {n : ℕ} : ↑n ≤ Module.rank K V ↔
+    ∃ s : Finset V, s.card = n ∧ LinearIndependent K ((↑) : ↥(s : Set V) → V) := by
   simp only [le_rank_iff_exists_linearIndependent, Cardinal.mk_set_eq_nat_iff_finset]
   constructor
   · rintro ⟨s, ⟨t, rfl, rfl⟩, si⟩
@@ -1289,8 +1279,8 @@ theorem rank_submodule_le_one_iff (s : Submodule K V) :
 /-- A submodule has dimension at most `1` if and only if there is a
 single vector, not necessarily in the submodule, such that the
 submodule is contained in its span. -/
-theorem rank_submodule_le_one_iff' (s : Submodule K V) : Module.rank K s ≤ 1 ↔ ∃ v₀, s ≤ K ∙ v₀ :=
-  by
+theorem rank_submodule_le_one_iff' (s : Submodule K V) :
+    Module.rank K s ≤ 1 ↔ ∃ v₀, s ≤ K ∙ v₀ := by
   rw [rank_submodule_le_one_iff]
   constructor
   · rintro ⟨v₀, _, h⟩
@@ -1391,11 +1381,9 @@ theorem rank_add_le (f g : V →ₗ[K] V') : rank (f + g) ≤ rank f + rank g :=
   calc
     rank (f + g) ≤ Module.rank K (LinearMap.range f ⊔ LinearMap.range g : Submodule K V') := by
       refine' rank_le_of_submodule _ _ _
-      exact
-        LinearMap.range_le_iff_comap.2 <|
-          eq_top_iff'.2 fun x =>
-            show f x + g x ∈ (LinearMap.range f ⊔ LinearMap.range g : Submodule K V') from
-              mem_sup.2 ⟨_, ⟨x, rfl⟩, _, ⟨x, rfl⟩, rfl⟩
+      exact LinearMap.range_le_iff_comap.2 <| eq_top_iff'.2 fun x =>
+        show f x + g x ∈ (LinearMap.range f ⊔ LinearMap.range g : Submodule K V') from
+        mem_sup.2 ⟨_, ⟨x, rfl⟩, _, ⟨x, rfl⟩, rfl⟩
     _ ≤ rank f + rank g := Submodule.rank_add_le_rank_add_rank _ _
 
 #align linear_map.rank_add_le LinearMap.rank_add_le
@@ -1409,9 +1397,8 @@ theorem rank_finset_sum_le {η} (s : Finset η) (f : η → V →ₗ[K] V') :
 
 set_option synthInstance.etaExperiment true in -- Porting note: gets around lean4#2074
 theorem le_rank_iff_exists_linearIndependent {c : Cardinal} {f : V →ₗ[K] V'} :
-    c ≤ rank f ↔
-      ∃ s : Set V,
-        Cardinal.lift.{v'} (#s) = Cardinal.lift.{v} c ∧ LinearIndependent K fun x : s => f x := by
+    c ≤ rank f ↔ ∃ s : Set V, Cardinal.lift.{v'} (#s) =
+    Cardinal.lift.{v} c ∧ LinearIndependent K fun x : s => f x := by
   rcases f.rangeRestrict.exists_rightInverse_of_surjective f.range_rangeRestrict with ⟨g, hg⟩
   have fg : LeftInverse f.rangeRestrict g := LinearMap.congr_fun hg
   refine' ⟨fun h => _, _⟩

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -1245,6 +1245,16 @@ theorem lift_le_aleph0 {c : Cardinal.{u}} : lift.{v} c ≤ ℵ₀ ↔ c ≤ ℵ�
   rw [← lift_aleph0.{u,v}, lift_le]
 #align cardinal.lift_le_aleph_0 Cardinal.lift_le_aleph0
 
+@[simp] -- Porting note: -- not yet forward-ported from mathlib3#18746
+theorem aleph0_lt_lift {c : Cardinal.{u}} : ℵ₀ < lift.{v} c ↔ ℵ₀ < c := by
+  rw [← lift_aleph0.{u,v}, lift_lt]
+#align cardinal.aleph_0_lt_lift Cardinal.aleph0_lt_lift
+
+@[simp] -- Porting note: -- not yet forward-ported from mathlib3#18746
+theorem lift_lt_aleph0 {c : Cardinal.{u}} : lift.{v} c < ℵ₀ ↔ c < ℵ₀ := by
+  rw [← lift_aleph0.{u,v}, lift_lt]
+#align cardinal.lift_lt_aleph_0 Cardinal.lift_lt_aleph0
+
 /-! ### Properties about the cast from `ℕ` -/
 
 -- Porting note : simp can prove this


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Rest assured that at the time of posting this PR, mathport had already incorporated the latest changes to this file. Cf. [Zulip](https://leanprover.zulipchat.com/#narrow/stream/144837-PR-reviews/topic/!4.233247).

* [`linear_algebra.dimension`@`3a2039ad20626aebbece10cddb18ef010f7d912d`..`45ce3929e3bf9a086a216feea3b1ab6c14bf0e67`](https://leanprover-community.github.io/mathlib-port-status/file/linear_algebra/dimension?range=3a2039ad20626aebbece10cddb18ef010f7d912d..45ce3929e3bf9a086a216feea3b1ab6c14bf0e67)

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
