### PR TITLE
chore: partially forward-port leanprover-community/mathlib#18746

### DIFF
--- a/Mathlib/SetTheory/Cardinal/Continuum.lean
+++ b/Mathlib/SetTheory/Cardinal/Continuum.lean
@@ -48,22 +48,26 @@ theorem lift_continuum : lift.{v} 𝔠 = 𝔠 := by
 
 @[simp]
 theorem continuum_le_lift {c : Cardinal.{u}} : 𝔠 ≤ lift.{v} c ↔ 𝔠 ≤ c := by
-  rw [← lift_continuum, lift_le]
+  -- porting note: added explicit universes
+  rw [← lift_continuum.{u,v}, lift_le]
 #align cardinal.continuum_le_lift Cardinal.continuum_le_lift
 
 @[simp]
 theorem lift_le_continuum {c : Cardinal.{u}} : lift.{v} c ≤ 𝔠 ↔ c ≤ 𝔠 := by
-  rw [← lift_continuum, lift_le]
+  -- porting note: added explicit universes
+  rw [← lift_continuum.{u,v}, lift_le]
 #align cardinal.lift_le_continuum Cardinal.lift_le_continuum
 
 @[simp]
 theorem continuum_lt_lift {c : Cardinal.{u}} : 𝔠 < lift.{v} c ↔ 𝔠 < c := by
-  rw [← lift_continuum, lift_lt]
+  -- porting note: added explicit universes
+  rw [← lift_continuum.{u,v}, lift_lt]
 #align cardinal.continuum_lt_lift Cardinal.continuum_lt_lift
 
 @[simp]
 theorem lift_lt_continuum {c : Cardinal.{u}} : lift.{v} c < 𝔠 ↔ c < 𝔠 := by
-  rw [← lift_continuum, lift_lt]
+  -- porting note: added explicit universes
+  rw [← lift_continuum.{u,v}, lift_lt]
 #align cardinal.lift_lt_continuum Cardinal.lift_lt_continuum
 
 /-!

--- a/Mathlib/SetTheory/Cardinal/Continuum.lean
+++ b/Mathlib/SetTheory/Cardinal/Continuum.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 
 ! This file was ported from Lean 3 source module set_theory.cardinal.continuum
-! leanprover-community/mathlib commit 3d7987cda72abc473c7cdbbb075170e9ac620042
+! leanprover-community/mathlib commit e08a42b2dd544cf11eba72e5fc7bf199d4349925
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -45,6 +45,26 @@ theorem two_power_aleph0 : 2 ^ aleph0.{u} = continuum.{u} :=
 theorem lift_continuum : lift.{v} 𝔠 = 𝔠 := by
   rw [← two_power_aleph0, lift_two_power, lift_aleph0, two_power_aleph0]
 #align cardinal.lift_continuum Cardinal.lift_continuum
+
+@[simp]
+theorem continuum_le_lift {c : Cardinal.{u}} : 𝔠 ≤ lift.{v} c ↔ 𝔠 ≤ c := by
+  rw [← lift_continuum, lift_le]
+#align cardinal.continuum_le_lift Cardinal.continuum_le_lift
+
+@[simp]
+theorem lift_le_continuum {c : Cardinal.{u}} : lift.{v} c ≤ 𝔠 ↔ c ≤ 𝔠 := by
+  rw [← lift_continuum, lift_le]
+#align cardinal.lift_le_continuum Cardinal.lift_le_continuum
+
+@[simp]
+theorem continuum_lt_lift {c : Cardinal.{u}} : 𝔠 < lift.{v} c ↔ 𝔠 < c := by
+  rw [← lift_continuum, lift_lt]
+#align cardinal.continuum_lt_lift Cardinal.continuum_lt_lift
+
+@[simp]
+theorem lift_lt_continuum {c : Cardinal.{u}} : lift.{v} c < 𝔠 ↔ c < 𝔠 := by
+  rw [← lift_continuum, lift_lt]
+#align cardinal.lift_lt_continuum Cardinal.lift_lt_continuum
 
 /-!
 ### Inequalities


### PR DESCRIPTION
Unfortunately this seems to need extra universe annotations in Lean 4.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

Most of the rest of this PR is waiting on other forward-ports.

* [`set_theory.cardinal.continuum`@`3d7987cda72abc473c7cdbbb075170e9ac620042`..`e08a42b2dd544cf11eba72e5fc7bf199d4349925`](https://leanprover-community.github.io/mathlib-port-status/file/set_theory/cardinal/continuum?range=3d7987cda72abc473c7cdbbb075170e9ac620042..e08a42b2dd544cf11eba72e5fc7bf199d4349925)
