### PR TITLE
[Merged by Bors] - chore: update SHA for mathlib#18268, #18771, RelIso/Basic

### DIFF
--- a/Mathlib/Algebra/Group/ULift.lean
+++ b/Mathlib/Algebra/Group/ULift.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 
 ! This file was ported from Lean 3 source module algebra.group.ulift
-! leanprover-community/mathlib commit 13e18cfa070ea337ea960176414f5ae3a1534aae
+! leanprover-community/mathlib commit 564bcc44d2b394a50c0cd6340c14a6b02a50a99a
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/

--- a/Mathlib/Order/RelIso/Basic.lean
+++ b/Mathlib/Order/RelIso/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 
 ! This file was ported from Lean 3 source module order.rel_iso.basic
-! leanprover-community/mathlib commit 3353f661228bd27f632c600cd1a58b874d847c90
+! leanprover-community/mathlib commit f29120f82f6e24a6f6579896dfa2de6769fec962
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -192,7 +192,6 @@ theorem Surjective.wellFounded_iff {f : α → β} (hf : Surjective f)
     (by
       refine RelHomClass.wellFounded (RelHom.mk ?_ ?_ : s →r r)
       · exact Classical.choose hf.hasRightInverse
-
       intro a b h
       apply o.2
       convert h
@@ -389,20 +388,36 @@ protected theorem wellFounded : ∀ (_ : r ↪r s) (_ : WellFounded s), WellFoun
   | f, ⟨H⟩ => ⟨fun _ => f.acc _ (H _)⟩
 #align rel_embedding.well_founded RelEmbedding.wellFounded
 
+protected theorem isWellFounded (f : r ↪r s) [IsWellFounded β s] : IsWellFounded α r :=
+  ⟨f.wellFounded IsWellFounded.wf⟩
+#align rel_embedding.is_well_founded RelEmbedding.isWellFounded
+
 protected theorem isWellOrder : ∀ (_ : r ↪r s) [IsWellOrder β s], IsWellOrder α r
   | f, H => { f.isStrictTotalOrder with wf := f.wellFounded H.wf }
 #align rel_embedding.is_well_order RelEmbedding.isWellOrder
 
+end RelEmbedding
+
+instance Subtype.wellFoundedLT [LT α] [WellFoundedLT α] (p : α → Prop) :
+    WellFoundedLT (Subtype p) :=
+  (Subtype.relEmbedding (· < ·) p).isWellFounded
+#align subtype.well_founded_lt Subtype.wellFoundedLT
+
+instance Subtype.wellFoundedGT [LT α] [WellFoundedGT α] (p : α → Prop) :
+    WellFoundedGT (Subtype p) :=
+  (Subtype.relEmbedding (· > ·) p).isWellFounded
+#align subtype.well_founded_gt Subtype.wellFoundedGT
+
 /-- `quotient.mk` as a relation homomorphism between the relation and the lift of a relation. -/
 @[simps]
-def _root_.Quotient.mkRelHom [Setoid α] {r : α → α → Prop}
+def Quotient.mkRelHom [Setoid α] {r : α → α → Prop}
     (H : ∀ (a₁ b₁ a₂ b₂ : α), a₁ ≈ a₂ → b₁ ≈ b₂ → r a₁ b₁ = r a₂ b₂) : r →r Quotient.lift₂ r H :=
   ⟨@Quotient.mk' α _, id⟩
 #align quotient.mk_rel_hom Quotient.mkRelHom
 
 /-- `Quotient.out` as a relation embedding between the lift of a relation and the relation. -/
 @[simps!]
-noncomputable def _root_.Quotient.outRelEmbedding [Setoid α] {r : α → α → Prop}
+noncomputable def Quotient.outRelEmbedding [Setoid α] {r : α → α → Prop}
     (H : ∀ (a₁ b₁ a₂ b₂ : α), a₁ ≈ a₂ → b₁ ≈ b₂ → r a₁ b₁ = r a₂ b₂) : Quotient.lift₂ r H ↪r r :=
   ⟨Embedding.quotientOut α, by
     refine' @fun x y => Quotient.inductionOn₂ x y fun a b => _
@@ -412,14 +427,14 @@ noncomputable def _root_.Quotient.outRelEmbedding [Setoid α] {r : α → α →
 
 /-- `Quotient.out'` as a relation embedding between the lift of a relation and the relation. -/
 @[simps]
-noncomputable def _root_.Quotient.out'RelEmbedding {_ : Setoid α} {r : α → α → Prop}
+noncomputable def Quotient.out'RelEmbedding {_ : Setoid α} {r : α → α → Prop}
     (H : ∀ (a₁ b₁ a₂ b₂ : α), a₁ ≈ a₂ → b₁ ≈ b₂ → r a₁ b₁ = r a₂ b₂) :
     (fun a b => Quotient.liftOn₂' a b r H) ↪r r :=
   { Quotient.outRelEmbedding _ with toFun := Quotient.out' }
 #align rel_embedding.quotient.out'_rel_embedding Quotient.out'RelEmbedding
 
 @[simp]
-theorem _root_.acc_lift₂_iff [Setoid α] {r : α → α → Prop}
+theorem acc_lift₂_iff [Setoid α] {r : α → α → Prop}
     {H : ∀ (a₁ b₁ a₂ b₂ : α), a₁ ≈ a₂ → b₁ ≈ b₂ → r a₁ b₁ = r a₂ b₂} {a} :
     Acc (Quotient.lift₂ r H) ⟦a⟧ ↔ Acc r a := by
   constructor
@@ -433,17 +448,16 @@ theorem _root_.acc_lift₂_iff [Setoid α] {r : α → α → Prop}
 #align acc_lift₂_iff acc_lift₂_iff
 
 @[simp]
-theorem _root_.acc_liftOn₂'_iff {s : Setoid α} {r : α → α → Prop} {H} {a} :
+theorem acc_liftOn₂'_iff {s : Setoid α} {r : α → α → Prop} {H} {a} :
     Acc (fun x y => Quotient.liftOn₂' x y r H) (Quotient.mk'' a : Quotient s) ↔ Acc r a :=
   acc_lift₂_iff
 #align acc_lift_on₂'_iff acc_liftOn₂'_iff
 
 /-- A relation is well founded iff its lift to a quotient is. -/
 @[simp]
-theorem _root_.wellFounded_lift₂_iff [Setoid α] {r : α → α → Prop}
+theorem wellFounded_lift₂_iff [Setoid α] {r : α → α → Prop}
     {H : ∀ (a₁ b₁ a₂ b₂ : α), a₁ ≈ a₂ → b₁ ≈ b₂ → r a₁ b₁ = r a₂ b₂} :
-    WellFounded (Quotient.lift₂ r H) ↔ WellFounded r :=
-  by
+    WellFounded (Quotient.lift₂ r H) ↔ WellFounded r := by
   constructor
   · exact RelHomClass.wellFounded (Quotient.mkRelHom H)
   · refine' fun wf => ⟨fun q => _⟩
@@ -451,21 +465,21 @@ theorem _root_.wellFounded_lift₂_iff [Setoid α] {r : α → α → Prop}
     exact acc_lift₂_iff.2 (wf.apply a)
 #align well_founded_lift₂_iff wellFounded_lift₂_iff
 
-alias _root_.wellFounded_lift₂_iff ↔
-  _root_.WellFounded.of_quotient_lift₂ _root_.WellFounded.quotient_lift₂
+alias wellFounded_lift₂_iff ↔ WellFounded.of_quotient_lift₂ WellFounded.quotient_lift₂
 #align well_founded.of_quotient_lift₂ WellFounded.of_quotient_lift₂
 #align well_founded.quotient_lift₂ WellFounded.quotient_lift₂
 
 @[simp]
-theorem _root_.wellFounded_liftOn₂'_iff {s : Setoid α} {r : α → α → Prop} {H} :
+theorem wellFounded_liftOn₂'_iff {s : Setoid α} {r : α → α → Prop} {H} :
     (WellFounded fun x y : Quotient s => Quotient.liftOn₂' x y r H) ↔ WellFounded r :=
   wellFounded_lift₂_iff
 #align well_founded_lift_on₂'_iff wellFounded_liftOn₂'_iff
 
-alias _root_.wellFounded_liftOn₂'_iff ↔
-  _root_.WellFounded.of_quotient_liftOn₂' _root_.WellFounded.quotient_liftOn₂'
+alias wellFounded_liftOn₂'_iff ↔ WellFounded.of_quotient_liftOn₂' WellFounded.quotient_liftOn₂'
 #align well_founded.of_quotient_lift_on₂' WellFounded.of_quotient_liftOn₂'
 #align well_founded.quotient_lift_on₂' WellFounded.quotient_liftOn₂'
+
+namespace RelEmbedding
 
 /-- To define an relation embedding from an antisymmetric relation `r` to a reflexive relation `s`
 it suffices to give a function together with a proof that it satisfies `s (f a) (f b) ↔ r a b`.
@@ -492,14 +506,10 @@ def ofMonotone [IsTrichotomous α r] [IsAsymm β s] (f : α → β) (H : ∀ a b
   refine' ⟨⟨f, fun a b e => _⟩, @fun a b => ⟨fun h => _, H _ _⟩⟩
   · refine' ((@trichotomous _ r _ a b).resolve_left _).resolve_right _ <;>
       exact fun h => @irrefl _ s _ _ (by simpa [e] using H _ _ h)
-
   · refine' (@trichotomous _ r _ a b).resolve_right (Or.rec (fun e => _) fun h' => _)
     · subst e
       exact irrefl _ h
-
     · exact asymm (H _ _ h') h
-
-
 #align rel_embedding.of_monotone RelEmbedding.ofMonotone
 
 @[simp]
@@ -615,8 +625,7 @@ def toRelEmbedding (f : r ≃r s) : r ↪r s :=
 #align rel_iso.to_rel_embedding RelIso.toRelEmbedding
 
 theorem toEquiv_injective : Injective (toEquiv : r ≃r s → α ≃ β)
-  | ⟨e₁, o₁⟩, ⟨e₂, _⟩, h => by
-    congr
+  | ⟨e₁, o₁⟩, ⟨e₂, _⟩, h => by congr
 #align rel_iso.to_equiv_injective RelIso.toEquiv_injective
 
 instance : CoeOut (r ≃r s) (r ↪r s) :=
@@ -716,22 +725,19 @@ protected def cast {α β : Type u} {r : α → α → Prop} {s : β → β → 
 
 @[simp]
 protected theorem cast_symm {α β : Type u} {r : α → α → Prop} {s : β → β → Prop} (h₁ : α = β)
-    (h₂ : HEq r s) :
-    (RelIso.cast h₁ h₂).symm = RelIso.cast h₁.symm h₂.symm :=
+    (h₂ : HEq r s) : (RelIso.cast h₁ h₂).symm = RelIso.cast h₁.symm h₂.symm :=
   rfl
 #align rel_iso.cast_symm RelIso.cast_symm
 
 @[simp]
 protected theorem cast_refl {α : Type u} {r : α → α → Prop} (h₁ : α = α := rfl)
-    (h₂ : HEq r r := HEq.rfl) :
-    RelIso.cast h₁ h₂ = RelIso.refl r :=
+    (h₂ : HEq r r := HEq.rfl) : RelIso.cast h₁ h₂ = RelIso.refl r :=
   rfl
 #align rel_iso.cast_refl RelIso.cast_refl
 
 @[simp]
 protected theorem cast_trans {α β γ : Type u} {r : α → α → Prop} {s : β → β → Prop}
-    {t : γ → γ → Prop} (h₁ : α = β)
-    (h₁' : β = γ) (h₂ : HEq r s) (h₂' : HEq s t) :
+    {t : γ → γ → Prop} (h₁ : α = β) (h₁' : β = γ) (h₂ : HEq r s) (h₂' : HEq s t) :
     (RelIso.cast h₁ h₂).trans (RelIso.cast h₁' h₂') = RelIso.cast (h₁.trans h₁') (h₂.trans h₂') :=
   ext fun x => by subst h₁; rfl
 #align rel_iso.cast_trans RelIso.cast_trans
@@ -756,12 +762,12 @@ theorem symm_apply_apply (e : r ≃r s) (x : α) : e.symm (e x) = x :=
   e.toEquiv.symm_apply_apply x
 #align rel_iso.symm_apply_apply RelIso.symm_apply_apply
 
-theorem rel_symm_apply (e : r ≃r s) {x y} : r x (e.symm y) ↔ s (e x) y :=
-  by rw [← e.map_rel_iff, e.apply_symm_apply]
+theorem rel_symm_apply (e : r ≃r s) {x y} : r x (e.symm y) ↔ s (e x) y := by
+  rw [← e.map_rel_iff, e.apply_symm_apply]
 #align rel_iso.rel_symm_apply RelIso.rel_symm_apply
 
-theorem symm_apply_rel (e : r ≃r s) {x y} : r (e.symm x) y ↔ s x (e y) :=
-  by rw [← e.map_rel_iff, e.apply_symm_apply]
+theorem symm_apply_rel (e : r ≃r s) {x y} : r (e.symm x) y ↔ s x (e y) := by
+  rw [← e.map_rel_iff, e.apply_symm_apply]
 #align rel_iso.symm_apply_rel RelIso.symm_apply_rel
 
 protected theorem bijective (e : r ≃r s) : Bijective e :=

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro, Floris van Doorn
 
 ! This file was ported from Lean 3 source module set_theory.cardinal.basic
-! leanprover-community/mathlib commit 9dba31df156d9d65b9d78db449542ca73d147c68
+! leanprover-community/mathlib commit e05ead7993520a432bec94ac504842d90707ad63
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -717,8 +717,7 @@ theorem power_le_power_left : ∀ {a b c : Cardinal}, a ≠ 0 → b ≤ c → (a
   exact ⟨@Function.Embedding.arrowCongrLeft _ _ _ ⟨a⟩ e⟩
 #align cardinal.power_le_power_left Cardinal.power_le_power_left
 
-theorem self_le_power (a : Cardinal) {b : Cardinal} (hb : 1 ≤ b) : a ≤ (a^b) :=
-  by
+theorem self_le_power (a : Cardinal) {b : Cardinal} (hb : 1 ≤ b) : a ≤ (a^b) := by
   rcases eq_or_ne a 0 with (rfl | ha)
   · exact zero_le _
   · convert power_le_power_left ha hb
@@ -726,8 +725,7 @@ theorem self_le_power (a : Cardinal) {b : Cardinal} (hb : 1 ≤ b) : a ≤ (a^b)
 #align cardinal.self_le_power Cardinal.self_le_power
 
 /-- **Cantor's theorem** -/
-theorem cantor (a : Cardinal.{u}) : a < (2^a) :=
-  by
+theorem cantor (a : Cardinal.{u}) : a < (2^a) := by
   induction' a using Cardinal.inductionOn with α
   rw [← mk_set]
   refine' ⟨⟨⟨singleton, fun a b => singleton_eq_singleton_iff.1⟩⟩, _⟩
@@ -744,8 +742,7 @@ theorem one_lt_iff_nontrivial {α : Type u} : 1 < (#α) ↔ Nontrivial α := by
   rw [← not_le, le_one_iff_subsingleton, ← not_nontrivial_iff_subsingleton, Classical.not_not]
 #align cardinal.one_lt_iff_nontrivial Cardinal.one_lt_iff_nontrivial
 
-theorem power_le_max_power_one {a b c : Cardinal} (h : b ≤ c) : (a^b) ≤ max (a^c) 1 :=
-  by
+theorem power_le_max_power_one {a b c : Cardinal} (h : b ≤ c) : (a^b) ≤ max (a^c) 1 := by
   by_cases ha : a = 0
   · simp [ha, zero_power_le]
   · exact (power_le_power_left ha h).trans (le_max_left _ _)
@@ -827,13 +824,12 @@ theorem add_one_le_succ (c : Cardinal.{u}) : c + 1 ≤ succ c := by
   calc
     (#γ) + 1 = (#Option γ) := mk_option.symm
     _ ≤ (#β) := (f.optionElim b hb).cardinal_le
-
 #align cardinal.add_one_le_succ Cardinal.add_one_le_succ
 
 /-- A cardinal is a limit if it is not zero or a successor cardinal. Note that `ℵ₀` is a limit
   cardinal by this definition, but `0` isn't.
 
-  Use `is_succ_limit` if you want to include the `c = 0` case. -/
+  Use `isSuccLimit` if you want to include the `c = 0` case. -/
 def IsLimit (c : Cardinal) : Prop :=
   c ≠ 0 ∧ IsSuccLimit c
 #align cardinal.is_limit Cardinal.IsLimit
@@ -878,7 +874,6 @@ theorem sum_const (ι : Type u) (a : Cardinal.{v}) :
       calc
         (Σ _ : ι, Quotient.out (#α)) ≃ ι × Quotient.out (#α) := Equiv.sigmaEquivProd _ _
         _ ≃ ULift ι × ULift α := Equiv.ulift.symm.prodCongr (outMkEquiv.trans Equiv.ulift.symm)
-
 #align cardinal.sum_const Cardinal.sum_const
 
 theorem sum_const' (ι : Type u) (a : Cardinal.{u}) : (sum fun _ : ι => a) = (#ι) * a := by simp
@@ -935,9 +930,7 @@ theorem lift_mk_le_lift_mk_mul_of_lift_mk_preimage_le {α : Type u} {β : Type v
                   exact Equiv.refl _)
                 Equiv.ulift.symm)).trans_le
         (hf b)
-#align
-  cardinal.lift_mk_le_lift_mk_mul_of_lift_mk_preimage_le
-  Cardinal.lift_mk_le_lift_mk_mul_of_lift_mk_preimage_le
+#align cardinal.lift_mk_le_lift_mk_mul_of_lift_mk_preimage_le Cardinal.lift_mk_le_lift_mk_mul_of_lift_mk_preimage_le
 
 /-- The range of an indexed cardinal function, whose outputs live in a higher universe than the
     inputs, is always bounded above. -/
@@ -948,8 +941,7 @@ theorem bddAbove_range {ι : Type u} (f : ι → Cardinal.{max u v}) : BddAbove 
     exact le_sum.{v,u} f i⟩
 #align cardinal.bdd_above_range Cardinal.bddAbove_range
 
-instance (a : Cardinal.{u}) : Small.{u} (Set.Iic a) :=
-  by
+instance (a : Cardinal.{u}) : Small.{u} (Set.Iic a) := by
   rw [← mk_out a]
   apply @small_of_surjective (Set a.out) (Iic (#a.out)) _ fun x => ⟨#x, mk_set_le x⟩
   rintro ⟨x, hx⟩
@@ -960,11 +952,9 @@ instance (a : Cardinal.{u}) : Small.{u} (Set.Iio a) :=
 
 /-- A set of cardinals is bounded above iff it's small, i.e. it corresponds to an usual ZFC set. -/
 theorem bddAbove_iff_small {s : Set Cardinal.{u}} : BddAbove s ↔ Small.{u} s :=
-  ⟨fun ⟨a, ha⟩ => @small_subset _ (Iic a) s (fun x h => ha h) _,
-    by
+  ⟨fun ⟨a, ha⟩ => @small_subset _ (Iic a) s (fun x h => ha h) _, by
     rintro ⟨ι, ⟨e⟩⟩
-    suffices (range fun x : ι => (e.symm x).1) = s
-      by
+    suffices (range fun x : ι => (e.symm x).1) = s by
       rw [← this]
       apply bddAbove_range.{u, u}
     ext x
@@ -986,8 +976,7 @@ theorem bddAbove_image (f : Cardinal.{u} → Cardinal.{max u v}) {s : Set Cardin
 #align cardinal.bdd_above_image Cardinal.bddAbove_image
 
 theorem bddAbove_range_comp {ι : Type u} {f : ι → Cardinal.{v}} (hf : BddAbove (range f))
-    (g : Cardinal.{v} → Cardinal.{max v w}) : BddAbove (range (g ∘ f)) :=
-  by
+    (g : Cardinal.{v} → Cardinal.{max v w}) : BddAbove (range (g ∘ f)) := by
   rw [range_comp]
   exact bddAbove_image.{v,w} g hf
 #align cardinal.bdd_above_range_comp Cardinal.bddAbove_range_comp
@@ -998,21 +987,18 @@ theorem supᵢ_le_sum {ι} (f : ι → Cardinal) : supᵢ f ≤ sum f :=
 
 -- Porting note: Added universe hint .{v,_} below
 theorem sum_le_supᵢ_lift {ι : Type u}
-    (f : ι → Cardinal.{max u v}) : sum f ≤ Cardinal.lift.{v,_} (#ι) * supᵢ f :=
-  by
+    (f : ι → Cardinal.{max u v}) : sum f ≤ Cardinal.lift.{v,_} (#ι) * supᵢ f := by
   rw [← (supᵢ f).lift_id, ← lift_umax, lift_umax.{max u v, u}, ← sum_const]
   exact sum_le_sum _ _ (le_csupᵢ <| bddAbove_range.{u, v} f)
 #align cardinal.sum_le_supr_lift Cardinal.sum_le_supᵢ_lift
 
-theorem sum_le_supᵢ {ι : Type u} (f : ι → Cardinal.{u}) : sum f ≤ (#ι) * supᵢ f :=
-  by
+theorem sum_le_supᵢ {ι : Type u} (f : ι → Cardinal.{u}) : sum f ≤ (#ι) * supᵢ f := by
   rw [← lift_id (#ι)]
   exact sum_le_supᵢ_lift f
 #align cardinal.sum_le_supr Cardinal.sum_le_supᵢ
 
 theorem sum_nat_eq_add_sum_succ (f : ℕ → Cardinal.{u}) :
-    Cardinal.sum f = f 0 + Cardinal.sum fun i => f (i + 1) :=
-  by
+    Cardinal.sum f = f 0 + Cardinal.sum fun i => f (i + 1) := by
   refine' (Equiv.sigmaNatSucc fun i => Quotient.out (f i)).cardinal_eq.trans _
   simp only [mk_sum, mk_out, lift_id, mk_sigma]
 #align cardinal.sum_nat_eq_add_sum_succ Cardinal.sum_nat_eq_add_sum_succ
@@ -1072,8 +1058,7 @@ theorem prod_le_prod {ι} (f g : ι → Cardinal) (H : ∀ i, f i ≤ g i) : pro
 #align cardinal.prod_le_prod Cardinal.prod_le_prod
 
 @[simp]
-theorem prod_eq_zero {ι} (f : ι → Cardinal.{u}) : prod f = 0 ↔ ∃ i, f i = 0 :=
-  by
+theorem prod_eq_zero {ι} (f : ι → Cardinal.{u}) : prod f = 0 ↔ ∃ i, f i = 0 := by
   lift f to ι → Type u using fun _ => trivial
   simp only [mk_eq_zero_iff, ← mk_pi, isEmpty_pi]
 #align cardinal.prod_eq_zero Cardinal.prod_eq_zero
@@ -1083,8 +1068,7 @@ theorem prod_ne_zero {ι} (f : ι → Cardinal) : prod f ≠ 0 ↔ ∀ i, f i �
 
 @[simp]
 theorem lift_prod {ι : Type u} (c : ι → Cardinal.{v}) :
-    lift.{w} (prod c) = prod fun i => lift.{w} (c i) :=
-  by
+    lift.{w} (prod c) = prod fun i => lift.{w} (c i) := by
   lift c to ι → Type v using fun _ => trivial
   simp only [← mk_pi, ← mk_uLift]
   exact mk_congr (Equiv.ulift.trans <| Equiv.piCongrRight fun i => Equiv.ulift.symm)
@@ -1108,8 +1092,7 @@ theorem prod_eq_of_fintype {α : Type u} [h : Fintype α] (f : α → Cardinal.{
 
 -- Porting note: Inserted .{u,v} below
 @[simp]
-theorem lift_infₛ (s : Set Cardinal) : lift.{u,v} (infₛ s) = infₛ (lift.{u,v} '' s) :=
-  by
+theorem lift_infₛ (s : Set Cardinal) : lift.{u,v} (infₛ s) = infₛ (lift.{u,v} '' s) := by
   rcases eq_empty_or_nonempty s with (rfl | hs)
   · simp
   · exact  lift_monotone.map_cinfₛ hs
@@ -1117,8 +1100,7 @@ theorem lift_infₛ (s : Set Cardinal) : lift.{u,v} (infₛ s) = infₛ (lift.{u
 
 -- Porting note: Inserted .{u,v} below
 @[simp]
-theorem lift_infᵢ {ι} (f : ι → Cardinal) : lift.{u,v} (infᵢ f) = ⨅ i, lift.{u,v} (f i) :=
-  by
+theorem lift_infᵢ {ι} (f : ι → Cardinal) : lift.{u,v} (infᵢ f) = ⨅ i, lift.{u,v} (f i) := by
   unfold infᵢ
   convert lift_infₛ (range f)
   simp_rw [←comp_apply (f := lift), range_comp]
@@ -1133,7 +1115,6 @@ theorem lift_down {a : Cardinal.{u}} {b : Cardinal.{max u v}} :
         Eq.symm <| lift_mk_eq.{_, _, v}.2
           ⟨Function.Embedding.equivOfSurjective (Embedding.codRestrict _ f Set.mem_range_self)
               fun ⟨a, ⟨b, e⟩⟩ => ⟨b, Subtype.eq e⟩⟩⟩
-
 #align cardinal.lift_down Cardinal.lift_down
 
 -- Porting note: Inserted .{u,v} below
@@ -1186,8 +1167,8 @@ theorem lift_max {a b : Cardinal} : lift.{u,v} (max a b) = max (lift.{u,v} a) (l
 #align cardinal.lift_max Cardinal.lift_max
 
 /-- The lift of a supremum is the supremum of the lifts. -/
-theorem lift_supₛ {s : Set Cardinal} (hs : BddAbove s) : lift.{u} (supₛ s) = supₛ (lift.{u} '' s) :=
-  by
+theorem lift_supₛ {s : Set Cardinal} (hs : BddAbove s) :
+    lift.{u} (supₛ s) = supₛ (lift.{u} '' s) := by
   apply ((le_csupₛ_iff' (bddAbove_image.{_,u} _ hs)).2 fun c hc => _).antisymm (csupₛ_le' _)
   · intro c hc
     by_contra h
@@ -1209,8 +1190,7 @@ theorem lift_supᵢ {ι : Type v} {f : ι → Cardinal.{w}} (hf : BddAbove (rang
 /-- To prove that the lift of a supremum is bounded by some cardinal `t`,
 it suffices to show that the lift of each cardinal is bounded by `t`. -/
 theorem lift_supᵢ_le {ι : Type v} {f : ι → Cardinal.{w}} {t : Cardinal} (hf : BddAbove (range f))
-    (w : ∀ i, lift.{u} (f i) ≤ t) : lift.{u} (supᵢ f) ≤ t :=
-  by
+    (w : ∀ i, lift.{u} (f i) ≤ t) : lift.{u} (supᵢ f) ≤ t := by
   rw [lift_supᵢ hf]
   exact csupᵢ_le' w
 #align cardinal.lift_supr_le Cardinal.lift_supᵢ_le
@@ -1230,8 +1210,7 @@ if bounded by the lift of some cardinal from the larger supremum.
 -/
 theorem lift_supᵢ_le_lift_supᵢ {ι : Type v} {ι' : Type v'} {f : ι → Cardinal.{w}}
     {f' : ι' → Cardinal.{w'}} (hf : BddAbove (range f)) (hf' : BddAbove (range f')) {g : ι → ι'}
-    (h : ∀ i, lift.{w'} (f i) ≤ lift.{w} (f' (g i))) : lift.{w'} (supᵢ f) ≤ lift.{w} (supᵢ f') :=
-  by
+    (h : ∀ i, lift.{w'} (f i) ≤ lift.{w} (f' (g i))) : lift.{w'} (supᵢ f) ≤ lift.{w} (supᵢ f') := by
   rw [lift_supᵢ hf, lift_supᵢ hf']
   exact csupᵢ_mono' (bddAbove_range_comp.{_,_,w} hf' _) fun i => ⟨_, h i⟩
 #align cardinal.lift_supr_le_lift_supr Cardinal.lift_supᵢ_le_lift_supᵢ
@@ -1400,8 +1379,7 @@ theorem nat_succ (n : ℕ) : (n.succ : Cardinal) = succ ↑n :=
 theorem succ_zero : succ (0 : Cardinal) = 1 := by norm_cast
 #align cardinal.succ_zero Cardinal.succ_zero
 
-theorem card_le_of {α : Type u} {n : ℕ} (H : ∀ s : Finset α, s.card ≤ n) : (#α) ≤ n :=
-  by
+theorem card_le_of {α : Type u} {n : ℕ} (H : ∀ s : Finset α, s.card ≤ n) : (#α) ≤ n := by
   refine' le_of_lt_succ (lt_of_not_ge fun hn => _)
   rw [← Cardinal.nat_succ, ← lift_mk_fin n.succ] at hn
   cases' hn with f
@@ -1410,8 +1388,7 @@ theorem card_le_of {α : Type u} {n : ℕ} (H : ∀ s : Finset α, s.card ≤ n)
   exact n.lt_succ_self
 #align cardinal.card_le_of Cardinal.card_le_of
 
-theorem cantor' (a) {b : Cardinal} (hb : 1 < b) : a < (b^a) :=
-  by
+theorem cantor' (a) {b : Cardinal} (hb : 1 < b) : a < (b^a) := by
   rw [← succ_le_iff, (by norm_cast : succ (1 : Cardinal) = 2)] at hb
   exact (cantor a).trans_le (power_le_power_right hb)
 #align cardinal.cantor' Cardinal.cantor'
@@ -1459,8 +1436,7 @@ theorem aleph0_le {c : Cardinal} : ℵ₀ ≤ c ↔ ∀ n : ℕ, ↑n ≤ c :=
 #align cardinal.aleph_0_le Cardinal.aleph0_le
 
 theorem isSuccLimit_aleph0 : IsSuccLimit ℵ₀ :=
-  isSuccLimit_of_succ_lt fun a ha =>
-    by
+  isSuccLimit_of_succ_lt fun a ha => by
     rcases lt_aleph0.1 ha with ⟨n, rfl⟩
     rw [← nat_succ]
     apply nat_lt_aleph0
@@ -1470,8 +1446,7 @@ theorem isLimit_aleph0 : IsLimit ℵ₀ :=
   ⟨aleph0_ne_zero, isSuccLimit_aleph0⟩
 #align cardinal.is_limit_aleph_0 Cardinal.isLimit_aleph0
 
-theorem IsLimit.aleph0_le {c : Cardinal} (h : IsLimit c) : ℵ₀ ≤ c :=
-  by
+theorem IsLimit.aleph0_le {c : Cardinal} (h : IsLimit c) : ℵ₀ ≤ c := by
   by_contra' h'
   rcases lt_aleph0.1 h' with ⟨_ | n, rfl⟩
   · exact h.ne_zero.irrefl
@@ -1559,8 +1534,7 @@ theorem aleph0_le_add_iff {a b : Cardinal} : ℵ₀ ≤ a + b ↔ ℵ₀ ≤ a �
 #align cardinal.aleph_0_le_add_iff Cardinal.aleph0_le_add_iff
 
 /-- See also `Cardinal.nsmul_lt_aleph0_iff_of_ne_zero` if you already have `n ≠ 0`. -/
-theorem nsmul_lt_aleph0_iff {n : ℕ} {a : Cardinal} : n • a < ℵ₀ ↔ n = 0 ∨ a < ℵ₀ :=
-  by
+theorem nsmul_lt_aleph0_iff {n : ℕ} {a : Cardinal} : n • a < ℵ₀ ↔ n = 0 ∨ a < ℵ₀ := by
   cases n with
   | zero => simpa using nat_lt_aleph0 0
   | succ n =>
@@ -1580,8 +1554,7 @@ theorem mul_lt_aleph0 {a b : Cardinal} (ha : a < ℵ₀) (hb : b < ℵ₀) : a *
   | _, _, ⟨m, rfl⟩, ⟨n, rfl⟩ => by rw [← Nat.cast_mul]; apply nat_lt_aleph0
 #align cardinal.mul_lt_aleph_0 Cardinal.mul_lt_aleph0
 
-theorem mul_lt_aleph0_iff {a b : Cardinal} : a * b < ℵ₀ ↔ a = 0 ∨ b = 0 ∨ a < ℵ₀ ∧ b < ℵ₀ :=
-  by
+theorem mul_lt_aleph0_iff {a b : Cardinal} : a * b < ℵ₀ ↔ a = 0 ∨ b = 0 ∨ a < ℵ₀ ∧ b < ℵ₀ := by
   refine' ⟨fun h => _, _⟩
   · by_cases ha : a = 0
     · exact Or.inl ha
@@ -1599,15 +1572,13 @@ theorem mul_lt_aleph0_iff {a b : Cardinal} : a * b < ℵ₀ ↔ a = 0 ∨ b = 0 
 #align cardinal.mul_lt_aleph_0_iff Cardinal.mul_lt_aleph0_iff
 
 /-- See also `Cardinal.aleph0_le_mul_iff`. -/
-theorem aleph0_le_mul_iff {a b : Cardinal} : ℵ₀ ≤ a * b ↔ a ≠ 0 ∧ b ≠ 0 ∧ (ℵ₀ ≤ a ∨ ℵ₀ ≤ b) :=
-  by
+theorem aleph0_le_mul_iff {a b : Cardinal} : ℵ₀ ≤ a * b ↔ a ≠ 0 ∧ b ≠ 0 ∧ (ℵ₀ ≤ a ∨ ℵ₀ ≤ b) := by
   let h := (@mul_lt_aleph0_iff a b).not
   rwa [not_lt, not_or, not_or, not_and_or, not_lt, not_lt] at h
 #align cardinal.aleph_0_le_mul_iff Cardinal.aleph0_le_mul_iff
 
 /-- See also `Cardinal.aleph0_le_mul_iff'`. -/
-theorem aleph0_le_mul_iff' {a b : Cardinal.{u}} : ℵ₀ ≤ a * b ↔ a ≠ 0 ∧ ℵ₀ ≤ b ∨ ℵ₀ ≤ a ∧ b ≠ 0 :=
-  by
+theorem aleph0_le_mul_iff' {a b : Cardinal.{u}} : ℵ₀ ≤ a * b ↔ a ≠ 0 ∧ ℵ₀ ≤ b ∨ ℵ₀ ≤ a ∧ b ≠ 0 := by
   have : ∀ {a : Cardinal.{u}}, ℵ₀ ≤ a → a ≠ 0 := fun a => ne_bot_of_le_ne_bot aleph0_ne_zero a
   simp only [aleph0_le_mul_iff, and_or_left, and_iff_right_of_imp this, @and_left_comm (a ≠ 0)]
   simp only [and_comm, or_comm]
@@ -1627,7 +1598,6 @@ theorem eq_one_iff_unique {α : Type _} : (#α) = 1 ↔ Subsingleton α ∧ None
     (#α) = 1 ↔ (#α) ≤ 1 ∧ 1 ≤ (#α) := le_antisymm_iff
     _ ↔ Subsingleton α ∧ Nonempty α :=
       le_one_iff_subsingleton.and (one_le_iff_ne_zero.trans mk_ne_zero_iff)
-
 #align cardinal.eq_one_iff_unique Cardinal.eq_one_iff_unique
 
 theorem infinite_iff {α : Type u} : Infinite α ↔ ℵ₀ ≤ (#α) := by
@@ -1645,8 +1615,7 @@ theorem mk_eq_aleph0 (α : Type _) [Countable α] [Infinite α] : (#α) = ℵ₀
 #align cardinal.mk_eq_aleph_0 Cardinal.mk_eq_aleph0
 
 theorem denumerable_iff {α : Type u} : Nonempty (Denumerable α) ↔ (#α) = ℵ₀ :=
-  ⟨fun ⟨h⟩ => mk_congr ((@Denumerable.eqv α h).trans Equiv.ulift.symm), fun h =>
-    by
+  ⟨fun ⟨h⟩ => mk_congr ((@Denumerable.eqv α h).trans Equiv.ulift.symm), fun h => by
     cases' Quotient.exact h with f
     exact ⟨Denumerable.mk' <| f.trans Equiv.ulift⟩⟩
 #align cardinal.denumerable_iff Cardinal.denumerable_iff
@@ -1695,8 +1664,7 @@ theorem nat_add_aleph0 (n : ℕ) : ↑n + ℵ₀ = ℵ₀ := by rw [add_comm, al
 /-- This function sends finite cardinals to the corresponding natural, and infinite cardinals
   to 0. -/
 def toNat : ZeroHom Cardinal ℕ :=
-  ⟨fun c => if h : c < aleph0.{v} then Classical.choose (lt_aleph0.1 h) else 0,
-    by
+  ⟨fun c => if h : c < aleph0.{v} then Classical.choose (lt_aleph0.1 h) else 0, by
     have h : 0 < ℵ₀ := nat_lt_aleph0 0
     dsimp only
     rw [dif_pos h, ← Cardinal.natCast_inj, ← Classical.choose_spec (lt_aleph0.1 h),
@@ -1741,8 +1709,7 @@ theorem toNat_lt_of_lt_of_lt_aleph0 {c d : Cardinal} (hd : d < ℵ₀) (hcd : c 
 #align cardinal.to_nat_lt_of_lt_of_lt_aleph_0 Cardinal.toNat_lt_of_lt_of_lt_aleph0
 
 @[simp]
-theorem toNat_cast (n : ℕ) : Cardinal.toNat n = n :=
-  by
+theorem toNat_cast (n : ℕ) : Cardinal.toNat n = n := by
   rw [toNat_apply_of_lt_aleph0 (nat_lt_aleph0 n), ← natCast_inj]
   exact (Classical.choose_spec (lt_aleph0.1 (nat_lt_aleph0 n))).symm
 #align cardinal.to_nat_cast Cardinal.toNat_cast
@@ -1801,8 +1768,7 @@ theorem toNat_eq_one_iff_unique {α : Type _} : toNat (#α) = 1 ↔ Subsingleton
 #align cardinal.to_nat_eq_one_iff_unique Cardinal.toNat_eq_one_iff_unique
 
 @[simp]
-theorem toNat_lift (c : Cardinal.{v}) : toNat (lift.{u, v} c) = toNat c :=
-  by
+theorem toNat_lift (c : Cardinal.{v}) : toNat (lift.{u, v} c) = toNat c := by
   apply natCast_injective
   cases' lt_or_ge c ℵ₀ with hc hc
   · rw [cast_toNat_of_lt_aleph0, ← lift_natCast.{u,v}, cast_toNat_of_lt_aleph0 hc]
@@ -1817,8 +1783,7 @@ theorem toNat_congr {β : Type v} (e : α ≃ β) : toNat (#α) = toNat (#β) :=
 #align cardinal.to_nat_congr Cardinal.toNat_congr
 
 @[simp]
-theorem toNat_mul (x y : Cardinal) : toNat (x * y) = toNat x * toNat y :=
-  by
+theorem toNat_mul (x y : Cardinal) : toNat (x * y) = toNat x * toNat y := by
   rcases eq_or_ne x 0 with (rfl | hx1)
   · rw [zero_mul, zero_toNat, zero_mul]
   rcases eq_or_ne y 0 with (rfl | hy1)
@@ -1850,8 +1815,7 @@ theorem toNat_finset_prod (s : Finset α) (f : α → Cardinal) :
 
 @[simp]
 theorem toNat_add_of_lt_aleph0 {a : Cardinal.{u}} {b : Cardinal.{v}} (ha : a < ℵ₀) (hb : b < ℵ₀) :
-    toNat (lift.{v, u} a + lift.{u, v} b) = toNat a + toNat b :=
-  by
+    toNat (lift.{v, u} a + lift.{u, v} b) = toNat a + toNat b := by
   apply Cardinal.natCast_injective
   replace ha : lift.{v, u} a < ℵ₀ := by rwa [lift_lt_aleph0]
   replace hb : lift.{u, v} b < ℵ₀ := by rwa [lift_lt_aleph0]
@@ -1924,10 +1888,8 @@ theorem mk_pNat : (#ℕ+) = ℵ₀ :=
 
 /-- **König's theorem** -/
 theorem sum_lt_prod {ι} (f g : ι → Cardinal) (H : ∀ i, f i < g i) : sum f < prod g :=
-  lt_of_not_ge fun ⟨F⟩ =>
-    by
-    have : Inhabited (∀ i : ι, (g i).out) :=
-      by
+  lt_of_not_ge fun ⟨F⟩ => by
+    have : Inhabited (∀ i : ι, (g i).out) := by
       refine' ⟨fun i => Classical.choice <| mk_ne_zero_iff.1 _⟩
       rw [mk_out]
       exact (H i).ne_bot
@@ -1994,7 +1956,6 @@ theorem mk_list_eq_sum_pow (α : Type u) : (#List α) = sum fun n : ℕ => (#α)
   calc
     (#List α) = (#Σn, Vector α n) := mk_congr (Equiv.sigmaFiberEquiv List.length).symm
     _ = sum fun n : ℕ => (#α) ^ℕ n := by simp
-
 #align cardinal.mk_list_eq_sum_pow Cardinal.mk_list_eq_sum_pow
 
 theorem mk_quot_le {α : Type u} {r : α → α → Prop} : (#Quot r) ≤ (#α) :=
@@ -2016,8 +1977,7 @@ theorem mk_emptyCollection (α : Type u) : (#(∅ : Set α)) = 0 :=
   mk_eq_zero _
 #align cardinal.mk_emptyc Cardinal.mk_emptyCollection
 
-theorem mk_emptyCollection_iff {α : Type u} {s : Set α} : (#s) = 0 ↔ s = ∅ :=
-  by
+theorem mk_emptyCollection_iff {α : Type u} {s : Set α} : (#s) = 0 ↔ s = ∅ := by
   constructor
   · intro h
     rw [mk_eq_zero_iff] at h
@@ -2071,7 +2031,6 @@ theorem mk_unionᵢ_le_sum_mk {α ι : Type u} {f : ι → Set α} : (#⋃ i, f 
   calc
     (#⋃ i, f i) ≤ (#Σi, f i) := mk_le_of_surjective (Set.sigmaToUnionᵢ_surjective f)
     _ = sum fun i => #f i := mk_sigma _
-
 #align cardinal.mk_Union_le_sum_mk Cardinal.mk_unionᵢ_le_sum_mk
 
 theorem mk_unionᵢ_eq_sum_mk {α ι : Type u} {f : ι → Set α}
@@ -2079,22 +2038,19 @@ theorem mk_unionᵢ_eq_sum_mk {α ι : Type u} {f : ι → Set α}
   calc
     (#⋃ i, f i) = (#Σi, f i) := mk_congr (Set.unionEqSigmaOfDisjoint h)
     _ = sum fun i => #f i := mk_sigma _
-
 #align cardinal.mk_Union_eq_sum_mk Cardinal.mk_unionᵢ_eq_sum_mk
 
 theorem mk_unionᵢ_le {α ι : Type u} (f : ι → Set α) : (#⋃ i, f i) ≤ (#ι) * ⨆ i, #f i :=
   mk_unionᵢ_le_sum_mk.trans (sum_le_supᵢ _)
 #align cardinal.mk_Union_le Cardinal.mk_unionᵢ_le
 
-theorem mk_unionₛ_le {α : Type u} (A : Set (Set α)) : (#⋃₀ A) ≤ (#A) * ⨆ s : A, #s :=
-  by
+theorem mk_unionₛ_le {α : Type u} (A : Set (Set α)) : (#⋃₀ A) ≤ (#A) * ⨆ s : A, #s := by
   rw [unionₛ_eq_unionᵢ]
   apply mk_unionᵢ_le
 #align cardinal.mk_sUnion_le Cardinal.mk_unionₛ_le
 
 theorem mk_bunionᵢ_le {ι α : Type u} (A : ι → Set α) (s : Set ι) :
-    (#⋃ x ∈ s, A x) ≤ (#s) * ⨆ x : s, #A x.1 :=
-  by
+    (#⋃ x ∈ s, A x) ≤ (#s) * ⨆ x : s, #A x.1 := by
   rw [bunionᵢ_eq_unionᵢ]
   apply mk_unionᵢ_le
 #align cardinal.mk_bUnion_le Cardinal.mk_bunionᵢ_le
@@ -2104,8 +2060,7 @@ theorem finset_card_lt_aleph0 (s : Finset α) : (#(↑s : Set α)) < ℵ₀ :=
 #align cardinal.finset_card_lt_aleph_0 Cardinal.finset_card_lt_aleph0
 
 theorem mk_set_eq_nat_iff_finset {α} {s : Set α} {n : ℕ} :
-    (#s) = n ↔ ∃ t : Finset α, (t : Set α) = s ∧ t.card = n :=
-  by
+    (#s) = n ↔ ∃ t : Finset α, (t : Set α) = s ∧ t.card = n := by
   constructor
   · intro h
     lift s to Finset α using lt_aleph0_iff_set_finite.1 (h.symm ▸ nat_lt_aleph0 n)
@@ -2119,8 +2074,7 @@ theorem mk_eq_nat_iff_finset {n : ℕ} :
   by rw [← mk_univ, mk_set_eq_nat_iff_finset]
 #align cardinal.mk_eq_nat_iff_finset Cardinal.mk_eq_nat_iff_finset
 
-theorem mk_eq_nat_iff_fintype {n : ℕ} : (#α) = n ↔ ∃ h : Fintype α, @Fintype.card α h = n :=
-  by
+theorem mk_eq_nat_iff_fintype {n : ℕ} : (#α) = n ↔ ∃ h : Fintype α, @Fintype.card α h = n := by
   rw [mk_eq_nat_iff_finset]
   constructor
   · rintro ⟨t, ht, hn⟩
@@ -2146,8 +2100,7 @@ theorem mk_union_of_disjoint {α : Type u} {S T : Set α} (H : Disjoint S T) :
 #align cardinal.mk_union_of_disjoint Cardinal.mk_union_of_disjoint
 
 theorem mk_insert {α : Type u} {s : Set α} {a : α} (h : a ∉ s) :
-    (#(insert a s : Set α)) = (#s) + 1 :=
-  by
+    (#(insert a s : Set α)) = (#s) + 1 := by
   rw [← union_singleton, mk_union_of_disjoint, mk_singleton]
   simpa
 #align cardinal.mk_insert Cardinal.mk_insert
@@ -2213,8 +2166,7 @@ theorem mk_preimage_of_injective_lift {α : Type u} {β : Type v} (f : α → β
 #align cardinal.mk_preimage_of_injective_lift Cardinal.mk_preimage_of_injective_lift
 
 theorem mk_preimage_of_subset_range_lift {α : Type u} {β : Type v} (f : α → β) (s : Set β)
-    (h : s ⊆ range f) : lift.{u} (#s) ≤ lift.{v} (#f ⁻¹' s) :=
-  by
+    (h : s ⊆ range f) : lift.{u} (#s) ≤ lift.{v} (#f ⁻¹' s) := by
   rw [lift_mk_le.{v, u, 0}]
   refine' ⟨⟨_, _⟩⟩
   · rintro ⟨y, hy⟩
@@ -2237,7 +2189,6 @@ theorem mk_preimage_of_injective (f : α → β) (s : Set β) (h : Injective f) 
     (#f ⁻¹' s) ≤ (#s) := by
   rw [← lift_id (#↑(f ⁻¹' s)), ← lift_id (#↑(s))]
   exact mk_preimage_of_injective_lift f s h
-
 #align cardinal.mk_preimage_of_injective Cardinal.mk_preimage_of_injective
 
 theorem mk_preimage_of_subset_range (f : α → β) (s : Set β) (h : s ⊆ range f) :
@@ -2254,8 +2205,7 @@ theorem mk_preimage_of_injective_of_subset_range (f : α → β) (s : Set β) (h
   Cardinal.mk_preimage_of_injective_of_subset_range
 
 theorem mk_subset_ge_of_subset_image_lift {α : Type u} {β : Type v} (f : α → β) {s : Set α}
-    {t : Set β} (h : t ⊆ f '' s) : lift.{u} (#t) ≤ lift.{v} (#({ x ∈ s | f x ∈ t } : Set α)) :=
-  by
+    {t : Set β} (h : t ⊆ f '' s) : lift.{u} (#t) ≤ lift.{v} (#({ x ∈ s | f x ∈ t } : Set α)) := by
   rw [image_eq_range] at h
   convert mk_preimage_of_subset_range_lift _ _ h using 1
   rw [mk_sep]
@@ -2263,8 +2213,7 @@ theorem mk_subset_ge_of_subset_image_lift {α : Type u} {β : Type v} (f : α �
 #align cardinal.mk_subset_ge_of_subset_image_lift Cardinal.mk_subset_ge_of_subset_image_lift
 
 theorem mk_subset_ge_of_subset_image (f : α → β) {s : Set α} {t : Set β} (h : t ⊆ f '' s) :
-    (#t) ≤ (#({ x ∈ s | f x ∈ t } : Set α)) :=
-  by
+    (#t) ≤ (#({ x ∈ s | f x ∈ t } : Set α)) := by
   rw [image_eq_range] at h
   convert mk_preimage_of_subset_range _ _ h using 1
   rw [mk_sep]
@@ -2272,8 +2221,7 @@ theorem mk_subset_ge_of_subset_image (f : α → β) {s : Set α} {t : Set β} (
 #align cardinal.mk_subset_ge_of_subset_image Cardinal.mk_subset_ge_of_subset_image
 
 theorem le_mk_iff_exists_subset {c : Cardinal} {α : Type u} {s : Set α} :
-    c ≤ (#s) ↔ ∃ p : Set α, p ⊆ s ∧ (#p) = c :=
-  by
+    c ≤ (#s) ↔ ∃ p : Set α, p ⊆ s ∧ (#p) = c := by
   rw [le_mk_iff_exists_set, ← Subtype.exists_set_subtype]
   apply exists_congr; intro t; rw [mk_image_eq]; apply Subtype.val_injective
 #align cardinal.le_mk_iff_exists_subset Cardinal.le_mk_iff_exists_subset
@@ -2286,8 +2234,7 @@ theorem two_le_iff' (x : α) : (2 : Cardinal) ≤ (#α) ↔ ∃ y : α, y ≠ x 
   rw [two_le_iff, ← nontrivial_iff, nontrivial_iff_exists_ne x]
 #align cardinal.two_le_iff' Cardinal.two_le_iff'
 
-theorem mk_eq_two_iff : (#α) = 2 ↔ ∃ x y : α, x ≠ y ∧ ({x, y} : Set α) = univ :=
-  by
+theorem mk_eq_two_iff : (#α) = 2 ↔ ∃ x y : α, x ≠ y ∧ ({x, y} : Set α) = univ := by
   simp only [← @Nat.cast_two Cardinal, mk_eq_nat_iff_finset, Finset.card_eq_two]
   constructor
   · rintro ⟨t, ht, x, y, hne, rfl⟩
@@ -2296,8 +2243,7 @@ theorem mk_eq_two_iff : (#α) = 2 ↔ ∃ x y : α, x ≠ y ∧ ({x, y} : Set α
     exact ⟨{x, y}, by simpa using h, x, y, hne, rfl⟩
 #align cardinal.mk_eq_two_iff Cardinal.mk_eq_two_iff
 
-theorem mk_eq_two_iff' (x : α) : (#α) = 2 ↔ ∃! y, y ≠ x :=
-  by
+theorem mk_eq_two_iff' (x : α) : (#α) = 2 ↔ ∃! y, y ≠ x := by
   rw [mk_eq_two_iff]; constructor
   · rintro ⟨a, b, hne, h⟩
     simp only [eq_univ_iff_forall, mem_insert_iff, mem_singleton_iff] at h
@@ -2315,11 +2261,9 @@ theorem exists_not_mem_of_length_lt {α : Type _} (l : List α) (h : ↑l.length
     _ ≤ (#l.toFinset) := mk_le_mk_of_subset fun x _ => List.mem_toFinset.mpr (h x)
     _ = l.toFinset.card := Cardinal.mk_coe_finset
     _ ≤ l.length := Cardinal.natCast_le.mpr (List.toFinset_card_le l)
-
 #align cardinal.exists_not_mem_of_length_lt Cardinal.exists_not_mem_of_length_lt
 
-theorem three_le {α : Type _} (h : 3 ≤ (#α)) (x : α) (y : α) : ∃ z : α, z ≠ x ∧ z ≠ y :=
-  by
+theorem three_le {α : Type _} (h : 3 ≤ (#α)) (x : α) (y : α) : ∃ z : α, z ≠ x ∧ z ≠ y := by
   have : ↑(3 : ℕ) ≤ (#α); simpa using h
   have : ↑(2 : ℕ) < (#α); rwa [← succ_le_iff, ← Cardinal.nat_succ]
   have := exists_not_mem_of_length_lt [x, y] this
@@ -2335,15 +2279,13 @@ def powerlt (a b : Cardinal.{u}) : Cardinal.{u} :=
 @[inherit_doc]
 infixl:80 " ^< " => powerlt
 
-theorem le_powerlt {b c : Cardinal.{u}} (a) (h : c < b) : (a^c) ≤ a ^< b :=
-  by
+theorem le_powerlt {b c : Cardinal.{u}} (a) (h : c < b) : (a^c) ≤ a ^< b := by
   apply @le_csupᵢ _ _ _ (fun y : Iio b => a^y) _ ⟨c, h⟩
   rw [← image_eq_range]
   exact bddAbove_image.{u, u} _ bddAbove_Iio
 #align cardinal.le_powerlt Cardinal.le_powerlt
 
-theorem powerlt_le {a b c : Cardinal.{u}} : a ^< b ≤ c ↔ ∀ x < b, (a^x) ≤ c :=
-  by
+theorem powerlt_le {a b c : Cardinal.{u}} : a ^< b ≤ c ↔ ∀ x < b, (a^x) ≤ c := by
   rw [powerlt, csupᵢ_le_iff']
   · simp
   · rw [← image_eq_range]
@@ -2370,8 +2312,7 @@ theorem powerlt_max {a b c : Cardinal} : a ^< max b c = max (a ^< b) (a ^< c) :=
   (powerlt_mono_left a).map_max
 #align cardinal.powerlt_max Cardinal.powerlt_max
 
-theorem zero_powerlt {a : Cardinal} (h : a ≠ 0) : 0 ^< a = 1 :=
-  by
+theorem zero_powerlt {a : Cardinal} (h : a ≠ 0) : 0 ^< a = 1 := by
   apply (powerlt_le.2 fun c _ => zero_power_le _).antisymm
   rw [← power_zero]
   exact le_powerlt 0 (pos_iff_ne_zero.2 h)


### PR DESCRIPTION
* `algebra.group.ulift`: this is a change that was already backported in leanprover-community/mathlib#18268 to match mathlib4, only the SHA needs to be updated.

* `set_theory.cardinal.basic`: the changes from leanprover-community/mathlib#18771 were already forward-ported in #3343, but the sha was not updated. Here I've also inlined all `by`s and generally tidied up the formatting.

* `order.rel_iso.basic` (leanprover-community/mathlib#18699, leanprover-community/mathlib#18758) is now fully forward-ported too.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

* [`algebra.group.ulift`@`13e18cfa070ea337ea960176414f5ae3a1534aae`..`564bcc44d2b394a50c0cd6340c14a6b02a50a99a`](https://leanprover-community.github.io/mathlib-port-status/file/algebra/group/ulift?range=13e18cfa070ea337ea960176414f5ae3a1534aae..564bcc44d2b394a50c0cd6340c14a6b02a50a99a)
* [`set_theory.cardinal.basic`@`9dba31df156d9d65b9d78db449542ca73d147c68`..`e05ead7993520a432bec94ac504842d90707ad63`](https://leanprover-community.github.io/mathlib-port-status/file/set_theory/cardinal/basic?range=9dba31df156d9d65b9d78db449542ca73d147c68..e05ead7993520a432bec94ac504842d90707ad63)
* [`order.rel_iso.basic`@`3353f661228bd27f632c600cd1a58b874d847c90`..`f29120f82f6e24a6f6579896dfa2de6769fec962`](https://leanprover-community.github.io/mathlib-port-status/file/order/rel_iso/basic?range=3353f661228bd27f632c600cd1a58b874d847c90..f29120f82f6e24a6f6579896dfa2de6769fec962)

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
