### PR TITLE
[Merged by Bors] - chore: update sha for LinearAlgebra.AffineSpace.Combination

### DIFF
--- a/Mathlib/LinearAlgebra/AffineSpace/Combination.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Combination.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joseph Myers
 
 ! This file was ported from Lean 3 source module linear_algebra.affine_space.combination
-! leanprover-community/mathlib commit 87c54600fe3cdc7d32ff5b50873ac724d86aef8d
+! leanprover-community/mathlib commit 2de9c37fa71dde2f1c6feff19876dd6a7b1519f0
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/


### PR DESCRIPTION
The hash was out of date due to a fix in the mathlib3 file, which was needed for porting.

* [`linear_algebra.affine_space.combination`@`87c54600fe3cdc7d32ff5b50873ac724d86aef8d`..`2de9c37fa71dde2f1c6feff19876dd6a7b1519f0`](https://leanprover-community.github.io/mathlib-port-status/file/linear_algebra/affine_space/combination?range=87c54600fe3cdc7d32ff5b50873ac724d86aef8d..2de9c37fa71dde2f1c6feff19876dd6a7b1519f0)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
