### PR TITLE
[Merged by Bors] - chore: sync Topology/FiberBundle/Trivialization.lean

### DIFF
--- a/Mathlib/Topology/FiberBundle/Trivialization.lean
+++ b/Mathlib/Topology/FiberBundle/Trivialization.lean
@@ -36,13 +36,13 @@ We provide the following operations on `Trivialization`s.
 ## Implementation notes
 
 Previously, in mathlib, there was a structure `topological_vector_bundle.trivialization` which
-extended another structure `topological_fibre_bundle.trivialization` by a linearity hypothesis. As
+extended another structure `topological_fiber_bundle.trivialization` by a linearity hypothesis. As
 of PR leanprover-community/mathlib#17359, we have changed this to a single structure
-`Trivialization` (no namespace), together with a mixin class `trivialization.is_linear`.
+`Trivialization` (no namespace), together with a mixin class `Trivialization.IsLinear`.
 
-This permits all the *data* of a vector bundle to be held at the level of fibre bundles, so that the
+This permits all the *data* of a vector bundle to be held at the level of fiber bundles, so that the
 same trivializations can underlie an object's structure as (say) a vector bundle over `ℂ` and as a
-vector bundle over `ℝ`, as well as its structure simply as a fibre bundle.
+vector bundle over `ℝ`, as well as its structure simply as a fiber bundle.
 
 This might be a little surprising, given the general trend of the library to ever-increased
 bundling.  But in this case the typical motivation for more bundling does not apply: there is no


### PR DESCRIPTION
Also fix a lean3-style name in the comment.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

See https://github.com/leanprover-community/mathlib/pull/17611.

* [`topology.fiber_bundle.trivialization`@`f2ce6086713c78a7f880485f7917ea547a215982`..`be2c24f56783935652cefffb4bfca7e4b25d167e`](https://leanprover-community.github.io/mathlib-port-status/file/topology/fiber_bundle/trivialization?range=f2ce6086713c78a7f880485f7917ea547a215982..be2c24f56783935652cefffb4bfca7e4b25d167e)

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
