### PR TITLE
[Merged by Bors] - chore: forward port mathlib#17611, 18742, 18198, 18520

### DIFF
--- a/Mathlib/CategoryTheory/Sites/Sheaf.lean
+++ b/Mathlib/CategoryTheory/Sites/Sheaf.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kevin Buzzard, Bhavik Mehta
 
 ! This file was ported from Lean 3 source module category_theory.sites.sheaf
-! leanprover-community/mathlib commit a67ec23dd8dc08195d77b6df2cd21f9c64989131
+! leanprover-community/mathlib commit 2efd2423f8d25fa57cf7a179f5d8652ab4d0df44
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kyle Miller
 
 ! This file was ported from Lean 3 source module combinatorics.simple_graph.connectivity
-! leanprover-community/mathlib commit 13cd3e89b30352d5b1b7349f5537ea18ba878e40
+! leanprover-community/mathlib commit e876965f7ee86f683b44e2f462ab5bfb47f993b3
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -1963,104 +1963,99 @@ def ConnectedComponent := Quot G.Reachable
 def connectedComponentMk (v : V) : G.ConnectedComponent := Quot.mk G.Reachable v
 #align simple_graph.connected_component_mk SimpleGraph.connectedComponentMk
 
+variable {G G' G''}
+
+namespace ConnectedComponent
+
 @[simps]
-instance ConnectedComponent.inhabited [Inhabited V] : Inhabited G.ConnectedComponent :=
+instance inhabited [Inhabited V] : Inhabited G.ConnectedComponent :=
   ⟨G.connectedComponentMk default⟩
 #align simple_graph.connected_component.inhabited SimpleGraph.ConnectedComponent.inhabited
 
-section connectedComponent
-
-variable {G}
-
 @[elab_as_elim]
-protected theorem ConnectedComponent.ind {β : G.ConnectedComponent → Prop}
+protected theorem ind {β : G.ConnectedComponent → Prop}
     (h : ∀ v : V, β (G.connectedComponentMk v)) (c : G.ConnectedComponent) : β c :=
   Quot.ind h c
 #align simple_graph.connected_component.ind SimpleGraph.ConnectedComponent.ind
 
 @[elab_as_elim]
-protected theorem ConnectedComponent.ind₂ {β : G.ConnectedComponent → G.ConnectedComponent → Prop}
+protected theorem ind₂ {β : G.ConnectedComponent → G.ConnectedComponent → Prop}
     (h : ∀ v w : V, β (G.connectedComponentMk v) (G.connectedComponentMk w))
     (c d : G.ConnectedComponent) : β c d :=
   Quot.induction_on₂ c d h
 #align simple_graph.connected_component.ind₂ SimpleGraph.ConnectedComponent.ind₂
 
-protected theorem ConnectedComponent.sound {v w : V} :
+protected theorem sound {v w : V} :
     G.Reachable v w → G.connectedComponentMk v = G.connectedComponentMk w :=
   Quot.sound
 #align simple_graph.connected_component.sound SimpleGraph.ConnectedComponent.sound
 
-protected theorem ConnectedComponent.exact {v w : V} :
+protected theorem exact {v w : V} :
     G.connectedComponentMk v = G.connectedComponentMk w → G.Reachable v w :=
   @Quotient.exact _ G.reachableSetoid _ _
 #align simple_graph.connected_component.exact SimpleGraph.ConnectedComponent.exact
 
 @[simp]
-protected theorem ConnectedComponent.eq {v w : V} :
+protected theorem eq {v w : V} :
     G.connectedComponentMk v = G.connectedComponentMk w ↔ G.Reachable v w :=
   @Quotient.eq' _ G.reachableSetoid _ _
 #align simple_graph.connected_component.eq SimpleGraph.ConnectedComponent.eq
 
 /-- The `ConnectedComponent` specialization of `Quot.lift`. Provides the stronger
 assumption that the vertices are connected by a path. -/
-protected def ConnectedComponent.lift {β : Sort _} (f : V → β)
+protected def lift {β : Sort _} (f : V → β)
     (h : ∀ (v w : V) (p : G.Walk v w), p.IsPath → f v = f w) : G.ConnectedComponent → β :=
   Quot.lift f fun v w (h' : G.Reachable v w) => h'.elim_path fun hp => h v w hp hp.2
 #align simple_graph.connected_component.lift SimpleGraph.ConnectedComponent.lift
 
 @[simp]
-protected theorem ConnectedComponent.lift_mk {β : Sort _} {f : V → β}
+protected theorem lift_mk {β : Sort _} {f : V → β}
     {h : ∀ (v w : V) (p : G.Walk v w), p.IsPath → f v = f w} {v : V} :
     ConnectedComponent.lift f h (G.connectedComponentMk v) = f v :=
   rfl
 #align simple_graph.connected_component.lift_mk SimpleGraph.ConnectedComponent.lift_mk
 
-protected theorem ConnectedComponent.exists {p : G.ConnectedComponent → Prop} :
+protected theorem «exists» {p : G.ConnectedComponent → Prop} :
     (∃ c : G.ConnectedComponent, p c) ↔ ∃ v, p (G.connectedComponentMk v) :=
   (surjective_quot_mk G.Reachable).exists
 #align simple_graph.connected_component.exists SimpleGraph.ConnectedComponent.exists
 
-protected theorem ConnectedComponent.forall {p : G.ConnectedComponent → Prop} :
+protected theorem «forall» {p : G.ConnectedComponent → Prop} :
     (∀ c : G.ConnectedComponent, p c) ↔ ∀ v, p (G.connectedComponentMk v) :=
   (surjective_quot_mk G.Reachable).forall
 #align simple_graph.connected_component.forall SimpleGraph.ConnectedComponent.forall
 
-theorem Preconnected.subsingleton_connectedComponent (h : G.Preconnected) :
+theorem _root_.SimpleGraph.Preconnected.subsingleton_connectedComponent (h : G.Preconnected) :
     Subsingleton G.ConnectedComponent :=
   ⟨ConnectedComponent.ind₂ fun v w => ConnectedComponent.sound (h v w)⟩
 #align simple_graph.preconnected.subsingleton_connected_component SimpleGraph.Preconnected.subsingleton_connectedComponent
 
 /-- The map on connected components induced by a graph homomorphism. -/
-def ConnectedComponent.map {V : Type _} {G : SimpleGraph V} {V' : Type _} {G' : SimpleGraph V'}
-    (φ : G →g G') (C : G.ConnectedComponent) : G'.ConnectedComponent :=
+def map (φ : G →g G') (C : G.ConnectedComponent) : G'.ConnectedComponent :=
   C.lift (fun v => G'.connectedComponentMk (φ v)) fun _ _ p _ =>
     ConnectedComponent.eq.mpr (p.map φ).reachable
 #align simple_graph.connected_component.map SimpleGraph.ConnectedComponent.map
 
 @[simp]
-theorem ConnectedComponent.map_mk {V : Type _} {G : SimpleGraph V} {V' : Type _}
-    {G' : SimpleGraph V'} (φ : G →g G') (v : V) :
+theorem map_mk (φ : G →g G') (v : V) :
     (G.connectedComponentMk v).map φ = G'.connectedComponentMk (φ v) :=
   rfl
 #align simple_graph.connected_component.map_mk SimpleGraph.ConnectedComponent.map_mk
 
 @[simp]
-theorem ConnectedComponent.map_id (C : ConnectedComponent G) : C.map Hom.id = C := by
+theorem map_id (C : ConnectedComponent G) : C.map Hom.id = C := by
   refine' C.ind _
   exact fun _ => rfl
 #align simple_graph.connected_component.map_id SimpleGraph.ConnectedComponent.map_id
 
 @[simp]
-theorem ConnectedComponent.map_comp {V' : Type _} {G' : SimpleGraph V'} {V'' : Type _}
-    {G'' : SimpleGraph V''} (C : G.ConnectedComponent) (φ : G →g G') (ψ : G' →g G'') :
+theorem map_comp (C : G.ConnectedComponent) (φ : G →g G') (ψ : G' →g G'') :
     (C.map φ).map ψ = C.map (ψ.comp φ) := by
   refine' C.ind _
   exact fun _ => rfl
 #align simple_graph.connected_component.map_comp SimpleGraph.ConnectedComponent.map_comp
 
-end connectedComponent
-
-variable {G}
+end ConnectedComponent
 
 /-- A subgraph is connected if it is connected as a simple graph. -/
 abbrev Subgraph.Connected (H : G.Subgraph) : Prop :=
@@ -2100,7 +2095,7 @@ theorem Connected.set_univ_walk_nonempty (hconn : G.Connected) (u v : V) :
 
 namespace Walk
 
-variable {G'} {u v w : V}
+variable {u v w : V}
 
 /-- The subgraph consisting of the vertices and edges of the walk. -/
 @[simp]

--- a/Mathlib/Data/PEquiv.lean
+++ b/Mathlib/Data/PEquiv.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes
 
 ! This file was ported from Lean 3 source module data.pequiv
-! leanprover-community/mathlib commit ee0c179cd3c8a45aa5bffbf1b41d8dbede452865
+! leanprover-community/mathlib commit 7c3269ca3fa4c0c19e4d127cd7151edbdbf99ed4
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/

--- a/Mathlib/Topology/FiberBundle/Trivialization.lean
+++ b/Mathlib/Topology/FiberBundle/Trivialization.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel
 
 ! This file was ported from Lean 3 source module topology.fiber_bundle.trivialization
-! leanprover-community/mathlib commit f2ce6086713c78a7f880485f7917ea547a215982
+! leanprover-community/mathlib commit be2c24f56783935652cefffb4bfca7e4b25d167e
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/


### PR DESCRIPTION
SHA-only updates:
* leanprover-community/mathlib#17611 – `CategoryTheory.Sites.Sheaf` already uses `aesop_cat` at this location, nothing to port.
* leanprover-community/mathlib#18742 – fiber spelling, which is all of the changes to `Topology.FiberBundle.Trivialization`, is already in mathlib4.
* leanprover-community/mathlib#18198 – `FunLike` change to `Data.PEquiv` is already in mathlib4.

Substantative forward port:
* leanprover-community/mathlib#18520

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

* [`category_theory.sites.sheaf`@`a67ec23dd8dc08195d77b6df2cd21f9c64989131`..`2efd2423f8d25fa57cf7a179f5d8652ab4d0df44`](https://leanprover-community.github.io/mathlib-port-status/file/category_theory/sites/sheaf?range=a67ec23dd8dc08195d77b6df2cd21f9c64989131..2efd2423f8d25fa57cf7a179f5d8652ab4d0df44)
* [`topology.fiber_bundle.trivialization`@`f2ce6086713c78a7f880485f7917ea547a215982`..`be2c24f56783935652cefffb4bfca7e4b25d167e`](https://leanprover-community.github.io/mathlib-port-status/file/topology/fiber_bundle/trivialization?range=f2ce6086713c78a7f880485f7917ea547a215982..be2c24f56783935652cefffb4bfca7e4b25d167e)
* [`data.pequiv`@`ee0c179cd3c8a45aa5bffbf1b41d8dbede452865`..`7c3269ca3fa4c0c19e4d127cd7151edbdbf99ed4`](https://leanprover-community.github.io/mathlib-port-status/file/data/pequiv?range=ee0c179cd3c8a45aa5bffbf1b41d8dbede452865..7c3269ca3fa4c0c19e4d127cd7151edbdbf99ed4)
* [`combinatorics.simple_graph.connectivity`@`13cd3e89b30352d5b1b7349f5537ea18ba878e40`..`e876965f7ee86f683b44e2f462ab5bfb47f993b3`](https://leanprover-community.github.io/mathlib-port-status/file/combinatorics/simple_graph/connectivity?range=13cd3e89b30352d5b1b7349f5537ea18ba878e40..e876965f7ee86f683b44e2f462ab5bfb47f993b3)

I have the diff that will forward port leanprover-community/mathlib#18442 as well but it apparently depends on #3082 for a replacement for `rel_embedding.coe_coe_fn`.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
