### PR TITLE
[Merged by Bors] - chore: forward port mathlib#18668, 18781, 18783, 18792, 18794

### DIFF
--- a/Mathlib/LinearAlgebra/Dimension.lean
+++ b/Mathlib/LinearAlgebra/Dimension.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Johannes Hölzl, Sander Dahmen, Scott Morrison
 
 ! This file was ported from Lean 3 source module linear_algebra.dimension
-! leanprover-community/mathlib commit 45ce3929e3bf9a086a216feea3b1ab6c14bf0e67
+! leanprover-community/mathlib commit b5b5dd5a47b5744260e2c9185013075ce9dadccd
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -727,6 +727,11 @@ theorem linearIndependent_le_span {ι : Type _} (v : ι → M) (i : LinearIndepe
   rw [s]
   exact le_top
 #align linear_independent_le_span linearIndependent_le_span
+
+/-- A version of `linearIndependent_le_span` for `Finset`. -/
+theorem linearIndependent_le_span_finset {ι : Type _} (v : ι → M) (i : LinearIndependent R v)
+    (w : Finset M) (s : span R (w : Set M) = ⊤) : (#ι) ≤ Fintype.card w := by
+  simpa only [Finset.coe_sort_coe, Fintype.card_coe] using linearIndependent_le_span v i w s
 
 /-- An auxiliary lemma for `linearIndependent_le_basis`:
 we handle the case where the basis `b` is infinite.

--- a/Mathlib/LinearAlgebra/Dimension.lean
+++ b/Mathlib/LinearAlgebra/Dimension.lean
@@ -730,8 +730,9 @@ theorem linearIndependent_le_span {ι : Type _} (v : ι → M) (i : LinearIndepe
 
 /-- A version of `linearIndependent_le_span` for `Finset`. -/
 theorem linearIndependent_le_span_finset {ι : Type _} (v : ι → M) (i : LinearIndependent R v)
-    (w : Finset M) (s : span R (w : Set M) = ⊤) : (#ι) ≤ Fintype.card w := by
+    (w : Finset M) (s : span R (w : Set M) = ⊤) : (#ι) ≤ w.card := by
   simpa only [Finset.coe_sort_coe, Fintype.card_coe] using linearIndependent_le_span v i w s
+#align linear_independent_le_span_finset linearIndependent_le_span_finset
 
 /-- An auxiliary lemma for `linearIndependent_le_basis`:
 we handle the case where the basis `b` is infinite.

--- a/Mathlib/LinearAlgebra/Finrank.lean
+++ b/Mathlib/LinearAlgebra/Finrank.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes, Anne Baanen
 
 ! This file was ported from Lean 3 source module linear_algebra.finrank
-! leanprover-community/mathlib commit 8535b76e601f11868af3e612fbecb730998a5631
+! leanprover-community/mathlib commit 347636a7a80595d55bedf6e6fbd996a3c39da69a
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/

--- a/Mathlib/LinearAlgebra/Matrix/DotProduct.lean
+++ b/Mathlib/LinearAlgebra/Matrix/DotProduct.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Patrick Massot, Casper Putz, Anne Baanen
 
 ! This file was ported from Lean 3 source module linear_algebra.matrix.dot_product
-! leanprover-community/mathlib commit 738c19f572805cff525a93aa4ffbdf232df05aa8
+! leanprover-community/mathlib commit 46822d96c0c0a8e58a41a0cba1291620967575c5
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -33,9 +33,13 @@ matrix, reindex
 
 universe v w
 
+variable {R : Type v} {n : Type w}
+
 namespace Matrix
 
-variable {R : Type v} [Semiring R] {n : Type w} [Fintype n]
+section semiring
+
+variable [Semiring R] [Fintype n]
 
 @[simp]
 theorem dotProduct_stdBasis_eq_mul [DecidableEq n] (v : n → R) (c : R) (i : n) :
@@ -67,5 +71,32 @@ theorem dotProduct_eq_zero (v : n → R) (h : ∀ w, dotProduct v w = 0) : v = 0
 theorem dotProduct_eq_zero_iff {v : n → R} : (∀ w, dotProduct v w = 0) ↔ v = 0 :=
   ⟨fun h => dotProduct_eq_zero v h, fun h w => h.symm ▸ zero_dotProduct w⟩
 #align matrix.dot_product_eq_zero_iff Matrix.dotProduct_eq_zero_iff
+
+end semiring
+
+section self
+
+variable [Fintype n]
+
+@[simp]
+theorem dot_product_self_eq_zero [LinearOrderedRing R] {v : n → R} : dotProduct v v = 0 ↔ v = 0 :=
+  (Finset.sum_eq_zero_iff_of_nonneg <| fun i _ => mul_self_nonneg (v i)).trans <| by
+    simp [Function.funext_iff]
+
+/-- Note that this applies to `ℂ` via `Complex.StrictOrderedCommRing`. -/
+@[simp]
+theorem dot_product_star_self_eq_zero [StrictOrderedRing R] [StarOrderedRing R] [NoZeroDivisors R]
+    {v : n → R} : dotProduct (star v) v = 0 ↔ v = 0 :=
+  (Finset.sum_eq_zero_iff_of_nonneg <| fun i _ => @star_mul_self_nonneg _ _ _ _ (v i)).trans <| by
+    simp [Function.funext_iff, mul_eq_zero]
+
+/-- Note that this applies to `ℂ` via `Complex.StrictOrderedCommRing`. -/
+@[simp]
+theorem dot_product_self_star_eq_zero [StrictOrderedRing R] [StarOrderedRing R] [NoZeroDivisors R]
+    {v : n → R} : dotProduct v (star v) = 0 ↔ v = 0 :=
+  (Finset.sum_eq_zero_iff_of_nonneg <| fun i _ => @star_mul_self_nonneg' _ _ _ _ (v i)).trans <| by
+    simp [Function.funext_iff, mul_eq_zero]
+
+end self
 
 end Matrix

--- a/Mathlib/LinearAlgebra/Matrix/DotProduct.lean
+++ b/Mathlib/LinearAlgebra/Matrix/DotProduct.lean
@@ -79,23 +79,26 @@ section self
 variable [Fintype n]
 
 @[simp]
-theorem dot_product_self_eq_zero [LinearOrderedRing R] {v : n → R} : dotProduct v v = 0 ↔ v = 0 :=
-  (Finset.sum_eq_zero_iff_of_nonneg <| fun i _ => mul_self_nonneg (v i)).trans <| by
+theorem dotProduct_self_eq_zero [LinearOrderedRing R] {v : n → R} : dotProduct v v = 0 ↔ v = 0 :=
+  (Finset.sum_eq_zero_iff_of_nonneg fun i _ => mul_self_nonneg (v i)).trans <| by
     simp [Function.funext_iff]
+#align matrix.dot_product_self_eq_zero Matrix.dotProduct_self_eq_zero
 
-/-- Note that this applies to `ℂ` via `Complex.StrictOrderedCommRing`. -/
+/-- Note that this applies to `ℂ` via `Complex.strictOrderedCommRing`. -/
 @[simp]
-theorem dot_product_star_self_eq_zero [StrictOrderedRing R] [StarOrderedRing R] [NoZeroDivisors R]
+theorem dotProduct_star_self_eq_zero [StrictOrderedRing R] [StarOrderedRing R] [NoZeroDivisors R]
     {v : n → R} : dotProduct (star v) v = 0 ↔ v = 0 :=
-  (Finset.sum_eq_zero_iff_of_nonneg <| fun i _ => @star_mul_self_nonneg _ _ _ _ (v i)).trans <| by
+  (Finset.sum_eq_zero_iff_of_nonneg fun i _ => @star_mul_self_nonneg _ _ _ _ (v i)).trans <| by
     simp [Function.funext_iff, mul_eq_zero]
+#align matrix.dot_product_star_self_eq_zero Matrix.dotProduct_star_self_eq_zero
 
-/-- Note that this applies to `ℂ` via `Complex.StrictOrderedCommRing`. -/
+/-- Note that this applies to `ℂ` via `Complex.strictOrderedCommRing`. -/
 @[simp]
-theorem dot_product_self_star_eq_zero [StrictOrderedRing R] [StarOrderedRing R] [NoZeroDivisors R]
+theorem dotProduct_self_star_eq_zero [StrictOrderedRing R] [StarOrderedRing R] [NoZeroDivisors R]
     {v : n → R} : dotProduct v (star v) = 0 ↔ v = 0 :=
-  (Finset.sum_eq_zero_iff_of_nonneg <| fun i _ => @star_mul_self_nonneg' _ _ _ _ (v i)).trans <| by
+  (Finset.sum_eq_zero_iff_of_nonneg fun i _ => @star_mul_self_nonneg' _ _ _ _ (v i)).trans <| by
     simp [Function.funext_iff, mul_eq_zero]
+#align matrix.dot_product_self_star_eq_zero Matrix.dotProduct_self_star_eq_zero
 
 end self
 

--- a/Mathlib/RingTheory/Int/Basic.lean
+++ b/Mathlib/RingTheory/Int/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Jens Wagemaker, Aaron Anderson
 
 ! This file was ported from Lean 3 source module ring_theory.int.basic
-! leanprover-community/mathlib commit 2196ab363eb097c008d4497125e0dde23fb36db2
+! leanprover-community/mathlib commit e655e4ea5c6d02854696f97494997ba4c31be802
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -543,9 +543,6 @@ instance commSemiring : CommSemiring Cardinal.{u} where
   npow_zero := @power_zero
   npow_succ n c := show (c ^ (n + 1)) = c * (c ^ n) by rw [power_add, power_one, mul_comm']
 
--- Porting note: this ensures a computable instance.
-instance commMonoid : CommMonoid Cardinal.{u} := CommSemiring.toCommMonoid
-
 /-! Porting note: Deprecated section. Remove. -/
 section deprecated
 set_option linter.deprecated false

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -709,6 +709,11 @@ instance : LinearOrderedCommMonoidWithZero Cardinal.{u} :=
 instance : CommMonoidWithZero Cardinal.{u} :=
   { Cardinal.canonicallyOrderedCommSemiring with }
 
+-- porting note: new
+-- Computable instance to prevent a non-computable one being found via the one above
+instance : CommMonoid Cardinal.{u} :=
+  { Cardinal.canonicallyOrderedCommSemiring with }
+
 theorem zero_power_le (c : Cardinal.{u}) : ((0 : Cardinal.{u})^c) ≤ 1 := by
   by_cases h : c = 0
   · rw [h, power_zero]

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -700,7 +700,7 @@ instance : CanonicallyLinearOrderedAddMonoid Cardinal.{u} :=
 
 -- Computable instance to prevent a non-computable one being found via the one above
 instance : CanonicallyOrderedAddMonoid Cardinal.{u} :=
-{ Cardinal.canonicallyOrderedCommSemiring with }
+  { Cardinal.canonicallyOrderedCommSemiring with }
 
 instance : LinearOrderedCommMonoidWithZero Cardinal.{u} :=
   { Cardinal.commSemiring,
@@ -710,7 +710,7 @@ instance : LinearOrderedCommMonoidWithZero Cardinal.{u} :=
 
 -- Computable instance to prevent a non-computable one being found via the one above
 instance : CommMonoidWithZero Cardinal.{u} :=
-{ Cardinal.canonicallyOrderedCommSemiring with }
+  { Cardinal.canonicallyOrderedCommSemiring with }
 
 theorem zero_power_le (c : Cardinal.{u}) : ((0 : Cardinal.{u})^c) ≤ 1 := by
   by_cases h : c = 0

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro, Floris van Doorn
 
 ! This file was ported from Lean 3 source module set_theory.cardinal.basic
-! leanprover-community/mathlib commit e05ead7993520a432bec94ac504842d90707ad63
+! leanprover-community/mathlib commit 9bb28972724354ac0574e2b318be896ec252025f
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -698,11 +698,19 @@ instance canonicallyOrderedCommSemiring : CanonicallyOrderedCommSemiring Cardina
 instance : CanonicallyLinearOrderedAddMonoid Cardinal.{u} :=
   { Cardinal.canonicallyOrderedCommSemiring, Cardinal.linearOrder with }
 
+-- Computable instance to prevent a non-computable one being found via the one above
+instance : CanonicallyOrderedAddMonoid Cardinal.{u} :=
+{ Cardinal.canonicallyOrderedCommSemiring with }
+
 instance : LinearOrderedCommMonoidWithZero Cardinal.{u} :=
   { Cardinal.commSemiring,
     Cardinal.linearOrder with
     mul_le_mul_left := @mul_le_mul_left' _ _ _ _
     zero_le_one := zero_le _ }
+
+-- Computable instance to prevent a non-computable one being found via the one above
+instance : CommMonoidWithZero Cardinal.{u} :=
+{ Cardinal.canonicallyOrderedCommSemiring with }
 
 theorem zero_power_le (c : Cardinal.{u}) : ((0 : Cardinal.{u})^c) ≤ 1 := by
   by_cases h : c = 0


### PR DESCRIPTION
* `set_theory.cardinal.basic`: forward-ports leanprover-community/mathlib#18781, which backports some ad-hoc changes in #3247 in a more principled way
* `ring_theory.int.basic`: these changes were already forward-ported in #3278, but we forgot the SHA.
* `linear_algebra.dimension`: forward-ports leanprover-community/mathlib#18792
* `linear_algebra.matrix.dot_product`: forward-ports leanprover-community/mathlib#18783
* `linear_algebra.finrank`: forward-ports leanprover-community/mathlib#18794 which is itself a backport of #3378, hence no changes to the file

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

* [`set_theory.cardinal.basic`@`e05ead7993520a432bec94ac504842d90707ad63`..`9bb28972724354ac0574e2b318be896ec252025f`](https://leanprover-community.github.io/mathlib-port-status/file/set_theory/cardinal/basic?range=e05ead7993520a432bec94ac504842d90707ad63..9bb28972724354ac0574e2b318be896ec252025f)
* [`ring_theory.int.basic`@`2196ab363eb097c008d4497125e0dde23fb36db2`..`e655e4ea5c6d02854696f97494997ba4c31be802`](https://leanprover-community.github.io/mathlib-port-status/file/ring_theory/int/basic?range=2196ab363eb097c008d4497125e0dde23fb36db2..e655e4ea5c6d02854696f97494997ba4c31be802)
* [`linear_algebra.dimension`@`45ce3929e3bf9a086a216feea3b1ab6c14bf0e67`..`b5b5dd5a47b5744260e2c9185013075ce9dadccd`](https://leanprover-community.github.io/mathlib-port-status/file/linear_algebra/dimension?range=45ce3929e3bf9a086a216feea3b1ab6c14bf0e67..b5b5dd5a47b5744260e2c9185013075ce9dadccd)
* [`linear_algebra.matrix.dot_product`@`738c19f572805cff525a93aa4ffbdf232df05aa8`..`46822d96c0c0a8e58a41a0cba1291620967575c5`](https://leanprover-community.github.io/mathlib-port-status/file/linear_algebra/matrix/dot_product?range=738c19f572805cff525a93aa4ffbdf232df05aa8..46822d96c0c0a8e58a41a0cba1291620967575c5)
* [`linear_algebra.finrank`@`8535b76e601f11868af3e612fbecb730998a5631`..`347636a7a80595d55bedf6e6fbd996a3c39da69a`](https://leanprover-community.github.io/mathlib-port-status/file/linear_algebra/finrank?range=8535b76e601f11868af3e612fbecb730998a5631..347636a7a80595d55bedf6e6fbd996a3c39da69a)

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
