### PR TITLE
[Merged by Bors] - feat: port Data.Matrix.Notation

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -840,6 +840,7 @@ import Mathlib.Data.Matrix.CharP
 import Mathlib.Data.Matrix.DMatrix
 import Mathlib.Data.Matrix.DualNumber
 import Mathlib.Data.Matrix.Hadamard
+import Mathlib.Data.Matrix.Notation
 import Mathlib.Data.Matrix.PEquiv
 import Mathlib.Data.Multiset.Antidiagonal
 import Mathlib.Data.Multiset.Basic

--- a/Mathlib/Data/Fin/VecNotation.lean
+++ b/Mathlib/Data/Fin/VecNotation.lean
@@ -18,25 +18,25 @@ import Qq
 # Matrix and vector notation
 
 This file defines notation for vectors and matrices. Given `a b c d : α`,
-the notation allows us to write `![a, b, c, d] : fin 4 → α`.
-Nesting vectors gives coefficients of a matrix, so `![![a, b], ![c, d]] : fin 2 → fin 2 → α`.
-In later files we introduce `!![a, b; c, d]` as notation for `matrix.of ![![a, b], ![c, d]]`.
+the notation allows us to write `![a, b, c, d] : Fin 4 → α`.
+Nesting vectors gives coefficients of a matrix, so `![![a, b], ![c, d]] : Fin 2 → Fin 2 → α`.
+In later files we introduce `!![a, b; c, d]` as notation for `Matrix.of ![![a, b], ![c, d]]`.
 
 ## Main definitions
 
-* `vec_empty` is the empty vector (or `0` by `n` matrix) `![]`
-* `vec_cons` prepends an entry to a vector, so `![a, b]` is `vec_cons a (vec_cons b vec_empty)`
+* `vecEmpty` is the empty vector (or `0` by `n` matrix) `![]`
+* `vecCons` prepends an entry to a vector, so `![a, b]` is `vecCons a (vecCons b vecEmpty)`
 
 ## Implementation notes
 
-The `simp` lemmas require that one of the arguments is of the form `vec_cons _ _`.
+The `simp` lemmas require that one of the arguments is of the form `vecCons _ _`.
 This ensures `simp` works with entries only when (some) entries are already given.
 In other words, this notation will only appear in the output of `simp` if it
 already appears in the input.
 
 ## Notations
 
-The main new notation is `![a, b]`, which gets expanded to `vec_cons a (vec_cons b vec_empty)`.
+The main new notation is `![a, b]`, which gets expanded to `vecCons a (vecCons b vecEmpty)`.
 
 ## Examples
 
@@ -60,14 +60,34 @@ def vecEmpty : Fin 0 → α :=
 /-- `vecCons h t` prepends an entry `h` to a vector `t`.
 
 The inverse functions are `vecHead` and `vecTail`.
-The notation `![a, b, ...]` expands to `vecCons a (vec_cons b ...)`.
+The notation `![a, b, ...]` expands to `vecCons a (vecCons b ...)`.
 -/
 def vecCons {n : ℕ} (h : α) (t : Fin n → α) : Fin n.succ → α :=
   Fin.cons h t
 #align matrix.vec_cons Matrix.vecCons
 
 /-- Construct a vector `Fin n → α` using `Matrix.vecEmpty` and `Matrix.vecCons`. -/
-notation3"!["(l", "* => foldr (h t => vecCons h t) vecEmpty)"]" => l
+syntax "![" term,+ "]" : term
+
+/-- Construct a vector `Fin n → α` using `Matrix.vecEmpty` and `Matrix.vecCons`. -/
+syntax "![" "]" : term
+
+macro_rules
+  | `(![$term:term, $terms:term,*]) => `(vecCons $term ![$terms,*])
+  | `(![$term:term]) => `(vecCons $term ![])
+  | `(![]) => `(vecEmpty)
+
+/-- Unexpander for the `![x, y, ...]` notation. -/
+@[app_unexpander vecCons]
+def vecConsUnexpander : Lean.PrettyPrinter.Unexpander
+  | `($_ $term ![$terms,*]) => `(![$term, $terms,*])
+  | `($_ $term ![]) => `(![$term])
+  | _ => throw ()
+
+/-- Unexpander for the `![]` notation. -/
+@[app_unexpander vecEmpty]
+def vecEmptyUnexpander : Lean.PrettyPrinter.Unexpander
+  | _ => `(![])
 
 /-- `vecHead v` gives the first entry of the vector `v` -/
 def vecHead {n : ℕ} (v : Fin n.succ → α) : α :=
@@ -81,7 +101,7 @@ def vecTail {n : ℕ} (v : Fin n.succ → α) : Fin n → α :=
 
 variable {m n : ℕ}
 
-/-- Use `![...]` notation for displaying a vector `fin n → α`, for example:
+/-- Use `![...]` notation for displaying a vector `Fin n → α`, for example:
 
 ```
 #eval ![1, 2] + ![3, 4] -- ![4, 6]
@@ -183,7 +203,7 @@ theorem vec_single_eq_const (a : α) : ![a] = fun _ => a :=
 /-- `![a, b, ...] 1` is equal to `b`.
 
   The simplifier needs a special lemma for length `≥ 2`, in addition to
-  `cons_val_succ`, because `1 : fin 1 = 0 : fin 1`.
+  `cons_val_succ`, because `1 : Fin 1 = 0 : Fin 1`.
 -/
 @[simp]
 theorem cons_val_one (x : α) (u : Fin m.succ → α) : vecCons x u 1 = vecHead u := by
@@ -225,13 +245,13 @@ protected instance _root_.PiFin.toExpr [ToLevel.{u}] [ToExpr α] (n : ℕ) : ToE
 --   | n + 1, v => ``(vecCons $(v 0) $(_root_.pi_fin.to_pexpr <| vecTail v))
 -- #align pi_fin.to_pexpr pi_fin.to_pexpr
 
-/-! ### Numeral (`bit0` and `bit1`) indices
-The following definitions and `simp` lemmas are to allow any
+/-! ### `bit0` and `bit1` indices
+The following definitions and `simp` lemmas are used to allow
 numeral-indexed element of a vector given with matrix notation to
-be extracted by `simp` (even when the numeral is larger than the
+be extracted by `simp` in Lean 3 (even when the numeral is larger than the
 number of elements in the vector, which is taken modulo that number
 of elements by virtue of the semantics of `bit0` and `bit1` and of
-addition on `fin n`).
+addition on `Fin n`).
 -/
 
 
@@ -241,7 +261,7 @@ which provides control of definitional equality for the vector length.
 
 This turns out to be helpful when providing simp lemmas to reduce `![a, b, c] n`, and also means
 that `vecAppend ho u v 0` is valid. `Fin.append u v 0` is not valid in this case because there is
-no `Zero (fin (m + n))` instance. -/
+no `Zero (Fin (m + n))` instance. -/
 def vecAppend {α : Type _} {o : ℕ} (ho : o = m + n) (u : Fin m → α) (v : Fin n → α) : Fin o → α :=
   Fin.append u v ∘ Fin.cast ho
 #align matrix.vec_append Matrix.vecAppend

--- a/Mathlib/Data/Fin/VecNotation.lean
+++ b/Mathlib/Data/Fin/VecNotation.lean
@@ -67,10 +67,7 @@ def vecCons {n : ℕ} (h : α) (t : Fin n → α) : Fin n.succ → α :=
 #align matrix.vec_cons Matrix.vecCons
 
 /-- Construct a vector `Fin n → α` using `Matrix.vecEmpty` and `Matrix.vecCons`. -/
-syntax "![" term,+ "]" : term
-
-/-- Construct a vector `Fin n → α` using `Matrix.vecEmpty` and `Matrix.vecCons`. -/
-syntax "![" "]" : term
+syntax (name := vecNotation) "![" term,* "]" : term
 
 macro_rules
   | `(![$term:term, $terms:term,*]) => `(vecCons $term ![$terms,*])
@@ -80,7 +77,8 @@ macro_rules
 /-- Unexpander for the `![x, y, ...]` notation. -/
 @[app_unexpander vecCons]
 def vecConsUnexpander : Lean.PrettyPrinter.Unexpander
-  | `($_ $term ![$terms,*]) => `(![$term, $terms,*])
+  | `($_ $term ![$term2, $terms,*]) => `(![$term, $term2, $terms,*])
+  | `($_ $term ![$term2]) => `(![$term, $term2])
   | `($_ $term ![]) => `(![$term])
   | _ => throw ()
 

--- a/Mathlib/Data/Matrix/Basic.lean
+++ b/Mathlib/Data/Matrix/Basic.lean
@@ -214,9 +214,13 @@ theorem row_apply (v : n → α) (i j) : row v i j = v j :=
 #align matrix.row_apply Matrix.row_apply
 
 instance inhabited [Inhabited α] : Inhabited (Matrix m n α) :=
+  -- Porting note: this instance was called `Pi.inhabited` in lean3-core, which is much
+  -- nicer than the name `instInhabitedForAll_1` it got in lean4-core...
   instInhabitedForAll_1 _
--- Porting note: this instance was called `Pi.inhabited` in lean3-core, which is much
--- nicer than the name `instInhabitedForAll_1` it got in lean4-core...
+
+-- porting note: new, Lean3 found this automatically
+instance decidableEq [DecidableEq α] [Fintype m] [Fintype n] : DecidableEq (Matrix m n α) :=
+  Fintype.decidablePiFintype
 
 instance add [Add α] : Add (Matrix m n α) :=
   Pi.instAdd

--- a/Mathlib/Data/Matrix/Notation.lean
+++ b/Mathlib/Data/Matrix/Notation.lean
@@ -80,11 +80,9 @@ end toExpr
 section Parser
 open Lean Elab Term Macro TSyntax
 
-syntax (name := matrixPosPos) "!![" sepBy1(sepBy1(term, ",", ", ", allowTrailingSep),
-              ";", "; ", allowTrailingSep) "]" : term
-syntax (name := matrixPosZero) "!![" ";"+ "]" : term
-syntax (name := matrixZeroPos) "!![" ","+ "]" : term
-syntax (name := matrixZeroZero) "!![" "]" : term
+syntax (name := matrixNotation) "!![" sepBy1(term,+,?, ";", "; ", allowTrailingSep) "]" : term
+syntax (name := matrixNotationRx0) "!![" ";"* "]" : term
+syntax (name := matrixNotation0xC) "!![" ","+ "]" : term
 
 macro_rules
   | `(!![$[$[$rows],*];*]) => do
@@ -100,7 +98,6 @@ macro_rules
     let emptyVecs := semicolons.map (fun _ => emptyVec)
     `(@Matrix.of (Fin $(quote semicolons.size)) (Fin 0) _ ![$emptyVecs,*])
   | `(!![$[,%$commas]*]) => `(@Matrix.of (Fin 0) (Fin $(quote commas.size)) _ ![])
-  | `(!![]) => `(@Matrix.of (Fin 0) (Fin 0) _ ![])
 
 end Parser
 

--- a/Mathlib/Data/Matrix/Notation.lean
+++ b/Mathlib/Data/Matrix/Notation.lean
@@ -65,16 +65,16 @@ protected instance toExpr [ToLevel.{u}] [ToLevel.{uₘ}] [ToLevel.{uₙ}]
     [Lean.ToExpr α] [Lean.ToExpr m'] [Lean.ToExpr n'] [Lean.ToExpr (m' → n' → α)] :
     Lean.ToExpr (Matrix m' n' α) where
   toTypeExpr :=
-    let eα : Q(Type $(toLevel.{u})) := toTypeExpr α
-    let em' : Q(Type $(toLevel.{uₘ})) := toTypeExpr m'
-    let en' : Q(Type $(toLevel.{uₙ})) := toTypeExpr n'
+    have eα : Q(Type $(toLevel.{u})) := toTypeExpr α
+    have em' : Q(Type $(toLevel.{uₘ})) := toTypeExpr m'
+    have en' : Q(Type $(toLevel.{uₙ})) := toTypeExpr n'
     q(Matrix $eα $em' $en')
   toExpr M :=
-    let eα : Q(Type $(toLevel.{u})) := toTypeExpr α
-    let em' : Q(Type $(toLevel.{uₘ})) := toTypeExpr m'
-    let en' : Q(Type $(toLevel.{uₙ})) := toTypeExpr n'
-    let eM : Q($em' → $en' → $eα) := toExpr (show m' → n' → α from M)
-    q(Matrix.of $eM) -- TODO: what does this error mean?
+    have eα : Q(Type $(toLevel.{u})) := toTypeExpr α
+    have em' : Q(Type $(toLevel.{uₘ})) := toTypeExpr m'
+    have en' : Q(Type $(toLevel.{uₙ})) := toTypeExpr n'
+    have eM : Q($em' → $en' → $eα) := toExpr (show m' → n' → α from M)
+    q(Matrix.of $eM)
 #align matrix.matrix.reflect Matrix.toExpr
 
 end toExpr

--- a/Mathlib/Data/Matrix/Notation.lean
+++ b/Mathlib/Data/Matrix/Notation.lean
@@ -61,18 +61,15 @@ open Qq
 prevent immediate decay to a function. -/
 protected instance toExpr [ToLevel.{u}] [ToLevel.{uₘ}] [ToLevel.{uₙ}]
     [Lean.ToExpr α] [Lean.ToExpr m'] [Lean.ToExpr n'] [Lean.ToExpr (m' → n' → α)] :
-    Lean.ToExpr (Matrix m' n' α) where
-  toTypeExpr :=
-    have eα : Q(Type $(toLevel.{u})) := toTypeExpr α
-    have em' : Q(Type $(toLevel.{uₘ})) := toTypeExpr m'
-    have en' : Q(Type $(toLevel.{uₙ})) := toTypeExpr n'
+    Lean.ToExpr (Matrix m' n' α) :=
+  have eα : Q(Type $(toLevel.{u})) := toTypeExpr α
+  have em' : Q(Type $(toLevel.{uₘ})) := toTypeExpr m'
+  have en' : Q(Type $(toLevel.{uₙ})) := toTypeExpr n'
+  { toTypeExpr :=
     q(Matrix $eα $em' $en')
-  toExpr M :=
-    have eα : Q(Type $(toLevel.{u})) := toTypeExpr α
-    have em' : Q(Type $(toLevel.{uₘ})) := toTypeExpr m'
-    have en' : Q(Type $(toLevel.{uₙ})) := toTypeExpr n'
-    have eM : Q($em' → $en' → $eα) := toExpr (show m' → n' → α from M)
-    q(Matrix.of $eM)
+    toExpr := fun M =>
+      have eM : Q($em' → $en' → $eα) := toExpr (show m' → n' → α from M)
+      q(Matrix.of $eM) }
 #align matrix.matrix.reflect Matrix.toExpr
 
 end toExpr

--- a/Mathlib/Data/Matrix/Notation.lean
+++ b/Mathlib/Data/Matrix/Notation.lean
@@ -88,7 +88,8 @@ macro_rules
     let rowVecs ← rows.mapM fun row : Array Term => do
       unless row.size = n do
         Macro.throwErrorAt (mkNullNode row)
-          s!"Rows must be of equal length; this row has {row.size} items, the previous rows have {n}"
+          s!"Rows must be of equal length; this row has {row.size} items, the previous rows {"
+          "}have {n}"
       `(![$row,*])
     `(@Matrix.of (Fin $(quote m)) (Fin $(quote n)) _ ![$rowVecs,*])
   | `(!![$[;%$semicolons]*]) => do

--- a/Mathlib/Data/Matrix/Notation.lean
+++ b/Mathlib/Data/Matrix/Notation.lean
@@ -111,14 +111,15 @@ variable (a b : ℕ)
 #eval !![1, 2; 3, 4] + !![3, 4; 5, 6]  -- !![4, 6; 8, 10]
 ```
 -/
-instance [Repr α] : Repr (Matrix (Fin m) (Fin n) α) where
+instance repr [Repr α] : Repr (Matrix (Fin m) (Fin n) α) where
   reprPrec f _p :=
     (Std.Format.bracket "!![" · "]") <|
       (Std.Format.joinSep · (";" ++ Std.Format.line)) <|
         (List.finRange m).map fun i =>
           Std.Format.fill <|  -- wrap line in a single place rather than all at once
             (Std.Format.joinSep · ("," ++ Std.Format.line)) <|
-            (List.finRange n).map fun j => repr (f i j)
+            (List.finRange n).map fun j => _root_.repr (f i j)
+#align matrix.has_repr Matrix.repr
 
 @[simp]
 theorem cons_val' (v : n' → α) (B : Fin m → n' → α) (i j) :

--- a/Mathlib/Data/Matrix/Notation.lean
+++ b/Mathlib/Data/Matrix/Notation.lean
@@ -126,12 +126,12 @@ theorem cons_val' (v : n' → α) (B : Fin m → n' → α) (i j) :
     vecCons v B i j = vecCons (v j) (fun i => B i j) i := by refine' Fin.cases _ _ i <;> simp
 #align matrix.cons_val' Matrix.cons_val'
 
-@[simp]
+@[simp, nolint simpNF] -- Porting note: LHS does not simplify.
 theorem head_val' (B : Fin m.succ → n' → α) (j : n') : (vecHead fun i => B i j) = vecHead B j :=
   rfl
 #align matrix.head_val' Matrix.head_val'
 
-@[simp]
+@[simp, nolint simpNF] -- Porting note: LHS does not simplify.
 theorem tail_val' (B : Fin m.succ → n' → α) (j : n') :
     (vecTail fun i => B i j) = fun i => vecTail B i j := by
   ext
@@ -159,7 +159,7 @@ theorem dotProduct_cons (v : Fin n.succ → α) (x : α) (w : Fin n → α) :
   simp [dotProduct, Fin.sum_univ_succ, vecHead, vecTail]
 #align matrix.dot_product_cons Matrix.dotProduct_cons
 
-@[simp]
+-- @[simp] -- Porting note: simp can prove this
 theorem cons_dotProduct_cons (x : α) (v : Fin n → α) (y : α) (w : Fin n → α) :
     dotProduct (vecCons x v) (vecCons y w) = x * y + dotProduct v w := by simp
 #align matrix.cons_dot_product_cons Matrix.cons_dotProduct_cons
@@ -290,7 +290,7 @@ theorem vecMul_cons (v : Fin n.succ → α) (w : o' → α) (B : Fin n → o' �
   simp [vecMul]
 #align matrix.vec_mul_cons Matrix.vecMul_cons
 
-@[simp]
+-- @[simp] -- Porting note: simp can prove this
 theorem cons_vecMul_cons (x : α) (v : Fin n → α) (w : o' → α) (B : Fin n → o' → α) :
     vecMul (vecCons x v) (of <| vecCons w B) = x • w + vecMul v (of B) := by simp
 #align matrix.cons_vec_mul_cons Matrix.cons_vecMul_cons
@@ -361,12 +361,12 @@ section Smul
 
 variable [Semiring α]
 
-@[simp]
+-- @[simp] -- Porting note: simp can prove this
 theorem smul_mat_empty {m' : Type _} (x : α) (A : Fin 0 → m' → α) : x • A = ![] :=
   empty_eq _
 #align matrix.smul_mat_empty Matrix.smul_mat_empty
 
-@[simp]
+-- @[simp] -- Porting note: simp can prove this
 theorem smul_mat_cons (x : α) (v : n' → α) (A : Fin m → n' → α) :
     x • vecCons v A = vecCons (x • v) (x • A) := by
   ext i

--- a/Mathlib/Data/Matrix/Notation.lean
+++ b/Mathlib/Data/Matrix/Notation.lean
@@ -80,11 +80,11 @@ end toExpr
 section Parser
 open Lean Elab Term Macro TSyntax
 
-syntax "!![" sepBy1(sepBy1(term, ",", ", ", allowTrailingSep),
+syntax (name := matrixPosPos) "!![" sepBy1(sepBy1(term, ",", ", ", allowTrailingSep),
               ";", "; ", allowTrailingSep) "]" : term
-syntax "!![" ";"+ "]" : term
-syntax "!![" ","+ "]" : term
-syntax "!![" "]" : term
+syntax (name := matrixPosZero) "!![" ";"+ "]" : term
+syntax (name := matrixZeroPos) "!![" ","+ "]" : term
+syntax (name := matrixZeroZero) "!![" "]" : term
 
 macro_rules
   | `(!![$[$[$rows],*];*]) => do

--- a/Mathlib/Data/Matrix/Notation.lean
+++ b/Mathlib/Data/Matrix/Notation.lean
@@ -84,7 +84,7 @@ syntax (name := matrixNotation0xC) "!![" ","+ "]" : term
 macro_rules
   | `(!![$[$[$rows],*];*]) => do
     let m := rows.size
-    let n := rows[0]!.size
+    let n := if h : 0 < m then rows[0].size else 0
     let rowVecs ← rows.mapM fun row : Array Term => do
       unless row.size = n do
         Macro.throwErrorAt (mkNullNode row)

--- a/Mathlib/Data/Matrix/Notation.lean
+++ b/Mathlib/Data/Matrix/Notation.lean
@@ -37,8 +37,8 @@ already appears in the input.
 
 This file provide notation `!![a, b; c, d]` for matrices, which corresponds to
 `Matrix.of ![![a, b], ![c, d]]`.
-Note that in lean 4 the pretty-printer will not show `!!` notation, instead showing the version
-with `of ![![...]]`.
+TODO: until we implement a `Lean.PrettyPrinter.Unexpander` for `Matrix.of`, the pretty-printer will
+not show `!!` notation, instead showing the version with `of ![![...]]`.
 
 ## Examples
 
@@ -80,8 +80,6 @@ open Lean Elab Term Macro TSyntax
 syntax (name := matrixNotation) "!![" sepBy1(term,+,?, ";", "; ", allowTrailingSep) "]" : term
 syntax (name := matrixNotationRx0) "!![" ";"* "]" : term
 syntax (name := matrixNotation0xC) "!![" ","+ "]" : term
-
-#check mkNullNode
 
 macro_rules
   | `(!![$[$[$rows],*];*]) => do

--- a/Mathlib/Data/Matrix/Notation.lean
+++ b/Mathlib/Data/Matrix/Notation.lean
@@ -161,7 +161,7 @@ theorem head_val' (B : Fin m.succ → n' → α) (j : n') : (vecHead fun i => B 
 theorem tail_val' (B : Fin m.succ → n' → α) (j : n') :
     (vecTail fun i => B i j) = fun i => vecTail B i j := by
   ext
-  simp [vec_tail]
+  simp [vecTail]
 #align matrix.tail_val' Matrix.tail_val'
 
 section DotProduct
@@ -176,13 +176,13 @@ theorem dotProduct_empty (v w : Fin 0 → α) : dotProduct v w = 0 :=
 @[simp]
 theorem cons_dotProduct (x : α) (v : Fin n → α) (w : Fin n.succ → α) :
     dotProduct (vecCons x v) w = x * vecHead w + dotProduct v (vecTail w) := by
-  simp [dot_product, Fin.sum_univ_succ, vec_head, vec_tail]
+  simp [dotProduct, Fin.sum_univ_succ, vecHead, vecTail]
 #align matrix.cons_dot_product Matrix.cons_dotProduct
 
 @[simp]
 theorem dotProduct_cons (v : Fin n.succ → α) (x : α) (w : Fin n → α) :
     dotProduct v (vecCons x w) = vecHead v * x + dotProduct (vecTail v) w := by
-  simp [dot_product, Fin.sum_univ_succ, vec_head, vec_tail]
+  simp [dotProduct, Fin.sum_univ_succ, vecHead, vecTail]
 #align matrix.dot_product_cons Matrix.dotProduct_cons
 
 @[simp]
@@ -202,7 +202,7 @@ theorem col_empty (v : Fin 0 → α) : col v = vecEmpty :=
 @[simp]
 theorem col_cons (x : α) (u : Fin m → α) : col (vecCons x u) = vecCons (fun _ => x) (col u) := by
   ext (i j)
-  refine' Fin.cases _ _ i <;> simp [vec_head, vec_tail]
+  refine' Fin.cases _ _ i <;> simp [vecHead, vecTail]
 #align matrix.col_cons Matrix.col_cons
 
 @[simp]
@@ -227,8 +227,8 @@ theorem transpose_empty_rows (A : Matrix m' (Fin 0) α) : Aᵀ = of ![] :=
 #align matrix.transpose_empty_rows Matrix.transpose_empty_rows
 
 @[simp]
-theorem transpose_empty_cols (A : Matrix (Fin 0) m' α) : Aᵀ = of fun i => ![] :=
-  funext fun i => empty_eq _
+theorem transpose_empty_cols (A : Matrix (Fin 0) m' α) : Aᵀ = of fun _ => ![] :=
+  funext fun _ => empty_eq _
 #align matrix.transpose_empty_cols Matrix.transpose_empty_cols
 
 @[simp]
@@ -306,14 +306,14 @@ theorem vecMul_empty [Fintype n'] (v : n' → α) (B : Matrix n' (Fin 0) α) : v
 theorem cons_vecMul (x : α) (v : Fin n → α) (B : Fin n.succ → o' → α) :
     vecMul (vecCons x v) (of B) = x • vecHead B + vecMul v (of <| vecTail B) := by
   ext i
-  simp [vec_mul]
+  simp [vecMul]
 #align matrix.cons_vec_mul Matrix.cons_vecMul
 
 @[simp]
 theorem vecMul_cons (v : Fin n.succ → α) (w : o' → α) (B : Fin n → o' → α) :
     vecMul v (of <| vecCons w B) = vecHead v • w + vecMul (vecTail v) (of B) := by
   ext i
-  simp [vec_mul]
+  simp [vecMul]
 #align matrix.vec_mul_cons Matrix.vecMul_cons
 
 @[simp]
@@ -341,14 +341,14 @@ theorem mulVec_empty (A : Matrix m' (Fin 0) α) (v : Fin 0 → α) : mulVec A v 
 theorem cons_mulVec [Fintype n'] (v : n' → α) (A : Fin m → n' → α) (w : n' → α) :
     mulVec (of <| vecCons v A) w = vecCons (dotProduct v w) (mulVec (of A) w) := by
   ext i
-  refine' Fin.cases _ _ i <;> simp [mul_vec]
+  refine' Fin.cases _ _ i <;> simp [mulVec]
 #align matrix.cons_mul_vec Matrix.cons_mulVec
 
 @[simp]
 theorem mulVec_cons {α} [CommSemiring α] (A : m' → Fin n.succ → α) (x : α) (v : Fin n → α) :
     mulVec (of A) (vecCons x v) = x • vecHead ∘ A + mulVec (of (vecTail ∘ A)) v := by
   ext i
-  simp [mul_vec, mul_comm]
+  simp [mulVec, mul_comm]
 #align matrix.mul_vec_cons Matrix.mulVec_cons
 
 end MulVec
@@ -364,21 +364,21 @@ theorem empty_vecMulVec (v : Fin 0 → α) (w : n' → α) : vecMulVec v w = ![]
 
 @[simp]
 theorem vecMulVec_empty (v : m' → α) (w : Fin 0 → α) : vecMulVec v w = fun _ => ![] :=
-  funext fun i => empty_eq _
+  funext fun _ => empty_eq _
 #align matrix.vec_mul_vec_empty Matrix.vecMulVec_empty
 
 @[simp]
 theorem cons_vecMulVec (x : α) (v : Fin m → α) (w : n' → α) :
     vecMulVec (vecCons x v) w = vecCons (x • w) (vecMulVec v w) := by
   ext i
-  refine' Fin.cases _ _ i <;> simp [vec_mul_vec]
+  refine' Fin.cases _ _ i <;> simp [vecMulVec]
 #align matrix.cons_vec_mul_vec Matrix.cons_vecMulVec
 
 @[simp]
 theorem vecMulVec_cons (v : m' → α) (x : α) (w : Fin n → α) :
     vecMulVec v (vecCons x w) = fun i => v i • vecCons x w := by
   ext (i j)
-  rw [vec_mul_vec_apply, Pi.smul_apply, smul_eq_mul]
+  rw [vecMulVec_apply, Pi.smul_apply, smul_eq_mul]
 #align matrix.vec_mul_vec_cons Matrix.vecMulVec_cons
 
 end VecMulVec
@@ -485,7 +485,7 @@ theorem mul_fin_two [AddCommMonoid α] [Mul α] (a₁₁ a₁₂ a₂₁ a₂₂
         "./././Mathport/Syntax/Translate/Expr.lean:387:14: unsupported user notation matrix.notation" :=
   by
   ext (i j)
-  fin_cases i <;> fin_cases j <;> simp [Matrix.mul, dot_product, Fin.sum_univ_succ]
+  fin_cases i <;> fin_cases j <;> simp [Matrix.mul, dotProduct, Fin.sum_univ_succ]
 #align matrix.mul_fin_two Matrix.mul_fin_two
 
 /- ./././Mathport/Syntax/Translate/Expr.lean:207:4: warning: unsupported notation `«expr!![ » -/
@@ -504,7 +504,7 @@ theorem mul_fin_three [AddCommMonoid α] [Mul α]
         "./././Mathport/Syntax/Translate/Expr.lean:387:14: unsupported user notation matrix.notation" :=
   by
   ext (i j)
-  fin_cases i <;> fin_cases j <;> simp [Matrix.mul, dot_product, Fin.sum_univ_succ, ← add_assoc]
+  fin_cases i <;> fin_cases j <;> simp [Matrix.mul, dotProduct, Fin.sum_univ_succ, ← add_assoc]
 #align matrix.mul_fin_three Matrix.mul_fin_three
 
 theorem vec2_eq {a₀ a₁ b₀ b₁ : α} (h₀ : a₀ = b₀) (h₁ : a₁ = b₁) : ![a₀, a₁] = ![b₀, b₁] := by
@@ -536,7 +536,7 @@ theorem smul_vec3 {R : Type _} [SMul R α] (x : R) (a₀ a₁ a₂ : α) :
 variable [AddCommMonoid α] [Mul α]
 
 theorem vec2_dot_product' {a₀ a₁ b₀ b₁ : α} : ![a₀, a₁] ⬝ᵥ ![b₀, b₁] = a₀ * b₀ + a₁ * b₁ := by
-  rw [cons_dot_product_cons, cons_dot_product_cons, dot_product_empty, add_zero]
+  rw [cons_dotProduct_cons, cons_dotProduct_cons, dotProduct_empty, add_zero]
 #align matrix.vec2_dot_product' Matrix.vec2_dot_product'
 
 @[simp]
@@ -546,7 +546,7 @@ theorem vec2_dotProduct (v w : Fin 2 → α) : v ⬝ᵥ w = v 0 * w 0 + v 1 * w 
 
 theorem vec3_dot_product' {a₀ a₁ a₂ b₀ b₁ b₂ : α} :
     ![a₀, a₁, a₂] ⬝ᵥ ![b₀, b₁, b₂] = a₀ * b₀ + a₁ * b₁ + a₂ * b₂ := by
-  rw [cons_dot_product_cons, cons_dot_product_cons, cons_dot_product_cons, dot_product_empty,
+  rw [cons_dotProduct_cons, cons_dotProduct_cons, cons_dotProduct_cons, dotProduct_empty,
     add_zero, add_assoc]
 #align matrix.vec3_dot_product' Matrix.vec3_dot_product'
 
@@ -558,4 +558,3 @@ theorem vec3_dotProduct (v w : Fin 3 → α) : v ⬝ᵥ w = v 0 * w 0 + v 1 * w 
 end Vec2AndVec3
 
 end Matrix
-

--- a/Mathlib/Data/Matrix/Notation.lean
+++ b/Mathlib/Data/Matrix/Notation.lean
@@ -81,13 +81,16 @@ syntax (name := matrixNotation) "!![" sepBy1(term,+,?, ";", "; ", allowTrailingS
 syntax (name := matrixNotationRx0) "!![" ";"* "]" : term
 syntax (name := matrixNotation0xC) "!![" ","+ "]" : term
 
+#check mkNullNode
+
 macro_rules
   | `(!![$[$[$rows],*];*]) => do
     let m := rows.size
     let n := rows[0]!.size
     let rowVecs ← rows.mapM fun row : Array Term => do
       unless row.size = n do
-        Macro.throwError "Rows must be of equal length"
+        Macro.throwErrorAt (mkNullNode row)
+          s!"Rows must be of equal length; this row has {row.size} items, the previous rows have {n}"
       `(![$row,*])
     `(@Matrix.of (Fin $(quote m)) (Fin $(quote n)) _ ![$rowVecs,*])
   | `(!![$[;%$semicolons]*]) => do

--- a/Mathlib/Data/Matrix/Notation.lean
+++ b/Mathlib/Data/Matrix/Notation.lean
@@ -18,17 +18,17 @@ import Qq
 /-!
 # Matrix and vector notation
 
-This file includes `simp` lemmas for applying operations in `data.matrix.basic` to values built out
-of the matrix notation `![a, b] = vec_cons a (vec_cons b vec_empty)` defined in
-`data.fin.vec_notation`.
+This file includes `simp` lemmas for applying operations in `Data.Matrix.Basic` to values built out
+of the matrix notation `![a, b] = vecCons a (vecCons b vecEmpty)` defined in
+`Data.Fin.VecNotation`.
 
-This also provides the new notation `!![a, b; c, d] = matrix.of ![![a, b], ![c, d]]`.
-This notation also works for empty matrices; `!![,,,] : matrix (fin 0) (fin 3)` and
-`!![;;;] : matrix (fin 3) (fin 0)`.
+This also provides the new notation `!![a, b; c, d] = Matrix.of ![![a, b], ![c, d]]`.
+This notation also works for empty matrices; `!![,,,] : Matrix (Fin 0) (Fin 3)` and
+`!![;;;] : Matrix (Fin 3) (Fin 0)`.
 
 ## Implementation notes
 
-The `simp` lemmas require that one of the arguments is of the form `vec_cons _ _`.
+The `simp` lemmas require that one of the arguments is of the form `vecCons _ _`.
 This ensures `simp` works with entries only when (some) entries are already given.
 In other words, this notation will only appear in the output of `simp` if it
 already appears in the input.
@@ -36,10 +36,8 @@ already appears in the input.
 ## Notations
 
 This file provide notation `!![a, b; c, d]` for matrices, which corresponds to
-`matrix.of ![![a, b], ![c, d]]`.
-A parser for `a, b; c, d`-style strings is provided as `matrix.entry_parser`, while
-`matrix.notation` provides the hook for the `!!` notation.
-Note that in lean 3 the pretty-printer will not show `!!` notation, instead showing the version
+`Matrix.of ![![a, b], ![c, d]]`.
+Note that in lean 4 the pretty-printer will not show `!!` notation, instead showing the version
 with `of ![![...]]`.
 
 ## Examples
@@ -107,7 +105,7 @@ end Parser
 
 variable (a b : ℕ)
 
-/-- Use `![...]` notation for displaying a `fin`-indexed matrix, for example:
+/-- Use `![...]` notation for displaying a `Fin`-indexed matrix, for example:
 
 ```
 #eval !![1, 2; 3, 4] + !![3, 4; 5, 6]  -- !![4, 6; 8, 10]
@@ -399,95 +397,63 @@ section One
 
 variable [Zero α] [One α]
 
-/- ./././Mathport/Syntax/Translate/Expr.lean:207:4: warning: unsupported notation `«expr!![ » -/
-/- ./././Mathport/Syntax/Translate/Expr.lean:387:14: unsupported user notation matrix.notation -/
-theorem one_fin_two :
-    (1 : Matrix (Fin 2) (Fin 2) α) =
-      «expr!![ »
-        "./././Mathport/Syntax/Translate/Expr.lean:387:14: unsupported user notation matrix.notation" :=
-  by
+theorem one_fin_two : (1 : Matrix (Fin 2) (Fin 2) α) = !![1, 0; 0, 1] := by
   ext (i j)
   fin_cases i <;> fin_cases j <;> rfl
 #align matrix.one_fin_two Matrix.one_fin_two
 
-/- ./././Mathport/Syntax/Translate/Expr.lean:207:4: warning: unsupported notation `«expr!![ » -/
-/- ./././Mathport/Syntax/Translate/Expr.lean:387:14: unsupported user notation matrix.notation -/
-theorem one_fin_three :
-    (1 : Matrix (Fin 3) (Fin 3) α) =
-      «expr!![ »
-        "./././Mathport/Syntax/Translate/Expr.lean:387:14: unsupported user notation matrix.notation" :=
-  by
+theorem one_fin_three : (1 : Matrix (Fin 3) (Fin 3) α) = !![1, 0, 0; 0, 1, 0; 0, 0, 1] := by
   ext (i j)
   fin_cases i <;> fin_cases j <;> rfl
 #align matrix.one_fin_three Matrix.one_fin_three
 
 end One
 
-/- ./././Mathport/Syntax/Translate/Expr.lean:207:4: warning: unsupported notation `«expr!![ » -/
-/- ./././Mathport/Syntax/Translate/Expr.lean:387:14: unsupported user notation matrix.notation -/
-theorem eta_fin_two (A : Matrix (Fin 2) (Fin 2) α) :
-    A =
-      «expr!![ »
-        "./././Mathport/Syntax/Translate/Expr.lean:387:14: unsupported user notation matrix.notation" :=
-  by
+theorem eta_fin_two (A : Matrix (Fin 2) (Fin 2) α) : A = !![A 0 0, A 0 1; A 1 0, A 1 1] := by
   ext (i j)
   fin_cases i <;> fin_cases j <;> rfl
 #align matrix.eta_fin_two Matrix.eta_fin_two
 
-/- ./././Mathport/Syntax/Translate/Expr.lean:207:4: warning: unsupported notation `«expr!![ » -/
-/- ./././Mathport/Syntax/Translate/Expr.lean:387:14: unsupported user notation matrix.notation -/
 theorem eta_fin_three (A : Matrix (Fin 3) (Fin 3) α) :
-    A =
-      «expr!![ »
-        "./././Mathport/Syntax/Translate/Expr.lean:387:14: unsupported user notation matrix.notation" :=
-  by
+    A = !![A 0 0, A 0 1, A 0 2;
+           A 1 0, A 1 1, A 1 2;
+           A 2 0, A 2 1, A 2 2] := by
   ext (i j)
   fin_cases i <;> fin_cases j <;> rfl
 #align matrix.eta_fin_three Matrix.eta_fin_three
 
-/- ./././Mathport/Syntax/Translate/Expr.lean:207:4: warning: unsupported notation `«expr!![ » -/
-/- ./././Mathport/Syntax/Translate/Expr.lean:387:14: unsupported user notation matrix.notation -/
-/- ./././Mathport/Syntax/Translate/Expr.lean:207:4: warning: unsupported notation `«expr!![ » -/
-/- ./././Mathport/Syntax/Translate/Expr.lean:387:14: unsupported user notation matrix.notation -/
-/- ./././Mathport/Syntax/Translate/Expr.lean:207:4: warning: unsupported notation `«expr!![ » -/
-/- ./././Mathport/Syntax/Translate/Expr.lean:387:14: unsupported user notation matrix.notation -/
 theorem mul_fin_two [AddCommMonoid α] [Mul α] (a₁₁ a₁₂ a₂₁ a₂₂ b₁₁ b₁₂ b₂₁ b₂₂ : α) :
-    «expr!![ »
-          "./././Mathport/Syntax/Translate/Expr.lean:387:14: unsupported user notation matrix.notation" ⬝
-        «expr!![ »
-          "./././Mathport/Syntax/Translate/Expr.lean:387:14: unsupported user notation matrix.notation" =
-      «expr!![ »
-        "./././Mathport/Syntax/Translate/Expr.lean:387:14: unsupported user notation matrix.notation" :=
-  by
+    !![a₁₁, a₁₂;
+       a₂₁, a₂₂] ⬝ !![b₁₁, b₁₂;
+                      b₂₁, b₂₂] = !![a₁₁ * b₁₁ + a₁₂ * b₂₁, a₁₁ * b₁₂ + a₁₂ * b₂₂;
+                                     a₂₁ * b₁₁ + a₂₂ * b₂₁, a₂₁ * b₁₂ + a₂₂ * b₂₂] := by
   ext (i j)
   fin_cases i <;> fin_cases j <;> simp [Matrix.mul, dotProduct, Fin.sum_univ_succ]
 #align matrix.mul_fin_two Matrix.mul_fin_two
 
-/- ./././Mathport/Syntax/Translate/Expr.lean:207:4: warning: unsupported notation `«expr!![ » -/
-/- ./././Mathport/Syntax/Translate/Expr.lean:387:14: unsupported user notation matrix.notation -/
-/- ./././Mathport/Syntax/Translate/Expr.lean:207:4: warning: unsupported notation `«expr!![ » -/
-/- ./././Mathport/Syntax/Translate/Expr.lean:387:14: unsupported user notation matrix.notation -/
-/- ./././Mathport/Syntax/Translate/Expr.lean:207:4: warning: unsupported notation `«expr!![ » -/
-/- ./././Mathport/Syntax/Translate/Expr.lean:387:14: unsupported user notation matrix.notation -/
 theorem mul_fin_three [AddCommMonoid α] [Mul α]
     (a₁₁ a₁₂ a₁₃ a₂₁ a₂₂ a₂₃ a₃₁ a₃₂ a₃₃ b₁₁ b₁₂ b₁₃ b₂₁ b₂₂ b₂₃ b₃₁ b₃₂ b₃₃ : α) :
-    «expr!![ »
-          "./././Mathport/Syntax/Translate/Expr.lean:387:14: unsupported user notation matrix.notation" ⬝
-        «expr!![ »
-          "./././Mathport/Syntax/Translate/Expr.lean:387:14: unsupported user notation matrix.notation" =
-      «expr!![ »
-        "./././Mathport/Syntax/Translate/Expr.lean:387:14: unsupported user notation matrix.notation" :=
-  by
+    !![a₁₁, a₁₂, a₁₃;
+       a₂₁, a₂₂, a₂₃;
+       a₃₁, a₃₂, a₃₃] ⬝ !![b₁₁, b₁₂, b₁₃;
+                           b₂₁, b₂₂, b₂₃;
+                           b₃₁, b₃₂, b₃₃] =
+    !![a₁₁*b₁₁ + a₁₂*b₂₁ + a₁₃*b₃₁, a₁₁*b₁₂ + a₁₂*b₂₂ + a₁₃*b₃₂, a₁₁*b₁₃ + a₁₂*b₂₃ + a₁₃*b₃₃;
+       a₂₁*b₁₁ + a₂₂*b₂₁ + a₂₃*b₃₁, a₂₁*b₁₂ + a₂₂*b₂₂ + a₂₃*b₃₂, a₂₁*b₁₃ + a₂₂*b₂₃ + a₂₃*b₃₃;
+       a₃₁*b₁₁ + a₃₂*b₂₁ + a₃₃*b₃₁, a₃₁*b₁₂ + a₃₂*b₂₂ + a₃₃*b₃₂, a₃₁*b₁₃ + a₃₂*b₂₃ + a₃₃*b₃₃] := by
   ext (i j)
   fin_cases i <;> fin_cases j <;> simp [Matrix.mul, dotProduct, Fin.sum_univ_succ, ← add_assoc]
 #align matrix.mul_fin_three Matrix.mul_fin_three
 
 theorem vec2_eq {a₀ a₁ b₀ b₁ : α} (h₀ : a₀ = b₀) (h₁ : a₁ = b₁) : ![a₀, a₁] = ![b₀, b₁] := by
   subst_vars
+  rfl
 #align matrix.vec2_eq Matrix.vec2_eq
 
 theorem vec3_eq {a₀ a₁ a₂ b₀ b₁ b₂ : α} (h₀ : a₀ = b₀) (h₁ : a₁ = b₁) (h₂ : a₂ = b₂) :
-    ![a₀, a₁, a₂] = ![b₀, b₁, b₂] := by subst_vars
+    ![a₀, a₁, a₂] = ![b₀, b₁, b₂] := by
+  subst_vars
+  rfl
 #align matrix.vec3_eq Matrix.vec3_eq
 
 theorem vec2_add [Add α] (a₀ a₁ b₀ b₁ : α) : ![a₀, a₁] + ![b₀, b₁] = ![a₀ + b₀, a₁ + b₁] := by
@@ -499,8 +465,8 @@ theorem vec3_add [Add α] (a₀ a₁ a₂ b₀ b₁ b₂ : α) :
   rw [cons_add_cons, cons_add_cons, cons_add_cons, empty_add_empty]
 #align matrix.vec3_add Matrix.vec3_add
 
-theorem smul_vec2 {R : Type _} [SMul R α] (x : R) (a₀ a₁ : α) : x • ![a₀, a₁] = ![x • a₀, x • a₁] :=
-  by rw [smul_cons, smul_cons, smul_empty]
+theorem smul_vec2 {R : Type _} [SMul R α] (x : R) (a₀ a₁ : α) :
+    x • ![a₀, a₁] = ![x • a₀, x • a₁] := by rw [smul_cons, smul_cons, smul_empty]
 #align matrix.smul_vec2 Matrix.smul_vec2
 
 theorem smul_vec3 {R : Type _} [SMul R α] (x : R) (a₀ a₁ a₂ : α) :

--- a/Mathlib/Data/Matrix/Notation.lean
+++ b/Mathlib/Data/Matrix/Notation.lean
@@ -1,0 +1,577 @@
+/-
+Copyright (c) 2020 Anne Baanen. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Anne Baanen, Eric Wieser
+
+! This file was ported from Lean 3 source module data.matrix.notation
+! leanprover-community/mathlib commit 3e068ece210655b7b9a9477c3aff38a492400aa1
+! Please do not edit these lines, except to modify the commit id
+! if you have ported upstream changes.
+-/
+import Mathbin.Data.Matrix.Basic
+import Mathbin.Data.Fin.VecNotation
+import Mathbin.Tactic.FinCases
+import Mathbin.Algebra.BigOperators.Fin
+
+/-!
+# Matrix and vector notation
+
+This file includes `simp` lemmas for applying operations in `data.matrix.basic` to values built out
+of the matrix notation `![a, b] = vec_cons a (vec_cons b vec_empty)` defined in
+`data.fin.vec_notation`.
+
+This also provides the new notation `!![a, b; c, d] = matrix.of ![![a, b], ![c, d]]`.
+This notation also works for empty matrices; `!![,,,] : matrix (fin 0) (fin 3)` and
+`!![;;;] : matrix (fin 3) (fin 0)`.
+
+## Implementation notes
+
+The `simp` lemmas require that one of the arguments is of the form `vec_cons _ _`.
+This ensures `simp` works with entries only when (some) entries are already given.
+In other words, this notation will only appear in the output of `simp` if it
+already appears in the input.
+
+## Notations
+
+This file provide notation `!![a, b; c, d]` for matrices, which corresponds to
+`matrix.of ![![a, b], ![c, d]]`.
+A parser for `a, b; c, d`-style strings is provided as `matrix.entry_parser`, while
+`matrix.notation` provides the hook for the `!!` notation.
+Note that in lean 3 the pretty-printer will not show `!!` notation, instead showing the version
+with `of ![![...]]`.
+
+## Examples
+
+Examples of usage can be found in the `test/matrix.lean` file.
+-/
+
+
+namespace Matrix
+
+universe u
+
+variable {α : Type u} {o n m : ℕ} {m' n' o' : Type _}
+
+open Matrix
+
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:73:14: unsupported tactic `reflect_name #[] -/
+/- ./././Mathport/Syntax/Translate/Tactic/Builtin.lean:73:14: unsupported tactic `reflect_name #[] -/
+/-- Matrices can be reflected whenever their entries can. We insert an `@id (matrix m' n' α)` to
+prevent immediate decay to a function. -/
+unsafe instance matrix.reflect [reflected_univ.{u}] [reflected_univ.{u_1}] [reflected_univ.{u_2}]
+    [reflected _ α] [reflected _ m'] [reflected _ n'] [h : has_reflect (m' → n' → α)] :
+    has_reflect (Matrix m' n' α) := fun m =>
+  (by
+          trace
+            "./././Mathport/Syntax/Translate/Tactic/Builtin.lean:73:14: unsupported tactic `reflect_name #[]" :
+          reflected _ @id.{max u_1 u_2 u + 1}).subst₂
+      ((by
+            trace
+              "./././Mathport/Syntax/Translate/Tactic/Builtin.lean:73:14: unsupported tactic `reflect_name #[]" :
+            reflected _ @Matrix.{u_1, u_2, u}).subst₃
+        q(_) q(_) q(_)) <|
+    by
+    dsimp only [Matrix]
+    exact h m
+#align matrix.matrix.reflect matrix.matrix.reflect
+
+section Parser
+
+open Lean
+
+open Lean.Parser
+
+open Interactive
+
+open Interactive.Types
+
+/- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
+/-- Parse the entries of a matrix -/
+unsafe def entry_parser {α : Type} (p : parser α) : parser (Σm n, Fin m → Fin n → α) := do
+  let-- a list of lists if the matrix has at least one row, or the number of columns if the matrix has
+  -- zero rows.
+  p :
+    parser (Sum (List (List α)) ℕ) :=-- empty rows
+        Sum.inl <$>
+        ((pure [] <* tk ";").repeat_at_least 1 <|>
+          (sep_by_trailing (tk ";") <| sep_by_trailing (tk ",") p)) <|>
+      Sum.inr <$> List.length <$> many (tk ",")
+  let which
+    ←-- empty columns
+      p
+  match which with
+    | Sum.inl l => do
+      let h::tl ← pure l
+      let n := h
+      let l : List (Vector α n) ←
+        l fun row =>
+            if h : row = n then pure (⟨row, h⟩ : Vector α n)
+            else interaction_monad.fail "Rows must be of equal length"
+      pure ⟨l, n, fun i j => (l _ i).get? j⟩
+    | Sum.inr n => pure ⟨0, n, finZeroElim⟩
+#align matrix.entry_parser matrix.entry_parser
+
+-- Lean can't find this instance without some help. We only need it available in `Type 0`, and it is
+-- a massive amount of effort to make it universe-polymorphic.
+@[instance]
+unsafe def sigma_sigma_fin_matrix_has_reflect {α : Type} [has_reflect α] [reflected _ α] :
+    has_reflect (Σm n : ℕ, Fin m → Fin n → α) :=
+  @sigma.reflect.{0, 0} _ _ ℕ (fun m => Σn, Fin m → Fin n → α) _ _ _ fun i =>
+    @sigma.reflect.{0, 0} _ _ ℕ _ _ _ _ fun j => inferInstance
+#align matrix.sigma_sigma_fin_matrix_has_reflect matrix.sigma_sigma_fin_matrix_has_reflect
+
+/-- `!![a, b; c, d]` notation for matrices indexed by `fin m` and `fin n`. See the module docstring
+for details. -/
+@[user_notation]
+unsafe def notation (_ : parse <| tk "!![")
+    (val : parse (entry_parser (parser.pexpr 1) <* tk "]")) : parser pexpr := do
+  let ⟨m, n, entries⟩ := val
+  let entry_vals := pi_fin.to_pexpr (pi_fin.to_pexpr ∘ entries)
+  pure (``(@Matrix.of (Fin $(q(m))) (Fin $(q(n))) _).app entry_vals)
+#align matrix.notation matrix.notation
+
+end Parser
+
+variable (a b : ℕ)
+
+/-- Use `![...]` notation for displaying a `fin`-indexed matrix, for example:
+
+```
+#eval !![1, 2; 3, 4] + !![3, 4; 5, 6]  -- !![4, 6; 8, 10]
+```
+-/
+instance [Repr α] : Repr (Matrix (Fin m) (Fin n) α)
+    where repr f :=
+    "!![" ++
+        (String.intercalate "; " <|
+          (List.finRange m).map fun i =>
+            String.intercalate ", " <| (List.finRange n).map fun j => repr (f i j)) ++
+      "]"
+
+@[simp]
+theorem cons_val' (v : n' → α) (B : Fin m → n' → α) (i j) :
+    vecCons v B i j = vecCons (v j) (fun i => B i j) i := by refine' Fin.cases _ _ i <;> simp
+#align matrix.cons_val' Matrix.cons_val'
+
+@[simp]
+theorem head_val' (B : Fin m.succ → n' → α) (j : n') : (vecHead fun i => B i j) = vecHead B j :=
+  rfl
+#align matrix.head_val' Matrix.head_val'
+
+@[simp]
+theorem tail_val' (B : Fin m.succ → n' → α) (j : n') :
+    (vecTail fun i => B i j) = fun i => vecTail B i j :=
+  by
+  ext
+  simp [vec_tail]
+#align matrix.tail_val' Matrix.tail_val'
+
+section DotProduct
+
+variable [AddCommMonoid α] [Mul α]
+
+@[simp]
+theorem dotProduct_empty (v w : Fin 0 → α) : dotProduct v w = 0 :=
+  Finset.sum_empty
+#align matrix.dot_product_empty Matrix.dotProduct_empty
+
+@[simp]
+theorem cons_dotProduct (x : α) (v : Fin n → α) (w : Fin n.succ → α) :
+    dotProduct (vecCons x v) w = x * vecHead w + dotProduct v (vecTail w) := by
+  simp [dot_product, Fin.sum_univ_succ, vec_head, vec_tail]
+#align matrix.cons_dot_product Matrix.cons_dotProduct
+
+@[simp]
+theorem dotProduct_cons (v : Fin n.succ → α) (x : α) (w : Fin n → α) :
+    dotProduct v (vecCons x w) = vecHead v * x + dotProduct (vecTail v) w := by
+  simp [dot_product, Fin.sum_univ_succ, vec_head, vec_tail]
+#align matrix.dot_product_cons Matrix.dotProduct_cons
+
+@[simp]
+theorem cons_dotProduct_cons (x : α) (v : Fin n → α) (y : α) (w : Fin n → α) :
+    dotProduct (vecCons x v) (vecCons y w) = x * y + dotProduct v w := by simp
+#align matrix.cons_dot_product_cons Matrix.cons_dotProduct_cons
+
+end DotProduct
+
+section ColRow
+
+@[simp]
+theorem col_empty (v : Fin 0 → α) : col v = vecEmpty :=
+  empty_eq _
+#align matrix.col_empty Matrix.col_empty
+
+@[simp]
+theorem col_cons (x : α) (u : Fin m → α) : col (vecCons x u) = vecCons (fun _ => x) (col u) :=
+  by
+  ext (i j)
+  refine' Fin.cases _ _ i <;> simp [vec_head, vec_tail]
+#align matrix.col_cons Matrix.col_cons
+
+@[simp]
+theorem row_empty : row (vecEmpty : Fin 0 → α) = fun _ => vecEmpty :=
+  by
+  ext
+  rfl
+#align matrix.row_empty Matrix.row_empty
+
+@[simp]
+theorem row_cons (x : α) (u : Fin m → α) : row (vecCons x u) = fun _ => vecCons x u :=
+  by
+  ext
+  rfl
+#align matrix.row_cons Matrix.row_cons
+
+end ColRow
+
+section Transpose
+
+@[simp]
+theorem transpose_empty_rows (A : Matrix m' (Fin 0) α) : Aᵀ = of ![] :=
+  empty_eq _
+#align matrix.transpose_empty_rows Matrix.transpose_empty_rows
+
+@[simp]
+theorem transpose_empty_cols (A : Matrix (Fin 0) m' α) : Aᵀ = of fun i => ![] :=
+  funext fun i => empty_eq _
+#align matrix.transpose_empty_cols Matrix.transpose_empty_cols
+
+@[simp]
+theorem cons_transpose (v : n' → α) (A : Matrix (Fin m) n' α) :
+    (of (vecCons v A))ᵀ = of fun i => vecCons (v i) (Aᵀ i) :=
+  by
+  ext (i j)
+  refine' Fin.cases _ _ j <;> simp
+#align matrix.cons_transpose Matrix.cons_transpose
+
+@[simp]
+theorem head_transpose (A : Matrix m' (Fin n.succ) α) :
+    vecHead (of.symm Aᵀ) = vecHead ∘ of.symm A :=
+  rfl
+#align matrix.head_transpose Matrix.head_transpose
+
+@[simp]
+theorem tail_transpose (A : Matrix m' (Fin n.succ) α) : vecTail (of.symm Aᵀ) = (vecTail ∘ A)ᵀ :=
+  by
+  ext (i j)
+  rfl
+#align matrix.tail_transpose Matrix.tail_transpose
+
+end Transpose
+
+section Mul
+
+variable [Semiring α]
+
+@[simp]
+theorem empty_mul [Fintype n'] (A : Matrix (Fin 0) n' α) (B : Matrix n' o' α) : A ⬝ B = of ![] :=
+  empty_eq _
+#align matrix.empty_mul Matrix.empty_mul
+
+@[simp]
+theorem empty_mul_empty (A : Matrix m' (Fin 0) α) (B : Matrix (Fin 0) o' α) : A ⬝ B = 0 :=
+  rfl
+#align matrix.empty_mul_empty Matrix.empty_mul_empty
+
+@[simp]
+theorem mul_empty [Fintype n'] (A : Matrix m' n' α) (B : Matrix n' (Fin 0) α) :
+    A ⬝ B = of fun _ => ![] :=
+  funext fun _ => empty_eq _
+#align matrix.mul_empty Matrix.mul_empty
+
+theorem mul_val_succ [Fintype n'] (A : Matrix (Fin m.succ) n' α) (B : Matrix n' o' α) (i : Fin m)
+    (j : o') : (A ⬝ B) i.succ j = (of (vecTail (of.symm A)) ⬝ B) i j :=
+  rfl
+#align matrix.mul_val_succ Matrix.mul_val_succ
+
+@[simp]
+theorem cons_mul [Fintype n'] (v : n' → α) (A : Fin m → n' → α) (B : Matrix n' o' α) :
+    of (vecCons v A) ⬝ B = of (vecCons (vecMul v B) (of.symm (of A ⬝ B))) :=
+  by
+  ext (i j)
+  refine' Fin.cases _ _ i
+  · rfl
+  simp [mul_val_succ]
+#align matrix.cons_mul Matrix.cons_mul
+
+end Mul
+
+section VecMul
+
+variable [Semiring α]
+
+@[simp]
+theorem empty_vecMul (v : Fin 0 → α) (B : Matrix (Fin 0) o' α) : vecMul v B = 0 :=
+  rfl
+#align matrix.empty_vec_mul Matrix.empty_vecMul
+
+@[simp]
+theorem vecMul_empty [Fintype n'] (v : n' → α) (B : Matrix n' (Fin 0) α) : vecMul v B = ![] :=
+  empty_eq _
+#align matrix.vec_mul_empty Matrix.vecMul_empty
+
+@[simp]
+theorem cons_vecMul (x : α) (v : Fin n → α) (B : Fin n.succ → o' → α) :
+    vecMul (vecCons x v) (of B) = x • vecHead B + vecMul v (of <| vecTail B) :=
+  by
+  ext i
+  simp [vec_mul]
+#align matrix.cons_vec_mul Matrix.cons_vecMul
+
+@[simp]
+theorem vecMul_cons (v : Fin n.succ → α) (w : o' → α) (B : Fin n → o' → α) :
+    vecMul v (of <| vecCons w B) = vecHead v • w + vecMul (vecTail v) (of B) :=
+  by
+  ext i
+  simp [vec_mul]
+#align matrix.vec_mul_cons Matrix.vecMul_cons
+
+@[simp]
+theorem cons_vecMul_cons (x : α) (v : Fin n → α) (w : o' → α) (B : Fin n → o' → α) :
+    vecMul (vecCons x v) (of <| vecCons w B) = x • w + vecMul v (of B) := by simp
+#align matrix.cons_vec_mul_cons Matrix.cons_vecMul_cons
+
+end VecMul
+
+section MulVec
+
+variable [Semiring α]
+
+@[simp]
+theorem empty_mulVec [Fintype n'] (A : Matrix (Fin 0) n' α) (v : n' → α) : mulVec A v = ![] :=
+  empty_eq _
+#align matrix.empty_mul_vec Matrix.empty_mulVec
+
+@[simp]
+theorem mulVec_empty (A : Matrix m' (Fin 0) α) (v : Fin 0 → α) : mulVec A v = 0 :=
+  rfl
+#align matrix.mul_vec_empty Matrix.mulVec_empty
+
+@[simp]
+theorem cons_mulVec [Fintype n'] (v : n' → α) (A : Fin m → n' → α) (w : n' → α) :
+    mulVec (of <| vecCons v A) w = vecCons (dotProduct v w) (mulVec (of A) w) :=
+  by
+  ext i
+  refine' Fin.cases _ _ i <;> simp [mul_vec]
+#align matrix.cons_mul_vec Matrix.cons_mulVec
+
+@[simp]
+theorem mulVec_cons {α} [CommSemiring α] (A : m' → Fin n.succ → α) (x : α) (v : Fin n → α) :
+    mulVec (of A) (vecCons x v) = x • vecHead ∘ A + mulVec (of (vecTail ∘ A)) v :=
+  by
+  ext i
+  simp [mul_vec, mul_comm]
+#align matrix.mul_vec_cons Matrix.mulVec_cons
+
+end MulVec
+
+section VecMulVec
+
+variable [Semiring α]
+
+@[simp]
+theorem empty_vecMulVec (v : Fin 0 → α) (w : n' → α) : vecMulVec v w = ![] :=
+  empty_eq _
+#align matrix.empty_vec_mul_vec Matrix.empty_vecMulVec
+
+@[simp]
+theorem vecMulVec_empty (v : m' → α) (w : Fin 0 → α) : vecMulVec v w = fun _ => ![] :=
+  funext fun i => empty_eq _
+#align matrix.vec_mul_vec_empty Matrix.vecMulVec_empty
+
+@[simp]
+theorem cons_vecMulVec (x : α) (v : Fin m → α) (w : n' → α) :
+    vecMulVec (vecCons x v) w = vecCons (x • w) (vecMulVec v w) :=
+  by
+  ext i
+  refine' Fin.cases _ _ i <;> simp [vec_mul_vec]
+#align matrix.cons_vec_mul_vec Matrix.cons_vecMulVec
+
+@[simp]
+theorem vecMulVec_cons (v : m' → α) (x : α) (w : Fin n → α) :
+    vecMulVec v (vecCons x w) = fun i => v i • vecCons x w :=
+  by
+  ext (i j)
+  rw [vec_mul_vec_apply, Pi.smul_apply, smul_eq_mul]
+#align matrix.vec_mul_vec_cons Matrix.vecMulVec_cons
+
+end VecMulVec
+
+section Smul
+
+variable [Semiring α]
+
+@[simp]
+theorem smul_mat_empty {m' : Type _} (x : α) (A : Fin 0 → m' → α) : x • A = ![] :=
+  empty_eq _
+#align matrix.smul_mat_empty Matrix.smul_mat_empty
+
+@[simp]
+theorem smul_mat_cons (x : α) (v : n' → α) (A : Fin m → n' → α) :
+    x • vecCons v A = vecCons (x • v) (x • A) :=
+  by
+  ext i
+  refine' Fin.cases _ _ i <;> simp
+#align matrix.smul_mat_cons Matrix.smul_mat_cons
+
+end Smul
+
+section Submatrix
+
+@[simp]
+theorem submatrix_empty (A : Matrix m' n' α) (row : Fin 0 → m') (col : o' → n') :
+    submatrix A row col = ![] :=
+  empty_eq _
+#align matrix.submatrix_empty Matrix.submatrix_empty
+
+@[simp]
+theorem submatrix_cons_row (A : Matrix m' n' α) (i : m') (row : Fin m → m') (col : o' → n') :
+    submatrix A (vecCons i row) col = vecCons (fun j => A i (col j)) (submatrix A row col) :=
+  by
+  ext (i j)
+  refine' Fin.cases _ _ i <;> simp [submatrix]
+#align matrix.submatrix_cons_row Matrix.submatrix_cons_row
+
+end Submatrix
+
+section Vec2AndVec3
+
+section One
+
+variable [Zero α] [One α]
+
+/- ./././Mathport/Syntax/Translate/Expr.lean:207:4: warning: unsupported notation `«expr!![ » -/
+/- ./././Mathport/Syntax/Translate/Expr.lean:387:14: unsupported user notation matrix.notation -/
+theorem one_fin_two :
+    (1 : Matrix (Fin 2) (Fin 2) α) =
+      «expr!![ »
+        "./././Mathport/Syntax/Translate/Expr.lean:387:14: unsupported user notation matrix.notation" :=
+  by
+  ext (i j)
+  fin_cases i <;> fin_cases j <;> rfl
+#align matrix.one_fin_two Matrix.one_fin_two
+
+/- ./././Mathport/Syntax/Translate/Expr.lean:207:4: warning: unsupported notation `«expr!![ » -/
+/- ./././Mathport/Syntax/Translate/Expr.lean:387:14: unsupported user notation matrix.notation -/
+theorem one_fin_three :
+    (1 : Matrix (Fin 3) (Fin 3) α) =
+      «expr!![ »
+        "./././Mathport/Syntax/Translate/Expr.lean:387:14: unsupported user notation matrix.notation" :=
+  by
+  ext (i j)
+  fin_cases i <;> fin_cases j <;> rfl
+#align matrix.one_fin_three Matrix.one_fin_three
+
+end One
+
+/- ./././Mathport/Syntax/Translate/Expr.lean:207:4: warning: unsupported notation `«expr!![ » -/
+/- ./././Mathport/Syntax/Translate/Expr.lean:387:14: unsupported user notation matrix.notation -/
+theorem eta_fin_two (A : Matrix (Fin 2) (Fin 2) α) :
+    A =
+      «expr!![ »
+        "./././Mathport/Syntax/Translate/Expr.lean:387:14: unsupported user notation matrix.notation" :=
+  by
+  ext (i j)
+  fin_cases i <;> fin_cases j <;> rfl
+#align matrix.eta_fin_two Matrix.eta_fin_two
+
+/- ./././Mathport/Syntax/Translate/Expr.lean:207:4: warning: unsupported notation `«expr!![ » -/
+/- ./././Mathport/Syntax/Translate/Expr.lean:387:14: unsupported user notation matrix.notation -/
+theorem eta_fin_three (A : Matrix (Fin 3) (Fin 3) α) :
+    A =
+      «expr!![ »
+        "./././Mathport/Syntax/Translate/Expr.lean:387:14: unsupported user notation matrix.notation" :=
+  by
+  ext (i j)
+  fin_cases i <;> fin_cases j <;> rfl
+#align matrix.eta_fin_three Matrix.eta_fin_three
+
+/- ./././Mathport/Syntax/Translate/Expr.lean:207:4: warning: unsupported notation `«expr!![ » -/
+/- ./././Mathport/Syntax/Translate/Expr.lean:387:14: unsupported user notation matrix.notation -/
+/- ./././Mathport/Syntax/Translate/Expr.lean:207:4: warning: unsupported notation `«expr!![ » -/
+/- ./././Mathport/Syntax/Translate/Expr.lean:387:14: unsupported user notation matrix.notation -/
+/- ./././Mathport/Syntax/Translate/Expr.lean:207:4: warning: unsupported notation `«expr!![ » -/
+/- ./././Mathport/Syntax/Translate/Expr.lean:387:14: unsupported user notation matrix.notation -/
+theorem mul_fin_two [AddCommMonoid α] [Mul α] (a₁₁ a₁₂ a₂₁ a₂₂ b₁₁ b₁₂ b₂₁ b₂₂ : α) :
+    «expr!![ »
+          "./././Mathport/Syntax/Translate/Expr.lean:387:14: unsupported user notation matrix.notation" ⬝
+        «expr!![ »
+          "./././Mathport/Syntax/Translate/Expr.lean:387:14: unsupported user notation matrix.notation" =
+      «expr!![ »
+        "./././Mathport/Syntax/Translate/Expr.lean:387:14: unsupported user notation matrix.notation" :=
+  by
+  ext (i j)
+  fin_cases i <;> fin_cases j <;> simp [Matrix.mul, dot_product, Fin.sum_univ_succ]
+#align matrix.mul_fin_two Matrix.mul_fin_two
+
+/- ./././Mathport/Syntax/Translate/Expr.lean:207:4: warning: unsupported notation `«expr!![ » -/
+/- ./././Mathport/Syntax/Translate/Expr.lean:387:14: unsupported user notation matrix.notation -/
+/- ./././Mathport/Syntax/Translate/Expr.lean:207:4: warning: unsupported notation `«expr!![ » -/
+/- ./././Mathport/Syntax/Translate/Expr.lean:387:14: unsupported user notation matrix.notation -/
+/- ./././Mathport/Syntax/Translate/Expr.lean:207:4: warning: unsupported notation `«expr!![ » -/
+/- ./././Mathport/Syntax/Translate/Expr.lean:387:14: unsupported user notation matrix.notation -/
+theorem mul_fin_three [AddCommMonoid α] [Mul α]
+    (a₁₁ a₁₂ a₁₃ a₂₁ a₂₂ a₂₃ a₃₁ a₃₂ a₃₃ b₁₁ b₁₂ b₁₃ b₂₁ b₂₂ b₂₃ b₃₁ b₃₂ b₃₃ : α) :
+    «expr!![ »
+          "./././Mathport/Syntax/Translate/Expr.lean:387:14: unsupported user notation matrix.notation" ⬝
+        «expr!![ »
+          "./././Mathport/Syntax/Translate/Expr.lean:387:14: unsupported user notation matrix.notation" =
+      «expr!![ »
+        "./././Mathport/Syntax/Translate/Expr.lean:387:14: unsupported user notation matrix.notation" :=
+  by
+  ext (i j)
+  fin_cases i <;> fin_cases j <;> simp [Matrix.mul, dot_product, Fin.sum_univ_succ, ← add_assoc]
+#align matrix.mul_fin_three Matrix.mul_fin_three
+
+theorem vec2_eq {a₀ a₁ b₀ b₁ : α} (h₀ : a₀ = b₀) (h₁ : a₁ = b₁) : ![a₀, a₁] = ![b₀, b₁] := by
+  subst_vars
+#align matrix.vec2_eq Matrix.vec2_eq
+
+theorem vec3_eq {a₀ a₁ a₂ b₀ b₁ b₂ : α} (h₀ : a₀ = b₀) (h₁ : a₁ = b₁) (h₂ : a₂ = b₂) :
+    ![a₀, a₁, a₂] = ![b₀, b₁, b₂] := by subst_vars
+#align matrix.vec3_eq Matrix.vec3_eq
+
+theorem vec2_add [Add α] (a₀ a₁ b₀ b₁ : α) : ![a₀, a₁] + ![b₀, b₁] = ![a₀ + b₀, a₁ + b₁] := by
+  rw [cons_add_cons, cons_add_cons, empty_add_empty]
+#align matrix.vec2_add Matrix.vec2_add
+
+theorem vec3_add [Add α] (a₀ a₁ a₂ b₀ b₁ b₂ : α) :
+    ![a₀, a₁, a₂] + ![b₀, b₁, b₂] = ![a₀ + b₀, a₁ + b₁, a₂ + b₂] := by
+  rw [cons_add_cons, cons_add_cons, cons_add_cons, empty_add_empty]
+#align matrix.vec3_add Matrix.vec3_add
+
+theorem smul_vec2 {R : Type _} [SMul R α] (x : R) (a₀ a₁ : α) : x • ![a₀, a₁] = ![x • a₀, x • a₁] :=
+  by rw [smul_cons, smul_cons, smul_empty]
+#align matrix.smul_vec2 Matrix.smul_vec2
+
+theorem smul_vec3 {R : Type _} [SMul R α] (x : R) (a₀ a₁ a₂ : α) :
+    x • ![a₀, a₁, a₂] = ![x • a₀, x • a₁, x • a₂] := by
+  rw [smul_cons, smul_cons, smul_cons, smul_empty]
+#align matrix.smul_vec3 Matrix.smul_vec3
+
+variable [AddCommMonoid α] [Mul α]
+
+theorem vec2_dot_product' {a₀ a₁ b₀ b₁ : α} : ![a₀, a₁] ⬝ᵥ ![b₀, b₁] = a₀ * b₀ + a₁ * b₁ := by
+  rw [cons_dot_product_cons, cons_dot_product_cons, dot_product_empty, add_zero]
+#align matrix.vec2_dot_product' Matrix.vec2_dot_product'
+
+@[simp]
+theorem vec2_dotProduct (v w : Fin 2 → α) : v ⬝ᵥ w = v 0 * w 0 + v 1 * w 1 :=
+  vec2_dot_product'
+#align matrix.vec2_dot_product Matrix.vec2_dotProduct
+
+theorem vec3_dot_product' {a₀ a₁ a₂ b₀ b₁ b₂ : α} :
+    ![a₀, a₁, a₂] ⬝ᵥ ![b₀, b₁, b₂] = a₀ * b₀ + a₁ * b₁ + a₂ * b₂ := by
+  rw [cons_dot_product_cons, cons_dot_product_cons, cons_dot_product_cons, dot_product_empty,
+    add_zero, add_assoc]
+#align matrix.vec3_dot_product' Matrix.vec3_dot_product'
+
+@[simp]
+theorem vec3_dotProduct (v w : Fin 3 → α) : v ⬝ᵥ w = v 0 * w 0 + v 1 * w 1 + v 2 * w 2 :=
+  vec3_dot_product'
+#align matrix.vec3_dot_product Matrix.vec3_dotProduct
+
+end Vec2AndVec3
+
+end Matrix
+

--- a/Mathlib/Data/Matrix/Notation.lean
+++ b/Mathlib/Data/Matrix/Notation.lean
@@ -139,13 +139,14 @@ variable (a b : ℕ)
 #eval !![1, 2; 3, 4] + !![3, 4; 5, 6]  -- !![4, 6; 8, 10]
 ```
 -/
-instance [Repr α] : Repr (Matrix (Fin m) (Fin n) α)
-    where repr f :=
-    "!![" ++
-        (String.intercalate "; " <|
-          (List.finRange m).map fun i =>
-            String.intercalate ", " <| (List.finRange n).map fun j => repr (f i j)) ++
-      "]"
+instance [Repr α] : Repr (Matrix (Fin m) (Fin n) α) where
+  reprPrec f _p :=
+    (Std.Format.bracket "!![" · "]") <|
+      (Std.Format.joinSep · (";" ++ Std.Format.line)) <|
+        (List.finRange m).map fun i =>
+          Std.Format.fill <|  -- wrap line in a single place rather than all at once
+            (Std.Format.joinSep · ("," ++ Std.Format.line)) <|
+            (List.finRange n).map fun j => repr (f i j)
 
 @[simp]
 theorem cons_val' (v : n' → α) (B : Fin m → n' → α) (i j) :

--- a/Mathlib/Data/Matrix/Notation.lean
+++ b/Mathlib/Data/Matrix/Notation.lean
@@ -8,10 +8,10 @@ Authors: Anne Baanen, Eric Wieser
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
-import Mathbin.Data.Matrix.Basic
-import Mathbin.Data.Fin.VecNotation
-import Mathbin.Tactic.FinCases
-import Mathbin.Algebra.BigOperators.Fin
+import Mathlib.Data.Matrix.Basic
+import Mathlib.Data.Fin.VecNotation
+import Mathlib.Tactic.FinCases
+import Mathlib.Algebra.BigOperators.Fin
 
 /-!
 # Matrix and vector notation
@@ -69,8 +69,7 @@ unsafe instance matrix.reflect [reflected_univ.{u}] [reflected_univ.{u_1}] [refl
             trace
               "./././Mathport/Syntax/Translate/Tactic/Builtin.lean:73:14: unsupported tactic `reflect_name #[]" :
             reflected _ @Matrix.{u_1, u_2, u}).subst₃
-        q(_) q(_) q(_)) <|
-    by
+        q(_) q(_) q(_)) <| by
     dsimp only [Matrix]
     exact h m
 #align matrix.matrix.reflect matrix.matrix.reflect
@@ -160,8 +159,7 @@ theorem head_val' (B : Fin m.succ → n' → α) (j : n') : (vecHead fun i => B 
 
 @[simp]
 theorem tail_val' (B : Fin m.succ → n' → α) (j : n') :
-    (vecTail fun i => B i j) = fun i => vecTail B i j :=
-  by
+    (vecTail fun i => B i j) = fun i => vecTail B i j := by
   ext
   simp [vec_tail]
 #align matrix.tail_val' Matrix.tail_val'
@@ -202,22 +200,19 @@ theorem col_empty (v : Fin 0 → α) : col v = vecEmpty :=
 #align matrix.col_empty Matrix.col_empty
 
 @[simp]
-theorem col_cons (x : α) (u : Fin m → α) : col (vecCons x u) = vecCons (fun _ => x) (col u) :=
-  by
+theorem col_cons (x : α) (u : Fin m → α) : col (vecCons x u) = vecCons (fun _ => x) (col u) := by
   ext (i j)
   refine' Fin.cases _ _ i <;> simp [vec_head, vec_tail]
 #align matrix.col_cons Matrix.col_cons
 
 @[simp]
-theorem row_empty : row (vecEmpty : Fin 0 → α) = fun _ => vecEmpty :=
-  by
+theorem row_empty : row (vecEmpty : Fin 0 → α) = fun _ => vecEmpty := by
   ext
   rfl
 #align matrix.row_empty Matrix.row_empty
 
 @[simp]
-theorem row_cons (x : α) (u : Fin m → α) : row (vecCons x u) = fun _ => vecCons x u :=
-  by
+theorem row_cons (x : α) (u : Fin m → α) : row (vecCons x u) = fun _ => vecCons x u := by
   ext
   rfl
 #align matrix.row_cons Matrix.row_cons
@@ -238,8 +233,7 @@ theorem transpose_empty_cols (A : Matrix (Fin 0) m' α) : Aᵀ = of fun i => ![]
 
 @[simp]
 theorem cons_transpose (v : n' → α) (A : Matrix (Fin m) n' α) :
-    (of (vecCons v A))ᵀ = of fun i => vecCons (v i) (Aᵀ i) :=
-  by
+    (of (vecCons v A))ᵀ = of fun i => vecCons (v i) (Aᵀ i) := by
   ext (i j)
   refine' Fin.cases _ _ j <;> simp
 #align matrix.cons_transpose Matrix.cons_transpose
@@ -251,8 +245,7 @@ theorem head_transpose (A : Matrix m' (Fin n.succ) α) :
 #align matrix.head_transpose Matrix.head_transpose
 
 @[simp]
-theorem tail_transpose (A : Matrix m' (Fin n.succ) α) : vecTail (of.symm Aᵀ) = (vecTail ∘ A)ᵀ :=
-  by
+theorem tail_transpose (A : Matrix m' (Fin n.succ) α) : vecTail (of.symm Aᵀ) = (vecTail ∘ A)ᵀ := by
   ext (i j)
   rfl
 #align matrix.tail_transpose Matrix.tail_transpose
@@ -286,8 +279,7 @@ theorem mul_val_succ [Fintype n'] (A : Matrix (Fin m.succ) n' α) (B : Matrix n'
 
 @[simp]
 theorem cons_mul [Fintype n'] (v : n' → α) (A : Fin m → n' → α) (B : Matrix n' o' α) :
-    of (vecCons v A) ⬝ B = of (vecCons (vecMul v B) (of.symm (of A ⬝ B))) :=
-  by
+    of (vecCons v A) ⬝ B = of (vecCons (vecMul v B) (of.symm (of A ⬝ B))) := by
   ext (i j)
   refine' Fin.cases _ _ i
   · rfl
@@ -312,16 +304,14 @@ theorem vecMul_empty [Fintype n'] (v : n' → α) (B : Matrix n' (Fin 0) α) : v
 
 @[simp]
 theorem cons_vecMul (x : α) (v : Fin n → α) (B : Fin n.succ → o' → α) :
-    vecMul (vecCons x v) (of B) = x • vecHead B + vecMul v (of <| vecTail B) :=
-  by
+    vecMul (vecCons x v) (of B) = x • vecHead B + vecMul v (of <| vecTail B) := by
   ext i
   simp [vec_mul]
 #align matrix.cons_vec_mul Matrix.cons_vecMul
 
 @[simp]
 theorem vecMul_cons (v : Fin n.succ → α) (w : o' → α) (B : Fin n → o' → α) :
-    vecMul v (of <| vecCons w B) = vecHead v • w + vecMul (vecTail v) (of B) :=
-  by
+    vecMul v (of <| vecCons w B) = vecHead v • w + vecMul (vecTail v) (of B) := by
   ext i
   simp [vec_mul]
 #align matrix.vec_mul_cons Matrix.vecMul_cons
@@ -349,16 +339,14 @@ theorem mulVec_empty (A : Matrix m' (Fin 0) α) (v : Fin 0 → α) : mulVec A v 
 
 @[simp]
 theorem cons_mulVec [Fintype n'] (v : n' → α) (A : Fin m → n' → α) (w : n' → α) :
-    mulVec (of <| vecCons v A) w = vecCons (dotProduct v w) (mulVec (of A) w) :=
-  by
+    mulVec (of <| vecCons v A) w = vecCons (dotProduct v w) (mulVec (of A) w) := by
   ext i
   refine' Fin.cases _ _ i <;> simp [mul_vec]
 #align matrix.cons_mul_vec Matrix.cons_mulVec
 
 @[simp]
 theorem mulVec_cons {α} [CommSemiring α] (A : m' → Fin n.succ → α) (x : α) (v : Fin n → α) :
-    mulVec (of A) (vecCons x v) = x • vecHead ∘ A + mulVec (of (vecTail ∘ A)) v :=
-  by
+    mulVec (of A) (vecCons x v) = x • vecHead ∘ A + mulVec (of (vecTail ∘ A)) v := by
   ext i
   simp [mul_vec, mul_comm]
 #align matrix.mul_vec_cons Matrix.mulVec_cons
@@ -381,16 +369,14 @@ theorem vecMulVec_empty (v : m' → α) (w : Fin 0 → α) : vecMulVec v w = fun
 
 @[simp]
 theorem cons_vecMulVec (x : α) (v : Fin m → α) (w : n' → α) :
-    vecMulVec (vecCons x v) w = vecCons (x • w) (vecMulVec v w) :=
-  by
+    vecMulVec (vecCons x v) w = vecCons (x • w) (vecMulVec v w) := by
   ext i
   refine' Fin.cases _ _ i <;> simp [vec_mul_vec]
 #align matrix.cons_vec_mul_vec Matrix.cons_vecMulVec
 
 @[simp]
 theorem vecMulVec_cons (v : m' → α) (x : α) (w : Fin n → α) :
-    vecMulVec v (vecCons x w) = fun i => v i • vecCons x w :=
-  by
+    vecMulVec v (vecCons x w) = fun i => v i • vecCons x w := by
   ext (i j)
   rw [vec_mul_vec_apply, Pi.smul_apply, smul_eq_mul]
 #align matrix.vec_mul_vec_cons Matrix.vecMulVec_cons
@@ -408,8 +394,7 @@ theorem smul_mat_empty {m' : Type _} (x : α) (A : Fin 0 → m' → α) : x • 
 
 @[simp]
 theorem smul_mat_cons (x : α) (v : n' → α) (A : Fin m → n' → α) :
-    x • vecCons v A = vecCons (x • v) (x • A) :=
-  by
+    x • vecCons v A = vecCons (x • v) (x • A) := by
   ext i
   refine' Fin.cases _ _ i <;> simp
 #align matrix.smul_mat_cons Matrix.smul_mat_cons
@@ -426,8 +411,7 @@ theorem submatrix_empty (A : Matrix m' n' α) (row : Fin 0 → m') (col : o' →
 
 @[simp]
 theorem submatrix_cons_row (A : Matrix m' n' α) (i : m') (row : Fin m → m') (col : o' → n') :
-    submatrix A (vecCons i row) col = vecCons (fun j => A i (col j)) (submatrix A row col) :=
-  by
+    submatrix A (vecCons i row) col = vecCons (fun j => A i (col j)) (submatrix A row col) := by
   ext (i j)
   refine' Fin.cases _ _ i <;> simp [submatrix]
 #align matrix.submatrix_cons_row Matrix.submatrix_cons_row

--- a/Mathlib/Data/Matrix/Notation.lean
+++ b/Mathlib/Data/Matrix/Notation.lean
@@ -57,7 +57,7 @@ section toExpr
 open Lean
 open Qq
 
-/-- Matrices can be reflected whenever their entries can. We insert a `matrix.of` to
+/-- Matrices can be reflected whenever their entries can. We insert a `Matrix.of` to
 prevent immediate decay to a function. -/
 protected instance toExpr [ToLevel.{u}] [ToLevel.{uₘ}] [ToLevel.{uₙ}]
     [Lean.ToExpr α] [Lean.ToExpr m'] [Lean.ToExpr n'] [Lean.ToExpr (m' → n' → α)] :

--- a/Mathlib/Data/Matrix/Notation.lean
+++ b/Mathlib/Data/Matrix/Notation.lean
@@ -11,6 +11,7 @@ Authors: Anne Baanen, Eric Wieser
 import Mathlib.Data.Matrix.Basic
 import Mathlib.Data.Fin.VecNotation
 import Mathlib.Tactic.FinCases
+import Mathlib.Tactic.ToExpr
 import Mathlib.Algebra.BigOperators.Fin
 import Qq
 
@@ -45,15 +46,6 @@ with `of ![![...]]`.
 
 Examples of usage can be found in the `test/matrix.lean` file.
 -/
-
--- TODO: remove once #3215 is bors'd
-class ToLevel.{u} where
-  /-- A `Level` that represents the universe level `u`. -/
-  toLevel : Level
-  /-- The universe itself. This is only here to avoid the "unused universe parameter" error. -/
-  univ : Type u := Sort u
-export ToLevel (toLevel)
-
 
 namespace Matrix
 

--- a/test/matrix.lean
+++ b/test/matrix.lean
@@ -44,23 +44,23 @@ open Lean Elab in
 def run (x : TermElabM α) : Command.CommandElabM α := Command.liftTermElabM x
 
 -- we test equality of expressions here to ensure that we have `2` and not `1.succ` in the type
-run_cmd run do let d ← getDims ``(!![]);        guard $ d == (q(0), q(0))
-run_cmd run do let d ← getDims ``(!![;]);       guard $ d == (q(1), q(0))
-run_cmd run do let d ← getDims ``(!![;;]);      guard $ d == (q(2), q(0))
-run_cmd run do let d ← getDims ``(!![,]);       guard $ d == (q(0), q(1))
-run_cmd run do let d ← getDims ``(!![,,]);      guard $ d == (q(0), q(2))
-run_cmd run do let d ← getDims ``(!![1]);       guard $ d == (q(1), q(1))
-run_cmd run do let d ← getDims ``(!![1,]);      guard $ d == (q(1), q(1))
-run_cmd run do let d ← getDims ``(!![1;]);      guard $ d == (q(1), q(1))
-run_cmd run do let d ← getDims ``(!![1,2;3,4]); guard $ d == (q(2), q(2))
+run_cmd run do let d ← getDims `(!![]);        guard $ d == (q(0), q(0))
+run_cmd run do let d ← getDims `(!![;]);       guard $ d == (q(1), q(0))
+run_cmd run do let d ← getDims `(!![;;]);      guard $ d == (q(2), q(0))
+run_cmd run do let d ← getDims `(!![,]);       guard $ d == (q(0), q(1))
+run_cmd run do let d ← getDims `(!![,,]);      guard $ d == (q(0), q(2))
+run_cmd run do let d ← getDims `(!![1]);       guard $ d == (q(1), q(1))
+run_cmd run do let d ← getDims `(!![1,]);      guard $ d == (q(1), q(1))
+run_cmd run do let d ← getDims `(!![1;]);      guard $ d == (q(1), q(1))
+run_cmd run do let d ← getDims `(!![1,2;3,4]); guard $ d == (q(2), q(2))
 
 end dimensions
 
-run_cmd guard $ (!![1;2])       = of ![![1], ![2]]
-run_cmd guard $ (!![1,3])       = of ![![1,3]]
-run_cmd guard $ (!![1,2;3,4])   = of ![![1,2], ![3,4]]
-run_cmd guard $ (!![1,2;3,4;])  = of ![![1,2], ![3,4]]
-run_cmd guard $ (!![1,2,;3,4,]) = of ![![1,2], ![3,4]]
+run_cmd run do guard $ (!![1;2])       = of ![![1], ![2]]
+run_cmd run do guard $ (!![1,3])       = of ![![1,3]]
+run_cmd run do guard $ (!![1,2;3,4])   = of ![![1,2], ![3,4]]
+run_cmd run do guard $ (!![1,2;3,4;])  = of ![![1,2], ![3,4]]
+run_cmd run do guard $ (!![1,2,;3,4,]) = of ![![1,2], ![3,4]]
 
 example {a a' b b' c c' d d' : α} :
   !![a, b; c, d] + !![a', b'; c', d'] = !![a + a', b + b'; c + c', d + d'] :=
@@ -73,12 +73,17 @@ by simp
 example {a a' b b' c c' d d' : α} :
   !![a, b; c, d] ⬝ !![a', b'; c', d'] =
     !![a * a' + b * c', a * b' + b * d'; c * a' + d * c', c * b' + d * d'] :=
-by simp [-Equiv.Perm.coe_subsingleton]
+by simp
 
 example {a b c d x y : α} :
   mulVec !![a, b; c, d] ![x, y] = ![a * x + b * y, c * x + d * y] :=
 by simp
 
+/-!
+TODO: the below lemmas rely on simp lemmas assuming the indexing numerals are assembled from
+`bit0` and `bit1`, so no longer work in Lean 4
+-/
+/-
 example {a b c d : α} : submatrix !![a, b; c, d] ![1, 0] ![0] = !![c; a] :=
 by ext; simp
 
@@ -109,35 +114,32 @@ example {a b c d e f g h : α} : ![a, b, c, d, e, f, g, h] 5 = f := by simp
 example {a b c d e f g h : α} : ![a, b, c, d, e, f, g, h] 7 = h := by simp
 example {a b c d e f g h : α} : ![a, b, c, d, e, f, g, h] 37 = f := by simp
 example {a b c d e f g h : α} : ![a, b, c, d, e, f, g, h] 99 = d := by simp
+-/
 
--- todo: uncomment when porting `Matrix.det`
+-- TODO: uncomment snd update `try this` when porting `Matrix.det`
+/-
+example {α : Type _} [CommRing α] {a b c d : α} :
+    Matrix.det !![a, b; c, d] = a * d - b * c := by
+  simp [Matrix.det_succ_row_zero, Fin.sum_univ_succ]
+  /-
+  Try this: simp only [det_succ_row_zero, Fin.sum_univ_succ, neg_mul, mul_one,
+  Fin.default_eq_zero, Fin.coe_zero, one_mul, cons_val_one, Fin.coe_succ, univ_unique,
+  submatrix_apply, pow_one, Fin.zero_succ_above, Fin.succ_succ_above_zero,  finset.sum_singleton,
+  cons_val_zero, cons_val_succ, det_fin_zero, pow_zero]
+  -/
+  ring
 
--- example {α : Type*} [comm_ring α] {a b c d : α} :
---   Matrix.det !![a, b; c, d] = a * d - b * c :=
--- begin
---   simp [Matrix.det_succ_row_zero, Fin.sum_univ_succ],
---   /-
---   Try this: simp only [det_succ_row_zero, Fin.sum_univ_succ, neg_mul, mul_one,
---   Fin.default_eq_zero, Fin.coe_zero, one_mul, cons_val_one, Fin.coe_succ, univ_unique,
---   submatrix_apply, pow_one, Fin.zero_succ_above, Fin.succ_succ_above_zero,  finset.sum_singleton,
---   cons_val_zero, cons_val_succ, det_fin_zero, pow_zero]
---   -/
---   ring
--- end
-
--- example {α : Type*} [comm_ring α] {a b c d e f g h i : α} :
---   Matrix.det !![a, b, c; d, e, f; g, h, i] =
---     a * e * i - a * f * h - b * d * i + b * f * g + c * d * h - c * e * g :=
--- begin
---   simp [Matrix.det_succ_row_zero, Fin.sum_univ_succ],
---   /-
---   Try this: simp only [det_succ_row_zero, Fin.sum_univ_succ, neg_mul, cons_append,
---   mul_one, Fin.default_eq_zero, Fin.coe_zero, cons_vec_bit0_eq_alt0, one_mul, cons_val_one,
---   cons_vec_alt0, Fin.succ_succ_above_one, Fin.coe_succ, univ_unique, submatrix_apply, pow_one,
---   Fin.zero_succ_above, Fin.succ_zero_eq_one, Fin.succ_succ_above_zero, nat.neg_one_sq,
---   finset.sum_singleton, cons_val_zero, cons_val_succ, det_fin_zero, head_cons, pow_zero]
---    -/
---   ring
--- end
-
+example {α : Type _} [CommRing α] {a b c d e f g h i : α} :
+    Matrix.det !![a, b, c; d, e, f; g, h, i] =
+      a * e * i - a * f * h - b * d * i + b * f * g + c * d * h - c * e * g := by
+  simp [Matrix.det_succ_row_zero, Fin.sum_univ_succ]
+  /-
+  Try this: simp only [det_succ_row_zero, Fin.sum_univ_succ, neg_mul, cons_append,
+  mul_one, Fin.default_eq_zero, Fin.coe_zero, cons_vec_bit0_eq_alt0, one_mul, cons_val_one,
+  cons_vec_alt0, Fin.succ_succ_above_one, Fin.coe_succ, univ_unique, submatrix_apply, pow_one,
+  Fin.zero_succ_above, Fin.succ_zero_eq_one, Fin.succ_succ_above_zero, nat.neg_one_sq,
+  finset.sum_singleton, cons_val_zero, cons_val_succ, det_fin_zero, head_cons, pow_zero]
+   -/
+  ring
+-/
 end Matrix

--- a/test/matrix.lean
+++ b/test/matrix.lean
@@ -38,7 +38,7 @@ def getDims (me : TermElabM Term) : TermElabM (Q(Nat) × Q(Nat)) := do
   let n ← instantiateMVars n
   if m.hasMVar || n.hasMVar then
     throwError "indices have metavariables"
-  return (← instantiateMVars m, ← instantiateMVars n)
+  return (m, n)
 
 open Lean Elab in
 def run (x : TermElabM α) : Command.CommandElabM α := Command.liftTermElabM x

--- a/test/matrix.lean
+++ b/test/matrix.lean
@@ -11,7 +11,7 @@ import Std.Tactic.GuardExpr
 
 open Qq
 
--- todo: uncomment above imports when they are ported
+-- TODO: uncomment above imports when they are ported
 
 variables {α β : Type} [Semiring α] [Ring β]
 

--- a/test/matrix.lean
+++ b/test/matrix.lean
@@ -1,0 +1,129 @@
+/-
+manually ported from
+https://github.com/leanprover-community/mathlib/blob/4f4a1c875d0baa92ab5d92f3fb1bb258ad9f3e5b/test/matrix.lean
+-/
+import Mathlib.Data.Matrix.Notation
+-- import linear_algebra.Matrix.determinant
+import Mathlib.GroupTheory.Perm.Fin
+-- import Mathlib.Tactic.NormSwap
+
+-- todo: uncomment above imports when they are ported
+
+variables {α β : Type} [Semiring α] [Ring β]
+
+namespace Matrix
+
+open Matrix
+
+/-! Test that the dimensions are inferred correctly, even for empty matrices -/
+section dimensions
+
+set_option pp.universes true
+set_option pp.all true
+
+meta def get_dims (e : pexpr) : tactic (Expr × Expr) :=
+do
+  elem_t ← tactic.mk_meta_var (expr.sort level.zero.succ),
+  e ← tactic.to_expr ``(%%e : matrix _ _ %%elem_t) tt ff,
+  t ← tactic.infer_type e,
+  `(Matrix.{0 0 0} (Fin %%m) (Fin %%n) %%elem_t) ← tactic.infer_type e,
+  return (m, n)
+
+-- we test equality of expressions here to ensure that we have `2` and not `1.succ` in the type
+run_cmd do let d ← get_dims ``(!![]);        guard $ d = (`(0), `(0))
+run_cmd do let d ← get_dims ``(!![;]);       guard $ d = (`(1), `(0))
+run_cmd do let d ← get_dims ``(!![;;]),      guard $ d = (`(2), `(0))
+run_cmd do let d ← get_dims ``(!![,]);       guard $ d = (`(0), `(1))
+run_cmd do let d ← get_dims ``(!![,,]);      guard $ d = (`(0), `(2))
+run_cmd do let d ← get_dims ``(!![1]);       guard $ d = (`(1), `(1))
+run_cmd do let d ← get_dims ``(!![1,]);      guard $ d = (`(1), `(1))
+run_cmd do let d ← get_dims ``(!![1;]);      guard $ d = (`(1), `(1))
+run_cmd do let d ← get_dims ``(!![1,2;3,4]); guard $ d = (`(2), `(2))
+
+end dimensions
+
+run_cmd guard $ (!![1;2])       = of ![![1], ![2]]
+run_cmd guard $ (!![1,3])       = of ![![1,3]]
+run_cmd guard $ (!![1,2;3,4])   = of ![![1,2], ![3,4]]
+run_cmd guard $ (!![1,2;3,4;])  = of ![![1,2], ![3,4]]
+run_cmd guard $ (!![1,2,;3,4,]) = of ![![1,2], ![3,4]]
+
+example {a a' b b' c c' d d' : α} :
+  !![a, b; c, d] + !![a', b'; c', d'] = !![a + a', b + b'; c + c', d + d'] :=
+by simp
+
+example {a a' b b' c c' d d' : β} :
+  !![a, b; c, d] - !![a', b'; c', d'] = !![a - a', b - b'; c - c', d - d'] :=
+by simp
+
+example {a a' b b' c c' d d' : α} :
+  !![a, b; c, d] ⬝ !![a', b'; c', d'] =
+    !![a * a' + b * c', a * b' + b * d'; c * a' + d * c', c * b' + d * d'] :=
+by simp [-Equiv.Perm.coe_subsingleton]
+
+example {a b c d x y : α} :
+  mulVec !![a, b; c, d] ![x, y] = ![a * x + b * y, c * x + d * y] :=
+by simp
+
+example {a b c d : α} : submatrix !![a, b; c, d] ![1, 0] ![0] = !![c; a] :=
+by ext; simp
+
+example {a b c : α} : ![a, b, c] 0 = a := by simp
+example {a b c : α} : ![a, b, c] 1 = b := by simp
+example {a b c : α} : ![a, b, c] 2 = c := by simp
+
+example {a b c d : α} : ![a, b, c, d] 0 = a := by simp
+example {a b c d : α} : ![a, b, c, d] 1 = b := by simp
+example {a b c d : α} : ![a, b, c, d] 2 = c := by simp
+example {a b c d : α} : ![a, b, c, d] 3 = d := by simp
+example {a b c d : α} : ![a, b, c, d] 42 = c := by simp
+
+example {a b c d e : α} : ![a, b, c, d, e] 0 = a := by simp
+example {a b c d e : α} : ![a, b, c, d, e] 1 = b := by simp
+example {a b c d e : α} : ![a, b, c, d, e] 2 = c := by simp
+example {a b c d e : α} : ![a, b, c, d, e] 3 = d := by simp
+example {a b c d e : α} : ![a, b, c, d, e] 4 = e := by simp
+example {a b c d e : α} : ![a, b, c, d, e] 5 = a := by simp
+example {a b c d e : α} : ![a, b, c, d, e] 6 = b := by simp
+example {a b c d e : α} : ![a, b, c, d, e] 7 = c := by simp
+example {a b c d e : α} : ![a, b, c, d, e] 8 = d := by simp
+example {a b c d e : α} : ![a, b, c, d, e] 9 = e := by simp
+example {a b c d e : α} : ![a, b, c, d, e] 123 = d := by simp
+example {a b c d e : α} : ![a, b, c, d, e] 123456789 = e := by simp
+
+example {a b c d e f g h : α} : ![a, b, c, d, e, f, g, h] 5 = f := by simp
+example {a b c d e f g h : α} : ![a, b, c, d, e, f, g, h] 7 = h := by simp
+example {a b c d e f g h : α} : ![a, b, c, d, e, f, g, h] 37 = f := by simp
+example {a b c d e f g h : α} : ![a, b, c, d, e, f, g, h] 99 = d := by simp
+
+-- todo: uncomment when porting `Matrix.det`
+
+-- example {α : Type*} [comm_ring α] {a b c d : α} :
+--   Matrix.det !![a, b; c, d] = a * d - b * c :=
+-- begin
+--   simp [Matrix.det_succ_row_zero, Fin.sum_univ_succ],
+--   /-
+--   Try this: simp only [det_succ_row_zero, Fin.sum_univ_succ, neg_mul, mul_one,
+--   Fin.default_eq_zero, Fin.coe_zero, one_mul, cons_val_one, Fin.coe_succ, univ_unique,
+--   submatrix_apply, pow_one, Fin.zero_succ_above, Fin.succ_succ_above_zero,  finset.sum_singleton,
+--   cons_val_zero, cons_val_succ, det_fin_zero, pow_zero]
+--   -/
+--   ring
+-- end
+
+-- example {α : Type*} [comm_ring α] {a b c d e f g h i : α} :
+--   Matrix.det !![a, b, c; d, e, f; g, h, i] =
+--     a * e * i - a * f * h - b * d * i + b * f * g + c * d * h - c * e * g :=
+-- begin
+--   simp [Matrix.det_succ_row_zero, Fin.sum_univ_succ],
+--   /-
+--   Try this: simp only [det_succ_row_zero, Fin.sum_univ_succ, neg_mul, cons_append,
+--   mul_one, Fin.default_eq_zero, Fin.coe_zero, cons_vec_bit0_eq_alt0, one_mul, cons_val_one,
+--   cons_vec_alt0, Fin.succ_succ_above_one, Fin.coe_succ, univ_unique, submatrix_apply, pow_one,
+--   Fin.zero_succ_above, Fin.succ_zero_eq_one, Fin.succ_succ_above_zero, nat.neg_one_sq,
+--   finset.sum_singleton, cons_val_zero, cons_val_succ, det_fin_zero, head_cons, pow_zero]
+--    -/
+--   ring
+-- end
+
+end Matrix


### PR DESCRIPTION
This PR also fixes the doc on `Data.Fin.VecNotation` and adds the unexpander for the `![x, y, ...]` notation.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
-->
- [x] depends on: #3215
- [x] depends on: #3430
- [x] depends on: https://github.com/leanprover-community/mathport/pull/235
- [x] depends on: #3485

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
