### PR TITLE
[Merged by Bors] - fix: add matrix notation stub for mathport

### DIFF
--- a/Mathlib/Mathport/Syntax.lean
+++ b/Mathlib/Mathport/Syntax.lean
@@ -354,3 +354,9 @@ namespace Command
 /- E -/ syntax (name := assertNoInstance) "assert_no_instance " term : command
 
 end Command
+
+namespace Term
+
+/- M -/ syntax (name := matrixNotation) "!![" sepBy(term,*, "; ") "]" : term
+
+end Term

--- a/Mathlib/Mathport/Syntax.lean
+++ b/Mathlib/Mathport/Syntax.lean
@@ -357,7 +357,8 @@ end Command
 
 namespace Term
 
-/- M -/ syntax (name := matrixNotation) "!![" sepBy1(term,+,?, ";", "; ", allowTrailingSep) "]" : term
+/- M -/ syntax (name := matrixNotation)
+  "!![" sepBy1(term,+,?, ";", "; ", allowTrailingSep) "]" : term
 /- M -/ syntax (name := matrixNotationRx0) "!![" ";"* "]" : term
 /- M -/ syntax (name := matrixNotation0xC) "!![" ","+ "]" : term
 

--- a/Mathlib/Mathport/Syntax.lean
+++ b/Mathlib/Mathport/Syntax.lean
@@ -357,6 +357,8 @@ end Command
 
 namespace Term
 
-/- M -/ syntax (name := matrixNotation) "!![" sepBy(term,*, "; ") "]" : term
+/- M -/ syntax (name := matrixNotation) "!![" sepBy1(term,+,?, ";", "; ", allowTrailingSep) "]" : term
+/- M -/ syntax (name := matrixNotationRx0) "!![" ";"* "]" : term
+/- M -/ syntax (name := matrixNotation0xC) "!![" ","+ "]" : term
 
 end Term


### PR DESCRIPTION
Part of the implementation of mathport support for the `matrix.notation`  user notation, see [Zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/!4.233215.20and.20data.2Ematrix.2Enotation/near/349219891).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
