### PR TITLE
[Merged by Bors] - fix: Fix `Polynomial.repr`

### DIFF
--- a/Mathlib/Data/Polynomial/Basic.lean
+++ b/Mathlib/Data/Polynomial/Basic.lean
@@ -1223,19 +1223,22 @@ variable [Semiring R]
 open Classical
 
 protected instance repr [Repr R] : Repr R[X] :=
-  ⟨fun p _ =>
-    if p = 0 then "0"
+  ⟨fun p prec =>
+    if p.support = ∅ then "0"
     else
-      (p.support.sort (· ≤ ·)).foldr
-        (fun n a =>
-          (a ++ if a = "" then "" else " + ") ++
-            if n = 0 then "C (" ++ repr (coeff p n) ++ ")"
-            else
-              if n = 1 then if coeff p n = 1 then "X" else "C (" ++ repr (coeff p n) ++ ") * X"
-              else
-                if coeff p n = 1 then "X ^ " ++ repr n
-                else "C (" ++ repr (coeff p n) ++ ") * X ^ " ++ repr n)
-        ""⟩
+      Repr.addAppParen
+        (Lean.Format.fill
+          (Lean.Format.joinSep
+            (List.map
+              (fun
+                | 0 => "C " ++ reprArg (coeff p 0)
+                | 1 => if coeff p 1 = 1 then "X" else "C " ++ reprArg (coeff p 1) ++ " * X"
+                | n =>
+                  if coeff p n = 1 then "X ^ " ++ Nat.repr n
+                  else "C " ++ reprArg (coeff p 1) ++ " * X ^ " ++ Nat.repr n)
+              (p.support.sort (· ≤ ·)))
+            (" +" ++ Lean.Format.line)))
+        prec⟩
 #align polynomial.has_repr Polynomial.repr
 
 end repr

--- a/Mathlib/Data/Polynomial/Basic.lean
+++ b/Mathlib/Data/Polynomial/Basic.lean
@@ -1221,10 +1221,10 @@ section repr
 variable [Semiring R]
 
 protected instance repr [Repr R] [DecidableEq R] : Repr R[X] :=
-  ⟨fun p prec =>
+  ⟨fun p _ =>
     if p.support = ∅ then "0"
     else
-      Repr.addAppParen
+      Lean.Format.paren
         (Lean.Format.fill
           (Lean.Format.joinSep
             (List.map
@@ -1235,9 +1235,23 @@ protected instance repr [Repr R] [DecidableEq R] : Repr R[X] :=
                   if coeff p n = 1 then "X ^ " ++ Nat.repr n
                   else "C " ++ reprArg (coeff p n) ++ " * X ^ " ++ Nat.repr n)
               (p.support.sort (· ≤ ·)))
-            (" +" ++ Lean.Format.line)))
-        prec⟩
+            (" +" ++ Lean.Format.line)))⟩
 #align polynomial.has_repr Polynomial.repr
+
+example : reprStr
+    (⟨⟨{}, Pi.single 0 0,
+      by intro; simp [Pi.single, Function.update_apply]⟩⟩ : ℕ[X]) =
+    "0" := by native_decide
+
+example : reprStr
+    (⟨⟨{1}, Pi.single 1 37,
+      by intro; simp [Pi.single, Function.update_apply]⟩⟩ : ℕ[X]) =
+    "(C 37 * X)" := by native_decide
+
+example : reprStr
+    (⟨⟨{0, 2}, Pi.single 0 57 + Pi.single 2 22,
+      by intro; simp [Pi.single, Function.update_apply]; tauto⟩⟩ : ℕ[X]) =
+    "(C 57 + C 22 * X ^ 2)" := by native_decide
 
 end repr
 

--- a/Mathlib/Data/Polynomial/Basic.lean
+++ b/Mathlib/Data/Polynomial/Basic.lean
@@ -1220,9 +1220,7 @@ section repr
 
 variable [Semiring R]
 
-open Classical
-
-protected instance repr [Repr R] : Repr R[X] :=
+protected instance repr [Repr R] [DecidableEq R] : Repr R[X] :=
   ⟨fun p prec =>
     if p.support = ∅ then "0"
     else

--- a/Mathlib/Data/Polynomial/Basic.lean
+++ b/Mathlib/Data/Polynomial/Basic.lean
@@ -1233,7 +1233,7 @@ protected instance repr [Repr R] [DecidableEq R] : Repr R[X] :=
                 | 1 => if coeff p 1 = 1 then "X" else "C " ++ reprArg (coeff p 1) ++ " * X"
                 | n =>
                   if coeff p n = 1 then "X ^ " ++ Nat.repr n
-                  else "C " ++ reprArg (coeff p 1) ++ " * X ^ " ++ Nat.repr n)
+                  else "C " ++ reprArg (coeff p n) ++ " * X ^ " ++ Nat.repr n)
               (p.support.sort (· ≤ ·)))
             (" +" ++ Lean.Format.line)))
         prec⟩

--- a/Mathlib/Data/Polynomial/Basic.lean
+++ b/Mathlib/Data/Polynomial/Basic.lean
@@ -1221,10 +1221,10 @@ section repr
 variable [Semiring R]
 
 protected instance repr [Repr R] [DecidableEq R] : Repr R[X] :=
-  ⟨fun p _ =>
+  ⟨fun p prec =>
     if p.support = ∅ then "0"
     else
-      Lean.Format.paren
+      Repr.addAppParen
         (Lean.Format.fill
           (Lean.Format.joinSep
             (List.map
@@ -1235,23 +1235,8 @@ protected instance repr [Repr R] [DecidableEq R] : Repr R[X] :=
                   if coeff p n = 1 then "X ^ " ++ Nat.repr n
                   else "C " ++ reprArg (coeff p n) ++ " * X ^ " ++ Nat.repr n)
               (p.support.sort (· ≤ ·)))
-            (" +" ++ Lean.Format.line)))⟩
+            (" +" ++ Lean.Format.line))) prec⟩
 #align polynomial.has_repr Polynomial.repr
-
-example : reprStr
-    (⟨⟨{}, Pi.single 0 0,
-      by intro; simp [Pi.single, Function.update_apply]⟩⟩ : ℕ[X]) =
-    "0" := by native_decide
-
-example : reprStr
-    (⟨⟨{1}, Pi.single 1 37,
-      by intro; simp [Pi.single, Function.update_apply]⟩⟩ : ℕ[X]) =
-    "(C 37 * X)" := by native_decide
-
-example : reprStr
-    (⟨⟨{0, 2}, Pi.single 0 57 + Pi.single 2 22,
-      by intro; simp [Pi.single, Function.update_apply]; tauto⟩⟩ : ℕ[X]) =
-    "(C 57 + C 22 * X ^ 2)" := by native_decide
 
 end repr
 

--- a/test/Polynomial.lean
+++ b/test/Polynomial.lean
@@ -6,16 +6,33 @@ def p0: ℕ[X] :=
   ⟨⟨{}, Pi.single 0 0, by intro; simp [Pi.single, Function.update_apply]⟩⟩
 example : reprStr p0 = "0" := by native_decide
 example : reprStr (Option.some p0) = "some 0" := by native_decide
+example : (reprPrec p0 65).pretty = "0" := by native_decide
+
+def pX : ℕ[X] :=
+  ⟨⟨{1}, Pi.single 1 1, by intro; simp [Pi.single, Function.update_apply]⟩⟩
+example : reprStr pX = "X" := by native_decide
+example : reprStr (Option.some pX) = "some X" := by native_decide
+
+def pXsq : ℕ[X] :=
+  ⟨⟨{2}, Pi.single 2 1, by intro; simp [Pi.single, Function.update_apply]⟩⟩
+example : reprStr pXsq = "X ^ 2" := by native_decide
+example : reprStr (Option.some pXsq) = "some (X ^ 2)" := by native_decide
+example : (reprPrec pXsq 65).pretty = "X ^ 2" := by native_decide
+example : (reprPrec pXsq 70).pretty = "X ^ 2" := by native_decide
+example : (reprPrec pXsq 80).pretty = "(X ^ 2)" := by native_decide
 
 def p1 : ℕ[X] :=
   ⟨⟨{1}, Pi.single 1 37, by intro; simp [Pi.single, Function.update_apply]⟩⟩
 example : reprStr p1 = "C 37 * X" := by native_decide
 example : reprStr (Option.some p1) = "some (C 37 * X)" := by native_decide
+example : (reprPrec p1 65).pretty = "C 37 * X" := by native_decide
+example : (reprPrec p1 70).pretty = "(C 37 * X)" := by native_decide
 
 def p2 : ℕ[X] :=
   ⟨⟨{0, 2}, Pi.single 0 57 + Pi.single 2 22,
     by intro; simp [Pi.single, Function.update_apply]; tauto⟩⟩
 example : reprStr p2 = "C 57 + C 22 * X ^ 2" := by native_decide
+example : (reprPrec p2 65).pretty = "(C 57 + C 22 * X ^ 2)" := by native_decide
 
 -- test that parens are added inside `C`
 def pu1 : (ULift.{1} ℕ)[X] :=

--- a/test/Polynomial.lean
+++ b/test/Polynomial.lean
@@ -2,7 +2,7 @@ import Mathlib.Data.Polynomial.Basic
 
 open Polynomial
 
-def p0: ℕ[X] :=
+def p0 : ℕ[X] :=
   ⟨⟨{}, Pi.single 0 0, by intro; simp [Pi.single, Function.update_apply]⟩⟩
 example : reprStr p0 = "0" := by native_decide
 example : reprStr (Option.some p0) = "some 0" := by native_decide

--- a/test/Polynomial.lean
+++ b/test/Polynomial.lean
@@ -1,0 +1,24 @@
+import Mathlib.Data.Polynomial.Basic
+
+open Polynomial
+
+def p0: ℕ[X] :=
+  ⟨⟨{}, Pi.single 0 0, by intro; simp [Pi.single, Function.update_apply]⟩⟩
+example : reprStr p0 = "0" := by native_decide
+example : reprStr (Option.some p0) = "some 0" := by native_decide
+
+def p1 : ℕ[X] :=
+  ⟨⟨{1}, Pi.single 1 37, by intro; simp [Pi.single, Function.update_apply]⟩⟩
+example : reprStr p1 = "C 37 * X" := by native_decide
+example : reprStr (Option.some p1) = "some (C 37 * X)" := by native_decide
+
+def p2 : ℕ[X] :=
+  ⟨⟨{0, 2}, Pi.single 0 57 + Pi.single 2 22,
+    by intro; simp [Pi.single, Function.update_apply]; tauto⟩⟩
+example : reprStr p2 = "C 57 + C 22 * X ^ 2" := by native_decide
+
+-- test that parens are added inside `C`
+def pu1 : (ULift.{1} ℕ)[X] :=
+  ⟨⟨{1}, Pi.single 1 (ULift.up 37),
+    by intro; simp [Pi.single, Function.update_apply, ←ULift.down_inj]⟩⟩
+example : reprStr pu1 = "C (ULift.up 37) * X" := by native_decide


### PR DESCRIPTION

I misunderstood the `Repr` instance when I port this file, In Lean 4, `Repr` returns `Format`, not `String`, so my porting of `Polynomial.repr` was unnatural.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

I fixed that in this PR. Of course, `Polynomial` is noncomputable and this instance is actually useless. 🥴

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
