### PR TITLE
[Merged by Bors] - chore: forward port mathlib#18810, 18798, 18738

### DIFF
--- a/Mathlib/Algebra/Order/Sub/Defs.lean
+++ b/Mathlib/Algebra/Order/Sub/Defs.lean
@@ -55,7 +55,6 @@ In other words, `a - b` is the least `c` such that `a ≤ b + c`.
 This is satisfied both by the subtraction in additive ordered groups and by truncated subtraction
 in canonically ordered monoids on many specific types.
 -/
--- porting note: changed to be a `Prop`
 class OrderedSub (α : Type _) [LE α] [Add α] [Sub α] : Prop where
   /-- `a - b` provides a lower bound on `c` such that `a ≤ c + b`. -/
   tsub_le_iff_right : ∀ a b c : α, a - b ≤ c ↔ a ≤ c + b

--- a/Mathlib/Algebra/Order/Sub/Defs.lean
+++ b/Mathlib/Algebra/Order/Sub/Defs.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn
 
 ! This file was ported from Lean 3 source module algebra.order.sub.defs
-! leanprover-community/mathlib commit 70d50ecfd4900dd6d328da39ab7ebd516abe4025
+! leanprover-community/mathlib commit de29c328903507bb7aff506af9135f4bdaf1849c
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/

--- a/Mathlib/Data/Matrix/Basic.lean
+++ b/Mathlib/Data/Matrix/Basic.lean
@@ -778,6 +778,7 @@ theorem dotProduct_comp_equiv_symm (e : n ≃ m) : u ⬝ᵥ x ∘ e.symm = u ∘
 /-- Permuting vectors on both sides of a dot product is a no-op. -/
 @[simp]
 theorem comp_equiv_dotProduct_comp_equiv (e : m ≃ n) : x ∘ e ⬝ᵥ y ∘ e = x ⬝ᵥ y := by
+  -- Porting note: was `simp only` with all three lemmas
   rw [← dotProduct_comp_equiv_symm]; simp only [Function.comp, Equiv.apply_symm_apply]
 #align matrix.comp_equiv_dot_product_comp_equiv Matrix.comp_equiv_dotProduct_comp_equiv
 

--- a/Mathlib/Data/Matrix/Basic.lean
+++ b/Mathlib/Data/Matrix/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Ellen Arlt, Blair Shi, Sean Leather, Mario Carneiro, Johan Commelin, Lu-Ming Zhang
 
 ! This file was ported from Lean 3 source module data.matrix.basic
-! leanprover-community/mathlib commit 3e068ece210655b7b9a9477c3aff38a492400aa1
+! leanprover-community/mathlib commit 0e2aab2b0d521f060f62a14d2cf2e2c54e8491d6
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -761,6 +761,25 @@ theorem dotProduct_add : u ⬝ᵥ (v + w) = u ⬝ᵥ v + u ⬝ᵥ w := by
 theorem sum_elim_dotProduct_sum_elim : Sum.elim u x ⬝ᵥ Sum.elim v y = u ⬝ᵥ v + x ⬝ᵥ y := by
   simp [dotProduct]
 #align matrix.sum_elim_dot_product_sum_elim Matrix.sum_elim_dotProduct_sum_elim
+
+/-- Permuting a vector on the left of a dot product can be transferred to the right. -/
+@[simp]
+theorem comp_equiv_symm_dotProduct (e : m ≃ n) : u ∘ e.symm ⬝ᵥ x = u ⬝ᵥ x ∘ e :=
+  (e.sum_comp _).symm.trans <|
+    Finset.sum_congr rfl fun _ _ => by simp only [Function.comp, Equiv.symm_apply_apply]
+#align matrix.comp_equiv_symm_dot_product Matrix.comp_equiv_symm_dotProduct
+
+/-- Permuting a vector on the right of a dot product can be transferred to the left. -/
+@[simp]
+theorem dotProduct_comp_equiv_symm (e : n ≃ m) : u ⬝ᵥ x ∘ e.symm = u ∘ e ⬝ᵥ x := by
+  simpa only [Equiv.symm_symm] using (comp_equiv_symm_dotProduct u x e.symm).symm
+#align matrix.dot_product_comp_equiv_symm Matrix.dotProduct_comp_equiv_symm
+
+/-- Permuting vectors on both sides of a dot product is a no-op. -/
+@[simp]
+theorem comp_equiv_dotProduct_comp_equiv (e : m ≃ n) : x ∘ e ⬝ᵥ y ∘ e = x ⬝ᵥ y := by
+  rw [← dotProduct_comp_equiv_symm]; simp only [Function.comp, Equiv.apply_symm_apply]
+#align matrix.comp_equiv_dot_product_comp_equiv Matrix.comp_equiv_dotProduct_comp_equiv
 
 end NonUnitalNonAssocSemiring
 
@@ -2446,6 +2465,18 @@ theorem submatrix_mul_equiv [Fintype n] [Fintype o] [AddCommMonoid α] [Mul α] 
   (submatrix_mul M N e₁ e₂ e₃ e₂.bijective).symm
 #align matrix.submatrix_mul_equiv Matrix.submatrix_mul_equiv
 
+theorem submatrix_mulVec_equiv [Fintype n] [Fintype o] [NonUnitalNonAssocSemiring α]
+    (M : Matrix m n α) (v : o → α) (e₁ : l → m) (e₂ : o ≃ n) :
+    (M.submatrix e₁ e₂).mulVec v = M.mulVec (v ∘ e₂.symm) ∘ e₁ :=
+  funext fun _ => Eq.symm (dotProduct_comp_equiv_symm _ _ _)
+#align matrix.submatrix_mul_vec_equiv Matrix.submatrix_mulVec_equiv
+
+theorem submatrix_vecMul_equiv [Fintype l] [Fintype m] [NonUnitalNonAssocSemiring α]
+    (M : Matrix m n α) (v : l → α) (e₁ : l ≃ m) (e₂ : o → n) :
+    vecMul v (M.submatrix e₁ e₂) = vecMul (v ∘ e₁.symm) M ∘ e₂ :=
+  funext fun _ => Eq.symm (comp_equiv_symm_dotProduct _ _ _)
+#align matrix.submatrix_vec_mul_equiv Matrix.submatrix_vecMul_equiv
+
 theorem mul_submatrix_one [Fintype n] [Fintype o] [NonAssocSemiring α] [DecidableEq o] (e₁ : n ≃ o)
     (e₂ : l → o) (M : Matrix m n α) :
     M ⬝ (1 : Matrix o o α).submatrix e₁ e₂ = submatrix M id (e₁.symm ∘ e₂) := by
@@ -2664,12 +2695,12 @@ section Update
 
 /-- Update, i.e. replace the `i`th row of matrix `A` with the values in `b`. -/
 def updateRow [DecidableEq m] (M : Matrix m n α) (i : m) (b : n → α) : Matrix m n α :=
-  Function.update M i b
+  of <| Function.update M i b
 #align matrix.update_row Matrix.updateRow
 
 /-- Update, i.e. replace the `j`th column of matrix `A` with the values in `b`. -/
-def updateColumn [DecidableEq n] (M : Matrix m n α) (j : n) (b : m → α) : Matrix m n α := fun i =>
-  Function.update (M i) j (b i)
+def updateColumn [DecidableEq n] (M : Matrix m n α) (j : n) (b : m → α) : Matrix m n α :=
+  of fun i => Function.update (M i) j (b i)
 #align matrix.update_column Matrix.updateColumn
 
 variable {M : Matrix m n α} {i : m} {j : n} {b : n → α} {c : m → α}
@@ -2796,6 +2827,62 @@ theorem diagonal_updateRow_single [DecidableEq n] [Zero α] (v : n → α) (i : 
     (diagonal v).updateRow i (Pi.single i x) = diagonal (Function.update v i x) := by
   rw [← diagonal_transpose, updateRow_transpose, diagonal_updateColumn_single, diagonal_transpose]
 #align matrix.diagonal_update_row_single Matrix.diagonal_updateRow_single
+
+/-! Updating rows and columns commutes in the obvious way with reindexing the matrix. -/
+
+
+theorem updateRow_submatrix_equiv [DecidableEq l] [DecidableEq m] (A : Matrix m n α) (i : l)
+    (r : o → α) (e : l ≃ m) (f : o ≃ n) :
+    updateRow (A.submatrix e f) i r = (A.updateRow (e i) fun j => r (f.symm j)).submatrix e f := by
+  ext (i' j)
+  simp only [submatrix_apply, updateRow_apply, Equiv.apply_eq_iff_eq, Equiv.symm_apply_apply]
+#align matrix.update_row_submatrix_equiv Matrix.updateRow_submatrix_equiv
+
+theorem submatrix_updateRow_equiv [DecidableEq l] [DecidableEq m] (A : Matrix m n α) (i : m)
+    (r : n → α) (e : l ≃ m) (f : o ≃ n) :
+    (A.updateRow i r).submatrix e f = updateRow (A.submatrix e f) (e.symm i) fun i => r (f i) :=
+  Eq.trans (by simp_rw [Equiv.apply_symm_apply]) (updateRow_submatrix_equiv A _ _ e f).symm
+#align matrix.submatrix_update_row_equiv Matrix.submatrix_updateRow_equiv
+
+theorem updateColumn_submatrix_equiv [DecidableEq o] [DecidableEq n] (A : Matrix m n α) (j : o)
+    (c : l → α) (e : l ≃ m) (f : o ≃ n) : updateColumn (A.submatrix e f) j c =
+    (A.updateColumn (f j) fun i => c (e.symm i)).submatrix e f := by
+  simpa only [← transpose_submatrix, updateRow_transpose] using
+    congr_arg transpose (updateRow_submatrix_equiv Aᵀ j c f e)
+#align matrix.update_column_submatrix_equiv Matrix.updateColumn_submatrix_equiv
+
+theorem submatrix_updateColumn_equiv [DecidableEq o] [DecidableEq n] (A : Matrix m n α) (j : n)
+    (c : m → α) (e : l ≃ m) (f : o ≃ n) : (A.updateColumn j c).submatrix e f =
+    updateColumn (A.submatrix e f) (f.symm j) fun i => c (e i) :=
+  Eq.trans (by simp_rw [Equiv.apply_symm_apply]) (updateColumn_submatrix_equiv A _ _ e f).symm
+#align matrix.submatrix_update_column_equiv Matrix.submatrix_updateColumn_equiv
+
+/-! `reindex` versions of the above `submatrix` lemmas for convenience. -/
+
+
+theorem updateRow_reindex [DecidableEq l] [DecidableEq m] (A : Matrix m n α) (i : l) (r : o → α)
+    (e : m ≃ l) (f : n ≃ o) :
+    updateRow (reindex e f A) i r = reindex e f (A.updateRow (e.symm i) fun j => r (f j)) :=
+  updateRow_submatrix_equiv _ _ _ _ _
+#align matrix.update_row_reindex Matrix.updateRow_reindex
+
+theorem reindex_updateRow [DecidableEq l] [DecidableEq m] (A : Matrix m n α) (i : m) (r : n → α)
+    (e : m ≃ l) (f : n ≃ o) :
+    reindex e f (A.updateRow i r) = updateRow (reindex e f A) (e i) fun i => r (f.symm i) :=
+  submatrix_updateRow_equiv _ _ _ _ _
+#align matrix.reindex_update_row Matrix.reindex_updateRow
+
+theorem updateColumn_reindex [DecidableEq o] [DecidableEq n] (A : Matrix m n α) (j : o) (c : l → α)
+    (e : m ≃ l) (f : n ≃ o) :
+    updateColumn (reindex e f A) j c = reindex e f (A.updateColumn (f.symm j) fun i => c (e i)) :=
+  updateColumn_submatrix_equiv _ _ _ _ _
+#align matrix.update_column_reindex Matrix.updateColumn_reindex
+
+theorem reindex_updateColumn [DecidableEq o] [DecidableEq n] (A : Matrix m n α) (j : n) (c : m → α)
+    (e : m ≃ l) (f : n ≃ o) :
+    reindex e f (A.updateColumn j c) = updateColumn (reindex e f A) (f j) fun i => c (e.symm i) :=
+  submatrix_updateColumn_equiv _ _ _ _ _
+#align matrix.reindex_update_column Matrix.reindex_updateColumn
 
 end Update
 

--- a/Mathlib/Data/Real/NNReal.lean
+++ b/Mathlib/Data/Real/NNReal.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin
 
 ! This file was ported from Lean 3 source module data.real.nnreal
-! leanprover-community/mathlib commit b3f4f007a962e3787aa0f3b5c7942a1317f7d88e
+! leanprover-community/mathlib commit de29c328903507bb7aff506af9135f4bdaf1849c
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -742,7 +742,7 @@ section Sub
 
 In this section we provide a few lemmas about subtraction that do not fit well into any other
 typeclass. For lemmas about subtraction and addition see lemmas about `OrderedSub` in the file
-`Mathlib.Algebra.Order.Sub.Bsic`. See also `mul_tsub` and `tsub_mul`.
+`Mathlib.Algebra.Order.Sub.Basic`. See also `mul_tsub` and `tsub_mul`.
 -/
 
 theorem sub_def {r p : ℝ≥0} : r - p = Real.toNNReal (r - p) :=
@@ -753,7 +753,7 @@ theorem coe_sub_def {r p : ℝ≥0} : ↑(r - p) = max (r - p : ℝ) 0 :=
   rfl
 #align nnreal.coe_sub_def NNReal.coe_sub_def
 
-noncomputable example : OrderedSub ℝ≥0 := by infer_instance
+example : OrderedSub ℝ≥0 := by infer_instance
 
 theorem sub_div (a b c : ℝ≥0) : (a - b) / c = a / c - b / c :=
   tsub_div _ _ _

--- a/Mathlib/LinearAlgebra/Matrix/DotProduct.lean
+++ b/Mathlib/LinearAlgebra/Matrix/DotProduct.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Patrick Massot, Casper Putz, Anne Baanen
 
 ! This file was ported from Lean 3 source module linear_algebra.matrix.dot_product
-! leanprover-community/mathlib commit 46822d96c0c0a8e58a41a0cba1291620967575c5
+! leanprover-community/mathlib commit 5ac1dab1670014b4c07a82c86a67f3d064a1b3e1
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -86,18 +86,18 @@ theorem dotProduct_self_eq_zero [LinearOrderedRing R] {v : n → R} : dotProduct
 
 /-- Note that this applies to `ℂ` via `Complex.strictOrderedCommRing`. -/
 @[simp]
-theorem dotProduct_star_self_eq_zero [StrictOrderedRing R] [StarOrderedRing R] [NoZeroDivisors R]
-    {v : n → R} : dotProduct (star v) v = 0 ↔ v = 0 :=
-  (Finset.sum_eq_zero_iff_of_nonneg fun i _ => @star_mul_self_nonneg _ _ _ _ (v i)).trans <| by
-    simp [Function.funext_iff, mul_eq_zero]
+theorem dotProduct_star_self_eq_zero [PartialOrder R] [NonUnitalRing R] [StarOrderedRing R]
+    [NoZeroDivisors R] {v : n → R} : dotProduct (star v) v = 0 ↔ v = 0 :=
+  (Finset.sum_eq_zero_iff_of_nonneg fun i _ => (@star_mul_self_nonneg _ _ _ _ (v i) : _)).trans <|
+    by simp [Function.funext_iff, mul_eq_zero]
 #align matrix.dot_product_star_self_eq_zero Matrix.dotProduct_star_self_eq_zero
 
 /-- Note that this applies to `ℂ` via `Complex.strictOrderedCommRing`. -/
 @[simp]
-theorem dotProduct_self_star_eq_zero [StrictOrderedRing R] [StarOrderedRing R] [NoZeroDivisors R]
-    {v : n → R} : dotProduct v (star v) = 0 ↔ v = 0 :=
-  (Finset.sum_eq_zero_iff_of_nonneg fun i _ => @star_mul_self_nonneg' _ _ _ _ (v i)).trans <| by
-    simp [Function.funext_iff, mul_eq_zero]
+theorem dotProduct_self_star_eq_zero [PartialOrder R] [NonUnitalRing R] [StarOrderedRing R]
+    [NoZeroDivisors R] {v : n → R} : dotProduct v (star v) = 0 ↔ v = 0 :=
+  (Finset.sum_eq_zero_iff_of_nonneg fun i _ => (@star_mul_self_nonneg' _ _ _ _ (v i) : _)).trans <|
+    by simp [Function.funext_iff, mul_eq_zero]
 #align matrix.dot_product_self_star_eq_zero Matrix.dotProduct_self_star_eq_zero
 
 end self


### PR DESCRIPTION
* `algebra.order.sub.defs`, `data.real.nnreal`: leanprover-community/mathlib#18810, which is itself a backport. Also fixes a docstring typo.
* `linear_algebra.matrix.dot_product`: leanprover-community/mathlib#18798
* `data.matrix.basic`: leanprover-community/mathlib#18738

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

* [`data.real.nnreal`@`b3f4f007a962e3787aa0f3b5c7942a1317f7d88e`..`de29c328903507bb7aff506af9135f4bdaf1849c`](https://leanprover-community.github.io/mathlib-port-status/file/data/real/nnreal?range=b3f4f007a962e3787aa0f3b5c7942a1317f7d88e..de29c328903507bb7aff506af9135f4bdaf1849c)
* [`algebra.order.sub.defs`@`70d50ecfd4900dd6d328da39ab7ebd516abe4025`..`de29c328903507bb7aff506af9135f4bdaf1849c`](https://leanprover-community.github.io/mathlib-port-status/file/algebra/order/sub/defs?range=70d50ecfd4900dd6d328da39ab7ebd516abe4025..de29c328903507bb7aff506af9135f4bdaf1849c)
* [`linear_algebra.matrix.dot_product`@`46822d96c0c0a8e58a41a0cba1291620967575c5`..`5ac1dab1670014b4c07a82c86a67f3d064a1b3e1`](https://leanprover-community.github.io/mathlib-port-status/file/linear_algebra/matrix/dot_product?range=46822d96c0c0a8e58a41a0cba1291620967575c5..5ac1dab1670014b4c07a82c86a67f3d064a1b3e1)
* [`data.matrix.basic`@`3e068ece210655b7b9a9477c3aff38a492400aa1`..`0e2aab2b0d521f060f62a14d2cf2e2c54e8491d6`](https://leanprover-community.github.io/mathlib-port-status/file/data/matrix/basic?range=3e068ece210655b7b9a9477c3aff38a492400aa1..0e2aab2b0d521f060f62a14d2cf2e2c54e8491d6)

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
