### PR TITLE
[Merged by Bors] - chore: forward port leanprover-community/mathlib#18811

### DIFF
--- a/Mathlib/RingTheory/Finiteness.lean
+++ b/Mathlib/RingTheory/Finiteness.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin
 
 ! This file was ported from Lean 3 source module ring_theory.finiteness
-! leanprover-community/mathlib commit 039ef89bef6e58b32b62898dd48e9d1a4312bb65
+! leanprover-community/mathlib commit e95e4f92c8f8da3c7f693c3ec948bcf9b6683f51
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -598,6 +598,12 @@ theorem of_surjective [hM : Finite R M] (f : M →ₗ[R] N) (hf : Surjective f) 
 instance range [Finite R M] (f : M →ₗ[R] N) : Finite R (LinearMap.range f) :=
   of_surjective f.rangeRestrict fun ⟨_, y, hy⟩ => ⟨y, Subtype.ext hy⟩
 #align module.finite.range Module.Finite.range
+
+/-- Pushforwards of finite submodules are finite. -/
+instance map (p : Submodule R M) [Finite R p] (f : M →ₗ[R] N) : Finite R (p.map f) :=
+  of_surjective (f.restrict fun _ => Submodule.mem_map_of_mem) fun ⟨_, _, hy, hy'⟩ =>
+    ⟨⟨_, hy⟩, Subtype.ext hy'⟩
+#align module.finite.map Module.Finite.map
 
 variable (R)
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

* [`ring_theory.finiteness`@`039ef89bef6e58b32b62898dd48e9d1a4312bb65`..`e95e4f92c8f8da3c7f693c3ec948bcf9b6683f51`](https://leanprover-community.github.io/mathlib-port-status/file/ring_theory/finiteness?range=039ef89bef6e58b32b62898dd48e9d1a4312bb65..e95e4f92c8f8da3c7f693c3ec948bcf9b6683f51)

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
