### PR TITLE
[Merged by Bors] - chore: ModelTheory.Syntax: whitespace fix

### DIFF
--- a/Mathlib/ModelTheory/Syntax.lean
+++ b/Mathlib/ModelTheory/Syntax.lean
@@ -996,22 +996,22 @@ set_option linter.uppercaseLean3 false in
 end LEquiv
 
 scoped[FirstOrder] infixl:88 " =' " => FirstOrder.Language.Term.bdEqual
-
 -- input \~- or \simeq
-scoped[FirstOrder] infixr:62 " ⟹ " => FirstOrder.Language.BoundedFormula.imp
 
+scoped[FirstOrder] infixr:62 " ⟹ " => FirstOrder.Language.BoundedFormula.imp
 -- input \==>
+
 scoped[FirstOrder] prefix:110 "∀'" => FirstOrder.Language.BoundedFormula.all
 
 scoped[FirstOrder] prefix:arg "∼" => FirstOrder.Language.BoundedFormula.not
-
 -- input \~, the ASCII character ~ has too low precedence
+
 scoped[FirstOrder] infixl:61 " ⇔ " => FirstOrder.Language.BoundedFormula.iff
-
 -- input \<=>
-scoped[FirstOrder] prefix:110 "∃'" => FirstOrder.Language.BoundedFormula.ex
 
+scoped[FirstOrder] prefix:110 "∃'" => FirstOrder.Language.BoundedFormula.ex
 -- input \ex
+
 namespace Formula
 
 /-- Relabels a formula's variables along a particular function. -/


### PR DESCRIPTION
The diff is not very helpful, but I made sure the comments about the notation were closer to the notation they were about by removing a newline above and adding one below.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
