### PR TITLE
[Merged by Bors] - chore: port `fin.reflect`

### DIFF
--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -2545,14 +2545,14 @@ protected theorem zero_mul [NeZero n] (k : Fin n) : (0 : Fin n) * k = 0 := by
 end Mul
 
 open Qq in
-unsafe instance toExpr (n : ℕ) : Lean.ToExpr (Fin n) where
+instance toExpr (n : ℕ) : Lean.ToExpr (Fin n) where
   toTypeExpr := q(Fin $n)
   toExpr := match n with
     | 0 => finZeroElim
-    | n'@(n + 1) => fun i =>
-      let i' : Q(ℕ) := Lean.ToExpr.toExpr (i : ℕ)
-      let _n_eq : ($n + 1) =Q $n' := ⟨⟩
-      q((haveI : NeZero $n' := @NeZero.succ $n; OfNat.ofNat $i' : Fin $(n')))
+    | k + 1 => fun i => show Q(Fin $n) from
+      have i : Q(Nat) := Lean.mkNatLit i -- raw literal to avoid ofNat-double-wrapping
+      have : Q(NeZero $n) := have : $n =Q $k + 1 := ⟨⟩; by exact q(NeZero.succ)
+      q(OfNat.ofNat $i)
 #align fin.reflect Fin.toExprₓ
 
 end Fin

--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -2551,7 +2551,7 @@ instance toExpr (n : ℕ) : Lean.ToExpr (Fin n) where
     | 0 => finZeroElim
     | k + 1 => fun i => show Q(Fin $n) from
       have i : Q(Nat) := Lean.mkNatLit i -- raw literal to avoid ofNat-double-wrapping
-      have : Q(NeZero $n) := have : $n =Q $k + 1 := ⟨⟩; by exact q(NeZero.succ)
+      have : Q(NeZero $n) := haveI : $n =Q $k + 1 := ⟨⟩; by exact q(NeZero.succ)
       q(OfNat.ofNat $i)
 #align fin.reflect Fin.toExprₓ
 

--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -14,6 +14,7 @@ import Mathlib.Order.RelIso.Basic
 import Mathlib.Data.Nat.Order.Basic
 import Mathlib.Order.Hom.Set
 import Mathlib.Tactic.Set
+import Qq
 
 /-!
 # The finite type with `n` elements
@@ -2542,5 +2543,16 @@ protected theorem zero_mul [NeZero n] (k : Fin n) : (0 : Fin n) * k = 0 := by
 #align fin.zero_mul Fin.zero_mul
 
 end Mul
+
+open Qq in
+unsafe instance toExpr (n : ℕ) : Lean.ToExpr (Fin n) where
+  toTypeExpr := q(Fin $n)
+  toExpr := match n with
+    | 0 => finZeroElim
+    | n'@(n + 1) => fun i =>
+      let i' : Q(ℕ) := Lean.ToExpr.toExpr (i : ℕ)
+      let _n_eq : ($n + 1) =Q $n' := ⟨⟩
+      q((haveI : NeZero $n' := @NeZero.succ $n; OfNat.ofNat $i' : Fin $(n')))
+#align fin.reflect Fin.toExprₓ
 
 end Fin


### PR DESCRIPTION
This definition was deleted during porting.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
