### PR TITLE
[Merged by Bors] - chore: forward port 18648

### DIFF
--- a/Mathlib/Data/Finset/Lattice.lean
+++ b/Mathlib/Data/Finset/Lattice.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 
 ! This file was ported from Lean 3 source module data.finset.lattice
-! leanprover-community/mathlib commit 1c857a1f6798cb054be942199463c2cf904cb937
+! leanprover-community/mathlib commit a968611b6a772cf7bdf61146e6d62fc882c92372
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/

--- a/Mathlib/Data/Finset/Lattice.lean
+++ b/Mathlib/Data/Finset/Lattice.lean
@@ -113,6 +113,9 @@ theorem le_sup {b : β} (hb : b ∈ s) : f b ≤ s.sup f :=
   Finset.sup_le_iff.1 le_rfl _ hb
 #align finset.le_sup Finset.le_sup
 
+theorem le_sup_of_le {b : β} (hb : b ∈ s) (h : a ≤ f b) : a ≤ s.sup f := h.trans <| le_sup hb
+#align finset.le_sup_of_le Finset.le_sup_of_le
+
 @[simp]
 theorem sup_bunionᵢ [DecidableEq β] (s : Finset γ) (t : γ → Finset β) :
     (s.bunionᵢ t).sup f = s.sup fun x => (t x).sup f :=
@@ -387,6 +390,9 @@ theorem le_inf_const_le : a ≤ s.inf fun _ => a :=
 theorem inf_le {b : β} (hb : b ∈ s) : s.inf f ≤ f b :=
   Finset.le_inf_iff.1 le_rfl _ hb
 #align finset.inf_le Finset.inf_le
+
+theorem inf_le_of_le {b : β} (hb : b ∈ s) (h : f b ≤ a) : s.inf f ≤ a := (inf_le hb).trans h
+#align finset.inf_le_of_le Finset.inf_le_of_le
 
 theorem inf_mono_fun {g : β → α} (h : ∀ b ∈ s, f b ≤ g b) : s.inf f ≤ s.inf g :=
   Finset.le_inf fun b hb => le_trans (inf_le hb) (h b hb)
@@ -702,6 +708,10 @@ theorem le_sup' {b : β} (h : b ∈ s) : f b ≤ s.sup' ⟨b, h⟩ f := by
   exact le_sup (f := fun c => WithBot.some (f c)) h
 #align finset.le_sup' Finset.le_sup'
 
+theorem le_sup'_of_le {a : α} {b : β} (hb : b ∈ s) (h : a ≤ f b) : a ≤ s.sup' ⟨b, hb⟩ f :=
+  h.trans <| le_sup' _ hb
+#align finset.le_sup'_of_le Finset.le_sup'_of_le
+
 @[simp]
 theorem sup'_const (a : α) : s.sup' H (fun _ => a) = a := by
   apply le_antisymm
@@ -822,6 +832,9 @@ theorem le_inf' {a : α} (hs : ∀ b ∈ s, a ≤ f b) : a ≤ s.inf' H f :=
 theorem inf'_le {b : β} (h : b ∈ s) : s.inf' ⟨b, h⟩ f ≤ f b :=
   le_sup' (α := αᵒᵈ) f h
 #align finset.inf'_le Finset.inf'_le
+
+theorem inf'_le_of_le (hb : b ∈ s) (h : f b ≤ a) : s.inf' ⟨b, hb⟩ f ≤ a := (inf'_le _ hb).trans h
+#align finset.inf'_le_of_le Finset.inf'_le_of_le
 
 @[simp]
 theorem inf'_const (a : α) : (s.inf' H fun _ => a) = a :=


### PR DESCRIPTION
* [`data.finset.lattice`@`1c857a1f6798cb054be942199463c2cf904cb937`..`a968611b6a772cf7bdf61146e6d62fc882c92372`](https://leanprover-community.github.io/mathlib-port-status/file/data/finset/lattice?range=1c857a1f6798cb054be942199463c2cf904cb937..a968611b6a772cf7bdf61146e6d62fc882c92372)

---

I've manually ported, because the output in mathlib3port is quite garbled.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
