### PR TITLE
[Merged by Bors] - chore: forward port last part of leanprover-community/mathlib#18248

### DIFF
--- a/Mathlib/Topology/Perfect.lean
+++ b/Mathlib/Topology/Perfect.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Felix Weilacher
 
 ! This file was ported from Lean 3 source module topology.perfect
-! leanprover-community/mathlib commit 4c19a16e4b705bf135cf9a80ac18fcc99c438514
+! leanprover-community/mathlib commit 49b7f94aab3a3bdca1f9f34c5d818afb253b3993
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/

--- a/Mathlib/Topology/Perfect.lean
+++ b/Mathlib/Topology/Perfect.lean
@@ -22,6 +22,8 @@ including a version of the Cantor-Bendixson Theorem.
 
 * `Perfect C`: A set `C` is perfect, meaning it is closed and every point of it
   is an accumulation point of itself.
+* `Set.scheme β α`: A `β`-scheme on `α`, a collection of subsets of `α` indexed by `List β`.
+  Used to construct maps `(β → ℕ) → α` as limiting objects.
 
 ## Main Statements
 
@@ -31,7 +33,7 @@ including a version of the Cantor-Bendixson Theorem.
 * `exists_countable_union_perfect_of_isClosed`: One version of the **Cantor-Bendixson Theorem**:
   A closed set in a second countable space can be written as the union of a countable set and a
   perfect set.
-* `Perfect.exists_nat_bool_injection`: A perfect nonempty set in a complete metric space
+* `exists_nat_bool_injection`: A perfect nonempty set in a complete metric space
   admits an embedding from the Cantor space.
 
 ## Implementation Notes
@@ -230,10 +232,8 @@ variable {α : Type _} [MetricSpace α] {C : Set α} (hC : Perfect C) {ε : ℝ�
 
 private theorem Perfect.small_diam_aux (ε_pos : 0 < ε) {x : α} (xC : x ∈ C) :
     let D := closure (EMetric.ball x (ε / 2) ∩ C)
-    Perfect D ∧ D.Nonempty ∧ D ⊆ C ∧ EMetric.diam D ≤ ε :=
-  by
-  have : x ∈ EMetric.ball x (ε / 2) :=
-    by
+    Perfect D ∧ D.Nonempty ∧ D ⊆ C ∧ EMetric.diam D ≤ ε := by
+  have : x ∈ EMetric.ball x (ε / 2) := by
     apply EMetric.mem_ball_self
     rw [ENNReal.div_pos_iff]
     exact ⟨ne_of_gt ε_pos, by norm_num⟩
@@ -248,13 +248,11 @@ private theorem Perfect.small_diam_aux (ε_pos : 0 < ε) {x : α} (xC : x ∈ C)
 
 variable (hnonempty : C.Nonempty)
 
-/-- A refinement of `perfect.splitting` for metric spaces, where we also control
+/-- A refinement of `Perfect.splitting` for metric spaces, where we also control
 the diameter of the new perfect sets. -/
 theorem Perfect.small_diam_splitting (ε_pos : 0 < ε) :
-    ∃ C₀ C₁ : Set α,
-      (Perfect C₀ ∧ C₀.Nonempty ∧ C₀ ⊆ C ∧ EMetric.diam C₀ ≤ ε) ∧
-        (Perfect C₁ ∧ C₁.Nonempty ∧ C₁ ⊆ C ∧ EMetric.diam C₁ ≤ ε) ∧ Disjoint C₀ C₁ :=
-  by
+    ∃ C₀ C₁ : Set α, (Perfect C₀ ∧ C₀.Nonempty ∧ C₀ ⊆ C ∧ EMetric.diam C₀ ≤ ε) ∧
+    (Perfect C₁ ∧ C₁.Nonempty ∧ C₁ ⊆ C ∧ EMetric.diam C₁ ≤ ε) ∧ Disjoint C₀ C₁ := by
   rcases hC.splitting hnonempty with ⟨D₀, D₁, ⟨perf0, non0, sub0⟩, ⟨perf1, non1, sub1⟩, hdisj⟩
   cases' non0 with x₀ hx₀
   cases' non1 with x₁ hx₁
@@ -269,10 +267,9 @@ theorem Perfect.small_diam_splitting (ε_pos : 0 < ε) :
 open CantorScheme
 
 /-- Any nonempty perfect set in a complete metric space admits a continuous injection
-from the cantor space, `ℕ → bool`. -/
+from the Cantor space, `ℕ → Bool`. -/
 theorem Perfect.exists_nat_bool_injection [CompleteSpace α] :
-    ∃ f : (ℕ → Bool) → α, range f ⊆ C ∧ Continuous f ∧ Injective f :=
-  by
+    ∃ f : (ℕ → Bool) → α, range f ⊆ C ∧ Continuous f ∧ Injective f := by
   obtain ⟨u, -, upos', hu⟩ := exists_seq_strictAnti_tendsto' (zero_lt_one' ℝ≥0∞)
   have upos := fun n => (upos' n).1
   let P := Subtype fun E : Set α => Perfect E ∧ E.Nonempty
@@ -287,8 +284,7 @@ theorem Perfect.exists_nat_bool_injection [CompleteSpace α] :
     use C1 ih.property.1 ih.property.2 (upos l.length.succ)
     exact ⟨(h1 _ _ _).1, (h1 _ _ _).2.1⟩
   let D : List Bool → Set α := fun l => (DP l).val
-  have hanti : ClosureAntitone D :=
-    by
+  have hanti : ClosureAntitone D := by
     refine' Antitone.closureAntitone _ fun l => (DP l).property.1.closed
     intro l a
     cases a
@@ -308,8 +304,7 @@ theorem Perfect.exists_nat_bool_injection [CompleteSpace α] :
       rw [PiNat.res_length]
     convert(h1 _ _ _).2.2.2
     rw [PiNat.res_length]
-  have hdisj' : CantorScheme.Disjoint D :=
-    by
+  have hdisj' : CantorScheme.Disjoint D := by
     rintro l (a | a) (b | b) hab <;> try contradiction
     · exact hdisj _ _ _
     exact (hdisj _ _ _).symm

--- a/Mathlib/Topology/Perfect.lean
+++ b/Mathlib/Topology/Perfect.lean
@@ -320,8 +320,8 @@ theorem Perfect.exists_nat_bool_injection [CompleteSpace α] :
   refine' ⟨fun x => (inducedMap D).2 ⟨x, hdom⟩, _, _, _⟩
   · rintro y ⟨x, rfl⟩
     exact map_mem ⟨_, hdom⟩ 0
-  · continuity
-    exact hdiam.map_continuous
+  · apply hdiam.map_continuous.comp
+    continuity
   intro x y hxy
   simpa only [← Subtype.val_inj] using hdisj'.map_injective hxy
 #align perfect.exists_nat_bool_injection Perfect.exists_nat_bool_injection

--- a/Mathlib/Topology/Perfect.lean
+++ b/Mathlib/Topology/Perfect.lean
@@ -10,6 +10,7 @@ Authors: Felix Weilacher
 -/
 import Mathlib.Topology.Separation
 import Mathlib.Topology.Bases
+import Mathlib.Topology.MetricSpace.CantorScheme
 
 /-!
 # Perfect Sets
@@ -30,6 +31,8 @@ including a version of the Cantor-Bendixson Theorem.
 * `exists_countable_union_perfect_of_isClosed`: One version of the **Cantor-Bendixson Theorem**:
   A closed set in a second countable space can be written as the union of a countable set and a
   perfect set.
+* `Perfect.exists_nat_bool_injection`: A perfect nonempty set in a complete metric space
+  admits an embedding from the Cantor space.
 
 ## Implementation Notes
 
@@ -41,11 +44,11 @@ see `preperfect_iff_perfect_closure`.
 
 ## References
 
-* [kechris1995] (Chapter 6)
+* [kechris1995] (Chapters 6-7)
 
 ## Tags
 
-accumulation point, perfect set, Cantor-Bendixson.
+accumulation point, perfect set, cantor-bendixson.
 
 -/
 
@@ -53,6 +56,8 @@ accumulation point, perfect set, Cantor-Bendixson.
 open Topology Filter
 
 open TopologicalSpace Filter Set
+
+section Basic
 
 variable {α : Type _} [TopologicalSpace α] {C : Set α}
 
@@ -214,3 +219,111 @@ theorem exists_perfect_nonempty_of_isClosed_of_not_countable [SecondCountableTop
 #align exists_perfect_nonempty_of_is_closed_of_not_countable exists_perfect_nonempty_of_isClosed_of_not_countable
 
 end Kernel
+
+end Basic
+
+section CantorInj
+
+open Function ENNReal
+
+variable {α : Type _} [MetricSpace α] {C : Set α} (hC : Perfect C) {ε : ℝ≥0∞}
+
+private theorem Perfect.small_diam_aux (ε_pos : 0 < ε) {x : α} (xC : x ∈ C) :
+    let D := closure (EMetric.ball x (ε / 2) ∩ C)
+    Perfect D ∧ D.Nonempty ∧ D ⊆ C ∧ EMetric.diam D ≤ ε :=
+  by
+  have : x ∈ EMetric.ball x (ε / 2) :=
+    by
+    apply EMetric.mem_ball_self
+    rw [ENNReal.div_pos_iff]
+    exact ⟨ne_of_gt ε_pos, by norm_num⟩
+  have := hC.closure_nhds_inter x xC this EMetric.isOpen_ball
+  refine' ⟨this.1, this.2, _, _⟩
+  · rw [IsClosed.closure_subset_iff hC.closed]
+    apply inter_subset_right
+  rw [EMetric.diam_closure]
+  apply le_trans (EMetric.diam_mono (inter_subset_left _ _))
+  convert EMetric.diam_ball (x := x)
+  rw [mul_comm, ENNReal.div_mul_cancel] <;> norm_num
+#align perfect.small_diam_aux Perfect.small_diam_aux
+
+variable (hnonempty : C.Nonempty)
+
+/-- A refinement of `perfect.splitting` for metric spaces, where we also control
+the diameter of the new perfect sets. -/
+theorem Perfect.small_diam_splitting (ε_pos : 0 < ε) :
+    ∃ C₀ C₁ : Set α,
+      (Perfect C₀ ∧ C₀.Nonempty ∧ C₀ ⊆ C ∧ EMetric.diam C₀ ≤ ε) ∧
+        (Perfect C₁ ∧ C₁.Nonempty ∧ C₁ ⊆ C ∧ EMetric.diam C₁ ≤ ε) ∧ Disjoint C₀ C₁ :=
+  by
+  rcases hC.splitting hnonempty with ⟨D₀, D₁, ⟨perf0, non0, sub0⟩, ⟨perf1, non1, sub1⟩, hdisj⟩
+  cases' non0 with x₀ hx₀
+  cases' non1 with x₁ hx₁
+  rcases perf0.small_diam_aux ε_pos hx₀ with ⟨perf0', non0', sub0', diam0⟩
+  rcases perf1.small_diam_aux ε_pos hx₁ with ⟨perf1', non1', sub1', diam1⟩
+  refine'
+    ⟨closure (EMetric.ball x₀ (ε / 2) ∩ D₀), closure (EMetric.ball x₁ (ε / 2) ∩ D₁),
+      ⟨perf0', non0', sub0'.trans sub0, diam0⟩, ⟨perf1', non1', sub1'.trans sub1, diam1⟩, _⟩
+  apply Disjoint.mono _ _ hdisj <;> assumption
+#align perfect.small_diam_splitting Perfect.small_diam_splitting
+
+open CantorScheme
+
+/-- Any nonempty perfect set in a complete metric space admits a continuous injection
+from the cantor space, `ℕ → bool`. -/
+theorem Perfect.exists_nat_bool_injection [CompleteSpace α] :
+    ∃ f : (ℕ → Bool) → α, range f ⊆ C ∧ Continuous f ∧ Injective f :=
+  by
+  obtain ⟨u, -, upos', hu⟩ := exists_seq_strictAnti_tendsto' (zero_lt_one' ℝ≥0∞)
+  have upos := fun n => (upos' n).1
+  let P := Subtype fun E : Set α => Perfect E ∧ E.Nonempty
+  choose C0 C1 h0 h1 hdisj using
+    fun {C : Set α} (hC : Perfect C) (hnonempty : C.Nonempty) {ε : ℝ≥0∞} (hε : 0 < ε) =>
+    hC.small_diam_splitting hnonempty hε
+  let DP : List Bool → P := fun l => by
+    induction' l with a l ih; · exact ⟨C, ⟨hC, hnonempty⟩⟩
+    cases a
+    · use C0 ih.property.1 ih.property.2 (upos l.length.succ)
+      exact ⟨(h0 _ _ _).1, (h0 _ _ _).2.1⟩
+    use C1 ih.property.1 ih.property.2 (upos l.length.succ)
+    exact ⟨(h1 _ _ _).1, (h1 _ _ _).2.1⟩
+  let D : List Bool → Set α := fun l => (DP l).val
+  have hanti : ClosureAntitone D :=
+    by
+    refine' Antitone.closureAntitone _ fun l => (DP l).property.1.closed
+    intro l a
+    cases a
+    · exact (h0 _ _ _).2.2.1
+    exact (h1 _ _ _).2.2.1
+  have hdiam : VanishingDiam D := by
+    intro x
+    apply tendsto_of_tendsto_of_tendsto_of_le_of_le' tendsto_const_nhds hu
+    · simp
+    rw [eventually_atTop]
+    refine' ⟨1, fun m (hm : 1 ≤ m) => _⟩
+    rw [Nat.one_le_iff_ne_zero] at hm
+    rcases Nat.exists_eq_succ_of_ne_zero hm with ⟨n, rfl⟩
+    dsimp
+    cases x n
+    · convert(h0 _ _ _).2.2.2
+      rw [PiNat.res_length]
+    convert(h1 _ _ _).2.2.2
+    rw [PiNat.res_length]
+  have hdisj' : CantorScheme.Disjoint D :=
+    by
+    rintro l (a | a) (b | b) hab <;> try contradiction
+    · exact hdisj _ _ _
+    exact (hdisj _ _ _).symm
+  have hdom : ∀ {x : ℕ → Bool}, x ∈ (inducedMap D).1 := fun {x} => by
+    rw [hanti.map_of_vanishingDiam hdiam fun l => (DP l).property.2]
+    apply mem_univ
+  refine' ⟨fun x => (inducedMap D).2 ⟨x, hdom⟩, _, _, _⟩
+  · rintro y ⟨x, rfl⟩
+    exact map_mem ⟨_, hdom⟩ 0
+  · continuity
+    exact hdiam.map_continuous
+  intro x y hxy
+  simpa only [← Subtype.val_inj] using hdisj'.map_injective hxy
+#align perfect.exists_nat_bool_injection Perfect.exists_nat_bool_injection
+
+end CantorInj

--- a/Mathlib/Topology/Perfect.lean
+++ b/Mathlib/Topology/Perfect.lean
@@ -245,7 +245,6 @@ private theorem Perfect.small_diam_aux (ε_pos : 0 < ε) {x : α} (xC : x ∈ C)
   apply le_trans (EMetric.diam_mono (inter_subset_left _ _))
   convert EMetric.diam_ball (x := x)
   rw [mul_comm, ENNReal.div_mul_cancel] <;> norm_num
-#align perfect.small_diam_aux Perfect.small_diam_aux
 
 variable (hnonempty : C.Nonempty)
 


### PR DESCRIPTION


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

This is a forward port of a recent mathlib3 PR which added the following theorem: Any nonempty perfect set in a complete metric space admits an embedding of the Cantor space. 

I am very new to Lean 4, so I may need a lot of time or help.

* [`topology.perfect`@`4c19a16e4b705bf135cf9a80ac18fcc99c438514`..`49b7f94aab3a3bdca1f9f34c5d818afb253b3993`](https://leanprover-community.github.io/mathlib-port-status/file/topology/perfect?range=4c19a16e4b705bf135cf9a80ac18fcc99c438514..49b7f94aab3a3bdca1f9f34c5d818afb253b3993)