### PR TITLE
[Merged by Bors] - feat: move doc-gen CI here

### DIFF
--- a/.github/workflows/mathlib4docs.yml
+++ b/.github/workflows/mathlib4docs.yml
@@ -1,0 +1,34 @@
+name: build and deploy mathlib3 docs
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 */8 * * *' # every 8 hours
+jobs:
+  build:
+    name: build and deploy mathlib4 docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: install elan
+        run: |
+          set -o pipefail
+          curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- --default-toolchain none -y
+          ~/.elan/bin/lean --version
+          echo "$HOME/.elan/bin" >> $GITHUB_PATH
+
+      - name: get cache
+        run: lake exe cache get
+
+      - name: build mathlib
+        run: env LEAN_ABORT_ON_PANIC=1 lake build
+
+      - name: generate and deploy docs
+        if: github.repository == 'leanprover-community/mathlib4'
+        run: |
+          cd ../
+          ./mathlib4/scripts/deploy_docs.sh
+        env:
+          MATHLIB4_DOCS_KEY: ${{ secrets.MATHLIB4_DOCS_KEY }}

--- a/.github/workflows/mathlib4docs.yml
+++ b/.github/workflows/mathlib4docs.yml
@@ -44,7 +44,6 @@ jobs:
       - name: clean up
         if: always()
         run: |
-          cd ..
-          rm -rf *
+          rm -rf workaround mathlib4_docs deploy_key
           rm -rf $HOME/.elan
           rm -rf $HOME/.cache/mathlib

--- a/.github/workflows/mathlib4docs.yml
+++ b/.github/workflows/mathlib4docs.yml
@@ -7,8 +7,15 @@ on:
 jobs:
   build:
     name: build and deploy mathlib4 docs
-    runs-on: ubuntu-latest
+    runs-on: doc-gen
+    if: github.repository == 'leanprover-community/mathlib4'
     steps:
+      - name: clean up
+        run: |
+          rm -rf *
+          rm -rf $HOME/.elan
+          rm -rf $HOME/.cache/mathlib
+
       - name: Checkout repo
         uses: actions/checkout@v3
 
@@ -26,9 +33,17 @@ jobs:
         run: env LEAN_ABORT_ON_PANIC=1 lake build
 
       - name: generate and deploy docs
-        if: github.repository == 'leanprover-community/mathlib4'
         run: |
           cd ../
           ./mathlib4/scripts/deploy_docs.sh
         env:
           MATHLIB4_DOCS_KEY: ${{ secrets.MATHLIB4_DOCS_KEY }}
+
+      - name: clean up
+        if: always()
+        run: |
+          rm -rf *
+          rm -rf $HOME/.elan
+          rm -rf $HOME/.cache/mathlib
+          rm -rf ../workaround
+          rm -rf ../mathlib4_docs

--- a/.github/workflows/mathlib4docs.yml
+++ b/.github/workflows/mathlib4docs.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 */8 * * *' # every 8 hours
+  push: # testing
 jobs:
   build:
     name: build and deploy mathlib4 docs

--- a/.github/workflows/mathlib4docs.yml
+++ b/.github/workflows/mathlib4docs.yml
@@ -16,6 +16,7 @@ jobs:
           rm -rf *
           rm -rf $HOME/.elan
           rm -rf $HOME/.cache/mathlib
+          rm -rf $HOME/.ssh
 
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -43,8 +44,7 @@ jobs:
       - name: clean up
         if: always()
         run: |
+          cd ..
           rm -rf *
           rm -rf $HOME/.elan
           rm -rf $HOME/.cache/mathlib
-          rm -rf ../workaround
-          rm -rf ../mathlib4_docs

--- a/.github/workflows/mathlib4docs.yml
+++ b/.github/workflows/mathlib4docs.yml
@@ -4,7 +4,6 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 */8 * * *' # every 8 hours
-  push: # testing
 jobs:
   build:
     name: build and deploy mathlib4 docs

--- a/scripts/deploy_docs.sh
+++ b/scripts/deploy_docs.sh
@@ -40,12 +40,14 @@ lake build Mathlib:docs Std:docs
 cd ..
 rm -rf mathlib4_docs/docs/
 cp -r "workaround/build/doc" mathlib4_docs/docs
-echo "$MATHLIB4_DOCS_KEY" > id_ed25519
-chmod 600 id_ed25519
+ssh_key=$PWD/deploy_key
+echo "$MATHLIB4_DOCS_KEY" > $ssh_key
+chmod 600 $ssh_key
+ssh -i $ssh_key git@github.com || true # check ssh access
 cd mathlib4_docs/docs
 git remote set-url origin "git@github.com:leanprover-community/mathlib4_docs.git"
 git add -A .
 git checkout --orphan master2
 git commit -m "automatic update to mathlib4 $mathlib_short_git_hash using doc-gen4 $doc_gen_short_git_hash"
-GIT_SSH_COMMAND='ssh -i ../id_ed25519' git push -f origin HEAD:master
-rm ../id_ed25519
+GIT_SSH_COMMAND="ssh -i $ssh_key" git push -f origin HEAD:master
+rm $ssh_key

--- a/scripts/deploy_docs.sh
+++ b/scripts/deploy_docs.sh
@@ -40,12 +40,12 @@ lake build Mathlib:docs Std:docs
 cd ..
 rm -rf mathlib4_docs/docs/
 cp -r "workaround/build/doc" mathlib4_docs/docs
-mkdir ~/.ssh
-echo "$MATHLIB4_DOCS_KEY" > ~/.ssh/id_ed25519
-chmod 600 ~/.ssh/id_ed25519
+echo "$MATHLIB4_DOCS_KEY" > id_ed25519
+chmod 600 id_ed25519
 cd mathlib4_docs/docs
 git remote set-url origin "git@github.com:leanprover-community/mathlib4_docs.git"
 git add -A .
 git checkout --orphan master2
 git commit -m "automatic update to mathlib4 $mathlib_short_git_hash using doc-gen4 $doc_gen_short_git_hash"
-git push -f origin HEAD:master
+GIT_SSH_COMMAND='ssh -i ../id_ed25519' git push -f origin HEAD:master
+rm ../id_ed25519

--- a/scripts/deploy_docs.sh
+++ b/scripts/deploy_docs.sh
@@ -43,6 +43,7 @@ cp -r "workaround/build/doc" mathlib4_docs/docs
 ssh_key=$PWD/deploy_key
 echo "$MATHLIB4_DOCS_KEY" > $ssh_key
 chmod 600 $ssh_key
+mkdir -p ~/.ssh; ssh-keyscan github.com >~/.ssh/known_hosts
 ssh -i $ssh_key git@github.com || true # check ssh access
 cd mathlib4_docs/docs
 git remote set-url origin "git@github.com:leanprover-community/mathlib4_docs.git"

--- a/scripts/deploy_docs.sh
+++ b/scripts/deploy_docs.sh
@@ -1,0 +1,51 @@
+set -e
+set -x
+
+git config --global user.email "leanprover.community@gmail.com"
+git config --global user.name "leanprover-community-bot"
+
+cd mathlib4
+mathlib_short_git_hash="$(git log -1 --pretty=format:%h)"
+cd ../
+
+git clone --depth 1 "https://github.com/leanprover-community/mathlib4_docs.git" mathlib4_docs
+
+# Workaround for the lake issue
+elan default leanprover/lean4:nightly
+lake new workaround
+cd workaround
+cp -f ../mathlib4/lean-toolchain .
+echo 'require «doc-gen4» from git "https://github.com/leanprover/doc-gen4" @ "main"' >> lakefile.lean
+echo 'require «mathlib» from ".." / "mathlib4"' >> lakefile.lean
+
+# doc-gen4 expects to work on github repos with at least one commit
+git add .
+git commit -m "workaround"
+git remote add origin "https://github.com/leanprover/workaround"
+
+mkdir lake-packages
+cp -r ../mathlib4/lake-packages/* lake-packages/
+lake update
+
+cd lake-packages/doc-gen4
+doc_gen_short_git_hash="$(git log -1 --pretty=format:%h)"
+cd ../../
+
+if [ "$(cd ../mathlib4_docs && git log -1 --pretty=format:%s)" == "automatic update to mathlib4 $mathlib_short_git_hash using doc-gen4 $doc_gen_short_git_hash" ]; then
+  exit 0
+fi
+
+lake build Mathlib:docs Std:docs
+
+cd ..
+rm -rf mathlib4_docs/docs/
+cp -r "workaround/build/doc" mathlib4_docs/docs
+mkdir ~/.ssh
+echo "$MATHLIB4_DOCS_KEY" > ~/.ssh/id_ed25519
+chmod 600 ~/.ssh/id_ed25519
+cd mathlib4_docs/docs
+git remote set-url origin "git@github.com:leanprover-community/mathlib4_docs.git"
+git add -A .
+git checkout --orphan master2
+git commit -m "automatic update to mathlib4 $mathlib_short_git_hash using doc-gen4 $doc_gen_short_git_hash"
+git push -f origin HEAD:master


### PR DESCRIPTION
Creates a Github Action which runs doc-gen4 from within the mathlib4.
This is done due to the speed issues of the original doc-gen4 CI
as suggested on Zulip.

While I ran these scripts locally it might very well be that I made some
mistake that will mess this up in CI. Furthermore someone with privileges
needs to configure a secret `MATHLIB4_DOCS_KEY` with an ed25519 SSH key
that has push access to `leanprover-community/mathlib4_docs` in order for
the script to upload the generated docs.
