### PR TITLE
[Merged by Bors] - chore: forward port leanprover-community/mathlib#18442

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity.lean
@@ -1905,6 +1905,16 @@ protected theorem Reachable.map {G : SimpleGraph V} {G' : SimpleGraph V'} (f : G
   h.elim fun p => ⟨p.map f⟩
 #align simple_graph.reachable.map SimpleGraph.Reachable.map
 
+theorem Iso.reachable_iff {G : SimpleGraph V} {G' : SimpleGraph V'} {φ : G ≃g G'} {u v : V} :
+    G'.Reachable (φ u) (φ v) ↔ G.Reachable u v :=
+  ⟨fun r => φ.left_inv u ▸ φ.left_inv v ▸ r.map φ.symm.toHom, Reachable.map φ.toHom⟩
+#align simple_graph.iso.reachable_iff SimpleGraph.Iso.reachable_iff
+
+theorem Iso.symm_apply_reachable {G : SimpleGraph V} {G' : SimpleGraph V'} {φ : G ≃g G'} {u : V}
+    {v : V'} : G.Reachable (φ.symm v) u ↔ G'.Reachable v (φ u) := by
+  rw [← Iso.reachable_iff, RelIso.apply_symm_apply]
+#align simple_graph.iso.symm_apply_reachable SimpleGraph.Iso.symm_apply_reachable
+
 variable (G)
 
 theorem reachable_is_equivalence : Equivalence G.Reachable :=
@@ -2001,6 +2011,11 @@ protected theorem eq {v w : V} :
   @Quotient.eq' _ G.reachableSetoid _ _
 #align simple_graph.connected_component.eq SimpleGraph.ConnectedComponent.eq
 
+theorem connectedComponentMk_eq_of_adj {v w : V} (a : G.Adj v w) :
+    G.connectedComponentMk v = G.connectedComponentMk w :=
+  ConnectedComponent.sound a.reachable
+#align simple_graph.connected_component.connected_component_mk_eq_of_adj SimpleGraph.ConnectedComponent.connectedComponentMk_eq_of_adj
+
 /-- The `ConnectedComponent` specialization of `Quot.lift`. Provides the stronger
 assumption that the vertices are connected by a path. -/
 protected def lift {β : Sort _} (f : V → β)
@@ -2054,6 +2069,110 @@ theorem map_comp (C : G.ConnectedComponent) (φ : G →g G') (ψ : G' →g G'') 
   refine' C.ind _
   exact fun _ => rfl
 #align simple_graph.connected_component.map_comp SimpleGraph.ConnectedComponent.map_comp
+
+variable {φ : G ≃g G'} {v : V} {v' : V'}
+
+@[simp]
+theorem iso_image_comp_eq_map_iff_eq_comp {C : G.ConnectedComponent} :
+    G'.connectedComponentMk (φ v) = C.map ↑(↑φ : G ↪g G') ↔ G.connectedComponentMk v = C := by
+  refine' C.ind fun u => _
+  simp only [Iso.reachable_iff, ConnectedComponent.map_mk, RelEmbedding.coe_toRelHom,
+    RelIso.coe_toRelEmbedding, ConnectedComponent.eq]
+#align simple_graph.connected_component.iso_image_comp_eq_map_iff_eq_comp SimpleGraph.ConnectedComponent.iso_image_comp_eq_map_iff_eq_comp
+
+@[simp]
+theorem iso_inv_image_comp_eq_iff_eq_map {C : G.ConnectedComponent} :
+    G.connectedComponentMk (φ.symm v') = C ↔ G'.connectedComponentMk v' = C.map φ := by
+  refine' C.ind fun u => _
+  simp only [Iso.symm_apply_reachable, ConnectedComponent.eq, ConnectedComponent.map_mk,
+    RelEmbedding.coe_toRelHom, RelIso.coe_toRelEmbedding]
+#align simple_graph.connected_component.iso_inv_image_comp_eq_iff_eq_map SimpleGraph.ConnectedComponent.iso_inv_image_comp_eq_iff_eq_map
+
+end ConnectedComponent
+
+namespace Iso
+
+/-- An isomorphism of graphs induces a bijection of connected components. -/
+@[simps]
+def connectedComponentEquiv (φ : G ≃g G') : G.ConnectedComponent ≃ G'.ConnectedComponent where
+  toFun := ConnectedComponent.map φ
+  invFun := ConnectedComponent.map φ.symm
+  left_inv C := ConnectedComponent.ind
+    (fun v => congr_arg G.connectedComponentMk (Equiv.left_inv φ.toEquiv v)) C
+  right_inv C := ConnectedComponent.ind
+    (fun v => congr_arg G'.connectedComponentMk (Equiv.right_inv φ.toEquiv v)) C
+#align simple_graph.iso.connected_component_equiv SimpleGraph.Iso.connectedComponentEquiv
+
+@[simp]
+theorem connectedComponentEquiv_refl :
+    (Iso.refl : G ≃g G).connectedComponentEquiv = Equiv.refl _ := by
+  ext ⟨v⟩
+  rfl
+#align simple_graph.iso.connected_component_equiv_refl SimpleGraph.Iso.connectedComponentEquiv_refl
+
+@[simp]
+theorem connectedComponentEquiv_symm (φ : G ≃g G') :
+    φ.symm.connectedComponentEquiv = φ.connectedComponentEquiv.symm := by
+  ext ⟨_⟩
+  rfl
+#align simple_graph.iso.connected_component_equiv_symm SimpleGraph.Iso.connectedComponentEquiv_symm
+
+@[simp]
+theorem connectedComponentEquiv_trans (φ : G ≃g G') (φ' : G' ≃g G'') :
+    connectedComponentEquiv (φ.trans φ') =
+    φ.connectedComponentEquiv.trans φ'.connectedComponentEquiv := by
+  ext ⟨_⟩
+  rfl
+#align simple_graph.iso.connected_component_equiv_trans SimpleGraph.Iso.connectedComponentEquiv_trans
+
+end Iso
+
+namespace ConnectedComponent
+
+/-- The set of vertices in a connected component of a graph. -/
+def supp (C : G.ConnectedComponent) :=
+  { v | G.connectedComponentMk v = C }
+#align simple_graph.connected_component.supp SimpleGraph.ConnectedComponent.supp
+
+@[ext]
+theorem supp_injective :
+    Function.Injective (ConnectedComponent.supp : G.ConnectedComponent → Set V) := by
+  refine' ConnectedComponent.ind₂ _
+  intro v w
+  simp only [ConnectedComponent.supp, Set.ext_iff, ConnectedComponent.eq, Set.mem_setOf_eq]
+  intro h
+  rw [reachable_comm, h]
+#align simple_graph.connected_component.supp_injective SimpleGraph.ConnectedComponent.supp_injective
+
+@[simp]
+theorem supp_inj {C D : G.ConnectedComponent} : C.supp = D.supp ↔ C = D :=
+  ConnectedComponent.supp_injective.eq_iff
+#align simple_graph.connected_component.supp_inj SimpleGraph.ConnectedComponent.supp_inj
+
+instance : SetLike G.ConnectedComponent V where
+  coe := ConnectedComponent.supp
+  coe_injective' := ConnectedComponent.supp_injective
+
+@[simp]
+theorem mem_supp_iff (C : G.ConnectedComponent) (v : V) :
+    v ∈ C.supp ↔ G.connectedComponentMk v = C :=
+  Iff.rfl
+#align simple_graph.connected_component.mem_supp_iff SimpleGraph.ConnectedComponent.mem_supp_iff
+
+theorem connectedComponentMk_mem {v : V} : v ∈ G.connectedComponentMk v :=
+  rfl
+#align simple_graph.connected_component.connected_component_mk_mem SimpleGraph.ConnectedComponent.connectedComponentMk_mem
+
+/-- The equivalence between connected components, induced by an isomorphism of graphs,
+itself defines an equivalence on the supports of each connected component.
+-/
+def isoEquivSupp (φ : G ≃g G') (C : G.ConnectedComponent) :
+    C.supp ≃ (φ.connectedComponentEquiv C).supp where
+  toFun v := ⟨φ v, ConnectedComponent.iso_image_comp_eq_map_iff_eq_comp.mpr v.prop⟩
+  invFun v' := ⟨φ.symm v', ConnectedComponent.iso_inv_image_comp_eq_iff_eq_map.mpr v'.prop⟩
+  left_inv v := Subtype.ext_val (φ.toEquiv.left_inv ↑v)
+  right_inv v := Subtype.ext_val (φ.toEquiv.right_inv ↑v)
+#align simple_graph.connected_component.iso_equiv_supp SimpleGraph.ConnectedComponent.isoEquivSupp
 
 end ConnectedComponent
 

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kyle Miller
 
 ! This file was ported from Lean 3 source module combinatorics.simple_graph.connectivity
-! leanprover-community/mathlib commit e876965f7ee86f683b44e2f462ab5bfb47f993b3
+! leanprover-community/mathlib commit b99e2d58a5e6861833fa8de11e51a81144258db4
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/


### PR DESCRIPTION
* leanprover-community/mathlib#18442

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

* [`combinatorics.simple_graph.connectivity`@`e876965f7ee86f683b44e2f462ab5bfb47f993b3`..`b99e2d58a5e6861833fa8de11e51a81144258db4`](https://leanprover-community.github.io/mathlib-port-status/file/combinatorics/simple_graph/connectivity?range=e876965f7ee86f683b44e2f462ab5bfb47f993b3..b99e2d58a5e6861833fa8de11e51a81144258db4)

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
