### PR TITLE
[Merged by Bors] - fix: enable ↦ in server mode

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -2,14 +2,17 @@ import Lake
 
 open Lake DSL
 
-package mathlib
+def moreLeanArgs := #[
+  "-DwarningAsError=true",
+  "-Dpp.unicode.fun=true" -- pretty-prints `fun a ↦ b`
+]
+
+package mathlib where
+  moreServerArgs := moreLeanArgs
 
 @[default_target]
 lean_lib Mathlib where
-  moreLeanArgs := #[
-    "-DwarningAsError=true",
-    "-Dpp.unicode.fun=true" -- pretty-prints `fun a ↦ b`
-  ]
+  moreLeanArgs := moreLeanArgs
 
 @[default_target]
 lean_exe runLinter where
@@ -24,6 +27,7 @@ require Qq from git "https://github.com/gebner/quote4" @ "master"
 require aesop from git "https://github.com/JLimperg/aesop" @ "master"
 
 lean_lib Cache where
+  moreLeanArgs := moreLeanArgs
   roots := #[`Cache]
 
 lean_exe cache where


### PR DESCRIPTION
Apparently we didn't enable the `pp.unicode.fun` in server mode, so you got inconsistent output depending on whether you run the lean file on the command-line (↦) or in the editor (=>).  This change makes the options uniform.

---

Maybe we should only enable `warningsAsErrors` in command-line mode though because it changes the color of the squiggles.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
