### PR TITLE
[Merged by Bors] - feat: make `ListM` safe

### DIFF
--- a/Mathlib/Data/ListM/Basic.lean
+++ b/Mathlib/Data/ListM/Basic.lean
@@ -9,65 +9,107 @@ Authors: Mario Carneiro, Keeley Hoek, Simon Hudon, Scott Morrison
 ! if you have ported upstream changes.
 -/
 import Mathlib.Data.Option.Defs
+import Mathlib.Control.Basic
 
 /-! # Monadic lazy lists.
 
 Lazy lists with "lazyness" controlled by an arbitrary monad.
-
-The inductive construction is unsafe (indeed, we can build infinite objects).
-This isn't so bad, as the typical use is with the tactic monad, in any case.
-Typical usage will be to do computations in `ListM`, and then eventually extract
-the first result (with `head` or `firstM`), first several results (using `take`),
-or all results (using `force`). At this point you can use the `unsafe` term elaborator
-from `Std.Util.TermUnsafe` to return to the "safe" world.
-
-As we're unsafe anyway, we don't bother with proofs about these constructions.
 -/
 
-universe u v
+section UnsafeWrapper
+variable (m : Type u → Type u)
+
+private structure ListMApi where
+  listM : Type u → Type u
+  nil : listM α
+  cons : m (Option α × listM α) → listM α
+  uncons : [Monad m] → listM α → m (Option (α × listM α))
+
+instance : Nonempty (ListMApi m) := .intro {
+  listM := fun _ => PUnit
+  nil := ⟨⟩
+  cons := fun _ => ⟨⟩
+  uncons := fun _ => pure none
+}
+
+private unsafe inductive ListMImpl (α : Type u) : Type u
+  | nil : ListMImpl α
+  | cons : m (Option α × ListMImpl α) → ListMImpl α
+
+private unsafe def unconsImpl [Monad m] :
+    ListMImpl m α → m (Option (α × ListMImpl m α))
+  | .nil => pure none
+  | .cons l => do match ← l with
+    | (none, xs) => unconsImpl xs
+    | (some x, xs) => return (x, xs)
+
+@[inline] private unsafe def listMApiImpl : ListMApi.{u} m where
+  listM := ListMImpl m
+  nil := .nil
+  cons := .cons
+  uncons := unconsImpl m
+
+@[implemented_by listMApiImpl]
+private opaque listMApi : ListMApi m
+end UnsafeWrapper
 
 /-- A monadic lazy list, controlled by an arbitrary monad. -/
-unsafe inductive ListM (m : Type u → Type u) (α : Type u) : Type u
-  | nil : ListM m α
-  | cons : m (Option α × ListM m α) → ListM m α
+def ListM (m : Type u → Type u) (α : Type u) : Type u := (listMApi m).listM α
 #align tactic.mllist ListM
 
 namespace ListM
 
 variable {α β : Type u} {m : Type u → Type u}
 
-unsafe instance : EmptyCollection (ListM m α) := ⟨nil⟩
+/-- The empty `ListM`. -/
+@[inline] def nil : ListM m α := (listMApi m).nil
+
+/--
+Constructs a `ListM` by providing a monadic value computing both the head and tail of the list.
+The head is an `Option`, when `none` it is skipped and the list is only the tail.
+-/
+@[inline] def cons : m (Option α × ListM m α) → ListM m α := (listMApi m).cons
+
+/-- Deconstruct a `ListM`, returning inside the monad an optional pair `α × ListM m α`
+representing the head and tail of the list. -/
+@[inline]
+def uncons [Monad m] : ListM m α → m (Option (α × ListM m α)) := (listMApi m).uncons
+#align tactic.mllist.uncons ListM.uncons
+
+instance : EmptyCollection (ListM m α) := ⟨nil⟩
+instance : Inhabited (ListM m α) := ⟨nil⟩
+
+private local instance [Monad n] : Inhabited (δ → (α → δ → n (ForInStep δ)) → n δ) where
+  default d _ := pure d in
 
 /-- The implementation of `ForIn`, which enables `for a in L do ...` notation. -/
-@[specialize] protected unsafe def forIn [Monad m] [Monad n] [MonadLiftT m n]
-    (as : ListM m α) (init : δ) (f : α → δ → n (ForInStep δ)) : n δ :=
-  match as with
-  | nil => pure init
-  | cons l => do match ← l with
-    | (none, t) => t.forIn init f
-    | (some a, t) => match (← f a init) with
+@[specialize] protected partial def forIn [Monad m] [Monad n] [MonadLiftT m n]
+    (as : ListM m α) (init : δ) (f : α → δ → n (ForInStep δ)) : n δ := do
+  match ← (as.uncons :) with
+  | none => pure init
+  | some (a, t) => match (← f a init) with
       | ForInStep.done d  => pure d
       | ForInStep.yield d => t.forIn d f
 
-unsafe instance [Monad m] [MonadLiftT m n] : ForIn n (ListM m α) α where
+instance [Monad m] [MonadLiftT m n] : ForIn n (ListM m α) α where
   forIn := ListM.forIn
 
 /-- Construct a `ListM` recursively. -/
-unsafe def fix [Alternative m] (f : α → m α) : α → ListM m α
+partial def fix [Alternative m] (f : α → m α) : α → ListM m α
   | x => cons <| (fun a => (some x, fix f a)) <$> f x <|> pure (some x, nil)
 #align tactic.mllist.fix ListM.fix
 
 variable [Monad m]
 
 /-- Construct a `ListM` by iteration. (`m` must be a stateful monad for this to be useful.) -/
-unsafe def iterate (f : m α) : ListM m α :=
+partial def iterate (f : m α) : ListM m α :=
   cons do pure (← f, iterate f)
 
 /-- Repeatedly apply a function `f : α → m (α × List β)` to an initial `a : α`,
 accumulating the elements of the resulting `List β` as a single monadic lazy list.
 
 (This variant allows starting with a specified `List β` of elements, as well. )-/
-unsafe def fixl_with [Alternative m] (f : α → m (α × List β)) : α → List β → ListM m β
+partial def fixl_with [Alternative m] (f : α → m (α × List β)) : α → List β → ListM m β
   | s, b :: rest => cons <| pure (some b, fixl_with f s rest)
   | s, [] => cons <| (do
     let (s', l) ← f s
@@ -79,246 +121,210 @@ unsafe def fixl_with [Alternative m] (f : α → m (α × List β)) : α → Lis
 
 /-- Repeatedly apply a function `f : α → m (α × List β)` to an initial `a : α`,
 accumulating the elements of the resulting `List β` as a single monadic lazy list. -/
-unsafe def fixl [Alternative m] (f : α → m (α × List β)) (s : α) : ListM m β :=
+def fixl [Alternative m] (f : α → m (α × List β)) (s : α) : ListM m β :=
   fixl_with f s []
 #align tactic.mllist.fixl ListM.fixl
 
-/-- Deconstruct a `ListM`, returning inside the monad an optional pair `α × ListM m α`
-representing the head and tail of the list. -/
-unsafe def uncons : ListM m α → m (Option (α × ListM m α))
-  | nil => pure none
-  | cons l => do
-    let (x, xs) ← l
-    let some x ← pure x | uncons xs
-    return (x, xs)
-#align tactic.mllist.uncons ListM.uncons
-
 /-- Compute, inside the monad, whether a `ListM` is empty. -/
-unsafe def isEmpty (xs : ListM m α) : m (ULift Bool) :=
+def isEmpty (xs : ListM m α) : m (ULift Bool) :=
   (ULift.up ∘ Option.isSome) <$> uncons xs
 #align tactic.mllist.empty ListM.isEmpty
 
 /-- Convert a `List` to a `ListM`. -/
-unsafe def ofList : List α → ListM m α
+def ofList : List α → ListM m α
   | [] => nil
   | h :: t => cons (pure (h, ofList t))
 #align tactic.mllist.of_list ListM.ofList
 
 /-- The empty `ListM`. -/
-unsafe def empty : ListM m α := ofList []
+abbrev empty : ListM m α := nil
 
 /-- Convert a `List` of values inside the monad into a `ListM`. -/
-unsafe def ofListM : List (m α) → ListM m α
+def ofListM : List (m α) → ListM m α
   | [] => nil
   | h :: t => cons ((fun x => (x, ofListM t)) <$> some <$> h)
 #align tactic.mllist.m_of_list ListM.ofListM
 
 /-- Extract a list inside the monad from a `ListM`. -/
-unsafe def force (L : ListM m α) : m (List α) := do
-  match ← uncons L with
+partial def force (L : ListM m α) : m (List α) := do
+  match ← L.uncons with
   | none => pure []
-  | some (x, xs) => (x :: ·) <$> force xs
+  | some (x, xs) => return x :: (← xs.force)
 #align tactic.mllist.force ListM.force
 
 /-- Extract an array inside the monad from a `ListM`. -/
-unsafe def asArray (L : ListM m α) : m (Array α) := do
+def asArray (L : ListM m α) : m (Array α) := do
   let mut r := #[]
   for a in L do
     r := r.push a
   return r
 
+/-- Lift a monadic lazy list inside the monad to a monadic lazy list. -/
+def squash (t : m (ListM m α)) : ListM m α :=
+  cons do return (none, ← t)
+#align tactic.mllist.squash ListM.squash
+
+/--
+Performs a case distinction on a `ListM` when the motive is a `ListM` as well.
+(We need to be in a monadic context to distinguish a nil from a cons.)
+-/
+@[specialize]
+def cases' (xs : ListM m α) (hnil : ListM m β) (hcons : α → ListM m α → ListM m β) : ListM m β :=
+  squash do return match ← xs.uncons with
+    | none => hnil
+    | some (x, xs) => hcons x xs
+
 /-- Gives the monadic lazy list consisting all of folds of a function on a given initial element.
 Thus `[a₀, a₁, ...].foldsM f b` will give `[b, ← f b a₀, ← f (← f b a₀) a₁, ...]`. -/
-unsafe def foldsM (f : β → α → m β) (init : β) (L : ListM m α) : ListM m β :=
-  cons do match ← uncons L with
-  | none => return (some init, empty)
-  | some (x, xs) => do
-    let b ← f init x
-    return (some init, foldsM f b xs)
+partial def foldsM (f : β → α → m β) (init : β) (L : ListM m α) : ListM m β :=
+  cons <| pure (init, L.cases' {} (fun x xs => squash do return foldsM f (← f init x) xs))
 
 /-- Gives the monadic lazy list consisting all of folds of a function on a given initial element.
 Thus `[a₀, a₁, ...].foldsM f b` will give `[b, f b a₀, f (f b a₀) a₁, ...]`. -/
-unsafe def folds (f : β → α → β) (init : β) (L : ListM m α) : ListM m β :=
+def folds (f : β → α → β) (init : β) (L : ListM m α) : ListM m β :=
   L.foldsM (fun b a => pure (f b a)) init
 
 /-- Take the first `n` elements, as a list inside the monad. -/
-unsafe def takeAsList : ListM m α → Nat → m (List α)
-  | _,  0 => pure []
-  | xs, n+1 => do
-    match ← uncons xs with
-    | some (x, xs) => (x :: ·) <$> takeAsList xs n
+partial def takeAsList (xs : ListM m α) : Nat → m (List α)
+  | 0 => pure []
+  | n+1 => do match ← xs.uncons with
     | none => pure []
+    | some (x, xs) => return x :: (← xs.takeAsList n)
 #align tactic.mllist.take ListM.takeAsList
 
 /-- Take the first `n` elements. -/
-unsafe def take : ListM m α → Nat → ListM m α
-  | _,  0    => empty
-  | xs, n+1 => cons do
-    match ← uncons xs with
-    | some (x, xs) => return (x, xs.take n)
-    | none => return (none, empty)
+partial def take (xs : ListM m α) : Nat → ListM m α
+  | 0 => empty
+  | n+1 => xs.cases' {} fun _ l => l.take n
 
 /-- Drop the first `n` elements. -/
-unsafe def drop : ListM m α → Nat → ListM m α
-  | xs, 0    => xs
-  | xs, n+1 => cons do
-    match ← uncons xs with
-    | some (_, xs) => return (none, drop xs n)
-    | none => return (none, empty)
+def drop (xs : ListM m α) : Nat → ListM m α
+  | 0 => xs
+  | n+1 => xs.cases' {} fun _ l => l.drop n
 
 /-- Apply a function which returns values in the monad to every element of a `ListM`. -/
-unsafe def mapM (f : α → m β) (L : ListM m α) : ListM m β :=
-  cons do match ← uncons L with
-  | some (x, xs) => return (← f x, mapM f xs)
-  | none => return (none, empty)
+partial def mapM (f : α → m β) (xs : ListM m α) : ListM m β :=
+  xs.cases' {} fun x xs => cons do return (← f x, xs.mapM f)
 #align tactic.mllist.mmap ListM.mapM
 
 /-- Apply a function to every element of a `ListM`. -/
-unsafe def map (f : α → β) (L : ListM m α) : ListM m β :=
+def map (f : α → β) (L : ListM m α) : ListM m β :=
   L.mapM fun a => pure (f a)
 #align tactic.mllist.map ListM.map
 
 /-- Filter a `ListM` using a monadic function. -/
-unsafe def filterM (p : α → m (ULift Bool)) (L : ListM m α) : ListM m α :=
-  cons do match ← uncons L with
-  | some (x, xs) => return (if (← p x).down then some x else none, filterM p xs)
-  | none => return (none, empty)
+partial def filterM (p : α → m (ULift Bool)) (L : ListM m α) : ListM m α :=
+  L.cases' {} fun x xs => cons do
+    return (if (← p x).down then some x else none, filterM p xs)
 #align tactic.mllist.mfilter ListM.filterM
 
 /-- Filter a `ListM`. -/
-unsafe def filter (p : α → Bool) (L : ListM m α) : ListM m α :=
+def filter (p : α → Bool) (L : ListM m α) : ListM m α :=
   L.filterM fun a => pure <| .up (p a)
 #align tactic.mllist.filter ListM.filter
 
 /-- Filter and transform a `ListM` using a function that returns values inside the monad. -/
 -- Note that the type signature has changed since Lean 3, when we allowed `f` to fail.
 -- Use `try?` from `Mathlib.Control.Basic` to lift a possibly failing function to `Option`.
-unsafe def filterMapM (f : α → m (Option β)) (L : ListM m α) : ListM m β :=
-  cons do match ← uncons L with
-  | none => return (none, empty)
-  | some (x, xs) => match ← f x with
-    | none => return (none, xs.filterMapM f)
-    | some b => return (some b, xs.filterMapM f)
+partial def filterMapM (f : α → m (Option β)) (xs : ListM m α) : ListM m β :=
+  xs.cases' {} fun x xs => cons do return (← f x, xs.filterMapM f)
 #align tactic.mllist.mfilter_map ListM.filterMapM
 
 /-- Filter and transform a `ListM` using an `Option` valued function. -/
-unsafe def filterMap (f : α → Option β) : ListM m α → ListM m β :=
+def filterMap (f : α → Option β) : ListM m α → ListM m β :=
   filterMapM fun a => do pure (f a)
 #align tactic.mllist.filter_map ListM.filterMap
 
 /-- Take the initial segment of the lazy list, until the function `f` first returns `false`. -/
-unsafe def takeWhileM (f : α → m (ULift Bool)) (L : ListM m α) : ListM m α :=
-  cons do match ← uncons L with
-  | none => return (none, empty)
-  | some (x, xs) => return if (← f x).down then (some x, xs.takeWhileM f) else (none, empty)
+partial def takeWhileM (f : α → m (ULift Bool)) (L : ListM m α) : ListM m α :=
+  L.cases' {} fun x xs => cons do
+    return if (← f x).down then (none, {}) else (some x, xs.takeWhileM f)
 
 /-- Take the initial segment of the lazy list, until the function `f` first returns `false`. -/
-unsafe def takeWhile (f : α → Bool) : ListM m α → ListM m α :=
+def takeWhile (f : α → Bool) : ListM m α → ListM m α :=
   takeWhileM fun a => pure (.up (f a))
 
 /-- Concatenate two monadic lazy lists. -/
-unsafe def append (L M : ListM m α) : ListM m α :=
-  cons do match ← uncons L with
-  | none => return (none, M)
-  | some (x, xs) => return (some x, append xs M)
+partial def append (xs ys : ListM m α) : ListM m α :=
+  xs.cases' ys fun x xs => cons do pure (x, append xs ys)
 #align tactic.mllist.append ListM.append
 
 /-- Join a monadic lazy list of monadic lazy lists into a single monadic lazy list. -/
-unsafe def join (L : ListM m (ListM m α)) : ListM m α :=
-  cons do match ← uncons L with
-  | none => return (none, empty)
-  | some (x, xs) => match ← uncons x with
-    | none => return (none, xs.join)
-    | some (y, ys) => return (some y, cons (pure (some ys, xs)) |>.join)
+partial def join (xs : ListM m (ListM m α)) : ListM m α :=
+  xs.cases' {} fun x xs => append x (join xs)
 #align tactic.mllist.join ListM.join
 
-/-- Lift a monadic lazy list inside the monad to a monadic lazy list. -/
-unsafe def squash (t : m (ListM m α)) : ListM m α :=
-  (ListM.ofListM [t]).join
-#align tactic.mllist.squash ListM.squash
-
 /-- Enumerate the elements of a monadic lazy list, starting at a specified offset. -/
-unsafe def enum_from (n : Nat) (L : ListM m α) : ListM m (Nat × α) :=
-  cons do match ← uncons L with
-  | none => return (none, empty)
-  | some (x, xs) => return (some (n, x), xs.enum_from (n+1))
+partial def enum_from (n : Nat) (xs : ListM m α) : ListM m (Nat × α) :=
+  xs.cases' {} fun x xs => cons do pure (some (n, x), xs.enum_from (n+1))
 #align tactic.mllist.enum_from ListM.enum_from
 
 /-- Enumerate the elements of a monadic lazy list. -/
-unsafe def enum : ListM m α → ListM m (Nat × α) :=
+def enum : ListM m α → ListM m (Nat × α) :=
   enum_from 0
 #align tactic.mllist.enum ListM.enum
 
 /-- The infinite monadic lazy list of natural numbers.-/
-unsafe def range {m : Type → Type} [Alternative m] : ListM m Nat :=
+def range {m : Type → Type} [Alternative m] : ListM m Nat :=
   ListM.fix (fun n => pure (n + 1)) 0
 #align tactic.mllist.range ListM.range
 
 /-- Add one element to the end of a monadic lazy list. -/
-unsafe def concat : ListM m α → α → ListM m α
+def concat : ListM m α → α → ListM m α
   | L, a => (ListM.ofList [L, ListM.ofList [a]]).join
 #align tactic.mllist.concat ListM.concat
 
 /-- Take the product of two monadic lazy lists. -/
-unsafe def zip (L : ListM m α) (M : ListM m β) : ListM m (α × β) :=
-  squash do match ← uncons L, ← uncons M with
-    | some (a, L'), some (b, M') => pure <| cons <| pure ((a, b), L'.zip M')
-    | _, _ => pure nil
+partial def zip (L : ListM m α) (M : ListM m β) : ListM m (α × β) :=
+  L.cases' {} fun a L =>
+  M.cases' {} fun b M =>
+  cons <| pure ((a, b), L.zip M)
 
 /-- Apply a function returning a monadic lazy list to each element of a monadic lazy list,
 joining the results. -/
-unsafe def bind (L : ListM m α) (f : α → ListM m β) : ListM m β :=
-  cons do match ← uncons L with
-  | none => return (none, empty)
-  | some (x, xs) => match ← uncons (f x) with
-    | none => return (none, (xs.bind f))
-    | some (y, ys) => return (some y, append ys (xs.bind f))
+partial def bind (xs : ListM m α) (f : α → ListM m β) : ListM m β :=
+  xs.cases' {} fun x xs => append (f x) (bind xs f)
 #align tactic.mllist.bind_ ListM.bind
 
 /-- Convert any value in the monad to the singleton monadic lazy list. -/
-unsafe def monadLift (x : m α) : ListM m α :=
+def monadLift (x : m α) : ListM m α :=
   cons <| (flip Prod.mk nil ∘ some) <$> x
 #align tactic.mllist.monad_lift ListM.monadLift
 
 /-- Lift the monad of a lazy list. -/
-unsafe def liftM [Monad n] [MonadLift m n] (L : ListM m α) : ListM n α :=
+partial def liftM [Monad n] [MonadLift m n] (L : ListM m α) : ListM n α :=
   squash do match ← (uncons L : m _) with
     | none => pure empty
     | some (a, L') => pure <| cons do pure (a, L'.liftM)
 
 /-- Given a lazy list in a state monad, run it on some initial state, recording the states. -/
-unsafe def runState (L : ListM (StateT.{u} σ m) α) (s : σ) : ListM m (α × σ) :=
+partial def runState (L : ListM (StateT.{u} σ m) α) (s : σ) : ListM m (α × σ) :=
   squash do match ← StateT.run (uncons L) s with
     | (none, _) => pure empty
     | (some (a, L'), s') => pure <| cons do pure (some (a, s'), L'.runState s')
 
 /-- Given a lazy list in a state monad, run it on some initial state. -/
-unsafe def runState' (L : ListM (StateT.{u} σ m) α) (s : σ) : ListM m α :=
+def runState' (L : ListM (StateT.{u} σ m) α) (s : σ) : ListM m α :=
   L.runState s |>.map (·.1)
 
 /-- Return the head of a monadic lazy list if it exists, as an `Option` in the monad. -/
-unsafe def head? (L : ListM m α) : m (Option α) := do
+def head? (L : ListM m α) : m (Option α) := do
   pure <| (← L.uncons).map (·.1)
 
 /-- Take the initial segment of the lazy list,
 up to and including the first place where `f` gives `true`. -/
-unsafe def takeUpToFirstM (L : ListM m α) (f : α → m (ULift Bool)) : ListM m α :=
-  cons do match ← uncons L with
-  | none => return (none, empty)
-  | some (x, xs) =>
-    if (← (f x)).down then
-      return (some x, empty)
-    else
-      return (some x, xs.takeUpToFirstM f)
+partial def takeUpToFirstM (L : ListM m α) (f : α → m (ULift Bool)) : ListM m α :=
+  L.cases' {} fun x xs => cons do
+    return (some x, if (← (f x)).down then empty else xs.takeUpToFirstM f)
 
 /-- Take the initial segment of the lazy list,
 up to and including the first place where `f` gives `true`. -/
-unsafe def takeUpToFirst (L : ListM m α) (f : α → Bool) : ListM m α :=
+def takeUpToFirst (L : ListM m α) (f : α → Bool) : ListM m α :=
   L.takeUpToFirstM fun a => pure (.up (f a))
 
 /-- Gets the last element of a monadic lazy list, as an option in the monad.
 This will run forever if the list is infinite. -/
-unsafe def getLast? (L : ListM m α) : m (Option α) := do
+partial def getLast? (L : ListM m α) : m (Option α) := do
   match ← uncons L with
   | none => return none
   | some (x, xs) => aux x xs
@@ -329,12 +335,12 @@ where aux (x : α) (L : ListM m α) : m (Option α) := do
 
 /-- Gets the last element of a monadic lazy list, or the default value if the list is empty.
 This will run forever if the list is infinite. -/
-unsafe def getLast! [Inhabited α] (L : ListM m α) : m α :=
+partial def getLast! [Inhabited α] (L : ListM m α) : m α :=
   Option.get! <$> L.getLast?
 
 /-- Folds a binary function across a monadic lazy list, from an initial starting value.
 This will run forever if the list is infinite. -/
-unsafe def foldM (f : β → α → m β) (init : β) (L : ListM m α) : m β :=
+partial def foldM (f : β → α → m β) (init : β) (L : ListM m α) : m β :=
   (L.foldsM f init |>.getLast?) <&> (·.getD init) -- `foldsM` is always non-empty, anyway.
 
 /-- Folds a binary function across a monadic lazy list, from an initial starting value.
@@ -349,7 +355,7 @@ variable [Alternative m]
 Return the head of a monadic lazy list, as a value in the monad.
 Fails if the list is empty.
 -/
-unsafe def head (L : ListM m α) : m α := do
+def head (L : ListM m α) : m α := do
   let some (r, _) ← L.uncons | failure
   return r
 #align tactic.mllist.head ListM.head
@@ -358,24 +364,24 @@ unsafe def head (L : ListM m α) : m α := do
 Apply a function returning values inside the monad to a monadic lazy list,
 returning only the first successful result.
 -/
-unsafe def firstM (L : ListM m α) (f : α → m (Option β)) : m β :=
+def firstM (L : ListM m α) (f : α → m (Option β)) : m β :=
   (L.filterMapM f).head
 #align tactic.mllist.mfirst ListM.firstM
 
 /-- Return the first value on which a predicate returns true. -/
-unsafe def first (L : ListM m α) (p : α → Bool) : m α :=
+def first (L : ListM m α) (p : α → Bool) : m α :=
   (L.filter p).head
 
 end Alternative
 
-unsafe instance : Monad (ListM m) where
+instance : Monad (ListM m) where
   pure := fun a => .ofList [a]
   seq := fun fs as => fs.zip (as ()) |>.map fun ⟨f, a⟩ => f a
   bind := bind
 
-unsafe instance : Alternative (ListM m) where
+instance : Alternative (ListM m) where
   failure := nil
   orElse := fun L M => L.append (M ())
 
-unsafe instance : MonadLift m (ListM m) where
+instance : MonadLift m (ListM m) where
   monadLift := monadLift

--- a/Mathlib/Data/ListM/Heartbeats.lean
+++ b/Mathlib/Data/ListM/Heartbeats.lean
@@ -14,7 +14,7 @@ open Lean.Core (CoreM)
 
 /-- Take an initial segment of a `MetaM` lazy list,
 trying to leave at least `percent` of the remaining allowed heartbeats. -/
-unsafe def ListM.whileAtLeastHeartbeatsPercent [Monad m] [MonadLiftT CoreM m]
+def ListM.whileAtLeastHeartbeatsPercent [Monad m] [MonadLiftT CoreM m]
     (L : ListM m α) (percent : Nat) : ListM m α :=
 ListM.squash do
   let initialHeartbeats ← getRemainingHeartbeats

--- a/Mathlib/Tactic/LibrarySearch.lean
+++ b/Mathlib/Tactic/LibrarySearch.lean
@@ -104,14 +104,13 @@ def librarySearchLemma (lem : Name) (mod : DeclMod) (required : List Expr) (solv
 Returns a lazy list of the results of applying a library lemma,
 then calling `solveByElim` on the resulting goals.
 -/
-unsafe def librarySearchCore (goal : MVarId) (lemmas : DiscrTree (Name × DeclMod) s)
+def librarySearchCore (goal : MVarId) (lemmas : DiscrTree (Name × DeclMod) s)
     (required : List Expr) (solveByElimDepth := 6) : ListM MetaM (MetavarContext × List MVarId) :=
   .squash do
     let ty ← goal.getType
-    withTraceNode `Tactic.librarySearch (return m!"{·.emoji} {ty}") do
-      let lemmas := ListM.ofList ((← lemmas.getMatch ty).toList)
-      return lemmas.filterMapM fun (lem, mod) =>
-        try? <| librarySearchLemma lem mod required solveByElimDepth goal
+    let lemmas := ListM.ofList ((← lemmas.getMatch ty).toList)
+    return lemmas.filterMapM fun (lem, mod) =>
+      try? <| librarySearchLemma lem mod required solveByElimDepth goal
 
 /--
 Try to solve the goal either by:
@@ -131,11 +130,16 @@ this is not currently tracked.)
 -/
 def librarySearch (goal : MVarId) (lemmas : DiscrTree (Name × DeclMod) s) (required : List Expr)
     (solveByElimDepth := 6) : MetaM (Option (Array (MetavarContext × List MVarId))) := do
+  let librarySearchEmoji := fun
+    | .error _ => bombEmoji
+    | .ok (some _) => crossEmoji
+    | .ok none => checkEmoji
+  withTraceNode `Tactic.librarySearch (return m!"{librarySearchEmoji ·} {← goal.getType}") do
   profileitM Exception "librarySearch" (← getOptions) do
   (do
     solveByElim [goal] required solveByElimDepth
     return none) <|>
-  unsafe (do
+  (do
     let results ← librarySearchCore goal lemmas required solveByElimDepth
       -- Don't use too many heartbeats.
       |>.whileAtLeastHeartbeatsPercent 10
@@ -178,6 +182,7 @@ elab_rules : tactic | `(tactic| library_search%$tk $[using $[$required:term],*]?
       for suggestion in suggestions do
         withMCtx suggestion.1 do
           addExactSuggestion tk (← instantiateMVars (mkMVar mvar)).headBeta
+      if suggestions.isEmpty then logError "library_search didn't find any relevant lemmas"
       admitGoal goal
     else
       addExactSuggestion tk (← instantiateMVars (mkMVar mvar)).headBeta
@@ -192,6 +197,7 @@ elab tk:"library_search%" : term <= expectedType => do
       for suggestion in suggestions do
         withMCtx suggestion.1 do
           addTermSuggestion tk (← instantiateMVars goal).headBeta
+      if suggestions.isEmpty then logError "library_search didn't find any relevant lemmas"
       mkSorry expectedType (synthetic := true)
     else
       addTermSuggestion tk (← instantiateMVars goal).headBeta

--- a/test/ListM.lean
+++ b/test/ListM.lean
@@ -22,13 +22,16 @@ open Lean
   let x := ((ListM.fix F 10).force).run []
   guard $ x = some ([10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
 
-#check (rfl : ((ListM.fix F 10).takeAsList 4).run [] = some ([10, 9, 8, 7], [7, 8, 9, 10]))
-#check (rfl :
-  (((ListM.fix F 10).map fun n => n*n).takeAsList 3).run [] = some ([100, 81, 64], [8, 9, 10]))
+example : ((ListM.fix F 10).takeAsList 4).run [] = some ([10, 9, 8, 7], [7, 8, 9, 10]) := by
+  native_decide
+example :
+    (((ListM.fix F 10).map fun n => n*n).takeAsList 3).run [] =
+      some ([100, 81, 64], [8, 9, 10]) := by
+  native_decide
 
-unsafe def l1 : ListM S Nat := ListM.ofList [0,1,2]
-unsafe def l2 : ListM S Nat := ListM.ofList [3,4,5]
-unsafe def ll : ListM S Nat := (ListM.ofList [l1, l2]).join
+def l1 : ListM S Nat := ListM.ofList [0,1,2]
+def l2 : ListM S Nat := ListM.ofList [3,4,5]
+def ll : ListM S Nat := (ListM.ofList [l1, l2]).join
 
 #eval show MetaM Unit from do
   let x := ll.force.run []

--- a/test/ListM.lean
+++ b/test/ListM.lean
@@ -22,11 +22,11 @@ open Lean
   let x := ((ListM.fix F 10).force).run []
   guard $ x = some ([10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
 
-example : ((ListM.fix F 10).takeAsList 4).run [] = some ([10, 9, 8, 7], [7, 8, 9, 10]) := by
+example : ((ListM.fix F 10).takeAsList 4).run [] = some ([10, 9, 8, 7], [8, 9, 10]) := by
   native_decide
 example :
     (((ListM.fix F 10).map fun n => n*n).takeAsList 3).run [] =
-      some ([100, 81, 64], [8, 9, 10]) := by
+      some ([100, 81, 64], [9, 10]) := by
   native_decide
 
 def l1 : ListM S Nat := ListM.ofList [0,1,2]


### PR DESCRIPTION
Hide the unsafe inductive powering `ListM` behind a safe API using `implemented_by`.

---

The motivation is of course Scott's recent barrage of library_search improvements using ListM which marks everything as unsafe.  I'd really like to stop the proliferation of unsafe, so that unsafe continues to be a meaningful indicator of memory unsafety or logical unsoundness.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
