### PR TITLE
feat: Lemmas about `f * pi.single i x`

### DIFF
--- a/Mathlib/Algebra/Group/Pi.lean
+++ b/Mathlib/Algebra/Group/Pi.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Simon Hudon, Patrick Massot
 
 ! This file was ported from Lean 3 source module algebra.group.pi
-! leanprover-community/mathlib commit b3f25363ae62cb169e72cd6b8b1ac97bacf21ca7
+! leanprover-community/mathlib commit 246f6f7989ff86bd07e1b014846f11304f33cf9e
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -42,7 +42,7 @@ variable {I : Type u}
 variable {f : I → Type v}
 
 -- The family of types already equipped with instances
-variable (x y : ∀ i, f i) (i : I)
+variable (x y : ∀ i, f i) (i j : I)
 
 @[to_additive]
 theorem Set.preimage_one {α β : Type _} [One β] (s : Set β) [Decidable ((1 : β) ∈ s)] :
@@ -498,6 +498,26 @@ theorem Pi.single_mul [∀ i, MulZeroClass <| f i] (i : I) (x y : f i) :
     single i (x * y) = single i x * single i y :=
   (MulHom.single f i).map_mul x y
 #align pi.single_mul Pi.single_mul
+
+theorem Pi.single_mul_left_apply [∀ i, MulZeroClass <| f i] (a : f i) :
+    Pi.single i (a * x i) j = Pi.single i a j * x j :=
+  (Pi.apply_single (fun i => (· * x i)) (fun i => MulZeroClass.zero_mul _) _ _ _).symm
+#align pi.single_mul_left_apply Pi.single_mul_left_apply
+
+theorem Pi.single_mul_right_apply [∀ i, MulZeroClass <| f i] (a : f i) :
+    Pi.single i (x i * a) j = x j * Pi.single i a j :=
+  (Pi.apply_single (fun i => (· * ·) (x i)) (fun i => MulZeroClass.mul_zero _) _ _ _).symm
+#align pi.single_mul_right_apply Pi.single_mul_right_apply
+
+theorem Pi.single_mul_left [∀ i, MulZeroClass <| f i] (a : f i) :
+    Pi.single i (a * x i) = Pi.single i a * x :=
+  funext fun j => Pi.single_mul_left_apply _ _ _ _
+#align pi.single_mul_left Pi.single_mul_left
+
+theorem Pi.single_mul_right [∀ i, MulZeroClass <| f i] (a : f i) :
+    Pi.single i (x i * a) = x * Pi.single i a :=
+  funext fun j => Pi.single_mul_right_apply _ _ _ _
+#align pi.single_mul_right Pi.single_mul_right
 
 /-- The injection into a pi group at different indices commutes.
 

--- a/Mathlib/Algebra/Group/Pi.lean
+++ b/Mathlib/Algebra/Group/Pi.lean
@@ -501,22 +501,22 @@ theorem Pi.single_mul [∀ i, MulZeroClass <| f i] (i : I) (x y : f i) :
 
 theorem Pi.single_mul_left_apply [∀ i, MulZeroClass <| f i] (a : f i) :
     Pi.single i (a * x i) j = Pi.single i a j * x j :=
-  (Pi.apply_single (fun i => (· * x i)) (fun i => MulZeroClass.zero_mul _) _ _ _).symm
+  (Pi.apply_single (fun i => (· * x i)) (fun _ => MulZeroClass.zero_mul _) _ _ _).symm
 #align pi.single_mul_left_apply Pi.single_mul_left_apply
 
 theorem Pi.single_mul_right_apply [∀ i, MulZeroClass <| f i] (a : f i) :
     Pi.single i (x i * a) j = x j * Pi.single i a j :=
-  (Pi.apply_single (fun i => (· * ·) (x i)) (fun i => MulZeroClass.mul_zero _) _ _ _).symm
+  (Pi.apply_single (fun i => (· * ·) (x i)) (fun _ => MulZeroClass.mul_zero _) _ _ _).symm
 #align pi.single_mul_right_apply Pi.single_mul_right_apply
 
 theorem Pi.single_mul_left [∀ i, MulZeroClass <| f i] (a : f i) :
     Pi.single i (a * x i) = Pi.single i a * x :=
-  funext fun j => Pi.single_mul_left_apply _ _ _ _
+  funext fun _ => Pi.single_mul_left_apply _ _ _ _
 #align pi.single_mul_left Pi.single_mul_left
 
 theorem Pi.single_mul_right [∀ i, MulZeroClass <| f i] (a : f i) :
     Pi.single i (x i * a) = x * Pi.single i a :=
-  funext fun j => Pi.single_mul_right_apply _ _ _ _
+  funext fun _ => Pi.single_mul_right_apply _ _ _ _
 #align pi.single_mul_right Pi.single_mul_right
 
 /-- The injection into a pi group at different indices commutes.


### PR DESCRIPTION
Match https://github.com/leanprover-community/mathlib/pull/6418

* [`algebra.group.pi`@`b3f25363ae62cb169e72cd6b8b1ac97bacf21ca7`..`246f6f7989ff86bd07e1b014846f11304f33cf9e`](https://leanprover-community.github.io/mathlib-port-status/file/algebra/group/pi?range=b3f25363ae62cb169e72cd6b8b1ac97bacf21ca7..246f6f7989ff86bd07e1b014846f11304f33cf9e)


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
