### PR TITLE
[Merged by Bors] - fix: sync file list expected by cache with Lake changes

### DIFF
--- a/Cache/IO.lean
+++ b/Cache/IO.lean
@@ -153,8 +153,7 @@ def mkBuildPaths (path : FilePath) : IO $ Array FilePath := do
     packageDir / LIBDIR / path.withExtension "olean",
     packageDir / LIBDIR / path.withExtension "ilean",
     packageDir / LIBDIR / path.withExtension "trace",
-    packageDir / IRDIR  / path.withExtension "c",
-    packageDir / IRDIR  / path.withExtension "c.trace"]
+    packageDir / IRDIR  / path.withExtension "c"]
 
 def allExist (paths : Array FilePath) : IO Bool := do
   for path in paths do


### PR DESCRIPTION
The `.c.trace` files no longer exist, see https://github.com/leanprover/lake/commit/6499494befc24e388d12f3d9411f99aae0769491#diff-43ead6410f2dcb31276401eb765b8ada18c8e288626dfa8d6123cfab46961e7aL81-L83.

---


Let's see if it uploads something now