### PR TITLE
[Merged by Bors] - feat: use more function coercions in `apply_fun`

### DIFF
--- a/test/apply_fun.lean
+++ b/test/apply_fun.lean
@@ -14,6 +14,44 @@ example (f : ℕ → ℕ) (h : f x = f y) : x = y := by
   · guard_target = Injective f
     sorry
 
+example (f : ℕ → ℕ → ℕ) (h : f 1 x = f 1 y) (hinj : ∀ n, Injective (f n)) : x = y := by
+  apply_fun f ?foo
+  guard_target = f ?foo x = f ?foo y
+  case foo => exact 1
+  · exact h
+  · apply hinj
+
+-- Uses `refine`-style rules for placeholders:
+example (f : ℕ → ℕ → ℕ) : x = y := by
+  fail_if_success apply_fun f _
+  sorry
+
+example (f : ℕ → ℕ → ℕ) (h : f 1 x = f 1 y) (hinj : Injective (f 1)) : x = y := by
+  apply_fun f _ using hinj
+  -- Solves for the hole using unification since it makes use of the `using` clause.
+  guard_target = f 1 x = f 1 y
+  assumption
+
+-- A test to show a perhaps unexpected consequence of how injectivity is auto-proved:
+example (f : ℕ → ℕ → ℕ) (h : f 1 x = f 1 y) (hinj : Injective (f 1)) : x = y := by
+  apply_fun f _
+  -- Solves for the hole using unification since `hinj` is pulled in by `assumption`.
+  guard_target = f 1 x = f 1 y
+  assumption
+
+-- A test to show a perhaps unexpected consequence of how injectivity is auto-proved:
+example (f : ℕ → ℕ) (h : f x = f y) (hinj : Injective f) : x = y := by
+  apply_fun _
+  guard_target = f x = f y
+  assumption
+
+-- Make sure named holes generate new goals for `≠`
+example (f : ℕ → ℕ → ℕ) (h : f 1 x ≠ f 1 y) : x ≠ y := by
+  apply_fun f ?foo
+  guard_target = f ?foo x ≠ f ?foo y
+  case foo => exact 1
+  assumption
+
 example (X Y Z : Type) (f : X → Y) (g : Y → Z) (H : Injective $ g ∘ f) : Injective f := by
   intros x x' h
   apply_fun g at h

--- a/test/apply_fun.lean
+++ b/test/apply_fun.lean
@@ -43,6 +43,10 @@ example (n m : ℕ) (f : ℕ → ℕ) (h : f n ≠ f m) : n ≠ m := by
   apply_fun f
   exact h
 
+example (n m : ℕ) (f : ℕ ≃ ℕ) (h : f n ≠ f m) : n ≠ m := by
+  apply_fun f
+  exact h
+
 example (n m : ℕ) (f : ℕ → ℕ) (w : Function.Injective f) (h : f n = f m) : n = m := by
   apply_fun f
   assumption
@@ -53,6 +57,18 @@ example (n m : ℕ) (f : ℕ → ℕ) (w : Function.Injective f) (h : f n = f m)
 
 example (n m : ℕ) (f : ℕ → ℕ) (w : Function.Injective f ∧ true) (h : f n = f m) : n = m := by
   apply_fun f using w.1
+  assumption
+
+example (f : ℕ ≃ ℕ) (h : f x = f y) : x = y := by
+  apply_fun f
+  assumption
+
+example (f : ℕ ≃ ℕ) (h : f x = f y) : x = y := by
+  apply_fun f using f.injective
+  assumption
+
+example {x y : ℕ} (h : Equiv.refl ℕ x = Equiv.refl ℕ y) : x = y := by
+  apply_fun Equiv.refl ℕ
   assumption
 
 example (a b : List α) (P : a = b) : True := by

--- a/test/apply_fun.lean
+++ b/test/apply_fun.lean
@@ -7,6 +7,13 @@ import Mathlib.Data.Fintype.Card
 
 open Function
 
+example (f : ℕ → ℕ) (h : f x = f y) : x = y := by
+  apply_fun f
+  · guard_target = f x = f y
+    assumption
+  · guard_target = Injective f
+    sorry
+
 example (X Y Z : Type) (f : X → Y) (g : Y → Z) (H : Injective $ g ∘ f) : Injective f := by
   intros x x' h
   apply_fun g at h


### PR DESCRIPTION
When `apply_fun f` is applied to the main goal, it creates the expression `Function.Injective f`, which requires that `f` be a function. Now `apply_fun` will insert a function coercion here if needed. Furthermore, `apply_fun` is now aware of `Equiv.injective`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
