### PR TITLE
[Merged by Bors] - feat: `Function.update` is monotone 

### DIFF
--- a/Mathlib/Algebra/Group/Pi.lean
+++ b/Mathlib/Algebra/Group/Pi.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Simon Hudon, Patrick Massot
 
 ! This file was ported from Lean 3 source module algebra.group.pi
-! leanprover-community/mathlib commit b3f25363ae62cb169e72cd6b8b1ac97bacf21ca7
+! leanprover-community/mathlib commit 90df25ded755a2cf9651ea850d1abe429b1e4eb1
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -42,7 +42,7 @@ variable {I : Type u}
 variable {f : I → Type v}
 
 -- The family of types already equipped with instances
-variable (x y : ∀ i, f i) (i : I)
+variable (x y : ∀ i, f i) (i j : I)
 
 @[to_additive]
 theorem Set.preimage_one {α β : Type _} [One β] (s : Set β) [Decidable ((1 : β) ∈ s)] :
@@ -499,6 +499,26 @@ theorem Pi.single_mul [∀ i, MulZeroClass <| f i] (i : I) (x y : f i) :
   (MulHom.single f i).map_mul x y
 #align pi.single_mul Pi.single_mul
 
+theorem Pi.single_mul_left_apply [∀ i, MulZeroClass <| f i] (a : f i) :
+    Pi.single i (a * x i) j = Pi.single i a j * x j :=
+  (Pi.apply_single (fun i => (· * x i)) (fun _ => MulZeroClass.zero_mul _) _ _ _).symm
+#align pi.single_mul_left_apply Pi.single_mul_left_apply
+
+theorem Pi.single_mul_right_apply [∀ i, MulZeroClass <| f i] (a : f i) :
+    Pi.single i (x i * a) j = x j * Pi.single i a j :=
+  (Pi.apply_single (fun i => (· * ·) (x i)) (fun _ => MulZeroClass.mul_zero _) _ _ _).symm
+#align pi.single_mul_right_apply Pi.single_mul_right_apply
+
+theorem Pi.single_mul_left [∀ i, MulZeroClass <| f i] (a : f i) :
+    Pi.single i (a * x i) = Pi.single i a * x :=
+  funext fun _ => Pi.single_mul_left_apply _ _ _ _
+#align pi.single_mul_left Pi.single_mul_left
+
+theorem Pi.single_mul_right [∀ i, MulZeroClass <| f i] (a : f i) :
+    Pi.single i (x i * a) = x * Pi.single i a :=
+  funext fun _ => Pi.single_mul_right_apply _ _ _ _
+#align pi.single_mul_right Pi.single_mul_right
+
 /-- The injection into a pi group at different indices commutes.
 
 For injections of commuting elements at the same index, see `Commute.map` -/
@@ -665,3 +685,21 @@ noncomputable def Function.ExtendByOne.hom [MulOneClass R] :
 #align function.extend_by_zero.hom_apply Function.ExtendByZero.hom_apply
 
 end Extend
+
+namespace Pi
+
+variable [DecidableEq I] [∀ i, Preorder (f i)] [∀ i, One (f i)]
+
+@[to_additive]
+theorem mulSingle_mono : Monotone (Pi.mulSingle i : f i → ∀ i, f i) :=
+  Function.update_mono
+#align pi.mul_single_mono Pi.mulSingle_mono
+#align pi.single_mono Pi.single_mono
+
+@[to_additive]
+theorem mulSingle_strictMono : StrictMono (Pi.mulSingle i : f i → ∀ i, f i) :=
+  Function.update_strictMono
+#align pi.mul_single_strict_mono Pi.mulSingle_strictMono
+#align pi.single_strict_mono Pi.single_strictMono
+
+end Pi

--- a/Mathlib/Order/Basic.lean
+++ b/Mathlib/Order/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Mario Carneiro
 
 ! This file was ported from Lean 3 source module order.basic
-! leanprover-community/mathlib commit 210657c4ea4a4a7b234392f70a3a2a83346dfa90
+! leanprover-community/mathlib commit 90df25ded755a2cf9651ea850d1abe429b1e4eb1
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -877,6 +877,16 @@ theorem update_le_update_iff :
     Function.update x i a ≤ Function.update y i b ↔ a ≤ b ∧ ∀ (j) (_ : j ≠ i), x j ≤ y j := by
   simp (config := { contextual := true }) [update_le_iff]
 #align update_le_update_iff update_le_update_iff
+
+@[simp]
+theorem update_le_update_iff' : update x i a ≤ update x i b ↔ a ≤ b := by
+  simp [update_le_update_iff]
+#align update_le_update_iff' update_le_update_iff'
+
+@[simp]
+theorem update_lt_update_iff : update x i a < update x i b ↔ a < b :=
+  lt_iff_lt_of_le_iff_le' update_le_update_iff' update_le_update_iff'
+#align update_lt_update_iff update_lt_update_iff
 
 @[simp]
 theorem le_update_self_iff : x ≤ update x i a ↔ x i ≤ a := by simp [le_update_iff]

--- a/Mathlib/Order/Monotone/Basic.lean
+++ b/Mathlib/Order/Monotone/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Mario Carneiro, Yaël Dillies
 
 ! This file was ported from Lean 3 source module order.monotone.basic
-! leanprover-community/mathlib commit ac5a7cec422c3909db52e13dde2e729657d19b0e
+! leanprover-community/mathlib commit 90df25ded755a2cf9651ea850d1abe429b1e4eb1
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -70,7 +70,8 @@ open Function OrderDual
 
 universe u v w
 
-variable {α : Type u} {β : Type v} {γ : Type w} {δ : Type _} {r : α → α → Prop}
+variable {ι : Type _} {α : Type u} {β : Type v} {γ : Type w} {δ : Type _} {π : ι → Type _}
+  {r : α → α → Prop}
 
 section MonotoneDef
 
@@ -1184,9 +1185,18 @@ theorem StrictAnti.prod_map (hf : StrictAnti f) (hg : StrictAnti g) : StrictAnti
 
 end PartialOrder
 
+/-! ### Pi types -/
+
 namespace Function
 
-variable [Preorder α]
+variable [Preorder α] [DecidableEq ι] [∀ i, Preorder (π i)] {f : ∀ i, π i} {i : ι}
+
+-- porting note: Dot notation breaks in `f.update i`
+theorem update_mono : Monotone (update f i) := fun _ _ => update_le_update_iff'.2
+#align function.update_mono Function.update_mono
+
+theorem update_strictMono : StrictMono (update f i) := fun _ _ => update_lt_update_iff.2
+#align function.update_strict_mono Function.update_strictMono
 
 theorem const_mono : Monotone (const β : α → β → α) := fun _ _ h _ ↦ h
 #align function.const_mono Function.const_mono


### PR DESCRIPTION
Match leanprover-community/mathlib#6418 and leanprover-community/mathlib#18841

* [`order.basic`@`210657c4ea4a4a7b234392f70a3a2a83346dfa90`..`90df25ded755a2cf9651ea850d1abe429b1e4eb1`](https://leanprover-community.github.io/mathlib-port-status/file/order/basic?range=210657c4ea4a4a7b234392f70a3a2a83346dfa90..90df25ded755a2cf9651ea850d1abe429b1e4eb1)
* [`order.monotone.basic`@`ac5a7cec422c3909db52e13dde2e729657d19b0e`..`90df25ded755a2cf9651ea850d1abe429b1e4eb1`](https://leanprover-community.github.io/mathlib-port-status/file/order/monotone/basic?range=ac5a7cec422c3909db52e13dde2e729657d19b0e..90df25ded755a2cf9651ea850d1abe429b1e4eb1)
* [`algebra.group.pi`@`b3f25363ae62cb169e72cd6b8b1ac97bacf21ca7`..`90df25ded755a2cf9651ea850d1abe429b1e4eb1`](https://leanprover-community.github.io/mathlib-port-status/file/algebra/group/pi?range=b3f25363ae62cb169e72cd6b8b1ac97bacf21ca7..90df25ded755a2cf9651ea850d1abe429b1e4eb1)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
