### PR TITLE
[Merged by Bors] - chore: Generalise `ess_sup` lemmas

### DIFF
--- a/Mathlib/Order/Filter/ENNReal.lean
+++ b/Mathlib/Order/Filter/ENNReal.lean
@@ -8,7 +8,7 @@ Authors: Rémy Degenne
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
-import Mathbin.Topology.Instances.Ennreal
+import Mathlib.Topology.Instances.Ennreal
 
 /-!
 # Order properties of extended non-negative reals

--- a/Mathlib/Order/Filter/ENNReal.lean
+++ b/Mathlib/Order/Filter/ENNReal.lean
@@ -25,7 +25,7 @@ variable {α : Type _} {f : Filter α}
 
 theorem eventually_le_limsup [CountableInterFilter f] (u : α → ℝ≥0∞) :
     ∀ᶠ y in f, u y ≤ f.limsup u :=
-  eventually_le_limsup
+  _root_.eventually_le_limsup
 #align ennreal.eventually_le_limsup ENNReal.eventually_le_limsup
 
 theorem limsup_eq_zero_iff [CountableInterFilter f] {u : α → ℝ≥0∞} :

--- a/Mathlib/Order/Filter/ENNReal.lean
+++ b/Mathlib/Order/Filter/ENNReal.lean
@@ -4,13 +4,11 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Rémy Degenne
 
 ! This file was ported from Lean 3 source module order.filter.ennreal
-! leanprover-community/mathlib commit 57ac39bd365c2f80589a700f9fbb664d3a1a30c2
+! leanprover-community/mathlib commit 52932b3a083d4142e78a15dc928084a22fea9ba0
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
-import Mathlib.Data.Real.ENNReal
-import Mathlib.Order.Filter.CountableInter
-import Mathlib.Order.LiminfLimsup
+import Mathbin.Topology.Instances.Ennreal
 
 /-!
 # Order properties of extended non-negative reals
@@ -26,32 +24,13 @@ namespace ENNReal
 variable {α : Type _} {f : Filter α}
 
 theorem eventually_le_limsup [CountableInterFilter f] (u : α → ℝ≥0∞) :
-    ∀ᶠ y in f, u y ≤ f.limsup u := by
-  by_cases hx_top : f.limsup u = ⊤
-  · simp_rw [hx_top]
-    exact eventually_of_forall fun a => le_top
-  have h_forall_le : ∀ᶠ y in f, ∀ n : ℕ, u y < f.limsup u + (1 : ℝ≥0∞) / n
-  · rw [eventually_countable_forall]
-    refine' fun n => eventually_lt_of_limsup_lt _
-    nth_rw 1 [← add_zero (f.limsup u)]
-    exact (ENNReal.add_lt_add_iff_left hx_top).mpr (by simp)
-  refine h_forall_le.mono fun y hy => le_of_forall_pos_le_add fun r hr_pos _ => ?_
-  have hr_ne_zero : (r : ℝ≥0∞) ≠ 0
-  · rw [Ne.def, coe_eq_zero]
-    exact hr_pos.ne'
-  cases' exists_inv_nat_lt hr_ne_zero with i hi
-  rw [inv_eq_one_div] at hi
-  exact (hy i).le.trans (add_le_add_left hi.le (f.limsup u))
+    ∀ᶠ y in f, u y ≤ f.limsup u :=
+  eventually_le_limsup
 #align ennreal.eventually_le_limsup ENNReal.eventually_le_limsup
 
 theorem limsup_eq_zero_iff [CountableInterFilter f] {u : α → ℝ≥0∞} :
-    f.limsup u = 0 ↔ u =ᶠ[f] 0 := by
-  constructor <;> intro h
-  · have hu_zero :=
-      EventuallyLE.trans (eventually_le_limsup u) (eventually_of_forall fun _ => le_of_eq h)
-    exact hu_zero.mono fun x hx => le_antisymm hx (zero_le _)
-  · rw [limsup_congr h]
-    simp_rw [Pi.zero_apply, ← ENNReal.bot_eq_zero, limsup_const_bot]
+    f.limsup u = 0 ↔ u =ᶠ[f] 0 :=
+  limsup_eq_bot
 #align ennreal.limsup_eq_zero_iff ENNReal.limsup_eq_zero_iff
 
 theorem limsup_const_mul_of_ne_top {u : α → ℝ≥0∞} {a : ℝ≥0∞} (ha_top : a ≠ ⊤) :

--- a/Mathlib/Order/Filter/ENNReal.lean
+++ b/Mathlib/Order/Filter/ENNReal.lean
@@ -8,7 +8,7 @@ Authors: Rémy Degenne
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
-import Mathlib.Topology.Instances.Ennreal
+import Mathlib.Topology.Instances.ENNReal
 
 /-!
 # Order properties of extended non-negative reals

--- a/Mathlib/Topology/Algebra/Order/LiminfLimsup.lean
+++ b/Mathlib/Topology/Algebra/Order/LiminfLimsup.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro, Yury Kudryashov
 
 ! This file was ported from Lean 3 source module topology.algebra.order.liminf_limsup
-! leanprover-community/mathlib commit 98e83c3d541c77cdb7da20d79611a780ff8e7d90
+! leanprover-community/mathlib commit 52932b3a083d4142e78a15dc928084a22fea9ba0
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -13,6 +13,7 @@ import Mathlib.Algebra.BigOperators.Order
 import Mathlib.Algebra.IndicatorFunction
 import Mathlib.Order.LiminfLimsup
 import Mathlib.Order.Filter.Archimedean
+import Mathbin.Order.Filter.CountableInter
 import Mathlib.Topology.Order.Basic
 
 /-!
@@ -20,7 +21,7 @@ import Mathlib.Topology.Order.Basic
 -/
 
 
-open Filter
+open Filter TopologicalSpace
 
 open Topology Classical
 
@@ -252,7 +253,56 @@ theorem tendsto_of_no_upcrossings [DenselyOrdered α] {f : Filter β} {u : β �
   exact H a as b bs ab ⟨A, B⟩
 #align tendsto_of_no_upcrossings tendsto_of_no_upcrossings
 
+variable [FirstCountableTopology α] {f : Filter β} [CountableInterFilter f] {u : β → α}
+
+theorem eventually_le_limsup (hf : IsBoundedUnder (· ≤ ·) f u := by isBoundedDefault) :
+    ∀ᶠ b in f, u b ≤ f.limsup u := by
+  obtain ha | ha := isTop_or_exists_gt (f.limsup u)
+  · exact eventually_of_forall fun _ => ha _
+  by_cases H : IsGLB (Set.Ioi (f.limsup u)) (f.limsup u)
+  · obtain ⟨u, -, -, hua, hu⟩ := H.exists_seq_antitone_tendsto ha
+    have := fun n => eventually_lt_of_limsup_lt (hu n) hf
+    exact
+      (eventually_countable_forall.2 this).mono fun b hb =>
+        ge_of_tendsto hua <| eventually_of_forall fun n => (hb _).le
+  · obtain ⟨x, hx, xa⟩ : ∃ x, (∀ ⦃b⦄, f.limsup u < b → x ≤ b) ∧ f.limsup u < x :=
+      by
+      simp only [IsGLB, IsGreatest, lowerBounds, upperBounds, Set.mem_Ioi, Set.mem_setOf_eq,
+        not_and, not_forall, not_le, exists_prop] at H
+      exact H fun x hx => le_of_lt hx
+    filter_upwards [eventually_lt_of_limsup_lt xa hf]with y hy
+    contrapose! hy
+    exact hx hy
+#align eventually_le_limsup eventually_le_limsup
+
+theorem eventually_liminf_le (hf : IsBoundedUnder (· ≥ ·) f u := by isBoundedDefault) :
+    ∀ᶠ b in f, f.liminf u ≤ u b :=
+  @eventually_le_limsup αᵒᵈ _ _ _ _ _ _ _ _ hf
+#align eventually_liminf_le eventually_liminf_le
+
 end ConditionallyCompleteLinearOrder
+
+section CompleteLinearOrder
+
+variable [CompleteLinearOrder α] [TopologicalSpace α] [FirstCountableTopology α] [OrderTopology α]
+  {f : Filter β} [CountableInterFilter f] {u : β → α}
+
+@[simp]
+theorem limsup_eq_bot : f.limsup u = ⊥ ↔ u =ᶠ[f] ⊥ :=
+  ⟨fun h =>
+    (EventuallyLE.trans eventually_le_limsup <| eventually_of_forall fun _ => h.le).mono fun x hx =>
+      le_antisymm hx bot_le,
+    fun h => by
+    rw [limsup_congr h]
+    exact limsup_const_bot⟩
+#align limsup_eq_bot limsup_eq_bot
+
+@[simp]
+theorem liminf_eq_top : f.liminf u = ⊤ ↔ u =ᶠ[f] ⊤ :=
+  @limsup_eq_bot αᵒᵈ _ _ _ _ _ _ _ _
+#align liminf_eq_top liminf_eq_top
+
+end CompleteLinearOrder
 
 end LiminfLimsup
 

--- a/Mathlib/Topology/Algebra/Order/LiminfLimsup.lean
+++ b/Mathlib/Topology/Algebra/Order/LiminfLimsup.lean
@@ -13,7 +13,7 @@ import Mathlib.Algebra.BigOperators.Order
 import Mathlib.Algebra.IndicatorFunction
 import Mathlib.Order.LiminfLimsup
 import Mathlib.Order.Filter.Archimedean
-import Mathbin.Order.Filter.CountableInter
+import Mathlib.Order.Filter.CountableInter
 import Mathlib.Topology.Order.Basic
 
 /-!
@@ -265,12 +265,11 @@ theorem eventually_le_limsup (hf : IsBoundedUnder (· ≤ ·) f u := by isBounde
     exact
       (eventually_countable_forall.2 this).mono fun b hb =>
         ge_of_tendsto hua <| eventually_of_forall fun n => (hb _).le
-  · obtain ⟨x, hx, xa⟩ : ∃ x, (∀ ⦃b⦄, f.limsup u < b → x ≤ b) ∧ f.limsup u < x :=
-      by
+  · obtain ⟨x, hx, xa⟩ : ∃ x, (∀ ⦃b⦄, f.limsup u < b → x ≤ b) ∧ f.limsup u < x := by
       simp only [IsGLB, IsGreatest, lowerBounds, upperBounds, Set.mem_Ioi, Set.mem_setOf_eq,
         not_and, not_forall, not_le, exists_prop] at H
-      exact H fun x hx => le_of_lt hx
-    filter_upwards [eventually_lt_of_limsup_lt xa hf]with y hy
+      exact H fun x => le_of_lt
+    filter_upwards [eventually_lt_of_limsup_lt xa hf] with y hy
     contrapose! hy
     exact hx hy
 #align eventually_le_limsup eventually_le_limsup


### PR DESCRIPTION
Match https://github.com/leanprover-community/mathlib/pull/18669

* [`order.filter.ennreal`@`57ac39bd365c2f80589a700f9fbb664d3a1a30c2`..`52932b3a083d4142e78a15dc928084a22fea9ba0`](https://leanprover-community.github.io/mathlib-port-status/file/order/filter/ennreal?range=57ac39bd365c2f80589a700f9fbb664d3a1a30c2..52932b3a083d4142e78a15dc928084a22fea9ba0)
* [`topology.algebra.order.liminf_limsup`@`98e83c3d541c77cdb7da20d79611a780ff8e7d90`..`52932b3a083d4142e78a15dc928084a22fea9ba0`](https://leanprover-community.github.io/mathlib-port-status/file/topology/algebra/order/liminf_limsup?range=98e83c3d541c77cdb7da20d79611a780ff8e7d90..52932b3a083d4142e78a15dc928084a22fea9ba0)


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
