### PR TITLE
[Merged by Bors] - chore: port missing instance priorities

### DIFF
--- a/Mathlib/Algebra/AddTorsor.lean
+++ b/Mathlib/Algebra/AddTorsor.lean
@@ -57,7 +57,7 @@ class AddTorsor (G : outParam (Type _)) (P : Type _) [outParam <| AddGroup G] ex
   vadd_vsub' : ∀ (g : G) (p : P), g +ᵥ p -ᵥ p = g
 #align add_torsor AddTorsor
 
-attribute [instance] AddTorsor.Nonempty -- porting note: removers `nolint instance_priority`
+attribute [instance 100] AddTorsor.Nonempty -- porting note: removers `nolint instance_priority`
 
 --Porting note: removed
 --attribute [nolint dangerous_instance] AddTorsor.toVSub

--- a/Mathlib/CategoryTheory/Abelian/Basic.lean
+++ b/Mathlib/CategoryTheory/Abelian/Basic.lean
@@ -115,9 +115,8 @@ class Abelian extends Preadditive C, NormalMonoCategory C, NormalEpiCategory C w
   [has_cokernels : HasCokernels C]
 #align category_theory.abelian CategoryTheory.Abelian
 
-attribute [instance] Abelian.has_finite_products
-
-attribute [instance] Abelian.has_kernels Abelian.has_cokernels
+attribute [instance 100] Abelian.has_finite_products
+attribute [instance 90] Abelian.has_kernels Abelian.has_cokernels
 
 end CategoryTheory
 

--- a/Mathlib/CategoryTheory/Closed/Monoidal.lean
+++ b/Mathlib/CategoryTheory/Closed/Monoidal.lean
@@ -45,7 +45,7 @@ class MonoidalClosed (C : Type u) [Category.{v} C] [MonoidalCategory.{v} C] wher
   closed : ∀ X : C, Closed X
 #align category_theory.monoidal_closed CategoryTheory.MonoidalClosed
 
-attribute [instance] MonoidalClosed.closed
+attribute [instance 100] MonoidalClosed.closed
 
 variable {C : Type u} [Category.{v} C] [MonoidalCategory.{v} C]
 

--- a/Mathlib/CategoryTheory/ConnectedComponents.lean
+++ b/Mathlib/CategoryTheory/ConnectedComponents.lean
@@ -34,7 +34,7 @@ open CategoryTheory.Category
 
 namespace CategoryTheory
 
-attribute [instance] IsConnected.is_nonempty
+attribute [instance 100] IsConnected.is_nonempty
 
 variable {J : Type u₁} [Category.{v₁} J]
 

--- a/Mathlib/CategoryTheory/IsConnected.lean
+++ b/Mathlib/CategoryTheory/IsConnected.lean
@@ -81,7 +81,7 @@ class IsConnected (J : Type u₁) [Category.{v₁} J] extends IsPreconnected J :
   [is_nonempty : Nonempty J]
 #align category_theory.is_connected CategoryTheory.IsConnected
 
-attribute [instance] IsConnected.is_nonempty
+attribute [instance 100] IsConnected.is_nonempty
 
 variable {J : Type u₁} [Category.{v₁} J]
 

--- a/Mathlib/CategoryTheory/Limits/Creates.lean
+++ b/Mathlib/CategoryTheory/Limits/Creates.lean
@@ -131,7 +131,8 @@ abbrev CreatesColimits (F : C ⥤ D) :=
   CreatesColimitsOfSize.{v₂, v₂} F
 #align category_theory.creates_colimits CategoryTheory.CreatesColimits
 
-attribute [instance] CreatesLimitsOfShape.CreatesLimit CreatesLimitsOfSize.CreatesLimitsOfShape
+-- see Note [lower instance priority]
+attribute [instance 100] CreatesLimitsOfShape.CreatesLimit CreatesLimitsOfSize.CreatesLimitsOfShape
   CreatesColimitsOfShape.CreatesColimit CreatesColimitsOfSize.CreatesColimitsOfShape
 
 -- see Note [lower instance priority]

--- a/Mathlib/CategoryTheory/Limits/Preserves/Basic.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Basic.lean
@@ -113,7 +113,8 @@ abbrev PreservesColimits (F : C ⥤ D) :=
   PreservesColimitsOfSize.{v₂, v₂} F
 #align category_theory.limits.preserves_colimits CategoryTheory.Limits.PreservesColimits
 
-attribute [instance]
+-- see Note [lower instance priority]
+attribute [instance 100]
   PreservesLimitsOfShape.preservesLimit PreservesLimitsOfSize.preservesLimitsOfShape
   PreservesColimitsOfShape.preservesColimit
   PreservesColimitsOfSize.preservesColimitsOfShape

--- a/Mathlib/CategoryTheory/Limits/Preserves/Filtered.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Filtered.lean
@@ -47,7 +47,7 @@ class PreservesFilteredColimits (F : C ⥤ D) : Type max u₁ u₂ (v + 1) where
     ∀ (J : Type v) [SmallCategory J] [IsFiltered J], PreservesColimitsOfShape J F
 #align category_theory.limits.preserves_filtered_colimits CategoryTheory.Limits.PreservesFilteredColimits
 
-attribute [instance] PreservesFilteredColimits.preserves_filtered_colimits
+attribute [instance 100] PreservesFilteredColimits.preserves_filtered_colimits
 
 instance (priority := 100) PreservesColimits.preservesFilteredColimits (F : C ⥤ D)
     [PreservesColimits F] : PreservesFilteredColimits F
@@ -67,7 +67,7 @@ class PreservesCofilteredLimits (F : C ⥤ D) : Type max u₁ u₂ (v + 1) where
     ∀ (J : Type v) [SmallCategory J] [IsCofiltered J], PreservesLimitsOfShape J F
 #align category_theory.limits.preserves_cofiltered_limits CategoryTheory.Limits.PreservesCofilteredLimits
 
-attribute [instance] PreservesCofilteredLimits.preserves_cofiltered_limits
+attribute [instance 100] PreservesCofilteredLimits.preserves_cofiltered_limits
 
 instance (priority := 100) PreservesLimits.preservesCofilteredLimits (F : C ⥤ D)
     [PreservesLimits F] : PreservesCofilteredLimits F

--- a/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Biproducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Biproducts.lean
@@ -124,7 +124,7 @@ class PreservesBiproductsOfShape (F : C ⥤ D) [PreservesZeroMorphisms F] where
 
 attribute [inherit_doc PreservesBiproductsOfShape] PreservesBiproductsOfShape.preserves
 
-attribute [instance] PreservesBiproductsOfShape.preserves
+attribute [instance 100] PreservesBiproductsOfShape.preserves
 
 end Bicone
 
@@ -136,7 +136,7 @@ class PreservesFiniteBiproducts (F : C ⥤ D) [PreservesZeroMorphisms F] where
 
 attribute [inherit_doc PreservesFiniteBiproducts] PreservesFiniteBiproducts.preserves
 
-attribute [instance] PreservesFiniteBiproducts.preserves
+attribute [instance 100] PreservesFiniteBiproducts.preserves
 
 /-- A functor `F` preserves biproducts if it preserves biproducts of any shape `J` of size `w`.
     The usual notion of preservation of biproducts is recovered by choosing `w` to be the universe
@@ -147,7 +147,7 @@ class PreservesBiproducts (F : C ⥤ D) [PreservesZeroMorphisms F] where
 
 attribute [inherit_doc PreservesBiproducts] PreservesBiproducts.preserves
 
-attribute [instance] PreservesBiproducts.preserves
+attribute [instance 100] PreservesBiproducts.preserves
 
 /-- Preserving biproducts at a bigger universe level implies preserving biproducts at a
 smaller universe level. -/
@@ -213,7 +213,7 @@ def preservesBinaryBiproductsOfPreservesBiproducts (F : C ⥤ D) [PreservesZeroM
   preserves {X} Y := preservesBinaryBiproductOfPreservesBiproduct F X Y
 #align category_theory.limits.preserves_binary_biproducts_of_preserves_biproducts CategoryTheory.Limits.preservesBinaryBiproductsOfPreservesBiproducts
 
-attribute [instance] PreservesBinaryBiproducts.preserves
+attribute [instance 100] PreservesBinaryBiproducts.preserves
 
 end Limits
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/Biproducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Biproducts.lean
@@ -319,7 +319,7 @@ class HasBiproductsOfShape : Prop where
   has_biproduct : ∀ F : J → C, HasBiproduct F
 #align category_theory.limits.has_biproducts_of_shape CategoryTheory.Limits.HasBiproductsOfShape
 
-attribute [instance] HasBiproductsOfShape.has_biproduct
+attribute [instance 100] HasBiproductsOfShape.has_biproduct
 
 /-- `HasFiniteBiproducts C` represents a choice of biproduct for every family of objects in `C`
 indexed by a finite type. -/
@@ -1227,7 +1227,7 @@ class HasBinaryBiproducts : Prop where
   has_binary_biproduct : ∀ P Q : C, HasBinaryBiproduct P Q
 #align category_theory.limits.has_binary_biproducts CategoryTheory.Limits.HasBinaryBiproducts
 
-attribute [instance] HasBinaryBiproducts.has_binary_biproduct
+attribute [instance 100] HasBinaryBiproducts.has_binary_biproduct
 
 /-- A category with finite biproducts has binary biproducts.
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/DisjointCoproduct.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/DisjointCoproduct.lean
@@ -120,7 +120,7 @@ class CoproductsDisjoint (C : Type u) [Category.{v} C] where
   CoproductDisjoint : ∀ X Y : C, CoproductDisjoint X Y
 #align category_theory.limits.coproducts_disjoint CategoryTheory.Limits.CoproductsDisjoint
 
-attribute [instance] CoproductsDisjoint.CoproductDisjoint
+attribute [instance 999] CoproductsDisjoint.CoproductDisjoint
 
 /-- If `C` has disjoint coproducts, any morphism out of initial is mono. Note it isn't true in
 general that `C` has strict initial objects, for instance consider the category of types and

--- a/Mathlib/CategoryTheory/Limits/Shapes/Images.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Images.lean
@@ -410,7 +410,7 @@ class HasImages : Prop where
 
 attribute [inherit_doc HasImages] HasImages.has_image
 
-attribute [instance] HasImages.has_image
+attribute [instance 100] HasImages.has_image
 
 end
 
@@ -857,7 +857,7 @@ class HasImageMaps where
   has_image_map : ∀ {f g : Arrow C} (st : f ⟶ g), HasImageMap st
 #align category_theory.limits.has_image_maps CategoryTheory.Limits.HasImageMaps
 
-attribute [instance] HasImageMaps.has_image_map
+attribute [instance 100] HasImageMaps.has_image_map
 
 end
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/Kernels.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Kernels.lean
@@ -1130,7 +1130,7 @@ class HasCokernels : Prop where
   has_colimit : ∀ {X Y : C} (f : X ⟶ Y), HasCokernel f := by infer_instance
 #align category_theory.limits.has_cokernels CategoryTheory.Limits.HasCokernels
 
-attribute [instance] HasKernels.has_limit HasCokernels.has_colimit
+attribute [instance 100] HasKernels.has_limit HasCokernels.has_colimit
 
 instance (priority := 100) hasKernels_of_hasEqualizers [HasEqualizers C] : HasKernels C where
 #align category_theory.limits.has_kernels_of_has_equalizers CategoryTheory.Limits.hasKernels_of_hasEqualizers

--- a/Mathlib/CategoryTheory/Limits/Shapes/Reflexive.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Reflexive.lean
@@ -148,9 +148,9 @@ class HasCoreflexiveEqualizers : Prop where
   has_eq : ∀ ⦃A B : C⦄ (f g : A ⟶ B) [IsCoreflexivePair f g], HasEqualizer f g
 #align category_theory.limits.has_coreflexive_equalizers CategoryTheory.Limits.HasCoreflexiveEqualizers
 
-attribute [instance] HasReflexiveCoequalizers.has_coeq
+attribute [instance 1] HasReflexiveCoequalizers.has_coeq
 
-attribute [instance] HasCoreflexiveEqualizers.has_eq
+attribute [instance 1] HasCoreflexiveEqualizers.has_eq
 
 theorem hasCoequalizer_of_common_section [HasReflexiveCoequalizers C] {A B : C} {f g : A ⟶ B}
     (r : B ⟶ A) (rf : r ≫ f = 𝟙 _) (rg : r ≫ g = 𝟙 _) : HasCoequalizer f g := by

--- a/Mathlib/CategoryTheory/Limits/Shapes/StrongEpi.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/StrongEpi.lean
@@ -82,9 +82,9 @@ theorem StrongMono.mk' {f : P ⟶ Q} [Mono f]
   rlp := fun {X Y} z hz => ⟨fun {u v} sq => hf X Y z hz u v sq⟩
 #align category_theory.strong_mono.mk' CategoryTheory.StrongMono.mk'
 
-attribute [instance] StrongEpi.llp
+attribute [instance 100] StrongEpi.llp
 
-attribute [instance] StrongMono.rlp
+attribute [instance 100] StrongMono.rlp
 
 instance (priority := 100) epi_of_strongEpi (f : P ⟶ Q) [StrongEpi f] : Epi f :=
   StrongEpi.epi
@@ -246,4 +246,3 @@ instance (priority := 100) balanced_of_strongMonoCategory [StrongMonoCategory C]
 end
 
 end CategoryTheory
-

--- a/Mathlib/Data/FinEnum.lean
+++ b/Mathlib/Data/FinEnum.lean
@@ -36,7 +36,7 @@ class FinEnum (α : Sort _) where
   [decEq : DecidableEq α]
 #align fin_enum FinEnum
 
-attribute [instance] FinEnum.decEq
+attribute [instance 100] FinEnum.decEq
 
 namespace FinEnum
 

--- a/Mathlib/Topology/Connected.lean
+++ b/Mathlib/Topology/Connected.lean
@@ -744,7 +744,7 @@ class ConnectedSpace (α : Type u) [TopologicalSpace α] extends PreconnectedSpa
   toNonempty : Nonempty α
 #align connected_space ConnectedSpace
 
-attribute [instance] ConnectedSpace.toNonempty
+attribute [instance 50] ConnectedSpace.toNonempty  -- see Note [lower instance priority]
 
 -- see Note [lower instance priority]
 theorem isConnected_univ [ConnectedSpace α] : IsConnected (univ : Set α) :=

--- a/Mathlib/Topology/SubsetProperties.lean
+++ b/Mathlib/Topology/SubsetProperties.lean
@@ -1782,7 +1782,7 @@ class IrreducibleSpace (α : Type u) [TopologicalSpace α] extends Preirreducibl
 #align irreducible_space IrreducibleSpace
 
 -- see Note [lower instance priority]
-attribute [instance] IrreducibleSpace.toNonempty
+attribute [instance 50] IrreducibleSpace.toNonempty
 
 theorem IrreducibleSpace.isIrreducible_univ (α : Type u) [TopologicalSpace α] [IrreducibleSpace α] :
     IsIrreducible (univ : Set α) :=


### PR DESCRIPTION
See discussion at https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/mathport.20drops.20priorities.20in.20.60attribute.20.5Binstance.5D.60. `mathport` has been dropping the priorities on instances when using the `attribute` command.

This PR adds back all the priorities, except for `local attribute`, and instances involving coercions, which I didn't want to mess with.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
