### PR TITLE
[Merged by Bors] - fix: make `apply_fun` instantiate metavariables when analyzing expression

### DIFF
--- a/test/apply_fun.lean
+++ b/test/apply_fun.lean
@@ -220,3 +220,15 @@ example (α β : Type u) [Fintype α] [Fintype β] (h : α = β) : True := by
   apply_fun Fintype.card at h
   guard_hyp h : Fintype.card α = Fintype.card β
   trivial
+
+-- Check that metavariables in the goal do not prevent apply_fun from detecting the relation
+example (f : α ≃ β) (x y : α) (h : f x = f y) : x = y := by
+  change _
+  -- now the goal is a metavariable
+  apply_fun f
+  exact h
+
+-- Check that lack of WHNF does not prevent apply_fun_from detecting the relation
+example (f : α ≃ β) (x y : α) (h : f x = f y) : (fun s => s) (x = y) := by
+  apply_fun f
+  exact h


### PR DESCRIPTION
`apply_fun` would erroneously raise an error when the goal is a metavariable, rather than instantiating it. Now it instantiates it and puts the goal into weak head normal form with reducible transparancy.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
