### PR TITLE
[Merged by Bors] - fix: add missing `_root_`

### DIFF
--- a/Mathlib/Algebra/Algebra/Bilinear.lean
+++ b/Mathlib/Algebra/Algebra/Bilinear.lean
@@ -117,7 +117,7 @@ variable (R A : Type _) [CommSemiring R] [NonUnitalSemiring A] [Module R A] [SMu
 /-- The multiplication in a non-unital algebra is a bilinear map.
 
 A weaker version of this for non-unital non-associative algebras exists as `LinearMap.mul`. -/
-def NonUnitalAlgHom.lmul : A →ₙₐ[R] End R A :=
+def _root_.NonUnitalAlgHom.lmul : A →ₙₐ[R] End R A :=
   { mul R A with
     map_mul' := by
       intro a b
@@ -126,14 +126,14 @@ def NonUnitalAlgHom.lmul : A →ₙₐ[R] End R A :=
     map_zero' := by
       ext a
       exact zero_mul a }
-#align non_unital_alg_hom.lmul LinearMap.NonUnitalAlgHom.lmul
+#align non_unital_alg_hom.lmul NonUnitalAlgHom.lmul
 
 variable {R A}
 
 @[simp]
-theorem NonUnitalAlgHom.coe_lmul_eq_mul : ⇑(NonUnitalAlgHom.lmul R A) = mul R A :=
+theorem _root_.NonUnitalAlgHom.coe_lmul_eq_mul : ⇑(NonUnitalAlgHom.lmul R A) = mul R A :=
   rfl
-#align non_unital_alg_hom.coe_lmul_eq_mul LinearMap.NonUnitalAlgHom.coe_lmul_eq_mul
+#align non_unital_alg_hom.coe_lmul_eq_mul NonUnitalAlgHom.coe_lmul_eq_mul
 
 theorem commute_mulLeft_right (a b : A) : Commute (mulLeft R a) (mulRight R b) := by
   ext c
@@ -162,7 +162,7 @@ variable (R A : Type _) [CommSemiring R] [Semiring A] [Algebra R A]
 the algebra.
 
 A weaker version of this for non-unital algebras exists as `NonUnitalAlgHom.mul`. -/
-def Algebra.lmul : A →ₐ[R] End R A :=
+def _root_.Algebra.lmul : A →ₐ[R] End R A :=
   { LinearMap.mul R A with
     map_one' := by
       ext a
@@ -178,14 +178,14 @@ def Algebra.lmul : A →ₐ[R] End R A :=
       intro r
       ext a
       exact (Algebra.smul_def r a).symm }
-#align algebra.lmul LinearMap.Algebra.lmul
+#align algebra.lmul Algebra.lmul
 
 variable {R A}
 
 @[simp]
-theorem Algebra.coe_lmul_eq_mul : ⇑(Algebra.lmul R A) = mul R A :=
+theorem _root_.Algebra.coe_lmul_eq_mul : ⇑(Algebra.lmul R A) = mul R A :=
   rfl
-#align algebra.coe_lmul_eq_mul LinearMap.Algebra.coe_lmul_eq_mul
+#align algebra.coe_lmul_eq_mul Algebra.coe_lmul_eq_mul
 
 @[simp]
 theorem mulLeft_eq_zero_iff (a : A) : mulLeft R a = 0 ↔ a = 0 := by

--- a/Mathlib/Algebra/Algebra/Operations.lean
+++ b/Mathlib/Algebra/Algebra/Operations.lean
@@ -258,7 +258,7 @@ theorem sup_mul : (M ⊔ N) * P = M * P ⊔ N * P :=
 #align submodule.sup_mul Submodule.sup_mul
 
 theorem mul_subset_mul : (↑M : Set A) * (↑N : Set A) ⊆ (↑(M * N) : Set A) :=
-  image2_subset_map₂ (LinearMap.Algebra.lmul R A).toLinearMap M N
+  image2_subset_map₂ (Algebra.lmul R A).toLinearMap M N
 #align submodule.mul_subset_mul Submodule.mul_subset_mul
 
 protected theorem map_mul {A'} [Semiring A'] [Algebra R A'] (f : A →ₐ[R] A') :

--- a/Mathlib/Algebra/Algebra/Subalgebra/Tower.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Tower.lean
@@ -46,8 +46,7 @@ variable [AddCommMonoid M] [Module R M] [Module A M] [IsScalarTower R A M]
 
 variable {A}
 
-theorem lmul_algebraMap (x : R) :
-    LinearMap.Algebra.lmul R A (algebraMap R A x) = Algebra.lsmul R A x :=
+theorem lmul_algebraMap (x : R) : Algebra.lmul R A (algebraMap R A x) = Algebra.lsmul R A x :=
   Eq.symm <| LinearMap.ext <| smul_def x
 #align algebra.lmul_algebra_map Algebra.lmul_algebraMap
 

--- a/Mathlib/Algebra/Algebra/Tower.lean
+++ b/Mathlib/Algebra/Algebra/Tower.lean
@@ -137,7 +137,8 @@ theorem coe_toAlgHom' : (toAlgHom R S A : S → A) = algebraMap S A := rfl
 variable {R S A B}
 
 @[simp]
-theorem _root_.AlgHom.map_algebraMap (f : A →ₐ[S] B) (r : R) : f (algebraMap R A r) = algebraMap R B r :=
+theorem _root_.AlgHom.map_algebraMap (f : A →ₐ[S] B) (r : R) :
+    f (algebraMap R A r) = algebraMap R B r :=
   by rw [algebraMap_apply R S A r, f.commutes, ← algebraMap_apply R S B]
 #align alg_hom.map_algebra_map AlgHom.map_algebraMap
 

--- a/Mathlib/Algebra/Algebra/Tower.lean
+++ b/Mathlib/Algebra/Algebra/Tower.lean
@@ -137,17 +137,17 @@ theorem coe_toAlgHom' : (toAlgHom R S A : S → A) = algebraMap S A := rfl
 variable {R S A B}
 
 @[simp]
-theorem AlgHom.map_algebraMap (f : A →ₐ[S] B) (r : R) : f (algebraMap R A r) = algebraMap R B r :=
+theorem _root_.AlgHom.map_algebraMap (f : A →ₐ[S] B) (r : R) : f (algebraMap R A r) = algebraMap R B r :=
   by rw [algebraMap_apply R S A r, f.commutes, ← algebraMap_apply R S B]
-#align alg_hom.map_algebra_map IsScalarTower.AlgHom.map_algebraMap
+#align alg_hom.map_algebra_map AlgHom.map_algebraMap
 
 variable (R)
 
 @[simp]
-theorem AlgHom.comp_algebraMap_of_tower (f : A →ₐ[S] B) :
+theorem _root_.AlgHom.comp_algebraMap_of_tower (f : A →ₐ[S] B) :
     (f : A →+* B).comp (algebraMap R A) = algebraMap R B :=
-  RingHom.ext (map_algebraMap f)
-#align alg_hom.comp_algebra_map_of_tower IsScalarTower.AlgHom.comp_algebraMap_of_tower
+  RingHom.ext (AlgHom.map_algebraMap f)
+#align alg_hom.comp_algebra_map_of_tower AlgHom.comp_algebraMap_of_tower
 
 -- conflicts with IsScalarTower.Subalgebra
 instance (priority := 999) subsemiring (U : Subsemiring S) : IsScalarTower U S A :=

--- a/Mathlib/Algebra/Group/ULift.lean
+++ b/Mathlib/Algebra/Group/ULift.lean
@@ -101,11 +101,10 @@ theorem pow_down [Pow α β] (a : ULift.{v} α) (b : β) : (a ^ b).down = a.down
 
 /-- The multiplicative equivalence between `ULift α` and `α`.
 -/
--- porting note: below errors: to_additive: can't transport `ULift.MulEquiv.ulift` to itself.
--- @[to_additive "The additive equivalence between `ULift α` and `α`."]
-def MulEquiv.ulift [Mul α] : ULift α ≃* α :=
+@[to_additive "The additive equivalence between `ULift α` and `α`."]
+def _root_.MulEquiv.ulift [Mul α] : ULift α ≃* α :=
   { Equiv.ulift with map_mul' := fun _ _ => rfl }
-#align mul_equiv.ulift ULift.MulEquiv.ulift
+#align mul_equiv.ulift MulEquiv.ulift
 
 -- porting notes: below failed due to error above, manually added
 --@[to_additive]

--- a/Mathlib/Algebra/Group/Units.lean
+++ b/Mathlib/Algebra/Group/Units.lean
@@ -164,7 +164,7 @@ attribute [instance] AddUnits.instDecidableEqAddUnits
 theorem mk_val (u : αˣ) (y h₁ h₂) : mk (u : α) y h₁ h₂ = u :=
   ext rfl
 #align units.mk_coe Units.mk_val
-#align add_units.mk_coe Units.mk_val
+#align add_units.mk_coe AddUnits.mk_val
 
 /-- Copy a unit, adjusting definition equalities. -/
 @[to_additive (attr := simps) "Copy an `AddUnit`, adjusting definitional equalities."]

--- a/Mathlib/Algebra/GroupPower/Lemmas.lean
+++ b/Mathlib/Algebra/GroupPower/Lemmas.lean
@@ -71,7 +71,6 @@ def Units.ofPow (u : Mˣ) (x : M) {n : ℕ} (hn : n ≠ 0) (hu : x ^ n = u) : M�
     (by rwa [← _root_.pow_succ, Nat.sub_add_cancel (Nat.succ_le_of_lt <| Nat.pos_of_ne_zero hn)])
     (Commute.self_pow _ _)
 #align units.of_pow Units.ofPow
-#align units.of_nsmul AddUnits.ofNSMul
 #align add_units.of_nsmul AddUnits.ofNSMul
 
 @[to_additive (attr := simp)]

--- a/Mathlib/Algebra/Hom/Equiv/Units/GroupWithZero.lean
+++ b/Mathlib/Algebra/Hom/Equiv/Units/GroupWithZero.lean
@@ -33,9 +33,9 @@ protected def mulLeft₀ (a : G) (ha : a ≠ 0) : Perm G :=
 #align equiv.mul_left₀_symm_apply Equiv.mulLeft₀_symm_apply
 #align equiv.mul_left₀_apply Equiv.mulLeft₀_apply
 
-theorem mulLeft_bijective₀ (a : G) (ha : a ≠ 0) : Function.Bijective ((· * ·) a : G → G) :=
+theorem _root_.mulLeft_bijective₀ (a : G) (ha : a ≠ 0) : Function.Bijective ((· * ·) a : G → G) :=
   (Equiv.mulLeft₀ a ha).bijective
-#align mul_left_bijective₀ Equiv.mulLeft_bijective₀
+#align mul_left_bijective₀ mulLeft_bijective₀
 
 /-- Right multiplication by a nonzero element in a `GroupWithZero` is a permutation of the
 underlying type. -/
@@ -46,9 +46,9 @@ protected def mulRight₀ (a : G) (ha : a ≠ 0) : Perm G :=
 #align equiv.mul_right₀_symm_apply Equiv.mulRight₀_symm_apply
 #align equiv.mul_right₀_apply Equiv.mulRight₀_apply
 
-theorem mulRight_bijective₀ (a : G) (ha : a ≠ 0) : Function.Bijective ((· * a) : G → G) :=
+theorem _root_.mulRight_bijective₀ (a : G) (ha : a ≠ 0) : Function.Bijective ((· * a) : G → G) :=
   (Equiv.mulRight₀ a ha).bijective
-#align mul_right_bijective₀ Equiv.mulRight_bijective₀
+#align mul_right_bijective₀ mulRight_bijective₀
 
 end GroupWithZero
 

--- a/Mathlib/Algebra/Hom/Iterate.lean
+++ b/Mathlib/Algebra/Hom/Iterate.lean
@@ -252,13 +252,13 @@ theorem Commute.function_commute_mul_left (h : _root_.Commute a b) :
 theorem SemiconjBy.function_semiconj_mul_right_swap (h : SemiconjBy a b c) :
     Function.Semiconj (· * a) (· * c) (· * b) := fun j => by simp_rw [mul_assoc, ← h.eq]
 #align semiconj_by.function_semiconj_mul_right_swap SemiconjBy.function_semiconj_mul_right_swap
-#align add_semiconj_by.function_semiconj_add_right_swap  SemiconjBy.function_semiconj_mul_right_swap
+#align add_semiconj_by.function_semiconj_add_right_swap AddSemiconjBy.function_semiconj_add_right_swap
 
 @[to_additive]
 theorem Commute.function_commute_mul_right (h : _root_.Commute a b) :
   Function.Commute (· * a) (· * b) :=
   SemiconjBy.function_semiconj_mul_right_swap h
 #align commute.function_commute_mul_right Commute.function_commute_mul_right
-#align add_commute.function_commute_add_right  AddCommute.function_commute_add_right
+#align add_commute.function_commute_add_right AddCommute.function_commute_add_right
 
 end Semigroup

--- a/Mathlib/Algebra/Module/Pi.lean
+++ b/Mathlib/Algebra/Module/Pi.lean
@@ -32,10 +32,10 @@ variable (x y : ∀ i, f i) (i : I)
 
 namespace Pi
 
-theorem IsSMulRegular.pi {α : Type _} [∀ i, SMul α <| f i] {k : α}
+theorem _root_.IsSMulRegular.pi {α : Type _} [∀ i, SMul α <| f i] {k : α}
     (hk : ∀ i, IsSMulRegular (f i) k) : IsSMulRegular (∀ i, f i) k := fun _ _ h =>
   funext fun i => hk i (congr_fun h i : _)
-#align is_smul_regular.pi Pi.IsSMulRegular.pi
+#align is_smul_regular.pi IsSMulRegular.pi
 
 instance smulWithZero (α) [Zero α] [∀ i, Zero (f i)] [∀ i, SMulWithZero α (f i)] :
     SMulWithZero α (∀ i, f i) :=

--- a/Mathlib/Data/Matrix/Basic.lean
+++ b/Mathlib/Data/Matrix/Basic.lean
@@ -382,7 +382,7 @@ theorem map_op_smul' [Mul α] [Mul β] (f : α → β) (r : α) (A : Matrix n n 
 
 theorem _root_.IsSMulRegular.matrix [SMul R S] {k : R} (hk : IsSMulRegular S k) :
     IsSMulRegular (Matrix m n S) k :=
-  Pi.IsSMulRegular.pi fun _ => Pi.IsSMulRegular.pi fun _ => hk
+  IsSMulRegular.pi fun _ => IsSMulRegular.pi fun _ => hk
 #align is_smul_regular.matrix IsSMulRegular.matrix
 
 theorem _root_.IsLeftRegular.matrix [Mul α] {k : α} (hk : IsLeftRegular k) :

--- a/Mathlib/Data/Nat/Lattice.lean
+++ b/Mathlib/Data/Nat/Lattice.lean
@@ -41,11 +41,11 @@ theorem supₛ_def {s : Set ℕ} (h : ∃ n, ∀ a ∈ s, a ≤ n) :
   dif_pos _
 #align nat.Sup_def Nat.supₛ_def
 
-theorem Set.Infinite.Nat.supₛ_eq_zero {s : Set ℕ} (h : s.Infinite) : supₛ s = 0 :=
+theorem _root_.Set.Infinite.Nat.supₛ_eq_zero {s : Set ℕ} (h : s.Infinite) : supₛ s = 0 :=
   dif_neg fun ⟨n, hn⟩ ↦
     let ⟨k, hks, hk⟩ := h.exists_nat_lt n
     (hn k hks).not_lt hk
-#align set.infinite.nat.Sup_eq_zero Nat.Set.Infinite.Nat.supₛ_eq_zero
+#align set.infinite.nat.Sup_eq_zero Set.Infinite.Nat.supₛ_eq_zero
 
 @[simp]
 theorem infₛ_eq_zero {s : Set ℕ} : infₛ s = 0 ↔ 0 ∈ s ∨ s = ∅ := by
@@ -218,4 +218,3 @@ theorem binterᵢ_lt_succ' (u : ℕ → Set α) (n : ℕ) : (⋂ k < n + 1, u k)
 #align set.bInter_lt_succ' Set.binterᵢ_lt_succ'
 
 end Set
-

--- a/Mathlib/Data/Nat/Periodic.lean
+++ b/Mathlib/Data/Nat/Periodic.lean
@@ -36,10 +36,10 @@ theorem periodic_mod (a : ℕ) : Periodic (fun n => n % a) a := by
   simp only [forall_const, eq_self_iff_true, add_mod_right, Periodic]
 #align nat.periodic_mod Nat.periodic_mod
 
-theorem Function.Periodic.map_mod_nat {α : Type _} {f : ℕ → α} {a : ℕ} (hf : Periodic f a) :
+theorem _root_.Function.Periodic.map_mod_nat {α : Type _} {f : ℕ → α} {a : ℕ} (hf : Periodic f a) :
     ∀ n, f (n % a) = f n := fun n => by
   conv_rhs => rw [← Nat.mod_add_div n a, mul_comm, ← Nat.nsmul_eq_mul, hf.nsmul]
-#align function.periodic.map_mod_nat Nat.Function.Periodic.map_mod_nat
+#align function.periodic.map_mod_nat Function.Periodic.map_mod_nat
 
 section Multiset
 
@@ -72,4 +72,3 @@ theorem filter_Ico_card_eq_of_periodic (n a : ℕ) (p : ℕ → Prop) [Decidable
 end Finset
 
 end Nat
-

--- a/Mathlib/Data/Rat/Denumerable.lean
+++ b/Mathlib/Data/Rat/Denumerable.lean
@@ -35,7 +35,7 @@ private def denumerable_aux : ℚ ≃ { x : ℤ × ℕ // 0 < x.2 ∧ x.1.natAbs
 instance : Denumerable ℚ := by
   let T := { x : ℤ × ℕ // 0 < x.2 ∧ x.1.natAbs.coprime x.2 }
   letI : Infinite T := Infinite.of_injective _ denumerable_aux.injective
-  letI : Encodable T := Encodable.Subtype.encodable
+  letI : Encodable T := Subtype.encodable
   letI : Denumerable T := ofEncodableOfInfinite T
   exact Denumerable.ofEquiv T denumerable_aux
 

--- a/Mathlib/Logic/Encodable/Basic.lean
+++ b/Mathlib/Logic/Encodable/Basic.lean
@@ -120,9 +120,9 @@ theorem decode_ofEquiv {α β} [Encodable α] (e : β ≃ α) (n : ℕ) :
   by rw [Option.map_eq_bind]
 #align encodable.decode_of_equiv Encodable.decode_ofEquiv
 
-instance Nat.encodable : Encodable ℕ :=
+instance _root_.Nat.encodable : Encodable ℕ :=
   ⟨id, some, fun _ => rfl⟩
-#align nat.encodable Encodable.Nat.encodable
+#align nat.encodable Nat.encodable
 
 @[simp]
 theorem encode_nat (n : ℕ) : encode n = n :=
@@ -134,13 +134,13 @@ theorem decode_nat (n : ℕ) : decode n = some n :=
   rfl
 #align encodable.decode_nat Encodable.decode_nat
 
-instance (priority := 100) IsEmpty.toEncodable [IsEmpty α] : Encodable α :=
+instance (priority := 100) _root_.IsEmpty.toEncodable [IsEmpty α] : Encodable α :=
   ⟨isEmptyElim, fun _ => none, isEmptyElim⟩
-#align is_empty.to_encodable Encodable.IsEmpty.toEncodable
+#align is_empty.to_encodable IsEmpty.toEncodable
 
-instance PUnit.encodable : Encodable PUnit :=
+instance _root_.PUnit.encodable : Encodable PUnit :=
   ⟨fun _ => 0, fun n => Nat.casesOn n (some PUnit.unit) fun _ => none, fun _ => by simp⟩
-#align punit.encodable Encodable.PUnit.encodable
+#align punit.encodable PUnit.encodable
 
 @[simp]
 theorem encode_star : encode PUnit.unit = 0 :=
@@ -257,9 +257,9 @@ def equivRangeEncode (α : Type _) [Encodable α] : α ≃ Set.range (@encode α
 #align encodable.equiv_range_encode Encodable.equivRangeEncode
 
 /-- A type with unique element is encodable. This is not an instance to avoid diamonds. -/
-def Unique.encodable [Unique α] : Encodable α :=
+def _root_.Unique.encodable [Unique α] : Encodable α :=
   ⟨fun _ => 0, fun _ => some default, Unique.forall_iff.2 rfl⟩
-#align unique.encodable Encodable.Unique.encodable
+#align unique.encodable Unique.encodable
 
 section Sum
 
@@ -280,9 +280,9 @@ def decodeSum (n : ℕ) : Option (Sum α β) :=
 #align encodable.decode_sum Encodable.decodeSum
 
 /-- If `α` and `β` are encodable, then so is their sum. -/
-instance Sum.encodable : Encodable (Sum α β) :=
+instance _root_.Sum.encodable : Encodable (Sum α β) :=
   ⟨encodeSum, decodeSum, fun s => by cases s <;> simp [encodeSum, div2_val, decodeSum, encodek]⟩
-#align sum.encodable Encodable.Sum.encodable
+#align sum.encodable Sum.encodable
 
 --Porting note: removing bit0 and bit1 from statement
 @[simp]
@@ -303,9 +303,9 @@ theorem decode_sum_val (n : ℕ) : (decode n : Option (Sum α β)) = decodeSum n
 
 end Sum
 
-instance Bool.encodable : Encodable Bool :=
+instance _root_.Bool.encodable : Encodable Bool :=
   ofEquiv (Sum Unit Unit) Equiv.boolEquivPUnitSumPUnit
-#align bool.encodable Encodable.Bool.encodable
+#align bool.encodable Bool.encodable
 
 @[simp]
 theorem encode_true : encode true = 1 :=
@@ -340,9 +340,9 @@ theorem decode_ge_two (n) (h : 2 ≤ n) : (decode n : Option Bool) = none :=
   simp [decodeSum, div2_val]; cases bodd n <;> simp [e]
 #align encodable.decode_ge_two Encodable.decode_ge_two
 
-noncomputable instance Prop.encodable : Encodable Prop :=
+noncomputable instance _root_.Prop.encodable : Encodable Prop :=
   ofEquiv Bool Equiv.propEquivBool
-#align Prop.encodable Encodable.Prop.encodable
+#align Prop.encodable Prop.encodable
 
 section Sigma
 
@@ -359,10 +359,10 @@ def decodeSigma (n : ℕ) : Option (Sigma γ) :=
   (decode n₁).bind fun a => (decode n₂).map <| Sigma.mk a
 #align encodable.decode_sigma Encodable.decodeSigma
 
-instance Sigma.encodable : Encodable (Sigma γ) :=
+instance _root_.Sigma.encodable : Encodable (Sigma γ) :=
   ⟨encodeSigma, decodeSigma, fun ⟨a, b⟩ => by
     simp [encodeSigma, decodeSigma, unpair_pair, encodek]⟩
-#align sigma.encodable Encodable.Sigma.encodable
+#align sigma.encodable Sigma.encodable
 
 @[simp]
 theorem decode_sigma_val (n : ℕ) :
@@ -423,36 +423,36 @@ def decodeSubtype (v : ℕ) : Option { a : α // P a } :=
 #align encodable.decode_subtype Encodable.decodeSubtype
 
 /-- A decidable subtype of an encodable type is encodable. -/
-instance Subtype.encodable : Encodable { a : α // P a } :=
+instance _root_.Subtype.encodable : Encodable { a : α // P a } :=
   ⟨encodeSubtype, decodeSubtype, fun ⟨v, h⟩ => by simp [encodeSubtype, decodeSubtype, encodek, h]⟩
-#align subtype.encodable Encodable.Subtype.encodable
+#align subtype.encodable Subtype.encodable
 
 theorem Subtype.encode_eq (a : Subtype P) : encode a = encode a.val := by cases a ; rfl
 #align encodable.subtype.encode_eq Encodable.Subtype.encode_eq
 
 end Subtype
 
-instance Fin.encodable (n) : Encodable (Fin n) :=
+instance _root_.Fin.encodable (n) : Encodable (Fin n) :=
   ofEquiv _ Fin.equivSubtype
-#align fin.encodable Encodable.Fin.encodable
+#align fin.encodable Fin.encodable
 
-instance Int.encodable : Encodable ℤ :=
+instance _root_.Int.encodable : Encodable ℤ :=
   ofEquiv _ Equiv.intEquivNat
-#align int.encodable Encodable.Int.encodable
+#align int.encodable Int.encodable
 
-instance PNat.encodable : Encodable ℕ+ :=
+instance _root_.PNat.encodable : Encodable ℕ+ :=
   ofEquiv _ Equiv.pnatEquivNat
-#align pnat.encodable Encodable.PNat.encodable
+#align pnat.encodable PNat.encodable
 
-/-- The lift of an encodable type is encodable. -/
-instance ULift.encodable [Encodable α] : Encodable (ULift α) :=
+/-- The lift of an encodable type is encodable -/
+instance _root_.ULift.encodable [Encodable α] : Encodable (ULift α) :=
   ofEquiv _ Equiv.ulift
-#align ulift.encodable Encodable.ULift.encodable
+#align ulift.encodable ULift.encodable
 
 /-- The lift of an encodable type is encodable. -/
-instance PLift.encodable [Encodable α] : Encodable (PLift α) :=
+instance _root_.PLift.encodable [Encodable α] : Encodable (PLift α) :=
   ofEquiv _ Equiv.plift
-#align plift.encodable Encodable.PLift.encodable
+#align plift.encodable PLift.encodable
 
 /-- If `β` is encodable and there is an injection `f : α → β`, then `α` is encodable as well. -/
 noncomputable def ofInj [Encodable β] (f : α → β) (hf : Injective f) : Encodable α :=

--- a/Mathlib/Logic/Equiv/List.lean
+++ b/Mathlib/Logic/Equiv/List.lean
@@ -149,7 +149,7 @@ noncomputable def _root_.Fintype.toEncodable (α : Type _) [Fintype α] : Encoda
 
 /-- If `α` is encodable, then so is `Vector α n`. -/
 instance _root_.Vector.encodable [Encodable α] {n} : Encodable (Vector α n) :=
-  Encodable.Subtype.encodable
+  Subtype.encodable
 #align vector.encodable Vector.encodable
 
 /-- If `α` is countable, then so is `Vector α n`. -/
@@ -192,9 +192,9 @@ encoding is not unique, we wrap it in `Trunc` to preserve computability. -/
 def fintypePi (α : Type _) (π : α → Type _) [DecidableEq α] [Fintype α] [∀ a, Encodable (π a)] :
     Trunc (Encodable (∀ a, π a)) :=
   (Fintype.truncEncodable α).bind fun a =>
-    (@fintypeArrow α (Σa, π a) _ _ (@Encodable.Sigma.encodable _ _ a _)).bind fun f =>
+    (@fintypeArrow α (Σa, π a) _ _ (@Sigma.encodable _ _ a _)).bind fun f =>
       Trunc.mk <|
-        @Encodable.ofEquiv _ _ (@Encodable.Subtype.encodable _ _ f _)
+        @Encodable.ofEquiv _ _ (@Subtype.encodable _ _ f _)
           (Equiv.piEquivSubtypeSigma α π)
 #align encodable.fintype_pi Encodable.fintypePi
 

--- a/Mathlib/Order/Ideal.lean
+++ b/Mathlib/Order/Ideal.lean
@@ -225,9 +225,9 @@ theorem IsProper.ne_top (_ : IsProper I) : I ≠ ⊤ :=
   fun h ↦ IsProper.ne_univ <| congr_arg SetLike.coe h
 #align order.ideal.is_proper.ne_top Order.Ideal.IsProper.ne_top
 
-theorem IsCoatom.isProper (hI : IsCoatom I) : IsProper I :=
+theorem _root_.IsCoatom.isProper (hI : IsCoatom I) : IsProper I :=
   isProper_of_ne_top hI.1
-#align is_coatom.is_proper Order.Ideal.IsCoatom.isProper
+#align is_coatom.is_proper IsCoatom.isProper
 
 theorem isProper_iff_ne_top : IsProper I ↔ I ≠ ⊤ :=
   ⟨fun h ↦ h.ne_top, fun h ↦ isProper_of_ne_top h⟩
@@ -241,9 +241,9 @@ theorem IsMaximal.isCoatom' [IsMaximal I] : IsCoatom I :=
   IsMaximal.isCoatom ‹_›
 #align order.ideal.is_maximal.is_coatom' Order.Ideal.IsMaximal.isCoatom'
 
-theorem IsCoatom.isMaximal (hI : IsCoatom I) : IsMaximal I :=
+theorem _root_.IsCoatom.isMaximal (hI : IsCoatom I) : IsMaximal I :=
   { IsCoatom.isProper hI with maximal_proper := fun _ hJ ↦ by simp [hI.2 _ hJ] }
-#align is_coatom.is_maximal Order.Ideal.IsCoatom.isMaximal
+#align is_coatom.is_maximal IsCoatom.isMaximal
 
 theorem isMaximal_iff_isCoatom : IsMaximal I ↔ IsCoatom I :=
   ⟨fun h ↦ h.isCoatom, fun h ↦ IsCoatom.isMaximal h⟩

--- a/Mathlib/Order/LocallyFinite.lean
+++ b/Mathlib/Order/LocallyFinite.lean
@@ -442,13 +442,13 @@ section OrderTop
 variable [LocallyFiniteOrder α] [OrderTop α] {a x : α}
 
 -- See note [lower priority instance]
-instance (priority := 100) LocallyFiniteOrder.toLocallyFiniteOrderTop : LocallyFiniteOrderTop α
-    where
+instance (priority := 100) _root_.LocallyFiniteOrder.toLocallyFiniteOrderTop :
+    LocallyFiniteOrderTop α where
   finsetIci b := Icc b ⊤
   finsetIoi b := Ioc b ⊤
   finset_mem_Ici a x := by rw [mem_Icc, and_iff_left le_top]
   finset_mem_Ioi a x := by rw [mem_Ioc, and_iff_left le_top]
-#align locally_finite_order.to_locally_finite_order_top Finset.LocallyFiniteOrder.toLocallyFiniteOrderTop
+#align locally_finite_order.to_locally_finite_order_top LocallyFiniteOrder.toLocallyFiniteOrderTop
 
 theorem Ici_eq_Icc (a : α) : Ici a = Icc a ⊤ :=
   rfl

--- a/Mathlib/Order/Partition/Finpartition.lean
+++ b/Mathlib/Order/Partition/Finpartition.lean
@@ -197,7 +197,7 @@ instance : Unique (Finpartition (⊥ : α)) :=
 -- See note [reducible non instances]
 /-- There's a unique partition of an atom. -/
 @[reducible]
-def IsAtom.uniqueFinpartition (ha : IsAtom a) : Unique (Finpartition a)
+def _root_.IsAtom.uniqueFinpartition (ha : IsAtom a) : Unique (Finpartition a)
     where
   default := indiscrete ha.1
   uniq P := by
@@ -209,7 +209,7 @@ def IsAtom.uniqueFinpartition (ha : IsAtom a) : Unique (Finpartition a)
     obtain ⟨c, hc⟩ := P.parts_nonempty ha.1
     simp_rw [← h c hc]
     exact hc
-#align is_atom.unique_finpartition Finpartition.IsAtom.uniqueFinpartition
+#align is_atom.unique_finpartition IsAtom.uniqueFinpartition
 
 instance [Fintype α] [DecidableEq α] (a : α) : Fintype (Finpartition a) :=
   @Fintype.ofSurjective { p : Finset α // p.SupIndep id ∧ p.sup id = a ∧ ⊥ ∉ p } (Finpartition a) _

--- a/Mathlib/Order/SuccPred/Basic.lean
+++ b/Mathlib/Order/SuccPred/Basic.lean
@@ -425,15 +425,15 @@ theorem le_le_succ_iff : a ≤ b ∧ b ≤ succ a ↔ b = a ∨ b = succ a := by
   · exact ⟨le_succ a, le_rfl⟩
 #align order.le_le_succ_iff Order.le_le_succ_iff
 
-theorem Covby.succ_eq (h : a ⋖ b) : succ a = b :=
+theorem _root_.Covby.succ_eq (h : a ⋖ b) : succ a = b :=
   (succ_le_of_lt h.lt).eq_of_not_lt fun h' => h.2 (lt_succ_of_not_isMax h.lt.not_isMax) h'
-#align covby.succ_eq Order.Covby.succ_eq
+#align covby.succ_eq Covby.succ_eq
 
-theorem Wcovby.le_succ (h : a ⩿ b) : b ≤ succ a := by
+theorem _root_.Wcovby.le_succ (h : a ⩿ b) : b ≤ succ a := by
   obtain h | rfl := h.covby_or_eq
   · exact (Covby.succ_eq h).ge
   · exact le_succ _
-#align wcovby.le_succ Order.Wcovby.le_succ
+#align wcovby.le_succ Wcovby.le_succ
 
 theorem le_succ_iff_eq_or_le : a ≤ succ b ↔ a = succ b ∨ a ≤ b := by
   by_cases hb : IsMax b
@@ -781,15 +781,15 @@ theorem pred_le_le_iff {a b : α} : pred a ≤ b ∧ b ≤ a ↔ b = a ∨ b = p
   · exact ⟨le_rfl, pred_le a⟩
 #align order.pred_le_le_iff Order.pred_le_le_iff
 
-theorem Covby.pred_eq {a b : α} (h : a ⋖ b) : pred b = a :=
+theorem _root_.Covby.pred_eq {a b : α} (h : a ⋖ b) : pred b = a :=
   (le_pred_of_lt h.lt).eq_of_not_gt fun h' => h.2 h' <| pred_lt_of_not_isMin h.lt.not_isMin
-#align covby.pred_eq Order.Covby.pred_eq
+#align covby.pred_eq Covby.pred_eq
 
-theorem Wcovby.pred_le (h : a ⩿ b) : pred b ≤ a := by
+theorem _root_.Wcovby.pred_le (h : a ⩿ b) : pred b ≤ a := by
   obtain h | rfl := h.covby_or_eq
   · exact (Covby.pred_eq h).le
   · exact pred_le _
-#align wcovby.pred_le Order.Wcovby.pred_le
+#align wcovby.pred_le Wcovby.pred_le
 
 theorem pred_le_iff_eq_or_le : pred a ≤ b ↔ b = pred a ∨ a ≤ b := by
   by_cases ha : IsMin a

--- a/Mathlib/Order/SuccPred/Limit.lean
+++ b/Mathlib/Order/SuccPred/Limit.lean
@@ -123,7 +123,7 @@ section PartialOrder
 variable [PartialOrder α] [SuccOrder α] {a b : α} {C : α → Sort _}
 
 theorem isSuccLimit_of_succ_ne (h : ∀ b, succ b ≠ a) : IsSuccLimit a := fun b hba =>
-  h b (Order.Covby.succ_eq hba)
+  h b (Covby.succ_eq hba)
 #align order.is_succ_limit_of_succ_ne Order.isSuccLimit_of_succ_ne
 
 theorem not_isSuccLimit_iff : ¬IsSuccLimit a ↔ ∃ b, ¬IsMax b ∧ succ b = a := by

--- a/Mathlib/Order/SuccPred/Limit.lean
+++ b/Mathlib/Order/SuccPred/Limit.lean
@@ -60,9 +60,9 @@ section Preorder
 
 variable [Preorder α] {a : α}
 
-protected theorem IsMin.isSuccLimit : IsMin a → IsSuccLimit a := fun h _ hab =>
+protected theorem _root_.IsMin.isSuccLimit : IsMin a → IsSuccLimit a := fun h _ hab =>
   not_isMin_of_lt hab.lt h
-#align is_min.is_succ_limit Order.IsMin.isSuccLimit
+#align is_min.is_succ_limit IsMin.isSuccLimit
 
 theorem isSuccLimit_bot [OrderBot α] : IsSuccLimit (⊥ : α) :=
   IsMin.isSuccLimit isMin_bot
@@ -277,9 +277,9 @@ section Preorder
 
 variable [Preorder α] {a : α}
 
-protected theorem IsMax.isPredLimit : IsMax a → IsPredLimit a := fun h _ hab =>
+protected theorem _root_.IsMax.isPredLimit : IsMax a → IsPredLimit a := fun h _ hab =>
   not_isMax_of_lt hab.lt h
-#align is_max.is_pred_limit Order.IsMax.isPredLimit
+#align is_max.is_pred_limit IsMax.isPredLimit
 
 theorem isPredLimit_top [OrderTop α] : IsPredLimit (⊤ : α) :=
    IsMax.isPredLimit isMax_top

--- a/Mathlib/RingTheory/Ideal/Operations.lean
+++ b/Mathlib/RingTheory/Ideal/Operations.lean
@@ -1961,7 +1961,7 @@ private instance : Module R S := Algebra.toModule
 noncomputable def basisSpanSingleton (b : Basis ι R S) {x : S} (hx : x ≠ 0) :
     Basis ι R (span ({x} : Set S)) :=
   b.map <|
-    LinearEquiv.ofInjective (LinearMap.Algebra.lmul R S x) (LinearMap.mul_injective hx) ≪≫ₗ
+    LinearEquiv.ofInjective (Algebra.lmul R S x) (LinearMap.mul_injective hx) ≪≫ₗ
         LinearEquiv.ofEq _ _
           (by
             ext
@@ -1974,13 +1974,13 @@ theorem basisSpanSingleton_apply (b : Basis ι R S) {x : S} (hx : x ≠ 0) (i : 
     (basisSpanSingleton b hx i : S) = x * b i := by
   simp only [basisSpanSingleton, Basis.map_apply, LinearEquiv.trans_apply,
     Submodule.restrictScalarsEquiv_apply, LinearEquiv.ofInjective_apply, LinearEquiv.coe_ofEq_apply,
-    LinearEquiv.restrictScalars_apply, LinearMap.Algebra.coe_lmul_eq_mul, LinearMap.mul_apply']
+    LinearEquiv.restrictScalars_apply, Algebra.coe_lmul_eq_mul, LinearMap.mul_apply']
 #align ideal.basis_span_singleton_apply Ideal.basisSpanSingleton_apply
 
 @[simp]
 theorem constr_basisSpanSingleton {N : Type _} [Semiring N] [Module N S] [SMulCommClass R N S]
     (b : Basis ι R S) {x : S} (hx : x ≠ 0) :
-    (b.constr N).toFun (((↑) : _ → S) ∘ (basisSpanSingleton b hx)) = LinearMap.Algebra.lmul R S x :=
+    (b.constr N).toFun (((↑) : _ → S) ∘ (basisSpanSingleton b hx)) = Algebra.lmul R S x :=
   b.ext fun i => by
     erw [Basis.constr_basis, Function.comp_apply, basisSpanSingleton_apply, LinearMap.mul_apply']
 #align ideal.constr_basis_span_singleton Ideal.constr_basisSpanSingleton

--- a/Mathlib/RingTheory/MvPolynomial/Symmetric.lean
+++ b/Mathlib/RingTheory/MvPolynomial/Symmetric.lean
@@ -169,12 +169,12 @@ def esymm (n : ℕ) : MvPolynomial σ R :=
 /-- The `n`th elementary symmetric `MvPolynomial σ R` is obtained by evaluating the
 `n`th elementary symmetric at the `Multiset` of the monomials -/
 theorem esymm_eq_multiset_esymm : esymm σ R = (Finset.univ.val.map X).esymm := by
-  refine' funext fun n => (Multiset.Finset.esymm_map_val X _ n).symm
+  refine' funext fun n => (Finset.esymm_map_val X _ n).symm
 #align mv_polynomial.esymm_eq_multiset_esymm MvPolynomial.esymm_eq_multiset_esymm
 
 theorem aeval_esymm_eq_multiset_esymm [Algebra R S] (f : σ → S) (n : ℕ) :
     aeval f (esymm σ R n) = (Finset.univ.val.map f).esymm n := by
-  simp_rw [esymm, aeval_sum, aeval_prod, aeval_X, Multiset.Finset.esymm_map_val]
+  simp_rw [esymm, aeval_sum, aeval_prod, aeval_X, Finset.esymm_map_val]
 #align mv_polynomial.aeval_esymm_eq_multiset_esymm MvPolynomial.aeval_esymm_eq_multiset_esymm
 
 /-- We can define `esymm σ R n` by summing over a subtype instead of over `powerset_len`. -/

--- a/Mathlib/RingTheory/MvPolynomial/Symmetric.lean
+++ b/Mathlib/RingTheory/MvPolynomial/Symmetric.lean
@@ -60,11 +60,11 @@ def esymm (s : Multiset R) (n : ℕ) : R :=
   ((s.powersetLen n).map Multiset.prod).sum
 #align multiset.esymm Multiset.esymm
 
-theorem Finset.esymm_map_val {σ} (f : σ → R) (s : Finset σ) (n : ℕ) :
+theorem _root_.Finset.esymm_map_val {σ} (f : σ → R) (s : Finset σ) (n : ℕ) :
     (s.val.map f).esymm n = (s.powersetLen n).sum fun t => t.prod f := by
   simp only [esymm, powersetLen_map, ← Finset.map_val_val_powersetLen, map_map]
   rfl
-#align finset.esymm_map_val Multiset.Finset.esymm_map_val
+#align finset.esymm_map_val Finset.esymm_map_val
 
 end Multiset
 

--- a/Mathlib/RingTheory/Polynomial/Vieta.lean
+++ b/Mathlib/RingTheory/Polynomial/Vieta.lean
@@ -83,7 +83,7 @@ set_option linter.uppercaseLean3 false in
 
 theorem _root_.Finset.prod_X_add_C_coeff {σ} (s : Finset σ) (r : σ → R) {k : ℕ} (h : k ≤ s.card) :
     (∏ i in s, (X + C (r i))).coeff k = ∑ t in s.powersetLen (s.card - k), ∏ i in t, r i := by
-  rw [Finset.prod, prod_X_add_C_coeff' _ r h, Multiset.Finset.esymm_map_val]
+  rw [Finset.prod, prod_X_add_C_coeff' _ r h, Finset.esymm_map_val]
   rfl
 set_option linter.uppercaseLean3 false in
 #align finset.prod_X_add_C_coeff Finset.prod_X_add_C_coeff

--- a/Mathlib/Topology/MetricSpace/Infsep.lean
+++ b/Mathlib/Topology/MetricSpace/Infsep.lean
@@ -513,8 +513,8 @@ theorem _root_.Finset.coe_infsep_of_offDiag_nonempty [DecidableEq α] {s : Finse
   rw [Finset.coe_infsep, dif_pos hs]
 #align finset.coe_infsep_of_off_diag_nonempty Finset.coe_infsep_of_offDiag_nonempty
 
-theorem _root_.Finset.coe_infsep_of_offDiag_empty [DecidableEq α] {s : Finset α} (hs : s.offDiag = ∅) :
-    (s : Set α).infsep = 0 := by
+theorem _root_.Finset.coe_infsep_of_offDiag_empty
+    [DecidableEq α] {s : Finset α} (hs : s.offDiag = ∅) : (s : Set α).infsep = 0 := by
   rw [← Finset.not_nonempty_iff_eq_empty] at hs
   rw [Finset.coe_infsep, dif_neg hs]
 #align finset.coe_infsep_of_off_diag_empty Finset.coe_infsep_of_offDiag_empty

--- a/Mathlib/Topology/MetricSpace/Infsep.lean
+++ b/Mathlib/Topology/MetricSpace/Infsep.lean
@@ -498,7 +498,7 @@ theorem Finite.infsep_of_nontrivial (hsf : s.Finite) (hs : s.Nontrivial) :
   classical simp_rw [hsf.infsep, dif_pos hs]
 #align set.finite.infsep_of_nontrivial Set.Finite.infsep_of_nontrivial
 
-theorem Finset.coe_infsep [DecidableEq α] (s : Finset α) :
+theorem _root_.Finset.coe_infsep [DecidableEq α] (s : Finset α) :
     (s : Set α).infsep = if hs : s.offDiag.Nonempty then s.offDiag.inf' hs (uncurry dist) else 0 :=
   by
   have H : (s : Set α).Nontrivial ↔ s.offDiag.Nonempty := by
@@ -506,18 +506,18 @@ theorem Finset.coe_infsep [DecidableEq α] (s : Finset α) :
   split_ifs with hs
   · simp_rw [(H.mpr hs).infsep_of_fintype, ← Finset.coe_offDiag, Finset.toFinset_coe]
   · exact (not_nontrivial_iff.mp (H.mp.mt hs)).infsep_zero
-#align finset.coe_infsep Set.Finset.coe_infsep
+#align finset.coe_infsep Finset.coe_infsep
 
-theorem Finset.coe_infsep_of_offDiag_nonempty [DecidableEq α] {s : Finset α}
+theorem _root_.Finset.coe_infsep_of_offDiag_nonempty [DecidableEq α] {s : Finset α}
     (hs : s.offDiag.Nonempty) : (s : Set α).infsep = s.offDiag.inf' hs (uncurry dist) := by
   rw [Finset.coe_infsep, dif_pos hs]
-#align finset.coe_infsep_of_off_diag_nonempty Set.Finset.coe_infsep_of_offDiag_nonempty
+#align finset.coe_infsep_of_off_diag_nonempty Finset.coe_infsep_of_offDiag_nonempty
 
-theorem Finset.coe_infsep_of_offDiag_empty [DecidableEq α] {s : Finset α} (hs : s.offDiag = ∅) :
+theorem _root_.Finset.coe_infsep_of_offDiag_empty [DecidableEq α] {s : Finset α} (hs : s.offDiag = ∅) :
     (s : Set α).infsep = 0 := by
   rw [← Finset.not_nonempty_iff_eq_empty] at hs
   rw [Finset.coe_infsep, dif_neg hs]
-#align finset.coe_infsep_of_off_diag_empty Set.Finset.coe_infsep_of_offDiag_empty
+#align finset.coe_infsep_of_off_diag_empty Finset.coe_infsep_of_offDiag_empty
 
 theorem Nontrivial.infsep_exists_of_finite [Finite s] (hs : s.Nontrivial) :
     ∃ (x : _)(_ : x ∈ s)(y : _)(_ : y ∈ s)(_hxy : x ≠ y), s.infsep = dist x y := by
@@ -562,15 +562,15 @@ theorem Finite.infsep_pos_iff_nontrivial (hs : s.Finite) : 0 < s.infsep ↔ s.No
   infsep_pos_iff_nontrivial_of_finite
 #align set.finite.infsep_pos_iff_nontrivial Set.Finite.infsep_pos_iff_nontrivial
 
-theorem Finset.infsep_zero_iff_subsingleton (s : Finset α) :
+theorem _root_.Finset.infsep_zero_iff_subsingleton (s : Finset α) :
     (s : Set α).infsep = 0 ↔ (s : Set α).Subsingleton :=
   infsep_zero_iff_subsingleton_of_finite
-#align finset.infsep_zero_iff_subsingleton Set.Finset.infsep_zero_iff_subsingleton
+#align finset.infsep_zero_iff_subsingleton Finset.infsep_zero_iff_subsingleton
 
-theorem Finset.infsep_pos_iff_nontrivial (s : Finset α) :
+theorem _root_.Finset.infsep_pos_iff_nontrivial (s : Finset α) :
     0 < (s : Set α).infsep ↔ (s : Set α).Nontrivial :=
   infsep_pos_iff_nontrivial_of_finite
-#align finset.infsep_pos_iff_nontrivial Set.Finset.infsep_pos_iff_nontrivial
+#align finset.infsep_pos_iff_nontrivial Finset.infsep_pos_iff_nontrivial
 
 end MetricSpace
 


### PR DESCRIPTION
Mathport doesn't understand this, and apparently nor do many of the humans fixing the errors it creates.

If your `#align` statement complains the def doesn't exist, **don't change the #align**; work out why it doesn't exist instead.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
