### PR TITLE
[Merged by Bors] - chore: forward-port leanprover-community/mathlib#18852

### DIFF
--- a/Mathlib/Algebra/Algebra/Basic.lean
+++ b/Mathlib/Algebra/Algebra/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau, Yury Kudryashov
 
 ! This file was ported from Lean 3 source module algebra.algebra.basic
-! leanprover-community/mathlib commit 2738d2ca56cbc63be80c3bd48e9ed90ad94e947d
+! leanprover-community/mathlib commit 2651125b48fc5c170ab1111afd0817c903b1fc6c
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -706,12 +706,6 @@ theorem map_mul_algebraMap (f : A →ₗ[R] B) (a : A) (r : R) :
 #align linear_map.map_mul_algebra_map LinearMap.map_mul_algebraMap
 
 end LinearMap
-
-@[simp]
-theorem Rat.smul_one_eq_coe {A : Type _} [DivisionRing A] [Algebra ℚ A] (m : ℚ) :
-    @SMul.smul _ _ Algebra.toSMul m (1 : A) = ↑m :=
-  (Algebra.algebraMap_eq_smul_one m).symm.trans <| @eq_ratCast (ℚ →+* A) A _ _ (algebraMap ℚ A) _
-#align rat.smul_one_eq_coe Rat.smul_one_eq_coe
 
 section Nat
 

--- a/Mathlib/Algebra/Field/Defs.lean
+++ b/Mathlib/Algebra/Field/Defs.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Lewis, Leonardo de Moura, Johannes Hölzl, Mario Carneiro
 
 ! This file was ported from Lean 3 source module algebra.field.defs
-! leanprover-community/mathlib commit 70d50ecfd4900dd6d328da39ab7ebd516abe4025
+! leanprover-community/mathlib commit 2651125b48fc5c170ab1111afd0817c903b1fc6c
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -151,6 +151,11 @@ instance (priority := 100) smulDivisionRing : SMul ℚ K :=
 theorem smul_def (a : ℚ) (x : K) : a • x = ↑a * x :=
   DivisionRing.qsmul_eq_mul' a x
 #align rat.smul_def Rat.smul_def
+
+@[simp]
+theorem smul_one_eq_coe (A : Type _) [DivisionRing A] (m : ℚ) : m • (1 : A) = ↑m := by
+  rw [Rat.smul_def, mul_one]
+#align rat.smul_one_eq_coe Rat.smul_one_eq_coe
 
 end Rat
 

--- a/Mathlib/Algebra/MonoidAlgebra/Basic.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Yury G. Kudryashov, Scott Morrison
 
 ! This file was ported from Lean 3 source module algebra.monoid_algebra.basic
-! leanprover-community/mathlib commit 57e09a1296bfb4330ddf6624f1028ba186117d82
+! leanprover-community/mathlib commit 2651125b48fc5c170ab1111afd0817c903b1fc6c
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/

--- a/Mathlib/Algebra/MonoidAlgebra/Basic.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Basic.lean
@@ -1480,6 +1480,10 @@ instance commRing [CommRing k] [AddCommMonoid G] : CommRing (AddMonoidAlgebra k 
 
 variable {S : Type _}
 
+instance distribSMul [Semiring k] [DistribSMul R k] : DistribSMul R (AddMonoidAlgebra k G) :=
+  Finsupp.distribSMul G k
+#align add_monoid_algebra.distrib_smul AddMonoidAlgebra.distribSMul
+
 instance distribMulAction [Monoid R] [Semiring k] [DistribMulAction R k] :
     DistribMulAction R (AddMonoidAlgebra k G) :=
   Finsupp.distribMulAction G k

--- a/Mathlib/Analysis/NormedSpace/Basic.lean
+++ b/Mathlib/Analysis/NormedSpace/Basic.lean
@@ -585,10 +585,7 @@ norm. -/
 instance normedAlgebraRat {𝕜} [NormedDivisionRing 𝕜] [CharZero 𝕜] [NormedAlgebra ℝ 𝕜] :
     NormedAlgebra ℚ 𝕜 where
   norm_smul_le q x := by
-    rw [← smul_one_smul ℝ q x]
-    -- Porting note: broken notation class seems to cause a problem here
-    conv_lhs => change ‖(SMul.smul q (1:ℝ)) • x‖; rw [Rat.smul_one_eq_coe q]
-    rw [norm_smul, Rat.norm_cast_real]
+    rw [← smul_one_smul ℝ q x, Rat.smul_one_eq_coe, norm_smul, Rat.norm_cast_real]
 #align normed_algebra_rat normedAlgebraRat
 
 instance PUnit.normedAlgebra : NormedAlgebra 𝕜 PUnit where

--- a/Mathlib/Data/Finsupp/Basic.lean
+++ b/Mathlib/Data/Finsupp/Basic.lean
@@ -1496,21 +1496,21 @@ Throughout this section, some `Monoid` and `Semiring` arguments are specified wi
 -/
 
 @[simp]
-theorem coe_smul [AddMonoid M] [SMulZeroClass R M] (b : R) (v : α →₀ M) : ⇑(b • v) = b • ⇑v :=
+theorem coe_smul [Zero M] [SMulZeroClass R M] (b : R) (v : α →₀ M) : ⇑(b • v) = b • ⇑v :=
   rfl
 #align finsupp.coe_smul Finsupp.coe_smul
 
-theorem smul_apply [AddMonoid M] [SMulZeroClass R M] (b : R) (v : α →₀ M) (a : α) :
+theorem smul_apply [Zero M] [SMulZeroClass R M] (b : R) (v : α →₀ M) (a : α) :
     (b • v) a = b • v a :=
   rfl
 #align finsupp.smul_apply Finsupp.smul_apply
 
-theorem _root_.IsSMulRegular.finsupp [AddMonoid M] [SMulZeroClass R M] {k : R}
+theorem _root_.IsSMulRegular.finsupp [Zero M] [SMulZeroClass R M] {k : R}
     (hk : IsSMulRegular M k) : IsSMulRegular (α →₀ M) k :=
   fun _ _ h => ext fun i => hk (FunLike.congr_fun h i)
 #align is_smul_regular.finsupp IsSMulRegular.finsupp
 
-instance faithfulSMul [Nonempty α] [AddMonoid M] [SMulZeroClass R M] [FaithfulSMul R M] :
+instance faithfulSMul [Nonempty α] [Zero M] [SMulZeroClass R M] [FaithfulSMul R M] :
     FaithfulSMul R (α →₀ M) where
   eq_of_smul_eq_smul h :=
     let ⟨a⟩ := ‹Nonempty α›

--- a/Mathlib/Data/Finsupp/Basic.lean
+++ b/Mathlib/Data/Finsupp/Basic.lean
@@ -1495,21 +1495,25 @@ Throughout this section, some `Monoid` and `Semiring` arguments are specified wi
 `[]`. See note [implicit instance arguments].
 -/
 
+-- porting note: changed `AddMonoid` to `Zero`
 @[simp]
 theorem coe_smul [Zero M] [SMulZeroClass R M] (b : R) (v : α →₀ M) : ⇑(b • v) = b • ⇑v :=
   rfl
 #align finsupp.coe_smul Finsupp.coe_smul
 
+-- porting note: changed `AddMonoid` to `Zero`
 theorem smul_apply [Zero M] [SMulZeroClass R M] (b : R) (v : α →₀ M) (a : α) :
     (b • v) a = b • v a :=
   rfl
 #align finsupp.smul_apply Finsupp.smul_apply
 
+-- porting note: changed `AddMonoid` to `Zero`
 theorem _root_.IsSMulRegular.finsupp [Zero M] [SMulZeroClass R M] {k : R}
     (hk : IsSMulRegular M k) : IsSMulRegular (α →₀ M) k :=
   fun _ _ h => ext fun i => hk (FunLike.congr_fun h i)
 #align is_smul_regular.finsupp IsSMulRegular.finsupp
 
+-- porting note: changed `AddMonoid` to `Zero`
 instance faithfulSMul [Nonempty α] [Zero M] [SMulZeroClass R M] [FaithfulSMul R M] :
     FaithfulSMul R (α →₀ M) where
   eq_of_smul_eq_smul h :=

--- a/Mathlib/Data/Finsupp/Basic.lean
+++ b/Mathlib/Data/Finsupp/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Scott Morrison
 
 ! This file was ported from Lean 3 source module data.finsupp.basic
-! leanprover-community/mathlib commit f7fc89d5d5ff1db2d1242c7bb0e9062ce47ef47c
+! leanprover-community/mathlib commit 2651125b48fc5c170ab1111afd0817c903b1fc6c
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -1495,23 +1495,22 @@ Throughout this section, some `Monoid` and `Semiring` arguments are specified wi
 `[]`. See note [implicit instance arguments].
 -/
 
-
 @[simp]
-theorem coe_smul [AddMonoid M] [DistribSMul R M] (b : R) (v : α →₀ M) : ⇑(b • v) = b • ⇑v :=
+theorem coe_smul [AddMonoid M] [SMulZeroClass R M] (b : R) (v : α →₀ M) : ⇑(b • v) = b • ⇑v :=
   rfl
 #align finsupp.coe_smul Finsupp.coe_smul
 
-theorem smul_apply [AddMonoid M] [DistribSMul R M] (b : R) (v : α →₀ M) (a : α) :
+theorem smul_apply [AddMonoid M] [SMulZeroClass R M] (b : R) (v : α →₀ M) (a : α) :
     (b • v) a = b • v a :=
   rfl
 #align finsupp.smul_apply Finsupp.smul_apply
 
-theorem _root_.IsSMulRegular.finsupp [AddMonoid M] [DistribSMul R M] {k : R}
+theorem _root_.IsSMulRegular.finsupp [AddMonoid M] [SMulZeroClass R M] {k : R}
     (hk : IsSMulRegular M k) : IsSMulRegular (α →₀ M) k :=
   fun _ _ h => ext fun i => hk (FunLike.congr_fun h i)
 #align is_smul_regular.finsupp IsSMulRegular.finsupp
 
-instance faithfulSMul [Nonempty α] [AddMonoid M] [DistribSMul R M] [FaithfulSMul R M] :
+instance faithfulSMul [Nonempty α] [AddMonoid M] [SMulZeroClass R M] [FaithfulSMul R M] :
     FaithfulSMul R (α →₀ M) where
   eq_of_smul_eq_smul h :=
     let ⟨a⟩ := ‹Nonempty α›
@@ -1533,18 +1532,17 @@ instance distribMulAction [Monoid R] [AddMonoid M] [DistribMulAction R M] :
     mul_smul := fun r s x => ext fun y => mul_smul r s (x y) }
 #align finsupp.distrib_mul_action Finsupp.distribMulAction
 
-instance isScalarTower [Monoid R] [Monoid S] [AddMonoid M] [DistribMulAction R M]
-    [DistribMulAction S M] [SMul R S] [IsScalarTower R S M] : IsScalarTower R S (α →₀ M) where
+instance isScalarTower [Zero M] [SMulZeroClass R M] [SMulZeroClass S M] [SMul R S]
+  [IsScalarTower R S M] : IsScalarTower R S (α →₀ M) where
   smul_assoc _ _ _ := ext fun _ => smul_assoc _ _ _
-#align finsuppp.is_scalar_tower Finsupp.isScalarTower
 
-instance smulCommClass [Monoid R] [Monoid S] [AddMonoid M] [DistribMulAction R M]
-    [DistribMulAction S M] [SMulCommClass R S M] : SMulCommClass R S (α →₀ M) where
+instance smulCommClass [Zero M] [SMulZeroClass R M] [SMulZeroClass S M] [SMulCommClass R S M] :
+  SMulCommClass R S (α →₀ M) where
   smul_comm _ _ _ := ext fun _ => smul_comm _ _ _
 #align finsupp.smul_comm_class Finsupp.smulCommClass
 
-instance isCentralScalar [Monoid R] [AddMonoid M] [DistribMulAction R M] [DistribMulAction Rᵐᵒᵖ M]
-    [IsCentralScalar R M] : IsCentralScalar R (α →₀ M) where
+instance isCentralScalar [Zero M] [SMulZeroClass R M] [SMulZeroClass Rᵐᵒᵖ M] [IsCentralScalar R M] :
+  IsCentralScalar R (α →₀ M) where
   op_smul_eq_smul _ _ := ext fun _ => op_smul_eq_smul _ _
 #align finsupp.is_central_scalar Finsupp.isCentralScalar
 
@@ -1587,7 +1585,7 @@ theorem mapDomain_smul {_ : Monoid R} [AddCommMonoid M] [DistribMulAction R M] {
 #align finsupp.map_domain_smul Finsupp.mapDomain_smul
 
 @[simp]
-theorem smul_single {_ : Monoid R} [AddMonoid M] [DistribMulAction R M] (c : R) (a : α) (b : M) :
+theorem smul_single [Zero M] [SMulZeroClass R M] (c : R) (a : α) (b : M) :
     c • Finsupp.single a b = Finsupp.single a (c • b) :=
   mapRange_single
 #align finsupp.smul_single Finsupp.smul_single

--- a/Mathlib/Data/Polynomial/Basic.lean
+++ b/Mathlib/Data/Polynomial/Basic.lean
@@ -1217,9 +1217,9 @@ section DivisionRing
 
 variable [DivisionRing R]
 
-theorem rat_smul_eq_c_mul (a : ℚ) (f : R[X]) : a • f = Polynomial.C (a : R) * f := by
+theorem rat_smul_eq_C_mul (a : ℚ) (f : R[X]) : a • f = Polynomial.C (a : R) * f := by
   rw [← Rat.smul_one_eq_coe, ← Polynomial.smul_C, C_1, smul_one_mul]
-#align polynomial.rat_smul_eq_C_mul Polynomial.rat_smul_eq_c_mul
+#align polynomial.rat_smul_eq_C_mul Polynomial.rat_smul_eq_C_mul
 
 end DivisionRing
 

--- a/Mathlib/Data/Polynomial/Basic.lean
+++ b/Mathlib/Data/Polynomial/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes, Johannes Hölzl, Scott Morrison, Jens Wagemaker
 
 ! This file was ported from Lean 3 source module data.polynomial.basic
-! leanprover-community/mathlib commit 1f0096e6caa61e9c849ec2adbd227e960e9dff58
+! leanprover-community/mathlib commit 2651125b48fc5c170ab1111afd0817c903b1fc6c
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -298,6 +298,11 @@ instance semiring : Semiring R[X] :=
     toFinsupp_add toFinsupp_mul (fun _ _ => toFinsupp_smul _ _) toFinsupp_pow fun _ => rfl
 #align polynomial.semiring Polynomial.semiring
 
+instance distribSMul {S} [DistribSMul S R] : DistribSMul S R[X] :=
+  Function.Injective.distribSMul ⟨⟨toFinsupp, toFinsupp_zero⟩, toFinsupp_add⟩ toFinsupp_injective
+    toFinsupp_smul
+#align polynomial.distrib_smul Polynomial.distribSMul
+
 instance distribMulAction {S} [Monoid S] [DistribMulAction S R] : DistribMulAction S R[X] :=
   Function.Injective.distribMulAction ⟨⟨toFinsupp, toFinsupp_zero⟩, toFinsupp_add⟩
     toFinsupp_injective toFinsupp_smul
@@ -452,7 +457,7 @@ theorem monomial_pow (n : ℕ) (r : R) (k : ℕ) : monomial n r ^ k = monomial (
   · simp [pow_succ, ih, monomial_mul_monomial, Nat.succ_eq_add_one, mul_add, add_comm]
 #align polynomial.monomial_pow Polynomial.monomial_pow
 
-theorem smul_monomial {S} [Monoid S] [DistribMulAction S R] (a : S) (n : ℕ) (b : R) :
+theorem smul_monomial {S} [SMulZeroClass S R] (a : S) (n : ℕ) (b : R) :
     a • monomial n b = monomial n (a • b) :=
   toFinsupp_injective <| by simp; rw [smul_single]
 #align polynomial.smul_monomial Polynomial.smul_monomial
@@ -508,7 +513,7 @@ theorem C_add : C (a + b) = C a + C b :=
 #align polynomial.C_add Polynomial.C_add
 
 @[simp]
-theorem smul_C {S} [Monoid S] [DistribMulAction S R] (s : S) (r : R) : s • C r = C (s • r) :=
+theorem smul_C {S} [SMulZeroClass S R] (s : S) (r : R) : s • C r = C (s • r) :=
   smul_monomial _ _ r
 #align polynomial.smul_C Polynomial.smul_C
 
@@ -1207,6 +1212,16 @@ theorem X_ne_zero : (X : R[X]) ≠ 0 :=
 #align polynomial.X_ne_zero Polynomial.X_ne_zero
 
 end NonzeroSemiring
+
+section DivisionRing
+
+variable [DivisionRing R]
+
+theorem rat_smul_eq_c_mul (a : ℚ) (f : R[X]) : a • f = Polynomial.C (a : R) * f := by
+  rw [← Rat.smul_one_eq_coe, ← Polynomial.smul_C, C_1, smul_one_mul]
+#align polynomial.rat_smul_eq_C_mul Polynomial.rat_smul_eq_c_mul
+
+end DivisionRing
 
 @[simp]
 theorem nontrivial_iff [Semiring R] : Nontrivial R[X] ↔ Nontrivial R :=

--- a/Mathlib/Data/Polynomial/Coeff.lean
+++ b/Mathlib/Data/Polynomial/Coeff.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes, Johannes Hölzl, Scott Morrison, Jens Wagemaker
 
 ! This file was ported from Lean 3 source module data.polynomial.coeff
-! leanprover-community/mathlib commit fa256f00ce018e7b40e1dc756e403c86680bf448
+! leanprover-community/mathlib commit 2651125b48fc5c170ab1111afd0817c903b1fc6c
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -57,7 +57,7 @@ theorem coeff_bit0 (p : R[X]) (n : ℕ) : coeff (bit0 p) n = bit0 (coeff p n) :=
 #align polynomial.coeff_bit0 Polynomial.coeff_bit0
 
 @[simp]
-theorem coeff_smul [Monoid S] [DistribMulAction S R] (r : S) (p : R[X]) (n : ℕ) :
+theorem coeff_smul [SMulZeroClass S R] (r : S) (p : R[X]) (n : ℕ) :
     coeff (r • p) n = r • coeff p n := by
   rcases p with ⟨⟩
   simp_rw [← ofFinsupp_smul, coeff]


### PR DESCRIPTION
This additionally makes a further small generalization to some of the finsupp instances (labelled with porting notes) which should be backported.

The new statement of `Rat.smul_one_eq_coe` fixes a proof in `Mathlib/Analysis/NormedSpace/Basic.lean` that was mangled during porting.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

* [`data.polynomial.coeff`@`fa256f00ce018e7b40e1dc756e403c86680bf448`..`2651125b48fc5c170ab1111afd0817c903b1fc6c`](https://leanprover-community.github.io/mathlib-port-status/file/data/polynomial/coeff?range=fa256f00ce018e7b40e1dc756e403c86680bf448..2651125b48fc5c170ab1111afd0817c903b1fc6c)
* [`data.polynomial.basic`@`1f0096e6caa61e9c849ec2adbd227e960e9dff58`..`2651125b48fc5c170ab1111afd0817c903b1fc6c`](https://leanprover-community.github.io/mathlib-port-status/file/data/polynomial/basic?range=1f0096e6caa61e9c849ec2adbd227e960e9dff58..2651125b48fc5c170ab1111afd0817c903b1fc6c)
* [`algebra.monoid_algebra.basic`@`57e09a1296bfb4330ddf6624f1028ba186117d82`..`2651125b48fc5c170ab1111afd0817c903b1fc6c`](https://leanprover-community.github.io/mathlib-port-status/file/algebra/monoid_algebra/basic?range=57e09a1296bfb4330ddf6624f1028ba186117d82..2651125b48fc5c170ab1111afd0817c903b1fc6c)
* [`algebra.algebra.basic`@`2738d2ca56cbc63be80c3bd48e9ed90ad94e947d`..`2651125b48fc5c170ab1111afd0817c903b1fc6c`](https://leanprover-community.github.io/mathlib-port-status/file/algebra/algebra/basic?range=2738d2ca56cbc63be80c3bd48e9ed90ad94e947d..2651125b48fc5c170ab1111afd0817c903b1fc6c)
* [`data.finsupp.basic`@`f7fc89d5d5ff1db2d1242c7bb0e9062ce47ef47c`..`2651125b48fc5c170ab1111afd0817c903b1fc6c`](https://leanprover-community.github.io/mathlib-port-status/file/data/finsupp/basic?range=f7fc89d5d5ff1db2d1242c7bb0e9062ce47ef47c..2651125b48fc5c170ab1111afd0817c903b1fc6c)
* [`algebra.field.defs`@`70d50ecfd4900dd6d328da39ab7ebd516abe4025`..`2651125b48fc5c170ab1111afd0817c903b1fc6c`](https://leanprover-community.github.io/mathlib-port-status/file/algebra/field/defs?range=70d50ecfd4900dd6d328da39ab7ebd516abe4025..2651125b48fc5c170ab1111afd0817c903b1fc6c)

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
