### PR TITLE
chore: exclude build artifacts from VSCode search

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,9 +7,5 @@
   "files.insertFinalNewline": true,
   "files.trimFinalNewlines": true,
   "files.trimTrailingWhitespace": true,
-  "search.exclude": {
-    "**/build/**/*.c": true,
-    "**/build/**/*.ilean": true,
-    "**/build/**/*.trace": true
-  }
+  "search.useIgnoreFiles": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,9 @@
   "files.insertFinalNewline": true,
   "files.trimFinalNewlines": true,
   "files.trimTrailingWhitespace": true,
-  "search.usePCRE2": true
+  "search.exclude": {
+    "**/build/**/*.c": true,
+    "**/build/**/*.ilean": true,
+    "**/build/**/*.trace": true
+  }
 }


### PR DESCRIPTION
Omits `.ilean`, `.c` and `.trace` files from the ctrl-P / cmd-P file search interface.

The option about `search.usePCRE2` was flagged with a deprecation warning from VSCode, so I removed that, too.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
