### PR TITLE
[Merged by Bors] - doc: move comments

### DIFF
--- a/Mathlib/Data/String/Basic.lean
+++ b/Mathlib/Data/String/Basic.lean
@@ -95,7 +95,7 @@ instance LT' : LT String :=
 
 instance decidableLT : @DecidableRel String (· < ·) := by
   simp only [LT']
-  infer_instance
+  infer_instance -- short-circuit type class inference
 #align string.decidable_lt String.decidableLT
 
 /-- Induction on `String.ltb`. -/
@@ -138,7 +138,6 @@ lemma ltb.cons_add_csize (c : Char) (cs₁ cs₂ : List Char) (i₁ i₂ : ℕ) 
   · rename_i h₂ h₁ hne
     simp [Iterator.curr, Iterator.hasNext.cons_add_csize, get.cons_add_csize, *] at *
 
--- short-circuit type class inference
 @[simp]
 theorem lt_iff_toList_lt : ∀ {s₁ s₂ : String}, s₁ < s₂ ↔ s₁.toList < s₂.toList
 | ⟨s₁⟩, ⟨s₂⟩ => show ltb ⟨⟨s₁⟩, 0⟩ ⟨⟨s₂⟩, 0⟩ ↔ s₁ < s₂ by
@@ -175,10 +174,9 @@ instance LE : LE String :=
 
 instance decidableLE : @DecidableRel String (· ≤ ·) := by
   simp only [LE]
-  infer_instance
+  infer_instance -- short-circuit type class inference
 #align string.decidable_le String.decidableLE
 
--- short-circuit type class inference
 @[simp]
 theorem le_iff_toList_le {s₁ s₂ : String} : s₁ ≤ s₂ ↔ s₁.toList ≤ s₂.toList :=
   (not_congr lt_iff_toList_lt).trans not_lt


### PR DESCRIPTION
Two comments were in the wrong places.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
