### PR TITLE
[Merged by Bors] - feat: definition of krull dimension for a preordered set

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1636,6 +1636,7 @@ import Mathlib.Order.WellFoundedSet
 import Mathlib.Order.WithBot
 import Mathlib.Order.Zorn
 import Mathlib.Order.ZornAtoms
+import Mathlib.Order.KrullDimension
 import Mathlib.RepresentationTheory.Maschke
 import Mathlib.RingTheory.Adjoin.Basic
 import Mathlib.RingTheory.Adjoin.Fg

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1593,6 +1593,7 @@ import Mathlib.Order.Ideal
 import Mathlib.Order.InitialSeg
 import Mathlib.Order.Iterate
 import Mathlib.Order.JordanHolder
+import Mathlib.Order.KrullDimension
 import Mathlib.Order.Lattice
 import Mathlib.Order.LatticeIntervals
 import Mathlib.Order.LiminfLimsup
@@ -1636,7 +1637,6 @@ import Mathlib.Order.WellFoundedSet
 import Mathlib.Order.WithBot
 import Mathlib.Order.Zorn
 import Mathlib.Order.ZornAtoms
-import Mathlib.Order.KrullDimension
 import Mathlib.RepresentationTheory.Maschke
 import Mathlib.RingTheory.Adjoin.Basic
 import Mathlib.RingTheory.Adjoin.Fg

--- a/Mathlib/Order/KrullDimension.lean
+++ b/Mathlib/Order/KrullDimension.lean
@@ -25,8 +25,8 @@ coheight is defined to be the krull dimension of `[a, +∞)`.
 ## Implementation notes
 Krull dimensions are defined to take value in `WithBot (WithTop ℕ)` so that `(-∞) + (+∞)` is
 also negative infinity. This is because we want Krull dimensions to be additive with respect
-to product of affine varieties so that `-∞` being the Krull dimension of empty variety is
-equal to sum of `-∞` and the Krull dimension of any other affine varieties.
+to product of varieties so that `-∞` being the Krull dimension of empty variety is equal to 
+sum of `-∞` and the Krull dimension of any other varieties.
 -/
 
 variable (α : Type _) [Preorder α]

--- a/Mathlib/Order/KrullDimension.lean
+++ b/Mathlib/Order/KrullDimension.lean
@@ -11,6 +11,14 @@ import Mathlib.Data.Fin.Basic
 import Mathlib.Data.Nat.Lattice
 import Mathlib.Logic.Equiv.Fin
 
+/-!
+# Krull dimension of a preordered set
+
+If `α` is a preordered set, then `krull_dim α` is defined to be `sup {n | a₀ < a₁ < ... < aₙ}`.
+For `a : α`, its height is defined to be the krull dimension of the subset `(-∞, a]` while its
+coheight is defined to be the krull dimension of `[a, +∞)`.
+-/
+
 variable (α : Type _) [Preorder α]
 
 /--

--- a/Mathlib/Order/KrullDimension.lean
+++ b/Mathlib/Order/KrullDimension.lean
@@ -26,8 +26,8 @@ For a preordered set `(α, <)`, a strict series of `α` of length `n` is a stric
 `fin (n + 1) → α`, i.e. `a₀ < a₁ < ... < aₙ` with `aᵢ : α`.
 -/
 structure StrictSeries where
-/-- the largest (right most) index of a strict series -/
-maxIndex : ℕ
+/-- the number of inequalities in the series -/
+length : ℕ
 /-- the underlying function of a strict series -/
 toFun : Fin (maxIndex + 1) → α
 /-- the underlying function should be strictly monotonic -/

--- a/Mathlib/Order/KrullDimension.lean
+++ b/Mathlib/Order/KrullDimension.lean
@@ -39,31 +39,31 @@ structure StrictSeries where
 /-- the number of inequalities in the series -/
 length : ℕ
 /-- the underlying function of a strict series -/
-toFun : Fin (maxIndex + 1) → α
+toFun : Fin (length + 1) → α
 /-- the underlying function should be strictly monotonic -/
 StrictMono : StrictMono toFun
 
 namespace StrictSeries
 
-instance : CoeFun (StrictSeries α) (fun x ↦ Fin (x.maxIndex + 1) → α) :=
+instance : CoeFun (StrictSeries α) (fun x ↦ Fin (x.length + 1) → α) :=
 { coe := StrictSeries.toFun }
 
 instance : Preorder (StrictSeries α) :=
-Preorder.lift StrictSeries.maxIndex
+Preorder.lift StrictSeries.length
 
 variable {α}
 
-lemma le_def (x y : StrictSeries α) : x ≤ y ↔ x.maxIndex ≤ y.maxIndex :=
+lemma le_def (x y : StrictSeries α) : x ≤ y ↔ x.length ≤ y.length :=
 Iff.rfl
 
-lemma lt_def (x y : StrictSeries α) : x < y ↔ x.maxIndex < y.maxIndex :=
+lemma lt_def (x y : StrictSeries α) : x < y ↔ x.length < y.length :=
 Iff.rfl
 
 /--
 In a preordered set `α`, each term of `α` gives a strict series with the right most index to be 0.
 -/
 @[simps!] def singleton (a : α) : StrictSeries α :=
-{ maxIndex := 0
+{ length := 0
   toFun := fun _ ↦ a
   StrictMono := fun _ _ h ↦ (ne_of_lt h $ @Subsingleton.elim _ subsingleton_fin_one _ _).elim }
 
@@ -77,10 +77,10 @@ instance [Nonempty α] : Nonempty (StrictSeries α) :=
 Nonempty.map singleton inferInstance
 
 lemma top_len_unique [OrderTop (StrictSeries α)] (p : StrictSeries α) (hp : IsTop p) :
-  p.maxIndex = (⊤ : StrictSeries α).maxIndex :=
+  p.length = (⊤ : StrictSeries α).length :=
 le_antisymm (@le_top (StrictSeries α) _ _ _) (hp ⊤)
 
-lemma top_len_unique' (H1 H2 : OrderTop (StrictSeries α)) : H1.top.maxIndex = H2.top.maxIndex :=
+lemma top_len_unique' (H1 H2 : OrderTop (StrictSeries α)) : H1.top.length = H2.top.length :=
 le_antisymm (H2.le_top H1.top) (H1.le_top H2.top)
 
 end StrictSeries
@@ -92,7 +92,7 @@ is defined to be negative infinity; if the length of `a₀ < a₁ < ... < aₙ` 
 dimension is defined to be positive infinity.
 -/
 noncomputable def krullDim : WithBot (WithTop ℕ) :=
-⨆ (p : StrictSeries α), p.maxIndex
+⨆ (p : StrictSeries α), p.length
 
 /--
 Height of an element `a` of a preordered set `α` is the Krull dimension of the subset `(-∞, a]`

--- a/Mathlib/Order/KrullDimension.lean
+++ b/Mathlib/Order/KrullDimension.lean
@@ -14,7 +14,7 @@ import Mathlib.Logic.Equiv.Fin
 /-!
 # Krull dimension of a preordered set
 
-If `α` is a preordered set, then `krull_dim α` is defined to be `sup {n | a₀ < a₁ < ... < aₙ}`.
+If `α` is a preordered set, then `krullDim α` is defined to be `sup {n | a₀ < a₁ < ... < aₙ}`.
 In case that `α` is empty, then its Krull dimension is defined to be negative infinity; if the
 length of all series `a₀ < a₁ < ... < aₙ` is unbounded, then its Krull dimension is defined to
 be positive infinity.

--- a/Mathlib/Order/KrullDimension.lean
+++ b/Mathlib/Order/KrullDimension.lean
@@ -21,6 +21,12 @@ be positive infinity.
 
 For `a : α`, its height is defined to be the krull dimension of the subset `(-∞, a]` while its
 coheight is defined to be the krull dimension of `[a, +∞)`.
+
+## Implementation notes
+Krull dimensions are defined to take value in `WithBot (WithTop ℕ)` so that `(-∞) + (+∞)` is
+also negative infinity. This is because we want Krull dimensions to be additive with respect
+to product of affine varieties so that `-∞` being the Krull dimension of empty variety is
+equal to sum of `-∞` and the Krull dimension of any other affine varieties.
 -/
 
 variable (α : Type _) [Preorder α]

--- a/Mathlib/Order/KrullDimension.lean
+++ b/Mathlib/Order/KrullDimension.lean
@@ -15,6 +15,10 @@ import Mathlib.Logic.Equiv.Fin
 # Krull dimension of a preordered set
 
 If `α` is a preordered set, then `krull_dim α` is defined to be `sup {n | a₀ < a₁ < ... < aₙ}`.
+In case that `α` is empty, then its Krull dimension is defined to be negative infinity; if the
+length of all series `a₀ < a₁ < ... < aₙ` is unbounded, then its Krull dimension is defined to
+be positive infinity.
+
 For `a : α`, its height is defined to be the krull dimension of the subset `(-∞, a]` while its
 coheight is defined to be the krull dimension of `[a, +∞)`.
 -/
@@ -77,7 +81,9 @@ end StrictSeries
 
 /--
 Krull dimension of a preordered set `α` is the supremum of the right most index of all strict
-series of `α`.
+series of `α`. If there is no strict series `a₀ < a₁ < ... < aₙ` in `α`, then its Krull dimension
+is defined to be negative infinity; if the length of `a₀ < a₁ < ... < aₙ` is unbounded, its Krull
+dimension is defined to be positive infinity.
 -/
 noncomputable def krullDim : WithBot (WithTop ℕ) :=
 ⨆ (p : StrictSeries α), p.maxIndex

--- a/Mathlib/Order/KrullDimension.lean
+++ b/Mathlib/Order/KrullDimension.lean
@@ -1,0 +1,84 @@
+/-
+Copyright (c) 2023 Jujian Zhang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jujian Zhang, Fangmin Li
+-/
+
+import Mathlib.Order.Monotone.Basic
+import Mathlib.Order.CompleteLattice
+import Mathlib.Order.WithBot
+import Mathlib.Data.Fin.Basic
+import Mathlib.Data.Nat.Lattice
+import Mathlib.Logic.Equiv.Fin
+
+variable (α : Type _) [Preorder α]
+
+/--
+For a preordered set `(α, <)`, a strict series of `α` of length `n` is a strictly monotonic function
+`fin (n + 1) → α`, i.e. `a₀ < a₁ < ... < aₙ` with `aᵢ : α`.
+-/
+structure StrictSeries where
+/-- length of a strict series -/
+length : ℕ
+/-- the underlying function of a strict series -/
+toFun : Fin (length + 1) → α
+/-- the underlying function should be strictly monotonic -/
+StrictMono : StrictMono toFun
+
+namespace StrictSeries
+
+instance : CoeFun (StrictSeries α) (fun x ↦ Fin (x.length + 1) → α) :=
+{ coe := StrictSeries.toFun }
+
+instance : Preorder (StrictSeries α) :=
+Preorder.lift StrictSeries.length
+
+variable {α}
+
+lemma le_def (x y : StrictSeries α) : x ≤ y ↔ x.length ≤ y.length :=
+Iff.rfl
+
+lemma lt_def (x y : StrictSeries α) : x < y ↔ x.length < y.length :=
+Iff.rfl
+
+/--
+In a preordered set `α`, each term of `α` gives a strict series of length 0.
+-/
+@[simps!] def singleton (a : α) : StrictSeries α :=
+{ length := 0
+  toFun := fun _ ↦ a
+  StrictMono := fun _ _ h ↦ (ne_of_lt h $ @Subsingleton.elim _ subsingleton_fin_one _ _).elim }
+
+instance [IsEmpty α] : IsEmpty (StrictSeries α) :=
+{ false := fun x ↦ IsEmpty.false (x 0) }
+
+instance [Inhabited α] : Inhabited (StrictSeries α) :=
+{ default := singleton default }
+
+instance [Nonempty α] : Nonempty (StrictSeries α) :=
+Nonempty.map singleton inferInstance
+
+lemma top_len_unique [OrderTop (StrictSeries α)] (p : StrictSeries α) (hp : IsTop p) :
+  p.length = (⊤ : StrictSeries α).length :=
+le_antisymm (@le_top (StrictSeries α) _ _ _) (hp ⊤)
+
+lemma top_len_unique' (H1 H2 : OrderTop (StrictSeries α)) : H1.top.length = H2.top.length :=
+le_antisymm (H2.le_top H1.top) (H1.le_top H2.top)
+
+end StrictSeries
+
+/--
+Krull dimension of a preordered set `α` is the supremum of lengths of all strict series of `α`.
+-/
+noncomputable def krull_dim : WithBot (WithTop ℕ) :=
+⨆ (p : StrictSeries α), p.length
+
+/--
+Height of an element `a` of a preordered set `α` is the Krull dimension of the subset `(-∞, a]`
+-/
+noncomputable def height (a : α) : WithBot (WithTop ℕ) := krull_dim (Set.Iic a)
+
+/--
+Coheight of an element `a` of a pre-ordered set `α` is the Krull dimension of the subset `[a, +∞)`
+-/
+noncomputable def coheight (a : α) : WithBot (WithTop ℕ) := krull_dim (Set.Ici a)

--- a/Mathlib/Order/KrullDimension.lean
+++ b/Mathlib/Order/KrullDimension.lean
@@ -26,34 +26,34 @@ For a preordered set `(α, <)`, a strict series of `α` of length `n` is a stric
 `fin (n + 1) → α`, i.e. `a₀ < a₁ < ... < aₙ` with `aᵢ : α`.
 -/
 structure StrictSeries where
-/-- length of a strict series -/
-length : ℕ
+/-- the largest (right most) index of a strict series -/
+maxIndex : ℕ
 /-- the underlying function of a strict series -/
-toFun : Fin (length + 1) → α
+toFun : Fin (maxIndex + 1) → α
 /-- the underlying function should be strictly monotonic -/
 StrictMono : StrictMono toFun
 
 namespace StrictSeries
 
-instance : CoeFun (StrictSeries α) (fun x ↦ Fin (x.length + 1) → α) :=
+instance : CoeFun (StrictSeries α) (fun x ↦ Fin (x.maxIndex + 1) → α) :=
 { coe := StrictSeries.toFun }
 
 instance : Preorder (StrictSeries α) :=
-Preorder.lift StrictSeries.length
+Preorder.lift StrictSeries.maxIndex
 
 variable {α}
 
-lemma le_def (x y : StrictSeries α) : x ≤ y ↔ x.length ≤ y.length :=
+lemma le_def (x y : StrictSeries α) : x ≤ y ↔ x.maxIndex ≤ y.maxIndex :=
 Iff.rfl
 
-lemma lt_def (x y : StrictSeries α) : x < y ↔ x.length < y.length :=
+lemma lt_def (x y : StrictSeries α) : x < y ↔ x.maxIndex < y.maxIndex :=
 Iff.rfl
 
 /--
-In a preordered set `α`, each term of `α` gives a strict series of length 0.
+In a preordered set `α`, each term of `α` gives a strict series with the right most index to be 0.
 -/
 @[simps!] def singleton (a : α) : StrictSeries α :=
-{ length := 0
+{ maxIndex := 0
   toFun := fun _ ↦ a
   StrictMono := fun _ _ h ↦ (ne_of_lt h $ @Subsingleton.elim _ subsingleton_fin_one _ _).elim }
 
@@ -67,26 +67,27 @@ instance [Nonempty α] : Nonempty (StrictSeries α) :=
 Nonempty.map singleton inferInstance
 
 lemma top_len_unique [OrderTop (StrictSeries α)] (p : StrictSeries α) (hp : IsTop p) :
-  p.length = (⊤ : StrictSeries α).length :=
+  p.maxIndex = (⊤ : StrictSeries α).maxIndex :=
 le_antisymm (@le_top (StrictSeries α) _ _ _) (hp ⊤)
 
-lemma top_len_unique' (H1 H2 : OrderTop (StrictSeries α)) : H1.top.length = H2.top.length :=
+lemma top_len_unique' (H1 H2 : OrderTop (StrictSeries α)) : H1.top.maxIndex = H2.top.maxIndex :=
 le_antisymm (H2.le_top H1.top) (H1.le_top H2.top)
 
 end StrictSeries
 
 /--
-Krull dimension of a preordered set `α` is the supremum of lengths of all strict series of `α`.
+Krull dimension of a preordered set `α` is the supremum of the right most index of all strict
+series of `α`.
 -/
-noncomputable def krull_dim : WithBot (WithTop ℕ) :=
-⨆ (p : StrictSeries α), p.length
+noncomputable def krullDim : WithBot (WithTop ℕ) :=
+⨆ (p : StrictSeries α), p.maxIndex
 
 /--
 Height of an element `a` of a preordered set `α` is the Krull dimension of the subset `(-∞, a]`
 -/
-noncomputable def height (a : α) : WithBot (WithTop ℕ) := krull_dim (Set.Iic a)
+noncomputable def height (a : α) : WithBot (WithTop ℕ) := krullDim (Set.Iic a)
 
 /--
 Coheight of an element `a` of a pre-ordered set `α` is the Krull dimension of the subset `[a, +∞)`
 -/
-noncomputable def coheight (a : α) : WithBot (WithTop ℕ) := krull_dim (Set.Ici a)
+noncomputable def coheight (a : α) : WithBot (WithTop ℕ) := krullDim (Set.Ici a)


### PR DESCRIPTION
Given a preordered set $(S, <)$, the krull dimension of $S$ is defined to be $\sup\{n | a_0 < a_1 < ... < a_n\}$ where the supremum takes place in extended natural numbers $\mathbb N \cup \{\pm \infty\}$, i.e. empty set is negative-infinite dimensional and a set with arbitrary long $a_0 < a_1 < ... < a_n$ is positive dimensional. 

Similar constructions in mathlib does require a chain to be nonempty so that empty set would have the wrong dimension, so I defined a new structure `StrictSeries` to avoid confusion with `chain`; in this structure, the underlying list is always nonempty. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
