### PR TITLE
[Merged by Bors] - chore: add hash for Data.MvPolynomial.Polynomial

### DIFF
--- a/Mathlib/Data/MvPolynomial/Polynomial.lean
+++ b/Mathlib/Data/MvPolynomial/Polynomial.lean
@@ -2,6 +2,11 @@
 Copyright (c) 2023 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
+
+! This file was ported from Lean 3 source module data.mv_polynomial.polynomial
+! leanprover-community/mathlib commit 0b89934139d3be96f9dab477f10c20f9f93da580
+! Please do not edit these lines, except to modify the commit id
+! if you have ported upstream changes.
 -/
 import Mathlib.Data.MvPolynomial.Equiv
 import Mathlib.Data.Polynomial.Eval


### PR DESCRIPTION
---

* This file was introduced to mathlib4 in: https://github.com/leanprover-community/mathlib4/pull/3225
* Later, this file was introduced to mathlib in: https://github.com/leanprover-community/mathlib/pull/18839
* I added the hash from [mathlib3port](https://github.com/leanprover-community/mathlib3port/blob/9d2a1d211c486c931a63692a1d898472274c9a50/Mathbin/Data/MvPolynomial/Polynomial.lean) to the file. Hopefully, this fixes the issue with the porting status page.


<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
