### PR TITLE
[Merged by Bors] - feat: annotate build errors in the github files changed tab using an action

### DIFF
--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -103,7 +103,10 @@ jobs:
         run: lake exe cache get
 
       - name: build mathlib
-        run: env LEAN_ABORT_ON_PANIC=1 lake build
+        uses: liskin/gh-problem-matcher-wrap@v2
+        with:
+          linters: gcc
+          run: env LEAN_ABORT_ON_PANIC=1 lake build
 
       - name: build library_search cache
         run: lake build MathlibExtras

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,7 +109,10 @@ jobs:
         run: lake exe cache get
 
       - name: build mathlib
-        run: env LEAN_ABORT_ON_PANIC=1 lake build
+        uses: liskin/gh-problem-matcher-wrap@v2
+        with:
+          linters: gcc
+          run: env LEAN_ABORT_ON_PANIC=1 lake build
 
       - name: build library_search cache
         run: lake build MathlibExtras

--- a/.github/workflows/build.yml.in
+++ b/.github/workflows/build.yml.in
@@ -89,7 +89,10 @@ jobs:
         run: lake exe cache get
 
       - name: build mathlib
-        run: env LEAN_ABORT_ON_PANIC=1 lake build
+        uses: liskin/gh-problem-matcher-wrap@v2
+        with:
+          linters: gcc
+          run: env LEAN_ABORT_ON_PANIC=1 lake build
 
       - name: build library_search cache
         run: lake build MathlibExtras

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -107,7 +107,10 @@ jobs:
         run: lake exe cache get
 
       - name: build mathlib
-        run: env LEAN_ABORT_ON_PANIC=1 lake build
+        uses: liskin/gh-problem-matcher-wrap@v2
+        with:
+          linters: gcc
+          run: env LEAN_ABORT_ON_PANIC=1 lake build
 
       - name: build library_search cache
         run: lake build MathlibExtras

--- a/Mathlib/CategoryTheory/Functor/Category.lean
+++ b/Mathlib/CategoryTheory/Functor/Category.lean
@@ -62,7 +62,7 @@ namespace NatTrans
 theorem ext' {α β : F ⟶ G} (w : α.app = β.app) : α = β := NatTrans.ext _ _ w
 
 @[simp]
-theorem vcomp_eq_comp (α : F ⟶ G) (β : G ⟶ H) : vomp α β = α ≫ β := rfl
+theorem vcomp_eq_comp (α : F ⟶ G) (β : G ⟶ H) : vcomp α β = α ≫ β := rfl
 #align category_theory.nat_trans.vcomp_eq_comp CategoryTheory.NatTrans.vcomp_eq_comp
 
 theorem vcomp_app' (α : F ⟶ G) (β : G ⟶ H) (X : C) : (α ≫ β).app X = α.app X ≫ β.app X := rfl

--- a/Mathlib/CategoryTheory/Functor/Category.lean
+++ b/Mathlib/CategoryTheory/Functor/Category.lean
@@ -62,7 +62,7 @@ namespace NatTrans
 theorem ext' {α β : F ⟶ G} (w : α.app = β.app) : α = β := NatTrans.ext _ _ w
 
 @[simp]
-theorem vcomp_eq_comp (α : F ⟶ G) (β : G ⟶ H) : vcomp α β = α ≫ β := rfl
+theorem vcomp_eq_comp (α : F ⟶ G) (β : G ⟶ H) : vomp α β = α ≫ β := rfl
 #align category_theory.nat_trans.vcomp_eq_comp CategoryTheory.NatTrans.vcomp_eq_comp
 
 theorem vcomp_app' (α : F ⟶ G) (β : G ⟶ H) (X : C) : (α ≫ β).app X = α.app X ≫ β.app X := rfl


### PR DESCRIPTION
This is suboptimal as it doesn't handle multiline comments, but it is better than nothing, and the implementation works out of the box. This is broadly similar to the support we had in mathlib 3, but the implementation is different as we no longer have json errors as an option, so must instead match an errorformat directly (the gcc one works fine).

Supporting multiline error messages appears not to be possible using the builtin output without further processing with the current state of problem matchers supported by github (which follow the vscode design).

Thus to get an improvement on this the build output must be piped through a second program that processes it in some way, or a lake build type command should be added that outputs in a required format.

Likewise to get annotations for linter failures we will need to add extra information to the linter output, either setting the annotations ourselves (as we did in mathlib 3) or at least adding line numbers to the existing output so that we can at least match it with a problem matcher again.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
