### PR TITLE
[Merged by Bors] - chore: Move lattice `finset` lemmas around

### DIFF
--- a/Mathlib/Data/Complex/Exponential.lean
+++ b/Mathlib/Data/Complex/Exponential.lean
@@ -1878,6 +1878,7 @@ theorem cos_bound {x : ℝ} (hx : |x| ≤ 1) : |cos x - (1 - x ^ 2 / 2)| ≤ |x|
     _ ≤ |x| ^ 4 * (5 / 96) := by norm_num
 #align real.cos_bound Real.cos_bound
 
+set_option maxHeartbeats 300000 in
 theorem sin_bound {x : ℝ} (hx : |x| ≤ 1) : |sin x - (x - x ^ 3 / 6)| ≤ |x| ^ 4 * (5 / 96) :=
   calc
     |sin x - (x - x ^ 3 / 6)| = Complex.abs (Complex.sin x - (x - x ^ 3 / 6 : ℝ)) := by

--- a/Mathlib/Data/Finset/Lattice.lean
+++ b/Mathlib/Data/Finset/Lattice.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 
 ! This file was ported from Lean 3 source module data.finset.lattice
-! leanprover-community/mathlib commit c813ed7de0f5115f956239124e9b30f3a621966f
+! leanprover-community/mathlib commit 9d684a893c52e1d6692a504a118bfccbae04feeb
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -13,13 +13,14 @@ import Mathlib.Data.Finset.Option
 import Mathlib.Data.Finset.Prod
 import Mathlib.Data.Multiset.Lattice
 import Mathlib.Order.CompleteLattice
+import Mathlib.Order.Hom.Lattice
 
 /-!
 # Lattice operations on finsets
 -/
 
 
-variable {α β γ ι : Type _}
+variable {F α β γ ι : Type _}
 
 namespace Finset
 
@@ -92,6 +93,13 @@ theorem sup_congr {f g : β → α} (hs : s₁ = s₂) (hfg : ∀ a ∈ s₂, f 
   subst hs
   exact Finset.fold_congr hfg
 #align finset.sup_congr Finset.sup_congr
+
+@[simp]
+theorem _root_.map_finset_sup [SemilatticeSup β] [OrderBot β] [SupBotHomClass F α β] (f : F)
+    (s : Finset ι) (g : ι → α) : f (s.sup g) = s.sup (f ∘ g) :=
+  Finset.cons_induction_on s (map_bot f) fun i s _ h => by
+    rw [sup_cons, sup_cons, map_sup, h, Function.comp_apply]
+#align map_finset_sup map_finset_sup
 
 @[simp]
 protected theorem sup_le_iff {a : α} : s.sup f ≤ a ↔ ∀ b ∈ s, f b ≤ a := by
@@ -360,6 +368,13 @@ theorem inf_congr {f g : β → α} (hs : s₁ = s₂) (hfg : ∀ a ∈ s₂, f 
 #align finset.inf_congr Finset.inf_congr
 
 @[simp]
+theorem _root_.map_finset_inf [SemilatticeInf β] [OrderTop β] [InfTopHomClass F α β] (f : F)
+    (s : Finset ι) (g : ι → α) : f (s.inf g) = s.inf (f ∘ g) :=
+  Finset.cons_induction_on s (map_top f) fun i s _ h => by
+    rw [inf_cons, inf_cons, map_inf, h, Function.comp_apply]
+#align map_finset_inf map_finset_inf
+
+@[simp]
 theorem inf_bunionᵢ [DecidableEq β] (s : Finset γ) (t : γ → Finset β) :
     (s.bunionᵢ t).inf f = s.inf fun x => (t x).inf f :=
   @sup_bunionᵢ αᵒᵈ _ _ _ _ _ _ _ _
@@ -425,27 +440,6 @@ theorem inf_product_right (s : Finset β) (t : Finset γ) (f : β × γ → α) 
 theorem inf_erase_top [DecidableEq α] (s : Finset α) : (s.erase ⊤).inf id = s.inf id :=
   @sup_erase_bot αᵒᵈ _ _ _ _
 #align finset.inf_erase_top Finset.inf_erase_top
-
-theorem sup_sdiff_left {α β : Type _} [BooleanAlgebra α] (s : Finset β) (f : β → α) (a : α) :
-    (s.sup fun b => a \ f b) = a \ s.inf f := by
-  refine' Finset.cons_induction_on s _ fun b t _ h => _
-  · rw [sup_empty, inf_empty, sdiff_top]
-  · rw [sup_cons, inf_cons, h, sdiff_inf]
-#align finset.sup_sdiff_left Finset.sup_sdiff_left
-
-theorem inf_sdiff_left {α β : Type _} [BooleanAlgebra α] {s : Finset β} (hs : s.Nonempty)
-    (f : β → α) (a : α) : (s.inf fun b => a \ f b) = a \ s.sup f := by
-  induction' hs using Finset.Nonempty.cons_induction with b b t _ _ h
-  · rw [sup_singleton, inf_singleton]
-  · rw [sup_cons, inf_cons, h, sdiff_sup]
-#align finset.inf_sdiff_left Finset.inf_sdiff_left
-
-theorem inf_sdiff_right {α β : Type _} [BooleanAlgebra α] {s : Finset β} (hs : s.Nonempty)
-    (f : β → α) (a : α) : (s.inf fun b => f b \ a) = s.inf f \ a := by
-  induction' hs using Finset.Nonempty.cons_induction with b b t _ _ h
-  · rw [inf_singleton, inf_singleton]
-  · rw [inf_cons, inf_cons, h, inf_sdiff]
-#align finset.inf_sdiff_right Finset.inf_sdiff_right
 
 theorem comp_inf_eq_inf_comp [SemilatticeInf γ] [OrderTop γ] {s : Finset β} {f : β → α} (g : α → γ)
     (g_inf : ∀ x y, g (x ⊓ y) = g x ⊓ g y) (top : g ⊤ = ⊤) : g (s.inf f) = s.inf (g ∘ f) :=
@@ -557,6 +551,33 @@ theorem inf_sup_distrib_right (s : Finset ι) (f : ι → α) (a : α) :
 end OrderTop
 
 end DistribLattice
+
+section BooleanAlgebra
+
+variable [BooleanAlgebra α] {s : Finset ι}
+
+theorem sup_sdiff_left (s : Finset ι) (f : ι → α) (a : α) :
+    (s.sup fun b => a \ f b) = a \ s.inf f := by
+  refine' Finset.cons_induction_on s _ fun b t _ h => _
+  · rw [sup_empty, inf_empty, sdiff_top]
+  · rw [sup_cons, inf_cons, h, sdiff_inf]
+#align finset.sup_sdiff_left Finset.sup_sdiff_left
+
+theorem inf_sdiff_left (hs : s.Nonempty) (f : ι → α) (a : α) :
+    (s.inf fun b => a \ f b) = a \ s.sup f := by
+  induction' hs using Finset.Nonempty.cons_induction with b b t _ _ h
+  · rw [sup_singleton, inf_singleton]
+  · rw [sup_cons, inf_cons, h, sdiff_sup]
+#align finset.inf_sdiff_left Finset.inf_sdiff_left
+
+theorem inf_sdiff_right (hs : s.Nonempty) (f : ι → α) (a : α) :
+    (s.inf fun b => f b \ a) = s.inf f \ a := by
+  induction' hs using Finset.Nonempty.cons_induction with b b t _ _ h
+  · rw [inf_singleton, inf_singleton]
+  · rw [inf_cons, inf_cons, h, inf_sdiff]
+#align finset.inf_sdiff_right Finset.inf_sdiff_right
+
+end BooleanAlgebra
 
 section LinearOrder
 

--- a/Mathlib/LinearAlgebra/Basic.lean
+++ b/Mathlib/LinearAlgebra/Basic.lean
@@ -5,7 +5,7 @@ Authors: Johannes Hölzl, Mario Carneiro, Kevin Buzzard, Yury Kudryashov, Fréd�
   Heather Macbeth
 
 ! This file was ported from Lean 3 source module linear_algebra.basic
-! leanprover-community/mathlib commit b363547b3113d350d053abdf2884e9850a56b205
+! leanprover-community/mathlib commit 9d684a893c52e1d6692a504a118bfccbae04feeb
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -1371,7 +1371,7 @@ theorem le_ker_iff_map [RingHomSurjective τ₁₂] {f : F} {p : Submodule R M} 
 #align linear_map.le_ker_iff_map LinearMap.le_ker_iff_map
 
 theorem ker_codRestrict {τ₂₁ : R₂ →+* R} (p : Submodule R M) (f : M₂ →ₛₗ[τ₂₁] M) (hf) :
-    ker (codRestrict p f hf) = ker f := by rw [ker, comap_codRestrict, map_bot]; rfl
+    ker (codRestrict p f hf) = ker f := by rw [ker, comap_codRestrict, Submodule.map_bot]; rfl
 #align linear_map.ker_cod_restrict LinearMap.ker_codRestrict
 
 theorem range_codRestrict {τ₂₁ : R₂ →+* R} [RingHomSurjective τ₂₁] (p : Submodule R M)

--- a/Mathlib/LinearAlgebra/Finsupp.lean
+++ b/Mathlib/LinearAlgebra/Finsupp.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl
 
 ! This file was ported from Lean 3 source module linear_algebra.finsupp
-! leanprover-community/mathlib commit 3dec44d0b621a174c56e994da4aae15ba60110a2
+! leanprover-community/mathlib commit 9d684a893c52e1d6692a504a118bfccbae04feeb
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -285,7 +285,7 @@ theorem supported_unionᵢ {δ : Type _} (s : δ → Set α) :
   suffices
     LinearMap.range ((Submodule.subtype _).comp (restrictDom M R (⋃ i, s i))) ≤
       ⨆ i, supported M R (s i) by
-    rwa [LinearMap.range_comp, range_restrictDom, map_top, range_subtype] at this
+    rwa [LinearMap.range_comp, range_restrictDom, Submodule.map_top, range_subtype] at this
   rw [range_le_iff_comap, eq_top_iff]
   rintro l ⟨⟩
   -- Porting note: Was ported as `induction l using Finsupp.induction`
@@ -735,8 +735,9 @@ protected def totalOn (s : Set α) : supported R R s →ₗ[R] span R (v '' s) :
 variable {α} {M} {v}
 
 theorem totalOn_range (s : Set α) : LinearMap.range (Finsupp.totalOn α M R v s) = ⊤ := by
-  rw [Finsupp.totalOn, LinearMap.range_eq_map, LinearMap.map_codRestrict, ←
-    LinearMap.range_le_iff_comap, range_subtype, map_top, LinearMap.range_comp, range_subtype]
+  rw [Finsupp.totalOn, LinearMap.range_eq_map, LinearMap.map_codRestrict,
+    ←LinearMap.range_le_iff_comap, range_subtype, Submodule.map_top, LinearMap.range_comp,
+    range_subtype]
   exact (span_image_eq_map_total _ _).le
 #align finsupp.total_on_range Finsupp.totalOn_range
 

--- a/Mathlib/LinearAlgebra/LinearIndependent.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro, Alexander Bentkamp, Anne Baanen
 
 ! This file was ported from Lean 3 source module linear_algebra.linear_independent
-! leanprover-community/mathlib commit 6d584f1709bedbed9175bd9350df46599bdd7213
+! leanprover-community/mathlib commit 9d684a893c52e1d6692a504a118bfccbae04feeb
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -401,7 +401,7 @@ theorem linearIndependent_subtype_disjoint {s : Set M} :
 theorem linearIndependent_iff_totalOn {s : Set M} :
     LinearIndependent R (fun x => x : s → M) ↔
     (LinearMap.ker $ Finsupp.totalOn M M R id s) = ⊥ := by
-  rw [Finsupp.totalOn, LinearMap.ker, LinearMap.comap_codRestrict, map_bot, comap_bot,
+  rw [Finsupp.totalOn, LinearMap.ker, LinearMap.comap_codRestrict, Submodule.map_bot, comap_bot,
     LinearMap.ker_comp, linearIndependent_subtype_disjoint, disjoint_iff_inf_le, ←
     map_comap_subtype, map_le_iff_le_comap, comap_bot, ker_subtype, le_bot_iff]
 #align linear_independent_iff_total_on linearIndependent_iff_totalOn
@@ -768,7 +768,7 @@ def LinearIndependent.totalEquiv (hv : LinearIndependent R v) :
       rw [LinearMap.mem_range]
       apply mem_range_self l
   · rw [← LinearMap.range_eq_top, LinearMap.range_eq_map, LinearMap.map_codRestrict, ←
-      LinearMap.range_le_iff_comap, range_subtype, map_top]
+      LinearMap.range_le_iff_comap, range_subtype, Submodule.map_top]
     rw [Finsupp.range_total]
 #align linear_independent.total_equiv LinearIndependent.totalEquiv
 #align linear_independent.total_equiv_symm_apply LinearIndependent.totalEquiv_symm_apply

--- a/Mathlib/LinearAlgebra/Quotient.lean
+++ b/Mathlib/LinearAlgebra/Quotient.lean
@@ -399,6 +399,8 @@ theorem comap_map_mkQ : comap p.mkQ (map p.mkQ p') = p ⊔ p' := by simp [comap_
 
 @[simp]
 theorem map_mkQ_eq_top : map p.mkQ p' = ⊤ ↔ p ⊔ p' = ⊤ := by
+  -- porting note: ambiguity of `map_eq_top_iff` is no longer automatically resolved by preferring
+  -- the current namespace
   simp only [LinearMap.map_eq_top_iff p.range_mkQ, sup_comm, ker_mkQ]
 #align submodule.map_mkq_eq_top Submodule.map_mkQ_eq_top
 

--- a/Mathlib/LinearAlgebra/Quotient.lean
+++ b/Mathlib/LinearAlgebra/Quotient.lean
@@ -399,7 +399,7 @@ theorem comap_map_mkQ : comap p.mkQ (map p.mkQ p') = p ⊔ p' := by simp [comap_
 
 @[simp]
 theorem map_mkQ_eq_top : map p.mkQ p' = ⊤ ↔ p ⊔ p' = ⊤ := by
-  simp only [map_eq_top_iff p.range_mkQ, sup_comm, ker_mkQ]
+  simp only [LinearMap.map_eq_top_iff p.range_mkQ, sup_comm, ker_mkQ]
 #align submodule.map_mkq_eq_top Submodule.map_mkQ_eq_top
 
 variable (q : Submodule R₂ M₂)

--- a/Mathlib/Order/Hom/CompleteLattice.lean
+++ b/Mathlib/Order/Hom/CompleteLattice.lean
@@ -4,11 +4,11 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 
 ! This file was ported from Lean 3 source module order.hom.complete_lattice
-! leanprover-community/mathlib commit 71b36b6f3bbe3b44e6538673819324d3ee9fcc96
+! leanprover-community/mathlib commit 9d684a893c52e1d6692a504a118bfccbae04feeb
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
-import Mathlib.Order.CompleteLattice
+import Mathlib.Data.Set.Lattice
 import Mathlib.Order.Hom.Lattice
 
 /-!

--- a/Mathlib/Order/Hom/Lattice.lean
+++ b/Mathlib/Order/Hom/Lattice.lean
@@ -4,11 +4,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 
 ! This file was ported from Lean 3 source module order.hom.lattice
-! leanprover-community/mathlib commit 9003f28797c0664a49e4179487267c494477d853
+! leanprover-community/mathlib commit 9d684a893c52e1d6692a504a118bfccbae04feeb
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
-import Mathlib.Data.Finset.Lattice
 import Mathlib.Order.Hom.Bounded
 import Mathlib.Order.SymmDiff
 
@@ -261,20 +260,6 @@ instance (priority := 100) OrderIsoClass.toBoundedLatticeHomClass [Lattice α] [
     BoundedLatticeHomClass F α β :=
   { OrderIsoClass.toLatticeHomClass, OrderIsoClass.toBoundedOrderHomClass with }
 #align order_iso_class.to_bounded_lattice_hom_class OrderIsoClass.toBoundedLatticeHomClass
-
-@[simp]
-theorem map_finset_sup [SemilatticeSup α] [OrderBot α] [SemilatticeSup β] [OrderBot β]
-    [SupBotHomClass F α β] (f : F) (s : Finset ι) (g : ι → α) : f (s.sup g) = s.sup (f ∘ g) :=
-  Finset.cons_induction_on s (map_bot f) fun i s _ h => by
-    rw [Finset.sup_cons, Finset.sup_cons, map_sup, h, Function.comp_apply]
-#align map_finset_sup map_finset_sup
-
-@[simp]
-theorem map_finset_inf [SemilatticeInf α] [OrderTop α] [SemilatticeInf β] [OrderTop β]
-    [InfTopHomClass F α β] (f : F) (s : Finset ι) (g : ι → α) : f (s.inf g) = s.inf (f ∘ g) :=
-  Finset.cons_induction_on s (map_top f) fun i s _ h => by
-    rw [Finset.inf_cons, Finset.inf_cons, map_inf, h, Function.comp_apply]
-#align map_finset_inf map_finset_inf
 
 section BoundedLattice
 

--- a/Mathlib/RingTheory/Ideal/Quotient.lean
+++ b/Mathlib/RingTheory/Ideal/Quotient.lean
@@ -299,6 +299,7 @@ section Pi
 
 variable (ι : Type v)
 
+set_option maxHeartbeats 300000 in
 /-- `R^n/I^n` is a `R/I`-module. -/
 instance modulePi : Module (R ⧸ I) ((ι → R) ⧸ I.pi ι) where
   smul c m :=

--- a/Mathlib/Topology/ContinuousOn.lean
+++ b/Mathlib/Topology/ContinuousOn.lean
@@ -1096,7 +1096,7 @@ theorem Embedding.continuousOn_iff {f : α → β} {g : β → γ} (hg : Embeddi
 
 theorem Embedding.map_nhdsWithin_eq {f : α → β} (hf : Embedding f) (s : Set α) (x : α) :
     map f (𝓝[s] x) = 𝓝[f '' s] f x := by
-  rw [nhdsWithin, map_inf hf.inj, hf.map_nhds_eq, map_principal, ← nhdsWithin_inter',
+  rw [nhdsWithin, Filter.map_inf hf.inj, hf.map_nhds_eq, map_principal, ← nhdsWithin_inter',
     inter_eq_self_of_subset_right (image_subset_range _ _)]
 #align embedding.map_nhds_within_eq Embedding.map_nhdsWithin_eq
 


### PR DESCRIPTION
Match https://github.com/leanprover-community/mathlib/pull/18900


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)


* [`order.hom.lattice`@`9003f28797c0664a49e4179487267c494477d853`..`9d684a893c52e1d6692a504a118bfccbae04feeb`](https://leanprover-community.github.io/mathlib-port-status/file/order/hom/lattice?range=9003f28797c0664a49e4179487267c494477d853..9d684a893c52e1d6692a504a118bfccbae04feeb)
* [`data.finset.lattice`@`c813ed7de0f5115f956239124e9b30f3a621966f`..`9d684a893c52e1d6692a504a118bfccbae04feeb`](https://leanprover-community.github.io/mathlib-port-status/file/data/finset/lattice?range=c813ed7de0f5115f956239124e9b30f3a621966f..9d684a893c52e1d6692a504a118bfccbae04feeb)
reviewers as shown:

* [`linear_algebra.basic`@`b363547b3113d350d053abdf2884e9850a56b205`..`9d684a893c52e1d6692a504a118bfccbae04feeb`](https://leanprover-community.github.io/mathlib-port-status/file/linear_algebra/basic?range=b363547b3113d350d053abdf2884e9850a56b205..9d684a893c52e1d6692a504a118bfccbae04feeb)
* [`linear_algebra.finsupp`@`3dec44d0b621a174c56e994da4aae15ba60110a2`..`9d684a893c52e1d6692a504a118bfccbae04feeb`](https://leanprover-community.github.io/mathlib-port-status/file/linear_algebra/finsupp?range=3dec44d0b621a174c56e994da4aae15ba60110a2..9d684a893c52e1d6692a504a118bfccbae04feeb)
* [`order.hom.complete_lattice`@`71b36b6f3bbe3b44e6538673819324d3ee9fcc96`..`9d684a893c52e1d6692a504a118bfccbae04feeb`](https://leanprover-community.github.io/mathlib-port-status/file/order/hom/complete_lattice?range=71b36b6f3bbe3b44e6538673819324d3ee9fcc96..9d684a893c52e1d6692a504a118bfccbae04feeb)
* [`linear_algebra.linear_independent`@`6d584f1709bedbed9175bd9350df46599bdd7213`..`9d684a893c52e1d6692a504a118bfccbae04feeb`](https://leanprover-community.github.io/mathlib-port-status/file/linear_algebra/linear_independent?range=6d584f1709bedbed9175bd9350df46599bdd7213..9d684a893c52e1d6692a504a118bfccbae04feeb)
