### PR TITLE
[Merged by Bors] - chore: forward-port backports

### DIFF
--- a/Mathlib/CategoryTheory/Abelian/Basic.lean
+++ b/Mathlib/CategoryTheory/Abelian/Basic.lean
@@ -268,6 +268,12 @@ namespace CategoryTheory.Abelian
 
 variable {C : Type u} [Category.{v} C] [Abelian C]
 
+-- Porting note: the below porting note is from mathlib3!
+-- Porting note: this should be an instance,
+-- but triggers https://github.com/leanprover/lean4/issues/2055
+-- We set it as a local instance instead.
+-- instance (priority := 100)
+theorem hasFiniteBiproducts : HasFiniteBiproducts C :=
 /-- An abelian category has finite biproducts. -/
 theorem hasFiniteBiproducts : HasFiniteBiproducts C :=
   Limits.HasFiniteBiproducts.of_hasFiniteProducts

--- a/Mathlib/CategoryTheory/Abelian/Basic.lean
+++ b/Mathlib/CategoryTheory/Abelian/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus Himmel, Johan Commelin, Scott Morrison
 
 ! This file was ported from Lean 3 source module category_theory.abelian.basic
-! leanprover-community/mathlib commit 8c75ef3517d4106e89fe524e6281d0b0545f47fc
+! leanprover-community/mathlib commit a5ff45a1c92c278b03b52459a620cfd9c49ebc80
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/

--- a/Mathlib/CategoryTheory/Abelian/Basic.lean
+++ b/Mathlib/CategoryTheory/Abelian/Basic.lean
@@ -273,7 +273,6 @@ variable {C : Type u} [Category.{v} C] [Abelian C]
 -- but triggers https://github.com/leanprover/lean4/issues/2055
 -- We set it as a local instance instead.
 -- instance (priority := 100)
-theorem hasFiniteBiproducts : HasFiniteBiproducts C :=
 /-- An abelian category has finite biproducts. -/
 theorem hasFiniteBiproducts : HasFiniteBiproducts C :=
   Limits.HasFiniteBiproducts.of_hasFiniteProducts

--- a/Mathlib/CategoryTheory/Abelian/Basic.lean
+++ b/Mathlib/CategoryTheory/Abelian/Basic.lean
@@ -269,11 +269,6 @@ namespace CategoryTheory.Abelian
 variable {C : Type u} [Category.{v} C] [Abelian C]
 
 /-- An abelian category has finite biproducts. -/
--- Porting note: we would like this to be an instance, and indeed it worked in mathlib3
--- however it triggers https://github.com/leanprover/lean4/issues/2055
--- during the simpNF linter, so for now we turn it on locally in this file.
--- This will likely cause problems in downstream ports, unfortunately.
--- instance (priority := 100)
 theorem hasFiniteBiproducts : HasFiniteBiproducts C :=
   Limits.HasFiniteBiproducts.of_hasFiniteProducts
 #align category_theory.abelian.has_finite_biproducts CategoryTheory.Abelian.hasFiniteBiproducts

--- a/Mathlib/CategoryTheory/Abelian/Opposite.lean
+++ b/Mathlib/CategoryTheory/Abelian/Opposite.lean
@@ -29,6 +29,7 @@ variable (C : Type _) [Category C] [Abelian C]
 --attribute [local instance]
 --  hasFiniteLimits_of_hasEqualizers_and_finite_products
 --  hasFiniteColimits_of_hasCoequalizers_and_finite_coproducts
+--  Abelian.hasFiniteBiproducts
 
 instance : Abelian Cᵒᵖ := by
   -- porting note: priorities of `Abelian.has_kernels` and `Abelian.has_cokernels` have

--- a/Mathlib/CategoryTheory/Abelian/Opposite.lean
+++ b/Mathlib/CategoryTheory/Abelian/Opposite.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 
 ! This file was ported from Lean 3 source module category_theory.abelian.opposite
-! leanprover-community/mathlib commit 8c75ef3517d4106e89fe524e6281d0b0545f47fc
+! leanprover-community/mathlib commit a5ff45a1c92c278b03b52459a620cfd9c49ebc80
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/

--- a/Mathlib/CategoryTheory/Limits/Preserves/Finite.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Finite.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Andrew Yang
 
 ! This file was ported from Lean 3 source module category_theory.limits.preserves.finite
-! leanprover-community/mathlib commit 024a4231815538ac739f52d08dd20a55da0d6b23
+! leanprover-community/mathlib commit 3974a774a707e2e06046a14c0eaef4654584fada
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/

--- a/Mathlib/CategoryTheory/Limits/Preserves/Finite.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Finite.lean
@@ -60,7 +60,8 @@ noncomputable instance (priority := 100) preservesLimitsOfShapeOfPreservesFinite
   apply preservesLimitsOfShapeOfEquiv (FinCategory.equivAsType J)
 #align category_theory.limits.preserves_limits_of_shape_of_preserves_finite_limits CategoryTheory.Limits.preservesLimitsOfShapeOfPreservesFiniteLimits
 
--- Porting note: this is a dangerous instance as it has unbound universe variables.
+-- This is a dangerous instance as it has unbound universe variables.
+/-- If we preserve limits of some arbitrary size, then we preserve all finite limits. -/
 noncomputable def PreservesLimitsOfSize.preservesFiniteLimits (F : C ⥤ D)
     [PreservesLimitsOfSize.{w, w₂} F] : PreservesFiniteLimits F where
   preservesFiniteLimits J (sJ : SmallCategory J) fJ := by
@@ -68,12 +69,13 @@ noncomputable def PreservesLimitsOfSize.preservesFiniteLimits (F : C ⥤ D)
     exact preservesLimitsOfShapeOfEquiv (FinCategory.equivAsType J) F
 #align category_theory.limits.preserves_limits.preserves_finite_limits_of_size CategoryTheory.Limits.PreservesLimitsOfSize.preservesFiniteLimits
 
--- Porting note: added as a specialization of the dangerous instance above.
+-- Added as a specialization of the dangerous instance above, for limits indexed in Type 0.
 noncomputable instance (priority := 120) PreservesLimitsOfSize0.preservesFiniteLimits
     (F : C ⥤ D) [PreservesLimitsOfSize.{0, 0} F] : PreservesFiniteLimits F :=
   PreservesLimitsOfSize.preservesFiniteLimits F
 #align preserves_limits_of_size.zero.preserves_finite_limits CategoryTheory.Limits.PreservesLimitsOfSize0.preservesFiniteLimits
 
+-- An alternative specialization of the dangerous instance for small limits.
 noncomputable instance (priority := 120) PreservesLimits.preservesFiniteLimits (F : C ⥤ D)
     [PreservesLimits F] : PreservesFiniteLimits F :=
   PreservesLimitsOfSize.preservesFiniteLimits F
@@ -129,15 +131,15 @@ noncomputable instance (priority := 100) preservesColimitsOfShapeOfPreservesFini
   apply preservesColimitsOfShapeOfEquiv (FinCategory.equivAsType J)
 #align category_theory.limits.preserves_colimits_of_shape_of_preserves_finite_colimits CategoryTheory.Limits.preservesColimitsOfShapeOfPreservesFiniteColimits
 
+-- This is a dangerous instance as it has unbound universe variables.
 /-- If we preserve colimits of some arbitrary size, then we preserve all finite colimits. -/
--- Porting note: this is a dangerous instance as it has unbound universe variables.
 noncomputable def PreservesColimitsOfSize.preservesFiniteColimits (F : C ⥤ D)
     [PreservesColimitsOfSize.{w, w₂} F] : PreservesFiniteColimits F where
   preservesFiniteColimits J (sJ : SmallCategory J) fJ := by
     haveI := preservesSmallestColimitsOfPreservesColimits F
     exact preservesColimitsOfShapeOfEquiv (FinCategory.equivAsType J) F
 
--- Porting note: added as a specialization of the dangerous instance above.
+-- Added as a specialization of the dangerous instance above, for colimits indexed in Type 0.
 noncomputable instance (priority := 120) PreservesColimitsOfSize0.preservesFiniteColimits
     (F : C ⥤ D) [PreservesColimitsOfSize.{0, 0} F] : PreservesFiniteColimits F :=
   PreservesColimitsOfSize.preservesFiniteColimits F

--- a/Mathlib/CategoryTheory/Limits/Preserves/Finite.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Finite.lean
@@ -138,6 +138,7 @@ noncomputable def PreservesColimitsOfSize.preservesFiniteColimits (F : C ⥤ D)
   preservesFiniteColimits J (sJ : SmallCategory J) fJ := by
     haveI := preservesSmallestColimitsOfPreservesColimits F
     exact preservesColimitsOfShapeOfEquiv (FinCategory.equivAsType J) F
+#align category_theory.limits.preserves_colimits_of_size.preserves_finite_colimits CategoryTheory.Limits.PreservesColimitsOfSize.preservesFiniteColimits
 
 -- Added as a specialization of the dangerous instance above, for colimits indexed in Type 0.
 noncomputable instance (priority := 120) PreservesColimitsOfSize0.preservesFiniteColimits

--- a/Mathlib/CategoryTheory/Limits/Preserves/Finite.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Finite.lean
@@ -72,6 +72,7 @@ noncomputable def PreservesLimitsOfSize.preservesFiniteLimits (F : C ⥤ D)
 noncomputable instance (priority := 120) PreservesLimitsOfSize0.preservesFiniteLimits
     (F : C ⥤ D) [PreservesLimitsOfSize.{0, 0} F] : PreservesFiniteLimits F :=
   PreservesLimitsOfSize.preservesFiniteLimits F
+#align preserves_limits_of_size.zero.preserves_finite_limits CategoryTheory.Limits.PreservesLimitsOfSize0.preservesFiniteLimits
 
 noncomputable instance (priority := 120) PreservesLimits.preservesFiniteLimits (F : C ⥤ D)
     [PreservesLimits F] : PreservesFiniteLimits F :=
@@ -128,6 +129,7 @@ noncomputable instance (priority := 100) preservesColimitsOfShapeOfPreservesFini
   apply preservesColimitsOfShapeOfEquiv (FinCategory.equivAsType J)
 #align category_theory.limits.preserves_colimits_of_shape_of_preserves_finite_colimits CategoryTheory.Limits.preservesColimitsOfShapeOfPreservesFiniteColimits
 
+/-- If we preserve colimits of some arbitrary size, then we preserve all finite colimits. -/
 -- Porting note: this is a dangerous instance as it has unbound universe variables.
 noncomputable def PreservesColimitsOfSize.preservesFiniteColimits (F : C ⥤ D)
     [PreservesColimitsOfSize.{w, w₂} F] : PreservesFiniteColimits F where
@@ -139,7 +141,9 @@ noncomputable def PreservesColimitsOfSize.preservesFiniteColimits (F : C ⥤ D)
 noncomputable instance (priority := 120) PreservesColimitsOfSize0.preservesFiniteColimits
     (F : C ⥤ D) [PreservesColimitsOfSize.{0, 0} F] : PreservesFiniteColimits F :=
   PreservesColimitsOfSize.preservesFiniteColimits F
+#align preserves_colimits_of_size.zero.preserves_finite_colimits CategoryTheory.Limits.PreservesColimitsOfSize0.preservesFiniteColimits
 
+-- An alternative specialization of the dangerous instance for small colimits.
 noncomputable instance (priority := 120) PreservesColimits.preservesFiniteColimits (F : C ⥤ D)
     [PreservesColimits F] : PreservesFiniteColimits F :=
   PreservesColimitsOfSize.preservesFiniteColimits F

--- a/Mathlib/CategoryTheory/Preadditive/Projective.lean
+++ b/Mathlib/CategoryTheory/Preadditive/Projective.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus Himmel, Scott Morrison
 
 ! This file was ported from Lean 3 source module category_theory.preadditive.projective
-! leanprover-community/mathlib commit f8d8465c3c392a93b9ed226956e26dee00975946
+! leanprover-community/mathlib commit 3974a774a707e2e06046a14c0eaef4654584fada
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/

--- a/Mathlib/Data/MvPolynomial/Basic.lean
+++ b/Mathlib/Data/MvPolynomial/Basic.lean
@@ -1148,6 +1148,11 @@ theorem eval_assoc {τ} (f : σ → MvPolynomial τ R) (g : τ → R) (p : MvPol
   congr with a; simp
 #align mv_polynomial.eval_assoc MvPolynomial.eval_assoc
 
+@[simp]
+theorem eval₂_id (p : MvPolynomial σ R) : eval₂ (RingHom.id _) g p = eval g p :=
+  rfl
+#align mv_polynomial.eval₂_id MvPolynomial.eval₂_id
+
 theorem eval_eval₂ [CommSemiring R] [CommSemiring S]
     (f : R →+* MvPolynomial τ S) (g : σ → MvPolynomial τ S) (p : MvPolynomial σ R) :
     eval x (eval₂ f g p) = eval₂ ((eval x).comp f) (fun s => eval x (g s)) p := by
@@ -1205,8 +1210,8 @@ theorem eval₂_eq_eval_map (g : σ → S₁) (p : MvPolynomial σ R) : p.eval�
 
   have h := eval₂_comp_left (eval₂Hom (RingHom.id S₁) g) (C.comp f) X p
   -- porting note: the Lean 3 version of `h` was full of metavariables which
-  -- were later unified during `rw [h]`
-  dsimp at h
+  -- were later unified during `rw [h]`. Also needed to add `-eval₂_id`.
+  dsimp [-eval₂_id] at h
   rw [h]
   congr
   · ext1 a
@@ -1214,14 +1219,6 @@ theorem eval₂_eq_eval_map (g : σ → S₁) (p : MvPolynomial σ R) : p.eval�
   · ext1 n
     simp only [comp_apply, eval₂_X]
 #align mv_polynomial.eval₂_eq_eval_map MvPolynomial.eval₂_eq_eval_map
-
--- Porting note: this was immediately before eval_eval₂ in mathlib3,
--- but it breaks the fragile proof of `eval₂_eq_eval_map`
--- so I've moved it here.
-@[simp]
-theorem eval₂_id (p : MvPolynomial σ R) : eval₂ (RingHom.id _) g p = eval g p :=
-  rfl
-#align mv_polynomial.eval₂_id MvPolynomial.eval₂_id
 
 theorem eval₂_comp_right {S₂} [CommSemiring S₂] (k : S₁ →+* S₂) (f : R →+* S₁) (g : σ → S₁) (p) :
     k (eval₂ f g p) = eval₂ k (k ∘ g) (map f p) := by

--- a/Mathlib/Data/MvPolynomial/Basic.lean
+++ b/Mathlib/Data/MvPolynomial/Basic.lean
@@ -1215,7 +1215,9 @@ theorem eval₂_eq_eval_map (g : σ → S₁) (p : MvPolynomial σ R) : p.eval�
     simp only [comp_apply, eval₂_X]
 #align mv_polynomial.eval₂_eq_eval_map MvPolynomial.eval₂_eq_eval_map
 
--- This probably belongs earlier, but it breaks the fragile proof of `eval₂_eq_eval_map`
+-- Porting note: this was immediately before eval_eval₂ in mathlib3,
+-- but it breaks the fragile proof of `eval₂_eq_eval_map`
+-- so I've moved it here.
 @[simp]
 theorem eval₂_id (p : MvPolynomial σ R) : eval₂ (RingHom.id _) g p = eval g p :=
   rfl

--- a/Mathlib/Data/MvPolynomial/Basic.lean
+++ b/Mathlib/Data/MvPolynomial/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Johan Commelin, Mario Carneiro
 
 ! This file was ported from Lean 3 source module data.mv_polynomial.basic
-! leanprover-community/mathlib commit 2d5739b61641ee4e7e53eca5688a08f66f2e6a60
+! leanprover-community/mathlib commit 0b89934139d3be96f9dab477f10c20f9f93da580
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -1148,7 +1148,6 @@ theorem eval_assoc {τ} (f : σ → MvPolynomial τ R) (g : τ → R) (p : MvPol
   congr with a; simp
 #align mv_polynomial.eval_assoc MvPolynomial.eval_assoc
 
--- Porting note: new theorem
 theorem eval_eval₂ [CommSemiring R] [CommSemiring S]
     (f : R →+* MvPolynomial τ S) (g : σ → MvPolynomial τ S) (p : MvPolynomial σ R) :
     eval x (eval₂ f g p) = eval₂ ((eval x).comp f) (fun s => eval x (g s)) p := by
@@ -1158,6 +1157,7 @@ theorem eval_eval₂ [CommSemiring R] [CommSemiring S]
     simp [hp, hq]
   · intro p n hp
     simp [hp]
+#align mv_polynomial.eval_eval₂ MvPolynomial.eval_eval₂
 
 end Eval
 
@@ -1215,11 +1215,11 @@ theorem eval₂_eq_eval_map (g : σ → S₁) (p : MvPolynomial σ R) : p.eval�
     simp only [comp_apply, eval₂_X]
 #align mv_polynomial.eval₂_eq_eval_map MvPolynomial.eval₂_eq_eval_map
 
--- Porting note: new theorem
 -- This probably belongs earlier, but it breaks the fragile proof of `eval₂_eq_eval_map`
 @[simp]
 theorem eval₂_id (p : MvPolynomial σ R) : eval₂ (RingHom.id _) g p = eval g p :=
   rfl
+#align mv_polynomial.eval₂_id MvPolynomial.eval₂_id
 
 theorem eval₂_comp_right {S₂} [CommSemiring S₂] (k : S₁ →+* S₂) (f : R →+* S₁) (g : σ → S₁) (p) :
     k (eval₂ f g p) = eval₂ k (k ∘ g) (map f p) := by

--- a/Mathlib/Data/MvPolynomial/Funext.lean
+++ b/Mathlib/Data/MvPolynomial/Funext.lean
@@ -10,8 +10,8 @@ Authors: Johan Commelin
 -/
 import Mathlib.Data.Polynomial.RingDivision
 import Mathlib.Data.MvPolynomial.Rename
-import Mathlib.Data.MvPolynomial.Polynomial
 import Mathlib.RingTheory.Polynomial.Basic
+import Mathlib.Data.MvPolynomial.Polynomial
 
 /-!
 ## Function extensionality for multivariate polynomials

--- a/Mathlib/Data/MvPolynomial/Funext.lean
+++ b/Mathlib/Data/MvPolynomial/Funext.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin
 
 ! This file was ported from Lean 3 source module data.mv_polynomial.funext
-! leanprover-community/mathlib commit da01792ca4894d4f3a98d06b6c50455e5ed25da3
+! leanprover-community/mathlib commit 0b89934139d3be96f9dab477f10c20f9f93da580
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/

--- a/Mathlib/Topology/Category/Top/Limits/Basic.lean
+++ b/Mathlib/Topology/Category/Top/Limits/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Patrick Massot, Scott Morrison, Mario Carneiro, Andrew Yang
 
 ! This file was ported from Lean 3 source module topology.category.Top.limits.basic
-! leanprover-community/mathlib commit 8195826f5c428fc283510bc67303dd4472d78498
+! leanprover-community/mathlib commit 178a32653e369dce2da68dc6b2694e385d484ef1
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/

--- a/Mathlib/Topology/Category/Top/Limits/Basic.lean
+++ b/Mathlib/Topology/Category/Top/Limits/Basic.lean
@@ -220,26 +220,26 @@ instance forgetPreservesColimits : PreservesColimits (forget : TopCat.{u} ⥤ Ty
   TopCat.forgetPreservesColimitsOfSize.{u, u}
 #align Top.forget_preserves_colimits TopCat.forgetPreservesColimits
 
-/-- The terminal object of `Top` is `punit`. -/
+/-- The terminal object of `Top` is `PUnit`. -/
 def isTerminalPunit : IsTerminal (TopCat.of PUnit.{u + 1}) :=
   haveI : ∀ X, Unique (X ⟶ TopCat.of PUnit.{u + 1}) := fun X =>
     ⟨⟨⟨fun _ => PUnit.unit, by continuity⟩⟩, fun f => by ext; aesop⟩
   Limits.IsTerminal.ofUnique _
 #align Top.is_terminal_punit TopCat.isTerminalPunit
 
-/-- The terminal object of `Top` is `punit`. -/
+/-- The terminal object of `Top` is `PUnit`. -/
 def terminalIsoPunit : ⊤_ TopCat.{u} ≅ TopCat.of PUnit :=
   terminalIsTerminal.uniqueUpToIso isTerminalPunit
 #align Top.terminal_iso_punit TopCat.terminalIsoPunit
 
-/-- The initial object of `Top` is `pempty`. -/
+/-- The initial object of `Top` is `PEmpty`. -/
 def isInitialPempty : IsInitial (TopCat.of PEmpty.{u + 1}) :=
   haveI : ∀ X, Unique (TopCat.of PEmpty.{u + 1} ⟶ X) := fun X =>
     ⟨⟨⟨fun x => x.elim, by continuity⟩⟩, fun f => by ext ⟨⟩⟩
   Limits.IsInitial.ofUnique _
 #align Top.is_initial_pempty TopCat.isInitialPempty
 
-/-- The initial object of `Top` is `pempty`. -/
+/-- The initial object of `Top` is `PEmpty`. -/
 def initialIsoPempty : ⊥_ TopCat.{u} ≅ TopCat.of PEmpty :=
   initialIsInitial.uniqueUpToIso isInitialPempty
 #align Top.initial_iso_pempty TopCat.initialIsoPempty

--- a/Mathlib/Topology/Category/Top/Limits/Basic.lean
+++ b/Mathlib/Topology/Category/Top/Limits/Basic.lean
@@ -223,8 +223,8 @@ instance forgetPreservesColimits : PreservesColimits (forget : TopCat.{u} ⥤ Ty
 /-- The terminal object of `Top` is `punit`. -/
 def isTerminalPunit : IsTerminal (TopCat.of PUnit.{u + 1}) :=
   haveI : ∀ X, Unique (X ⟶ TopCat.of PUnit.{u + 1}) := fun X =>
-    ⟨⟨⟨fun x => PUnit.unit, by continuity⟩⟩, fun f => by ext⟩
-  limits.is_terminal.of_unique _
+    ⟨⟨⟨fun _ => PUnit.unit, by continuity⟩⟩, fun f => by ext; aesop⟩
+  Limits.IsTerminal.ofUnique _
 #align Top.is_terminal_punit TopCat.isTerminalPunit
 
 /-- The terminal object of `Top` is `punit`. -/
@@ -236,7 +236,7 @@ def terminalIsoPunit : ⊤_ TopCat.{u} ≅ TopCat.of PUnit :=
 def isInitialPempty : IsInitial (TopCat.of PEmpty.{u + 1}) :=
   haveI : ∀ X, Unique (TopCat.of PEmpty.{u + 1} ⟶ X) := fun X =>
     ⟨⟨⟨fun x => x.elim, by continuity⟩⟩, fun f => by ext ⟨⟩⟩
-  limits.is_initial.of_unique _
+  Limits.IsInitial.ofUnique _
 #align Top.is_initial_pempty TopCat.isInitialPempty
 
 /-- The initial object of `Top` is `pempty`. -/

--- a/Mathlib/Topology/Category/Top/Limits/Basic.lean
+++ b/Mathlib/Topology/Category/Top/Limits/Basic.lean
@@ -219,3 +219,27 @@ instance forgetPreservesColimitsOfSize :
 instance forgetPreservesColimits : PreservesColimits (forget : TopCat.{u} ⥤ Type u) :=
   TopCat.forgetPreservesColimitsOfSize.{u, u}
 #align Top.forget_preserves_colimits TopCat.forgetPreservesColimits
+
+/-- The terminal object of `Top` is `punit`. -/
+def isTerminalPunit : IsTerminal (TopCat.of PUnit.{u + 1}) :=
+  haveI : ∀ X, Unique (X ⟶ TopCat.of PUnit.{u + 1}) := fun X =>
+    ⟨⟨⟨fun x => PUnit.unit, by continuity⟩⟩, fun f => by ext⟩
+  limits.is_terminal.of_unique _
+#align Top.is_terminal_punit TopCat.isTerminalPunit
+
+/-- The terminal object of `Top` is `punit`. -/
+def terminalIsoPunit : ⊤_ TopCat.{u} ≅ TopCat.of PUnit :=
+  terminalIsTerminal.uniqueUpToIso isTerminalPunit
+#align Top.terminal_iso_punit TopCat.terminalIsoPunit
+
+/-- The initial object of `Top` is `pempty`. -/
+def isInitialPempty : IsInitial (TopCat.of PEmpty.{u + 1}) :=
+  haveI : ∀ X, Unique (TopCat.of PEmpty.{u + 1} ⟶ X) := fun X =>
+    ⟨⟨⟨fun x => x.elim, by continuity⟩⟩, fun f => by ext ⟨⟩⟩
+  limits.is_initial.of_unique _
+#align Top.is_initial_pempty TopCat.isInitialPempty
+
+/-- The initial object of `Top` is `pempty`. -/
+def initialIsoPempty : ⊥_ TopCat.{u} ≅ TopCat.of PEmpty :=
+  initialIsInitial.uniqueUpToIso isInitialPempty
+#align Top.initial_iso_pempty TopCat.initialIsoPempty


### PR DESCRIPTION
* `data.mv_polynomial.basic`, `data.mv_polynomial.funext`: leanprover-community/mathlib#18839
* `category_theory.limits.preserves.finite`, `category_theory.preadditive.projective`:  leanprover-community/mathlib#18890
* `category_theory.abelian.basic`, `category_theory.abelian.opposite`:  leanprover-community/mathlib#18740
* `topology.category.Top.limits.basic`: leanprover-community/mathlib#18871. Note that this does not show a useful diff on the dashboard pages as file splits aren't tracked well by git.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
* [`data.mv_polynomial.basic`@`2d5739b61641ee4e7e53eca5688a08f66f2e6a60`..`0b89934139d3be96f9dab477f10c20f9f93da580`](https://leanprover-community.github.io/mathlib-port-status/file/data/mv_polynomial/basic?range=2d5739b61641ee4e7e53eca5688a08f66f2e6a60..0b89934139d3be96f9dab477f10c20f9f93da580)
* [`category_theory.limits.preserves.finite`@`024a4231815538ac739f52d08dd20a55da0d6b23`..`3974a774a707e2e06046a14c0eaef4654584fada`](https://leanprover-community.github.io/mathlib-port-status/file/category_theory/limits/preserves/finite?range=024a4231815538ac739f52d08dd20a55da0d6b23..3974a774a707e2e06046a14c0eaef4654584fada)
* [`category_theory.abelian.basic`@`8c75ef3517d4106e89fe524e6281d0b0545f47fc`..`a5ff45a1c92c278b03b52459a620cfd9c49ebc80`](https://leanprover-community.github.io/mathlib-port-status/file/category_theory/abelian/basic?range=8c75ef3517d4106e89fe524e6281d0b0545f47fc..a5ff45a1c92c278b03b52459a620cfd9c49ebc80)
* [`topology.category.Top.limits.basic`@`8195826f5c428fc283510bc67303dd4472d78498`..`178a32653e369dce2da68dc6b2694e385d484ef1`](https://leanprover-community.github.io/mathlib-port-status/file/topology/category/Top/limits/basic?range=8195826f5c428fc283510bc67303dd4472d78498..178a32653e369dce2da68dc6b2694e385d484ef1)
* [`category_theory.abelian.opposite`@`8c75ef3517d4106e89fe524e6281d0b0545f47fc`..`a5ff45a1c92c278b03b52459a620cfd9c49ebc80`](https://leanprover-community.github.io/mathlib-port-status/file/category_theory/abelian/opposite?range=8c75ef3517d4106e89fe524e6281d0b0545f47fc..a5ff45a1c92c278b03b52459a620cfd9c49ebc80)
* [`data.mv_polynomial.funext`@`da01792ca4894d4f3a98d06b6c50455e5ed25da3`..`0b89934139d3be96f9dab477f10c20f9f93da580`](https://leanprover-community.github.io/mathlib-port-status/file/data/mv_polynomial/funext?range=da01792ca4894d4f3a98d06b6c50455e5ed25da3..0b89934139d3be96f9dab477f10c20f9f93da580)
* [`category_theory.preadditive.projective`@`f8d8465c3c392a93b9ed226956e26dee00975946`..`3974a774a707e2e06046a14c0eaef4654584fada`](https://leanprover-community.github.io/mathlib-port-status/file/category_theory/preadditive/projective?range=f8d8465c3c392a93b9ed226956e26dee00975946..3974a774a707e2e06046a14c0eaef4654584fada)
