### PR TITLE
[Merged by Bors] - refactor, fix: `MetaM` version of `rfl` tactic and missing `whnfR`/`instantiateMVars`

### DIFF
--- a/Mathlib/Data/Complex/Exponential.lean
+++ b/Mathlib/Data/Complex/Exponential.lean
@@ -180,7 +180,6 @@ theorem series_ratio_test {f : ℕ → β} (n : ℕ) (r : α) (hr0 : 0 ≤ r) (h
   replace hk : m = k + n.succ := (tsub_eq_iff_eq_add_of_le hmn).1 hk
   induction' k with k ih generalizing m n
   · rw [hk, Nat.zero_add, mul_right_comm, inv_pow _ _, ← div_eq_mul_inv, mul_div_cancel]
-    exact le_refl _
     exact (ne_of_lt (pow_pos r_pos _)).symm
   · have kn : k + n.succ ≥ n.succ := by
       rw [← zero_add n.succ]; exact add_le_add (Nat.zero_le _) (by simp)

--- a/Mathlib/Data/MvPolynomial/Variables.lean
+++ b/Mathlib/Data/MvPolynomial/Variables.lean
@@ -97,7 +97,6 @@ theorem degrees_monomial (s : σ →₀ ℕ) (a : R) : degrees (monomial s a) �
     have := Finsupp.support_single_subset h
     rw [Finset.mem_singleton] at this
     rw [this]
-    exact le_refl _
 #align mv_polynomial.degrees_monomial MvPolynomial.degrees_monomial
 
 theorem degrees_monomial_eq (s : σ →₀ ℕ) (a : R) (ha : a ≠ 0) :

--- a/Mathlib/LinearAlgebra/AffineSpace/Basis.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Basis.lean
@@ -126,7 +126,6 @@ noncomputable def basisOf (i : ι) : Basis { j : ι // j ≠ i } k V :=
       suffices
         Submodule.span k (range fun j : { x // x ≠ i } => b ↑j -ᵥ b i) = vectorSpan k (range b) by
         rw [this, ← direction_affineSpan, b.tot, AffineSubspace.direction_top]
-        exact le_rfl
       conv_rhs => rw [← image_univ]
       rw [vectorSpan_image_eq_span_vsub_set_right_ne k b (mem_univ i)]
       congr

--- a/Mathlib/LinearAlgebra/FiniteDimensional.lean
+++ b/Mathlib/LinearAlgebra/FiniteDimensional.lean
@@ -1448,8 +1448,6 @@ theorem Subalgebra.eq_bot_of_finrank_one {S : Subalgebra F E} (h : finrank F S =
     -- porting note: fails without explicit type
     haveI : FiniteDimensional F S := finiteDimensional_of_finrank_eq_succ h
     rw [← finrank_eq_rank, h, Nat.cast_one]
-    -- porting note: added, `rw` forgot to close this
-    exact le_rfl
 #align subalgebra.eq_bot_of_finrank_one Subalgebra.eq_bot_of_finrank_one
 
 set_option synthInstance.etaExperiment true in

--- a/Mathlib/RingTheory/Multiplicity.lean
+++ b/Mathlib/RingTheory/Multiplicity.lean
@@ -243,8 +243,7 @@ theorem multiplicity_le_multiplicity_iff {a b c d : α} :
         exact le_multiplicity_of_pow_dvd (h _ (pow_multiplicity_dvd _))
     else by
       have : ∀ n : ℕ, c ^ n ∣ d := fun n => h n (not_finite_iff_forall.1 hab _)
-      rw [eq_top_iff_not_finite.2 hab, eq_top_iff_not_finite.2 (not_finite_iff_forall.2 this)]
-      apply le_refl⟩
+      rw [eq_top_iff_not_finite.2 hab, eq_top_iff_not_finite.2 (not_finite_iff_forall.2 this)]⟩
 #align multiplicity.multiplicity_le_multiplicity_iff multiplicity.multiplicity_le_multiplicity_iff
 
 theorem multiplicity_eq_multiplicity_iff {a b c d : α} :

--- a/Mathlib/Tactic/Relation/Rfl.lean
+++ b/Mathlib/Tactic/Relation/Rfl.lean
@@ -38,9 +38,13 @@ initialize registerBuiltinAttribute {
     reflExt.add (decl, key) kind
 }
 
---!! Can we use this in the tactic, or is saving the tactic state important?
+/-- `MetaM` version of the `rfl` tactic.
+
+This tactic applies to a goal whose target has the form `x ~ x`, where `~` is a reflexive
+relation, that is, a relation which has a reflexive lemma tagged with the attribute [refl].
+-/
 def _root_.Lean.MVarId.rfl (goal : MVarId) : MetaM (List MVarId) := do
-  let .app (.app rel _) _ ← goal.getType
+  let .app (.app rel _) _ ← whnfR <|← instantiateMVars <|← goal.getType
     | throwError "reflexivity lemmas only apply to binary relations, not
       {indentExpr (← goal.getType)}"
   let s ← saveState

--- a/Mathlib/Tactic/Relation/Rfl.lean
+++ b/Mathlib/Tactic/Relation/Rfl.lean
@@ -60,11 +60,12 @@ def _root_.Lean.MVarId.rfl (goal : MVarId) : MetaM Unit := do
           {goalsToMessageData gs}"
     catch e =>
       ex? := ex? <|> (some (← saveState, e)) -- stash the first failure of `apply`
+    s.restore
   if let some (sErr, e) := ex? then
     sErr.restore
-      throw e
+    throw e
   else
-  throwError "rfl failed, no lemma with @[refl] applies"
+    throwError "rfl failed, no lemma with @[refl] applies"
 
 /--
 This tactic applies to a goal whose target has the form `x ~ x`, where `~` is a reflexive

--- a/test/rfl.lean
+++ b/test/rfl.lean
@@ -28,3 +28,7 @@ instance : LE Foo := ⟨Foo.le⟩
 
 example (a : Foo) : a ≤ a := by apply Foo.le_refl
 example (a : Foo) : a ≤ a := by rfl
+
+example (x : Nat) : x ≤ x := by
+  show _
+  rfl


### PR DESCRIPTION
This PR factors out a `MetaM` version of the `rfl` tactic and adds a missing `whnfR` and `instantiateMVars` in front of the goal type. This means that a few `rw`s across mathlib4 now close the goal instead of e.g. requiring a trailing `exact le_rfl`.

Note: we do not use `whnfR` on the return type when adding the `refl` extension in the first place, as `forallMetaTelescopeReducing` already performs `whnf` (here, at reducible transparency).

See [zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/!4.233758.20.E2.80.93.20rfl.20refactor.20.26.20fix) for some discussion on the internal changes made.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
