### PR TITLE
[Merged by Bors] - fix: linarith variable shadowing bug

### DIFF
--- a/Mathlib/Tactic/Linarith/Frontend.lean
+++ b/Mathlib/Tactic/Linarith/Frontend.lean
@@ -202,8 +202,9 @@ prove `false` by calling `linarith` on each list in succession. It will stop at 
 -/
 def findLinarithContradiction (cfg : LinarithConfig) (g : MVarId) (ls : List (List Expr)) :
     MetaM Expr :=
-  ls.firstM (fun L => proveFalseByLinarith cfg g L)
-    <|> throwError "linarith failed to find a contradiction\n{g}"
+  try
+    ls.firstM (fun L => proveFalseByLinarith cfg g L)
+  catch e => throwError "linarith failed to find a contradiction\n{g}\n{e.toMessageData}"
 
 
 /--

--- a/Mathlib/Tactic/Linarith/Parsing.lean
+++ b/Mathlib/Tactic/Linarith/Parsing.lean
@@ -169,10 +169,10 @@ partial def linearFormOfExpr (red : TransparencyMode) (m : ExprMap) (e : Expr) :
   | (``Neg.neg, #[_, _, e]) => do
     let (m1, comp) ← linearFormOfExpr red m e
     return (m1, comp.mapVal (fun _ v => -v))
-  | (``HPow.hPow, #[_, _, _, _, e, n]) => do
+  | (``HPow.hPow, #[_, _, _, _, a, n]) => do
     match n.numeral? with
     | some n => do
-      let (m1, comp) ← linearFormOfExpr red m e
+      let (m1, comp) ← linearFormOfExpr red m a
       return (m1, comp.pow n)
     | none => linearFormOfAtom red m e
   | _ => linearFormOfAtom red m e

--- a/Mathlib/Tactic/Linarith/Verification.lean
+++ b/Mathlib/Tactic/Linarith/Verification.lean
@@ -198,6 +198,7 @@ def proveFalseByLinarith (cfg : LinarithConfig) : MVarId → List Expr → MetaM
     trace[linarith.detail] "... finished `addNegEqProofs`."
     let inputs := (← mkNegOneLtZeroProof (← typeOfIneqProof h))::l'.reverse
     trace[linarith.detail] "... finished `mkNegOneLtZeroProof`."
+    trace[linarith.detail] (← inputs.mapM inferType)
     let (comps, max_var) ← linearFormsAndMaxVar cfg.transparency inputs
     trace[linarith.detail] "... finished `linearFormsAndMaxVar`."
     trace[linarith.detail] "{comps}"

--- a/test/linarith.lean
+++ b/test/linarith.lean
@@ -161,6 +161,9 @@ example (x : Rat) (hx : x > 0) (h : x.num < 0) : False := by
 
 end term_arguments
 
+example (i n : ℕ) (h : (2:ℤ) ^ i ≤ 2 ^ n) : (0:ℤ) ≤ 2 ^ n - 2 ^ i := by
+  linarith
+
 -- Check we use `exfalso` on non-comparison goals.
 example (a b c : Rat) (h2 : b > 0) (h3 : b < 0) : Nat.prime 10 := by
   linarith


### PR DESCRIPTION
As reported on [zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/linarith.20bug).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
