### PR TITLE
feat: #formalize, backed by GPT

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2074,6 +2074,9 @@ import Mathlib.Util.AddRelatedDecl
 import Mathlib.Util.AssertNoSorry
 import Mathlib.Util.AtomM
 import Mathlib.Util.Export
+import Mathlib.Util.GPT.API
+import Mathlib.Util.GPT.Chat
+import Mathlib.Util.GPT.Json
 import Mathlib.Util.IncludeStr
 import Mathlib.Util.LongNames
 import Mathlib.Util.MemoFix

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1789,6 +1789,7 @@ import Mathlib.Tactic.FailIfNoProgress
 import Mathlib.Tactic.FieldSimp
 import Mathlib.Tactic.FinCases
 import Mathlib.Tactic.Find
+import Mathlib.Tactic.Formalize
 import Mathlib.Tactic.GeneralizeProofs
 import Mathlib.Tactic.Group
 import Mathlib.Tactic.GuardGoalNums

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -32,6 +32,7 @@ import Mathlib.Tactic.FailIfNoProgress
 import Mathlib.Tactic.FieldSimp
 import Mathlib.Tactic.FinCases
 import Mathlib.Tactic.Find
+import Mathlib.Tactic.Formalize
 import Mathlib.Tactic.GeneralizeProofs
 import Mathlib.Tactic.Group
 import Mathlib.Tactic.GuardGoalNums

--- a/Mathlib/Tactic/Formalize.lean
+++ b/Mathlib/Tactic/Formalize.lean
@@ -1,0 +1,54 @@
+/-
+Copyright (c) 2023 Scott Morrison. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Scott Morrison
+-/
+import Mathlib.Util.GPT.Chat
+
+/-!
+# `#formalize` command, requesting auto-formalization from GPT.
+
+You must have your OpenAI API key, with available quota,
+stored in the environment variables `OPENAI_API_KEY` for this to work.
+We start by trying the "gpt-4" model, but if this is not available we fall back automatically to
+"gpt-3.5-turbo".
+-/
+
+open Lean Elab Command
+
+/-- The system message for `#formalize`. -/
+-- Please feel free to suggest changes, or to provide a customization hook.
+-- Not much thought has gone into this prompt!
+def systemMessage : String :=
+"You are an expert mathematician user of the interactive theorem prover Lean 4.
+You will be ask to formalize mathematical statements into Lean 4.
+
+Here are some examples:
+
+Query: There are infinitely many prime numbers.
+Response:
+theorem infinitely_many_primes : ∀ N : Nat, ∃ p, N < p ∧ p.Prime := sorry
+
+Query: The length of the concatenation of two lists is the sum of the lengths of the lists.
+theorem List.append_length {L M : List α} : (L ++ M).length = L.length + M.length := sorry
+
+Query: The Lebesgue number lemma.
+Response:
+/-- Let `c : ι → Set α` be an open cover of a compact set `s`. Then there exists an entourage
+`n` such that for each `x ∈ s` its `n`-neighborhood is contained in some `c i`. -/
+theorem lebesgue_number_lemma {α : Type u} [UniformSpace α] {s : Set α} {ι} {c : ι → Set α}
+    (hs : IsCompact s) (hc₁ : ∀ i, IsOpen (c i)) (hc₂ : s ⊆ ⋃ i, c i) :
+    ∃ n ∈ 𝓤 α, ∀ x ∈ s, ∃ i, { y | (x, y) ∈ n } ⊆ c i := sorry
+
+Your answer should be in the form of a Lean 4 theorem statement equivalent to the query statement,
+with the proof given as `sorry`.
+You may include a short natural language explanation as a doc-string.
+"
+
+elab tk:"#formalize" t:term : command => liftTermElabM do
+  let .lit (.strVal s) ← Term.elabTerm t none
+    | throwError "#formalize must be followed by a string literal"
+  if s.trim.endsWith "." || s.trim.endsWith "?" then
+    logInfoAt tk (← GPT.send s systemMessage)
+  else logInfoAt tk <|
+    "Please terminate your request with a '.' or '?', to avoid intermediate requests to GPT."

--- a/Mathlib/Util/GPT/API.lean
+++ b/Mathlib/Util/GPT/API.lean
@@ -31,8 +31,10 @@ def runCmd (cmd : String) (args : Array String) (throwFailure := true) (input : 
   else
     IO.ofExcept stdout.get
 
+namespace GPT
+
 /-- Retrieve the API key from the OPENAI_API_KEY environment variable. -/
-def APIKey : IO String := do match (← IO.getEnv "OPENAI_API_KEY") with
+def OPENAI_API_KEY : IO String := do match (← IO.getEnv "OPENAI_API_KEY") with
   | none => throw $ IO.userError "No API key found in environment variable OPENAI_API_KEY"
   | some k => pure k
 
@@ -41,6 +43,6 @@ def chat (msg : String) (trace : Bool := false) : IO String := do
   if trace then IO.println msg
   let r ← runCmd "curl"
       #["https://api.openai.com/v1/chat/completions", "-H", "Content-Type: application/json",
-        "-H", "Authorization: Bearer " ++ (← APIKey), "--data-binary", "@-"] false msg
+        "-H", "Authorization: Bearer " ++ (← OPENAI_API_KEY), "--data-binary", "@-"] false msg
   if trace then IO.print r
   return r

--- a/Mathlib/Util/GPT/API.lean
+++ b/Mathlib/Util/GPT/API.lean
@@ -1,0 +1,46 @@
+/-
+Copyright (c) 2023 Scott Morrison. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Scott Morrison
+-/
+import Lean.Util.Trace
+
+/-!
+# Minimal interface to the ChatGPT API, without any parsing.
+
+See `Mathlib.Util.GPT.Json` for parsing.
+-/
+
+open System (FilePath)
+
+open IO.Process in
+/-- Pipe input into stdin of the spawned process, then return stdout upon completion. -/
+-- TODO Put this somewhere central / share with `cache` executable.
+def runCmd (cmd : String) (args : Array String) (throwFailure := true) (input : String := "") :
+    IO String := do
+  let child ← spawn
+    { cmd := cmd, args := args, stdin := .piped, stdout := .piped, stderr := .piped }
+  let (stdin, child) ← child.takeStdin
+  stdin.putStr input
+  stdin.flush
+  let stdout ← IO.asTask child.stdout.readToEnd Task.Priority.dedicated
+  let stderr ← child.stderr.readToEnd
+  let exitCode ← child.wait
+  if exitCode != 0 && throwFailure then
+    throw $ IO.userError stderr
+  else
+    IO.ofExcept stdout.get
+
+/-- Retrieve the API key from the OPENAI_API_KEY environment variable. -/
+def APIKey : IO String := do match (← IO.getEnv "OPENAI_API_KEY") with
+  | none => throw $ IO.userError "No API key found in environment variable OPENAI_API_KEY"
+  | some k => pure k
+
+/-- Send a JSON message to the OpenAI chat endpoint, and return the response. -/
+def chat (msg : String) (trace : Bool := false) : IO String := do
+  if trace then IO.println msg
+  let r ← runCmd "curl"
+      #["https://api.openai.com/v1/chat/completions", "-H", "Content-Type: application/json",
+        "-H", "Authorization: Bearer " ++ (← APIKey), "--data-binary", "@-"] false msg
+  if trace then IO.print r
+  return r

--- a/Mathlib/Util/GPT/Chat.lean
+++ b/Mathlib/Util/GPT/Chat.lean
@@ -7,7 +7,7 @@ import Mathlib.Data.Option.Basic
 import Mathlib.Util.GPT.API
 import Mathlib.Util.GPT.Json
 
-/-
+/-!
 # Interace for ChatGPT.
 
 We provide two functions

--- a/Mathlib/Util/GPT/Chat.lean
+++ b/Mathlib/Util/GPT/Chat.lean
@@ -27,6 +27,9 @@ initialize unavailableModels : IO.Ref (HashSet Model) ← IO.mkRef {}
 def disableModel (m : Model) : IO Unit := unavailableModels.modify (·.insert m)
 
 structure ChatConfig where
+  /-- Model temperature.
+  0 is close to deterministic, selecting the most probably token,
+  while 1 samples from the predicted probability density on tokens. -/
   temperature : Float := 0.7
   /-- Specify a list of models to use.
   Within each file, if one model fails with an access denied message,

--- a/Mathlib/Util/GPT/Chat.lean
+++ b/Mathlib/Util/GPT/Chat.lean
@@ -5,7 +5,7 @@ Authors: Scott Morrison
 -/
 import Mathlib.Data.Option.Basic
 import Mathlib.Util.GPT.API
-import Mathlib.Util.GPT.JSON
+import Mathlib.Util.GPT.Json
 
 open Lean
 

--- a/Mathlib/Util/GPT/Chat.lean
+++ b/Mathlib/Util/GPT/Chat.lean
@@ -1,0 +1,88 @@
+/-
+Copyright (c) 2023 Scott Morrison. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Scott Morrison
+-/
+import Mathlib.Data.Option.Basic
+import Mathlib.Util.GPT.API
+import Mathlib.Util.GPT.JSON
+
+open Lean
+
+namespace GPT
+
+/-- See https://platform.openai.com/docs/models/model-endpoint-compatibility for
+the list of models. -/
+inductive Model
+| gpt_4 | gpt_4_32k | gpt_35_turbo
+deriving BEq, Hashable
+
+instance : ToString Model where
+  toString m := match m with
+    | .gpt_4 => "gpt-4" | .gpt_4_32k => "gpt-4-32k" | .gpt_35_turbo => "gpt-3.5-turbo"
+
+initialize unavailableModels : IO.Ref (HashSet Model) ← IO.mkRef {}
+
+/-- Mark a model as unavailable. -/
+def disableModel (m : Model) : IO Unit := unavailableModels.modify (·.insert m)
+
+structure ChatConfig where
+  temperature : Float := 0.7
+  /-- Specify a list of models to use.
+  Within each file, if one model fails with an access denied message,
+  subsequent attempts will ignore that model. -/
+  models : List Model := [.gpt_4, .gpt_35_turbo]
+  /-- Retry after server errors. -/
+  attempts : Nat := 3
+  /-- Log JSON messages to and from https://api.openai.com/ on stdout. -/
+  trace : Bool := false
+
+namespace ChatConfig
+
+/-- Select the first model from a list of models, which has not been marked as unavailable. -/
+def selectModel (cfg : ChatConfig) : IO (Option Model) := do
+  let unavailable ← unavailableModels.get
+  return cfg.models.filter (fun m => ¬ unavailable.contains m) |>.head?
+
+end ChatConfig
+
+/-- Send a list of messages representing a chat session to GPT, making retries as needed. -/
+def sendMessages (messages : List Message) (cfg : ChatConfig := {}) : IO Response := do
+  aux none none (← selectModel) cfg.attempts
+where
+  selectModel : IO Model := do match ← cfg.selectModel with
+    | none => throw <| IO.userError "No available models."
+    | some m => return m
+  constructMessage (m : Model) : IO String := do
+    let request : Request :=
+      { model := toString m, temperature := cfg.temperature, messages := messages }
+    return toString <| toJson <| request
+  aux (error lastJSON : Option String) (model : Model) : Nat → IO Response
+  | 0 => throw <| IO.userError <|
+      s!"Failed after {cfg.attempts} attempts.\n" ++ error.getD "" ++ "\n" ++ lastJSON.getD ""
+  | i+1 => do
+    let jsonResponse ← chat (← constructMessage model) cfg.trace
+    match parseResponse jsonResponse with
+    | .error e =>
+        -- We couldn't even parse the response:
+        throw <| IO.userError <| e ++ "\n" ++ jsonResponse
+    | .ok (.error e) =>
+      -- An error message from OpenAI
+      if e.isModelNotFound then
+        -- Disable this model and try again.
+        disableModel model
+        aux (toString e) jsonResponse (← selectModel) i
+      else if e.isServerError then
+        -- Just retry!
+        aux (toString e) jsonResponse model i
+      else
+        throw <| IO.userError <| jsonResponse
+    | .ok (.ok r) => pure r
+
+/-- Send a one-off query to GPT. -/
+def send (request : String) (systemMessage : Option String := none) (cfg : ChatConfig := {}) :
+    IO String := do
+  let messages := (systemMessage.map fun s => ⟨.system, s⟩).toList ++ [⟨.user, request⟩]
+  match (← sendMessages messages cfg).content with
+  | none => throw <| IO.userError "ChatGPT response did not contain content."
+  | some r => pure r

--- a/Mathlib/Util/GPT/Chat.lean
+++ b/Mathlib/Util/GPT/Chat.lean
@@ -7,6 +7,17 @@ import Mathlib.Data.Option.Basic
 import Mathlib.Util.GPT.API
 import Mathlib.Util.GPT.Json
 
+/-
+# Interace for ChatGPT.
+
+We provide two functions
+* `sendMessages` which sends a conversation log (including the new query) of `List Message`
+  to ChatGPT, retrieving a `Response`.
+* `send` which sends a single message (and optional system message), retrieving a `String`.
+
+We'll later add a monadic API that keeps track of the conversation for you.
+-/
+
 open Lean
 
 namespace GPT

--- a/Mathlib/Util/GPT/Json.lean
+++ b/Mathlib/Util/GPT/Json.lean
@@ -1,0 +1,134 @@
+/-
+Copyright (c) 2023 Scott Morrison. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Scott Morrison
+-/
+import Lean.Data.Json
+
+/-!
+# OpenAI JSON messages.
+-/
+
+open Lean (ToJson FromJson Json fromJson?)
+
+namespace GPT
+
+/-- A GPT role,
+either `.system` for system messages, `.user` for queries, or `.assistant` for responses. -/
+inductive Role
+| system | assistant | user
+deriving ToJson, FromJson, BEq
+
+instance : ToString Role where
+  toString r := match r with | .system => "system" | .assistant => "assistant" | .user => "user"
+
+/-- A message consists of a role and the contents of the message. -/
+structure Message where
+  role : Role
+  content : String
+deriving ToJson, FromJson
+
+/-- A request consists of the desired model and temperature, and a list of messages so far. -/
+structure Request where
+  model : String := "gpt-4"
+  messages : List Message
+  temperature : Float := 0.7
+  stream : Option Bool := none
+deriving ToJson, FromJson
+
+/-- GPT may return multiple choices, if instructed. -/
+structure Choice where
+  message : Message
+  finish_reason : String
+  index : Nat
+deriving ToJson, FromJson
+
+/-- Usage information about a GPT query. -/
+structure Usage where
+  prompt_tokens : Nat
+  completion_tokens : Nat
+  total_tokens : Nat
+deriving ToJson, FromJson
+
+/-- Parent of `Response` and `StreamData`, extracting common fields. Not used directly for JSON. -/
+structure GenericResponse where
+  id : String
+  object : String
+  created : Nat
+  model : String
+
+/-- A response from GPT records some basic information,
+along with usage information and a choice of results. -/
+structure Response extends GenericResponse where
+  usage : Usage
+  choices : List Choice
+deriving ToJson, FromJson
+
+/-- A 'delta' appearing in streamed data. -/
+structure Delta where
+  content : String
+deriving ToJson, FromJson
+
+/-- A choice node in streamed data.-/
+structure StreamChoice where
+  delta : Delta
+  index : Nat
+  finish_reason : Option String
+deriving ToJson, FromJson
+
+/-- JSON data received in streaming mode. -/
+structure StreamData extends GenericResponse where
+  choices : List StreamChoice
+deriving ToJson, FromJson
+
+/-- An error message from GPT. -/
+structure ErrorMessage where
+  message : String
+  type : String
+  param : Option Nat := none
+  code : Option String := none
+deriving ToJson, FromJson
+
+instance : ToString ErrorMessage where
+  toString e := e.type ++ ": " ++ e.message
+
+/-- Check if the error message is "model_not_found". -/
+def ErrorMessage.isModelNotFound (e : ErrorMessage) : Bool := e.code = some "model_not_found"
+
+/-- Check for server errors. -/
+def ErrorMessage.isServerError (e : ErrorMessage) : Bool := e.type = "server error"
+
+/-- An error response from GPT. -/
+structure Error where
+  error : ErrorMessage
+deriving ToJson, FromJson
+
+/-- Parse a raw JSON string to a `Response` term,
+returning both JSON parsing errors or OpenAI API errors via `Except.error`. -/
+def parseResponse (response : String) : Except String (Except ErrorMessage Response) :=
+match Json.parse response with
+| .ok r => match fromJson? r with
+  | .ok r => .ok (.ok r)
+  | .error e₁ => match (fromJson? r : Except String Error) with
+    | .ok { error := e₂ } => .ok (.error e₂)
+    | .error e₂ => .error (e₁ ++ "\n" ++ e₂)
+| .error e => .error e
+
+/--
+Extract the content of ChatGPT's reply.
+This assumes that there is only one `choice`, discarding others.
+-/
+def Response.content (r : Response) : Option String :=
+r.choices.head?.map (·.message.content)
+
+/--
+Parse a JSON response from ChatGPT, returning error messages from JSON parsing,
+from the OpenAI API, or if the response contains no choice node.
+-/
+def parse (response : String) : Except String String :=
+match parseResponse response with
+  | .ok (.ok r) => match r.content with
+    | some r' => .ok r'
+    | none => .error "ChatGPT response contained no choice nodes."
+  | .ok (.error e) => .error (toString e ++ "\n" ++ response)
+  | .error e => .error e

--- a/test/ChatGPT.lean
+++ b/test/ChatGPT.lean
@@ -4,7 +4,7 @@ open GPT
 
 -- These tests are all disabled as they should not be run in CI.
 
--- #eval APIKey
+-- #eval OPENAI_API_KEY
 -- #eval send "Hello world" (cfg := { trace := true })
 -- #eval send "Please write just the statement of the abc conjecture, in Lean 3 syntax."
 

--- a/test/ChatGPT.lean
+++ b/test/ChatGPT.lean
@@ -1,0 +1,12 @@
+import Mathlib.Util.GPT.Chat
+
+open GPT
+
+-- These tests are all disabled as they should not be run in CI.
+
+-- #eval APIKey
+-- #eval send "Hello world" (cfg := { trace := true })
+-- #eval send "Please write just the statement of the abc conjecture, in Lean 3 syntax."
+
+-- Check if "GPT-4" has been disabled because you don't have access yet:
+-- #eval show IO _  from do return (← unavailableModels.get).toList

--- a/test/ChatGPT.lean
+++ b/test/ChatGPT.lean
@@ -6,7 +6,7 @@ open GPT
 
 -- #eval OPENAI_API_KEY
 -- #eval send "Hello world" (cfg := { trace := true })
--- #eval send "Please write just the statement of the abc conjecture, in Lean 3 syntax."
+-- #eval send "Please write just the statement of the abc conjecture, in Lean 4 syntax."
 
 -- Check if "GPT-4" has been disabled because you don't have access yet:
 -- #eval show IO _  from do return (← unavailableModels.get).toList

--- a/test/formalize.lean
+++ b/test/formalize.lean
@@ -1,0 +1,34 @@
+/-
+Copyright (c) 2023 Scott Morrison. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Scott Morrison
+-/
+import Mathlib.Tactic.Formalize
+import Mathlib.Data.Nat.Prime
+import Mathlib.Algebra.BigOperators.Basic
+
+open BigOperators
+
+/-!
+These tests are all commented out as they rely on API access to ChatGPT.
+-/
+
+-- #formalize "There are infinitely many primes numbers ending with a 7."
+-- /-- There are infinitely many prime numbers ending with a 7. -/
+-- theorem infinitely_many_primes_ending_with_7 : ∀ N : Nat, ∃ p, N < p ∧ p.Prime ∧ p % 10 = 7 := sorry
+
+-- #formalize "Concatenation of lists is associative."
+-- /-- Concatenation of lists is associative. -/
+-- theorem List.append_assoc {α : Type u} : ∀ (L M N : List α), (L ++ M) ++ N = L ++ (M ++ N) := sorry
+
+-- #formalize "The sum of the first n natural numbers."
+-- /-- The sum of the first `n` natural numbers is equal to n * (n + 1) / 2. -/
+-- theorem sum_of_first_n_natural_numbers (n : ℕ) : (n * (n + 1)) / 2 = ∑ i in Finset.range (n + 1), i := sorry
+
+-- #formalize "The only even prime number is 2."
+-- -- /-- The only even prime number is 2. -/
+-- theorem only_even_prime_is_two : ∀ p : Nat, p.Prime ∧ p % 2 = 0 → p = 2 := sorry
+
+-- #formalize "The abc conjecture"
+-- theorem abc_conjecture {a b c : ℤ} (h₁ : a * b * c ≠ 0) (h₂ : gcd a b = 1) (h₃ : gcd a c = 1) (h₄ : gcd b c = 1) (h₅ : a + b = c) :
+--   ∃ K : ℝ, ∀ ε > 0, abs (c : ℝ) ≤ K * (rad (a * b * c))^ε := sorry


### PR DESCRIPTION
A cheap demonstration of what we can do using the GPT interface proposed in https://github.com/leanprover-community/mathlib4/pull/3785.

This adds a `#formalize` command, which asks GPT to formalize natural language statements.

Typical output:
```
#formalize "The sum of the first n natural numbers."
```
producing
```lean
/-- The sum of the first `n` natural numbers is equal to n * (n + 1) / 2. -/
theorem sum_of_first_n_natural_numbers (n : ℕ) : (n * (n + 1)) / 2 = ∑ i in Finset.range (n + 1), i := sorry
```

See
* https://arxiv.org/abs/2205.12615
* https://arxiv.org/abs/2302.12433

for some of the literature on doing this properly.

- [x] depends on: #3785

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
