### PR TITLE
[Merged by Bors] - feat: `cancel_denoms` tactic

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1764,6 +1764,7 @@ import Mathlib.Tactic.Backtracking
 import Mathlib.Tactic.Basic
 import Mathlib.Tactic.ByContra
 import Mathlib.Tactic.Cache
+import Mathlib.Tactic.CancelDenoms
 import Mathlib.Tactic.Cases
 import Mathlib.Tactic.CasesM
 import Mathlib.Tactic.Choose

--- a/Mathlib/Tactic/CancelDenoms.lean
+++ b/Mathlib/Tactic/CancelDenoms.lean
@@ -125,21 +125,21 @@ def synthesizeUsingNormNum (type : Expr) : MetaM Expr := do
 `mkProdPrf n tr e` produces a proof of `n*e = e'`, where numeric denominators have been
 canceled in `e'`, distributing `n` proportionally according to `tr`.
 -/
-partial def mkProdPrf (α : Q(Type u)) (_sα : Q(Field $α)) (v : ℕ) (t : Tree ℕ)
+partial def mkProdPrf (α : Q(Type u)) (sα : Q(Field $α)) (v : ℕ) (t : Tree ℕ)
     (e : Q($α)) : MetaM Expr := do
   let amwo ← synthInstanceQ q(AddMonoidWithOne $α)
   match t, e with
   | .node _ lhs rhs, ~q($e1 + $e2) => do
-    let v1 ← mkProdPrf α _sα v lhs e1
-    let v2 ← mkProdPrf α _sα v rhs e2
+    let v1 ← mkProdPrf α sα v lhs e1
+    let v2 ← mkProdPrf α sα v rhs e2
     mkAppM `CancelFactors.add_subst #[v1, v2]
   | .node _ lhs rhs, ~q($e1 - $e2) => do
-    let v1 ← mkProdPrf α _sα v lhs e1
-    let v2 ← mkProdPrf α _sα v rhs e2
+    let v1 ← mkProdPrf α sα v lhs e1
+    let v2 ← mkProdPrf α sα v rhs e2
     mkAppM `CancelFactors.sub_subst #[v1, v2]
   | .node _ lhs@(.node ln _ _) rhs, ~q($e1 * $e2) => do
-    let v1 ← mkProdPrf α _sα ln lhs e1
-    let v2 ← mkProdPrf α _sα (v / ln) rhs e2
+    let v1 ← mkProdPrf α sα ln lhs e1
+    let v2 ← mkProdPrf α sα (v / ln) rhs e2
     have ln' := (← mkOfNat α amwo <| mkRawNatLit ln).1
     have vln' := (← mkOfNat α amwo <| mkRawNatLit (v/ln)).1
     have v' := (← mkOfNat α amwo <| mkRawNatLit v).1
@@ -147,7 +147,7 @@ partial def mkProdPrf (α : Q(Type u)) (_sα : Q(Field $α)) (v : ℕ) (t : Tree
     let npf ← synthesizeUsingNormNum ntp
     mkAppM `CancelFactors.mul_subst #[v1, v2, npf]
   | .node n lhs (.node rn _ _), ~q($e1 / $e2) => do
-    let v1 ← mkProdPrf α _sα (v / rn) lhs e1
+    let v1 ← mkProdPrf α sα (v / rn) lhs e1
     have rn' := (← mkOfNat α amwo <| mkRawNatLit rn).1
     have vrn' := (← mkOfNat α amwo <| mkRawNatLit <| v / rn).1
     have n' := (← mkOfNat α amwo <| mkRawNatLit <| n).1
@@ -158,12 +158,12 @@ partial def mkProdPrf (α : Q(Type u)) (_sα : Q(Field $α)) (v : ℕ) (t : Tree
     let npf2 ← synthesizeUsingNormNum ntp2
     mkAppM `CancelFactors.div_subst #[v1, npf, npf2]
   | t, ~q(-$e) => do
-    let v ← mkProdPrf α _sα v t e
+    let v ← mkProdPrf α sα v t e
     mkAppM `CancelFactors.neg_subst #[v]
   | _, _ => do
     have v' := (← mkOfNat α amwo <| mkRawNatLit <| v).1
     let e' ← mkAppM `HMul.hMul #[v', e]
-    mkAppM `Eq.refl #[e']
+    mkEqRefl e'
 
 /--
 Given `e`, a term with rational division, produces a natural number `n` and a proof of `n*e = e'`,

--- a/Mathlib/Tactic/CancelDenoms.lean
+++ b/Mathlib/Tactic/CancelDenoms.lean
@@ -8,10 +8,10 @@ Authors: Robert Y. Lewis
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
-import Mathlib.Data.Rat.MetaDefs
+--import Mathlib.Data.Rat.MetaDefs
 import Mathlib.Tactic.NormNum
 import Mathlib.Data.Tree
-import Mathlib.Meta.Expr
+--import Mathlib.Meta.Expr
 
 /-!
 # A tactic for canceling numeric denominators
@@ -91,244 +91,23 @@ theorem cancel_factors_eq {α} [LinearOrderedField α] {a b ad bd a' b' gcd : α
     refine' mul_left_cancel₀ (mul_ne_zero _ _) h
     apply mul_ne_zero
     apply div_ne_zero
-    all_goals apply ne_of_gt <;> first |assumption|exact zero_lt_one
+    all_goals apply ne_of_gt ; first |assumption|exact zero_lt_one
 #align cancel_factors.cancel_factors_eq CancelFactors.cancel_factors_eq
 
-open Tactic Expr
 
-/-! ### Computing cancelation factors -/
-
-
-open Tree
-
--- failed to format: unknown constant 'term.pseudo.antiquot'
-/--
-      `find_cancel_factor e` produces a natural number `n`, such that multiplying `e` by `n` will
-      be able to cancel all the numeric denominators in `e`. The returned `tree` describes how to
-      distribute the value `n` over products inside `e`.
-      -/
-    unsafe
-  def
-    find_cancel_factor
-    : expr → ℕ × Tree ℕ
-    |
-        q( $ ( e1 ) + $ ( e2 ) )
-        =>
-        let
-          ( v1 , t1 ) := find_cancel_factor e1
-          let ( v2 , t2 ) := find_cancel_factor e2 let lcm := v1 . lcm v2 ( lcm , node lcm t1 t2 )
-      |
-        q( $ ( e1 ) - $ ( e2 ) )
-        =>
-        let
-          ( v1 , t1 ) := find_cancel_factor e1
-          let ( v2 , t2 ) := find_cancel_factor e2 let lcm := v1 . lcm v2 ( lcm , node lcm t1 t2 )
-      |
-        q( $ ( e1 ) * $ ( e2 ) )
-        =>
-        let
-          ( v1 , t1 ) := find_cancel_factor e1
-          let ( v2 , t2 ) := find_cancel_factor e2 let pd := v1 * v2 ( pd , node pd t1 t2 )
-      |
-        q( $ ( e1 ) / $ ( e2 ) )
-        =>
-        match
-          e2 . to_nonneg_rat
-          with
-          |
-              some q
-              =>
-              let
-                ( v1 , t1 ) := find_cancel_factor e1
-                let
-                  n := v1 . lcm q . num . natAbs
-                  ( n , node n t1 ( node q . num . natAbs Tree.nil Tree.nil ) )
-            | none => ( 1 , node 1 Tree.nil Tree.nil )
-      | q( - $ ( e ) ) => find_cancel_factor e
-      | _ => ( 1 , node 1 Tree.nil Tree.nil )
-#align cancel_factors.find_cancel_factor cancel_factors.find_cancel_factor
-
-/- ./././Mathport/Syntax/Translate/Expr.lean:330:4: warning: unsupported (TODO): `[tacs] -/
-/- ./././Mathport/Syntax/Translate/Expr.lean:330:4: warning: unsupported (TODO): `[tacs] -/
-/- ./././Mathport/Syntax/Translate/Expr.lean:330:4: warning: unsupported (TODO): `[tacs] -/
--- failed to format: unknown constant 'term.pseudo.antiquot'
-/--
-      `mk_prod_prf n tr e` produces a proof of `n*e = e'`, where numeric denominators have been
-      canceled in `e'`, distributing `n` proportionally according to `tr`.
-      -/
-    unsafe
-  def
-    mk_prod_prf
-    : ℕ → Tree ℕ → expr → tactic expr
-    |
-        v , node _ lhs rhs , q( $ ( e1 ) + $ ( e2 ) )
-        =>
-        do
-          let v1 ← mk_prod_prf v lhs e1
-            let v2 ← mk_prod_prf v rhs e2
-            mk_app ` ` add_subst [ v1 , v2 ]
-      |
-        v , node _ lhs rhs , q( $ ( e1 ) - $ ( e2 ) )
-        =>
-        do
-          let v1 ← mk_prod_prf v lhs e1
-            let v2 ← mk_prod_prf v rhs e2
-            mk_app ` ` sub_subst [ v1 , v2 ]
-      |
-        v , node n ( lhs @ ( node ln _ _ ) ) rhs , q( $ ( e1 ) * $ ( e2 ) )
-        =>
-        do
-          let tp ← infer_type e1
-            let v1 ← mk_prod_prf ln lhs e1
-            let v2 ← mk_prod_prf ( v / ln ) rhs e2
-            let ln' ← tp . ofNat ln
-            let vln' ← tp . ofNat ( v / ln )
-            let v' ← tp . ofNat v
-            let ntp ← to_expr ` `( $ ( ln' ) * $ ( vln' ) = $ ( v' ) )
-            let ( _ , npf ) ← solve_aux ntp sorry
-            mk_app ` ` mul_subst [ v1 , v2 , npf ]
-      |
-        v , node n lhs rhs @ ( node rn _ _ ) , q( $ ( e1 ) / $ ( e2 ) )
-        =>
-        do
-          let tp ← infer_type e1
-            let v1 ← mk_prod_prf ( v / rn ) lhs e1
-            let rn' ← tp . ofNat rn
-            let vrn' ← tp . ofNat ( v / rn )
-            let n' ← tp . ofNat n
-            let v' ← tp . ofNat v
-            let ntp ← to_expr ` `( $ ( rn' ) / $ ( e2 ) = 1 )
-            let ( _ , npf ) ← solve_aux ntp sorry
-            let ntp2 ← to_expr ` `( $ ( vrn' ) * $ ( n' ) = $ ( v' ) )
-            let ( _ , npf2 ) ← solve_aux ntp2 sorry
-            mk_app ` ` div_subst [ v1 , npf , npf2 ]
-      | v , t , q( - $ ( e ) ) => do let v' ← mk_prod_prf v t e mk_app ` ` neg_subst [ v' ]
-      |
-        v , _ , e
-        =>
-        do
-          let tp ← infer_type e
-            let v' ← tp . ofNat v
-            let e' ← to_expr ` `( $ ( v' ) * $ ( e ) )
-            mk_app `eq.refl [ e' ]
-#align cancel_factors.mk_prod_prf cancel_factors.mk_prod_prf
+open Lean Parser Tactic
 
 /--
-Given `e`, a term with rational division, produces a natural number `n` and a proof of `n*e = e'`,
-where `e'` has no division. Assumes "well-behaved" division.
--/
-unsafe def derive (e : expr) : tactic (ℕ × expr) :=
-  let (n, t) := find_cancel_factor e
-  Prod.mk n <$> mk_prod_prf n t e <|>
-    throwError
-      "cancel_factors.derive failed to normalize {← e}. Are you sure this is well-behaved division?"
-#align cancel_factors.derive cancel_factors.derive
-
-/- ./././Mathport/Syntax/Translate/Expr.lean:330:4: warning: unsupported (TODO): `[tacs] -/
--- failed to format: unknown constant 'term.pseudo.antiquot'
-/--
-      Given `e`, a term with rational divison, produces a natural number `n` and a proof of `e = e' / n`,
-      where `e'` has no divison. Assumes "well-behaved" division.
-      -/
-    unsafe
-  def
-    derive_div
-    ( e : expr ) : tactic ( ℕ × expr )
-    :=
-      do
-        let ( n , p ) ← derive e
-          let tp ← infer_type e
-          let n' ← tp . ofNat n
-          let tgt ← to_expr ` `( $ ( n' ) ≠ 0 )
-          let ( _ , pn ) ← solve_aux tgt sorry
-          Prod.mk n
-            <$>
-            mk_mapp ` ` cancel_factors_eq_div [ none , none , n' , none , none , p , pn ]
-#align cancel_factors.derive_div cancel_factors.derive_div
-
--- failed to format: unknown constant 'term.pseudo.antiquot'
-/--
-      `find_comp_lemma e` arranges `e` in the form `lhs R rhs`, where `R ∈ {<, ≤, =}`, and returns
-      `lhs`, `rhs`, and the `cancel_factors` lemma corresponding to `R`.
-      -/
-    unsafe
-  def
-    find_comp_lemma
-    : expr → Option ( expr × expr × Name )
-    | q( $ ( a ) < $ ( b ) ) => ( a , b , ` ` cancel_factors_lt )
-      | q( $ ( a ) ≤ $ ( b ) ) => ( a , b , ` ` cancel_factors_le )
-      | q( $ ( a ) = $ ( b ) ) => ( a , b , ` ` cancel_factors_eq )
-      | q( $ ( a ) ≥ $ ( b ) ) => ( b , a , ` ` cancel_factors_le )
-      | q( $ ( a ) > $ ( b ) ) => ( b , a , ` ` cancel_factors_lt )
-      | _ => none
-#align cancel_factors.find_comp_lemma cancel_factors.find_comp_lemma
-
-/- ./././Mathport/Syntax/Translate/Expr.lean:330:4: warning: unsupported (TODO): `[tacs] -/
-/- ./././Mathport/Syntax/Translate/Expr.lean:330:4: warning: unsupported (TODO): `[tacs] -/
-/- ./././Mathport/Syntax/Translate/Expr.lean:330:4: warning: unsupported (TODO): `[tacs] -/
-/-- `cancel_denominators_in_type h` assumes that `h` is of the form `lhs R rhs`,
-where `R ∈ {<, ≤, =, ≥, >}`.
-It produces an expression `h'` of the form `lhs' R rhs'` and a proof that `h = h'`.
-Numeric denominators have been canceled in `lhs'` and `rhs'`.
--/
-unsafe def cancel_denominators_in_type (h : expr) : tactic (expr × expr) := do
-  let some (lhs, rhs, lem) ← return <| find_comp_lemma h |
-    fail "cannot kill factors"
-  let (al, lhs_p) ← derive lhs
-  let (ar, rhs_p) ← derive rhs
-  let gcd := al.gcd ar
-  let tp ← infer_type lhs
-  let al ← tp.ofNat al
-  let ar ← tp.ofNat ar
-  let gcd ← tp.ofNat gcd
-  let al_pos ← to_expr ``(0 < $(al))
-  let ar_pos ← to_expr ``(0 < $(ar))
-  let gcd_pos ← to_expr ``(0 < $(gcd))
-  let (_, al_pos) ← solve_aux al_pos sorry
-  let (_, ar_pos) ← solve_aux ar_pos sorry
-  let (_, gcd_pos) ← solve_aux gcd_pos sorry
-  let pf ← mk_app lem [lhs_p, rhs_p, al_pos, ar_pos, gcd_pos]
-  let pf_tp ← infer_type pf
-  return ((find_comp_lemma pf_tp).elim default (Prod.fst ∘ Prod.snd), pf)
-#align cancel_factors.cancel_denominators_in_type cancel_factors.cancel_denominators_in_type
-
-end CancelFactors
-
-/-! ### Interactive version -/
-
-
-/- ./././Mathport/Syntax/Translate/Tactic/Mathlib/Core.lean:38:34: unsupported: setup_tactic_parser -/
-open Tactic Expr CancelFactors
-
-/-- `cancel_denoms` attempts to remove numerals from the denominators of fractions.
+`cancel_denoms` attempts to remove numerals from the denominators of fractions.
 It works on propositions that are field-valued inequalities.
-
 ```lean
-variables {α : Type} [linear_ordered_field α] (a b c : α)
-
-example (h : a / 5 + b / 4 < c) : 4*a + 5*b < 20*c :=
-begin
-  cancel_denoms at h,
+variable [LinearOrderedField α] (a b c : α)
+example (h : a / 5 + b / 4 < c) : 4*a + 5*b < 20*c := by
+  cancel_denoms at h
   exact h
-end
-
-example (h : a > 0) : a / 5 > 0 :=
-begin
-  cancel_denoms,
+example (h : a > 0) : a / 5 > 0 := by
+  cancel_denoms
   exact h
-end
 ```
 -/
-unsafe def tactic.interactive.cancel_denoms (l : parse location) : tactic Unit := do
-  let locs ← l.get_locals
-  tactic.replace_at cancel_denominators_in_type locs l >>= guardb <|>
-      fail "failed to cancel any denominators"
-  tactic.interactive.norm_num [simp_arg_type.symm_expr ``(mul_assoc)] l
-#align tactic.interactive.cancel_denoms tactic.interactive.cancel_denoms
-
-add_tactic_doc
-  { Name := "cancel_denoms"
-    category := DocCategory.tactic
-    declNames := [`tactic.interactive.cancel_denoms]
-    tags := ["simplification"] }
-
+syntax (name := cancelDenoms) "cancel_denoms" (ppSpace location)? : tactic

--- a/Mathlib/Tactic/CancelDenoms.lean
+++ b/Mathlib/Tactic/CancelDenoms.lean
@@ -141,9 +141,9 @@ partial def mkProdPrf (α : Q(Type u)) (_sα : Q(Field $α)) (v : ℕ) (t : Tree
   | .node _ lhs@(.node ln _ _) rhs, ~q($e1 * $e2) => do
     let v1 ← mkProdPrf α _sα ln lhs e1
     let v2 ← mkProdPrf α _sα (v / ln) rhs e2
-    have ln' := (← mkOfNat α _sα <| mkRawNatLit ln).1
-    have vln' := (← mkOfNat α _sα <| mkRawNatLit (v/ln)).1
-    have v' := (← mkOfNat α _sα <| mkRawNatLit v).1
+    have ln' := (← mkOfNat α amwo <| mkRawNatLit ln).1
+    have vln' := (← mkOfNat α amwo <| mkRawNatLit (v/ln)).1
+    have v' := (← mkOfNat α amwo <| mkRawNatLit v).1
     let ntp : Q(Prop) := q($ln' * $vln' = $v')
     let npf ← synthesizeUsing ntp norm_num_done
     mkAppM `CancelFactors.mul_subst #[v1, v2, npf]
@@ -266,18 +266,3 @@ elab "cancel_denoms" loc?:(location)? : tactic => do
     Lean.Elab.Tactic.evalTactic (←`(tactic| norm_num [←mul_assoc] $loc))
   else
     Lean.Elab.Tactic.evalTactic (←`(tactic| norm_num [←mul_assoc]))
-
-variable [lof : LinearOrderedField α] (a b c : α)
-
-set_option warningAsError false
-
-example : (0 : α) < (1 : α) := by
-  norm_num
-
-example (h : a / 5 + b / 4 < c) : 4*a + 5*b < 20*c := by
-  cancel_denoms at h
-  exact h
-
-example (h : a > 0) : a / 5 > 0 := by
-  cancel_denoms
-  exact h

--- a/Mathlib/Tactic/CancelDenoms.lean
+++ b/Mathlib/Tactic/CancelDenoms.lean
@@ -246,15 +246,13 @@ open Elab Tactic
 def cancelDenominatorsAt (fvar: FVarId) : TacticM Unit := do
   let t ← instantiateMVars (← fvar.getDecl).type
   let (new, eqPrf) ← CancelFactors.cancelDenominatorsInType t
-  let goal ← getMainGoal
-  let res ← goal.replaceLocalDecl fvar new eqPrf
-  replaceMainGoal [res.mvarId]
+  liftMetaTactic' fun g => do
+    let res ← g.replaceLocalDecl fvar new eqPrf
+    return res.mvarId
 
-def cancelDenominatorsTarget : TacticM Unit := withMainContext do
-  let goal ← getMainTarget
-  let (new, eqPrf) ← CancelFactors.cancelDenominatorsInType goal
-  let goal' ← (← getMainGoal).replaceTargetEq new eqPrf
-  replaceMainGoal [goal']
+def cancelDenominatorsTarget : TacticM Unit := do
+  let (new, eqPrf) ← CancelFactors.cancelDenominatorsInType (← getMainTarget)
+  liftMetaTactic' fun g => g.replaceTargetEq new eqPrf
 
 def cancelDenominators (loc : Location) : TacticM Unit := do
   withLocation loc cancelDenominatorsAt cancelDenominatorsTarget

--- a/Mathlib/Tactic/CancelDenoms.lean
+++ b/Mathlib/Tactic/CancelDenoms.lean
@@ -176,17 +176,6 @@ catch _ => throwError
   "cancel_factors.derive failed to normalize {e}. Are you sure this is well-behaved division?"
 
 /--
-Given `e`, a term with rational divison, produces a natural number `n` and a proof of `e = e' / n`,
-where `e'` has no divison. Assumes "well-behaved" division.
--/
-def deriveDiv (e : Expr) : MetaM (ℕ × Expr) :=
-do let (n, p) ← derive e
-   let tp ← inferType e
-   let n' ← tp.of_nat n, tgt ← to_Expr ``(%%n' ≠ 0)
-   let (_, pn) ← solve_aux tgt `[norm_num, done]
-   prod.mk n <$> mk_mapp ``cancel_factors_eq_div [none, none, n', none, none, p, pn]
-
-/--
 `findCompLemma e` arranges `e` in the form `lhs R rhs`, where `R ∈ {<, ≤, =}`, and returns
 `lhs`, `rhs`, and the `cancel_factors` lemma corresponding to `R`.
 -/

--- a/Mathlib/Tactic/CancelDenoms.lean
+++ b/Mathlib/Tactic/CancelDenoms.lean
@@ -8,10 +8,10 @@ Authors: Robert Y. Lewis
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
-import Mathbin.Data.Rat.MetaDefs
-import Mathbin.Tactic.NormNum
-import Mathbin.Data.Tree
-import Mathbin.Meta.Expr
+import Mathlib.Data.Rat.MetaDefs
+import Mathlib.Tactic.NormNum
+import Mathlib.Data.Tree
+import Mathlib.Meta.Expr
 
 /-!
 # A tactic for canceling numeric denominators
@@ -65,8 +65,7 @@ theorem neg_subst {α} [Ring α] {n e t : α} (h1 : n * e = t) : n * -e = -t := 
 
 theorem cancel_factors_lt {α} [LinearOrderedField α] {a b ad bd a' b' gcd : α} (ha : ad * a = a')
     (hb : bd * b = b') (had : 0 < ad) (hbd : 0 < bd) (hgcd : 0 < gcd) :
-    (a < b) = (1 / gcd * (bd * a') < 1 / gcd * (ad * b')) :=
-  by
+    (a < b) = (1 / gcd * (bd * a') < 1 / gcd * (ad * b')) := by
   rw [mul_lt_mul_left, ← ha, ← hb, ← mul_assoc, ← mul_assoc, mul_comm bd, mul_lt_mul_left]
   exact mul_pos had hbd
   exact one_div_pos.2 hgcd
@@ -74,8 +73,7 @@ theorem cancel_factors_lt {α} [LinearOrderedField α] {a b ad bd a' b' gcd : α
 
 theorem cancel_factors_le {α} [LinearOrderedField α] {a b ad bd a' b' gcd : α} (ha : ad * a = a')
     (hb : bd * b = b') (had : 0 < ad) (hbd : 0 < bd) (hgcd : 0 < gcd) :
-    (a ≤ b) = (1 / gcd * (bd * a') ≤ 1 / gcd * (ad * b')) :=
-  by
+    (a ≤ b) = (1 / gcd * (bd * a') ≤ 1 / gcd * (ad * b')) := by
   rw [mul_le_mul_left, ← ha, ← hb, ← mul_assoc, ← mul_assoc, mul_comm bd, mul_le_mul_left]
   exact mul_pos had hbd
   exact one_div_pos.2 hgcd
@@ -83,8 +81,7 @@ theorem cancel_factors_le {α} [LinearOrderedField α] {a b ad bd a' b' gcd : α
 
 theorem cancel_factors_eq {α} [LinearOrderedField α] {a b ad bd a' b' gcd : α} (ha : ad * a = a')
     (hb : bd * b = b') (had : 0 < ad) (hbd : 0 < bd) (hgcd : 0 < gcd) :
-    (a = b) = (1 / gcd * (bd * a') = 1 / gcd * (ad * b')) :=
-  by
+    (a = b) = (1 / gcd * (bd * a') = 1 / gcd * (ad * b')) := by
   rw [← ha, ← hb, ← mul_assoc bd, ← mul_assoc ad, mul_comm bd]
   ext; constructor
   · rintro rfl

--- a/Mathlib/Tactic/CancelDenoms.lean
+++ b/Mathlib/Tactic/CancelDenoms.lean
@@ -262,7 +262,4 @@ def cancelDenominators (loc : Location) : TacticM Unit := do
 
 elab "cancel_denoms" loc?:(location)? : tactic => do
   cancelDenominators (expandOptLocation (Lean.mkOptionalNode loc?))
-  if let some loc := loc? then
-    Lean.Elab.Tactic.evalTactic (←`(tactic| norm_num [←mul_assoc] $loc))
-  else
-    Lean.Elab.Tactic.evalTactic (←`(tactic| norm_num [←mul_assoc]))
+  Lean.Elab.Tactic.evalTactic (←`(tactic| norm_num [←mul_assoc] $[$loc?]?))

--- a/Mathlib/Tactic/CancelDenoms.lean
+++ b/Mathlib/Tactic/CancelDenoms.lean
@@ -168,7 +168,7 @@ partial def mkProdPrf (α : Q(Type u)) (sα : Q(Field $α)) (v : ℕ) (t : Tree 
 def inferTypeQ' (e : Expr) : MetaM ((u : Level) × (α : Q(Type $u)) × Q($α)) := do
   let α ← inferType e
   let .sort u ← whnf (← inferType α) | throwError "not a type{indentExpr α}"
-  let some u' := u.dec | throwError "is a Prop, not a Type"
+  let some u' := u.dec | throwError "is a Prop, not a Type{indentExpr e}"
   pure ⟨u', α, e⟩
 
 /--

--- a/Mathlib/Tactic/CancelDenoms.lean
+++ b/Mathlib/Tactic/CancelDenoms.lean
@@ -31,20 +31,19 @@ namespace CancelFactors
 
 /-! ### Lemmas used in the procedure -/
 
-
-theorem mul_subst {α} [CommRing α] {n1 n2 k e1 e2 t1 t2 : α} (h1 : n1 * e1 = t1) (h2 : n2 * e2 = t2)
-    (h3 : n1 * n2 = k) : k * (e1 * e2) = t1 * t2 := by
-  rw [← h3, mul_comm n1, mul_assoc n2, ← mul_assoc n1, h1, ← mul_assoc n2, mul_comm n2, mul_assoc,
-    h2]
+theorem mul_subst {α} [CommRing α] {n1 n2 k e1 e2 t1 t2 : α}
+    (h1 : n1 * e1 = t1) (h2 : n2 * e2 = t2) (h3 : n1 * n2 = k) : k * (e1 * e2) = t1 * t2 := by
+  rw [← h3, mul_comm n1, mul_assoc n2, ← mul_assoc n1, h1,
+      ← mul_assoc n2, mul_comm n2, mul_assoc, h2]
 #align cancel_factors.mul_subst CancelFactors.mul_subst
 
-theorem div_subst {α} [Field α] {n1 n2 k e1 e2 t1 : α} (h1 : n1 * e1 = t1) (h2 : n2 / e2 = 1)
-    (h3 : n1 * n2 = k) : k * (e1 / e2) = t1 := by
+theorem div_subst {α} [Field α] {n1 n2 k e1 e2 t1 : α}
+    (h1 : n1 * e1 = t1) (h2 : n2 / e2 = 1) (h3 : n1 * n2 = k) : k * (e1 / e2) = t1 := by
   rw [← h3, mul_assoc, mul_div_left_comm, h2, ← mul_assoc, h1, mul_comm, one_mul]
 #align cancel_factors.div_subst CancelFactors.div_subst
 
-theorem cancel_factors_eq_div {α} [Field α] {n e e' : α} (h : n * e = e') (h2 : n ≠ 0) :
-    e = e' / n :=
+theorem cancel_factors_eq_div {α} [Field α] {n e e' : α}
+    (h : n * e = e') (h2 : n ≠ 0) : e = e' / n :=
   eq_div_of_mul_eq h2 <| by rwa [mul_comm] at h
 #align cancel_factors.cancel_factors_eq_div CancelFactors.cancel_factors_eq_div
 
@@ -59,20 +58,20 @@ theorem sub_subst {α} [Ring α] {n e1 e2 t1 t2 : α} (h1 : n * e1 = t1) (h2 : n
 theorem neg_subst {α} [Ring α] {n e t : α} (h1 : n * e = t) : n * -e = -t := by simp [*]
 #align cancel_factors.neg_subst CancelFactors.neg_subst
 
-theorem cancel_factors_lt {α} [LinearOrderedField α] {a b ad bd a' b' gcd : α} (ha : ad * a = a')
-    (hb : bd * b = b') (had : 0 < ad) (hbd : 0 < bd) (hgcd : 0 < gcd) :
+theorem cancel_factors_lt {α} [LinearOrderedField α] {a b ad bd a' b' gcd : α}
+    (ha : ad * a = a') (hb : bd * b = b') (had : 0 < ad) (hbd : 0 < bd) (hgcd : 0 < gcd) :
     (a < b) = (1 / gcd * (bd * a') < 1 / gcd * (ad * b')) := by
   rw [mul_lt_mul_left, ← ha, ← hb, ← mul_assoc, ← mul_assoc, mul_comm bd, mul_lt_mul_left]
-  exact mul_pos had hbd
-  exact one_div_pos.2 hgcd
+  · exact mul_pos had hbd
+  · exact one_div_pos.2 hgcd
 #align cancel_factors.cancel_factors_lt CancelFactors.cancel_factors_lt
 
-theorem cancel_factors_le {α} [LinearOrderedField α] {a b ad bd a' b' gcd : α} (ha : ad * a = a')
-    (hb : bd * b = b') (had : 0 < ad) (hbd : 0 < bd) (hgcd : 0 < gcd) :
+theorem cancel_factors_le {α} [LinearOrderedField α] {a b ad bd a' b' gcd : α}
+    (ha : ad * a = a') (hb : bd * b = b') (had : 0 < ad) (hbd : 0 < bd) (hgcd : 0 < gcd) :
     (a ≤ b) = (1 / gcd * (bd * a') ≤ 1 / gcd * (ad * b')) := by
   rw [mul_le_mul_left, ← ha, ← hb, ← mul_assoc, ← mul_assoc, mul_comm bd, mul_le_mul_left]
-  exact mul_pos had hbd
-  exact one_div_pos.2 hgcd
+  · exact mul_pos had hbd
+  · exact one_div_pos.2 hgcd
 #align cancel_factors.cancel_factors_le CancelFactors.cancel_factors_le
 
 theorem cancel_factors_eq {α} [LinearOrderedField α] {a b ad bd a' b' gcd : α} (ha : ad * a = a')
@@ -87,7 +86,7 @@ theorem cancel_factors_eq {α} [LinearOrderedField α] {a b ad bd a' b' gcd : α
     refine' mul_left_cancel₀ (mul_ne_zero _ _) h
     apply mul_ne_zero
     apply div_ne_zero
-    all_goals apply ne_of_gt ; first |assumption|exact zero_lt_one
+    all_goals apply ne_of_gt ; first | assumption | exact zero_lt_one
 #align cancel_factors.cancel_factors_eq CancelFactors.cancel_factors_eq
 
 /-! ### Computing cancelation factors -/

--- a/Mathlib/Tactic/CancelDenoms.lean
+++ b/Mathlib/Tactic/CancelDenoms.lean
@@ -1,0 +1,337 @@
+/-
+Copyright (c) 2020 Robert Y. Lewis. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Y. Lewis
+
+! This file was ported from Lean 3 source module tactic.cancel_denoms
+! leanprover-community/mathlib commit eaa771fc4f5f356afeacac4ab92e0cbf10b0b1df
+! Please do not edit these lines, except to modify the commit id
+! if you have ported upstream changes.
+-/
+import Mathbin.Data.Rat.MetaDefs
+import Mathbin.Tactic.NormNum
+import Mathbin.Data.Tree
+import Mathbin.Meta.Expr
+
+/-!
+# A tactic for canceling numeric denominators
+
+This file defines tactics that cancel numeric denominators from field expressions.
+
+As an example, we want to transform a comparison `5*(a/3 + b/4) < c/3` into the equivalent
+`5*(4*a + 3*b) < 4*c`.
+
+## Implementation notes
+
+The tooling here was originally written for `linarith`, not intended as an interactive tactic.
+The interactive version has been split off because it is sometimes convenient to use on its own.
+There are likely some rough edges to it.
+
+Improving this tactic would be a good project for someone interested in learning tactic programming.
+-/
+
+
+namespace CancelFactors
+
+/-! ### Lemmas used in the procedure -/
+
+
+theorem mul_subst {α} [CommRing α] {n1 n2 k e1 e2 t1 t2 : α} (h1 : n1 * e1 = t1) (h2 : n2 * e2 = t2)
+    (h3 : n1 * n2 = k) : k * (e1 * e2) = t1 * t2 := by
+  rw [← h3, mul_comm n1, mul_assoc n2, ← mul_assoc n1, h1, ← mul_assoc n2, mul_comm n2, mul_assoc,
+    h2]
+#align cancel_factors.mul_subst CancelFactors.mul_subst
+
+theorem div_subst {α} [Field α] {n1 n2 k e1 e2 t1 : α} (h1 : n1 * e1 = t1) (h2 : n2 / e2 = 1)
+    (h3 : n1 * n2 = k) : k * (e1 / e2) = t1 := by
+  rw [← h3, mul_assoc, mul_div_left_comm, h2, ← mul_assoc, h1, mul_comm, one_mul]
+#align cancel_factors.div_subst CancelFactors.div_subst
+
+theorem cancel_factors_eq_div {α} [Field α] {n e e' : α} (h : n * e = e') (h2 : n ≠ 0) :
+    e = e' / n :=
+  eq_div_of_mul_eq h2 <| by rwa [mul_comm] at h
+#align cancel_factors.cancel_factors_eq_div CancelFactors.cancel_factors_eq_div
+
+theorem add_subst {α} [Ring α] {n e1 e2 t1 t2 : α} (h1 : n * e1 = t1) (h2 : n * e2 = t2) :
+    n * (e1 + e2) = t1 + t2 := by simp [left_distrib, *]
+#align cancel_factors.add_subst CancelFactors.add_subst
+
+theorem sub_subst {α} [Ring α] {n e1 e2 t1 t2 : α} (h1 : n * e1 = t1) (h2 : n * e2 = t2) :
+    n * (e1 - e2) = t1 - t2 := by simp [left_distrib, *, sub_eq_add_neg]
+#align cancel_factors.sub_subst CancelFactors.sub_subst
+
+theorem neg_subst {α} [Ring α] {n e t : α} (h1 : n * e = t) : n * -e = -t := by simp [*]
+#align cancel_factors.neg_subst CancelFactors.neg_subst
+
+theorem cancel_factors_lt {α} [LinearOrderedField α] {a b ad bd a' b' gcd : α} (ha : ad * a = a')
+    (hb : bd * b = b') (had : 0 < ad) (hbd : 0 < bd) (hgcd : 0 < gcd) :
+    (a < b) = (1 / gcd * (bd * a') < 1 / gcd * (ad * b')) :=
+  by
+  rw [mul_lt_mul_left, ← ha, ← hb, ← mul_assoc, ← mul_assoc, mul_comm bd, mul_lt_mul_left]
+  exact mul_pos had hbd
+  exact one_div_pos.2 hgcd
+#align cancel_factors.cancel_factors_lt CancelFactors.cancel_factors_lt
+
+theorem cancel_factors_le {α} [LinearOrderedField α] {a b ad bd a' b' gcd : α} (ha : ad * a = a')
+    (hb : bd * b = b') (had : 0 < ad) (hbd : 0 < bd) (hgcd : 0 < gcd) :
+    (a ≤ b) = (1 / gcd * (bd * a') ≤ 1 / gcd * (ad * b')) :=
+  by
+  rw [mul_le_mul_left, ← ha, ← hb, ← mul_assoc, ← mul_assoc, mul_comm bd, mul_le_mul_left]
+  exact mul_pos had hbd
+  exact one_div_pos.2 hgcd
+#align cancel_factors.cancel_factors_le CancelFactors.cancel_factors_le
+
+theorem cancel_factors_eq {α} [LinearOrderedField α] {a b ad bd a' b' gcd : α} (ha : ad * a = a')
+    (hb : bd * b = b') (had : 0 < ad) (hbd : 0 < bd) (hgcd : 0 < gcd) :
+    (a = b) = (1 / gcd * (bd * a') = 1 / gcd * (ad * b')) :=
+  by
+  rw [← ha, ← hb, ← mul_assoc bd, ← mul_assoc ad, mul_comm bd]
+  ext; constructor
+  · rintro rfl
+    rfl
+  · intro h
+    simp only [← mul_assoc] at h
+    refine' mul_left_cancel₀ (mul_ne_zero _ _) h
+    apply mul_ne_zero
+    apply div_ne_zero
+    all_goals apply ne_of_gt <;> first |assumption|exact zero_lt_one
+#align cancel_factors.cancel_factors_eq CancelFactors.cancel_factors_eq
+
+open Tactic Expr
+
+/-! ### Computing cancelation factors -/
+
+
+open Tree
+
+-- failed to format: unknown constant 'term.pseudo.antiquot'
+/--
+      `find_cancel_factor e` produces a natural number `n`, such that multiplying `e` by `n` will
+      be able to cancel all the numeric denominators in `e`. The returned `tree` describes how to
+      distribute the value `n` over products inside `e`.
+      -/
+    unsafe
+  def
+    find_cancel_factor
+    : expr → ℕ × Tree ℕ
+    |
+        q( $ ( e1 ) + $ ( e2 ) )
+        =>
+        let
+          ( v1 , t1 ) := find_cancel_factor e1
+          let ( v2 , t2 ) := find_cancel_factor e2 let lcm := v1 . lcm v2 ( lcm , node lcm t1 t2 )
+      |
+        q( $ ( e1 ) - $ ( e2 ) )
+        =>
+        let
+          ( v1 , t1 ) := find_cancel_factor e1
+          let ( v2 , t2 ) := find_cancel_factor e2 let lcm := v1 . lcm v2 ( lcm , node lcm t1 t2 )
+      |
+        q( $ ( e1 ) * $ ( e2 ) )
+        =>
+        let
+          ( v1 , t1 ) := find_cancel_factor e1
+          let ( v2 , t2 ) := find_cancel_factor e2 let pd := v1 * v2 ( pd , node pd t1 t2 )
+      |
+        q( $ ( e1 ) / $ ( e2 ) )
+        =>
+        match
+          e2 . to_nonneg_rat
+          with
+          |
+              some q
+              =>
+              let
+                ( v1 , t1 ) := find_cancel_factor e1
+                let
+                  n := v1 . lcm q . num . natAbs
+                  ( n , node n t1 ( node q . num . natAbs Tree.nil Tree.nil ) )
+            | none => ( 1 , node 1 Tree.nil Tree.nil )
+      | q( - $ ( e ) ) => find_cancel_factor e
+      | _ => ( 1 , node 1 Tree.nil Tree.nil )
+#align cancel_factors.find_cancel_factor cancel_factors.find_cancel_factor
+
+/- ./././Mathport/Syntax/Translate/Expr.lean:330:4: warning: unsupported (TODO): `[tacs] -/
+/- ./././Mathport/Syntax/Translate/Expr.lean:330:4: warning: unsupported (TODO): `[tacs] -/
+/- ./././Mathport/Syntax/Translate/Expr.lean:330:4: warning: unsupported (TODO): `[tacs] -/
+-- failed to format: unknown constant 'term.pseudo.antiquot'
+/--
+      `mk_prod_prf n tr e` produces a proof of `n*e = e'`, where numeric denominators have been
+      canceled in `e'`, distributing `n` proportionally according to `tr`.
+      -/
+    unsafe
+  def
+    mk_prod_prf
+    : ℕ → Tree ℕ → expr → tactic expr
+    |
+        v , node _ lhs rhs , q( $ ( e1 ) + $ ( e2 ) )
+        =>
+        do
+          let v1 ← mk_prod_prf v lhs e1
+            let v2 ← mk_prod_prf v rhs e2
+            mk_app ` ` add_subst [ v1 , v2 ]
+      |
+        v , node _ lhs rhs , q( $ ( e1 ) - $ ( e2 ) )
+        =>
+        do
+          let v1 ← mk_prod_prf v lhs e1
+            let v2 ← mk_prod_prf v rhs e2
+            mk_app ` ` sub_subst [ v1 , v2 ]
+      |
+        v , node n ( lhs @ ( node ln _ _ ) ) rhs , q( $ ( e1 ) * $ ( e2 ) )
+        =>
+        do
+          let tp ← infer_type e1
+            let v1 ← mk_prod_prf ln lhs e1
+            let v2 ← mk_prod_prf ( v / ln ) rhs e2
+            let ln' ← tp . ofNat ln
+            let vln' ← tp . ofNat ( v / ln )
+            let v' ← tp . ofNat v
+            let ntp ← to_expr ` `( $ ( ln' ) * $ ( vln' ) = $ ( v' ) )
+            let ( _ , npf ) ← solve_aux ntp sorry
+            mk_app ` ` mul_subst [ v1 , v2 , npf ]
+      |
+        v , node n lhs rhs @ ( node rn _ _ ) , q( $ ( e1 ) / $ ( e2 ) )
+        =>
+        do
+          let tp ← infer_type e1
+            let v1 ← mk_prod_prf ( v / rn ) lhs e1
+            let rn' ← tp . ofNat rn
+            let vrn' ← tp . ofNat ( v / rn )
+            let n' ← tp . ofNat n
+            let v' ← tp . ofNat v
+            let ntp ← to_expr ` `( $ ( rn' ) / $ ( e2 ) = 1 )
+            let ( _ , npf ) ← solve_aux ntp sorry
+            let ntp2 ← to_expr ` `( $ ( vrn' ) * $ ( n' ) = $ ( v' ) )
+            let ( _ , npf2 ) ← solve_aux ntp2 sorry
+            mk_app ` ` div_subst [ v1 , npf , npf2 ]
+      | v , t , q( - $ ( e ) ) => do let v' ← mk_prod_prf v t e mk_app ` ` neg_subst [ v' ]
+      |
+        v , _ , e
+        =>
+        do
+          let tp ← infer_type e
+            let v' ← tp . ofNat v
+            let e' ← to_expr ` `( $ ( v' ) * $ ( e ) )
+            mk_app `eq.refl [ e' ]
+#align cancel_factors.mk_prod_prf cancel_factors.mk_prod_prf
+
+/--
+Given `e`, a term with rational division, produces a natural number `n` and a proof of `n*e = e'`,
+where `e'` has no division. Assumes "well-behaved" division.
+-/
+unsafe def derive (e : expr) : tactic (ℕ × expr) :=
+  let (n, t) := find_cancel_factor e
+  Prod.mk n <$> mk_prod_prf n t e <|>
+    throwError
+      "cancel_factors.derive failed to normalize {← e}. Are you sure this is well-behaved division?"
+#align cancel_factors.derive cancel_factors.derive
+
+/- ./././Mathport/Syntax/Translate/Expr.lean:330:4: warning: unsupported (TODO): `[tacs] -/
+-- failed to format: unknown constant 'term.pseudo.antiquot'
+/--
+      Given `e`, a term with rational divison, produces a natural number `n` and a proof of `e = e' / n`,
+      where `e'` has no divison. Assumes "well-behaved" division.
+      -/
+    unsafe
+  def
+    derive_div
+    ( e : expr ) : tactic ( ℕ × expr )
+    :=
+      do
+        let ( n , p ) ← derive e
+          let tp ← infer_type e
+          let n' ← tp . ofNat n
+          let tgt ← to_expr ` `( $ ( n' ) ≠ 0 )
+          let ( _ , pn ) ← solve_aux tgt sorry
+          Prod.mk n
+            <$>
+            mk_mapp ` ` cancel_factors_eq_div [ none , none , n' , none , none , p , pn ]
+#align cancel_factors.derive_div cancel_factors.derive_div
+
+-- failed to format: unknown constant 'term.pseudo.antiquot'
+/--
+      `find_comp_lemma e` arranges `e` in the form `lhs R rhs`, where `R ∈ {<, ≤, =}`, and returns
+      `lhs`, `rhs`, and the `cancel_factors` lemma corresponding to `R`.
+      -/
+    unsafe
+  def
+    find_comp_lemma
+    : expr → Option ( expr × expr × Name )
+    | q( $ ( a ) < $ ( b ) ) => ( a , b , ` ` cancel_factors_lt )
+      | q( $ ( a ) ≤ $ ( b ) ) => ( a , b , ` ` cancel_factors_le )
+      | q( $ ( a ) = $ ( b ) ) => ( a , b , ` ` cancel_factors_eq )
+      | q( $ ( a ) ≥ $ ( b ) ) => ( b , a , ` ` cancel_factors_le )
+      | q( $ ( a ) > $ ( b ) ) => ( b , a , ` ` cancel_factors_lt )
+      | _ => none
+#align cancel_factors.find_comp_lemma cancel_factors.find_comp_lemma
+
+/- ./././Mathport/Syntax/Translate/Expr.lean:330:4: warning: unsupported (TODO): `[tacs] -/
+/- ./././Mathport/Syntax/Translate/Expr.lean:330:4: warning: unsupported (TODO): `[tacs] -/
+/- ./././Mathport/Syntax/Translate/Expr.lean:330:4: warning: unsupported (TODO): `[tacs] -/
+/-- `cancel_denominators_in_type h` assumes that `h` is of the form `lhs R rhs`,
+where `R ∈ {<, ≤, =, ≥, >}`.
+It produces an expression `h'` of the form `lhs' R rhs'` and a proof that `h = h'`.
+Numeric denominators have been canceled in `lhs'` and `rhs'`.
+-/
+unsafe def cancel_denominators_in_type (h : expr) : tactic (expr × expr) := do
+  let some (lhs, rhs, lem) ← return <| find_comp_lemma h |
+    fail "cannot kill factors"
+  let (al, lhs_p) ← derive lhs
+  let (ar, rhs_p) ← derive rhs
+  let gcd := al.gcd ar
+  let tp ← infer_type lhs
+  let al ← tp.ofNat al
+  let ar ← tp.ofNat ar
+  let gcd ← tp.ofNat gcd
+  let al_pos ← to_expr ``(0 < $(al))
+  let ar_pos ← to_expr ``(0 < $(ar))
+  let gcd_pos ← to_expr ``(0 < $(gcd))
+  let (_, al_pos) ← solve_aux al_pos sorry
+  let (_, ar_pos) ← solve_aux ar_pos sorry
+  let (_, gcd_pos) ← solve_aux gcd_pos sorry
+  let pf ← mk_app lem [lhs_p, rhs_p, al_pos, ar_pos, gcd_pos]
+  let pf_tp ← infer_type pf
+  return ((find_comp_lemma pf_tp).elim default (Prod.fst ∘ Prod.snd), pf)
+#align cancel_factors.cancel_denominators_in_type cancel_factors.cancel_denominators_in_type
+
+end CancelFactors
+
+/-! ### Interactive version -/
+
+
+/- ./././Mathport/Syntax/Translate/Tactic/Mathlib/Core.lean:38:34: unsupported: setup_tactic_parser -/
+open Tactic Expr CancelFactors
+
+/-- `cancel_denoms` attempts to remove numerals from the denominators of fractions.
+It works on propositions that are field-valued inequalities.
+
+```lean
+variables {α : Type} [linear_ordered_field α] (a b c : α)
+
+example (h : a / 5 + b / 4 < c) : 4*a + 5*b < 20*c :=
+begin
+  cancel_denoms at h,
+  exact h
+end
+
+example (h : a > 0) : a / 5 > 0 :=
+begin
+  cancel_denoms,
+  exact h
+end
+```
+-/
+unsafe def tactic.interactive.cancel_denoms (l : parse location) : tactic Unit := do
+  let locs ← l.get_locals
+  tactic.replace_at cancel_denominators_in_type locs l >>= guardb <|>
+      fail "failed to cancel any denominators"
+  tactic.interactive.norm_num [simp_arg_type.symm_expr ``(mul_assoc)] l
+#align tactic.interactive.cancel_denoms tactic.interactive.cancel_denoms
+
+add_tactic_doc
+  { Name := "cancel_denoms"
+    category := DocCategory.tactic
+    declNames := [`tactic.interactive.cancel_denoms]
+    tags := ["simplification"] }
+

--- a/Mathlib/Tactic/Linarith/Datatypes.lean
+++ b/Mathlib/Tactic/Linarith/Datatypes.lean
@@ -402,7 +402,6 @@ def mkSingleCompZeroOf (c : Nat) (h : Expr) : MetaM (Ineq × Expr) := do
   else do
     let tp ← inferType (← getRelSides (← inferType h)).2
     let cpos ← mkAppM ``GT.gt #[(← tp.ofNat c), (← tp.ofNat 0)]
-    -- TODO There should be a def for this, rather than using `evalTactic`.
-    let ex ← synthesizeUsing cpos (do evalTactic (←`(tactic| norm_num; done)))
+    let ex ← synthesizeUsingTactic' cpos (← `(tactic| norm_num))
     let e' ← mkAppM iq.toConstMulName #[h, ex]
     return (iq, e')

--- a/Mathlib/Tactic/Linarith/Verification.lean
+++ b/Mathlib/Tactic/Linarith/Verification.lean
@@ -160,7 +160,7 @@ def addNegEqProofs : List Expr → MetaM (List Expr)
 def proveEqZeroUsing (tac : TacticM Unit) (e : Expr) : MetaM Expr := do
   let ⟨u, α, e⟩ ← inferTypeQ' e
   let _h : Q(Zero $α) ← synthInstanceQ q(Zero $α)
-  synthesizeUsing q($e = 0) tac
+  synthesizeUsing' q($e = 0) tac
 
 /-! #### The main method -/
 

--- a/Mathlib/Util/Qq.lean
+++ b/Mathlib/Util/Qq.lean
@@ -14,12 +14,14 @@ open Lean Elab Tactic Meta
 
 namespace Qq
 
-/-- Analogue of `inferTypeQ`, but that gets universe levels right for our application. -/
+/-- Variant of `inferTypeQ` that yields a type in `Type u` rather than `Sort u`.
+Throws an error if the type is a `Prop` or if it's otherwise not possible to represent
+the universe as `Type u` (for example due to universe level metavariables). -/
 -- See https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Using.20.60QQ.60.20when.20you.20only.20have.20an.20.60Expr.60/near/303349037
 def inferTypeQ' (e : Expr) : MetaM ((u : Level) × (α : Q(Type $u)) × Q($α)) := do
   let α ← inferType e
-  let .sort u ← instantiateMVars (← whnf (← inferType α)) | unreachable!
-  let some v := u.dec | throwError "not a type{indentExpr α}"
+  let .sort u ← whnf (← inferType α) | throwError "not a type{indentExpr α}"
+  let some v := (← instantiateLevelMVars u).dec | throwError "not a Type{indentExpr e}"
   pure ⟨v, α, e⟩
 
 end Qq

--- a/Mathlib/Util/SynthesizeUsing.lean
+++ b/Mathlib/Util/SynthesizeUsing.lean
@@ -38,7 +38,12 @@ def synthesizeUsing' (type : Expr) (tac : TacticM Unit) : MetaM Expr := do
 
 /--
 `synthesizeUsing type tacticSyntax` synthesizes an element of type `type` by evaluating the
-tactic with the given syntax.
+given tactic syntax.
+
+Example:
+```lean
+let (gs, e) ← synthesizeUsing ty (← `(tactic| congr!))
+```
 
 The tactic `tac` is allowed to leave goals open, and these remain as metavariables in the
 returned expression.
@@ -48,7 +53,12 @@ def synthesizeUsingTactic (type : Expr) (tac : Syntax) : MetaM (List MVarId × E
 
 /--
 `synthesizeUsing' type tacticSyntax` synthesizes an element of type `type` by evaluating the
-tactic with the given syntax.
+given tactic syntax.
+
+Example:
+```lean
+let e ← synthesizeUsing ty (← `(tactic| norm_num))
+```
 
 The tactic must solve for all goals, in contrast to `synthesizeUsingTactic`.
 -/

--- a/Mathlib/Util/SynthesizeUsing.lean
+++ b/Mathlib/Util/SynthesizeUsing.lean
@@ -69,11 +69,11 @@ is a term elaborator that wraps the `simp at ...` tactic:
 def simpTerm (e : Expr) : MetaM Expr := do
   let mvar ← Meta.mkFreshTypeMVar
   let e' ← synthesizeUsing' mvar
-    -- Note: `simp` does not always insert type hints, so `exact id h` is a way to ensure
-    -- that the type of `h` in the local context is saved. Otherwise the type might
-    -- be merely defeq.
-    (do evalTactic (← `(tactic| have h := $(← Term.exprToSyntax e); simp at h; exact id h)))
-  return e'
+    (do evalTactic (← `(tactic| have h := $(← Term.exprToSyntax e); simp at h; exact h)))
+  -- Note: `simp` does not always insert type hints, so to ensure that we get a term
+  -- with the simplified type (as opposed to one that is merely defeq), we should add
+  -- a type hint ourselves.
+  Meta.mkExpectedTypeHint e' mvar
 
 elab "simpTerm% " t:term : term => do simpTerm (← Term.elabTerm t none)
 ```

--- a/Mathlib/Util/SynthesizeUsing.lean
+++ b/Mathlib/Util/SynthesizeUsing.lean
@@ -14,14 +14,43 @@ This is a slight simplification of the `solve_aux` tactic in Lean3.
 open Lean Elab Tactic Meta
 
 /--
-`synthesizeUsing type tac` synthesizes an element of `type` using tactic `tac`.
+`synthesizeUsing type tac` synthesizes an element of type `type` using tactic `tac`.
 
-The tactic `tac` may leave goals open, these remain as metavariables in the returned expression.
+The tactic `tac` is allowed to leave goals open, and these remain as metavariables in the
+returned expression.
 -/
 -- In Lean3 this was called `solve_aux`,
 -- and took a `TacticM α` and captured the produced value in `α`.
 -- As this was barely used, we've simplified here.
-def synthesizeUsing (type : Expr) (tac : TacticM Unit) : MetaM Expr := do
+def synthesizeUsing (type : Expr) (tac : TacticM Unit) : MetaM (List MVarId × Expr) := do
   let m ← mkFreshExprMVar type
-  let _ ← (run m.mvarId! tac).run'
-  instantiateMVars m
+  let goals ← (run m.mvarId! tac).run'
+  return (goals, ← instantiateMVars m)
+
+/--
+`synthesizeUsing type tac` synthesizes an element of type `type` using tactic `tac`.
+
+The tactic must solve for all goals, in contrast to `synthesizeUsing`.
+-/
+def synthesizeUsing' (type : Expr) (tac : TacticM Unit) : MetaM Expr := do
+  let (_, e) ← synthesizeUsing type (tac *> Tactic.done)
+  return e
+
+/--
+`synthesizeUsing type tacticSyntax` synthesizes an element of type `type` by evaluating the
+tactic with the given syntax.
+
+The tactic `tac` is allowed to leave goals open, and these remain as metavariables in the
+returned expression.
+-/
+def synthesizeUsingTactic (type : Expr) (tac : Syntax) : MetaM (List MVarId × Expr) := do
+  synthesizeUsing type (do evalTactic tac)
+
+/--
+`synthesizeUsing' type tacticSyntax` synthesizes an element of type `type` by evaluating the
+tactic with the given syntax.
+
+The tactic must solve for all goals, in contrast to `synthesizeUsingTactic`.
+-/
+def synthesizeUsingTactic' (type : Expr) (tac : Syntax) : MetaM Expr := do
+  synthesizeUsing' type (do evalTactic tac)

--- a/Mathlib/Util/SynthesizeUsing.lean
+++ b/Mathlib/Util/SynthesizeUsing.lean
@@ -71,7 +71,7 @@ def simpTerm (e : Expr) : MetaM Expr := do
   let e' ← synthesizeUsing' mvar
     -- Note: `simp` does not always insert type hints, so `exact id h` is a way to ensure
     -- that the type of `h` in the local context is saved. Otherwise the type might
-    -- merely be defeq.
+    -- be merely defeq.
     (do evalTactic (← `(tactic| have h := $(← Term.exprToSyntax e); simp at h; exact id h)))
   return e'
 

--- a/test/cancel_denoms.lean
+++ b/test/cancel_denoms.lean
@@ -1,0 +1,17 @@
+import Mathlib.Tactic.CancelDenoms
+import Mathlib.Tactic.Ring
+
+variable [LinearOrderedField α] (a b c d : α)
+
+example (h : a / 5 + b / 4 < c) : 4*a + 5*b < 20*c := by
+  cancel_denoms at h
+  exact h
+
+example (h : a > 0) : a / 5 > 0 := by
+  cancel_denoms
+  exact h
+
+example (h : a + b = c) : a/5 + d*(b/4) = c - 4*a/5 + b*2*d/8 - b := by
+  cancel_denoms
+  rw [← h]
+  ring

--- a/test/cancel_denoms.lean
+++ b/test/cancel_denoms.lean
@@ -1,7 +1,7 @@
 import Mathlib.Tactic.CancelDenoms
 import Mathlib.Tactic.Ring
 
-variable [LinearOrderedField α] (a b c d : α)
+variable {α : Type u} [LinearOrderedField α] (a b c d : α)
 
 example (h : a / 5 + b / 4 < c) : 4*a + 5*b < 20*c := by
   cancel_denoms at h

--- a/test/cancel_denoms.lean
+++ b/test/cancel_denoms.lean
@@ -16,8 +16,34 @@ example (h : a + b = c) : a/5 + d*(b/4) = c - 4*a/5 + b*2*d/8 - b := by
   cancel_denoms
   rw [← h]
   ring
+
+example (h : 0 < a) : a / (3/2) > 0 := by
+  cancel_denoms
+  exact h
+
+example (h : 0 < a): 0 < a / 1 := by
+  cancel_denoms
+  exact h
+
+example (h : a < 0): 0 < a / -1 := by
+  cancel_denoms
+  exact h
+
+example (h : -a < 2 * b): a / -2 < b := by
+  cancel_denoms
+  exact h
+
+example (h : a < 6 * a) : a / 2 / 3 < a := by
+  cancel_denoms
+  exact h
+
+example (h : a < 9 * a) : a / 3 / 3 < a := by
+  cancel_denoms
+  exact h
+
 end
 
+-- Some tests with a concrete type universe.
 section
 variable {α : Type} [LinearOrderedField α] (a b c d : α)
 
@@ -35,7 +61,7 @@ example (h : a + b = c) : a/5 + d*(b/4) = c - 4*a/5 + b*2*d/8 - b := by
   ring
 end
 
-
+-- Some tests with a concrete type.
 section
 variable (a b c d : ℚ)
 

--- a/test/cancel_denoms.lean
+++ b/test/cancel_denoms.lean
@@ -1,6 +1,7 @@
 import Mathlib.Tactic.CancelDenoms
 import Mathlib.Tactic.Ring
 
+section
 variable {α : Type u} [LinearOrderedField α] (a b c d : α)
 
 example (h : a / 5 + b / 4 < c) : 4*a + 5*b < 20*c := by
@@ -15,3 +16,39 @@ example (h : a + b = c) : a/5 + d*(b/4) = c - 4*a/5 + b*2*d/8 - b := by
   cancel_denoms
   rw [← h]
   ring
+end
+
+section
+variable {α : Type} [LinearOrderedField α] (a b c d : α)
+
+example (h : a / 5 + b / 4 < c) : 4*a + 5*b < 20*c := by
+  cancel_denoms at h
+  exact h
+
+example (h : a > 0) : a / 5 > 0 := by
+  cancel_denoms
+  exact h
+
+example (h : a + b = c) : a/5 + d*(b/4) = c - 4*a/5 + b*2*d/8 - b := by
+  cancel_denoms
+  rw [← h]
+  ring
+end
+
+
+section
+variable (a b c d : ℚ)
+
+example (h : a / 5 + b / 4 < c) : 4*a + 5*b < 20*c := by
+  cancel_denoms at h
+  exact h
+
+example (h : a > 0) : a / 5 > 0 := by
+  cancel_denoms
+  exact h
+
+example (h : a + b = c) : a/5 + d*(b/4) = c - 4*a/5 + b*2*d/8 - b := by
+  cancel_denoms
+  rw [← h]
+  ring
+end


### PR DESCRIPTION
Ports the tactic `CancelDenoms.derive` and the interactive tactic `cancel_denoms`. This tactic is needed to make `linarith` handle divisions by numbers, but this PR does not involve `linarith`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
