### PR TITLE
[Merged by Bors] - fix: `lift` can't be used when the type of the goal is `Sort.{?u}` while `?u` is assigned by `0`

### DIFF
--- a/Mathlib/Tactic/Lift.lean
+++ b/Mathlib/Tactic/Lift.lean
@@ -127,7 +127,7 @@ def Lift.main (e t : TSyntax `term) (hUsing : Option (TSyntax `term))
   let isNewEq := newEqName != `rfl
   let e ← elabTerm e none
   let goal ← getMainGoal
-  if !(← inferType (← goal.getType)).isProp then throwError
+  if !(← inferType (← instantiateMVars (← goal.getType))).isProp then throwError
     "lift tactic failed. Tactic is only applicable when the target is a proposition."
   if newVarName == none ∧ !e.isFVar then throwError
     "lift tactic failed. When lifting an expression, a new variable name must be given"

--- a/test/lift.lean
+++ b/test/lift.lean
@@ -200,6 +200,14 @@ example (n : ℕ) (hn : 0 < n) : True := by
   guard_hyp hn : 0 < (n : ℕ)
   trivial
 
+example (n : ℕ) : n = 0 ∨ ∃ p : ℕ+, n = p := by
+  by_cases hn : 0 < n
+  · lift n to ℕ+ using hn
+    right
+    exact ⟨n, rfl⟩
+  · left
+    exact Nat.eq_zero_of_nonpos _ hn
+
 example (n : ℤ) (hn : 0 < n) : True := by
   lift n to ℕ+
   · guard_target =ₛ 0 < n


### PR DESCRIPTION
For example, this emits error.
```lean
example (n : ℕ) : n = 0 ∨ ∃ p : ℕ+, n = p := by
  by_cases hn : 0 < n
  · lift n to ℕ+ using hn -- error
    right
    exact ⟨n, rfl⟩
  · left
    exact Nat.eq_zero_of_nonpos _ hn
```
The cause is that `lift` doesn't instantiate level metavariables when checking that the type of the goal is `Prop`.
This PR makes the above example available. Please refer to `test/lift.lean`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
