### PR TITLE
[Merged by Bors] - feat: enable cancel_denoms preprocessor in linarith

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1764,6 +1764,7 @@ import Mathlib.Tactic.Backtracking
 import Mathlib.Tactic.Basic
 import Mathlib.Tactic.ByContra
 import Mathlib.Tactic.Cache
+import Mathlib.Tactic.CancelDenoms
 import Mathlib.Tactic.Cases
 import Mathlib.Tactic.CasesM
 import Mathlib.Tactic.Choose

--- a/Mathlib/Algebra/Order/Floor.lean
+++ b/Mathlib/Algebra/Order/Floor.lean
@@ -1437,26 +1437,18 @@ theorem round_eq (x : α) : round x = ⌊x + 1 / 2⌋ := by
     rw [if_pos hx, self_eq_add_right, floor_eq_iff, cast_zero, zero_add]
     constructor
     . linarith [fract_nonneg x]
-    · -- Porting note: `add_halves` can be removed after linarith learns about fractions
-      linarith [add_halves (1:α)]
+    · linarith
   · have : ⌊fract x + 1 / 2⌋ = 1 := by
       rw [floor_eq_iff]
       constructor
-      . -- norm_num at *
-        -- linarith
-        -- Porting note: linarith broke here after the move to ℚ in norm_num.
-        have := add_le_add_right hx (1/2)
-        norm_num at *
-        assumption
-      · -- Porting note: `norm_num at *` can lose the *, after linarith learns about fractions
-        norm_num at *
+      . norm_num
+        linarith
+      · norm_num
         linarith [fract_lt_one x]
     rw [if_neg (not_lt.mpr hx), ← fract_add_floor x, add_assoc, add_left_comm, floor_int_add,
       ceil_add_int, add_comm _ ⌊x⌋, add_right_inj, ceil_eq_iff, this, cast_one, sub_self]
     constructor
-    . -- Porting note: can be just `norm_num ; linarith` after linarith learns about fractions
-      have : (0:α) < 1/2 := half_pos <| by norm_num
-      linarith
+    . linarith
     · linarith [fract_lt_one x]
 #align round_eq round_eq
 
@@ -1473,7 +1465,6 @@ theorem round_neg_two_inv : round (-2⁻¹ : α) = 0 := by
 @[simp]
 theorem round_eq_zero_iff {x : α} : round x = 0 ↔ x ∈ Ico (-(1 / 2)) ((1 : α) / 2) := by
   rw [round_eq, floor_eq_zero_iff, add_mem_Ico_iff_left]
-  rw [← add_halves (1:α)] -- porting note: line can be removed after norm_num learns about fractions
   norm_num
 #align round_eq_zero_iff round_eq_zero_iff
 
@@ -1481,10 +1472,7 @@ theorem abs_sub_round (x : α) : |x - round x| ≤ 1 / 2 := by
   rw [round_eq, abs_sub_le_iff]
   have := floor_le (x + 1 / 2)
   have := lt_floor_add_one (x + 1 / 2)
-  constructor
-  . -- Porting note: `add_halves` can be removed after linarith learns about fractions
-    linarith [add_halves (1:α)]
-  . linarith
+  constructor <;> linarith
 #align abs_sub_round abs_sub_round
 
 theorem abs_sub_round_div_natCast_eq {m n : ℕ} :

--- a/Mathlib/Analysis/Normed/Order/UpperLower.lean
+++ b/Mathlib/Analysis/Normed/Order/UpperLower.lean
@@ -133,16 +133,7 @@ theorem IsUpperSet.exists_subset_ball (hs : IsUpperSet s) (hx : x ∈ closure s)
   replace hz := (norm_le_pi_norm _ i).trans hz
   dsimp at hxy hz
   rw [abs_sub_le_iff] at hxy hz
-  -- Porting note: rest of proof was just `linarith`. Probably mathlib4#2714
-  have hxz : x i - z i ≤ -2 / 4 * δ := by
-    have h3 : -2 / 4 * δ - δ / 4 = -(3 / 4 * δ) := by ring
-    linarith
-  have hyz : y i - z i ≤ -δ / 4 := by
-    have t := add_le_add hxy.2 hxz
-    have h1 : δ / 4 + -2 / 4 * δ = -δ / 4 := by ring
-    linarith
-  have hδ4 : -δ / 4 < 0 := div_neg_of_neg_of_pos (Left.neg_neg_iff.mpr hδ) zero_lt_four
-  exact sub_neg.mp (lt_of_le_of_lt hyz hδ4)
+  linarith
 #align is_upper_set.exists_subset_ball IsUpperSet.exists_subset_ball
 
 theorem IsLowerSet.exists_subset_ball (hs : IsLowerSet s) (hx : x ∈ closure s) (hδ : 0 < δ) :
@@ -160,16 +151,7 @@ theorem IsLowerSet.exists_subset_ball (hs : IsLowerSet s) (hx : x ∈ closure s)
   replace hz := (norm_le_pi_norm _ i).trans hz
   dsimp at hxy hz
   rw [abs_sub_le_iff] at hxy hz
-  -- Porting note: rest of proof was just `linarith`. Probably mathlib4#2714
-  have hzx : z i - x i ≤ -2 / 4 * δ := by
-    have h3 : -2 / 4 * δ - δ / 4 = -(3 / 4 * δ) := by ring
-    linarith
-  have hzy : z i - y i ≤ -δ / 4 := by
-    have t := add_le_add hzx hxy.1
-    have h1 : -2 / 4 * δ + δ / 4 = -δ / 4 := by ring
-    linarith
-  have hδ4 : -δ / 4 < 0 := div_neg_of_neg_of_pos (Left.neg_neg_iff.mpr hδ) zero_lt_four
-  exact sub_neg.mp (lt_of_le_of_lt hzy hδ4)
+  linarith
 #align is_lower_set.exists_subset_ball IsLowerSet.exists_subset_ball
 
 end Fintype

--- a/Mathlib/Data/Complex/Exponential.lean
+++ b/Mathlib/Data/Complex/Exponential.lean
@@ -1697,27 +1697,13 @@ theorem exp_bound' {x : ℂ} {n : ℕ} (hx : abs x / n.succ ≤ 1 / 2) :
     · simp_rw [← div_pow]
       rw [geom_sum_eq, div_le_iff_of_neg]
       · trans (-1 : ℝ)
-        · -- Porting note: was linarith
-          simp [Nat.succ_eq_add_one] at hx
-          rw [mul_comm, ← le_div_iff]
-          simp [hx]
-          . norm_num [this, hx]
-            simp [hx]
-          . exact zero_lt_two
+        · linarith
         · simp only [neg_le_sub_iff_le_add, div_pow, Nat.cast_succ, le_add_iff_nonneg_left]
           exact
             div_nonneg (pow_nonneg (abs.nonneg x) k)
               (pow_nonneg (add_nonneg n.cast_nonneg zero_le_one) k)
-      · -- Porting note: was linarith
-        simp [Nat.succ_eq_add_one] at hx
-        simp
-        apply lt_of_le_of_lt hx
-        norm_num
-      · -- Porting note: was linarith
-        intro h
-        simp at h
-        simp [h] at hx
-        norm_num at hx
+      · linarith
+      · linarith
     · exact div_nonneg (pow_nonneg (abs.nonneg x) n) (Nat.cast_nonneg n.factorial)
 #align complex.exp_bound' Complex.exp_bound'
 
@@ -1942,9 +1928,7 @@ theorem sin_pos_of_pos_of_le_one {x : ℝ} (hx0 : 0 < x) (hx : x ≤ 1) : 0 < si
                     x ^ 3 ≤ x ^ 1 := pow_le_pow_of_le_one (le_of_lt hx0) hx (by decide)
                     _ = x := pow_one _
                     ))
-            --Porting note : was `_ < x := by linarith`
-            _ = x * (7 / 32) := by ring
-            _ < x := (mul_lt_iff_lt_one_right hx0).2 (by norm_num))
+            _ < x := by linarith)
     _ ≤ sin x :=
       sub_le_comm.1 (abs_sub_le_iff.1 (sin_bound (by rwa [_root_.abs_of_nonneg (le_of_lt hx0)]))).2
 #align real.sin_pos_of_pos_of_le_one Real.sin_pos_of_pos_of_le_one

--- a/Mathlib/Data/Nat/Digits.lean
+++ b/Mathlib/Data/Nat/Digits.lean
@@ -633,10 +633,8 @@ namespace NormDigits
 theorem digits_succ (b n m r l) (e : r + b * m = n) (hr : r < b)
     (h : Nat.digits b m = l ∧ 1 < b ∧ 0 < m) : (Nat.digits b n = r :: l) ∧ 1 < b ∧ 0 < n := by
   rcases h with ⟨h, b2, m0⟩
-  -- Porting note: Below line was proved by `by linarith`
-  have b0 : 0 < b := by simp_arith [lt_iff_le_and_ne.mp b2]
-  -- Porting note: Below line was proved by `by linarith [mul_pos b0 m0]`
-  have n0 : 0 < n := le_trans (lt_iff_add_one_le.mp (mul_pos b0 m0)) (e.subst (le_add_left _ r))
+  have b0 : 0 < b := by linarith
+  have n0 : 0 < n := by linarith [mul_pos b0 m0]
   refine' ⟨_, b2, n0⟩
   obtain ⟨rfl, rfl⟩ := (Nat.div_mod_unique b0).2 ⟨e, hr⟩
   subst h; exact Nat.digits_def' b2 n0

--- a/Mathlib/GroupTheory/Perm/Cycle/Type.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/Type.lean
@@ -583,8 +583,7 @@ theorem _root_.card_support_eq_three_iff : σ.support.card = 3 ↔ σ.IsThreeCyc
   obtain ⟨m, hm⟩ := exists_mem_of_ne_zero h1
   rw [← sum_cycleType, ← cons_erase hn, ← cons_erase hm, Multiset.sum_cons, Multiset.sum_cons] at h
   -- TODO: linarith [...] should solve this directly
-  have : ∀ {k}, 2 ≤ m → 2 ≤ n → n + (m + k) = 3 → False :=
-    by
+  have : ∀ {k}, 2 ≤ m → 2 ≤ n → n + (m + k) = 3 → False := by
     intros
     linarith
   cases this (two_le_of_mem_cycleType (mem_of_mem_erase hm)) (two_le_of_mem_cycleType hn) h

--- a/Mathlib/Lean/Expr/Basic.lean
+++ b/Mathlib/Lean/Expr/Basic.lean
@@ -340,6 +340,30 @@ def mkProjection (e : Expr) (fieldName : Name) : MetaM Expr := do
     e := mkAppN (.const projName us) (type.getAppArgs.push e)
   mkDirectProjection e fieldName
 
+/-- Returns true if `e` contains a name `n` where `p n` is true. -/
+def containsConst (e : Expr) (p : Name → Bool) : Bool :=
+e.foldConsts false (fun n b => b || p n)
+
+/--
+Rewrites `e` via some `eq`, producing a proof `e = e'` for some `e'`.
+
+Rewrites with a fresh metavariable as the ambient goal.
+Fails if the rewrite produces any subgoals.
+-/
+def rewrite (e eq : Expr) : MetaM Expr := do
+  let ⟨_, eq', []⟩ ← (← mkFreshExprMVar none).mvarId!.rewrite e eq
+    | throwError "Expr.rewrite may not produce subgoals."
+  return eq'
+
+/--
+Rewrites the type of `e` via some `eq`, then moves `e` into the new type via `Eq.mp`.
+
+Rewrites with a fresh metavariable as the ambient goal.
+Fails if the rewrite produces any subgoals.
+-/
+def rewriteType (e eq : Expr) : MetaM Expr := do
+  mkEqMP (← (← inferType e).rewrite eq) e
+
 end Expr
 
 /-- Get the projections that are projections to parent structures. Similar to `getParentStructures`,

--- a/Mathlib/Lean/Expr/Basic.lean
+++ b/Mathlib/Lean/Expr/Basic.lean
@@ -342,7 +342,7 @@ def mkProjection (e : Expr) (fieldName : Name) : MetaM Expr := do
 
 /-- Returns true if `e` contains a name `n` where `p n` is true. -/
 def containsConst (e : Expr) (p : Name → Bool) : Bool :=
-e.foldConsts false (fun n b => b || p n)
+  Option.isSome <| e.find? fun | .const n _ => p n | _ => false
 
 /--
 Rewrites `e` via some `eq`, producing a proof `e = e'` for some `e'`.

--- a/Mathlib/Tactic/CancelDenoms.lean
+++ b/Mathlib/Tactic/CancelDenoms.lean
@@ -125,21 +125,21 @@ def synthesizeUsingNormNum (type : Expr) : MetaM Expr := do
 `mkProdPrf n tr e` produces a proof of `n*e = e'`, where numeric denominators have been
 canceled in `e'`, distributing `n` proportionally according to `tr`.
 -/
-partial def mkProdPrf (α : Q(Type u)) (_sα : Q(Field $α)) (v : ℕ) (t : Tree ℕ)
+partial def mkProdPrf (α : Q(Type u)) (sα : Q(Field $α)) (v : ℕ) (t : Tree ℕ)
     (e : Q($α)) : MetaM Expr := do
   let amwo ← synthInstanceQ q(AddMonoidWithOne $α)
   match t, e with
   | .node _ lhs rhs, ~q($e1 + $e2) => do
-    let v1 ← mkProdPrf α _sα v lhs e1
-    let v2 ← mkProdPrf α _sα v rhs e2
+    let v1 ← mkProdPrf α sα v lhs e1
+    let v2 ← mkProdPrf α sα v rhs e2
     mkAppM `CancelFactors.add_subst #[v1, v2]
   | .node _ lhs rhs, ~q($e1 - $e2) => do
-    let v1 ← mkProdPrf α _sα v lhs e1
-    let v2 ← mkProdPrf α _sα v rhs e2
+    let v1 ← mkProdPrf α sα v lhs e1
+    let v2 ← mkProdPrf α sα v rhs e2
     mkAppM `CancelFactors.sub_subst #[v1, v2]
   | .node _ lhs@(.node ln _ _) rhs, ~q($e1 * $e2) => do
-    let v1 ← mkProdPrf α _sα ln lhs e1
-    let v2 ← mkProdPrf α _sα (v / ln) rhs e2
+    let v1 ← mkProdPrf α sα ln lhs e1
+    let v2 ← mkProdPrf α sα (v / ln) rhs e2
     have ln' := (← mkOfNat α amwo <| mkRawNatLit ln).1
     have vln' := (← mkOfNat α amwo <| mkRawNatLit (v/ln)).1
     have v' := (← mkOfNat α amwo <| mkRawNatLit v).1
@@ -147,7 +147,7 @@ partial def mkProdPrf (α : Q(Type u)) (_sα : Q(Field $α)) (v : ℕ) (t : Tree
     let npf ← synthesizeUsingNormNum ntp
     mkAppM `CancelFactors.mul_subst #[v1, v2, npf]
   | .node n lhs (.node rn _ _), ~q($e1 / $e2) => do
-    let v1 ← mkProdPrf α _sα (v / rn) lhs e1
+    let v1 ← mkProdPrf α sα (v / rn) lhs e1
     have rn' := (← mkOfNat α amwo <| mkRawNatLit rn).1
     have vrn' := (← mkOfNat α amwo <| mkRawNatLit <| v / rn).1
     have n' := (← mkOfNat α amwo <| mkRawNatLit <| n).1
@@ -158,12 +158,12 @@ partial def mkProdPrf (α : Q(Type u)) (_sα : Q(Field $α)) (v : ℕ) (t : Tree
     let npf2 ← synthesizeUsingNormNum ntp2
     mkAppM `CancelFactors.div_subst #[v1, npf, npf2]
   | t, ~q(-$e) => do
-    let v ← mkProdPrf α _sα v t e
+    let v ← mkProdPrf α sα v t e
     mkAppM `CancelFactors.neg_subst #[v]
   | _, _ => do
     have v' := (← mkOfNat α amwo <| mkRawNatLit <| v).1
     let e' ← mkAppM `HMul.hMul #[v', e]
-    mkAppM `Eq.refl #[e']
+    mkEqRefl e'
 
 /--
 Given `e`, a term with rational division, produces a natural number `n` and a proof of `n*e = e'`,

--- a/Mathlib/Tactic/CancelDenoms.lean
+++ b/Mathlib/Tactic/CancelDenoms.lean
@@ -8,10 +8,10 @@ Authors: Robert Y. Lewis
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
-import Mathlib.Data.Rat.MetaDefs
+--import Mathlib.Data.Rat.MetaDefs
 import Mathlib.Tactic.NormNum
 import Mathlib.Data.Tree
-import Mathlib.Meta.Expr
+--import Mathlib.Meta.Expr
 
 /-!
 # A tactic for canceling numeric denominators
@@ -91,244 +91,23 @@ theorem cancel_factors_eq {α} [LinearOrderedField α] {a b ad bd a' b' gcd : α
     refine' mul_left_cancel₀ (mul_ne_zero _ _) h
     apply mul_ne_zero
     apply div_ne_zero
-    all_goals apply ne_of_gt <;> first |assumption|exact zero_lt_one
+    all_goals apply ne_of_gt ; first |assumption|exact zero_lt_one
 #align cancel_factors.cancel_factors_eq CancelFactors.cancel_factors_eq
 
-open Tactic Expr
 
-/-! ### Computing cancelation factors -/
-
-
-open Tree
-
--- failed to format: unknown constant 'term.pseudo.antiquot'
-/--
-      `find_cancel_factor e` produces a natural number `n`, such that multiplying `e` by `n` will
-      be able to cancel all the numeric denominators in `e`. The returned `tree` describes how to
-      distribute the value `n` over products inside `e`.
-      -/
-    unsafe
-  def
-    find_cancel_factor
-    : expr → ℕ × Tree ℕ
-    |
-        q( $ ( e1 ) + $ ( e2 ) )
-        =>
-        let
-          ( v1 , t1 ) := find_cancel_factor e1
-          let ( v2 , t2 ) := find_cancel_factor e2 let lcm := v1 . lcm v2 ( lcm , node lcm t1 t2 )
-      |
-        q( $ ( e1 ) - $ ( e2 ) )
-        =>
-        let
-          ( v1 , t1 ) := find_cancel_factor e1
-          let ( v2 , t2 ) := find_cancel_factor e2 let lcm := v1 . lcm v2 ( lcm , node lcm t1 t2 )
-      |
-        q( $ ( e1 ) * $ ( e2 ) )
-        =>
-        let
-          ( v1 , t1 ) := find_cancel_factor e1
-          let ( v2 , t2 ) := find_cancel_factor e2 let pd := v1 * v2 ( pd , node pd t1 t2 )
-      |
-        q( $ ( e1 ) / $ ( e2 ) )
-        =>
-        match
-          e2 . to_nonneg_rat
-          with
-          |
-              some q
-              =>
-              let
-                ( v1 , t1 ) := find_cancel_factor e1
-                let
-                  n := v1 . lcm q . num . natAbs
-                  ( n , node n t1 ( node q . num . natAbs Tree.nil Tree.nil ) )
-            | none => ( 1 , node 1 Tree.nil Tree.nil )
-      | q( - $ ( e ) ) => find_cancel_factor e
-      | _ => ( 1 , node 1 Tree.nil Tree.nil )
-#align cancel_factors.find_cancel_factor cancel_factors.find_cancel_factor
-
-/- ./././Mathport/Syntax/Translate/Expr.lean:330:4: warning: unsupported (TODO): `[tacs] -/
-/- ./././Mathport/Syntax/Translate/Expr.lean:330:4: warning: unsupported (TODO): `[tacs] -/
-/- ./././Mathport/Syntax/Translate/Expr.lean:330:4: warning: unsupported (TODO): `[tacs] -/
--- failed to format: unknown constant 'term.pseudo.antiquot'
-/--
-      `mk_prod_prf n tr e` produces a proof of `n*e = e'`, where numeric denominators have been
-      canceled in `e'`, distributing `n` proportionally according to `tr`.
-      -/
-    unsafe
-  def
-    mk_prod_prf
-    : ℕ → Tree ℕ → expr → tactic expr
-    |
-        v , node _ lhs rhs , q( $ ( e1 ) + $ ( e2 ) )
-        =>
-        do
-          let v1 ← mk_prod_prf v lhs e1
-            let v2 ← mk_prod_prf v rhs e2
-            mk_app ` ` add_subst [ v1 , v2 ]
-      |
-        v , node _ lhs rhs , q( $ ( e1 ) - $ ( e2 ) )
-        =>
-        do
-          let v1 ← mk_prod_prf v lhs e1
-            let v2 ← mk_prod_prf v rhs e2
-            mk_app ` ` sub_subst [ v1 , v2 ]
-      |
-        v , node n ( lhs @ ( node ln _ _ ) ) rhs , q( $ ( e1 ) * $ ( e2 ) )
-        =>
-        do
-          let tp ← infer_type e1
-            let v1 ← mk_prod_prf ln lhs e1
-            let v2 ← mk_prod_prf ( v / ln ) rhs e2
-            let ln' ← tp . ofNat ln
-            let vln' ← tp . ofNat ( v / ln )
-            let v' ← tp . ofNat v
-            let ntp ← to_expr ` `( $ ( ln' ) * $ ( vln' ) = $ ( v' ) )
-            let ( _ , npf ) ← solve_aux ntp sorry
-            mk_app ` ` mul_subst [ v1 , v2 , npf ]
-      |
-        v , node n lhs rhs @ ( node rn _ _ ) , q( $ ( e1 ) / $ ( e2 ) )
-        =>
-        do
-          let tp ← infer_type e1
-            let v1 ← mk_prod_prf ( v / rn ) lhs e1
-            let rn' ← tp . ofNat rn
-            let vrn' ← tp . ofNat ( v / rn )
-            let n' ← tp . ofNat n
-            let v' ← tp . ofNat v
-            let ntp ← to_expr ` `( $ ( rn' ) / $ ( e2 ) = 1 )
-            let ( _ , npf ) ← solve_aux ntp sorry
-            let ntp2 ← to_expr ` `( $ ( vrn' ) * $ ( n' ) = $ ( v' ) )
-            let ( _ , npf2 ) ← solve_aux ntp2 sorry
-            mk_app ` ` div_subst [ v1 , npf , npf2 ]
-      | v , t , q( - $ ( e ) ) => do let v' ← mk_prod_prf v t e mk_app ` ` neg_subst [ v' ]
-      |
-        v , _ , e
-        =>
-        do
-          let tp ← infer_type e
-            let v' ← tp . ofNat v
-            let e' ← to_expr ` `( $ ( v' ) * $ ( e ) )
-            mk_app `eq.refl [ e' ]
-#align cancel_factors.mk_prod_prf cancel_factors.mk_prod_prf
+open Lean Parser Tactic
 
 /--
-Given `e`, a term with rational division, produces a natural number `n` and a proof of `n*e = e'`,
-where `e'` has no division. Assumes "well-behaved" division.
--/
-unsafe def derive (e : expr) : tactic (ℕ × expr) :=
-  let (n, t) := find_cancel_factor e
-  Prod.mk n <$> mk_prod_prf n t e <|>
-    throwError
-      "cancel_factors.derive failed to normalize {← e}. Are you sure this is well-behaved division?"
-#align cancel_factors.derive cancel_factors.derive
-
-/- ./././Mathport/Syntax/Translate/Expr.lean:330:4: warning: unsupported (TODO): `[tacs] -/
--- failed to format: unknown constant 'term.pseudo.antiquot'
-/--
-      Given `e`, a term with rational divison, produces a natural number `n` and a proof of `e = e' / n`,
-      where `e'` has no divison. Assumes "well-behaved" division.
-      -/
-    unsafe
-  def
-    derive_div
-    ( e : expr ) : tactic ( ℕ × expr )
-    :=
-      do
-        let ( n , p ) ← derive e
-          let tp ← infer_type e
-          let n' ← tp . ofNat n
-          let tgt ← to_expr ` `( $ ( n' ) ≠ 0 )
-          let ( _ , pn ) ← solve_aux tgt sorry
-          Prod.mk n
-            <$>
-            mk_mapp ` ` cancel_factors_eq_div [ none , none , n' , none , none , p , pn ]
-#align cancel_factors.derive_div cancel_factors.derive_div
-
--- failed to format: unknown constant 'term.pseudo.antiquot'
-/--
-      `find_comp_lemma e` arranges `e` in the form `lhs R rhs`, where `R ∈ {<, ≤, =}`, and returns
-      `lhs`, `rhs`, and the `cancel_factors` lemma corresponding to `R`.
-      -/
-    unsafe
-  def
-    find_comp_lemma
-    : expr → Option ( expr × expr × Name )
-    | q( $ ( a ) < $ ( b ) ) => ( a , b , ` ` cancel_factors_lt )
-      | q( $ ( a ) ≤ $ ( b ) ) => ( a , b , ` ` cancel_factors_le )
-      | q( $ ( a ) = $ ( b ) ) => ( a , b , ` ` cancel_factors_eq )
-      | q( $ ( a ) ≥ $ ( b ) ) => ( b , a , ` ` cancel_factors_le )
-      | q( $ ( a ) > $ ( b ) ) => ( b , a , ` ` cancel_factors_lt )
-      | _ => none
-#align cancel_factors.find_comp_lemma cancel_factors.find_comp_lemma
-
-/- ./././Mathport/Syntax/Translate/Expr.lean:330:4: warning: unsupported (TODO): `[tacs] -/
-/- ./././Mathport/Syntax/Translate/Expr.lean:330:4: warning: unsupported (TODO): `[tacs] -/
-/- ./././Mathport/Syntax/Translate/Expr.lean:330:4: warning: unsupported (TODO): `[tacs] -/
-/-- `cancel_denominators_in_type h` assumes that `h` is of the form `lhs R rhs`,
-where `R ∈ {<, ≤, =, ≥, >}`.
-It produces an expression `h'` of the form `lhs' R rhs'` and a proof that `h = h'`.
-Numeric denominators have been canceled in `lhs'` and `rhs'`.
--/
-unsafe def cancel_denominators_in_type (h : expr) : tactic (expr × expr) := do
-  let some (lhs, rhs, lem) ← return <| find_comp_lemma h |
-    fail "cannot kill factors"
-  let (al, lhs_p) ← derive lhs
-  let (ar, rhs_p) ← derive rhs
-  let gcd := al.gcd ar
-  let tp ← infer_type lhs
-  let al ← tp.ofNat al
-  let ar ← tp.ofNat ar
-  let gcd ← tp.ofNat gcd
-  let al_pos ← to_expr ``(0 < $(al))
-  let ar_pos ← to_expr ``(0 < $(ar))
-  let gcd_pos ← to_expr ``(0 < $(gcd))
-  let (_, al_pos) ← solve_aux al_pos sorry
-  let (_, ar_pos) ← solve_aux ar_pos sorry
-  let (_, gcd_pos) ← solve_aux gcd_pos sorry
-  let pf ← mk_app lem [lhs_p, rhs_p, al_pos, ar_pos, gcd_pos]
-  let pf_tp ← infer_type pf
-  return ((find_comp_lemma pf_tp).elim default (Prod.fst ∘ Prod.snd), pf)
-#align cancel_factors.cancel_denominators_in_type cancel_factors.cancel_denominators_in_type
-
-end CancelFactors
-
-/-! ### Interactive version -/
-
-
-/- ./././Mathport/Syntax/Translate/Tactic/Mathlib/Core.lean:38:34: unsupported: setup_tactic_parser -/
-open Tactic Expr CancelFactors
-
-/-- `cancel_denoms` attempts to remove numerals from the denominators of fractions.
+`cancel_denoms` attempts to remove numerals from the denominators of fractions.
 It works on propositions that are field-valued inequalities.
-
 ```lean
-variables {α : Type} [linear_ordered_field α] (a b c : α)
-
-example (h : a / 5 + b / 4 < c) : 4*a + 5*b < 20*c :=
-begin
-  cancel_denoms at h,
+variable [LinearOrderedField α] (a b c : α)
+example (h : a / 5 + b / 4 < c) : 4*a + 5*b < 20*c := by
+  cancel_denoms at h
   exact h
-end
-
-example (h : a > 0) : a / 5 > 0 :=
-begin
-  cancel_denoms,
+example (h : a > 0) : a / 5 > 0 := by
+  cancel_denoms
   exact h
-end
 ```
 -/
-unsafe def tactic.interactive.cancel_denoms (l : parse location) : tactic Unit := do
-  let locs ← l.get_locals
-  tactic.replace_at cancel_denominators_in_type locs l >>= guardb <|>
-      fail "failed to cancel any denominators"
-  tactic.interactive.norm_num [simp_arg_type.symm_expr ``(mul_assoc)] l
-#align tactic.interactive.cancel_denoms tactic.interactive.cancel_denoms
-
-add_tactic_doc
-  { Name := "cancel_denoms"
-    category := DocCategory.tactic
-    declNames := [`tactic.interactive.cancel_denoms]
-    tags := ["simplification"] }
-
+syntax (name := cancelDenoms) "cancel_denoms" (ppSpace location)? : tactic

--- a/Mathlib/Tactic/CancelDenoms.lean
+++ b/Mathlib/Tactic/CancelDenoms.lean
@@ -141,9 +141,9 @@ partial def mkProdPrf (α : Q(Type u)) (_sα : Q(Field $α)) (v : ℕ) (t : Tree
   | .node _ lhs@(.node ln _ _) rhs, ~q($e1 * $e2) => do
     let v1 ← mkProdPrf α _sα ln lhs e1
     let v2 ← mkProdPrf α _sα (v / ln) rhs e2
-    have ln' := (← mkOfNat α _sα <| mkRawNatLit ln).1
-    have vln' := (← mkOfNat α _sα <| mkRawNatLit (v/ln)).1
-    have v' := (← mkOfNat α _sα <| mkRawNatLit v).1
+    have ln' := (← mkOfNat α amwo <| mkRawNatLit ln).1
+    have vln' := (← mkOfNat α amwo <| mkRawNatLit (v/ln)).1
+    have v' := (← mkOfNat α amwo <| mkRawNatLit v).1
     let ntp : Q(Prop) := q($ln' * $vln' = $v')
     let npf ← synthesizeUsing ntp norm_num_done
     mkAppM `CancelFactors.mul_subst #[v1, v2, npf]
@@ -266,18 +266,3 @@ elab "cancel_denoms" loc?:(location)? : tactic => do
     Lean.Elab.Tactic.evalTactic (←`(tactic| norm_num [←mul_assoc] $loc))
   else
     Lean.Elab.Tactic.evalTactic (←`(tactic| norm_num [←mul_assoc]))
-
-variable [lof : LinearOrderedField α] (a b c : α)
-
-set_option warningAsError false
-
-example : (0 : α) < (1 : α) := by
-  norm_num
-
-example (h : a / 5 + b / 4 < c) : 4*a + 5*b < 20*c := by
-  cancel_denoms at h
-  exact h
-
-example (h : a > 0) : a / 5 > 0 := by
-  cancel_denoms
-  exact h

--- a/Mathlib/Tactic/CancelDenoms.lean
+++ b/Mathlib/Tactic/CancelDenoms.lean
@@ -246,15 +246,13 @@ open Elab Tactic
 def cancelDenominatorsAt (fvar: FVarId) : TacticM Unit := do
   let t ← instantiateMVars (← fvar.getDecl).type
   let (new, eqPrf) ← CancelFactors.cancelDenominatorsInType t
-  let goal ← getMainGoal
-  let res ← goal.replaceLocalDecl fvar new eqPrf
-  replaceMainGoal [res.mvarId]
+  liftMetaTactic' fun g => do
+    let res ← g.replaceLocalDecl fvar new eqPrf
+    return res.mvarId
 
-def cancelDenominatorsTarget : TacticM Unit := withMainContext do
-  let goal ← getMainTarget
-  let (new, eqPrf) ← CancelFactors.cancelDenominatorsInType goal
-  let goal' ← (← getMainGoal).replaceTargetEq new eqPrf
-  replaceMainGoal [goal']
+def cancelDenominatorsTarget : TacticM Unit := do
+  let (new, eqPrf) ← CancelFactors.cancelDenominatorsInType (← getMainTarget)
+  liftMetaTactic' fun g => g.replaceTargetEq new eqPrf
 
 def cancelDenominators (loc : Location) : TacticM Unit := do
   withLocation loc cancelDenominatorsAt cancelDenominatorsTarget

--- a/Mathlib/Tactic/CancelDenoms.lean
+++ b/Mathlib/Tactic/CancelDenoms.lean
@@ -176,17 +176,6 @@ catch _ => throwError
   "cancel_factors.derive failed to normalize {e}. Are you sure this is well-behaved division?"
 
 /--
-Given `e`, a term with rational divison, produces a natural number `n` and a proof of `e = e' / n`,
-where `e'` has no divison. Assumes "well-behaved" division.
--/
-def deriveDiv (e : Expr) : MetaM (ℕ × Expr) :=
-do let (n, p) ← derive e
-   let tp ← inferType e
-   let n' ← tp.of_nat n, tgt ← to_Expr ``(%%n' ≠ 0)
-   let (_, pn) ← solve_aux tgt `[norm_num, done]
-   prod.mk n <$> mk_mapp ``cancel_factors_eq_div [none, none, n', none, none, p, pn]
-
-/--
 `findCompLemma e` arranges `e` in the form `lhs R rhs`, where `R ∈ {<, ≤, =}`, and returns
 `lhs`, `rhs`, and the `cancel_factors` lemma corresponding to `R`.
 -/

--- a/Mathlib/Tactic/CancelDenoms.lean
+++ b/Mathlib/Tactic/CancelDenoms.lean
@@ -8,10 +8,10 @@ Authors: Robert Y. Lewis
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
-import Mathbin.Data.Rat.MetaDefs
-import Mathbin.Tactic.NormNum
-import Mathbin.Data.Tree
-import Mathbin.Meta.Expr
+import Mathlib.Data.Rat.MetaDefs
+import Mathlib.Tactic.NormNum
+import Mathlib.Data.Tree
+import Mathlib.Meta.Expr
 
 /-!
 # A tactic for canceling numeric denominators
@@ -65,8 +65,7 @@ theorem neg_subst {α} [Ring α] {n e t : α} (h1 : n * e = t) : n * -e = -t := 
 
 theorem cancel_factors_lt {α} [LinearOrderedField α] {a b ad bd a' b' gcd : α} (ha : ad * a = a')
     (hb : bd * b = b') (had : 0 < ad) (hbd : 0 < bd) (hgcd : 0 < gcd) :
-    (a < b) = (1 / gcd * (bd * a') < 1 / gcd * (ad * b')) :=
-  by
+    (a < b) = (1 / gcd * (bd * a') < 1 / gcd * (ad * b')) := by
   rw [mul_lt_mul_left, ← ha, ← hb, ← mul_assoc, ← mul_assoc, mul_comm bd, mul_lt_mul_left]
   exact mul_pos had hbd
   exact one_div_pos.2 hgcd
@@ -74,8 +73,7 @@ theorem cancel_factors_lt {α} [LinearOrderedField α] {a b ad bd a' b' gcd : α
 
 theorem cancel_factors_le {α} [LinearOrderedField α] {a b ad bd a' b' gcd : α} (ha : ad * a = a')
     (hb : bd * b = b') (had : 0 < ad) (hbd : 0 < bd) (hgcd : 0 < gcd) :
-    (a ≤ b) = (1 / gcd * (bd * a') ≤ 1 / gcd * (ad * b')) :=
-  by
+    (a ≤ b) = (1 / gcd * (bd * a') ≤ 1 / gcd * (ad * b')) := by
   rw [mul_le_mul_left, ← ha, ← hb, ← mul_assoc, ← mul_assoc, mul_comm bd, mul_le_mul_left]
   exact mul_pos had hbd
   exact one_div_pos.2 hgcd
@@ -83,8 +81,7 @@ theorem cancel_factors_le {α} [LinearOrderedField α] {a b ad bd a' b' gcd : α
 
 theorem cancel_factors_eq {α} [LinearOrderedField α] {a b ad bd a' b' gcd : α} (ha : ad * a = a')
     (hb : bd * b = b') (had : 0 < ad) (hbd : 0 < bd) (hgcd : 0 < gcd) :
-    (a = b) = (1 / gcd * (bd * a') = 1 / gcd * (ad * b')) :=
-  by
+    (a = b) = (1 / gcd * (bd * a') = 1 / gcd * (ad * b')) := by
   rw [← ha, ← hb, ← mul_assoc bd, ← mul_assoc ad, mul_comm bd]
   ext; constructor
   · rintro rfl

--- a/Mathlib/Tactic/CancelDenoms.lean
+++ b/Mathlib/Tactic/CancelDenoms.lean
@@ -262,7 +262,4 @@ def cancelDenominators (loc : Location) : TacticM Unit := do
 
 elab "cancel_denoms" loc?:(location)? : tactic => do
   cancelDenominators (expandOptLocation (Lean.mkOptionalNode loc?))
-  if let some loc := loc? then
-    Lean.Elab.Tactic.evalTactic (←`(tactic| norm_num [←mul_assoc] $loc))
-  else
-    Lean.Elab.Tactic.evalTactic (←`(tactic| norm_num [←mul_assoc]))
+  Lean.Elab.Tactic.evalTactic (←`(tactic| norm_num [←mul_assoc] $[$loc?]?))

--- a/Mathlib/Tactic/CancelDenoms.lean
+++ b/Mathlib/Tactic/CancelDenoms.lean
@@ -168,7 +168,7 @@ partial def mkProdPrf (α : Q(Type u)) (sα : Q(Field $α)) (v : ℕ) (t : Tree 
 def inferTypeQ' (e : Expr) : MetaM ((u : Level) × (α : Q(Type $u)) × Q($α)) := do
   let α ← inferType e
   let .sort u ← whnf (← inferType α) | throwError "not a type{indentExpr α}"
-  let some u' := u.dec | throwError "is a Prop, not a Type"
+  let some u' := u.dec | throwError "is a Prop, not a Type{indentExpr e}"
   pure ⟨u', α, e⟩
 
 /--

--- a/Mathlib/Tactic/CancelDenoms.lean
+++ b/Mathlib/Tactic/CancelDenoms.lean
@@ -31,20 +31,19 @@ namespace CancelFactors
 
 /-! ### Lemmas used in the procedure -/
 
-
-theorem mul_subst {α} [CommRing α] {n1 n2 k e1 e2 t1 t2 : α} (h1 : n1 * e1 = t1) (h2 : n2 * e2 = t2)
-    (h3 : n1 * n2 = k) : k * (e1 * e2) = t1 * t2 := by
-  rw [← h3, mul_comm n1, mul_assoc n2, ← mul_assoc n1, h1, ← mul_assoc n2, mul_comm n2, mul_assoc,
-    h2]
+theorem mul_subst {α} [CommRing α] {n1 n2 k e1 e2 t1 t2 : α}
+    (h1 : n1 * e1 = t1) (h2 : n2 * e2 = t2) (h3 : n1 * n2 = k) : k * (e1 * e2) = t1 * t2 := by
+  rw [← h3, mul_comm n1, mul_assoc n2, ← mul_assoc n1, h1,
+      ← mul_assoc n2, mul_comm n2, mul_assoc, h2]
 #align cancel_factors.mul_subst CancelFactors.mul_subst
 
-theorem div_subst {α} [Field α] {n1 n2 k e1 e2 t1 : α} (h1 : n1 * e1 = t1) (h2 : n2 / e2 = 1)
-    (h3 : n1 * n2 = k) : k * (e1 / e2) = t1 := by
+theorem div_subst {α} [Field α] {n1 n2 k e1 e2 t1 : α}
+    (h1 : n1 * e1 = t1) (h2 : n2 / e2 = 1) (h3 : n1 * n2 = k) : k * (e1 / e2) = t1 := by
   rw [← h3, mul_assoc, mul_div_left_comm, h2, ← mul_assoc, h1, mul_comm, one_mul]
 #align cancel_factors.div_subst CancelFactors.div_subst
 
-theorem cancel_factors_eq_div {α} [Field α] {n e e' : α} (h : n * e = e') (h2 : n ≠ 0) :
-    e = e' / n :=
+theorem cancel_factors_eq_div {α} [Field α] {n e e' : α}
+    (h : n * e = e') (h2 : n ≠ 0) : e = e' / n :=
   eq_div_of_mul_eq h2 <| by rwa [mul_comm] at h
 #align cancel_factors.cancel_factors_eq_div CancelFactors.cancel_factors_eq_div
 
@@ -59,20 +58,20 @@ theorem sub_subst {α} [Ring α] {n e1 e2 t1 t2 : α} (h1 : n * e1 = t1) (h2 : n
 theorem neg_subst {α} [Ring α] {n e t : α} (h1 : n * e = t) : n * -e = -t := by simp [*]
 #align cancel_factors.neg_subst CancelFactors.neg_subst
 
-theorem cancel_factors_lt {α} [LinearOrderedField α] {a b ad bd a' b' gcd : α} (ha : ad * a = a')
-    (hb : bd * b = b') (had : 0 < ad) (hbd : 0 < bd) (hgcd : 0 < gcd) :
+theorem cancel_factors_lt {α} [LinearOrderedField α] {a b ad bd a' b' gcd : α}
+    (ha : ad * a = a') (hb : bd * b = b') (had : 0 < ad) (hbd : 0 < bd) (hgcd : 0 < gcd) :
     (a < b) = (1 / gcd * (bd * a') < 1 / gcd * (ad * b')) := by
   rw [mul_lt_mul_left, ← ha, ← hb, ← mul_assoc, ← mul_assoc, mul_comm bd, mul_lt_mul_left]
-  exact mul_pos had hbd
-  exact one_div_pos.2 hgcd
+  · exact mul_pos had hbd
+  · exact one_div_pos.2 hgcd
 #align cancel_factors.cancel_factors_lt CancelFactors.cancel_factors_lt
 
-theorem cancel_factors_le {α} [LinearOrderedField α] {a b ad bd a' b' gcd : α} (ha : ad * a = a')
-    (hb : bd * b = b') (had : 0 < ad) (hbd : 0 < bd) (hgcd : 0 < gcd) :
+theorem cancel_factors_le {α} [LinearOrderedField α] {a b ad bd a' b' gcd : α}
+    (ha : ad * a = a') (hb : bd * b = b') (had : 0 < ad) (hbd : 0 < bd) (hgcd : 0 < gcd) :
     (a ≤ b) = (1 / gcd * (bd * a') ≤ 1 / gcd * (ad * b')) := by
   rw [mul_le_mul_left, ← ha, ← hb, ← mul_assoc, ← mul_assoc, mul_comm bd, mul_le_mul_left]
-  exact mul_pos had hbd
-  exact one_div_pos.2 hgcd
+  · exact mul_pos had hbd
+  · exact one_div_pos.2 hgcd
 #align cancel_factors.cancel_factors_le CancelFactors.cancel_factors_le
 
 theorem cancel_factors_eq {α} [LinearOrderedField α] {a b ad bd a' b' gcd : α} (ha : ad * a = a')
@@ -87,7 +86,7 @@ theorem cancel_factors_eq {α} [LinearOrderedField α] {a b ad bd a' b' gcd : α
     refine' mul_left_cancel₀ (mul_ne_zero _ _) h
     apply mul_ne_zero
     apply div_ne_zero
-    all_goals apply ne_of_gt ; first |assumption|exact zero_lt_one
+    all_goals apply ne_of_gt ; first | assumption | exact zero_lt_one
 #align cancel_factors.cancel_factors_eq CancelFactors.cancel_factors_eq
 
 /-! ### Computing cancelation factors -/

--- a/Mathlib/Tactic/CancelDenoms.lean
+++ b/Mathlib/Tactic/CancelDenoms.lean
@@ -1,0 +1,337 @@
+/-
+Copyright (c) 2020 Robert Y. Lewis. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Y. Lewis
+
+! This file was ported from Lean 3 source module tactic.cancel_denoms
+! leanprover-community/mathlib commit eaa771fc4f5f356afeacac4ab92e0cbf10b0b1df
+! Please do not edit these lines, except to modify the commit id
+! if you have ported upstream changes.
+-/
+import Mathbin.Data.Rat.MetaDefs
+import Mathbin.Tactic.NormNum
+import Mathbin.Data.Tree
+import Mathbin.Meta.Expr
+
+/-!
+# A tactic for canceling numeric denominators
+
+This file defines tactics that cancel numeric denominators from field expressions.
+
+As an example, we want to transform a comparison `5*(a/3 + b/4) < c/3` into the equivalent
+`5*(4*a + 3*b) < 4*c`.
+
+## Implementation notes
+
+The tooling here was originally written for `linarith`, not intended as an interactive tactic.
+The interactive version has been split off because it is sometimes convenient to use on its own.
+There are likely some rough edges to it.
+
+Improving this tactic would be a good project for someone interested in learning tactic programming.
+-/
+
+
+namespace CancelFactors
+
+/-! ### Lemmas used in the procedure -/
+
+
+theorem mul_subst {α} [CommRing α] {n1 n2 k e1 e2 t1 t2 : α} (h1 : n1 * e1 = t1) (h2 : n2 * e2 = t2)
+    (h3 : n1 * n2 = k) : k * (e1 * e2) = t1 * t2 := by
+  rw [← h3, mul_comm n1, mul_assoc n2, ← mul_assoc n1, h1, ← mul_assoc n2, mul_comm n2, mul_assoc,
+    h2]
+#align cancel_factors.mul_subst CancelFactors.mul_subst
+
+theorem div_subst {α} [Field α] {n1 n2 k e1 e2 t1 : α} (h1 : n1 * e1 = t1) (h2 : n2 / e2 = 1)
+    (h3 : n1 * n2 = k) : k * (e1 / e2) = t1 := by
+  rw [← h3, mul_assoc, mul_div_left_comm, h2, ← mul_assoc, h1, mul_comm, one_mul]
+#align cancel_factors.div_subst CancelFactors.div_subst
+
+theorem cancel_factors_eq_div {α} [Field α] {n e e' : α} (h : n * e = e') (h2 : n ≠ 0) :
+    e = e' / n :=
+  eq_div_of_mul_eq h2 <| by rwa [mul_comm] at h
+#align cancel_factors.cancel_factors_eq_div CancelFactors.cancel_factors_eq_div
+
+theorem add_subst {α} [Ring α] {n e1 e2 t1 t2 : α} (h1 : n * e1 = t1) (h2 : n * e2 = t2) :
+    n * (e1 + e2) = t1 + t2 := by simp [left_distrib, *]
+#align cancel_factors.add_subst CancelFactors.add_subst
+
+theorem sub_subst {α} [Ring α] {n e1 e2 t1 t2 : α} (h1 : n * e1 = t1) (h2 : n * e2 = t2) :
+    n * (e1 - e2) = t1 - t2 := by simp [left_distrib, *, sub_eq_add_neg]
+#align cancel_factors.sub_subst CancelFactors.sub_subst
+
+theorem neg_subst {α} [Ring α] {n e t : α} (h1 : n * e = t) : n * -e = -t := by simp [*]
+#align cancel_factors.neg_subst CancelFactors.neg_subst
+
+theorem cancel_factors_lt {α} [LinearOrderedField α] {a b ad bd a' b' gcd : α} (ha : ad * a = a')
+    (hb : bd * b = b') (had : 0 < ad) (hbd : 0 < bd) (hgcd : 0 < gcd) :
+    (a < b) = (1 / gcd * (bd * a') < 1 / gcd * (ad * b')) :=
+  by
+  rw [mul_lt_mul_left, ← ha, ← hb, ← mul_assoc, ← mul_assoc, mul_comm bd, mul_lt_mul_left]
+  exact mul_pos had hbd
+  exact one_div_pos.2 hgcd
+#align cancel_factors.cancel_factors_lt CancelFactors.cancel_factors_lt
+
+theorem cancel_factors_le {α} [LinearOrderedField α] {a b ad bd a' b' gcd : α} (ha : ad * a = a')
+    (hb : bd * b = b') (had : 0 < ad) (hbd : 0 < bd) (hgcd : 0 < gcd) :
+    (a ≤ b) = (1 / gcd * (bd * a') ≤ 1 / gcd * (ad * b')) :=
+  by
+  rw [mul_le_mul_left, ← ha, ← hb, ← mul_assoc, ← mul_assoc, mul_comm bd, mul_le_mul_left]
+  exact mul_pos had hbd
+  exact one_div_pos.2 hgcd
+#align cancel_factors.cancel_factors_le CancelFactors.cancel_factors_le
+
+theorem cancel_factors_eq {α} [LinearOrderedField α] {a b ad bd a' b' gcd : α} (ha : ad * a = a')
+    (hb : bd * b = b') (had : 0 < ad) (hbd : 0 < bd) (hgcd : 0 < gcd) :
+    (a = b) = (1 / gcd * (bd * a') = 1 / gcd * (ad * b')) :=
+  by
+  rw [← ha, ← hb, ← mul_assoc bd, ← mul_assoc ad, mul_comm bd]
+  ext; constructor
+  · rintro rfl
+    rfl
+  · intro h
+    simp only [← mul_assoc] at h
+    refine' mul_left_cancel₀ (mul_ne_zero _ _) h
+    apply mul_ne_zero
+    apply div_ne_zero
+    all_goals apply ne_of_gt <;> first |assumption|exact zero_lt_one
+#align cancel_factors.cancel_factors_eq CancelFactors.cancel_factors_eq
+
+open Tactic Expr
+
+/-! ### Computing cancelation factors -/
+
+
+open Tree
+
+-- failed to format: unknown constant 'term.pseudo.antiquot'
+/--
+      `find_cancel_factor e` produces a natural number `n`, such that multiplying `e` by `n` will
+      be able to cancel all the numeric denominators in `e`. The returned `tree` describes how to
+      distribute the value `n` over products inside `e`.
+      -/
+    unsafe
+  def
+    find_cancel_factor
+    : expr → ℕ × Tree ℕ
+    |
+        q( $ ( e1 ) + $ ( e2 ) )
+        =>
+        let
+          ( v1 , t1 ) := find_cancel_factor e1
+          let ( v2 , t2 ) := find_cancel_factor e2 let lcm := v1 . lcm v2 ( lcm , node lcm t1 t2 )
+      |
+        q( $ ( e1 ) - $ ( e2 ) )
+        =>
+        let
+          ( v1 , t1 ) := find_cancel_factor e1
+          let ( v2 , t2 ) := find_cancel_factor e2 let lcm := v1 . lcm v2 ( lcm , node lcm t1 t2 )
+      |
+        q( $ ( e1 ) * $ ( e2 ) )
+        =>
+        let
+          ( v1 , t1 ) := find_cancel_factor e1
+          let ( v2 , t2 ) := find_cancel_factor e2 let pd := v1 * v2 ( pd , node pd t1 t2 )
+      |
+        q( $ ( e1 ) / $ ( e2 ) )
+        =>
+        match
+          e2 . to_nonneg_rat
+          with
+          |
+              some q
+              =>
+              let
+                ( v1 , t1 ) := find_cancel_factor e1
+                let
+                  n := v1 . lcm q . num . natAbs
+                  ( n , node n t1 ( node q . num . natAbs Tree.nil Tree.nil ) )
+            | none => ( 1 , node 1 Tree.nil Tree.nil )
+      | q( - $ ( e ) ) => find_cancel_factor e
+      | _ => ( 1 , node 1 Tree.nil Tree.nil )
+#align cancel_factors.find_cancel_factor cancel_factors.find_cancel_factor
+
+/- ./././Mathport/Syntax/Translate/Expr.lean:330:4: warning: unsupported (TODO): `[tacs] -/
+/- ./././Mathport/Syntax/Translate/Expr.lean:330:4: warning: unsupported (TODO): `[tacs] -/
+/- ./././Mathport/Syntax/Translate/Expr.lean:330:4: warning: unsupported (TODO): `[tacs] -/
+-- failed to format: unknown constant 'term.pseudo.antiquot'
+/--
+      `mk_prod_prf n tr e` produces a proof of `n*e = e'`, where numeric denominators have been
+      canceled in `e'`, distributing `n` proportionally according to `tr`.
+      -/
+    unsafe
+  def
+    mk_prod_prf
+    : ℕ → Tree ℕ → expr → tactic expr
+    |
+        v , node _ lhs rhs , q( $ ( e1 ) + $ ( e2 ) )
+        =>
+        do
+          let v1 ← mk_prod_prf v lhs e1
+            let v2 ← mk_prod_prf v rhs e2
+            mk_app ` ` add_subst [ v1 , v2 ]
+      |
+        v , node _ lhs rhs , q( $ ( e1 ) - $ ( e2 ) )
+        =>
+        do
+          let v1 ← mk_prod_prf v lhs e1
+            let v2 ← mk_prod_prf v rhs e2
+            mk_app ` ` sub_subst [ v1 , v2 ]
+      |
+        v , node n ( lhs @ ( node ln _ _ ) ) rhs , q( $ ( e1 ) * $ ( e2 ) )
+        =>
+        do
+          let tp ← infer_type e1
+            let v1 ← mk_prod_prf ln lhs e1
+            let v2 ← mk_prod_prf ( v / ln ) rhs e2
+            let ln' ← tp . ofNat ln
+            let vln' ← tp . ofNat ( v / ln )
+            let v' ← tp . ofNat v
+            let ntp ← to_expr ` `( $ ( ln' ) * $ ( vln' ) = $ ( v' ) )
+            let ( _ , npf ) ← solve_aux ntp sorry
+            mk_app ` ` mul_subst [ v1 , v2 , npf ]
+      |
+        v , node n lhs rhs @ ( node rn _ _ ) , q( $ ( e1 ) / $ ( e2 ) )
+        =>
+        do
+          let tp ← infer_type e1
+            let v1 ← mk_prod_prf ( v / rn ) lhs e1
+            let rn' ← tp . ofNat rn
+            let vrn' ← tp . ofNat ( v / rn )
+            let n' ← tp . ofNat n
+            let v' ← tp . ofNat v
+            let ntp ← to_expr ` `( $ ( rn' ) / $ ( e2 ) = 1 )
+            let ( _ , npf ) ← solve_aux ntp sorry
+            let ntp2 ← to_expr ` `( $ ( vrn' ) * $ ( n' ) = $ ( v' ) )
+            let ( _ , npf2 ) ← solve_aux ntp2 sorry
+            mk_app ` ` div_subst [ v1 , npf , npf2 ]
+      | v , t , q( - $ ( e ) ) => do let v' ← mk_prod_prf v t e mk_app ` ` neg_subst [ v' ]
+      |
+        v , _ , e
+        =>
+        do
+          let tp ← infer_type e
+            let v' ← tp . ofNat v
+            let e' ← to_expr ` `( $ ( v' ) * $ ( e ) )
+            mk_app `eq.refl [ e' ]
+#align cancel_factors.mk_prod_prf cancel_factors.mk_prod_prf
+
+/--
+Given `e`, a term with rational division, produces a natural number `n` and a proof of `n*e = e'`,
+where `e'` has no division. Assumes "well-behaved" division.
+-/
+unsafe def derive (e : expr) : tactic (ℕ × expr) :=
+  let (n, t) := find_cancel_factor e
+  Prod.mk n <$> mk_prod_prf n t e <|>
+    throwError
+      "cancel_factors.derive failed to normalize {← e}. Are you sure this is well-behaved division?"
+#align cancel_factors.derive cancel_factors.derive
+
+/- ./././Mathport/Syntax/Translate/Expr.lean:330:4: warning: unsupported (TODO): `[tacs] -/
+-- failed to format: unknown constant 'term.pseudo.antiquot'
+/--
+      Given `e`, a term with rational divison, produces a natural number `n` and a proof of `e = e' / n`,
+      where `e'` has no divison. Assumes "well-behaved" division.
+      -/
+    unsafe
+  def
+    derive_div
+    ( e : expr ) : tactic ( ℕ × expr )
+    :=
+      do
+        let ( n , p ) ← derive e
+          let tp ← infer_type e
+          let n' ← tp . ofNat n
+          let tgt ← to_expr ` `( $ ( n' ) ≠ 0 )
+          let ( _ , pn ) ← solve_aux tgt sorry
+          Prod.mk n
+            <$>
+            mk_mapp ` ` cancel_factors_eq_div [ none , none , n' , none , none , p , pn ]
+#align cancel_factors.derive_div cancel_factors.derive_div
+
+-- failed to format: unknown constant 'term.pseudo.antiquot'
+/--
+      `find_comp_lemma e` arranges `e` in the form `lhs R rhs`, where `R ∈ {<, ≤, =}`, and returns
+      `lhs`, `rhs`, and the `cancel_factors` lemma corresponding to `R`.
+      -/
+    unsafe
+  def
+    find_comp_lemma
+    : expr → Option ( expr × expr × Name )
+    | q( $ ( a ) < $ ( b ) ) => ( a , b , ` ` cancel_factors_lt )
+      | q( $ ( a ) ≤ $ ( b ) ) => ( a , b , ` ` cancel_factors_le )
+      | q( $ ( a ) = $ ( b ) ) => ( a , b , ` ` cancel_factors_eq )
+      | q( $ ( a ) ≥ $ ( b ) ) => ( b , a , ` ` cancel_factors_le )
+      | q( $ ( a ) > $ ( b ) ) => ( b , a , ` ` cancel_factors_lt )
+      | _ => none
+#align cancel_factors.find_comp_lemma cancel_factors.find_comp_lemma
+
+/- ./././Mathport/Syntax/Translate/Expr.lean:330:4: warning: unsupported (TODO): `[tacs] -/
+/- ./././Mathport/Syntax/Translate/Expr.lean:330:4: warning: unsupported (TODO): `[tacs] -/
+/- ./././Mathport/Syntax/Translate/Expr.lean:330:4: warning: unsupported (TODO): `[tacs] -/
+/-- `cancel_denominators_in_type h` assumes that `h` is of the form `lhs R rhs`,
+where `R ∈ {<, ≤, =, ≥, >}`.
+It produces an expression `h'` of the form `lhs' R rhs'` and a proof that `h = h'`.
+Numeric denominators have been canceled in `lhs'` and `rhs'`.
+-/
+unsafe def cancel_denominators_in_type (h : expr) : tactic (expr × expr) := do
+  let some (lhs, rhs, lem) ← return <| find_comp_lemma h |
+    fail "cannot kill factors"
+  let (al, lhs_p) ← derive lhs
+  let (ar, rhs_p) ← derive rhs
+  let gcd := al.gcd ar
+  let tp ← infer_type lhs
+  let al ← tp.ofNat al
+  let ar ← tp.ofNat ar
+  let gcd ← tp.ofNat gcd
+  let al_pos ← to_expr ``(0 < $(al))
+  let ar_pos ← to_expr ``(0 < $(ar))
+  let gcd_pos ← to_expr ``(0 < $(gcd))
+  let (_, al_pos) ← solve_aux al_pos sorry
+  let (_, ar_pos) ← solve_aux ar_pos sorry
+  let (_, gcd_pos) ← solve_aux gcd_pos sorry
+  let pf ← mk_app lem [lhs_p, rhs_p, al_pos, ar_pos, gcd_pos]
+  let pf_tp ← infer_type pf
+  return ((find_comp_lemma pf_tp).elim default (Prod.fst ∘ Prod.snd), pf)
+#align cancel_factors.cancel_denominators_in_type cancel_factors.cancel_denominators_in_type
+
+end CancelFactors
+
+/-! ### Interactive version -/
+
+
+/- ./././Mathport/Syntax/Translate/Tactic/Mathlib/Core.lean:38:34: unsupported: setup_tactic_parser -/
+open Tactic Expr CancelFactors
+
+/-- `cancel_denoms` attempts to remove numerals from the denominators of fractions.
+It works on propositions that are field-valued inequalities.
+
+```lean
+variables {α : Type} [linear_ordered_field α] (a b c : α)
+
+example (h : a / 5 + b / 4 < c) : 4*a + 5*b < 20*c :=
+begin
+  cancel_denoms at h,
+  exact h
+end
+
+example (h : a > 0) : a / 5 > 0 :=
+begin
+  cancel_denoms,
+  exact h
+end
+```
+-/
+unsafe def tactic.interactive.cancel_denoms (l : parse location) : tactic Unit := do
+  let locs ← l.get_locals
+  tactic.replace_at cancel_denominators_in_type locs l >>= guardb <|>
+      fail "failed to cancel any denominators"
+  tactic.interactive.norm_num [simp_arg_type.symm_expr ``(mul_assoc)] l
+#align tactic.interactive.cancel_denoms tactic.interactive.cancel_denoms
+
+add_tactic_doc
+  { Name := "cancel_denoms"
+    category := DocCategory.tactic
+    declNames := [`tactic.interactive.cancel_denoms]
+    tags := ["simplification"] }
+

--- a/Mathlib/Tactic/Linarith/Datatypes.lean
+++ b/Mathlib/Tactic/Linarith/Datatypes.lean
@@ -266,16 +266,16 @@ structure GlobalBranchingPreprocessor : Type where
 /--
 A `Preprocessor` lifts to a `GlobalPreprocessor` by folding it over the input list.
 -/
-def Preprocessor.globalize (pp : Preprocessor) : GlobalPreprocessor :=
-{ name := pp.name,
-  transform := List.foldrM (fun e ret => do return (← pp.transform e) ++ ret) [] }
+def Preprocessor.globalize (pp : Preprocessor) : GlobalPreprocessor where
+  name := pp.name
+  transform := List.foldrM (fun e ret => do return (← pp.transform e) ++ ret) []
 
 /--
 A `GlobalPreprocessor` lifts to a `GlobalBranchingPreprocessor` by producing only one branch.
 -/
-def GlobalPreprocessor.branching (pp : GlobalPreprocessor) : GlobalBranchingPreprocessor :=
-{ name := pp.name,
-  transform := fun g l => do return [⟨g, ← pp.transform l⟩] }
+def GlobalPreprocessor.branching (pp : GlobalPreprocessor) : GlobalBranchingPreprocessor where
+  name := pp.name
+  transform := fun g l => do return [⟨g, ← pp.transform l⟩]
 
 /--
 `process pp l` runs `pp.transform` on `l` and returns the result,

--- a/Mathlib/Tactic/Linarith/Datatypes.lean
+++ b/Mathlib/Tactic/Linarith/Datatypes.lean
@@ -402,7 +402,6 @@ def mkSingleCompZeroOf (c : Nat) (h : Expr) : MetaM (Ineq × Expr) := do
   else do
     let tp ← inferType (← getRelSides (← inferType h)).2
     let cpos ← mkAppM ``GT.gt #[(← tp.ofNat c), (← tp.ofNat 0)]
-    -- TODO There should be a def for this, rather than using `evalTactic`.
-    let ex ← synthesizeUsing cpos (do evalTactic (←`(tactic| norm_num; done)))
+    let ex ← synthesizeUsingTactic' cpos (← `(tactic| norm_num))
     let e' ← mkAppM iq.toConstMulName #[h, ex]
     return (iq, e')

--- a/Mathlib/Tactic/Linarith/Preprocessing.lean
+++ b/Mathlib/Tactic/Linarith/Preprocessing.lean
@@ -6,6 +6,7 @@ Ported by: Scott Morrison
 -/
 import Mathlib.Tactic.Linarith.Datatypes
 import Mathlib.Tactic.Zify
+import Mathlib.Tactic.CancelDenoms
 import Mathlib.Lean.Exception
 import Std.Data.RBMap.Basic
 import Mathlib.Data.HashMap
@@ -276,31 +277,28 @@ def compWithZero : Preprocessor where
 
 end compWithZero
 
--- FIXME the `cancelDenoms : Preprocessor` from mathlib3 will need to wait
--- for a port of the `cancel_denoms` tactic.
 section cancelDenoms
--- /--
--- `normalize_denominators_in_lhs h lhs` assumes that `h` is a proof of `lhs R 0`.
--- It creates a proof of `lhs' R 0`, where all numeric division in `lhs` has been cancelled.
--- -/
--- meta def normalize_denominators_in_lhs (h lhs : expr) : tactic expr :=
--- do (v, lhs') ← cancel_factors.derive lhs,
---    if v = 1 then return h else do
---    (ih, h'') ← mk_single_comp_zero_pf v h,
---    (_, nep, _) ← infer_type h'' >>= rewrite_core lhs',
---    mk_eq_mp nep h''
+/--
+`normalizeDenominatorsLHS h lhs` assumes that `h` is a proof of `lhs R 0`.
+It creates a proof of `lhs' R 0`, where all numeric division in `lhs` has been cancelled.
+-/
+def normalizeDenominatorsLHS (h lhs : Expr) : MetaM Expr := do
+  let (v, lhs') ← CancelFactors.derive lhs
+  if v = 1 then return h else do
+    let (_, h'') ← mkSingleCompZeroOf v h
+    h''.rewriteType lhs'
 
--- /--
--- `cancel_denoms pf` assumes `pf` is a proof of `t R 0`. If `t` contains the division symbol `/`,
--- it tries to scale `t` to cancel out division by numerals.
--- -/
--- meta def cancel_denoms : preprocessor :=
--- { name := "cancel denominators",
---   transform := λ pf,
--- (do some (_, lhs) ← parse_into_comp_and_expr <$> infer_type pf,
---    guardb $ lhs.contains_constant (= `has_div.div),
---    singleton <$> normalize_denominators_in_lhs pf lhs)
--- <|> return [pf] }
+/--
+`cancelDenoms pf` assumes `pf` is a proof of `t R 0`. If `t` contains the division symbol `/`,
+it tries to scale `t` to cancel out division by numerals.
+-/
+def cancelDenoms : Preprocessor where
+  name := "cancel denominators"
+  transform := fun pf => (do
+    let (_, lhs) ← parseCompAndExpr (← inferType pf)
+    guard $ lhs.containsConst (fun n => n = `HDiv.hDiv || n = `Div.div)
+    pure [← normalizeDenominatorsLHS pf lhs])
+  <|> return [pf]
 end cancelDenoms
 
 section nlinarith
@@ -405,7 +403,7 @@ The default list of preprocessors, in the order they should typically run.
 -/
 def defaultPreprocessors : List GlobalBranchingPreprocessor :=
   [filterComparisons, removeNegations, natToInt, strengthenStrictInt,
-    compWithZero/-, cancelDenoms-/]
+    compWithZero, cancelDenoms]
 
 /--
 `preprocess pps l` takes a list `l` of proofs of propositions.

--- a/Mathlib/Tactic/Linarith/Verification.lean
+++ b/Mathlib/Tactic/Linarith/Verification.lean
@@ -160,7 +160,7 @@ def addNegEqProofs : List Expr → MetaM (List Expr)
 def proveEqZeroUsing (tac : TacticM Unit) (e : Expr) : MetaM Expr := do
   let ⟨u, α, e⟩ ← inferTypeQ' e
   let _h : Q(Zero $α) ← synthInstanceQ q(Zero $α)
-  synthesizeUsing q($e = 0) tac
+  synthesizeUsing' q($e = 0) tac
 
 /-! #### The main method -/
 

--- a/Mathlib/Topology/Homotopy/Basic.lean
+++ b/Mathlib/Topology/Homotopy/Basic.lean
@@ -270,9 +270,7 @@ theorem symm_trans {f₀ f₁ f₂ : C(X, Y)} (F : Homotopy f₀ f₁) (G : Homo
   rw [trans_apply, symm_apply, trans_apply]
   simp only [coe_symm_eq, symm_apply]
   split_ifs with h₁ h₂ h₂
-  . have ht : (t : ℝ) = 1 / 2 :=
-      -- porting note: this was proved by linarith in mathlib
-      le_antisymm h₂ (by convert sub_le_comm.mp h₁ using 1; norm_num)
+  . have ht : (t : ℝ) = 1 / 2 := by linarith
     simp only [ht]
     norm_num
   . congr 2
@@ -284,11 +282,7 @@ theorem symm_trans {f₀ f₁ f₂ : C(X, Y)} (F : Homotopy f₀ f₁) (G : Homo
     simp only [coe_symm_eq]
     linarith
   . exfalso
-    -- porting note: this was proved by linarith in mathlib
-    apply h₂
-    rw [sub_le_comm, not_le] at h₁
-    convert le_of_lt h₁ using 1
-    norm_num
+    linarith
 #align continuous_map.homotopy.symm_trans ContinuousMap.Homotopy.symm_trans
 
 /-- Casting a `Homotopy f₀ f₁` to a `Homotopy g₀ g₁` where `f₀ = g₀` and `f₁ = g₁`.

--- a/Mathlib/Topology/MetricSpace/Basic.lean
+++ b/Mathlib/Topology/MetricSpace/Basic.lean
@@ -449,8 +449,7 @@ contains it.
 See also `exists_lt_subset_ball`. -/
 theorem exists_lt_mem_ball_of_mem_ball (h : x ∈ ball y ε) : ∃ ε' < ε, x ∈ ball y ε' := by
   simp only [mem_ball] at h ⊢
-  -- porting note: todo: Mathlib 3 used `by linarith` here
-  exact ⟨(dist x y + ε) / 2, add_div_two_lt_right.2 h, left_lt_add_div_two.2 h⟩
+  exact ⟨(dist x y + ε) / 2, by linarith, by linarith⟩
 #align metric.exists_lt_mem_ball_of_mem_ball Metric.exists_lt_mem_ball_of_mem_ball
 
 theorem ball_eq_ball (ε : ℝ) (x : α) :

--- a/Mathlib/Topology/MetricSpace/CantorScheme.lean
+++ b/Mathlib/Topology/MetricSpace/CantorScheme.lean
@@ -134,19 +134,16 @@ theorem VanishingDiam.dist_lt (hA : VanishingDiam A) (ε : ℝ) (ε_pos : 0 < ε
     ∃ n : ℕ, ∀ (y) (_ : y ∈ A (res x n)) (z) (_ : z ∈ A (res x n)), dist y z < ε := by
   specialize hA x
   rw [ENNReal.tendsto_atTop_zero] at hA
-  cases'
-    hA (ENNReal.ofReal (ε / 2))
-      (by
-        simp only [gt_iff_lt, ENNReal.ofReal_pos]
-        exact half_pos ε_pos) with -- Porting note: was `linarith`
-    n hn
+  cases' hA (ENNReal.ofReal (ε / 2)) (by
+    simp only [gt_iff_lt, ENNReal.ofReal_pos]
+    linarith) with n hn
   use n
   intro y hy z hz
   rw [← ENNReal.ofReal_lt_ofReal_iff ε_pos, ← edist_dist]
   apply lt_of_le_of_lt (EMetric.edist_le_diam_of_mem hy hz)
   apply lt_of_le_of_lt (hn _ (le_refl _))
   rw [ENNReal.ofReal_lt_ofReal_iff ε_pos]
-  exact half_lt_self ε_pos -- Porting note: was `linarith`
+  linarith
 #align cantor_scheme.vanishing_diam.dist_lt CantorScheme.VanishingDiam.dist_lt
 
 /-- A scheme with vanishing diameter along each branch induces a continuous map. -/

--- a/Mathlib/Topology/PathConnected.lean
+++ b/Mathlib/Topology/PathConnected.lean
@@ -354,6 +354,8 @@ theorem trans_symm (γ : Path x y) (γ' : Path y z) : (γ.trans γ').symm = γ'.
       exact h
     -- porting note: was `linarith [unitInterval.nonneg t, unitInterval.le_one t]` but `linarith`
     -- doesn't know about `ℚ` yet. https://github.com/leanprover-community/mathlib4/issues/2714
+    -- porting note: although `linarith` now knows about `ℚ`, it still fails here as it doesn't
+    -- find `LinearOrder X`.
     simp_rw [unitInterval.symm, ht]
     norm_num
   · refine' congr_arg _ (Subtype.ext _)
@@ -362,12 +364,14 @@ theorem trans_symm (γ : Path x y) (γ' : Path y z) : (γ.trans γ').symm = γ'.
   · refine' congr_arg _ (Subtype.ext _)
     norm_num [mul_sub, h]
     ring
-  · exfalso
+  · -- porting note: was `linarith [unitInterval.nonneg t, unitInterval.le_one t]` but `linarith`
+    -- doesn't know about `ℚ` yet. https://github.com/leanprover-community/mathlib4/issues/2714
+    -- porting note: although `linarith` now knows about `ℚ`, it still fails here as it doesn't
+    -- find `LinearOrder X`.
+    exfalso
     rw [sub_le_comm] at h
     norm_num at h h₂
     exact (h.trans h₂).ne rfl
-    -- porting note: was `linarith [unitInterval.nonneg t, unitInterval.le_one t]` but `linarith`
-    -- doesn't know about `ℚ` yet. https://github.com/leanprover-community/mathlib4/issues/2714
 #align path.trans_symm Path.trans_symm
 
 @[simp]
@@ -385,48 +389,31 @@ theorem trans_range {X : Type _} [TopologicalSpace X] {a b c : X} (γ₁ : Path 
   · rintro x ⟨⟨t, ht0, ht1⟩, hxt⟩
     by_cases h : t ≤ 1 / 2
     · left
-      refine' ⟨⟨2 * t, ⟨by positivity, (le_div_iff' <| by norm_num).mp h⟩⟩, _⟩
-      -- porting note: was `use 2 * t, ⟨by linarith, by linarith⟩`
-      -- https://github.com/leanprover-community/mathlib4/issues/2714
+      use ⟨2 * t, ⟨by linarith, by linarith⟩⟩
       rw [← γ₁.extend_extends]
       rwa [coe_mk_mk, Function.comp_apply, if_pos h] at hxt
     · right
-      refine' ⟨⟨2 * t - 1, ⟨_, by norm_num; exact ht1⟩⟩, _⟩
-      -- porting note: was `use 2 * t - 1, ⟨by linarith, by linarith⟩`
-      -- https://github.com/leanprover-community/mathlib4/issues/2714
-      · rw [not_le, div_lt_iff (zero_lt_two : (0 : ℝ) < 2)] at h
-        norm_num
-        exact mul_comm t 2 ▸ h.le
+      use ⟨2 * t - 1, ⟨by linarith, by linarith⟩⟩
       rw [← γ₂.extend_extends]
       rwa [coe_mk_mk, Function.comp_apply, if_neg h] at hxt
   · rintro x (⟨⟨t, ht0, ht1⟩, hxt⟩ | ⟨⟨t, ht0, ht1⟩, hxt⟩)
-    · refine' ⟨⟨t / 2, ⟨by positivity,
-        (div_le_iff <| by norm_num).mpr <| ht1.trans (by norm_num)⟩⟩, _⟩
-      -- porting note: was `use ⟨t / 2, ⟨by linarith, by linarith⟩⟩`
-      -- https://github.com/leanprover-community/mathlib4/issues/2714
+    · use ⟨t / 2, ⟨by linarith, by linarith⟩⟩
       have : t / 2 ≤ 1 / 2 := (div_le_div_right (zero_lt_two : (0 : ℝ) < 2)).mpr ht1
       rw [coe_mk_mk, Function.comp_apply, if_pos this, Subtype.coe_mk]
       ring_nf
       rwa [γ₁.extend_extends]
     · by_cases h : t = 0
-      · refine' ⟨⟨1 / 2, ⟨by positivity, by norm_num⟩⟩, _⟩
-        -- porting note: was `use ⟨1 / 2, ⟨by linarith, by linarith⟩⟩`
-        -- https://github.com/leanprover-community/mathlib4/issues/2714
+      · use ⟨1 / 2, ⟨by linarith, by linarith⟩⟩
         rw [coe_mk_mk, Function.comp_apply, if_pos le_rfl, Subtype.coe_mk,
           mul_one_div_cancel (two_ne_zero' ℝ)]
         rw [γ₁.extend_one]
         rwa [← γ₂.extend_extends, h, γ₂.extend_zero] at hxt
-      · refine' ⟨⟨(t + 1) / 2, ⟨by positivity, _⟩⟩, _⟩
-        -- porting note: was `use ⟨(t + 1) / 2, ⟨by linarith, by linarith⟩⟩`
-        -- https://github.com/leanprover-community/mathlib4/issues/2714
-        · exact (div_le_iff <| by norm_num).mpr <| (add_le_add_right ht1 1).trans (by norm_num)
+      · use ⟨(t + 1) / 2, ⟨by linarith, by linarith⟩⟩
         replace h : t ≠ 0 := h
         have ht0 := lt_of_le_of_ne ht0 h.symm
         have : ¬(t + 1) / 2 ≤ 1 / 2 := by
           rw [not_le]
-          exact (div_lt_div_right (zero_lt_two : (0 : ℝ) < 2)).mpr (by norm_num; exact ht0)
-          -- porting note: was `linarith`
-          -- https://github.com/leanprover-community/mathlib4/issues/2714
+          linarith
         rw [coe_mk_mk, Function.comp_apply, Subtype.coe_mk, if_neg this]
         ring_nf
         rwa [γ₂.extend_extends]

--- a/Mathlib/Topology/UnitInterval.lean
+++ b/Mathlib/Topology/UnitInterval.lean
@@ -175,14 +175,7 @@ theorem mul_pos_mem_iff {a t : ℝ} (ha : 0 < a) : a * t ∈ I ↔ t ∈ Set.Icc
 #align unit_interval.mul_pos_mem_iff unitInterval.mul_pos_mem_iff
 
 theorem two_mul_sub_one_mem_iff {t : ℝ} : 2 * t - 1 ∈ I ↔ t ∈ Set.Icc (1 / 2 : ℝ) 1 := by
--- Porting note: used to be
--- constructor <;> rintro ⟨h₁, h₂⟩ <;> constructor <;> linarith
-letI : NeZero 1 := inferInstance
-constructor <;> rintro ⟨h₁, h₂⟩ <;> constructor <;> try {linarith}
-· rw [← (mul_le_mul_left (zero_lt_two))]
-  simp [le_of_sub_nonneg h₁]
-· rw [sub_nonneg]
-  exact (div_le_iff' (zero_lt_two)).1 h₁
+constructor <;> rintro ⟨h₁, h₂⟩ <;> constructor <;> linarith
 #align unit_interval.two_mul_sub_one_mem_iff unitInterval.two_mul_sub_one_mem_iff
 
 end unitInterval

--- a/Mathlib/Util/Qq.lean
+++ b/Mathlib/Util/Qq.lean
@@ -14,12 +14,14 @@ open Lean Elab Tactic Meta
 
 namespace Qq
 
-/-- Analogue of `inferTypeQ`, but that gets universe levels right for our application. -/
+/-- Variant of `inferTypeQ` that yields a type in `Type u` rather than `Sort u`.
+Throws an error if the type is a `Prop` or if it's otherwise not possible to represent
+the universe as `Type u` (for example due to universe level metavariables). -/
 -- See https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Using.20.60QQ.60.20when.20you.20only.20have.20an.20.60Expr.60/near/303349037
 def inferTypeQ' (e : Expr) : MetaM ((u : Level) × (α : Q(Type $u)) × Q($α)) := do
   let α ← inferType e
-  let .sort u ← instantiateMVars (← whnf (← inferType α)) | unreachable!
-  let some v := u.dec | throwError "not a type{indentExpr α}"
+  let .sort u ← whnf (← inferType α) | throwError "not a type{indentExpr α}"
+  let some v := (← instantiateLevelMVars u).dec | throwError "not a Type{indentExpr e}"
   pure ⟨v, α, e⟩
 
 end Qq

--- a/Mathlib/Util/SynthesizeUsing.lean
+++ b/Mathlib/Util/SynthesizeUsing.lean
@@ -38,7 +38,12 @@ def synthesizeUsing' (type : Expr) (tac : TacticM Unit) : MetaM Expr := do
 
 /--
 `synthesizeUsing type tacticSyntax` synthesizes an element of type `type` by evaluating the
-tactic with the given syntax.
+given tactic syntax.
+
+Example:
+```lean
+let (gs, e) ← synthesizeUsing ty (← `(tactic| congr!))
+```
 
 The tactic `tac` is allowed to leave goals open, and these remain as metavariables in the
 returned expression.
@@ -48,7 +53,12 @@ def synthesizeUsingTactic (type : Expr) (tac : Syntax) : MetaM (List MVarId × E
 
 /--
 `synthesizeUsing' type tacticSyntax` synthesizes an element of type `type` by evaluating the
-tactic with the given syntax.
+given tactic syntax.
+
+Example:
+```lean
+let e ← synthesizeUsing ty (← `(tactic| norm_num))
+```
 
 The tactic must solve for all goals, in contrast to `synthesizeUsingTactic`.
 -/

--- a/Mathlib/Util/SynthesizeUsing.lean
+++ b/Mathlib/Util/SynthesizeUsing.lean
@@ -69,11 +69,11 @@ is a term elaborator that wraps the `simp at ...` tactic:
 def simpTerm (e : Expr) : MetaM Expr := do
   let mvar ← Meta.mkFreshTypeMVar
   let e' ← synthesizeUsing' mvar
-    -- Note: `simp` does not always insert type hints, so `exact id h` is a way to ensure
-    -- that the type of `h` in the local context is saved. Otherwise the type might
-    -- be merely defeq.
-    (do evalTactic (← `(tactic| have h := $(← Term.exprToSyntax e); simp at h; exact id h)))
-  return e'
+    (do evalTactic (← `(tactic| have h := $(← Term.exprToSyntax e); simp at h; exact h)))
+  -- Note: `simp` does not always insert type hints, so to ensure that we get a term
+  -- with the simplified type (as opposed to one that is merely defeq), we should add
+  -- a type hint ourselves.
+  Meta.mkExpectedTypeHint e' mvar
 
 elab "simpTerm% " t:term : term => do simpTerm (← Term.elabTerm t none)
 ```

--- a/Mathlib/Util/SynthesizeUsing.lean
+++ b/Mathlib/Util/SynthesizeUsing.lean
@@ -14,14 +14,43 @@ This is a slight simplification of the `solve_aux` tactic in Lean3.
 open Lean Elab Tactic Meta
 
 /--
-`synthesizeUsing type tac` synthesizes an element of `type` using tactic `tac`.
+`synthesizeUsing type tac` synthesizes an element of type `type` using tactic `tac`.
 
-The tactic `tac` may leave goals open, these remain as metavariables in the returned expression.
+The tactic `tac` is allowed to leave goals open, and these remain as metavariables in the
+returned expression.
 -/
 -- In Lean3 this was called `solve_aux`,
 -- and took a `TacticM α` and captured the produced value in `α`.
 -- As this was barely used, we've simplified here.
-def synthesizeUsing (type : Expr) (tac : TacticM Unit) : MetaM Expr := do
+def synthesizeUsing (type : Expr) (tac : TacticM Unit) : MetaM (List MVarId × Expr) := do
   let m ← mkFreshExprMVar type
-  let _ ← (run m.mvarId! tac).run'
-  instantiateMVars m
+  let goals ← (run m.mvarId! tac).run'
+  return (goals, ← instantiateMVars m)
+
+/--
+`synthesizeUsing type tac` synthesizes an element of type `type` using tactic `tac`.
+
+The tactic must solve for all goals, in contrast to `synthesizeUsing`.
+-/
+def synthesizeUsing' (type : Expr) (tac : TacticM Unit) : MetaM Expr := do
+  let (_, e) ← synthesizeUsing type (tac *> Tactic.done)
+  return e
+
+/--
+`synthesizeUsing type tacticSyntax` synthesizes an element of type `type` by evaluating the
+tactic with the given syntax.
+
+The tactic `tac` is allowed to leave goals open, and these remain as metavariables in the
+returned expression.
+-/
+def synthesizeUsingTactic (type : Expr) (tac : Syntax) : MetaM (List MVarId × Expr) := do
+  synthesizeUsing type (do evalTactic tac)
+
+/--
+`synthesizeUsing' type tacticSyntax` synthesizes an element of type `type` by evaluating the
+tactic with the given syntax.
+
+The tactic must solve for all goals, in contrast to `synthesizeUsingTactic`.
+-/
+def synthesizeUsingTactic' (type : Expr) (tac : Syntax) : MetaM Expr := do
+  synthesizeUsing' type (do evalTactic tac)

--- a/Mathlib/Util/SynthesizeUsing.lean
+++ b/Mathlib/Util/SynthesizeUsing.lean
@@ -71,7 +71,7 @@ def simpTerm (e : Expr) : MetaM Expr := do
   let e' ← synthesizeUsing' mvar
     -- Note: `simp` does not always insert type hints, so `exact id h` is a way to ensure
     -- that the type of `h` in the local context is saved. Otherwise the type might
-    -- merely be defeq.
+    -- be merely defeq.
     (do evalTactic (← `(tactic| have h := $(← Term.exprToSyntax e); simp at h; exact id h)))
   return e'
 

--- a/test/cancel_denoms.lean
+++ b/test/cancel_denoms.lean
@@ -1,0 +1,17 @@
+import Mathlib.Tactic.CancelDenoms
+import Mathlib.Tactic.Ring
+
+variable [LinearOrderedField α] (a b c d : α)
+
+example (h : a / 5 + b / 4 < c) : 4*a + 5*b < 20*c := by
+  cancel_denoms at h
+  exact h
+
+example (h : a > 0) : a / 5 > 0 := by
+  cancel_denoms
+  exact h
+
+example (h : a + b = c) : a/5 + d*(b/4) = c - 4*a/5 + b*2*d/8 - b := by
+  cancel_denoms
+  rw [← h]
+  ring

--- a/test/cancel_denoms.lean
+++ b/test/cancel_denoms.lean
@@ -1,7 +1,7 @@
 import Mathlib.Tactic.CancelDenoms
 import Mathlib.Tactic.Ring
 
-variable [LinearOrderedField α] (a b c d : α)
+variable {α : Type u} [LinearOrderedField α] (a b c d : α)
 
 example (h : a / 5 + b / 4 < c) : 4*a + 5*b < 20*c := by
   cancel_denoms at h

--- a/test/cancel_denoms.lean
+++ b/test/cancel_denoms.lean
@@ -16,8 +16,34 @@ example (h : a + b = c) : a/5 + d*(b/4) = c - 4*a/5 + b*2*d/8 - b := by
   cancel_denoms
   rw [← h]
   ring
+
+example (h : 0 < a) : a / (3/2) > 0 := by
+  cancel_denoms
+  exact h
+
+example (h : 0 < a): 0 < a / 1 := by
+  cancel_denoms
+  exact h
+
+example (h : a < 0): 0 < a / -1 := by
+  cancel_denoms
+  exact h
+
+example (h : -a < 2 * b): a / -2 < b := by
+  cancel_denoms
+  exact h
+
+example (h : a < 6 * a) : a / 2 / 3 < a := by
+  cancel_denoms
+  exact h
+
+example (h : a < 9 * a) : a / 3 / 3 < a := by
+  cancel_denoms
+  exact h
+
 end
 
+-- Some tests with a concrete type universe.
 section
 variable {α : Type} [LinearOrderedField α] (a b c d : α)
 
@@ -35,7 +61,7 @@ example (h : a + b = c) : a/5 + d*(b/4) = c - 4*a/5 + b*2*d/8 - b := by
   ring
 end
 
-
+-- Some tests with a concrete type.
 section
 variable (a b c d : ℚ)
 

--- a/test/cancel_denoms.lean
+++ b/test/cancel_denoms.lean
@@ -1,6 +1,7 @@
 import Mathlib.Tactic.CancelDenoms
 import Mathlib.Tactic.Ring
 
+section
 variable {α : Type u} [LinearOrderedField α] (a b c d : α)
 
 example (h : a / 5 + b / 4 < c) : 4*a + 5*b < 20*c := by
@@ -15,3 +16,39 @@ example (h : a + b = c) : a/5 + d*(b/4) = c - 4*a/5 + b*2*d/8 - b := by
   cancel_denoms
   rw [← h]
   ring
+end
+
+section
+variable {α : Type} [LinearOrderedField α] (a b c d : α)
+
+example (h : a / 5 + b / 4 < c) : 4*a + 5*b < 20*c := by
+  cancel_denoms at h
+  exact h
+
+example (h : a > 0) : a / 5 > 0 := by
+  cancel_denoms
+  exact h
+
+example (h : a + b = c) : a/5 + d*(b/4) = c - 4*a/5 + b*2*d/8 - b := by
+  cancel_denoms
+  rw [← h]
+  ring
+end
+
+
+section
+variable (a b c d : ℚ)
+
+example (h : a / 5 + b / 4 < c) : 4*a + 5*b < 20*c := by
+  cancel_denoms at h
+  exact h
+
+example (h : a > 0) : a / 5 > 0 := by
+  cancel_denoms
+  exact h
+
+example (h : a + b = c) : a/5 + d*(b/4) = c - 4*a/5 + b*2*d/8 - b := by
+  cancel_denoms
+  rw [← h]
+  ring
+end

--- a/test/linarith.lean
+++ b/test/linarith.lean
@@ -80,8 +80,16 @@ by linarith
 -- Make sure special case for division by 1 is handled:
 example (x : Rat) (h : 0 < x) : 0 < x/1 := by linarith
 
--- Failure. Will look into this, but pushing changes so far.
---example (x : Rat) (h : 0 < x) : 0 < x/(-1) := by linarith
+-- Make sure can divide by -1
+example (x : Rat) (h : x < 0) : 0 < x/(-1) := by linarith
+
+example (x : Rat) (h : x < 0) : 0 < x/(-2) := by linarith
+
+example (x : Rat) (h : x < 0) : 0 < x/(-4/5) := by linarith
+
+example (x : Rat) (h : 0 < x) : 0 < x/2/3 := by linarith
+
+example (x : Rat) (h : 0 < x) : 0 < x/(2/3) := by linarith
 
 end cancel_denoms
 

--- a/test/linarith.lean
+++ b/test/linarith.lean
@@ -77,6 +77,12 @@ by linarith
 example (ε : Rat) (h1 : ε > 0) : ε / 3 + ε / 3 + ε / 3 = ε :=
 by linarith
 
+-- Make sure special case for division by 1 is handled:
+example (x : Rat) (h : 0 < x) : 0 < x/1 := by linarith
+
+-- Failure. Will look into this, but pushing changes so far.
+--example (x : Rat) (h : 0 < x) : 0 < x/(-1) := by linarith
+
 end cancel_denoms
 
 example (a b c : Rat) (h2 : b + 2 > 3 + b) : False := by

--- a/test/linarith.lean
+++ b/test/linarith.lean
@@ -56,26 +56,27 @@ example [LinearOrderedCommRing α] (A B : α) (h : 0 < A * B) : 0 < 8*A*B := by
 
 example (s : Set ℕ) (_h : s = ∅) : 0 ≤ 1 := by linarith
 
--- Needs the `cancel_denoms` preprocessor, which in turn needs the `cancel_denoms` tactic ported.
 section cancel_denoms
--- example (A B : Rat) (h : 0 < A * B) : 0 < A*B/8 := by
---   linarith
 
--- example (A B : Rat) (h : 0 < A * B) : 0 < A/8*B := by
---   linarith
+example (A B : Rat) (h : 0 < A * B) : 0 < A*B/8 := by
+  linarith
 
--- example (ε : Rat) (h1 : ε > 0) : ε / 2 + ε / 3 + ε / 7 < ε :=
---  by linarith
+example (A B : Rat) (h : 0 < A * B) : 0 < A/8*B := by
+  linarith
 
--- example (x y z : Rat) (h1 : 2*x  < 3*y) (h2 : -4*x + z/2 < 0)
---         (h3 : 12*y - z < 0)  : False :=
--- by linarith
+example (ε : Rat) (h1 : ε > 0) : ε / 2 + ε / 3 + ε / 7 < ε :=
+ by linarith
 
--- example (ε : Rat) (h1 : ε > 0) : ε / 2 < ε :=
--- by linarith
+example (x y z : Rat) (h1 : 2*x  < 3*y) (h2 : -4*x + z/2 < 0)
+        (h3 : 12*y - z < 0)  : False :=
+by linarith
 
--- example (ε : Rat) (h1 : ε > 0) : ε / 3 + ε / 3 + ε / 3 = ε :=
--- by linarith
+example (ε : Rat) (h1 : ε > 0) : ε / 2 < ε :=
+by linarith
+
+example (ε : Rat) (h1 : ε > 0) : ε / 3 + ε / 3 + ε / 3 = ε :=
+by linarith
+
 end cancel_denoms
 
 example (a b c : Rat) (h2 : b + 2 > 3 + b) : False := by
@@ -382,10 +383,9 @@ example (u v x y A B : Rat)
   intros
   linarith
 
--- TODO this needs the `cancelDenoms` preprocessor.
--- example (A B : ℚ) : (0 < A) → (1 ≤ B) → (0 < A / 8 * B) := by
---   intros
---   nlinarith
+example (A B : ℚ) : (0 < A) → (1 ≤ B) → (0 < A / 8 * B) := by
+  intros
+  nlinarith
 
 example (x y : ℚ) : 0 ≤ x ^2 + y ^2 := by
   nlinarith

--- a/test/linarith.lean
+++ b/test/linarith.lean
@@ -229,26 +229,26 @@ example (mess : ℕ → ℕ) (S n : ℕ) :
 example (p n p' n' : ℕ) (h : p + n' = p' + n) : n + p' = n' + p := by
   linarith
 
--- example (a b c : ℚ) (h1 : 1 / a < b) (h2 : b < c) : 1 / a < c := by
---   linarith
+example (a b c : ℚ) (h1 : 1 / a < b) (h2 : b < c) : 1 / a < c := by
+  linarith
 
 example (N : ℕ) (n : ℕ) (Hirrelevant : n > N) (A : Rat) (l : Rat) (h : A - l ≤ -(A - l))
     (h_1 : ¬A ≤ -A) (h_2 : ¬l ≤ -l) (h_3 : -(A - l) < 1) :  A < l + 1 := by
   linarith
 
--- example (d : Rat) (q n : ℕ) (h1 : ((q : Rat) - 1)*n ≥ 0) (h2 : d = 2/3*(((q : Rat) - 1)*n)) :
---     d ≤ ((q : Rat) - 1)*n := by
---   linarith
+example (d : Rat) (q n : ℕ) (h1 : ((q : Rat) - 1)*n ≥ 0) (h2 : d = 2/3*(((q : Rat) - 1)*n)) :
+    d ≤ ((q : Rat) - 1)*n := by
+  linarith
 
--- example (d : Rat) (q n : ℕ) (h1 : ((q : Rat) - 1)*n ≥ 0) (h2 : d = 2/3*(((q : Rat) - 1)*n)) :
---     ((q : Rat) - 1)*n - d = 1/3 * (((q : Rat) - 1)*n) := by
---   linarith
+example (d : Rat) (q n : ℕ) (h1 : ((q : Rat) - 1)*n ≥ 0) (h2 : d = 2/3*(((q : Rat) - 1)*n)) :
+    ((q : Rat) - 1)*n - d = 1/3 * (((q : Rat) - 1)*n) := by
+  linarith
 
--- example (x y z : ℚ) (hx : x < 5) (hx2 : x > 5) (hy : y < 5000000000) (hz : z > 34*y) : false :=
--- by linarith only [hx, hx2]
+example (x y z : ℚ) (hx : x < 5) (hx2 : x > 5) (hy : y < 5000000000) (hz : z > 34*y) : false :=
+by linarith only [hx, hx2]
 
--- example (x y z : ℚ) (hx : x < 5) (hy : y < 5000000000) (hz : z > 34*y) : x ≤ 5 :=
--- by linarith only [hx]
+example (x y z : ℚ) (hx : x < 5) (hy : y < 5000000000) (hz : z > 34*y) : x ≤ 5 :=
+by linarith only [hx]
 
 example (u v x y A B : ℚ)
 (a : 0 < A)
@@ -433,36 +433,33 @@ example (p q r s t u v w : ℕ) (h1 : p + u = q + t) (h2 : r + w = s + v) :
   p * r + q * s + (t * w + u * v) = p * s + q * r + (t * v + u * w) :=
 by nlinarith
 
--- -- Tests involving a norm, including that squares in a type where `sq_nonneg` does not apply
--- -- do not cause an exception
--- variables {R : Type _} [Ring R] (abs : R → ℚ)
+-- Tests involving a norm, including that squares in a type where `sq_nonneg` does not apply
+-- do not cause an exception
+variable {R : Type _} [Ring R] (abs : R → ℚ)
 
--- lemma abs_nonneg' : ∀ r, 0 ≤ abs r := (fact.out false).elim
+axiom abs_nonneg' : ∀ r, 0 ≤ abs r
 
--- example (t : R) (a b : ℚ) (h : a ≤ b) : abs (t^2) * a ≤ abs (t^2) * b :=
--- by nlinarith [abs_nonneg' abs (t^2)]
+example (t : R) (a b : ℚ) (h : a ≤ b) : abs (t^2) * a ≤ abs (t^2) * b :=
+by nlinarith [abs_nonneg' abs (t^2)]
 
--- example (t : R)  (a b : ℚ) (h : a ≤ b) : a ≤ abs (t^2) + b :=
--- by linarith [abs_nonneg' abs (t^2)]
+example (t : R)  (a b : ℚ) (h : a ≤ b) : a ≤ abs (t^2) + b :=
+by linarith [abs_nonneg' abs (t^2)]
 
--- example (t : R) (a b : ℚ) (h : a ≤ b) : abs t * a ≤ abs t * b :=
--- by nlinarith [abs_nonneg' abs t]
+example (t : R) (a b : ℚ) (h : a ≤ b) : abs t * a ≤ abs t * b :=
+by nlinarith [abs_nonneg' abs t]
 
--- constant T : Type
+axiom T : Type
 
--- attribute [instance]
--- constant T_zero : ordered_ring T
+@[instance] axiom T_zero : OrderedRing T
 
--- namespace T
+namespace T
 
--- lemma zero_lt_one : (0 : T) < 1 := (fact.out false).elim
+axiom zero_lt_one : (0 : T) < 1
 
--- lemma works {a b : ℕ} (hab : a ≤ b) (h : b < a) : false :=
--- begin
---   linarith,
--- end
+lemma works {a b : ℕ} (hab : a ≤ b) (h : b < a) : false := by
+  linarith
 
--- end T
+end T
 
 -- example (a b c : ℚ) (h : a ≠ b) (h3 : b ≠ c) (h2 : a ≥ b) : b ≠ c :=
 -- by linarith {split_ne := tt}
@@ -502,8 +499,8 @@ example (n : Nat) (h1 : ¬n = 1) (h2 : n ≥ 1) : n ≥ 2 := by
   linarith
 
 -- simulate the type of MvPolynomial
-def R : Type u → Type v → Sort (max (u+1) (v+1)) := sorry
-instance : LinearOrderedField (R c d) := sorry
+def P : Type u → Type v → Sort (max (u+1) (v+1)) := sorry
+instance : LinearOrderedField (P c d) := sorry
 
-example (p : R PUnit.{u+1} PUnit.{v+1}) (h : 0 < p) : 0 < 2 * p := by
+example (p : P PUnit.{u+1} PUnit.{v+1}) (h : 0 < p) : 0 < 2 * p := by
   linarith

--- a/test/linear_combination.lean
+++ b/test/linear_combination.lean
@@ -1,4 +1,5 @@
 import Mathlib.Tactic.LinearCombination
+import Mathlib.Tactic.Linarith
 
 -- We deliberately mock R here so that we don't have to import the deps
 axiom Real : Type
@@ -48,13 +49,13 @@ example (x y : ℤ) (h1 : x + 2 = -3) (h2 : y = 10) : -y + 2 * x + 4 = -16 := by
 example (x y : ℚ) (h1 : 3 * x + 2 * y = 10) (h2 : 2 * x + 5 * y = 3) : -11 * y + 1 = 11 + 1 := by
   linear_combination 2 * h1 - 3 * h2
 
--- example (a b : ℝ) (ha : 2 * a = 4) (hab : 2 * b = a - b) : b = 2 / 3 := by
---   linear_combination ha / 6 + hab / 3
+example (a b : ℝ) (ha : 2 * a = 4) (hab : 2 * b = a - b) : b = 2 / 3 := by
+  linear_combination ha / 6 + hab / 3
 
 /-! ### Cases with more than 2 equations -/
 
--- example (a b : ℝ) (ha : 2 * a = 4) (hab : 2 * b = a - b) (hignore : 3 = a + b) : b = 2 / 3 := by
---   linear_combination 1 / 6 * ha + 1 / 3 * hab + 0 * hignore
+example (a b : ℝ) (ha : 2 * a = 4) (hab : 2 * b = a - b) (hignore : 3 = a + b) : b = 2 / 3 := by
+  linear_combination 1 / 6 * ha + 1 / 3 * hab + 0 * hignore
 
 example (x y z : ℝ) (ha : x + 2 * y - z = 4) (hb : 2 * x + y + z = -2) (hc : x + 2 * y + z = 2) :
     -3 * x - 3 * y - 4 * z = 2 := by linear_combination ha - hb - 2 * hc
@@ -67,13 +68,13 @@ example (x y z : ℝ) (ha : x + 2 * y - z = 4) (hb : 2 * x + y + z = -2) (hc : x
     10 = 6 * -x := by
   linear_combination ha + 4 * hb - 3 * hc
 
--- example (w x y z : ℝ) (h1 : x + 2.1 * y + 2 * z = 2) (h2 : x + 8 * z + 5 * w = -6.5)
---     (h3 : x + y + 5 * z + 5 * w = 3) : x + 2.2 * y + 2 * z - 5 * w = -8.5 := by
---   linear_combination 2 * h1 + 1 * h2 - 2 * h3
+example (w x y z : ℝ) (h1 : x + 2.1 * y + 2 * z = 2) (h2 : x + 8 * z + 5 * w = -6.5)
+    (h3 : x + y + 5 * z + 5 * w = 3) : x + 2.2 * y + 2 * z - 5 * w = -8.5 := by
+  linear_combination 2 * h1 + 1 * h2 - 2 * h3
 
--- example (w x y z : ℝ) (h1 : x + 2.1 * y + 2 * z = 2) (h2 : x + 8 * z + 5 * w = -6.5)
---     (h3 : x + y + 5 * z + 5 * w = 3) : x + 2.2 * y + 2 * z - 5 * w = -8.5 := by
---   linear_combination 2 * h1 + h2 - 2 * h3
+example (w x y z : ℝ) (h1 : x + 2.1 * y + 2 * z = 2) (h2 : x + 8 * z + 5 * w = -6.5)
+    (h3 : x + y + 5 * z + 5 * w = 3) : x + 2.2 * y + 2 * z - 5 * w = -8.5 := by
+  linear_combination 2 * h1 + h2 - 2 * h3
 
 example (a b c d : ℚ) (h1 : a = 4) (h2 : 3 = b) (h3 : c * 3 = d) (h4 : -d = a) :
     2 * a - 3 + 9 * c + 3 * d = 8 - b + 3 * d - 3 * a := by
@@ -122,17 +123,17 @@ example (x y : ℚ) (h1 : 3 * x + 2 * y = 10) (h2 : 2 * x + 5 * y = 3) : -11 * y
 example (x y : ℚ) (h1 : 3 * x + 2 * y = 10) (h2 : 2 * x + 5 * y = 3) : -11 * y + 1 = 11 + 1 := by
   linear_combination (norm := ring1) 2 * h1 + -3 * h2
 
--- example (a b : ℝ) (ha : 2 * a = 4) (hab : 2 * b = a - b) : b = 2 / 3 := by
---   linear_combination (norm := ring_nf) 1 / 6 * ha + 1 / 3 * hab
+example (a b : ℝ) (ha : 2 * a = 4) (hab : 2 * b = a - b) : b = 2 / 3 := by
+  linear_combination (norm := ring_nf) 1 / 6 * ha + 1 / 3 * hab
 
 example (x y : ℤ) (h1 : 3 * x + 2 * y = 10) : 3 * x + 2 * y = 10 := by
   linear_combination (norm := simp) h1
 
 /-! ### Cases that have linear_combination skip normalization -/
 
--- example (a b : ℝ) (ha : 2 * a = 4) (hab : 2 * b = a - b) : b = 2 / 3 := by
---   linear_combination (norm := skip) 1 / 6 * ha + 1 / 3 * hab
---   linarith
+example (a b : ℝ) (ha : 2 * a = 4) (hab : 2 * b = a - b) : b = 2 / 3 := by
+  linear_combination (norm := skip) 1 / 6 * ha + 1 / 3 * hab
+  linarith
 
 example (x y : ℤ) (h1 : x = -3) (_h2 : y = 10) : 2 * x = -6 := by
   linear_combination (norm := skip) 2 * h1


### PR DESCRIPTION
Enable the `cancelDenoms` preprocessor in `linarith`. Closes #2714.

- [x] depends on: #3797


[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
