### PR TITLE
[Merged by Bors] - chore: forward-port leanprover-community/mathlib#18341 and leanprover-community/mathlib#18950

### DIFF
--- a/Mathlib/Algebra/BigOperators/Fin.lean
+++ b/Mathlib/Algebra/BigOperators/Fin.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov, Anne Baanen
 
 ! This file was ported from Lean 3 source module algebra.big_operators.fin
-! leanprover-community/mathlib commit cdb01be3c499930fd29be05dce960f4d8d201c54
+! leanprover-community/mathlib commit ef997baa41b5c428be3fb50089a7139bf4ee886b
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -297,6 +297,38 @@ theorem partialProd_right_inv {G : Type _} [Group G] (g : G) (f : Fin n → G) (
       exact i.lt_succ_self.trans <| hn.trans n.lt_succ_self
 #align fin.partial_prod_right_inv Fin.partialProd_right_inv
 #align fin.partial_sum_right_neg Fin.partialSum_right_neg
+
+/-- Let `(g₀, g₁, ..., gₙ)` be a tuple of elements in `Gⁿ⁺¹`.
+Then if `k < j`, this says `(g₀g₁...gₖ₋₁)⁻¹ * g₀g₁...gₖ = gₖ`.
+If `k = j`, it says `(g₀g₁...gₖ₋₁)⁻¹ * g₀g₁...gₖ₊₁ = gₖgₖ₊₁`.
+If `k > j`, it says `(g₀g₁...gₖ)⁻¹ * g₀g₁...gₖ₊₁ = gₖ₊₁.`
+Useful for defining group cohomology. -/
+@[to_additive
+      "Let `(g₀, g₁, ..., gₙ)` be a tuple of elements in `Gⁿ⁺¹`.\nThen if `k < j`, this says `-(g₀ + g₁ + ... + gₖ₋₁) + (g₀ + g₁ + ... + gₖ) = gₖ`.\nIf `k = j`, it says `-(g₀ + g₁ + ... + gₖ₋₁) + (g₀ + g₁ + ... + gₖ₊₁) = gₖ + gₖ₊₁`.\nIf `k > j`, it says `-(g₀ + g₁ + ... + gₖ) + (g₀ + g₁ + ... + gₖ₊₁) = gₖ₊₁.`\nUseful for defining group cohomology."]
+theorem inv_partialProd_mul_eq_contractNth {G : Type _} [Group G] (g : Fin (n + 1) → G)
+    (j : Fin (n + 1)) (k : Fin n) :
+    (partialProd g (j.succ.succAbove k.cast_succ))⁻¹ * partialProd g (j.succAbove k).succ =
+      j.contractNth Mul.mul g k :=
+  by
+  have := partial_prod_right_inv (1 : G) g
+  simp only [one_smul, coe_eq_cast_succ] at this
+  rcases lt_trichotomy (k : ℕ) j with (h | h | h)
+  · rwa [succ_above_below, succ_above_below, this, contract_nth_apply_of_lt]
+    · assumption
+    · rw [cast_succ_lt_iff_succ_le, succ_le_succ_iff, le_iff_coe_le_coe]
+      exact le_of_lt h
+  · rwa [succ_above_below, succ_above_above, partial_prod_succ, cast_succ_fin_succ, ← mul_assoc,
+      this, contract_nth_apply_of_eq]
+    · simpa only [le_iff_coe_le_coe, ← h]
+    · rw [cast_succ_lt_iff_succ_le, succ_le_succ_iff, le_iff_coe_le_coe]
+      exact le_of_eq h
+  · rwa [succ_above_above, succ_above_above, partial_prod_succ, partial_prod_succ,
+      cast_succ_fin_succ, partial_prod_succ, inv_mul_cancel_left, contract_nth_apply_of_gt]
+    · exact le_iff_coe_le_coe.2 (le_of_lt h)
+    · rw [le_iff_coe_le_coe, coe_succ]
+      exact Nat.succ_le_of_lt h
+#align fin.inv_partial_prod_mul_eq_contract_nth Fin.inv_partialProd_mul_eq_contractNth
+#align fin.neg_partial_sum_add_eq_contract_nth Fin.neg_partial_sum_add_eq_contract_nth
 
 end PartialProd
 

--- a/Mathlib/Algebra/BigOperators/Fin.lean
+++ b/Mathlib/Algebra/BigOperators/Fin.lean
@@ -256,11 +256,9 @@ theorem partialProd_left_inv {G : Type _} [Group G] (f : Fin (n + 1) → G) :
 #align fin.partial_sum_left_neg Fin.partialSum_left_neg
 
 -- Porting note:
--- 1) Changed `i` in statement to `(Fin.castLT i (Nat.lt_succ_of_lt i.2))` because of
---    coercion issues. Might need to be fixed later.
--- 2) The current proof is really bad! It should be redone once `assoc_rw` is
+-- 1) The current proof is really bad! It should be redone once `assoc_rw` is
 --    implemented and `rw` knows that `i.succ = i + 1`.
--- 3) The original Mathport output was:
+-- 2) The original Mathport output was:
 --   cases' i with i hn
 --   induction' i with i hi generalizing hn
 --   · simp [← Fin.succ_mk, partialProd_succ]
@@ -272,29 +270,31 @@ theorem partialProd_left_inv {G : Type _} [Group G] (f : Fin (n + 1) → G) :
 --     assoc_rw [hi, inv_mul_cancel_left]
 @[to_additive]
 theorem partialProd_right_inv {G : Type _} [Group G] (g : G) (f : Fin n → G) (i : Fin n) :
-    ((g • partialProd f) (Fin.castLT i (Nat.lt_succ_of_lt i.2)))⁻¹ *
-    (g • partialProd f) i.succ = f i := by
+    ((g • partialProd f) i)⁻¹ * (g • partialProd f) i.succ = f i := by
   rcases i with ⟨i, hn⟩
   induction i with
   | zero =>
-    simp
-    change partialProd f (succ ⟨0, hn⟩) = f ⟨0, hn⟩
-    rw [partialProd_succ]
-    simp
+    simp only [Nat.zero_eq, Nat.cast_zero, Pi.smul_apply, partialProd_zero, smul_eq_mul, mul_one,
+      zero_add, inv_mul_cancel_left, partialProd_succ, castSucc_mk, mk_zero, partialProd_zero,
+      one_mul]
   | succ i hi =>
     specialize hi (lt_trans (Nat.lt_succ_self i) hn)
-    simp at hi ⊢
-    change (partialProd f (succ ⟨i, Nat.lt_of_succ_lt hn⟩))⁻¹ * g⁻¹ * (g *
-      partialProd f (succ ⟨i + 1, hn⟩)) = f ⟨Nat.succ i, hn⟩
+    simp only [Pi.smul_apply, smul_eq_mul, mul_inv_rev, Nat.cast_succ] at hi⊢
+    rw [coe_add_one_eq_cast (i.lt_succ_self.trans hn)]
+    simp_rw [Nat.succ_eq_add_one]
     rw [partialProd_succ, partialProd_succ, Fin.castSucc_mk, Fin.castSucc_mk, mul_inv_rev]
     simp_rw [← mul_assoc] at hi ⊢
     suffices h : (f ⟨i, Nat.lt_of_succ_lt hn⟩)⁻¹ *
         ((partialProd f ⟨i, Nat.lt_succ_of_lt (Nat.lt_of_succ_lt hn)⟩)⁻¹ * g⁻¹ *
         (g * partialProd f ⟨i + 1, Nat.succ_lt_succ (Nat.lt_of_succ_lt hn)⟩)) *
         f ⟨Nat.succ i, hn⟩ = f ⟨Nat.succ i, hn⟩
-    · simp_rw[←mul_assoc] at h
+    · simp_rw [←mul_assoc] at h
       assumption
     · rw [mul_left_eq_self, inv_mul_eq_one, ←hi, ← mul_assoc]
+      simp only [inv_mul_cancel_right, succ_mk, mul_left_inj, inv_inj]
+      congr
+      rw [Fin.eq_mk_iff_val_eq, coe_ofNat_eq_mod, Nat.mod_succ_eq_iff_lt]
+      exact i.lt_succ_self.trans <| hn.trans n.lt_succ_self
 #align fin.partial_prod_right_inv Fin.partialProd_right_inv
 #align fin.partial_sum_right_neg Fin.partialSum_right_neg
 

--- a/Mathlib/Algebra/BigOperators/Fin.lean
+++ b/Mathlib/Algebra/BigOperators/Fin.lean
@@ -304,31 +304,35 @@ If `k = j`, it says `(g₀g₁...gₖ₋₁)⁻¹ * g₀g₁...gₖ₊₁ = gₖ
 If `k > j`, it says `(g₀g₁...gₖ)⁻¹ * g₀g₁...gₖ₊₁ = gₖ₊₁.`
 Useful for defining group cohomology. -/
 @[to_additive
-      "Let `(g₀, g₁, ..., gₙ)` be a tuple of elements in `Gⁿ⁺¹`.\nThen if `k < j`, this says `-(g₀ + g₁ + ... + gₖ₋₁) + (g₀ + g₁ + ... + gₖ) = gₖ`.\nIf `k = j`, it says `-(g₀ + g₁ + ... + gₖ₋₁) + (g₀ + g₁ + ... + gₖ₊₁) = gₖ + gₖ₊₁`.\nIf `k > j`, it says `-(g₀ + g₁ + ... + gₖ) + (g₀ + g₁ + ... + gₖ₊₁) = gₖ₊₁.`\nUseful for defining group cohomology."]
+      "Let `(g₀, g₁, ..., gₙ)` be a tuple of elements in `Gⁿ⁺¹`.
+      Then if `k < j`, this says `-(g₀ + g₁ + ... + gₖ₋₁) + (g₀ + g₁ + ... + gₖ) = gₖ`.
+      If `k = j`, it says `-(g₀ + g₁ + ... + gₖ₋₁) + (g₀ + g₁ + ... + gₖ₊₁) = gₖ + gₖ₊₁`.
+      If `k > j`, it says `-(g₀ + g₁ + ... + gₖ) + (g₀ + g₁ + ... + gₖ₊₁) = gₖ₊₁.`
+      Useful for defining group cohomology."]
 theorem inv_partialProd_mul_eq_contractNth {G : Type _} [Group G] (g : Fin (n + 1) → G)
     (j : Fin (n + 1)) (k : Fin n) :
-    (partialProd g (j.succ.succAbove k.cast_succ))⁻¹ * partialProd g (j.succAbove k).succ =
-      j.contractNth Mul.mul g k :=
-  by
-  have := partial_prod_right_inv (1 : G) g
-  simp only [one_smul, coe_eq_cast_succ] at this
+    (partialProd g (j.succ.succAbove (Fin.castSucc k)))⁻¹ * partialProd g (j.succAbove k).succ =
+      j.contractNth (· * ·) g k := by
+  have := partialProd_right_inv (1 : G) g
+  simp only [one_smul, coe_eq_castSucc] at this
   rcases lt_trichotomy (k : ℕ) j with (h | h | h)
-  · rwa [succ_above_below, succ_above_below, this, contract_nth_apply_of_lt]
+  · rwa [succAbove_below, succAbove_below, this, contractNth_apply_of_lt]
     · assumption
-    · rw [cast_succ_lt_iff_succ_le, succ_le_succ_iff, le_iff_coe_le_coe]
+    · rw [castSucc_lt_iff_succ_le, succ_le_succ_iff, le_iff_val_le_val]
       exact le_of_lt h
-  · rwa [succ_above_below, succ_above_above, partial_prod_succ, cast_succ_fin_succ, ← mul_assoc,
-      this, contract_nth_apply_of_eq]
-    · simpa only [le_iff_coe_le_coe, ← h]
-    · rw [cast_succ_lt_iff_succ_le, succ_le_succ_iff, le_iff_coe_le_coe]
+  · rw [succAbove_below, succAbove_above, partialProd_succ, castSucc_fin_succ, ← mul_assoc,
+      this, contractNth_apply_of_eq]
+    · assumption
+    · simp [le_iff_val_le_val, ← h]
+    · rw [castSucc_lt_iff_succ_le, succ_le_succ_iff, le_iff_val_le_val]
       exact le_of_eq h
-  · rwa [succ_above_above, succ_above_above, partial_prod_succ, partial_prod_succ,
-      cast_succ_fin_succ, partial_prod_succ, inv_mul_cancel_left, contract_nth_apply_of_gt]
-    · exact le_iff_coe_le_coe.2 (le_of_lt h)
-    · rw [le_iff_coe_le_coe, coe_succ]
+  · rwa [succAbove_above, succAbove_above, partialProd_succ, partialProd_succ,
+      castSucc_fin_succ, partialProd_succ, inv_mul_cancel_left, contractNth_apply_of_gt]
+    · exact le_iff_val_le_val.2 (le_of_lt h)
+    · rw [le_iff_val_le_val, val_succ]
       exact Nat.succ_le_of_lt h
 #align fin.inv_partial_prod_mul_eq_contract_nth Fin.inv_partialProd_mul_eq_contractNth
-#align fin.neg_partial_sum_add_eq_contract_nth Fin.neg_partial_sum_add_eq_contract_nth
+#align fin.neg_partial_sum_add_eq_contract_nth Fin.neg_partialSum_add_eq_contractNth
 
 end PartialProd
 

--- a/Mathlib/Algebra/BigOperators/Fin.lean
+++ b/Mathlib/Algebra/BigOperators/Fin.lean
@@ -287,8 +287,7 @@ Useful for defining group cohomology. -/
 theorem inv_partialProd_mul_eq_contractNth {G : Type _} [Group G] (g : Fin (n + 1) → G)
     (j : Fin (n + 1)) (k : Fin n) :
     (partialProd g (j.succ.succAbove (Fin.castSucc k)))⁻¹ * partialProd g (j.succAbove k).succ =
-      j.contractNth (· * ·) g k :=
-  by
+      j.contractNth (· * ·) g k := by
   rcases lt_trichotomy (k : ℕ) j with (h | h | h)
   · rwa [succAbove_below, succAbove_below, partialProd_right_inv, contractNth_apply_of_lt]
     · assumption

--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -2504,6 +2504,10 @@ theorem coe_ofNat_eq_mod (m n : ℕ) [NeZero m] :
   rfl
 #align fin.coe_of_nat_eq_mod Fin.coe_ofNat_eq_mod
 
+lemma coe_add_one_eq_cast {n i : ℕ} (h : i < n) : (i + 1 : Fin (n + 1)) = Fin.succ ⟨i, h⟩ := by
+  rw [succ_mk, Fin.eq_mk_iff_val_eq, ←Nat.cast_add_one, coe_ofNat_eq_mod, Nat.mod_succ_eq_iff_lt]
+  exact Nat.succ_lt_succ h
+
 section Mul
 
 /-!

--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -2504,10 +2504,6 @@ theorem coe_ofNat_eq_mod (m n : ℕ) [NeZero m] :
   rfl
 #align fin.coe_of_nat_eq_mod Fin.coe_ofNat_eq_mod
 
-lemma coe_add_one_eq_cast {n i : ℕ} (h : i < n) : (i + 1 : Fin (n + 1)) = Fin.succ ⟨i, h⟩ := by
-  rw [succ_mk, Fin.eq_mk_iff_val_eq, ←Nat.cast_add_one, coe_ofNat_eq_mod, Nat.mod_succ_eq_iff_lt]
-  exact Nat.succ_lt_succ h
-
 section Mul
 
 /-!

--- a/Mathlib/Data/Fin/Tuple/Basic.lean
+++ b/Mathlib/Data/Fin/Tuple/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn, Yury Kudryashov, Sébastien Gouëzel, Chris Hughes
 
 ! This file was ported from Lean 3 source module data.fin.tuple.basic
-! leanprover-community/mathlib commit d97a0c9f7a7efe6d76d652c5a6b7c9c634b70e0a
+! leanprover-community/mathlib commit ef997baa41b5c428be3fb50089a7139bf4ee886b
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -948,6 +948,46 @@ theorem mem_find_of_unique {p : Fin n → Prop} [DecidablePred p] (h : ∀ i j, 
 #align fin.mem_find_of_unique Fin.mem_find_of_unique
 
 end Find
+
+section ContractNth
+
+variable {α : Type _}
+
+/-- Sends `(g₀, ..., gₙ)` to `(g₀, ..., op gⱼ gⱼ₊₁, ..., gₙ)`. -/
+def contractNth (j : Fin (n + 1)) (op : α → α → α) (g : Fin (n + 1) → α) (k : Fin n) : α :=
+  if (k : ℕ) < j then g k.cast_succ
+  else if (k : ℕ) = j then op (g k.cast_succ) (g k.succ) else g k.succ
+#align fin.contract_nth Fin.contractNth
+
+theorem contractNth_apply_of_lt (j : Fin (n + 1)) (op : α → α → α) (g : Fin (n + 1) → α) (k : Fin n)
+    (h : (k : ℕ) < j) : contractNth j op g k = g k.cast_succ :=
+  if_pos h
+#align fin.contract_nth_apply_of_lt Fin.contractNth_apply_of_lt
+
+theorem contractNth_apply_of_eq (j : Fin (n + 1)) (op : α → α → α) (g : Fin (n + 1) → α) (k : Fin n)
+    (h : (k : ℕ) = j) : contractNth j op g k = op (g k.cast_succ) (g k.succ) :=
+  by
+  have : ¬(k : ℕ) < j := not_lt.2 (le_of_eq h.symm)
+  rw [contract_nth, if_neg this, if_pos h]
+#align fin.contract_nth_apply_of_eq Fin.contractNth_apply_of_eq
+
+theorem contractNth_apply_of_gt (j : Fin (n + 1)) (op : α → α → α) (g : Fin (n + 1) → α) (k : Fin n)
+    (h : (j : ℕ) < k) : contractNth j op g k = g k.succ := by
+  rw [contract_nth, if_neg (not_lt_of_gt h), if_neg (Ne.symm <| ne_of_lt h)]
+#align fin.contract_nth_apply_of_gt Fin.contractNth_apply_of_gt
+
+theorem contractNth_apply_of_ne (j : Fin (n + 1)) (op : α → α → α) (g : Fin (n + 1) → α) (k : Fin n)
+    (hjk : (j : ℕ) ≠ k) : contractNth j op g k = g (j.succAbove k) :=
+  by
+  rcases lt_trichotomy (k : ℕ) j with (h | h | h)
+  · rwa [j.succ_above_below, contract_nth_apply_of_lt]
+    · rwa [Fin.lt_iff_val_lt_val]
+  · exact False.elim (hjk h.symm)
+  · rwa [j.succ_above_above, contract_nth_apply_of_gt]
+    · exact Fin.le_iff_val_le_val.2 (le_of_lt h)
+#align fin.contract_nth_apply_of_ne Fin.contractNth_apply_of_ne
+
+end ContractNth
 
 /-- To show two sigma pairs of tuples agree, it to show the second elements are related via
 `Fin.cast`. -/

--- a/Mathlib/Data/Fin/Tuple/Basic.lean
+++ b/Mathlib/Data/Fin/Tuple/Basic.lean
@@ -955,35 +955,33 @@ variable {α : Type _}
 
 /-- Sends `(g₀, ..., gₙ)` to `(g₀, ..., op gⱼ gⱼ₊₁, ..., gₙ)`. -/
 def contractNth (j : Fin (n + 1)) (op : α → α → α) (g : Fin (n + 1) → α) (k : Fin n) : α :=
-  if (k : ℕ) < j then g k.cast_succ
-  else if (k : ℕ) = j then op (g k.cast_succ) (g k.succ) else g k.succ
+  if (k : ℕ) < j then g (Fin.castSucc k)
+  else if (k : ℕ) = j then op (g (Fin.castSucc k)) (g k.succ) else g k.succ
 #align fin.contract_nth Fin.contractNth
 
 theorem contractNth_apply_of_lt (j : Fin (n + 1)) (op : α → α → α) (g : Fin (n + 1) → α) (k : Fin n)
-    (h : (k : ℕ) < j) : contractNth j op g k = g k.cast_succ :=
+    (h : (k : ℕ) < j) : contractNth j op g k = g (Fin.castSucc k) :=
   if_pos h
 #align fin.contract_nth_apply_of_lt Fin.contractNth_apply_of_lt
 
 theorem contractNth_apply_of_eq (j : Fin (n + 1)) (op : α → α → α) (g : Fin (n + 1) → α) (k : Fin n)
-    (h : (k : ℕ) = j) : contractNth j op g k = op (g k.cast_succ) (g k.succ) :=
-  by
+    (h : (k : ℕ) = j) : contractNth j op g k = op (g (Fin.castSucc k)) (g k.succ) := by
   have : ¬(k : ℕ) < j := not_lt.2 (le_of_eq h.symm)
-  rw [contract_nth, if_neg this, if_pos h]
+  rw [contractNth, if_neg this, if_pos h]
 #align fin.contract_nth_apply_of_eq Fin.contractNth_apply_of_eq
 
 theorem contractNth_apply_of_gt (j : Fin (n + 1)) (op : α → α → α) (g : Fin (n + 1) → α) (k : Fin n)
     (h : (j : ℕ) < k) : contractNth j op g k = g k.succ := by
-  rw [contract_nth, if_neg (not_lt_of_gt h), if_neg (Ne.symm <| ne_of_lt h)]
+  rw [contractNth, if_neg (not_lt_of_gt h), if_neg (Ne.symm <| ne_of_lt h)]
 #align fin.contract_nth_apply_of_gt Fin.contractNth_apply_of_gt
 
 theorem contractNth_apply_of_ne (j : Fin (n + 1)) (op : α → α → α) (g : Fin (n + 1) → α) (k : Fin n)
-    (hjk : (j : ℕ) ≠ k) : contractNth j op g k = g (j.succAbove k) :=
-  by
+    (hjk : (j : ℕ) ≠ k) : contractNth j op g k = g (j.succAbove k) := by
   rcases lt_trichotomy (k : ℕ) j with (h | h | h)
-  · rwa [j.succ_above_below, contract_nth_apply_of_lt]
+  · rwa [j.succAbove_below, contractNth_apply_of_lt]
     · rwa [Fin.lt_iff_val_lt_val]
   · exact False.elim (hjk h.symm)
-  · rwa [j.succ_above_above, contract_nth_apply_of_gt]
+  · rwa [j.succAbove_above, contractNth_apply_of_gt]
     · exact Fin.le_iff_val_le_val.2 (le_of_lt h)
 #align fin.contract_nth_apply_of_ne Fin.contractNth_apply_of_ne
 


### PR DESCRIPTION
This also brings the proof of `partialProd_right_inv` in line with mathlib3.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

- [ ] depends on: https://github.com/leanprover-community/mathlib/pull/18950

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
