### PR TITLE
chore: remove redundant instance in Algbra.Order.LatticeGroup

### DIFF
--- a/Mathlib/Algebra/Order/LatticeGroup.lean
+++ b/Mathlib/Algebra/Order/LatticeGroup.lean
@@ -63,18 +63,7 @@ lattice, ordered, group
 
 
 -- Needed for squares
--- Needed for squares
 universe u
-
--- A linearly ordered additive commutative group is a lattice ordered commutative group
--- see Note [lower instance priority]
-@[to_additive]
-instance (priority := 100) LinearOrderedCommGroup.to_covariantClass (α : Type u)
-    [LinearOrderedCommGroup α] :
-    CovariantClass α α (· * ·)
-      (· ≤ ·) where elim a _ _ bc := OrderedCommGroup.mul_le_mul_left _ _ bc a
-#align linear_ordered_comm_group.to_covariant_class LinearOrderedCommGroup.to_covariantClass
-#align linear_ordered_add_comm_group.to_covariant_class LinearOrderedAddCommGroup.to_covariantClass
 
 variable {α : Type u} [Lattice α] [CommGroup α]
 


### PR DESCRIPTION
This removes a redundant instance, which is implicated in a timeout in fixing the reenableeta branch. 

https://github.com/leanprover-community/mathlib/pull/18951 verifies that it is really redundant in mathlib3. (I built locally already.)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
