### PR TITLE
[Merged by Bors] - fix: make `ConcreteCategory.Forget` reducible

### DIFF
--- a/Mathlib/CategoryTheory/ConcreteCategory/Basic.lean
+++ b/Mathlib/CategoryTheory/ConcreteCategory/Basic.lean
@@ -63,6 +63,7 @@ class ConcreteCategory (C : Type u) [Category.{v} C] where
 #align category_theory.concrete_category CategoryTheory.ConcreteCategory
 #align category_theory.concrete_category.forget CategoryTheory.ConcreteCategory.Forget
 
+attribute [reducible] ConcreteCategory.Forget
 attribute [instance] ConcreteCategory.forget_faithful
 
 /-- The forgetful functor from a concrete category to `Type u`. -/
@@ -71,6 +72,8 @@ def forget (C : Type v) [Category C] [ConcreteCategory.{u} C] : C ⥤ Type u :=
   ConcreteCategory.Forget
 #align category_theory.forget CategoryTheory.forget
 
+-- this is reducible because we want `forget (Type u)` to unfold to `𝟭 _`
+@[reducible]
 instance ConcreteCategory.types : ConcreteCategory (Type u) where
   Forget := 𝟭 _
 #align category_theory.concrete_category.types CategoryTheory.ConcreteCategory.types


### PR DESCRIPTION
This seems to help in downstream files, [See Zulip](https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/typeclass.20inference.20not.20seeing.20through.20reducible.20definition/near/356130343)


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
