### PR TITLE
[Merged by Bors] - chore: correct the author list for Topology.Category.Top.Limits.Konig

### DIFF
--- a/Mathlib/Topology/Category/Top/Limits/Konig.lean
+++ b/Mathlib/Topology/Category/Top/Limits/Konig.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2017 Scott Morrison. All rights reserved.
+Copyright (c) 2021 Kyle Miller. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Patrick Massot, Scott Morrison, Mario Carneiro, Andrew Yang
+Authors: Kyle Miller
 
 ! This file was ported from Lean 3 source module topology.category.Top.limits
 ! leanprover-community/mathlib commit 8195826f5c428fc283510bc67303dd4472d78498


### PR DESCRIPTION
The changes from https://github.com/leanprover-community/mathlib/commit/d4ef2e856125fc9c90a38b00dc8aeb44a70e3a6d underwent a refactor and were moved to a new file in mathlib3, and an inaccurate authors list made it into that file.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
