### PR TITLE
[Merged by Bors] - feat: `lift_lets` tactic

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1849,6 +1849,7 @@ import Mathlib.Tactic.LabelAttr
 import Mathlib.Tactic.LeftRight
 import Mathlib.Tactic.LibrarySearch
 import Mathlib.Tactic.Lift
+import Mathlib.Tactic.LiftLets
 import Mathlib.Tactic.Linarith
 import Mathlib.Tactic.Linarith.Datatypes
 import Mathlib.Tactic.Linarith.Elimination

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -48,6 +48,7 @@ import Mathlib.Tactic.LabelAttr
 import Mathlib.Tactic.LeftRight
 import Mathlib.Tactic.LibrarySearch
 import Mathlib.Tactic.Lift
+import Mathlib.Tactic.LiftLets
 import Mathlib.Tactic.Linarith
 import Mathlib.Tactic.Linarith.Datatypes
 import Mathlib.Tactic.Linarith.Elimination

--- a/Mathlib/Tactic/LiftLets.lean
+++ b/Mathlib/Tactic/LiftLets.lean
@@ -1,0 +1,108 @@
+/-
+Copyright (c) 2023 Kyle Miller. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kyle Miller
+-/
+import Mathlib.Tactic.Basic
+
+/-!
+# The `lift_lets` tactic
+
+This module defines a tactic `lift_lets` that can be used to pull `let` bindings as far out
+of an expression as possible.
+-/
+
+
+open Lean Elab Parser Meta Tactic
+
+/--
+Auxiliary definition for `Lean.Expr.liftLets`. Takes a list of the current fvars so
+that it can be threaded through the computation.
+-/
+private partial def Lean.Expr.liftLetsAux (e : Expr) (fvars : Array Expr)
+    (f : Array Expr → Expr → MetaM Expr) : MetaM Expr := do
+  match e with
+  | .letE n t v b _ =>
+    -- Eliminate the let binding if there is already one of the same name and value.
+    let fvar? ← fvars.findM? (fun fvar => do
+      let decl ← fvar.fvarId!.getDecl
+      return decl.userName == n && decl.value? == some v)
+    if let some fvar' := fvar? then
+      (b.instantiate1 fvar').liftLetsAux fvars f
+    else
+      withLetDecl n t v fun fvar => (b.instantiate1 fvar).liftLetsAux (fvars.push fvar) f
+  | .app x y =>
+    x.liftLetsAux fvars fun fvars x' => y.liftLetsAux fvars fun fvars y' => f fvars (.app x' y')
+  | .proj n idx s =>
+    s.liftLetsAux fvars fun fvars s' => f fvars (.proj n idx s')
+  | .lam n t b i =>
+    t.liftLetsAux fvars fun fvars t => do
+      -- Enter the binding, do liftLets, and lift out liftable lets
+      let e' ← withLocalDecl n i t fun fvar => do
+        (b.instantiate1 fvar).liftLetsAux #[] fun fvars2 b => do
+          -- See which bindings can't be migrated out
+          let deps ← collectForwardDeps #[fvar] false
+          let (fvars2, fvars2') := fvars2.partition deps.contains
+          mkLetFVars fvars2' (← mkLambdaFVars #[fvar] (← mkLetFVars fvars2 b))
+      -- Re-enter the new lets; we do it this way to keep the local context clean
+      insideLets e' fvars fun fvars e'' => f fvars e''
+  | .forallE n t b i =>
+    t.liftLetsAux fvars fun fvars t => do
+      -- Enter the binding, do liftLets, and lift out liftable lets
+      let e' ← withLocalDecl n i t fun fvar => do
+        (b.instantiate1 fvar).liftLetsAux #[] fun fvars2 b => do
+          -- See which bindings can't be migrated out
+          let deps ← collectForwardDeps #[fvar] false
+          let (fvars2, fvars2') := fvars2.partition deps.contains
+          mkLetFVars fvars2' (← mkForallFVars #[fvar] (← mkLetFVars fvars2 b))
+      -- Re-enter the new lets; we do it this way to keep the local context clean
+      insideLets e' fvars fun fvars e'' => f fvars e''
+  | .mdata _ e => e.liftLetsAux fvars f
+  | _ => f fvars e
+where
+  -- Like the whole `Lean.Expr.liftLets`, but only handles lets
+  insideLets {α} (e : Expr) (fvars : Array Expr) (f : Array Expr → Expr → MetaM α) : MetaM α := do
+    match e with
+    | .letE n t v b _ =>
+      withLetDecl n t v fun fvar => insideLets (b.instantiate1 fvar) (fvars.push fvar) f
+    | _ => f fvars e
+
+/-- Take all the `let`s in an expression and move them outwards as far as possible.
+All top-level `let`s are added to the local context, and then `f` is called with the list
+of local bindings (each an fvar) and the new expression.
+
+Let bindings are merged if they have the same name and value.
+
+Use `e.liftLets mkLetFVars` to get a defeq expression with all `let`s lifted as far as possible. -/
+def Lean.Expr.liftLets (e : Expr) (f : Array Expr → Expr → MetaM Expr) : MetaM Expr :=
+  e.liftLetsAux #[] f
+
+namespace Mathlib
+
+/--
+Lift all the `let` bindings in the type of an expression as far out as possible.
+
+When applied to the main goal, this gives one the ability to `intro` embedded `let` expressions.
+For example,
+```lean
+example : (let x := 1; x) = 1 := by
+  lift_lets
+  -- ⊢ let x := 1; x = 1
+  intro x
+  sorry
+```
+-/
+syntax (name := lift_lets) "lift_lets" (ppSpace location)? : tactic
+
+elab_rules : tactic
+  | `(tactic| lift_lets $[$loc:location]?) => do
+    withLocation (expandOptLocation (Lean.mkOptionalNode loc))
+      (atLocal := fun h ↦ liftMetaTactic1 fun mvarId ↦ do
+        let hTy ← instantiateMVars (← h.getType)
+        mvarId.changeLocalDecl' h (← hTy.liftLets mkLetFVars))
+      (atTarget := liftMetaTactic1 fun mvarId ↦ do
+        let ty ← instantiateMVars (← mvarId.getType)
+        mvarId.change (← ty.liftLets mkLetFVars))
+      (failed := fun _ ↦ throwError "lift_lets tactic failed")
+
+end Mathlib

--- a/Mathlib/Tactic/LiftLets.lean
+++ b/Mathlib/Tactic/LiftLets.lean
@@ -91,6 +91,8 @@ example : (let x := 1; x) = 1 := by
   intro x
   sorry
 ```
+
+During the lifting process, let bindings are merged if they have the same name and value.
 -/
 syntax (name := lift_lets) "lift_lets" (ppSpace location)? : tactic
 

--- a/test/LiftLets.lean
+++ b/test/LiftLets.lean
@@ -13,6 +13,12 @@ example : (let x := 1; x) = (let y := 1; y) := by
   intro _x _y
   rfl
 
+example : (let x := (let y := 1; y + 1); x + 1) = 3 := by
+  lift_lets
+  guard_target =ₛ let y := 1; let x := y + 1; x + 1 = 3
+  intros _y _x
+  rfl
+
 example : (fun x => let a := x; let y := 1; a + y) 2 = 2 + 1 := by
   lift_lets
   guard_target =ₛ let y := 1; (fun x ↦ let a := x; a + y) 2 = 2 + 1

--- a/test/LiftLets.lean
+++ b/test/LiftLets.lean
@@ -9,8 +9,8 @@ example : (let x := 1; x) = 1 := by
 
 example : (let x := 1; x) = (let y := 1; y) := by
   lift_lets
-  guard_target =ₛ let x := 1; let y := 1; x = y
-  intro _x _y
+  guard_target =ₛ let x := 1; x = x
+  intro _x
   rfl
 
 example : (let x := (let y := 1; y + 1); x + 1) = 3 := by
@@ -67,9 +67,9 @@ example : (let x := 1; x) = (let x := 1; x) := by
   guard_target =ₛ let x := 1; x = x
   rfl
 
-example : (let x := 1; x) = (let y := 1; y) := by
+example : (let x := 2; x) = (let y := 1; y + 1) := by
   lift_lets
-  guard_target =ₛ let x := 1; let y := 1; x = y
+  guard_target =ₛ let x := 2; let y := 1; x = y + 1
   rfl
 
 example (h : (let x := 1; x) = y) : True := by
@@ -84,3 +84,9 @@ example (h : (let x := 1; x) = y) : True := by
   guard_hyp x : Nat := 1
   guard_hyp h :ₛ x = y
   trivial
+
+example : let x := 1; ∀ n, let y := 1; x + n = y + n := by
+  lift_lets
+  guard_target =ₛ let x := 1; ∀ n, x + n = x + n
+  intros x n
+  rfl

--- a/test/LiftLets.lean
+++ b/test/LiftLets.lean
@@ -70,3 +70,11 @@ example (h : (let x := 1; x) = y) : True := by
   lift_lets at h
   guard_hyp h :ₛ let x := 1; x = y
   trivial
+
+example (h : (let x := 1; x) = y) : True := by
+  revert h
+  lift_lets
+  intro x h
+  guard_hyp x : Nat := 1
+  guard_hyp h :ₛ x = y
+  trivial

--- a/test/LiftLets.lean
+++ b/test/LiftLets.lean
@@ -1,0 +1,72 @@
+import Mathlib.Tactic.LiftLets
+import Std.Tactic.GuardExpr
+
+example : (let x := 1; x) = 1 := by
+  lift_lets
+  guard_target =ₛ let x := 1; x = 1
+  intro _x
+  rfl
+
+example : (let x := 1; x) = (let y := 1; y) := by
+  lift_lets
+  guard_target =ₛ let x := 1; let y := 1; x = y
+  intro _x _y
+  rfl
+
+example : (fun x => let a := x; let y := 1; a + y) 2 = 2 + 1 := by
+  lift_lets
+  guard_target =ₛ let y := 1; (fun x ↦ let a := x; a + y) 2 = 2 + 1
+  intro _y
+  rfl
+
+example : (fun (_ : let ty := Nat; ty) => Nat) (2 : Nat) := by
+  lift_lets
+  guard_target =ₛ let ty := Nat; (fun (_ : ty) ↦ Nat) (2 : Nat)
+  exact 0
+
+example : (fun (x : let ty := Nat; ty) => Fin x) (2 : Nat) := by
+  lift_lets
+  guard_target =ₛ let ty := Nat; (fun (x : ty) ↦ Fin x) (2 : Nat)
+  exact 0
+
+
+example : (id : Nat → Nat) = (fun (x : let ty := Nat; ty) => x) := by
+  lift_lets
+  guard_target =ₛ let ty := Nat; (id: Nat → Nat) = fun (x : ty) ↦ x
+  rfl
+
+example : (x : let ty := Nat; ty) → let y := (1 : Nat); Fin (y + Nat.succ x) := by
+  lift_lets
+  guard_target =ₛ let ty := Nat; let y := 1; (x : ty) → Fin (y + Nat.succ x)
+  intro ty y x
+  rw [Nat.add_succ, Nat.succ_eq_add_one]
+  exact 0
+
+example : (x : Nat) → (y : Nat) → let z := x + 1; let w := 3; Fin (z + w) := by
+  lift_lets
+  guard_target =ₛ let w := 3; (x : Nat) → let z := x + 1; Nat → Fin (z + w)
+  intro w x z _y
+  simp
+  exact 0
+
+example : (x : Nat) → let z := x + 1; (y : Nat) → let w := 3; Fin (z + w) := by
+  lift_lets
+  guard_target =ₛ let w := 3; (x : Nat) → let z := x + 1; Nat → Fin (z + w)
+  intro w x z _y
+  simp
+  exact 0
+
+example : (let x := 1; x) = (let x := 1; x) := by
+  lift_lets
+  guard_target =ₛ let x := 1; x = x
+  rfl
+
+example : (let x := 1; x) = (let y := 1; y) := by
+  lift_lets
+  guard_target =ₛ let x := 1; let y := 1; x = y
+  rfl
+
+example (h : (let x := 1; x) = y) : True := by
+  lift_lets at h
+  guard_hyp h :ₛ let x := 1; x = y
+  trivial


### PR DESCRIPTION
This tactic was suggested by @eric-wieser in https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F/topic/Pulling.20.60let.60s.20to.20the.20outside.20of.20a.20statement/near/315581119

The tactic tries to take all `let`s in an expression and lift them out as far as possible. For example, if the goal is `(let x := 1; x) = 1` then `lift_lets` turns the goal into `let x := 1; x = 1`. This then allows the user to do `intro x` to create a local `let` binding.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
