### PR TITLE
fix: delete `String.csize_pos`

### DIFF
--- a/Mathlib/Data/Char.lean
+++ b/Mathlib/Data/Char.lean
@@ -27,8 +27,6 @@ theorem Char.utf8Size_pos (c : Char) : 0 < c.utf8Size := by
   repeat (split; decide)
   decide
 
-theorem String.csize_pos : (c : Char) → 0 < String.csize c := Char.utf8Size_pos
-
 /--
 Provides a `LinearOrder` instance on `Char`. `Char` is the type of Unicode scalar values.
 -/

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -10,12 +10,12 @@
   {"git":
    {"url": "https://github.com/JLimperg/aesop",
     "subDir?": null,
-    "rev": "cdc00b640d0179910ebaa9c931e3b733a04b881c",
+    "rev": "5cf2eb0722e8d0cb58149c744f9888de1b9f0855",
     "name": "aesop",
     "inputRev?": "master"}},
   {"git":
    {"url": "https://github.com/leanprover/std4",
     "subDir?": null,
-    "rev": "6006307d2ceb8743fea7e00ba0036af8654d0347",
+    "rev": "f6525373c9fd639adffa259bcb98c17dfd00e61e",
     "name": "std",
     "inputRev?": "main"}}]}


### PR DESCRIPTION
Std4 already has `String.csize_pos`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
