### PR TITLE
[Merged by Bors] - feat: port Analysis.NormedSpace.OperatorNorm

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -424,6 +424,7 @@ import Mathlib.Analysis.NormedSpace.IndicatorFunction
 import Mathlib.Analysis.NormedSpace.Int
 import Mathlib.Analysis.NormedSpace.LinearIsometry
 import Mathlib.Analysis.NormedSpace.MStructure
+import Mathlib.Analysis.NormedSpace.OperatorNorm
 import Mathlib.Analysis.NormedSpace.Pointwise
 import Mathlib.Analysis.NormedSpace.Ray
 import Mathlib.Analysis.NormedSpace.RieszLemma

--- a/Mathlib/Analysis/NormedSpace/OperatorNorm.lean
+++ b/Mathlib/Analysis/NormedSpace/OperatorNorm.lean
@@ -403,11 +403,12 @@ protected theorem tmp_topology_eq :
       ((@Metric.nhds_basis_closedBall _ ContinuousLinearMap.tmpPseudoMetricSpace 0).ext
         (ContinuousLinearMap.hasBasis_nhds_zero_of_basis Metric.nhds_basis_closedBall) _ _)
   · rcases NormedField.exists_norm_lt_one 𝕜 with ⟨c, hc₀, hc₁⟩
-    refine' fun ε hε => ⟨⟨closedBall 0 (1 / ‖c‖), ε⟩,
-      ⟨NormedSpace.isVonNBounded_closedBall _ _ _, hε⟩, fun f hf => _⟩
-    change ∀ x, _ at hf
+    intro ε hε
+    refine' ⟨⟨closedBall 0 (1 / ‖c‖), ε⟩, ⟨⟨_, hε⟩, _⟩⟩
+    · exact NormedSpace.isVonNBounded_closedBall _ _ _
+    intro f (hf : ∀ x, _)
     simp_rw [mem_closedBall_zero_iff] at hf
-    rw [@mem_closedBall_zero_iff _ SeminormedAddCommGroup.toSeminormedAddGroup]
+    convert (@mem_closedBall_zero_iff _ (_) f ε).2 _ -- Porting note: needed `convert`
     refine' op_norm_le_of_shell' (div_pos one_pos hc₀) hε.le hc₁ fun x hx₁ hxc => _
     rw [div_mul_cancel 1 hc₀.ne.symm] at hx₁
     exact (hf x hxc.le).trans (le_mul_of_one_le_right hε.le hx₁)

--- a/Mathlib/Analysis/NormedSpace/OperatorNorm.lean
+++ b/Mathlib/Analysis/NormedSpace/OperatorNorm.lean
@@ -180,7 +180,7 @@ theorem op_norm_le_bound' (f : E →SL[σ₁₂] F) {M : ℝ} (hMp : 0 ≤ M)
     (hM : ∀ x, ‖x‖ ≠ 0 → ‖f x‖ ≤ M * ‖x‖) : ‖f‖ ≤ M :=
   op_norm_le_bound f hMp fun x =>
     (ne_or_eq ‖x‖ 0).elim (hM x) fun h => by
-      simp only [h, MulZeroClass.mul_zero, norm_image_of_norm_zero f f.2 h]
+      simp only [h, MulZeroClass.mul_zero, norm_image_of_norm_zero f f.2 h, le_refl]
 #align continuous_linear_map.op_norm_le_bound' ContinuousLinearMap.op_norm_le_bound'
 
 set_option synthInstance.etaExperiment true in

--- a/Mathlib/Analysis/NormedSpace/OperatorNorm.lean
+++ b/Mathlib/Analysis/NormedSpace/OperatorNorm.lean
@@ -483,6 +483,9 @@ theorem op_nnnorm_eq_of_bounds {φ : E →SL[σ₁₂] F} (M : ℝ≥0) (h_above
   Subtype.ext <| op_norm_eq_of_bounds (zero_le M) h_above <| Subtype.forall'.mpr h_below
 #align continuous_linear_map.op_nnnorm_eq_of_bounds ContinuousLinearMap.op_nnnorm_eq_of_bounds
 
+set_option synthInstance.etaExperiment true in
+set_option maxHeartbeats 0 in
+set_option synthInstance.maxHeartbeats 0 in
 instance toNormedSpace {𝕜' : Type _} [NormedField 𝕜'] [NormedSpace 𝕜' F] [SMulCommClass 𝕜₂ 𝕜' F] :
     NormedSpace 𝕜' (E →SL[σ₁₂] F) :=
   ⟨op_norm_smul_le⟩
@@ -502,17 +505,22 @@ theorem op_nnnorm_comp_le [RingHomIsometric σ₁₃] (f : E →SL[σ₁₂] F) 
   op_norm_comp_le h f
 #align continuous_linear_map.op_nnnorm_comp_le ContinuousLinearMap.op_nnnorm_comp_le
 
+set_option synthInstance.etaExperiment true in
 /-- Continuous linear maps form a seminormed ring with respect to the operator norm. -/
 instance toSemiNormedRing : SeminormedRing (E →L[𝕜] E) :=
   { ContinuousLinearMap.toSeminormedAddCommGroup, ContinuousLinearMap.ring with
     norm_mul := fun f g => op_norm_comp_le f g }
 #align continuous_linear_map.to_semi_normed_ring ContinuousLinearMap.toSemiNormedRing
 
-/-- For a normed space `E`, continuous linear endomorphisms form a normed algebra with
-respect to the operator norm. -/
-instance toNormedAlgebra : NormedAlgebra 𝕜 (E →L[𝕜] E) :=
-  { ContinuousLinearMap.toNormedSpace, ContinuousLinearMap.algebra with }
-#align continuous_linear_map.to_normed_algebra ContinuousLinearMap.toNormedAlgebra
+-- Porting FIXME: this instance is not actually needed in this file (verified in mathlib3)
+-- and as it is incredible slow, it's commented out for now.
+-- set_option synthInstance.etaExperiment true in
+-- set_option maxHeartbeats 0 in
+-- /-- For a normed space `E`, continuous linear endomorphisms form a normed algebra with
+-- respect to the operator norm. -/
+-- instance toNormedAlgebra : NormedAlgebra 𝕜 (E →L[𝕜] E) :=
+--   { ContinuousLinearMap.toNormedSpace, ContinuousLinearMap.algebra with }
+-- #align continuous_linear_map.to_normed_algebra ContinuousLinearMap.toNormedAlgebra
 
 set_option synthInstance.etaExperiment true in
 theorem le_op_nnnorm : ‖f x‖₊ ≤ ‖f‖₊ * ‖x‖₊ :=

--- a/Mathlib/Analysis/NormedSpace/OperatorNorm.lean
+++ b/Mathlib/Analysis/NormedSpace/OperatorNorm.lean
@@ -435,7 +435,7 @@ instance toPseudoMetricSpace : PseudoMetricSpace (E →SL[σ₁₂] F) :=
 #align continuous_linear_map.to_pseudo_metric_space ContinuousLinearMap.toPseudoMetricSpace
 
 set_option synthInstance.etaExperiment true in
-set_option maxHeartbeats 0 in
+set_option maxHeartbeats 1600000 in
 /-- Continuous linear maps themselves form a seminormed space with respect to
     the operator norm. -/
 instance toSeminormedAddCommGroup : SeminormedAddCommGroup (E →SL[σ₁₂] F) where
@@ -484,8 +484,8 @@ theorem op_nnnorm_eq_of_bounds {φ : E →SL[σ₁₂] F} (M : ℝ≥0) (h_above
 #align continuous_linear_map.op_nnnorm_eq_of_bounds ContinuousLinearMap.op_nnnorm_eq_of_bounds
 
 set_option synthInstance.etaExperiment true in
-set_option maxHeartbeats 0 in
-set_option synthInstance.maxHeartbeats 0 in
+set_option maxHeartbeats 400000 in
+set_option synthInstance.maxHeartbeats 80000 in
 instance toNormedSpace {𝕜' : Type _} [NormedField 𝕜'] [NormedSpace 𝕜' F] [SMulCommClass 𝕜₂ 𝕜' F] :
     NormedSpace 𝕜' (E →SL[σ₁₂] F) :=
   ⟨op_norm_smul_le⟩
@@ -514,6 +514,8 @@ instance toSemiNormedRing : SeminormedRing (E →L[𝕜] E) :=
 
 -- Porting FIXME: this instance is not actually needed in this file (verified in mathlib3)
 -- and as it is incredible slow, it's commented out for now.
+-- It is eventually needed in (at least) `Mathlib.Analysis.Calculus.ContDiff`.
+
 -- set_option synthInstance.etaExperiment true in
 -- set_option maxHeartbeats 0 in
 -- /-- For a normed space `E`, continuous linear endomorphisms form a normed algebra with
@@ -694,6 +696,8 @@ theorem op_nnnorm_prod (f : E →L[𝕜] Fₗ) (g : E →L[𝕜] Gₗ) : ‖f.pr
 #align continuous_linear_map.op_nnnorm_prod ContinuousLinearMap.op_nnnorm_prod
 
 set_option synthInstance.etaExperiment true in
+set_option maxHeartbeats 3200000 in
+set_option synthInstance.maxHeartbeats 640000 in
 /-- `ContinuousLinearMap.prod` as a `LinearIsometryEquiv`. -/
 def prodₗᵢ (R : Type _) [Semiring R] [Module R Fₗ] [Module R Gₗ] [ContinuousConstSMul R Fₗ]
     [ContinuousConstSMul R Gₗ] [SMulCommClass 𝕜 R Fₗ] [SMulCommClass 𝕜 R Gₗ] :
@@ -703,6 +707,7 @@ def prodₗᵢ (R : Type _) [Semiring R] [Module R Fₗ] [Module R Gₗ] [Contin
 
 variable [RingHomIsometric σ₁₂] (f : E →SL[σ₁₂] F)
 
+set_option synthInstance.etaExperiment true in
 @[simp, nontriviality]
 theorem op_norm_subsingleton [Subsingleton E] : ‖f‖ = 0 := by
   refine' le_antisymm _ (norm_nonneg _)
@@ -793,6 +798,8 @@ theorem mkContinuous_norm_le' (f : E →ₛₗ[σ₁₂] F) {C : ℝ} (h : ∀ x
 variable [RingHomIsometric σ₂₃]
 
 set_option synthInstance.etaExperiment true in
+set_option maxHeartbeats 800000 in
+set_option synthInstance.maxHeartbeats 80000 in
 /-- Create a bilinear map (represented as a map `E →L[𝕜] F →L[𝕜] G`) from the corresponding linear
 map and a bound on the norm of the image. The linear map can be constructed using
 `LinearMap.mk₂`. -/
@@ -802,15 +809,17 @@ def mkContinuous₂ (f : E →ₛₗ[σ₁₃] F →ₛₗ[σ₂₃] G) (C : ℝ
     { toFun := fun x => (f x).mkContinuous (C * ‖x‖) (hC x)
       map_add' := fun x y => by
         ext z
-        rw [ContinuousLinearMap.add_apply, mk_continuous_apply, mk_continuous_apply,
-          mk_continuous_apply, map_add, add_apply]
+        rw [ContinuousLinearMap.add_apply, mkContinuous_apply, mkContinuous_apply,
+          mkContinuous_apply, map_add, add_apply]
       map_smul' := fun c x => by
         ext z
-        rw [ContinuousLinearMap.smul_apply, mk_continuous_apply, mk_continuous_apply, map_smulₛₗ,
+        rw [ContinuousLinearMap.smul_apply, mkContinuous_apply, mkContinuous_apply, map_smulₛₗ,
           smul_apply] }
     (max C 0) fun x =>
-    (mkContinuous_norm_le' _ _).trans_eq <| by
-      rw [max_mul_of_nonneg _ _ (norm_nonneg x), MulZeroClass.zero_mul]
+    sorry
+    -- Porting FIXME: this proof needs fixing.
+    -- (mkContinuous_norm_le' _ _).trans_eq <| by
+    --   rw [max_mul_of_nonneg _ _ (norm_nonneg x), MulZeroClass.zero_mul]
 #align linear_map.mk_continuous₂ LinearMap.mkContinuous₂
 
 set_option synthInstance.etaExperiment true in
@@ -839,18 +848,22 @@ namespace ContinuousLinearMap
 variable [RingHomIsometric σ₂₃] [RingHomIsometric σ₁₃]
 
 set_option synthInstance.etaExperiment true in
+set_option maxHeartbeats 400000 in
 /-- Flip the order of arguments of a continuous bilinear map.
 For a version bundled as `LinearIsometryEquiv`, see
 `ContinuousLinearMap.flipL`. -/
 def flip (f : E →SL[σ₁₃] F →SL[σ₂₃] G) : F →SL[σ₂₃] E →SL[σ₁₃] G :=
   LinearMap.mkContinuous₂
+    -- Porting note: the `simp only`s below used to be `rw`.
+    -- Now that doesn't work as we need to do some beta reduction along the way.
     (LinearMap.mk₂'ₛₗ σ₂₃ σ₁₃ (fun y x => f x y) (fun x y z => (f z).map_add x y)
-      (fun c y x => (f x).map_smulₛₗ c y) (fun z x y => by rw [f.map_add, add_apply]) fun c y x =>
-      by rw [f.map_smulₛₗ, smul_apply])
-    ‖f‖ fun y x => (f.le_op_norm₂ x y).trans_eq <| by rw [mul_right_comm]
+      (fun c y x => (f x).map_smulₛₗ c y) (fun z x y => by simp only [f.map_add, add_apply])
+        (fun c y x => by simp only [f.map_smulₛₗ, smul_apply]))
+    ‖f‖ fun y x => (f.le_op_norm₂ x y).trans_eq <| by simp only [mul_right_comm]
 #align continuous_linear_map.flip ContinuousLinearMap.flip
 
 set_option synthInstance.etaExperiment true in
+set_option maxHeartbeats 400000 in
 private theorem le_norm_flip (f : E →SL[σ₁₃] F →SL[σ₂₃] G) : ‖f‖ ≤ ‖flip f‖ :=
   f.op_norm_le_bound₂ (norm_nonneg _) fun x y => by
     rw [mul_right_comm]
@@ -876,12 +889,16 @@ theorem op_norm_flip (f : E →SL[σ₁₃] F →SL[σ₂₃] G) : ‖f.flip‖ 
 #align continuous_linear_map.op_norm_flip ContinuousLinearMap.op_norm_flip
 
 set_option synthInstance.etaExperiment true in
+set_option maxHeartbeats 400000 in
+set_option synthInstance.maxHeartbeats 40000 in
 @[simp]
 theorem flip_add (f g : E →SL[σ₁₃] F →SL[σ₂₃] G) : (f + g).flip = f.flip + g.flip :=
   rfl
 #align continuous_linear_map.flip_add ContinuousLinearMap.flip_add
 
 set_option synthInstance.etaExperiment true in
+set_option maxHeartbeats 400000 in
+set_option synthInstance.maxHeartbeats 40000 in
 @[simp]
 theorem flip_smul (c : 𝕜₃) (f : E →SL[σ₁₃] F →SL[σ₂₃] G) : (c • f).flip = c • f.flip :=
   rfl

--- a/Mathlib/Analysis/NormedSpace/OperatorNorm.lean
+++ b/Mathlib/Analysis/NormedSpace/OperatorNorm.lean
@@ -435,7 +435,6 @@ instance toPseudoMetricSpace : PseudoMetricSpace (E →SL[σ₁₂] F) :=
 #align continuous_linear_map.to_pseudo_metric_space ContinuousLinearMap.toPseudoMetricSpace
 
 set_option synthInstance.etaExperiment true in
-set_option maxHeartbeats 1600000 in
 /-- Continuous linear maps themselves form a seminormed space with respect to
     the operator norm. -/
 instance toSeminormedAddCommGroup : SeminormedAddCommGroup (E →SL[σ₁₂] F) where
@@ -484,8 +483,6 @@ theorem op_nnnorm_eq_of_bounds {φ : E →SL[σ₁₂] F} (M : ℝ≥0) (h_above
 #align continuous_linear_map.op_nnnorm_eq_of_bounds ContinuousLinearMap.op_nnnorm_eq_of_bounds
 
 set_option synthInstance.etaExperiment true in
-set_option maxHeartbeats 400000 in
-set_option synthInstance.maxHeartbeats 80000 in
 instance toNormedSpace {𝕜' : Type _} [NormedField 𝕜'] [NormedSpace 𝕜' F] [SMulCommClass 𝕜₂ 𝕜' F] :
     NormedSpace 𝕜' (E →SL[σ₁₂] F) :=
   ⟨op_norm_smul_le⟩
@@ -516,13 +513,16 @@ instance toSemiNormedRing : SeminormedRing (E →L[𝕜] E) :=
 -- and as it is incredible slow, it's commented out for now.
 -- It is eventually needed in (at least) `Mathlib.Analysis.Calculus.ContDiff`.
 
--- set_option synthInstance.etaExperiment true in
--- set_option maxHeartbeats 0 in
--- /-- For a normed space `E`, continuous linear endomorphisms form a normed algebra with
--- respect to the operator norm. -/
--- instance toNormedAlgebra : NormedAlgebra 𝕜 (E →L[𝕜] E) :=
---   { ContinuousLinearMap.toNormedSpace, ContinuousLinearMap.algebra with }
--- #align continuous_linear_map.to_normed_algebra ContinuousLinearMap.toNormedAlgebra
+-- Note that this is still really slow even on `reenableeta` branches,
+-- so something else bad is going on here.
+
+set_option synthInstance.etaExperiment true in
+set_option maxHeartbeats 0 in
+/-- For a normed space `E`, continuous linear endomorphisms form a normed algebra with
+respect to the operator norm. -/
+instance toNormedAlgebra : NormedAlgebra 𝕜 (E →L[𝕜] E) :=
+  { ContinuousLinearMap.toNormedSpace, ContinuousLinearMap.algebra with }
+#align continuous_linear_map.to_normed_algebra ContinuousLinearMap.toNormedAlgebra
 
 set_option synthInstance.etaExperiment true in
 theorem le_op_nnnorm : ‖f x‖₊ ≤ ‖f‖₊ * ‖x‖₊ :=
@@ -696,8 +696,6 @@ theorem op_nnnorm_prod (f : E →L[𝕜] Fₗ) (g : E →L[𝕜] Gₗ) : ‖f.pr
 #align continuous_linear_map.op_nnnorm_prod ContinuousLinearMap.op_nnnorm_prod
 
 set_option synthInstance.etaExperiment true in
-set_option maxHeartbeats 3200000 in
-set_option synthInstance.maxHeartbeats 640000 in
 /-- `ContinuousLinearMap.prod` as a `LinearIsometryEquiv`. -/
 def prodₗᵢ (R : Type _) [Semiring R] [Module R Fₗ] [Module R Gₗ] [ContinuousConstSMul R Fₗ]
     [ContinuousConstSMul R Gₗ] [SMulCommClass 𝕜 R Fₗ] [SMulCommClass 𝕜 R Gₗ] :
@@ -798,8 +796,6 @@ theorem mkContinuous_norm_le' (f : E →ₛₗ[σ₁₂] F) {C : ℝ} (h : ∀ x
 variable [RingHomIsometric σ₂₃]
 
 set_option synthInstance.etaExperiment true in
-set_option maxHeartbeats 800000 in
-set_option synthInstance.maxHeartbeats 80000 in
 /-- Create a bilinear map (represented as a map `E →L[𝕜] F →L[𝕜] G`) from the corresponding linear
 map and a bound on the norm of the image. The linear map can be constructed using
 `LinearMap.mk₂`. -/
@@ -848,7 +844,6 @@ namespace ContinuousLinearMap
 variable [RingHomIsometric σ₂₃] [RingHomIsometric σ₁₃]
 
 set_option synthInstance.etaExperiment true in
-set_option maxHeartbeats 400000 in
 /-- Flip the order of arguments of a continuous bilinear map.
 For a version bundled as `LinearIsometryEquiv`, see
 `ContinuousLinearMap.flipL`. -/
@@ -863,7 +858,6 @@ def flip (f : E →SL[σ₁₃] F →SL[σ₂₃] G) : F →SL[σ₂₃] E →SL
 #align continuous_linear_map.flip ContinuousLinearMap.flip
 
 set_option synthInstance.etaExperiment true in
-set_option maxHeartbeats 400000 in
 private theorem le_norm_flip (f : E →SL[σ₁₃] F →SL[σ₂₃] G) : ‖f‖ ≤ ‖flip f‖ :=
   f.op_norm_le_bound₂ (norm_nonneg _) fun x y => by
     rw [mul_right_comm]
@@ -889,16 +883,12 @@ theorem op_norm_flip (f : E →SL[σ₁₃] F →SL[σ₂₃] G) : ‖f.flip‖ 
 #align continuous_linear_map.op_norm_flip ContinuousLinearMap.op_norm_flip
 
 set_option synthInstance.etaExperiment true in
-set_option maxHeartbeats 400000 in
-set_option synthInstance.maxHeartbeats 40000 in
 @[simp]
 theorem flip_add (f g : E →SL[σ₁₃] F →SL[σ₂₃] G) : (f + g).flip = f.flip + g.flip :=
   rfl
 #align continuous_linear_map.flip_add ContinuousLinearMap.flip_add
 
 set_option synthInstance.etaExperiment true in
-set_option maxHeartbeats 400000 in
-set_option synthInstance.maxHeartbeats 40000 in
 @[simp]
 theorem flip_smul (c : 𝕜₃) (f : E →SL[σ₁₃] F →SL[σ₂₃] G) : (c • f).flip = c • f.flip :=
   rfl
@@ -907,6 +897,8 @@ theorem flip_smul (c : 𝕜₃) (f : E →SL[σ₁₃] F →SL[σ₂₃] G) : (c
 variable (E F G σ₁₃ σ₂₃)
 
 set_option synthInstance.etaExperiment true in
+set_option maxHeartbeats 400000 in
+set_option synthInstance.maxHeartbeats 40000 in
 /-- Flip the order of arguments of a continuous bilinear map.
 This is a version bundled as a `LinearIsometryEquiv`.
 For an unbundled version see `ContinuousLinearMap.flip`. -/
@@ -922,11 +914,13 @@ def flipₗᵢ' : (E →SL[σ₁₃] F →SL[σ₂₃] G) ≃ₗᵢ[𝕜₃] F �
 
 variable {E F G σ₁₃ σ₂₃}
 
+set_option synthInstance.maxHeartbeats 40000 in
 @[simp]
 theorem flipₗᵢ'_symm : (flipₗᵢ' E F G σ₂₃ σ₁₃).symm = flipₗᵢ' F E G σ₁₃ σ₂₃ :=
   rfl
 #align continuous_linear_map.flipₗᵢ'_symm ContinuousLinearMap.flipₗᵢ'_symm
 
+set_option synthInstance.maxHeartbeats 80000 in
 @[simp]
 theorem coe_flipₗᵢ' : ⇑(flipₗᵢ' E F G σ₂₃ σ₁₃) = flip :=
   rfl
@@ -935,6 +929,7 @@ theorem coe_flipₗᵢ' : ⇑(flipₗᵢ' E F G σ₂₃ σ₁₃) = flip :=
 variable (𝕜 E Fₗ Gₗ)
 
 set_option synthInstance.etaExperiment true in
+set_option maxHeartbeats 400000 in
 /-- Flip the order of arguments of a continuous bilinear map.
 This is a version bundled as a `LinearIsometryEquiv`.
 For an unbundled version see `ContinuousLinearMap.flip`. -/
@@ -955,6 +950,7 @@ theorem flipₗᵢ_symm : (flipₗᵢ 𝕜 E Fₗ Gₗ).symm = flipₗᵢ 𝕜 F
   rfl
 #align continuous_linear_map.flipₗᵢ_symm ContinuousLinearMap.flipₗᵢ_symm
 
+set_option synthInstance.maxHeartbeats 80000 in
 @[simp]
 theorem coe_flipₗᵢ : ⇑(flipₗᵢ 𝕜 E Fₗ Gₗ) = flip :=
   rfl
@@ -1030,7 +1026,7 @@ set_option synthInstance.etaExperiment true in
 theorem _root_.Continuous.const_clm_comp {X} [TopologicalSpace X] {f : X → E →SL[σ₁₂] F}
     (hf : Continuous f) (g : F →SL[σ₂₃] G) :
     Continuous (fun x => g.comp (f x) : X → E →SL[σ₁₃] G) :=
-  (compSL E F G σ₁₂ σ₂₃ g).Continuous.comp hf
+  (compSL E F G σ₁₂ σ₂₃ g).continuous.comp hf
 #align continuous.const_clm_comp Continuous.const_clm_comp
 
 set_option synthInstance.etaExperiment true in
@@ -1039,7 +1035,7 @@ theorem _root_.Continuous.clm_comp_const {X} [TopologicalSpace X] {g : X → F �
     (hg : Continuous g) (f : E →SL[σ₁₂] F) :
     Continuous (fun x => (g x).comp f : X → E →SL[σ₁₃] G) :=
   (@ContinuousLinearMap.flip _ _ _ _ _ (E →SL[σ₁₃] G) _ _ _ _ _ _ _ _ _ _ _ _ _
-    (compSL E F G σ₁₂ σ₂₃) f).Continuous.comp hg
+    (compSL E F G σ₁₂ σ₂₃) f).continuous.comp hg
 #align continuous.clm_comp_const Continuous.clm_comp_const
 
 variable (𝕜 σ₁₂ σ₂₃ E Fₗ Gₗ)
@@ -1065,7 +1061,7 @@ variable (Eₗ) {𝕜 E Fₗ Gₗ}
 
 set_option synthInstance.etaExperiment true in
 /-- Apply `L(x,-)` pointwise to bilinear maps, as a continuous bilinear map -/
-@[simps apply]
+@[simps! apply]
 def precompR (L : E →L[𝕜] Fₗ →L[𝕜] Gₗ) : E →L[𝕜] (Eₗ →L[𝕜] Fₗ) →L[𝕜] Eₗ →L[𝕜] Gₗ :=
   (compL 𝕜 Eₗ Fₗ Gₗ).comp L
 #align continuous_linear_map.precompR ContinuousLinearMap.precompR
@@ -1103,6 +1099,7 @@ variable {Eₗ} (𝕜)
 set_option linter.uppercaseLean3 false
 
 set_option synthInstance.etaExperiment true in
+set_option maxHeartbeats 400000 in
 /-- `ContinuousLinearMap.prodMap` as a continuous linear map. -/
 def prodMapL : (M₁ →L[𝕜] M₂) × (M₃ →L[𝕜] M₄) →L[𝕜] M₁ × M₃ →L[𝕜] M₂ × M₄ :=
   ContinuousLinearMap.copy
@@ -1119,12 +1116,12 @@ def prodMapL : (M₁ →L[𝕜] M₂) × (M₃ →L[𝕜] M₄) →L[𝕜] M₁ 
     have Ψ₂ : (M₁ →L[𝕜] M₂) × (M₃ →L[𝕜] M₄) →L[𝕜] M₃ →L[𝕜] M₄ :=
       ContinuousLinearMap.snd 𝕜 (M₁ →L[𝕜] M₂) (M₃ →L[𝕜] M₄)
     Φ₁' ∘L Φ₁ ∘L Ψ₁ + Φ₂' ∘L Φ₂ ∘L Ψ₂)
-    (fun p : (M₁ →L[𝕜] M₂) × (M₃ →L[𝕜] M₄) => p.1.prod_map p.2) (by
+    (fun p : (M₁ →L[𝕜] M₂) × (M₃ →L[𝕜] M₄) => p.1.prodMap p.2) (by
       apply funext
       rintro ⟨φ, ψ⟩
       apply ContinuousLinearMap.ext fun x => _
       simp only [add_apply, coe_comp', coe_fst', Function.comp_apply, compL_apply, flip_apply,
-        coe_snd', inl_apply, inr_apply, Prod.mk_add_mk, add_zero, zero_add, coe_prod_map', Prod_map,
+        coe_snd', inl_apply, inr_apply, Prod.mk_add_mk, add_zero, zero_add, coe_prod_map, Prod_map,
         Prod.mk.inj_iff, eq_self_iff_true, and_self_iff]
       rfl)
 #align continuous_linear_map.prod_mapL ContinuousLinearMap.prodMapL
@@ -1161,11 +1158,11 @@ theorem _root_.ContinuousOn.prod_mapL {f : X → M₁ →L[𝕜] M₂} {g : X �
 #align continuous_on.prod_mapL ContinuousOn.prod_mapL
 
 set_option synthInstance.etaExperiment true in
-theorem ContinuousOn.prod_map_equivL {f : X → M₁ ≃L[𝕜] M₂} {g : X → M₃ ≃L[𝕜] M₄} {s : Set X}
+theorem _root_.ContinuousOn.prod_map_equivL {f : X → M₁ ≃L[𝕜] M₂} {g : X → M₃ ≃L[𝕜] M₄} {s : Set X}
     (hf : ContinuousOn (fun x => (f x : M₁ →L[𝕜] M₂)) s)
     (hg : ContinuousOn (fun x => (g x : M₃ →L[𝕜] M₄)) s) :
     ContinuousOn (fun x => ((f x).prod (g x) : M₁ × M₃ →L[𝕜] M₂ × M₄)) s :=
-  (prodMapL 𝕜 M₁ M₂ M₃ M₄).continuous.comp_continuousOn (hf.Prod hg)
+  (prodMapL 𝕜 M₁ M₂ M₃ M₄).continuous.comp_continuousOn (hf.prod hg)
 #align continuous_on.prod_map_equivL ContinuousOn.prod_map_equivL
 
 end Prod
@@ -1404,13 +1401,17 @@ protected theorem lipschitz : LipschitzWith ‖(e : E →SL[σ₁₂] F)‖₊ e
 #align continuous_linear_equiv.lipschitz ContinuousLinearEquiv.lipschitz
 
 set_option synthInstance.etaExperiment true in
-theorem isBigO_comp {α : Type _} (f : α → E) (l : Filter α) : (fun x' => e (f x')) =O[l] f :=
+theorem isBigO_comp (e : E ≃SL[σ₁₂] F) {α : Type _} (f : α → E) (l : Filter α) :
+    (fun x' => e (f x')) =O[l] f :=
   (e : E →SL[σ₁₂] F).isBigO_comp f l
+set_option linter.uppercaseLean3 false in
 #align continuous_linear_equiv.is_O_comp ContinuousLinearEquiv.isBigO_comp
 
 set_option synthInstance.etaExperiment true in
-theorem isBigO_sub (l : Filter E) (x : E) : (fun x' => e (x' - x)) =O[l] fun x' => x' - x :=
+theorem isBigO_sub (e : E ≃SL[σ₁₂] F) (l : Filter E) (x : E) :
+    (fun x' => e (x' - x)) =O[l] fun x' => x' - x :=
   (e : E →SL[σ₁₂] F).isBigO_sub l x
+set_option linter.uppercaseLean3 false in
 #align continuous_linear_equiv.is_O_sub ContinuousLinearEquiv.isBigO_sub
 
 end
@@ -1422,12 +1423,16 @@ variable [RingHomIsometric σ₂₁]
 set_option synthInstance.etaExperiment true in
 variable (e : E ≃SL[σ₁₂] F)
 
-theorem isBigO_comp_rev {α : Type _} (f : α → E) (l : Filter α) : f =O[l] fun x' => e (f x') :=
+theorem isBigO_comp_rev (e : E ≃SL[σ₁₂] F) {α : Type _} (f : α → E) (l : Filter α) :
+    f =O[l] fun x' => e (f x') :=
   (e.symm.isBigO_comp _ l).congr_left fun _ => e.symm_apply_apply _
+set_option linter.uppercaseLean3 false in
 #align continuous_linear_equiv.is_O_comp_rev ContinuousLinearEquiv.isBigO_comp_rev
 
-theorem isBigO_sub_rev (l : Filter E) (x : E) : (fun x' => x' - x) =O[l] fun x' => e (x' - x) :=
+theorem isBigO_sub_rev (e : E ≃SL[σ₁₂] F) (l : Filter E) (x : E) :
+    (fun x' => x' - x) =O[l] fun x' => e (x' - x) :=
   e.isBigO_comp_rev _ _
+set_option linter.uppercaseLean3 false in
 #align continuous_linear_equiv.is_O_sub_rev ContinuousLinearEquiv.isBigO_sub_rev
 
 end ContinuousLinearEquiv
@@ -1478,6 +1483,7 @@ set_option synthInstance.etaExperiment true in
 theorem map_add_add (f : E →L[𝕜] Fₗ →L[𝕜] Gₗ) (x x' : E) (y y' : Fₗ) :
     f (x + x') (y + y') = f x y + f.deriv₂ (x, y) (x', y') + f x' y' := by
   simp only [map_add, add_apply, coe_deriv₂, add_assoc]
+  abel
 #align continuous_linear_map.map_add_add ContinuousLinearMap.map_add_add
 
 end ContinuousLinearMap
@@ -1637,10 +1643,10 @@ that it belongs to the closure of the image of a bounded set `s : set (E →SL[�
 to function. Coercion to function of the result is definitionally equal to `f`. -/
 @[simps! (config := { fullyApplied := false }) apply]
 def ofMemClosureImageCoeBounded (f : E' → F) {s : Set (E' →SL[σ₁₂] F)} (hs : Bounded s)
-    (hf : f ∈ closure ((coeFn : (E' →SL[σ₁₂] F) → E' → F) '' s)) : E' →SL[σ₁₂] F := by
+    (hf : f ∈ closure (((↑) : (E' →SL[σ₁₂] F) → E' → F) '' s)) : E' →SL[σ₁₂] F := by
   -- `f` is a linear map due to `linearMapOfMemClosureRangeCoe`
   refine' (linearMapOfMemClosureRangeCoe f _).mkContinuousOfExistsBound _
-  · refine' closure_mono (image_subset_iff.2 fun g hg => _) hf
+  · refine' closure_mono (image_subset_iff.2 fun g _ => _) hf
     exact ⟨g, rfl⟩
   · -- We need to show that `f` has bounded norm. Choose `C` such that `‖g‖ ≤ C` for all `g ∈ s`.
     rcases bounded_iff_forall_norm_le.1 hs with ⟨C, hC⟩
@@ -1659,7 +1665,7 @@ def ofTendstoOfBoundedRange {α : Type _} {l : Filter α} [l.NeBot] (f : E' → 
     (g : α → E' →SL[σ₁₂] F) (hf : Tendsto (fun a x => g a x) l (𝓝 f)) (hg : Bounded (Set.range g)) :
     E' →SL[σ₁₂] F :=
   ofMemClosureImageCoeBounded f hg <| mem_closure_of_tendsto hf <|
-    eventually_of_forall fun a => mem_image_of_mem _ <| Set.mem_range_self _
+    eventually_of_forall fun _ => mem_image_of_mem _ <| Set.mem_range_self _
 #align continuous_linear_map.of_tendsto_of_bounded_range ContinuousLinearMap.ofTendstoOfBoundedRange
 
 set_option synthInstance.etaExperiment true in
@@ -1677,10 +1683,10 @@ theorem tendsto_of_tendsto_pointwise_of_cauchySeq {f : ℕ → E' →SL[σ₁₂
     (squeeze_zero (fun n => norm_nonneg _) (fun n => op_norm_le_bound _ (hb₀ n) (this n)) hb_lim)
   intro n x
   -- Note that `f m x → g x`, hence `‖f n x - f m x‖ → ‖f n x - g x‖` as `m → ∞`
-  have : tendsto (fun m => ‖f n x - f m x‖) at_top (𝓝 ‖f n x - g x‖) :=
+  have : Tendsto (fun m => ‖f n x - f m x‖) atTop (𝓝 ‖f n x - g x‖) :=
     (tendsto_const_nhds.sub <| tendsto_pi_nhds.1 hg _).norm
   -- Thus it suffices to verify `‖f n x - f m x‖ ≤ b n * ‖x‖` for `m ≥ n`.
-  refine' le_of_tendsto this (eventually_at_top.2 ⟨n, fun m hm => _⟩)
+  refine' le_of_tendsto this (eventually_atTop.2 ⟨n, fun m hm => _⟩)
   -- This inequality follows from `‖f n - f m‖ ≤ b n`.
   exact (f n - f m).le_of_op_norm_le (hfb _ _ _ le_rfl hm) _
 #align continuous_linear_map.tendsto_of_tendsto_pointwise_of_cauchy_seq ContinuousLinearMap.tendsto_of_tendsto_pointwise_of_cauchySeq
@@ -1703,17 +1709,17 @@ instance [CompleteSpace F] : CompleteSpace (E' →SL[σ₁₂] F) := by
     ofTendstoOfBoundedRange _ _ (tendsto_pi_nhds.mpr hG) hf.bounded_range
   -- Finally, `f n` converges to `Glin` in norm because of
   -- `ContinuousLinearMap.tendsto_of_tendsto_pointwise_of_cauchy_seq`
-  exact ⟨Glin, tendsto_of_tendsto_pointwise_of_cauchy_seq (tendsto_pi_nhds.2 hG) hf⟩
+  exact ⟨Glin, tendsto_of_tendsto_pointwise_of_cauchySeq (tendsto_pi_nhds.2 hG) hf⟩
 
 /-- Let `s` be a bounded set in the space of continuous (semi)linear maps `E →SL[σ] F` taking values
 in a proper space. Then `s` interpreted as a set in the space of maps `E → F` with topology of
 pointwise convergence is precompact: its closure is a compact set. -/
 theorem isCompact_closure_image_coe_of_bounded [ProperSpace F] {s : Set (E' →SL[σ₁₂] F)}
-    (hb : Bounded s) : IsCompact (closure ((coeFn : (E' →SL[σ₁₂] F) → E' → F) '' s)) :=
+    (hb : Bounded s) : IsCompact (closure (((↑) : (E' →SL[σ₁₂] F) → E' → F) '' s)) :=
   have : ∀ x, IsCompact (closure (apply' F σ₁₂ x '' s)) := fun x =>
     ((apply' F σ₁₂ x).lipschitz.bounded_image hb).isCompact_closure
   isCompact_closure_of_subset_compact (isCompact_pi_infinite this)
-    (image_subset_iff.2 fun g hg x => subset_closure <| mem_image_of_mem _ hg)
+    (image_subset_iff.2 fun _ hg _ => subset_closure <| mem_image_of_mem _ hg)
 #align continuous_linear_map.is_compact_closure_image_coe_of_bounded ContinuousLinearMap.isCompact_closure_image_coe_of_bounded
 
 /-- Let `s` be a bounded set in the space of continuous (semi)linear maps `E →SL[σ] F` taking values
@@ -1722,8 +1728,8 @@ pointwise convergence is closed, then it is compact.
 
 TODO: reformulate this in terms of a type synonym with the right topology. -/
 theorem isCompact_image_coe_of_bounded_of_closed_image [ProperSpace F] {s : Set (E' →SL[σ₁₂] F)}
-    (hb : Bounded s) (hc : IsClosed ((coeFn : (E' →SL[σ₁₂] F) → E' → F) '' s)) :
-    IsCompact ((coeFn : (E' →SL[σ₁₂] F) → E' → F) '' s) :=
+    (hb : Bounded s) (hc : IsClosed (((↑) : (E' →SL[σ₁₂] F) → E' → F) '' s)) :
+    IsCompact (((↑) : (E' →SL[σ₁₂] F) → E' → F) '' s) :=
   hc.closure_eq ▸ isCompact_closure_image_coe_of_bounded hb
 #align continuous_linear_map.is_compact_image_coe_of_bounded_of_closed_image ContinuousLinearMap.isCompact_image_coe_of_bounded_of_closed_image
 
@@ -1734,8 +1740,9 @@ with weak-* topology in `mathlib`, so we use an equivalent condition (see `isClo
 
 TODO: reformulate this in terms of a type synonym with the right topology. -/
 theorem isClosed_image_coe_of_bounded_of_weak_closed {s : Set (E' →SL[σ₁₂] F)} (hb : Bounded s)
-    (hc : ∀ f, (⇑f : E' → F) ∈ closure ((coeFn : (E' →SL[σ₁₂] F) → E' → F) '' s) → f ∈ s) :
-    IsClosed ((coeFn : (E' →SL[σ₁₂] F) → E' → F) '' s) :=
+    (hc : ∀ f : E' →SL[σ₁₂] F,
+      (⇑f : E' → F) ∈ closure (((↑) : (E' →SL[σ₁₂] F) → E' → F) '' s) → f ∈ s) :
+    IsClosed (((↑) : (E' →SL[σ₁₂] F) → E' → F) '' s) :=
   isClosed_of_closure_subset fun f hf =>
     ⟨ofMemClosureImageCoeBounded f hb hf, hc (ofMemClosureImageCoeBounded f hb hf) hf, rfl⟩
 #align continuous_linear_map.is_closed_image_coe_of_bounded_of_weak_closed ContinuousLinearMap.isClosed_image_coe_of_bounded_of_weak_closed
@@ -1747,8 +1754,9 @@ with weak-* topology in `mathlib`, so we use an equivalent condition (see `isClo
 -/
 theorem isCompact_image_coe_of_bounded_of_weak_closed [ProperSpace F] {s : Set (E' →SL[σ₁₂] F)}
     (hb : Bounded s)
-    (hc : ∀ f, (⇑f : E' → F) ∈ closure ((coeFn : (E' →SL[σ₁₂] F) → E' → F) '' s) → f ∈ s) :
-    IsCompact ((coeFn : (E' →SL[σ₁₂] F) → E' → F) '' s) :=
+    (hc : ∀ f : E' →SL[σ₁₂] F,
+      (⇑f : E' → F) ∈ closure (((↑) : (E' →SL[σ₁₂] F) → E' → F) '' s) → f ∈ s) :
+    IsCompact (((↑) : (E' →SL[σ₁₂] F) → E' → F) '' s) :=
   isCompact_image_coe_of_bounded_of_closed_image hb <|
     isClosed_image_coe_of_bounded_of_weak_closed hb hc
 #align continuous_linear_map.is_compact_image_coe_of_bounded_of_weak_closed ContinuousLinearMap.isCompact_image_coe_of_bounded_of_weak_closed
@@ -1757,12 +1765,12 @@ set_option synthInstance.etaExperiment true in
 /-- A closed ball is closed in the weak-* topology. We don't have a name for `E →SL[σ] F` with
 weak-* topology in `mathlib`, so we use an equivalent condition (see `isClosed_induced_iff'`). -/
 theorem is_weak_closed_closedBall (f₀ : E' →SL[σ₁₂] F) (r : ℝ) ⦃f : E' →SL[σ₁₂] F⦄
-    (hf : ⇑f ∈ closure ((coeFn : (E' →SL[σ₁₂] F) → E' → F) '' closedBall f₀ r)) :
+    (hf : ⇑f ∈ closure (((↑) : (E' →SL[σ₁₂] F) → E' → F) '' closedBall f₀ r)) :
     f ∈ closedBall f₀ r := by
   have hr : 0 ≤ r := nonempty_closedBall.1 (nonempty_image_iff.1 (closure_nonempty_iff.1 ⟨_, hf⟩))
   refine' mem_closedBall_iff_norm.2 (op_norm_le_bound _ hr fun x => _)
   have : IsClosed { g : E' → F | ‖g x - f₀ x‖ ≤ r * ‖x‖ } :=
-    is_closed_Iic.preimage ((@continuous_apply E' (fun _ => F) _ x).sub continuous_const).norm
+    isClosed_Iic.preimage ((@continuous_apply E' (fun _ => F) _ x).sub continuous_const).norm
   refine' this.closure_subset_iff.2 (image_subset_iff.2 fun g hg => _) hf
   exact (g - f₀).le_of_op_norm_le (mem_closedBall_iff_norm.1 hg) _
 #align continuous_linear_map.is_weak_closed_closed_ball ContinuousLinearMap.is_weak_closed_closedBall
@@ -1771,7 +1779,7 @@ theorem is_weak_closed_closedBall (f₀ : E' →SL[σ₁₂] F) (r : ℝ) ⦃f :
 at distance `≤ r` from `f₀ : E →SL[σ₁₂] F` is closed in the topology of pointwise convergence.
 This is one of the key steps in the proof of the **Banach-Alaoglu** theorem. -/
 theorem isClosed_image_coe_closedBall (f₀ : E →SL[σ₁₂] F) (r : ℝ) :
-    IsClosed ((coeFn : (E →SL[σ₁₂] F) → E → F) '' closedBall f₀ r) :=
+    IsClosed (((↑) : (E →SL[σ₁₂] F) → E → F) '' closedBall f₀ r) :=
   isClosed_image_coe_of_bounded_of_weak_closed bounded_closedBall (is_weak_closed_closedBall f₀ r)
 #align continuous_linear_map.is_closed_image_coe_closed_ball ContinuousLinearMap.isClosed_image_coe_closedBall
 
@@ -1780,7 +1788,7 @@ maps `f : E →SL[σ₁₂] F` at distance `≤ r` from `f₀ : E →SL[σ₁₂
 pointwise convergence. Other versions of this theorem can be found in
 `Analysis.NormedSpace.WeakDual`. -/
 theorem isCompact_image_coe_closedBall [ProperSpace F] (f₀ : E →SL[σ₁₂] F) (r : ℝ) :
-    IsCompact ((coeFn : (E →SL[σ₁₂] F) → E → F) '' closedBall f₀ r) :=
+    IsCompact (((↑) : (E →SL[σ₁₂] F) → E → F) '' closedBall f₀ r) :=
   isCompact_image_coe_of_bounded_of_weak_closed bounded_closedBall <| is_weak_closed_closedBall f₀ r
 #align continuous_linear_map.is_compact_image_coe_closed_ball ContinuousLinearMap.isCompact_image_coe_closedBall
 
@@ -1800,17 +1808,17 @@ def extend : Fₗ →SL[σ₁₂] F :=
   have cont :=
     (-- extension of `f` is continuous
         uniformContinuous_uniformly_extend
-        h_e h_dense f.UniformContinuous).Continuous
+        h_e h_dense f.uniformContinuous).continuous
   -- extension of `f` agrees with `f` on the domain of the embedding `e`
-  have eq := uniformly_extend_of_ind h_e h_dense f.UniformContinuous
-  { toFun := (h_e.DenseInducing h_dense).extend f
+  have eq := uniformly_extend_of_ind h_e h_dense f.uniformContinuous
+  { toFun := (h_e.denseInducing h_dense).extend f
     map_add' := by
       refine' h_dense.induction_on₂ _ _
       · exact
           isClosed_eq (cont.comp continuous_add)
             ((cont.comp continuous_fst).add (cont.comp continuous_snd))
       · intro x y
-        simp only [Eq, ← e.map_add]
+        simp only [eq, ← e.map_add]
         exact f.map_add _ _
     map_smul' := fun k => by
       refine' fun b => h_dense.induction_on b _ _
@@ -1818,7 +1826,7 @@ def extend : Fₗ →SL[σ₁₂] F :=
           isClosed_eq (cont.comp (continuous_const_smul _)) ((continuous_const_smul _).comp cont)
       · intro x
         rw [← map_smul]
-        simp only [Eq]
+        simp only [eq]
         exact ContinuousLinearMap.map_smulₛₗ _ _ _
     cont }
 #align continuous_linear_map.extend ContinuousLinearMap.extend
@@ -1830,7 +1838,7 @@ theorem extend_eq (x : E) : extend f e h_dense h_e (e x) = f x :=
 
 theorem extend_unique (g : Fₗ →SL[σ₁₂] F) (H : g.comp e = f) : extend f e h_dense h_e = g :=
   ContinuousLinearMap.coeFn_injective <|
-    uniformly_extend_unique h_e h_dense (ContinuousLinearMap.ext_iff.1 H) g.Continuous
+    uniformly_extend_unique h_e h_dense (ContinuousLinearMap.ext_iff.1 H) g.continuous
 #align continuous_linear_map.extend_unique ContinuousLinearMap.extend_unique
 
 @[simp]
@@ -1844,20 +1852,20 @@ section
 
 variable {N : ℝ≥0} (h_e : ∀ x, ‖x‖ ≤ N * ‖e x‖) [RingHomIsometric σ₁₂]
 
-local notation "ψ" => f.extend e h_dense (uniformEmbedding_of_bound _ h_e).to_uniformInducing
+local notation "ψ" => f.extend e h_dense (uniformEmbedding_of_bound _ h_e).toUniformInducing
 
 /-- If a dense embedding `e : E →L[𝕜] G` expands the norm by a constant factor `N⁻¹`, then the
 norm of the extension of `f` along `e` is bounded by `N * ‖f‖`. -/
 theorem op_norm_extend_le : ‖ψ‖ ≤ N * ‖f‖ := by
-  have uni : UniformInducing e := (uniform_embedding_of_bound _ h_e).to_uniformInducing
-  have eq : ∀ x, ψ (e x) = f x := uniformly_extend_of_ind uni h_dense f.uniform_continuous
+  have uni : UniformInducing e := (uniformEmbedding_of_bound _ h_e).toUniformInducing
+  have eq : ∀ x, ψ (e x) = f x := uniformly_extend_of_ind uni h_dense f.uniformContinuous
   by_cases N0 : 0 ≤ N
   · refine' op_norm_le_bound ψ _ (isClosed_property h_dense (isClosed_le _ _) _)
     · exact mul_nonneg N0 (norm_nonneg _)
     · exact continuous_norm.comp (cont ψ)
     · exact continuous_const.mul continuous_norm
     · intro x
-      rw [Eq]
+      rw [eq]
       calc
         ‖f x‖ ≤ ‖f‖ * ‖x‖ := le_op_norm _ _
         _ ≤ ‖f‖ * (N * ‖e x‖) := (mul_le_mul_of_nonneg_left (h_e x) (norm_nonneg _))
@@ -1900,7 +1908,7 @@ the operator norm. -/
 theorem norm_toContinuousLinearMap_comp [RingHomIsometric σ₁₂] (f : F →ₛₗᵢ[σ₂₃] G)
     {g : E →SL[σ₁₂] F} : ‖f.toContinuousLinearMap.comp g‖ = ‖g‖ :=
   op_norm_ext (f.toContinuousLinearMap.comp g) g fun x => by
-    simp only [norm_map, coe_toContinuousLinearMap, coe_comp']
+    simp only [norm_map, coe_toContinuousLinearMap, coe_comp', Function.comp_apply]
 #align linear_isometry.norm_to_continuous_linear_map_comp LinearIsometry.norm_toContinuousLinearMap_comp
 
 end LinearIsometry
@@ -1943,7 +1951,7 @@ is the product of the norms. -/
 @[simp]
 theorem norm_smulRight_apply (c : E →L[𝕜] 𝕜) (f : Fₗ) : ‖smulRight c f‖ = ‖c‖ * ‖f‖ := by
   refine' le_antisymm _ _
-  · apply op_norm_le_bound _ (mul_nonneg (norm_nonneg _) (norm_nonneg _)) fun x => _
+  · refine op_norm_le_bound _ (mul_nonneg (norm_nonneg _) (norm_nonneg _)) fun x => ?_
     calc
       ‖c x • f‖ = ‖c x‖ * ‖f‖ := norm_smul _ _
       _ ≤ ‖c‖ * ‖x‖ * ‖f‖ := (mul_le_mul_of_nonneg_right (le_op_norm _ _) (norm_nonneg _))
@@ -1952,12 +1960,12 @@ theorem norm_smulRight_apply (c : E →L[𝕜] 𝕜) (f : Fₗ) : ‖smulRight c
     · simp [h]
     · have : 0 < ‖f‖ := norm_pos_iff.2 h
       rw [← le_div_iff this]
-      apply op_norm_le_bound _ (div_nonneg (norm_nonneg _) (norm_nonneg f)) fun x => _
+      refine op_norm_le_bound _ (div_nonneg (norm_nonneg _) (norm_nonneg f)) fun x => ?_
       rw [div_mul_eq_mul_div, le_div_iff this]
       calc
         ‖c x‖ * ‖f‖ = ‖c x • f‖ := (norm_smul _ _).symm
-        _ = ‖smul_right c f x‖ := rfl
-        _ ≤ ‖smul_right c f‖ * ‖x‖ := le_op_norm _ _
+        _ = ‖smulRight c f x‖ := rfl
+        _ ≤ ‖smulRight c f‖ * ‖x‖ := le_op_norm _ _
 #align continuous_linear_map.norm_smul_right_apply ContinuousLinearMap.norm_smulRight_apply
 
 set_option synthInstance.etaExperiment true in
@@ -1978,12 +1986,14 @@ def smulRightL : (E →L[𝕜] 𝕜) →L[𝕜] Fₗ →L[𝕜] E →L[𝕜] F�
     { toFun := smulRightₗ
       map_add' := fun c₁ c₂ => by
         ext x
-        simp only [add_smul, coe_smul_rightₗ, add_apply, smul_right_apply, LinearMap.add_apply]
+        simp only [add_smul, coe_smulRightₗ, add_apply, smulRight_apply, LinearMap.add_apply]
       map_smul' := fun m c => by
         ext x
-        simp only [smul_smul, coe_smul_rightₗ, Algebra.id.smul_eq_mul, coe_smul', smul_right_apply,
+        simp only [smul_smul, coe_smulRightₗ, Algebra.id.smul_eq_mul, coe_smul', smulRight_apply,
           LinearMap.smul_apply, RingHom.id_apply, Pi.smul_apply] }
-    1 fun c x => by simp only [coe_smul_rightₗ, one_mul, norm_smul_right_apply, LinearMap.coe_mk]
+    1 fun c x => by
+      simp only [coe_smulRightₗ, one_mul, norm_smulRight_apply, LinearMap.coe_mk, AddHom.coe_mk,
+        le_refl]
 set_option linter.uppercaseLean3 false in
 #align continuous_linear_map.smul_rightL ContinuousLinearMap.smulRightL
 
@@ -2148,8 +2158,8 @@ def arrowCongrSL (e₁₂ : E ≃SL[σ₁₂] F) (e₄₃ : H ≃SL[σ₄₃] G)
   {e₁₂.arrowCongrEquiv e₄₃ with -- given explicitly to help `simps`
     toFun := fun L => (e₄₃ : H →SL[σ₄₃] G).comp (L.comp (e₁₂.symm : F →SL[σ₂₁] E))
     invFun := fun L => (e₄₃.symm : G →SL[σ₃₄] H).comp (L.comp (e₁₂ : E →SL[σ₁₂] F))
-    map_add' := fun f g => by rw [add_comp, comp_add]
-    map_smul' := fun t f => by rw [smul_comp, comp_smulₛₗ]
+    map_add' := fun f g => by simp only [add_comp, comp_add]
+    map_smul' := fun t f => by simp only [smul_comp, comp_smulₛₗ]
     continuous_toFun := (continuous_id.clm_comp_const _).const_clm_comp _
     continuous_invFun := (continuous_id.clm_comp_const _).const_clm_comp _ }
 set_option linter.uppercaseLean3 false in

--- a/Mathlib/Analysis/NormedSpace/OperatorNorm.lean
+++ b/Mathlib/Analysis/NormedSpace/OperatorNorm.lean
@@ -811,11 +811,10 @@ def mkContinuous₂ (f : E →ₛₗ[σ₁₃] F →ₛₗ[σ₂₃] G) (C : ℝ
         ext z
         rw [ContinuousLinearMap.smul_apply, mkContinuous_apply, mkContinuous_apply, map_smulₛₗ,
           smul_apply] }
-    (max C 0) fun x =>
-    sorry
-    -- Porting FIXME: this proof needs fixing.
-    -- (mkContinuous_norm_le' _ _).trans_eq <| by
-    --   rw [max_mul_of_nonneg _ _ (norm_nonneg x), MulZeroClass.zero_mul]
+    (max C 0) fun x => by
+      dsimp
+      exact (mkContinuous_norm_le' _ _).trans_eq <| by
+        rw [max_mul_of_nonneg _ _ (norm_nonneg x), MulZeroClass.zero_mul]
 #align linear_map.mk_continuous₂ LinearMap.mkContinuous₂
 
 set_option synthInstance.etaExperiment true in
@@ -1122,13 +1121,14 @@ def prodMapL : (M₁ →L[𝕜] M₂) × (M₃ →L[𝕜] M₄) →L[𝕜] M₁ 
       refine ContinuousLinearMap.ext fun x => ?_
       -- Porting FIXME: this proof is broken. Mathport suggested:
       -- simp only [add_apply, coe_comp', coe_fst', Function.comp_apply, compL_apply, flip_apply,
-      --   coe_snd', inl_apply, inr_apply, Prod.mk_add_mk, add_zero, zero_add, coe_prod_map, Prod_map,
+      --   coe_snd', inl_apply, inr_apply, Prod.mk_add_mk, add_zero, zero_add, coe_prodMap', Prod_map,
       --   Prod.mk.inj_iff, eq_self_iff_true, and_self_iff]
       -- rfl
-      dsimp -- Frustratingly, in mathlib3 this gets us all the way to `⊢ (⇑φ x.fst, ⇑ψ x.snd) = (⇑φ x.fst + 0, 0 + ⇑ψ x.snd)`
+      -- Just a mess of trying to work things out here:
+      -- dsimp -- Frustratingly, in mathlib3 this gets us all the way to `⊢ (⇑φ x.fst, ⇑ψ x.snd) = (⇑φ x.fst + 0, 0 + ⇑ψ x.snd)`
       -- Lots of these simp lemmas seem to not be firing:
       simp only [add_apply, coe_comp', coe_fst', Function.comp_apply, compL_apply, flip_apply,
-        coe_snd', inl_apply, inr_apply, Prod.mk_add_mk, add_zero, zero_add, coe_prod_map, Prod_map,
+        coe_snd', inl_apply, inr_apply, Prod.mk_add_mk, add_zero, zero_add, coe_prodMap', Prod_map,
         Prod.mk.inj_iff, eq_self_iff_true, and_self_iff]
       -- We can:
       rw [add_apply]
@@ -1233,8 +1233,16 @@ theorem op_norm_mulLeftRight_apply_le (x : 𝕜') : ‖mulLeftRight 𝕜 𝕜' x
   op_norm_le_bound _ (norm_nonneg x) (op_norm_mulLeftRight_apply_apply_le 𝕜 𝕜' x)
 #align continuous_linear_map.op_norm_mul_left_right_apply_le ContinuousLinearMap.op_norm_mulLeftRight_apply_le
 
+#check topologicalSpace
+
+example : (topologicalSpace : TopologicalSpace (𝕜' →L[𝕜] 𝕜' →L[𝕜] 𝕜')) = UniformSpace.toTopologicalSpace := rfl
+example : (addCommMonoid : AddCommMonoid (𝕜' →L[𝕜] 𝕜' →L[𝕜] 𝕜')) = AddCommGroup.toAddCommMonoid := rfl
+#synth SeminormedAddCommGroup (𝕜' →L[𝕜] 𝕜' →L[𝕜] 𝕜')
+example : (module : Module 𝕜 (𝕜' →L[𝕜] 𝕜' →L[𝕜] 𝕜')) = NormedSpace.toModule := rfl
+
 -- Porting FIXME: why isn't this instance found?
 example : Norm (𝕜' →L[𝕜] 𝕜' →L[𝕜] 𝕜' →L[𝕜] 𝕜') := ContinuousLinearMap.hasOpNorm
+
 theorem op_norm_mulLeftRight_le : ‖mulLeftRight 𝕜 𝕜'‖ ≤ 1 :=
   op_norm_le_bound _ zero_le_one fun x => (one_mul ‖x‖).symm ▸ op_norm_mulLeftRight_apply_le 𝕜 𝕜' x
 #align continuous_linear_map.op_norm_mul_left_right_le ContinuousLinearMap.op_norm_mulLeftRight_le

--- a/Mathlib/Analysis/NormedSpace/OperatorNorm.lean
+++ b/Mathlib/Analysis/NormedSpace/OperatorNorm.lean
@@ -1079,15 +1079,13 @@ def precompL (L : E →L[𝕜] Fₗ →L[𝕜] Gₗ) : (Eₗ →L[𝕜] E) →L[
   (precompR Eₗ (flip L)).flip
 #align continuous_linear_map.precompL ContinuousLinearMap.precompL
 
--- Porting note: this instance should just be `inferInstance`,
--- and indeed simply unneeded.
-local instance : Norm (E →L[𝕜] (Eₗ →L[𝕜] Fₗ) →L[𝕜] Eₗ →L[𝕜] Gₗ) := by
-  exact @hasOpNorm _ _ E ((Eₗ →L[𝕜] Fₗ) →L[𝕜] Eₗ →L[𝕜] Gₗ) _ _ _ _ _ _ _
-
+-- Porting note: we need additional instances close at hand to get this to compile.
+local instance : SeminormedAddCommGroup ((Eₗ →L[𝕜] Fₗ) →L[𝕜] Eₗ →L[𝕜] Gₗ) := inferInstance in
+local instance : NormedSpace 𝕜 ((Eₗ →L[𝕜] Fₗ) →L[𝕜] Eₗ →L[𝕜] Gₗ) := inferInstance in
 set_option synthInstance.etaExperiment true in
 theorem norm_precompR_le (L : E →L[𝕜] Fₗ →L[𝕜] Gₗ) : ‖precompR Eₗ L‖ ≤ ‖L‖ :=
   calc
-    ‖precompR Eₗ L‖ ≤ ‖compL 𝕜 Eₗ Fₗ Gₗ‖ * ‖L‖ := op_norm_comp_le _ _
+    ‖precompR Eₗ L‖ ≤ ‖compL 𝕜 Eₗ Fₗ Gₗ‖ * ‖L‖ := op_norm_comp_le (compL 𝕜 Eₗ Fₗ Gₗ) L
     _ ≤ 1 * ‖L‖ := (mul_le_mul_of_nonneg_right (norm_compL_le _ _ _ _) (norm_nonneg _))
     _ = ‖L‖ := by rw [one_mul]
 #align continuous_linear_map.norm_precompR_le ContinuousLinearMap.norm_precompR_le

--- a/Mathlib/Analysis/NormedSpace/OperatorNorm.lean
+++ b/Mathlib/Analysis/NormedSpace/OperatorNorm.lean
@@ -203,9 +203,8 @@ theorem le_op_norm : ‖f x‖ ≤ ‖f‖ * ‖x‖ := by
   by_cases h : ‖x‖ = 0
   · rwa [h, MulZeroClass.mul_zero] at hC⊢
   have hlt : 0 < ‖x‖ := lt_of_le_of_ne (norm_nonneg x) (Ne.symm h)
-  exact
-    (div_le_iff hlt).mp
-      (le_csInf bounds_nonempty fun c ⟨_, hc⟩ => (div_le_iff hlt).mpr <| by apply hc)
+  exact (div_le_iff hlt).mp
+    (le_csInf bounds_nonempty fun c ⟨_, hc⟩ => (div_le_iff hlt).mpr <| by apply hc)
 #align continuous_linear_map.le_op_norm ContinuousLinearMap.le_op_norm
 
 theorem dist_le_op_norm (x y : E) : dist (f x) (f y) ≤ ‖f‖ * dist x y := by
@@ -409,9 +408,8 @@ instance toSeminormedAddCommGroup : SeminormedAddCommGroup (E →SL[σ₁₂] F)
 theorem nnnorm_def (f : E →SL[σ₁₂] F) : ‖f‖₊ = sInf { c | ∀ x, ‖f x‖₊ ≤ c * ‖x‖₊ } := by
   ext
   rw [NNReal.coe_sInf, coe_nnnorm, norm_def, NNReal.coe_image]
-  -- Porting note: this was `simp_rw`, and can probably be optimised.
-  simp [← NNReal.coe_le_coe, NNReal.coe_mul, coe_nnnorm, mem_setOf_eq, Subtype.coe_mk,
-    exists_prop]
+  simp_rw [← NNReal.coe_le_coe, NNReal.coe_mul, coe_nnnorm, mem_setOf_eq, Subtype.coe_mk,
+    exists_prop, NNReal.coe_mk, exists_prop]
 #align continuous_linear_map.nnnorm_def ContinuousLinearMap.nnnorm_def
 
 /-- If one controls the norm of every `A x`, then one controls the norm of `A`. -/
@@ -479,6 +477,7 @@ instance toNormedAlgebra : NormedAlgebra 𝕜 (E →L[𝕜] E) :=
     norm_smul_le := by
       intro c f
       apply op_norm_smul_le c f}
+#align continuous_linear_map.to_normed_algebra ContinuousLinearMap.toNormedAlgebra
 
 theorem le_op_nnnorm : ‖f x‖₊ ≤ ‖f‖₊ * ‖x‖₊ :=
   f.le_op_norm x
@@ -548,9 +547,8 @@ theorem sSup_unit_ball_eq_nnnorm {𝕜 𝕜₂ E F : Type _} [NormedAddCommGroup
     [SeminormedAddCommGroup F] [DenselyNormedField 𝕜] [NontriviallyNormedField 𝕜₂] {σ₁₂ : 𝕜 →+* 𝕜₂}
     [NormedSpace 𝕜 E] [NormedSpace 𝕜₂ F] [RingHomIsometric σ₁₂] (f : E →SL[σ₁₂] F) :
     sSup ((fun x => ‖f x‖₊) '' ball 0 1) = ‖f‖₊ := by
-  refine'
-    csSup_eq_of_forall_le_of_forall_lt_exists_gt ((nonempty_ball.mpr zero_lt_one).image _) _
-      fun ub hub => _
+  refine' csSup_eq_of_forall_le_of_forall_lt_exists_gt ((nonempty_ball.mpr zero_lt_one).image _) _
+    fun ub hub => _
   · rintro - ⟨x, hx, rfl⟩
     simpa only [mul_one] using f.le_op_norm_of_le (mem_ball_zero_iff.1 hx).le
   · obtain ⟨x, hx, hxf⟩ := f.exists_lt_apply_of_lt_op_nnnorm hub
@@ -654,42 +652,38 @@ end OpNorm
 
 section IsO
 
+set_option linter.uppercaseLean3 false
+
 variable [RingHomIsometric σ₁₂] (c : 𝕜) (f g : E →SL[σ₁₂] F) (h : F →SL[σ₂₃] G) (x y z : E)
 
 open Asymptotics
 
 theorem isBigOWith_id (l : Filter E) : IsBigOWith ‖f‖ l f fun x => x :=
   isBigOWith_of_le' _ f.le_op_norm
-set_option linter.uppercaseLean3 false in
 #align continuous_linear_map.is_O_with_id ContinuousLinearMap.isBigOWith_id
 
 theorem isBigO_id (l : Filter E) : f =O[l] fun x => x :=
   (f.isBigOWith_id l).isBigO
-set_option linter.uppercaseLean3 false in
 #align continuous_linear_map.is_O_id ContinuousLinearMap.isBigO_id
 
 theorem isBigOWith_comp [RingHomIsometric σ₂₃] {α : Type _} (g : F →SL[σ₂₃] G) (f : α → F)
     (l : Filter α) : IsBigOWith ‖g‖ l (fun x' => g (f x')) f :=
   (g.isBigOWith_id ⊤).comp_tendsto le_top
-set_option linter.uppercaseLean3 false in
 #align continuous_linear_map.is_O_with_comp ContinuousLinearMap.isBigOWith_comp
 
 theorem isBigO_comp [RingHomIsometric σ₂₃] {α : Type _} (g : F →SL[σ₂₃] G) (f : α → F)
     (l : Filter α) : (fun x' => g (f x')) =O[l] f :=
   (g.isBigOWith_comp f l).isBigO
-set_option linter.uppercaseLean3 false in
 #align continuous_linear_map.is_O_comp ContinuousLinearMap.isBigO_comp
 
 theorem isBigOWith_sub (f : E →SL[σ₁₂] F) (l : Filter E) (x : E) :
     IsBigOWith ‖f‖ l (fun x' => f (x' - x)) fun x' => x' - x :=
   f.isBigOWith_comp _ l
-set_option linter.uppercaseLean3 false in
 #align continuous_linear_map.is_O_with_sub ContinuousLinearMap.isBigOWith_sub
 
 theorem isBigO_sub (f : E →SL[σ₁₂] F) (l : Filter E) (x : E) :
     (fun x' => f (x' - x)) =O[l] fun x' => x' - x :=
   f.isBigO_comp _ l
-set_option linter.uppercaseLean3 false in
 #align continuous_linear_map.is_O_sub ContinuousLinearMap.isBigO_sub
 
 end IsO
@@ -814,8 +808,8 @@ theorem flip_smul (c : 𝕜₃) (f : E →SL[σ₁₃] F →SL[σ₂₃] G) : (c
 
 variable (E F G σ₁₃ σ₂₃)
 
-set_option maxHeartbeats 400000 in
-set_option synthInstance.maxHeartbeats 40000 in
+set_option maxHeartbeats 300000 in
+set_option synthInstance.maxHeartbeats 25000 in
 /-- Flip the order of arguments of a continuous bilinear map.
 This is a version bundled as a `LinearIsometryEquiv`.
 For an unbundled version see `ContinuousLinearMap.flip`. -/
@@ -831,13 +825,13 @@ def flipₗᵢ' : (E →SL[σ₁₃] F →SL[σ₂₃] G) ≃ₗᵢ[𝕜₃] F �
 
 variable {E F G σ₁₃ σ₂₃}
 
-set_option synthInstance.maxHeartbeats 40000 in
+set_option synthInstance.maxHeartbeats 25000 in
 @[simp]
 theorem flipₗᵢ'_symm : (flipₗᵢ' E F G σ₂₃ σ₁₃).symm = flipₗᵢ' F E G σ₁₃ σ₂₃ :=
   rfl
 #align continuous_linear_map.flipₗᵢ'_symm ContinuousLinearMap.flipₗᵢ'_symm
 
-set_option synthInstance.maxHeartbeats 80000 in
+set_option synthInstance.maxHeartbeats 75000 in
 @[simp]
 theorem coe_flipₗᵢ' : ⇑(flipₗᵢ' E F G σ₂₃ σ₁₃) = flip :=
   rfl
@@ -845,7 +839,7 @@ theorem coe_flipₗᵢ' : ⇑(flipₗᵢ' E F G σ₂₃ σ₁₃) = flip :=
 
 variable (𝕜 E Fₗ Gₗ)
 
-set_option maxHeartbeats 400000 in
+set_option maxHeartbeats 250000 in
 /-- Flip the order of arguments of a continuous bilinear map.
 This is a version bundled as a `LinearIsometryEquiv`.
 For an unbundled version see `ContinuousLinearMap.flip`. -/
@@ -866,7 +860,7 @@ theorem flipₗᵢ_symm : (flipₗᵢ 𝕜 E Fₗ Gₗ).symm = flipₗᵢ 𝕜 F
   rfl
 #align continuous_linear_map.flipₗᵢ_symm ContinuousLinearMap.flipₗᵢ_symm
 
-set_option synthInstance.maxHeartbeats 80000 in
+set_option synthInstance.maxHeartbeats 60000 in
 @[simp]
 theorem coe_flipₗᵢ : ⇑(flipₗᵢ 𝕜 E Fₗ Gₗ) = flip :=
   rfl
@@ -922,8 +916,8 @@ def compSL : (F →SL[σ₂₃] G) →L[𝕜₃] (E →SL[σ₁₂] F) →SL[σ�
 
 /-- Porting note: Local instance for `norm_compSL_le`.
 Should be by `inferInstance`, and indeed not be needed. -/
-local instance : Norm ((F →SL[σ₂₃] G) →L[𝕜₃] (E →SL[σ₁₂] F) →SL[σ₂₃] E →SL[σ₁₃] G) := by
-  exact @hasOpNorm _ _ (F →SL[σ₂₃] G) ((E →SL[σ₁₂] F) →SL[σ₂₃] E →SL[σ₁₃] G) _ _ _ _ _ _ _ in
+local instance : Norm ((F →SL[σ₂₃] G) →L[𝕜₃] (E →SL[σ₁₂] F) →SL[σ₂₃] E →SL[σ₁₃] G) :=
+  hasOpNorm (E := F →SL[σ₂₃] G) (F := (E →SL[σ₁₂] F) →SL[σ₂₃] E →SL[σ₁₃] G) in
 theorem norm_compSL_le : ‖compSL E F G σ₁₂ σ₂₃‖ ≤ 1 :=
   LinearMap.mkContinuous₂_norm_le _ zero_le_one _
 #align continuous_linear_map.norm_compSL_le ContinuousLinearMap.norm_compSL_le
@@ -958,8 +952,8 @@ def compL : (Fₗ →L[𝕜] Gₗ) →L[𝕜] (E →L[𝕜] Fₗ) →L[𝕜] E �
 
 /-- Porting note: Local instance for `norm_compL_le`.
 Should be by `inferInstance`, and indeed not be needed. -/
-local instance : Norm ((Fₗ →L[𝕜] Gₗ) →L[𝕜] (E →L[𝕜] Fₗ) →L[𝕜] E →L[𝕜] Gₗ) := by
-  exact @hasOpNorm _ _ (Fₗ →L[𝕜] Gₗ) ((E →L[𝕜] Fₗ) →L[𝕜] E →L[𝕜] Gₗ) _ _ _ _ _ _ _ in
+local instance : Norm ((Fₗ →L[𝕜] Gₗ) →L[𝕜] (E →L[𝕜] Fₗ) →L[𝕜] E →L[𝕜] Gₗ) :=
+  hasOpNorm (E := Fₗ →L[𝕜] Gₗ) (F := (E →L[𝕜] Fₗ) →L[𝕜] E →L[𝕜] Gₗ) in
 theorem norm_compL_le : ‖compL 𝕜 E Fₗ Gₗ‖ ≤ 1 :=
   norm_compSL_le _ _ _ _ _
 #align continuous_linear_map.norm_compL_le ContinuousLinearMap.norm_compL_le
@@ -982,23 +976,21 @@ def precompL (L : E →L[𝕜] Fₗ →L[𝕜] Gₗ) : (Eₗ →L[𝕜] E) →L[
   (precompR Eₗ (flip L)).flip
 #align continuous_linear_map.precompL ContinuousLinearMap.precompL
 
-/-- Porting note: Local instance for `norm_precompR_le`.
+/-- Porting note: Local instances for `norm_precompR_le`.
 Should be by `inferInstance`, and indeed not be needed. -/
 local instance : SeminormedAddCommGroup ((Eₗ →L[𝕜] Fₗ) →L[𝕜] Eₗ →L[𝕜] Gₗ) := inferInstance in
-/-- Porting note: Local instance for `norm_precompR_le`.
-Should be by `inferInstance`, and indeed not be needed. -/
 local instance : NormedSpace 𝕜 ((Eₗ →L[𝕜] Fₗ) →L[𝕜] Eₗ →L[𝕜] Gₗ) := inferInstance in
 theorem norm_precompR_le (L : E →L[𝕜] Fₗ →L[𝕜] Gₗ) : ‖precompR Eₗ L‖ ≤ ‖L‖ :=
   calc
-    ‖precompR Eₗ L‖ ≤ ‖compL 𝕜 Eₗ Fₗ Gₗ‖ * ‖L‖ := op_norm_comp_le (compL 𝕜 Eₗ Fₗ Gₗ) L
+    ‖precompR Eₗ L‖ ≤ ‖compL 𝕜 Eₗ Fₗ Gₗ‖ * ‖L‖ := op_norm_comp_le _ _
     _ ≤ 1 * ‖L‖ := (mul_le_mul_of_nonneg_right (norm_compL_le _ _ _ _) (norm_nonneg _))
     _ = ‖L‖ := by rw [one_mul]
 #align continuous_linear_map.norm_precompR_le ContinuousLinearMap.norm_precompR_le
 
 /-- Porting note: Local instance for `norm_precompL_le`.
 Should be by `inferInstance`, and indeed not be needed. -/
-local instance : Norm ((Eₗ →L[𝕜] E) →L[𝕜] Fₗ →L[𝕜] Eₗ →L[𝕜] Gₗ) := by
-  exact @hasOpNorm _ _ (Eₗ →L[𝕜] E) (Fₗ →L[𝕜] Eₗ →L[𝕜] Gₗ) _ _ _ _ _ _ _ in
+local instance : Norm ((Eₗ →L[𝕜] E) →L[𝕜] Fₗ →L[𝕜] Eₗ →L[𝕜] Gₗ) :=
+  hasOpNorm (E := Eₗ →L[𝕜] E) (F := Fₗ →L[𝕜] Eₗ →L[𝕜] Gₗ) in
 theorem norm_precompL_le (L : E →L[𝕜] Fₗ →L[𝕜] Gₗ) : ‖precompL Eₗ L‖ ≤ ‖L‖ := by
   rw [precompL, op_norm_flip, ← op_norm_flip L]
   exact norm_precompR_le _ L.flip
@@ -1014,9 +1006,7 @@ variable (M₁ : Type u₁) [SeminormedAddCommGroup M₁] [NormedSpace 𝕜 M₁
 
 variable {Eₗ} (𝕜)
 
-set_option linter.uppercaseLean3 false
-
-set_option maxHeartbeats 800000 in
+set_option maxHeartbeats 750000 in
 /-- `ContinuousLinearMap.prodMap` as a continuous linear map. -/
 def prodMapL : (M₁ →L[𝕜] M₂) × (M₃ →L[𝕜] M₄) →L[𝕜] M₁ × M₃ →L[𝕜] M₂ × M₄ :=
   ContinuousLinearMap.copy
@@ -1036,7 +1026,7 @@ def prodMapL : (M₁ →L[𝕜] M₂) × (M₃ →L[𝕜] M₄) →L[𝕜] M₁ 
     (fun p : (M₁ →L[𝕜] M₂) × (M₃ →L[𝕜] M₄) => p.1.prodMap p.2) (by
       apply funext
       rintro ⟨φ, ψ⟩
-      refine ContinuousLinearMap.ext fun ⟨x₁, x₂⟩ => ?_
+      refine' ContinuousLinearMap.ext fun ⟨x₁, x₂⟩ => _
       -- Porting note: mathport suggested:
       -- ```
       -- simp only [add_apply, coe_comp', coe_fst', Function.comp_apply, compL_apply, flip_apply,
@@ -1050,13 +1040,9 @@ def prodMapL : (M₁ →L[𝕜] M₂) × (M₃ →L[𝕜] M₄) →L[𝕜] M₁ 
       -- simp
       -- ```
       -- Here neither `dsimp` or `simp` seem to make progress.
-      rw [add_apply, add_apply]
-      rw [comp_apply, comp_apply, comp_apply, comp_apply]
-      rw [compL_apply, compL_apply]
-      rw [flip_apply, flip_apply]
-      rw [compL_apply, compL_apply]
-      rw [comp_apply, comp_apply, comp_apply, comp_apply]
-      simp)
+      repeat first | rw [add_apply] | rw [comp_apply] | rw [flip_apply] | rw [compL_apply]
+      simp only [coe_prodMap', Prod_map, coe_fst', inl_apply, coe_snd', inr_apply, Prod.mk_add_mk,
+        add_zero, zero_add])
 #align continuous_linear_map.prod_mapL ContinuousLinearMap.prodMapL
 
 variable {M₁ M₂ M₃ M₄}
@@ -1148,8 +1134,8 @@ theorem op_norm_mulLeftRight_apply_le (x : 𝕜') : ‖mulLeftRight 𝕜 𝕜' x
 
 /-- Porting note: Local instance for `op_norm_mulLeftRight_le`.
 Should be by `inferInstance`, and indeed not be needed. -/
-local instance : Norm (𝕜' →L[𝕜] 𝕜' →L[𝕜] 𝕜' →L[𝕜] 𝕜') := by
-  exact @hasOpNorm _ _ 𝕜' (𝕜' →L[𝕜] 𝕜' →L[𝕜] 𝕜') _ _ _ _ _ _ _ in
+local instance : Norm (𝕜' →L[𝕜] 𝕜' →L[𝕜] 𝕜' →L[𝕜] 𝕜') :=
+  hasOpNorm (E := 𝕜') (F := 𝕜' →L[𝕜] 𝕜' →L[𝕜] 𝕜') in
 theorem op_norm_mulLeftRight_le : ‖mulLeftRight 𝕜 𝕜'‖ ≤ 1 :=
   op_norm_le_bound _ zero_le_one fun x => (one_mul ‖x‖).symm ▸ op_norm_mulLeftRight_apply_le 𝕜 𝕜' x
 #align continuous_linear_map.op_norm_mul_left_right_le ContinuousLinearMap.op_norm_mulLeftRight_le
@@ -1253,7 +1239,7 @@ def restrictScalarsIsometry : (E →L[𝕜] Fₗ) →ₗᵢ[𝕜''] E →L[𝕜'
   ⟨restrictScalarsₗ 𝕜 E Fₗ 𝕜' 𝕜'', norm_restrictScalars⟩
 #align continuous_linear_map.restrict_scalars_isometry ContinuousLinearMap.restrictScalarsIsometry
 
-variable {𝕜 E Fₗ 𝕜' 𝕜''}
+variable {𝕜''}
 
 @[simp]
 theorem coe_restrictScalarsIsometry :
@@ -1267,28 +1253,26 @@ theorem restrictScalarsIsometry_toLinearMap :
   rfl
 #align continuous_linear_map.restrict_scalars_isometry_to_linear_map ContinuousLinearMap.restrictScalarsIsometry_toLinearMap
 
-variable (𝕜 E Fₗ 𝕜' 𝕜'')
+variable (𝕜'')
+
+set_option linter.uppercaseLean3 false
 
 /-- `ContinuousLinearMap.restrictScalars` as a `ContinuousLinearMap`. -/
 def restrictScalarsL : (E →L[𝕜] Fₗ) →L[𝕜''] E →L[𝕜'] Fₗ :=
   (restrictScalarsIsometry 𝕜 E Fₗ 𝕜' 𝕜'').toContinuousLinearMap
-set_option linter.uppercaseLean3 false in
 #align continuous_linear_map.restrict_scalarsL ContinuousLinearMap.restrictScalarsL
 
 variable {𝕜 E Fₗ 𝕜' 𝕜''}
 
 @[simp]
-theorem coe_restrictScalarsL :
-    (restrictScalarsL 𝕜 E Fₗ 𝕜' 𝕜'' : (E →L[𝕜] Fₗ) →ₗ[𝕜''] E →L[𝕜'] Fₗ) =
-      restrictScalarsₗ 𝕜 E Fₗ 𝕜' 𝕜'' :=
+theorem coe_restrictScalarsL : (restrictScalarsL 𝕜 E Fₗ 𝕜' 𝕜'' : (E →L[𝕜] Fₗ) →ₗ[𝕜''] E →L[𝕜'] Fₗ) =
+    restrictScalarsₗ 𝕜 E Fₗ 𝕜' 𝕜'' :=
   rfl
-set_option linter.uppercaseLean3 false in
 #align continuous_linear_map.coe_restrict_scalarsL ContinuousLinearMap.coe_restrictScalarsL
 
 @[simp]
 theorem coe_restrict_scalarsL' : ⇑(restrictScalarsL 𝕜 E Fₗ 𝕜' 𝕜'') = restrictScalars 𝕜' :=
   rfl
-set_option linter.uppercaseLean3 false in
 #align continuous_linear_map.coe_restrict_scalarsL' ContinuousLinearMap.coe_restrict_scalarsL'
 
 end RestrictScalars
@@ -1306,45 +1290,38 @@ end Submodule
 
 namespace ContinuousLinearEquiv
 
+set_option linter.uppercaseLean3 false
+
 section
 
 variable {σ₂₁ : 𝕜₂ →+* 𝕜} [RingHomInvPair σ₁₂ σ₂₁] [RingHomInvPair σ₂₁ σ₁₂] [RingHomIsometric σ₁₂]
+
 variable (e : E ≃SL[σ₁₂] F)
 
 protected theorem lipschitz : LipschitzWith ‖(e : E →SL[σ₁₂] F)‖₊ e :=
   (e : E →SL[σ₁₂] F).lipschitz
 #align continuous_linear_equiv.lipschitz ContinuousLinearEquiv.lipschitz
 
-theorem isBigO_comp (e : E ≃SL[σ₁₂] F) {α : Type _} (f : α → E) (l : Filter α) :
-    (fun x' => e (f x')) =O[l] f :=
+theorem isBigO_comp {α : Type _} (f : α → E) (l : Filter α) : (fun x' => e (f x')) =O[l] f :=
   (e : E →SL[σ₁₂] F).isBigO_comp f l
-set_option linter.uppercaseLean3 false in
 #align continuous_linear_equiv.is_O_comp ContinuousLinearEquiv.isBigO_comp
 
-theorem isBigO_sub (e : E ≃SL[σ₁₂] F) (l : Filter E) (x : E) :
-    (fun x' => e (x' - x)) =O[l] fun x' => x' - x :=
+theorem isBigO_sub (l : Filter E) (x : E) : (fun x' => e (x' - x)) =O[l] fun x' => x' - x :=
   (e : E →SL[σ₁₂] F).isBigO_sub l x
-set_option linter.uppercaseLean3 false in
 #align continuous_linear_equiv.is_O_sub ContinuousLinearEquiv.isBigO_sub
 
 end
 
 variable {σ₂₁ : 𝕜₂ →+* 𝕜} [RingHomInvPair σ₁₂ σ₂₁] [RingHomInvPair σ₂₁ σ₁₂]
 
-variable [RingHomIsometric σ₂₁]
+variable [RingHomIsometric σ₂₁] (e : E ≃SL[σ₁₂] F)
 
-variable (e : E ≃SL[σ₁₂] F)
-
-theorem isBigO_comp_rev (e : E ≃SL[σ₁₂] F) {α : Type _} (f : α → E) (l : Filter α) :
-    f =O[l] fun x' => e (f x') :=
+theorem isBigO_comp_rev {α : Type _} (f : α → E) (l : Filter α) : f =O[l] fun x' => e (f x') :=
   (e.symm.isBigO_comp _ l).congr_left fun _ => e.symm_apply_apply _
-set_option linter.uppercaseLean3 false in
 #align continuous_linear_equiv.is_O_comp_rev ContinuousLinearEquiv.isBigO_comp_rev
 
-theorem isBigO_sub_rev (e : E ≃SL[σ₁₂] F) (l : Filter E) (x : E) :
-    (fun x' => x' - x) =O[l] fun x' => e (x' - x) :=
+theorem isBigO_sub_rev (l : Filter E) (x : E) : (fun x' => x' - x) =O[l] fun x' => e (x' - x) :=
   e.isBigO_comp_rev _ _
-set_option linter.uppercaseLean3 false in
 #align continuous_linear_equiv.is_O_sub_rev ContinuousLinearEquiv.isBigO_sub_rev
 
 end ContinuousLinearEquiv
@@ -1447,10 +1424,8 @@ theorem antilipschitz_of_comap_nhds_le [h : RingHomIsometric σ₁₂] (f : E �
   refine' ⟨ε⁻¹ * ‖c‖₊, AddMonoidHomClass.antilipschitz_of_bound f fun x => _⟩
   by_cases hx : f x = 0
   · rw [← hx] at hf
-    obtain rfl : x = 0 :=
-      Specializes.eq
-        (specializes_iff_pure.2 <|
-          ((Filter.tendsto_pure_pure _ _).mono_right (pure_le_nhds _)).le_comap.trans hf)
+    obtain rfl : x = 0 := Specializes.eq (specializes_iff_pure.2 <|
+      ((Filter.tendsto_pure_pure _ _).mono_right (pure_le_nhds _)).le_comap.trans hf)
     exact norm_zero.trans_le (mul_nonneg (NNReal.coe_nonneg _) (norm_nonneg _))
   have hc₀ : c ≠ 0 := norm_pos_iff.1 (one_pos.trans hc)
   rw [← h.1] at hc
@@ -1474,12 +1449,10 @@ open Set Real
 /-- An operator is zero iff its norm vanishes. -/
 theorem op_norm_zero_iff [RingHomIsometric σ₁₂] : ‖f‖ = 0 ↔ f = 0 :=
   Iff.intro
-    (fun hn =>
-      ContinuousLinearMap.ext fun x =>
-        norm_le_zero_iff.1
-          (calc
-            _ ≤ ‖f‖ * ‖x‖ := le_op_norm _ _
-            _ = _ := by rw [hn, MulZeroClass.zero_mul]))
+    (fun hn => ContinuousLinearMap.ext fun x => norm_le_zero_iff.1
+      (calc
+        _ ≤ ‖f‖ * ‖x‖ := le_op_norm _ _
+        _ = _ := by rw [hn, MulZeroClass.zero_mul]))
     (by
       rintro rfl
       exact op_norm_zero)
@@ -1604,7 +1577,7 @@ instance [CompleteSpace F] : CompleteSpace (E' →SL[σ₁₂] F) := by
   set Glin : E' →SL[σ₁₂] F :=
     ofTendstoOfBoundedRange _ _ (tendsto_pi_nhds.mpr hG) hf.bounded_range
   -- Finally, `f n` converges to `Glin` in norm because of
-  -- `ContinuousLinearMap.tendsto_of_tendsto_pointwise_of_cauchy_seq`
+  -- `ContinuousLinearMap.tendsto_of_tendsto_pointwise_of_cauchySeq`
   exact ⟨Glin, tendsto_of_tendsto_pointwise_of_cauchySeq (tendsto_pi_nhds.2 hG) hf⟩
 
 /-- Let `s` be a bounded set in the space of continuous (semi)linear maps `E →SL[σ] F` taking values
@@ -1647,8 +1620,7 @@ image under coercion to functions `E → F` is a compact set. We don't have a na
 with weak-* topology in `mathlib`, so we use an equivalent condition (see `isClosed_induced_iff'`).
 -/
 theorem isCompact_image_coe_of_bounded_of_weak_closed [ProperSpace F] {s : Set (E' →SL[σ₁₂] F)}
-    (hb : Bounded s)
-    (hc : ∀ f : E' →SL[σ₁₂] F,
+    (hb : Bounded s) (hc : ∀ f : E' →SL[σ₁₂] F,
       (⇑f : E' → F) ∈ closure (((↑) : (E' →SL[σ₁₂] F) → E' → F) '' s) → f ∈ s) :
     IsCompact (((↑) : (E' →SL[σ₁₂] F) → E' → F) '' s) :=
   isCompact_image_coe_of_bounded_of_closed_image hb <|
@@ -1698,18 +1670,15 @@ variable (h_e : UniformInducing e)
 /-- Extension of a continuous linear map `f : E →SL[σ₁₂] F`, with `E` a normed space and `F` a
 complete normed space, along a uniform and dense embedding `e : E →L[𝕜] Fₗ`.  -/
 def extend : Fₗ →SL[σ₁₂] F :=
-  have cont :=
-    (-- extension of `f` is continuous
-        uniformContinuous_uniformly_extend
-        h_e h_dense f.uniformContinuous).continuous
+  -- extension of `f` is continuous
+  have cont := (uniformContinuous_uniformly_extend h_e h_dense f.uniformContinuous).continuous
   -- extension of `f` agrees with `f` on the domain of the embedding `e`
   have eq := uniformly_extend_of_ind h_e h_dense f.uniformContinuous
   { toFun := (h_e.denseInducing h_dense).extend f
     map_add' := by
       refine' h_dense.induction_on₂ _ _
-      · exact
-          isClosed_eq (cont.comp continuous_add)
-            ((cont.comp continuous_fst).add (cont.comp continuous_snd))
+      · exact isClosed_eq (cont.comp continuous_add)
+          ((cont.comp continuous_fst).add (cont.comp continuous_snd))
       · intro x y
         simp only [eq, ← e.map_add]
         exact f.map_add _ _
@@ -1846,7 +1815,7 @@ is the product of the norms. -/
 @[simp]
 theorem norm_smulRight_apply (c : E →L[𝕜] 𝕜) (f : Fₗ) : ‖smulRight c f‖ = ‖c‖ * ‖f‖ := by
   refine' le_antisymm _ _
-  · refine op_norm_le_bound _ (mul_nonneg (norm_nonneg _) (norm_nonneg _)) fun x => ?_
+  · refine' op_norm_le_bound _ (mul_nonneg (norm_nonneg _) (norm_nonneg _)) fun x => _
     calc
       ‖c x • f‖ = ‖c x‖ * ‖f‖ := norm_smul _ _
       _ ≤ ‖c‖ * ‖x‖ * ‖f‖ := (mul_le_mul_of_nonneg_right (le_op_norm _ _) (norm_nonneg _))
@@ -1855,7 +1824,7 @@ theorem norm_smulRight_apply (c : E →L[𝕜] 𝕜) (f : Fₗ) : ‖smulRight c
     · simp [h]
     · have : 0 < ‖f‖ := norm_pos_iff.2 h
       rw [← le_div_iff this]
-      refine op_norm_le_bound _ (div_nonneg (norm_nonneg _) (norm_nonneg f)) fun x => ?_
+      refine' op_norm_le_bound _ (div_nonneg (norm_nonneg _) (norm_nonneg f)) fun x => _
       rw [div_mul_eq_mul_div, le_div_iff this]
       calc
         ‖c x‖ * ‖f‖ = ‖c x • f‖ := (norm_smul _ _).symm
@@ -1872,8 +1841,10 @@ theorem nnnorm_smulRight_apply (c : E →L[𝕜] 𝕜) (f : Fₗ) : ‖smulRight
 
 variable (𝕜 E Fₗ)
 
+set_option linter.uppercaseLean3 false
+
 /-- `ContinuousLinearMap.smulRight` as a continuous trilinear map:
-`smul_rightL (c : E →L[𝕜] 𝕜) (f : F) (x : E) = c x • f`. -/
+`smulRightL (c : E →L[𝕜] 𝕜) (f : F) (x : E) = c x • f`. -/
 def smulRightL : (E →L[𝕜] 𝕜) →L[𝕜] Fₗ →L[𝕜] E →L[𝕜] Fₗ :=
   LinearMap.mkContinuous₂
     { toFun := smulRightₗ
@@ -1887,7 +1858,6 @@ def smulRightL : (E →L[𝕜] 𝕜) →L[𝕜] Fₗ →L[𝕜] E →L[𝕜] F�
     1 fun c x => by
       simp only [coe_smulRightₗ, one_mul, norm_smulRight_apply, LinearMap.coe_mk, AddHom.coe_mk,
         le_refl]
-set_option linter.uppercaseLean3 false in
 #align continuous_linear_map.smul_rightL ContinuousLinearMap.smulRightL
 
 variable {𝕜 E Fₗ}
@@ -1895,13 +1865,11 @@ variable {𝕜 E Fₗ}
 @[simp]
 theorem norm_smulRightL_apply (c : E →L[𝕜] 𝕜) (f : Fₗ) : ‖smulRightL 𝕜 E Fₗ c f‖ = ‖c‖ * ‖f‖ :=
   norm_smulRight_apply c f
-set_option linter.uppercaseLean3 false in
 #align continuous_linear_map.norm_smul_rightL_apply ContinuousLinearMap.norm_smulRightL_apply
 
 @[simp]
 theorem norm_smulRightL (c : E →L[𝕜] 𝕜) [Nontrivial Fₗ] : ‖smulRightL 𝕜 E Fₗ c‖ = ‖c‖ :=
   ContinuousLinearMap.homothety_norm _ c.norm_smulRight_apply
-set_option linter.uppercaseLean3 false in
 #align continuous_linear_map.norm_smul_rightL ContinuousLinearMap.norm_smulRightL
 
 variable (𝕜) (𝕜' : Type _)

--- a/Mathlib/Analysis/NormedSpace/OperatorNorm.lean
+++ b/Mathlib/Analysis/NormedSpace/OperatorNorm.lean
@@ -71,7 +71,6 @@ theorem SemilinearMapClass.bound_of_shell_semi_normed [SemilinearMapClass 𝓕 �
     (hf : ∀ x, ε / ‖c‖ ≤ ‖x‖ → ‖x‖ < ε → ‖f x‖ ≤ C * ‖x‖) {x : E} (hx : ‖x‖ ≠ 0) :
     ‖f x‖ ≤ C * ‖x‖ := by
   rcases rescale_to_shell_semi_normed hc ε_pos hx with ⟨δ, hδ, δxle, leδx, _⟩
-  have := hf (δ • x) leδx δxle
   simpa only [map_smulₛₗ, norm_smul, mul_left_comm C, mul_le_mul_left (norm_pos_iff.2 hδ),
     RingHomIsometric.is_iso] using hf (δ • x) leδx δxle
 #align semilinear_map_class.bound_of_shell_semi_normed SemilinearMapClass.bound_of_shell_semi_normed
@@ -1011,11 +1010,10 @@ def compSL : (F →SL[σ₂₃] G) →L[𝕜₃] (E →SL[σ₁₂] F) →SL[σ�
     1 fun f g => by simpa only [one_mul] using op_norm_comp_le f g
 #align continuous_linear_map.compSL ContinuousLinearMap.compSL
 
--- Porting note: this instance should just be `inferInstance`,
--- and indeed simply unneeded.
+/-- Porting note: Local instance for `norm_compSL_le`.
+Should be by `inferInstance`, and indeed not be needed. -/
 local instance : Norm ((F →SL[σ₂₃] G) →L[𝕜₃] (E →SL[σ₁₂] F) →SL[σ₂₃] E →SL[σ₁₃] G) := by
-  exact @hasOpNorm _ _ (F →SL[σ₂₃] G) ((E →SL[σ₁₂] F) →SL[σ₂₃] E →SL[σ₁₃] G) _ _ _ _ _ _ _
-
+  exact @hasOpNorm _ _ (F →SL[σ₂₃] G) ((E →SL[σ₁₂] F) →SL[σ₂₃] E →SL[σ₁₃] G) _ _ _ _ _ _ _ in
 set_option synthInstance.etaExperiment true in
 theorem norm_compSL_le : ‖compSL E F G σ₁₂ σ₂₃‖ ≤ 1 :=
   LinearMap.mkContinuous₂_norm_le _ zero_le_one _
@@ -1053,6 +1051,10 @@ def compL : (Fₗ →L[𝕜] Gₗ) →L[𝕜] (E →L[𝕜] Fₗ) →L[𝕜] E �
   compSL E Fₗ Gₗ (RingHom.id 𝕜) (RingHom.id 𝕜)
 #align continuous_linear_map.compL ContinuousLinearMap.compL
 
+/-- Porting note: Local instance for `norm_compL_le`.
+Should be by `inferInstance`, and indeed not be needed. -/
+local instance : Norm ((Fₗ →L[𝕜] Gₗ) →L[𝕜] (E →L[𝕜] Fₗ) →L[𝕜] E →L[𝕜] Gₗ) := by
+  exact @hasOpNorm _ _ (Fₗ →L[𝕜] Gₗ) ((E →L[𝕜] Fₗ) →L[𝕜] E →L[𝕜] Gₗ) _ _ _ _ _ _ _ in
 set_option synthInstance.etaExperiment true in
 theorem norm_compL_le : ‖compL 𝕜 E Fₗ Gₗ‖ ≤ 1 :=
   norm_compSL_le _ _ _ _ _
@@ -1079,10 +1081,13 @@ def precompL (L : E →L[𝕜] Fₗ →L[𝕜] Gₗ) : (Eₗ →L[𝕜] E) →L[
   (precompR Eₗ (flip L)).flip
 #align continuous_linear_map.precompL ContinuousLinearMap.precompL
 
--- Porting note: we need additional instances close at hand to get this to compile.
-local instance : SeminormedAddCommGroup ((Eₗ →L[𝕜] Fₗ) →L[𝕜] Eₗ →L[𝕜] Gₗ) := inferInstance in
-local instance : NormedSpace 𝕜 ((Eₗ →L[𝕜] Fₗ) →L[𝕜] Eₗ →L[𝕜] Gₗ) := inferInstance in
 set_option synthInstance.etaExperiment true in
+/-- Porting note: Local instance for `norm_precompR_le`.
+Should be by `inferInstance`, and indeed not be needed. -/
+local instance : SeminormedAddCommGroup ((Eₗ →L[𝕜] Fₗ) →L[𝕜] Eₗ →L[𝕜] Gₗ) := inferInstance in
+/-- Porting note: Local instance for `norm_precompR_le`.
+Should be by `inferInstance`, and indeed not be needed. -/
+local instance : NormedSpace 𝕜 ((Eₗ →L[𝕜] Fₗ) →L[𝕜] Eₗ →L[𝕜] Gₗ) := inferInstance in
 theorem norm_precompR_le (L : E →L[𝕜] Fₗ →L[𝕜] Gₗ) : ‖precompR Eₗ L‖ ≤ ‖L‖ :=
   calc
     ‖precompR Eₗ L‖ ≤ ‖compL 𝕜 Eₗ Fₗ Gₗ‖ * ‖L‖ := op_norm_comp_le (compL 𝕜 Eₗ Fₗ Gₗ) L
@@ -1090,9 +1095,10 @@ theorem norm_precompR_le (L : E →L[𝕜] Fₗ →L[𝕜] Gₗ) : ‖precompR E
     _ = ‖L‖ := by rw [one_mul]
 #align continuous_linear_map.norm_precompR_le ContinuousLinearMap.norm_precompR_le
 
+/-- Porting note: Local instance for `norm_precompL_le`.
+Should be by `inferInstance`, and indeed not be needed. -/
 local instance : Norm ((Eₗ →L[𝕜] E) →L[𝕜] Fₗ →L[𝕜] Eₗ →L[𝕜] Gₗ) := by
-  exact @hasOpNorm _ _ (Eₗ →L[𝕜] E) (Fₗ →L[𝕜] Eₗ →L[𝕜] Gₗ) _ _ _ _ _ _ _
-
+  exact @hasOpNorm _ _ (Eₗ →L[𝕜] E) (Fₗ →L[𝕜] Eₗ →L[𝕜] Gₗ) _ _ _ _ _ _ _ in
 set_option synthInstance.etaExperiment true in
 theorem norm_precompL_le (L : E →L[𝕜] Fₗ →L[𝕜] Gₗ) : ‖precompL Eₗ L‖ ≤ ‖L‖ := by
   rw [precompL, op_norm_flip, ← op_norm_flip L]
@@ -1252,11 +1258,10 @@ theorem op_norm_mulLeftRight_apply_le (x : 𝕜') : ‖mulLeftRight 𝕜 𝕜' x
   op_norm_le_bound _ (norm_nonneg x) (op_norm_mulLeftRight_apply_apply_le 𝕜 𝕜' x)
 #align continuous_linear_map.op_norm_mul_left_right_apply_le ContinuousLinearMap.op_norm_mulLeftRight_apply_le
 
--- Porting note: this instance should just be `inferInstance`,
--- and indeed simply unneeded.
+/-- Porting note: Local instance for `op_norm_mulLeftRight_le`.
+Should be by `inferInstance`, and indeed not be needed. -/
 local instance : Norm (𝕜' →L[𝕜] 𝕜' →L[𝕜] 𝕜' →L[𝕜] 𝕜') := by
-  exact @hasOpNorm _ _ 𝕜' (𝕜' →L[𝕜] 𝕜' →L[𝕜] 𝕜') _ _ _ _ _ _ _
-
+  exact @hasOpNorm _ _ 𝕜' (𝕜' →L[𝕜] 𝕜' →L[𝕜] 𝕜') _ _ _ _ _ _ _ in
 theorem op_norm_mulLeftRight_le : ‖mulLeftRight 𝕜 𝕜'‖ ≤ 1 :=
   op_norm_le_bound _ zero_le_one fun x => (one_mul ‖x‖).symm ▸ op_norm_mulLeftRight_apply_le 𝕜 𝕜' x
 #align continuous_linear_map.op_norm_mul_left_right_le ContinuousLinearMap.op_norm_mulLeftRight_le
@@ -1886,9 +1891,10 @@ section
 
 variable {N : ℝ≥0} (h_e : ∀ x, ‖x‖ ≤ N * ‖e x‖) [RingHomIsometric σ₁₂]
 
+set_option quotPrecheck false in
 -- Porting note: this should be `local notation`, not `scoped notation`,
 -- as we don't want it beyond the next declaration, but that causes errors.
-set_option quotPrecheck false in
+/-- Convenient notation for `op_norm_extend_le`. -/
 scoped notation "ψ" => f.extend e h_dense (uniformEmbedding_of_bound _ h_e).toUniformInducing
 
 /-- If a dense embedding `e : E →L[𝕜] G` expands the norm by a constant factor `N⁻¹`, then the

--- a/Mathlib/Analysis/NormedSpace/OperatorNorm.lean
+++ b/Mathlib/Analysis/NormedSpace/OperatorNorm.lean
@@ -376,9 +376,9 @@ attribute [-instance] ContinuousLinearMap.uniformSpace
 attribute [local instance] ContinuousLinearMap.tmpSeminormedAddCommGroup
 
 set_option synthInstance.etaExperiment true in
-protected theorem tmp_topologicalAddGroup : TopologicalAddGroup (E →SL[σ₁₂] F) :=
+protected theorem tmpTopologicalAddGroup : TopologicalAddGroup (E →SL[σ₁₂] F) :=
   inferInstance
-#align continuous_linear_map.tmp_topological_add_group ContinuousLinearMap.tmp_topologicalAddGroup
+#align continuous_linear_map.tmp_topological_add_group ContinuousLinearMap.tmpTopologicalAddGroup
 
 set_option synthInstance.etaExperiment true in
 protected theorem tmp_closedBall_div_subset {a b : ℝ} (ha : 0 < a) (hb : 0 < b) :
@@ -403,9 +403,8 @@ protected theorem tmp_topology_eq :
       ((@Metric.nhds_basis_closedBall _ ContinuousLinearMap.tmpPseudoMetricSpace 0).ext
         (ContinuousLinearMap.hasBasis_nhds_zero_of_basis Metric.nhds_basis_closedBall) _ _)
   · rcases NormedField.exists_norm_lt_one 𝕜 with ⟨c, hc₀, hc₁⟩
-    refine' fun ε hε =>
-      ⟨⟨closed_ball 0 (1 / ‖c‖), ε⟩, ⟨NormedSpace.isVonNBounded_closedBall _ _ _, hε⟩, fun f hf =>
-        _⟩
+    refine' fun ε hε => ⟨⟨closedBall 0 (1 / ‖c‖), ε⟩,
+      ⟨NormedSpace.isVonNBounded_closedBall _ _ _, hε⟩, fun f hf => _⟩
     change ∀ x, _ at hf
     simp_rw [mem_closedBall_zero_iff] at hf
     rw [@mem_closedBall_zero_iff _ SeminormedAddCommGroup.toSeminormedAddGroup]
@@ -413,11 +412,10 @@ protected theorem tmp_topology_eq :
     rw [div_mul_cancel 1 hc₀.ne.symm] at hx₁
     exact (hf x hxc.le).trans (le_mul_of_one_le_right hε.le hx₁)
   · rintro ⟨S, ε⟩ ⟨hS, hε⟩
-    rw [NormedSpace.isVonNBounded_iff, ← bounded_iff_is_bounded] at hS
+    rw [NormedSpace.isVonNBounded_iff, ← bounded_iff_isBounded] at hS
     rcases hS.subset_ball_lt 0 0 with ⟨δ, hδ, hSδ⟩
-    exact
-      ⟨ε / δ, div_pos hε hδ,
-        (ContinuousLinearMap.tmp_closedBall_div_subset hε hδ).trans fun f hf x hx => hf x <| hSδ hx⟩
+    exact ⟨ε / δ, div_pos hε hδ,
+      (ContinuousLinearMap.tmp_closedBall_div_subset hε hδ).trans fun f hf x hx => hf x <| hSδ hx⟩
 #align continuous_linear_map.tmp_topology_eq ContinuousLinearMap.tmp_topology_eq
 
 set_option synthInstance.etaExperiment true in
@@ -426,7 +424,7 @@ protected theorem tmpUniformSpace_eq :
       ContinuousLinearMap.uniformSpace := by
   rw [← @UniformAddGroup.toUniformSpace_eq _ ContinuousLinearMap.tmpUniformSpace, ←
     @UniformAddGroup.toUniformSpace_eq _ ContinuousLinearMap.uniformSpace]
-  congr 1
+  congr! 1
   exact ContinuousLinearMap.tmp_topology_eq
 #align continuous_linear_map.tmp_uniform_space_eq ContinuousLinearMap.tmpUniformSpace_eq
 
@@ -845,7 +843,6 @@ private theorem le_norm_flip (f : E →SL[σ₁₃] F →SL[σ₂₃] G) : ‖f�
   f.op_norm_le_bound₂ (norm_nonneg _) fun x y => by
     rw [mul_right_comm]
     exact (flip f).le_op_norm₂ y x
-#align continuous_linear_map.le_norm_flip continuous_linear_map.le_norm_flip
 
 set_option synthInstance.etaExperiment true in
 @[simp]
@@ -1152,21 +1149,25 @@ variable (𝕜) (𝕜' : Type _) [NonUnitalSeminormedRing 𝕜']
 
 variable [NormedSpace 𝕜 𝕜'] [IsScalarTower 𝕜 𝕜' 𝕜'] [SMulCommClass 𝕜 𝕜' 𝕜']
 
+set_option synthInstance.etaExperiment true in
 /-- Multiplication in a non-unital normed algebra as a continuous bilinear map. -/
 def mul : 𝕜' →L[𝕜] 𝕜' →L[𝕜] 𝕜' :=
   (LinearMap.mul 𝕜 𝕜').mkContinuous₂ 1 fun x y => by simpa using norm_mul_le x y
 #align continuous_linear_map.mul ContinuousLinearMap.mul
 
+set_option synthInstance.etaExperiment true in
 @[simp]
 theorem mul_apply' (x y : 𝕜') : mul 𝕜 𝕜' x y = x * y :=
   rfl
 #align continuous_linear_map.mul_apply' ContinuousLinearMap.mul_apply'
 
+set_option synthInstance.etaExperiment true in
 @[simp]
 theorem op_norm_mul_apply_le (x : 𝕜') : ‖mul 𝕜 𝕜' x‖ ≤ ‖x‖ :=
   op_norm_le_bound _ (norm_nonneg x) (norm_mul_le x)
 #align continuous_linear_map.op_norm_mul_apply_le ContinuousLinearMap.op_norm_mul_apply_le
 
+set_option synthInstance.etaExperiment true in
 theorem op_norm_mul_le : ‖mul 𝕜 𝕜'‖ ≤ 1 :=
   LinearMap.mkContinuous₂_norm_le _ zero_le_one _
 #align continuous_linear_map.op_norm_mul_le ContinuousLinearMap.op_norm_mul_le
@@ -1500,7 +1501,7 @@ theorem bound_of_ball_bound {r : ℝ} (r_pos : 0 < r) (c : ℝ) (f : E →ₗ[�
 set_option synthInstance.etaExperiment true in
 theorem antilipschitz_of_comap_nhds_le [h : RingHomIsometric σ₁₂] (f : E →ₛₗ[σ₁₂] F)
     (hf : (𝓝 0).comap f ≤ 𝓝 0) : ∃ K, AntilipschitzWith K f := by
-  rcases((nhds_basis_ball.comap _).le_basis_iffₓ nhds_basis_ball).1 hf 1 one_pos with ⟨ε, ε0, hε⟩
+  rcases ((nhds_basis_ball.comap _).le_basis_iff nhds_basis_ball).1 hf 1 one_pos with ⟨ε, ε0, hε⟩
   simp only [Set.subset_def, Set.mem_preimage, mem_ball_zero_iff] at hε
   lift ε to ℝ≥0 using ε0.le
   rcases NormedField.exists_one_lt_norm 𝕜 with ⟨c, hc⟩
@@ -1628,9 +1629,8 @@ that takes values in a bounded set and converges to `f` pointwise along a nontri
 def ofTendstoOfBoundedRange {α : Type _} {l : Filter α} [l.NeBot] (f : E' → F)
     (g : α → E' →SL[σ₁₂] F) (hf : Tendsto (fun a x => g a x) l (𝓝 f)) (hg : Bounded (Set.range g)) :
     E' →SL[σ₁₂] F :=
-  ofMemClosureImageCoeBounded f hg <|
-    mem_closure_of_tendsto hf <|
-      eventually_of_forall fun a => mem_image_of_mem _ <| Set.mem_range_self _
+  ofMemClosureImageCoeBounded f hg <| mem_closure_of_tendsto hf <|
+    eventually_of_forall fun a => mem_image_of_mem _ <| Set.mem_range_self _
 #align continuous_linear_map.of_tendsto_of_bounded_range ContinuousLinearMap.ofTendstoOfBoundedRange
 
 set_option synthInstance.etaExperiment true in
@@ -1656,21 +1656,22 @@ theorem tendsto_of_tendsto_pointwise_of_cauchySeq {f : ℕ → E' →SL[σ₁₂
   exact (f n - f m).le_of_op_norm_le (hfb _ _ _ le_rfl hm) _
 #align continuous_linear_map.tendsto_of_tendsto_pointwise_of_cauchy_seq ContinuousLinearMap.tendsto_of_tendsto_pointwise_of_cauchySeq
 
+set_option synthInstance.etaExperiment true in
 /-- If the target space is complete, the space of continuous linear maps with its norm is also
 complete. This works also if the source space is seminormed. -/
 instance [CompleteSpace F] : CompleteSpace (E' →SL[σ₁₂] F) := by
   -- We show that every Cauchy sequence converges.
   refine' Metric.complete_of_cauchySeq_tendsto fun f hf => _
   -- The evaluation at any point `v : E` is Cauchy.
-  have cau : ∀ v, CauchySeq fun n => f n v := fun v => hf.map (lipschitz_apply v).UniformContinuous
+  have cau : ∀ v, CauchySeq fun n => f n v := fun v => hf.map (lipschitz_apply v).uniformContinuous
   -- We assemble the limits points of those Cauchy sequences
   -- (which exist as `F` is complete)
   -- into a function which we call `G`.
   choose G hG using fun v => cauchySeq_tendsto_of_complete (cau v)
   -- Next, we show that this `G` is a continuous linear map.
-  -- This is done in `ContinuousLinearMap.of_tendsto_of_bounded_range`.
+  -- This is done in `ContinuousLinearMap.ofTendstoOfBoundedRange`.
   set Glin : E' →SL[σ₁₂] F :=
-    of_tendsto_of_bounded_range _ _ (tendsto_pi_nhds.mpr hG) hf.bounded_range
+    ofTendstoOfBoundedRange _ _ (tendsto_pi_nhds.mpr hG) hf.bounded_range
   -- Finally, `f n` converges to `Glin` in norm because of
   -- `ContinuousLinearMap.tendsto_of_tendsto_pointwise_of_cauchy_seq`
   exact ⟨Glin, tendsto_of_tendsto_pointwise_of_cauchy_seq (tendsto_pi_nhds.2 hG) hf⟩
@@ -1889,11 +1890,12 @@ variable {𝕜₂' : Type _} [NontriviallyNormedField 𝕜₂'] {F' : Type _} [N
   [RingHomCompTriple σ₂'' σ₂₃' σ₂₃] [RingHomIsometric σ₂₃] [RingHomIsometric σ₂']
   [RingHomIsometric σ₂''] [RingHomIsometric σ₂₃']
 
+set_option synthInstance.etaExperiment true in
 /-- Precomposition with a linear isometry preserves the operator norm. -/
 theorem op_norm_comp_linearIsometryEquiv (f : F →SL[σ₂₃] G) (g : F' ≃ₛₗᵢ[σ₂'] F) :
     ‖f.comp g.toLinearIsometry.toContinuousLinearMap‖ = ‖f‖ := by
   cases subsingleton_or_nontrivial F'
-  · haveI := g.symm.to_linear_equiv.to_equiv.subsingleton
+  · haveI := g.symm.toLinearEquiv.toEquiv.subsingleton
     simp
   refine' le_antisymm _ _
   · convert f.op_norm_comp_le g.toLinearIsometry.toContinuousLinearMap
@@ -1906,6 +1908,7 @@ theorem op_norm_comp_linearIsometryEquiv (f : F →SL[σ₂₃] G) (g : F' ≃�
     simp [g.symm.toLinearIsometry.norm_toContinuousLinearMap]
 #align continuous_linear_map.op_norm_comp_linear_isometry_equiv ContinuousLinearMap.op_norm_comp_linearIsometryEquiv
 
+set_option synthInstance.etaExperiment true in
 /-- The norm of the tensor product of a scalar linear map and of an element of a normed space
 is the product of the norms. -/
 @[simp]

--- a/Mathlib/Analysis/NormedSpace/OperatorNorm.lean
+++ b/Mathlib/Analysis/NormedSpace/OperatorNorm.lean
@@ -437,8 +437,8 @@ instance toPseudoMetricSpace : PseudoMetricSpace (E →SL[σ₁₂] F) :=
 
 /-- Continuous linear maps themselves form a seminormed space with respect to
     the operator norm. -/
-instance toSeminormedAddCommGroup : SeminormedAddCommGroup (E →SL[σ₁₂] F)
-    where dist_eq := ContinuousLinearMap.tmpSeminormedAddCommGroup.dist_eq
+instance toSeminormedAddCommGroup : SeminormedAddCommGroup (E →SL[σ₁₂] F) where
+  dist_eq := ContinuousLinearMap.tmpSeminormedAddCommGroup.dist_eq
 #align continuous_linear_map.to_seminormed_add_comm_group ContinuousLinearMap.toSeminormedAddCommGroup
 
 set_option synthInstance.etaExperiment true in
@@ -603,7 +603,7 @@ theorem sSup_unit_ball_eq_norm {𝕜 𝕜₂ E F : Type _} [NormedAddCommGroup E
     [DenselyNormedField 𝕜] [NontriviallyNormedField 𝕜₂] {σ₁₂ : 𝕜 →+* 𝕜₂} [NormedSpace 𝕜 E]
     [NormedSpace 𝕜₂ F] [RingHomIsometric σ₁₂] (f : E →SL[σ₁₂] F) :
     sSup ((fun x => ‖f x‖) '' ball 0 1) = ‖f‖ := by
-  simpa only [NNReal.coe_sSup, Set.image_image] using NNReal.coe_eq.2 f.Sup_unit_ball_eq_nnnorm
+  simpa only [NNReal.coe_sSup, Set.image_image] using NNReal.coe_eq.2 f.sSup_unit_ball_eq_nnnorm
 #align continuous_linear_map.Sup_unit_ball_eq_norm ContinuousLinearMap.sSup_unit_ball_eq_norm
 
 set_option synthInstance.etaExperiment true in
@@ -611,14 +611,14 @@ theorem sSup_closed_unit_ball_eq_nnnorm {𝕜 𝕜₂ E F : Type _} [NormedAddCo
     [SeminormedAddCommGroup F] [DenselyNormedField 𝕜] [NontriviallyNormedField 𝕜₂] {σ₁₂ : 𝕜 →+* 𝕜₂}
     [NormedSpace 𝕜 E] [NormedSpace 𝕜₂ F] [RingHomIsometric σ₁₂] (f : E →SL[σ₁₂] F) :
     sSup ((fun x => ‖f x‖₊) '' closedBall 0 1) = ‖f‖₊ := by
-  have hbdd : ∀ y ∈ (fun x => ‖f x‖₊) '' closed_ball 0 1, y ≤ ‖f‖₊ := by
+  have hbdd : ∀ y ∈ (fun x => ‖f x‖₊) '' closedBall 0 1, y ≤ ‖f‖₊ := by
     rintro - ⟨x, hx, rfl⟩
     exact f.unit_le_op_norm x (mem_closedBall_zero_iff.1 hx)
-  refine' le_antisymm (csSup_le ((nonempty_closed_ball.mpr zero_le_one).image _) hbdd) _
+  refine' le_antisymm (csSup_le ((nonempty_closedBall.mpr zero_le_one).image _) hbdd) _
   rw [← Sup_unit_ball_eq_nnnorm]
   exact
     csSup_le_csSup ⟨‖f‖₊, hbdd⟩ ((nonempty_ball.2 zero_lt_one).image _)
-      (Set.image_subset _ ball_subset_closed_ball)
+      (Set.image_subset _ ball_subset_closedBall)
 #align continuous_linear_map.Sup_closed_unit_ball_eq_nnnorm ContinuousLinearMap.sSup_closed_unit_ball_eq_nnnorm
 
 set_option synthInstance.etaExperiment true in
@@ -627,7 +627,7 @@ theorem sSup_closed_unit_ball_eq_norm {𝕜 𝕜₂ E F : Type _} [NormedAddComm
     [NormedSpace 𝕜 E] [NormedSpace 𝕜₂ F] [RingHomIsometric σ₁₂] (f : E →SL[σ₁₂] F) :
     sSup ((fun x => ‖f x‖) '' closedBall 0 1) = ‖f‖ := by
   simpa only [NNReal.coe_sSup, Set.image_image] using
-    NNReal.coe_eq.2 f.Sup_closed_unit_ball_eq_nnnorm
+    NNReal.coe_eq.2 f.sSup_closed_unit_ball_eq_nnnorm
 #align continuous_linear_map.Sup_closed_unit_ball_eq_norm ContinuousLinearMap.sSup_closed_unit_ball_eq_norm
 
 end Sup
@@ -974,6 +974,8 @@ theorem apply_apply (v : E) (f : E →L[𝕜] Fₗ) : apply 𝕜 Fₗ v f = f v 
 
 variable (σ₁₂ σ₂₃ E F G)
 
+set_option linter.uppercaseLean3 false
+
 set_option synthInstance.etaExperiment true in
 /-- Composition of continuous semilinear maps as a continuous semibilinear map. -/
 def compSL : (F →SL[σ₂₃] G) →L[𝕜₃] (E →SL[σ₁₂] F) →SL[σ₂₃] E →SL[σ₁₃] G :=
@@ -999,7 +1001,7 @@ theorem compSL_apply (f : F →SL[σ₂₃] G) (g : E →SL[σ₁₂] F) : compS
 #align continuous_linear_map.compSL_apply ContinuousLinearMap.compSL_apply
 
 set_option synthInstance.etaExperiment true in
-theorem Continuous.const_clm_comp {X} [TopologicalSpace X] {f : X → E →SL[σ₁₂] F}
+theorem _root_.Continuous.const_clm_comp {X} [TopologicalSpace X] {f : X → E →SL[σ₁₂] F}
     (hf : Continuous f) (g : F →SL[σ₂₃] G) :
     Continuous (fun x => g.comp (f x) : X → E →SL[σ₁₃] G) :=
   (compSL E F G σ₁₂ σ₂₃ g).Continuous.comp hf
@@ -1007,7 +1009,7 @@ theorem Continuous.const_clm_comp {X} [TopologicalSpace X] {f : X → E →SL[σ
 
 set_option synthInstance.etaExperiment true in
 -- Giving the implicit argument speeds up elaboration significantly
-theorem Continuous.clm_comp_const {X} [TopologicalSpace X] {g : X → F →SL[σ₂₃] G}
+theorem _root_.Continuous.clm_comp_const {X} [TopologicalSpace X] {g : X → F →SL[σ₂₃] G}
     (hg : Continuous g) (f : E →SL[σ₁₂] F) :
     Continuous (fun x => (g x).comp f : X → E →SL[σ₁₃] G) :=
   (@ContinuousLinearMap.flip _ _ _ _ _ (E →SL[σ₁₃] G) _ _ _ _ _ _ _ _ _ _ _ _ _
@@ -1072,6 +1074,8 @@ variable (M₁ : Type u₁) [SeminormedAddCommGroup M₁] [NormedSpace 𝕜 M₁
 
 variable {Eₗ} (𝕜)
 
+set_option linter.uppercaseLean3 false
+
 set_option synthInstance.etaExperiment true in
 /-- `ContinuousLinearMap.prodMap` as a continuous linear map. -/
 def prodMapL : (M₁ →L[𝕜] M₂) × (M₃ →L[𝕜] M₄) →L[𝕜] M₁ × M₃ →L[𝕜] M₂ × M₄ :=
@@ -1089,8 +1093,7 @@ def prodMapL : (M₁ →L[𝕜] M₂) × (M₃ →L[𝕜] M₄) →L[𝕜] M₁ 
     have Ψ₂ : (M₁ →L[𝕜] M₂) × (M₃ →L[𝕜] M₄) →L[𝕜] M₃ →L[𝕜] M₄ :=
       ContinuousLinearMap.snd 𝕜 (M₁ →L[𝕜] M₂) (M₃ →L[𝕜] M₄)
     Φ₁' ∘L Φ₁ ∘L Ψ₁ + Φ₂' ∘L Φ₂ ∘L Ψ₂)
-    (fun p : (M₁ →L[𝕜] M₂) × (M₃ →L[𝕜] M₄) => p.1.prod_map p.2)
-    (by
+    (fun p : (M₁ →L[𝕜] M₂) × (M₃ →L[𝕜] M₄) => p.1.prod_map p.2) (by
       apply funext
       rintro ⟨φ, ψ⟩
       apply ContinuousLinearMap.ext fun x => _
@@ -1112,20 +1115,20 @@ theorem prodMapL_apply (p : (M₁ →L[𝕜] M₂) × (M₃ →L[𝕜] M₄)) :
 variable {X : Type _} [TopologicalSpace X]
 
 set_option synthInstance.etaExperiment true in
-theorem Continuous.prod_mapL {f : X → M₁ →L[𝕜] M₂} {g : X → M₃ →L[𝕜] M₄} (hf : Continuous f)
+theorem _root_.Continuous.prod_mapL {f : X → M₁ →L[𝕜] M₂} {g : X → M₃ →L[𝕜] M₄} (hf : Continuous f)
     (hg : Continuous g) : Continuous fun x => (f x).prodMap (g x) :=
   (prodMapL 𝕜 M₁ M₂ M₃ M₄).continuous.comp (hf.prod_mk hg)
 #align continuous.prod_mapL Continuous.prod_mapL
 
 set_option synthInstance.etaExperiment true in
-theorem Continuous.prod_map_equivL {f : X → M₁ ≃L[𝕜] M₂} {g : X → M₃ ≃L[𝕜] M₄}
+theorem _root_.Continuous.prod_map_equivL {f : X → M₁ ≃L[𝕜] M₂} {g : X → M₃ ≃L[𝕜] M₄}
     (hf : Continuous fun x => (f x : M₁ →L[𝕜] M₂)) (hg : Continuous fun x => (g x : M₃ →L[𝕜] M₄)) :
     Continuous fun x => ((f x).prod (g x) : M₁ × M₃ →L[𝕜] M₂ × M₄) :=
   (prodMapL 𝕜 M₁ M₂ M₃ M₄).continuous.comp (hf.prod_mk hg)
 #align continuous.prod_map_equivL Continuous.prod_map_equivL
 
 set_option synthInstance.etaExperiment true in
-theorem ContinuousOn.prod_mapL {f : X → M₁ →L[𝕜] M₂} {g : X → M₃ →L[𝕜] M₄} {s : Set X}
+theorem _root_.ContinuousOn.prod_mapL {f : X → M₁ →L[𝕜] M₂} {g : X → M₃ →L[𝕜] M₄} {s : Set X}
     (hf : ContinuousOn f s) (hg : ContinuousOn g s) :
     ContinuousOn (fun x => (f x).prodMap (g x)) s :=
   ((prodMapL 𝕜 M₁ M₂ M₃ M₄).continuous.comp_continuousOn (hf.prod hg) : _)
@@ -1140,8 +1143,6 @@ theorem ContinuousOn.prod_map_equivL {f : X → M₁ ≃L[𝕜] M₂} {g : X →
 #align continuous_on.prod_map_equivL ContinuousOn.prod_map_equivL
 
 end Prod
-
-variable {𝕜 E Fₗ Gₗ}
 
 section MultiplicationLinear
 
@@ -1203,8 +1204,11 @@ end NonUnital
 
 section Unital
 
-variable (𝕜) (𝕜' : Type _) [SeminormedRing 𝕜'] [NormedAlgebra 𝕜 𝕜'] [NormOneClass 𝕜']
+variable (𝕜) (𝕜' : Type _) [SeminormedRing 𝕜']
 
+variable [NormedAlgebra 𝕜 𝕜'] [NormOneClass 𝕜']
+
+set_option synthInstance.etaExperiment true in
 /-- Multiplication in a normed algebra as a linear isometry to the space of
 continuous linear maps. -/
 def mulₗᵢ : 𝕜' →ₗᵢ[𝕜] 𝕜' →L[𝕜] 𝕜' where
@@ -1222,6 +1226,7 @@ theorem coe_mulₗᵢ : ⇑(mulₗᵢ 𝕜 𝕜') = mul 𝕜 𝕜' :=
   rfl
 #align continuous_linear_map.coe_mulₗᵢ ContinuousLinearMap.coe_mulₗᵢ
 
+set_option synthInstance.etaExperiment true in
 @[simp]
 theorem op_norm_mul_apply (x : 𝕜') : ‖mul 𝕜 𝕜' x‖ = ‖x‖ :=
   (mulₗᵢ 𝕜 𝕜').norm_map x
@@ -1233,15 +1238,18 @@ end MultiplicationLinear
 
 section SmulLinear
 
-variable (𝕜) (𝕜' : Type _) [NormedField 𝕜'] [NormedAlgebra 𝕜 𝕜'] [NormedSpace 𝕜' E]
-  [IsScalarTower 𝕜 𝕜' E]
+variable (𝕜) (𝕜' : Type _) [NormedField 𝕜']
 
+variable [NormedAlgebra 𝕜 𝕜'] [NormedSpace 𝕜' E] [IsScalarTower 𝕜 𝕜' E]
+
+set_option synthInstance.etaExperiment true in
 /-- Scalar multiplication as a continuous bilinear map. -/
 def lsmul : 𝕜' →L[𝕜] E →L[𝕜] E :=
   ((Algebra.lsmul 𝕜 E).toLinearMap : 𝕜' →ₗ[𝕜] E →ₗ[𝕜] E).mkContinuous₂ 1 fun c x => by
     simpa only [one_mul] using norm_smul_le c x
 #align continuous_linear_map.lsmul ContinuousLinearMap.lsmul
 
+set_option synthInstance.etaExperiment true in
 @[simp]
 theorem lsmul_apply (c : 𝕜') (x : E) : lsmul 𝕜 𝕜' c x = c • x :=
   rfl
@@ -1250,17 +1258,19 @@ theorem lsmul_apply (c : 𝕜') (x : E) : lsmul 𝕜 𝕜' c x = c • x :=
 variable {𝕜'}
 
 theorem norm_toSpanSingleton (x : E) : ‖toSpanSingleton 𝕜 x‖ = ‖x‖ := by
-  refine' op_norm_eq_of_bounds (norm_nonneg _) (fun x => _) fun N hN_nonneg h => _
-  · rw [to_span_singleton_apply, norm_smul, mul_comm]
+  refine' op_norm_eq_of_bounds (norm_nonneg _) (fun x => _) fun N _ h => _
+  · rw [toSpanSingleton_apply, norm_smul, mul_comm]
   · specialize h 1
-    rw [to_span_singleton_apply, norm_smul, mul_comm] at h
+    rw [toSpanSingleton_apply, norm_smul, mul_comm] at h
     exact (mul_le_mul_right (by simp)).mp h
 #align continuous_linear_map.norm_to_span_singleton ContinuousLinearMap.norm_toSpanSingleton
 
+set_option synthInstance.etaExperiment true in
 theorem op_norm_lsmul_apply_le (x : 𝕜') : ‖(lsmul 𝕜 𝕜' x : E →L[𝕜] E)‖ ≤ ‖x‖ :=
   ContinuousLinearMap.op_norm_le_bound _ (norm_nonneg x) fun y => norm_smul_le x y
 #align continuous_linear_map.op_norm_lsmul_apply_le ContinuousLinearMap.op_norm_lsmul_apply_le
 
+set_option synthInstance.etaExperiment true in
 /-- The norm of `lsmul` is at most 1 in any semi-normed group. -/
 theorem op_norm_lsmul_le : ‖(lsmul 𝕜 𝕜' : 𝕜' →L[𝕜] E →L[𝕜] E)‖ ≤ 1 := by
   refine' ContinuousLinearMap.op_norm_le_bound _ zero_le_one fun x => _
@@ -1278,6 +1288,7 @@ variable [NormedSpace 𝕜' E] [IsScalarTower 𝕜' 𝕜 E]
 
 variable [NormedSpace 𝕜' Fₗ] [IsScalarTower 𝕜' 𝕜 Fₗ]
 
+set_option synthInstance.etaExperiment true in
 @[simp]
 theorem norm_restrictScalars (f : E →L[𝕜] Fₗ) : ‖f.restrictScalars 𝕜'‖ = ‖f‖ :=
   le_antisymm (op_norm_le_bound _ (norm_nonneg _) fun x => f.le_op_norm x)
@@ -1311,6 +1322,7 @@ theorem restrictScalarsIsometry_toLinearMap :
 
 variable (𝕜 E Fₗ 𝕜' 𝕜'')
 
+set_option synthInstance.etaExperiment true in
 /-- `ContinuousLinearMap.restrictScalars` as a `ContinuousLinearMap`. -/
 def restrictScalarsL : (E →L[𝕜] Fₗ) →L[𝕜''] E →L[𝕜'] Fₗ :=
   (restrictScalarsIsometry 𝕜 E Fₗ 𝕜' 𝕜'').toContinuousLinearMap
@@ -1353,16 +1365,20 @@ section
 
 variable {σ₂₁ : 𝕜₂ →+* 𝕜} [RingHomInvPair σ₁₂ σ₂₁] [RingHomInvPair σ₂₁ σ₁₂] [RingHomIsometric σ₁₂]
 
+set_option synthInstance.etaExperiment true in
 variable (e : E ≃SL[σ₁₂] F)
 
+set_option synthInstance.etaExperiment true in
 protected theorem lipschitz : LipschitzWith ‖(e : E →SL[σ₁₂] F)‖₊ e :=
   (e : E →SL[σ₁₂] F).lipschitz
 #align continuous_linear_equiv.lipschitz ContinuousLinearEquiv.lipschitz
 
+set_option synthInstance.etaExperiment true in
 theorem isBigO_comp {α : Type _} (f : α → E) (l : Filter α) : (fun x' => e (f x')) =O[l] f :=
   (e : E →SL[σ₁₂] F).isBigO_comp f l
 #align continuous_linear_equiv.is_O_comp ContinuousLinearEquiv.isBigO_comp
 
+set_option synthInstance.etaExperiment true in
 theorem isBigO_sub (l : Filter E) (x : E) : (fun x' => e (x' - x)) =O[l] fun x' => x' - x :=
   (e : E →SL[σ₁₂] F).isBigO_sub l x
 #align continuous_linear_equiv.is_O_sub ContinuousLinearEquiv.isBigO_sub
@@ -1371,7 +1387,10 @@ end
 
 variable {σ₂₁ : 𝕜₂ →+* 𝕜} [RingHomInvPair σ₁₂ σ₂₁] [RingHomInvPair σ₂₁ σ₁₂]
 
-variable [RingHomIsometric σ₂₁] (e : E ≃SL[σ₁₂] F)
+variable [RingHomIsometric σ₂₁]
+
+set_option synthInstance.etaExperiment true in
+variable (e : E ≃SL[σ₁₂] F)
 
 theorem isBigO_comp_rev {α : Type _} (f : α → E) (l : Filter α) : f =O[l] fun x' => e (f x') :=
   (e.symm.isBigO_comp _ l).congr_left fun _ => e.symm_apply_apply _
@@ -1394,6 +1413,7 @@ variable {𝕜₁' : Type _} {𝕜₂' : Type _} [NontriviallyNormedField 𝕜�
   {σ₂₃' : 𝕜₂' →+* 𝕜₃} [RingHomCompTriple σ₁' σ₁₃ σ₁₃'] [RingHomCompTriple σ₂' σ₂₃ σ₂₃']
   [RingHomIsometric σ₂₃] [RingHomIsometric σ₁₃'] [RingHomIsometric σ₂₃']
 
+set_option synthInstance.etaExperiment true in
 /-- Compose a bilinear map `E →SL[σ₁₃] F →SL[σ₂₃] G` with two linear maps
 `E' →SL[σ₁'] E` and `F' →SL[σ₂'] F`.  -/
 def bilinearComp (f : E →SL[σ₁₃] F →SL[σ₂₃] G) (gE : E' →SL[σ₁'] E) (gF : F' →SL[σ₂'] F) :
@@ -1401,6 +1421,7 @@ def bilinearComp (f : E →SL[σ₁₃] F →SL[σ₂₃] G) (gE : E' →SL[σ�
   ((f.comp gE).flip.comp gF).flip
 #align continuous_linear_map.bilinear_comp ContinuousLinearMap.bilinearComp
 
+set_option synthInstance.etaExperiment true in
 @[simp]
 theorem bilinearComp_apply (f : E →SL[σ₁₃] F →SL[σ₂₃] G) (gE : E' →SL[σ₁'] E) (gF : F' →SL[σ₂'] F)
     (x : E') (y : F') : f.bilinearComp gE gF x y = f (gE x) (gF y) :=
@@ -1469,7 +1490,7 @@ theorem bound_of_ball_bound {r : ℝ} (r_pos : 0 < r) (c : ℝ) (f : E →ₗ[�
   refine' bound_of_shell _ r_pos hk (fun x hko hxo => _) _
   calc
     ‖f x‖ ≤ c := h _ (mem_ball_zero_iff.mpr hxo)
-    _ ≤ c * (‖x‖ * ‖k‖ / r) := (le_mul_of_one_le_right _ _)
+    _ ≤ c * (‖x‖ * ‖k‖ / r) := (le_mul_of_one_le_right ?_ ?_)
     _ = _ := by ring
   · exact le_trans (norm_nonneg _) (h 0 (by simp [r_pos]))
   · rw [div_le_iff (zero_lt_one.trans hk)] at hko
@@ -1510,6 +1531,7 @@ section OpNorm
 
 open Set Real
 
+set_option synthInstance.etaExperiment true in
 /-- An operator is zero iff its norm vanishes. -/
 theorem op_norm_zero_iff [RingHomIsometric σ₁₂] : ‖f‖ = 0 ↔ f = 0 :=
   Iff.intro
@@ -1579,6 +1601,7 @@ open Filter
 
 variable {E' : Type _} [SeminormedAddCommGroup E'] [NormedSpace 𝕜 E'] [RingHomIsometric σ₁₂]
 
+set_option synthInstance.etaExperiment true in
 /-- Construct a bundled continuous (semi)linear map from a map `f : E → F` and a proof of the fact
 that it belongs to the closure of the image of a bounded set `s : set (E →SL[σ₁₂] F)` under coercion
 to function. Coercion to function of the result is definitionally equal to `f`. -/
@@ -1621,9 +1644,8 @@ theorem tendsto_of_tendsto_pointwise_of_cauchySeq {f : ℕ → E' →SL[σ₁₂
   rcases cauchySeq_iff_le_tendsto_0.1 hf with ⟨b, hb₀, hfb, hb_lim⟩
   -- Since `b → 0`, it suffices to show that `‖f n x - g x‖ ≤ b n * ‖x‖` for all `n` and `x`.
   suffices : ∀ n x, ‖f n x - g x‖ ≤ b n * ‖x‖
-  exact
-    tendsto_iff_norm_tendsto_zero.2
-      (squeeze_zero (fun n => norm_nonneg _) (fun n => op_norm_le_bound _ (hb₀ n) (this n)) hb_lim)
+  exact tendsto_iff_norm_tendsto_zero.2
+    (squeeze_zero (fun n => norm_nonneg _) (fun n => op_norm_le_bound _ (hb₀ n) (this n)) hb_lim)
   intro n x
   -- Note that `f m x → g x`, hence `‖f n x - f m x‖ → ‖f n x - g x‖` as `m → ∞`
   have : tendsto (fun m => ‖f n x - f m x‖) at_top (𝓝 ‖f n x - g x‖) :=
@@ -1701,6 +1723,7 @@ theorem isCompact_image_coe_of_bounded_of_weak_closed [ProperSpace F] {s : Set (
     isClosed_image_coe_of_bounded_of_weak_closed hb hc
 #align continuous_linear_map.is_compact_image_coe_of_bounded_of_weak_closed ContinuousLinearMap.isCompact_image_coe_of_bounded_of_weak_closed
 
+set_option synthInstance.etaExperiment true in
 /-- A closed ball is closed in the weak-* topology. We don't have a name for `E →SL[σ] F` with
 weak-* topology in `mathlib`, so we use an equivalent condition (see `isClosed_induced_iff'`). -/
 theorem is_weak_closed_closedBall (f₀ : E' →SL[σ₁₂] F) (r : ℝ) ⦃f : E' →SL[σ₁₂] F⦄
@@ -1873,10 +1896,10 @@ theorem op_norm_comp_linearIsometryEquiv (f : F →SL[σ₂₃] G) (g : F' ≃�
   · haveI := g.symm.to_linear_equiv.to_equiv.subsingleton
     simp
   refine' le_antisymm _ _
-  · convert f.op_norm_comp_le g.to_linear_isometry.toContinuousLinearMap
-    simp [g.to_linear_isometry.norm_toContinuousLinearMap]
-  · convert(f.comp g.to_linear_isometry.toContinuousLinearMap).op_norm_comp_le
-        g.symm.to_linear_isometry.toContinuousLinearMap
+  · convert f.op_norm_comp_le g.toLinearIsometry.toContinuousLinearMap
+    simp [g.toLinearIsometry.norm_toContinuousLinearMap]
+  · convert(f.comp g.toLinearIsometry.toContinuousLinearMap).op_norm_comp_le
+        g.symm.toLinearIsometry.toContinuousLinearMap
     · ext
       simp
     haveI := g.symm.surjective.nontrivial
@@ -1905,6 +1928,7 @@ theorem norm_smulRight_apply (c : E →L[𝕜] 𝕜) (f : Fₗ) : ‖smulRight c
         _ ≤ ‖smul_right c f‖ * ‖x‖ := le_op_norm _ _
 #align continuous_linear_map.norm_smul_right_apply ContinuousLinearMap.norm_smulRight_apply
 
+set_option synthInstance.etaExperiment true in
 /-- The non-negative norm of the tensor product of a scalar linear map and of an element of a normed
 space is the product of the non-negative norms. -/
 @[simp]
@@ -1914,6 +1938,7 @@ theorem nnnorm_smulRight_apply (c : E →L[𝕜] 𝕜) (f : Fₗ) : ‖smulRight
 
 variable (𝕜 E Fₗ)
 
+set_option synthInstance.etaExperiment true in
 /-- `ContinuousLinearMap.smulRight` as a continuous trilinear map:
 `smul_rightL (c : E →L[𝕜] 𝕜) (f : F) (x : E) = c x • f`. -/
 def smulRightL : (E →L[𝕜] 𝕜) →L[𝕜] Fₗ →L[𝕜] E →L[𝕜] Fₗ :=
@@ -1927,6 +1952,7 @@ def smulRightL : (E →L[𝕜] 𝕜) →L[𝕜] Fₗ →L[𝕜] E →L[𝕜] F�
         simp only [smul_smul, coe_smul_rightₗ, Algebra.id.smul_eq_mul, coe_smul', smul_right_apply,
           LinearMap.smul_apply, RingHom.id_apply, Pi.smul_apply] }
     1 fun c x => by simp only [coe_smul_rightₗ, one_mul, norm_smul_right_apply, LinearMap.coe_mk]
+set_option linter.uppercaseLean3 false in
 #align continuous_linear_map.smul_rightL ContinuousLinearMap.smulRightL
 
 variable {𝕜 E Fₗ}
@@ -1934,11 +1960,13 @@ variable {𝕜 E Fₗ}
 @[simp]
 theorem norm_smulRightL_apply (c : E →L[𝕜] 𝕜) (f : Fₗ) : ‖smulRightL 𝕜 E Fₗ c f‖ = ‖c‖ * ‖f‖ :=
   norm_smulRight_apply c f
+set_option linter.uppercaseLean3 false in
 #align continuous_linear_map.norm_smul_rightL_apply ContinuousLinearMap.norm_smulRightL_apply
 
 @[simp]
 theorem norm_smulRightL (c : E →L[𝕜] 𝕜) [Nontrivial Fₗ] : ‖smulRightL 𝕜 E Fₗ c‖ = ‖c‖ :=
   ContinuousLinearMap.homothety_norm _ c.norm_smulRight_apply
+set_option linter.uppercaseLean3 false in
 #align continuous_linear_map.norm_smul_rightL ContinuousLinearMap.norm_smulRightL
 
 variable (𝕜) (𝕜' : Type _)
@@ -1955,6 +1983,7 @@ theorem op_norm_mul [NormOneClass 𝕜'] : ‖mul 𝕜 𝕜'‖ = 1 :=
 
 end
 
+set_option synthInstance.etaExperiment true in
 /-- The norm of `lsmul` equals 1 in any nontrivial normed group.
 
 This is `ContinuousLinearMap.op_norm_lsmul_le` as an equality. -/
@@ -1978,6 +2007,7 @@ namespace Submodule
 variable [NontriviallyNormedField 𝕜] [NontriviallyNormedField 𝕜₂] [NontriviallyNormedField 𝕜₃]
   [NormedSpace 𝕜 E] [NormedSpace 𝕜₂ F] {σ₁₂ : 𝕜 →+* 𝕜₂}
 
+set_option synthInstance.etaExperiment true in
 theorem norm_subtypeL (K : Submodule 𝕜 E) [Nontrivial K] : ‖K.subtypeL‖ = 1 :=
   K.subtypeₗᵢ.norm_toContinuousLinearMap
 set_option linter.uppercaseLean3 false in
@@ -2050,9 +2080,8 @@ set_option synthInstance.etaExperiment true in
 theorem coord_norm (x : E) (h : x ≠ 0) : ‖coord 𝕜 x h‖ = ‖x‖⁻¹ := by
   have hx : 0 < ‖x‖ := norm_pos_iff.mpr h
   haveI : Nontrivial (𝕜 ∙ x) := Submodule.nontrivial_span_singleton h
-  exact
-    ContinuousLinearMap.homothety_norm _ fun y =>
-      homothety_inverse _ hx _ (toSpanNonzeroSingleton_homothety 𝕜 x h) _
+  exact ContinuousLinearMap.homothety_norm _ fun y =>
+    homothety_inverse _ hx _ (toSpanNonzeroSingleton_homothety 𝕜 x h) _
 #align continuous_linear_equiv.coord_norm ContinuousLinearEquiv.coord_norm
 
 variable {𝕜} {𝕜₄ : Type _} [NontriviallyNormedField 𝕜₄]
@@ -2091,6 +2120,7 @@ def arrowCongrSL (e₁₂ : E ≃SL[σ₁₂] F) (e₄₃ : H ≃SL[σ₄₃] G)
     map_smul' := fun t f => by rw [smul_comp, comp_smulₛₗ]
     continuous_toFun := (continuous_id.clm_comp_const _).const_clm_comp _
     continuous_invFun := (continuous_id.clm_comp_const _).const_clm_comp _ }
+set_option linter.uppercaseLean3 false in
 #align continuous_linear_equiv.arrow_congrSL ContinuousLinearEquiv.arrowCongrSL
 
 set_option synthInstance.etaExperiment true in

--- a/Mathlib/Analysis/NormedSpace/OperatorNorm.lean
+++ b/Mathlib/Analysis/NormedSpace/OperatorNorm.lean
@@ -507,7 +507,7 @@ variable [RingHomIsometric σ₁₂]
 theorem exists_mul_lt_apply_of_lt_op_nnnorm (f : E →SL[σ₁₂] F) {r : ℝ≥0} (hr : r < ‖f‖₊) :
     ∃ x, r * ‖x‖₊ < ‖f x‖₊ := by
   simpa only [not_forall, not_le, Set.mem_setOf] using
-    not_mem_of_lt_csInf (nnnorm_def f ▸ hr : r < Inf { c : ℝ≥0 | ∀ x, ‖f x‖₊ ≤ c * ‖x‖₊ })
+    not_mem_of_lt_csInf (nnnorm_def f ▸ hr : r < sInf { c : ℝ≥0 | ∀ x, ‖f x‖₊ ≤ c * ‖x‖₊ })
       (OrderBot.bddBelow _)
 #align continuous_linear_map.exists_mul_lt_apply_of_lt_op_nnnorm ContinuousLinearMap.exists_mul_lt_apply_of_lt_op_nnnorm
 

--- a/Mathlib/Analysis/NormedSpace/OperatorNorm.lean
+++ b/Mathlib/Analysis/NormedSpace/OperatorNorm.lean
@@ -48,7 +48,6 @@ variable [NontriviallyNormedField 𝕜] [NontriviallyNormedField 𝕜₂] [Nontr
   [NormedSpace 𝕜 Gₗ] {σ₁₂ : 𝕜 →+* 𝕜₂} {σ₂₃ : 𝕜₂ →+* 𝕜₃} {σ₁₃ : 𝕜 →+* 𝕜₃}
   [RingHomCompTriple σ₁₂ σ₂₃ σ₁₃]
 
-set_option synthInstance.etaExperiment true in
 /-- If `‖x‖ = 0` and `f` is continuous then `‖f x‖ = 0`. -/
 theorem norm_image_of_norm_zero [SemilinearMapClass 𝓕 σ₁₂ E F] (f : 𝓕) (hf : Continuous f) {x : E}
     (hx : ‖x‖ = 0) : ‖f x‖ = 0 := by
@@ -65,7 +64,6 @@ section
 
 variable [RingHomIsometric σ₁₂] [RingHomIsometric σ₂₃]
 
-set_option synthInstance.etaExperiment true in
 theorem SemilinearMapClass.bound_of_shell_semi_normed [SemilinearMapClass 𝓕 σ₁₂ E F] (f : 𝓕)
     {ε C : ℝ} (ε_pos : 0 < ε) {c : 𝕜} (hc : 1 < ‖c‖)
     (hf : ∀ x, ε / ‖c‖ ≤ ‖x‖ → ‖x‖ < ε → ‖f x‖ ≤ C * ‖x‖) {x : E} (hx : ‖x‖ ≠ 0) :
@@ -75,7 +73,6 @@ theorem SemilinearMapClass.bound_of_shell_semi_normed [SemilinearMapClass 𝓕 �
     RingHomIsometric.is_iso] using hf (δ • x) leδx δxle
 #align semilinear_map_class.bound_of_shell_semi_normed SemilinearMapClass.bound_of_shell_semi_normed
 
-set_option synthInstance.etaExperiment true in
 /-- A continuous linear map between seminormed spaces is bounded when the field is nontrivially
 normed. The continuity ensures boundedness on a ball of some radius `ε`. The nontriviality of the
 norm is then used to rescale any element into an element of norm in `[ε/C, ε]`, whose image has a
@@ -99,7 +96,6 @@ end
 
 namespace ContinuousLinearMap
 
-set_option synthInstance.etaExperiment true in
 theorem bound [RingHomIsometric σ₁₂] (f : E →SL[σ₁₂] F) : ∃ C, 0 < C ∧ ∀ x : E, ‖f x‖ ≤ C * ‖x‖ :=
   SemilinearMapClass.bound_of_continuous f f.2
 #align continuous_linear_map.bound ContinuousLinearMap.bound
@@ -118,7 +114,6 @@ def _root_.LinearIsometry.toSpanSingleton {v : E} (hv : ‖v‖ = 1) : 𝕜 →�
 
 variable {𝕜 E}
 
-set_option synthInstance.etaExperiment true in
 @[simp]
 theorem _root_.LinearIsometry.toSpanSingleton_apply {v : E} (hv : ‖v‖ = 1) (a : 𝕜) :
     LinearIsometry.toSpanSingleton 𝕜 E hv a = a • v :=
@@ -137,7 +132,6 @@ section OpNorm
 
 open Set Real
 
-set_option synthInstance.etaExperiment true in
 /-- The operator norm of a continuous linear map is the inf of all its bounds. -/
 def opNorm (f : E →SL[σ₁₂] F) :=
   sInf { c | 0 ≤ c ∧ ∀ x, ‖f x‖ ≤ c * ‖x‖ }
@@ -147,13 +141,11 @@ instance hasOpNorm : Norm (E →SL[σ₁₂] F) :=
   ⟨opNorm⟩
 #align continuous_linear_map.has_op_norm ContinuousLinearMap.hasOpNorm
 
-set_option synthInstance.etaExperiment true in
 theorem norm_def (f : E →SL[σ₁₂] F) : ‖f‖ = sInf { c | 0 ≤ c ∧ ∀ x, ‖f x‖ ≤ c * ‖x‖ } :=
   rfl
 #align continuous_linear_map.norm_def ContinuousLinearMap.norm_def
 
-set_option synthInstance.etaExperiment true in
--- So that invocations of `le_cinfₛ` make sense: we show that the set of
+-- So that invocations of `le_csInf` make sense: we show that the set of
 -- bounds is nonempty and bounded below.
 theorem bounds_nonempty [RingHomIsometric σ₁₂] {f : E →SL[σ₁₂] F} :
     ∃ c, c ∈ { c | 0 ≤ c ∧ ∀ x, ‖f x‖ ≤ c * ‖x‖ } :=
@@ -161,19 +153,16 @@ theorem bounds_nonempty [RingHomIsometric σ₁₂] {f : E →SL[σ₁₂] F} :
   ⟨M, le_of_lt hMp, hMb⟩
 #align continuous_linear_map.bounds_nonempty ContinuousLinearMap.bounds_nonempty
 
-set_option synthInstance.etaExperiment true in
 theorem bounds_bddBelow {f : E →SL[σ₁₂] F} : BddBelow { c | 0 ≤ c ∧ ∀ x, ‖f x‖ ≤ c * ‖x‖ } :=
   ⟨0, fun _ ⟨hn, _⟩ => hn⟩
 #align continuous_linear_map.bounds_bdd_below ContinuousLinearMap.bounds_bddBelow
 
-set_option synthInstance.etaExperiment true in
 /-- If one controls the norm of every `A x`, then one controls the norm of `A`. -/
 theorem op_norm_le_bound (f : E →SL[σ₁₂] F) {M : ℝ} (hMp : 0 ≤ M) (hM : ∀ x, ‖f x‖ ≤ M * ‖x‖) :
     ‖f‖ ≤ M :=
   csInf_le bounds_bddBelow ⟨hMp, hM⟩
 #align continuous_linear_map.op_norm_le_bound ContinuousLinearMap.op_norm_le_bound
 
-set_option synthInstance.etaExperiment true in
 /-- If one controls the norm of every `A x`, `‖x‖ ≠ 0`, then one controls the norm of `A`. -/
 theorem op_norm_le_bound' (f : E →SL[σ₁₂] F) {M : ℝ} (hMp : 0 ≤ M)
     (hM : ∀ x, ‖x‖ ≠ 0 → ‖f x‖ ≤ M * ‖x‖) : ‖f‖ ≤ M :=
@@ -182,13 +171,11 @@ theorem op_norm_le_bound' (f : E →SL[σ₁₂] F) {M : ℝ} (hMp : 0 ≤ M)
       simp only [h, MulZeroClass.mul_zero, norm_image_of_norm_zero f f.2 h, le_refl]
 #align continuous_linear_map.op_norm_le_bound' ContinuousLinearMap.op_norm_le_bound'
 
-set_option synthInstance.etaExperiment true in
 theorem op_norm_le_of_lipschitz {f : E →SL[σ₁₂] F} {K : ℝ≥0} (hf : LipschitzWith K f) : ‖f‖ ≤ K :=
   f.op_norm_le_bound K.2 fun x => by
     simpa only [dist_zero_right, f.map_zero] using hf.dist_le_mul x 0
 #align continuous_linear_map.op_norm_le_of_lipschitz ContinuousLinearMap.op_norm_le_of_lipschitz
 
-set_option synthInstance.etaExperiment true in
 theorem op_norm_eq_of_bounds {φ : E →SL[σ₁₂] F} {M : ℝ} (M_nonneg : 0 ≤ M)
     (h_above : ∀ x, ‖φ x‖ ≤ M * ‖x‖) (h_below : ∀ N ≥ 0, (∀ x, ‖φ x‖ ≤ N * ‖x‖) → M ≤ N) :
     ‖φ‖ = M :=
@@ -209,7 +196,6 @@ theorem op_norm_nonneg : 0 ≤ ‖f‖ :=
   le_csInf bounds_nonempty fun _ ⟨hx, _⟩ => hx
 #align continuous_linear_map.op_norm_nonneg ContinuousLinearMap.op_norm_nonneg
 
-set_option synthInstance.etaExperiment true in
 /-- The fundamental property of the operator norm: `‖f x‖ ≤ ‖f‖ * ‖x‖`. -/
 theorem le_op_norm : ‖f x‖ ≤ ‖f‖ * ‖x‖ := by
   obtain ⟨C, _, hC⟩ := f.bound
@@ -222,39 +208,32 @@ theorem le_op_norm : ‖f x‖ ≤ ‖f‖ * ‖x‖ := by
       (le_csInf bounds_nonempty fun c ⟨_, hc⟩ => (div_le_iff hlt).mpr <| by apply hc)
 #align continuous_linear_map.le_op_norm ContinuousLinearMap.le_op_norm
 
-set_option synthInstance.etaExperiment true in
 theorem dist_le_op_norm (x y : E) : dist (f x) (f y) ≤ ‖f‖ * dist x y := by
   simp_rw [dist_eq_norm, ← map_sub, f.le_op_norm]
 #align continuous_linear_map.dist_le_op_norm ContinuousLinearMap.dist_le_op_norm
 
-set_option synthInstance.etaExperiment true in
 theorem le_op_norm_of_le {c : ℝ} {x} (h : ‖x‖ ≤ c) : ‖f x‖ ≤ ‖f‖ * c :=
   le_trans (f.le_op_norm x) (mul_le_mul_of_nonneg_left h f.op_norm_nonneg)
 #align continuous_linear_map.le_op_norm_of_le ContinuousLinearMap.le_op_norm_of_le
 
-set_option synthInstance.etaExperiment true in
 theorem le_of_op_norm_le {c : ℝ} (h : ‖f‖ ≤ c) (x : E) : ‖f x‖ ≤ c * ‖x‖ :=
   (f.le_op_norm x).trans (mul_le_mul_of_nonneg_right h (norm_nonneg x))
 #align continuous_linear_map.le_of_op_norm_le ContinuousLinearMap.le_of_op_norm_le
 
-set_option synthInstance.etaExperiment true in
 theorem ratio_le_op_norm : ‖f x‖ / ‖x‖ ≤ ‖f‖ :=
   div_le_of_nonneg_of_le_mul (norm_nonneg _) f.op_norm_nonneg (le_op_norm _ _)
 #align continuous_linear_map.ratio_le_op_norm ContinuousLinearMap.ratio_le_op_norm
 
-set_option synthInstance.etaExperiment true in
 /-- The image of the unit ball under a continuous linear map is bounded. -/
 theorem unit_le_op_norm : ‖x‖ ≤ 1 → ‖f x‖ ≤ ‖f‖ :=
   mul_one ‖f‖ ▸ f.le_op_norm_of_le
 #align continuous_linear_map.unit_le_op_norm ContinuousLinearMap.unit_le_op_norm
 
-set_option synthInstance.etaExperiment true in
 theorem op_norm_le_of_shell {f : E →SL[σ₁₂] F} {ε C : ℝ} (ε_pos : 0 < ε) (hC : 0 ≤ C) {c : 𝕜}
     (hc : 1 < ‖c‖) (hf : ∀ x, ε / ‖c‖ ≤ ‖x‖ → ‖x‖ < ε → ‖f x‖ ≤ C * ‖x‖) : ‖f‖ ≤ C :=
   f.op_norm_le_bound' hC fun _ hx => SemilinearMapClass.bound_of_shell_semi_normed f ε_pos hc hf hx
 #align continuous_linear_map.op_norm_le_of_shell ContinuousLinearMap.op_norm_le_of_shell
 
-set_option synthInstance.etaExperiment true in
 theorem op_norm_le_of_ball {f : E →SL[σ₁₂] F} {ε : ℝ} {C : ℝ} (ε_pos : 0 < ε) (hC : 0 ≤ C)
     (hf : ∀ x ∈ ball (0 : E) ε, ‖f x‖ ≤ C * ‖x‖) : ‖f‖ ≤ C := by
   rcases NormedField.exists_one_lt_norm 𝕜 with ⟨c, hc⟩
@@ -262,14 +241,12 @@ theorem op_norm_le_of_ball {f : E →SL[σ₁₂] F} {ε : ℝ} {C : ℝ} (ε_po
   rwa [ball_zero_eq]
 #align continuous_linear_map.op_norm_le_of_ball ContinuousLinearMap.op_norm_le_of_ball
 
-set_option synthInstance.etaExperiment true in
 theorem op_norm_le_of_nhds_zero {f : E →SL[σ₁₂] F} {C : ℝ} (hC : 0 ≤ C)
     (hf : ∀ᶠ x in 𝓝 (0 : E), ‖f x‖ ≤ C * ‖x‖) : ‖f‖ ≤ C :=
   let ⟨_, ε0, hε⟩ := Metric.eventually_nhds_iff_ball.1 hf
   op_norm_le_of_ball ε0 hC hε
 #align continuous_linear_map.op_norm_le_of_nhds_zero ContinuousLinearMap.op_norm_le_of_nhds_zero
 
-set_option synthInstance.etaExperiment true in
 theorem op_norm_le_of_shell' {f : E →SL[σ₁₂] F} {ε C : ℝ} (ε_pos : 0 < ε) (hC : 0 ≤ C) {c : 𝕜}
     (hc : ‖c‖ < 1) (hf : ∀ x, ε * ‖c‖ ≤ ‖x‖ → ‖x‖ < ε → ‖f x‖ ≤ C * ‖x‖) : ‖f‖ ≤ C := by
   by_cases h0 : c = 0
@@ -292,14 +269,12 @@ theorem op_norm_le_of_unit_norm [NormedSpace ℝ E] [NormedSpace ℝ F] {f : E �
   exact (norm_nonneg x).lt_of_ne' hx
 #align continuous_linear_map.op_norm_le_of_unit_norm ContinuousLinearMap.op_norm_le_of_unit_norm
 
-set_option synthInstance.etaExperiment true in
 /-- The operator norm satisfies the triangle inequality. -/
 theorem op_norm_add_le : ‖f + g‖ ≤ ‖f‖ + ‖g‖ :=
   (f + g).op_norm_le_bound (add_nonneg f.op_norm_nonneg g.op_norm_nonneg) fun x =>
     (norm_add_le_of_le (f.le_op_norm x) (g.le_op_norm x)).trans_eq (add_mul _ _ _).symm
 #align continuous_linear_map.op_norm_add_le ContinuousLinearMap.op_norm_add_le
 
-set_option synthInstance.etaExperiment true in
 /-- The norm of the `0` operator is `0`. -/
 theorem op_norm_zero : ‖(0 : E →SL[σ₁₂] F)‖ = 0 :=
   le_antisymm (csInf_le bounds_bddBelow ⟨le_rfl, fun _ => le_of_eq (by
@@ -307,14 +282,12 @@ theorem op_norm_zero : ‖(0 : E →SL[σ₁₂] F)‖ = 0 :=
     exact norm_zero)⟩) (op_norm_nonneg _)
 #align continuous_linear_map.op_norm_zero ContinuousLinearMap.op_norm_zero
 
-set_option synthInstance.etaExperiment true in
 /-- The norm of the identity is at most `1`. It is in fact `1`, except when the space is trivial
 where it is `0`. It means that one can not do better than an inequality in general. -/
 theorem norm_id_le : ‖id 𝕜 E‖ ≤ 1 :=
   op_norm_le_bound _ zero_le_one fun x => by simp
 #align continuous_linear_map.norm_id_le ContinuousLinearMap.norm_id_le
 
-set_option synthInstance.etaExperiment true in
 /-- If there is an element with norm different from `0`, then the norm of the identity equals `1`.
 (Since we are working with seminorms supposing that the space is non-trivial is not enough.) -/
 theorem norm_id_of_nontrivial_seminorm (h : ∃ x : E, ‖x‖ ≠ 0) : ‖id 𝕜 E‖ = 1 :=
@@ -324,7 +297,6 @@ theorem norm_id_of_nontrivial_seminorm (h : ∃ x : E, ‖x‖ ≠ 0) : ‖id �
     rwa [id_apply, div_self hx] at this
 #align continuous_linear_map.norm_id_of_nontrivial_seminorm ContinuousLinearMap.norm_id_of_nontrivial_seminorm
 
-set_option synthInstance.etaExperiment true in
 theorem op_norm_smul_le {𝕜' : Type _} [NormedField 𝕜'] [NormedSpace 𝕜' F] [SMulCommClass 𝕜₂ 𝕜' F]
     (c : 𝕜') (f : E →SL[σ₁₂] F) : ‖c • f‖ ≤ ‖c‖ * ‖f‖ :=
   (c • f).op_norm_le_bound (mul_nonneg (norm_nonneg _) (op_norm_nonneg _)) fun _ => by
@@ -332,7 +304,6 @@ theorem op_norm_smul_le {𝕜' : Type _} [NormedField 𝕜'] [NormedSpace 𝕜' 
     exact mul_le_mul_of_nonneg_left (le_op_norm _ _) (norm_nonneg _)
 #align continuous_linear_map.op_norm_smul_le ContinuousLinearMap.op_norm_smul_le
 
-set_option synthInstance.etaExperiment true in
 /-- Continuous linear maps themselves form a seminormed space with respect to
 the operator norm. This is only a temporary definition because we want to replace the topology
 with `ContinuousLinearMap.topologicalSpace` to avoid diamond issues.
@@ -374,12 +345,10 @@ attribute [-instance] ContinuousLinearMap.uniformSpace
 
 attribute [local instance] ContinuousLinearMap.tmpSeminormedAddCommGroup
 
-set_option synthInstance.etaExperiment true in
 protected theorem tmpTopologicalAddGroup : TopologicalAddGroup (E →SL[σ₁₂] F) :=
   inferInstance
 #align continuous_linear_map.tmp_topological_add_group ContinuousLinearMap.tmpTopologicalAddGroup
 
-set_option synthInstance.etaExperiment true in
 protected theorem tmp_closedBall_div_subset {a b : ℝ} (ha : 0 < a) (hb : 0 < b) :
     closedBall (0 : E →SL[σ₁₂] F) (a / b) ⊆
       { f | ∀ x ∈ closedBall (0 : E) b, f x ∈ closedBall (0 : F) a } := by
@@ -393,7 +362,6 @@ protected theorem tmp_closedBall_div_subset {a b : ℝ} (ha : 0 < a) (hb : 0 < b
 
 end Tmp
 
-set_option synthInstance.etaExperiment true in
 protected theorem tmp_topology_eq :
     (ContinuousLinearMap.tmpTopologicalSpace : TopologicalSpace (E →SL[σ₁₂] F)) =
       ContinuousLinearMap.topologicalSpace := by
@@ -418,7 +386,6 @@ protected theorem tmp_topology_eq :
       (ContinuousLinearMap.tmp_closedBall_div_subset hε hδ).trans fun f hf x hx => hf x <| hSδ hx⟩
 #align continuous_linear_map.tmp_topology_eq ContinuousLinearMap.tmp_topology_eq
 
-set_option synthInstance.etaExperiment true in
 protected theorem tmpUniformSpace_eq :
     (ContinuousLinearMap.tmpUniformSpace : UniformSpace (E →SL[σ₁₂] F)) =
       ContinuousLinearMap.uniformSpace := by
@@ -433,14 +400,12 @@ instance toPseudoMetricSpace : PseudoMetricSpace (E →SL[σ₁₂] F) :=
     (congr_arg _ ContinuousLinearMap.tmpUniformSpace_eq.symm)
 #align continuous_linear_map.to_pseudo_metric_space ContinuousLinearMap.toPseudoMetricSpace
 
-set_option synthInstance.etaExperiment true in
 /-- Continuous linear maps themselves form a seminormed space with respect to
     the operator norm. -/
 instance toSeminormedAddCommGroup : SeminormedAddCommGroup (E →SL[σ₁₂] F) where
   dist_eq := ContinuousLinearMap.tmpSeminormedAddCommGroup.dist_eq
 #align continuous_linear_map.to_seminormed_add_comm_group ContinuousLinearMap.toSeminormedAddCommGroup
 
-set_option synthInstance.etaExperiment true in
 theorem nnnorm_def (f : E →SL[σ₁₂] F) : ‖f‖₊ = sInf { c | ∀ x, ‖f x‖₊ ≤ c * ‖x‖₊ } := by
   ext
   rw [NNReal.coe_sInf, coe_nnnorm, norm_def, NNReal.coe_image]
@@ -449,13 +414,11 @@ theorem nnnorm_def (f : E →SL[σ₁₂] F) : ‖f‖₊ = sInf { c | ∀ x, �
     exists_prop]
 #align continuous_linear_map.nnnorm_def ContinuousLinearMap.nnnorm_def
 
-set_option synthInstance.etaExperiment true in
 /-- If one controls the norm of every `A x`, then one controls the norm of `A`. -/
 theorem op_nnnorm_le_bound (f : E →SL[σ₁₂] F) (M : ℝ≥0) (hM : ∀ x, ‖f x‖₊ ≤ M * ‖x‖₊) : ‖f‖₊ ≤ M :=
   op_norm_le_bound f (zero_le M) hM
 #align continuous_linear_map.op_nnnorm_le_bound ContinuousLinearMap.op_nnnorm_le_bound
 
-set_option synthInstance.etaExperiment true in
 /-- If one controls the norm of every `A x`, `‖x‖₊ ≠ 0`, then one controls the norm of `A`. -/
 theorem op_nnnorm_le_bound' (f : E →SL[σ₁₂] F) (M : ℝ≥0) (hM : ∀ x, ‖x‖₊ ≠ 0 → ‖f x‖₊ ≤ M * ‖x‖₊) :
     ‖f‖₊ ≤ M :=
@@ -469,25 +432,21 @@ theorem op_nnnorm_le_of_unit_nnnorm [NormedSpace ℝ E] [NormedSpace ℝ F] {f :
   op_norm_le_of_unit_norm C.coe_nonneg fun x hx => hf x <| by rwa [← NNReal.coe_eq_one]
 #align continuous_linear_map.op_nnnorm_le_of_unit_nnnorm ContinuousLinearMap.op_nnnorm_le_of_unit_nnnorm
 
-set_option synthInstance.etaExperiment true in
 theorem op_nnnorm_le_of_lipschitz {f : E →SL[σ₁₂] F} {K : ℝ≥0} (hf : LipschitzWith K f) :
     ‖f‖₊ ≤ K :=
   op_norm_le_of_lipschitz hf
 #align continuous_linear_map.op_nnnorm_le_of_lipschitz ContinuousLinearMap.op_nnnorm_le_of_lipschitz
 
-set_option synthInstance.etaExperiment true in
 theorem op_nnnorm_eq_of_bounds {φ : E →SL[σ₁₂] F} (M : ℝ≥0) (h_above : ∀ x, ‖φ x‖ ≤ M * ‖x‖)
     (h_below : ∀ N, (∀ x, ‖φ x‖₊ ≤ N * ‖x‖₊) → M ≤ N) : ‖φ‖₊ = M :=
   Subtype.ext <| op_norm_eq_of_bounds (zero_le M) h_above <| Subtype.forall'.mpr h_below
 #align continuous_linear_map.op_nnnorm_eq_of_bounds ContinuousLinearMap.op_nnnorm_eq_of_bounds
 
-set_option synthInstance.etaExperiment true in
 instance toNormedSpace {𝕜' : Type _} [NormedField 𝕜'] [NormedSpace 𝕜' F] [SMulCommClass 𝕜₂ 𝕜' F] :
     NormedSpace 𝕜' (E →SL[σ₁₂] F) :=
   ⟨op_norm_smul_le⟩
 #align continuous_linear_map.to_normed_space ContinuousLinearMap.toNormedSpace
 
-set_option synthInstance.etaExperiment true in
 /-- The operator norm is submultiplicative. -/
 theorem op_norm_comp_le (f : E →SL[σ₁₂] F) : ‖h.comp f‖ ≤ ‖h‖ * ‖f‖ :=
   csInf_le bounds_bddBelow
@@ -501,12 +460,10 @@ theorem op_norm_comp_le (f : E →SL[σ₁₂] F) : ‖h.comp f‖ ≤ ‖h‖ *
 theorem op_norm_comp_le' (h : Eₗ →L[𝕜] Fₗ) (f : E →L[𝕜] Eₗ) : ‖h.comp f‖ ≤ ‖h‖ * ‖f‖ :=
   op_norm_comp_le h f
 
-set_option synthInstance.etaExperiment true in
 theorem op_nnnorm_comp_le [RingHomIsometric σ₁₃] (f : E →SL[σ₁₂] F) : ‖h.comp f‖₊ ≤ ‖h‖₊ * ‖f‖₊ :=
   op_norm_comp_le h f
 #align continuous_linear_map.op_nnnorm_comp_le ContinuousLinearMap.op_nnnorm_comp_le
 
-set_option synthInstance.etaExperiment true in
 /-- Continuous linear maps form a seminormed ring with respect to the operator norm. -/
 instance toSemiNormedRing : SeminormedRing (E →L[𝕜] E) :=
   { ContinuousLinearMap.toSeminormedAddCommGroup, ContinuousLinearMap.ring with
@@ -515,7 +472,6 @@ instance toSemiNormedRing : SeminormedRing (E →L[𝕜] E) :=
 
 -- Porting FIXME: replacing `(algebra : Algebra 𝕜 (E →L[𝕜] E))` with
 -- just `algebra` below causes a massive timeout.
-set_option synthInstance.etaExperiment true in
 /-- For a normed space `E`, continuous linear endomorphisms form a normed algebra with
 respect to the operator norm. -/
 instance toNormedAlgebra : NormedAlgebra 𝕜 (E →L[𝕜] E) :=
@@ -524,23 +480,19 @@ instance toNormedAlgebra : NormedAlgebra 𝕜 (E →L[𝕜] E) :=
       intro c f
       apply op_norm_smul_le c f}
 
-set_option synthInstance.etaExperiment true in
 theorem le_op_nnnorm : ‖f x‖₊ ≤ ‖f‖₊ * ‖x‖₊ :=
   f.le_op_norm x
 #align continuous_linear_map.le_op_nnnorm ContinuousLinearMap.le_op_nnnorm
 
-set_option synthInstance.etaExperiment true in
 theorem nndist_le_op_nnnorm (x y : E) : nndist (f x) (f y) ≤ ‖f‖₊ * nndist x y :=
   dist_le_op_norm f x y
 #align continuous_linear_map.nndist_le_op_nnnorm ContinuousLinearMap.nndist_le_op_nnnorm
 
-set_option synthInstance.etaExperiment true in
 /-- continuous linear maps are Lipschitz continuous. -/
 theorem lipschitz : LipschitzWith ‖f‖₊ f :=
   AddMonoidHomClass.lipschitz_of_bound_nnnorm f _ f.le_op_nnnorm
 #align continuous_linear_map.lipschitz ContinuousLinearMap.lipschitz
 
-set_option synthInstance.etaExperiment true in
 /-- Evaluation of a continuous linear map `f` at a point is Lipschitz continuous in `f`. -/
 theorem lipschitz_apply (x : E) : LipschitzWith ‖x‖₊ fun f : E →SL[σ₁₂] F => f x :=
   lipschitzWith_iff_norm_sub_le.2 fun f g => ((f - g).le_op_norm x).trans_eq (mul_comm _ _)
@@ -552,7 +504,6 @@ section Sup
 
 variable [RingHomIsometric σ₁₂]
 
-set_option synthInstance.etaExperiment true in
 theorem exists_mul_lt_apply_of_lt_op_nnnorm (f : E →SL[σ₁₂] F) {r : ℝ≥0} (hr : r < ‖f‖₊) :
     ∃ x, r * ‖x‖₊ < ‖f x‖₊ := by
   simpa only [not_forall, not_le, Set.mem_setOf] using
@@ -560,14 +511,12 @@ theorem exists_mul_lt_apply_of_lt_op_nnnorm (f : E →SL[σ₁₂] F) {r : ℝ�
       (OrderBot.bddBelow _)
 #align continuous_linear_map.exists_mul_lt_apply_of_lt_op_nnnorm ContinuousLinearMap.exists_mul_lt_apply_of_lt_op_nnnorm
 
-set_option synthInstance.etaExperiment true in
 theorem exists_mul_lt_of_lt_op_norm (f : E →SL[σ₁₂] F) {r : ℝ} (hr₀ : 0 ≤ r) (hr : r < ‖f‖) :
     ∃ x, r * ‖x‖ < ‖f x‖ := by
   lift r to ℝ≥0 using hr₀
   exact f.exists_mul_lt_apply_of_lt_op_nnnorm hr
 #align continuous_linear_map.exists_mul_lt_of_lt_op_norm ContinuousLinearMap.exists_mul_lt_of_lt_op_norm
 
-set_option synthInstance.etaExperiment true in
 theorem exists_lt_apply_of_lt_op_nnnorm {𝕜 𝕜₂ E F : Type _} [NormedAddCommGroup E]
     [SeminormedAddCommGroup F] [DenselyNormedField 𝕜] [NontriviallyNormedField 𝕜₂] {σ₁₂ : 𝕜 →+* 𝕜₂}
     [NormedSpace 𝕜 E] [NormedSpace 𝕜₂ F] [RingHomIsometric σ₁₂] (f : E →SL[σ₁₂] F) {r : ℝ≥0}
@@ -585,7 +534,6 @@ theorem exists_lt_apply_of_lt_op_nnnorm {𝕜 𝕜₂ E F : Type _} [NormedAddCo
   rwa [map_smulₛₗ f, nnnorm_smul, ← NNReal.div_lt_iff hfy, div_eq_mul_inv, this]
 #align continuous_linear_map.exists_lt_apply_of_lt_op_nnnorm ContinuousLinearMap.exists_lt_apply_of_lt_op_nnnorm
 
-set_option synthInstance.etaExperiment true in
 theorem exists_lt_apply_of_lt_op_norm {𝕜 𝕜₂ E F : Type _} [NormedAddCommGroup E]
     [SeminormedAddCommGroup F] [DenselyNormedField 𝕜] [NontriviallyNormedField 𝕜₂] {σ₁₂ : 𝕜 →+* 𝕜₂}
     [NormedSpace 𝕜 E] [NormedSpace 𝕜₂ F] [RingHomIsometric σ₁₂] (f : E →SL[σ₁₂] F) {r : ℝ}
@@ -596,7 +544,6 @@ theorem exists_lt_apply_of_lt_op_norm {𝕜 𝕜₂ E F : Type _} [NormedAddComm
     exact f.exists_lt_apply_of_lt_op_nnnorm hr
 #align continuous_linear_map.exists_lt_apply_of_lt_op_norm ContinuousLinearMap.exists_lt_apply_of_lt_op_norm
 
-set_option synthInstance.etaExperiment true in
 theorem sSup_unit_ball_eq_nnnorm {𝕜 𝕜₂ E F : Type _} [NormedAddCommGroup E]
     [SeminormedAddCommGroup F] [DenselyNormedField 𝕜] [NontriviallyNormedField 𝕜₂] {σ₁₂ : 𝕜 →+* 𝕜₂}
     [NormedSpace 𝕜 E] [NormedSpace 𝕜₂ F] [RingHomIsometric σ₁₂] (f : E →SL[σ₁₂] F) :
@@ -610,7 +557,6 @@ theorem sSup_unit_ball_eq_nnnorm {𝕜 𝕜₂ E F : Type _} [NormedAddCommGroup
     exact ⟨_, ⟨x, mem_ball_zero_iff.2 hx, rfl⟩, hxf⟩
 #align continuous_linear_map.Sup_unit_ball_eq_nnnorm ContinuousLinearMap.sSup_unit_ball_eq_nnnorm
 
-set_option synthInstance.etaExperiment true in
 theorem sSup_unit_ball_eq_norm {𝕜 𝕜₂ E F : Type _} [NormedAddCommGroup E] [SeminormedAddCommGroup F]
     [DenselyNormedField 𝕜] [NontriviallyNormedField 𝕜₂] {σ₁₂ : 𝕜 →+* 𝕜₂} [NormedSpace 𝕜 E]
     [NormedSpace 𝕜₂ F] [RingHomIsometric σ₁₂] (f : E →SL[σ₁₂] F) :
@@ -618,7 +564,6 @@ theorem sSup_unit_ball_eq_norm {𝕜 𝕜₂ E F : Type _} [NormedAddCommGroup E
   simpa only [NNReal.coe_sSup, Set.image_image] using NNReal.coe_eq.2 f.sSup_unit_ball_eq_nnnorm
 #align continuous_linear_map.Sup_unit_ball_eq_norm ContinuousLinearMap.sSup_unit_ball_eq_norm
 
-set_option synthInstance.etaExperiment true in
 theorem sSup_closed_unit_ball_eq_nnnorm {𝕜 𝕜₂ E F : Type _} [NormedAddCommGroup E]
     [SeminormedAddCommGroup F] [DenselyNormedField 𝕜] [NontriviallyNormedField 𝕜₂] {σ₁₂ : 𝕜 →+* 𝕜₂}
     [NormedSpace 𝕜 E] [NormedSpace 𝕜₂ F] [RingHomIsometric σ₁₂] (f : E →SL[σ₁₂] F) :
@@ -627,13 +572,11 @@ theorem sSup_closed_unit_ball_eq_nnnorm {𝕜 𝕜₂ E F : Type _} [NormedAddCo
     rintro - ⟨x, hx, rfl⟩
     exact f.unit_le_op_norm x (mem_closedBall_zero_iff.1 hx)
   refine' le_antisymm (csSup_le ((nonempty_closedBall.mpr zero_le_one).image _) hbdd) _
-  rw [← Sup_unit_ball_eq_nnnorm]
-  exact
-    csSup_le_csSup ⟨‖f‖₊, hbdd⟩ ((nonempty_ball.2 zero_lt_one).image _)
-      (Set.image_subset _ ball_subset_closedBall)
+  rw [← sSup_unit_ball_eq_nnnorm]
+  exact csSup_le_csSup ⟨‖f‖₊, hbdd⟩ ((nonempty_ball.2 zero_lt_one).image _)
+    (Set.image_subset _ ball_subset_closedBall)
 #align continuous_linear_map.Sup_closed_unit_ball_eq_nnnorm ContinuousLinearMap.sSup_closed_unit_ball_eq_nnnorm
 
-set_option synthInstance.etaExperiment true in
 theorem sSup_closed_unit_ball_eq_norm {𝕜 𝕜₂ E F : Type _} [NormedAddCommGroup E]
     [SeminormedAddCommGroup F] [DenselyNormedField 𝕜] [NontriviallyNormedField 𝕜₂] {σ₁₂ : 𝕜 →+* 𝕜₂}
     [NormedSpace 𝕜 E] [NormedSpace 𝕜₂ F] [RingHomIsometric σ₁₂] (f : E →SL[σ₁₂] F) :
@@ -646,7 +589,6 @@ end Sup
 
 section
 
-set_option synthInstance.etaExperiment true in
 theorem op_norm_ext [RingHomIsometric σ₁₃] (f : E →SL[σ₁₂] F) (g : E →SL[σ₁₃] G)
     (h : ∀ x, ‖f x‖ = ‖g x‖) : ‖f‖ = ‖g‖ :=
   op_norm_eq_of_bounds (norm_nonneg _)
@@ -661,13 +603,11 @@ theorem op_norm_ext [RingHomIsometric σ₁₃] (f : E →SL[σ₁₂] F) (g : E
 
 variable [RingHomIsometric σ₂₃]
 
-set_option synthInstance.etaExperiment true in
 theorem op_norm_le_bound₂ (f : E →SL[σ₁₃] F →SL[σ₂₃] G) {C : ℝ} (h0 : 0 ≤ C)
     (hC : ∀ x y, ‖f x y‖ ≤ C * ‖x‖ * ‖y‖) : ‖f‖ ≤ C :=
   f.op_norm_le_bound h0 fun x => (f x).op_norm_le_bound (mul_nonneg h0 (norm_nonneg _)) <| hC x
 #align continuous_linear_map.op_norm_le_bound₂ ContinuousLinearMap.op_norm_le_bound₂
 
-set_option synthInstance.etaExperiment true in
 theorem le_op_norm₂ [RingHomIsometric σ₁₃] (f : E →SL[σ₁₃] F →SL[σ₂₃] G) (x : E) (y : F) :
     ‖f x y‖ ≤ ‖f‖ * ‖x‖ * ‖y‖ :=
   (f x).le_of_op_norm_le (f.le_op_norm x) y
@@ -675,7 +615,6 @@ theorem le_op_norm₂ [RingHomIsometric σ₁₃] (f : E →SL[σ₁₃] F →SL
 
 end
 
-set_option synthInstance.etaExperiment true in
 @[simp]
 theorem op_norm_prod (f : E →L[𝕜] Fₗ) (g : E →L[𝕜] Gₗ) : ‖f.prod g‖ = ‖(f, g)‖ :=
   le_antisymm
@@ -689,13 +628,11 @@ theorem op_norm_prod (f : E →L[𝕜] Fₗ) (g : E →L[𝕜] Gₗ) : ‖f.prod
         (le_max_right _ _).trans ((f.prod g).le_op_norm x))
 #align continuous_linear_map.op_norm_prod ContinuousLinearMap.op_norm_prod
 
-set_option synthInstance.etaExperiment true in
 @[simp]
 theorem op_nnnorm_prod (f : E →L[𝕜] Fₗ) (g : E →L[𝕜] Gₗ) : ‖f.prod g‖₊ = ‖(f, g)‖₊ :=
   Subtype.ext <| op_norm_prod f g
 #align continuous_linear_map.op_nnnorm_prod ContinuousLinearMap.op_nnnorm_prod
 
-set_option synthInstance.etaExperiment true in
 /-- `ContinuousLinearMap.prod` as a `LinearIsometryEquiv`. -/
 def prodₗᵢ (R : Type _) [Semiring R] [Module R Fₗ] [Module R Gₗ] [ContinuousConstSMul R Fₗ]
     [ContinuousConstSMul R Gₗ] [SMulCommClass 𝕜 R Fₗ] [SMulCommClass 𝕜 R Gₗ] :
@@ -705,7 +642,6 @@ def prodₗᵢ (R : Type _) [Semiring R] [Module R Fₗ] [Module R Gₗ] [Contin
 
 variable [RingHomIsometric σ₁₂] (f : E →SL[σ₁₂] F)
 
-set_option synthInstance.etaExperiment true in
 @[simp, nontriviality]
 theorem op_norm_subsingleton [Subsingleton E] : ‖f‖ = 0 := by
   refine' le_antisymm _ (norm_nonneg _)
@@ -722,40 +658,34 @@ variable [RingHomIsometric σ₁₂] (c : 𝕜) (f g : E →SL[σ₁₂] F) (h :
 
 open Asymptotics
 
-set_option synthInstance.etaExperiment true in
 theorem isBigOWith_id (l : Filter E) : IsBigOWith ‖f‖ l f fun x => x :=
   isBigOWith_of_le' _ f.le_op_norm
 set_option linter.uppercaseLean3 false in
 #align continuous_linear_map.is_O_with_id ContinuousLinearMap.isBigOWith_id
 
-set_option synthInstance.etaExperiment true in
 theorem isBigO_id (l : Filter E) : f =O[l] fun x => x :=
   (f.isBigOWith_id l).isBigO
 set_option linter.uppercaseLean3 false in
 #align continuous_linear_map.is_O_id ContinuousLinearMap.isBigO_id
 
-set_option synthInstance.etaExperiment true in
 theorem isBigOWith_comp [RingHomIsometric σ₂₃] {α : Type _} (g : F →SL[σ₂₃] G) (f : α → F)
     (l : Filter α) : IsBigOWith ‖g‖ l (fun x' => g (f x')) f :=
   (g.isBigOWith_id ⊤).comp_tendsto le_top
 set_option linter.uppercaseLean3 false in
 #align continuous_linear_map.is_O_with_comp ContinuousLinearMap.isBigOWith_comp
 
-set_option synthInstance.etaExperiment true in
 theorem isBigO_comp [RingHomIsometric σ₂₃] {α : Type _} (g : F →SL[σ₂₃] G) (f : α → F)
     (l : Filter α) : (fun x' => g (f x')) =O[l] f :=
   (g.isBigOWith_comp f l).isBigO
 set_option linter.uppercaseLean3 false in
 #align continuous_linear_map.is_O_comp ContinuousLinearMap.isBigO_comp
 
-set_option synthInstance.etaExperiment true in
 theorem isBigOWith_sub (f : E →SL[σ₁₂] F) (l : Filter E) (x : E) :
     IsBigOWith ‖f‖ l (fun x' => f (x' - x)) fun x' => x' - x :=
   f.isBigOWith_comp _ l
 set_option linter.uppercaseLean3 false in
 #align continuous_linear_map.is_O_with_sub ContinuousLinearMap.isBigOWith_sub
 
-set_option synthInstance.etaExperiment true in
 theorem isBigO_sub (f : E →SL[σ₁₂] F) (l : Filter E) (x : E) :
     (fun x' => f (x' - x)) =O[l] fun x' => x' - x :=
   f.isBigO_comp _ l
@@ -776,7 +706,6 @@ end LinearIsometry
 
 namespace LinearMap
 
-set_option synthInstance.etaExperiment true in
 /-- If a continuous linear map is constructed from a linear map via the constructor `mkContinuous`,
 then its norm is bounded by the bound given to the constructor if it is nonnegative. -/
 theorem mkContinuous_norm_le (f : E →ₛₗ[σ₁₂] F) {C : ℝ} (hC : 0 ≤ C) (h : ∀ x, ‖f x‖ ≤ C * ‖x‖) :
@@ -784,7 +713,6 @@ theorem mkContinuous_norm_le (f : E →ₛₗ[σ₁₂] F) {C : ℝ} (hC : 0 ≤
   ContinuousLinearMap.op_norm_le_bound _ hC h
 #align linear_map.mk_continuous_norm_le LinearMap.mkContinuous_norm_le
 
-set_option synthInstance.etaExperiment true in
 /-- If a continuous linear map is constructed from a linear map via the constructor `mkContinuous`,
 then its norm is bounded by the bound or zero if bound is negative. -/
 theorem mkContinuous_norm_le' (f : E →ₛₗ[σ₁₂] F) {C : ℝ} (h : ∀ x, ‖f x‖ ≤ C * ‖x‖) :
@@ -795,7 +723,6 @@ theorem mkContinuous_norm_le' (f : E →ₛₗ[σ₁₂] F) {C : ℝ} (h : ∀ x
 
 variable [RingHomIsometric σ₂₃]
 
-set_option synthInstance.etaExperiment true in
 /-- Create a bilinear map (represented as a map `E →L[𝕜] F →L[𝕜] G`) from the corresponding linear
 map and a bound on the norm of the image. The linear map can be constructed using
 `LinearMap.mk₂`. -/
@@ -817,20 +744,17 @@ def mkContinuous₂ (f : E →ₛₗ[σ₁₃] F →ₛₗ[σ₂₃] G) (C : ℝ
         rw [max_mul_of_nonneg _ _ (norm_nonneg x), MulZeroClass.zero_mul]
 #align linear_map.mk_continuous₂ LinearMap.mkContinuous₂
 
-set_option synthInstance.etaExperiment true in
 @[simp]
 theorem mkContinuous₂_apply (f : E →ₛₗ[σ₁₃] F →ₛₗ[σ₂₃] G) {C : ℝ}
     (hC : ∀ x y, ‖f x y‖ ≤ C * ‖x‖ * ‖y‖) (x : E) (y : F) : f.mkContinuous₂ C hC x y = f x y :=
   rfl
 #align linear_map.mk_continuous₂_apply LinearMap.mkContinuous₂_apply
 
-set_option synthInstance.etaExperiment true in
 theorem mkContinuous₂_norm_le' (f : E →ₛₗ[σ₁₃] F →ₛₗ[σ₂₃] G) {C : ℝ}
     (hC : ∀ x y, ‖f x y‖ ≤ C * ‖x‖ * ‖y‖) : ‖f.mkContinuous₂ C hC‖ ≤ max C 0 :=
   mkContinuous_norm_le _ (le_max_iff.2 <| Or.inr le_rfl) _
 #align linear_map.mk_continuous₂_norm_le' LinearMap.mkContinuous₂_norm_le'
 
-set_option synthInstance.etaExperiment true in
 theorem mkContinuous₂_norm_le (f : E →ₛₗ[σ₁₃] F →ₛₗ[σ₂₃] G) {C : ℝ} (h0 : 0 ≤ C)
     (hC : ∀ x y, ‖f x y‖ ≤ C * ‖x‖ * ‖y‖) : ‖f.mkContinuous₂ C hC‖ ≤ C :=
   (f.mkContinuous₂_norm_le' hC).trans_eq <| max_eq_left h0
@@ -842,7 +766,6 @@ namespace ContinuousLinearMap
 
 variable [RingHomIsometric σ₂₃] [RingHomIsometric σ₁₃]
 
-set_option synthInstance.etaExperiment true in
 /-- Flip the order of arguments of a continuous bilinear map.
 For a version bundled as `LinearIsometryEquiv`, see
 `ContinuousLinearMap.flipL`. -/
@@ -858,38 +781,32 @@ def flip (f : E →SL[σ₁₃] F →SL[σ₂₃] G) : F →SL[σ₂₃] E →SL
 
 -- Porting note: in mathlib3, in the proof `norm_nonneg (flip f)` was just `norm_nonneg _`,
 -- but this causes a defeq error now.
-set_option synthInstance.etaExperiment true in
 private theorem le_norm_flip (f : E →SL[σ₁₃] F →SL[σ₂₃] G) : ‖f‖ ≤ ‖flip f‖ :=
   f.op_norm_le_bound₂ (norm_nonneg (flip f)) fun x y => by
     rw [mul_right_comm]
     exact (flip f).le_op_norm₂ y x
 
-set_option synthInstance.etaExperiment true in
 @[simp]
 theorem flip_apply (f : E →SL[σ₁₃] F →SL[σ₂₃] G) (x : E) (y : F) : f.flip y x = f x y :=
   rfl
 #align continuous_linear_map.flip_apply ContinuousLinearMap.flip_apply
 
-set_option synthInstance.etaExperiment true in
 @[simp]
 theorem flip_flip (f : E →SL[σ₁₃] F →SL[σ₂₃] G) : f.flip.flip = f := by
   ext
   rfl
 #align continuous_linear_map.flip_flip ContinuousLinearMap.flip_flip
 
-set_option synthInstance.etaExperiment true in
 @[simp]
 theorem op_norm_flip (f : E →SL[σ₁₃] F →SL[σ₂₃] G) : ‖f.flip‖ = ‖f‖ :=
   le_antisymm (by simpa only [flip_flip] using le_norm_flip f.flip) (le_norm_flip f)
 #align continuous_linear_map.op_norm_flip ContinuousLinearMap.op_norm_flip
 
-set_option synthInstance.etaExperiment true in
 @[simp]
 theorem flip_add (f g : E →SL[σ₁₃] F →SL[σ₂₃] G) : (f + g).flip = f.flip + g.flip :=
   rfl
 #align continuous_linear_map.flip_add ContinuousLinearMap.flip_add
 
-set_option synthInstance.etaExperiment true in
 @[simp]
 theorem flip_smul (c : 𝕜₃) (f : E →SL[σ₁₃] F →SL[σ₂₃] G) : (c • f).flip = c • f.flip :=
   rfl
@@ -897,9 +814,6 @@ theorem flip_smul (c : 𝕜₃) (f : E →SL[σ₁₃] F →SL[σ₂₃] G) : (c
 
 variable (E F G σ₁₃ σ₂₃)
 
-set_option synthInstance.etaExperiment true in
-set_option maxHeartbeats 400000 in
-set_option synthInstance.maxHeartbeats 40000 in
 /-- Flip the order of arguments of a continuous bilinear map.
 This is a version bundled as a `LinearIsometryEquiv`.
 For an unbundled version see `ContinuousLinearMap.flip`. -/
@@ -915,13 +829,11 @@ def flipₗᵢ' : (E →SL[σ₁₃] F →SL[σ₂₃] G) ≃ₗᵢ[𝕜₃] F �
 
 variable {E F G σ₁₃ σ₂₃}
 
-set_option synthInstance.maxHeartbeats 40000 in
 @[simp]
 theorem flipₗᵢ'_symm : (flipₗᵢ' E F G σ₂₃ σ₁₃).symm = flipₗᵢ' F E G σ₁₃ σ₂₃ :=
   rfl
 #align continuous_linear_map.flipₗᵢ'_symm ContinuousLinearMap.flipₗᵢ'_symm
 
-set_option synthInstance.maxHeartbeats 80000 in
 @[simp]
 theorem coe_flipₗᵢ' : ⇑(flipₗᵢ' E F G σ₂₃ σ₁₃) = flip :=
   rfl
@@ -929,8 +841,6 @@ theorem coe_flipₗᵢ' : ⇑(flipₗᵢ' E F G σ₂₃ σ₁₃) = flip :=
 
 variable (𝕜 E Fₗ Gₗ)
 
-set_option synthInstance.etaExperiment true in
-set_option maxHeartbeats 400000 in
 /-- Flip the order of arguments of a continuous bilinear map.
 This is a version bundled as a `LinearIsometryEquiv`.
 For an unbundled version see `ContinuousLinearMap.flip`. -/
@@ -951,7 +861,6 @@ theorem flipₗᵢ_symm : (flipₗᵢ 𝕜 E Fₗ Gₗ).symm = flipₗᵢ 𝕜 F
   rfl
 #align continuous_linear_map.flipₗᵢ_symm ContinuousLinearMap.flipₗᵢ_symm
 
-set_option synthInstance.maxHeartbeats 80000 in
 @[simp]
 theorem coe_flipₗᵢ : ⇑(flipₗᵢ 𝕜 E Fₗ Gₗ) = flip :=
   rfl
@@ -959,7 +868,6 @@ theorem coe_flipₗᵢ : ⇑(flipₗᵢ 𝕜 E Fₗ Gₗ) = flip :=
 
 variable (F σ₁₂) [RingHomIsometric σ₁₂]
 
-set_option synthInstance.etaExperiment true in
 /-- The continuous semilinear map obtained by applying a continuous semilinear map at a given
 vector.
 
@@ -970,7 +878,6 @@ def apply' : E →SL[σ₁₂] (E →SL[σ₁₂] F) →L[𝕜₂] F :=
 
 variable {F σ₁₂}
 
-set_option synthInstance.etaExperiment true in
 @[simp]
 theorem apply_apply' (v : E) (f : E →SL[σ₁₂] F) : apply' F σ₁₂ v f = f v :=
   rfl
@@ -978,7 +885,6 @@ theorem apply_apply' (v : E) (f : E →SL[σ₁₂] F) : apply' F σ₁₂ v f =
 
 variable (𝕜 Fₗ)
 
-set_option synthInstance.etaExperiment true in
 /-- The continuous semilinear map obtained by applying a continuous semilinear map at a given
 vector.
 
@@ -989,7 +895,6 @@ def apply : E →L[𝕜] (E →L[𝕜] Fₗ) →L[𝕜] Fₗ :=
 
 variable {𝕜 Fₗ}
 
-set_option synthInstance.etaExperiment true in
 @[simp]
 theorem apply_apply (v : E) (f : E →L[𝕜] Fₗ) : apply 𝕜 Fₗ v f = f v :=
   rfl
@@ -999,7 +904,6 @@ variable (σ₁₂ σ₂₃ E F G)
 
 set_option linter.uppercaseLean3 false
 
-set_option synthInstance.etaExperiment true in
 /-- Composition of continuous semilinear maps as a continuous semibilinear map. -/
 def compSL : (F →SL[σ₂₃] G) →L[𝕜₃] (E →SL[σ₁₂] F) →SL[σ₂₃] E →SL[σ₁₃] G :=
   LinearMap.mkContinuous₂
@@ -1014,27 +918,23 @@ def compSL : (F →SL[σ₂₃] G) →L[𝕜₃] (E →SL[σ₁₂] F) →SL[σ�
 Should be by `inferInstance`, and indeed not be needed. -/
 local instance : Norm ((F →SL[σ₂₃] G) →L[𝕜₃] (E →SL[σ₁₂] F) →SL[σ₂₃] E →SL[σ₁₃] G) := by
   exact @hasOpNorm _ _ (F →SL[σ₂₃] G) ((E →SL[σ₁₂] F) →SL[σ₂₃] E →SL[σ₁₃] G) _ _ _ _ _ _ _ in
-set_option synthInstance.etaExperiment true in
 theorem norm_compSL_le : ‖compSL E F G σ₁₂ σ₂₃‖ ≤ 1 :=
   LinearMap.mkContinuous₂_norm_le _ zero_le_one _
 #align continuous_linear_map.norm_compSL_le ContinuousLinearMap.norm_compSL_le
 
 variable {σ₁₂ σ₂₃ E F G}
 
-set_option synthInstance.etaExperiment true in
 @[simp]
 theorem compSL_apply (f : F →SL[σ₂₃] G) (g : E →SL[σ₁₂] F) : compSL E F G σ₁₂ σ₂₃ f g = f.comp g :=
   rfl
 #align continuous_linear_map.compSL_apply ContinuousLinearMap.compSL_apply
 
-set_option synthInstance.etaExperiment true in
 theorem _root_.Continuous.const_clm_comp {X} [TopologicalSpace X] {f : X → E →SL[σ₁₂] F}
     (hf : Continuous f) (g : F →SL[σ₂₃] G) :
     Continuous (fun x => g.comp (f x) : X → E →SL[σ₁₃] G) :=
   (compSL E F G σ₁₂ σ₂₃ g).continuous.comp hf
 #align continuous.const_clm_comp Continuous.const_clm_comp
 
-set_option synthInstance.etaExperiment true in
 -- Giving the implicit argument speeds up elaboration significantly
 theorem _root_.Continuous.clm_comp_const {X} [TopologicalSpace X] {g : X → F →SL[σ₂₃] G}
     (hg : Continuous g) (f : E →SL[σ₁₂] F) :
@@ -1045,7 +945,6 @@ theorem _root_.Continuous.clm_comp_const {X} [TopologicalSpace X] {g : X → F �
 
 variable (𝕜 σ₁₂ σ₂₃ E Fₗ Gₗ)
 
-set_option synthInstance.etaExperiment true in
 /-- Composition of continuous linear maps as a continuous bilinear map. -/
 def compL : (Fₗ →L[𝕜] Gₗ) →L[𝕜] (E →L[𝕜] Fₗ) →L[𝕜] E →L[𝕜] Gₗ :=
   compSL E Fₗ Gₗ (RingHom.id 𝕜) (RingHom.id 𝕜)
@@ -1055,12 +954,10 @@ def compL : (Fₗ →L[𝕜] Gₗ) →L[𝕜] (E →L[𝕜] Fₗ) →L[𝕜] E �
 Should be by `inferInstance`, and indeed not be needed. -/
 local instance : Norm ((Fₗ →L[𝕜] Gₗ) →L[𝕜] (E →L[𝕜] Fₗ) →L[𝕜] E →L[𝕜] Gₗ) := by
   exact @hasOpNorm _ _ (Fₗ →L[𝕜] Gₗ) ((E →L[𝕜] Fₗ) →L[𝕜] E →L[𝕜] Gₗ) _ _ _ _ _ _ _ in
-set_option synthInstance.etaExperiment true in
 theorem norm_compL_le : ‖compL 𝕜 E Fₗ Gₗ‖ ≤ 1 :=
   norm_compSL_le _ _ _ _ _
 #align continuous_linear_map.norm_compL_le ContinuousLinearMap.norm_compL_le
 
-set_option synthInstance.etaExperiment true in
 @[simp]
 theorem compL_apply (f : Fₗ →L[𝕜] Gₗ) (g : E →L[𝕜] Fₗ) : compL 𝕜 E Fₗ Gₗ f g = f.comp g :=
   rfl
@@ -1068,20 +965,17 @@ theorem compL_apply (f : Fₗ →L[𝕜] Gₗ) (g : E →L[𝕜] Fₗ) : compL �
 
 variable (Eₗ) {𝕜 E Fₗ Gₗ}
 
-set_option synthInstance.etaExperiment true in
 /-- Apply `L(x,-)` pointwise to bilinear maps, as a continuous bilinear map -/
 @[simps! apply]
 def precompR (L : E →L[𝕜] Fₗ →L[𝕜] Gₗ) : E →L[𝕜] (Eₗ →L[𝕜] Fₗ) →L[𝕜] Eₗ →L[𝕜] Gₗ :=
   (compL 𝕜 Eₗ Fₗ Gₗ).comp L
 #align continuous_linear_map.precompR ContinuousLinearMap.precompR
 
-set_option synthInstance.etaExperiment true in
 /-- Apply `L(-,y)` pointwise to bilinear maps, as a continuous bilinear map -/
 def precompL (L : E →L[𝕜] Fₗ →L[𝕜] Gₗ) : (Eₗ →L[𝕜] E) →L[𝕜] Fₗ →L[𝕜] Eₗ →L[𝕜] Gₗ :=
   (precompR Eₗ (flip L)).flip
 #align continuous_linear_map.precompL ContinuousLinearMap.precompL
 
-set_option synthInstance.etaExperiment true in
 /-- Porting note: Local instance for `norm_precompR_le`.
 Should be by `inferInstance`, and indeed not be needed. -/
 local instance : SeminormedAddCommGroup ((Eₗ →L[𝕜] Fₗ) →L[𝕜] Eₗ →L[𝕜] Gₗ) := inferInstance in
@@ -1099,7 +993,6 @@ theorem norm_precompR_le (L : E →L[𝕜] Fₗ →L[𝕜] Gₗ) : ‖precompR E
 Should be by `inferInstance`, and indeed not be needed. -/
 local instance : Norm ((Eₗ →L[𝕜] E) →L[𝕜] Fₗ →L[𝕜] Eₗ →L[𝕜] Gₗ) := by
   exact @hasOpNorm _ _ (Eₗ →L[𝕜] E) (Fₗ →L[𝕜] Eₗ →L[𝕜] Gₗ) _ _ _ _ _ _ _ in
-set_option synthInstance.etaExperiment true in
 theorem norm_precompL_le (L : E →L[𝕜] Fₗ →L[𝕜] Gₗ) : ‖precompL Eₗ L‖ ≤ ‖L‖ := by
   rw [precompL, op_norm_flip, ← op_norm_flip L]
   exact norm_precompR_le _ L.flip
@@ -1117,8 +1010,6 @@ variable {Eₗ} (𝕜)
 
 set_option linter.uppercaseLean3 false
 
-set_option synthInstance.etaExperiment true in
-set_option maxHeartbeats 800000 in
 /-- `ContinuousLinearMap.prodMap` as a continuous linear map. -/
 def prodMapL : (M₁ →L[𝕜] M₂) × (M₃ →L[𝕜] M₄) →L[𝕜] M₁ × M₃ →L[𝕜] M₂ × M₄ :=
   ContinuousLinearMap.copy
@@ -1163,7 +1054,6 @@ def prodMapL : (M₁ →L[𝕜] M₂) × (M₃ →L[𝕜] M₄) →L[𝕜] M₁ 
 
 variable {M₁ M₂ M₃ M₄}
 
-set_option synthInstance.etaExperiment true in
 @[simp]
 theorem prodMapL_apply (p : (M₁ →L[𝕜] M₂) × (M₃ →L[𝕜] M₄)) :
     ContinuousLinearMap.prodMapL 𝕜 M₁ M₂ M₃ M₄ p = p.1.prodMap p.2 :=
@@ -1172,27 +1062,23 @@ theorem prodMapL_apply (p : (M₁ →L[𝕜] M₂) × (M₃ →L[𝕜] M₄)) :
 
 variable {X : Type _} [TopologicalSpace X]
 
-set_option synthInstance.etaExperiment true in
 theorem _root_.Continuous.prod_mapL {f : X → M₁ →L[𝕜] M₂} {g : X → M₃ →L[𝕜] M₄} (hf : Continuous f)
     (hg : Continuous g) : Continuous fun x => (f x).prodMap (g x) :=
   (prodMapL 𝕜 M₁ M₂ M₃ M₄).continuous.comp (hf.prod_mk hg)
 #align continuous.prod_mapL Continuous.prod_mapL
 
-set_option synthInstance.etaExperiment true in
 theorem _root_.Continuous.prod_map_equivL {f : X → M₁ ≃L[𝕜] M₂} {g : X → M₃ ≃L[𝕜] M₄}
     (hf : Continuous fun x => (f x : M₁ →L[𝕜] M₂)) (hg : Continuous fun x => (g x : M₃ →L[𝕜] M₄)) :
     Continuous fun x => ((f x).prod (g x) : M₁ × M₃ →L[𝕜] M₂ × M₄) :=
   (prodMapL 𝕜 M₁ M₂ M₃ M₄).continuous.comp (hf.prod_mk hg)
 #align continuous.prod_map_equivL Continuous.prod_map_equivL
 
-set_option synthInstance.etaExperiment true in
 theorem _root_.ContinuousOn.prod_mapL {f : X → M₁ →L[𝕜] M₂} {g : X → M₃ →L[𝕜] M₄} {s : Set X}
     (hf : ContinuousOn f s) (hg : ContinuousOn g s) :
     ContinuousOn (fun x => (f x).prodMap (g x)) s :=
   ((prodMapL 𝕜 M₁ M₂ M₃ M₄).continuous.comp_continuousOn (hf.prod hg) : _)
 #align continuous_on.prod_mapL ContinuousOn.prod_mapL
 
-set_option synthInstance.etaExperiment true in
 theorem _root_.ContinuousOn.prod_map_equivL {f : X → M₁ ≃L[𝕜] M₂} {g : X → M₃ ≃L[𝕜] M₄} {s : Set X}
     (hf : ContinuousOn (fun x => (f x : M₁ →L[𝕜] M₂)) s)
     (hg : ContinuousOn (fun x => (g x : M₃ →L[𝕜] M₄)) s) :
@@ -1210,30 +1096,25 @@ variable (𝕜) (𝕜' : Type _) [NonUnitalSeminormedRing 𝕜']
 
 variable [NormedSpace 𝕜 𝕜'] [IsScalarTower 𝕜 𝕜' 𝕜'] [SMulCommClass 𝕜 𝕜' 𝕜']
 
-set_option synthInstance.etaExperiment true in
 /-- Multiplication in a non-unital normed algebra as a continuous bilinear map. -/
 def mul : 𝕜' →L[𝕜] 𝕜' →L[𝕜] 𝕜' :=
   (LinearMap.mul 𝕜 𝕜').mkContinuous₂ 1 fun x y => by simpa using norm_mul_le x y
 #align continuous_linear_map.mul ContinuousLinearMap.mul
 
-set_option synthInstance.etaExperiment true in
 @[simp]
 theorem mul_apply' (x y : 𝕜') : mul 𝕜 𝕜' x y = x * y :=
   rfl
 #align continuous_linear_map.mul_apply' ContinuousLinearMap.mul_apply'
 
-set_option synthInstance.etaExperiment true in
 @[simp]
 theorem op_norm_mul_apply_le (x : 𝕜') : ‖mul 𝕜 𝕜' x‖ ≤ ‖x‖ :=
   op_norm_le_bound _ (norm_nonneg x) (norm_mul_le x)
 #align continuous_linear_map.op_norm_mul_apply_le ContinuousLinearMap.op_norm_mul_apply_le
 
-set_option synthInstance.etaExperiment true in
 theorem op_norm_mul_le : ‖mul 𝕜 𝕜'‖ ≤ 1 :=
   LinearMap.mkContinuous₂_norm_le _ zero_le_one _
 #align continuous_linear_map.op_norm_mul_le ContinuousLinearMap.op_norm_mul_le
 
-set_option synthInstance.etaExperiment true in
 /-- Simultaneous left- and right-multiplication in a non-unital normed algebra, considered as a
 continuous trilinear map. This is akin to its non-continuous version `LinearMap.mulLeftRight`,
 but there is a minor difference: `LinearMap.mulLeftRight` is uncurried. -/
@@ -1274,7 +1155,6 @@ variable (𝕜) (𝕜' : Type _) [SeminormedRing 𝕜']
 
 variable [NormedAlgebra 𝕜 𝕜'] [NormOneClass 𝕜']
 
-set_option synthInstance.etaExperiment true in
 /-- Multiplication in a normed algebra as a linear isometry to the space of
 continuous linear maps. -/
 def mulₗᵢ : 𝕜' →ₗᵢ[𝕜] 𝕜' →L[𝕜] 𝕜' where
@@ -1291,7 +1171,6 @@ theorem coe_mulₗᵢ : ⇑(mulₗᵢ 𝕜 𝕜') = mul 𝕜 𝕜' :=
   rfl
 #align continuous_linear_map.coe_mulₗᵢ ContinuousLinearMap.coe_mulₗᵢ
 
-set_option synthInstance.etaExperiment true in
 @[simp]
 theorem op_norm_mul_apply (x : 𝕜') : ‖mul 𝕜 𝕜' x‖ = ‖x‖ :=
   (mulₗᵢ 𝕜 𝕜').norm_map x
@@ -1307,14 +1186,12 @@ variable (𝕜) (𝕜' : Type _) [NormedField 𝕜']
 
 variable [NormedAlgebra 𝕜 𝕜'] [NormedSpace 𝕜' E] [IsScalarTower 𝕜 𝕜' E]
 
-set_option synthInstance.etaExperiment true in
 /-- Scalar multiplication as a continuous bilinear map. -/
 def lsmul : 𝕜' →L[𝕜] E →L[𝕜] E :=
   ((Algebra.lsmul 𝕜 E).toLinearMap : 𝕜' →ₗ[𝕜] E →ₗ[𝕜] E).mkContinuous₂ 1 fun c x => by
     simpa only [one_mul] using norm_smul_le c x
 #align continuous_linear_map.lsmul ContinuousLinearMap.lsmul
 
-set_option synthInstance.etaExperiment true in
 @[simp]
 theorem lsmul_apply (c : 𝕜') (x : E) : lsmul 𝕜 𝕜' c x = c • x :=
   rfl
@@ -1332,12 +1209,10 @@ theorem norm_toSpanSingleton (x : E) : ‖toSpanSingleton 𝕜 x‖ = ‖x‖ :=
 
 variable {𝕜}
 
-set_option synthInstance.etaExperiment true in
 theorem op_norm_lsmul_apply_le (x : 𝕜') : ‖(lsmul 𝕜 𝕜' x : E →L[𝕜] E)‖ ≤ ‖x‖ :=
   ContinuousLinearMap.op_norm_le_bound _ (norm_nonneg x) fun y => norm_smul_le x y
 #align continuous_linear_map.op_norm_lsmul_apply_le ContinuousLinearMap.op_norm_lsmul_apply_le
 
-set_option synthInstance.etaExperiment true in
 /-- The norm of `lsmul` is at most 1 in any semi-normed group. -/
 theorem op_norm_lsmul_le : ‖(lsmul 𝕜 𝕜' : 𝕜' →L[𝕜] E →L[𝕜] E)‖ ≤ 1 := by
   refine' ContinuousLinearMap.op_norm_le_bound _ zero_le_one fun x => _
@@ -1355,7 +1230,6 @@ variable [NormedSpace 𝕜' E] [IsScalarTower 𝕜' 𝕜 E]
 
 variable [NormedSpace 𝕜' Fₗ] [IsScalarTower 𝕜' 𝕜 Fₗ]
 
-set_option synthInstance.etaExperiment true in
 @[simp]
 theorem norm_restrictScalars (f : E →L[𝕜] Fₗ) : ‖f.restrictScalars 𝕜'‖ = ‖f‖ :=
   le_antisymm (op_norm_le_bound _ (norm_nonneg _) fun x => f.le_op_norm x)
@@ -1367,7 +1241,6 @@ variable (𝕜 E Fₗ 𝕜') (𝕜'' : Type _) [Ring 𝕜'']
 variable [Module 𝕜'' Fₗ] [ContinuousConstSMul 𝕜'' Fₗ]
   [SMulCommClass 𝕜 𝕜'' Fₗ] [SMulCommClass 𝕜' 𝕜'' Fₗ]
 
-set_option synthInstance.etaExperiment true in
 /-- `ContinuousLinearMap.restrictScalars` as a `LinearIsometry`. -/
 def restrictScalarsIsometry : (E →L[𝕜] Fₗ) →ₗᵢ[𝕜''] E →L[𝕜'] Fₗ :=
   ⟨restrictScalarsₗ 𝕜 E Fₗ 𝕜' 𝕜'', norm_restrictScalars⟩
@@ -1389,7 +1262,6 @@ theorem restrictScalarsIsometry_toLinearMap :
 
 variable (𝕜 E Fₗ 𝕜' 𝕜'')
 
-set_option synthInstance.etaExperiment true in
 /-- `ContinuousLinearMap.restrictScalars` as a `ContinuousLinearMap`. -/
 def restrictScalarsL : (E →L[𝕜] Fₗ) →L[𝕜''] E →L[𝕜'] Fₗ :=
   (restrictScalarsIsometry 𝕜 E Fₗ 𝕜' 𝕜'').toContinuousLinearMap
@@ -1398,7 +1270,6 @@ set_option linter.uppercaseLean3 false in
 
 variable {𝕜 E Fₗ 𝕜' 𝕜''}
 
-set_option synthInstance.etaExperiment true in
 @[simp]
 theorem coe_restrictScalarsL :
     (restrictScalarsL 𝕜 E Fₗ 𝕜' 𝕜'' : (E →L[𝕜] Fₗ) →ₗ[𝕜''] E →L[𝕜'] Fₗ) =
@@ -1433,19 +1304,16 @@ section
 variable {σ₂₁ : 𝕜₂ →+* 𝕜} [RingHomInvPair σ₁₂ σ₂₁] [RingHomInvPair σ₂₁ σ₁₂] [RingHomIsometric σ₁₂]
 variable (e : E ≃SL[σ₁₂] F)
 
-set_option synthInstance.etaExperiment true in
 protected theorem lipschitz : LipschitzWith ‖(e : E →SL[σ₁₂] F)‖₊ e :=
   (e : E →SL[σ₁₂] F).lipschitz
 #align continuous_linear_equiv.lipschitz ContinuousLinearEquiv.lipschitz
 
-set_option synthInstance.etaExperiment true in
 theorem isBigO_comp (e : E ≃SL[σ₁₂] F) {α : Type _} (f : α → E) (l : Filter α) :
     (fun x' => e (f x')) =O[l] f :=
   (e : E →SL[σ₁₂] F).isBigO_comp f l
 set_option linter.uppercaseLean3 false in
 #align continuous_linear_equiv.is_O_comp ContinuousLinearEquiv.isBigO_comp
 
-set_option synthInstance.etaExperiment true in
 theorem isBigO_sub (e : E ≃SL[σ₁₂] F) (l : Filter E) (x : E) :
     (fun x' => e (x' - x)) =O[l] fun x' => x' - x :=
   (e : E →SL[σ₁₂] F).isBigO_sub l x
@@ -1458,7 +1326,6 @@ variable {σ₂₁ : 𝕜₂ →+* 𝕜} [RingHomInvPair σ₁₂ σ₂₁] [Rin
 
 variable [RingHomIsometric σ₂₁]
 
-set_option synthInstance.etaExperiment true in
 variable (e : E ≃SL[σ₁₂] F)
 
 theorem isBigO_comp_rev (e : E ≃SL[σ₁₂] F) {α : Type _} (f : α → E) (l : Filter α) :
@@ -1486,7 +1353,6 @@ variable {𝕜₁' : Type _} {𝕜₂' : Type _} [NontriviallyNormedField 𝕜�
   {σ₂₃' : 𝕜₂' →+* 𝕜₃} [RingHomCompTriple σ₁' σ₁₃ σ₁₃'] [RingHomCompTriple σ₂' σ₂₃ σ₂₃']
   [RingHomIsometric σ₂₃] [RingHomIsometric σ₁₃'] [RingHomIsometric σ₂₃']
 
-set_option synthInstance.etaExperiment true in
 /-- Compose a bilinear map `E →SL[σ₁₃] F →SL[σ₂₃] G` with two linear maps
 `E' →SL[σ₁'] E` and `F' →SL[σ₂'] F`.  -/
 def bilinearComp (f : E →SL[σ₁₃] F →SL[σ₂₃] G) (gE : E' →SL[σ₁'] E) (gF : F' →SL[σ₂'] F) :
@@ -1494,7 +1360,6 @@ def bilinearComp (f : E →SL[σ₁₃] F →SL[σ₂₃] G) (gE : E' →SL[σ�
   ((f.comp gE).flip.comp gF).flip
 #align continuous_linear_map.bilinear_comp ContinuousLinearMap.bilinearComp
 
-set_option synthInstance.etaExperiment true in
 @[simp]
 theorem bilinearComp_apply (f : E →SL[σ₁₃] F →SL[σ₂₃] G) (gE : E' →SL[σ₁'] E) (gF : F' →SL[σ₂'] F)
     (x : E') (y : F') : f.bilinearComp gE gF x y = f (gE x) (gF y) :=
@@ -1503,21 +1368,18 @@ theorem bilinearComp_apply (f : E →SL[σ₁₃] F →SL[σ₂₃] G) (gE : E' 
 
 variable [RingHomIsometric σ₁₃] [RingHomIsometric σ₁'] [RingHomIsometric σ₂']
 
-set_option synthInstance.etaExperiment true in
 /-- Derivative of a continuous bilinear map `f : E →L[𝕜] F →L[𝕜] G` interpreted as a map `E × F → G`
 at point `p : E × F` evaluated at `q : E × F`, as a continuous bilinear map. -/
 def deriv₂ (f : E →L[𝕜] Fₗ →L[𝕜] Gₗ) : E × Fₗ →L[𝕜] E × Fₗ →L[𝕜] Gₗ :=
   f.bilinearComp (fst _ _ _) (snd _ _ _) + f.flip.bilinearComp (snd _ _ _) (fst _ _ _)
 #align continuous_linear_map.deriv₂ ContinuousLinearMap.deriv₂
 
-set_option synthInstance.etaExperiment true in
 @[simp]
 theorem coe_deriv₂ (f : E →L[𝕜] Fₗ →L[𝕜] Gₗ) (p : E × Fₗ) :
     ⇑(f.deriv₂ p) = fun q : E × Fₗ => f p.1 q.2 + f q.1 p.2 :=
   rfl
 #align continuous_linear_map.coe_deriv₂ ContinuousLinearMap.coe_deriv₂
 
-set_option synthInstance.etaExperiment true in
 theorem map_add_add (f : E →L[𝕜] Fₗ →L[𝕜] Gₗ) (x x' : E) (y y' : Fₗ) :
     f (x + x') (y + y') = f x y + f.deriv₂ (x, y) (x', y') + f x' y' := by
   simp only [map_add, add_apply, coe_deriv₂, add_assoc]
@@ -1543,7 +1405,6 @@ variable [NontriviallyNormedField 𝕜] [NontriviallyNormedField 𝕜₂] [Nontr
 
 namespace LinearMap
 
-set_option synthInstance.etaExperiment true in
 theorem bound_of_shell [RingHomIsometric σ₁₂] (f : E →ₛₗ[σ₁₂] F) {ε C : ℝ} (ε_pos : 0 < ε) {c : 𝕜}
     (hc : 1 < ‖c‖) (hf : ∀ x, ε / ‖c‖ ≤ ‖x‖ → ‖x‖ < ε → ‖f x‖ ≤ C * ‖x‖) (x : E) :
     ‖f x‖ ≤ C * ‖x‖ := by
@@ -1552,7 +1413,6 @@ theorem bound_of_shell [RingHomIsometric σ₁₂] (f : E →ₛₗ[σ₁₂] F)
     SemilinearMapClass.bound_of_shell_semi_normed f ε_pos hc hf (ne_of_lt (norm_pos_iff.2 hx)).symm
 #align linear_map.bound_of_shell LinearMap.bound_of_shell
 
-set_option synthInstance.etaExperiment true in
 /-- `LinearMap.bound_of_ball_bound'` is a version of this lemma over a field satisfying `IsROrC`
 that produces a concrete bound.
 -/
@@ -1571,7 +1431,6 @@ theorem bound_of_ball_bound {r : ℝ} (r_pos : 0 < r) (c : ℝ) (f : E →ₗ[�
     exact (one_le_div r_pos).mpr hko
 #align linear_map.bound_of_ball_bound LinearMap.bound_of_ball_bound
 
-set_option synthInstance.etaExperiment true in
 theorem antilipschitz_of_comap_nhds_le [h : RingHomIsometric σ₁₂] (f : E →ₛₗ[σ₁₂] F)
     (hf : (𝓝 0).comap f ≤ 𝓝 0) : ∃ K, AntilipschitzWith K f := by
   rcases ((nhds_basis_ball.comap _).le_basis_iff nhds_basis_ball).1 hf 1 one_pos with ⟨ε, ε0, hε⟩
@@ -1605,7 +1464,6 @@ section OpNorm
 
 open Set Real
 
-set_option synthInstance.etaExperiment true in
 /-- An operator is zero iff its norm vanishes. -/
 theorem op_norm_zero_iff [RingHomIsometric σ₁₂] : ‖f‖ = 0 ↔ f = 0 :=
   Iff.intro
@@ -1620,7 +1478,6 @@ theorem op_norm_zero_iff [RingHomIsometric σ₁₂] : ‖f‖ = 0 ↔ f = 0 :=
       exact op_norm_zero)
 #align continuous_linear_map.op_norm_zero_iff ContinuousLinearMap.op_norm_zero_iff
 
-set_option synthInstance.etaExperiment true in
 /-- If a normed space is non-trivial, then the norm of the identity equals `1`. -/
 @[simp]
 theorem norm_id [Nontrivial E] : ‖id 𝕜 E‖ = 1 := by
@@ -1629,7 +1486,6 @@ theorem norm_id [Nontrivial E] : ‖id 𝕜 E‖ = 1 := by
   exact ⟨x, ne_of_gt (norm_pos_iff.2 hx)⟩
 #align continuous_linear_map.norm_id ContinuousLinearMap.norm_id
 
-set_option synthInstance.etaExperiment true in
 instance normOneClass [Nontrivial E] : NormOneClass (E →L[𝕜] E) :=
   ⟨norm_id⟩
 #align continuous_linear_map.norm_one_class ContinuousLinearMap.normOneClass
@@ -1647,7 +1503,6 @@ instance toNormedRing : NormedRing (E →L[𝕜] E) :=
 
 variable {f}
 
-set_option synthInstance.etaExperiment true in
 theorem homothety_norm [RingHomIsometric σ₁₂] [Nontrivial E] (f : E →SL[σ₁₂] F) {a : ℝ}
     (hf : ∀ x, ‖f x‖ = a * ‖x‖) : ‖f‖ = a := by
   obtain ⟨x, hx⟩ : ∃ x : E, x ≠ 0 := exists_ne 0
@@ -1659,7 +1514,6 @@ theorem homothety_norm [RingHomIsometric σ₁₂] [Nontrivial E] (f : E →SL[�
 
 variable (f)
 
-set_option synthInstance.etaExperiment true in
 /-- If a continuous linear map is a topology embedding, then it is expands the distances
 by a positive factor.-/
 theorem antilipschitz_of_embedding (f : E →L[𝕜] Fₗ) (hf : Embedding f) :
@@ -1675,7 +1529,6 @@ open Filter
 
 variable {E' : Type _} [SeminormedAddCommGroup E'] [NormedSpace 𝕜 E'] [RingHomIsometric σ₁₂]
 
-set_option synthInstance.etaExperiment true in
 /-- Construct a bundled continuous (semi)linear map from a map `f : E → F` and a proof of the fact
 that it belongs to the closure of the image of a bounded set `s : set (E →SL[σ₁₂] F)` under coercion
 to function. Coercion to function of the result is definitionally equal to `f`. -/
@@ -1706,7 +1559,6 @@ def ofTendstoOfBoundedRange {α : Type _} {l : Filter α} [l.NeBot] (f : E' → 
     eventually_of_forall fun _ => mem_image_of_mem _ <| Set.mem_range_self _
 #align continuous_linear_map.of_tendsto_of_bounded_range ContinuousLinearMap.ofTendstoOfBoundedRange
 
-set_option synthInstance.etaExperiment true in
 /-- If a Cauchy sequence of continuous linear map converges to a continuous linear map pointwise,
 then it converges to the same map in norm. This lemma is used to prove that the space of continuous
 linear maps is complete provided that the codomain is a complete space. -/
@@ -1729,7 +1581,6 @@ theorem tendsto_of_tendsto_pointwise_of_cauchySeq {f : ℕ → E' →SL[σ₁₂
   exact (f n - f m).le_of_op_norm_le (hfb _ _ _ le_rfl hm) _
 #align continuous_linear_map.tendsto_of_tendsto_pointwise_of_cauchy_seq ContinuousLinearMap.tendsto_of_tendsto_pointwise_of_cauchySeq
 
-set_option synthInstance.etaExperiment true in
 /-- If the target space is complete, the space of continuous linear maps with its norm is also
 complete. This works also if the source space is seminormed. -/
 instance [CompleteSpace F] : CompleteSpace (E' →SL[σ₁₂] F) := by
@@ -1771,7 +1622,6 @@ theorem isCompact_image_coe_of_bounded_of_closed_image [ProperSpace F] {s : Set 
   hc.closure_eq ▸ isCompact_closure_image_coe_of_bounded hb
 #align continuous_linear_map.is_compact_image_coe_of_bounded_of_closed_image ContinuousLinearMap.isCompact_image_coe_of_bounded_of_closed_image
 
-set_option synthInstance.etaExperiment true in
 /-- If a set `s` of semilinear functions is bounded and is closed in the weak-* topology, then its
 image under coercion to functions `E → F` is a closed set. We don't have a name for `E →SL[σ] F`
 with weak-* topology in `mathlib`, so we use an equivalent condition (see `isClosed_induced_iff'`).
@@ -1785,7 +1635,6 @@ theorem isClosed_image_coe_of_bounded_of_weak_closed {s : Set (E' →SL[σ₁₂
     ⟨ofMemClosureImageCoeBounded f hb hf, hc (ofMemClosureImageCoeBounded f hb hf) hf, rfl⟩
 #align continuous_linear_map.is_closed_image_coe_of_bounded_of_weak_closed ContinuousLinearMap.isClosed_image_coe_of_bounded_of_weak_closed
 
-set_option synthInstance.etaExperiment true in
 /-- If a set `s` of semilinear functions is bounded and is closed in the weak-* topology, then its
 image under coercion to functions `E → F` is a compact set. We don't have a name for `E →SL[σ] F`
 with weak-* topology in `mathlib`, so we use an equivalent condition (see `isClosed_induced_iff'`).
@@ -1799,7 +1648,6 @@ theorem isCompact_image_coe_of_bounded_of_weak_closed [ProperSpace F] {s : Set (
     isClosed_image_coe_of_bounded_of_weak_closed hb hc
 #align continuous_linear_map.is_compact_image_coe_of_bounded_of_weak_closed ContinuousLinearMap.isCompact_image_coe_of_bounded_of_weak_closed
 
-set_option synthInstance.etaExperiment true in
 /-- A closed ball is closed in the weak-* topology. We don't have a name for `E →SL[σ] F` with
 weak-* topology in `mathlib`, so we use an equivalent condition (see `isClosed_induced_iff'`). -/
 theorem is_weak_closed_closedBall (f₀ : E' →SL[σ₁₂] F) (r : ℝ) ⦃f : E' →SL[σ₁₂] F⦄
@@ -1945,7 +1793,6 @@ theorem norm_toContinuousLinearMap [Nontrivial E] [RingHomIsometric σ₁₂] (f
 
 variable {σ₁₃ : 𝕜 →+* 𝕜₃} [RingHomCompTriple σ₁₂ σ₂₃ σ₁₃]
 
-set_option synthInstance.etaExperiment true in
 /-- Postcomposition of a continuous linear map with a linear isometry preserves
 the operator norm. -/
 theorem norm_toContinuousLinearMap_comp [RingHomIsometric σ₁₂] (f : F →ₛₗᵢ[σ₂₃] G)
@@ -1970,7 +1817,6 @@ variable {𝕜₂' : Type _} [NontriviallyNormedField 𝕜₂'] {F' : Type _} [N
   [RingHomCompTriple σ₂'' σ₂₃' σ₂₃] [RingHomIsometric σ₂₃] [RingHomIsometric σ₂']
   [RingHomIsometric σ₂''] [RingHomIsometric σ₂₃']
 
-set_option synthInstance.etaExperiment true in
 /-- Precomposition with a linear isometry preserves the operator norm. -/
 theorem op_norm_comp_linearIsometryEquiv (f : F →SL[σ₂₃] G) (g : F' ≃ₛₗᵢ[σ₂'] F) :
     ‖f.comp g.toLinearIsometry.toContinuousLinearMap‖ = ‖f‖ := by
@@ -1988,7 +1834,6 @@ theorem op_norm_comp_linearIsometryEquiv (f : F →SL[σ₂₃] G) (g : F' ≃�
     simp [g.symm.toLinearIsometry.norm_toContinuousLinearMap]
 #align continuous_linear_map.op_norm_comp_linear_isometry_equiv ContinuousLinearMap.op_norm_comp_linearIsometryEquiv
 
-set_option synthInstance.etaExperiment true in
 /-- The norm of the tensor product of a scalar linear map and of an element of a normed space
 is the product of the norms. -/
 @[simp]
@@ -2011,7 +1856,6 @@ theorem norm_smulRight_apply (c : E →L[𝕜] 𝕜) (f : Fₗ) : ‖smulRight c
         _ ≤ ‖smulRight c f‖ * ‖x‖ := le_op_norm _ _
 #align continuous_linear_map.norm_smul_right_apply ContinuousLinearMap.norm_smulRight_apply
 
-set_option synthInstance.etaExperiment true in
 /-- The non-negative norm of the tensor product of a scalar linear map and of an element of a normed
 space is the product of the non-negative norms. -/
 @[simp]
@@ -2021,7 +1865,6 @@ theorem nnnorm_smulRight_apply (c : E →L[𝕜] 𝕜) (f : Fₗ) : ‖smulRight
 
 variable (𝕜 E Fₗ)
 
-set_option synthInstance.etaExperiment true in
 /-- `ContinuousLinearMap.smulRight` as a continuous trilinear map:
 `smul_rightL (c : E →L[𝕜] 𝕜) (f : F) (x : E) = c x • f`. -/
 def smulRightL : (E →L[𝕜] 𝕜) →L[𝕜] Fₗ →L[𝕜] E →L[𝕜] Fₗ :=
@@ -2068,7 +1911,6 @@ theorem op_norm_mul [NormOneClass 𝕜'] : ‖mul 𝕜 𝕜'‖ = 1 :=
 
 end
 
-set_option synthInstance.etaExperiment true in
 /-- The norm of `lsmul` equals 1 in any nontrivial normed group.
 
 This is `ContinuousLinearMap.op_norm_lsmul_le` as an equality. -/
@@ -2092,7 +1934,6 @@ namespace Submodule
 variable [NontriviallyNormedField 𝕜] [NontriviallyNormedField 𝕜₂] [NontriviallyNormedField 𝕜₃]
   [NormedSpace 𝕜 E] [NormedSpace 𝕜₂ F] {σ₁₂ : 𝕜 →+* 𝕜₂}
 
-set_option synthInstance.etaExperiment true in
 theorem norm_subtypeL (K : Submodule 𝕜 E) [Nontrivial K] : ‖K.subtypeL‖ = 1 :=
   K.subtypeₗᵢ.norm_toContinuousLinearMap
 set_option linter.uppercaseLean3 false in
@@ -2110,13 +1951,11 @@ section
 
 variable [RingHomIsometric σ₂₁]
 
-set_option synthInstance.etaExperiment true in
 protected theorem antilipschitz (e : E ≃SL[σ₁₂] F) :
     AntilipschitzWith ‖(e.symm : F →SL[σ₂₁] E)‖₊ e :=
   e.symm.lipschitz.to_rightInverse e.left_inv
 #align continuous_linear_equiv.antilipschitz ContinuousLinearEquiv.antilipschitz
 
-set_option synthInstance.etaExperiment true in
 theorem one_le_norm_mul_norm_symm [RingHomIsometric σ₁₂] [Nontrivial E] (e : E ≃SL[σ₁₂] F) :
     1 ≤ ‖(e : E →SL[σ₁₂] F)‖ * ‖(e.symm : F →SL[σ₂₁] E)‖ := by
   rw [mul_comm]
@@ -2124,25 +1963,21 @@ theorem one_le_norm_mul_norm_symm [RingHomIsometric σ₁₂] [Nontrivial E] (e 
   rw [e.coe_symm_comp_coe, ContinuousLinearMap.norm_id]
 #align continuous_linear_equiv.one_le_norm_mul_norm_symm ContinuousLinearEquiv.one_le_norm_mul_norm_symm
 
-set_option synthInstance.etaExperiment true in
 theorem norm_pos [RingHomIsometric σ₁₂] [Nontrivial E] (e : E ≃SL[σ₁₂] F) :
     0 < ‖(e : E →SL[σ₁₂] F)‖ :=
   pos_of_mul_pos_left (lt_of_lt_of_le zero_lt_one e.one_le_norm_mul_norm_symm) (norm_nonneg _)
 #align continuous_linear_equiv.norm_pos ContinuousLinearEquiv.norm_pos
 
-set_option synthInstance.etaExperiment true in
 theorem norm_symm_pos [RingHomIsometric σ₁₂] [Nontrivial E] (e : E ≃SL[σ₁₂] F) :
     0 < ‖(e.symm : F →SL[σ₂₁] E)‖ :=
   pos_of_mul_pos_right (zero_lt_one.trans_le e.one_le_norm_mul_norm_symm) (norm_nonneg _)
 #align continuous_linear_equiv.norm_symm_pos ContinuousLinearEquiv.norm_symm_pos
 
-set_option synthInstance.etaExperiment true in
 theorem nnnorm_symm_pos [RingHomIsometric σ₁₂] [Nontrivial E] (e : E ≃SL[σ₁₂] F) :
     0 < ‖(e.symm : F →SL[σ₂₁] E)‖₊ :=
   e.norm_symm_pos
 #align continuous_linear_equiv.nnnorm_symm_pos ContinuousLinearEquiv.nnnorm_symm_pos
 
-set_option synthInstance.etaExperiment true in
 theorem subsingleton_or_norm_symm_pos [RingHomIsometric σ₁₂] (e : E ≃SL[σ₁₂] F) :
     Subsingleton E ∨ 0 < ‖(e.symm : F →SL[σ₂₁] E)‖ := by
   rcases subsingleton_or_nontrivial E with (_i | _i) <;> skip
@@ -2152,7 +1987,6 @@ theorem subsingleton_or_norm_symm_pos [RingHomIsometric σ₁₂] (e : E ≃SL[�
     exact e.norm_symm_pos
 #align continuous_linear_equiv.subsingleton_or_norm_symm_pos ContinuousLinearEquiv.subsingleton_or_norm_symm_pos
 
-set_option synthInstance.etaExperiment true in
 theorem subsingleton_or_nnnorm_symm_pos [RingHomIsometric σ₁₂] (e : E ≃SL[σ₁₂] F) :
     Subsingleton E ∨ 0 < ‖(e.symm : F →SL[σ₂₁] E)‖₊ :=
   subsingleton_or_norm_symm_pos e
@@ -2160,7 +1994,6 @@ theorem subsingleton_or_nnnorm_symm_pos [RingHomIsometric σ₁₂] (e : E ≃SL
 
 variable (𝕜)
 
-set_option synthInstance.etaExperiment true in
 @[simp]
 theorem coord_norm (x : E) (h : x ≠ 0) : ‖coord 𝕜 x h‖ = ‖x‖⁻¹ := by
   have hx : 0 < ‖x‖ := norm_pos_iff.mpr h
@@ -2193,7 +2026,6 @@ variable [RingHomIsometric σ₁₃] [RingHomIsometric σ₁₂]
 
 variable [RingHomIsometric σ₃₄]
 
-set_option synthInstance.etaExperiment true in
 /-- A pair of continuous (semi)linear equivalences generates an continuous (semi)linear equivalence
 between the spaces of continuous (semi)linear maps. -/
 @[simps apply symm_apply]
@@ -2208,7 +2040,6 @@ def arrowCongrSL (e₁₂ : E ≃SL[σ₁₂] F) (e₄₃ : H ≃SL[σ₄₃] G)
 set_option linter.uppercaseLean3 false in
 #align continuous_linear_equiv.arrow_congrSL ContinuousLinearEquiv.arrowCongrSL
 
-set_option synthInstance.etaExperiment true in
 /-- A pair of continuous linear equivalences generates an continuous linear equivalence between
 the spaces of continuous linear maps. -/
 def arrowCongr {F H : Type _} [NormedAddCommGroup F] [NormedAddCommGroup H] [NormedSpace 𝕜 F]

--- a/Mathlib/Analysis/NormedSpace/OperatorNorm.lean
+++ b/Mathlib/Analysis/NormedSpace/OperatorNorm.lean
@@ -814,6 +814,8 @@ theorem flip_smul (c : 𝕜₃) (f : E →SL[σ₁₃] F →SL[σ₂₃] G) : (c
 
 variable (E F G σ₁₃ σ₂₃)
 
+set_option maxHeartbeats 400000 in
+set_option synthInstance.maxHeartbeats 40000 in
 /-- Flip the order of arguments of a continuous bilinear map.
 This is a version bundled as a `LinearIsometryEquiv`.
 For an unbundled version see `ContinuousLinearMap.flip`. -/
@@ -829,11 +831,13 @@ def flipₗᵢ' : (E →SL[σ₁₃] F →SL[σ₂₃] G) ≃ₗᵢ[𝕜₃] F �
 
 variable {E F G σ₁₃ σ₂₃}
 
+set_option synthInstance.maxHeartbeats 40000 in
 @[simp]
 theorem flipₗᵢ'_symm : (flipₗᵢ' E F G σ₂₃ σ₁₃).symm = flipₗᵢ' F E G σ₁₃ σ₂₃ :=
   rfl
 #align continuous_linear_map.flipₗᵢ'_symm ContinuousLinearMap.flipₗᵢ'_symm
 
+set_option synthInstance.maxHeartbeats 80000 in
 @[simp]
 theorem coe_flipₗᵢ' : ⇑(flipₗᵢ' E F G σ₂₃ σ₁₃) = flip :=
   rfl
@@ -841,6 +845,7 @@ theorem coe_flipₗᵢ' : ⇑(flipₗᵢ' E F G σ₂₃ σ₁₃) = flip :=
 
 variable (𝕜 E Fₗ Gₗ)
 
+set_option maxHeartbeats 400000 in
 /-- Flip the order of arguments of a continuous bilinear map.
 This is a version bundled as a `LinearIsometryEquiv`.
 For an unbundled version see `ContinuousLinearMap.flip`. -/
@@ -861,6 +866,7 @@ theorem flipₗᵢ_symm : (flipₗᵢ 𝕜 E Fₗ Gₗ).symm = flipₗᵢ 𝕜 F
   rfl
 #align continuous_linear_map.flipₗᵢ_symm ContinuousLinearMap.flipₗᵢ_symm
 
+set_option synthInstance.maxHeartbeats 80000 in
 @[simp]
 theorem coe_flipₗᵢ : ⇑(flipₗᵢ 𝕜 E Fₗ Gₗ) = flip :=
   rfl
@@ -1010,6 +1016,7 @@ variable {Eₗ} (𝕜)
 
 set_option linter.uppercaseLean3 false
 
+set_option maxHeartbeats 800000 in
 /-- `ContinuousLinearMap.prodMap` as a continuous linear map. -/
 def prodMapL : (M₁ →L[𝕜] M₂) × (M₃ →L[𝕜] M₄) →L[𝕜] M₁ × M₃ →L[𝕜] M₂ × M₄ :=
   ContinuousLinearMap.copy

--- a/Mathlib/Analysis/NormedSpace/OperatorNorm.lean
+++ b/Mathlib/Analysis/NormedSpace/OperatorNorm.lean
@@ -1,0 +1,2078 @@
+/-
+Copyright (c) 2019 Jan-David Salchow. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jan-David Salchow, Sébastien Gouëzel, Jean Lo
+
+! This file was ported from Lean 3 source module analysis.normed_space.operator_norm
+! leanprover-community/mathlib commit 91862a6001a8b6ae3f261cdd8eea42f6ac596886
+! Please do not edit these lines, except to modify the commit id
+! if you have ported upstream changes.
+-/
+import Mathbin.Algebra.Algebra.Tower
+import Mathbin.Analysis.Asymptotics.Asymptotics
+import Mathbin.Analysis.NormedSpace.ContinuousLinearMap
+import Mathbin.Analysis.NormedSpace.LinearIsometry
+import Mathbin.Topology.Algebra.Module.StrongTopology
+
+/-!
+# Operator norm on the space of continuous linear maps
+
+Define the operator norm on the space of continuous (semi)linear maps between normed spaces, and
+prove its basic properties. In particular, show that this space is itself a normed space.
+
+Since a lot of elementary properties don't require `‖x‖ = 0 → x = 0` we start setting up the
+theory for `seminormed_add_comm_group` and we specialize to `normed_add_comm_group` at the end.
+
+Note that most of statements that apply to semilinear maps only hold when the ring homomorphism
+is isometric, as expressed by the typeclass `[ring_hom_isometric σ]`.
+
+-/
+
+
+noncomputable section
+
+open Classical NNReal Topology
+
+-- the `ₗ` subscript variables are for special cases about linear (as opposed to semilinear) maps
+variable {𝕜 𝕜₂ 𝕜₃ E Eₗ F Fₗ G Gₗ 𝓕 : Type _}
+
+section SemiNormed
+
+open Metric ContinuousLinearMap
+
+variable [SeminormedAddCommGroup E] [SeminormedAddCommGroup Eₗ] [SeminormedAddCommGroup F]
+  [SeminormedAddCommGroup Fₗ] [SeminormedAddCommGroup G] [SeminormedAddCommGroup Gₗ]
+
+variable [NontriviallyNormedField 𝕜] [NontriviallyNormedField 𝕜₂] [NontriviallyNormedField 𝕜₃]
+  [NormedSpace 𝕜 E] [NormedSpace 𝕜 Eₗ] [NormedSpace 𝕜₂ F] [NormedSpace 𝕜 Fₗ] [NormedSpace 𝕜₃ G]
+  [NormedSpace 𝕜 Gₗ] {σ₁₂ : 𝕜 →+* 𝕜₂} {σ₂₃ : 𝕜₂ →+* 𝕜₃} {σ₁₃ : 𝕜 →+* 𝕜₃}
+  [RingHomCompTriple σ₁₂ σ₂₃ σ₁₃]
+
+/-- If `‖x‖ = 0` and `f` is continuous then `‖f x‖ = 0`. -/
+theorem norm_image_of_norm_zero [SemilinearMapClass 𝓕 σ₁₂ E F] (f : 𝓕) (hf : Continuous f) {x : E}
+    (hx : ‖x‖ = 0) : ‖f x‖ = 0 :=
+  by
+  refine' le_antisymm (le_of_forall_pos_le_add fun ε hε => _) (norm_nonneg (f x))
+  rcases NormedAddCommGroup.tendsto_nhds_nhds.1 (hf.tendsto 0) ε hε with ⟨δ, δ_pos, hδ⟩
+  replace hδ := hδ x
+  rw [sub_zero, hx] at hδ
+  replace hδ := le_of_lt (hδ δ_pos)
+  rw [map_zero, sub_zero] at hδ
+  rwa [zero_add]
+#align norm_image_of_norm_zero norm_image_of_norm_zero
+
+section
+
+variable [RingHomIsometric σ₁₂] [RingHomIsometric σ₂₃]
+
+theorem SemilinearMapClass.bound_of_shell_semi_normed [SemilinearMapClass 𝓕 σ₁₂ E F] (f : 𝓕)
+    {ε C : ℝ} (ε_pos : 0 < ε) {c : 𝕜} (hc : 1 < ‖c‖)
+    (hf : ∀ x, ε / ‖c‖ ≤ ‖x‖ → ‖x‖ < ε → ‖f x‖ ≤ C * ‖x‖) {x : E} (hx : ‖x‖ ≠ 0) :
+    ‖f x‖ ≤ C * ‖x‖ :=
+  by
+  rcases rescale_to_shell_semi_normed hc ε_pos hx with ⟨δ, hδ, δxle, leδx, δinv⟩
+  have := hf (δ • x) leδx δxle
+  simpa only [map_smulₛₗ, norm_smul, mul_left_comm C, mul_le_mul_left (norm_pos_iff.2 hδ),
+    RingHomIsometric.is_iso] using hf (δ • x) leδx δxle
+#align semilinear_map_class.bound_of_shell_semi_normed SemilinearMapClass.bound_of_shell_semi_normed
+
+/-- A continuous linear map between seminormed spaces is bounded when the field is nontrivially
+normed. The continuity ensures boundedness on a ball of some radius `ε`. The nontriviality of the
+norm is then used to rescale any element into an element of norm in `[ε/C, ε]`, whose image has a
+controlled norm. The norm control for the original element follows by rescaling. -/
+theorem SemilinearMapClass.bound_of_continuous [SemilinearMapClass 𝓕 σ₁₂ E F] (f : 𝓕)
+    (hf : Continuous f) : ∃ C, 0 < C ∧ ∀ x : E, ‖f x‖ ≤ C * ‖x‖ :=
+  by
+  rcases NormedAddCommGroup.tendsto_nhds_nhds.1 (hf.tendsto 0) 1 zero_lt_one with ⟨ε, ε_pos, hε⟩
+  simp only [sub_zero, map_zero] at hε
+  rcases NormedField.exists_one_lt_norm 𝕜 with ⟨c, hc⟩
+  have : 0 < ‖c‖ / ε := div_pos (zero_lt_one.trans hc) ε_pos
+  refine' ⟨‖c‖ / ε, this, fun x => _⟩
+  by_cases hx : ‖x‖ = 0
+  · rw [hx, MulZeroClass.mul_zero]
+    exact le_of_eq (norm_image_of_norm_zero f hf hx)
+  refine' SemilinearMapClass.bound_of_shell_semi_normed f ε_pos hc (fun x hle hlt => _) hx
+  refine' (hε _ hlt).le.trans _
+  rwa [← div_le_iff' this, one_div_div]
+#align semilinear_map_class.bound_of_continuous SemilinearMapClass.bound_of_continuous
+
+end
+
+namespace ContinuousLinearMap
+
+theorem bound [RingHomIsometric σ₁₂] (f : E →SL[σ₁₂] F) : ∃ C, 0 < C ∧ ∀ x : E, ‖f x‖ ≤ C * ‖x‖ :=
+  SemilinearMapClass.bound_of_continuous f f.2
+#align continuous_linear_map.bound ContinuousLinearMap.bound
+
+section
+
+open Filter
+
+variable (𝕜 E)
+
+/-- Given a unit-length element `x` of a normed space `E` over a field `𝕜`, the natural linear
+    isometry map from `𝕜` to `E` by taking multiples of `x`.-/
+def LinearIsometry.toSpanSingleton {v : E} (hv : ‖v‖ = 1) : 𝕜 →ₗᵢ[𝕜] E :=
+  { LinearMap.toSpanSingleton 𝕜 E v with norm_map' := fun x => by simp [norm_smul, hv] }
+#align linear_isometry.to_span_singleton LinearIsometry.toSpanSingleton
+
+variable {𝕜 E}
+
+@[simp]
+theorem LinearIsometry.toSpanSingleton_apply {v : E} (hv : ‖v‖ = 1) (a : 𝕜) :
+    LinearIsometry.toSpanSingleton 𝕜 E hv a = a • v :=
+  rfl
+#align linear_isometry.to_span_singleton_apply LinearIsometry.toSpanSingleton_apply
+
+@[simp]
+theorem LinearIsometry.coe_toSpanSingleton {v : E} (hv : ‖v‖ = 1) :
+    (LinearIsometry.toSpanSingleton 𝕜 E hv).toLinearMap = LinearMap.toSpanSingleton 𝕜 E v :=
+  rfl
+#align linear_isometry.coe_to_span_singleton LinearIsometry.coe_toSpanSingleton
+
+end
+
+section OpNorm
+
+open Set Real
+
+/-- The operator norm of a continuous linear map is the inf of all its bounds. -/
+def opNorm (f : E →SL[σ₁₂] F) :=
+  sInf { c | 0 ≤ c ∧ ∀ x, ‖f x‖ ≤ c * ‖x‖ }
+#align continuous_linear_map.op_norm ContinuousLinearMap.opNorm
+
+instance hasOpNorm : Norm (E →SL[σ₁₂] F) :=
+  ⟨opNorm⟩
+#align continuous_linear_map.has_op_norm ContinuousLinearMap.hasOpNorm
+
+theorem norm_def (f : E →SL[σ₁₂] F) : ‖f‖ = sInf { c | 0 ≤ c ∧ ∀ x, ‖f x‖ ≤ c * ‖x‖ } :=
+  rfl
+#align continuous_linear_map.norm_def ContinuousLinearMap.norm_def
+
+-- So that invocations of `le_cInf` make sense: we show that the set of
+-- bounds is nonempty and bounded below.
+theorem bounds_nonempty [RingHomIsometric σ₁₂] {f : E →SL[σ₁₂] F} :
+    ∃ c, c ∈ { c | 0 ≤ c ∧ ∀ x, ‖f x‖ ≤ c * ‖x‖ } :=
+  let ⟨M, hMp, hMb⟩ := f.bound
+  ⟨M, le_of_lt hMp, hMb⟩
+#align continuous_linear_map.bounds_nonempty ContinuousLinearMap.bounds_nonempty
+
+theorem bounds_bddBelow {f : E →SL[σ₁₂] F} : BddBelow { c | 0 ≤ c ∧ ∀ x, ‖f x‖ ≤ c * ‖x‖ } :=
+  ⟨0, fun _ ⟨hn, _⟩ => hn⟩
+#align continuous_linear_map.bounds_bdd_below ContinuousLinearMap.bounds_bddBelow
+
+/-- If one controls the norm of every `A x`, then one controls the norm of `A`. -/
+theorem op_norm_le_bound (f : E →SL[σ₁₂] F) {M : ℝ} (hMp : 0 ≤ M) (hM : ∀ x, ‖f x‖ ≤ M * ‖x‖) :
+    ‖f‖ ≤ M :=
+  csInf_le bounds_bddBelow ⟨hMp, hM⟩
+#align continuous_linear_map.op_norm_le_bound ContinuousLinearMap.op_norm_le_bound
+
+/-- If one controls the norm of every `A x`, `‖x‖ ≠ 0`, then one controls the norm of `A`. -/
+theorem op_norm_le_bound' (f : E →SL[σ₁₂] F) {M : ℝ} (hMp : 0 ≤ M)
+    (hM : ∀ x, ‖x‖ ≠ 0 → ‖f x‖ ≤ M * ‖x‖) : ‖f‖ ≤ M :=
+  op_norm_le_bound f hMp fun x =>
+    (ne_or_eq ‖x‖ 0).elim (hM x) fun h => by
+      simp only [h, MulZeroClass.mul_zero, norm_image_of_norm_zero f f.2 h]
+#align continuous_linear_map.op_norm_le_bound' ContinuousLinearMap.op_norm_le_bound'
+
+theorem op_norm_le_of_lipschitz {f : E →SL[σ₁₂] F} {K : ℝ≥0} (hf : LipschitzWith K f) : ‖f‖ ≤ K :=
+  f.op_norm_le_bound K.2 fun x => by
+    simpa only [dist_zero_right, f.map_zero] using hf.dist_le_mul x 0
+#align continuous_linear_map.op_norm_le_of_lipschitz ContinuousLinearMap.op_norm_le_of_lipschitz
+
+theorem op_norm_eq_of_bounds {φ : E →SL[σ₁₂] F} {M : ℝ} (M_nonneg : 0 ≤ M)
+    (h_above : ∀ x, ‖φ x‖ ≤ M * ‖x‖) (h_below : ∀ N ≥ 0, (∀ x, ‖φ x‖ ≤ N * ‖x‖) → M ≤ N) :
+    ‖φ‖ = M :=
+  le_antisymm (φ.op_norm_le_bound M_nonneg h_above)
+    ((le_csInf_iff ContinuousLinearMap.bounds_bddBelow ⟨M, M_nonneg, h_above⟩).mpr
+      fun N ⟨N_nonneg, hN⟩ => h_below N N_nonneg hN)
+#align continuous_linear_map.op_norm_eq_of_bounds ContinuousLinearMap.op_norm_eq_of_bounds
+
+theorem op_norm_neg (f : E →SL[σ₁₂] F) : ‖-f‖ = ‖f‖ := by simp only [norm_def, neg_apply, norm_neg]
+#align continuous_linear_map.op_norm_neg ContinuousLinearMap.op_norm_neg
+
+section
+
+variable [RingHomIsometric σ₁₂] [RingHomIsometric σ₂₃] (f g : E →SL[σ₁₂] F) (h : F →SL[σ₂₃] G)
+  (x : E)
+
+theorem op_norm_nonneg : 0 ≤ ‖f‖ :=
+  le_csInf bounds_nonempty fun _ ⟨hx, _⟩ => hx
+#align continuous_linear_map.op_norm_nonneg ContinuousLinearMap.op_norm_nonneg
+
+/-- The fundamental property of the operator norm: `‖f x‖ ≤ ‖f‖ * ‖x‖`. -/
+theorem le_op_norm : ‖f x‖ ≤ ‖f‖ * ‖x‖ :=
+  by
+  obtain ⟨C, Cpos, hC⟩ := f.bound
+  replace hC := hC x
+  by_cases h : ‖x‖ = 0
+  · rwa [h, MulZeroClass.mul_zero] at hC⊢
+  have hlt : 0 < ‖x‖ := lt_of_le_of_ne (norm_nonneg x) (Ne.symm h)
+  exact
+    (div_le_iff hlt).mp
+      (le_csInf bounds_nonempty fun c ⟨_, hc⟩ => (div_le_iff hlt).mpr <| by apply hc)
+#align continuous_linear_map.le_op_norm ContinuousLinearMap.le_op_norm
+
+theorem dist_le_op_norm (x y : E) : dist (f x) (f y) ≤ ‖f‖ * dist x y := by
+  simp_rw [dist_eq_norm, ← map_sub, f.le_op_norm]
+#align continuous_linear_map.dist_le_op_norm ContinuousLinearMap.dist_le_op_norm
+
+theorem le_op_norm_of_le {c : ℝ} {x} (h : ‖x‖ ≤ c) : ‖f x‖ ≤ ‖f‖ * c :=
+  le_trans (f.le_op_norm x) (mul_le_mul_of_nonneg_left h f.op_norm_nonneg)
+#align continuous_linear_map.le_op_norm_of_le ContinuousLinearMap.le_op_norm_of_le
+
+theorem le_of_op_norm_le {c : ℝ} (h : ‖f‖ ≤ c) (x : E) : ‖f x‖ ≤ c * ‖x‖ :=
+  (f.le_op_norm x).trans (mul_le_mul_of_nonneg_right h (norm_nonneg x))
+#align continuous_linear_map.le_of_op_norm_le ContinuousLinearMap.le_of_op_norm_le
+
+theorem ratio_le_op_norm : ‖f x‖ / ‖x‖ ≤ ‖f‖ :=
+  div_le_of_nonneg_of_le_mul (norm_nonneg _) f.op_norm_nonneg (le_op_norm _ _)
+#align continuous_linear_map.ratio_le_op_norm ContinuousLinearMap.ratio_le_op_norm
+
+/-- The image of the unit ball under a continuous linear map is bounded. -/
+theorem unit_le_op_norm : ‖x‖ ≤ 1 → ‖f x‖ ≤ ‖f‖ :=
+  mul_one ‖f‖ ▸ f.le_op_norm_of_le
+#align continuous_linear_map.unit_le_op_norm ContinuousLinearMap.unit_le_op_norm
+
+theorem op_norm_le_of_shell {f : E →SL[σ₁₂] F} {ε C : ℝ} (ε_pos : 0 < ε) (hC : 0 ≤ C) {c : 𝕜}
+    (hc : 1 < ‖c‖) (hf : ∀ x, ε / ‖c‖ ≤ ‖x‖ → ‖x‖ < ε → ‖f x‖ ≤ C * ‖x‖) : ‖f‖ ≤ C :=
+  f.op_norm_le_bound' hC fun x hx => SemilinearMapClass.bound_of_shell_semi_normed f ε_pos hc hf hx
+#align continuous_linear_map.op_norm_le_of_shell ContinuousLinearMap.op_norm_le_of_shell
+
+theorem op_norm_le_of_ball {f : E →SL[σ₁₂] F} {ε : ℝ} {C : ℝ} (ε_pos : 0 < ε) (hC : 0 ≤ C)
+    (hf : ∀ x ∈ ball (0 : E) ε, ‖f x‖ ≤ C * ‖x‖) : ‖f‖ ≤ C :=
+  by
+  rcases NormedField.exists_one_lt_norm 𝕜 with ⟨c, hc⟩
+  refine' op_norm_le_of_shell ε_pos hC hc fun x _ hx => hf x _
+  rwa [ball_zero_eq]
+#align continuous_linear_map.op_norm_le_of_ball ContinuousLinearMap.op_norm_le_of_ball
+
+theorem op_norm_le_of_nhds_zero {f : E →SL[σ₁₂] F} {C : ℝ} (hC : 0 ≤ C)
+    (hf : ∀ᶠ x in 𝓝 (0 : E), ‖f x‖ ≤ C * ‖x‖) : ‖f‖ ≤ C :=
+  let ⟨ε, ε0, hε⟩ := Metric.eventually_nhds_iff_ball.1 hf
+  op_norm_le_of_ball ε0 hC hε
+#align continuous_linear_map.op_norm_le_of_nhds_zero ContinuousLinearMap.op_norm_le_of_nhds_zero
+
+theorem op_norm_le_of_shell' {f : E →SL[σ₁₂] F} {ε C : ℝ} (ε_pos : 0 < ε) (hC : 0 ≤ C) {c : 𝕜}
+    (hc : ‖c‖ < 1) (hf : ∀ x, ε * ‖c‖ ≤ ‖x‖ → ‖x‖ < ε → ‖f x‖ ≤ C * ‖x‖) : ‖f‖ ≤ C :=
+  by
+  by_cases h0 : c = 0
+  · refine' op_norm_le_of_ball ε_pos hC fun x hx => hf x _ _
+    · simp [h0]
+    · rwa [ball_zero_eq] at hx
+  · rw [← inv_inv c, norm_inv, inv_lt_one_iff_of_pos (norm_pos_iff.2 <| inv_ne_zero h0)] at hc
+    refine' op_norm_le_of_shell ε_pos hC hc _
+    rwa [norm_inv, div_eq_mul_inv, inv_inv]
+#align continuous_linear_map.op_norm_le_of_shell' ContinuousLinearMap.op_norm_le_of_shell'
+
+/-- For a continuous real linear map `f`, if one controls the norm of every `f x`, `‖x‖ = 1`, then
+one controls the norm of `f`. -/
+theorem op_norm_le_of_unit_norm [NormedSpace ℝ E] [NormedSpace ℝ F] {f : E →L[ℝ] F} {C : ℝ}
+    (hC : 0 ≤ C) (hf : ∀ x, ‖x‖ = 1 → ‖f x‖ ≤ C) : ‖f‖ ≤ C :=
+  by
+  refine' op_norm_le_bound' f hC fun x hx => _
+  have H₁ : ‖‖x‖⁻¹ • x‖ = 1 := by rw [norm_smul, norm_inv, norm_norm, inv_mul_cancel hx]
+  have H₂ := hf _ H₁
+  rwa [map_smul, norm_smul, norm_inv, norm_norm, ← div_eq_inv_mul, div_le_iff] at H₂
+  exact (norm_nonneg x).lt_of_ne' hx
+#align continuous_linear_map.op_norm_le_of_unit_norm ContinuousLinearMap.op_norm_le_of_unit_norm
+
+/-- The operator norm satisfies the triangle inequality. -/
+theorem op_norm_add_le : ‖f + g‖ ≤ ‖f‖ + ‖g‖ :=
+  (f + g).op_norm_le_bound (add_nonneg f.op_norm_nonneg g.op_norm_nonneg) fun x =>
+    (norm_add_le_of_le (f.le_op_norm x) (g.le_op_norm x)).trans_eq (add_mul _ _ _).symm
+#align continuous_linear_map.op_norm_add_le ContinuousLinearMap.op_norm_add_le
+
+/-- The norm of the `0` operator is `0`. -/
+theorem op_norm_zero : ‖(0 : E →SL[σ₁₂] F)‖ = 0 :=
+  le_antisymm
+    (csInf_le bounds_bddBelow
+      ⟨le_rfl, fun _ =>
+        le_of_eq
+          (by
+            rw [MulZeroClass.zero_mul]
+            exact norm_zero)⟩)
+    (op_norm_nonneg _)
+#align continuous_linear_map.op_norm_zero ContinuousLinearMap.op_norm_zero
+
+/-- The norm of the identity is at most `1`. It is in fact `1`, except when the space is trivial
+where it is `0`. It means that one can not do better than an inequality in general. -/
+theorem norm_id_le : ‖id 𝕜 E‖ ≤ 1 :=
+  op_norm_le_bound _ zero_le_one fun x => by simp
+#align continuous_linear_map.norm_id_le ContinuousLinearMap.norm_id_le
+
+/-- If there is an element with norm different from `0`, then the norm of the identity equals `1`.
+(Since we are working with seminorms supposing that the space is non-trivial is not enough.) -/
+theorem norm_id_of_nontrivial_seminorm (h : ∃ x : E, ‖x‖ ≠ 0) : ‖id 𝕜 E‖ = 1 :=
+  le_antisymm norm_id_le <| by
+    let ⟨x, hx⟩ := h
+    have := (id 𝕜 E).ratio_le_op_norm x
+    rwa [id_apply, div_self hx] at this
+#align continuous_linear_map.norm_id_of_nontrivial_seminorm ContinuousLinearMap.norm_id_of_nontrivial_seminorm
+
+theorem op_norm_smul_le {𝕜' : Type _} [NormedField 𝕜'] [NormedSpace 𝕜' F] [SMulCommClass 𝕜₂ 𝕜' F]
+    (c : 𝕜') (f : E →SL[σ₁₂] F) : ‖c • f‖ ≤ ‖c‖ * ‖f‖ :=
+  (c • f).op_norm_le_bound (mul_nonneg (norm_nonneg _) (op_norm_nonneg _)) fun _ =>
+    by
+    erw [norm_smul, mul_assoc]
+    exact mul_le_mul_of_nonneg_left (le_op_norm _ _) (norm_nonneg _)
+#align continuous_linear_map.op_norm_smul_le ContinuousLinearMap.op_norm_smul_le
+
+/-- Continuous linear maps themselves form a seminormed space with respect to
+the operator norm. This is only a temporary definition because we want to replace the topology
+with `continuous_linear_map.topological_space` to avoid diamond issues.
+See Note [forgetful inheritance] -/
+protected def tmpSeminormedAddCommGroup : SeminormedAddCommGroup (E →SL[σ₁₂] F) :=
+  AddGroupSeminorm.toSeminormedAddCommGroup
+    { toFun := norm
+      map_zero' := op_norm_zero
+      add_le' := op_norm_add_le
+      neg' := op_norm_neg }
+#align continuous_linear_map.tmp_seminormed_add_comm_group ContinuousLinearMap.tmpSeminormedAddCommGroup
+
+/-- The `pseudo_metric_space` structure on `E →SL[σ₁₂] F` coming from
+`continuous_linear_map.tmp_seminormed_add_comm_group`.
+See Note [forgetful inheritance] -/
+protected def tmpPseudoMetricSpace : PseudoMetricSpace (E →SL[σ₁₂] F) :=
+  ContinuousLinearMap.tmpSeminormedAddCommGroup.toPseudoMetricSpace
+#align continuous_linear_map.tmp_pseudo_metric_space ContinuousLinearMap.tmpPseudoMetricSpace
+
+/-- The `uniform_space` structure on `E →SL[σ₁₂] F` coming from
+`continuous_linear_map.tmp_seminormed_add_comm_group`.
+See Note [forgetful inheritance] -/
+protected def tmpUniformSpace : UniformSpace (E →SL[σ₁₂] F) :=
+  ContinuousLinearMap.tmpPseudoMetricSpace.toUniformSpace
+#align continuous_linear_map.tmp_uniform_space ContinuousLinearMap.tmpUniformSpace
+
+/-- The `topological_space` structure on `E →SL[σ₁₂] F` coming from
+`continuous_linear_map.tmp_seminormed_add_comm_group`.
+See Note [forgetful inheritance] -/
+protected def tmpTopologicalSpace : TopologicalSpace (E →SL[σ₁₂] F) :=
+  ContinuousLinearMap.tmpUniformSpace.toTopologicalSpace
+#align continuous_linear_map.tmp_topological_space ContinuousLinearMap.tmpTopologicalSpace
+
+section Tmp
+
+attribute [-instance] ContinuousLinearMap.topologicalSpace
+
+attribute [-instance] ContinuousLinearMap.uniformSpace
+
+attribute [local instance] ContinuousLinearMap.tmpSeminormedAddCommGroup
+
+protected theorem tmp_topologicalAddGroup : TopologicalAddGroup (E →SL[σ₁₂] F) :=
+  inferInstance
+#align continuous_linear_map.tmp_topological_add_group ContinuousLinearMap.tmp_topologicalAddGroup
+
+protected theorem tmp_closedBall_div_subset {a b : ℝ} (ha : 0 < a) (hb : 0 < b) :
+    closedBall (0 : E →SL[σ₁₂] F) (a / b) ⊆
+      { f | ∀ x ∈ closedBall (0 : E) b, f x ∈ closedBall (0 : F) a } :=
+  by
+  intro f hf x hx
+  rw [mem_closedBall_zero_iff] at hf hx⊢
+  calc
+    ‖f x‖ ≤ ‖f‖ * ‖x‖ := le_op_norm _ _
+    _ ≤ a / b * b := (mul_le_mul hf hx (norm_nonneg _) (div_pos ha hb).le)
+    _ = a := div_mul_cancel a hb.ne.symm
+    
+#align continuous_linear_map.tmp_closed_ball_div_subset ContinuousLinearMap.tmp_closedBall_div_subset
+
+end Tmp
+
+protected theorem tmp_topology_eq :
+    (ContinuousLinearMap.tmpTopologicalSpace : TopologicalSpace (E →SL[σ₁₂] F)) =
+      ContinuousLinearMap.topologicalSpace :=
+  by
+  refine'
+    continuous_linear_map.tmp_topological_add_group.ext inferInstance
+      ((@Metric.nhds_basis_closedBall _ ContinuousLinearMap.tmpPseudoMetricSpace 0).ext
+        (ContinuousLinearMap.hasBasis_nhds_zero_of_basis Metric.nhds_basis_closedBall) _ _)
+  · rcases NormedField.exists_norm_lt_one 𝕜 with ⟨c, hc₀, hc₁⟩
+    refine' fun ε hε =>
+      ⟨⟨closed_ball 0 (1 / ‖c‖), ε⟩, ⟨NormedSpace.isVonNBounded_closedBall _ _ _, hε⟩, fun f hf =>
+        _⟩
+    change ∀ x, _ at hf
+    simp_rw [mem_closedBall_zero_iff] at hf
+    rw [@mem_closedBall_zero_iff _ SeminormedAddCommGroup.toSeminormedAddGroup]
+    refine' op_norm_le_of_shell' (div_pos one_pos hc₀) hε.le hc₁ fun x hx₁ hxc => _
+    rw [div_mul_cancel 1 hc₀.ne.symm] at hx₁
+    exact (hf x hxc.le).trans (le_mul_of_one_le_right hε.le hx₁)
+  · rintro ⟨S, ε⟩ ⟨hS, hε⟩
+    rw [NormedSpace.isVonNBounded_iff, ← bounded_iff_is_bounded] at hS
+    rcases hS.subset_ball_lt 0 0 with ⟨δ, hδ, hSδ⟩
+    exact
+      ⟨ε / δ, div_pos hε hδ,
+        (ContinuousLinearMap.tmp_closedBall_div_subset hε hδ).trans fun f hf x hx => hf x <| hSδ hx⟩
+#align continuous_linear_map.tmp_topology_eq ContinuousLinearMap.tmp_topology_eq
+
+protected theorem tmpUniformSpace_eq :
+    (ContinuousLinearMap.tmpUniformSpace : UniformSpace (E →SL[σ₁₂] F)) =
+      ContinuousLinearMap.uniformSpace :=
+  by
+  rw [← @UniformAddGroup.toUniformSpace_eq _ ContinuousLinearMap.tmpUniformSpace, ←
+    @UniformAddGroup.toUniformSpace_eq _ ContinuousLinearMap.uniformSpace]
+  congr 1
+  exact ContinuousLinearMap.tmp_topology_eq
+#align continuous_linear_map.tmp_uniform_space_eq ContinuousLinearMap.tmpUniformSpace_eq
+
+instance toPseudoMetricSpace : PseudoMetricSpace (E →SL[σ₁₂] F) :=
+  ContinuousLinearMap.tmpPseudoMetricSpace.replaceUniformity
+    (congr_arg _ ContinuousLinearMap.tmpUniformSpace_eq.symm)
+#align continuous_linear_map.to_pseudo_metric_space ContinuousLinearMap.toPseudoMetricSpace
+
+/-- Continuous linear maps themselves form a seminormed space with respect to
+    the operator norm. -/
+instance toSeminormedAddCommGroup : SeminormedAddCommGroup (E →SL[σ₁₂] F)
+    where dist_eq := ContinuousLinearMap.tmpSeminormedAddCommGroup.dist_eq
+#align continuous_linear_map.to_seminormed_add_comm_group ContinuousLinearMap.toSeminormedAddCommGroup
+
+theorem nnnorm_def (f : E →SL[σ₁₂] F) : ‖f‖₊ = sInf { c | ∀ x, ‖f x‖₊ ≤ c * ‖x‖₊ } :=
+  by
+  ext
+  rw [NNReal.coe_sInf, coe_nnnorm, norm_def, NNReal.coe_image]
+  simp_rw [← NNReal.coe_le_coe, NNReal.coe_mul, coe_nnnorm, mem_set_of_eq, Subtype.coe_mk,
+    exists_prop]
+#align continuous_linear_map.nnnorm_def ContinuousLinearMap.nnnorm_def
+
+/-- If one controls the norm of every `A x`, then one controls the norm of `A`. -/
+theorem op_nnnorm_le_bound (f : E →SL[σ₁₂] F) (M : ℝ≥0) (hM : ∀ x, ‖f x‖₊ ≤ M * ‖x‖₊) : ‖f‖₊ ≤ M :=
+  op_norm_le_bound f (zero_le M) hM
+#align continuous_linear_map.op_nnnorm_le_bound ContinuousLinearMap.op_nnnorm_le_bound
+
+/-- If one controls the norm of every `A x`, `‖x‖₊ ≠ 0`, then one controls the norm of `A`. -/
+theorem op_nnnorm_le_bound' (f : E →SL[σ₁₂] F) (M : ℝ≥0) (hM : ∀ x, ‖x‖₊ ≠ 0 → ‖f x‖₊ ≤ M * ‖x‖₊) :
+    ‖f‖₊ ≤ M :=
+  op_norm_le_bound' f (zero_le M) fun x hx => hM x <| by rwa [← NNReal.coe_ne_zero]
+#align continuous_linear_map.op_nnnorm_le_bound' ContinuousLinearMap.op_nnnorm_le_bound'
+
+/-- For a continuous real linear map `f`, if one controls the norm of every `f x`, `‖x‖₊ = 1`, then
+one controls the norm of `f`. -/
+theorem op_nnnorm_le_of_unit_nnnorm [NormedSpace ℝ E] [NormedSpace ℝ F] {f : E →L[ℝ] F} {C : ℝ≥0}
+    (hf : ∀ x, ‖x‖₊ = 1 → ‖f x‖₊ ≤ C) : ‖f‖₊ ≤ C :=
+  op_norm_le_of_unit_norm C.coe_nonneg fun x hx => hf x <| by rwa [← NNReal.coe_eq_one]
+#align continuous_linear_map.op_nnnorm_le_of_unit_nnnorm ContinuousLinearMap.op_nnnorm_le_of_unit_nnnorm
+
+theorem op_nnnorm_le_of_lipschitz {f : E →SL[σ₁₂] F} {K : ℝ≥0} (hf : LipschitzWith K f) :
+    ‖f‖₊ ≤ K :=
+  op_norm_le_of_lipschitz hf
+#align continuous_linear_map.op_nnnorm_le_of_lipschitz ContinuousLinearMap.op_nnnorm_le_of_lipschitz
+
+theorem op_nnnorm_eq_of_bounds {φ : E →SL[σ₁₂] F} (M : ℝ≥0) (h_above : ∀ x, ‖φ x‖ ≤ M * ‖x‖)
+    (h_below : ∀ N, (∀ x, ‖φ x‖₊ ≤ N * ‖x‖₊) → M ≤ N) : ‖φ‖₊ = M :=
+  Subtype.ext <| op_norm_eq_of_bounds (zero_le M) h_above <| Subtype.forall'.mpr h_below
+#align continuous_linear_map.op_nnnorm_eq_of_bounds ContinuousLinearMap.op_nnnorm_eq_of_bounds
+
+instance toNormedSpace {𝕜' : Type _} [NormedField 𝕜'] [NormedSpace 𝕜' F] [SMulCommClass 𝕜₂ 𝕜' F] :
+    NormedSpace 𝕜' (E →SL[σ₁₂] F) :=
+  ⟨op_norm_smul_le⟩
+#align continuous_linear_map.to_normed_space ContinuousLinearMap.toNormedSpace
+
+include σ₁₃
+
+/-- The operator norm is submultiplicative. -/
+theorem op_norm_comp_le (f : E →SL[σ₁₂] F) : ‖h.comp f‖ ≤ ‖h‖ * ‖f‖ :=
+  csInf_le bounds_bddBelow
+    ⟨mul_nonneg (op_norm_nonneg _) (op_norm_nonneg _), fun x =>
+      by
+      rw [mul_assoc]
+      exact h.le_op_norm_of_le (f.le_op_norm x)⟩
+#align continuous_linear_map.op_norm_comp_le ContinuousLinearMap.op_norm_comp_le
+
+theorem op_nnnorm_comp_le [RingHomIsometric σ₁₃] (f : E →SL[σ₁₂] F) : ‖h.comp f‖₊ ≤ ‖h‖₊ * ‖f‖₊ :=
+  op_norm_comp_le h f
+#align continuous_linear_map.op_nnnorm_comp_le ContinuousLinearMap.op_nnnorm_comp_le
+
+omit σ₁₃
+
+/-- Continuous linear maps form a seminormed ring with respect to the operator norm. -/
+instance toSemiNormedRing : SeminormedRing (E →L[𝕜] E) :=
+  { ContinuousLinearMap.toSeminormedAddCommGroup, ContinuousLinearMap.ring with
+    norm_mul := fun f g => op_norm_comp_le f g }
+#align continuous_linear_map.to_semi_normed_ring ContinuousLinearMap.toSemiNormedRing
+
+/-- For a normed space `E`, continuous linear endomorphisms form a normed algebra with
+respect to the operator norm. -/
+instance toNormedAlgebra : NormedAlgebra 𝕜 (E →L[𝕜] E) :=
+  { ContinuousLinearMap.toNormedSpace, ContinuousLinearMap.algebra with }
+#align continuous_linear_map.to_normed_algebra ContinuousLinearMap.toNormedAlgebra
+
+theorem le_op_nnnorm : ‖f x‖₊ ≤ ‖f‖₊ * ‖x‖₊ :=
+  f.le_op_norm x
+#align continuous_linear_map.le_op_nnnorm ContinuousLinearMap.le_op_nnnorm
+
+theorem nndist_le_op_nnnorm (x y : E) : nndist (f x) (f y) ≤ ‖f‖₊ * nndist x y :=
+  dist_le_op_norm f x y
+#align continuous_linear_map.nndist_le_op_nnnorm ContinuousLinearMap.nndist_le_op_nnnorm
+
+/-- continuous linear maps are Lipschitz continuous. -/
+theorem lipschitz : LipschitzWith ‖f‖₊ f :=
+  AddMonoidHomClass.lipschitz_of_bound_nnnorm f _ f.le_op_nnnorm
+#align continuous_linear_map.lipschitz ContinuousLinearMap.lipschitz
+
+/-- Evaluation of a continuous linear map `f` at a point is Lipschitz continuous in `f`. -/
+theorem lipschitz_apply (x : E) : LipschitzWith ‖x‖₊ fun f : E →SL[σ₁₂] F => f x :=
+  lipschitzWith_iff_norm_sub_le.2 fun f g => ((f - g).le_op_norm x).trans_eq (mul_comm _ _)
+#align continuous_linear_map.lipschitz_apply ContinuousLinearMap.lipschitz_apply
+
+end
+
+section Sup
+
+variable [RingHomIsometric σ₁₂]
+
+theorem exists_mul_lt_apply_of_lt_op_nnnorm (f : E →SL[σ₁₂] F) {r : ℝ≥0} (hr : r < ‖f‖₊) :
+    ∃ x, r * ‖x‖₊ < ‖f x‖₊ := by
+  simpa only [not_forall, not_le, Set.mem_setOf] using
+    not_mem_of_lt_csInf (nnnorm_def f ▸ hr : r < Inf { c : ℝ≥0 | ∀ x, ‖f x‖₊ ≤ c * ‖x‖₊ })
+      (OrderBot.bddBelow _)
+#align continuous_linear_map.exists_mul_lt_apply_of_lt_op_nnnorm ContinuousLinearMap.exists_mul_lt_apply_of_lt_op_nnnorm
+
+theorem exists_mul_lt_of_lt_op_norm (f : E →SL[σ₁₂] F) {r : ℝ} (hr₀ : 0 ≤ r) (hr : r < ‖f‖) :
+    ∃ x, r * ‖x‖ < ‖f x‖ := by
+  lift r to ℝ≥0 using hr₀
+  exact f.exists_mul_lt_apply_of_lt_op_nnnorm hr
+#align continuous_linear_map.exists_mul_lt_of_lt_op_norm ContinuousLinearMap.exists_mul_lt_of_lt_op_norm
+
+theorem exists_lt_apply_of_lt_op_nnnorm {𝕜 𝕜₂ E F : Type _} [NormedAddCommGroup E]
+    [SeminormedAddCommGroup F] [DenselyNormedField 𝕜] [NontriviallyNormedField 𝕜₂] {σ₁₂ : 𝕜 →+* 𝕜₂}
+    [NormedSpace 𝕜 E] [NormedSpace 𝕜₂ F] [RingHomIsometric σ₁₂] (f : E →SL[σ₁₂] F) {r : ℝ≥0}
+    (hr : r < ‖f‖₊) : ∃ x : E, ‖x‖₊ < 1 ∧ r < ‖f x‖₊ :=
+  by
+  obtain ⟨y, hy⟩ := f.exists_mul_lt_apply_of_lt_op_nnnorm hr
+  have hy' : ‖y‖₊ ≠ 0 :=
+    nnnorm_ne_zero_iff.2 fun heq => by
+      simpa only [HEq, nnnorm_zero, map_zero, not_lt_zero'] using hy
+  have hfy : ‖f y‖₊ ≠ 0 := (zero_le'.trans_lt hy).ne'
+  rw [← inv_inv ‖f y‖₊, NNReal.lt_inv_iff_mul_lt (inv_ne_zero hfy), mul_assoc, mul_comm ‖y‖₊, ←
+    mul_assoc, ← NNReal.lt_inv_iff_mul_lt hy'] at hy
+  obtain ⟨k, hk₁, hk₂⟩ := NormedField.exists_lt_nnnorm_lt 𝕜 hy
+  refine' ⟨k • y, (nnnorm_smul k y).symm ▸ (NNReal.lt_inv_iff_mul_lt hy').1 hk₂, _⟩
+  have : ‖σ₁₂ k‖₊ = ‖k‖₊ := Subtype.ext RingHomIsometric.is_iso
+  rwa [map_smulₛₗ f, nnnorm_smul, ← NNReal.div_lt_iff hfy, div_eq_mul_inv, this]
+#align continuous_linear_map.exists_lt_apply_of_lt_op_nnnorm ContinuousLinearMap.exists_lt_apply_of_lt_op_nnnorm
+
+theorem exists_lt_apply_of_lt_op_norm {𝕜 𝕜₂ E F : Type _} [NormedAddCommGroup E]
+    [SeminormedAddCommGroup F] [DenselyNormedField 𝕜] [NontriviallyNormedField 𝕜₂] {σ₁₂ : 𝕜 →+* 𝕜₂}
+    [NormedSpace 𝕜 E] [NormedSpace 𝕜₂ F] [RingHomIsometric σ₁₂] (f : E →SL[σ₁₂] F) {r : ℝ}
+    (hr : r < ‖f‖) : ∃ x : E, ‖x‖ < 1 ∧ r < ‖f x‖ :=
+  by
+  by_cases hr₀ : r < 0
+  · exact ⟨0, by simpa using hr₀⟩
+  · lift r to ℝ≥0 using not_lt.1 hr₀
+    exact f.exists_lt_apply_of_lt_op_nnnorm hr
+#align continuous_linear_map.exists_lt_apply_of_lt_op_norm ContinuousLinearMap.exists_lt_apply_of_lt_op_norm
+
+theorem sSup_unit_ball_eq_nnnorm {𝕜 𝕜₂ E F : Type _} [NormedAddCommGroup E]
+    [SeminormedAddCommGroup F] [DenselyNormedField 𝕜] [NontriviallyNormedField 𝕜₂] {σ₁₂ : 𝕜 →+* 𝕜₂}
+    [NormedSpace 𝕜 E] [NormedSpace 𝕜₂ F] [RingHomIsometric σ₁₂] (f : E →SL[σ₁₂] F) :
+    sSup ((fun x => ‖f x‖₊) '' ball 0 1) = ‖f‖₊ :=
+  by
+  refine'
+    csSup_eq_of_forall_le_of_forall_lt_exists_gt ((nonempty_ball.mpr zero_lt_one).image _) _
+      fun ub hub => _
+  · rintro - ⟨x, hx, rfl⟩
+    simpa only [mul_one] using f.le_op_norm_of_le (mem_ball_zero_iff.1 hx).le
+  · obtain ⟨x, hx, hxf⟩ := f.exists_lt_apply_of_lt_op_nnnorm hub
+    exact ⟨_, ⟨x, mem_ball_zero_iff.2 hx, rfl⟩, hxf⟩
+#align continuous_linear_map.Sup_unit_ball_eq_nnnorm ContinuousLinearMap.sSup_unit_ball_eq_nnnorm
+
+theorem sSup_unit_ball_eq_norm {𝕜 𝕜₂ E F : Type _} [NormedAddCommGroup E] [SeminormedAddCommGroup F]
+    [DenselyNormedField 𝕜] [NontriviallyNormedField 𝕜₂] {σ₁₂ : 𝕜 →+* 𝕜₂} [NormedSpace 𝕜 E]
+    [NormedSpace 𝕜₂ F] [RingHomIsometric σ₁₂] (f : E →SL[σ₁₂] F) :
+    sSup ((fun x => ‖f x‖) '' ball 0 1) = ‖f‖ := by
+  simpa only [NNReal.coe_sSup, Set.image_image] using NNReal.coe_eq.2 f.Sup_unit_ball_eq_nnnorm
+#align continuous_linear_map.Sup_unit_ball_eq_norm ContinuousLinearMap.sSup_unit_ball_eq_norm
+
+theorem sSup_closed_unit_ball_eq_nnnorm {𝕜 𝕜₂ E F : Type _} [NormedAddCommGroup E]
+    [SeminormedAddCommGroup F] [DenselyNormedField 𝕜] [NontriviallyNormedField 𝕜₂] {σ₁₂ : 𝕜 →+* 𝕜₂}
+    [NormedSpace 𝕜 E] [NormedSpace 𝕜₂ F] [RingHomIsometric σ₁₂] (f : E →SL[σ₁₂] F) :
+    sSup ((fun x => ‖f x‖₊) '' closedBall 0 1) = ‖f‖₊ :=
+  by
+  have hbdd : ∀ y ∈ (fun x => ‖f x‖₊) '' closed_ball 0 1, y ≤ ‖f‖₊ :=
+    by
+    rintro - ⟨x, hx, rfl⟩
+    exact f.unit_le_op_norm x (mem_closedBall_zero_iff.1 hx)
+  refine' le_antisymm (csSup_le ((nonempty_closed_ball.mpr zero_le_one).image _) hbdd) _
+  rw [← Sup_unit_ball_eq_nnnorm]
+  exact
+    csSup_le_csSup ⟨‖f‖₊, hbdd⟩ ((nonempty_ball.2 zero_lt_one).image _)
+      (Set.image_subset _ ball_subset_closed_ball)
+#align continuous_linear_map.Sup_closed_unit_ball_eq_nnnorm ContinuousLinearMap.sSup_closed_unit_ball_eq_nnnorm
+
+theorem sSup_closed_unit_ball_eq_norm {𝕜 𝕜₂ E F : Type _} [NormedAddCommGroup E]
+    [SeminormedAddCommGroup F] [DenselyNormedField 𝕜] [NontriviallyNormedField 𝕜₂] {σ₁₂ : 𝕜 →+* 𝕜₂}
+    [NormedSpace 𝕜 E] [NormedSpace 𝕜₂ F] [RingHomIsometric σ₁₂] (f : E →SL[σ₁₂] F) :
+    sSup ((fun x => ‖f x‖) '' closedBall 0 1) = ‖f‖ := by
+  simpa only [NNReal.coe_sSup, Set.image_image] using
+    NNReal.coe_eq.2 f.Sup_closed_unit_ball_eq_nnnorm
+#align continuous_linear_map.Sup_closed_unit_ball_eq_norm ContinuousLinearMap.sSup_closed_unit_ball_eq_norm
+
+end Sup
+
+section
+
+theorem op_norm_ext [RingHomIsometric σ₁₃] (f : E →SL[σ₁₂] F) (g : E →SL[σ₁₃] G)
+    (h : ∀ x, ‖f x‖ = ‖g x‖) : ‖f‖ = ‖g‖ :=
+  op_norm_eq_of_bounds (norm_nonneg _)
+    (fun x => by
+      rw [h x]
+      exact le_op_norm _ _)
+    fun c hc h₂ =>
+    op_norm_le_bound _ hc fun z => by
+      rw [← h z]
+      exact h₂ z
+#align continuous_linear_map.op_norm_ext ContinuousLinearMap.op_norm_ext
+
+variable [RingHomIsometric σ₂₃]
+
+theorem op_norm_le_bound₂ (f : E →SL[σ₁₃] F →SL[σ₂₃] G) {C : ℝ} (h0 : 0 ≤ C)
+    (hC : ∀ x y, ‖f x y‖ ≤ C * ‖x‖ * ‖y‖) : ‖f‖ ≤ C :=
+  f.op_norm_le_bound h0 fun x => (f x).op_norm_le_bound (mul_nonneg h0 (norm_nonneg _)) <| hC x
+#align continuous_linear_map.op_norm_le_bound₂ ContinuousLinearMap.op_norm_le_bound₂
+
+theorem le_op_norm₂ [RingHomIsometric σ₁₃] (f : E →SL[σ₁₃] F →SL[σ₂₃] G) (x : E) (y : F) :
+    ‖f x y‖ ≤ ‖f‖ * ‖x‖ * ‖y‖ :=
+  (f x).le_of_op_norm_le (f.le_op_norm x) y
+#align continuous_linear_map.le_op_norm₂ ContinuousLinearMap.le_op_norm₂
+
+end
+
+@[simp]
+theorem op_norm_prod (f : E →L[𝕜] Fₗ) (g : E →L[𝕜] Gₗ) : ‖f.Prod g‖ = ‖(f, g)‖ :=
+  le_antisymm
+      (op_norm_le_bound _ (norm_nonneg _) fun x => by
+        simpa only [prod_apply, Prod.norm_def, max_mul_of_nonneg, norm_nonneg] using
+          max_le_max (le_op_norm f x) (le_op_norm g x)) <|
+    max_le
+      (op_norm_le_bound _ (norm_nonneg _) fun x =>
+        (le_max_left _ _).trans ((f.Prod g).le_op_norm x))
+      (op_norm_le_bound _ (norm_nonneg _) fun x =>
+        (le_max_right _ _).trans ((f.Prod g).le_op_norm x))
+#align continuous_linear_map.op_norm_prod ContinuousLinearMap.op_norm_prod
+
+@[simp]
+theorem op_nnnorm_prod (f : E →L[𝕜] Fₗ) (g : E →L[𝕜] Gₗ) : ‖f.Prod g‖₊ = ‖(f, g)‖₊ :=
+  Subtype.ext <| op_norm_prod f g
+#align continuous_linear_map.op_nnnorm_prod ContinuousLinearMap.op_nnnorm_prod
+
+/-- `continuous_linear_map.prod` as a `linear_isometry_equiv`. -/
+def prodₗᵢ (R : Type _) [Semiring R] [Module R Fₗ] [Module R Gₗ] [ContinuousConstSMul R Fₗ]
+    [ContinuousConstSMul R Gₗ] [SMulCommClass 𝕜 R Fₗ] [SMulCommClass 𝕜 R Gₗ] :
+    (E →L[𝕜] Fₗ) × (E →L[𝕜] Gₗ) ≃ₗᵢ[R] E →L[𝕜] Fₗ × Gₗ :=
+  ⟨prodₗ R, fun ⟨f, g⟩ => op_norm_prod f g⟩
+#align continuous_linear_map.prodₗᵢ ContinuousLinearMap.prodₗᵢ
+
+variable [RingHomIsometric σ₁₂] (f : E →SL[σ₁₂] F)
+
+@[simp, nontriviality]
+theorem op_norm_subsingleton [Subsingleton E] : ‖f‖ = 0 :=
+  by
+  refine' le_antisymm _ (norm_nonneg _)
+  apply op_norm_le_bound _ rfl.ge
+  intro x
+  simp [Subsingleton.elim x 0]
+#align continuous_linear_map.op_norm_subsingleton ContinuousLinearMap.op_norm_subsingleton
+
+end OpNorm
+
+section IsO
+
+variable [RingHomIsometric σ₁₂] (c : 𝕜) (f g : E →SL[σ₁₂] F) (h : F →SL[σ₂₃] G) (x y z : E)
+
+open Asymptotics
+
+theorem isBigOWith_id (l : Filter E) : IsBigOWith ‖f‖ l f fun x => x :=
+  isBigOWith_of_le' _ f.le_op_norm
+#align continuous_linear_map.is_O_with_id ContinuousLinearMap.isBigOWith_id
+
+theorem isBigO_id (l : Filter E) : f =O[l] fun x => x :=
+  (f.isBigOWith_id l).IsBigO
+#align continuous_linear_map.is_O_id ContinuousLinearMap.isBigO_id
+
+theorem isBigOWith_comp [RingHomIsometric σ₂₃] {α : Type _} (g : F →SL[σ₂₃] G) (f : α → F)
+    (l : Filter α) : IsBigOWith ‖g‖ l (fun x' => g (f x')) f :=
+  (g.isBigOWith_id ⊤).comp_tendsto le_top
+#align continuous_linear_map.is_O_with_comp ContinuousLinearMap.isBigOWith_comp
+
+theorem isBigO_comp [RingHomIsometric σ₂₃] {α : Type _} (g : F →SL[σ₂₃] G) (f : α → F)
+    (l : Filter α) : (fun x' => g (f x')) =O[l] f :=
+  (g.isBigOWith_comp f l).IsBigO
+#align continuous_linear_map.is_O_comp ContinuousLinearMap.isBigO_comp
+
+theorem isBigOWith_sub (f : E →SL[σ₁₂] F) (l : Filter E) (x : E) :
+    IsBigOWith ‖f‖ l (fun x' => f (x' - x)) fun x' => x' - x :=
+  f.isBigOWith_comp _ l
+#align continuous_linear_map.is_O_with_sub ContinuousLinearMap.isBigOWith_sub
+
+theorem isBigO_sub (f : E →SL[σ₁₂] F) (l : Filter E) (x : E) :
+    (fun x' => f (x' - x)) =O[l] fun x' => x' - x :=
+  f.isBigO_comp _ l
+#align continuous_linear_map.is_O_sub ContinuousLinearMap.isBigO_sub
+
+end IsO
+
+end ContinuousLinearMap
+
+namespace LinearIsometry
+
+theorem norm_toContinuousLinearMap_le (f : E →ₛₗᵢ[σ₁₂] F) : ‖f.toContinuousLinearMap‖ ≤ 1 :=
+  f.toContinuousLinearMap.op_norm_le_bound zero_le_one fun x => by simp
+#align linear_isometry.norm_to_continuous_linear_map_le LinearIsometry.norm_toContinuousLinearMap_le
+
+end LinearIsometry
+
+namespace LinearMap
+
+/-- If a continuous linear map is constructed from a linear map via the constructor `mk_continuous`,
+then its norm is bounded by the bound given to the constructor if it is nonnegative. -/
+theorem mkContinuous_norm_le (f : E →ₛₗ[σ₁₂] F) {C : ℝ} (hC : 0 ≤ C) (h : ∀ x, ‖f x‖ ≤ C * ‖x‖) :
+    ‖f.mkContinuous C h‖ ≤ C :=
+  ContinuousLinearMap.op_norm_le_bound _ hC h
+#align linear_map.mk_continuous_norm_le LinearMap.mkContinuous_norm_le
+
+/-- If a continuous linear map is constructed from a linear map via the constructor `mk_continuous`,
+then its norm is bounded by the bound or zero if bound is negative. -/
+theorem mkContinuous_norm_le' (f : E →ₛₗ[σ₁₂] F) {C : ℝ} (h : ∀ x, ‖f x‖ ≤ C * ‖x‖) :
+    ‖f.mkContinuous C h‖ ≤ max C 0 :=
+  ContinuousLinearMap.op_norm_le_bound _ (le_max_right _ _) fun x =>
+    (h x).trans <| mul_le_mul_of_nonneg_right (le_max_left _ _) (norm_nonneg x)
+#align linear_map.mk_continuous_norm_le' LinearMap.mkContinuous_norm_le'
+
+variable [RingHomIsometric σ₂₃]
+
+/-- Create a bilinear map (represented as a map `E →L[𝕜] F →L[𝕜] G`) from the corresponding linear
+map and a bound on the norm of the image. The linear map can be constructed using
+`linear_map.mk₂`. -/
+def mkContinuous₂ (f : E →ₛₗ[σ₁₃] F →ₛₗ[σ₂₃] G) (C : ℝ) (hC : ∀ x y, ‖f x y‖ ≤ C * ‖x‖ * ‖y‖) :
+    E →SL[σ₁₃] F →SL[σ₂₃] G :=
+  LinearMap.mkContinuous
+    { toFun := fun x => (f x).mkContinuous (C * ‖x‖) (hC x)
+      map_add' := fun x y => by
+        ext z
+        rw [ContinuousLinearMap.add_apply, mk_continuous_apply, mk_continuous_apply,
+          mk_continuous_apply, map_add, add_apply]
+      map_smul' := fun c x => by
+        ext z
+        rw [ContinuousLinearMap.smul_apply, mk_continuous_apply, mk_continuous_apply, map_smulₛₗ,
+          smul_apply] }
+    (max C 0) fun x =>
+    (mkContinuous_norm_le' _ _).trans_eq <| by
+      rw [max_mul_of_nonneg _ _ (norm_nonneg x), MulZeroClass.zero_mul]
+#align linear_map.mk_continuous₂ LinearMap.mkContinuous₂
+
+@[simp]
+theorem mkContinuous₂_apply (f : E →ₛₗ[σ₁₃] F →ₛₗ[σ₂₃] G) {C : ℝ}
+    (hC : ∀ x y, ‖f x y‖ ≤ C * ‖x‖ * ‖y‖) (x : E) (y : F) : f.mkContinuous₂ C hC x y = f x y :=
+  rfl
+#align linear_map.mk_continuous₂_apply LinearMap.mkContinuous₂_apply
+
+theorem mkContinuous₂_norm_le' (f : E →ₛₗ[σ₁₃] F →ₛₗ[σ₂₃] G) {C : ℝ}
+    (hC : ∀ x y, ‖f x y‖ ≤ C * ‖x‖ * ‖y‖) : ‖f.mkContinuous₂ C hC‖ ≤ max C 0 :=
+  mkContinuous_norm_le _ (le_max_iff.2 <| Or.inr le_rfl) _
+#align linear_map.mk_continuous₂_norm_le' LinearMap.mkContinuous₂_norm_le'
+
+theorem mkContinuous₂_norm_le (f : E →ₛₗ[σ₁₃] F →ₛₗ[σ₂₃] G) {C : ℝ} (h0 : 0 ≤ C)
+    (hC : ∀ x y, ‖f x y‖ ≤ C * ‖x‖ * ‖y‖) : ‖f.mkContinuous₂ C hC‖ ≤ C :=
+  (f.mkContinuous₂_norm_le' hC).trans_eq <| max_eq_left h0
+#align linear_map.mk_continuous₂_norm_le LinearMap.mkContinuous₂_norm_le
+
+end LinearMap
+
+namespace ContinuousLinearMap
+
+variable [RingHomIsometric σ₂₃] [RingHomIsometric σ₁₃]
+
+/-- Flip the order of arguments of a continuous bilinear map.
+For a version bundled as `linear_isometry_equiv`, see
+`continuous_linear_map.flipL`. -/
+def flip (f : E →SL[σ₁₃] F →SL[σ₂₃] G) : F →SL[σ₂₃] E →SL[σ₁₃] G :=
+  LinearMap.mkContinuous₂
+    (LinearMap.mk₂'ₛₗ σ₂₃ σ₁₃ (fun y x => f x y) (fun x y z => (f z).map_add x y)
+      (fun c y x => (f x).map_smulₛₗ c y) (fun z x y => by rw [f.map_add, add_apply]) fun c y x =>
+      by rw [f.map_smulₛₗ, smul_apply])
+    ‖f‖ fun y x => (f.le_op_norm₂ x y).trans_eq <| by rw [mul_right_comm]
+#align continuous_linear_map.flip ContinuousLinearMap.flip
+
+private theorem le_norm_flip (f : E →SL[σ₁₃] F →SL[σ₂₃] G) : ‖f‖ ≤ ‖flip f‖ :=
+  f.op_norm_le_bound₂ (norm_nonneg _) fun x y =>
+    by
+    rw [mul_right_comm]
+    exact (flip f).le_op_norm₂ y x
+#align continuous_linear_map.le_norm_flip continuous_linear_map.le_norm_flip
+
+@[simp]
+theorem flip_apply (f : E →SL[σ₁₃] F →SL[σ₂₃] G) (x : E) (y : F) : f.flip y x = f x y :=
+  rfl
+#align continuous_linear_map.flip_apply ContinuousLinearMap.flip_apply
+
+@[simp]
+theorem flip_flip (f : E →SL[σ₁₃] F →SL[σ₂₃] G) : f.flip.flip = f :=
+  by
+  ext
+  rfl
+#align continuous_linear_map.flip_flip ContinuousLinearMap.flip_flip
+
+@[simp]
+theorem op_norm_flip (f : E →SL[σ₁₃] F →SL[σ₂₃] G) : ‖f.flip‖ = ‖f‖ :=
+  le_antisymm (by simpa only [flip_flip] using le_norm_flip f.flip) (le_norm_flip f)
+#align continuous_linear_map.op_norm_flip ContinuousLinearMap.op_norm_flip
+
+@[simp]
+theorem flip_add (f g : E →SL[σ₁₃] F →SL[σ₂₃] G) : (f + g).flip = f.flip + g.flip :=
+  rfl
+#align continuous_linear_map.flip_add ContinuousLinearMap.flip_add
+
+@[simp]
+theorem flip_smul (c : 𝕜₃) (f : E →SL[σ₁₃] F →SL[σ₂₃] G) : (c • f).flip = c • f.flip :=
+  rfl
+#align continuous_linear_map.flip_smul ContinuousLinearMap.flip_smul
+
+variable (E F G σ₁₃ σ₂₃)
+
+/-- Flip the order of arguments of a continuous bilinear map.
+This is a version bundled as a `linear_isometry_equiv`.
+For an unbundled version see `continuous_linear_map.flip`. -/
+def flipₗᵢ' : (E →SL[σ₁₃] F →SL[σ₂₃] G) ≃ₗᵢ[𝕜₃] F →SL[σ₂₃] E →SL[σ₁₃] G
+    where
+  toFun := flip
+  invFun := flip
+  map_add' := flip_add
+  map_smul' := flip_smul
+  left_inv := flip_flip
+  right_inv := flip_flip
+  norm_map' := op_norm_flip
+#align continuous_linear_map.flipₗᵢ' ContinuousLinearMap.flipₗᵢ'
+
+variable {E F G σ₁₃ σ₂₃}
+
+@[simp]
+theorem flipₗᵢ'_symm : (flipₗᵢ' E F G σ₂₃ σ₁₃).symm = flipₗᵢ' F E G σ₁₃ σ₂₃ :=
+  rfl
+#align continuous_linear_map.flipₗᵢ'_symm ContinuousLinearMap.flipₗᵢ'_symm
+
+@[simp]
+theorem coe_flipₗᵢ' : ⇑(flipₗᵢ' E F G σ₂₃ σ₁₃) = flip :=
+  rfl
+#align continuous_linear_map.coe_flipₗᵢ' ContinuousLinearMap.coe_flipₗᵢ'
+
+variable (𝕜 E Fₗ Gₗ)
+
+/-- Flip the order of arguments of a continuous bilinear map.
+This is a version bundled as a `linear_isometry_equiv`.
+For an unbundled version see `continuous_linear_map.flip`. -/
+def flipₗᵢ : (E →L[𝕜] Fₗ →L[𝕜] Gₗ) ≃ₗᵢ[𝕜] Fₗ →L[𝕜] E →L[𝕜] Gₗ
+    where
+  toFun := flip
+  invFun := flip
+  map_add' := flip_add
+  map_smul' := flip_smul
+  left_inv := flip_flip
+  right_inv := flip_flip
+  norm_map' := op_norm_flip
+#align continuous_linear_map.flipₗᵢ ContinuousLinearMap.flipₗᵢ
+
+variable {𝕜 E Fₗ Gₗ}
+
+@[simp]
+theorem flipₗᵢ_symm : (flipₗᵢ 𝕜 E Fₗ Gₗ).symm = flipₗᵢ 𝕜 Fₗ E Gₗ :=
+  rfl
+#align continuous_linear_map.flipₗᵢ_symm ContinuousLinearMap.flipₗᵢ_symm
+
+@[simp]
+theorem coe_flipₗᵢ : ⇑(flipₗᵢ 𝕜 E Fₗ Gₗ) = flip :=
+  rfl
+#align continuous_linear_map.coe_flipₗᵢ ContinuousLinearMap.coe_flipₗᵢ
+
+variable (F σ₁₂) [RingHomIsometric σ₁₂]
+
+/-- The continuous semilinear map obtained by applying a continuous semilinear map at a given
+vector.
+
+This is the continuous version of `linear_map.applyₗ`. -/
+def apply' : E →SL[σ₁₂] (E →SL[σ₁₂] F) →L[𝕜₂] F :=
+  flip (id 𝕜₂ (E →SL[σ₁₂] F))
+#align continuous_linear_map.apply' ContinuousLinearMap.apply'
+
+variable {F σ₁₂}
+
+@[simp]
+theorem apply_apply' (v : E) (f : E →SL[σ₁₂] F) : apply' F σ₁₂ v f = f v :=
+  rfl
+#align continuous_linear_map.apply_apply' ContinuousLinearMap.apply_apply'
+
+variable (𝕜 Fₗ)
+
+/-- The continuous semilinear map obtained by applying a continuous semilinear map at a given
+vector.
+
+This is the continuous version of `linear_map.applyₗ`. -/
+def apply : E →L[𝕜] (E →L[𝕜] Fₗ) →L[𝕜] Fₗ :=
+  flip (id 𝕜 (E →L[𝕜] Fₗ))
+#align continuous_linear_map.apply ContinuousLinearMap.apply
+
+variable {𝕜 Fₗ}
+
+@[simp]
+theorem apply_apply (v : E) (f : E →L[𝕜] Fₗ) : apply 𝕜 Fₗ v f = f v :=
+  rfl
+#align continuous_linear_map.apply_apply ContinuousLinearMap.apply_apply
+
+variable (σ₁₂ σ₂₃ E F G)
+
+/-- Composition of continuous semilinear maps as a continuous semibilinear map. -/
+def compSL : (F →SL[σ₂₃] G) →L[𝕜₃] (E →SL[σ₁₂] F) →SL[σ₂₃] E →SL[σ₁₃] G :=
+  LinearMap.mkContinuous₂
+    (LinearMap.mk₂'ₛₗ (RingHom.id 𝕜₃) σ₂₃ comp add_comp smul_comp comp_add fun c f g =>
+      by
+      ext
+      simp only [ContinuousLinearMap.map_smulₛₗ, coe_smul', coe_comp', Function.comp_apply,
+        Pi.smul_apply])
+    1 fun f g => by simpa only [one_mul] using op_norm_comp_le f g
+#align continuous_linear_map.compSL ContinuousLinearMap.compSL
+
+include σ₁₃
+
+theorem norm_compSL_le : ‖compSL E F G σ₁₂ σ₂₃‖ ≤ 1 :=
+  LinearMap.mkContinuous₂_norm_le _ zero_le_one _
+#align continuous_linear_map.norm_compSL_le ContinuousLinearMap.norm_compSL_le
+
+variable {𝕜 σ₁₂ σ₂₃ E F G}
+
+@[simp]
+theorem compSL_apply (f : F →SL[σ₂₃] G) (g : E →SL[σ₁₂] F) : compSL E F G σ₁₂ σ₂₃ f g = f.comp g :=
+  rfl
+#align continuous_linear_map.compSL_apply ContinuousLinearMap.compSL_apply
+
+theorem Continuous.const_clm_comp {X} [TopologicalSpace X] {f : X → E →SL[σ₁₂] F}
+    (hf : Continuous f) (g : F →SL[σ₂₃] G) :
+    Continuous (fun x => g.comp (f x) : X → E →SL[σ₁₃] G) :=
+  (compSL E F G σ₁₂ σ₂₃ g).Continuous.comp hf
+#align continuous.const_clm_comp Continuous.const_clm_comp
+
+-- Giving the implicit argument speeds up elaboration significantly
+theorem Continuous.clm_comp_const {X} [TopologicalSpace X] {g : X → F →SL[σ₂₃] G}
+    (hg : Continuous g) (f : E →SL[σ₁₂] F) :
+    Continuous (fun x => (g x).comp f : X → E →SL[σ₁₃] G) :=
+  (@ContinuousLinearMap.flip _ _ _ _ _ (E →SL[σ₁₃] G) _ _ _ _ _ _ _ _ _ _ _ _ _
+          (compSL E F G σ₁₂ σ₂₃) f).Continuous.comp
+    hg
+#align continuous.clm_comp_const Continuous.clm_comp_const
+
+omit σ₁₃
+
+variable (𝕜 σ₁₂ σ₂₃ E Fₗ Gₗ)
+
+/-- Composition of continuous linear maps as a continuous bilinear map. -/
+def compL : (Fₗ →L[𝕜] Gₗ) →L[𝕜] (E →L[𝕜] Fₗ) →L[𝕜] E →L[𝕜] Gₗ :=
+  compSL E Fₗ Gₗ (RingHom.id 𝕜) (RingHom.id 𝕜)
+#align continuous_linear_map.compL ContinuousLinearMap.compL
+
+theorem norm_compL_le : ‖compL 𝕜 E Fₗ Gₗ‖ ≤ 1 :=
+  norm_compSL_le _ _ _ _ _
+#align continuous_linear_map.norm_compL_le ContinuousLinearMap.norm_compL_le
+
+@[simp]
+theorem compL_apply (f : Fₗ →L[𝕜] Gₗ) (g : E →L[𝕜] Fₗ) : compL 𝕜 E Fₗ Gₗ f g = f.comp g :=
+  rfl
+#align continuous_linear_map.compL_apply ContinuousLinearMap.compL_apply
+
+variable (Eₗ) {𝕜 E Fₗ Gₗ}
+
+/-- Apply `L(x,-)` pointwise to bilinear maps, as a continuous bilinear map -/
+@[simps apply]
+def precompR (L : E →L[𝕜] Fₗ →L[𝕜] Gₗ) : E →L[𝕜] (Eₗ →L[𝕜] Fₗ) →L[𝕜] Eₗ →L[𝕜] Gₗ :=
+  (compL 𝕜 Eₗ Fₗ Gₗ).comp L
+#align continuous_linear_map.precompR ContinuousLinearMap.precompR
+
+/-- Apply `L(-,y)` pointwise to bilinear maps, as a continuous bilinear map -/
+def precompL (L : E →L[𝕜] Fₗ →L[𝕜] Gₗ) : (Eₗ →L[𝕜] E) →L[𝕜] Fₗ →L[𝕜] Eₗ →L[𝕜] Gₗ :=
+  (precompR Eₗ (flip L)).flip
+#align continuous_linear_map.precompL ContinuousLinearMap.precompL
+
+theorem norm_precompR_le (L : E →L[𝕜] Fₗ →L[𝕜] Gₗ) : ‖precompR Eₗ L‖ ≤ ‖L‖ :=
+  calc
+    ‖precompR Eₗ L‖ ≤ ‖compL 𝕜 Eₗ Fₗ Gₗ‖ * ‖L‖ := op_norm_comp_le _ _
+    _ ≤ 1 * ‖L‖ := (mul_le_mul_of_nonneg_right (norm_compL_le _ _ _ _) (norm_nonneg _))
+    _ = ‖L‖ := by rw [one_mul]
+    
+#align continuous_linear_map.norm_precompR_le ContinuousLinearMap.norm_precompR_le
+
+theorem norm_precompL_le (L : E →L[𝕜] Fₗ →L[𝕜] Gₗ) : ‖precompL Eₗ L‖ ≤ ‖L‖ :=
+  by
+  rw [precompL, op_norm_flip, ← op_norm_flip L]
+  exact norm_precompR_le _ L.flip
+#align continuous_linear_map.norm_precompL_le ContinuousLinearMap.norm_precompL_le
+
+section Prod
+
+universe u₁ u₂ u₃ u₄
+
+variable (M₁ : Type u₁) [SeminormedAddCommGroup M₁] [NormedSpace 𝕜 M₁] (M₂ : Type u₂)
+  [SeminormedAddCommGroup M₂] [NormedSpace 𝕜 M₂] (M₃ : Type u₃) [SeminormedAddCommGroup M₃]
+  [NormedSpace 𝕜 M₃] (M₄ : Type u₄) [SeminormedAddCommGroup M₄] [NormedSpace 𝕜 M₄]
+
+variable {Eₗ} (𝕜)
+
+/-- `continuous_linear_map.prod_map` as a continuous linear map. -/
+def prodMapL : (M₁ →L[𝕜] M₂) × (M₃ →L[𝕜] M₄) →L[𝕜] M₁ × M₃ →L[𝕜] M₂ × M₄ :=
+  ContinuousLinearMap.copy
+    (have Φ₁ : (M₁ →L[𝕜] M₂) →L[𝕜] M₁ →L[𝕜] M₂ × M₄ :=
+      ContinuousLinearMap.compL 𝕜 M₁ M₂ (M₂ × M₄) (ContinuousLinearMap.inl 𝕜 M₂ M₄)
+    have Φ₂ : (M₃ →L[𝕜] M₄) →L[𝕜] M₃ →L[𝕜] M₂ × M₄ :=
+      ContinuousLinearMap.compL 𝕜 M₃ M₄ (M₂ × M₄) (ContinuousLinearMap.inr 𝕜 M₂ M₄)
+    have Φ₁' :=
+      (ContinuousLinearMap.compL 𝕜 (M₁ × M₃) M₁ (M₂ × M₄)).flip (ContinuousLinearMap.fst 𝕜 M₁ M₃)
+    have Φ₂' :=
+      (ContinuousLinearMap.compL 𝕜 (M₁ × M₃) M₃ (M₂ × M₄)).flip (ContinuousLinearMap.snd 𝕜 M₁ M₃)
+    have Ψ₁ : (M₁ →L[𝕜] M₂) × (M₃ →L[𝕜] M₄) →L[𝕜] M₁ →L[𝕜] M₂ :=
+      ContinuousLinearMap.fst 𝕜 (M₁ →L[𝕜] M₂) (M₃ →L[𝕜] M₄)
+    have Ψ₂ : (M₁ →L[𝕜] M₂) × (M₃ →L[𝕜] M₄) →L[𝕜] M₃ →L[𝕜] M₄ :=
+      ContinuousLinearMap.snd 𝕜 (M₁ →L[𝕜] M₂) (M₃ →L[𝕜] M₄)
+    Φ₁' ∘L Φ₁ ∘L Ψ₁ + Φ₂' ∘L Φ₂ ∘L Ψ₂)
+    (fun p : (M₁ →L[𝕜] M₂) × (M₃ →L[𝕜] M₄) => p.1.Prod_map p.2)
+    (by
+      apply funext
+      rintro ⟨φ, ψ⟩
+      apply ContinuousLinearMap.ext fun x => _
+      simp only [add_apply, coe_comp', coe_fst', Function.comp_apply, compL_apply, flip_apply,
+        coe_snd', inl_apply, inr_apply, Prod.mk_add_mk, add_zero, zero_add, coe_prod_map', Prod_map,
+        Prod.mk.inj_iff, eq_self_iff_true, and_self_iff]
+      rfl)
+#align continuous_linear_map.prod_mapL ContinuousLinearMap.prodMapL
+
+variable {M₁ M₂ M₃ M₄}
+
+@[simp]
+theorem prodMapL_apply (p : (M₁ →L[𝕜] M₂) × (M₃ →L[𝕜] M₄)) :
+    ContinuousLinearMap.prodMapL 𝕜 M₁ M₂ M₃ M₄ p = p.1.Prod_map p.2 :=
+  rfl
+#align continuous_linear_map.prod_mapL_apply ContinuousLinearMap.prodMapL_apply
+
+variable {X : Type _} [TopologicalSpace X]
+
+theorem Continuous.prod_mapL {f : X → M₁ →L[𝕜] M₂} {g : X → M₃ →L[𝕜] M₄} (hf : Continuous f)
+    (hg : Continuous g) : Continuous fun x => (f x).Prod_map (g x) :=
+  (prodMapL 𝕜 M₁ M₂ M₃ M₄).Continuous.comp (hf.prod_mk hg)
+#align continuous.prod_mapL Continuous.prod_mapL
+
+theorem Continuous.prod_map_equivL {f : X → M₁ ≃L[𝕜] M₂} {g : X → M₃ ≃L[𝕜] M₄}
+    (hf : Continuous fun x => (f x : M₁ →L[𝕜] M₂)) (hg : Continuous fun x => (g x : M₃ →L[𝕜] M₄)) :
+    Continuous fun x => ((f x).Prod (g x) : M₁ × M₃ →L[𝕜] M₂ × M₄) :=
+  (prodMapL 𝕜 M₁ M₂ M₃ M₄).Continuous.comp (hf.prod_mk hg)
+#align continuous.prod_map_equivL Continuous.prod_map_equivL
+
+theorem ContinuousOn.prod_mapL {f : X → M₁ →L[𝕜] M₂} {g : X → M₃ →L[𝕜] M₄} {s : Set X}
+    (hf : ContinuousOn f s) (hg : ContinuousOn g s) :
+    ContinuousOn (fun x => (f x).Prod_map (g x)) s :=
+  ((prodMapL 𝕜 M₁ M₂ M₃ M₄).Continuous.comp_continuousOn (hf.Prod hg) : _)
+#align continuous_on.prod_mapL ContinuousOn.prod_mapL
+
+theorem ContinuousOn.prod_map_equivL {f : X → M₁ ≃L[𝕜] M₂} {g : X → M₃ ≃L[𝕜] M₄} {s : Set X}
+    (hf : ContinuousOn (fun x => (f x : M₁ →L[𝕜] M₂)) s)
+    (hg : ContinuousOn (fun x => (g x : M₃ →L[𝕜] M₄)) s) :
+    ContinuousOn (fun x => ((f x).Prod (g x) : M₁ × M₃ →L[𝕜] M₂ × M₄)) s :=
+  (prodMapL 𝕜 M₁ M₂ M₃ M₄).Continuous.comp_continuousOn (hf.Prod hg)
+#align continuous_on.prod_map_equivL ContinuousOn.prod_map_equivL
+
+end Prod
+
+variable {𝕜 E Fₗ Gₗ}
+
+section MultiplicationLinear
+
+section NonUnital
+
+variable (𝕜) (𝕜' : Type _) [NonUnitalSeminormedRing 𝕜'] [NormedSpace 𝕜 𝕜'] [IsScalarTower 𝕜 𝕜' 𝕜']
+  [SMulCommClass 𝕜 𝕜' 𝕜']
+
+/- warning: continuous_linear_map.mul clashes with continuous_linear_map.has_mul -> ContinuousLinearMap.mul
+warning: continuous_linear_map.mul -> ContinuousLinearMap.mul is a dubious translation:
+lean 3 declaration is
+  forall (𝕜 : Type.{u1}) [_inst_7 : NontriviallyNormedField.{u1} 𝕜] (𝕜' : Type.{u2}) [_inst_20 : NonUnitalSeminormedRing.{u2} 𝕜'] [_inst_21 : NormedSpace.{u1, u2} 𝕜 𝕜' (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7) (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20)] [_inst_22 : IsScalarTower.{u1, u2, u2} 𝕜 𝕜' 𝕜' (SMulZeroClass.toHasSmul.{u1, u2} 𝕜 𝕜' (AddZeroClass.toHasZero.{u2} 𝕜' (AddMonoid.toAddZeroClass.{u2} 𝕜' (AddCommMonoid.toAddMonoid.{u2} 𝕜' (AddCommGroup.toAddCommMonoid.{u2} 𝕜' (SeminormedAddCommGroup.toAddCommGroup.{u2} 𝕜' (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20)))))) (SMulWithZero.toSmulZeroClass.{u1, u2} 𝕜 𝕜' (MulZeroClass.toHasZero.{u1} 𝕜 (MulZeroOneClass.toMulZeroClass.{u1} 𝕜 (MonoidWithZero.toMulZeroOneClass.{u1} 𝕜 (Semiring.toMonoidWithZero.{u1} 𝕜 (Ring.toSemiring.{u1} 𝕜 (NormedRing.toRing.{u1} 𝕜 (NormedCommRing.toNormedRing.{u1} 𝕜 (NormedField.toNormedCommRing.{u1} 𝕜 (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7))))))))) (AddZeroClass.toHasZero.{u2} 𝕜' (AddMonoid.toAddZeroClass.{u2} 𝕜' (AddCommMonoid.toAddMonoid.{u2} 𝕜' (AddCommGroup.toAddCommMonoid.{u2} 𝕜' (SeminormedAddCommGroup.toAddCommGroup.{u2} 𝕜' (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20)))))) (MulActionWithZero.toSMulWithZero.{u1, u2} 𝕜 𝕜' (Semiring.toMonoidWithZero.{u1} 𝕜 (Ring.toSemiring.{u1} 𝕜 (NormedRing.toRing.{u1} 𝕜 (NormedCommRing.toNormedRing.{u1} 𝕜 (NormedField.toNormedCommRing.{u1} 𝕜 (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7)))))) (AddZeroClass.toHasZero.{u2} 𝕜' (AddMonoid.toAddZeroClass.{u2} 𝕜' (AddCommMonoid.toAddMonoid.{u2} 𝕜' (AddCommGroup.toAddCommMonoid.{u2} 𝕜' (SeminormedAddCommGroup.toAddCommGroup.{u2} 𝕜' (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20)))))) (Module.toMulActionWithZero.{u1, u2} 𝕜 𝕜' (Ring.toSemiring.{u1} 𝕜 (NormedRing.toRing.{u1} 𝕜 (NormedCommRing.toNormedRing.{u1} 𝕜 (NormedField.toNormedCommRing.{u1} 𝕜 (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7))))) (AddCommGroup.toAddCommMonoid.{u2} 𝕜' (SeminormedAddCommGroup.toAddCommGroup.{u2} 𝕜' (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20))) (NormedSpace.toModule.{u1, u2} 𝕜 𝕜' (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7) (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20) _inst_21))))) (Mul.toSMul.{u2} 𝕜' (Distrib.toHasMul.{u2} 𝕜' (NonUnitalNonAssocSemiring.toDistrib.{u2} 𝕜' (NonUnitalNonAssocRing.toNonUnitalNonAssocSemiring.{u2} 𝕜' (NonUnitalRing.toNonUnitalNonAssocRing.{u2} 𝕜' (NonUnitalSeminormedRing.toNonUnitalRing.{u2} 𝕜' _inst_20)))))) (SMulZeroClass.toHasSmul.{u1, u2} 𝕜 𝕜' (AddZeroClass.toHasZero.{u2} 𝕜' (AddMonoid.toAddZeroClass.{u2} 𝕜' (AddCommMonoid.toAddMonoid.{u2} 𝕜' (AddCommGroup.toAddCommMonoid.{u2} 𝕜' (SeminormedAddCommGroup.toAddCommGroup.{u2} 𝕜' (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20)))))) (SMulWithZero.toSmulZeroClass.{u1, u2} 𝕜 𝕜' (MulZeroClass.toHasZero.{u1} 𝕜 (MulZeroOneClass.toMulZeroClass.{u1} 𝕜 (MonoidWithZero.toMulZeroOneClass.{u1} 𝕜 (Semiring.toMonoidWithZero.{u1} 𝕜 (Ring.toSemiring.{u1} 𝕜 (NormedRing.toRing.{u1} 𝕜 (NormedCommRing.toNormedRing.{u1} 𝕜 (NormedField.toNormedCommRing.{u1} 𝕜 (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7))))))))) (AddZeroClass.toHasZero.{u2} 𝕜' (AddMonoid.toAddZeroClass.{u2} 𝕜' (AddCommMonoid.toAddMonoid.{u2} 𝕜' (AddCommGroup.toAddCommMonoid.{u2} 𝕜' (SeminormedAddCommGroup.toAddCommGroup.{u2} 𝕜' (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20)))))) (MulActionWithZero.toSMulWithZero.{u1, u2} 𝕜 𝕜' (Semiring.toMonoidWithZero.{u1} 𝕜 (Ring.toSemiring.{u1} 𝕜 (NormedRing.toRing.{u1} 𝕜 (NormedCommRing.toNormedRing.{u1} 𝕜 (NormedField.toNormedCommRing.{u1} 𝕜 (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7)))))) (AddZeroClass.toHasZero.{u2} 𝕜' (AddMonoid.toAddZeroClass.{u2} 𝕜' (AddCommMonoid.toAddMonoid.{u2} 𝕜' (AddCommGroup.toAddCommMonoid.{u2} 𝕜' (SeminormedAddCommGroup.toAddCommGroup.{u2} 𝕜' (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20)))))) (Module.toMulActionWithZero.{u1, u2} 𝕜 𝕜' (Ring.toSemiring.{u1} 𝕜 (NormedRing.toRing.{u1} 𝕜 (NormedCommRing.toNormedRing.{u1} 𝕜 (NormedField.toNormedCommRing.{u1} 𝕜 (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7))))) (AddCommGroup.toAddCommMonoid.{u2} 𝕜' (SeminormedAddCommGroup.toAddCommGroup.{u2} 𝕜' (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20))) (NormedSpace.toModule.{u1, u2} 𝕜 𝕜' (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7) (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20) _inst_21)))))] [_inst_23 : SMulCommClass.{u1, u2, u2} 𝕜 𝕜' 𝕜' (SMulZeroClass.toHasSmul.{u1, u2} 𝕜 𝕜' (AddZeroClass.toHasZero.{u2} 𝕜' (AddMonoid.toAddZeroClass.{u2} 𝕜' (AddCommMonoid.toAddMonoid.{u2} 𝕜' (AddCommGroup.toAddCommMonoid.{u2} 𝕜' (SeminormedAddCommGroup.toAddCommGroup.{u2} 𝕜' (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20)))))) (SMulWithZero.toSmulZeroClass.{u1, u2} 𝕜 𝕜' (MulZeroClass.toHasZero.{u1} 𝕜 (MulZeroOneClass.toMulZeroClass.{u1} 𝕜 (MonoidWithZero.toMulZeroOneClass.{u1} 𝕜 (Semiring.toMonoidWithZero.{u1} 𝕜 (Ring.toSemiring.{u1} 𝕜 (NormedRing.toRing.{u1} 𝕜 (NormedCommRing.toNormedRing.{u1} 𝕜 (NormedField.toNormedCommRing.{u1} 𝕜 (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7))))))))) (AddZeroClass.toHasZero.{u2} 𝕜' (AddMonoid.toAddZeroClass.{u2} 𝕜' (AddCommMonoid.toAddMonoid.{u2} 𝕜' (AddCommGroup.toAddCommMonoid.{u2} 𝕜' (SeminormedAddCommGroup.toAddCommGroup.{u2} 𝕜' (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20)))))) (MulActionWithZero.toSMulWithZero.{u1, u2} 𝕜 𝕜' (Semiring.toMonoidWithZero.{u1} 𝕜 (Ring.toSemiring.{u1} 𝕜 (NormedRing.toRing.{u1} 𝕜 (NormedCommRing.toNormedRing.{u1} 𝕜 (NormedField.toNormedCommRing.{u1} 𝕜 (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7)))))) (AddZeroClass.toHasZero.{u2} 𝕜' (AddMonoid.toAddZeroClass.{u2} 𝕜' (AddCommMonoid.toAddMonoid.{u2} 𝕜' (AddCommGroup.toAddCommMonoid.{u2} 𝕜' (SeminormedAddCommGroup.toAddCommGroup.{u2} 𝕜' (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20)))))) (Module.toMulActionWithZero.{u1, u2} 𝕜 𝕜' (Ring.toSemiring.{u1} 𝕜 (NormedRing.toRing.{u1} 𝕜 (NormedCommRing.toNormedRing.{u1} 𝕜 (NormedField.toNormedCommRing.{u1} 𝕜 (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7))))) (AddCommGroup.toAddCommMonoid.{u2} 𝕜' (SeminormedAddCommGroup.toAddCommGroup.{u2} 𝕜' (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20))) (NormedSpace.toModule.{u1, u2} 𝕜 𝕜' (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7) (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20) _inst_21))))) (Mul.toSMul.{u2} 𝕜' (Distrib.toHasMul.{u2} 𝕜' (NonUnitalNonAssocSemiring.toDistrib.{u2} 𝕜' (NonUnitalNonAssocRing.toNonUnitalNonAssocSemiring.{u2} 𝕜' (NonUnitalRing.toNonUnitalNonAssocRing.{u2} 𝕜' (NonUnitalSeminormedRing.toNonUnitalRing.{u2} 𝕜' _inst_20))))))], ContinuousLinearMap.{u1, u1, u2, u2} 𝕜 𝕜 (Ring.toSemiring.{u1} 𝕜 (NormedRing.toRing.{u1} 𝕜 (NormedCommRing.toNormedRing.{u1} 𝕜 (NormedField.toNormedCommRing.{u1} 𝕜 (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7))))) (Ring.toSemiring.{u1} 𝕜 (NormedRing.toRing.{u1} 𝕜 (NormedCommRing.toNormedRing.{u1} 𝕜 (NormedField.toNormedCommRing.{u1} 𝕜 (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7))))) (RingHom.id.{u1} 𝕜 (Semiring.toNonAssocSemiring.{u1} 𝕜 (Ring.toSemiring.{u1} 𝕜 (NormedRing.toRing.{u1} 𝕜 (NormedCommRing.toNormedRing.{u1} 𝕜 (NormedField.toNormedCommRing.{u1} 𝕜 (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7))))))) 𝕜' (UniformSpace.toTopologicalSpace.{u2} 𝕜' (PseudoMetricSpace.toUniformSpace.{u2} 𝕜' (NonUnitalSeminormedRing.toPseudoMetricSpace.{u2} 𝕜' _inst_20))) (AddCommGroup.toAddCommMonoid.{u2} 𝕜' (SeminormedAddCommGroup.toAddCommGroup.{u2} 𝕜' (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20))) (ContinuousLinearMap.{u1, u1, u2, u2} 𝕜 𝕜 (Ring.toSemiring.{u1} 𝕜 (NormedRing.toRing.{u1} 𝕜 (NormedCommRing.toNormedRing.{u1} 𝕜 (NormedField.toNormedCommRing.{u1} 𝕜 (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7))))) (Ring.toSemiring.{u1} 𝕜 (NormedRing.toRing.{u1} 𝕜 (NormedCommRing.toNormedRing.{u1} 𝕜 (NormedField.toNormedCommRing.{u1} 𝕜 (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7))))) (RingHom.id.{u1} 𝕜 (Semiring.toNonAssocSemiring.{u1} 𝕜 (Ring.toSemiring.{u1} 𝕜 (NormedRing.toRing.{u1} 𝕜 (NormedCommRing.toNormedRing.{u1} 𝕜 (NormedField.toNormedCommRing.{u1} 𝕜 (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7))))))) 𝕜' (UniformSpace.toTopologicalSpace.{u2} 𝕜' (PseudoMetricSpace.toUniformSpace.{u2} 𝕜' (NonUnitalSeminormedRing.toPseudoMetricSpace.{u2} 𝕜' _inst_20))) (AddCommGroup.toAddCommMonoid.{u2} 𝕜' (SeminormedAddCommGroup.toAddCommGroup.{u2} 𝕜' (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20))) 𝕜' (UniformSpace.toTopologicalSpace.{u2} 𝕜' (PseudoMetricSpace.toUniformSpace.{u2} 𝕜' (NonUnitalSeminormedRing.toPseudoMetricSpace.{u2} 𝕜' _inst_20))) (AddCommGroup.toAddCommMonoid.{u2} 𝕜' (SeminormedAddCommGroup.toAddCommGroup.{u2} 𝕜' (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20))) (NormedSpace.toModule.{u1, u2} 𝕜 𝕜' (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7) (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20) _inst_21) (NormedSpace.toModule.{u1, u2} 𝕜 𝕜' (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7) (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20) _inst_21)) (ContinuousLinearMap.topologicalSpace.{u1, u1, u2, u2} 𝕜 𝕜 (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7) (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7) (RingHom.id.{u1} 𝕜 (Semiring.toNonAssocSemiring.{u1} 𝕜 (Ring.toSemiring.{u1} 𝕜 (NormedRing.toRing.{u1} 𝕜 (NormedCommRing.toNormedRing.{u1} 𝕜 (NormedField.toNormedCommRing.{u1} 𝕜 (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7))))))) 𝕜' 𝕜' (SeminormedAddCommGroup.toAddCommGroup.{u2} 𝕜' (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20)) (NormedSpace.toModule.{u1, u2} 𝕜 𝕜' (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7) (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20) _inst_21) (SeminormedAddCommGroup.toAddCommGroup.{u2} 𝕜' (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20)) (NormedSpace.toModule.{u1, u2} 𝕜 𝕜' (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7) (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20) _inst_21) (UniformSpace.toTopologicalSpace.{u2} 𝕜' (PseudoMetricSpace.toUniformSpace.{u2} 𝕜' (NonUnitalSeminormedRing.toPseudoMetricSpace.{u2} 𝕜' _inst_20))) (UniformSpace.toTopologicalSpace.{u2} 𝕜' (PseudoMetricSpace.toUniformSpace.{u2} 𝕜' (NonUnitalSeminormedRing.toPseudoMetricSpace.{u2} 𝕜' _inst_20))) (ContinuousLinearMap.Mul._proof_1.{u2} 𝕜' _inst_20)) (ContinuousLinearMap.addCommMonoid.{u1, u1, u2, u2} 𝕜 𝕜 (Ring.toSemiring.{u1} 𝕜 (NormedRing.toRing.{u1} 𝕜 (NormedCommRing.toNormedRing.{u1} 𝕜 (NormedField.toNormedCommRing.{u1} 𝕜 (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7))))) (Ring.toSemiring.{u1} 𝕜 (NormedRing.toRing.{u1} 𝕜 (NormedCommRing.toNormedRing.{u1} 𝕜 (NormedField.toNormedCommRing.{u1} 𝕜 (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7))))) (RingHom.id.{u1} 𝕜 (Semiring.toNonAssocSemiring.{u1} 𝕜 (Ring.toSemiring.{u1} 𝕜 (NormedRing.toRing.{u1} 𝕜 (NormedCommRing.toNormedRing.{u1} 𝕜 (NormedField.toNormedCommRing.{u1} 𝕜 (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7))))))) 𝕜' (UniformSpace.toTopologicalSpace.{u2} 𝕜' (PseudoMetricSpace.toUniformSpace.{u2} 𝕜' (NonUnitalSeminormedRing.toPseudoMetricSpace.{u2} 𝕜' _inst_20))) (AddCommGroup.toAddCommMonoid.{u2} 𝕜' (SeminormedAddCommGroup.toAddCommGroup.{u2} 𝕜' (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20))) 𝕜' (UniformSpace.toTopologicalSpace.{u2} 𝕜' (PseudoMetricSpace.toUniformSpace.{u2} 𝕜' (NonUnitalSeminormedRing.toPseudoMetricSpace.{u2} 𝕜' _inst_20))) (AddCommGroup.toAddCommMonoid.{u2} 𝕜' (SeminormedAddCommGroup.toAddCommGroup.{u2} 𝕜' (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20))) (NormedSpace.toModule.{u1, u2} 𝕜 𝕜' (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7) (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20) _inst_21) (NormedSpace.toModule.{u1, u2} 𝕜 𝕜' (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7) (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20) _inst_21) (ContinuousLinearMap.Mul._proof_2.{u2} 𝕜' _inst_20)) (NormedSpace.toModule.{u1, u2} 𝕜 𝕜' (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7) (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20) _inst_21) (ContinuousLinearMap.module.{u1, u1, u1, u2, u2} 𝕜 𝕜 𝕜 (Ring.toSemiring.{u1} 𝕜 (NormedRing.toRing.{u1} 𝕜 (NormedCommRing.toNormedRing.{u1} 𝕜 (NormedField.toNormedCommRing.{u1} 𝕜 (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7))))) (Ring.toSemiring.{u1} 𝕜 (NormedRing.toRing.{u1} 𝕜 (NormedCommRing.toNormedRing.{u1} 𝕜 (NormedField.toNormedCommRing.{u1} 𝕜 (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7))))) (Ring.toSemiring.{u1} 𝕜 (NormedRing.toRing.{u1} 𝕜 (NormedCommRing.toNormedRing.{u1} 𝕜 (NormedField.toNormedCommRing.{u1} 𝕜 (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7))))) 𝕜' (UniformSpace.toTopologicalSpace.{u2} 𝕜' (PseudoMetricSpace.toUniformSpace.{u2} 𝕜' (NonUnitalSeminormedRing.toPseudoMetricSpace.{u2} 𝕜' _inst_20))) (AddCommGroup.toAddCommMonoid.{u2} 𝕜' (SeminormedAddCommGroup.toAddCommGroup.{u2} 𝕜' (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20))) (NormedSpace.toModule.{u1, u2} 𝕜 𝕜' (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7) (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20) _inst_21) 𝕜' (UniformSpace.toTopologicalSpace.{u2} 𝕜' (PseudoMetricSpace.toUniformSpace.{u2} 𝕜' (NonUnitalSeminormedRing.toPseudoMetricSpace.{u2} 𝕜' _inst_20))) (AddCommGroup.toAddCommMonoid.{u2} 𝕜' (SeminormedAddCommGroup.toAddCommGroup.{u2} 𝕜' (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20))) (NormedSpace.toModule.{u1, u2} 𝕜 𝕜' (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7) (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20) _inst_21) (NormedSpace.toModule.{u1, u2} 𝕜 𝕜' (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7) (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20) _inst_21) (ContinuousLinearMap.Mul._proof_3.{u1, u2} 𝕜 _inst_7 𝕜' _inst_20 _inst_21) (ContinuousLinearMap.Mul._proof_4.{u1, u2} 𝕜 _inst_7 𝕜' _inst_20 _inst_21) (RingHom.id.{u1} 𝕜 (Semiring.toNonAssocSemiring.{u1} 𝕜 (Ring.toSemiring.{u1} 𝕜 (NormedRing.toRing.{u1} 𝕜 (NormedCommRing.toNormedRing.{u1} 𝕜 (NormedField.toNormedCommRing.{u1} 𝕜 (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7))))))) (ContinuousLinearMap.Mul._proof_5.{u2} 𝕜' _inst_20))
+but is expected to have type
+  forall {𝕜 : Type.{u1}} [_inst_7 : Semiring.{u1} 𝕜] {𝕜' : Type.{u2}} [_inst_20 : TopologicalSpace.{u2} 𝕜'] [_inst_21 : AddCommMonoid.{u2} 𝕜'] [_inst_22 : Module.{u1, u2} 𝕜 𝕜' _inst_7 _inst_21], Mul.{u2} (ContinuousLinearMap.{u1, u1, u2, u2} 𝕜 𝕜 _inst_7 _inst_7 (RingHom.id.{u1} 𝕜 (Semiring.toNonAssocSemiring.{u1} 𝕜 _inst_7)) 𝕜' _inst_20 _inst_21 𝕜' _inst_20 _inst_21 _inst_22 _inst_22)
+Case conversion may be inaccurate. Consider using '#align continuous_linear_map.mul ContinuousLinearMap.mulₓ'. -/
+/-- Multiplication in a non-unital normed algebra as a continuous bilinear map. -/
+def mul : 𝕜' →L[𝕜] 𝕜' →L[𝕜] 𝕜' :=
+  (LinearMap.mul 𝕜 𝕜').mkContinuous₂ 1 fun x y => by simpa using norm_mul_le x y
+#align continuous_linear_map.mul ContinuousLinearMap.mul
+
+@[simp]
+theorem mul_apply' (x y : 𝕜') : mul 𝕜 𝕜' x y = x * y :=
+  rfl
+#align continuous_linear_map.mul_apply' ContinuousLinearMap.mul_apply'
+
+@[simp]
+theorem op_norm_mul_apply_le (x : 𝕜') : ‖mul 𝕜 𝕜' x‖ ≤ ‖x‖ :=
+  op_norm_le_bound _ (norm_nonneg x) (norm_mul_le x)
+#align continuous_linear_map.op_norm_mul_apply_le ContinuousLinearMap.op_norm_mul_apply_le
+
+theorem op_norm_mul_le : ‖mul 𝕜 𝕜'‖ ≤ 1 :=
+  LinearMap.mkContinuous₂_norm_le _ zero_le_one _
+#align continuous_linear_map.op_norm_mul_le ContinuousLinearMap.op_norm_mul_le
+
+/-- Simultaneous left- and right-multiplication in a non-unital normed algebra, considered as a
+continuous trilinear map. This is akin to its non-continuous version `linear_map.mul_left_right`,
+but there is a minor difference: `linear_map.mul_left_right` is uncurried. -/
+def mulLeftRight : 𝕜' →L[𝕜] 𝕜' →L[𝕜] 𝕜' →L[𝕜] 𝕜' :=
+  ((compL 𝕜 𝕜' 𝕜' 𝕜').comp (mul 𝕜 𝕜').flip).flip.comp (mul 𝕜 𝕜')
+#align continuous_linear_map.mul_left_right ContinuousLinearMap.mulLeftRight
+
+@[simp]
+theorem mulLeftRight_apply (x y z : 𝕜') : mulLeftRight 𝕜 𝕜' x y z = x * z * y :=
+  rfl
+#align continuous_linear_map.mul_left_right_apply ContinuousLinearMap.mulLeftRight_apply
+
+theorem op_norm_mulLeftRight_apply_apply_le (x y : 𝕜') : ‖mulLeftRight 𝕜 𝕜' x y‖ ≤ ‖x‖ * ‖y‖ :=
+  (op_norm_comp_le _ _).trans <|
+    (mul_comm _ _).trans_le <|
+      mul_le_mul (op_norm_mul_apply_le _ _ _)
+        (op_norm_le_bound _ (norm_nonneg _) fun _ => (norm_mul_le _ _).trans_eq (mul_comm _ _))
+        (norm_nonneg _) (norm_nonneg _)
+#align continuous_linear_map.op_norm_mul_left_right_apply_apply_le ContinuousLinearMap.op_norm_mulLeftRight_apply_apply_le
+
+theorem op_norm_mulLeftRight_apply_le (x : 𝕜') : ‖mulLeftRight 𝕜 𝕜' x‖ ≤ ‖x‖ :=
+  op_norm_le_bound _ (norm_nonneg x) (op_norm_mulLeftRight_apply_apply_le 𝕜 𝕜' x)
+#align continuous_linear_map.op_norm_mul_left_right_apply_le ContinuousLinearMap.op_norm_mulLeftRight_apply_le
+
+theorem op_norm_mulLeftRight_le : ‖mulLeftRight 𝕜 𝕜'‖ ≤ 1 :=
+  op_norm_le_bound _ zero_le_one fun x => (one_mul ‖x‖).symm ▸ op_norm_mulLeftRight_apply_le 𝕜 𝕜' x
+#align continuous_linear_map.op_norm_mul_left_right_le ContinuousLinearMap.op_norm_mulLeftRight_le
+
+end NonUnital
+
+section Unital
+
+variable (𝕜) (𝕜' : Type _) [SeminormedRing 𝕜'] [NormedAlgebra 𝕜 𝕜'] [NormOneClass 𝕜']
+
+/-- Multiplication in a normed algebra as a linear isometry to the space of
+continuous linear maps. -/
+def mulₗᵢ : 𝕜' →ₗᵢ[𝕜] 𝕜' →L[𝕜] 𝕜' where
+  toLinearMap := mul 𝕜 𝕜'
+  norm_map' x :=
+    le_antisymm (op_norm_mul_apply_le _ _ _)
+      (by
+        convert ratio_le_op_norm _ (1 : 𝕜')
+        simp [norm_one]
+        infer_instance)
+#align continuous_linear_map.mulₗᵢ ContinuousLinearMap.mulₗᵢ
+
+@[simp]
+theorem coe_mulₗᵢ : ⇑(mulₗᵢ 𝕜 𝕜') = mul 𝕜 𝕜' :=
+  rfl
+#align continuous_linear_map.coe_mulₗᵢ ContinuousLinearMap.coe_mulₗᵢ
+
+@[simp]
+theorem op_norm_mul_apply (x : 𝕜') : ‖mul 𝕜 𝕜' x‖ = ‖x‖ :=
+  (mulₗᵢ 𝕜 𝕜').norm_map x
+#align continuous_linear_map.op_norm_mul_apply ContinuousLinearMap.op_norm_mul_apply
+
+end Unital
+
+end MultiplicationLinear
+
+section SmulLinear
+
+variable (𝕜) (𝕜' : Type _) [NormedField 𝕜'] [NormedAlgebra 𝕜 𝕜'] [NormedSpace 𝕜' E]
+  [IsScalarTower 𝕜 𝕜' E]
+
+/-- Scalar multiplication as a continuous bilinear map. -/
+def lsmul : 𝕜' →L[𝕜] E →L[𝕜] E :=
+  ((Algebra.lsmul 𝕜 E).toLinearMap : 𝕜' →ₗ[𝕜] E →ₗ[𝕜] E).mkContinuous₂ 1 fun c x => by
+    simpa only [one_mul] using norm_smul_le c x
+#align continuous_linear_map.lsmul ContinuousLinearMap.lsmul
+
+@[simp]
+theorem lsmul_apply (c : 𝕜') (x : E) : lsmul 𝕜 𝕜' c x = c • x :=
+  rfl
+#align continuous_linear_map.lsmul_apply ContinuousLinearMap.lsmul_apply
+
+variable {𝕜'}
+
+theorem norm_toSpanSingleton (x : E) : ‖toSpanSingleton 𝕜 x‖ = ‖x‖ :=
+  by
+  refine' op_norm_eq_of_bounds (norm_nonneg _) (fun x => _) fun N hN_nonneg h => _
+  · rw [to_span_singleton_apply, norm_smul, mul_comm]
+  · specialize h 1
+    rw [to_span_singleton_apply, norm_smul, mul_comm] at h
+    exact (mul_le_mul_right (by simp)).mp h
+#align continuous_linear_map.norm_to_span_singleton ContinuousLinearMap.norm_toSpanSingleton
+
+variable {𝕜}
+
+theorem op_norm_lsmul_apply_le (x : 𝕜') : ‖(lsmul 𝕜 𝕜' x : E →L[𝕜] E)‖ ≤ ‖x‖ :=
+  ContinuousLinearMap.op_norm_le_bound _ (norm_nonneg x) fun y => norm_smul_le x y
+#align continuous_linear_map.op_norm_lsmul_apply_le ContinuousLinearMap.op_norm_lsmul_apply_le
+
+/-- The norm of `lsmul` is at most 1 in any semi-normed group. -/
+theorem op_norm_lsmul_le : ‖(lsmul 𝕜 𝕜' : 𝕜' →L[𝕜] E →L[𝕜] E)‖ ≤ 1 :=
+  by
+  refine' ContinuousLinearMap.op_norm_le_bound _ zero_le_one fun x => _
+  simp_rw [one_mul]
+  exact op_norm_lsmul_apply_le _
+#align continuous_linear_map.op_norm_lsmul_le ContinuousLinearMap.op_norm_lsmul_le
+
+end SmulLinear
+
+section RestrictScalars
+
+variable {𝕜' : Type _} [NontriviallyNormedField 𝕜'] [NormedAlgebra 𝕜' 𝕜]
+
+variable [NormedSpace 𝕜' E] [IsScalarTower 𝕜' 𝕜 E]
+
+variable [NormedSpace 𝕜' Fₗ] [IsScalarTower 𝕜' 𝕜 Fₗ]
+
+@[simp]
+theorem norm_restrictScalars (f : E →L[𝕜] Fₗ) : ‖f.restrictScalars 𝕜'‖ = ‖f‖ :=
+  le_antisymm (op_norm_le_bound _ (norm_nonneg _) fun x => f.le_op_norm x)
+    (op_norm_le_bound _ (norm_nonneg _) fun x => f.le_op_norm x)
+#align continuous_linear_map.norm_restrict_scalars ContinuousLinearMap.norm_restrictScalars
+
+variable (𝕜 E Fₗ 𝕜') (𝕜'' : Type _) [Ring 𝕜''] [Module 𝕜'' Fₗ] [ContinuousConstSMul 𝕜'' Fₗ]
+  [SMulCommClass 𝕜 𝕜'' Fₗ] [SMulCommClass 𝕜' 𝕜'' Fₗ]
+
+/-- `continuous_linear_map.restrict_scalars` as a `linear_isometry`. -/
+def restrictScalarsIsometry : (E →L[𝕜] Fₗ) →ₗᵢ[𝕜''] E →L[𝕜'] Fₗ :=
+  ⟨restrictScalarsₗ 𝕜 E Fₗ 𝕜' 𝕜'', norm_restrictScalars⟩
+#align continuous_linear_map.restrict_scalars_isometry ContinuousLinearMap.restrictScalarsIsometry
+
+variable {𝕜 E Fₗ 𝕜' 𝕜''}
+
+@[simp]
+theorem coe_restrictScalarsIsometry :
+    ⇑(restrictScalarsIsometry 𝕜 E Fₗ 𝕜' 𝕜'') = restrictScalars 𝕜' :=
+  rfl
+#align continuous_linear_map.coe_restrict_scalars_isometry ContinuousLinearMap.coe_restrictScalarsIsometry
+
+@[simp]
+theorem restrictScalarsIsometry_toLinearMap :
+    (restrictScalarsIsometry 𝕜 E Fₗ 𝕜' 𝕜'').toLinearMap = restrictScalarsₗ 𝕜 E Fₗ 𝕜' 𝕜'' :=
+  rfl
+#align continuous_linear_map.restrict_scalars_isometry_to_linear_map ContinuousLinearMap.restrictScalarsIsometry_toLinearMap
+
+variable (𝕜 E Fₗ 𝕜' 𝕜'')
+
+/-- `continuous_linear_map.restrict_scalars` as a `continuous_linear_map`. -/
+def restrictScalarsL : (E →L[𝕜] Fₗ) →L[𝕜''] E →L[𝕜'] Fₗ :=
+  (restrictScalarsIsometry 𝕜 E Fₗ 𝕜' 𝕜'').toContinuousLinearMap
+#align continuous_linear_map.restrict_scalarsL ContinuousLinearMap.restrictScalarsL
+
+variable {𝕜 E Fₗ 𝕜' 𝕜''}
+
+@[simp]
+theorem coe_restrictScalarsL :
+    (restrictScalarsL 𝕜 E Fₗ 𝕜' 𝕜'' : (E →L[𝕜] Fₗ) →ₗ[𝕜''] E →L[𝕜'] Fₗ) =
+      restrictScalarsₗ 𝕜 E Fₗ 𝕜' 𝕜'' :=
+  rfl
+#align continuous_linear_map.coe_restrict_scalarsL ContinuousLinearMap.coe_restrictScalarsL
+
+@[simp]
+theorem coe_restrict_scalarsL' : ⇑(restrictScalarsL 𝕜 E Fₗ 𝕜' 𝕜'') = restrictScalars 𝕜' :=
+  rfl
+#align continuous_linear_map.coe_restrict_scalarsL' ContinuousLinearMap.coe_restrict_scalarsL'
+
+end RestrictScalars
+
+end ContinuousLinearMap
+
+namespace Submodule
+
+theorem norm_subtypeL_le (K : Submodule 𝕜 E) : ‖K.subtypeL‖ ≤ 1 :=
+  K.subtypeₗᵢ.norm_toContinuousLinearMap_le
+#align submodule.norm_subtypeL_le Submodule.norm_subtypeL_le
+
+end Submodule
+
+namespace ContinuousLinearEquiv
+
+section
+
+variable {σ₂₁ : 𝕜₂ →+* 𝕜} [RingHomInvPair σ₁₂ σ₂₁] [RingHomInvPair σ₂₁ σ₁₂] [RingHomIsometric σ₁₂]
+
+variable (e : E ≃SL[σ₁₂] F)
+
+include σ₂₁
+
+protected theorem lipschitz : LipschitzWith ‖(e : E →SL[σ₁₂] F)‖₊ e :=
+  (e : E →SL[σ₁₂] F).lipschitz
+#align continuous_linear_equiv.lipschitz ContinuousLinearEquiv.lipschitz
+
+theorem isBigO_comp {α : Type _} (f : α → E) (l : Filter α) : (fun x' => e (f x')) =O[l] f :=
+  (e : E →SL[σ₁₂] F).isBigO_comp f l
+#align continuous_linear_equiv.is_O_comp ContinuousLinearEquiv.isBigO_comp
+
+theorem isBigO_sub (l : Filter E) (x : E) : (fun x' => e (x' - x)) =O[l] fun x' => x' - x :=
+  (e : E →SL[σ₁₂] F).isBigO_sub l x
+#align continuous_linear_equiv.is_O_sub ContinuousLinearEquiv.isBigO_sub
+
+end
+
+variable {σ₂₁ : 𝕜₂ →+* 𝕜} [RingHomInvPair σ₁₂ σ₂₁] [RingHomInvPair σ₂₁ σ₁₂]
+
+variable [RingHomIsometric σ₂₁] (e : E ≃SL[σ₁₂] F)
+
+include σ₂₁
+
+theorem isBigO_comp_rev {α : Type _} (f : α → E) (l : Filter α) : f =O[l] fun x' => e (f x') :=
+  (e.symm.isBigO_comp _ l).congr_left fun _ => e.symm_apply_apply _
+#align continuous_linear_equiv.is_O_comp_rev ContinuousLinearEquiv.isBigO_comp_rev
+
+theorem isBigO_sub_rev (l : Filter E) (x : E) : (fun x' => x' - x) =O[l] fun x' => e (x' - x) :=
+  e.isBigO_comp_rev _ _
+#align continuous_linear_equiv.is_O_sub_rev ContinuousLinearEquiv.isBigO_sub_rev
+
+end ContinuousLinearEquiv
+
+variable {σ₂₁ : 𝕜₂ →+* 𝕜} [RingHomInvPair σ₁₂ σ₂₁] [RingHomInvPair σ₂₁ σ₁₂]
+
+namespace ContinuousLinearMap
+
+variable {E' F' : Type _} [SeminormedAddCommGroup E'] [SeminormedAddCommGroup F']
+
+variable {𝕜₁' : Type _} {𝕜₂' : Type _} [NontriviallyNormedField 𝕜₁'] [NontriviallyNormedField 𝕜₂']
+  [NormedSpace 𝕜₁' E'] [NormedSpace 𝕜₂' F'] {σ₁' : 𝕜₁' →+* 𝕜} {σ₁₃' : 𝕜₁' →+* 𝕜₃} {σ₂' : 𝕜₂' →+* 𝕜₂}
+  {σ₂₃' : 𝕜₂' →+* 𝕜₃} [RingHomCompTriple σ₁' σ₁₃ σ₁₃'] [RingHomCompTriple σ₂' σ₂₃ σ₂₃']
+  [RingHomIsometric σ₂₃] [RingHomIsometric σ₁₃'] [RingHomIsometric σ₂₃']
+
+/-- Compose a bilinear map `E →SL[σ₁₃] F →SL[σ₂₃] G` with two linear maps
+`E' →SL[σ₁'] E` and `F' →SL[σ₂'] F`.  -/
+def bilinearComp (f : E →SL[σ₁₃] F →SL[σ₂₃] G) (gE : E' →SL[σ₁'] E) (gF : F' →SL[σ₂'] F) :
+    E' →SL[σ₁₃'] F' →SL[σ₂₃'] G :=
+  ((f.comp gE).flip.comp gF).flip
+#align continuous_linear_map.bilinear_comp ContinuousLinearMap.bilinearComp
+
+include σ₁₃' σ₂₃'
+
+@[simp]
+theorem bilinearComp_apply (f : E →SL[σ₁₃] F →SL[σ₂₃] G) (gE : E' →SL[σ₁'] E) (gF : F' →SL[σ₂'] F)
+    (x : E') (y : F') : f.bilinearComp gE gF x y = f (gE x) (gF y) :=
+  rfl
+#align continuous_linear_map.bilinear_comp_apply ContinuousLinearMap.bilinearComp_apply
+
+omit σ₁₃' σ₂₃'
+
+variable [RingHomIsometric σ₁₃] [RingHomIsometric σ₁'] [RingHomIsometric σ₂']
+
+/-- Derivative of a continuous bilinear map `f : E →L[𝕜] F →L[𝕜] G` interpreted as a map `E × F → G`
+at point `p : E × F` evaluated at `q : E × F`, as a continuous bilinear map. -/
+def deriv₂ (f : E →L[𝕜] Fₗ →L[𝕜] Gₗ) : E × Fₗ →L[𝕜] E × Fₗ →L[𝕜] Gₗ :=
+  f.bilinearComp (fst _ _ _) (snd _ _ _) + f.flip.bilinearComp (snd _ _ _) (fst _ _ _)
+#align continuous_linear_map.deriv₂ ContinuousLinearMap.deriv₂
+
+@[simp]
+theorem coe_deriv₂ (f : E →L[𝕜] Fₗ →L[𝕜] Gₗ) (p : E × Fₗ) :
+    ⇑(f.deriv₂ p) = fun q : E × Fₗ => f p.1 q.2 + f q.1 p.2 :=
+  rfl
+#align continuous_linear_map.coe_deriv₂ ContinuousLinearMap.coe_deriv₂
+
+theorem map_add_add (f : E →L[𝕜] Fₗ →L[𝕜] Gₗ) (x x' : E) (y y' : Fₗ) :
+    f (x + x') (y + y') = f x y + f.deriv₂ (x, y) (x', y') + f x' y' := by
+  simp only [map_add, add_apply, coe_deriv₂, add_assoc]
+#align continuous_linear_map.map_add_add ContinuousLinearMap.map_add_add
+
+end ContinuousLinearMap
+
+end SemiNormed
+
+section Normed
+
+variable [NormedAddCommGroup E] [NormedAddCommGroup F] [NormedAddCommGroup G]
+  [NormedAddCommGroup Fₗ]
+
+open Metric ContinuousLinearMap
+
+section
+
+variable [NontriviallyNormedField 𝕜] [NontriviallyNormedField 𝕜₂] [NontriviallyNormedField 𝕜₃]
+  [NormedSpace 𝕜 E] [NormedSpace 𝕜₂ F] [NormedSpace 𝕜₃ G] [NormedSpace 𝕜 Fₗ] (c : 𝕜)
+  {σ₁₂ : 𝕜 →+* 𝕜₂} {σ₂₃ : 𝕜₂ →+* 𝕜₃} (f g : E →SL[σ₁₂] F) (x y z : E)
+
+namespace LinearMap
+
+theorem bound_of_shell [RingHomIsometric σ₁₂] (f : E →ₛₗ[σ₁₂] F) {ε C : ℝ} (ε_pos : 0 < ε) {c : 𝕜}
+    (hc : 1 < ‖c‖) (hf : ∀ x, ε / ‖c‖ ≤ ‖x‖ → ‖x‖ < ε → ‖f x‖ ≤ C * ‖x‖) (x : E) :
+    ‖f x‖ ≤ C * ‖x‖ := by
+  by_cases hx : x = 0; · simp [hx]
+  exact
+    SemilinearMapClass.bound_of_shell_semi_normed f ε_pos hc hf (ne_of_lt (norm_pos_iff.2 hx)).symm
+#align linear_map.bound_of_shell LinearMap.bound_of_shell
+
+/-- `linear_map.bound_of_ball_bound'` is a version of this lemma over a field satisfying `is_R_or_C`
+that produces a concrete bound.
+-/
+theorem bound_of_ball_bound {r : ℝ} (r_pos : 0 < r) (c : ℝ) (f : E →ₗ[𝕜] Fₗ)
+    (h : ∀ z ∈ Metric.ball (0 : E) r, ‖f z‖ ≤ c) : ∃ C, ∀ z : E, ‖f z‖ ≤ C * ‖z‖ :=
+  by
+  cases' @NontriviallyNormedField.non_trivial 𝕜 _ with k hk
+  use c * (‖k‖ / r)
+  intro z
+  refine' bound_of_shell _ r_pos hk (fun x hko hxo => _) _
+  calc
+    ‖f x‖ ≤ c := h _ (mem_ball_zero_iff.mpr hxo)
+    _ ≤ c * (‖x‖ * ‖k‖ / r) := (le_mul_of_one_le_right _ _)
+    _ = _ := by ring
+    
+  · exact le_trans (norm_nonneg _) (h 0 (by simp [r_pos]))
+  · rw [div_le_iff (zero_lt_one.trans hk)] at hko
+    exact (one_le_div r_pos).mpr hko
+#align linear_map.bound_of_ball_bound LinearMap.bound_of_ball_bound
+
+theorem antilipschitz_of_comap_nhds_le [h : RingHomIsometric σ₁₂] (f : E →ₛₗ[σ₁₂] F)
+    (hf : (𝓝 0).comap f ≤ 𝓝 0) : ∃ K, AntilipschitzWith K f :=
+  by
+  rcases((nhds_basis_ball.comap _).le_basis_iffₓ nhds_basis_ball).1 hf 1 one_pos with ⟨ε, ε0, hε⟩
+  simp only [Set.subset_def, Set.mem_preimage, mem_ball_zero_iff] at hε
+  lift ε to ℝ≥0 using ε0.le
+  rcases NormedField.exists_one_lt_norm 𝕜 with ⟨c, hc⟩
+  refine' ⟨ε⁻¹ * ‖c‖₊, AddMonoidHomClass.antilipschitz_of_bound f fun x => _⟩
+  by_cases hx : f x = 0
+  · rw [← hx] at hf
+    obtain rfl : x = 0 :=
+      Specializes.eq
+        (specializes_iff_pure.2 <|
+          ((Filter.tendsto_pure_pure _ _).mono_right (pure_le_nhds _)).le_comap.trans hf)
+    exact norm_zero.trans_le (mul_nonneg (NNReal.coe_nonneg _) (norm_nonneg _))
+  have hc₀ : c ≠ 0 := norm_pos_iff.1 (one_pos.trans hc)
+  rw [← h.1] at hc
+  rcases rescale_to_shell_zpow hc ε0 hx with ⟨n, -, hlt, -, hle⟩
+  simp only [← map_zpow₀, h.1, ← map_smulₛₗ] at hlt hle
+  calc
+    ‖x‖ = ‖c ^ n‖⁻¹ * ‖c ^ n • x‖ := by
+      rwa [← norm_inv, ← norm_smul, inv_smul_smul₀ (zpow_ne_zero _ _)]
+    _ ≤ ‖c ^ n‖⁻¹ * 1 := (mul_le_mul_of_nonneg_left (hε _ hlt).le (inv_nonneg.2 (norm_nonneg _)))
+    _ ≤ ε⁻¹ * ‖c‖ * ‖f x‖ := by rwa [mul_one]
+    
+#align linear_map.antilipschitz_of_comap_nhds_le LinearMap.antilipschitz_of_comap_nhds_le
+
+end LinearMap
+
+namespace ContinuousLinearMap
+
+section OpNorm
+
+open Set Real
+
+/-- An operator is zero iff its norm vanishes. -/
+theorem op_norm_zero_iff [RingHomIsometric σ₁₂] : ‖f‖ = 0 ↔ f = 0 :=
+  Iff.intro
+    (fun hn =>
+      ContinuousLinearMap.ext fun x =>
+        norm_le_zero_iff.1
+          (calc
+            _ ≤ ‖f‖ * ‖x‖ := le_op_norm _ _
+            _ = _ := by rw [hn, MulZeroClass.zero_mul]
+            ))
+    (by
+      rintro rfl
+      exact op_norm_zero)
+#align continuous_linear_map.op_norm_zero_iff ContinuousLinearMap.op_norm_zero_iff
+
+/-- If a normed space is non-trivial, then the norm of the identity equals `1`. -/
+@[simp]
+theorem norm_id [Nontrivial E] : ‖id 𝕜 E‖ = 1 :=
+  by
+  refine' norm_id_of_nontrivial_seminorm _
+  obtain ⟨x, hx⟩ := exists_ne (0 : E)
+  exact ⟨x, ne_of_gt (norm_pos_iff.2 hx)⟩
+#align continuous_linear_map.norm_id ContinuousLinearMap.norm_id
+
+instance normOneClass [Nontrivial E] : NormOneClass (E →L[𝕜] E) :=
+  ⟨norm_id⟩
+#align continuous_linear_map.norm_one_class ContinuousLinearMap.normOneClass
+
+/-- Continuous linear maps themselves form a normed space with respect to
+    the operator norm. -/
+instance toNormedAddCommGroup [RingHomIsometric σ₁₂] : NormedAddCommGroup (E →SL[σ₁₂] F) :=
+  NormedAddCommGroup.ofSeparation fun f => (op_norm_zero_iff f).mp
+#align continuous_linear_map.to_normed_add_comm_group ContinuousLinearMap.toNormedAddCommGroup
+
+/-- Continuous linear maps form a normed ring with respect to the operator norm. -/
+instance toNormedRing : NormedRing (E →L[𝕜] E) :=
+  { ContinuousLinearMap.toNormedAddCommGroup, ContinuousLinearMap.toSemiNormedRing with }
+#align continuous_linear_map.to_normed_ring ContinuousLinearMap.toNormedRing
+
+variable {f}
+
+theorem homothety_norm [RingHomIsometric σ₁₂] [Nontrivial E] (f : E →SL[σ₁₂] F) {a : ℝ}
+    (hf : ∀ x, ‖f x‖ = a * ‖x‖) : ‖f‖ = a :=
+  by
+  obtain ⟨x, hx⟩ : ∃ x : E, x ≠ 0 := exists_ne 0
+  rw [← norm_pos_iff] at hx
+  have ha : 0 ≤ a := by simpa only [hf, hx, zero_le_mul_right] using norm_nonneg (f x)
+  apply le_antisymm (f.op_norm_le_bound ha fun y => le_of_eq (hf y))
+  simpa only [hf, hx, mul_le_mul_right] using f.le_op_norm x
+#align continuous_linear_map.homothety_norm ContinuousLinearMap.homothety_norm
+
+variable (f)
+
+/-- If a continuous linear map is a topology embedding, then it is expands the distances
+by a positive factor.-/
+theorem antilipschitz_of_embedding (f : E →L[𝕜] Fₗ) (hf : Embedding f) :
+    ∃ K, AntilipschitzWith K f :=
+  f.toLinearMap.antilipschitz_of_comap_nhds_le <| map_zero f ▸ (hf.nhds_eq_comap 0).ge
+#align continuous_linear_map.antilipschitz_of_embedding ContinuousLinearMap.antilipschitz_of_embedding
+
+section Completeness
+
+open Topology
+
+open Filter
+
+variable {E' : Type _} [SeminormedAddCommGroup E'] [NormedSpace 𝕜 E'] [RingHomIsometric σ₁₂]
+
+/-- Construct a bundled continuous (semi)linear map from a map `f : E → F` and a proof of the fact
+that it belongs to the closure of the image of a bounded set `s : set (E →SL[σ₁₂] F)` under coercion
+to function. Coercion to function of the result is definitionally equal to `f`. -/
+@[simps (config := { fullyApplied := false }) apply]
+def ofMemClosureImageCoeBounded (f : E' → F) {s : Set (E' →SL[σ₁₂] F)} (hs : Bounded s)
+    (hf : f ∈ closure ((coeFn : (E' →SL[σ₁₂] F) → E' → F) '' s)) : E' →SL[σ₁₂] F :=
+  by
+  -- `f` is a linear map due to `linear_map_of_mem_closure_range_coe`
+  refine' (linearMapOfMemClosureRangeCoe f _).mkContinuousOfExistsBound _
+  · refine' closure_mono (image_subset_iff.2 fun g hg => _) hf
+    exact ⟨g, rfl⟩
+  · -- We need to show that `f` has bounded norm. Choose `C` such that `‖g‖ ≤ C` for all `g ∈ s`.
+    rcases bounded_iff_forall_norm_le.1 hs with ⟨C, hC⟩
+    -- Then `‖g x‖ ≤ C * ‖x‖` for all `g ∈ s`, `x : E`, hence `‖f x‖ ≤ C * ‖x‖` for all `x`.
+    have : ∀ x, IsClosed { g : E' → F | ‖g x‖ ≤ C * ‖x‖ } := fun x =>
+      is_closed_Iic.preimage (@continuous_apply E' (fun _ => F) _ x).norm
+    refine' ⟨C, fun x => (this x).closure_subset_iff.2 (image_subset_iff.2 fun g hg => _) hf⟩
+    exact g.le_of_op_norm_le (hC _ hg) _
+#align continuous_linear_map.of_mem_closure_image_coe_bounded ContinuousLinearMap.ofMemClosureImageCoeBounded
+
+/-- Let `f : E → F` be a map, let `g : α → E →SL[σ₁₂] F` be a family of continuous (semi)linear maps
+that takes values in a bounded set and converges to `f` pointwise along a nontrivial filter. Then
+`f` is a continuous (semi)linear map. -/
+@[simps (config := { fullyApplied := false }) apply]
+def ofTendstoOfBoundedRange {α : Type _} {l : Filter α} [l.ne_bot] (f : E' → F)
+    (g : α → E' →SL[σ₁₂] F) (hf : Tendsto (fun a x => g a x) l (𝓝 f)) (hg : Bounded (Set.range g)) :
+    E' →SL[σ₁₂] F :=
+  ofMemClosureImageCoeBounded f hg <|
+    mem_closure_of_tendsto hf <|
+      eventually_of_forall fun a => mem_image_of_mem _ <| Set.mem_range_self _
+#align continuous_linear_map.of_tendsto_of_bounded_range ContinuousLinearMap.ofTendstoOfBoundedRange
+
+/-- If a Cauchy sequence of continuous linear map converges to a continuous linear map pointwise,
+then it converges to the same map in norm. This lemma is used to prove that the space of continuous
+linear maps is complete provided that the codomain is a complete space. -/
+theorem tendsto_of_tendsto_pointwise_of_cauchySeq {f : ℕ → E' →SL[σ₁₂] F} {g : E' →SL[σ₁₂] F}
+    (hg : Tendsto (fun n x => f n x) atTop (𝓝 g)) (hf : CauchySeq f) : Tendsto f atTop (𝓝 g) :=
+  by
+  /- Since `f` is a Cauchy sequence, there exists `b → 0` such that `‖f n - f m‖ ≤ b N` for any
+    `m, n ≥ N`. -/
+  rcases cauchySeq_iff_le_tendsto_0.1 hf with ⟨b, hb₀, hfb, hb_lim⟩
+  -- Since `b → 0`, it suffices to show that `‖f n x - g x‖ ≤ b n * ‖x‖` for all `n` and `x`.
+  suffices : ∀ n x, ‖f n x - g x‖ ≤ b n * ‖x‖
+  exact
+    tendsto_iff_norm_tendsto_zero.2
+      (squeeze_zero (fun n => norm_nonneg _) (fun n => op_norm_le_bound _ (hb₀ n) (this n)) hb_lim)
+  intro n x
+  -- Note that `f m x → g x`, hence `‖f n x - f m x‖ → ‖f n x - g x‖` as `m → ∞`
+  have : tendsto (fun m => ‖f n x - f m x‖) at_top (𝓝 ‖f n x - g x‖) :=
+    (tendsto_const_nhds.sub <| tendsto_pi_nhds.1 hg _).norm
+  -- Thus it suffices to verify `‖f n x - f m x‖ ≤ b n * ‖x‖` for `m ≥ n`.
+  refine' le_of_tendsto this (eventually_at_top.2 ⟨n, fun m hm => _⟩)
+  -- This inequality follows from `‖f n - f m‖ ≤ b n`.
+  exact (f n - f m).le_of_op_norm_le (hfb _ _ _ le_rfl hm) _
+#align continuous_linear_map.tendsto_of_tendsto_pointwise_of_cauchy_seq ContinuousLinearMap.tendsto_of_tendsto_pointwise_of_cauchySeq
+
+/-- If the target space is complete, the space of continuous linear maps with its norm is also
+complete. This works also if the source space is seminormed. -/
+instance [CompleteSpace F] : CompleteSpace (E' →SL[σ₁₂] F) :=
+  by
+  -- We show that every Cauchy sequence converges.
+  refine' Metric.complete_of_cauchySeq_tendsto fun f hf => _
+  -- The evaluation at any point `v : E` is Cauchy.
+  have cau : ∀ v, CauchySeq fun n => f n v := fun v => hf.map (lipschitz_apply v).UniformContinuous
+  -- We assemble the limits points of those Cauchy sequences
+  -- (which exist as `F` is complete)
+  -- into a function which we call `G`.
+  choose G hG using fun v => cauchySeq_tendsto_of_complete (cau v)
+  -- Next, we show that this `G` is a continuous linear map.
+  -- This is done in `continuous_linear_map.of_tendsto_of_bounded_range`.
+  set Glin : E' →SL[σ₁₂] F :=
+    of_tendsto_of_bounded_range _ _ (tendsto_pi_nhds.mpr hG) hf.bounded_range
+  -- Finally, `f n` converges to `Glin` in norm because of
+  -- `continuous_linear_map.tendsto_of_tendsto_pointwise_of_cauchy_seq`
+  exact ⟨Glin, tendsto_of_tendsto_pointwise_of_cauchy_seq (tendsto_pi_nhds.2 hG) hf⟩
+
+/-- Let `s` be a bounded set in the space of continuous (semi)linear maps `E →SL[σ] F` taking values
+in a proper space. Then `s` interpreted as a set in the space of maps `E → F` with topology of
+pointwise convergence is precompact: its closure is a compact set. -/
+theorem isCompact_closure_image_coe_of_bounded [ProperSpace F] {s : Set (E' →SL[σ₁₂] F)}
+    (hb : Bounded s) : IsCompact (closure ((coeFn : (E' →SL[σ₁₂] F) → E' → F) '' s)) :=
+  have : ∀ x, IsCompact (closure (apply' F σ₁₂ x '' s)) := fun x =>
+    ((apply' F σ₁₂ x).lipschitz.bounded_image hb).isCompact_closure
+  isCompact_closure_of_subset_compact (isCompact_pi_infinite this)
+    (image_subset_iff.2 fun g hg x => subset_closure <| mem_image_of_mem _ hg)
+#align continuous_linear_map.is_compact_closure_image_coe_of_bounded ContinuousLinearMap.isCompact_closure_image_coe_of_bounded
+
+/-- Let `s` be a bounded set in the space of continuous (semi)linear maps `E →SL[σ] F` taking values
+in a proper space. If `s` interpreted as a set in the space of maps `E → F` with topology of
+pointwise convergence is closed, then it is compact.
+
+TODO: reformulate this in terms of a type synonym with the right topology. -/
+theorem isCompact_image_coe_of_bounded_of_closed_image [ProperSpace F] {s : Set (E' →SL[σ₁₂] F)}
+    (hb : Bounded s) (hc : IsClosed ((coeFn : (E' →SL[σ₁₂] F) → E' → F) '' s)) :
+    IsCompact ((coeFn : (E' →SL[σ₁₂] F) → E' → F) '' s) :=
+  hc.closure_eq ▸ isCompact_closure_image_coe_of_bounded hb
+#align continuous_linear_map.is_compact_image_coe_of_bounded_of_closed_image ContinuousLinearMap.isCompact_image_coe_of_bounded_of_closed_image
+
+/-- If a set `s` of semilinear functions is bounded and is closed in the weak-* topology, then its
+image under coercion to functions `E → F` is a closed set. We don't have a name for `E →SL[σ] F`
+with weak-* topology in `mathlib`, so we use an equivalent condition (see `is_closed_induced_iff'`).
+
+TODO: reformulate this in terms of a type synonym with the right topology. -/
+theorem isClosed_image_coe_of_bounded_of_weak_closed {s : Set (E' →SL[σ₁₂] F)} (hb : Bounded s)
+    (hc : ∀ f, (⇑f : E' → F) ∈ closure ((coeFn : (E' →SL[σ₁₂] F) → E' → F) '' s) → f ∈ s) :
+    IsClosed ((coeFn : (E' →SL[σ₁₂] F) → E' → F) '' s) :=
+  isClosed_of_closure_subset fun f hf =>
+    ⟨ofMemClosureImageCoeBounded f hb hf, hc (ofMemClosureImageCoeBounded f hb hf) hf, rfl⟩
+#align continuous_linear_map.is_closed_image_coe_of_bounded_of_weak_closed ContinuousLinearMap.isClosed_image_coe_of_bounded_of_weak_closed
+
+/-- If a set `s` of semilinear functions is bounded and is closed in the weak-* topology, then its
+image under coercion to functions `E → F` is a compact set. We don't have a name for `E →SL[σ] F`
+with weak-* topology in `mathlib`, so we use an equivalent condition (see `is_closed_induced_iff'`).
+-/
+theorem isCompact_image_coe_of_bounded_of_weak_closed [ProperSpace F] {s : Set (E' →SL[σ₁₂] F)}
+    (hb : Bounded s)
+    (hc : ∀ f, (⇑f : E' → F) ∈ closure ((coeFn : (E' →SL[σ₁₂] F) → E' → F) '' s) → f ∈ s) :
+    IsCompact ((coeFn : (E' →SL[σ₁₂] F) → E' → F) '' s) :=
+  isCompact_image_coe_of_bounded_of_closed_image hb <|
+    isClosed_image_coe_of_bounded_of_weak_closed hb hc
+#align continuous_linear_map.is_compact_image_coe_of_bounded_of_weak_closed ContinuousLinearMap.isCompact_image_coe_of_bounded_of_weak_closed
+
+/-- A closed ball is closed in the weak-* topology. We don't have a name for `E →SL[σ] F` with
+weak-* topology in `mathlib`, so we use an equivalent condition (see `is_closed_induced_iff'`). -/
+theorem is_weak_closed_closedBall (f₀ : E' →SL[σ₁₂] F) (r : ℝ) ⦃f : E' →SL[σ₁₂] F⦄
+    (hf : ⇑f ∈ closure ((coeFn : (E' →SL[σ₁₂] F) → E' → F) '' closedBall f₀ r)) :
+    f ∈ closedBall f₀ r :=
+  by
+  have hr : 0 ≤ r := nonempty_closed_ball.1 (nonempty_image_iff.1 (closure_nonempty_iff.1 ⟨_, hf⟩))
+  refine' mem_closedBall_iff_norm.2 (op_norm_le_bound _ hr fun x => _)
+  have : IsClosed { g : E' → F | ‖g x - f₀ x‖ ≤ r * ‖x‖ } :=
+    is_closed_Iic.preimage ((@continuous_apply E' (fun _ => F) _ x).sub continuous_const).norm
+  refine' this.closure_subset_iff.2 (image_subset_iff.2 fun g hg => _) hf
+  exact (g - f₀).le_of_op_norm_le (mem_closedBall_iff_norm.1 hg) _
+#align continuous_linear_map.is_weak_closed_closed_ball ContinuousLinearMap.is_weak_closed_closedBall
+
+/-- The set of functions `f : E → F` that represent continuous linear maps `f : E →SL[σ₁₂] F`
+at distance `≤ r` from `f₀ : E →SL[σ₁₂] F` is closed in the topology of pointwise convergence.
+This is one of the key steps in the proof of the **Banach-Alaoglu** theorem. -/
+theorem isClosed_image_coe_closedBall (f₀ : E →SL[σ₁₂] F) (r : ℝ) :
+    IsClosed ((coeFn : (E →SL[σ₁₂] F) → E → F) '' closedBall f₀ r) :=
+  isClosed_image_coe_of_bounded_of_weak_closed bounded_closedBall (is_weak_closed_closedBall f₀ r)
+#align continuous_linear_map.is_closed_image_coe_closed_ball ContinuousLinearMap.isClosed_image_coe_closedBall
+
+/-- **Banach-Alaoglu** theorem. The set of functions `f : E → F` that represent continuous linear
+maps `f : E →SL[σ₁₂] F` at distance `≤ r` from `f₀ : E →SL[σ₁₂] F` is compact in the topology of
+pointwise convergence. Other versions of this theorem can be found in
+`analysis.normed_space.weak_dual`. -/
+theorem isCompact_image_coe_closedBall [ProperSpace F] (f₀ : E →SL[σ₁₂] F) (r : ℝ) :
+    IsCompact ((coeFn : (E →SL[σ₁₂] F) → E → F) '' closedBall f₀ r) :=
+  isCompact_image_coe_of_bounded_of_weak_closed bounded_closedBall <| is_weak_closed_closedBall f₀ r
+#align continuous_linear_map.is_compact_image_coe_closed_ball ContinuousLinearMap.isCompact_image_coe_closedBall
+
+end Completeness
+
+section UniformlyExtend
+
+variable [CompleteSpace F] (e : E →L[𝕜] Fₗ) (h_dense : DenseRange e)
+
+section
+
+variable (h_e : UniformInducing e)
+
+/-- Extension of a continuous linear map `f : E →SL[σ₁₂] F`, with `E` a normed space and `F` a
+complete normed space, along a uniform and dense embedding `e : E →L[𝕜] Fₗ`.  -/
+def extend : Fₗ →SL[σ₁₂] F :=
+  have cont :=
+    (-- extension of `f` is continuous
+        uniformContinuous_uniformly_extend
+        h_e h_dense f.UniformContinuous).Continuous
+  -- extension of `f` agrees with `f` on the domain of the embedding `e`
+  have eq := uniformly_extend_of_ind h_e h_dense f.UniformContinuous
+  { toFun := (h_e.DenseInducing h_dense).extend f
+    map_add' := by
+      refine' h_dense.induction_on₂ _ _
+      ·
+        exact
+          isClosed_eq (cont.comp continuous_add)
+            ((cont.comp continuous_fst).add (cont.comp continuous_snd))
+      · intro x y
+        simp only [Eq, ← e.map_add]
+        exact f.map_add _ _
+    map_smul' := fun k => by
+      refine' fun b => h_dense.induction_on b _ _
+      ·
+        exact
+          isClosed_eq (cont.comp (continuous_const_smul _)) ((continuous_const_smul _).comp cont)
+      · intro x
+        rw [← map_smul]
+        simp only [Eq]
+        exact ContinuousLinearMap.map_smulₛₗ _ _ _
+    cont }
+#align continuous_linear_map.extend ContinuousLinearMap.extend
+
+@[simp]
+theorem extend_eq (x : E) : extend f e h_dense h_e (e x) = f x :=
+  DenseInducing.extend_eq _ f.cont _
+#align continuous_linear_map.extend_eq ContinuousLinearMap.extend_eq
+
+theorem extend_unique (g : Fₗ →SL[σ₁₂] F) (H : g.comp e = f) : extend f e h_dense h_e = g :=
+  ContinuousLinearMap.coeFn_injective <|
+    uniformly_extend_unique h_e h_dense (ContinuousLinearMap.ext_iff.1 H) g.Continuous
+#align continuous_linear_map.extend_unique ContinuousLinearMap.extend_unique
+
+@[simp]
+theorem extend_zero : extend (0 : E →SL[σ₁₂] F) e h_dense h_e = 0 :=
+  extend_unique _ _ _ _ _ (zero_comp _)
+#align continuous_linear_map.extend_zero ContinuousLinearMap.extend_zero
+
+end
+
+section
+
+variable {N : ℝ≥0} (h_e : ∀ x, ‖x‖ ≤ N * ‖e x‖) [RingHomIsometric σ₁₂]
+
+-- mathport name: exprψ
+local notation "ψ" => f.extend e h_dense (uniformEmbedding_of_bound _ h_e).to_uniformInducing
+
+/-- If a dense embedding `e : E →L[𝕜] G` expands the norm by a constant factor `N⁻¹`, then the
+norm of the extension of `f` along `e` is bounded by `N * ‖f‖`. -/
+theorem op_norm_extend_le : ‖ψ‖ ≤ N * ‖f‖ :=
+  by
+  have uni : UniformInducing e := (uniform_embedding_of_bound _ h_e).to_uniformInducing
+  have eq : ∀ x, ψ (e x) = f x := uniformly_extend_of_ind uni h_dense f.uniform_continuous
+  by_cases N0 : 0 ≤ N
+  · refine' op_norm_le_bound ψ _ (isClosed_property h_dense (isClosed_le _ _) _)
+    · exact mul_nonneg N0 (norm_nonneg _)
+    · exact continuous_norm.comp (cont ψ)
+    · exact continuous_const.mul continuous_norm
+    · intro x
+      rw [Eq]
+      calc
+        ‖f x‖ ≤ ‖f‖ * ‖x‖ := le_op_norm _ _
+        _ ≤ ‖f‖ * (N * ‖e x‖) := (mul_le_mul_of_nonneg_left (h_e x) (norm_nonneg _))
+        _ ≤ N * ‖f‖ * ‖e x‖ := by rw [mul_comm ↑N ‖f‖, mul_assoc]
+        
+  · have he : ∀ x : E, x = 0 := by
+      intro x
+      have N0 : N ≤ 0 := le_of_lt (lt_of_not_ge N0)
+      rw [← norm_le_zero_iff]
+      exact le_trans (h_e x) (mul_nonpos_of_nonpos_of_nonneg N0 (norm_nonneg _))
+    have hf : f = 0 := by
+      ext
+      simp only [he x, zero_apply, map_zero]
+    have hψ : ψ = 0 := by
+      rw [hf]
+      apply extend_zero
+    rw [hψ, hf, norm_zero, norm_zero, MulZeroClass.mul_zero]
+#align continuous_linear_map.op_norm_extend_le ContinuousLinearMap.op_norm_extend_le
+
+end
+
+end UniformlyExtend
+
+end OpNorm
+
+end ContinuousLinearMap
+
+namespace LinearIsometry
+
+@[simp]
+theorem norm_toContinuousLinearMap [Nontrivial E] [RingHomIsometric σ₁₂] (f : E →ₛₗᵢ[σ₁₂] F) :
+    ‖f.toContinuousLinearMap‖ = 1 :=
+  f.toContinuousLinearMap.homothety_norm <| by simp
+#align linear_isometry.norm_to_continuous_linear_map LinearIsometry.norm_toContinuousLinearMap
+
+variable {σ₁₃ : 𝕜 →+* 𝕜₃} [RingHomCompTriple σ₁₂ σ₂₃ σ₁₃]
+
+include σ₁₃
+
+/-- Postcomposition of a continuous linear map with a linear isometry preserves
+the operator norm. -/
+theorem norm_toContinuousLinearMap_comp [RingHomIsometric σ₁₂] (f : F →ₛₗᵢ[σ₂₃] G)
+    {g : E →SL[σ₁₂] F} : ‖f.toContinuousLinearMap.comp g‖ = ‖g‖ :=
+  op_norm_ext (f.toContinuousLinearMap.comp g) g fun x => by
+    simp only [norm_map, coe_to_continuous_linear_map, coe_comp']
+#align linear_isometry.norm_to_continuous_linear_map_comp LinearIsometry.norm_toContinuousLinearMap_comp
+
+omit σ₁₃
+
+end LinearIsometry
+
+end
+
+namespace ContinuousLinearMap
+
+variable [NontriviallyNormedField 𝕜] [NontriviallyNormedField 𝕜₂] [NontriviallyNormedField 𝕜₃]
+  [NormedSpace 𝕜 E] [NormedSpace 𝕜₂ F] [NormedSpace 𝕜₃ G] [NormedSpace 𝕜 Fₗ] (c : 𝕜)
+  {σ₁₂ : 𝕜 →+* 𝕜₂} {σ₂₃ : 𝕜₂ →+* 𝕜₃}
+
+variable {𝕜₂' : Type _} [NontriviallyNormedField 𝕜₂'] {F' : Type _} [NormedAddCommGroup F']
+  [NormedSpace 𝕜₂' F'] {σ₂' : 𝕜₂' →+* 𝕜₂} {σ₂'' : 𝕜₂ →+* 𝕜₂'} {σ₂₃' : 𝕜₂' →+* 𝕜₃}
+  [RingHomInvPair σ₂' σ₂''] [RingHomInvPair σ₂'' σ₂'] [RingHomCompTriple σ₂' σ₂₃ σ₂₃']
+  [RingHomCompTriple σ₂'' σ₂₃' σ₂₃] [RingHomIsometric σ₂₃] [RingHomIsometric σ₂']
+  [RingHomIsometric σ₂''] [RingHomIsometric σ₂₃']
+
+include σ₂'' σ₂₃'
+
+/-- Precomposition with a linear isometry preserves the operator norm. -/
+theorem op_norm_comp_linearIsometryEquiv (f : F →SL[σ₂₃] G) (g : F' ≃ₛₗᵢ[σ₂'] F) :
+    ‖f.comp g.toLinearIsometry.toContinuousLinearMap‖ = ‖f‖ :=
+  by
+  cases subsingleton_or_nontrivial F'
+  · haveI := g.symm.to_linear_equiv.to_equiv.subsingleton
+    simp
+  refine' le_antisymm _ _
+  · convert f.op_norm_comp_le g.to_linear_isometry.to_continuous_linear_map
+    simp [g.to_linear_isometry.norm_to_continuous_linear_map]
+  · convert(f.comp g.to_linear_isometry.to_continuous_linear_map).op_norm_comp_le
+        g.symm.to_linear_isometry.to_continuous_linear_map
+    · ext
+      simp
+    haveI := g.symm.surjective.nontrivial
+    simp [g.symm.to_linear_isometry.norm_to_continuous_linear_map]
+#align continuous_linear_map.op_norm_comp_linear_isometry_equiv ContinuousLinearMap.op_norm_comp_linearIsometryEquiv
+
+omit σ₂'' σ₂₃'
+
+/-- The norm of the tensor product of a scalar linear map and of an element of a normed space
+is the product of the norms. -/
+@[simp]
+theorem norm_smulRight_apply (c : E →L[𝕜] 𝕜) (f : Fₗ) : ‖smulRight c f‖ = ‖c‖ * ‖f‖ :=
+  by
+  refine' le_antisymm _ _
+  · apply op_norm_le_bound _ (mul_nonneg (norm_nonneg _) (norm_nonneg _)) fun x => _
+    calc
+      ‖c x • f‖ = ‖c x‖ * ‖f‖ := norm_smul _ _
+      _ ≤ ‖c‖ * ‖x‖ * ‖f‖ := (mul_le_mul_of_nonneg_right (le_op_norm _ _) (norm_nonneg _))
+      _ = ‖c‖ * ‖f‖ * ‖x‖ := by ring
+      
+  · by_cases h : f = 0
+    · simp [h]
+    · have : 0 < ‖f‖ := norm_pos_iff.2 h
+      rw [← le_div_iff this]
+      apply op_norm_le_bound _ (div_nonneg (norm_nonneg _) (norm_nonneg f)) fun x => _
+      rw [div_mul_eq_mul_div, le_div_iff this]
+      calc
+        ‖c x‖ * ‖f‖ = ‖c x • f‖ := (norm_smul _ _).symm
+        _ = ‖smul_right c f x‖ := rfl
+        _ ≤ ‖smul_right c f‖ * ‖x‖ := le_op_norm _ _
+        
+#align continuous_linear_map.norm_smul_right_apply ContinuousLinearMap.norm_smulRight_apply
+
+/-- The non-negative norm of the tensor product of a scalar linear map and of an element of a normed
+space is the product of the non-negative norms. -/
+@[simp]
+theorem nnnorm_smulRight_apply (c : E →L[𝕜] 𝕜) (f : Fₗ) : ‖smulRight c f‖₊ = ‖c‖₊ * ‖f‖₊ :=
+  NNReal.eq <| c.norm_smulRight_apply f
+#align continuous_linear_map.nnnorm_smul_right_apply ContinuousLinearMap.nnnorm_smulRight_apply
+
+variable (𝕜 E Fₗ)
+
+/-- `continuous_linear_map.smul_right` as a continuous trilinear map:
+`smul_rightL (c : E →L[𝕜] 𝕜) (f : F) (x : E) = c x • f`. -/
+def smulRightL : (E →L[𝕜] 𝕜) →L[𝕜] Fₗ →L[𝕜] E →L[𝕜] Fₗ :=
+  LinearMap.mkContinuous₂
+    { toFun := smulRightₗ
+      map_add' := fun c₁ c₂ => by
+        ext x
+        simp only [add_smul, coe_smul_rightₗ, add_apply, smul_right_apply, LinearMap.add_apply]
+      map_smul' := fun m c => by
+        ext x
+        simp only [smul_smul, coe_smul_rightₗ, Algebra.id.smul_eq_mul, coe_smul', smul_right_apply,
+          LinearMap.smul_apply, RingHom.id_apply, Pi.smul_apply] }
+    1 fun c x => by simp only [coe_smul_rightₗ, one_mul, norm_smul_right_apply, LinearMap.coe_mk]
+#align continuous_linear_map.smul_rightL ContinuousLinearMap.smulRightL
+
+variable {𝕜 E Fₗ}
+
+@[simp]
+theorem norm_smulRightL_apply (c : E →L[𝕜] 𝕜) (f : Fₗ) : ‖smulRightL 𝕜 E Fₗ c f‖ = ‖c‖ * ‖f‖ :=
+  norm_smulRight_apply c f
+#align continuous_linear_map.norm_smul_rightL_apply ContinuousLinearMap.norm_smulRightL_apply
+
+@[simp]
+theorem norm_smulRightL (c : E →L[𝕜] 𝕜) [Nontrivial Fₗ] : ‖smulRightL 𝕜 E Fₗ c‖ = ‖c‖ :=
+  ContinuousLinearMap.homothety_norm _ c.norm_smulRight_apply
+#align continuous_linear_map.norm_smul_rightL ContinuousLinearMap.norm_smulRightL
+
+variable (𝕜) (𝕜' : Type _)
+
+section
+
+variable [NormedRing 𝕜'] [NormedAlgebra 𝕜 𝕜']
+
+@[simp]
+theorem op_norm_mul [NormOneClass 𝕜'] : ‖mul 𝕜 𝕜'‖ = 1 :=
+  haveI := NormOneClass.nontrivial 𝕜'
+  (mulₗᵢ 𝕜 𝕜').norm_toContinuousLinearMap
+#align continuous_linear_map.op_norm_mul ContinuousLinearMap.op_norm_mul
+
+end
+
+/-- The norm of `lsmul` equals 1 in any nontrivial normed group.
+
+This is `continuous_linear_map.op_norm_lsmul_le` as an equality. -/
+@[simp]
+theorem op_norm_lsmul [NormedField 𝕜'] [NormedAlgebra 𝕜 𝕜'] [NormedSpace 𝕜' E]
+    [IsScalarTower 𝕜 𝕜' E] [Nontrivial E] : ‖(lsmul 𝕜 𝕜' : 𝕜' →L[𝕜] E →L[𝕜] E)‖ = 1 :=
+  by
+  refine' ContinuousLinearMap.op_norm_eq_of_bounds zero_le_one (fun x => _) fun N hN h => _
+  · rw [one_mul]
+    exact op_norm_lsmul_apply_le _
+  obtain ⟨y, hy⟩ := exists_ne (0 : E)
+  have := le_of_op_norm_le _ (h 1) y
+  simp_rw [lsmul_apply, one_smul, norm_one, mul_one] at this
+  refine' le_of_mul_le_mul_right _ (norm_pos_iff.mpr hy)
+  simp_rw [one_mul, this]
+#align continuous_linear_map.op_norm_lsmul ContinuousLinearMap.op_norm_lsmul
+
+end ContinuousLinearMap
+
+namespace Submodule
+
+variable [NontriviallyNormedField 𝕜] [NontriviallyNormedField 𝕜₂] [NontriviallyNormedField 𝕜₃]
+  [NormedSpace 𝕜 E] [NormedSpace 𝕜₂ F] {σ₁₂ : 𝕜 →+* 𝕜₂}
+
+theorem norm_subtypeL (K : Submodule 𝕜 E) [Nontrivial K] : ‖K.subtypeL‖ = 1 :=
+  K.subtypeₗᵢ.norm_toContinuousLinearMap
+#align submodule.norm_subtypeL Submodule.norm_subtypeL
+
+end Submodule
+
+namespace ContinuousLinearEquiv
+
+variable [NontriviallyNormedField 𝕜] [NontriviallyNormedField 𝕜₂] [NontriviallyNormedField 𝕜₃]
+  [NormedSpace 𝕜 E] [NormedSpace 𝕜₂ F] {σ₁₂ : 𝕜 →+* 𝕜₂} {σ₂₁ : 𝕜₂ →+* 𝕜} [RingHomInvPair σ₁₂ σ₂₁]
+  [RingHomInvPair σ₂₁ σ₁₂]
+
+section
+
+variable [RingHomIsometric σ₂₁]
+
+protected theorem antilipschitz (e : E ≃SL[σ₁₂] F) :
+    AntilipschitzWith ‖(e.symm : F →SL[σ₂₁] E)‖₊ e :=
+  e.symm.lipschitz.to_rightInverse e.left_inv
+#align continuous_linear_equiv.antilipschitz ContinuousLinearEquiv.antilipschitz
+
+theorem one_le_norm_mul_norm_symm [RingHomIsometric σ₁₂] [Nontrivial E] (e : E ≃SL[σ₁₂] F) :
+    1 ≤ ‖(e : E →SL[σ₁₂] F)‖ * ‖(e.symm : F →SL[σ₂₁] E)‖ :=
+  by
+  rw [mul_comm]
+  convert(e.symm : F →SL[σ₂₁] E).op_norm_comp_le (e : E →SL[σ₁₂] F)
+  rw [e.coe_symm_comp_coe, ContinuousLinearMap.norm_id]
+#align continuous_linear_equiv.one_le_norm_mul_norm_symm ContinuousLinearEquiv.one_le_norm_mul_norm_symm
+
+include σ₂₁
+
+theorem norm_pos [RingHomIsometric σ₁₂] [Nontrivial E] (e : E ≃SL[σ₁₂] F) :
+    0 < ‖(e : E →SL[σ₁₂] F)‖ :=
+  pos_of_mul_pos_left (lt_of_lt_of_le zero_lt_one e.one_le_norm_mul_norm_symm) (norm_nonneg _)
+#align continuous_linear_equiv.norm_pos ContinuousLinearEquiv.norm_pos
+
+omit σ₂₁
+
+theorem norm_symm_pos [RingHomIsometric σ₁₂] [Nontrivial E] (e : E ≃SL[σ₁₂] F) :
+    0 < ‖(e.symm : F →SL[σ₂₁] E)‖ :=
+  pos_of_mul_pos_right (zero_lt_one.trans_le e.one_le_norm_mul_norm_symm) (norm_nonneg _)
+#align continuous_linear_equiv.norm_symm_pos ContinuousLinearEquiv.norm_symm_pos
+
+theorem nnnorm_symm_pos [RingHomIsometric σ₁₂] [Nontrivial E] (e : E ≃SL[σ₁₂] F) :
+    0 < ‖(e.symm : F →SL[σ₂₁] E)‖₊ :=
+  e.norm_symm_pos
+#align continuous_linear_equiv.nnnorm_symm_pos ContinuousLinearEquiv.nnnorm_symm_pos
+
+theorem subsingleton_or_norm_symm_pos [RingHomIsometric σ₁₂] (e : E ≃SL[σ₁₂] F) :
+    Subsingleton E ∨ 0 < ‖(e.symm : F →SL[σ₂₁] E)‖ :=
+  by
+  rcases subsingleton_or_nontrivial E with (_i | _i) <;> skip
+  · left
+    infer_instance
+  · right
+    exact e.norm_symm_pos
+#align continuous_linear_equiv.subsingleton_or_norm_symm_pos ContinuousLinearEquiv.subsingleton_or_norm_symm_pos
+
+theorem subsingleton_or_nnnorm_symm_pos [RingHomIsometric σ₁₂] (e : E ≃SL[σ₁₂] F) :
+    Subsingleton E ∨ 0 < ‖(e.symm : F →SL[σ₂₁] E)‖₊ :=
+  subsingleton_or_norm_symm_pos e
+#align continuous_linear_equiv.subsingleton_or_nnnorm_symm_pos ContinuousLinearEquiv.subsingleton_or_nnnorm_symm_pos
+
+variable (𝕜)
+
+@[simp]
+theorem coord_norm (x : E) (h : x ≠ 0) : ‖coord 𝕜 x h‖ = ‖x‖⁻¹ :=
+  by
+  have hx : 0 < ‖x‖ := norm_pos_iff.mpr h
+  haveI : Nontrivial (𝕜 ∙ x) := Submodule.nontrivial_span_singleton h
+  exact
+    ContinuousLinearMap.homothety_norm _ fun y =>
+      homothety_inverse _ hx _ (to_span_nonzero_singleton_homothety 𝕜 x h) _
+#align continuous_linear_equiv.coord_norm ContinuousLinearEquiv.coord_norm
+
+variable {𝕜} {𝕜₄ : Type _} [NontriviallyNormedField 𝕜₄]
+
+variable {H : Type _} [NormedAddCommGroup H] [NormedSpace 𝕜₄ H] [NormedSpace 𝕜₃ G]
+
+variable {σ₂₃ : 𝕜₂ →+* 𝕜₃} {σ₁₃ : 𝕜 →+* 𝕜₃}
+
+variable {σ₃₄ : 𝕜₃ →+* 𝕜₄} {σ₄₃ : 𝕜₄ →+* 𝕜₃}
+
+variable {σ₂₄ : 𝕜₂ →+* 𝕜₄} {σ₁₄ : 𝕜 →+* 𝕜₄}
+
+variable [RingHomInvPair σ₃₄ σ₄₃] [RingHomInvPair σ₄₃ σ₃₄]
+
+variable [RingHomCompTriple σ₂₁ σ₁₄ σ₂₄] [RingHomCompTriple σ₂₄ σ₄₃ σ₂₃]
+
+variable [RingHomCompTriple σ₁₂ σ₂₃ σ₁₃] [RingHomCompTriple σ₁₃ σ₃₄ σ₁₄]
+
+variable [RingHomIsometric σ₁₄] [RingHomIsometric σ₂₃]
+
+variable [RingHomIsometric σ₄₃] [RingHomIsometric σ₂₄]
+
+variable [RingHomIsometric σ₁₃] [RingHomIsometric σ₁₂]
+
+variable [RingHomIsometric σ₃₄]
+
+include σ₂₁ σ₃₄ σ₁₃ σ₂₄
+
+/-- A pair of continuous (semi)linear equivalences generates an continuous (semi)linear equivalence
+between the spaces of continuous (semi)linear maps. -/
+@[simps apply symm_apply]
+def arrowCongrSL (e₁₂ : E ≃SL[σ₁₂] F) (e₄₃ : H ≃SL[σ₄₃] G) : (E →SL[σ₁₄] H) ≃SL[σ₄₃] F →SL[σ₂₃] G :=
+  {-- given explicitly to help `simps`
+        -- given explicitly to help `simps`
+        e₁₂.arrowCongrEquiv
+      e₄₃ with
+    toFun := fun L => (e₄₃ : H →SL[σ₄₃] G).comp (L.comp (e₁₂.symm : F →SL[σ₂₁] E))
+    invFun := fun L => (e₄₃.symm : G →SL[σ₃₄] H).comp (L.comp (e₁₂ : E →SL[σ₁₂] F))
+    map_add' := fun f g => by rw [add_comp, comp_add]
+    map_smul' := fun t f => by rw [smul_comp, comp_smulₛₗ]
+    continuous_toFun := (continuous_id.clm_comp_const _).const_clm_comp _
+    continuous_invFun := (continuous_id.clm_comp_const _).const_clm_comp _ }
+#align continuous_linear_equiv.arrow_congrSL ContinuousLinearEquiv.arrowCongrSL
+
+omit σ₂₁ σ₃₄ σ₁₃ σ₂₄
+
+/-- A pair of continuous linear equivalences generates an continuous linear equivalence between
+the spaces of continuous linear maps. -/
+def arrowCongr {F H : Type _} [NormedAddCommGroup F] [NormedAddCommGroup H] [NormedSpace 𝕜 F]
+    [NormedSpace 𝕜 G] [NormedSpace 𝕜 H] (e₁ : E ≃L[𝕜] F) (e₂ : H ≃L[𝕜] G) :
+    (E →L[𝕜] H) ≃L[𝕜] F →L[𝕜] G :=
+  arrowCongrSL e₁ e₂
+#align continuous_linear_equiv.arrow_congr ContinuousLinearEquiv.arrowCongr
+
+end
+
+end ContinuousLinearEquiv
+
+end Normed
+
+/-- A bounded bilinear form `B` in a real normed space is *coercive*
+if there is some positive constant C such that `C * ‖u‖ * ‖u‖ ≤ B u u`.
+-/
+def IsCoercive [NormedAddCommGroup E] [NormedSpace ℝ E] (B : E →L[ℝ] E →L[ℝ] ℝ) : Prop :=
+  ∃ C, 0 < C ∧ ∀ u, C * ‖u‖ * ‖u‖ ≤ B u u
+#align is_coercive IsCoercive
+

--- a/Mathlib/Analysis/NormedSpace/OperatorNorm.lean
+++ b/Mathlib/Analysis/NormedSpace/OperatorNorm.lean
@@ -1136,8 +1136,8 @@ def prodMapL : (M₁ →L[𝕜] M₂) × (M₃ →L[𝕜] M₄) →L[𝕜] M₁ 
       -- Porting note: mathport suggested:
       -- ```
       -- simp only [add_apply, coe_comp', coe_fst', Function.comp_apply, compL_apply, flip_apply,
-      --   coe_snd', inl_apply, inr_apply, Prod.mk_add_mk, add_zero, zero_add, coe_prodMap', Prod_map,
-      --   Prod.mk.inj_iff, eq_self_iff_true, and_self_iff]
+      --   coe_snd', inl_apply, inr_apply, Prod.mk_add_mk, add_zero, zero_add, coe_prodMap'
+      --   Prod_map, Prod.mk.inj_iff, eq_self_iff_true, and_self_iff]
       -- rfl
       -- ```
       -- Frustratingly, in `mathlib3` we can use:

--- a/Mathlib/Analysis/NormedSpace/OperatorNorm.lean
+++ b/Mathlib/Analysis/NormedSpace/OperatorNorm.lean
@@ -21,10 +21,10 @@ Define the operator norm on the space of continuous (semi)linear maps between no
 prove its basic properties. In particular, show that this space is itself a normed space.
 
 Since a lot of elementary properties don't require `‖x‖ = 0 → x = 0` we start setting up the
-theory for `seminormed_add_comm_group` and we specialize to `normed_add_comm_group` at the end.
+theory for `SeminormedAddCommGroup` and we specialize to `NormedAddCommGroup` at the end.
 
 Note that most of statements that apply to semilinear maps only hold when the ring homomorphism
-is isometric, as expressed by the typeclass `[ring_hom_isometric σ]`.
+is isometric, as expressed by the typeclass `[RingHomIsometric σ]`.
 
 -/
 
@@ -48,6 +48,7 @@ variable [NontriviallyNormedField 𝕜] [NontriviallyNormedField 𝕜₂] [Nontr
   [NormedSpace 𝕜 Gₗ] {σ₁₂ : 𝕜 →+* 𝕜₂} {σ₂₃ : 𝕜₂ →+* 𝕜₃} {σ₁₃ : 𝕜 →+* 𝕜₃}
   [RingHomCompTriple σ₁₂ σ₂₃ σ₁₃]
 
+set_option synthInstance.etaExperiment true in
 /-- If `‖x‖ = 0` and `f` is continuous then `‖f x‖ = 0`. -/
 theorem norm_image_of_norm_zero [SemilinearMapClass 𝓕 σ₁₂ E F] (f : 𝓕) (hf : Continuous f) {x : E}
     (hx : ‖x‖ = 0) : ‖f x‖ = 0 := by
@@ -64,16 +65,18 @@ section
 
 variable [RingHomIsometric σ₁₂] [RingHomIsometric σ₂₃]
 
+set_option synthInstance.etaExperiment true in
 theorem SemilinearMapClass.bound_of_shell_semi_normed [SemilinearMapClass 𝓕 σ₁₂ E F] (f : 𝓕)
     {ε C : ℝ} (ε_pos : 0 < ε) {c : 𝕜} (hc : 1 < ‖c‖)
     (hf : ∀ x, ε / ‖c‖ ≤ ‖x‖ → ‖x‖ < ε → ‖f x‖ ≤ C * ‖x‖) {x : E} (hx : ‖x‖ ≠ 0) :
     ‖f x‖ ≤ C * ‖x‖ := by
-  rcases rescale_to_shell_semi_normed hc ε_pos hx with ⟨δ, hδ, δxle, leδx, δinv⟩
+  rcases rescale_to_shell_semi_normed hc ε_pos hx with ⟨δ, hδ, δxle, leδx, _⟩
   have := hf (δ • x) leδx δxle
   simpa only [map_smulₛₗ, norm_smul, mul_left_comm C, mul_le_mul_left (norm_pos_iff.2 hδ),
     RingHomIsometric.is_iso] using hf (δ • x) leδx δxle
 #align semilinear_map_class.bound_of_shell_semi_normed SemilinearMapClass.bound_of_shell_semi_normed
 
+set_option synthInstance.etaExperiment true in
 /-- A continuous linear map between seminormed spaces is bounded when the field is nontrivially
 normed. The continuity ensures boundedness on a ball of some radius `ε`. The nontriviality of the
 norm is then used to rescale any element into an element of norm in `[ε/C, ε]`, whose image has a
@@ -97,6 +100,7 @@ end
 
 namespace ContinuousLinearMap
 
+set_option synthInstance.etaExperiment true in
 theorem bound [RingHomIsometric σ₁₂] (f : E →SL[σ₁₂] F) : ∃ C, 0 < C ∧ ∀ x : E, ‖f x‖ ≤ C * ‖x‖ :=
   SemilinearMapClass.bound_of_continuous f f.2
 #align continuous_linear_map.bound ContinuousLinearMap.bound
@@ -109,20 +113,21 @@ variable (𝕜 E)
 
 /-- Given a unit-length element `x` of a normed space `E` over a field `𝕜`, the natural linear
     isometry map from `𝕜` to `E` by taking multiples of `x`.-/
-def LinearIsometry.toSpanSingleton {v : E} (hv : ‖v‖ = 1) : 𝕜 →ₗᵢ[𝕜] E :=
+def _root_.LinearIsometry.toSpanSingleton {v : E} (hv : ‖v‖ = 1) : 𝕜 →ₗᵢ[𝕜] E :=
   { LinearMap.toSpanSingleton 𝕜 E v with norm_map' := fun x => by simp [norm_smul, hv] }
 #align linear_isometry.to_span_singleton LinearIsometry.toSpanSingleton
 
 variable {𝕜 E}
 
+set_option synthInstance.etaExperiment true in
 @[simp]
-theorem LinearIsometry.toSpanSingleton_apply {v : E} (hv : ‖v‖ = 1) (a : 𝕜) :
+theorem _root_.LinearIsometry.toSpanSingleton_apply {v : E} (hv : ‖v‖ = 1) (a : 𝕜) :
     LinearIsometry.toSpanSingleton 𝕜 E hv a = a • v :=
   rfl
 #align linear_isometry.to_span_singleton_apply LinearIsometry.toSpanSingleton_apply
 
 @[simp]
-theorem LinearIsometry.coe_toSpanSingleton {v : E} (hv : ‖v‖ = 1) :
+theorem _root_.LinearIsometry.coe_toSpanSingleton {v : E} (hv : ‖v‖ = 1) :
     (LinearIsometry.toSpanSingleton 𝕜 E hv).toLinearMap = LinearMap.toSpanSingleton 𝕜 E v :=
   rfl
 #align linear_isometry.coe_to_span_singleton LinearIsometry.coe_toSpanSingleton
@@ -133,6 +138,7 @@ section OpNorm
 
 open Set Real
 
+set_option synthInstance.etaExperiment true in
 /-- The operator norm of a continuous linear map is the inf of all its bounds. -/
 def opNorm (f : E →SL[σ₁₂] F) :=
   sInf { c | 0 ≤ c ∧ ∀ x, ‖f x‖ ≤ c * ‖x‖ }
@@ -142,11 +148,13 @@ instance hasOpNorm : Norm (E →SL[σ₁₂] F) :=
   ⟨opNorm⟩
 #align continuous_linear_map.has_op_norm ContinuousLinearMap.hasOpNorm
 
+set_option synthInstance.etaExperiment true in
 theorem norm_def (f : E →SL[σ₁₂] F) : ‖f‖ = sInf { c | 0 ≤ c ∧ ∀ x, ‖f x‖ ≤ c * ‖x‖ } :=
   rfl
 #align continuous_linear_map.norm_def ContinuousLinearMap.norm_def
 
--- So that invocations of `le_cInf` make sense: we show that the set of
+set_option synthInstance.etaExperiment true in
+-- So that invocations of `le_cinfₛ` make sense: we show that the set of
 -- bounds is nonempty and bounded below.
 theorem bounds_nonempty [RingHomIsometric σ₁₂] {f : E →SL[σ₁₂] F} :
     ∃ c, c ∈ { c | 0 ≤ c ∧ ∀ x, ‖f x‖ ≤ c * ‖x‖ } :=
@@ -154,16 +162,19 @@ theorem bounds_nonempty [RingHomIsometric σ₁₂] {f : E →SL[σ₁₂] F} :
   ⟨M, le_of_lt hMp, hMb⟩
 #align continuous_linear_map.bounds_nonempty ContinuousLinearMap.bounds_nonempty
 
+set_option synthInstance.etaExperiment true in
 theorem bounds_bddBelow {f : E →SL[σ₁₂] F} : BddBelow { c | 0 ≤ c ∧ ∀ x, ‖f x‖ ≤ c * ‖x‖ } :=
   ⟨0, fun _ ⟨hn, _⟩ => hn⟩
 #align continuous_linear_map.bounds_bdd_below ContinuousLinearMap.bounds_bddBelow
 
+set_option synthInstance.etaExperiment true in
 /-- If one controls the norm of every `A x`, then one controls the norm of `A`. -/
 theorem op_norm_le_bound (f : E →SL[σ₁₂] F) {M : ℝ} (hMp : 0 ≤ M) (hM : ∀ x, ‖f x‖ ≤ M * ‖x‖) :
     ‖f‖ ≤ M :=
   csInf_le bounds_bddBelow ⟨hMp, hM⟩
 #align continuous_linear_map.op_norm_le_bound ContinuousLinearMap.op_norm_le_bound
 
+set_option synthInstance.etaExperiment true in
 /-- If one controls the norm of every `A x`, `‖x‖ ≠ 0`, then one controls the norm of `A`. -/
 theorem op_norm_le_bound' (f : E →SL[σ₁₂] F) {M : ℝ} (hMp : 0 ≤ M)
     (hM : ∀ x, ‖x‖ ≠ 0 → ‖f x‖ ≤ M * ‖x‖) : ‖f‖ ≤ M :=
@@ -172,11 +183,13 @@ theorem op_norm_le_bound' (f : E →SL[σ₁₂] F) {M : ℝ} (hMp : 0 ≤ M)
       simp only [h, MulZeroClass.mul_zero, norm_image_of_norm_zero f f.2 h]
 #align continuous_linear_map.op_norm_le_bound' ContinuousLinearMap.op_norm_le_bound'
 
+set_option synthInstance.etaExperiment true in
 theorem op_norm_le_of_lipschitz {f : E →SL[σ₁₂] F} {K : ℝ≥0} (hf : LipschitzWith K f) : ‖f‖ ≤ K :=
   f.op_norm_le_bound K.2 fun x => by
     simpa only [dist_zero_right, f.map_zero] using hf.dist_le_mul x 0
 #align continuous_linear_map.op_norm_le_of_lipschitz ContinuousLinearMap.op_norm_le_of_lipschitz
 
+set_option synthInstance.etaExperiment true in
 theorem op_norm_eq_of_bounds {φ : E →SL[σ₁₂] F} {M : ℝ} (M_nonneg : 0 ≤ M)
     (h_above : ∀ x, ‖φ x‖ ≤ M * ‖x‖) (h_below : ∀ N ≥ 0, (∀ x, ‖φ x‖ ≤ N * ‖x‖) → M ≤ N) :
     ‖φ‖ = M :=
@@ -197,9 +210,10 @@ theorem op_norm_nonneg : 0 ≤ ‖f‖ :=
   le_csInf bounds_nonempty fun _ ⟨hx, _⟩ => hx
 #align continuous_linear_map.op_norm_nonneg ContinuousLinearMap.op_norm_nonneg
 
+set_option synthInstance.etaExperiment true in
 /-- The fundamental property of the operator norm: `‖f x‖ ≤ ‖f‖ * ‖x‖`. -/
 theorem le_op_norm : ‖f x‖ ≤ ‖f‖ * ‖x‖ := by
-  obtain ⟨C, Cpos, hC⟩ := f.bound
+  obtain ⟨C, _, hC⟩ := f.bound
   replace hC := hC x
   by_cases h : ‖x‖ = 0
   · rwa [h, MulZeroClass.mul_zero] at hC⊢
@@ -209,32 +223,39 @@ theorem le_op_norm : ‖f x‖ ≤ ‖f‖ * ‖x‖ := by
       (le_csInf bounds_nonempty fun c ⟨_, hc⟩ => (div_le_iff hlt).mpr <| by apply hc)
 #align continuous_linear_map.le_op_norm ContinuousLinearMap.le_op_norm
 
+set_option synthInstance.etaExperiment true in
 theorem dist_le_op_norm (x y : E) : dist (f x) (f y) ≤ ‖f‖ * dist x y := by
   simp_rw [dist_eq_norm, ← map_sub, f.le_op_norm]
 #align continuous_linear_map.dist_le_op_norm ContinuousLinearMap.dist_le_op_norm
 
+set_option synthInstance.etaExperiment true in
 theorem le_op_norm_of_le {c : ℝ} {x} (h : ‖x‖ ≤ c) : ‖f x‖ ≤ ‖f‖ * c :=
   le_trans (f.le_op_norm x) (mul_le_mul_of_nonneg_left h f.op_norm_nonneg)
 #align continuous_linear_map.le_op_norm_of_le ContinuousLinearMap.le_op_norm_of_le
 
+set_option synthInstance.etaExperiment true in
 theorem le_of_op_norm_le {c : ℝ} (h : ‖f‖ ≤ c) (x : E) : ‖f x‖ ≤ c * ‖x‖ :=
   (f.le_op_norm x).trans (mul_le_mul_of_nonneg_right h (norm_nonneg x))
 #align continuous_linear_map.le_of_op_norm_le ContinuousLinearMap.le_of_op_norm_le
 
+set_option synthInstance.etaExperiment true in
 theorem ratio_le_op_norm : ‖f x‖ / ‖x‖ ≤ ‖f‖ :=
   div_le_of_nonneg_of_le_mul (norm_nonneg _) f.op_norm_nonneg (le_op_norm _ _)
 #align continuous_linear_map.ratio_le_op_norm ContinuousLinearMap.ratio_le_op_norm
 
+set_option synthInstance.etaExperiment true in
 /-- The image of the unit ball under a continuous linear map is bounded. -/
 theorem unit_le_op_norm : ‖x‖ ≤ 1 → ‖f x‖ ≤ ‖f‖ :=
   mul_one ‖f‖ ▸ f.le_op_norm_of_le
 #align continuous_linear_map.unit_le_op_norm ContinuousLinearMap.unit_le_op_norm
 
+set_option synthInstance.etaExperiment true in
 theorem op_norm_le_of_shell {f : E →SL[σ₁₂] F} {ε C : ℝ} (ε_pos : 0 < ε) (hC : 0 ≤ C) {c : 𝕜}
     (hc : 1 < ‖c‖) (hf : ∀ x, ε / ‖c‖ ≤ ‖x‖ → ‖x‖ < ε → ‖f x‖ ≤ C * ‖x‖) : ‖f‖ ≤ C :=
-  f.op_norm_le_bound' hC fun x hx => SemilinearMapClass.bound_of_shell_semi_normed f ε_pos hc hf hx
+  f.op_norm_le_bound' hC fun _ hx => SemilinearMapClass.bound_of_shell_semi_normed f ε_pos hc hf hx
 #align continuous_linear_map.op_norm_le_of_shell ContinuousLinearMap.op_norm_le_of_shell
 
+set_option synthInstance.etaExperiment true in
 theorem op_norm_le_of_ball {f : E →SL[σ₁₂] F} {ε : ℝ} {C : ℝ} (ε_pos : 0 < ε) (hC : 0 ≤ C)
     (hf : ∀ x ∈ ball (0 : E) ε, ‖f x‖ ≤ C * ‖x‖) : ‖f‖ ≤ C := by
   rcases NormedField.exists_one_lt_norm 𝕜 with ⟨c, hc⟩
@@ -242,12 +263,14 @@ theorem op_norm_le_of_ball {f : E →SL[σ₁₂] F} {ε : ℝ} {C : ℝ} (ε_po
   rwa [ball_zero_eq]
 #align continuous_linear_map.op_norm_le_of_ball ContinuousLinearMap.op_norm_le_of_ball
 
+set_option synthInstance.etaExperiment true in
 theorem op_norm_le_of_nhds_zero {f : E →SL[σ₁₂] F} {C : ℝ} (hC : 0 ≤ C)
     (hf : ∀ᶠ x in 𝓝 (0 : E), ‖f x‖ ≤ C * ‖x‖) : ‖f‖ ≤ C :=
-  let ⟨ε, ε0, hε⟩ := Metric.eventually_nhds_iff_ball.1 hf
+  let ⟨_, ε0, hε⟩ := Metric.eventually_nhds_iff_ball.1 hf
   op_norm_le_of_ball ε0 hC hε
 #align continuous_linear_map.op_norm_le_of_nhds_zero ContinuousLinearMap.op_norm_le_of_nhds_zero
 
+set_option synthInstance.etaExperiment true in
 theorem op_norm_le_of_shell' {f : E →SL[σ₁₂] F} {ε C : ℝ} (ε_pos : 0 < ε) (hC : 0 ≤ C) {c : 𝕜}
     (hc : ‖c‖ < 1) (hf : ∀ x, ε * ‖c‖ ≤ ‖x‖ → ‖x‖ < ε → ‖f x‖ ≤ C * ‖x‖) : ‖f‖ ≤ C := by
   by_cases h0 : c = 0
@@ -266,34 +289,33 @@ theorem op_norm_le_of_unit_norm [NormedSpace ℝ E] [NormedSpace ℝ F] {f : E �
   refine' op_norm_le_bound' f hC fun x hx => _
   have H₁ : ‖‖x‖⁻¹ • x‖ = 1 := by rw [norm_smul, norm_inv, norm_norm, inv_mul_cancel hx]
   have H₂ := hf _ H₁
-  rwa [map_smul, norm_smul, norm_inv, norm_norm, ← div_eq_inv_mul, div_le_iff] at H₂
+  rwa [map_smul, norm_smul, norm_inv, norm_norm, ← div_eq_inv_mul, _root_.div_le_iff] at H₂
   exact (norm_nonneg x).lt_of_ne' hx
 #align continuous_linear_map.op_norm_le_of_unit_norm ContinuousLinearMap.op_norm_le_of_unit_norm
 
+set_option synthInstance.etaExperiment true in
 /-- The operator norm satisfies the triangle inequality. -/
 theorem op_norm_add_le : ‖f + g‖ ≤ ‖f‖ + ‖g‖ :=
   (f + g).op_norm_le_bound (add_nonneg f.op_norm_nonneg g.op_norm_nonneg) fun x =>
     (norm_add_le_of_le (f.le_op_norm x) (g.le_op_norm x)).trans_eq (add_mul _ _ _).symm
 #align continuous_linear_map.op_norm_add_le ContinuousLinearMap.op_norm_add_le
 
+set_option synthInstance.etaExperiment true in
 /-- The norm of the `0` operator is `0`. -/
 theorem op_norm_zero : ‖(0 : E →SL[σ₁₂] F)‖ = 0 :=
-  le_antisymm
-    (csInf_le bounds_bddBelow
-      ⟨le_rfl, fun _ =>
-        le_of_eq
-          (by
-            rw [MulZeroClass.zero_mul]
-            exact norm_zero)⟩)
-    (op_norm_nonneg _)
+  le_antisymm (csInf_le bounds_bddBelow ⟨le_rfl, fun _ => le_of_eq (by
+    rw [MulZeroClass.zero_mul]
+    exact norm_zero)⟩) (op_norm_nonneg _)
 #align continuous_linear_map.op_norm_zero ContinuousLinearMap.op_norm_zero
 
+set_option synthInstance.etaExperiment true in
 /-- The norm of the identity is at most `1`. It is in fact `1`, except when the space is trivial
 where it is `0`. It means that one can not do better than an inequality in general. -/
 theorem norm_id_le : ‖id 𝕜 E‖ ≤ 1 :=
   op_norm_le_bound _ zero_le_one fun x => by simp
 #align continuous_linear_map.norm_id_le ContinuousLinearMap.norm_id_le
 
+set_option synthInstance.etaExperiment true in
 /-- If there is an element with norm different from `0`, then the norm of the identity equals `1`.
 (Since we are working with seminorms supposing that the space is non-trivial is not enough.) -/
 theorem norm_id_of_nontrivial_seminorm (h : ∃ x : E, ‖x‖ ≠ 0) : ‖id 𝕜 E‖ = 1 :=
@@ -303,6 +325,7 @@ theorem norm_id_of_nontrivial_seminorm (h : ∃ x : E, ‖x‖ ≠ 0) : ‖id �
     rwa [id_apply, div_self hx] at this
 #align continuous_linear_map.norm_id_of_nontrivial_seminorm ContinuousLinearMap.norm_id_of_nontrivial_seminorm
 
+set_option synthInstance.etaExperiment true in
 theorem op_norm_smul_le {𝕜' : Type _} [NormedField 𝕜'] [NormedSpace 𝕜' F] [SMulCommClass 𝕜₂ 𝕜' F]
     (c : 𝕜') (f : E →SL[σ₁₂] F) : ‖c • f‖ ≤ ‖c‖ * ‖f‖ :=
   (c • f).op_norm_le_bound (mul_nonneg (norm_nonneg _) (op_norm_nonneg _)) fun _ => by
@@ -310,9 +333,10 @@ theorem op_norm_smul_le {𝕜' : Type _} [NormedField 𝕜'] [NormedSpace 𝕜' 
     exact mul_le_mul_of_nonneg_left (le_op_norm _ _) (norm_nonneg _)
 #align continuous_linear_map.op_norm_smul_le ContinuousLinearMap.op_norm_smul_le
 
+set_option synthInstance.etaExperiment true in
 /-- Continuous linear maps themselves form a seminormed space with respect to
 the operator norm. This is only a temporary definition because we want to replace the topology
-with `continuous_linear_map.topological_space` to avoid diamond issues.
+with `ContinuousLinearMap.topologicalSpace` to avoid diamond issues.
 See Note [forgetful inheritance] -/
 protected def tmpSeminormedAddCommGroup : SeminormedAddCommGroup (E →SL[σ₁₂] F) :=
   AddGroupSeminorm.toSeminormedAddCommGroup
@@ -322,22 +346,22 @@ protected def tmpSeminormedAddCommGroup : SeminormedAddCommGroup (E →SL[σ₁�
       neg' := op_norm_neg }
 #align continuous_linear_map.tmp_seminormed_add_comm_group ContinuousLinearMap.tmpSeminormedAddCommGroup
 
-/-- The `pseudo_metric_space` structure on `E →SL[σ₁₂] F` coming from
-`continuous_linear_map.tmp_seminormed_add_comm_group`.
+/-- The `PseudoMetricSpace` structure on `E →SL[σ₁₂] F` coming from
+`ContinuousLinearMap.tmpSeminormedAddCommGroup`.
 See Note [forgetful inheritance] -/
 protected def tmpPseudoMetricSpace : PseudoMetricSpace (E →SL[σ₁₂] F) :=
   ContinuousLinearMap.tmpSeminormedAddCommGroup.toPseudoMetricSpace
 #align continuous_linear_map.tmp_pseudo_metric_space ContinuousLinearMap.tmpPseudoMetricSpace
 
-/-- The `uniform_space` structure on `E →SL[σ₁₂] F` coming from
-`continuous_linear_map.tmp_seminormed_add_comm_group`.
+/-- The `UniformSpace` structure on `E →SL[σ₁₂] F` coming from
+`ContinuousLinearMap.tmpSeminormedAddCommGroup`.
 See Note [forgetful inheritance] -/
 protected def tmpUniformSpace : UniformSpace (E →SL[σ₁₂] F) :=
   ContinuousLinearMap.tmpPseudoMetricSpace.toUniformSpace
 #align continuous_linear_map.tmp_uniform_space ContinuousLinearMap.tmpUniformSpace
 
-/-- The `topological_space` structure on `E →SL[σ₁₂] F` coming from
-`continuous_linear_map.tmp_seminormed_add_comm_group`.
+/-- The `TopologicalSpace` structure on `E →SL[σ₁₂] F` coming from
+`ContinuousLinearMap.tmpSeminormedAddCommGroup`.
 See Note [forgetful inheritance] -/
 protected def tmpTopologicalSpace : TopologicalSpace (E →SL[σ₁₂] F) :=
   ContinuousLinearMap.tmpUniformSpace.toTopologicalSpace
@@ -351,10 +375,12 @@ attribute [-instance] ContinuousLinearMap.uniformSpace
 
 attribute [local instance] ContinuousLinearMap.tmpSeminormedAddCommGroup
 
+set_option synthInstance.etaExperiment true in
 protected theorem tmp_topologicalAddGroup : TopologicalAddGroup (E →SL[σ₁₂] F) :=
   inferInstance
 #align continuous_linear_map.tmp_topological_add_group ContinuousLinearMap.tmp_topologicalAddGroup
 
+set_option synthInstance.etaExperiment true in
 protected theorem tmp_closedBall_div_subset {a b : ℝ} (ha : 0 < a) (hb : 0 < b) :
     closedBall (0 : E →SL[σ₁₂] F) (a / b) ⊆
       { f | ∀ x ∈ closedBall (0 : E) b, f x ∈ closedBall (0 : F) a } := by
@@ -364,16 +390,16 @@ protected theorem tmp_closedBall_div_subset {a b : ℝ} (ha : 0 < a) (hb : 0 < b
     ‖f x‖ ≤ ‖f‖ * ‖x‖ := le_op_norm _ _
     _ ≤ a / b * b := (mul_le_mul hf hx (norm_nonneg _) (div_pos ha hb).le)
     _ = a := div_mul_cancel a hb.ne.symm
-    
 #align continuous_linear_map.tmp_closed_ball_div_subset ContinuousLinearMap.tmp_closedBall_div_subset
 
 end Tmp
 
+set_option synthInstance.etaExperiment true in
 protected theorem tmp_topology_eq :
     (ContinuousLinearMap.tmpTopologicalSpace : TopologicalSpace (E →SL[σ₁₂] F)) =
       ContinuousLinearMap.topologicalSpace := by
   refine'
-    continuous_linear_map.tmp_topological_add_group.ext inferInstance
+    ContinuousLinearMap.tmpTopologicalAddGroup.ext inferInstance
       ((@Metric.nhds_basis_closedBall _ ContinuousLinearMap.tmpPseudoMetricSpace 0).ext
         (ContinuousLinearMap.hasBasis_nhds_zero_of_basis Metric.nhds_basis_closedBall) _ _)
   · rcases NormedField.exists_norm_lt_one 𝕜 with ⟨c, hc₀, hc₁⟩
@@ -394,6 +420,7 @@ protected theorem tmp_topology_eq :
         (ContinuousLinearMap.tmp_closedBall_div_subset hε hδ).trans fun f hf x hx => hf x <| hSδ hx⟩
 #align continuous_linear_map.tmp_topology_eq ContinuousLinearMap.tmp_topology_eq
 
+set_option synthInstance.etaExperiment true in
 protected theorem tmpUniformSpace_eq :
     (ContinuousLinearMap.tmpUniformSpace : UniformSpace (E →SL[σ₁₂] F)) =
       ContinuousLinearMap.uniformSpace := by
@@ -414,6 +441,7 @@ instance toSeminormedAddCommGroup : SeminormedAddCommGroup (E →SL[σ₁₂] F)
     where dist_eq := ContinuousLinearMap.tmpSeminormedAddCommGroup.dist_eq
 #align continuous_linear_map.to_seminormed_add_comm_group ContinuousLinearMap.toSeminormedAddCommGroup
 
+set_option synthInstance.etaExperiment true in
 theorem nnnorm_def (f : E →SL[σ₁₂] F) : ‖f‖₊ = sInf { c | ∀ x, ‖f x‖₊ ≤ c * ‖x‖₊ } := by
   ext
   rw [NNReal.coe_sInf, coe_nnnorm, norm_def, NNReal.coe_image]
@@ -421,11 +449,13 @@ theorem nnnorm_def (f : E →SL[σ₁₂] F) : ‖f‖₊ = sInf { c | ∀ x, �
     exists_prop]
 #align continuous_linear_map.nnnorm_def ContinuousLinearMap.nnnorm_def
 
+set_option synthInstance.etaExperiment true in
 /-- If one controls the norm of every `A x`, then one controls the norm of `A`. -/
 theorem op_nnnorm_le_bound (f : E →SL[σ₁₂] F) (M : ℝ≥0) (hM : ∀ x, ‖f x‖₊ ≤ M * ‖x‖₊) : ‖f‖₊ ≤ M :=
   op_norm_le_bound f (zero_le M) hM
 #align continuous_linear_map.op_nnnorm_le_bound ContinuousLinearMap.op_nnnorm_le_bound
 
+set_option synthInstance.etaExperiment true in
 /-- If one controls the norm of every `A x`, `‖x‖₊ ≠ 0`, then one controls the norm of `A`. -/
 theorem op_nnnorm_le_bound' (f : E →SL[σ₁₂] F) (M : ℝ≥0) (hM : ∀ x, ‖x‖₊ ≠ 0 → ‖f x‖₊ ≤ M * ‖x‖₊) :
     ‖f‖₊ ≤ M :=
@@ -439,11 +469,13 @@ theorem op_nnnorm_le_of_unit_nnnorm [NormedSpace ℝ E] [NormedSpace ℝ F] {f :
   op_norm_le_of_unit_norm C.coe_nonneg fun x hx => hf x <| by rwa [← NNReal.coe_eq_one]
 #align continuous_linear_map.op_nnnorm_le_of_unit_nnnorm ContinuousLinearMap.op_nnnorm_le_of_unit_nnnorm
 
+set_option synthInstance.etaExperiment true in
 theorem op_nnnorm_le_of_lipschitz {f : E →SL[σ₁₂] F} {K : ℝ≥0} (hf : LipschitzWith K f) :
     ‖f‖₊ ≤ K :=
   op_norm_le_of_lipschitz hf
 #align continuous_linear_map.op_nnnorm_le_of_lipschitz ContinuousLinearMap.op_nnnorm_le_of_lipschitz
 
+set_option synthInstance.etaExperiment true in
 theorem op_nnnorm_eq_of_bounds {φ : E →SL[σ₁₂] F} (M : ℝ≥0) (h_above : ∀ x, ‖φ x‖ ≤ M * ‖x‖)
     (h_below : ∀ N, (∀ x, ‖φ x‖₊ ≤ N * ‖x‖₊) → M ≤ N) : ‖φ‖₊ = M :=
   Subtype.ext <| op_norm_eq_of_bounds (zero_le M) h_above <| Subtype.forall'.mpr h_below
@@ -454,8 +486,7 @@ instance toNormedSpace {𝕜' : Type _} [NormedField 𝕜'] [NormedSpace 𝕜' F
   ⟨op_norm_smul_le⟩
 #align continuous_linear_map.to_normed_space ContinuousLinearMap.toNormedSpace
 
-include σ₁₃
-
+set_option synthInstance.etaExperiment true in
 /-- The operator norm is submultiplicative. -/
 theorem op_norm_comp_le (f : E →SL[σ₁₂] F) : ‖h.comp f‖ ≤ ‖h‖ * ‖f‖ :=
   csInf_le bounds_bddBelow
@@ -464,11 +495,10 @@ theorem op_norm_comp_le (f : E →SL[σ₁₂] F) : ‖h.comp f‖ ≤ ‖h‖ *
       exact h.le_op_norm_of_le (f.le_op_norm x)⟩
 #align continuous_linear_map.op_norm_comp_le ContinuousLinearMap.op_norm_comp_le
 
+set_option synthInstance.etaExperiment true in
 theorem op_nnnorm_comp_le [RingHomIsometric σ₁₃] (f : E →SL[σ₁₂] F) : ‖h.comp f‖₊ ≤ ‖h‖₊ * ‖f‖₊ :=
   op_norm_comp_le h f
 #align continuous_linear_map.op_nnnorm_comp_le ContinuousLinearMap.op_nnnorm_comp_le
-
-omit σ₁₃
 
 /-- Continuous linear maps form a seminormed ring with respect to the operator norm. -/
 instance toSemiNormedRing : SeminormedRing (E →L[𝕜] E) :=
@@ -482,19 +512,23 @@ instance toNormedAlgebra : NormedAlgebra 𝕜 (E →L[𝕜] E) :=
   { ContinuousLinearMap.toNormedSpace, ContinuousLinearMap.algebra with }
 #align continuous_linear_map.to_normed_algebra ContinuousLinearMap.toNormedAlgebra
 
+set_option synthInstance.etaExperiment true in
 theorem le_op_nnnorm : ‖f x‖₊ ≤ ‖f‖₊ * ‖x‖₊ :=
   f.le_op_norm x
 #align continuous_linear_map.le_op_nnnorm ContinuousLinearMap.le_op_nnnorm
 
+set_option synthInstance.etaExperiment true in
 theorem nndist_le_op_nnnorm (x y : E) : nndist (f x) (f y) ≤ ‖f‖₊ * nndist x y :=
   dist_le_op_norm f x y
 #align continuous_linear_map.nndist_le_op_nnnorm ContinuousLinearMap.nndist_le_op_nnnorm
 
+set_option synthInstance.etaExperiment true in
 /-- continuous linear maps are Lipschitz continuous. -/
 theorem lipschitz : LipschitzWith ‖f‖₊ f :=
   AddMonoidHomClass.lipschitz_of_bound_nnnorm f _ f.le_op_nnnorm
 #align continuous_linear_map.lipschitz ContinuousLinearMap.lipschitz
 
+set_option synthInstance.etaExperiment true in
 /-- Evaluation of a continuous linear map `f` at a point is Lipschitz continuous in `f`. -/
 theorem lipschitz_apply (x : E) : LipschitzWith ‖x‖₊ fun f : E →SL[σ₁₂] F => f x :=
   lipschitzWith_iff_norm_sub_le.2 fun f g => ((f - g).le_op_norm x).trans_eq (mul_comm _ _)
@@ -506,6 +540,7 @@ section Sup
 
 variable [RingHomIsometric σ₁₂]
 
+set_option synthInstance.etaExperiment true in
 theorem exists_mul_lt_apply_of_lt_op_nnnorm (f : E →SL[σ₁₂] F) {r : ℝ≥0} (hr : r < ‖f‖₊) :
     ∃ x, r * ‖x‖₊ < ‖f x‖₊ := by
   simpa only [not_forall, not_le, Set.mem_setOf] using
@@ -513,12 +548,14 @@ theorem exists_mul_lt_apply_of_lt_op_nnnorm (f : E →SL[σ₁₂] F) {r : ℝ�
       (OrderBot.bddBelow _)
 #align continuous_linear_map.exists_mul_lt_apply_of_lt_op_nnnorm ContinuousLinearMap.exists_mul_lt_apply_of_lt_op_nnnorm
 
+set_option synthInstance.etaExperiment true in
 theorem exists_mul_lt_of_lt_op_norm (f : E →SL[σ₁₂] F) {r : ℝ} (hr₀ : 0 ≤ r) (hr : r < ‖f‖) :
     ∃ x, r * ‖x‖ < ‖f x‖ := by
   lift r to ℝ≥0 using hr₀
   exact f.exists_mul_lt_apply_of_lt_op_nnnorm hr
 #align continuous_linear_map.exists_mul_lt_of_lt_op_norm ContinuousLinearMap.exists_mul_lt_of_lt_op_norm
 
+set_option synthInstance.etaExperiment true in
 theorem exists_lt_apply_of_lt_op_nnnorm {𝕜 𝕜₂ E F : Type _} [NormedAddCommGroup E]
     [SeminormedAddCommGroup F] [DenselyNormedField 𝕜] [NontriviallyNormedField 𝕜₂] {σ₁₂ : 𝕜 →+* 𝕜₂}
     [NormedSpace 𝕜 E] [NormedSpace 𝕜₂ F] [RingHomIsometric σ₁₂] (f : E →SL[σ₁₂] F) {r : ℝ≥0}
@@ -526,7 +563,7 @@ theorem exists_lt_apply_of_lt_op_nnnorm {𝕜 𝕜₂ E F : Type _} [NormedAddCo
   obtain ⟨y, hy⟩ := f.exists_mul_lt_apply_of_lt_op_nnnorm hr
   have hy' : ‖y‖₊ ≠ 0 :=
     nnnorm_ne_zero_iff.2 fun heq => by
-      simpa only [HEq, nnnorm_zero, map_zero, not_lt_zero'] using hy
+      simp [heq, nnnorm_zero, map_zero, not_lt_zero'] at hy
   have hfy : ‖f y‖₊ ≠ 0 := (zero_le'.trans_lt hy).ne'
   rw [← inv_inv ‖f y‖₊, NNReal.lt_inv_iff_mul_lt (inv_ne_zero hfy), mul_assoc, mul_comm ‖y‖₊, ←
     mul_assoc, ← NNReal.lt_inv_iff_mul_lt hy'] at hy
@@ -536,6 +573,7 @@ theorem exists_lt_apply_of_lt_op_nnnorm {𝕜 𝕜₂ E F : Type _} [NormedAddCo
   rwa [map_smulₛₗ f, nnnorm_smul, ← NNReal.div_lt_iff hfy, div_eq_mul_inv, this]
 #align continuous_linear_map.exists_lt_apply_of_lt_op_nnnorm ContinuousLinearMap.exists_lt_apply_of_lt_op_nnnorm
 
+set_option synthInstance.etaExperiment true in
 theorem exists_lt_apply_of_lt_op_norm {𝕜 𝕜₂ E F : Type _} [NormedAddCommGroup E]
     [SeminormedAddCommGroup F] [DenselyNormedField 𝕜] [NontriviallyNormedField 𝕜₂] {σ₁₂ : 𝕜 →+* 𝕜₂}
     [NormedSpace 𝕜 E] [NormedSpace 𝕜₂ F] [RingHomIsometric σ₁₂] (f : E →SL[σ₁₂] F) {r : ℝ}
@@ -546,6 +584,7 @@ theorem exists_lt_apply_of_lt_op_norm {𝕜 𝕜₂ E F : Type _} [NormedAddComm
     exact f.exists_lt_apply_of_lt_op_nnnorm hr
 #align continuous_linear_map.exists_lt_apply_of_lt_op_norm ContinuousLinearMap.exists_lt_apply_of_lt_op_norm
 
+set_option synthInstance.etaExperiment true in
 theorem sSup_unit_ball_eq_nnnorm {𝕜 𝕜₂ E F : Type _} [NormedAddCommGroup E]
     [SeminormedAddCommGroup F] [DenselyNormedField 𝕜] [NontriviallyNormedField 𝕜₂] {σ₁₂ : 𝕜 →+* 𝕜₂}
     [NormedSpace 𝕜 E] [NormedSpace 𝕜₂ F] [RingHomIsometric σ₁₂] (f : E →SL[σ₁₂] F) :
@@ -559,6 +598,7 @@ theorem sSup_unit_ball_eq_nnnorm {𝕜 𝕜₂ E F : Type _} [NormedAddCommGroup
     exact ⟨_, ⟨x, mem_ball_zero_iff.2 hx, rfl⟩, hxf⟩
 #align continuous_linear_map.Sup_unit_ball_eq_nnnorm ContinuousLinearMap.sSup_unit_ball_eq_nnnorm
 
+set_option synthInstance.etaExperiment true in
 theorem sSup_unit_ball_eq_norm {𝕜 𝕜₂ E F : Type _} [NormedAddCommGroup E] [SeminormedAddCommGroup F]
     [DenselyNormedField 𝕜] [NontriviallyNormedField 𝕜₂] {σ₁₂ : 𝕜 →+* 𝕜₂} [NormedSpace 𝕜 E]
     [NormedSpace 𝕜₂ F] [RingHomIsometric σ₁₂] (f : E →SL[σ₁₂] F) :
@@ -566,6 +606,7 @@ theorem sSup_unit_ball_eq_norm {𝕜 𝕜₂ E F : Type _} [NormedAddCommGroup E
   simpa only [NNReal.coe_sSup, Set.image_image] using NNReal.coe_eq.2 f.Sup_unit_ball_eq_nnnorm
 #align continuous_linear_map.Sup_unit_ball_eq_norm ContinuousLinearMap.sSup_unit_ball_eq_norm
 
+set_option synthInstance.etaExperiment true in
 theorem sSup_closed_unit_ball_eq_nnnorm {𝕜 𝕜₂ E F : Type _} [NormedAddCommGroup E]
     [SeminormedAddCommGroup F] [DenselyNormedField 𝕜] [NontriviallyNormedField 𝕜₂] {σ₁₂ : 𝕜 →+* 𝕜₂}
     [NormedSpace 𝕜 E] [NormedSpace 𝕜₂ F] [RingHomIsometric σ₁₂] (f : E →SL[σ₁₂] F) :
@@ -580,6 +621,7 @@ theorem sSup_closed_unit_ball_eq_nnnorm {𝕜 𝕜₂ E F : Type _} [NormedAddCo
       (Set.image_subset _ ball_subset_closed_ball)
 #align continuous_linear_map.Sup_closed_unit_ball_eq_nnnorm ContinuousLinearMap.sSup_closed_unit_ball_eq_nnnorm
 
+set_option synthInstance.etaExperiment true in
 theorem sSup_closed_unit_ball_eq_norm {𝕜 𝕜₂ E F : Type _} [NormedAddCommGroup E]
     [SeminormedAddCommGroup F] [DenselyNormedField 𝕜] [NontriviallyNormedField 𝕜₂] {σ₁₂ : 𝕜 →+* 𝕜₂}
     [NormedSpace 𝕜 E] [NormedSpace 𝕜₂ F] [RingHomIsometric σ₁₂] (f : E →SL[σ₁₂] F) :
@@ -592,6 +634,7 @@ end Sup
 
 section
 
+set_option synthInstance.etaExperiment true in
 theorem op_norm_ext [RingHomIsometric σ₁₃] (f : E →SL[σ₁₂] F) (g : E →SL[σ₁₃] G)
     (h : ∀ x, ‖f x‖ = ‖g x‖) : ‖f‖ = ‖g‖ :=
   op_norm_eq_of_bounds (norm_nonneg _)
@@ -606,11 +649,13 @@ theorem op_norm_ext [RingHomIsometric σ₁₃] (f : E →SL[σ₁₂] F) (g : E
 
 variable [RingHomIsometric σ₂₃]
 
+set_option synthInstance.etaExperiment true in
 theorem op_norm_le_bound₂ (f : E →SL[σ₁₃] F →SL[σ₂₃] G) {C : ℝ} (h0 : 0 ≤ C)
     (hC : ∀ x y, ‖f x y‖ ≤ C * ‖x‖ * ‖y‖) : ‖f‖ ≤ C :=
   f.op_norm_le_bound h0 fun x => (f x).op_norm_le_bound (mul_nonneg h0 (norm_nonneg _)) <| hC x
 #align continuous_linear_map.op_norm_le_bound₂ ContinuousLinearMap.op_norm_le_bound₂
 
+set_option synthInstance.etaExperiment true in
 theorem le_op_norm₂ [RingHomIsometric σ₁₃] (f : E →SL[σ₁₃] F →SL[σ₂₃] G) (x : E) (y : F) :
     ‖f x y‖ ≤ ‖f‖ * ‖x‖ * ‖y‖ :=
   (f x).le_of_op_norm_le (f.le_op_norm x) y
@@ -618,25 +663,28 @@ theorem le_op_norm₂ [RingHomIsometric σ₁₃] (f : E →SL[σ₁₃] F →SL
 
 end
 
+set_option synthInstance.etaExperiment true in
 @[simp]
-theorem op_norm_prod (f : E →L[𝕜] Fₗ) (g : E →L[𝕜] Gₗ) : ‖f.Prod g‖ = ‖(f, g)‖ :=
+theorem op_norm_prod (f : E →L[𝕜] Fₗ) (g : E →L[𝕜] Gₗ) : ‖f.prod g‖ = ‖(f, g)‖ :=
   le_antisymm
       (op_norm_le_bound _ (norm_nonneg _) fun x => by
         simpa only [prod_apply, Prod.norm_def, max_mul_of_nonneg, norm_nonneg] using
           max_le_max (le_op_norm f x) (le_op_norm g x)) <|
     max_le
       (op_norm_le_bound _ (norm_nonneg _) fun x =>
-        (le_max_left _ _).trans ((f.Prod g).le_op_norm x))
+        (le_max_left _ _).trans ((f.prod g).le_op_norm x))
       (op_norm_le_bound _ (norm_nonneg _) fun x =>
-        (le_max_right _ _).trans ((f.Prod g).le_op_norm x))
+        (le_max_right _ _).trans ((f.prod g).le_op_norm x))
 #align continuous_linear_map.op_norm_prod ContinuousLinearMap.op_norm_prod
 
+set_option synthInstance.etaExperiment true in
 @[simp]
-theorem op_nnnorm_prod (f : E →L[𝕜] Fₗ) (g : E →L[𝕜] Gₗ) : ‖f.Prod g‖₊ = ‖(f, g)‖₊ :=
+theorem op_nnnorm_prod (f : E →L[𝕜] Fₗ) (g : E →L[𝕜] Gₗ) : ‖f.prod g‖₊ = ‖(f, g)‖₊ :=
   Subtype.ext <| op_norm_prod f g
 #align continuous_linear_map.op_nnnorm_prod ContinuousLinearMap.op_nnnorm_prod
 
-/-- `continuous_linear_map.prod` as a `linear_isometry_equiv`. -/
+set_option synthInstance.etaExperiment true in
+/-- `ContinuousLinearMap.prod` as a `LinearIsometryEquiv`. -/
 def prodₗᵢ (R : Type _) [Semiring R] [Module R Fₗ] [Module R Gₗ] [ContinuousConstSMul R Fₗ]
     [ContinuousConstSMul R Gₗ] [SMulCommClass 𝕜 R Fₗ] [SMulCommClass 𝕜 R Gₗ] :
     (E →L[𝕜] Fₗ) × (E →L[𝕜] Gₗ) ≃ₗᵢ[R] E →L[𝕜] Fₗ × Gₗ :=
@@ -661,32 +709,44 @@ variable [RingHomIsometric σ₁₂] (c : 𝕜) (f g : E →SL[σ₁₂] F) (h :
 
 open Asymptotics
 
+set_option synthInstance.etaExperiment true in
 theorem isBigOWith_id (l : Filter E) : IsBigOWith ‖f‖ l f fun x => x :=
   isBigOWith_of_le' _ f.le_op_norm
+set_option linter.uppercaseLean3 false in
 #align continuous_linear_map.is_O_with_id ContinuousLinearMap.isBigOWith_id
 
+set_option synthInstance.etaExperiment true in
 theorem isBigO_id (l : Filter E) : f =O[l] fun x => x :=
-  (f.isBigOWith_id l).IsBigO
+  (f.isBigOWith_id l).isBigO
+set_option linter.uppercaseLean3 false in
 #align continuous_linear_map.is_O_id ContinuousLinearMap.isBigO_id
 
+set_option synthInstance.etaExperiment true in
 theorem isBigOWith_comp [RingHomIsometric σ₂₃] {α : Type _} (g : F →SL[σ₂₃] G) (f : α → F)
     (l : Filter α) : IsBigOWith ‖g‖ l (fun x' => g (f x')) f :=
   (g.isBigOWith_id ⊤).comp_tendsto le_top
+set_option linter.uppercaseLean3 false in
 #align continuous_linear_map.is_O_with_comp ContinuousLinearMap.isBigOWith_comp
 
+set_option synthInstance.etaExperiment true in
 theorem isBigO_comp [RingHomIsometric σ₂₃] {α : Type _} (g : F →SL[σ₂₃] G) (f : α → F)
     (l : Filter α) : (fun x' => g (f x')) =O[l] f :=
-  (g.isBigOWith_comp f l).IsBigO
+  (g.isBigOWith_comp f l).isBigO
+set_option linter.uppercaseLean3 false in
 #align continuous_linear_map.is_O_comp ContinuousLinearMap.isBigO_comp
 
+set_option synthInstance.etaExperiment true in
 theorem isBigOWith_sub (f : E →SL[σ₁₂] F) (l : Filter E) (x : E) :
     IsBigOWith ‖f‖ l (fun x' => f (x' - x)) fun x' => x' - x :=
   f.isBigOWith_comp _ l
+set_option linter.uppercaseLean3 false in
 #align continuous_linear_map.is_O_with_sub ContinuousLinearMap.isBigOWith_sub
 
+set_option synthInstance.etaExperiment true in
 theorem isBigO_sub (f : E →SL[σ₁₂] F) (l : Filter E) (x : E) :
     (fun x' => f (x' - x)) =O[l] fun x' => x' - x :=
   f.isBigO_comp _ l
+set_option linter.uppercaseLean3 false in
 #align continuous_linear_map.is_O_sub ContinuousLinearMap.isBigO_sub
 
 end IsO
@@ -703,14 +763,16 @@ end LinearIsometry
 
 namespace LinearMap
 
-/-- If a continuous linear map is constructed from a linear map via the constructor `mk_continuous`,
+set_option synthInstance.etaExperiment true in
+/-- If a continuous linear map is constructed from a linear map via the constructor `mkContinuous`,
 then its norm is bounded by the bound given to the constructor if it is nonnegative. -/
 theorem mkContinuous_norm_le (f : E →ₛₗ[σ₁₂] F) {C : ℝ} (hC : 0 ≤ C) (h : ∀ x, ‖f x‖ ≤ C * ‖x‖) :
     ‖f.mkContinuous C h‖ ≤ C :=
   ContinuousLinearMap.op_norm_le_bound _ hC h
 #align linear_map.mk_continuous_norm_le LinearMap.mkContinuous_norm_le
 
-/-- If a continuous linear map is constructed from a linear map via the constructor `mk_continuous`,
+set_option synthInstance.etaExperiment true in
+/-- If a continuous linear map is constructed from a linear map via the constructor `mkContinuous`,
 then its norm is bounded by the bound or zero if bound is negative. -/
 theorem mkContinuous_norm_le' (f : E →ₛₗ[σ₁₂] F) {C : ℝ} (h : ∀ x, ‖f x‖ ≤ C * ‖x‖) :
     ‖f.mkContinuous C h‖ ≤ max C 0 :=
@@ -720,9 +782,10 @@ theorem mkContinuous_norm_le' (f : E →ₛₗ[σ₁₂] F) {C : ℝ} (h : ∀ x
 
 variable [RingHomIsometric σ₂₃]
 
+set_option synthInstance.etaExperiment true in
 /-- Create a bilinear map (represented as a map `E →L[𝕜] F →L[𝕜] G`) from the corresponding linear
 map and a bound on the norm of the image. The linear map can be constructed using
-`linear_map.mk₂`. -/
+`LinearMap.mk₂`. -/
 def mkContinuous₂ (f : E →ₛₗ[σ₁₃] F →ₛₗ[σ₂₃] G) (C : ℝ) (hC : ∀ x y, ‖f x y‖ ≤ C * ‖x‖ * ‖y‖) :
     E →SL[σ₁₃] F →SL[σ₂₃] G :=
   LinearMap.mkContinuous
@@ -740,17 +803,20 @@ def mkContinuous₂ (f : E →ₛₗ[σ₁₃] F →ₛₗ[σ₂₃] G) (C : ℝ
       rw [max_mul_of_nonneg _ _ (norm_nonneg x), MulZeroClass.zero_mul]
 #align linear_map.mk_continuous₂ LinearMap.mkContinuous₂
 
+set_option synthInstance.etaExperiment true in
 @[simp]
 theorem mkContinuous₂_apply (f : E →ₛₗ[σ₁₃] F →ₛₗ[σ₂₃] G) {C : ℝ}
     (hC : ∀ x y, ‖f x y‖ ≤ C * ‖x‖ * ‖y‖) (x : E) (y : F) : f.mkContinuous₂ C hC x y = f x y :=
   rfl
 #align linear_map.mk_continuous₂_apply LinearMap.mkContinuous₂_apply
 
+set_option synthInstance.etaExperiment true in
 theorem mkContinuous₂_norm_le' (f : E →ₛₗ[σ₁₃] F →ₛₗ[σ₂₃] G) {C : ℝ}
     (hC : ∀ x y, ‖f x y‖ ≤ C * ‖x‖ * ‖y‖) : ‖f.mkContinuous₂ C hC‖ ≤ max C 0 :=
   mkContinuous_norm_le _ (le_max_iff.2 <| Or.inr le_rfl) _
 #align linear_map.mk_continuous₂_norm_le' LinearMap.mkContinuous₂_norm_le'
 
+set_option synthInstance.etaExperiment true in
 theorem mkContinuous₂_norm_le (f : E →ₛₗ[σ₁₃] F →ₛₗ[σ₂₃] G) {C : ℝ} (h0 : 0 ≤ C)
     (hC : ∀ x y, ‖f x y‖ ≤ C * ‖x‖ * ‖y‖) : ‖f.mkContinuous₂ C hC‖ ≤ C :=
   (f.mkContinuous₂_norm_le' hC).trans_eq <| max_eq_left h0
@@ -762,9 +828,10 @@ namespace ContinuousLinearMap
 
 variable [RingHomIsometric σ₂₃] [RingHomIsometric σ₁₃]
 
+set_option synthInstance.etaExperiment true in
 /-- Flip the order of arguments of a continuous bilinear map.
-For a version bundled as `linear_isometry_equiv`, see
-`continuous_linear_map.flipL`. -/
+For a version bundled as `LinearIsometryEquiv`, see
+`ContinuousLinearMap.flipL`. -/
 def flip (f : E →SL[σ₁₃] F →SL[σ₂₃] G) : F →SL[σ₂₃] E →SL[σ₁₃] G :=
   LinearMap.mkContinuous₂
     (LinearMap.mk₂'ₛₗ σ₂₃ σ₁₃ (fun y x => f x y) (fun x y z => (f z).map_add x y)
@@ -773,33 +840,39 @@ def flip (f : E →SL[σ₁₃] F →SL[σ₂₃] G) : F →SL[σ₂₃] E →SL
     ‖f‖ fun y x => (f.le_op_norm₂ x y).trans_eq <| by rw [mul_right_comm]
 #align continuous_linear_map.flip ContinuousLinearMap.flip
 
+set_option synthInstance.etaExperiment true in
 private theorem le_norm_flip (f : E →SL[σ₁₃] F →SL[σ₂₃] G) : ‖f‖ ≤ ‖flip f‖ :=
   f.op_norm_le_bound₂ (norm_nonneg _) fun x y => by
     rw [mul_right_comm]
     exact (flip f).le_op_norm₂ y x
 #align continuous_linear_map.le_norm_flip continuous_linear_map.le_norm_flip
 
+set_option synthInstance.etaExperiment true in
 @[simp]
 theorem flip_apply (f : E →SL[σ₁₃] F →SL[σ₂₃] G) (x : E) (y : F) : f.flip y x = f x y :=
   rfl
 #align continuous_linear_map.flip_apply ContinuousLinearMap.flip_apply
 
+set_option synthInstance.etaExperiment true in
 @[simp]
 theorem flip_flip (f : E →SL[σ₁₃] F →SL[σ₂₃] G) : f.flip.flip = f := by
   ext
   rfl
 #align continuous_linear_map.flip_flip ContinuousLinearMap.flip_flip
 
+set_option synthInstance.etaExperiment true in
 @[simp]
 theorem op_norm_flip (f : E →SL[σ₁₃] F →SL[σ₂₃] G) : ‖f.flip‖ = ‖f‖ :=
   le_antisymm (by simpa only [flip_flip] using le_norm_flip f.flip) (le_norm_flip f)
 #align continuous_linear_map.op_norm_flip ContinuousLinearMap.op_norm_flip
 
+set_option synthInstance.etaExperiment true in
 @[simp]
 theorem flip_add (f g : E →SL[σ₁₃] F →SL[σ₂₃] G) : (f + g).flip = f.flip + g.flip :=
   rfl
 #align continuous_linear_map.flip_add ContinuousLinearMap.flip_add
 
+set_option synthInstance.etaExperiment true in
 @[simp]
 theorem flip_smul (c : 𝕜₃) (f : E →SL[σ₁₃] F →SL[σ₂₃] G) : (c • f).flip = c • f.flip :=
   rfl
@@ -807,9 +880,10 @@ theorem flip_smul (c : 𝕜₃) (f : E →SL[σ₁₃] F →SL[σ₂₃] G) : (c
 
 variable (E F G σ₁₃ σ₂₃)
 
+set_option synthInstance.etaExperiment true in
 /-- Flip the order of arguments of a continuous bilinear map.
-This is a version bundled as a `linear_isometry_equiv`.
-For an unbundled version see `continuous_linear_map.flip`. -/
+This is a version bundled as a `LinearIsometryEquiv`.
+For an unbundled version see `ContinuousLinearMap.flip`. -/
 def flipₗᵢ' : (E →SL[σ₁₃] F →SL[σ₂₃] G) ≃ₗᵢ[𝕜₃] F →SL[σ₂₃] E →SL[σ₁₃] G where
   toFun := flip
   invFun := flip
@@ -834,9 +908,10 @@ theorem coe_flipₗᵢ' : ⇑(flipₗᵢ' E F G σ₂₃ σ₁₃) = flip :=
 
 variable (𝕜 E Fₗ Gₗ)
 
+set_option synthInstance.etaExperiment true in
 /-- Flip the order of arguments of a continuous bilinear map.
-This is a version bundled as a `linear_isometry_equiv`.
-For an unbundled version see `continuous_linear_map.flip`. -/
+This is a version bundled as a `LinearIsometryEquiv`.
+For an unbundled version see `ContinuousLinearMap.flip`. -/
 def flipₗᵢ : (E →L[𝕜] Fₗ →L[𝕜] Gₗ) ≃ₗᵢ[𝕜] Fₗ →L[𝕜] E →L[𝕜] Gₗ where
   toFun := flip
   invFun := flip
@@ -861,16 +936,18 @@ theorem coe_flipₗᵢ : ⇑(flipₗᵢ 𝕜 E Fₗ Gₗ) = flip :=
 
 variable (F σ₁₂) [RingHomIsometric σ₁₂]
 
+set_option synthInstance.etaExperiment true in
 /-- The continuous semilinear map obtained by applying a continuous semilinear map at a given
 vector.
 
-This is the continuous version of `linear_map.applyₗ`. -/
+This is the continuous version of `LinearMap.applyₗ`. -/
 def apply' : E →SL[σ₁₂] (E →SL[σ₁₂] F) →L[𝕜₂] F :=
   flip (id 𝕜₂ (E →SL[σ₁₂] F))
 #align continuous_linear_map.apply' ContinuousLinearMap.apply'
 
 variable {F σ₁₂}
 
+set_option synthInstance.etaExperiment true in
 @[simp]
 theorem apply_apply' (v : E) (f : E →SL[σ₁₂] F) : apply' F σ₁₂ v f = f v :=
   rfl
@@ -878,16 +955,18 @@ theorem apply_apply' (v : E) (f : E →SL[σ₁₂] F) : apply' F σ₁₂ v f =
 
 variable (𝕜 Fₗ)
 
+set_option synthInstance.etaExperiment true in
 /-- The continuous semilinear map obtained by applying a continuous semilinear map at a given
 vector.
 
-This is the continuous version of `linear_map.applyₗ`. -/
+This is the continuous version of `LinearMap.applyₗ`. -/
 def apply : E →L[𝕜] (E →L[𝕜] Fₗ) →L[𝕜] Fₗ :=
   flip (id 𝕜 (E →L[𝕜] Fₗ))
 #align continuous_linear_map.apply ContinuousLinearMap.apply
 
 variable {𝕜 Fₗ}
 
+set_option synthInstance.etaExperiment true in
 @[simp]
 theorem apply_apply (v : E) (f : E →L[𝕜] Fₗ) : apply 𝕜 Fₗ v f = f v :=
   rfl
@@ -895,6 +974,7 @@ theorem apply_apply (v : E) (f : E →L[𝕜] Fₗ) : apply 𝕜 Fₗ v f = f v 
 
 variable (σ₁₂ σ₂₃ E F G)
 
+set_option synthInstance.etaExperiment true in
 /-- Composition of continuous semilinear maps as a continuous semibilinear map. -/
 def compSL : (F →SL[σ₂₃] G) →L[𝕜₃] (E →SL[σ₁₂] F) →SL[σ₂₃] E →SL[σ₁₃] G :=
   LinearMap.mkContinuous₂
@@ -905,47 +985,49 @@ def compSL : (F →SL[σ₂₃] G) →L[𝕜₃] (E →SL[σ₁₂] F) →SL[σ�
     1 fun f g => by simpa only [one_mul] using op_norm_comp_le f g
 #align continuous_linear_map.compSL ContinuousLinearMap.compSL
 
-include σ₁₃
-
+set_option synthInstance.etaExperiment true in
 theorem norm_compSL_le : ‖compSL E F G σ₁₂ σ₂₃‖ ≤ 1 :=
   LinearMap.mkContinuous₂_norm_le _ zero_le_one _
 #align continuous_linear_map.norm_compSL_le ContinuousLinearMap.norm_compSL_le
 
-variable {𝕜 σ₁₂ σ₂₃ E F G}
+variable {σ₁₂ σ₂₃ E F G}
 
+set_option synthInstance.etaExperiment true in
 @[simp]
 theorem compSL_apply (f : F →SL[σ₂₃] G) (g : E →SL[σ₁₂] F) : compSL E F G σ₁₂ σ₂₃ f g = f.comp g :=
   rfl
 #align continuous_linear_map.compSL_apply ContinuousLinearMap.compSL_apply
 
+set_option synthInstance.etaExperiment true in
 theorem Continuous.const_clm_comp {X} [TopologicalSpace X] {f : X → E →SL[σ₁₂] F}
     (hf : Continuous f) (g : F →SL[σ₂₃] G) :
     Continuous (fun x => g.comp (f x) : X → E →SL[σ₁₃] G) :=
   (compSL E F G σ₁₂ σ₂₃ g).Continuous.comp hf
 #align continuous.const_clm_comp Continuous.const_clm_comp
 
+set_option synthInstance.etaExperiment true in
 -- Giving the implicit argument speeds up elaboration significantly
 theorem Continuous.clm_comp_const {X} [TopologicalSpace X] {g : X → F →SL[σ₂₃] G}
     (hg : Continuous g) (f : E →SL[σ₁₂] F) :
     Continuous (fun x => (g x).comp f : X → E →SL[σ₁₃] G) :=
   (@ContinuousLinearMap.flip _ _ _ _ _ (E →SL[σ₁₃] G) _ _ _ _ _ _ _ _ _ _ _ _ _
-          (compSL E F G σ₁₂ σ₂₃) f).Continuous.comp
-    hg
+    (compSL E F G σ₁₂ σ₂₃) f).Continuous.comp hg
 #align continuous.clm_comp_const Continuous.clm_comp_const
-
-omit σ₁₃
 
 variable (𝕜 σ₁₂ σ₂₃ E Fₗ Gₗ)
 
+set_option synthInstance.etaExperiment true in
 /-- Composition of continuous linear maps as a continuous bilinear map. -/
 def compL : (Fₗ →L[𝕜] Gₗ) →L[𝕜] (E →L[𝕜] Fₗ) →L[𝕜] E →L[𝕜] Gₗ :=
   compSL E Fₗ Gₗ (RingHom.id 𝕜) (RingHom.id 𝕜)
 #align continuous_linear_map.compL ContinuousLinearMap.compL
 
+set_option synthInstance.etaExperiment true in
 theorem norm_compL_le : ‖compL 𝕜 E Fₗ Gₗ‖ ≤ 1 :=
   norm_compSL_le _ _ _ _ _
 #align continuous_linear_map.norm_compL_le ContinuousLinearMap.norm_compL_le
 
+set_option synthInstance.etaExperiment true in
 @[simp]
 theorem compL_apply (f : Fₗ →L[𝕜] Gₗ) (g : E →L[𝕜] Fₗ) : compL 𝕜 E Fₗ Gₗ f g = f.comp g :=
   rfl
@@ -953,25 +1035,28 @@ theorem compL_apply (f : Fₗ →L[𝕜] Gₗ) (g : E →L[𝕜] Fₗ) : compL �
 
 variable (Eₗ) {𝕜 E Fₗ Gₗ}
 
+set_option synthInstance.etaExperiment true in
 /-- Apply `L(x,-)` pointwise to bilinear maps, as a continuous bilinear map -/
 @[simps apply]
 def precompR (L : E →L[𝕜] Fₗ →L[𝕜] Gₗ) : E →L[𝕜] (Eₗ →L[𝕜] Fₗ) →L[𝕜] Eₗ →L[𝕜] Gₗ :=
   (compL 𝕜 Eₗ Fₗ Gₗ).comp L
 #align continuous_linear_map.precompR ContinuousLinearMap.precompR
 
+set_option synthInstance.etaExperiment true in
 /-- Apply `L(-,y)` pointwise to bilinear maps, as a continuous bilinear map -/
 def precompL (L : E →L[𝕜] Fₗ →L[𝕜] Gₗ) : (Eₗ →L[𝕜] E) →L[𝕜] Fₗ →L[𝕜] Eₗ →L[𝕜] Gₗ :=
   (precompR Eₗ (flip L)).flip
 #align continuous_linear_map.precompL ContinuousLinearMap.precompL
 
+set_option synthInstance.etaExperiment true in
 theorem norm_precompR_le (L : E →L[𝕜] Fₗ →L[𝕜] Gₗ) : ‖precompR Eₗ L‖ ≤ ‖L‖ :=
   calc
     ‖precompR Eₗ L‖ ≤ ‖compL 𝕜 Eₗ Fₗ Gₗ‖ * ‖L‖ := op_norm_comp_le _ _
     _ ≤ 1 * ‖L‖ := (mul_le_mul_of_nonneg_right (norm_compL_le _ _ _ _) (norm_nonneg _))
     _ = ‖L‖ := by rw [one_mul]
-    
 #align continuous_linear_map.norm_precompR_le ContinuousLinearMap.norm_precompR_le
 
+set_option synthInstance.etaExperiment true in
 theorem norm_precompL_le (L : E →L[𝕜] Fₗ →L[𝕜] Gₗ) : ‖precompL Eₗ L‖ ≤ ‖L‖ := by
   rw [precompL, op_norm_flip, ← op_norm_flip L]
   exact norm_precompR_le _ L.flip
@@ -987,7 +1072,8 @@ variable (M₁ : Type u₁) [SeminormedAddCommGroup M₁] [NormedSpace 𝕜 M₁
 
 variable {Eₗ} (𝕜)
 
-/-- `continuous_linear_map.prod_map` as a continuous linear map. -/
+set_option synthInstance.etaExperiment true in
+/-- `ContinuousLinearMap.prodMap` as a continuous linear map. -/
 def prodMapL : (M₁ →L[𝕜] M₂) × (M₃ →L[𝕜] M₄) →L[𝕜] M₁ × M₃ →L[𝕜] M₂ × M₄ :=
   ContinuousLinearMap.copy
     (have Φ₁ : (M₁ →L[𝕜] M₂) →L[𝕜] M₁ →L[𝕜] M₂ × M₄ :=
@@ -1003,7 +1089,7 @@ def prodMapL : (M₁ →L[𝕜] M₂) × (M₃ →L[𝕜] M₄) →L[𝕜] M₁ 
     have Ψ₂ : (M₁ →L[𝕜] M₂) × (M₃ →L[𝕜] M₄) →L[𝕜] M₃ →L[𝕜] M₄ :=
       ContinuousLinearMap.snd 𝕜 (M₁ →L[𝕜] M₂) (M₃ →L[𝕜] M₄)
     Φ₁' ∘L Φ₁ ∘L Ψ₁ + Φ₂' ∘L Φ₂ ∘L Ψ₂)
-    (fun p : (M₁ →L[𝕜] M₂) × (M₃ →L[𝕜] M₄) => p.1.Prod_map p.2)
+    (fun p : (M₁ →L[𝕜] M₂) × (M₃ →L[𝕜] M₄) => p.1.prod_map p.2)
     (by
       apply funext
       rintro ⟨φ, ψ⟩
@@ -1016,36 +1102,41 @@ def prodMapL : (M₁ →L[𝕜] M₂) × (M₃ →L[𝕜] M₄) →L[𝕜] M₁ 
 
 variable {M₁ M₂ M₃ M₄}
 
+set_option synthInstance.etaExperiment true in
 @[simp]
 theorem prodMapL_apply (p : (M₁ →L[𝕜] M₂) × (M₃ →L[𝕜] M₄)) :
-    ContinuousLinearMap.prodMapL 𝕜 M₁ M₂ M₃ M₄ p = p.1.Prod_map p.2 :=
+    ContinuousLinearMap.prodMapL 𝕜 M₁ M₂ M₃ M₄ p = p.1.prodMap p.2 :=
   rfl
 #align continuous_linear_map.prod_mapL_apply ContinuousLinearMap.prodMapL_apply
 
 variable {X : Type _} [TopologicalSpace X]
 
+set_option synthInstance.etaExperiment true in
 theorem Continuous.prod_mapL {f : X → M₁ →L[𝕜] M₂} {g : X → M₃ →L[𝕜] M₄} (hf : Continuous f)
-    (hg : Continuous g) : Continuous fun x => (f x).Prod_map (g x) :=
-  (prodMapL 𝕜 M₁ M₂ M₃ M₄).Continuous.comp (hf.prod_mk hg)
+    (hg : Continuous g) : Continuous fun x => (f x).prodMap (g x) :=
+  (prodMapL 𝕜 M₁ M₂ M₃ M₄).continuous.comp (hf.prod_mk hg)
 #align continuous.prod_mapL Continuous.prod_mapL
 
+set_option synthInstance.etaExperiment true in
 theorem Continuous.prod_map_equivL {f : X → M₁ ≃L[𝕜] M₂} {g : X → M₃ ≃L[𝕜] M₄}
     (hf : Continuous fun x => (f x : M₁ →L[𝕜] M₂)) (hg : Continuous fun x => (g x : M₃ →L[𝕜] M₄)) :
-    Continuous fun x => ((f x).Prod (g x) : M₁ × M₃ →L[𝕜] M₂ × M₄) :=
-  (prodMapL 𝕜 M₁ M₂ M₃ M₄).Continuous.comp (hf.prod_mk hg)
+    Continuous fun x => ((f x).prod (g x) : M₁ × M₃ →L[𝕜] M₂ × M₄) :=
+  (prodMapL 𝕜 M₁ M₂ M₃ M₄).continuous.comp (hf.prod_mk hg)
 #align continuous.prod_map_equivL Continuous.prod_map_equivL
 
+set_option synthInstance.etaExperiment true in
 theorem ContinuousOn.prod_mapL {f : X → M₁ →L[𝕜] M₂} {g : X → M₃ →L[𝕜] M₄} {s : Set X}
     (hf : ContinuousOn f s) (hg : ContinuousOn g s) :
-    ContinuousOn (fun x => (f x).Prod_map (g x)) s :=
-  ((prodMapL 𝕜 M₁ M₂ M₃ M₄).Continuous.comp_continuousOn (hf.Prod hg) : _)
+    ContinuousOn (fun x => (f x).prodMap (g x)) s :=
+  ((prodMapL 𝕜 M₁ M₂ M₃ M₄).continuous.comp_continuousOn (hf.prod hg) : _)
 #align continuous_on.prod_mapL ContinuousOn.prod_mapL
 
+set_option synthInstance.etaExperiment true in
 theorem ContinuousOn.prod_map_equivL {f : X → M₁ ≃L[𝕜] M₂} {g : X → M₃ ≃L[𝕜] M₄} {s : Set X}
     (hf : ContinuousOn (fun x => (f x : M₁ →L[𝕜] M₂)) s)
     (hg : ContinuousOn (fun x => (g x : M₃ →L[𝕜] M₄)) s) :
-    ContinuousOn (fun x => ((f x).Prod (g x) : M₁ × M₃ →L[𝕜] M₂ × M₄)) s :=
-  (prodMapL 𝕜 M₁ M₂ M₃ M₄).Continuous.comp_continuousOn (hf.Prod hg)
+    ContinuousOn (fun x => ((f x).prod (g x) : M₁ × M₃ →L[𝕜] M₂ × M₄)) s :=
+  (prodMapL 𝕜 M₁ M₂ M₃ M₄).continuous.comp_continuousOn (hf.Prod hg)
 #align continuous_on.prod_map_equivL ContinuousOn.prod_map_equivL
 
 end Prod
@@ -1056,16 +1147,10 @@ section MultiplicationLinear
 
 section NonUnital
 
-variable (𝕜) (𝕜' : Type _) [NonUnitalSeminormedRing 𝕜'] [NormedSpace 𝕜 𝕜'] [IsScalarTower 𝕜 𝕜' 𝕜']
-  [SMulCommClass 𝕜 𝕜' 𝕜']
+variable (𝕜) (𝕜' : Type _) [NonUnitalSeminormedRing 𝕜']
 
-/- warning: continuous_linear_map.mul clashes with continuous_linear_map.has_mul -> ContinuousLinearMap.mul
-warning: continuous_linear_map.mul -> ContinuousLinearMap.mul is a dubious translation:
-lean 3 declaration is
-  forall (𝕜 : Type.{u1}) [_inst_7 : NontriviallyNormedField.{u1} 𝕜] (𝕜' : Type.{u2}) [_inst_20 : NonUnitalSeminormedRing.{u2} 𝕜'] [_inst_21 : NormedSpace.{u1, u2} 𝕜 𝕜' (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7) (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20)] [_inst_22 : IsScalarTower.{u1, u2, u2} 𝕜 𝕜' 𝕜' (SMulZeroClass.toHasSmul.{u1, u2} 𝕜 𝕜' (AddZeroClass.toHasZero.{u2} 𝕜' (AddMonoid.toAddZeroClass.{u2} 𝕜' (AddCommMonoid.toAddMonoid.{u2} 𝕜' (AddCommGroup.toAddCommMonoid.{u2} 𝕜' (SeminormedAddCommGroup.toAddCommGroup.{u2} 𝕜' (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20)))))) (SMulWithZero.toSmulZeroClass.{u1, u2} 𝕜 𝕜' (MulZeroClass.toHasZero.{u1} 𝕜 (MulZeroOneClass.toMulZeroClass.{u1} 𝕜 (MonoidWithZero.toMulZeroOneClass.{u1} 𝕜 (Semiring.toMonoidWithZero.{u1} 𝕜 (Ring.toSemiring.{u1} 𝕜 (NormedRing.toRing.{u1} 𝕜 (NormedCommRing.toNormedRing.{u1} 𝕜 (NormedField.toNormedCommRing.{u1} 𝕜 (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7))))))))) (AddZeroClass.toHasZero.{u2} 𝕜' (AddMonoid.toAddZeroClass.{u2} 𝕜' (AddCommMonoid.toAddMonoid.{u2} 𝕜' (AddCommGroup.toAddCommMonoid.{u2} 𝕜' (SeminormedAddCommGroup.toAddCommGroup.{u2} 𝕜' (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20)))))) (MulActionWithZero.toSMulWithZero.{u1, u2} 𝕜 𝕜' (Semiring.toMonoidWithZero.{u1} 𝕜 (Ring.toSemiring.{u1} 𝕜 (NormedRing.toRing.{u1} 𝕜 (NormedCommRing.toNormedRing.{u1} 𝕜 (NormedField.toNormedCommRing.{u1} 𝕜 (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7)))))) (AddZeroClass.toHasZero.{u2} 𝕜' (AddMonoid.toAddZeroClass.{u2} 𝕜' (AddCommMonoid.toAddMonoid.{u2} 𝕜' (AddCommGroup.toAddCommMonoid.{u2} 𝕜' (SeminormedAddCommGroup.toAddCommGroup.{u2} 𝕜' (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20)))))) (Module.toMulActionWithZero.{u1, u2} 𝕜 𝕜' (Ring.toSemiring.{u1} 𝕜 (NormedRing.toRing.{u1} 𝕜 (NormedCommRing.toNormedRing.{u1} 𝕜 (NormedField.toNormedCommRing.{u1} 𝕜 (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7))))) (AddCommGroup.toAddCommMonoid.{u2} 𝕜' (SeminormedAddCommGroup.toAddCommGroup.{u2} 𝕜' (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20))) (NormedSpace.toModule.{u1, u2} 𝕜 𝕜' (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7) (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20) _inst_21))))) (Mul.toSMul.{u2} 𝕜' (Distrib.toHasMul.{u2} 𝕜' (NonUnitalNonAssocSemiring.toDistrib.{u2} 𝕜' (NonUnitalNonAssocRing.toNonUnitalNonAssocSemiring.{u2} 𝕜' (NonUnitalRing.toNonUnitalNonAssocRing.{u2} 𝕜' (NonUnitalSeminormedRing.toNonUnitalRing.{u2} 𝕜' _inst_20)))))) (SMulZeroClass.toHasSmul.{u1, u2} 𝕜 𝕜' (AddZeroClass.toHasZero.{u2} 𝕜' (AddMonoid.toAddZeroClass.{u2} 𝕜' (AddCommMonoid.toAddMonoid.{u2} 𝕜' (AddCommGroup.toAddCommMonoid.{u2} 𝕜' (SeminormedAddCommGroup.toAddCommGroup.{u2} 𝕜' (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20)))))) (SMulWithZero.toSmulZeroClass.{u1, u2} 𝕜 𝕜' (MulZeroClass.toHasZero.{u1} 𝕜 (MulZeroOneClass.toMulZeroClass.{u1} 𝕜 (MonoidWithZero.toMulZeroOneClass.{u1} 𝕜 (Semiring.toMonoidWithZero.{u1} 𝕜 (Ring.toSemiring.{u1} 𝕜 (NormedRing.toRing.{u1} 𝕜 (NormedCommRing.toNormedRing.{u1} 𝕜 (NormedField.toNormedCommRing.{u1} 𝕜 (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7))))))))) (AddZeroClass.toHasZero.{u2} 𝕜' (AddMonoid.toAddZeroClass.{u2} 𝕜' (AddCommMonoid.toAddMonoid.{u2} 𝕜' (AddCommGroup.toAddCommMonoid.{u2} 𝕜' (SeminormedAddCommGroup.toAddCommGroup.{u2} 𝕜' (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20)))))) (MulActionWithZero.toSMulWithZero.{u1, u2} 𝕜 𝕜' (Semiring.toMonoidWithZero.{u1} 𝕜 (Ring.toSemiring.{u1} 𝕜 (NormedRing.toRing.{u1} 𝕜 (NormedCommRing.toNormedRing.{u1} 𝕜 (NormedField.toNormedCommRing.{u1} 𝕜 (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7)))))) (AddZeroClass.toHasZero.{u2} 𝕜' (AddMonoid.toAddZeroClass.{u2} 𝕜' (AddCommMonoid.toAddMonoid.{u2} 𝕜' (AddCommGroup.toAddCommMonoid.{u2} 𝕜' (SeminormedAddCommGroup.toAddCommGroup.{u2} 𝕜' (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20)))))) (Module.toMulActionWithZero.{u1, u2} 𝕜 𝕜' (Ring.toSemiring.{u1} 𝕜 (NormedRing.toRing.{u1} 𝕜 (NormedCommRing.toNormedRing.{u1} 𝕜 (NormedField.toNormedCommRing.{u1} 𝕜 (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7))))) (AddCommGroup.toAddCommMonoid.{u2} 𝕜' (SeminormedAddCommGroup.toAddCommGroup.{u2} 𝕜' (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20))) (NormedSpace.toModule.{u1, u2} 𝕜 𝕜' (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7) (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20) _inst_21)))))] [_inst_23 : SMulCommClass.{u1, u2, u2} 𝕜 𝕜' 𝕜' (SMulZeroClass.toHasSmul.{u1, u2} 𝕜 𝕜' (AddZeroClass.toHasZero.{u2} 𝕜' (AddMonoid.toAddZeroClass.{u2} 𝕜' (AddCommMonoid.toAddMonoid.{u2} 𝕜' (AddCommGroup.toAddCommMonoid.{u2} 𝕜' (SeminormedAddCommGroup.toAddCommGroup.{u2} 𝕜' (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20)))))) (SMulWithZero.toSmulZeroClass.{u1, u2} 𝕜 𝕜' (MulZeroClass.toHasZero.{u1} 𝕜 (MulZeroOneClass.toMulZeroClass.{u1} 𝕜 (MonoidWithZero.toMulZeroOneClass.{u1} 𝕜 (Semiring.toMonoidWithZero.{u1} 𝕜 (Ring.toSemiring.{u1} 𝕜 (NormedRing.toRing.{u1} 𝕜 (NormedCommRing.toNormedRing.{u1} 𝕜 (NormedField.toNormedCommRing.{u1} 𝕜 (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7))))))))) (AddZeroClass.toHasZero.{u2} 𝕜' (AddMonoid.toAddZeroClass.{u2} 𝕜' (AddCommMonoid.toAddMonoid.{u2} 𝕜' (AddCommGroup.toAddCommMonoid.{u2} 𝕜' (SeminormedAddCommGroup.toAddCommGroup.{u2} 𝕜' (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20)))))) (MulActionWithZero.toSMulWithZero.{u1, u2} 𝕜 𝕜' (Semiring.toMonoidWithZero.{u1} 𝕜 (Ring.toSemiring.{u1} 𝕜 (NormedRing.toRing.{u1} 𝕜 (NormedCommRing.toNormedRing.{u1} 𝕜 (NormedField.toNormedCommRing.{u1} 𝕜 (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7)))))) (AddZeroClass.toHasZero.{u2} 𝕜' (AddMonoid.toAddZeroClass.{u2} 𝕜' (AddCommMonoid.toAddMonoid.{u2} 𝕜' (AddCommGroup.toAddCommMonoid.{u2} 𝕜' (SeminormedAddCommGroup.toAddCommGroup.{u2} 𝕜' (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20)))))) (Module.toMulActionWithZero.{u1, u2} 𝕜 𝕜' (Ring.toSemiring.{u1} 𝕜 (NormedRing.toRing.{u1} 𝕜 (NormedCommRing.toNormedRing.{u1} 𝕜 (NormedField.toNormedCommRing.{u1} 𝕜 (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7))))) (AddCommGroup.toAddCommMonoid.{u2} 𝕜' (SeminormedAddCommGroup.toAddCommGroup.{u2} 𝕜' (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20))) (NormedSpace.toModule.{u1, u2} 𝕜 𝕜' (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7) (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20) _inst_21))))) (Mul.toSMul.{u2} 𝕜' (Distrib.toHasMul.{u2} 𝕜' (NonUnitalNonAssocSemiring.toDistrib.{u2} 𝕜' (NonUnitalNonAssocRing.toNonUnitalNonAssocSemiring.{u2} 𝕜' (NonUnitalRing.toNonUnitalNonAssocRing.{u2} 𝕜' (NonUnitalSeminormedRing.toNonUnitalRing.{u2} 𝕜' _inst_20))))))], ContinuousLinearMap.{u1, u1, u2, u2} 𝕜 𝕜 (Ring.toSemiring.{u1} 𝕜 (NormedRing.toRing.{u1} 𝕜 (NormedCommRing.toNormedRing.{u1} 𝕜 (NormedField.toNormedCommRing.{u1} 𝕜 (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7))))) (Ring.toSemiring.{u1} 𝕜 (NormedRing.toRing.{u1} 𝕜 (NormedCommRing.toNormedRing.{u1} 𝕜 (NormedField.toNormedCommRing.{u1} 𝕜 (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7))))) (RingHom.id.{u1} 𝕜 (Semiring.toNonAssocSemiring.{u1} 𝕜 (Ring.toSemiring.{u1} 𝕜 (NormedRing.toRing.{u1} 𝕜 (NormedCommRing.toNormedRing.{u1} 𝕜 (NormedField.toNormedCommRing.{u1} 𝕜 (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7))))))) 𝕜' (UniformSpace.toTopologicalSpace.{u2} 𝕜' (PseudoMetricSpace.toUniformSpace.{u2} 𝕜' (NonUnitalSeminormedRing.toPseudoMetricSpace.{u2} 𝕜' _inst_20))) (AddCommGroup.toAddCommMonoid.{u2} 𝕜' (SeminormedAddCommGroup.toAddCommGroup.{u2} 𝕜' (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20))) (ContinuousLinearMap.{u1, u1, u2, u2} 𝕜 𝕜 (Ring.toSemiring.{u1} 𝕜 (NormedRing.toRing.{u1} 𝕜 (NormedCommRing.toNormedRing.{u1} 𝕜 (NormedField.toNormedCommRing.{u1} 𝕜 (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7))))) (Ring.toSemiring.{u1} 𝕜 (NormedRing.toRing.{u1} 𝕜 (NormedCommRing.toNormedRing.{u1} 𝕜 (NormedField.toNormedCommRing.{u1} 𝕜 (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7))))) (RingHom.id.{u1} 𝕜 (Semiring.toNonAssocSemiring.{u1} 𝕜 (Ring.toSemiring.{u1} 𝕜 (NormedRing.toRing.{u1} 𝕜 (NormedCommRing.toNormedRing.{u1} 𝕜 (NormedField.toNormedCommRing.{u1} 𝕜 (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7))))))) 𝕜' (UniformSpace.toTopologicalSpace.{u2} 𝕜' (PseudoMetricSpace.toUniformSpace.{u2} 𝕜' (NonUnitalSeminormedRing.toPseudoMetricSpace.{u2} 𝕜' _inst_20))) (AddCommGroup.toAddCommMonoid.{u2} 𝕜' (SeminormedAddCommGroup.toAddCommGroup.{u2} 𝕜' (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20))) 𝕜' (UniformSpace.toTopologicalSpace.{u2} 𝕜' (PseudoMetricSpace.toUniformSpace.{u2} 𝕜' (NonUnitalSeminormedRing.toPseudoMetricSpace.{u2} 𝕜' _inst_20))) (AddCommGroup.toAddCommMonoid.{u2} 𝕜' (SeminormedAddCommGroup.toAddCommGroup.{u2} 𝕜' (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20))) (NormedSpace.toModule.{u1, u2} 𝕜 𝕜' (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7) (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20) _inst_21) (NormedSpace.toModule.{u1, u2} 𝕜 𝕜' (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7) (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20) _inst_21)) (ContinuousLinearMap.topologicalSpace.{u1, u1, u2, u2} 𝕜 𝕜 (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7) (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7) (RingHom.id.{u1} 𝕜 (Semiring.toNonAssocSemiring.{u1} 𝕜 (Ring.toSemiring.{u1} 𝕜 (NormedRing.toRing.{u1} 𝕜 (NormedCommRing.toNormedRing.{u1} 𝕜 (NormedField.toNormedCommRing.{u1} 𝕜 (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7))))))) 𝕜' 𝕜' (SeminormedAddCommGroup.toAddCommGroup.{u2} 𝕜' (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20)) (NormedSpace.toModule.{u1, u2} 𝕜 𝕜' (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7) (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20) _inst_21) (SeminormedAddCommGroup.toAddCommGroup.{u2} 𝕜' (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20)) (NormedSpace.toModule.{u1, u2} 𝕜 𝕜' (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7) (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20) _inst_21) (UniformSpace.toTopologicalSpace.{u2} 𝕜' (PseudoMetricSpace.toUniformSpace.{u2} 𝕜' (NonUnitalSeminormedRing.toPseudoMetricSpace.{u2} 𝕜' _inst_20))) (UniformSpace.toTopologicalSpace.{u2} 𝕜' (PseudoMetricSpace.toUniformSpace.{u2} 𝕜' (NonUnitalSeminormedRing.toPseudoMetricSpace.{u2} 𝕜' _inst_20))) (ContinuousLinearMap.Mul._proof_1.{u2} 𝕜' _inst_20)) (ContinuousLinearMap.addCommMonoid.{u1, u1, u2, u2} 𝕜 𝕜 (Ring.toSemiring.{u1} 𝕜 (NormedRing.toRing.{u1} 𝕜 (NormedCommRing.toNormedRing.{u1} 𝕜 (NormedField.toNormedCommRing.{u1} 𝕜 (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7))))) (Ring.toSemiring.{u1} 𝕜 (NormedRing.toRing.{u1} 𝕜 (NormedCommRing.toNormedRing.{u1} 𝕜 (NormedField.toNormedCommRing.{u1} 𝕜 (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7))))) (RingHom.id.{u1} 𝕜 (Semiring.toNonAssocSemiring.{u1} 𝕜 (Ring.toSemiring.{u1} 𝕜 (NormedRing.toRing.{u1} 𝕜 (NormedCommRing.toNormedRing.{u1} 𝕜 (NormedField.toNormedCommRing.{u1} 𝕜 (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7))))))) 𝕜' (UniformSpace.toTopologicalSpace.{u2} 𝕜' (PseudoMetricSpace.toUniformSpace.{u2} 𝕜' (NonUnitalSeminormedRing.toPseudoMetricSpace.{u2} 𝕜' _inst_20))) (AddCommGroup.toAddCommMonoid.{u2} 𝕜' (SeminormedAddCommGroup.toAddCommGroup.{u2} 𝕜' (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20))) 𝕜' (UniformSpace.toTopologicalSpace.{u2} 𝕜' (PseudoMetricSpace.toUniformSpace.{u2} 𝕜' (NonUnitalSeminormedRing.toPseudoMetricSpace.{u2} 𝕜' _inst_20))) (AddCommGroup.toAddCommMonoid.{u2} 𝕜' (SeminormedAddCommGroup.toAddCommGroup.{u2} 𝕜' (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20))) (NormedSpace.toModule.{u1, u2} 𝕜 𝕜' (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7) (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20) _inst_21) (NormedSpace.toModule.{u1, u2} 𝕜 𝕜' (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7) (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20) _inst_21) (ContinuousLinearMap.Mul._proof_2.{u2} 𝕜' _inst_20)) (NormedSpace.toModule.{u1, u2} 𝕜 𝕜' (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7) (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20) _inst_21) (ContinuousLinearMap.module.{u1, u1, u1, u2, u2} 𝕜 𝕜 𝕜 (Ring.toSemiring.{u1} 𝕜 (NormedRing.toRing.{u1} 𝕜 (NormedCommRing.toNormedRing.{u1} 𝕜 (NormedField.toNormedCommRing.{u1} 𝕜 (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7))))) (Ring.toSemiring.{u1} 𝕜 (NormedRing.toRing.{u1} 𝕜 (NormedCommRing.toNormedRing.{u1} 𝕜 (NormedField.toNormedCommRing.{u1} 𝕜 (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7))))) (Ring.toSemiring.{u1} 𝕜 (NormedRing.toRing.{u1} 𝕜 (NormedCommRing.toNormedRing.{u1} 𝕜 (NormedField.toNormedCommRing.{u1} 𝕜 (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7))))) 𝕜' (UniformSpace.toTopologicalSpace.{u2} 𝕜' (PseudoMetricSpace.toUniformSpace.{u2} 𝕜' (NonUnitalSeminormedRing.toPseudoMetricSpace.{u2} 𝕜' _inst_20))) (AddCommGroup.toAddCommMonoid.{u2} 𝕜' (SeminormedAddCommGroup.toAddCommGroup.{u2} 𝕜' (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20))) (NormedSpace.toModule.{u1, u2} 𝕜 𝕜' (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7) (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20) _inst_21) 𝕜' (UniformSpace.toTopologicalSpace.{u2} 𝕜' (PseudoMetricSpace.toUniformSpace.{u2} 𝕜' (NonUnitalSeminormedRing.toPseudoMetricSpace.{u2} 𝕜' _inst_20))) (AddCommGroup.toAddCommMonoid.{u2} 𝕜' (SeminormedAddCommGroup.toAddCommGroup.{u2} 𝕜' (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20))) (NormedSpace.toModule.{u1, u2} 𝕜 𝕜' (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7) (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20) _inst_21) (NormedSpace.toModule.{u1, u2} 𝕜 𝕜' (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7) (NonUnitalSeminormedRing.toSeminormedAddCommGroup.{u2} 𝕜' _inst_20) _inst_21) (ContinuousLinearMap.Mul._proof_3.{u1, u2} 𝕜 _inst_7 𝕜' _inst_20 _inst_21) (ContinuousLinearMap.Mul._proof_4.{u1, u2} 𝕜 _inst_7 𝕜' _inst_20 _inst_21) (RingHom.id.{u1} 𝕜 (Semiring.toNonAssocSemiring.{u1} 𝕜 (Ring.toSemiring.{u1} 𝕜 (NormedRing.toRing.{u1} 𝕜 (NormedCommRing.toNormedRing.{u1} 𝕜 (NormedField.toNormedCommRing.{u1} 𝕜 (NontriviallyNormedField.toNormedField.{u1} 𝕜 _inst_7))))))) (ContinuousLinearMap.Mul._proof_5.{u2} 𝕜' _inst_20))
-but is expected to have type
-  forall {𝕜 : Type.{u1}} [_inst_7 : Semiring.{u1} 𝕜] {𝕜' : Type.{u2}} [_inst_20 : TopologicalSpace.{u2} 𝕜'] [_inst_21 : AddCommMonoid.{u2} 𝕜'] [_inst_22 : Module.{u1, u2} 𝕜 𝕜' _inst_7 _inst_21], Mul.{u2} (ContinuousLinearMap.{u1, u1, u2, u2} 𝕜 𝕜 _inst_7 _inst_7 (RingHom.id.{u1} 𝕜 (Semiring.toNonAssocSemiring.{u1} 𝕜 _inst_7)) 𝕜' _inst_20 _inst_21 𝕜' _inst_20 _inst_21 _inst_22 _inst_22)
-Case conversion may be inaccurate. Consider using '#align continuous_linear_map.mul ContinuousLinearMap.mulₓ'. -/
+variable [NormedSpace 𝕜 𝕜'] [IsScalarTower 𝕜 𝕜' 𝕜'] [SMulCommClass 𝕜 𝕜' 𝕜']
+
 /-- Multiplication in a non-unital normed algebra as a continuous bilinear map. -/
 def mul : 𝕜' →L[𝕜] 𝕜' →L[𝕜] 𝕜' :=
   (LinearMap.mul 𝕜 𝕜').mkContinuous₂ 1 fun x y => by simpa using norm_mul_le x y
@@ -1085,9 +1170,10 @@ theorem op_norm_mul_le : ‖mul 𝕜 𝕜'‖ ≤ 1 :=
   LinearMap.mkContinuous₂_norm_le _ zero_le_one _
 #align continuous_linear_map.op_norm_mul_le ContinuousLinearMap.op_norm_mul_le
 
+set_option synthInstance.etaExperiment true in
 /-- Simultaneous left- and right-multiplication in a non-unital normed algebra, considered as a
-continuous trilinear map. This is akin to its non-continuous version `linear_map.mul_left_right`,
-but there is a minor difference: `linear_map.mul_left_right` is uncurried. -/
+continuous trilinear map. This is akin to its non-continuous version `LinearMap.mulLeftRight`,
+but there is a minor difference: `LinearMap.mulLeftRight` is uncurried. -/
 def mulLeftRight : 𝕜' →L[𝕜] 𝕜' →L[𝕜] 𝕜' →L[𝕜] 𝕜' :=
   ((compL 𝕜 𝕜' 𝕜' 𝕜').comp (mul 𝕜 𝕜').flip).flip.comp (mul 𝕜 𝕜')
 #align continuous_linear_map.mul_left_right ContinuousLinearMap.mulLeftRight
@@ -1171,8 +1257,6 @@ theorem norm_toSpanSingleton (x : E) : ‖toSpanSingleton 𝕜 x‖ = ‖x‖ :=
     exact (mul_le_mul_right (by simp)).mp h
 #align continuous_linear_map.norm_to_span_singleton ContinuousLinearMap.norm_toSpanSingleton
 
-variable {𝕜}
-
 theorem op_norm_lsmul_apply_le (x : 𝕜') : ‖(lsmul 𝕜 𝕜' x : E →L[𝕜] E)‖ ≤ ‖x‖ :=
   ContinuousLinearMap.op_norm_le_bound _ (norm_nonneg x) fun y => norm_smul_le x y
 #align continuous_linear_map.op_norm_lsmul_apply_le ContinuousLinearMap.op_norm_lsmul_apply_le
@@ -1200,10 +1284,13 @@ theorem norm_restrictScalars (f : E →L[𝕜] Fₗ) : ‖f.restrictScalars 𝕜
     (op_norm_le_bound _ (norm_nonneg _) fun x => f.le_op_norm x)
 #align continuous_linear_map.norm_restrict_scalars ContinuousLinearMap.norm_restrictScalars
 
-variable (𝕜 E Fₗ 𝕜') (𝕜'' : Type _) [Ring 𝕜''] [Module 𝕜'' Fₗ] [ContinuousConstSMul 𝕜'' Fₗ]
+variable (𝕜 E Fₗ 𝕜') (𝕜'' : Type _) [Ring 𝕜'']
+
+variable [Module 𝕜'' Fₗ] [ContinuousConstSMul 𝕜'' Fₗ]
   [SMulCommClass 𝕜 𝕜'' Fₗ] [SMulCommClass 𝕜' 𝕜'' Fₗ]
 
-/-- `continuous_linear_map.restrict_scalars` as a `linear_isometry`. -/
+set_option synthInstance.etaExperiment true in
+/-- `ContinuousLinearMap.restrictScalars` as a `LinearIsometry`. -/
 def restrictScalarsIsometry : (E →L[𝕜] Fₗ) →ₗᵢ[𝕜''] E →L[𝕜'] Fₗ :=
   ⟨restrictScalarsₗ 𝕜 E Fₗ 𝕜' 𝕜'', norm_restrictScalars⟩
 #align continuous_linear_map.restrict_scalars_isometry ContinuousLinearMap.restrictScalarsIsometry
@@ -1224,23 +1311,27 @@ theorem restrictScalarsIsometry_toLinearMap :
 
 variable (𝕜 E Fₗ 𝕜' 𝕜'')
 
-/-- `continuous_linear_map.restrict_scalars` as a `continuous_linear_map`. -/
+/-- `ContinuousLinearMap.restrictScalars` as a `ContinuousLinearMap`. -/
 def restrictScalarsL : (E →L[𝕜] Fₗ) →L[𝕜''] E →L[𝕜'] Fₗ :=
   (restrictScalarsIsometry 𝕜 E Fₗ 𝕜' 𝕜'').toContinuousLinearMap
+set_option linter.uppercaseLean3 false in
 #align continuous_linear_map.restrict_scalarsL ContinuousLinearMap.restrictScalarsL
 
 variable {𝕜 E Fₗ 𝕜' 𝕜''}
 
+set_option synthInstance.etaExperiment true in
 @[simp]
 theorem coe_restrictScalarsL :
     (restrictScalarsL 𝕜 E Fₗ 𝕜' 𝕜'' : (E →L[𝕜] Fₗ) →ₗ[𝕜''] E →L[𝕜'] Fₗ) =
       restrictScalarsₗ 𝕜 E Fₗ 𝕜' 𝕜'' :=
   rfl
+set_option linter.uppercaseLean3 false in
 #align continuous_linear_map.coe_restrict_scalarsL ContinuousLinearMap.coe_restrictScalarsL
 
 @[simp]
 theorem coe_restrict_scalarsL' : ⇑(restrictScalarsL 𝕜 E Fₗ 𝕜' 𝕜'') = restrictScalars 𝕜' :=
   rfl
+set_option linter.uppercaseLean3 false in
 #align continuous_linear_map.coe_restrict_scalarsL' ContinuousLinearMap.coe_restrict_scalarsL'
 
 end RestrictScalars
@@ -1251,6 +1342,7 @@ namespace Submodule
 
 theorem norm_subtypeL_le (K : Submodule 𝕜 E) : ‖K.subtypeL‖ ≤ 1 :=
   K.subtypeₗᵢ.norm_toContinuousLinearMap_le
+set_option linter.uppercaseLean3 false in
 #align submodule.norm_subtypeL_le Submodule.norm_subtypeL_le
 
 end Submodule
@@ -1262,8 +1354,6 @@ section
 variable {σ₂₁ : 𝕜₂ →+* 𝕜} [RingHomInvPair σ₁₂ σ₂₁] [RingHomInvPair σ₂₁ σ₁₂] [RingHomIsometric σ₁₂]
 
 variable (e : E ≃SL[σ₁₂] F)
-
-include σ₂₁
 
 protected theorem lipschitz : LipschitzWith ‖(e : E →SL[σ₁₂] F)‖₊ e :=
   (e : E →SL[σ₁₂] F).lipschitz
@@ -1282,8 +1372,6 @@ end
 variable {σ₂₁ : 𝕜₂ →+* 𝕜} [RingHomInvPair σ₁₂ σ₂₁] [RingHomInvPair σ₂₁ σ₁₂]
 
 variable [RingHomIsometric σ₂₁] (e : E ≃SL[σ₁₂] F)
-
-include σ₂₁
 
 theorem isBigO_comp_rev {α : Type _} (f : α → E) (l : Filter α) : f =O[l] fun x' => e (f x') :=
   (e.symm.isBigO_comp _ l).congr_left fun _ => e.symm_apply_apply _
@@ -1313,30 +1401,29 @@ def bilinearComp (f : E →SL[σ₁₃] F →SL[σ₂₃] G) (gE : E' →SL[σ�
   ((f.comp gE).flip.comp gF).flip
 #align continuous_linear_map.bilinear_comp ContinuousLinearMap.bilinearComp
 
-include σ₁₃' σ₂₃'
-
 @[simp]
 theorem bilinearComp_apply (f : E →SL[σ₁₃] F →SL[σ₂₃] G) (gE : E' →SL[σ₁'] E) (gF : F' →SL[σ₂'] F)
     (x : E') (y : F') : f.bilinearComp gE gF x y = f (gE x) (gF y) :=
   rfl
 #align continuous_linear_map.bilinear_comp_apply ContinuousLinearMap.bilinearComp_apply
 
-omit σ₁₃' σ₂₃'
-
 variable [RingHomIsometric σ₁₃] [RingHomIsometric σ₁'] [RingHomIsometric σ₂']
 
+set_option synthInstance.etaExperiment true in
 /-- Derivative of a continuous bilinear map `f : E →L[𝕜] F →L[𝕜] G` interpreted as a map `E × F → G`
 at point `p : E × F` evaluated at `q : E × F`, as a continuous bilinear map. -/
 def deriv₂ (f : E →L[𝕜] Fₗ →L[𝕜] Gₗ) : E × Fₗ →L[𝕜] E × Fₗ →L[𝕜] Gₗ :=
   f.bilinearComp (fst _ _ _) (snd _ _ _) + f.flip.bilinearComp (snd _ _ _) (fst _ _ _)
 #align continuous_linear_map.deriv₂ ContinuousLinearMap.deriv₂
 
+set_option synthInstance.etaExperiment true in
 @[simp]
 theorem coe_deriv₂ (f : E →L[𝕜] Fₗ →L[𝕜] Gₗ) (p : E × Fₗ) :
     ⇑(f.deriv₂ p) = fun q : E × Fₗ => f p.1 q.2 + f q.1 p.2 :=
   rfl
 #align continuous_linear_map.coe_deriv₂ ContinuousLinearMap.coe_deriv₂
 
+set_option synthInstance.etaExperiment true in
 theorem map_add_add (f : E →L[𝕜] Fₗ →L[𝕜] Gₗ) (x x' : E) (y y' : Fₗ) :
     f (x + x') (y + y') = f x y + f.deriv₂ (x, y) (x', y') + f x' y' := by
   simp only [map_add, add_apply, coe_deriv₂, add_assoc]
@@ -1361,6 +1448,7 @@ variable [NontriviallyNormedField 𝕜] [NontriviallyNormedField 𝕜₂] [Nontr
 
 namespace LinearMap
 
+set_option synthInstance.etaExperiment true in
 theorem bound_of_shell [RingHomIsometric σ₁₂] (f : E →ₛₗ[σ₁₂] F) {ε C : ℝ} (ε_pos : 0 < ε) {c : 𝕜}
     (hc : 1 < ‖c‖) (hf : ∀ x, ε / ‖c‖ ≤ ‖x‖ → ‖x‖ < ε → ‖f x‖ ≤ C * ‖x‖) (x : E) :
     ‖f x‖ ≤ C * ‖x‖ := by
@@ -1369,7 +1457,8 @@ theorem bound_of_shell [RingHomIsometric σ₁₂] (f : E →ₛₗ[σ₁₂] F)
     SemilinearMapClass.bound_of_shell_semi_normed f ε_pos hc hf (ne_of_lt (norm_pos_iff.2 hx)).symm
 #align linear_map.bound_of_shell LinearMap.bound_of_shell
 
-/-- `linear_map.bound_of_ball_bound'` is a version of this lemma over a field satisfying `is_R_or_C`
+set_option synthInstance.etaExperiment true in
+/-- `LinearMap.bound_of_ball_bound'` is a version of this lemma over a field satisfying `IsROrC`
 that produces a concrete bound.
 -/
 theorem bound_of_ball_bound {r : ℝ} (r_pos : 0 < r) (c : ℝ) (f : E →ₗ[𝕜] Fₗ)
@@ -1382,12 +1471,12 @@ theorem bound_of_ball_bound {r : ℝ} (r_pos : 0 < r) (c : ℝ) (f : E →ₗ[�
     ‖f x‖ ≤ c := h _ (mem_ball_zero_iff.mpr hxo)
     _ ≤ c * (‖x‖ * ‖k‖ / r) := (le_mul_of_one_le_right _ _)
     _ = _ := by ring
-    
   · exact le_trans (norm_nonneg _) (h 0 (by simp [r_pos]))
   · rw [div_le_iff (zero_lt_one.trans hk)] at hko
     exact (one_le_div r_pos).mpr hko
 #align linear_map.bound_of_ball_bound LinearMap.bound_of_ball_bound
 
+set_option synthInstance.etaExperiment true in
 theorem antilipschitz_of_comap_nhds_le [h : RingHomIsometric σ₁₂] (f : E →ₛₗ[σ₁₂] F)
     (hf : (𝓝 0).comap f ≤ 𝓝 0) : ∃ K, AntilipschitzWith K f := by
   rcases((nhds_basis_ball.comap _).le_basis_iffₓ nhds_basis_ball).1 hf 1 one_pos with ⟨ε, ε0, hε⟩
@@ -1411,7 +1500,6 @@ theorem antilipschitz_of_comap_nhds_le [h : RingHomIsometric σ₁₂] (f : E �
       rwa [← norm_inv, ← norm_smul, inv_smul_smul₀ (zpow_ne_zero _ _)]
     _ ≤ ‖c ^ n‖⁻¹ * 1 := (mul_le_mul_of_nonneg_left (hε _ hlt).le (inv_nonneg.2 (norm_nonneg _)))
     _ ≤ ε⁻¹ * ‖c‖ * ‖f x‖ := by rwa [mul_one]
-    
 #align linear_map.antilipschitz_of_comap_nhds_le LinearMap.antilipschitz_of_comap_nhds_le
 
 end LinearMap
@@ -1430,13 +1518,13 @@ theorem op_norm_zero_iff [RingHomIsometric σ₁₂] : ‖f‖ = 0 ↔ f = 0 :=
         norm_le_zero_iff.1
           (calc
             _ ≤ ‖f‖ * ‖x‖ := le_op_norm _ _
-            _ = _ := by rw [hn, MulZeroClass.zero_mul]
-            ))
+            _ = _ := by rw [hn, MulZeroClass.zero_mul]))
     (by
       rintro rfl
       exact op_norm_zero)
 #align continuous_linear_map.op_norm_zero_iff ContinuousLinearMap.op_norm_zero_iff
 
+set_option synthInstance.etaExperiment true in
 /-- If a normed space is non-trivial, then the norm of the identity equals `1`. -/
 @[simp]
 theorem norm_id [Nontrivial E] : ‖id 𝕜 E‖ = 1 := by
@@ -1445,6 +1533,7 @@ theorem norm_id [Nontrivial E] : ‖id 𝕜 E‖ = 1 := by
   exact ⟨x, ne_of_gt (norm_pos_iff.2 hx)⟩
 #align continuous_linear_map.norm_id ContinuousLinearMap.norm_id
 
+set_option synthInstance.etaExperiment true in
 instance normOneClass [Nontrivial E] : NormOneClass (E →L[𝕜] E) :=
   ⟨norm_id⟩
 #align continuous_linear_map.norm_one_class ContinuousLinearMap.normOneClass
@@ -1462,6 +1551,7 @@ instance toNormedRing : NormedRing (E →L[𝕜] E) :=
 
 variable {f}
 
+set_option synthInstance.etaExperiment true in
 theorem homothety_norm [RingHomIsometric σ₁₂] [Nontrivial E] (f : E →SL[σ₁₂] F) {a : ℝ}
     (hf : ∀ x, ‖f x‖ = a * ‖x‖) : ‖f‖ = a := by
   obtain ⟨x, hx⟩ : ∃ x : E, x ≠ 0 := exists_ne 0
@@ -1473,6 +1563,7 @@ theorem homothety_norm [RingHomIsometric σ₁₂] [Nontrivial E] (f : E →SL[�
 
 variable (f)
 
+set_option synthInstance.etaExperiment true in
 /-- If a continuous linear map is a topology embedding, then it is expands the distances
 by a positive factor.-/
 theorem antilipschitz_of_embedding (f : E →L[𝕜] Fₗ) (hf : Embedding f) :
@@ -1491,10 +1582,10 @@ variable {E' : Type _} [SeminormedAddCommGroup E'] [NormedSpace 𝕜 E'] [RingHo
 /-- Construct a bundled continuous (semi)linear map from a map `f : E → F` and a proof of the fact
 that it belongs to the closure of the image of a bounded set `s : set (E →SL[σ₁₂] F)` under coercion
 to function. Coercion to function of the result is definitionally equal to `f`. -/
-@[simps (config := { fullyApplied := false }) apply]
+@[simps! (config := { fullyApplied := false }) apply]
 def ofMemClosureImageCoeBounded (f : E' → F) {s : Set (E' →SL[σ₁₂] F)} (hs : Bounded s)
     (hf : f ∈ closure ((coeFn : (E' →SL[σ₁₂] F) → E' → F) '' s)) : E' →SL[σ₁₂] F := by
-  -- `f` is a linear map due to `linear_map_of_mem_closure_range_coe`
+  -- `f` is a linear map due to `linearMapOfMemClosureRangeCoe`
   refine' (linearMapOfMemClosureRangeCoe f _).mkContinuousOfExistsBound _
   · refine' closure_mono (image_subset_iff.2 fun g hg => _) hf
     exact ⟨g, rfl⟩
@@ -1502,7 +1593,7 @@ def ofMemClosureImageCoeBounded (f : E' → F) {s : Set (E' →SL[σ₁₂] F)} 
     rcases bounded_iff_forall_norm_le.1 hs with ⟨C, hC⟩
     -- Then `‖g x‖ ≤ C * ‖x‖` for all `g ∈ s`, `x : E`, hence `‖f x‖ ≤ C * ‖x‖` for all `x`.
     have : ∀ x, IsClosed { g : E' → F | ‖g x‖ ≤ C * ‖x‖ } := fun x =>
-      is_closed_Iic.preimage (@continuous_apply E' (fun _ => F) _ x).norm
+      isClosed_Iic.preimage (@continuous_apply E' (fun _ => F) _ x).norm
     refine' ⟨C, fun x => (this x).closure_subset_iff.2 (image_subset_iff.2 fun g hg => _) hf⟩
     exact g.le_of_op_norm_le (hC _ hg) _
 #align continuous_linear_map.of_mem_closure_image_coe_bounded ContinuousLinearMap.ofMemClosureImageCoeBounded
@@ -1510,8 +1601,8 @@ def ofMemClosureImageCoeBounded (f : E' → F) {s : Set (E' →SL[σ₁₂] F)} 
 /-- Let `f : E → F` be a map, let `g : α → E →SL[σ₁₂] F` be a family of continuous (semi)linear maps
 that takes values in a bounded set and converges to `f` pointwise along a nontrivial filter. Then
 `f` is a continuous (semi)linear map. -/
-@[simps (config := { fullyApplied := false }) apply]
-def ofTendstoOfBoundedRange {α : Type _} {l : Filter α} [l.ne_bot] (f : E' → F)
+@[simps! (config := { fullyApplied := false }) apply]
+def ofTendstoOfBoundedRange {α : Type _} {l : Filter α} [l.NeBot] (f : E' → F)
     (g : α → E' →SL[σ₁₂] F) (hf : Tendsto (fun a x => g a x) l (𝓝 f)) (hg : Bounded (Set.range g)) :
     E' →SL[σ₁₂] F :=
   ofMemClosureImageCoeBounded f hg <|
@@ -1519,6 +1610,7 @@ def ofTendstoOfBoundedRange {α : Type _} {l : Filter α} [l.ne_bot] (f : E' →
       eventually_of_forall fun a => mem_image_of_mem _ <| Set.mem_range_self _
 #align continuous_linear_map.of_tendsto_of_bounded_range ContinuousLinearMap.ofTendstoOfBoundedRange
 
+set_option synthInstance.etaExperiment true in
 /-- If a Cauchy sequence of continuous linear map converges to a continuous linear map pointwise,
 then it converges to the same map in norm. This lemma is used to prove that the space of continuous
 linear maps is complete provided that the codomain is a complete space. -/
@@ -1554,11 +1646,11 @@ instance [CompleteSpace F] : CompleteSpace (E' →SL[σ₁₂] F) := by
   -- into a function which we call `G`.
   choose G hG using fun v => cauchySeq_tendsto_of_complete (cau v)
   -- Next, we show that this `G` is a continuous linear map.
-  -- This is done in `continuous_linear_map.of_tendsto_of_bounded_range`.
+  -- This is done in `ContinuousLinearMap.of_tendsto_of_bounded_range`.
   set Glin : E' →SL[σ₁₂] F :=
     of_tendsto_of_bounded_range _ _ (tendsto_pi_nhds.mpr hG) hf.bounded_range
   -- Finally, `f n` converges to `Glin` in norm because of
-  -- `continuous_linear_map.tendsto_of_tendsto_pointwise_of_cauchy_seq`
+  -- `ContinuousLinearMap.tendsto_of_tendsto_pointwise_of_cauchy_seq`
   exact ⟨Glin, tendsto_of_tendsto_pointwise_of_cauchy_seq (tendsto_pi_nhds.2 hG) hf⟩
 
 /-- Let `s` be a bounded set in the space of continuous (semi)linear maps `E →SL[σ] F` taking values
@@ -1583,9 +1675,10 @@ theorem isCompact_image_coe_of_bounded_of_closed_image [ProperSpace F] {s : Set 
   hc.closure_eq ▸ isCompact_closure_image_coe_of_bounded hb
 #align continuous_linear_map.is_compact_image_coe_of_bounded_of_closed_image ContinuousLinearMap.isCompact_image_coe_of_bounded_of_closed_image
 
+set_option synthInstance.etaExperiment true in
 /-- If a set `s` of semilinear functions is bounded and is closed in the weak-* topology, then its
 image under coercion to functions `E → F` is a closed set. We don't have a name for `E →SL[σ] F`
-with weak-* topology in `mathlib`, so we use an equivalent condition (see `is_closed_induced_iff'`).
+with weak-* topology in `mathlib`, so we use an equivalent condition (see `isClosed_induced_iff'`).
 
 TODO: reformulate this in terms of a type synonym with the right topology. -/
 theorem isClosed_image_coe_of_bounded_of_weak_closed {s : Set (E' →SL[σ₁₂] F)} (hb : Bounded s)
@@ -1595,9 +1688,10 @@ theorem isClosed_image_coe_of_bounded_of_weak_closed {s : Set (E' →SL[σ₁₂
     ⟨ofMemClosureImageCoeBounded f hb hf, hc (ofMemClosureImageCoeBounded f hb hf) hf, rfl⟩
 #align continuous_linear_map.is_closed_image_coe_of_bounded_of_weak_closed ContinuousLinearMap.isClosed_image_coe_of_bounded_of_weak_closed
 
+set_option synthInstance.etaExperiment true in
 /-- If a set `s` of semilinear functions is bounded and is closed in the weak-* topology, then its
 image under coercion to functions `E → F` is a compact set. We don't have a name for `E →SL[σ] F`
-with weak-* topology in `mathlib`, so we use an equivalent condition (see `is_closed_induced_iff'`).
+with weak-* topology in `mathlib`, so we use an equivalent condition (see `isClosed_induced_iff'`).
 -/
 theorem isCompact_image_coe_of_bounded_of_weak_closed [ProperSpace F] {s : Set (E' →SL[σ₁₂] F)}
     (hb : Bounded s)
@@ -1608,11 +1702,11 @@ theorem isCompact_image_coe_of_bounded_of_weak_closed [ProperSpace F] {s : Set (
 #align continuous_linear_map.is_compact_image_coe_of_bounded_of_weak_closed ContinuousLinearMap.isCompact_image_coe_of_bounded_of_weak_closed
 
 /-- A closed ball is closed in the weak-* topology. We don't have a name for `E →SL[σ] F` with
-weak-* topology in `mathlib`, so we use an equivalent condition (see `is_closed_induced_iff'`). -/
+weak-* topology in `mathlib`, so we use an equivalent condition (see `isClosed_induced_iff'`). -/
 theorem is_weak_closed_closedBall (f₀ : E' →SL[σ₁₂] F) (r : ℝ) ⦃f : E' →SL[σ₁₂] F⦄
     (hf : ⇑f ∈ closure ((coeFn : (E' →SL[σ₁₂] F) → E' → F) '' closedBall f₀ r)) :
     f ∈ closedBall f₀ r := by
-  have hr : 0 ≤ r := nonempty_closed_ball.1 (nonempty_image_iff.1 (closure_nonempty_iff.1 ⟨_, hf⟩))
+  have hr : 0 ≤ r := nonempty_closedBall.1 (nonempty_image_iff.1 (closure_nonempty_iff.1 ⟨_, hf⟩))
   refine' mem_closedBall_iff_norm.2 (op_norm_le_bound _ hr fun x => _)
   have : IsClosed { g : E' → F | ‖g x - f₀ x‖ ≤ r * ‖x‖ } :=
     is_closed_Iic.preimage ((@continuous_apply E' (fun _ => F) _ x).sub continuous_const).norm
@@ -1631,7 +1725,7 @@ theorem isClosed_image_coe_closedBall (f₀ : E →SL[σ₁₂] F) (r : ℝ) :
 /-- **Banach-Alaoglu** theorem. The set of functions `f : E → F` that represent continuous linear
 maps `f : E →SL[σ₁₂] F` at distance `≤ r` from `f₀ : E →SL[σ₁₂] F` is compact in the topology of
 pointwise convergence. Other versions of this theorem can be found in
-`analysis.normed_space.weak_dual`. -/
+`Analysis.NormedSpace.WeakDual`. -/
 theorem isCompact_image_coe_closedBall [ProperSpace F] (f₀ : E →SL[σ₁₂] F) (r : ℝ) :
     IsCompact ((coeFn : (E →SL[σ₁₂] F) → E → F) '' closedBall f₀ r) :=
   isCompact_image_coe_of_bounded_of_weak_closed bounded_closedBall <| is_weak_closed_closedBall f₀ r
@@ -1659,8 +1753,7 @@ def extend : Fₗ →SL[σ₁₂] F :=
   { toFun := (h_e.DenseInducing h_dense).extend f
     map_add' := by
       refine' h_dense.induction_on₂ _ _
-      ·
-        exact
+      · exact
           isClosed_eq (cont.comp continuous_add)
             ((cont.comp continuous_fst).add (cont.comp continuous_snd))
       · intro x y
@@ -1668,8 +1761,7 @@ def extend : Fₗ →SL[σ₁₂] F :=
         exact f.map_add _ _
     map_smul' := fun k => by
       refine' fun b => h_dense.induction_on b _ _
-      ·
-        exact
+      · exact
           isClosed_eq (cont.comp (continuous_const_smul _)) ((continuous_const_smul _).comp cont)
       · intro x
         rw [← map_smul]
@@ -1699,7 +1791,6 @@ section
 
 variable {N : ℝ≥0} (h_e : ∀ x, ‖x‖ ≤ N * ‖e x‖) [RingHomIsometric σ₁₂]
 
--- mathport name: exprψ
 local notation "ψ" => f.extend e h_dense (uniformEmbedding_of_bound _ h_e).to_uniformInducing
 
 /-- If a dense embedding `e : E →L[𝕜] G` expands the norm by a constant factor `N⁻¹`, then the
@@ -1718,7 +1809,6 @@ theorem op_norm_extend_le : ‖ψ‖ ≤ N * ‖f‖ := by
         ‖f x‖ ≤ ‖f‖ * ‖x‖ := le_op_norm _ _
         _ ≤ ‖f‖ * (N * ‖e x‖) := (mul_le_mul_of_nonneg_left (h_e x) (norm_nonneg _))
         _ ≤ N * ‖f‖ * ‖e x‖ := by rw [mul_comm ↑N ‖f‖, mul_assoc]
-        
   · have he : ∀ x : E, x = 0 := by
       intro x
       have N0 : N ≤ 0 := le_of_lt (lt_of_not_ge N0)
@@ -1751,17 +1841,14 @@ theorem norm_toContinuousLinearMap [Nontrivial E] [RingHomIsometric σ₁₂] (f
 
 variable {σ₁₃ : 𝕜 →+* 𝕜₃} [RingHomCompTriple σ₁₂ σ₂₃ σ₁₃]
 
-include σ₁₃
-
+set_option synthInstance.etaExperiment true in
 /-- Postcomposition of a continuous linear map with a linear isometry preserves
 the operator norm. -/
 theorem norm_toContinuousLinearMap_comp [RingHomIsometric σ₁₂] (f : F →ₛₗᵢ[σ₂₃] G)
     {g : E →SL[σ₁₂] F} : ‖f.toContinuousLinearMap.comp g‖ = ‖g‖ :=
   op_norm_ext (f.toContinuousLinearMap.comp g) g fun x => by
-    simp only [norm_map, coe_to_continuous_linear_map, coe_comp']
+    simp only [norm_map, coe_toContinuousLinearMap, coe_comp']
 #align linear_isometry.norm_to_continuous_linear_map_comp LinearIsometry.norm_toContinuousLinearMap_comp
-
-omit σ₁₃
 
 end LinearIsometry
 
@@ -1779,8 +1866,6 @@ variable {𝕜₂' : Type _} [NontriviallyNormedField 𝕜₂'] {F' : Type _} [N
   [RingHomCompTriple σ₂'' σ₂₃' σ₂₃] [RingHomIsometric σ₂₃] [RingHomIsometric σ₂']
   [RingHomIsometric σ₂''] [RingHomIsometric σ₂₃']
 
-include σ₂'' σ₂₃'
-
 /-- Precomposition with a linear isometry preserves the operator norm. -/
 theorem op_norm_comp_linearIsometryEquiv (f : F →SL[σ₂₃] G) (g : F' ≃ₛₗᵢ[σ₂'] F) :
     ‖f.comp g.toLinearIsometry.toContinuousLinearMap‖ = ‖f‖ := by
@@ -1788,17 +1873,15 @@ theorem op_norm_comp_linearIsometryEquiv (f : F →SL[σ₂₃] G) (g : F' ≃�
   · haveI := g.symm.to_linear_equiv.to_equiv.subsingleton
     simp
   refine' le_antisymm _ _
-  · convert f.op_norm_comp_le g.to_linear_isometry.to_continuous_linear_map
-    simp [g.to_linear_isometry.norm_to_continuous_linear_map]
-  · convert(f.comp g.to_linear_isometry.to_continuous_linear_map).op_norm_comp_le
-        g.symm.to_linear_isometry.to_continuous_linear_map
+  · convert f.op_norm_comp_le g.to_linear_isometry.toContinuousLinearMap
+    simp [g.to_linear_isometry.norm_toContinuousLinearMap]
+  · convert(f.comp g.to_linear_isometry.toContinuousLinearMap).op_norm_comp_le
+        g.symm.to_linear_isometry.toContinuousLinearMap
     · ext
       simp
     haveI := g.symm.surjective.nontrivial
-    simp [g.symm.to_linear_isometry.norm_to_continuous_linear_map]
+    simp [g.symm.toLinearIsometry.norm_toContinuousLinearMap]
 #align continuous_linear_map.op_norm_comp_linear_isometry_equiv ContinuousLinearMap.op_norm_comp_linearIsometryEquiv
-
-omit σ₂'' σ₂₃'
 
 /-- The norm of the tensor product of a scalar linear map and of an element of a normed space
 is the product of the norms. -/
@@ -1810,7 +1893,6 @@ theorem norm_smulRight_apply (c : E →L[𝕜] 𝕜) (f : Fₗ) : ‖smulRight c
       ‖c x • f‖ = ‖c x‖ * ‖f‖ := norm_smul _ _
       _ ≤ ‖c‖ * ‖x‖ * ‖f‖ := (mul_le_mul_of_nonneg_right (le_op_norm _ _) (norm_nonneg _))
       _ = ‖c‖ * ‖f‖ * ‖x‖ := by ring
-      
   · by_cases h : f = 0
     · simp [h]
     · have : 0 < ‖f‖ := norm_pos_iff.2 h
@@ -1821,7 +1903,6 @@ theorem norm_smulRight_apply (c : E →L[𝕜] 𝕜) (f : Fₗ) : ‖smulRight c
         ‖c x‖ * ‖f‖ = ‖c x • f‖ := (norm_smul _ _).symm
         _ = ‖smul_right c f x‖ := rfl
         _ ≤ ‖smul_right c f‖ * ‖x‖ := le_op_norm _ _
-        
 #align continuous_linear_map.norm_smul_right_apply ContinuousLinearMap.norm_smulRight_apply
 
 /-- The non-negative norm of the tensor product of a scalar linear map and of an element of a normed
@@ -1833,7 +1914,7 @@ theorem nnnorm_smulRight_apply (c : E →L[𝕜] 𝕜) (f : Fₗ) : ‖smulRight
 
 variable (𝕜 E Fₗ)
 
-/-- `continuous_linear_map.smul_right` as a continuous trilinear map:
+/-- `ContinuousLinearMap.smulRight` as a continuous trilinear map:
 `smul_rightL (c : E →L[𝕜] 𝕜) (f : F) (x : E) = c x • f`. -/
 def smulRightL : (E →L[𝕜] 𝕜) →L[𝕜] Fₗ →L[𝕜] E →L[𝕜] Fₗ :=
   LinearMap.mkContinuous₂
@@ -1876,7 +1957,7 @@ end
 
 /-- The norm of `lsmul` equals 1 in any nontrivial normed group.
 
-This is `continuous_linear_map.op_norm_lsmul_le` as an equality. -/
+This is `ContinuousLinearMap.op_norm_lsmul_le` as an equality. -/
 @[simp]
 theorem op_norm_lsmul [NormedField 𝕜'] [NormedAlgebra 𝕜 𝕜'] [NormedSpace 𝕜' E]
     [IsScalarTower 𝕜 𝕜' E] [Nontrivial E] : ‖(lsmul 𝕜 𝕜' : 𝕜' →L[𝕜] E →L[𝕜] E)‖ = 1 := by
@@ -1899,6 +1980,7 @@ variable [NontriviallyNormedField 𝕜] [NontriviallyNormedField 𝕜₂] [Nontr
 
 theorem norm_subtypeL (K : Submodule 𝕜 E) [Nontrivial K] : ‖K.subtypeL‖ = 1 :=
   K.subtypeₗᵢ.norm_toContinuousLinearMap
+set_option linter.uppercaseLean3 false in
 #align submodule.norm_subtypeL Submodule.norm_subtypeL
 
 end Submodule
@@ -1913,11 +1995,13 @@ section
 
 variable [RingHomIsometric σ₂₁]
 
+set_option synthInstance.etaExperiment true in
 protected theorem antilipschitz (e : E ≃SL[σ₁₂] F) :
     AntilipschitzWith ‖(e.symm : F →SL[σ₂₁] E)‖₊ e :=
   e.symm.lipschitz.to_rightInverse e.left_inv
 #align continuous_linear_equiv.antilipschitz ContinuousLinearEquiv.antilipschitz
 
+set_option synthInstance.etaExperiment true in
 theorem one_le_norm_mul_norm_symm [RingHomIsometric σ₁₂] [Nontrivial E] (e : E ≃SL[σ₁₂] F) :
     1 ≤ ‖(e : E →SL[σ₁₂] F)‖ * ‖(e.symm : F →SL[σ₂₁] E)‖ := by
   rw [mul_comm]
@@ -1925,25 +2009,25 @@ theorem one_le_norm_mul_norm_symm [RingHomIsometric σ₁₂] [Nontrivial E] (e 
   rw [e.coe_symm_comp_coe, ContinuousLinearMap.norm_id]
 #align continuous_linear_equiv.one_le_norm_mul_norm_symm ContinuousLinearEquiv.one_le_norm_mul_norm_symm
 
-include σ₂₁
-
+set_option synthInstance.etaExperiment true in
 theorem norm_pos [RingHomIsometric σ₁₂] [Nontrivial E] (e : E ≃SL[σ₁₂] F) :
     0 < ‖(e : E →SL[σ₁₂] F)‖ :=
   pos_of_mul_pos_left (lt_of_lt_of_le zero_lt_one e.one_le_norm_mul_norm_symm) (norm_nonneg _)
 #align continuous_linear_equiv.norm_pos ContinuousLinearEquiv.norm_pos
 
-omit σ₂₁
-
+set_option synthInstance.etaExperiment true in
 theorem norm_symm_pos [RingHomIsometric σ₁₂] [Nontrivial E] (e : E ≃SL[σ₁₂] F) :
     0 < ‖(e.symm : F →SL[σ₂₁] E)‖ :=
   pos_of_mul_pos_right (zero_lt_one.trans_le e.one_le_norm_mul_norm_symm) (norm_nonneg _)
 #align continuous_linear_equiv.norm_symm_pos ContinuousLinearEquiv.norm_symm_pos
 
+set_option synthInstance.etaExperiment true in
 theorem nnnorm_symm_pos [RingHomIsometric σ₁₂] [Nontrivial E] (e : E ≃SL[σ₁₂] F) :
     0 < ‖(e.symm : F →SL[σ₂₁] E)‖₊ :=
   e.norm_symm_pos
 #align continuous_linear_equiv.nnnorm_symm_pos ContinuousLinearEquiv.nnnorm_symm_pos
 
+set_option synthInstance.etaExperiment true in
 theorem subsingleton_or_norm_symm_pos [RingHomIsometric σ₁₂] (e : E ≃SL[σ₁₂] F) :
     Subsingleton E ∨ 0 < ‖(e.symm : F →SL[σ₂₁] E)‖ := by
   rcases subsingleton_or_nontrivial E with (_i | _i) <;> skip
@@ -1953,6 +2037,7 @@ theorem subsingleton_or_norm_symm_pos [RingHomIsometric σ₁₂] (e : E ≃SL[�
     exact e.norm_symm_pos
 #align continuous_linear_equiv.subsingleton_or_norm_symm_pos ContinuousLinearEquiv.subsingleton_or_norm_symm_pos
 
+set_option synthInstance.etaExperiment true in
 theorem subsingleton_or_nnnorm_symm_pos [RingHomIsometric σ₁₂] (e : E ≃SL[σ₁₂] F) :
     Subsingleton E ∨ 0 < ‖(e.symm : F →SL[σ₂₁] E)‖₊ :=
   subsingleton_or_norm_symm_pos e
@@ -1960,13 +2045,14 @@ theorem subsingleton_or_nnnorm_symm_pos [RingHomIsometric σ₁₂] (e : E ≃SL
 
 variable (𝕜)
 
+set_option synthInstance.etaExperiment true in
 @[simp]
 theorem coord_norm (x : E) (h : x ≠ 0) : ‖coord 𝕜 x h‖ = ‖x‖⁻¹ := by
   have hx : 0 < ‖x‖ := norm_pos_iff.mpr h
   haveI : Nontrivial (𝕜 ∙ x) := Submodule.nontrivial_span_singleton h
   exact
     ContinuousLinearMap.homothety_norm _ fun y =>
-      homothety_inverse _ hx _ (to_span_nonzero_singleton_homothety 𝕜 x h) _
+      homothety_inverse _ hx _ (toSpanNonzeroSingleton_homothety 𝕜 x h) _
 #align continuous_linear_equiv.coord_norm ContinuousLinearEquiv.coord_norm
 
 variable {𝕜} {𝕜₄ : Type _} [NontriviallyNormedField 𝕜₄]
@@ -1993,16 +2079,12 @@ variable [RingHomIsometric σ₁₃] [RingHomIsometric σ₁₂]
 
 variable [RingHomIsometric σ₃₄]
 
-include σ₂₁ σ₃₄ σ₁₃ σ₂₄
-
+set_option synthInstance.etaExperiment true in
 /-- A pair of continuous (semi)linear equivalences generates an continuous (semi)linear equivalence
 between the spaces of continuous (semi)linear maps. -/
 @[simps apply symm_apply]
 def arrowCongrSL (e₁₂ : E ≃SL[σ₁₂] F) (e₄₃ : H ≃SL[σ₄₃] G) : (E →SL[σ₁₄] H) ≃SL[σ₄₃] F →SL[σ₂₃] G :=
-  {-- given explicitly to help `simps`
-        -- given explicitly to help `simps`
-        e₁₂.arrowCongrEquiv
-      e₄₃ with
+  {e₁₂.arrowCongrEquiv e₄₃ with -- given explicitly to help `simps`
     toFun := fun L => (e₄₃ : H →SL[σ₄₃] G).comp (L.comp (e₁₂.symm : F →SL[σ₂₁] E))
     invFun := fun L => (e₄₃.symm : G →SL[σ₃₄] H).comp (L.comp (e₁₂ : E →SL[σ₁₂] F))
     map_add' := fun f g => by rw [add_comp, comp_add]
@@ -2011,8 +2093,7 @@ def arrowCongrSL (e₁₂ : E ≃SL[σ₁₂] F) (e₄₃ : H ≃SL[σ₄₃] G)
     continuous_invFun := (continuous_id.clm_comp_const _).const_clm_comp _ }
 #align continuous_linear_equiv.arrow_congrSL ContinuousLinearEquiv.arrowCongrSL
 
-omit σ₂₁ σ₃₄ σ₁₃ σ₂₄
-
+set_option synthInstance.etaExperiment true in
 /-- A pair of continuous linear equivalences generates an continuous linear equivalence between
 the spaces of continuous linear maps. -/
 def arrowCongr {F H : Type _} [NormedAddCommGroup F] [NormedAddCommGroup H] [NormedSpace 𝕜 F]
@@ -2033,4 +2114,3 @@ if there is some positive constant C such that `C * ‖u‖ * ‖u‖ ≤ B u u`
 def IsCoercive [NormedAddCommGroup E] [NormedSpace ℝ E] (B : E →L[ℝ] E →L[ℝ] ℝ) : Prop :=
   ∃ C, 0 < C ∧ ∀ u, C * ‖u‖ * ‖u‖ ≤ B u u
 #align is_coercive IsCoercive
-

--- a/Mathlib/Analysis/NormedSpace/OperatorNorm.lean
+++ b/Mathlib/Analysis/NormedSpace/OperatorNorm.lean
@@ -8,11 +8,11 @@ Authors: Jan-David Salchow, Sébastien Gouëzel, Jean Lo
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
-import Mathbin.Algebra.Algebra.Tower
-import Mathbin.Analysis.Asymptotics.Asymptotics
-import Mathbin.Analysis.NormedSpace.ContinuousLinearMap
-import Mathbin.Analysis.NormedSpace.LinearIsometry
-import Mathbin.Topology.Algebra.Module.StrongTopology
+import Mathlib.Algebra.Algebra.Tower
+import Mathlib.Analysis.Asymptotics.Asymptotics
+import Mathlib.Analysis.NormedSpace.ContinuousLinearMap
+import Mathlib.Analysis.NormedSpace.LinearIsometry
+import Mathlib.Topology.Algebra.Module.StrongTopology
 
 /-!
 # Operator norm on the space of continuous linear maps
@@ -50,8 +50,7 @@ variable [NontriviallyNormedField 𝕜] [NontriviallyNormedField 𝕜₂] [Nontr
 
 /-- If `‖x‖ = 0` and `f` is continuous then `‖f x‖ = 0`. -/
 theorem norm_image_of_norm_zero [SemilinearMapClass 𝓕 σ₁₂ E F] (f : 𝓕) (hf : Continuous f) {x : E}
-    (hx : ‖x‖ = 0) : ‖f x‖ = 0 :=
-  by
+    (hx : ‖x‖ = 0) : ‖f x‖ = 0 := by
   refine' le_antisymm (le_of_forall_pos_le_add fun ε hε => _) (norm_nonneg (f x))
   rcases NormedAddCommGroup.tendsto_nhds_nhds.1 (hf.tendsto 0) ε hε with ⟨δ, δ_pos, hδ⟩
   replace hδ := hδ x
@@ -68,8 +67,7 @@ variable [RingHomIsometric σ₁₂] [RingHomIsometric σ₂₃]
 theorem SemilinearMapClass.bound_of_shell_semi_normed [SemilinearMapClass 𝓕 σ₁₂ E F] (f : 𝓕)
     {ε C : ℝ} (ε_pos : 0 < ε) {c : 𝕜} (hc : 1 < ‖c‖)
     (hf : ∀ x, ε / ‖c‖ ≤ ‖x‖ → ‖x‖ < ε → ‖f x‖ ≤ C * ‖x‖) {x : E} (hx : ‖x‖ ≠ 0) :
-    ‖f x‖ ≤ C * ‖x‖ :=
-  by
+    ‖f x‖ ≤ C * ‖x‖ := by
   rcases rescale_to_shell_semi_normed hc ε_pos hx with ⟨δ, hδ, δxle, leδx, δinv⟩
   have := hf (δ • x) leδx δxle
   simpa only [map_smulₛₗ, norm_smul, mul_left_comm C, mul_le_mul_left (norm_pos_iff.2 hδ),
@@ -81,8 +79,7 @@ normed. The continuity ensures boundedness on a ball of some radius `ε`. The no
 norm is then used to rescale any element into an element of norm in `[ε/C, ε]`, whose image has a
 controlled norm. The norm control for the original element follows by rescaling. -/
 theorem SemilinearMapClass.bound_of_continuous [SemilinearMapClass 𝓕 σ₁₂ E F] (f : 𝓕)
-    (hf : Continuous f) : ∃ C, 0 < C ∧ ∀ x : E, ‖f x‖ ≤ C * ‖x‖ :=
-  by
+    (hf : Continuous f) : ∃ C, 0 < C ∧ ∀ x : E, ‖f x‖ ≤ C * ‖x‖ := by
   rcases NormedAddCommGroup.tendsto_nhds_nhds.1 (hf.tendsto 0) 1 zero_lt_one with ⟨ε, ε_pos, hε⟩
   simp only [sub_zero, map_zero] at hε
   rcases NormedField.exists_one_lt_norm 𝕜 with ⟨c, hc⟩
@@ -201,8 +198,7 @@ theorem op_norm_nonneg : 0 ≤ ‖f‖ :=
 #align continuous_linear_map.op_norm_nonneg ContinuousLinearMap.op_norm_nonneg
 
 /-- The fundamental property of the operator norm: `‖f x‖ ≤ ‖f‖ * ‖x‖`. -/
-theorem le_op_norm : ‖f x‖ ≤ ‖f‖ * ‖x‖ :=
-  by
+theorem le_op_norm : ‖f x‖ ≤ ‖f‖ * ‖x‖ := by
   obtain ⟨C, Cpos, hC⟩ := f.bound
   replace hC := hC x
   by_cases h : ‖x‖ = 0
@@ -240,8 +236,7 @@ theorem op_norm_le_of_shell {f : E →SL[σ₁₂] F} {ε C : ℝ} (ε_pos : 0 <
 #align continuous_linear_map.op_norm_le_of_shell ContinuousLinearMap.op_norm_le_of_shell
 
 theorem op_norm_le_of_ball {f : E →SL[σ₁₂] F} {ε : ℝ} {C : ℝ} (ε_pos : 0 < ε) (hC : 0 ≤ C)
-    (hf : ∀ x ∈ ball (0 : E) ε, ‖f x‖ ≤ C * ‖x‖) : ‖f‖ ≤ C :=
-  by
+    (hf : ∀ x ∈ ball (0 : E) ε, ‖f x‖ ≤ C * ‖x‖) : ‖f‖ ≤ C := by
   rcases NormedField.exists_one_lt_norm 𝕜 with ⟨c, hc⟩
   refine' op_norm_le_of_shell ε_pos hC hc fun x _ hx => hf x _
   rwa [ball_zero_eq]
@@ -254,8 +249,7 @@ theorem op_norm_le_of_nhds_zero {f : E →SL[σ₁₂] F} {C : ℝ} (hC : 0 ≤ 
 #align continuous_linear_map.op_norm_le_of_nhds_zero ContinuousLinearMap.op_norm_le_of_nhds_zero
 
 theorem op_norm_le_of_shell' {f : E →SL[σ₁₂] F} {ε C : ℝ} (ε_pos : 0 < ε) (hC : 0 ≤ C) {c : 𝕜}
-    (hc : ‖c‖ < 1) (hf : ∀ x, ε * ‖c‖ ≤ ‖x‖ → ‖x‖ < ε → ‖f x‖ ≤ C * ‖x‖) : ‖f‖ ≤ C :=
-  by
+    (hc : ‖c‖ < 1) (hf : ∀ x, ε * ‖c‖ ≤ ‖x‖ → ‖x‖ < ε → ‖f x‖ ≤ C * ‖x‖) : ‖f‖ ≤ C := by
   by_cases h0 : c = 0
   · refine' op_norm_le_of_ball ε_pos hC fun x hx => hf x _ _
     · simp [h0]
@@ -268,8 +262,7 @@ theorem op_norm_le_of_shell' {f : E →SL[σ₁₂] F} {ε C : ℝ} (ε_pos : 0 
 /-- For a continuous real linear map `f`, if one controls the norm of every `f x`, `‖x‖ = 1`, then
 one controls the norm of `f`. -/
 theorem op_norm_le_of_unit_norm [NormedSpace ℝ E] [NormedSpace ℝ F] {f : E →L[ℝ] F} {C : ℝ}
-    (hC : 0 ≤ C) (hf : ∀ x, ‖x‖ = 1 → ‖f x‖ ≤ C) : ‖f‖ ≤ C :=
-  by
+    (hC : 0 ≤ C) (hf : ∀ x, ‖x‖ = 1 → ‖f x‖ ≤ C) : ‖f‖ ≤ C := by
   refine' op_norm_le_bound' f hC fun x hx => _
   have H₁ : ‖‖x‖⁻¹ • x‖ = 1 := by rw [norm_smul, norm_inv, norm_norm, inv_mul_cancel hx]
   have H₂ := hf _ H₁
@@ -312,8 +305,7 @@ theorem norm_id_of_nontrivial_seminorm (h : ∃ x : E, ‖x‖ ≠ 0) : ‖id �
 
 theorem op_norm_smul_le {𝕜' : Type _} [NormedField 𝕜'] [NormedSpace 𝕜' F] [SMulCommClass 𝕜₂ 𝕜' F]
     (c : 𝕜') (f : E →SL[σ₁₂] F) : ‖c • f‖ ≤ ‖c‖ * ‖f‖ :=
-  (c • f).op_norm_le_bound (mul_nonneg (norm_nonneg _) (op_norm_nonneg _)) fun _ =>
-    by
+  (c • f).op_norm_le_bound (mul_nonneg (norm_nonneg _) (op_norm_nonneg _)) fun _ => by
     erw [norm_smul, mul_assoc]
     exact mul_le_mul_of_nonneg_left (le_op_norm _ _) (norm_nonneg _)
 #align continuous_linear_map.op_norm_smul_le ContinuousLinearMap.op_norm_smul_le
@@ -365,8 +357,7 @@ protected theorem tmp_topologicalAddGroup : TopologicalAddGroup (E →SL[σ₁�
 
 protected theorem tmp_closedBall_div_subset {a b : ℝ} (ha : 0 < a) (hb : 0 < b) :
     closedBall (0 : E →SL[σ₁₂] F) (a / b) ⊆
-      { f | ∀ x ∈ closedBall (0 : E) b, f x ∈ closedBall (0 : F) a } :=
-  by
+      { f | ∀ x ∈ closedBall (0 : E) b, f x ∈ closedBall (0 : F) a } := by
   intro f hf x hx
   rw [mem_closedBall_zero_iff] at hf hx⊢
   calc
@@ -380,8 +371,7 @@ end Tmp
 
 protected theorem tmp_topology_eq :
     (ContinuousLinearMap.tmpTopologicalSpace : TopologicalSpace (E →SL[σ₁₂] F)) =
-      ContinuousLinearMap.topologicalSpace :=
-  by
+      ContinuousLinearMap.topologicalSpace := by
   refine'
     continuous_linear_map.tmp_topological_add_group.ext inferInstance
       ((@Metric.nhds_basis_closedBall _ ContinuousLinearMap.tmpPseudoMetricSpace 0).ext
@@ -406,8 +396,7 @@ protected theorem tmp_topology_eq :
 
 protected theorem tmpUniformSpace_eq :
     (ContinuousLinearMap.tmpUniformSpace : UniformSpace (E →SL[σ₁₂] F)) =
-      ContinuousLinearMap.uniformSpace :=
-  by
+      ContinuousLinearMap.uniformSpace := by
   rw [← @UniformAddGroup.toUniformSpace_eq _ ContinuousLinearMap.tmpUniformSpace, ←
     @UniformAddGroup.toUniformSpace_eq _ ContinuousLinearMap.uniformSpace]
   congr 1
@@ -425,8 +414,7 @@ instance toSeminormedAddCommGroup : SeminormedAddCommGroup (E →SL[σ₁₂] F)
     where dist_eq := ContinuousLinearMap.tmpSeminormedAddCommGroup.dist_eq
 #align continuous_linear_map.to_seminormed_add_comm_group ContinuousLinearMap.toSeminormedAddCommGroup
 
-theorem nnnorm_def (f : E →SL[σ₁₂] F) : ‖f‖₊ = sInf { c | ∀ x, ‖f x‖₊ ≤ c * ‖x‖₊ } :=
-  by
+theorem nnnorm_def (f : E →SL[σ₁₂] F) : ‖f‖₊ = sInf { c | ∀ x, ‖f x‖₊ ≤ c * ‖x‖₊ } := by
   ext
   rw [NNReal.coe_sInf, coe_nnnorm, norm_def, NNReal.coe_image]
   simp_rw [← NNReal.coe_le_coe, NNReal.coe_mul, coe_nnnorm, mem_set_of_eq, Subtype.coe_mk,
@@ -471,8 +459,7 @@ include σ₁₃
 /-- The operator norm is submultiplicative. -/
 theorem op_norm_comp_le (f : E →SL[σ₁₂] F) : ‖h.comp f‖ ≤ ‖h‖ * ‖f‖ :=
   csInf_le bounds_bddBelow
-    ⟨mul_nonneg (op_norm_nonneg _) (op_norm_nonneg _), fun x =>
-      by
+    ⟨mul_nonneg (op_norm_nonneg _) (op_norm_nonneg _), fun x => by
       rw [mul_assoc]
       exact h.le_op_norm_of_le (f.le_op_norm x)⟩
 #align continuous_linear_map.op_norm_comp_le ContinuousLinearMap.op_norm_comp_le
@@ -535,8 +522,7 @@ theorem exists_mul_lt_of_lt_op_norm (f : E →SL[σ₁₂] F) {r : ℝ} (hr₀ :
 theorem exists_lt_apply_of_lt_op_nnnorm {𝕜 𝕜₂ E F : Type _} [NormedAddCommGroup E]
     [SeminormedAddCommGroup F] [DenselyNormedField 𝕜] [NontriviallyNormedField 𝕜₂] {σ₁₂ : 𝕜 →+* 𝕜₂}
     [NormedSpace 𝕜 E] [NormedSpace 𝕜₂ F] [RingHomIsometric σ₁₂] (f : E →SL[σ₁₂] F) {r : ℝ≥0}
-    (hr : r < ‖f‖₊) : ∃ x : E, ‖x‖₊ < 1 ∧ r < ‖f x‖₊ :=
-  by
+    (hr : r < ‖f‖₊) : ∃ x : E, ‖x‖₊ < 1 ∧ r < ‖f x‖₊ := by
   obtain ⟨y, hy⟩ := f.exists_mul_lt_apply_of_lt_op_nnnorm hr
   have hy' : ‖y‖₊ ≠ 0 :=
     nnnorm_ne_zero_iff.2 fun heq => by
@@ -553,8 +539,7 @@ theorem exists_lt_apply_of_lt_op_nnnorm {𝕜 𝕜₂ E F : Type _} [NormedAddCo
 theorem exists_lt_apply_of_lt_op_norm {𝕜 𝕜₂ E F : Type _} [NormedAddCommGroup E]
     [SeminormedAddCommGroup F] [DenselyNormedField 𝕜] [NontriviallyNormedField 𝕜₂] {σ₁₂ : 𝕜 →+* 𝕜₂}
     [NormedSpace 𝕜 E] [NormedSpace 𝕜₂ F] [RingHomIsometric σ₁₂] (f : E →SL[σ₁₂] F) {r : ℝ}
-    (hr : r < ‖f‖) : ∃ x : E, ‖x‖ < 1 ∧ r < ‖f x‖ :=
-  by
+    (hr : r < ‖f‖) : ∃ x : E, ‖x‖ < 1 ∧ r < ‖f x‖ := by
   by_cases hr₀ : r < 0
   · exact ⟨0, by simpa using hr₀⟩
   · lift r to ℝ≥0 using not_lt.1 hr₀
@@ -564,8 +549,7 @@ theorem exists_lt_apply_of_lt_op_norm {𝕜 𝕜₂ E F : Type _} [NormedAddComm
 theorem sSup_unit_ball_eq_nnnorm {𝕜 𝕜₂ E F : Type _} [NormedAddCommGroup E]
     [SeminormedAddCommGroup F] [DenselyNormedField 𝕜] [NontriviallyNormedField 𝕜₂] {σ₁₂ : 𝕜 →+* 𝕜₂}
     [NormedSpace 𝕜 E] [NormedSpace 𝕜₂ F] [RingHomIsometric σ₁₂] (f : E →SL[σ₁₂] F) :
-    sSup ((fun x => ‖f x‖₊) '' ball 0 1) = ‖f‖₊ :=
-  by
+    sSup ((fun x => ‖f x‖₊) '' ball 0 1) = ‖f‖₊ := by
   refine'
     csSup_eq_of_forall_le_of_forall_lt_exists_gt ((nonempty_ball.mpr zero_lt_one).image _) _
       fun ub hub => _
@@ -585,10 +569,8 @@ theorem sSup_unit_ball_eq_norm {𝕜 𝕜₂ E F : Type _} [NormedAddCommGroup E
 theorem sSup_closed_unit_ball_eq_nnnorm {𝕜 𝕜₂ E F : Type _} [NormedAddCommGroup E]
     [SeminormedAddCommGroup F] [DenselyNormedField 𝕜] [NontriviallyNormedField 𝕜₂] {σ₁₂ : 𝕜 →+* 𝕜₂}
     [NormedSpace 𝕜 E] [NormedSpace 𝕜₂ F] [RingHomIsometric σ₁₂] (f : E →SL[σ₁₂] F) :
-    sSup ((fun x => ‖f x‖₊) '' closedBall 0 1) = ‖f‖₊ :=
-  by
-  have hbdd : ∀ y ∈ (fun x => ‖f x‖₊) '' closed_ball 0 1, y ≤ ‖f‖₊ :=
-    by
+    sSup ((fun x => ‖f x‖₊) '' closedBall 0 1) = ‖f‖₊ := by
+  have hbdd : ∀ y ∈ (fun x => ‖f x‖₊) '' closed_ball 0 1, y ≤ ‖f‖₊ := by
     rintro - ⟨x, hx, rfl⟩
     exact f.unit_le_op_norm x (mem_closedBall_zero_iff.1 hx)
   refine' le_antisymm (csSup_le ((nonempty_closed_ball.mpr zero_le_one).image _) hbdd) _
@@ -664,8 +646,7 @@ def prodₗᵢ (R : Type _) [Semiring R] [Module R Fₗ] [Module R Gₗ] [Contin
 variable [RingHomIsometric σ₁₂] (f : E →SL[σ₁₂] F)
 
 @[simp, nontriviality]
-theorem op_norm_subsingleton [Subsingleton E] : ‖f‖ = 0 :=
-  by
+theorem op_norm_subsingleton [Subsingleton E] : ‖f‖ = 0 := by
   refine' le_antisymm _ (norm_nonneg _)
   apply op_norm_le_bound _ rfl.ge
   intro x
@@ -793,8 +774,7 @@ def flip (f : E →SL[σ₁₃] F →SL[σ₂₃] G) : F →SL[σ₂₃] E →SL
 #align continuous_linear_map.flip ContinuousLinearMap.flip
 
 private theorem le_norm_flip (f : E →SL[σ₁₃] F →SL[σ₂₃] G) : ‖f‖ ≤ ‖flip f‖ :=
-  f.op_norm_le_bound₂ (norm_nonneg _) fun x y =>
-    by
+  f.op_norm_le_bound₂ (norm_nonneg _) fun x y => by
     rw [mul_right_comm]
     exact (flip f).le_op_norm₂ y x
 #align continuous_linear_map.le_norm_flip continuous_linear_map.le_norm_flip
@@ -805,8 +785,7 @@ theorem flip_apply (f : E →SL[σ₁₃] F →SL[σ₂₃] G) (x : E) (y : F) :
 #align continuous_linear_map.flip_apply ContinuousLinearMap.flip_apply
 
 @[simp]
-theorem flip_flip (f : E →SL[σ₁₃] F →SL[σ₂₃] G) : f.flip.flip = f :=
-  by
+theorem flip_flip (f : E →SL[σ₁₃] F →SL[σ₂₃] G) : f.flip.flip = f := by
   ext
   rfl
 #align continuous_linear_map.flip_flip ContinuousLinearMap.flip_flip
@@ -831,8 +810,7 @@ variable (E F G σ₁₃ σ₂₃)
 /-- Flip the order of arguments of a continuous bilinear map.
 This is a version bundled as a `linear_isometry_equiv`.
 For an unbundled version see `continuous_linear_map.flip`. -/
-def flipₗᵢ' : (E →SL[σ₁₃] F →SL[σ₂₃] G) ≃ₗᵢ[𝕜₃] F →SL[σ₂₃] E →SL[σ₁₃] G
-    where
+def flipₗᵢ' : (E →SL[σ₁₃] F →SL[σ₂₃] G) ≃ₗᵢ[𝕜₃] F →SL[σ₂₃] E →SL[σ₁₃] G where
   toFun := flip
   invFun := flip
   map_add' := flip_add
@@ -859,8 +837,7 @@ variable (𝕜 E Fₗ Gₗ)
 /-- Flip the order of arguments of a continuous bilinear map.
 This is a version bundled as a `linear_isometry_equiv`.
 For an unbundled version see `continuous_linear_map.flip`. -/
-def flipₗᵢ : (E →L[𝕜] Fₗ →L[𝕜] Gₗ) ≃ₗᵢ[𝕜] Fₗ →L[𝕜] E →L[𝕜] Gₗ
-    where
+def flipₗᵢ : (E →L[𝕜] Fₗ →L[𝕜] Gₗ) ≃ₗᵢ[𝕜] Fₗ →L[𝕜] E →L[𝕜] Gₗ where
   toFun := flip
   invFun := flip
   map_add' := flip_add
@@ -921,8 +898,7 @@ variable (σ₁₂ σ₂₃ E F G)
 /-- Composition of continuous semilinear maps as a continuous semibilinear map. -/
 def compSL : (F →SL[σ₂₃] G) →L[𝕜₃] (E →SL[σ₁₂] F) →SL[σ₂₃] E →SL[σ₁₃] G :=
   LinearMap.mkContinuous₂
-    (LinearMap.mk₂'ₛₗ (RingHom.id 𝕜₃) σ₂₃ comp add_comp smul_comp comp_add fun c f g =>
-      by
+    (LinearMap.mk₂'ₛₗ (RingHom.id 𝕜₃) σ₂₃ comp add_comp smul_comp comp_add fun c f g => by
       ext
       simp only [ContinuousLinearMap.map_smulₛₗ, coe_smul', coe_comp', Function.comp_apply,
         Pi.smul_apply])
@@ -996,8 +972,7 @@ theorem norm_precompR_le (L : E →L[𝕜] Fₗ →L[𝕜] Gₗ) : ‖precompR E
     
 #align continuous_linear_map.norm_precompR_le ContinuousLinearMap.norm_precompR_le
 
-theorem norm_precompL_le (L : E →L[𝕜] Fₗ →L[𝕜] Gₗ) : ‖precompL Eₗ L‖ ≤ ‖L‖ :=
-  by
+theorem norm_precompL_le (L : E →L[𝕜] Fₗ →L[𝕜] Gₗ) : ‖precompL Eₗ L‖ ≤ ‖L‖ := by
   rw [precompL, op_norm_flip, ← op_norm_flip L]
   exact norm_precompR_le _ L.flip
 #align continuous_linear_map.norm_precompL_le ContinuousLinearMap.norm_precompL_le
@@ -1188,8 +1163,7 @@ theorem lsmul_apply (c : 𝕜') (x : E) : lsmul 𝕜 𝕜' c x = c • x :=
 
 variable {𝕜'}
 
-theorem norm_toSpanSingleton (x : E) : ‖toSpanSingleton 𝕜 x‖ = ‖x‖ :=
-  by
+theorem norm_toSpanSingleton (x : E) : ‖toSpanSingleton 𝕜 x‖ = ‖x‖ := by
   refine' op_norm_eq_of_bounds (norm_nonneg _) (fun x => _) fun N hN_nonneg h => _
   · rw [to_span_singleton_apply, norm_smul, mul_comm]
   · specialize h 1
@@ -1204,8 +1178,7 @@ theorem op_norm_lsmul_apply_le (x : 𝕜') : ‖(lsmul 𝕜 𝕜' x : E →L[�
 #align continuous_linear_map.op_norm_lsmul_apply_le ContinuousLinearMap.op_norm_lsmul_apply_le
 
 /-- The norm of `lsmul` is at most 1 in any semi-normed group. -/
-theorem op_norm_lsmul_le : ‖(lsmul 𝕜 𝕜' : 𝕜' →L[𝕜] E →L[𝕜] E)‖ ≤ 1 :=
-  by
+theorem op_norm_lsmul_le : ‖(lsmul 𝕜 𝕜' : 𝕜' →L[𝕜] E →L[𝕜] E)‖ ≤ 1 := by
   refine' ContinuousLinearMap.op_norm_le_bound _ zero_le_one fun x => _
   simp_rw [one_mul]
   exact op_norm_lsmul_apply_le _
@@ -1400,8 +1373,7 @@ theorem bound_of_shell [RingHomIsometric σ₁₂] (f : E →ₛₗ[σ₁₂] F)
 that produces a concrete bound.
 -/
 theorem bound_of_ball_bound {r : ℝ} (r_pos : 0 < r) (c : ℝ) (f : E →ₗ[𝕜] Fₗ)
-    (h : ∀ z ∈ Metric.ball (0 : E) r, ‖f z‖ ≤ c) : ∃ C, ∀ z : E, ‖f z‖ ≤ C * ‖z‖ :=
-  by
+    (h : ∀ z ∈ Metric.ball (0 : E) r, ‖f z‖ ≤ c) : ∃ C, ∀ z : E, ‖f z‖ ≤ C * ‖z‖ := by
   cases' @NontriviallyNormedField.non_trivial 𝕜 _ with k hk
   use c * (‖k‖ / r)
   intro z
@@ -1417,8 +1389,7 @@ theorem bound_of_ball_bound {r : ℝ} (r_pos : 0 < r) (c : ℝ) (f : E →ₗ[�
 #align linear_map.bound_of_ball_bound LinearMap.bound_of_ball_bound
 
 theorem antilipschitz_of_comap_nhds_le [h : RingHomIsometric σ₁₂] (f : E →ₛₗ[σ₁₂] F)
-    (hf : (𝓝 0).comap f ≤ 𝓝 0) : ∃ K, AntilipschitzWith K f :=
-  by
+    (hf : (𝓝 0).comap f ≤ 𝓝 0) : ∃ K, AntilipschitzWith K f := by
   rcases((nhds_basis_ball.comap _).le_basis_iffₓ nhds_basis_ball).1 hf 1 one_pos with ⟨ε, ε0, hε⟩
   simp only [Set.subset_def, Set.mem_preimage, mem_ball_zero_iff] at hε
   lift ε to ℝ≥0 using ε0.le
@@ -1468,8 +1439,7 @@ theorem op_norm_zero_iff [RingHomIsometric σ₁₂] : ‖f‖ = 0 ↔ f = 0 :=
 
 /-- If a normed space is non-trivial, then the norm of the identity equals `1`. -/
 @[simp]
-theorem norm_id [Nontrivial E] : ‖id 𝕜 E‖ = 1 :=
-  by
+theorem norm_id [Nontrivial E] : ‖id 𝕜 E‖ = 1 := by
   refine' norm_id_of_nontrivial_seminorm _
   obtain ⟨x, hx⟩ := exists_ne (0 : E)
   exact ⟨x, ne_of_gt (norm_pos_iff.2 hx)⟩
@@ -1493,8 +1463,7 @@ instance toNormedRing : NormedRing (E →L[𝕜] E) :=
 variable {f}
 
 theorem homothety_norm [RingHomIsometric σ₁₂] [Nontrivial E] (f : E →SL[σ₁₂] F) {a : ℝ}
-    (hf : ∀ x, ‖f x‖ = a * ‖x‖) : ‖f‖ = a :=
-  by
+    (hf : ∀ x, ‖f x‖ = a * ‖x‖) : ‖f‖ = a := by
   obtain ⟨x, hx⟩ : ∃ x : E, x ≠ 0 := exists_ne 0
   rw [← norm_pos_iff] at hx
   have ha : 0 ≤ a := by simpa only [hf, hx, zero_le_mul_right] using norm_nonneg (f x)
@@ -1524,8 +1493,7 @@ that it belongs to the closure of the image of a bounded set `s : set (E →SL[�
 to function. Coercion to function of the result is definitionally equal to `f`. -/
 @[simps (config := { fullyApplied := false }) apply]
 def ofMemClosureImageCoeBounded (f : E' → F) {s : Set (E' →SL[σ₁₂] F)} (hs : Bounded s)
-    (hf : f ∈ closure ((coeFn : (E' →SL[σ₁₂] F) → E' → F) '' s)) : E' →SL[σ₁₂] F :=
-  by
+    (hf : f ∈ closure ((coeFn : (E' →SL[σ₁₂] F) → E' → F) '' s)) : E' →SL[σ₁₂] F := by
   -- `f` is a linear map due to `linear_map_of_mem_closure_range_coe`
   refine' (linearMapOfMemClosureRangeCoe f _).mkContinuousOfExistsBound _
   · refine' closure_mono (image_subset_iff.2 fun g hg => _) hf
@@ -1555,8 +1523,7 @@ def ofTendstoOfBoundedRange {α : Type _} {l : Filter α} [l.ne_bot] (f : E' →
 then it converges to the same map in norm. This lemma is used to prove that the space of continuous
 linear maps is complete provided that the codomain is a complete space. -/
 theorem tendsto_of_tendsto_pointwise_of_cauchySeq {f : ℕ → E' →SL[σ₁₂] F} {g : E' →SL[σ₁₂] F}
-    (hg : Tendsto (fun n x => f n x) atTop (𝓝 g)) (hf : CauchySeq f) : Tendsto f atTop (𝓝 g) :=
-  by
+    (hg : Tendsto (fun n x => f n x) atTop (𝓝 g)) (hf : CauchySeq f) : Tendsto f atTop (𝓝 g) := by
   /- Since `f` is a Cauchy sequence, there exists `b → 0` such that `‖f n - f m‖ ≤ b N` for any
     `m, n ≥ N`. -/
   rcases cauchySeq_iff_le_tendsto_0.1 hf with ⟨b, hb₀, hfb, hb_lim⟩
@@ -1577,8 +1544,7 @@ theorem tendsto_of_tendsto_pointwise_of_cauchySeq {f : ℕ → E' →SL[σ₁₂
 
 /-- If the target space is complete, the space of continuous linear maps with its norm is also
 complete. This works also if the source space is seminormed. -/
-instance [CompleteSpace F] : CompleteSpace (E' →SL[σ₁₂] F) :=
-  by
+instance [CompleteSpace F] : CompleteSpace (E' →SL[σ₁₂] F) := by
   -- We show that every Cauchy sequence converges.
   refine' Metric.complete_of_cauchySeq_tendsto fun f hf => _
   -- The evaluation at any point `v : E` is Cauchy.
@@ -1645,8 +1611,7 @@ theorem isCompact_image_coe_of_bounded_of_weak_closed [ProperSpace F] {s : Set (
 weak-* topology in `mathlib`, so we use an equivalent condition (see `is_closed_induced_iff'`). -/
 theorem is_weak_closed_closedBall (f₀ : E' →SL[σ₁₂] F) (r : ℝ) ⦃f : E' →SL[σ₁₂] F⦄
     (hf : ⇑f ∈ closure ((coeFn : (E' →SL[σ₁₂] F) → E' → F) '' closedBall f₀ r)) :
-    f ∈ closedBall f₀ r :=
-  by
+    f ∈ closedBall f₀ r := by
   have hr : 0 ≤ r := nonempty_closed_ball.1 (nonempty_image_iff.1 (closure_nonempty_iff.1 ⟨_, hf⟩))
   refine' mem_closedBall_iff_norm.2 (op_norm_le_bound _ hr fun x => _)
   have : IsClosed { g : E' → F | ‖g x - f₀ x‖ ≤ r * ‖x‖ } :=
@@ -1739,8 +1704,7 @@ local notation "ψ" => f.extend e h_dense (uniformEmbedding_of_bound _ h_e).to_u
 
 /-- If a dense embedding `e : E →L[𝕜] G` expands the norm by a constant factor `N⁻¹`, then the
 norm of the extension of `f` along `e` is bounded by `N * ‖f‖`. -/
-theorem op_norm_extend_le : ‖ψ‖ ≤ N * ‖f‖ :=
-  by
+theorem op_norm_extend_le : ‖ψ‖ ≤ N * ‖f‖ := by
   have uni : UniformInducing e := (uniform_embedding_of_bound _ h_e).to_uniformInducing
   have eq : ∀ x, ψ (e x) = f x := uniformly_extend_of_ind uni h_dense f.uniform_continuous
   by_cases N0 : 0 ≤ N
@@ -1819,8 +1783,7 @@ include σ₂'' σ₂₃'
 
 /-- Precomposition with a linear isometry preserves the operator norm. -/
 theorem op_norm_comp_linearIsometryEquiv (f : F →SL[σ₂₃] G) (g : F' ≃ₛₗᵢ[σ₂'] F) :
-    ‖f.comp g.toLinearIsometry.toContinuousLinearMap‖ = ‖f‖ :=
-  by
+    ‖f.comp g.toLinearIsometry.toContinuousLinearMap‖ = ‖f‖ := by
   cases subsingleton_or_nontrivial F'
   · haveI := g.symm.to_linear_equiv.to_equiv.subsingleton
     simp
@@ -1840,8 +1803,7 @@ omit σ₂'' σ₂₃'
 /-- The norm of the tensor product of a scalar linear map and of an element of a normed space
 is the product of the norms. -/
 @[simp]
-theorem norm_smulRight_apply (c : E →L[𝕜] 𝕜) (f : Fₗ) : ‖smulRight c f‖ = ‖c‖ * ‖f‖ :=
-  by
+theorem norm_smulRight_apply (c : E →L[𝕜] 𝕜) (f : Fₗ) : ‖smulRight c f‖ = ‖c‖ * ‖f‖ := by
   refine' le_antisymm _ _
   · apply op_norm_le_bound _ (mul_nonneg (norm_nonneg _) (norm_nonneg _)) fun x => _
     calc
@@ -1917,8 +1879,7 @@ end
 This is `continuous_linear_map.op_norm_lsmul_le` as an equality. -/
 @[simp]
 theorem op_norm_lsmul [NormedField 𝕜'] [NormedAlgebra 𝕜 𝕜'] [NormedSpace 𝕜' E]
-    [IsScalarTower 𝕜 𝕜' E] [Nontrivial E] : ‖(lsmul 𝕜 𝕜' : 𝕜' →L[𝕜] E →L[𝕜] E)‖ = 1 :=
-  by
+    [IsScalarTower 𝕜 𝕜' E] [Nontrivial E] : ‖(lsmul 𝕜 𝕜' : 𝕜' →L[𝕜] E →L[𝕜] E)‖ = 1 := by
   refine' ContinuousLinearMap.op_norm_eq_of_bounds zero_le_one (fun x => _) fun N hN h => _
   · rw [one_mul]
     exact op_norm_lsmul_apply_le _
@@ -1958,8 +1919,7 @@ protected theorem antilipschitz (e : E ≃SL[σ₁₂] F) :
 #align continuous_linear_equiv.antilipschitz ContinuousLinearEquiv.antilipschitz
 
 theorem one_le_norm_mul_norm_symm [RingHomIsometric σ₁₂] [Nontrivial E] (e : E ≃SL[σ₁₂] F) :
-    1 ≤ ‖(e : E →SL[σ₁₂] F)‖ * ‖(e.symm : F →SL[σ₂₁] E)‖ :=
-  by
+    1 ≤ ‖(e : E →SL[σ₁₂] F)‖ * ‖(e.symm : F →SL[σ₂₁] E)‖ := by
   rw [mul_comm]
   convert(e.symm : F →SL[σ₂₁] E).op_norm_comp_le (e : E →SL[σ₁₂] F)
   rw [e.coe_symm_comp_coe, ContinuousLinearMap.norm_id]
@@ -1985,8 +1945,7 @@ theorem nnnorm_symm_pos [RingHomIsometric σ₁₂] [Nontrivial E] (e : E ≃SL[
 #align continuous_linear_equiv.nnnorm_symm_pos ContinuousLinearEquiv.nnnorm_symm_pos
 
 theorem subsingleton_or_norm_symm_pos [RingHomIsometric σ₁₂] (e : E ≃SL[σ₁₂] F) :
-    Subsingleton E ∨ 0 < ‖(e.symm : F →SL[σ₂₁] E)‖ :=
-  by
+    Subsingleton E ∨ 0 < ‖(e.symm : F →SL[σ₂₁] E)‖ := by
   rcases subsingleton_or_nontrivial E with (_i | _i) <;> skip
   · left
     infer_instance
@@ -2002,8 +1961,7 @@ theorem subsingleton_or_nnnorm_symm_pos [RingHomIsometric σ₁₂] (e : E ≃SL
 variable (𝕜)
 
 @[simp]
-theorem coord_norm (x : E) (h : x ≠ 0) : ‖coord 𝕜 x h‖ = ‖x‖⁻¹ :=
-  by
+theorem coord_norm (x : E) (h : x ≠ 0) : ‖coord 𝕜 x h‖ = ‖x‖⁻¹ := by
   have hx : 0 < ‖x‖ := norm_pos_iff.mpr h
   haveI : Nontrivial (𝕜 ∙ x) := Submodule.nontrivial_span_singleton h
   exact

--- a/Mathlib/Analysis/NormedSpace/OperatorNorm.lean
+++ b/Mathlib/Analysis/NormedSpace/OperatorNorm.lean
@@ -434,6 +434,8 @@ instance toPseudoMetricSpace : PseudoMetricSpace (E →SL[σ₁₂] F) :=
     (congr_arg _ ContinuousLinearMap.tmpUniformSpace_eq.symm)
 #align continuous_linear_map.to_pseudo_metric_space ContinuousLinearMap.toPseudoMetricSpace
 
+set_option synthInstance.etaExperiment true in
+set_option maxHeartbeats 0 in
 /-- Continuous linear maps themselves form a seminormed space with respect to
     the operator norm. -/
 instance toSeminormedAddCommGroup : SeminormedAddCommGroup (E →SL[σ₁₂] F) where
@@ -444,7 +446,8 @@ set_option synthInstance.etaExperiment true in
 theorem nnnorm_def (f : E →SL[σ₁₂] F) : ‖f‖₊ = sInf { c | ∀ x, ‖f x‖₊ ≤ c * ‖x‖₊ } := by
   ext
   rw [NNReal.coe_sInf, coe_nnnorm, norm_def, NNReal.coe_image]
-  simp_rw [← NNReal.coe_le_coe, NNReal.coe_mul, coe_nnnorm, mem_set_of_eq, Subtype.coe_mk,
+  -- Porting note: this was `simp_rw`, and can probably be optimised.
+  simp [← NNReal.coe_le_coe, NNReal.coe_mul, coe_nnnorm, mem_setOf_eq, Subtype.coe_mk,
     exists_prop]
 #align continuous_linear_map.nnnorm_def ContinuousLinearMap.nnnorm_def
 

--- a/Mathlib/Topology/Algebra/Module/Basic.lean
+++ b/Mathlib/Topology/Algebra/Module/Basic.lean
@@ -839,9 +839,9 @@ theorem comp_assoc {R₄ : Type _} [Semiring R₄] [Module R₄ M₄] {σ₁₄ 
   rfl
 #align continuous_linear_map.comp_assoc ContinuousLinearMap.comp_assoc
 
-instance mul : Mul (M₁ →L[R₁] M₁) :=
+instance instMul : Mul (M₁ →L[R₁] M₁) :=
   ⟨comp⟩
-#align continuous_linear_map.has_mul ContinuousLinearMap.mul
+#align continuous_linear_map.has_mul ContinuousLinearMap.instMul
 
 theorem mul_def (f g : M₁ →L[R₁] M₁) : f * g = f.comp g :=
   rfl

--- a/Mathlib/Topology/Algebra/Module/StrongTopology.lean
+++ b/Mathlib/Topology/Algebra/Module/StrongTopology.lean
@@ -199,10 +199,10 @@ instance continuousSMul [RingHomSurjective σ] [RingHomIsometric σ] [Topologica
     ⟨∅, Bornology.isVonNBounded_empty 𝕜₁ E⟩
     (directedOn_of_sup_mem fun _ _ => Bornology.IsVonNBounded.union) fun _ hs => hs
 
-instance [UniformSpace F] [UniformAddGroup F] : UniformSpace (E →SL[σ] F) :=
+instance uniformSpace [UniformSpace F] [UniformAddGroup F] : UniformSpace (E →SL[σ] F) :=
   strongUniformity σ F { S | Bornology.IsVonNBounded 𝕜₁ S }
 
-instance [UniformSpace F] [UniformAddGroup F] : UniformAddGroup (E →SL[σ] F) :=
+instance uniformAddGroup [UniformSpace F] [UniformAddGroup F] : UniformAddGroup (E →SL[σ] F) :=
   strongUniformity.uniformAddGroup σ F _
 
 instance [TopologicalSpace F] [TopologicalAddGroup F] [ContinuousSMul 𝕜₁ E] [T2Space F] :


### PR DESCRIPTION

---

This is the pushout of https://github.com/leanprover-community/mathlib4/pull/3708 and the reenableeta branch https://github.com/leanprover-community/mathlib4/pull/3414, to verify that even though #3708 is taking over 6 hours in CI, it is no problem with reenableeta.

- [x] depends on: #3414

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
