### PR TITLE
[Merged by Bors] - chore: make sorry only a warning again in the editor

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -2,13 +2,17 @@ import Lake
 
 open Lake DSL
 
-def moreLeanArgs := #[
-  "-DwarningAsError=true",
+def moreServerArgs := #[
   "-Dpp.unicode.fun=true" -- pretty-prints `fun a ↦ b`
 ]
 
+-- These settings only apply during `lake build`, but not in VSCode editor.
+def moreLeanArgs := #[
+  "-DwarningAsError=true"
+] ++ moreServerArgs
+
 package mathlib where
-  moreServerArgs := moreLeanArgs
+  moreServerArgs := moreServerArgs
 
 @[default_target]
 lean_lib Mathlib where


### PR DESCRIPTION
Sorry everyone, my fault that `sorry` has been an error in the editor the past two weeks. I merged https://github.com/leanprover-community/mathlib4/pull/3556 prematurely.

This PR leaves `sorry` as an error during `lake build` (and when rebuilding dependencies in VSCode), but in your active editor it is only a warning.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
