### PR TITLE
[Merged by Bors] - chore: forward-port leanprover-community/mathlib#18958

### DIFF
--- a/Mathlib/Algebra/Group/Basic.lean
+++ b/Mathlib/Algebra/Group/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura, Simon Hudon, Mario Carneiro
 
 ! This file was ported from Lean 3 source module algebra.group.basic
-! leanprover-community/mathlib commit 84771a9f5f0bd5e5d6218811556508ddf476dcbd
+! leanprover-community/mathlib commit a07d750983b94c530ab69a726862c2ab6802b38c
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -754,6 +754,11 @@ theorem mul_div_cancel'' (a b : G) : a * b / b = a :=
   by rw [div_eq_mul_inv, mul_inv_cancel_right a b]
 #align mul_div_cancel'' mul_div_cancel''
 #align add_sub_cancel add_sub_cancel
+
+@[to_additive (attr := simp) sub_add_cancel'']
+theorem div_mul_cancel''' (a b : G) : a / (b * a) = b⁻¹ := by rw [← inv_div, mul_div_cancel'']
+#align div_mul_cancel''' div_mul_cancel'''
+#align sub_add_cancel'' sub_add_cancel''
 
 @[to_additive (attr := simp)]
 theorem mul_div_mul_right_eq_div (a b c : G) : a * c / (b * c) = a / b := by

--- a/Mathlib/Algebra/GroupPower/Lemmas.lean
+++ b/Mathlib/Algebra/GroupPower/Lemmas.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Robert Y. Lewis
 
 ! This file was ported from Lean 3 source module algebra.group_power.lemmas
-! leanprover-community/mathlib commit e655e4ea5c6d02854696f97494997ba4c31be802
+! leanprover-community/mathlib commit a07d750983b94c530ab69a726862c2ab6802b38c
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -578,6 +578,13 @@ theorem mul_bit1 [NonAssocRing R] {n r : R} : r * bit1 n = (2 : ℤ) • (r * n)
 #align mul_bit1 mul_bit1
 
 end bit0_bit1
+
+/-- Note this holds in marginally more generality than `Int.cast_mul` -/
+theorem Int.cast_mul_eq_zsmul_cast [AddCommGroupWithOne α] : ∀ m n, ((m * n : ℤ) : α) = m • n :=
+  fun m =>
+  Int.inductionOn' m 0 (by simp) (fun k _ ih n => by simp [add_mul, add_zsmul, ih]) fun k _ ih n =>
+    by simp [sub_mul, sub_zsmul, ih, ← sub_eq_add_neg]
+#align int.cast_mul_eq_zsmul_cast Int.cast_mul_eq_zsmul_cast
 
 @[simp]
 theorem zsmul_eq_mul [Ring R] (a : R) : ∀ n : ℤ, n • a = n * a

--- a/Mathlib/Algebra/Hom/Units.lean
+++ b/Mathlib/Algebra/Hom/Units.lean
@@ -5,7 +5,7 @@ Authors: Johan Commelin, Chris Hughes, Kevin Buzzard
 Ported by: Winston Yin
 
 ! This file was ported from Lean 3 source module algebra.hom.units
-! leanprover-community/mathlib commit dc6c365e751e34d100e80fe6e314c3c3e0fd2988
+! leanprover-community/mathlib commit a07d750983b94c530ab69a726862c2ab6802b38c
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -437,7 +437,8 @@ protected theorem div_eq_one_iff_eq (h : IsUnit b) : a / b = 1 ↔ a = b :=
 #align is_unit.div_eq_one_iff_eq IsUnit.div_eq_one_iff_eq
 #align is_add_unit.sub_eq_zero_iff_eq IsAddUnit.sub_eq_zero_iff_eq
 
-@[to_additive]
+/-- The `group` version of this lemma is `div_mul_cancel'''` -/
+@[to_additive "The `add_group` version of this lemma is `sub_add_cancel''`"]
 protected theorem div_mul_left (h : IsUnit b) : b / (a * b) = 1 / a := by
   rw [div_eq_mul_inv, mul_inv_rev, h.mul_inv_cancel_left, one_div]
 #align is_unit.div_mul_left IsUnit.div_mul_left

--- a/Mathlib/Algebra/Hom/Units.lean
+++ b/Mathlib/Algebra/Hom/Units.lean
@@ -437,8 +437,8 @@ protected theorem div_eq_one_iff_eq (h : IsUnit b) : a / b = 1 ↔ a = b :=
 #align is_unit.div_eq_one_iff_eq IsUnit.div_eq_one_iff_eq
 #align is_add_unit.sub_eq_zero_iff_eq IsAddUnit.sub_eq_zero_iff_eq
 
-/-- The `group` version of this lemma is `div_mul_cancel'''` -/
-@[to_additive "The `add_group` version of this lemma is `sub_add_cancel''`"]
+/-- The `Group` version of this lemma is `div_mul_cancel'''` -/
+@[to_additive "The `AddGroup` version of this lemma is `sub_add_cancel''`"]
 protected theorem div_mul_left (h : IsUnit b) : b / (a * b) = 1 / a := by
   rw [div_eq_mul_inv, mul_inv_rev, h.mul_inv_cancel_left, one_div]
 #align is_unit.div_mul_left IsUnit.div_mul_left


### PR DESCRIPTION
Match https://github.com/leanprover-community/mathlib/pull/18958

* [`algebra.group.basic`@`84771a9f5f0bd5e5d6218811556508ddf476dcbd`..`a07d750983b94c530ab69a726862c2ab6802b38c`](https://leanprover-community.github.io/mathlib-port-status/file/algebra/group/basic?range=84771a9f5f0bd5e5d6218811556508ddf476dcbd..a07d750983b94c530ab69a726862c2ab6802b38c)
* [`algebra.group_power.lemmas`@`e655e4ea5c6d02854696f97494997ba4c31be802`..`a07d750983b94c530ab69a726862c2ab6802b38c`](https://leanprover-community.github.io/mathlib-port-status/file/algebra/group_power/lemmas?range=e655e4ea5c6d02854696f97494997ba4c31be802..a07d750983b94c530ab69a726862c2ab6802b38c)
* [`algebra.hom.units`@`dc6c365e751e34d100e80fe6e314c3c3e0fd2988`..`a07d750983b94c530ab69a726862c2ab6802b38c`](https://leanprover-community.github.io/mathlib-port-status/file/algebra/hom/units?range=dc6c365e751e34d100e80fe6e314c3c3e0fd2988..a07d750983b94c530ab69a726862c2ab6802b38c)


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
