### PR TITLE
[Merged by Bors] - fix: unexpanders for SetOf, supi, and infi

### DIFF
--- a/Mathlib/Init/Set.lean
+++ b/Mathlib/Init/Set.lean
@@ -78,7 +78,7 @@ macro_rules
 @[app_unexpander setOf]
 def setOf.unexpander : Lean.PrettyPrinter.Unexpander
   | `($_ fun $x:ident ↦ $p) => `({ $x:ident | $p })
-  | `($_ fun $x:ident : $ty:term ↦ $p) => `({ $x:ident : $ty:term | $p })
+  | `($_ fun ($x:ident : $ty:term) ↦ $p) => `({ $x:ident : $ty:term | $p })
   | _ => throw ()
 
 open Std.ExtendedBinder in

--- a/Mathlib/Order/CompleteLattice.lean
+++ b/Mathlib/Order/CompleteLattice.lean
@@ -114,7 +114,7 @@ notation3 "⨆ "(...)", "r:(scoped f => supᵢ f) => r
 @[app_unexpander supᵢ]
 def supᵢ.unexpander : Lean.PrettyPrinter.Unexpander
   | `($_ fun $x:ident ↦ $p) => `(⨆ $x:ident, $p)
-  | `($_ fun $x:ident : $ty:term ↦ $p) => `(⨆ $x:ident : $ty:term, $p)
+  | `($_ fun ($x:ident : $ty:term) ↦ $p) => `(⨆ ($x:ident : $ty:term), $p)
   | _ => throw ()
 
 /-- Indexed infimum. -/
@@ -124,7 +124,7 @@ notation3 "⨅ "(...)", "r:(scoped f => infᵢ f) => r
 @[app_unexpander infᵢ]
 def infᵢ.unexpander : Lean.PrettyPrinter.Unexpander
   | `($_ fun $x:ident ↦ $p) => `(⨅ $x:ident, $p)
-  | `($_ fun $x:ident : $ty:term ↦ $p) => `(⨅ $x:ident : $ty:term, $p)
+  | `($_ fun ($x:ident : $ty:term) ↦ $p) => `(⨅ ($x:ident : $ty:term), $p)
   | _ => throw ()
 
 instance OrderDual.supSet (α) [InfSet α] : SupSet αᵒᵈ :=


### PR DESCRIPTION
The `fun` notation uses parentheses when the type is explicit. This can be checked with `set_option pp.funBinderTypes true`. Closes #1654.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
