### PR TITLE
[Merged by Bors] - doc(Algebra/EuclideanDomain/Defs) : correct two typos in the doc

### DIFF
--- a/Mathlib/Algebra/EuclideanDomain/Defs.lean
+++ b/Mathlib/Algebra/EuclideanDomain/Defs.lean
@@ -34,10 +34,10 @@ don't satisfy the classical notion were provided independently by Hiblot and Nag
 
 ## Main statements
 
-See `Algebra.EuclideanDomain.Basic` for most of the theorems about Eucliean domains,
+See `Algebra.EuclideanDomain.Basic` for most of the theorems about Euclidean domains,
 including Bézout's lemma.
 
-See `Algebra.EuclideanDomain.Instances` for the facts that `ℤ` is a Euclidean domain,
+See `Algebra.EuclideanDomain.Instances` for the fact that `ℤ` is a Euclidean domain,
 as is any field.
 
 ## Notation


### PR DESCRIPTION
Correct two typos in the doc concerning the Main Statements of `Algebra.EuclideanDomain/Defs.lean`. The corresponding PR for `mathlib-3` is [#19001](https://github.com/leanprover-community/mathlib/pull/19001)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
