### PR TITLE
[Merged by Bors] - chore: forward port leanprover-community/mathlib#19001, 17743

### DIFF
--- a/Mathlib/Algebra/EuclideanDomain/Defs.lean
+++ b/Mathlib/Algebra/EuclideanDomain/Defs.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Louis Carlin, Mario Carneiro
 
 ! This file was ported from Lean 3 source module algebra.euclidean_domain.defs
-! leanprover-community/mathlib commit f1a2caaf51ef593799107fe9a8d5e411599f3996
+! leanprover-community/mathlib commit ee7b9f9a9ac2a8d9f04ea39bbfe6b1a3be053b38
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/

--- a/Mathlib/Order/Circular.lean
+++ b/Mathlib/Order/Circular.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 
 ! This file was ported from Lean 3 source module order.circular
-! leanprover-community/mathlib commit a2d2e18906e2b62627646b5d5be856e6a642062f
+! leanprover-community/mathlib commit 213b0cff7bc5ab6696ee07cceec80829ce42efec
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -73,7 +73,7 @@ What is the correct generality of "rolling the necklace" open? At least, this wo
 `β × α` where `α` is a circular order and `β` is a linear order.
 
 What's next is to define circular groups and provide instances for `ZMod n`, the usual circle group
-`Circle`, `Real.Angle`, and `RootsOfUnity M`. What conditions do we need on `M` for this last one
+`Circle`, and `RootsOfUnity M`. What conditions do we need on `M` for this last one
 to work?
 
 We should have circular order homomorphisms. The typical example is


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

* [`algebra.euclidean_domain.defs`@`f1a2caaf51ef593799107fe9a8d5e411599f3996`..`ee7b9f9a9ac2a8d9f04ea39bbfe6b1a3be053b38`](https://leanprover-community.github.io/mathlib-port-status/file/algebra/euclidean_domain/defs?range=f1a2caaf51ef593799107fe9a8d5e411599f3996..ee7b9f9a9ac2a8d9f04ea39bbfe6b1a3be053b38) – SHA-only update, missed in #3945
* [`order.circular`@`a2d2e18906e2b62627646b5d5be856e6a642062f`..`213b0cff7bc5ab6696ee07cceec80829ce42efec`](https://leanprover-community.github.io/mathlib-port-status/file/order/circular?range=a2d2e18906e2b62627646b5d5be856e6a642062f..213b0cff7bc5ab6696ee07cceec80829ce42efec)

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
