### PR TITLE
[Merged by Bors] - feat: port Topology.Instances.AddCircle

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2084,6 +2084,7 @@ import Mathlib.Topology.Homotopy.Contractible
 import Mathlib.Topology.Homotopy.Equiv
 import Mathlib.Topology.Homotopy.Path
 import Mathlib.Topology.Inseparable
+import Mathlib.Topology.Instances.AddCircle
 import Mathlib.Topology.Instances.ENNReal
 import Mathlib.Topology.Instances.EReal
 import Mathlib.Topology.Instances.Int

--- a/Mathlib/Algebra/CharZero/Quotient.lean
+++ b/Mathlib/Algebra/CharZero/Quotient.lean
@@ -53,7 +53,7 @@ theorem nsmul_mem_zmultiples_iff_exists_sub_div {r : R} {n : ℕ} (hn : n ≠ 0)
 
 end AddSubgroup
 
-namespace quotientAddGroup
+namespace QuotientAddGroup
 
 theorem zmultiples_zsmul_eq_zsmul_iff {ψ θ : R ⧸ AddSubgroup.zmultiples p} {z : ℤ} (hz : z ≠ 0) :
     z • ψ = z • θ ↔ ∃ k : Fin z.natAbs, ψ = θ + (k : ℕ) • (p / z : R) := by
@@ -66,13 +66,13 @@ theorem zmultiples_zsmul_eq_zsmul_iff {ψ θ : R ⧸ AddSubgroup.zmultiples p} {
   simp_rw [← QuotientAddGroup.mk_zsmul, ← QuotientAddGroup.mk_add,
     QuotientAddGroup.eq_iff_sub_mem, ← smul_sub, ← sub_sub]
   exact AddSubgroup.zsmul_mem_zmultiples_iff_exists_sub_div hz
-#align quotient_add_group.zmultiples_zsmul_eq_zsmul_iff quotientAddGroup.zmultiples_zsmul_eq_zsmul_iff
+#align quotient_add_group.zmultiples_zsmul_eq_zsmul_iff QuotientAddGroup.zmultiples_zsmul_eq_zsmul_iff
 
 theorem zmultiples_nsmul_eq_nsmul_iff {ψ θ : R ⧸ AddSubgroup.zmultiples p} {n : ℕ} (hz : n ≠ 0) :
     n • ψ = n • θ ↔ ∃ k : Fin n, ψ = θ + (k : ℕ) • (p / n : R) := by
   rw [← coe_nat_zsmul ψ, ← coe_nat_zsmul θ,
     zmultiples_zsmul_eq_zsmul_iff (Int.coe_nat_ne_zero.mpr hz), Int.cast_ofNat]
   rfl
-#align quotient_add_group.zmultiples_nsmul_eq_nsmul_iff quotientAddGroup.zmultiples_nsmul_eq_nsmul_iff
+#align quotient_add_group.zmultiples_nsmul_eq_nsmul_iff QuotientAddGroup.zmultiples_nsmul_eq_nsmul_iff
 
-end quotientAddGroup
+end QuotientAddGroup

--- a/Mathlib/Algebra/Order/ToIntervalMod.lean
+++ b/Mathlib/Algebra/Order/ToIntervalMod.lean
@@ -793,7 +793,7 @@ end Zero
 
 /-- `toIcoMod` as an equiv from the quotient. -/
 @[simps symm_apply]
-def quotientAddGroup.equivIcoMod (a : α) : α ⧸ AddSubgroup.zmultiples p ≃ Set.Ico a (a + p) where
+def QuotientAddGroup.equivIcoMod (a : α) : α ⧸ AddSubgroup.zmultiples p ≃ Set.Ico a (a + p) where
   toFun b :=
     ⟨(toIcoMod_periodic hp a).lift b, QuotientAddGroup.induction_on' b <| toIcoMod_mem_Ico hp a⟩
   invFun := (↑)
@@ -803,23 +803,23 @@ def quotientAddGroup.equivIcoMod (a : α) : α ⧸ AddSubgroup.zmultiples p ≃ 
     dsimp
     rw [QuotientAddGroup.eq_iff_sub_mem, toIcoMod_sub_self]
     apply AddSubgroup.zsmul_mem_zmultiples
-#align quotient_add_group.equiv_Ico_mod quotientAddGroup.equivIcoMod
+#align quotient_add_group.equiv_Ico_mod QuotientAddGroup.equivIcoMod
 
 @[simp]
-theorem quotientAddGroup.equivIcoMod_coe (a b : α) :
-    quotientAddGroup.equivIcoMod hp a ↑b = ⟨toIcoMod hp a b, toIcoMod_mem_Ico hp a _⟩ :=
+theorem QuotientAddGroup.equivIcoMod_coe (a b : α) :
+    QuotientAddGroup.equivIcoMod hp a ↑b = ⟨toIcoMod hp a b, toIcoMod_mem_Ico hp a _⟩ :=
   rfl
-#align quotient_add_group.equiv_Ico_mod_coe quotientAddGroup.equivIcoMod_coe
+#align quotient_add_group.equiv_Ico_mod_coe QuotientAddGroup.equivIcoMod_coe
 
 @[simp]
-theorem quotientAddGroup.equivIcoMod_zero (a : α) :
-    quotientAddGroup.equivIcoMod hp a 0 = ⟨toIcoMod hp a 0, toIcoMod_mem_Ico hp a _⟩ :=
+theorem QuotientAddGroup.equivIcoMod_zero (a : α) :
+    QuotientAddGroup.equivIcoMod hp a 0 = ⟨toIcoMod hp a 0, toIcoMod_mem_Ico hp a _⟩ :=
   rfl
-#align quotient_add_group.equiv_Ico_mod_zero quotientAddGroup.equivIcoMod_zero
+#align quotient_add_group.equiv_Ico_mod_zero QuotientAddGroup.equivIcoMod_zero
 
 /-- `toIocMod` as an equiv from the quotient. -/
 @[simps symm_apply]
-def quotientAddGroup.equivIocMod (a : α) : α ⧸ AddSubgroup.zmultiples p ≃ Set.Ioc a (a + p) where
+def QuotientAddGroup.equivIocMod (a : α) : α ⧸ AddSubgroup.zmultiples p ≃ Set.Ioc a (a + p) where
   toFun b :=
     ⟨(toIocMod_periodic hp a).lift b, QuotientAddGroup.induction_on' b <| toIocMod_mem_Ioc hp a⟩
   invFun := (↑)
@@ -829,19 +829,19 @@ def quotientAddGroup.equivIocMod (a : α) : α ⧸ AddSubgroup.zmultiples p ≃ 
     dsimp
     rw [QuotientAddGroup.eq_iff_sub_mem, toIocMod_sub_self]
     apply AddSubgroup.zsmul_mem_zmultiples
-#align quotient_add_group.equiv_Ioc_mod quotientAddGroup.equivIocMod
+#align quotient_add_group.equiv_Ioc_mod QuotientAddGroup.equivIocMod
 
 @[simp]
-theorem quotientAddGroup.equivIocMod_coe (a b : α) :
-    quotientAddGroup.equivIocMod hp a ↑b = ⟨toIocMod hp a b, toIocMod_mem_Ioc hp a _⟩ :=
+theorem QuotientAddGroup.equivIocMod_coe (a b : α) :
+    QuotientAddGroup.equivIocMod hp a ↑b = ⟨toIocMod hp a b, toIocMod_mem_Ioc hp a _⟩ :=
   rfl
-#align quotient_add_group.equiv_Ioc_mod_coe quotientAddGroup.equivIocMod_coe
+#align quotient_add_group.equiv_Ioc_mod_coe QuotientAddGroup.equivIocMod_coe
 
 @[simp]
-theorem quotientAddGroup.equivIocMod_zero (a : α) :
-    quotientAddGroup.equivIocMod hp a 0 = ⟨toIocMod hp a 0, toIocMod_mem_Ioc hp a _⟩ :=
+theorem QuotientAddGroup.equivIocMod_zero (a : α) :
+    QuotientAddGroup.equivIocMod hp a 0 = ⟨toIocMod hp a 0, toIocMod_mem_Ioc hp a _⟩ :=
   rfl
-#align quotient_add_group.equiv_Ioc_mod_zero quotientAddGroup.equivIocMod_zero
+#align quotient_add_group.equiv_Ioc_mod_zero QuotientAddGroup.equivIocMod_zero
 
 /-!
 ### The circular order structure on `α ⧸ AddSubgroup.zmultiples p`
@@ -921,7 +921,7 @@ private theorem toIxxMod_trans {x₁ x₂ x₃ x₄ : α}
   · rw [not_le] at h₁₂₃ h₂₃₄⊢
     exact (h₁₂₃.2.trans_le (toIcoMod_le_toIocMod _ x₃ x₂)).trans h₂₃₄.2
 
-namespace quotientAddGroup
+namespace QuotientAddGroup
 
 variable [hp' : Fact (0 < p)]
 
@@ -932,14 +932,14 @@ theorem btw_coe_iff' {x₁ x₂ x₃ : α} :
     Btw.btw (x₁ : α ⧸ AddSubgroup.zmultiples p) x₂ x₃ ↔
       toIcoMod hp'.out 0 (x₂ - x₁) ≤ toIocMod hp'.out 0 (x₃ - x₁) :=
   Iff.rfl
-#align quotient_add_group.btw_coe_iff' quotientAddGroup.btw_coe_iff'
+#align quotient_add_group.btw_coe_iff' QuotientAddGroup.btw_coe_iff'
 
 -- maybe harder to use than the primed one?
 theorem btw_coe_iff {x₁ x₂ x₃ : α} :
     Btw.btw (x₁ : α ⧸ AddSubgroup.zmultiples p) x₂ x₃ ↔
       toIcoMod hp'.out x₁ x₂ ≤ toIocMod hp'.out x₁ x₃ :=
   by rw [btw_coe_iff', toIocMod_sub_eq_sub, toIcoMod_sub_eq_sub, zero_add, sub_le_sub_iff_right]
-#align quotient_add_group.btw_coe_iff quotientAddGroup.btw_coe_iff
+#align quotient_add_group.btw_coe_iff QuotientAddGroup.btw_coe_iff
 
 instance circularPreorder : CircularPreorder (α ⧸ AddSubgroup.zmultiples p) where
   btw_refl x := show _ ≤ _ by simp [sub_self, hp'.out.le]
@@ -959,10 +959,10 @@ instance circularPreorder : CircularPreorder (α ⧸ AddSubgroup.zmultiples p) w
       induction x₄ using QuotientAddGroup.induction_on'
       simp_rw [btw_coe_iff] at h₁₂₃ h₂₃₄⊢
       apply toIxxMod_trans _ h₁₂₃ h₂₃₄
-#align quotient_add_group.circular_preorder quotientAddGroup.circularPreorder
+#align quotient_add_group.circular_preorder QuotientAddGroup.circularPreorder
 
 instance circularOrder : CircularOrder (α ⧸ AddSubgroup.zmultiples p) :=
-  { quotientAddGroup.circularPreorder with
+  { QuotientAddGroup.circularPreorder with
     btw_antisymm := fun {x₁ x₂ x₃} h₁₂₃ h₃₂₁ => by
       induction x₁ using QuotientAddGroup.induction_on'
       induction x₂ using QuotientAddGroup.induction_on'
@@ -977,9 +977,9 @@ instance circularOrder : CircularOrder (α ⧸ AddSubgroup.zmultiples p) :=
       induction x₃ using QuotientAddGroup.induction_on'
       simp_rw [btw_coe_iff]
       apply toIxxMod_total }
-#align quotient_add_group.circular_order quotientAddGroup.circularOrder
+#align quotient_add_group.circular_order QuotientAddGroup.circularOrder
 
-end quotientAddGroup
+end QuotientAddGroup
 
 end Circular
 

--- a/Mathlib/Topology/Instances/AddCircle.lean
+++ b/Mathlib/Topology/Instances/AddCircle.lean
@@ -292,23 +292,23 @@ end Continuity
 /-- The image of the closed-open interval `[a, a + p)` under the quotient map `𝕜 → add_circle p` is
 the entire space. -/
 @[simp]
-theorem coe_image_Ico_eq : (coe : 𝕜 → AddCircle p) '' Ico a (a + p) = univ := by
+theorem coe_image_Ico_eq : ((↑) : 𝕜 → AddCircle p) '' Ico a (a + p) = univ := by
   rw [image_eq_range]
-  exact (equiv_Ico p a).symm.range_eq_univ
+  exact (equivIco p a).symm.range_eq_univ
 #align add_circle.coe_image_Ico_eq AddCircle.coe_image_Ico_eq
 
 /-- The image of the closed-open interval `[a, a + p)` under the quotient map `𝕜 → add_circle p` is
 the entire space. -/
 @[simp]
-theorem coe_image_Ioc_eq : (coe : 𝕜 → AddCircle p) '' Ioc a (a + p) = univ := by
+theorem coe_image_Ioc_eq : ((↑) : 𝕜 → AddCircle p) '' Ioc a (a + p) = univ := by
   rw [image_eq_range]
-  exact (equiv_Ioc p a).symm.range_eq_univ
+  exact (equivIoc p a).symm.range_eq_univ
 #align add_circle.coe_image_Ioc_eq AddCircle.coe_image_Ioc_eq
 
 /-- The image of the closed interval `[0, p]` under the quotient map `𝕜 → add_circle p` is the
 entire space. -/
 @[simp]
-theorem coe_image_Icc_eq : (coe : 𝕜 → AddCircle p) '' Icc a (a + p) = univ :=
+theorem coe_image_Icc_eq : ((↑) : 𝕜 → AddCircle p) '' Icc a (a + p) = univ :=
   eq_top_mono (image_subset _ Ico_subset_Icc_self) <| coe_image_Ico_eq _ _
 #align add_circle.coe_image_Icc_eq AddCircle.coe_image_Icc_eq
 
@@ -384,10 +384,10 @@ variable (p)
 theorem gcd_mul_addOrderOf_div_eq {n : ℕ} (m : ℕ) (hn : 0 < n) :
     m.gcd n * addOrderOf (↑(↑m / ↑n * p) : AddCircle p) = n := by
   rw [mul_comm_div, ← nsmul_eq_mul, coe_nsmul, addOrderOf_nsmul'']
-  · rw [add_order_of_period_div hn, Nat.gcd_comm, Nat.mul_div_cancel']
-    exacts[n.gcd_dvd_left m, hp]
-  · rw [← addOrderOf_pos_iff, add_order_of_period_div hn]
-    exacts[hn, hp]
+  · rw [addOrderOf_period_div hn, Nat.gcd_comm, Nat.mul_div_cancel']
+    exact n.gcd_dvd_left m
+  · rw [← addOrderOf_pos_iff, addOrderOf_period_div hn]
+    exact hn
 #align add_circle.gcd_mul_add_order_of_div_eq AddCircle.gcd_mul_addOrderOf_div_eq
 
 variable {p}
@@ -412,15 +412,14 @@ theorem addOrderOf_coe_rat {q : ℚ} : addOrderOf (↑(↑q * p) : AddCircle p) 
     norm_cast
     exact q.pos.ne.symm
   rw [← @Rat.num_den q, Rat.cast_mk_of_ne_zero _ _ this, Int.cast_ofNat, Rat.num_den,
-    addOrderOf_div_of_gcd_eq_one' q.pos q.cop]
-  infer_instance
+    addOrderOf_div_of_gcd_eq_one' q.pos q.reduced]
 #align add_circle.add_order_of_coe_rat AddCircle.addOrderOf_coe_rat
 
 theorem addOrderOf_eq_pos_iff {u : AddCircle p} {n : ℕ} (h : 0 < n) :
     addOrderOf u = n ↔ ∃ m < n, m.gcd n = 1 ∧ ↑(↑m / ↑n * p) = u := by
-  refine' ⟨QuotientAddGroup.induction_on' u fun k hk => _, _⟩; swap
+  refine' ⟨QuotientAddGroup.induction_on' u fun k hk => _, _⟩
   · rintro ⟨m, h₀, h₁, rfl⟩
-    exact add_order_of_div_of_gcd_eq_one h h₁
+    exact addOrderOf_div_of_gcd_eq_one h h₁
   have h0 := addOrderOf_nsmul_eq_zero (k : AddCircle p)
   rw [hk, ← coe_nsmul, coe_eq_zero_iff] at h0
   obtain ⟨a, ha⟩ := h0
@@ -431,7 +430,7 @@ theorem addOrderOf_eq_pos_iff {u : AddCircle p} {n : ℕ} (h : 0 < n) :
   have he := _; refine' ⟨(a % n).toNat, _, _, he⟩
   · rw [← Int.ofNat_lt, han]
     exact Int.emod_lt_of_pos _ (Int.ofNat_lt.2 h)
-  · have := (gcd_mul_add_order_of_div_eq p _ h).trans ((congr_arg addOrderOf he).trans hk).symm
+  · have := (gcd_mul_addOrderOf_div_eq p _ h).trans ((congr_arg addOrderOf he).trans hk).symm
     rw [he, Nat.mul_left_eq_self_iff] at this
     · exact this
     · rwa [hk]
@@ -454,23 +453,23 @@ satisfies `0 ≤ m < n`. -/
 def setAddOrderOfEquiv {n : ℕ} (hn : 0 < n) :
     { u : AddCircle p | addOrderOf u = n } ≃ { m | m < n ∧ m.gcd n = 1 } :=
   Equiv.symm <|
-    Equiv.ofBijective (fun m => ⟨↑((m : 𝕜) / n * p), addOrderOf_div_of_gcd_eq_one hn m.Prop.2⟩)
+    Equiv.ofBijective (fun m => ⟨↑((m : 𝕜) / n * p), addOrderOf_div_of_gcd_eq_one hn m.prop.2⟩)
       (by
         refine' ⟨fun m₁ m₂ h => Subtype.ext _, fun u => _⟩
         · simp_rw [Subtype.ext_iff, Subtype.coe_mk] at h
-          rw [← sub_eq_zero, ← coe_sub, ← sub_mul, ← sub_div, coe_coe, coe_coe, ← Int.cast_ofNat m₁,
+          rw [← sub_eq_zero, ← coe_sub, ← sub_mul, ← sub_div, ← Int.cast_ofNat m₁,
             ← Int.cast_ofNat m₂, ← Int.cast_sub, coe_eq_zero_iff] at h
           obtain ⟨m, hm⟩ := h
           rw [← mul_div_right_comm, eq_div_iff, mul_comm, ← zsmul_eq_mul, mul_smul_comm, ←
             nsmul_eq_mul, ← coe_nat_zsmul, smul_smul,
-            (zsmul_strictMono_left hp.out).Injective.eq_iff, mul_comm] at hm
+            (zsmul_strictMono_left hp.out).injective.eq_iff, mul_comm] at hm
           swap
           · exact Nat.cast_ne_zero.2 hn.ne'
           rw [← @Nat.cast_inj ℤ, ← sub_eq_zero]
           refine' Int.eq_zero_of_abs_lt_dvd ⟨_, hm.symm⟩ (abs_sub_lt_iff.2 ⟨_, _⟩) <;>
             apply (Int.sub_le_self _ <| Nat.cast_nonneg _).trans_lt (Nat.cast_lt.2 _)
           exacts[m₁.2.1, m₂.2.1]
-        obtain ⟨m, hmn, hg, he⟩ := (add_order_of_eq_pos_iff hn).mp u.2
+        obtain ⟨m, hmn, hg, he⟩ := (addOrderOf_eq_pos_iff hn).mp u.2
         exact ⟨⟨m, hmn, hg⟩, Subtype.ext he⟩)
 #align add_circle.set_add_order_of_equiv AddCircle.setAddOrderOfEquiv
 
@@ -507,12 +506,12 @@ variable (p : ℝ)
 /-- The "additive circle" `ℝ ⧸ (ℤ ∙ p)` is compact. -/
 instance compactSpace [Fact (0 < p)] : CompactSpace <| AddCircle p := by
   rw [← isCompact_univ_iff, ← coe_image_Icc_eq p 0]
-  exact is_compact_Icc.image (AddCircle.continuous_mk' p)
+  exact isCompact_Icc.image (AddCircle.continuous_mk' p)
 #align add_circle.compact_space AddCircle.compactSpace
 
 /-- The action on `ℝ` by right multiplication of its the subgroup `zmultiples p` (the multiples of
 `p:ℝ`) is properly discontinuous. -/
-instance : ProperlyDiscontinuousVAdd (zmultiples p).opposite ℝ :=
+instance : ProperlyDiscontinuousVAdd (AddSubgroup.opposite (zmultiples p)) ℝ :=
   (zmultiples p).properlyDiscontinuousVAdd_opposite_of_tendsto_cofinite
     (AddSubgroup.tendsto_zmultiples_subtype_cofinite p)
 

--- a/Mathlib/Topology/Instances/AddCircle.lean
+++ b/Mathlib/Topology/Instances/AddCircle.lean
@@ -190,7 +190,10 @@ theorem coe_period : (p : AddCircle p) = 0 :=
   (QuotientAddGroup.eq_zero_iff p).2 <| mem_zmultiples p
 #align add_circle.coe_period AddCircle.coe_period
 
-@[simp]
+/- Porting note: `simp` attribute removed because linter reports:
+simp can prove this:
+  by simp only [@mem_zmultiples, @QuotientAddGroup.mk_add_of_mem]
+-/
 theorem coe_add_period (x : 𝕜) : ((x + p : 𝕜) : AddCircle p) = x := by
   rw [coe_add, ← eq_sub_iff_add_eq', sub_self, coe_period]
 #align add_circle.coe_add_period AddCircle.coe_add_period
@@ -579,16 +582,19 @@ def equivIccQuot : 𝕋 ≃ Quot (EndpointIdent p a) where
   right_inv :=
     Quot.ind <| by
       rintro ⟨x, hx⟩
-      have := _
       rcases ne_or_eq x (a + p) with (h | rfl)
       · revert x
-        exact this
-      · rw [← Quot.sound endpoint_ident.mk]
-        exact this _ _ (lt_add_of_pos_right a hp.out).ne
-      intro x hx h
-      congr
-      ext1
-      apply congr_arg Subtype.val ((equiv_Ico p a).right_inv ⟨x, hx.1, hx.2.lt_of_ne h⟩)
+        dsimp only
+        intro x hx h
+        congr
+        ext1
+        apply congr_arg Subtype.val ((equivIco p a).right_inv ⟨x, hx.1, hx.2.lt_of_ne h⟩)
+      · rw [← Quot.sound EndpointIdent.mk]
+        dsimp only
+        congr
+        ext1
+        apply congr_arg Subtype.val
+          ((equivIco p a).right_inv ⟨a, le_refl a, lt_add_of_pos_right a hp.out⟩)
 #align add_circle.equiv_Icc_quot AddCircle.equivIccQuot
 
 theorem equivIccQuot_comp_mk_eq_toIcoMod :
@@ -668,3 +674,4 @@ end ZeroBased
 end AddCircle
 
 end IdentifyIccEnds
+#lint

--- a/Mathlib/Topology/Instances/AddCircle.lean
+++ b/Mathlib/Topology/Instances/AddCircle.lean
@@ -204,18 +204,18 @@ protected theorem continuous_mk' :
 variable [hp : Fact (0 < p)] (a : 𝕜) [Archimedean 𝕜]
 
 instance : CircularOrder (AddCircle p) :=
-  quotientAddGroup.circularOrder
+  QuotientAddGroup.circularOrder
 
 /-- The equivalence between `add_circle p` and the half-open interval `[a, a + p)`, whose inverse
 is the natural quotient map. -/
 def equivIco : AddCircle p ≃ Ico a (a + p) :=
-  quotientAddGroup.equivIcoMod hp.out a
+  QuotientAddGroup.equivIcoMod hp.out a
 #align add_circle.equiv_Ico AddCircle.equivIco
 
 /-- The equivalence between `add_circle p` and the half-open interval `(a, a + p]`, whose inverse
 is the natural quotient map. -/
 def equivIoc : AddCircle p ≃ Ioc a (a + p) :=
-  quotientAddGroup.equivIocMod hp.out a
+  QuotientAddGroup.equivIocMod hp.out a
 #align add_circle.equiv_Ioc AddCircle.equivIoc
 
 /-- Given a function on `𝕜`, return the unique function on `add_circle p` agreeing with `f` on
@@ -422,25 +422,28 @@ theorem addOrderOf_coe_rat {q : ℚ} : addOrderOf (↑(↑q * p) : AddCircle p) 
 theorem addOrderOf_eq_pos_iff {u : AddCircle p} {n : ℕ} (h : 0 < n) :
     addOrderOf u = n ↔ ∃ m < n, m.gcd n = 1 ∧ ↑(↑m / ↑n * p) = u := by
   refine' ⟨QuotientAddGroup.induction_on' u fun k hk => _, _⟩
-  · rintro ⟨m, h₀, h₁, rfl⟩
+  · rintro ⟨m, _, h₁, rfl⟩
     exact addOrderOf_div_of_gcd_eq_one h h₁
   have h0 := addOrderOf_nsmul_eq_zero (k : AddCircle p)
   rw [hk, ← coe_nsmul, coe_eq_zero_iff] at h0
   obtain ⟨a, ha⟩ := h0
   have h0 : (_ : 𝕜) ≠ 0 := Nat.cast_ne_zero.2 h.ne'
-  rw [nsmul_eq_mul, mul_comm, ← div_eq_iff h0, ← a.div_add_mod' n, add_smul, add_div, zsmul_eq_mul,
-    Int.cast_mul, Int.cast_ofNat, mul_assoc, ← mul_div, mul_comm _ p, mul_div_cancel p h0] at ha
+  rw [nsmul_eq_mul, mul_comm, ← div_eq_iff h0, ← a.ediv_add_emod' n, add_smul, add_div,
+    zsmul_eq_mul, Int.cast_mul, Int.cast_ofNat, mul_assoc, ← mul_div, mul_comm _ p,
+    mul_div_cancel p h0] at ha
   have han : _ = a % n := Int.toNat_of_nonneg (Int.emod_nonneg _ <| by exact_mod_cast h.ne')
-  have he := _; refine' ⟨(a % n).toNat, _, _, he⟩
+  have he : (↑(↑((a % n).toNat) / ↑n * p) : AddCircle p) = k
+  · convert congr_arg (QuotientAddGroup.mk : 𝕜 → (AddCircle p)) ha using 1
+    rw [coe_add, ← Int.cast_ofNat, han, zsmul_eq_mul, mul_div_right_comm, eq_comm, add_left_eq_self,
+      ←zsmul_eq_mul, coe_zsmul, coe_period, smul_zero]
+  refine' ⟨(a % n).toNat, _, _, he⟩
   · rw [← Int.ofNat_lt, han]
     exact Int.emod_lt_of_pos _ (Int.ofNat_lt.2 h)
-  · have := (gcd_mul_addOrderOf_div_eq p _ h).trans ((congr_arg addOrderOf he).trans hk).symm
+  · have := (gcd_mul_addOrderOf_div_eq p (Int.toNat (a % ↑n)) h).trans
+      ((congr_arg addOrderOf he).trans hk).symm
     rw [he, Nat.mul_left_eq_self_iff] at this
     · exact this
     · rwa [hk]
-  convert congr_arg coe ha using 1
-  rw [coe_add, ← Int.cast_ofNat, han, zsmul_eq_mul, mul_div_right_comm, eq_comm, add_left_eq_self, ←
-    zsmul_eq_mul, coe_zsmul, coe_period, smul_zero]
 #align add_circle.add_order_of_eq_pos_iff AddCircle.addOrderOf_eq_pos_iff
 
 theorem exists_gcd_eq_one_of_isOfFinAddOrder {u : AddCircle p} (h : IsOfFinAddOrder u) :

--- a/Mathlib/Topology/Instances/AddCircle.lean
+++ b/Mathlib/Topology/Instances/AddCircle.lean
@@ -86,6 +86,8 @@ theorem continuous_right_toIcoMod : ContinuousWithinAt (toIcoMod hp a) (Ici x) x
 theorem continuous_left_toIocMod : ContinuousWithinAt (toIocMod hp a) (Iic x) x := by
   rw [(funext fun y => Eq.trans (by rw [neg_neg]) <| toIocMod_neg _ _ _ :
       toIocMod hp a = (fun x => p - x) ∘ toIcoMod hp (-a) ∘ Neg.neg)]
+  -- Porting note: added
+  have : ContinuousNeg 𝕜 := TopologicalAddGroup.toContinuousNeg
   exact
     (continuous_sub_left _).continuousAt.comp_continuousWithinAt <|
       (continuous_right_toIcoMod _ _ _).comp continuous_neg.continuousWithinAt fun y => neg_le_neg
@@ -119,13 +121,30 @@ theorem continuousAt_toIocMod : ContinuousAt (toIocMod hp a) x :=
 
 end Continuity
 
-/- ./././Mathport/Syntax/Translate/Command.lean:42:9: unsupported derive handler has_coe_t[has_coe_t] 𝕜 -/
 /-- The "additive circle": `𝕜 ⧸ (ℤ ∙ p)`. See also `circle` and `real.angle`. -/
 @[nolint unusedArguments]
 def AddCircle [LinearOrderedAddCommGroup 𝕜] [TopologicalSpace 𝕜] [OrderTopology 𝕜] (p : 𝕜) :=
-  𝕜 ⧸ zmultiples p deriving AddCommGroup, TopologicalSpace, TopologicalAddGroup, Inhabited,
-  «./././Mathport/Syntax/Translate/Command.lean:42:9: unsupported derive handler has_coe_t[has_coe_t] 𝕜»
+  𝕜 ⧸ zmultiples p
 #align add_circle AddCircle
+
+-- Porting note: the following section replaces a failing `deriving` statement
+section instances
+
+variable [LinearOrderedAddCommGroup 𝕜] [TopologicalSpace 𝕜] [OrderTopology 𝕜] (p : 𝕜)
+
+instance : AddCommGroup (AddCircle p) :=
+  inferInstanceAs (AddCommGroup (𝕜 ⧸ zmultiples p))
+instance : TopologicalSpace (AddCircle p) :=
+  inferInstanceAs (TopologicalSpace (𝕜 ⧸ zmultiples p))
+instance : TopologicalAddGroup (AddCircle p) :=
+  inferInstanceAs (TopologicalAddGroup (𝕜 ⧸ zmultiples p))
+instance : Inhabited (AddCircle p) :=
+  inferInstanceAs (Inhabited (𝕜 ⧸ zmultiples p))
+
+-- instance : Coe (AddCircle p) 𝕜 :=
+  -- inferInstanceAs (Coe (𝕜 ⧸ zmultiples p) 𝕜)
+
+end instances
 
 namespace AddCircle
 

--- a/Mathlib/Topology/Instances/AddCircle.lean
+++ b/Mathlib/Topology/Instances/AddCircle.lean
@@ -553,9 +553,8 @@ local notation "𝕋" => AddCircle p
 
 /-- The relation identifying the endpoints of `Icc a (a + p)`. -/
 inductive EndpointIdent : Icc a (a + p) → Icc a (a + p) → Prop
-  |
-  mk :
-    endpoint_ident ⟨a, left_mem_Icc.mpr <| le_add_of_nonneg_right hp.out.le⟩
+  | mk :
+    EndpointIdent ⟨a, left_mem_Icc.mpr <| le_add_of_nonneg_right hp.out.le⟩
       ⟨a + p, right_mem_Icc.mpr <| le_add_of_nonneg_right hp.out.le⟩
 #align add_circle.endpoint_ident AddCircle.EndpointIdent
 
@@ -578,7 +577,7 @@ def equivIccQuot : 𝕋 ≃ Quot (EndpointIdent p a) where
       · revert x
         exact this
       · rw [← Quot.sound endpoint_ident.mk]
-        exact this _ _ (lt_add_of_pos_right a hp.out).Ne
+        exact this _ _ (lt_add_of_pos_right a hp.out).ne
       intro x hx h
       congr
       ext1
@@ -594,11 +593,12 @@ theorem equivIccQuot_comp_mk_eq_toIcoMod :
 theorem equivIccQuot_comp_mk_eq_toIocMod :
     equivIccQuot p a ∘ Quotient.mk'' = fun x =>
       Quot.mk _ ⟨toIocMod hp.out a x, Ioc_subset_Icc_self <| toIocMod_mem_Ioc _ _ x⟩ := by
-  rw [equiv_Icc_quot_comp_mk_eq_to_Ico_mod]; funext
+  rw [equivIccQuot_comp_mk_eq_toIcoMod]
+  funext x
   by_cases a ≡ x [PMOD p]
-  · simp_rw [(modeq_iff_to_Ico_mod_eq_left hp.out).1 h, (modeq_iff_to_Ioc_mod_eq_right hp.out).1 h]
-    exact Quot.sound endpoint_ident.mk
-  · simp_rw [(not_modeq_iff_to_Ico_mod_eq_to_Ioc_mod hp.out).1 h]
+  · simp_rw [(modEq_iff_toIcoMod_eq_left hp.out).1 h, (modEq_iff_toIocMod_eq_right hp.out).1 h]
+    exact Quot.sound EndpointIdent.mk
+  · simp_rw [(not_modEq_iff_toIcoMod_eq_toIocMod hp.out).1 h]
 #align add_circle.equiv_Icc_quot_comp_mk_eq_to_Ioc_mod AddCircle.equivIccQuot_comp_mk_eq_toIocMod
 
 /-- The natural map from `[a, a + p] ⊂ 𝕜` with endpoints identified to `𝕜 / ℤ • p`, as a
@@ -606,7 +606,7 @@ homeomorphism of topological spaces. -/
 def homeoIccQuot : 𝕋 ≃ₜ Quot (EndpointIdent p a) where
   toEquiv := equivIccQuot p a
   continuous_toFun := by
-    simp_rw [quotient_map_quotient_mk.continuous_iff, continuous_iff_continuousAt,
+    simp_rw [quotientMap_quotient_mk'.continuous_iff, continuous_iff_continuousAt,
       continuousAt_iff_continuous_left_right]
     intro x; constructor
     on_goal 1 => erw [equiv_Icc_quot_comp_mk_eq_to_Ioc_mod]
@@ -639,8 +639,8 @@ theorem liftIco_eq_lift_Icc {f : 𝕜 → B} (h : f a = f (a + p)) :
 theorem liftIco_continuous [TopologicalSpace B] {f : 𝕜 → B} (hf : f a = f (a + p))
     (hc : ContinuousOn f <| Icc a (a + p)) : Continuous (liftIco p a f) := by
   rw [liftIco_eq_lift_Icc hf]
-  refine' Continuous.comp _ (homeo_Icc_quot p a).continuous_toFun
-  exact continuous_coinduced_dom.mpr (continuous_on_iff_continuous_restrict.mp hc)
+  refine' Continuous.comp _ (homeoIccQuot p a).continuous_toFun
+  exact continuous_coinduced_dom.mpr (continuousOn_iff_continuous_restrict.mp hc)
 #align add_circle.lift_Ico_continuous AddCircle.liftIco_continuous
 
 section ZeroBased

--- a/Mathlib/Topology/Instances/AddCircle.lean
+++ b/Mathlib/Topology/Instances/AddCircle.lean
@@ -354,19 +354,21 @@ theorem coe_equivIco_mk_apply (x : 𝕜) :
   toIcoMod_eq_fract_mul _ x
 #align add_circle.coe_equiv_Ico_mk_apply AddCircle.coe_equivIco_mk_apply
 
--- Porting note: fails to find `Archimedean 𝕜`
+/- Porting note: without `etaExperiment`, fails to find `Archimedean 𝕜`. With `etaExperiment`,
+needs extra heartbeats to find `Zero ℤ`, see Lean4 PR #2210. -/
 set_option synthInstance.etaExperiment true in
+set_option synthInstance.maxHeartbeats 100000 in
+set_option maxHeartbeats 600000 in
 instance : DivisibleBy (AddCircle p) ℤ where
   div x n := (↑((n : 𝕜)⁻¹ * (equivIco p 0 x : 𝕜)) : AddCircle p)
   div_zero x := by
-    simp only [algebraMap.coe_zero, QuotientAddGroup.mk_zero, inv_zero, MulZeroClass.zero_mul]
-  div_cancel n x hn := by
-    replace hn : (n : 𝕜) ≠ 0;
+    simp only [algebraMap.coe_zero, Int.cast_zero, inv_zero, zero_mul, QuotientAddGroup.mk_zero]
+  div_cancel {n} x hn := by
+    replace hn : (n : 𝕜) ≠ 0
     · norm_cast
-      assumption
-    change n • QuotientAddGroup.mk' _ ((n : 𝕜)⁻¹ * ↑(equiv_Ico p 0 x)) = x
+    change n • QuotientAddGroup.mk' _ ((n : 𝕜)⁻¹ * ↑(equivIco p 0 x)) = x
     rw [← map_zsmul, ← smul_mul_assoc, zsmul_eq_mul, mul_inv_cancel hn, one_mul]
-    exact (equiv_Ico p 0).symm_apply_apply x
+    exact (equivIco p 0).symm_apply_apply x
 
 end FloorRing
 

--- a/Mathlib/Topology/Instances/AddCircle.lean
+++ b/Mathlib/Topology/Instances/AddCircle.lean
@@ -8,13 +8,13 @@ Authors: Oliver Nash
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
-import Mathbin.Data.Nat.Totient
-import Mathbin.Algebra.Ring.AddAut
-import Mathbin.GroupTheory.Divisible
-import Mathbin.GroupTheory.OrderOfElement
-import Mathbin.Algebra.Order.Floor
-import Mathbin.Algebra.Order.ToIntervalMod
-import Mathbin.Topology.Instances.Real
+import Mathlib.Data.Nat.Totient
+import Mathlib.Algebra.Ring.AddAut
+import Mathlib.GroupTheory.Divisible
+import Mathlib.GroupTheory.OrderOfElement
+import Mathlib.Algebra.Order.Floor
+import Mathlib.Algebra.Order.ToIntervalMod
+import Mathlib.Topology.Instances.Real
 
 /-!
 # The additive circle
@@ -65,8 +65,7 @@ section Continuity
 variable [LinearOrderedAddCommGroup 𝕜] [Archimedean 𝕜] [TopologicalSpace 𝕜] [OrderTopology 𝕜]
   {p : 𝕜} (hp : 0 < p) (a x : 𝕜)
 
-theorem continuous_right_toIcoMod : ContinuousWithinAt (toIcoMod hp a) (Ici x) x :=
-  by
+theorem continuous_right_toIcoMod : ContinuousWithinAt (toIcoMod hp a) (Ici x) x := by
   intro s h
   rw [Filter.mem_map, mem_nhdsWithin_iff_exists_mem_nhds_inter]
   haveI : Nontrivial 𝕜 := ⟨⟨0, p, hp.ne⟩⟩
@@ -84,8 +83,7 @@ theorem continuous_right_toIcoMod : ContinuousWithinAt (toIcoMod hp a) (Ici x) x
     exacts[⟨h.1, h.2.2⟩, ⟨hd.1.trans (sub_le_sub_right h' _), h.2.1⟩]
 #align continuous_right_to_Ico_mod continuous_right_toIcoMod
 
-theorem continuous_left_toIocMod : ContinuousWithinAt (toIocMod hp a) (Iic x) x :=
-  by
+theorem continuous_left_toIocMod : ContinuousWithinAt (toIocMod hp a) (Iic x) x := by
   rw [(funext fun y => Eq.trans (by rw [neg_neg]) <| toIocMod_neg _ _ _ :
       toIocMod hp a = (fun x => p - x) ∘ toIcoMod hp (-a) ∘ Neg.neg)]
   exact
@@ -160,8 +158,7 @@ theorem coe_eq_zero_iff {x : 𝕜} : (x : AddCircle p) = 0 ↔ ∃ n : ℤ, n �
 #align add_circle.coe_eq_zero_iff AddCircle.coe_eq_zero_iff
 
 theorem coe_eq_zero_of_pos_iff (hp : 0 < p) {x : 𝕜} (hx : 0 < x) :
-    (x : AddCircle p) = 0 ↔ ∃ n : ℕ, n • p = x :=
-  by
+    (x : AddCircle p) = 0 ↔ ∃ n : ℕ, n • p = x := by
   rw [coe_eq_zero_iff]
   constructor <;> rintro ⟨n, rfl⟩
   · replace hx : 0 < n
@@ -222,8 +219,7 @@ def liftIoc (f : 𝕜 → B) : AddCircle p → B :=
 variable {p a}
 
 theorem coe_eq_coe_iff_of_mem_Ico {x y : 𝕜} (hx : x ∈ Ico a (a + p)) (hy : y ∈ Ico a (a + p)) :
-    (x : AddCircle p) = y ↔ x = y :=
-  by
+    (x : AddCircle p) = y ↔ x = y := by
   refine' ⟨fun h => _, by tauto⟩
   suffices (⟨x, hx⟩ : Ico a (a + p)) = ⟨y, hy⟩ by exact Subtype.mk.inj this
   apply_fun equiv_Ico p a  at h
@@ -233,8 +229,7 @@ theorem coe_eq_coe_iff_of_mem_Ico {x y : 𝕜} (hx : x ∈ Ico a (a + p)) (hy : 
 
 theorem liftIco_coe_apply {f : 𝕜 → B} {x : 𝕜} (hx : x ∈ Ico a (a + p)) : liftIco p a f ↑x = f x :=
   by
-  have : (equiv_Ico p a) x = ⟨x, hx⟩ :=
-    by
+  have : (equiv_Ico p a) x = ⟨x, hx⟩ := by
     rw [Equiv.apply_eq_iff_eq_symm_apply]
     rfl
   rw [lift_Ico, comp_apply, this]
@@ -243,8 +238,7 @@ theorem liftIco_coe_apply {f : 𝕜 → B} {x : 𝕜} (hx : x ∈ Ico a (a + p))
 
 theorem liftIoc_coe_apply {f : 𝕜 → B} {x : 𝕜} (hx : x ∈ Ioc a (a + p)) : liftIoc p a f ↑x = f x :=
   by
-  have : (equiv_Ioc p a) x = ⟨x, hx⟩ :=
-    by
+  have : (equiv_Ioc p a) x = ⟨x, hx⟩ := by
     rw [Equiv.apply_eq_iff_eq_symm_apply]
     rfl
   rw [lift_Ioc, comp_apply, this]
@@ -269,15 +263,13 @@ variable {x : AddCircle p} (hx : x ≠ a)
 
 include hx
 
-theorem continuousAt_equivIco : ContinuousAt (equivIco p a) x :=
-  by
+theorem continuousAt_equivIco : ContinuousAt (equivIco p a) x := by
   induction x using QuotientAddGroup.induction_on'
   rw [ContinuousAt, Filter.Tendsto, QuotientAddGroup.nhds_eq, Filter.map_map]
   exact (continuousAt_toIcoMod hp.out a hx).codRestrict _
 #align add_circle.continuous_at_equiv_Ico AddCircle.continuousAt_equivIco
 
-theorem continuousAt_equivIoc : ContinuousAt (equivIoc p a) x :=
-  by
+theorem continuousAt_equivIoc : ContinuousAt (equivIoc p a) x := by
   induction x using QuotientAddGroup.induction_on'
   rw [ContinuousAt, Filter.Tendsto, QuotientAddGroup.nhds_eq, Filter.map_map]
   exact (continuousAt_toIocMod hp.out a hx).codRestrict _
@@ -288,8 +280,7 @@ end Continuity
 /-- The image of the closed-open interval `[a, a + p)` under the quotient map `𝕜 → add_circle p` is
 the entire space. -/
 @[simp]
-theorem coe_image_Ico_eq : (coe : 𝕜 → AddCircle p) '' Ico a (a + p) = univ :=
-  by
+theorem coe_image_Ico_eq : (coe : 𝕜 → AddCircle p) '' Ico a (a + p) = univ := by
   rw [image_eq_range]
   exact (equiv_Ico p a).symm.range_eq_univ
 #align add_circle.coe_image_Ico_eq AddCircle.coe_image_Ico_eq
@@ -297,8 +288,7 @@ theorem coe_image_Ico_eq : (coe : 𝕜 → AddCircle p) '' Ico a (a + p) = univ 
 /-- The image of the closed-open interval `[a, a + p)` under the quotient map `𝕜 → add_circle p` is
 the entire space. -/
 @[simp]
-theorem coe_image_Ioc_eq : (coe : 𝕜 → AddCircle p) '' Ioc a (a + p) = univ :=
-  by
+theorem coe_image_Ioc_eq : (coe : 𝕜 → AddCircle p) '' Ioc a (a + p) = univ := by
   rw [image_eq_range]
   exact (equiv_Ioc p a).symm.range_eq_univ
 #align add_circle.coe_image_Ioc_eq AddCircle.coe_image_Ioc_eq
@@ -349,8 +339,7 @@ theorem coe_equivIco_mk_apply (x : 𝕜) :
   toIcoMod_eq_fract_mul _ x
 #align add_circle.coe_equiv_Ico_mk_apply AddCircle.coe_equivIco_mk_apply
 
-instance : DivisibleBy (AddCircle p) ℤ
-    where
+instance : DivisibleBy (AddCircle p) ℤ where
   div x n := (↑((n : 𝕜)⁻¹ * (equivIco p 0 x : 𝕜)) : AddCircle p)
   div_zero x := by
     simp only [algebraMap.coe_zero, QuotientAddGroup.mk_zero, inv_zero, MulZeroClass.zero_mul]
@@ -368,8 +357,7 @@ section FiniteOrderPoints
 
 variable {p}
 
-theorem addOrderOf_period_div {n : ℕ} (h : 0 < n) : addOrderOf ((p / n : 𝕜) : AddCircle p) = n :=
-  by
+theorem addOrderOf_period_div {n : ℕ} (h : 0 < n) : addOrderOf ((p / n : 𝕜) : AddCircle p) = n := by
   rw [addOrderOf_eq_iff h]
   replace h : 0 < (n : 𝕜) := Nat.cast_pos.2 h
   refine' ⟨_, fun m hn h0 => _⟩ <;> simp only [Ne, ← coe_nsmul, nsmul_eq_mul]
@@ -384,8 +372,7 @@ theorem addOrderOf_period_div {n : ℕ} (h : 0 < n) : addOrderOf ((p / n : 𝕜)
 variable (p)
 
 theorem gcd_mul_addOrderOf_div_eq {n : ℕ} (m : ℕ) (hn : 0 < n) :
-    m.gcd n * addOrderOf (↑(↑m / ↑n * p) : AddCircle p) = n :=
-  by
+    m.gcd n * addOrderOf (↑(↑m / ↑n * p) : AddCircle p) = n := by
   rw [mul_comm_div, ← nsmul_eq_mul, coe_nsmul, addOrderOf_nsmul'']
   · rw [add_order_of_period_div hn, Nat.gcd_comm, Nat.mul_div_cancel']
     exacts[n.gcd_dvd_left m, hp]
@@ -396,15 +383,13 @@ theorem gcd_mul_addOrderOf_div_eq {n : ℕ} (m : ℕ) (hn : 0 < n) :
 variable {p}
 
 theorem addOrderOf_div_of_gcd_eq_one {m n : ℕ} (hn : 0 < n) (h : m.gcd n = 1) :
-    addOrderOf (↑(↑m / ↑n * p) : AddCircle p) = n :=
-  by
+    addOrderOf (↑(↑m / ↑n * p) : AddCircle p) = n := by
   convert gcd_mul_add_order_of_div_eq p m hn
   rw [h, one_mul]
 #align add_circle.add_order_of_div_of_gcd_eq_one AddCircle.addOrderOf_div_of_gcd_eq_one
 
 theorem addOrderOf_div_of_gcd_eq_one' {m : ℤ} {n : ℕ} (hn : 0 < n) (h : m.natAbs.gcd n = 1) :
-    addOrderOf (↑(↑m / ↑n * p) : AddCircle p) = n :=
-  by
+    addOrderOf (↑(↑m / ↑n * p) : AddCircle p) = n := by
   induction m
   · simp only [Int.ofNat_eq_coe, Int.cast_ofNat, Int.natAbs_ofNat] at h⊢
     exact add_order_of_div_of_gcd_eq_one hn h
@@ -412,8 +397,7 @@ theorem addOrderOf_div_of_gcd_eq_one' {m : ℤ} {n : ℕ} (hn : 0 < n) (h : m.na
     exact add_order_of_div_of_gcd_eq_one hn h
 #align add_circle.add_order_of_div_of_gcd_eq_one' AddCircle.addOrderOf_div_of_gcd_eq_one'
 
-theorem addOrderOf_coe_rat {q : ℚ} : addOrderOf (↑(↑q * p) : AddCircle p) = q.den :=
-  by
+theorem addOrderOf_coe_rat {q : ℚ} : addOrderOf (↑(↑q * p) : AddCircle p) = q.den := by
   have : (↑(q.denom : ℤ) : 𝕜) ≠ 0 := by
     norm_cast
     exact q.pos.ne.symm
@@ -423,8 +407,7 @@ theorem addOrderOf_coe_rat {q : ℚ} : addOrderOf (↑(↑q * p) : AddCircle p) 
 #align add_circle.add_order_of_coe_rat AddCircle.addOrderOf_coe_rat
 
 theorem addOrderOf_eq_pos_iff {u : AddCircle p} {n : ℕ} (h : 0 < n) :
-    addOrderOf u = n ↔ ∃ m < n, m.gcd n = 1 ∧ ↑(↑m / ↑n * p) = u :=
-  by
+    addOrderOf u = n ↔ ∃ m < n, m.gcd n = 1 ∧ ↑(↑m / ↑n * p) = u := by
   refine' ⟨QuotientAddGroup.induction_on' u fun k hk => _, _⟩; swap
   · rintro ⟨m, h₀, h₁, rfl⟩
     exact add_order_of_div_of_gcd_eq_one h h₁
@@ -483,13 +466,11 @@ def setAddOrderOfEquiv {n : ℕ} (hn : 0 < n) :
 
 @[simp]
 theorem card_addOrderOf_eq_totient {n : ℕ} :
-    Nat.card { u : AddCircle p // addOrderOf u = n } = n.totient :=
-  by
+    Nat.card { u : AddCircle p // addOrderOf u = n } = n.totient := by
   rcases n.eq_zero_or_pos with (rfl | hn)
   · simp only [Nat.totient_zero, addOrderOf_eq_zero_iff]
     rcases em (∃ u : AddCircle p, ¬IsOfFinAddOrder u) with (⟨u, hu⟩ | h)
-    · have : Infinite { u : AddCircle p // ¬IsOfFinAddOrder u } :=
-        by
+    · have : Infinite { u : AddCircle p // ¬IsOfFinAddOrder u } := by
         erw [infinite_coe_iff]
         exact infinite_not_isOfFinAddOrder hu
       exact Nat.card_eq_zero_of_infinite
@@ -514,8 +495,7 @@ end LinearOrderedField
 variable (p : ℝ)
 
 /-- The "additive circle" `ℝ ⧸ (ℤ ∙ p)` is compact. -/
-instance compactSpace [Fact (0 < p)] : CompactSpace <| AddCircle p :=
-  by
+instance compactSpace [Fact (0 < p)] : CompactSpace <| AddCircle p := by
   rw [← isCompact_univ_iff, ← coe_image_Icc_eq p 0]
   exact is_compact_Icc.image (AddCircle.continuous_mk' p)
 #align add_circle.compact_space AddCircle.compactSpace
@@ -577,8 +557,7 @@ variable [Archimedean 𝕜]
 
 /-- The equivalence between `add_circle p` and the quotient of `[a, a + p]` by the relation
 identifying the endpoints. -/
-def equivIccQuot : 𝕋 ≃ Quot (EndpointIdent p a)
-    where
+def equivIccQuot : 𝕋 ≃ Quot (EndpointIdent p a) where
   toFun x := Quot.mk _ <| inclusion Ico_subset_Icc_self (equivIco _ _ x)
   invFun x :=
     Quot.liftOn x coe <| by
@@ -608,8 +587,7 @@ theorem equivIccQuot_comp_mk_eq_toIcoMod :
 
 theorem equivIccQuot_comp_mk_eq_toIocMod :
     equivIccQuot p a ∘ Quotient.mk'' = fun x =>
-      Quot.mk _ ⟨toIocMod hp.out a x, Ioc_subset_Icc_self <| toIocMod_mem_Ioc _ _ x⟩ :=
-  by
+      Quot.mk _ ⟨toIocMod hp.out a x, Ioc_subset_Icc_self <| toIocMod_mem_Ioc _ _ x⟩ := by
   rw [equiv_Icc_quot_comp_mk_eq_to_Ico_mod]; funext
   by_cases a ≡ x [PMOD p]
   · simp_rw [(modeq_iff_to_Ico_mod_eq_left hp.out).1 h, (modeq_iff_to_Ioc_mod_eq_right hp.out).1 h]
@@ -619,11 +597,9 @@ theorem equivIccQuot_comp_mk_eq_toIocMod :
 
 /-- The natural map from `[a, a + p] ⊂ 𝕜` with endpoints identified to `𝕜 / ℤ • p`, as a
 homeomorphism of topological spaces. -/
-def homeoIccQuot : 𝕋 ≃ₜ Quot (EndpointIdent p a)
-    where
+def homeoIccQuot : 𝕋 ≃ₜ Quot (EndpointIdent p a) where
   toEquiv := equivIccQuot p a
-  continuous_toFun :=
-    by
+  continuous_toFun := by
     simp_rw [quotient_map_quotient_mk.continuous_iff, continuous_iff_continuousAt,
       continuousAt_iff_continuous_left_right]
     intro x; constructor
@@ -655,8 +631,7 @@ theorem liftIco_eq_lift_Icc {f : 𝕜 → B} (h : f a = f (a + p)) :
 #align add_circle.lift_Ico_eq_lift_Icc AddCircle.liftIco_eq_lift_Icc
 
 theorem liftIco_continuous [TopologicalSpace B] {f : 𝕜 → B} (hf : f a = f (a + p))
-    (hc : ContinuousOn f <| Icc a (a + p)) : Continuous (liftIco p a f) :=
-  by
+    (hc : ContinuousOn f <| Icc a (a + p)) : Continuous (liftIco p a f) := by
   rw [lift_Ico_eq_lift_Icc hf]
   refine' Continuous.comp _ (homeo_Icc_quot p a).continuous_toFun
   exact continuous_coinduced_dom.mpr (continuous_on_iff_continuous_restrict.mp hc)

--- a/Mathlib/Topology/Instances/AddCircle.lean
+++ b/Mathlib/Topology/Instances/AddCircle.lean
@@ -141,8 +141,7 @@ instance : TopologicalAddGroup (AddCircle p) :=
 instance : Inhabited (AddCircle p) :=
   inferInstanceAs (Inhabited (𝕜 ⧸ zmultiples p))
 
--- instance : Coe (AddCircle p) 𝕜 :=
-  -- inferInstanceAs (Coe (𝕜 ⧸ zmultiples p) 𝕜)
+instance : Coe 𝕜 (AddCircle p) := ⟨QuotientAddGroup.mk⟩
 
 end instances
 
@@ -183,7 +182,7 @@ theorem coe_eq_zero_of_pos_iff (hp : 0 < p) {x : 𝕜} (hx : 0 < x) :
   · replace hx : 0 < n
     · contrapose! hx
       simpa only [← neg_nonneg, ← zsmul_neg, zsmul_neg'] using zsmul_nonneg hp.le (neg_nonneg.2 hx)
-    exact ⟨n.to_nat, by rw [← coe_nat_zsmul, Int.toNat_of_nonneg hx.le]⟩
+    exact ⟨n.toNat, by rw [← coe_nat_zsmul, Int.toNat_of_nonneg hx.le]⟩
   · exact ⟨(n : ℤ), by simp⟩
 #align add_circle.coe_eq_zero_of_pos_iff AddCircle.coe_eq_zero_of_pos_iff
 
@@ -237,26 +236,26 @@ theorem coe_eq_coe_iff_of_mem_Ico {x y : 𝕜} (hx : x ∈ Ico a (a + p)) (hy : 
     (x : AddCircle p) = y ↔ x = y := by
   refine' ⟨fun h => _, by tauto⟩
   suffices (⟨x, hx⟩ : Ico a (a + p)) = ⟨y, hy⟩ by exact Subtype.mk.inj this
-  apply_fun equiv_Ico p a  at h
-  rw [← (equiv_Ico p a).right_inv ⟨x, hx⟩, ← (equiv_Ico p a).right_inv ⟨y, hy⟩]
+  apply_fun equivIco p a  at h
+  rw [← (equivIco p a).right_inv ⟨x, hx⟩, ← (equivIco p a).right_inv ⟨y, hy⟩]
   exact h
 #align add_circle.coe_eq_coe_iff_of_mem_Ico AddCircle.coe_eq_coe_iff_of_mem_Ico
 
 theorem liftIco_coe_apply {f : 𝕜 → B} {x : 𝕜} (hx : x ∈ Ico a (a + p)) : liftIco p a f ↑x = f x :=
   by
-  have : (equiv_Ico p a) x = ⟨x, hx⟩ := by
+  have : (equivIco p a) x = ⟨x, hx⟩ := by
     rw [Equiv.apply_eq_iff_eq_symm_apply]
     rfl
-  rw [lift_Ico, comp_apply, this]
+  rw [liftIco, comp_apply, this]
   rfl
 #align add_circle.lift_Ico_coe_apply AddCircle.liftIco_coe_apply
 
 theorem liftIoc_coe_apply {f : 𝕜 → B} {x : 𝕜} (hx : x ∈ Ioc a (a + p)) : liftIoc p a f ↑x = f x :=
   by
-  have : (equiv_Ioc p a) x = ⟨x, hx⟩ := by
+  have : (equivIoc p a) x = ⟨x, hx⟩ := by
     rw [Equiv.apply_eq_iff_eq_symm_apply]
     rfl
-  rw [lift_Ioc, comp_apply, this]
+  rw [liftIoc, comp_apply, this]
   rfl
 #align add_circle.lift_Ioc_coe_apply AddCircle.liftIoc_coe_apply
 

--- a/Mathlib/Topology/Instances/AddCircle.lean
+++ b/Mathlib/Topology/Instances/AddCircle.lean
@@ -1,0 +1,681 @@
+/-
+Copyright (c) 2022 Oliver Nash. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Oliver Nash
+
+! This file was ported from Lean 3 source module topology.instances.add_circle
+! leanprover-community/mathlib commit 213b0cff7bc5ab6696ee07cceec80829ce42efec
+! Please do not edit these lines, except to modify the commit id
+! if you have ported upstream changes.
+-/
+import Mathbin.Data.Nat.Totient
+import Mathbin.Algebra.Ring.AddAut
+import Mathbin.GroupTheory.Divisible
+import Mathbin.GroupTheory.OrderOfElement
+import Mathbin.Algebra.Order.Floor
+import Mathbin.Algebra.Order.ToIntervalMod
+import Mathbin.Topology.Instances.Real
+
+/-!
+# The additive circle
+
+We define the additive circle `add_circle p` as the quotient `𝕜 ⧸ (ℤ ∙ p)` for some period `p : 𝕜`.
+
+See also `circle` and `real.angle`.  For the normed group structure on `add_circle`, see
+`add_circle.normed_add_comm_group` in a later file.
+
+## Main definitions and results:
+
+ * `add_circle`: the additive circle `𝕜 ⧸ (ℤ ∙ p)` for some period `p : 𝕜`
+ * `unit_add_circle`: the special case `ℝ ⧸ ℤ`
+ * `add_circle.equiv_add_circle`: the rescaling equivalence `add_circle p ≃+ add_circle q`
+ * `add_circle.equiv_Ico`: the natural equivalence `add_circle p ≃ Ico a (a + p)`
+ * `add_circle.add_order_of_div_of_gcd_eq_one`: rational points have finite order
+ * `add_circle.exists_gcd_eq_one_of_is_of_fin_add_order`: finite-order points are rational
+ * `add_circle.homeo_Icc_quot`: the natural topological equivalence between `add_circle p` and
+   `Icc a (a + p)` with its endpoints identified.
+ * `add_circle.lift_Ico_continuous`: if `f : ℝ → B` is continuous, and `f a = f (a + p)` for
+   some `a`, then there is a continuous function `add_circle p → B` which agrees with `f` on
+   `Icc a (a + p)`.
+
+## Implementation notes:
+
+Although the most important case is `𝕜 = ℝ` we wish to support other types of scalars, such as
+the rational circle `add_circle (1 : ℚ)`, and so we set things up more generally.
+
+## TODO
+
+ * Link with periodicity
+ * Lie group structure
+ * Exponential equivalence to `circle`
+
+-/
+
+
+noncomputable section
+
+open AddCommGroup Set Function AddSubgroup TopologicalSpace
+
+open Topology
+
+variable {𝕜 B : Type _}
+
+section Continuity
+
+variable [LinearOrderedAddCommGroup 𝕜] [Archimedean 𝕜] [TopologicalSpace 𝕜] [OrderTopology 𝕜]
+  {p : 𝕜} (hp : 0 < p) (a x : 𝕜)
+
+theorem continuous_right_toIcoMod : ContinuousWithinAt (toIcoMod hp a) (Ici x) x :=
+  by
+  intro s h
+  rw [Filter.mem_map, mem_nhdsWithin_iff_exists_mem_nhds_inter]
+  haveI : Nontrivial 𝕜 := ⟨⟨0, p, hp.ne⟩⟩
+  simp_rw [mem_nhds_iff_exists_Ioo_subset] at h⊢
+  obtain ⟨l, u, hxI, hIs⟩ := h
+  let d := toIcoDiv hp a x • p
+  have hd := toIcoMod_mem_Ico hp a x
+  simp_rw [subset_def, mem_inter_iff]
+  refine' ⟨_, ⟨l + d, min (a + p) u + d, _, fun x => id⟩, fun y => _⟩ <;>
+    simp_rw [← sub_mem_Ioo_iff_left, mem_Ioo, lt_min_iff]
+  · exact ⟨hxI.1, hd.2, hxI.2⟩
+  · rintro ⟨h, h'⟩
+    apply hIs
+    rw [← toIcoMod_sub_zsmul, (toIcoMod_eq_self _).2]
+    exacts[⟨h.1, h.2.2⟩, ⟨hd.1.trans (sub_le_sub_right h' _), h.2.1⟩]
+#align continuous_right_to_Ico_mod continuous_right_toIcoMod
+
+theorem continuous_left_toIocMod : ContinuousWithinAt (toIocMod hp a) (Iic x) x :=
+  by
+  rw [(funext fun y => Eq.trans (by rw [neg_neg]) <| toIocMod_neg _ _ _ :
+      toIocMod hp a = (fun x => p - x) ∘ toIcoMod hp (-a) ∘ Neg.neg)]
+  exact
+    (continuous_sub_left _).ContinuousAt.comp_continuousWithinAt <|
+      (continuous_right_toIcoMod _ _ _).comp continuous_neg.continuous_within_at fun y => neg_le_neg
+#align continuous_left_to_Ioc_mod continuous_left_toIocMod
+
+variable {x} (hx : (x : 𝕜 ⧸ zmultiples p) ≠ a)
+
+theorem toIcoMod_eventuallyEq_toIocMod : toIcoMod hp a =ᶠ[𝓝 x] toIocMod hp a :=
+  IsOpen.mem_nhds
+      (by
+        rw [Ico_eq_locus_Ioc_eq_iUnion_Ioo]
+        exact isOpen_iUnion fun i => isOpen_Ioo) <|
+    (not_modEq_iff_toIcoMod_eq_toIocMod hp).1 <| not_modEq_iff_ne_mod_zmultiples.2 hx
+#align to_Ico_mod_eventually_eq_to_Ioc_mod toIcoMod_eventuallyEq_toIocMod
+
+theorem continuousAt_toIcoMod : ContinuousAt (toIcoMod hp a) x :=
+  let h := toIcoMod_eventuallyEq_toIocMod hp a hx
+  continuousAt_iff_continuous_left_right.2 <|
+    ⟨(continuous_left_toIocMod hp a x).congr_of_eventuallyEq (h.filter_mono nhdsWithin_le_nhds)
+        h.eq_of_nhds,
+      continuous_right_toIcoMod hp a x⟩
+#align continuous_at_to_Ico_mod continuousAt_toIcoMod
+
+theorem continuousAt_toIocMod : ContinuousAt (toIocMod hp a) x :=
+  let h := toIcoMod_eventuallyEq_toIocMod hp a hx
+  continuousAt_iff_continuous_left_right.2 <|
+    ⟨continuous_left_toIocMod hp a x,
+      (continuous_right_toIcoMod hp a x).congr_of_eventuallyEq
+        (h.symm.filter_mono nhdsWithin_le_nhds) h.symm.eq_of_nhds⟩
+#align continuous_at_to_Ioc_mod continuousAt_toIocMod
+
+end Continuity
+
+/- ./././Mathport/Syntax/Translate/Command.lean:42:9: unsupported derive handler has_coe_t[has_coe_t] 𝕜 -/
+/-- The "additive circle": `𝕜 ⧸ (ℤ ∙ p)`. See also `circle` and `real.angle`. -/
+@[nolint unused_arguments]
+def AddCircle [LinearOrderedAddCommGroup 𝕜] [TopologicalSpace 𝕜] [OrderTopology 𝕜] (p : 𝕜) :=
+  𝕜 ⧸ zmultiples p deriving AddCommGroup, TopologicalSpace, TopologicalAddGroup, Inhabited,
+  «./././Mathport/Syntax/Translate/Command.lean:42:9: unsupported derive handler has_coe_t[has_coe_t] 𝕜»
+#align add_circle AddCircle
+
+namespace AddCircle
+
+section LinearOrderedAddCommGroup
+
+variable [LinearOrderedAddCommGroup 𝕜] [TopologicalSpace 𝕜] [OrderTopology 𝕜] (p : 𝕜)
+
+theorem coe_nsmul {n : ℕ} {x : 𝕜} : (↑(n • x) : AddCircle p) = n • (x : AddCircle p) :=
+  rfl
+#align add_circle.coe_nsmul AddCircle.coe_nsmul
+
+theorem coe_zsmul {n : ℤ} {x : 𝕜} : (↑(n • x) : AddCircle p) = n • (x : AddCircle p) :=
+  rfl
+#align add_circle.coe_zsmul AddCircle.coe_zsmul
+
+theorem coe_add (x y : 𝕜) : (↑(x + y) : AddCircle p) = (x : AddCircle p) + (y : AddCircle p) :=
+  rfl
+#align add_circle.coe_add AddCircle.coe_add
+
+theorem coe_sub (x y : 𝕜) : (↑(x - y) : AddCircle p) = (x : AddCircle p) - (y : AddCircle p) :=
+  rfl
+#align add_circle.coe_sub AddCircle.coe_sub
+
+theorem coe_neg {x : 𝕜} : (↑(-x) : AddCircle p) = -(x : AddCircle p) :=
+  rfl
+#align add_circle.coe_neg AddCircle.coe_neg
+
+theorem coe_eq_zero_iff {x : 𝕜} : (x : AddCircle p) = 0 ↔ ∃ n : ℤ, n • p = x := by
+  simp [AddSubgroup.mem_zmultiples_iff]
+#align add_circle.coe_eq_zero_iff AddCircle.coe_eq_zero_iff
+
+theorem coe_eq_zero_of_pos_iff (hp : 0 < p) {x : 𝕜} (hx : 0 < x) :
+    (x : AddCircle p) = 0 ↔ ∃ n : ℕ, n • p = x :=
+  by
+  rw [coe_eq_zero_iff]
+  constructor <;> rintro ⟨n, rfl⟩
+  · replace hx : 0 < n
+    · contrapose! hx
+      simpa only [← neg_nonneg, ← zsmul_neg, zsmul_neg'] using zsmul_nonneg hp.le (neg_nonneg.2 hx)
+    exact ⟨n.to_nat, by rw [← coe_nat_zsmul, Int.toNat_of_nonneg hx.le]⟩
+  · exact ⟨(n : ℤ), by simp⟩
+#align add_circle.coe_eq_zero_of_pos_iff AddCircle.coe_eq_zero_of_pos_iff
+
+theorem coe_period : (p : AddCircle p) = 0 :=
+  (QuotientAddGroup.eq_zero_iff p).2 <| mem_zmultiples p
+#align add_circle.coe_period AddCircle.coe_period
+
+@[simp]
+theorem coe_add_period (x : 𝕜) : ((x + p : 𝕜) : AddCircle p) = x := by
+  rw [coe_add, ← eq_sub_iff_add_eq', sub_self, coe_period]
+#align add_circle.coe_add_period AddCircle.coe_add_period
+
+@[continuity, nolint unused_arguments]
+protected theorem continuous_mk' :
+    Continuous (QuotientAddGroup.mk' (zmultiples p) : 𝕜 → AddCircle p) :=
+  continuous_coinduced_rng
+#align add_circle.continuous_mk' AddCircle.continuous_mk'
+
+variable [hp : Fact (0 < p)]
+
+include hp
+
+variable (a : 𝕜) [Archimedean 𝕜]
+
+instance : CircularOrder (AddCircle p) :=
+  quotientAddGroup.circularOrder
+
+/-- The equivalence between `add_circle p` and the half-open interval `[a, a + p)`, whose inverse
+is the natural quotient map. -/
+def equivIco : AddCircle p ≃ Ico a (a + p) :=
+  quotientAddGroup.equivIcoMod hp.out a
+#align add_circle.equiv_Ico AddCircle.equivIco
+
+/-- The equivalence between `add_circle p` and the half-open interval `(a, a + p]`, whose inverse
+is the natural quotient map. -/
+def equivIoc : AddCircle p ≃ Ioc a (a + p) :=
+  quotientAddGroup.equivIocMod hp.out a
+#align add_circle.equiv_Ioc AddCircle.equivIoc
+
+/-- Given a function on `𝕜`, return the unique function on `add_circle p` agreeing with `f` on
+`[a, a + p)`. -/
+def liftIco (f : 𝕜 → B) : AddCircle p → B :=
+  restrict _ f ∘ AddCircle.equivIco p a
+#align add_circle.lift_Ico AddCircle.liftIco
+
+/-- Given a function on `𝕜`, return the unique function on `add_circle p` agreeing with `f` on
+`(a, a + p]`. -/
+def liftIoc (f : 𝕜 → B) : AddCircle p → B :=
+  restrict _ f ∘ AddCircle.equivIoc p a
+#align add_circle.lift_Ioc AddCircle.liftIoc
+
+variable {p a}
+
+theorem coe_eq_coe_iff_of_mem_Ico {x y : 𝕜} (hx : x ∈ Ico a (a + p)) (hy : y ∈ Ico a (a + p)) :
+    (x : AddCircle p) = y ↔ x = y :=
+  by
+  refine' ⟨fun h => _, by tauto⟩
+  suffices (⟨x, hx⟩ : Ico a (a + p)) = ⟨y, hy⟩ by exact Subtype.mk.inj this
+  apply_fun equiv_Ico p a  at h
+  rw [← (equiv_Ico p a).right_inv ⟨x, hx⟩, ← (equiv_Ico p a).right_inv ⟨y, hy⟩]
+  exact h
+#align add_circle.coe_eq_coe_iff_of_mem_Ico AddCircle.coe_eq_coe_iff_of_mem_Ico
+
+theorem liftIco_coe_apply {f : 𝕜 → B} {x : 𝕜} (hx : x ∈ Ico a (a + p)) : liftIco p a f ↑x = f x :=
+  by
+  have : (equiv_Ico p a) x = ⟨x, hx⟩ :=
+    by
+    rw [Equiv.apply_eq_iff_eq_symm_apply]
+    rfl
+  rw [lift_Ico, comp_apply, this]
+  rfl
+#align add_circle.lift_Ico_coe_apply AddCircle.liftIco_coe_apply
+
+theorem liftIoc_coe_apply {f : 𝕜 → B} {x : 𝕜} (hx : x ∈ Ioc a (a + p)) : liftIoc p a f ↑x = f x :=
+  by
+  have : (equiv_Ioc p a) x = ⟨x, hx⟩ :=
+    by
+    rw [Equiv.apply_eq_iff_eq_symm_apply]
+    rfl
+  rw [lift_Ioc, comp_apply, this]
+  rfl
+#align add_circle.lift_Ioc_coe_apply AddCircle.liftIoc_coe_apply
+
+variable (p a)
+
+section Continuity
+
+@[continuity]
+theorem continuous_equivIco_symm : Continuous (equivIco p a).symm :=
+  continuous_quotient_mk'.comp continuous_subtype_val
+#align add_circle.continuous_equiv_Ico_symm AddCircle.continuous_equivIco_symm
+
+@[continuity]
+theorem continuous_equivIoc_symm : Continuous (equivIoc p a).symm :=
+  continuous_quotient_mk'.comp continuous_subtype_val
+#align add_circle.continuous_equiv_Ioc_symm AddCircle.continuous_equivIoc_symm
+
+variable {x : AddCircle p} (hx : x ≠ a)
+
+include hx
+
+theorem continuousAt_equivIco : ContinuousAt (equivIco p a) x :=
+  by
+  induction x using QuotientAddGroup.induction_on'
+  rw [ContinuousAt, Filter.Tendsto, QuotientAddGroup.nhds_eq, Filter.map_map]
+  exact (continuousAt_toIcoMod hp.out a hx).codRestrict _
+#align add_circle.continuous_at_equiv_Ico AddCircle.continuousAt_equivIco
+
+theorem continuousAt_equivIoc : ContinuousAt (equivIoc p a) x :=
+  by
+  induction x using QuotientAddGroup.induction_on'
+  rw [ContinuousAt, Filter.Tendsto, QuotientAddGroup.nhds_eq, Filter.map_map]
+  exact (continuousAt_toIocMod hp.out a hx).codRestrict _
+#align add_circle.continuous_at_equiv_Ioc AddCircle.continuousAt_equivIoc
+
+end Continuity
+
+/-- The image of the closed-open interval `[a, a + p)` under the quotient map `𝕜 → add_circle p` is
+the entire space. -/
+@[simp]
+theorem coe_image_Ico_eq : (coe : 𝕜 → AddCircle p) '' Ico a (a + p) = univ :=
+  by
+  rw [image_eq_range]
+  exact (equiv_Ico p a).symm.range_eq_univ
+#align add_circle.coe_image_Ico_eq AddCircle.coe_image_Ico_eq
+
+/-- The image of the closed-open interval `[a, a + p)` under the quotient map `𝕜 → add_circle p` is
+the entire space. -/
+@[simp]
+theorem coe_image_Ioc_eq : (coe : 𝕜 → AddCircle p) '' Ioc a (a + p) = univ :=
+  by
+  rw [image_eq_range]
+  exact (equiv_Ioc p a).symm.range_eq_univ
+#align add_circle.coe_image_Ioc_eq AddCircle.coe_image_Ioc_eq
+
+/-- The image of the closed interval `[0, p]` under the quotient map `𝕜 → add_circle p` is the
+entire space. -/
+@[simp]
+theorem coe_image_Icc_eq : (coe : 𝕜 → AddCircle p) '' Icc a (a + p) = univ :=
+  eq_top_mono (image_subset _ Ico_subset_Icc_self) <| coe_image_Ico_eq _ _
+#align add_circle.coe_image_Icc_eq AddCircle.coe_image_Icc_eq
+
+end LinearOrderedAddCommGroup
+
+section LinearOrderedField
+
+variable [LinearOrderedField 𝕜] [TopologicalSpace 𝕜] [OrderTopology 𝕜] (p q : 𝕜)
+
+/-- The rescaling equivalence between additive circles with different periods. -/
+def equivAddCircle (hp : p ≠ 0) (hq : q ≠ 0) : AddCircle p ≃+ AddCircle q :=
+  QuotientAddGroup.congr _ _ (AddAut.mulRight <| (Units.mk0 p hp)⁻¹ * Units.mk0 q hq) <| by
+    rw [AddMonoidHom.map_zmultiples, AddMonoidHom.coe_coe, AddAut.mulRight_apply, Units.val_mul,
+      Units.val_mk0, Units.val_inv_eq_inv_val, Units.val_mk0, mul_inv_cancel_left₀ hp]
+#align add_circle.equiv_add_circle AddCircle.equivAddCircle
+
+@[simp]
+theorem equivAddCircle_apply_mk (hp : p ≠ 0) (hq : q ≠ 0) (x : 𝕜) :
+    equivAddCircle p q hp hq (x : 𝕜) = (x * (p⁻¹ * q) : 𝕜) :=
+  rfl
+#align add_circle.equiv_add_circle_apply_mk AddCircle.equivAddCircle_apply_mk
+
+@[simp]
+theorem equivAddCircle_symm_apply_mk (hp : p ≠ 0) (hq : q ≠ 0) (x : 𝕜) :
+    (equivAddCircle p q hp hq).symm (x : 𝕜) = (x * (q⁻¹ * p) : 𝕜) :=
+  rfl
+#align add_circle.equiv_add_circle_symm_apply_mk AddCircle.equivAddCircle_symm_apply_mk
+
+variable [hp : Fact (0 < p)]
+
+include hp
+
+section FloorRing
+
+variable [FloorRing 𝕜]
+
+@[simp]
+theorem coe_equivIco_mk_apply (x : 𝕜) :
+    (equivIco p 0 <| QuotientAddGroup.mk x : 𝕜) = Int.fract (x / p) * p :=
+  toIcoMod_eq_fract_mul _ x
+#align add_circle.coe_equiv_Ico_mk_apply AddCircle.coe_equivIco_mk_apply
+
+instance : DivisibleBy (AddCircle p) ℤ
+    where
+  div x n := (↑((n : 𝕜)⁻¹ * (equivIco p 0 x : 𝕜)) : AddCircle p)
+  div_zero x := by
+    simp only [algebraMap.coe_zero, QuotientAddGroup.mk_zero, inv_zero, MulZeroClass.zero_mul]
+  div_cancel n x hn := by
+    replace hn : (n : 𝕜) ≠ 0;
+    · norm_cast
+      assumption
+    change n • QuotientAddGroup.mk' _ ((n : 𝕜)⁻¹ * ↑(equiv_Ico p 0 x)) = x
+    rw [← map_zsmul, ← smul_mul_assoc, zsmul_eq_mul, mul_inv_cancel hn, one_mul]
+    exact (equiv_Ico p 0).symm_apply_apply x
+
+end FloorRing
+
+section FiniteOrderPoints
+
+variable {p}
+
+theorem addOrderOf_period_div {n : ℕ} (h : 0 < n) : addOrderOf ((p / n : 𝕜) : AddCircle p) = n :=
+  by
+  rw [addOrderOf_eq_iff h]
+  replace h : 0 < (n : 𝕜) := Nat.cast_pos.2 h
+  refine' ⟨_, fun m hn h0 => _⟩ <;> simp only [Ne, ← coe_nsmul, nsmul_eq_mul]
+  · rw [mul_div_cancel' _ h.ne', coe_period]
+  rw [coe_eq_zero_of_pos_iff p hp.out (mul_pos (Nat.cast_pos.2 h0) <| div_pos hp.out h)]
+  rintro ⟨k, hk⟩
+  rw [mul_div, eq_div_iff h.ne', nsmul_eq_mul, mul_right_comm, ← Nat.cast_mul,
+    (mul_left_injective₀ hp.out.ne').eq_iff, Nat.cast_inj, mul_comm] at hk
+  exact (Nat.le_of_dvd h0 ⟨_, hk.symm⟩).not_lt hn
+#align add_circle.add_order_of_period_div AddCircle.addOrderOf_period_div
+
+variable (p)
+
+theorem gcd_mul_addOrderOf_div_eq {n : ℕ} (m : ℕ) (hn : 0 < n) :
+    m.gcd n * addOrderOf (↑(↑m / ↑n * p) : AddCircle p) = n :=
+  by
+  rw [mul_comm_div, ← nsmul_eq_mul, coe_nsmul, addOrderOf_nsmul'']
+  · rw [add_order_of_period_div hn, Nat.gcd_comm, Nat.mul_div_cancel']
+    exacts[n.gcd_dvd_left m, hp]
+  · rw [← addOrderOf_pos_iff, add_order_of_period_div hn]
+    exacts[hn, hp]
+#align add_circle.gcd_mul_add_order_of_div_eq AddCircle.gcd_mul_addOrderOf_div_eq
+
+variable {p}
+
+theorem addOrderOf_div_of_gcd_eq_one {m n : ℕ} (hn : 0 < n) (h : m.gcd n = 1) :
+    addOrderOf (↑(↑m / ↑n * p) : AddCircle p) = n :=
+  by
+  convert gcd_mul_add_order_of_div_eq p m hn
+  rw [h, one_mul]
+#align add_circle.add_order_of_div_of_gcd_eq_one AddCircle.addOrderOf_div_of_gcd_eq_one
+
+theorem addOrderOf_div_of_gcd_eq_one' {m : ℤ} {n : ℕ} (hn : 0 < n) (h : m.natAbs.gcd n = 1) :
+    addOrderOf (↑(↑m / ↑n * p) : AddCircle p) = n :=
+  by
+  induction m
+  · simp only [Int.ofNat_eq_coe, Int.cast_ofNat, Int.natAbs_ofNat] at h⊢
+    exact add_order_of_div_of_gcd_eq_one hn h
+  · simp only [Int.cast_negSucc, neg_div, neg_mul, coe_neg, addOrderOf_neg]
+    exact add_order_of_div_of_gcd_eq_one hn h
+#align add_circle.add_order_of_div_of_gcd_eq_one' AddCircle.addOrderOf_div_of_gcd_eq_one'
+
+theorem addOrderOf_coe_rat {q : ℚ} : addOrderOf (↑(↑q * p) : AddCircle p) = q.den :=
+  by
+  have : (↑(q.denom : ℤ) : 𝕜) ≠ 0 := by
+    norm_cast
+    exact q.pos.ne.symm
+  rw [← @Rat.num_den q, Rat.cast_mk_of_ne_zero _ _ this, Int.cast_ofNat, Rat.num_den,
+    add_order_of_div_of_gcd_eq_one' q.pos q.cop]
+  infer_instance
+#align add_circle.add_order_of_coe_rat AddCircle.addOrderOf_coe_rat
+
+theorem addOrderOf_eq_pos_iff {u : AddCircle p} {n : ℕ} (h : 0 < n) :
+    addOrderOf u = n ↔ ∃ m < n, m.gcd n = 1 ∧ ↑(↑m / ↑n * p) = u :=
+  by
+  refine' ⟨QuotientAddGroup.induction_on' u fun k hk => _, _⟩; swap
+  · rintro ⟨m, h₀, h₁, rfl⟩
+    exact add_order_of_div_of_gcd_eq_one h h₁
+  have h0 := addOrderOf_nsmul_eq_zero (k : AddCircle p)
+  rw [hk, ← coe_nsmul, coe_eq_zero_iff] at h0
+  obtain ⟨a, ha⟩ := h0
+  have h0 : (_ : 𝕜) ≠ 0 := Nat.cast_ne_zero.2 h.ne'
+  rw [nsmul_eq_mul, mul_comm, ← div_eq_iff h0, ← a.div_add_mod' n, add_smul, add_div, zsmul_eq_mul,
+    Int.cast_mul, Int.cast_ofNat, mul_assoc, ← mul_div, mul_comm _ p, mul_div_cancel p h0] at ha
+  have han : _ = a % n := Int.toNat_of_nonneg (Int.emod_nonneg _ <| by exact_mod_cast h.ne')
+  have he := _; refine' ⟨(a % n).toNat, _, _, he⟩
+  · rw [← Int.ofNat_lt, han]
+    exact Int.emod_lt_of_pos _ (Int.ofNat_lt.2 h)
+  · have := (gcd_mul_add_order_of_div_eq p _ h).trans ((congr_arg addOrderOf he).trans hk).symm
+    rw [he, Nat.mul_left_eq_self_iff] at this
+    · exact this
+    · rwa [hk]
+  convert congr_arg coe ha using 1
+  rw [coe_add, ← Int.cast_ofNat, han, zsmul_eq_mul, mul_div_right_comm, eq_comm, add_left_eq_self, ←
+    zsmul_eq_mul, coe_zsmul, coe_period, smul_zero]
+#align add_circle.add_order_of_eq_pos_iff AddCircle.addOrderOf_eq_pos_iff
+
+theorem exists_gcd_eq_one_of_isOfFinAddOrder {u : AddCircle p} (h : IsOfFinAddOrder u) :
+    ∃ m : ℕ, m.gcd (addOrderOf u) = 1 ∧ m < addOrderOf u ∧ ↑((m : 𝕜) / addOrderOf u * p) = u :=
+  let ⟨m, hl, hg, he⟩ := (addOrderOf_eq_pos_iff <| addOrderOf_pos' h).1 rfl
+  ⟨m, hg, hl, he⟩
+#align add_circle.exists_gcd_eq_one_of_is_of_fin_add_order AddCircle.exists_gcd_eq_one_of_isOfFinAddOrder
+
+variable (p)
+
+/-- The natural bijection between points of order `n` and natural numbers less than and coprime to
+`n`. The inverse of the map sends `m ↦ (m/n * p : add_circle p)` where `m` is coprime to `n` and
+satisfies `0 ≤ m < n`. -/
+def setAddOrderOfEquiv {n : ℕ} (hn : 0 < n) :
+    { u : AddCircle p | addOrderOf u = n } ≃ { m | m < n ∧ m.gcd n = 1 } :=
+  Equiv.symm <|
+    Equiv.ofBijective (fun m => ⟨↑((m : 𝕜) / n * p), addOrderOf_div_of_gcd_eq_one hn m.Prop.2⟩)
+      (by
+        refine' ⟨fun m₁ m₂ h => Subtype.ext _, fun u => _⟩
+        · simp_rw [Subtype.ext_iff, Subtype.coe_mk] at h
+          rw [← sub_eq_zero, ← coe_sub, ← sub_mul, ← sub_div, coe_coe, coe_coe, ← Int.cast_ofNat m₁,
+            ← Int.cast_ofNat m₂, ← Int.cast_sub, coe_eq_zero_iff] at h
+          obtain ⟨m, hm⟩ := h
+          rw [← mul_div_right_comm, eq_div_iff, mul_comm, ← zsmul_eq_mul, mul_smul_comm, ←
+            nsmul_eq_mul, ← coe_nat_zsmul, smul_smul,
+            (zsmul_strictMono_left hp.out).Injective.eq_iff, mul_comm] at hm
+          swap
+          · exact Nat.cast_ne_zero.2 hn.ne'
+          rw [← @Nat.cast_inj ℤ, ← sub_eq_zero]
+          refine' Int.eq_zero_of_abs_lt_dvd ⟨_, hm.symm⟩ (abs_sub_lt_iff.2 ⟨_, _⟩) <;>
+            apply (Int.sub_le_self _ <| Nat.cast_nonneg _).trans_lt (Nat.cast_lt.2 _)
+          exacts[m₁.2.1, m₂.2.1]
+        obtain ⟨m, hmn, hg, he⟩ := (add_order_of_eq_pos_iff hn).mp u.2
+        exact ⟨⟨m, hmn, hg⟩, Subtype.ext he⟩)
+#align add_circle.set_add_order_of_equiv AddCircle.setAddOrderOfEquiv
+
+@[simp]
+theorem card_addOrderOf_eq_totient {n : ℕ} :
+    Nat.card { u : AddCircle p // addOrderOf u = n } = n.totient :=
+  by
+  rcases n.eq_zero_or_pos with (rfl | hn)
+  · simp only [Nat.totient_zero, addOrderOf_eq_zero_iff]
+    rcases em (∃ u : AddCircle p, ¬IsOfFinAddOrder u) with (⟨u, hu⟩ | h)
+    · have : Infinite { u : AddCircle p // ¬IsOfFinAddOrder u } :=
+        by
+        erw [infinite_coe_iff]
+        exact infinite_not_isOfFinAddOrder hu
+      exact Nat.card_eq_zero_of_infinite
+    · have : IsEmpty { u : AddCircle p // ¬IsOfFinAddOrder u } := by simpa using h
+      exact Nat.card_of_isEmpty
+  · rw [← coe_set_of, Nat.card_congr (set_add_order_of_equiv p hn),
+      n.totient_eq_card_lt_and_coprime]
+    simp only [Nat.gcd_comm]
+#align add_circle.card_add_order_of_eq_totient AddCircle.card_addOrderOf_eq_totient
+
+theorem finite_setOf_add_order_eq {n : ℕ} (hn : 0 < n) :
+    { u : AddCircle p | addOrderOf u = n }.Finite :=
+  finite_coe_iff.mp <|
+    Nat.finite_of_card_ne_zero <| by
+      simpa only [coe_set_of, card_add_order_of_eq_totient p] using (Nat.totient_pos hn).ne'
+#align add_circle.finite_set_of_add_order_eq AddCircle.finite_setOf_add_order_eq
+
+end FiniteOrderPoints
+
+end LinearOrderedField
+
+variable (p : ℝ)
+
+/-- The "additive circle" `ℝ ⧸ (ℤ ∙ p)` is compact. -/
+instance compactSpace [Fact (0 < p)] : CompactSpace <| AddCircle p :=
+  by
+  rw [← isCompact_univ_iff, ← coe_image_Icc_eq p 0]
+  exact is_compact_Icc.image (AddCircle.continuous_mk' p)
+#align add_circle.compact_space AddCircle.compactSpace
+
+/-- The action on `ℝ` by right multiplication of its the subgroup `zmultiples p` (the multiples of
+`p:ℝ`) is properly discontinuous. -/
+instance : ProperlyDiscontinuousVAdd (zmultiples p).opposite ℝ :=
+  (zmultiples p).properlyDiscontinuousVAdd_opposite_of_tendsto_cofinite
+    (AddSubgroup.tendsto_zmultiples_subtype_cofinite p)
+
+/-- The "additive circle" `ℝ ⧸ (ℤ ∙ p)` is Hausdorff. -/
+instance : T2Space (AddCircle p) :=
+  t2Space_of_properlyDiscontinuousVAdd_of_t2Space
+
+/-- The "additive circle" `ℝ ⧸ (ℤ ∙ p)` is normal. -/
+instance [Fact (0 < p)] : NormalSpace (AddCircle p) :=
+  normalOfCompactT2
+
+/-- The "additive circle" `ℝ ⧸ (ℤ ∙ p)` is second-countable. -/
+instance : SecondCountableTopology (AddCircle p) :=
+  QuotientAddGroup.secondCountableTopology
+
+end AddCircle
+
+attribute [local instance] Real.fact_zero_lt_one
+
+/- ./././Mathport/Syntax/Translate/Command.lean:328:31: unsupported: @[derive] abbrev -/
+/-- The unit circle `ℝ ⧸ ℤ`. -/
+abbrev UnitAddCircle :=
+  AddCircle (1 : ℝ)
+#align unit_add_circle UnitAddCircle
+
+section IdentifyIccEnds
+
+/-! This section proves that for any `a`, the natural map from `[a, a + p] ⊂ 𝕜` to `add_circle p`
+gives an identification of `add_circle p`, as a topological space, with the quotient of `[a, a + p]`
+by the equivalence relation identifying the endpoints. -/
+
+
+namespace AddCircle
+
+variable [LinearOrderedAddCommGroup 𝕜] [TopologicalSpace 𝕜] [OrderTopology 𝕜] (p a : 𝕜)
+  [hp : Fact (0 < p)]
+
+include hp
+
+-- mathport name: expr𝕋
+local notation "𝕋" => AddCircle p
+
+/-- The relation identifying the endpoints of `Icc a (a + p)`. -/
+inductive EndpointIdent : Icc a (a + p) → Icc a (a + p) → Prop
+  |
+  mk :
+    endpoint_ident ⟨a, left_mem_Icc.mpr <| le_add_of_nonneg_right hp.out.le⟩
+      ⟨a + p, right_mem_Icc.mpr <| le_add_of_nonneg_right hp.out.le⟩
+#align add_circle.endpoint_ident AddCircle.EndpointIdent
+
+variable [Archimedean 𝕜]
+
+/-- The equivalence between `add_circle p` and the quotient of `[a, a + p]` by the relation
+identifying the endpoints. -/
+def equivIccQuot : 𝕋 ≃ Quot (EndpointIdent p a)
+    where
+  toFun x := Quot.mk _ <| inclusion Ico_subset_Icc_self (equivIco _ _ x)
+  invFun x :=
+    Quot.liftOn x coe <| by
+      rintro _ _ ⟨_⟩
+      exact (coe_add_period p a).symm
+  left_inv := (equivIco p a).symm_apply_apply
+  right_inv :=
+    Quot.ind <| by
+      rintro ⟨x, hx⟩
+      have := _
+      rcases ne_or_eq x (a + p) with (h | rfl)
+      · revert x
+        exact this
+      · rw [← Quot.sound endpoint_ident.mk]
+        exact this _ _ (lt_add_of_pos_right a hp.out).Ne
+      intro x hx h
+      congr
+      ext1
+      apply congr_arg Subtype.val ((equiv_Ico p a).right_inv ⟨x, hx.1, hx.2.lt_of_ne h⟩)
+#align add_circle.equiv_Icc_quot AddCircle.equivIccQuot
+
+theorem equivIccQuot_comp_mk_eq_toIcoMod :
+    equivIccQuot p a ∘ Quotient.mk'' = fun x =>
+      Quot.mk _ ⟨toIcoMod hp.out a x, Ico_subset_Icc_self <| toIcoMod_mem_Ico _ _ x⟩ :=
+  rfl
+#align add_circle.equiv_Icc_quot_comp_mk_eq_to_Ico_mod AddCircle.equivIccQuot_comp_mk_eq_toIcoMod
+
+theorem equivIccQuot_comp_mk_eq_toIocMod :
+    equivIccQuot p a ∘ Quotient.mk'' = fun x =>
+      Quot.mk _ ⟨toIocMod hp.out a x, Ioc_subset_Icc_self <| toIocMod_mem_Ioc _ _ x⟩ :=
+  by
+  rw [equiv_Icc_quot_comp_mk_eq_to_Ico_mod]; funext
+  by_cases a ≡ x [PMOD p]
+  · simp_rw [(modeq_iff_to_Ico_mod_eq_left hp.out).1 h, (modeq_iff_to_Ioc_mod_eq_right hp.out).1 h]
+    exact Quot.sound endpoint_ident.mk
+  · simp_rw [(not_modeq_iff_to_Ico_mod_eq_to_Ioc_mod hp.out).1 h]
+#align add_circle.equiv_Icc_quot_comp_mk_eq_to_Ioc_mod AddCircle.equivIccQuot_comp_mk_eq_toIocMod
+
+/-- The natural map from `[a, a + p] ⊂ 𝕜` with endpoints identified to `𝕜 / ℤ • p`, as a
+homeomorphism of topological spaces. -/
+def homeoIccQuot : 𝕋 ≃ₜ Quot (EndpointIdent p a)
+    where
+  toEquiv := equivIccQuot p a
+  continuous_toFun :=
+    by
+    simp_rw [quotient_map_quotient_mk.continuous_iff, continuous_iff_continuousAt,
+      continuousAt_iff_continuous_left_right]
+    intro x; constructor
+    on_goal 1 => erw [equiv_Icc_quot_comp_mk_eq_to_Ioc_mod]
+    on_goal 2 => erw [equiv_Icc_quot_comp_mk_eq_to_Ico_mod]
+    all_goals
+      apply continuous_quot_mk.continuous_at.comp_continuous_within_at
+      rw [inducing_coe.continuous_within_at_iff]
+    · apply continuous_left_toIocMod
+    · apply continuous_right_toIcoMod
+  continuous_invFun :=
+    continuous_quot_lift _ ((AddCircle.continuous_mk' p).comp continuous_subtype_val)
+#align add_circle.homeo_Icc_quot AddCircle.homeoIccQuot
+
+/-! We now show that a continuous function on `[a, a + p]` satisfying `f a = f (a + p)` is the
+pullback of a continuous function on `add_circle p`. -/
+
+
+variable {p a}
+
+theorem liftIco_eq_lift_Icc {f : 𝕜 → B} (h : f a = f (a + p)) :
+    liftIco p a f =
+      Quot.lift (restrict (Icc a <| a + p) f)
+          (by
+            rintro _ _ ⟨_⟩
+            exact h) ∘
+        equivIccQuot p a :=
+  rfl
+#align add_circle.lift_Ico_eq_lift_Icc AddCircle.liftIco_eq_lift_Icc
+
+theorem liftIco_continuous [TopologicalSpace B] {f : 𝕜 → B} (hf : f a = f (a + p))
+    (hc : ContinuousOn f <| Icc a (a + p)) : Continuous (liftIco p a f) :=
+  by
+  rw [lift_Ico_eq_lift_Icc hf]
+  refine' Continuous.comp _ (homeo_Icc_quot p a).continuous_toFun
+  exact continuous_coinduced_dom.mpr (continuous_on_iff_continuous_restrict.mp hc)
+#align add_circle.lift_Ico_continuous AddCircle.liftIco_continuous
+
+section ZeroBased
+
+theorem liftIco_zero_coe_apply {f : 𝕜 → B} {x : 𝕜} (hx : x ∈ Ico 0 p) : liftIco p 0 f ↑x = f x :=
+  liftIco_coe_apply (by rwa [zero_add])
+#align add_circle.lift_Ico_zero_coe_apply AddCircle.liftIco_zero_coe_apply
+
+theorem liftIco_zero_continuous [TopologicalSpace B] {f : 𝕜 → B} (hf : f 0 = f p)
+    (hc : ContinuousOn f <| Icc 0 p) : Continuous (liftIco p 0 f) :=
+  liftIco_continuous (by rwa [zero_add] : f 0 = f (0 + p)) (by rwa [zero_add])
+#align add_circle.lift_Ico_zero_continuous AddCircle.liftIco_zero_continuous
+
+end ZeroBased
+
+end AddCircle
+
+end IdentifyIccEnds
+

--- a/Mathlib/Topology/Instances/AddCircle.lean
+++ b/Mathlib/Topology/Instances/AddCircle.lean
@@ -244,8 +244,8 @@ theorem coe_eq_coe_iff_of_mem_Ico {x y : 𝕜} (hx : x ∈ Ico a (a + p)) (hy : 
   exact h
 #align add_circle.coe_eq_coe_iff_of_mem_Ico AddCircle.coe_eq_coe_iff_of_mem_Ico
 
-theorem liftIco_coe_apply {f : 𝕜 → B} {x : 𝕜} (hx : x ∈ Ico a (a + p)) : liftIco p a f ↑x = f x :=
-  by
+theorem liftIco_coe_apply {f : 𝕜 → B} {x : 𝕜} (hx : x ∈ Ico a (a + p)) :
+  liftIco p a f ↑x = f x := by
   have : (equivIco p a) x = ⟨x, hx⟩ := by
     rw [Equiv.apply_eq_iff_eq_symm_apply]
     rfl
@@ -253,8 +253,8 @@ theorem liftIco_coe_apply {f : 𝕜 → B} {x : 𝕜} (hx : x ∈ Ico a (a + p))
   rfl
 #align add_circle.lift_Ico_coe_apply AddCircle.liftIco_coe_apply
 
-theorem liftIoc_coe_apply {f : 𝕜 → B} {x : 𝕜} (hx : x ∈ Ioc a (a + p)) : liftIoc p a f ↑x = f x :=
-  by
+theorem liftIoc_coe_apply {f : 𝕜 → B} {x : 𝕜} (hx : x ∈ Ioc a (a + p)) :
+  liftIoc p a f ↑x = f x := by
   have : (equivIoc p a) x = ⟨x, hx⟩ := by
     rw [Equiv.apply_eq_iff_eq_symm_apply]
     rfl

--- a/Mathlib/Topology/Instances/AddCircle.lean
+++ b/Mathlib/Topology/Instances/AddCircle.lean
@@ -343,12 +343,16 @@ section FloorRing
 
 variable [FloorRing 𝕜]
 
+-- Porting note: fails to find `Archimedean 𝕜`
+set_option synthInstance.etaExperiment true in
 @[simp]
 theorem coe_equivIco_mk_apply (x : 𝕜) :
     (equivIco p 0 <| QuotientAddGroup.mk x : 𝕜) = Int.fract (x / p) * p :=
   toIcoMod_eq_fract_mul _ x
 #align add_circle.coe_equiv_Ico_mk_apply AddCircle.coe_equivIco_mk_apply
 
+-- Porting note: fails to find `Archimedean 𝕜`
+set_option synthInstance.etaExperiment true in
 instance : DivisibleBy (AddCircle p) ℤ where
   div x n := (↑((n : 𝕜)⁻¹ * (equivIco p 0 x : 𝕜)) : AddCircle p)
   div_zero x := by
@@ -606,14 +610,16 @@ homeomorphism of topological spaces. -/
 def homeoIccQuot : 𝕋 ≃ₜ Quot (EndpointIdent p a) where
   toEquiv := equivIccQuot p a
   continuous_toFun := by
-    simp_rw [quotientMap_quotient_mk'.continuous_iff, continuous_iff_continuousAt,
+    -- Porting note: was `simp_rw`
+    rw [quotientMap_quotient_mk'.continuous_iff]
+    simp_rw [continuous_iff_continuousAt,
       continuousAt_iff_continuous_left_right]
     intro x; constructor
-    on_goal 1 => erw [equiv_Icc_quot_comp_mk_eq_to_Ioc_mod]
-    on_goal 2 => erw [equiv_Icc_quot_comp_mk_eq_to_Ico_mod]
+    on_goal 1 => erw [equivIccQuot_comp_mk_eq_toIocMod]
+    on_goal 2 => erw [equivIccQuot_comp_mk_eq_toIcoMod]
     all_goals
-      apply continuous_quot_mk.continuous_at.comp_continuous_within_at
-      rw [inducing_coe.continuous_within_at_iff]
+      apply continuous_quot_mk.continuousAt.comp_continuousWithinAt
+      rw [inducing_subtype_val.continuousWithinAt_iff]
     · apply continuous_left_toIocMod
     · apply continuous_right_toIcoMod
   continuous_invFun :=

--- a/Mathlib/Topology/Instances/AddCircle.lean
+++ b/Mathlib/Topology/Instances/AddCircle.lean
@@ -87,8 +87,8 @@ theorem continuous_left_toIocMod : ContinuousWithinAt (toIocMod hp a) (Iic x) x 
   rw [(funext fun y => Eq.trans (by rw [neg_neg]) <| toIocMod_neg _ _ _ :
       toIocMod hp a = (fun x => p - x) ∘ toIcoMod hp (-a) ∘ Neg.neg)]
   exact
-    (continuous_sub_left _).ContinuousAt.comp_continuousWithinAt <|
-      (continuous_right_toIcoMod _ _ _).comp continuous_neg.continuous_within_at fun y => neg_le_neg
+    (continuous_sub_left _).continuousAt.comp_continuousWithinAt <|
+      (continuous_right_toIcoMod _ _ _).comp continuous_neg.continuousWithinAt fun y => neg_le_neg
 #align continuous_left_to_Ioc_mod continuous_left_toIocMod
 
 variable {x} (hx : (x : 𝕜 ⧸ zmultiples p) ≠ a)
@@ -121,7 +121,7 @@ end Continuity
 
 /- ./././Mathport/Syntax/Translate/Command.lean:42:9: unsupported derive handler has_coe_t[has_coe_t] 𝕜 -/
 /-- The "additive circle": `𝕜 ⧸ (ℤ ∙ p)`. See also `circle` and `real.angle`. -/
-@[nolint unused_arguments]
+@[nolint unusedArguments]
 def AddCircle [LinearOrderedAddCommGroup 𝕜] [TopologicalSpace 𝕜] [OrderTopology 𝕜] (p : 𝕜) :=
   𝕜 ⧸ zmultiples p deriving AddCommGroup, TopologicalSpace, TopologicalAddGroup, Inhabited,
   «./././Mathport/Syntax/Translate/Command.lean:42:9: unsupported derive handler has_coe_t[has_coe_t] 𝕜»
@@ -177,17 +177,13 @@ theorem coe_add_period (x : 𝕜) : ((x + p : 𝕜) : AddCircle p) = x := by
   rw [coe_add, ← eq_sub_iff_add_eq', sub_self, coe_period]
 #align add_circle.coe_add_period AddCircle.coe_add_period
 
-@[continuity, nolint unused_arguments]
+@[continuity, nolint unusedArguments]
 protected theorem continuous_mk' :
     Continuous (QuotientAddGroup.mk' (zmultiples p) : 𝕜 → AddCircle p) :=
   continuous_coinduced_rng
 #align add_circle.continuous_mk' AddCircle.continuous_mk'
 
-variable [hp : Fact (0 < p)]
-
-include hp
-
-variable (a : 𝕜) [Archimedean 𝕜]
+variable [hp : Fact (0 < p)] (a : 𝕜) [Archimedean 𝕜]
 
 instance : CircularOrder (AddCircle p) :=
   quotientAddGroup.circularOrder
@@ -261,8 +257,6 @@ theorem continuous_equivIoc_symm : Continuous (equivIoc p a).symm :=
 
 variable {x : AddCircle p} (hx : x ≠ a)
 
-include hx
-
 theorem continuousAt_equivIco : ContinuousAt (equivIco p a) x := by
   induction x using QuotientAddGroup.induction_on'
   rw [ContinuousAt, Filter.Tendsto, QuotientAddGroup.nhds_eq, Filter.map_map]
@@ -327,8 +321,6 @@ theorem equivAddCircle_symm_apply_mk (hp : p ≠ 0) (hq : q ≠ 0) (x : 𝕜) :
 
 variable [hp : Fact (0 < p)]
 
-include hp
-
 section FloorRing
 
 variable [FloorRing 𝕜]
@@ -384,7 +376,7 @@ variable {p}
 
 theorem addOrderOf_div_of_gcd_eq_one {m n : ℕ} (hn : 0 < n) (h : m.gcd n = 1) :
     addOrderOf (↑(↑m / ↑n * p) : AddCircle p) = n := by
-  convert gcd_mul_add_order_of_div_eq p m hn
+  convert gcd_mul_addOrderOf_div_eq p m hn
   rw [h, one_mul]
 #align add_circle.add_order_of_div_of_gcd_eq_one AddCircle.addOrderOf_div_of_gcd_eq_one
 
@@ -392,17 +384,17 @@ theorem addOrderOf_div_of_gcd_eq_one' {m : ℤ} {n : ℕ} (hn : 0 < n) (h : m.na
     addOrderOf (↑(↑m / ↑n * p) : AddCircle p) = n := by
   induction m
   · simp only [Int.ofNat_eq_coe, Int.cast_ofNat, Int.natAbs_ofNat] at h⊢
-    exact add_order_of_div_of_gcd_eq_one hn h
+    exact addOrderOf_div_of_gcd_eq_one hn h
   · simp only [Int.cast_negSucc, neg_div, neg_mul, coe_neg, addOrderOf_neg]
-    exact add_order_of_div_of_gcd_eq_one hn h
+    exact addOrderOf_div_of_gcd_eq_one hn h
 #align add_circle.add_order_of_div_of_gcd_eq_one' AddCircle.addOrderOf_div_of_gcd_eq_one'
 
 theorem addOrderOf_coe_rat {q : ℚ} : addOrderOf (↑(↑q * p) : AddCircle p) = q.den := by
-  have : (↑(q.denom : ℤ) : 𝕜) ≠ 0 := by
+  have : (↑(q.den : ℤ) : 𝕜) ≠ 0 := by
     norm_cast
     exact q.pos.ne.symm
   rw [← @Rat.num_den q, Rat.cast_mk_of_ne_zero _ _ this, Int.cast_ofNat, Rat.num_den,
-    add_order_of_div_of_gcd_eq_one' q.pos q.cop]
+    addOrderOf_div_of_gcd_eq_one' q.pos q.cop]
   infer_instance
 #align add_circle.add_order_of_coe_rat AddCircle.addOrderOf_coe_rat
 
@@ -476,7 +468,7 @@ theorem card_addOrderOf_eq_totient {n : ℕ} :
       exact Nat.card_eq_zero_of_infinite
     · have : IsEmpty { u : AddCircle p // ¬IsOfFinAddOrder u } := by simpa using h
       exact Nat.card_of_isEmpty
-  · rw [← coe_set_of, Nat.card_congr (set_add_order_of_equiv p hn),
+  · rw [← coe_setOf, Nat.card_congr (setAddOrderOfEquiv p hn),
       n.totient_eq_card_lt_and_coprime]
     simp only [Nat.gcd_comm]
 #align add_circle.card_add_order_of_eq_totient AddCircle.card_addOrderOf_eq_totient
@@ -485,7 +477,7 @@ theorem finite_setOf_add_order_eq {n : ℕ} (hn : 0 < n) :
     { u : AddCircle p | addOrderOf u = n }.Finite :=
   finite_coe_iff.mp <|
     Nat.finite_of_card_ne_zero <| by
-      simpa only [coe_set_of, card_add_order_of_eq_totient p] using (Nat.totient_pos hn).ne'
+      simpa only [coe_setOf, card_addOrderOf_eq_totient p] using (Nat.totient_pos hn).ne'
 #align add_circle.finite_set_of_add_order_eq AddCircle.finite_setOf_add_order_eq
 
 end FiniteOrderPoints
@@ -540,9 +532,6 @@ namespace AddCircle
 variable [LinearOrderedAddCommGroup 𝕜] [TopologicalSpace 𝕜] [OrderTopology 𝕜] (p a : 𝕜)
   [hp : Fact (0 < p)]
 
-include hp
-
--- mathport name: expr𝕋
 local notation "𝕋" => AddCircle p
 
 /-- The relation identifying the endpoints of `Icc a (a + p)`. -/
@@ -560,7 +549,7 @@ identifying the endpoints. -/
 def equivIccQuot : 𝕋 ≃ Quot (EndpointIdent p a) where
   toFun x := Quot.mk _ <| inclusion Ico_subset_Icc_self (equivIco _ _ x)
   invFun x :=
-    Quot.liftOn x coe <| by
+    Quot.liftOn x (↑) <| by
       rintro _ _ ⟨_⟩
       exact (coe_add_period p a).symm
   left_inv := (equivIco p a).symm_apply_apply
@@ -632,7 +621,7 @@ theorem liftIco_eq_lift_Icc {f : 𝕜 → B} (h : f a = f (a + p)) :
 
 theorem liftIco_continuous [TopologicalSpace B] {f : 𝕜 → B} (hf : f a = f (a + p))
     (hc : ContinuousOn f <| Icc a (a + p)) : Continuous (liftIco p a f) := by
-  rw [lift_Ico_eq_lift_Icc hf]
+  rw [liftIco_eq_lift_Icc hf]
   refine' Continuous.comp _ (homeo_Icc_quot p a).continuous_toFun
   exact continuous_coinduced_dom.mpr (continuous_on_iff_continuous_restrict.mp hc)
 #align add_circle.lift_Ico_continuous AddCircle.liftIco_continuous
@@ -653,4 +642,3 @@ end ZeroBased
 end AddCircle
 
 end IdentifyIccEnds
-


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

TODO:

- [x] `DivisibleBy (AddCircle p) ℤ` fails quickly ("failed to synthesize instance `Archimedean 𝕜`") without `etaExperiment`; fails slowly ("failed to synthesize `Zero ℤ`") with `etaExperiment`
- [x] `addOrderOf_eq_pos_iff` uses a questionable trick with `have he := _; ... do something with he ...` which no longer works (not with `?_` either)
- [x] `equivIccQuot` uses the same trick


[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
