### PR TITLE
[Merged by Bors] - fix: correct names of `LinearOrder` decidable fields

### DIFF
--- a/Mathlib/Algebra/Order/Field/Basic.lean
+++ b/Mathlib/Algebra/Order/Field/Basic.lean
@@ -574,7 +574,7 @@ theorem exists_pos_lt_mul {a : α} (h : 0 < a) (b : α) : ∃ c : α, 0 < c ∧ 
 
 theorem Monotone.div_const {β : Type _} [Preorder β] {f : β → α} (hf : Monotone f) {c : α}
     (hc : 0 ≤ c) : Monotone fun x => f x / c := by
-  haveI := @LinearOrder.decidable_le α _
+  haveI := @LinearOrder.decidableLE α _
   simpa only [div_eq_mul_inv] using (monotone_mul_right_of_nonneg (inv_nonneg.2 hc)).comp hf
 #align monotone.div_const Monotone.div_const
 

--- a/Mathlib/Algebra/Order/Group/Defs.lean
+++ b/Mathlib/Algebra/Order/Group/Defs.lean
@@ -1223,7 +1223,7 @@ def mkOfPositiveCone {α : Type _} [AddCommGroup α] (C : TotalPositiveCone α) 
   { OrderedAddCommGroup.mkOfPositiveCone C.toPositiveCone with
     -- Porting note: was `C.nonneg_total (b - a)`
     le_total := fun a b => by simpa [neg_sub] using C.nonneg_total (b - a)
-    decidable_le := fun a b => C.nonnegDecidable _ }
+    decidableLE := fun a b => C.nonnegDecidable _ }
 #align linear_ordered_add_comm_group.mk_of_positive_cone LinearOrderedAddCommGroup.mkOfPositiveCone
 
 end LinearOrderedAddCommGroup

--- a/Mathlib/Algebra/Order/Ring/Defs.lean
+++ b/Mathlib/Algebra/Order/Ring/Defs.lean
@@ -794,7 +794,7 @@ instance (priority := 200) LinearOrderedSemiring.toMulPosReflectLT : MulPosRefle
   ⟨fun a _ _ => (monotone_mul_right_of_nonneg a.2).reflect_lt⟩
 #align linear_ordered_semiring.to_mul_pos_reflect_lt LinearOrderedSemiring.toMulPosReflectLT
 
-attribute [local instance] LinearOrderedSemiring.decidable_le LinearOrderedSemiring.decidable_lt
+attribute [local instance] LinearOrderedSemiring.decidableLE LinearOrderedSemiring.decidableLT
 
 theorem nonneg_and_nonneg_or_nonpos_and_nonpos_of_mul_nnonneg (hab : 0 ≤ a * b) :
     0 ≤ a ∧ 0 ≤ b ∨ a ≤ 0 ∧ b ≤ 0 := by
@@ -1013,7 +1013,7 @@ section LinearOrderedRing
 
 variable [LinearOrderedRing α] {a b c : α}
 
-attribute [local instance] LinearOrderedRing.decidable_le LinearOrderedRing.decidable_lt
+attribute [local instance] LinearOrderedRing.decidableLE LinearOrderedRing.decidableLT
 
 -- see Note [lower instance priority]
 instance (priority := 100) LinearOrderedRing.toLinearOrderedSemiring : LinearOrderedSemiring α :=

--- a/Mathlib/Algebra/Tropical/Basic.lean
+++ b/Mathlib/Algebra/Tropical/Basic.lean
@@ -291,7 +291,7 @@ theorem trop_add_def (x y : Tropical R) : x + y = trop (min (untrop x) (untrop y
 instance : LinearOrder (Tropical R) :=
   { instPartialOrderTropical with
     le_total := fun a b => le_total (untrop a) (untrop b)
-    decidable_le := Tropical.decidableLE
+    decidableLE := Tropical.decidableLE
     max := fun a b => trop (max (untrop a) (untrop b))
     max_def := fun a b => untrop_injective (by simp [max_def]; split_ifs <;> simp)
     min := (· + ·)

--- a/Mathlib/Analysis/Convex/Caratheodory.lean
+++ b/Mathlib/Analysis/Convex/Caratheodory.lean
@@ -62,7 +62,7 @@ theorem mem_convexHull_erase [DecidableEq E] {t : Finset E} (h : ¬AffineIndepen
   obtain ⟨g, gcombo, gsum, gpos⟩ := exists_nontrivial_relation_sum_zero_of_not_affine_ind h
   replace gpos := exists_pos_of_sum_zero_of_exists_nonzero g gsum gpos
   clear h
-  let s := @Finset.filter _ (fun z => 0 < g z) (fun _ => LinearOrder.decidable_lt _ _) t
+  let s := @Finset.filter _ (fun z => 0 < g z) (fun _ => LinearOrder.decidableLT _ _) t
   obtain ⟨i₀, mem, w⟩ : ∃ i₀ ∈ s, ∀ i ∈ s, f i₀ / g i₀ ≤ f i / g i := by
     apply s.exists_min_image fun z => f z / g z
     obtain ⟨x, hx, hgx⟩ : ∃ x ∈ t, 0 < g x := gpos

--- a/Mathlib/Combinatorics/Colex.lean
+++ b/Mathlib/Combinatorics/Colex.lean
@@ -221,11 +221,11 @@ instance [LinearOrder α] : LinearOrder (Finset.Colex α) :=
     le_total := fun A B =>
       (lt_trichotomy A B).elim3 (Or.inl ∘ Or.inl) (Or.inl ∘ Or.inr) (Or.inr ∘ Or.inl)
     -- Porting note: we must give some hints for instances
-    decidable_le := by
+    decidableLE := by
       letI : DecidableEq (Finset.Colex α) := inferInstanceAs (DecidableEq (Finset α))
       exact fun A B => inferInstanceAs (Decidable (A < B ∨ A = B))
-    decidable_lt := inferInstance
-    decidable_eq := inferInstanceAs (DecidableEq (Finset α))
+    decidableLT := inferInstance
+    decidableEq := inferInstanceAs (DecidableEq (Finset α))
     lt_iff_le_not_le := fun A B => by
       constructor
       · intro t

--- a/Mathlib/Combinatorics/SetFamily/Compression/UV.lean
+++ b/Mathlib/Combinatorics/SetFamily/Compression/UV.lean
@@ -82,7 +82,7 @@ section GeneralizedBooleanAlgebra
 variable [GeneralizedBooleanAlgebra α] [DecidableRel (@Disjoint α _ _)]
   [DecidableRel ((· ≤ ·) : α → α → Prop)] {s : Finset α} {u v a b : α}
 
-attribute [local instance] decidableEq_of_decidableLE
+attribute [local instance] decidableEqOfDecidableLE
 
 /-- To UV-compress `a`, if it doesn't touch `U` and does contain `V`, we remove `V` and
 put `U` in. We'll only really use this when `|U| = |V|` and `U ∩ V = ∅`. -/

--- a/Mathlib/Data/Bool/Basic.lean
+++ b/Mathlib/Data/Bool/Basic.lean
@@ -323,8 +323,8 @@ instance linearOrder : LinearOrder Bool where
   le_trans := by unfold LE.le; decide
   le_antisymm := by unfold LE.le Preorder.toLE; decide
   le_total := by unfold LE.le Preorder.toLE PartialOrder.toPreorder; decide
-  decidable_le := by unfold LE.le Preorder.toLE PartialOrder.toPreorder; exact inferInstance
-  decidable_eq := inferInstance
+  decidableLE := by unfold LE.le Preorder.toLE PartialOrder.toPreorder; exact inferInstance
+  decidableEq := inferInstance
   max := or
   max_def := λ a b => by cases a <;> cases b <;> decide
   min := and

--- a/Mathlib/Data/Char.lean
+++ b/Mathlib/Data/Char.lean
@@ -41,7 +41,7 @@ instance : LinearOrder Char where
   le_total := fun _ _ => @le_total ℕ _ _ _
   min := fun a b => if a ≤ b then a else b
   max := fun a b => if a ≤ b then b else a
-  decidable_le := inferInstance
+  decidableLE := inferInstance
 
 theorem Char.ofNat_toNat {c : Char} (h : isValidCharNat c.toNat) : Char.ofNat c.toNat = c := by
   rw [Char.ofNat, dif_pos h]

--- a/Mathlib/Data/Dfinsupp/Lex.lean
+++ b/Mathlib/Data/Dfinsupp/Lex.lean
@@ -121,9 +121,9 @@ instance : DecidableEq (Lex (Π₀ i, α i)) :=
 instance Lex.linearOrder : LinearOrder (Lex (Π₀ i, α i)) :=
   { Lex.partialOrder with
     le_total := lt_trichotomy_rec (fun h ↦ Or.inl h.le) (fun h ↦ Or.inl h.le) fun h ↦ Or.inr h.le
-    decidable_lt := decidableLT
-    decidable_le := decidableLE
-    decidable_eq := inferInstance }
+    decidableLT := decidableLT
+    decidableLE := decidableLE
+    decidableEq := inferInstance }
 #align dfinsupp.lex.linear_order Dfinsupp.Lex.linearOrder
 
 end LinearOrder

--- a/Mathlib/Data/Nat/PartENat.lean
+++ b/Mathlib/Data/Nat/PartENat.lean
@@ -411,7 +411,7 @@ instance isTotal: IsTotal PartENat (· ≤ ·) where
 noncomputable instance linearOrder : LinearOrder PartENat :=
   { PartENat.partialOrder with
     le_total := IsTotal.total
-    decidable_le := Classical.decRel _
+    decidableLE := Classical.decRel _
     max := (· ⊔ ·)
     -- Porting note: was `max_def := @sup_eq_maxDefault _ _ (id _) _ }`
     max_def := fun a b => by

--- a/Mathlib/Data/Num/Lemmas.lean
+++ b/Mathlib/Data/Num/Lemmas.lean
@@ -466,9 +466,9 @@ instance linearOrderedSemiring : LinearOrderedSemiring Num :=
       intro a b c
       transfer_rw
       apply mul_lt_mul_of_pos_right
-    decidable_lt := Num.decidableLT
-    decidable_le := Num.decidableLE
-    decidable_eq := instDecidableEqNum
+    decidableLT := Num.decidableLT
+    decidableLE := Num.decidableLE
+    decidableEq := instDecidableEqNum
     exists_pair_ne := ⟨0, 1, by decide⟩ }
 #align num.linear_ordered_semiring Num.linearOrderedSemiring
 
@@ -646,9 +646,9 @@ instance linearOrder : LinearOrder PosNum where
     intro a b
     transfer_rw
     apply le_total
-  decidable_lt := by infer_instance
-  decidable_le := by infer_instance
-  decidable_eq := by infer_instance
+  decidableLT := by infer_instance
+  decidableLE := by infer_instance
+  decidableEq := by infer_instance
 #align pos_num.linear_order PosNum.linearOrder
 
 @[simp]
@@ -1462,9 +1462,9 @@ instance linearOrder : LinearOrder ZNum where
     intro a b
     transfer_rw
     apply le_total
-  decidable_eq := instDecidableEqZNum
-  decidable_le := ZNum.decidableLE
-  decidable_lt := ZNum.decidableLT
+  decidableEq := instDecidableEqZNum
+  decidableLE := ZNum.decidableLE
+  decidableLT := ZNum.decidableLT
 #align znum.linear_order ZNum.linearOrder
 
 instance addCommGroup : AddCommGroup ZNum where

--- a/Mathlib/Data/PSigma/Order.lean
+++ b/Mathlib/Data/PSigma/Order.lean
@@ -103,8 +103,8 @@ instance linearOrder [LinearOrder ι] [∀ i, LinearOrder (α i)] : LinearOrder 
         · exact Or.inl (Lex.right _ hab)
         · exact Or.inr (Lex.right _ hba)
       · exact Or.inr (Lex.left _ _ hji),
-    decidable_eq := PSigma.decidableEq, decidable_le := Lex.decidable _ _,
-    decidable_lt := Lex.decidable _ _ }
+    decidableEq := PSigma.decidableEq, decidableLE := Lex.decidable _ _,
+    decidableLT := Lex.decidable _ _ }
 #align psigma.lex.linear_order PSigma.Lex.linearOrder
 
 /-- The lexicographical linear order on a sigma type. -/

--- a/Mathlib/Data/Prod/Lex.lean
+++ b/Mathlib/Data/Prod/Lex.lean
@@ -148,9 +148,9 @@ instance partialOrder (α β : Type _) [PartialOrder α] [PartialOrder β] : Par
 instance linearOrder (α β : Type _) [LinearOrder α] [LinearOrder β] : LinearOrder (α ×ₗ β) :=
   { Prod.Lex.partialOrder α β with
     le_total := total_of (Prod.Lex _ _),
-    decidable_le := Prod.Lex.decidable _ _,
-    decidable_lt := Prod.Lex.decidable _ _,
-    decidable_eq := Lex.decidableEq _ _, }
+    decidableLE := Prod.Lex.decidable _ _,
+    decidableLT := Prod.Lex.decidable _ _,
+    decidableEq := Lex.decidableEq _ _, }
 #align prod.lex.linear_order Prod.Lex.linearOrder
 
 instance orderBot [PartialOrder α] [Preorder β] [OrderBot α] [OrderBot β] : OrderBot (α ×ₗ β) where

--- a/Mathlib/Data/Rat/Order.lean
+++ b/Mathlib/Data/Rat/Order.lean
@@ -196,7 +196,7 @@ instance linearOrder : LinearOrder ℚ where
   le_trans := @Rat.le_trans
   le_antisymm := @Rat.le_antisymm
   le_total := Rat.le_total
-  decidable_le _ _ := by infer_instance
+  decidableLE _ _ := by infer_instance
   lt_iff_le_not_le _ _ := by
     rw [← Rat.not_le, and_iff_right_of_imp (Rat.le_total _ _).resolve_left]
 

--- a/Mathlib/Data/Sigma/Order.lean
+++ b/Mathlib/Data/Sigma/Order.lean
@@ -183,8 +183,8 @@ instance linearOrder [LinearOrder ι] [∀ i, LinearOrder (α i)] :
     LinearOrder (Σₗ i, α i) :=
   { Lex.partialOrder with
     le_total := total_of ((Lex (· < ·)) fun _ => (· ≤ ·)),
-    decidable_eq := Sigma.instDecidableEqSigma,
-    decidable_le := Lex.decidable _ _ }
+    decidableEq := Sigma.instDecidableEqSigma,
+    decidableLE := Lex.decidable _ _ }
 #align sigma.lex.linear_order Sigma.Lex.linearOrder
 
 /-- The lexicographical linear order on a sigma type. -/

--- a/Mathlib/Data/Sign.lean
+++ b/Mathlib/Data/Sign.lean
@@ -123,8 +123,8 @@ instance : LinearOrder SignType where
   le_total a b := by cases a <;> cases b <;> first | left; constructor | right; constructor
   le_antisymm := le_antisymm
   le_trans := le_trans
-  decidable_le := Le.decidableRel
-  decidable_eq := SignType.decidableEq
+  decidableLE := Le.decidableRel
+  decidableEq := SignType.decidableEq
 
 instance : BoundedOrder SignType where
   top := 1
@@ -396,7 +396,7 @@ variable [LinearOrderedRing α] {a b : α}
 
 /- I'm not sure why this is necessary, see https://leanprover.zulipchat.com/#narrow/stream/
 113488-general/topic/type.20class.20inference.20issues/near/276937942 -/
-attribute [local instance] LinearOrderedRing.decidable_lt
+attribute [local instance] LinearOrderedRing.decidableLT
 
 theorem sign_mul (x y : α) : sign (x * y) = sign x * sign y := by
   rcases lt_trichotomy x 0 with (hx | hx | hx) <;> rcases lt_trichotomy y 0 with (hy | hy | hy) <;>
@@ -464,7 +464,7 @@ variable [LinearOrderedAddCommGroup α]
 /- I'm not sure why this is necessary, see
 https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Decidable.20vs.20decidable_rel
 -/
-attribute [local instance] LinearOrderedAddCommGroup.decidable_lt
+attribute [local instance] LinearOrderedAddCommGroup.decidableLT
 
 theorem sign_sum {ι : Type _} {s : Finset ι} {f : ι → α} (hs : s.Nonempty) (t : SignType)
     (h : ∀ i ∈ s, sign (f i) = t) : sign (∑ i in s, f i) = t := by

--- a/Mathlib/Data/String/Basic.lean
+++ b/Mathlib/Data/String/Basic.lean
@@ -192,7 +192,7 @@ instance : LinearOrder String where
   le_total a b := by
     simp only [le_iff_toList_le]
     apply le_total
-  decidable_le := String.decidableLE
+  decidableLE := String.decidableLE
   compare_eq_compareOfLessAndEq a b := by
     simp [compare, compareOfLessAndEq, toList, instLTString, List.instLTList, List.LT']
     split_ifs <;>

--- a/Mathlib/Data/Sum/Order.lean
+++ b/Mathlib/Data/Sum/Order.lean
@@ -427,8 +427,8 @@ instance partialOrder [PartialOrder α] [PartialOrder β] : PartialOrder (α ⊕
 instance linearOrder [LinearOrder α] [LinearOrder β] : LinearOrder (α ⊕ₗ β) :=
   { Lex.partialOrder with
     le_total := total_of (Lex (· ≤ ·) (· ≤ ·)),
-    decidable_le := instDecidableRelSumLex,
-    decidable_eq := instDecidableEqSum }
+    decidableLE := instDecidableRelSumLex,
+    decidableEq := instDecidableEqSum }
 #align sum.lex.linear_order Sum.Lex.linearOrder
 
 /-- The lexicographical bottom of a sum is the bottom of the left component. -/

--- a/Mathlib/GroupTheory/MonoidLocalization.lean
+++ b/Mathlib/GroupTheory/MonoidLocalization.lean
@@ -2024,8 +2024,8 @@ instance [LinearOrderedCancelCommMonoid α] {s : Submonoid α} :
       Localization.induction_on₂ a b fun _ _ => by
         simp_rw [mk_le_mk]
         exact le_total _ _
-    decidable_le := Localization.decidableLE
-    decidable_lt := Localization.decidableLT  -- porting note: was wrong in mathlib3
-    decidable_eq := Localization.decidableEq }
+    decidableLE := Localization.decidableLE
+    decidableLT := Localization.decidableLT  -- porting note: was wrong in mathlib3
+    decidableEq := Localization.decidableEq }
 
 end Localization

--- a/Mathlib/Init/Algebra/Order.lean
+++ b/Mathlib/Init/Algebra/Order.lean
@@ -236,12 +236,12 @@ class LinearOrder (α : Type u) extends PartialOrder α, Min α, Max α, Ord α 
   /-- A linear order is total. -/
   le_total (a b : α) : a ≤ b ∨ b ≤ a
   /-- In a linearly ordered type, we assume the order relations are all decidable. -/
-  decidable_le : DecidableRel (. ≤ . : α → α → Prop)
+  decidableLE : DecidableRel (. ≤ . : α → α → Prop)
   /-- In a linearly ordered type, we assume the order relations are all decidable. -/
-  decidable_eq : DecidableEq α := @decidableEqOfDecidableLE _ _ decidable_le
+  decidableEq : DecidableEq α := @decidableEqOfDecidableLE _ _ decidableLE
   /-- In a linearly ordered type, we assume the order relations are all decidable. -/
-  decidable_lt : DecidableRel (. < . : α → α → Prop) :=
-    @decidableLTOfdecidableLE _ _ decidable_le
+  decidableLT : DecidableRel (. < . : α → α → Prop) :=
+    @decidableLTOfdecidableLE _ _ decidableLE
   min := fun a b => if a ≤ b then a else b
   max := fun a b => if a ≤ b then b else a
   /-- The minimum function is equivalent to the one you get from `minOfLe`. -/

--- a/Mathlib/Init/Algebra/Order.lean
+++ b/Mathlib/Init/Algebra/Order.lean
@@ -133,7 +133,7 @@ theorem le_of_eq_or_lt {a b : α} (h : a = b ∨ a < b) : a ≤ b := match h wit
 | (Or.inl h) => le_of_eq h
 | (Or.inr h) => le_of_lt h
 
-instance decidableLTOfdecidableLE [DecidableRel (. ≤ . : α → α → Prop)] :
+instance decidableLTOfDecidableLE [DecidableRel (. ≤ . : α → α → Prop)] :
   DecidableRel (. < . : α → α → Prop)
 | a, b =>
   if hab : a ≤ b then
@@ -241,7 +241,7 @@ class LinearOrder (α : Type u) extends PartialOrder α, Min α, Max α, Ord α 
   decidableEq : DecidableEq α := @decidableEqOfDecidableLE _ _ decidableLE
   /-- In a linearly ordered type, we assume the order relations are all decidable. -/
   decidableLT : DecidableRel (. < . : α → α → Prop) :=
-    @decidableLTOfdecidableLE _ _ decidableLE
+    @decidableLTOfDecidableLE _ _ decidableLE
   min := fun a b => if a ≤ b then a else b
   max := fun a b => if a ≤ b then b else a
   /-- The minimum function is equivalent to the one you get from `minOfLe`. -/

--- a/Mathlib/Init/Algebra/Order.lean
+++ b/Mathlib/Init/Algebra/Order.lean
@@ -133,7 +133,7 @@ theorem le_of_eq_or_lt {a b : α} (h : a = b ∨ a < b) : a ≤ b := match h wit
 | (Or.inl h) => le_of_eq h
 | (Or.inr h) => le_of_lt h
 
-instance decidableLT_of_decidableLE [DecidableRel (. ≤ . : α → α → Prop)] :
+instance decidableLTOfdecidableLE [DecidableRel (. ≤ . : α → α → Prop)] :
   DecidableRel (. < . : α → α → Prop)
 | a, b =>
   if hab : a ≤ b then
@@ -167,7 +167,7 @@ theorem le_antisymm_iff {a b : α} : a = b ↔ a ≤ b ∧ b ≤ a :=
 theorem lt_of_le_of_ne {a b : α} : a ≤ b → a ≠ b → a < b :=
 λ h₁ h₂ => lt_of_le_not_le h₁ $ mt (le_antisymm h₁) h₂
 
-instance decidableEq_of_decidableLE [DecidableRel (. ≤ . : α → α → Prop)] :
+instance decidableEqOfDecidableLE [DecidableRel (. ≤ . : α → α → Prop)] :
   DecidableEq α
 | a, b =>
   if hab : a ≤ b then
@@ -238,10 +238,10 @@ class LinearOrder (α : Type u) extends PartialOrder α, Min α, Max α, Ord α 
   /-- In a linearly ordered type, we assume the order relations are all decidable. -/
   decidable_le : DecidableRel (. ≤ . : α → α → Prop)
   /-- In a linearly ordered type, we assume the order relations are all decidable. -/
-  decidable_eq : DecidableEq α := @decidableEq_of_decidableLE _ _ decidable_le
+  decidable_eq : DecidableEq α := @decidableEqOfDecidableLE _ _ decidable_le
   /-- In a linearly ordered type, we assume the order relations are all decidable. -/
   decidable_lt : DecidableRel (. < . : α → α → Prop) :=
-    @decidableLT_of_decidableLE _ _ decidable_le
+    @decidableLTOfdecidableLE _ _ decidable_le
   min := fun a b => if a ≤ b then a else b
   max := fun a b => if a ≤ b then b else a
   /-- The minimum function is equivalent to the one you get from `minOfLe`. -/
@@ -255,7 +255,7 @@ class LinearOrder (α : Type u) extends PartialOrder α, Min α, Max α, Ord α 
 
 variable [LinearOrder α]
 
-attribute [local instance] LinearOrder.decidable_le
+attribute [local instance] LinearOrder.decidableLE
 
 theorem le_total : ∀ a b : α, a ≤ b ∨ b ≤ a :=
 LinearOrder.le_total
@@ -322,13 +322,13 @@ theorem lt_iff_not_ge (x y : α) : x < y ↔ ¬ x ≥ y :=
 @[simp] theorem not_le {a b : α} : ¬ a ≤ b ↔ b < a := (lt_iff_not_ge _ _).symm
 
 instance (a b : α) : Decidable (a < b) :=
-LinearOrder.decidable_lt a b
+LinearOrder.decidableLT a b
 
 instance (a b : α) : Decidable (a ≤ b) :=
-LinearOrder.decidable_le a b
+LinearOrder.decidableLE a b
 
 instance (a b : α) : Decidable (a = b) :=
-LinearOrder.decidable_eq a b
+LinearOrder.decidableEq a b
 
 theorem eq_or_lt_of_not_lt {a b : α} (h : ¬ a < b) : a = b ∨ b < a :=
 if h₁ : a = b then Or.inl h₁

--- a/Mathlib/Init/Data/Int/Order.lean
+++ b/Mathlib/Init/Data/Int/Order.lean
@@ -51,9 +51,9 @@ instance : LinearOrder ℤ where
   lt := (·<·)
   lt_iff_le_not_le := @Int.lt_iff_le_not_le
   le_total := Int.le_total
-  decidable_eq := by infer_instance
-  decidable_le := by infer_instance
-  decidable_lt := by infer_instance
+  decidableEq := by infer_instance
+  decidableLE := by infer_instance
+  decidableLT := by infer_instance
 
 #align int.eq_nat_abs_of_zero_le Int.eq_natAbs_of_zero_le
 #align int.le_nat_abs Int.le_natAbs

--- a/Mathlib/Init/Data/Nat/Lemmas.lean
+++ b/Mathlib/Init/Data/Nat/Lemmas.lean
@@ -31,9 +31,9 @@ instance linearOrder : LinearOrder ℕ where
   le_total := @Nat.le_total
   lt := Nat.lt
   lt_iff_le_not_le := @Nat.lt_iff_le_not_le
-  decidable_lt := inferInstance
-  decidable_le := inferInstance
-  decidable_eq := inferInstance
+  decidableLT := inferInstance
+  decidableLE := inferInstance
+  decidableEq := inferInstance
 
 /- TODO(Leo): sub + inequalities -/
 

--- a/Mathlib/LinearAlgebra/AffineSpace/Independent.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Independent.lean
@@ -723,7 +723,7 @@ variable {k : Type _} {V : Type _} {P : Type _} [LinearOrderedRing k] [AddCommGr
 
 variable [Module k V] [AffineSpace V P] {ι : Type _}
 
-attribute [local instance] LinearOrderedRing.decidable_lt
+attribute [local instance] LinearOrderedRing.decidableLT
 
 /-- Given an affinely independent family of points, suppose that an affine combination lies in
 the span of two points given as affine combinations, and suppose that, for two indices, the

--- a/Mathlib/NumberTheory/Zsqrtd/Basic.lean
+++ b/Mathlib/NumberTheory/Zsqrtd/Basic.lean
@@ -951,7 +951,7 @@ instance linearOrder : LinearOrder (ℤ√d) :=
   { Zsqrtd.preorder with
     le_antisymm := fun _ _ => Zsqrtd.le_antisymm
     le_total := Zsqrtd.le_total
-    decidable_le := Zsqrtd.decidableLE }
+    decidableLE := Zsqrtd.decidableLE }
 
 protected theorem eq_zero_or_eq_zero_of_mul_eq_zero : ∀ {a b : ℤ√d}, a * b = 0 → a = 0 ∨ b = 0
   | ⟨x, y⟩, ⟨z, w⟩, h => by

--- a/Mathlib/Order/Antisymmetrization.lean
+++ b/Mathlib/Order/Antisymmetrization.lean
@@ -176,8 +176,8 @@ instance [@DecidableRel α (· ≤ ·)] [@DecidableRel α (· < ·)] [IsTotal α
     LinearOrder (Antisymmetrization α (· ≤ ·)) :=
   { instPartialOrderAntisymmetrizationLeToLEInstIsPreorderLeToLE with
     le_total := fun a b => Quotient.inductionOn₂' a b <| total_of (· ≤ ·),
-    decidable_le := fun _ _ => show Decidable (Quotient.liftOn₂' _ _ _ _) from inferInstance,
-    decidable_lt := fun _ _ => show Decidable (Quotient.liftOn₂' _ _ _ _) from inferInstance }
+    decidableLE := fun _ _ => show Decidable (Quotient.liftOn₂' _ _ _ _) from inferInstance,
+    decidableLT := fun _ _ => show Decidable (Quotient.liftOn₂' _ _ _ _) from inferInstance }
 
 @[simp]
 theorem toAntisymmetrization_le_toAntisymmetrization_iff :

--- a/Mathlib/Order/Atoms.lean
+++ b/Mathlib/Order/Atoms.lean
@@ -473,7 +473,7 @@ This is not an instance to prevent loops. -/
 protected def IsSimpleOrder.linearOrder [DecidableEq α] : LinearOrder α :=
   { (inferInstance : PartialOrder α) with
     le_total := fun a b => by rcases eq_bot_or_eq_top a with (rfl | rfl) <;> simp
-    decidable_le := fun a b =>
+    decidableLE := fun a b =>
       if ha : a = ⊥ then isTrue (ha.le.trans bot_le)
       else
         if hb : b = ⊤ then isTrue (le_top.trans hb.ge)

--- a/Mathlib/Order/Basic.lean
+++ b/Mathlib/Order/Basic.lean
@@ -628,17 +628,17 @@ theorem LinearOrder.toPartialOrder_injective {α : Type _} :
     Function.Injective (@LinearOrder.toPartialOrder α) :=
   fun A B h ↦ match A, B with
   | { le := A_le, lt := A_lt,
-      decidable_le := A_decidable_le, decidable_eq := A_decidable_eq, decidable_lt := A_decidable_lt
+      decidableLE := A_decidable_le, decidableEq := A_decidable_eq, decidableLT := A_decidable_lt
       min := A_min, max := A_max, min_def := A_min_def, max_def := A_max_def,
       compare := A_compare, compare_eq_compareOfLessAndEq := A_compare_canonical,  .. },
     { le := B_le, lt := B_lt,
-      decidable_le := B_decidable_le, decidable_eq := B_decidable_eq, decidable_lt := B_decidable_lt
+      decidableLE := B_decidable_le, decidableEq := B_decidable_eq, decidableLT := B_decidable_lt
       min := B_min, max := B_max, min_def := B_min_def, max_def := B_max_def,
       compare := B_compare, compare_eq_compareOfLessAndEq := B_compare_canonical, .. } => by
     cases h
-    obtain rfl : A_decidable_le = B_decidable_le := Subsingleton.elim _ _
-    obtain rfl : A_decidable_eq = B_decidable_eq := Subsingleton.elim _ _
-    obtain rfl : A_decidable_lt = B_decidable_lt := Subsingleton.elim _ _
+    obtain rfl : A_decidable_le = B_decidableLE := Subsingleton.elim _ _
+    obtain rfl : A_decidable_eq = B_decidableEq := Subsingleton.elim _ _
+    obtain rfl : A_decidable_lt = B_decidableLT := Subsingleton.elim _ _
     have : A_min = B_min := by
       funext a b
       exact (A_min_def _ _).trans (B_min_def _ _).symm
@@ -729,8 +729,8 @@ instance linearOrder (α : Type _) [LinearOrder α] : LinearOrder αᵒᵈ where
   min := fun a b ↦ (max a b : α)
   min_def := fun a b ↦ show (max .. : α) = _ by rw [max_comm, max_def]; rfl
   max_def := fun a b ↦ show (min .. : α) = _ by rw [min_comm, min_def]; rfl
-  decidable_le := (inferInstance : DecidableRel (λ a b : α => b ≤ a))
-  decidable_lt := (inferInstance : DecidableRel (λ a b : α => b < a))
+  decidableLE := (inferInstance : DecidableRel (λ a b : α => b ≤ a))
+  decidableLT := (inferInstance : DecidableRel (λ a b : α => b < a))
 #align order_dual.linear_order OrderDual.linearOrder
 
 instance : ∀ [Inhabited α], Inhabited αᵒᵈ := λ [x: Inhabited α] => x
@@ -1038,14 +1038,14 @@ def LinearOrder.lift {α β} [LinearOrder β] [Sup α] [Inf α] (f : α → β) 
     (hsup : ∀ x y, f (x ⊔ y) = max (f x) (f y)) (hinf : ∀ x y, f (x ⊓ y) = min (f x) (f y)) :
     LinearOrder α :=
   letI instOrdα : Ord α := ⟨fun a b ↦ compare (f a) (f b)⟩
-  letI decidable_le := fun x y ↦ (inferInstance : Decidable (f x ≤ f y))
-  letI decidable_lt := fun x y ↦ (inferInstance : Decidable (f x < f y))
-  letI decidable_eq := fun x y ↦ decidable_of_iff (f x = f y) inj.eq_iff
+  letI decidableLE := fun x y ↦ (inferInstance : Decidable (f x ≤ f y))
+  letI decidableLT := fun x y ↦ (inferInstance : Decidable (f x < f y))
+  letI decidableEq := fun x y ↦ decidable_of_iff (f x = f y) inj.eq_iff
   { PartialOrder.lift f inj, instOrdα with
     le_total := fun x y ↦ le_total (f x) (f y)
-    decidable_le := decidable_le
-    decidable_lt := decidable_lt
-    decidable_eq := decidable_eq
+    decidableLE := decidable_le
+    decidableLT := decidable_lt
+    decidableEq := decidable_eq
     min := (· ⊓ ·)
     max := (· ⊔ ·)
     min_def := by
@@ -1085,14 +1085,14 @@ def LinearOrder.liftWithOrd {α β} [LinearOrder β] [Sup α] [Inf α] [Ord α] 
     (inj : Injective f) (hsup : ∀ x y, f (x ⊔ y) = max (f x) (f y))
     (hinf : ∀ x y, f (x ⊓ y) = min (f x) (f y))
     (compare_f : ∀ a b : α, compare a b = compare (f a) (f b)) : LinearOrder α :=
-  letI decidable_le := fun x y ↦ (inferInstance : Decidable (f x ≤ f y))
-  letI decidable_lt := fun x y ↦ (inferInstance : Decidable (f x < f y))
-  letI decidable_eq := fun x y ↦ decidable_of_iff (f x = f y) inj.eq_iff
+  letI decidableLE := fun x y ↦ (inferInstance : Decidable (f x ≤ f y))
+  letI decidableLT := fun x y ↦ (inferInstance : Decidable (f x < f y))
+  letI decidableEq := fun x y ↦ decidable_of_iff (f x = f y) inj.eq_iff
   { PartialOrder.lift f inj with
     le_total := fun x y ↦ le_total (f x) (f y)
-    decidable_le := decidable_le
-    decidable_lt := decidable_lt
-    decidable_eq := decidable_eq
+    decidableLE := decidable_le
+    decidableLT := decidable_lt
+    decidableEq := decidable_eq
     min := (· ⊓ ·)
     max := (· ⊔ ·)
     min_def := by
@@ -1360,9 +1360,9 @@ instance linearOrder: LinearOrder PUnit where
   lt  := fun _ _ ↦ False
   max := fun _ _ ↦ unit
   min := fun _ _ ↦ unit
-  decidable_eq := inferInstance
-  decidable_le := fun _ _ ↦ Decidable.isTrue trivial
-  decidable_lt := fun _ _ ↦ Decidable.isFalse id
+  decidableEq := inferInstance
+  decidableLE := fun _ _ ↦ Decidable.isTrue trivial
+  decidableLT := fun _ _ ↦ Decidable.isFalse id
   le_refl     := by intros; trivial
   le_trans    := by intros; trivial
   le_total    := by intros; exact Or.inl trivial
@@ -1434,5 +1434,5 @@ noncomputable instance AsLinearOrder.linearOrder {α} [PartialOrder α] [IsTotal
     LinearOrder (AsLinearOrder α) where
   __ := inferInstanceAs (PartialOrder α)
   le_total := @total_of α (· ≤ ·) _
-  decidable_le := Classical.decRel _
+  decidableLE := Classical.decRel _
 #align as_linear_order.linear_order AsLinearOrder.linearOrder

--- a/Mathlib/Order/Basic.lean
+++ b/Mathlib/Order/Basic.lean
@@ -628,17 +628,17 @@ theorem LinearOrder.toPartialOrder_injective {α : Type _} :
     Function.Injective (@LinearOrder.toPartialOrder α) :=
   fun A B h ↦ match A, B with
   | { le := A_le, lt := A_lt,
-      decidableLE := A_decidable_le, decidableEq := A_decidable_eq, decidableLT := A_decidable_lt
+      decidableLE := A_decidableLE, decidableEq := A_decidableEq, decidableLT := A_decidableLT
       min := A_min, max := A_max, min_def := A_min_def, max_def := A_max_def,
       compare := A_compare, compare_eq_compareOfLessAndEq := A_compare_canonical,  .. },
     { le := B_le, lt := B_lt,
-      decidableLE := B_decidable_le, decidableEq := B_decidable_eq, decidableLT := B_decidable_lt
+      decidableLE := B_decidableLE, decidableEq := B_decidableEq, decidableLT := B_decidableLT
       min := B_min, max := B_max, min_def := B_min_def, max_def := B_max_def,
       compare := B_compare, compare_eq_compareOfLessAndEq := B_compare_canonical, .. } => by
     cases h
-    obtain rfl : A_decidable_le = B_decidableLE := Subsingleton.elim _ _
-    obtain rfl : A_decidable_eq = B_decidableEq := Subsingleton.elim _ _
-    obtain rfl : A_decidable_lt = B_decidableLT := Subsingleton.elim _ _
+    obtain rfl : A_decidableLE = B_decidableLE := Subsingleton.elim _ _
+    obtain rfl : A_decidableEq = B_decidableEq := Subsingleton.elim _ _
+    obtain rfl : A_decidableLT = B_decidableLT := Subsingleton.elim _ _
     have : A_min = B_min := by
       funext a b
       exact (A_min_def _ _).trans (B_min_def _ _).symm
@@ -1043,9 +1043,9 @@ def LinearOrder.lift {α β} [LinearOrder β] [Sup α] [Inf α] (f : α → β) 
   letI decidableEq := fun x y ↦ decidable_of_iff (f x = f y) inj.eq_iff
   { PartialOrder.lift f inj, instOrdα with
     le_total := fun x y ↦ le_total (f x) (f y)
-    decidableLE := decidable_le
-    decidableLT := decidable_lt
-    decidableEq := decidable_eq
+    decidableLE := decidableLE
+    decidableLT := decidableLT
+    decidableEq := decidableEq
     min := (· ⊓ ·)
     max := (· ⊔ ·)
     min_def := by
@@ -1090,9 +1090,9 @@ def LinearOrder.liftWithOrd {α β} [LinearOrder β] [Sup α] [Inf α] [Ord α] 
   letI decidableEq := fun x y ↦ decidable_of_iff (f x = f y) inj.eq_iff
   { PartialOrder.lift f inj with
     le_total := fun x y ↦ le_total (f x) (f y)
-    decidableLE := decidable_le
-    decidableLT := decidable_lt
-    decidableEq := decidable_eq
+    decidableLE := decidableLE
+    decidableLT := decidableLT
+    decidableEq := decidableEq
     min := (· ⊓ ·)
     max := (· ⊔ ·)
     min_def := by

--- a/Mathlib/Order/Chain.lean
+++ b/Mathlib/Order/Chain.lean
@@ -378,8 +378,8 @@ instance [@DecidableRel α (· ≤ ·)] [@DecidableRel α (· < ·)] (s : Flag �
     LinearOrder s :=
   { Subtype.partialOrder _ with
     le_total := fun a b => s.le_or_le a.2 b.2
-    decidable_le := Subtype.decidableLE
-    decidable_lt := Subtype.decidableLT }
+    decidableLE := Subtype.decidableLE
+    decidableLT := Subtype.decidableLT }
 
 end PartialOrder
 

--- a/Mathlib/Order/Compare.lean
+++ b/Mathlib/Order/Compare.lean
@@ -218,9 +218,9 @@ def linearOrderOfCompares [Preorder α] (cmp : α → α → Ordering)
     le_total := fun a b => (h a b).le_total,
     toMin := minOfLe,
     toMax := maxOfLe,
-    decidable_le := H,
-    decidable_lt := fun a b => decidable_of_iff _ (h a b).eq_lt,
-    decidable_eq := fun a b => decidable_of_iff _ (h a b).eq_eq }
+    decidableLE := H,
+    decidableLT := fun a b => decidable_of_iff _ (h a b).eq_lt,
+    decidableEq := fun a b => decidable_of_iff _ (h a b).eq_eq }
 #align linear_order_of_compares linearOrderOfCompares
 
 variable [LinearOrder α] (x y : α)

--- a/Mathlib/Order/CompleteLattice.lean
+++ b/Mathlib/Order/CompleteLattice.lean
@@ -393,10 +393,10 @@ class CompleteLinearOrder (α : Type _) extends CompleteLattice α where
   /-- In a linearly ordered type, we assume the order relations are all decidable. -/
   decidable_le : DecidableRel (. ≤ . : α → α → Prop)
   /-- In a linearly ordered type, we assume the order relations are all decidable. -/
-  decidable_eq : DecidableEq α := @decidableEq_of_decidableLE _ _ decidable_le
+  decidable_eq : DecidableEq α := @decidableEqOfDecidableLE _ _ decidable_le
   /-- In a linearly ordered type, we assume the order relations are all decidable. -/
   decidable_lt : DecidableRel (. < . : α → α → Prop) :=
-    @decidableLT_of_decidableLE _ _ decidable_le
+    @decidableLTOfdecidableLE _ _ decidable_le
 #align complete_linear_order CompleteLinearOrder
 
 instance CompleteLinearOrder.toLinearOrder [i : CompleteLinearOrder α] : LinearOrder α :=

--- a/Mathlib/Order/CompleteLattice.lean
+++ b/Mathlib/Order/CompleteLattice.lean
@@ -393,10 +393,10 @@ class CompleteLinearOrder (α : Type _) extends CompleteLattice α where
   /-- In a linearly ordered type, we assume the order relations are all decidable. -/
   decidableLE : DecidableRel (. ≤ . : α → α → Prop)
   /-- In a linearly ordered type, we assume the order relations are all decidable. -/
-  decidableEq : DecidableEq α := @decidableEqOfDecidableLE _ _ decidable_le
+  decidableEq : DecidableEq α := @decidableEqOfDecidableLE _ _ decidableLE
   /-- In a linearly ordered type, we assume the order relations are all decidable. -/
   decidableLT : DecidableRel (. < . : α → α → Prop) :=
-    @decidableLTOfdecidableLE _ _ decidable_le
+    @decidableLTOfdecidableLE _ _ decidableLE
 #align complete_linear_order CompleteLinearOrder
 
 instance CompleteLinearOrder.toLinearOrder [i : CompleteLinearOrder α] : LinearOrder α :=

--- a/Mathlib/Order/CompleteLattice.lean
+++ b/Mathlib/Order/CompleteLattice.lean
@@ -396,7 +396,7 @@ class CompleteLinearOrder (α : Type _) extends CompleteLattice α where
   decidableEq : DecidableEq α := @decidableEqOfDecidableLE _ _ decidableLE
   /-- In a linearly ordered type, we assume the order relations are all decidable. -/
   decidableLT : DecidableRel (. < . : α → α → Prop) :=
-    @decidableLTOfdecidableLE _ _ decidableLE
+    @decidableLTOfDecidableLE _ _ decidableLE
 #align complete_linear_order CompleteLinearOrder
 
 instance CompleteLinearOrder.toLinearOrder [i : CompleteLinearOrder α] : LinearOrder α :=

--- a/Mathlib/Order/CompleteLattice.lean
+++ b/Mathlib/Order/CompleteLattice.lean
@@ -391,11 +391,11 @@ class CompleteLinearOrder (α : Type _) extends CompleteLattice α where
   /-- A linear order is total. -/
   le_total (a b : α) : a ≤ b ∨ b ≤ a
   /-- In a linearly ordered type, we assume the order relations are all decidable. -/
-  decidable_le : DecidableRel (. ≤ . : α → α → Prop)
+  decidableLE : DecidableRel (. ≤ . : α → α → Prop)
   /-- In a linearly ordered type, we assume the order relations are all decidable. -/
-  decidable_eq : DecidableEq α := @decidableEqOfDecidableLE _ _ decidable_le
+  decidableEq : DecidableEq α := @decidableEqOfDecidableLE _ _ decidable_le
   /-- In a linearly ordered type, we assume the order relations are all decidable. -/
-  decidable_lt : DecidableRel (. < . : α → α → Prop) :=
+  decidableLT : DecidableRel (. < . : α → α → Prop) :=
     @decidableLTOfdecidableLE _ _ decidable_le
 #align complete_linear_order CompleteLinearOrder
 

--- a/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
+++ b/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
@@ -198,10 +198,10 @@ class ConditionallyCompleteLinearOrder (α : Type _) extends ConditionallyComple
   /-- In a `ConditionallyCompleteLinearOrder`, we assume the order relations are all decidable. -/
   decidableLE : DecidableRel (. ≤ . : α → α → Prop)
   /-- In a `ConditionallyCompleteLinearOrder`, we assume the order relations are all decidable. -/
-  decidableEq : DecidableEq α := @decidableEqOfDecidableLE _ _ decidable_le
+  decidableEq : DecidableEq α := @decidableEqOfDecidableLE _ _ decidableLE
   /-- In a `ConditionallyCompleteLinearOrder`, we assume the order relations are all decidable. -/
   decidableLT : DecidableRel (. < . : α → α → Prop) :=
-    @decidableLTOfdecidableLE _ _ decidable_le
+    @decidableLTOfdecidableLE _ _ decidableLE
 #align conditionally_complete_linear_order ConditionallyCompleteLinearOrder
 
 instance (α : Type _) [ConditionallyCompleteLinearOrder α] : LinearOrder α :=

--- a/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
+++ b/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
@@ -196,11 +196,11 @@ class ConditionallyCompleteLinearOrder (α : Type _) extends ConditionallyComple
   /-- A `ConditionallyCompleteLinearOrder` is total. -/
   le_total (a b : α) : a ≤ b ∨ b ≤ a
   /-- In a `ConditionallyCompleteLinearOrder`, we assume the order relations are all decidable. -/
-  decidable_le : DecidableRel (. ≤ . : α → α → Prop)
+  decidableLE : DecidableRel (. ≤ . : α → α → Prop)
   /-- In a `ConditionallyCompleteLinearOrder`, we assume the order relations are all decidable. -/
-  decidable_eq : DecidableEq α := @decidableEqOfDecidableLE _ _ decidable_le
+  decidableEq : DecidableEq α := @decidableEqOfDecidableLE _ _ decidable_le
   /-- In a `ConditionallyCompleteLinearOrder`, we assume the order relations are all decidable. -/
-  decidable_lt : DecidableRel (. < . : α → α → Prop) :=
+  decidableLT : DecidableRel (. < . : α → α → Prop) :=
     @decidableLTOfdecidableLE _ _ decidable_le
 #align conditionally_complete_linear_order ConditionallyCompleteLinearOrder
 

--- a/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
+++ b/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
@@ -201,7 +201,7 @@ class ConditionallyCompleteLinearOrder (α : Type _) extends ConditionallyComple
   decidableEq : DecidableEq α := @decidableEqOfDecidableLE _ _ decidableLE
   /-- In a `ConditionallyCompleteLinearOrder`, we assume the order relations are all decidable. -/
   decidableLT : DecidableRel (. < . : α → α → Prop) :=
-    @decidableLTOfdecidableLE _ _ decidableLE
+    @decidableLTOfDecidableLE _ _ decidableLE
 #align conditionally_complete_linear_order ConditionallyCompleteLinearOrder
 
 instance (α : Type _) [ConditionallyCompleteLinearOrder α] : LinearOrder α :=

--- a/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
+++ b/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
@@ -198,10 +198,10 @@ class ConditionallyCompleteLinearOrder (α : Type _) extends ConditionallyComple
   /-- In a `ConditionallyCompleteLinearOrder`, we assume the order relations are all decidable. -/
   decidable_le : DecidableRel (. ≤ . : α → α → Prop)
   /-- In a `ConditionallyCompleteLinearOrder`, we assume the order relations are all decidable. -/
-  decidable_eq : DecidableEq α := @decidableEq_of_decidableLE _ _ decidable_le
+  decidable_eq : DecidableEq α := @decidableEqOfDecidableLE _ _ decidable_le
   /-- In a `ConditionallyCompleteLinearOrder`, we assume the order relations are all decidable. -/
   decidable_lt : DecidableRel (. < . : α → α → Prop) :=
-    @decidableLT_of_decidableLE _ _ decidable_le
+    @decidableLTOfdecidableLE _ _ decidable_le
 #align conditionally_complete_linear_order ConditionallyCompleteLinearOrder
 
 instance (α : Type _) [ConditionallyCompleteLinearOrder α] : LinearOrder α :=

--- a/Mathlib/Order/Extension/Linear.lean
+++ b/Mathlib/Order/Extension/Linear.lean
@@ -88,7 +88,7 @@ noncomputable instance {α : Type u} [PartialOrder α] : LinearOrder (LinearExte
   le_trans := (extend_partialOrder ((· ≤ ·) : α → α → Prop)).choose_spec.choose.1.1.2.1
   le_antisymm := (extend_partialOrder ((· ≤ ·) : α → α → Prop)).choose_spec.choose.1.2.1
   le_total := (extend_partialOrder ((· ≤ ·) : α → α → Prop)).choose_spec.choose.2.1
-  decidable_le := Classical.decRel _
+  decidableLE := Classical.decRel _
 
 /-- The embedding of `α` into `LinearExtension α` as a relation homomorphism. -/
 def toLinearExtension {α : Type u} [PartialOrder α] :

--- a/Mathlib/Order/Lattice.lean
+++ b/Mathlib/Order/Lattice.lean
@@ -923,9 +923,9 @@ def Lattice.toLinearOrder (α : Type u) [Lattice α] [DecidableEq α]
     [DecidableRel ((· ≤ ·) : α → α → Prop)]
     [DecidableRel ((· < ·) : α → α → Prop)] [IsTotal α (· ≤ ·)] : LinearOrder α :=
   { ‹Lattice α› with
-    decidable_le := ‹_›,
-    decidable_eq := ‹_›,
-    decidable_lt := ‹_›,
+    decidableLE := ‹_›,
+    decidableEq := ‹_›,
+    decidableLT := ‹_›,
     le_total := total_of (· ≤ ·),
     max := (· ⊔ ·),
     max_def := by exact congr_fun₂ sup_eq_maxDefault,

--- a/Mathlib/Order/RelClasses.lean
+++ b/Mathlib/Order/RelClasses.lean
@@ -226,7 +226,7 @@ def linearOrderOfSTO (r) [IsStrictTotalOrder α r] [∀ x y, Decidable ¬r x y] 
       | _, Or.inr (Or.inr h) => Or.inr (Or.inr h),
     toMin := minOfLe,
     toMax := maxOfLe,
-    decidable_le := hD }
+    decidableLE := hD }
 set_option linter.uppercaseLean3 false in
 #align linear_order_of_STO linearOrderOfSTO
 

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -263,7 +263,7 @@ instance linearOrder : LinearOrder Cardinal.{u} :=
     le_total := by
       rintro ⟨α⟩ ⟨β⟩
       apply Embedding.total
-    decidable_le := Classical.decRel _ }
+    decidableLE := Classical.decRel _ }
 
 theorem le_def (α β : Type u) : (#α) ≤ (#β) ↔ Nonempty (α ↪ β) :=
   Iff.rfl

--- a/Mathlib/SetTheory/Ordinal/Basic.lean
+++ b/Mathlib/SetTheory/Ordinal/Basic.lean
@@ -993,7 +993,7 @@ instance linearOrder : LinearOrder Ordinal :=
                   right
                   rw [h],
                   exact Or.inr (Or.inl h)]
-    decidable_le := Classical.decRel _ }
+    decidableLE := Classical.decRel _ }
 
 instance wellFoundedLT : WellFoundedLT Ordinal :=
   ⟨lt_wf⟩


### PR DESCRIPTION
This renames
* `decidable_eq` to `decidableEq`
* `decidable_lt` to `decidableLT`
* `decidable_le` to `decidableLE`
* `decidableLT_of_decidableLE` to `decidableLTOfDecidableLE`
* `decidableEq_of_decidableLE` to `decidableEqOfDecidableLE`

These fields are data not proofs, so they should be `lowerCamelCased`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
