### PR TITLE
[Merged by Bors] - fix: sUnion doc comment typos

### DIFF
--- a/Mathlib/Data/Set/Lattice.lean
+++ b/Mathlib/Data/Set/Lattice.lean
@@ -86,7 +86,7 @@ def sUnion (S : Set (Set α)) : Set α :=
   sSup S
 #align set.sUnion Set.sUnion
 
-/-- Notation for Set.sUnion`. Union of a set of sets. -/
+/-- Notation for `Set.sUnion`. Union of a set of sets. -/
 prefix:110 "⋃₀ " => sUnion
 
 @[simp]

--- a/Mathlib/Data/Set/Lattice.lean
+++ b/Mathlib/Data/Set/Lattice.lean
@@ -81,7 +81,7 @@ def sInter (S : Set (Set α)) : Set α :=
 /-- Notation for `Set.sInter` Intersection of a set of sets. -/
 prefix:110 "⋂₀ " => sInter
 
-/-- Intersection of a set of sets. -/
+/-- Union of a set of sets. -/
 def sUnion (S : Set (Set α)) : Set α :=
   sSup S
 #align set.sUnion Set.sUnion


### PR DESCRIPTION
Fixes some doc comment typos added added in #1121.

Note that the `sUnion` comment is correct is mathlib3:
https://github.com/leanprover-community/mathlib/blob/b76e9f654df09f8a832aeee712511fe5f3e57869/src/data/set/lattice.lean#L72-L74