### PR TITLE
[Merged by Bors] - feat: add Mathlib.Tactic.Common, and import

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1890,6 +1890,7 @@ import Mathlib.Tactic.Clear!
 import Mathlib.Tactic.ClearExcept
 import Mathlib.Tactic.Clear_
 import Mathlib.Tactic.Coe
+import Mathlib.Tactic.Common
 import Mathlib.Tactic.Congr!
 import Mathlib.Tactic.Constructor
 import Mathlib.Tactic.Continuity

--- a/Mathlib/Algebra/BigOperators/Basic.lean
+++ b/Mathlib/Algebra/BigOperators/Basic.lean
@@ -18,7 +18,6 @@ import Mathlib.Data.Fintype.Basic
 import Mathlib.Data.Finset.Sigma
 import Mathlib.Data.Multiset.Powerset
 import Mathlib.Data.Set.Pairwise.Basic
-import Mathlib.Tactic.ScopedNS
 
 /-!
 # Big operators

--- a/Mathlib/Algebra/BigOperators/Finprod.lean
+++ b/Mathlib/Algebra/BigOperators/Finprod.lean
@@ -10,7 +10,6 @@ Authors: Kexing Ying, Kevin Buzzard, Yury Kudryashov
 -/
 import Mathlib.Algebra.BigOperators.Order
 import Mathlib.Algebra.IndicatorFunction
-import Mathlib.Tactic.ScopedNS
 
 /-!
 # Finite products and sums over types and sets

--- a/Mathlib/Algebra/ContinuedFractions/ConvergentsEquiv.lean
+++ b/Mathlib/Algebra/ContinuedFractions/ConvergentsEquiv.lean
@@ -12,7 +12,6 @@ import Mathlib.Algebra.ContinuedFractions.ContinuantsRecurrence
 import Mathlib.Algebra.ContinuedFractions.TerminatedStable
 import Mathlib.Tactic.FieldSimp
 import Mathlib.Tactic.Ring
-import Mathlib.Tactic.Set
 
 /-!
 # Equivalence of Recursive and Direct Computations of `GCF` Convergents

--- a/Mathlib/Algebra/DirectSum/Basic.lean
+++ b/Mathlib/Algebra/DirectSum/Basic.lean
@@ -10,7 +10,6 @@ Authors: Kenny Lau
 -/
 import Mathlib.Data.Dfinsupp.Basic
 import Mathlib.GroupTheory.Submonoid.Operations
-import Mathlib.Tactic.ScopedNS
 
 /-!
 # Direct sum

--- a/Mathlib/Algebra/Field/Defs.lean
+++ b/Mathlib/Algebra/Field/Defs.lean
@@ -10,7 +10,6 @@ Authors: Robert Lewis, Leonardo de Moura, Johannes Hölzl, Mario Carneiro
 -/
 
 import Mathlib.Algebra.Ring.Defs
-import Mathlib.Tactic.Convert
 import Std.Data.Rat
 import Mathlib.Data.Rat.Init
 

--- a/Mathlib/Algebra/GCDMonoid/Basic.lean
+++ b/Mathlib/Algebra/GCDMonoid/Basic.lean
@@ -11,7 +11,6 @@ Authors: Johannes Hölzl, Jens Wagemaker
 import Mathlib.Algebra.Associated
 import Mathlib.Algebra.GroupPower.Lemmas
 import Mathlib.Algebra.Ring.Regular
-import Mathlib.Tactic.Set
 
 /-!
 # Monoids with normalization functions, `gcd`, and `lcm`

--- a/Mathlib/Algebra/Group/Commute.lean
+++ b/Mathlib/Algebra/Group/Commute.lean
@@ -9,7 +9,6 @@ Authors: Neil Strickland, Yury Kudryashov
 ! if you have ported upstream changes.
 -/
 import Mathlib.Algebra.Group.Semiconj
-import Mathlib.Tactic.SimpRw
 
 /-!
 # Commuting pairs of elements in monoids

--- a/Mathlib/Algebra/Group/Defs.lean
+++ b/Mathlib/Algebra/Group/Defs.lean
@@ -12,6 +12,7 @@ Authors: Jeremy Avigad, Leonardo de Moura, Simon Hudon, Mario Carneiro
 import Mathlib.Init.ZeroOne
 import Mathlib.Init.Data.Int.Basic
 import Mathlib.Logic.Function.Basic
+import Mathlib.Tactic.Common
 
 /-!
 # Typeclasses for (semi)groups and monoids

--- a/Mathlib/Algebra/Group/Ext.lean
+++ b/Mathlib/Algebra/Group/Ext.lean
@@ -9,7 +9,6 @@ Authors: Bryan Gin-ge Chen, Yury Kudryashov
 ! if you have ported upstream changes.
 -/
 import Mathlib.Algebra.Hom.Group
-import Mathlib.Tactic.Basic
 
 /-!
 # Extensionality lemmas for monoid and group structures

--- a/Mathlib/Algebra/Group/Units.lean
+++ b/Mathlib/Algebra/Group/Units.lean
@@ -12,8 +12,6 @@ import Mathlib.Algebra.Group.Basic
 import Mathlib.Logic.Nontrivial
 import Mathlib.Logic.Unique
 import Mathlib.Tactic.Nontriviality
-import Mathlib.Tactic.Simps.Basic
-import Mathlib.Tactic.Lift
 
 /-!
 # Units (i.e., invertible elements) of a monoid

--- a/Mathlib/Algebra/Group/WithOne/Defs.lean
+++ b/Mathlib/Algebra/Group/WithOne/Defs.lean
@@ -10,7 +10,6 @@ Authors: Mario Carneiro, Johan Commelin
 -/
 import Mathlib.Order.WithBot
 import Mathlib.Algebra.Ring.Defs
-import Mathlib.Tactic.Lift
 
 /-!
 # Adjoining a zero/one to semigroups and related algebraic structures

--- a/Mathlib/Algebra/GroupWithZero/Basic.lean
+++ b/Mathlib/Algebra/GroupWithZero/Basic.lean
@@ -12,7 +12,6 @@ Authors: Johan Commelin
 import Mathlib.Algebra.Group.Basic
 import Mathlib.Algebra.GroupWithZero.Defs
 import Mathlib.Algebra.Group.OrderSynonym
-import Mathlib.Tactic.SimpRw
 
 /-!
 # Groups with an adjoined zero element

--- a/Mathlib/Algebra/GroupWithZero/Units/Basic.lean
+++ b/Mathlib/Algebra/GroupWithZero/Units/Basic.lean
@@ -11,8 +11,6 @@ Authors: Johan Commelin
 import Mathlib.Algebra.GroupWithZero.Basic
 import Mathlib.Algebra.Group.Units
 import Mathlib.Tactic.Nontriviality
-import Mathlib.Tactic.Convert
-import Mathlib.Tactic.Contrapose
 
 /-!
 # Lemmas about units in a `MonoidWithZero` or a `GroupWithZero`.

--- a/Mathlib/Algebra/Homology/ComplexShape.lean
+++ b/Mathlib/Algebra/Homology/ComplexShape.lean
@@ -10,7 +10,6 @@ Authors: Johan Commelin, Scott Morrison
 -/
 import Mathlib.Algebra.Group.Defs
 import Mathlib.Logic.Relation
-import Mathlib.Tactic.Simps.Basic
 
 /-!
 # Shapes of homological complexes

--- a/Mathlib/Algebra/Module/Basic.lean
+++ b/Mathlib/Algebra/Module/Basic.lean
@@ -14,7 +14,6 @@ import Mathlib.Data.Rat.Defs
 import Mathlib.Data.Rat.Basic
 import Mathlib.GroupTheory.GroupAction.Group
 import Mathlib.Tactic.Abel
-import Mathlib.Tactic.NthRewrite
 
 /-!
 # Modules over a ring

--- a/Mathlib/Algebra/Order/Hom/Ring.lean
+++ b/Mathlib/Algebra/Order/Hom/Ring.lean
@@ -12,9 +12,6 @@ import Mathlib.Algebra.Order.Archimedean
 import Mathlib.Algebra.Order.Hom.Monoid
 import Mathlib.Algebra.Order.Ring.Defs
 import Mathlib.Algebra.Ring.Equiv
-import Mathlib.Tactic.ByContra
-import Mathlib.Tactic.SwapVar
-import Mathlib.Tactic.WLOG
 
 /-!
 # Ordered ring homomorphisms

--- a/Mathlib/Algebra/Order/Kleene.lean
+++ b/Mathlib/Algebra/Order/Kleene.lean
@@ -12,7 +12,6 @@ import Mathlib.Algebra.Order.Ring.Canonical
 import Mathlib.Algebra.Ring.Pi
 import Mathlib.Algebra.Ring.Prod
 import Mathlib.Order.Hom.CompleteLattice
-import Mathlib.Tactic.ScopedNS  -- Porting note: `scoped[]`
 
 /-!
 # Kleene Algebras

--- a/Mathlib/Algebra/Order/LatticeGroup.lean
+++ b/Mathlib/Algebra/Order/LatticeGroup.lean
@@ -10,7 +10,6 @@ Authors: Christopher Hoskin
 -/
 import Mathlib.Algebra.GroupPower.Basic
 import Mathlib.Algebra.Order.Group.Abs
-import Mathlib.Tactic.NthRewrite
 import Mathlib.Order.Closure
 
 /-!

--- a/Mathlib/Algebra/Order/Monoid/Lemmas.lean
+++ b/Mathlib/Algebra/Order/Monoid/Lemmas.lean
@@ -12,9 +12,6 @@ Yuyang Zhao
 import Mathlib.Algebra.CovariantAndContravariant
 import Mathlib.Init.Data.Ordering.Basic
 import Mathlib.Order.MinMax
-import Mathlib.Tactic.Contrapose
-import Mathlib.Tactic.PushNeg
-import Mathlib.Tactic.Use
 
 /-!
 # Ordered monoids

--- a/Mathlib/Algebra/Order/Monoid/MinMax.lean
+++ b/Mathlib/Algebra/Order/Monoid/MinMax.lean
@@ -10,7 +10,6 @@ Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro, Johannes Hölzl
 -/
 import Mathlib.Order.MinMax
 import Mathlib.Algebra.Order.Monoid.Lemmas
-import Mathlib.Tactic.Contrapose
 
 /-!
 # Lemmas about `min` and `max` in an ordered monoid.

--- a/Mathlib/Algebra/Quandle.lean
+++ b/Mathlib/Algebra/Quandle.lean
@@ -11,7 +11,6 @@ Authors: Kyle Miller
 import Mathlib.Algebra.Hom.Equiv.Basic
 import Mathlib.Algebra.Hom.Aut
 import Mathlib.Data.ZMod.Defs
-import Mathlib.Tactic.ScopedNS
 import Mathlib.Tactic.Ring
 /-!
 # Racks and Quandles

--- a/Mathlib/Algebra/Quotient.lean
+++ b/Mathlib/Algebra/Quotient.lean
@@ -9,6 +9,8 @@ Authors: Anne Baanen
 ! if you have ported upstream changes.
 -/
 import Mathlib.Mathport.Rename
+import Mathlib.Tactic.Common
+
 /-!
 # Algebraic quotients
 

--- a/Mathlib/Algebra/Ring/BooleanRing.lean
+++ b/Mathlib/Algebra/Ring/BooleanRing.lean
@@ -12,7 +12,6 @@ import Mathlib.Algebra.PUnitInstances
 import Mathlib.Tactic.Abel
 import Mathlib.Tactic.Ring
 import Mathlib.Order.Hom.Lattice
-import Mathlib.Tactic.ScopedNS
 
 /-!
 # Boolean rings

--- a/Mathlib/Algebra/Ring/Defs.lean
+++ b/Mathlib/Algebra/Ring/Defs.lean
@@ -12,7 +12,6 @@ import Mathlib.Algebra.Group.Basic
 import Mathlib.Algebra.GroupWithZero.Defs
 import Mathlib.Data.Int.Cast.Defs
 import Mathlib.Logic.Nontrivial
-import Mathlib.Tactic.Spread
 
 /-!
 # Semirings and rings

--- a/Mathlib/Algebra/Ring/Divisibility.lean
+++ b/Mathlib/Algebra/Ring/Divisibility.lean
@@ -12,7 +12,6 @@ Ported by: Matej Penciak
 import Mathlib.Algebra.Divisibility.Basic
 import Mathlib.Algebra.Hom.Equiv.Basic
 import Mathlib.Algebra.Ring.Defs
-import Mathlib.Tactic.Convert
 
 /-!
 # Lemmas about divisibility in rings

--- a/Mathlib/Algebra/Star/Basic.lean
+++ b/Mathlib/Algebra/Star/Basic.lean
@@ -13,7 +13,6 @@ import Mathlib.Algebra.Ring.CompTypeclasses
 import Mathlib.Data.Rat.Cast
 import Mathlib.GroupTheory.GroupAction.Opposite
 import Mathlib.Data.SetLike.Basic
-import Mathlib.Tactic.ScopedNS
 
 /-!
 # Star monoids, rings, and modules

--- a/Mathlib/AlgebraicTopology/SimplexCategory.lean
+++ b/Mathlib/AlgebraicTopology/SimplexCategory.lean
@@ -13,7 +13,6 @@ import Mathlib.CategoryTheory.Skeletal
 import Mathlib.Data.Fintype.Sort
 import Mathlib.Order.Category.NonemptyFinLinOrdCat
 import Mathlib.CategoryTheory.Functor.ReflectsIso
-import Mathlib.Tactic.ScopedNS
 
 /-! # The simplex category
 

--- a/Mathlib/Analysis/Convex/Function.lean
+++ b/Mathlib/Analysis/Convex/Function.lean
@@ -9,7 +9,6 @@ Authors: Alexander Bentkamp, François Dupuis
 ! if you have ported upstream changes.
 -/
 import Mathlib.Analysis.Convex.Basic
-import Mathlib.Tactic.WLOG
 
 /-!
 # Convex and concave functions

--- a/Mathlib/Analysis/NormedSpace/Ray.lean
+++ b/Mathlib/Analysis/NormedSpace/Ray.lean
@@ -10,7 +10,6 @@ Authors: Yury Kudryashov, Yaël Dillies
 -/
 import Mathlib.LinearAlgebra.Ray
 import Mathlib.Analysis.NormedSpace.Basic
-import Mathlib.Tactic.WLOG
 
 /-!
 # Rays in a real normed vector space

--- a/Mathlib/CategoryTheory/Abelian/Homology.lean
+++ b/Mathlib/CategoryTheory/Abelian/Homology.lean
@@ -12,8 +12,6 @@ import Mathlib.Algebra.Homology.Additive
 import Mathlib.CategoryTheory.Abelian.Pseudoelements
 import Mathlib.CategoryTheory.Limits.Preserves.Shapes.Kernels
 import Mathlib.CategoryTheory.Limits.Preserves.Shapes.Images
-import Mathlib.Tactic.RSuffices
-import Mathlib.Tactic.FailIfNoProgress
 
 /-!
 

--- a/Mathlib/CategoryTheory/Category/Basic.lean
+++ b/Mathlib/CategoryTheory/Category/Basic.lean
@@ -12,8 +12,6 @@ Ported by: Scott Morrison
 import Mathlib.CategoryTheory.Category.Init
 import Mathlib.Combinatorics.Quiver.Basic
 import Mathlib.Tactic.RestateAxiom
-import Mathlib.Tactic.Convert
-import Mathlib.Tactic.Replace
 
 /-!
 # Categories

--- a/Mathlib/CategoryTheory/DiscreteCategory.lean
+++ b/Mathlib/CategoryTheory/DiscreteCategory.lean
@@ -10,7 +10,6 @@ Authors: Stephen Morgan, Scott Morrison, Floris van Doorn
 -/
 import Mathlib.CategoryTheory.EqToHom
 import Mathlib.Data.ULift
-import Mathlib.Tactic.CasesM
 
 /-!
 # Discrete categories

--- a/Mathlib/CategoryTheory/EssentiallySmall.lean
+++ b/Mathlib/CategoryTheory/EssentiallySmall.lean
@@ -11,7 +11,6 @@ Authors: Scott Morrison
 import Mathlib.Logic.Small.Basic
 import Mathlib.CategoryTheory.Category.ULift
 import Mathlib.CategoryTheory.Skeletal
-import Mathlib.Tactic.Constructor
 
 /-!
 # Essentially small categories.

--- a/Mathlib/CategoryTheory/Functor/FullyFaithful.lean
+++ b/Mathlib/CategoryTheory/Functor/FullyFaithful.lean
@@ -10,7 +10,6 @@ Authors: Scott Morrison
 -/
 import Mathlib.CategoryTheory.NatIso
 import Mathlib.Logic.Equiv.Defs
-import Mathlib.Tactic.Choose
 
 /-!
 # Full and faithful functors

--- a/Mathlib/CategoryTheory/Limits/Shapes/ZeroObjects.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/ZeroObjects.lean
@@ -9,7 +9,6 @@ Authors: Scott Morrison, Johan Commelin
 ! if you have ported upstream changes.
 -/
 import Mathlib.CategoryTheory.Limits.Shapes.Terminal
-import Mathlib.Tactic.ScopedNS
 
 /-!
 # Zero objects

--- a/Mathlib/Combinatorics/Composition.lean
+++ b/Mathlib/Combinatorics/Composition.lean
@@ -11,7 +11,6 @@ Authors: Sébastien Gouëzel
 import Mathlib.Data.Finset.Sort
 import Mathlib.Algebra.BigOperators.Order
 import Mathlib.Algebra.BigOperators.Fin
-import Mathlib.Tactic.WLOG
 
 /-!
 # Compositions

--- a/Mathlib/Combinatorics/Quiver/Basic.lean
+++ b/Mathlib/Combinatorics/Quiver/Basic.lean
@@ -10,7 +10,6 @@ Ported by: Scott Morrison
 ! if you have ported upstream changes.
 -/
 import Mathlib.Data.Opposite
-import Mathlib.Tactic.ProjectionNotation
 
 /-!
 # Quivers

--- a/Mathlib/Combinatorics/SetFamily/Compression/Down.lean
+++ b/Mathlib/Combinatorics/SetFamily/Compression/Down.lean
@@ -9,7 +9,6 @@ Authors: Yaël Dillies
 ! if you have ported upstream changes.
 -/
 import Mathlib.Data.Finset.Card
-import Mathlib.Tactic.ScopedNS
 
 /-!
 # Down-compressions

--- a/Mathlib/Combinatorics/SetFamily/Compression/UV.lean
+++ b/Mathlib/Combinatorics/SetFamily/Compression/UV.lean
@@ -9,7 +9,6 @@ Authors: Yaël Dillies, Bhavik Mehta
 ! if you have ported upstream changes.
 -/
 import Mathlib.Data.Finset.Card
-import Mathlib.Tactic.ScopedNS -- Porting note: scoped
 
 /-!
 # UV-compressions

--- a/Mathlib/Computability/DFA.lean
+++ b/Mathlib/Computability/DFA.lean
@@ -11,7 +11,6 @@ Authors: Fox Thomson
 import Mathlib.Data.Fintype.Card
 import Mathlib.Computability.Language
 import Mathlib.Tactic.NormNum
-import Mathlib.Tactic.WLOG
 
 /-!
 # Deterministic Finite Automata

--- a/Mathlib/Computability/PartrecCode.lean
+++ b/Mathlib/Computability/PartrecCode.lean
@@ -9,7 +9,6 @@ Authors: Mario Carneiro
 ! if you have ported upstream changes.
 -/
 import Mathlib.Computability.Partrec
-import Mathlib.Tactic.RSuffices
 
 /-!
 # Gödel Numbering for Partial Recursive Functions.

--- a/Mathlib/Computability/TMToPartrec.lean
+++ b/Mathlib/Computability/TMToPartrec.lean
@@ -12,7 +12,6 @@ import Mathlib.Computability.Halting
 import Mathlib.Computability.TuringMachine
 import Mathlib.Data.Num.Lemmas
 import Mathlib.Tactic.DeriveFintype
-import Mathlib.Tactic.Eqns
 
 /-!
 # Modelling partial recursive functions using Turing machines

--- a/Mathlib/Computability/TuringMachine.lean
+++ b/Mathlib/Computability/TuringMachine.lean
@@ -16,8 +16,6 @@ import Mathlib.Data.PFun
 import Mathlib.Logic.Function.Iterate
 import Mathlib.Order.Basic
 import Mathlib.Tactic.ApplyFun
-import Mathlib.Tactic.WLOG
-import Mathlib.Tactic.RSuffices
 
 /-!
 # Turing machines

--- a/Mathlib/Control/Basic.lean
+++ b/Mathlib/Control/Basic.lean
@@ -9,8 +9,8 @@ Authors: Johannes Hölzl
 ! if you have ported upstream changes.
 -/
 import Mathlib.Control.SimpSet
-import Mathlib.Tactic.CasesM
 import Mathlib.Init.Control.Combinators
+import Mathlib.Tactic.CasesM
 
 /-!
 Extends the theory on functors, applicatives and monads.

--- a/Mathlib/Control/Bifunctor.lean
+++ b/Mathlib/Control/Bifunctor.lean
@@ -8,7 +8,6 @@ Authors: Simon Hudon
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
-import Aesop
 import Mathlib.Control.Functor
 import Mathlib.Data.Sum.Basic
 import Mathlib.Tactic.Common

--- a/Mathlib/Control/Bifunctor.lean
+++ b/Mathlib/Control/Bifunctor.lean
@@ -11,7 +11,7 @@ Authors: Simon Hudon
 import Aesop
 import Mathlib.Control.Functor
 import Mathlib.Data.Sum.Basic
-import Mathlib.Tactic.HigherOrder
+import Mathlib.Tactic.Common
 
 /-!
 # Functors with two arguments

--- a/Mathlib/Control/EquivFunctor.lean
+++ b/Mathlib/Control/EquivFunctor.lean
@@ -9,7 +9,6 @@ Authors: Scott Morrison
 ! if you have ported upstream changes.
 -/
 import Mathlib.Logic.Equiv.Defs
-import Mathlib.Tactic.Convert
 
 /-!
 # Functions functorial with respect to equivalences

--- a/Mathlib/Control/LawfulFix.lean
+++ b/Mathlib/Control/LawfulFix.lean
@@ -12,7 +12,6 @@ import Mathlib.Data.Stream.Init
 import Mathlib.Tactic.ApplyFun
 import Mathlib.Control.Fix
 import Mathlib.Order.OmegaCompletePartialOrder
-import Mathlib.Tactic.WLOG
 
 /-!
 # Lawful fixed point operators

--- a/Mathlib/Control/Monad/Basic.lean
+++ b/Mathlib/Control/Monad/Basic.lean
@@ -10,6 +10,7 @@ Authors: Simon Hudon
 -/
 import Mathlib.Logic.Equiv.Defs
 import Mathlib.Control.SimpSet
+import Mathlib.Tactic.Common
 
 /-!
 # Monad

--- a/Mathlib/Data/Countable/Defs.lean
+++ b/Mathlib/Data/Countable/Defs.lean
@@ -9,7 +9,6 @@ Authors: Yury Kudryashov
 ! if you have ported upstream changes.
 -/
 import Mathlib.Data.Finite.Defs
-import Mathlib.Tactic.MkIffOfInductiveProp
 
 /-!
 # Countable types

--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -13,7 +13,6 @@ import Mathlib.Algebra.Order.WithZero
 import Mathlib.Order.RelIso.Basic
 import Mathlib.Data.Nat.Order.Basic
 import Mathlib.Order.Hom.Set
-import Mathlib.Tactic.Set
 import Qq
 
 /-!

--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -13,7 +13,6 @@ import Mathlib.Algebra.Order.WithZero
 import Mathlib.Order.RelIso.Basic
 import Mathlib.Data.Nat.Order.Basic
 import Mathlib.Order.Hom.Set
-import Qq
 
 /-!
 # The finite type with `n` elements

--- a/Mathlib/Data/Fin/VecNotation.lean
+++ b/Mathlib/Data/Fin/VecNotation.lean
@@ -11,7 +11,6 @@ Authors: Anne Baanen
 import Mathlib.Data.Fin.Tuple.Basic
 import Mathlib.Data.List.Range
 import Mathlib.GroupTheory.GroupAction.Pi
-import Qq
 
 /-!
 # Matrix and vector notation

--- a/Mathlib/Data/Fin/VecNotation.lean
+++ b/Mathlib/Data/Fin/VecNotation.lean
@@ -11,7 +11,6 @@ Authors: Anne Baanen
 import Mathlib.Data.Fin.Tuple.Basic
 import Mathlib.Data.List.Range
 import Mathlib.GroupTheory.GroupAction.Pi
-import Mathlib.Tactic.ToExpr
 import Qq
 
 /-!

--- a/Mathlib/Data/Finset/Card.lean
+++ b/Mathlib/Data/Finset/Card.lean
@@ -9,7 +9,6 @@ Authors: Leonardo de Moura, Jeremy Avigad
 ! if you have ported upstream changes.
 -/
 import Mathlib.Data.Finset.Image
-import Mathlib.Tactic.ByContra
 
 /-!
 # Cardinality of a finite set

--- a/Mathlib/Data/Int/Basic.lean
+++ b/Mathlib/Data/Int/Basic.lean
@@ -8,7 +8,6 @@ Authors: Jeremy Avigad
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
-import Mathlib.Tactic.Convert
 import Mathlib.Init.Data.Int.Order
 import Mathlib.Data.Int.Cast.Basic
 import Mathlib.Algebra.Ring.Basic

--- a/Mathlib/Data/Int/Bitwise.lean
+++ b/Mathlib/Data/Int/Bitwise.lean
@@ -12,7 +12,6 @@ import Mathlib.Data.Int.Basic
 import Mathlib.Data.Nat.Pow
 import Mathlib.Data.Nat.Size
 import Mathlib.Init.Data.Int.Bitwise
-import Mathlib.Tactic.Coe
 
 /-!
 # Bitwise operations on integers

--- a/Mathlib/Data/Int/Units.lean
+++ b/Mathlib/Data/Int/Units.lean
@@ -11,7 +11,6 @@ Authors: Jeremy Avigad
 import Mathlib.Data.Nat.Units
 import Mathlib.Data.Int.Basic
 import Mathlib.Algebra.Ring.Units
-import Mathlib.Tactic.Tauto
 
 /-!
 # Lemmas about units in `ℤ`.

--- a/Mathlib/Data/List/Lex.lean
+++ b/Mathlib/Data/List/Lex.lean
@@ -9,7 +9,6 @@ Authors: Mario Carneiro
 ! if you have ported upstream changes.
 -/
 import Mathlib.Order.RelClasses
-import Mathlib.Tactic.Classical
 
 /-!
 # Lexicographic ordering of lists.

--- a/Mathlib/Data/Matrix/Notation.lean
+++ b/Mathlib/Data/Matrix/Notation.lean
@@ -11,7 +11,6 @@ Authors: Anne Baanen, Eric Wieser
 import Mathlib.Data.Matrix.Basic
 import Mathlib.Data.Fin.VecNotation
 import Mathlib.Tactic.FinCases
-import Mathlib.Tactic.ToExpr
 import Mathlib.Algebra.BigOperators.Fin
 import Qq
 

--- a/Mathlib/Data/Matrix/Notation.lean
+++ b/Mathlib/Data/Matrix/Notation.lean
@@ -12,7 +12,6 @@ import Mathlib.Data.Matrix.Basic
 import Mathlib.Data.Fin.VecNotation
 import Mathlib.Tactic.FinCases
 import Mathlib.Algebra.BigOperators.Fin
-import Qq
 
 /-!
 # Matrix and vector notation

--- a/Mathlib/Data/Nat/Basic.lean
+++ b/Mathlib/Data/Nat/Basic.lean
@@ -11,9 +11,6 @@ Authors: Floris van Doorn, Leonardo de Moura, Jeremy Avigad, Mario Carneiro
 import Mathlib.Order.Basic
 import Mathlib.Algebra.GroupWithZero.Basic
 import Mathlib.Algebra.Ring.Defs
-import Mathlib.Tactic.Convert
-import Mathlib.Tactic.PushNeg
-import Mathlib.Tactic.Use
 
 /-!
 # Basic operations on the natural numbers

--- a/Mathlib/Data/Nat/Bitwise.lean
+++ b/Mathlib/Data/Nat/Bitwise.lean
@@ -14,7 +14,6 @@ import Mathlib.Data.Nat.Bits
 import Mathlib.Data.Nat.Size
 import Mathlib.Data.Nat.Order.Lemmas
 import Mathlib.Tactic.Linarith
-import Mathlib.Tactic.Set
 
 /-!
 # Bitwise operations on natural numbers

--- a/Mathlib/Data/Nat/Cast/Defs.lean
+++ b/Mathlib/Data/Nat/Cast/Defs.lean
@@ -10,7 +10,6 @@ Authors: Mario Carneiro, Gabriel Ebner
 -/
 import Mathlib.Algebra.Group.Defs
 import Mathlib.Algebra.NeZero
-import Mathlib.Tactic.SplitIfs
 
 /-!
 # Cast of natural numbers

--- a/Mathlib/Data/Nat/Count.lean
+++ b/Mathlib/Data/Nat/Count.lean
@@ -10,7 +10,6 @@ Authors: Yaël Dillies, Vladimir Goryachev, Kyle Miller, Scott Morrison, Eric Ro
 -/
 import Mathlib.SetTheory.Cardinal.Basic
 import Mathlib.Tactic.Ring
-import Mathlib.Tactic.WLOG
 
 /-!
 # Counting on ℕ

--- a/Mathlib/Data/Nat/Factors.lean
+++ b/Mathlib/Data/Nat/Factors.lean
@@ -11,7 +11,6 @@ Authors: Leonardo de Moura, Jeremy Avigad, Mario Carneiro
 import Mathlib.Data.Nat.Prime
 import Mathlib.Data.List.Prime
 import Mathlib.Data.List.Sort
-import Mathlib.Tactic.NthRewrite
 
 /-!
 # Prime numbers

--- a/Mathlib/Data/Nat/Fib.lean
+++ b/Mathlib/Data/Nat/Fib.lean
@@ -15,7 +15,6 @@ import Mathlib.Logic.Function.Iterate
 import Mathlib.Data.Finset.NatAntidiagonal
 import Mathlib.Algebra.BigOperators.Basic
 import Mathlib.Tactic.Ring
-import Mathlib.Tactic.WLOG
 import Mathlib.Tactic.Zify
 
 /-!

--- a/Mathlib/Data/Nat/Log.lean
+++ b/Mathlib/Data/Nat/Log.lean
@@ -10,7 +10,6 @@ Ported by: Rémy Degenne
 ! if you have ported upstream changes.
 -/
 import Mathlib.Data.Nat.Pow
-import Mathlib.Tactic.ByContra
 
 /-!
 # Natural number logarithms

--- a/Mathlib/Data/Nat/Prime.lean
+++ b/Mathlib/Data/Nat/Prime.lean
@@ -16,7 +16,6 @@ import Mathlib.Data.Nat.Factorial.Basic
 import Mathlib.Data.Nat.GCD.Basic
 import Mathlib.Data.Nat.Sqrt
 import Mathlib.Order.Bounds.Basic
-import Mathlib.Tactic.ByContra
 
 /-!
 # Prime numbers

--- a/Mathlib/Data/Nat/WithBot.lean
+++ b/Mathlib/Data/Nat/WithBot.lean
@@ -11,7 +11,6 @@ Authors: Chris Hughes
 
 import Mathlib.Data.Nat.Order.Basic
 import Mathlib.Algebra.Order.Monoid.WithTop
-import Aesop
 
 /-!
 # `WithBot ℕ`

--- a/Mathlib/Data/Option/Basic.lean
+++ b/Mathlib/Data/Option/Basic.lean
@@ -12,7 +12,7 @@ import Mathlib.Init.Control.Combinators
 import Mathlib.Data.Option.Defs
 import Mathlib.Logic.IsEmpty
 import Mathlib.Logic.Relator
-import Mathlib.Mathport.Rename
+import Mathlib.Tactic.Common
 
 /-!
 # Option of a type

--- a/Mathlib/Data/PNat/Defs.lean
+++ b/Mathlib/Data/PNat/Defs.lean
@@ -12,8 +12,6 @@ Authors: Mario Carneiro, Neil Strickland
 import Mathlib.Algebra.NeZero
 import Mathlib.Data.Nat.Cast.Defs
 import Mathlib.Order.Basic
-import Mathlib.Tactic.Coe
-import Mathlib.Tactic.Lift
 
 /-!
 # The positive natural numbers

--- a/Mathlib/Data/Pi/Algebra.lean
+++ b/Mathlib/Data/Pi/Algebra.lean
@@ -13,7 +13,6 @@ import Mathlib.Algebra.Group.Defs
 import Mathlib.Data.Prod.Basic
 import Mathlib.Logic.Unique
 import Mathlib.Data.Sum.Basic
-import Mathlib.Tactic.Classical
 
 /-!
 # Instances and theorems on pi types

--- a/Mathlib/Data/Prod/Basic.lean
+++ b/Mathlib/Data/Prod/Basic.lean
@@ -12,7 +12,7 @@ import Mathlib.Init.Core
 import Mathlib.Init.Data.Prod
 import Mathlib.Init.Function
 import Mathlib.Logic.Function.Basic
-import Mathlib.Tactic.Inhabit
+import Mathlib.Tactic.Common
 
 /-!
 # Extra facts about `prod`

--- a/Mathlib/Data/Rat/Floor.lean
+++ b/Mathlib/Data/Rat/Floor.lean
@@ -12,7 +12,6 @@ import Mathlib.Algebra.Order.Floor
 import Mathlib.Algebra.EuclideanDomain.Instances
 import Mathlib.Data.Rat.Cast
 import Mathlib.Tactic.FieldSimp
-import Mathlib.Tactic.Set
 
 /-!
 # Floor Function for Rational Numbers

--- a/Mathlib/Data/Rat/Lemmas.lean
+++ b/Mathlib/Data/Rat/Lemmas.lean
@@ -12,7 +12,6 @@ import Mathlib.Data.Rat.Defs
 import Mathlib.Data.Int.Cast.Lemmas
 import Mathlib.Data.Int.Div
 import Mathlib.Algebra.GroupWithZero.Units.Lemmas
-import Mathlib.Tactic.NthRewrite
 
 /-!
 # Further lemmas for the Rational Numbers

--- a/Mathlib/Data/Real/CauSeq.lean
+++ b/Mathlib/Data/Real/CauSeq.lean
@@ -928,7 +928,6 @@ protected theorem sup_eq_right {a b : CauSeq α abs} (h : a ≤ b) : a ⊔ b ≈
     exact ε0.le.trans (h _ hj)
   · refine' Setoid.trans (sup_equiv_sup h (Setoid.refl _)) _
     rw [CauSeq.sup_idem]
-    exact Setoid.refl _
 #align cau_seq.sup_eq_right CauSeq.sup_eq_right
 
 protected theorem inf_eq_right {a b : CauSeq α abs} (h : b ≤ a) : a ⊓ b ≈ b := by
@@ -941,7 +940,6 @@ protected theorem inf_eq_right {a b : CauSeq α abs} (h : b ≤ a) : a ⊓ b ≈
     exact ε0.le.trans (h _ hj)
   · refine' Setoid.trans (inf_equiv_inf (Setoid.symm h) (Setoid.refl _)) _
     rw [CauSeq.inf_idem]
-    exact Setoid.refl _
 #align cau_seq.inf_eq_right CauSeq.inf_eq_right
 
 protected theorem sup_eq_left {a b : CauSeq α abs} (h : b ≤ a) : a ⊔ b ≈ a := by

--- a/Mathlib/Data/Real/CauSeq.lean
+++ b/Mathlib/Data/Real/CauSeq.lean
@@ -15,7 +15,6 @@ import Mathlib.Algebra.Order.Field.Basic
 import Mathlib.Algebra.Ring.Pi
 import Mathlib.GroupTheory.GroupAction.Pi
 import Mathlib.Tactic.Ring
-import Mathlib.Tactic.Set
 
 /-!
 # Cauchy sequences

--- a/Mathlib/Data/Seq/Computation.lean
+++ b/Mathlib/Data/Seq/Computation.lean
@@ -11,7 +11,7 @@ Coinductive formalization of unbounded computations.
 ! if you have ported upstream changes.
 -/
 import Mathlib.Data.Stream.Init
-import Mathlib.Tactic.Basic
+import Mathlib.Tactic.Common
 
 /-!
 # Coinductive formalization of unbounded computations.

--- a/Mathlib/Data/Set/Basic.lean
+++ b/Mathlib/Data/Set/Basic.lean
@@ -10,11 +10,6 @@ Authors: Jeremy Avigad, Leonardo de Moura
 -/
 import Mathlib.Order.SymmDiff
 import Mathlib.Logic.Function.Iterate
-import Mathlib.Tactic.Use
-import Mathlib.Tactic.SolveByElim
-import Mathlib.Tactic.Tauto
-import Mathlib.Tactic.ByContra
-import Mathlib.Tactic.Lift
 
 /-!
 # Basic properties of sets

--- a/Mathlib/Data/Set/Enumerate.lean
+++ b/Mathlib/Data/Set/Enumerate.lean
@@ -10,7 +10,6 @@ Authors: Johannes Hölzl
 -/
 import Mathlib.Data.Nat.Order.Basic
 import Mathlib.Data.Set.Basic
-import Mathlib.Tactic.SwapVar
 
 /-!
 # Set enumeration

--- a/Mathlib/Data/Set/Intervals/OrdConnectedComponent.lean
+++ b/Mathlib/Data/Set/Intervals/OrdConnectedComponent.lean
@@ -9,7 +9,7 @@ Authors: Yury Kudryashov
 ! if you have ported upstream changes.
 -/
 import Mathlib.Data.Set.Intervals.OrdConnected
-import Mathlib.Tactic.SwapVar
+
 /-!
 # Order connected components of a set
 

--- a/Mathlib/Data/Set/Intervals/UnorderedInterval.lean
+++ b/Mathlib/Data/Set/Intervals/UnorderedInterval.lean
@@ -10,8 +10,6 @@ Authors: Zhouhang Zhou
 -/
 import Mathlib.Order.Bounds.Basic
 import Mathlib.Data.Set.Intervals.Basic
-import Mathlib.Tactic.ScopedNS
-import Mathlib.Tactic.Tauto
 
 /-!
 # Intervals without endpoints ordering

--- a/Mathlib/Data/Set/Pointwise/Basic.lean
+++ b/Mathlib/Data/Set/Pointwise/Basic.lean
@@ -13,7 +13,6 @@ import Mathlib.Algebra.Hom.Equiv.Basic
 import Mathlib.Algebra.Hom.Units
 import Mathlib.Data.Set.Lattice
 import Mathlib.Data.Nat.Order.Basic
-import Mathlib.Tactic.ScopedNS
 
 /-!
 # Pointwise operations of sets

--- a/Mathlib/Data/Set/Pointwise/SMul.lean
+++ b/Mathlib/Data/Set/Pointwise/SMul.lean
@@ -11,7 +11,6 @@ Authors: Johan Commelin, Floris van Doorn
 import Mathlib.Algebra.Module.Basic
 import Mathlib.Data.Set.Pairwise.Lattice
 import Mathlib.Data.Set.Pointwise.Basic
-import Mathlib.Tactic.ByContra
 
 /-!
 # Pointwise operations of sets

--- a/Mathlib/Data/Subtype.lean
+++ b/Mathlib/Data/Subtype.lean
@@ -9,7 +9,6 @@ Authors: Johannes Hölzl
 ! if you have ported upstream changes.
 -/
 import Mathlib.Logic.Function.Basic
-import Mathlib.Tactic.Simps.Basic
 
 /-!
 # Subtypes

--- a/Mathlib/Data/Sum/Basic.lean
+++ b/Mathlib/Data/Sum/Basic.lean
@@ -9,7 +9,6 @@ Authors: Mario Carneiro, Yury G. Kudryashov
 ! if you have ported upstream changes.
 -/
 import Mathlib.Logic.Function.Basic
-import Mathlib.Tactic.Rename
 
 /-!
 # Disjoint union of types

--- a/Mathlib/Data/Sum/Basic.lean
+++ b/Mathlib/Data/Sum/Basic.lean
@@ -9,7 +9,7 @@ Authors: Mario Carneiro, Yury G. Kudryashov
 ! if you have ported upstream changes.
 -/
 import Mathlib.Logic.Function.Basic
-import Mathlib.Mathport.Rename
+import Mathlib.Tactic.Rename
 
 /-!
 # Disjoint union of types

--- a/Mathlib/Data/Sym/Basic.lean
+++ b/Mathlib/Data/Sym/Basic.lean
@@ -12,7 +12,6 @@ import Mathlib.Data.Multiset.Basic
 import Mathlib.Data.Vector.Basic
 import Mathlib.Data.Setoid.Basic
 import Mathlib.Tactic.ApplyFun
-import Mathlib.Tactic.Lift
 
 /-!
 # Symmetric powers

--- a/Mathlib/Data/TypeVec.lean
+++ b/Mathlib/Data/TypeVec.lean
@@ -11,10 +11,7 @@ Authors: Jeremy Avigad, Mario Carneiro, Simon Hudon
 import Mathlib.Data.Fin.Fin2
 import Mathlib.Data.TypeVec.Attr
 import Mathlib.Logic.Function.Basic
-import Mathlib.Tactic.Basic
-import Mathlib.Tactic.ScopedNS
-import Mathlib.Tactic.Replace
-import Mathlib.Tactic.SolveByElim
+import Mathlib.Tactic.Common
 
 /-!
 

--- a/Mathlib/Dynamics/PeriodicPts.lean
+++ b/Mathlib/Dynamics/PeriodicPts.lean
@@ -14,7 +14,6 @@ import Mathlib.Data.PNat.Basic
 import Mathlib.Data.Nat.Prime
 import Mathlib.Dynamics.FixedPoints.Basic
 import Mathlib.GroupTheory.GroupAction.Group
-import Mathlib.Tactic.NthRewrite
 
 /-!
 # Periodic points

--- a/Mathlib/GroupTheory/OrderOfElement.lean
+++ b/Mathlib/GroupTheory/OrderOfElement.lean
@@ -14,7 +14,6 @@ import Mathlib.Data.Set.Pointwise.Basic
 import Mathlib.Data.Set.Intervals.Infinite
 import Mathlib.Dynamics.PeriodicPts
 import Mathlib.GroupTheory.Index
-import Mathlib.Tactic.WLOG
 
 /-!
 # Order of an element

--- a/Mathlib/Logic/Equiv/Basic.lean
+++ b/Mathlib/Logic/Equiv/Basic.lean
@@ -17,10 +17,6 @@ import Mathlib.Data.Sum.Basic
 import Mathlib.Init.Data.Sigma.Basic
 import Mathlib.Logic.Equiv.Defs
 import Mathlib.Logic.Function.Conjugate
-import Mathlib.Tactic.Convert
-import Mathlib.Tactic.Contrapose
-import Mathlib.Tactic.GeneralizeProofs
-import Mathlib.Tactic.Lift
 
 /-!
 # Equivalence between types

--- a/Mathlib/Logic/Equiv/Defs.lean
+++ b/Mathlib/Logic/Equiv/Defs.lean
@@ -12,13 +12,6 @@ import Mathlib.Data.FunLike.Equiv
 import Mathlib.Data.Quot
 import Mathlib.Init.Data.Bool.Lemmas
 import Mathlib.Logic.Unique
-import Mathlib.Tactic.Conv
-import Mathlib.Tactic.ProjectionNotation
-import Mathlib.Tactic.Relation.Rfl
-import Mathlib.Tactic.Relation.Symm
-import Mathlib.Tactic.Relation.Trans
-import Mathlib.Tactic.Simps.Basic
-import Mathlib.Tactic.Substs
 
 /-!
 # Equivalence between types

--- a/Mathlib/Logic/Pairwise.lean
+++ b/Mathlib/Logic/Pairwise.lean
@@ -11,6 +11,7 @@ Authors: Johannes Hölzl
 import Mathlib.Logic.Function.Basic
 import Mathlib.Logic.Relation
 import Mathlib.Init.Set
+import Mathlib.Tactic.Common
 
 /-!
 # Relations holding pairwise

--- a/Mathlib/Logic/Relation.lean
+++ b/Mathlib/Logic/Relation.lean
@@ -10,10 +10,8 @@ Authors: Johannes Hölzl
 -/
 import Mathlib.Logic.Relator
 import Mathlib.Init.Propext
-import Mathlib.Tactic.Relation.Rfl
-import Mathlib.Tactic.Use
 import Mathlib.Init.Data.Quot
-import Mathlib.Tactic.MkIffOfInductiveProp
+import Mathlib.Tactic.Common
 
 /-!
 # Relation closures

--- a/Mathlib/Logic/Unique.lean
+++ b/Mathlib/Logic/Unique.lean
@@ -11,7 +11,7 @@ Authors: Johan Commelin
 import Mathlib.Logic.IsEmpty
 import Mathlib.Init.Logic
 import Mathlib.Init.Data.Fin.Basic
-import Mathlib.Tactic.Inhabit
+import Mathlib.Tactic.Common
 
 /-!
 # Types with a unique term

--- a/Mathlib/Order/Basic.lean
+++ b/Mathlib/Order/Basic.lean
@@ -10,12 +10,6 @@ Authors: Jeremy Avigad, Mario Carneiro
 -/
 import Mathlib.Data.Prod.Basic
 import Mathlib.Data.Subtype
-import Mathlib.Tactic.Classical
-import Mathlib.Tactic.Convert
-import Mathlib.Tactic.Inhabit
-import Mathlib.Tactic.SimpRw
-import Mathlib.Tactic.Spread
-import Mathlib.Tactic.SplitIfs
 
 /-!
 # Basic definitions about `≤` and `<`

--- a/Mathlib/Order/BooleanAlgebra.lean
+++ b/Mathlib/Order/BooleanAlgebra.lean
@@ -9,7 +9,6 @@ Authors: Johannes Hölzl, Bryan Gin-ge Chen
 ! if you have ported upstream changes.
 -/
 import Mathlib.Order.Heyting.Basic
-import Aesop
 
 /-!
 # (Generalized) Boolean algebras

--- a/Mathlib/Order/BoundedOrder.lean
+++ b/Mathlib/Order/BoundedOrder.lean
@@ -10,10 +10,6 @@ Authors: Johannes Hölzl
 -/
 import Mathlib.Data.Option.Basic
 import Mathlib.Order.Lattice
-import Mathlib.Tactic.Classical
-import Mathlib.Tactic.Convert
-import Mathlib.Tactic.PushNeg
-import Mathlib.Tactic.SimpRw
 
 /-!
 # ⊤ and ⊥, bounded lattices and variants

--- a/Mathlib/Order/Circular.lean
+++ b/Mathlib/Order/Circular.lean
@@ -9,7 +9,6 @@ Authors: Yaël Dillies
 ! if you have ported upstream changes.
 -/
 import Mathlib.Data.Set.Basic
-import Mathlib.Tactic.Set
 
 /-!
 # Circular order hierarchy

--- a/Mathlib/Order/Extension/Linear.lean
+++ b/Mathlib/Order/Extension/Linear.lean
@@ -9,7 +9,6 @@ Authors: Bhavik Mehta
 ! if you have ported upstream changes.
 -/
 import Mathlib.Order.Zorn
-import Mathlib.Tactic.ByContra
 
 /-!
 # Extend a partial order to a linear order

--- a/Mathlib/Order/FixedPoints.lean
+++ b/Mathlib/Order/FixedPoints.lean
@@ -10,7 +10,6 @@ Authors: Johannes Hölzl, Kenny Lau, Yury Kudryashov
 -/
 import Mathlib.Dynamics.FixedPoints.Basic
 import Mathlib.Order.Hom.Order
-import Mathlib.Tactic.Set
 
 /-!
 # Fixed point construction on complete lattices

--- a/Mathlib/Order/Heyting/Boundary.lean
+++ b/Mathlib/Order/Heyting/Boundary.lean
@@ -9,7 +9,6 @@ Authors: Yaël Dillies
 ! if you have ported upstream changes.
 -/
 import Mathlib.Order.BooleanAlgebra
-import Mathlib.Tactic.ScopedNS
 
 /-!
 # Co-Heyting boundary

--- a/Mathlib/Order/Hom/Basic.lean
+++ b/Mathlib/Order/Hom/Basic.lean
@@ -13,7 +13,6 @@ import Mathlib.Order.RelIso.Basic
 import Mathlib.Order.Disjoint
 import Mathlib.Order.WithBot
 import Mathlib.Tactic.Monotonicity.Attr
-import Mathlib.Tactic.Replace
 
 /-!
 # Order homomorphisms

--- a/Mathlib/Order/Lattice.lean
+++ b/Mathlib/Order/Lattice.lean
@@ -11,7 +11,6 @@ Authors: Johannes Hölzl
 import Mathlib.Data.Bool.Basic
 import Mathlib.Init.Algebra.Order
 import Mathlib.Order.Monotone.Basic
-import Mathlib.Tactic.Simps.Basic
 
 /-!
 # (Semi-)lattices

--- a/Mathlib/Order/Max.lean
+++ b/Mathlib/Order/Max.lean
@@ -9,7 +9,6 @@ Authors: Jeremy Avigad, Yury Kudryashov, Yaël Dillies
 ! if you have ported upstream changes.
 -/
 import Mathlib.Order.Synonym
-import Mathlib.Tactic.Classical
 
 /-!
 # Minimal/maximal and bottom/top elements

--- a/Mathlib/Order/MinMax.lean
+++ b/Mathlib/Order/MinMax.lean
@@ -9,7 +9,6 @@ Authors: Mario Carneiro
 ! if you have ported upstream changes.
 -/
 import Mathlib.Order.Lattice
-import Mathlib.Tactic.SimpRw
 
 /-!
 # `max` and `min`

--- a/Mathlib/Order/Monotone/Basic.lean
+++ b/Mathlib/Order/Monotone/Basic.lean
@@ -12,9 +12,6 @@ import Mathlib.Init.Data.Int.Order
 import Mathlib.Order.Compare
 import Mathlib.Order.Max
 import Mathlib.Order.RelClasses
-import Mathlib.Tactic.Choose
-import Mathlib.Tactic.SimpRw
-import Mathlib.Tactic.Coe
 
 /-!
 # Monotonicity

--- a/Mathlib/Order/RelClasses.lean
+++ b/Mathlib/Order/RelClasses.lean
@@ -11,7 +11,6 @@ Authors: Jeremy Avigad, Mario Carneiro, Yury G. Kudryashov
 import Mathlib.Logic.IsEmpty
 import Mathlib.Logic.Relation
 import Mathlib.Order.Basic
-import Mathlib.Tactic.MkIffOfInductiveProp
 
 /-!
 # Unbundled relation classes

--- a/Mathlib/Order/WellFounded.lean
+++ b/Mathlib/Order/WellFounded.lean
@@ -8,7 +8,6 @@ Authors: Jeremy Avigad, Mario Carneiro
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
-import Mathlib.Tactic.ByContra
 import Mathlib.Data.Set.Image
 
 /-!

--- a/Mathlib/Order/WithBot.lean
+++ b/Mathlib/Order/WithBot.lean
@@ -10,7 +10,6 @@ Authors: Johannes Hölzl
 -/
 import Mathlib.Order.BoundedOrder
 import Mathlib.Data.Option.NAry
-import Mathlib.Tactic.Lift
 
 /-!
 # `WithBot`, `WithTop`

--- a/Mathlib/RingTheory/Valuation/Basic.lean
+++ b/Mathlib/RingTheory/Valuation/Basic.lean
@@ -10,7 +10,6 @@ Authors: Kevin Buzzard, Johan Commelin, Patrick Massot
 -/
 import Mathlib.Algebra.Order.WithZero
 import Mathlib.RingTheory.Ideal.Operations
-import Mathlib.Tactic.WLOG
 import Mathlib.Tactic.TFAE
 
 /-!

--- a/Mathlib/SetTheory/Ordinal/Arithmetic.lean
+++ b/Mathlib/SetTheory/Ordinal/Arithmetic.lean
@@ -9,7 +9,6 @@ Authors: Mario Carneiro, Floris van Doorn, Violeta Hernández Palacios
 ! if you have ported upstream changes.
 -/
 import Mathlib.SetTheory.Ordinal.Basic
-import Mathlib.Tactic.ByContra
 
 /-!
 # Ordinal arithmetic

--- a/Mathlib/SetTheory/Ordinal/NaturalOps.lean
+++ b/Mathlib/SetTheory/Ordinal/NaturalOps.lean
@@ -9,7 +9,7 @@ Authors: Violeta Hernández Palacios
 ! if you have ported upstream changes.
 -/
 import Mathlib.SetTheory.Ordinal.Arithmetic
-import Mathlib.Tactic.SolveByElim
+
 /-!
 # Natural operations on ordinals
 

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -16,6 +16,7 @@ import Mathlib.Tactic.Clear!
 import Mathlib.Tactic.ClearExcept
 import Mathlib.Tactic.Clear_
 import Mathlib.Tactic.Coe
+import Mathlib.Tactic.Common
 import Mathlib.Tactic.Congr!
 import Mathlib.Tactic.Constructor
 import Mathlib.Tactic.Continuity

--- a/Mathlib/Tactic/Backtracking.lean
+++ b/Mathlib/Tactic/Backtracking.lean
@@ -45,7 +45,8 @@ def Except.emoji : Except ε α → String
 returning the list of elements on which the function fails, and the list of successful results. -/
 def List.tryAllM [Monad m] [Alternative m] (L : List α) (f : α → m β) : m (List α × List β) := do
   let R ← L.mapM (fun a => (Sum.inr <$> f a) <|> (pure (Sum.inl a)))
-  return (R.filterMap Sum.getLeft, R.filterMap Sum.getRight)
+  return (R.filterMap (fun s => match s with | .inl a => a | _ => none),
+    R.filterMap (fun s => match s with | .inr b => b | _ => none))
 
 namespace Lean.MVarId
 

--- a/Mathlib/Tactic/Common.lean
+++ b/Mathlib/Tactic/Common.lean
@@ -1,0 +1,98 @@
+/-
+Copyright (c) 2023 Scott Morrison. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Scott Morrison
+-/
+
+/-
+This file imports all tactics which do not have significant theory imports,
+and hence can be imported very low in the theory import hierarchy,
+thereby making tactics widely available without needing specific imports.
+
+We include some commented out imports here, with an explanation of their theory requirements,
+to save some time for anyone wondering why they are not here.
+-/
+
+import Mathlib.Mathport.Rename
+import Mathlib.Tactic.Alias
+import Mathlib.Tactic.ApplyCongr
+-- ApplyFun imports `Mathlib.Order.Monotone.Basic`
+-- import Mathlib.Tactic.ApplyFun
+import Mathlib.Tactic.ApplyWith
+import Mathlib.Tactic.Basic
+import Mathlib.Tactic.ByContra
+import Mathlib.Tactic.Cases
+import Mathlib.Tactic.CasesM
+import Mathlib.Tactic.Choose
+import Mathlib.Tactic.Classical
+import Mathlib.Tactic.Clear_
+import Mathlib.Tactic.Clear!
+import Mathlib.Tactic.ClearExcept
+import Mathlib.Tactic.Congr!
+import Mathlib.Tactic.Constructor
+import Mathlib.Tactic.Contrapose
+import Mathlib.Tactic.Conv
+import Mathlib.Tactic.Convert
+import Mathlib.Tactic.DeriveToExpr
+import Mathlib.Tactic.Eqns
+import Mathlib.Tactic.Existsi
+import Mathlib.Tactic.Find
+import Mathlib.Tactic.GeneralizeProofs
+import Mathlib.Tactic.GuardGoalNums
+import Mathlib.Tactic.GuardHypNums
+import Mathlib.Tactic.Have
+import Mathlib.Tactic.HelpCmd
+import Mathlib.Tactic.HigherOrder
+import Mathlib.Tactic.InferParam
+import Mathlib.Tactic.Inhabit
+import Mathlib.Tactic.IrreducibleDef
+import Mathlib.Tactic.LabelAttr
+import Mathlib.Tactic.LeftRight
+import Mathlib.Tactic.LibrarySearch
+import Mathlib.Tactic.Lift
+import Mathlib.Tactic.MkIffOfInductiveProp
+-- NormCast imports `Mathlib.Algebra.Group.Defs`
+-- import Mathlib.Tactic.NormCast
+import Mathlib.Tactic.NthRewrite
+import Mathlib.Tactic.PermuteGoals
+import Mathlib.Tactic.PrintPrefix
+import Mathlib.Tactic.ProjectionNotation
+import Mathlib.Tactic.Propose
+import Mathlib.Tactic.PushNeg
+import Mathlib.Tactic.Recover
+import Mathlib.Tactic.Rename
+import Mathlib.Tactic.RenameBVar
+import Mathlib.Tactic.Relation.Rfl
+import Mathlib.Tactic.Relation.Symm
+import Mathlib.Tactic.Relation.Trans
+import Mathlib.Tactic.Replace
+import Mathlib.Tactic.Rewrites
+import Mathlib.Tactic.RSuffices
+import Mathlib.Tactic.RunCmd
+import Mathlib.Tactic.ScopedNS
+import Mathlib.Tactic.Set
+import Mathlib.Tactic.SimpIntro
+import Mathlib.Tactic.SimpRw
+-- SlimCheck has unnecessarily complicated imports, and could be streamlined.
+-- `Gen` / `Testable` / `Sampleable` instances for types should be out in the library,
+-- rather than the theory for those types being imported into `SlimCheck`.
+-- import Mathlib.Tactic.SlimCheck
+import Mathlib.Tactic.SolveByElim
+import Mathlib.Tactic.SplitIfs
+import Mathlib.Tactic.Spread
+import Mathlib.Tactic.Substs
+import Mathlib.Tactic.SuccessIfFailWithMsg
+import Mathlib.Tactic.SudoSetOption
+import Mathlib.Tactic.SwapVar
+import Mathlib.Tactic.SplitIfs
+import Mathlib.Tactic.Tauto
+-- TFAE imports `Mathlib.Data.List.TFAE` and thence `Mathlib.Data.List.Basic`.
+-- import Mathlib.Tactic.TFAE
+import Mathlib.Tactic.ToExpr
+import Mathlib.Tactic.ToLevel
+import Mathlib.Tactic.Trace
+import Mathlib.Tactic.TryThis
+import Mathlib.Tactic.TypeCheck
+import Mathlib.Tactic.UnsetOption
+import Mathlib.Tactic.Use
+import Mathlib.Tactic.WLOG

--- a/Mathlib/Tactic/Common.lean
+++ b/Mathlib/Tactic/Common.lean
@@ -13,6 +13,11 @@ We include some commented out imports here, with an explanation of their theory 
 to save some time for anyone wondering why they are not here.
 -/
 
+-- First import Aesop and Qq
+import Aesop
+import Qq
+
+-- Now import all tactics defined in Mathlib that do not require theory files.
 import Mathlib.Mathport.Rename
 import Mathlib.Tactic.Alias
 import Mathlib.Tactic.ApplyCongr
@@ -28,6 +33,7 @@ import Mathlib.Tactic.Classical
 import Mathlib.Tactic.Clear_
 import Mathlib.Tactic.Clear!
 import Mathlib.Tactic.ClearExcept
+import Mathlib.Tactic.Coe
 import Mathlib.Tactic.Congr!
 import Mathlib.Tactic.Constructor
 import Mathlib.Tactic.Contrapose
@@ -36,6 +42,7 @@ import Mathlib.Tactic.Convert
 import Mathlib.Tactic.DeriveToExpr
 import Mathlib.Tactic.Eqns
 import Mathlib.Tactic.Existsi
+import Mathlib.Tactic.FailIfNoProgress
 import Mathlib.Tactic.Find
 import Mathlib.Tactic.GeneralizeProofs
 import Mathlib.Tactic.GuardGoalNums
@@ -53,6 +60,8 @@ import Mathlib.Tactic.Lift
 import Mathlib.Tactic.MkIffOfInductiveProp
 -- NormCast imports `Mathlib.Algebra.Group.Defs`
 -- import Mathlib.Tactic.NormCast
+-- NormNum imports `Mathlib.Algebra.GroupPower.Lemmas` and `Mathlib.Algebra.Order.Invertible`
+-- import Mathlib.Tactic.NormNum.Basic
 import Mathlib.Tactic.NthRewrite
 import Mathlib.Tactic.PermuteGoals
 import Mathlib.Tactic.PrintPrefix
@@ -73,6 +82,7 @@ import Mathlib.Tactic.ScopedNS
 import Mathlib.Tactic.Set
 import Mathlib.Tactic.SimpIntro
 import Mathlib.Tactic.SimpRw
+import Mathlib.Tactic.Simps.Basic
 -- SlimCheck has unnecessarily complicated imports, and could be streamlined.
 -- `Gen` / `Testable` / `Sampleable` instances for types should be out in the library,
 -- rather than the theory for those types being imported into `SlimCheck`.

--- a/Mathlib/Tactic/FieldSimp.lean
+++ b/Mathlib/Tactic/FieldSimp.lean
@@ -9,6 +9,7 @@ import Lean.Meta.Tactic.Simp.Main
 import Std.Lean.Parser
 import Mathlib.Algebra.Group.Units
 import Mathlib.Tactic.NormNum.Core
+import Mathlib.Tactic.Set
 import Qq
 
 /-!

--- a/Mathlib/Tactic/Set.lean
+++ b/Mathlib/Tactic/Set.lean
@@ -10,7 +10,9 @@ open Lean Elab Elab.Tactic Meta
 
 syntax setArgsRest := ppSpace ident (" : " term)? " := " term (" with " "←"? ident)?
 
-syntax (name := set) "set" "!"? setArgsRest : tactic
+-- This is called `setTactic` rather than `set`
+-- as we sometimes refer to `MonadStateOf.set` from inside `Mathlib.Tactic`.
+syntax (name := setTactic) "set" "!"? setArgsRest : tactic
 
 macro "set!" rest:setArgsRest : tactic => `(tactic|set ! $rest:setArgsRest)
 

--- a/Mathlib/Testing/SlimCheck/Gen.lean
+++ b/Mathlib/Testing/SlimCheck/Gen.lean
@@ -4,9 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Henrik Böving, Simon Hudon
 -/
 import Mathlib.Control.Random
--- import Mathlib.Data.List.Perm
--- import Mathlib.Data.Subtype
--- import Mathlib.Data.Nat.Basic
+import Mathlib.Data.List.Perm
+import Mathlib.Data.Subtype
+import Mathlib.Data.Nat.Basic
 
 /-!
 # `Gen` Monad

--- a/Mathlib/Testing/SlimCheck/Gen.lean
+++ b/Mathlib/Testing/SlimCheck/Gen.lean
@@ -4,9 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Henrik Böving, Simon Hudon
 -/
 import Mathlib.Control.Random
-import Mathlib.Data.List.Perm
-import Mathlib.Data.Subtype
-import Mathlib.Data.Nat.Basic
+-- import Mathlib.Data.List.Perm
+-- import Mathlib.Data.Subtype
+-- import Mathlib.Data.Nat.Basic
 
 /-!
 # `Gen` Monad

--- a/Mathlib/Testing/SlimCheck/Testable.lean
+++ b/Mathlib/Testing/SlimCheck/Testable.lean
@@ -3,8 +3,6 @@ Copyright (c) 2022 Henrik Böving. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Henrik Böving, Simon Hudon
 -/
-
-import Mathlib.Data.Array.Basic
 import Mathlib.Testing.SlimCheck.Sampleable
 import Lean
 

--- a/Mathlib/Topology/Algebra/Order/LeftRightLim.lean
+++ b/Mathlib/Topology/Algebra/Order/LeftRightLim.lean
@@ -8,7 +8,6 @@ Authors: Sébastien Gouëzel
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
-import Mathlib.Tactic.WLOG
 import Mathlib.Topology.Order.Basic
 import Mathlib.Topology.Algebra.Order.LeftRight
 

--- a/Mathlib/Topology/Algebra/WithZeroTopology.lean
+++ b/Mathlib/Topology/Algebra/WithZeroTopology.lean
@@ -11,7 +11,6 @@ Authors: Patrick Massot
 import Mathlib.Algebra.Order.WithZero
 import Mathlib.Topology.Algebra.GroupWithZero
 import Mathlib.Topology.Order.Basic
-import Mathlib.Tactic.WLOG
 
 /-!
 # The topology on linearly ordered commutative groups with zero

--- a/Mathlib/Topology/ContinuousFunction/Algebra.lean
+++ b/Mathlib/Topology/ContinuousFunction/Algebra.lean
@@ -12,7 +12,6 @@ import Mathlib.Algebra.Algebra.Pi
 import Mathlib.Algebra.Periodic
 import Mathlib.Algebra.Algebra.Subalgebra.Basic
 import Mathlib.Algebra.Star.StarAlgHom
-import Mathlib.Tactic.Constructor
 import Mathlib.Tactic.FieldSimp
 import Mathlib.Topology.Algebra.Module.Basic
 import Mathlib.Topology.Algebra.InfiniteSum.Basic

--- a/Mathlib/Topology/MetricSpace/EMetricParacompact.lean
+++ b/Mathlib/Topology/MetricSpace/EMetricParacompact.lean
@@ -9,7 +9,6 @@ Authors: Yury G. Kudryashov
 ! if you have ported upstream changes.
 -/
 import Mathlib.SetTheory.Ordinal.Basic
-import Mathlib.Tactic.WLOG
 import Mathlib.Topology.MetricSpace.EMetricSpace
 import Mathlib.Topology.Paracompact
 

--- a/Mathlib/Topology/Separation.lean
+++ b/Mathlib/Topology/Separation.lean
@@ -8,8 +8,6 @@ Authors: Johannes Hölzl, Mario Carneiro
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
-import Mathlib.Tactic.RSuffices
-import Mathlib.Tactic.WLOG
 import Mathlib.Topology.SubsetProperties
 import Mathlib.Topology.Connected
 import Mathlib.Topology.NhdsSet

--- a/test/Simps.lean
+++ b/test/Simps.lean
@@ -958,7 +958,7 @@ def some_test1 (M : Type _) [CommMonoid M] : Subtype (λ _ : M => True) := ⟨1,
 
 run_cmd liftTermElabM <| do
   let env ← getEnv
-  guard <| env.find? `some_test2_val |>.isSome
+  guard <| env.find? `some_test2_coe |>.isSome
 
 end
 


### PR DESCRIPTION
This makes a mathlib4 version of mathlib3's `tactic.basic`, now called `Mathlib.Tactic.Common`, which imports all tactics which do not have significant theory requirements, and then is imported all across the base of the hierarchy.

This ensures that all common tactics are available nearly everywhere in the library, rather than having to be imported one-by-one as you need them.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
