### PR TITLE
[Merged by Bors] - chore Set/UnionLift: generalize to Sort

### DIFF
--- a/Mathlib/Data/Set/UnionLift.lean
+++ b/Mathlib/Data/Set/UnionLift.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes
 
 ! This file was ported from Lean 3 source module data.set.Union_lift
-! leanprover-community/mathlib commit 207cfac9fcd06138865b5d04f7091e46d9320432
+! leanprover-community/mathlib commit 5a4ea8453f128345f73cc656e80a49de2a54f481
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/

--- a/Mathlib/Data/Set/UnionLift.lean
+++ b/Mathlib/Data/Set/UnionLift.lean
@@ -41,7 +41,7 @@ constants, unary functions, or binary functions are preserved. These lemmas are:
 directed union, directed supremum, glue, gluing
 -/
 
-variable {α ι β : Sort _}
+variable {α : Type _} {ι β : Sort _}
 
 namespace Set
 

--- a/Mathlib/Data/Set/UnionLift.lean
+++ b/Mathlib/Data/Set/UnionLift.lean
@@ -41,7 +41,7 @@ constants, unary functions, or binary functions are preserved. These lemmas are:
 directed union, directed supremum, glue, gluing
 -/
 
-variable {ι α β : Sort _}
+variable {α ι β : Sort _}
 
 namespace Set
 

--- a/Mathlib/Data/Set/UnionLift.lean
+++ b/Mathlib/Data/Set/UnionLift.lean
@@ -41,7 +41,7 @@ constants, unary functions, or binary functions are preserved. These lemmas are:
 directed union, directed supremum, glue, gluing
 -/
 
-variable {α ι β : Type _}
+variable {ι α β : Sort _}
 
 namespace Set
 


### PR DESCRIPTION
---

* [`data.set.Union_lift`@`207cfac9fcd06138865b5d04f7091e46d9320432`..`5a4ea8453f128345f73cc656e80a49de2a54f481`](https://leanprover-community.github.io/mathlib-port-status/file/data/set/Union_lift?range=207cfac9fcd06138865b5d04f7091e46d9320432..5a4ea8453f128345f73cc656e80a49de2a54f481)
- [x] depends on: leanprover-community/mathlib#19033

This should make the suggestions Eric made in #4038 easier.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
