### PR TITLE
chore: don't rely on linkifier in maintainer merge bot

### DIFF
--- a/.github/workflows/maintainer_merge_comment.yml
+++ b/.github/workflows/maintainer_merge_comment.yml
@@ -30,7 +30,7 @@ jobs:
           type: 'stream'
           topic: 'maintainer merge'
           content: |
-            ${{ format('{0} requested a maintainer merge on PR #{1}:', github.event.comment.user.login, github.event.issue.number) }}
+            ${{ format('{0} requested a maintainer merge on PR [#{1}]({2}):', github.event.comment.user.login, github.event.issue.number, github.event.issue.url) }}
 
             > ${{ github.event.issue.title }}
 

--- a/.github/workflows/maintainer_merge_review.yml
+++ b/.github/workflows/maintainer_merge_review.yml
@@ -28,7 +28,7 @@ jobs:
           type: 'stream'
           topic: 'maintainer merge'
           content: |
-            ${{ format('{0} requested a maintainer merge on PR #{1}:', github.event.review.user.login, github.event.pull_request.number) }}
+            ${{ format('{0} requested a maintainer merge on PR [#{1}]({2}):', github.event.comment.user.login, github.event.pull_request.number, github.event.pull_request.url) }}
 
             > ${{ github.event.pull_request.title }}
 

--- a/.github/workflows/maintainer_merge_review_comment.yml
+++ b/.github/workflows/maintainer_merge_review_comment.yml
@@ -28,7 +28,7 @@ jobs:
           type: 'stream'
           topic: 'maintainer merge'
           content: |
-            ${{ format('{0} requested a maintainer merge on PR #{1}:', github.event.comment.user.login, github.event.pull_request.number) }}
+            ${{ format('{0} requested a maintainer merge on PR [#{1}]({2}):', github.event.comment.user.login, github.event.pull_request.number, github.event.pull_request.url) }}
 
             > ${{ github.event.pull_request.title }}
 


### PR DESCRIPTION
Not tested, and I'm just guessing that the relevant properties exist as I can't find the relevant API docs...

Per https://leanprover.zulipchat.com/#narrow/stream/345428-mathlib-reviewers/topic/maintainer.20merge/near/359509442

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
