### PR TITLE
[Merged by Bors] - fix: remove duplicate syntax definitions

### DIFF
--- a/Mathlib/Data/Matrix/Notation.lean
+++ b/Mathlib/Data/Matrix/Notation.lean
@@ -75,7 +75,8 @@ end toExpr
 section Parser
 open Lean Elab Term Macro TSyntax
 
-syntax (name := matrixNotation) "!![" sepBy1(term,+,?, ";", "; ", allowTrailingSep) "]" : term
+syntax (name := matrixNotation)
+  "!![" ppRealGroup(sepBy1(ppGroup(term,+,?), ";", "; ", allowTrailingSep)) "]" : term
 syntax (name := matrixNotationRx0) "!![" ";"* "]" : term
 syntax (name := matrixNotation0xC) "!![" ","+ "]" : term
 

--- a/Mathlib/Mathport/Syntax.lean
+++ b/Mathlib/Mathport/Syntax.lean
@@ -7,13 +7,17 @@ import Lean.Elab.Command
 import Lean.Elab.Quotation
 import Std.Tactic.Ext
 import Std.Tactic.RCases
+import Mathlib.Data.Matrix.Notation
 import Mathlib.Logic.Equiv.LocalEquiv
 import Mathlib.Order.Filter.Basic
+import Mathlib.SetTheory.Game.PGame
 import Mathlib.Tactic.Abel
 import Mathlib.Tactic.Alias
+import Mathlib.Tactic.ApplyCongr
 import Mathlib.Tactic.ApplyFun
 import Mathlib.Tactic.ApplyWith
 import Mathlib.Tactic.ByContra
+import Mathlib.Tactic.CancelDenoms
 import Mathlib.Tactic.Cases
 import Mathlib.Tactic.CasesM
 import Mathlib.Tactic.Choose
@@ -27,6 +31,7 @@ import Mathlib.Tactic.Contrapose
 import Mathlib.Tactic.Conv
 import Mathlib.Tactic.Convert
 import Mathlib.Tactic.Core
+import Mathlib.Tactic.Elementwise
 import Mathlib.Tactic.Existsi
 import Mathlib.Tactic.FieldSimp
 import Mathlib.Tactic.FinCases
@@ -39,8 +44,10 @@ import Mathlib.Tactic.Inhabit
 import Mathlib.Tactic.IrreducibleDef
 import Mathlib.Tactic.LeftRight
 import Mathlib.Tactic.LibrarySearch
+import Mathlib.Tactic.Lift
 import Mathlib.Tactic.Linarith
 import Mathlib.Tactic.LinearCombination
+import Mathlib.Tactic.Measurability
 import Mathlib.Tactic.MkIffOfInductiveProp
 import Mathlib.Tactic.ModCases
 import Mathlib.Tactic.Monotonicity
@@ -163,6 +170,9 @@ namespace Tactic
 
 /- M -/ syntax (name := congrM) "congrm " term : tactic
 /- E -/ syntax (name := acChange) "ac_change " term (" using " num)? : tactic
+
+/- S -/ syntax (name := rcases?) "rcases?" casesTarget,* (" : " num)? : tactic
+/- S -/ syntax (name := rintro?) "rintro?" (" : " num)? : tactic
 
 /- M -/ syntax (name := decide!) "decide!" : tactic
 
@@ -298,8 +308,6 @@ namespace Attr
 /- S -/ syntax (name := protectProj) "protect_proj" (&" without" (ppSpace ident)+)? : attr
 
 /- M -/ syntax (name := notationClass) "notation_class" "*"? (ppSpace ident)? : attr
-
-/- M -/ syntax (name := elementwise) "elementwise" (ppSpace ident)? : attr
 
 /- N -/ syntax (name := pp_nodot) "pp_nodot" : attr
 

--- a/Mathlib/Mathport/Syntax.lean
+++ b/Mathlib/Mathport/Syntax.lean
@@ -158,15 +158,11 @@ namespace Tactic
 /- S -/ syntax (name := revertDeps) "revert_deps" (ppSpace colGt ident)* : tactic
 /- S -/ syntax (name := revertAfter) "revert_after " ident : tactic
 /- S -/ syntax (name := revertTargetDeps) "revert_target_deps" : tactic
-/- E -/ syntax (name := clearValue) "clear_value" (ppSpace colGt ident)* : tactic
 
 /- S -/ syntax (name := hint) "hint" : tactic
 
 /- M -/ syntax (name := congrM) "congrm " term : tactic
 /- E -/ syntax (name := acChange) "ac_change " term (" using " num)? : tactic
-
-/- S -/ syntax (name := rcases?) "rcases?" casesTarget,* (" : " num)? : tactic
-/- S -/ syntax (name := rintro?) "rintro?" (" : " num)? : tactic
 
 /- M -/ syntax (name := decide!) "decide!" : tactic
 
@@ -195,9 +191,6 @@ syntax generalizingClause := " generalizing" (ppSpace ident)+
 syntax termList := " [" term,* "]"
 /- B -/ syntax (name := itauto) "itauto" (" *" <|> termList)? : tactic
 /- B -/ syntax (name := itauto!) "itauto!" (" *" <|> termList)? : tactic
-
-/- B -/ syntax (name := lift) "lift " term " to " term
-  (" using " term)? (" with " binderIdent+)? : tactic
 
 /- B -/ syntax (name := obviously) "obviously" : tactic
 
@@ -233,8 +226,6 @@ syntax termList := " [" term,* "]"
 
 /- M -/ syntax (name := group) "group" (ppSpace location)? : tactic
 
-/- M -/ syntax (name := cancelDenoms) "cancel_denoms" (ppSpace location)? : tactic
-
 /- S -/ syntax (name := transport) "transport" (ppSpace term)? " using " term : tactic
 
 /- M -/ syntax (name := unfoldCases) "unfold_cases " tacticSeq : tactic
@@ -255,8 +246,6 @@ syntax termList := " [" term,* "]"
 /- B -/ syntax (name := tidy) "tidy" (config)? : tactic
 /- B -/ syntax (name := tidy?) "tidy?" (config)? : tactic
 
-/- M -/ syntax (name := elementwise) "elementwise" (ppSpace (colGt ident))* : tactic
-/- M -/ syntax (name := elementwise!) "elementwise!" (ppSpace (colGt ident))* : tactic
 /- M -/ syntax (name := deriveElementwiseProof) "derive_elementwise_proof" : tactic
 
 /- M -/ syntax (name := computeDegreeLE) "compute_degree_le" : tactic
@@ -272,10 +261,6 @@ syntax termList := " [" term,* "]"
 
 /- E -/ syntax (name := unitInterval) "unit_interval" : tactic
 
-/- N -/ syntax (name := measurability) "measurability" (config)? : tactic
-/- N -/ syntax (name := measurability!) "measurability!" (config)? : tactic
-/- N -/ syntax (name := measurability?) "measurability?" (config)? : tactic
-/- N -/ syntax (name := measurability!?) "measurability!?" (config)? : tactic
 /- M -/ syntax (name := padicIndexSimp) "padic_index_simp" " [" term,* "]" (ppSpace location)? :
   tactic
 
@@ -292,20 +277,12 @@ syntax termList := " [" term,* "]"
 /- M -/ syntax (name := pure_coherence) "pure_coherence" : tactic
 /- M -/ syntax (name := coherence) "coherence" : tactic
 
-/- E -/ syntax (name := pgameWFTac) "pgame_wf_tac" : tactic
-
 /- M -/ syntax (name := moveOp) "move_op " term:max rwRule,+ (location)? : tactic
 macro (name := moveMul) "move_mul " pats:rwRule,+ loc:(location)? : tactic =>
   `(tactic| move_op (·*·) $pats,* $(loc)?)
 macro (name := moveAdd) "move_add " pats:rwRule,+ loc:(location)? : tactic =>
   `(tactic| move_op (·+·) $pats,* $(loc)?)
 
-namespace Conv
-
--- https://github.com/leanprover-community/mathlib/issues/2882
-/- M -/ syntax (name := applyCongr) "apply_congr" (ppSpace (colGt term))? : conv
-
-end Conv
 end Tactic
 
 namespace Attr
@@ -354,12 +331,3 @@ namespace Command
 /- E -/ syntax (name := assertNoInstance) "assert_no_instance " term : command
 
 end Command
-
-namespace Term
-
-/- M -/ syntax (name := matrixNotation)
-  "!![" ppRealGroup(sepBy1(ppGroup(term,+,?), ";", "; ", allowTrailingSep)) "]" : term
-/- M -/ syntax (name := matrixNotationRx0) "!![" ";"* "]" : term
-/- M -/ syntax (name := matrixNotation0xC) "!![" ","+ "]" : term
-
-end Term

--- a/Mathlib/Tactic/ApplyCongr.lean
+++ b/Mathlib/Tactic/ApplyCongr.lean
@@ -82,6 +82,9 @@ def Lean.Elab.Tactic.applyCongr (q : Option Expr) : TacticM Unit := do
 
 syntax (name := Lean.Parser.Tactic.applyCongr) "apply_congr" (ppSpace (colGt term))? : conv
 
+-- TODO: add `apply_congr with h` to specify hypothesis name
+-- https://github.com/leanprover-community/mathlib/issues/2882
+
 elab_rules : conv
   | `(conv| apply_congr$[ $t?]?) => do
     let e? ← t?.mapM (fun t => elabTerm t.raw none)

--- a/Mathlib/Tactic/Elementwise.lean
+++ b/Mathlib/Tactic/Elementwise.lean
@@ -227,4 +227,8 @@ elab "elementwise_of% " t:term : term => do
   let (pf, _) ← elementwiseExpr .anonymous (← inferType e) e (simpSides := false)
   return pf
 
+-- TODO: elementwise tactic
+syntax "elementwise" (ppSpace (colGt ident))* : tactic
+syntax "elementwise!" (ppSpace (colGt ident))* : tactic
+
 end Tactic.Elementwise

--- a/Mathlib/Tactic/Measurability.lean
+++ b/Mathlib/Tactic/Measurability.lean
@@ -12,6 +12,8 @@ import Mathlib.Algebra.Group.Defs
 
 We define the `measurability` tactic using `aesop`. -/
 
+open Lean.Parser.Tactic (config)
+
 attribute [aesop (rule_sets [Measurable]) unfold norm] Function.comp
 attribute [aesop (rule_sets [Measurable]) unfold norm] npowRec
 
@@ -24,12 +26,14 @@ macro "measurability" : attr =>
 The tactic `measurability` solves goals of the form `Measurable f`, `AEMeasurable f`,
 `AEStronglyMeasurable f μ`, or `MeasurableSet s` by applying lemmas tagged with the
 `measurability` user attribute. -/
-macro "measurability" : tactic =>
-  `(tactic|aesop (options := { terminal := true }) (rule_sets [$(Lean.mkIdent `Measurable):ident]))
+macro "measurability" (config)? : tactic =>
+  `(tactic| aesop (options := { terminal := true }) (rule_sets [$(Lean.mkIdent `Measurable):ident]))
 
 -- Todo: implement `measurability?`, `measurability!` and `measurability!?` and add configuration,
 -- original syntax was (same for the missing `measurability` variants):
--- syntax (name := measurability) "measurability" (config)? : tactic
+syntax (name := measurability!) "measurability!" (config)? : tactic
+syntax (name := measurability?) "measurability?" (config)? : tactic
+syntax (name := measurability!?) "measurability!?" (config)? : tactic
 
 /- Todo:
 Give the below attr to `Measurable.aestronglyMeasurable` when we port


### PR DESCRIPTION
Many of the tactics stubbed in Mathlib.Mathport.Syntax have been implemented already, but we forgot about removing the stubs.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
