### PR TITLE
[Merged by Bors] - chore: Add reference for SRL

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Regularity/Energy.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Regularity/Energy.lean
@@ -63,10 +63,9 @@ theorem energy_le_one : P.energy G ≤ 1 :=
 
 @[simp, norm_cast]
 theorem coe_energy {𝕜 : Type _} [LinearOrderedField 𝕜] :
-    (P.energy G : 𝕜) = (∑ uv in P.parts.offDiag, G.edgeDensity uv.1 uv.2 ^ 2) / P.parts.card ^ 2 :=
-  by
-  rw [energy]
-  norm_cast
+    (P.energy G : 𝕜) =
+      (∑ uv in P.parts.offDiag, G.edgeDensity uv.1 uv.2 ^ 2 : ℚ) / ((↑P.parts.card : ℚ) ^ 2 : ℚ) :=
+  by rw [energy]; norm_cast
 #align finpartition.coe_energy Finpartition.coe_energy
 
 end Finpartition

--- a/Mathlib/Combinatorics/SimpleGraph/Regularity/Energy.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Regularity/Energy.lean
@@ -4,13 +4,14 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies, Bhavik Mehta
 
 ! This file was ported from Lean 3 source module combinatorics.simple_graph.regularity.energy
-! leanprover-community/mathlib commit f7707875544ef1f81b32cb68c79e0e24e45a0e76
+! leanprover-community/mathlib commit bf7ef0e83e5b7e6c1169e97f055e58a2e4e9d52d
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
 import Mathlib.Algebra.BigOperators.Order
 import Mathlib.Algebra.Module.Basic
 import Mathlib.Combinatorics.SimpleGraph.Density
+import Mathlib.Data.Rat.BigOperators
 
 /-!
 # Energy of a partition
@@ -20,6 +21,10 @@ This file defines the energy of a partition.
 The energy is the auxiliary quantity that drives the induction process in the proof of Szemerédi's
 Regularity Lemma. As long as we do not have a suitable equipartition, we will find a new one that
 has an energy greater than the previous one plus some fixed constant.
+
+## References
+
+[Yaël Dillies, Bhavik Mehta, *Formalising Szemerédi’s Regularity Lemma in Lean*][srl_itp]
 -/
 
 
@@ -55,5 +60,13 @@ theorem energy_le_one : P.energy G ≤ 1 :=
         rw [sq]
         exact tsub_le_self
 #align finpartition.energy_le_one Finpartition.energy_le_one
+
+@[simp, norm_cast]
+theorem coe_energy {𝕜 : Type _} [LinearOrderedField 𝕜] :
+    (P.energy G : 𝕜) = (∑ uv in P.parts.offDiag, G.edgeDensity uv.1 uv.2 ^ 2) / P.parts.card ^ 2 :=
+  by
+  rw [energy]
+  norm_cast
+#align finpartition.coe_energy Finpartition.coe_energy
 
 end Finpartition

--- a/Mathlib/Combinatorics/SimpleGraph/Regularity/Equitabilise.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Regularity/Equitabilise.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies, Bhavik Mehta
 
 ! This file was ported from Lean 3 source module combinatorics.simple_graph.regularity.equitabilise
-! leanprover-community/mathlib commit 4c19a16e4b705bf135cf9a80ac18fcc99c438514
+! leanprover-community/mathlib commit bf7ef0e83e5b7e6c1169e97f055e58a2e4e9d52d
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -24,6 +24,10 @@ This file allows to blow partitions up into parts of controlled size. Given a pa
 * `Finpartition.equitabilise`: `P.equitabilise h` where `h : a * m + b * (m + 1)` is a partition
   with `a` parts of size `m` and `b` parts of size `m + 1` which almost refines `P`.
 * `Finpartition.exists_equipartition_card_eq`: We can find equipartitions of arbitrary size.
+
+## References
+
+[Yaël Dillies, Bhavik Mehta, *Formalising Szemerédi’s Regularity Lemma in Lean*][srl_itp]
 -/
 
 

--- a/Mathlib/Combinatorics/SimpleGraph/Regularity/Uniform.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Regularity/Uniform.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies, Bhavik Mehta
 
 ! This file was ported from Lean 3 source module combinatorics.simple_graph.regularity.uniform
-! leanprover-community/mathlib commit 32b08ef840dd25ca2e47e035c5da03ce16d2dc3c
+! leanprover-community/mathlib commit bf7ef0e83e5b7e6c1169e97f055e58a2e4e9d52d
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -35,6 +35,10 @@ is less than `ε`.
 * `Finpartition.IsUniform`: Uniformity of a partition.
 * `Finpartition.nonuniformWitnesses`: For each non-uniform pair of parts of a partition, pick
   witnesses of non-uniformity and dump them all together.
+
+## References
+
+[Yaël Dillies, Bhavik Mehta, *Formalising Szemerédi’s Regularity Lemma in Lean*][srl_itp]
 -/
 
 
@@ -168,13 +172,13 @@ theorem nonuniformWitness_subset (h : ¬G.IsUniform ε s t) : G.nonuniformWitnes
   · exact G.right_nonuniformWitnesses_subset fun i => h i.symm
 #align simple_graph.nonuniform_witness_subset SimpleGraph.nonuniformWitness_subset
 
-theorem nonuniformWitness_card_le (h : ¬G.IsUniform ε s t) :
+theorem le_card_nonuniformWitness (h : ¬G.IsUniform ε s t) :
     (s.card : 𝕜) * ε ≤ (G.nonuniformWitness ε s t).card := by
   unfold nonuniformWitness
   split_ifs
   · exact G.left_nonuniformWitnesses_card h
   · exact G.right_nonuniformWitnesses_card fun i => h i.symm
-#align simple_graph.nonuniform_witness_card_le SimpleGraph.nonuniformWitness_card_le
+#align simple_graph.le_card_nonuniform_witness SimpleGraph.le_card_nonuniformWitness
 
 theorem nonuniformWitness_spec (h₁ : s ≠ t) (h₂ : ¬G.IsUniform ε s t) : ε ≤ |G.edgeDensity
     (G.nonuniformWitness ε s t) (G.nonuniformWitness ε t s) - G.edgeDensity s t| := by


### PR DESCRIPTION
Match https://github.com/leanprover-community/mathlib/pull/19051 (and one line of https://github.com/leanprover-community/mathlib/pull/18371)

* [`combinatorics.simple_graph.regularity.energy`@`f7707875544ef1f81b32cb68c79e0e24e45a0e76`..`bf7ef0e83e5b7e6c1169e97f055e58a2e4e9d52d`](https://leanprover-community.github.io/mathlib-port-status/file/combinatorics/simple_graph/regularity/energy?range=f7707875544ef1f81b32cb68c79e0e24e45a0e76..bf7ef0e83e5b7e6c1169e97f055e58a2e4e9d52d)
* [`combinatorics.simple_graph.regularity.equitabilise`@`4c19a16e4b705bf135cf9a80ac18fcc99c438514`..`bf7ef0e83e5b7e6c1169e97f055e58a2e4e9d52d`](https://leanprover-community.github.io/mathlib-port-status/file/combinatorics/simple_graph/regularity/equitabilise?range=4c19a16e4b705bf135cf9a80ac18fcc99c438514..bf7ef0e83e5b7e6c1169e97f055e58a2e4e9d52d)
* [`combinatorics.simple_graph.regularity.uniform`@`32b08ef840dd25ca2e47e035c5da03ce16d2dc3c`..`bf7ef0e83e5b7e6c1169e97f055e58a2e4e9d52d`](https://leanprover-community.github.io/mathlib-port-status/file/combinatorics/simple_graph/regularity/uniform?range=32b08ef840dd25ca2e47e035c5da03ce16d2dc3c..bf7ef0e83e5b7e6c1169e97f055e58a2e4e9d52d)


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
