### PR TITLE
[Merged by Bors] - feat: allow cancel_denoms to handle equalities and inequalities over fields

### DIFF
--- a/Mathlib/Tactic/CancelDenoms.lean
+++ b/Mathlib/Tactic/CancelDenoms.lean
@@ -213,7 +213,8 @@ def derive (e : Expr) : MetaM (ℕ × Expr) := do
 
 /--
 `findCompLemma e` arranges `e` in the form `lhs R rhs`, where `R ∈ {<, ≤, =, ≠}`, and returns
-`lhs`, `rhs`, and the `cancel_factors` lemma corresponding to `R`.
+`lhs`, `rhs`, the `cancel_factors` lemma corresponding to `R`, and a boolean indicating whether
+`R` involves the order (i.e. `<` and `≤`) or not (i.e. `=` and `≠`).
 In the case of `LT`, `LE`, `GE`, and `GT` an order on the type is needed, in the last case
 it is not, the final component of the return value tracks this.
 -/

--- a/Mathlib/Tactic/CancelDenoms.lean
+++ b/Mathlib/Tactic/CancelDenoms.lean
@@ -77,8 +77,8 @@ theorem cancel_factors_le {α} [LinearOrderedField α] {a b ad bd a' b' gcd : α
   · exact one_div_pos.2 hgcd
 #align cancel_factors.cancel_factors_le CancelDenoms.cancel_factors_le
 
-theorem cancel_factors_eq {α} [LinearOrderedField α] {a b ad bd a' b' gcd : α} (ha : ad * a = a')
-    (hb : bd * b = b') (had : 0 < ad) (hbd : 0 < bd) (hgcd : 0 < gcd) :
+theorem cancel_factors_eq {α} [Field α] {a b ad bd a' b' gcd : α} (ha : ad * a = a')
+    (hb : bd * b = b') (had : ad ≠ 0) (hbd : bd ≠ 0) (hgcd : gcd ≠ 0) :
     (a = b) = (1 / gcd * (bd * a') = 1 / gcd * (ad * b')) := by
   rw [← ha, ← hb, ← mul_assoc bd, ← mul_assoc ad, mul_comm bd]
   ext; constructor
@@ -89,10 +89,11 @@ theorem cancel_factors_eq {α} [LinearOrderedField α] {a b ad bd a' b' gcd : α
     refine' mul_left_cancel₀ (mul_ne_zero _ _) h
     apply mul_ne_zero
     apply div_ne_zero
-    all_goals apply ne_of_gt ; first | assumption | exact zero_lt_one
+    exact one_ne_zero
+    all_goals assumption
 #align cancel_factors.cancel_factors_eq CancelDenoms.cancel_factors_eq
 
-/-! ### Computing cancelation factors -/
+/-! ### Computing cancellation factors -/
 
 /--
 `findCancelFactor e` produces a natural number `n`, such that multiplying `e` by `n` will
@@ -208,13 +209,13 @@ def derive (e : Expr) : MetaM (ℕ × Expr) := do
 `findCompLemma e` arranges `e` in the form `lhs R rhs`, where `R ∈ {<, ≤, =}`, and returns
 `lhs`, `rhs`, and the `cancel_factors` lemma corresponding to `R`.
 -/
-def findCompLemma (e : Expr) : Option (Expr × Expr × Name) :=
+def findCompLemma (e : Expr) : Option (Expr × Expr × Name × Bool) :=
   match e.getAppFnArgs with
-  | (``LT.lt, #[_, _, a, b]) => (a, b, ``cancel_factors_lt)
-  | (``LE.le, #[_, _, a, b]) => (a, b, ``cancel_factors_le)
-  | (``Eq, #[_, a, b]) => (a, b, ``cancel_factors_eq)
-  | (``GE.ge, #[_, _, a, b]) => (b, a, ``cancel_factors_le)
-  | (``GT.gt, #[_, _, a, b]) => (b, a, ``cancel_factors_lt)
+  | (``LT.lt, #[_, _, a, b]) => (a, b, ``cancel_factors_lt, true)
+  | (``LE.le, #[_, _, a, b]) => (a, b, ``cancel_factors_le, true)
+  | (``Eq, #[_, a, b]) => (a, b, ``cancel_factors_eq, false)
+  | (``GE.ge, #[_, _, a, b]) => (b, a, ``cancel_factors_le, true)
+  | (``GT.gt, #[_, _, a, b]) => (b, a, ``cancel_factors_lt, true)
   | _ => none
 
 /--
@@ -224,23 +225,31 @@ It produces an Expression `h'` of the form `lhs' R rhs'` and a proof that `h = h
 Numeric denominators have been canceled in `lhs'` and `rhs'`.
 -/
 def cancelDenominatorsInType (h : Expr) : MetaM (Expr × Expr) := do
-  let some (lhs, rhs, lem) := findCompLemma h | throwError "cannot kill factors"
+  let some (lhs, rhs, lem, ord) := findCompLemma h | throwError "cannot kill factors"
   let (al, lhs_p) ← derive lhs
   let ⟨u, α, _⟩ ← inferTypeQ' lhs
-  let _ ← synthInstanceQ q(LinearOrderedField $α)
   let amwo ← synthInstanceQ q(AddMonoidWithOne $α)
   let (ar, rhs_p) ← derive rhs
   let gcd := al.gcd ar
   have al := (← mkOfNat α amwo <| mkRawNatLit al).1
   have ar := (← mkOfNat α amwo <| mkRawNatLit ar).1
   have gcd := (← mkOfNat α amwo <| mkRawNatLit gcd).1
-  let al_pos : Q(Prop) := q(0 < $al)
-  let ar_pos : Q(Prop) := q(0 < $ar)
-  let gcd_pos : Q(Prop) := q(0 < $gcd)
-  let al_pos ← synthesizeUsingNormNum al_pos
-  let ar_pos ← synthesizeUsingNormNum ar_pos
-  let gcd_pos ← synthesizeUsingNormNum gcd_pos
-  let pf ← mkAppM lem #[lhs_p, rhs_p, al_pos, ar_pos, gcd_pos]
+  let (al_cond, ar_cond, gcd_cond) ← if ord then do
+      let _ ← synthInstanceQ q(LinearOrderedField $α)
+      let al_pos : Q(Prop) := q(0 < $al)
+      let ar_pos : Q(Prop) := q(0 < $ar)
+      let gcd_pos : Q(Prop) := q(0 < $gcd)
+      pure (al_pos, ar_pos, gcd_pos)
+    else do
+      let _ ← synthInstanceQ q(Field $α)
+      let al_ne : Q(Prop) := q($al ≠ 0)
+      let ar_ne : Q(Prop) := q($ar ≠ 0)
+      let gcd_ne : Q(Prop) := q($gcd ≠ 0)
+      pure (al_ne, ar_ne, gcd_ne)
+  let al_cond ← synthesizeUsingNormNum al_cond
+  let ar_cond ← synthesizeUsingNormNum ar_cond
+  let gcd_cond ← synthesizeUsingNormNum gcd_cond
+  let pf ← mkAppM lem #[lhs_p, rhs_p, al_cond, ar_cond, gcd_cond]
   let pf_tp ← inferType pf
   return ((findCompLemma pf_tp).elim default (Prod.fst ∘ Prod.snd), pf)
 
@@ -284,3 +293,9 @@ def cancelDenominators (loc : Location) : TacticM Unit := do
 elab "cancel_denoms" loc?:(location)? : tactic => do
   cancelDenominators (expandOptLocation (Lean.mkOptionalNode loc?))
   Lean.Elab.Tactic.evalTactic (← `(tactic| try norm_num [← mul_assoc] $[$loc?]?))
+
+variable {α : Type} [Field α] [CharZero α] (a b c d : α)
+example (h : a + b = c) : a/5 + d*(b/4) = c - 4*a/5 + b*2*d/8 - b := by
+  cancel_denoms
+  rw [← h]
+  sorry

--- a/Mathlib/Tactic/CancelDenoms.lean
+++ b/Mathlib/Tactic/CancelDenoms.lean
@@ -8,7 +8,6 @@ import Mathlib.Tactic.NormNum
 import Mathlib.Util.SynthesizeUsing
 import Mathlib.Data.Tree
 import Mathlib.Util.Qq
-import Mathlib.Tactic.LibrarySearch
 
 /-!
 # A tactic for canceling numeric denominators

--- a/Mathlib/Tactic/CancelDenoms.lean
+++ b/Mathlib/Tactic/CancelDenoms.lean
@@ -212,7 +212,7 @@ def derive (e : Expr) : MetaM (ℕ × Expr) := do
     throwError "CancelDenoms.derive failed to normalize {e}.\n{E.toMessageData}"
 
 /--
-`findCompLemma e` arranges `e` in the form `lhs R rhs`, where `R ∈ {<, ≤, =}`, and returns
+`findCompLemma e` arranges `e` in the form `lhs R rhs`, where `R ∈ {<, ≤, =, ≠}`, and returns
 `lhs`, `rhs`, and the `cancel_factors` lemma corresponding to `R`.
 In the case of `LT`, `LE`, `GE`, and `GT` an order on the type is needed, in the last case
 it is not, the final component of the return value tracks this.
@@ -229,7 +229,7 @@ def findCompLemma (e : Expr) : Option (Expr × Expr × Name × Bool) :=
 
 /--
 `cancelDenominatorsInType h` assumes that `h` is of the form `lhs R rhs`,
-where `R ∈ {<, ≤, =, ≥, >}`.
+where `R ∈ {<, ≤, =, ≠, ≥, >}`.
 It produces an Expression `h'` of the form `lhs' R rhs'` and a proof that `h = h'`.
 Numeric denominators have been canceled in `lhs'` and `rhs'`.
 -/
@@ -237,7 +237,6 @@ def cancelDenominatorsInType (h : Expr) : MetaM (Expr × Expr) := do
   let some (lhs, rhs, lem, ord) := findCompLemma h | throwError "cannot kill factors"
   let (al, lhs_p) ← derive lhs
   let ⟨u, α, _⟩ ← inferTypeQ' lhs
-  let _ ← synthInstanceQ q(Field $α)
   let amwo ← synthInstanceQ q(AddMonoidWithOne $α)
   let (ar, rhs_p) ← derive rhs
   let gcd := al.gcd ar

--- a/Mathlib/Tactic/CancelDenoms.lean
+++ b/Mathlib/Tactic/CancelDenoms.lean
@@ -292,10 +292,3 @@ def cancelDenominators (loc : Location) : TacticM Unit := do
 
 elab "cancel_denoms" loc?:(location)? : tactic => do
   cancelDenominators (expandOptLocation (Lean.mkOptionalNode loc?))
-  Lean.Elab.Tactic.evalTactic (← `(tactic| try norm_num [← mul_assoc] $[$loc?]?))
-
-variable {α : Type} [Field α] [CharZero α] (a b c d : α)
-example (h : a + b = c) : a/5 + d*(b/4) = c - 4*a/5 + b*2*d/8 - b := by
-  cancel_denoms
-  rw [← h]
-  sorry

--- a/test/cancel_denoms.lean
+++ b/test/cancel_denoms.lean
@@ -55,6 +55,7 @@ example (h : a > 0) : a / 5 > 0 := by
   cancel_denoms
   exact h
 
+variable {α : Type} [Field α] [CharZero α] (a b c d : α)
 example (h : a + b = c) : a/5 + d*(b/4) = c - 4*a/5 + b*2*d/8 - b := by
   cancel_denoms
   rw [← h]
@@ -73,6 +74,18 @@ example (h : a > 0) : a / 5 > 0 := by
   cancel_denoms
   exact h
 
+example (h : a + b = c) : a/5 + d*(b/4) = c - 4*a/5 + b*2*d/8 - b := by
+  cancel_denoms
+  rw [← h]
+  ring
+end
+
+section
+-- simulate the type of complex numbers
+def C : Type := sorry
+instance : Field C := sorry
+instance : CharZero C := sorry
+variable (a b c d : C)
 example (h : a + b = c) : a/5 + d*(b/4) = c - 4*a/5 + b*2*d/8 - b := by
   cancel_denoms
   rw [← h]

--- a/test/cancel_denoms.lean
+++ b/test/cancel_denoms.lean
@@ -78,6 +78,11 @@ example (h : a + b = c) : a/5 + d*(b/4) = c - 4*a/5 + b*2*d/8 - b := by
   cancel_denoms
   rw [← h]
   ring
+
+example (h : 40 * (4 * a + d * (5 * b)) ≠ 20 * (40 * c - 4 * (8 * a) + b * 2 * (5 * d) - 40 * b)) : a/5 + d*(b/4) ≠ c - 4*a/5 + b*2*d/8 - b := by
+  cancel_denoms
+  assumption
+
 end
 
 section


### PR DESCRIPTION
Previously it assumed a linear order, due perhaps to its historical origins as a linarith internal.
We also allow canceling in inequalities, ne. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
