### PR TITLE
[Merged by Bors] - fix: OreLocalization notation breaks []

### DIFF
--- a/Mathlib/RingTheory/OreLocalization/Basic.lean
+++ b/Mathlib/RingTheory/OreLocalization/Basic.lean
@@ -942,6 +942,3 @@ instance divisionRing : DivisionRing R[R⁰⁻¹] :=
 end DivisionRing
 
 end OreLocalization
-
-open Lean
-#check Lean.Expr.const `a []

--- a/Mathlib/RingTheory/OreLocalization/Basic.lean
+++ b/Mathlib/RingTheory/OreLocalization/Basic.lean
@@ -85,9 +85,9 @@ variable {R : Type _} [Monoid R] {S : Submonoid R}
 
 variable (R S) [OreSet S]
 
--- mathport name: «expr [ ⁻¹]»
 @[inherit_doc OreLocalization]
-notation:1075 R "[" S "⁻¹]" => OreLocalization R S
+scoped syntax:1075 term noWs atomic("[" term "⁻¹" noWs "]") : term
+macro_rules | `($R[$S⁻¹]) => ``(OreLocalization $R $S)
 
 attribute [local instance] oreEqv
 
@@ -942,3 +942,6 @@ instance divisionRing : DivisionRing R[R⁰⁻¹] :=
 end DivisionRing
 
 end OreLocalization
+
+open Lean
+#check Lean.Expr.const `a []


### PR DESCRIPTION
As [reported on Zulip](https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/Bug.2FObservation.20about.20Empty.20Lists/near/360479548).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
