### PR TITLE
[Merged by Bors] - doc: porting note on quotient `⟦a⟧` notation

### DIFF
--- a/Mathlib/Data/Quot.lean
+++ b/Mathlib/Data/Quot.lean
@@ -216,6 +216,11 @@ variable [sa : Setoid α] [sb : Setoid β]
 
 variable {φ : Quotient sa → Quotient sb → Sort _}
 
+-- Porting note: in mathlib3 this notation took the Setoid as an instance-implicit argument,
+-- now it's explicit but left as a metavariable.
+-- We have not yet decided which one works best, since the setoid instance can't always be
+-- reliably found but it can't always be inferred from the expected type either.
+-- See also: https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/confusion.20between.20equivalence.20and.20instance.20setoid/near/360822354
 @[inherit_doc]
 notation:arg "⟦" a "⟧" => Quotient.mk _ a
 


### PR DESCRIPTION
The details of this notation changed between mathlib 3 and 4, so we should leave a porting note about this change and give a bit motivation (the motivation is actually not totally clear anymore).

Zulip thread: https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/confusion.20between.20equivalence.20and.20instance.20setoid/near/360822354


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
