### PR TITLE
[Merged by Bors] - feat: `fbinop%` term elaborator to support set product notation

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2091,8 +2091,8 @@ import Mathlib.Tactic.DeriveToExpr
 import Mathlib.Tactic.Elementwise
 import Mathlib.Tactic.Eqns
 import Mathlib.Tactic.Existsi
-import Mathlib.Tactic.FailIfNoProgress
 import Mathlib.Tactic.FBinop
+import Mathlib.Tactic.FailIfNoProgress
 import Mathlib.Tactic.FieldSimp
 import Mathlib.Tactic.FinCases
 import Mathlib.Tactic.Find

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2092,6 +2092,7 @@ import Mathlib.Tactic.Elementwise
 import Mathlib.Tactic.Eqns
 import Mathlib.Tactic.Existsi
 import Mathlib.Tactic.FailIfNoProgress
+import Mathlib.Tactic.FBinop
 import Mathlib.Tactic.FieldSimp
 import Mathlib.Tactic.FinCases
 import Mathlib.Tactic.Find

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -31,6 +31,7 @@ import Mathlib.Tactic.Elementwise
 import Mathlib.Tactic.Eqns
 import Mathlib.Tactic.Existsi
 import Mathlib.Tactic.FailIfNoProgress
+import Mathlib.Tactic.FBinop
 import Mathlib.Tactic.FieldSimp
 import Mathlib.Tactic.FinCases
 import Mathlib.Tactic.Find

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -30,8 +30,8 @@ import Mathlib.Tactic.DeriveToExpr
 import Mathlib.Tactic.Elementwise
 import Mathlib.Tactic.Eqns
 import Mathlib.Tactic.Existsi
-import Mathlib.Tactic.FailIfNoProgress
 import Mathlib.Tactic.FBinop
+import Mathlib.Tactic.FailIfNoProgress
 import Mathlib.Tactic.FieldSimp
 import Mathlib.Tactic.FinCases
 import Mathlib.Tactic.Find

--- a/Mathlib/Tactic/FBinop.lean
+++ b/Mathlib/Tactic/FBinop.lean
@@ -1,0 +1,244 @@
+/-
+Copyright (c) 2023 Kyle Miller. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kyle Miller
+-/
+import Mathlib.Tactic.ToExpr
+
+/-! # Elaborator for functorial binary operators
+
+`fbinop% f x y` elaborates `f x y` for `x : S α` and `y : S' β`, taking into account
+any coercions that the "functors" `S` and `S'` posess.
+
+While `binop%` tries to solve for a single minimal type, `fbinop%` tries to solve
+the parameterized problem of solving for a single minimal "functor."
+
+The code is drawn from the Lean 4 core `binop%` elaborator. Two simplifications made were
+1. It is assumed that every `f` has a "homogeneous" instance
+   (think `Set.prod : Set α → Set β → Set (α × β)`).
+2. It is assumed that there are no "non-homogeneous" default instances.
+
+It also makes the assumption that the binop wants to be as homegenous as possible.
+For example, when the type of an argument is unknown it will try to unify the argument's type
+with `S _`, which can help certain elaboration problems proceed (like for `{a,b,c}` notation).
+
+The main goal is to support generic set product notation and have it elaborate in a convenient way.
+-/
+
+namespace FBinopElab
+open Lean Elab Term Meta
+
+initialize registerTraceClass `Elab.fbinop
+
+/-- `fbinop% f x y` elaborates `f x y` for `x : S α` and `y : S' β`, taking into account
+any coercions that the "functors" `S` and `S'` posess. -/
+syntax:max (name := prodSyntax) "fbinop% " ident term:max term:max : term
+
+/-- Tree recording the structure of the `fbinop%` expression. -/
+private inductive Tree where
+  /-- Leaf of the tree. Stores the generated `InfoTree` from elaborating `val`. -/
+  | term (ref : Syntax) (infoTrees : PersistentArray InfoTree) (val : Expr)
+  /-- An `fbinop%` node.
+  `ref` is the original syntax that expanded into `binop%`.
+  `f` is the constant for the binary operator -/
+  | binop (ref : Syntax) (f : Expr) (lhs rhs : Tree)
+  /-- Store macro expansion information to make sure that "go to definition" behaves
+  similarly to notation defined without using `fbinop%`. -/
+  | macroExpansion (macroName : Name) (stx stx' : Syntax) (nested : Tree)
+
+private partial def toTree (s : Syntax) : TermElabM Tree := do
+  let result ← go s
+  synthesizeSyntheticMVars (mayPostpone := true)
+  return result
+where
+  go (s : Syntax) : TermElabM Tree := do
+    match s with
+    | `(fbinop% $f $lhs $rhs) => processBinOp s f lhs rhs
+    | `(($e)) =>
+      if hasCDot e then
+        processLeaf s
+      else
+        go e
+    | _ =>
+      withRef s do
+        match ← liftMacroM <| expandMacroImpl? (← getEnv) s with
+        | some (macroName, s?) =>
+          let s' ← liftMacroM <| liftExcept s?
+          withPushMacroExpansionStack s s' do
+            return .macroExpansion macroName s s' (← go s')
+        | none => processLeaf s
+
+  processBinOp (ref : Syntax) (f lhs rhs : Syntax) := do
+    let some f ← resolveId? f | throwUnknownConstant f.getId
+    return .binop ref f (← go lhs) (← go rhs)
+
+  processLeaf (s : Syntax) := do
+    let e ← elabTerm s none
+    let info ← getResetInfoTrees
+    return .term s info e
+
+/-- Records a "functor", which is some function `Type u → Type v`. We only
+allow `c a1 ... an` for `c` a constant. This is so we can abstract out the universe variables. -/
+structure SRec where
+  name : Name
+  args : Array Expr
+  deriving Inhabited, ToExpr
+
+/-- Given a type expression, try to remove the last argument and create an `SRec` for the
+underlying "functor". Only applies to function applications with a constant head.
+Returns the `SRec` and the argument. -/
+private partial def extractS (e : Expr) : TermElabM (Option (SRec × Expr)) :=
+  match e with
+  | .letE .. => extractS (e.letBody!.instantiate1 e.letValue!)
+  | .mdata _ b => extractS b
+  | .app S x => do
+    let .const n _ := S.getAppFn | return none
+    return some ({name := n, args := S.getAppArgs}, x)
+  | _ => return none
+
+/-- Does `mkAppN` but also checks all types (and unifies metavariables). -/
+private partial def mkAppN' (f : Expr) (args : Array Expr) : MetaM Expr := do
+  loop 0 (← inferType f)
+where
+  loop (i : Nat) (fty : Expr) : MetaM Expr := do
+    if i < args.size then
+      let x := args[i]!
+      forallBoundedTelescope fty (some 1) fun fvars fty' => do
+        if let #[fvar] := fvars then
+          if ← isDefEq (← inferType fvar) (← inferType x) then
+            loop (i + 1) fty'
+          else
+            throwAppTypeMismatch (mkAppN f (args.extract 0 i)) x
+        else
+          throwError "too many arguments provided to{indentExpr f}\narguments{indentD args}"
+    else
+      return mkAppN f args
+
+/-- Computes `S x := c a1 ... an x` if it is type correct. -/
+private def applyS (S : SRec) (x : Expr) : TermElabM (Option Expr) :=
+  try
+    let f ← mkConstWithFreshMVarLevels S.name
+    return some (← mkAppN' f (S.args.push x))
+  catch _ =>
+    return none
+
+/-- For a given argument `x`, checks if there is a coercion from `fromS x` to `toS x`
+if these expressions are type correct. -/
+private def hasCoeS (fromS toS : SRec) (x : Expr) : TermElabM Bool := do
+  let some fromType ← applyS fromS x | return false
+  let some toType ← applyS toS x | return false
+  trace[Elab.fbinop] m!"fromType = {fromType}, toType = {toType}"
+  withLocalDeclD `v fromType fun v => do
+    match ← coerceSimple? v toType with
+    | .some _ => return true
+    | .none   => return false
+    | .undef  => return false -- TODO: should we do something smarter here?
+
+/-- Result returned by `analyze`. -/
+private structure AnalyzeResult where
+  maxS? : Option SRec := none
+  /-- `true` if there are two types `α` and `β` where we don't have coercions in any direction. -/
+  hasUncomparable : Bool := false
+
+/-- Compute a minimal `SRec` for an expression tree. -/
+private def analyze (t : Tree) (expectedType? : Option Expr) : TermElabM AnalyzeResult := do
+  let maxS? ←
+    match expectedType? with
+    | none => pure none
+    | some expectedType =>
+      let expectedType ← instantiateMVars expectedType
+      if let some (S, _) ← extractS expectedType then
+        pure S
+      else
+        pure none
+  (go t *> get).run' { maxS? }
+where
+  go (t : Tree) : StateRefT AnalyzeResult TermElabM Unit := do
+    unless (← get).hasUncomparable do
+      match t with
+      | .macroExpansion _ _ _ nested => go nested
+      | .binop _ _ lhs rhs => go lhs; go rhs
+      | .term _ _ val =>
+        let type ← instantiateMVars (← inferType val)
+        let some (S, x) ← extractS type
+          | return -- Rather than marking as incomparable, let's hope there's a coercion!
+        match (← get).maxS? with
+        | none     => modify fun s => { s with maxS? := S }
+        | some maxS =>
+          let some maxSx ← applyS maxS x | return -- Same here.
+          unless ← withNewMCtxDepth <| isDefEqGuarded maxSx type do
+            if ← hasCoeS S maxS x then
+              return ()
+            else if ← hasCoeS maxS S x then
+              modify fun s => { s with maxS? := S }
+            else
+              trace[Elab.fbinop] "uncomparable types: {maxSx}, {type}"
+              modify fun s => { s with hasUncomparable := true }
+
+private def mkBinOp (f : Expr) (lhs rhs : Expr) : TermElabM Expr := do
+  elabAppArgs f #[] #[Arg.expr lhs, Arg.expr rhs] (expectedType? := none)
+    (explicit := false) (ellipsis := false) (resultIsOutParamSupport := false)
+
+/-- Turn a tree back into an expression. -/
+private def toExprCore (t : Tree) : TermElabM Expr := do
+  match t with
+  | .term _ trees e =>
+    modifyInfoState (fun s => { s with trees := s.trees ++ trees }); return e
+  | .binop ref f lhs rhs =>
+    withRef ref <| withInfoContext' ref (mkInfo := mkTermInfo .anonymous ref) do
+      let lhs ← toExprCore lhs
+      let mut rhs ← toExprCore rhs
+      mkBinOp f lhs rhs
+  | .macroExpansion macroName stx stx' nested =>
+    withRef stx <| withInfoContext' stx (mkInfo := mkTermInfo macroName stx) do
+      withMacroExpansion stx stx' do
+        toExprCore nested
+
+/-- Try to coerce elements in the tree to `maxS` when needed. -/
+private def applyCoe (t : Tree) (maxS : SRec) : TermElabM Tree := do
+  go t none
+where
+  go (t : Tree) (f? : Option Expr) : TermElabM Tree := do
+    match t with
+    | .binop ref f lhs rhs =>
+      let lhs' ← go lhs f
+      let rhs' ← go rhs f
+      return .binop ref f lhs' rhs'
+    | .term ref trees e =>
+      trace[Elab.fbinop] "visiting {e}"
+      let type ← instantiateMVars (← inferType e)
+      let some (_, x) ← extractS type
+        | -- We want our operators to be "homogenous" so do a defeq check as an elaboration hint
+          let x' ← mkFreshExprMVar none
+          let some maxType ← applyS maxS x' | trace[Elab.fbinop] "mvar apply failed"; return t
+          trace[Elab.fbinop] "defeq hint {maxType} =?= {type}"
+          _ ← isDefEqGuarded maxType type
+          return t
+      let some maxType ← applyS maxS x
+        | return t
+      trace[Elab.fbinop] "{type} =?= {maxType}"
+      if ← isDefEqGuarded maxType type then
+        return t
+      else
+        trace[Elab.fbinop] "added coercion: {e} : {type} => {maxType}"
+        withRef ref <| return .term ref trees (← mkCoe maxType e)
+    | .macroExpansion macroName stx stx' nested =>
+      withRef stx <| withPushMacroExpansionStack stx stx' do
+        return .macroExpansion macroName stx stx' (← go nested f?)
+
+private def toExpr (tree : Tree) (expectedType? : Option Expr) : TermElabM Expr := do
+  let r ← analyze tree expectedType?
+  trace[Elab.fbinop] "hasUncomparable: {r.hasUncomparable}, maxType: {Lean.toExpr r.maxS?}"
+  if r.hasUncomparable || r.maxS?.isNone then
+    let result ← toExprCore tree
+    ensureHasType expectedType? result
+  else
+    let result ← toExprCore (← applyCoe tree r.maxS?.get!)
+    trace[Elab.fbinop] "result: {result}"
+    ensureHasType expectedType? result
+
+@[term_elab prodSyntax]
+def elabBinOp : TermElab := fun stx expectedType? => do
+  toExpr (← toTree stx) expectedType?
+
+end FBinopElab

--- a/test/FBinop.lean
+++ b/test/FBinop.lean
@@ -61,8 +61,19 @@ instance : SetLike (SubObj X) X
   coe s := s.carrier
   coe_injective' p q h := by cases p; cases q; congr
 
--- Note: this only works because the last argument of `SubObj` is a type.
--- For other algebra subobjects, an instance argument comes next -- perhaps we should strip
--- these off in the calculation?
+-- Note: this easily works because the last argument of `SubObj` is a type.
 def SubObj.prod (s : SubObj X) (t : SubObj Y) : SubObj (X × Y) where
+  carrier := s ×ˢ' t
+
+/-- Modeling subobjects of algebraic types, which have an instance argument after the type. -/
+structure DecSubObj (X : Type _) [DecidableEq X] where
+  carrier : Set X
+
+instance [DecidableEq X] : SetLike (DecSubObj X) X
+    where
+  coe s := s.carrier
+  coe_injective' p q h := by cases p; cases q; congr
+
+-- Note: this is testing instance arguments after the type.
+def DecSubObj.prod [DecidableEq X] [DecidableEq Y] (s : DecSubObj X) (t : DecSubObj Y) : DecSubObj (X × Y) where
   carrier := s ×ˢ' t

--- a/test/FBinop.lean
+++ b/test/FBinop.lean
@@ -41,12 +41,13 @@ example (s : Set α) (t : Set (α × ℕ)) : s ×ˢ' {n | 0 < n} = t := sorry
 example (s : Set α) (t : Set (α × ℕ)) : s ×ˢ' {1, 2, 3} = t := sorry
 example (s : Set α) (t : Set (ℕ × α)) : {1, 2, 3} ×ˢ' s = t := sorry
 
--- These need `fbinop%`.
+-- These need `fbinop%`. (Comment out `macro_rules` above to check.)
 
 example {α : Type u} {β : Type v} (s : Finset α) (t : Set β) : s ×ˢ' t = s ×ˢ' t := rfl
 example (s : Finset α) (t : Finset (α × ℕ)) : s ×ˢ' {1, 2, 3} = t := sorry
 example (s : Finset α) (t : Finset (ℕ × α)) : {1, 2, 3} ×ˢ' s = t := sorry
 example (s : Finset α) (t : Finset (ℕ × α)) : ({1, 2, 3} ×ˢ' s).card = 22 := sorry
+#check ({1,2,3} ×ˢ' {4,5,6} : Finset _)
 
 example (s : Finset α) (t : Set β) (u : Finset γ) : Nat.card (s ×ˢ' t ×ˢ' u) = 0 := sorry
 

--- a/test/FBinop.lean
+++ b/test/FBinop.lean
@@ -1,0 +1,41 @@
+import Mathlib.Tactic.FBinop
+import Mathlib.Data.Set.Prod
+import Mathlib.Data.Finset.Prod
+
+universe u v w
+
+/-- Notation type class for the set product `×ˢ`. -/
+class SProd (α : Type u) (β : Type v) (γ : outParam (Type w)) where
+  /-- The cartesian product `s ×ˢ t` is the set of `(a, b)` such that `a ∈ s` and `b ∈ t`. -/
+  sprod : α → β → γ
+
+-- This notation binds more strongly than (pre)images, unions and intersections.
+@[inherit_doc SProd.sprod] infixr:82 " ×ˢ' " => SProd.sprod
+macro_rules | `($x ×ˢ' $y)   => `(fbinop% SProd.sprod $x $y)
+
+@[default_instance] instance : SProd (Set α) (Set β) (Set (α × β)) := ⟨Set.prod⟩
+instance : SProd (Finset α) (Finset β) (Finset (α × β)) := ⟨Finset.product⟩
+
+-- set_option trace.Elab.fbinop true
+
+example (s : Set α) (t : Set β) : s ×ˢ' t = s ×ˢ' t := rfl
+example {α : Type u} {β : Type v} (s : Finset α) (t : Finset β) : s ×ˢ' t = s ×ˢ' t := rfl
+example {α : Type u} {β : Type v} (s : Finset α) (t : Set β) : s ×ˢ' t = s ×ˢ' t := rfl
+
+example (f : α × α → β) (s : Set (α × α)) : s.InjOn f := sorry
+example (f : α × α → β) (s t : Set α) : (s ×ˢ' t).InjOn f := sorry
+example (f : α × α → β) (s t : Finset α) : (s ×ˢ' t : Set (α × α)).InjOn f := sorry
+example (f : α × α → β) (s t : Finset α) : (s ×ˢ' t : Set _).InjOn f := sorry
+example (f : α × α → β) (s t : Finset α) : ((s : Set _) ×ˢ' (t : Set _)).InjOn f := sorry
+example (f : α × α → β) (s t : Finset α) : ((s : Set _) ×ˢ' (t : Set _)).InjOn f := sorry
+example (f : α × α → β) (s t : Finset α) : Set.InjOn f (s ×ˢ' t) := sorry
+
+example (s : Set α) (t : Set (α × ℕ)) : s ×ˢ' {n | 0 < n} = t := sorry
+example (s : Set α) (t : Set (α × ℕ)) : s ×ˢ' {1, 2, 3} = t := sorry
+example (s : Set α) (t : Set (ℕ × α)) : {1, 2, 3} ×ˢ' s = t := sorry
+example (s : Finset α) (t : Finset (α × ℕ)) : s ×ˢ' {1, 2, 3} = t := sorry
+example (s : Finset α) (t : Finset (ℕ × α)) : {1, 2, 3} ×ˢ' s = t := sorry
+example (s : Finset α) (t : Finset (ℕ × α)) : ({1, 2, 3} ×ˢ' s).card = 22 := sorry
+
+axiom Nat.card : Sort u → Nat
+example (s : Finset α) (t : Set β) (u : Finset γ) : Nat.card (s ×ˢ' t ×ˢ' u) = 0 := sorry

--- a/test/FBinop.lean
+++ b/test/FBinop.lean
@@ -5,18 +5,20 @@ import Mathlib.Data.SetLike.Basic
 
 universe u v w
 
+namespace FBinopTests
+
 /-- Notation type class for the set product `×ˢ`. -/
-class SProd (α : Type u) (β : Type v) (γ : outParam (Type w)) where
+class SProd' (α : Type u) (β : Type v) (γ : outParam (Type w)) where
   /-- The cartesian product `s ×ˢ t` is the set of `(a, b)` such that `a ∈ s` and `b ∈ t`. -/
   sprod : α → β → γ
 
 -- This notation binds more strongly than (pre)images, unions and intersections.
-@[inherit_doc SProd.sprod] infixr:82 " ×ˢ' " => SProd.sprod
-macro_rules | `($x ×ˢ' $y)   => `(fbinop% SProd.sprod $x $y)
+@[inherit_doc SProd'.sprod] infixr:82 " ×ˢ' " => SProd'.sprod
+macro_rules | `($x ×ˢ' $y)   => `(fbinop% SProd'.sprod $x $y)
 
 @[default_instance]
-instance : SProd (Set α) (Set β) (Set (α × β)) := ⟨Set.prod⟩
-instance : SProd (Finset α) (Finset β) (Finset (α × β)) := ⟨Finset.product⟩
+instance : SProd' (Set α) (Set β) (Set (α × β)) := ⟨Set.prod⟩
+instance : SProd' (Finset α) (Finset β) (Finset (α × β)) := ⟨Finset.product⟩
 
 -- set_option trace.Elab.fbinop true
 

--- a/test/FBinop.lean
+++ b/test/FBinop.lean
@@ -1,6 +1,7 @@
 import Mathlib.Tactic.FBinop
 import Mathlib.Data.Set.Prod
 import Mathlib.Data.Finset.Prod
+import Mathlib.Data.SetLike.Basic
 
 universe u v w
 
@@ -13,29 +14,55 @@ class SProd (α : Type u) (β : Type v) (γ : outParam (Type w)) where
 @[inherit_doc SProd.sprod] infixr:82 " ×ˢ' " => SProd.sprod
 macro_rules | `($x ×ˢ' $y)   => `(fbinop% SProd.sprod $x $y)
 
-@[default_instance] instance : SProd (Set α) (Set β) (Set (α × β)) := ⟨Set.prod⟩
+@[default_instance]
+instance : SProd (Set α) (Set β) (Set (α × β)) := ⟨Set.prod⟩
 instance : SProd (Finset α) (Finset β) (Finset (α × β)) := ⟨Finset.product⟩
 
--- set_option trace.Elab.fbinop true
+set_option trace.Elab.fbinop true
+
+-- These work without `fbinop%`. They're tests that we haven't broken anything.
 
 example (s : Set α) (t : Set β) : s ×ˢ' t = s ×ˢ' t := rfl
 example {α : Type u} {β : Type v} (s : Finset α) (t : Finset β) : s ×ˢ' t = s ×ˢ' t := rfl
-example {α : Type u} {β : Type v} (s : Finset α) (t : Set β) : s ×ˢ' t = s ×ˢ' t := rfl
 
 example (f : α × α → β) (s : Set (α × α)) : s.InjOn f := sorry
 example (f : α × α → β) (s t : Set α) : (s ×ˢ' t).InjOn f := sorry
 example (f : α × α → β) (s t : Finset α) : (s ×ˢ' t : Set (α × α)).InjOn f := sorry
 example (f : α × α → β) (s t : Finset α) : (s ×ˢ' t : Set _).InjOn f := sorry
+example (f : α × α → β) (s t : Finset α) : (s ×ˢ' t : Set _).InjOn f := sorry
 example (f : α × α → β) (s t : Finset α) : ((s : Set _) ×ˢ' (t : Set _)).InjOn f := sorry
 example (f : α × α → β) (s t : Finset α) : ((s : Set _) ×ˢ' (t : Set _)).InjOn f := sorry
 example (f : α × α → β) (s t : Finset α) : Set.InjOn f (s ×ˢ' t) := sorry
 
+axiom Nat.card : Sort u → Nat
+example (s : Finset α) (t : Finset γ) : Nat.card (s ×ˢ' t) = 0 := sorry
+
 example (s : Set α) (t : Set (α × ℕ)) : s ×ˢ' {n | 0 < n} = t := sorry
 example (s : Set α) (t : Set (α × ℕ)) : s ×ˢ' {1, 2, 3} = t := sorry
 example (s : Set α) (t : Set (ℕ × α)) : {1, 2, 3} ×ˢ' s = t := sorry
+
+-- These need `fbinop%`.
+
+example {α : Type u} {β : Type v} (s : Finset α) (t : Set β) : s ×ˢ' t = s ×ˢ' t := rfl
 example (s : Finset α) (t : Finset (α × ℕ)) : s ×ˢ' {1, 2, 3} = t := sorry
 example (s : Finset α) (t : Finset (ℕ × α)) : {1, 2, 3} ×ˢ' s = t := sorry
 example (s : Finset α) (t : Finset (ℕ × α)) : ({1, 2, 3} ×ˢ' s).card = 22 := sorry
 
-axiom Nat.card : Sort u → Nat
 example (s : Finset α) (t : Set β) (u : Finset γ) : Nat.card (s ×ˢ' t ×ˢ' u) = 0 := sorry
+
+example (s : Finset α) (t : Finset β) :
+    (↑(s ×ˢ' t) : Set _) = (s : Set α) ×ˢ' t := Finset.coe_product s t
+
+structure SubObj (X : Type _) where
+  carrier : Set X
+
+instance : SetLike (SubObj X) X
+    where
+  coe s := s.carrier
+  coe_injective' p q h := by cases p; cases q; congr
+
+-- Note: this only works because the last argument of `SubObj` is a type.
+-- For other algebra subobjects, an instance argument comes next -- perhaps we should strip
+-- these off in the calculation?
+def SubObj.prod (s : SubObj X) (t : SubObj Y) : SubObj (X × Y) where
+  carrier := s ×ˢ' t

--- a/test/FBinop.lean
+++ b/test/FBinop.lean
@@ -18,7 +18,7 @@ macro_rules | `($x ×ˢ' $y)   => `(fbinop% SProd.sprod $x $y)
 instance : SProd (Set α) (Set β) (Set (α × β)) := ⟨Set.prod⟩
 instance : SProd (Finset α) (Finset β) (Finset (α × β)) := ⟨Finset.product⟩
 
-set_option trace.Elab.fbinop true
+-- set_option trace.Elab.fbinop true
 
 -- These work without `fbinop%`. They're tests that we haven't broken anything.
 


### PR DESCRIPTION
This introduces a term elaborator like the `binop%` term elaborator to help elaborate expressions involving "functorial" types, like `Set`, `Finset`, `List`, etc., and coercions between them. The `binop%` elaborator tries to solve for the minimal type where an arithmetic expression makes sense given which coercions exist. The `fbinop%` elaborator tries to solve for the minimal "functor."

This is designed specifically to support the generic `s ×ˢ t` set product notation. Using just a class is unsufficient because often you want the expected type to help drive the coercions. This also is able to supply hints to the arguments to help homogenize the operator.

Some examples:

```
example (s : Finset α) (t : Set β) (u : Finset γ) : Nat.card (s ×ˢ t ×ˢ u) = 0
-- After elaboration: Nat.card ↑(↑s ×ˢ t ×ˢ ↑u) with the Finsets as Sets

example (s : Set α) (t : Set (α × ℕ)) : s ×ˢ {1, 2, 3} = t
-- The {1, 2, 3} is a Set

example (s : Finset α) (t : Finset (α × ℕ)) : s ×ˢ {1, 2, 3} = t
-- The {1, 2, 3} is a Finset
```
These would fail without the `fbinop%` elaborator.

To support subobjects in the algebraic hierarchy, a "functorial type" may have any number of instance arguments after the type argument.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
