### PR TITLE
[Merged by Bors] - feat: forward-port PR 18990

### DIFF
--- a/Mathlib/Analysis/Normed/MulAction.lean
+++ b/Mathlib/Analysis/Normed/MulAction.lean
@@ -50,6 +50,10 @@ theorem lipschitzWith_smul (s : α) : LipschitzWith ‖s‖₊ ((· • ·) s : 
   lipschitzWith_iff_dist_le_mul.2 <| dist_smul_le _
 #align lipschitz_with_smul lipschitzWith_smul
 
+theorem edist_smul_le (s : α) (x y : β) : edist (s • x) (s • y) ≤ ‖s‖₊ • edist x y :=
+  lipschitzWith_smul s x y
+#align edist_smul_le edist_smul_le
+
 end SeminormedAddGroup
 
 /-- Left multiplication is bounded. -/
@@ -114,5 +118,9 @@ theorem dist_smul₀ (s : α) (x y : β) : dist (s • x) (s • y) = ‖s‖ * 
 theorem nndist_smul₀ (s : α) (x y : β) : nndist (s • x) (s • y) = ‖s‖₊ * nndist x y :=
   NNReal.eq <| dist_smul₀ s x y
 #align nndist_smul₀ nndist_smul₀
+
+theorem edist_smul₀ (s : α) (x y : β) : edist (s • x) (s • y) = ‖s‖₊ • edist x y := by
+  simp only [edist_nndist, nndist_smul₀, ENNReal.coe_mul, ENNReal.smul_def, smul_eq_mul]
+#align edist_smul₀ edist_smul₀
 
 end NormedDivisionRingModule

--- a/Mathlib/Analysis/NormedSpace/Basic.lean
+++ b/Mathlib/Analysis/NormedSpace/Basic.lean
@@ -25,7 +25,7 @@ about these definitions.
 
 variable {α : Type _} {β : Type _} {γ : Type _} {ι : Type _}
 
-open Filter Metric Function Set Topology BigOperators NNReal ENNReal uniformity Pointwise
+open Filter Metric Function Set Topology BigOperators NNReal ENNReal uniformity
 
 section SeminormedAddCommGroup
 

--- a/Mathlib/Analysis/NormedSpace/Pointwise.lean
+++ b/Mathlib/Analysis/NormedSpace/Pointwise.lean
@@ -25,7 +25,63 @@ open Metric Set
 
 open Pointwise Topology
 
-variable {𝕜 E : Type _} [NormedField 𝕜]
+variable {𝕜 E : Type _}
+
+section SMulZeroClass
+
+variable [SeminormedAddCommGroup 𝕜] [SeminormedAddCommGroup E]
+
+variable [SMulZeroClass 𝕜 E] [BoundedSMul 𝕜 E]
+
+theorem ediam_smul_le (c : 𝕜) (s : Set E) : EMetric.diam (c • s) ≤ ‖c‖₊ • EMetric.diam s :=
+  (lipschitzWith_smul c).ediam_image_le s
+#align ediam_smul_le ediam_smul_le
+
+end SMulZeroClass
+
+section DivisionRing
+
+variable [NormedDivisionRing 𝕜] [SeminormedAddCommGroup E]
+
+variable [Module 𝕜 E] [BoundedSMul 𝕜 E]
+
+theorem ediam_smul₀ (c : 𝕜) (s : Set E) : EMetric.diam (c • s) = ‖c‖₊ • EMetric.diam s := by
+  refine' le_antisymm (ediam_smul_le c s) _
+  obtain rfl | hc := eq_or_ne c 0
+  · obtain rfl | hs := s.eq_empty_or_nonempty
+    · simp
+    simp [zero_smul_set hs, ← Set.singleton_zero]
+  · have := (lipschitzWith_smul c⁻¹).ediam_image_le (c • s)
+    rwa [← smul_eq_mul, ← ENNReal.smul_def, Set.image_smul, inv_smul_smul₀ hc s, nnnorm_inv,
+      ENNReal.le_inv_smul_iff (nnnorm_ne_zero_iff.mpr hc)] at this
+#align ediam_smul₀ ediam_smul₀
+
+theorem diam_smul₀ (c : 𝕜) (x : Set E) : diam (c • x) = ‖c‖ * diam x := by
+  simp_rw [diam, ediam_smul₀, ENNReal.toReal_smul, NNReal.smul_def, coe_nnnorm, smul_eq_mul]
+#align diam_smul₀ diam_smul₀
+
+theorem infEdist_smul₀ {c : 𝕜} (hc : c ≠ 0) (s : Set E) (x : E) :
+    EMetric.infEdist (c • x) (c • s) = ‖c‖₊ • EMetric.infEdist x s := by
+  simp_rw [EMetric.infEdist]
+  have : Function.Surjective ((c • ·) : E → E) :=
+    Function.RightInverse.surjective (smul_inv_smul₀ hc)
+  trans ⨅ (y) (_H : y ∈ s), ‖c‖₊ • edist x y
+  · refine' (this.iInf_congr _ fun y => _).symm
+    simp_rw [smul_mem_smul_set_iff₀ hc, edist_smul₀]
+  · have : (‖c‖₊ : ENNReal) ≠ 0 := by simp [hc]
+    simp_rw [ENNReal.smul_def, smul_eq_mul, ENNReal.mul_iInf_of_ne this ENNReal.coe_ne_top]
+#align inf_edist_smul₀ infEdist_smul₀
+
+theorem infDist_smul₀ {c : 𝕜} (hc : c ≠ 0) (s : Set E) (x : E) :
+    Metric.infDist (c • x) (c • s) = ‖c‖ * Metric.infDist x s := by
+  simp_rw [Metric.infDist, infEdist_smul₀ hc s, ENNReal.toReal_smul, NNReal.smul_def, coe_nnnorm,
+    smul_eq_mul]
+#align inf_dist_smul₀ infDist_smul₀
+
+end DivisionRing
+
+
+variable [NormedField 𝕜]
 
 section SeminormedAddCommGroup
 

--- a/Mathlib/Data/Real/ENNReal.lean
+++ b/Mathlib/Data/Real/ENNReal.lean
@@ -1640,6 +1640,16 @@ theorem mul_le_iff_le_inv {a b r : ℝ≥0∞} (hr₀ : r ≠ 0) (hr₁ : r ≠ 
     one_mul]
 #align ennreal.mul_le_iff_le_inv ENNReal.mul_le_iff_le_inv
 
+/-- A variant of `le_inv_smul_iff` that holds for `ennreal`. -/
+protected theorem le_inv_smul_iff {a b : ℝ≥0∞} {r : ℝ≥0} (hr₀ : r ≠ 0) : a ≤ r⁻¹ • b ↔ r • a ≤ b :=
+  by simpa [hr₀, ENNReal.smul_def] using (mul_le_iff_le_inv (coe_ne_zero.mpr hr₀) coe_ne_top).symm
+#align ennreal.le_inv_smul_iff ENNReal.le_inv_smul_iff
+
+/-- A variant of `inv_smul_le_iff` that holds for `ennreal`. -/
+protected theorem inv_smul_le_iff {a b : ℝ≥0∞} {r : ℝ≥0} (hr₀ : r ≠ 0) : r⁻¹ • a ≤ b ↔ a ≤ r • b :=
+  by simpa only [inv_inv] using (ENNReal.le_inv_smul_iff (inv_ne_zero hr₀)).symm
+#align ennreal.inv_smul_le_iff ENNReal.inv_smul_le_iff
+
 theorem le_of_forall_nnreal_lt {x y : ℝ≥0∞} (h : ∀ r : ℝ≥0, ↑r < x → ↑r ≤ y) : x ≤ y := by
   refine' le_of_forall_ge_of_dense fun r hr => _
   lift r to ℝ≥0 using ne_top_of_lt hr

--- a/Mathlib/Topology/MetricSpace/HausdorffDistance.lean
+++ b/Mathlib/Topology/MetricSpace/HausdorffDistance.lean
@@ -9,7 +9,7 @@ Authors: Sébastien Gouëzel
 ! if you have ported upstream changes.
 -/
 import Mathlib.Analysis.SpecificLimits.Basic
-import Mathlib.Topology.MetricSpace.Isometry
+import Mathlib.Topology.MetricSpace.IsometricSMul
 import Mathlib.Topology.Instances.ENNReal
 
 /-!
@@ -37,7 +37,7 @@ This files introduces:
 
 noncomputable section
 
-open Classical NNReal ENNReal Topology Set Function TopologicalSpace Filter
+open Classical NNReal ENNReal Topology Set Function TopologicalSpace Filter Pointwise
 
 universe u v w
 
@@ -196,6 +196,13 @@ theorem disjoint_closedBall_of_lt_infEdist {r : ℝ≥0∞} (h : r < infEdist x 
 theorem infEdist_image (hΦ : Isometry Φ) : infEdist (Φ x) (Φ '' t) = infEdist x t := by
   simp only [infEdist, iInf_image, hΦ.edist_eq]
 #align emetric.inf_edist_image EMetric.infEdist_image
+
+@[to_additive (attr := simp)]
+theorem infEdist_smul {M} [SMul M α] [IsometricSMul M α] (c : M) (x : α) (s : Set α) :
+    infEdist (c • x) (c • s) = infEdist x s :=
+  infEdist_image (isometry_smul _ _)
+#align emetric.inf_edist_smul EMetric.infEdist_smul
+#align emetric.inf_edist_vadd EMetric.infEdist_vadd
 
 theorem _root_.IsOpen.exists_iUnion_isClosed {U : Set α} (hU : IsOpen U) :
     ∃ F : ℕ → Set α, (∀ n, IsClosed (F n)) ∧ (∀ n, F n ⊆ U) ∧ (⋃ n, F n) = U ∧ Monotone F := by

--- a/Mathlib/Topology/MetricSpace/IsometricSMul.lean
+++ b/Mathlib/Topology/MetricSpace/IsometricSMul.lean
@@ -83,6 +83,13 @@ theorem edist_smul_left [SMul M X] [IsometricSMul M X] (c : M) (x y : X) :
 #align edist_smul_left edist_smul_left
 #align edist_vadd_left edist_vadd_left
 
+@[to_additive (attr := simp)]
+theorem ediam_smul [SMul M X] [IsometricSMul M X] (c : M) (s : Set X) :
+    EMetric.diam (c • s) = EMetric.diam s :=
+  (isometry_smul _ _).ediam_image s
+#align ediam_smul ediam_smul
+#align ediam_vadd ediam_vadd
+
 @[to_additive]
 theorem isometry_mul_left [Mul M] [PseudoEMetricSpace M] [IsometricSMul M M] (a : M) :
     Isometry ((· * ·) a) :=
@@ -339,6 +346,13 @@ theorem nndist_smul [PseudoMetricSpace X] [SMul M X] [IsometricSMul M X] (c : M)
   (isometry_smul X c).nndist_eq x y
 #align nndist_smul nndist_smul
 #align nndist_vadd nndist_vadd
+
+@[to_additive (attr := simp)]
+theorem diam_smul [PseudoMetricSpace X] [SMul M X] [IsometricSMul M X] (c : M) (s : Set X) :
+    Metric.diam (c • s) = Metric.diam s :=
+  (isometry_smul _ _).diam_image s
+#align diam_smul diam_smul
+#align diam_vadd diam_vadd
 
 @[to_additive (attr := simp)]
 theorem dist_mul_left [PseudoMetricSpace M] [Mul M] [IsometricSMul M M] (a b c : M) :


### PR DESCRIPTION
Forward-port of leanprover-community/mathlib#18990

Original title:
feat(analysis/normed_space/basic): scaling a set scales its diameter, translating it leaves it unchanged

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)