### PR TITLE
chore: update std to 05-25

### DIFF
--- a/Mathlib/Algebra/EuclideanDomain/Defs.lean
+++ b/Mathlib/Algebra/EuclideanDomain/Defs.lean
@@ -69,7 +69,7 @@ Euclidean domain, transfinite Euclidean domain, Bézout's lemma
 
 universe u
 
-/-- A `EuclideanDomain` is an non-trivial commutative ring with a division and a remainder,
+/-- A `EuclideanDomain` is a non-trivial commutative ring with a division and a remainder,
   satisfying `b * (a / b) + a % b = a`.
   The definition of a Euclidean domain usually includes a valuation function `R → ℕ`.
   This definition is slightly generalised to include a well founded relation

--- a/Mathlib/Algebra/Homology/Single.lean
+++ b/Mathlib/Algebra/Homology/Single.lean
@@ -474,7 +474,7 @@ def single₀IsoSingle : single₀ V ≅ single V _ 0 :=
           . dsimp
             rw [Category.id_comp]
             rfl })
-    fun f => by ext (_ | i) <;> aesop_cat
+    fun f => by ext (_ | i)
 #align cochain_complex.single₀_iso_single CochainComplex.single₀IsoSingle
 
 instance : Faithful (single₀ V) :=

--- a/Mathlib/Algebra/Homology/Single.lean
+++ b/Mathlib/Algebra/Homology/Single.lean
@@ -474,7 +474,7 @@ def single₀IsoSingle : single₀ V ≅ single V _ 0 :=
           . dsimp
             rw [Category.id_comp]
             rfl })
-    fun f => by ext (_ | i)
+    fun f => by ext; simp
 #align cochain_complex.single₀_iso_single CochainComplex.single₀IsoSingle
 
 instance : Faithful (single₀ V) :=

--- a/Mathlib/Analysis/NormedSpace/Star/Multiplier.lean
+++ b/Mathlib/Analysis/NormedSpace/Star/Multiplier.lean
@@ -511,7 +511,6 @@ theorem coe_eq_algebraMap : (DoubleCentralizer.coe 𝕜 : 𝕜 → 𝓜(𝕜, �
   simp only [coe_fst, mul_apply', mul_one, algebraMap_toProd, Prod.algebraMap_apply, coe_snd,
     flip_apply, one_mul] <;>
   simp only [Algebra.algebraMap_eq_smul_one, smul_apply, one_apply, smul_eq_mul, mul_one]
-  exact mul_comm _ _
 #align double_centralizer.coe_eq_algebra_map DoubleCentralizer.coe_eq_algebraMap
 
 /-- The coercion of an algebra into its multiplier algebra as a non-unital star algebra

--- a/Mathlib/CategoryTheory/Abelian/InjectiveResolution.lean
+++ b/Mathlib/CategoryTheory/Abelian/InjectiveResolution.lean
@@ -99,13 +99,11 @@ def desc {Y Z : C} (f : Z ⟶ Y) (I : InjectiveResolution Y) (J : InjectiveResol
 #align category_theory.InjectiveResolution.desc CategoryTheory.InjectiveResolution.desc
 
 /-- The resolution maps intertwine the descent of a morphism and that morphism. -/
-@[reassoc (attr := simp)] -- Porting note: Originally `@[simp, reassoc.1]`
+@[reassoc (attr := simp)]
 theorem desc_commutes {Y Z : C} (f : Z ⟶ Y) (I : InjectiveResolution Y)
     (J : InjectiveResolution Z) : J.ι ≫ desc f I J = (CochainComplex.single₀ C).map f ≫ I.ι := by
   ext n
-  rcases n with (_ | _ | n) <;>
-    · dsimp [desc, descFOne, descFZero]
-      simp
+  simp [desc, descFOne, descFZero]
 #align category_theory.InjectiveResolution.desc_commutes CategoryTheory.InjectiveResolution.desc_commutes
 
 -- Now that we've checked this property of the descent, we can seal away the actual definition.

--- a/Mathlib/CategoryTheory/IsConnected.lean
+++ b/Mathlib/CategoryTheory/IsConnected.lean
@@ -317,7 +317,7 @@ theorem isConnected_zigzag [IsConnected J] (j₁ j₂ : J) : Zigzag j₁ j₂ :=
     (@fun _ _ f => Relation.ReflTransGen.single (Or.inl (Nonempty.intro f))) _ _
 #align category_theory.is_connected_zigzag CategoryTheory.isConnected_zigzag
 
-/-- If any two objects in an nonempty category are related by `zigzag`, the category is connected.
+/-- If any two objects in a nonempty category are related by `zigzag`, the category is connected.
 -/
 theorem zigzag_isConnected [Nonempty J] (h : ∀ j₁ j₂ : J, Zigzag j₁ j₂) : IsConnected J := by
   apply IsConnected.of_induct
@@ -338,7 +338,7 @@ theorem exists_zigzag' [IsConnected J] (j₁ j₂ : J) :
   List.exists_chain_of_relationReflTransGen (isConnected_zigzag _ _)
 #align category_theory.exists_zigzag' CategoryTheory.exists_zigzag'
 
-/-- If any two objects in an nonempty category are linked by a sequence of (potentially reversed)
+/-- If any two objects in a nonempty category are linked by a sequence of (potentially reversed)
 morphisms, then J is connected.
 
 The converse of `exists_zigzag'`.

--- a/Mathlib/CategoryTheory/Preadditive/HomOrthogonal.lean
+++ b/Mathlib/CategoryTheory/Preadditive/HomOrthogonal.lean
@@ -94,7 +94,8 @@ noncomputable def matrixDecomposition (o : HomOrthogonal s) {α β : Type} [Fint
       if h : f j = g k then z (f j) ⟨k, by simp [h]⟩ ⟨j, by simp⟩ ≫ eqToHom (by simp [h]) else 0
   left_inv z := by
     ext (j k)
-    simp only [biproduct.matrix_π, biproduct.ι_desc]
+    simp only [eqToHom_refl, Category.id_comp, Category.assoc, eqToHom_trans, Category.comp_id,
+      dite_eq_ite, biproduct.ι_matrix, biproduct.lift_π]
     split_ifs with h
     · simp
       rfl

--- a/Mathlib/CategoryTheory/Preadditive/ProjectiveResolution.lean
+++ b/Mathlib/CategoryTheory/Preadditive/ProjectiveResolution.lean
@@ -206,7 +206,7 @@ set_option linter.uppercaseLean3 false in
 @[reassoc (attr := simp)]
 theorem lift_commutes {Y Z : C} (f : Y ⟶ Z) (P : ProjectiveResolution Y)
     (Q : ProjectiveResolution Z) : lift f P Q ≫ Q.π = P.π ≫ (ChainComplex.single₀ C).map f := by
-  ext (_|_) <;> simp [lift, liftZero]
+  ext (_|_); simp [lift, liftZero]
 set_option linter.uppercaseLean3 false in
 #align category_theory.ProjectiveResolution.lift_commutes CategoryTheory.ProjectiveResolution.lift_commutes
 

--- a/Mathlib/Data/Dfinsupp/Basic.lean
+++ b/Mathlib/Data/Dfinsupp/Basic.lean
@@ -2020,14 +2020,11 @@ def liftAddHom [∀ i, AddZeroClass (β i)] [AddCommMonoid γ] : (∀ i, β i �
   right_inv ψ := by
     classical
     ext x
-    apply Dfinsupp.induction x
-    · simp
-    intros i b f _ _ IH
-    simp [IH]
+    simp
   map_add' F G := by
     classical
     ext
-    simp [sumAddHom_apply, sum, Finset.sum_add_distrib]
+    simp
 #align dfinsupp.lift_add_hom Dfinsupp.liftAddHom
 #align dfinsupp.lift_add_hom_apply Dfinsupp.liftAddHom_apply
 #align dfinsupp.lift_add_hom_symm_apply Dfinsupp.liftAddHom_symm_apply

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -3073,20 +3073,7 @@ end ModifyLast
 
 /-! ### map for partial functions -/
 
-/-- Partial map. If `f : Π a, p a → β` is a partial function defined on
-  `a : α` satisfying `p`, then `pmap f l h` is essentially the same as `map f l`
-  but is defined only when all members of `l` satisfy `p`, using the proof
-  to apply `f`. -/
-@[simp]
-def pmap {p : α → Prop} (f : ∀ a, p a → β) : ∀ l : List α, (∀ a ∈ l, p a) → List β
-  | [], _ => []
-  | a :: l, H => f a (forall_mem_cons.1 H).1 :: pmap f l (forall_mem_cons.1 H).2
 #align list.pmap List.pmap
-
-/-- "Attach" the proof that the elements of `l` are in `l` to produce a new list
-  with the same elements but in the type `{x // x ∈ l}`. -/
-def attach (l : List α) : List { x // x ∈ l } :=
-  pmap Subtype.mk l fun _ => id
 #align list.attach List.attach
 
 theorem sizeOf_lt_sizeOf_of_mem [SizeOf α] {x : α} {l : List α} (hx : x ∈ l) :

--- a/Mathlib/Data/List/Chain.lean
+++ b/Mathlib/Data/List/Chain.lean
@@ -33,33 +33,11 @@ variable {α : Type u} {β : Type v} {R r : α → α → Prop} {l l₁ l₂ : L
 mk_iff_of_inductive_prop List.Chain List.chain_iff
 #align list.chain_iff List.chain_iff
 
---Porting note: attribute in Lean3, but not in Lean4 Std so added here instead
-attribute [simp] Chain.nil
-
 #align list.chain.nil List.Chain.nil
 #align list.chain.cons List.Chain.cons
-
-theorem rel_of_chain_cons {a b : α} {l : List α} (p : Chain R a (b :: l)) : R a b :=
-  (chain_cons.1 p).1
 #align list.rel_of_chain_cons List.rel_of_chain_cons
-
-theorem chain_of_chain_cons {a b : α} {l : List α} (p : Chain R a (b :: l)) : Chain R b l :=
-  (chain_cons.1 p).2
 #align list.chain_of_chain_cons List.chain_of_chain_cons
-
-theorem Chain.imp' {R S : α → α → Prop} (HRS : ∀ ⦃a b⦄, R a b → S a b) {a b : α}
-    (Hab : ∀ ⦃c⦄, R a c → S b c) {l : List α} (p : Chain R a l) : Chain S b l := by
-  induction p generalizing b with
-  | nil => constructor
-  | cons r _ ih =>
-    constructor
-    · exact Hab r
-    · exact ih (@HRS _)
 #align list.chain.imp' List.Chain.imp'
-
-theorem Chain.imp {R S : α → α → Prop} (H : ∀ a b, R a b → S a b) {a : α} {l : List α}
-    (p : Chain R a l) : Chain S a l :=
-  p.imp' H (H a)
 #align list.chain.imp List.Chain.imp
 
 theorem Chain.iff {S : α → α → Prop} (H : ∀ a b, R a b ↔ S a b) {a : α} {l : List α} :
@@ -135,11 +113,6 @@ theorem chain_of_chain_pmap {S : β → β → Prop} {p : α → Prop} (f : ∀ 
   · simp [H _ _ _ _ (rel_of_chain_cons hl₂), l_ih _ _ (chain_of_chain_cons hl₂)]
 #align list.chain_of_chain_pmap List.chain_of_chain_pmap
 
-protected theorem Pairwise.chain (p : Pairwise R (a :: l)) : Chain R a l := by
-  cases' pairwise_cons.1 p with r p'; clear p
-  induction' p' with b l r' _ IH generalizing a; · exact Chain.nil
-  simp only [chain_cons, forall_mem_cons] at r
-  exact chain_cons.2 ⟨r.1, IH r'⟩
 #align list.pairwise.chain List.Pairwise.chain
 
 protected theorem Chain.pairwise [IsTrans α R] :

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -364,14 +364,9 @@ infixr:82 " ×ˢ " => List.product
 #align list.pw_filter List.pwFilter
 #align list.chain List.Chain
 #align list.chain' List.Chain'
+#align list.chain_cons List.chain_cons
 
 section Chain
-
-@[simp]
-theorem chain_cons {a b : α} {l : List α} : Chain R a (b :: l) ↔ R a b ∧ Chain R b l :=
-  ⟨fun p ↦ by cases p with | cons n p => exact ⟨n, p⟩,
-   fun ⟨n, p⟩ ↦ p.cons n⟩
-#align list.chain_cons List.chain_cons
 
 instance decidableChain [DecidableRel R] (a : α) (l : List α) :
     Decidable (Chain R a l) := by

--- a/Mathlib/Data/List/Intervals.lean
+++ b/Mathlib/Data/List/Intervals.lean
@@ -98,8 +98,8 @@ theorem eq_empty_iff {n m : ℕ} : Ico n m = [] ↔ m ≤ n :=
 theorem append_consecutive {n m l : ℕ} (hnm : n ≤ m) (hml : m ≤ l) :
     Ico n m ++ Ico m l = Ico n l := by
   dsimp only [Ico]
-  convert range'_append n (m-n) (l-m) using 2
-  · rw [add_tsub_cancel_of_le hnm]
+  convert range'_append n (m-n) (l-m) 1 using 2
+  · rw [one_mul, add_tsub_cancel_of_le hnm]
   · rw [tsub_add_tsub_cancel hml hnm]
 #align list.Ico.append_consecutive List.Ico.append_consecutive
 
@@ -138,13 +138,14 @@ theorem eq_cons {n m : ℕ} (h : n < m) : Ico n m = n :: Ico (n + 1) m := by
 theorem pred_singleton {m : ℕ} (h : 0 < m) : Ico (m - 1) m = [m - 1] := by
   dsimp [Ico]
   rw [tsub_tsub_cancel_of_le (succ_le_of_lt h)]
-  simp
+  simp [← Nat.one_eq_succ_zero]
+
 #align list.Ico.pred_singleton List.Ico.pred_singleton
 
 theorem chain'_succ (n m : ℕ) : Chain' (fun a b => b = succ a) (Ico n m) := by
   by_cases n < m
   · rw [eq_cons h]
-    exact chain_succ_range' _ _
+    exact chain_succ_range' _ _ 1
   · rw [eq_nil_of_le (le_of_not_gt h)]
     trivial
 #align list.Ico.chain'_succ List.Ico.chain'_succ

--- a/Mathlib/Data/List/Range.lean
+++ b/Mathlib/Data/List/Range.lean
@@ -170,11 +170,7 @@ theorem prod_range_succ' {α : Type u} [Monoid α] (f : ℕ → α) (n : ℕ) :
 #align list.prod_range_succ' List.prod_range_succ'
 #align list.sum_range_succ' List.sum_range_succ'
 
-@[simp]
-theorem enum_from_map_fst : ∀ (n) (l : List α), map Prod.fst (enumFrom n l) = range' n l.length
-  | _, [] => rfl
-  | _, _ :: _ => congr_arg (cons _) (enum_from_map_fst _ _)
-#align list.enum_from_map_fst List.enum_from_map_fst
+#align list.enum_from_map_fst List.enumFrom_map_fst
 #align list.enum_map_fst List.enum_map_fst
 
 theorem enum_eq_zip_range (l : List α) : l.enum = (range l.length).zip l :=
@@ -186,15 +182,15 @@ theorem unzip_enum_eq_prod (l : List α) : l.enum.unzip = (range l.length, l) :=
   simp only [enum_eq_zip_range, unzip_zip, length_range]
 #align list.unzip_enum_eq_prod List.unzip_enum_eq_prod
 
-theorem enum_from_eq_zip_range' (l : List α) {n : ℕ} : l.enumFrom n = (range' n l.length).zip l :=
-  zip_of_prod (enum_from_map_fst _ _) (enumFrom_map_snd _ _)
-#align list.enum_from_eq_zip_range' List.enum_from_eq_zip_range'
+theorem enumFrom_eq_zip_range' (l : List α) {n : ℕ} : l.enumFrom n = (range' n l.length).zip l :=
+  zip_of_prod (enumFrom_map_fst _ _) (enumFrom_map_snd _ _)
+#align list.enum_from_eq_zip_range' List.enumFrom_eq_zip_range'
 
 @[simp]
-theorem unzip_enum_from_eq_prod (l : List α) {n : ℕ} :
+theorem unzip_enumFrom_eq_prod (l : List α) {n : ℕ} :
     (l.enumFrom n).unzip = (range' n l.length, l) := by
-  simp only [enum_from_eq_zip_range', unzip_zip, length_range']
-#align list.unzip_enum_from_eq_prod List.unzip_enum_from_eq_prod
+  simp only [enumFrom_eq_zip_range', unzip_zip, length_range']
+#align list.unzip_enum_from_eq_prod List.unzip_enumFrom_eq_prod
 
 set_option linter.deprecated false in
 @[simp]

--- a/Mathlib/Data/List/Range.lean
+++ b/Mathlib/Data/List/Range.lean
@@ -14,7 +14,8 @@ import Mathlib.Data.List.Zip
 /-!
 # Ranges of naturals as lists
 
-This file shows basic results about `List.iota`, `List.range`, `List.range'` and defines `List.finRange`.
+This file shows basic results about `List.iota`, `List.range`, `List.range'`
+and defines `List.finRange`.
 `finRange n` is the list of elements of `Fin n`.
 `iota n = [n, n - 1, ..., 1]` and `range n = [0, ..., n - 1]` are basic list constructions used for
 tactics. `range' a b = [a, ..., a + b - 1]` is there to help prove properties about them.

--- a/Mathlib/Data/List/Range.lean
+++ b/Mathlib/Data/List/Range.lean
@@ -14,8 +14,7 @@ import Mathlib.Data.List.Zip
 /-!
 # Ranges of naturals as lists
 
-This file shows basic results about `List.iota`, `List.range`, `List.range'` (all defined in
-`data.list.defs`) and defines `List.finRange`.
+This file shows basic results about `List.iota`, `List.range`, `List.range'` and defines `List.finRange`.
 `finRange n` is the list of elements of `Fin n`.
 `iota n = [n, n - 1, ..., 1]` and `range n = [0, ..., n - 1]` are basic list constructions used for
 tactics. `range' a b = [a, ..., a + b - 1]` is there to help prove properties about them.
@@ -31,133 +30,44 @@ namespace List
 
 variable {α : Type u}
 
-@[simp]
-theorem length_range' : ∀ s n : ℕ, length (range' s n) = n
-  | _, 0 => rfl
-  | _, _ + 1 => congr_arg succ (length_range' _ _)
+@[simp] theorem range'_one : range' s 1 step = [s] := rfl
+
 #align list.length_range' List.length_range'
-
-@[simp]
-theorem range'_eq_nil {s n : ℕ} : range' s n = [] ↔ n = 0 := by rw [← length_eq_zero, length_range']
 #align list.range'_eq_nil List.range'_eq_nil
-
-@[simp]
-theorem mem_range' {m : ℕ} : ∀ {s n : ℕ}, m ∈ range' s n ↔ s ≤ m ∧ m < s + n
-  | s, 0 => by
-    simp only [range', find?, not_mem_nil, add_zero, false_iff, not_and, not_lt, imp_self]
-  | s, n + 1 =>
-    have : m = s → m < s + n + 1 := fun e => e ▸ lt_succ_of_le (Nat.le_add_right _ _)
-    have l : m = s ∨ s + 1 ≤ m ↔ s ≤ m := by
-      simpa only [eq_comm] using (@Decidable.le_iff_eq_or_lt _ _ _ s m).symm
-    mem_cons.trans <| by
-      simp only [@mem_range' m (s + 1) n, or_and_left, or_iff_right_of_imp this, l,
-        add_right_comm, add_eq, add_zero, and_congr_right_iff, add_assoc, or_iff_right_iff_imp]
-      intro; exact this
 #align list.mem_range' List.mem_range'
-
-theorem map_add_range' (a) : ∀ s n : ℕ, map ((· + ·) a) (range' s n) = range' (a + s) n
-  | _, 0 => rfl
-  | s, n + 1 => congr_arg (cons _) (map_add_range' _ (s + 1) n)
 #align list.map_add_range' List.map_add_range'
-
-theorem map_sub_range' (a) :
-    ∀ (s n : ℕ) (_ : a ≤ s), map (fun x => x - a) (range' s n) = range' (s - a) n
-  | s, 0, _ => rfl
-  | s, n + 1, h => by
-    convert congr_arg (cons (s - a)) (map_sub_range' _ (s + 1) n (Nat.le_succ_of_le h)) using 1
-    rw [Nat.succ_sub h]
-    rfl
 #align list.map_sub_range' List.map_sub_range'
-
-theorem chain_succ_range' : ∀ s n : ℕ, Chain (fun a b => b = succ a) s (range' (s + 1) n)
-  | _, 0 => Chain.nil
-  | s, n + 1 => (chain_succ_range' (s + 1) n).cons rfl
 #align list.chain_succ_range' List.chain_succ_range'
-
-theorem chain_lt_range' (s n : ℕ) : Chain (· < ·) s (range' (s + 1) n) :=
-  (chain_succ_range' s n).imp fun _ _ e => e.symm ▸ lt_succ_self _
 #align list.chain_lt_range' List.chain_lt_range'
 
-theorem pairwise_lt_range' : ∀ s n : ℕ, Pairwise (· < ·) (range' s n)
-  | _, 0 => Pairwise.nil
-  | s, n + 1 => chain_iff_pairwise.1 (chain_lt_range' s n)
+theorem pairwise_lt_range' : ∀ s n (step := 1) (_ : 0 < step := by simp),
+  Pairwise (· < ·) (range' s n step)
+  | _, 0, _, _ => Pairwise.nil
+  | s, n + 1, _, h => chain_iff_pairwise.1 (chain_lt_range' s n h)
 #align list.pairwise_lt_range' List.pairwise_lt_range'
 
-theorem nodup_range' (s n : ℕ) : Nodup (range' s n) :=
-  (pairwise_lt_range' s n).imp _root_.ne_of_lt
+theorem nodup_range' (s n : ℕ) (step := 1) (h : 0 < step := by simp) : Nodup (range' s n step) :=
+  (pairwise_lt_range' s n step h).imp _root_.ne_of_lt
 #align list.nodup_range' List.nodup_range'
-
-@[simp]
-theorem range'_append : ∀ s m n : ℕ, range' s m ++ range' (s + m) n = range' s (n + m)
-  | s, 0, n => rfl
-  | s, m + 1, n =>
-    show s :: (range' (s + 1) m ++ range' (s + m + 1) n) = s :: range' (s + 1) (n + m) by
-      rw [add_right_comm, range'_append (s + 1) m n]
 #align list.range'_append List.range'_append
-
-theorem range'_sublist_right {s m n : ℕ} : range' s m <+ range' s n ↔ m ≤ n :=
-  ⟨fun h => by simpa only [length_range'] using h.length_le, fun h => by
-    rw [← tsub_add_cancel_of_le h, ← range'_append] ; apply sublist_append_left⟩
 #align list.range'_sublist_right List.range'_sublist_right
-
-theorem range'_subset_right {s m n : ℕ} : range' s m ⊆ range' s n ↔ m ≤ n :=
-  ⟨fun h =>
-    le_of_not_lt fun hn =>
-      lt_irrefl (s + n) <|
-        (mem_range'.1 <| h <| mem_range'.2 ⟨Nat.le_add_right _ _, Nat.add_lt_add_left hn s⟩).2,
-    fun h => (range'_sublist_right.2 h).subset⟩
 #align list.range'_subset_right List.range'_subset_right
-
-theorem get?_range' : ∀ (s) {m n : ℕ}, m < n → get? (range' s n) m = some (s + m)
-  | s, 0, n + 1, _ => rfl
-  | s, m + 1, n + 1, h =>
-    (get?_range' (s + 1) (lt_of_add_lt_add_right h)).trans <| by rw [add_right_comm] ; rfl
 #align list.nth_range' List.get?_range'
-
--- Porting note: new theorem
-@[simp]
-theorem get_range' {n m} (i) (H : i < (range' n m).length) : get (range' n m) ⟨i, H⟩ = n + i :=
-  Option.some.inj <| by rw [← get?_eq_get _, get?_range' _ (by simpa using H)]
 
 set_option linter.deprecated false in
 @[simp]
-theorem nthLe_range' {n m} (i) (H : i < (range' n m).length) : nthLe (range' n m) i H = n + i :=
+theorem nthLe_range' {n m step} (i) (H : i < (range' n m step).length) :
+  nthLe (range' n m step) i H = n + step * i :=
   get_range' i H
 #align list.nth_le_range' List.nthLe_range'
-
-theorem range'_concat (s n : ℕ) : range' s (n + 1) = range' s n ++ [s + n] := by
-  rw [add_comm n 1] ; exact (range'_append s n 1).symm
 #align list.range'_concat List.range'_concat
 
 #align list.range_core List.range.loop
-
-theorem range_loop_range' : ∀ s n : ℕ, range.loop s (range' s n) = range' 0 (n + s)
-  | 0, n => rfl
-  | s + 1, n => by
-    rw [show n + (s + 1) = n + 1 + s from add_right_comm n s 1]
-    exact range_loop_range' s (n + 1)
 #align list.range_core_range' List.range_loop_range'
-
-theorem range_eq_range' (n : ℕ) : range n = range' 0 n :=
-  (range_loop_range' n 0).trans <| by rw [zero_add]
 #align list.range_eq_range' List.range_eq_range'
-
-theorem range_succ_eq_map (n : ℕ) : range (n + 1) = 0 :: map succ (range n) := by
-  rw [range_eq_range', range_eq_range', range', add_comm, ← map_add_range']
-  congr
-  exact funext one_add
 #align list.range_succ_eq_map List.range_succ_eq_map
-
-theorem range'_eq_map_range (s n : ℕ) : range' s n = map (s + ·) (range n) := by
-  rw [range_eq_range', map_add_range'] ; rfl
 #align list.range'_eq_map_range List.range'_eq_map_range
-
-@[simp]
-theorem length_range (n : ℕ) : length (range n) = n := by simp only [range_eq_range', length_range']
 #align list.length_range List.length_range
-
-@[simp]
-theorem range_eq_nil {n : ℕ} : range n = [] ↔ n = 0 := by rw [← length_eq_zero, length_range]
 #align list.range_eq_nil List.range_eq_nil
 
 theorem pairwise_lt_range (n : ℕ) : Pairwise (· < ·) (range n) := by
@@ -170,41 +80,13 @@ theorem pairwise_le_range (n : ℕ) : Pairwise (· ≤ ·) (range n) :=
 
 theorem nodup_range (n : ℕ) : Nodup (range n) := by simp only [range_eq_range', nodup_range']
 #align list.nodup_range List.nodup_range
-
-theorem range_sublist {m n : ℕ} : range m <+ range n ↔ m ≤ n := by
-  simp only [range_eq_range', range'_sublist_right]
 #align list.range_sublist List.range_sublist
-
-theorem range_subset {m n : ℕ} : range m ⊆ range n ↔ m ≤ n := by
-  simp only [range_eq_range', range'_subset_right]
 #align list.range_subset List.range_subset
-
-@[simp]
-theorem mem_range {m n : ℕ} : m ∈ range n ↔ m < n := by
-  simp only [range_eq_range', mem_range', Nat.zero_le, true_and_iff, zero_add]
 #align list.mem_range List.mem_range
-
--- @[simp] -- Porting note: simp can prove this
-theorem not_mem_range_self {n : ℕ} : n ∉ range n :=
-  mt mem_range.1 <| lt_irrefl _
 #align list.not_mem_range_self List.not_mem_range_self
-
--- @[simp] -- Porting note: simp can prove this
-theorem self_mem_range_succ (n : ℕ) : n ∈ range (n + 1) := by
-  simp only [succ_pos', lt_add_iff_pos_right, mem_range]
 #align list.self_mem_range_succ List.self_mem_range_succ
-
-theorem get?_range {m n : ℕ} (h : m < n) : get? (range n) m = some m := by
-  simp only [range_eq_range', get?_range' _ h, zero_add]
 #align list.nth_range List.get?_range
-
-theorem range_succ (n : ℕ) : range (succ n) = range n ++ [n] := by
-  simp only [range_eq_range', range'_concat, zero_add]
 #align list.range_succ List.range_succ
-
-@[simp]
-theorem range_zero : range 0 = [] :=
-  rfl
 #align list.range_zero List.range_zero
 
 theorem chain'_range_succ (r : ℕ → ℕ → Prop) (n : ℕ) :
@@ -223,23 +105,8 @@ theorem chain_range_succ (r : ℕ → ℕ → Prop) (n a : ℕ) :
   rw [range_succ_eq_map, chain_cons, and_congr_right_iff, ← chain'_range_succ, range_succ_eq_map]
   exact fun _ => Iff.rfl
 #align list.chain_range_succ List.chain_range_succ
-
-theorem range_add (a : ℕ) : ∀ b, range (a + b) = range a ++ (range b).map fun x => a + x
-  | 0 => by rw [add_zero, range_zero, map_nil, append_nil]
-  | b + 1 => by
-    rw [Nat.add_succ, range_succ, range_add a b, range_succ, map_append,
-      map_singleton, append_assoc]
 #align list.range_add List.range_add
-
-theorem iota_eq_reverse_range' : ∀ n : ℕ, iota n = reverse (range' 1 n)
-  | 0 => rfl
-  | n + 1 => by
-    simp only [iota, range'_concat, iota_eq_reverse_range' (n.add 0), reverse_append, add_comm]; rfl
 #align list.iota_eq_reverse_range' List.iota_eq_reverse_range'
-
-@[simp]
-theorem length_iota (n : ℕ) : length (iota n) = n := by
-  simp only [iota_eq_reverse_range', length_reverse, length_range']
 #align list.length_iota List.length_iota
 
 theorem pairwise_gt_iota (n : ℕ) : Pairwise (· > ·) (iota n) := by
@@ -249,18 +116,7 @@ theorem pairwise_gt_iota (n : ℕ) : Pairwise (· > ·) (iota n) := by
 theorem nodup_iota (n : ℕ) : Nodup (iota n) :=
   (pairwise_gt_iota n).imp _root_.ne_of_gt
 #align list.nodup_iota List.nodup_iota
-
-theorem mem_iota {m n : ℕ} : m ∈ iota n ↔ 1 ≤ m ∧ m ≤ n := by
-  simp only [iota_eq_reverse_range', mem_reverse, mem_range', add_comm, lt_succ_iff]
 #align list.mem_iota List.mem_iota
-
-theorem reverse_range' : ∀ s n : ℕ, reverse (range' s n) = map (fun i => s + n - 1 - i) (range n)
-  | s, 0 => rfl
-  | s, n + 1 => by
-    rw [range'_concat, reverse_append, range_succ_eq_map]
-    simp only [show s + (n + 1) - 1 = s + n from rfl, (· ∘ ·), fun a i =>
-      show a - 1 - i = a - succ i from pred_sub _ _, reverse_singleton, map_cons, tsub_zero,
-      cons_append, nil_append, eq_self_iff_true, true_and_iff, map_map, reverse_range' s n]
 #align list.reverse_range' List.reverse_range'
 
 /-- All elements of `Fin n`, from `0` to `n-1`. The corresponding finset is `Finset.univ`. -/
@@ -318,10 +174,6 @@ theorem enum_from_map_fst : ∀ (n) (l : List α), map Prod.fst (enumFrom n l) =
   | _, [] => rfl
   | _, _ :: _ => congr_arg (cons _) (enum_from_map_fst _ _)
 #align list.enum_from_map_fst List.enum_from_map_fst
-
-@[simp]
-theorem enum_map_fst (l : List α) : map Prod.fst (enum l) = range l.length := by
-  simp only [enum, enum_from_map_fst, range_eq_range']
 #align list.enum_map_fst List.enum_map_fst
 
 theorem enum_eq_zip_range (l : List α) : l.enum = (range l.length).zip l :=
@@ -342,11 +194,6 @@ theorem unzip_enum_from_eq_prod (l : List α) {n : ℕ} :
     (l.enumFrom n).unzip = (range' n l.length, l) := by
   simp only [enum_from_eq_zip_range', unzip_zip, length_range']
 #align list.unzip_enum_from_eq_prod List.unzip_enum_from_eq_prod
-
--- Porting note: new theorem
-@[simp]
-theorem get_range {n} (i) (H : i < (range n).length) : get (range n) ⟨i, H⟩ = i :=
-  Option.some.inj <| by rw [← get?_eq_get _, get?_range (by simpa using H)]
 
 set_option linter.deprecated false in
 @[simp]

--- a/Mathlib/Data/List/Range.lean
+++ b/Mathlib/Data/List/Range.lean
@@ -35,7 +35,7 @@ variable {α : Type u}
 
 #align list.length_range' List.length_range'
 #align list.range'_eq_nil List.range'_eq_nil
-#align list.mem_range' List.mem_range'
+#align list.mem_range' List.mem_range'_1
 #align list.map_add_range' List.map_add_range'
 #align list.map_sub_range' List.map_sub_range'
 #align list.chain_succ_range' List.chain_succ_range'

--- a/Mathlib/Data/Nat/Interval.lean
+++ b/Mathlib/Data/Nat/Interval.lean
@@ -31,21 +31,21 @@ instance : LocallyFiniteOrder ℕ where
   finsetIoc a b := ⟨List.range' (a + 1) (b - a), List.nodup_range' _ _⟩
   finsetIoo a b := ⟨List.range' (a + 1) (b - a - 1), List.nodup_range' _ _⟩
   finset_mem_Icc a b x := by
-    rw [Finset.mem_mk, Multiset.mem_coe, List.mem_range']
+    rw [Finset.mem_mk, Multiset.mem_coe, List.mem_range'_1]
     cases le_or_lt a b with
     | inl h => rw [add_tsub_cancel_of_le (Nat.lt_succ_of_le h).le, Nat.lt_succ_iff]
     | inr h =>
       rw [tsub_eq_zero_iff_le.2 (succ_le_of_lt h), add_zero]
       exact iff_of_false (fun hx => hx.2.not_le hx.1) fun hx => h.not_le (hx.1.trans hx.2)
   finset_mem_Ico a b x := by
-    rw [Finset.mem_mk, Multiset.mem_coe, List.mem_range']
+    rw [Finset.mem_mk, Multiset.mem_coe, List.mem_range'_1]
     cases le_or_lt a b with
     | inl h => rw [add_tsub_cancel_of_le h]
     | inr h =>
       rw [tsub_eq_zero_iff_le.2 h.le, add_zero]
       exact iff_of_false (fun hx => hx.2.not_le hx.1) fun hx => h.not_le (hx.1.trans hx.2.le)
   finset_mem_Ioc a b x := by
-    rw [Finset.mem_mk, Multiset.mem_coe, List.mem_range']
+    rw [Finset.mem_mk, Multiset.mem_coe, List.mem_range'_1]
     cases le_or_lt a b with
     | inl h =>
       rw [← succ_sub_succ, add_tsub_cancel_of_le (succ_le_succ h), Nat.lt_succ_iff, Nat.succ_le_iff]
@@ -53,7 +53,7 @@ instance : LocallyFiniteOrder ℕ where
       rw [tsub_eq_zero_iff_le.2 h.le, add_zero]
       exact iff_of_false (fun hx => hx.2.not_le hx.1) fun hx => h.not_le (hx.1.le.trans hx.2)
   finset_mem_Ioo a b x := by
-    rw [Finset.mem_mk, Multiset.mem_coe, List.mem_range', ← tsub_add_eq_tsub_tsub]
+    rw [Finset.mem_mk, Multiset.mem_coe, List.mem_range'_1, ← tsub_add_eq_tsub_tsub]
     cases le_or_lt (a + 1) b with
     | inl h => rw [add_tsub_cancel_of_le h, Nat.succ_le_iff]
     | inr h =>
@@ -95,22 +95,22 @@ theorem _root_.Finset.range_eq_Ico : range = Ico 0 :=
 
 @[simp]
 theorem card_Icc : (Icc a b).card = b + 1 - a :=
-  List.length_range' _ _
+  List.length_range' _ _ _
 #align nat.card_Icc Nat.card_Icc
 
 @[simp]
 theorem card_Ico : (Ico a b).card = b - a :=
-  List.length_range' _ _
+  List.length_range' _ _ _
 #align nat.card_Ico Nat.card_Ico
 
 @[simp]
 theorem card_Ioc : (Ioc a b).card = b - a :=
-  List.length_range' _ _
+  List.length_range' _ _ _
 #align nat.card_Ioc Nat.card_Ioc
 
 @[simp]
 theorem card_Ioo : (Ioo a b).card = b - a - 1 :=
-  List.length_range' _ _
+  List.length_range' _ _ _
 #align nat.card_Ioo Nat.card_Ioo
 
 @[simp]

--- a/Mathlib/Data/Nat/Totient.lean
+++ b/Mathlib/Data/Nat/Totient.lean
@@ -256,7 +256,7 @@ theorem prime_iff_card_units (p : ℕ) [Fintype (ZMod p)ˣ] :
   cases' eq_zero_or_neZero p with hp hp
   · subst hp
     simp only [ZMod, not_prime_zero, false_iff_iff, zero_tsub]
-    -- the subst created an non-defeq but subsingleton instance diamond; resolve it
+    -- the subst created a non-defeq but subsingleton instance diamond; resolve it
     suffices Fintype.card ℤˣ ≠ 0 by convert this
     simp
   rw [ZMod.card_units_eq_totient, Nat.totient_eq_iff_prime <| NeZero.pos p]

--- a/Mathlib/LinearAlgebra/FiniteDimensional.lean
+++ b/Mathlib/LinearAlgebra/FiniteDimensional.lean
@@ -606,8 +606,7 @@ noncomputable def basisSingleton (ι : Type _) [Unique ι] (h : finrank K V = 1)
           RingHom.id_apply, smul_eq_mul, Pi.smul_apply, Equiv.finsuppUnique_apply]
         exact div_mul_cancel _ h
       right_inv := fun f => by
-        ext a
-        rw [Subsingleton.elim a default] -- porting note: added
+        ext
         simp only [LinearEquiv.map_smulₛₗ, Finsupp.coe_smul, Finsupp.single_eq_same,
           RingHom.id_apply, smul_eq_mul, Pi.smul_apply]
         exact mul_div_cancel _ h }

--- a/Mathlib/LinearAlgebra/Finsupp.lean
+++ b/Mathlib/LinearAlgebra/Finsupp.lean
@@ -1058,8 +1058,8 @@ protected def Fintype.total : (α → M) →ₗ[S] (α → R) →ₗ[R] M where
     simp [Finset.sum_add_distrib, Pi.add_apply, smul_add]
   map_smul' r v := by
     ext g
-    -- Porting note: `smul_comm _ r` → `fun x => smul_comm (g x) r (v x)`
-    simp [Finset.smul_sum, fun x => smul_comm (g x) r (v x)]
+    simp [Finset.smul_sum, smul_comm]
+
 #align fintype.total Fintype.total
 
 variable {S}

--- a/Mathlib/LinearAlgebra/Matrix/ToLin.lean
+++ b/Mathlib/LinearAlgebra/Matrix/ToLin.lean
@@ -248,8 +248,8 @@ variable [Fintype n]
 @[simp]
 theorem Matrix.mulVecLin_one [DecidableEq n] :
     Matrix.mulVecLin (1 : Matrix n n R) = LinearMap.id := by
-  ext
-  simp [LinearMap.one_apply, stdBasis_apply]
+  ext x y t : 3
+  simp [Matrix.one_apply, Pi.single_apply]
 #align matrix.mul_vec_lin_one Matrix.mulVecLin_one
 
 @[simp]

--- a/Mathlib/Logic/Basic.lean
+++ b/Mathlib/Logic/Basic.lean
@@ -823,8 +823,6 @@ theorem forall_eq_apply_imp_iff {f : α → β} {p : β → Prop} :
 @[simp] theorem exists_eq_right' {a' : α} : (∃ a, p a ∧ a' = a) ↔ p a' := by simp [@eq_comm _ a']
 #align exists_eq_right' exists_eq_right'
 
-theorem exists_comm {p : α → β → Prop} : (∃ a b, p a b) ↔ ∃ b a, p a b :=
-  ⟨fun ⟨a, b, h⟩ ↦ ⟨b, a, h⟩, fun ⟨b, a, h⟩ ↦ ⟨a, b, h⟩⟩
 #align exists_comm exists_comm
 
 theorem exists₂_comm {κ₁ : ι₁ → Sort _} {κ₂ : ι₂ → Sort _} {p : ∀ i₁, κ₁ i₁ → ∀ i₂, κ₂ i₂ → Prop} :

--- a/Mathlib/Logic/Equiv/List.lean
+++ b/Mathlib/Logic/Equiv/List.lean
@@ -318,7 +318,7 @@ theorem raise_chain : ∀ l n, List.Chain (· ≤ ·) n (raise l n)
   | _ :: _, _ => List.Chain.cons (Nat.le_add_left _ _) (raise_chain _ _)
 #align denumerable.raise_chain Denumerable.raise_chain
 
-/-- `raise l n` is an non-decreasing sequence. -/
+/-- `raise l n` is a non-decreasing sequence. -/
 theorem raise_sorted : ∀ l n, List.Sorted (· ≤ ·) (raise l n)
   | [], _ => List.sorted_nil
   | _ :: _, _ => List.chain_iff_pairwise.1 (raise_chain _ _)

--- a/Mathlib/RingTheory/IntegralClosure.lean
+++ b/Mathlib/RingTheory/IntegralClosure.lean
@@ -435,16 +435,18 @@ theorem Algebra.IsIntegral.finite (h : Algebra.IsIntegral R A) [h' : Algebra.Fin
         -- Porting note: was `ext`
         refine IsScalarTower.Algebra.ext (algebraMap R A).toAlgebra _ fun r x => ?_
         exact (Algebra.smul_def _ _).symm)
-  -- porting note: the rest of the proof was
-  -- `delta RingHom.Finite at this; convert this; ext; exact Algebra.smul_def _ _`
-  rw [RingHom.Finite] at this; convert this; ext; rfl
+  rw [RingHom.Finite] at this
+  convert this
+  ext
+  exact (Algebra.smul_def _ _)
 #align algebra.is_integral.finite Algebra.IsIntegral.finite
 
 theorem Algebra.IsIntegral.of_finite [h : Module.Finite R A] : Algebra.IsIntegral R A := by
   apply RingHom.Finite.to_isIntegral
-  -- porting note: the rest of the proof was
-  -- `delta RingHom.Finite; convert h; ext; exact (Algebra.smul_def _ _).symm`
-  rw [RingHom.Finite]; convert h; ext; rfl
+  rw [RingHom.Finite]
+  convert h
+  ext
+  exact (Algebra.smul_def _ _).symm
 #align algebra.is_integral.of_finite Algebra.IsIntegral.of_finite
 
 /-- finite = integral + finite type -/

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -16,6 +16,6 @@
   {"git":
    {"url": "https://github.com/leanprover/std4",
     "subDir?": null,
-    "rev": "b886042255d5e93b8d0adb780d49b1c8f3482fbb",
+    "rev": "d02dea6b813b41369e538b128360195d83f2d1bc",
     "name": "std",
     "inputRev?": "main"}}]}


### PR DESCRIPTION
- `List.range'` was moved to std and generalized which caused a little breakage

- `ext` got better in places and seemingly just changed somehow in others so some proofs broke

- several lemmas moved to std, some changed in this process

- changed "an non" -> "a non"

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
