### PR TITLE
[Merged by Bors] - feat: port LinearAlgebra.FreeModule.IdealQuotient

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1662,6 +1662,7 @@ import Mathlib.LinearAlgebra.FreeModule.Determinant
 import Mathlib.LinearAlgebra.FreeModule.Finite.Basic
 import Mathlib.LinearAlgebra.FreeModule.Finite.Matrix
 import Mathlib.LinearAlgebra.FreeModule.Finite.Rank
+import Mathlib.LinearAlgebra.FreeModule.IdealQuotient
 import Mathlib.LinearAlgebra.FreeModule.PID
 import Mathlib.LinearAlgebra.FreeModule.Rank
 import Mathlib.LinearAlgebra.FreeModule.StrongRankCondition

--- a/Mathlib/LinearAlgebra/Basis.lean
+++ b/Mathlib/LinearAlgebra/Basis.lean
@@ -999,7 +999,7 @@ theorem Basis.constr_apply_fintype (f : ι → M') (x : M) :
 /-- If the submodule `P` has a finite basis,
 `x ∈ P` iff it is a linear combination of basis vectors. -/
 theorem Basis.mem_submodule_iff' {P : Submodule R M} (b : Basis ι R P) {x : M} :
-    x ∈ P ↔ ∃ c : ι → R, x = ∑ i, c i • b i :=
+    x ∈ P ↔ ∃ c : ι → R, x = ∑ i, c i • (b i : M) :=
   b.mem_submodule_iff.trans <|
     Finsupp.equivFunOnFinite.exists_congr_left.trans <|
       exists_congr fun c => by simp [Finsupp.sum_fintype, Finsupp.equivFunOnFinite]

--- a/Mathlib/LinearAlgebra/FreeModule/IdealQuotient.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/IdealQuotient.lean
@@ -72,17 +72,19 @@ noncomputable def Ideal.quotientEquivPiSpan (I : Ideal S) (b : Basis ι R S) (hI
     · rintro ⟨y, hy, rfl⟩ i
       exact hy i
     · rintro hdvd
-      refine' ⟨∑ i, x i • b' i, fun i => _, _⟩ <;> rwa [b'.repr_sum_self]
+      refine' ⟨∑ i, x i • b' i, fun i => _, _⟩ <;> rw [b'.repr_sum_self]
       · exact hdvd i
-  refine' ((Submodule.Quotient.restrictScalarsEquiv R I).restrictScalars R).symm.trans _
-  any_goals apply RingHom.id
-  any_goals infer_instance
-  refine' (Submodule.Quotient.equiv (I.restrictScalars R) I' b'.equiv_fun this).trans _
-  any_goals apply RingHom.id
-  any_goals infer_instance
+  refine' ((Submodule.Quotient.restrictScalarsEquiv R I).restrictScalars R).symm.trans
+    (σ₁₂ := RingHom.id R) (σ₃₂ := RingHom.id R) _
+  · infer_instance
+  · infer_instance
+  refine' (Submodule.Quotient.equiv (I.restrictScalars R) I' b'.equivFun this).trans
+    (σ₁₂ := RingHom.id R) (σ₃₂ := RingHom.id R) _
+  · infer_instance
+  · infer_instance
   classical
     let this :=
-      Submodule.quotientPi (show ∀ i, Submodule R R from fun i => Ideal.span ({a i} : Set R))
+      Submodule.quotientPi (show ∀ _, Submodule R R from fun i => Ideal.span ({a i} : Set R))
     exact this
 #align ideal.quotient_equiv_pi_span Ideal.quotientEquivPiSpan
 
@@ -108,8 +110,7 @@ noncomputable def Ideal.fintypeQuotientOfFreeOfNeBot [Module.Free ℤ S] [Module
   let a := I.smithCoeffs b hI
   let e := I.quotientEquivPiZMod b hI
   haveI : ∀ i, NeZero (a i).natAbs := fun i =>
-        ⟨Int.natAbs_ne_zero_of_ne_zero (Ideal.smithCoeffs_ne_zero b I hI i)⟩ <;>
-      classical skip <;>
-    exact Fintype.ofEquiv (∀ i, ZMod (a i).natAbs) e.symm
+        ⟨Int.natAbs_ne_zero_of_ne_zero (Ideal.smithCoeffs_ne_zero b I hI i)⟩
+  classical exact Fintype.ofEquiv (∀ i, ZMod (a i).natAbs) e.symm
 #align ideal.fintype_quotient_of_free_of_ne_bot Ideal.fintypeQuotientOfFreeOfNeBot
 

--- a/Mathlib/LinearAlgebra/FreeModule/IdealQuotient.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/IdealQuotient.lean
@@ -10,14 +10,14 @@ Authors: Anne Baanen
 -/
 import Mathlib.Data.ZMod.Quotient
 import Mathlib.LinearAlgebra.FreeModule.Finite.Basic
-import Mathlib.LinearAlgebra.FreeModule.Pid
+import Mathlib.LinearAlgebra.FreeModule.PID
 import Mathlib.LinearAlgebra.QuotientPi
 
 /-! # Ideals in free modules over PIDs
 
 ## Main results
 
- - `ideal.quotient_equiv_pi_span`: `S ⧸ I`, if `S` is finite free as a module over a PID `R`,
+ - `Ideal.quotientEquivPiSpan`: `S ⧸ I`, if `S` is finite free as a module over a PID `R`,
    can be written as a product of quotients of `R` by principal ideals.
 
 -/
@@ -86,14 +86,14 @@ noncomputable def Ideal.quotientEquivPiSpan (I : Ideal S) (b : Basis ι R S) (hI
 
 /-- Ideal quotients over a free finite extension of `ℤ` are isomorphic to a direct product of
 `zmod`. -/
-noncomputable def Ideal.quotientEquivPiZmod (I : Ideal S) (b : Basis ι ℤ S) (hI : I ≠ ⊥) :
+noncomputable def Ideal.quotientEquivPiZMod (I : Ideal S) (b : Basis ι ℤ S) (hI : I ≠ ⊥) :
     S ⧸ I ≃+ ∀ i, ZMod (I.smithCoeffs b hI i).natAbs :=
   let a := I.smithCoeffs b hI
   let e := I.quotientEquivPiSpan b hI
   let e' : (∀ i : ι, ℤ ⧸ Ideal.span ({a i} : Set ℤ)) ≃+ ∀ i : ι, ZMod (a i).natAbs :=
     AddEquiv.piCongrRight fun i => ↑(Int.quotientSpanEquivZMod (a i))
   (↑(e : (S ⧸ I) ≃ₗ[ℤ] _) : S ⧸ I ≃+ _).trans e'
-#align ideal.quotient_equiv_pi_zmod Ideal.quotientEquivPiZmod
+#align ideal.quotient_equiv_pi_zmod Ideal.quotientEquivPiZMod
 
 /-- A nonzero ideal over a free finite extension of `ℤ` has a finite quotient.
 
@@ -104,7 +104,7 @@ noncomputable def Ideal.fintypeQuotientOfFreeOfNeBot [Module.Free ℤ S] [Module
     (I : Ideal S) (hI : I ≠ ⊥) : Fintype (S ⧸ I) := by
   let b := Module.Free.chooseBasis ℤ S
   let a := I.smithCoeffs b hI
-  let e := I.quotientEquivPiZmod b hI
+  let e := I.quotientEquivPiZMod b hI
   haveI : ∀ i, NeZero (a i).natAbs := fun i =>
         ⟨Int.natAbs_ne_zero_of_ne_zero (Ideal.smithCoeffs_ne_zero b I hI i)⟩ <;>
       classical skip <;>

--- a/Mathlib/LinearAlgebra/FreeModule/IdealQuotient.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/IdealQuotient.lean
@@ -104,6 +104,6 @@ noncomputable def Ideal.fintypeQuotientOfFreeOfNeBot [Module.Free ℤ S] [Module
   let a := I.smithCoeffs b hI
   let e := I.quotientEquivPiZMod b hI
   haveI : ∀ i, NeZero (a i).natAbs := fun i =>
-    ⟨Int.natAbs_ne_zero_of_ne_zero (Ideal.smithCoeffs_ne_zero b I hI i)⟩
+    ⟨Int.natAbs_ne_zero.mpr (Ideal.smithCoeffs_ne_zero b I hI i)⟩
   classical exact Fintype.ofEquiv (∀ i, ZMod (a i).natAbs) e.symm
 #align ideal.fintype_quotient_of_free_of_ne_bot Ideal.fintypeQuotientOfFreeOfNeBot

--- a/Mathlib/LinearAlgebra/FreeModule/IdealQuotient.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/IdealQuotient.lean
@@ -1,0 +1,118 @@
+/-
+Copyright (c) 2022 Anne Baanen. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Anne Baanen
+
+! This file was ported from Lean 3 source module linear_algebra.free_module.ideal_quotient
+! leanprover-community/mathlib commit 6623e6af705e97002a9054c1c05a980180276fc1
+! Please do not edit these lines, except to modify the commit id
+! if you have ported upstream changes.
+-/
+import Mathbin.Data.Zmod.Quotient
+import Mathbin.LinearAlgebra.FreeModule.Finite.Basic
+import Mathbin.LinearAlgebra.FreeModule.Pid
+import Mathbin.LinearAlgebra.QuotientPi
+
+/-! # Ideals in free modules over PIDs
+
+## Main results
+
+ - `ideal.quotient_equiv_pi_span`: `S ⧸ I`, if `S` is finite free as a module over a PID `R`,
+   can be written as a product of quotients of `R` by principal ideals.
+
+-/
+
+
+open BigOperators
+
+variable {ι R S : Type _} [CommRing R] [CommRing S] [Algebra R S]
+
+variable [IsDomain R] [IsPrincipalIdealRing R] [IsDomain S] [Fintype ι]
+
+/-- We can write the quotient of an ideal over a PID as a product of quotients by principal ideals.
+-/
+noncomputable def Ideal.quotientEquivPiSpan (I : Ideal S) (b : Basis ι R S) (hI : I ≠ ⊥) :
+    (S ⧸ I) ≃ₗ[R] ∀ i, R ⧸ Ideal.span ({I.smithCoeffs b hI i} : Set R) :=
+  by
+  -- Choose `e : S ≃ₗ I` and a basis `b'` for `S` that turns the map
+  -- `f := ((submodule.subtype I).restrict_scalars R).comp e` into a diagonal matrix:
+  -- there is an `a : ι → ℤ` such that `f (b' i) = a i • b' i`.
+  let a := I.smith_coeffs b hI
+  let b' := I.ring_basis b hI
+  let ab := I.self_basis b hI
+  have ab_eq := I.self_basis_def b hI
+  let e : S ≃ₗ[R] I := b'.equiv ab (Equiv.refl _)
+  let f : S →ₗ[R] S := (I.subtype.restrict_scalars R).comp (e : S →ₗ[R] I)
+  let f_apply : ∀ x, f x = b'.equiv ab (Equiv.refl _) x := fun x => rfl
+  have ha : ∀ i, f (b' i) = a i • b' i := by
+    intro i
+    rw [f_apply, b'.equiv_apply, Equiv.refl_apply, ab_eq]
+  have mem_I_iff : ∀ x, x ∈ I ↔ ∀ i, a i ∣ b'.repr x i :=
+    by
+    intro x
+    simp_rw [ab.mem_ideal_iff', ab_eq]
+    have : ∀ (c : ι → R) (i), b'.repr (∑ j : ι, c j • a j • b' j) i = a i * c i :=
+      by
+      intro c i
+      simp only [← MulAction.mul_smul, b'.repr_sum_self, mul_comm]
+    constructor
+    · rintro ⟨c, rfl⟩ i
+      exact ⟨c i, this c i⟩
+    · rintro ha
+      choose c hc using ha
+      exact ⟨c, b'.ext_elem fun i => trans (hc i) (this c i).symm⟩
+  -- Now we map everything through the linear equiv `S ≃ₗ (ι → R)`,
+  -- which maps `I` to `I' := Π i, a i ℤ`.
+  let I' : Submodule R (ι → R) := Submodule.pi Set.univ fun i => Ideal.span ({a i} : Set R)
+  have : Submodule.map (b'.equiv_fun : S →ₗ[R] ι → R) (I.restrict_scalars R) = I' :=
+    by
+    ext x
+    simp only [Submodule.mem_map, Submodule.mem_pi, Ideal.mem_span_singleton, Set.mem_univ,
+      Submodule.restrictScalars_mem, mem_I_iff, smul_eq_mul, forall_true_left, LinearEquiv.coe_coe,
+      Basis.equivFun_apply]
+    constructor
+    · rintro ⟨y, hy, rfl⟩ i
+      exact hy i
+    · rintro hdvd
+      refine' ⟨∑ i, x i • b' i, fun i => _, _⟩ <;> rwa [b'.repr_sum_self]
+      · exact hdvd i
+  refine' ((Submodule.Quotient.restrictScalarsEquiv R I).restrictScalars R).symm.trans _
+  any_goals apply RingHom.id
+  any_goals infer_instance
+  refine' (Submodule.Quotient.equiv (I.restrict_scalars R) I' b'.equiv_fun this).trans _
+  any_goals apply RingHom.id
+  any_goals infer_instance
+  classical
+    let this :=
+      Submodule.quotientPi (show ∀ i, Submodule R R from fun i => Ideal.span ({a i} : Set R))
+    exact this
+#align ideal.quotient_equiv_pi_span Ideal.quotientEquivPiSpan
+
+/-- Ideal quotients over a free finite extension of `ℤ` are isomorphic to a direct product of
+`zmod`. -/
+noncomputable def Ideal.quotientEquivPiZmod (I : Ideal S) (b : Basis ι ℤ S) (hI : I ≠ ⊥) :
+    S ⧸ I ≃+ ∀ i, ZMod (I.smithCoeffs b hI i).natAbs :=
+  let a := I.smithCoeffs b hI
+  let e := I.quotientEquivPiSpan b hI
+  let e' : (∀ i : ι, ℤ ⧸ Ideal.span ({a i} : Set ℤ)) ≃+ ∀ i : ι, ZMod (a i).natAbs :=
+    AddEquiv.piCongrRight fun i => ↑(Int.quotientSpanEquivZMod (a i))
+  (↑(e : (S ⧸ I) ≃ₗ[ℤ] _) : S ⧸ I ≃+ _).trans e'
+#align ideal.quotient_equiv_pi_zmod Ideal.quotientEquivPiZmod
+
+/-- A nonzero ideal over a free finite extension of `ℤ` has a finite quotient.
+
+Can't be an instance because of the side condition `I ≠ ⊥`, and more importantly,
+because the choice of `fintype` instance is non-canonical.
+-/
+noncomputable def Ideal.fintypeQuotientOfFreeOfNeBot [Module.Free ℤ S] [Module.Finite ℤ S]
+    (I : Ideal S) (hI : I ≠ ⊥) : Fintype (S ⧸ I) :=
+  by
+  let b := Module.Free.chooseBasis ℤ S
+  let a := I.smithCoeffs b hI
+  let e := I.quotientEquivPiZmod b hI
+  haveI : ∀ i, NeZero (a i).natAbs := fun i =>
+        ⟨Int.natAbs_ne_zero_of_ne_zero (Ideal.smithCoeffs_ne_zero b I hI i)⟩ <;>
+      classical skip <;>
+    exact Fintype.ofEquiv (∀ i, ZMod (a i).natAbs) e.symm
+#align ideal.fintype_quotient_of_free_of_ne_bot Ideal.fintypeQuotientOfFreeOfNeBot
+

--- a/Mathlib/LinearAlgebra/FreeModule/IdealQuotient.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/IdealQuotient.lean
@@ -48,20 +48,24 @@ noncomputable def Ideal.quotientEquivPiSpan (I : Ideal S) (b : Basis ι R S) (hI
     rw [f_apply, b'.equiv_apply, Equiv.refl_apply, ab_eq]
   have mem_I_iff : ∀ x, x ∈ I ↔ ∀ i, a i ∣ b'.repr x i := by
     intro x
-    simp_rw [ab.mem_ideal_iff', ab_eq]
+    -- Porting note: these lines used to be `simp_rw [ab.mem_ideal_iff', ab_eq]`
+    rw [ab.mem_ideal_iff']
+    simp_rw [ab_eq]
     have : ∀ (c : ι → R) (i), b'.repr (∑ j : ι, c j • a j • b' j) i = a i * c i := by
       intro c i
       simp only [← MulAction.mul_smul, b'.repr_sum_self, mul_comm]
     constructor
     · rintro ⟨c, rfl⟩ i
-      exact ⟨c i, this c i⟩
+      use c i
+      convert this c i
+      sorry
     · rintro ha
       choose c hc using ha
-      exact ⟨c, b'.ext_elem fun i => trans (hc i) (this c i).symm⟩
+      exact ⟨c, b'.ext_elem fun i => Eq.trans (hc i) (this c i).symm⟩
   -- Now we map everything through the linear equiv `S ≃ₗ (ι → R)`,
   -- which maps `I` to `I' := Π i, a i ℤ`.
   let I' : Submodule R (ι → R) := Submodule.pi Set.univ fun i => Ideal.span ({a i} : Set R)
-  have : Submodule.map (b'.equiv_fun : S →ₗ[R] ι → R) (I.restrictScalars R) = I' := by
+  have : Submodule.map (b'.equivFun : S →ₗ[R] ι → R) (I.restrictScalars R) = I' := by
     ext x
     simp only [Submodule.mem_map, Submodule.mem_pi, Ideal.mem_span_singleton, Set.mem_univ,
       Submodule.restrictScalars_mem, mem_I_iff, smul_eq_mul, forall_true_left, LinearEquiv.coe_coe,

--- a/Mathlib/LinearAlgebra/FreeModule/IdealQuotient.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/IdealQuotient.lean
@@ -40,12 +40,6 @@ noncomputable def Ideal.quotientEquivPiSpan (I : Ideal S) (b : Basis ι R S) (hI
   let b' := I.ringBasis b hI
   let ab := I.selfBasis b hI
   have ab_eq := I.selfBasis_def b hI
-  let e : S ≃ₗ[R] I := b'.equiv ab (Equiv.refl _)
-  let f : S →ₗ[R] S := (I.subtype.restrictScalars R).comp (e : S →ₗ[R] I)
-  let f_apply : ∀ x, f x = b'.equiv ab (Equiv.refl _) x := fun x => rfl
-  have ha : ∀ i, f (b' i) = a i • b' i := by
-    intro i
-    rw [f_apply, b'.equiv_apply, Equiv.refl_apply, ab_eq]
   have mem_I_iff : ∀ x, x ∈ I ↔ ∀ i, a i ∣ b'.repr x i := by
     intro x
     -- Porting note: these lines used to be `simp_rw [ab.mem_ideal_iff', ab_eq]`
@@ -110,7 +104,6 @@ noncomputable def Ideal.fintypeQuotientOfFreeOfNeBot [Module.Free ℤ S] [Module
   let a := I.smithCoeffs b hI
   let e := I.quotientEquivPiZMod b hI
   haveI : ∀ i, NeZero (a i).natAbs := fun i =>
-        ⟨Int.natAbs_ne_zero_of_ne_zero (Ideal.smithCoeffs_ne_zero b I hI i)⟩
+    ⟨Int.natAbs_ne_zero_of_ne_zero (Ideal.smithCoeffs_ne_zero b I hI i)⟩
   classical exact Fintype.ofEquiv (∀ i, ZMod (a i).natAbs) e.symm
 #align ideal.fintype_quotient_of_free_of_ne_bot Ideal.fintypeQuotientOfFreeOfNeBot
-

--- a/Mathlib/LinearAlgebra/FreeModule/IdealQuotient.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/IdealQuotient.lean
@@ -34,14 +34,14 @@ variable [IsDomain R] [IsPrincipalIdealRing R] [IsDomain S] [Fintype ι]
 noncomputable def Ideal.quotientEquivPiSpan (I : Ideal S) (b : Basis ι R S) (hI : I ≠ ⊥) :
     (S ⧸ I) ≃ₗ[R] ∀ i, R ⧸ Ideal.span ({I.smithCoeffs b hI i} : Set R) := by
   -- Choose `e : S ≃ₗ I` and a basis `b'` for `S` that turns the map
-  -- `f := ((submodule.subtype I).restrict_scalars R).comp e` into a diagonal matrix:
+  -- `f := ((Submodule.subtype I).restrictScalars R).comp e` into a diagonal matrix:
   -- there is an `a : ι → ℤ` such that `f (b' i) = a i • b' i`.
-  let a := I.smith_coeffs b hI
-  let b' := I.ring_basis b hI
-  let ab := I.self_basis b hI
-  have ab_eq := I.self_basis_def b hI
+  let a := I.smithCoeffs b hI
+  let b' := I.ringBasis b hI
+  let ab := I.selfBasis b hI
+  have ab_eq := I.selfBasis_def b hI
   let e : S ≃ₗ[R] I := b'.equiv ab (Equiv.refl _)
-  let f : S →ₗ[R] S := (I.subtype.restrict_scalars R).comp (e : S →ₗ[R] I)
+  let f : S →ₗ[R] S := (I.subtype.restrictScalars R).comp (e : S →ₗ[R] I)
   let f_apply : ∀ x, f x = b'.equiv ab (Equiv.refl _) x := fun x => rfl
   have ha : ∀ i, f (b' i) = a i • b' i := by
     intro i
@@ -61,7 +61,7 @@ noncomputable def Ideal.quotientEquivPiSpan (I : Ideal S) (b : Basis ι R S) (hI
   -- Now we map everything through the linear equiv `S ≃ₗ (ι → R)`,
   -- which maps `I` to `I' := Π i, a i ℤ`.
   let I' : Submodule R (ι → R) := Submodule.pi Set.univ fun i => Ideal.span ({a i} : Set R)
-  have : Submodule.map (b'.equiv_fun : S →ₗ[R] ι → R) (I.restrict_scalars R) = I' := by
+  have : Submodule.map (b'.equiv_fun : S →ₗ[R] ι → R) (I.restrictScalars R) = I' := by
     ext x
     simp only [Submodule.mem_map, Submodule.mem_pi, Ideal.mem_span_singleton, Set.mem_univ,
       Submodule.restrictScalars_mem, mem_I_iff, smul_eq_mul, forall_true_left, LinearEquiv.coe_coe,
@@ -75,7 +75,7 @@ noncomputable def Ideal.quotientEquivPiSpan (I : Ideal S) (b : Basis ι R S) (hI
   refine' ((Submodule.Quotient.restrictScalarsEquiv R I).restrictScalars R).symm.trans _
   any_goals apply RingHom.id
   any_goals infer_instance
-  refine' (Submodule.Quotient.equiv (I.restrict_scalars R) I' b'.equiv_fun this).trans _
+  refine' (Submodule.Quotient.equiv (I.restrictScalars R) I' b'.equiv_fun this).trans _
   any_goals apply RingHom.id
   any_goals infer_instance
   classical
@@ -85,7 +85,7 @@ noncomputable def Ideal.quotientEquivPiSpan (I : Ideal S) (b : Basis ι R S) (hI
 #align ideal.quotient_equiv_pi_span Ideal.quotientEquivPiSpan
 
 /-- Ideal quotients over a free finite extension of `ℤ` are isomorphic to a direct product of
-`zmod`. -/
+`ZMod`. -/
 noncomputable def Ideal.quotientEquivPiZMod (I : Ideal S) (b : Basis ι ℤ S) (hI : I ≠ ⊥) :
     S ⧸ I ≃+ ∀ i, ZMod (I.smithCoeffs b hI i).natAbs :=
   let a := I.smithCoeffs b hI
@@ -98,7 +98,7 @@ noncomputable def Ideal.quotientEquivPiZMod (I : Ideal S) (b : Basis ι ℤ S) (
 /-- A nonzero ideal over a free finite extension of `ℤ` has a finite quotient.
 
 Can't be an instance because of the side condition `I ≠ ⊥`, and more importantly,
-because the choice of `fintype` instance is non-canonical.
+because the choice of `Fintype` instance is non-canonical.
 -/
 noncomputable def Ideal.fintypeQuotientOfFreeOfNeBot [Module.Free ℤ S] [Module.Finite ℤ S]
     (I : Ideal S) (hI : I ≠ ⊥) : Fintype (S ⧸ I) := by

--- a/Mathlib/LinearAlgebra/FreeModule/IdealQuotient.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/IdealQuotient.lean
@@ -56,9 +56,7 @@ noncomputable def Ideal.quotientEquivPiSpan (I : Ideal S) (b : Basis ι R S) (hI
       simp only [← MulAction.mul_smul, b'.repr_sum_self, mul_comm]
     constructor
     · rintro ⟨c, rfl⟩ i
-      use c i
-      convert this c i
-      sorry
+      exact ⟨c i, this c i⟩
     · rintro ha
       choose c hc using ha
       exact ⟨c, b'.ext_elem fun i => Eq.trans (hc i) (this c i).symm⟩

--- a/Mathlib/LinearAlgebra/FreeModule/IdealQuotient.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/IdealQuotient.lean
@@ -8,10 +8,10 @@ Authors: Anne Baanen
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
-import Mathbin.Data.Zmod.Quotient
-import Mathbin.LinearAlgebra.FreeModule.Finite.Basic
-import Mathbin.LinearAlgebra.FreeModule.Pid
-import Mathbin.LinearAlgebra.QuotientPi
+import Mathlib.Data.ZMod.Quotient
+import Mathlib.LinearAlgebra.FreeModule.Finite.Basic
+import Mathlib.LinearAlgebra.FreeModule.Pid
+import Mathlib.LinearAlgebra.QuotientPi
 
 /-! # Ideals in free modules over PIDs
 
@@ -32,8 +32,7 @@ variable [IsDomain R] [IsPrincipalIdealRing R] [IsDomain S] [Fintype ι]
 /-- We can write the quotient of an ideal over a PID as a product of quotients by principal ideals.
 -/
 noncomputable def Ideal.quotientEquivPiSpan (I : Ideal S) (b : Basis ι R S) (hI : I ≠ ⊥) :
-    (S ⧸ I) ≃ₗ[R] ∀ i, R ⧸ Ideal.span ({I.smithCoeffs b hI i} : Set R) :=
-  by
+    (S ⧸ I) ≃ₗ[R] ∀ i, R ⧸ Ideal.span ({I.smithCoeffs b hI i} : Set R) := by
   -- Choose `e : S ≃ₗ I` and a basis `b'` for `S` that turns the map
   -- `f := ((submodule.subtype I).restrict_scalars R).comp e` into a diagonal matrix:
   -- there is an `a : ι → ℤ` such that `f (b' i) = a i • b' i`.
@@ -47,12 +46,10 @@ noncomputable def Ideal.quotientEquivPiSpan (I : Ideal S) (b : Basis ι R S) (hI
   have ha : ∀ i, f (b' i) = a i • b' i := by
     intro i
     rw [f_apply, b'.equiv_apply, Equiv.refl_apply, ab_eq]
-  have mem_I_iff : ∀ x, x ∈ I ↔ ∀ i, a i ∣ b'.repr x i :=
-    by
+  have mem_I_iff : ∀ x, x ∈ I ↔ ∀ i, a i ∣ b'.repr x i := by
     intro x
     simp_rw [ab.mem_ideal_iff', ab_eq]
-    have : ∀ (c : ι → R) (i), b'.repr (∑ j : ι, c j • a j • b' j) i = a i * c i :=
-      by
+    have : ∀ (c : ι → R) (i), b'.repr (∑ j : ι, c j • a j • b' j) i = a i * c i := by
       intro c i
       simp only [← MulAction.mul_smul, b'.repr_sum_self, mul_comm]
     constructor
@@ -64,8 +61,7 @@ noncomputable def Ideal.quotientEquivPiSpan (I : Ideal S) (b : Basis ι R S) (hI
   -- Now we map everything through the linear equiv `S ≃ₗ (ι → R)`,
   -- which maps `I` to `I' := Π i, a i ℤ`.
   let I' : Submodule R (ι → R) := Submodule.pi Set.univ fun i => Ideal.span ({a i} : Set R)
-  have : Submodule.map (b'.equiv_fun : S →ₗ[R] ι → R) (I.restrict_scalars R) = I' :=
-    by
+  have : Submodule.map (b'.equiv_fun : S →ₗ[R] ι → R) (I.restrict_scalars R) = I' := by
     ext x
     simp only [Submodule.mem_map, Submodule.mem_pi, Ideal.mem_span_singleton, Set.mem_univ,
       Submodule.restrictScalars_mem, mem_I_iff, smul_eq_mul, forall_true_left, LinearEquiv.coe_coe,
@@ -105,8 +101,7 @@ Can't be an instance because of the side condition `I ≠ ⊥`, and more importa
 because the choice of `fintype` instance is non-canonical.
 -/
 noncomputable def Ideal.fintypeQuotientOfFreeOfNeBot [Module.Free ℤ S] [Module.Finite ℤ S]
-    (I : Ideal S) (hI : I ≠ ⊥) : Fintype (S ⧸ I) :=
-  by
+    (I : Ideal S) (hI : I ≠ ⊥) : Fintype (S ⧸ I) := by
   let b := Module.Free.chooseBasis ℤ S
   let a := I.smithCoeffs b hI
   let e := I.quotientEquivPiZmod b hI

--- a/Mathlib/RingTheory/Ideal/Operations.lean
+++ b/Mathlib/RingTheory/Ideal/Operations.lean
@@ -1980,7 +1980,7 @@ theorem Basis.mem_ideal_iff {ι R S : Type _} [CommRing R] [CommRing S] [Algebra
 /-- If `I : Ideal S` has a finite basis over `R`,
 `x ∈ I` iff it is a linear combination of basis vectors. -/
 theorem Basis.mem_ideal_iff' {ι R S : Type _} [Fintype ι] [CommRing R] [CommRing S] [Algebra R S]
-    {I : Ideal S} (b : Basis ι R I) {x : S} : x ∈ I ↔ ∃ c : ι → R, x = ∑ i, c i • b i :=
+    {I : Ideal S} (b : Basis ι R I) {x : S} : x ∈ I ↔ ∃ c : ι → R, x = ∑ i, c i • (b i : S) :=
   (b.map ((I.restrictScalarsEquiv R _ _).restrictScalars R).symm).mem_submodule_iff'
 #align basis.mem_ideal_iff' Basis.mem_ideal_iff'
 


### PR DESCRIPTION
This changes `Basis.mem_submodule_iff'` and `Basis.mem_ideal_iff'` because Lean 4 inserts the coercion in a different place than Lean 3 does. Otherwise, just a few implicits that needed to be explicit and one syntax weirdness.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
