### PR TITLE
chore: Small `variable` cleanup in FieldTheory/RatFunc

### DIFF
--- a/Mathlib/FieldTheory/RatFunc.lean
+++ b/Mathlib/FieldTheory/RatFunc.lean
@@ -301,8 +301,7 @@ section Field
 
 /-! ### Defining the field structure -/
 
--- porting note: replaced `omit hdomain` by working with a new type variable `R` instead
--- I believe this is because `irreducible_def` includes `hdomain` when it is not needed
+-- porting note: replaced `omit hdomain`
 variable {R : Type _} [CommRing R]
 
 /-- The zero rational function. -/
@@ -433,8 +432,6 @@ section SMul
 
 -- porting note: removed `omit hdomain`
 
-variable {R : Type _}
-
 /-- Scalar multiplication of rational functions. -/
 protected irreducible_def smul [SMul R (FractionRing K[X])] : R → RatFunc K → RatFunc K
   | r, ⟨p⟩ => ⟨r • p⟩
@@ -471,7 +468,7 @@ set_option linter.uppercaseLean3 false in
 
 variable [Monoid R] [DistribMulAction R K[X]]
 
-variable [htower : IsScalarTower R K[X] K[X]]
+variable [IsScalarTower R K[X] K[X]]
 
 -- porting note: removed `include htower`
 
@@ -489,8 +486,8 @@ instance : IsScalarTower R K[X] (RatFunc K) := ⟨by
 
 end SMul
 
--- porting note: replaced `omit hdomain` with using a new type variable
-variable (R : Type _) [CommRing R]
+-- porting note: removed `omit hdomain`
+variable (R)
 
 instance [Subsingleton R] : Subsingleton (RatFunc R) :=
   toFractionRing_injective.subsingleton


### PR DESCRIPTION
Removes some unnecessary introduction of new `variable`s, favouring recycling of pre-existing one.  This exploits the new feature of getting Lean to figure out what variables to `include/omit` automatically.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
