### PR TITLE
[Merged by Bors] - feat: cache: show 200 errors different from 404

### DIFF
--- a/Cache/Requests.lean
+++ b/Cache/Requests.lean
@@ -34,9 +34,9 @@ def mkGetConfigContent (hashMap : IO.HashMap) : IO String := do
     -- this does not exactly match the requirements for quoting for curl:
     -- ```
     -- If the parameter contains whitespace (or starts with : or =),
-    --  the parameter must be enclosed within quotes. 
+    --  the parameter must be enclosed within quotes.
     -- Within double quotes, the following escape sequences are available:
-    --  \, ", \t, \n, \r and \v. 
+    --  \, ", \t, \n, \r and \v.
     -- A backslash preceding any other letter is ignored.
     -- ```
     -- If this becomes an issue we can implement the curl spec.
@@ -67,13 +67,17 @@ def downloadFiles (hashMap : IO.HashMap) (forceDownload : Bool) (parallel : Bool
       IO.FS.writeFile IO.CURLCFG (← mkGetConfigContent hashMap)
       let args := #["--request", "GET", "--parallel", "--fail", "--silent",
           "--write-out", "%{json}\n", "--config", IO.CURLCFG.toString]
-      let (_, failed, done) ← IO.runCurlStreaming args (← IO.monoMsNow, 0, 0) fun a line => do
-        let mut (last, failed, done) := a
+      let (_, success, failed, done) ←
+          IO.runCurlStreaming args (← IO.monoMsNow, 0, 0, 0) fun a line => do
+        let mut (last, success, failed, done) := a
         -- output errors other than 404 and remove corresponding partial downloads
         let line := line.trim
         if !line.isEmpty then
           let result ← IO.ofExcept <| Lean.Json.parse line
-          if !(result.getObjValAs? Nat "http_code" matches .ok 200 | .ok 404) then
+          match result.getObjValAs? Nat "http_code" with
+          | .ok 200 => success := success + 1
+          | .ok 404 => pure ()
+          | _ =>
             failed := failed + 1
             if let .ok e := result.getObjValAs? String "errormsg" then
               IO.println e
@@ -84,15 +88,15 @@ def downloadFiles (hashMap : IO.HashMap) (forceDownload : Bool) (parallel : Bool
           done := done + 1
           let now ← IO.monoMsNow
           if now - last ≥ 100 then -- max 10/s update rate
-            let mut msg := s!"\rDownloaded {done}/{size} file(s) [{100*done/size}%]"
+            let mut msg := s!"\rDownloaded {success} file(s) [{done}/{size} = {100*done/size}%]"
             if failed != 0 then
               msg := msg ++ ", {failed} failed"
             IO.eprint msg
             last := now
-        pure (last, failed, done)
+        pure (last, success, failed, done)
       if done > 0 then
         -- to avoid confusingly moving on without finishing the count
-        let mut msg := s!"\rDownloaded {size}/{size} file(s) [100%]"
+        let mut msg := s!"\rDownloaded {success} file(s) [{size}/{size} = 100%]"
         if failed != 0 then
           msg := msg ++ ", {failed} failed"
         IO.eprintln msg


### PR DESCRIPTION
The `lake exe cache get` progress bar now shows
```
Downloaded S file(s) [N/T = ...%]
```
instead of
```
Downloaded N/T file(s) [...%]
```
where `T` is the total number of files to download, `N` is the number of downloads resolved to either OK 200 or Missing 404, and `S` is the number of files resolving to OK 200. Under normal conditions `S` and `N` will be equal, but if there are a lot of new files which are not reflected upstream then `S` will be somewhat less than `N`, and if `S` is stuck at 0 then there is [something wrong with the hashing](https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/.60lake.20exe.60.20interpreted.20mode.3F/near/361194937).