### PR TITLE
[Merged by Bors] - feat: port Analysis.InnerProductSpace.PiL2

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -476,6 +476,7 @@ import Mathlib.Analysis.InnerProductSpace.ConformalLinearMap
 import Mathlib.Analysis.InnerProductSpace.Dual
 import Mathlib.Analysis.InnerProductSpace.LaxMilgram
 import Mathlib.Analysis.InnerProductSpace.Orthogonal
+import Mathlib.Analysis.InnerProductSpace.PiL2
 import Mathlib.Analysis.InnerProductSpace.Projection
 import Mathlib.Analysis.InnerProductSpace.Symmetric
 import Mathlib.Analysis.LocallyConvex.AbsConvex

--- a/Mathlib/Analysis/InnerProductSpace/Basic.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Basic.lean
@@ -798,7 +798,8 @@ theorem Orthonormal.inner_right_finsupp {v : ι → E} (hv : Orthonormal 𝕜 v)
 vectors picks out the coefficient of that vector. -/
 theorem Orthonormal.inner_right_sum {v : ι → E} (hv : Orthonormal 𝕜 v) (l : ι → 𝕜) {s : Finset ι}
     {i : ι} (hi : i ∈ s) : ⟪v i, ∑ i in s, l i • v i⟫ = l i := by
-  classical!; simp [inner_sum, inner_smul_right, orthonormal_iff_ite.mp hv, hi]
+  classical!
+  simp [inner_sum, inner_smul_right, orthonormal_iff_ite.mp hv, hi]
 #align orthonormal.inner_right_sum Orthonormal.inner_right_sum
 
 /-- The inner product of a linear combination of a set of orthonormal vectors with one of those
@@ -818,8 +819,9 @@ theorem Orthonormal.inner_left_finsupp {v : ι → E} (hv : Orthonormal 𝕜 v) 
 vectors picks out the coefficient of that vector. -/
 theorem Orthonormal.inner_left_sum {v : ι → E} (hv : Orthonormal 𝕜 v) (l : ι → 𝕜) {s : Finset ι}
     {i : ι} (hi : i ∈ s) : ⟪∑ i in s, l i • v i, v i⟫ = conj (l i) := by
-  classical!; simp only [sum_inner, inner_smul_left, orthonormal_iff_ite.mp hv, hi, mul_boole,
-      Finset.sum_ite_eq', if_true]
+  classical!
+  simp only [sum_inner, inner_smul_left, orthonormal_iff_ite.mp hv, hi, mul_boole,
+    Finset.sum_ite_eq', if_true]
 #align orthonormal.inner_left_sum Orthonormal.inner_left_sum
 
 /-- The inner product of a linear combination of a set of orthonormal vectors with one of those
@@ -858,7 +860,8 @@ sum of the weights.
 -/
 theorem Orthonormal.inner_left_right_finset {s : Finset ι} {v : ι → E} (hv : Orthonormal 𝕜 v)
     {a : ι → ι → 𝕜} : (∑ i in s, ∑ j in s, a i j • ⟪v j, v i⟫) = ∑ k in s, a k k := by
-  classical!; simp [orthonormal_iff_ite.mp hv, Finset.sum_ite_of_true]
+  classical!
+  simp [orthonormal_iff_ite.mp hv, Finset.sum_ite_of_true]
 #align orthonormal.inner_left_right_finset Orthonormal.inner_left_right_finset
 
 /-- An orthonormal set is linearly independent. -/
@@ -927,7 +930,8 @@ adapted from the corresponding development of the theory of linearly independent
 variable (𝕜 E)
 
 theorem orthonormal_empty : Orthonormal 𝕜 (fun x => x : (∅ : Set E) → E) := by
-  classical!; simp [orthonormal_subtype_iff_ite]
+  classical!
+  simp [orthonormal_subtype_iff_ite]
 #align orthonormal_empty orthonormal_empty
 
 variable {𝕜 E}

--- a/Mathlib/Analysis/InnerProductSpace/Basic.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Basic.lean
@@ -790,14 +790,14 @@ theorem orthonormal_subtype_iff_ite {s : Set E} :
 vectors picks out the coefficient of that vector. -/
 theorem Orthonormal.inner_right_finsupp {v : ι → E} (hv : Orthonormal 𝕜 v) (l : ι →₀ 𝕜) (i : ι) :
     ⟪v i, Finsupp.total ι E 𝕜 v l⟫ = l i := by
-  classical simpa [Finsupp.total_apply, Finsupp.inner_sum, orthonormal_iff_ite.mp hv] using Eq.symm
+  classical!; simpa [Finsupp.total_apply, Finsupp.inner_sum, orthonormal_iff_ite.mp hv] using Eq.symm
 #align orthonormal.inner_right_finsupp Orthonormal.inner_right_finsupp
 
 /-- The inner product of a linear combination of a set of orthonormal vectors with one of those
 vectors picks out the coefficient of that vector. -/
 theorem Orthonormal.inner_right_sum {v : ι → E} (hv : Orthonormal 𝕜 v) (l : ι → 𝕜) {s : Finset ι}
     {i : ι} (hi : i ∈ s) : ⟪v i, ∑ i in s, l i • v i⟫ = l i := by
-  classical simp [inner_sum, inner_smul_right, orthonormal_iff_ite.mp hv, hi]
+  classical!; simp [inner_sum, inner_smul_right, orthonormal_iff_ite.mp hv, hi]
 #align orthonormal.inner_right_sum Orthonormal.inner_right_sum
 
 /-- The inner product of a linear combination of a set of orthonormal vectors with one of those
@@ -817,7 +817,7 @@ theorem Orthonormal.inner_left_finsupp {v : ι → E} (hv : Orthonormal 𝕜 v) 
 vectors picks out the coefficient of that vector. -/
 theorem Orthonormal.inner_left_sum {v : ι → E} (hv : Orthonormal 𝕜 v) (l : ι → 𝕜) {s : Finset ι}
     {i : ι} (hi : i ∈ s) : ⟪∑ i in s, l i • v i, v i⟫ = conj (l i) := by
-  classical simp only [sum_inner, inner_smul_left, orthonormal_iff_ite.mp hv, hi, mul_boole,
+  classical!; simp only [sum_inner, inner_smul_left, orthonormal_iff_ite.mp hv, hi, mul_boole,
       Finset.sum_ite_eq', if_true]
 #align orthonormal.inner_left_sum Orthonormal.inner_left_sum
 
@@ -857,7 +857,7 @@ sum of the weights.
 -/
 theorem Orthonormal.inner_left_right_finset {s : Finset ι} {v : ι → E} (hv : Orthonormal 𝕜 v)
     {a : ι → ι → 𝕜} : (∑ i in s, ∑ j in s, a i j • ⟪v j, v i⟫) = ∑ k in s, a k k := by
-  classical simp [orthonormal_iff_ite.mp hv, Finset.sum_ite_of_true]
+  classical!; simp [orthonormal_iff_ite.mp hv, Finset.sum_ite_of_true]
 #align orthonormal.inner_left_right_finset Orthonormal.inner_left_right_finset
 
 /-- An orthonormal set is linearly independent. -/
@@ -874,11 +874,11 @@ theorem Orthonormal.linearIndependent {v : ι → E} (hv : Orthonormal 𝕜 v) :
 orthonormal family. -/
 theorem Orthonormal.comp {ι' : Type _} {v : ι → E} (hv : Orthonormal 𝕜 v) (f : ι' → ι)
     (hf : Function.Injective f) : Orthonormal 𝕜 (v ∘ f) := by
-  classical
-    rw [orthonormal_iff_ite] at hv⊢
-    intro i j
-    convert hv (f i) (f j) using 1
-    simp [hf.eq_iff]
+  classical!
+  rw [orthonormal_iff_ite] at hv ⊢
+  intro i j
+  convert hv (f i) (f j) using 1
+  simp [hf.eq_iff]
 #align orthonormal.comp Orthonormal.comp
 
 /-- An injective family `v : ι → E` is orthonormal if and only if `Subtype.val : (range v) → E` is
@@ -911,12 +911,13 @@ theorem Orthonormal.inner_finsupp_eq_zero {v : ι → E} (hv : Orthonormal 𝕜 
 the corresponding vector in the original family or its negation. -/
 theorem Orthonormal.orthonormal_of_forall_eq_or_eq_neg {v w : ι → E} (hv : Orthonormal 𝕜 v)
     (hw : ∀ i, w i = v i ∨ w i = -v i) : Orthonormal 𝕜 w := by
-  classical
-    rw [orthonormal_iff_ite] at *
-    intro i j
-    cases' hw i with hi hi <;> cases' hw j with hj hj <;> split_ifs with h <;>
-      simpa only [hi, hj, h, inner_neg_right, inner_neg_left, neg_neg, eq_self_iff_true,
-        neg_eq_zero] using hv i j
+  classical!
+  rw [orthonormal_iff_ite] at *
+  intro i j
+  cases' hw i with hi hi <;> cases' hw j with hj hj <;>
+    replace hv := hv i j <;> split_ifs at hv ⊢ with h <;>
+    simpa only [hi, hj, h, inner_neg_right, inner_neg_left, neg_neg, eq_self_iff_true,
+      neg_eq_zero] using hv
 #align orthonormal.orthonormal_of_forall_eq_or_eq_neg Orthonormal.orthonormal_of_forall_eq_or_eq_neg
 
 /- The material that follows, culminating in the existence of a maximal orthonormal subset, is
@@ -925,7 +926,7 @@ adapted from the corresponding development of the theory of linearly independent
 variable (𝕜 E)
 
 theorem orthonormal_empty : Orthonormal 𝕜 (fun x => x : (∅ : Set E) → E) := by
-  classical simp [orthonormal_subtype_iff_ite]
+  classical!; simp [orthonormal_subtype_iff_ite]
 #align orthonormal_empty orthonormal_empty
 
 variable {𝕜 E}
@@ -933,13 +934,13 @@ variable {𝕜 E}
 theorem orthonormal_iUnion_of_directed {η : Type _} {s : η → Set E} (hs : Directed (· ⊆ ·) s)
     (h : ∀ i, Orthonormal 𝕜 (fun x => x : s i → E)) :
     Orthonormal 𝕜 (fun x => x : (⋃ i, s i) → E) := by
-  classical
-    rw [orthonormal_subtype_iff_ite]
-    rintro x ⟨_, ⟨i, rfl⟩, hxi⟩ y ⟨_, ⟨j, rfl⟩, hyj⟩
-    obtain ⟨k, hik, hjk⟩ := hs i j
-    have h_orth : Orthonormal 𝕜 (fun x => x : s k → E) := h k
-    rw [orthonormal_subtype_iff_ite] at h_orth
-    exact h_orth x (hik hxi) y (hjk hyj)
+  classical!
+  rw [orthonormal_subtype_iff_ite]
+  rintro x ⟨_, ⟨i, rfl⟩, hxi⟩ y ⟨_, ⟨j, rfl⟩, hyj⟩
+  obtain ⟨k, hik, hjk⟩ := hs i j
+  have h_orth : Orthonormal 𝕜 (fun x => x : s k → E) := h k
+  rw [orthonormal_subtype_iff_ite] at h_orth
+  exact h_orth x (hik hxi) y (hjk hyj)
 #align orthonormal_Union_of_directed orthonormal_iUnion_of_directed
 
 theorem orthonormal_sUnion_of_directed {s : Set (Set E)} (hs : DirectedOn (· ⊆ ·) s)
@@ -2018,28 +2019,28 @@ theorem OrthogonalFamily.inner_right_dfinsupp (l : ⨁ i, G i) (i : ι) (v : G i
 
 theorem OrthogonalFamily.inner_right_fintype [Fintype ι] (l : ∀ i, G i) (i : ι) (v : G i) :
     ⟪V i v, ∑ j : ι, V j (l j)⟫ = ⟪v, l i⟫ := by
-  classical calc
-      ⟪V i v, ∑ j : ι, V j (l j)⟫ = ∑ j : ι, ⟪V i v, V j (l j)⟫ := by rw [inner_sum]
-      _ = ∑ j, ite (i = j) ⟪V i v, V j (l j)⟫ 0 :=
-        (congr_arg (Finset.sum Finset.univ) <| funext fun j => hV.eq_ite v (l j))
-      _ = ⟪v, l i⟫ := by
-        simp only [Finset.sum_ite_eq, Finset.mem_univ, (V i).inner_map_map, if_true]
-
+  classical!
+  calc
+    ⟪V i v, ∑ j : ι, V j (l j)⟫ = ∑ j : ι, ⟪V i v, V j (l j)⟫ := by rw [inner_sum]
+    _ = ∑ j, ite (i = j) ⟪V i v, V j (l j)⟫ 0 :=
+      (congr_arg (Finset.sum Finset.univ) <| funext fun j => hV.eq_ite v (l j))
+    _ = ⟪v, l i⟫ := by
+      simp only [Finset.sum_ite_eq, Finset.mem_univ, (V i).inner_map_map, if_true]
 #align orthogonal_family.inner_right_fintype OrthogonalFamily.inner_right_fintype
 
 theorem OrthogonalFamily.inner_sum (l₁ l₂ : ∀ i, G i) (s : Finset ι) :
     ⟪∑ i in s, V i (l₁ i), ∑ j in s, V j (l₂ j)⟫ = ∑ i in s, ⟪l₁ i, l₂ i⟫ := by
-  classical calc
-      ⟪∑ i in s, V i (l₁ i), ∑ j in s, V j (l₂ j)⟫ = ∑ j in s, ∑ i in s, ⟪V i (l₁ i), V j (l₂ j)⟫ :=
-        by simp only [_root_.sum_inner, _root_.inner_sum]
-      _ = ∑ j in s, ∑ i in s, ite (i = j) ⟪V i (l₁ i), V j (l₂ j)⟫ 0 := by
-        congr with i
-        congr with j
-        apply hV.eq_ite
-      _ = ∑ i in s, ⟪l₁ i, l₂ i⟫ := by
-        simp only [Finset.sum_ite_of_true, Finset.sum_ite_eq', LinearIsometry.inner_map_map,
-          imp_self, imp_true_iff]
-
+  classical!
+  calc
+    ⟪∑ i in s, V i (l₁ i), ∑ j in s, V j (l₂ j)⟫ = ∑ j in s, ∑ i in s, ⟪V i (l₁ i), V j (l₂ j)⟫ :=
+      by simp only [_root_.sum_inner, _root_.inner_sum]
+    _ = ∑ j in s, ∑ i in s, ite (i = j) ⟪V i (l₁ i), V j (l₂ j)⟫ 0 := by
+      congr with i
+      congr with j
+      apply hV.eq_ite
+    _ = ∑ i in s, ⟪l₁ i, l₂ i⟫ := by
+      simp only [Finset.sum_ite_of_true, Finset.sum_ite_eq', LinearIsometry.inner_map_map,
+        imp_self, imp_true_iff]
 #align orthogonal_family.inner_sum OrthogonalFamily.inner_sum
 
 theorem OrthogonalFamily.norm_sum (l : ∀ i, G i) (s : Finset ι) :
@@ -2148,20 +2149,19 @@ pairwise intersections of elements of the family are 0. -/
 theorem OrthogonalFamily.independent {V : ι → Submodule 𝕜 E}
     (hV : OrthogonalFamily 𝕜 (fun i => V i) fun i => (V i).subtypeₗᵢ) :
     CompleteLattice.Independent V := by
-  classical
-    apply CompleteLattice.independent_of_dfinsupp_lsum_injective
-    refine LinearMap.ker_eq_bot.mp ?_
-    rw [Submodule.eq_bot_iff]
-    intro v hv
-    rw [LinearMap.mem_ker] at hv
-    ext i
-    suffices ⟪(v i : E), v i⟫ = 0 by simpa only [inner_self_eq_zero] using this
-    calc
-      ⟪(v i : E), v i⟫ = ⟪(v i : E), Dfinsupp.lsum ℕ (fun i => (V i).subtype) v⟫ := by
-        simpa only [Dfinsupp.sumAddHom_apply, Dfinsupp.lsum_apply_apply] using
-          (hV.inner_right_dfinsupp v i (v i)).symm
-      _ = 0 := by simp only [hv, inner_zero_right]
-
+  classical!
+  apply CompleteLattice.independent_of_dfinsupp_lsum_injective
+  refine LinearMap.ker_eq_bot.mp ?_
+  rw [Submodule.eq_bot_iff]
+  intro v hv
+  rw [LinearMap.mem_ker] at hv
+  ext i
+  suffices ⟪(v i : E), v i⟫ = 0 by simpa only [inner_self_eq_zero] using this
+  calc
+    ⟪(v i : E), v i⟫ = ⟪(v i : E), Dfinsupp.lsum ℕ (fun i => (V i).subtype) v⟫ := by
+      simpa only [Dfinsupp.sumAddHom_apply, Dfinsupp.lsum_apply_apply] using
+        (hV.inner_right_dfinsupp v i (v i)).symm
+    _ = 0 := by simp only [hv, inner_zero_right]
 #align orthogonal_family.independent OrthogonalFamily.independent
 
 theorem DirectSum.IsInternal.collectedBasis_orthonormal {V : ι → Submodule 𝕜 E}

--- a/Mathlib/Analysis/InnerProductSpace/Basic.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Basic.lean
@@ -790,7 +790,8 @@ theorem orthonormal_subtype_iff_ite {s : Set E} :
 vectors picks out the coefficient of that vector. -/
 theorem Orthonormal.inner_right_finsupp {v : ι → E} (hv : Orthonormal 𝕜 v) (l : ι →₀ 𝕜) (i : ι) :
     ⟪v i, Finsupp.total ι E 𝕜 v l⟫ = l i := by
-  classical!; simpa [Finsupp.total_apply, Finsupp.inner_sum, orthonormal_iff_ite.mp hv] using Eq.symm
+  classical!
+  simpa [Finsupp.total_apply, Finsupp.inner_sum, orthonormal_iff_ite.mp hv] using Eq.symm
 #align orthonormal.inner_right_finsupp Orthonormal.inner_right_finsupp
 
 /-- The inner product of a linear combination of a set of orthonormal vectors with one of those

--- a/Mathlib/Analysis/InnerProductSpace/PiL2.lean
+++ b/Mathlib/Analysis/InnerProductSpace/PiL2.lean
@@ -654,7 +654,10 @@ theorem Complex.isometryOfOrthonormal_symm_apply (v : OrthonormalBasis (Fin 2) �
 
 theorem Complex.isometryOfOrthonormal_apply (v : OrthonormalBasis (Fin 2) ℝ F) (z : ℂ) :
     Complex.isometryOfOrthonormal v z = z.re • v 0 + z.im • v 1 := by
-  simp [Complex.isometryOfOrthonormal, ← v.sum_repr_symm]
+  -- Porting note: was
+  -- simp [Complex.isometryOfOrthonormal, ← v.sum_repr_symm]
+  rw [Complex.isometryOfOrthonormal, LinearIsometryEquiv.trans_apply]
+  simp [← v.sum_repr_symm]
 #align complex.isometry_of_orthonormal_apply Complex.isometryOfOrthonormal_apply
 
 open FiniteDimensional

--- a/Mathlib/Analysis/InnerProductSpace/PiL2.lean
+++ b/Mathlib/Analysis/InnerProductSpace/PiL2.lean
@@ -219,7 +219,7 @@ variable (ι 𝕜)
 and `ι → 𝕜`. -/
 @[simps!]
 def EuclideanSpace.equiv : EuclideanSpace 𝕜 ι ≃L[𝕜] ι → 𝕜 :=
-  (PiLp.linearEquiv 2 𝕜 fun i : ι => 𝕜).toContinuousLinearEquiv
+  (PiLp.linearEquiv 2 𝕜 fun _ : ι => 𝕜).toContinuousLinearEquiv
 #align euclidean_space.equiv EuclideanSpace.equiv
 
 variable {ι 𝕜}
@@ -228,7 +228,7 @@ variable {ι 𝕜}
 /-- The projection on the `i`-th coordinate of `euclidean_space 𝕜 ι`, as a linear map. -/
 @[simps!]
 def EuclideanSpace.projₗ (i : ι) : EuclideanSpace 𝕜 ι →ₗ[𝕜] 𝕜 :=
-  (LinearMap.proj i).comp (PiLp.linearEquiv 2 𝕜 fun i : ι => 𝕜 : EuclideanSpace 𝕜 ι →ₗ[𝕜] ι → 𝕜)
+  (LinearMap.proj i).comp (PiLp.linearEquiv 2 𝕜 fun _ : ι => 𝕜 : EuclideanSpace 𝕜 ι →ₗ[𝕜] ι → 𝕜)
 #align euclidean_space.projₗ EuclideanSpace.projₗ
 
 -- TODO : This should be generalized to `pi_Lp`.
@@ -608,8 +608,9 @@ theorem Complex.toBasis_orthonormalBasisOneI :
 #align complex.to_basis_orthonormal_basis_one_I Complex.toBasis_orthonormalBasisOneI
 
 @[simp]
-theorem Complex.coe_orthonormalBasisOneI : (Complex.orthonormalBasisOneI : Fin 2 → ℂ) = ![1, I] :=
-  by simp [Complex.orthonormalBasisOneI]
+theorem Complex.coe_orthonormalBasisOneI :
+    (Complex.orthonormalBasisOneI : Fin 2 → ℂ) = ![1, I] := by
+  simp [Complex.orthonormalBasisOneI]
 #align complex.coe_orthonormal_basis_one_I Complex.coe_orthonormalBasisOneI
 
 /-- The isometry between `ℂ` and a two-dimensional real inner product space given by a basis. -/

--- a/Mathlib/Analysis/InnerProductSpace/PiL2.lean
+++ b/Mathlib/Analysis/InnerProductSpace/PiL2.lean
@@ -8,10 +8,10 @@ Authors: Joseph Myers, Sébastien Gouëzel, Heather Macbeth
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
-import Mathbin.Analysis.InnerProductSpace.Projection
-import Mathbin.Analysis.NormedSpace.PiLp
-import Mathbin.LinearAlgebra.FiniteDimensional
-import Mathbin.LinearAlgebra.UnitaryGroup
+import Mathlib.Analysis.InnerProductSpace.Projection
+import Mathlib.Analysis.NormedSpace.PiLp
+import Mathlib.LinearAlgebra.FiniteDimensional
+import Mathlib.LinearAlgebra.UnitaryGroup
 
 /-!
 # `L²` inner product space structure on finite products of inner product spaces
@@ -85,8 +85,7 @@ we use instead `pi_Lp 2 f` for the product space, which is endowed with the `L^2
 -/
 instance PiLp.innerProductSpace {ι : Type _} [Fintype ι] (f : ι → Type _)
     [∀ i, NormedAddCommGroup (f i)] [∀ i, InnerProductSpace 𝕜 (f i)] :
-    InnerProductSpace 𝕜 (PiLp 2 f)
-    where
+    InnerProductSpace 𝕜 (PiLp 2 f) where
   inner x y := ∑ i, inner (x i) (y i)
   norm_sq_eq_inner x := by
     simp only [PiLp.norm_sq_eq_of_L2, AddMonoidHom.map_sum, ← norm_sq_eq_inner, one_div]
@@ -177,13 +176,11 @@ from `E` to `pi_Lp 2` of the subspaces equipped with the `L2` inner product. -/
 def DirectSum.IsInternal.isometryL2OfOrthogonalFamily [DecidableEq ι] {V : ι → Submodule 𝕜 E}
     (hV : DirectSum.IsInternal V)
     (hV' : OrthogonalFamily 𝕜 (fun i => V i) fun i => (V i).subtypeₗᵢ) :
-    E ≃ₗᵢ[𝕜] PiLp 2 fun i => V i :=
-  by
+    E ≃ₗᵢ[𝕜] PiLp 2 fun i => V i := by
   let e₁ := DirectSum.linearEquivFunOnFintype 𝕜 ι fun i => V i
   let e₂ := LinearEquiv.ofBijective (DirectSum.coeLinearMap V) hV
   refine' LinearEquiv.isometryOfInner (e₂.symm.trans e₁) _
-  suffices ∀ v w, ⟪v, w⟫ = ⟪e₂ (e₁.symm v), e₂ (e₁.symm w)⟫
-    by
+  suffices ∀ v w, ⟪v, w⟫ = ⟪e₂ (e₁.symm v), e₂ (e₁.symm w)⟫ by
     intro v₀ w₀
     convert this (e₁ (e₂.symm v₀)) (e₁ (e₂.symm w₀)) <;>
       simp only [LinearEquiv.symm_apply_apply, LinearEquiv.apply_symm_apply]
@@ -300,8 +297,7 @@ theorem EuclideanSpace.edist_single_same [DecidableEq ι] (i : ι) (a b : 𝕜) 
 
 /-- `euclidean_space.single` forms an orthonormal family. -/
 theorem EuclideanSpace.orthonormal_single [DecidableEq ι] :
-    Orthonormal 𝕜 fun i : ι => EuclideanSpace.single i (1 : 𝕜) :=
-  by
+    Orthonormal 𝕜 fun i : ι => EuclideanSpace.single i (1 : 𝕜) := by
   simp_rw [orthonormal_iff_ite, EuclideanSpace.inner_single_left, map_one, one_mul,
     EuclideanSpace.single_apply]
   intro i j
@@ -336,8 +332,7 @@ instance : CoeFun (OrthonormalBasis ι 𝕜 E) fun _ => ι → E
 
 @[simp]
 theorem coe_of_repr [DecidableEq ι] (e : E ≃ₗᵢ[𝕜] EuclideanSpace 𝕜 ι) :
-    ⇑(OrthonormalBasis.of_repr e) = fun i => e.symm (EuclideanSpace.single i (1 : 𝕜)) :=
-  by
+    ⇑(OrthonormalBasis.of_repr e) = fun i => e.symm (EuclideanSpace.single i (1 : 𝕜)) := by
   rw [coeFn]
   unfold CoeFun.coe
   funext
@@ -381,8 +376,7 @@ protected def toBasis (b : OrthonormalBasis ι 𝕜 E) : Basis ι 𝕜 E :=
 #align orthonormal_basis.to_basis OrthonormalBasis.toBasis
 
 @[simp]
-protected theorem coe_toBasis (b : OrthonormalBasis ι 𝕜 E) : (⇑b.toBasis : ι → E) = ⇑b :=
-  by
+protected theorem coe_toBasis (b : OrthonormalBasis ι 𝕜 E) : (⇑b.toBasis : ι → E) = ⇑b := by
   change ⇑(Basis.ofEquivFun b.repr.to_linear_equiv) = b
   ext j
   classical
@@ -412,8 +406,7 @@ protected theorem sum_repr_symm (b : OrthonormalBasis ι 𝕜 E) (v : EuclideanS
 #align orthonormal_basis.sum_repr_symm OrthonormalBasis.sum_repr_symm
 
 protected theorem sum_inner_mul_inner (b : OrthonormalBasis ι 𝕜 E) (x y : E) :
-    (∑ i, ⟪x, b i⟫ * ⟪b i, y⟫) = ⟪x, y⟫ :=
-  by
+    (∑ i, ⟪x, b i⟫ * ⟪b i, y⟫) = ⟪x, y⟫ := by
   have := congr_arg (innerSL 𝕜 x) (b.sum_repr y)
   rw [map_sum] at this
   convert this
@@ -652,8 +645,7 @@ variable (a b : OrthonormalBasis ι 𝕜 E)
 
 /-- The change-of-basis matrix between two orthonormal bases `a`, `b` is a unitary matrix. -/
 theorem OrthonormalBasis.toMatrix_orthonormalBasis_mem_unitary :
-    a.toBasis.toMatrix b ∈ Matrix.unitaryGroup ι 𝕜 :=
-  by
+    a.toBasis.toMatrix b ∈ Matrix.unitaryGroup ι 𝕜 := by
   rw [Matrix.mem_unitaryGroup_iff']
   ext (i j)
   convert a.repr.inner_map_map (b i) (b j)
@@ -664,8 +656,7 @@ theorem OrthonormalBasis.toMatrix_orthonormalBasis_mem_unitary :
 /-- The determinant of the change-of-basis matrix between two orthonormal bases `a`, `b` has
 unit length. -/
 @[simp]
-theorem OrthonormalBasis.det_to_matrix_orthonormalBasis : ‖a.toBasis.det b‖ = 1 :=
-  by
+theorem OrthonormalBasis.det_to_matrix_orthonormalBasis : ‖a.toBasis.det b‖ = 1 := by
   have : (norm_sq (a.to_basis.det b) : 𝕜) = 1 := by
     simpa [IsROrC.mul_conj] using
       (Matrix.det_of_mem_unitary (a.to_matrix_orthonormal_basis_mem_unitary b)).2
@@ -687,8 +678,7 @@ theorem OrthonormalBasis.toMatrix_orthonormalBasis_mem_orthogonal :
 
 /-- The determinant of the change-of-basis matrix between two orthonormal bases `a`, `b` is ±1. -/
 theorem OrthonormalBasis.det_to_matrix_orthonormalBasis_real :
-    a.toBasis.det b = 1 ∨ a.toBasis.det b = -1 :=
-  by
+    a.toBasis.det b = 1 ∨ a.toBasis.det b = -1 := by
   rw [← sq_eq_one_iff]
   simpa [unitary, sq] using Matrix.det_of_mem_unitary (a.to_matrix_orthonormal_basis_mem_unitary b)
 #align orthonormal_basis.det_to_matrix_orthonormal_basis_real OrthonormalBasis.det_to_matrix_orthonormalBasis_real
@@ -731,8 +721,7 @@ variable [FiniteDimensional 𝕜 E]
 /-- In a finite-dimensional `inner_product_space`, any orthonormal subset can be extended to an
 orthonormal basis. -/
 theorem Orthonormal.exists_orthonormalBasis_extension (hv : Orthonormal 𝕜 (coe : v → E)) :
-    ∃ (u : Finset E)(b : OrthonormalBasis u 𝕜 E), v ⊆ u ∧ ⇑b = coe :=
-  by
+    ∃ (u : Finset E)(b : OrthonormalBasis u 𝕜 E), v ⊆ u ∧ ⇑b = coe := by
   obtain ⟨u₀, hu₀s, hu₀, hu₀_max⟩ := exists_maximal_orthonormal hv
   rw [maximal_orthonormal_iff_orthogonalComplement_eq_bot hu₀] at hu₀_max
   have hu₀_finite : u₀.finite := hu₀.linear_independent.finite
@@ -748,14 +737,12 @@ theorem Orthonormal.exists_orthonormalBasis_extension (hv : Orthonormal 𝕜 (co
 
 theorem Orthonormal.exists_orthonormalBasis_extension_of_card_eq {ι : Type _} [Fintype ι]
     (card_ι : finrank 𝕜 E = Fintype.card ι) {v : ι → E} {s : Set ι}
-    (hv : Orthonormal 𝕜 (s.restrict v)) : ∃ b : OrthonormalBasis ι 𝕜 E, ∀ i ∈ s, b i = v i :=
-  by
+    (hv : Orthonormal 𝕜 (s.restrict v)) : ∃ b : OrthonormalBasis ι 𝕜 E, ∀ i ∈ s, b i = v i := by
   have hsv : injective (s.restrict v) := hv.linear_independent.injective
   have hX : Orthonormal 𝕜 (coe : Set.range (s.restrict v) → E) := by
     rwa [orthonormal_subtype_range hsv]
   obtain ⟨Y, b₀, hX, hb₀⟩ := hX.exists_orthonormal_basis_extension
-  have hιY : Fintype.card ι = Y.card :=
-    by
+  have hιY : Fintype.card ι = Y.card := by
     refine' card_ι.symm.trans _
     exact FiniteDimensional.finrank_eq_card_finset_basis b₀.to_basis
   have hvsY : s.maps_to v Y := (s.maps_to_image v).mono_right (by rwa [← range_restrict])
@@ -778,8 +765,7 @@ theorem exists_orthonormalBasis :
 #align exists_orthonormal_basis exists_orthonormalBasis
 
 /-- A finite-dimensional `inner_product_space` has an orthonormal basis. -/
-irreducible_def stdOrthonormalBasis : OrthonormalBasis (Fin (finrank 𝕜 E)) 𝕜 E :=
-  by
+irreducible_def stdOrthonormalBasis : OrthonormalBasis (Fin (finrank 𝕜 E)) 𝕜 E := by
   let b := Classical.choose (Classical.choose_spec <| exists_orthonormalBasis 𝕜 E)
   rw [finrank_eq_card_basis b.to_basis]
   exact b.reindex (Fintype.equivFinOfCardEq rfl)
@@ -787,11 +773,9 @@ irreducible_def stdOrthonormalBasis : OrthonormalBasis (Fin (finrank 𝕜 E)) �
 
 /-- An orthonormal basis of `ℝ` is made either of the vector `1`, or of the vector `-1`. -/
 theorem orthonormalBasis_one_dim (b : OrthonormalBasis ι ℝ ℝ) :
-    (⇑b = fun _ => (1 : ℝ)) ∨ ⇑b = fun _ => (-1 : ℝ) :=
-  by
+    (⇑b = fun _ => (1 : ℝ)) ∨ ⇑b = fun _ => (-1 : ℝ) := by
   have : Unique ι := b.to_basis.unique
-  have : b default = 1 ∨ b default = -1 :=
-    by
+  have : b default = 1 ∨ b default = -1 := by
     have : ‖b default‖ = 1 := b.orthonormal.1 _
     rwa [Real.norm_eq_abs, abs_eq (zero_le_one : (0 : ℝ) ≤ 1)] at this
   rw [eq_const_of_unique b]
@@ -869,8 +853,7 @@ open FiniteDimensional
 isometry mapping `S` into `V` can be extended to a full isometry of `V`.
 
 TODO:  The case when `S` is a finite-dimensional subspace of an infinite-dimensional `V`.-/
-noncomputable def LinearIsometry.extend (L : S →ₗᵢ[𝕜] V) : V →ₗᵢ[𝕜] V :=
-  by
+noncomputable def LinearIsometry.extend (L : S →ₗᵢ[𝕜] V) : V →ₗᵢ[𝕜] V := by
   -- Build an isometry from Sᗮ to L(S)ᗮ through euclidean_space
   let d := finrank 𝕜 Sᗮ
   have dim_S_perp : finrank 𝕜 Sᗮ = d := rfl
@@ -902,12 +885,10 @@ noncomputable def LinearIsometry.extend (L : S →ₗᵢ[𝕜] V) : V →ₗᵢ[
       simp only [LinearMap.add_apply, LinearMap.comp_apply, LinearMap.comp_apply,
         LinearIsometry.coe_toLinearMap]
     -- Mx_decomp is the orthogonal decomposition of M x
-    have Mx_orth : ⟪L (p1 x), L3 (p2 x)⟫ = 0 :=
-      by
+    have Mx_orth : ⟪L (p1 x), L3 (p2 x)⟫ = 0 := by
       have Lp1x : L (p1 x) ∈ L.to_linear_map.range :=
         LinearMap.mem_range_self L.to_linear_map (p1 x)
-      have Lp2x : L3 (p2 x) ∈ L.to_linear_map.rangeᗮ :=
-        by
+      have Lp2x : L3 (p2 x) ∈ L.to_linear_map.rangeᗮ := by
         simp only [L3, LinearIsometry.coe_comp, Function.comp_apply, Submodule.coe_subtypeₗᵢ, ←
           Submodule.range_subtype LSᗮ]
         apply LinearMap.mem_range_self
@@ -924,8 +905,7 @@ noncomputable def LinearIsometry.extend (L : S →ₗᵢ[𝕜] V) : V →ₗᵢ[
       norm_map' := M_norm_map }
 #align linear_isometry.extend LinearIsometry.extend
 
-theorem LinearIsometry.extend_apply (L : S →ₗᵢ[𝕜] V) (s : S) : L.extend s = L s :=
-  by
+theorem LinearIsometry.extend_apply (L : S →ₗᵢ[𝕜] V) (s : S) : L.extend s = L s := by
   haveI : CompleteSpace S := FiniteDimensional.complete 𝕜 S
   simp only [LinearIsometry.extend, [anonymous], ← LinearIsometry.coe_toLinearMap]
   simp only [add_right_eq_self, LinearIsometry.coe_toLinearMap,

--- a/Mathlib/Analysis/InnerProductSpace/PiL2.lean
+++ b/Mathlib/Analysis/InnerProductSpace/PiL2.lean
@@ -857,7 +857,7 @@ theorem DirectSum.IsInternal.subordinateOrthonormalBasis_subordinate (a : Fin n)
   simpa only [DirectSum.IsInternal.subordinateOrthonormalBasis, OrthonormalBasis.coe_reindex,
     DirectSum.IsInternal.subordinateOrthonormalBasisIndex] using
     hV.collectedOrthonormalBasis_mem hV' (fun i => stdOrthonormalBasis 𝕜 (V i))
-      ((hV.sigma_orthonormalBasis_index_equiv hn hV').symm a)
+      ((hV.sigmaOrthonormalBasisIndexEquiv hn hV').symm a)
 #align direct_sum.is_internal.subordinate_orthonormal_basis_subordinate DirectSum.IsInternal.subordinateOrthonormalBasis_subordinate
 
 end SubordinateOrthonormalBasis

--- a/Mathlib/Analysis/InnerProductSpace/PiL2.lean
+++ b/Mathlib/Analysis/InnerProductSpace/PiL2.lean
@@ -130,17 +130,17 @@ theorem EuclideanSpace.norm_eq {𝕜 : Type _} [IsROrC 𝕜] {n : Type _} [Finty
 
 theorem EuclideanSpace.dist_eq {𝕜 : Type _} [IsROrC 𝕜] {n : Type _} [Fintype n]
     (x y : EuclideanSpace 𝕜 n) : dist x y = (∑ i, dist (x i) (y i) ^ 2).sqrt :=
-  (PiLp.dist_eq_of_L2 x y : _)
+  PiLp.dist_eq_of_L2 x y
 #align euclidean_space.dist_eq EuclideanSpace.dist_eq
 
 theorem EuclideanSpace.nndist_eq {𝕜 : Type _} [IsROrC 𝕜] {n : Type _} [Fintype n]
     (x y : EuclideanSpace 𝕜 n) : nndist x y = NNReal.sqrt (∑ i, nndist (x i) (y i) ^ 2) :=
-  (PiLp.nndist_eq_of_L2 x y : _)
+  PiLp.nndist_eq_of_L2 x y
 #align euclidean_space.nndist_eq EuclideanSpace.nndist_eq
 
 theorem EuclideanSpace.edist_eq {𝕜 : Type _} [IsROrC 𝕜] {n : Type _} [Fintype n]
     (x y : EuclideanSpace 𝕜 n) : edist x y = (∑ i, edist (x i) (y i) ^ 2) ^ (1 / 2 : ℝ) :=
-  (PiLp.edist_eq_of_L2 x y : _)
+  PiLp.edist_eq_of_L2 x y
 #align euclidean_space.edist_eq EuclideanSpace.edist_eq
 
 variable [Fintype ι]
@@ -150,15 +150,18 @@ section
 -- Porting note: no longer supported
 -- attribute [local reducible] PiLp
 
-instance : FiniteDimensional 𝕜 (EuclideanSpace 𝕜 ι) := by infer_instance
+instance EuclideanSpace.instFiniteDimensional : FiniteDimensional 𝕜 (EuclideanSpace 𝕜 ι) := by
+  infer_instance
+#align euclidean_space.finite_dimensional EuclideanSpace.instFiniteDimensional
 
-instance : InnerProductSpace 𝕜 (EuclideanSpace 𝕜 ι) := by infer_instance
+instance EuclideanSpace.instInnerProductSpace : InnerProductSpace 𝕜 (EuclideanSpace 𝕜 ι) := by
+  infer_instance
+#align euclidean_space.inner_product_space EuclideanSpace.instInnerProductSpace
 
 @[simp]
 theorem finrank_euclideanSpace :
     FiniteDimensional.finrank 𝕜 (EuclideanSpace 𝕜 ι) = Fintype.card ι := by
-  unfold EuclideanSpace PiLp
-  simp
+  simp [EuclideanSpace, PiLp]
 #align finrank_euclidean_space finrank_euclideanSpace
 
 theorem finrank_euclideanSpace_fin {n : ℕ} :
@@ -184,7 +187,7 @@ def DirectSum.IsInternal.isometryL2OfOrthogonalFamily [DecidableEq ι] {V : ι �
   let e₁ := DirectSum.linearEquivFunOnFintype 𝕜 ι fun i => V i
   let e₂ := LinearEquiv.ofBijective (DirectSum.coeLinearMap V) hV
   refine' LinearEquiv.isometryOfInner (e₂.symm.trans e₁) _
-  suffices ∀ (v w : PiLp 2 (fun i : ι => V i)), ⟪v, w⟫ = ⟪e₂ (e₁.symm v), e₂ (e₁.symm w)⟫ by
+  suffices ∀ (v w : PiLp 2 fun i => V i), ⟪v, w⟫ = ⟪e₂ (e₁.symm v), e₂ (e₁.symm w)⟫ by
     intro v₀ w₀
     convert this (e₁ (e₂.symm v₀)) (e₁ (e₂.symm w₀)) <;>
       simp only [LinearEquiv.symm_apply_apply, LinearEquiv.apply_symm_apply]
@@ -204,10 +207,8 @@ theorem DirectSum.IsInternal.isometryL2OfOrthogonalFamily_symm_apply [DecidableE
     let e₂ := LinearEquiv.ofBijective (DirectSum.coeLinearMap V) hV
     suffices ∀ v : ⨁ i, V i, e₂ v = ∑ i, e₁ v i by exact this (e₁.symm w)
     intro v
-    -- Porting note: added the next two lines
-    simp only [coeLinearMap, toModule, LinearEquiv.ofBijective_apply, linearEquivFunOnFintype_apply]
-    erw [Dfinsupp.lsum_apply_apply ℕ (fun i ↦ Submodule.subtype (V i)) v]
-    simp [DirectSum.coeLinearMap, DirectSum.toModule, Dfinsupp.sumAddHom_apply]
+    -- Porting note: added `Dfinsupp.lsum`
+    simp [DirectSum.coeLinearMap, DirectSum.toModule, Dfinsupp.lsum, Dfinsupp.sumAddHom_apply]
 #align direct_sum.is_internal.isometry_L2_of_orthogonal_family_symm_apply DirectSum.IsInternal.isometryL2OfOrthogonalFamily_symm_apply
 
 end
@@ -217,10 +218,14 @@ variable (ι 𝕜)
 -- TODO : This should be generalized to `pi_Lp` with finite dimensional factors.
 /-- `pi_Lp.linear_equiv` upgraded to a continuous linear map between `euclidean_space 𝕜 ι`
 and `ι → 𝕜`. -/
-@[simps!]
+@[simps! toLinearEquiv_apply apply toLinearEquiv_symm_apply symm_apply]
 def EuclideanSpace.equiv : EuclideanSpace 𝕜 ι ≃L[𝕜] ι → 𝕜 :=
   (PiLp.linearEquiv 2 𝕜 fun _ : ι => 𝕜).toContinuousLinearEquiv
 #align euclidean_space.equiv EuclideanSpace.equiv
+#align euclidean_space.equiv_to_linear_equiv_apply EuclideanSpace.equiv_toLinearEquiv_apply
+#align euclidean_space.equiv_apply EuclideanSpace.equiv_apply
+#align euclidean_space.equiv_to_linear_equiv_symm_apply EuclideanSpace.equiv_toLinearEquiv_symm_apply
+#align euclidean_space.equiv_symm_apply EuclideanSpace.equiv_symm_apply
 
 variable {ι 𝕜}
 
@@ -230,14 +235,17 @@ variable {ι 𝕜}
 def EuclideanSpace.projₗ (i : ι) : EuclideanSpace 𝕜 ι →ₗ[𝕜] 𝕜 :=
   (LinearMap.proj i).comp (PiLp.linearEquiv 2 𝕜 fun _ : ι => 𝕜 : EuclideanSpace 𝕜 ι →ₗ[𝕜] ι → 𝕜)
 #align euclidean_space.projₗ EuclideanSpace.projₗ
+#align euclidean_space.projₗ_apply EuclideanSpace.projₗ_apply
 
 -- TODO : This should be generalized to `pi_Lp`.
 /-- The projection on the `i`-th coordinate of `euclidean_space 𝕜 ι`,
 as a continuous linear map. -/
-@[simps!]
+@[simps! apply coe]
 def EuclideanSpace.proj (i : ι) : EuclideanSpace 𝕜 ι →L[𝕜] 𝕜 :=
   ⟨EuclideanSpace.projₗ i, continuous_apply i⟩
 #align euclidean_space.proj EuclideanSpace.proj
+#align euclidean_space.proj_coe EuclideanSpace.proj_coe
+#align euclidean_space.proj_apply EuclideanSpace.proj_apply
 
 -- TODO : This should be generalized to `pi_Lp`.
 /-- The vector given in euclidean space by being `1 : 𝕜` at coordinate `i : ι` and `0 : 𝕜` at
@@ -275,31 +283,31 @@ theorem EuclideanSpace.inner_single_right [DecidableEq ι] (i : ι) (a : 𝕜) (
 @[simp]
 theorem EuclideanSpace.norm_single [DecidableEq ι] (i : ι) (a : 𝕜) :
     ‖EuclideanSpace.single i (a : 𝕜)‖ = ‖a‖ :=
-  (PiLp.norm_equiv_symm_single 2 (fun _ => 𝕜) i a : _)
+  PiLp.norm_equiv_symm_single 2 (fun _ => 𝕜) i a
 #align euclidean_space.norm_single EuclideanSpace.norm_single
 
 @[simp]
 theorem EuclideanSpace.nnnorm_single [DecidableEq ι] (i : ι) (a : 𝕜) :
     ‖EuclideanSpace.single i (a : 𝕜)‖₊ = ‖a‖₊ :=
-  (PiLp.nnnorm_equiv_symm_single 2 (fun _ => 𝕜) i a : _)
+  PiLp.nnnorm_equiv_symm_single 2 (fun _ => 𝕜) i a
 #align euclidean_space.nnnorm_single EuclideanSpace.nnnorm_single
 
 @[simp]
 theorem EuclideanSpace.dist_single_same [DecidableEq ι] (i : ι) (a b : 𝕜) :
     dist (EuclideanSpace.single i (a : 𝕜)) (EuclideanSpace.single i (b : 𝕜)) = dist a b :=
-  (PiLp.dist_equiv_symm_single_same 2 (fun _ => 𝕜) i a b : _)
+  PiLp.dist_equiv_symm_single_same 2 (fun _ => 𝕜) i a b
 #align euclidean_space.dist_single_same EuclideanSpace.dist_single_same
 
 @[simp]
 theorem EuclideanSpace.nndist_single_same [DecidableEq ι] (i : ι) (a b : 𝕜) :
     nndist (EuclideanSpace.single i (a : 𝕜)) (EuclideanSpace.single i (b : 𝕜)) = nndist a b :=
-  (PiLp.nndist_equiv_symm_single_same 2 (fun _ => 𝕜) i a b : _)
+  PiLp.nndist_equiv_symm_single_same 2 (fun _ => 𝕜) i a b
 #align euclidean_space.nndist_single_same EuclideanSpace.nndist_single_same
 
 @[simp]
 theorem EuclideanSpace.edist_single_same [DecidableEq ι] (i : ι) (a b : 𝕜) :
     edist (EuclideanSpace.single i (a : 𝕜)) (EuclideanSpace.single i (b : 𝕜)) = edist a b :=
-  (PiLp.edist_equiv_symm_single_same 2 (fun _ => 𝕜) i a b : _)
+  PiLp.edist_equiv_symm_single_same 2 (fun _ => 𝕜) i a b
 #align euclidean_space.edist_single_same EuclideanSpace.edist_single_same
 
 /-- `euclidean_space.single` forms an orthonormal family. -/
@@ -325,17 +333,24 @@ variable (ι 𝕜 E)
 structure OrthonormalBasis where ofRepr ::
   repr : E ≃ₗᵢ[𝕜] EuclideanSpace 𝕜 ι
 #align orthonormal_basis OrthonormalBasis
+#align orthonormal_basis.of_repr OrthonormalBasis.ofRepr
+#align orthonormal_basis.repr OrthonormalBasis.repr
 
 variable {ι 𝕜 E}
 
 namespace OrthonormalBasis
 
-instance : Inhabited (OrthonormalBasis ι 𝕜 (EuclideanSpace 𝕜 ι)) :=
+instance instInhabited : Inhabited (OrthonormalBasis ι 𝕜 (EuclideanSpace 𝕜 ι)) :=
   ⟨ofRepr (LinearIsometryEquiv.refl 𝕜 (EuclideanSpace 𝕜 ι))⟩
+#align orthonormal_basis.inhabited OrthonormalBasis.instInhabited
+
+@[coe, inherit_doc OrthonormalBasis]
+protected def cast (b : OrthonormalBasis ι 𝕜 E) (i : ι) : E := by
+  classical exact b.repr.symm (EuclideanSpace.single i (1 : 𝕜))
 
 /-- `b i` is the `i`th basis vector. -/
 instance instCoeFun : CoeFun (OrthonormalBasis ι 𝕜 E) fun _ => ι → E where
-  coe b i := by classical exact b.repr.symm (EuclideanSpace.single i (1 : 𝕜))
+  coe := OrthonormalBasis.cast
 #align orthonormal_basis.has_coe_to_fun OrthonormalBasis.instCoeFun
 
 @[simp]
@@ -428,8 +443,8 @@ protected theorem orthogonalProjection_eq_sum {U : Submodule 𝕜 E} [CompleteSp
 
 /-- Mapping an orthonormal basis along a `linear_isometry_equiv`. -/
 protected def map {G : Type _} [NormedAddCommGroup G] [InnerProductSpace 𝕜 G]
-    (b : OrthonormalBasis ι 𝕜 E) (L : E ≃ₗᵢ[𝕜] G) : OrthonormalBasis ι 𝕜 G
-    where repr := L.symm.trans b.repr
+    (b : OrthonormalBasis ι 𝕜 E) (L : E ≃ₗᵢ[𝕜] G) : OrthonormalBasis ι 𝕜 G where
+  repr := L.symm.trans b.repr
 #align orthonormal_basis.map OrthonormalBasis.map
 
 @[simp]
@@ -446,7 +461,8 @@ protected theorem toBasis_map {G : Type _} [NormedAddCommGroup G] [InnerProductS
 #align orthonormal_basis.to_basis_map OrthonormalBasis.toBasis_map
 
 /-- A basis that is orthonormal is an orthonormal basis. -/
-def _root_.Basis.toOrthonormalBasis (v : Basis ι 𝕜 E) (hv : Orthonormal 𝕜 v) : OrthonormalBasis ι 𝕜 E :=
+def _root_.Basis.toOrthonormalBasis (v : Basis ι 𝕜 E) (hv : Orthonormal 𝕜 v) :
+    OrthonormalBasis ι 𝕜 E :=
   OrthonormalBasis.ofRepr <|
     LinearEquiv.isometryOfInner v.equivFun
       (by

--- a/Mathlib/Analysis/InnerProductSpace/PiL2.lean
+++ b/Mathlib/Analysis/InnerProductSpace/PiL2.lean
@@ -542,7 +542,8 @@ protected def span [DecidableEq E] {v' : ι' → E} (h : Orthonormal 𝕜 v') (s
 protected theorem span_apply [DecidableEq E] {v' : ι' → E} (h : Orthonormal 𝕜 v') (s : Finset ι')
     (i : s) : (OrthonormalBasis.span h s i : E) = v' i := by
   simp only [OrthonormalBasis.span, Basis.span_apply, LinearIsometryEquiv.ofEq_symm,
-    OrthonormalBasis.map_apply, OrthonormalBasis.coe_mk, LinearIsometryEquiv.coe_ofEq_apply]
+    OrthonormalBasis.map_apply, OrthonormalBasis.coe_mk, LinearIsometryEquiv.coe_ofEq_apply,
+    comp_apply]
 #align orthonormal_basis.span_apply OrthonormalBasis.span_apply
 
 open Submodule
@@ -592,7 +593,9 @@ protected theorem coe_reindex (b : OrthonormalBasis ι 𝕜 E) (e : ι ≃ ι') 
 @[simp]
 protected theorem repr_reindex (b : OrthonormalBasis ι 𝕜 E) (e : ι ≃ ι') (x : E) (i' : ι') :
     (b.reindex e).repr x i' = b.repr x (e.symm i') := by
-  classical rw [OrthonormalBasis.repr_apply_apply, b.repr_apply_apply, OrthonormalBasis.coe_reindex]
+  classical
+  rw [OrthonormalBasis.repr_apply_apply, b.repr_apply_apply, OrthonormalBasis.coe_reindex,
+    comp_apply]
 #align orthonormal_basis.repr_reindex OrthonormalBasis.repr_reindex
 
 end OrthonormalBasis
@@ -638,6 +641,7 @@ def Complex.isometryOfOrthonormal (v : OrthonormalBasis (Fin 2) ℝ F) : ℂ ≃
 theorem Complex.map_isometryOfOrthonormal (v : OrthonormalBasis (Fin 2) ℝ F) (f : F ≃ₗᵢ[ℝ] F') :
     Complex.isometryOfOrthonormal (v.map f) = (Complex.isometryOfOrthonormal v).trans f := by
   simp [Complex.isometryOfOrthonormal, LinearIsometryEquiv.trans_assoc, OrthonormalBasis.map]
+  rfl
 #align complex.map_isometry_of_orthonormal Complex.map_isometryOfOrthonormal
 
 theorem Complex.isometryOfOrthonormal_symm_apply (v : OrthonormalBasis (Fin 2) ℝ F) (f : F) :
@@ -803,7 +807,7 @@ theorem orthonormalBasis_one_dim (b : OrthonormalBasis ι ℝ ℝ) :
     have : ‖b default‖ = 1 := b.orthonormal.1 _
     rwa [Real.norm_eq_abs, abs_eq (zero_le_one' ℝ)] at this
   rw [eq_const_of_unique b]
-  refine' this.imp _ _ <;> simp
+  refine' this.imp _ _ <;> (intro; ext; simp [*])
 #align orthonormal_basis_one_dim orthonormalBasis_one_dim
 
 variable {𝕜 E}

--- a/Mathlib/Analysis/InnerProductSpace/PiL2.lean
+++ b/Mathlib/Analysis/InnerProductSpace/PiL2.lean
@@ -348,19 +348,25 @@ theorem repr_injective :
     Injective (repr : OrthonormalBasis ι 𝕜 E → E ≃ₗᵢ[𝕜] EuclideanSpace 𝕜 ι) := fun f g h => by
   cases f; cases g; congr
 
+-- Porting note: `CoeFun` → `FunLike`
 /-- `b i` is the `i`th basis vector. -/
 instance instFunLike : FunLike (OrthonormalBasis ι 𝕜 E) ι fun _ => E where
   coe b i := by classical exact b.repr.symm (EuclideanSpace.single i (1 : 𝕜))
   coe_injective' b b' h := repr_injective <| LinearIsometryEquiv.toLinearEquiv_injective <|
-    LinearEquiv.symm_bijective.injective <| by
-      simp only [LinearIsometryEquiv.toLinearEquiv_symm, LinearIsometryEquiv.toLinearEquiv_inj]
-      ext x
-      rw [← Finsupp.sum_single x, map_finsupp_sum, map_finsupp_sum]
-      congr with (i r)
-      have := congr_fun h i
-      dsimp at this
-      rw [← mul_one r, ← Finsupp.smul_single', LinearEquiv.map_smul, LinearEquiv.map_smul, this]
-#align orthonormal_basis.has_coe_to_fun OrthonormalBasis.instFunLike
+    LinearEquiv.symm_bijective.injective <| LinearEquiv.toLinearMap_injective <| by
+      classical
+        rw [← LinearMap.cancel_right (PiLp.linearEquiv 2 𝕜 (fun _ => 𝕜)).symm.surjective]
+        simp only [LinearIsometryEquiv.toLinearEquiv_symm]
+        refine LinearMap.pi_ext fun i k => ?_
+        have : k = k • (1 : 𝕜) := by rw [smul_eq_mul, mul_one]
+        rw [this, Pi.single_smul]
+        replace h := congr_fun h i
+        simp only [LinearEquiv.comp_coe, SMulHomClass.map_smul, LinearEquiv.coe_coe,
+          LinearEquiv.trans_apply, PiLp.linearEquiv_symm_apply, PiLp.equiv_symm_single,
+          LinearIsometryEquiv.coe_toLinearEquiv] at h ⊢
+        rw [h]
+
+#noalign orthonormal_basis.has_coe_to_fun
 
 @[simp]
 theorem coe_ofRepr [DecidableEq ι] (e : E ≃ₗᵢ[𝕜] EuclideanSpace 𝕜 ι) :

--- a/Mathlib/Analysis/InnerProductSpace/PiL2.lean
+++ b/Mathlib/Analysis/InnerProductSpace/PiL2.lean
@@ -28,7 +28,7 @@ between `E` and `EuclideanSpace 𝕜 ι`. Then `stdOrthonormalBasis` shows that 
 always exists if `E` is finite dimensional. We provide language for converting between a basis
 that is orthonormal and an orthonormal basis (e.g. `Basis.toOrthonormalBasis`). We show that
 orthonormal bases for each summand in a direct sum of spaces can be combined into an orthonormal
-basis for the the whole sum in `direct_sum.submodule_is_internal.subordinate_orthonormal_basis`. In
+basis for the the whole sum in `DirectSum.IsInternal.subordinateOrthonormalBasis`. In
 the last section, various properties of matrices are explored.
 
 ## Main definitions
@@ -52,7 +52,7 @@ the last section, various properties of matrices are explored.
   dimensional inner product space
 
 For consequences in infinite dimension (Hilbert bases, etc.), see the file
-`analysis.inner_product_space.l2_space`.
+`Analysis.InnerProductSpace.L2Space`.
 
 -/
 
@@ -356,7 +356,7 @@ instance instCoeFun : CoeFun (OrthonormalBasis ι 𝕜 E) fun _ => ι → E wher
 @[simp]
 theorem coe_ofRepr [DecidableEq ι] (e : E ≃ₗᵢ[𝕜] EuclideanSpace 𝕜 ι) :
     ⇑(OrthonormalBasis.ofRepr e) = fun i => e.symm (EuclideanSpace.single i (1 : 𝕜)) := by
-  -- Porting note: simplified with `congr!`
+  -- Porting note: simplified with `congr!`, added `OrthonormalBasis.cast`
   unfold OrthonormalBasis.cast
   funext
   congr!
@@ -365,6 +365,7 @@ theorem coe_ofRepr [DecidableEq ι] (e : E ≃ₗᵢ[𝕜] EuclideanSpace 𝕜 �
 @[simp]
 protected theorem repr_symm_single [DecidableEq ι] (b : OrthonormalBasis ι 𝕜 E) (i : ι) :
     b.repr.symm (EuclideanSpace.single i (1 : 𝕜)) = b i := by
+  -- Porting note: simplified with `congr!`, added `OrthonormalBasis.cast`
   unfold OrthonormalBasis.cast
   congr!
 #align orthonormal_basis.repr_symm_single OrthonormalBasis.repr_symm_single
@@ -468,7 +469,7 @@ def _root_.Basis.toOrthonormalBasis (v : Basis ι 𝕜 E) (hv : Orthonormal 𝕜
   OrthonormalBasis.ofRepr <|
     LinearEquiv.isometryOfInner v.equivFun
       (by
-      classical
+      classical -- Porting note: added
         intro x y
         let p : EuclideanSpace 𝕜 ι := v.equivFun x
         let q : EuclideanSpace 𝕜 ι := v.equivFun y
@@ -690,7 +691,7 @@ theorem OrthonormalBasis.det_to_matrix_orthonormalBasis : ‖a.toBasis.det b‖ 
   have : (normSq (a.toBasis.det b) : 𝕜) = 1 := by
     simpa [IsROrC.mul_conj] using
       (Matrix.det_of_mem_unitary (a.toMatrix_orthonormalBasis_mem_unitary b)).2
-  norm_cast  at this
+  norm_cast at this
   rwa [← sqrt_normSq_eq_norm, sqrt_eq_one]
 #align orthonormal_basis.det_to_matrix_orthonormal_basis OrthonormalBasis.det_to_matrix_orthonormalBasis
 
@@ -826,8 +827,8 @@ variable {n : ℕ} (hn : finrank 𝕜 E = n) [DecidableEq ι] {V : ι → Submod
 /-- Exhibit a bijection between `Fin n` and the index set of a certain basis of an `n`-dimensional
 inner product space `E`.  This should not be accessed directly, but only via the subsequent API. -/
 irreducible_def DirectSum.IsInternal.sigmaOrthonormalBasisIndexEquiv
-  (hV' : OrthogonalFamily 𝕜 (fun i => V i) fun i => (V i).subtypeₗᵢ) :
-  (Σi, Fin (finrank 𝕜 (V i))) ≃ Fin n :=
+    (hV' : OrthogonalFamily 𝕜 (fun i => V i) fun i => (V i).subtypeₗᵢ) :
+    (Σi, Fin (finrank 𝕜 (V i))) ≃ Fin n :=
   let b := hV.collectedOrthonormalBasis hV' fun i => stdOrthonormalBasis 𝕜 (V i)
   Fintype.equivFinOfCardEq <| (FiniteDimensional.finrank_eq_card_basis b.toBasis).symm.trans hn
 #align direct_sum.is_internal.sigma_orthonormal_basis_index_equiv DirectSum.IsInternal.sigmaOrthonormalBasisIndexEquiv
@@ -835,8 +836,8 @@ irreducible_def DirectSum.IsInternal.sigmaOrthonormalBasisIndexEquiv
 /-- An `n`-dimensional `InnerProductSpace` equipped with a decomposition as an internal direct
 sum has an orthonormal basis indexed by `Fin n` and subordinate to that direct sum. -/
 irreducible_def DirectSum.IsInternal.subordinateOrthonormalBasis
-  (hV' : OrthogonalFamily 𝕜 (fun i => V i) fun i => (V i).subtypeₗᵢ) :
-  OrthonormalBasis (Fin n) 𝕜 E :=
+    (hV' : OrthogonalFamily 𝕜 (fun i => V i) fun i => (V i).subtypeₗᵢ) :
+    OrthonormalBasis (Fin n) 𝕜 E :=
   (hV.collectedOrthonormalBasis hV' fun i => stdOrthonormalBasis 𝕜 (V i)).reindex
     (hV.sigmaOrthonormalBasisIndexEquiv hn hV')
 #align direct_sum.is_internal.subordinate_orthonormal_basis DirectSum.IsInternal.subordinateOrthonormalBasis
@@ -845,11 +846,11 @@ irreducible_def DirectSum.IsInternal.subordinateOrthonormalBasis
 sum has an orthonormal basis indexed by `Fin n` and subordinate to that direct sum. This function
 provides the mapping by which it is subordinate. -/
 irreducible_def DirectSum.IsInternal.subordinateOrthonormalBasisIndex (a : Fin n)
-  (hV' : OrthogonalFamily 𝕜 (fun i => V i) fun i => (V i).subtypeₗᵢ) : ι :=
+    (hV' : OrthogonalFamily 𝕜 (fun i => V i) fun i => (V i).subtypeₗᵢ) : ι :=
   ((hV.sigmaOrthonormalBasisIndexEquiv hn hV').symm a).1
 #align direct_sum.is_internal.subordinate_orthonormal_basis_index DirectSum.IsInternal.subordinateOrthonormalBasisIndex
 
-/-- The basis constructed in `orthogonal_family.subordinate_orthonormal_basis` is subordinate to
+/-- The basis constructed in `DirectSum.IsInternal.subordinateOrthonormalBasis` is subordinate to
 the `OrthogonalFamily` in question. -/
 theorem DirectSum.IsInternal.subordinateOrthonormalBasis_subordinate (a : Fin n)
     (hV' : OrthogonalFamily 𝕜 (fun i => V i) fun i => (V i).subtypeₗᵢ) :
@@ -869,7 +870,7 @@ space, there exists an isometry from the orthogonal complement of a nonzero sing
 `EuclideanSpace 𝕜 (Fin n)`. -/
 def OrthonormalBasis.fromOrthogonalSpanSingleton (n : ℕ) [Fact (finrank 𝕜 E = n + 1)] {v : E}
     (hv : v ≠ 0) : OrthonormalBasis (Fin n) 𝕜 (𝕜 ∙ v)ᗮ :=
-  -- Poritng note: was `attribute [local instance] fact_finiteDimensional_of_finrank_eq_succ`
+  -- Porting note: was `attribute [local instance] fact_finiteDimensional_of_finrank_eq_succ`
   haveI : FiniteDimensional 𝕜 E := fact_finiteDimensional_of_finrank_eq_succ (K := 𝕜) (V := E) n
   (stdOrthonormalBasis _ _).reindex <| finCongr <| finrank_orthogonal_span_singleton hv
 #align orthonormal_basis.from_orthogonal_span_singleton OrthonormalBasis.fromOrthogonalSpanSingleton
@@ -891,12 +892,12 @@ noncomputable def LinearIsometry.extend (L : S →ₗᵢ[𝕜] V) : V →ₗᵢ[
   let d := finrank 𝕜 Sᗮ
   let LS := LinearMap.range L.toLinearMap
   have E : Sᗮ ≃ₗᵢ[𝕜] LSᗮ := by
-    have dim_LS_perp : finrank 𝕜 LSᗮ = d
-    calc
-      finrank 𝕜 LSᗮ = finrank 𝕜 V - finrank 𝕜 LS := by
-        simp only [← LS.finrank_add_finrank_orthogonal, add_tsub_cancel_left]
-      _ = finrank 𝕜 V - finrank 𝕜 S := by simp only [LinearMap.finrank_range_of_inj L.injective]
-      _ = finrank 𝕜 Sᗮ := by simp only [← S.finrank_add_finrank_orthogonal, add_tsub_cancel_left]
+    have dim_LS_perp : finrank 𝕜 LSᗮ = d :=
+      calc
+        finrank 𝕜 LSᗮ = finrank 𝕜 V - finrank 𝕜 LS := by
+          simp only [← LS.finrank_add_finrank_orthogonal, add_tsub_cancel_left]
+        _ = finrank 𝕜 V - finrank 𝕜 S := by simp only [LinearMap.finrank_range_of_inj L.injective]
+        _ = finrank 𝕜 Sᗮ := by simp only [← S.finrank_add_finrank_orthogonal, add_tsub_cancel_left]
 
     exact
       (stdOrthonormalBasis 𝕜 Sᗮ).repr.trans

--- a/Mathlib/Analysis/InnerProductSpace/PiL2.lean
+++ b/Mathlib/Analysis/InnerProductSpace/PiL2.lean
@@ -434,7 +434,7 @@ protected theorem sum_inner_mul_inner (b : OrthonormalBasis ι 𝕜 E) (x y : E)
   rw [map_sum] at this
   convert this
   rw [SMulHomClass.map_smul, b.repr_apply_apply, mul_comm]
-  simp only [innerSL_apply, smul_eq_mul] -- Porting note: was `rfl`
+  rfl
 #align orthonormal_basis.sum_inner_mul_inner OrthonormalBasis.sum_inner_mul_inner
 
 protected theorem orthogonalProjection_eq_sum {U : Submodule 𝕜 E} [CompleteSpace U]
@@ -469,7 +469,6 @@ def _root_.Basis.toOrthonormalBasis (v : Basis ι 𝕜 E) (hv : Orthonormal 𝕜
   OrthonormalBasis.ofRepr <|
     LinearEquiv.isometryOfInner v.equivFun
       (by
-      classical -- Porting note: added
         intro x y
         let p : EuclideanSpace 𝕜 ι := v.equivFun x
         let q : EuclideanSpace 𝕜 ι := v.equivFun y
@@ -508,7 +507,6 @@ theorem _root_.Basis.coe_toOrthonormalBasis (v : Basis ι 𝕜 E) (hv : Orthonor
 #align basis.coe_to_orthonormal_basis Basis.coe_toOrthonormalBasis
 
 variable {v : ι → E}
-variable [DecidableEq ι] [DecidableEq ι'] -- Porting note: added
 
 /-- A finite orthonormal set that spans is an orthonormal basis -/
 protected def mk (hon : Orthonormal 𝕜 v) (hsp : ⊤ ≤ Submodule.span 𝕜 (Set.range v)) :

--- a/Mathlib/Analysis/InnerProductSpace/PiL2.lean
+++ b/Mathlib/Analysis/InnerProductSpace/PiL2.lean
@@ -346,7 +346,9 @@ instance instInhabited : Inhabited (OrthonormalBasis ι 𝕜 (EuclideanSpace �
 
 theorem repr_injective :
     Injective (repr : OrthonormalBasis ι 𝕜 E → E ≃ₗᵢ[𝕜] EuclideanSpace 𝕜 ι) := fun f g h => by
-  cases f; cases g; congr
+  cases f
+  cases g
+  congr
 
 -- Porting note: `CoeFun` → `FunLike`
 /-- `b i` is the `i`th basis vector. -/
@@ -449,7 +451,7 @@ protected theorem sum_inner_mul_inner (b : OrthonormalBasis ι 𝕜 E) (x y : E)
   rw [map_sum] at this
   convert this
   rw [SMulHomClass.map_smul, b.repr_apply_apply, mul_comm]
-  rfl
+  simp only [innerSL_apply, smul_eq_mul] -- Porting note: was `rfl`
 #align orthonormal_basis.sum_inner_mul_inner OrthonormalBasis.sum_inner_mul_inner
 
 protected theorem orthogonalProjection_eq_sum {U : Submodule 𝕜 E} [CompleteSpace U]
@@ -657,13 +659,14 @@ def Complex.isometryOfOrthonormal (v : OrthonormalBasis (Fin 2) ℝ F) : ℂ ≃
 theorem Complex.map_isometryOfOrthonormal (v : OrthonormalBasis (Fin 2) ℝ F) (f : F ≃ₗᵢ[ℝ] F') :
     Complex.isometryOfOrthonormal (v.map f) = (Complex.isometryOfOrthonormal v).trans f := by
   simp [Complex.isometryOfOrthonormal, LinearIsometryEquiv.trans_assoc, OrthonormalBasis.map]
-  rfl
+  -- Porting note: `LinearIsometryEquiv.trans_assoc` doesn't trigger in the `simp` above
+  rw [LinearIsometryEquiv.trans_assoc]
 #align complex.map_isometry_of_orthonormal Complex.map_isometryOfOrthonormal
 
 theorem Complex.isometryOfOrthonormal_symm_apply (v : OrthonormalBasis (Fin 2) ℝ F) (f : F) :
     (Complex.isometryOfOrthonormal v).symm f =
-      (v.toBasis.coord 0 f : ℂ) + (v.toBasis.coord 1 f : ℂ) * I :=
-  by simp [Complex.isometryOfOrthonormal]
+      (v.toBasis.coord 0 f : ℂ) + (v.toBasis.coord 1 f : ℂ) * I := by
+  simp [Complex.isometryOfOrthonormal]
 #align complex.isometry_of_orthonormal_symm_apply Complex.isometryOfOrthonormal_symm_apply
 
 theorem Complex.isometryOfOrthonormal_apply (v : OrthonormalBasis (Fin 2) ℝ F) (z : ℂ) :
@@ -766,7 +769,6 @@ variable [FiniteDimensional 𝕜 E]
 orthonormal basis. -/
 theorem Orthonormal.exists_orthonormalBasis_extension (hv : Orthonormal 𝕜 ((↑) : v → E)) :
     ∃ (u : Finset E)(b : OrthonormalBasis u 𝕜 E), v ⊆ u ∧ ⇑b = ((↑) : u → E) := by
-  classical
   obtain ⟨u₀, hu₀s, hu₀, hu₀_max⟩ := exists_maximal_orthonormal hv
   rw [maximal_orthonormal_iff_orthogonalComplement_eq_bot hu₀] at hu₀_max
   have hu₀_finite : u₀.Finite := hu₀.linearIndependent.finite
@@ -783,7 +785,6 @@ theorem Orthonormal.exists_orthonormalBasis_extension (hv : Orthonormal 𝕜 ((�
 theorem Orthonormal.exists_orthonormalBasis_extension_of_card_eq {ι : Type _} [Fintype ι]
     (card_ι : finrank 𝕜 E = Fintype.card ι) {v : ι → E} {s : Set ι}
     (hv : Orthonormal 𝕜 (s.restrict v)) : ∃ b : OrthonormalBasis ι 𝕜 E, ∀ i ∈ s, b i = v i := by
-  classical
   have hsv : Injective (s.restrict v) := hv.linearIndependent.injective
   have hX : Orthonormal 𝕜 ((↑) : Set.range (s.restrict v) → E) := by
     rwa [orthonormal_subtype_range hsv]
@@ -805,10 +806,9 @@ variable (𝕜 E)
 
 /-- A finite-dimensional inner product space admits an orthonormal basis. -/
 theorem _root_.exists_orthonormalBasis :
-    ∃ (w : Finset E)(b : OrthonormalBasis w 𝕜 E), ⇑b = ((↑) : w → E) := by
-  classical
+    ∃ (w : Finset E)(b : OrthonormalBasis w 𝕜 E), ⇑b = ((↑) : w → E) :=
   let ⟨w, hw, _, hw''⟩ := (orthonormal_empty 𝕜 E).exists_orthonormalBasis_extension
-  exact ⟨w, hw, hw''⟩
+  ⟨w, hw, hw''⟩
 #align exists_orthonormal_basis exists_orthonormalBasis
 
 /-- A finite-dimensional `InnerProductSpace` has an orthonormal basis. -/

--- a/Mathlib/Analysis/InnerProductSpace/PiL2.lean
+++ b/Mathlib/Analysis/InnerProductSpace/PiL2.lean
@@ -56,10 +56,10 @@ For consequences in infinite dimension (Hilbert bases, etc.), see the file
 
 -/
 
+local macro_rules | `($x ^ $y)   => `(HPow.hPow $x $y) -- Porting note: See issue #2220
 
-open Real Set Filter IsROrC Submodule Function
-
-open BigOperators uniformity Topology NNReal ENNReal ComplexConjugate DirectSum
+open Real Set Filter IsROrC Submodule Function BigOperators Uniformity Topology NNReal ENNReal
+  ComplexConjugate DirectSum
 
 noncomputable section
 
@@ -75,7 +75,6 @@ variable {F : Type _} [NormedAddCommGroup F] [InnerProductSpace ℝ F]
 
 variable {F' : Type _} [NormedAddCommGroup F'] [InnerProductSpace ℝ F']
 
--- mathport name: «expr⟪ , ⟫»
 local notation "⟪" x ", " y "⟫" => @inner 𝕜 _ _ x y
 
 /-
@@ -88,11 +87,11 @@ instance PiLp.innerProductSpace {ι : Type _} [Fintype ι] (f : ι → Type _)
     InnerProductSpace 𝕜 (PiLp 2 f) where
   inner x y := ∑ i, inner (x i) (y i)
   norm_sq_eq_inner x := by
-    simp only [PiLp.norm_sq_eq_of_L2, AddMonoidHom.map_sum, ← norm_sq_eq_inner, one_div]
+    simp only [PiLp.norm_sq_eq_of_L2, map_sum, ← norm_sq_eq_inner, one_div]
   conj_symm := by
     intro x y
     unfold inner
-    rw [RingHom.map_sum]
+    rw [map_sum]
     apply Finset.sum_congr rfl
     rintro z -
     apply inner_conj_symm
@@ -112,9 +111,9 @@ theorem PiLp.inner_apply {ι : Type _} [Fintype ι] {f : ι → Type _} [∀ i, 
 
 /-- The standard real/complex Euclidean space, functions on a finite type. For an `n`-dimensional
 space use `euclidean_space 𝕜 (fin n)`. -/
-@[reducible, nolint unused_arguments]
+@[reducible, nolint unusedArguments]
 def EuclideanSpace (𝕜 : Type _) [IsROrC 𝕜] (n : Type _) [Fintype n] : Type _ :=
-  PiLp 2 fun i : n => 𝕜
+  PiLp 2 fun _ : n => 𝕜
 #align euclidean_space EuclideanSpace
 
 theorem EuclideanSpace.nnnorm_eq {𝕜 : Type _} [IsROrC 𝕜] {n : Type _} [Fintype n]
@@ -124,7 +123,7 @@ theorem EuclideanSpace.nnnorm_eq {𝕜 : Type _} [IsROrC 𝕜] {n : Type _} [Fin
 
 theorem EuclideanSpace.norm_eq {𝕜 : Type _} [IsROrC 𝕜] {n : Type _} [Fintype n]
     (x : EuclideanSpace 𝕜 n) : ‖x‖ = Real.sqrt (∑ i, ‖x i‖ ^ 2) := by
-  simpa only [Real.coe_sqrt, NNReal.coe_sum] using congr_arg (coe : ℝ≥0 → ℝ) x.nnnorm_eq
+  simpa only [Real.coe_sqrt, NNReal.coe_sum] using congr_arg ((↑) : ℝ≥0 → ℝ) x.nnnorm_eq
 #align euclidean_space.norm_eq EuclideanSpace.norm_eq
 
 theorem EuclideanSpace.dist_eq {𝕜 : Type _} [IsROrC 𝕜] {n : Type _} [Fintype n]
@@ -133,7 +132,7 @@ theorem EuclideanSpace.dist_eq {𝕜 : Type _} [IsROrC 𝕜] {n : Type _} [Finty
 #align euclidean_space.dist_eq EuclideanSpace.dist_eq
 
 theorem EuclideanSpace.nndist_eq {𝕜 : Type _} [IsROrC 𝕜] {n : Type _} [Fintype n]
-    (x y : EuclideanSpace 𝕜 n) : nndist x y = (∑ i, nndist (x i) (y i) ^ 2).sqrt :=
+    (x y : EuclideanSpace 𝕜 n) : nndist x y = NNReal.sqrt (∑ i, nndist (x i) (y i) ^ 2) :=
   (PiLp.nndist_eq_of_L2 x y : _)
 #align euclidean_space.nndist_eq EuclideanSpace.nndist_eq
 
@@ -146,7 +145,8 @@ variable [Fintype ι]
 
 section
 
-attribute [local reducible] PiLp
+-- Porting note: no longer supported
+-- attribute [local reducible] PiLp
 
 instance : FiniteDimensional 𝕜 (EuclideanSpace 𝕜 ι) := by infer_instance
 
@@ -154,7 +154,9 @@ instance : InnerProductSpace 𝕜 (EuclideanSpace 𝕜 ι) := by infer_instance
 
 @[simp]
 theorem finrank_euclideanSpace :
-    FiniteDimensional.finrank 𝕜 (EuclideanSpace 𝕜 ι) = Fintype.card ι := by simp
+    FiniteDimensional.finrank 𝕜 (EuclideanSpace 𝕜 ι) = Fintype.card ι := by
+  unfold EuclideanSpace PiLp
+  simp
 #align finrank_euclidean_space finrank_euclideanSpace
 
 theorem finrank_euclideanSpace_fin {n : ℕ} :
@@ -481,7 +483,7 @@ theorem Basis.coe_toOrthonormalBasis (v : Basis ι 𝕜 E) (hv : Orthonormal �
     (v.toOrthonormalBasis hv : ι → E) = ((v.toOrthonormalBasis hv).toBasis : ι → E) := by
       classical rw [OrthonormalBasis.coe_toBasis]
     _ = (v : ι → E) := by simp
-    
+
 #align basis.coe_to_orthonormal_basis Basis.coe_toOrthonormalBasis
 
 variable {v : ι → E}
@@ -865,7 +867,7 @@ noncomputable def LinearIsometry.extend (L : S →ₗᵢ[𝕜] V) : V →ₗᵢ[
         simp only [← LS.finrank_add_finrank_orthogonal, add_tsub_cancel_left]
       _ = finrank 𝕜 V - finrank 𝕜 S := by simp only [LinearMap.finrank_range_of_inj L.injective]
       _ = finrank 𝕜 Sᗮ := by simp only [← S.finrank_add_finrank_orthogonal, add_tsub_cancel_left]
-      
+
     exact
       (stdOrthonormalBasis 𝕜 Sᗮ).repr.trans
         ((stdOrthonormalBasis 𝕜 LSᗮ).reindex <| finCongr dim_LS_perp).repr.symm
@@ -974,4 +976,3 @@ theorem inner_matrix_col_col [Fintype m] (A B : Matrix m n 𝕜) (i j : n) :
 #align inner_matrix_col_col inner_matrix_col_col
 
 end Matrix
-

--- a/Mathlib/Analysis/InnerProductSpace/PiL2.lean
+++ b/Mathlib/Analysis/InnerProductSpace/PiL2.lean
@@ -864,13 +864,13 @@ end SubordinateOrthonormalBasis
 
 end FiniteDimensional
 
-attribute [local instance] fact_finiteDimensional_of_finrank_eq_succ
-
 /-- Given a natural number `n` one less than the `finrank` of a finite-dimensional inner product
 space, there exists an isometry from the orthogonal complement of a nonzero singleton to
 `euclidean_space 𝕜 (fin n)`. -/
 def OrthonormalBasis.fromOrthogonalSpanSingleton (n : ℕ) [Fact (finrank 𝕜 E = n + 1)] {v : E}
     (hv : v ≠ 0) : OrthonormalBasis (Fin n) 𝕜 (𝕜 ∙ v)ᗮ :=
+  -- Poritng note: was `attribute [local instance] fact_finiteDimensional_of_finrank_eq_succ`
+  haveI : FiniteDimensional 𝕜 E := fact_finiteDimensional_of_finrank_eq_succ (K := 𝕜) (V := E) n
   (stdOrthonormalBasis _ _).reindex <| finCongr <| finrank_orthogonal_span_singleton hv
 #align orthonormal_basis.from_orthogonal_span_singleton OrthonormalBasis.fromOrthogonalSpanSingleton
 

--- a/Mathlib/Analysis/InnerProductSpace/PiL2.lean
+++ b/Mathlib/Analysis/InnerProductSpace/PiL2.lean
@@ -58,6 +58,8 @@ For consequences in infinite dimension (Hilbert bases, etc.), see the file
 
 local macro_rules | `($x ^ $y)   => `(HPow.hPow $x $y) -- Porting note: See issue #2220
 
+set_option linter.uppercaseLean3 false
+
 open Real Set Filter IsROrC Submodule Function BigOperators Uniformity Topology NNReal ENNReal
   ComplexConjugate DirectSum
 
@@ -215,7 +217,7 @@ variable (ι 𝕜)
 -- TODO : This should be generalized to `pi_Lp` with finite dimensional factors.
 /-- `pi_Lp.linear_equiv` upgraded to a continuous linear map between `euclidean_space 𝕜 ι`
 and `ι → 𝕜`. -/
-@[simps]
+@[simps!]
 def EuclideanSpace.equiv : EuclideanSpace 𝕜 ι ≃L[𝕜] ι → 𝕜 :=
   (PiLp.linearEquiv 2 𝕜 fun i : ι => 𝕜).toContinuousLinearEquiv
 #align euclidean_space.equiv EuclideanSpace.equiv
@@ -224,7 +226,7 @@ variable {ι 𝕜}
 
 -- TODO : This should be generalized to `pi_Lp`.
 /-- The projection on the `i`-th coordinate of `euclidean_space 𝕜 ι`, as a linear map. -/
-@[simps]
+@[simps!]
 def EuclideanSpace.projₗ (i : ι) : EuclideanSpace 𝕜 ι →ₗ[𝕜] 𝕜 :=
   (LinearMap.proj i).comp (PiLp.linearEquiv 2 𝕜 fun i : ι => 𝕜 : EuclideanSpace 𝕜 ι →ₗ[𝕜] ι → 𝕜)
 #align euclidean_space.projₗ EuclideanSpace.projₗ
@@ -232,7 +234,7 @@ def EuclideanSpace.projₗ (i : ι) : EuclideanSpace 𝕜 ι →ₗ[𝕜] 𝕜 :
 -- TODO : This should be generalized to `pi_Lp`.
 /-- The projection on the `i`-th coordinate of `euclidean_space 𝕜 ι`,
 as a continuous linear map. -/
-@[simps]
+@[simps!]
 def EuclideanSpace.proj (i : ι) : EuclideanSpace 𝕜 ι →L[𝕜] 𝕜 :=
   ⟨EuclideanSpace.projₗ i, continuous_apply i⟩
 #align euclidean_space.proj EuclideanSpace.proj
@@ -829,7 +831,7 @@ theorem DirectSum.IsInternal.subordinateOrthonormalBasis_subordinate (a : Fin n)
   simpa only [DirectSum.IsInternal.subordinateOrthonormalBasis, OrthonormalBasis.coe_reindex,
     DirectSum.IsInternal.subordinateOrthonormalBasisIndex] using
     hV.collectedOrthonormalBasis_mem hV' (fun i => stdOrthonormalBasis 𝕜 (V i))
-      ((hV.sigma_orthonormal_basis_index_equiv hn hV').symm a)
+      ((hV.sigma_orthonormalBasis_index_equiv hn hV').symm a)
 #align direct_sum.is_internal.subordinate_orthonormal_basis_subordinate DirectSum.IsInternal.subordinateOrthonormalBasis_subordinate
 
 end SubordinateOrthonormalBasis
@@ -861,8 +863,7 @@ TODO:  The case when `S` is a finite-dimensional subspace of an infinite-dimensi
 noncomputable def LinearIsometry.extend (L : S →ₗᵢ[𝕜] V) : V →ₗᵢ[𝕜] V := by
   -- Build an isometry from Sᗮ to L(S)ᗮ through euclidean_space
   let d := finrank 𝕜 Sᗮ
-  have dim_S_perp : finrank 𝕜 Sᗮ = d := rfl
-  let LS := L.to_linear_map.range
+  let LS := LinearMap.range L.toLinearMap
   have E : Sᗮ ≃ₗᵢ[𝕜] LSᗮ := by
     have dim_LS_perp : finrank 𝕜 LSᗮ = d
     calc
@@ -874,14 +875,14 @@ noncomputable def LinearIsometry.extend (L : S →ₗᵢ[𝕜] V) : V →ₗᵢ[
     exact
       (stdOrthonormalBasis 𝕜 Sᗮ).repr.trans
         ((stdOrthonormalBasis 𝕜 LSᗮ).reindex <| finCongr dim_LS_perp).repr.symm
-  let L3 := LSᗮ.subtypeₗᵢ.comp E.to_linear_isometry
+  let L3 := LSᗮ.subtypeₗᵢ.comp E.toLinearIsometry
   -- Project onto S and Sᗮ
   haveI : CompleteSpace S := FiniteDimensional.complete 𝕜 S
   haveI : CompleteSpace V := FiniteDimensional.complete 𝕜 V
   let p1 := (orthogonalProjection S).toLinearMap
   let p2 := (orthogonalProjection Sᗮ).toLinearMap
   -- Build a linear map from the isometries on S and Sᗮ
-  let M := L.to_linear_map.comp p1 + L3.to_linear_map.comp p2
+  let M := L.toLinearMap.comp p1 + L3.toLinearMap.comp p2
   -- Prove that M is an isometry
   have M_norm_map : ∀ x : V, ‖M x‖ = ‖x‖ := by
     intro x
@@ -891,10 +892,10 @@ noncomputable def LinearIsometry.extend (L : S →ₗᵢ[𝕜] V) : V →ₗᵢ[
         LinearIsometry.coe_toLinearMap]
     -- Mx_decomp is the orthogonal decomposition of M x
     have Mx_orth : ⟪L (p1 x), L3 (p2 x)⟫ = 0 := by
-      have Lp1x : L (p1 x) ∈ L.to_linear_map.range :=
-        LinearMap.mem_range_self L.to_linear_map (p1 x)
-      have Lp2x : L3 (p2 x) ∈ L.to_linear_map.rangeᗮ := by
-        simp only [L3, LinearIsometry.coe_comp, Function.comp_apply, Submodule.coe_subtypeₗᵢ, ←
+      have Lp1x : L (p1 x) ∈ LinearMap.range L.toLinearMap :=
+        LinearMap.mem_range_self L.toLinearMap (p1 x)
+      have Lp2x : L3 (p2 x) ∈ (LinearMap.range L.toLinearMap)ᗮ := by
+        simp only [LinearIsometry.coe_comp, Function.comp_apply, Submodule.coe_subtypeₗᵢ, ←
           Submodule.range_subtype LSᗮ]
         apply LinearMap.mem_range_self
       apply Submodule.inner_right_of_mem_orthogonal Lp1x Lp2x
@@ -902,7 +903,7 @@ noncomputable def LinearIsometry.extend (L : S →ₗᵢ[𝕜] V) : V →ₗᵢ[
     rw [← sq_eq_sq (norm_nonneg _) (norm_nonneg _), norm_sq_eq_add_norm_sq_projection x S]
     simp only [sq, Mx_decomp]
     rw [norm_add_sq_eq_norm_sq_add_norm_sq_of_inner_eq_zero (L (p1 x)) (L3 (p2 x)) Mx_orth]
-    simp only [LinearIsometry.norm_map, p1, p2, [anonymous], add_left_inj, mul_eq_mul_left_iff,
+    simp only [LinearIsometry.norm_map, _root_.add_left_inj, mul_eq_mul_left_iff,
       norm_eq_zero, true_or_iff, eq_self_iff_true, ContinuousLinearMap.coe_coe, Submodule.coe_norm,
       Submodule.coe_eq_zero]
   exact
@@ -912,7 +913,7 @@ noncomputable def LinearIsometry.extend (L : S →ₗᵢ[𝕜] V) : V →ₗᵢ[
 
 theorem LinearIsometry.extend_apply (L : S →ₗᵢ[𝕜] V) (s : S) : L.extend s = L s := by
   haveI : CompleteSpace S := FiniteDimensional.complete 𝕜 S
-  simp only [LinearIsometry.extend, [anonymous], ← LinearIsometry.coe_toLinearMap]
+  simp only [LinearIsometry.extend, ← LinearIsometry.coe_toLinearMap]
   simp only [add_right_eq_self, LinearIsometry.coe_toLinearMap,
     LinearIsometryEquiv.coe_toLinearIsometry, LinearIsometry.coe_comp, Function.comp_apply,
     orthogonalProjection_mem_subspace_eq_self, LinearMap.coe_comp, ContinuousLinearMap.coe_coe,
@@ -943,13 +944,14 @@ def toEuclideanLin : Matrix m n 𝕜 ≃ₗ[𝕜] EuclideanSpace 𝕜 n →ₗ[�
 
 @[simp]
 theorem toEuclideanLin_piLp_equiv_symm (A : Matrix m n 𝕜) (x : n → 𝕜) :
-    A.toEuclideanLin ((PiLp.equiv _ _).symm x) = (PiLp.equiv _ _).symm (A.toLin' x) :=
+    Matrix.toEuclideanLin A ((PiLp.equiv _ _).symm x) =
+      (PiLp.equiv _ _).symm (Matrix.toLin' A x) :=
   rfl
 #align matrix.to_euclidean_lin_pi_Lp_equiv_symm Matrix.toEuclideanLin_piLp_equiv_symm
 
 @[simp]
 theorem piLp_equiv_toEuclideanLin (A : Matrix m n 𝕜) (x : EuclideanSpace 𝕜 n) :
-    PiLp.equiv _ _ (A.toEuclideanLin x) = A.toLin' (PiLp.equiv _ _ x) :=
+    PiLp.equiv _ _ (Matrix.toEuclideanLin A x) = Matrix.toLin' A (PiLp.equiv _ _ x) :=
   rfl
 #align matrix.pi_Lp_equiv_to_euclidean_lin Matrix.piLp_equiv_toEuclideanLin
 
@@ -962,8 +964,8 @@ theorem toEuclideanLin_eq_toLin :
 
 end Matrix
 
--- mathport name: «expr⟪ , ⟫ₑ»
-local notation "⟪" x ", " y "⟫ₑ" => @inner 𝕜 _ _ ((PiLp.equiv 2 _).symm x) ((PiLp.equiv 2 _).symm y)
+local notation "⟪" x ", " y "⟫ₑ" =>
+  @inner 𝕜 _ _ (Equiv.symm (PiLp.equiv 2 _) x) (Equiv.symm (PiLp.equiv 2 _) y)
 
 /-- The inner product of a row of `A` and a row of `B` is an entry of `B ⬝ Aᴴ`. -/
 theorem inner_matrix_row_row [Fintype n] (A B : Matrix m n 𝕜) (i j : m) :

--- a/Mathlib/Analysis/InnerProductSpace/PiL2.lean
+++ b/Mathlib/Analysis/InnerProductSpace/PiL2.lean
@@ -344,20 +344,29 @@ instance instInhabited : Inhabited (OrthonormalBasis ι 𝕜 (EuclideanSpace �
   ⟨ofRepr (LinearIsometryEquiv.refl 𝕜 (EuclideanSpace 𝕜 ι))⟩
 #align orthonormal_basis.inhabited OrthonormalBasis.instInhabited
 
-@[coe, inherit_doc OrthonormalBasis]
-protected def cast (b : OrthonormalBasis ι 𝕜 E) (i : ι) : E := by
-  classical exact b.repr.symm (EuclideanSpace.single i (1 : 𝕜))
+theorem repr_injective :
+    Injective (repr : OrthonormalBasis ι 𝕜 E → E ≃ₗᵢ[𝕜] EuclideanSpace 𝕜 ι) := fun f g h => by
+  cases f; cases g; congr
 
 /-- `b i` is the `i`th basis vector. -/
-instance instCoeFun : CoeFun (OrthonormalBasis ι 𝕜 E) fun _ => ι → E where
-  coe := OrthonormalBasis.cast
-#align orthonormal_basis.has_coe_to_fun OrthonormalBasis.instCoeFun
+instance instFunLike : FunLike (OrthonormalBasis ι 𝕜 E) ι fun _ => E where
+  coe b i := by classical exact b.repr.symm (EuclideanSpace.single i (1 : 𝕜))
+  coe_injective' b b' h := repr_injective <| LinearIsometryEquiv.toLinearEquiv_injective <|
+    LinearEquiv.symm_bijective.injective <| by
+      simp only [LinearIsometryEquiv.toLinearEquiv_symm, LinearIsometryEquiv.toLinearEquiv_inj]
+      ext x
+      rw [← Finsupp.sum_single x, map_finsupp_sum, map_finsupp_sum]
+      congr with (i r)
+      have := congr_fun h i
+      dsimp at this
+      rw [← mul_one r, ← Finsupp.smul_single', LinearEquiv.map_smul, LinearEquiv.map_smul, this]
+#align orthonormal_basis.has_coe_to_fun OrthonormalBasis.instFunLike
 
 @[simp]
 theorem coe_ofRepr [DecidableEq ι] (e : E ≃ₗᵢ[𝕜] EuclideanSpace 𝕜 ι) :
     ⇑(OrthonormalBasis.ofRepr e) = fun i => e.symm (EuclideanSpace.single i (1 : 𝕜)) := by
-  -- Porting note: simplified with `congr!`, added `OrthonormalBasis.cast`
-  unfold OrthonormalBasis.cast
+  -- Porting note: simplified with `congr!`
+  dsimp only [FunLike.coe]
   funext
   congr!
 #align orthonormal_basis.coe_of_repr OrthonormalBasis.coe_ofRepr
@@ -365,8 +374,8 @@ theorem coe_ofRepr [DecidableEq ι] (e : E ≃ₗᵢ[𝕜] EuclideanSpace 𝕜 �
 @[simp]
 protected theorem repr_symm_single [DecidableEq ι] (b : OrthonormalBasis ι 𝕜 E) (i : ι) :
     b.repr.symm (EuclideanSpace.single i (1 : 𝕜)) = b i := by
-  -- Porting note: simplified with `congr!`, added `OrthonormalBasis.cast`
-  unfold OrthonormalBasis.cast
+  -- Porting note: simplified with `congr!`
+  dsimp only [FunLike.coe]
   congr!
 #align orthonormal_basis.repr_symm_single OrthonormalBasis.repr_symm_single
 
@@ -578,7 +587,7 @@ def reindex (b : OrthonormalBasis ι 𝕜 E) (e : ι ≃ ι') : OrthonormalBasis
 protected theorem reindex_apply (b : OrthonormalBasis ι 𝕜 E) (e : ι ≃ ι') (i' : ι') :
     (b.reindex e) i' = b (e.symm i') := by
   classical
-    dsimp [reindex, OrthonormalBasis.instCoeFun]
+    dsimp [reindex]
     rw [coe_ofRepr]
     dsimp
     rw [← b.repr_symm_single, LinearIsometryEquiv.piLpCongrLeft_symm,

--- a/Mathlib/Analysis/InnerProductSpace/PiL2.lean
+++ b/Mathlib/Analysis/InnerProductSpace/PiL2.lean
@@ -357,6 +357,7 @@ instance instCoeFun : CoeFun (OrthonormalBasis ι 𝕜 E) fun _ => ι → E wher
 theorem coe_ofRepr [DecidableEq ι] (e : E ≃ₗᵢ[𝕜] EuclideanSpace 𝕜 ι) :
     ⇑(OrthonormalBasis.ofRepr e) = fun i => e.symm (EuclideanSpace.single i (1 : 𝕜)) := by
   -- Porting note: simplified with `congr!`
+  unfold OrthonormalBasis.cast
   funext
   congr!
 #align orthonormal_basis.coe_of_repr OrthonormalBasis.coe_ofRepr
@@ -364,6 +365,7 @@ theorem coe_ofRepr [DecidableEq ι] (e : E ≃ₗᵢ[𝕜] EuclideanSpace 𝕜 �
 @[simp]
 protected theorem repr_symm_single [DecidableEq ι] (b : OrthonormalBasis ι 𝕜 E) (i : ι) :
     b.repr.symm (EuclideanSpace.single i (1 : 𝕜)) = b i := by
+  unfold OrthonormalBasis.cast
   congr!
 #align orthonormal_basis.repr_symm_single OrthonormalBasis.repr_symm_single
 

--- a/Mathlib/Analysis/InnerProductSpace/PiL2.lean
+++ b/Mathlib/Analysis/InnerProductSpace/PiL2.lean
@@ -182,7 +182,7 @@ def DirectSum.IsInternal.isometryL2OfOrthogonalFamily [DecidableEq ι] {V : ι �
   let e₁ := DirectSum.linearEquivFunOnFintype 𝕜 ι fun i => V i
   let e₂ := LinearEquiv.ofBijective (DirectSum.coeLinearMap V) hV
   refine' LinearEquiv.isometryOfInner (e₂.symm.trans e₁) _
-  suffices ∀ v w, ⟪v, w⟫ = ⟪e₂ (e₁.symm v), e₂ (e₁.symm w)⟫ by
+  suffices ∀ (v w : PiLp 2 (fun i : ι => V i)), ⟪v, w⟫ = ⟪e₂ (e₁.symm v), e₂ (e₁.symm w)⟫ by
     intro v₀ w₀
     convert this (e₁ (e₂.symm v₀)) (e₁ (e₂.symm w₀)) <;>
       simp only [LinearEquiv.symm_apply_apply, LinearEquiv.apply_symm_apply]
@@ -202,7 +202,10 @@ theorem DirectSum.IsInternal.isometryL2OfOrthogonalFamily_symm_apply [DecidableE
     let e₂ := LinearEquiv.ofBijective (DirectSum.coeLinearMap V) hV
     suffices ∀ v : ⨁ i, V i, e₂ v = ∑ i, e₁ v i by exact this (e₁.symm w)
     intro v
-    simp [e₂, DirectSum.coeLinearMap, DirectSum.toModule, Dfinsupp.sumAddHom_apply]
+    -- Porting note: added the next two lines
+    simp only [coeLinearMap, toModule, LinearEquiv.ofBijective_apply, linearEquivFunOnFintype_apply]
+    erw [Dfinsupp.lsum_apply_apply ℕ (fun i ↦ Submodule.subtype (V i)) v]
+    simp [DirectSum.coeLinearMap, DirectSum.toModule, Dfinsupp.sumAddHom_apply]
 #align direct_sum.is_internal.isometry_L2_of_orthogonal_family_symm_apply DirectSum.IsInternal.isometryL2OfOrthogonalFamily_symm_apply
 
 end
@@ -270,31 +273,31 @@ theorem EuclideanSpace.inner_single_right [DecidableEq ι] (i : ι) (a : 𝕜) (
 @[simp]
 theorem EuclideanSpace.norm_single [DecidableEq ι] (i : ι) (a : 𝕜) :
     ‖EuclideanSpace.single i (a : 𝕜)‖ = ‖a‖ :=
-  (PiLp.norm_equiv_symm_single 2 (fun i => 𝕜) i a : _)
+  (PiLp.norm_equiv_symm_single 2 (fun _ => 𝕜) i a : _)
 #align euclidean_space.norm_single EuclideanSpace.norm_single
 
 @[simp]
 theorem EuclideanSpace.nnnorm_single [DecidableEq ι] (i : ι) (a : 𝕜) :
     ‖EuclideanSpace.single i (a : 𝕜)‖₊ = ‖a‖₊ :=
-  (PiLp.nnnorm_equiv_symm_single 2 (fun i => 𝕜) i a : _)
+  (PiLp.nnnorm_equiv_symm_single 2 (fun _ => 𝕜) i a : _)
 #align euclidean_space.nnnorm_single EuclideanSpace.nnnorm_single
 
 @[simp]
 theorem EuclideanSpace.dist_single_same [DecidableEq ι] (i : ι) (a b : 𝕜) :
     dist (EuclideanSpace.single i (a : 𝕜)) (EuclideanSpace.single i (b : 𝕜)) = dist a b :=
-  (PiLp.dist_equiv_symm_single_same 2 (fun i => 𝕜) i a b : _)
+  (PiLp.dist_equiv_symm_single_same 2 (fun _ => 𝕜) i a b : _)
 #align euclidean_space.dist_single_same EuclideanSpace.dist_single_same
 
 @[simp]
 theorem EuclideanSpace.nndist_single_same [DecidableEq ι] (i : ι) (a b : 𝕜) :
     nndist (EuclideanSpace.single i (a : 𝕜)) (EuclideanSpace.single i (b : 𝕜)) = nndist a b :=
-  (PiLp.nndist_equiv_symm_single_same 2 (fun i => 𝕜) i a b : _)
+  (PiLp.nndist_equiv_symm_single_same 2 (fun _ => 𝕜) i a b : _)
 #align euclidean_space.nndist_single_same EuclideanSpace.nndist_single_same
 
 @[simp]
 theorem EuclideanSpace.edist_single_same [DecidableEq ι] (i : ι) (a b : 𝕜) :
     edist (EuclideanSpace.single i (a : 𝕜)) (EuclideanSpace.single i (b : 𝕜)) = edist a b :=
-  (PiLp.edist_equiv_symm_single_same 2 (fun i => 𝕜) i a b : _)
+  (PiLp.edist_equiv_symm_single_same 2 (fun _ => 𝕜) i a b : _)
 #align euclidean_space.edist_single_same EuclideanSpace.edist_single_same
 
 /-- `euclidean_space.single` forms an orthonormal family. -/
@@ -302,8 +305,8 @@ theorem EuclideanSpace.orthonormal_single [DecidableEq ι] :
     Orthonormal 𝕜 fun i : ι => EuclideanSpace.single i (1 : 𝕜) := by
   simp_rw [orthonormal_iff_ite, EuclideanSpace.inner_single_left, map_one, one_mul,
     EuclideanSpace.single_apply]
-  intro i j
-  rfl
+  intros
+  trivial
 #align euclidean_space.orthonormal_single EuclideanSpace.orthonormal_single
 
 theorem EuclideanSpace.piLpCongrLeft_single [DecidableEq ι] {ι' : Type _} [Fintype ι']
@@ -326,28 +329,25 @@ variable {ι 𝕜 E}
 namespace OrthonormalBasis
 
 instance : Inhabited (OrthonormalBasis ι 𝕜 (EuclideanSpace 𝕜 ι)) :=
-  ⟨of_repr (LinearIsometryEquiv.refl 𝕜 (EuclideanSpace 𝕜 ι))⟩
+  ⟨ofRepr (LinearIsometryEquiv.refl 𝕜 (EuclideanSpace 𝕜 ι))⟩
 
 /-- `b i` is the `i`th basis vector. -/
-instance : CoeFun (OrthonormalBasis ι 𝕜 E) fun _ => ι → E
-    where coe b i := by classical exact b.repr.symm (EuclideanSpace.single i (1 : 𝕜))
+instance instCoeFun : CoeFun (OrthonormalBasis ι 𝕜 E) fun _ => ι → E where
+  coe b i := by classical exact b.repr.symm (EuclideanSpace.single i (1 : 𝕜))
+#align orthonormal_basis.has_coe_to_fun OrthonormalBasis.instCoeFun
 
 @[simp]
-theorem coe_of_repr [DecidableEq ι] (e : E ≃ₗᵢ[𝕜] EuclideanSpace 𝕜 ι) :
-    ⇑(OrthonormalBasis.of_repr e) = fun i => e.symm (EuclideanSpace.single i (1 : 𝕜)) := by
-  rw [coeFn]
-  unfold CoeFun.coe
+theorem coe_ofRepr [DecidableEq ι] (e : E ≃ₗᵢ[𝕜] EuclideanSpace 𝕜 ι) :
+    ⇑(OrthonormalBasis.ofRepr e) = fun i => e.symm (EuclideanSpace.single i (1 : 𝕜)) := by
+  -- Porting note: simplified with `congr!`
   funext
-  congr
-  simp only [eq_iff_true_of_subsingleton]
-#align orthonormal_basis.coe_of_repr OrthonormalBasis.coe_of_repr
+  congr!
+#align orthonormal_basis.coe_of_repr OrthonormalBasis.coe_ofRepr
 
 @[simp]
 protected theorem repr_symm_single [DecidableEq ι] (b : OrthonormalBasis ι 𝕜 E) (i : ι) :
     b.repr.symm (EuclideanSpace.single i (1 : 𝕜)) = b i := by
-  classical
-    congr
-    simp
+  congr!
 #align orthonormal_basis.repr_symm_single OrthonormalBasis.repr_symm_single
 
 @[simp]
@@ -379,7 +379,7 @@ protected def toBasis (b : OrthonormalBasis ι 𝕜 E) : Basis ι 𝕜 E :=
 
 @[simp]
 protected theorem coe_toBasis (b : OrthonormalBasis ι 𝕜 E) : (⇑b.toBasis : ι → E) = ⇑b := by
-  change ⇑(Basis.ofEquivFun b.repr.to_linear_equiv) = b
+  rw [OrthonormalBasis.toBasis] -- Porting note: was `change`
   ext j
   classical
     rw [Basis.coe_ofEquivFun]
@@ -400,11 +400,12 @@ protected theorem coe_toBasis_repr_apply (b : OrthonormalBasis ι 𝕜 E) (x : E
 #align orthonormal_basis.coe_to_basis_repr_apply OrthonormalBasis.coe_toBasis_repr_apply
 
 protected theorem sum_repr (b : OrthonormalBasis ι 𝕜 E) (x : E) : (∑ i, b.repr x i • b i) = x := by
-  simp_rw [← b.coe_to_basis_repr_apply, ← b.coe_to_basis]; exact b.to_basis.sum_repr x
+  simp_rw [← b.coe_toBasis_repr_apply, ← b.coe_toBasis]
+  exact b.toBasis.sum_repr x
 #align orthonormal_basis.sum_repr OrthonormalBasis.sum_repr
 
 protected theorem sum_repr_symm (b : OrthonormalBasis ι 𝕜 E) (v : EuclideanSpace 𝕜 ι) :
-    (∑ i, v i • b i) = b.repr.symm v := by simpa using (b.to_basis.equiv_fun_symm_apply v).symm
+    (∑ i, v i • b i) = b.repr.symm v := by simpa using (b.toBasis.equivFun_symm_apply v).symm
 #align orthonormal_basis.sum_repr_symm OrthonormalBasis.sum_repr_symm
 
 protected theorem sum_inner_mul_inner (b : OrthonormalBasis ι 𝕜 E) (x y : E) :
@@ -412,14 +413,13 @@ protected theorem sum_inner_mul_inner (b : OrthonormalBasis ι 𝕜 E) (x y : E)
   have := congr_arg (innerSL 𝕜 x) (b.sum_repr y)
   rw [map_sum] at this
   convert this
-  ext i
   rw [SMulHomClass.map_smul, b.repr_apply_apply, mul_comm]
-  rfl
+  simp only [innerSL_apply, smul_eq_mul] -- Porting note: was `rfl`
 #align orthonormal_basis.sum_inner_mul_inner OrthonormalBasis.sum_inner_mul_inner
 
 protected theorem orthogonalProjection_eq_sum {U : Submodule 𝕜 E} [CompleteSpace U]
-    (b : OrthonormalBasis ι 𝕜 U) (x : E) : orthogonalProjection U x = ∑ i, ⟪(b i : E), x⟫ • b i :=
-  by
+    (b : OrthonormalBasis ι 𝕜 U) (x : E) :
+    orthogonalProjection U x = ∑ i, ⟪(b i : E), x⟫ • b i := by
   simpa only [b.repr_apply_apply, inner_orthogonalProjection_eq_of_mem_left] using
     (b.sum_repr (orthogonalProjection U x)).symm
 #align orthonormal_basis.orthogonal_projection_eq_sum OrthonormalBasis.orthogonalProjection_eq_sum
@@ -444,49 +444,50 @@ protected theorem toBasis_map {G : Type _} [NormedAddCommGroup G] [InnerProductS
 #align orthonormal_basis.to_basis_map OrthonormalBasis.toBasis_map
 
 /-- A basis that is orthonormal is an orthonormal basis. -/
-def Basis.toOrthonormalBasis (v : Basis ι 𝕜 E) (hv : Orthonormal 𝕜 v) : OrthonormalBasis ι 𝕜 E :=
-  OrthonormalBasis.of_repr <|
+def _root_.Basis.toOrthonormalBasis (v : Basis ι 𝕜 E) (hv : Orthonormal 𝕜 v) : OrthonormalBasis ι 𝕜 E :=
+  OrthonormalBasis.ofRepr <|
     LinearEquiv.isometryOfInner v.equivFun
       (by
+      classical
         intro x y
-        let p : EuclideanSpace 𝕜 ι := v.equiv_fun x
-        let q : EuclideanSpace 𝕜 ι := v.equiv_fun y
+        let p : EuclideanSpace 𝕜 ι := v.equivFun x
+        let q : EuclideanSpace 𝕜 ι := v.equivFun y
         have key : ⟪p, q⟫ = ⟪∑ i, p i • v i, ∑ i, q i • v i⟫ := by
           simp [sum_inner, inner_smul_left, hv.inner_right_fintype]
         convert key
-        · rw [← v.equiv_fun.symm_apply_apply x, v.equiv_fun_symm_apply]
-        · rw [← v.equiv_fun.symm_apply_apply y, v.equiv_fun_symm_apply])
+        · rw [← v.equivFun.symm_apply_apply x, v.equivFun_symm_apply]
+        · rw [← v.equivFun.symm_apply_apply y, v.equivFun_symm_apply])
 #align basis.to_orthonormal_basis Basis.toOrthonormalBasis
 
 @[simp]
-theorem Basis.coe_toOrthonormalBasis_repr (v : Basis ι 𝕜 E) (hv : Orthonormal 𝕜 v) :
+theorem _root_.Basis.coe_toOrthonormalBasis_repr (v : Basis ι 𝕜 E) (hv : Orthonormal 𝕜 v) :
     ((v.toOrthonormalBasis hv).repr : E → EuclideanSpace 𝕜 ι) = v.equivFun :=
   rfl
 #align basis.coe_to_orthonormal_basis_repr Basis.coe_toOrthonormalBasis_repr
 
 @[simp]
-theorem Basis.coe_toOrthonormalBasis_repr_symm (v : Basis ι 𝕜 E) (hv : Orthonormal 𝕜 v) :
+theorem _root_.Basis.coe_toOrthonormalBasis_repr_symm (v : Basis ι 𝕜 E) (hv : Orthonormal 𝕜 v) :
     ((v.toOrthonormalBasis hv).repr.symm : EuclideanSpace 𝕜 ι → E) = v.equivFun.symm :=
   rfl
 #align basis.coe_to_orthonormal_basis_repr_symm Basis.coe_toOrthonormalBasis_repr_symm
 
 @[simp]
-theorem Basis.toBasis_toOrthonormalBasis (v : Basis ι 𝕜 E) (hv : Orthonormal 𝕜 v) :
+theorem _root_.Basis.toBasis_toOrthonormalBasis (v : Basis ι 𝕜 E) (hv : Orthonormal 𝕜 v) :
     (v.toOrthonormalBasis hv).toBasis = v := by
   simp [Basis.toOrthonormalBasis, OrthonormalBasis.toBasis]
 #align basis.to_basis_to_orthonormal_basis Basis.toBasis_toOrthonormalBasis
 
 @[simp]
-theorem Basis.coe_toOrthonormalBasis (v : Basis ι 𝕜 E) (hv : Orthonormal 𝕜 v) :
+theorem _root_.Basis.coe_toOrthonormalBasis (v : Basis ι 𝕜 E) (hv : Orthonormal 𝕜 v) :
     (v.toOrthonormalBasis hv : ι → E) = (v : ι → E) :=
   calc
     (v.toOrthonormalBasis hv : ι → E) = ((v.toOrthonormalBasis hv).toBasis : ι → E) := by
       classical rw [OrthonormalBasis.coe_toBasis]
     _ = (v : ι → E) := by simp
-
 #align basis.coe_to_orthonormal_basis Basis.coe_toOrthonormalBasis
 
 variable {v : ι → E}
+variable [DecidableEq ι] [DecidableEq ι'] -- Porting note: added
 
 /-- A finite orthonormal set that spans is an orthonormal basis -/
 protected def mk (hon : Orthonormal 𝕜 v) (hsp : ⊤ ≤ Submodule.span 𝕜 (Set.range v)) :
@@ -497,22 +498,21 @@ protected def mk (hon : Orthonormal 𝕜 v) (hsp : ⊤ ≤ Submodule.span 𝕜 (
 @[simp]
 protected theorem coe_mk (hon : Orthonormal 𝕜 v) (hsp : ⊤ ≤ Submodule.span 𝕜 (Set.range v)) :
     ⇑(OrthonormalBasis.mk hon hsp) = v := by
-  classical rw [OrthonormalBasis.mk, _root_.basis.coe_to_orthonormal_basis, Basis.coe_mk]
+  classical rw [OrthonormalBasis.mk, _root_.Basis.coe_toOrthonormalBasis, Basis.coe_mk]
 #align orthonormal_basis.coe_mk OrthonormalBasis.coe_mk
 
 /-- Any finite subset of a orthonormal family is an `orthonormal_basis` for its span. -/
 protected def span [DecidableEq E] {v' : ι' → E} (h : Orthonormal 𝕜 v') (s : Finset ι') :
     OrthonormalBasis s 𝕜 (span 𝕜 (s.image v' : Set E)) :=
   let e₀' : Basis s 𝕜 _ :=
-    Basis.span (h.LinearIndependent.comp (coe : s → ι') Subtype.coe_injective)
+    Basis.span (h.linearIndependent.comp ((↑) : s → ι') Subtype.val_injective)
   let e₀ : OrthonormalBasis s 𝕜 _ :=
     OrthonormalBasis.mk
       (by
-        convert orthonormal_span (h.comp (coe : s → ι') Subtype.coe_injective)
-        ext
-        simp [e₀', Basis.span_apply])
+        convert orthonormal_span (h.comp ((↑) : s → ι') Subtype.val_injective)
+        simp [Basis.span_apply])
       e₀'.span_eq.ge
-  let φ : span 𝕜 (s.image v' : Set E) ≃ₗᵢ[𝕜] span 𝕜 (range (v' ∘ (coe : s → ι'))) :=
+  let φ : span 𝕜 (s.image v' : Set E) ≃ₗᵢ[𝕜] span 𝕜 (range (v' ∘ ((↑) : s → ι'))) :=
     LinearIsometryEquiv.ofEq _ _
       (by
         rw [Finset.coe_image, image_eq_range]
@@ -552,14 +552,14 @@ variable [Fintype ι']
 
 /-- `b.reindex (e : ι ≃ ι')` is an `orthonormal_basis` indexed by `ι'` -/
 def reindex (b : OrthonormalBasis ι 𝕜 E) (e : ι ≃ ι') : OrthonormalBasis ι' 𝕜 E :=
-  OrthonormalBasis.of_repr (b.repr.trans (LinearIsometryEquiv.piLpCongrLeft 2 𝕜 𝕜 e))
+  OrthonormalBasis.ofRepr (b.repr.trans (LinearIsometryEquiv.piLpCongrLeft 2 𝕜 𝕜 e))
 #align orthonormal_basis.reindex OrthonormalBasis.reindex
 
 protected theorem reindex_apply (b : OrthonormalBasis ι 𝕜 E) (e : ι ≃ ι') (i' : ι') :
     (b.reindex e) i' = b (e.symm i') := by
   classical
-    dsimp [reindex, OrthonormalBasis.hasCoeToFun]
-    rw [coe_of_repr]
+    dsimp [reindex, OrthonormalBasis.instCoeFun]
+    rw [coe_ofRepr]
     dsimp
     rw [← b.repr_symm_single, LinearIsometryEquiv.piLpCongrLeft_symm,
       EuclideanSpace.piLpCongrLeft_single]
@@ -567,7 +567,7 @@ protected theorem reindex_apply (b : OrthonormalBasis ι 𝕜 E) (e : ι ≃ ι'
 
 @[simp]
 protected theorem coe_reindex (b : OrthonormalBasis ι 𝕜 E) (e : ι ≃ ι') :
-    ⇑(b.reindex e) = ⇑b ∘ ⇑e.symm :=
+    ⇑(b.reindex e) = b ∘ e.symm :=
   funext (b.reindex_apply e)
 #align orthonormal_basis.coe_reindex OrthonormalBasis.coe_reindex
 
@@ -595,7 +595,7 @@ theorem Complex.orthonormalBasisOneI_repr_apply (z : ℂ) :
 
 @[simp]
 theorem Complex.orthonormalBasisOneI_repr_symm_apply (x : EuclideanSpace ℝ (Fin 2)) :
-    Complex.orthonormalBasisOneI.repr.symm x = x 0 + x 1 * i :=
+    Complex.orthonormalBasisOneI.repr.symm x = x 0 + x 1 * I :=
   rfl
 #align complex.orthonormal_basis_one_I_repr_symm_apply Complex.orthonormalBasisOneI_repr_symm_apply
 
@@ -606,7 +606,7 @@ theorem Complex.toBasis_orthonormalBasisOneI :
 #align complex.to_basis_orthonormal_basis_one_I Complex.toBasis_orthonormalBasisOneI
 
 @[simp]
-theorem Complex.coe_orthonormalBasisOneI : (Complex.orthonormalBasisOneI : Fin 2 → ℂ) = ![1, i] :=
+theorem Complex.coe_orthonormalBasisOneI : (Complex.orthonormalBasisOneI : Fin 2 → ℂ) = ![1, I] :=
   by simp [Complex.orthonormalBasisOneI]
 #align complex.coe_orthonormal_basis_one_I Complex.coe_orthonormalBasisOneI
 
@@ -623,7 +623,7 @@ theorem Complex.map_isometryOfOrthonormal (v : OrthonormalBasis (Fin 2) ℝ F) (
 
 theorem Complex.isometryOfOrthonormal_symm_apply (v : OrthonormalBasis (Fin 2) ℝ F) (f : F) :
     (Complex.isometryOfOrthonormal v).symm f =
-      (v.toBasis.Coord 0 f : ℂ) + (v.toBasis.Coord 1 f : ℂ) * i :=
+      (v.toBasis.coord 0 f : ℂ) + (v.toBasis.coord 1 f : ℂ) * I :=
   by simp [Complex.isometryOfOrthonormal]
 #align complex.isometry_of_orthonormal_symm_apply Complex.isometryOfOrthonormal_symm_apply
 
@@ -659,11 +659,11 @@ theorem OrthonormalBasis.toMatrix_orthonormalBasis_mem_unitary :
 unit length. -/
 @[simp]
 theorem OrthonormalBasis.det_to_matrix_orthonormalBasis : ‖a.toBasis.det b‖ = 1 := by
-  have : (norm_sq (a.to_basis.det b) : 𝕜) = 1 := by
+  have : (normSq (a.toBasis.det b) : 𝕜) = 1 := by
     simpa [IsROrC.mul_conj] using
-      (Matrix.det_of_mem_unitary (a.to_matrix_orthonormal_basis_mem_unitary b)).2
+      (Matrix.det_of_mem_unitary (a.toMatrix_orthonormalBasis_mem_unitary b)).2
   norm_cast  at this
-  rwa [← sqrt_norm_sq_eq_norm, sqrt_eq_one]
+  rwa [← sqrt_normSq_eq_norm, sqrt_eq_one]
 #align orthonormal_basis.det_to_matrix_orthonormal_basis OrthonormalBasis.det_to_matrix_orthonormalBasis
 
 end
@@ -682,7 +682,7 @@ theorem OrthonormalBasis.toMatrix_orthonormalBasis_mem_orthogonal :
 theorem OrthonormalBasis.det_to_matrix_orthonormalBasis_real :
     a.toBasis.det b = 1 ∨ a.toBasis.det b = -1 := by
   rw [← sq_eq_one_iff]
-  simpa [unitary, sq] using Matrix.det_of_mem_unitary (a.to_matrix_orthonormal_basis_mem_unitary b)
+  simpa [unitary, sq] using Matrix.det_of_mem_unitary (a.toMatrix_orthonormalBasis_mem_unitary b)
 #align orthonormal_basis.det_to_matrix_orthonormal_basis_real OrthonormalBasis.det_to_matrix_orthonormalBasis_real
 
 end Real
@@ -722,15 +722,16 @@ variable [FiniteDimensional 𝕜 E]
 
 /-- In a finite-dimensional `inner_product_space`, any orthonormal subset can be extended to an
 orthonormal basis. -/
-theorem Orthonormal.exists_orthonormalBasis_extension (hv : Orthonormal 𝕜 (coe : v → E)) :
-    ∃ (u : Finset E)(b : OrthonormalBasis u 𝕜 E), v ⊆ u ∧ ⇑b = coe := by
+theorem Orthonormal.exists_orthonormalBasis_extension (hv : Orthonormal 𝕜 ((↑) : v → E)) :
+    ∃ (u : Finset E)(b : OrthonormalBasis u 𝕜 E), v ⊆ u ∧ ⇑b = ((↑) : u → E) := by
+  classical
   obtain ⟨u₀, hu₀s, hu₀, hu₀_max⟩ := exists_maximal_orthonormal hv
   rw [maximal_orthonormal_iff_orthogonalComplement_eq_bot hu₀] at hu₀_max
-  have hu₀_finite : u₀.finite := hu₀.linear_independent.finite
-  let u : Finset E := hu₀_finite.to_finset
-  let fu : ↥u ≃ ↥u₀ := Equiv.cast (congr_arg coeSort hu₀_finite.coe_to_finset)
-  have hfu : (coe : u → E) = (coe : u₀ → E) ∘ fu := by ext; simp
-  have hu : Orthonormal 𝕜 (coe : u → E) := by simpa [hfu] using hu₀.comp _ fu.injective
+  have hu₀_finite : u₀.Finite := hu₀.linearIndependent.finite
+  let u : Finset E := hu₀_finite.toFinset
+  let fu : ↥u ≃ ↥u₀ := Equiv.cast (congr_arg (↥) hu₀_finite.coe_toFinset)
+  have hfu : ((↑) : u → E) = ((↑) : u₀ → E) ∘ fu := by ext; simp
+  have hu : Orthonormal 𝕜 ((↑) : u → E) := by simpa [hfu] using hu₀.comp _ fu.injective
   refine' ⟨u, OrthonormalBasis.mkOfOrthogonalEqBot hu _, _, _⟩
   · simpa using hu₀_max
   · simpa using hu₀s
@@ -740,14 +741,15 @@ theorem Orthonormal.exists_orthonormalBasis_extension (hv : Orthonormal 𝕜 (co
 theorem Orthonormal.exists_orthonormalBasis_extension_of_card_eq {ι : Type _} [Fintype ι]
     (card_ι : finrank 𝕜 E = Fintype.card ι) {v : ι → E} {s : Set ι}
     (hv : Orthonormal 𝕜 (s.restrict v)) : ∃ b : OrthonormalBasis ι 𝕜 E, ∀ i ∈ s, b i = v i := by
-  have hsv : injective (s.restrict v) := hv.linear_independent.injective
-  have hX : Orthonormal 𝕜 (coe : Set.range (s.restrict v) → E) := by
+  classical
+  have hsv : Injective (s.restrict v) := hv.linearIndependent.injective
+  have hX : Orthonormal 𝕜 ((↑) : Set.range (s.restrict v) → E) := by
     rwa [orthonormal_subtype_range hsv]
-  obtain ⟨Y, b₀, hX, hb₀⟩ := hX.exists_orthonormal_basis_extension
+  obtain ⟨Y, b₀, hX, hb₀⟩ := hX.exists_orthonormalBasis_extension
   have hιY : Fintype.card ι = Y.card := by
     refine' card_ι.symm.trans _
-    exact FiniteDimensional.finrank_eq_card_finset_basis b₀.to_basis
-  have hvsY : s.maps_to v Y := (s.maps_to_image v).mono_right (by rwa [← range_restrict])
+    exact FiniteDimensional.finrank_eq_card_finset_basis b₀.toBasis
+  have hvsY : s.MapsTo v Y := (s.mapsTo_image v).mono_right (by rwa [← range_restrict])
   have hsv' : Set.InjOn v s := by
     rw [Set.injOn_iff_injective]
     exact hsv
@@ -760,26 +762,27 @@ theorem Orthonormal.exists_orthonormalBasis_extension_of_card_eq {ι : Type _} [
 variable (𝕜 E)
 
 /-- A finite-dimensional inner product space admits an orthonormal basis. -/
-theorem exists_orthonormalBasis :
-    ∃ (w : Finset E)(b : OrthonormalBasis w 𝕜 E), ⇑b = (coe : w → E) :=
-  let ⟨w, hw, hw', hw''⟩ := (orthonormal_empty 𝕜 E).exists_orthonormalBasis_extension
-  ⟨w, hw, hw''⟩
+theorem _root_.exists_orthonormalBasis :
+    ∃ (w : Finset E)(b : OrthonormalBasis w 𝕜 E), ⇑b = ((↑) : w → E) := by
+  classical
+  let ⟨w, hw, _, hw''⟩ := (orthonormal_empty 𝕜 E).exists_orthonormalBasis_extension
+  exact ⟨w, hw, hw''⟩
 #align exists_orthonormal_basis exists_orthonormalBasis
 
 /-- A finite-dimensional `inner_product_space` has an orthonormal basis. -/
 irreducible_def stdOrthonormalBasis : OrthonormalBasis (Fin (finrank 𝕜 E)) 𝕜 E := by
   let b := Classical.choose (Classical.choose_spec <| exists_orthonormalBasis 𝕜 E)
-  rw [finrank_eq_card_basis b.to_basis]
+  rw [finrank_eq_card_basis b.toBasis]
   exact b.reindex (Fintype.equivFinOfCardEq rfl)
 #align std_orthonormal_basis stdOrthonormalBasis
 
 /-- An orthonormal basis of `ℝ` is made either of the vector `1`, or of the vector `-1`. -/
 theorem orthonormalBasis_one_dim (b : OrthonormalBasis ι ℝ ℝ) :
     (⇑b = fun _ => (1 : ℝ)) ∨ ⇑b = fun _ => (-1 : ℝ) := by
-  have : Unique ι := b.to_basis.unique
+  have : Unique ι := b.toBasis.unique
   have : b default = 1 ∨ b default = -1 := by
     have : ‖b default‖ = 1 := b.orthonormal.1 _
-    rwa [Real.norm_eq_abs, abs_eq (zero_le_one : (0 : ℝ) ≤ 1)] at this
+    rwa [Real.norm_eq_abs, abs_eq (zero_le_one' ℝ)] at this
   rw [eq_const_of_unique b]
   refine' this.imp _ _ <;> simp
 #align orthonormal_basis_one_dim orthonormalBasis_one_dim
@@ -825,7 +828,7 @@ theorem DirectSum.IsInternal.subordinateOrthonormalBasis_subordinate (a : Fin n)
     hV.subordinateOrthonormalBasis hn hV' a ∈ V (hV.subordinateOrthonormalBasisIndex hn a hV') := by
   simpa only [DirectSum.IsInternal.subordinateOrthonormalBasis, OrthonormalBasis.coe_reindex,
     DirectSum.IsInternal.subordinateOrthonormalBasisIndex] using
-    hV.collected_orthonormal_basis_mem hV' (fun i => stdOrthonormalBasis 𝕜 (V i))
+    hV.collectedOrthonormalBasis_mem hV' (fun i => stdOrthonormalBasis 𝕜 (V i))
       ((hV.sigma_orthonormal_basis_index_equiv hn hV').symm a)
 #align direct_sum.is_internal.subordinate_orthonormal_basis_subordinate DirectSum.IsInternal.subordinateOrthonormalBasis_subordinate
 
@@ -833,7 +836,7 @@ end SubordinateOrthonormalBasis
 
 end FiniteDimensional
 
-attribute [local instance] fact_finite_dimensional_of_finrank_eq_succ
+attribute [local instance] fact_finiteDimensional_of_finrank_eq_succ
 
 /-- Given a natural number `n` one less than the `finrank` of a finite-dimensional inner product
 space, there exists an isometry from the orthogonal complement of a nonzero singleton to

--- a/Mathlib/Analysis/InnerProductSpace/PiL2.lean
+++ b/Mathlib/Analysis/InnerProductSpace/PiL2.lean
@@ -20,35 +20,35 @@ The `L²` norm on a finite product of inner product spaces is compatible with an
 $$
 \langle x, y\rangle = \sum \langle x_i, y_i \rangle.
 $$
-This is recorded in this file as an inner product space instance on `pi_Lp 2`.
+This is recorded in this file as an inner product space instance on `PiLp 2`.
 
 This file develops the notion of a finite dimensional Hilbert space over `𝕜 = ℂ, ℝ`, referred to as
-`E`. We define an `orthonormal_basis 𝕜 ι E` as a linear isometric equivalence
-between `E` and `euclidean_space 𝕜 ι`. Then `std_orthonormal_basis` shows that such an equivalence
+`E`. We define an `OrthonormalBasis 𝕜 ι E` as a linear isometric equivalence
+between `E` and `EuclideanSpace 𝕜 ι`. Then `stdOrthonormalBasis` shows that such an equivalence
 always exists if `E` is finite dimensional. We provide language for converting between a basis
-that is orthonormal and an orthonormal basis (e.g. `basis.to_orthonormal_basis`). We show that
+that is orthonormal and an orthonormal basis (e.g. `Basis.toOrthonormalBasis`). We show that
 orthonormal bases for each summand in a direct sum of spaces can be combined into an orthonormal
 basis for the the whole sum in `direct_sum.submodule_is_internal.subordinate_orthonormal_basis`. In
 the last section, various properties of matrices are explored.
 
 ## Main definitions
 
-- `euclidean_space 𝕜 n`: defined to be `pi_Lp 2 (n → 𝕜)` for any `fintype n`, i.e., the space
+- `EuclideanSpace 𝕜 n`: defined to be `PiLp 2 (n → 𝕜)` for any `Fintype n`, i.e., the space
   from functions to `n` to `𝕜` with the `L²` norm. We register several instances on it (notably
   that it is a finite-dimensional inner product space).
 
-- `orthonormal_basis 𝕜 ι`: defined to be an isometry to Euclidean space from a given
-  finite-dimensional innner product space, `E ≃ₗᵢ[𝕜] euclidean_space 𝕜 ι`.
+- `OrthonormalBasis 𝕜 ι`: defined to be an isometry to Euclidean space from a given
+  finite-dimensional innner product space, `E ≃ₗᵢ[𝕜] EuclideanSpace 𝕜 ι`.
 
-- `basis.to_orthonormal_basis`: constructs an `orthonormal_basis` for a finite-dimensional
-  Euclidean space from a `basis` which is `orthonormal`.
+- `Basis.toOrthonormalBasis`: constructs an `OrthonormalBasis` for a finite-dimensional
+  Euclidean space from a `Basis` which is `Orthonormal`.
 
-- `orthonormal.exists_orthonormal_basis_extension`: provides an existential result of an
-  `orthonormal_basis` extending a given orthonormal set
+- `Orthonormal.exists_orthonormalBasis_extension`: provides an existential result of an
+  `OrthonormalBasis` extending a given orthonormal set
 
-- `exists_orthonormal_basis`: provides an orthonormal basis on a finite dimensional vector space
+- `exists_orthonormalBasis`: provides an orthonormal basis on a finite dimensional vector space
 
-- `std_orthonormal_basis`: provides an arbitrarily-chosen `orthonormal_basis` of a given finite
+- `stdOrthonormalBasis`: provides an arbitrarily-chosen `OrthonormalBasis` of a given finite
   dimensional inner product space
 
 For consequences in infinite dimension (Hilbert bases, etc.), see the file
@@ -82,7 +82,7 @@ local notation "⟪" x ", " y "⟫" => @inner 𝕜 _ _ x y
 /-
  If `ι` is a finite type and each space `f i`, `i : ι`, is an inner product space,
 then `Π i, f i` is an inner product space as well. Since `Π i, f i` is endowed with the sup norm,
-we use instead `pi_Lp 2 f` for the product space, which is endowed with the `L^2` norm.
+we use instead `PiLp 2 f` for the product space, which is endowed with the `L^2` norm.
 -/
 instance PiLp.innerProductSpace {ι : Type _} [Fintype ι] (f : ι → Type _)
     [∀ i, NormedAddCommGroup (f i)] [∀ i, InnerProductSpace 𝕜 (f i)] :
@@ -112,7 +112,7 @@ theorem PiLp.inner_apply {ι : Type _} [Fintype ι] {f : ι → Type _} [∀ i, 
 #align pi_Lp.inner_apply PiLp.inner_apply
 
 /-- The standard real/complex Euclidean space, functions on a finite type. For an `n`-dimensional
-space use `euclidean_space 𝕜 (fin n)`. -/
+space use `EuclideanSpace 𝕜 (Fin n)`. -/
 @[reducible, nolint unusedArguments]
 def EuclideanSpace (𝕜 : Type _) [IsROrC 𝕜] (n : Type _) [Fintype n] : Type _ :=
   PiLp 2 fun _ : n => 𝕜
@@ -179,7 +179,7 @@ theorem EuclideanSpace.inner_piLp_equiv_symm (x y : ι → 𝕜) :
 #align euclidean_space.inner_pi_Lp_equiv_symm EuclideanSpace.inner_piLp_equiv_symm
 
 /-- A finite, mutually orthogonal family of subspaces of `E`, which span `E`, induce an isometry
-from `E` to `pi_Lp 2` of the subspaces equipped with the `L2` inner product. -/
+from `E` to `PiLp 2` of the subspaces equipped with the `L2` inner product. -/
 def DirectSum.IsInternal.isometryL2OfOrthogonalFamily [DecidableEq ι] {V : ι → Submodule 𝕜 E}
     (hV : DirectSum.IsInternal V)
     (hV' : OrthogonalFamily 𝕜 (fun i => V i) fun i => (V i).subtypeₗᵢ) :
@@ -215,8 +215,8 @@ end
 
 variable (ι 𝕜)
 
--- TODO : This should be generalized to `pi_Lp` with finite dimensional factors.
-/-- `pi_Lp.linear_equiv` upgraded to a continuous linear map between `euclidean_space 𝕜 ι`
+-- TODO : This should be generalized to `PiLp` with finite dimensional factors.
+/-- `PiLp.linearEquiv` upgraded to a continuous linear map between `EuclideanSpace 𝕜 ι`
 and `ι → 𝕜`. -/
 @[simps! toLinearEquiv_apply apply toLinearEquiv_symm_apply symm_apply]
 def EuclideanSpace.equiv : EuclideanSpace 𝕜 ι ≃L[𝕜] ι → 𝕜 :=
@@ -229,16 +229,16 @@ def EuclideanSpace.equiv : EuclideanSpace 𝕜 ι ≃L[𝕜] ι → 𝕜 :=
 
 variable {ι 𝕜}
 
--- TODO : This should be generalized to `pi_Lp`.
-/-- The projection on the `i`-th coordinate of `euclidean_space 𝕜 ι`, as a linear map. -/
+-- TODO : This should be generalized to `PiLp`.
+/-- The projection on the `i`-th coordinate of `EuclideanSpace 𝕜 ι`, as a linear map. -/
 @[simps!]
 def EuclideanSpace.projₗ (i : ι) : EuclideanSpace 𝕜 ι →ₗ[𝕜] 𝕜 :=
   (LinearMap.proj i).comp (PiLp.linearEquiv 2 𝕜 fun _ : ι => 𝕜 : EuclideanSpace 𝕜 ι →ₗ[𝕜] ι → 𝕜)
 #align euclidean_space.projₗ EuclideanSpace.projₗ
 #align euclidean_space.projₗ_apply EuclideanSpace.projₗ_apply
 
--- TODO : This should be generalized to `pi_Lp`.
-/-- The projection on the `i`-th coordinate of `euclidean_space 𝕜 ι`,
+-- TODO : This should be generalized to `PiLp`.
+/-- The projection on the `i`-th coordinate of `EuclideanSpace 𝕜 ι`,
 as a continuous linear map. -/
 @[simps! apply coe]
 def EuclideanSpace.proj (i : ι) : EuclideanSpace 𝕜 ι →L[𝕜] 𝕜 :=
@@ -247,7 +247,7 @@ def EuclideanSpace.proj (i : ι) : EuclideanSpace 𝕜 ι →L[𝕜] 𝕜 :=
 #align euclidean_space.proj_coe EuclideanSpace.proj_coe
 #align euclidean_space.proj_apply EuclideanSpace.proj_apply
 
--- TODO : This should be generalized to `pi_Lp`.
+-- TODO : This should be generalized to `PiLp`.
 /-- The vector given in euclidean space by being `1 : 𝕜` at coordinate `i : ι` and `0 : 𝕜` at
 all other coordinates. -/
 def EuclideanSpace.single [DecidableEq ι] (i : ι) (a : 𝕜) : EuclideanSpace 𝕜 ι :=
@@ -310,7 +310,7 @@ theorem EuclideanSpace.edist_single_same [DecidableEq ι] (i : ι) (a b : 𝕜) 
   PiLp.edist_equiv_symm_single_same 2 (fun _ => 𝕜) i a b
 #align euclidean_space.edist_single_same EuclideanSpace.edist_single_same
 
-/-- `euclidean_space.single` forms an orthonormal family. -/
+/-- `EuclideanSpace.single` forms an orthonormal family. -/
 theorem EuclideanSpace.orthonormal_single [DecidableEq ι] :
     Orthonormal 𝕜 fun i : ι => EuclideanSpace.single i (1 : 𝕜) := by
   simp_rw [orthonormal_iff_ite, EuclideanSpace.inner_single_left, map_one, one_mul,
@@ -329,7 +329,7 @@ theorem EuclideanSpace.piLpCongrLeft_single [DecidableEq ι] {ι' : Type _} [Fin
 variable (ι 𝕜 E)
 
 /-- An orthonormal basis on E is an identification of `E` with its dimensional-matching
-`euclidean_space 𝕜 ι`. -/
+`EuclideanSpace 𝕜 ι`. -/
 structure OrthonormalBasis where ofRepr ::
   repr : E ≃ₗᵢ[𝕜] EuclideanSpace 𝕜 ι
 #align orthonormal_basis OrthonormalBasis
@@ -391,7 +391,7 @@ protected theorem orthonormal (b : OrthonormalBasis ι 𝕜 E) : Orthonormal �
       EuclideanSpace.inner_single_left, EuclideanSpace.single_apply, map_one, one_mul]
 #align orthonormal_basis.orthonormal OrthonormalBasis.orthonormal
 
-/-- The `basis ι 𝕜 E` underlying the `orthonormal_basis` -/
+/-- The `Basis ι 𝕜 E` underlying the `OrthonormalBasis` -/
 protected def toBasis (b : OrthonormalBasis ι 𝕜 E) : Basis ι 𝕜 E :=
   Basis.ofEquivFun b.repr.toLinearEquiv
 #align orthonormal_basis.to_basis OrthonormalBasis.toBasis
@@ -443,7 +443,7 @@ protected theorem orthogonalProjection_eq_sum {U : Submodule 𝕜 E} [CompleteSp
     (b.sum_repr (orthogonalProjection U x)).symm
 #align orthonormal_basis.orthogonal_projection_eq_sum OrthonormalBasis.orthogonalProjection_eq_sum
 
-/-- Mapping an orthonormal basis along a `linear_isometry_equiv`. -/
+/-- Mapping an orthonormal basis along a `LinearIsometryEquiv`. -/
 protected def map {G : Type _} [NormedAddCommGroup G] [InnerProductSpace 𝕜 G]
     (b : OrthonormalBasis ι 𝕜 E) (L : E ≃ₗᵢ[𝕜] G) : OrthonormalBasis ι 𝕜 G where
   repr := L.symm.trans b.repr
@@ -521,7 +521,7 @@ protected theorem coe_mk (hon : Orthonormal 𝕜 v) (hsp : ⊤ ≤ Submodule.spa
   classical rw [OrthonormalBasis.mk, _root_.Basis.coe_toOrthonormalBasis, Basis.coe_mk]
 #align orthonormal_basis.coe_mk OrthonormalBasis.coe_mk
 
-/-- Any finite subset of a orthonormal family is an `orthonormal_basis` for its span. -/
+/-- Any finite subset of a orthonormal family is an `OrthonormalBasis` for its span. -/
 protected def span [DecidableEq E] {v' : ι' → E} (h : Orthonormal 𝕜 v') (s : Finset ι') :
     OrthonormalBasis s 𝕜 (span 𝕜 (s.image v' : Set E)) :=
   let e₀' : Basis s 𝕜 _ :=
@@ -571,7 +571,7 @@ protected theorem coe_of_orthogonal_eq_bot_mk (hon : Orthonormal 𝕜 v)
 
 variable [Fintype ι']
 
-/-- `b.reindex (e : ι ≃ ι')` is an `orthonormal_basis` indexed by `ι'` -/
+/-- `b.reindex (e : ι ≃ ι')` is an `OrthonormalBasis` indexed by `ι'` -/
 def reindex (b : OrthonormalBasis ι 𝕜 E) (e : ι ≃ ι') : OrthonormalBasis ι' 𝕜 E :=
   OrthonormalBasis.ofRepr (b.repr.trans (LinearIsometryEquiv.piLpCongrLeft 2 𝕜 𝕜 e))
 #align orthonormal_basis.reindex OrthonormalBasis.reindex
@@ -748,7 +748,7 @@ theorem DirectSum.IsInternal.collectedOrthonormalBasis_mem [DecidableEq ι]
 
 variable [FiniteDimensional 𝕜 E]
 
-/-- In a finite-dimensional `inner_product_space`, any orthonormal subset can be extended to an
+/-- In a finite-dimensional `InnerProductSpace`, any orthonormal subset can be extended to an
 orthonormal basis. -/
 theorem Orthonormal.exists_orthonormalBasis_extension (hv : Orthonormal 𝕜 ((↑) : v → E)) :
     ∃ (u : Finset E)(b : OrthonormalBasis u 𝕜 E), v ⊆ u ∧ ⇑b = ((↑) : u → E) := by
@@ -797,7 +797,7 @@ theorem _root_.exists_orthonormalBasis :
   exact ⟨w, hw, hw''⟩
 #align exists_orthonormal_basis exists_orthonormalBasis
 
-/-- A finite-dimensional `inner_product_space` has an orthonormal basis. -/
+/-- A finite-dimensional `InnerProductSpace` has an orthonormal basis. -/
 irreducible_def stdOrthonormalBasis : OrthonormalBasis (Fin (finrank 𝕜 E)) 𝕜 E := by
   let b := Classical.choose (Classical.choose_spec <| exists_orthonormalBasis 𝕜 E)
   rw [finrank_eq_card_basis b.toBasis]
@@ -823,7 +823,7 @@ open DirectSum
 
 variable {n : ℕ} (hn : finrank 𝕜 E = n) [DecidableEq ι] {V : ι → Submodule 𝕜 E} (hV : IsInternal V)
 
-/-- Exhibit a bijection between `fin n` and the index set of a certain basis of an `n`-dimensional
+/-- Exhibit a bijection between `Fin n` and the index set of a certain basis of an `n`-dimensional
 inner product space `E`.  This should not be accessed directly, but only via the subsequent API. -/
 irreducible_def DirectSum.IsInternal.sigmaOrthonormalBasisIndexEquiv
   (hV' : OrthogonalFamily 𝕜 (fun i => V i) fun i => (V i).subtypeₗᵢ) :
@@ -832,8 +832,8 @@ irreducible_def DirectSum.IsInternal.sigmaOrthonormalBasisIndexEquiv
   Fintype.equivFinOfCardEq <| (FiniteDimensional.finrank_eq_card_basis b.toBasis).symm.trans hn
 #align direct_sum.is_internal.sigma_orthonormal_basis_index_equiv DirectSum.IsInternal.sigmaOrthonormalBasisIndexEquiv
 
-/-- An `n`-dimensional `inner_product_space` equipped with a decomposition as an internal direct
-sum has an orthonormal basis indexed by `fin n` and subordinate to that direct sum. -/
+/-- An `n`-dimensional `InnerProductSpace` equipped with a decomposition as an internal direct
+sum has an orthonormal basis indexed by `Fin n` and subordinate to that direct sum. -/
 irreducible_def DirectSum.IsInternal.subordinateOrthonormalBasis
   (hV' : OrthogonalFamily 𝕜 (fun i => V i) fun i => (V i).subtypeₗᵢ) :
   OrthonormalBasis (Fin n) 𝕜 E :=
@@ -841,8 +841,8 @@ irreducible_def DirectSum.IsInternal.subordinateOrthonormalBasis
     (hV.sigmaOrthonormalBasisIndexEquiv hn hV')
 #align direct_sum.is_internal.subordinate_orthonormal_basis DirectSum.IsInternal.subordinateOrthonormalBasis
 
-/-- An `n`-dimensional `inner_product_space` equipped with a decomposition as an internal direct
-sum has an orthonormal basis indexed by `fin n` and subordinate to that direct sum. This function
+/-- An `n`-dimensional `InnerProductSpace` equipped with a decomposition as an internal direct
+sum has an orthonormal basis indexed by `Fin n` and subordinate to that direct sum. This function
 provides the mapping by which it is subordinate. -/
 irreducible_def DirectSum.IsInternal.subordinateOrthonormalBasisIndex (a : Fin n)
   (hV' : OrthogonalFamily 𝕜 (fun i => V i) fun i => (V i).subtypeₗᵢ) : ι :=
@@ -850,7 +850,7 @@ irreducible_def DirectSum.IsInternal.subordinateOrthonormalBasisIndex (a : Fin n
 #align direct_sum.is_internal.subordinate_orthonormal_basis_index DirectSum.IsInternal.subordinateOrthonormalBasisIndex
 
 /-- The basis constructed in `orthogonal_family.subordinate_orthonormal_basis` is subordinate to
-the `orthogonal_family` in question. -/
+the `OrthogonalFamily` in question. -/
 theorem DirectSum.IsInternal.subordinateOrthonormalBasis_subordinate (a : Fin n)
     (hV' : OrthogonalFamily 𝕜 (fun i => V i) fun i => (V i).subtypeₗᵢ) :
     hV.subordinateOrthonormalBasis hn hV' a ∈ V (hV.subordinateOrthonormalBasisIndex hn a hV') := by
@@ -866,7 +866,7 @@ end FiniteDimensional
 
 /-- Given a natural number `n` one less than the `finrank` of a finite-dimensional inner product
 space, there exists an isometry from the orthogonal complement of a nonzero singleton to
-`euclidean_space 𝕜 (fin n)`. -/
+`EuclideanSpace 𝕜 (Fin n)`. -/
 def OrthonormalBasis.fromOrthogonalSpanSingleton (n : ℕ) [Fact (finrank 𝕜 E = n + 1)] {v : E}
     (hv : v ≠ 0) : OrthonormalBasis (Fin n) 𝕜 (𝕜 ∙ v)ᗮ :=
   -- Poritng note: was `attribute [local instance] fact_finiteDimensional_of_finrank_eq_succ`
@@ -961,7 +961,7 @@ namespace Matrix
 
 variable [Fintype m] [Fintype n] [DecidableEq n]
 
-/-- `matrix.to_lin'` adapted for `euclidean_space 𝕜 _`. -/
+/-- `Matrix.toLin'` adapted for `EuclideanSpace 𝕜 _`. -/
 def toEuclideanLin : Matrix m n 𝕜 ≃ₗ[𝕜] EuclideanSpace 𝕜 n →ₗ[𝕜] EuclideanSpace 𝕜 m :=
   Matrix.toLin' ≪≫ₗ
     LinearEquiv.arrowCongr (PiLp.linearEquiv _ 𝕜 fun _ : n => 𝕜).symm
@@ -981,7 +981,7 @@ theorem piLp_equiv_toEuclideanLin (A : Matrix m n 𝕜) (x : EuclideanSpace 𝕜
   rfl
 #align matrix.pi_Lp_equiv_to_euclidean_lin Matrix.piLp_equiv_toEuclideanLin
 
--- `matrix.to_euclidean_lin` is the same as `matrix.to_lin` applied to `pi_Lp.basis_fun`,
+-- `Matrix.toEuclideanLin` is the same as `Matrix.toLin` applied to `PiLp.basisFun`,
 theorem toEuclideanLin_eq_toLin :
     (toEuclideanLin : Matrix m n 𝕜 ≃ₗ[𝕜] _) =
       Matrix.toLin (PiLp.basisFun _ _ _) (PiLp.basisFun _ _ _) :=

--- a/Mathlib/Analysis/InnerProductSpace/Projection.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Projection.lean
@@ -1269,7 +1269,6 @@ theorem OrthogonalFamily.isInternal_iff_of_isComplete [DecidableEq ι] {V : ι �
     (hV : OrthogonalFamily 𝕜 (fun i => V i) fun i => (V i).subtypeₗᵢ)
     (hc : IsComplete (↑(iSup V) : Set E)) : DirectSum.IsInternal V ↔ (iSup V)ᗮ = ⊥ := by
   haveI : CompleteSpace (↥(iSup V)) := hc.completeSpace_coe
-  classical
   simp only [DirectSum.isInternal_submodule_iff_independent_and_iSup_eq_top, hV.independent,
     true_and_iff, Submodule.orthogonal_eq_bot_iff]
 #align orthogonal_family.is_internal_iff_of_is_complete OrthogonalFamily.isInternal_iff_of_isComplete
@@ -1353,7 +1352,7 @@ theorem maximal_orthonormal_iff_orthogonalComplement_eq_bot (hv : Orthonormal �
       ∃ l ∈ Finsupp.supported 𝕜 𝕜 ((↑) ⁻¹' v : Set u), (Finsupp.total (↥u) E 𝕜 (↑)) l = y := by
       rw [← Finsupp.mem_span_image_iff_total]
       simp [huv, inter_eq_self_of_subset_left, hy]
-    classical exact hu.inner_finsupp_eq_zero hxv' hl
+    exact hu.inner_finsupp_eq_zero hxv' hl
 #align maximal_orthonormal_iff_orthogonal_complement_eq_bot maximal_orthonormal_iff_orthogonalComplement_eq_bot
 
 variable [FiniteDimensional 𝕜 E]
@@ -1363,7 +1362,6 @@ is a basis. -/
 theorem maximal_orthonormal_iff_basis_of_finiteDimensional (hv : Orthonormal 𝕜 ((↑) : v → E)) :
     (∀ (u) (_ : u ⊇ v), Orthonormal 𝕜 ((↑) : u → E) → u = v) ↔
       ∃ b : Basis v 𝕜 E, ⇑b = ((↑) : v → E) := by
-  classical
   haveI := proper_isROrC 𝕜 (span 𝕜 v)
   rw [maximal_orthonormal_iff_orthogonalComplement_eq_bot hv]
   rw [Submodule.orthogonal_eq_bot_iff]


### PR DESCRIPTION
Some theorems in `Analysis.InnerProductSpace.Basic`, such as `Orthonormal.inner_right_finsupp`, accidentally gained  a new `DecidableEq` hypothesis during the port. This removes the hypothesis by using `classical!` instead of `classical` in their proofs.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
