### PR TITLE
[Merged by Bors] - fix: recover `convert` proof in Geometry.Euclidean.Inversion

### DIFF
--- a/Mathlib/Geometry/Euclidean/Inversion.lean
+++ b/Mathlib/Geometry/Euclidean/Inversion.lean
@@ -134,10 +134,7 @@ theorem mul_dist_le_mul_dist_add_mul_dist (a b c d : P) :
     dist_inversion_inversion hc hd, one_pow] at H
   rw [← dist_pos] at hb hc hd
   rw [← div_le_div_right (mul_pos hb (mul_pos hc hd))]
-  calc
-    _ = _ := by field_simp [hb.ne', hc.ne', hd.ne', dist_comm a]; ring
-    _ ≤ _ := H
-    _ = _ := by field_simp [hb.ne', hc.ne', hd.ne', dist_comm a]; ring
+  convert H using 1 <;> (field_simp [hb.ne', hc.ne', hd.ne', dist_comm a]; ring)
 #align euclidean_geometry.mul_dist_le_mul_dist_add_mul_dist EuclideanGeometry.mul_dist_le_mul_dist_add_mul_dist
 
 end EuclideanGeometry


### PR DESCRIPTION
During porting a `convert` proof was converted to `calc`. This switches to a more direct translation of the original.

We need `using` now because `convert` is happy to descend into the expressions and equate `(HMul.hMul : ℝ → ℝ → ℝ) = (HDiv.hDiv : ℝ → ℝ → ℝ)` since these involve the same types. The old `convert` wouldn't do this because it used simp's congr lemmas, and these require that the functions be defeq rather than just equal.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
