### PR TITLE
[Merged by Bors] - perf: replace solveByElim by DFS in TFAE

### DIFF
--- a/test/tfae.lean
+++ b/test/tfae.lean
@@ -18,21 +18,21 @@ axiom qp : Q → P
 
 example : TFAE [P, Q] := by
   tfae_have 1 → 2
-  { exact pq }
+  · exact pq
   tfae_have 2 → 1
-  { exact qp }
+  · exact qp
   tfae_finish
 
 example : TFAE [P, Q] := by
   tfae_have 1 ↔ 2
-  { exact Iff.intro pq qp }
+  · exact Iff.intro pq qp
   tfae_finish
 
 example : TFAE [P, Q] := by
   tfae_have 2 ← 1
-  { exact pq }
+  · exact pq
   tfae_have 1 ← 2
-  { exact qp }
+  · exact qp
   tfae_finish
 
 end two
@@ -48,30 +48,66 @@ axiom rp : R → P
 
 example : TFAE [P, Q, R] := by
   tfae_have 1 → 2
-  { exact pq }
+  · exact pq
   tfae_have 2 → 3
-  { exact qr }
+  · exact qr
   tfae_have 3 → 1
-  { exact rp }
+  · exact rp
   tfae_finish
 
 example : TFAE [P, Q, R] := by
   tfae_have 1 ↔ 2
-  { exact Iff.intro pq (rp ∘ qr) }
+  · exact Iff.intro pq (rp ∘ qr)
   tfae_have 3 ↔ 2
-  { exact Iff.intro (pq ∘ rp) qr }
+  · exact Iff.intro (pq ∘ rp) qr
   tfae_finish
 
 example : TFAE [P, Q, R] := by
   tfae_have 1 → 2
-  { exact pq }
+  · exact pq
   tfae_have 2 → 1
-  { exact rp ∘ qr }
+  · exact rp ∘ qr
   tfae_have 2 ↔ 3
-  { exact Iff.intro qr (pq ∘ rp) }
+  · exact Iff.intro qr (pq ∘ rp)
   tfae_finish
 
 end three
+
+section seven
+
+axiom P₁ : Prop
+axiom P₂ : Prop
+axiom P₃ : Prop
+axiom P₄ : Prop
+axiom P₅ : Prop
+axiom P₆ : Prop
+axiom P₇ : Prop
+axiom h₁ : P₁ ↔ P₂
+axiom h₂ : P₁ → P₆
+axiom h₃ : P₆ → P₇
+axiom h₄ : P₇ → P₄
+axiom h₅ : P₄ → P₅
+axiom h₆ : P₅ → P₃
+axiom h₇ : P₃ → P₂
+
+example : TFAE [P₁, P₂, P₃, P₄, P₅, P₆, P₇] := by
+  tfae_have 1 ↔ 2
+  · exact h₁
+  tfae_have 1 → 6
+  · exact h₂
+  tfae_have 6 → 7
+  · exact h₃
+  tfae_have 7 → 4
+  · exact h₄
+  tfae_have 4 → 5
+  · exact h₅
+  tfae_have 5 → 3
+  · exact h₆
+  tfae_have 3 → 2
+  · exact h₇
+  tfae_finish
+
+end seven
 
 section context
 


### PR DESCRIPTION
This is an alternative to #4154, where rather than replacing the backend of TFAE with the `scc` tactic we use limited forward reasoning to apply `Iff.mp` and `Iff.mpr` to iff hypotheses, and use a manual DFS implementation to find a path through the graph.

(A previous version of this PR used solveByElim, but the implications can have irrelevant structure which confuses `apply` and hence `solve_by_elim` as well.) The implementation is now *very* fast, and takes no measurable time on the test file.