### PR TITLE
[Merged by Bors] - feat: functors which commute with shifts

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -823,6 +823,7 @@ import Mathlib.CategoryTheory.Products.Basic
 import Mathlib.CategoryTheory.Products.Bifunctor
 import Mathlib.CategoryTheory.Quotient
 import Mathlib.CategoryTheory.Shift.Basic
+import Mathlib.CategoryTheory.Shift.CommShift
 import Mathlib.CategoryTheory.Sigma.Basic
 import Mathlib.CategoryTheory.Simple
 import Mathlib.CategoryTheory.SingleObj

--- a/Mathlib/CategoryTheory/Shift/CommShift.lean
+++ b/Mathlib/CategoryTheory/Shift/CommShift.lean
@@ -133,7 +133,7 @@ lemma commShiftIso_zero :
 
 variable {A}
 
-lemma commShiftIso_add (a b : A):
+lemma commShiftIso_add (a b : A) :
     F.commShiftIso (a + b) = CommShift.isoAdd (F.commShiftIso a) (F.commShiftIso b) :=
   CommShift.add a b
 

--- a/Mathlib/CategoryTheory/Shift/CommShift.lean
+++ b/Mathlib/CategoryTheory/Shift/CommShift.lean
@@ -10,7 +10,7 @@ import Mathlib.CategoryTheory.Shift.Basic
 # Functors which commute with shifts
 
 Let `C` and `D` be two categories equipped with shifts by an additive monoid `A`. In this file,
-we define the notion of functor `F : C ⥤ D` which "commute" with these shifts. The associated
+we define the notion of functor `F : C ⥤ D` which "commutes" with these shifts. The associated
 type class is `[F.CommShift A]`. The data consists of commutation isomorphisms
 `F.commShiftIso a : shiftFunctor C a ⋙ F ≅ F ⋙ shiftFunctor D a` for all `a : A`
 which satisfy a compatibility with the addition and the zero. After this was formalised in Lean,
@@ -49,7 +49,7 @@ noncomputable def isoZero : shiftFunctor C (0 : A) ⋙ F ≅ F ⋙ shiftFunctor 
 variable {F A}
 
 /-- If a functor `F : C ⥤ D` is equipped with "commutation isomorphisms" with the
-shifts by `a` and `b`, then there is a commutation isomorphism for the shift by `c` when
+shifts by `a` and `b`, then there is a commutation isomorphism with the shift by `c` when
 `a + b = c`. -/
 @[simps!]
 noncomputable def isoAdd' {a b c : A} (h : a + b = c)
@@ -61,7 +61,7 @@ noncomputable def isoAdd' {a b c : A} (h : a + b = c)
       Functor.associator _ _ _ ≪≫ isoWhiskerLeft _ (shiftFunctorAdd' D _ _ _ h).symm
 
 /-- If a functor `F : C ⥤ D` is equipped with "commutation isomorphisms" with the
-shifts by `a` and `b`, then there is a commutation isomorphism for the shift by `a + b`. -/
+shifts by `a` and `b`, then there is a commutation isomorphism with the shift by `a + b`. -/
 noncomputable def isoAdd {a b : A}
     (e₁ : shiftFunctor C a ⋙ F ≅ F ⋙ shiftFunctor D a)
     (e₂ : shiftFunctor C b ⋙ F ≅ F ⋙ shiftFunctor D b) :
@@ -88,7 +88,7 @@ lemma isoAdd_inv_app  {a b : A}
 
 end CommShift
 
-/-- A functor `F` commute with the shift by a monoid `A` if it is equipped with
+/-- A functor `F` commutes with the shift by a monoid `A` if it is equipped with
 commutation isomorphisms with the shifts by all `a : A`, and these isomorphisms
 satisfy coherence properties with respect to `0 : A` and the addition in `A`. -/
 class CommShift where
@@ -128,17 +128,17 @@ lemma commShiftIso_inv_naturality {X Y : C} (f : X ⟶ Y) (a : A) :
 variable (A)
 
 lemma commShiftIso_zero :
-  F.commShiftIso (0 : A) = CommShift.isoZero F A :=
+    F.commShiftIso (0 : A) = CommShift.isoZero F A :=
   CommShift.zero
 
 variable {A}
 
 lemma commShiftIso_add (a b : A):
-  F.commShiftIso (a + b) = CommShift.isoAdd (F.commShiftIso a) (F.commShiftIso b) :=
+    F.commShiftIso (a + b) = CommShift.isoAdd (F.commShiftIso a) (F.commShiftIso b) :=
   CommShift.add a b
 
 lemma commShiftIso_add' {a b c : A} (h : a + b = c) :
-  F.commShiftIso c = CommShift.isoAdd' h (F.commShiftIso a) (F.commShiftIso b) := by
+    F.commShiftIso c = CommShift.isoAdd' h (F.commShiftIso a) (F.commShiftIso b) := by
   subst h
   simp only [commShiftIso_add, CommShift.isoAdd]
 

--- a/Mathlib/CategoryTheory/Shift/CommShift.lean
+++ b/Mathlib/CategoryTheory/Shift/CommShift.lean
@@ -1,0 +1,158 @@
+/-
+Copyright (c) 2023 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+
+import Mathlib.CategoryTheory.Shift.Basic
+
+/-!
+# Functors which commute with shifts
+
+Let `C` and `D` be two categories equipped with shifts by an additive monoid `A`. In this file,
+we define the notion of functor `F : C ⥤ D` which "commute" with these shifts. The associated
+type class is `[F.CommShift A]`. The data consists of commutation isomorphisms
+`F.commShiftIso a : shiftFunctor C a ⋙ F ≅ F ⋙ shiftFunctor D a` for all `a : A`
+which satisfy a compatibility with the addition and the zero. After this was formalised in Lean,
+it was found that this definition is exactly the definition which appears in Jean-Louis
+Verdier's thesis (I 1.2.3/1.2.4), allthough the language is different. (In Verdier's thesis,
+the shift is not given by a monoidal functor `Discrete A ⥤ C ⥤ C`, but by a fibred
+category `C ⥤ BA`, where `BA` is the category with one object, the endomorphisms of which
+identify to `A`. The choice of a cleavage for this fibered category gives the individual
+shift functors.)
+
+## References
+* [Jean-Louis Verdier, *Des catégories dérivées des catégories abéliennes*][verdier1996]
+
+-/
+
+namespace CategoryTheory
+
+open Category
+
+namespace Functor
+
+variable {C D E : Type _} [Category C] [Category D] [Category E]
+  (F : C ⥤ D) (G : D ⥤ E) (A : Type _) [AddMonoid A]
+  [HasShift C A] [HasShift D A] [HasShift E A]
+
+namespace CommShift
+
+/-- For any functor `F : C ⥤ D`, this is the obvious isomorphism
+`shiftFunctor C (0 : A) ⋙ F ≅ F ⋙ shiftFunctor D (0 : A)` deduced from the
+isomorphisms `shiftFunctorZero` on both categories `C` and `D`. -/
+@[simps!]
+noncomputable def isoZero : shiftFunctor C (0 : A) ⋙ F ≅ F ⋙ shiftFunctor D (0 : A) :=
+  isoWhiskerRight (shiftFunctorZero C A) F ≪≫ F.leftUnitor ≪≫
+     F.rightUnitor.symm ≪≫ isoWhiskerLeft F (shiftFunctorZero D A).symm
+
+variable {F A}
+
+/-- If a functor `F : C ⥤ D` is equipped with "commutation isomorphisms" with the
+shifts by `a` and `b`, then there is a commutation isomorphism for the shift by `c` when
+`a + b = c`. -/
+@[simps!]
+noncomputable def isoAdd' {a b c : A} (h : a + b = c)
+    (e₁ : shiftFunctor C a ⋙ F ≅ F ⋙ shiftFunctor D a)
+    (e₂ : shiftFunctor C b ⋙ F ≅ F ⋙ shiftFunctor D b) :
+    shiftFunctor C c ⋙ F ≅ F ⋙ shiftFunctor D c :=
+  isoWhiskerRight (shiftFunctorAdd' C _ _ _ h) F ≪≫ Functor.associator _ _ _ ≪≫
+    isoWhiskerLeft _ e₂ ≪≫ (Functor.associator _ _ _).symm ≪≫ isoWhiskerRight e₁ _ ≪≫
+      Functor.associator _ _ _ ≪≫ isoWhiskerLeft _ (shiftFunctorAdd' D _ _ _ h).symm
+
+/-- If a functor `F : C ⥤ D` is equipped with "commutation isomorphisms" with the
+shifts by `a` and `b`, then there is a commutation isomorphism for the shift by `a + b`. -/
+noncomputable def isoAdd {a b : A}
+    (e₁ : shiftFunctor C a ⋙ F ≅ F ⋙ shiftFunctor D a)
+    (e₂ : shiftFunctor C b ⋙ F ≅ F ⋙ shiftFunctor D b) :
+    shiftFunctor C (a + b) ⋙ F ≅ F ⋙ shiftFunctor D (a + b) :=
+  CommShift.isoAdd' rfl e₁ e₂
+
+@[simp]
+lemma isoAdd_hom_app  {a b : A}
+    (e₁ : shiftFunctor C a ⋙ F ≅ F ⋙ shiftFunctor D a)
+    (e₂ : shiftFunctor C b ⋙ F ≅ F ⋙ shiftFunctor D b) (X : C) :
+      (CommShift.isoAdd e₁ e₂).hom.app X =
+        F.map ((shiftFunctorAdd C a b).hom.app X) ≫ e₂.hom.app ((shiftFunctor C a).obj X) ≫
+          (shiftFunctor D b).map (e₁.hom.app X) ≫ (shiftFunctorAdd D a b).inv.app (F.obj X) := by
+  simp only [isoAdd, isoAdd'_hom_app, shiftFunctorAdd'_eq_shiftFunctorAdd]
+
+@[simp]
+lemma isoAdd_inv_app  {a b : A}
+    (e₁ : shiftFunctor C a ⋙ F ≅ F ⋙ shiftFunctor D a)
+    (e₂ : shiftFunctor C b ⋙ F ≅ F ⋙ shiftFunctor D b) (X : C) :
+      (CommShift.isoAdd e₁ e₂).inv.app X = (shiftFunctorAdd D a b).hom.app (F.obj X) ≫
+        (shiftFunctor D b).map (e₁.inv.app X) ≫ e₂.inv.app ((shiftFunctor C a).obj X) ≫
+        F.map ((shiftFunctorAdd C a b).inv.app X) := by
+  simp only [isoAdd, isoAdd'_inv_app, shiftFunctorAdd'_eq_shiftFunctorAdd]
+
+end CommShift
+
+/-- A functor `F` commute with the shift by a monoid `A` if it is equipped with
+commutation isomorphisms with the shifts by all `a : A`, and these isomorphisms
+satisfy coherence properties with respect to `0 : A` and the addition in `A`. -/
+class CommShift where
+  iso (a : A) : shiftFunctor C a ⋙ F ≅ F ⋙ shiftFunctor D a
+  zero : iso 0 = CommShift.isoZero F A := by aesop_cat
+  add (a b : A) : iso (a + b) = CommShift.isoAdd (iso a) (iso b) := by aesop_cat
+
+variable {A}
+
+section
+
+variable [F.CommShift A]
+
+/-- If a functor `F` commutes with the shift by `A` (i.e. `[F.CommShift A]`), then
+`F.commShiftIso a` is the given isomorphism `shiftFunctor C a ⋙ F ≅ F ⋙ shiftFunctor D a`. -/
+def commShiftIso (a : A) :
+    shiftFunctor C a ⋙ F ≅ F ⋙ shiftFunctor D a :=
+  CommShift.iso a
+
+-- Note: The following two lemmas are introduced in order to have more proofs work `by simp`.
+-- Indeed, `simp only [(F.commShiftIso a).hom.naturality f]` would almost never work because
+-- of the compositions of functors which appear in both the source and target of
+-- `F.commShiftIso a`. Otherwise, we would be forced to use `erw [NatTrans.naturality]`.
+
+@[reassoc (attr := simp)]
+lemma commShiftIso_hom_naturality {X Y : C} (f : X ⟶ Y) (a : A) :
+    F.map (f⟦a⟧') ≫ (F.commShiftIso a).hom.app Y =
+      (F.commShiftIso a).hom.app X ≫ (F.map f)⟦a⟧' :=
+  (F.commShiftIso a).hom.naturality f
+
+@[reassoc (attr := simp)]
+lemma commShiftIso_inv_naturality {X Y : C} (f : X ⟶ Y) (a : A) :
+    (F.map f)⟦a⟧' ≫ (F.commShiftIso a).inv.app Y =
+      (F.commShiftIso a).inv.app X ≫ F.map (f⟦a⟧') :=
+  (F.commShiftIso a).inv.naturality f
+
+variable (A)
+
+lemma commShiftIso_zero :
+  F.commShiftIso (0 : A) = CommShift.isoZero F A :=
+  CommShift.zero
+
+variable {A}
+
+lemma commShiftIso_add (a b : A):
+  F.commShiftIso (a + b) = CommShift.isoAdd (F.commShiftIso a) (F.commShiftIso b) :=
+  CommShift.add a b
+
+lemma commShiftIso_add' {a b c : A} (h : a + b = c) :
+  F.commShiftIso c = CommShift.isoAdd' h (F.commShiftIso a) (F.commShiftIso b) := by
+  subst h
+  simp only [commShiftIso_add, CommShift.isoAdd]
+
+end
+
+namespace CommShift
+
+variable (C)
+
+instance id : CommShift (𝟭 C) A where
+  iso := fun a => rightUnitor _ ≪≫ (leftUnitor _).symm
+
+end CommShift
+
+end Functor
+
+end CategoryTheory

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -2186,6 +2186,20 @@
   doi           = {10.1215/ijm/1258138061}
 }
 
+@book{            verdier1996,
+  author   = {Verdier, Jean-Louis},
+  title    = {Des cat\'{e}gories d\'{e}riv\'{e}es des cat\'{e}gories ab\'{e}liennes},
+  note     = {With a preface by Luc Illusie,
+              Edited and with a note by Georges Maltsiniotis},
+  journal  = {Ast\'{e}risque},
+  number   = {239},
+  year     = {1996},
+  pages    = {xii+253 pp. (1997)},
+  issn     = {0303-1179},
+  mrclass  = {18E30 (18-03 18E35)},
+  mrnumber = {1453167},
+}
+
 @Book{            wall2018analytic,
   title         = {Analytic Theory of Continued Fractions},
   author        = {Wall, H.S.},
@@ -2227,22 +2241,6 @@
   title         = {Cone Programming},
   url           = {https://ti.inf.ethz.ch/ew/lehre/ApproxSDP09/notes/conelp.pdf}
 }
-
-
-@book{            verdier1996,
-  author   = {Verdier, Jean-Louis},
-  title    = {Des cat\'{e}gories d\'{e}riv\'{e}es des cat\'{e}gories ab\'{e}liennes},
-  note     = {With a preface by Luc Illusie,
-              Edited and with a note by Georges Maltsiniotis},
-  journal  = {Ast\'{e}risque},
-  number   = {239},
-  year     = {1996},
-  pages    = {xii+253 pp. (1997)},
-  issn     = {0303-1179},
-  mrclass  = {18E30 (18-03 18E35)},
-  mrnumber = {1453167},
-}
-
 
 @TechReport{      zaanen1966,
   author        = {Zaanen, A. C.},

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -2186,18 +2186,19 @@
   doi           = {10.1215/ijm/1258138061}
 }
 
-@book{            verdier1996,
-  author   = {Verdier, Jean-Louis},
-  title    = {Des cat\'{e}gories d\'{e}riv\'{e}es des cat\'{e}gories ab\'{e}liennes},
-  note     = {With a preface by Luc Illusie,
-              Edited and with a note by Georges Maltsiniotis},
-  journal  = {Ast\'{e}risque},
-  number   = {239},
-  year     = {1996},
-  pages    = {xii+253 pp. (1997)},
-  issn     = {0303-1179},
-  mrclass  = {18E30 (18-03 18E35)},
-  mrnumber = {1453167},
+@Book{            verdier1996,
+  author        = {Verdier, Jean-Louis},
+  title         = {Des cat\'{e}gories d\'{e}riv\'{e}es des cat\'{e}gories
+                  ab\'{e}liennes},
+  note          = {With a preface by Luc Illusie, Edited and with a note by
+                  Georges Maltsiniotis},
+  journal       = {Ast\'{e}risque},
+  number        = {239},
+  year          = {1996},
+  pages         = {xii+253 pp. (1997)},
+  issn          = {0303-1179},
+  mrclass       = {18E30 (18-03 18E35)},
+  mrnumber      = {1453167}
 }
 
 @Book{            wall2018analytic,

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -2228,6 +2228,22 @@
   url           = {https://ti.inf.ethz.ch/ew/lehre/ApproxSDP09/notes/conelp.pdf}
 }
 
+
+@book{            verdier1996,
+  author   = {Verdier, Jean-Louis},
+  title    = {Des cat\'{e}gories d\'{e}riv\'{e}es des cat\'{e}gories ab\'{e}liennes},
+  note     = {With a preface by Luc Illusie,
+              Edited and with a note by Georges Maltsiniotis},
+  journal  = {Ast\'{e}risque},
+  number   = {239},
+  year     = {1996},
+  pages    = {xii+253 pp. (1997)},
+  issn     = {0303-1179},
+  mrclass  = {18E30 (18-03 18E35)},
+  mrnumber = {1453167},
+}
+
+
 @TechReport{      zaanen1966,
   author        = {Zaanen, A. C.},
   title         = {Lectures on "Riesz Spaces"},


### PR DESCRIPTION
This PR defines the notion of a functor which commutes with shifts, when both the source and target categories are equipped with shifts by a monoid.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
