### PR TITLE
[Merged by Bors] - feat: port Analysis.Calculus.Deriv.Support

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -423,6 +423,7 @@ import Mathlib.Analysis.Calculus.Deriv.Linear
 import Mathlib.Analysis.Calculus.Deriv.Mul
 import Mathlib.Analysis.Calculus.Deriv.Prod
 import Mathlib.Analysis.Calculus.Deriv.Slope
+import Mathlib.Analysis.Calculus.Deriv.Support
 import Mathlib.Analysis.Calculus.FDeriv.Add
 import Mathlib.Analysis.Calculus.FDeriv.Basic
 import Mathlib.Analysis.Calculus.FDeriv.Bilinear

--- a/Mathlib/Analysis/Calculus/Deriv/Support.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Support.lean
@@ -1,0 +1,55 @@
+/-
+Copyright (c) 2022 Floris van Doorn. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Floris van Doorn
+
+! This file was ported from Lean 3 source module analysis.calculus.deriv.support
+! leanprover-community/mathlib commit 3bce8d800a6f2b8f63fe1e588fd76a9ff4adcebe
+! Please do not edit these lines, except to modify the commit id
+! if you have ported upstream changes.
+-/
+import Mathbin.Analysis.Calculus.Deriv.Basic
+
+/-!
+# Support of the derivative of a function
+
+In this file we prove that the (topological) support of a function includes the support of its
+derivative. As a corollary, we show that the derivative of a function with compact support has
+compact support.
+
+## Keywords
+
+derivative, support
+-/
+
+
+universe u v
+
+variable {𝕜 : Type u} [NontriviallyNormedField 𝕜]
+
+variable {E : Type v} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+
+variable {f : 𝕜 → E}
+
+/-! ### Support of derivatives -/
+
+
+section Support
+
+open Function
+
+theorem support_deriv_subset : support (deriv f) ⊆ tsupport f :=
+  by
+  intro x
+  rw [← not_imp_not]
+  intro h2x
+  rw [not_mem_tsupport_iff_eventuallyEq] at h2x
+  exact nmem_support.mpr (h2x.deriv_eq.trans (deriv_const x 0))
+#align support_deriv_subset support_deriv_subset
+
+theorem HasCompactSupport.deriv (hf : HasCompactSupport f) : HasCompactSupport (deriv f) :=
+  hf.mono' support_deriv_subset
+#align has_compact_support.deriv HasCompactSupport.deriv
+
+end Support
+

--- a/Mathlib/Analysis/Calculus/Deriv/Support.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Support.lean
@@ -8,7 +8,7 @@ Authors: Floris van Doorn
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
-import Mathbin.Analysis.Calculus.Deriv.Basic
+import Mathlib.Analysis.Calculus.Deriv.Basic
 
 /-!
 # Support of the derivative of a function
@@ -38,8 +38,7 @@ section Support
 
 open Function
 
-theorem support_deriv_subset : support (deriv f) ⊆ tsupport f :=
-  by
+theorem support_deriv_subset : support (deriv f) ⊆ tsupport f := by
   intro x
   rw [← not_imp_not]
   intro h2x


### PR DESCRIPTION
---

Github shows `Deriv.Basic` as a part of this PR. In fact, the first commit in the history is already in `master`. I don't know how to fix this. Please ignore that file.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
- [x] depends on: #4434

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)