### PR TITLE
[Merged by Bors] - feat: port Analysis.NormedSpace.LpSpace

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -542,6 +542,7 @@ import Mathlib.Analysis.NormedSpace.IndicatorFunction
 import Mathlib.Analysis.NormedSpace.Int
 import Mathlib.Analysis.NormedSpace.IsROrC
 import Mathlib.Analysis.NormedSpace.LinearIsometry
+import Mathlib.Analysis.NormedSpace.LpSpace
 import Mathlib.Analysis.NormedSpace.MStructure
 import Mathlib.Analysis.NormedSpace.MazurUlam
 import Mathlib.Analysis.NormedSpace.Multilinear

--- a/Mathlib/Analysis/NormedSpace/LpSpace.lean
+++ b/Mathlib/Analysis/NormedSpace/LpSpace.lean
@@ -82,7 +82,8 @@ def Memℓp (f : ∀ i, E i) (p : ℝ≥0∞) : Prop :=
 #align mem_ℓp Memℓp
 
 theorem memℓp_zero_iff {f : ∀ i, E i} : Memℓp f 0 ↔ Set.Finite { i | f i ≠ 0 } := by
-  dsimp [Memℓp] <;> rw [if_pos rfl]
+  dsimp [Memℓp]
+  rw [if_pos rfl]
 #align mem_ℓp_zero_iff memℓp_zero_iff
 
 theorem memℓp_zero {f : ∀ i, E i} (hf : Set.Finite { i | f i ≠ 0 }) : Memℓp f 0 :=
@@ -90,7 +91,8 @@ theorem memℓp_zero {f : ∀ i, E i} (hf : Set.Finite { i | f i ≠ 0 }) : Mem�
 #align mem_ℓp_zero memℓp_zero
 
 theorem memℓp_infty_iff {f : ∀ i, E i} : Memℓp f ∞ ↔ BddAbove (Set.range fun i => ‖f i‖) := by
-  dsimp [Memℓp] <;> rw [if_neg ENNReal.top_ne_zero, if_pos rfl]
+  dsimp [Memℓp]
+  rw [if_neg ENNReal.top_ne_zero, if_pos rfl]
 #align mem_ℓp_infty_iff memℓp_infty_iff
 
 theorem memℓp_infty {f : ∀ i, E i} (hf : BddAbove (Set.range fun i => ‖f i‖)) : Memℓp f ∞ :=
@@ -101,24 +103,24 @@ theorem memℓp_gen_iff (hp : 0 < p.toReal) {f : ∀ i, E i} :
     Memℓp f p ↔ Summable fun i => ‖f i‖ ^ p.toReal := by
   rw [ENNReal.toReal_pos_iff] at hp
   dsimp [Memℓp]
-  rw [if_neg hp.1.ne', if_neg hp.2.Ne]
+  rw [if_neg hp.1.ne', if_neg hp.2.ne]
 #align mem_ℓp_gen_iff memℓp_gen_iff
 
 theorem memℓp_gen {f : ∀ i, E i} (hf : Summable fun i => ‖f i‖ ^ p.toReal) : Memℓp f p := by
   rcases p.trichotomy with (rfl | rfl | hp)
   · apply memℓp_zero
-    have H : Summable fun i : α => (1 : ℝ) := by simpa using hf
-    exact (Set.Finite.of_summable_const (by norm_num) H).Subset (Set.subset_univ _)
+    have H : Summable fun _ : α => (1 : ℝ) := by simpa using hf
+    exact (Set.Finite.of_summable_const (by norm_num) H).subset (Set.subset_univ _)
   · apply memℓp_infty
-    have H : Summable fun i : α => (1 : ℝ) := by simpa using hf
-    simpa using ((Set.Finite.of_summable_const (by norm_num) H).image fun i => ‖f i‖).BddAbove
+    have H : Summable fun _ : α => (1 : ℝ) := by simpa using hf
+    simpa using ((Set.Finite.of_summable_const (by norm_num) H).image fun i => ‖f i‖).bddAbove
   exact (memℓp_gen_iff hp).2 hf
 #align mem_ℓp_gen memℓp_gen
 
 theorem memℓp_gen' {C : ℝ} {f : ∀ i, E i} (hf : ∀ s : Finset α, (∑ i in s, ‖f i‖ ^ p.toReal) ≤ C) :
     Memℓp f p := by
   apply memℓp_gen
-  use ⨆ s : Finset α, ∑ i in s, ‖f i‖ ^ p.to_real
+  use ⨆ s : Finset α, ∑ i in s, ‖f i‖ ^ p.toReal
   apply hasSum_of_isLUB_of_nonneg
   · intro b
     exact Real.rpow_nonneg_of_nonneg (norm_nonneg _) _
@@ -134,7 +136,7 @@ theorem zero_memℓp : Memℓp (0 : ∀ i, E i) p := by
     simp
   · apply memℓp_infty
     simp only [norm_zero, Pi.zero_apply]
-    exact bdd_above_singleton.mono Set.range_const_subset
+    exact bddAbove_singleton.mono Set.range_const_subset
   · apply memℓp_gen
     simp [Real.zero_rpow hp.ne', summable_zero]
 #align zero_mem_ℓp zero_memℓp
@@ -163,7 +165,7 @@ theorem neg {f : ∀ i, E i} (hf : Memℓp f p) : Memℓp (-f) p := by
   · apply memℓp_zero
     simp [hf.finite_dsupport]
   · apply memℓp_infty
-    simpa using hf.bdd_above
+    simpa using hf.bddAbove
   · apply memℓp_gen
     simpa using hf.summable hp
 #align mem_ℓp.neg Memℓp.neg
@@ -173,20 +175,19 @@ theorem neg_iff {f : ∀ i, E i} : Memℓp (-f) p ↔ Memℓp f p :=
   ⟨fun h => neg_neg f ▸ h.neg, Memℓp.neg⟩
 #align mem_ℓp.neg_iff Memℓp.neg_iff
 
-/- ./././Mathport/Syntax/Translate/Basic.lean:635:2: warning: expanding binder collection (i «expr ∉ » hfq.finite_dsupport.to_finset) -/
 theorem of_exponent_ge {p q : ℝ≥0∞} {f : ∀ i, E i} (hfq : Memℓp f q) (hpq : q ≤ p) : Memℓp f p := by
   rcases ENNReal.trichotomy₂ hpq with
     (⟨rfl, rfl⟩ | ⟨rfl, rfl⟩ | ⟨rfl, hp⟩ | ⟨rfl, rfl⟩ | ⟨hq, rfl⟩ | ⟨hq, hp, hpq'⟩)
   · exact hfq
   · apply memℓp_infty
-    obtain ⟨C, hC⟩ := (hfq.finite_dsupport.image fun i => ‖f i‖).BddAbove
+    obtain ⟨C, hC⟩ := (hfq.finite_dsupport.image fun i => ‖f i‖).bddAbove
     use max 0 C
     rintro x ⟨i, rfl⟩
     by_cases hi : f i = 0
     · simp [hi]
     · exact (hC ⟨i, hi, rfl⟩).trans (le_max_right _ _)
   · apply memℓp_gen
-    have : ∀ (i) (_ : i ∉ hfq.finite_dsupport.to_finset), ‖f i‖ ^ p.to_real = 0 := by
+    have : ∀ (i) (_ : i ∉ hfq.finite_dsupport.toFinset), ‖f i‖ ^ p.toReal = 0 := by
       intro i hi
       have : f i = 0 := by simpa using hi
       simp [this, Real.zero_rpow hp.ne']
@@ -194,21 +195,21 @@ theorem of_exponent_ge {p q : ℝ≥0∞} {f : ∀ i, E i} (hfq : Memℓp f q) (
   · exact hfq
   · apply memℓp_infty
     obtain ⟨A, hA⟩ := (hfq.summable hq).tendsto_cofinite_zero.bddAbove_range_of_cofinite
-    use A ^ q.to_real⁻¹
+    use A ^ q.toReal⁻¹
     rintro x ⟨i, rfl⟩
-    have : 0 ≤ ‖f i‖ ^ q.to_real := Real.rpow_nonneg_of_nonneg (norm_nonneg _) _
+    have : 0 ≤ ‖f i‖ ^ q.toReal := Real.rpow_nonneg_of_nonneg (norm_nonneg _) _
     simpa [← Real.rpow_mul, mul_inv_cancel hq.ne'] using
       Real.rpow_le_rpow this (hA ⟨i, rfl⟩) (inv_nonneg.mpr hq.le)
   · apply memℓp_gen
     have hf' := hfq.summable hq
     refine' summable_of_norm_bounded_eventually _ hf' (@Set.Finite.subset _ { i | 1 ≤ ‖f i‖ } _ _ _)
-    · have H : { x : α | 1 ≤ ‖f x‖ ^ q.to_real }.Finite := by
+    · have H : { x : α | 1 ≤ ‖f x‖ ^ q.toReal }.Finite := by
         simpa using
           eventually_lt_of_tendsto_lt (by norm_num : (0 : ℝ) < 1) hf'.tendsto_cofinite_zero
       exact H.subset fun i hi => Real.one_le_rpow hi hq.le
-    · show ∀ i, ¬|‖f i‖ ^ p.to_real| ≤ ‖f i‖ ^ q.to_real → 1 ≤ ‖f i‖
+    · show ∀ i, ¬|‖f i‖ ^ p.toReal| ≤ ‖f i‖ ^ q.toReal → 1 ≤ ‖f i‖
       intro i hi
-      have : 0 ≤ ‖f i‖ ^ p.to_real := Real.rpow_nonneg_of_nonneg (norm_nonneg _) p.to_real
+      have : 0 ≤ ‖f i‖ ^ p.toReal := Real.rpow_nonneg_of_nonneg (norm_nonneg _) p.toReal
       simp only [abs_of_nonneg, this] at hi
       contrapose! hi
       exact Real.rpow_le_rpow_of_exponent_ge' (norm_nonneg _) hi.le hq.le hpq'
@@ -217,30 +218,30 @@ theorem of_exponent_ge {p q : ℝ≥0∞} {f : ∀ i, E i} (hfq : Memℓp f q) (
 theorem add {f g : ∀ i, E i} (hf : Memℓp f p) (hg : Memℓp g p) : Memℓp (f + g) p := by
   rcases p.trichotomy with (rfl | rfl | hp)
   · apply memℓp_zero
-    refine' (hf.finite_dsupport.union hg.finite_dsupport).Subset fun i => _
+    refine' (hf.finite_dsupport.union hg.finite_dsupport).subset fun i => _
     simp only [Pi.add_apply, Ne.def, Set.mem_union, Set.mem_setOf_eq]
     contrapose!
     rintro ⟨hf', hg'⟩
     simp [hf', hg']
   · apply memℓp_infty
-    obtain ⟨A, hA⟩ := hf.bdd_above
-    obtain ⟨B, hB⟩ := hg.bdd_above
+    obtain ⟨A, hA⟩ := hf.bddAbove
+    obtain ⟨B, hB⟩ := hg.bddAbove
     refine' ⟨A + B, _⟩
     rintro a ⟨i, rfl⟩
     exact le_trans (norm_add_le _ _) (add_le_add (hA ⟨i, rfl⟩) (hB ⟨i, rfl⟩))
   apply memℓp_gen
-  let C : ℝ := if p.to_real < 1 then 1 else 2 ^ (p.to_real - 1)
+  let C : ℝ := if p.toReal < 1 then 1 else 2 ^ (p.toReal - 1)
   refine'
     summable_of_nonneg_of_le _ (fun i => _) (((hf.summable hp).add (hg.summable hp)).mul_left C)
-  · exact fun b => Real.rpow_nonneg_of_nonneg (norm_nonneg (f b + g b)) p.to_real
+  · exact fun b => Real.rpow_nonneg_of_nonneg (norm_nonneg (f b + g b)) p.toReal
   · refine' (Real.rpow_le_rpow (norm_nonneg _) (norm_add_le _ _) hp.le).trans _
-    dsimp [C]
-    split_ifs with h h
+    dsimp only
+    split_ifs with h
     · simpa using NNReal.coe_le_coe.2 (NNReal.rpow_add_le_add_rpow ‖f i‖₊ ‖g i‖₊ hp.le h.le)
     · let F : Fin 2 → ℝ≥0 := ![‖f i‖₊, ‖g i‖₊]
       have : ∀ i, (0 : ℝ) ≤ F i := fun i => (F i).coe_nonneg
       simp only [not_lt] at h
-      simpa [F, Fin.sum_univ_succ] using
+      simpa [Fin.sum_univ_succ] using
         Real.rpow_sum_le_const_mul_sum_rpow_of_nonneg (Finset.univ : Finset (Fin 2)) h fun i _ =>
           (F i).coe_nonneg
 #align mem_ℓp.add Memℓp.add
@@ -269,13 +270,13 @@ theorem const_smul {f : ∀ i, E i} (hf : Memℓp f p) (c : 𝕜) : Memℓp (c �
   · apply memℓp_zero
     refine' hf.finite_dsupport.subset fun i => (_ : ¬c • f i = 0 → ¬f i = 0)
     exact not_imp_not.mpr fun hf' => hf'.symm ▸ smul_zero c
-  · obtain ⟨A, hA⟩ := hf.bdd_above
+  · obtain ⟨A, hA⟩ := hf.bddAbove
     refine' memℓp_infty ⟨‖c‖ * A, _⟩
     rintro a ⟨i, rfl⟩
     refine' (norm_smul_le _ _).trans _
     exact mul_le_mul_of_nonneg_left (hA ⟨i, rfl⟩) (norm_nonneg c)
   · apply memℓp_gen
-    have := (hf.summable hp).mul_left (↑(‖c‖₊ ^ p.to_real) : ℝ)
+    have := (hf.summable hp).mul_left (↑(‖c‖₊ ^ p.toReal) : ℝ)
     simp_rw [← coe_nnnorm, ← NNReal.coe_rpow, ← NNReal.coe_mul, NNReal.summable_coe, ←
       NNReal.mul_rpow] at this⊢
     refine' NNReal.summable_of_le _ this
@@ -284,7 +285,7 @@ theorem const_smul {f : ∀ i, E i} (hf : Memℓp f p) (c : 𝕜) : Memℓp (c �
 #align mem_ℓp.const_smul Memℓp.const_smul
 
 theorem const_mul {f : α → 𝕜} (hf : Memℓp f p) (c : 𝕜) : Memℓp (fun x => c * f x) p :=
-  @Memℓp.const_smul α (fun i => 𝕜) _ _ 𝕜 _ _ (fun i => by infer_instance) _ hf c
+  @Memℓp.const_smul α (fun _ => 𝕜) _ _ 𝕜 _ _ (fun i => by infer_instance) _ hf c
 #align mem_ℓp.const_mul Memℓp.const_mul
 
 end BoundedSMul
@@ -305,10 +306,12 @@ with the normed group topology we will later equip it with.)
 We choose to deal with this issue by making a type synonym for `Π i, E i` rather than for the `lp`
 subgroup itself, because this allows all the spaces `lp E p` (for varying `p`) to be subgroups of
 the same ambient group, which permits lemma statements like `lp.monotone` (below). -/
-@[nolint unused_arguments]
+@[nolint unusedArguments]
 def PreLp (E : α → Type _) [∀ i, NormedAddCommGroup (E i)] : Type _ :=
-  ∀ i, E i deriving AddCommGroup
+  ∀ i, E i --deriving AddCommGroup
 #align pre_lp PreLp
+
+instance : AddCommGroup (PreLp E) := by unfold PreLp; infer_instance
 
 instance PreLp.unique [IsEmpty α] : Unique (PreLp E) :=
   Pi.uniqueOfIsEmpty E
@@ -318,14 +321,14 @@ instance PreLp.unique [IsEmpty α] : Unique (PreLp E) :=
 def lp (E : α → Type _) [∀ i, NormedAddCommGroup (E i)] (p : ℝ≥0∞) : AddSubgroup (PreLp E) where
   carrier := { f | Memℓp f p }
   zero_mem' := zero_memℓp
-  add_mem' f g := Memℓp.add
-  neg_mem' f := Memℓp.neg
+  add_mem' := Memℓp.add
+  neg_mem' := Memℓp.neg
 #align lp lp
 
 namespace lp
 
 instance : Coe (lp E p) (∀ i, E i) :=
-  coeSubtype
+  ⟨Subtype.val⟩ -- Porting note: Originally `coeSubtype`
 
 instance : CoeFun (lp E p) fun _ => ∀ i, E i :=
   ⟨fun f => ((f : ∀ i, E i) : ∀ i, E i)⟩
@@ -343,12 +346,12 @@ theorem eq_zero' [IsEmpty α] (f : lp E p) : f = 0 :=
   Subsingleton.elim f 0
 #align lp.eq_zero' lp.eq_zero'
 
-protected theorem monotone {p q : ℝ≥0∞} (hpq : q ≤ p) : lp E q ≤ lp E p := fun f hf =>
-  Memℓp.of_exponent_ge hf hpq
+protected theorem monotone {p q : ℝ≥0∞} (hpq : q ≤ p) : lp E q ≤ lp E p :=
+  fun _ hf => Memℓp.of_exponent_ge hf hpq
 #align lp.monotone lp.monotone
 
 protected theorem memℓp (f : lp E p) : Memℓp f p :=
-  f.Prop
+  f.prop
 #align lp.mem_ℓp lp.memℓp
 
 variable (E p)
@@ -385,9 +388,11 @@ theorem coeFn_sub (f g : lp E p) : ⇑(f - g) = f - g :=
   rfl
 #align lp.coe_fn_sub lp.coeFn_sub
 
-instance : Norm (lp E p)
-    where norm f :=
-    if hp : p = 0 then by subst hp <;> exact (lp.memℓp f).finite_dsupport.toFinset.card
+instance : Norm (lp E p) where
+  norm f :=
+    if hp : p = 0 then by
+      subst hp
+      exact ((lp.memℓp f).finite_dsupport.toFinset.card : ℝ)
     else if p = ∞ then ⨆ i, ‖f i‖ else (∑' i, ‖f i‖ ^ p.toReal) ^ (1 / p.toReal)
 
 theorem norm_eq_card_dsupport (f : lp E 0) : ‖f‖ = (lp.memℓp f).finite_dsupport.toFinset.card :=
@@ -408,7 +413,7 @@ theorem norm_eq_tsum_rpow (hp : 0 < p.toReal) (f : lp E p) :
     ‖f‖ = (∑' i, ‖f i‖ ^ p.toReal) ^ (1 / p.toReal) := by
   dsimp [norm]
   rw [ENNReal.toReal_pos_iff] at hp
-  rw [dif_neg hp.1.ne', if_neg hp.2.Ne]
+  rw [dif_neg hp.1.ne', if_neg hp.2.ne]
 #align lp.norm_eq_tsum_rpow lp.norm_eq_tsum_rpow
 
 theorem norm_rpow_eq_tsum (hp : 0 < p.toReal) (f : lp E p) :
@@ -418,15 +423,14 @@ theorem norm_rpow_eq_tsum (hp : 0 < p.toReal) (f : lp E p) :
   apply tsum_nonneg
   intro i
   calc
-    (0 : ℝ) = 0 ^ p.to_real := by rw [Real.zero_rpow hp.ne']
+    (0 : ℝ) = 0 ^ p.toReal := by rw [Real.zero_rpow hp.ne']
     _ ≤ _ := Real.rpow_le_rpow rfl.le (norm_nonneg (f i)) hp.le
-    
 #align lp.norm_rpow_eq_tsum lp.norm_rpow_eq_tsum
 
 theorem hasSum_norm (hp : 0 < p.toReal) (f : lp E p) :
     HasSum (fun i => ‖f i‖ ^ p.toReal) (‖f‖ ^ p.toReal) := by
   rw [norm_rpow_eq_tsum hp]
-  exact ((lp.memℓp f).Summable hp).HasSum
+  exact ((lp.memℓp f).summable hp).hasSum
 #align lp.has_sum_norm lp.hasSum_norm
 
 theorem norm_nonneg' (f : lp E p) : 0 ≤ ‖f‖ := by
@@ -448,7 +452,7 @@ theorem norm_zero : ‖(0 : lp E p)‖ = 0 := by
   · simp [lp.norm_eq_card_dsupport]
   · simp [lp.norm_eq_csupr]
   · rw [lp.norm_eq_tsum_rpow hp]
-    have hp' : 1 / p.to_real ≠ 0 := one_div_ne_zero hp.ne'
+    have hp' : 1 / p.toReal ≠ 0 := one_div_ne_zero hp.ne'
     simpa [Real.zero_rpow hp.ne'] using Real.zero_rpow hp'
 #align lp.norm_zero lp.norm_zero
 
@@ -466,18 +470,19 @@ theorem norm_eq_zero_iff {f : lp E p} : ‖f‖ = 0 ↔ f = 0 := by
       ext i
       have : ‖f i‖ = 0 := le_antisymm (H.1 ⟨i, rfl⟩) (norm_nonneg _)
       simpa using this
-    · have hf : HasSum (fun i : α => ‖f i‖ ^ p.to_real) 0 := by
+    · have hf : HasSum (fun i : α => ‖f i‖ ^ p.toReal) 0 := by
         have := lp.hasSum_norm hp f
         rwa [h, Real.zero_rpow hp.ne'] at this
-      have : ∀ i, 0 ≤ ‖f i‖ ^ p.to_real := fun i => Real.rpow_nonneg_of_nonneg (norm_nonneg _) _
+      have : ∀ i, 0 ≤ ‖f i‖ ^ p.toReal := fun i => Real.rpow_nonneg_of_nonneg (norm_nonneg _) _
       rw [hasSum_zero_iff_of_nonneg this] at hf
       ext i
-      have : f i = 0 ∧ p.to_real ≠ 0 := by
+      have : f i = 0 ∧ p.toReal ≠ 0 := by
         simpa [Real.rpow_eq_zero_iff_of_nonneg (norm_nonneg (f i))] using congr_fun hf i
       exact this.1
 #align lp.norm_eq_zero_iff lp.norm_eq_zero_iff
 
-theorem eq_zero_iff_coeFn_eq_zero {f : lp E p} : f = 0 ↔ ⇑f = 0 := by rw [lp.ext_iff, coe_fn_zero]
+theorem eq_zero_iff_coeFn_eq_zero {f : lp E p} : f = 0 ↔ ⇑f = 0 := by
+  rw [lp.ext_iff, coeFn_zero]
 #align lp.eq_zero_iff_coe_fn_eq_zero lp.eq_zero_iff_coeFn_eq_zero
 
 @[simp]
@@ -488,13 +493,13 @@ theorem norm_neg ⦃f : lp E p⦄ : ‖-f‖ = ‖f‖ := by
     · simp [lp.eq_zero' f]
     apply (lp.isLUB_norm (-f)).unique
     simpa using lp.isLUB_norm f
-  · suffices ‖-f‖ ^ p.to_real = ‖f‖ ^ p.to_real by
+  · suffices ‖-f‖ ^ p.toReal = ‖f‖ ^ p.toReal by
       exact Real.rpow_left_injOn hp.ne' (norm_nonneg' _) (norm_nonneg' _) this
     apply (lp.hasSum_norm hp (-f)).unique
     simpa using lp.hasSum_norm hp f
 #align lp.norm_neg lp.norm_neg
 
-instance [hp : Fact (1 ≤ p)] : NormedAddCommGroup (lp E p) :=
+instance normedAddCommGroup [hp : Fact (1 ≤ p)] : NormedAddCommGroup (lp E p) :=
   AddGroupNorm.toNormedAddCommGroup
     { toFun := norm
       map_zero' := norm_zero
@@ -510,7 +515,7 @@ instance [hp : Fact (1 ≤ p)] : NormedAddCommGroup (lp E p) :=
               (add_mem_upperBounds_add (lp.isLUB_norm f).1 (lp.isLUB_norm g).1
                 ⟨_, _, ⟨i, rfl⟩, ⟨i, rfl⟩, rfl⟩)
           exact norm_add_le (f i) (g i)
-        · have hp'' : 0 < p.to_real := zero_lt_one.trans_le hp'
+        · have hp'' : 0 < p.toReal := zero_lt_one.trans_le hp'
           have hf₁ : ∀ i, 0 ≤ ‖f i‖ := fun i => norm_nonneg _
           have hg₁ : ∀ i, 0 ≤ ‖g i‖ := fun i => norm_nonneg _
           have hf₂ := lp.hasSum_norm hp'' f
@@ -556,24 +561,24 @@ section ComparePointwise
 theorem norm_apply_le_norm (hp : p ≠ 0) (f : lp E p) (i : α) : ‖f i‖ ≤ ‖f‖ := by
   rcases eq_or_ne p ∞ with (rfl | hp')
   · haveI : Nonempty α := ⟨i⟩
-    exact (is_lub_norm f).1 ⟨i, rfl⟩
-  have hp'' : 0 < p.to_real := ENNReal.toReal_pos hp hp'
-  have : ∀ i, 0 ≤ ‖f i‖ ^ p.to_real := fun i => Real.rpow_nonneg_of_nonneg (norm_nonneg _) _
+    exact (isLUB_norm f).1 ⟨i, rfl⟩
+  have hp'' : 0 < p.toReal := ENNReal.toReal_pos hp hp'
+  have : ∀ i, 0 ≤ ‖f i‖ ^ p.toReal := fun i => Real.rpow_nonneg_of_nonneg (norm_nonneg _) _
   rw [← Real.rpow_le_rpow_iff (norm_nonneg _) (norm_nonneg' _) hp'']
-  convert le_hasSum (has_sum_norm hp'' f) i fun i hi => this i
+  convert le_hasSum (hasSum_norm hp'' f) i fun i _ => this i
 #align lp.norm_apply_le_norm lp.norm_apply_le_norm
 
 theorem sum_rpow_le_norm_rpow (hp : 0 < p.toReal) (f : lp E p) (s : Finset α) :
     (∑ i in s, ‖f i‖ ^ p.toReal) ≤ ‖f‖ ^ p.toReal := by
   rw [lp.norm_rpow_eq_tsum hp f]
-  have : ∀ i, 0 ≤ ‖f i‖ ^ p.to_real := fun i => Real.rpow_nonneg_of_nonneg (norm_nonneg _) _
-  refine' sum_le_tsum _ (fun i hi => this i) _
-  exact (lp.memℓp f).Summable hp
+  have : ∀ i, 0 ≤ ‖f i‖ ^ p.toReal := fun i => Real.rpow_nonneg_of_nonneg (norm_nonneg _) _
+  refine' sum_le_tsum _ (fun i _ => this i) _
+  exact (lp.memℓp f).summable hp
 #align lp.sum_rpow_le_norm_rpow lp.sum_rpow_le_norm_rpow
 
 theorem norm_le_of_forall_le' [Nonempty α] {f : lp E ∞} (C : ℝ) (hCf : ∀ i, ‖f i‖ ≤ C) : ‖f‖ ≤ C :=
   by
-  refine' (is_lub_norm f).2 _
+  refine' (isLUB_norm f).2 _
   rintro - ⟨i, rfl⟩
   exact hCf i
 #align lp.norm_le_of_forall_le' lp.norm_le_of_forall_le'
@@ -593,7 +598,7 @@ theorem norm_le_of_tsum_le (hp : 0 < p.toReal) {C : ℝ} (hC : 0 ≤ C) {f : lp 
 
 theorem norm_le_of_forall_sum_le (hp : 0 < p.toReal) {C : ℝ} (hC : 0 ≤ C) {f : lp E p}
     (hf : ∀ s : Finset α, (∑ i in s, ‖f i‖ ^ p.toReal) ≤ C ^ p.toReal) : ‖f‖ ≤ C :=
-  norm_le_of_tsum_le hp hC (tsum_le_of_sum_le ((lp.memℓp f).Summable hp) hf)
+  norm_le_of_tsum_le hp hC (tsum_le_of_sum_le ((lp.memℓp f).summable hp) hf)
 #align lp.norm_le_of_forall_sum_le lp.norm_le_of_forall_sum_le
 
 end ComparePointwise
@@ -628,7 +633,7 @@ variable (E p 𝕜)
 
 /-- The `𝕜`-submodule of elements of `Π i : α, E i` whose `lp` norm is finite.  This is `lp E p`,
 with extra structure. -/
-def lpSubmodule : Submodule 𝕜 (PreLp E) :=
+def _root_.lpSubmodule : Submodule 𝕜 (PreLp E) :=
   { lp E p with smul_mem' := fun c f hf => by simpa using mem_lp_const_smul c ⟨f, hf⟩ }
 #align lp_submodule lpSubmodule
 
@@ -639,7 +644,7 @@ theorem coe_lpSubmodule : (lpSubmodule E p 𝕜).toAddSubgroup = lp E p :=
 #align lp.coe_lp_submodule lp.coe_lpSubmodule
 
 instance : Module 𝕜 (lp E p) :=
-  { (lpSubmodule E p 𝕜).Module with }
+  { (lpSubmodule E p 𝕜).module with }
 
 @[simp]
 theorem coeFn_smul (c : 𝕜) (f : lp E p) : ⇑(c • f) = c • f :=
@@ -647,13 +652,13 @@ theorem coeFn_smul (c : 𝕜) (f : lp E p) : ⇑(c • f) = c • f :=
 #align lp.coe_fn_smul lp.coeFn_smul
 
 instance [∀ i, SMulCommClass 𝕜' 𝕜 (E i)] : SMulCommClass 𝕜' 𝕜 (lp E p) :=
-  ⟨fun r c f => Subtype.ext <| smul_comm _ _ _⟩
+  ⟨fun _ _ _ => Subtype.ext <| smul_comm _ _ _⟩
 
 instance [SMul 𝕜' 𝕜] [∀ i, IsScalarTower 𝕜' 𝕜 (E i)] : IsScalarTower 𝕜' 𝕜 (lp E p) :=
-  ⟨fun r c f => Subtype.ext <| smul_assoc _ _ _⟩
+  ⟨fun _ _ _ => Subtype.ext <| smul_assoc _ _ _⟩
 
 instance [∀ i, Module 𝕜ᵐᵒᵖ (E i)] [∀ i, IsCentralScalar 𝕜 (E i)] : IsCentralScalar 𝕜 (lp E p) :=
-  ⟨fun r f => Subtype.ext <| op_smul_eq_smul _ _⟩
+  ⟨fun _ _ => Subtype.ext <| op_smul_eq_smul _ _⟩
 
 theorem norm_const_smul_le (hp : p ≠ 0) (c : 𝕜) (f : lp E p) : ‖c • f‖ ≤ ‖c‖ * ‖f‖ := by
   rcases p.trichotomy with (rfl | rfl | hp)
@@ -671,12 +676,12 @@ theorem norm_const_smul_le (hp : p ≠ 0) (c : 𝕜) (f : lp E p) : ‖c • f�
     exact (norm_smul_le _ _).trans (this a)
   · letI inst : NNNorm (lp E p) := ⟨fun f => ⟨‖f‖, norm_nonneg' _⟩⟩
     have coe_nnnorm : ∀ f : lp E p, ↑‖f‖₊ = ‖f‖ := fun _ => rfl
-    suffices ‖c • f‖₊ ^ p.to_real ≤ (‖c‖₊ * ‖f‖₊) ^ p.to_real by
+    suffices ‖c • f‖₊ ^ p.toReal ≤ (‖c‖₊ * ‖f‖₊) ^ p.toReal by
       rwa [NNReal.rpow_le_rpow_iff hp] at this
     clear_value inst
     rw [NNReal.mul_rpow]
     have hLHS := lp.hasSum_norm hp (c • f)
-    have hRHS := (lp.hasSum_norm hp f).mul_left (‖c‖ ^ p.to_real)
+    have hRHS := (lp.hasSum_norm hp f).mul_left (‖c‖ ^ p.toReal)
     simp_rw [← coe_nnnorm, ← _root_.coe_nnnorm, ← NNReal.coe_rpow, ← NNReal.coe_mul,
       NNReal.hasSum_coe] at hRHS hLHS
     refine' hasSum_mono hLHS hRHS fun i => _
@@ -686,7 +691,8 @@ theorem norm_const_smul_le (hp : p ≠ 0) (c : 𝕜) (f : lp E p) : ‖c • f�
 #align lp.norm_const_smul_le lp.norm_const_smul_le
 
 instance [Fact (1 ≤ p)] : BoundedSMul 𝕜 (lp E p) :=
-  BoundedSMul.of_norm_smul_le <| norm_const_smul_le (zero_lt_one.trans_le <| Fact.out (1 ≤ p)).ne'
+  BoundedSMul.of_norm_smul_le <|
+    norm_const_smul_le (zero_lt_one.trans_le <| Fact.out (p := 1 ≤ p)).ne'
 
 end BoundedSMul
 
@@ -718,22 +724,23 @@ section NormedStarGroup
 
 variable [∀ i, StarAddMonoid (E i)] [∀ i, NormedStarGroup (E i)]
 
-theorem Memℓp.star_mem {f : ∀ i, E i} (hf : Memℓp f p) : Memℓp (star f) p := by
+theorem _root_.Memℓp.star_mem {f : ∀ i, E i} (hf : Memℓp f p) : Memℓp (star f) p := by
   rcases p.trichotomy with (rfl | rfl | hp)
   · apply memℓp_zero
     simp [hf.finite_dsupport]
   · apply memℓp_infty
-    simpa using hf.bdd_above
+    simpa using hf.bddAbove
   · apply memℓp_gen
     simpa using hf.summable hp
 #align mem_ℓp.star_mem Memℓp.star_mem
 
 @[simp]
-theorem Memℓp.star_iff {f : ∀ i, E i} : Memℓp (star f) p ↔ Memℓp f p :=
+theorem _root_.Memℓp.star_iff {f : ∀ i, E i} : Memℓp (star f) p ↔ Memℓp f p :=
   ⟨fun h => star_star f ▸ Memℓp.star_mem h, Memℓp.star_mem⟩
 #align mem_ℓp.star_iff Memℓp.star_iff
 
-instance : Star (lp E p) where unit f := ⟨(star f : ∀ i, E i), f.property.star_mem⟩
+instance : Star (lp E p) where
+  star f := ⟨(star f : ∀ i, E i), f.property.star_mem⟩
 
 @[simp]
 theorem coeFn_star (f : lp E p) : ⇑(star f) = star f :=
@@ -749,8 +756,8 @@ instance : InvolutiveStar (lp E p) where star_involutive x := by ext; simp
 
 instance : StarAddMonoid (lp E p) where star_add f g := ext <| star_add _ _
 
-instance [hp : Fact (1 ≤ p)] : NormedStarGroup (lp E p)
-    where norm_star f := by
+instance [hp : Fact (1 ≤ p)] : NormedStarGroup (lp E p) where
+  norm_star f := by
     rcases p.trichotomy with (rfl | rfl | h)
     · exfalso
       have := ENNReal.toReal_mono ENNReal.zero_ne_top hp.elim
@@ -770,9 +777,10 @@ section NonUnitalNormedRing
 
 variable {I : Type _} {B : I → Type _} [∀ i, NonUnitalNormedRing (B i)]
 
-theorem Memℓp.infty_mul {f g : ∀ i, B i} (hf : Memℓp f ∞) (hg : Memℓp g ∞) : Memℓp (f * g) ∞ := by
+theorem _root_.Memℓp.infty_mul {f g : ∀ i, B i} (hf : Memℓp f ∞) (hg : Memℓp g ∞) :
+    Memℓp (f * g) ∞ := by
   rw [memℓp_infty_iff]
-  obtain ⟨⟨Cf, hCf⟩, ⟨Cg, hCg⟩⟩ := hf.bdd_above, hg.bdd_above
+  obtain ⟨⟨Cf, hCf⟩, ⟨Cg, hCg⟩⟩ := hf.bddAbove, hg.bddAbove
   refine' ⟨Cf * Cg, _⟩
   rintro _ ⟨i, rfl⟩
   calc
@@ -780,7 +788,6 @@ theorem Memℓp.infty_mul {f g : ∀ i, B i} (hf : Memℓp f ∞) (hg : Memℓp 
     _ ≤ Cf * Cg :=
       mul_le_mul (hCf ⟨i, rfl⟩) (hCg ⟨i, rfl⟩) (norm_nonneg _)
         ((norm_nonneg _).trans (hCf ⟨i, rfl⟩))
-    
 #align mem_ℓp.infty_mul Memℓp.infty_mul
 
 instance : Mul (lp B ∞) where mul f g := ⟨(f * g : ∀ i, B i), f.property.infty_mul g.property⟩
@@ -790,11 +797,11 @@ theorem infty_coeFn_mul (f g : lp B ∞) : ⇑(f * g) = f * g :=
   rfl
 #align lp.infty_coe_fn_mul lp.infty_coeFn_mul
 
-instance : NonUnitalRing (lp B ∞) :=
+instance nonUnitalRing : NonUnitalRing (lp B ∞) :=
   Function.Injective.nonUnitalRing lp.hasCoeToFun.coe Subtype.coe_injective (lp.coeFn_zero B ∞)
     lp.coeFn_add infty_coeFn_mul lp.coeFn_neg lp.coeFn_sub (fun _ _ => rfl) fun _ _ => rfl
 
-instance : NonUnitalNormedRing (lp B ∞) :=
+instance nonUnitalNormedRing : NonUnitalNormedRing (lp B ∞) :=
   { lp.normedAddCommGroup with
     norm_mul := fun f g =>
       lp.norm_le_of_forall_le (mul_nonneg (norm_nonneg f) (norm_nonneg g)) fun i =>
@@ -802,18 +809,17 @@ instance : NonUnitalNormedRing (lp B ∞) :=
           ‖(f * g) i‖ ≤ ‖f i‖ * ‖g i‖ := norm_mul_le _ _
           _ ≤ ‖f‖ * ‖g‖ :=
             mul_le_mul (lp.norm_apply_le_norm ENNReal.top_ne_zero f i)
-              (lp.norm_apply_le_norm ENNReal.top_ne_zero g i) (norm_nonneg _) (norm_nonneg _)
-           }
+              (lp.norm_apply_le_norm ENNReal.top_ne_zero g i) (norm_nonneg _) (norm_nonneg _) }
 
 -- we also want a `non_unital_normed_comm_ring` instance, but this has to wait for #13719
 instance infty_isScalarTower {𝕜} [NormedRing 𝕜] [∀ i, Module 𝕜 (B i)] [∀ i, BoundedSMul 𝕜 (B i)]
     [∀ i, IsScalarTower 𝕜 (B i) (B i)] : IsScalarTower 𝕜 (lp B ∞) (lp B ∞) :=
-  ⟨fun r f g => lp.ext <| smul_assoc r (⇑f) ⇑g⟩
+  ⟨fun r f g => lp.ext <| smul_assoc r (⇑f) (⇑g)⟩
 #align lp.infty_is_scalar_tower lp.infty_isScalarTower
 
 instance infty_sMulCommClass {𝕜} [NormedRing 𝕜] [∀ i, Module 𝕜 (B i)] [∀ i, BoundedSMul 𝕜 (B i)]
     [∀ i, SMulCommClass 𝕜 (B i) (B i)] : SMulCommClass 𝕜 (lp B ∞) (lp B ∞) :=
-  ⟨fun r f g => lp.ext <| smul_comm r (⇑f) ⇑g⟩
+  ⟨fun r f g => lp.ext <| smul_comm r (⇑f) (⇑g)⟩
 #align lp.infty_smul_comm_class lp.infty_sMulCommClass
 
 section StarRing
@@ -827,8 +833,8 @@ instance inftyStarRing : StarRing (lp B ∞) :=
     star_mul := fun f g => ext <| star_mul (_ : ∀ i, B i) _ }
 #align lp.infty_star_ring lp.inftyStarRing
 
-instance infty_cstarRing [∀ i, CstarRing (B i)] : CstarRing (lp B ∞)
-    where norm_star_mul_self f := by
+instance infty_cstarRing [∀ i, CstarRing (B i)] : CstarRing (lp B ∞) where
+  norm_star_mul_self f := by
     apply le_antisymm
     · rw [← sq]
       refine' lp.norm_le_of_forall_le (sq_nonneg ‖f‖) fun i => _
@@ -849,13 +855,13 @@ section NormedRing
 
 variable {I : Type _} {B : I → Type _} [∀ i, NormedRing (B i)]
 
-instance PreLp.ring : Ring (PreLp B) :=
+instance _root_.PreLp.ring : Ring (PreLp B) :=
   Pi.ring
 #align pre_lp.ring PreLp.ring
 
 variable [∀ i, NormOneClass (B i)]
 
-theorem one_memℓp_infty : Memℓp (1 : ∀ i, B i) ∞ :=
+theorem _root_.one_memℓp_infty : Memℓp (1 : ∀ i, B i) ∞ :=
   ⟨1, by rintro i ⟨i, rfl⟩; exact norm_one.le⟩
 #align one_mem_ℓp_infty one_memℓp_infty
 
@@ -863,11 +869,11 @@ variable (B)
 
 /-- The `𝕜`-subring of elements of `Π i : α, B i` whose `lp` norm is finite. This is `lp E ∞`,
 with extra structure. -/
-def lpInftySubring : Subring (PreLp B) :=
+def _root_.lpInftySubring : Subring (PreLp B) :=
   { lp B ∞ with
     carrier := { f | Memℓp f ∞ }
     one_mem' := one_memℓp_infty
-    mul_mem' := fun f g hf hg => hf.infty_mul hg }
+    mul_mem' := fun hf hg => hf.infty_mul hg }
 #align lp_infty_subring lpInftySubring
 
 variable {B}
@@ -876,15 +882,15 @@ instance inftyRing : Ring (lp B ∞) :=
   (lpInftySubring B).toRing
 #align lp.infty_ring lp.inftyRing
 
-theorem Memℓp.infty_pow {f : ∀ i, B i} (hf : Memℓp f ∞) (n : ℕ) : Memℓp (f ^ n) ∞ :=
+theorem _root_.Memℓp.infty_pow {f : ∀ i, B i} (hf : Memℓp f ∞) (n : ℕ) : Memℓp (f ^ n) ∞ :=
   (lpInftySubring B).pow_mem hf n
 #align mem_ℓp.infty_pow Memℓp.infty_pow
 
-theorem nat_cast_memℓp_infty (n : ℕ) : Memℓp (n : ∀ i, B i) ∞ :=
+theorem _root_.nat_cast_memℓp_infty (n : ℕ) : Memℓp (n : ∀ i, B i) ∞ :=
   natCast_mem (lpInftySubring B) n
 #align nat_cast_mem_ℓp_infty nat_cast_memℓp_infty
 
-theorem int_cast_memℓp_infty (z : ℤ) : Memℓp (z : ∀ i, B i) ∞ :=
+theorem _root_.int_cast_memℓp_infty (z : ℤ) : Memℓp (z : ∀ i, B i) ∞ :=
   coe_int_mem (lpInftySubring B) z
 #align int_cast_mem_ℓp_infty int_cast_memℓp_infty
 
@@ -908,9 +914,8 @@ theorem infty_coeFn_int_cast (z : ℤ) : ⇑(z : lp B ∞) = z :=
   rfl
 #align lp.infty_coe_fn_int_cast lp.infty_coeFn_int_cast
 
-instance [Nonempty I] : NormOneClass (lp B ∞)
-    where norm_one := by
-    simp_rw [lp.norm_eq_csupr, infty_coe_fn_one, Pi.one_apply, norm_one, ciSup_const]
+instance [Nonempty I] : NormOneClass (lp B ∞) where
+  norm_one := by simp_rw [lp.norm_eq_csupr, infty_coeFn_one, Pi.one_apply, norm_one, ciSup_const]
 
 instance inftyNormedRing : NormedRing (lp B ∞) :=
   { lp.inftyRing, lp.nonUnitalNormedRing with }
@@ -940,26 +945,26 @@ variable {I : Type _} {𝕜 : Type _} {B : I → Type _}
 variable [NormedField 𝕜] [∀ i, NormedRing (B i)] [∀ i, NormedAlgebra 𝕜 (B i)]
 
 /-- A variant of `pi.algebra` that lean can't find otherwise. -/
-instance Pi.algebraOfNormedAlgebra : Algebra 𝕜 (∀ i, B i) :=
-  @Pi.algebra I 𝕜 B _ _ fun i => NormedAlgebra.toAlgebra
+instance _root_.Pi.algebraOfNormedAlgebra : Algebra 𝕜 (∀ i, B i) :=
+  @Pi.algebra I 𝕜 B _ _ fun _ => NormedAlgebra.toAlgebra
 #align pi.algebra_of_normed_algebra Pi.algebraOfNormedAlgebra
 
-instance PreLp.algebra : Algebra 𝕜 (PreLp B) :=
+instance _root_.PreLp.algebra : Algebra 𝕜 (PreLp B) :=
   Pi.algebraOfNormedAlgebra
 #align pre_lp.algebra PreLp.algebra
 
 variable [∀ i, NormOneClass (B i)]
 
-theorem algebraMap_memℓp_infty (k : 𝕜) : Memℓp (algebraMap 𝕜 (∀ i, B i) k) ∞ := by
+theorem _root_.algebraMap_memℓp_infty (k : 𝕜) : Memℓp (algebraMap 𝕜 (∀ i, B i) k) ∞ := by
   rw [Algebra.algebraMap_eq_smul_one]
-  exact (one_mem_ℓp_infty.const_smul k : Memℓp (k • 1 : ∀ i, B i) ∞)
+  exact (one_memℓp_infty.const_smul k : Memℓp (k • 1 : ∀ i, B i) ∞)
 #align algebra_map_mem_ℓp_infty algebraMap_memℓp_infty
 
 variable (𝕜 B)
 
 /-- The `𝕜`-subalgebra of elements of `Π i : α, B i` whose `lp` norm is finite. This is `lp E ∞`,
 with extra structure. -/
-def lpInftySubalgebra : Subalgebra 𝕜 (PreLp B) :=
+def _root_.lpInftySubalgebra : Subalgebra 𝕜 (PreLp B) :=
   { lpInftySubring B with
     carrier := { f | Memℓp f ∞ }
     algebraMap_mem' := algebraMap_memℓp_infty }
@@ -968,7 +973,7 @@ def lpInftySubalgebra : Subalgebra 𝕜 (PreLp B) :=
 variable {𝕜 B}
 
 instance inftyNormedAlgebra : NormedAlgebra 𝕜 (lp B ∞) :=
-  { (lpInftySubalgebra 𝕜 B).Algebra, (lp.normedSpace : NormedSpace 𝕜 (lp B ∞)) with }
+  { (lpInftySubalgebra 𝕜 B).algebra, (lp.normedSpace : NormedSpace 𝕜 (lp B ∞)) with }
 #align lp.infty_normed_algebra lp.inftyNormedAlgebra
 
 end Algebra
@@ -983,7 +988,7 @@ variable [DecidableEq α]
 protected def single (p) (i : α) (a : E i) : lp E p :=
   ⟨fun j => if h : j = i then Eq.ndrec a h.symm else 0, by
     refine' (memℓp_zero _).of_exponent_ge (zero_le p)
-    refine' (Set.finite_singleton i).Subset _
+    refine' (Set.finite_singleton i).subset _
     intro j
     simp only [forall_exists_index, Set.mem_singleton_iff, Ne.def, dite_eq_right_iff,
       Set.mem_setOf_eq, not_forall]
@@ -1026,12 +1031,12 @@ protected theorem single_smul (p) (i : α) (a : E i) (c : 𝕜) :
 /- ./././Mathport/Syntax/Translate/Basic.lean:635:2: warning: expanding binder collection (i «expr ∉ » s) -/
 protected theorem norm_sum_single (hp : 0 < p.toReal) (f : ∀ i, E i) (s : Finset α) :
     ‖∑ i in s, lp.single p i (f i)‖ ^ p.toReal = ∑ i in s, ‖f i‖ ^ p.toReal := by
-  refine' (has_sum_norm hp (∑ i in s, lp.single p i (f i))).unique _
-  simp only [lp.single_apply, coe_fn_sum, Finset.sum_apply, Finset.sum_dite_eq]
-  have h : ∀ (i) (_ : i ∉ s), ‖ite (i ∈ s) (f i) 0‖ ^ p.to_real = 0 := by
+  refine' (hasSum_norm hp (∑ i in s, lp.single p i (f i))).unique _
+  simp only [lp.single_apply, coeFn_sum, Finset.sum_apply, Finset.sum_dite_eq]
+  have h : ∀ (i) (_ : i ∉ s), ‖ite (i ∈ s) (f i) 0‖ ^ p.toReal = 0 := by
     intro i hi
     simp [if_neg hi, Real.zero_rpow hp.ne']
-  have h' : ∀ i ∈ s, ‖f i‖ ^ p.to_real = ‖ite (i ∈ s) (f i) 0‖ ^ p.to_real := by
+  have h' : ∀ i ∈ s, ‖f i‖ ^ p.toReal = ‖ite (i ∈ s) (f i) 0‖ ^ p.toReal := by
     intro i hi
     rw [if_pos hi]
   simpa [Finset.sum_congr rfl h'] using hasSum_sum_of_ne_finset_zero h
@@ -1047,17 +1052,17 @@ protected theorem norm_single (hp : 0 < p.toReal) (f : ∀ i, E i) (i : α) :
 protected theorem norm_sub_norm_compl_sub_single (hp : 0 < p.toReal) (f : lp E p) (s : Finset α) :
     ‖f‖ ^ p.toReal - ‖f - ∑ i in s, lp.single p i (f i)‖ ^ p.toReal = ∑ i in s, ‖f i‖ ^ p.toReal :=
   by
-  refine' ((has_sum_norm hp f).sub (has_sum_norm hp (f - ∑ i in s, lp.single p i (f i)))).unique _
-  let F : α → ℝ := fun i => ‖f i‖ ^ p.to_real - ‖(f - ∑ i in s, lp.single p i (f i)) i‖ ^ p.to_real
+  refine' ((hasSum_norm hp f).sub (hasSum_norm hp (f - ∑ i in s, lp.single p i (f i)))).unique _
+  let F : α → ℝ := fun i => ‖f i‖ ^ p.toReal - ‖(f - ∑ i in s, lp.single p i (f i)) i‖ ^ p.toReal
   have hF : ∀ (i) (_ : i ∉ s), F i = 0 := by
     intro i hi
-    suffices ‖f i‖ ^ p.to_real - ‖f i - ite (i ∈ s) (f i) 0‖ ^ p.to_real = 0 by
-      simpa only [F, coe_fn_sum, lp.single_apply, coe_fn_sub, Pi.sub_apply, Finset.sum_apply,
+    suffices ‖f i‖ ^ p.toReal - ‖f i - ite (i ∈ s) (f i) 0‖ ^ p.toReal = 0 by
+      simpa only [coeFn_sum, lp.single_apply, coeFn_sub, Pi.sub_apply, Finset.sum_apply,
         Finset.sum_dite_eq] using this
     simp only [if_neg hi, sub_zero, sub_self]
-  have hF' : ∀ i ∈ s, F i = ‖f i‖ ^ p.to_real := by
+  have hF' : ∀ i ∈ s, F i = ‖f i‖ ^ p.toReal := by
     intro i hi
-    simp only [F, coe_fn_sum, lp.single_apply, if_pos hi, sub_self, eq_self_iff_true, coe_fn_sub,
+    simp only [coeFn_sum, lp.single_apply, if_pos hi, sub_self, eq_self_iff_true, coeFn_sub,
       Pi.sub_apply, Finset.sum_apply, Finset.sum_dite_eq, sub_eq_self]
     simp [Real.zero_rpow hp.ne']
   have : HasSum F (∑ i in s, F i) := hasSum_sum_of_ne_finset_zero hF
@@ -1073,25 +1078,25 @@ protected theorem norm_compl_sum_single (hp : 0 < p.toReal) (f : lp E p) (s : Fi
 `lp` topology. -/
 protected theorem hasSum_single [Fact (1 ≤ p)] (hp : p ≠ ⊤) (f : lp E p) :
     HasSum (fun i : α => lp.single p i (f i : E i)) f := by
-  have hp₀ : 0 < p := zero_lt_one.trans_le (Fact.out _)
-  have hp' : 0 < p.to_real := ENNReal.toReal_pos hp₀.ne' hp
+  have hp₀ : 0 < p := zero_lt_one.trans_le Fact.out
+  have hp' : 0 < p.toReal := ENNReal.toReal_pos hp₀.ne' hp
   have := lp.hasSum_norm hp' f
   rw [HasSum, Metric.tendsto_nhds] at this⊢
   intro ε hε
-  refine' (this _ (Real.rpow_pos_of_pos hε p.to_real)).mono _
+  refine' (this _ (Real.rpow_pos_of_pos hε p.toReal)).mono _
   intro s hs
   rw [← Real.rpow_lt_rpow_iff dist_nonneg (le_of_lt hε) hp']
   rw [dist_comm] at hs
   simp only [dist_eq_norm, Real.norm_eq_abs] at hs⊢
   have H :
-    ‖(∑ i in s, lp.single p i (f i : E i)) - f‖ ^ p.to_real =
-      ‖f‖ ^ p.to_real - ∑ i in s, ‖f i‖ ^ p.to_real := by
-    simpa only [coe_fn_neg, Pi.neg_apply, lp.single_neg, Finset.sum_neg_distrib, neg_sub_neg,
+    ‖(∑ i in s, lp.single p i (f i : E i)) - f‖ ^ p.toReal =
+      ‖f‖ ^ p.toReal - ∑ i in s, ‖f i‖ ^ p.toReal := by
+    simpa only [coeFn_neg, Pi.neg_apply, lp.single_neg, Finset.sum_neg_distrib, neg_sub_neg,
       norm_neg, _root_.norm_neg] using lp.norm_compl_sum_single hp' (-f) s
   rw [← H] at hs
   have :
-    |‖(∑ i in s, lp.single p i (f i : E i)) - f‖ ^ p.to_real| =
-      ‖(∑ i in s, lp.single p i (f i : E i)) - f‖ ^ p.to_real :=
+    |‖(∑ i in s, lp.single p i (f i : E i)) - f‖ ^ p.toReal| =
+      ‖(∑ i in s, lp.single p i (f i : E i)) - f‖ ^ p.toReal :=
     by simp only [Real.abs_rpow_of_nonneg (norm_nonneg _), abs_norm]
   linarith
 #align lp.has_sum_single lp.hasSum_single
@@ -1105,12 +1110,12 @@ open Filter
 open scoped Topology uniformity
 
 /-- The coercion from `lp E p` to `Π i, E i` is uniformly continuous. -/
-theorem uniformContinuous_coe [_i : Fact (1 ≤ p)] : UniformContinuous (coe : lp E p → ∀ i, E i) :=
-  by
+theorem uniformContinuous_coe [_i : Fact (1 ≤ p)] :
+    UniformContinuous ((↑) : lp E p → ∀ i, E i) := by
   have hp : p ≠ 0 := (zero_lt_one.trans_le _i.elim).ne'
   rw [uniformContinuous_pi]
   intro i
-  rw [normed_add_comm_group.uniformity_basis_dist.uniform_continuous_iff
+  rw [NormedAddCommGroup.uniformity_basis_dist.uniformContinuous_iff
       NormedAddCommGroup.uniformity_basis_dist]
   intro ε hε
   refine' ⟨ε, hε, _⟩
@@ -1123,8 +1128,8 @@ variable {ι : Type _} {l : Filter ι} [Filter.NeBot l]
 
 theorem norm_apply_le_of_tendsto {C : ℝ} {F : ι → lp E ∞} (hCF : ∀ᶠ k in l, ‖F k‖ ≤ C)
     {f : ∀ a, E a} (hf : Tendsto (id fun i => F i : ι → ∀ a, E a) l (𝓝 f)) (a : α) : ‖f a‖ ≤ C := by
-  have : tendsto (fun k => ‖F k a‖) l (𝓝 ‖f a‖) :=
-    (tendsto.comp (continuous_apply a).ContinuousAt hf).norm
+  have : Tendsto (fun k => ‖F k a‖) l (𝓝 ‖f a‖) :=
+    (Tendsto.comp (continuous_apply a).continuousAt hf).norm
   refine' le_of_tendsto this (hCF.mono _)
   intro k hCFk
   exact (norm_apply_le_norm ENNReal.top_ne_zero (F k) a).trans hCFk
@@ -1132,20 +1137,18 @@ theorem norm_apply_le_of_tendsto {C : ℝ} {F : ι → lp E ∞} (hCF : ∀ᶠ k
 
 variable [_i : Fact (1 ≤ p)]
 
-include _i
-
 theorem sum_rpow_le_of_tendsto (hp : p ≠ ∞) {C : ℝ} {F : ι → lp E p} (hCF : ∀ᶠ k in l, ‖F k‖ ≤ C)
     {f : ∀ a, E a} (hf : Tendsto (id fun i => F i : ι → ∀ a, E a) l (𝓝 f)) (s : Finset α) :
     (∑ i : α in s, ‖f i‖ ^ p.toReal) ≤ C ^ p.toReal := by
   have hp' : p ≠ 0 := (zero_lt_one.trans_le _i.elim).ne'
-  have hp'' : 0 < p.to_real := ENNReal.toReal_pos hp' hp
-  let G : (∀ a, E a) → ℝ := fun f => ∑ a in s, ‖f a‖ ^ p.to_real
+  have hp'' : 0 < p.toReal := ENNReal.toReal_pos hp' hp
+  let G : (∀ a, E a) → ℝ := fun f => ∑ a in s, ‖f a‖ ^ p.toReal
   have hG : Continuous G := by
     refine' continuous_finset_sum s _
-    intro a ha
+    intro a _
     have : Continuous fun f : ∀ a, E a => f a := continuous_apply a
     exact this.norm.rpow_const fun _ => Or.inr hp''.le
-  refine' le_of_tendsto (hG.continuous_at.tendsto.comp hf) _
+  refine' le_of_tendsto (hG.continuousAt.tendsto.comp hf) _
   refine' hCF.mono _
   intro k hCFk
   refine' (lp.sum_rpow_le_norm_rpow hp'' (F k) s).trans _
@@ -1162,7 +1165,7 @@ theorem norm_le_of_tendsto {C : ℝ} {F : ι → lp E p} (hCF : ∀ᶠ k in l, �
   · apply norm_le_of_forall_le hC
     exact norm_apply_le_of_tendsto hCF hf
   · have : 0 < p := zero_lt_one.trans_le _i.elim
-    have hp' : 0 < p.to_real := ENNReal.toReal_pos this.ne' hp.ne
+    have hp' : 0 < p.toReal := ENNReal.toReal_pos this.ne' hp.ne
     apply norm_le_of_forall_sum_le hp' hC
     exact sum_rpow_le_of_tendsto hp.ne hCF hf
 #align lp.norm_le_of_tendsto lp.norm_le_of_tendsto
@@ -1170,7 +1173,7 @@ theorem norm_le_of_tendsto {C : ℝ} {F : ι → lp E p} (hCF : ∀ᶠ k in l, �
 /-- If `f` is the pointwise limit of a bounded sequence in `lp E p`, then `f` is in `lp E p`. -/
 theorem memℓp_of_tendsto {F : ι → lp E p} (hF : Metric.Bounded (Set.range F)) {f : ∀ a, E a}
     (hf : Tendsto (id fun i => F i : ι → ∀ a, E a) l (𝓝 f)) : Memℓp f p := by
-  obtain ⟨C, hC, hCF'⟩ := hF.exists_pos_norm_le
+  obtain ⟨C, _, hCF'⟩ := hF.exists_pos_norm_le
   have hCF : ∀ k, ‖F k‖ ≤ C := fun k => hCF' _ ⟨k, rfl⟩
   rcases eq_top_or_lt_top p with (rfl | hp)
   · apply memℓp_infty
@@ -1185,10 +1188,10 @@ theorem memℓp_of_tendsto {F : ι → lp E p} (hF : Metric.Bounded (Set.range F
 `lp E p`, then it converges to `f` in the `lp E p` topology. -/
 theorem tendsto_lp_of_tendsto_pi {F : ℕ → lp E p} (hF : CauchySeq F) {f : lp E p}
     (hf : Tendsto (id fun i => F i : ℕ → ∀ a, E a) atTop (𝓝 f)) : Tendsto F atTop (𝓝 f) := by
-  rw [metric.nhds_basis_closed_ball.tendsto_right_iff]
+  rw [Metric.nhds_basis_closedBall.tendsto_right_iff]
   intro ε hε
   have hε' : { p : lp E p × lp E p | ‖p.1 - p.2‖ < ε } ∈ 𝓤 (lp E p) :=
-    normed_add_comm_group.uniformity_basis_dist.mem_of_mem hε
+    NormedAddCommGroup.uniformity_basis_dist.mem_of_mem hε
   refine' (hF.eventually_eventually hε').mono _
   rintro n (hn : ∀ᶠ l in at_top, ‖(fun f => F n - f) (F l)‖ < ε)
   refine' norm_le_of_tendsto (hn.mono fun k hk => hk.le) _
@@ -1204,13 +1207,13 @@ instance : CompleteSpace (lp E p) :=
     (by
       intro F hF
       -- A Cauchy sequence in `lp E p` is pointwise convergent; let `f` be the pointwise limit.
-      obtain ⟨f, hf⟩ := cauchySeq_tendsto_of_complete (uniform_continuous_coe.comp_cauchy_seq hF)
+      obtain ⟨f, hf⟩ := cauchySeq_tendsto_of_complete
+        ((uniformContinuous_coe (p := p)).comp_cauchySeq hF)
       -- Since the Cauchy sequence is bounded, its pointwise limit `f` is in `lp E p`.
-      have hf' : Memℓp f p := mem_ℓp_of_tendsto hF.bounded_range hf
+      have hf' : Memℓp f p := memℓp_of_tendsto hF.bounded_range hf
       -- And therefore `f` is its limit in the `lp E p` topology as well as pointwise.
       exact ⟨⟨f, hf'⟩, tendsto_lp_of_tendsto_pi hF hf⟩)
 
 end Topology
 
 end lp
-

--- a/Mathlib/Analysis/NormedSpace/LpSpace.lean
+++ b/Mathlib/Analysis/NormedSpace/LpSpace.lean
@@ -8,10 +8,10 @@ Authors: Heather Macbeth
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
-import Mathbin.Analysis.MeanInequalities
-import Mathbin.Analysis.MeanInequalitiesPow
-import Mathbin.Analysis.SpecialFunctions.Pow.Continuity
-import Mathbin.Topology.Algebra.Order.LiminfLimsup
+import Mathlib.Analysis.MeanInequalities
+import Mathlib.Analysis.MeanInequalitiesPow
+import Mathlib.Analysis.SpecialFunctions.Pow.Continuity
+import Mathlib.Topology.Algebra.Order.LiminfLimsup
 
 /-!
 # ℓp space
@@ -98,15 +98,13 @@ theorem memℓp_infty {f : ∀ i, E i} (hf : BddAbove (Set.range fun i => ‖f i
 #align mem_ℓp_infty memℓp_infty
 
 theorem memℓp_gen_iff (hp : 0 < p.toReal) {f : ∀ i, E i} :
-    Memℓp f p ↔ Summable fun i => ‖f i‖ ^ p.toReal :=
-  by
+    Memℓp f p ↔ Summable fun i => ‖f i‖ ^ p.toReal := by
   rw [ENNReal.toReal_pos_iff] at hp
   dsimp [Memℓp]
   rw [if_neg hp.1.ne', if_neg hp.2.Ne]
 #align mem_ℓp_gen_iff memℓp_gen_iff
 
-theorem memℓp_gen {f : ∀ i, E i} (hf : Summable fun i => ‖f i‖ ^ p.toReal) : Memℓp f p :=
-  by
+theorem memℓp_gen {f : ∀ i, E i} (hf : Summable fun i => ‖f i‖ ^ p.toReal) : Memℓp f p := by
   rcases p.trichotomy with (rfl | rfl | hp)
   · apply memℓp_zero
     have H : Summable fun i : α => (1 : ℝ) := by simpa using hf
@@ -130,8 +128,7 @@ theorem memℓp_gen' {C : ℝ} {f : ∀ i, E i} (hf : ∀ s : Finset α, (∑ i 
   exact hf s
 #align mem_ℓp_gen' memℓp_gen'
 
-theorem zero_memℓp : Memℓp (0 : ∀ i, E i) p :=
-  by
+theorem zero_memℓp : Memℓp (0 : ∀ i, E i) p := by
   rcases p.trichotomy with (rfl | rfl | hp)
   · apply memℓp_zero
     simp
@@ -161,8 +158,7 @@ theorem summable (hp : 0 < p.toReal) {f : ∀ i, E i} (hf : Memℓp f p) :
   (memℓp_gen_iff hp).1 hf
 #align mem_ℓp.summable Memℓp.summable
 
-theorem neg {f : ∀ i, E i} (hf : Memℓp f p) : Memℓp (-f) p :=
-  by
+theorem neg {f : ∀ i, E i} (hf : Memℓp f p) : Memℓp (-f) p := by
   rcases p.trichotomy with (rfl | rfl | hp)
   · apply memℓp_zero
     simp [hf.finite_dsupport]
@@ -178,8 +174,7 @@ theorem neg_iff {f : ∀ i, E i} : Memℓp (-f) p ↔ Memℓp f p :=
 #align mem_ℓp.neg_iff Memℓp.neg_iff
 
 /- ./././Mathport/Syntax/Translate/Basic.lean:635:2: warning: expanding binder collection (i «expr ∉ » hfq.finite_dsupport.to_finset) -/
-theorem of_exponent_ge {p q : ℝ≥0∞} {f : ∀ i, E i} (hfq : Memℓp f q) (hpq : q ≤ p) : Memℓp f p :=
-  by
+theorem of_exponent_ge {p q : ℝ≥0∞} {f : ∀ i, E i} (hfq : Memℓp f q) (hpq : q ≤ p) : Memℓp f p := by
   rcases ENNReal.trichotomy₂ hpq with
     (⟨rfl, rfl⟩ | ⟨rfl, rfl⟩ | ⟨rfl, hp⟩ | ⟨rfl, rfl⟩ | ⟨hq, rfl⟩ | ⟨hq, hp, hpq'⟩)
   · exact hfq
@@ -191,8 +186,7 @@ theorem of_exponent_ge {p q : ℝ≥0∞} {f : ∀ i, E i} (hfq : Memℓp f q) (
     · simp [hi]
     · exact (hC ⟨i, hi, rfl⟩).trans (le_max_right _ _)
   · apply memℓp_gen
-    have : ∀ (i) (_ : i ∉ hfq.finite_dsupport.to_finset), ‖f i‖ ^ p.to_real = 0 :=
-      by
+    have : ∀ (i) (_ : i ∉ hfq.finite_dsupport.to_finset), ‖f i‖ ^ p.to_real = 0 := by
       intro i hi
       have : f i = 0 := by simpa using hi
       simp [this, Real.zero_rpow hp.ne']
@@ -220,8 +214,7 @@ theorem of_exponent_ge {p q : ℝ≥0∞} {f : ∀ i, E i} (hfq : Memℓp f q) (
       exact Real.rpow_le_rpow_of_exponent_ge' (norm_nonneg _) hi.le hq.le hpq'
 #align mem_ℓp.of_exponent_ge Memℓp.of_exponent_ge
 
-theorem add {f g : ∀ i, E i} (hf : Memℓp f p) (hg : Memℓp g p) : Memℓp (f + g) p :=
-  by
+theorem add {f g : ∀ i, E i} (hf : Memℓp f p) (hg : Memℓp g p) : Memℓp (f + g) p := by
   rcases p.trichotomy with (rfl | rfl | hp)
   · apply memℓp_zero
     refine' (hf.finite_dsupport.union hg.finite_dsupport).Subset fun i => _
@@ -257,8 +250,7 @@ theorem sub {f g : ∀ i, E i} (hf : Memℓp f p) (hg : Memℓp g p) : Memℓp (
 #align mem_ℓp.sub Memℓp.sub
 
 theorem finset_sum {ι} (s : Finset ι) {f : ι → ∀ i, E i} (hf : ∀ i ∈ s, Memℓp (f i) p) :
-    Memℓp (fun a => ∑ i in s, f i a) p :=
-  by
+    Memℓp (fun a => ∑ i in s, f i a) p := by
   haveI : DecidableEq ι := Classical.decEq _
   revert hf
   refine' Finset.induction_on s _ _
@@ -272,8 +264,7 @@ section BoundedSMul
 
 variable {𝕜 : Type _} [NormedRing 𝕜] [∀ i, Module 𝕜 (E i)] [∀ i, BoundedSMul 𝕜 (E i)]
 
-theorem const_smul {f : ∀ i, E i} (hf : Memℓp f p) (c : 𝕜) : Memℓp (c • f) p :=
-  by
+theorem const_smul {f : ∀ i, E i} (hf : Memℓp f p) (c : 𝕜) : Memℓp (c • f) p := by
   rcases p.trichotomy with (rfl | rfl | hp)
   · apply memℓp_zero
     refine' hf.finite_dsupport.subset fun i => (_ : ¬c • f i = 0 → ¬f i = 0)
@@ -324,8 +315,7 @@ instance PreLp.unique [IsEmpty α] : Unique (PreLp E) :=
 #align pre_lp.unique PreLp.unique
 
 /-- lp space -/
-def lp (E : α → Type _) [∀ i, NormedAddCommGroup (E i)] (p : ℝ≥0∞) : AddSubgroup (PreLp E)
-    where
+def lp (E : α → Type _) [∀ i, NormedAddCommGroup (E i)] (p : ℝ≥0∞) : AddSubgroup (PreLp E) where
   carrier := { f | Memℓp f p }
   zero_mem' := zero_memℓp
   add_mem' f g := Memℓp.add
@@ -404,29 +394,25 @@ theorem norm_eq_card_dsupport (f : lp E 0) : ‖f‖ = (lp.memℓp f).finite_dsu
   dif_pos rfl
 #align lp.norm_eq_card_dsupport lp.norm_eq_card_dsupport
 
-theorem norm_eq_csupr (f : lp E ∞) : ‖f‖ = ⨆ i, ‖f i‖ :=
-  by
+theorem norm_eq_csupr (f : lp E ∞) : ‖f‖ = ⨆ i, ‖f i‖ := by
   dsimp [norm]
   rw [dif_neg ENNReal.top_ne_zero, if_pos rfl]
 #align lp.norm_eq_csupr lp.norm_eq_csupr
 
-theorem isLUB_norm [Nonempty α] (f : lp E ∞) : IsLUB (Set.range fun i => ‖f i‖) ‖f‖ :=
-  by
+theorem isLUB_norm [Nonempty α] (f : lp E ∞) : IsLUB (Set.range fun i => ‖f i‖) ‖f‖ := by
   rw [lp.norm_eq_csupr]
   exact isLUB_ciSup (lp.memℓp f)
 #align lp.is_lub_norm lp.isLUB_norm
 
 theorem norm_eq_tsum_rpow (hp : 0 < p.toReal) (f : lp E p) :
-    ‖f‖ = (∑' i, ‖f i‖ ^ p.toReal) ^ (1 / p.toReal) :=
-  by
+    ‖f‖ = (∑' i, ‖f i‖ ^ p.toReal) ^ (1 / p.toReal) := by
   dsimp [norm]
   rw [ENNReal.toReal_pos_iff] at hp
   rw [dif_neg hp.1.ne', if_neg hp.2.Ne]
 #align lp.norm_eq_tsum_rpow lp.norm_eq_tsum_rpow
 
 theorem norm_rpow_eq_tsum (hp : 0 < p.toReal) (f : lp E p) :
-    ‖f‖ ^ p.toReal = ∑' i, ‖f i‖ ^ p.toReal :=
-  by
+    ‖f‖ ^ p.toReal = ∑' i, ‖f i‖ ^ p.toReal := by
   rw [norm_eq_tsum_rpow hp, ← Real.rpow_mul]
   · field_simp [hp.ne']
   apply tsum_nonneg
@@ -438,14 +424,12 @@ theorem norm_rpow_eq_tsum (hp : 0 < p.toReal) (f : lp E p) :
 #align lp.norm_rpow_eq_tsum lp.norm_rpow_eq_tsum
 
 theorem hasSum_norm (hp : 0 < p.toReal) (f : lp E p) :
-    HasSum (fun i => ‖f i‖ ^ p.toReal) (‖f‖ ^ p.toReal) :=
-  by
+    HasSum (fun i => ‖f i‖ ^ p.toReal) (‖f‖ ^ p.toReal) := by
   rw [norm_rpow_eq_tsum hp]
   exact ((lp.memℓp f).Summable hp).HasSum
 #align lp.has_sum_norm lp.hasSum_norm
 
-theorem norm_nonneg' (f : lp E p) : 0 ≤ ‖f‖ :=
-  by
+theorem norm_nonneg' (f : lp E p) : 0 ≤ ‖f‖ := by
   rcases p.trichotomy with (rfl | rfl | hp)
   · simp [lp.norm_eq_card_dsupport f]
   · cases' isEmpty_or_nonempty α with _i _i <;> skip
@@ -459,8 +443,7 @@ theorem norm_nonneg' (f : lp E p) : 0 ≤ ‖f‖ :=
 #align lp.norm_nonneg' lp.norm_nonneg'
 
 @[simp]
-theorem norm_zero : ‖(0 : lp E p)‖ = 0 :=
-  by
+theorem norm_zero : ‖(0 : lp E p)‖ = 0 := by
   rcases p.trichotomy with (rfl | rfl | hp)
   · simp [lp.norm_eq_card_dsupport]
   · simp [lp.norm_eq_csupr]
@@ -483,8 +466,7 @@ theorem norm_eq_zero_iff {f : lp E p} : ‖f‖ = 0 ↔ f = 0 := by
       ext i
       have : ‖f i‖ = 0 := le_antisymm (H.1 ⟨i, rfl⟩) (norm_nonneg _)
       simpa using this
-    · have hf : HasSum (fun i : α => ‖f i‖ ^ p.to_real) 0 :=
-        by
+    · have hf : HasSum (fun i : α => ‖f i‖ ^ p.to_real) 0 := by
         have := lp.hasSum_norm hp f
         rwa [h, Real.zero_rpow hp.ne'] at this
       have : ∀ i, 0 ≤ ‖f i‖ ^ p.to_real := fun i => Real.rpow_nonneg_of_nonneg (norm_nonneg _) _
@@ -499,8 +481,7 @@ theorem eq_zero_iff_coeFn_eq_zero {f : lp E p} : f = 0 ↔ ⇑f = 0 := by rw [lp
 #align lp.eq_zero_iff_coe_fn_eq_zero lp.eq_zero_iff_coeFn_eq_zero
 
 @[simp]
-theorem norm_neg ⦃f : lp E p⦄ : ‖-f‖ = ‖f‖ :=
-  by
+theorem norm_neg ⦃f : lp E p⦄ : ‖-f‖ = ‖f‖ := by
   rcases p.trichotomy with (rfl | rfl | hp)
   · simp [lp.norm_eq_card_dsupport]
   · cases isEmpty_or_nonempty α <;> skip
@@ -549,8 +530,7 @@ instance [hp : Fact (1 ≤ p)] : NormedAddCommGroup (lp E p) :=
 /-- Hölder inequality -/
 protected theorem tsum_mul_le_mul_norm {p q : ℝ≥0∞} (hpq : p.toReal.IsConjugateExponent q.toReal)
     (f : lp E p) (g : lp E q) :
-    (Summable fun i => ‖f i‖ * ‖g i‖) ∧ (∑' i, ‖f i‖ * ‖g i‖) ≤ ‖f‖ * ‖g‖ :=
-  by
+    (Summable fun i => ‖f i‖ * ‖g i‖) ∧ (∑' i, ‖f i‖ * ‖g i‖) ≤ ‖f‖ * ‖g‖ := by
   have hf₁ : ∀ i, 0 ≤ ‖f i‖ := fun i => norm_nonneg _
   have hg₁ : ∀ i, 0 ≤ ‖g i‖ := fun i => norm_nonneg _
   have hf₂ := lp.hasSum_norm hpq.pos f
@@ -573,8 +553,7 @@ protected theorem tsum_mul_le_mul_norm' {p q : ℝ≥0∞} (hpq : p.toReal.IsCon
 
 section ComparePointwise
 
-theorem norm_apply_le_norm (hp : p ≠ 0) (f : lp E p) (i : α) : ‖f i‖ ≤ ‖f‖ :=
-  by
+theorem norm_apply_le_norm (hp : p ≠ 0) (f : lp E p) (i : α) : ‖f i‖ ≤ ‖f‖ := by
   rcases eq_or_ne p ∞ with (rfl | hp')
   · haveI : Nonempty α := ⟨i⟩
     exact (is_lub_norm f).1 ⟨i, rfl⟩
@@ -585,8 +564,7 @@ theorem norm_apply_le_norm (hp : p ≠ 0) (f : lp E p) (i : α) : ‖f i‖ ≤ 
 #align lp.norm_apply_le_norm lp.norm_apply_le_norm
 
 theorem sum_rpow_le_norm_rpow (hp : 0 < p.toReal) (f : lp E p) (s : Finset α) :
-    (∑ i in s, ‖f i‖ ^ p.toReal) ≤ ‖f‖ ^ p.toReal :=
-  by
+    (∑ i in s, ‖f i‖ ^ p.toReal) ≤ ‖f‖ ^ p.toReal := by
   rw [lp.norm_rpow_eq_tsum hp f]
   have : ∀ i, 0 ≤ ‖f i‖ ^ p.to_real := fun i => Real.rpow_nonneg_of_nonneg (norm_nonneg _) _
   refine' sum_le_tsum _ (fun i hi => this i) _
@@ -608,8 +586,7 @@ theorem norm_le_of_forall_le {f : lp E ∞} {C : ℝ} (hC : 0 ≤ C) (hCf : ∀ 
 #align lp.norm_le_of_forall_le lp.norm_le_of_forall_le
 
 theorem norm_le_of_tsum_le (hp : 0 < p.toReal) {C : ℝ} (hC : 0 ≤ C) {f : lp E p}
-    (hf : (∑' i, ‖f i‖ ^ p.toReal) ≤ C ^ p.toReal) : ‖f‖ ≤ C :=
-  by
+    (hf : (∑' i, ‖f i‖ ^ p.toReal) ≤ C ^ p.toReal) : ‖f‖ ≤ C := by
   rw [← Real.rpow_le_rpow_iff (norm_nonneg' _) hC hp, norm_rpow_eq_tsum hp]
   exact hf
 #align lp.norm_le_of_tsum_le lp.norm_le_of_tsum_le
@@ -678,8 +655,7 @@ instance [SMul 𝕜' 𝕜] [∀ i, IsScalarTower 𝕜' 𝕜 (E i)] : IsScalarTow
 instance [∀ i, Module 𝕜ᵐᵒᵖ (E i)] [∀ i, IsCentralScalar 𝕜 (E i)] : IsCentralScalar 𝕜 (lp E p) :=
   ⟨fun r f => Subtype.ext <| op_smul_eq_smul _ _⟩
 
-theorem norm_const_smul_le (hp : p ≠ 0) (c : 𝕜) (f : lp E p) : ‖c • f‖ ≤ ‖c‖ * ‖f‖ :=
-  by
+theorem norm_const_smul_le (hp : p ≠ 0) (c : 𝕜) (f : lp E p) : ‖c • f‖ ≤ ‖c‖ * ‖f‖ := by
   rcases p.trichotomy with (rfl | rfl | hp)
   · exact absurd rfl hp
   · cases isEmpty_or_nonempty α <;> skip
@@ -720,8 +696,7 @@ variable {𝕜 : Type _}
 
 variable [NormedDivisionRing 𝕜] [∀ i, Module 𝕜 (E i)] [∀ i, BoundedSMul 𝕜 (E i)]
 
-theorem norm_const_smul (hp : p ≠ 0) {c : 𝕜} (f : lp E p) : ‖c • f‖ = ‖c‖ * ‖f‖ :=
-  by
+theorem norm_const_smul (hp : p ≠ 0) {c : 𝕜} (f : lp E p) : ‖c • f‖ = ‖c‖ * ‖f‖ := by
   obtain rfl | hc := eq_or_ne c 0
   · simp
   refine' le_antisymm (norm_const_smul_le hp c f) _
@@ -743,8 +718,7 @@ section NormedStarGroup
 
 variable [∀ i, StarAddMonoid (E i)] [∀ i, NormedStarGroup (E i)]
 
-theorem Memℓp.star_mem {f : ∀ i, E i} (hf : Memℓp f p) : Memℓp (star f) p :=
-  by
+theorem Memℓp.star_mem {f : ∀ i, E i} (hf : Memℓp f p) : Memℓp (star f) p := by
   rcases p.trichotomy with (rfl | rfl | hp)
   · apply memℓp_zero
     simp [hf.finite_dsupport]
@@ -796,8 +770,7 @@ section NonUnitalNormedRing
 
 variable {I : Type _} {B : I → Type _} [∀ i, NonUnitalNormedRing (B i)]
 
-theorem Memℓp.infty_mul {f g : ∀ i, B i} (hf : Memℓp f ∞) (hg : Memℓp g ∞) : Memℓp (f * g) ∞ :=
-  by
+theorem Memℓp.infty_mul {f g : ∀ i, B i} (hf : Memℓp f ∞) (hg : Memℓp g ∞) : Memℓp (f * g) ∞ := by
   rw [memℓp_infty_iff]
   obtain ⟨⟨Cf, hCf⟩, ⟨Cg, hCg⟩⟩ := hf.bdd_above, hg.bdd_above
   refine' ⟨Cf * Cg, _⟩
@@ -977,8 +950,7 @@ instance PreLp.algebra : Algebra 𝕜 (PreLp B) :=
 
 variable [∀ i, NormOneClass (B i)]
 
-theorem algebraMap_memℓp_infty (k : 𝕜) : Memℓp (algebraMap 𝕜 (∀ i, B i) k) ∞ :=
-  by
+theorem algebraMap_memℓp_infty (k : 𝕜) : Memℓp (algebraMap 𝕜 (∀ i, B i) k) ∞ := by
   rw [Algebra.algebraMap_eq_smul_one]
   exact (one_mem_ℓp_infty.const_smul k : Memℓp (k • 1 : ∀ i, B i) ∞)
 #align algebra_map_mem_ℓp_infty algebraMap_memℓp_infty
@@ -1009,8 +981,7 @@ variable [DecidableEq α]
 
 /-- The element of `lp E p` which is `a : E i` at the index `i`, and zero elsewhere. -/
 protected def single (p) (i : α) (a : E i) : lp E p :=
-  ⟨fun j => if h : j = i then Eq.ndrec a h.symm else 0,
-    by
+  ⟨fun j => if h : j = i then Eq.ndrec a h.symm else 0, by
     refine' (memℓp_zero _).of_exponent_ge (zero_le p)
     refine' (Set.finite_singleton i).Subset _
     intro j
@@ -1034,8 +1005,7 @@ protected theorem single_apply_ne (p) (i : α) (a : E i) {j : α} (hij : j ≠ i
 #align lp.single_apply_ne lp.single_apply_ne
 
 @[simp]
-protected theorem single_neg (p) (i : α) (a : E i) : lp.single p i (-a) = -lp.single p i a :=
-  by
+protected theorem single_neg (p) (i : α) (a : E i) : lp.single p i (-a) = -lp.single p i a := by
   ext j
   by_cases hi : j = i
   · subst hi
@@ -1045,8 +1015,7 @@ protected theorem single_neg (p) (i : α) (a : E i) : lp.single p i (-a) = -lp.s
 
 @[simp]
 protected theorem single_smul (p) (i : α) (a : E i) (c : 𝕜) :
-    lp.single p i (c • a) = c • lp.single p i a :=
-  by
+    lp.single p i (c • a) = c • lp.single p i a := by
   ext j
   by_cases hi : j = i
   · subst hi
@@ -1056,24 +1025,20 @@ protected theorem single_smul (p) (i : α) (a : E i) (c : 𝕜) :
 
 /- ./././Mathport/Syntax/Translate/Basic.lean:635:2: warning: expanding binder collection (i «expr ∉ » s) -/
 protected theorem norm_sum_single (hp : 0 < p.toReal) (f : ∀ i, E i) (s : Finset α) :
-    ‖∑ i in s, lp.single p i (f i)‖ ^ p.toReal = ∑ i in s, ‖f i‖ ^ p.toReal :=
-  by
+    ‖∑ i in s, lp.single p i (f i)‖ ^ p.toReal = ∑ i in s, ‖f i‖ ^ p.toReal := by
   refine' (has_sum_norm hp (∑ i in s, lp.single p i (f i))).unique _
   simp only [lp.single_apply, coe_fn_sum, Finset.sum_apply, Finset.sum_dite_eq]
-  have h : ∀ (i) (_ : i ∉ s), ‖ite (i ∈ s) (f i) 0‖ ^ p.to_real = 0 :=
-    by
+  have h : ∀ (i) (_ : i ∉ s), ‖ite (i ∈ s) (f i) 0‖ ^ p.to_real = 0 := by
     intro i hi
     simp [if_neg hi, Real.zero_rpow hp.ne']
-  have h' : ∀ i ∈ s, ‖f i‖ ^ p.to_real = ‖ite (i ∈ s) (f i) 0‖ ^ p.to_real :=
-    by
+  have h' : ∀ i ∈ s, ‖f i‖ ^ p.to_real = ‖ite (i ∈ s) (f i) 0‖ ^ p.to_real := by
     intro i hi
     rw [if_pos hi]
   simpa [Finset.sum_congr rfl h'] using hasSum_sum_of_ne_finset_zero h
 #align lp.norm_sum_single lp.norm_sum_single
 
 protected theorem norm_single (hp : 0 < p.toReal) (f : ∀ i, E i) (i : α) :
-    ‖lp.single p i (f i)‖ = ‖f i‖ :=
-  by
+    ‖lp.single p i (f i)‖ = ‖f i‖ := by
   refine' Real.rpow_left_injOn hp.ne' (norm_nonneg' _) (norm_nonneg _) _
   simpa using lp.norm_sum_single hp f {i}
 #align lp.norm_single lp.norm_single
@@ -1090,8 +1055,7 @@ protected theorem norm_sub_norm_compl_sub_single (hp : 0 < p.toReal) (f : lp E p
       simpa only [F, coe_fn_sum, lp.single_apply, coe_fn_sub, Pi.sub_apply, Finset.sum_apply,
         Finset.sum_dite_eq] using this
     simp only [if_neg hi, sub_zero, sub_self]
-  have hF' : ∀ i ∈ s, F i = ‖f i‖ ^ p.to_real :=
-    by
+  have hF' : ∀ i ∈ s, F i = ‖f i‖ ^ p.to_real := by
     intro i hi
     simp only [F, coe_fn_sum, lp.single_apply, if_pos hi, sub_self, eq_self_iff_true, coe_fn_sub,
       Pi.sub_apply, Finset.sum_apply, Finset.sum_dite_eq, sub_eq_self]
@@ -1108,8 +1072,7 @@ protected theorem norm_compl_sum_single (hp : 0 < p.toReal) (f : lp E p) (s : Fi
 /-- The canonical finitely-supported approximations to an element `f` of `lp` converge to it, in the
 `lp` topology. -/
 protected theorem hasSum_single [Fact (1 ≤ p)] (hp : p ≠ ⊤) (f : lp E p) :
-    HasSum (fun i : α => lp.single p i (f i : E i)) f :=
-  by
+    HasSum (fun i : α => lp.single p i (f i : E i)) f := by
   have hp₀ : 0 < p := zero_lt_one.trans_le (Fact.out _)
   have hp' : 0 < p.to_real := ENNReal.toReal_pos hp₀.ne' hp
   have := lp.hasSum_norm hp' f
@@ -1122,8 +1085,7 @@ protected theorem hasSum_single [Fact (1 ≤ p)] (hp : p ≠ ⊤) (f : lp E p) :
   simp only [dist_eq_norm, Real.norm_eq_abs] at hs⊢
   have H :
     ‖(∑ i in s, lp.single p i (f i : E i)) - f‖ ^ p.to_real =
-      ‖f‖ ^ p.to_real - ∑ i in s, ‖f i‖ ^ p.to_real :=
-    by
+      ‖f‖ ^ p.to_real - ∑ i in s, ‖f i‖ ^ p.to_real := by
     simpa only [coe_fn_neg, Pi.neg_apply, lp.single_neg, Finset.sum_neg_distrib, neg_sub_neg,
       norm_neg, _root_.norm_neg] using lp.norm_compl_sum_single hp' (-f) s
   rw [← H] at hs
@@ -1160,8 +1122,7 @@ theorem uniformContinuous_coe [_i : Fact (1 ≤ p)] : UniformContinuous (coe : l
 variable {ι : Type _} {l : Filter ι} [Filter.NeBot l]
 
 theorem norm_apply_le_of_tendsto {C : ℝ} {F : ι → lp E ∞} (hCF : ∀ᶠ k in l, ‖F k‖ ≤ C)
-    {f : ∀ a, E a} (hf : Tendsto (id fun i => F i : ι → ∀ a, E a) l (𝓝 f)) (a : α) : ‖f a‖ ≤ C :=
-  by
+    {f : ∀ a, E a} (hf : Tendsto (id fun i => F i : ι → ∀ a, E a) l (𝓝 f)) (a : α) : ‖f a‖ ≤ C := by
   have : tendsto (fun k => ‖F k a‖) l (𝓝 ‖f a‖) :=
     (tendsto.comp (continuous_apply a).ContinuousAt hf).norm
   refine' le_of_tendsto this (hCF.mono _)
@@ -1175,8 +1136,7 @@ include _i
 
 theorem sum_rpow_le_of_tendsto (hp : p ≠ ∞) {C : ℝ} {F : ι → lp E p} (hCF : ∀ᶠ k in l, ‖F k‖ ≤ C)
     {f : ∀ a, E a} (hf : Tendsto (id fun i => F i : ι → ∀ a, E a) l (𝓝 f)) (s : Finset α) :
-    (∑ i : α in s, ‖f i‖ ^ p.toReal) ≤ C ^ p.toReal :=
-  by
+    (∑ i : α in s, ‖f i‖ ^ p.toReal) ≤ C ^ p.toReal := by
   have hp' : p ≠ 0 := (zero_lt_one.trans_le _i.elim).ne'
   have hp'' : 0 < p.to_real := ENNReal.toReal_pos hp' hp
   let G : (∀ a, E a) → ℝ := fun f => ∑ a in s, ‖f a‖ ^ p.to_real
@@ -1195,8 +1155,7 @@ theorem sum_rpow_le_of_tendsto (hp : p ≠ ∞) {C : ℝ} {F : ι → lp E p} (h
 /-- "Semicontinuity of the `lp` norm": If all sufficiently large elements of a sequence in `lp E p`
  have `lp` norm `≤ C`, then the pointwise limit, if it exists, also has `lp` norm `≤ C`. -/
 theorem norm_le_of_tendsto {C : ℝ} {F : ι → lp E p} (hCF : ∀ᶠ k in l, ‖F k‖ ≤ C) {f : lp E p}
-    (hf : Tendsto (id fun i => F i : ι → ∀ a, E a) l (𝓝 f)) : ‖f‖ ≤ C :=
-  by
+    (hf : Tendsto (id fun i => F i : ι → ∀ a, E a) l (𝓝 f)) : ‖f‖ ≤ C := by
   obtain ⟨i, hi⟩ := hCF.exists
   have hC : 0 ≤ C := (norm_nonneg _).trans hi
   rcases eq_top_or_lt_top p with (rfl | hp)
@@ -1210,8 +1169,7 @@ theorem norm_le_of_tendsto {C : ℝ} {F : ι → lp E p} (hCF : ∀ᶠ k in l, �
 
 /-- If `f` is the pointwise limit of a bounded sequence in `lp E p`, then `f` is in `lp E p`. -/
 theorem memℓp_of_tendsto {F : ι → lp E p} (hF : Metric.Bounded (Set.range F)) {f : ∀ a, E a}
-    (hf : Tendsto (id fun i => F i : ι → ∀ a, E a) l (𝓝 f)) : Memℓp f p :=
-  by
+    (hf : Tendsto (id fun i => F i : ι → ∀ a, E a) l (𝓝 f)) : Memℓp f p := by
   obtain ⟨C, hC, hCF'⟩ := hF.exists_pos_norm_le
   have hCF : ∀ k, ‖F k‖ ≤ C := fun k => hCF' _ ⟨k, rfl⟩
   rcases eq_top_or_lt_top p with (rfl | hp)
@@ -1226,8 +1184,7 @@ theorem memℓp_of_tendsto {F : ι → lp E p} (hF : Metric.Bounded (Set.range F
 /-- If a sequence is Cauchy in the `lp E p` topology and pointwise convergent to a element `f` of
 `lp E p`, then it converges to `f` in the `lp E p` topology. -/
 theorem tendsto_lp_of_tendsto_pi {F : ℕ → lp E p} (hF : CauchySeq F) {f : lp E p}
-    (hf : Tendsto (id fun i => F i : ℕ → ∀ a, E a) atTop (𝓝 f)) : Tendsto F atTop (𝓝 f) :=
-  by
+    (hf : Tendsto (id fun i => F i : ℕ → ∀ a, E a) atTop (𝓝 f)) : Tendsto F atTop (𝓝 f) := by
   rw [metric.nhds_basis_closed_ball.tendsto_right_iff]
   intro ε hε
   have hε' : { p : lp E p × lp E p | ‖p.1 - p.2‖ < ε } ∈ 𝓤 (lp E p) :=

--- a/Mathlib/Analysis/NormedSpace/LpSpace.lean
+++ b/Mathlib/Analysis/NormedSpace/LpSpace.lean
@@ -396,13 +396,13 @@ theorem norm_eq_card_dsupport (f : lp E 0) : ‖f‖ = (lp.memℓp f).finite_dsu
   dif_pos rfl
 #align lp.norm_eq_card_dsupport lp.norm_eq_card_dsupport
 
-theorem norm_eq_csupr (f : lp E ∞) : ‖f‖ = ⨆ i, ‖f i‖ := by
+theorem norm_eq_ciSup (f : lp E ∞) : ‖f‖ = ⨆ i, ‖f i‖ := by
   dsimp [norm]
   rw [dif_neg ENNReal.top_ne_zero, if_pos rfl]
-#align lp.norm_eq_csupr lp.norm_eq_csupr
+#align lp.norm_eq_csupr lp.norm_eq_ciSup
 
 theorem isLUB_norm [Nonempty α] (f : lp E ∞) : IsLUB (Set.range fun i => ‖f i‖) ‖f‖ := by
-  rw [lp.norm_eq_csupr]
+  rw [lp.norm_eq_ciSup]
   exact isLUB_ciSup (lp.memℓp f)
 #align lp.is_lub_norm lp.isLUB_norm
 
@@ -434,7 +434,7 @@ theorem norm_nonneg' (f : lp E p) : 0 ≤ ‖f‖ := by
   rcases p.trichotomy with (rfl | rfl | hp)
   · simp [lp.norm_eq_card_dsupport f]
   · cases' isEmpty_or_nonempty α with _i _i
-    · rw [lp.norm_eq_csupr]
+    · rw [lp.norm_eq_ciSup]
       simp [Real.ciSup_empty]
     inhabit α
     exact (norm_nonneg (f default)).trans ((lp.isLUB_norm f).1 ⟨default, rfl⟩)
@@ -447,7 +447,7 @@ theorem norm_nonneg' (f : lp E p) : 0 ≤ ‖f‖ := by
 theorem norm_zero : ‖(0 : lp E p)‖ = 0 := by
   rcases p.trichotomy with (rfl | rfl | hp)
   · simp [lp.norm_eq_card_dsupport]
-  · simp [lp.norm_eq_csupr]
+  · simp [lp.norm_eq_ciSup]
   · rw [lp.norm_eq_tsum_rpow hp]
     have hp' : 1 / p.toReal ≠ 0 := one_div_ne_zero hp.ne'
     simpa [Real.zero_rpow hp.ne'] using Real.zero_rpow hp'
@@ -763,7 +763,7 @@ instance [hp : Fact (1 ≤ p)] : NormedStarGroup (lp E p) where
     · exfalso
       have := ENNReal.toReal_mono ENNReal.zero_ne_top hp.elim
       norm_num at this
-    · simp only [lp.norm_eq_csupr, lp.star_apply, norm_star]
+    · simp only [lp.norm_eq_ciSup, lp.star_apply, norm_star]
     · simp only [lp.norm_eq_tsum_rpow h, lp.star_apply, norm_star]
 
 variable {𝕜 : Type _} [Star 𝕜] [NormedRing 𝕜]
@@ -917,7 +917,7 @@ theorem infty_coeFn_int_cast (z : ℤ) : ⇑(z : lp B ∞) = z :=
 #align lp.infty_coe_fn_int_cast lp.infty_coeFn_int_cast
 
 instance [Nonempty I] : NormOneClass (lp B ∞) where
-  norm_one := by simp_rw [lp.norm_eq_csupr, infty_coeFn_one, Pi.one_apply, norm_one, ciSup_const]
+  norm_one := by simp_rw [lp.norm_eq_ciSup, infty_coeFn_one, Pi.one_apply, norm_one, ciSup_const]
 
 instance inftyNormedRing : NormedRing (lp B ∞) :=
   { lp.inftyRing, lp.nonUnitalNormedRing with }

--- a/Mathlib/Analysis/NormedSpace/LpSpace.lean
+++ b/Mathlib/Analysis/NormedSpace/LpSpace.lean
@@ -78,7 +78,8 @@ variable {α : Type _} {E : α → Type _} {p q : ℝ≥0∞} [∀ i, NormedAddC
 * has the series `∑' i, ‖f i‖ ^ p` be summable, if `0 < p < ∞`. -/
 def Memℓp (f : ∀ i, E i) (p : ℝ≥0∞) : Prop :=
   if p = 0 then Set.Finite { i | f i ≠ 0 }
-  else if p = ∞ then BddAbove (Set.range fun i => ‖f i‖) else Summable fun i => ‖f i‖ ^ p.toReal
+  else if p = ∞ then BddAbove (Set.range fun i => ‖f i‖)
+  else Summable fun i => ‖f i‖ ^ p.toReal
 #align mem_ℓp Memℓp
 
 theorem memℓp_zero_iff {f : ∀ i, E i} : Memℓp f 0 ↔ Set.Finite { i | f i ≠ 0 } := by
@@ -177,7 +178,7 @@ theorem neg_iff {f : ∀ i, E i} : Memℓp (-f) p ↔ Memℓp f p :=
 
 theorem of_exponent_ge {p q : ℝ≥0∞} {f : ∀ i, E i} (hfq : Memℓp f q) (hpq : q ≤ p) : Memℓp f p := by
   rcases ENNReal.trichotomy₂ hpq with
-    (⟨rfl, rfl⟩ | ⟨rfl, rfl⟩ | ⟨rfl, hp⟩ | ⟨rfl, rfl⟩ | ⟨hq, rfl⟩ | ⟨hq, hp, hpq'⟩)
+    (⟨rfl, rfl⟩ | ⟨rfl, rfl⟩ | ⟨rfl, hp⟩ | ⟨rfl, rfl⟩ | ⟨hq, rfl⟩ | ⟨hq, _, hpq'⟩)
   · exact hfq
   · apply memℓp_infty
     obtain ⟨C, hC⟩ := (hfq.finite_dsupport.image fun i => ‖f i‖).bddAbove
@@ -204,14 +205,14 @@ theorem of_exponent_ge {p q : ℝ≥0∞} {f : ∀ i, E i} (hfq : Memℓp f q) (
     have hf' := hfq.summable hq
     refine' summable_of_norm_bounded_eventually _ hf' (@Set.Finite.subset _ { i | 1 ≤ ‖f i‖ } _ _ _)
     · have H : { x : α | 1 ≤ ‖f x‖ ^ q.toReal }.Finite := by
-        simpa using
-          eventually_lt_of_tendsto_lt (by norm_num : (0 : ℝ) < 1) hf'.tendsto_cofinite_zero
+        simpa using eventually_lt_of_tendsto_lt (by norm_num) hf'.tendsto_cofinite_zero
       exact H.subset fun i hi => Real.one_le_rpow hi hq.le
     · show ∀ i, ¬|‖f i‖ ^ p.toReal| ≤ ‖f i‖ ^ q.toReal → 1 ≤ ‖f i‖
       intro i hi
       have : 0 ≤ ‖f i‖ ^ p.toReal := Real.rpow_nonneg_of_nonneg (norm_nonneg _) p.toReal
       simp only [abs_of_nonneg, this] at hi
       contrapose! hi
+      rw [not_le] at hi
       exact Real.rpow_le_rpow_of_exponent_ge' (norm_nonneg _) hi.le hq.le hpq'
 #align mem_ℓp.of_exponent_ge Memℓp.of_exponent_ge
 
@@ -242,8 +243,7 @@ theorem add {f g : ∀ i, E i} (hf : Memℓp f p) (hg : Memℓp g p) : Memℓp (
       have : ∀ i, (0 : ℝ) ≤ F i := fun i => (F i).coe_nonneg
       simp only [not_lt] at h
       simpa [Fin.sum_univ_succ] using
-        Real.rpow_sum_le_const_mul_sum_rpow_of_nonneg (Finset.univ : Finset (Fin 2)) h fun i _ =>
-          (F i).coe_nonneg
+        Real.rpow_sum_le_const_mul_sum_rpow_of_nonneg Finset.univ h fun i _ => (F i).coe_nonneg
 #align mem_ℓp.add Memℓp.add
 
 theorem sub {f g : ∀ i, E i} (hf : Memℓp f p) (hg : Memℓp g p) : Memℓp (f - g) p := by
@@ -277,8 +277,8 @@ theorem const_smul {f : ∀ i, E i} (hf : Memℓp f p) (c : 𝕜) : Memℓp (c �
     exact mul_le_mul_of_nonneg_left (hA ⟨i, rfl⟩) (norm_nonneg c)
   · apply memℓp_gen
     have := (hf.summable hp).mul_left (↑(‖c‖₊ ^ p.toReal) : ℝ)
-    simp_rw [← coe_nnnorm, ← NNReal.coe_rpow, ← NNReal.coe_mul, NNReal.summable_coe, ←
-      NNReal.mul_rpow] at this⊢
+    simp_rw [← coe_nnnorm, ← NNReal.coe_rpow, ← NNReal.coe_mul, NNReal.summable_coe,
+      ← NNReal.mul_rpow] at this⊢
     refine' NNReal.summable_of_le _ this
     intro i
     exact NNReal.rpow_le_rpow (nnnorm_smul_le _ _) ENNReal.toReal_nonneg
@@ -330,8 +330,8 @@ namespace lp
 instance : Coe (lp E p) (∀ i, E i) :=
   ⟨Subtype.val⟩ -- Porting note: Originally `coeSubtype`
 
-instance : CoeFun (lp E p) fun _ => ∀ i, E i :=
-  ⟨fun f => ((f : ∀ i, E i) : ∀ i, E i)⟩
+instance coeFun : CoeFun (lp E p) fun _ => ∀ i, E i :=
+  ⟨fun f => (f : ∀ i, E i)⟩
 
 @[ext]
 theorem ext {f g : lp E p} (h : (f : ∀ i, E i) = g) : f = g :=
@@ -377,10 +377,10 @@ theorem coeFn_add (f g : lp E p) : ⇑(f + g) = f + g :=
 theorem coeFn_sum {ι : Type _} (f : ι → lp E p) (s : Finset ι) :
     ⇑(∑ i in s, f i) = ∑ i in s, ⇑(f i) := by
   classical
-    refine' Finset.induction _ _ s
-    · simp
-    intro i s his
-    simp [Finset.sum_insert his]
+  refine' Finset.induction _ _ s
+  · simp
+  intro i s his
+  simp [Finset.sum_insert his]
 #align lp.coe_fn_sum lp.coeFn_sum
 
 @[simp]
@@ -436,7 +436,7 @@ theorem hasSum_norm (hp : 0 < p.toReal) (f : lp E p) :
 theorem norm_nonneg' (f : lp E p) : 0 ≤ ‖f‖ := by
   rcases p.trichotomy with (rfl | rfl | hp)
   · simp [lp.norm_eq_card_dsupport f]
-  · cases' isEmpty_or_nonempty α with _i _i <;> skip
+  · cases' isEmpty_or_nonempty α with _i _i
     · rw [lp.norm_eq_csupr]
       simp [Real.ciSup_empty]
     inhabit α
@@ -457,28 +457,27 @@ theorem norm_zero : ‖(0 : lp E p)‖ = 0 := by
 #align lp.norm_zero lp.norm_zero
 
 theorem norm_eq_zero_iff {f : lp E p} : ‖f‖ = 0 ↔ f = 0 := by
-  classical
-    refine' ⟨fun h => _, by rintro rfl; exact norm_zero⟩
-    rcases p.trichotomy with (rfl | rfl | hp)
-    · ext i
-      have : { i : α | ¬f i = 0 } = ∅ := by simpa [lp.norm_eq_card_dsupport f] using h
-      have : (¬f i = 0) = False := congr_fun this i
-      tauto
-    · cases' isEmpty_or_nonempty α with _i _i <;> skip
-      · simp
-      have H : IsLUB (Set.range fun i => ‖f i‖) 0 := by simpa [h] using lp.isLUB_norm f
-      ext i
-      have : ‖f i‖ = 0 := le_antisymm (H.1 ⟨i, rfl⟩) (norm_nonneg _)
-      simpa using this
-    · have hf : HasSum (fun i : α => ‖f i‖ ^ p.toReal) 0 := by
-        have := lp.hasSum_norm hp f
-        rwa [h, Real.zero_rpow hp.ne'] at this
-      have : ∀ i, 0 ≤ ‖f i‖ ^ p.toReal := fun i => Real.rpow_nonneg_of_nonneg (norm_nonneg _) _
-      rw [hasSum_zero_iff_of_nonneg this] at hf
-      ext i
-      have : f i = 0 ∧ p.toReal ≠ 0 := by
-        simpa [Real.rpow_eq_zero_iff_of_nonneg (norm_nonneg (f i))] using congr_fun hf i
-      exact this.1
+  refine' ⟨fun h => _, by rintro rfl; exact norm_zero⟩
+  rcases p.trichotomy with (rfl | rfl | hp)
+  · ext; funext i
+    have : { i : α | ¬f i = 0 } = ∅ := by simpa [lp.norm_eq_card_dsupport f] using h
+    have : (¬f i = 0) = False := congr_fun this i
+    tauto
+  · cases' isEmpty_or_nonempty α with _i _i
+    · simp
+    have H : IsLUB (Set.range fun i => ‖f i‖) 0 := by simpa [h] using lp.isLUB_norm f
+    ext; funext i
+    have : ‖f i‖ = 0 := le_antisymm (H.1 ⟨i, rfl⟩) (norm_nonneg _)
+    simpa using this
+  · have hf : HasSum (fun i : α => ‖f i‖ ^ p.toReal) 0 := by
+      have := lp.hasSum_norm hp f
+      rwa [h, Real.zero_rpow hp.ne'] at this
+    have : ∀ i, 0 ≤ ‖f i‖ ^ p.toReal := fun i => Real.rpow_nonneg_of_nonneg (norm_nonneg _) _
+    rw [hasSum_zero_iff_of_nonneg this] at hf
+    ext; funext i
+    have : f i = 0 ∧ p.toReal ≠ 0 := by
+      simpa [Real.rpow_eq_zero_iff_of_nonneg (norm_nonneg (f i))] using congr_fun hf i
+    exact this.1
 #align lp.norm_eq_zero_iff lp.norm_eq_zero_iff
 
 theorem eq_zero_iff_coeFn_eq_zero {f : lp E p} : f = 0 ↔ ⇑f = 0 := by
@@ -489,7 +488,7 @@ theorem eq_zero_iff_coeFn_eq_zero {f : lp E p} : f = 0 ↔ ⇑f = 0 := by
 theorem norm_neg ⦃f : lp E p⦄ : ‖-f‖ = ‖f‖ := by
   rcases p.trichotomy with (rfl | rfl | hp)
   · simp [lp.norm_eq_card_dsupport]
-  · cases isEmpty_or_nonempty α <;> skip
+  · cases isEmpty_or_nonempty α
     · simp [lp.eq_zero' f]
     apply (lp.isLUB_norm (-f)).unique
     simpa using lp.isLUB_norm f
@@ -510,10 +509,8 @@ instance normedAddCommGroup [hp : Fact (1 ≤ p)] : NormedAddCommGroup (lp E p) 
           · simp [lp.eq_zero' f]
           refine' (lp.isLUB_norm (f + g)).2 _
           rintro x ⟨i, rfl⟩
-          refine'
-            le_trans _
-              (add_mem_upperBounds_add (lp.isLUB_norm f).1 (lp.isLUB_norm g).1
-                ⟨_, _, ⟨i, rfl⟩, ⟨i, rfl⟩, rfl⟩)
+          refine' le_trans _ (add_mem_upperBounds_add
+            (lp.isLUB_norm f).1 (lp.isLUB_norm g).1 ⟨_, _, ⟨i, rfl⟩, ⟨i, rfl⟩, rfl⟩)
           exact norm_add_le (f i) (g i)
         · have hp'' : 0 < p.toReal := zero_lt_one.trans_le hp'
           have hf₁ : ∀ i, 0 ≤ ‖f i‖ := fun i => norm_nonneg _
@@ -576,15 +573,15 @@ theorem sum_rpow_le_norm_rpow (hp : 0 < p.toReal) (f : lp E p) (s : Finset α) :
   exact (lp.memℓp f).summable hp
 #align lp.sum_rpow_le_norm_rpow lp.sum_rpow_le_norm_rpow
 
-theorem norm_le_of_forall_le' [Nonempty α] {f : lp E ∞} (C : ℝ) (hCf : ∀ i, ‖f i‖ ≤ C) : ‖f‖ ≤ C :=
-  by
+theorem norm_le_of_forall_le' [Nonempty α] {f : lp E ∞} (C : ℝ) (hCf : ∀ i, ‖f i‖ ≤ C) :
+    ‖f‖ ≤ C := by
   refine' (isLUB_norm f).2 _
   rintro - ⟨i, rfl⟩
   exact hCf i
 #align lp.norm_le_of_forall_le' lp.norm_le_of_forall_le'
 
-theorem norm_le_of_forall_le {f : lp E ∞} {C : ℝ} (hC : 0 ≤ C) (hCf : ∀ i, ‖f i‖ ≤ C) : ‖f‖ ≤ C :=
-  by
+theorem norm_le_of_forall_le {f : lp E ∞} {C : ℝ} (hC : 0 ≤ C) (hCf : ∀ i, ‖f i‖ ≤ C) :
+    ‖f‖ ≤ C := by
   cases isEmpty_or_nonempty α
   · simpa [eq_zero' f] using hC
   · exact norm_le_of_forall_le' C hCf
@@ -663,7 +660,7 @@ instance [∀ i, Module 𝕜ᵐᵒᵖ (E i)] [∀ i, IsCentralScalar 𝕜 (E i)]
 theorem norm_const_smul_le (hp : p ≠ 0) (c : 𝕜) (f : lp E p) : ‖c • f‖ ≤ ‖c‖ * ‖f‖ := by
   rcases p.trichotomy with (rfl | rfl | hp)
   · exact absurd rfl hp
-  · cases isEmpty_or_nonempty α <;> skip
+  · cases isEmpty_or_nonempty α
     · simp [lp.eq_zero' f]
     have hcf := lp.isLUB_norm (c • f)
     have hfc := (lp.isLUB_norm f).mul_left (norm_nonneg c)
@@ -691,8 +688,7 @@ theorem norm_const_smul_le (hp : p ≠ 0) (c : 𝕜) (f : lp E p) : ‖c • f�
 #align lp.norm_const_smul_le lp.norm_const_smul_le
 
 instance [Fact (1 ≤ p)] : BoundedSMul 𝕜 (lp E p) :=
-  BoundedSMul.of_norm_smul_le <|
-    norm_const_smul_le (zero_lt_one.trans_le <| Fact.out (p := 1 ≤ p)).ne'
+  BoundedSMul.of_norm_smul_le <| norm_const_smul_le (zero_lt_one.trans_le <| Fact.out).ne'
 
 end BoundedSMul
 
@@ -716,7 +712,8 @@ section NormedSpace
 
 variable {𝕜 : Type _} [NormedField 𝕜] [∀ i, NormedSpace 𝕜 (E i)]
 
-instance [Fact (1 ≤ p)] : NormedSpace 𝕜 (lp E p) where norm_smul_le c f := norm_smul_le _ _
+instance [Fact (1 ≤ p)] : NormedSpace 𝕜 (lp E p) where
+  norm_smul_le c f := norm_smul_le _ _
 
 end NormedSpace
 
@@ -752,9 +749,11 @@ protected theorem star_apply (f : lp E p) (i : α) : star f i = star (f i) :=
   rfl
 #align lp.star_apply lp.star_apply
 
-instance : InvolutiveStar (lp E p) where star_involutive x := by ext; simp
+instance : InvolutiveStar (lp E p) where
+  star_involutive x := by simp [star]
 
-instance : StarAddMonoid (lp E p) where star_add f g := ext <| star_add _ _
+instance : StarAddMonoid (lp E p) where
+  star_add f g := ext <| star_add _ _
 
 instance [hp : Fact (1 ≤ p)] : NormedStarGroup (lp E p) where
   norm_star f := by
@@ -769,7 +768,8 @@ variable {𝕜 : Type _} [Star 𝕜] [NormedRing 𝕜]
 
 variable [∀ i, Module 𝕜 (E i)] [∀ i, BoundedSMul 𝕜 (E i)] [∀ i, StarModule 𝕜 (E i)]
 
-instance : StarModule 𝕜 (lp E p) where star_smul r f := ext <| star_smul _ _
+instance : StarModule 𝕜 (lp E p) where
+  star_smul r f := ext <| star_smul _ _
 
 end NormedStarGroup
 
@@ -790,7 +790,11 @@ theorem _root_.Memℓp.infty_mul {f g : ∀ i, B i} (hf : Memℓp f ∞) (hg : M
         ((norm_nonneg _).trans (hCf ⟨i, rfl⟩))
 #align mem_ℓp.infty_mul Memℓp.infty_mul
 
-instance : Mul (lp B ∞) where mul f g := ⟨(f * g : ∀ i, B i), f.property.infty_mul g.property⟩
+-- Porting note: Added this instance to get `Mul (lp B ∞)` to work.
+instance : Mul (PreLp B) := by unfold PreLp; infer_instance
+
+instance : Mul (lp B ∞) where
+  mul f g := ⟨(f * g : ∀ i, B i), f.property.infty_mul g.property⟩
 
 @[simp]
 theorem infty_coeFn_mul (f g : lp B ∞) : ⇑(f * g) = f * g :=
@@ -798,7 +802,7 @@ theorem infty_coeFn_mul (f g : lp B ∞) : ⇑(f * g) = f * g :=
 #align lp.infty_coe_fn_mul lp.infty_coeFn_mul
 
 instance nonUnitalRing : NonUnitalRing (lp B ∞) :=
-  Function.Injective.nonUnitalRing lp.hasCoeToFun.coe Subtype.coe_injective (lp.coeFn_zero B ∞)
+  Function.Injective.nonUnitalRing lp.coeFun.coe Subtype.coe_injective (lp.coeFn_zero B ∞)
     lp.coeFn_add infty_coeFn_mul lp.coeFn_neg lp.coeFn_sub (fun _ _ => rfl) fun _ _ => rfl
 
 instance nonUnitalNormedRing : NonUnitalNormedRing (lp B ∞) :=
@@ -827,9 +831,9 @@ section StarRing
 variable [∀ i, StarRing (B i)] [∀ i, NormedStarGroup (B i)]
 
 instance inftyStarRing : StarRing (lp B ∞) :=
-  {
-    show StarAddMonoid (lp B ∞) by letI : ∀ i, StarAddMonoid (B i) := fun i => inferInstance;
-      infer_instance with
+  { (show StarAddMonoid (lp B ∞) by
+      letI : ∀ i, StarAddMonoid (B i) := fun i => inferInstance
+      infer_instance) with
     star_mul := fun f g => ext <| star_mul (_ : ∀ i, B i) _ }
 #align lp.infty_star_ring lp.inftyStarRing
 
@@ -873,7 +877,7 @@ def _root_.lpInftySubring : Subring (PreLp B) :=
   { lp B ∞ with
     carrier := { f | Memℓp f ∞ }
     one_mem' := one_memℓp_infty
-    mul_mem' := fun hf hg => hf.infty_mul hg }
+    mul_mem' := Memℓp.infty_mul }
 #align lp_infty_subring lpInftySubring
 
 variable {B}
@@ -1006,7 +1010,8 @@ protected theorem single_apply_self (p) (i : α) (a : E i) : lp.single p i a i =
 #align lp.single_apply_self lp.single_apply_self
 
 protected theorem single_apply_ne (p) (i : α) (a : E i) {j : α} (hij : j ≠ i) :
-    lp.single p i a j = 0 := by rw [lp.single_apply, dif_neg hij]
+    lp.single p i a j = 0 := by
+  rw [lp.single_apply, dif_neg hij]
 #align lp.single_apply_ne lp.single_apply_ne
 
 @[simp]
@@ -1050,8 +1055,8 @@ protected theorem norm_single (hp : 0 < p.toReal) (f : ∀ i, E i) (i : α) :
 
 /- ./././Mathport/Syntax/Translate/Basic.lean:635:2: warning: expanding binder collection (i «expr ∉ » s) -/
 protected theorem norm_sub_norm_compl_sub_single (hp : 0 < p.toReal) (f : lp E p) (s : Finset α) :
-    ‖f‖ ^ p.toReal - ‖f - ∑ i in s, lp.single p i (f i)‖ ^ p.toReal = ∑ i in s, ‖f i‖ ^ p.toReal :=
-  by
+    ‖f‖ ^ p.toReal - ‖f - ∑ i in s, lp.single p i (f i)‖ ^ p.toReal =
+      ∑ i in s, ‖f i‖ ^ p.toReal := by
   refine' ((hasSum_norm hp f).sub (hasSum_norm hp (f - ∑ i in s, lp.single p i (f i)))).unique _
   let F : α → ℝ := fun i => ‖f i‖ ^ p.toReal - ‖(f - ∑ i in s, lp.single p i (f i)) i‖ ^ p.toReal
   have hF : ∀ (i) (_ : i ∉ s), F i = 0 := by
@@ -1088,16 +1093,14 @@ protected theorem hasSum_single [Fact (1 ≤ p)] (hp : p ≠ ⊤) (f : lp E p) :
   rw [← Real.rpow_lt_rpow_iff dist_nonneg (le_of_lt hε) hp']
   rw [dist_comm] at hs
   simp only [dist_eq_norm, Real.norm_eq_abs] at hs⊢
-  have H :
-    ‖(∑ i in s, lp.single p i (f i : E i)) - f‖ ^ p.toReal =
+  have H : ‖(∑ i in s, lp.single p i (f i : E i)) - f‖ ^ p.toReal =
       ‖f‖ ^ p.toReal - ∑ i in s, ‖f i‖ ^ p.toReal := by
     simpa only [coeFn_neg, Pi.neg_apply, lp.single_neg, Finset.sum_neg_distrib, neg_sub_neg,
       norm_neg, _root_.norm_neg] using lp.norm_compl_sum_single hp' (-f) s
   rw [← H] at hs
-  have :
-    |‖(∑ i in s, lp.single p i (f i : E i)) - f‖ ^ p.toReal| =
-      ‖(∑ i in s, lp.single p i (f i : E i)) - f‖ ^ p.toReal :=
-    by simp only [Real.abs_rpow_of_nonneg (norm_nonneg _), abs_norm]
+  have : |‖(∑ i in s, lp.single p i (f i : E i)) - f‖ ^ p.toReal| =
+      ‖(∑ i in s, lp.single p i (f i : E i)) - f‖ ^ p.toReal := by
+    simp only [Real.abs_rpow_of_nonneg (norm_nonneg _), abs_norm]
   linarith
 #align lp.has_sum_single lp.hasSum_single
 
@@ -1190,10 +1193,10 @@ theorem tendsto_lp_of_tendsto_pi {F : ℕ → lp E p} (hF : CauchySeq F) {f : lp
     (hf : Tendsto (id fun i => F i : ℕ → ∀ a, E a) atTop (𝓝 f)) : Tendsto F atTop (𝓝 f) := by
   rw [Metric.nhds_basis_closedBall.tendsto_right_iff]
   intro ε hε
-  have hε' : { p : lp E p × lp E p | ‖p.1 - p.2‖ < ε } ∈ 𝓤 (lp E p) :=
+  have hε' : { p : lp E p × lp E p | ‖p.1 - p.2‖ < ε } ∈ uniformity (lp E p) :=
     NormedAddCommGroup.uniformity_basis_dist.mem_of_mem hε
   refine' (hF.eventually_eventually hε').mono _
-  rintro n (hn : ∀ᶠ l in at_top, ‖(fun f => F n - f) (F l)‖ < ε)
+  rintro n (hn : ∀ᶠ l in atTop, ‖(fun f => F n - f) (F l)‖ < ε)
   refine' norm_le_of_tendsto (hn.mono fun k hk => hk.le) _
   rw [tendsto_pi_nhds]
   intro a
@@ -1203,16 +1206,15 @@ theorem tendsto_lp_of_tendsto_pi {F : ℕ → lp E p} (hF : CauchySeq F) {f : lp
 variable [∀ a, CompleteSpace (E a)]
 
 instance : CompleteSpace (lp E p) :=
-  Metric.complete_of_cauchySeq_tendsto
-    (by
-      intro F hF
-      -- A Cauchy sequence in `lp E p` is pointwise convergent; let `f` be the pointwise limit.
-      obtain ⟨f, hf⟩ := cauchySeq_tendsto_of_complete
-        ((uniformContinuous_coe (p := p)).comp_cauchySeq hF)
-      -- Since the Cauchy sequence is bounded, its pointwise limit `f` is in `lp E p`.
-      have hf' : Memℓp f p := memℓp_of_tendsto hF.bounded_range hf
-      -- And therefore `f` is its limit in the `lp E p` topology as well as pointwise.
-      exact ⟨⟨f, hf'⟩, tendsto_lp_of_tendsto_pi hF hf⟩)
+  Metric.complete_of_cauchySeq_tendsto (by
+    intro F hF
+    -- A Cauchy sequence in `lp E p` is pointwise convergent; let `f` be the pointwise limit.
+    obtain ⟨f, hf⟩ := cauchySeq_tendsto_of_complete
+      ((uniformContinuous_coe (p := p)).comp_cauchySeq hF)
+    -- Since the Cauchy sequence is bounded, its pointwise limit `f` is in `lp E p`.
+    have hf' : Memℓp f p := memℓp_of_tendsto hF.bounded_range hf
+    -- And therefore `f` is its limit in the `lp E p` topology as well as pointwise.
+    exact ⟨⟨f, hf'⟩, tendsto_lp_of_tendsto_pi hF hf⟩)
 
 end Topology
 

--- a/Mathlib/Analysis/NormedSpace/LpSpace.lean
+++ b/Mathlib/Analysis/NormedSpace/LpSpace.lean
@@ -16,39 +16,38 @@ import Mathlib.Topology.Algebra.Order.LiminfLimsup
 /-!
 # ℓp space
 
-This file describes properties of elements `f` of a pi-type `Π i, E i` with finite "norm",
+This file describes properties of elements `f` of a pi-type `∀ i, E i` with finite "norm",
 defined for `p:ℝ≥0∞` as the size of the support of `f` if `p=0`, `(∑' a, ‖f a‖^p) ^ (1/p)` for
 `0 < p < ∞` and `⨆ a, ‖f a‖` for `p=∞`.
 
-The Prop-valued `mem_ℓp f p` states that a function `f : Π i, E i` has finite norm according
-to the above definition; that is, `f` has finite support if `p = 0`, `summable (λ a, ‖f a‖^p)` if
-`0 < p < ∞`, and `bdd_above (norm '' (set.range f))` if `p = ∞`.
+The Prop-valued `Memℓp f p` states that a function `f : ∀ i, E i` has finite norm according
+to the above definition; that is, `f` has finite support if `p = 0`, `Summable (fun a ↦ ‖f a‖^p)` if
+`0 < p < ∞`, and `BddAbove (norm '' (Set.range f))` if `p = ∞`.
 
-The space `lp E p` is the subtype of elements of `Π i : α, E i` which satisfy `mem_ℓp f p`. For
+The space `lp E p` is the subtype of elements of `∀ i : α, E i` which satisfy `Memℓp f p`. For
 `1 ≤ p`, the "norm" is genuinely a norm and `lp` is a complete metric space.
 
 ## Main definitions
 
-* `mem_ℓp f p` : property that the function `f` satisfies, as appropriate, `f` finitely supported
-  if `p = 0`, `summable (λ a, ‖f a‖^p)` if `0 < p < ∞`, and `bdd_above (norm '' (set.range f))` if
+* `Memℓp f p` : property that the function `f` satisfies, as appropriate, `f` finitely supported
+  if `p = 0`, `Summable (fun a ↦ ‖f a‖^p)` if `0 < p < ∞`, and `BddAbove (norm '' (Set.range f))` if
   `p = ∞`.
-* `lp E p` : elements of `Π i : α, E i` such that `mem_ℓp f p`. Defined as an `add_subgroup` of
-  a type synonym `pre_lp` for `Π i : α, E i`, and equipped with a `normed_add_comm_group` structure.
-  Under appropriate conditions, this is also equipped with the instances `lp.normed_space`,
-  `lp.complete_space`. For `p=∞`, there is also `lp.infty_normed_ring`,
-  `lp.infty_normed_algebra`, `lp.infty_star_ring` and `lp.infty_cstar_ring`.
+* `lp E p` : elements of `∀ i : α, E i` such that `Memℓp f p`. Defined as an `AddSubgroup` of
+  a type synonym `PreLp` for `∀ i : α, E i`, and equipped with a `NormedAddCommGroup` structure.
+  Under appropriate conditions, this is also equipped with the instances `lp.normedSpace`,
+  `lp.completeSpace`. For `p=∞`, there is also `lp.inftyNormedRing`,
+  `lp.inftyNormedAlgebra`, `lp.inftyStarRing` and `lp.inftyCstarRing`.
 
 ## Main results
 
-* `mem_ℓp.of_exponent_ge`: For `q ≤ p`, a function which is `mem_ℓp` for `q` is also `mem_ℓp` for
-  `p`
-* `lp.mem_ℓp_of_tendsto`, `lp.norm_le_of_tendsto`: A pointwise limit of functions in `lp`, all with
+* `Memℓp.of_exponent_ge`: For `q ≤ p`, a function which is `Memℓp` for `q` is also `Memℓp` for `p`.
+* `lp.memℓp_of_tendsto`, `lp.norm_le_of_tendsto`: A pointwise limit of functions in `lp`, all with
   `lp` norm `≤ C`, is itself in `lp` and has `lp` norm `≤ C`.
 * `lp.tsum_mul_le_mul_norm`: basic form of Hölder's inequality
 
 ## Implementation
 
-Since `lp` is defined as an `add_subgroup`, dot notation does not work. Use `lp.norm_neg f` to
+Since `lp` is defined as an `AddSubgroup`, dot notation does not work. Use `lp.norm_neg f` to
 say that `‖-f‖ = ‖f‖`, instead of the non-working `f.norm_neg`.
 
 ## TODO
@@ -67,14 +66,14 @@ open scoped NNReal ENNReal BigOperators
 variable {α : Type _} {E : α → Type _} {p q : ℝ≥0∞} [∀ i, NormedAddCommGroup (E i)]
 
 /-!
-### `mem_ℓp` predicate
+### `Memℓp` predicate
 
 -/
 
 
-/-- The property that `f : Π i : α, E i`
+/-- The property that `f : ∀ i : α, E i`
 * is finitely supported, if `p = 0`, or
-* admits an upper bound for `set.range (λ i, ‖f i‖)`, if `p = ∞`, or
+* admits an upper bound for `Set.range (fun i ↦ ‖f i‖)`, if `p = ∞`, or
 * has the series `∑' i, ‖f i‖ ^ p` be summable, if `0 < p < ∞`. -/
 def Memℓp (f : ∀ i, E i) (p : ℝ≥0∞) : Prop :=
   if p = 0 then Set.Finite { i | f i ≠ 0 }
@@ -295,15 +294,15 @@ end Memℓp
 /-!
 ### lp space
 
-The space of elements of `Π i, E i` satisfying the predicate `mem_ℓp`.
+The space of elements of `∀ i, E i` satisfying the predicate `Memℓp`.
 -/
 
 
-/-- We define `pre_lp E` to be a type synonym for `Π i, E i` which, importantly, does not inherit
-the `pi` topology on `Π i, E i` (otherwise this topology would descend to `lp E p` and conflict
+/-- We define `PreLp E` to be a type synonym for `∀ i, E i` which, importantly, does not inherit
+the `pi` topology on `∀ i, E i` (otherwise this topology would descend to `lp E p` and conflict
 with the normed group topology we will later equip it with.)
 
-We choose to deal with this issue by making a type synonym for `Π i, E i` rather than for the `lp`
+We choose to deal with this issue by making a type synonym for `∀ i, E i` rather than for the `lp`
 subgroup itself, because this allows all the spaces `lp E p` (for varying `p`) to be subgroups of
 the same ambient group, which permits lemma statements like `lp.monotone` (below). -/
 @[nolint unusedArguments]
@@ -527,7 +526,7 @@ instance normedAddCommGroup [hp : Fact (1 ≤ p)] : NormedAddCommGroup (lp E p) 
           exact Real.rpow_le_rpow (norm_nonneg _) (norm_add_le _ _) hp''.le
       eq_zero_of_map_eq_zero' := fun f => norm_eq_zero_iff.1 }
 
--- TODO: define an `ennreal` version of `is_conjugate_exponent`, and then express this inequality
+-- TODO: define an `ENNReal` version of `IsConjugateExponent`, and then express this inequality
 -- in a better version which also covers the case `p = 1, q = ∞`.
 /-- Hölder inequality -/
 protected theorem tsum_mul_le_mul_norm {p q : ℝ≥0∞} (hpq : p.toReal.IsConjugateExponent q.toReal)
@@ -628,7 +627,7 @@ theorem mem_lp_const_smul (c : 𝕜) (f : lp E p) : c • (f : PreLp E) ∈ lp E
 
 variable (E p 𝕜)
 
-/-- The `𝕜`-submodule of elements of `Π i : α, E i` whose `lp` norm is finite.  This is `lp E p`,
+/-- The `𝕜`-submodule of elements of `∀ i : α, E i` whose `lp` norm is finite. This is `lp E p`,
 with extra structure. -/
 def _root_.lpSubmodule : Submodule 𝕜 (PreLp E) :=
   { lp E p with smul_mem' := fun c f hf => by simpa using mem_lp_const_smul c ⟨f, hf⟩ }
@@ -665,7 +664,7 @@ theorem norm_const_smul_le (hp : p ≠ 0) (c : 𝕜) (f : lp E p) : ‖c • f�
     have hcf := lp.isLUB_norm (c • f)
     have hfc := (lp.isLUB_norm f).mul_left (norm_nonneg c)
     simp_rw [← Set.range_comp, Function.comp] at hfc
-    -- TODO: some `is_lub` API should make it a one-liner from here.
+    -- TODO: some `IsLUB` API should make it a one-liner from here.
     refine' hcf.right _
     have := hfc.left
     simp_rw [mem_upperBounds, Set.mem_range, forall_exists_index, forall_apply_eq_imp_iff'] at this⊢
@@ -837,7 +836,7 @@ instance inftyStarRing : StarRing (lp B ∞) :=
     star_mul := fun f g => ext <| star_mul (_ : ∀ i, B i) _ }
 #align lp.infty_star_ring lp.inftyStarRing
 
-instance infty_cstarRing [∀ i, CstarRing (B i)] : CstarRing (lp B ∞) where
+instance inftyCstarRing [∀ i, CstarRing (B i)] : CstarRing (lp B ∞) where
   norm_star_mul_self f := by
     apply le_antisymm
     · rw [← sq]
@@ -849,7 +848,7 @@ instance infty_cstarRing [∀ i, CstarRing (B i)] : CstarRing (lp B ∞) where
       refine' lp.norm_le_of_forall_le ‖star f * f‖.sqrt_nonneg fun i => _
       rw [Real.le_sqrt (norm_nonneg _) (norm_nonneg _), sq, ← CstarRing.norm_star_mul_self]
       exact lp.norm_apply_le_norm ENNReal.top_ne_zero (star f * f) i
-#align lp.infty_cstar_ring lp.infty_cstarRing
+#align lp.infty_cstar_ring lp.inftyCstarRing
 
 end StarRing
 
@@ -871,7 +870,7 @@ theorem _root_.one_memℓp_infty : Memℓp (1 : ∀ i, B i) ∞ :=
 
 variable (B)
 
-/-- The `𝕜`-subring of elements of `Π i : α, B i` whose `lp` norm is finite. This is `lp E ∞`,
+/-- The `𝕜`-subring of elements of `∀ i : α, B i` whose `lp` norm is finite. This is `lp E ∞`,
 with extra structure. -/
 def _root_.lpInftySubring : Subring (PreLp B) :=
   { lp B ∞ with
@@ -948,7 +947,7 @@ variable {I : Type _} {𝕜 : Type _} {B : I → Type _}
 
 variable [NormedField 𝕜] [∀ i, NormedRing (B i)] [∀ i, NormedAlgebra 𝕜 (B i)]
 
-/-- A variant of `pi.algebra` that lean can't find otherwise. -/
+/-- A variant of `Pi.algebra` that lean can't find otherwise. -/
 instance _root_.Pi.algebraOfNormedAlgebra : Algebra 𝕜 (∀ i, B i) :=
   @Pi.algebra I 𝕜 B _ _ fun _ => NormedAlgebra.toAlgebra
 #align pi.algebra_of_normed_algebra Pi.algebraOfNormedAlgebra
@@ -966,7 +965,7 @@ theorem _root_.algebraMap_memℓp_infty (k : 𝕜) : Memℓp (algebraMap 𝕜 (�
 
 variable (𝕜 B)
 
-/-- The `𝕜`-subalgebra of elements of `Π i : α, B i` whose `lp` norm is finite. This is `lp E ∞`,
+/-- The `𝕜`-subalgebra of elements of `∀ i : α, B i` whose `lp` norm is finite. This is `lp E ∞`,
 with extra structure. -/
 def _root_.lpInftySubalgebra : Subalgebra 𝕜 (PreLp B) :=
   { lpInftySubring B with
@@ -1112,7 +1111,7 @@ open Filter
 
 open scoped Topology uniformity
 
-/-- The coercion from `lp E p` to `Π i, E i` is uniformly continuous. -/
+/-- The coercion from `lp E p` to `∀ i, E i` is uniformly continuous. -/
 theorem uniformContinuous_coe [_i : Fact (1 ≤ p)] :
     UniformContinuous ((↑) : lp E p → ∀ i, E i) := by
   have hp : p ≠ 0 := (zero_lt_one.trans_le _i.elim).ne'
@@ -1205,7 +1204,7 @@ theorem tendsto_lp_of_tendsto_pi {F : ℕ → lp E p} (hF : CauchySeq F) {f : lp
 
 variable [∀ a, CompleteSpace (E a)]
 
-instance : CompleteSpace (lp E p) :=
+instance completeSpace : CompleteSpace (lp E p) :=
   Metric.complete_of_cauchySeq_tendsto (by
     intro F hF
     -- A Cauchy sequence in `lp E p` is pointwise convergent; let `f` be the pointwise limit.

--- a/Mathlib/Analysis/NormedSpace/LpSpace.lean
+++ b/Mathlib/Analysis/NormedSpace/LpSpace.lean
@@ -1030,7 +1030,7 @@ protected theorem single_apply_ne (p) (i : α) (a : E i) {j : α} (hij : j ≠ i
 
 @[simp]
 protected theorem single_neg (p) (i : α) (a : E i) : lp.single p i (-a) = -lp.single p i a := by
-  ext j
+  refine' ext (funext (fun (j : α) => _))
   by_cases hi : j = i
   · subst hi
     simp [lp.single_apply_self]

--- a/Mathlib/Analysis/NormedSpace/LpSpace.lean
+++ b/Mathlib/Analysis/NormedSpace/LpSpace.lean
@@ -1,0 +1,1259 @@
+/-
+Copyright (c) 2021 Heather Macbeth. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Heather Macbeth
+
+! This file was ported from Lean 3 source module analysis.normed_space.lp_space
+! leanprover-community/mathlib commit de83b43717abe353f425855fcf0cedf9ea0fe8a4
+! Please do not edit these lines, except to modify the commit id
+! if you have ported upstream changes.
+-/
+import Mathbin.Analysis.MeanInequalities
+import Mathbin.Analysis.MeanInequalitiesPow
+import Mathbin.Analysis.SpecialFunctions.Pow.Continuity
+import Mathbin.Topology.Algebra.Order.LiminfLimsup
+
+/-!
+# ℓp space
+
+This file describes properties of elements `f` of a pi-type `Π i, E i` with finite "norm",
+defined for `p:ℝ≥0∞` as the size of the support of `f` if `p=0`, `(∑' a, ‖f a‖^p) ^ (1/p)` for
+`0 < p < ∞` and `⨆ a, ‖f a‖` for `p=∞`.
+
+The Prop-valued `mem_ℓp f p` states that a function `f : Π i, E i` has finite norm according
+to the above definition; that is, `f` has finite support if `p = 0`, `summable (λ a, ‖f a‖^p)` if
+`0 < p < ∞`, and `bdd_above (norm '' (set.range f))` if `p = ∞`.
+
+The space `lp E p` is the subtype of elements of `Π i : α, E i` which satisfy `mem_ℓp f p`. For
+`1 ≤ p`, the "norm" is genuinely a norm and `lp` is a complete metric space.
+
+## Main definitions
+
+* `mem_ℓp f p` : property that the function `f` satisfies, as appropriate, `f` finitely supported
+  if `p = 0`, `summable (λ a, ‖f a‖^p)` if `0 < p < ∞`, and `bdd_above (norm '' (set.range f))` if
+  `p = ∞`.
+* `lp E p` : elements of `Π i : α, E i` such that `mem_ℓp f p`. Defined as an `add_subgroup` of
+  a type synonym `pre_lp` for `Π i : α, E i`, and equipped with a `normed_add_comm_group` structure.
+  Under appropriate conditions, this is also equipped with the instances `lp.normed_space`,
+  `lp.complete_space`. For `p=∞`, there is also `lp.infty_normed_ring`,
+  `lp.infty_normed_algebra`, `lp.infty_star_ring` and `lp.infty_cstar_ring`.
+
+## Main results
+
+* `mem_ℓp.of_exponent_ge`: For `q ≤ p`, a function which is `mem_ℓp` for `q` is also `mem_ℓp` for
+  `p`
+* `lp.mem_ℓp_of_tendsto`, `lp.norm_le_of_tendsto`: A pointwise limit of functions in `lp`, all with
+  `lp` norm `≤ C`, is itself in `lp` and has `lp` norm `≤ C`.
+* `lp.tsum_mul_le_mul_norm`: basic form of Hölder's inequality
+
+## Implementation
+
+Since `lp` is defined as an `add_subgroup`, dot notation does not work. Use `lp.norm_neg f` to
+say that `‖-f‖ = ‖f‖`, instead of the non-working `f.norm_neg`.
+
+## TODO
+
+* More versions of Hölder's inequality (for example: the case `p = 1`, `q = ∞`; a version for normed
+  rings which has `‖∑' i, f i * g i‖` rather than `∑' i, ‖f i‖ * g i‖` on the RHS; a version for
+  three exponents satisfying `1 / r = 1 / p + 1 / q`)
+
+-/
+
+
+noncomputable section
+
+open scoped NNReal ENNReal BigOperators
+
+variable {α : Type _} {E : α → Type _} {p q : ℝ≥0∞} [∀ i, NormedAddCommGroup (E i)]
+
+/-!
+### `mem_ℓp` predicate
+
+-/
+
+
+/-- The property that `f : Π i : α, E i`
+* is finitely supported, if `p = 0`, or
+* admits an upper bound for `set.range (λ i, ‖f i‖)`, if `p = ∞`, or
+* has the series `∑' i, ‖f i‖ ^ p` be summable, if `0 < p < ∞`. -/
+def Memℓp (f : ∀ i, E i) (p : ℝ≥0∞) : Prop :=
+  if p = 0 then Set.Finite { i | f i ≠ 0 }
+  else if p = ∞ then BddAbove (Set.range fun i => ‖f i‖) else Summable fun i => ‖f i‖ ^ p.toReal
+#align mem_ℓp Memℓp
+
+theorem memℓp_zero_iff {f : ∀ i, E i} : Memℓp f 0 ↔ Set.Finite { i | f i ≠ 0 } := by
+  dsimp [Memℓp] <;> rw [if_pos rfl]
+#align mem_ℓp_zero_iff memℓp_zero_iff
+
+theorem memℓp_zero {f : ∀ i, E i} (hf : Set.Finite { i | f i ≠ 0 }) : Memℓp f 0 :=
+  memℓp_zero_iff.2 hf
+#align mem_ℓp_zero memℓp_zero
+
+theorem memℓp_infty_iff {f : ∀ i, E i} : Memℓp f ∞ ↔ BddAbove (Set.range fun i => ‖f i‖) := by
+  dsimp [Memℓp] <;> rw [if_neg ENNReal.top_ne_zero, if_pos rfl]
+#align mem_ℓp_infty_iff memℓp_infty_iff
+
+theorem memℓp_infty {f : ∀ i, E i} (hf : BddAbove (Set.range fun i => ‖f i‖)) : Memℓp f ∞ :=
+  memℓp_infty_iff.2 hf
+#align mem_ℓp_infty memℓp_infty
+
+theorem memℓp_gen_iff (hp : 0 < p.toReal) {f : ∀ i, E i} :
+    Memℓp f p ↔ Summable fun i => ‖f i‖ ^ p.toReal :=
+  by
+  rw [ENNReal.toReal_pos_iff] at hp
+  dsimp [Memℓp]
+  rw [if_neg hp.1.ne', if_neg hp.2.Ne]
+#align mem_ℓp_gen_iff memℓp_gen_iff
+
+theorem memℓp_gen {f : ∀ i, E i} (hf : Summable fun i => ‖f i‖ ^ p.toReal) : Memℓp f p :=
+  by
+  rcases p.trichotomy with (rfl | rfl | hp)
+  · apply memℓp_zero
+    have H : Summable fun i : α => (1 : ℝ) := by simpa using hf
+    exact (Set.Finite.of_summable_const (by norm_num) H).Subset (Set.subset_univ _)
+  · apply memℓp_infty
+    have H : Summable fun i : α => (1 : ℝ) := by simpa using hf
+    simpa using ((Set.Finite.of_summable_const (by norm_num) H).image fun i => ‖f i‖).BddAbove
+  exact (memℓp_gen_iff hp).2 hf
+#align mem_ℓp_gen memℓp_gen
+
+theorem memℓp_gen' {C : ℝ} {f : ∀ i, E i} (hf : ∀ s : Finset α, (∑ i in s, ‖f i‖ ^ p.toReal) ≤ C) :
+    Memℓp f p := by
+  apply memℓp_gen
+  use ⨆ s : Finset α, ∑ i in s, ‖f i‖ ^ p.to_real
+  apply hasSum_of_isLUB_of_nonneg
+  · intro b
+    exact Real.rpow_nonneg_of_nonneg (norm_nonneg _) _
+  apply isLUB_ciSup
+  use C
+  rintro - ⟨s, rfl⟩
+  exact hf s
+#align mem_ℓp_gen' memℓp_gen'
+
+theorem zero_memℓp : Memℓp (0 : ∀ i, E i) p :=
+  by
+  rcases p.trichotomy with (rfl | rfl | hp)
+  · apply memℓp_zero
+    simp
+  · apply memℓp_infty
+    simp only [norm_zero, Pi.zero_apply]
+    exact bdd_above_singleton.mono Set.range_const_subset
+  · apply memℓp_gen
+    simp [Real.zero_rpow hp.ne', summable_zero]
+#align zero_mem_ℓp zero_memℓp
+
+theorem zero_mem_ℓp' : Memℓp (fun i : α => (0 : E i)) p :=
+  zero_memℓp
+#align zero_mem_ℓp' zero_mem_ℓp'
+
+namespace Memℓp
+
+theorem finite_dsupport {f : ∀ i, E i} (hf : Memℓp f 0) : Set.Finite { i | f i ≠ 0 } :=
+  memℓp_zero_iff.1 hf
+#align mem_ℓp.finite_dsupport Memℓp.finite_dsupport
+
+theorem bddAbove {f : ∀ i, E i} (hf : Memℓp f ∞) : BddAbove (Set.range fun i => ‖f i‖) :=
+  memℓp_infty_iff.1 hf
+#align mem_ℓp.bdd_above Memℓp.bddAbove
+
+theorem summable (hp : 0 < p.toReal) {f : ∀ i, E i} (hf : Memℓp f p) :
+    Summable fun i => ‖f i‖ ^ p.toReal :=
+  (memℓp_gen_iff hp).1 hf
+#align mem_ℓp.summable Memℓp.summable
+
+theorem neg {f : ∀ i, E i} (hf : Memℓp f p) : Memℓp (-f) p :=
+  by
+  rcases p.trichotomy with (rfl | rfl | hp)
+  · apply memℓp_zero
+    simp [hf.finite_dsupport]
+  · apply memℓp_infty
+    simpa using hf.bdd_above
+  · apply memℓp_gen
+    simpa using hf.summable hp
+#align mem_ℓp.neg Memℓp.neg
+
+@[simp]
+theorem neg_iff {f : ∀ i, E i} : Memℓp (-f) p ↔ Memℓp f p :=
+  ⟨fun h => neg_neg f ▸ h.neg, Memℓp.neg⟩
+#align mem_ℓp.neg_iff Memℓp.neg_iff
+
+/- ./././Mathport/Syntax/Translate/Basic.lean:635:2: warning: expanding binder collection (i «expr ∉ » hfq.finite_dsupport.to_finset) -/
+theorem of_exponent_ge {p q : ℝ≥0∞} {f : ∀ i, E i} (hfq : Memℓp f q) (hpq : q ≤ p) : Memℓp f p :=
+  by
+  rcases ENNReal.trichotomy₂ hpq with
+    (⟨rfl, rfl⟩ | ⟨rfl, rfl⟩ | ⟨rfl, hp⟩ | ⟨rfl, rfl⟩ | ⟨hq, rfl⟩ | ⟨hq, hp, hpq'⟩)
+  · exact hfq
+  · apply memℓp_infty
+    obtain ⟨C, hC⟩ := (hfq.finite_dsupport.image fun i => ‖f i‖).BddAbove
+    use max 0 C
+    rintro x ⟨i, rfl⟩
+    by_cases hi : f i = 0
+    · simp [hi]
+    · exact (hC ⟨i, hi, rfl⟩).trans (le_max_right _ _)
+  · apply memℓp_gen
+    have : ∀ (i) (_ : i ∉ hfq.finite_dsupport.to_finset), ‖f i‖ ^ p.to_real = 0 :=
+      by
+      intro i hi
+      have : f i = 0 := by simpa using hi
+      simp [this, Real.zero_rpow hp.ne']
+    exact summable_of_ne_finset_zero this
+  · exact hfq
+  · apply memℓp_infty
+    obtain ⟨A, hA⟩ := (hfq.summable hq).tendsto_cofinite_zero.bddAbove_range_of_cofinite
+    use A ^ q.to_real⁻¹
+    rintro x ⟨i, rfl⟩
+    have : 0 ≤ ‖f i‖ ^ q.to_real := Real.rpow_nonneg_of_nonneg (norm_nonneg _) _
+    simpa [← Real.rpow_mul, mul_inv_cancel hq.ne'] using
+      Real.rpow_le_rpow this (hA ⟨i, rfl⟩) (inv_nonneg.mpr hq.le)
+  · apply memℓp_gen
+    have hf' := hfq.summable hq
+    refine' summable_of_norm_bounded_eventually _ hf' (@Set.Finite.subset _ { i | 1 ≤ ‖f i‖ } _ _ _)
+    · have H : { x : α | 1 ≤ ‖f x‖ ^ q.to_real }.Finite := by
+        simpa using
+          eventually_lt_of_tendsto_lt (by norm_num : (0 : ℝ) < 1) hf'.tendsto_cofinite_zero
+      exact H.subset fun i hi => Real.one_le_rpow hi hq.le
+    · show ∀ i, ¬|‖f i‖ ^ p.to_real| ≤ ‖f i‖ ^ q.to_real → 1 ≤ ‖f i‖
+      intro i hi
+      have : 0 ≤ ‖f i‖ ^ p.to_real := Real.rpow_nonneg_of_nonneg (norm_nonneg _) p.to_real
+      simp only [abs_of_nonneg, this] at hi
+      contrapose! hi
+      exact Real.rpow_le_rpow_of_exponent_ge' (norm_nonneg _) hi.le hq.le hpq'
+#align mem_ℓp.of_exponent_ge Memℓp.of_exponent_ge
+
+theorem add {f g : ∀ i, E i} (hf : Memℓp f p) (hg : Memℓp g p) : Memℓp (f + g) p :=
+  by
+  rcases p.trichotomy with (rfl | rfl | hp)
+  · apply memℓp_zero
+    refine' (hf.finite_dsupport.union hg.finite_dsupport).Subset fun i => _
+    simp only [Pi.add_apply, Ne.def, Set.mem_union, Set.mem_setOf_eq]
+    contrapose!
+    rintro ⟨hf', hg'⟩
+    simp [hf', hg']
+  · apply memℓp_infty
+    obtain ⟨A, hA⟩ := hf.bdd_above
+    obtain ⟨B, hB⟩ := hg.bdd_above
+    refine' ⟨A + B, _⟩
+    rintro a ⟨i, rfl⟩
+    exact le_trans (norm_add_le _ _) (add_le_add (hA ⟨i, rfl⟩) (hB ⟨i, rfl⟩))
+  apply memℓp_gen
+  let C : ℝ := if p.to_real < 1 then 1 else 2 ^ (p.to_real - 1)
+  refine'
+    summable_of_nonneg_of_le _ (fun i => _) (((hf.summable hp).add (hg.summable hp)).mul_left C)
+  · exact fun b => Real.rpow_nonneg_of_nonneg (norm_nonneg (f b + g b)) p.to_real
+  · refine' (Real.rpow_le_rpow (norm_nonneg _) (norm_add_le _ _) hp.le).trans _
+    dsimp [C]
+    split_ifs with h h
+    · simpa using NNReal.coe_le_coe.2 (NNReal.rpow_add_le_add_rpow ‖f i‖₊ ‖g i‖₊ hp.le h.le)
+    · let F : Fin 2 → ℝ≥0 := ![‖f i‖₊, ‖g i‖₊]
+      have : ∀ i, (0 : ℝ) ≤ F i := fun i => (F i).coe_nonneg
+      simp only [not_lt] at h
+      simpa [F, Fin.sum_univ_succ] using
+        Real.rpow_sum_le_const_mul_sum_rpow_of_nonneg (Finset.univ : Finset (Fin 2)) h fun i _ =>
+          (F i).coe_nonneg
+#align mem_ℓp.add Memℓp.add
+
+theorem sub {f g : ∀ i, E i} (hf : Memℓp f p) (hg : Memℓp g p) : Memℓp (f - g) p := by
+  rw [sub_eq_add_neg]; exact hf.add hg.neg
+#align mem_ℓp.sub Memℓp.sub
+
+theorem finset_sum {ι} (s : Finset ι) {f : ι → ∀ i, E i} (hf : ∀ i ∈ s, Memℓp (f i) p) :
+    Memℓp (fun a => ∑ i in s, f i a) p :=
+  by
+  haveI : DecidableEq ι := Classical.decEq _
+  revert hf
+  refine' Finset.induction_on s _ _
+  · simp only [zero_mem_ℓp', Finset.sum_empty, imp_true_iff]
+  · intro i s his ih hf
+    simp only [his, Finset.sum_insert, not_false_iff]
+    exact (hf i (s.mem_insert_self i)).add (ih fun j hj => hf j (Finset.mem_insert_of_mem hj))
+#align mem_ℓp.finset_sum Memℓp.finset_sum
+
+section BoundedSMul
+
+variable {𝕜 : Type _} [NormedRing 𝕜] [∀ i, Module 𝕜 (E i)] [∀ i, BoundedSMul 𝕜 (E i)]
+
+theorem const_smul {f : ∀ i, E i} (hf : Memℓp f p) (c : 𝕜) : Memℓp (c • f) p :=
+  by
+  rcases p.trichotomy with (rfl | rfl | hp)
+  · apply memℓp_zero
+    refine' hf.finite_dsupport.subset fun i => (_ : ¬c • f i = 0 → ¬f i = 0)
+    exact not_imp_not.mpr fun hf' => hf'.symm ▸ smul_zero c
+  · obtain ⟨A, hA⟩ := hf.bdd_above
+    refine' memℓp_infty ⟨‖c‖ * A, _⟩
+    rintro a ⟨i, rfl⟩
+    refine' (norm_smul_le _ _).trans _
+    exact mul_le_mul_of_nonneg_left (hA ⟨i, rfl⟩) (norm_nonneg c)
+  · apply memℓp_gen
+    have := (hf.summable hp).mul_left (↑(‖c‖₊ ^ p.to_real) : ℝ)
+    simp_rw [← coe_nnnorm, ← NNReal.coe_rpow, ← NNReal.coe_mul, NNReal.summable_coe, ←
+      NNReal.mul_rpow] at this⊢
+    refine' NNReal.summable_of_le _ this
+    intro i
+    exact NNReal.rpow_le_rpow (nnnorm_smul_le _ _) ENNReal.toReal_nonneg
+#align mem_ℓp.const_smul Memℓp.const_smul
+
+theorem const_mul {f : α → 𝕜} (hf : Memℓp f p) (c : 𝕜) : Memℓp (fun x => c * f x) p :=
+  @Memℓp.const_smul α (fun i => 𝕜) _ _ 𝕜 _ _ (fun i => by infer_instance) _ hf c
+#align mem_ℓp.const_mul Memℓp.const_mul
+
+end BoundedSMul
+
+end Memℓp
+
+/-!
+### lp space
+
+The space of elements of `Π i, E i` satisfying the predicate `mem_ℓp`.
+-/
+
+
+/-- We define `pre_lp E` to be a type synonym for `Π i, E i` which, importantly, does not inherit
+the `pi` topology on `Π i, E i` (otherwise this topology would descend to `lp E p` and conflict
+with the normed group topology we will later equip it with.)
+
+We choose to deal with this issue by making a type synonym for `Π i, E i` rather than for the `lp`
+subgroup itself, because this allows all the spaces `lp E p` (for varying `p`) to be subgroups of
+the same ambient group, which permits lemma statements like `lp.monotone` (below). -/
+@[nolint unused_arguments]
+def PreLp (E : α → Type _) [∀ i, NormedAddCommGroup (E i)] : Type _ :=
+  ∀ i, E i deriving AddCommGroup
+#align pre_lp PreLp
+
+instance PreLp.unique [IsEmpty α] : Unique (PreLp E) :=
+  Pi.uniqueOfIsEmpty E
+#align pre_lp.unique PreLp.unique
+
+/-- lp space -/
+def lp (E : α → Type _) [∀ i, NormedAddCommGroup (E i)] (p : ℝ≥0∞) : AddSubgroup (PreLp E)
+    where
+  carrier := { f | Memℓp f p }
+  zero_mem' := zero_memℓp
+  add_mem' f g := Memℓp.add
+  neg_mem' f := Memℓp.neg
+#align lp lp
+
+namespace lp
+
+instance : Coe (lp E p) (∀ i, E i) :=
+  coeSubtype
+
+instance : CoeFun (lp E p) fun _ => ∀ i, E i :=
+  ⟨fun f => ((f : ∀ i, E i) : ∀ i, E i)⟩
+
+@[ext]
+theorem ext {f g : lp E p} (h : (f : ∀ i, E i) = g) : f = g :=
+  Subtype.ext h
+#align lp.ext lp.ext
+
+protected theorem ext_iff {f g : lp E p} : f = g ↔ (f : ∀ i, E i) = g :=
+  Subtype.ext_iff
+#align lp.ext_iff lp.ext_iff
+
+theorem eq_zero' [IsEmpty α] (f : lp E p) : f = 0 :=
+  Subsingleton.elim f 0
+#align lp.eq_zero' lp.eq_zero'
+
+protected theorem monotone {p q : ℝ≥0∞} (hpq : q ≤ p) : lp E q ≤ lp E p := fun f hf =>
+  Memℓp.of_exponent_ge hf hpq
+#align lp.monotone lp.monotone
+
+protected theorem memℓp (f : lp E p) : Memℓp f p :=
+  f.Prop
+#align lp.mem_ℓp lp.memℓp
+
+variable (E p)
+
+@[simp]
+theorem coeFn_zero : ⇑(0 : lp E p) = 0 :=
+  rfl
+#align lp.coe_fn_zero lp.coeFn_zero
+
+variable {E p}
+
+@[simp]
+theorem coeFn_neg (f : lp E p) : ⇑(-f) = -f :=
+  rfl
+#align lp.coe_fn_neg lp.coeFn_neg
+
+@[simp]
+theorem coeFn_add (f g : lp E p) : ⇑(f + g) = f + g :=
+  rfl
+#align lp.coe_fn_add lp.coeFn_add
+
+@[simp]
+theorem coeFn_sum {ι : Type _} (f : ι → lp E p) (s : Finset ι) :
+    ⇑(∑ i in s, f i) = ∑ i in s, ⇑(f i) := by
+  classical
+    refine' Finset.induction _ _ s
+    · simp
+    intro i s his
+    simp [Finset.sum_insert his]
+#align lp.coe_fn_sum lp.coeFn_sum
+
+@[simp]
+theorem coeFn_sub (f g : lp E p) : ⇑(f - g) = f - g :=
+  rfl
+#align lp.coe_fn_sub lp.coeFn_sub
+
+instance : Norm (lp E p)
+    where norm f :=
+    if hp : p = 0 then by subst hp <;> exact (lp.memℓp f).finite_dsupport.toFinset.card
+    else if p = ∞ then ⨆ i, ‖f i‖ else (∑' i, ‖f i‖ ^ p.toReal) ^ (1 / p.toReal)
+
+theorem norm_eq_card_dsupport (f : lp E 0) : ‖f‖ = (lp.memℓp f).finite_dsupport.toFinset.card :=
+  dif_pos rfl
+#align lp.norm_eq_card_dsupport lp.norm_eq_card_dsupport
+
+theorem norm_eq_csupr (f : lp E ∞) : ‖f‖ = ⨆ i, ‖f i‖ :=
+  by
+  dsimp [norm]
+  rw [dif_neg ENNReal.top_ne_zero, if_pos rfl]
+#align lp.norm_eq_csupr lp.norm_eq_csupr
+
+theorem isLUB_norm [Nonempty α] (f : lp E ∞) : IsLUB (Set.range fun i => ‖f i‖) ‖f‖ :=
+  by
+  rw [lp.norm_eq_csupr]
+  exact isLUB_ciSup (lp.memℓp f)
+#align lp.is_lub_norm lp.isLUB_norm
+
+theorem norm_eq_tsum_rpow (hp : 0 < p.toReal) (f : lp E p) :
+    ‖f‖ = (∑' i, ‖f i‖ ^ p.toReal) ^ (1 / p.toReal) :=
+  by
+  dsimp [norm]
+  rw [ENNReal.toReal_pos_iff] at hp
+  rw [dif_neg hp.1.ne', if_neg hp.2.Ne]
+#align lp.norm_eq_tsum_rpow lp.norm_eq_tsum_rpow
+
+theorem norm_rpow_eq_tsum (hp : 0 < p.toReal) (f : lp E p) :
+    ‖f‖ ^ p.toReal = ∑' i, ‖f i‖ ^ p.toReal :=
+  by
+  rw [norm_eq_tsum_rpow hp, ← Real.rpow_mul]
+  · field_simp [hp.ne']
+  apply tsum_nonneg
+  intro i
+  calc
+    (0 : ℝ) = 0 ^ p.to_real := by rw [Real.zero_rpow hp.ne']
+    _ ≤ _ := Real.rpow_le_rpow rfl.le (norm_nonneg (f i)) hp.le
+    
+#align lp.norm_rpow_eq_tsum lp.norm_rpow_eq_tsum
+
+theorem hasSum_norm (hp : 0 < p.toReal) (f : lp E p) :
+    HasSum (fun i => ‖f i‖ ^ p.toReal) (‖f‖ ^ p.toReal) :=
+  by
+  rw [norm_rpow_eq_tsum hp]
+  exact ((lp.memℓp f).Summable hp).HasSum
+#align lp.has_sum_norm lp.hasSum_norm
+
+theorem norm_nonneg' (f : lp E p) : 0 ≤ ‖f‖ :=
+  by
+  rcases p.trichotomy with (rfl | rfl | hp)
+  · simp [lp.norm_eq_card_dsupport f]
+  · cases' isEmpty_or_nonempty α with _i _i <;> skip
+    · rw [lp.norm_eq_csupr]
+      simp [Real.ciSup_empty]
+    inhabit α
+    exact (norm_nonneg (f default)).trans ((lp.isLUB_norm f).1 ⟨default, rfl⟩)
+  · rw [lp.norm_eq_tsum_rpow hp f]
+    refine' Real.rpow_nonneg_of_nonneg (tsum_nonneg _) _
+    exact fun i => Real.rpow_nonneg_of_nonneg (norm_nonneg _) _
+#align lp.norm_nonneg' lp.norm_nonneg'
+
+@[simp]
+theorem norm_zero : ‖(0 : lp E p)‖ = 0 :=
+  by
+  rcases p.trichotomy with (rfl | rfl | hp)
+  · simp [lp.norm_eq_card_dsupport]
+  · simp [lp.norm_eq_csupr]
+  · rw [lp.norm_eq_tsum_rpow hp]
+    have hp' : 1 / p.to_real ≠ 0 := one_div_ne_zero hp.ne'
+    simpa [Real.zero_rpow hp.ne'] using Real.zero_rpow hp'
+#align lp.norm_zero lp.norm_zero
+
+theorem norm_eq_zero_iff {f : lp E p} : ‖f‖ = 0 ↔ f = 0 := by
+  classical
+    refine' ⟨fun h => _, by rintro rfl; exact norm_zero⟩
+    rcases p.trichotomy with (rfl | rfl | hp)
+    · ext i
+      have : { i : α | ¬f i = 0 } = ∅ := by simpa [lp.norm_eq_card_dsupport f] using h
+      have : (¬f i = 0) = False := congr_fun this i
+      tauto
+    · cases' isEmpty_or_nonempty α with _i _i <;> skip
+      · simp
+      have H : IsLUB (Set.range fun i => ‖f i‖) 0 := by simpa [h] using lp.isLUB_norm f
+      ext i
+      have : ‖f i‖ = 0 := le_antisymm (H.1 ⟨i, rfl⟩) (norm_nonneg _)
+      simpa using this
+    · have hf : HasSum (fun i : α => ‖f i‖ ^ p.to_real) 0 :=
+        by
+        have := lp.hasSum_norm hp f
+        rwa [h, Real.zero_rpow hp.ne'] at this
+      have : ∀ i, 0 ≤ ‖f i‖ ^ p.to_real := fun i => Real.rpow_nonneg_of_nonneg (norm_nonneg _) _
+      rw [hasSum_zero_iff_of_nonneg this] at hf
+      ext i
+      have : f i = 0 ∧ p.to_real ≠ 0 := by
+        simpa [Real.rpow_eq_zero_iff_of_nonneg (norm_nonneg (f i))] using congr_fun hf i
+      exact this.1
+#align lp.norm_eq_zero_iff lp.norm_eq_zero_iff
+
+theorem eq_zero_iff_coeFn_eq_zero {f : lp E p} : f = 0 ↔ ⇑f = 0 := by rw [lp.ext_iff, coe_fn_zero]
+#align lp.eq_zero_iff_coe_fn_eq_zero lp.eq_zero_iff_coeFn_eq_zero
+
+@[simp]
+theorem norm_neg ⦃f : lp E p⦄ : ‖-f‖ = ‖f‖ :=
+  by
+  rcases p.trichotomy with (rfl | rfl | hp)
+  · simp [lp.norm_eq_card_dsupport]
+  · cases isEmpty_or_nonempty α <;> skip
+    · simp [lp.eq_zero' f]
+    apply (lp.isLUB_norm (-f)).unique
+    simpa using lp.isLUB_norm f
+  · suffices ‖-f‖ ^ p.to_real = ‖f‖ ^ p.to_real by
+      exact Real.rpow_left_injOn hp.ne' (norm_nonneg' _) (norm_nonneg' _) this
+    apply (lp.hasSum_norm hp (-f)).unique
+    simpa using lp.hasSum_norm hp f
+#align lp.norm_neg lp.norm_neg
+
+instance [hp : Fact (1 ≤ p)] : NormedAddCommGroup (lp E p) :=
+  AddGroupNorm.toNormedAddCommGroup
+    { toFun := norm
+      map_zero' := norm_zero
+      neg' := norm_neg
+      add_le' := fun f g => by
+        rcases p.dichotomy with (rfl | hp')
+        · cases isEmpty_or_nonempty α
+          · simp [lp.eq_zero' f]
+          refine' (lp.isLUB_norm (f + g)).2 _
+          rintro x ⟨i, rfl⟩
+          refine'
+            le_trans _
+              (add_mem_upperBounds_add (lp.isLUB_norm f).1 (lp.isLUB_norm g).1
+                ⟨_, _, ⟨i, rfl⟩, ⟨i, rfl⟩, rfl⟩)
+          exact norm_add_le (f i) (g i)
+        · have hp'' : 0 < p.to_real := zero_lt_one.trans_le hp'
+          have hf₁ : ∀ i, 0 ≤ ‖f i‖ := fun i => norm_nonneg _
+          have hg₁ : ∀ i, 0 ≤ ‖g i‖ := fun i => norm_nonneg _
+          have hf₂ := lp.hasSum_norm hp'' f
+          have hg₂ := lp.hasSum_norm hp'' g
+          -- apply Minkowski's inequality
+          obtain ⟨C, hC₁, hC₂, hCfg⟩ :=
+            Real.Lp_add_le_hasSum_of_nonneg hp' hf₁ hg₁ (norm_nonneg' _) (norm_nonneg' _) hf₂ hg₂
+          refine' le_trans _ hC₂
+          rw [← Real.rpow_le_rpow_iff (norm_nonneg' (f + g)) hC₁ hp'']
+          refine' hasSum_le _ (lp.hasSum_norm hp'' (f + g)) hCfg
+          intro i
+          exact Real.rpow_le_rpow (norm_nonneg _) (norm_add_le _ _) hp''.le
+      eq_zero_of_map_eq_zero' := fun f => norm_eq_zero_iff.1 }
+
+-- TODO: define an `ennreal` version of `is_conjugate_exponent`, and then express this inequality
+-- in a better version which also covers the case `p = 1, q = ∞`.
+/-- Hölder inequality -/
+protected theorem tsum_mul_le_mul_norm {p q : ℝ≥0∞} (hpq : p.toReal.IsConjugateExponent q.toReal)
+    (f : lp E p) (g : lp E q) :
+    (Summable fun i => ‖f i‖ * ‖g i‖) ∧ (∑' i, ‖f i‖ * ‖g i‖) ≤ ‖f‖ * ‖g‖ :=
+  by
+  have hf₁ : ∀ i, 0 ≤ ‖f i‖ := fun i => norm_nonneg _
+  have hg₁ : ∀ i, 0 ≤ ‖g i‖ := fun i => norm_nonneg _
+  have hf₂ := lp.hasSum_norm hpq.pos f
+  have hg₂ := lp.hasSum_norm hpq.symm.pos g
+  obtain ⟨C, -, hC', hC⟩ :=
+    Real.inner_le_Lp_mul_Lq_hasSum_of_nonneg hpq (norm_nonneg' _) (norm_nonneg' _) hf₁ hg₁ hf₂ hg₂
+  rw [← hC.tsum_eq] at hC'
+  exact ⟨hC.summable, hC'⟩
+#align lp.tsum_mul_le_mul_norm lp.tsum_mul_le_mul_norm
+
+protected theorem summable_mul {p q : ℝ≥0∞} (hpq : p.toReal.IsConjugateExponent q.toReal)
+    (f : lp E p) (g : lp E q) : Summable fun i => ‖f i‖ * ‖g i‖ :=
+  (lp.tsum_mul_le_mul_norm hpq f g).1
+#align lp.summable_mul lp.summable_mul
+
+protected theorem tsum_mul_le_mul_norm' {p q : ℝ≥0∞} (hpq : p.toReal.IsConjugateExponent q.toReal)
+    (f : lp E p) (g : lp E q) : (∑' i, ‖f i‖ * ‖g i‖) ≤ ‖f‖ * ‖g‖ :=
+  (lp.tsum_mul_le_mul_norm hpq f g).2
+#align lp.tsum_mul_le_mul_norm' lp.tsum_mul_le_mul_norm'
+
+section ComparePointwise
+
+theorem norm_apply_le_norm (hp : p ≠ 0) (f : lp E p) (i : α) : ‖f i‖ ≤ ‖f‖ :=
+  by
+  rcases eq_or_ne p ∞ with (rfl | hp')
+  · haveI : Nonempty α := ⟨i⟩
+    exact (is_lub_norm f).1 ⟨i, rfl⟩
+  have hp'' : 0 < p.to_real := ENNReal.toReal_pos hp hp'
+  have : ∀ i, 0 ≤ ‖f i‖ ^ p.to_real := fun i => Real.rpow_nonneg_of_nonneg (norm_nonneg _) _
+  rw [← Real.rpow_le_rpow_iff (norm_nonneg _) (norm_nonneg' _) hp'']
+  convert le_hasSum (has_sum_norm hp'' f) i fun i hi => this i
+#align lp.norm_apply_le_norm lp.norm_apply_le_norm
+
+theorem sum_rpow_le_norm_rpow (hp : 0 < p.toReal) (f : lp E p) (s : Finset α) :
+    (∑ i in s, ‖f i‖ ^ p.toReal) ≤ ‖f‖ ^ p.toReal :=
+  by
+  rw [lp.norm_rpow_eq_tsum hp f]
+  have : ∀ i, 0 ≤ ‖f i‖ ^ p.to_real := fun i => Real.rpow_nonneg_of_nonneg (norm_nonneg _) _
+  refine' sum_le_tsum _ (fun i hi => this i) _
+  exact (lp.memℓp f).Summable hp
+#align lp.sum_rpow_le_norm_rpow lp.sum_rpow_le_norm_rpow
+
+theorem norm_le_of_forall_le' [Nonempty α] {f : lp E ∞} (C : ℝ) (hCf : ∀ i, ‖f i‖ ≤ C) : ‖f‖ ≤ C :=
+  by
+  refine' (is_lub_norm f).2 _
+  rintro - ⟨i, rfl⟩
+  exact hCf i
+#align lp.norm_le_of_forall_le' lp.norm_le_of_forall_le'
+
+theorem norm_le_of_forall_le {f : lp E ∞} {C : ℝ} (hC : 0 ≤ C) (hCf : ∀ i, ‖f i‖ ≤ C) : ‖f‖ ≤ C :=
+  by
+  cases isEmpty_or_nonempty α
+  · simpa [eq_zero' f] using hC
+  · exact norm_le_of_forall_le' C hCf
+#align lp.norm_le_of_forall_le lp.norm_le_of_forall_le
+
+theorem norm_le_of_tsum_le (hp : 0 < p.toReal) {C : ℝ} (hC : 0 ≤ C) {f : lp E p}
+    (hf : (∑' i, ‖f i‖ ^ p.toReal) ≤ C ^ p.toReal) : ‖f‖ ≤ C :=
+  by
+  rw [← Real.rpow_le_rpow_iff (norm_nonneg' _) hC hp, norm_rpow_eq_tsum hp]
+  exact hf
+#align lp.norm_le_of_tsum_le lp.norm_le_of_tsum_le
+
+theorem norm_le_of_forall_sum_le (hp : 0 < p.toReal) {C : ℝ} (hC : 0 ≤ C) {f : lp E p}
+    (hf : ∀ s : Finset α, (∑ i in s, ‖f i‖ ^ p.toReal) ≤ C ^ p.toReal) : ‖f‖ ≤ C :=
+  norm_le_of_tsum_le hp hC (tsum_le_of_sum_le ((lp.memℓp f).Summable hp) hf)
+#align lp.norm_le_of_forall_sum_le lp.norm_le_of_forall_sum_le
+
+end ComparePointwise
+
+section BoundedSMul
+
+variable {𝕜 : Type _} {𝕜' : Type _}
+
+variable [NormedRing 𝕜] [NormedRing 𝕜']
+
+variable [∀ i, Module 𝕜 (E i)] [∀ i, Module 𝕜' (E i)]
+
+instance : Module 𝕜 (PreLp E) :=
+  Pi.module α E 𝕜
+
+instance [∀ i, SMulCommClass 𝕜' 𝕜 (E i)] : SMulCommClass 𝕜' 𝕜 (PreLp E) :=
+  Pi.smulCommClass
+
+instance [SMul 𝕜' 𝕜] [∀ i, IsScalarTower 𝕜' 𝕜 (E i)] : IsScalarTower 𝕜' 𝕜 (PreLp E) :=
+  Pi.isScalarTower
+
+instance [∀ i, Module 𝕜ᵐᵒᵖ (E i)] [∀ i, IsCentralScalar 𝕜 (E i)] : IsCentralScalar 𝕜 (PreLp E) :=
+  Pi.isCentralScalar
+
+variable [∀ i, BoundedSMul 𝕜 (E i)] [∀ i, BoundedSMul 𝕜' (E i)]
+
+theorem mem_lp_const_smul (c : 𝕜) (f : lp E p) : c • (f : PreLp E) ∈ lp E p :=
+  (lp.memℓp f).const_smul c
+#align lp.mem_lp_const_smul lp.mem_lp_const_smul
+
+variable (E p 𝕜)
+
+/-- The `𝕜`-submodule of elements of `Π i : α, E i` whose `lp` norm is finite.  This is `lp E p`,
+with extra structure. -/
+def lpSubmodule : Submodule 𝕜 (PreLp E) :=
+  { lp E p with smul_mem' := fun c f hf => by simpa using mem_lp_const_smul c ⟨f, hf⟩ }
+#align lp_submodule lpSubmodule
+
+variable {E p 𝕜}
+
+theorem coe_lpSubmodule : (lpSubmodule E p 𝕜).toAddSubgroup = lp E p :=
+  rfl
+#align lp.coe_lp_submodule lp.coe_lpSubmodule
+
+instance : Module 𝕜 (lp E p) :=
+  { (lpSubmodule E p 𝕜).Module with }
+
+@[simp]
+theorem coeFn_smul (c : 𝕜) (f : lp E p) : ⇑(c • f) = c • f :=
+  rfl
+#align lp.coe_fn_smul lp.coeFn_smul
+
+instance [∀ i, SMulCommClass 𝕜' 𝕜 (E i)] : SMulCommClass 𝕜' 𝕜 (lp E p) :=
+  ⟨fun r c f => Subtype.ext <| smul_comm _ _ _⟩
+
+instance [SMul 𝕜' 𝕜] [∀ i, IsScalarTower 𝕜' 𝕜 (E i)] : IsScalarTower 𝕜' 𝕜 (lp E p) :=
+  ⟨fun r c f => Subtype.ext <| smul_assoc _ _ _⟩
+
+instance [∀ i, Module 𝕜ᵐᵒᵖ (E i)] [∀ i, IsCentralScalar 𝕜 (E i)] : IsCentralScalar 𝕜 (lp E p) :=
+  ⟨fun r f => Subtype.ext <| op_smul_eq_smul _ _⟩
+
+theorem norm_const_smul_le (hp : p ≠ 0) (c : 𝕜) (f : lp E p) : ‖c • f‖ ≤ ‖c‖ * ‖f‖ :=
+  by
+  rcases p.trichotomy with (rfl | rfl | hp)
+  · exact absurd rfl hp
+  · cases isEmpty_or_nonempty α <;> skip
+    · simp [lp.eq_zero' f]
+    have hcf := lp.isLUB_norm (c • f)
+    have hfc := (lp.isLUB_norm f).mul_left (norm_nonneg c)
+    simp_rw [← Set.range_comp, Function.comp] at hfc
+    -- TODO: some `is_lub` API should make it a one-liner from here.
+    refine' hcf.right _
+    have := hfc.left
+    simp_rw [mem_upperBounds, Set.mem_range, forall_exists_index, forall_apply_eq_imp_iff'] at this⊢
+    intro a
+    exact (norm_smul_le _ _).trans (this a)
+  · letI inst : NNNorm (lp E p) := ⟨fun f => ⟨‖f‖, norm_nonneg' _⟩⟩
+    have coe_nnnorm : ∀ f : lp E p, ↑‖f‖₊ = ‖f‖ := fun _ => rfl
+    suffices ‖c • f‖₊ ^ p.to_real ≤ (‖c‖₊ * ‖f‖₊) ^ p.to_real by
+      rwa [NNReal.rpow_le_rpow_iff hp] at this
+    clear_value inst
+    rw [NNReal.mul_rpow]
+    have hLHS := lp.hasSum_norm hp (c • f)
+    have hRHS := (lp.hasSum_norm hp f).mul_left (‖c‖ ^ p.to_real)
+    simp_rw [← coe_nnnorm, ← _root_.coe_nnnorm, ← NNReal.coe_rpow, ← NNReal.coe_mul,
+      NNReal.hasSum_coe] at hRHS hLHS
+    refine' hasSum_mono hLHS hRHS fun i => _
+    dsimp only
+    rw [← NNReal.mul_rpow]
+    exact NNReal.rpow_le_rpow (nnnorm_smul_le _ _) ENNReal.toReal_nonneg
+#align lp.norm_const_smul_le lp.norm_const_smul_le
+
+instance [Fact (1 ≤ p)] : BoundedSMul 𝕜 (lp E p) :=
+  BoundedSMul.of_norm_smul_le <| norm_const_smul_le (zero_lt_one.trans_le <| Fact.out (1 ≤ p)).ne'
+
+end BoundedSMul
+
+section DivisionRing
+
+variable {𝕜 : Type _}
+
+variable [NormedDivisionRing 𝕜] [∀ i, Module 𝕜 (E i)] [∀ i, BoundedSMul 𝕜 (E i)]
+
+theorem norm_const_smul (hp : p ≠ 0) {c : 𝕜} (f : lp E p) : ‖c • f‖ = ‖c‖ * ‖f‖ :=
+  by
+  obtain rfl | hc := eq_or_ne c 0
+  · simp
+  refine' le_antisymm (norm_const_smul_le hp c f) _
+  have := mul_le_mul_of_nonneg_left (norm_const_smul_le hp c⁻¹ (c • f)) (norm_nonneg c)
+  rwa [inv_smul_smul₀ hc, norm_inv, mul_inv_cancel_left₀ (norm_ne_zero_iff.mpr hc)] at this
+#align lp.norm_const_smul lp.norm_const_smul
+
+end DivisionRing
+
+section NormedSpace
+
+variable {𝕜 : Type _} [NormedField 𝕜] [∀ i, NormedSpace 𝕜 (E i)]
+
+instance [Fact (1 ≤ p)] : NormedSpace 𝕜 (lp E p) where norm_smul_le c f := norm_smul_le _ _
+
+end NormedSpace
+
+section NormedStarGroup
+
+variable [∀ i, StarAddMonoid (E i)] [∀ i, NormedStarGroup (E i)]
+
+theorem Memℓp.star_mem {f : ∀ i, E i} (hf : Memℓp f p) : Memℓp (star f) p :=
+  by
+  rcases p.trichotomy with (rfl | rfl | hp)
+  · apply memℓp_zero
+    simp [hf.finite_dsupport]
+  · apply memℓp_infty
+    simpa using hf.bdd_above
+  · apply memℓp_gen
+    simpa using hf.summable hp
+#align mem_ℓp.star_mem Memℓp.star_mem
+
+@[simp]
+theorem Memℓp.star_iff {f : ∀ i, E i} : Memℓp (star f) p ↔ Memℓp f p :=
+  ⟨fun h => star_star f ▸ Memℓp.star_mem h, Memℓp.star_mem⟩
+#align mem_ℓp.star_iff Memℓp.star_iff
+
+instance : Star (lp E p) where unit f := ⟨(star f : ∀ i, E i), f.property.star_mem⟩
+
+@[simp]
+theorem coeFn_star (f : lp E p) : ⇑(star f) = star f :=
+  rfl
+#align lp.coe_fn_star lp.coeFn_star
+
+@[simp]
+protected theorem star_apply (f : lp E p) (i : α) : star f i = star (f i) :=
+  rfl
+#align lp.star_apply lp.star_apply
+
+instance : InvolutiveStar (lp E p) where star_involutive x := by ext; simp
+
+instance : StarAddMonoid (lp E p) where star_add f g := ext <| star_add _ _
+
+instance [hp : Fact (1 ≤ p)] : NormedStarGroup (lp E p)
+    where norm_star f := by
+    rcases p.trichotomy with (rfl | rfl | h)
+    · exfalso
+      have := ENNReal.toReal_mono ENNReal.zero_ne_top hp.elim
+      norm_num at this
+    · simp only [lp.norm_eq_csupr, lp.star_apply, norm_star]
+    · simp only [lp.norm_eq_tsum_rpow h, lp.star_apply, norm_star]
+
+variable {𝕜 : Type _} [Star 𝕜] [NormedRing 𝕜]
+
+variable [∀ i, Module 𝕜 (E i)] [∀ i, BoundedSMul 𝕜 (E i)] [∀ i, StarModule 𝕜 (E i)]
+
+instance : StarModule 𝕜 (lp E p) where star_smul r f := ext <| star_smul _ _
+
+end NormedStarGroup
+
+section NonUnitalNormedRing
+
+variable {I : Type _} {B : I → Type _} [∀ i, NonUnitalNormedRing (B i)]
+
+theorem Memℓp.infty_mul {f g : ∀ i, B i} (hf : Memℓp f ∞) (hg : Memℓp g ∞) : Memℓp (f * g) ∞ :=
+  by
+  rw [memℓp_infty_iff]
+  obtain ⟨⟨Cf, hCf⟩, ⟨Cg, hCg⟩⟩ := hf.bdd_above, hg.bdd_above
+  refine' ⟨Cf * Cg, _⟩
+  rintro _ ⟨i, rfl⟩
+  calc
+    ‖(f * g) i‖ ≤ ‖f i‖ * ‖g i‖ := norm_mul_le (f i) (g i)
+    _ ≤ Cf * Cg :=
+      mul_le_mul (hCf ⟨i, rfl⟩) (hCg ⟨i, rfl⟩) (norm_nonneg _)
+        ((norm_nonneg _).trans (hCf ⟨i, rfl⟩))
+    
+#align mem_ℓp.infty_mul Memℓp.infty_mul
+
+instance : Mul (lp B ∞) where mul f g := ⟨(f * g : ∀ i, B i), f.property.infty_mul g.property⟩
+
+@[simp]
+theorem infty_coeFn_mul (f g : lp B ∞) : ⇑(f * g) = f * g :=
+  rfl
+#align lp.infty_coe_fn_mul lp.infty_coeFn_mul
+
+instance : NonUnitalRing (lp B ∞) :=
+  Function.Injective.nonUnitalRing lp.hasCoeToFun.coe Subtype.coe_injective (lp.coeFn_zero B ∞)
+    lp.coeFn_add infty_coeFn_mul lp.coeFn_neg lp.coeFn_sub (fun _ _ => rfl) fun _ _ => rfl
+
+instance : NonUnitalNormedRing (lp B ∞) :=
+  { lp.normedAddCommGroup with
+    norm_mul := fun f g =>
+      lp.norm_le_of_forall_le (mul_nonneg (norm_nonneg f) (norm_nonneg g)) fun i =>
+        calc
+          ‖(f * g) i‖ ≤ ‖f i‖ * ‖g i‖ := norm_mul_le _ _
+          _ ≤ ‖f‖ * ‖g‖ :=
+            mul_le_mul (lp.norm_apply_le_norm ENNReal.top_ne_zero f i)
+              (lp.norm_apply_le_norm ENNReal.top_ne_zero g i) (norm_nonneg _) (norm_nonneg _)
+           }
+
+-- we also want a `non_unital_normed_comm_ring` instance, but this has to wait for #13719
+instance infty_isScalarTower {𝕜} [NormedRing 𝕜] [∀ i, Module 𝕜 (B i)] [∀ i, BoundedSMul 𝕜 (B i)]
+    [∀ i, IsScalarTower 𝕜 (B i) (B i)] : IsScalarTower 𝕜 (lp B ∞) (lp B ∞) :=
+  ⟨fun r f g => lp.ext <| smul_assoc r (⇑f) ⇑g⟩
+#align lp.infty_is_scalar_tower lp.infty_isScalarTower
+
+instance infty_sMulCommClass {𝕜} [NormedRing 𝕜] [∀ i, Module 𝕜 (B i)] [∀ i, BoundedSMul 𝕜 (B i)]
+    [∀ i, SMulCommClass 𝕜 (B i) (B i)] : SMulCommClass 𝕜 (lp B ∞) (lp B ∞) :=
+  ⟨fun r f g => lp.ext <| smul_comm r (⇑f) ⇑g⟩
+#align lp.infty_smul_comm_class lp.infty_sMulCommClass
+
+section StarRing
+
+variable [∀ i, StarRing (B i)] [∀ i, NormedStarGroup (B i)]
+
+instance inftyStarRing : StarRing (lp B ∞) :=
+  {
+    show StarAddMonoid (lp B ∞) by letI : ∀ i, StarAddMonoid (B i) := fun i => inferInstance;
+      infer_instance with
+    star_mul := fun f g => ext <| star_mul (_ : ∀ i, B i) _ }
+#align lp.infty_star_ring lp.inftyStarRing
+
+instance infty_cstarRing [∀ i, CstarRing (B i)] : CstarRing (lp B ∞)
+    where norm_star_mul_self f := by
+    apply le_antisymm
+    · rw [← sq]
+      refine' lp.norm_le_of_forall_le (sq_nonneg ‖f‖) fun i => _
+      simp only [lp.star_apply, CstarRing.norm_star_mul_self, ← sq, infty_coe_fn_mul, Pi.mul_apply]
+      refine' sq_le_sq' _ (lp.norm_apply_le_norm ENNReal.top_ne_zero _ _)
+      linarith [norm_nonneg (f i), norm_nonneg f]
+    · rw [← sq, ← Real.le_sqrt (norm_nonneg _) (norm_nonneg _)]
+      refine' lp.norm_le_of_forall_le ‖star f * f‖.sqrt_nonneg fun i => _
+      rw [Real.le_sqrt (norm_nonneg _) (norm_nonneg _), sq, ← CstarRing.norm_star_mul_self]
+      exact lp.norm_apply_le_norm ENNReal.top_ne_zero (star f * f) i
+#align lp.infty_cstar_ring lp.infty_cstarRing
+
+end StarRing
+
+end NonUnitalNormedRing
+
+section NormedRing
+
+variable {I : Type _} {B : I → Type _} [∀ i, NormedRing (B i)]
+
+instance PreLp.ring : Ring (PreLp B) :=
+  Pi.ring
+#align pre_lp.ring PreLp.ring
+
+variable [∀ i, NormOneClass (B i)]
+
+theorem one_memℓp_infty : Memℓp (1 : ∀ i, B i) ∞ :=
+  ⟨1, by rintro i ⟨i, rfl⟩; exact norm_one.le⟩
+#align one_mem_ℓp_infty one_memℓp_infty
+
+variable (B)
+
+/-- The `𝕜`-subring of elements of `Π i : α, B i` whose `lp` norm is finite. This is `lp E ∞`,
+with extra structure. -/
+def lpInftySubring : Subring (PreLp B) :=
+  { lp B ∞ with
+    carrier := { f | Memℓp f ∞ }
+    one_mem' := one_memℓp_infty
+    mul_mem' := fun f g hf hg => hf.infty_mul hg }
+#align lp_infty_subring lpInftySubring
+
+variable {B}
+
+instance inftyRing : Ring (lp B ∞) :=
+  (lpInftySubring B).toRing
+#align lp.infty_ring lp.inftyRing
+
+theorem Memℓp.infty_pow {f : ∀ i, B i} (hf : Memℓp f ∞) (n : ℕ) : Memℓp (f ^ n) ∞ :=
+  (lpInftySubring B).pow_mem hf n
+#align mem_ℓp.infty_pow Memℓp.infty_pow
+
+theorem nat_cast_memℓp_infty (n : ℕ) : Memℓp (n : ∀ i, B i) ∞ :=
+  natCast_mem (lpInftySubring B) n
+#align nat_cast_mem_ℓp_infty nat_cast_memℓp_infty
+
+theorem int_cast_memℓp_infty (z : ℤ) : Memℓp (z : ∀ i, B i) ∞ :=
+  coe_int_mem (lpInftySubring B) z
+#align int_cast_mem_ℓp_infty int_cast_memℓp_infty
+
+@[simp]
+theorem infty_coeFn_one : ⇑(1 : lp B ∞) = 1 :=
+  rfl
+#align lp.infty_coe_fn_one lp.infty_coeFn_one
+
+@[simp]
+theorem infty_coeFn_pow (f : lp B ∞) (n : ℕ) : ⇑(f ^ n) = f ^ n :=
+  rfl
+#align lp.infty_coe_fn_pow lp.infty_coeFn_pow
+
+@[simp]
+theorem infty_coeFn_nat_cast (n : ℕ) : ⇑(n : lp B ∞) = n :=
+  rfl
+#align lp.infty_coe_fn_nat_cast lp.infty_coeFn_nat_cast
+
+@[simp]
+theorem infty_coeFn_int_cast (z : ℤ) : ⇑(z : lp B ∞) = z :=
+  rfl
+#align lp.infty_coe_fn_int_cast lp.infty_coeFn_int_cast
+
+instance [Nonempty I] : NormOneClass (lp B ∞)
+    where norm_one := by
+    simp_rw [lp.norm_eq_csupr, infty_coe_fn_one, Pi.one_apply, norm_one, ciSup_const]
+
+instance inftyNormedRing : NormedRing (lp B ∞) :=
+  { lp.inftyRing, lp.nonUnitalNormedRing with }
+#align lp.infty_normed_ring lp.inftyNormedRing
+
+end NormedRing
+
+section NormedCommRing
+
+variable {I : Type _} {B : I → Type _} [∀ i, NormedCommRing (B i)] [∀ i, NormOneClass (B i)]
+
+instance inftyCommRing : CommRing (lp B ∞) :=
+  { lp.inftyRing with
+    mul_comm := fun f g => by ext; simp only [lp.infty_coeFn_mul, Pi.mul_apply, mul_comm] }
+#align lp.infty_comm_ring lp.inftyCommRing
+
+instance inftyNormedCommRing : NormedCommRing (lp B ∞) :=
+  { lp.inftyCommRing, lp.inftyNormedRing with }
+#align lp.infty_normed_comm_ring lp.inftyNormedCommRing
+
+end NormedCommRing
+
+section Algebra
+
+variable {I : Type _} {𝕜 : Type _} {B : I → Type _}
+
+variable [NormedField 𝕜] [∀ i, NormedRing (B i)] [∀ i, NormedAlgebra 𝕜 (B i)]
+
+/-- A variant of `pi.algebra` that lean can't find otherwise. -/
+instance Pi.algebraOfNormedAlgebra : Algebra 𝕜 (∀ i, B i) :=
+  @Pi.algebra I 𝕜 B _ _ fun i => NormedAlgebra.toAlgebra
+#align pi.algebra_of_normed_algebra Pi.algebraOfNormedAlgebra
+
+instance PreLp.algebra : Algebra 𝕜 (PreLp B) :=
+  Pi.algebraOfNormedAlgebra
+#align pre_lp.algebra PreLp.algebra
+
+variable [∀ i, NormOneClass (B i)]
+
+theorem algebraMap_memℓp_infty (k : 𝕜) : Memℓp (algebraMap 𝕜 (∀ i, B i) k) ∞ :=
+  by
+  rw [Algebra.algebraMap_eq_smul_one]
+  exact (one_mem_ℓp_infty.const_smul k : Memℓp (k • 1 : ∀ i, B i) ∞)
+#align algebra_map_mem_ℓp_infty algebraMap_memℓp_infty
+
+variable (𝕜 B)
+
+/-- The `𝕜`-subalgebra of elements of `Π i : α, B i` whose `lp` norm is finite. This is `lp E ∞`,
+with extra structure. -/
+def lpInftySubalgebra : Subalgebra 𝕜 (PreLp B) :=
+  { lpInftySubring B with
+    carrier := { f | Memℓp f ∞ }
+    algebraMap_mem' := algebraMap_memℓp_infty }
+#align lp_infty_subalgebra lpInftySubalgebra
+
+variable {𝕜 B}
+
+instance inftyNormedAlgebra : NormedAlgebra 𝕜 (lp B ∞) :=
+  { (lpInftySubalgebra 𝕜 B).Algebra, (lp.normedSpace : NormedSpace 𝕜 (lp B ∞)) with }
+#align lp.infty_normed_algebra lp.inftyNormedAlgebra
+
+end Algebra
+
+section Single
+
+variable {𝕜 : Type _} [NormedRing 𝕜] [∀ i, Module 𝕜 (E i)] [∀ i, BoundedSMul 𝕜 (E i)]
+
+variable [DecidableEq α]
+
+/-- The element of `lp E p` which is `a : E i` at the index `i`, and zero elsewhere. -/
+protected def single (p) (i : α) (a : E i) : lp E p :=
+  ⟨fun j => if h : j = i then Eq.ndrec a h.symm else 0,
+    by
+    refine' (memℓp_zero _).of_exponent_ge (zero_le p)
+    refine' (Set.finite_singleton i).Subset _
+    intro j
+    simp only [forall_exists_index, Set.mem_singleton_iff, Ne.def, dite_eq_right_iff,
+      Set.mem_setOf_eq, not_forall]
+    rintro rfl
+    simp⟩
+#align lp.single lp.single
+
+protected theorem single_apply (p) (i : α) (a : E i) (j : α) :
+    lp.single p i a j = if h : j = i then Eq.ndrec a h.symm else 0 :=
+  rfl
+#align lp.single_apply lp.single_apply
+
+protected theorem single_apply_self (p) (i : α) (a : E i) : lp.single p i a i = a := by
+  rw [lp.single_apply, dif_pos rfl]
+#align lp.single_apply_self lp.single_apply_self
+
+protected theorem single_apply_ne (p) (i : α) (a : E i) {j : α} (hij : j ≠ i) :
+    lp.single p i a j = 0 := by rw [lp.single_apply, dif_neg hij]
+#align lp.single_apply_ne lp.single_apply_ne
+
+@[simp]
+protected theorem single_neg (p) (i : α) (a : E i) : lp.single p i (-a) = -lp.single p i a :=
+  by
+  ext j
+  by_cases hi : j = i
+  · subst hi
+    simp [lp.single_apply_self]
+  · simp [lp.single_apply_ne p i _ hi]
+#align lp.single_neg lp.single_neg
+
+@[simp]
+protected theorem single_smul (p) (i : α) (a : E i) (c : 𝕜) :
+    lp.single p i (c • a) = c • lp.single p i a :=
+  by
+  ext j
+  by_cases hi : j = i
+  · subst hi
+    simp [lp.single_apply_self]
+  · simp [lp.single_apply_ne p i _ hi]
+#align lp.single_smul lp.single_smul
+
+/- ./././Mathport/Syntax/Translate/Basic.lean:635:2: warning: expanding binder collection (i «expr ∉ » s) -/
+protected theorem norm_sum_single (hp : 0 < p.toReal) (f : ∀ i, E i) (s : Finset α) :
+    ‖∑ i in s, lp.single p i (f i)‖ ^ p.toReal = ∑ i in s, ‖f i‖ ^ p.toReal :=
+  by
+  refine' (has_sum_norm hp (∑ i in s, lp.single p i (f i))).unique _
+  simp only [lp.single_apply, coe_fn_sum, Finset.sum_apply, Finset.sum_dite_eq]
+  have h : ∀ (i) (_ : i ∉ s), ‖ite (i ∈ s) (f i) 0‖ ^ p.to_real = 0 :=
+    by
+    intro i hi
+    simp [if_neg hi, Real.zero_rpow hp.ne']
+  have h' : ∀ i ∈ s, ‖f i‖ ^ p.to_real = ‖ite (i ∈ s) (f i) 0‖ ^ p.to_real :=
+    by
+    intro i hi
+    rw [if_pos hi]
+  simpa [Finset.sum_congr rfl h'] using hasSum_sum_of_ne_finset_zero h
+#align lp.norm_sum_single lp.norm_sum_single
+
+protected theorem norm_single (hp : 0 < p.toReal) (f : ∀ i, E i) (i : α) :
+    ‖lp.single p i (f i)‖ = ‖f i‖ :=
+  by
+  refine' Real.rpow_left_injOn hp.ne' (norm_nonneg' _) (norm_nonneg _) _
+  simpa using lp.norm_sum_single hp f {i}
+#align lp.norm_single lp.norm_single
+
+/- ./././Mathport/Syntax/Translate/Basic.lean:635:2: warning: expanding binder collection (i «expr ∉ » s) -/
+protected theorem norm_sub_norm_compl_sub_single (hp : 0 < p.toReal) (f : lp E p) (s : Finset α) :
+    ‖f‖ ^ p.toReal - ‖f - ∑ i in s, lp.single p i (f i)‖ ^ p.toReal = ∑ i in s, ‖f i‖ ^ p.toReal :=
+  by
+  refine' ((has_sum_norm hp f).sub (has_sum_norm hp (f - ∑ i in s, lp.single p i (f i)))).unique _
+  let F : α → ℝ := fun i => ‖f i‖ ^ p.to_real - ‖(f - ∑ i in s, lp.single p i (f i)) i‖ ^ p.to_real
+  have hF : ∀ (i) (_ : i ∉ s), F i = 0 := by
+    intro i hi
+    suffices ‖f i‖ ^ p.to_real - ‖f i - ite (i ∈ s) (f i) 0‖ ^ p.to_real = 0 by
+      simpa only [F, coe_fn_sum, lp.single_apply, coe_fn_sub, Pi.sub_apply, Finset.sum_apply,
+        Finset.sum_dite_eq] using this
+    simp only [if_neg hi, sub_zero, sub_self]
+  have hF' : ∀ i ∈ s, F i = ‖f i‖ ^ p.to_real :=
+    by
+    intro i hi
+    simp only [F, coe_fn_sum, lp.single_apply, if_pos hi, sub_self, eq_self_iff_true, coe_fn_sub,
+      Pi.sub_apply, Finset.sum_apply, Finset.sum_dite_eq, sub_eq_self]
+    simp [Real.zero_rpow hp.ne']
+  have : HasSum F (∑ i in s, F i) := hasSum_sum_of_ne_finset_zero hF
+  rwa [Finset.sum_congr rfl hF'] at this
+#align lp.norm_sub_norm_compl_sub_single lp.norm_sub_norm_compl_sub_single
+
+protected theorem norm_compl_sum_single (hp : 0 < p.toReal) (f : lp E p) (s : Finset α) :
+    ‖f - ∑ i in s, lp.single p i (f i)‖ ^ p.toReal = ‖f‖ ^ p.toReal - ∑ i in s, ‖f i‖ ^ p.toReal :=
+  by linarith [lp.norm_sub_norm_compl_sub_single hp f s]
+#align lp.norm_compl_sum_single lp.norm_compl_sum_single
+
+/-- The canonical finitely-supported approximations to an element `f` of `lp` converge to it, in the
+`lp` topology. -/
+protected theorem hasSum_single [Fact (1 ≤ p)] (hp : p ≠ ⊤) (f : lp E p) :
+    HasSum (fun i : α => lp.single p i (f i : E i)) f :=
+  by
+  have hp₀ : 0 < p := zero_lt_one.trans_le (Fact.out _)
+  have hp' : 0 < p.to_real := ENNReal.toReal_pos hp₀.ne' hp
+  have := lp.hasSum_norm hp' f
+  rw [HasSum, Metric.tendsto_nhds] at this⊢
+  intro ε hε
+  refine' (this _ (Real.rpow_pos_of_pos hε p.to_real)).mono _
+  intro s hs
+  rw [← Real.rpow_lt_rpow_iff dist_nonneg (le_of_lt hε) hp']
+  rw [dist_comm] at hs
+  simp only [dist_eq_norm, Real.norm_eq_abs] at hs⊢
+  have H :
+    ‖(∑ i in s, lp.single p i (f i : E i)) - f‖ ^ p.to_real =
+      ‖f‖ ^ p.to_real - ∑ i in s, ‖f i‖ ^ p.to_real :=
+    by
+    simpa only [coe_fn_neg, Pi.neg_apply, lp.single_neg, Finset.sum_neg_distrib, neg_sub_neg,
+      norm_neg, _root_.norm_neg] using lp.norm_compl_sum_single hp' (-f) s
+  rw [← H] at hs
+  have :
+    |‖(∑ i in s, lp.single p i (f i : E i)) - f‖ ^ p.to_real| =
+      ‖(∑ i in s, lp.single p i (f i : E i)) - f‖ ^ p.to_real :=
+    by simp only [Real.abs_rpow_of_nonneg (norm_nonneg _), abs_norm]
+  linarith
+#align lp.has_sum_single lp.hasSum_single
+
+end Single
+
+section Topology
+
+open Filter
+
+open scoped Topology uniformity
+
+/-- The coercion from `lp E p` to `Π i, E i` is uniformly continuous. -/
+theorem uniformContinuous_coe [_i : Fact (1 ≤ p)] : UniformContinuous (coe : lp E p → ∀ i, E i) :=
+  by
+  have hp : p ≠ 0 := (zero_lt_one.trans_le _i.elim).ne'
+  rw [uniformContinuous_pi]
+  intro i
+  rw [normed_add_comm_group.uniformity_basis_dist.uniform_continuous_iff
+      NormedAddCommGroup.uniformity_basis_dist]
+  intro ε hε
+  refine' ⟨ε, hε, _⟩
+  rintro f g (hfg : ‖f - g‖ < ε)
+  have : ‖f i - g i‖ ≤ ‖f - g‖ := norm_apply_le_norm hp (f - g) i
+  exact this.trans_lt hfg
+#align lp.uniform_continuous_coe lp.uniformContinuous_coe
+
+variable {ι : Type _} {l : Filter ι} [Filter.NeBot l]
+
+theorem norm_apply_le_of_tendsto {C : ℝ} {F : ι → lp E ∞} (hCF : ∀ᶠ k in l, ‖F k‖ ≤ C)
+    {f : ∀ a, E a} (hf : Tendsto (id fun i => F i : ι → ∀ a, E a) l (𝓝 f)) (a : α) : ‖f a‖ ≤ C :=
+  by
+  have : tendsto (fun k => ‖F k a‖) l (𝓝 ‖f a‖) :=
+    (tendsto.comp (continuous_apply a).ContinuousAt hf).norm
+  refine' le_of_tendsto this (hCF.mono _)
+  intro k hCFk
+  exact (norm_apply_le_norm ENNReal.top_ne_zero (F k) a).trans hCFk
+#align lp.norm_apply_le_of_tendsto lp.norm_apply_le_of_tendsto
+
+variable [_i : Fact (1 ≤ p)]
+
+include _i
+
+theorem sum_rpow_le_of_tendsto (hp : p ≠ ∞) {C : ℝ} {F : ι → lp E p} (hCF : ∀ᶠ k in l, ‖F k‖ ≤ C)
+    {f : ∀ a, E a} (hf : Tendsto (id fun i => F i : ι → ∀ a, E a) l (𝓝 f)) (s : Finset α) :
+    (∑ i : α in s, ‖f i‖ ^ p.toReal) ≤ C ^ p.toReal :=
+  by
+  have hp' : p ≠ 0 := (zero_lt_one.trans_le _i.elim).ne'
+  have hp'' : 0 < p.to_real := ENNReal.toReal_pos hp' hp
+  let G : (∀ a, E a) → ℝ := fun f => ∑ a in s, ‖f a‖ ^ p.to_real
+  have hG : Continuous G := by
+    refine' continuous_finset_sum s _
+    intro a ha
+    have : Continuous fun f : ∀ a, E a => f a := continuous_apply a
+    exact this.norm.rpow_const fun _ => Or.inr hp''.le
+  refine' le_of_tendsto (hG.continuous_at.tendsto.comp hf) _
+  refine' hCF.mono _
+  intro k hCFk
+  refine' (lp.sum_rpow_le_norm_rpow hp'' (F k) s).trans _
+  exact Real.rpow_le_rpow (norm_nonneg _) hCFk hp''.le
+#align lp.sum_rpow_le_of_tendsto lp.sum_rpow_le_of_tendsto
+
+/-- "Semicontinuity of the `lp` norm": If all sufficiently large elements of a sequence in `lp E p`
+ have `lp` norm `≤ C`, then the pointwise limit, if it exists, also has `lp` norm `≤ C`. -/
+theorem norm_le_of_tendsto {C : ℝ} {F : ι → lp E p} (hCF : ∀ᶠ k in l, ‖F k‖ ≤ C) {f : lp E p}
+    (hf : Tendsto (id fun i => F i : ι → ∀ a, E a) l (𝓝 f)) : ‖f‖ ≤ C :=
+  by
+  obtain ⟨i, hi⟩ := hCF.exists
+  have hC : 0 ≤ C := (norm_nonneg _).trans hi
+  rcases eq_top_or_lt_top p with (rfl | hp)
+  · apply norm_le_of_forall_le hC
+    exact norm_apply_le_of_tendsto hCF hf
+  · have : 0 < p := zero_lt_one.trans_le _i.elim
+    have hp' : 0 < p.to_real := ENNReal.toReal_pos this.ne' hp.ne
+    apply norm_le_of_forall_sum_le hp' hC
+    exact sum_rpow_le_of_tendsto hp.ne hCF hf
+#align lp.norm_le_of_tendsto lp.norm_le_of_tendsto
+
+/-- If `f` is the pointwise limit of a bounded sequence in `lp E p`, then `f` is in `lp E p`. -/
+theorem memℓp_of_tendsto {F : ι → lp E p} (hF : Metric.Bounded (Set.range F)) {f : ∀ a, E a}
+    (hf : Tendsto (id fun i => F i : ι → ∀ a, E a) l (𝓝 f)) : Memℓp f p :=
+  by
+  obtain ⟨C, hC, hCF'⟩ := hF.exists_pos_norm_le
+  have hCF : ∀ k, ‖F k‖ ≤ C := fun k => hCF' _ ⟨k, rfl⟩
+  rcases eq_top_or_lt_top p with (rfl | hp)
+  · apply memℓp_infty
+    use C
+    rintro _ ⟨a, rfl⟩
+    refine' norm_apply_le_of_tendsto (eventually_of_forall hCF) hf a
+  · apply memℓp_gen'
+    exact sum_rpow_le_of_tendsto hp.ne (eventually_of_forall hCF) hf
+#align lp.mem_ℓp_of_tendsto lp.memℓp_of_tendsto
+
+/-- If a sequence is Cauchy in the `lp E p` topology and pointwise convergent to a element `f` of
+`lp E p`, then it converges to `f` in the `lp E p` topology. -/
+theorem tendsto_lp_of_tendsto_pi {F : ℕ → lp E p} (hF : CauchySeq F) {f : lp E p}
+    (hf : Tendsto (id fun i => F i : ℕ → ∀ a, E a) atTop (𝓝 f)) : Tendsto F atTop (𝓝 f) :=
+  by
+  rw [metric.nhds_basis_closed_ball.tendsto_right_iff]
+  intro ε hε
+  have hε' : { p : lp E p × lp E p | ‖p.1 - p.2‖ < ε } ∈ 𝓤 (lp E p) :=
+    normed_add_comm_group.uniformity_basis_dist.mem_of_mem hε
+  refine' (hF.eventually_eventually hε').mono _
+  rintro n (hn : ∀ᶠ l in at_top, ‖(fun f => F n - f) (F l)‖ < ε)
+  refine' norm_le_of_tendsto (hn.mono fun k hk => hk.le) _
+  rw [tendsto_pi_nhds]
+  intro a
+  exact (hf.apply a).const_sub (F n a)
+#align lp.tendsto_lp_of_tendsto_pi lp.tendsto_lp_of_tendsto_pi
+
+variable [∀ a, CompleteSpace (E a)]
+
+instance : CompleteSpace (lp E p) :=
+  Metric.complete_of_cauchySeq_tendsto
+    (by
+      intro F hF
+      -- A Cauchy sequence in `lp E p` is pointwise convergent; let `f` be the pointwise limit.
+      obtain ⟨f, hf⟩ := cauchySeq_tendsto_of_complete (uniform_continuous_coe.comp_cauchy_seq hF)
+      -- Since the Cauchy sequence is bounded, its pointwise limit `f` is in `lp E p`.
+      have hf' : Memℓp f p := mem_ℓp_of_tendsto hF.bounded_range hf
+      -- And therefore `f` is its limit in the `lp E p` topology as well as pointwise.
+      exact ⟨⟨f, hf'⟩, tendsto_lp_of_tendsto_pi hF hf⟩)
+
+end Topology
+
+end lp
+

--- a/Mathlib/Analysis/NormedSpace/LpSpace.lean
+++ b/Mathlib/Analysis/NormedSpace/LpSpace.lean
@@ -1040,11 +1040,15 @@ protected theorem single_neg (p) (i : α) (a : E i) : lp.single p i (-a) = -lp.s
 @[simp]
 protected theorem single_smul (p) (i : α) (a : E i) (c : 𝕜) :
     lp.single p i (c • a) = c • lp.single p i a := by
-  ext j
+  refine' ext (funext (fun (j : α) => _))
   by_cases hi : j = i
   · subst hi
+    dsimp
+    rw [Pi.smul_apply]
     simp [lp.single_apply_self]
-  · simp [lp.single_apply_ne p i _ hi]
+  · dsimp
+    rw [Pi.smul_apply]
+    simp [lp.single_apply_ne p i _ hi]
 #align lp.single_smul lp.single_smul
 
 /- ./././Mathport/Syntax/Translate/Basic.lean:635:2: warning: expanding binder collection (i «expr ∉ » s) -/


### PR DESCRIPTION
Notes [Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/!4.234465.20.60lp.60) :
1. There are both `CoeOut` and `CoeFun` instances for `lp E p`. This is consistent with mathlib3, but it seems strange and I would expect it to cause problems.
2. It seems there is some defeq abuse (identifiying `PreLp E` with `∀ i, E i` in the aforementioned `CoeOut` instance, for example) happening here which is rather convenient, but it's possible it may cause problems. (this abuse was also present in mathlib3)
3. What should the name of this file be? `LpSpace` seems wrong semantically, but `lpSpace` doesn't seem allowable by our file name conventions.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
