### PR TITLE
[Merged by Bors] - feat: add `Real.iSup_nonneg` etc

### DIFF
--- a/Mathlib/Data/Real/Basic.lean
+++ b/Mathlib/Data/Real/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Floris van Doorn
 
 ! This file was ported from Lean 3 source module data.real.basic
-! leanprover-community/mathlib commit 7c523cb78f4153682c2929e3006c863bfef463d0
+! leanprover-community/mathlib commit cb42593171ba005beaaf4549fcfe0dece9ada4c9
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -852,7 +852,7 @@ theorem iInf_of_not_bddBelow {α : Sort _} {f : α → ℝ} (hf : ¬BddBelow (Se
 
 /--
 As `0` is the default value for `Real.sSup` of the empty set or sets which are not bounded above, it
-suffices to show that `S` is bounded below by `0` to show that `0 ≤ sInf S`.
+suffices to show that `S` is bounded below by `0` to show that `0 ≤ sSup S`.
 -/
 theorem sSup_nonneg (S : Set ℝ) (hS : ∀ x ∈ S, (0 : ℝ) ≤ x) : 0 ≤ sSup S := by
   rcases S.eq_empty_or_nonempty with (rfl | ⟨y, hy⟩)
@@ -860,12 +860,34 @@ theorem sSup_nonneg (S : Set ℝ) (hS : ∀ x ∈ S, (0 : ℝ) ≤ x) : 0 ≤ sS
   · apply dite _ (fun h => le_csSup_of_le h hy <| hS y hy) fun h => (sSup_of_not_bddAbove h).ge
 #align real.Sup_nonneg Real.sSup_nonneg
 
+/--
+As `0` is the default value for `Real.sSup` of the empty set or sets which are not bounded above, it
+suffices to show that `f i` is nonnegative to show that `0 ≤ ⨆ i, f i`.
+-/
+protected theorem iSup_nonneg {ι : Sort _} {f : ι → ℝ} (hf : ∀ i, 0 ≤ f i) : 0 ≤ ⨆ i, f i :=
+  sSup_nonneg _ <| Set.forall_range_iff.2 hf
+#align real.supr_nonneg Real.iSup_nonneg
+
+/--
+As `0` is the default value for `Real.sSup` of the empty set or sets which are not bounded above, it
+suffices to show that all elements of `S` are bounded by a nonnagative number to show that `sSup S`
+is bounded by this number.
+-/
+protected theorem sSup_le {S : Set ℝ} {a : ℝ} (hS : ∀ x ∈ S, x ≤ a) (ha : 0 ≤ a) : sSup S ≤ a := by
+  rcases S.eq_empty_or_nonempty with (rfl | hS₂)
+  exacts [sSup_empty.trans_le ha, csSup_le hS₂ hS]
+#align real.Sup_le Real.sSup_le
+
+protected theorem iSup_le {ι : Sort _} {f : ι → ℝ} {a : ℝ} (hS : ∀ i, f i ≤ a) (ha : 0 ≤ a) :
+    (⨆ i, f i) ≤ a :=
+  Real.sSup_le (Set.forall_range_iff.2 hS) ha
+#align real.supr_le Real.iSup_le
+
 /-- As `0` is the default value for `Real.sSup` of the empty set, it suffices to show that `S` is
 bounded above by `0` to show that `sSup S ≤ 0`.
 -/
-theorem sSup_nonpos (S : Set ℝ) (hS : ∀ x ∈ S, x ≤ (0 : ℝ)) : sSup S ≤ 0 := by
-  rcases S.eq_empty_or_nonempty with (rfl | hS₂)
-  exacts[sSup_empty.le, csSup_le hS₂ hS]
+theorem sSup_nonpos (S : Set ℝ) (hS : ∀ x ∈ S, x ≤ (0 : ℝ)) : sSup S ≤ 0 :=
+  Real.sSup_le hS le_rfl
 #align real.Sup_nonpos Real.sSup_nonpos
 
 /-- As `0` is the default value for `Real.sInf` of the empty set, it suffices to show that `S` is


### PR DESCRIPTION
Forward-port of leanprover-community/mathlib#19096

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)