### PR TITLE
[Merged by Bors] - fix: `push_neg` check that inferred correct instances

### DIFF
--- a/Mathlib/Tactic/PushNeg.lean
+++ b/Mathlib/Tactic/PushNeg.lean
@@ -39,8 +39,20 @@ register_option push_neg.use_distrib : Bool :=
 
 /-- Push negations at the top level of the current expression. -/
 def transformNegationStep (e : Expr) : SimpM (Option Simp.Step) := do
+  -- Wrapper around `Simp.Step.visit`
   let mkSimpStep (e : Expr) (pf : Expr) : Simp.Step :=
     Simp.Step.visit { expr := e, proof? := some pf }
+  -- Try applying the inequality lemma and verify that we do get a defeq type.
+  -- Sometimes there might be the wrong LinearOrder available!
+  let handleIneq (e₁ e₂ : Expr) (notThm : Name) : SimpM (Option Simp.Step) := do
+    try
+      -- Allowed to fail if it can't synthesize an instance:
+      let thm ← mkAppM notThm #[e₁, e₂]
+      let some (_, lhs, rhs) := (← inferType thm).eq? | failure -- this should never fail
+      -- Make sure the inferred instances are right:
+      guard <| ← isDefEq e lhs
+      return some <| mkSimpStep rhs thm
+    catch _ => return none
   let e_whnf ← whnfR e
   let some ex := e_whnf.not? | return Simp.Step.visit { expr := e }
   match ex.getAppFnArgs with
@@ -56,26 +68,10 @@ def transformNegationStep (e : Expr) : SimpM (Option Simp.Step) := do
       return Simp.Step.visit { expr := ← mkAppM ``Ne #[e₁, e₂] }
   | (``Ne, #[_ty, e₁, e₂]) =>
       return mkSimpStep (← mkAppM ``Eq #[e₁, e₂]) (← mkAppM ``not_ne_eq #[e₁, e₂])
-  | (``LE.le, #[ty, _inst, e₁, e₂]) =>
-      let linOrd ← synthInstance? (← mkAppM ``LinearOrder #[ty])
-      match linOrd with
-      | some _ => return mkSimpStep (← mkAppM ``LT.lt #[e₂, e₁]) (← mkAppM ``not_le_eq #[e₁, e₂])
-      | none => return none
-  | (``LT.lt, #[ty, _inst, e₁, e₂]) =>
-      let linOrd ← synthInstance? (← mkAppM ``LinearOrder #[ty])
-      match linOrd with
-      | some _ => return mkSimpStep (← mkAppM ``LE.le #[e₂, e₁]) (← mkAppM ``not_lt_eq #[e₁, e₂])
-      | none => return none
-  | (``GE.ge, #[ty, _inst, e₁, e₂]) =>
-      let linOrd ← synthInstance? (← mkAppM ``LinearOrder #[ty])
-      match linOrd with
-      | some _ => return mkSimpStep (← mkAppM ``LT.lt #[e₁, e₂]) (← mkAppM ``not_ge_eq #[e₁, e₂])
-      | none => return none
-  | (``GT.gt, #[ty, _inst, e₁, e₂]) =>
-      let linOrd ← synthInstance? (← mkAppM ``LinearOrder #[ty])
-      match linOrd with
-      | some _ => return mkSimpStep (← mkAppM ``LE.le #[e₁, e₂]) (← mkAppM ``not_gt_eq #[e₁, e₂])
-      | none => return none
+  | (``LE.le, #[_ty, _inst, e₁, e₂]) => handleIneq e₁ e₂ ``not_le_eq
+  | (``LT.lt, #[_ty, _inst, e₁, e₂]) => handleIneq e₁ e₂ ``not_lt_eq
+  | (``GE.ge, #[_ty, _inst, e₁, e₂]) => handleIneq e₁ e₂ ``not_ge_eq
+  | (``GT.gt, #[_ty, _inst, e₁, e₂]) => handleIneq e₁ e₂ ``not_gt_eq
   | (``Exists, #[_, .lam n typ bo bi]) =>
       return mkSimpStep (.forallE n typ (mkNot bo) bi)
                         (← mkAppM ``not_exists_eq #[.lam n typ bo bi])

--- a/test/push_neg.lean
+++ b/test/push_neg.lean
@@ -112,6 +112,17 @@ example {α} [Preorder α] (m n : α) (h : ¬(∃ k : α, m < k)) (h₂ : m ≤ 
   guard_hyp h : ∀ k, ¬(m < k)
   exact h₂
 
+example (r : LinearOrder α) (s : Preorder α) (a b : α) : ¬(s.lt a b → r.lt a b) := by
+  push_neg
+  guard_target = s.lt a b ∧ r.le b a
+  sorry
+
+example (r : LinearOrder α) (s : Preorder α) (a b : α) : ¬(r.lt a b → s.lt a b) := by
+  push_neg
+  guard_target = r.lt a b ∧ ¬ s.lt a b
+  sorry
+
+section use_distrib
 set_option push_neg.use_distrib true
 
 example (h : ¬ p ∨ ¬ q): ¬ (p ∧ q) := by
@@ -128,3 +139,5 @@ example (h : x = 0 ∧ y ≠ 0) : ¬(x = 0 → y = 0) := by
   push_neg
   guard_target = x = 0 ∧ y ≠ 0
   exact h
+
+end use_distrib


### PR DESCRIPTION
Adds a defeq check that `push_neg` infers the correct instances for `LinearOrder` transformations. Also uses the transformation theorem to produce the LE/LT/GE/GT instance rather than inferring it separately, since otherwise these answers can be different.

Fixes error reported by Sophie Morel [on Zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Strange.20push_neg.20behaviour/near/362022527).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
