### PR TITLE
[Merged by Bors] - fix: tinker with structure fields for better defeqs

### DIFF
--- a/Mathlib/RingTheory/AdjoinRoot.lean
+++ b/Mathlib/RingTheory/AdjoinRoot.lean
@@ -394,7 +394,7 @@ instance span_maximal_of_irreducible [Fact (Irreducible f)] : (span {f}).IsMaxim
 #align adjoin_root.span_maximal_of_irreducible AdjoinRoot.span_maximal_of_irreducible
 
 noncomputable instance field [Fact (Irreducible f)] : Field (AdjoinRoot f) :=
-  { Ideal.Quotient.field (span {f} : Ideal K[X]) with
+  { Quotient.groupWithZero (span {f} : Ideal K[X]) with
     toCommRing := AdjoinRoot.instCommRing f
     ratCast := fun a => of f (a : K)
     ratCast_mk := fun a b h1 h2 => by

--- a/Mathlib/RingTheory/AdjoinRoot.lean
+++ b/Mathlib/RingTheory/AdjoinRoot.lean
@@ -936,5 +936,3 @@ theorem quotientEquivQuotientMinpolyMap_symm_apply_mk (pb : PowerBasis R S) (I :
 #align power_basis.quotient_equiv_quotient_minpoly_map_symm_apply_mk PowerBasis.quotientEquivQuotientMinpolyMap_symm_apply_mk
 
 end PowerBasis
-
-attribute [irreducible] AdjoinRoot

--- a/Mathlib/RingTheory/AdjoinRoot.lean
+++ b/Mathlib/RingTheory/AdjoinRoot.lean
@@ -394,8 +394,8 @@ instance span_maximal_of_irreducible [Fact (Irreducible f)] : (span {f}).IsMaxim
 #align adjoin_root.span_maximal_of_irreducible AdjoinRoot.span_maximal_of_irreducible
 
 noncomputable instance field [Fact (Irreducible f)] : Field (AdjoinRoot f) :=
-  { AdjoinRoot.instCommRing f,
-    Quotient.groupWithZero (span {f} : Ideal K[X]) with
+  { Ideal.Quotient.field (span {f} : Ideal K[X]) with
+    toCommRing := AdjoinRoot.instCommRing f
     ratCast := fun a => of f (a : K)
     ratCast_mk := fun a b h1 h2 => by
       letI : GroupWithZero (AdjoinRoot f) := Ideal.Quotient.groupWithZero _
@@ -424,8 +424,7 @@ theorem coe_injective' [Fact (Irreducible f)] : Function.Injective ((â†‘) : K â†
 variable (f)
 
 theorem mul_div_root_cancel [Fact (Irreducible f)] :
-    -- porting note: I do not know how to get this to typecheck without using the ugly `Div.div`
-    (X - C (root f)) * (Div.div (f.map (of f)) (X - C (root f))) = f.map (of f) :=
+    (X - C (root f)) * ((f.map (of f)) / (X - C (root f))) = f.map (of f) :=
   mul_div_eq_iff_isRoot.2 <| isRoot_root _
 #align adjoin_root.mul_div_root_cancel AdjoinRoot.mul_div_root_cancel
 
@@ -937,3 +936,5 @@ theorem quotientEquivQuotientMinpolyMap_symm_apply_mk (pb : PowerBasis R S) (I :
 #align power_basis.quotient_equiv_quotient_minpoly_map_symm_apply_mk PowerBasis.quotientEquivQuotientMinpolyMap_symm_apply_mk
 
 end PowerBasis
+
+attribute [irreducible] AdjoinRoot


### PR DESCRIPTION
This is the outcome of the discussion in the 29/5/23 porting meeting about the spurious `Div.div` in AdjoinRoot. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

More details: `instance X := {foo, bar with ...}` might completely ignore `foo` if all its fields are covered by `bar` and the fields after the `with`. This PR ensures that `AdjoinRoot.instCommRing f` is not ignored. The current version of mathlib is also not ignoring it, because `Ideal.Quotient.field` was changed to `Quotient.groupWithZero`. But we want `AdjoinRoot.instCommRing f` to be as unignored as possible because these seem to be the instances which `AdjoinRoot` typically picks up. This PR makes a nicer term because it actually forces Lean to use `AdjoinRoot.instCommRing f` itself.

Note that this PR also enables us to fix the `Div.div` issue in this file (although probably this had already been fixed by the previous change from `Quotient.field` to `Quotient.groupWithZero`).