### PR TITLE
[Merged by Bors] - fix: Data/Bitvec change definition of `ofInt` to the ring homomorphism

### DIFF
--- a/Mathlib/Data/Bitvec/Core.lean
+++ b/Mathlib/Data/Bitvec/Core.lean
@@ -283,18 +283,10 @@ protected def ofNat : ∀ n : ℕ, Nat → Bitvec n
   | succ n, x => Bitvec.ofNat n (x / 2)++ₜdecide (x % 2 = 1) ::ᵥ nil
 #align bitvec.of_nat Bitvec.ofNat
 
-/-- Create a bitvector from an `Int`. This is the ring homorphism, and
-it is not sign preserving. -/
+/-- Create a bitvector from an `Int`. The ring homomorphism from Int to bitvectors. -/
 protected def ofInt : ∀ n : ℕ, Int → Bitvec n
   | n, Int.ofNat m => Bitvec.ofNat n m
   | n, Int.negSucc m => (Bitvec.ofNat n m).not
-
-/-- The sign preserving map from `Int` to `Bitvec` in two's complements.
-This function is not a ring homomorphism -/
-protected def ofIntSign : ∀ n : ℕ, Int → Bitvec (succ n)
-  | n, Int.ofNat m => false ::ᵥ Bitvec.ofNat n m
-  | n, Int.negSucc m => true ::ᵥ (Bitvec.ofNat n m).not
-#align bitvec.of_int Bitvec.ofIntSign
 
 /-- `add_lsb r b` is `r + r + 1` if `b` is `true` and `r + r` otherwise. -/
 def addLsb (r : ℕ) (b : Bool) :=

--- a/Mathlib/Data/Bitvec/Core.lean
+++ b/Mathlib/Data/Bitvec/Core.lean
@@ -283,12 +283,18 @@ protected def ofNat : ∀ n : ℕ, Nat → Bitvec n
   | succ n, x => Bitvec.ofNat n (x / 2)++ₜdecide (x % 2 = 1) ::ᵥ nil
 #align bitvec.of_nat Bitvec.ofNat
 
-/-- Create a bitvector from an `int`. This is the ring homorphism, and
+/-- Create a bitvector from an `Int`. This is the ring homorphism, and
 it is not sign preserving. -/
 protected def ofInt : ∀ n : ℕ, Int → Bitvec n
   | n, Int.ofNat m => Bitvec.ofNat n m
   | n, Int.negSucc m => (Bitvec.ofNat n m).not
-#align bitvec.of_int Bitvec.ofInt
+
+/-- The sign preserving map from `Int` to `Bitvec` in two's complements.
+This function is not a ring homomorphism -/
+protected def ofIntSign : ∀ n : ℕ, Int → Bitvec (succ n)
+  | n, Int.ofNat m => false ::ᵥ Bitvec.ofNat n m
+  | n, Int.negSucc m => true ::ᵥ (Bitvec.ofNat n m).not
+#align bitvec.of_int Bitvec.ofIntSign
 
 /-- `add_lsb r b` is `r + r + 1` if `b` is `true` and `r + r` otherwise. -/
 def addLsb (r : ℕ) (b : Bool) :=

--- a/Mathlib/Data/Bitvec/Core.lean
+++ b/Mathlib/Data/Bitvec/Core.lean
@@ -283,10 +283,11 @@ protected def ofNat : ∀ n : ℕ, Nat → Bitvec n
   | succ n, x => Bitvec.ofNat n (x / 2)++ₜdecide (x % 2 = 1) ::ᵥ nil
 #align bitvec.of_nat Bitvec.ofNat
 
-/-- Create a bitvector in the two's complement representation from an `int` -/
-protected def ofInt : ∀ n : ℕ, Int → Bitvec (succ n)
-  | n, Int.ofNat m => false ::ᵥ Bitvec.ofNat n m
-  | n, Int.negSucc m => true ::ᵥ (Bitvec.ofNat n m).not
+/-- Create a bitvector from an `int`. This is the ring homorphism, and
+it is not sign preserving. -/
+protected def ofInt : ∀ n : ℕ, Int → Bitvec n
+  | n, Int.ofNat m => Bitvec.ofNat n m
+  | n, Int.negSucc m => (Bitvec.ofNat n m).not
 #align bitvec.of_int Bitvec.ofInt
 
 /-- `add_lsb r b` is `r + r + 1` if `b` is `true` and `r + r` otherwise. -/


### PR DESCRIPTION
---
After discussion with colleagues, we agreed that this was probably the more usual definition of `ofInt`.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
