### PR TITLE
[Merged by Bors] - chore(Mathlib/FieldTheory/RatFunc): change from `elab` to `macro` in custom tactic

### DIFF
--- a/Mathlib/FieldTheory/RatFunc.lean
+++ b/Mathlib/FieldTheory/RatFunc.lean
@@ -517,22 +517,17 @@ def toFractionRingRingEquiv : RatFunc R ≃+* FractionRing R[X] where
 #align ratfunc.to_fraction_ring_ring_equiv RatFunc.toFractionRingRingEquiv
 
 -- porting note: reimplemented the `frac_tac` and `smul_tac` as close to the originals as I could
-open Lean Elab.Tactic in
 /-- Solve equations for `RatFunc K` by working in `FractionRing K[X]`. -/
-elab (name := frac_tac) "frac_tac" : tactic => do
-  evalTactic (← `(tactic| repeat (rintro (⟨⟩ : RatFunc _))
-  <;>
+macro "frac_tac" : tactic => `(tactic| repeat (rintro (⟨⟩ : RatFunc _)) <;>
   simp only [← ofFractionRing_zero, ← ofFractionRing_add, ← ofFractionRing_sub,
     ← ofFractionRing_neg, ← ofFractionRing_one, ← ofFractionRing_mul, ← ofFractionRing_div,
     ← ofFractionRing_inv,
     add_assoc, zero_add, add_zero, mul_assoc, mul_zero, mul_one, mul_add, inv_zero,
     add_comm, add_left_comm, mul_comm, mul_left_comm, sub_eq_add_neg, div_eq_mul_inv,
-    add_mul, zero_mul, one_mul, neg_mul, mul_neg, add_right_neg]))
+    add_mul, zero_mul, one_mul, neg_mul, mul_neg, add_right_neg])
 
-open Lean Elab.Tactic in
 /-- Solve equations for `RatFunc K` by applying `RatFunc.induction_on`. -/
-elab (name := smul_tac) "smul_tac" : tactic => do
-  evalTactic (← `(tactic|
+macro "smul_tac" : tactic => `(tactic|
     repeat
       (first
         | rintro (⟨⟩ : RatFunc _)
@@ -543,7 +538,7 @@ elab (name := smul_tac) "smul_tac" : tactic => do
       Int.ofNat_eq_coe, Int.cast_zero, Int.cast_add, Int.cast_one,
       Int.cast_negSucc, Int.cast_ofNat, Nat.cast_succ,
       Localization.mk_zero, Localization.add_mk_self, Localization.neg_mk,
-      ofFractionRing_zero, ← ofFractionRing_add, ← ofFractionRing_neg]))
+      ofFractionRing_zero, ← ofFractionRing_add, ← ofFractionRing_neg])
 
 -- Porting note: split the CommRing instance up into multiple defs because it was hard to see
 -- if the big instance declaration made any progress.


### PR DESCRIPTION
This PR switches a custom tactic, used just in RatFunc, to a simple `macro`.

Although this is quite straightforward, this is my first "official" metaprogramming in Lean4, so any kind of feedback is more than welcome!

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
