### PR TITLE
[Merged by Bors] - fix: rewrites doesn't fail when trying an unimported lemma

### DIFF
--- a/Mathlib/Lean/Meta/DiscrTree.lean
+++ b/Mathlib/Lean/Meta/DiscrTree.lean
@@ -25,9 +25,13 @@ def insertIfSpecific [BEq α] (d : DiscrTree α s)
 
 /--
 Find keys which match the expression, or some subexpression.
+
+Implementation: we reverse the results from `getMatch`,
+so that we return lemmas matching larger subexpressions first,
+and amongst those we return more specific lemmas first.
 -/
 partial def getSubexpressionMatches (d : DiscrTree α s) (e : Expr) : MetaM (Array α) := do
-  e.foldlM (fun a f => do pure <| a ++ (← d.getSubexpressionMatches f)) (← d.getMatch e)
+  e.foldlM (fun a f => do pure <| a ++ (← d.getSubexpressionMatches f)) (← d.getMatch e).reverse
 variable {m : Type → Type} [Monad m]
 
 /-- Apply a monadic function to the array of values at each node in a `DiscrTree`. -/

--- a/Mathlib/Tactic/Rewrites.lean
+++ b/Mathlib/Tactic/Rewrites.lean
@@ -32,6 +32,7 @@ namespace Mathlib.Tactic.Rewrites
 open Lean Meta Std.Tactic.TryThis
 
 initialize registerTraceClass `Tactic.rewrites
+initialize registerTraceClass `Tactic.rewrites.lemmas
 
 /-- Prepare the discrimination tree entries for a lemma. -/
 def processLemma (name : Name) (constInfo : ConstantInfo) :
@@ -114,18 +115,18 @@ structure RewriteResult where
   result : Meta.RewriteResult
   /-- Can the new goal in `result` be closed by `with_reducible rfl`? -/
   -- This is an `Option` so that it can be computed lazily.
-  refl? : Option Bool
+  rfl? : Option Bool
 
-/-- Update a `RewriteResult` by filling in the `refl?` field if it is currently `none`,
+/-- Update a `RewriteResult` by filling in the `rfl?` field if it is currently `none`,
 to reflect whether the remaining goal can be closed by `with_reducible rfl`. -/
-def RewriteResult.computeRefl (r : RewriteResult) : MetaM RewriteResult := do
-  if let some _ := r.refl? then
+def RewriteResult.computeRfl (r : RewriteResult) : MetaM RewriteResult := do
+  if let some _ := r.rfl? then
     return r
   try
-    (← mkFreshExprMVar r.result.eNew).mvarId!.refl
-    pure { r with refl? := some true }
+    (← mkFreshExprMVar r.result.eNew).mvarId!.rfl
+    pure { r with rfl? := some true }
   catch _ =>
-    pure { r with refl? := some false }
+    pure { r with rfl? := some false }
 
 /--
 Find lemmas which can rewrite the goal.
@@ -142,21 +143,19 @@ def rewritesCore (lemmas : DiscrTree (Name × Bool × Nat) s × DiscrTree (Name 
   let candidates := (← lemmas.1.getSubexpressionMatches type)
     ++ (← lemmas.2.getSubexpressionMatches type)
 
-  -- TODO the sort used below should be optimized.
-  -- Remember also that the discrimination tree returns most specific results last,
-  -- so simply reversing might be sufficient.
-
   -- Sort them by our preferring weighting
   -- (length of discriminant key, doubled for the forward implication)
 
-  -- let candidates := candidates.insertionSort fun r s => r.2.2 > s.2.2
+  let candidates := candidates.insertionSort fun r s => r.2.2 > s.2.2
+
+  trace[Tactic.rewrites.lemmas] m!"Candidate rewrite lemmas:\n{candidates}"
+
   -- Lift to a monadic list, so the caller can decide how much of the computation to run.
   let candidates := ListM.ofList candidates.toList
   pure <| candidates.filterMapM fun ⟨lem, symm, weight⟩ => do
     trace[Tactic.rewrites] "considering {if symm then "←" else ""}{lem}"
-    let result ← try
-      goal.rewrite type (← mkConstWithFreshMVarLevels lem) symm
-    catch _ => return none
+    let some result ← try? do goal.rewrite type (← mkConstWithFreshMVarLevels lem) symm
+      | return none
     return if result.mvarIds.isEmpty then
       some ⟨lem, symm, weight, result, none⟩
     else
@@ -165,19 +164,23 @@ def rewritesCore (lemmas : DiscrTree (Name × Bool × Nat) s × DiscrTree (Name 
 
 /-- Find lemmas which can rewrite the goal. -/
 def rewrites (lemmas : DiscrTree (Name × Bool × Nat) s × DiscrTree (Name × Bool × Nat) s)
-    (goal : MVarId) (max : Nat := 10) (leavePercentHeartbeats : Nat := 10) :
-    MetaM (List RewriteResult) :=
-rewritesCore lemmas goal
-  -- Don't use too many heartbeats.
-  |>.whileAtLeastHeartbeatsPercent leavePercentHeartbeats
-  -- Stop if we find a rewrite after which `with_reducible rfl` would succeed.
-  |>.mapM RewriteResult.computeRefl
-  |>.takeUpToFirst (fun r => r.refl? = some true)
-  -- Bound the number of results.
-  |>.takeAsList max
-  -- TODO consider sorting the successful results,
-  -- e.g. if we use solveByElim to fill arguments,
-  -- prefer results using local hypotheses.
+    (goal : MVarId) (max : Nat := 20) (leavePercentHeartbeats : Nat := 10) :
+    MetaM (List RewriteResult) := do
+  let results ← rewritesCore lemmas goal
+    -- Don't use too many heartbeats.
+    |>.whileAtLeastHeartbeatsPercent leavePercentHeartbeats
+    -- Stop if we find a rewrite after which `with_reducible rfl` would succeed.
+    |>.mapM RewriteResult.computeRfl
+    |>.takeUpToFirst (fun r => r.rfl? = some true)
+    -- Bound the number of results.
+    |>.takeAsList max
+  return match results.filter (fun r => r.rfl? = some true) with
+  | [] =>
+    -- TODO consider sorting the results,
+    -- e.g. if we use solveByElim to fill arguments,
+    -- prefer results using local hypotheses.
+    results
+  | results => results
 
 open Lean.Parser.Tactic
 
@@ -201,7 +204,7 @@ elab_rules : tactic |
     if results.isEmpty then
       throwError "rewrites could not find any lemmas which can rewrite the goal"
     for r in results do
-      let newGoal := if r.refl? = some true then Expr.lit (.strVal "no goals") else r.result.eNew
+      let newGoal := if r.rfl? = some true then Expr.lit (.strVal "no goals") else r.result.eNew
       addRewriteSuggestion tk (← mkConstWithFreshMVarLevels r.name) r.symm newGoal
     if lucky.isSome then
       match results[0]? with

--- a/test/rewrites.lean
+++ b/test/rewrites.lean
@@ -4,6 +4,9 @@ import Mathlib.CategoryTheory.Category.Basic
 import Mathlib.Data.List.Basic
 import Mathlib.Algebra.Group.Basic
 
+-- To see the (sorted) list of lemmas that `rewrites` will try rewriting by, use:
+-- set_option trace.Tactic.rewrites.lemmas true
+
 -- Recall that `rewrites` caches the discrimination tree on disk.
 -- If you are modifying the way that `rewrites` indexes lemmas,
 -- while testing you will probably want to delete
@@ -49,4 +52,4 @@ example [Group G] (g h : G) : g * g⁻¹ * h = h := by
   rw [one_mul]
 
 lemma prime_of_prime (n : ℕ) : Prime n ↔ Nat.Prime n := by
-  rewrites
+  rewrites!

--- a/test/rewrites.lean
+++ b/test/rewrites.lean
@@ -1,5 +1,8 @@
 import Mathlib.Tactic.Rewrites
-import Mathlib
+import Mathlib.Data.Nat.Prime
+import Mathlib.CategoryTheory.Category.Basic
+import Mathlib.Data.List.Basic
+import Mathlib.Algebra.Group.Basic
 
 -- Recall that `rewrites` caches the discrimination tree on disk.
 -- If you are modifying the way that `rewrites` indexes lemmas,
@@ -44,3 +47,6 @@ example [Group G] (g h : G) : g * g⁻¹ * h = h := by
   -/
   rw [mul_inv_self]
   rw [one_mul]
+
+lemma prime_of_prime (n : ℕ) : Prime n ↔ Nat.Prime n := by
+  rewrites


### PR DESCRIPTION
Because of the global `DiscrTree` cache, `rewrites` was encountering lemmas that were not yet imported, and failing when calling `mkConst`.

We also switch to using `MVarId.rfl` rather than `MVarId.refl` to see if goals can be closed, make sure that if a solution closes the goal it is reported ahead of other solutions, and slightly tweak the sort order again.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
