### PR TITLE
[Merged by Bors] - chore: Remove commutativity assumption in ModuleCat.Images

### DIFF
--- a/Mathlib/Algebra/Category/ModuleCat/Images.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Images.lean
@@ -28,7 +28,7 @@ universe u v
 namespace ModuleCat
 set_option linter.uppercaseLean3 false -- `Module`
 
-variable {R : Type u} [CommRing R]
+variable {R : Type u} [Ring R]
 
 variable {G H : ModuleCat.{v} R} (f : G ⟶ H)
 


### PR DESCRIPTION
Change [CommRing R] to [Ring R] at the top of the file Mathlib.Algebra.Category.ModuleCat.Images.

---
[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
