### PR TITLE
[Merged by Bors] - feat: Forgetful functor `NonemptyFinLinOrd ⥤ FinPartOrd`

### DIFF
--- a/Mathlib/Order/Category/NonemptyFinLinOrdCat.lean
+++ b/Mathlib/Order/Category/NonemptyFinLinOrdCat.lean
@@ -4,12 +4,13 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin
 
 ! This file was ported from Lean 3 source module order.category.NonemptyFinLinOrd
-! leanprover-community/mathlib commit e8ac6315bcfcbaf2d19a046719c3b553206dac75
+! leanprover-community/mathlib commit fa4a805d16a9cd9c96e0f8edeb57dc5a07af1a19
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
 import Mathlib.Data.Fintype.Order
 import Mathlib.Data.Set.Finite
+import Mathlib.Order.Category.FinPartOrd
 import Mathlib.Order.Category.LinOrdCat
 import Mathlib.CategoryTheory.Limits.Shapes.Images
 import Mathlib.CategoryTheory.Limits.Shapes.RegularMono
@@ -19,6 +20,9 @@ import Mathlib.CategoryTheory.Limits.Shapes.RegularMono
 
 This defines `NonemptyFinLinOrdCat`, the category of nonempty finite linear
 orders with monotone maps. This is the index category for simplicial objects.
+
+Note: `NonemptyFinLinOrd` is *not* a subcategory of `FinBddDistLat` because its morphisms do not
+preserve `⊥` and `⊤`.
 -/
 
 
@@ -94,6 +98,13 @@ instance hasForgetToLinOrd : HasForget₂ NonemptyFinLinOrdCat LinOrdCat :=
 set_option linter.uppercaseLean3 false in
 #align NonemptyFinLinOrd.has_forget_to_LinOrd NonemptyFinLinOrdCat.hasForgetToLinOrd
 
+instance hasForgetToFinPartOrd : HasForget₂ NonemptyFinLinOrdCat FinPartOrd
+    where forget₂ :=
+    { obj := fun X => FinPartOrd.of X
+      map := @fun X Y => id }
+set_option linter.uppercaseLean3 false in
+#align NonemptyFinLinOrd.has_forget_to_FinPartOrd NonemptyFinLinOrdCat.hasForgetToFinPartOrd
+
 /-- Constructs an equivalence between nonempty finite linear orders from an order isomorphism
 between them. -/
 @[simps]
@@ -117,7 +128,7 @@ def dual : NonemptyFinLinOrdCat ⥤ NonemptyFinLinOrdCat where
 set_option linter.uppercaseLean3 false in
 #align NonemptyFinLinOrd.dual NonemptyFinLinOrdCat.dual
 
-/-- The equivalence between `FinPartOrdCat` and itself induced by `OrderDual` both ways. -/
+/-- The equivalence between `NonemptyFinLinOrdCat` and itself induced by `OrderDual` both ways. -/
 @[simps functor inverse]
 def dualEquiv : NonemptyFinLinOrdCat ≌ NonemptyFinLinOrdCat where
   functor := dual
@@ -244,3 +255,13 @@ theorem nonemptyFinLinOrdCat_dual_comp_forget_to_linOrdCat :
   rfl
 set_option linter.uppercaseLean3 false in
 #align NonemptyFinLinOrd_dual_comp_forget_to_LinOrd nonemptyFinLinOrdCat_dual_comp_forget_to_linOrdCat
+
+/-- The forgetful functor `NonemptyFinLinOrd ⥤ FinPartOrd` and `order_dual` commute. -/
+def nonemptyFinLinOrdDualCompForgetToFinPartOrd :
+    NonemptyFinLinOrdCat.dual ⋙ forget₂ NonemptyFinLinOrdCat FinPartOrd ≅
+      forget₂ NonemptyFinLinOrdCat FinPartOrd ⋙ FinPartOrd.dual
+    where
+  hom := { app := fun X => OrderHom.id }
+  inv := { app := fun X => OrderHom.id }
+set_option linter.uppercaseLean3 false in
+#align NonemptyFinLinOrd_dual_comp_forget_to_FinPartOrd nonemptyFinLinOrdDualCompForgetToFinPartOrd


### PR DESCRIPTION
Match https://github.com/leanprover-community/mathlib/pull/18948

[`order.category.NonemptyFinLinOrd`@`e8ac6315bcfcbaf2d19a046719c3b553206dac75`..`fa4a805d16a9cd9c96e0f8edeb57dc5a07af1a19`](https://leanprover-community.github.io/mathlib-port-status/file/order/category/NonemptyFinLinOrd?range=e8ac6315bcfcbaf2d19a046719c3b553206dac75..fa4a805d16a9cd9c96e0f8edeb57dc5a07af1a19)


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
