### PR TITLE
[Merged by Bors] - fix: less confusing percentage

### DIFF
--- a/Cache/Requests.lean
+++ b/Cache/Requests.lean
@@ -88,7 +88,7 @@ def downloadFiles (hashMap : IO.HashMap) (forceDownload : Bool) (parallel : Bool
           done := done + 1
           let now ← IO.monoMsNow
           if now - last ≥ 100 then -- max 10/s update rate
-            let mut msg := s!"\rDownloaded {success} file(s) [{done}/{size} = {100*done/size}%]"
+            let mut msg := s!"\rAttempted: {done} file(s) [{done}/{size} = {100*done/size}%] --- Successful: {success} file(s) [{success}/{done} = {100*success/done}%] "
             if failed != 0 then
               msg := msg ++ ", {failed} failed"
             IO.eprint msg
@@ -96,7 +96,7 @@ def downloadFiles (hashMap : IO.HashMap) (forceDownload : Bool) (parallel : Bool
         pure (last, success, failed, done)
       if done > 0 then
         -- to avoid confusingly moving on without finishing the count
-        let mut msg := s!"\rDownloaded {success} file(s) [{success}/{size} = {100*success/size}%]"
+        let mut msg := s!"\rAttempted: {done} file(s) [{done}/{size} = {100*done/size}%] --- Successful: {success} file(s) [{success}/{done} = {100*success/done}%] "
         if failed != 0 then
           msg := msg ++ ", {failed} failed"
         IO.eprintln msg

--- a/Cache/Requests.lean
+++ b/Cache/Requests.lean
@@ -88,7 +88,7 @@ def downloadFiles (hashMap : IO.HashMap) (forceDownload : Bool) (parallel : Bool
           done := done + 1
           let now ← IO.monoMsNow
           if now - last ≥ 100 then -- max 10/s update rate
-            let mut msg := s!"\rAttempted: {done} file(s) [{done}/{size} = {100*done/size}%] --- Successful: {success} file(s) [{success}/{done} = {100*success/done}%] "
+            let mut msg := s!"\rAttempted: {done} file(s) [{done}/{size} = {100*done/size}%] --- Successful: {success} file(s) [{success}/{done} = {100*success/done}% of attempted, {success}/{size} = {100*success/size}% of total]"
             if failed != 0 then
               msg := msg ++ ", {failed} failed"
             IO.eprint msg
@@ -96,7 +96,7 @@ def downloadFiles (hashMap : IO.HashMap) (forceDownload : Bool) (parallel : Bool
         pure (last, success, failed, done)
       if done > 0 then
         -- to avoid confusingly moving on without finishing the count
-        let mut msg := s!"\rAttempted: {done} file(s) [{done}/{size} = {100*done/size}%] --- Successful: {success} file(s) [{success}/{done} = {100*success/done}%] "
+        let mut msg := s!"\rAttempted: {done} file(s) [{done}/{size} = {100*done/size}%] --- Successful: {success} file(s) [{success}/{done} = {100*success/done}% of attempted, {success}/{size} = {100*success/size}% of total]] "
         if failed != 0 then
           msg := msg ++ ", {failed} failed"
         IO.eprintln msg

--- a/Cache/Requests.lean
+++ b/Cache/Requests.lean
@@ -96,7 +96,7 @@ def downloadFiles (hashMap : IO.HashMap) (forceDownload : Bool) (parallel : Bool
         pure (last, success, failed, done)
       if done > 0 then
         -- to avoid confusingly moving on without finishing the count
-        let mut msg := s!"\rDownloaded {success} file(s) [{size}/{size} = 100%]"
+        let mut msg := s!"\rDownloaded {success} file(s) [{success}/{size} = {100*success/size}%]"
         if failed != 0 then
           msg := msg ++ ", {failed} failed"
         IO.eprintln msg

--- a/Cache/Requests.lean
+++ b/Cache/Requests.lean
@@ -88,7 +88,7 @@ def downloadFiles (hashMap : IO.HashMap) (forceDownload : Bool) (parallel : Bool
           done := done + 1
           let now ← IO.monoMsNow
           if now - last ≥ 100 then -- max 10/s update rate
-            let mut msg := s!"\rAttempted: {done} file(s) [{done}/{size} = {100*done/size}%] --- Successful: {success} file(s) [{success}/{done} = {100*success/done}% of attempted, {success}/{size} = {100*success/size}% of total]"
+            let mut msg := s!"\rDownloaded: {success} file(s) [attempted {done}/{size} = {100*done/size}%]"
             if failed != 0 then
               msg := msg ++ ", {failed} failed"
             IO.eprint msg
@@ -96,7 +96,7 @@ def downloadFiles (hashMap : IO.HashMap) (forceDownload : Bool) (parallel : Bool
         pure (last, success, failed, done)
       if done > 0 then
         -- to avoid confusingly moving on without finishing the count
-        let mut msg := s!"\rAttempted: {done} file(s) [{done}/{size} = {100*done/size}%] --- Successful: {success} file(s) [{success}/{done} = {100*success/done}% of attempted, {success}/{size} = {100*success/size}% of total]] "
+        let mut msg := s!"\rDownloaded: {success} file(s) [attempted {done}/{size} = {100*done/size}%] ({100*success/done}% success)"
         if failed != 0 then
           msg := msg ++ ", {failed} failed"
         IO.eprintln msg


### PR DESCRIPTION
This fixes output that we have currently like:
```
Attempting to download 19 file(s)
Downloaded 14 file(s) [19/19 = 100%]
```
I mean `19/19 = 100%` is true in this case, but I think `14/19 = ...` would be more relevant. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
