### PR TITLE
chore: disable new compiler for now

### DIFF
--- a/Mathlib/Analysis/Analytic/Linear.lean
+++ b/Mathlib/Analysis/Analytic/Linear.lean
@@ -32,7 +32,9 @@ namespace ContinuousLinearMap
 
 /-- Formal power series of a continuous linear map `f : E →L[𝕜] F` at `x : E`:
 `f y = f x + f (y - x)`. -/
-@[simp]
+-- @[simp] -- Porting note: removed during !4#4573
+-- This was interacting badly with disabling the new compiler.
+-- See https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/initialization.20order.20fiasco
 def fpowerSeries (f : E →L[𝕜] F) (x : E) : FormalMultilinearSeries 𝕜 E F
   | 0 => ContinuousMultilinearMap.curry0 𝕜 _ (f x)
   | 1 => (continuousMultilinearCurryFin1 𝕜 E F).symm f
@@ -83,7 +85,9 @@ theorem uncurryBilinear_apply (f : E →L[𝕜] F →L[𝕜] G) (m : Fin 2 → E
 #align continuous_linear_map.uncurry_bilinear_apply ContinuousLinearMap.uncurryBilinear_apply
 
 /-- Formal multilinear series expansion of a bilinear function `f : E →L[𝕜] F →L[𝕜] G`. -/
-@[simp]
+-- @[simp] -- Porting note: removed during !4#4573
+-- This was interacting badly with disabling the new compiler.
+-- See https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/initialization.20order.20fiasco
 def fpowerSeriesBilinear (f : E →L[𝕜] F →L[𝕜] G) (x : E × F) : FormalMultilinearSeries 𝕜 (E × F) G
   | 0 => ContinuousMultilinearMap.curry0 𝕜 _ (f x.1 x.2)
   | 1 => (continuousMultilinearCurryFin1 𝕜 (E × F) G).symm (f.deriv₂ x)

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -8,7 +8,8 @@ def moreServerArgs := #[
 
 -- These settings only apply during `lake build`, but not in VSCode editor.
 def moreLeanArgs := #[
-  "-DwarningAsError=true"
+  "-DwarningAsError=true",
+  "-Dcompiler.enableNew=false"
 ] ++ moreServerArgs
 
 package mathlib where
@@ -27,6 +28,7 @@ meta if get_config? doc = some "on" then -- do not download and build doc-gen4 b
 require «doc-gen4» from git "https://github.com/leanprover/doc-gen4" @ "main"
 
 require std from git "https://github.com/leanprover/std4" @ "main"
+  with NameMap.empty.insert `disable_new_compiler ""
 require Qq from git "https://github.com/gebner/quote4" @ "master"
 require aesop from git "https://github.com/JLimperg/aesop" @ "master"
 


### PR DESCRIPTION
This was recently added as an option in Lean 4. It should reduce the size of oleans, and hopefully not otherwise have any practical effect.

When work on the new compiler resumes we can re-enable it or set up some other testing regime.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
