### PR TITLE
[Merged by Bors] - fix: workaround for leanprover/lean4#2249

### DIFF
--- a/Mathlib/Mathport/Syntax.lean
+++ b/Mathlib/Mathport/Syntax.lean
@@ -111,18 +111,12 @@ estimated difficulty of writing the tactic. The key is as follows:
 * `S`: Possibly easy, because we can just stub it out or replace with something else
 * `?`: uncategorized
 -/
-namespace Lean
-
-namespace Parser.Command
+namespace Mathlib.Tactic
+open Lean Parser.Tactic
 
 /- N -/ elab (name := include) "include" (ppSpace ident)+ : command => pure ()
 /- N -/ elab (name := omit) "omit" (ppSpace ident)+ : command => pure ()
 /- N -/ syntax (name := parameter) "parameter" (ppSpace bracketedBinder)+ : command
-
-end Parser.Command
-
-namespace Parser
-namespace Tactic
 
 /- S -/ syntax (name := propagateTags) "propagate_tags " tacticSeq : tactic
 /- S -/ syntax (name := mapply) "mapply " term : tactic
@@ -294,10 +288,6 @@ macro (name := moveMul) "move_mul " pats:rwRule,+ loc:(location)? : tactic =>
 macro (name := moveAdd) "move_add " pats:rwRule,+ loc:(location)? : tactic =>
   `(tactic| move_op (·+·) $pats,* $(loc)?)
 
-end Tactic
-
-namespace Attr
-
 /- S -/ syntax (name := intro) "intro" : attr
 /- S -/ syntax (name := intro!) "intro!" : attr
 
@@ -312,10 +302,6 @@ namespace Attr
 
 /- N -/ syntax (name := pp_nodot) "pp_nodot" : attr
 
-end Attr
-
-namespace Command
-
 /- N -/ syntax (name := addTacticDoc) (docComment)? "add_tactic_doc " term : command
 
 /- M -/ syntax (name := addHintTactic) "add_hint_tactic " tactic : command
@@ -324,7 +310,7 @@ namespace Command
 
 /- S -/ syntax (name := listUnusedDecls) "#list_unused_decls" : command
 
-/- N -/ syntax (name := defReplacer) "def_replacer " ident Term.optType : command
+/- N -/ syntax (name := defReplacer) "def_replacer " ident Parser.Term.optType : command
 
 /- S -/ syntax (name := «where») "#where" : command
 
@@ -336,5 +322,3 @@ namespace Command
 
 /- E -/ syntax (name := assertInstance) "assert_instance " term : command
 /- E -/ syntax (name := assertNoInstance) "assert_no_instance " term : command
-
-end Command


### PR DESCRIPTION
This puts all the mathlib tactics in the `Mathlib.Tactic` namespace instead of pretending we are an extension of the `Lean` package, which is causing problems.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
