### PR TITLE
[Merged by Bors] - fix: move `dummy_label_attr` to a separate file

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2679,6 +2679,7 @@ import Mathlib.Util.AssertExists
 import Mathlib.Util.AssertNoSorry
 import Mathlib.Util.AtomM
 import Mathlib.Util.CompileInductive
+import Mathlib.Util.DummyLabelAttr
 import Mathlib.Util.Export
 import Mathlib.Util.IncludeStr
 import Mathlib.Util.LongNames

--- a/Mathlib/Tactic/LabelAttr.lean
+++ b/Mathlib/Tactic/LabelAttr.lean
@@ -91,6 +91,3 @@ def labelled (attrName : Name) : MetaM (Array Name) := do
   match (← labelExtensionMapRef.get).find? attrName with
   | none => throwError "No extension named {attrName}"
   | some ext => pure <| ext.getState (← getEnv)
-
-/-- A dummy label attribute, to ease testing. -/
-register_label_attr dummy_label_attr

--- a/Mathlib/Util/DummyLabelAttr.lean
+++ b/Mathlib/Util/DummyLabelAttr.lean
@@ -1,0 +1,16 @@
+/-
+Copyright (c) 2023 Scott Morrison. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Scott Morrison
+-/
+import Mathlib.Tactic.LabelAttr
+
+/-! # Dummy label attribute, for tests
+
+This has to be in a separate file from `Mathlib.Tactic.LabelAttr`, and also a separate file
+from the files in `test/` that actually want to use it, so it ends up alone. This could be in
+`test/` but the tests are set up for single file use only and can only import things from mathlib.
+-/
+
+/-- A dummy label attribute, to ease testing. -/
+register_label_attr dummy_label_attr

--- a/test/solve_by_elim/basic.lean
+++ b/test/solve_by_elim/basic.lean
@@ -9,6 +9,7 @@ import Std.Tactic.RCases
 import Mathlib.Tactic.Constructor
 import Mathlib.Tactic.PermuteGoals
 import Mathlib.Tactic.SolveByElim
+import Mathlib.Util.DummyLabelAttr
 
 example (h : Nat) : Nat := by solve_by_elim
 example {α β : Type} (f : α → β) (a : α) : β := by solve_by_elim


### PR DESCRIPTION
This setup was AFAIK never designed to work, and only worked by luck in this case. It is nondeterministic whether `dummy_label_attr` is evaluated before or after `labelExtensionMapRef`, depending on the iteration order over the constants in the file. See https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/initialization.20order.20fiasco/near/363247722