### PR TITLE
[Merged by Bors] - chore: start port from non-master branch

### DIFF
--- a/scripts/start_port.sh
+++ b/scripts/start_port.sh
@@ -33,7 +33,8 @@ mathlib3port_url=$MATHLIB3PORT_BASE_URL/Mathbin/${1#Mathlib/}
 
 # start the port from the latest master
 git fetch
-BASE_COMMIT=$(git rev-parse origin/master)
+BASE_BRANCH=${BASE_BRANCH=origin/master}
+BASE_COMMIT=$(git rev-parse $BASE_BRANCH)
 
 TMP_DIR=$(mktemp -d)
 trap 'rm -fr "$TMP_DIR"' 0 1 2 13 15


### PR DESCRIPTION
Add an undocumented way to start new port from a non-`master`
branch. This is useful if some dependencies were not merged to
`master` yet.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)