### PR TITLE
[Merged by Bors] - feat: precedence in notation3

### DIFF
--- a/Mathlib/Mathport/Notation.lean
+++ b/Mathlib/Mathport/Notation.lean
@@ -68,10 +68,11 @@ syntax foldKind := &"foldl" <|> &"foldr"
 /-- `notation3` argument matching `extBinders`. -/
 syntax bindersItem := atomic("(" "..." ")")
 /-- `notation3` argument simulating a Lean 3 fold notation. -/
-syntax foldAction := "(" ident ppSpace strLit "*" " => " foldKind
+syntax foldAction := "(" ident ppSpace strLit "*" (precedence)? " => " foldKind
   " (" ident ppSpace ident " => " term ") " term ")"
 /-- `notation3` argument binding a name. -/
-syntax identOptScoped := ident (":" "(" "scoped " ident " => " term ")")?
+syntax identOptScoped :=
+  ident (notFollowedBy(":" "(" "scoped") precedence)? (":" "(" "scoped " ident " => " term ")")?
 /-- `notation3` argument. -/
 -- Note: there is deliberately no ppSpace between items
 -- so that the space in the literals themselves stands out
@@ -457,9 +458,9 @@ elab doc:(docComment)? attrs?:(Parser.Term.attributes)? attrKind:Term.attrKind
       if let `(stx| $lit:str) := syntaxArgs.back then
         syntaxArgs := syntaxArgs.pop.push (← `(stx| $(quote lit.getString.trimRight):str))
       (syntaxArgs, pattArgs) ← pushMacro syntaxArgs pattArgs (← `(macroArg| binders:extBinders))
-    | `(notation3Item| ($id:ident $sep:str* => $kind ($x $y => $scopedTerm) $init)) =>
+    | `(notation3Item| ($id:ident $sep:str* $(prec?)? => $kind ($x $y => $scopedTerm) $init)) =>
       (syntaxArgs, pattArgs) ← pushMacro syntaxArgs pattArgs <| ←
-        `(macroArg| $id:ident:sepBy(term, $sep:str))
+        `(macroArg| $id:ident:sepBy(term $(prec?)?, $sep:str))
       -- N.B. `Syntax.getId` returns `.anonymous` for non-idents
       let scopedTerm' ← scopedTerm.replaceM fun s => pure (boundValues.find? s.getId)
       let init' ← init.replaceM fun s => pure (boundValues.find? s.getId)
@@ -478,11 +479,12 @@ elab doc:(docComment)? attrs?:(Parser.Term.attributes)? attrKind:Term.attrKind
           matchers := matchers.push <|
             mkFoldrMatcher id.getId x.getId y.getId scopedTerm init (getBoundNames boundValues)
         | _ => throwUnsupportedSyntax
-    | `(notation3Item| $lit:ident : (scoped $scopedId:ident => $scopedTerm)) =>
+    | `(notation3Item| $lit:ident $(prec?)? : (scoped $scopedId:ident => $scopedTerm)) =>
       if hasScoped then
         throwErrorAt item "Cannot have more than one `scoped` item."
       hasScoped := true
-      (syntaxArgs, pattArgs) ← pushMacro syntaxArgs pattArgs (← `(macroArg| $lit:ident:term))
+      (syntaxArgs, pattArgs) ← pushMacro syntaxArgs pattArgs <|←
+        `(macroArg| $lit:ident:term $(prec?)?)
       matchers := matchers.push <|
         mkScopedMatcher lit.getId scopedId.getId scopedTerm (getBoundNames boundValues)
       let scopedTerm' ← scopedTerm.replaceM fun s => pure (boundValues.find? s.getId)
@@ -490,8 +492,9 @@ elab doc:(docComment)? attrs?:(Parser.Term.attributes)? attrKind:Term.attrKind
       boundValues := boundValues.insert lit.getId <| ←
         `(expand_binders% ($scopedId => $scopedTerm') $$binders:extBinders,
           $(⟨lit.1.mkAntiquotNode `term⟩):term)
-    | `(notation3Item| $lit:ident) =>
-      (syntaxArgs, pattArgs) ← pushMacro syntaxArgs pattArgs (← `(macroArg| $lit:ident:term))
+    | `(notation3Item| $lit:ident $(prec?)?) =>
+      (syntaxArgs, pattArgs) ← pushMacro syntaxArgs pattArgs <|←
+        `(macroArg| $lit:ident:term $(prec?)?)
       boundIdents := boundIdents.insert lit.getId lit
       boundValues := boundValues.insert lit.getId <| lit.1.mkAntiquotNode `term
     | stx => throwUnsupportedSyntax


### PR DESCRIPTION
The mathlib side of the fix for https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/mathport.3A.20big.20operators/near/363878759 .

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
