### PR TITLE
[Merged by Bors] - feat: pi notation for pi types

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2765,8 +2765,8 @@ import Mathlib.Util.Export
 import Mathlib.Util.IncludeStr
 import Mathlib.Util.LongNames
 import Mathlib.Util.MemoFix
-import Mathlib.Util.Pickle
 import Mathlib.Util.PiNotation
+import Mathlib.Util.Pickle
 import Mathlib.Util.Qq
 import Mathlib.Util.Syntax
 import Mathlib.Util.SynthesizeUsing

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2766,6 +2766,7 @@ import Mathlib.Util.IncludeStr
 import Mathlib.Util.LongNames
 import Mathlib.Util.MemoFix
 import Mathlib.Util.Pickle
+import Mathlib.Util.PiNotation
 import Mathlib.Util.Qq
 import Mathlib.Util.Syntax
 import Mathlib.Util.SynthesizeUsing

--- a/Mathlib/Util/PiNotation.lean
+++ b/Mathlib/Util/PiNotation.lean
@@ -1,0 +1,61 @@
+/-
+Copyright (c) 2023 Kyle Miller. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kyle Miller
+-/
+import Std.Util.ExtendedBinder
+
+/-! # Pi type notation
+
+Provides the `Π x : α, β x` notation as an alternative to Lean 4's built-in
+`(x : α) → β x` notation. To get all non-`∀` pi types to pretty print this way
+then do `open scoped PiNotation`.
+
+The notation also accepts extended binders, like `Π x ∈ s, β x` for `Π x, x ∈ s → β x`.
+-/
+
+namespace PiNotation
+open Lean.Parser Term
+open Lean.PrettyPrinter.Delaborator
+
+/-- Dependent function type (a "pi type"). The notation `Π x : α, β x` can
+also be written as `(x : α) → β x`. -/
+-- A direct copy of forall notation but with `Π`/`Pi` instead of `∀`/`Forall`.
+@[term_parser]
+def piNotation := leading_parser:leadPrec
+  unicodeSymbol "Π" "Pi" >>
+  many1 (ppSpace >> (binderIdent <|> bracketedBinder)) >>
+  optType >> ", " >> termParser
+
+/-- Dependent function type (a "pi type"). The notation `Π x ∈ s, β x` is
+short for `Π x, x ∈ s → β x`. -/
+-- A copy of forall notation from `Std.Util.ExtendedBinder` for pi notation
+syntax "Π " binderIdent binderPred ", " term : term
+
+macro_rules
+  | `(Π $x:ident $pred:binderPred, $p) => `(Π $x:ident, satisfies_binder_pred% $x $pred → $p)
+  | `(Π _ $pred:binderPred, $p) => `(Π x, satisfies_binder_pred% x $pred → $p)
+
+/-- Since pi notation and forall notation are interchangable, we can
+parse it by simply using the pre-existing forall parser. -/
+@[macro PiNotation.piNotation] def replacePiNotation : Lean.Macro
+  | .node info _ args => return .node info ``Lean.Parser.Term.forall args
+  | _ => Lean.Macro.throwUnsupported
+
+/-- Override the Lean 4 pi notation delaborator with one that uses `Π`.
+Note that this takes advantage of the fact that `(x : α) → p x` notation is
+never used for propositions, so we can match on this result and rewrite it. -/
+@[scoped delab forallE]
+def delabPi : Delab := whenPPOption Lean.getPPNotation do
+  let stx ← delabForall
+  -- Replacements
+  let stx : Term ←
+    match stx with
+    | `($group:bracketedBinder → $body) => `(Π $group:bracketedBinder, $body)
+    | _ => pure stx
+  -- Merging
+  match stx with
+  | `(Π $group, Π $groups*, $body) => `(Π $group $groups*, $body)
+  | _ => pure stx
+
+end PiNotation


### PR DESCRIPTION
Adds a parser for pi notation (like `Π x : α, β x`). Also adds a pretty printer that can be activated using `open scoped PiNotation`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
