### PR TITLE
chore: Revert "chore: run CI on Hoskinson machines (#4539)"

### DIFF
--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -86,7 +86,7 @@ jobs:
   build:
     if: github.repository == 'leanprover-community/mathlib4'
     name: Build
-    runs-on: bors
+    runs-on: ubuntu-latest
     steps:
       - name: cleanup
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,7 @@ jobs:
   build:
     if: github.repository == 'leanprover-community/mathlib4'
     name: Build
-    runs-on: pr
+    runs-on: ubuntu-latest
     steps:
       - name: cleanup
         run: |

--- a/.github/workflows/build.yml.in
+++ b/.github/workflows/build.yml.in
@@ -72,7 +72,7 @@ jobs:
   build:
     if: github.repository MAIN_OR_FORK 'leanprover-community/mathlib4'
     name: BuildJOB_NAME
-    runs-on: RUNS_ON
+    runs-on: ubuntu-latest
     steps:
       - name: cleanup
         run: |


### PR DESCRIPTION
This reverts commit 18b622df767cc9ef272454f416192a53e52a41e4.

Unfortunately we forgot to clean the `.cache` directories on the Hoskinson machines. This removes mathlib4 CI from these machines until we can clean them up.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
