### PR TITLE
[Merged by Bors] - chore: Add import to Mathlib.Data.Nat.PrimeNormNum

### DIFF
--- a/Mathlib/Data/Nat/PrimeNormNum.lean
+++ b/Mathlib/Data/Nat/PrimeNormNum.lean
@@ -11,6 +11,7 @@ Authors: Leonardo de Moura, Jeremy Avigad, Mario Carneiro
 import Mathlib.Data.Nat.Factors
 import Mathlib.Data.Nat.Prime
 import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.NormNum.Prime
 
 /-!
 # Primality prover


### PR DESCRIPTION
This PR adds the import to `Mathlib.Data.Nat.PrimeNormNum` that enables `norm_num` to check primality.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
