### PR TITLE
[Merged by Bors] - feat: port `noncomm_ring` tactic

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2476,6 +2476,7 @@ import Mathlib.Tactic.Monotonicity
 import Mathlib.Tactic.Monotonicity.Attr
 import Mathlib.Tactic.Monotonicity.Basic
 import Mathlib.Tactic.Monotonicity.Lemmas
+import Mathlib.Tactic.NoncommRing
 import Mathlib.Tactic.Nontriviality
 import Mathlib.Tactic.Nontriviality.Core
 import Mathlib.Tactic.NormCast

--- a/Mathlib/Algebra/Lie/SkewAdjoint.lean
+++ b/Mathlib/Algebra/Lie/SkewAdjoint.lean
@@ -10,6 +10,7 @@ Authors: Oliver Nash
 -/
 import Mathlib.Algebra.Lie.Matrix
 import Mathlib.LinearAlgebra.Matrix.BilinearForm
+import Mathlib.Tactic.NoncommRing
 
 /-!
 # Lie algebras of skew-adjoint endomorphisms of a bilinear form
@@ -112,8 +113,7 @@ theorem Matrix.isSkewAdjoint_bracket {A B : Matrix n n R} (hA : A ∈ skewAdjoin
   rw [Matrix.lie_transpose, LieRing.of_associative_ring_bracket,
     LieRing.of_associative_ring_bracket, sub_mul, mul_assoc, mul_assoc, hA, hB, ← mul_assoc,
     ← mul_assoc, hA, hB]
-  --noncomm_ring -- Porting note: This tactic doesn't exist yet, so write a new `rw`
-  rw [neg_sub, mul_sub_left_distrib, mul_assoc, mul_assoc, neg_mul_neg, neg_mul_neg]
+  noncomm_ring
 #align matrix.is_skew_adjoint_bracket Matrix.isSkewAdjoint_bracket
 
 /-- The Lie subalgebra of skew-adjoint square matrices corresponding to a square matrix `J`. -/

--- a/Mathlib/Analysis/NormedSpace/MStructure.lean
+++ b/Mathlib/Analysis/NormedSpace/MStructure.lean
@@ -10,6 +10,7 @@ Authors: Christopher Hoskin
 -/
 import Mathlib.Algebra.Ring.Idempotents
 import Mathlib.Analysis.Normed.Group.Basic
+import Mathlib.Tactic.NoncommRing
 
 /-!
 # M-structure
@@ -140,11 +141,7 @@ theorem commute [FaithfulSMul M X] {P Q : M} (h₁ : IsLprojection X P) (h₂ : 
     have e1 : P * (1 - Q) = P * (1 - Q) - (Q * P - Q * P * Q) :=
       calc
         P * (1 - Q) = (1 - Q) * P * (1 - Q) := by rw [PR_eq_RPR (1 - Q) h₂.Lcomplement]
-        --porting note: noncomm_ring tactic not yet ported, so complete proof with rewrites for now
-        _ = 1 * (P * (1 - Q)) - Q * (P * (1 - Q)) := by rw [mul_assoc, sub_mul]
-        _ = P * (1 - Q) - Q * (P * (1 - Q)) := by rw [one_mul]
-        _ = P * (1 - Q) - Q * (P - P * Q) := by rw [mul_sub, mul_one]
-        _ = P * (1 - Q) - (Q * P - Q * P * Q) := by rw [mul_sub Q, mul_assoc]
+        _ = P * (1 - Q) - (Q * P - Q * P * Q) := by noncomm_ring
     rwa [eq_sub_iff_add_eq, add_right_eq_self, sub_eq_zero] at e1
   show P * Q = Q * P
   · rw [QP_eq_QPQ, PR_eq_RPR Q h₂]
@@ -171,8 +168,7 @@ theorem mul [FaithfulSMul M X] {P Q : M} (h₁ : IsLprojection X P) (h₂ : IsLp
 theorem join [FaithfulSMul M X] {P Q : M} (h₁ : IsLprojection X P) (h₂ : IsLprojection X Q) :
     IsLprojection X (P + Q - P * Q) := by
   convert (Lcomplement_iff _).mp (h₁.Lcomplement.mul h₂.Lcomplement) using 1
-  --porting note: noncomm_ring tactic not yet ported, so complete proof with rewrites for now
-  rw [sub_mul, one_mul, sub_sub, sub_sub_self, mul_sub, mul_one, add_sub, add_comm]
+  noncomm_ring
 #align is_Lprojection.join IsLprojection.join
 
 --porting note: Advice is to explicitly name instances

--- a/Mathlib/RingTheory/OreLocalization/Basic.lean
+++ b/Mathlib/RingTheory/OreLocalization/Basic.lean
@@ -11,6 +11,7 @@ Authors: Jakob von Raumer, Kevin Klinge
 import Mathlib.GroupTheory.MonoidLocalization
 import Mathlib.RingTheory.NonZeroDivisors
 import Mathlib.RingTheory.OreLocalization.OreSet
+import Mathlib.Tactic.NoncommRing
 
 /-!
 
@@ -521,11 +522,11 @@ private theorem add''_char (r₁ : R) (s₁ : S) (r₂ : R) (s₂ : S) (rb : R) 
   use sc * sd
   use rc * sd
   constructor <;> simp only [Submonoid.coe_mul]
-  · simp only [right_distrib, mul_assoc]
+  · noncomm_ring
     rw [← mul_assoc (a := rb), hd, ← mul_assoc (a := (sa : R)), hc]
-    simp only [mul_assoc]
+    noncomm_ring
   · rw [mul_assoc (a := (s₁ : R)), ← mul_assoc (a := (sa : R)), hc]
-    simp only [mul_assoc]
+    noncomm_ring
 
 attribute [local instance] OreLocalization.oreEqv
 

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -73,6 +73,7 @@ import Mathlib.Tactic.Monotonicity
 import Mathlib.Tactic.Monotonicity.Attr
 import Mathlib.Tactic.Monotonicity.Basic
 import Mathlib.Tactic.Monotonicity.Lemmas
+import Mathlib.Tactic.NoncommRing
 import Mathlib.Tactic.Nontriviality
 import Mathlib.Tactic.Nontriviality.Core
 import Mathlib.Tactic.NormCast

--- a/Mathlib/Tactic/NoncommRing.lean
+++ b/Mathlib/Tactic/NoncommRing.lean
@@ -1,0 +1,55 @@
+/-
+Copyright (c) 2020 Oliver Nash. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jireh Loreaux, Scott Morrison, Oliver Nash
+-/
+import Mathlib.Tactic.Abel
+
+/-! # The `noncomm_ring` tactic
+
+Solve goals in not necessarily commutative rings.
+
+This tactic is rudimentary, but useful for solving simple goals in noncommutative rings. One
+glaring flaw is that numeric powers are unfolded entirely with `pow_succ` and can easily exceed the
+maximum recursion depth.
+ -/
+
+namespace Mathlib.Tactic.NoncommRing
+
+section nat_lit_mul
+variable {R : Type _} [NonAssocSemiring R] (r : R) (n : ℕ)
+
+lemma nat_lit_mul_eq_nsmul [n.AtLeastTwo] : (OfNat.ofNat n) * r = n • r := by
+  simp only [nsmul_eq_mul, Nat.cast_eq_ofNat]
+lemma mul_nat_lit_eq_nsmul [n.AtLeastTwo] : r * (OfNat.ofNat n) = n • r := by
+  simp only [nsmul_eq_mul', Nat.cast_eq_ofNat]
+
+end nat_lit_mul
+
+/-- A tactic for simplifying identities in not-necessarily-commutative rings.
+
+An example:
+```lean
+example {R : Type*} [ring R] (a b c : R) : a * (b + c + c - b) = 2*a*c :=
+by noncomm_ring
+```
+-/
+syntax (name := noncomm_ring) "noncomm_ring" : tactic
+macro_rules
+  | `(tactic| noncomm_ring) => `(tactic| (
+      simp only [ -- Expand everything out.
+                  add_mul, mul_add, sub_eq_add_neg,
+                  -- Right associate all products.
+                  mul_assoc,
+                  -- Expand powers to numerals.
+                  pow_one, pow_zero, pow_succ,
+                  -- Replace multiplication by numerals with `zsmul`.
+                  one_mul, mul_one, zero_mul, mul_zero,
+                  nat_lit_mul_eq_nsmul, mul_nat_lit_eq_nsmul,
+                  -- Pull `zsmul n` out the front so `abel` can see them.
+                  mul_smul_comm, smul_mul_assoc,
+                  -- Pull out negations.
+                  neg_mul, mul_neg ] <;>
+      abel ))
+
+end Mathlib.Tactic.NoncommRing

--- a/Mathlib/Tactic/NoncommRing.lean
+++ b/Mathlib/Tactic/NoncommRing.lean
@@ -12,6 +12,9 @@ Solve goals in not necessarily commutative rings.
 This tactic is rudimentary, but useful for solving simple goals in noncommutative rings. One
 glaring flaw is that numeric powers are unfolded entirely with `pow_succ` and can easily exceed the
 maximum recursion depth.
+
+`noncomm_ring` is just a `simp only [some lemmas]` followed by `abel`. It automatically uses `abel1`
+to close the goal, and if that doesn't succeed, defaults to `abel_nf`.
  -/
 
 namespace Mathlib.Tactic.NoncommRing
@@ -50,6 +53,6 @@ macro_rules
                   mul_smul_comm, smul_mul_assoc,
                   -- Pull out negations.
                   neg_mul, mul_neg ] <;>
-      abel ))
+      first | abel1 | abel_nf ))
 
 end Mathlib.Tactic.NoncommRing

--- a/test/NoncommRing.lean
+++ b/test/NoncommRing.lean
@@ -1,0 +1,61 @@
+import Mathlib.Tactic.NoncommRing
+
+local notation (name := commutator) "⁅"a", "b"⁆" => a * b - b * a
+
+set_option quotPrecheck false
+local infix:70  " ⚬ " => fun a b => a * b + b * a
+
+variable {R : Type _} [Ring R]
+variable (a b c : R)
+
+example : 0 = 0 := by noncomm_ring
+example : a = a := by noncomm_ring
+
+example : (a + b) * c = a * c + b * c := by noncomm_ring
+example : a * (b + c) = a * b + a * c := by noncomm_ring
+example : a - b = a + -b := by noncomm_ring
+example : a * b * c = a * (b * c) := by noncomm_ring
+example : a + a = 2 * a := by noncomm_ring
+
+example : a + a = a * 2 := by noncomm_ring
+example : -a - a = a * (-2) := by noncomm_ring
+example : -a = (-1) * a := by noncomm_ring
+example : a + a + a = 3 * a := by noncomm_ring
+example : a ^ 2 = a * a := by noncomm_ring
+example : a ^ 3 = a * a * a := by noncomm_ring
+example : (-a) * b = -(a * b) := by noncomm_ring
+example : a * (-b) = -(a * b) := by noncomm_ring
+example : a * (b + c + b + c - 2*b) = 2*a*c := by noncomm_ring
+example : a * (b + c + b + c - (2 : ℕ) • b) = 2*a*c := by noncomm_ring
+example : (a + b)^2 = a^2 + a*b + b*a + b^2 := by noncomm_ring
+example : (a - b)^2 = a^2 - a*b - b*a + b^2 := by noncomm_ring
+example : (a + b)^3 = a^3 + a^2*b + a*b*a + a*b^2 + b*a^2 + b*a*b + b^2*a + b^3 := by noncomm_ring
+example : (a - b)^3 = a^3 - a^2*b - a*b*a + a*b^2 - b*a^2 + b*a*b + b^2*a - b^3 := by noncomm_ring
+
+example : ⁅a, a⁆ = 0 := by noncomm_ring
+example : ⁅a, b⁆ = -⁅b, a⁆ := by noncomm_ring
+example : ⁅a + b, c⁆ = ⁅a, c⁆ + ⁅b, c⁆ := by noncomm_ring
+example : ⁅a, b + c⁆ = ⁅a, b⁆ + ⁅a, c⁆ := by noncomm_ring
+example : ⁅a, ⁅b, c⁆⁆ + ⁅b, ⁅c, a⁆⁆ + ⁅c, ⁅a, b⁆⁆ = 0 := by noncomm_ring
+example : ⁅⁅a, b⁆, c⁆ + ⁅⁅b, c⁆, a⁆ + ⁅⁅c, a⁆, b⁆ = 0 := by noncomm_ring
+example : ⁅a, ⁅b, c⁆⁆ = ⁅⁅a, b⁆, c⁆ + ⁅b, ⁅a, c⁆⁆ := by noncomm_ring
+example : ⁅⁅a, b⁆, c⁆ = ⁅⁅a, c⁆, b⁆ + ⁅a, ⁅b, c⁆⁆ := by noncomm_ring
+example : ⁅a * b, c⁆ = a * ⁅b, c⁆ + ⁅a, c⁆ * b := by noncomm_ring
+example : ⁅a, b * c⁆ = ⁅a, b⁆ * c + b * ⁅a, c⁆ := by noncomm_ring
+example : ⁅3 * a, a⁆ = 0 := by noncomm_ring
+example : ⁅a * -5, a⁆ = 0 := by noncomm_ring
+example : ⁅a^3, a⁆ = 0 := by noncomm_ring
+
+example : a ⚬ a = 2*a^2 := by noncomm_ring
+example : (2 * a) ⚬ a = 4*a^2 := by noncomm_ring
+example : a ⚬ b = b ⚬ a := by noncomm_ring
+example : a ⚬ (b + c) = a ⚬ b + a ⚬ c := by noncomm_ring
+example : (a + b) ⚬ c = a ⚬ c + b ⚬ c := by noncomm_ring
+example : (a ⚬ b) ⚬ (a ⚬ a) = a ⚬ (b ⚬ (a ⚬ a)) := by noncomm_ring
+
+example : ⁅a, b ⚬ c⁆ = ⁅a, b⁆ ⚬ c + b ⚬ ⁅a, c⁆ := by noncomm_ring
+example : ⁅a ⚬ b, c⁆ = a ⚬ ⁅b, c⁆ + ⁅a, c⁆ ⚬ b := by noncomm_ring
+example : (a ⚬ b) ⚬ c - a ⚬ (b ⚬ c) = -⁅⁅a, b⁆, c⁆ + ⁅a, ⁅b, c⁆⁆ := by noncomm_ring
+
+example : a + -b = -b + a := by noncomm_ring
+example : a ^ 50 * a ^ 37 = a ^ 23 * a ^ 64 := by noncomm_ring


### PR DESCRIPTION
This aims to be a faithful implementation of mathlib3's `noncomm_ring` tactic.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
