### PR TITLE
[Merged by Bors] - fix: allow porting Archive files

### DIFF
--- a/scripts/start_port.sh
+++ b/scripts/start_port.sh
@@ -19,7 +19,9 @@ mathlib4_path="$1"
 
 case $mathlib4_path in
     Mathlib/*) true ;;
-    *) echo "argument must begin with Mathlib/"
+    Archive/*) true ;;
+    Counterexamples/*) true ;;
+    *) echo "argument must begin with Mathlib/, Archive/, or Counterexamples/"
        exit 1 ;;
 esac
 
@@ -29,7 +31,7 @@ PORT_STATUS_YAML=https://raw.githubusercontent.com/wiki/leanprover-community/mat
 # process path name
 mathlib4_mod=$(basename $(echo "$mathlib4_path" | tr / .) .lean)
 mathlib4_mod_tail=${mathlib4_mod#Mathlib.}
-mathlib3port_url=$MATHLIB3PORT_BASE_URL/Mathbin/${1#Mathlib/}
+mathlib3port_url=$MATHLIB3PORT_BASE_URL/${1/#Mathlib/Mathbin}
 
 # start the port from the latest master
 git fetch
@@ -72,8 +74,11 @@ echo "Applying automated fixes"
     python3 "$root_path/scripts/fix-line-breaks.py" "$mathlib4_path" "$mathlib4_path.tmp"
     mv "$mathlib4_path.tmp" "$mathlib4_path"
 
-    (echo "import $mathlib4_mod" ; cat Mathlib.lean) | LC_ALL=C sort | uniq > Mathlib.lean.tmp
-    mv -f Mathlib.lean.tmp Mathlib.lean
+    # TODO: note the commit message claims we did this even if we didn't!
+    if [[ "$mathlib4_mod" =~ ^Mathlib. ]]; then
+        (echo "import $mathlib4_mod" ; cat Mathlib.lean) | LC_ALL=C sort | uniq > Mathlib.lean.tmp
+        mv -f Mathlib.lean.tmp Mathlib.lean
+    fi
 )
 
 # Commit them


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
-->
- [x] depends on: #5078

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

Do we want `Archive.lean` and `Counterexamples.lean` to exist? How can we configure CI?

#4812 is a demo of a PR created with the updated version. I tested on a regular mathlib file and everything still seems to work.
