### PR TITLE
[Merged by Bors] - fix: library_search doesn't get tired

### DIFF
--- a/Mathlib/Data/ListM/Heartbeats.lean
+++ b/Mathlib/Data/ListM/Heartbeats.lean
@@ -15,9 +15,9 @@ open Lean.Core (CoreM)
 /-- Take an initial segment of a `MetaM` lazy list,
 trying to leave at least `percent` of the remaining allowed heartbeats. -/
 def ListM.whileAtLeastHeartbeatsPercent [Monad m] [MonadLiftT CoreM m]
-    (L : ListM m α) (percent : Nat) : ListM m α :=
+    (L : ListM m α) (percent : Nat := 10) : ListM m α :=
 ListM.squash do
-  if (← getMaxHeartbeats) = 0 then
+  if (← getMaxHeartbeats) = 0 then do
     return L
   let initialHeartbeats ← getRemainingHeartbeats
   pure <| L.takeWhileM fun _ => do

--- a/Mathlib/Lean/CoreM.lean
+++ b/Mathlib/Lean/CoreM.lean
@@ -12,19 +12,24 @@ import Lean.CoreM
 open Lean
 
 /-- Return the current `maxHeartbeats`. -/
-def getMaxHeartbeats : CoreM Nat := do pure (← read).maxHeartbeats
+def getMaxHeartbeats : CoreM Nat := do pure <| (← read).maxHeartbeats
+
+/-- Return the current `initHeartbeats`. -/
+def getInitHeartbeats : CoreM Nat := do pure <| (← read).initHeartbeats
 
 /-- Return the remaining heartbeats available in this computation. -/
-def getRemainingHeartbeats : CoreM Nat := do pure <| (← getMaxHeartbeats) - (← IO.getNumHeartbeats)
+def getRemainingHeartbeats : CoreM Nat := do
+  pure <| (← getMaxHeartbeats) - ((← IO.getNumHeartbeats) - (← getInitHeartbeats))
 
 /--
 Return the percentage of the max heartbeats allowed
 that have been consumed so far in this computation.
 -/
-def heartbeatsPercent : CoreM Nat := do pure <| (← IO.getNumHeartbeats) * 100 / (← getMaxHeartbeats)
+def heartbeatsPercent : CoreM Nat := do
+  pure <| ((← IO.getNumHeartbeats) - (← getInitHeartbeats)) * 100 / (← getMaxHeartbeats)
 
 /-- Log a message if it looks like we ran out of time. -/
-def reportOutOfHeartbeats (tac : Name) (stx : Syntax) : CoreM Unit := do
-  if (← heartbeatsPercent) ≥ 90 then
+def reportOutOfHeartbeats (tac : Name) (stx : Syntax) (threshold : Nat := 90) : CoreM Unit := do
+  if (← heartbeatsPercent) ≥ 90 threshold
     logInfoAt stx (s!"`{tac}` stopped because it was running out of time.\n" ++
       "You may get better results using `set_option maxHeartbeats 0`.")

--- a/Mathlib/Lean/CoreM.lean
+++ b/Mathlib/Lean/CoreM.lean
@@ -30,6 +30,6 @@ def heartbeatsPercent : CoreM Nat := do
 
 /-- Log a message if it looks like we ran out of time. -/
 def reportOutOfHeartbeats (tac : Name) (stx : Syntax) (threshold : Nat := 90) : CoreM Unit := do
-  if (← heartbeatsPercent) ≥ 90 threshold
+  if (← heartbeatsPercent) ≥ threshold then
     logInfoAt stx (s!"`{tac}` stopped because it was running out of time.\n" ++
       "You may get better results using `set_option maxHeartbeats 0`.")

--- a/Mathlib/Tactic/LibrarySearch.lean
+++ b/Mathlib/Tactic/LibrarySearch.lean
@@ -210,7 +210,8 @@ unless the goal was completely solved.)
 this is not currently tracked.)
 -/
 def librarySearch (goal : MVarId) (required : List Expr)
-    (solveByElimDepth := 6) : MetaM (Option (Array (MetavarContext × List MVarId))) := do
+    (solveByElimDepth := 6) (leavePercentHeartbeats : Nat := 10) :
+    MetaM (Option (Array (MetavarContext × List MVarId))) := do
   let librarySearchEmoji := fun
     | .error _ => bombEmoji
     | .ok (some _) => crossEmoji
@@ -223,7 +224,7 @@ def librarySearch (goal : MVarId) (required : List Expr)
   (do
     let results ← librarySearchCore goal required solveByElimDepth
       -- Don't use too many heartbeats.
-      |>.whileAtLeastHeartbeatsPercent 10
+      |>.whileAtLeastHeartbeatsPercent leavePercentHeartbeats
       -- Stop if we find something that closes the goal
       |>.takeUpToFirst (·.2.isEmpty)
       |>.asArray


### PR DESCRIPTION
I had badly misunderstood how to keep track of remaining heartbeats in a given computation, and library_search was using a thread-local heartbeat count, rather than a declaration-local heartbeat count, so would "get tired" after working in the same file for a while.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
