### PR TITLE
[Merged by Bors] - feat: prove concavity of `x ↦ x^p` for `p ∈ (0,1)`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -544,6 +544,7 @@ import Mathlib.Analysis.Convex.SimplicialComplex.Basic
 import Mathlib.Analysis.Convex.Slope
 import Mathlib.Analysis.Convex.SpecificFunctions.Basic
 import Mathlib.Analysis.Convex.SpecificFunctions.Deriv
+import Mathlib.Analysis.Convex.SpecificFunctions.Pow
 import Mathlib.Analysis.Convex.Star
 import Mathlib.Analysis.Convex.StoneSeparation
 import Mathlib.Analysis.Convex.Strict

--- a/Mathlib/Analysis/Convex/Function.lean
+++ b/Mathlib/Analysis/Convex/Function.lean
@@ -1085,6 +1085,51 @@ end OrderedAddCommMonoid
 
 end LinearOrderedField
 
+section OrderIso
+
+variable [OrderedSemiring 𝕜] [OrderedAddCommMonoid α] [SMul 𝕜 α]
+  [OrderedAddCommMonoid β] [SMul 𝕜 β]
+
+theorem strictConvexOn_orderIso_symm (f : α ≃o β) (hf : StrictConcaveOn 𝕜 univ f) :
+    StrictConvexOn 𝕜 univ f.symm := by
+  refine ⟨convex_univ, fun x _ y _ hxy a b ha hb hab => ?_⟩
+  obtain ⟨x', hx''⟩ := f.surjective.exists.mp ⟨x, rfl⟩
+  obtain ⟨y', hy''⟩ := f.surjective.exists.mp ⟨y, rfl⟩
+  have hxy' : x' ≠ y' := by rw [←f.injective.ne_iff, ←hx'', ←hy'']; exact hxy
+  simp only [hx'', hy'', OrderIso.symm_apply_apply, gt_iff_lt]
+  rw [←f.lt_iff_lt, OrderIso.apply_symm_apply]
+  exact hf.2 (by simp : x' ∈ Set.univ) (by simp : y' ∈ Set.univ) hxy' ha hb hab
+
+theorem convexOn_orderIso_symm (f : α ≃o β) (hf : ConcaveOn 𝕜 univ f) :
+    ConvexOn 𝕜 univ f.symm := by
+  refine ⟨convex_univ, fun x _ y _ a b ha hb hab => ?_⟩
+  obtain ⟨x', hx''⟩ := f.surjective.exists.mp ⟨x, rfl⟩
+  obtain ⟨y', hy''⟩ := f.surjective.exists.mp ⟨y, rfl⟩
+  simp only [hx'', hy'', OrderIso.symm_apply_apply, gt_iff_lt]
+  rw [←f.le_iff_le, OrderIso.apply_symm_apply]
+  exact hf.2 (by simp : x' ∈ Set.univ) (by simp : y' ∈ Set.univ) ha hb hab
+
+theorem strictConcaveOn_orderIso_symm (f : α ≃o β) (hf : StrictConvexOn 𝕜 univ f) :
+    StrictConcaveOn 𝕜 univ f.symm := by
+  refine ⟨convex_univ, fun x _ y _ hxy a b ha hb hab => ?_⟩
+  obtain ⟨x', hx''⟩ := f.surjective.exists.mp ⟨x, rfl⟩
+  obtain ⟨y', hy''⟩ := f.surjective.exists.mp ⟨y, rfl⟩
+  have hxy' : x' ≠ y' := by rw [←f.injective.ne_iff, ←hx'', ←hy'']; exact hxy
+  simp only [hx'', hy'', OrderIso.symm_apply_apply, gt_iff_lt]
+  rw [←f.lt_iff_lt, OrderIso.apply_symm_apply]
+  exact hf.2 (by simp : x' ∈ Set.univ) (by simp : y' ∈ Set.univ) hxy' ha hb hab
+
+theorem concaveOn_orderIso_symm (f : α ≃o β) (hf : ConvexOn 𝕜 univ f) :
+    ConcaveOn 𝕜 univ f.symm := by
+  refine ⟨convex_univ, fun x _ y _ a b ha hb hab => ?_⟩
+  obtain ⟨x', hx''⟩ := f.surjective.exists.mp ⟨x, rfl⟩
+  obtain ⟨y', hy''⟩ := f.surjective.exists.mp ⟨y, rfl⟩
+  simp only [hx'', hy'', OrderIso.symm_apply_apply, gt_iff_lt]
+  rw [←f.le_iff_le, OrderIso.apply_symm_apply]
+  exact hf.2 (by simp : x' ∈ Set.univ) (by simp : y' ∈ Set.univ) ha hb hab
+
+end OrderIso
+
 section
 
 variable [LinearOrderedField 𝕜] [LinearOrderedCancelAddCommMonoid β] [Module 𝕜 β] [OrderedSMul 𝕜 β]

--- a/Mathlib/Analysis/Convex/Function.lean
+++ b/Mathlib/Analysis/Convex/Function.lean
@@ -31,7 +31,7 @@ a convex set.
 -/
 
 
-open Finset LinearMap Set BigOperators Classical Convex Pointwise
+open LinearMap Set BigOperators Classical Convex Pointwise
 
 variable {𝕜 E F α β ι : Type _}
 
@@ -1090,7 +1090,7 @@ section OrderIso
 variable [OrderedSemiring 𝕜] [OrderedAddCommMonoid α] [SMul 𝕜 α]
   [OrderedAddCommMonoid β] [SMul 𝕜 β]
 
-theorem strictConvexOn_orderIso_symm (f : α ≃o β) (hf : StrictConcaveOn 𝕜 univ f) :
+theorem OrderIso.strictConvexOn_symm (f : α ≃o β) (hf : StrictConcaveOn 𝕜 univ f) :
     StrictConvexOn 𝕜 univ f.symm := by
   refine ⟨convex_univ, fun x _ y _ hxy a b ha hb hab => ?_⟩
   obtain ⟨x', hx''⟩ := f.surjective.exists.mp ⟨x, rfl⟩
@@ -1098,18 +1098,18 @@ theorem strictConvexOn_orderIso_symm (f : α ≃o β) (hf : StrictConcaveOn 𝕜
   have hxy' : x' ≠ y' := by rw [←f.injective.ne_iff, ←hx'', ←hy'']; exact hxy
   simp only [hx'', hy'', OrderIso.symm_apply_apply, gt_iff_lt]
   rw [←f.lt_iff_lt, OrderIso.apply_symm_apply]
-  exact hf.2 (by simp : x' ∈ Set.univ) (by simp : y' ∈ Set.univ) hxy' ha hb hab
+  exact hf.2 (by simp : x' ∈ univ) (by simp : y' ∈ _root_.Set.univ) hxy' ha hb hab
 
-theorem convexOn_orderIso_symm (f : α ≃o β) (hf : ConcaveOn 𝕜 univ f) :
+theorem OrderIso.convexOn_symm (f : α ≃o β) (hf : ConcaveOn 𝕜 univ f) :
     ConvexOn 𝕜 univ f.symm := by
   refine ⟨convex_univ, fun x _ y _ a b ha hb hab => ?_⟩
   obtain ⟨x', hx''⟩ := f.surjective.exists.mp ⟨x, rfl⟩
   obtain ⟨y', hy''⟩ := f.surjective.exists.mp ⟨y, rfl⟩
   simp only [hx'', hy'', OrderIso.symm_apply_apply, gt_iff_lt]
   rw [←f.le_iff_le, OrderIso.apply_symm_apply]
-  exact hf.2 (by simp : x' ∈ Set.univ) (by simp : y' ∈ Set.univ) ha hb hab
+  exact hf.2 (by simp : x' ∈ univ) (by simp : y' ∈ univ) ha hb hab
 
-theorem strictConcaveOn_orderIso_symm (f : α ≃o β) (hf : StrictConvexOn 𝕜 univ f) :
+theorem OrderIso.strictConcaveOn_symm (f : α ≃o β) (hf : StrictConvexOn 𝕜 univ f) :
     StrictConcaveOn 𝕜 univ f.symm := by
   refine ⟨convex_univ, fun x _ y _ hxy a b ha hb hab => ?_⟩
   obtain ⟨x', hx''⟩ := f.surjective.exists.mp ⟨x, rfl⟩
@@ -1117,16 +1117,16 @@ theorem strictConcaveOn_orderIso_symm (f : α ≃o β) (hf : StrictConvexOn 𝕜
   have hxy' : x' ≠ y' := by rw [←f.injective.ne_iff, ←hx'', ←hy'']; exact hxy
   simp only [hx'', hy'', OrderIso.symm_apply_apply, gt_iff_lt]
   rw [←f.lt_iff_lt, OrderIso.apply_symm_apply]
-  exact hf.2 (by simp : x' ∈ Set.univ) (by simp : y' ∈ Set.univ) hxy' ha hb hab
+  exact hf.2 (by simp : x' ∈ univ) (by simp : y' ∈ univ) hxy' ha hb hab
 
-theorem concaveOn_orderIso_symm (f : α ≃o β) (hf : ConvexOn 𝕜 univ f) :
+theorem OrderIso.concaveOn_symm (f : α ≃o β) (hf : ConvexOn 𝕜 univ f) :
     ConcaveOn 𝕜 univ f.symm := by
   refine ⟨convex_univ, fun x _ y _ a b ha hb hab => ?_⟩
   obtain ⟨x', hx''⟩ := f.surjective.exists.mp ⟨x, rfl⟩
   obtain ⟨y', hy''⟩ := f.surjective.exists.mp ⟨y, rfl⟩
   simp only [hx'', hy'', OrderIso.symm_apply_apply, gt_iff_lt]
   rw [←f.le_iff_le, OrderIso.apply_symm_apply]
-  exact hf.2 (by simp : x' ∈ Set.univ) (by simp : y' ∈ Set.univ) ha hb hab
+  exact hf.2 (by simp : x' ∈ univ) (by simp : y' ∈ univ) ha hb hab
 
 end OrderIso
 

--- a/Mathlib/Analysis/Convex/Function.lean
+++ b/Mathlib/Analysis/Convex/Function.lean
@@ -1098,7 +1098,7 @@ theorem OrderIso.strictConvexOn_symm (f : α ≃o β) (hf : StrictConcaveOn 𝕜
   have hxy' : x' ≠ y' := by rw [←f.injective.ne_iff, ←hx'', ←hy'']; exact hxy
   simp only [hx'', hy'', OrderIso.symm_apply_apply, gt_iff_lt]
   rw [←f.lt_iff_lt, OrderIso.apply_symm_apply]
-  exact hf.2 (by simp : x' ∈ univ) (by simp : y' ∈ _root_.Set.univ) hxy' ha hb hab
+  exact hf.2 (by simp : x' ∈ univ) (by simp : y' ∈ univ) hxy' ha hb hab
 
 theorem OrderIso.convexOn_symm (f : α ≃o β) (hf : ConcaveOn 𝕜 univ f) :
     ConvexOn 𝕜 univ f.symm := by

--- a/Mathlib/Analysis/Convex/SpecificFunctions/Pow.lean
+++ b/Mathlib/Analysis/Convex/SpecificFunctions/Pow.lean
@@ -7,14 +7,34 @@ Authors: Frédéric Dupuis
 import Mathlib.Analysis.Convex.SpecificFunctions.Basic
 import Mathlib.Analysis.SpecialFunctions.Pow.NNReal
 
-local macro_rules | `($x ^ $y)   => `(HPow.hPow $x $y)
+/-!
+# Convexity properties of `rpow`
+
+We prove basic convexity properties of the `rpow` function. The proofs are elementary and do not
+require calculus, and as such this file has only moderate dependencies.
+
+## Main declarations
+
+* `NNReal.strictConcaveOn_rpow`, `Real.strictConcaveOn_rpow`: strict concavity of
+  `fun x ↦ x ^ p` for p ∈ (0,1)
+* `NNReal.concaveOn_rpow`, `Real.concaveOn_rpow`: concavity of `fun x ↦ x ^ p` for p ∈ [0,1]
+
+Note that convexity for `p > 1` can be found in `Analysis.Convex.SpecificFunctions.Basic`, which
+requires slightly less imports.
+
+## TODO
+
+* Prove convexity for negative powers.
+-/
+
+local macro_rules | `($x ^ $y) => `(HPow.hPow $x $y) -- Porting note: See issue #2220
 
 open Set
 
 namespace NNReal
 
 lemma strictConcaveOn_rpow {p : ℝ} (hp₀ : 0 < p) (hp₁ : p < 1) :
-    StrictConcaveOn ℝ≥0 univ fun x : ℝ≥0 => x ^ p := by
+    StrictConcaveOn ℝ≥0 univ fun x : ℝ≥0 ↦ x ^ p := by
   have hp₀' : 0 < 1 / p := by positivity
   have hp₁' : 1 < 1 / p := by rw [one_lt_div hp₀]; exact hp₁
   let f := NNReal.orderIsoRpow (1 / p) hp₀'
@@ -28,7 +48,7 @@ lemma strictConcaveOn_rpow {p : ℝ} (hp₀ : 0 < p) (hp₁ : p < 1) :
   exact (strictConcaveOn_orderIso_symm f h₁).2 (Set.mem_univ x) (Set.mem_univ y) hxy ha hb hab
 
 lemma concaveOn_rpow {p : ℝ} (hp₀ : 0 ≤ p) (hp₁ : p ≤ 1) :
-    ConcaveOn ℝ≥0 univ fun x : ℝ≥0 => x ^ p := by
+    ConcaveOn ℝ≥0 univ fun x : ℝ≥0 ↦ x ^ p := by
   by_cases hp : p = 0
   case pos => exact ⟨convex_univ, fun _ _ _ _ _ _ _ _ hab => by simp [hp, hab]⟩
   case neg =>
@@ -40,7 +60,7 @@ lemma concaveOn_rpow {p : ℝ} (hp₀ : 0 ≤ p) (hp₁ : p ≤ 1) :
       exact (strictConcaveOn_rpow (by positivity) (lt_of_le_of_ne hp₁ hp')).concaveOn
 
 lemma strictConcaveOn_sqrt : StrictConcaveOn ℝ≥0 univ NNReal.sqrt := by
-  have : NNReal.sqrt = fun (x:ℝ≥0) => x ^ (1 / (2:ℝ)) := by
+  have : NNReal.sqrt = fun (x:ℝ≥0) ↦ x ^ (1 / (2:ℝ)) := by
     ext x; exact_mod_cast NNReal.sqrt_eq_rpow x
   rw [this]
   exact strictConcaveOn_rpow (by positivity) (by linarith)
@@ -52,7 +72,7 @@ namespace Real
 open NNReal
 
 lemma strictConcaveOn_rpow {p : ℝ} (hp₀ : 0 < p) (hp₁ : p < 1) :
-    StrictConcaveOn ℝ (Set.Ici 0) fun x : ℝ => x ^ p := by
+    StrictConcaveOn ℝ (Set.Ici 0) fun x : ℝ ↦ x ^ p := by
   refine ⟨convex_Ici _, fun x hx y hy hxy a b ha hb hab => ?_⟩
   let x' : ℝ≥0 := ⟨x, hx⟩
   let y' : ℝ≥0 := ⟨y, hy⟩
@@ -67,7 +87,7 @@ lemma strictConcaveOn_rpow {p : ℝ} (hp₀ : 0 < p) (hp₁ : p < 1) :
     hxy' (by exact_mod_cast ha) (by exact_mod_cast hb) hab'
 
 lemma concaveOn_rpow {p : ℝ} (hp₀ : 0 ≤ p) (hp₁ : p ≤ 1) :
-    ConcaveOn ℝ (Set.Ici 0) fun x : ℝ => x ^ p := by
+    ConcaveOn ℝ (Set.Ici 0) fun x : ℝ ↦ x ^ p := by
   by_cases hp : p = 0
   case pos => exact ⟨convex_Ici 0, fun _ _ _ _ _ _ _ _ hab => by simp [hp, hab]⟩
   case neg =>
@@ -79,7 +99,7 @@ lemma concaveOn_rpow {p : ℝ} (hp₀ : 0 ≤ p) (hp₁ : p ≤ 1) :
       exact (strictConcaveOn_rpow (by positivity) (lt_of_le_of_ne hp₁ hp')).concaveOn
 
 lemma strictConcaveOn_sqrt : StrictConcaveOn ℝ (Set.Ici 0) Real.sqrt := by
-  have : Real.sqrt = fun (x:ℝ) => x ^ (1 / (2:ℝ)) := by
+  have : Real.sqrt = fun (x:ℝ) ↦ x ^ (1 / (2:ℝ)) := by
     ext x; exact Real.sqrt_eq_rpow x
   rw [this]
   exact strictConcaveOn_rpow (by positivity) (by linarith)

--- a/Mathlib/Analysis/Convex/SpecificFunctions/Pow.lean
+++ b/Mathlib/Analysis/Convex/SpecificFunctions/Pow.lean
@@ -1,0 +1,87 @@
+/-
+Copyright (c) 2023 Frédéric Dupuis. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Frédéric Dupuis
+-/
+
+import Mathlib.Analysis.Convex.SpecificFunctions.Basic
+import Mathlib.Analysis.SpecialFunctions.Pow.NNReal
+
+local macro_rules | `($x ^ $y)   => `(HPow.hPow $x $y)
+
+open Set
+
+namespace NNReal
+
+lemma strictConcaveOn_rpow {p : ℝ} (hp₀ : 0 < p) (hp₁ : p < 1) :
+    StrictConcaveOn ℝ≥0 univ fun x : ℝ≥0 => x ^ p := by
+  have hp₀' : 0 < 1 / p := by positivity
+  have hp₁' : 1 < 1 / p := by rw [one_lt_div hp₀]; exact hp₁
+  let f := NNReal.orderIsoRpow (1 / p) hp₀'
+  have h₁ : StrictConvexOn ℝ≥0 univ f := by
+    refine ⟨convex_univ, fun x _ y _ hxy a b ha hb hab => ?_⟩
+    exact (strictConvexOn_rpow hp₁').2 (by positivity : 0 ≤ x) (by positivity : 0 ≤ y)
+      (by simp [hxy]) ha hb (by simp; norm_cast)
+  have h₂ : ∀ x, f.symm x = x ^ p := by simp [NNReal.orderIsoRpow_symm_eq]
+  refine ⟨convex_univ, fun x _ y _ hxy a b ha hb hab => ?_⟩
+  simp only [←h₂]
+  exact (strictConcaveOn_orderIso_symm f h₁).2 (Set.mem_univ x) (Set.mem_univ y) hxy ha hb hab
+
+lemma concaveOn_rpow {p : ℝ} (hp₀ : 0 ≤ p) (hp₁ : p ≤ 1) :
+    ConcaveOn ℝ≥0 univ fun x : ℝ≥0 => x ^ p := by
+  by_cases hp : p = 0
+  case pos => exact ⟨convex_univ, fun _ _ _ _ _ _ _ _ hab => by simp [hp, hab]⟩
+  case neg =>
+    push_neg at hp
+    by_cases hp' : p = 1
+    case pos => exact ⟨convex_univ, by simp [hp']⟩
+    case neg =>
+      push_neg at hp'
+      exact (strictConcaveOn_rpow (by positivity) (lt_of_le_of_ne hp₁ hp')).concaveOn
+
+lemma strictConcaveOn_sqrt : StrictConcaveOn ℝ≥0 univ NNReal.sqrt := by
+  have : NNReal.sqrt = fun (x:ℝ≥0) => x ^ (1 / (2:ℝ)) := by
+    ext x; exact_mod_cast NNReal.sqrt_eq_rpow x
+  rw [this]
+  exact strictConcaveOn_rpow (by positivity) (by linarith)
+
+end NNReal
+
+namespace Real
+
+open NNReal
+
+lemma strictConcaveOn_rpow {p : ℝ} (hp₀ : 0 < p) (hp₁ : p < 1) :
+    StrictConcaveOn ℝ (Set.Ici 0) fun x : ℝ => x ^ p := by
+  refine ⟨convex_Ici _, fun x hx y hy hxy a b ha hb hab => ?_⟩
+  let x' : ℝ≥0 := ⟨x, hx⟩
+  let y' : ℝ≥0 := ⟨y, hy⟩
+  let a' : ℝ≥0 := ⟨a, by positivity⟩
+  let b' : ℝ≥0 := ⟨b, by positivity⟩
+  have hx' : (fun z => z ^ p) x = (fun z => z ^ p) x' := rfl
+  have hy' : (fun z => z ^ p) y = (fun z => z ^ p) y' := rfl
+  have hxy' : x' ≠ y' := Subtype.ne_of_val_ne hxy
+  have hab' : a' + b' = 1 := by ext; simp [hab]
+  rw [hx', hy']
+  exact (NNReal.strictConcaveOn_rpow hp₀ hp₁).2 (Set.mem_univ x') (Set.mem_univ y')
+    hxy' (by exact_mod_cast ha) (by exact_mod_cast hb) hab'
+
+lemma concaveOn_rpow {p : ℝ} (hp₀ : 0 ≤ p) (hp₁ : p ≤ 1) :
+    ConcaveOn ℝ (Set.Ici 0) fun x : ℝ => x ^ p := by
+  by_cases hp : p = 0
+  case pos => exact ⟨convex_Ici 0, fun _ _ _ _ _ _ _ _ hab => by simp [hp, hab]⟩
+  case neg =>
+    push_neg at hp
+    by_cases hp' : p = 1
+    case pos => exact ⟨convex_Ici 0, by simp [hp']⟩
+    case neg =>
+      push_neg at hp'
+      exact (strictConcaveOn_rpow (by positivity) (lt_of_le_of_ne hp₁ hp')).concaveOn
+
+lemma strictConcaveOn_sqrt : StrictConcaveOn ℝ (Set.Ici 0) Real.sqrt := by
+  have : Real.sqrt = fun (x:ℝ) => x ^ (1 / (2:ℝ)) := by
+    ext x; exact Real.sqrt_eq_rpow x
+  rw [this]
+  exact strictConcaveOn_rpow (by positivity) (by linarith)
+
+end Real

--- a/Mathlib/Analysis/Convex/SpecificFunctions/Pow.lean
+++ b/Mathlib/Analysis/Convex/SpecificFunctions/Pow.lean
@@ -27,7 +27,7 @@ requires slightly less imports.
 * Prove convexity for negative powers.
 -/
 
-local macro_rules | `($x ^ $y) => `(HPow.hPow $x $y) -- Porting note: See issue #2220
+local macro_rules | `($x ^ $y) => `(HPow.hPow $x $y) -- Porting note: See issue lean4#2220
 
 open Set
 

--- a/Mathlib/Analysis/Convex/SpecificFunctions/Pow.lean
+++ b/Mathlib/Analysis/Convex/SpecificFunctions/Pow.lean
@@ -45,7 +45,7 @@ lemma strictConcaveOn_rpow {p : ℝ} (hp₀ : 0 < p) (hp₁ : p < 1) :
   have h₂ : ∀ x, f.symm x = x ^ p := by simp [NNReal.orderIsoRpow_symm_eq]
   refine ⟨convex_univ, fun x _ y _ hxy a b ha hb hab => ?_⟩
   simp only [←h₂]
-  exact (strictConcaveOn_orderIso_symm f h₁).2 (Set.mem_univ x) (Set.mem_univ y) hxy ha hb hab
+  exact (f.strictConcaveOn_symm h₁).2 (Set.mem_univ x) (Set.mem_univ y) hxy ha hb hab
 
 lemma concaveOn_rpow {p : ℝ} (hp₀ : 0 ≤ p) (hp₁ : p ≤ 1) :
     ConcaveOn ℝ≥0 univ fun x : ℝ≥0 ↦ x ^ p := by

--- a/Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean
@@ -279,6 +279,26 @@ theorem _root_.Real.toNNReal_rpow_of_nonneg {x y : ℝ} (hx : 0 ≤ x) :
   rw [← NNReal.coe_rpow, Real.toNNReal_coe]
 #align real.to_nnreal_rpow_of_nonneg Real.toNNReal_rpow_of_nonneg
 
+theorem strictMono_rpow_of_pos {z : ℝ} (h : 0 < z) : StrictMono fun x : ℝ≥0 => x ^ z :=
+  fun x y hxy => by simp only [NNReal.rpow_lt_rpow hxy h, coe_lt_coe]
+
+theorem monotone_rpow_of_nonneg {z : ℝ} (h : 0 ≤ z) : Monotone fun x : ℝ≥0 => x ^ z :=
+  h.eq_or_lt.elim (fun h0 => h0 ▸ by simp only [rpow_zero, monotone_const]) fun h0 =>
+    (strictMono_rpow_of_pos h0).monotone
+
+/-- Bundles `fun x : ℝ≥0 => x ^ y` into an order isomorphism when `y : ℝ` is positive,
+where the inverse is `fun x : ℝ≥0 => x ^ (1 / y)`. -/
+@[simps! apply]
+def orderIsoRpow (y : ℝ) (hy : 0 < y) : ℝ≥0 ≃o ℝ≥0 :=
+  (strictMono_rpow_of_pos hy).orderIsoOfRightInverse (fun x => x ^ y) (fun x => x ^ (1 / y))
+    fun x => by
+    dsimp
+    rw [← rpow_mul, one_div_mul_cancel hy.ne.symm, rpow_one]
+
+theorem orderIsoRpow_symm_eq (y : ℝ) (hy : 0 < y) :
+    (orderIsoRpow y hy).symm = orderIsoRpow (1 / y) (one_div_pos.2 hy) := by
+  simp only [orderIsoRpow, one_div_one_div]; rfl
+
 end NNReal
 
 namespace ENNReal

--- a/Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean
@@ -292,8 +292,8 @@ where the inverse is `fun x : ℝ≥0 => x ^ (1 / y)`. -/
 def orderIsoRpow (y : ℝ) (hy : 0 < y) : ℝ≥0 ≃o ℝ≥0 :=
   (strictMono_rpow_of_pos hy).orderIsoOfRightInverse (fun x => x ^ y) (fun x => x ^ (1 / y))
     fun x => by
-    dsimp
-    rw [← rpow_mul, one_div_mul_cancel hy.ne.symm, rpow_one]
+      dsimp
+      rw [← rpow_mul, one_div_mul_cancel hy.ne.symm, rpow_one]
 
 theorem orderIsoRpow_symm_eq (y : ℝ) (hy : 0 < y) :
     (orderIsoRpow y hy).symm = orderIsoRpow (1 / y) (one_div_pos.2 hy) := by


### PR DESCRIPTION
This PR prove the (strict) concavity of `x ↦ x^p` for `p` between 0 and 1.

The main results are in a new file to avoid adding dependencies to `Analysis.Convex.SpecificFunctions.Basic` which is carefully designed to be low in the import hierarchy.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
