### PR TITLE
[Merged by Bors] - chore: fix `addCentralizer` naming

### DIFF
--- a/Mathlib/GroupTheory/Subsemigroup/Centralizer.lean
+++ b/Mathlib/GroupTheory/Subsemigroup/Centralizer.lean
@@ -41,13 +41,11 @@ def centralizer [Mul M] : Set M :=
 
 variable {S}
 
--- TODO: this additive naming in this section does not conform to the
--- naming convention. This will be fixed soon.
-@[to_additive mem_add_centralizer]
+@[to_additive mem_addCentralizer]
 theorem mem_centralizer_iff [Mul M] {c : M} : c ∈ centralizer S ↔ ∀ m ∈ S, m * c = c * m :=
   Iff.rfl
 #align set.mem_centralizer_iff Set.mem_centralizer_iff
-#align set.mem_add_centralizer Set.mem_add_centralizer
+#align set.mem_add_centralizer Set.mem_addCentralizer
 
 @[to_additive decidableMemAddCentralizer]
 instance decidableMemCentralizer [Mul M] [∀ a : M, Decidable <| ∀ b ∈ S, b * a = a * b] :
@@ -57,11 +55,11 @@ instance decidableMemCentralizer [Mul M] [∀ a : M, Decidable <| ∀ b ∈ S, b
 
 variable (S)
 
-@[to_additive (attr := simp) zero_mem_add_centralizer]
+@[to_additive (attr := simp) zero_mem_addCentralizer]
 theorem one_mem_centralizer [MulOneClass M] : (1 : M) ∈ centralizer S := by
   simp [mem_centralizer_iff]
 #align set.one_mem_centralizer Set.one_mem_centralizer
-#align set.zero_mem_add_centralizer Set.zero_mem_add_centralizer
+#align set.zero_mem_add_centralizer Set.zero_mem_addCentralizer
 
 @[simp]
 theorem zero_mem_centralizer [MulZeroClass M] : (0 : M) ∈ centralizer S := by
@@ -70,18 +68,18 @@ theorem zero_mem_centralizer [MulZeroClass M] : (0 : M) ∈ centralizer S := by
 
 variable {S} {a b : M}
 
-@[to_additive (attr := simp) add_mem_add_centralizer]
+@[to_additive (attr := simp) add_mem_addCentralizer]
 theorem mul_mem_centralizer [Semigroup M] (ha : a ∈ centralizer S) (hb : b ∈ centralizer S) :
     a * b ∈ centralizer S := fun g hg => by
   rw [mul_assoc, ← hb g hg, ← mul_assoc, ha g hg, mul_assoc]
 #align set.mul_mem_centralizer Set.mul_mem_centralizer
-#align set.add_mem_add_centralizer Set.add_mem_add_centralizer
+#align set.add_mem_add_centralizer Set.add_mem_addCentralizer
 
-@[to_additive (attr := simp) neg_mem_add_centralizer]
+@[to_additive (attr := simp) neg_mem_addCentralizer]
 theorem inv_mem_centralizer [Group M] (ha : a ∈ centralizer S) : a⁻¹ ∈ centralizer S := fun g hg =>
   by rw [mul_inv_eq_iff_eq_mul, mul_assoc, eq_inv_mul_iff_mul_eq, ha g hg]
 #align set.inv_mem_centralizer Set.inv_mem_centralizer
-#align set.neg_mem_add_centralizer Set.neg_mem_add_centralizer
+#align set.neg_mem_add_centralizer Set.neg_mem_addCentralizer
 
 @[simp]
 theorem add_mem_centralizer [Distrib M] (ha : a ∈ centralizer S) (hb : b ∈ centralizer S) :
@@ -103,13 +101,13 @@ theorem inv_mem_centralizer₀ [GroupWithZero M] (ha : a ∈ centralizer S) : a�
     rw [mul_inv_eq_iff_eq_mul₀ ha0, mul_assoc, eq_inv_mul_iff_mul_eq₀ ha0, ha c hc]
 #align set.inv_mem_centralizer₀ Set.inv_mem_centralizer₀
 
-@[to_additive (attr := simp) sub_mem_add_centralizer]
+@[to_additive (attr := simp) sub_mem_addCentralizer]
 theorem div_mem_centralizer [Group M] (ha : a ∈ centralizer S) (hb : b ∈ centralizer S) :
     a / b ∈ centralizer S := by
   rw [div_eq_mul_inv]
   exact mul_mem_centralizer ha (inv_mem_centralizer hb)
 #align set.div_mem_centralizer Set.div_mem_centralizer
-#align set.sub_mem_add_centralizer Set.sub_mem_add_centralizer
+#align set.sub_mem_add_centralizer Set.sub_mem_addCentralizer
 
 @[simp]
 theorem div_mem_centralizer₀ [GroupWithZero M] (ha : a ∈ centralizer S) (hb : b ∈ centralizer S) :
@@ -118,11 +116,11 @@ theorem div_mem_centralizer₀ [GroupWithZero M] (ha : a ∈ centralizer S) (hb 
   exact mul_mem_centralizer ha (inv_mem_centralizer₀ hb)
 #align set.div_mem_centralizer₀ Set.div_mem_centralizer₀
 
-@[to_additive add_centralizer_subset]
+@[to_additive addCentralizer_subset]
 theorem centralizer_subset [Mul M] (h : S ⊆ T) : centralizer T ⊆ centralizer S := fun _ ht s hs =>
   ht s (h hs)
 #align set.centralizer_subset Set.centralizer_subset
-#align set.add_centralizer_subset Set.add_centralizer_subset
+#align set.add_centralizer_subset Set.addCentralizer_subset
 
 @[to_additive addCenter_subset_addCentralizer]
 theorem center_subset_centralizer [Mul M] (S : Set M) : Set.center M ⊆ S.centralizer :=
@@ -139,19 +137,19 @@ theorem centralizer_eq_top_iff_subset {s : Set M} [Mul M] :
 
 variable (M)
 
-@[to_additive (attr := simp) add_centralizer_univ]
+@[to_additive (attr := simp) addCentralizer_univ]
 theorem centralizer_univ [Mul M] : centralizer univ = center M :=
   Subset.antisymm (fun _ ha b => ha b (Set.mem_univ b)) fun _ ha b _ => ha b
 #align set.centralizer_univ Set.centralizer_univ
-#align set.add_centralizer_univ Set.add_centralizer_univ
+#align set.add_centralizer_univ Set.addCentralizer_univ
 
 variable {M} (S)
 
-@[to_additive (attr := simp) add_centralizer_eq_univ]
+@[to_additive (attr := simp) addCentralizer_eq_univ]
 theorem centralizer_eq_univ [CommSemigroup M] : centralizer S = univ :=
   (Subset.antisymm (subset_univ _)) fun x _ y _ => mul_comm y x
 #align set.centralizer_eq_univ Set.centralizer_eq_univ
-#align set.add_centralizer_eq_univ Set.add_centralizer_eq_univ
+#align set.add_centralizer_eq_univ Set.addCentralizer_eq_univ
 
 end Set
 


### PR DESCRIPTION
This did not obey the naming convention; this is now fixed.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
