### PR TITLE
[Merged by Bors] - fix: correct for surprising precedence in Bool DeMorgan laws

### DIFF
--- a/Mathlib/Data/Bool/Basic.lean
+++ b/Mathlib/Data/Bool/Basic.lean
@@ -304,11 +304,11 @@ theorem xor_iff_ne : ∀ {x y : Bool}, xor x y = true ↔ x ≠ y := by decide
 /-! ### De Morgan's laws for booleans-/
 
 @[simp]
-theorem not_and : ∀ a b : Bool, !(a && b) = (!a || !b) := by decide
+theorem not_and : ∀ a b : Bool, (!(a && b)) = (!a || !b) := by decide
 #align bool.bnot_band Bool.not_and
 
 @[simp]
-theorem not_or : ∀ a b : Bool, !(a || b) = (!a && !b) := by decide
+theorem not_or : ∀ a b : Bool, (!(a || b)) = (!a && !b) := by decide
 #align bool.bnot_bor Bool.not_or
 
 theorem not_inj : ∀ {a b : Bool}, !a = !b → a = b := by decide


### PR DESCRIPTION
The DeMorgan laws as stated were being parsed as an inequality
```lean
! ((a && b) = (!a || !b))
```
So, I added parenthesis to force the intended meaning of 
```lean
(!(a && b)) = (!a || !b)
```

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->


[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
