### PR TITLE
[Merged by Bors] - chore: forward-port leanprover-community/mathlib#19182

### DIFF
--- a/Mathlib/FieldTheory/SplittingField/IsSplittingField.lean
+++ b/Mathlib/FieldTheory/SplittingField/IsSplittingField.lean
@@ -159,7 +159,7 @@ variable {K L} [Field K] [Field L] [Algebra K L] {p : K[X]}
 
 theorem splits_of_splits {F : IntermediateField K L} (h : p.Splits (algebraMap K L))
     (hF : ∀ x ∈ p.rootSet L, x ∈ F) : p.Splits (algebraMap K F) := by
-  simp_rw [rootSet, Finset.mem_coe, Multiset.mem_toFinset] at hF
+  simp_rw [rootSet_def, Finset.mem_coe, Multiset.mem_toFinset] at hF
   rw [splits_iff_exists_multiset]
   refine' ⟨Multiset.pmap Subtype.mk _ hF, map_injective _ (algebraMap F L).injective _⟩
   conv_lhs =>

--- a/Mathlib/LinearAlgebra/Eigenspace/Minpoly.lean
+++ b/Mathlib/LinearAlgebra/Eigenspace/Minpoly.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Alexander Bentkamp
 
 ! This file was ported from Lean 3 source module linear_algebra.eigenspace.minpoly
-! leanprover-community/mathlib commit 6b0169218d01f2837d79ea2784882009a0da1aa1
+! leanprover-community/mathlib commit 8efcf8022aac8e01df8d302dcebdbc25d6a886c8
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/


### PR DESCRIPTION
The important thing to forward-port here is the addition of `[DecidableEq _]` to a handful of lemmas.

`linear_algebra.eigenspace.minpoly` did not need anything forward-porting, as the proof which broke in mathlib3 did not break in mathlib4.

The `nthRootsFinset_def` lemma was forgotten in the mathlib3 PR.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
