### PR TITLE
[Merged by Bors] - chore: partially forward-port #18760

### DIFF
--- a/Mathlib/Data/Fintype/Basic.lean
+++ b/Mathlib/Data/Fintype/Basic.lean
@@ -778,6 +778,7 @@ theorem toFinset_range [DecidableEq α] [Fintype β] (f : β → α) [Fintype (S
   simp
 #align set.to_finset_range Set.toFinset_range
 
+@[simp] -- porting note: new attribute
 theorem toFinset_singleton (a : α) [Fintype ({a} : Set α)] : ({a} : Set α).toFinset = {a} := by
   ext
   simp

--- a/Mathlib/Data/Set/Finite.lean
+++ b/Mathlib/Data/Set/Finite.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro, Kyle Miller
 
 ! This file was ported from Lean 3 source module data.set.finite
-! leanprover-community/mathlib commit 5bb9fffd23f9f65b367f5d451da18cc60bf47335
+! leanprover-community/mathlib commit 7fdd4f3746cb059edfdb5d52cba98f66fce418c0
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -111,6 +111,19 @@ protected noncomputable def Finite.fintype {s : Set α} (h : s.Finite) : Fintype
 protected noncomputable def Finite.toFinset {s : Set α} (h : s.Finite) : Finset α :=
   @Set.toFinset _ _ h.fintype
 #align set.finite.to_finset Set.Finite.toFinset
+
+theorem Finite.toFinset_eq_toFinset {s : Set α} [Fintype s] (h : s.Finite) :
+    h.toFinset = s.toFinset := by
+  -- porting note: was `rw [Finite.toFinset]; congr`
+  -- in Lean 4, a goal is left after `congr`
+  have : h.fintype = ‹_› := Subsingleton.elim _ _
+  rw [Finite.toFinset, this]
+#align set.finite.to_finset_eq_to_finset Set.Finite.toFinset_eq_toFinset
+
+@[simp]
+theorem toFinite_toFinset (s : Set α) [Fintype s] : s.toFinite.toFinset = s.toFinset :=
+  s.toFinite.toFinset_eq_toFinset
+#align set.to_finite_to_finset Set.toFinite_toFinset
 
 theorem Finite.exists_finset {s : Set α} (h : s.Finite) :
     ∃ s' : Finset α, ∀ a : α, a ∈ s' ↔ a ∈ s := by

--- a/Mathlib/Data/Set/Finite.lean
+++ b/Mathlib/Data/Set/Finite.lean
@@ -240,6 +240,8 @@ alias Finite.toFinset_ssubset_toFinset ↔ _ toFinset_strictMono
 protected theorem toFinset_setOf [Fintype α] (p : α → Prop) [DecidablePred p]
     (h : { x | p x }.Finite) : h.toFinset = Finset.univ.filter p := by
   ext
+  -- porting note: next line wasn't needed in Lean 3
+  letI := h.fintype
   simp
 #align set.finite.to_finset_set_of Set.Finite.toFinset_setOf
 

--- a/Mathlib/Data/Set/Finite.lean
+++ b/Mathlib/Data/Set/Finite.lean
@@ -241,7 +241,8 @@ alias Finite.toFinset_ssubset_toFinset ↔ _ toFinset_strictMono
 @[simp high]
 protected theorem toFinset_setOf [Fintype α] (p : α → Prop) [DecidablePred p]
     (h : { x | p x }.Finite) : h.toFinset = Finset.univ.filter p := by
-  simp only [toFinite_toFinset, Set.toFinset_setOf]
+  -- porting note: `simp` doesn't use the `simp` lemma `Set.toFinset_setOf` without the `_`
+  ext; simp [Set.toFinset_setOf _]
 #align set.finite.to_finset_set_of Set.Finite.toFinset_setOf
 
 @[simp]

--- a/Mathlib/Data/Set/Finite.lean
+++ b/Mathlib/Data/Set/Finite.lean
@@ -236,13 +236,12 @@ alias Finite.toFinset_ssubset_toFinset ↔ _ toFinset_strictMono
 -- Porting note: attribute [protected] doesn't work
 -- attribute [protected] toFinset_mono toFinset_strictMono
 
-@[simp]
+-- porting note: `simp` can simplify LHS but then it simplifies something
+-- in the generated `Fintype {x | p x}` instance and fails to apply `Set.toFinset_setOf`
+@[simp high]
 protected theorem toFinset_setOf [Fintype α] (p : α → Prop) [DecidablePred p]
     (h : { x | p x }.Finite) : h.toFinset = Finset.univ.filter p := by
-  ext
-  -- porting note: next line wasn't needed in Lean 3
-  letI := h.fintype
-  simp
+  simp only [toFinite_toFinset, Set.toFinset_setOf]
 #align set.finite.to_finset_set_of Set.Finite.toFinset_setOf
 
 @[simp]
@@ -281,10 +280,9 @@ protected theorem toFinset_compl [DecidableEq α] [Fintype α] (hs : s.Finite) (
   simp
 #align set.finite.to_finset_compl Set.Finite.toFinset_compl
 
-@[simp]
-protected theorem toFinset_empty (h : (∅ : Set α).Finite) : h.toFinset = ∅ := by
-  ext
-  simp
+-- porting note: was `@[simp]`, now `simp` can prove it
+protected theorem toFinset_empty (h : (∅ : Set α).Finite) : h.toFinset = ∅ :=
+  toFinite_toFinset _
 #align set.finite.to_finset_empty Set.Finite.toFinset_empty
 
 protected theorem toFinset_univ [Fintype α] (h : (Set.univ : Set α).Finite) :
@@ -309,7 +307,7 @@ protected theorem toFinset_image [DecidableEq β] (f : α → β) (hs : s.Finite
   simp
 #align set.finite.to_finset_image Set.Finite.toFinset_image
 
-@[simp]
+-- porting note: now `simp` can prove it but it needs an instance from the next section
 protected theorem toFinset_range [DecidableEq α] [Fintype β] (f : β → α) (h : (range f).Finite) :
     h.toFinset = Finset.univ.image f := by
   ext
@@ -321,8 +319,7 @@ end Finite
 /-! ### Fintype instances
 
 Every instance here should have a corresponding `Set.Finite` constructor in the next section.
- -/
-
+-/
 
 section FintypeInstances
 
@@ -549,10 +546,9 @@ theorem finite_toSet (s : Finset α) : (s : Set α).Finite :=
   Set.toFinite _
 #align finset.finite_to_set Finset.finite_toSet
 
-@[simp]
+-- porting note: was @[simp], now `simp` can prove it
 theorem finite_toSet_toFinset (s : Finset α) : s.finite_toSet.toFinset = s := by
-  ext
-  rw [Set.Finite.mem_toFinset, mem_coe]
+  rw [toFinite_toFinset, toFinset_coe]
 #align finset.finite_to_set_to_finset Finset.finite_toSet_toFinset
 
 end Finset
@@ -1064,10 +1060,10 @@ theorem univ_finite_iff_nonempty_fintype : (univ : Set α).Finite ↔ Nonempty (
   ⟨fun h => ⟨fintypeOfFiniteUniv h⟩, fun ⟨_i⟩ => finite_univ⟩
 #align set.univ_finite_iff_nonempty_fintype Set.univ_finite_iff_nonempty_fintype
 
-@[simp]
+-- porting note: moved `@[simp]` to `Set.toFinset_singleton` because `simp` can now simplify LHS
 theorem Finite.toFinset_singleton {a : α} (ha : ({a} : Set α).Finite := finite_singleton _) :
     ha.toFinset = {a} :=
-  Finset.ext <| by simp
+  Set.toFinite_toFinset _
 #align set.finite.to_finset_singleton Set.Finite.toFinset_singleton
 
 @[simp]

--- a/Mathlib/Data/Set/Finite.lean
+++ b/Mathlib/Data/Set/Finite.lean
@@ -307,7 +307,8 @@ protected theorem toFinset_image [DecidableEq β] (f : α → β) (hs : s.Finite
   simp
 #align set.finite.to_finset_image Set.Finite.toFinset_image
 
--- porting note: now `simp` can prove it but it needs an instance from the next section
+-- porting note: now `simp` can prove it but it needs the `fintypeRange` instance from the next
+-- section
 protected theorem toFinset_range [DecidableEq α] [Fintype β] (f : β → α) (h : (range f).Finite) :
     h.toFinset = Finset.univ.image f := by
   ext

--- a/Mathlib/Data/Set/Finite.lean
+++ b/Mathlib/Data/Set/Finite.lean
@@ -242,7 +242,8 @@ alias Finite.toFinset_ssubset_toFinset ↔ _ toFinset_strictMono
 protected theorem toFinset_setOf [Fintype α] (p : α → Prop) [DecidablePred p]
     (h : { x | p x }.Finite) : h.toFinset = Finset.univ.filter p := by
   -- porting note: `simp` doesn't use the `simp` lemma `Set.toFinset_setOf` without the `_`
-  ext; simp [Set.toFinset_setOf _]
+  ext
+  simp [Set.toFinset_setOf _]
 #align set.finite.to_finset_set_of Set.Finite.toFinset_setOf
 
 @[simp]

--- a/Mathlib/Data/Set/Finite.lean
+++ b/Mathlib/Data/Set/Finite.lean
@@ -241,8 +241,8 @@ alias Finite.toFinset_ssubset_toFinset ↔ _ toFinset_strictMono
 @[simp high]
 protected theorem toFinset_setOf [Fintype α] (p : α → Prop) [DecidablePred p]
     (h : { x | p x }.Finite) : h.toFinset = Finset.univ.filter p := by
-  -- porting note: `simp` doesn't use the `simp` lemma `Set.toFinset_setOf` without the `_`
   ext
+  -- porting note: `simp` doesn't use the `simp` lemma `Set.toFinset_setOf` without the `_`
   simp [Set.toFinset_setOf _]
 #align set.finite.to_finset_set_of Set.Finite.toFinset_setOf
 


### PR DESCRIPTION
---
`simp` and `simpNF` behaves different from Lean 3, so forward-porting caused some compile and lint errors. I tried to fix them (awaiting CI).
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)