### PR TITLE
[Merged by Bors] - fix: compile inductives recursively

### DIFF
--- a/Mathlib/Util/CompileInductive.lean
+++ b/Mathlib/Util/CompileInductive.lean
@@ -5,6 +5,7 @@ Authors: Parth Shastri, Gabriel Ebner, Mario Carneiro
 -/
 import Lean.Compiler.CSimpAttr
 import Lean.Elab.PreDefinition
+import Mathlib.Tactic.RunCmd
 
 /-!
 # Define the `compile_inductive%` command.
@@ -37,6 +38,14 @@ def mkRecNames (all : List Name) (numMotives : Nat) : List Name :=
     all.map mkRecName ++
       (List.range (numMotives - all.length)).map (fun i => main.str s!"rec_{i+1}")
 
+private def addAndCompile' (decl : Declaration) : CoreM Unit := do
+  try addAndCompile decl
+  catch e =>
+    match decl with
+    | .defnDecl val => throwError "while compiling {val.name}: {e.toMessageData}"
+    | .mutualDefnDecl val => throwError "while compiling {val.map (·.name)}: {e.toMessageData}"
+    | _ => unreachable!
+
 /--
 Compile the definition `dv` by adding a second definition `dv✝` with the same body,
 and registering a `csimp`-lemma `dv = dv✝`.
@@ -47,7 +56,7 @@ def compileDefn (dv : DefinitionVal) : MetaM Unit := do
     -- on the original definition
     return ← compileDecl <| .defnDecl dv
   let name ← mkFreshUserName dv.name
-  addAndCompile <| .defnDecl { dv with name }
+  addAndCompile' <| .defnDecl { dv with name }
   let levels := dv.levelParams.map .param
   let old := .const dv.name levels
   let new := .const name levels
@@ -62,6 +71,11 @@ def compileDefn (dv : DefinitionVal) : MetaM Unit := do
 
 open Elab
 
+/-- Returns true if the given declaration has already been compiled, either directly or via a
+`@[csimp]` lemma. -/
+def isCompiled (env : Environment) (n : Name) : Bool :=
+  env.contains (n.str "_cstage2") || (Compiler.CSimp.ext.getState env).map.contains n
+
 /--
 `compile_def% Foo.foo` adds compiled code for the definition `Foo.foo`.
 This can be used for type class projections or definitions like `List._sizeOf_1`,
@@ -70,57 +84,55 @@ for which Lean does not generate compiled code by default
 -/
 elab tk:"compile_def% " i:ident : command => Command.liftTermElabM do
   let n ← resolveGlobalConstNoOverloadWithInfo i
+  if isCompiled (← getEnv) n then
+    logWarningAt tk m!"already compiled {n}"
+    return
   let dv ← withRef i <| getConstInfoDefn n
   withRef tk <| compileDefn dv
 
-private def compileSizeOf (iv : InductiveVal) : MetaM Unit := do
-  for name in iv.all do
-    for aux in [name.str "_sizeOf_1", name.str "_sizeOf_inst"] do
-      if let some (.defnInfo dv) := (← getEnv).find? aux then
-        compileDefn dv
-
-private def compileStruct (iv : InductiveVal) (rv : RecursorVal) : MetaM Unit := do
-  let name ← mkFreshUserName rv.name
-  addAndCompile <| .defnDecl { rv with
-    name
-    value := ← forallTelescope rv.type fun xs _ =>
-      let val := xs[rv.getFirstMinorIdx]!
-      let val := mkAppN val ⟨.map (xs[rv.getMajorIdx]!.proj iv.name) <| .range rv.rules[0]!.nfields⟩
-      mkLambdaFVars xs val
-    hints := .abbrev
-    safety := .safe
-  }
-  let levels := rv.levelParams.map .param
-  let old := .const rv.name levels
-  let new := .const name levels
-  let name ← mkFreshUserName <| rv.name.str "eq"
-  addDecl <| .mutualDefnDecl [{
-    name
-    levelParams := rv.levelParams
-    type := ← mkEq old new
-    value := .const name levels
-    hints := .opaque
-    safety := .partial
-  }]
-  Compiler.CSimp.add name .global
-  compileDefn <| ← getConstInfoDefn <| mkRecOnName iv.name
-  compileSizeOf iv
+private def compileStructOnly (iv : InductiveVal) (rv : RecursorVal) : MetaM Unit := do
+  let value ← forallTelescope rv.type fun xs _ =>
+    let val := xs[rv.getFirstMinorIdx]!
+    let val := mkAppN val ⟨.map (xs[rv.getMajorIdx]!.proj iv.name) <| .range rv.rules[0]!.nfields⟩
+    mkLambdaFVars xs val
+  go value
+where
+  go value := do
+    let name ← mkFreshUserName rv.name
+    addAndCompile' <| .defnDecl { rv with
+      name
+      value
+      hints := .abbrev
+      safety := .safe
+    }
+    let levels := rv.levelParams.map .param
+    let old := .const rv.name levels
+    let new := .const name levels
+    let name ← mkFreshUserName <| rv.name.str "eq"
+    addDecl <| .mutualDefnDecl [{
+      name
+      levelParams := rv.levelParams
+      type := ← mkEq old new
+      value := .const name levels
+      hints := .opaque
+      safety := .partial
+    }]
+    Compiler.CSimp.add name .global
+    compileDefn <| ← getConstInfoDefn <| mkRecOnName iv.name
 
 /--
-Generate compiled code for the recursor for `iv`.
+Generate compiled code for the recursor for `iv`, excluding the `sizeOf` function.
 -/
-def compileInductive (iv : InductiveVal) : MetaM Unit := do
+def compileInductiveOnly (iv : InductiveVal) (warn := true) : MetaM Unit := do
   let rv ← getConstInfoRec <| mkRecName iv.name
   if ← isProp rv.type then
-    logWarning m!"not compiling {rv.name}"
+    if warn then logWarning m!"not compiling {rv.name}"
     return
-  if (← getEnv).contains (rv.name.str "_cstage2") ||
-    (Compiler.CSimp.ext.getState (← getEnv)).map.contains rv.name
-  then
-    logWarning m!"already compiled {rv.name}"
+  if isCompiled (← getEnv) rv.name then
+    if warn then logWarning m!"already compiled {rv.name}"
     return
   if !iv.isRec && rv.numMotives == 1 && iv.numCtors == 1 && iv.numIndices == 0 then
-    compileStruct iv rv
+    compileStructOnly iv rv
     return
   let levels := rv.levelParams.map .param
   let rvs ←
@@ -128,7 +140,7 @@ def compileInductive (iv : InductiveVal) : MetaM Unit := do
     else mkRecNames iv.all rv.numMotives |>.mapM getConstInfoRec
   let rvs ← rvs.mapM fun rv => return (rv, ← mkFreshUserName rv.name)
   let repl := rvs.foldl (fun l (rv, name) => .cons rv.name name l) .nil
-  addAndCompile <| .mutualDefnDecl <|← rvs.mapM fun (rv, name) => do
+  addAndCompile' <| .mutualDefnDecl <|← rvs.mapM fun (rv, name) => do
     pure { rv with
       name
       value := ← forallTelescope rv.type fun xs body => do
@@ -170,7 +182,37 @@ def compileInductive (iv : InductiveVal) : MetaM Unit := do
     for aux in [mkRecOnName name, mkBRecOnName name] do
       if let some (.defnInfo dv) := (← getEnv).find? aux then
         compileDefn dv
+
+mutual
+
+/--
+Generate compiled code for the recursor for `iv`.
+-/
+partial def compileInductive (iv : InductiveVal) (warn := true) : MetaM Unit := do
+  compileInductiveOnly iv warn
   compileSizeOf iv
+
+/--
+Compiles the `sizeOf` auxiliary functions. It also recursively compiles any inductives required to
+compile the `sizeOf` definition (because `sizeOf` definitions depend on `T.rec`).
+-/
+partial def compileSizeOf (iv : InductiveVal) : MetaM Unit := do
+  let go aux := do
+    if let some (.defnInfo dv) := (← getEnv).find? aux then
+      if !isCompiled (← getEnv) aux then
+        let deps : NameSet := dv.value.foldConsts ∅ fun c arr =>
+          if let .str name "_sizeOf_inst" := c then arr.insert name else arr
+        for i in deps do
+          if let some (.inductInfo iv) := (← getEnv).find? i then
+            compileInductive iv (warn := false)
+        compileDefn dv
+  let rv ← getConstInfoRec <| mkRecName iv.name
+  for name in iv.all do
+    for i in [:rv.numMotives] do
+      go <| name.str s!"_sizeOf_{i+1}"
+    go <| name.str "_sizeOf_inst"
+
+end
 
 /--
 `compile_inductive% Foo` creates compiled code for the recursor `Foo.rec`,
@@ -181,6 +223,8 @@ elab tk:"compile_inductive% " i:ident : command => Command.liftTermElabM do
   let n ← resolveGlobalConstNoOverloadWithInfo i
   let iv ← withRef i <| getConstInfoInduct n
   withRef tk <| compileInductive iv
+
+end Mathlib.Util
 
 compile_inductive% Nat
 compile_inductive% List
@@ -193,3 +237,33 @@ compile_inductive% False
 compile_inductive% Empty
 compile_inductive% Bool
 compile_inductive% Sigma
+
+-- In addition to the manual implementation below, we also have to override the `Float.val` and
+-- `Float.mk` functions because these also have no implementation in core lean.
+-- Because `floatSpec.float` is an opaque type, the identity function is as good an implementation
+-- as any.
+private unsafe def Float.valUnsafe : Float → floatSpec.float := unsafeCast
+private unsafe def Float.mkUnsafe : floatSpec.float → Float := unsafeCast
+@[implemented_by Float.valUnsafe] private def Float.valImpl (x : Float) : floatSpec.float := x.1
+@[implemented_by Float.mkUnsafe] private def Float.mkImpl (x : floatSpec.float) : Float := ⟨x⟩
+@[csimp] private theorem Float.val_eq : @Float.val = Float.valImpl := rfl
+@[csimp] private theorem Float.mk_eq : @Float.mk = Float.mkImpl := rfl
+
+-- These types need manual implementations because the default implementation in `compileStruct`
+-- uses `Expr.proj` which has an invalid IR type.
+open Lean Meta Elab Mathlib.Util in
+run_cmd Command.liftTermElabM do
+  for n in [``UInt8, ``UInt16, ``UInt32, ``UInt64, ``USize, ``Float] do
+    let iv ← getConstInfoInduct n
+    let rv ← getConstInfoRec <| mkRecName n
+    let value ← Elab.Term.elabTerm (← `(fun H t => H t.1))
+      (← inferType (.const rv.name (rv.levelParams.map .param)))
+    compileStructOnly.go iv rv value
+    compileSizeOf iv
+
+-- These need special handling because `Lean.Name.sizeOf` and `Lean.instSizeOfName`
+-- were manually implemented as `noncomputable`
+compile_inductive% String
+compile_inductive% Lean.Name
+compile_def% Lean.Name.sizeOf
+compile_def% Lean.instSizeOfName

--- a/test/CompileInductive.lean
+++ b/test/CompileInductive.lean
@@ -27,15 +27,15 @@ example := @List._sizeOf_1
 open Lean Elab Term
 
 def tryToCompileAllInductives : TermElabM Unit := do
-  let ivs := (← getEnv).constants.toList.filterMap λ | (_, .inductInfo iv) => some iv | _ => none
+  let ivs := (← getEnv).constants.toList.filterMap fun | (_, .inductInfo iv) => some iv | _ => none
   let mut success := 0
   for iv in ivs do
     try
       withCurrHeartbeats <| Mathlib.Util.compileInductive iv
       success := success + 1
     catch | e => logError m!"[{iv.name}] {e.toMessageData}"
-  modifyThe Core.State λ s => { s with messages.msgs := s.messages.msgs.filter (·.severity != .warning) }
-  modifyThe Core.State λ s => { s with messages := s.messages.errorsToWarnings }
+  modifyThe Core.State fun s => { s with messages.msgs := s.messages.msgs.filter (·.severity != .warning) }
+  modifyThe Core.State fun s => { s with messages := s.messages.errorsToWarnings }
   logInfo m!"{success} / {ivs.length}"
 
 -- #eval Command.liftTermElabM tryToCompileAllInductives


### PR DESCRIPTION
The `compileSizeOf` addition inadvertently broke the `tryToCompileAllInductives` test (which is disabled on master because it is too expensive); if you actually run it there are hundreds of failures (`421 / 1134` success), where it should only have failed a small handful of times. The reason for the failure is that compiling a `T.sizeOf` function requires `U.rec` and `U.sizeOf` if the definition of inductive type `T` uses `U`, so now we process them recursively.

In addition there are a few more fixes for completeness:

* The `UInt8`, `UInt16` etc types were generating invalid IR because `Expr.proj` doesn't work on them. We can work around this by using `UInt8.val` etc instead.
* The `Float` type needs a further hack because `Float.val` also fails; we implement this and `Float.mk` using `unsafeCast`, which is fine since they are conversions to and from `floatSpec.float` which is an opaque type.
* `instSizeOfName` and `Name.sizeOf` were manually implemented as `noncomputable` so they need a `compile_def%`.

All together this unblocks essentially all the inductive types in `Lean`, and now the `tryToCompileAllInductives` test has 1131 / 1134 successes, where the three failures are `Acc.below`, `HEq` and `Acc` which are all expected because large-eliminating Props are not implemented. (We could special case implement these like with `UInt8` et al, but these represent a general class of unimplemented inductives while `UInt8` is special cased by the code generator.)


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
