### PR TITLE
[Merged by Bors] - feat: port RepresentationTheory.Rep

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2394,6 +2394,7 @@ import Mathlib.Probability.ProbabilityMassFunction.Uniform
 import Mathlib.RepresentationTheory.Action
 import Mathlib.RepresentationTheory.Basic
 import Mathlib.RepresentationTheory.Maschke
+import Mathlib.RepresentationTheory.Rep
 import Mathlib.RingTheory.Adjoin.Basic
 import Mathlib.RingTheory.Adjoin.FG
 import Mathlib.RingTheory.Adjoin.Field

--- a/Mathlib/Algebra/Category/ModuleCat/Limits.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Limits.lean
@@ -138,6 +138,9 @@ instance hasLimits : HasLimits (ModuleCat.{w} R) :=
   ModuleCat.hasLimitsOfSize.{w, w, u}
 #align Module.has_limits ModuleCat.hasLimits
 
+instance (priority := high) hasLimits' : HasLimits (ModuleCat.{u} R) :=
+  ModuleCat.hasLimitsOfSize.{u, u, u}
+
 /-- An auxiliary declaration to speed up typechecking.
 -/
 def forget₂AddCommGroupPreservesLimitsAux (F : J ⥤ ModuleCatMax.{v, w, u} R) :

--- a/Mathlib/RepresentationTheory/Action.lean
+++ b/Mathlib/RepresentationTheory/Action.lean
@@ -321,10 +321,12 @@ def functorCategoryEquivalenceCompEvaluation :
 set_option linter.uppercaseLean3 false in
 #align Action.functor_category_equivalence_comp_evaluation Action.functorCategoryEquivalenceCompEvaluation
 
-noncomputable instance [HasLimits V] : Limits.PreservesLimits (forget V G) :=
+noncomputable instance instPreservesLimitsForget [HasLimits V] :
+    Limits.PreservesLimits (forget V G) :=
   Limits.preservesLimitsOfNatIso (Action.functorCategoryEquivalenceCompEvaluation V G)
 
-noncomputable instance [HasColimits V] : PreservesColimits (forget V G) :=
+noncomputable instance instPreservesColimitsForget [HasColimits V] :
+    PreservesColimits (forget V G) :=
   preservesColimitsOfNatIso (Action.functorCategoryEquivalenceCompEvaluation V G)
 
 -- TODO construct categorical images?

--- a/Mathlib/RepresentationTheory/Rep.lean
+++ b/Mathlib/RepresentationTheory/Rep.lean
@@ -8,13 +8,13 @@ Authors: Scott Morrison
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
-import Mathbin.RepresentationTheory.Basic
-import Mathbin.RepresentationTheory.Action
-import Mathbin.Algebra.Category.Module.Abelian
-import Mathbin.Algebra.Category.Module.Colimits
-import Mathbin.Algebra.Category.Module.Monoidal.Closed
-import Mathbin.Algebra.Category.Module.Adjunctions
-import Mathbin.CategoryTheory.Closed.FunctorCategory
+import Mathlib.RepresentationTheory.Basic
+import Mathlib.RepresentationTheory.Action
+import Mathlib.Algebra.Category.Module.Abelian
+import Mathlib.Algebra.Category.Module.Colimits
+import Mathlib.Algebra.Category.Module.Monoidal.Closed
+import Mathlib.Algebra.Category.Module.Adjunctions
+import Mathlib.CategoryTheory.Closed.FunctorCategory
 
 /-!
 # `Rep k G` is the category of `k`-linear representations of `G`.
@@ -187,8 +187,7 @@ theorem linearization_μ_hom (X Y : Action (Type u) (MonCat.of G)) :
 
 @[simp]
 theorem linearization_μ_inv_hom (X Y : Action (Type u) (MonCat.of G)) :
-    (inv ((linearization k G).μ X Y)).hom = (finsuppTensorFinsupp' k X.V Y.V).symm.toLinearMap :=
-  by
+    (inv ((linearization k G).μ X Y)).hom = (finsuppTensorFinsupp' k X.V Y.V).symm.toLinearMap := by
   simp_rw [← Action.forget_map, functor.map_inv, Action.forget_map, linearization_μ_hom]
   apply is_iso.inv_eq_of_hom_inv_id _
   exact LinearMap.ext fun x => LinearEquiv.symm_apply_apply _ _
@@ -201,8 +200,7 @@ theorem linearization_ε_hom : (linearization k G).ε.hom = Finsupp.lsingle PUni
 
 @[simp]
 theorem linearization_ε_inv_hom_apply (r : k) :
-    (inv (linearization k G).ε).hom (Finsupp.single PUnit.unit r) = r :=
-  by
+    (inv (linearization k G).ε).hom (Finsupp.single PUnit.unit r) = r := by
   simp_rw [← Action.forget_map, functor.map_inv, Action.forget_map]
   rw [← Finsupp.lsingle_apply PUnit.unit r]
   apply is_iso.hom_inv_id_apply _ _
@@ -248,8 +246,7 @@ variable {k G}
 /-- Given an element `x : A`, there is a natural morphism of representations `k[G] ⟶ A` sending
 `g ↦ A.ρ(g)(x).` -/
 @[simps]
-noncomputable def leftRegularHom (A : Rep k G) (x : A) : Rep.ofMulAction k G G ⟶ A
-    where
+noncomputable def leftRegularHom (A : Rep k G) (x : A) : Rep.ofMulAction k G G ⟶ A where
   hom := Finsupp.lift _ _ _ fun g => A.ρ g x
   comm' g := by
     refine' Finsupp.lhom_ext' fun y => LinearMap.ext_ring _
@@ -267,14 +264,12 @@ theorem leftRegularHom_apply {A : Rep k G} (x : A) :
 /-- Given a `k`-linear `G`-representation `A`, there is a `k`-linear isomorphism between
 representation morphisms `Hom(k[G], A)` and `A`. -/
 @[simps]
-noncomputable def leftRegularHomEquiv (A : Rep k G) : (Rep.ofMulAction k G G ⟶ A) ≃ₗ[k] A
-    where
+noncomputable def leftRegularHomEquiv (A : Rep k G) : (Rep.ofMulAction k G G ⟶ A) ≃ₗ[k] A where
   toFun f := f.hom (Finsupp.single 1 1)
   map_add' x y := rfl
   map_smul' r x := rfl
   invFun x := leftRegularHom A x
-  left_inv f :=
-    by
+  left_inv f := by
     refine' Action.Hom.ext _ _ (Finsupp.lhom_ext' fun x : G => LinearMap.ext_ring _)
     have :
       f.hom ((of_mul_action k G G).ρ x (Finsupp.single (1 : G) (1 : k))) =
@@ -306,8 +301,7 @@ variable [Group G] (A B C : Rep k G)
 `(B, ρ₂)` to the representation `Homₖ(A, B)` that maps `g : G` and `f : A →ₗ[k] B` to
 `(ρ₂ g) ∘ₗ f ∘ₗ (ρ₁ g⁻¹)`. -/
 @[simps]
-protected def ihom (A : Rep k G) : Rep k G ⥤ Rep k G
-    where
+protected def ihom (A : Rep k G) : Rep k G ⥤ Rep k G where
   obj B := Rep.of (Representation.linHom A.ρ B.ρ)
   map X Y f :=
     { hom := ModuleCat.ofHom (LinearMap.llcomp k _ _ _ f.hom)
@@ -329,8 +323,7 @@ protected theorem ihom_obj_ρ_apply {A B : Rep k G} (g : G) (x : A →ₗ[k] B) 
 `A ⊗ - ⊣ ihom(A, -)`. It sends `f : A ⊗ B ⟶ C` to a `Rep k G` morphism defined by currying the
 `k`-linear map underlying `f`, giving a map `A →ₗ[k] B →ₗ[k] C`, then flipping the arguments. -/
 @[simps]
-protected def homEquiv (A B C : Rep k G) : (A ⊗ B ⟶ C) ≃ (B ⟶ (Rep.ihom A).obj C)
-    where
+protected def homEquiv (A B C : Rep k G) : (A ⊗ B ⟶ C) ≃ (B ⟶ (Rep.ihom A).obj C) where
   toFun f :=
     { hom := (TensorProduct.curry f.hom).flip
       comm' := fun g => by
@@ -342,8 +335,7 @@ protected def homEquiv (A B C : Rep k G) : (A ⊗ B ⟶ C) ≃ (B ⟶ (Rep.ihom 
   invFun f :=
     { hom := TensorProduct.uncurry k _ _ _ f.hom.flip
       comm' := fun g =>
-        TensorProduct.ext' fun x y =>
-          by
+        TensorProduct.ext' fun x y => by
           dsimp only [monoidal_category.tensor_left_obj, ModuleCat.comp_def, LinearMap.comp_apply,
             tensor_rho, ModuleCat.MonoidalCategory.hom_apply, TensorProduct.map_tmul]
           simp only [TensorProduct.uncurry_apply f.hom.flip, LinearMap.flip_apply, Action_ρ_eq_ρ,
@@ -481,8 +473,7 @@ theorem to_Module_monoidAlgebra_map_aux {k G : Type _} [CommRing k] [Monoid G] (
     (σ : G →* W →ₗ[k] W) (f : V →ₗ[k] W) (w : ∀ g : G, f.comp (ρ g) = (σ g).comp f)
     (r : MonoidAlgebra k G) (x : V) :
     f ((((MonoidAlgebra.lift k G (V →ₗ[k] V)) ρ) r) x) =
-      (((MonoidAlgebra.lift k G (W →ₗ[k] W)) σ) r) (f x) :=
-  by
+      (((MonoidAlgebra.lift k G (W →ₗ[k] W)) σ) r) (f x) := by
   apply MonoidAlgebra.induction_on r
   · intro g
     simp only [one_smul, MonoidAlgebra.lift_single, MonoidAlgebra.of_apply]
@@ -500,15 +491,13 @@ def toModuleMonoidAlgebraMap {V W : Rep k G} (f : V ⟶ W) :
 #align Rep.to_Module_monoid_algebra_map Rep.toModuleMonoidAlgebraMap
 
 /-- Functorially convert a representation of `G` into a module over `monoid_algebra k G`. -/
-def toModuleMonoidAlgebra : Rep k G ⥤ ModuleCat.{u} (MonoidAlgebra k G)
-    where
+def toModuleMonoidAlgebra : Rep k G ⥤ ModuleCat.{u} (MonoidAlgebra k G) where
   obj V := ModuleCat.of _ V.ρ.asModule
   map V W f := toModuleMonoidAlgebraMap f
 #align Rep.to_Module_monoid_algebra Rep.toModuleMonoidAlgebra
 
 /-- Functorially convert a module over `monoid_algebra k G` into a representation of `G`. -/
-def ofModuleMonoidAlgebra : ModuleCat.{u} (MonoidAlgebra k G) ⥤ Rep k G
-    where
+def ofModuleMonoidAlgebra : ModuleCat.{u} (MonoidAlgebra k G) ⥤ Rep k G where
   obj M := Rep.of (Representation.ofModule k G M)
   map M N f :=
     { hom := { f with map_smul' := fun r x => f.map_smul (algebraMap k _ r) x }
@@ -527,15 +516,13 @@ theorem ofModuleMonoidAlgebra_obj_ρ (M : ModuleCat.{u} (MonoidAlgebra k G)) :
 
 /-- Auxilliary definition for `equivalence_Module_monoid_algebra`. -/
 def counitIsoAddEquiv {M : ModuleCat.{u} (MonoidAlgebra k G)} :
-    (ofModuleMonoidAlgebra ⋙ toModuleMonoidAlgebra).obj M ≃+ M :=
-  by
+    (ofModuleMonoidAlgebra ⋙ toModuleMonoidAlgebra).obj M ≃+ M := by
   dsimp [of_Module_monoid_algebra, to_Module_monoid_algebra]
   refine' (Representation.ofModule k G ↥M).asModuleEquiv.trans (RestrictScalars.addEquiv _ _ _)
 #align Rep.counit_iso_add_equiv Rep.counitIsoAddEquiv
 
 /-- Auxilliary definition for `equivalence_Module_monoid_algebra`. -/
-def unitIsoAddEquiv {V : Rep k G} : V ≃+ (toModuleMonoidAlgebra ⋙ ofModuleMonoidAlgebra).obj V :=
-  by
+def unitIsoAddEquiv {V : Rep k G} : V ≃+ (toModuleMonoidAlgebra ⋙ ofModuleMonoidAlgebra).obj V := by
   dsimp [of_Module_monoid_algebra, to_Module_monoid_algebra]
   refine' V.ρ.as_module_equiv.symm.trans _
   exact (RestrictScalars.addEquiv _ _ _).symm
@@ -573,8 +560,7 @@ def unitIso (V : Rep k G) : V ≅ (toModuleMonoidAlgebra ⋙ ofModuleMonoidAlgeb
 #align Rep.unit_iso Rep.unitIso
 
 /-- The categorical equivalence `Rep k G ≌ Module (monoid_algebra k G)`. -/
-def equivalenceModuleMonoidAlgebra : Rep k G ≌ ModuleCat.{u} (MonoidAlgebra k G)
-    where
+def equivalenceModuleMonoidAlgebra : Rep k G ≌ ModuleCat.{u} (MonoidAlgebra k G) where
   Functor := toModuleMonoidAlgebra
   inverse := ofModuleMonoidAlgebra
   unitIso := NatIso.ofComponents (fun V => unitIso V) (by tidy)

--- a/Mathlib/RepresentationTheory/Rep.lean
+++ b/Mathlib/RepresentationTheory/Rep.lean
@@ -10,10 +10,10 @@ Authors: Scott Morrison
 -/
 import Mathlib.RepresentationTheory.Basic
 import Mathlib.RepresentationTheory.Action
-import Mathlib.Algebra.Category.Module.Abelian
-import Mathlib.Algebra.Category.Module.Colimits
-import Mathlib.Algebra.Category.Module.Monoidal.Closed
-import Mathlib.Algebra.Category.Module.Adjunctions
+import Mathlib.Algebra.Category.ModuleCat.Abelian
+import Mathlib.Algebra.Category.ModuleCat.Colimits
+import Mathlib.Algebra.Category.ModuleCat.Monoidal.Closed
+import Mathlib.Algebra.Category.ModuleCat.Adjunctions
 import Mathlib.CategoryTheory.Closed.FunctorCategory
 
 /-!

--- a/Mathlib/RepresentationTheory/Rep.lean
+++ b/Mathlib/RepresentationTheory/Rep.lean
@@ -1,0 +1,586 @@
+/-
+Copyright (c) 2020 Scott Morrison. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Scott Morrison
+
+! This file was ported from Lean 3 source module representation_theory.Rep
+! leanprover-community/mathlib commit cec81510e48e579bde6acd8568c06a87af045b63
+! Please do not edit these lines, except to modify the commit id
+! if you have ported upstream changes.
+-/
+import Mathbin.RepresentationTheory.Basic
+import Mathbin.RepresentationTheory.Action
+import Mathbin.Algebra.Category.Module.Abelian
+import Mathbin.Algebra.Category.Module.Colimits
+import Mathbin.Algebra.Category.Module.Monoidal.Closed
+import Mathbin.Algebra.Category.Module.Adjunctions
+import Mathbin.CategoryTheory.Closed.FunctorCategory
+
+/-!
+# `Rep k G` is the category of `k`-linear representations of `G`.
+
+If `V : Rep k G`, there is a coercion that allows you to treat `V` as a type,
+and this type comes equipped with a `module k V` instance.
+Also `V.ρ` gives the homomorphism `G →* (V →ₗ[k] V)`.
+
+Conversely, given a homomorphism `ρ : G →* (V →ₗ[k] V)`,
+you can construct the bundled representation as `Rep.of ρ`.
+
+We construct the categorical equivalence `Rep k G ≌ Module (monoid_algebra k G)`.
+We verify that `Rep k G` is a `k`-linear abelian symmetric monoidal category with all (co)limits.
+-/
+
+
+universe u
+
+open CategoryTheory
+
+open CategoryTheory.Limits
+
+/- ./././Mathport/Syntax/Translate/Command.lean:328:31: unsupported: @[derive] abbrev -/
+/-- The category of `k`-linear representations of a monoid `G`. -/
+abbrev Rep (k G : Type u) [Ring k] [Monoid G] :=
+  Action (ModuleCat.{u} k) (MonCat.of G)
+#align Rep Rep
+
+instance (k G : Type u) [CommRing k] [Monoid G] : Linear k (Rep k G) := by infer_instance
+
+namespace Rep
+
+variable {k G : Type u} [CommRing k]
+
+section
+
+variable [Monoid G]
+
+instance : CoeSort (Rep k G) (Type u) :=
+  ConcreteCategory.hasCoeToSort _
+
+instance (V : Rep k G) : AddCommGroup V := by
+  change AddCommGroup ((forget₂ (Rep k G) (ModuleCat k)).obj V); infer_instance
+
+instance (V : Rep k G) : Module k V := by change Module k ((forget₂ (Rep k G) (ModuleCat k)).obj V);
+  infer_instance
+
+/-- Specialize the existing `Action.ρ`, changing the type to `representation k G V`.
+-/
+def ρ (V : Rep k G) : Representation k G V :=
+  V.ρ
+#align Rep.ρ Rep.ρ
+
+/-- Lift an unbundled representation to `Rep`. -/
+def of {V : Type u} [AddCommGroup V] [Module k V] (ρ : G →* V →ₗ[k] V) : Rep k G :=
+  ⟨ModuleCat.of k V, ρ⟩
+#align Rep.of Rep.of
+
+@[simp]
+theorem coe_of {V : Type u} [AddCommGroup V] [Module k V] (ρ : G →* V →ₗ[k] V) :
+    (of ρ : Type u) = V :=
+  rfl
+#align Rep.coe_of Rep.coe_of
+
+@[simp]
+theorem of_ρ {V : Type u} [AddCommGroup V] [Module k V] (ρ : G →* V →ₗ[k] V) : (of ρ).ρ = ρ :=
+  rfl
+#align Rep.of_ρ Rep.of_ρ
+
+theorem Action_ρ_eq_ρ {A : Rep k G} : Action.ρ A = A.ρ :=
+  rfl
+#align Rep.Action_ρ_eq_ρ Rep.Action_ρ_eq_ρ
+
+/-- Allows us to apply lemmas about the underlying `ρ`, which would take an element `g : G` rather
+than `g : Mon.of G` as an argument. -/
+theorem of_ρ_apply {V : Type u} [AddCommGroup V] [Module k V] (ρ : Representation k G V)
+    (g : MonCat.of G) : (Rep.of ρ).ρ g = ρ (g : G) :=
+  rfl
+#align Rep.of_ρ_apply Rep.of_ρ_apply
+
+@[simp]
+theorem ρ_inv_self_apply {G : Type u} [Group G] (A : Rep k G) (g : G) (x : A) :
+    A.ρ g⁻¹ (A.ρ g x) = x :=
+  show (A.ρ g⁻¹ * A.ρ g) x = x by rw [← map_mul, inv_mul_self, map_one, LinearMap.one_apply]
+#align Rep.ρ_inv_self_apply Rep.ρ_inv_self_apply
+
+@[simp]
+theorem ρ_self_inv_apply {G : Type u} [Group G] {A : Rep k G} (g : G) (x : A) :
+    A.ρ g (A.ρ g⁻¹ x) = x :=
+  show (A.ρ g * A.ρ g⁻¹) x = x by rw [← map_mul, mul_inv_self, map_one, LinearMap.one_apply]
+#align Rep.ρ_self_inv_apply Rep.ρ_self_inv_apply
+
+theorem hom_comm_apply {A B : Rep k G} (f : A ⟶ B) (g : G) (x : A) :
+    f.hom (A.ρ g x) = B.ρ g (f.hom x) :=
+  LinearMap.ext_iff.1 (f.comm g) x
+#align Rep.hom_comm_apply Rep.hom_comm_apply
+
+variable (k G)
+
+/-- The trivial `k`-linear `G`-representation on a `k`-module `V.` -/
+def trivial (V : Type u) [AddCommGroup V] [Module k V] : Rep k G :=
+  Rep.of (@Representation.trivial k G V _ _ _ _)
+#align Rep.trivial Rep.trivial
+
+variable {k G}
+
+theorem trivial_def {V : Type u} [AddCommGroup V] [Module k V] (g : G) (v : V) :
+    (trivial k G V).ρ g v = v :=
+  rfl
+#align Rep.trivial_def Rep.trivial_def
+
+-- Verify that limits are calculated correctly.
+noncomputable example : PreservesLimits (forget₂ (Rep k G) (ModuleCat.{u} k)) := by infer_instance
+
+noncomputable example : PreservesColimits (forget₂ (Rep k G) (ModuleCat.{u} k)) := by infer_instance
+
+@[simp]
+theorem MonoidalCategory.braiding_hom_apply {A B : Rep k G} (x : A) (y : B) :
+    Action.Hom.hom (β_ A B).hom (TensorProduct.tmul k x y) = TensorProduct.tmul k y x :=
+  rfl
+#align Rep.monoidal_category.braiding_hom_apply Rep.MonoidalCategory.braiding_hom_apply
+
+@[simp]
+theorem MonoidalCategory.braiding_inv_apply {A B : Rep k G} (x : A) (y : B) :
+    Action.Hom.hom (β_ A B).inv (TensorProduct.tmul k y x) = TensorProduct.tmul k x y :=
+  rfl
+#align Rep.monoidal_category.braiding_inv_apply Rep.MonoidalCategory.braiding_inv_apply
+
+section Linearization
+
+variable (k G)
+
+/-- The monoidal functor sending a type `H` with a `G`-action to the induced `k`-linear
+`G`-representation on `k[H].` -/
+noncomputable def linearization : MonoidalFunctor (Action (Type u) (MonCat.of G)) (Rep k G) :=
+  (ModuleCat.monoidalFree k).mapAction (MonCat.of G)
+#align Rep.linearization Rep.linearization
+
+variable {k G}
+
+@[simp]
+theorem linearization_obj_ρ (X : Action (Type u) (MonCat.of G)) (g : G) (x : X.V →₀ k) :
+    ((linearization k G).obj X).ρ g x = Finsupp.lmapDomain k k (X.ρ g) x :=
+  rfl
+#align Rep.linearization_obj_ρ Rep.linearization_obj_ρ
+
+@[simp]
+theorem linearization_of (X : Action (Type u) (MonCat.of G)) (g : G) (x : X.V) :
+    ((linearization k G).obj X).ρ g (Finsupp.single x (1 : k)) = Finsupp.single (X.ρ g x) (1 : k) :=
+  by rw [linearization_obj_ρ, Finsupp.lmapDomain_apply, Finsupp.mapDomain_single]
+#align Rep.linearization_of Rep.linearization_of
+
+variable {X Y : Action (Type u) (MonCat.of G)} (f : X ⟶ Y)
+
+@[simp]
+theorem linearization_map_hom : ((linearization k G).map f).hom = Finsupp.lmapDomain k k f.hom :=
+  rfl
+#align Rep.linearization_map_hom Rep.linearization_map_hom
+
+theorem linearization_map_hom_single (x : X.V) (r : k) :
+    ((linearization k G).map f).hom (Finsupp.single x r) = Finsupp.single (f.hom x) r := by
+  rw [linearization_map_hom, Finsupp.lmapDomain_apply, Finsupp.mapDomain_single]
+#align Rep.linearization_map_hom_single Rep.linearization_map_hom_single
+
+@[simp]
+theorem linearization_μ_hom (X Y : Action (Type u) (MonCat.of G)) :
+    ((linearization k G).μ X Y).hom = (finsuppTensorFinsupp' k X.V Y.V).toLinearMap :=
+  rfl
+#align Rep.linearization_μ_hom Rep.linearization_μ_hom
+
+@[simp]
+theorem linearization_μ_inv_hom (X Y : Action (Type u) (MonCat.of G)) :
+    (inv ((linearization k G).μ X Y)).hom = (finsuppTensorFinsupp' k X.V Y.V).symm.toLinearMap :=
+  by
+  simp_rw [← Action.forget_map, functor.map_inv, Action.forget_map, linearization_μ_hom]
+  apply is_iso.inv_eq_of_hom_inv_id _
+  exact LinearMap.ext fun x => LinearEquiv.symm_apply_apply _ _
+#align Rep.linearization_μ_inv_hom Rep.linearization_μ_inv_hom
+
+@[simp]
+theorem linearization_ε_hom : (linearization k G).ε.hom = Finsupp.lsingle PUnit.unit :=
+  rfl
+#align Rep.linearization_ε_hom Rep.linearization_ε_hom
+
+@[simp]
+theorem linearization_ε_inv_hom_apply (r : k) :
+    (inv (linearization k G).ε).hom (Finsupp.single PUnit.unit r) = r :=
+  by
+  simp_rw [← Action.forget_map, functor.map_inv, Action.forget_map]
+  rw [← Finsupp.lsingle_apply PUnit.unit r]
+  apply is_iso.hom_inv_id_apply _ _
+#align Rep.linearization_ε_inv_hom_apply Rep.linearization_ε_inv_hom_apply
+
+variable (k G)
+
+/-- The linearization of a type `X` on which `G` acts trivially is the trivial `G`-representation
+on `k[X]`. -/
+@[simps]
+noncomputable def linearizationTrivialIso (X : Type u) :
+    (linearization k G).obj (Action.mk X 1) ≅ trivial k G (X →₀ k) :=
+  Action.mkIso (Iso.refl _) fun g => by ext1; ext1; exact linearization_of _ _ _
+#align Rep.linearization_trivial_iso Rep.linearizationTrivialIso
+
+variable (k G)
+
+/-- Given a `G`-action on `H`, this is `k[H]` bundled with the natural representation
+`G →* End(k[H])` as a term of type `Rep k G`. -/
+noncomputable abbrev ofMulAction (H : Type u) [MulAction G H] : Rep k G :=
+  of <| Representation.ofMulAction k G H
+#align Rep.of_mul_action Rep.ofMulAction
+
+/-- The `k`-linear `G`-representation on `k[G]`, induced by left multiplication. -/
+noncomputable def leftRegular : Rep k G :=
+  ofMulAction k G G
+#align Rep.left_regular Rep.leftRegular
+
+/-- The `k`-linear `G`-representation on `k[Gⁿ]`, induced by left multiplication. -/
+noncomputable def diagonal (n : ℕ) : Rep k G :=
+  ofMulAction k G (Fin n → G)
+#align Rep.diagonal Rep.diagonal
+
+/-- The linearization of a type `H` with a `G`-action is definitionally isomorphic to the
+`k`-linear `G`-representation on `k[H]` induced by the `G`-action on `H`. -/
+noncomputable def linearizationOfMulActionIso (H : Type u) [MulAction G H] :
+    (linearization k G).obj (Action.ofMulAction G H) ≅ ofMulAction k G H :=
+  Iso.refl _
+#align Rep.linearization_of_mul_action_iso Rep.linearizationOfMulActionIso
+
+variable {k G}
+
+/-- Given an element `x : A`, there is a natural morphism of representations `k[G] ⟶ A` sending
+`g ↦ A.ρ(g)(x).` -/
+@[simps]
+noncomputable def leftRegularHom (A : Rep k G) (x : A) : Rep.ofMulAction k G G ⟶ A
+    where
+  hom := Finsupp.lift _ _ _ fun g => A.ρ g x
+  comm' g := by
+    refine' Finsupp.lhom_ext' fun y => LinearMap.ext_ring _
+    simpa only [LinearMap.comp_apply, ModuleCat.comp_def, Finsupp.lsingle_apply, Finsupp.lift_apply,
+      Action_ρ_eq_ρ, of_ρ_apply, Representation.ofMulAction_single, Finsupp.sum_single_index,
+      zero_smul, one_smul, smul_eq_mul, A.ρ.map_mul]
+#align Rep.left_regular_hom Rep.leftRegularHom
+
+theorem leftRegularHom_apply {A : Rep k G} (x : A) :
+    (leftRegularHom A x).hom (Finsupp.single 1 1) = x := by
+  simpa only [left_regular_hom_hom, Finsupp.lift_apply, Finsupp.sum_single_index, one_smul,
+    A.ρ.map_one, zero_smul]
+#align Rep.left_regular_hom_apply Rep.leftRegularHom_apply
+
+/-- Given a `k`-linear `G`-representation `A`, there is a `k`-linear isomorphism between
+representation morphisms `Hom(k[G], A)` and `A`. -/
+@[simps]
+noncomputable def leftRegularHomEquiv (A : Rep k G) : (Rep.ofMulAction k G G ⟶ A) ≃ₗ[k] A
+    where
+  toFun f := f.hom (Finsupp.single 1 1)
+  map_add' x y := rfl
+  map_smul' r x := rfl
+  invFun x := leftRegularHom A x
+  left_inv f :=
+    by
+    refine' Action.Hom.ext _ _ (Finsupp.lhom_ext' fun x : G => LinearMap.ext_ring _)
+    have :
+      f.hom ((of_mul_action k G G).ρ x (Finsupp.single (1 : G) (1 : k))) =
+        A.ρ x (f.hom (Finsupp.single (1 : G) (1 : k))) :=
+      LinearMap.ext_iff.1 (f.comm x) (Finsupp.single 1 1)
+    simp only [LinearMap.comp_apply, Finsupp.lsingle_apply, left_regular_hom_hom,
+      Finsupp.lift_apply, Finsupp.sum_single_index, one_smul, ← this, zero_smul, of_ρ_apply,
+      Representation.ofMulAction_single x (1 : G) (1 : k), smul_eq_mul, mul_one]
+  right_inv x := leftRegularHom_apply x
+#align Rep.left_regular_hom_equiv Rep.leftRegularHomEquiv
+
+theorem leftRegularHomEquiv_symm_single {A : Rep k G} (x : A) (g : G) :
+    ((leftRegularHomEquiv A).symm x).hom (Finsupp.single g 1) = A.ρ g x := by
+  simp only [left_regular_hom_equiv_symm_apply, left_regular_hom_hom, Finsupp.lift_apply,
+    Finsupp.sum_single_index, zero_smul, one_smul]
+#align Rep.left_regular_hom_equiv_symm_single Rep.leftRegularHomEquiv_symm_single
+
+end Linearization
+
+end
+
+section MonoidalClosed
+
+open Action
+
+variable [Group G] (A B C : Rep k G)
+
+/-- Given a `k`-linear `G`-representation `(A, ρ₁)`, this is the 'internal Hom' functor sending
+`(B, ρ₂)` to the representation `Homₖ(A, B)` that maps `g : G` and `f : A →ₗ[k] B` to
+`(ρ₂ g) ∘ₗ f ∘ₗ (ρ₁ g⁻¹)`. -/
+@[simps]
+protected def ihom (A : Rep k G) : Rep k G ⥤ Rep k G
+    where
+  obj B := Rep.of (Representation.linHom A.ρ B.ρ)
+  map X Y f :=
+    { hom := ModuleCat.ofHom (LinearMap.llcomp k _ _ _ f.hom)
+      comm' := fun g =>
+        LinearMap.ext fun x =>
+          LinearMap.ext fun y => show f.hom (X.ρ g _) = _ by simpa only [hom_comm_apply] }
+  map_id' B := by ext <;> rfl
+  map_comp' B C D f g := by ext <;> rfl
+#align Rep.ihom Rep.ihom
+
+@[simp]
+protected theorem ihom_obj_ρ_apply {A B : Rep k G} (g : G) (x : A →ₗ[k] B) :
+    ((Rep.ihom A).obj B).ρ g x = B.ρ g ∘ₗ x ∘ₗ A.ρ g⁻¹ :=
+  rfl
+#align Rep.ihom_obj_ρ_apply Rep.ihom_obj_ρ_apply
+
+/- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
+/-- Given a `k`-linear `G`-representation `A`, this is the Hom-set bijection in the adjunction
+`A ⊗ - ⊣ ihom(A, -)`. It sends `f : A ⊗ B ⟶ C` to a `Rep k G` morphism defined by currying the
+`k`-linear map underlying `f`, giving a map `A →ₗ[k] B →ₗ[k] C`, then flipping the arguments. -/
+@[simps]
+protected def homEquiv (A B C : Rep k G) : (A ⊗ B ⟶ C) ≃ (B ⟶ (Rep.ihom A).obj C)
+    where
+  toFun f :=
+    { hom := (TensorProduct.curry f.hom).flip
+      comm' := fun g => by
+        refine' LinearMap.ext fun x => LinearMap.ext fun y => _
+        change f.hom (_ ⊗ₜ[k] _) = C.ρ g (f.hom (_ ⊗ₜ[k] _))
+        rw [← hom_comm_apply]
+        change _ = f.hom ((A.ρ g * A.ρ g⁻¹) y ⊗ₜ[k] _)
+        simpa only [← map_mul, mul_inv_self, map_one] }
+  invFun f :=
+    { hom := TensorProduct.uncurry k _ _ _ f.hom.flip
+      comm' := fun g =>
+        TensorProduct.ext' fun x y =>
+          by
+          dsimp only [monoidal_category.tensor_left_obj, ModuleCat.comp_def, LinearMap.comp_apply,
+            tensor_rho, ModuleCat.MonoidalCategory.hom_apply, TensorProduct.map_tmul]
+          simp only [TensorProduct.uncurry_apply f.hom.flip, LinearMap.flip_apply, Action_ρ_eq_ρ,
+            hom_comm_apply f g y, Rep.ihom_obj_ρ_apply, LinearMap.comp_apply, ρ_inv_self_apply] }
+  left_inv f := Action.Hom.ext _ _ (TensorProduct.ext' fun x y => rfl)
+  right_inv f := by ext <;> rfl
+#align Rep.hom_equiv Rep.homEquiv
+
+instance : MonoidalClosed (Rep k G)
+    where closed' A :=
+    {
+      isAdj :=
+        { right := Rep.ihom A
+          adj :=
+            Adjunction.mkOfHomEquiv
+              { homEquiv := Rep.homEquiv A
+                homEquiv_naturality_left_symm := fun X Y Z f g => by ext <;> rfl
+                homEquiv_naturality_right := fun X Y Z f g => by ext <;> rfl } } }
+
+@[simp]
+theorem ihom_obj_ρ_def (A B : Rep k G) : ((ihom A).obj B).ρ = ((Rep.ihom A).obj B).ρ :=
+  rfl
+#align Rep.ihom_obj_ρ_def Rep.ihom_obj_ρ_def
+
+@[simp]
+theorem homEquiv_def (A B C : Rep k G) : (ihom.adjunction A).homEquiv B C = Rep.homEquiv A B C :=
+  rfl
+#align Rep.hom_equiv_def Rep.homEquiv_def
+
+@[simp]
+theorem ihom_ev_app_hom (A B : Rep k G) :
+    Action.Hom.hom ((ihom.ev A).app B) = TensorProduct.uncurry _ _ _ _ LinearMap.id.flip := by
+  ext <;> rfl
+#align Rep.ihom_ev_app_hom Rep.ihom_ev_app_hom
+
+@[simp]
+theorem ihom_coev_app_hom (A B : Rep k G) :
+    Action.Hom.hom ((ihom.coev A).app B) = (TensorProduct.mk _ _ _).flip := by ext <;> rfl
+#align Rep.ihom_coev_app_hom Rep.ihom_coev_app_hom
+
+variable (A B C)
+
+/- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
+/-- There is a `k`-linear isomorphism between the sets of representation morphisms`Hom(A ⊗ B, C)`
+and `Hom(B, Homₖ(A, C))`. -/
+def MonoidalClosed.linearHomEquiv : (A ⊗ B ⟶ C) ≃ₗ[k] B ⟶ A ⟶[Rep k G] C :=
+  {
+    (ihom.adjunction A).homEquiv _
+      _ with
+    map_add' := fun f g => rfl
+    map_smul' := fun r f => rfl }
+#align Rep.monoidal_closed.linear_hom_equiv Rep.MonoidalClosed.linearHomEquiv
+
+/- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
+/-- There is a `k`-linear isomorphism between the sets of representation morphisms`Hom(A ⊗ B, C)`
+and `Hom(A, Homₖ(B, C))`. -/
+def MonoidalClosed.linearHomEquivComm : (A ⊗ B ⟶ C) ≃ₗ[k] A ⟶ B ⟶[Rep k G] C :=
+  Linear.homCongr k (β_ A B) (Iso.refl _) ≪≫ₗ MonoidalClosed.linearHomEquiv _ _ _
+#align Rep.monoidal_closed.linear_hom_equiv_comm Rep.MonoidalClosed.linearHomEquivComm
+
+variable {A B C}
+
+/- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
+@[simp]
+theorem MonoidalClosed.linearHomEquiv_hom (f : A ⊗ B ⟶ C) :
+    (MonoidalClosed.linearHomEquiv A B C f).hom = (TensorProduct.curry f.hom).flip :=
+  rfl
+#align Rep.monoidal_closed.linear_hom_equiv_hom Rep.MonoidalClosed.linearHomEquiv_hom
+
+/- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
+@[simp]
+theorem MonoidalClosed.linearHomEquivComm_hom (f : A ⊗ B ⟶ C) :
+    (MonoidalClosed.linearHomEquivComm A B C f).hom = TensorProduct.curry f.hom :=
+  rfl
+#align Rep.monoidal_closed.linear_hom_equiv_comm_hom Rep.MonoidalClosed.linearHomEquivComm_hom
+
+@[simp]
+theorem MonoidalClosed.linearHomEquiv_symm_hom (f : B ⟶ A ⟶[Rep k G] C) :
+    ((MonoidalClosed.linearHomEquiv A B C).symm f).hom = TensorProduct.uncurry k A B C f.hom.flip :=
+  rfl
+#align Rep.monoidal_closed.linear_hom_equiv_symm_hom Rep.MonoidalClosed.linearHomEquiv_symm_hom
+
+@[simp]
+theorem MonoidalClosed.linearHomEquivComm_symm_hom (f : A ⟶ B ⟶[Rep k G] C) :
+    ((MonoidalClosed.linearHomEquivComm A B C).symm f).hom = TensorProduct.uncurry k A B C f.hom :=
+  by ext <;> rfl
+#align Rep.monoidal_closed.linear_hom_equiv_comm_symm_hom Rep.MonoidalClosed.linearHomEquivComm_symm_hom
+
+end MonoidalClosed
+
+end Rep
+
+namespace Representation
+
+variable {k G : Type u} [CommRing k] [Monoid G] {V W : Type u} [AddCommGroup V] [AddCommGroup W]
+  [Module k V] [Module k W] (ρ : Representation k G V) (τ : Representation k G W)
+
+/- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
+/-- Tautological isomorphism to help Lean in typechecking. -/
+def repOfTprodIso : Rep.of (ρ.tprod τ) ≅ Rep.of ρ ⊗ Rep.of τ :=
+  Iso.refl _
+#align representation.Rep_of_tprod_iso Representation.repOfTprodIso
+
+theorem repOfTprodIso_apply (x : TensorProduct k V W) : (repOfTprodIso ρ τ).hom.hom x = x :=
+  rfl
+#align representation.Rep_of_tprod_iso_apply Representation.repOfTprodIso_apply
+
+theorem repOfTprodIso_inv_apply (x : TensorProduct k V W) : (repOfTprodIso ρ τ).inv.hom x = x :=
+  rfl
+#align representation.Rep_of_tprod_iso_inv_apply Representation.repOfTprodIso_inv_apply
+
+end Representation
+
+/-!
+# The categorical equivalence `Rep k G ≌ Module.{u} (monoid_algebra k G)`.
+-/
+
+
+namespace Rep
+
+variable {k G : Type u} [CommRing k] [Monoid G]
+
+-- Verify that the symmetric monoidal structure is available.
+example : SymmetricCategory (Rep k G) := by infer_instance
+
+example : MonoidalPreadditive (Rep k G) := by infer_instance
+
+example : MonoidalLinear k (Rep k G) := by infer_instance
+
+noncomputable section
+
+/-- Auxilliary lemma for `to_Module_monoid_algebra`. -/
+theorem to_Module_monoidAlgebra_map_aux {k G : Type _} [CommRing k] [Monoid G] (V W : Type _)
+    [AddCommGroup V] [AddCommGroup W] [Module k V] [Module k W] (ρ : G →* V →ₗ[k] V)
+    (σ : G →* W →ₗ[k] W) (f : V →ₗ[k] W) (w : ∀ g : G, f.comp (ρ g) = (σ g).comp f)
+    (r : MonoidAlgebra k G) (x : V) :
+    f ((((MonoidAlgebra.lift k G (V →ₗ[k] V)) ρ) r) x) =
+      (((MonoidAlgebra.lift k G (W →ₗ[k] W)) σ) r) (f x) :=
+  by
+  apply MonoidAlgebra.induction_on r
+  · intro g
+    simp only [one_smul, MonoidAlgebra.lift_single, MonoidAlgebra.of_apply]
+    exact LinearMap.congr_fun (w g) x
+  · intro g h gw hw; simp only [map_add, add_left_inj, LinearMap.add_apply, hw, gw]
+  · intro r g w
+    simp only [AlgHom.map_smul, w, RingHom.id_apply, LinearMap.smul_apply, LinearMap.map_smulₛₗ]
+#align Rep.to_Module_monoid_algebra_map_aux Rep.to_Module_monoidAlgebra_map_aux
+
+/-- Auxilliary definition for `to_Module_monoid_algebra`. -/
+def toModuleMonoidAlgebraMap {V W : Rep k G} (f : V ⟶ W) :
+    ModuleCat.of (MonoidAlgebra k G) V.ρ.asModule ⟶ ModuleCat.of (MonoidAlgebra k G) W.ρ.asModule :=
+  { f.hom with
+    map_smul' := fun r x => to_Module_monoidAlgebra_map_aux V.V W.V V.ρ W.ρ f.hom f.comm r x }
+#align Rep.to_Module_monoid_algebra_map Rep.toModuleMonoidAlgebraMap
+
+/-- Functorially convert a representation of `G` into a module over `monoid_algebra k G`. -/
+def toModuleMonoidAlgebra : Rep k G ⥤ ModuleCat.{u} (MonoidAlgebra k G)
+    where
+  obj V := ModuleCat.of _ V.ρ.asModule
+  map V W f := toModuleMonoidAlgebraMap f
+#align Rep.to_Module_monoid_algebra Rep.toModuleMonoidAlgebra
+
+/-- Functorially convert a module over `monoid_algebra k G` into a representation of `G`. -/
+def ofModuleMonoidAlgebra : ModuleCat.{u} (MonoidAlgebra k G) ⥤ Rep k G
+    where
+  obj M := Rep.of (Representation.ofModule k G M)
+  map M N f :=
+    { hom := { f with map_smul' := fun r x => f.map_smul (algebraMap k _ r) x }
+      comm' := fun g => by ext; apply f.map_smul }
+#align Rep.of_Module_monoid_algebra Rep.ofModuleMonoidAlgebra
+
+theorem ofModuleMonoidAlgebra_obj_coe (M : ModuleCat.{u} (MonoidAlgebra k G)) :
+    (ofModuleMonoidAlgebra.obj M : Type u) = RestrictScalars k (MonoidAlgebra k G) M :=
+  rfl
+#align Rep.of_Module_monoid_algebra_obj_coe Rep.ofModuleMonoidAlgebra_obj_coe
+
+theorem ofModuleMonoidAlgebra_obj_ρ (M : ModuleCat.{u} (MonoidAlgebra k G)) :
+    (ofModuleMonoidAlgebra.obj M).ρ = Representation.ofModule k G M :=
+  rfl
+#align Rep.of_Module_monoid_algebra_obj_ρ Rep.ofModuleMonoidAlgebra_obj_ρ
+
+/-- Auxilliary definition for `equivalence_Module_monoid_algebra`. -/
+def counitIsoAddEquiv {M : ModuleCat.{u} (MonoidAlgebra k G)} :
+    (ofModuleMonoidAlgebra ⋙ toModuleMonoidAlgebra).obj M ≃+ M :=
+  by
+  dsimp [of_Module_monoid_algebra, to_Module_monoid_algebra]
+  refine' (Representation.ofModule k G ↥M).asModuleEquiv.trans (RestrictScalars.addEquiv _ _ _)
+#align Rep.counit_iso_add_equiv Rep.counitIsoAddEquiv
+
+/-- Auxilliary definition for `equivalence_Module_monoid_algebra`. -/
+def unitIsoAddEquiv {V : Rep k G} : V ≃+ (toModuleMonoidAlgebra ⋙ ofModuleMonoidAlgebra).obj V :=
+  by
+  dsimp [of_Module_monoid_algebra, to_Module_monoid_algebra]
+  refine' V.ρ.as_module_equiv.symm.trans _
+  exact (RestrictScalars.addEquiv _ _ _).symm
+#align Rep.unit_iso_add_equiv Rep.unitIsoAddEquiv
+
+/-- Auxilliary definition for `equivalence_Module_monoid_algebra`. -/
+def counitIso (M : ModuleCat.{u} (MonoidAlgebra k G)) :
+    (ofModuleMonoidAlgebra ⋙ toModuleMonoidAlgebra).obj M ≅ M :=
+  LinearEquiv.toModuleIso'
+    { counitIsoAddEquiv with
+      map_smul' := fun r x => by
+        dsimp [counit_iso_add_equiv]
+        simp }
+#align Rep.counit_iso Rep.counitIso
+
+theorem unit_iso_comm (V : Rep k G) (g : G) (x : V) :
+    unitIsoAddEquiv ((V.ρ g).toFun x) =
+      ((ofModuleMonoidAlgebra.obj (toModuleMonoidAlgebra.obj V)).ρ g).toFun (unitIsoAddEquiv x) :=
+  by
+  dsimp [unit_iso_add_equiv, of_Module_monoid_algebra, to_Module_monoid_algebra]
+  simp only [AddEquiv.apply_eq_iff_eq, AddEquiv.apply_symm_apply,
+    Representation.asModuleEquiv_symm_map_rho, Representation.ofModule_asModule_act]
+#align Rep.unit_iso_comm Rep.unit_iso_comm
+
+/-- Auxilliary definition for `equivalence_Module_monoid_algebra`. -/
+def unitIso (V : Rep k G) : V ≅ (toModuleMonoidAlgebra ⋙ ofModuleMonoidAlgebra).obj V :=
+  Action.mkIso
+    (LinearEquiv.toModuleIso'
+      { unitIsoAddEquiv with
+        map_smul' := fun r x => by
+          dsimp [unit_iso_add_equiv]
+          simp only [Representation.asModuleEquiv_symm_map_smul,
+            RestrictScalars.addEquiv_symm_map_algebraMap_smul] })
+    fun g => by ext; apply unit_iso_comm
+#align Rep.unit_iso Rep.unitIso
+
+/-- The categorical equivalence `Rep k G ≌ Module (monoid_algebra k G)`. -/
+def equivalenceModuleMonoidAlgebra : Rep k G ≌ ModuleCat.{u} (MonoidAlgebra k G)
+    where
+  Functor := toModuleMonoidAlgebra
+  inverse := ofModuleMonoidAlgebra
+  unitIso := NatIso.ofComponents (fun V => unitIso V) (by tidy)
+  counitIso := NatIso.ofComponents (fun M => counitIso M) (by tidy)
+#align Rep.equivalence_Module_monoid_algebra Rep.equivalenceModuleMonoidAlgebra
+
+-- TODO Verify that the equivalence with `Module (monoid_algebra k G)` is a monoidal functor.
+end Rep
+

--- a/Mathlib/RepresentationTheory/Rep.lean
+++ b/Mathlib/RepresentationTheory/Rep.lean
@@ -126,10 +126,12 @@ theorem trivial_def {V : Type u} [AddCommGroup V] [Module k V] (g : G) (v : V) :
   rfl
 #align Rep.trivial_def Rep.trivial_def
 
--- Verify that limits are calculated correctly.
-noncomputable example : PreservesLimits (forget₂ (Rep k G) (ModuleCat.{u} k)) := by infer_instance
+-- Porting note: the two following instances were found automatically in mathlib3
+noncomputable instance : PreservesLimits (forget₂ (Rep k G) (ModuleCat.{u} k)) :=
+  Action.instPreservesLimitsForget.{u} _ _
 
-noncomputable example : PreservesColimits (forget₂ (Rep k G) (ModuleCat.{u} k)) := by infer_instance
+noncomputable instance : PreservesColimits (forget₂ (Rep k G) (ModuleCat.{u} k)) :=
+  Action.instPreservesColimitsForget.{u} _ _
 
 @[simp]
 theorem MonoidalCategory.braiding_hom_apply {A B : Rep k G} (x : A) (y : B) :
@@ -569,4 +571,3 @@ def equivalenceModuleMonoidAlgebra : Rep k G ≌ ModuleCat.{u} (MonoidAlgebra k 
 
 -- TODO Verify that the equivalence with `Module (monoid_algebra k G)` is a monoidal functor.
 end Rep
-

--- a/Mathlib/RepresentationTheory/Rep.lean
+++ b/Mathlib/RepresentationTheory/Rep.lean
@@ -41,6 +41,7 @@ open CategoryTheory.Limits
 /-- The category of `k`-linear representations of a monoid `G`. -/
 abbrev Rep (k G : Type u) [Ring k] [Monoid G] :=
   Action (ModuleCat.{u} k) (MonCat.of G)
+set_option linter.uppercaseLean3 false in
 #align Rep Rep
 
 instance (k G : Type u) [CommRing k] [Monoid G] : Linear k (Rep k G) := by infer_instance
@@ -67,26 +68,31 @@ instance (V : Rep k G) : Module k V := by
 -/
 def ρ (V : Rep k G) : Representation k G V :=
   Action.ρ V
+set_option linter.uppercaseLean3 false in
 #align Rep.ρ Rep.ρ
 
 /-- Lift an unbundled representation to `Rep`. -/
 def of {V : Type u} [AddCommGroup V] [Module k V] (ρ : G →* V →ₗ[k] V) : Rep k G :=
   ⟨ModuleCat.of k V, ρ⟩
+set_option linter.uppercaseLean3 false in
 #align Rep.of Rep.of
 
 @[simp]
 theorem coe_of {V : Type u} [AddCommGroup V] [Module k V] (ρ : G →* V →ₗ[k] V) :
     (of ρ : Type u) = V :=
   rfl
+set_option linter.uppercaseLean3 false in
 #align Rep.coe_of Rep.coe_of
 
 @[simp]
 theorem of_ρ {V : Type u} [AddCommGroup V] [Module k V] (ρ : G →* V →ₗ[k] V) : (of ρ).ρ = ρ :=
   rfl
+set_option linter.uppercaseLean3 false in
 #align Rep.of_ρ Rep.of_ρ
 
 theorem Action_ρ_eq_ρ {A : Rep k G} : Action.ρ A = A.ρ :=
   rfl
+set_option linter.uppercaseLean3 false in
 #align Rep.Action_ρ_eq_ρ Rep.Action_ρ_eq_ρ
 
 /-- Allows us to apply lemmas about the underlying `ρ`, which would take an element `g : G` rather
@@ -94,23 +100,27 @@ than `g : MonCat.of G` as an argument. -/
 theorem of_ρ_apply {V : Type u} [AddCommGroup V] [Module k V] (ρ : Representation k G V)
     (g : MonCat.of G) : (Rep.of ρ).ρ g = ρ (g : G) :=
   rfl
+set_option linter.uppercaseLean3 false in
 #align Rep.of_ρ_apply Rep.of_ρ_apply
 
 @[simp]
 theorem ρ_inv_self_apply {G : Type u} [Group G] (A : Rep k G) (g : G) (x : A) :
     A.ρ g⁻¹ (A.ρ g x) = x :=
   show (A.ρ g⁻¹ * A.ρ g) x = x by rw [← map_mul, inv_mul_self, map_one, LinearMap.one_apply]
+set_option linter.uppercaseLean3 false in
 #align Rep.ρ_inv_self_apply Rep.ρ_inv_self_apply
 
 @[simp]
 theorem ρ_self_inv_apply {G : Type u} [Group G] {A : Rep k G} (g : G) (x : A) :
     A.ρ g (A.ρ g⁻¹ x) = x :=
   show (A.ρ g * A.ρ g⁻¹) x = x by rw [← map_mul, mul_inv_self, map_one, LinearMap.one_apply]
+set_option linter.uppercaseLean3 false in
 #align Rep.ρ_self_inv_apply Rep.ρ_self_inv_apply
 
 theorem hom_comm_apply {A B : Rep k G} (f : A ⟶ B) (g : G) (x : A) :
     f.hom (A.ρ g x) = B.ρ g (f.hom x) :=
   LinearMap.ext_iff.1 (f.comm g) x
+set_option linter.uppercaseLean3 false in
 #align Rep.hom_comm_apply Rep.hom_comm_apply
 
 variable (k G)
@@ -118,6 +128,7 @@ variable (k G)
 /-- The trivial `k`-linear `G`-representation on a `k`-module `V.` -/
 def trivial (V : Type u) [AddCommGroup V] [Module k V] : Rep k G :=
   Rep.of (@Representation.trivial k G V _ _ _ _)
+set_option linter.uppercaseLean3 false in
 #align Rep.trivial Rep.trivial
 
 variable {k G}
@@ -125,6 +136,7 @@ variable {k G}
 theorem trivial_def {V : Type u} [AddCommGroup V] [Module k V] (g : G) (v : V) :
     (trivial k G V).ρ g v = v :=
   rfl
+set_option linter.uppercaseLean3 false in
 #align Rep.trivial_def Rep.trivial_def
 
 -- Porting note: the two following instances were found automatically in mathlib3
@@ -138,12 +150,14 @@ noncomputable instance : PreservesColimits (forget₂ (Rep k G) (ModuleCat.{u} k
 theorem MonoidalCategory.braiding_hom_apply {A B : Rep k G} (x : A) (y : B) :
     Action.Hom.hom (β_ A B).hom (TensorProduct.tmul k x y) = TensorProduct.tmul k y x :=
   rfl
+set_option linter.uppercaseLean3 false in
 #align Rep.monoidal_category.braiding_hom_apply Rep.MonoidalCategory.braiding_hom_apply
 
 @[simp]
 theorem MonoidalCategory.braiding_inv_apply {A B : Rep k G} (x : A) (y : B) :
     Action.Hom.hom (β_ A B).inv (TensorProduct.tmul k y x) = TensorProduct.tmul k x y :=
   rfl
+set_option linter.uppercaseLean3 false in
 #align Rep.monoidal_category.braiding_inv_apply Rep.MonoidalCategory.braiding_inv_apply
 
 section Linearization
@@ -154,6 +168,7 @@ variable (k G)
 `G`-representation on `k[H].` -/
 noncomputable def linearization : MonoidalFunctor (Action (Type u) (MonCat.of G)) (Rep k G) :=
   (ModuleCat.monoidalFree k).mapAction (MonCat.of G)
+set_option linter.uppercaseLean3 false in
 #align Rep.linearization Rep.linearization
 
 variable {k G}
@@ -162,12 +177,14 @@ variable {k G}
 theorem linearization_obj_ρ (X : Action (Type u) (MonCat.of G)) (g : G) (x : X.V →₀ k) :
     ((linearization k G).obj X).ρ g x = Finsupp.lmapDomain k k (X.ρ g) x :=
   rfl
+set_option linter.uppercaseLean3 false in
 #align Rep.linearization_obj_ρ Rep.linearization_obj_ρ
 
 @[simp]
 theorem linearization_of (X : Action (Type u) (MonCat.of G)) (g : G) (x : X.V) :
     ((linearization k G).obj X).ρ g (Finsupp.single x (1 : k)) = Finsupp.single (X.ρ g x) (1 : k) :=
   by rw [linearization_obj_ρ, Finsupp.lmapDomain_apply, Finsupp.mapDomain_single]
+set_option linter.uppercaseLean3 false in
 #align Rep.linearization_of Rep.linearization_of
 
 -- Porting note: helps fixing `linearizationTrivialIso` since change in behaviour of ext
@@ -180,17 +197,20 @@ variable {X Y : Action (Type u) (MonCat.of G)} (f : X ⟶ Y)
 @[simp]
 theorem linearization_map_hom : ((linearization k G).map f).hom = Finsupp.lmapDomain k k f.hom :=
   rfl
+set_option linter.uppercaseLean3 false in
 #align Rep.linearization_map_hom Rep.linearization_map_hom
 
 theorem linearization_map_hom_single (x : X.V) (r : k) :
     ((linearization k G).map f).hom (Finsupp.single x r) = Finsupp.single (f.hom x) r :=
   Finsupp.mapDomain_single
+set_option linter.uppercaseLean3 false in
 #align Rep.linearization_map_hom_single Rep.linearization_map_hom_single
 
 @[simp]
 theorem linearization_μ_hom (X Y : Action (Type u) (MonCat.of G)) :
     ((linearization k G).μ X Y).hom = (finsuppTensorFinsupp' k X.V Y.V).toLinearMap :=
   rfl
+set_option linter.uppercaseLean3 false in
 #align Rep.linearization_μ_hom Rep.linearization_μ_hom
 
 -- Porting note: broken proof was
@@ -203,17 +223,20 @@ theorem linearization_μ_inv_hom (X Y : Action (Type u) (MonCat.of G)) :
   rw [← Action.forget_map, Functor.map_inv]
   apply IsIso.inv_eq_of_hom_inv_id
   exact LinearMap.ext fun x => LinearEquiv.symm_apply_apply (finsuppTensorFinsupp' k X.V Y.V) x
+set_option linter.uppercaseLean3 false in
 #align Rep.linearization_μ_inv_hom Rep.linearization_μ_inv_hom
 
 @[simp]
 theorem linearization_ε_hom : (linearization k G).ε.hom = Finsupp.lsingle PUnit.unit :=
   rfl
+set_option linter.uppercaseLean3 false in
 #align Rep.linearization_ε_hom Rep.linearization_ε_hom
 
 @[simp]
 theorem linearization_ε_inv_hom_apply (r : k) :
     (inv (linearization k G).ε).hom (Finsupp.single PUnit.unit r) = r :=
   IsIso.hom_inv_id_apply (linearization k G).ε r
+set_option linter.uppercaseLean3 false in
 #align Rep.linearization_ε_inv_hom_apply Rep.linearization_ε_inv_hom_apply
 
 variable (k G)
@@ -225,22 +248,26 @@ noncomputable def linearizationTrivialIso (X : Type u) :
     (linearization k G).obj (Action.mk X 1) ≅ trivial k G (X →₀ k) :=
   Action.mkIso (Iso.refl _) fun _ => Finsupp.lhom_ext' fun _ => LinearMap.ext
     fun _ => linearization_single ..
+set_option linter.uppercaseLean3 false in
 #align Rep.linearization_trivial_iso Rep.linearizationTrivialIso
 
 /-- Given a `G`-action on `H`, this is `k[H]` bundled with the natural representation
 `G →* End(k[H])` as a term of type `Rep k G`. -/
 noncomputable abbrev ofMulAction (H : Type u) [MulAction G H] : Rep k G :=
   of <| Representation.ofMulAction k G H
+set_option linter.uppercaseLean3 false in
 #align Rep.of_mul_action Rep.ofMulAction
 
 /-- The `k`-linear `G`-representation on `k[G]`, induced by left multiplication. -/
 noncomputable def leftRegular : Rep k G :=
   ofMulAction k G G
+set_option linter.uppercaseLean3 false in
 #align Rep.left_regular Rep.leftRegular
 
 /-- The `k`-linear `G`-representation on `k[Gⁿ]`, induced by left multiplication. -/
 noncomputable def diagonal (n : ℕ) : Rep k G :=
   ofMulAction k G (Fin n → G)
+set_option linter.uppercaseLean3 false in
 #align Rep.diagonal Rep.diagonal
 
 /-- The linearization of a type `H` with a `G`-action is definitionally isomorphic to the
@@ -248,6 +275,7 @@ noncomputable def diagonal (n : ℕ) : Rep k G :=
 noncomputable def linearizationOfMulActionIso (H : Type u) [MulAction G H] :
     (linearization k G).obj (Action.ofMulAction G H) ≅ ofMulAction k G H :=
   Iso.refl _
+set_option linter.uppercaseLean3 false in
 #align Rep.linearization_of_mul_action_iso Rep.linearizationOfMulActionIso
 
 variable {k G}
@@ -268,6 +296,7 @@ noncomputable def leftRegularHom (A : Rep k G) (x : A) : Rep.ofMulAction k G G �
     erw [Finsupp.lift_apply, Finsupp.lift_apply, Representation.ofMulAction_single (G := G)]
     simp only [Finsupp.sum_single_index, zero_smul, one_smul, smul_eq_mul, A.ρ.map_mul, of_ρ]
     rfl
+set_option linter.uppercaseLean3 false in
 #align Rep.left_regular_hom Rep.leftRegularHom
 
 theorem leftRegularHom_apply {A : Rep k G} (x : A) :
@@ -275,6 +304,7 @@ theorem leftRegularHom_apply {A : Rep k G} (x : A) :
   rw [leftRegularHom_hom, Finsupp.lift_apply, Finsupp.sum_single_index, one_smul,
     A.ρ.map_one, LinearMap.one_apply]
   · rw [zero_smul]
+set_option linter.uppercaseLean3 false in
 #align Rep.left_regular_hom_apply Rep.leftRegularHom_apply
 
 /- Porting note: in the proof of `left_inv`, the lines after `have : ... := ...` used to just be
@@ -302,6 +332,7 @@ noncomputable def leftRegularHomEquiv (A : Rep k G) : (Rep.ofMulAction k G G ⟶
     simp only [one_smul, smul_eq_mul, mul_one]
     · rw [zero_smul]
   right_inv x := leftRegularHom_apply x
+set_option linter.uppercaseLean3 false in
 #align Rep.left_regular_hom_equiv Rep.leftRegularHomEquiv
 
 theorem leftRegularHomEquiv_symm_single {A : Rep k G} (x : A) (g : G) :
@@ -309,6 +340,7 @@ theorem leftRegularHomEquiv_symm_single {A : Rep k G} (x : A) (g : G) :
   rw [leftRegularHomEquiv_symm_apply, leftRegularHom_hom, Finsupp.lift_apply,
     Finsupp.sum_single_index, one_smul]
   · rw [zero_smul]
+set_option linter.uppercaseLean3 false in
 #align Rep.left_regular_hom_equiv_symm_single Rep.leftRegularHomEquiv_symm_single
 
 end Linearization
@@ -333,12 +365,14 @@ protected def ihom (A : Rep k G) : Rep k G ⥤ Rep k G where
         simp only [hom_comm_apply]; rfl }
   map_id := fun _ => by ext; rfl
   map_comp := fun _ _ => by ext; rfl
+set_option linter.uppercaseLean3 false in
 #align Rep.ihom Rep.ihom
 
 @[simp]
 protected theorem ihom_obj_ρ_apply {A B : Rep k G} (g : G) (x : A →ₗ[k] B) :
     ((Rep.ihom A).obj B).ρ g x = B.ρ g ∘ₗ x ∘ₗ A.ρ g⁻¹ :=
   rfl
+set_option linter.uppercaseLean3 false in
 #align Rep.ihom_obj_ρ_apply Rep.ihom_obj_ρ_apply
 
 /- Porting note: the lines after `TensorProduct.ext'...` in the proof of `comm` of `invFun` were
@@ -372,6 +406,7 @@ protected def homEquiv (A B C : Rep k G) : (A ⊗ B ⟶ C) ≃ (B ⟶ (Rep.ihom 
         rfl}
   left_inv f := Action.Hom.ext _ _ (TensorProduct.ext' fun _ _ => rfl)
   right_inv f := by ext; rfl
+set_option linter.uppercaseLean3 false in
 #align Rep.hom_equiv Rep.homEquiv
 
 instance : MonoidalClosed (Rep k G) where
@@ -388,11 +423,13 @@ instance : MonoidalClosed (Rep k G) where
 @[simp]
 theorem ihom_obj_ρ_def (A B : Rep k G) : ((ihom A).obj B).ρ = ((Rep.ihom A).obj B).ρ :=
   rfl
+set_option linter.uppercaseLean3 false in
 #align Rep.ihom_obj_ρ_def Rep.ihom_obj_ρ_def
 
 @[simp]
 theorem homEquiv_def (A B C : Rep k G) : (ihom.adjunction A).homEquiv B C = Rep.homEquiv A B C :=
   rfl
+set_option linter.uppercaseLean3 false in
 #align Rep.hom_equiv_def Rep.homEquiv_def
 
 @[simp]
@@ -400,6 +437,7 @@ theorem ihom_ev_app_hom (A B : Rep k G) :
   Action.Hom.hom ((ihom.ev A).app B)
     = TensorProduct.uncurry k A (A →ₗ[k] B) B LinearMap.id.flip :=
 by ext; rfl
+set_option linter.uppercaseLean3 false in
 #align Rep.ihom_ev_app_hom Rep.ihom_ev_app_hom
 
 /- Porting note: needs extra heartbeats. -/
@@ -407,6 +445,7 @@ set_option maxHeartbeats 230000 in
 @[simp] theorem ihom_coev_app_hom (A B : Rep k G) :
     Action.Hom.hom ((ihom.coev A).app B) = (TensorProduct.mk k _ _).flip :=
   LinearMap.ext fun _ => LinearMap.ext fun _ => rfl
+set_option linter.uppercaseLean3 false in
 #align Rep.ihom_coev_app_hom Rep.ihom_coev_app_hom
 
 /- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
@@ -416,6 +455,7 @@ def MonoidalClosed.linearHomEquiv : (A ⊗ B ⟶ C) ≃ₗ[k] B ⟶ A ⟶[Rep k 
   { (ihom.adjunction A).homEquiv _ _ with
     map_add' := fun _ _ => rfl
     map_smul' := fun _ _ => rfl }
+  set_option linter.uppercaseLean3 false in
 #align Rep.monoidal_closed.linear_hom_equiv Rep.MonoidalClosed.linearHomEquiv
 
 /- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
@@ -423,6 +463,7 @@ def MonoidalClosed.linearHomEquiv : (A ⊗ B ⟶ C) ≃ₗ[k] B ⟶ A ⟶[Rep k 
 and `Hom(A, Homₖ(B, C))`. -/
 def MonoidalClosed.linearHomEquivComm : (A ⊗ B ⟶ C) ≃ₗ[k] A ⟶ B ⟶[Rep k G] C :=
   Linear.homCongr k (β_ A B) (Iso.refl _) ≪≫ₗ MonoidalClosed.linearHomEquiv _ _ _
+set_option linter.uppercaseLean3 false in
 #align Rep.monoidal_closed.linear_hom_equiv_comm Rep.MonoidalClosed.linearHomEquivComm
 
 variable {A B C}
@@ -432,6 +473,7 @@ variable {A B C}
 theorem MonoidalClosed.linearHomEquiv_hom (f : A ⊗ B ⟶ C) :
     (MonoidalClosed.linearHomEquiv A B C f).hom = (TensorProduct.curry f.hom).flip :=
   rfl
+set_option linter.uppercaseLean3 false in
 #align Rep.monoidal_closed.linear_hom_equiv_hom Rep.MonoidalClosed.linearHomEquiv_hom
 
 /- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
@@ -439,12 +481,14 @@ theorem MonoidalClosed.linearHomEquiv_hom (f : A ⊗ B ⟶ C) :
 theorem MonoidalClosed.linearHomEquivComm_hom (f : A ⊗ B ⟶ C) :
     (MonoidalClosed.linearHomEquivComm A B C f).hom = TensorProduct.curry f.hom :=
   rfl
+set_option linter.uppercaseLean3 false in
 #align Rep.monoidal_closed.linear_hom_equiv_comm_hom Rep.MonoidalClosed.linearHomEquivComm_hom
 
 @[simp]
 theorem MonoidalClosed.linearHomEquiv_symm_hom (f : B ⟶ A ⟶[Rep k G] C) :
     ((MonoidalClosed.linearHomEquiv A B C).symm f).hom = TensorProduct.uncurry k A B C f.hom.flip :=
   rfl
+set_option linter.uppercaseLean3 false in
 #align Rep.monoidal_closed.linear_hom_equiv_symm_hom Rep.MonoidalClosed.linearHomEquiv_symm_hom
 
 @[simp]
@@ -452,6 +496,7 @@ theorem MonoidalClosed.linearHomEquivComm_symm_hom (f : A ⟶ B ⟶[Rep k G] C) 
     ((MonoidalClosed.linearHomEquivComm A B C).symm f).hom
       = TensorProduct.uncurry k A B C f.hom :=
   TensorProduct.ext' fun _ _ => rfl
+set_option linter.uppercaseLean3 false in
 #align Rep.monoidal_closed.linear_hom_equiv_comm_symm_hom Rep.MonoidalClosed.linearHomEquivComm_symm_hom
 
 end MonoidalClosed
@@ -467,14 +512,17 @@ variable {k G : Type u} [CommRing k] [Monoid G] {V W : Type u} [AddCommGroup V] 
 /-- Tautological isomorphism to help Lean in typechecking. -/
 def repOfTprodIso : Rep.of (ρ.tprod τ) ≅ Rep.of ρ ⊗ Rep.of τ :=
   Iso.refl _
+set_option linter.uppercaseLean3 false in
 #align representation.Rep_of_tprod_iso Representation.repOfTprodIso
 
 theorem repOfTprodIso_apply (x : TensorProduct k V W) : (repOfTprodIso ρ τ).hom.hom x = x :=
   rfl
+set_option linter.uppercaseLean3 false in
 #align representation.Rep_of_tprod_iso_apply Representation.repOfTprodIso_apply
 
 theorem repOfTprodIso_inv_apply (x : TensorProduct k V W) : (repOfTprodIso ρ τ).inv.hom x = x :=
   rfl
+set_option linter.uppercaseLean3 false in
 #align representation.Rep_of_tprod_iso_inv_apply Representation.repOfTprodIso_inv_apply
 
 end Representation
@@ -511,6 +559,7 @@ theorem to_Module_monoidAlgebra_map_aux {k G : Type _} [CommRing k] [Monoid G] (
   · intro g h gw hw; simp only [map_add, add_left_inj, LinearMap.add_apply, hw, gw]
   · intro r g w
     simp only [AlgHom.map_smul, w, RingHom.id_apply, LinearMap.smul_apply, LinearMap.map_smulₛₗ]
+set_option linter.uppercaseLean3 false in
 #align Rep.to_Module_monoid_algebra_map_aux Rep.to_Module_monoidAlgebra_map_aux
 
 /-- Auxilliary definition for `to_Module_monoid_algebra`. -/
@@ -518,12 +567,14 @@ def toModuleMonoidAlgebraMap {V W : Rep k G} (f : V ⟶ W) :
     ModuleCat.of (MonoidAlgebra k G) V.ρ.asModule ⟶ ModuleCat.of (MonoidAlgebra k G) W.ρ.asModule :=
   { f.hom with
     map_smul' := fun r x => to_Module_monoidAlgebra_map_aux V.V W.V V.ρ W.ρ f.hom f.comm r x }
+set_option linter.uppercaseLean3 false in
 #align Rep.to_Module_monoid_algebra_map Rep.toModuleMonoidAlgebraMap
 
 /-- Functorially convert a representation of `G` into a module over `MonoidAlgebra k G`. -/
 def toModuleMonoidAlgebra : Rep k G ⥤ ModuleCat.{u} (MonoidAlgebra k G) where
   obj V := ModuleCat.of _ V.ρ.asModule
   map f := toModuleMonoidAlgebraMap f
+set_option linter.uppercaseLean3 false in
 #align Rep.to_Module_monoid_algebra Rep.toModuleMonoidAlgebra
 
 /-- Functorially convert a module over `MonoidAlgebra k G` into a representation of `G`. -/
@@ -532,16 +583,19 @@ def ofModuleMonoidAlgebra : ModuleCat.{u} (MonoidAlgebra k G) ⥤ Rep k G where
   map f :=
     { hom := { f with map_smul' := fun r x => f.map_smul (algebraMap k _ r) x }
       comm := fun g => by ext; apply f.map_smul }
+set_option linter.uppercaseLean3 false in
 #align Rep.of_Module_monoid_algebra Rep.ofModuleMonoidAlgebra
 
 theorem ofModuleMonoidAlgebra_obj_coe (M : ModuleCat.{u} (MonoidAlgebra k G)) :
     (ofModuleMonoidAlgebra.obj M : Type u) = RestrictScalars k (MonoidAlgebra k G) M :=
   rfl
+set_option linter.uppercaseLean3 false in
 #align Rep.of_Module_monoid_algebra_obj_coe Rep.ofModuleMonoidAlgebra_obj_coe
 
 theorem ofModuleMonoidAlgebra_obj_ρ (M : ModuleCat.{u} (MonoidAlgebra k G)) :
     (ofModuleMonoidAlgebra.obj M).ρ = Representation.ofModule M :=
   rfl
+set_option linter.uppercaseLean3 false in
 #align Rep.of_Module_monoid_algebra_obj_ρ Rep.ofModuleMonoidAlgebra_obj_ρ
 
 /-- Auxilliary definition for `equivalence_Module_monoid_algebra`. -/
@@ -550,6 +604,7 @@ def counitIsoAddEquiv {M : ModuleCat.{u} (MonoidAlgebra k G)} :
   dsimp [ofModuleMonoidAlgebra, toModuleMonoidAlgebra]
   refine' (Representation.ofModule M).asModuleEquiv.trans
     (RestrictScalars.addEquiv k (MonoidAlgebra k G) _)
+set_option linter.uppercaseLean3 false in
 #align Rep.counit_iso_add_equiv Rep.counitIsoAddEquiv
 
 /-- Auxilliary definition for `equivalence_Module_monoid_algebra`. -/
@@ -557,6 +612,7 @@ def unitIsoAddEquiv {V : Rep k G} : V ≃+ (toModuleMonoidAlgebra ⋙ ofModuleMo
   dsimp [ofModuleMonoidAlgebra, toModuleMonoidAlgebra]
   refine' V.ρ.asModuleEquiv.symm.trans _
   exact (RestrictScalars.addEquiv _ _ _).symm
+set_option linter.uppercaseLean3 false in
 #align Rep.unit_iso_add_equiv Rep.unitIsoAddEquiv
 
 /- Porting note: in the proof of `map_smul'`, the lines after `dsimp` used to just be one `simp`. -/
@@ -570,6 +626,7 @@ def counitIso (M : ModuleCat.{u} (MonoidAlgebra k G)) :
         rw [AddEquiv.coe_toEquiv, AddEquiv.trans_apply]
         erw [Representation.ofModule_asAlgebraHom_apply_apply]
         exact AddEquiv.symm_apply_apply _ _}
+set_option linter.uppercaseLean3 false in
 #align Rep.counit_iso Rep.counitIso
 
 theorem unit_iso_comm (V : Rep k G) (g : G) (x : V) :
@@ -578,6 +635,7 @@ theorem unit_iso_comm (V : Rep k G) (g : G) (x : V) :
   dsimp [unitIsoAddEquiv, ofModuleMonoidAlgebra, toModuleMonoidAlgebra]
   erw [Representation.asModuleEquiv_symm_map_rho]
   rfl
+set_option linter.uppercaseLean3 false in
 #align Rep.unit_iso_comm Rep.unit_iso_comm
 
 /- Porting note: in the proof of `map_smul'`, the lines after `dsimp [unitIsoAddEquiv]` were
@@ -596,6 +654,7 @@ def unitIso (V : Rep k G) : V ≅ (toModuleMonoidAlgebra ⋙ ofModuleMonoidAlgeb
             RestrictScalars.addEquiv_symm_map_algebraMap_smul]
           rfl })
     fun g => by ext; apply unit_iso_comm
+set_option linter.uppercaseLean3 false in
 #align Rep.unit_iso Rep.unitIso
 
 /-- The categorical equivalence `Rep k G ≌ ModuleCat (MonoidAlgebra k G)`. -/
@@ -604,6 +663,7 @@ def equivalenceModuleMonoidAlgebra : Rep k G ≌ ModuleCat.{u} (MonoidAlgebra k 
   inverse := ofModuleMonoidAlgebra
   unitIso := NatIso.ofComponents (fun V => unitIso V) (by aesop_cat)
   counitIso := NatIso.ofComponents (fun M => counitIso M) (by aesop_cat)
+set_option linter.uppercaseLean3 false in
 #align Rep.equivalence_Module_monoid_algebra Rep.equivalenceModuleMonoidAlgebra
 
 -- TODO Verify that the equivalence with `ModuleCat (MonoidAlgebra k G)` is a monoidal functor.

--- a/Mathlib/RepresentationTheory/Rep.lean
+++ b/Mathlib/RepresentationTheory/Rep.lean
@@ -370,8 +370,7 @@ protected def ihom (A : Rep k G) : Rep k G ⥤ Rep k G where
 set_option linter.uppercaseLean3 false in
 #align Rep.ihom Rep.ihom
 
-@[simp]
-protected theorem ihom_obj_ρ_apply {A B : Rep k G} (g : G) (x : A →ₗ[k] B) :
+@[simp] theorem ihom_obj_ρ_apply {A B : Rep k G} (g : G) (x : A →ₗ[k] B) :
     ((Rep.ihom A).obj B).ρ g x = B.ρ g ∘ₗ x ∘ₗ A.ρ g⁻¹ :=
   rfl
 set_option linter.uppercaseLean3 false in
@@ -381,8 +380,7 @@ set_option linter.uppercaseLean3 false in
 /-- Given a `k`-linear `G`-representation `A`, this is the Hom-set bijection in the adjunction
 `A ⊗ - ⊣ ihom(A, -)`. It sends `f : A ⊗ B ⟶ C` to a `Rep k G` morphism defined by currying the
 `k`-linear map underlying `f`, giving a map `A →ₗ[k] B →ₗ[k] C`, then flipping the arguments. -/
-@[simps]
-protected def homEquiv (A B C : Rep k G) : (A ⊗ B ⟶ C) ≃ (B ⟶ (Rep.ihom A).obj C) where
+@[simps] def homEquiv (A B C : Rep k G) : (A ⊗ B ⟶ C) ≃ (B ⟶ (Rep.ihom A).obj C) where
   toFun f :=
     { hom := (TensorProduct.curry f.hom).flip
       comm := fun g => by

--- a/Mathlib/RepresentationTheory/Rep.lean
+++ b/Mathlib/RepresentationTheory/Rep.lean
@@ -20,13 +20,13 @@ import Mathlib.CategoryTheory.Closed.FunctorCategory
 # `Rep k G` is the category of `k`-linear representations of `G`.
 
 If `V : Rep k G`, there is a coercion that allows you to treat `V` as a type,
-and this type comes equipped with a `module k V` instance.
+and this type comes equipped with a `Module k V` instance.
 Also `V.ρ` gives the homomorphism `G →* (V →ₗ[k] V)`.
 
 Conversely, given a homomorphism `ρ : G →* (V →ₗ[k] V)`,
 you can construct the bundled representation as `Rep.of ρ`.
 
-We construct the categorical equivalence `Rep k G ≌ Module (monoid_algebra k G)`.
+We construct the categorical equivalence `Rep k G ≌ ModuleCat (MonoidAlgebra k G)`.
 We verify that `Rep k G` is a `k`-linear abelian symmetric monoidal category with all (co)limits.
 -/
 
@@ -63,7 +63,7 @@ instance (V : Rep k G) : Module k V := by
   change Module k ((forget₂ (Rep k G) (ModuleCat k)).obj V)
   infer_instance
 
-/-- Specialize the existing `Action.ρ`, changing the type to `representation k G V`.
+/-- Specialize the existing `Action.ρ`, changing the type to `Representation k G V`.
 -/
 def ρ (V : Rep k G) : Representation k G V :=
   Action.ρ V
@@ -90,7 +90,7 @@ theorem Action_ρ_eq_ρ {A : Rep k G} : Action.ρ A = A.ρ :=
 #align Rep.Action_ρ_eq_ρ Rep.Action_ρ_eq_ρ
 
 /-- Allows us to apply lemmas about the underlying `ρ`, which would take an element `g : G` rather
-than `g : Mon.of G` as an argument. -/
+than `g : MonCat.of G` as an argument. -/
 theorem of_ρ_apply {V : Type u} [AddCommGroup V] [Module k V] (ρ : Representation k G V)
     (g : MonCat.of G) : (Rep.of ρ).ρ g = ρ (g : G) :=
   rfl
@@ -480,7 +480,7 @@ theorem repOfTprodIso_inv_apply (x : TensorProduct k V W) : (repOfTprodIso ρ τ
 end Representation
 
 /-!
-# The categorical equivalence `Rep k G ≌ Module.{u} (monoid_algebra k G)`.
+# The categorical equivalence `Rep k G ≌ Module.{u} (MonoidAlgebra k G)`.
 -/
 
 
@@ -520,13 +520,13 @@ def toModuleMonoidAlgebraMap {V W : Rep k G} (f : V ⟶ W) :
     map_smul' := fun r x => to_Module_monoidAlgebra_map_aux V.V W.V V.ρ W.ρ f.hom f.comm r x }
 #align Rep.to_Module_monoid_algebra_map Rep.toModuleMonoidAlgebraMap
 
-/-- Functorially convert a representation of `G` into a module over `monoid_algebra k G`. -/
+/-- Functorially convert a representation of `G` into a module over `MonoidAlgebra k G`. -/
 def toModuleMonoidAlgebra : Rep k G ⥤ ModuleCat.{u} (MonoidAlgebra k G) where
   obj V := ModuleCat.of _ V.ρ.asModule
   map f := toModuleMonoidAlgebraMap f
 #align Rep.to_Module_monoid_algebra Rep.toModuleMonoidAlgebra
 
-/-- Functorially convert a module over `monoid_algebra k G` into a representation of `G`. -/
+/-- Functorially convert a module over `MonoidAlgebra k G` into a representation of `G`. -/
 def ofModuleMonoidAlgebra : ModuleCat.{u} (MonoidAlgebra k G) ⥤ Rep k G where
   obj M := Rep.of (Representation.ofModule M)
   map f :=
@@ -598,7 +598,7 @@ def unitIso (V : Rep k G) : V ≅ (toModuleMonoidAlgebra ⋙ ofModuleMonoidAlgeb
     fun g => by ext; apply unit_iso_comm
 #align Rep.unit_iso Rep.unitIso
 
-/-- The categorical equivalence `Rep k G ≌ Module (monoid_algebra k G)`. -/
+/-- The categorical equivalence `Rep k G ≌ ModuleCat (MonoidAlgebra k G)`. -/
 def equivalenceModuleMonoidAlgebra : Rep k G ≌ ModuleCat.{u} (MonoidAlgebra k G) where
   functor := toModuleMonoidAlgebra
   inverse := ofModuleMonoidAlgebra
@@ -606,5 +606,5 @@ def equivalenceModuleMonoidAlgebra : Rep k G ≌ ModuleCat.{u} (MonoidAlgebra k 
   counitIso := NatIso.ofComponents (fun M => counitIso M) (by aesop_cat)
 #align Rep.equivalence_Module_monoid_algebra Rep.equivalenceModuleMonoidAlgebra
 
--- TODO Verify that the equivalence with `Module (monoid_algebra k G)` is a monoidal functor.
+-- TODO Verify that the equivalence with `ModuleCat (MonoidAlgebra k G)` is a monoidal functor.
 end

--- a/Mathlib/RepresentationTheory/Rep.lean
+++ b/Mathlib/RepresentationTheory/Rep.lean
@@ -389,7 +389,7 @@ simp only [TensorProduct.uncurry_apply f.hom.flip, LinearMap.flip_apply, Action_
 /-- Given a `k`-linear `G`-representation `A`, this is the Hom-set bijection in the adjunction
 `A ⊗ - ⊣ ihom(A, -)`. It sends `f : A ⊗ B ⟶ C` to a `Rep k G` morphism defined by currying the
 `k`-linear map underlying `f`, giving a map `A →ₗ[k] B →ₗ[k] C`, then flipping the arguments. -/
-@[simps, nolint simpNF]
+@[simps]
 protected def homEquiv (A B C : Rep k G) : (A ⊗ B ⟶ C) ≃ (B ⟶ (Rep.ihom A).obj C) where
   toFun f :=
     { hom := (TensorProduct.curry f.hom).flip
@@ -412,6 +412,8 @@ protected def homEquiv (A B C : Rep k G) : (A ⊗ B ⟶ C) ≃ (B ⟶ (Rep.ihom 
   right_inv f := by ext; rfl
 set_option linter.uppercaseLean3 false in
 #align Rep.hom_equiv Rep.homEquiv
+
+attribute [nolint simpNF] Rep.homEquiv_apply_hom Rep.homEquiv_symm_apply_hom
 
 instance : MonoidalClosed (Rep k G) where
   closed := fun A =>

--- a/Mathlib/RepresentationTheory/Rep.lean
+++ b/Mathlib/RepresentationTheory/Rep.lean
@@ -14,7 +14,6 @@ import Mathlib.Algebra.Category.ModuleCat.Abelian
 import Mathlib.Algebra.Category.ModuleCat.Colimits
 import Mathlib.Algebra.Category.ModuleCat.Monoidal.Closed
 import Mathlib.Algebra.Category.ModuleCat.Adjunctions
-import Mathlib.CategoryTheory.Closed.FunctorCategory
 
 /-!
 # `Rep k G` is the category of `k`-linear representations of `G`.
@@ -66,6 +65,7 @@ instance (V : Rep k G) : Module k V := by
 /-- Specialize the existing `Action.ρ`, changing the type to `Representation k G V`.
 -/
 def ρ (V : Rep k G) : Representation k G V :=
+-- porting note: was `V.ρ`
   Action.ρ V
 set_option linter.uppercaseLean3 false in
 #align Rep.ρ Rep.ρ
@@ -543,7 +543,7 @@ example : MonoidalLinear k (Rep k G) := by infer_instance
 
 noncomputable section
 
-/-- Auxilliary lemma for `to_Module_monoid_algebra`. -/
+/-- Auxiliary lemma for `to_Module_monoid_algebra`. -/
 theorem to_Module_monoidAlgebra_map_aux {k G : Type _} [CommRing k] [Monoid G] (V W : Type _)
     [AddCommGroup V] [AddCommGroup W] [Module k V] [Module k W] (ρ : G →* V →ₗ[k] V)
     (σ : G →* W →ₗ[k] W) (f : V →ₗ[k] W) (w : ∀ g : G, f.comp (ρ g) = (σ g).comp f)
@@ -560,7 +560,7 @@ theorem to_Module_monoidAlgebra_map_aux {k G : Type _} [CommRing k] [Monoid G] (
 set_option linter.uppercaseLean3 false in
 #align Rep.to_Module_monoid_algebra_map_aux Rep.to_Module_monoidAlgebra_map_aux
 
-/-- Auxilliary definition for `to_Module_monoid_algebra`. -/
+/-- Auxiliary definition for `to_Module_monoid_algebra`. -/
 def toModuleMonoidAlgebraMap {V W : Rep k G} (f : V ⟶ W) :
     ModuleCat.of (MonoidAlgebra k G) V.ρ.asModule ⟶ ModuleCat.of (MonoidAlgebra k G) W.ρ.asModule :=
   { f.hom with
@@ -596,7 +596,7 @@ theorem ofModuleMonoidAlgebra_obj_ρ (M : ModuleCat.{u} (MonoidAlgebra k G)) :
 set_option linter.uppercaseLean3 false in
 #align Rep.of_Module_monoid_algebra_obj_ρ Rep.ofModuleMonoidAlgebra_obj_ρ
 
-/-- Auxilliary definition for `equivalence_Module_monoid_algebra`. -/
+/-- Auxiliary definition for `equivalence_Module_monoid_algebra`. -/
 def counitIsoAddEquiv {M : ModuleCat.{u} (MonoidAlgebra k G)} :
     (ofModuleMonoidAlgebra ⋙ toModuleMonoidAlgebra).obj M ≃+ M := by
   dsimp [ofModuleMonoidAlgebra, toModuleMonoidAlgebra]
@@ -605,7 +605,7 @@ def counitIsoAddEquiv {M : ModuleCat.{u} (MonoidAlgebra k G)} :
 set_option linter.uppercaseLean3 false in
 #align Rep.counit_iso_add_equiv Rep.counitIsoAddEquiv
 
-/-- Auxilliary definition for `equivalence_Module_monoid_algebra`. -/
+/-- Auxiliary definition for `equivalence_Module_monoid_algebra`. -/
 def unitIsoAddEquiv {V : Rep k G} : V ≃+ (toModuleMonoidAlgebra ⋙ ofModuleMonoidAlgebra).obj V := by
   dsimp [ofModuleMonoidAlgebra, toModuleMonoidAlgebra]
   refine' V.ρ.asModuleEquiv.symm.trans _
@@ -613,7 +613,7 @@ def unitIsoAddEquiv {V : Rep k G} : V ≃+ (toModuleMonoidAlgebra ⋙ ofModuleMo
 set_option linter.uppercaseLean3 false in
 #align Rep.unit_iso_add_equiv Rep.unitIsoAddEquiv
 
-/-- Auxilliary definition for `equivalenceModuleMonoidAlgebra`. -/
+/-- Auxiliary definition for `equivalenceModuleMonoidAlgebra`. -/
 def counitIso (M : ModuleCat.{u} (MonoidAlgebra k G)) :
     (ofModuleMonoidAlgebra ⋙ toModuleMonoidAlgebra).obj M ≅ M :=
   LinearEquiv.toModuleIso'
@@ -631,12 +631,15 @@ theorem unit_iso_comm (V : Rep k G) (g : G) (x : V) :
     unitIsoAddEquiv ((V.ρ g).toFun x) = ((ofModuleMonoidAlgebra.obj
       (toModuleMonoidAlgebra.obj V)).ρ g).toFun (unitIsoAddEquiv x) := by
   dsimp [unitIsoAddEquiv, ofModuleMonoidAlgebra, toModuleMonoidAlgebra]
+/- Porting note: rest of broken proof was
+  simp only [AddEquiv.apply_eq_iff_eq, AddEquiv.apply_symm_apply,
+    Representation.asModuleEquiv_symm_map_rho, Representation.ofModule_asModule_act] -/
   erw [Representation.asModuleEquiv_symm_map_rho]
   rfl
 set_option linter.uppercaseLean3 false in
 #align Rep.unit_iso_comm Rep.unit_iso_comm
 
-/-- Auxilliary definition for `equivalenceModuleMonoidAlgebra`. -/
+/-- Auxiliary definition for `equivalenceModuleMonoidAlgebra`. -/
 def unitIso (V : Rep k G) : V ≅ (toModuleMonoidAlgebra ⋙ ofModuleMonoidAlgebra).obj V :=
   Action.mkIso
     (LinearEquiv.toModuleIso'

--- a/Mathlib/RepresentationTheory/Rep.lean
+++ b/Mathlib/RepresentationTheory/Rep.lean
@@ -359,7 +359,7 @@ variable [Group G] (A B C : Rep k G)
 protected def ihom (A : Rep k G) : Rep k G ⥤ Rep k G where
   obj B := Rep.of (Representation.linHom A.ρ B.ρ)
   map := fun {X} {Y} f =>
-    { hom := ModuleCat.ofHom (LinearMap.llcomp k _ _ _ f.hom),
+    { hom := ModuleCat.ofHom (LinearMap.llcomp k _ _ _ f.hom)
       comm := fun g => LinearMap.ext fun x => LinearMap.ext fun y => by
         show f.hom (X.ρ g _) = _
         simp only [hom_comm_apply]; rfl }
@@ -414,7 +414,7 @@ instance : MonoidalClosed (Rep k G) where
   { isAdj :=
     { right := Rep.ihom A
       adj := Adjunction.mkOfHomEquiv (
-      { homEquiv := Rep.homEquiv A,
+      { homEquiv := Rep.homEquiv A
         homEquiv_naturality_left_symm := fun _ _ => Action.Hom.ext _ _
           (TensorProduct.ext' fun _ _ => rfl)
         homEquiv_naturality_right := fun _ _ => Action.Hom.ext _ _ (LinearMap.ext
@@ -434,9 +434,9 @@ set_option linter.uppercaseLean3 false in
 
 @[simp]
 theorem ihom_ev_app_hom (A B : Rep k G) :
-  Action.Hom.hom ((ihom.ev A).app B)
-    = TensorProduct.uncurry k A (A →ₗ[k] B) B LinearMap.id.flip :=
-by ext; rfl
+    Action.Hom.hom ((ihom.ev A).app B)
+      = TensorProduct.uncurry k A (A →ₗ[k] B) B LinearMap.id.flip := by
+  ext; rfl
 set_option linter.uppercaseLean3 false in
 #align Rep.ihom_ev_app_hom Rep.ihom_ev_app_hom
 

--- a/Mathlib/RepresentationTheory/Rep.lean
+++ b/Mathlib/RepresentationTheory/Rep.lean
@@ -146,14 +146,17 @@ noncomputable instance : PreservesLimits (forget₂ (Rep k G) (ModuleCat.{u} k))
 noncomputable instance : PreservesColimits (forget₂ (Rep k G) (ModuleCat.{u} k)) :=
   Action.instPreservesColimitsForget.{u} _ _
 
-@[simp]
+/- Porting note: linter informs me the LHS simplifies to... itself.
+But fwiw I also can't get simp to use this lemma. -/
+@[simp, nolint simpNF]
 theorem MonoidalCategory.braiding_hom_apply {A B : Rep k G} (x : A) (y : B) :
     Action.Hom.hom (β_ A B).hom (TensorProduct.tmul k x y) = TensorProduct.tmul k y x :=
   rfl
 set_option linter.uppercaseLean3 false in
 #align Rep.monoidal_category.braiding_hom_apply Rep.MonoidalCategory.braiding_hom_apply
 
-@[simp]
+/- Porting note: same note as above. -/
+@[simp, nolint simpNF]
 theorem MonoidalCategory.braiding_inv_apply {A B : Rep k G} (x : A) (y : B) :
     Action.Hom.hom (β_ A B).inv (TensorProduct.tmul k y x) = TensorProduct.tmul k x y :=
   rfl
@@ -180,10 +183,10 @@ theorem linearization_obj_ρ (X : Action (Type u) (MonCat.of G)) (g : G) (x : X.
 set_option linter.uppercaseLean3 false in
 #align Rep.linearization_obj_ρ Rep.linearization_obj_ρ
 
-@[simp]
 theorem linearization_of (X : Action (Type u) (MonCat.of G)) (g : G) (x : X.V) :
-    ((linearization k G).obj X).ρ g (Finsupp.single x (1 : k)) = Finsupp.single (X.ρ g x) (1 : k) :=
-  by rw [linearization_obj_ρ, Finsupp.lmapDomain_apply, Finsupp.mapDomain_single]
+    ((linearization k G).obj X).ρ g (Finsupp.single x (1 : k))
+      = Finsupp.single (X.ρ g x) (1 : k) := by
+  rw [linearization_obj_ρ, Finsupp.lmapDomain_apply, Finsupp.mapDomain_single]
 set_option linter.uppercaseLean3 false in
 #align Rep.linearization_of Rep.linearization_of
 
@@ -381,11 +384,12 @@ dsimp only [monoidal_category.tensor_left_obj, ModuleCat.comp_def, LinearMap.com
   tensor_rho, ModuleCat.MonoidalCategory.hom_apply, TensorProduct.map_tmul]
 simp only [TensorProduct.uncurry_apply f.hom.flip, LinearMap.flip_apply, Action_ρ_eq_ρ,
   hom_comm_apply f g y, Rep.ihom_obj_ρ_apply, LinearMap.comp_apply, ρ_inv_self_apply] -/
+/- Porting note: the linter simplifies some of the LHSs of the `simps` lemmas to themselves. -/
 /- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
 /-- Given a `k`-linear `G`-representation `A`, this is the Hom-set bijection in the adjunction
 `A ⊗ - ⊣ ihom(A, -)`. It sends `f : A ⊗ B ⟶ C` to a `Rep k G` morphism defined by currying the
 `k`-linear map underlying `f`, giving a map `A →ₗ[k] B →ₗ[k] C`, then flipping the arguments. -/
-@[simps]
+@[simps, nolint simpNF]
 protected def homEquiv (A B C : Rep k G) : (A ⊗ B ⟶ C) ≃ (B ⟶ (Rep.ihom A).obj C) where
   toFun f :=
     { hom := (TensorProduct.curry f.hom).flip

--- a/Mathlib/RepresentationTheory/Rep.lean
+++ b/Mathlib/RepresentationTheory/Rep.lean
@@ -223,8 +223,8 @@ on `k[X]`. -/
 @[simps!]
 noncomputable def linearizationTrivialIso (X : Type u) :
     (linearization k G).obj (Action.mk X 1) ≅ trivial k G (X →₀ k) :=
-  Action.mkIso (Iso.refl _) fun _ => Finsupp.lhom_ext' (fun _ => LinearMap.ext
-    (fun _ => linearization_single ..))
+  Action.mkIso (Iso.refl _) fun _ => Finsupp.lhom_ext' fun _ => LinearMap.ext
+    fun _ => linearization_single ..
 #align Rep.linearization_trivial_iso Rep.linearizationTrivialIso
 
 /-- Given a `G`-action on `H`, this is `k[H]` bundled with the natural representation
@@ -319,7 +319,7 @@ section MonoidalClosed
 open MonoidalCategory Action
 
 variable [Group G] (A B C : Rep k G)
-set_option profiler true
+
 /-- Given a `k`-linear `G`-representation `(A, ρ₁)`, this is the 'internal Hom' functor sending
 `(B, ρ₂)` to the representation `Homₖ(A, B)` that maps `g : G` and `f : A →ₗ[k] B` to
 `(ρ₂ g) ∘ₗ f ∘ₗ (ρ₁ g⁻¹)`. -/
@@ -328,9 +328,9 @@ protected def ihom (A : Rep k G) : Rep k G ⥤ Rep k G where
   obj B := Rep.of (Representation.linHom A.ρ B.ρ)
   map := fun {X} {Y} f =>
     { hom := ModuleCat.ofHom (LinearMap.llcomp k _ _ _ f.hom),
-      comm := fun g => LinearMap.ext (fun x => LinearMap.ext (fun y => by
+      comm := fun g => LinearMap.ext fun x => LinearMap.ext fun y => by
         show f.hom (X.ρ g _) = _
-        simp only [hom_comm_apply]; rfl)) }
+        simp only [hom_comm_apply]; rfl }
   map_id := fun _ => by ext; rfl
   map_comp := fun _ _ => by ext; rfl
 #align Rep.ihom Rep.ihom
@@ -356,7 +356,7 @@ protected def homEquiv (A B C : Rep k G) : (A ⊗ B ⟶ C) ≃ (B ⟶ (Rep.ihom 
   toFun f :=
     { hom := (TensorProduct.curry f.hom).flip
       comm := fun g => by
-        refine' LinearMap.ext (fun x => LinearMap.ext (fun y => _))
+        refine' LinearMap.ext fun x => LinearMap.ext fun y => _
         change f.hom (_ ⊗ₜ[k] _) = C.ρ g (f.hom (_ ⊗ₜ[k] _))
         rw [←hom_comm_apply]
         change _ = f.hom ((A.ρ g * A.ρ g⁻¹) y ⊗ₜ[k] _)
@@ -364,12 +364,12 @@ protected def homEquiv (A B C : Rep k G) : (A ⊗ B ⟶ C) ≃ (B ⟶ (Rep.ihom 
         rfl }
   invFun f :=
     { hom := TensorProduct.uncurry k _ _ _ f.hom.flip
-      comm := fun g => TensorProduct.ext' (fun x y => by
+      comm := fun g => TensorProduct.ext' fun x y => by
         change TensorProduct.uncurry k _ _ _ f.hom.flip (A.ρ g x ⊗ₜ[k] B.ρ g y) =
           C.ρ g (TensorProduct.uncurry k _ _ _ f.hom.flip (x ⊗ₜ[k] y))
         rw [TensorProduct.uncurry_apply, LinearMap.flip_apply, hom_comm_apply, Rep.ihom_obj_ρ_apply,
           LinearMap.comp_apply, LinearMap.comp_apply, ρ_inv_self_apply]
-        rfl)}
+        rfl}
   left_inv f := Action.Hom.ext _ _ (TensorProduct.ext' fun _ _ => rfl)
   right_inv f := by ext; rfl
 #align Rep.hom_equiv Rep.homEquiv
@@ -381,9 +381,9 @@ instance : MonoidalClosed (Rep k G) where
       adj := Adjunction.mkOfHomEquiv (
       { homEquiv := Rep.homEquiv A,
         homEquiv_naturality_left_symm := fun _ _ => Action.Hom.ext _ _
-          (TensorProduct.ext' (fun _ _ => rfl))
+          (TensorProduct.ext' fun _ _ => rfl)
         homEquiv_naturality_right := fun _ _ => Action.Hom.ext _ _ (LinearMap.ext
-          (fun _ => LinearMap.ext (fun _ => rfl))) }) } }
+          fun _ => LinearMap.ext fun _ => rfl) })}}
 
 @[simp]
 theorem ihom_obj_ρ_def (A B : Rep k G) : ((ihom A).obj B).ρ = ((Rep.ihom A).obj B).ρ :=

--- a/Mathlib/RepresentationTheory/Rep.lean
+++ b/Mathlib/RepresentationTheory/Rep.lean
@@ -147,7 +147,7 @@ noncomputable instance : PreservesColimits (forget₂ (Rep k G) (ModuleCat.{u} k
 
 /- Porting note: linter informs me the LHS simplifies to... itself.
 But fwiw I also can't get simp to use this lemma. -/
-@[simp]
+@[simp, nolint simpNF]
 theorem MonoidalCategory.braiding_hom_apply {A B : Rep k G} (x : A) (y : B) :
     Action.Hom.hom (β_ A B).hom (TensorProduct.tmul k x y) = TensorProduct.tmul k y x :=
   rfl

--- a/Mathlib/RepresentationTheory/Rep.lean
+++ b/Mathlib/RepresentationTheory/Rep.lean
@@ -37,7 +37,6 @@ open CategoryTheory
 
 open CategoryTheory.Limits
 
-/- ./././Mathport/Syntax/Translate/Command.lean:328:31: unsupported: @[derive] abbrev -/
 /-- The category of `k`-linear representations of a monoid `G`. -/
 abbrev Rep (k G : Type u) [Ring k] [Monoid G] :=
   Action (ModuleCat.{u} k) (MonCat.of G)
@@ -148,14 +147,15 @@ noncomputable instance : PreservesColimits (forget₂ (Rep k G) (ModuleCat.{u} k
 
 /- Porting note: linter informs me the LHS simplifies to... itself.
 But fwiw I also can't get simp to use this lemma. -/
-@[simp, nolint simpNF]
+@[simp]
 theorem MonoidalCategory.braiding_hom_apply {A B : Rep k G} (x : A) (y : B) :
     Action.Hom.hom (β_ A B).hom (TensorProduct.tmul k x y) = TensorProduct.tmul k y x :=
   rfl
 set_option linter.uppercaseLean3 false in
 #align Rep.monoidal_category.braiding_hom_apply Rep.MonoidalCategory.braiding_hom_apply
 
-/- Porting note: same note as above. -/
+/- Porting note: linter informs me the LHS simplifies to... itself.
+But fwiw I also can't get simp to use this lemma. -/
 @[simp, nolint simpNF]
 theorem MonoidalCategory.braiding_inv_apply {A B : Rep k G} (x : A) (y : B) :
     Action.Hom.hom (β_ A B).inv (TensorProduct.tmul k y x) = TensorProduct.tmul k x y :=
@@ -216,13 +216,13 @@ theorem linearization_μ_hom (X Y : Action (Type u) (MonCat.of G)) :
 set_option linter.uppercaseLean3 false in
 #align Rep.linearization_μ_hom Rep.linearization_μ_hom
 
+@[simp]
+theorem linearization_μ_inv_hom (X Y : Action (Type u) (MonCat.of G)) :
+    (inv ((linearization k G).μ X Y)).hom = (finsuppTensorFinsupp' k X.V Y.V).symm.toLinearMap := by
 -- Porting note: broken proof was
 /-simp_rw [← Action.forget_map, Functor.map_inv, Action.forget_map, linearization_μ_hom]
   apply IsIso.inv_eq_of_hom_inv_id _
   exact LinearMap.ext fun x => LinearEquiv.symm_apply_apply _ _-/
-@[simp]
-theorem linearization_μ_inv_hom (X Y : Action (Type u) (MonCat.of G)) :
-    (inv ((linearization k G).μ X Y)).hom = (finsuppTensorFinsupp' k X.V Y.V).symm.toLinearMap := by
   rw [← Action.forget_map, Functor.map_inv]
   apply IsIso.inv_eq_of_hom_inv_id
   exact LinearMap.ext fun x => LinearEquiv.symm_apply_apply (finsuppTensorFinsupp' k X.V Y.V) x
@@ -283,11 +283,6 @@ set_option linter.uppercaseLean3 false in
 
 variable {k G}
 
-/- Porting note: broken proof was
-   refine' Finsupp.lhom_ext' fun y => LinearMap.ext_ring _
-    simpa only [LinearMap.comp_apply, ModuleCat.comp_def, Finsupp.lsingle_apply, Finsupp.lift_apply,
-      Action_ρ_eq_ρ, of_ρ_apply, Representation.ofMulAction_single, Finsupp.sum_single_index,
-      zero_smul, one_smul, smul_eq_mul, A.ρ.map_mul] -/
 /-- Given an element `x : A`, there is a natural morphism of representations `k[G] ⟶ A` sending
 `g ↦ A.ρ(g)(x).` -/
 @[simps]
@@ -295,6 +290,10 @@ noncomputable def leftRegularHom (A : Rep k G) (x : A) : Rep.ofMulAction k G G �
   hom := Finsupp.lift _ _ _ fun g => A.ρ g x
   comm g := by
     refine' Finsupp.lhom_ext' fun y => LinearMap.ext_ring _
+/- Porting note: rest of broken proof was
+    simpa only [LinearMap.comp_apply, ModuleCat.comp_def, Finsupp.lsingle_apply, Finsupp.lift_apply,
+      Action_ρ_eq_ρ, of_ρ_apply, Representation.ofMulAction_single, Finsupp.sum_single_index,
+      zero_smul, one_smul, smul_eq_mul, A.ρ.map_mul] -/
     simp only [LinearMap.comp_apply, ModuleCat.comp_def, Finsupp.lsingle_apply]
     erw [Finsupp.lift_apply, Finsupp.lift_apply, Representation.ofMulAction_single (G := G)]
     simp only [Finsupp.sum_single_index, zero_smul, one_smul, smul_eq_mul, A.ρ.map_mul, of_ρ]
@@ -310,10 +309,6 @@ theorem leftRegularHom_apply {A : Rep k G} (x : A) :
 set_option linter.uppercaseLean3 false in
 #align Rep.left_regular_hom_apply Rep.leftRegularHom_apply
 
-/- Porting note: in the proof of `left_inv`, the lines after `have : ... := ...` used to just be
-    simp only [LinearMap.comp_apply, Finsupp.lsingle_apply, left_regular_hom_hom,
-      Finsupp.lift_apply, Finsupp.sum_single_index, one_smul, ← this, zero_smul, of_ρ_apply,
-      Representation.ofMulAction_single x (1 : G) (1 : k), smul_eq_mul, mul_one] -/
 /-- Given a `k`-linear `G`-representation `A`, there is a `k`-linear isomorphism between
 representation morphisms `Hom(k[G], A)` and `A`. -/
 @[simps]
@@ -328,6 +323,10 @@ noncomputable def leftRegularHomEquiv (A : Rep k G) : (Rep.ofMulAction k G G ⟶
       f.hom ((ofMulAction k G G).ρ x (Finsupp.single (1 : G) (1 : k))) =
         A.ρ x (f.hom (Finsupp.single (1 : G) (1 : k))) :=
       LinearMap.ext_iff.1 (f.comm x) (Finsupp.single 1 1)
+/- Porting note: rest of broken proof was
+    simp only [LinearMap.comp_apply, Finsupp.lsingle_apply, left_regular_hom_hom,
+      Finsupp.lift_apply, Finsupp.sum_single_index, one_smul, ← this, zero_smul, of_ρ_apply,
+      Representation.ofMulAction_single x (1 : G) (1 : k), smul_eq_mul, mul_one] -/
     simp only [LinearMap.comp_apply, Finsupp.lsingle_apply, leftRegularHom_hom]
     erw [Finsupp.lift_apply]
     rw [Finsupp.sum_single_index, ←this, of_ρ_apply]
@@ -378,14 +377,7 @@ protected theorem ihom_obj_ρ_apply {A B : Rep k G} (g : G) (x : A →ₗ[k] B) 
 set_option linter.uppercaseLean3 false in
 #align Rep.ihom_obj_ρ_apply Rep.ihom_obj_ρ_apply
 
-/- Porting note: the lines after `TensorProduct.ext'...` in the proof of `comm` of `invFun` were
-originally:
-dsimp only [monoidal_category.tensor_left_obj, ModuleCat.comp_def, LinearMap.comp_apply,
-  tensor_rho, ModuleCat.MonoidalCategory.hom_apply, TensorProduct.map_tmul]
-simp only [TensorProduct.uncurry_apply f.hom.flip, LinearMap.flip_apply, Action_ρ_eq_ρ,
-  hom_comm_apply f g y, Rep.ihom_obj_ρ_apply, LinearMap.comp_apply, ρ_inv_self_apply] -/
 /- Porting note: the linter simplifies some of the LHSs of the `simps` lemmas to themselves. -/
-/- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
 /-- Given a `k`-linear `G`-representation `A`, this is the Hom-set bijection in the adjunction
 `A ⊗ - ⊣ ihom(A, -)`. It sends `f : A ⊗ B ⟶ C` to a `Rep k G` morphism defined by currying the
 `k`-linear map underlying `f`, giving a map `A →ₗ[k] B →ₗ[k] C`, then flipping the arguments. -/
@@ -403,6 +395,11 @@ protected def homEquiv (A B C : Rep k G) : (A ⊗ B ⟶ C) ≃ (B ⟶ (Rep.ihom 
   invFun f :=
     { hom := TensorProduct.uncurry k _ _ _ f.hom.flip
       comm := fun g => TensorProduct.ext' fun x y => by
+/- Porting note: rest of broken proof was
+        dsimp only [MonoidalCategory.tensorLeft_obj, ModuleCat.comp_def, LinearMap.comp_apply,
+          tensor_rho, ModuleCat.MonoidalCategory.hom_apply, TensorProduct.map_tmul]
+        simp only [TensorProduct.uncurry_apply f.hom.flip, LinearMap.flip_apply, Action_ρ_eq_ρ,
+          hom_comm_apply f g y, Rep.ihom_obj_ρ_apply, LinearMap.comp_apply, ρ_inv_self_apply] -/
         change TensorProduct.uncurry k _ _ _ f.hom.flip (A.ρ g x ⊗ₜ[k] B.ρ g y) =
           C.ρ g (TensorProduct.uncurry k _ _ _ f.hom.flip (x ⊗ₜ[k] y))
         rw [TensorProduct.uncurry_apply, LinearMap.flip_apply, hom_comm_apply, Rep.ihom_obj_ρ_apply,
@@ -454,7 +451,6 @@ set_option maxHeartbeats 230000 in
 set_option linter.uppercaseLean3 false in
 #align Rep.ihom_coev_app_hom Rep.ihom_coev_app_hom
 
-/- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
 /-- There is a `k`-linear isomorphism between the sets of representation morphisms`Hom(A ⊗ B, C)`
 and `Hom(B, Homₖ(A, C))`. -/
 def MonoidalClosed.linearHomEquiv : (A ⊗ B ⟶ C) ≃ₗ[k] B ⟶ A ⟶[Rep k G] C :=
@@ -464,7 +460,6 @@ def MonoidalClosed.linearHomEquiv : (A ⊗ B ⟶ C) ≃ₗ[k] B ⟶ A ⟶[Rep k 
   set_option linter.uppercaseLean3 false in
 #align Rep.monoidal_closed.linear_hom_equiv Rep.MonoidalClosed.linearHomEquiv
 
-/- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
 /-- There is a `k`-linear isomorphism between the sets of representation morphisms`Hom(A ⊗ B, C)`
 and `Hom(A, Homₖ(B, C))`. -/
 def MonoidalClosed.linearHomEquivComm : (A ⊗ B ⟶ C) ≃ₗ[k] A ⟶ B ⟶[Rep k G] C :=
@@ -474,7 +469,6 @@ set_option linter.uppercaseLean3 false in
 
 variable {A B C}
 
-/- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
 @[simp]
 theorem MonoidalClosed.linearHomEquiv_hom (f : A ⊗ B ⟶ C) :
     (MonoidalClosed.linearHomEquiv A B C f).hom = (TensorProduct.curry f.hom).flip :=
@@ -482,7 +476,6 @@ theorem MonoidalClosed.linearHomEquiv_hom (f : A ⊗ B ⟶ C) :
 set_option linter.uppercaseLean3 false in
 #align Rep.monoidal_closed.linear_hom_equiv_hom Rep.MonoidalClosed.linearHomEquiv_hom
 
-/- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
 @[simp]
 theorem MonoidalClosed.linearHomEquivComm_hom (f : A ⊗ B ⟶ C) :
     (MonoidalClosed.linearHomEquivComm A B C f).hom = TensorProduct.curry f.hom :=
@@ -514,7 +507,6 @@ open MonoidalCategory
 variable {k G : Type u} [CommRing k] [Monoid G] {V W : Type u} [AddCommGroup V] [AddCommGroup W]
   [Module k V] [Module k W] (ρ : Representation k G V) (τ : Representation k G W)
 
-/- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
 /-- Tautological isomorphism to help Lean in typechecking. -/
 def repOfTprodIso : Rep.of (ρ.tprod τ) ≅ Rep.of ρ ⊗ Rep.of τ :=
   Iso.refl _
@@ -621,7 +613,6 @@ def unitIsoAddEquiv {V : Rep k G} : V ≃+ (toModuleMonoidAlgebra ⋙ ofModuleMo
 set_option linter.uppercaseLean3 false in
 #align Rep.unit_iso_add_equiv Rep.unitIsoAddEquiv
 
-/- Porting note: in the proof of `map_smul'`, the lines after `dsimp` used to just be one `simp`. -/
 /-- Auxilliary definition for `equivalenceModuleMonoidAlgebra`. -/
 def counitIso (M : ModuleCat.{u} (MonoidAlgebra k G)) :
     (ofModuleMonoidAlgebra ⋙ toModuleMonoidAlgebra).obj M ≅ M :=
@@ -629,6 +620,7 @@ def counitIso (M : ModuleCat.{u} (MonoidAlgebra k G)) :
     { counitIsoAddEquiv with
       map_smul' := fun r x => by
         dsimp [counitIsoAddEquiv]
+/- Porting note: rest of broken proof was `simp`. -/
         rw [AddEquiv.coe_toEquiv, AddEquiv.trans_apply]
         erw [Representation.ofModule_asAlgebraHom_apply_apply]
         exact AddEquiv.symm_apply_apply _ _}
@@ -644,10 +636,6 @@ theorem unit_iso_comm (V : Rep k G) (g : G) (x : V) :
 set_option linter.uppercaseLean3 false in
 #align Rep.unit_iso_comm Rep.unit_iso_comm
 
-/- Porting note: in the proof of `map_smul'`, the lines after `dsimp [unitIsoAddEquiv]` were
-originally just
-simp only [Representation.asModuleEquiv_symm_map_smul,
-  RestrictScalars.addEquiv_symm_map_algebraMap_smul] -/
 /-- Auxilliary definition for `equivalenceModuleMonoidAlgebra`. -/
 def unitIso (V : Rep k G) : V ≅ (toModuleMonoidAlgebra ⋙ ofModuleMonoidAlgebra).obj V :=
   Action.mkIso
@@ -655,6 +643,9 @@ def unitIso (V : Rep k G) : V ≅ (toModuleMonoidAlgebra ⋙ ofModuleMonoidAlgeb
       { unitIsoAddEquiv with
         map_smul' := fun r x => by
           dsimp [unitIsoAddEquiv]
+/- Porting note: rest of broken proof was
+          simp only [Representation.asModuleEquiv_symm_map_smul,
+            RestrictScalars.addEquiv_symm_map_algebraMap_smul] -/
           rw [AddEquiv.coe_toEquiv, AddEquiv.trans_apply,
             Representation.asModuleEquiv_symm_map_smul,
             RestrictScalars.addEquiv_symm_map_algebraMap_smul]

--- a/Mathlib/RepresentationTheory/Rep.lean
+++ b/Mathlib/RepresentationTheory/Rep.lean
@@ -145,18 +145,16 @@ noncomputable instance : PreservesLimits (forget₂ (Rep k G) (ModuleCat.{u} k))
 noncomputable instance : PreservesColimits (forget₂ (Rep k G) (ModuleCat.{u} k)) :=
   Action.instPreservesColimitsForget.{u} _ _
 
-/- Porting note: linter informs me the LHS simplifies to... itself.
-But fwiw I also can't get simp to use this lemma. -/
-@[simp, nolint simpNF]
+/- Porting note: linter complains `simp` unfolds some types in the LHS, so
+have removed `@[simp]`. -/
 theorem MonoidalCategory.braiding_hom_apply {A B : Rep k G} (x : A) (y : B) :
     Action.Hom.hom (β_ A B).hom (TensorProduct.tmul k x y) = TensorProduct.tmul k y x :=
   rfl
 set_option linter.uppercaseLean3 false in
 #align Rep.monoidal_category.braiding_hom_apply Rep.MonoidalCategory.braiding_hom_apply
 
-/- Porting note: linter informs me the LHS simplifies to... itself.
-But fwiw I also can't get simp to use this lemma. -/
-@[simp, nolint simpNF]
+/- Porting note: linter complains `simp` unfolds some types in the LHS, so
+have removed `@[simp]`. -/
 theorem MonoidalCategory.braiding_inv_apply {A B : Rep k G} (x : A) (y : B) :
     Action.Hom.hom (β_ A B).inv (TensorProduct.tmul k y x) = TensorProduct.tmul k x y :=
   rfl
@@ -376,11 +374,10 @@ set_option linter.uppercaseLean3 false in
 set_option linter.uppercaseLean3 false in
 #align Rep.ihom_obj_ρ_apply Rep.ihom_obj_ρ_apply
 
-/- Porting note: the linter simplifies some of the LHSs of the `simps` lemmas to themselves. -/
 /-- Given a `k`-linear `G`-representation `A`, this is the Hom-set bijection in the adjunction
 `A ⊗ - ⊣ ihom(A, -)`. It sends `f : A ⊗ B ⟶ C` to a `Rep k G` morphism defined by currying the
 `k`-linear map underlying `f`, giving a map `A →ₗ[k] B →ₗ[k] C`, then flipping the arguments. -/
-@[simps] def homEquiv (A B C : Rep k G) : (A ⊗ B ⟶ C) ≃ (B ⟶ (Rep.ihom A).obj C) where
+def homEquiv (A B C : Rep k G) : (A ⊗ B ⟶ C) ≃ (B ⟶ (Rep.ihom A).obj C) where
   toFun f :=
     { hom := (TensorProduct.curry f.hom).flip
       comm := fun g => by
@@ -408,7 +405,21 @@ set_option linter.uppercaseLean3 false in
 set_option linter.uppercaseLean3 false in
 #align Rep.hom_equiv Rep.homEquiv
 
-attribute [nolint simpNF] Rep.homEquiv_apply_hom Rep.homEquiv_symm_apply_hom
+variable {A B C}
+
+/-- Porting note: if we generate this with `@[simps]` the linter complains some types in the LHS
+simplify. -/
+theorem homEquiv_apply_hom (f : A ⊗ B ⟶ C) :
+  (homEquiv A B C f).hom = (TensorProduct.curry f.hom).flip := rfl
+set_option linter.uppercaseLean3 false in
+#align Rep.hom_equiv_apply_hom Rep.homEquiv_apply_hom
+
+/-- Porting note: if we generate this with `@[simps]` the linter complains some types in the LHS
+simplify. -/
+theorem homEquiv_symm_apply_hom (f : B ⟶ (Rep.ihom A).obj C) :
+  ((homEquiv A B C).symm f).hom = TensorProduct.uncurry k A B C f.hom.flip := rfl
+set_option linter.uppercaseLean3 false in
+#align Rep.hom_equiv_symm_apply_hom Rep.homEquiv_symm_apply_hom
 
 instance : MonoidalClosed (Rep k G) where
   closed := fun A =>
@@ -448,6 +459,8 @@ set_option maxHeartbeats 230000 in
   LinearMap.ext fun _ => LinearMap.ext fun _ => rfl
 set_option linter.uppercaseLean3 false in
 #align Rep.ihom_coev_app_hom Rep.ihom_coev_app_hom
+
+variable (A B C)
 
 /-- There is a `k`-linear isomorphism between the sets of representation morphisms`Hom(A ⊗ B, C)`
 and `Hom(B, Homₖ(A, C))`. -/


### PR DESCRIPTION
---

Trying again to port this now the mathlib3 PR [#19170](https://github.com/leanprover-community/mathlib/pull/19170) is merged. The first port attempt was #4761.
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
