### PR TITLE
feat(Tactic/Prune + test/Prune): add `prune` tactic, for removing unnecessary hypotheses

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2674,6 +2674,7 @@ import Mathlib.Tactic.PrintPrefix
 import Mathlib.Tactic.ProjectionNotation
 import Mathlib.Tactic.Propose
 import Mathlib.Tactic.ProxyType
+import Mathlib.Tactic.Prune
 import Mathlib.Tactic.PushNeg
 import Mathlib.Tactic.Qify
 import Mathlib.Tactic.Qify.Attr

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -99,6 +99,7 @@ import Mathlib.Tactic.PrintPrefix
 import Mathlib.Tactic.ProjectionNotation
 import Mathlib.Tactic.Propose
 import Mathlib.Tactic.ProxyType
+import Mathlib.Tactic.Prune
 import Mathlib.Tactic.PushNeg
 import Mathlib.Tactic.Qify
 import Mathlib.Tactic.Qify.Attr

--- a/Mathlib/Tactic/Prune.lean
+++ b/Mathlib/Tactic/Prune.lean
@@ -1,0 +1,104 @@
+/-
+Copyright (c) 2023 Damiano Testa. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Damiano Testa
+-/
+import Std.Data.List.Basic
+
+/-!
+
+# `prune` tactic
+
+The `prune` tactic `clear`s hypotheses from the main goal.  The default behaviour is
+to remove the hypotheses very conservatively.  See the tactic doc-string for more details.
+
+This tactic is intended as a way to clean up the local context at the beginning of a proof,
+pruning away all variables that are in scope, but do not appear in the goal.
+
+## Implementation notes
+
+The tactic has two stages:
+1. an iterative stage, where variables are successively `revert`ed in "layers of dependent batches";
+2. a final step, in which all left-over variables are `clear`ed and all previously`revert`ed
+   variables are `intro`duced.
+
+The tactic `prune n` stops the iterative stage at the `n`-th step.
+The tactic `prune` performs the whole iterative stage.
+
+Both tactics then `clear` the remaining variables and re-`intro`duce the `revert`ed variables.
+-/
+
+namespace Mathlib.Tactic.Prune
+
+open Lean Elab Meta Tactic
+
+/-- `revertVarsOnce` `revert`s all hypotheses that appear in the main goal.
+It returns the array of `FVarIds` of the reverted hypotheses. -/
+def revertVarsOnce : TacticM (Array FVarId) := focus do
+  let ctx := (← getLCtx).decls.toList.reduceOption
+  let gMVar := ← getMainGoal
+  let goal := ← getMainTarget
+  let foundDecls := (ctx.map fun x =>
+    if x.toExpr.occurs goal then some x else none).reduceOption
+  let fvarIdFound := (foundDecls.map Lean.LocalDecl.fvarId).toArray
+  let (fvs, newGoal) := ← gMVar.revert fvarIdFound
+  setGoals [newGoal]
+  pure fvs
+
+/-- `revertLoop` iterates `revertVarsOnce`, reverting all variables that
+recursively appear in the main goal. -/
+partial
+def revertLoop : TacticM Unit := focus do
+  let fvars := ← revertVarsOnce
+  if fvars.size == 0 then pure () else revertLoop
+
+/-- `revertNLoop n` iterates `revertVarsOnce` up to `n` times.
+If at some point, no new variables get reverted, then `revertNLoop`
+shows a message, suggesting to use `prune`, instead of `prune n`. -/
+def revertNLoop (n : Nat) : TacticM Unit := focus do
+  match n with
+  | 0     => do let _goal := ← getMainGoal; pure ()
+  | n + 1 => focus do
+    let fvars := ← revertVarsOnce
+    if fvars.size == 0 then
+      logInfo m!"Excessive number of iterations.\nTry this: prune"
+      pure () else revertNLoop n
+
+/-- `pruneTac offset` clears all hypotheses and then re`intro`duces all hypotheses contained in
+the goal, except for the last `offset`.  The `offset` is intended to leave the final goal
+as it was before all the previous `revert`s and introduce only the variables that have been
+explicitly reverted by one of the `revertX` tactics above. -/
+def pruneTac (offset : Nat := 0) : TacticM Unit := focus do
+  let dcls := (← getLCtx).decls.toList.reduceOption
+  let goal := ← getMainGoal
+  let newGoal ← goal.tryClearMany (dcls.map LocalDecl.fvarId).toArray
+  setGoals [newGoal]
+  let nms := (← getMainTarget).getForallBinderNames
+  let (_newfvs, rGoal) := ← introNCore newGoal (nms.length - offset) [] True True
+  setGoals [rGoal]
+
+/-- The `prune` tactic `clear`s hypotheses from the main goal.  The default behaviour is
+to remove the hypotheses very conservatively.  `prune` also takes an optional natural
+number input:
+* `prune 0` removes all hypotheses that do not appear in the main goal;
+* `prune 1` removes all hypotheses that do not appear in the main goal nor contain hypotheses
+  that `prune 0` had kept;
+* ...
+* `prune n+1` removes all hypotheses that do not appear in the main goal nor contain hypotheses
+  that `prune n` had kept.
+
+For sufficiently large `n`, `prune n` is a synonym for `prune`.  The tactic reports when
+this happens, suggesting to use `prune`, if `n` is too large. -/
+syntax "prune" (num)? : tactic
+
+elab_rules : tactic
+  | `(tactic| prune)        => do
+    let offset := (← getMainTarget).getForallBinderNames.length
+    revertLoop
+    pruneTac offset
+  | `(tactic| prune $[$n]?) => do
+    let offset := (← getMainTarget).getForallBinderNames.length
+    revertNLoop (n.getD default).getNat
+    pruneTac offset
+
+end Mathlib.Tactic.Prune

--- a/test/Prune.lean
+++ b/test/Prune.lean
@@ -1,0 +1,75 @@
+import Mathlib.Tactic.Prune
+
+universe u
+variable {α : Type u} [Add α] [Add α] {e f : α} {a b _d : Nat} {_h : e ≠ f} (h₁ : a = b)
+  (h₂ : ff = b) {c : Int}
+
+example : ∀ n : Nat, 0 = 0 := by
+  prune
+  exact fun _ => rfl
+
+example : ∀ _ _ _ : Bool,  a + 5 = c ∨ True := by
+  prune
+  /- goal state:
+  b a: Nat
+  h₁: a = b
+  c: Int
+  ⊢ Bool → Bool → Bool → Int.ofNat a + 5 = c ∨ True
+  -/
+  intros _ _ _
+  exact Or.inr trivial
+
+/-- Lots of duplication of variables, since they are included *again*! -/
+example {α : Type u} [Add α] [OfNat α 0] {e f : α} {a b _d : Nat} {_h : e ≠ f} (_h₁ : a = b)
+  {_c : Int} : e + f = e ∨ True := by
+  /- goal state:
+  α✝: Type u
+  inst✝³ inst✝²: Add α✝
+  e✝ f✝: α✝
+  a✝ b✝ _d✝: Nat
+  _h✝: e✝ ≠ f✝
+  h₁: a✝ = b✝
+  c: Int
+  α: Type u
+  inst✝¹: Add α
+  inst✝: OfNat α 0
+  e f: α
+  a b _d: Nat
+  _h: e ≠ f
+  _h₁: a = b
+  _c: Int
+  ⊢ e + f = e ∨ True
+  -/
+  prune 1
+  /- goal state:
+  α: Type u
+  inst✝¹: Add α
+  inst✝: OfNat α 0
+  e f: α
+  _h: e ≠ f
+  ⊢ e + f = e ∨ True
+  -/
+  exact Or.inr trivial
+
+example : ∃ n, n = 0 := by
+  constructor
+  /-
+  2 goals
+  case h
+  a: ℕ
+  ⊢ ?w = 0
+  case w
+  a: ℕ
+  ⊢ ℕ
+  -/
+  prune 0
+  rotate_left
+  prune 0
+  exact 0
+  rfl
+  /-
+  1 goal
+  case h
+  a: ℕ
+  ⊢ ?w = 0
+  -/


### PR DESCRIPTION
This tactic removes very conservatively all local declarations that
1. do not appear in the main goal,
2. do not appear in a declaration that appears in the main goal,
3. ... and so on recursively.

The main motivation for this tactic is that all available variables in the current `namespace/section` appear in the goal state, not just the ones that are needed for the statement to type-check.  Using `prune` mitigates this situation.

The tactic also admits an optional natural number argument: `prune n` removes all variables that have not appeared at the `(n+1)`-st stage in the above list.  Thus, `prune 0` only leaves the variables needed for the statement to type-check.  Also, for sufficiently large `n`, `prune n` is a synonym for `prune`.

[Zulip discussion](https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/substitute.20for.20.60include.2Fomit.60.3F)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
