### PR TITLE
[Merged by Bors] - chore: remove reducible from Function.Surjective

### DIFF
--- a/Mathlib/Init/Function.lean
+++ b/Mathlib/Init/Function.lean
@@ -68,7 +68,7 @@ fun _ _ h ↦ hf (hg h)
 
 /-- A function `f : α → β` is called surjective if every `b : β` is equal to `f a`
 for some `a : α`. -/
-@[reducible] def Surjective (f : α → β) : Prop := ∀ b, ∃ a, f a = b
+def Surjective (f : α → β) : Prop := ∀ b, ∃ a, f a = b
 
 theorem Surjective.comp {g : β → φ} {f : α → β} (hg : Surjective g) (hf : Surjective f) :
   Surjective (g ∘ f) :=


### PR DESCRIPTION
The @[reducible] attribute on `Function.Surjective` is apparently not needed, and currently prevents `@[simp]` lemmas with `Function.Surjective` side conditions from firing, see [zulip discussion](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/simp.20lemmas.20with.20side.20conditions).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
