### PR TITLE
[Merged by Bors] - chore: move around `gcongr` material

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2623,6 +2623,7 @@ import Mathlib.Tactic.FinCases
 import Mathlib.Tactic.Find
 import Mathlib.Tactic.GCongr
 import Mathlib.Tactic.GCongr.Core
+import Mathlib.Tactic.GCongr.ForwardAttr
 import Mathlib.Tactic.GeneralizeProofs
 import Mathlib.Tactic.Group
 import Mathlib.Tactic.GuardGoalNums

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -44,6 +44,7 @@ import Mathlib.Tactic.FinCases
 import Mathlib.Tactic.Find
 import Mathlib.Tactic.GCongr
 import Mathlib.Tactic.GCongr.Core
+import Mathlib.Tactic.GCongr.ForwardAttr
 import Mathlib.Tactic.GeneralizeProofs
 import Mathlib.Tactic.Group
 import Mathlib.Tactic.GuardGoalNums

--- a/Mathlib/Tactic/GCongr.lean
+++ b/Mathlib/Tactic/GCongr.lean
@@ -12,33 +12,9 @@ import Mathlib.Tactic.GCongr.Core
 The core implementation of the `gcongr` ("generalized congruence") tactic is in the file
 `Tactic.GCongr.Core`.  In this file we set it up for use across the library by tagging a minimal
 set of lemmas with the attribute `@[gcongr]` and by listing `positivity` as a first-pass
-discharger for side goals (`gcongr_discharger`) and four simple tactics as first-pass dischargers
-for main goals (`@[gcongr_forward]`). -/
+discharger for side goals (`gcongr_discharger`). -/
 
 macro_rules | `(tactic| gcongr_discharger) => `(tactic| positivity)
-
-namespace Mathlib.Tactic.GCongr
-open Lean Meta
-
-/-- See if the term is `a = b` and the goal is `a ∼ b` or `b ∼ a`, with `∼` reflexive. -/
-@[gcongr_forward] def exactRefl : ForwardExt where
-  eval h goal := do
-    let m ← mkFreshExprMVar none
-    goal.exact (← mkAppOptM ``Eq.subst #[h, m])
-    goal.rfl
-
-/-- See if the term is `a < b` and the goal is `a ≤ b`. -/
-@[gcongr_forward] def exactLeOfLt : ForwardExt where
-  eval h goal := do goal.exact (← mkAppM ``le_of_lt #[h])
-
-/-- See if the term is `a ∼ b` with `∼` symmetric and the goal is `b ∼ a`. -/
-@[gcongr_forward] def symmExact : ForwardExt where
-  eval h goal := do (← goal.symm).exact h
-
-@[gcongr_forward] def exact : ForwardExt where
-  eval := MVarId.exact
-
-end Mathlib.Tactic.GCongr
 
 /-! # ≤, - -/
 

--- a/Mathlib/Tactic/GCongr/Core.lean
+++ b/Mathlib/Tactic/GCongr/Core.lean
@@ -3,10 +3,8 @@ Copyright (c) 2023 Mario Carneiro, Heather Macbeth. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Heather Macbeth
 -/
-import Mathlib.Init.Algebra.Order
-import Mathlib.Tactic.Relation.Rfl
-import Mathlib.Tactic.Relation.Symm
 import Mathlib.Tactic.Backtracking
+import Mathlib.Tactic.GCongr.ForwardAttr
 
 /-!
 # The `gcongr` ("generalized congruence") tactic
@@ -357,44 +355,23 @@ def _root_.Lean.MVarId.exact (e : Expr) (g : MVarId) : MetaM Unit := do
   g.checkNotAssigned `myExact
   g.assign e
 
-/-- An extension for `gcongr_forward`. -/
-structure ForwardExt where
-  eval (h : Expr) (goal : MVarId) : MetaM Unit
+/-- See if the term is `a = b` and the goal is `a ∼ b` or `b ∼ a`, with `∼` reflexive. -/
+@[gcongr_forward] def exactRefl : ForwardExt where
+  eval h goal := do
+    let m ← mkFreshExprMVar none
+    goal.exact (← mkAppOptM ``Eq.subst #[h, m])
+    goal.rfl
 
-/-- Read a `gcongr_forward` extension from a declaration of the right type. -/
-def mkForwardExt (n : Name) : ImportM ForwardExt := do
-  let { env, opts, .. } ← read
-  IO.ofExcept <| unsafe env.evalConstCheck ForwardExt opts ``ForwardExt n
+/-- See if the term is `a < b` and the goal is `a ≤ b`. -/
+@[gcongr_forward] def exactLeOfLt : ForwardExt where
+  eval h goal := do goal.exact (← mkAppM ``le_of_lt #[h])
 
-/-- Environment extensions for `gcongrForward` declarations -/
-initialize forwardExt : PersistentEnvExtension Name (Name × ForwardExt)
-    (List Name × List (Name × ForwardExt)) ←
-  registerPersistentEnvExtension {
-    mkInitial := pure ([], {})
-    addImportedFn := fun s => do
-      let dt ← s.foldlM (init := {}) fun dt s => s.foldlM (init := dt) fun dt n => do
-        return (n, ← mkForwardExt n) :: dt
-      pure ([], dt)
-    addEntryFn := fun (entries, s) (n, ext) => (n :: entries, (n, ext) :: s)
-    exportEntriesFn := fun s => s.1.reverse.toArray
-  }
+/-- See if the term is `a ∼ b` with `∼` symmetric and the goal is `b ∼ a`. -/
+@[gcongr_forward] def symmExact : ForwardExt where
+  eval h goal := do (← goal.symm).exact h
 
-initialize registerBuiltinAttribute {
-  name := `gcongr_forward
-  descr := "adds a gcongr_forward extension"
-  applicationTime := .afterCompilation
-  add := fun declName stx kind => match stx with
-    | `(attr| gcongr_forward) => do
-      unless kind == AttributeKind.global do
-        throwError "invalid attribute 'gcongr_forward', must be global"
-      let env ← getEnv
-      unless (env.getModuleIdxFor? declName).isNone do
-        throwError "invalid attribute 'gcongr_forward', declaration is in an imported module"
-      if (IR.getSorryDep env declName).isSome then return -- ignore in progress definitions
-      let ext ← mkForwardExt declName
-      setEnv <| forwardExt.addEntry env (declName, ext)
-    | _ => throwUnsupportedSyntax
-}
+@[gcongr_forward] def exact : ForwardExt where
+  eval := MVarId.exact
 
 /-- Attempt to resolve an (implicitly) relational goal by one of a provided list of hypotheses,
 either with such a hypothesis directly or by a limited palette of relational forward-reasoning from

--- a/Mathlib/Tactic/GCongr/ForwardAttr.lean
+++ b/Mathlib/Tactic/GCongr/ForwardAttr.lean
@@ -1,0 +1,53 @@
+/-
+Copyright (c) 2023 Mario Carneiro, Heather Macbeth. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro, Heather Macbeth
+-/
+import Std.Tactic.Basic
+
+/-!
+# Environment extension for the forward-reasoning part of the `gcongr` tactic
+-/
+
+open Lean Meta Elab Tactic
+
+namespace Mathlib.Tactic.GCongr
+
+/-- An extension for `gcongr_forward`. -/
+structure ForwardExt where
+  eval (h : Expr) (goal : MVarId) : MetaM Unit
+
+/-- Read a `gcongr_forward` extension from a declaration of the right type. -/
+def mkForwardExt (n : Name) : ImportM ForwardExt := do
+  let { env, opts, .. } ← read
+  IO.ofExcept <| unsafe env.evalConstCheck ForwardExt opts ``ForwardExt n
+
+/-- Environment extensions for `gcongrForward` declarations -/
+initialize forwardExt : PersistentEnvExtension Name (Name × ForwardExt)
+    (List Name × List (Name × ForwardExt)) ←
+  registerPersistentEnvExtension {
+    mkInitial := pure ([], {})
+    addImportedFn := fun s => do
+      let dt ← s.foldlM (init := {}) fun dt s => s.foldlM (init := dt) fun dt n => do
+        return (n, ← mkForwardExt n) :: dt
+      pure ([], dt)
+    addEntryFn := fun (entries, s) (n, ext) => (n :: entries, (n, ext) :: s)
+    exportEntriesFn := fun s => s.1.reverse.toArray
+  }
+
+initialize registerBuiltinAttribute {
+  name := `gcongr_forward
+  descr := "adds a gcongr_forward extension"
+  applicationTime := .afterCompilation
+  add := fun declName stx kind => match stx with
+    | `(attr| gcongr_forward) => do
+      unless kind == AttributeKind.global do
+        throwError "invalid attribute 'gcongr_forward', must be global"
+      let env ← getEnv
+      unless (env.getModuleIdxFor? declName).isNone do
+        throwError "invalid attribute 'gcongr_forward', declaration is in an imported module"
+      if (IR.getSorryDep env declName).isSome then return -- ignore in progress definitions
+      let ext ← mkForwardExt declName
+      setEnv <| forwardExt.addEntry env (declName, ext)
+    | _ => throwUnsupportedSyntax
+}


### PR DESCRIPTION
Move the `gcongr_forward` attribute setup from `Tactic.GCongr.Core` into a new (earlier) file `Tactic.GCongr.ForwardAttr`, allowing the four seed mini-tactics with this attribute to be moved (earlier) from `Tactic.GCongr` into `Tactic.GCongr.Core`.

This fixes the broken tests #5065 as well as an issue

> I naively assumed that if the tactic`gcongr` is known, then I would not have to import additional files. So if I import this file, .... `gcongr` suddenly used a hypothesis where it didn’t do it before.

[reported by](https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/New.20tactic.20for.20.22relational.20congruence.22/near/363801891) @nomeata .

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
