### PR TITLE
[Merged by Bors] - fix(Tactic/PushNeg): add `cleanupAnnotations` to push_neg

### DIFF
--- a/Mathlib/Analysis/NormedSpace/lpSpace.lean
+++ b/Mathlib/Analysis/NormedSpace/lpSpace.lean
@@ -213,7 +213,6 @@ theorem of_exponent_ge {p q : ℝ≥0∞} {f : ∀ i, E i} (hfq : Memℓp f q) (
       have : 0 ≤ ‖f i‖ ^ p.toReal := Real.rpow_nonneg_of_nonneg (norm_nonneg _) p.toReal
       simp only [abs_of_nonneg, this] at hi
       contrapose! hi
-      rw [not_le] at hi
       exact Real.rpow_le_rpow_of_exponent_ge' (norm_nonneg _) hi.le hq.le hpq'
 #align mem_ℓp.of_exponent_ge Memℓp.of_exponent_ge
 

--- a/Mathlib/Data/Set/Finite.lean
+++ b/Mathlib/Data/Set/Finite.lean
@@ -1394,9 +1394,6 @@ theorem not_injOn_infinite_finite_image {f : α → β} {s : Set α} (h_inf : s.
   have h := not_injective_infinite_finite
             ((f '' s).codRestrict (s.restrict f) fun x => ⟨x, x.property, rfl⟩)
   contrapose! h
-  --  re-porting note: the porting note below can probably be removed now: there was an extra
-  --  `rwa [not_not] at h` after the next `rw`.
-  --porting note: why do we have `contrapose!` if the `push_neg` behaviour doesn't work?
   rwa [injective_codRestrict, ← injOn_iff_injective]
 #align set.not_inj_on_infinite_finite_image Set.not_injOn_infinite_finite_image
 

--- a/Mathlib/Data/Set/Finite.lean
+++ b/Mathlib/Data/Set/Finite.lean
@@ -1394,9 +1394,10 @@ theorem not_injOn_infinite_finite_image {f : α → β} {s : Set α} (h_inf : s.
   have h := not_injective_infinite_finite
             ((f '' s).codRestrict (s.restrict f) fun x => ⟨x, x.property, rfl⟩)
   contrapose! h
+  --  re-porting note: the porting note below can probably be removed now: there was an extra
+  --  `rwa [not_not] at h` afte the next `rw`.
   --porting note: why do we have `contrapose!` if the `push_neg` behaviour doesn't work?
-  rw [injective_codRestrict, ← injOn_iff_injective]
-  rwa [not_not] at h
+  rwa [injective_codRestrict, ← injOn_iff_injective]
 #align set.not_inj_on_infinite_finite_image Set.not_injOn_infinite_finite_image
 
 /-! ### Order properties -/

--- a/Mathlib/Data/Set/Finite.lean
+++ b/Mathlib/Data/Set/Finite.lean
@@ -1395,7 +1395,7 @@ theorem not_injOn_infinite_finite_image {f : α → β} {s : Set α} (h_inf : s.
             ((f '' s).codRestrict (s.restrict f) fun x => ⟨x, x.property, rfl⟩)
   contrapose! h
   --  re-porting note: the porting note below can probably be removed now: there was an extra
-  --  `rwa [not_not] at h` afte the next `rw`.
+  --  `rwa [not_not] at h` after the next `rw`.
   --porting note: why do we have `contrapose!` if the `push_neg` behaviour doesn't work?
   rwa [injective_codRestrict, ← injOn_iff_injective]
 #align set.not_inj_on_infinite_finite_image Set.not_injOn_infinite_finite_image

--- a/Mathlib/GroupTheory/OrderOfElement.lean
+++ b/Mathlib/GroupTheory/OrderOfElement.lean
@@ -524,7 +524,6 @@ theorem infinite_not_isOfFinOrder {x : G} (h : ¬IsOfFinOrder x) :
   have : ¬Injective fun n : ℕ => x ^ n := by
     have H := Set.not_injOn_infinite_finite_image (Set.Ioi_infinite 0) (Set.not_infinite.mp h)
     contrapose! H -- Porting note: `contrapose! this` errored, so renamed `this ↦ H`
-    rw [not_not] at H -- Porting note: why is `contrapose!` not taking care of this?
     exact Set.injOn_of_injective H _
   rwa [injective_pow_iff_not_isOfFinOrder, Classical.not_not] at this
 #align infinite_not_is_of_fin_order infinite_not_isOfFinOrder

--- a/Mathlib/GroupTheory/OrderOfElement.lean
+++ b/Mathlib/GroupTheory/OrderOfElement.lean
@@ -522,9 +522,9 @@ theorem infinite_not_isOfFinOrder {x : G} (h : ¬IsOfFinOrder x) :
   suffices s.Infinite by exact this.mono hs
   contrapose! h
   have : ¬Injective fun n : ℕ => x ^ n := by
-    have H := Set.not_injOn_infinite_finite_image (Set.Ioi_infinite 0) (Set.not_infinite.mp h)
-    contrapose! H -- Porting note: `contrapose! this` errored, so renamed `this ↦ H`
-    exact Set.injOn_of_injective H _
+    have := Set.not_injOn_infinite_finite_image (Set.Ioi_infinite 0) (Set.not_infinite.mp h)
+    contrapose! this
+    exact Set.injOn_of_injective this _
   rwa [injective_pow_iff_not_isOfFinOrder, Classical.not_not] at this
 #align infinite_not_is_of_fin_order infinite_not_isOfFinOrder
 #align infinite_not_is_of_fin_add_order infinite_not_isOfFinAddOrder

--- a/Mathlib/GroupTheory/SchurZassenhaus.lean
+++ b/Mathlib/GroupTheory/SchurZassenhaus.lean
@@ -200,7 +200,6 @@ private theorem step2 (K : Subgroup G) [K.Normal] (hK : K ≤ N) : K = ⊥ ∨ K
   have : Function.Surjective (QuotientGroup.mk' K) := Quotient.surjective_Quotient_mk''
   have h4 := step1 h1 h2 h3
   contrapose! h4
-  rw [not_or] at h4 -- porting note: had to add `rw [not_or] at h4`
   have h5 : Fintype.card (G ⧸ K) < Fintype.card G := by
     rw [← index_eq_card, ← K.index_mul_card]
     refine'

--- a/Mathlib/LinearAlgebra/Matrix/ZPow.lean
+++ b/Mathlib/LinearAlgebra/Matrix/ZPow.lean
@@ -294,11 +294,7 @@ theorem coe_units_zpow (u : Mˣ) : ∀ n : ℤ, ((u ^ n : Mˣ) : M) = (u : M) ^ 
 theorem zpow_ne_zero_of_isUnit_det [Nonempty n'] [Nontrivial R] {A : M} (ha : IsUnit A.det)
     (z : ℤ) : A ^ z ≠ 0 := by
   have := ha.det_zpow z
-  -- Porting note: was `contrapose! this`
-  revert this
-  contrapose!
-  rw [ne_eq, not_not]
-  intro this
+  contrapose! this
   rw [this, det_zero ‹_›]
   exact not_isUnit_zero
 #align matrix.zpow_ne_zero_of_is_unit_det Matrix.zpow_ne_zero_of_isUnit_det

--- a/Mathlib/NumberTheory/ADEInequality.lean
+++ b/Mathlib/NumberTheory/ADEInequality.lean
@@ -177,7 +177,7 @@ theorem lt_three {p q r : ℕ+} (hpq : p ≤ q) (hqr : q ≤ r) (H : 1 < sumInv 
   have h3 : (0 : ℚ) < 3 := by norm_num
   contrapose! H
   rw [sumInv_pqr]
-  have h3q := (not_lt.mp H).trans hpq
+  have h3q := H.trans hpq
   have h3r := h3q.trans hqr
   simp at H
   have hp: (p : ℚ)⁻¹ ≤ 3⁻¹ := by
@@ -201,7 +201,7 @@ theorem lt_four {q r : ℕ+} (hqr : q ≤ r) (H : 1 < sumInv {2, q, r}) : q < 4 
   have h4 : (0 : ℚ) < 4 := by norm_num
   contrapose! H
   rw [sumInv_pqr]
-  have h4r := (not_lt.mp H).trans hqr
+  have h4r := H.trans hqr
   simp at H
   have hq: (q : ℚ)⁻¹ ≤ 4⁻¹ := by
     rw [inv_le_inv _ h4]

--- a/Mathlib/RingTheory/SimpleModule.lean
+++ b/Mathlib/RingTheory/SimpleModule.lean
@@ -50,13 +50,6 @@ theorem IsSimpleModule.nontrivial [IsSimpleModule R M] : Nontrivial M :=
   ⟨⟨0, by
       have h : (⊥ : Submodule R M) ≠ ⊤ := bot_ne_top
       contrapose! h
-      -- Porting note: push_neg at h not giving fun y => 0 = y
-      have h : ∀ (y : M), 0 = y := by
-        intro y
-        have em := Classical.em (0 = y)
-        match em with
-        | .inl h' => exact h'
-        | .inr h' => apply False.elim <| h ⟨y,h'⟩
       ext x
       simp [Submodule.mem_bot, Submodule.mem_top, h x]⟩⟩
 #align is_simple_module.nontrivial IsSimpleModule.nontrivial

--- a/Mathlib/Tactic/PushNeg.lean
+++ b/Mathlib/Tactic/PushNeg.lean
@@ -55,7 +55,8 @@ def transformNegationStep (e : Expr) : SimpM (Option Simp.Step) := do
     catch _ => return none
   let e_whnf ← whnfR e
   let some ex := e_whnf.not? | return Simp.Step.visit { expr := e }
-  match ex.cleanupAnnotations.getAppFnArgs with
+  let ex := (← instantiateMVars ex).cleanupAnnotations
+  match ex.getAppFnArgs with
   | (``Not, #[e]) =>
       return mkSimpStep e (← mkAppM ``not_not_eq #[e])
   | (``And, #[p, q]) =>

--- a/Mathlib/Tactic/PushNeg.lean
+++ b/Mathlib/Tactic/PushNeg.lean
@@ -55,6 +55,7 @@ def transformNegationStep (e : Expr) : SimpM (Option Simp.Step) := do
     catch _ => return none
   let e_whnf ← whnfR e
   let some ex := e_whnf.not? | return Simp.Step.visit { expr := e }
+  let ex := ex.consumeMData
   match ex.getAppFnArgs with
   | (``Not, #[e]) =>
       return mkSimpStep e (← mkAppM ``not_not_eq #[e])

--- a/Mathlib/Tactic/PushNeg.lean
+++ b/Mathlib/Tactic/PushNeg.lean
@@ -55,8 +55,7 @@ def transformNegationStep (e : Expr) : SimpM (Option Simp.Step) := do
     catch _ => return none
   let e_whnf ← whnfR e
   let some ex := e_whnf.not? | return Simp.Step.visit { expr := e }
-  let ex := ex.consumeMData
-  match ex.getAppFnArgs with
+  match ex.cleanupAnnotations.getAppFnArgs with
   | (``Not, #[e]) =>
       return mkSimpStep e (← mkAppM ``not_not_eq #[e])
   | (``And, #[p, q]) =>

--- a/Mathlib/Topology/MetricSpace/PiNat.lean
+++ b/Mathlib/Topology/MetricSpace/PiNat.lean
@@ -515,7 +515,7 @@ theorem firstDiff_lt_shortestPrefixDiff {s : Set (∀ n, E n)} (hs : IsClosed s)
   have A := exists_disjoint_cylinder hs hx
   rw [shortestPrefixDiff, dif_pos A]
   have B := Nat.find_spec A
-  contrapose! B; rw [not_lt] at B -- porting note: why this `rw` is needed?
+  contrapose! B
   rw [not_disjoint_iff_nonempty_inter]
   refine' ⟨y, hy, _⟩
   rw [mem_cylinder_comm]

--- a/test/byContra.lean
+++ b/test/byContra.lean
@@ -32,3 +32,24 @@ example (p : Prop) (bar : False) : ¬ ¬ ¬ ¬ ¬ ¬ P := by
   by_contra' : ¬ ¬ ¬ P
   guard_hyp this : ¬ ¬ ¬ P
   exact bar
+
+variable [LinearOrder α] [One α] [Mul α]
+
+example (x : α) (f : False) : x ≤ 1 := by
+  set a := x * x
+  by_contra' h
+  guard_hyp h : 1 < x
+  assumption
+
+example (x : α) (f : False) : x ≤ 1 := by
+  let _a := x * x
+  by_contra' h
+  guard_hyp h : 1 < x
+  assumption
+
+example (x : α) (f : False) : x ≤ 1 := by
+  set a := x * x
+  have : a ≤ a := le_rfl
+  by_contra' h
+  guard_hyp h : 1 < x
+  assumption


### PR DESCRIPTION
`Expr`s now have an `mdata` field.  It seems that this gets in the way of `push_neg`, as [reported on Zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/push_neg.20behavior).

The above seems to fix the reported errors.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
