### PR TITLE
[Merged by Bors] - chore: use mathport output in FieldTheory.SplittingField.Construction

### DIFF
--- a/Mathlib/FieldTheory/SplittingField/Construction.lean
+++ b/Mathlib/FieldTheory/SplittingField/Construction.lean
@@ -8,7 +8,7 @@ Authors: Chris Hughes
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
-import Mathbin.FieldTheory.Normal
+import Mathlib.FieldTheory.Normal
 
 /-!
 # Splitting fields
@@ -17,18 +17,18 @@ In this file we prove the existence and uniqueness of splitting fields.
 
 ## Main definitions
 
-* `polynomial.splitting_field f`: A fixed splitting field of the polynomial `f`.
+* `Polynomial.SplittingField f`: A fixed splitting field of the polynomial `f`.
 
 ## Main statements
 
-* `polynomial.is_splitting_field.alg_equiv`: Every splitting field of a polynomial `f` is isomorphic
+* `Polynomial.IsSplittingField.algEquiv`: Every splitting field of a polynomial `f` is isomorphic
   to `splitting_field f` and thus, being a splitting field is unique up to isomorphism.
 
 ## Implementation details
-We construct a `splitting_field_aux` without worrying about whether the instances satisfy nice
-definitional equalities. Then the actual `splitting_field` is defined to be a quotient of a
-`mv_polynomial` ring by the kernel of the obvious map into `splitting_field_aux`. Because the
-actual `splitting_field` will be a quotient of a `mv_polynomial`, it has nice instances on it.
+We construct a `SplittingFieldAux` without worrying about whether the instances satisfy nice
+definitional equalities. Then the actual `SplittingField` is defined to be a quotient of a
+`MvPolynomial` ring by the kernel of the obvious map into `SplittingFieldAux`. Because the
+actual `SplittingField` will be a quotient of a `MvPolynomial`, it has nice instances on it.
 
 -/
 
@@ -54,8 +54,11 @@ def factor (f : K[X]) : K[X] :=
   if H : ∃ g, Irreducible g ∧ g ∣ f then Classical.choose H else X
 #align polynomial.factor Polynomial.factor
 
-theorem irreducible_factor (f : K[X]) : Irreducible (factor f) := by rw [factor]; split_ifs with H;
-  · exact (Classical.choose_spec H).1; · exact irreducible_X
+theorem irreducible_factor (f : K[X]) : Irreducible (factor f) := by
+  rw [factor]
+  split_ifs with H
+  · exact (Classical.choose_spec H).1
+  · exact irreducible_X
 #align polynomial.irreducible_factor Polynomial.irreducible_factor
 
 /-- See note [fact non-instances]. -/
@@ -85,21 +88,24 @@ def removeFactor (f : K[X]) : Polynomial (AdjoinRoot <| factor f) :=
   map (AdjoinRoot.of f.factor) f /ₘ (X - C (AdjoinRoot.root f.factor))
 #align polynomial.remove_factor Polynomial.removeFactor
 
-theorem x_sub_c_mul_removeFactor (f : K[X]) (hf : f.natDegree ≠ 0) :
-    (X - C (AdjoinRoot.root f.factor)) * f.removeFactor = map (AdjoinRoot.of f.factor) f :=
+theorem X_sub_C_mul_removeFactor (f : K[X]) (hf : f.natDegree ≠ 0) :
+    (X - C (AdjoinRoot.root f.factor)) * f.removeFactor = map (AdjoinRoot.of f.factor) f := by
   let ⟨g, hg⟩ := factor_dvd_of_natDegree_ne_zero hf
-  mul_divByMonic_eq_iff_isRoot.2 <| by
-    rw [is_root.def, eval_map, hg, eval₂_mul, ← hg, AdjoinRoot.eval₂_root, MulZeroClass.zero_mul]
-#align polynomial.X_sub_C_mul_remove_factor Polynomial.x_sub_c_mul_removeFactor
+  apply (mul_divByMonic_eq_iff_isRoot
+    (R := AdjoinRoot f.factor) (a := AdjoinRoot.root f.factor)).mpr
+  rw [IsRoot.def, eval_map, hg, eval₂_mul, ← hg, AdjoinRoot.eval₂_root, MulZeroClass.zero_mul]
+set_option linter.uppercaseLean3 false in
+#align polynomial.X_sub_C_mul_remove_factor Polynomial.X_sub_C_mul_removeFactor
 
 theorem natDegree_removeFactor (f : K[X]) : f.removeFactor.natDegree = f.natDegree - 1 := by
-  rw [remove_factor, nat_degree_div_by_monic _ (monic_X_sub_C _), nat_degree_map,
-    nat_degree_X_sub_C]
+  -- Porting note: `(map (AdjoinRoot.of f.factor) f)` was `_`
+  rw [removeFactor, natDegree_divByMonic (map (AdjoinRoot.of f.factor) f) (monic_X_sub_C _),
+    natDegree_map, natDegree_X_sub_C]
 #align polynomial.nat_degree_remove_factor Polynomial.natDegree_removeFactor
 
-theorem natDegree_remove_factor' {f : K[X]} {n : ℕ} (hfn : f.natDegree = n + 1) :
-    f.removeFactor.natDegree = n := by rw [nat_degree_remove_factor, hfn, n.add_sub_cancel]
-#align polynomial.nat_degree_remove_factor' Polynomial.natDegree_remove_factor'
+theorem natDegree_removeFactor' {f : K[X]} {n : ℕ} (hfn : f.natDegree = n + 1) :
+  f.removeFactor.natDegree = n := by rw [natDegree_removeFactor, hfn, n.add_sub_cancel]
+#align polynomial.nat_degree_remove_factor' Polynomial.natDegree_removeFactor'
 
 /-- Auxiliary construction to a splitting field of a polynomial, which removes
 `n` (arbitrarily-chosen) factors.
@@ -108,25 +114,26 @@ It constructs the type, proves that is a field and algebra over the base field.
 
 Uses recursion on the degree.
 -/
-def splittingFieldAuxAux (n : ℕ) :
-    ∀ {K : Type u} [Field K], ∀ f : K[X], Σ (L : Type u) (inst : Field L), Algebra K L :=
-  Nat.recOn n (fun K inst f => ⟨K, inst, inferInstance⟩) fun m ih K inst f =>
-    let L := ih (@removeFactor K inst f)
-    let h₁ := L.2.1
-    let h₂ := L.2.2
-    ⟨L.1, L.2.1, (RingHom.comp (algebraMap _ _) (AdjoinRoot.of f.factor)).toAlgebra⟩
-#align polynomial.splitting_field_aux_aux Polynomial.splittingFieldAuxAux
+def SplittingFieldAuxAux (n : ℕ) : ∀ {K : Type u} [Field K], ∀ _ : K[X],
+    Σ (L : Type u) (_ : Field L), Algebra K L :=
+  -- Porting note: added motive
+  Nat.recOn (motive := fun (_x : ℕ) => ∀ {K : Type u} [_inst_4 : Field K], K[X] →
+      Σ (L : Type u) (_ : Field L), Algebra K L) n
+    (fun {K} _ _ => ⟨K, inferInstance, inferInstance⟩)
+    fun _ ih _ _ f =>
+      let ⟨L, fL, _⟩ := ih f.removeFactor
+      ⟨L, fL, (RingHom.comp (algebraMap _ _) (AdjoinRoot.of f.factor)).toAlgebra⟩
 
 /-- Auxiliary construction to a splitting field of a polynomial, which removes
 `n` (arbitrarily-chosen) factors. It is the type constructed in `splitting_field_aux_aux`.
 -/
 def SplittingFieldAux (n : ℕ) {K : Type u} [Field K] (f : K[X]) : Type u :=
-  (splittingFieldAuxAux n f).1
+  (SplittingFieldAuxAux n f).1
 #align polynomial.splitting_field_aux Polynomial.SplittingFieldAux
 
 instance SplittingFieldAux.field (n : ℕ) {K : Type u} [Field K] (f : K[X]) :
     Field (SplittingFieldAux n f) :=
-  (splittingFieldAuxAux n f).2.1
+  (SplittingFieldAuxAux n f).2.1
 #align polynomial.splitting_field_aux.field Polynomial.SplittingFieldAux.field
 
 instance (n : ℕ) {K : Type u} [Field K] (f : K[X]) : Inhabited (SplittingFieldAux n f) :=
@@ -134,7 +141,7 @@ instance (n : ℕ) {K : Type u} [Field K] (f : K[X]) : Inhabited (SplittingField
 
 instance SplittingFieldAux.algebra (n : ℕ) {K : Type u} [Field K] (f : K[X]) :
     Algebra K (SplittingFieldAux n f) :=
-  (splittingFieldAuxAux n f).2.2
+  (SplittingFieldAuxAux n f).2.2
 #align polynomial.splitting_field_aux.algebra Polynomial.SplittingFieldAux.algebra
 
 namespace SplittingFieldAux
@@ -143,6 +150,27 @@ theorem succ (n : ℕ) (f : K[X]) :
     SplittingFieldAux (n + 1) f = SplittingFieldAux n f.removeFactor :=
   rfl
 #align polynomial.splitting_field_aux.succ Polynomial.SplittingFieldAux.succ
+
+section LiftInstances
+
+#noalign polynomial.splitting_field_aux.zero
+#noalign polynomial.splitting_field_aux.add
+#noalign polynomial.splitting_field_aux.smul
+#noalign polynomial.splitting_field_aux.is_scalar_tower
+#noalign polynomial.splitting_field_aux.neg
+#noalign polynomial.splitting_field_aux.sub
+#noalign polynomial.splitting_field_aux.one
+#noalign polynomial.splitting_field_aux.mul
+#noalign polynomial.splitting_field_aux.npow
+#noalign polynomial.splitting_field_aux.mk
+#noalign polynomial.splitting_field_aux.Inv
+#noalign polynomial.splitting_field_aux.div
+#noalign polynomial.splitting_field_aux.zpow
+#noalign polynomial.splitting_field_aux.Field
+#noalign polynomial.splitting_field_aux.inhabited
+#noalign polynomial.splitting_field_aux.mk_hom
+
+end LiftInstances
 
 instance algebra''' {n : ℕ} {f : K[X]} :
     Algebra (AdjoinRoot f.factor) (SplittingFieldAux n f.removeFactor) :=
@@ -159,51 +187,60 @@ instance algebra'' {n : ℕ} {f : K[X]} : Algebra K (SplittingFieldAux n f.remov
 
 instance scalar_tower' {n : ℕ} {f : K[X]} :
     IsScalarTower K (AdjoinRoot f.factor) (SplittingFieldAux n f.removeFactor) :=
-  IsScalarTower.of_algebraMap_eq fun x => rfl
+  IsScalarTower.of_algebraMap_eq fun _ => rfl
 #align polynomial.splitting_field_aux.scalar_tower' Polynomial.SplittingFieldAux.scalar_tower'
 
 theorem algebraMap_succ (n : ℕ) (f : K[X]) :
-    algebraMap K (splitting_field_aux (n + 1) f) =
-      (algebraMap (AdjoinRoot f.factor) (splitting_field_aux n f.remove_factor)).comp
+    algebraMap K (SplittingFieldAux (n + 1) f) =
+      (algebraMap (AdjoinRoot f.factor) (SplittingFieldAux n f.removeFactor)).comp
         (AdjoinRoot.of f.factor) :=
   rfl
 #align polynomial.splitting_field_aux.algebra_map_succ Polynomial.SplittingFieldAux.algebraMap_succ
 
 protected theorem splits (n : ℕ) :
     ∀ {K : Type u} [Field K],
-      ∀ (f : K[X]) (hfn : f.natDegree = n), splits (algebraMap K <| splitting_field_aux n f) f :=
-  Nat.recOn n
-    (fun K _ _ hf =>
+      ∀ (f : K[X]) (_hfn : f.natDegree = n), Splits (algebraMap K <| SplittingFieldAux n f) f :=
+  Nat.recOn (motive := fun n => ∀ {K : Type u} [Field K],
+      ∀ (f : K[X]) (_hfn : f.natDegree = n), Splits (algebraMap K <| SplittingFieldAux n f) f) n
+    (fun {K} _ _ hf =>
       splits_of_degree_le_one _
-        (le_trans degree_le_nat_degree <| hf.symm ▸ WithBot.coe_le_coe.2 zero_le_one))
-    fun n ih K _ f hf => by
-    skip;
-    rw [← splits_id_iff_splits, algebra_map_succ, ← map_map, splits_id_iff_splits, ←
-      X_sub_C_mul_remove_factor f fun h => by rw [h] at hf ; cases hf]
-    exact splits_mul _ (splits_X_sub_C _) (ih _ (nat_degree_remove_factor' hf))
+        (le_trans degree_le_natDegree <| hf.symm ▸ WithBot.coe_le_coe.2 zero_le_one))
+    fun n ih {K} _ f hf => by
+    rw [← splits_id_iff_splits, algebraMap_succ, ← map_map, splits_id_iff_splits,
+      ← X_sub_C_mul_removeFactor f fun h => by rw [h] at hf ; cases hf]
+    exact splits_mul _ (splits_X_sub_C _) (ih _ (natDegree_removeFactor' hf))
 #align polynomial.splitting_field_aux.splits Polynomial.SplittingFieldAux.splits
 
 theorem adjoin_rootSet (n : ℕ) :
     ∀ {K : Type u} [Field K],
-      ∀ (f : K[X]) (hfn : f.natDegree = n),
-        Algebra.adjoin K (f.rootSet (splitting_field_aux n f)) = ⊤ :=
-  Nat.recOn n (fun K _ f hf => Algebra.eq_top_iff.2 fun x => Subalgebra.range_le _ ⟨x, rfl⟩)
-    fun n ih K _ f hfn =>
-    by
-    have hndf : f.nat_degree ≠ 0 := by intro h; rw [h] at hfn ; cases hfn
+      ∀ (f : K[X]) (_hfn : f.natDegree = n),
+        Algebra.adjoin K (f.rootSet (SplittingFieldAux n f)) = ⊤ :=
+  Nat.recOn (motive := fun n =>
+    ∀ {K : Type u} [Field K],
+      ∀ (f : K[X]) (_hfn : f.natDegree = n),
+        Algebra.adjoin K
+            (↑(f.map <| algebraMap K <| SplittingFieldAux n f).roots.toFinset :
+              Set (SplittingFieldAux n f)) = ⊤)
+    n (fun {K} _ f _hf => Algebra.eq_top_iff.2 fun x => Subalgebra.range_le _ ⟨x, rfl⟩)
+    fun n ih {K} _ f hfn => by
+    have hndf : f.natDegree ≠ 0 := by intro h; rw [h] at hfn ; cases hfn
     have hfn0 : f ≠ 0 := by intro h; rw [h] at hndf ; exact hndf rfl
-    have hmf0 : map (algebraMap K (splitting_field_aux n.succ f)) f ≠ 0 := map_ne_zero hfn0
-    simp_rw [root_set] at ih ⊢
-    rw [algebra_map_succ, ← map_map, ← X_sub_C_mul_remove_factor _ hndf, Polynomial.map_mul] at hmf0
-      ⊢
+    have hmf0 : map (algebraMap K (SplittingFieldAux n.succ f)) f ≠ 0 := map_ne_zero hfn0
+    rw [algebraMap_succ, ←map_map, ←X_sub_C_mul_removeFactor _ hndf, Polynomial.map_mul] at hmf0 ⊢
     rw [roots_mul hmf0, Polynomial.map_sub, map_X, map_C, roots_X_sub_C, Multiset.toFinset_add,
       Finset.coe_union, Multiset.toFinset_singleton, Finset.coe_singleton,
       Algebra.adjoin_union_eq_adjoin_adjoin, ← Set.image_singleton,
-      Algebra.adjoin_algebraMap K (AdjoinRoot f.factor) (splitting_field_aux n f.remove_factor),
-      AdjoinRoot.adjoinRoot_eq_top, Algebra.map_top,
-      IsScalarTower.adjoin_range_toAlgHom K (AdjoinRoot f.factor)
-        (splitting_field_aux n f.remove_factor),
-      ih _ (nat_degree_remove_factor' hfn), Subalgebra.restrictScalars_top]
+      Algebra.adjoin_algebraMap K (AdjoinRoot f.factor) (SplittingFieldAux n f.removeFactor),
+      AdjoinRoot.adjoinRoot_eq_top, Algebra.map_top]
+    /- Porting note: was `rw [IsScalarTower.adjoin_range_toAlgHom K (AdjoinRoot f.factor)
+        (SplittingFieldAux n f.removeFactor)]` -/
+    have := IsScalarTower.adjoin_range_toAlgHom K (AdjoinRoot f.factor)
+        (SplittingFieldAux n f.removeFactor)
+        (↑(f.removeFactor.map <| algebraMap (AdjoinRoot f.factor) <|
+          SplittingFieldAux n f.removeFactor).roots.toFinset :
+              Set (SplittingFieldAux n f.removeFactor))
+    refine this.trans ?_
+    rw [ih _ (natDegree_removeFactor' hfn), Subalgebra.restrictScalars_top]
 #align polynomial.splitting_field_aux.adjoin_root_set Polynomial.SplittingFieldAux.adjoin_rootSet
 
 instance (f : K[X]) : IsSplittingField K (SplittingFieldAux f.natDegree f) f :=
@@ -217,13 +254,14 @@ def ofMvPolynomial (f : K[X]) :
   MvPolynomial.aeval fun i => i.1
 #align polynomial.splitting_field_aux.of_mv_polynomial Polynomial.SplittingFieldAux.ofMvPolynomial
 
-theorem ofMvPolynomial_surjective (f : K[X]) : Function.Surjective (ofMvPolynomial f) :=
-  by
-  suffices AlgHom.range (of_mv_polynomial f) = ⊤ by
-    rw [← Set.range_iff_surjective] <;> rwa [SetLike.ext'_iff] at this
-  rw [of_mv_polynomial, ← Algebra.adjoin_range_eq_range_aeval K, eq_top_iff, ←
-    adjoin_root_set _ _ rfl]
-  exact Algebra.adjoin_le fun α hα => Algebra.subset_adjoin ⟨⟨α, hα⟩, rfl⟩
+theorem ofMvPolynomial_surjective (f : K[X]) : Function.Surjective (ofMvPolynomial f) := by
+  suffices AlgHom.range (ofMvPolynomial f) = ⊤ by
+    rw [← Set.range_iff_surjective]; rwa [SetLike.ext'_iff] at this
+  rw [ofMvPolynomial, ← Algebra.adjoin_range_eq_range_aeval K, eq_top_iff, ← adjoin_rootSet _ _ rfl]
+  apply Algebra.adjoin_le
+  intro α hα
+  apply Algebra.subset_adjoin
+  exact ⟨⟨α, hα⟩, rfl⟩
 #align polynomial.splitting_field_aux.of_mv_polynomial_surjective Polynomial.SplittingFieldAux.ofMvPolynomial_surjective
 
 /-- The algebra isomorphism between the quotient of
@@ -281,40 +319,34 @@ def algEquivSplittingFieldAux (f : K[X]) : SplittingField f ≃ₐ[K] SplittingF
 
 instance : Field (SplittingField f) :=
   let e := algEquivSplittingFieldAux f
-  {
-    SplittingField.commRing
-      f with
+  { toCommRing := SplittingField.commRing f
     ratCast := fun a => algebraMap K _ (a : K)
     inv := fun a => e.symm (e a)⁻¹
     qsmul := (· • ·)
     qsmul_eq_mul' := fun a x =>
-      Quotient.inductionOn' x fun p =>
-        congr_arg Quotient.mk''
-          (by
-            ext
-            simp only [MvPolynomial.algebraMap_eq, Rat.smul_def, MvPolynomial.coeff_smul,
-              MvPolynomial.coeff_C_mul])
+      Quotient.inductionOn x (fun p => congr_arg Quotient.mk''
+        (by ext; simp [MvPolynomial.algebraMap_eq, Rat.smul_def]))
     ratCast_mk := fun a b h1 h2 => by
-      apply e.injective
+      apply_fun e
       change e (algebraMap K _ _) = _
-      simp only [map_ratCast, map_natCast, map_mul, map_intCast, AlgEquiv.commutes]
-      change _ = e ↑a * e (e.symm (e b)⁻¹)
-      rw [AlgEquiv.apply_symm_apply]
-      convert Field.ratCast_mk a b h1 h2
-      all_goals simp
-    exists_pair_ne := ⟨e.symm 0, e.symm 1, fun w => zero_ne_one (e.symm.Injective w)⟩
+      simp only [map_ratCast, map_natCast, map_mul, map_intCast, AlgEquiv.commutes,
+        AlgEquiv.apply_symm_apply]
+      apply Field.ratCast_mk
+    exists_pair_ne := ⟨e.symm 0, e.symm 1, fun w => zero_ne_one ((e.symm).injective w)⟩
     mul_inv_cancel := fun a w => by
-      apply e.injective
-      rw [map_mul, map_one]
-      change e a * e (e.symm (e a)⁻¹) = 1
-      rw [AlgEquiv.apply_symm_apply, mul_inv_cancel]
-      exact fun w' => w (by simpa only [AddEquivClass.map_eq_zero_iff] using w')
-    inv_zero := by
-      change e.symm (e 0)⁻¹ = 0
-      simp }
+      -- This could surely be golfed.
+      apply_fun e
+      have : e a ≠ 0 := fun w' => by
+        apply w
+        simp at w'
+        exact w'
+      simp only [map_mul, AlgEquiv.apply_symm_apply, ne_eq, AddEquivClass.map_eq_zero_iff, map_one]
+      rw [mul_inv_cancel]
+      assumption
+    inv_zero := by simp }
 
 instance [CharZero K] : CharZero (SplittingField f) :=
-  charZero_of_injective_algebraMap (algebraMap K _).Injective
+  charZero_of_injective_algebraMap (algebraMap K _).injective
 
 -- The algebra instance deriving from `K` should be definitionally equal to that
 -- deriving from the field structure on `splitting_field f`.
@@ -334,7 +366,7 @@ example [CharZero K] : SplittingField.algebra' f = algebraRat :=
 example {q : ℚ[X]} : algebraInt (SplittingField q) = SplittingField.algebra' q :=
   rfl
 
-instance Polynomial.IsSplittingField.splittingField (f : K[X]) :
+instance _root_.Polynomial.IsSplittingField.splittingField (f : K[X]) :
     IsSplittingField K (SplittingField f) f :=
   IsSplittingField.of_algEquiv _ f (SplittingFieldAux.algEquivQuotientMvPolynomial f).symm
 #align polynomial.is_splitting_field.splitting_field Polynomial.IsSplittingField.splittingField
@@ -360,7 +392,8 @@ end SplittingField
 
 namespace IsSplittingField
 
-variable (K L) [Algebra K L]
+variable (K L)
+variable [Algebra K L]
 
 variable {K}
 
@@ -374,24 +407,23 @@ instance (f : K[X]) : NoZeroSMulDivisors K f.SplittingField :=
   inferInstance
 
 /-- Any splitting field is isomorphic to `splitting_field f`. -/
-def algEquiv (f : K[X]) [IsSplittingField K L f] : L ≃ₐ[K] SplittingField f :=
-  by
+def algEquiv (f : K[X]) [IsSplittingField K L f] : L ≃ₐ[K] SplittingField f := by
   refine'
-    AlgEquiv.ofBijective (lift L f <| splits (splitting_field f) f)
-      ⟨RingHom.injective (lift L f <| splits (splitting_field f) f).toRingHom, _⟩
-  haveI := FiniteDimensional (splitting_field f) f
-  haveI := FiniteDimensional L f
-  have : FiniteDimensional.finrank K L = FiniteDimensional.finrank K (splitting_field f) :=
+    AlgEquiv.ofBijective (lift L f <| splits (SplittingField f) f)
+      ⟨RingHom.injective (lift L f <| splits (SplittingField f) f).toRingHom, _⟩
+  haveI := finiteDimensional (SplittingField f) f
+  haveI := finiteDimensional L f
+  have : FiniteDimensional.finrank K L = FiniteDimensional.finrank K (SplittingField f) :=
     le_antisymm
       (LinearMap.finrank_le_finrank_of_injective
-        (show Function.Injective (lift L f <| splits (splitting_field f) f).toLinearMap from
-          RingHom.injective (lift L f <| splits (splitting_field f) f : L →+* f.splitting_field)))
+        (show Function.Injective (lift L f <| splits (SplittingField f) f).toLinearMap from
+          RingHom.injective (lift L f <| splits (SplittingField f) f : L →+* f.SplittingField)))
       (LinearMap.finrank_le_finrank_of_injective
-        (show Function.Injective (lift (splitting_field f) f <| splits L f).toLinearMap from
-          RingHom.injective (lift (splitting_field f) f <| splits L f : f.splitting_field →+* L)))
-  change Function.Surjective (lift L f <| splits (splitting_field f) f).toLinearMap
+        (show Function.Injective (lift (SplittingField f) f <| splits L f).toLinearMap from
+          RingHom.injective (lift (SplittingField f) f <| splits L f : f.SplittingField →+* L)))
+  change Function.Surjective (lift L f <| splits (SplittingField f) f).toLinearMap
   refine' (LinearMap.injective_iff_surjective_of_finrank_eq_finrank this).1 _
-  exact RingHom.injective (lift L f <| splits (splitting_field f) f : L →+* f.splitting_field)
+  exact RingHom.injective (lift L f <| splits (SplittingField f) f : L →+* f.SplittingField)
 #align polynomial.is_splitting_field.alg_equiv Polynomial.IsSplittingField.algEquiv
 
 end IsSplittingField

--- a/Mathlib/FieldTheory/SplittingField/Construction.lean
+++ b/Mathlib/FieldTheory/SplittingField/Construction.lean
@@ -68,8 +68,7 @@ theorem fact_irreducible_factor (f : K[X]) : Fact (Irreducible (factor f)) :=
 
 attribute [local instance] fact_irreducible_factor
 
-theorem factor_dvd_of_not_isUnit {f : K[X]} (hf1 : ¬IsUnit f) : factor f ∣ f :=
-  by
+theorem factor_dvd_of_not_isUnit {f : K[X]} (hf1 : ¬IsUnit f) : factor f ∣ f := by
   by_cases hf2 : f = 0; · rw [hf2]; exact dvd_zero _
   rw [factor, dif_pos (WfDvdMonoid.exists_irreducible_factor hf1 hf2)]
   exact (Classical.choose_spec <| WfDvdMonoid.exists_irreducible_factor hf1 hf2).2

--- a/Mathlib/FieldTheory/SplittingField/Construction.lean
+++ b/Mathlib/FieldTheory/SplittingField/Construction.lean
@@ -122,6 +122,7 @@ def SplittingFieldAuxAux (n : ℕ) : ∀ {K : Type u} [Field K], ∀ _ : K[X],
     fun _ ih _ _ f =>
       let ⟨L, fL, _⟩ := ih f.removeFactor
       ⟨L, fL, (RingHom.comp (algebraMap _ _) (AdjoinRoot.of f.factor)).toAlgebra⟩
+#align polynomial.splitting_field_aux_aux Polynomial.SplittingFieldAuxAux
 
 /-- Auxiliary construction to a splitting field of a polynomial, which removes
 `n` (arbitrarily-chosen) factors. It is the type constructed in `SplittingFieldAuxAux`.

--- a/Mathlib/FieldTheory/SplittingField/Construction.lean
+++ b/Mathlib/FieldTheory/SplittingField/Construction.lean
@@ -82,7 +82,7 @@ theorem factor_dvd_of_natDegree_ne_zero {f : K[X]} (hf : f.natDegree ≠ 0) : fa
   factor_dvd_of_degree_ne_zero (mt natDegree_eq_of_degree_eq_some hf)
 #align polynomial.factor_dvd_of_nat_degree_ne_zero Polynomial.factor_dvd_of_natDegree_ne_zero
 
-/-- Divide a polynomial f by X - C r where r is a root of f in a bigger field extension. -/
+/-- Divide a polynomial f by `X - C r` where `r` is a root of `f` in a bigger field extension. -/
 def removeFactor (f : K[X]) : Polynomial (AdjoinRoot <| factor f) :=
   map (AdjoinRoot.of f.factor) f /ₘ (X - C (AdjoinRoot.root f.factor))
 #align polynomial.remove_factor Polynomial.removeFactor
@@ -124,7 +124,7 @@ def SplittingFieldAuxAux (n : ℕ) : ∀ {K : Type u} [Field K], ∀ _ : K[X],
       ⟨L, fL, (RingHom.comp (algebraMap _ _) (AdjoinRoot.of f.factor)).toAlgebra⟩
 
 /-- Auxiliary construction to a splitting field of a polynomial, which removes
-`n` (arbitrarily-chosen) factors. It is the type constructed in `splitting_field_aux_aux`.
+`n` (arbitrarily-chosen) factors. It is the type constructed in `SplittingFieldAuxAux`.
 -/
 def SplittingFieldAux (n : ℕ) {K : Type u} [Field K] (f : K[X]) : Type u :=
   (SplittingFieldAuxAux n f).1
@@ -245,8 +245,8 @@ theorem adjoin_rootSet (n : ℕ) :
 instance (f : K[X]) : IsSplittingField K (SplittingFieldAux f.natDegree f) f :=
   ⟨SplittingFieldAux.splits _ _ rfl, SplittingFieldAux.adjoin_rootSet _ _ rfl⟩
 
-/-- The natural map from `mv_polynomial (f.root_set (splitting_field_aux f.nat_degree f))`
-to `splitting_field_aux f.nat_degree f` sendind a variable to the corresponding root. -/
+/-- The natural map from `MvPolynomial (f.rootSet (SplittingFieldAux f.natDegree f))`
+to `SplittingFieldAux f.natDegree f` sendind a variable to the corresponding root. -/
 def ofMvPolynomial (f : K[X]) :
     MvPolynomial (f.rootSet (SplittingFieldAux f.natDegree f)) K →ₐ[K]
       SplittingFieldAux f.natDegree f :=
@@ -264,9 +264,9 @@ theorem ofMvPolynomial_surjective (f : K[X]) : Function.Surjective (ofMvPolynomi
 #align polynomial.splitting_field_aux.of_mv_polynomial_surjective Polynomial.SplittingFieldAux.ofMvPolynomial_surjective
 
 /-- The algebra isomorphism between the quotient of
-`mv_polynomial (f.root_set (splitting_field_aux f.nat_degree f)) K` by the kernel of
-`of_mv_polynomial f` and `splitting_field_aux f.nat_degree f`. It is used to transport all the
-algebraic structures from the latter to `f.splitting_field`, that is defined as the former. -/
+`MvPolynomial (f.rootSet (SplittingFieldAuxAux f.natDegree f)) K` by the kernel of
+`ofMvPolynomial f` and `SplittingFieldAux f.natDegree f`. It is used to transport all the
+algebraic structures from the latter to `f.SplittingFieldAux`, that is defined as the former. -/
 def algEquivQuotientMvPolynomial (f : K[X]) :
     (MvPolynomial (f.rootSet (SplittingFieldAux f.natDegree f)) K ⧸
         RingHom.ker (ofMvPolynomial f).toRingHom) ≃ₐ[K]
@@ -310,7 +310,7 @@ instance isScalarTower {R : Type _} [CommSemiring R] [Algebra R K] :
   Ideal.Quotient.isScalarTower _ _ _
 #align polynomial.splitting_field.is_scalar_tower Polynomial.SplittingField.isScalarTower
 
-/-- The algebra equivalence with `splitting_field_aux`,
+/-- The algebra equivalence with `SplittingFieldAux`,
 which we will use to construct the field structure. -/
 def algEquivSplittingFieldAux (f : K[X]) : SplittingField f ≃ₐ[K] SplittingFieldAux f.natDegree f :=
   SplittingFieldAux.algEquivQuotientMvPolynomial f
@@ -348,7 +348,7 @@ instance [CharZero K] : CharZero (SplittingField f) :=
   charZero_of_injective_algebraMap (algebraMap K _).injective
 
 -- The algebra instance deriving from `K` should be definitionally equal to that
--- deriving from the field structure on `splitting_field f`.
+-- deriving from the field structure on `SplittingField f`.
 example :
     (AddCommMonoid.natModule : Module ℕ (SplittingField f)) =
       @Algebra.toModule _ _ _ _ (SplittingField.algebra' f) :=
@@ -405,7 +405,7 @@ instance [Fintype K] (f : K[X]) : Fintype f.SplittingField :=
 instance (f : K[X]) : NoZeroSMulDivisors K f.SplittingField :=
   inferInstance
 
-/-- Any splitting field is isomorphic to `splitting_field f`. -/
+/-- Any splitting field is isomorphic to `SplittingFieldAux f`. -/
 def algEquiv (f : K[X]) [IsSplittingField K L f] : L ≃ₐ[K] SplittingField f := by
   refine'
     AlgEquiv.ofBijective (lift L f <| splits (SplittingField f) f)

--- a/Mathlib/FieldTheory/SplittingField/Construction.lean
+++ b/Mathlib/FieldTheory/SplittingField/Construction.lean
@@ -151,27 +151,6 @@ theorem succ (n : ℕ) (f : K[X]) :
   rfl
 #align polynomial.splitting_field_aux.succ Polynomial.SplittingFieldAux.succ
 
-section LiftInstances
-
-#noalign polynomial.splitting_field_aux.zero
-#noalign polynomial.splitting_field_aux.add
-#noalign polynomial.splitting_field_aux.smul
-#noalign polynomial.splitting_field_aux.is_scalar_tower
-#noalign polynomial.splitting_field_aux.neg
-#noalign polynomial.splitting_field_aux.sub
-#noalign polynomial.splitting_field_aux.one
-#noalign polynomial.splitting_field_aux.mul
-#noalign polynomial.splitting_field_aux.npow
-#noalign polynomial.splitting_field_aux.mk
-#noalign polynomial.splitting_field_aux.Inv
-#noalign polynomial.splitting_field_aux.div
-#noalign polynomial.splitting_field_aux.zpow
-#noalign polynomial.splitting_field_aux.Field
-#noalign polynomial.splitting_field_aux.inhabited
-#noalign polynomial.splitting_field_aux.mk_hom
-
-end LiftInstances
-
 instance algebra''' {n : ℕ} {f : K[X]} :
     Algebra (AdjoinRoot f.factor) (SplittingFieldAux n f.removeFactor) :=
   SplittingFieldAux.algebra n _

--- a/Mathlib/FieldTheory/SplittingField/Construction.lean
+++ b/Mathlib/FieldTheory/SplittingField/Construction.lean
@@ -22,7 +22,7 @@ In this file we prove the existence and uniqueness of splitting fields.
 ## Main statements
 
 * `Polynomial.IsSplittingField.algEquiv`: Every splitting field of a polynomial `f` is isomorphic
-  to `splitting_field f` and thus, being a splitting field is unique up to isomorphism.
+  to `SplittingField f` and thus, being a splitting field is unique up to isomorphism.
 
 ## Implementation details
 We construct a `SplittingFieldAux` without worrying about whether the instances satisfy nice


### PR DESCRIPTION
The mathlib3 version was manually backported from the mathlib4 version. We use here the mathport output.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
