### PR TITLE
perf: expand Measure in all variable lines

### DIFF
--- a/Mathlib/Analysis/Calculus/BumpFunctionInner.lean
+++ b/Mathlib/Analysis/Calculus/BumpFunctionInner.lean
@@ -479,7 +479,7 @@ protected theorem continuous : Continuous f :=
 
 open MeasureTheory
 
-variable [MeasurableSpace E] {μ : Measure E}
+variable [MeasurableSpace E] {μ : MeasureTheory.Measure E}
 
 /-- A bump function normed so that `∫ x, f.normed μ x ∂μ = 1`. -/
 protected def normed (μ : Measure E) : E → ℝ := fun x => f x / ∫ x, f x ∂μ

--- a/Mathlib/Analysis/Calculus/ParametricIntegral.lean
+++ b/Mathlib/Analysis/Calculus/ParametricIntegral.lean
@@ -62,7 +62,8 @@ open TopologicalSpace MeasureTheory Filter Metric
 
 open scoped Topology Filter
 
-variable {α : Type _} [MeasurableSpace α] {μ : Measure α} {𝕜 : Type _} [IsROrC 𝕜] {E : Type _}
+variable {α : Type _} [MeasurableSpace α] {μ : MeasureTheory.Measure α}
+  {𝕜 : Type _} [IsROrC 𝕜] {E : Type _}
   [NormedAddCommGroup E] [NormedSpace ℝ E] [NormedSpace 𝕜 E] [CompleteSpace E] {H : Type _}
   [NormedAddCommGroup H] [NormedSpace 𝕜 H]
 
@@ -92,7 +93,7 @@ theorem hasFDerivAt_integral_of_dominated_loc_of_lip' {F : H → α → E} {F' :
       simp only [norm_sub_rev (F x₀ _)]
       refine' h_lipsch.mono fun a ha => (ha x x_in).trans _
       rw [mul_comm ε]
-      rw [mem_ball, dist_eq_norm] at x_in 
+      rw [mem_ball, dist_eq_norm] at x_in
       exact mul_le_mul_of_nonneg_left x_in.le (b_nonneg _)
     exact integrable_of_norm_sub_le (hF_meas x x_in) hF_int
       (bound_integrable.norm.const_mul ε) this
@@ -144,7 +145,7 @@ theorem hasFDerivAt_integral_of_dominated_loc_of_lip' {F : H → α → E} {F' :
         ‖‖x - x₀‖⁻¹ • (F x a - F x₀ a - F' a (x - x₀))‖ := by
       ext x
       rw [norm_smul_of_nonneg (nneg _)]
-    rwa [hasFDerivAt_iff_tendsto, this] at ha 
+    rwa [hasFDerivAt_iff_tendsto, this] at ha
 #align has_fderiv_at_integral_of_dominated_loc_of_lip' hasFDerivAt_integral_of_dominated_loc_of_lip'
 
 /-- Differentiation under integral of `x ↦ ∫ F x a` at a given point `x₀`, assuming
@@ -215,7 +216,7 @@ theorem hasDerivAt_integral_of_dominated_loc_of_lip {F : 𝕜 → α → E} {F' 
       h_diff with
     hF'_int key
   replace hF'_int : Integrable F' μ
-  · rw [← integrable_norm_iff hm] at hF'_int 
+  · rw [← integrable_norm_iff hm] at hF'_int
     simpa only [(· ∘ ·), integrable_norm_iff, hF'_meas, one_mul, norm_one,
       ContinuousLinearMap.comp_apply, ContinuousLinearMap.coe_restrict_scalarsL',
       ContinuousLinearMap.norm_restrictScalars, ContinuousLinearMap.norm_smulRightL_apply] using
@@ -249,4 +250,3 @@ theorem hasDerivAt_integral_of_dominated_loc_of_deriv_le {F : 𝕜 → α → E}
     hasDerivAt_integral_of_dominated_loc_of_lip ε_pos hF_meas hF_int hF'_meas this bound_integrable
       diff_x₀
 #align has_deriv_at_integral_of_dominated_loc_of_deriv_le hasDerivAt_integral_of_dominated_loc_of_deriv_le
-

--- a/Mathlib/Analysis/Calculus/ParametricIntervalIntegral.lean
+++ b/Mathlib/Analysis/Calculus/ParametricIntervalIntegral.lean
@@ -22,7 +22,7 @@ open TopologicalSpace MeasureTheory Filter Metric
 
 open scoped Topology Filter Interval
 
-variable {𝕜 : Type _} [IsROrC 𝕜] {μ : Measure ℝ} {E : Type _} [NormedAddCommGroup E]
+variable {𝕜 : Type _} [IsROrC 𝕜] {μ : MeasureTheory.Measure ℝ} {E : Type _} [NormedAddCommGroup E]
   [NormedSpace ℝ E] [NormedSpace 𝕜 E] [CompleteSpace E] {H : Type _} [NormedAddCommGroup H]
   [NormedSpace 𝕜 H] {a b ε : ℝ} {bound : ℝ → ℝ}
 

--- a/Mathlib/Analysis/SpecialFunctions/Integrals.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Integrals.lean
@@ -48,7 +48,7 @@ namespace intervalIntegral
 
 open MeasureTheory
 
-variable {f : ℝ → ℝ} {μ ν : Measure ℝ} [IsLocallyFiniteMeasure μ] (c d : ℝ)
+variable {f : ℝ → ℝ} {μ ν : MeasureTheory.Measure ℝ} [IsLocallyFiniteMeasure μ] (c d : ℝ)
 
 /-! ### Interval integrability -/
 

--- a/Mathlib/Dynamics/Ergodic/Conservative.lean
+++ b/Mathlib/Dynamics/Ergodic/Conservative.lean
@@ -47,7 +47,8 @@ open Classical Set Filter MeasureTheory Finset Function TopologicalSpace
 
 open Classical Topology
 
-variable {ι : Type _} {α : Type _} [MeasurableSpace α] {f : α → α} {s : Set α} {μ : Measure α}
+variable {ι : Type _} {α : Type _} [MeasurableSpace α] {f : α → α} {s : Set α}
+  {μ : MeasureTheory.Measure α}
 
 namespace MeasureTheory
 

--- a/Mathlib/Dynamics/Ergodic/Ergodic.lean
+++ b/Mathlib/Dynamics/Ergodic/Ergodic.lean
@@ -60,7 +60,7 @@ structure QuasiErgodic (μ : Measure α := by volume_tac) extends
   QuasiMeasurePreserving f μ μ, PreErgodic f μ : Prop
 #align quasi_ergodic QuasiErgodic
 
-variable {f} {μ : Measure α}
+variable {f} {μ : MeasureTheory.Measure α}
 
 namespace PreErgodic
 
@@ -83,7 +83,8 @@ end PreErgodic
 
 namespace MeasureTheory.MeasurePreserving
 
-variable {β : Type _} {m' : MeasurableSpace β} {μ' : Measure β} {s' : Set β} {g : α → β}
+variable {β : Type _} {m' : MeasurableSpace β} {μ' : MeasureTheory.Measure β}
+  {s' : Set β} {g : α → β}
 
 theorem preErgodic_of_preErgodic_conjugate (hg : MeasurePreserving g μ μ') (hf : PreErgodic f μ)
     {f' : β → β} (h_comm : g ∘ f = f' ∘ g) : PreErgodic f' μ' :=

--- a/Mathlib/Dynamics/Ergodic/MeasurePreserving.lean
+++ b/Mathlib/Dynamics/Ergodic/MeasurePreserving.lean
@@ -38,7 +38,8 @@ namespace MeasureTheory
 
 open Measure Function Set
 
-variable {μa : Measure α} {μb : Measure β} {μc : Measure γ} {μd : Measure δ}
+variable {μa : MeasureTheory.Measure α} {μb : MeasureTheory.Measure β}
+  {μc : MeasureTheory.Measure γ} {μd : MeasureTheory.Measure δ}
 
 /-- `f` is a measure preserving map w.r.t. measures `μa` and `μb` if `f` is measurable
 and `map f μa = μb`. -/
@@ -136,7 +137,7 @@ protected theorem iterate {f : α → α} (hf : MeasurePreserving f μa μa) :
   | n + 1 => (MeasurePreserving.iterate hf n).comp hf
 #align measure_theory.measure_preserving.iterate MeasureTheory.MeasurePreserving.iterate
 
-variable {μ : Measure α} {f : α → α} {s : Set α}
+variable {μ : MeasureTheory.Measure α} {f : α → α} {s : Set α}
 
 /-- If `μ univ < n * μ s` and `f` is a map preserving measure `μ`,
 then for some `x ∈ s` and `0 < m < n`, `f^[m] x ∈ s`. -/

--- a/Mathlib/MeasureTheory/Constructions/Pi.lean
+++ b/Mathlib/MeasureTheory/Constructions/Pi.lean
@@ -217,7 +217,7 @@ end OuterMeasure
 
 namespace Measure
 
-variable [∀ i, MeasurableSpace (α i)] (μ : ∀ i, Measure (α i))
+variable [∀ i, MeasurableSpace (α i)] (μ : ∀ i, MeasureTheory.Measure (α i))
 
 section Tprod
 

--- a/Mathlib/MeasureTheory/Constructions/Prod/Basic.lean
+++ b/Mathlib/MeasureTheory/Constructions/Prod/Basic.lean
@@ -91,7 +91,7 @@ variable [MeasurableSpace α] [MeasurableSpace α'] [MeasurableSpace β] [Measur
 
 variable [MeasurableSpace γ]
 
-variable {μ μ' : Measure α} {ν ν' : Measure β} {τ : Measure γ}
+variable {μ μ' : Measure α} {ν ν' : Measure β} {τ : MeasureTheory.Measure γ}
 
 variable [NormedAddCommGroup E]
 
@@ -616,8 +616,8 @@ open Measure
 
 namespace MeasurePreserving
 
-variable {δ : Type _} [MeasurableSpace δ] {μa : Measure α} {μb : Measure β} {μc : Measure γ}
-  {μd : Measure δ}
+variable {δ : Type _} [MeasurableSpace δ] {μa : Measure α} {μb : Measure β}
+  {μc : MeasureTheory.Measure γ} {μd : Measure δ}
 
 theorem skew_product [SigmaFinite μb] [SigmaFinite μd] {f : α → β} (hf : MeasurePreserving f μa μb)
     {g : α → γ → δ} (hgm : Measurable (uncurry g)) (hg : ∀ᵐ x ∂μa, map (g x) μc = μd) :
@@ -809,7 +809,7 @@ theorem lintegral_prod_mul {f : α → ℝ≥0∞} {g : β → ℝ≥0∞} (hf :
 
 namespace Measure
 
-variable {ρ : Measure (α × β)}
+variable {ρ : MeasureTheory.Measure (α × β)}
 
 /-- Marginal measure on `α` obtained from a measure `ρ` on `α × β`, defined by `ρ.map Prod.fst`. -/
 noncomputable def fst (ρ : Measure (α × β)) : Measure α :=

--- a/Mathlib/MeasureTheory/Constructions/Prod/Integral.lean
+++ b/Mathlib/MeasureTheory/Constructions/Prod/Integral.lean
@@ -52,7 +52,7 @@ variable [MeasurableSpace α] [MeasurableSpace α'] [MeasurableSpace β] [Measur
 
 variable [MeasurableSpace γ]
 
-variable {μ μ' : Measure α} {ν ν' : Measure β} {τ : Measure γ}
+variable {μ μ' : Measure α} {ν ν' : Measure β} {τ : MeasureTheory.Measure γ}
 
 variable [NormedAddCommGroup E]
 

--- a/Mathlib/MeasureTheory/Covering/DensityTheorem.lean
+++ b/Mathlib/MeasureTheory/Covering/DensityTheorem.lean
@@ -40,7 +40,7 @@ open scoped NNReal Topology
 
 namespace IsUnifLocDoublingMeasure
 
-variable {α : Type _} [MetricSpace α] [MeasurableSpace α] (μ : Measure α)
+variable {α : Type _} [MetricSpace α] [MeasurableSpace α] (μ : MeasureTheory.Measure α)
   [IsUnifLocDoublingMeasure μ]
 
 section

--- a/Mathlib/MeasureTheory/Covering/Differentiation.lean
+++ b/Mathlib/MeasureTheory/Covering/Differentiation.lean
@@ -86,8 +86,8 @@ open MeasureTheory Metric Set Filter TopologicalSpace MeasureTheory.Measure
 
 open scoped Filter ENNReal MeasureTheory NNReal Topology
 
-variable {α : Type _} [MetricSpace α] {m0 : MeasurableSpace α} {μ : Measure α} (v : VitaliFamily μ)
-  {E : Type _} [NormedAddCommGroup E]
+variable {α : Type _} [MetricSpace α] {m0 : MeasurableSpace α} {μ : MeasureTheory.Measure α}
+  (v : VitaliFamily μ) {E : Type _} [NormedAddCommGroup E]
 
 namespace VitaliFamily
 
@@ -159,8 +159,8 @@ theorem measure_le_of_frequently_le [SecondCountableTopology α] [BorelSpace α]
 
 section
 
-variable [SecondCountableTopology α] [BorelSpace α] [IsLocallyFiniteMeasure μ] {ρ : Measure α}
-  [IsLocallyFiniteMeasure ρ]
+variable [SecondCountableTopology α] [BorelSpace α] [IsLocallyFiniteMeasure μ]
+  {ρ : MeasureTheory.Measure α} [IsLocallyFiniteMeasure ρ]
 
 /-- If a measure `ρ` is singular with respect to `μ`, then for `μ` almost every `x`, the ratio
 `ρ a / μ a` tends to zero when `a` shrinks to `x` along the Vitali family. This makes sense

--- a/Mathlib/MeasureTheory/Covering/LiminfLimsup.lean
+++ b/Mathlib/MeasureTheory/Covering/LiminfLimsup.lean
@@ -35,7 +35,7 @@ open scoped NNReal ENNReal Topology
 
 variable {α : Type _} [MetricSpace α] [SecondCountableTopology α] [MeasurableSpace α] [BorelSpace α]
 
-variable (μ : Measure α) [IsLocallyFiniteMeasure μ] [IsUnifLocDoublingMeasure μ]
+variable (μ : MeasureTheory.Measure α) [IsLocallyFiniteMeasure μ] [IsUnifLocDoublingMeasure μ]
 
 /-- This is really an auxiliary result en route to `blimsup_cthickening_ae_le_of_eventually_mul_le`
 (which is itself an auxiliary result en route to `blimsup_cthickening_mul_ae_eq`).

--- a/Mathlib/MeasureTheory/Covering/VitaliFamily.lean
+++ b/Mathlib/MeasureTheory/Covering/VitaliFamily.lean
@@ -82,7 +82,7 @@ structure VitaliFamily {m : MeasurableSpace α} (μ : Measure α) where
 
 namespace VitaliFamily
 
-variable {m0 : MeasurableSpace α} {μ : Measure α}
+variable {m0 : MeasurableSpace α} {μ : MeasureTheory.Measure α}
 
 /-- A Vitali family for a measure `μ` is also a Vitali family for any measure absolutely continuous
 with respect to `μ`. -/

--- a/Mathlib/MeasureTheory/Decomposition/Jordan.lean
+++ b/Mathlib/MeasureTheory/Decomposition/Jordan.lean
@@ -222,7 +222,8 @@ namespace SignedMeasure
 
 open Classical JordanDecomposition Measure Set VectorMeasure
 
-variable {s : SignedMeasure α} {μ ν : Measure α} [IsFiniteMeasure μ] [IsFiniteMeasure ν]
+variable {s : SignedMeasure α} {μ ν : MeasureTheory.Measure α}
+  [IsFiniteMeasure μ] [IsFiniteMeasure ν]
 
 /-- Given a signed measure `s`, `s.toJordanDecomposition` is the Jordan decomposition `j`,
 such that `s = j.toSignedMeasure`. This property is known as the Jordan decomposition

--- a/Mathlib/MeasureTheory/Decomposition/UnsignedHahn.lean
+++ b/Mathlib/MeasureTheory/Decomposition/UnsignedHahn.lean
@@ -33,7 +33,7 @@ open Classical Topology ENNReal
 
 namespace MeasureTheory
 
-variable {α : Type _} [MeasurableSpace α] {μ ν : Measure α}
+variable {α : Type _} [MeasurableSpace α] {μ ν : MeasureTheory.Measure α}
 
 /-- **Hahn decomposition theorem** -/
 theorem hahn_decomposition [IsFiniteMeasure μ] [IsFiniteMeasure ν] :

--- a/Mathlib/MeasureTheory/Function/AEEqFun.lean
+++ b/Mathlib/MeasureTheory/Function/AEEqFun.lean
@@ -79,7 +79,7 @@ open Classical ENNReal Topology
 
 open Set Filter TopologicalSpace ENNReal EMetric MeasureTheory Function
 
-variable {α β γ δ : Type _} [MeasurableSpace α] {μ ν : Measure α}
+variable {α β γ δ : Type _} [MeasurableSpace α] {μ ν : MeasureTheory.Measure α}
 
 namespace MeasureTheory
 

--- a/Mathlib/MeasureTheory/Function/AEEqOfIntegral.lean
+++ b/Mathlib/MeasureTheory/Function/AEEqOfIntegral.lean
@@ -55,7 +55,7 @@ namespace MeasureTheory
 
 section AeEqOfForall
 
-variable {α E 𝕜 : Type _} {m : MeasurableSpace α} {μ : Measure α} [IsROrC 𝕜]
+variable {α E 𝕜 : Type _} {m : MeasurableSpace α} {μ : MeasureTheory.Measure α} [IsROrC 𝕜]
 
 theorem ae_eq_zero_of_forall_inner [NormedAddCommGroup E] [InnerProductSpace 𝕜 E]
     [SecondCountableTopology E] {f : α → E} (hf : ∀ c : E, (fun x => (inner c (f x) : 𝕜)) =ᵐ[μ] 0) :
@@ -121,7 +121,7 @@ variable {𝕜}
 
 end AeEqOfForall
 
-variable {α E : Type _} {m m0 : MeasurableSpace α} {μ : Measure α} {s t : Set α}
+variable {α E : Type _} {m m0 : MeasurableSpace α} {μ : MeasureTheory.Measure α} {s t : Set α}
   [NormedAddCommGroup E] [NormedSpace ℝ E] [CompleteSpace E] {p : ℝ≥0∞}
 
 section AeEqOfForallSetIntegralEq

--- a/Mathlib/MeasureTheory/Function/ConditionalExpectation/AEMeasurable.lean
+++ b/Mathlib/MeasureTheory/Function/ConditionalExpectation/AEMeasurable.lean
@@ -56,8 +56,8 @@ def AEStronglyMeasurable' {α β} [TopologicalSpace β] (m : MeasurableSpace α)
 
 namespace AEStronglyMeasurable'
 
-variable {α β 𝕜 : Type _} {m m0 : MeasurableSpace α} {μ : Measure α} [TopologicalSpace β]
-  {f g : α → β}
+variable {α β 𝕜 : Type _} {m m0 : MeasurableSpace α} {μ : MeasureTheory.Measure α}
+  [TopologicalSpace β] {f g : α → β}
 
 theorem congr (hf : AEStronglyMeasurable' m f μ) (hfg : f =ᵐ[μ] g) : AEStronglyMeasurable' m g μ :=
   by obtain ⟨f', hf'_meas, hff'⟩ := hf; exact ⟨f', hf'_meas, hfg.symm.trans hff'⟩
@@ -274,7 +274,7 @@ measure `μ.trim hm`. As a consequence, the completeness of `Lp` implies complet
 `lpMeasSubgroup` (and `lpMeas`). -/
 
 
-variable {ι : Type _} {m m0 : MeasurableSpace α} {μ : Measure α}
+variable {ι : Type _} {m m0 : MeasurableSpace α} {μ : MeasureTheory.Measure α}
 
 /-- If `f` belongs to `lpMeasSubgroup F m p μ`, then the measurable function it is almost
 everywhere equal to (given by `AEMeasurable.mk`) belongs to `ℒp` for the measure `μ.trim hm`. -/
@@ -515,7 +515,7 @@ end CompleteSubspace
 
 section StronglyMeasurable
 
-variable {m m0 : MeasurableSpace α} {μ : Measure α}
+variable {m m0 : MeasurableSpace α} {μ : MeasureTheory.Measure α}
 
 /-- We do not get `ae_fin_strongly_measurable f (μ.trim hm)`, since we don't have
 `f =ᵐ[μ.trim hm] Lp_meas_to_Lp_trim F 𝕜 p μ hm f` but only the weaker
@@ -560,7 +560,7 @@ end LpMeas
 
 section Induction
 
-variable {m m0 : MeasurableSpace α} {μ : Measure α} [Fact (1 ≤ p)] [NormedSpace ℝ F]
+variable {m m0 : MeasurableSpace α} {μ : MeasureTheory.Measure α} [Fact (1 ≤ p)] [NormedSpace ℝ F]
 
 /-- Auxiliary lemma for `Lp.induction_stronglyMeasurable`. -/
 @[elab_as_elim]

--- a/Mathlib/MeasureTheory/Function/ConditionalExpectation/Unique.lean
+++ b/Mathlib/MeasureTheory/Function/ConditionalExpectation/Unique.lean
@@ -36,7 +36,8 @@ open scoped ENNReal MeasureTheory
 
 namespace MeasureTheory
 
-variable {α E' F' 𝕜 : Type _} {p : ℝ≥0∞} {m m0 : MeasurableSpace α} {μ : Measure α} [IsROrC 𝕜]
+variable {α E' F' 𝕜 : Type _} {p : ℝ≥0∞} {m m0 : MeasurableSpace α}
+  {μ : MeasureTheory.Measure α} [IsROrC 𝕜]
   -- 𝕜 for ℝ or ℂ
   -- E' for an inner product space on which we compute integrals
   [NormedAddCommGroup E']

--- a/Mathlib/MeasureTheory/Function/ContinuousMapDense.lean
+++ b/Mathlib/MeasureTheory/Function/ContinuousMapDense.lean
@@ -68,7 +68,7 @@ open MeasureTheory TopologicalSpace ContinuousMap Set
 
 variable {α : Type _} [MeasurableSpace α] [TopologicalSpace α] [NormalSpace α] [BorelSpace α]
 
-variable {E : Type _} [NormedAddCommGroup E] {μ : Measure α} {p : ℝ≥0∞}
+variable {E : Type _} [NormedAddCommGroup E] {μ : MeasureTheory.Measure α} {p : ℝ≥0∞}
 
 namespace MeasureTheory
 

--- a/Mathlib/MeasureTheory/Function/ConvergenceInMeasure.lean
+++ b/Mathlib/MeasureTheory/Function/ConvergenceInMeasure.lean
@@ -48,7 +48,7 @@ open scoped NNReal ENNReal MeasureTheory Topology
 
 namespace MeasureTheory
 
-variable {α ι E : Type _} {m : MeasurableSpace α} {μ : Measure α}
+variable {α ι E : Type _} {m : MeasurableSpace α} {μ : MeasureTheory.Measure α}
 
 /-- A sequence of functions `f` is said to converge in measure to some function `g` if for all
 `ε > 0`, the measure of the set `{x | ε ≤ dist (f i x) (g x)}` tends to 0 as `i` converges along

--- a/Mathlib/MeasureTheory/Function/Egorov.lean
+++ b/Mathlib/MeasureTheory/Function/Egorov.lean
@@ -34,7 +34,7 @@ namespace MeasureTheory
 
 open Set Filter TopologicalSpace
 
-variable {α β ι : Type _} {m : MeasurableSpace α} [MetricSpace β] {μ : Measure α}
+variable {α β ι : Type _} {m : MeasurableSpace α} [MetricSpace β] {μ : MeasureTheory.Measure α}
 
 namespace Egorov
 

--- a/Mathlib/MeasureTheory/Function/EssSup.lean
+++ b/Mathlib/MeasureTheory/Function/EssSup.lean
@@ -36,7 +36,7 @@ open MeasureTheory Filter Set TopologicalSpace
 
 open ENNReal MeasureTheory NNReal
 
-variable {α β : Type _} {m : MeasurableSpace α} {μ ν : Measure α}
+variable {α β : Type _} {m : MeasurableSpace α} {μ ν : MeasureTheory.Measure α}
 
 section ConditionallyCompleteLattice
 

--- a/Mathlib/MeasureTheory/Function/Jacobian.lean
+++ b/Mathlib/MeasureTheory/Function/Jacobian.lean
@@ -249,7 +249,7 @@ theorem exists_closed_cover_approximatesLinearOn_of_hasFDerivWithinAt [SecondCou
   simp (config := { zeta := false }) only [hq, subset_closure hnz, hp, mem_inter_iff, and_true, hnz]
 #align exists_closed_cover_approximates_linear_on_of_has_fderiv_within_at exists_closed_cover_approximatesLinearOn_of_hasFDerivWithinAt
 
-variable [MeasurableSpace E] [BorelSpace E] (μ : Measure E) [IsAddHaarMeasure μ]
+variable [MeasurableSpace E] [BorelSpace E] (μ : MeasureTheory.Measure E) [IsAddHaarMeasure μ]
 
 /-- Assume that a function `f` has a derivative at every point of a set `s`. Then one may
 partition `s` into countably many disjoint relatively measurable sets (i.e., intersections

--- a/Mathlib/MeasureTheory/Function/L1Space.lean
+++ b/Mathlib/MeasureTheory/Function/L1Space.lean
@@ -56,11 +56,8 @@ open Classical Topology BigOperators ENNReal MeasureTheory NNReal
 
 open Set Filter TopologicalSpace ENNReal EMetric MeasureTheory
 
-variable {α β γ δ : Type _} {m : MeasurableSpace α} {μ ν : Measure α} [MeasurableSpace δ]
-
-variable [NormedAddCommGroup β]
-
-variable [NormedAddCommGroup γ]
+variable {α β γ δ : Type _} {m : MeasurableSpace α} {μ ν : MeasureTheory.Measure α}
+  [MeasurableSpace δ] [NormedAddCommGroup β] [NormedAddCommGroup γ]
 
 namespace MeasureTheory
 
@@ -1156,7 +1153,8 @@ end IsROrC
 
 section Trim
 
-variable {H : Type _} [NormedAddCommGroup H] {m0 : MeasurableSpace α} {μ' : Measure α} {f : α → H}
+variable {H : Type _} [NormedAddCommGroup H] {m0 : MeasurableSpace α}
+  {μ' : MeasureTheory.Measure α} {f : α → H}
 
 theorem Integrable.trim (hm : m ≤ m0) (hf_int : Integrable f μ') (hf : StronglyMeasurable[m] f) :
     Integrable f (μ'.trim hm) := by

--- a/Mathlib/MeasureTheory/Function/L2Space.lean
+++ b/Mathlib/MeasureTheory/Function/L2Space.lean
@@ -42,7 +42,7 @@ namespace MeasureTheory
 
 section
 
-variable {α F : Type _} {m : MeasurableSpace α} {μ : Measure α} [NormedAddCommGroup F]
+variable {α F : Type _} {m : MeasurableSpace α} {μ : MeasureTheory.Measure α} [NormedAddCommGroup F]
 
 theorem Memℒp.integrable_sq {f : α → ℝ} (h : Memℒp f 2 μ) : Integrable (fun x => f x ^ 2) μ := by
   simpa [← memℒp_one_iff_integrable] using h.norm_rpow two_ne_zero ENNReal.two_ne_top
@@ -66,7 +66,7 @@ end
 
 section InnerProductSpace
 
-variable {α : Type _} {m : MeasurableSpace α} {p : ℝ≥0∞} {μ : Measure α}
+variable {α : Type _} {m : MeasurableSpace α} {p : ℝ≥0∞} {μ : MeasureTheory.Measure α}
 
 variable {E 𝕜 : Type _} [IsROrC 𝕜] [NormedAddCommGroup E] [InnerProductSpace 𝕜 E]
 
@@ -116,8 +116,8 @@ end InnerProductSpace
 
 namespace L2
 
-variable {α E F 𝕜 : Type _} [IsROrC 𝕜] [MeasurableSpace α] {μ : Measure α} [NormedAddCommGroup E]
-  [InnerProductSpace 𝕜 E] [NormedAddCommGroup F]
+variable {α E F 𝕜 : Type _} [IsROrC 𝕜] [MeasurableSpace α] {μ : MeasureTheory.Measure α}
+  [NormedAddCommGroup E] [InnerProductSpace 𝕜 E] [NormedAddCommGroup F]
 
 -- mathport name: «expr⟪ , ⟫»
 local notation "⟪" x ", " y "⟫" => @inner 𝕜 _ _ x y
@@ -287,7 +287,7 @@ section InnerContinuous
 
 variable {α : Type _} [TopologicalSpace α] [MeasureSpace α] [BorelSpace α] {𝕜 : Type _} [IsROrC 𝕜]
 
-variable (μ : Measure α) [IsFiniteMeasure μ]
+variable (μ : MeasureTheory.Measure α) [IsFiniteMeasure μ]
 
 open scoped BoundedContinuousFunction ComplexConjugate
 

--- a/Mathlib/MeasureTheory/Function/LocallyIntegrable.lean
+++ b/Mathlib/MeasureTheory/Function/LocallyIntegrable.lean
@@ -36,7 +36,7 @@ variable {X Y E R : Type _} [MeasurableSpace X] [TopologicalSpace X]
 
 variable [MeasurableSpace Y] [TopologicalSpace Y]
 
-variable [NormedAddCommGroup E] {f : X → E} {μ : Measure X} {s : Set X}
+variable [NormedAddCommGroup E] {f : X → E} {μ : MeasureTheory.Measure X} {s : Set X}
 
 namespace MeasureTheory
 

--- a/Mathlib/MeasureTheory/Function/LpOrder.lean
+++ b/Mathlib/MeasureTheory/Function/LpOrder.lean
@@ -32,7 +32,7 @@ open TopologicalSpace MeasureTheory LatticeOrderedCommGroup
 
 open scoped ENNReal
 
-variable {α E : Type _} {m : MeasurableSpace α} {μ : Measure α} {p : ℝ≥0∞}
+variable {α E : Type _} {m : MeasurableSpace α} {μ : MeasureTheory.Measure α} {p : ℝ≥0∞}
 
 namespace MeasureTheory
 

--- a/Mathlib/MeasureTheory/Function/LpSeminorm.lean
+++ b/Mathlib/MeasureTheory/Function/LpSeminorm.lean
@@ -46,7 +46,8 @@ open TopologicalSpace MeasureTheory Filter
 
 open NNReal ENNReal BigOperators Topology MeasureTheory
 
-variable {α E F G : Type _} {m m0 : MeasurableSpace α} {p : ℝ≥0∞} {q : ℝ} {μ ν : Measure α}
+variable {α E F G : Type _} {m m0 : MeasurableSpace α} {p : ℝ≥0∞} {q : ℝ}
+  {μ ν : MeasureTheory.Measure α}
   [NormedAddCommGroup E] [NormedAddCommGroup F] [NormedAddCommGroup G]
 
 namespace MeasureTheory

--- a/Mathlib/MeasureTheory/Function/LpSpace.lean
+++ b/Mathlib/MeasureTheory/Function/LpSpace.lean
@@ -72,7 +72,8 @@ open NNReal ENNReal BigOperators Topology MeasureTheory
 
 local macro_rules | `($x ^ $y)   => `(HPow.hPow $x $y) -- Porting note: See issue #2220
 
-variable {α E F G : Type _} {m m0 : MeasurableSpace α} {p : ℝ≥0∞} {q : ℝ} {μ ν : Measure α}
+variable {α E F G : Type _} {m m0 : MeasurableSpace α} {p : ℝ≥0∞} {q : ℝ}
+  {μ ν : MeasureTheory.Measure α}
   [NormedAddCommGroup E] [NormedAddCommGroup F] [NormedAddCommGroup G]
 
 namespace MeasureTheory

--- a/Mathlib/MeasureTheory/Function/SimpleFunc.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFunc.lean
@@ -961,7 +961,7 @@ end Measurable
 
 section Measure
 
-variable {m : MeasurableSpace α} {μ ν : Measure α}
+variable {m : MeasurableSpace α} {μ ν : MeasureTheory.Measure α}
 
 /-- Integral of a simple function whose codomain is `ℝ≥0∞`. -/
 def lintegral {_m : MeasurableSpace α} (f : α →ₛ ℝ≥0∞) (μ : Measure α) : ℝ≥0∞ :=
@@ -1172,7 +1172,7 @@ theorem support_eq [MeasurableSpace α] [Zero β] (f : α →ₛ β) :
       mem_iUnion, Set.mem_range, mem_singleton_iff, exists_eq_right']
 #align measure_theory.simple_func.support_eq MeasureTheory.SimpleFunc.support_eq
 
-variable {m : MeasurableSpace α} [Zero β] [Zero γ] {μ : Measure α} {f : α →ₛ β}
+variable {m : MeasurableSpace α} [Zero β] [Zero γ] {μ : MeasureTheory.Measure α} {f : α →ₛ β}
 
 theorem measurableSet_support [MeasurableSpace α] (f : α →ₛ β) : MeasurableSet (support f) := by
   rw [f.support_eq]

--- a/Mathlib/MeasureTheory/Function/SimpleFuncDenseLp.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFuncDenseLp.lean
@@ -278,7 +278,7 @@ variable [MeasurableSpace α]
 
 variable [NormedAddCommGroup E] [NormedAddCommGroup F]
 
-variable {μ : Measure α} {p : ℝ≥0∞}
+variable {μ : MeasureTheory.Measure α} {p : ℝ≥0∞}
 
 /-!
 ### Properties of simple functions in `Lp` spaces
@@ -951,7 +951,8 @@ end simpleFunc
 
 end Lp
 
-variable [MeasurableSpace α] [NormedAddCommGroup E] {f : α → E} {p : ℝ≥0∞} {μ : Measure α}
+variable [MeasurableSpace α] [NormedAddCommGroup E] {f : α → E} {p : ℝ≥0∞}
+  {μ : MeasureTheory.Measure α}
 
 /-- To prove something for an arbitrary `Lp` function in a second countable Borel normed group, it
 suffices to show that

--- a/Mathlib/MeasureTheory/Function/StronglyMeasurable/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/StronglyMeasurable/Basic.lean
@@ -992,7 +992,7 @@ theorem finStronglyMeasurable_zero {α β} {m : MeasurableSpace α} {μ : Measur
 
 namespace FinStronglyMeasurable
 
-variable {m0 : MeasurableSpace α} {μ : Measure α} {f g : α → β}
+variable {m0 : MeasurableSpace α} {μ : MeasureTheory.Measure α} {f g : α → β}
 
 theorem aefinStronglyMeasurable [Zero β] [TopologicalSpace β] (hf : FinStronglyMeasurable f μ) :
     AEFinStronglyMeasurable f μ :=
@@ -1186,8 +1186,8 @@ theorem SimpleFunc.aestronglyMeasurable {_ : MeasurableSpace α} {μ : Measure �
 
 namespace AEStronglyMeasurable
 
-variable {m : MeasurableSpace α} {μ : Measure α} [TopologicalSpace β] [TopologicalSpace γ]
-  {f g : α → β}
+variable {m : MeasurableSpace α} {μ : MeasureTheory.Measure α}
+  [TopologicalSpace β] [TopologicalSpace γ] {f g : α → β}
 
 section Mk
 
@@ -1837,7 +1837,7 @@ end AEStronglyMeasurable
 
 namespace AEFinStronglyMeasurable
 
-variable {m : MeasurableSpace α} {μ : Measure α} [TopologicalSpace β] {f g : α → β}
+variable {m : MeasurableSpace α} {μ : MeasureTheory.Measure α} [TopologicalSpace β] {f g : α → β}
 
 section Mk
 
@@ -1956,7 +1956,7 @@ end AEFinStronglyMeasurable
 
 section SecondCountableTopology
 
-variable {G : Type _} {p : ℝ≥0∞} {m m0 : MeasurableSpace α} {μ : Measure α}
+variable {G : Type _} {p : ℝ≥0∞} {m m0 : MeasurableSpace α} {μ : MeasureTheory.Measure α}
   [SeminormedAddCommGroup G] [MeasurableSpace G] [BorelSpace G] [SecondCountableTopology G]
   {f : α → G}
 

--- a/Mathlib/MeasureTheory/Function/StronglyMeasurable/Inner.lean
+++ b/Mathlib/MeasureTheory/Function/StronglyMeasurable/Inner.lean
@@ -36,7 +36,7 @@ end StronglyMeasurable
 
 namespace AEStronglyMeasurable
 
-variable {m : MeasurableSpace α} {μ : Measure α} {𝕜 : Type _} {E : Type _} [IsROrC 𝕜]
+variable {m : MeasurableSpace α} {μ : MeasureTheory.Measure α} {𝕜 : Type _} {E : Type _} [IsROrC 𝕜]
   [NormedAddCommGroup E] [InnerProductSpace 𝕜 E]
 
 local notation "⟪" x ", " y "⟫" => @inner 𝕜 _ _ x y

--- a/Mathlib/MeasureTheory/Function/StronglyMeasurable/Lp.lean
+++ b/Mathlib/MeasureTheory/Function/StronglyMeasurable/Lp.lean
@@ -38,8 +38,8 @@ namespace MeasureTheory
 -- mathport name: «expr →ₛ »
 local infixr:25 " →ₛ " => SimpleFunc
 
-variable {α G : Type _} {p : ℝ≥0∞} {m m0 : MeasurableSpace α} {μ : Measure α} [NormedAddCommGroup G]
-  {f : α → G}
+variable {α G : Type _} {p : ℝ≥0∞} {m m0 : MeasurableSpace α} {μ : MeasureTheory.Measure α}
+  [NormedAddCommGroup G] {f : α → G}
 
 theorem Memℒp.finStronglyMeasurable_of_stronglyMeasurable (hf : Memℒp f p μ)
     (hf_meas : StronglyMeasurable f) (hp_ne_zero : p ≠ 0) (hp_ne_top : p ≠ ∞) :

--- a/Mathlib/MeasureTheory/Function/UniformIntegrable.lean
+++ b/Mathlib/MeasureTheory/Function/UniformIntegrable.lean
@@ -56,7 +56,8 @@ namespace MeasureTheory
 
 open Set Filter TopologicalSpace
 
-variable {α β ι : Type _} {m : MeasurableSpace α} {μ : Measure α} [NormedAddCommGroup β]
+variable {α β ι : Type _} {m : MeasurableSpace α} {μ : MeasureTheory.Measure α}
+  [NormedAddCommGroup β]
 
 /-- Uniform integrability in the measure theory sense.
 

--- a/Mathlib/MeasureTheory/Group/Action.lean
+++ b/Mathlib/MeasureTheory/Group/Action.lean
@@ -56,7 +56,7 @@ instance zero [MeasurableSpace α] [SMul M α] : SMulInvariantMeasure M α (0 : 
 #align measure_theory.smul_invariant_measure.zero MeasureTheory.SMulInvariantMeasure.zero
 #align measure_theory.vadd_invariant_measure.zero MeasureTheory.VAddInvariantMeasure.zero
 
-variable [SMul M α] {m : MeasurableSpace α} {μ ν : Measure α}
+variable [SMul M α] {m : MeasurableSpace α} {μ ν : MeasureTheory.Measure α}
 
 @[to_additive]
 instance add [SMulInvariantMeasure M α μ] [SMulInvariantMeasure M α ν] :

--- a/Mathlib/MeasureTheory/Group/Arithmetic.lean
+++ b/Mathlib/MeasureTheory/Group/Arithmetic.lean
@@ -628,7 +628,7 @@ instance (priority := 100) MeasurableSMul₂.toMeasurableSMul [MeasurableSMul₂
 #align has_measurable_smul₂.to_has_measurable_smul MeasurableSMul₂.toMeasurableSMul
 #align has_measurable_vadd₂.to_has_measurable_vadd MeasurableVAdd₂.toMeasurableVAdd
 
-variable [MeasurableSMul M β] {μ : Measure α}
+variable [MeasurableSMul M β] {μ : MeasureTheory.Measure α}
 
 @[to_additive (attr := measurability)]
 theorem Measurable.smul_const (hf : Measurable f) (y : β) : Measurable fun x => f x • y :=

--- a/Mathlib/MeasureTheory/Group/FundamentalDomain.lean
+++ b/Mathlib/MeasureTheory/Group/FundamentalDomain.lean
@@ -84,7 +84,7 @@ theorem mk' (h_meas : NullMeasurableSet s μ) (h_exists : ∀ x : α, ∃! g : G
   nullMeasurableSet := h_meas
   ae_covers := eventually_of_forall fun x => (h_exists x).exists
   aedisjoint a b hab := Disjoint.aedisjoint <| disjoint_left.2 fun x hxa hxb => by
-    rw [mem_smul_set_iff_inv_smul_mem] at hxa hxb 
+    rw [mem_smul_set_iff_inv_smul_mem] at hxa hxb
     exact hab (inv_injective <| (h_exists x).unique hxa hxb)
 #align measure_theory.is_fundamental_domain.mk' MeasureTheory.IsFundamentalDomain.mk'
 #align measure_theory.is_add_fundamental_domain.mk' MeasureTheory.IsAddFundamentalDomain.mk'
@@ -214,7 +214,7 @@ theorem smul (h : IsFundamentalDomain G s μ) (g : G) : IsFundamentalDomain G (g
 #align measure_theory.is_fundamental_domain.smul MeasureTheory.IsFundamentalDomain.smul
 #align measure_theory.is_add_fundamental_domain.vadd MeasureTheory.IsAddFundamentalDomain.vadd
 
-variable [Countable G] {ν : Measure α}
+variable [Countable G] {ν : MeasureTheory.Measure α}
 
 @[to_additive]
 theorem sum_restrict_of_ac (h : IsFundamentalDomain G s μ) (hν : ν ≪ μ) :
@@ -463,7 +463,7 @@ protected theorem set_integral_eq (hs : IsFundamentalDomain G s μ) (ht : IsFund
       _ = ∑' g : G, ∫ x in g • t ∩ s, f (g⁻¹ • x) ∂μ := by simp only [hf, inter_comm]
       _ = ∫ x in t, f x ∂μ := (hs.set_integral_eq_tsum' hft).symm
   · rw [integral_undef hfs, integral_undef]
-    rwa [hs.integrableOn_iff ht hf] at hfs 
+    rwa [hs.integrableOn_iff ht hf] at hfs
 #align measure_theory.is_fundamental_domain.set_integral_eq MeasureTheory.IsFundamentalDomain.set_integral_eq
 #align measure_theory.is_add_fundamental_domain.set_integral_eq MeasureTheory.IsAddFundamentalDomain.set_integral_eq
 
@@ -515,7 +515,7 @@ theorem essSup_measure_restrict (hs : IsFundamentalDomain G s μ) {f : α → �
   rw [essSup_eq_sInf (μ.restrict s) f, essSup_eq_sInf μ f]
   refine' sInf_le_sInf _
   rintro a (ha : (μ.restrict s) {x : α | a < f x} = 0)
-  rw [Measure.restrict_apply₀' hs.nullMeasurableSet] at ha 
+  rw [Measure.restrict_apply₀' hs.nullMeasurableSet] at ha
   refine' measure_zero_of_invariant hs _ _ ha
   intro γ
   ext x
@@ -631,15 +631,15 @@ theorem pairwise_disjoint_fundamentalInterior :
     Pairwise (Disjoint on fun g : G => g • fundamentalInterior G s) := by
   refine' fun a b hab => disjoint_left.2 _
   rintro _ ⟨x, hx, rfl⟩ ⟨y, hy, hxy⟩
-  rw [mem_fundamentalInterior] at hx hy 
+  rw [mem_fundamentalInterior] at hx hy
   refine' hx.2 (a⁻¹ * b) _ _
   rwa [Ne.def, inv_mul_eq_iff_eq_mul, mul_one, eq_comm]
   simpa [mul_smul, ← hxy, mem_inv_smul_set_iff] using hy.1
 #align measure_theory.pairwise_disjoint_fundamental_interior MeasureTheory.pairwise_disjoint_fundamentalInterior
 #align measure_theory.pairwise_disjoint_add_fundamental_interior MeasureTheory.pairwise_disjoint_addFundamentalInterior
 
-variable [Countable G] [MeasurableSpace G] [MeasurableSpace α] [MeasurableSMul G α] {μ : Measure α}
-  [SMulInvariantMeasure G α μ]
+variable [Countable G] [MeasurableSpace G] [MeasurableSpace α] [MeasurableSMul G α]
+  {μ : MeasureTheory.Measure α} [SMulInvariantMeasure G α μ]
 
 @[to_additive MeasureTheory.NullMeasurableSet.addFundamentalFrontier]
 protected theorem NullMeasurableSet.fundamentalFrontier (hs : NullMeasurableSet s μ) :
@@ -661,8 +661,8 @@ namespace IsFundamentalDomain
 
 section Group
 
-variable [Countable G] [Group G] [MulAction G α] [MeasurableSpace α] {μ : Measure α} {s : Set α}
-  (hs : IsFundamentalDomain G s μ)
+variable [Countable G] [Group G] [MulAction G α] [MeasurableSpace α]
+  {μ : MeasureTheory.Measure α} {s : Set α} (hs : IsFundamentalDomain G s μ)
 
 @[to_additive MeasureTheory.IsAddFundamentalDomain.measure_addFundamentalFrontier]
 theorem measure_fundamentalFrontier : μ (fundamentalFrontier G s) = 0 := by
@@ -680,7 +680,8 @@ theorem measure_fundamentalInterior : μ (fundamentalInterior G s) = μ s :=
 
 end Group
 
-variable [Countable G] [Group G] [MulAction G α] [MeasurableSpace α] {μ : Measure α} {s : Set α}
+variable [Countable G] [Group G] [MulAction G α] [MeasurableSpace α]
+  {μ : MeasureTheory.Measure α} {s : Set α}
   (hs : IsFundamentalDomain G s μ) [MeasurableSpace G] [MeasurableSMul G α]
   [SMulInvariantMeasure G α μ]
 
@@ -705,4 +706,3 @@ protected theorem fundamentalInterior : IsFundamentalDomain G (fundamentalInteri
 end IsFundamentalDomain
 
 end MeasureTheory
-

--- a/Mathlib/MeasureTheory/Group/GeometryOfNumbers.lean
+++ b/Mathlib/MeasureTheory/Group/GeometryOfNumbers.lean
@@ -45,7 +45,7 @@ open ENNReal FiniteDimensional MeasureTheory MeasureTheory.Measure Set
 
 open scoped Pointwise
 
-variable {E L : Type _} [MeasurableSpace E] {μ : Measure E} {F s : Set E}
+variable {E L : Type _} [MeasurableSpace E] {μ : MeasureTheory.Measure E} {F s : Set E}
 
 /-- **Blichfeldt's Theorem**. If the volume of the set `s` is larger than the covolume of the
 countable subgroup `L` of `E`, then there exist two distinct points `x, y ∈ L` such that `(x + s)`

--- a/Mathlib/MeasureTheory/Group/Integration.lean
+++ b/Mathlib/MeasureTheory/Group/Integration.lean
@@ -30,7 +30,7 @@ variable {𝕜 M α G E F : Type _} [MeasurableSpace G]
 
 variable [NormedAddCommGroup E] [NormedSpace ℝ E] [CompleteSpace E] [NormedAddCommGroup F]
 
-variable {μ : Measure G} {f : G → E} {g : G}
+variable {μ : MeasureTheory.Measure G} {f : G → E} {g : G}
 
 section MeasurableInv
 

--- a/Mathlib/MeasureTheory/Group/Measure.lean
+++ b/Mathlib/MeasureTheory/Group/Measure.lean
@@ -79,7 +79,7 @@ open Measure
 
 section Mul
 
-variable [Mul G] {μ : Measure G}
+variable [Mul G] {μ : MeasureTheory.Measure G}
 
 @[to_additive]
 theorem map_mul_left_eq_self (μ : Measure G) [IsMulLeftInvariant μ] (g : G) :
@@ -432,7 +432,7 @@ end InvolutiveInv
 
 section DivisionMonoid
 
-variable [DivisionMonoid G] [MeasurableMul G] [MeasurableInv G] {μ : Measure G}
+variable [DivisionMonoid G] [MeasurableMul G] [MeasurableInv G] {μ : MeasureTheory.Measure G}
 
 @[to_additive]
 instance inv.instIsMulRightInvariant [IsMulLeftInvariant μ] : IsMulRightInvariant μ.inv := by
@@ -487,7 +487,7 @@ end DivisionMonoid
 
 section Group
 
-variable [Group G] [MeasurableMul G] [MeasurableInv G] {μ : Measure G}
+variable [Group G] [MeasurableMul G] [MeasurableInv G] {μ : MeasureTheory.Measure G}
 
 @[to_additive]
 theorem map_div_left_ae (μ : Measure G) [IsMulLeftInvariant μ] [IsInvInvariant μ] (x : G) :
@@ -502,7 +502,7 @@ end Measure
 
 section TopologicalGroup
 
-variable [TopologicalSpace G] [BorelSpace G] {μ : Measure G} [Group G]
+variable [TopologicalSpace G] [BorelSpace G] {μ : MeasureTheory.Measure G} [Group G]
 
 @[to_additive]
 instance Measure.Regular.inv [ContinuousInv G] [T2Space G] [Regular μ] : Regular μ.inv :=
@@ -716,7 +716,7 @@ instance (priority := 100) isLocallyFiniteMeasure_of_isHaarMeasure {G : Type _} 
 
 section
 
-variable [Group G] [TopologicalSpace G] (μ : Measure G) [IsHaarMeasure μ]
+variable [Group G] [TopologicalSpace G] (μ : MeasureTheory.Measure G) [IsHaarMeasure μ]
 
 @[to_additive (attr := simp)]
 theorem haar_singleton [TopologicalGroup G] [BorelSpace G] (g : G) : μ {g} = μ {(1 : G)} := by

--- a/Mathlib/MeasureTheory/Group/Prod.lean
+++ b/Mathlib/MeasureTheory/Group/Prod.lean
@@ -52,7 +52,7 @@ variable (G : Type _) [MeasurableSpace G]
 
 variable [Group G] [MeasurableMul₂ G]
 
-variable (μ ν : Measure G) [SigmaFinite ν] [SigmaFinite μ] {s : Set G}
+variable (μ ν : MeasureTheory.Measure G) [SigmaFinite ν] [SigmaFinite μ] {s : Set G}
 
 /-- The map `(x, y) ↦ (x, xy)` as a `MeasurableEquiv`. -/
 @[to_additive "The map `(x, y) ↦ (x, x + y)` as a `MeasurableEquiv`."]

--- a/Mathlib/MeasureTheory/Integral/Bochner.lean
+++ b/Mathlib/MeasureTheory/Integral/Bochner.lean
@@ -162,7 +162,8 @@ section WeightedSmul
 
 open ContinuousLinearMap
 
-variable [NormedAddCommGroup F] [NormedSpace ℝ F] {m : MeasurableSpace α} {μ : Measure α}
+variable [NormedAddCommGroup F] [NormedSpace ℝ F] {m : MeasurableSpace α}
+  {μ : MeasureTheory.Measure α}
 
 /-- Given a set `s`, return the continuous linear map `fun x => (μ s).toReal • x`. The extension
 of that set function through `setToL1` gives the Bochner integral of L1 functions. -/
@@ -466,7 +467,8 @@ set_option linter.uppercaseLean3 false -- `L1`
 
 open AEEqFun Lp.simpleFunc Lp
 
-variable [NormedAddCommGroup E] [NormedAddCommGroup F] {m : MeasurableSpace α} {μ : Measure α}
+variable [NormedAddCommGroup E] [NormedAddCommGroup F] {m : MeasurableSpace α}
+  {μ : MeasureTheory.Measure α}
 
 namespace SimpleFunc
 
@@ -815,7 +817,7 @@ section Properties
 
 open ContinuousLinearMap MeasureTheory.SimpleFunc
 
-variable {f g : α → E} {m : MeasurableSpace α} {μ : Measure α}
+variable {f g : α → E} {m : MeasurableSpace α} {μ : MeasureTheory.Measure α}
 
 theorem integral_eq (f : α → E) (hf : Integrable f μ) : ∫ a, f a ∂μ = L1.integral (hf.toL1 f) :=
   by rw [integral]; exact @dif_pos _ (id _) hf _ _ _
@@ -1397,7 +1399,7 @@ theorem tendsto_integral_approxOn_of_measurable_of_range_subset [MeasurableSpace
   exact eventually_of_forall fun x => subset_closure (hs (Set.mem_union_left _ (mem_range_self _)))
 #align measure_theory.tendsto_integral_approx_on_of_measurable_of_range_subset MeasureTheory.tendsto_integral_approxOn_of_measurable_of_range_subset
 
-variable {ν : Measure α}
+variable {ν : MeasureTheory.Measure α}
 
 theorem integral_add_measure {f : α → E} (hμ : Integrable f μ) (hν : Integrable f ν) :
     ∫ x, f x ∂(μ + ν) = ∫ x, f x ∂μ + ∫ x, f x ∂ν := by
@@ -1724,7 +1726,8 @@ attribute [integral_simps] integral_neg integral_smul L1.integral_add L1.integra
 
 section IntegralTrim
 
-variable {H β γ : Type _} [NormedAddCommGroup H] {m m0 : MeasurableSpace β} {μ : Measure β}
+variable {H β γ : Type _} [NormedAddCommGroup H] {m m0 : MeasurableSpace β}
+  {μ : MeasureTheory.Measure β}
 
 /-- Simple function seen as simple function of a larger `MeasurableSpace`. -/
 def SimpleFunc.toLargerSpace (hm : m ≤ m0) (f : @SimpleFunc β m γ) : SimpleFunc β γ :=
@@ -1823,7 +1826,7 @@ end IntegralTrim
 
 section SnormBound
 
-variable {m0 : MeasurableSpace α} {μ : Measure α}
+variable {m0 : MeasurableSpace α} {μ : MeasureTheory.Measure α}
 
 theorem snorm_one_le_of_le {r : ℝ≥0} {f : α → ℝ} (hfint : Integrable f μ) (hfint' : 0 ≤ ∫ x, f x ∂μ)
     (hf : ∀ᵐ ω ∂μ, f ω ≤ r) : snorm f 1 μ ≤ 2 * μ Set.univ * r := by

--- a/Mathlib/MeasureTheory/Integral/IntegrableOn.lean
+++ b/Mathlib/MeasureTheory/Integral/IntegrableOn.lean
@@ -34,7 +34,7 @@ variable {α β E F : Type _} [MeasurableSpace α]
 
 section
 
-variable [TopologicalSpace β] {l l' : Filter α} {f g : α → β} {μ ν : Measure α}
+variable [TopologicalSpace β] {l l' : Filter α} {f g : α → β} {μ ν : MeasureTheory.Measure α}
 
 /-- A function `f` is strongly measurable at a filter `l` w.r.t. a measure `μ` if it is
 ae strongly measurable w.r.t. `μ.restrict s` for some `s ∈ l`. -/
@@ -86,7 +86,7 @@ theorem hasFiniteIntegral_restrict_of_bounded [NormedAddCommGroup E] {f : α →
   hasFiniteIntegral_of_bounded hf
 #align measure_theory.has_finite_integral_restrict_of_bounded MeasureTheory.hasFiniteIntegral_restrict_of_bounded
 
-variable [NormedAddCommGroup E] {f g : α → E} {s t : Set α} {μ ν : Measure α}
+variable [NormedAddCommGroup E] {f g : α → E} {s t : Set α} {μ ν : MeasureTheory.Measure α}
 
 /-- A function is `IntegrableOn` a set `s` if it is almost everywhere strongly measurable on `s`
 and if the integral of its pointwise norm over `s` is less than infinity. -/
@@ -617,7 +617,8 @@ the unprimed ones use `[NoAtoms μ]`.
 
 section PartialOrder
 
-variable [PartialOrder α] [MeasurableSingletonClass α] {f : α → E} {μ : Measure α} {a b : α}
+variable [PartialOrder α] [MeasurableSingletonClass α] {f : α → E}
+  {μ : MeasureTheory.Measure α} {a b : α}
 
 theorem integrableOn_Icc_iff_integrableOn_Ioc' (ha : μ {a} ≠ ∞) :
     IntegrableOn f (Icc a b) μ ↔ IntegrableOn f (Ioc a b) μ := by

--- a/Mathlib/MeasureTheory/Integral/IntegralEqImproper.lean
+++ b/Mathlib/MeasureTheory/Integral/IntegralEqImproper.lean
@@ -80,7 +80,7 @@ namespace MeasureTheory
 
 section AECover
 
-variable {α ι : Type _} [MeasurableSpace α] (μ : Measure α) (l : Filter ι)
+variable {α ι : Type _} [MeasurableSpace α] (μ : MeasureTheory.Measure α) (l : Filter ι)
 
 /-- A sequence `φ` of subsets of `α` is a `MeasureTheory.AECover` w.r.t. a measure `μ` and a filter
     `l` if almost every point (w.r.t. `μ`) of `α` eventually belongs to `φ n` (w.r.t. `l`), and if
@@ -332,7 +332,7 @@ theorem AECover.comp_tendsto {α ι ι' : Type _} [MeasurableSpace α] {μ : Mea
 
 section AECoverUnionInterCountable
 
-variable {α ι : Type _} [Countable ι] [MeasurableSpace α] {μ : Measure α}
+variable {α ι : Type _} [Countable ι] [MeasurableSpace α] {μ : MeasureTheory.Measure α}
 
 theorem AECover.biUnion_Iic_aecover [Preorder ι] {φ : ι → Set α} (hφ : AECover μ atTop φ) :
     AECover μ atTop fun n : ι => ⋃ (k) (_h : k ∈ Iic n), φ k :=
@@ -352,7 +352,7 @@ end AECoverUnionInterCountable
 
 section Lintegral
 
-variable {α ι : Type _} [MeasurableSpace α] {μ : Measure α} {l : Filter ι}
+variable {α ι : Type _} [MeasurableSpace α] {μ : MeasureTheory.Measure α} {l : Filter ι}
 
 private theorem lintegral_tendsto_of_monotone_of_nat {φ : ℕ → Set α} (hφ : AECover μ atTop φ)
     (hmono : Monotone φ) {f : α → ℝ≥0∞} (hfm : AEMeasurable f μ) :
@@ -403,7 +403,8 @@ end Lintegral
 
 section Integrable
 
-variable {α ι E : Type _} [MeasurableSpace α] {μ : Measure α} {l : Filter ι} [NormedAddCommGroup E]
+variable {α ι E : Type _} [MeasurableSpace α] {μ : MeasureTheory.Measure α}
+  {l : Filter ι} [NormedAddCommGroup E]
 
 theorem AECover.integrable_of_lintegral_nnnorm_bounded [l.NeBot] [l.IsCountablyGenerated]
     {φ : ι → Set α} (hφ : AECover μ l φ) {f : α → E} (I : ℝ) (hfm : AEStronglyMeasurable f μ)
@@ -480,8 +481,8 @@ end Integrable
 
 section Integral
 
-variable {α ι E : Type _} [MeasurableSpace α] {μ : Measure α} {l : Filter ι} [NormedAddCommGroup E]
-  [NormedSpace ℝ E] [CompleteSpace E]
+variable {α ι E : Type _} [MeasurableSpace α] {μ : MeasureTheory.Measure α}
+  {l : Filter ι} [NormedAddCommGroup E] [NormedSpace ℝ E] [CompleteSpace E]
 
 theorem AECover.integral_tendsto_of_countably_generated [l.IsCountablyGenerated] {φ : ι → Set α}
     (hφ : AECover μ l φ) {f : α → E} (hfi : Integrable f μ) :
@@ -514,8 +515,8 @@ end Integral
 
 section IntegrableOfIntervalIntegral
 
-variable {ι E : Type _} {μ : Measure ℝ} {l : Filter ι} [Filter.NeBot l] [IsCountablyGenerated l]
-  [NormedAddCommGroup E] {a b : ι → ℝ} {f : ℝ → E}
+variable {ι E : Type _} {μ : MeasureTheory.Measure ℝ} {l : Filter ι} [Filter.NeBot l]
+  [IsCountablyGenerated l] [NormedAddCommGroup E] {a b : ι → ℝ} {f : ℝ → E}
 
 theorem integrable_of_intervalIntegral_norm_bounded (I : ℝ)
     (hfi : ∀ i, IntegrableOn f (Ioc (a i) (b i)) μ) (ha : Tendsto a l atBot)
@@ -618,7 +619,7 @@ end IntegrableOfIntervalIntegral
 
 section IntegralOfIntervalIntegral
 
-variable {ι E : Type _} {μ : Measure ℝ} {l : Filter ι} [IsCountablyGenerated l]
+variable {ι E : Type _} {μ : MeasureTheory.Measure ℝ} {l : Filter ι} [IsCountablyGenerated l]
   [NormedAddCommGroup E] [NormedSpace ℝ E] [CompleteSpace E] {a b : ι → ℝ} {f : ℝ → E}
 
 theorem intervalIntegral_tendsto_integral (hfi : Integrable f μ) (ha : Tendsto a l atBot)

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral.lean
@@ -76,7 +76,7 @@ def IntervalIntegrable (f : ℝ → E) (μ : Measure ℝ) (a b : ℝ) : Prop :=
 
 section
 
-variable {f : ℝ → E} {a b : ℝ} {μ : Measure ℝ}
+variable {f : ℝ → E} {a b : ℝ} {μ : MeasureTheory.Measure ℝ}
 
 /-- A function is interval integrable with respect to a given measure `μ` on `a..b` if and
   only if it is integrable on `uIoc a b` with respect to `μ`. This is an equivalent
@@ -136,7 +136,7 @@ namespace IntervalIntegrable
 
 section
 
-variable {f : ℝ → E} {a b c d : ℝ} {μ ν : Measure ℝ}
+variable {f : ℝ → E} {a b c d : ℝ} {μ ν : MeasureTheory.Measure ℝ}
 
 @[symm]
 nonrec theorem symm (h : IntervalIntegrable f μ a b) : IntervalIntegrable f μ b a :=
@@ -237,7 +237,7 @@ protected theorem ae_strongly_measurable' (h : IntervalIntegrable f μ a b) :
 
 end
 
-variable [NormedRing A] {f g : ℝ → E} {a b : ℝ} {μ : Measure ℝ}
+variable [NormedRing A] {f g : ℝ → E} {a b : ℝ} {μ : MeasureTheory.Measure ℝ}
 
 theorem smul [NormedField 𝕜] [NormedSpace 𝕜 E] {f : ℝ → E} {a b : ℝ} {μ : Measure ℝ}
     (h : IntervalIntegrable f μ a b) (r : 𝕜) : IntervalIntegrable (r • f) μ a b :=
@@ -352,7 +352,7 @@ end IntervalIntegrable
 
 section
 
-variable {μ : Measure ℝ} [IsLocallyFiniteMeasure μ]
+variable {μ : MeasureTheory.Measure ℝ} [IsLocallyFiniteMeasure μ]
 
 theorem ContinuousOn.intervalIntegrable {u : ℝ → E} {a b : ℝ} (hu : ContinuousOn u (uIcc a b)) :
     IntervalIntegrable u μ a b :=
@@ -375,8 +375,8 @@ end
 
 section
 
-variable {μ : Measure ℝ} [IsLocallyFiniteMeasure μ] [ConditionallyCompleteLinearOrder E]
-  [OrderTopology E] [SecondCountableTopology E]
+variable {μ : MeasureTheory.Measure ℝ} [IsLocallyFiniteMeasure μ]
+  [ConditionallyCompleteLinearOrder E] [OrderTopology E] [SecondCountableTopology E]
 
 theorem MonotoneOn.intervalIntegrable {u : ℝ → E} {a b : ℝ} (hu : MonotoneOn u (uIcc a b)) :
     IntervalIntegrable u μ a b := by
@@ -459,7 +459,7 @@ namespace intervalIntegral
 
 section Basic
 
-variable {a b : ℝ} {f g : ℝ → E} {μ : Measure ℝ}
+variable {a b : ℝ} {f g : ℝ → E} {μ : MeasureTheory.Measure ℝ}
 
 @[simp]
 theorem integral_zero : (∫ _ in a..b, (0 : E) ∂μ) = 0 := by simp [intervalIntegral]
@@ -662,7 +662,7 @@ nonrec theorem integral_ofReal {a b : ℝ} {μ : Measure ℝ} {f : ℝ → ℝ} 
 
 section ContinuousLinearMap
 
-variable {a b : ℝ} {μ : Measure ℝ} {f : ℝ → E}
+variable {a b : ℝ} {μ : MeasureTheory.Measure ℝ} {f : ℝ → E}
 
 variable [IsROrC 𝕜] [NormedSpace 𝕜 E] [NormedAddCommGroup F] [NormedSpace 𝕜 F]
 
@@ -876,7 +876,7 @@ as well as a few other identities trivially equivalent to this one. We also prov
 
 section OrderClosedTopology
 
-variable {a b c d : ℝ} {f g : ℝ → E} {μ : Measure ℝ}
+variable {a b c d : ℝ} {f g : ℝ → E} {μ : MeasureTheory.Measure ℝ}
 
 /-- If two functions are equal in the relevant interval, their interval integrals are also equal. -/
 theorem integral_congr {a b : ℝ} (h : EqOn f g [[a, b]]) :
@@ -1123,7 +1123,7 @@ section ContinuousPrimitive
 
 open TopologicalSpace
 
-variable {a b b₀ b₁ b₂ : ℝ} {μ : Measure ℝ} {f g : ℝ → E}
+variable {a b b₀ b₁ b₂ : ℝ} {μ : MeasureTheory.Measure ℝ} {f g : ℝ → E}
 
 theorem continuousWithinAt_primitive (hb₀ : μ {b₀} = 0)
     (h_int : IntervalIntegrable f μ (min a b₁) (max a b₂)) :
@@ -1258,7 +1258,7 @@ end ContinuousPrimitive
 
 section
 
-variable {f g : ℝ → ℝ} {a b : ℝ} {μ : Measure ℝ}
+variable {f g : ℝ → ℝ} {a b : ℝ} {μ : MeasureTheory.Measure ℝ}
 
 theorem integral_eq_zero_iff_of_le_of_nonneg_ae (hab : a ≤ b) (hf : 0 ≤ᵐ[μ.restrict (Ioc a b)] f)
     (hfi : IntervalIntegrable f μ a b) : (∫ x in a..b, f x ∂μ) = 0 ↔ f =ᵐ[μ.restrict (Ioc a b)] 0 :=
@@ -1425,7 +1425,7 @@ end
 
 section HasSum
 
-variable {μ : Measure ℝ} {f : ℝ → E}
+variable {μ : MeasureTheory.Measure ℝ} {f : ℝ → E}
 
 theorem _root_.MeasureTheory.Integrable.hasSum_intervalIntegral (hfi : Integrable f μ) (y : ℝ) :
     HasSum (fun n : ℤ => ∫ x in y + n..y + n + 1, f x ∂μ) (∫ x, f x ∂μ) := by

--- a/Mathlib/MeasureTheory/Integral/Layercake.lean
+++ b/Mathlib/MeasureTheory/Integral/Layercake.lean
@@ -267,7 +267,7 @@ section LayercakeLT
 
 open MeasureTheory
 
-variable {α : Type _} [MeasurableSpace α] (μ : Measure α)
+variable {α : Type _} [MeasurableSpace α] (μ : MeasureTheory.Measure α)
 
 variable {β : Type _} [MeasurableSpace β] [MeasurableSingletonClass β]
 

--- a/Mathlib/MeasureTheory/Integral/Lebesgue.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue.lean
@@ -89,7 +89,7 @@ section Lintegral
 
 open SimpleFunc
 
-variable {m : MeasurableSpace α} {μ ν : Measure α}
+variable {m : MeasurableSpace α} {μ ν : MeasureTheory.Measure α}
 
 /-- The **lower Lebesgue integral** of a function `f` with respect to a measure `μ`. -/
 irreducible_def lintegral {_ : MeasurableSpace α} (μ : Measure α) (f : α → ℝ≥0∞) : ℝ≥0∞ :=

--- a/Mathlib/MeasureTheory/Integral/MeanInequalities.lean
+++ b/Mathlib/MeasureTheory/Integral/MeanInequalities.lean
@@ -57,7 +57,7 @@ set_option linter.uppercaseLean3 false
 
 local macro_rules | `($x ^ $y)   => `(HPow.hPow $x $y) -- Porting note: See issue #2220
 
-variable {α : Type _} [MeasurableSpace α] {μ : Measure α}
+variable {α : Type _} [MeasurableSpace α] {μ : MeasureTheory.Measure α}
 
 namespace ENNReal
 

--- a/Mathlib/MeasureTheory/Integral/PeakFunction.lean
+++ b/Mathlib/MeasureTheory/Integral/PeakFunction.lean
@@ -48,7 +48,8 @@ theorem Set.disjoint_sdiff_inter {α : Type _} (s t : Set α) : Disjoint (s \ t)
 
 open Set
 
-variable {α E ι : Type _} {hm : MeasurableSpace α} {μ : Measure α} [TopologicalSpace α]
+variable {α E ι : Type _} {hm : MeasurableSpace α} {μ : MeasureTheory.Measure α}
+  [TopologicalSpace α]
   [BorelSpace α] [NormedAddCommGroup E] [NormedSpace ℝ E] {g : α → E} {l : Filter ι} {x₀ : α}
   {s : Set α} {φ : ι → α → ℝ}
 

--- a/Mathlib/MeasureTheory/Integral/SetIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/SetIntegral.lean
@@ -68,7 +68,8 @@ namespace MeasureTheory
 
 section NormedAddCommGroup
 
-variable [NormedAddCommGroup E] {f g : α → E} {s t : Set α} {μ ν : Measure α} {l l' : Filter α}
+variable [NormedAddCommGroup E] {f g : α → E} {s t : Set α} {μ ν : MeasureTheory.Measure α}
+  {l l' : Filter α}
 
 variable [CompleteSpace E] [NormedSpace ℝ E]
 
@@ -678,7 +679,7 @@ end NormedAddCommGroup
 
 section Mono
 
-variable {μ : Measure α} {f g : α → ℝ} {s t : Set α} (hf : IntegrableOn f s μ)
+variable {μ : MeasureTheory.Measure α} {f g : α → ℝ} {s t : Set α} (hf : IntegrableOn f s μ)
   (hg : IntegrableOn g s μ)
 
 theorem set_integral_mono_ae_restrict (h : f ≤ᵐ[μ.restrict s] g) :
@@ -721,7 +722,7 @@ end Mono
 
 section Nonneg
 
-variable {μ : Measure α} {f : α → ℝ} {s : Set α}
+variable {μ : MeasureTheory.Measure α} {f : α → ℝ} {s : Set α}
 
 theorem set_integral_nonneg_of_ae_restrict (hf : 0 ≤ᵐ[μ.restrict s] f) : 0 ≤ ∫ a in s, f a ∂μ :=
   integral_nonneg_of_ae hf
@@ -782,7 +783,7 @@ end Nonneg
 
 section IntegrableUnion
 
-variable {μ : Measure α} [NormedAddCommGroup E] [Countable β]
+variable {μ : MeasureTheory.Measure α} [NormedAddCommGroup E] [Countable β]
 
 theorem integrableOn_iUnion_of_summable_integral_norm {f : α → E} {s : β → Set α}
     (hs : ∀ b : β, MeasurableSet (s b)) (hi : ∀ b : β, IntegrableOn f (s b) μ)
@@ -830,8 +831,8 @@ end IntegrableUnion
 
 section TendstoMono
 
-variable {μ : Measure α} [NormedAddCommGroup E] [CompleteSpace E] [NormedSpace ℝ E] {s : ℕ → Set α}
-  {f : α → E}
+variable {μ : MeasureTheory.Measure α} [NormedAddCommGroup E] [CompleteSpace E] [NormedSpace ℝ E]
+  {s : ℕ → Set α} {f : α → E}
 
 theorem _root_.Antitone.tendsto_set_integral (hsm : ∀ i, MeasurableSet (s i)) (h_anti : Antitone s)
     (hfi : IntegrableOn f (s 0) μ) :
@@ -1055,8 +1056,8 @@ as `ContinuousLinearMap.compLp`. We take advantage of this construction here.
 
 open scoped ComplexConjugate
 
-variable {μ : Measure α} {𝕜 : Type _} [IsROrC 𝕜] [NormedSpace 𝕜 E] [NormedAddCommGroup F]
-  [NormedSpace 𝕜 F] {p : ENNReal}
+variable {μ : MeasureTheory.Measure α} {𝕜 : Type _} [IsROrC 𝕜] [NormedSpace 𝕜 E]
+  [NormedAddCommGroup F] [NormedSpace 𝕜 F] {p : ENNReal}
 
 namespace ContinuousLinearMap
 
@@ -1318,7 +1319,7 @@ section BilinearMap
 
 namespace MeasureTheory
 
-variable {f : β → ℝ} {m m0 : MeasurableSpace β} {μ : Measure β}
+variable {f : β → ℝ} {m m0 : MeasurableSpace β} {μ : MeasureTheory.Measure β}
 
 theorem Integrable.simpleFunc_mul (g : SimpleFunc β ℝ) (hf : Integrable f μ) :
     Integrable (⇑g * f) μ := by

--- a/Mathlib/MeasureTheory/Integral/VitaliCaratheodory.lean
+++ b/Mathlib/MeasureTheory/Integral/VitaliCaratheodory.lean
@@ -79,8 +79,8 @@ open scoped ENNReal NNReal
 
 open MeasureTheory MeasureTheory.Measure
 
-variable {α : Type _} [TopologicalSpace α] [MeasurableSpace α] [BorelSpace α] (μ : Measure α)
-  [WeaklyRegular μ]
+variable {α : Type _} [TopologicalSpace α] [MeasurableSpace α] [BorelSpace α]
+  (μ : MeasureTheory.Measure α) [WeaklyRegular μ]
 
 namespace MeasureTheory
 

--- a/Mathlib/MeasureTheory/Lattice.lean
+++ b/Mathlib/MeasureTheory/Lattice.lean
@@ -101,7 +101,7 @@ instance (priority := 100) OrderDual.instMeasurableInf₂ [Sup M] [MeasurableSup
 
 end OrderDual
 
-variable {α : Type _} {m : MeasurableSpace α} {μ : Measure α} {f g : α → M}
+variable {α : Type _} {m : MeasurableSpace α} {μ : MeasureTheory.Measure α} {f g : α → M}
 
 section Sup
 

--- a/Mathlib/MeasureTheory/Measure/AEDisjoint.lean
+++ b/Mathlib/MeasureTheory/Measure/AEDisjoint.lean
@@ -23,7 +23,7 @@ open Set Function
 
 namespace MeasureTheory
 
-variable {ι α : Type _} {m : MeasurableSpace α} (μ : Measure α)
+variable {ι α : Type _} {m : MeasurableSpace α} (μ : MeasureTheory.Measure α)
 
 /-- Two sets are said to be `μ`-a.e. disjoint if their intersection has measure zero. -/
 def AEDisjoint (s t : Set α) :=

--- a/Mathlib/MeasureTheory/Measure/Doubling.lean
+++ b/Mathlib/MeasureTheory/Measure/Doubling.lean
@@ -52,7 +52,7 @@ class IsUnifLocDoublingMeasure {α : Type _} [MetricSpace α] [MeasurableSpace �
 
 namespace IsUnifLocDoublingMeasure
 
-variable {α : Type _} [MetricSpace α] [MeasurableSpace α] (μ : Measure α)
+variable {α : Type _} [MetricSpace α] [MeasurableSpace α] (μ : MeasureTheory.Measure α)
   [IsUnifLocDoublingMeasure μ]
 
 -- Porting note: added for missing infer kinds

--- a/Mathlib/MeasureTheory/Measure/Lebesgue/Basic.lean
+++ b/Mathlib/MeasureTheory/Measure/Lebesgue/Basic.lean
@@ -474,7 +474,7 @@ theorem regionBetween_subset (f g : α → ℝ) (s : Set α) : regionBetween f g
   simpa only [prod_univ, regionBetween, Set.preimage, setOf_subset_setOf] using fun a => And.left
 #align region_between_subset regionBetween_subset
 
-variable [MeasurableSpace α] {μ : Measure α} {f g : α → ℝ} {s : Set α}
+variable [MeasurableSpace α] {μ : MeasureTheory.Measure α} {f g : α → ℝ} {s : Set α}
 
 /-- The region between two measurable functions on a measurable set is measurable. -/
 theorem measurableSet_regionBetween (hf : Measurable f) (hg : Measurable g) (hs : MeasurableSet s) :

--- a/Mathlib/MeasureTheory/Measure/Lebesgue/Integral.lean
+++ b/Mathlib/MeasureTheory/Measure/Lebesgue/Integral.lean
@@ -20,7 +20,7 @@ section regionBetween
 
 variable {α : Type _}
 
-variable [MeasurableSpace α] {μ : Measure α} {f g : α → ℝ} {s : Set α}
+variable [MeasurableSpace α] {μ : MeasureTheory.Measure α} {f g : α → ℝ} {s : Set α}
 
 theorem volume_regionBetween_eq_integral' [SigmaFinite μ] (f_int : IntegrableOn f s μ)
     (g_int : IntegrableOn g s μ) (hs : MeasurableSet s) (hfg : f ≤ᵐ[μ.restrict s] g) :

--- a/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
+++ b/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
@@ -111,7 +111,7 @@ namespace MeasureTheory
 
 section
 
-variable {m : MeasurableSpace α} {μ μ₁ μ₂ : Measure α} {s s₁ s₂ t : Set α}
+variable {m : MeasurableSpace α} {μ μ₁ μ₂ : MeasureTheory.Measure α} {s s₁ s₂ t : Set α}
 
 instance ae_isMeasurablyGenerated : IsMeasurablyGenerated μ.ae :=
   ⟨fun _s hs =>
@@ -707,7 +707,7 @@ synthesizing instances in `MeasureSpace` section. -/
 
 variable {m0 : MeasurableSpace α} [MeasurableSpace β] [MeasurableSpace γ]
 
-variable {μ μ₁ μ₂ μ₃ ν ν' ν₁ ν₂ : Measure α} {s s' t : Set α}
+variable {μ μ₁ μ₂ μ₃ ν ν' ν₁ ν₂ : MeasureTheory.Measure α} {s s' t : Set α}
 namespace Measure
 
 /-- If `u` is a superset of `t` with the same (finite) measure (both sets possibly non-measurable),
@@ -998,7 +998,7 @@ protected theorem le_add_right (h : μ ≤ ν) : μ ≤ ν + ν' := fun s hs => 
 
 section sInf
 
-variable {m : Set (Measure α)}
+variable {m : Set (MeasureTheory.Measure α)}
 
 theorem sInf_caratheodory (s : Set α) (hs : MeasurableSet s) :
     MeasurableSet[(sInf (toOuterMeasure '' m)).caratheodory] s := by
@@ -1477,7 +1477,7 @@ section
 
 variable {m0 : MeasurableSpace α} [MeasurableSpace β] [MeasurableSpace γ]
 
-variable {μ μ₁ μ₂ μ₃ ν ν' ν₁ ν₂ : Measure α} {s s' t : Set α}
+variable {μ μ₁ μ₂ μ₃ ν ν' ν₁ ν₂ : MeasureTheory.Measure α} {s s' t : Set α}
 
 namespace Measure
 
@@ -2447,7 +2447,7 @@ protected theorem id {_m0 : MeasurableSpace α} (μ : Measure α) : QuasiMeasure
   ⟨measurable_id, map_id.absolutelyContinuous⟩
 #align measure_theory.measure.quasi_measure_preserving.id MeasureTheory.Measure.QuasiMeasurePreserving.id
 
-variable {μa μa' : Measure α} {μb μb' : Measure β} {μc : Measure γ} {f : α → β}
+variable {μa μa' : Measure α} {μb μb' : Measure β} {μc : MeasureTheory.Measure γ} {f : α → β}
 
 protected theorem _root_.Measurable.quasiMeasurePreserving
     {_m0 : MeasurableSpace α} (hf : Measurable f) (μ : Measure α) :
@@ -4285,7 +4285,7 @@ namespace MeasurableEquiv
 
 open Equiv MeasureTheory.Measure
 
-variable [MeasurableSpace α] [MeasurableSpace β] {μ : Measure α} {ν : Measure β}
+variable [MeasurableSpace α] [MeasurableSpace β] {μ : Measure α} {ν : MeasureTheory.Measure β}
 
 /-- If we map a measure along a measurable equivalence, we can compute the measure on all sets
   (not just the measurable ones). -/
@@ -4356,7 +4356,7 @@ theorem trim_eq_self [MeasurableSpace α] {μ : Measure α} : μ.trim le_rfl = �
   simp [Measure.trim]
 #align measure_theory.trim_eq_self MeasureTheory.trim_eq_self
 
-variable {m m0 : MeasurableSpace α} {μ : Measure α} {s : Set α}
+variable {m m0 : MeasurableSpace α} {μ : MeasureTheory.Measure α} {s : Set α}
 
 theorem toOuterMeasure_trim_eq_trim_toOuterMeasure (μ : Measure α) (hm : m ≤ m0) :
     @Measure.toOuterMeasure _ m (μ.trim hm) = @OuterMeasure.trim _ m μ.toOuterMeasure := by
@@ -4454,7 +4454,7 @@ end MeasureTheory
 
 namespace IsCompact
 
-variable [TopologicalSpace α] [MeasurableSpace α] {μ : Measure α} {s : Set α}
+variable [TopologicalSpace α] [MeasurableSpace α] {μ : MeasureTheory.Measure α} {s : Set α}
 
 /-- If `s` is a compact set and `μ` is finite at `𝓝 x` for every `x ∈ s`, then `s` admits an open
 superset of finite measure. -/
@@ -4606,7 +4606,7 @@ end MeasureIxx
 
 section Piecewise
 
-variable [MeasurableSpace α] {μ : Measure α} {s t : Set α} {f g : α → β}
+variable [MeasurableSpace α] {μ : MeasureTheory.Measure α} {s t : Set α} {f g : α → β}
 
 theorem piecewise_ae_eq_restrict (hs : MeasurableSet s) : piecewise s f g =ᵐ[μ.restrict s] f := by
   rw [ae_restrict_eq hs]
@@ -4627,7 +4627,7 @@ end Piecewise
 
 section IndicatorFunction
 
-variable [MeasurableSpace α] {μ : Measure α} {s t : Set α} {f : α → β}
+variable [MeasurableSpace α] {μ : MeasureTheory.Measure α} {s t : Set α} {f : α → β}
 
 theorem mem_map_indicator_ae_iff_mem_map_restrict_ae_of_zero_mem [Zero β] {t : Set β}
     (ht : (0 : β) ∈ t) (hs : MeasurableSet s) :

--- a/Mathlib/MeasureTheory/Measure/MeasureSpaceDef.lean
+++ b/Mathlib/MeasureTheory/Measure/MeasureSpaceDef.lean
@@ -95,7 +95,7 @@ attribute [coe] Measure.toOuterMeasure
 
 section
 
-variable [MeasurableSpace α] {μ μ₁ μ₂ : Measure α} {s s₁ s₂ t : Set α}
+variable [MeasurableSpace α] {μ μ₁ μ₂ : MeasureTheory.Measure α} {s s₁ s₂ t : Set α}
 
 namespace Measure
 
@@ -667,7 +667,7 @@ function. We define this property, called `AEMeasurable f μ`. It's properties a
 -/
 
 
-variable {m : MeasurableSpace α} [MeasurableSpace β] {f g : α → β} {μ ν : Measure α}
+variable {m : MeasurableSpace α} [MeasurableSpace β] {f g : α → β} {μ ν : MeasureTheory.Measure α}
 
 /-- A function is almost everywhere measurable if it coincides almost everywhere with a measurable
 function. -/

--- a/Mathlib/MeasureTheory/Measure/MutuallySingular.lean
+++ b/Mathlib/MeasureTheory/Measure/MutuallySingular.lean
@@ -35,7 +35,7 @@ namespace MeasureTheory
 
 namespace Measure
 
-variable {α : Type _} {m0 : MeasurableSpace α} {μ μ₁ μ₂ ν ν₁ ν₂ : Measure α}
+variable {α : Type _} {m0 : MeasurableSpace α} {μ μ₁ μ₂ ν ν₁ ν₂ : MeasureTheory.Measure α}
 
 /-- Two measures `μ`, `ν` are said to be mutually singular if there exists a measurable set `s`
 such that `μ s = 0` and `ν sᶜ = 0`. -/

--- a/Mathlib/MeasureTheory/Measure/NullMeasurable.lean
+++ b/Mathlib/MeasureTheory/Measure/NullMeasurable.lean
@@ -74,7 +74,7 @@ def NullMeasurableSpace (α : Type _) [MeasurableSpace α]
 
 section
 
-variable {m0 : MeasurableSpace α} {μ : Measure α} {s t : Set α}
+variable {m0 : MeasurableSpace α} {μ : MeasureTheory.Measure α} {s t : Set α}
 
 instance NullMeasurableSpace.instInhabited [h : Inhabited α] :
     Inhabited (NullMeasurableSpace α μ) :=
@@ -410,7 +410,8 @@ end
 
 section NullMeasurable
 
-variable [MeasurableSpace α] [MeasurableSpace β] [MeasurableSpace γ] {f : α → β} {μ : Measure α}
+variable [MeasurableSpace α] [MeasurableSpace β] [MeasurableSpace γ] {f : α → β}
+  {μ : MeasureTheory.Measure α}
 
 /-- A function `f : α → β` is null measurable if the preimage of a measurable set is a null
 measurable set. -/
@@ -450,7 +451,7 @@ class Measure.IsComplete {_ : MeasurableSpace α} (μ : Measure α) : Prop where
   out' : ∀ s, μ s = 0 → MeasurableSet s
 #align measure_theory.measure.is_complete MeasureTheory.Measure.IsComplete
 
-variable {m0 : MeasurableSpace α} {μ : Measure α} {s t : Set α}
+variable {m0 : MeasurableSpace α} {μ : MeasureTheory.Measure α} {s t : Set α}
 
 theorem Measure.isComplete_iff : μ.IsComplete ↔ ∀ s, μ s = 0 → MeasurableSet s :=
   ⟨fun h => h.1, fun h => ⟨h⟩⟩

--- a/Mathlib/MeasureTheory/Measure/OpenPos.lean
+++ b/Mathlib/MeasureTheory/Measure/OpenPos.lean
@@ -181,7 +181,7 @@ open MeasureTheory MeasureTheory.Measure
 
 namespace Metric
 
-variable {X : Type _} [PseudoMetricSpace X] {m : MeasurableSpace X} (μ : Measure X)
+variable {X : Type _} [PseudoMetricSpace X] {m : MeasurableSpace X} (μ : MeasureTheory.Measure X)
   [IsOpenPosMeasure μ]
 
 theorem measure_ball_pos (x : X) {r : ℝ} (hr : 0 < r) : 0 < μ (ball x r) :=
@@ -196,7 +196,7 @@ end Metric
 
 namespace EMetric
 
-variable {X : Type _} [PseudoEMetricSpace X] {m : MeasurableSpace X} (μ : Measure X)
+variable {X : Type _} [PseudoEMetricSpace X] {m : MeasurableSpace X} (μ : MeasureTheory.Measure X)
   [IsOpenPosMeasure μ]
 
 theorem measure_ball_pos (x : X) {r : ℝ≥0∞} (hr : r ≠ 0) : 0 < μ (ball x r) :=

--- a/Mathlib/MeasureTheory/Measure/Regular.lean
+++ b/Mathlib/MeasureTheory/Measure/Regular.lean
@@ -150,8 +150,8 @@ def InnerRegular {α} {_ : MeasurableSpace α} (μ : Measure α) (p q : Set α �
 
 namespace InnerRegular
 
-variable {α : Type _} {m : MeasurableSpace α} {μ : Measure α} {p q : Set α → Prop} {U : Set α}
-  {ε : ℝ≥0∞}
+variable {α : Type _} {m : MeasurableSpace α} {μ : MeasureTheory.Measure α} {p q : Set α → Prop}
+  {U : Set α} {ε : ℝ≥0∞}
 
 theorem measure_eq_iSup (H : InnerRegular μ p q) (hU : q U) :
     μ U = ⨆ (K) (_ : K ⊆ U) (_ : p K), μ K := by
@@ -196,7 +196,7 @@ theorem trans {q' : Set α → Prop} (H : InnerRegular μ p q) (H' : InnerRegula
 
 end InnerRegular
 
-variable {α β : Type _} [MeasurableSpace α] [TopologicalSpace α] {μ : Measure α}
+variable {α β : Type _} [MeasurableSpace α] [TopologicalSpace α] {μ : MeasureTheory.Measure α}
 
 /-- A measure `μ` is outer regular if `μ(A) = inf {μ(U) | A ⊆ U open}` for a measurable set `A`.
 

--- a/Mathlib/MeasureTheory/Measure/Sub.lean
+++ b/Mathlib/MeasureTheory/Measure/Sub.lean
@@ -37,7 +37,7 @@ noncomputable instance instSub {α : Type _} [MeasurableSpace α] : Sub (Measure
   ⟨fun μ ν => sInf { τ | μ ≤ τ + ν }⟩
 #align measure_theory.measure.has_sub MeasureTheory.Measure.instSub
 
-variable {α : Type _} {m : MeasurableSpace α} {μ ν : Measure α} {s : Set α}
+variable {α : Type _} {m : MeasurableSpace α} {μ ν : MeasureTheory.Measure α} {s : Set α}
 
 theorem sub_def : μ - ν = sInf { d | μ ≤ d + ν } := rfl
 #align measure_theory.measure.sub_def MeasureTheory.Measure.sub_def

--- a/Mathlib/MeasureTheory/Measure/VectorMeasure.lean
+++ b/Mathlib/MeasureTheory/Measure/VectorMeasure.lean
@@ -1417,7 +1417,7 @@ namespace Measure
 
 open VectorMeasure
 
-variable (μ : Measure α) [IsFiniteMeasure μ]
+variable (μ : MeasureTheory.Measure α) [IsFiniteMeasure μ]
 
 theorem zero_le_toSignedMeasure : 0 ≤ μ.toSignedMeasure := by
   rw [← le_restrict_univ_iff_le]

--- a/Mathlib/MeasureTheory/Measure/WithDensityVectorMeasure.lean
+++ b/Mathlib/MeasureTheory/Measure/WithDensityVectorMeasure.lean
@@ -37,7 +37,7 @@ namespace MeasureTheory
 
 open TopologicalSpace
 
-variable {μ ν : Measure α}
+variable {μ ν : MeasureTheory.Measure α}
 
 variable {E : Type _} [NormedAddCommGroup E] [NormedSpace ℝ E] [CompleteSpace E]
 

--- a/Mathlib/Probability/ConditionalProbability.lean
+++ b/Mathlib/Probability/ConditionalProbability.lean
@@ -63,7 +63,7 @@ noncomputable section
 
 open ENNReal MeasureTheory MeasurableSpace
 
-variable {Ω : Type _} {m : MeasurableSpace Ω} (μ : Measure Ω) {s t : Set Ω}
+variable {Ω : Type _} {m : MeasurableSpace Ω} (μ : MeasureTheory.Measure Ω) {s t : Set Ω}
 
 namespace ProbabilityTheory
 

--- a/Mathlib/Probability/Density.lean
+++ b/Mathlib/Probability/Density.lean
@@ -131,7 +131,7 @@ theorem map_eq_set_lintegral_pdf {m : MeasurableSpace Ω} (X : Ω → E) (ℙ : 
 
 namespace pdf
 
-variable {m : MeasurableSpace Ω} {ℙ : Measure Ω} {μ : Measure E}
+variable {m : MeasurableSpace Ω} {ℙ : Measure Ω} {μ : MeasureTheory.Measure E}
 
 theorem lintegral_eq_measure_univ {X : Ω → E} [HasPDF X ℙ μ] :
     (∫⁻ x, pdf X ℙ μ x ∂μ) = ℙ Set.univ := by
@@ -239,7 +239,7 @@ theorem hasPDF_iff_of_measurable {X : Ω → E} (hX : Measurable X) :
 
 section
 
-variable {F : Type _} [MeasurableSpace F] {ν : Measure F}
+variable {F : Type _} [MeasurableSpace F] {ν : MeasureTheory.Measure F}
 
 /-- A random variable that `HasPDF` transformed under a `quasi_measure_preserving`
 map also `HasPDF` if `(map g (map X ℙ)).have_lebesgue_decomposition μ`.

--- a/Mathlib/Probability/Independence/Basic.lean
+++ b/Mathlib/Probability/Independence/Basic.lean
@@ -385,7 +385,7 @@ theorem IndepSets.indep' {_m : MeasurableSpace Ω} {μ : Measure Ω} [IsProbabil
   hyp.indep (generateFrom_le hp1m) (generateFrom_le hp2m) hp1 hp2 rfl rfl
 #align probability_theory.indep_sets.indep' ProbabilityTheory.IndepSets.indep'
 
-variable {m0 : MeasurableSpace Ω} {μ : Measure Ω}
+variable {m0 : MeasurableSpace Ω} {μ : MeasureTheory.Measure Ω}
 
 theorem indepSets_piiUnionInter_of_disjoint [IsProbabilityMeasure μ] {s : ι → Set (Set Ω)}
     {S T : Set ι} (h_indep : iIndepSets s μ) (hST : Disjoint S T) :
@@ -651,7 +651,8 @@ section IndepFun
 -/
 
 
-variable {β β' γ γ' : Type _} {mΩ : MeasurableSpace Ω} {μ : Measure Ω} {f : Ω → β} {g : Ω → β'}
+variable {β β' γ γ' : Type _} {mΩ : MeasurableSpace Ω} {μ : MeasureTheory.Measure Ω}
+  {f : Ω → β} {g : Ω → β'}
 
 theorem indepFun_iff_measure_inter_preimage_eq_mul {mβ : MeasurableSpace β}
     {mβ' : MeasurableSpace β'} :

--- a/Mathlib/Probability/Independence/ZeroOne.lean
+++ b/Mathlib/Probability/Independence/ZeroOne.lean
@@ -30,7 +30,7 @@ open scoped MeasureTheory ENNReal
 
 namespace ProbabilityTheory
 
-variable {Ω ι : Type _} {m m0 : MeasurableSpace Ω} {μ : Measure Ω}
+variable {Ω ι : Type _} {m m0 : MeasurableSpace Ω} {μ : MeasureTheory.Measure Ω}
 
 theorem measure_eq_zero_or_one_or_top_of_indepSet_self {t : Set Ω}
     (h_indep : IndepSet t t μ) : μ t = 0 ∨ μ t = 1 ∨ μ t = ∞ := by

--- a/Mathlib/Probability/Integration.lean
+++ b/Mathlib/Probability/Integration.lean
@@ -38,7 +38,8 @@ open Set MeasureTheory
 
 open scoped ENNReal MeasureTheory
 
-variable {Ω : Type _} {mΩ : MeasurableSpace Ω} {μ : Measure Ω} {f g : Ω → ℝ≥0∞} {X Y : Ω → ℝ}
+variable {Ω : Type _} {mΩ : MeasurableSpace Ω} {μ : MeasureTheory.Measure Ω} {f g : Ω → ℝ≥0∞}
+  {X Y : Ω → ℝ}
 
 namespace ProbabilityTheory
 

--- a/Mathlib/Probability/ProbabilityMassFunction/Basic.lean
+++ b/Mathlib/Probability/ProbabilityMassFunction/Basic.lean
@@ -350,8 +350,8 @@ def toPmf [Countable α] [MeasurableSpace α] [MeasurableSingletonClass α] (μ 
         h.measure_univ)⟩
 #align measure_theory.measure.to_pmf MeasureTheory.Measure.toPmf
 
-variable [Countable α] [MeasurableSpace α] [MeasurableSingletonClass α] (μ : Measure α)
-  [IsProbabilityMeasure μ]
+variable [Countable α] [MeasurableSpace α] [MeasurableSingletonClass α]
+  (μ : MeasureTheory.Measure α) [IsProbabilityMeasure μ]
 
 theorem toPmf_apply (x : α) : μ.toPmf x = μ {x} := rfl
 #align measure_theory.measure.to_pmf_apply MeasureTheory.Measure.toPmf_apply
@@ -379,8 +379,8 @@ instance toMeasure.isProbabilityMeasure [MeasurableSpace α] (p : Pmf α) :
       toOuterMeasure_apply, ENNReal.coe_eq_one] using tsum_coe p⟩
 #align pmf.to_measure.is_probability_measure Pmf.toMeasure.isProbabilityMeasure
 
-variable [Countable α] [MeasurableSpace α] [MeasurableSingletonClass α] (p : Pmf α) (μ : Measure α)
-  [IsProbabilityMeasure μ]
+variable [Countable α] [MeasurableSpace α] [MeasurableSingletonClass α] (p : Pmf α)
+  (μ : MeasureTheory.Measure α) [IsProbabilityMeasure μ]
 
 @[simp]
 theorem toMeasure_toPmf : p.toMeasure.toPmf = p :=


### PR DESCRIPTION
(Temporarily) replace `Measure` by `MeasureTheory.Measure`, at least on all variable lines, because that is super slow ([Zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Measure.20is.20overloaded)).

This PR need not be merged if we get a quick other fix. Also let's perf check this PR first.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
