### PR TITLE
[Merged by Bors] - feat: Lipschitz extensions of maps into l^infty

### DIFF
--- a/Mathlib/Analysis/NormedSpace/lpSpace.lean
+++ b/Mathlib/Analysis/NormedSpace/lpSpace.lean
@@ -325,6 +325,9 @@ def lp (E : α → Type _) [∀ i, NormedAddCommGroup (E i)] (p : ℝ≥0∞) : 
   neg_mem' := Memℓp.neg
 #align lp lp
 
+scoped[lp] notation "ℓ^∞(" ι ", " E ")" => lp (fun i : ι => E) ∞
+scoped[lp] notation "ℓ^∞(" ι ")" => lp (fun i : ι => ℝ) ∞
+
 namespace lp
 
 -- Porting note: was `Coe`

--- a/Mathlib/Analysis/NormedSpace/lpSpace.lean
+++ b/Mathlib/Analysis/NormedSpace/lpSpace.lean
@@ -1223,6 +1223,10 @@ end lp
 
 section Lipschitz
 
+local notation "ℓ^∞(" ι ")" => lp (fun i : ι => ℝ) ∞
+
+open ENNReal
+
 lemma LipschitzWith.uniformly_bounded [PseudoMetricSpace α] (g : α → ι → ℝ) {K : ℝ≥0}
     (hg : ∀ i, LipschitzWith K (g · i)) (a₀ : α) (hga₀b : Memℓp (g a₀) ∞) (a : α) :
     Memℓp (g a) ∞ := by

--- a/Mathlib/Analysis/NormedSpace/lpSpace.lean
+++ b/Mathlib/Analysis/NormedSpace/lpSpace.lean
@@ -1223,9 +1223,7 @@ end lp
 
 section Lipschitz
 
-local notation "ℓ^∞(" ι ")" => lp (fun i : ι => ℝ) ∞
-
-open ENNReal
+open ENNReal lp
 
 lemma LipschitzWith.uniformly_bounded [PseudoMetricSpace α] (g : α → ι → ℝ) {K : ℝ≥0}
     (hg : ∀ i, LipschitzWith K (g · i)) (a₀ : α) (hga₀b : Memℓp (g a₀) ∞) (a : α) :

--- a/Mathlib/Topology/MetricSpace/Kuratowski.lean
+++ b/Mathlib/Topology/MetricSpace/Kuratowski.lean
@@ -26,7 +26,7 @@ set_option linter.uppercaseLean3 false
 
 open Set Metric TopologicalSpace NNReal ENNReal
 
-notation "ℓ^∞(" ι ") " => lp (fun i : ι => ℝ ) ∞
+local notation "ℓ^∞(" ι ") " => lp (fun i : ι => ℝ ) ∞
 
 universe u v w
 
@@ -112,7 +112,8 @@ end KuratowskiEmbedding
 
 open TopologicalSpace KuratowskiEmbedding
 
-/-- The Kuratowski embedding is an isometric embedding of a separable metric space in `ℓ^∞(ℕ, ℝ)`. -/
+/-- The Kuratowski embedding is an isometric embedding of a separable metric space in `ℓ^∞(ℕ, ℝ)`.
+-/
 def kuratowskiEmbedding (α : Type u) [MetricSpace α] [SeparableSpace α] : α → ℓ^∞(ℕ) :=
   Classical.choose (KuratowskiEmbedding.exists_isometric_embedding α)
 #align Kuratowski_embedding kuratowskiEmbedding

--- a/Mathlib/Topology/MetricSpace/Kuratowski.lean
+++ b/Mathlib/Topology/MetricSpace/Kuratowski.lean
@@ -144,12 +144,10 @@ The same result for the case of a finite type `ι` is implemented in
 theorem LipschitzOnWith.extend_lp_infty [PseudoMetricSpace α] {s : Set α} {f : α → ℓ^∞(ι)}
     {K : ℝ≥0} (hfl : LipschitzOnWith K f s): ∃ g : α → ℓ^∞(ι), LipschitzWith K g ∧ EqOn f g s := by
   -- Construct the coordinate-wise extensions
+  rw [LipschitzOnWith.coordinate] at hfl
   have : ∀ i : ι, ∃ g : α → ℝ, LipschitzWith K g ∧ EqOn (fun x => f x i) g s
   · intro i
-    apply LipschitzOnWith.extend_real -- use the nonlinear Hahn-Banach theorem here!
-    revert i
-    rw [← LipschitzOnWith.coordinate]
-    exact hfl
+    exact LipschitzOnWith.extend_real (hfl i) -- use the nonlinear Hahn-Banach theorem here!
   choose g hgl hgeq using this
   rcases s.eq_empty_or_nonempty with rfl | ⟨a₀, ha₀_in_s⟩
   . exact ⟨fun _ ↦ 0, LipschitzWith.const' 0, by simp⟩

--- a/Mathlib/Topology/MetricSpace/Kuratowski.lean
+++ b/Mathlib/Topology/MetricSpace/Kuratowski.lean
@@ -142,6 +142,9 @@ nonrec def NonemptyCompacts.kuratowskiEmbedding (α : Type u) [MetricSpace α] [
 
     Theorem 2.2 of Metric Embeddings and Lipschitz Extensions by Assaf Naor
     https://web.math.princeton.edu/~naor/homepage%20files/embeddings_extensions.pdf
+
+    The same result for the case of a finite type `ι` is implemented in
+    `LipschitzOnWith.extend_pi`.
 -/
 theorem LipschitzOnWith.extend_linf [PseudoMetricSpace α] {s : Set α} {f : α → ℓ^∞(ι)}
     {K : ℝ≥0} (hfl : LipschitzOnWith K f s): ∃ g : α → ℓ^∞(ι), LipschitzWith K g ∧ EqOn f g s := by

--- a/Mathlib/Topology/MetricSpace/Kuratowski.lean
+++ b/Mathlib/Topology/MetricSpace/Kuratowski.lean
@@ -135,10 +135,6 @@ nonrec def NonemptyCompacts.kuratowskiEmbedding (α : Type u) [MetricSpace α] [
   nonempty' := range_nonempty _
 #align nonempty_compacts.Kuratowski_embedding NonemptyCompacts.kuratowskiEmbedding
 
-theorem lipschitzWith_const [PseudoMetricSpace α] [PseudoMetricSpace β] (b: β) (K : ℝ≥0):
-  LipschitzWith K (fun _ : α ↦ b):= by
-  intro x y; simp
-
 /--
     A function `f : α → (ι → ℝ)` which is `K`-Lipschitz on a subset `s` admits a `K`-Lipschitz
     extension to the whole space.
@@ -159,7 +155,7 @@ theorem LipschitzOnWith.extend_linf [PseudoMetricSpace α] {s : Set α} {f : α 
       _ ≤ K * dist x y := hfl x hx y hy
   choose g hg using this
   rcases s.eq_empty_or_nonempty with rfl | ⟨a₀, ha₀_in_s⟩
-  . exact ⟨fun _ ↦ 0, lipschitzWith_const 0 K, by simp⟩
+  . exact ⟨fun _ ↦ 0, LipschitzWith.const' 0, by simp⟩
   · let f_ext : α → ι → ℝ := fun x i ↦ g i x
     -- Show that the extensions are uniformly bounded
     have hf_extb : ∀ a : α, Memℓp (f_ext a) ∞

--- a/Mathlib/Topology/MetricSpace/Kuratowski.lean
+++ b/Mathlib/Topology/MetricSpace/Kuratowski.lean
@@ -143,7 +143,7 @@ Theorem 2.2 of [Assaf Naor, *Metric Embeddings and Lipschitz Extensions*][Naor-2
 The same result for the case of a finite type `ι` is implemented in
 `LipschitzOnWith.extend_pi`.
 -/
-theorem LipschitzOnWith.extend_linf [PseudoMetricSpace α] {s : Set α} {f : α → ℓ^∞(ι)}
+theorem LipschitzOnWith.extend_lp_infty [PseudoMetricSpace α] {s : Set α} {f : α → ℓ^∞(ι)}
     {K : ℝ≥0} (hfl : LipschitzOnWith K f s): ∃ g : α → ℓ^∞(ι), LipschitzWith K g ∧ EqOn f g s := by
   -- Construct the coordinate-wise extensions
   have : ∀ i : ι, ∃ g : α → ℝ, LipschitzWith K g ∧ EqOn (fun x => f x i) g s

--- a/Mathlib/Topology/MetricSpace/Kuratowski.lean
+++ b/Mathlib/Topology/MetricSpace/Kuratowski.lean
@@ -135,7 +135,7 @@ nonrec def NonemptyCompacts.kuratowskiEmbedding (α : Type u) [MetricSpace α] [
 #align nonempty_compacts.Kuratowski_embedding NonemptyCompacts.kuratowskiEmbedding
 
 /--
-A function `f : α → (ι → ℝ)` which is `K`-Lipschitz on a subset `s` admits a `K`-Lipschitz
+A function `f : α → ℓ^∞(ι, ℝ)` which is `K`-Lipschitz on a subset `s` admits a `K`-Lipschitz
 extension to the whole space.
 
 Theorem 2.2 of [Assaf Naor, *Metric Embeddings and Lipschitz Extensions*][Naor-2015]

--- a/Mathlib/Topology/MetricSpace/Kuratowski.lean
+++ b/Mathlib/Topology/MetricSpace/Kuratowski.lean
@@ -150,7 +150,7 @@ theorem LipschitzOnWith.extend_lp_infty [PseudoMetricSpace α] {s : Set α} {f :
     exact LipschitzOnWith.extend_real (hfl i) -- use the nonlinear Hahn-Banach theorem here!
   choose g hgl hgeq using this
   rcases s.eq_empty_or_nonempty with rfl | ⟨a₀, ha₀_in_s⟩
-  . exact ⟨fun _ ↦ 0, LipschitzWith.const' 0, by simp⟩
+  . exact ⟨0, LipschitzWith.const' 0, by simp⟩
   · -- Show that the extensions are uniformly bounded
     have hf_extb : ∀ a : α, Memℓp (swap g a) ∞
     . apply LipschitzWith.uniformly_bounded (swap g) hgl a₀

--- a/Mathlib/Topology/MetricSpace/Kuratowski.lean
+++ b/Mathlib/Topology/MetricSpace/Kuratowski.lean
@@ -119,9 +119,9 @@ def kuratowskiEmbedding (α : Type u) [MetricSpace α] [SeparableSpace α] : α 
 #align Kuratowski_embedding kuratowskiEmbedding
 
 /--
-    The Kuratowski embedding is an isometry.
-    Theorem 2.1 of Metric Embeddings and Lipschitz Extensions by Assaf Naor
-    https://web.math.princeton.edu/~naor/homepage%20files/embeddings_extensions.pdf
+The Kuratowski embedding is an isometry.
+Theorem 2.1 of Metric Embeddings and Lipschitz Extensions by Assaf Naor
+https://web.math.princeton.edu/~naor/homepage%20files/embeddings_extensions.pdf
  -/
 protected theorem kuratowskiEmbedding.isometry (α : Type u) [MetricSpace α] [SeparableSpace α] :
     Isometry (kuratowskiEmbedding α) :=
@@ -137,14 +137,14 @@ nonrec def NonemptyCompacts.kuratowskiEmbedding (α : Type u) [MetricSpace α] [
 #align nonempty_compacts.Kuratowski_embedding NonemptyCompacts.kuratowskiEmbedding
 
 /--
-    A function `f : α → (ι → ℝ)` which is `K`-Lipschitz on a subset `s` admits a `K`-Lipschitz
-    extension to the whole space.
+A function `f : α → (ι → ℝ)` which is `K`-Lipschitz on a subset `s` admits a `K`-Lipschitz
+extension to the whole space.
 
-    Theorem 2.2 of Metric Embeddings and Lipschitz Extensions by Assaf Naor
-    https://web.math.princeton.edu/~naor/homepage%20files/embeddings_extensions.pdf
+Theorem 2.2 of Metric Embeddings and Lipschitz Extensions by Assaf Naor
+https://web.math.princeton.edu/~naor/homepage%20files/embeddings_extensions.pdf
 
-    The same result for the case of a finite type `ι` is implemented in
-    `LipschitzOnWith.extend_pi`.
+The same result for the case of a finite type `ι` is implemented in
+`LipschitzOnWith.extend_pi`.
 -/
 theorem LipschitzOnWith.extend_linf [PseudoMetricSpace α] {s : Set α} {f : α → ℓ^∞(ι)}
     {K : ℝ≥0} (hfl : LipschitzOnWith K f s): ∃ g : α → ℓ^∞(ι), LipschitzWith K g ∧ EqOn f g s := by

--- a/Mathlib/Topology/MetricSpace/Kuratowski.lean
+++ b/Mathlib/Topology/MetricSpace/Kuratowski.lean
@@ -120,9 +120,7 @@ def kuratowskiEmbedding (α : Type u) [MetricSpace α] [SeparableSpace α] : α 
 
 /--
 The Kuratowski embedding is an isometry.
-Theorem 2.1 of Metric Embeddings and Lipschitz Extensions by Assaf Naor
-https://web.math.princeton.edu/~naor/homepage%20files/embeddings_extensions.pdf
- -/
+Theorem 2.1 of [Assaf Naor, *Metric Embeddings and Lipschitz Extensions*][Naor-2015]. -/
 protected theorem kuratowskiEmbedding.isometry (α : Type u) [MetricSpace α] [SeparableSpace α] :
     Isometry (kuratowskiEmbedding α) :=
   Classical.choose_spec (exists_isometric_embedding α)
@@ -140,8 +138,7 @@ nonrec def NonemptyCompacts.kuratowskiEmbedding (α : Type u) [MetricSpace α] [
 A function `f : α → (ι → ℝ)` which is `K`-Lipschitz on a subset `s` admits a `K`-Lipschitz
 extension to the whole space.
 
-Theorem 2.2 of Metric Embeddings and Lipschitz Extensions by Assaf Naor
-https://web.math.princeton.edu/~naor/homepage%20files/embeddings_extensions.pdf
+Theorem 2.2 of [Assaf Naor, *Metric Embeddings and Lipschitz Extensions*][Naor-2015]
 
 The same result for the case of a finite type `ι` is implemented in
 `LipschitzOnWith.extend_pi`.

--- a/Mathlib/Topology/MetricSpace/Kuratowski.lean
+++ b/Mathlib/Topology/MetricSpace/Kuratowski.lean
@@ -24,9 +24,7 @@ noncomputable section
 
 set_option linter.uppercaseLean3 false
 
-open Set Metric TopologicalSpace NNReal ENNReal
-
-local notation "ℓ^∞(" ι ") " => lp (fun i : ι => ℝ ) ∞
+open Set Metric TopologicalSpace NNReal ENNReal lp
 
 universe u v w
 

--- a/Mathlib/Topology/MetricSpace/Lipschitz.lean
+++ b/Mathlib/Topology/MetricSpace/Lipschitz.lean
@@ -672,9 +672,8 @@ theorem LipschitzOnWith.extend_real [PseudoMetricSpace α] {f : α → ℝ} {s :
 #align lipschitz_on_with.extend_real LipschitzOnWith.extend_real
 
 /-- A function `f : α → (ι → ℝ)` which is `K`-Lipschitz on a subset `s` admits a `K`-Lipschitz
-extension to the whole space.
-The same result (with the same proof) for the space `ℓ^∞ (ι, ℝ)` over a possibly
-infinite type `ι` is implemented in `LipschitzOnWith.extend_linf`. -/
+extension to the whole space. The same result for the space `ℓ^∞ (ι, ℝ)` over a possibly infinite
+type `ι` is implemented in `LipschitzOnWith.extend_lp_infty`.-/
 theorem LipschitzOnWith.extend_pi [PseudoMetricSpace α] [Fintype ι] {f : α → ι → ℝ} {s : Set α}
     {K : ℝ≥0} (hf : LipschitzOnWith K f s) : ∃ g : α → ι → ℝ, LipschitzWith K g ∧ EqOn f g s := by
   have : ∀ i, ∃ g : α → ℝ, LipschitzWith K g ∧ EqOn (fun x => f x i) g s := fun i => by

--- a/Mathlib/Topology/MetricSpace/Lipschitz.lean
+++ b/Mathlib/Topology/MetricSpace/Lipschitz.lean
@@ -200,6 +200,9 @@ protected theorem const (b : β) : LipschitzWith 0 fun _ : α => b := fun x y =>
   simp only [edist_self, zero_le]
 #align lipschitz_with.const LipschitzWith.const
 
+protected theorem const' (b : β) {K : ℝ≥0} : LipschitzWith K fun _ : α => b := fun x y => by
+  simp only [edist_self, zero_le]
+
 protected theorem id : LipschitzWith 1 (@id α) :=
   LipschitzWith.of_edist_le fun _ _ => le_rfl
 #align lipschitz_with.id LipschitzWith.id

--- a/Mathlib/Topology/MetricSpace/Lipschitz.lean
+++ b/Mathlib/Topology/MetricSpace/Lipschitz.lean
@@ -673,8 +673,8 @@ theorem LipschitzOnWith.extend_real [PseudoMetricSpace α] {f : α → ℝ} {s :
 
 /-- A function `f : α → (ι → ℝ)` which is `K`-Lipschitz on a subset `s` admits a `K`-Lipschitz
 extension to the whole space.
-TODO: state the same result (with the same proof) for the space `ℓ^∞ (ι, ℝ)` over a possibly
-infinite type `ι`. -/
+The same result (with the same proof) for the space `ℓ^∞ (ι, ℝ)` over a possibly
+infinite type `ι` is implemented in `LipschitzOnWith.extend_linf`. -/
 theorem LipschitzOnWith.extend_pi [PseudoMetricSpace α] [Fintype ι] {f : α → ι → ℝ} {s : Set α}
     {K : ℝ≥0} (hf : LipschitzOnWith K f s) : ∃ g : α → ι → ℝ, LipschitzWith K g ∧ EqOn f g s := by
   have : ∀ i, ∃ g : α → ℝ, LipschitzWith K g ∧ EqOn (fun x => f x i) g s := fun i => by

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -1832,6 +1832,13 @@
   url           = {https://doi.org/10.1007/BF00417500}
 }
 
+@unpublished{Naor-2015,
+  author = {Assaf Naor},
+  title  = {Metric Embeddings and Lipschitz Extensions},
+  year   = {2015},
+  url    = {https://web.math.princeton.edu/~naor/homepage%20files/embeddings_extensions.pdf}
+}
+
 @Article{         Nash-Williams63,
   title         = {On well-quasi-ordering finite trees},
   volume        = {59},

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -1832,11 +1832,11 @@
   url           = {https://doi.org/10.1007/BF00417500}
 }
 
-@unpublished{Naor-2015,
-  author = {Assaf Naor},
-  title  = {Metric Embeddings and Lipschitz Extensions},
-  year   = {2015},
-  url    = {https://web.math.princeton.edu/~naor/homepage%20files/embeddings_extensions.pdf}
+@Unpublished{     Naor-2015,
+  author        = {Assaf Naor},
+  title         = {Metric Embeddings and Lipschitz Extensions},
+  year          = {2015},
+  url           = {https://web.math.princeton.edu/~naor/homepage%20files/embeddings_extensions.pdf}
 }
 
 @Article{         Nash-Williams63,


### PR DESCRIPTION
A function `f : α → ℓ^∞(ι, ℝ)` which is `K`-Lipschitz on a subset `s` admits a `K`-Lipschitz extension to the whole space.

Co-authored-by: Ian Bunner <31334766+ian-bunner@users.noreply.github.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
