### PR TITLE
[Merged by Bors] - doc: add link to mathlib4 docs in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 This is the work in progress port of [mathlib](https://github.com/leanprover-community/mathlib) to [Lean 4](https://leanprover.github.io/).
 
+## Documentation
+The [mathlib4 docs](https://leanprover-community.github.io/mathlib4_docs/index.html) are
+[generated automatically](https://github.com/leanprover/doc-gen4) from the source `.lean` files.
+
 ## Contributing
 A guide on how to port a file from mathlib3 to mathlib4 can be found in the [wiki](https://github.com/leanprover-community/mathlib4/wiki/Porting-wiki).
 The porting effort is coordinated through [zulip](https://leanprover.zulipchat.com/),


### PR DESCRIPTION
My current method for accessing the mathlib4 docs is:
  1. google for "mathlib docs"
  2. insert a "4" into the url
  
The [mathlib3 readme](https://github.com/leanprover-community/mathlib/blob/893964fc28cefbcffc7cb784ed00a2895b4e65cf/README.md) has a prominent link to the mathlib3 docs. We should have something similar for mathlib4.

Hopefully this will help google find the mathlib4 docs, too.
