### PR TITLE
[Merged by Bors] - chore: resolve a porting note in Profinite/CofilteredLimit

### DIFF
--- a/Mathlib/Topology/Category/Profinite/CofilteredLimit.lean
+++ b/Mathlib/Topology/Category/Profinite/CofilteredLimit.lean
@@ -52,22 +52,18 @@ theorem exists_clopen_of_cofiltered {U : Set C.pt} (hC : IsLimit C) (hU : IsClop
     ∃ (j : J) (V : Set (F.obj j)) (_ : IsClopen V), U = C.π.app j ⁻¹' V := by
   -- First, we have the topological basis of the cofiltered limit obtained by pulling back
   -- clopen sets from the factors in the limit. By continuity, all such sets are again clopen.
-  have hT : ∀ (j : J), TopologicalSpace.IsTopologicalBasis
-      ((fun j ↦ {W : Set (F.obj j)| IsClopen W}) j)
+  have hB := TopCat.isTopologicalBasis_cofiltered_limit.{u, u} (F ⋙ Profinite.toTopCat)
+      (Profinite.toTopCat.mapCone C) (isLimitOfPreserves _ hC) (fun j => {W | IsClopen W}) ?_
+      (fun i => isClopen_univ) (fun i U1 U2 hU1 hU2 => hU1.inter hU2) ?_
+  swap
   · intro i
     change TopologicalSpace.IsTopologicalBasis {W : Set (F.obj i) | IsClopen W}
     apply isTopologicalBasis_clopen
-  have compat : ∀ (i j : J) (f : i ⟶ j) (V : Set ↑((F ⋙ toTopCat).obj j)),
-      V ∈ (fun j ↦ {W | IsClopen W}) j → (forget TopCat).map ((F ⋙ toTopCat).map f) ⁻¹' V ∈
-      (fun j ↦ {W | IsClopen W}) i
+  swap
   · rintro i j f V (hV : IsClopen _)
     exact ⟨hV.1.preimage ((F ⋙ toTopCat).map f).continuous,
       hV.2.preimage ((F ⋙ toTopCat).map f).continuous⟩
     -- Porting note: `<;> continuity` fails
-  have hB := TopCat.isTopologicalBasis_cofiltered_limit.{u, u} (F ⋙ Profinite.toTopCat)
-      (Profinite.toTopCat.mapCone C) (isLimitOfPreserves _ hC) (fun j => {W | IsClopen W}) hT
-      (fun i => isClopen_univ) (fun i U1 U2 hU1 hU2 => hU1.inter hU2) compat
-  -- Porting note: before, `hT` and `compat` were blank and created new goals proved afterwards.
   -- Using this, since `U` is open, we can write `U` as a union of clopen sets all of which
   -- are preimages of clopens from the factors in the limit.
   obtain ⟨S, hS, h⟩ := hB.open_eq_sUnion hU.1

--- a/Mathlib/Topology/Category/Profinite/CofilteredLimit.lean
+++ b/Mathlib/Topology/Category/Profinite/CofilteredLimit.lean
@@ -55,11 +55,10 @@ theorem exists_clopen_of_cofiltered {U : Set C.pt} (hC : IsLimit C) (hU : IsClop
   have hB := TopCat.isTopologicalBasis_cofiltered_limit.{u, u} (F ⋙ Profinite.toTopCat)
       (Profinite.toTopCat.mapCone C) (isLimitOfPreserves _ hC) (fun j => {W | IsClopen W}) ?_
       (fun i => isClopen_univ) (fun i U1 U2 hU1 hU2 => hU1.inter hU2) ?_
-  swap
+  rotate_left
   · intro i
     change TopologicalSpace.IsTopologicalBasis {W : Set (F.obj i) | IsClopen W}
     apply isTopologicalBasis_clopen
-  swap
   · rintro i j f V (hV : IsClopen _)
     exact ⟨hV.1.preimage ((F ⋙ toTopCat).map f).continuous,
       hV.2.preimage ((F ⋙ toTopCat).map f).continuous⟩


### PR DESCRIPTION
To create new goals from `have` you need to use `?_`, rather than `_`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
