### PR TITLE
[Merged by Bors] - feat: add two basic lemmas about `selfAdjoint` elements

### DIFF
--- a/Mathlib/Algebra/Star/SelfAdjoint.lean
+++ b/Mathlib/Algebra/Star/SelfAdjoint.lean
@@ -100,6 +100,12 @@ theorem starHom_apply {F R S : Type _} [Star R] [Star S] [StarHomClass F R S] {x
   show star (f x) = f x from map_star f x ▸ congr_arg f hx
 #align is_self_adjoint.star_hom_apply IsSelfAdjoint.starHom_apply
 
+/- note: this lemma is *not* marked as `simp` so that Lean doesn't look for a `[TrivialStar R]`
+instance every time it sees `⊢ IsSelfAdjoint (f x)`, which will likely occur relatively often. -/
+theorem _root_.isSelfAdjoint_starHom_apply {F R S : Type _} [Star R] [Star S] [StarHomClass F R S]
+    [TrivialStar R] (f : F) (x : R) : IsSelfAdjoint (f x) :=
+  (IsSelfAdjoint.all x).starHom_apply f
+
 section AddMonoid
 
 variable [AddMonoid R] [StarAddMonoid R]
@@ -313,6 +319,10 @@ instance : Inhabited (selfAdjoint R) :=
   ⟨0⟩
 
 end AddGroup
+
+instance isStarNormal [NonUnitalRing R] [StarRing R] (x : selfAdjoint R) :
+    IsStarNormal (x : R) :=
+  x.prop.isStarNormal
 
 section Ring
 


### PR DESCRIPTION
- `selfAdjoint` elements are automatically normal
- the image of an element under a star-preserving map in a space with a `TrivialStar` is self-adjoint

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
