### PR TITLE
[Merged by Bors] - chore: cleanup CategoryTheory.Pi.Basic

### DIFF
--- a/Mathlib/CategoryTheory/Pi/Basic.lean
+++ b/Mathlib/CategoryTheory/Pi/Basic.lean
@@ -57,6 +57,11 @@ theorem comp_apply {X Y Z : ∀ i, C i} (f : X ⟶ Y) (g : Y ⟶ Z) (i) :
   rfl
 #align category_theory.pi.comp_apply CategoryTheory.Pi.comp_apply
 
+-- Porting note: need to add an additional `ext` lemma.
+@[ext]
+lemma ext {X Y : ∀ i, C i} {f g : X ⟶ Y} (w : ∀ i, f i = g i) : f = g :=
+  funext (w ·)
+
 /--
 The evaluation functor at `i : I`, sending an `I`-indexed family of objects to the object over `i`.
 -/
@@ -80,7 +85,7 @@ instance (f : J → I) : (j : J) → Category ((C ∘ f) j) := by
 /-- Pull back an `I`-indexed family of objects to a `J`-indexed family, along a function `J → I`.
 -/
 @[simps]
-def comap (h : J → I) : (∀ i, C i) ⥤  (∀ j, C (h j)) where
+def comap (h : J → I) : (∀ i, C i) ⥤ (∀ j, C (h j)) where
   obj f i := f (h i)
   map α i := α (h i)
 #align category_theory.pi.comap CategoryTheory.Pi.comap
@@ -92,7 +97,7 @@ pulling back a grading along the identity function,
 and the identity functor. -/
 @[simps]
 def comapId : comap C (id : I → I) ≅ 𝟭 (∀ i, C i) where
-  hom := { app := fun X => 𝟙 X, naturality := by simp only [comap]; aesop_cat }
+  hom := { app := fun X => 𝟙 X }
   inv := { app := fun X => 𝟙 X }
 #align category_theory.pi.comap_id CategoryTheory.Pi.comapId
 
@@ -114,14 +119,6 @@ def comapComp (f : K → J) (g : J → I) : comap C g ⋙ comap (C ∘ g) f ≅ 
   inv :=
   { app := fun X b => 𝟙 (X (g (f b)))
     naturality := fun X Y f' => by simp only [comap, Function.comp]; funext; simp }
-  hom_inv_id := by
-    simp only [comap]
-    ext Y
-    simp [CategoryStruct.comp,CategoryStruct.id]
-  inv_hom_id := by
-    simp only [comap]
-    ext X
-    simp [CategoryStruct.comp,CategoryStruct.id]
 #align category_theory.pi.comap_comp CategoryTheory.Pi.comapComp
 
 /-- The natural isomorphism between pulling back then evaluating, and just evaluating. -/
@@ -162,25 +159,12 @@ def sum : (∀ i, C i) ⥤ (∀ j, D j) ⥤ ∀ s : Sum I J, Sum.elim C D s wher
       map := fun {Y} {Y'} f s =>
         match s with
         | .inl i => 𝟙 (X i)
-        | .inr j => f j
-      map_id := fun Y => by
-          dsimp
-          simp only [CategoryStruct.id]
-          funext s
-          match s with
-          | .inl i => simp
-          | .inr j => simp
-      map_comp := fun {Y₁} {Y₂} {Y₃} f g => by funext s; cases s; repeat {simp} }
+        | .inr j => f j }
   map {X} {X'} f :=
     { app := fun Y s =>
         match s with
         | .inl i => f i
-        | .inr j => 𝟙 (Y j)
-      naturality := fun {Y} {Y'} g => by funext s; cases s; repeat {simp} }
-  map_id := fun X => by
-    ext Y; dsimp; simp only [CategoryStruct.id]; funext s; cases s; repeat {simp}
-  map_comp := fun f g => by
-    ext Y; dsimp; simp only [CategoryStruct.comp]; funext s; cases s; repeat {simp}
+        | .inr j => 𝟙 (Y j) }
 #align category_theory.pi.sum CategoryTheory.Pi.sum
 
 end
@@ -292,7 +276,6 @@ variable {F G : ∀ i, C i ⥤ D i}
 @[simps!]
 def pi (α : ∀ i, F i ⟶ G i) : Functor.pi F ⟶ Functor.pi G where
   app f i := (α i).app (f i)
-  naturality := fun X Y f => by simp [Functor.pi,CategoryStruct.comp]
 #align category_theory.nat_trans.pi CategoryTheory.NatTrans.pi
 
 end NatTrans


### PR DESCRIPTION
While experimenting with making `ext` more powerful a proof was failing here. Rather than fix it, it seemed easier to just remove it.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
