### PR TITLE
[Merged by Bors] - fix(Mathlib.Tactic.IntervalCases, test.interval_cases): `interval_cases` can't be used for global variables

### DIFF
--- a/Mathlib/Tactic/IntervalCases.lean
+++ b/Mathlib/Tactic/IntervalCases.lean
@@ -382,12 +382,12 @@ elab_rules : tactic
         let (lo, _) ← parseBound ubTy
         let .true ← isDefEq e lo | failure
       catch _ => throwErrorAt ub "expected a term of the form {e} < _ or {e} ≤ _, got {ubTy}"
-      let (subst, xs, g) ← g.generalizeHyp #[{ expr := e, hName? }] (← getLCtx).getFVarIds
+      let (subst, xs, g) ← g.generalizeHyp #[{ expr := e, hName? }] (← getFVarIdsAt g)
       g.withContext do
       cont xs[0]! xs[1]? subst g e #[subst.apply lb'] #[subst.apply ub'] (mustUseBounds := true)
     | some e, none, none =>
       let e ← Tactic.elabTerm e none
-      let (subst, xs, g) ← g.generalizeHyp #[{ expr := e, hName? }] (← getLCtx).getFVarIds
+      let (subst, xs, g) ← g.generalizeHyp #[{ expr := e, hName? }] (← getFVarIdsAt g)
       let x := xs[0]!
       g.withContext do
       let e := subst.apply e

--- a/test/interval_cases.lean
+++ b/test/interval_cases.lean
@@ -162,3 +162,13 @@ In Lean 3 this one didn't work! It reported:
 example (n : ℕ) (w₁ : n > 1000000) (w₁ : n < 1000002) : n < 2000000 := by
   interval_cases n
   norm_num
+
+section
+
+variable (d : ℕ)
+
+example (h : d ≤ 0) : d = 0 := by
+  interval_cases d
+  rfl
+
+end


### PR DESCRIPTION
```lean
variable (d : ℕ)

example (h : d ≤ 0) : d = 0 := by
  interval_cases d
  rfl
```
This fails.
This PR fixes this bug.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
