### PR TITLE
[Merged by Bors] - fix: move up a `.withContext` in `rel`

### DIFF
--- a/Mathlib/Tactic/GCongr/Core.lean
+++ b/Mathlib/Tactic/GCongr/Core.lean
@@ -488,10 +488,10 @@ be discharged in this way, the tactic fails. -/
 syntax "rel" " [" term,* "]" : tactic
 
 elab_rules : tactic
-  | `(tactic| rel [$hyps,*]) => withMainContext do
-    let hyps ← hyps.getElems.mapM (elabTerm · none)
+  | `(tactic| rel [$hyps,*]) => do
     let g ← getMainGoal
     g.withContext do
+    let hyps ← hyps.getElems.mapM (elabTerm · none)
     let .app (.app _rel lhs) rhs ← withReducible g.getType'
       | throwError "rel failed, goal not a relation"
     unless ← isDefEq (← inferType lhs) (← inferType rhs) do

--- a/Mathlib/Tactic/GCongr/Core.lean
+++ b/Mathlib/Tactic/GCongr/Core.lean
@@ -488,7 +488,7 @@ be discharged in this way, the tactic fails. -/
 syntax "rel" " [" term,* "]" : tactic
 
 elab_rules : tactic
-  | `(tactic| rel [$hyps,*]) => do
+  | `(tactic| rel [$hyps,*]) => withMainContext do
     let hyps ← hyps.getElems.mapM (elabTerm · none)
     let g ← getMainGoal
     g.withContext do

--- a/test/GCongr/inequalities.lean
+++ b/test/GCongr/inequalities.lean
@@ -107,6 +107,13 @@ example {a b x c d : ℝ} (h1 : a ≤ b) (h2 : c ≤ d) (h3 : 1 ≤ x + 1) : x *
   have : 0 ≤ x := by linarith
   rel [h1, h2]
 
+-- test for a missing `withMainContext`
+example {x y : ℚ} {n : ℕ} (hx : 0 ≤ x) (hn : 0 < n) : y ≤ x := by
+  have h : x < y := sorry
+  have : x ^ n < y ^ n
+  · rel [h] -- before bugfix: complained "unknown identifier 'h'"
+  sorry
+
 /-! ## Non-finishing examples -/
 
 example {a b x c d : ℝ} (h1 : a + 1 ≤ b + 1) (h2 : c + 2 ≤ d + 2) :

--- a/test/GCongr/inequalities.lean
+++ b/test/GCongr/inequalities.lean
@@ -107,7 +107,7 @@ example {a b x c d : ℝ} (h1 : a ≤ b) (h2 : c ≤ d) (h3 : 1 ≤ x + 1) : x *
   have : 0 ≤ x := by linarith
   rel [h1, h2]
 
--- test for a missing `withMainContext`
+-- test for a missing `withContext`
 example {x y : ℚ} {n : ℕ} (hx : 0 ≤ x) (hn : 0 < n) : y ≤ x := by
   have h : x < y := sorry
   have : x ^ n < y ^ n


### PR DESCRIPTION
One of the steps of `rel` was taking place outside the `.withContext`, causing problems -- see the newly added test for a sample bug.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
