### PR TITLE
[Merged by Bors] - feat: functions eventually constant along filters

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2351,6 +2351,7 @@ import Mathlib.Order.Filter.Cofinite
 import Mathlib.Order.Filter.CountableInter
 import Mathlib.Order.Filter.Curry
 import Mathlib.Order.Filter.ENNReal
+import Mathlib.Order.Filter.EventuallyConst
 import Mathlib.Order.Filter.Extr
 import Mathlib.Order.Filter.FilterProduct
 import Mathlib.Order.Filter.Germ

--- a/Mathlib/Logic/Basic.lean
+++ b/Mathlib/Logic/Basic.lean
@@ -871,6 +871,13 @@ theorem Exists.snd {b : Prop} {p : b → Prop} : ∀ h : Exists p, p h.fst
   | ⟨_, h⟩ => h
 #align Exists.snd Exists.snd
 
+theorem Prop.exists_iff {p : Prop → Prop} : (∃ h, p h) ↔ p False ∨ p True :=
+  ⟨fun ⟨h₁, h₂⟩ ↦ by_cases (fun H : h₁ ↦ .inr <| by simpa only [H] using h₂)
+    (fun H ↦ .inl <| by simpa only [H] using h₂), fun h ↦ h.elim (.intro _) (.intro _)⟩
+
+theorem Prop.forall_iff {p : Prop → Prop} : (∀ h, p h) ↔ p False ∧ p True :=
+  ⟨fun H ↦ ⟨H _, H _⟩, fun ⟨h₁, h₂⟩ h ↦ by by_cases H : h <;> simpa only [H]⟩
+
 theorem exists_prop_of_true {p : Prop} {q : p → Prop} (h : p) : (∃ h' : p, q h') ↔ q h :=
   @exists_const (q h) p ⟨h⟩
 #align exists_prop_of_true exists_prop_of_true

--- a/Mathlib/Order/Filter/EventuallyConst.lean
+++ b/Mathlib/Order/Filter/EventuallyConst.lean
@@ -4,6 +4,13 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov, Floris van Doorn
 -/
 import Mathlib.Order.Filter.AtTopBot
+/-!
+# Functions that are eventually constant along a filter
+
+In this file we define a predicate `Filter.EventuallyConst f l` saying that a function `f : α → β`
+is eventually equal to a constant along a filter `l`. We also prove some basic properties of these
+functions.
+-/
 
 open Set
 
@@ -22,17 +29,34 @@ alias eventuallyConst_iff_tendsto ↔ EventuallyConst.exists_tendsto _
 
 namespace EventuallyConst
 
+@[simp] protected lemma bot [Nonempty β] : EventuallyConst f ⊥ := by
+  simp [EventuallyConst, EventuallyEq]
+
 protected lemma nonempty (h : EventuallyConst f l) : Nonempty β := nonempty_of_exists h
 
 protected lemma const (c : β) : EventuallyConst (fun _ ↦ c) l :=
   ⟨c, eventually_of_forall fun _ ↦ rfl⟩
 
+@[nontriviality]
 lemma of_unique [Unique β] : EventuallyConst f l :=
   ⟨default, eventually_of_forall fun _ ↦ Unique.uniq _ _⟩
+
+lemma mono (h : EventuallyConst f l) (hl' : l' ≤ l) : EventuallyConst f l' :=
+  h.imp fun _c hc ↦ hl' hc
+
+@[nontriviality]
+lemma of_subsingleton [Subsingleton α] [Nonempty β] : EventuallyConst f l := by
+  rcases isEmpty_or_nonempty α with h | h
+  · simp only [l.filter_eq_bot_of_isEmpty, EventuallyConst.bot]
+  · inhabit α
+    refine ⟨f default, eventually_of_forall fun x ↦ congr_arg f <| Subsingleton.elim _ _⟩
 
 lemma comp (h : EventuallyConst f l) (g : β → γ) : EventuallyConst (g ∘ f) l :=
   let ⟨c, hc⟩ := h
   ⟨g c, hc.fun_comp g⟩
+
+@[to_additive]
+protected lemma inv [Inv β] (h : EventuallyConst f l) : EventuallyConst (f⁻¹) l := h.comp Inv.inv
 
 lemma comp_tendsto {lb : Filter β} {g : β → γ} (hg : EventuallyConst g lb)
     (hf : Tendsto f l lb) : EventuallyConst (g ∘ f) l :=
@@ -42,87 +66,51 @@ lemma apply {ι : Type _} {p : ι → Type _} {g : α → ∀ x, p x}
     (h : EventuallyConst g l) (i : ι) : EventuallyConst (g · i) l :=
   h.comp <| Function.eval i
 
+lemma comp₂ {g : α → γ} (hf : EventuallyConst f l) (op : β → γ → δ) (hg : EventuallyConst g l) :
+    EventuallyConst (fun x ↦ op (f x) (g x)) l :=
+  let ⟨cf, hf⟩ := hf; let ⟨cg, hg⟩ := hg; ⟨op cf cg, hg.mp <| hf.mono fun _ ↦ congr_arg₂ op⟩
+
+lemma prod_mk {g : α → γ} (hf : EventuallyConst f l) (hg : EventuallyConst g l) :
+    EventuallyConst (fun x ↦ (f x, g x)) l :=
+  hf.comp₂ Prod.mk hg
+
+@[to_additive]
+lemma mul [Mul β] {g : α → β} (hf : EventuallyConst f l) (hg : EventuallyConst g l) :
+    EventuallyConst (f * g) l :=
+  hf.comp₂ (· * ·) hg
+
 end EventuallyConst
 
+theorem eventuallyConst_pred' {p : α → Prop} :
+    EventuallyConst p l ↔ (p =ᶠ[l] fun _ ↦ False) ∨ (p =ᶠ[l] fun _ ↦ True) := by
+  simp only [EventuallyConst, Prop.exists_iff]
+
 theorem eventuallyConst_pred {p : α → Prop} :
-    EventuallyConst p l ↔ (p =ᶠ[l] fun _ ↦ false) ∨ (p =ᶠ[l] fun _ ↦ true) := by
-  simp only [EventuallyConst]
+    EventuallyConst p l ↔ (∀ᶠ x in l, p x) ∨ (∀ᶠ x in l, ¬p x) := by
+  simp [eventuallyConst_pred', or_comm, EventuallyEq]
+
+theorem eventuallyConst_set' {s : Set α} :
+    EventuallyConst s l ↔ (s =ᶠ[l] (∅ : Set α)) ∨ s =ᶠ[l] univ :=
+  eventuallyConst_pred'
 
 theorem eventuallyConst_set {s : Set α} :
-    EventuallyConst s ↔ (s =ᶠ[l] (∅ : Set α)) ∨ s =ᶠ[l] univ
+    EventuallyConst s l ↔ (∀ᶠ x in l, x ∈ s) ∨ (∀ᶠ x in l, x ∉ s) :=
+  eventuallyConst_pred
 
-lemma EventuallyConst_at_top [semilattice_sup α] [nonempty α] :
-  (∃ i, ∀ j, i ≤ j → g j = g i) ↔ EventuallyConst g at_top :=
-begin
-  simp_rw [EventuallyConst, eventually_at_top],
-  split,
-  { rintro ⟨i, hi⟩, refine ⟨g i, i, hi⟩ },
-  { rintro ⟨y, i, hi⟩, use i, simp_rw [hi i le_rfl], exact hi },
-end
+lemma eventuallyConst_atTop [SemilatticeSup α] [Nonempty α] :
+    EventuallyConst f atTop ↔ (∃ i, ∀ j, i ≤ j → f j = f i) := by
+  constructor
+  · rintro ⟨c, hc⟩
+    rcases eventually_atTop.1 hc with ⟨i, hi⟩
+    exact ⟨i, fun j hj ↦ (hi j hj).trans (hi i le_rfl).symm⟩
+  · rintro ⟨i, hi⟩
+    exact ⟨f i, eventually_atTop.2 ⟨i, hi⟩⟩
 
-lemma EventuallyConst_at_top_nat {g : ℕ → α} :
-  (∃ n, ∀ m, n ≤ m → g (m + 1) = g m) ↔ EventuallyConst g at_top :=
-begin
-  rw [← EventuallyConst_at_top],
-  apply exists_congr, intro n,
-  split,
-  { intros h m hm, induction hm with m hm ih, refl, rw [nat.succ_eq_add_one, h m hm, ih] },
-  { intros h m hm, rw [h m hm, h (m + 1) hm.step] }
-end
-
-/-- The eventual value of an eventually-constant function.
-
-For convenience, `eventual_value` may be applied to any function; if the input is not
-eventually-constant the result should be regarded as a "junk" value. -/
-noncomputable def eventual_value [nonempty β] (g : α → β) (f : Filter α) : β :=
-classical.epsilon $ λ x : β, ∀ᶠ i in f, g i = x
-
-lemma eventually_eq_eventual_value (h : EventuallyConst g f) :
-  ∀ᶠ i in f, g i = @eventual_value _ _ h.nonempty g f :=
-classical.epsilon_spec h
-
-lemma eventual_value_unique [f.ne_bot] {y : β} (hy : ∀ᶠ i in f, g i = y) :
-  y = @eventual_value _ _ ⟨y⟩ g f :=
-by { obtain ⟨x, rfl, hx⟩ := (hy.and $ eventually_eq_eventual_value ⟨y, hy⟩).exists, exact hx }
-
-/-- This lemma is sometimes useful if the elaborator uses the nonempty instance in
-  `eventual_value_unique` to find the implicit argument `y`. -/
-lemma eventual_value_unique' [f.ne_bot] {hβ : nonempty β} {y : β} (hy : ∀ᶠ i in f, g i = y) :
-  eventual_value g f = y  :=
-(eventual_value_unique hy).symm
-
-lemma eventual_value_eq_fn {g : ℕ → β} {hβ : nonempty β} {n : ℕ} (h : ∀ m, n ≤ m → g m = g n) :
-  eventual_value g at_top = g n :=
-eventual_value_unique' $ eventually_of_mem (mem_at_top _) h
-
-lemma EventuallyConst.exists_eventual_value_eq [f.ne_bot] (h : EventuallyConst g f) :
-  ∃ i, @eventual_value _ _ h.nonempty g f = g i :=
-begin
-  obtain ⟨y, hy⟩ := h,
-  obtain ⟨x, rfl⟩ := hy.exists,
-  exact ⟨x, (eventual_value_unique hy).symm⟩
-end
-
-lemma EventuallyConst.tendsto [nonempty β] (h : EventuallyConst g f) :
-  tendsto g f (pure (eventual_value g f)) :=
-by { rw [tendsto_pure], exact eventually_eq_eventual_value h }
-
-lemma eventual_value_compose [f.ne_bot] (h : EventuallyConst g f) (g' : β → γ) :
-  @eventual_value _ _ (h.compose g').nonempty (g' ∘ g) f =
-  g' (@eventual_value _ _ h.nonempty g f) :=
-(eventual_value_unique $ (eventually_eq_eventual_value h).mono $ λ x, congr_arg g').symm
-
-lemma eventual_value_apply {ι : Type*} {p : ι → Type*} [f.ne_bot] {g : α → ∀ x, p x}
-  (h : EventuallyConst g f) (i : ι) :
-  @eventual_value _ _ h.nonempty g f i = @eventual_value _ _ (h.apply i).nonempty (λ x, g x i) f :=
-(eventual_value_compose h $ λ p, p i).symm
-
-lemma EventuallyConst.tendsto_nhds [nonempty β] [topological_space β]
-  (h : EventuallyConst g f) : tendsto g f (𝓝 (eventual_value g f)) :=
-h.tendsto.mono_right $ pure_le_nhds _
-
-/-- todo: generalize to `t1_space`. -/
-lemma eventual_value_eq_lim [f.ne_bot] [nonempty β] [topological_space β] [t2_space β]
-  (h : EventuallyConst g f) : eventual_value g f = lim f g :=
-h.tendsto_nhds.lim_eq.symm
-
+lemma eventuallyConst_atTop_nat {f : ℕ → α} :
+    EventuallyConst f atTop ↔ ∃ n, ∀ m, n ≤ m → f (m + 1) = f m := by
+  rw [eventuallyConst_atTop]
+  refine exists_congr fun n ↦ ⟨fun h m hm ↦ ?_, fun h m hm ↦ ?_⟩
+  · exact (h (m + 1) (hm.trans m.le_succ)).trans (h m hm).symm
+  · induction m, hm using Nat.le_induction with
+    | base => rfl
+    | succ m hm ihm => exact (h m hm).trans ihm

--- a/Mathlib/Order/Filter/EventuallyConst.lean
+++ b/Mathlib/Order/Filter/EventuallyConst.lean
@@ -1,0 +1,128 @@
+/-
+Copyright (c) 2023 Yury Kudryashov. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yury Kudryashov, Floris van Doorn
+-/
+import Mathlib.Order.Filter.AtTopBot
+
+open Set
+
+namespace Filter
+
+variable {l : Filter α} {f : α → β}
+
+/-- The proposition that a function is eventually constant along a filter on the domain. -/
+def EventuallyConst (f : α → β) (l : Filter α) : Prop :=
+  ∃ c : β, f =ᶠ[l] fun _ ↦ c
+
+lemma eventuallyConst_iff_tendsto : EventuallyConst f l ↔ ∃ x, Tendsto f l (pure x) := by
+  simp_rw [EventuallyConst, EventuallyEq, tendsto_pure]
+
+alias eventuallyConst_iff_tendsto ↔ EventuallyConst.exists_tendsto _
+
+namespace EventuallyConst
+
+protected lemma nonempty (h : EventuallyConst f l) : Nonempty β := nonempty_of_exists h
+
+protected lemma const (c : β) : EventuallyConst (fun _ ↦ c) l :=
+  ⟨c, eventually_of_forall fun _ ↦ rfl⟩
+
+lemma of_unique [Unique β] : EventuallyConst f l :=
+  ⟨default, eventually_of_forall fun _ ↦ Unique.uniq _ _⟩
+
+lemma comp (h : EventuallyConst f l) (g : β → γ) : EventuallyConst (g ∘ f) l :=
+  let ⟨c, hc⟩ := h
+  ⟨g c, hc.fun_comp g⟩
+
+lemma comp_tendsto {lb : Filter β} {g : β → γ} (hg : EventuallyConst g lb)
+    (hf : Tendsto f l lb) : EventuallyConst (g ∘ f) l :=
+  let ⟨c, hc⟩ := hg; ⟨c, hf hc⟩
+
+lemma apply {ι : Type _} {p : ι → Type _} {g : α → ∀ x, p x}
+    (h : EventuallyConst g l) (i : ι) : EventuallyConst (g · i) l :=
+  h.comp <| Function.eval i
+
+end EventuallyConst
+
+theorem eventuallyConst_pred {p : α → Prop} :
+    EventuallyConst p l ↔ (p =ᶠ[l] fun _ ↦ false) ∨ (p =ᶠ[l] fun _ ↦ true) := by
+  simp only [EventuallyConst]
+
+theorem eventuallyConst_set {s : Set α} :
+    EventuallyConst s ↔ (s =ᶠ[l] (∅ : Set α)) ∨ s =ᶠ[l] univ
+
+lemma EventuallyConst_at_top [semilattice_sup α] [nonempty α] :
+  (∃ i, ∀ j, i ≤ j → g j = g i) ↔ EventuallyConst g at_top :=
+begin
+  simp_rw [EventuallyConst, eventually_at_top],
+  split,
+  { rintro ⟨i, hi⟩, refine ⟨g i, i, hi⟩ },
+  { rintro ⟨y, i, hi⟩, use i, simp_rw [hi i le_rfl], exact hi },
+end
+
+lemma EventuallyConst_at_top_nat {g : ℕ → α} :
+  (∃ n, ∀ m, n ≤ m → g (m + 1) = g m) ↔ EventuallyConst g at_top :=
+begin
+  rw [← EventuallyConst_at_top],
+  apply exists_congr, intro n,
+  split,
+  { intros h m hm, induction hm with m hm ih, refl, rw [nat.succ_eq_add_one, h m hm, ih] },
+  { intros h m hm, rw [h m hm, h (m + 1) hm.step] }
+end
+
+/-- The eventual value of an eventually-constant function.
+
+For convenience, `eventual_value` may be applied to any function; if the input is not
+eventually-constant the result should be regarded as a "junk" value. -/
+noncomputable def eventual_value [nonempty β] (g : α → β) (f : Filter α) : β :=
+classical.epsilon $ λ x : β, ∀ᶠ i in f, g i = x
+
+lemma eventually_eq_eventual_value (h : EventuallyConst g f) :
+  ∀ᶠ i in f, g i = @eventual_value _ _ h.nonempty g f :=
+classical.epsilon_spec h
+
+lemma eventual_value_unique [f.ne_bot] {y : β} (hy : ∀ᶠ i in f, g i = y) :
+  y = @eventual_value _ _ ⟨y⟩ g f :=
+by { obtain ⟨x, rfl, hx⟩ := (hy.and $ eventually_eq_eventual_value ⟨y, hy⟩).exists, exact hx }
+
+/-- This lemma is sometimes useful if the elaborator uses the nonempty instance in
+  `eventual_value_unique` to find the implicit argument `y`. -/
+lemma eventual_value_unique' [f.ne_bot] {hβ : nonempty β} {y : β} (hy : ∀ᶠ i in f, g i = y) :
+  eventual_value g f = y  :=
+(eventual_value_unique hy).symm
+
+lemma eventual_value_eq_fn {g : ℕ → β} {hβ : nonempty β} {n : ℕ} (h : ∀ m, n ≤ m → g m = g n) :
+  eventual_value g at_top = g n :=
+eventual_value_unique' $ eventually_of_mem (mem_at_top _) h
+
+lemma EventuallyConst.exists_eventual_value_eq [f.ne_bot] (h : EventuallyConst g f) :
+  ∃ i, @eventual_value _ _ h.nonempty g f = g i :=
+begin
+  obtain ⟨y, hy⟩ := h,
+  obtain ⟨x, rfl⟩ := hy.exists,
+  exact ⟨x, (eventual_value_unique hy).symm⟩
+end
+
+lemma EventuallyConst.tendsto [nonempty β] (h : EventuallyConst g f) :
+  tendsto g f (pure (eventual_value g f)) :=
+by { rw [tendsto_pure], exact eventually_eq_eventual_value h }
+
+lemma eventual_value_compose [f.ne_bot] (h : EventuallyConst g f) (g' : β → γ) :
+  @eventual_value _ _ (h.compose g').nonempty (g' ∘ g) f =
+  g' (@eventual_value _ _ h.nonempty g f) :=
+(eventual_value_unique $ (eventually_eq_eventual_value h).mono $ λ x, congr_arg g').symm
+
+lemma eventual_value_apply {ι : Type*} {p : ι → Type*} [f.ne_bot] {g : α → ∀ x, p x}
+  (h : EventuallyConst g f) (i : ι) :
+  @eventual_value _ _ h.nonempty g f i = @eventual_value _ _ (h.apply i).nonempty (λ x, g x i) f :=
+(eventual_value_compose h $ λ p, p i).symm
+
+lemma EventuallyConst.tendsto_nhds [nonempty β] [topological_space β]
+  (h : EventuallyConst g f) : tendsto g f (𝓝 (eventual_value g f)) :=
+h.tendsto.mono_right $ pure_le_nhds _
+
+/-- todo: generalize to `t1_space`. -/
+lemma eventual_value_eq_lim [f.ne_bot] [nonempty β] [topological_space β] [t2_space β]
+  (h : EventuallyConst g f) : eventual_value g f = lim f g :=
+h.tendsto_nhds.lim_eq.symm
+


### PR DESCRIPTION
Heavily based on the code from the sphere eversion project.

Co-authored-by: @fpvandoorn

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)