### PR TITLE
[Merged by Bors] - fix(Tactic.PushNeg): `push_neg` makes loose bounded variables

### DIFF
--- a/Mathlib/Tactic/PushNeg.lean
+++ b/Mathlib/Tactic/PushNeg.lean
@@ -84,7 +84,7 @@ def transformNegationStep (e : Expr) : SimpM (Option Simp.Step) := do
       return none
   | _ => match ex with
           | .forallE name ty body binfo => do
-              if (← isProp ty) then
+              if (← isProp ty) && !body.hasLooseBVars then
                 return mkSimpStep (← mkAppM ``And #[ty, mkNot body])
                   (← mkAppM ``not_implies_eq #[ty, body])
               else

--- a/test/push_neg.lean
+++ b/test/push_neg.lean
@@ -141,3 +141,7 @@ example (h : x = 0 ∧ y ≠ 0) : ¬(x = 0 → y = 0) := by
   exact h
 
 end use_distrib
+
+example (a : α) (o : Option α) (h : ¬∀ hs, o.get hs ≠ a) : ∃ hs, o.get hs = a := by
+  push_neg at h
+  exact h


### PR DESCRIPTION
```lean
example (a : α) (o : Option α) (h : ¬∀ hs, o.get hs ≠ a) : ∃ hs, o.get hs = a := by
  push_neg at h
  exact h
```
In this example, h become `o.isSome = true ∧ o.get #0 = a` (`#0` is a loose bounded variable).
This PR fixes this bug.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
