### PR TITLE
chore: replace some rings with ring_nfs

### DIFF
--- a/Mathlib/NumberTheory/Multiplicity.lean
+++ b/Mathlib/NumberTheory/Multiplicity.lean
@@ -105,7 +105,7 @@ theorem odd_sq_dvd_geom_sum₂_sub (hp : Odd p) :
         mk (span {s})
             (∑ x : ℕ in Finset.range p, a ^ (x - 1) * (a ^ (p - 1 - x) * (↑p * (b * ↑x)))) +
           mk (span {s}) (∑ x : ℕ in Finset.range p, a ^ (x + (p - 1 - x))) := by
-      ring
+      ring_nf
       simp only [← pow_add, map_add, Finset.sum_add_distrib, ← map_sum]
       congr
       simp [pow_add a, mul_assoc]
@@ -145,7 +145,7 @@ theorem odd_sq_dvd_geom_sum₂_sub (hp : Odd p) :
       norm_cast
       simp only [Nat.cast_mul, _root_.map_mul,
           Nat.mul_div_assoc p (even_iff_two_dvd.mp (Nat.Odd.sub_odd hp odd_one))]
-      ring
+      ring_nf
       rw [mul_assoc, mul_assoc]
       refine' mul_eq_zero_of_left _ _
       refine' Ideal.Quotient.eq_zero_iff_mem.mpr _

--- a/Mathlib/RingTheory/Polynomial/Hermite/Basic.lean
+++ b/Mathlib/RingTheory/Polynomial/Hermite/Basic.lean
@@ -194,7 +194,7 @@ theorem coeff_hermite_explicit :
       rw [Nat.choose, Nat.choose_succ_right_eq (2 * n + 1 + (k + 1)) (k + 1), Nat.add_sub_cancel,
       Int.negSucc_eq]
       -- porting note: ring could not solve the goal so the lines 195, 198-200 were added.
-      ring
+      ring_nf
       simp only [sub_eq_add_neg, ← neg_mul, ← right_distrib _ _ ((-(1 : ℤ)) ^ n), ← neg_add]
       norm_cast
       simp only [← add_assoc, add_comm]

--- a/Mathlib/Tactic/Ring/RingNF.lean
+++ b/Mathlib/Tactic/Ring/RingNF.lean
@@ -247,9 +247,9 @@ example (x y : ℕ) : x + id y = y + id x := by ring!
 ```
 -/
 macro (name := ring) "ring" : tactic =>
-  `(tactic| first | ring1 | ring_nf; fail "Try this: ring_nf")
+  `(tactic| first | ring1 | ring_nf; trace "Try this: ring_nf")
 @[inherit_doc ring] macro "ring!" : tactic =>
-  `(tactic| first | ring1! | ring_nf!; fail "Try this: ring_nf!")
+  `(tactic| first | ring1! | ring_nf!; trace "Try this: ring_nf!")
 
 /--
 The tactic `ring` evaluates expressions in *commutative* (semi)rings.
@@ -258,6 +258,6 @@ This is the conv tactic version, which rewrites a target which is a ring equalit
 See also the `ring` tactic.
 -/
 macro (name := ringConv) "ring" : conv =>
-  `(conv| first | discharge => ring1 | ring_nf; tactic => fail "Try this: ring_nf")
+  `(conv| first | discharge => ring1 | ring_nf; tactic => trace "Try this: ring_nf")
 @[inherit_doc ringConv] macro "ring!" : conv =>
-  `(conv| first | discharge => ring1! | ring_nf!; tactic => fail "Try this: ring_nf!")
+  `(conv| first | discharge => ring1! | ring_nf!; tactic => trace "Try this: ring_nf!")

--- a/Mathlib/Tactic/Ring/RingNF.lean
+++ b/Mathlib/Tactic/Ring/RingNF.lean
@@ -247,9 +247,9 @@ example (x y : ℕ) : x + id y = y + id x := by ring!
 ```
 -/
 macro (name := ring) "ring" : tactic =>
-  `(tactic| first | ring1 | ring_nf; trace "Try this: ring_nf")
+  `(tactic| first | ring1 | ring_nf; fail "Try this: ring_nf")
 @[inherit_doc ring] macro "ring!" : tactic =>
-  `(tactic| first | ring1! | ring_nf!; trace "Try this: ring_nf!")
+  `(tactic| first | ring1! | ring_nf!; fail "Try this: ring_nf!")
 
 /--
 The tactic `ring` evaluates expressions in *commutative* (semi)rings.
@@ -258,6 +258,6 @@ This is the conv tactic version, which rewrites a target which is a ring equalit
 See also the `ring` tactic.
 -/
 macro (name := ringConv) "ring" : conv =>
-  `(conv| first | discharge => ring1 | ring_nf; tactic => trace "Try this: ring_nf")
+  `(conv| first | discharge => ring1 | ring_nf; tactic => fail "Try this: ring_nf")
 @[inherit_doc ringConv] macro "ring!" : conv =>
-  `(conv| first | discharge => ring1! | ring_nf!; tactic => trace "Try this: ring_nf!")
+  `(conv| first | discharge => ring1! | ring_nf!; tactic => fail "Try this: ring_nf!")


### PR DESCRIPTION
There were some stray calls to `ring`, plaintively emitting their `Try this: ring_nf` instructions, and being ignored.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
