### PR TITLE
[Merged by Bors] - chore: rename fields of AddGroupWithZeroNhd

### DIFF
--- a/Mathlib/Topology/Algebra/Group/Basic.lean
+++ b/Mathlib/Topology/Algebra/Group/Basic.lean
@@ -1394,16 +1394,16 @@ theorem IsOpen.closure_div (ht : IsOpen t) (s : Set α) : closure s / t = s / t 
 
 end TopologicalGroup
 
-/-- additive group with a neighbourhood around 0.
+/-- Additive group with a neighbourhood around 0.
 Only used to construct a topology and uniform space.
 
 This is currently only available for commutative groups, but it can be extended to
 non-commutative groups too.
 -/
 class AddGroupWithZeroNhd (G : Type u) extends AddCommGroup G where
-  z : Filter G
-  zero_z : pure 0 ≤ z
-  sub_z : Tendsto (fun p : G × G => p.1 - p.2) (Z ×ˢ Z) Z
+  zeroNhd : Filter G
+  zero_le : pure 0 ≤ zeroNhd
+  sub_tendsto : Tendsto (fun p : G × G => p.1 - p.2) (zeroNhd ×ˢ zeroNhd) zeroNhd
 #align add_group_with_zero_nhd AddGroupWithZeroNhd
 
 section FilterMul

--- a/Mathlib/Topology/Algebra/Nonarchimedean/Bases.lean
+++ b/Mathlib/Topology/Algebra/Nonarchimedean/Bases.lean
@@ -30,7 +30,7 @@ sub-modules in a commutative algebra. This important example gives rise to the a
 (studied in its own file).
 -/
 
-open Set Filter Function Lattice AddGroupWithZeroNhd
+open Set Filter Function Lattice
 
 open Topology Filter Pointwise
 


### PR DESCRIPTION
This definition was broken because of not noticing auto-implicits.

(Perhaps we might even just delete it: it's not used. Who wrote it?)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
