### PR TITLE
[Merged by Bors] - feat: add `Commute.of_map`

### DIFF
--- a/Mathlib/Algebra/Hom/Commute.lean
+++ b/Mathlib/Algebra/Hom/Commute.lean
@@ -34,4 +34,14 @@ protected theorem Commute.map [MulHomClass F M N] (h : Commute x y) (f : F) : Co
 #align commute.map Commute.map
 #align add_commute.map AddCommute.map
 
+@[to_additive (attr := simp)]
+protected theorem SemiconjBy.of_map [MulHomClass F M N] (f : F) (hf : Function.Injective f)
+    (h : SemiconjBy (f a) (f x) (f y)) : SemiconjBy a x y :=
+  hf (by simpa only [SemiconjBy, map_mul] using h)
+
+@[to_additive (attr := simp)]
+theorem Commute.of_map [MulHomClass F M N] {f : F} (hf : Function.Injective f)
+    (h : Commute (f x) (f y)) : Commute x y :=
+  hf (by simpa only [map_mul] using h.eq)
+
 end Commute


### PR DESCRIPTION
elements commute if their images under and injective `MulHom` do.

---

I thought I needed these for something, but then didn't, so I have just separated them out into a separate PR.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
