### PR TITLE
[Merged by Bors] - chore: remove obsolete comment

### DIFF
--- a/Mathlib/NumberTheory/Padics/PadicNorm.lean
+++ b/Mathlib/NumberTheory/Padics/PadicNorm.lean
@@ -23,10 +23,6 @@ assumptions on `p`.
 The valuation induces a norm on `ℚ`. This norm is a nonarchimedean absolute value.
 It takes values in {0} ∪ {1/p^k | k ∈ ℤ}.
 
-## Notations
-
-This file uses the local notation `/.` for `rat.mk`.
-
 ## Implementation notes
 
 Much, but not all, of this file assumes that `p` is prime. This assumption is inferred automatically


### PR DESCRIPTION
This module-doc is quoted on the webpage as a good example of a module-doc. Seems a good idea to remove the obsolete comment about notation. :-)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
