### PR TITLE
[Merged by Bors] - fix: don't change bornology with `PseudoMetricSpace.replaceUniformity`

### DIFF
--- a/Mathlib/Topology/MetricSpace/Basic.lean
+++ b/Mathlib/Topology/MetricSpace/Basic.lean
@@ -1247,6 +1247,11 @@ theorem PseudoMetricSpace.replaceUniformity_eq {α} [U : UniformSpace α] (m : P
   rfl
 #align pseudo_metric_space.replace_uniformity_eq PseudoMetricSpace.replaceUniformity_eq
 
+-- ensure that the bornology is unchanged when replacing the uniformity.
+example {α} [U : UniformSpace α] (m : PseudoMetricSpace α)
+    (H : 𝓤[U] = 𝓤[PseudoEMetricSpace.toUniformSpace]) :
+  (PseudoMetricSpace.replaceUniformity m H).toBornology = m.toBornology := rfl
+
 /-- Build a new pseudo metric space from an old one where the bundled topological structure is
 provably (but typically non-definitionaly) equal to some given topological structure.
 See Note [forgetful inheritance].
@@ -1315,6 +1320,11 @@ theorem PseudoMetricSpace.replaceBornology_eq {α} [m : PseudoMetricSpace α] [B
   ext
   rfl
 #align pseudo_metric_space.replace_bornology_eq PseudoMetricSpace.replaceBornology_eq
+
+-- ensure that the uniformity is unchanged when replacing the bornology.
+example {α} [B : Bornology α] (m : PseudoMetricSpace α)
+    (H : ∀ s, @IsBounded _ B s ↔ @IsBounded _ PseudoMetricSpace.toBornology s) :
+  (PseudoMetricSpace.replaceBornology m H).toUniformSpace = m.toUniformSpace := rfl
 
 /-- A very useful criterion to show that a space is complete is to show that all sequences
 which satisfy a bound of the form `dist (u n) (u m) < B N` for all `n m ≥ N` are

--- a/Mathlib/Topology/MetricSpace/Basic.lean
+++ b/Mathlib/Topology/MetricSpace/Basic.lean
@@ -1235,15 +1235,10 @@ See Note [forgetful inheritance].
 -/
 @[reducible]
 def PseudoMetricSpace.replaceUniformity {α} [U : UniformSpace α] (m : PseudoMetricSpace α)
-    (H : 𝓤[U] = 𝓤[PseudoEMetricSpace.toUniformSpace]) : PseudoMetricSpace α where
-  toDist := m.toDist
-  dist_self := dist_self
-  dist_comm := dist_comm
-  dist_triangle := dist_triangle
-  edist := edist
-  edist_dist := edist_dist
-  toUniformSpace := U
-  uniformity_dist := H.trans PseudoMetricSpace.uniformity_dist
+    (H : 𝓤[U] = 𝓤[PseudoEMetricSpace.toUniformSpace]) : PseudoMetricSpace α :=
+  { m with
+    toUniformSpace := U
+    uniformity_dist := H.trans PseudoMetricSpace.uniformity_dist }
 #align pseudo_metric_space.replace_uniformity PseudoMetricSpace.replaceUniformity
 
 theorem PseudoMetricSpace.replaceUniformity_eq {α} [U : UniformSpace α] (m : PseudoMetricSpace α)


### PR DESCRIPTION
This fixes `PseudoMetricSpace.replaceUniformity` so that it no longer silently changes the bornology. Before the fix, the following example fails, but afterwards, it succeeds.

```lean
example {α} [U : UniformSpace α] (m : PseudoMetricSpace α)
    (H : 𝓤[U] = 𝓤[PseudoEMetricSpace.toUniformSpace]) :
  (PseudoMetricSpace.replaceUniformity m H).toBornology = m.toBornology := rfl
```

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
