### PR TITLE
[Merged by Bors] - feat: Compare card of subgroup to card of group

### DIFF
--- a/Mathlib/GroupTheory/Subgroup/Finite.lean
+++ b/Mathlib/GroupTheory/Subgroup/Finite.lean
@@ -144,6 +144,13 @@ theorem eq_top_of_card_eq [Fintype H] [Fintype G] (h : Fintype.card H = Fintype.
 #align add_subgroup.eq_top_of_card_eq AddSubgroup.eq_top_of_card_eq
 
 @[to_additive]
+theorem card_eq_iff_eq_top [Fintype H] [Fintype G] : Fintype.card H = Fintype.card G ↔ H = ⊤ := by
+  apply Iff.intro (eq_top_of_card_eq H) _
+  intro h
+  simp_rw [h]
+  exact card_top
+
+@[to_additive]
 theorem eq_top_of_le_card [Fintype H] [Fintype G] (h : Fintype.card G ≤ Fintype.card H) : H = ⊤ :=
   eq_top_of_card_eq H
     (le_antisymm (Fintype.card_le_of_injective Subtype.val Subtype.coe_injective) h)

--- a/Mathlib/GroupTheory/Subgroup/Finite.lean
+++ b/Mathlib/GroupTheory/Subgroup/Finite.lean
@@ -145,7 +145,7 @@ theorem eq_top_of_card_eq [Fintype H] [Fintype G] (h : Fintype.card H = Fintype.
 
 @[to_additive]
 theorem card_eq_iff_eq_top [Fintype H] [Fintype G] : Fintype.card H = Fintype.card G ↔ H = ⊤ := by
-  apply Iff.intro (eq_top_of_card_eq H) _
+  apply Iff.intro (eq_top_of_card_eq H)
   intro h
   simp_rw [h]
   exact card_top

--- a/Mathlib/GroupTheory/Subgroup/Finite.lean
+++ b/Mathlib/GroupTheory/Subgroup/Finite.lean
@@ -186,7 +186,8 @@ theorem one_lt_card_iff_ne_bot [Fintype H] : 1 < Fintype.card H ↔ H ≠ ⊥ :=
 #align add_subgroup.pos_card_iff_ne_bot AddSubgroup.one_lt_card_iff_ne_bot
 
 @[to_additive]
-theorem card_le_card_group [Fintype G] [Fintype H] : Fintype.card H ≤ Fintype.card G := Fintype.card_le_of_injective _ Subtype.coe_injective
+theorem card_le_card_group [Fintype G] [Fintype H] : Fintype.card H ≤ Fintype.card G :=
+  Fintype.card_le_of_injective _ Subtype.coe_injective
 
 end Subgroup
 

--- a/Mathlib/GroupTheory/Subgroup/Finite.lean
+++ b/Mathlib/GroupTheory/Subgroup/Finite.lean
@@ -143,12 +143,9 @@ theorem eq_top_of_card_eq [Fintype H] [Fintype G] (h : Fintype.card H = Fintype.
 #align subgroup.eq_top_of_card_eq Subgroup.eq_top_of_card_eq
 #align add_subgroup.eq_top_of_card_eq AddSubgroup.eq_top_of_card_eq
 
-@[to_additive]
-theorem card_eq_iff_eq_top [Fintype H] [Fintype G] : Fintype.card H = Fintype.card G ↔ H = ⊤ := by
-  apply Iff.intro (eq_top_of_card_eq H)
-  intro h
-  simp_rw [h]
-  exact card_top
+@[to_additive (attr := simp)]
+theorem card_eq_iff_eq_top [Fintype H] [Fintype G] : Fintype.card H = Fintype.card G ↔ H = ⊤ :=
+  Iff.intro (eq_top_of_card_eq H) (fun h ↦ by simpa only [h] using card_top)
 
 @[to_additive]
 theorem eq_top_of_le_card [Fintype H] [Fintype G] (h : Fintype.card G ≤ Fintype.card H) : H = ⊤ :=

--- a/Mathlib/GroupTheory/Subgroup/Finite.lean
+++ b/Mathlib/GroupTheory/Subgroup/Finite.lean
@@ -129,6 +129,11 @@ theorem card_bot {_ : Fintype (⊥ : Subgroup G)} : Fintype.card (⊥ : Subgroup
 #align add_subgroup.card_bot AddSubgroup.card_bot
 
 @[to_additive]
+theorem card_top [Fintype G] : Fintype.card (⊤ : Subgroup G) = Fintype.card G := by
+  rw [Fintype.card_eq]
+  exact Nonempty.intro Subgroup.topEquiv.toEquiv
+
+@[to_additive]
 theorem eq_top_of_card_eq [Fintype H] [Fintype G] (h : Fintype.card H = Fintype.card G) :
     H = ⊤ := by
   letI : Fintype (H : Set G) := ‹Fintype H›
@@ -172,6 +177,9 @@ theorem one_lt_card_iff_ne_bot [Fintype H] : 1 < Fintype.card H ↔ H ≠ ⊥ :=
   lt_iff_not_le.trans H.card_le_one_iff_eq_bot.not
 #align subgroup.one_lt_card_iff_ne_bot Subgroup.one_lt_card_iff_ne_bot
 #align add_subgroup.pos_card_iff_ne_bot AddSubgroup.one_lt_card_iff_ne_bot
+
+@[to_additive]
+theorem card_le_card_group [Fintype G] [Fintype H] : Fintype.card H ≤ Fintype.card G := Fintype.card_le_of_injective _ Subtype.coe_injective
 
 end Subgroup
 


### PR DESCRIPTION
Includes new lemmas, one that shows that the cardinality of a subgroup is at most the cardinality of the ambient group, and others which shows that the cardinality of the top group is equal to that of the ambient group, and that in fact this is iff.

Co-authored-by: Floris van Doorn

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
