### PR TITLE
[Merged by Bors] - fix: use main context in `tfae` tactics

### DIFF
--- a/Mathlib/Tactic/TFAE.lean
+++ b/Mathlib/Tactic/TFAE.lean
@@ -200,21 +200,22 @@ def mkImplType (Pi : Q(Prop)) (arr : TSyntax ``impArrow) (Pj : Q(Prop)) : MetaM 
 elab_rules : tactic
 | `(tactic| tfae_have $[$h:ident : ]? $i:num $arr:impArrow $j:num) => do
   let goal ← getMainGoal
-  let (_, tfaeList) ← getTFAEList (← goal.getType)
-  let l₀ := tfaeList.length
-  let i' ← elabIndex i l₀
-  let j' ← elabIndex j l₀
-  let Pi := tfaeList.get! (i'-1)
-  let Pj := tfaeList.get! (j'-1)
-  let type ← mkImplType Pi arr Pj
-  let (goal1, goal2) ← tfaeHaveCore goal h i j arr type
-  replaceMainGoal [goal1, goal2]
+  goal.withContext do
+    let (_, tfaeList) ← getTFAEList (← goal.getType)
+    let l₀ := tfaeList.length
+    let i' ← elabIndex i l₀
+    let j' ← elabIndex j l₀
+    let Pi := tfaeList.get! (i'-1)
+    let Pj := tfaeList.get! (j'-1)
+    let type ← mkImplType Pi arr Pj
+    let (goal1, goal2) ← tfaeHaveCore goal h i j arr type
+    replaceMainGoal [goal1, goal2]
 
 elab_rules : tactic
 | `(tactic| tfae_finish) => do
   let goal ← getMainGoal
-  let (tfaeListQ, tfaeList) ← getTFAEList (← goal.getType)
   goal.withContext do
+    let (tfaeListQ, tfaeList) ← getTFAEList (← goal.getType)
     closeMainGoal <|← AtomM.run .reducible do
       let is ← tfaeList.mapM AtomM.addAtom
       let mut hyps := #[]

--- a/Mathlib/Tactic/TFAE.lean
+++ b/Mathlib/Tactic/TFAE.lean
@@ -81,7 +81,7 @@ syntax (name := tfaeFinish) "tfae_finish" : tactic
 /-- Extract a list of `Prop` expressions from an expression of the form `TFAE [P₁, P₂, ...]` as
 long as `[P₁, P₂, ...]` is an explicit list. -/
 partial def getTFAEList (t : Expr) : MetaM (Q(List Prop) × List Q(Prop)) := do
-  let .app tfae (l : Q(List Prop)) ← whnfR t
+  let .app tfae (l : Q(List Prop)) ← whnfR <|← instantiateMVars t
     | throwError "goal must be of the form TFAE [P₁, P₂, ...]"
   unless (← withNewMCtxDepth <| isDefEq tfae q(TFAE)) do
     throwError "goal must be of the form TFAE [P₁, P₂, ...]"

--- a/test/tfae.lean
+++ b/test/tfae.lean
@@ -111,6 +111,11 @@ end seven
 
 section context
 
+example (n : ℕ) : List.TFAE [n = 1, n + 1 = 2] := by
+  generalize n = m
+  tfae_have 1 ↔ 2; simp
+  tfae_finish
+
 example (h₁ : P → Q) (h₂ : Q → P) : TFAE [P, Q] := by
   tfae_finish
 


### PR DESCRIPTION
A Qq match in `tfae` was failing due to an absent `withContext`. See [zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Bug.20with.20tfae_have.3F).

Separately, we also add an `instantiateMVars` in the appropriate place while we're at it, just to preempt problems there.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
