### PR TITLE
[Merged by Bors] - fix(Probability/Notation): fix notation for `rnDeriv`

### DIFF
--- a/Mathlib/Probability/Notation.lean
+++ b/Mathlib/Probability/Notation.lean
@@ -10,6 +10,7 @@ Authors: Rémy Degenne
 -/
 import Mathlib.Probability.ProbabilityMassFunction.Basic
 import Mathlib.MeasureTheory.Function.ConditionalExpectation.Basic
+import Mathlib.MeasureTheory.Decomposition.Lebesgue
 
 /-! # Notations for probability theory
 
@@ -52,7 +53,6 @@ scoped[ProbabilityTheory] notation:50 X " =ₐₛ " Y:50 => X =ᵐ[MeasureTheory
 
 scoped[ProbabilityTheory] notation:50 X " ≤ₐₛ " Y:50 => X ≤ᵐ[MeasureTheory.MeasureSpace.volume] Y
 
-set_option quotPrecheck false in
-scoped[ProbabilityTheory] notation "∂" _P "/∂" Q:50 => P.rnDeriv Q
+scoped[ProbabilityTheory] notation "∂" P "/∂" Q:100 => MeasureTheory.Measure.rnDeriv P Q
 
 scoped[ProbabilityTheory] notation "ℙ" => MeasureTheory.MeasureSpace.volume


### PR DESCRIPTION
This PR fixes the `∂P/∂Q` notation for the Radon-Nikodym derivative.

I chose a priority to ensure that `∂P/∂Q = 0` parses correctly, but I didn't extensively investigate this.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
