### PR TITLE
[Merged by Bors] - fix: `wlog`: don't supply let vars to `mkAppN`

### DIFF
--- a/Mathlib/Tactic/WLOG.lean
+++ b/Mathlib/Tactic/WLOG.lean
@@ -100,8 +100,10 @@ def _root_.Lean.MVarId.wlog (goal : MVarId) (h : Option Name) (P : Expr)
   let (⟨easyGoal, hyp⟩, ⟨reductionGoal, negHyp⟩) ←
     reductionGoal.byCases P <| if inaccessible then `_ else h
   easyGoal.withContext do
+    -- Exclude ldecls from the `mkAppN` arguments
+    let HArgFVarIds ← revertedFVars.filterM (notM ·.isLetVar)
     let HApp ← instantiateMVars <|
-      mkAppN (.fvar HFVarId) (revertedFVars.map .fvar) |>.app (.fvar hyp)
+      mkAppN (.fvar HFVarId) (HArgFVarIds.map .fvar) |>.app (.fvar hyp)
     ensureHasNoMVars HApp
     easyGoal.assign HApp
   return ⟨reductionGoal, (HFVarId, negHyp), hGoal, hFVar, revertedFVars⟩

--- a/test/wlog.lean
+++ b/test/wlog.lean
@@ -71,3 +71,10 @@ example {x y : ℕ} : True := by
     guard_hyp h : x ≤ y
     guard_target =ₛ True
     trivial
+
+-- Handle ldecls properly:
+example (x y : ℕ) : True := by
+  let z := 0
+  wlog hxy' : z ≤ y with H
+  · trivial
+  · trivial


### PR DESCRIPTION
`wlog` was erroneously supplying all reverted fvars to `mkAppN`, instead of just supplying the ones which weren't ldecls. This fixes #5348.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
