### PR TITLE
feat: define Bitvec constants for -1, INT_MIN and INT_MAX

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1215,6 +1215,7 @@ import Mathlib.Data.Analysis.Topology
 import Mathlib.Data.Array.Basic
 import Mathlib.Data.Array.Defs
 import Mathlib.Data.BinaryHeap
+import Mathlib.Data.Bitvec.ConstantLemmas
 import Mathlib.Data.Bitvec.Defs
 import Mathlib.Data.Bitvec.Lemmas
 import Mathlib.Data.Bool.AllAny

--- a/Mathlib/Data/Bitvec/ConstantLemmas.lean
+++ b/Mathlib/Data/Bitvec/ConstantLemmas.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2023 Alex Keizer. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Alex Keizer
+-/
 import Mathlib.Data.Bitvec.Defs
 import Mathlib.Data.Bitvec.Lemmas
 
@@ -7,61 +12,30 @@ open Bitvec (zero one not)
 
 
 /-!
-  ### Negation
-  Show how bitwise negation relates various constants
+  ### Bitwise Negation
+  Show how bitwise negation relates the various constants
 -/
-section NegateConstants
+section Not
   @[simp]
-  theorem not_zero : not (negOne n) = zero n := by
-    ext; simp
-
-  @[simp]
-  theorem not_ones : not (zero n) = (negOne n) := by
-    ext; simp
-end NegateConstants
-
-
-
-
-section NegOne
-  private theorem toList_neg_one_aux : ∀ (n : ℕ),
-  (List.mapAccumr (fun y c ↦ (y || c, xor y c))
-    (List.replicate n false ++ [true]) false) =
-    (true, List.replicate (n+1) true)
-  | 0 => rfl
-  | n+1 => by rw [List.replicate_succ, List.cons_append, List.mapAccumr,
-    toList_neg_one_aux n]; simp
-
-
-  theorem neg_one : ∀ {n : ℕ}, (-1: Bitvec n) = Vector.replicate n true
-    | 0 => rfl
-    | n+1 => by
-      show (Bitvec.one (n+1)).neg = Vector.replicate (n+1) true
-      simp [Bitvec.neg, Bitvec.one, Vector.mapAccumr, Vector.replicate,
-        Vector.append, List.cons_append, List.mapAccumr, toList_neg_one_aux n]
-
-
-  theorem toList_neg_one : ∀ {n : ℕ}, (-1 : Bitvec n).toList = List.replicate n true := by
-    simp only [neg_one, Vector.replicate, Vector.toList_mk, forall_const, toList]
-
-  /-- The all-ones bit pattern is also spelled `-1` -/
-  @[simp]
-  theorem neg_one_eq_allOnes : (-1 : Bitvec n) = negOne n :=
-    neg_one
+  theorem not_negOne : not (negOne n) = zero n := by
+    simp[Bitvec.not, negOne, zero]
 
   @[simp]
-  theorem ofInt_neg_one_eq_negOne : (Bitvec.ofInt n (-1)) = negOne n := by
-    simp only [Bitvec.ofInt, Neg.neg, Int.neg, Int.negOfNat, ofNat_zero_eq_zero, not_ones]
+  theorem not_zero : not (zero n) = (negOne n) := by
+    simp[Bitvec.not, negOne, zero]
 
+  @[simp]
+  theorem not_intMax : not (intMax n) = intMin n := by
+    cases n
+    . rfl
+    . simp[Bitvec.not, intMax, intMin, negOne, zero, Vector.map_cons]
 
-end NegOne
-
-
-
-
-
-
-
+  @[simp]
+  theorem not_intMin : not (intMin n) = intMax n := by
+    cases n
+    . rfl
+    . simp[Bitvec.not, intMax, intMin, negOne, zero, Vector.map_cons]
+end Not
 
 
 end Bitvec

--- a/Mathlib/Data/Bitvec/ConstantLemmas.lean
+++ b/Mathlib/Data/Bitvec/ConstantLemmas.lean
@@ -6,6 +6,10 @@ Authors: Alex Keizer
 import Mathlib.Data.Bitvec.Defs
 import Mathlib.Data.Bitvec.Lemmas
 
+/-!
+  Show how bitwise negation interacts with the predefined `Bitvec` constants
+-/
+
 namespace Bitvec
 
 open Bitvec (zero one not)

--- a/Mathlib/Data/Bitvec/ConstantLemmas.lean
+++ b/Mathlib/Data/Bitvec/ConstantLemmas.lean
@@ -1,0 +1,67 @@
+import Mathlib.Data.Bitvec.Defs
+import Mathlib.Data.Bitvec.Lemmas
+
+namespace Bitvec
+
+open Bitvec (zero one not)
+
+
+/-!
+  ### Negation
+  Show how bitwise negation relates various constants
+-/
+section NegateConstants
+  @[simp]
+  theorem not_zero : not (negOne n) = zero n := by
+    ext; simp
+
+  @[simp]
+  theorem not_ones : not (zero n) = (negOne n) := by
+    ext; simp
+end NegateConstants
+
+
+
+
+section NegOne
+  private theorem toList_neg_one_aux : ∀ (n : ℕ),
+  (List.mapAccumr (fun y c ↦ (y || c, xor y c))
+    (List.replicate n false ++ [true]) false) =
+    (true, List.replicate (n+1) true)
+  | 0 => rfl
+  | n+1 => by rw [List.replicate_succ, List.cons_append, List.mapAccumr,
+    toList_neg_one_aux n]; simp
+
+
+  theorem neg_one : ∀ {n : ℕ}, (-1: Bitvec n) = Vector.replicate n true
+    | 0 => rfl
+    | n+1 => by
+      show (Bitvec.one (n+1)).neg = Vector.replicate (n+1) true
+      simp [Bitvec.neg, Bitvec.one, Vector.mapAccumr, Vector.replicate,
+        Vector.append, List.cons_append, List.mapAccumr, toList_neg_one_aux n]
+
+
+  theorem toList_neg_one : ∀ {n : ℕ}, (-1 : Bitvec n).toList = List.replicate n true := by
+    simp only [neg_one, Vector.replicate, Vector.toList_mk, forall_const, toList]
+
+  /-- The all-ones bit pattern is also spelled `-1` -/
+  @[simp]
+  theorem neg_one_eq_allOnes : (-1 : Bitvec n) = negOne n :=
+    neg_one
+
+  @[simp]
+  theorem ofInt_neg_one_eq_negOne : (Bitvec.ofInt n (-1)) = negOne n := by
+    simp only [Bitvec.ofInt, Neg.neg, Int.neg, Int.negOfNat, ofNat_zero_eq_zero, not_ones]
+
+
+end NegOne
+
+
+
+
+
+
+
+
+
+end Bitvec

--- a/Mathlib/Data/Bitvec/Defs.lean
+++ b/Mathlib/Data/Bitvec/Defs.lean
@@ -76,6 +76,13 @@ section Constants
     | 0   => Vector.nil
     | n+1 => true ::ᵥ Bitvec.zero n
 
+
+  /-- Define the all-zero bitpattern as the bottom element of `Bitvec n` -/
+  instance : Bot (Bitvec n) := ⟨Bitvec.zero n⟩
+
+  /-- Define the all-ones bitpattern as the top element of `Bitvec n` -/
+  instance : Top (Bitvec n) := ⟨Bitvec.negOne n⟩
+
 end Constants
 
 

--- a/Mathlib/Data/Bitvec/Defs.lean
+++ b/Mathlib/Data/Bitvec/Defs.lean
@@ -36,18 +36,50 @@ open Vector
 -- mathport name: «expr ++ₜ »
 local infixl:65 "++ₜ" => Vector.append
 
-/-- Create a zero bitvector -/
-@[reducible]
-protected def zero (n : ℕ) : Bitvec n :=
-  replicate n false
-#align bitvec.zero Bitvec.zero
+/-! ### Constant Bitvectors -/
+section Constants
 
-/-- Create a bitvector of length `n` whose `n-1`st entry is 1 and other entries are 0. -/
-@[reducible]
-protected def one : ∀ n : ℕ, Bitvec n
-  | 0 => nil
-  | succ n => replicate n false++ₜtrue ::ᵥ nil
-#align bitvec.one Bitvec.one
+  /-- The bitvector `0000..`, whose entries are all `0`, represents the value `0` -/
+  @[reducible]
+  protected def zero (n : ℕ) : Bitvec n :=
+    replicate n false
+  #align bitvec.zero Bitvec.zero
+
+  /-- The bitvector `1000..`, whose `n-1`st entry is `1` and other entries are `0`, represents the
+      value `1` -/
+  @[reducible]
+  protected def one : ∀ (n : ℕ), Bitvec n
+    | 0 => nil
+    | succ n => replicate n false++ₜtrue ::ᵥ nil
+  #align bitvec.one Bitvec.one
+
+  /-- The bitvector `1111..`, whose entries are all `1`, represents the value `-1` as a signed
+      integer, or `(2^n)-1` as an unsigned integer -/
+  def negOne (n : ℕ) : Bitvec n :=
+    replicate n true
+
+  /--
+  The maximal positive (signed) integer for a given bitwidth has bitpattern `011111..`, representing
+  the value `2^n-1`
+  -/
+  @[reducible]
+  def intMax : ∀ n, Bitvec n
+    | 0   => Vector.nil
+    | n+1 => false ::ᵥ negOne n
+
+  /--
+    The minimal negative integer for a given bitwidth has bitpattern `10000...`, representing
+    `-2^n` as a signed integer, or `2^(n-1)` as an unsigned integer
+   -/
+  @[reducible]
+  def intMin : ∀ n, Bitvec n
+    | 0   => Vector.nil
+    | n+1 => true ::ᵥ Bitvec.zero n
+
+end Constants
+
+
+
 
 /-- Create a bitvector from another with a provably equal length. -/
 protected def cong {a b : ℕ} (h : a = b) : Bitvec a → Bitvec b

--- a/Mathlib/Data/Bitvec/Defs.lean
+++ b/Mathlib/Data/Bitvec/Defs.lean
@@ -134,9 +134,7 @@ instance : Xor (Bitvec n) :=
 
 end Bitwise
 
-/-! ### Arithmetic operators -/
-
-
+/-! ### Addition, Subtraction and Negation -/
 section Arith
 
 variable {n : ℕ}
@@ -189,15 +187,6 @@ instance : Sub (Bitvec n) :=
 instance : Neg (Bitvec n) :=
   ⟨Bitvec.neg⟩
 
-/-- The product of two bitvectors -/
-protected def mul (x y : Bitvec n) : Bitvec n :=
-  let f r b := cond b (r + r + y) (r + r)
-  (toList x).foldl f 0
-#align bitvec.mul Bitvec.mul
-
-instance : Mul (Bitvec n) :=
-  ⟨Bitvec.mul⟩
-
 end Arith
 
 
@@ -219,10 +208,18 @@ section Constants
     | succ n => replicate n false++ₜtrue ::ᵥ nil
   #align bitvec.one Bitvec.one
 
+  instance : Zero (Bitvec n) :=
+    ⟨Bitvec.zero n⟩
+
+  instance : One (Bitvec n) :=
+    ⟨Bitvec.one n⟩
+
+
   /-- The bitvector `1111..`, whose entries are all `1`, represents the value `-1` as a signed
       integer, or `(2^n)-1` as an unsigned integer. This corresponds to the maximal unsigned value
   -/
-  abbrev negOne (n : ℕ) : Bitvec n :=
+  @[reducible, simp]
+  def negOne (n : ℕ) : Bitvec n :=
     -1
 
   /--
@@ -244,12 +241,6 @@ section Constants
     | n+1 => true ::ᵥ Bitvec.zero n
 
 
-  instance : Zero (Bitvec n) :=
-    ⟨Bitvec.zero n⟩
-
-  instance : One (Bitvec n) :=
-    ⟨Bitvec.one n⟩
-
   /-- Define the all-zero bitpattern as the bottom element of `Bitvec n` -/
   instance : Bot (Bitvec n) :=
     ⟨Bitvec.zero n⟩
@@ -259,6 +250,21 @@ section Constants
     ⟨Bitvec.negOne n⟩
 
 end Constants
+
+
+
+/-! ### Multiplication -/
+section Arith
+
+/-- The product of two bitvectors -/
+protected def mul (x y : Bitvec n) : Bitvec n :=
+  let f r b := cond b (r + r + y) (r + r)
+  (toList x).foldl f 0
+#align bitvec.mul Bitvec.mul
+
+instance : Mul (Bitvec n) :=
+  ⟨Bitvec.mul⟩
+end Arith
 
 
 

--- a/Mathlib/Data/Bitvec/Defs.lean
+++ b/Mathlib/Data/Bitvec/Defs.lean
@@ -54,7 +54,8 @@ section Constants
   #align bitvec.one Bitvec.one
 
   /-- The bitvector `1111..`, whose entries are all `1`, represents the value `-1` as a signed
-      integer, or `(2^n)-1` as an unsigned integer -/
+      integer, or `(2^n)-1` as an unsigned integer. This corresponds to the maximal unsigned value
+  -/
   def negOne (n : ℕ) : Bitvec n :=
     replicate n true
 

--- a/Mathlib/Data/Bitvec/Defs.lean
+++ b/Mathlib/Data/Bitvec/Defs.lean
@@ -36,57 +36,6 @@ open Vector
 -- mathport name: «expr ++ₜ »
 local infixl:65 "++ₜ" => Vector.append
 
-/-! ### Constant Bitvectors -/
-section Constants
-
-  /-- The bitvector `0000..`, whose entries are all `0`, represents the value `0` -/
-  @[reducible]
-  protected def zero (n : ℕ) : Bitvec n :=
-    replicate n false
-  #align bitvec.zero Bitvec.zero
-
-  /-- The bitvector `1000..`, whose `n-1`st entry is `1` and other entries are `0`, represents the
-      value `1` -/
-  @[reducible]
-  protected def one : ∀ (n : ℕ), Bitvec n
-    | 0 => nil
-    | succ n => replicate n false++ₜtrue ::ᵥ nil
-  #align bitvec.one Bitvec.one
-
-  /-- The bitvector `1111..`, whose entries are all `1`, represents the value `-1` as a signed
-      integer, or `(2^n)-1` as an unsigned integer. This corresponds to the maximal unsigned value
-  -/
-  def negOne (n : ℕ) : Bitvec n :=
-    replicate n true
-
-  /--
-  The maximal positive (signed) integer for a given bitwidth has bitpattern `011111..`, representing
-  the value `2^n-1`
-  -/
-  @[reducible]
-  def intMax : ∀ n, Bitvec n
-    | 0   => Vector.nil
-    | n+1 => false ::ᵥ negOne n
-
-  /--
-    The minimal negative integer for a given bitwidth has bitpattern `10000...`, representing
-    `-2^n` as a signed integer, or `2^(n-1)` as an unsigned integer
-   -/
-  @[reducible]
-  def intMin : ∀ n, Bitvec n
-    | 0   => Vector.nil
-    | n+1 => true ::ᵥ Bitvec.zero n
-
-
-  /-- Define the all-zero bitpattern as the bottom element of `Bitvec n` -/
-  instance : Bot (Bitvec n) := ⟨Bitvec.zero n⟩
-
-  /-- Define the all-ones bitpattern as the top element of `Bitvec n` -/
-  instance : Top (Bitvec n) := ⟨Bitvec.negOne n⟩
-
-end Constants
-
-
 
 
 /-- Create a bitvector from another with a provably equal length. -/
@@ -231,12 +180,6 @@ protected def sub (x y : Bitvec n) : Bitvec n :=
   Prod.snd (sbb x y false)
 #align bitvec.sub Bitvec.sub
 
-instance : Zero (Bitvec n) :=
-  ⟨Bitvec.zero n⟩
-
-instance : One (Bitvec n) :=
-  ⟨Bitvec.one n⟩
-
 instance : Add (Bitvec n) :=
   ⟨Bitvec.add⟩
 
@@ -257,8 +200,69 @@ instance : Mul (Bitvec n) :=
 
 end Arith
 
-/-! ### Comparison operators -/
 
+
+/-! ### Constant Bitvectors -/
+section Constants
+
+  /-- The bitvector `0000..`, whose entries are all `0`, represents the value `0` -/
+  @[reducible]
+  protected def zero (n : ℕ) : Bitvec n :=
+    replicate n false
+  #align bitvec.zero Bitvec.zero
+
+  /-- The bitvector `1000..`, whose `n-1`st entry is `1` and other entries are `0`, represents the
+      value `1` -/
+  @[reducible]
+  protected def one : ∀ (n : ℕ), Bitvec n
+    | 0 => nil
+    | succ n => replicate n false++ₜtrue ::ᵥ nil
+  #align bitvec.one Bitvec.one
+
+  /-- The bitvector `1111..`, whose entries are all `1`, represents the value `-1` as a signed
+      integer, or `(2^n)-1` as an unsigned integer. This corresponds to the maximal unsigned value
+  -/
+  abbrev negOne (n : ℕ) : Bitvec n :=
+    -1
+
+  /--
+  The maximal positive (signed) integer for a given bitwidth has bitpattern `011111..`, representing
+  the value `2^n-1`
+  -/
+  @[reducible]
+  def intMax : ∀ n, Bitvec n
+    | 0   => Vector.nil
+    | n+1 => false ::ᵥ negOne n
+
+  /--
+    The minimal negative integer for a given bitwidth has bitpattern `10000...`, representing
+    `-2^n` as a signed integer, or `2^(n-1)` as an unsigned integer
+   -/
+  @[reducible]
+  def intMin : ∀ n, Bitvec n
+    | 0   => Vector.nil
+    | n+1 => true ::ᵥ Bitvec.zero n
+
+
+  instance : Zero (Bitvec n) :=
+    ⟨Bitvec.zero n⟩
+
+  instance : One (Bitvec n) :=
+    ⟨Bitvec.one n⟩
+
+  /-- Define the all-zero bitpattern as the bottom element of `Bitvec n` -/
+  instance : Bot (Bitvec n) :=
+    ⟨Bitvec.zero n⟩
+
+  /-- Define the all-ones bitpattern as the top element of `Bitvec n` -/
+  instance : Top (Bitvec n) :=
+    ⟨Bitvec.negOne n⟩
+
+end Constants
+
+
+
+/-! ### Comparison operators -/
 
 section Comparison
 

--- a/Mathlib/Data/Vector/Basic.lean
+++ b/Mathlib/Data/Vector/Basic.lean
@@ -736,4 +736,10 @@ instance : IsLawfulTraversable.{u} (flip Vector n) where
 --       q(α) q(n) q(x) ih
 -- #align vector.reflect vector.reflect
 
+
+@[simp]
+theorem map_replicate (f : α → β) (n : Nat) (a : α) :
+    map f (replicate n a) = replicate n (f a) := by
+  simp[map, replicate]
+
 end Vector


### PR DESCRIPTION
Define constant bitvectors that represent -1, the minimal negative signed integer, and the maximal positive signed integer, at arbitrary bitwidths

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

- [x] depends on #4994 


[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
