### PR TITLE
[Merged by Bors] - feat: don't re-elaborate terms in set

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3144,6 +3144,7 @@ import Mathlib.Util.MemoFix
 import Mathlib.Util.PiNotation
 import Mathlib.Util.Pickle
 import Mathlib.Util.Qq
+import Mathlib.Util.SleepHeartbeats
 import Mathlib.Util.Superscript
 import Mathlib.Util.Syntax
 import Mathlib.Util.SynthesizeUsing

--- a/Mathlib/Algebra/Category/GroupCat/Injective.lean
+++ b/Mathlib/Algebra/Category/GroupCat/Injective.lean
@@ -156,4 +156,3 @@ instance injective_of_divisible [DivisibleBy A ℤ] :
 #align AddCommGroup.injective_of_divisible AddCommGroupCat.injective_of_divisible
 
 end AddCommGroupCat
-

--- a/Mathlib/Algebra/Category/GroupCat/Injective.lean
+++ b/Mathlib/Algebra/Category/GroupCat/Injective.lean
@@ -1,3 +1,13 @@
+/-
+Copyright (c) 2022 Jujian Zhang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jujian Zhang
+
+! This file was ported from Lean 3 source module algebra.category.Group.injective
+! leanprover-community/mathlib commit 70fd9563a21e7b963887c9360bd29b2393e6225a
+! Please do not edit these lines, except to modify the commit id
+! if you have ported upstream changes.
+-/
 import Mathlib.Algebra.Category.GroupCat.EpiMono
 import Mathlib.Algebra.Category.ModuleCat.EpiMono
 import Mathlib.Algebra.Module.Injective
@@ -99,7 +109,6 @@ theorem injective_as_module_of_injective_as_Ab [Injective (⟨A,inferInstance⟩
       apply this }
 #align AddCommGroup.injective_as_module_of_injective_as_Ab AddCommGroupCat.injective_as_module_of_injective_as_Ab
 
-set_option trace.Elab.step.result true in
 instance injective_of_divisible [DivisibleBy A ℤ] :
     CategoryTheory.Injective (⟨A,inferInstance⟩ : AddCommGroupCat) :=
   @injective_of_injective_as_module A _ <|
@@ -122,8 +131,7 @@ instance injective_of_divisible [DivisibleBy A ℤ] :
             simp only [hn, map_zero]
             symm
             convert map_zero g
-        .
-          set gₘ := g ⟨m, Submodule.subset_span (Set.mem_singleton _)⟩ with gm_eq
+        · set gₘ := g ⟨m, Submodule.subset_span (Set.mem_singleton _)⟩ with gm_eq
           refine'
             ⟨{  toFun := _
                 map_add' := _

--- a/Mathlib/Algebra/Category/GroupCat/Injective.lean
+++ b/Mathlib/Algebra/Category/GroupCat/Injective.lean
@@ -156,3 +156,4 @@ instance injective_of_divisible [DivisibleBy A ℤ] :
 #align AddCommGroup.injective_of_divisible AddCommGroupCat.injective_of_divisible
 
 end AddCommGroupCat
+

--- a/Mathlib/Algebra/Category/GroupCat/Injective.lean
+++ b/Mathlib/Algebra/Category/GroupCat/Injective.lean
@@ -1,13 +1,3 @@
-/-
-Copyright (c) 2022 Jujian Zhang. All rights reserved.
-Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Jujian Zhang
-
-! This file was ported from Lean 3 source module algebra.category.Group.injective
-! leanprover-community/mathlib commit 70fd9563a21e7b963887c9360bd29b2393e6225a
-! Please do not edit these lines, except to modify the commit id
-! if you have ported upstream changes.
--/
 import Mathlib.Algebra.Category.GroupCat.EpiMono
 import Mathlib.Algebra.Category.ModuleCat.EpiMono
 import Mathlib.Algebra.Module.Injective
@@ -109,6 +99,7 @@ theorem injective_as_module_of_injective_as_Ab [Injective (⟨A,inferInstance⟩
       apply this }
 #align AddCommGroup.injective_as_module_of_injective_as_Ab AddCommGroupCat.injective_as_module_of_injective_as_Ab
 
+set_option trace.Elab.step.result true in
 instance injective_of_divisible [DivisibleBy A ℤ] :
     CategoryTheory.Injective (⟨A,inferInstance⟩ : AddCommGroupCat) :=
   @injective_of_injective_as_module A _ <|
@@ -131,7 +122,8 @@ instance injective_of_divisible [DivisibleBy A ℤ] :
             simp only [hn, map_zero]
             symm
             convert map_zero g
-        · set gₘ := g ⟨m, Submodule.subset_span (Set.mem_singleton _)⟩ with gm_eq
+        .
+          set gₘ := g ⟨m, Submodule.subset_span (Set.mem_singleton _)⟩ with gm_eq
           refine'
             ⟨{  toFun := _
                 map_add' := _

--- a/Mathlib/Analysis/BoxIntegral/DivergenceTheorem.lean
+++ b/Mathlib/Analysis/BoxIntegral/DivergenceTheorem.lean
@@ -173,7 +173,7 @@ theorem hasIntegral_GP_pderiv (f : (Fin (n + 1) → ℝ) → E)
     integral.{0, u, u} J GP (fun x => f (i.insertNth y x)) BoxAdditiveMap.volume
   set fb : Icc (I.lower i) (I.upper i) → Fin n →ᵇᵃ[↑(I.face i)] E := fun x =>
     (integrable_of_continuousOn GP (Box.continuousOn_face_Icc Hc x.2) volume).toBoxAdditive
-  set F : Fin (n + 1) →ᵇᵃ[I] E := BoxAdditiveMap.upperSubLower I i fI fb fun x _hx J => rfl
+  set F : Fin (n + 1) →ᵇᵃ[I] E := BoxAdditiveMap.upperSubLower I i fI fb fun x _ J => rfl
   -- Thus our statement follows from some local estimates.
   change HasIntegral I GP (fun x => f' x (Pi.single i 1)) _ (F I)
   refine' HasIntegral.of_le_Henstock_of_forall_isLittleO gp_le _ _ _ s hs _ _

--- a/Mathlib/Analysis/BoxIntegral/DivergenceTheorem.lean
+++ b/Mathlib/Analysis/BoxIntegral/DivergenceTheorem.lean
@@ -102,7 +102,7 @@ theorem norm_volume_sub_integral_face_upper_sub_lower_smul_le {f : (Fin (n + 1) 
           (f (e (I.upper i) y) - f (e (I.lower i) y))‖ ≤
         2 * ε * diam (Box.Icc I) := fun y hy ↦ by
     set g := fun y => f y - a - f' (y - x) with hg
-    change ∀ y ∈ (Box.Icc I), ‖g y‖ ≤ ε * ‖y - x‖ at hε 
+    change ∀ y ∈ (Box.Icc I), ‖g y‖ ≤ ε * ‖y - x‖ at hε
     clear_value g; obtain rfl : f = fun y => a + f' (y - x) + g y := by simp [hg]
     convert_to ‖g (e (I.lower i) y) - g (e (I.upper i) y)‖ ≤ _
     · congr 1
@@ -173,7 +173,7 @@ theorem hasIntegral_GP_pderiv (f : (Fin (n + 1) → ℝ) → E)
     integral.{0, u, u} J GP (fun x => f (i.insertNth y x)) BoxAdditiveMap.volume
   set fb : Icc (I.lower i) (I.upper i) → Fin n →ᵇᵃ[↑(I.face i)] E := fun x =>
     (integrable_of_continuousOn GP (Box.continuousOn_face_Icc Hc x.2) volume).toBoxAdditive
-  set F : Fin (n + 1) →ᵇᵃ[I] E := BoxAdditiveMap.upperSubLower I i fI fb fun x hx J => rfl
+  set F : Fin (n + 1) →ᵇᵃ[I] E := BoxAdditiveMap.upperSubLower I i fI fb fun x _hx J => rfl
   -- Thus our statement follows from some local estimates.
   change HasIntegral I GP (fun x => f' x (Pi.single i 1)) _ (F I)
   refine' HasIntegral.of_le_Henstock_of_forall_isLittleO gp_le _ _ _ s hs _ _
@@ -283,10 +283,9 @@ theorem hasIntegral_GP_divergence_of_forall_hasDerivWithinAt
           integral.{0, u, u} (I.face i) GP (fun x => f (i.insertNth (I.lower i) x) i)
             BoxAdditiveMap.volume)) := by
   refine HasIntegral.sum fun i _ => ?_
-  simp only [hasFDerivWithinAt_pi', continuousWithinAt_pi] at Hd Hs 
+  simp only [hasFDerivWithinAt_pi', continuousWithinAt_pi] at Hd Hs
   exact hasIntegral_GP_pderiv I _ _ s hs (fun x hx => Hs x hx i) (fun x hx => Hd x hx i) i
 set_option linter.uppercaseLean3 false in
 #align box_integral.has_integral_GP_divergence_of_forall_has_deriv_within_at BoxIntegral.hasIntegral_GP_divergence_of_forall_hasDerivWithinAt
 
 end BoxIntegral
-

--- a/Mathlib/Analysis/Calculus/ContDiff.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff.lean
@@ -506,7 +506,7 @@ product of `f` and `g` admits the cartesian product of `p` and `q` as a Taylor s
 theorem HasFTaylorSeriesUpToOn.prod (hf : HasFTaylorSeriesUpToOn n f p s) {g : E → G}
     {q : E → FormalMultilinearSeries 𝕜 E G} (hg : HasFTaylorSeriesUpToOn n g q s) :
     HasFTaylorSeriesUpToOn n (fun y => (f y, g y)) (fun y k => (p y k).prod (q y k)) s := by
-  set L := fun m => ContinuousMultilinearMap.prodL 𝕜 (fun i : Fin m => E) F G
+  set L := fun m => ContinuousMultilinearMap.prodL 𝕜 (fun _ : Fin m => E) F G
   constructor
   · intro x hx; rw [← hf.zero_eq x hx, ← hg.zero_eq x hx]; rfl
   · intro m hm x hx

--- a/Mathlib/Data/Set/Finite.lean
+++ b/Mathlib/Data/Set/Finite.lean
@@ -1419,7 +1419,7 @@ variable [Preorder α] [Nonempty α] {s : Set α}
 
 theorem infinite_of_forall_exists_gt (h : ∀ a, ∃ b ∈ s, a < b) : s.Infinite := by
   inhabit α
-  set f : ℕ → α := fun n => Nat.recOn n (h default).choose fun n a => (h a).choose
+  set f : ℕ → α := fun n => Nat.recOn n (h default).choose fun _ a => (h a).choose
   have hf : ∀ n, f n ∈ s := by rintro (_ | _) <;> exact (h _).choose_spec.1
   exact infinite_of_injective_forall_mem
     (strictMono_nat_of_lt_succ fun n => (h _).choose_spec.2).injective hf

--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Metrizable.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Metrizable.lean
@@ -161,7 +161,7 @@ theorem measurable_limit_of_tendsto_metrizable_ae {ι} [Countable ι] [Nonempty 
     aeSeq.fun_prop_of_mem_aeSeqSet hf hx
   have h_ae_eq : ∀ᵐ x ∂μ, ∀ n, aeSeq hf p n x = f n x := aeSeq.aeSeq_eq_fun_ae hf h_ae_tendsto
   set f_lim : α → β := fun x => dite (x ∈ aeSeqSet hf p) (fun h => (hp_mem x h).choose)
-    fun h => (⟨f default x⟩ : Nonempty β).some
+    fun _h => (⟨f default x⟩ : Nonempty β).some
   have hf_lim : ∀ x, Tendsto (fun n => aeSeq hf p n x) L (𝓝 (f_lim x)) := by
     intro x
     simp only [aeSeq]

--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Metrizable.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Metrizable.lean
@@ -161,7 +161,7 @@ theorem measurable_limit_of_tendsto_metrizable_ae {ι} [Countable ι] [Nonempty 
     aeSeq.fun_prop_of_mem_aeSeqSet hf hx
   have h_ae_eq : ∀ᵐ x ∂μ, ∀ n, aeSeq hf p n x = f n x := aeSeq.aeSeq_eq_fun_ae hf h_ae_tendsto
   set f_lim : α → β := fun x => dite (x ∈ aeSeqSet hf p) (fun h => (hp_mem x h).choose)
-    fun _h => (⟨f default x⟩ : Nonempty β).some
+    fun _ => (⟨f default x⟩ : Nonempty β).some
   have hf_lim : ∀ x, Tendsto (fun n => aeSeq hf p n x) L (𝓝 (f_lim x)) := by
     intro x
     simp only [aeSeq]

--- a/Mathlib/MeasureTheory/Covering/Vitali.lean
+++ b/Mathlib/MeasureTheory/Covering/Vitali.lean
@@ -332,7 +332,7 @@ theorem exists_disjoint_covering_ae [MetricSpace α] [MeasurableSpace α] [Opens
   have M : (s \ ⋃ a ∈ u, B a) ∩
       ball x (R x) ⊆ ⋃ a : { a // a ∉ w }, closedBall (c a) (3 * r a) := by
     intro z hz
-    set k := ⋃ (a : v) (_ha : a ∈ w), B a
+    set k := ⋃ (a : v) (_ : a ∈ w), B a
     have k_closed : IsClosed k := isClosed_biUnion w.finite_toSet fun i _ => h't _ (ut (vu i.2))
     have z_notmem_k : z ∉ k := by
       simp only [not_exists, exists_prop, mem_iUnion, mem_sep_iff, forall_exists_index,

--- a/Mathlib/MeasureTheory/Covering/Vitali.lean
+++ b/Mathlib/MeasureTheory/Covering/Vitali.lean
@@ -332,7 +332,7 @@ theorem exists_disjoint_covering_ae [MetricSpace α] [MeasurableSpace α] [Opens
   have M : (s \ ⋃ a ∈ u, B a) ∩
       ball x (R x) ⊆ ⋃ a : { a // a ∉ w }, closedBall (c a) (3 * r a) := by
     intro z hz
-    set k := ⋃ (a : v) (ha : a ∈ w), B a
+    set k := ⋃ (a : v) (_ha : a ∈ w), B a
     have k_closed : IsClosed k := isClosed_biUnion w.finite_toSet fun i _ => h't _ (ut (vu i.2))
     have z_notmem_k : z ∉ k := by
       simp only [not_exists, exists_prop, mem_iUnion, mem_sep_iff, forall_exists_index,

--- a/Mathlib/MeasureTheory/Decomposition/Lebesgue.lean
+++ b/Mathlib/MeasureTheory/Decomposition/Lebesgue.lean
@@ -484,8 +484,8 @@ theorem iSup_succ_eq_sup {α} (f : ℕ → α → ℝ≥0∞) (m : ℕ) (a : α)
   simp only [Option.mem_def, ENNReal.some_eq_coe]
   constructor <;> intro h <;> rw [← h]; symm
   all_goals
-    set c := ⨆ (k : ℕ) (hk : k ≤ m + 1), f k a with hc
-    set d := f m.succ a ⊔ ⨆ (k : ℕ) (hk : k ≤ m), f k a with hd
+    set c := ⨆ (k : ℕ) (_hk : k ≤ m + 1), f k a with hc
+    set d := f m.succ a ⊔ ⨆ (k : ℕ) (_hk : k ≤ m), f k a with hd
     rw [@le_antisymm_iff ℝ≥0∞, hc, hd]
     -- Specifying the type is weirdly necessary
     refine' ⟨_, _⟩

--- a/Mathlib/MeasureTheory/Decomposition/Lebesgue.lean
+++ b/Mathlib/MeasureTheory/Decomposition/Lebesgue.lean
@@ -561,7 +561,7 @@ theorem haveLebesgueDecomposition_of_finiteMeasure [IsFiniteMeasure μ] [IsFinit
         ⟨0, 0, zero_mem_measurableLE, by simp⟩ (OrderTop.bddAbove _)
     choose g _ hg₂ f hf₁ hf₂ using h
     -- we set `ξ` to be the supremum of an increasing sequence of functions obtained from above
-    set ξ := ⨆ (n) (k) (_hk : k ≤ n), f k with hξ
+    set ξ := ⨆ (n) (k) (_ : k ≤ n), f k with hξ
     -- we see that `ξ` has the largest integral among all functions in `measurableLE`
     have hξ₁ : sSup (measurableLEEval ν μ) = ∫⁻ a, ξ a ∂ν := by
       have :=

--- a/Mathlib/MeasureTheory/Decomposition/Lebesgue.lean
+++ b/Mathlib/MeasureTheory/Decomposition/Lebesgue.lean
@@ -484,8 +484,8 @@ theorem iSup_succ_eq_sup {α} (f : ℕ → α → ℝ≥0∞) (m : ℕ) (a : α)
   simp only [Option.mem_def, ENNReal.some_eq_coe]
   constructor <;> intro h <;> rw [← h]; symm
   all_goals
-    set c := ⨆ (k : ℕ) (_hk : k ≤ m + 1), f k a with hc
-    set d := f m.succ a ⊔ ⨆ (k : ℕ) (_hk : k ≤ m), f k a with hd
+    set c := ⨆ (k : ℕ) (_ : k ≤ m + 1), f k a with hc
+    set d := f m.succ a ⊔ ⨆ (k : ℕ) (_ : k ≤ m), f k a with hd
     rw [@le_antisymm_iff ℝ≥0∞, hc, hd]
     -- Specifying the type is weirdly necessary
     refine' ⟨_, _⟩

--- a/Mathlib/MeasureTheory/Decomposition/Lebesgue.lean
+++ b/Mathlib/MeasureTheory/Decomposition/Lebesgue.lean
@@ -561,7 +561,7 @@ theorem haveLebesgueDecomposition_of_finiteMeasure [IsFiniteMeasure μ] [IsFinit
         ⟨0, 0, zero_mem_measurableLE, by simp⟩ (OrderTop.bddAbove _)
     choose g _ hg₂ f hf₁ hf₂ using h
     -- we set `ξ` to be the supremum of an increasing sequence of functions obtained from above
-    set ξ := ⨆ (n) (k) (hk : k ≤ n), f k with hξ
+    set ξ := ⨆ (n) (k) (_hk : k ≤ n), f k with hξ
     -- we see that `ξ` has the largest integral among all functions in `measurableLE`
     have hξ₁ : sSup (measurableLEEval ν μ) = ∫⁻ a, ξ a ∂ν := by
       have :=

--- a/Mathlib/MeasureTheory/Integral/Layercake.lean
+++ b/Mathlib/MeasureTheory/Integral/Layercake.lean
@@ -217,7 +217,7 @@ instead. -/
 theorem lintegral_eq_lintegral_meas_le (μ : Measure α) [SigmaFinite μ] (f_nn : 0 ≤ f)
     (f_mble : Measurable f) :
     (∫⁻ ω, ENNReal.ofReal (f ω) ∂μ) = ∫⁻ t in Ioi 0, μ {a : α | t ≤ f a} := by
-  set cst := fun t : ℝ => (1 : ℝ)
+  set cst := fun _ : ℝ => (1 : ℝ)
   have cst_intble : ∀ t > 0, IntervalIntegrable cst volume 0 t := fun _ _ =>
     intervalIntegrable_const
   have key :=

--- a/Mathlib/MeasureTheory/Measure/OuterMeasure.lean
+++ b/Mathlib/MeasureTheory/Measure/OuterMeasure.lean
@@ -1690,7 +1690,7 @@ theorem trim_sum_ge {ι} (m : ι → OuterMeasure α) : (sum fun i => (m i).trim
 
 theorem exists_measurable_superset_eq_trim (m : OuterMeasure α) (s : Set α) :
     ∃ t, s ⊆ t ∧ MeasurableSet t ∧ m t = m.trim s := by
-  simp only [trim_eq_iInf]; set ms := ⨅ (t : Set α) (_st : s ⊆ t) (_ht : MeasurableSet t), m t
+  simp only [trim_eq_iInf]; set ms := ⨅ (t : Set α) (_ : s ⊆ t) (_ : MeasurableSet t), m t
   by_cases hs : ms = ∞
   · simp only [hs]
     simp only [iInf_eq_top] at hs

--- a/Mathlib/MeasureTheory/Measure/OuterMeasure.lean
+++ b/Mathlib/MeasureTheory/Measure/OuterMeasure.lean
@@ -1690,7 +1690,7 @@ theorem trim_sum_ge {ι} (m : ι → OuterMeasure α) : (sum fun i => (m i).trim
 
 theorem exists_measurable_superset_eq_trim (m : OuterMeasure α) (s : Set α) :
     ∃ t, s ⊆ t ∧ MeasurableSet t ∧ m t = m.trim s := by
-  simp only [trim_eq_iInf]; set ms := ⨅ (t : Set α) (st : s ⊆ t) (ht : MeasurableSet t), m t
+  simp only [trim_eq_iInf]; set ms := ⨅ (t : Set α) (_st : s ⊆ t) (_ht : MeasurableSet t), m t
   by_cases hs : ms = ∞
   · simp only [hs]
     simp only [iInf_eq_top] at hs

--- a/Mathlib/MeasureTheory/Measure/VectorMeasure.lean
+++ b/Mathlib/MeasureTheory/Measure/VectorMeasure.lean
@@ -148,7 +148,7 @@ variable [T2Space M] {v : VectorMeasure α M} {f : ℕ → Set α}
 theorem hasSum_of_disjoint_iUnion [Countable β] {f : β → Set α} (hf₁ : ∀ i, MeasurableSet (f i))
     (hf₂ : Pairwise (Disjoint on f)) : HasSum (fun i => v (f i)) (v (⋃ i, f i)) := by
   cases nonempty_encodable β
-  set g := fun i : ℕ => ⋃ (b : β) (_H : b ∈ Encodable.decode₂ β i), f b with hg
+  set g := fun i : ℕ => ⋃ (b : β) (_ : b ∈ Encodable.decode₂ β i), f b with hg
   have hg₁ : ∀ i, MeasurableSet (g i) :=
     fun _ => MeasurableSet.iUnion fun b => MeasurableSet.iUnion fun _ => hf₁ b
   have hg₂ : Pairwise (Disjoint on g) := Encodable.iUnion_decode₂_disjoint_on hf₂

--- a/Mathlib/MeasureTheory/Measure/VectorMeasure.lean
+++ b/Mathlib/MeasureTheory/Measure/VectorMeasure.lean
@@ -148,7 +148,7 @@ variable [T2Space M] {v : VectorMeasure α M} {f : ℕ → Set α}
 theorem hasSum_of_disjoint_iUnion [Countable β] {f : β → Set α} (hf₁ : ∀ i, MeasurableSet (f i))
     (hf₂ : Pairwise (Disjoint on f)) : HasSum (fun i => v (f i)) (v (⋃ i, f i)) := by
   cases nonempty_encodable β
-  set g := fun i : ℕ => ⋃ (b : β) (H : b ∈ Encodable.decode₂ β i), f b with hg
+  set g := fun i : ℕ => ⋃ (b : β) (_H : b ∈ Encodable.decode₂ β i), f b with hg
   have hg₁ : ∀ i, MeasurableSet (g i) :=
     fun _ => MeasurableSet.iUnion fun b => MeasurableSet.iUnion fun _ => hf₁ b
   have hg₂ : Pairwise (Disjoint on g) := Encodable.iUnion_decode₂_disjoint_on hf₂

--- a/Mathlib/Tactic/FieldSimp.lean
+++ b/Mathlib/Tactic/FieldSimp.lean
@@ -9,7 +9,6 @@ import Lean.Meta.Tactic.Simp.Main
 import Std.Lean.Parser
 import Mathlib.Algebra.Group.Units
 import Mathlib.Tactic.NormNum.Core
-import Mathlib.Tactic.Set
 import Qq
 
 /-!

--- a/Mathlib/Tactic/Set.lean
+++ b/Mathlib/Tactic/Set.lean
@@ -39,7 +39,7 @@ h2 : x = y
 
 -/
 elab_rules : tactic
-| `(tactic| set%$tk $[!%$rw]? $a:ident $[: $ty:term]? := $val:term $[with $[←%$rev]? $h:ident]?) =>
+| `(tactic| set%$tk $[!%$rw]? $a:ident $[: $ty:term]? := $val:term $[with $[←%$rev]? $h:ident]?) => do
   withMainContext do
     let (ty, vale) ← match ty with
     | some ty =>
@@ -51,13 +51,12 @@ elab_rules : tactic
     let fvar ← liftMetaTacticAux fun goal ↦ do
       let (fvar, goal) ← (← goal.define a.getId ty vale).intro1P
       pure (fvar, [goal])
-    withMainContext do
-      Term.addTermInfo' (isBinder := true) a (mkFVar fvar)
+    Term.addTermInfo' (isBinder := true) a (mkFVar fvar)
     if rw.isNone then
       evalTactic (← `(tactic| try rewrite [(id rfl : $val = $a)] at *))
     match h, rev with
     | some h, some none =>
-      evalTactic (← `(tactic| have $h : ($a : $(← delab ty)) = ($val : $(← delab ty)) := rfl))
+      evalTactic (← `(tactic| have%$tk $h : $a = ($val : $(← delab ty)) := rfl))
     | some h, some (some _) =>
-      evalTactic (← `(tactic| have $h : ($val : $(← delab ty)) = ($a : $(← delab ty)) := rfl))
+      evalTactic (← `(tactic| have%$tk $h : ($val : $(← delab ty)) = $a := rfl))
     | _, _ => pure ()

--- a/Mathlib/Tactic/Set.lean
+++ b/Mathlib/Tactic/Set.lean
@@ -16,7 +16,6 @@ syntax (name := setTactic) "set" "!"? setArgsRest : tactic
 
 macro "set!" rest:setArgsRest : tactic => `(tactic| set ! $rest:setArgsRest)
 
--- set_option pp.structureInstanceTypes true
 /--
 `set a := t with h` is a variant of `let a := t`. It adds the hypothesis `h : a = t` to
 the local context and replaces `t` with `a` everywhere it can.
@@ -40,7 +39,7 @@ h2 : x = y
 
 -/
 elab_rules : tactic
-| `(tactic| set%$tk $[!%$rw]? $a:ident $[: $ty:term]? := $val:term $[with $[←%$rev]? $h:ident]?) => do
+| `(tactic| set%$tk $[!%$rw]? $a:ident $[: $ty:term]? := $val:term $[with $[←%$rev]? $h:ident]?) =>
   withMainContext do
     let (ty, vale) ← match ty with
     | some ty =>
@@ -55,7 +54,8 @@ elab_rules : tactic
     Term.addTermInfo' (isBinder := true) a (mkFVar fvar)
     if rw.isNone then
       evalTactic (← `(tactic| try rewrite [(id rfl : $val = $a)] at *))
-    let tt ← delab ty (({} : RBMap _ _ _).insert .root <| KVMap.mk [((`pp).append `structureInstanceTypes, true)])
+    let tt ← delab ty
+      (RBMap.empty.insert .root <| KVMap.empty.setBool `pp.structureInstanceTypes true)
     match h, rev with
     | some h, some none =>
       evalTactic (← `(tactic| have%$tk $h : $a = ($val : $tt) := rfl))

--- a/Mathlib/Tactic/Set.lean
+++ b/Mathlib/Tactic/Set.lean
@@ -52,9 +52,9 @@ elab_rules : tactic
       let (fvar, goal) ← (← goal.define a.getId ty vale).intro1P
       pure (fvar, [goal])
     Term.addTermInfo' (isBinder := true) a (mkFVar fvar)
-    if rw.isNone then
-      evalTactic (← `(tactic| try rewrite [(id rfl : $val = $a)] at *))
     let tt ← Term.exprToSyntax ty
+    if rw.isNone then
+      evalTactic (← `(tactic| try rewrite [show ($val : $tt) = $a from rfl] at *))
     match h, rev with
     | some h, some none =>
       evalTactic (← `(tactic| have%$tk $h : $a = ($val : $tt) := rfl))

--- a/Mathlib/Tactic/Set.lean
+++ b/Mathlib/Tactic/Set.lean
@@ -52,12 +52,11 @@ elab_rules : tactic
       let (fvar, goal) ← (← goal.define a.getId ty vale).intro1P
       pure (fvar, [goal])
     Term.addTermInfo' (isBinder := true) a (mkFVar fvar)
-    let tt ← Term.exprToSyntax ty
     if rw.isNone then
       evalTactic (← `(tactic| try rewrite [show $(← Term.exprToSyntax vale) = $a from rfl] at *))
     match h, rev with
     | some h, some none =>
-      evalTactic (← `(tactic| have%$tk $h : $a = ($val : $tt) := rfl))
+      evalTactic (← `(tactic| have%$tk $h : $a = ($val : $(← Term.exprToSyntax ty)) := rfl))
     | some h, some (some _) =>
-      evalTactic (← `(tactic| have%$tk $h : ($val : $tt) = $a := rfl))
+      evalTactic (← `(tactic| have%$tk $h : ($val : $(← Term.exprToSyntax ty)) = $a := rfl))
     | _, _ => pure ()

--- a/Mathlib/Tactic/Set.lean
+++ b/Mathlib/Tactic/Set.lean
@@ -56,7 +56,9 @@ elab_rules : tactic
       evalTactic (← `(tactic| try rewrite [show $(← Term.exprToSyntax vale) = $a from rfl] at *))
     match h, rev with
     | some h, some none =>
-      evalTactic (← `(tactic| have%$tk $h : $a = ($val : $(← Term.exprToSyntax ty)) := rfl))
+      evalTactic (← `(tactic| have%$tk
+        $h : $a = ($(← Term.exprToSyntax vale) : $(← Term.exprToSyntax ty)) := rfl))
     | some h, some (some _) =>
-      evalTactic (← `(tactic| have%$tk $h : ($val : $(← Term.exprToSyntax ty)) = $a := rfl))
+      evalTactic (← `(tactic| have%$tk
+        $h : ($(← Term.exprToSyntax vale) : $(← Term.exprToSyntax ty)) = $a := rfl))
     | _, _ => pure ()

--- a/Mathlib/Tactic/Set.lean
+++ b/Mathlib/Tactic/Set.lean
@@ -16,6 +16,7 @@ syntax (name := setTactic) "set" "!"? setArgsRest : tactic
 
 macro "set!" rest:setArgsRest : tactic => `(tactic| set ! $rest:setArgsRest)
 
+set_option pp.structureInstanceTypes true
 /--
 `set a := t with h` is a variant of `let a := t`. It adds the hypothesis `h : a = t` to
 the local context and replaces `t` with `a` everywhere it can.
@@ -54,7 +55,7 @@ elab_rules : tactic
     Term.addTermInfo' (isBinder := true) a (mkFVar fvar)
     if rw.isNone then
       evalTactic (← `(tactic| try rewrite [(id rfl : $val = $a)] at *))
-    let tt ← delab ty (({} : RBMap _ _ _).insert .root <| KVMap.insert {} `pp.Analyze true)
+    let tt ← delab ty (({} : RBMap _ _ _).insert .root <| KVMap.mk [((`pp).append `Analyze, true)])
     match h, rev with
     | some h, some none =>
       evalTactic (← `(tactic| have%$tk $h : $a = ($val : $tt) := rfl))

--- a/Mathlib/Tactic/Set.lean
+++ b/Mathlib/Tactic/Set.lean
@@ -16,7 +16,7 @@ syntax (name := setTactic) "set" "!"? setArgsRest : tactic
 
 macro "set!" rest:setArgsRest : tactic => `(tactic| set ! $rest:setArgsRest)
 
-set_option pp.structureInstanceTypes true
+-- set_option pp.structureInstanceTypes true
 /--
 `set a := t with h` is a variant of `let a := t`. It adds the hypothesis `h : a = t` to
 the local context and replaces `t` with `a` everywhere it can.
@@ -55,7 +55,7 @@ elab_rules : tactic
     Term.addTermInfo' (isBinder := true) a (mkFVar fvar)
     if rw.isNone then
       evalTactic (← `(tactic| try rewrite [(id rfl : $val = $a)] at *))
-    let tt ← delab ty (({} : RBMap _ _ _).insert .root <| KVMap.mk [((`pp).append `Analyze, true)])
+    let tt ← delab ty (({} : RBMap _ _ _).insert .root <| KVMap.mk [((`pp).append `structureInstanceTypes, true)])
     match h, rev with
     | some h, some none =>
       evalTactic (← `(tactic| have%$tk $h : $a = ($val : $tt) := rfl))

--- a/Mathlib/Tactic/Set.lean
+++ b/Mathlib/Tactic/Set.lean
@@ -6,7 +6,7 @@ Authors: Ian Benway.
 import Lean
 
 namespace Mathlib.Tactic
-open Lean Elab Elab.Tactic Meta PrettyPrinter Delaborator
+open Lean Elab Elab.Tactic Meta
 
 syntax setArgsRest := ppSpace ident (" : " term)? " := " term (" with " "← "? ident)?
 
@@ -54,8 +54,7 @@ elab_rules : tactic
     Term.addTermInfo' (isBinder := true) a (mkFVar fvar)
     if rw.isNone then
       evalTactic (← `(tactic| try rewrite [(id rfl : $val = $a)] at *))
-    let tt ← delab ty
-      (RBMap.empty.insert .root <| KVMap.empty.setBool `pp.structureInstanceTypes true)
+    let tt ← Term.exprToSyntax ty
     match h, rev with
     | some h, some none =>
       evalTactic (← `(tactic| have%$tk $h : $a = ($val : $tt) := rfl))

--- a/Mathlib/Tactic/Set.lean
+++ b/Mathlib/Tactic/Set.lean
@@ -56,7 +56,7 @@ elab_rules : tactic
       evalTactic (← `(tactic| try rewrite [(id rfl : $val = $a)] at *))
     match h, rev with
     | some h, some none =>
-      evalTactic (← `(tactic| have%$tk $h : $a = ($val : $(← delab ty)) := rfl))
+      evalTactic (← `(tactic| have%$tk $h : $a = ($val : $(← ppTerm ty)) := rfl))
     | some h, some (some _) =>
-      evalTactic (← `(tactic| have%$tk $h : ($val : $(← delab ty)) = $a := rfl))
+      evalTactic (← `(tactic| have%$tk $h : ($val : $(← ppTerm ty)) = $a := rfl))
     | _, _ => pure ()

--- a/Mathlib/Tactic/Set.lean
+++ b/Mathlib/Tactic/Set.lean
@@ -54,7 +54,7 @@ elab_rules : tactic
     Term.addTermInfo' (isBinder := true) a (mkFVar fvar)
     let tt ← Term.exprToSyntax ty
     if rw.isNone then
-      evalTactic (← `(tactic| try rewrite [← show ($a : $tt) = $val from rfl] at *))
+      evalTactic (← `(tactic| try rewrite [show (← .exprToSyntax vale) = $a from rfl] at *))
     match h, rev with
     | some h, some none =>
       evalTactic (← `(tactic| have%$tk $h : $a = ($val : $tt) := rfl))

--- a/Mathlib/Tactic/Set.lean
+++ b/Mathlib/Tactic/Set.lean
@@ -54,9 +54,10 @@ elab_rules : tactic
     Term.addTermInfo' (isBinder := true) a (mkFVar fvar)
     if rw.isNone then
       evalTactic (← `(tactic| try rewrite [(id rfl : $val = $a)] at *))
+    let tt ← delab ty (({} : RBMap _ _ _).insert .root <| KVMap.insert {} `pp.Analyze true)
     match h, rev with
     | some h, some none =>
-      evalTactic (← `(tactic| have%$tk $h : $a = ($val : $(← ppTerm ty)) := rfl))
+      evalTactic (← `(tactic| have%$tk $h : $a = ($val : $tt) := rfl))
     | some h, some (some _) =>
-      evalTactic (← `(tactic| have%$tk $h : ($val : $(← ppTerm ty)) = $a := rfl))
+      evalTactic (← `(tactic| have%$tk $h : ($val : $tt) = $a := rfl))
     | _, _ => pure ()

--- a/Mathlib/Tactic/Set.lean
+++ b/Mathlib/Tactic/Set.lean
@@ -54,7 +54,7 @@ elab_rules : tactic
     Term.addTermInfo' (isBinder := true) a (mkFVar fvar)
     let tt ← Term.exprToSyntax ty
     if rw.isNone then
-      evalTactic (← `(tactic| try rewrite [show (← .exprToSyntax vale) = $a from rfl] at *))
+      evalTactic (← `(tactic| try rewrite [show $(← Term.exprToSyntax vale) = $a from rfl] at *))
     match h, rev with
     | some h, some none =>
       evalTactic (← `(tactic| have%$tk $h : $a = ($val : $tt) := rfl))

--- a/Mathlib/Tactic/Set.lean
+++ b/Mathlib/Tactic/Set.lean
@@ -54,7 +54,7 @@ elab_rules : tactic
     Term.addTermInfo' (isBinder := true) a (mkFVar fvar)
     let tt ← Term.exprToSyntax ty
     if rw.isNone then
-      evalTactic (← `(tactic| try rewrite [show ($val : $tt) = $a from rfl] at *))
+      evalTactic (← `(tactic| try rewrite [← show ($a : $tt) = $val from rfl] at *))
     match h, rev with
     | some h, some none =>
       evalTactic (← `(tactic| have%$tk $h : $a = ($val : $tt) := rfl))

--- a/Mathlib/Topology/Separation.lean
+++ b/Mathlib/Topology/Separation.lean
@@ -2065,7 +2065,7 @@ instance ConnectedComponents.t2 [T2Space α] [CompactSpace α] : T2Space (Connec
       exact fun Z => Z.2.1.2
     cases' h with fin_a ha
     -- This clopen and its complement will separate the connected components of `a` and `b`
-    set U : Set α := ⋂ (i : { Z // IsClopen Z ∧ b ∈ Z }) (H : i ∈ fin_a), i
+    set U : Set α := ⋂ (i : { Z // IsClopen Z ∧ b ∈ Z }) (_H : i ∈ fin_a), i
     have hU : IsClopen U := isClopen_biInter_finset fun i _ => i.2.1
     exact ⟨U, (↑) '' U, hU, ha, subset_iInter₂ fun Z _ => Z.2.1.connectedComponent_subset Z.2.2,
       (connectedComponents_preimage_image U).symm ▸ hU.biUnion_connectedComponent_eq⟩

--- a/Mathlib/Topology/Separation.lean
+++ b/Mathlib/Topology/Separation.lean
@@ -2065,7 +2065,7 @@ instance ConnectedComponents.t2 [T2Space α] [CompactSpace α] : T2Space (Connec
       exact fun Z => Z.2.1.2
     cases' h with fin_a ha
     -- This clopen and its complement will separate the connected components of `a` and `b`
-    set U : Set α := ⋂ (i : { Z // IsClopen Z ∧ b ∈ Z }) (_H : i ∈ fin_a), i
+    set U : Set α := ⋂ (i : { Z // IsClopen Z ∧ b ∈ Z }) (_ : i ∈ fin_a), i
     have hU : IsClopen U := isClopen_biInter_finset fun i _ => i.2.1
     exact ⟨U, (↑) '' U, hU, ha, subset_iInter₂ fun Z _ => Z.2.1.connectedComponent_subset Z.2.2,
       (connectedComponents_preimage_image U).symm ▸ hU.biUnion_connectedComponent_eq⟩

--- a/Mathlib/Util/SleepHeartbeats.lean
+++ b/Mathlib/Util/SleepHeartbeats.lean
@@ -14,7 +14,11 @@ manner.
 open Lean Elab
 
 /-- A low level command to sleep for at least a given number of heartbeats by running in a loop
-  until the desired number of heartbeats is hit. -/
+until the desired number of heartbeats is hit.
+Warning: this function relies on interpreter / compiler
+behaviour that is not guaranteed to function in the way that is relied upon here.
+As such this function is not to be considered reliable, especially after future updates to Lean.
+This should be used with caution and basically only for demo / testing purposes and not in compiled code without further testing. -/
 def sleepAtLeastHeartbeats (n : Nat) : IO Unit := do
   let i ← IO.getNumHeartbeats
   while (← IO.getNumHeartbeats) < i + n do

--- a/Mathlib/Util/SleepHeartbeats.lean
+++ b/Mathlib/Util/SleepHeartbeats.lean
@@ -18,7 +18,8 @@ until the desired number of heartbeats is hit.
 Warning: this function relies on interpreter / compiler
 behaviour that is not guaranteed to function in the way that is relied upon here.
 As such this function is not to be considered reliable, especially after future updates to Lean.
-This should be used with caution and basically only for demo / testing purposes and not in compiled code without further testing. -/
+This should be used with caution and basically only for demo / testing purposes
+and not in compiled code without further testing. -/
 def sleepAtLeastHeartbeats (n : Nat) : IO Unit := do
   let i ← IO.getNumHeartbeats
   while (← IO.getNumHeartbeats) < i + n do

--- a/Mathlib/Util/SleepHeartbeats.lean
+++ b/Mathlib/Util/SleepHeartbeats.lean
@@ -1,0 +1,33 @@
+/-
+Copyright (c) 2023 Alex J. Best. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Alex J. Best
+-/
+import Lean
+
+/-!
+# Defines `sleep_heartbeats` tactic.
+
+This is useful for testing / debugging long running commands or elaboration in a somewhat precise
+manner.
+-/
+open Lean Elab
+
+/-- A low level command to sleep for at least a given number of heartbeats by running in a loop
+  until the desired number of heartbeats is hit. -/
+def sleepAtLeastHeartbeats (n : Nat) : IO Unit := do
+  let i ← IO.getNumHeartbeats
+  while (← IO.getNumHeartbeats) < i + n do
+    continue
+
+/-- do nothing for at least n heartbeats -/
+elab "sleep_heartbeats " n:num : tactic => do
+  match Syntax.isNatLit? n with
+  | none    => throwIllFormedSyntax
+  /- as this is a user facing command we multiply the user input by 1000 to match the maxHeartbeats
+     option -/
+  | some m => sleepAtLeastHeartbeats (m * 1000)
+
+example : 1 = 1 := by
+  sleep_heartbeats 1000
+  rfl

--- a/test/Set.lean
+++ b/test/Set.lean
@@ -6,19 +6,7 @@ Authors: Ian Benway.
 
 import Mathlib.Tactic.Set
 import Mathlib.Tactic.Basic
-import Mathlib.Data.Complex.Basic
--- import Mathlib.RingTheory.Ideal.Operations
--- import Mathlib.Algebra.Algebra.Operations
-import Mathlib.Algebra.Algebra.Bilinear
-import Mathlib.Algebra.Algebra.Equiv
--- import Mathlib.Algebra.Module.Submodule.Pointwise
--- import Mathlib.Algebra.Module.Submodule.Bilinear
--- import Mathlib.Algebra.Module.Opposites
-import Mathlib.Algebra.Order.Kleene
--- import Mathlib.Data.Finset.Pointwise
--- import Mathlib.Data.Set.Semiring
--- import Mathlib.Data.Set.Pointwise.BigOperators
--- import Mathlib.GroupTheory.GroupAction.SubMulAction.Pointwise
+import Qq
 
 example (x : Nat) (h : x = x) : x = x := by
   set! p := h
@@ -49,24 +37,30 @@ example : True := by
   set g : Nat → Int := (fun ε => ε) with h
   trivial
 
-open Complex
-open scoped Real
-/-
-example : True := by
-  let a : ℝ := sorry
-  let d : ℝ  := sorry
-  set aff : ℂ → ℂ := (fun w => d * (w - a * I) )
-  set g : ℝ → ℂ → ℂ  := fun ε w => exp (ε * (exp (aff w) + exp (-aff w)))
-  -/
---en Set Function Filter Asymptotics Metric Complex
---en scoped Topology Filter Real
+open Lean Elab
 
+def sleepAtLeastHeartbeats (n : Nat) : CoreM Unit := do
+  let i ← IO.getNumHeartbeats
+  while (← IO.getNumHeartbeats) < i + n do
+    continue
 
-variable {a b C l o p m n b v c j l k u y : ℝ}
--- set_option trace.Meta.synthInstance true
--- set_option trace.profiler true
-theorem horizontal_strip
-   : True := by
-  set aff : ℂ → ℂ := sorry
-  set g : ℝ → ℂ → ℂ  := fun ε w => (ε * ( (aff w) ))
-  sorry
+elab "sleep_heartbeats" n:num : tactic => do
+  match Syntax.isNatLit? n with
+  | none    => throwIllFormedSyntax
+  | some m => sleepAtLeastHeartbeats (m * 1000)
+
+example {a b c d e f g h : ℕ} : 1 = 1 := by
+  sleep_heartbeats 1000
+  rfl
+
+-- simulate a slow to elaborate term
+open Qq in
+elab "test" : term => do
+  sleepAtLeastHeartbeats (1000 * 1000)
+  return q((1 : Nat))
+
+-- this will timeout if test is elaborated multiple times
+set_option maxHeartbeats 2000 in
+example {a b c d e f g h : Nat} : 1 = 1 := by
+  set a : Nat := test with h
+  trivial

--- a/test/Set.lean
+++ b/test/Set.lean
@@ -6,10 +6,10 @@ Authors: Ian Benway.
 
 import Mathlib.Tactic.Set
 import Mathlib.Tactic.Basic
-import Mathlib.Data.Complex.Exponential
+import Mathlib.Data.Complex.Basic
 import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
-import Mathlib.Analysis.Complex.AbsMax
-import Mathlib.Analysis.Asymptotics.SuperpolynomialDecay
+--import Mathlib.Analysis.Complex.AbsMax
+--import Mathlib.Analysis.Asymptotics.SuperpolynomialDecay
 
 example (x : Nat) (h : x = x) : x = x := by
   set! p := h
@@ -42,25 +42,22 @@ example : True := by
 
 open Complex
 open scoped Real
+/-
 example : True := by
   let a : ℝ := sorry
   let d : ℝ  := sorry
   set aff : ℂ → ℂ := (fun w => d * (w - a * I) )
   set g : ℝ → ℂ → ℂ  := fun ε w => exp (ε * (exp (aff w) + exp (-aff w)))
-  sorry
-open Set Function Filter Asymptotics Metric Complex
-open scoped Topology Filter Real
+  -/
+--en Set Function Filter Asymptotics Metric Complex
+--en scoped Topology Filter Real
 
 
-variable {E : Type _} [NormedAddCommGroup E]
-
-variable [NormedSpace ℂ E] {a b C : ℝ} {f g : ℂ → E} {z : ℂ}
+variable {a b C l o p m n b v c j l k u y : ℝ}
 set_option trace.Meta.synthInstance true
-set_option trace.profiler true
+--set_option trace.profiler true
 theorem horizontal_strip
-  {d : ℝ}
-  {hb' : d * b < Real.pi}
    : True := by
   set aff : ℂ → ℂ := sorry
-  set g : ℝ → ℂ → ℂ  := fun ε w => exp (ε * (exp (aff w) + exp (-aff w)))
+  set g : ℝ → ℂ → ℂ  := fun ε w => (ε * ( (aff w) ))
   sorry

--- a/test/Set.lean
+++ b/test/Set.lean
@@ -6,7 +6,7 @@ Authors: Ian Benway.
 
 import Mathlib.Tactic.Set
 import Mathlib.Tactic.Basic
-import Qq
+import Mathlib.Util.SleepHeartbeats
 
 example (x : Nat) (h : x = x) : x = x := by
   set! p := h
@@ -36,22 +36,6 @@ example (x : Nat) (h : x - x = 0) : x = x := by
 example : True := by
   set g : Nat → Int := (fun ε => ε) with h
   trivial
-
-open Lean Elab
-
-def sleepAtLeastHeartbeats (n : Nat) : CoreM Unit := do
-  let i ← IO.getNumHeartbeats
-  while (← IO.getNumHeartbeats) < i + n do
-    continue
-
-elab "sleep_heartbeats" n:num : tactic => do
-  match Syntax.isNatLit? n with
-  | none    => throwIllFormedSyntax
-  | some m => sleepAtLeastHeartbeats (m * 1000)
-
-example {a b c d e f g h : ℕ} : 1 = 1 := by
-  sleep_heartbeats 1000
-  rfl
 
 -- simulate a slow to elaborate term
 open Qq in

--- a/test/Set.lean
+++ b/test/Set.lean
@@ -6,6 +6,10 @@ Authors: Ian Benway.
 
 import Mathlib.Tactic.Set
 import Mathlib.Tactic.Basic
+import Mathlib.Data.Complex.Exponential
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
+import Mathlib.Analysis.Complex.AbsMax
+import Mathlib.Analysis.Asymptotics.SuperpolynomialDecay
 
 example (x : Nat) (h : x = x) : x = x := by
   set! p := h
@@ -35,3 +39,28 @@ example (x : Nat) (h : x - x = 0) : x = x := by
 example : True := by
   set g : Nat → Int := (fun ε => ε) with h
   trivial
+
+open Complex
+open scoped Real
+example : True := by
+  let a : ℝ := sorry
+  let d : ℝ  := sorry
+  set aff : ℂ → ℂ := (fun w => d * (w - a * I) )
+  set g : ℝ → ℂ → ℂ  := fun ε w => exp (ε * (exp (aff w) + exp (-aff w)))
+  sorry
+open Set Function Filter Asymptotics Metric Complex
+open scoped Topology Filter Real
+
+
+variable {E : Type _} [NormedAddCommGroup E]
+
+variable [NormedSpace ℂ E] {a b C : ℝ} {f g : ℂ → E} {z : ℂ}
+set_option trace.Meta.synthInstance true
+set_option trace.profiler true
+theorem horizontal_strip
+  {d : ℝ}
+  {hb' : d * b < Real.pi}
+   : True := by
+  set aff : ℂ → ℂ := sorry
+  set g : ℝ → ℂ → ℂ  := fun ε w => exp (ε * (exp (aff w) + exp (-aff w)))
+  sorry

--- a/test/Set.lean
+++ b/test/Set.lean
@@ -7,6 +7,7 @@ Authors: Ian Benway.
 import Mathlib.Tactic.Set
 import Mathlib.Tactic.Basic
 import Mathlib.Util.SleepHeartbeats
+import Qq
 
 example (x : Nat) (h : x = x) : x = x := by
   set! p := h

--- a/test/Set.lean
+++ b/test/Set.lean
@@ -7,7 +7,7 @@ Authors: Ian Benway.
 import Mathlib.Tactic.Set
 import Mathlib.Tactic.Basic
 import Mathlib.Data.Complex.Basic
-import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
+import Mathlib.Analysis.SpecificLimits.Basic
 --import Mathlib.Analysis.Complex.AbsMax
 --import Mathlib.Analysis.Asymptotics.SuperpolynomialDecay
 
@@ -55,7 +55,7 @@ example : True := by
 
 variable {a b C l o p m n b v c j l k u y : ℝ}
 set_option trace.Meta.synthInstance true
---set_option trace.profiler true
+set_option trace.profiler true
 theorem horizontal_strip
    : True := by
   set aff : ℂ → ℂ := sorry

--- a/test/Set.lean
+++ b/test/Set.lean
@@ -45,7 +45,7 @@ elab "test" : term => do
   return q((1 : Nat))
 
 -- this will timeout if test is elaborated multiple times
-set_option maxHeartbeats 2000 in
+set_option maxHeartbeats 3000 in
 example {a b c d e f g h : Nat} : 1 = 1 := by
   set a : Nat := test with h
   trivial

--- a/test/Set.lean
+++ b/test/Set.lean
@@ -7,9 +7,18 @@ Authors: Ian Benway.
 import Mathlib.Tactic.Set
 import Mathlib.Tactic.Basic
 import Mathlib.Data.Complex.Basic
-import Mathlib.Analysis.SpecificLimits.Basic
---import Mathlib.Analysis.Complex.AbsMax
---import Mathlib.Analysis.Asymptotics.SuperpolynomialDecay
+-- import Mathlib.RingTheory.Ideal.Operations
+-- import Mathlib.Algebra.Algebra.Operations
+import Mathlib.Algebra.Algebra.Bilinear
+import Mathlib.Algebra.Algebra.Equiv
+-- import Mathlib.Algebra.Module.Submodule.Pointwise
+-- import Mathlib.Algebra.Module.Submodule.Bilinear
+-- import Mathlib.Algebra.Module.Opposites
+import Mathlib.Algebra.Order.Kleene
+-- import Mathlib.Data.Finset.Pointwise
+-- import Mathlib.Data.Set.Semiring
+-- import Mathlib.Data.Set.Pointwise.BigOperators
+-- import Mathlib.GroupTheory.GroupAction.SubMulAction.Pointwise
 
 example (x : Nat) (h : x = x) : x = x := by
   set! p := h
@@ -54,8 +63,8 @@ example : True := by
 
 
 variable {a b C l o p m n b v c j l k u y : ℝ}
-set_option trace.Meta.synthInstance true
-set_option trace.profiler true
+-- set_option trace.Meta.synthInstance true
+-- set_option trace.profiler true
 theorem horizontal_strip
    : True := by
   set aff : ℂ → ℂ := sorry


### PR DESCRIPTION
Fix the set tactic to not time out when dealing with slow to elaborate terms and many local hypotheses.

The root cause of this is that the `rewrite [blah] at *` tactic causes blah to be elaborated again and again for each local hypothesis, this is possibly a core issue that should be fixed separately, but in `set` we have the elaborated term already so we can just use it.

We also add some functionality to simply test / demonstrate failures when elaboration takes too long, namely `sleepAtLeastHeartbeats` and a `sleep_heartbeats` tactic.

@urkud was facing some slow running set's in https://github.com/leanprover-community/mathlib4/pull/4912, see https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Timeout.20in.20.60set.20.2E.2E.20with.60/near/367958828 that this issue was minimized from and should fix.

Some other linter failures show up due to changes to the set internals so fix these too.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
