### PR TITLE
[Merged by Bors] - fix: docstring for CategoryTheory.Limits.HasFiniteProducts

### DIFF
--- a/Mathlib/CategoryTheory/Limits/Shapes/FiniteProducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/FiniteProducts.lean
@@ -62,7 +62,7 @@ theorem hasFiniteProducts_of_hasProducts [HasProducts.{w} C] : HasFiniteProducts
   ⟨fun _ => hasLimitsOfShape_of_equivalence (Discrete.equivalence Equiv.ulift.{w})⟩
 #align category_theory.limits.has_finite_products_of_has_products CategoryTheory.Limits.hasFiniteProducts_of_hasProducts
 
-/-- A category has finite coproducts if there is a chosen colimit for every diagram
+/-- A category has finite coproducts if there exists a colimit for every diagram
 with shape `Discrete J`, where we have `[Fintype J]`.
 
 We require this condition only for `J = Fin n` in the definition, then deduce a version for any

--- a/Mathlib/CategoryTheory/Limits/Shapes/FiniteProducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/FiniteProducts.lean
@@ -28,7 +28,7 @@ namespace CategoryTheory.Limits
 
 variable (C : Type u) [Category.{v} C]
 
-/-- A category has finite products if there is a chosen limit for every diagram
+/-- A category has finite products if there exists a limit for every diagram
 with shape `Discrete J`, where we have `[Finite J]`.
 
 We require this condition only for `J = Fin n` in the definition, then deduce a version for any


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

My reading of what's going on here is that the docstring for `HasFiniteProducts` is incorrectly claiming that this instance contains data. When the instance was [created in mathlib3](https://github.com/leanprover-community/mathlib/blob/5680428f3f2d98cbd7f2100ebc78d2244acf57c9/src/category_theory/limits/shapes/finite_products.lean#L17-L24) this was the case, but this was changed in https://github.com/leanprover-community/mathlib/pull/3995 .

Same story for `HasFiniteCoproducts`.
