### PR TITLE
[Merged by Bors] - feat: add reverse induction principle for Vector

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1755,6 +1755,7 @@ import Mathlib.Data.UnionFind
 import Mathlib.Data.Vector
 import Mathlib.Data.Vector.Basic
 import Mathlib.Data.Vector.Mem
+import Mathlib.Data.Vector.Snoc
 import Mathlib.Data.Vector.Zip
 import Mathlib.Data.Vector3
 import Mathlib.Data.W.Basic

--- a/Mathlib/Data/Vector/Basic.lean
+++ b/Mathlib/Data/Vector/Basic.lean
@@ -813,17 +813,19 @@ theorem get_map₂ (v₁ : Vector α n) (v₂ : Vector β n) (f : α → β → 
 
 
 @[simp]
-theorem mapAccumr_cons :  mapAccumr f (x ::ᵥ xs) s
-                          = let r := mapAccumr f xs s
-                            let q := f x r.1
-                            (q.1, q.2 ::ᵥ r.2) :=
+theorem mapAccumr_cons :
+    mapAccumr f (x ::ᵥ xs) s
+    = let r := mapAccumr f xs s
+      let q := f x r.1
+      (q.1, q.2 ::ᵥ r.2) :=
   rfl
 
 @[simp]
-theorem mapAccumr₂_cons : mapAccumr₂ f (x ::ᵥ xs) (y ::ᵥ ys) s
-                          = let r := mapAccumr₂ f xs ys s
-                            let q := f x y r.1
-                            (q.1, q.2 ::ᵥ r.2) :=
+theorem mapAccumr₂_cons :
+    mapAccumr₂ f (x ::ᵥ xs) (y ::ᵥ ys) s
+    = let r := mapAccumr₂ f xs ys s
+      let q := f x y r.1
+      (q.1, q.2 ::ᵥ r.2) :=
   rfl
 
 end Simp

--- a/Mathlib/Data/Vector/Basic.lean
+++ b/Mathlib/Data/Vector/Basic.lean
@@ -770,25 +770,32 @@ instance : IsLawfulTraversable.{u} (flip Vector n) where
 
 section Simp
 
-variable (xs : Vector α n) (ys : Vector α m)
+variable (xs : Vector α n)
 
 @[simp]
 theorem replicate_succ (val : α) :
     replicate (n+1) val = val ::ᵥ (replicate n val) :=
   rfl
 
-@[simp]
-theorem get_append_cons_zero : get (append (x ::ᵥ xs) ys) ⟨0, by simp⟩ = x :=
-  rfl
+section Append
+  variable (ys : Vector α m)
 
-@[simp]
-theorem get_append_cons_succ {i : Fin (n + m)} {h} :
-    get (append (x ::ᵥ xs) ys) ⟨i+1, h⟩ = get (append xs ys) i :=
-  rfl
+  @[simp]
+  theorem get_append_cons_zero : get (append (x ::ᵥ xs) ys) ⟨0, by simp⟩ = x :=
+    rfl
 
-@[simp]
-theorem append_nil : append xs nil = xs := by
-  cases xs; simp [append]
+  @[simp]
+  theorem get_append_cons_succ {i : Fin (n + m)} {h} :
+      get (append (x ::ᵥ xs) ys) ⟨i+1, h⟩ = get (append xs ys) i :=
+    rfl
+
+  @[simp]
+  theorem append_nil : append xs nil = xs := by
+    cases xs; simp [append]
+
+end Append
+
+variable (ys : Vector β n)
 
 @[simp]
 theorem get_map₂ (v₁ : Vector α n) (v₂ : Vector β n) (f : α → β → γ) (i : Fin n) :
@@ -802,6 +809,22 @@ theorem get_map₂ (v₁ : Vector α n) (v₂ : Vector β n) (f : α → β → 
     cases i using Fin.cases
     . simp only [get_zero, head_cons]
     . simp only [get_cons_succ, ih]
+
+
+
+@[simp]
+theorem mapAccumr_cons :  mapAccumr f (x ::ᵥ xs) s
+                          = let r := mapAccumr f xs s
+                            let q := f x r.1
+                            (q.1, q.2 ::ᵥ r.2) :=
+  rfl
+
+@[simp]
+theorem mapAccumr₂_cons : mapAccumr₂ f (x ::ᵥ xs) (y ::ᵥ ys) s
+                          = let r := mapAccumr₂ f xs ys s
+                            let q := f x y r.1
+                            (q.1, q.2 ::ᵥ r.2) :=
+  rfl
 
 end Simp
 

--- a/Mathlib/Data/Vector/Basic.lean
+++ b/Mathlib/Data/Vector/Basic.lean
@@ -778,20 +778,20 @@ theorem replicate_succ (val : α) :
   rfl
 
 section Append
-  variable (ys : Vector α m)
+variable (ys : Vector α m)
 
-  @[simp]
-  theorem get_append_cons_zero : get (append (x ::ᵥ xs) ys) ⟨0, by simp⟩ = x :=
-    rfl
+@[simp]
+theorem get_append_cons_zero : get (append (x ::ᵥ xs) ys) ⟨0, by simp⟩ = x :=
+  rfl
 
-  @[simp]
-  theorem get_append_cons_succ {i : Fin (n + m)} {h} :
-      get (append (x ::ᵥ xs) ys) ⟨i+1, h⟩ = get (append xs ys) i :=
-    rfl
+@[simp]
+theorem get_append_cons_succ {i : Fin (n + m)} {h} :
+    get (append (x ::ᵥ xs) ys) ⟨i+1, h⟩ = get (append xs ys) i :=
+  rfl
 
-  @[simp]
-  theorem append_nil : append xs nil = xs := by
-    cases xs; simp [append]
+@[simp]
+theorem append_nil : append xs nil = xs := by
+  cases xs; simp [append]
 
 end Append
 

--- a/Mathlib/Data/Vector/Snoc.lean
+++ b/Mathlib/Data/Vector/Snoc.lean
@@ -27,6 +27,7 @@ namespace Vector
   ## Simplification lemmas
   -/
   section Simp
+    variable (xs : Vector α n)
 
   @[simp]
   theorem snoc_cons : (x ::ᵥ xs).snoc y = x ::ᵥ (xs.snoc y) :=
@@ -51,7 +52,9 @@ namespace Vector
     rfl
 
 
-  theorem replicate_succ_to_snoc : replicate (n+1) val = (replicate n val).snoc val := by
+  theorem replicate_succ_to_snoc (val : α) :
+      replicate (n+1) val = (replicate n val).snoc val := by
+    clear xs
     induction n
     case zero => rfl
     case succ n ih =>
@@ -122,6 +125,7 @@ namespace Vector
   -/
 
   section Simp
+    variable (xs : Vector α n)
 
 
   @[simp]
@@ -129,18 +133,7 @@ namespace Vector
     induction xs using Vector.inductionOn <;> simp_all
 
   @[simp]
-  theorem map₂_snoc : map₂ f (xs.snoc x) (ys.snoc y) = (map₂ f xs ys).snoc (f x y) := by
-    induction xs, ys using Vector.inductionOn₂ <;> simp_all
-
-  @[simp]
   theorem mapAccumr_nil : mapAccumr f Vector.nil s = (s, Vector.nil) :=
-    rfl
-
-  @[simp]
-  theorem mapAccumr_cons :  mapAccumr f (x ::ᵥ xs) s
-                            = let r := mapAccumr f xs s
-                              let q := f x r.1
-                              (q.1, q.2 ::ᵥ r.2) :=
     rfl
 
   @[simp]
@@ -152,20 +145,18 @@ namespace Vector
     . rfl
     . simp[*]
 
+  variable (ys : Vector β n)
+
+  @[simp]
+  theorem map₂_snoc : map₂ f (xs.snoc x) (ys.snoc y) = (map₂ f xs ys).snoc (f x y) := by
+    induction xs, ys using Vector.inductionOn₂ <;> simp_all
+
   @[simp]
   theorem mapAccumr₂_nil : mapAccumr₂ f Vector.nil Vector.nil s = (s, Vector.nil) :=
     rfl
 
   @[simp]
-  theorem mapAccumr₂_cons : mapAccumr₂ f (x ::ᵥ xs) (y ::ᵥ ys) s =
-                              let r := mapAccumr₂ f xs ys s
-                              let q := f x y r.1
-                              (q.1, q.2 ::ᵥ r.2) :=
-    rfl
-
-  @[simp]
-  theorem mapAccumr₂_snoc (f : α → β → σ → σ × φ) (xs : Vector α n) (ys : Vector β n)
-                          (x : α) (y : β) :
+  theorem mapAccumr₂_snoc (f : α → β → σ → σ × φ) (x : α) (y : β) :
     mapAccumr₂ f (xs.snoc x) (ys.snoc y) c
         = let q := f x y c
           let r := mapAccumr₂ f xs ys q.1

--- a/Mathlib/Data/Vector/Snoc.lean
+++ b/Mathlib/Data/Vector/Snoc.lean
@@ -18,150 +18,150 @@ import Mathlib.Data.Vector.Basic
 
 namespace Vector
 
-  /-- Append a single element to the end of a vector -/
-  def snoc : Vector α n → α → Vector α (n+1) :=
-    fun xs x => append xs (x ::ᵥ Vector.nil)
+/-- Append a single element to the end of a vector -/
+def snoc : Vector α n → α → Vector α (n+1) :=
+  fun xs x => append xs (x ::ᵥ Vector.nil)
 
 
-  /-!
-  ## Simplification lemmas
-  -/
-  section Simp
-    variable (xs : Vector α n)
+/-!
+## Simplification lemmas
+-/
+section Simp
+  variable (xs : Vector α n)
 
-  @[simp]
-  theorem snoc_cons : (x ::ᵥ xs).snoc y = x ::ᵥ (xs.snoc y) :=
-    rfl
+@[simp]
+theorem snoc_cons : (x ::ᵥ xs).snoc y = x ::ᵥ (xs.snoc y) :=
+  rfl
 
-  @[simp]
-  theorem snoc_nil : (nil.snoc x) = x ::ᵥ nil :=
-    rfl
+@[simp]
+theorem snoc_nil : (nil.snoc x) = x ::ᵥ nil :=
+  rfl
 
-  @[simp]
-  theorem reverse_cons : reverse (x ::ᵥ xs) = (reverse xs).snoc x := by
-    cases xs
-    simp only [reverse, cons, toList_mk, List.reverse_cons, snoc]
-    congr
+@[simp]
+theorem reverse_cons : reverse (x ::ᵥ xs) = (reverse xs).snoc x := by
+  cases xs
+  simp only [reverse, cons, toList_mk, List.reverse_cons, snoc]
+  congr
 
-  @[simp]
-  theorem reverse_snoc : reverse (xs.snoc x) = x ::ᵥ (reverse xs) := by
-    cases xs
-    simp only [reverse, snoc, cons, toList_mk]
-    congr
-    simp[toList, (·++·), Vector.append, Append.append]
-    rfl
-
-
-  theorem replicate_succ_to_snoc (val : α) :
-      replicate (n+1) val = (replicate n val).snoc val := by
-    clear xs
-    induction n
-    case zero => rfl
-    case succ n ih =>
-      rw[replicate_succ]
-      conv => {
-        rhs; rw[replicate_succ]
-      }
-      rw[snoc_cons, ih]
-
-  end Simp
+@[simp]
+theorem reverse_snoc : reverse (xs.snoc x) = x ::ᵥ (reverse xs) := by
+  cases xs
+  simp only [reverse, snoc, cons, toList_mk]
+  congr
+  simp[toList, (·++·), Vector.append, Append.append]
+  rfl
 
 
-  /-!
-  ## Reverse induction principle
-  -/
-  section Induction
+theorem replicate_succ_to_snoc (val : α) :
+    replicate (n+1) val = (replicate n val).snoc val := by
+  clear xs
+  induction n
+  case zero => rfl
+  case succ n ih =>
+    rw[replicate_succ]
+    conv => {
+      rhs; rw[replicate_succ]
+    }
+    rw[snoc_cons, ih]
 
-  /-- Define `C v` by *reverse* induction on `v : Vector α n`.
-      That is, break the vector down starting from the right-most element, using `snoc`
-
-      This function has two arguments: `nil` handles the base case on `C nil`,
-      and `snoc` defines the inductive step using `∀ x : α, C xs → C (xs.snoc x)`.
-
-      This can be used as `induction v using Vector.revInductionOn`. -/
-  @[elab_as_elim]
-  def revInductionOn {C : ∀ {n : ℕ}, Vector α n → Sort _} {n : ℕ} (v : Vector α n)
-      (nil : C nil)
-      (snoc : ∀ {n : ℕ} (xs : Vector α n) (x : α), C xs → C (xs.snoc x)) :
-      C v :=
-    cast (by simp) <| inductionOn
-      (C := fun v => C v.reverse)
-      v.reverse
-      nil
-      (@fun n x xs (r : C xs.reverse) => cast (by simp) <| snoc xs.reverse x r)
-
-  /-- Define `C v w` by *reverse* induction on a pair of vectors `v : Vector α n` and
-      `w : Vector β n`. -/
-  @[elab_as_elim]
-  def revInductionOn₂ {C : ∀ {n : ℕ}, Vector α n → Vector β n → Sort _} {n : ℕ}
-      (v : Vector α n) (w : Vector β n)
-      (nil : C nil nil)
-      (snoc : ∀ {n : ℕ} (xs : Vector α n) (ys : Vector β n) (x : α) (y : β),
-        C xs ys → C (xs.snoc x) (ys.snoc y)) :
-      C v w :=
-    cast (by simp) <| inductionOn₂
-      (C := fun v w => C v.reverse w.reverse)
-      v.reverse
-      w.reverse
-      nil
-      (@fun n x y xs ys (r : C xs.reverse ys.reverse) =>
-        cast (by simp) <| snoc xs.reverse ys.reverse x y r)
-
-  /-- Define `C v` by *reverse* case analysis, i.e. by handling the cases `nil` and `xs.snoc x`
-      separately -/
-  @[elab_as_elim]
-  def revCasesOn {C : ∀ {n : ℕ}, Vector α n → Sort _} {n : ℕ} (v : Vector α n)
-      (nil : C nil)
-      (snoc : ∀ {n : ℕ} (xs : Vector α n) (x : α), C (xs.snoc x)) :
-      C v :=
-    revInductionOn v nil fun xs x _ => snoc xs x
-  end Induction
+end Simp
 
 
+/-!
+## Reverse induction principle
+-/
+section Induction
 
-  /-!
-  ## More simplification lemmas
-  -/
+/-- Define `C v` by *reverse* induction on `v : Vector α n`.
+    That is, break the vector down starting from the right-most element, using `snoc`
 
-  section Simp
-    variable (xs : Vector α n)
+    This function has two arguments: `nil` handles the base case on `C nil`,
+    and `snoc` defines the inductive step using `∀ x : α, C xs → C (xs.snoc x)`.
+
+    This can be used as `induction v using Vector.revInductionOn`. -/
+@[elab_as_elim]
+def revInductionOn {C : ∀ {n : ℕ}, Vector α n → Sort _} {n : ℕ} (v : Vector α n)
+    (nil : C nil)
+    (snoc : ∀ {n : ℕ} (xs : Vector α n) (x : α), C xs → C (xs.snoc x)) :
+    C v :=
+  cast (by simp) <| inductionOn
+    (C := fun v => C v.reverse)
+    v.reverse
+    nil
+    (@fun n x xs (r : C xs.reverse) => cast (by simp) <| snoc xs.reverse x r)
+
+/-- Define `C v w` by *reverse* induction on a pair of vectors `v : Vector α n` and
+    `w : Vector β n`. -/
+@[elab_as_elim]
+def revInductionOn₂ {C : ∀ {n : ℕ}, Vector α n → Vector β n → Sort _} {n : ℕ}
+    (v : Vector α n) (w : Vector β n)
+    (nil : C nil nil)
+    (snoc : ∀ {n : ℕ} (xs : Vector α n) (ys : Vector β n) (x : α) (y : β),
+      C xs ys → C (xs.snoc x) (ys.snoc y)) :
+    C v w :=
+  cast (by simp) <| inductionOn₂
+    (C := fun v w => C v.reverse w.reverse)
+    v.reverse
+    w.reverse
+    nil
+    (@fun n x y xs ys (r : C xs.reverse ys.reverse) =>
+      cast (by simp) <| snoc xs.reverse ys.reverse x y r)
+
+/-- Define `C v` by *reverse* case analysis, i.e. by handling the cases `nil` and `xs.snoc x`
+    separately -/
+@[elab_as_elim]
+def revCasesOn {C : ∀ {n : ℕ}, Vector α n → Sort _} {n : ℕ} (v : Vector α n)
+    (nil : C nil)
+    (snoc : ∀ {n : ℕ} (xs : Vector α n) (x : α), C (xs.snoc x)) :
+    C v :=
+  revInductionOn v nil fun xs x _ => snoc xs x
+end Induction
 
 
-  @[simp]
-  theorem map_snoc : map f (xs.snoc x) = (map f xs).snoc (f x) := by
-    induction xs using Vector.inductionOn <;> simp_all
 
-  @[simp]
-  theorem mapAccumr_nil : mapAccumr f Vector.nil s = (s, Vector.nil) :=
-    rfl
+/-!
+## More simplification lemmas
+-/
 
-  @[simp]
-  theorem mapAccumr_snoc :
-      mapAccumr f (xs.snoc x) s
-      = let q := f x s
-        let r := mapAccumr f xs q.1
-        (r.1, r.2.snoc q.2) := by
-    induction xs using Vector.inductionOn
-    . rfl
-    . simp[*]
+section Simp
+  variable (xs : Vector α n)
 
-  variable (ys : Vector β n)
 
-  @[simp]
-  theorem map₂_snoc : map₂ f (xs.snoc x) (ys.snoc y) = (map₂ f xs ys).snoc (f x y) := by
-    induction xs, ys using Vector.inductionOn₂ <;> simp_all
+@[simp]
+theorem map_snoc : map f (xs.snoc x) = (map f xs).snoc (f x) := by
+  induction xs using Vector.inductionOn <;> simp_all
 
-  @[simp]
-  theorem mapAccumr₂_nil : mapAccumr₂ f Vector.nil Vector.nil s = (s, Vector.nil) :=
-    rfl
+@[simp]
+theorem mapAccumr_nil : mapAccumr f Vector.nil s = (s, Vector.nil) :=
+  rfl
 
-  @[simp]
-  theorem mapAccumr₂_snoc (f : α → β → σ → σ × φ) (x : α) (y : β) :
-      mapAccumr₂ f (xs.snoc x) (ys.snoc y) c
-      = let q := f x y c
-        let r := mapAccumr₂ f xs ys q.1
-        (r.1, r.2.snoc q.2) := by
-    induction xs, ys using Vector.inductionOn₂ <;> simp_all
+@[simp]
+theorem mapAccumr_snoc :
+    mapAccumr f (xs.snoc x) s
+    = let q := f x s
+      let r := mapAccumr f xs q.1
+      (r.1, r.2.snoc q.2) := by
+  induction xs using Vector.inductionOn
+  . rfl
+  . simp[*]
 
-  end Simp
+variable (ys : Vector β n)
+
+@[simp]
+theorem map₂_snoc : map₂ f (xs.snoc x) (ys.snoc y) = (map₂ f xs ys).snoc (f x y) := by
+  induction xs, ys using Vector.inductionOn₂ <;> simp_all
+
+@[simp]
+theorem mapAccumr₂_nil : mapAccumr₂ f Vector.nil Vector.nil s = (s, Vector.nil) :=
+  rfl
+
+@[simp]
+theorem mapAccumr₂_snoc (f : α → β → σ → σ × φ) (x : α) (y : β) :
+    mapAccumr₂ f (xs.snoc x) (ys.snoc y) c
+    = let q := f x y c
+      let r := mapAccumr₂ f xs ys q.1
+      (r.1, r.2.snoc q.2) := by
+  induction xs, ys using Vector.inductionOn₂ <;> simp_all
+
+end Simp
 end Vector

--- a/Mathlib/Data/Vector/Snoc.lean
+++ b/Mathlib/Data/Vector/Snoc.lean
@@ -48,7 +48,7 @@ theorem reverse_snoc : reverse (xs.snoc x) = x ::ᵥ (reverse xs) := by
   cases xs
   simp only [reverse, snoc, cons, toList_mk]
   congr
-  simp[toList, (·++·), Vector.append, Append.append]
+  simp [toList, (·++·), Vector.append, Append.append]
   rfl
 
 
@@ -58,9 +58,9 @@ theorem replicate_succ_to_snoc (val : α) :
   induction n
   case zero => rfl
   case succ n ih =>
-    rw[replicate_succ]
+    rw [replicate_succ]
     conv => {
-      rhs; rw[replicate_succ]
+      rhs; rw [replicate_succ]
     }
     rw[snoc_cons, ih]
 
@@ -115,17 +115,16 @@ def revCasesOn {C : ∀ {n : ℕ}, Vector α n → Sort _} {n : ℕ} (v : Vector
     (snoc : ∀ {n : ℕ} (xs : Vector α n) (x : α), C (xs.snoc x)) :
     C v :=
   revInductionOn v nil fun xs x _ => snoc xs x
+  
 end Induction
-
-
 
 /-!
 ## More simplification lemmas
 -/
 
 section Simp
-  variable (xs : Vector α n)
 
+variable (xs : Vector α n)
 
 @[simp]
 theorem map_snoc : map f (xs.snoc x) = (map f xs).snoc (f x) := by

--- a/Mathlib/Data/Vector/Snoc.lean
+++ b/Mathlib/Data/Vector/Snoc.lean
@@ -81,9 +81,9 @@ namespace Vector
       This can be used as `induction v using Vector.revInductionOn`. -/
   @[elab_as_elim]
   def revInductionOn {C : ∀ {n : ℕ}, Vector α n → Sort _} {n : ℕ} (v : Vector α n)
-                      (nil : C nil)
-                      (snoc : ∀ {n : ℕ} (xs : Vector α n) (x : α), C xs → C (xs.snoc x))
-                      : C v :=
+      (nil : C nil)
+      (snoc : ∀ {n : ℕ} (xs : Vector α n) (x : α), C xs → C (xs.snoc x)) :
+      C v :=
     cast (by simp) <| inductionOn
       (C := fun v => C v.reverse)
       v.reverse
@@ -94,12 +94,11 @@ namespace Vector
       `w : Vector β n`. -/
   @[elab_as_elim]
   def revInductionOn₂ {C : ∀ {n : ℕ}, Vector α n → Vector β n → Sort _} {n : ℕ}
-                      (v : Vector α n)
-                      (w : Vector β n)
-                      (nil : C nil nil)
-                      (snoc : ∀ {n : ℕ} (xs : Vector α n) (ys : Vector β n) (x : α) (y : β),
-                              C xs ys → C (xs.snoc x) (ys.snoc y))
-                      : C v w :=
+      (v : Vector α n) (w : Vector β n)
+      (nil : C nil nil)
+      (snoc : ∀ {n : ℕ} (xs : Vector α n) (ys : Vector β n) (x : α) (y : β),
+        C xs ys → C (xs.snoc x) (ys.snoc y)) :
+      C v w :=
     cast (by simp) <| inductionOn₂
       (C := fun v w => C v.reverse w.reverse)
       v.reverse
@@ -112,9 +111,9 @@ namespace Vector
       separately -/
   @[elab_as_elim]
   def revCasesOn {C : ∀ {n : ℕ}, Vector α n → Sort _} {n : ℕ} (v : Vector α n)
-                    (nil : C nil)
-                    (snoc : ∀ {n : ℕ} (xs : Vector α n) (x : α), C (xs.snoc x))
-                      : C v :=
+      (nil : C nil)
+      (snoc : ∀ {n : ℕ} (xs : Vector α n) (x : α), C (xs.snoc x)) :
+      C v :=
     revInductionOn v nil fun xs x _ => snoc xs x
   end Induction
 
@@ -137,10 +136,11 @@ namespace Vector
     rfl
 
   @[simp]
-  theorem mapAccumr_snoc :  mapAccumr f (xs.snoc x) s
-                            = let q := f x s
-                              let r := mapAccumr f xs q.1
-                              (r.1, r.2.snoc q.2) := by
+  theorem mapAccumr_snoc :
+      mapAccumr f (xs.snoc x) s
+      = let q := f x s
+        let r := mapAccumr f xs q.1
+        (r.1, r.2.snoc q.2) := by
     induction xs using Vector.inductionOn
     . rfl
     . simp[*]
@@ -157,10 +157,10 @@ namespace Vector
 
   @[simp]
   theorem mapAccumr₂_snoc (f : α → β → σ → σ × φ) (x : α) (y : β) :
-    mapAccumr₂ f (xs.snoc x) (ys.snoc y) c
-        = let q := f x y c
-          let r := mapAccumr₂ f xs ys q.1
-          (r.1, r.2.snoc q.2) := by
+      mapAccumr₂ f (xs.snoc x) (ys.snoc y) c
+      = let q := f x y c
+        let r := mapAccumr₂ f xs ys q.1
+        (r.1, r.2.snoc q.2) := by
     induction xs, ys using Vector.inductionOn₂ <;> simp_all
 
   end Simp

--- a/Mathlib/Data/Vector/Snoc.lean
+++ b/Mathlib/Data/Vector/Snoc.lean
@@ -102,7 +102,8 @@ namespace Vector
       v.reverse
       w.reverse
       nil
-      (@fun n x y xs ys (r : C xs.reverse ys.reverse) => cast (by simp) <| snoc xs.reverse ys.reverse x y r)
+      (@fun n x y xs ys (r : C xs.reverse ys.reverse) =>
+        cast (by simp) <| snoc xs.reverse ys.reverse x y r)
 
   /-- Define `C v` by *reverse* case analysis, i.e. by handling the cases `nil` and `xs.snoc x`
       separately -/

--- a/Mathlib/Data/Vector/Snoc.lean
+++ b/Mathlib/Data/Vector/Snoc.lean
@@ -1,0 +1,175 @@
+/-
+Copyright (c) 2023 Alex Keizer. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Alex Keizer
+-/
+import Mathlib.Data.Vector.Basic
+
+/-!
+  This file establishes a `snoc : Vector α n → α → Vector α (n+1)` operation, that appends a single
+  element to the back of a vector.
+
+  It provides a collection of lemmas that show how different `Vector` operations reduce when their
+  argument is `snoc xs x`.
+
+  Also, an alternative, reverse, induction principle is added, that breaks down a vector into
+  `snoc xs x` for its inductive case. Effectively doing induction from right-to-left
+-/
+
+namespace Vector
+
+  /-- Append a single element to the end of a vector -/
+  def snoc : Vector α n → α → Vector α (n+1) :=
+    fun xs x => append xs (x ::ᵥ Vector.nil)
+
+
+  /-!
+  ## Simplification lemmas
+  -/
+  section Simp
+
+  @[simp]
+  theorem snoc_cons : (x ::ᵥ xs).snoc y = x ::ᵥ (xs.snoc y) :=
+    rfl
+
+  @[simp]
+  theorem snoc_nil : (nil.snoc x) = x ::ᵥ nil :=
+    rfl
+
+  @[simp]
+  theorem reverse_cons : reverse (x ::ᵥ xs) = (reverse xs).snoc x := by
+    cases xs
+    simp only [reverse, cons, toList_mk, List.reverse_cons, snoc]
+    congr
+
+  @[simp]
+  theorem reverse_snoc : reverse (xs.snoc x) = x ::ᵥ (reverse xs) := by
+    cases xs
+    simp only [reverse, snoc, cons, toList_mk]
+    congr
+    simp[toList, (·++·), Vector.append, Append.append]
+    rfl
+
+
+  theorem replicate_succ_to_snoc : replicate (n+1) val = (replicate n val).snoc val := by
+    induction n
+    case zero => rfl
+    case succ n ih =>
+      rw[replicate_succ]
+      conv => {
+        rhs; rw[replicate_succ]
+      }
+      rw[snoc_cons, ih]
+
+  end Simp
+
+
+  /-!
+  ## Reverse induction principle
+  -/
+  section Induction
+
+  /-- Define `C v` by *reverse* induction on `v : Vector α n`.
+      That is, break the vector down starting from the right-most element, using `snoc`
+
+      This function has two arguments: `nil` handles the base case on `C nil`,
+      and `snoc` defines the inductive step using `∀ x : α, C xs → C (xs.snoc x)`.
+
+      This can be used as `induction v using Vector.revInductionOn`. -/
+  @[elab_as_elim]
+  def revInductionOn {C : ∀ {n : ℕ}, Vector α n → Sort _} {n : ℕ} (v : Vector α n)
+                      (nil : C nil)
+                      (snoc : ∀ {n : ℕ} (xs : Vector α n) (x : α), C xs → C (xs.snoc x))
+                      : C v :=
+    cast (by simp) <| inductionOn
+      (C := fun v => C v.reverse)
+      v.reverse
+      nil
+      (@fun n x xs (r : C xs.reverse) => cast (by simp) <| snoc xs.reverse x r)
+
+  /-- Define `C v w` by *reverse* induction on a pair of vectors `v : Vector α n` and
+      `w : Vector β n`. -/
+  @[elab_as_elim]
+  def revInductionOn₂ {C : ∀ {n : ℕ}, Vector α n → Vector β n → Sort _} {n : ℕ}
+                      (v : Vector α n)
+                      (w : Vector β n)
+                      (nil : C nil nil)
+                      (snoc : ∀ {n : ℕ} (xs : Vector α n) (ys : Vector β n) (x : α) (y : β),
+                              C xs ys → C (xs.snoc x) (ys.snoc y))
+                      : C v w :=
+    cast (by simp) <| inductionOn₂
+      (C := fun v w => C v.reverse w.reverse)
+      v.reverse
+      w.reverse
+      nil
+      (@fun n x y xs ys (r : C xs.reverse ys.reverse) => cast (by simp) <| snoc xs.reverse ys.reverse x y r)
+
+  /-- Define `C v` by *reverse* case analysis, i.e. by handling the cases `nil` and `xs.snoc x`
+      separately -/
+  @[elab_as_elim]
+  def revCasesOn {C : ∀ {n : ℕ}, Vector α n → Sort _} {n : ℕ} (v : Vector α n)
+                    (nil : C nil)
+                    (snoc : ∀ {n : ℕ} (xs : Vector α n) (x : α), C (xs.snoc x))
+                      : C v :=
+    revInductionOn v nil fun xs x _ => snoc xs x
+  end Induction
+
+
+
+  /-!
+  ## More simplification lemmas
+  -/
+
+  section Simp
+
+
+  @[simp]
+  theorem map_snoc : map f (xs.snoc x) = (map f xs).snoc (f x) := by
+    induction xs using Vector.inductionOn <;> simp_all
+
+  @[simp]
+  theorem map₂_snoc : map₂ f (xs.snoc x) (ys.snoc y) = (map₂ f xs ys).snoc (f x y) := by
+    induction xs, ys using Vector.inductionOn₂ <;> simp_all
+
+  @[simp]
+  theorem mapAccumr_nil : mapAccumr f Vector.nil s = (s, Vector.nil) :=
+    rfl
+
+  @[simp]
+  theorem mapAccumr_cons :  mapAccumr f (x ::ᵥ xs) s
+                            = let r := mapAccumr f xs s
+                              let q := f x r.1
+                              (q.1, q.2 ::ᵥ r.2) :=
+    rfl
+
+  @[simp]
+  theorem mapAccumr_snoc :  mapAccumr f (xs.snoc x) s
+                            = let q := f x s
+                              let r := mapAccumr f xs q.1
+                              (r.1, r.2.snoc q.2) := by
+    induction xs using Vector.inductionOn
+    . rfl
+    . simp[*]
+
+  @[simp]
+  theorem mapAccumr₂_nil : mapAccumr₂ f Vector.nil Vector.nil s = (s, Vector.nil) :=
+    rfl
+
+  @[simp]
+  theorem mapAccumr₂_cons : mapAccumr₂ f (x ::ᵥ xs) (y ::ᵥ ys) s =
+                              let r := mapAccumr₂ f xs ys s
+                              let q := f x y r.1
+                              (q.1, q.2 ::ᵥ r.2) :=
+    rfl
+
+  @[simp]
+  theorem mapAccumr₂_snoc (f : α → β → σ → σ × φ) (xs : Vector α n) (ys : Vector β n)
+                          (x : α) (y : β) :
+    mapAccumr₂ f (xs.snoc x) (ys.snoc y) c
+        = let q := f x y c
+          let r := mapAccumr₂ f xs ys q.1
+          (r.1, r.2.snoc q.2) := by
+    induction xs, ys using Vector.inductionOn₂ <;> simp_all
+
+  end Simp
+end Vector


### PR DESCRIPTION
Add a snoc pseudo-constructor, lemmas to reason about snoc, and a reverse induction principle for Vectors.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

`Vector.snoc xs x` is just a short-hand for `xs ++ [x]`.
The reverse induction principle uses `xs.snoc x` for it's recursive step, which makes it easier to reason about algorithms that work on a `Vector` right-to-left, such as `foldr` or `mapAccumr`.
The PR also add some simplification rules for `snoc` which help with such backwards proofs.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
