### PR TITLE
[Merged by Bors] - fix: use the same atom state for `abel_nf` subterms

### DIFF
--- a/Mathlib/Tactic/Abel.lean
+++ b/Mathlib/Tactic/Abel.lean
@@ -424,10 +424,13 @@ declare_config_elab elabAbelNFConfig AbelNF.Config
 /--
 The core of `abel_nf`, which rewrites the expression `e` into `abel` normal form.
 
+* `s`: a reference to the mutable state of `abel`, for persisting across calls.
+  This ensures that atom ordering is used consistently.
 * `cfg`: the configuration options
 * `e`: the expression to rewrite
 -/
-partial def abelNFCore (cfg : AbelNF.Config) (e : Expr) : MetaM Simp.Result := do
+partial def abelNFCore
+    (s : IO.Ref AtomM.State) (cfg : AbelNF.Config) (e : Expr) : MetaM Simp.Result := do
   let ctx := {
     simpTheorems := #[← Elab.Tactic.simpOnlyBuiltins.foldlM (·.addConst ·) {}]
     congrTheorems := ← getSimpCongrTheorems }
@@ -438,7 +441,6 @@ partial def abelNFCore (cfg : AbelNF.Config) (e : Expr) : MetaM Simp.Result := d
     let ctx' := { ctx with simpTheorems := #[← thms.foldlM (·.addConst ·) {:_}] }
     pure fun r' : Simp.Result ↦ do
       Simp.mkEqTrans r' (← Simp.main r'.expr ctx' (methods := Simp.DefaultMethods.methods)).1
-  let atomSt ← IO.mkRef {}
   let rec
     /-- The recursive case of `abelNF`.
     * `root`: true when the function is called directly from `abelNFCore`
@@ -453,7 +455,7 @@ partial def abelNFCore (cfg : AbelNF.Config) (e : Expr) : MetaM Simp.Result := d
           guard <| root || parent != e -- recursion guard
           let e ← withReducible <| whnf e
           guard e.isApp -- all interesting group expressions are applications
-          let (a, pa) ← eval e (← mkContext e) { red := cfg.red, evalAtom } atomSt
+          let (a, pa) ← eval e (← mkContext e) { red := cfg.red, evalAtom } s
           guard !a.isAtom
           let r ← simp { expr := a, proof? := pa }
           if ← withReducible <| isDefEq r.expr e then return .done { expr := r.expr }
@@ -468,10 +470,10 @@ partial def abelNFCore (cfg : AbelNF.Config) (e : Expr) : MetaM Simp.Result := d
 
 open Elab.Tactic Parser.Tactic
 /-- Use `abel_nf` to rewrite the main goal. -/
-def abelNFTarget (cfg : AbelNF.Config) : TacticM Unit := withMainContext do
+def abelNFTarget (s : IO.Ref AtomM.State) (cfg : AbelNF.Config) : TacticM Unit := withMainContext do
   let goal ← getMainGoal
   let tgt ← instantiateMVars (← goal.getType)
-  let r ← abelNFCore cfg tgt
+  let r ← abelNFCore s cfg tgt
   if r.expr.isConstOf ``True then
     goal.assign (← mkOfEqTrue (← r.getProof))
     replaceMainGoal []
@@ -479,11 +481,11 @@ def abelNFTarget (cfg : AbelNF.Config) : TacticM Unit := withMainContext do
     replaceMainGoal [← applySimpResultToTarget goal tgt r]
 
 /-- Use `abel_nf` to rewrite hypothesis `h`. -/
-def abelNFLocalDecl (cfg : AbelNF.Config) (fvarId : FVarId) :
+def abelNFLocalDecl (s : IO.Ref AtomM.State) (cfg : AbelNF.Config) (fvarId : FVarId) :
     TacticM Unit := withMainContext do
   let tgt ← instantiateMVars (← fvarId.getType)
   let goal ← getMainGoal
-  let myres ← abelNFCore cfg tgt
+  let myres ← abelNFCore s cfg tgt
   match ← applySimpResultToLocalDecl goal fvarId myres false with
   | none => replaceMainGoal []
   | some (_, newGoal) => replaceMainGoal [newGoal]
@@ -507,7 +509,8 @@ elab (name := abelNF) "abel_nf" tk:"!"? cfg:(config ?) loc:(location)? : tactic 
   let mut cfg ← elabAbelNFConfig cfg
   if tk.isSome then cfg := { cfg with red := .default }
   let loc := (loc.map expandLocation).getD (.targets #[] true)
-  withLocation loc (abelNFLocalDecl cfg) (abelNFTarget cfg)
+  let s ← IO.mkRef {}
+  withLocation loc (abelNFLocalDecl s cfg) (abelNFTarget s cfg)
     fun _ ↦ throwError "abel_nf failed"
 
 @[inherit_doc abelNF] macro "abel_nf!" cfg:(config)? loc:(location)? : tactic =>
@@ -520,7 +523,7 @@ elab (name := abelNF) "abel_nf" tk:"!"? cfg:(config ?) loc:(location)? : tactic 
   | `(conv| abel_nf $[!%$tk]? $(_cfg)?) => withMainContext do
     let mut cfg ← elabAbelNFConfig stx[2]
     if tk.isSome then cfg := { cfg with red := .default }
-    Conv.applySimpResult (← abelNFCore cfg (← instantiateMVars (← Conv.getLhs)))
+    Conv.applySimpResult (← abelNFCore (← IO.mkRef {}) cfg (← instantiateMVars (← Conv.getLhs)))
   | _ => Elab.throwUnsupportedSyntax
 
 @[inherit_doc abelNF] macro "abel_nf!" cfg:(config)? : conv => `(conv| abel_nf ! $(cfg)?)

--- a/test/abel.lean
+++ b/test/abel.lean
@@ -69,3 +69,6 @@ example [AddCommGroup α] : True := by
 example [AddCommGroup α] (x y z : α) : y = x + z - (x - y + z) := by
   have : True := trivial
   abel
+
+-- https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/abel.20bug.3F/near/368707560
+example [AddCommGroup A] (a b s : A) : -b + (s - a) = s - b - a := by abel_nf


### PR DESCRIPTION
As [reported on Zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/abel.20bug.3F/near/368707560).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
