### PR TITLE
[Merged by Bors] - feat: port LinearAlgebra.CliffordAlgebra.Conjugation

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1996,6 +1996,7 @@ import Mathlib.LinearAlgebra.BilinearMap
 import Mathlib.LinearAlgebra.Charpoly.Basic
 import Mathlib.LinearAlgebra.Charpoly.ToMatrix
 import Mathlib.LinearAlgebra.CliffordAlgebra.Basic
+import Mathlib.LinearAlgebra.CliffordAlgebra.Grading
 import Mathlib.LinearAlgebra.Coevaluation
 import Mathlib.LinearAlgebra.Contraction
 import Mathlib.LinearAlgebra.CrossProduct

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1996,6 +1996,7 @@ import Mathlib.LinearAlgebra.BilinearMap
 import Mathlib.LinearAlgebra.Charpoly.Basic
 import Mathlib.LinearAlgebra.Charpoly.ToMatrix
 import Mathlib.LinearAlgebra.CliffordAlgebra.Basic
+import Mathlib.LinearAlgebra.CliffordAlgebra.Conjugation
 import Mathlib.LinearAlgebra.CliffordAlgebra.Grading
 import Mathlib.LinearAlgebra.Coevaluation
 import Mathlib.LinearAlgebra.Contraction

--- a/Mathlib/LinearAlgebra/CliffordAlgebra/Basic.lean
+++ b/Mathlib/LinearAlgebra/CliffordAlgebra/Basic.lean
@@ -168,7 +168,7 @@ theorem lift_comp_ι (g : CliffordAlgebra Q →ₐ[R] A) :
 #align clifford_algebra.lift_comp_ι CliffordAlgebra.lift_comp_ι
 
 /-- See note [partially-applied ext lemmas]. -/
-@[ext]
+@[ext high]
 theorem hom_ext {A : Type _} [Semiring A] [Algebra R A] {f g : CliffordAlgebra Q →ₐ[R] A} :
     f.toLinearMap.comp (ι Q) = g.toLinearMap.comp (ι Q) → f = g := by
   intro h

--- a/Mathlib/LinearAlgebra/CliffordAlgebra/Conjugation.lean
+++ b/Mathlib/LinearAlgebra/CliffordAlgebra/Conjugation.lean
@@ -22,16 +22,16 @@ https://en.wikipedia.org/wiki/Clifford_algebra#Antiautomorphisms
 
 ## Main definitions
 
-* `clifford_algebra.involute`: the grade involution, negating each basis vector
-* `clifford_algebra.reverse`: the grade reversion, reversing the order of a product of vectors
+* `CliffordAlgebra.involute`: the grade involution, negating each basis vector
+* `CliffordAlgebra.reverse`: the grade reversion, reversing the order of a product of vectors
 
 ## Main statements
 
-* `clifford_algebra.involute_involutive`
-* `clifford_algebra.reverse_involutive`
-* `clifford_algebra.reverse_involute_commute`
-* `clifford_algebra.involute_mem_even_odd_iff`
-* `clifford_algebra.reverse_mem_even_odd_iff`
+* `CliffordAlgebra.involute_involutive`
+* `CliffordAlgebra.reverse_involutive`
+* `CliffordAlgebra.reverse_involute_commute`
+* `CliffordAlgebra.involute_mem_evenOdd_iff`
+* `CliffordAlgebra.reverse_mem_evenOdd_iff`
 
 -/
 
@@ -70,7 +70,7 @@ theorem involute_involute : ∀ a : CliffordAlgebra Q, involute (involute a) = a
   involute_involutive
 #align clifford_algebra.involute_involute CliffordAlgebra.involute_involute
 
-/-- `clifford_algebra.involute` as an `alg_equiv`. -/
+/-- `CliffordAlgebra.involute` as an `AlgEquiv`. -/
 @[simps!]
 def involuteEquiv : CliffordAlgebra Q ≃ₐ[R] CliffordAlgebra Q :=
   AlgEquiv.ofAlgHom involute involute (AlgHom.ext <| involute_involute)
@@ -140,7 +140,7 @@ theorem reverse_reverse : ∀ a : CliffordAlgebra Q, reverse (Q := Q) (reverse (
   reverse_involutive
 #align clifford_algebra.reverse_reverse CliffordAlgebra.reverse_reverse
 
-/-- `clifford_algebra.reverse` as a `linear_equiv`. -/
+/-- `CliffordAlgebra.reverse` as a `LinearEquiv`. -/
 @[simps!]
 def reverseEquiv : CliffordAlgebra Q ≃ₗ[R] CliffordAlgebra Q :=
   LinearEquiv.ofInvolutive reverse reverse_involutive
@@ -158,7 +158,7 @@ theorem reverse_comp_involute :
   case h_add a b ha hb => simp only [ha, hb, reverse.map_add, AlgHom.map_add]
 #align clifford_algebra.reverse_comp_involute CliffordAlgebra.reverse_comp_involute
 
-/-- `clifford_algebra.reverse` and `clifford_algebra.inverse` commute. Note that the composition
+/-- `CliffordAlgebra.reverse` and `clifford_algebra.inverse` commute. Note that the composition
 is sometimes referred to as the "clifford conjugate". -/
 theorem reverse_involute_commute : Function.Commute (reverse (Q := Q)) involute :=
   LinearMap.congr_fun reverse_comp_involute
@@ -199,7 +199,7 @@ theorem involute_prod_map_ι :
 end List
 
 /-!
-### Statements about `submodule.map` and `submodule.comap`
+### Statements about `Submodule.map` and `Submodule.comap`
 -/
 
 
@@ -268,7 +268,7 @@ theorem ι_range_comap_reverse :
   rw [← submodule_map_reverse_eq_comap, ι_range_map_reverse]
 #align clifford_algebra.ι_range_comap_reverse CliffordAlgebra.ι_range_comap_reverse
 
-/-- Like `submodule.map_mul`, but with the multiplication reversed. -/
+/-- Like `Submodule.map_mul`, but with the multiplication reversed. -/
 theorem submodule_map_mul_reverse (p q : Submodule R (CliffordAlgebra Q)) :
     (p * q).map (reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q) =
       q.map (reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q) *
@@ -283,7 +283,7 @@ theorem submodule_comap_mul_reverse (p q : Submodule R (CliffordAlgebra Q)) :
   by simp_rw [← submodule_map_reverse_eq_comap, submodule_map_mul_reverse]
 #align clifford_algebra.submodule_comap_mul_reverse CliffordAlgebra.submodule_comap_mul_reverse
 
-/-- Like `submodule.map_pow` -/
+/-- Like `Submodule.map_pow` -/
 theorem submodule_map_pow_reverse (p : Submodule R (CliffordAlgebra Q)) (n : ℕ) :
     (p ^ n).map (reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q) =
       p.map (reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q) ^ n := by
@@ -328,7 +328,7 @@ end Submodule
 /-!
 ### Related properties of the even and odd submodules
 
-TODO: show that these are `iff`s when `invertible (2 : R)`.
+TODO: show that these are `iff`s when `Invertible (2 : R)`.
 -/
 
 

--- a/Mathlib/LinearAlgebra/CliffordAlgebra/Conjugation.lean
+++ b/Mathlib/LinearAlgebra/CliffordAlgebra/Conjugation.lean
@@ -1,0 +1,349 @@
+/-
+Copyright (c) 2020 Eric Wieser. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Eric Wieser
+
+! This file was ported from Lean 3 source module linear_algebra.clifford_algebra.conjugation
+! leanprover-community/mathlib commit 34020e531ebc4e8aac6d449d9eecbcd1508ea8d0
+! Please do not edit these lines, except to modify the commit id
+! if you have ported upstream changes.
+-/
+import Mathbin.LinearAlgebra.CliffordAlgebra.Grading
+import Mathbin.Algebra.Module.Opposites
+
+/-!
+# Conjugations
+
+This file defines the grade reversal and grade involution functions on multivectors, `reverse` and
+`involute`.
+Together, these operations compose to form the "Clifford conjugate", hence the name of this file.
+
+https://en.wikipedia.org/wiki/Clifford_algebra#Antiautomorphisms
+
+## Main definitions
+
+* `clifford_algebra.involute`: the grade involution, negating each basis vector
+* `clifford_algebra.reverse`: the grade reversion, reversing the order of a product of vectors
+
+## Main statements
+
+* `clifford_algebra.involute_involutive`
+* `clifford_algebra.reverse_involutive`
+* `clifford_algebra.reverse_involute_commute`
+* `clifford_algebra.involute_mem_even_odd_iff`
+* `clifford_algebra.reverse_mem_even_odd_iff`
+
+-/
+
+
+variable {R : Type _} [CommRing R]
+
+variable {M : Type _} [AddCommGroup M] [Module R M]
+
+variable {Q : QuadraticForm R M}
+
+namespace CliffordAlgebra
+
+section Involute
+
+/-- Grade involution, inverting the sign of each basis vector. -/
+def involute : CliffordAlgebra Q →ₐ[R] CliffordAlgebra Q :=
+  CliffordAlgebra.lift Q ⟨-ι Q, fun m => by simp⟩
+#align clifford_algebra.involute CliffordAlgebra.involute
+
+@[simp]
+theorem involute_ι (m : M) : involute (ι Q m) = -ι Q m :=
+  lift_ι_apply _ _ m
+#align clifford_algebra.involute_ι CliffordAlgebra.involute_ι
+
+@[simp]
+theorem involute_comp_involute : involute.comp involute = AlgHom.id R (CliffordAlgebra Q) := by ext;
+  simp
+#align clifford_algebra.involute_comp_involute CliffordAlgebra.involute_comp_involute
+
+theorem involute_involutive : Function.Involutive (involute : _ → CliffordAlgebra Q) :=
+  AlgHom.congr_fun involute_comp_involute
+#align clifford_algebra.involute_involutive CliffordAlgebra.involute_involutive
+
+@[simp]
+theorem involute_involute : ∀ a : CliffordAlgebra Q, involute (involute a) = a :=
+  involute_involutive
+#align clifford_algebra.involute_involute CliffordAlgebra.involute_involute
+
+/-- `clifford_algebra.involute` as an `alg_equiv`. -/
+@[simps]
+def involuteEquiv : CliffordAlgebra Q ≃ₐ[R] CliffordAlgebra Q :=
+  AlgEquiv.ofAlgHom involute involute (AlgHom.ext <| involute_involute)
+    (AlgHom.ext <| involute_involute)
+#align clifford_algebra.involute_equiv CliffordAlgebra.involuteEquiv
+
+end Involute
+
+section Reverse
+
+open MulOpposite
+
+/-- Grade reversion, inverting the multiplication order of basis vectors.
+Also called *transpose* in some literature. -/
+def reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q :=
+  (opLinearEquiv R).symm.toLinearMap.comp
+    (CliffordAlgebra.lift Q
+        ⟨(MulOpposite.opLinearEquiv R).toLinearMap.comp (ι Q), fun m =>
+          unop_injective <| by simp⟩).toLinearMap
+#align clifford_algebra.reverse CliffordAlgebra.reverse
+
+@[simp]
+theorem reverse_ι (m : M) : reverse (ι Q m) = ι Q m := by simp [reverse]
+#align clifford_algebra.reverse_ι CliffordAlgebra.reverse_ι
+
+@[simp]
+theorem reverse.commutes (r : R) :
+    reverse (algebraMap R (CliffordAlgebra Q) r) = algebraMap R _ r := by simp [reverse]
+#align clifford_algebra.reverse.commutes CliffordAlgebra.reverse.commutes
+
+@[simp]
+theorem reverse.map_one : reverse (1 : CliffordAlgebra Q) = 1 := by
+  convert reverse.commutes (1 : R) <;> simp
+#align clifford_algebra.reverse.map_one CliffordAlgebra.reverse.map_one
+
+@[simp]
+theorem reverse.map_mul (a b : CliffordAlgebra Q) : reverse (a * b) = reverse b * reverse a := by
+  simp [reverse]
+#align clifford_algebra.reverse.map_mul CliffordAlgebra.reverse.map_mul
+
+@[simp]
+theorem reverse_comp_reverse : reverse.comp reverse = (LinearMap.id : _ →ₗ[R] CliffordAlgebra Q) :=
+  by
+  ext m
+  simp only [LinearMap.id_apply, LinearMap.comp_apply]
+  induction m using CliffordAlgebra.induction
+  -- simp can close these goals, but is slow
+  case h_grade0 => rw [reverse.commutes, reverse.commutes]
+  case h_grade1 => rw [reverse_ι, reverse_ι]
+  case h_mul a b ha hb => rw [reverse.map_mul, reverse.map_mul, ha, hb]
+  case h_add a b ha hb => rw [reverse.map_add, reverse.map_add, ha, hb]
+#align clifford_algebra.reverse_comp_reverse CliffordAlgebra.reverse_comp_reverse
+
+@[simp]
+theorem reverse_involutive : Function.Involutive (reverse : _ → CliffordAlgebra Q) :=
+  LinearMap.congr_fun reverse_comp_reverse
+#align clifford_algebra.reverse_involutive CliffordAlgebra.reverse_involutive
+
+@[simp]
+theorem reverse_reverse : ∀ a : CliffordAlgebra Q, reverse (reverse a) = a :=
+  reverse_involutive
+#align clifford_algebra.reverse_reverse CliffordAlgebra.reverse_reverse
+
+/-- `clifford_algebra.reverse` as a `linear_equiv`. -/
+@[simps]
+def reverseEquiv : CliffordAlgebra Q ≃ₗ[R] CliffordAlgebra Q :=
+  LinearEquiv.ofInvolutive reverse reverse_involutive
+#align clifford_algebra.reverse_equiv CliffordAlgebra.reverseEquiv
+
+theorem reverse_comp_involute :
+    reverse.comp involute.toLinearMap =
+      (involute.toLinearMap.comp reverse : _ →ₗ[R] CliffordAlgebra Q) :=
+  by
+  ext
+  simp only [LinearMap.comp_apply, AlgHom.toLinearMap_apply]
+  induction x using CliffordAlgebra.induction
+  case h_grade0 => simp
+  case h_grade1 => simp
+  case h_mul a b ha hb => simp only [ha, hb, reverse.map_mul, AlgHom.map_mul]
+  case h_add a b ha hb => simp only [ha, hb, reverse.map_add, AlgHom.map_add]
+#align clifford_algebra.reverse_comp_involute CliffordAlgebra.reverse_comp_involute
+
+/-- `clifford_algebra.reverse` and `clifford_algebra.inverse` commute. Note that the composition
+is sometimes referred to as the "clifford conjugate". -/
+theorem reverse_involute_commute : Function.Commute (reverse : _ → CliffordAlgebra Q) involute :=
+  LinearMap.congr_fun reverse_comp_involute
+#align clifford_algebra.reverse_involute_commute CliffordAlgebra.reverse_involute_commute
+
+theorem reverse_involute : ∀ a : CliffordAlgebra Q, reverse (involute a) = involute (reverse a) :=
+  reverse_involute_commute
+#align clifford_algebra.reverse_involute CliffordAlgebra.reverse_involute
+
+end Reverse
+
+/-!
+### Statements about conjugations of products of lists
+-/
+
+
+section List
+
+/- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
+/-- Taking the reverse of the product a list of $n$ vectors lifted via `ι` is equivalent to
+taking the product of the reverse of that list. -/
+theorem reverse_prod_map_ι : ∀ l : List M, reverse (l.map <| ι Q).Prod = (l.map <| ι Q).reverse.Prod
+  | [] => by simp
+  | x::xs => by simp [reverse_prod_map_ι xs]
+#align clifford_algebra.reverse_prod_map_ι CliffordAlgebra.reverse_prod_map_ι
+
+/- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
+/-- Taking the involute of the product a list of $n$ vectors lifted via `ι` is equivalent to
+premultiplying by ${-1}^n$. -/
+theorem involute_prod_map_ι :
+    ∀ l : List M, involute (l.map <| ι Q).Prod = (-1 : R) ^ l.length • (l.map <| ι Q).Prod
+  | [] => by simp
+  | x::xs => by simp [pow_add, involute_prod_map_ι xs]
+#align clifford_algebra.involute_prod_map_ι CliffordAlgebra.involute_prod_map_ι
+
+end List
+
+/-!
+### Statements about `submodule.map` and `submodule.comap`
+-/
+
+
+section Submodule
+
+variable (Q)
+
+section Involute
+
+theorem submodule_map_involute_eq_comap (p : Submodule R (CliffordAlgebra Q)) :
+    p.map (involute : CliffordAlgebra Q →ₐ[R] CliffordAlgebra Q).toLinearMap =
+      p.comap (involute : CliffordAlgebra Q →ₐ[R] CliffordAlgebra Q).toLinearMap :=
+  Submodule.map_equiv_eq_comap_symm involuteEquiv.toLinearEquiv _
+#align clifford_algebra.submodule_map_involute_eq_comap CliffordAlgebra.submodule_map_involute_eq_comap
+
+@[simp]
+theorem ι_range_map_involute :
+    (ι Q).range.map (involute : CliffordAlgebra Q →ₐ[R] CliffordAlgebra Q).toLinearMap =
+      (ι Q).range :=
+  (ι_range_map_lift _ _).trans (LinearMap.range_neg _)
+#align clifford_algebra.ι_range_map_involute CliffordAlgebra.ι_range_map_involute
+
+@[simp]
+theorem ι_range_comap_involute :
+    (ι Q).range.comap (involute : CliffordAlgebra Q →ₐ[R] CliffordAlgebra Q).toLinearMap =
+      (ι Q).range :=
+  by rw [← submodule_map_involute_eq_comap, ι_range_map_involute]
+#align clifford_algebra.ι_range_comap_involute CliffordAlgebra.ι_range_comap_involute
+
+@[simp]
+theorem evenOdd_map_involute (n : ZMod 2) :
+    (evenOdd Q n).map (involute : CliffordAlgebra Q →ₐ[R] CliffordAlgebra Q).toLinearMap =
+      evenOdd Q n :=
+  by simp_rw [even_odd, Submodule.map_iSup, Submodule.map_pow, ι_range_map_involute]
+#align clifford_algebra.even_odd_map_involute CliffordAlgebra.evenOdd_map_involute
+
+@[simp]
+theorem evenOdd_comap_involute (n : ZMod 2) :
+    (evenOdd Q n).comap (involute : CliffordAlgebra Q →ₐ[R] CliffordAlgebra Q).toLinearMap =
+      evenOdd Q n :=
+  by rw [← submodule_map_involute_eq_comap, even_odd_map_involute]
+#align clifford_algebra.even_odd_comap_involute CliffordAlgebra.evenOdd_comap_involute
+
+end Involute
+
+section Reverse
+
+theorem submodule_map_reverse_eq_comap (p : Submodule R (CliffordAlgebra Q)) :
+    p.map (reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q) =
+      p.comap (reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q) :=
+  Submodule.map_equiv_eq_comap_symm (reverseEquiv : _ ≃ₗ[R] _) _
+#align clifford_algebra.submodule_map_reverse_eq_comap CliffordAlgebra.submodule_map_reverse_eq_comap
+
+@[simp]
+theorem ι_range_map_reverse :
+    (ι Q).range.map (reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q) = (ι Q).range :=
+  by
+  rw [reverse, Submodule.map_comp, ι_range_map_lift, LinearMap.range_comp, ← Submodule.map_comp]
+  exact Submodule.map_id _
+#align clifford_algebra.ι_range_map_reverse CliffordAlgebra.ι_range_map_reverse
+
+@[simp]
+theorem ι_range_comap_reverse :
+    (ι Q).range.comap (reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q) = (ι Q).range := by
+  rw [← submodule_map_reverse_eq_comap, ι_range_map_reverse]
+#align clifford_algebra.ι_range_comap_reverse CliffordAlgebra.ι_range_comap_reverse
+
+/-- Like `submodule.map_mul`, but with the multiplication reversed. -/
+theorem submodule_map_mul_reverse (p q : Submodule R (CliffordAlgebra Q)) :
+    (p * q).map (reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q) =
+      q.map (reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q) *
+        p.map (reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q) :=
+  by
+  simp_rw [reverse, Submodule.map_comp, LinearEquiv.toLinearMap_eq_coe, Submodule.map_mul,
+    Submodule.map_unop_mul]
+#align clifford_algebra.submodule_map_mul_reverse CliffordAlgebra.submodule_map_mul_reverse
+
+theorem submodule_comap_mul_reverse (p q : Submodule R (CliffordAlgebra Q)) :
+    (p * q).comap (reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q) =
+      q.comap (reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q) *
+        p.comap (reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q) :=
+  by simp_rw [← submodule_map_reverse_eq_comap, submodule_map_mul_reverse]
+#align clifford_algebra.submodule_comap_mul_reverse CliffordAlgebra.submodule_comap_mul_reverse
+
+/-- Like `submodule.map_pow` -/
+theorem submodule_map_pow_reverse (p : Submodule R (CliffordAlgebra Q)) (n : ℕ) :
+    (p ^ n).map (reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q) =
+      p.map (reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q) ^ n :=
+  by
+  simp_rw [reverse, Submodule.map_comp, LinearEquiv.toLinearMap_eq_coe, Submodule.map_pow,
+    Submodule.map_unop_pow]
+#align clifford_algebra.submodule_map_pow_reverse CliffordAlgebra.submodule_map_pow_reverse
+
+theorem submodule_comap_pow_reverse (p : Submodule R (CliffordAlgebra Q)) (n : ℕ) :
+    (p ^ n).comap (reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q) =
+      p.comap (reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q) ^ n :=
+  by simp_rw [← submodule_map_reverse_eq_comap, submodule_map_pow_reverse]
+#align clifford_algebra.submodule_comap_pow_reverse CliffordAlgebra.submodule_comap_pow_reverse
+
+@[simp]
+theorem evenOdd_map_reverse (n : ZMod 2) :
+    (evenOdd Q n).map (reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q) = evenOdd Q n := by
+  simp_rw [even_odd, Submodule.map_iSup, submodule_map_pow_reverse, ι_range_map_reverse]
+#align clifford_algebra.even_odd_map_reverse CliffordAlgebra.evenOdd_map_reverse
+
+@[simp]
+theorem evenOdd_comap_reverse (n : ZMod 2) :
+    (evenOdd Q n).comap (reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q) = evenOdd Q n := by
+  rw [← submodule_map_reverse_eq_comap, even_odd_map_reverse]
+#align clifford_algebra.even_odd_comap_reverse CliffordAlgebra.evenOdd_comap_reverse
+
+end Reverse
+
+@[simp]
+theorem involute_mem_evenOdd_iff {x : CliffordAlgebra Q} {n : ZMod 2} :
+    involute x ∈ evenOdd Q n ↔ x ∈ evenOdd Q n :=
+  SetLike.ext_iff.mp (evenOdd_comap_involute Q n) x
+#align clifford_algebra.involute_mem_even_odd_iff CliffordAlgebra.involute_mem_evenOdd_iff
+
+@[simp]
+theorem reverse_mem_evenOdd_iff {x : CliffordAlgebra Q} {n : ZMod 2} :
+    reverse x ∈ evenOdd Q n ↔ x ∈ evenOdd Q n :=
+  SetLike.ext_iff.mp (evenOdd_comap_reverse Q n) x
+#align clifford_algebra.reverse_mem_even_odd_iff CliffordAlgebra.reverse_mem_evenOdd_iff
+
+end Submodule
+
+/-!
+### Related properties of the even and odd submodules
+
+TODO: show that these are `iff`s when `invertible (2 : R)`.
+-/
+
+
+theorem involute_eq_of_mem_even {x : CliffordAlgebra Q} (h : x ∈ evenOdd Q 0) : involute x = x :=
+  by
+  refine' even_induction Q (AlgHom.commutes _) _ _ x h
+  · rintro x y hx hy ihx ihy
+    rw [map_add, ihx, ihy]
+  · intro m₁ m₂ x hx ihx
+    rw [map_mul, map_mul, involute_ι, involute_ι, ihx, neg_mul_neg]
+#align clifford_algebra.involute_eq_of_mem_even CliffordAlgebra.involute_eq_of_mem_even
+
+theorem involute_eq_of_mem_odd {x : CliffordAlgebra Q} (h : x ∈ evenOdd Q 1) : involute x = -x :=
+  by
+  refine' odd_induction Q involute_ι _ _ x h
+  · rintro x y hx hy ihx ihy
+    rw [map_add, ihx, ihy, neg_add]
+  · intro m₁ m₂ x hx ihx
+    rw [map_mul, map_mul, involute_ι, involute_ι, ihx, neg_mul_neg, mul_neg]
+#align clifford_algebra.involute_eq_of_mem_odd CliffordAlgebra.involute_eq_of_mem_odd
+
+end CliffordAlgebra
+

--- a/Mathlib/LinearAlgebra/CliffordAlgebra/Conjugation.lean
+++ b/Mathlib/LinearAlgebra/CliffordAlgebra/Conjugation.lean
@@ -57,8 +57,8 @@ theorem involute_ι (m : M) : involute (ι Q m) = -ι Q m :=
 #align clifford_algebra.involute_ι CliffordAlgebra.involute_ι
 
 @[simp]
-theorem involute_comp_involute : involute.comp involute = AlgHom.id R (CliffordAlgebra Q) := by ext;
-  simp
+theorem involute_comp_involute : involute.comp involute = AlgHom.id R (CliffordAlgebra Q) := by
+  ext; simp
 #align clifford_algebra.involute_comp_involute CliffordAlgebra.involute_comp_involute
 
 theorem involute_involutive : Function.Involutive (involute : _ → CliffordAlgebra Q) :=
@@ -71,7 +71,7 @@ theorem involute_involute : ∀ a : CliffordAlgebra Q, involute (involute a) = a
 #align clifford_algebra.involute_involute CliffordAlgebra.involute_involute
 
 /-- `clifford_algebra.involute` as an `alg_equiv`. -/
-@[simps]
+@[simps!]
 def involuteEquiv : CliffordAlgebra Q ≃ₐ[R] CliffordAlgebra Q :=
   AlgEquiv.ofAlgHom involute involute (AlgHom.ext <| involute_involute)
     (AlgHom.ext <| involute_involute)
@@ -92,22 +92,27 @@ def reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q :=
           unop_injective <| by simp⟩).toLinearMap
 #align clifford_algebra.reverse CliffordAlgebra.reverse
 
+-- porting note: can't infer `Q`
 @[simp]
-theorem reverse_ι (m : M) : reverse (ι Q m) = ι Q m := by simp [reverse]
+theorem reverse_ι (m : M) : reverse (Q := Q) (ι Q m) = ι Q m := by simp [reverse]
 #align clifford_algebra.reverse_ι CliffordAlgebra.reverse_ι
 
 @[simp]
 theorem reverse.commutes (r : R) :
-    reverse (algebraMap R (CliffordAlgebra Q) r) = algebraMap R _ r := by simp [reverse]
+    -- porting note: can't infer `Q`
+    reverse (Q := Q) (algebraMap R (CliffordAlgebra Q) r) = algebraMap R _ r := by simp [reverse]
 #align clifford_algebra.reverse.commutes CliffordAlgebra.reverse.commutes
 
+-- porting note: can't infer `Q`
 @[simp]
-theorem reverse.map_one : reverse (1 : CliffordAlgebra Q) = 1 := by
-  convert reverse.commutes (1 : R) <;> simp
+theorem reverse.map_one : reverse (Q := Q) (1 : CliffordAlgebra Q) = 1 := by
+  convert reverse.commutes (Q := Q) (1 : R) <;> simp
 #align clifford_algebra.reverse.map_one CliffordAlgebra.reverse.map_one
 
 @[simp]
-theorem reverse.map_mul (a b : CliffordAlgebra Q) : reverse (a * b) = reverse b * reverse a := by
+theorem reverse.map_mul (a b : CliffordAlgebra Q) :
+  -- porting note: can't infer `Q`
+  reverse (Q := Q) (a * b) = reverse (Q := Q) b * reverse (Q := Q) a := by
   simp [reverse]
 #align clifford_algebra.reverse.map_mul CliffordAlgebra.reverse.map_mul
 
@@ -125,17 +130,18 @@ theorem reverse_comp_reverse : reverse.comp reverse = (LinearMap.id : _ →ₗ[R
 #align clifford_algebra.reverse_comp_reverse CliffordAlgebra.reverse_comp_reverse
 
 @[simp]
-theorem reverse_involutive : Function.Involutive (reverse : _ → CliffordAlgebra Q) :=
+theorem reverse_involutive : Function.Involutive (reverse (Q := Q)) :=
   LinearMap.congr_fun reverse_comp_reverse
 #align clifford_algebra.reverse_involutive CliffordAlgebra.reverse_involutive
 
+-- porting note: can't infer `Q`
 @[simp]
-theorem reverse_reverse : ∀ a : CliffordAlgebra Q, reverse (reverse a) = a :=
+theorem reverse_reverse : ∀ a : CliffordAlgebra Q, reverse (Q := Q) (reverse (Q := Q) a) = a :=
   reverse_involutive
 #align clifford_algebra.reverse_reverse CliffordAlgebra.reverse_reverse
 
 /-- `clifford_algebra.reverse` as a `linear_equiv`. -/
-@[simps]
+@[simps!]
 def reverseEquiv : CliffordAlgebra Q ≃ₗ[R] CliffordAlgebra Q :=
   LinearEquiv.ofInvolutive reverse reverse_involutive
 #align clifford_algebra.reverse_equiv CliffordAlgebra.reverseEquiv
@@ -143,7 +149,7 @@ def reverseEquiv : CliffordAlgebra Q ≃ₗ[R] CliffordAlgebra Q :=
 theorem reverse_comp_involute :
     reverse.comp involute.toLinearMap =
       (involute.toLinearMap.comp reverse : _ →ₗ[R] CliffordAlgebra Q) := by
-  ext
+  ext x
   simp only [LinearMap.comp_apply, AlgHom.toLinearMap_apply]
   induction x using CliffordAlgebra.induction
   case h_grade0 => simp
@@ -154,11 +160,13 @@ theorem reverse_comp_involute :
 
 /-- `clifford_algebra.reverse` and `clifford_algebra.inverse` commute. Note that the composition
 is sometimes referred to as the "clifford conjugate". -/
-theorem reverse_involute_commute : Function.Commute (reverse : _ → CliffordAlgebra Q) involute :=
+theorem reverse_involute_commute : Function.Commute (reverse (Q := Q)) involute :=
   LinearMap.congr_fun reverse_comp_involute
 #align clifford_algebra.reverse_involute_commute CliffordAlgebra.reverse_involute_commute
 
-theorem reverse_involute : ∀ a : CliffordAlgebra Q, reverse (involute a) = involute (reverse a) :=
+theorem reverse_involute :
+    -- porting note: can't infer `Q`
+    ∀ a : CliffordAlgebra Q, reverse (Q := Q) (involute a) = involute (reverse (Q := Q) a) :=
   reverse_involute_commute
 #align clifford_algebra.reverse_involute CliffordAlgebra.reverse_involute
 
@@ -171,21 +179,21 @@ end Reverse
 
 section List
 
-/- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
 /-- Taking the reverse of the product a list of $n$ vectors lifted via `ι` is equivalent to
 taking the product of the reverse of that list. -/
-theorem reverse_prod_map_ι : ∀ l : List M, reverse (l.map <| ι Q).Prod = (l.map <| ι Q).reverse.Prod
+theorem reverse_prod_map_ι :
+  -- porting note: can't infer `Q`
+    ∀ l : List M, reverse (Q := Q) (l.map <| ι Q).prod = (l.map <| ι Q).reverse.prod
   | [] => by simp
   | x::xs => by simp [reverse_prod_map_ι xs]
 #align clifford_algebra.reverse_prod_map_ι CliffordAlgebra.reverse_prod_map_ι
 
-/- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
 /-- Taking the involute of the product a list of $n$ vectors lifted via `ι` is equivalent to
 premultiplying by ${-1}^n$. -/
 theorem involute_prod_map_ι :
-    ∀ l : List M, involute (l.map <| ι Q).Prod = (-1 : R) ^ l.length • (l.map <| ι Q).Prod
+    ∀ l : List M, involute (l.map <| ι Q).prod = (-1 : R) ^ l.length • (l.map <| ι Q).prod
   | [] => by simp
-  | x::xs => by simp [pow_add, involute_prod_map_ι xs]
+  | x::xs => by simp [pow_succ, involute_prod_map_ι xs]
 #align clifford_algebra.involute_prod_map_ι CliffordAlgebra.involute_prod_map_ι
 
 end List
@@ -210,14 +218,14 @@ theorem submodule_map_involute_eq_comap (p : Submodule R (CliffordAlgebra Q)) :
 @[simp]
 theorem ι_range_map_involute :
     (ι Q).range.map (involute : CliffordAlgebra Q →ₐ[R] CliffordAlgebra Q).toLinearMap =
-      (ι Q).range :=
+      LinearMap.range (ι Q) :=
   (ι_range_map_lift _ _).trans (LinearMap.range_neg _)
 #align clifford_algebra.ι_range_map_involute CliffordAlgebra.ι_range_map_involute
 
 @[simp]
 theorem ι_range_comap_involute :
     (ι Q).range.comap (involute : CliffordAlgebra Q →ₐ[R] CliffordAlgebra Q).toLinearMap =
-      (ι Q).range :=
+      LinearMap.range (ι Q) :=
   by rw [← submodule_map_involute_eq_comap, ι_range_map_involute]
 #align clifford_algebra.ι_range_comap_involute CliffordAlgebra.ι_range_comap_involute
 
@@ -225,14 +233,14 @@ theorem ι_range_comap_involute :
 theorem evenOdd_map_involute (n : ZMod 2) :
     (evenOdd Q n).map (involute : CliffordAlgebra Q →ₐ[R] CliffordAlgebra Q).toLinearMap =
       evenOdd Q n :=
-  by simp_rw [even_odd, Submodule.map_iSup, Submodule.map_pow, ι_range_map_involute]
+  by simp_rw [evenOdd, Submodule.map_iSup, Submodule.map_pow, ι_range_map_involute]
 #align clifford_algebra.even_odd_map_involute CliffordAlgebra.evenOdd_map_involute
 
 @[simp]
 theorem evenOdd_comap_involute (n : ZMod 2) :
     (evenOdd Q n).comap (involute : CliffordAlgebra Q →ₐ[R] CliffordAlgebra Q).toLinearMap =
       evenOdd Q n :=
-  by rw [← submodule_map_involute_eq_comap, even_odd_map_involute]
+  by rw [← submodule_map_involute_eq_comap, evenOdd_map_involute]
 #align clifford_algebra.even_odd_comap_involute CliffordAlgebra.evenOdd_comap_involute
 
 end Involute
@@ -247,14 +255,16 @@ theorem submodule_map_reverse_eq_comap (p : Submodule R (CliffordAlgebra Q)) :
 
 @[simp]
 theorem ι_range_map_reverse :
-    (ι Q).range.map (reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q) = (ι Q).range := by
+    (ι Q).range.map (reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q)
+      = LinearMap.range (ι Q) := by
   rw [reverse, Submodule.map_comp, ι_range_map_lift, LinearMap.range_comp, ← Submodule.map_comp]
   exact Submodule.map_id _
 #align clifford_algebra.ι_range_map_reverse CliffordAlgebra.ι_range_map_reverse
 
 @[simp]
 theorem ι_range_comap_reverse :
-    (ι Q).range.comap (reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q) = (ι Q).range := by
+    (ι Q).range.comap (reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q)
+      = LinearMap.range (ι Q) := by
   rw [← submodule_map_reverse_eq_comap, ι_range_map_reverse]
 #align clifford_algebra.ι_range_comap_reverse CliffordAlgebra.ι_range_comap_reverse
 
@@ -263,8 +273,7 @@ theorem submodule_map_mul_reverse (p q : Submodule R (CliffordAlgebra Q)) :
     (p * q).map (reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q) =
       q.map (reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q) *
         p.map (reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q) := by
-  simp_rw [reverse, Submodule.map_comp, LinearEquiv.toLinearMap_eq_coe, Submodule.map_mul,
-    Submodule.map_unop_mul]
+  simp_rw [reverse, Submodule.map_comp, Submodule.map_mul, Submodule.map_unop_mul]
 #align clifford_algebra.submodule_map_mul_reverse CliffordAlgebra.submodule_map_mul_reverse
 
 theorem submodule_comap_mul_reverse (p q : Submodule R (CliffordAlgebra Q)) :
@@ -278,8 +287,7 @@ theorem submodule_comap_mul_reverse (p q : Submodule R (CliffordAlgebra Q)) :
 theorem submodule_map_pow_reverse (p : Submodule R (CliffordAlgebra Q)) (n : ℕ) :
     (p ^ n).map (reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q) =
       p.map (reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q) ^ n := by
-  simp_rw [reverse, Submodule.map_comp, LinearEquiv.toLinearMap_eq_coe, Submodule.map_pow,
-    Submodule.map_unop_pow]
+  simp_rw [reverse, Submodule.map_comp, Submodule.map_pow, Submodule.map_unop_pow]
 #align clifford_algebra.submodule_map_pow_reverse CliffordAlgebra.submodule_map_pow_reverse
 
 theorem submodule_comap_pow_reverse (p : Submodule R (CliffordAlgebra Q)) (n : ℕ) :
@@ -291,13 +299,13 @@ theorem submodule_comap_pow_reverse (p : Submodule R (CliffordAlgebra Q)) (n : �
 @[simp]
 theorem evenOdd_map_reverse (n : ZMod 2) :
     (evenOdd Q n).map (reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q) = evenOdd Q n := by
-  simp_rw [even_odd, Submodule.map_iSup, submodule_map_pow_reverse, ι_range_map_reverse]
+  simp_rw [evenOdd, Submodule.map_iSup, submodule_map_pow_reverse, ι_range_map_reverse]
 #align clifford_algebra.even_odd_map_reverse CliffordAlgebra.evenOdd_map_reverse
 
 @[simp]
 theorem evenOdd_comap_reverse (n : ZMod 2) :
     (evenOdd Q n).comap (reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q) = evenOdd Q n := by
-  rw [← submodule_map_reverse_eq_comap, even_odd_map_reverse]
+  rw [← submodule_map_reverse_eq_comap, evenOdd_map_reverse]
 #align clifford_algebra.even_odd_comap_reverse CliffordAlgebra.evenOdd_comap_reverse
 
 end Reverse
@@ -310,7 +318,8 @@ theorem involute_mem_evenOdd_iff {x : CliffordAlgebra Q} {n : ZMod 2} :
 
 @[simp]
 theorem reverse_mem_evenOdd_iff {x : CliffordAlgebra Q} {n : ZMod 2} :
-    reverse x ∈ evenOdd Q n ↔ x ∈ evenOdd Q n :=
+    -- porting note: cannot infer `Q`
+    reverse (Q := Q) x ∈ evenOdd Q n ↔ x ∈ evenOdd Q n :=
   SetLike.ext_iff.mp (evenOdd_comap_reverse Q n) x
 #align clifford_algebra.reverse_mem_even_odd_iff CliffordAlgebra.reverse_mem_evenOdd_iff
 
@@ -325,19 +334,18 @@ TODO: show that these are `iff`s when `invertible (2 : R)`.
 
 theorem involute_eq_of_mem_even {x : CliffordAlgebra Q} (h : x ∈ evenOdd Q 0) : involute x = x := by
   refine' even_induction Q (AlgHom.commutes _) _ _ x h
-  · rintro x y hx hy ihx ihy
+  · rintro x y _hx _hy ihx ihy
     rw [map_add, ihx, ihy]
-  · intro m₁ m₂ x hx ihx
+  · intro m₁ m₂ x _hx ihx
     rw [map_mul, map_mul, involute_ι, involute_ι, ihx, neg_mul_neg]
 #align clifford_algebra.involute_eq_of_mem_even CliffordAlgebra.involute_eq_of_mem_even
 
 theorem involute_eq_of_mem_odd {x : CliffordAlgebra Q} (h : x ∈ evenOdd Q 1) : involute x = -x := by
   refine' odd_induction Q involute_ι _ _ x h
-  · rintro x y hx hy ihx ihy
+  · rintro x y _hx _hy ihx ihy
     rw [map_add, ihx, ihy, neg_add]
-  · intro m₁ m₂ x hx ihx
+  · intro m₁ m₂ x _hx ihx
     rw [map_mul, map_mul, involute_ι, involute_ι, ihx, neg_mul_neg, mul_neg]
 #align clifford_algebra.involute_eq_of_mem_odd CliffordAlgebra.involute_eq_of_mem_odd
 
 end CliffordAlgebra
-

--- a/Mathlib/LinearAlgebra/CliffordAlgebra/Conjugation.lean
+++ b/Mathlib/LinearAlgebra/CliffordAlgebra/Conjugation.lean
@@ -8,8 +8,8 @@ Authors: Eric Wieser
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
-import Mathbin.LinearAlgebra.CliffordAlgebra.Grading
-import Mathbin.Algebra.Module.Opposites
+import Mathlib.LinearAlgebra.CliffordAlgebra.Grading
+import Mathlib.Algebra.Module.Opposites
 
 /-!
 # Conjugations
@@ -142,8 +142,7 @@ def reverseEquiv : CliffordAlgebra Q ≃ₗ[R] CliffordAlgebra Q :=
 
 theorem reverse_comp_involute :
     reverse.comp involute.toLinearMap =
-      (involute.toLinearMap.comp reverse : _ →ₗ[R] CliffordAlgebra Q) :=
-  by
+      (involute.toLinearMap.comp reverse : _ →ₗ[R] CliffordAlgebra Q) := by
   ext
   simp only [LinearMap.comp_apply, AlgHom.toLinearMap_apply]
   induction x using CliffordAlgebra.induction
@@ -248,8 +247,7 @@ theorem submodule_map_reverse_eq_comap (p : Submodule R (CliffordAlgebra Q)) :
 
 @[simp]
 theorem ι_range_map_reverse :
-    (ι Q).range.map (reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q) = (ι Q).range :=
-  by
+    (ι Q).range.map (reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q) = (ι Q).range := by
   rw [reverse, Submodule.map_comp, ι_range_map_lift, LinearMap.range_comp, ← Submodule.map_comp]
   exact Submodule.map_id _
 #align clifford_algebra.ι_range_map_reverse CliffordAlgebra.ι_range_map_reverse
@@ -264,8 +262,7 @@ theorem ι_range_comap_reverse :
 theorem submodule_map_mul_reverse (p q : Submodule R (CliffordAlgebra Q)) :
     (p * q).map (reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q) =
       q.map (reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q) *
-        p.map (reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q) :=
-  by
+        p.map (reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q) := by
   simp_rw [reverse, Submodule.map_comp, LinearEquiv.toLinearMap_eq_coe, Submodule.map_mul,
     Submodule.map_unop_mul]
 #align clifford_algebra.submodule_map_mul_reverse CliffordAlgebra.submodule_map_mul_reverse
@@ -280,8 +277,7 @@ theorem submodule_comap_mul_reverse (p q : Submodule R (CliffordAlgebra Q)) :
 /-- Like `submodule.map_pow` -/
 theorem submodule_map_pow_reverse (p : Submodule R (CliffordAlgebra Q)) (n : ℕ) :
     (p ^ n).map (reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q) =
-      p.map (reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q) ^ n :=
-  by
+      p.map (reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q) ^ n := by
   simp_rw [reverse, Submodule.map_comp, LinearEquiv.toLinearMap_eq_coe, Submodule.map_pow,
     Submodule.map_unop_pow]
 #align clifford_algebra.submodule_map_pow_reverse CliffordAlgebra.submodule_map_pow_reverse
@@ -327,8 +323,7 @@ TODO: show that these are `iff`s when `invertible (2 : R)`.
 -/
 
 
-theorem involute_eq_of_mem_even {x : CliffordAlgebra Q} (h : x ∈ evenOdd Q 0) : involute x = x :=
-  by
+theorem involute_eq_of_mem_even {x : CliffordAlgebra Q} (h : x ∈ evenOdd Q 0) : involute x = x := by
   refine' even_induction Q (AlgHom.commutes _) _ _ x h
   · rintro x y hx hy ihx ihy
     rw [map_add, ihx, ihy]
@@ -336,8 +331,7 @@ theorem involute_eq_of_mem_even {x : CliffordAlgebra Q} (h : x ∈ evenOdd Q 0) 
     rw [map_mul, map_mul, involute_ι, involute_ι, ihx, neg_mul_neg]
 #align clifford_algebra.involute_eq_of_mem_even CliffordAlgebra.involute_eq_of_mem_even
 
-theorem involute_eq_of_mem_odd {x : CliffordAlgebra Q} (h : x ∈ evenOdd Q 1) : involute x = -x :=
-  by
+theorem involute_eq_of_mem_odd {x : CliffordAlgebra Q} (h : x ∈ evenOdd Q 1) : involute x = -x := by
   refine' odd_induction Q involute_ι _ _ x h
   · rintro x y hx hy ihx ihy
     rw [map_add, ihx, ihy, neg_add]

--- a/Mathlib/LinearAlgebra/CliffordAlgebra/Conjugation.lean
+++ b/Mathlib/LinearAlgebra/CliffordAlgebra/Conjugation.lean
@@ -117,8 +117,8 @@ theorem reverse.map_mul (a b : CliffordAlgebra Q) :
 #align clifford_algebra.reverse.map_mul CliffordAlgebra.reverse.map_mul
 
 @[simp]
-theorem reverse_comp_reverse : reverse.comp reverse = (LinearMap.id : _ →ₗ[R] CliffordAlgebra Q) :=
-  by
+theorem reverse_comp_reverse :
+    reverse.comp reverse = (LinearMap.id : _ →ₗ[R] CliffordAlgebra Q) := by
   ext m
   simp only [LinearMap.id_apply, LinearMap.comp_apply]
   induction m using CliffordAlgebra.induction

--- a/Mathlib/LinearAlgebra/CliffordAlgebra/Grading.lean
+++ b/Mathlib/LinearAlgebra/CliffordAlgebra/Grading.lean
@@ -8,9 +8,9 @@ Authors: Eric Wieser
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
-import Mathbin.LinearAlgebra.CliffordAlgebra.Basic
-import Mathbin.Data.Zmod.Basic
-import Mathbin.RingTheory.GradedAlgebra.Basic
+import Mathlib.LinearAlgebra.CliffordAlgebra.Basic
+import Mathlib.Data.ZMod.Basic
+import Mathlib.RingTheory.GradedAlgebra.Basic
 
 /-!
 # Results about the grading structure of the clifford algebra
@@ -36,14 +36,12 @@ def evenOdd (i : ZMod 2) : Submodule R (CliffordAlgebra Q) :=
   ⨆ j : { n : ℕ // ↑n = i }, (ι Q).range ^ (j : ℕ)
 #align clifford_algebra.even_odd CliffordAlgebra.evenOdd
 
-theorem one_le_evenOdd_zero : 1 ≤ evenOdd Q 0 :=
-  by
+theorem one_le_evenOdd_zero : 1 ≤ evenOdd Q 0 := by
   refine' le_trans _ (le_iSup _ ⟨0, Nat.cast_zero⟩)
   exact (pow_zero _).ge
 #align clifford_algebra.one_le_even_odd_zero CliffordAlgebra.one_le_evenOdd_zero
 
-theorem range_ι_le_evenOdd_one : (ι Q).range ≤ evenOdd Q 1 :=
-  by
+theorem range_ι_le_evenOdd_one : (ι Q).range ≤ evenOdd Q 1 := by
   refine' le_trans _ (le_iSup _ ⟨1, Nat.cast_one⟩)
   exact (pow_one _).ge
 #align clifford_algebra.range_ι_le_even_odd_one CliffordAlgebra.range_ι_le_evenOdd_one
@@ -61,8 +59,7 @@ theorem ι_mul_ι_mem_evenOdd_zero (m₁ m₂ : M) : ι Q m₁ * ι Q m₂ ∈ e
           (LinearMap.mem_range_self (ι Q) m₂))
 #align clifford_algebra.ι_mul_ι_mem_even_odd_zero CliffordAlgebra.ι_mul_ι_mem_evenOdd_zero
 
-theorem evenOdd_mul_le (i j : ZMod 2) : evenOdd Q i * evenOdd Q j ≤ evenOdd Q (i + j) :=
-  by
+theorem evenOdd_mul_le (i j : ZMod 2) : evenOdd Q i * evenOdd Q j ≤ evenOdd Q (i + j) := by
   simp_rw [even_odd, Submodule.iSup_eq_span, Submodule.span_mul_span]
   apply Submodule.span_mono
   intro z hz
@@ -74,8 +71,7 @@ theorem evenOdd_mul_le (i j : ZMod 2) : evenOdd Q i * evenOdd Q j ≤ evenOdd Q 
   exact Submodule.mul_mem_mul hx' hy'
 #align clifford_algebra.even_odd_mul_le CliffordAlgebra.evenOdd_mul_le
 
-instance evenOdd.gradedMonoid : SetLike.GradedMonoid (evenOdd Q)
-    where
+instance evenOdd.gradedMonoid : SetLike.GradedMonoid (evenOdd Q) where
   one_mem := Submodule.one_le.mp (one_le_evenOdd_zero Q)
   mul_mem i j p q hp hq := Submodule.mul_le.mp (evenOdd_mul_le Q _ _) _ hp _ hq
 #align clifford_algebra.even_odd.graded_monoid CliffordAlgebra.evenOdd.gradedMonoid
@@ -92,16 +88,14 @@ theorem GradedAlgebra.ι_apply (m : M) :
 #align clifford_algebra.graded_algebra.ι_apply CliffordAlgebra.GradedAlgebra.ι_apply
 
 theorem GradedAlgebra.ι_sq_scalar (m : M) :
-    GradedAlgebra.ι Q m * GradedAlgebra.ι Q m = algebraMap R _ (Q m) :=
-  by
+    GradedAlgebra.ι Q m * GradedAlgebra.ι Q m = algebraMap R _ (Q m) := by
   rw [graded_algebra.ι_apply Q, DirectSum.of_mul_of, DirectSum.algebraMap_apply]
   refine' DirectSum.of_eq_of_gradedMonoid_eq (Sigma.subtype_ext rfl <| ι_sq_scalar _ _)
 #align clifford_algebra.graded_algebra.ι_sq_scalar CliffordAlgebra.GradedAlgebra.ι_sq_scalar
 
 theorem GradedAlgebra.lift_ι_eq (i' : ZMod 2) (x' : evenOdd Q i') :
     lift Q ⟨by apply graded_algebra.ι Q, GradedAlgebra.ι_sq_scalar Q⟩ x' =
-      DirectSum.of (fun i => evenOdd Q i) i' x' :=
-  by
+      DirectSum.of (fun i => evenOdd Q i) i' x' := by
   cases' x' with x' hx'
   dsimp only [Subtype.coe_mk, DirectSum.lof_eq_of]
   refine' Submodule.iSup_induction' _ (fun i x hx => _) _ (fun x y hx hy ihx ihy => _) hx'
@@ -140,8 +134,7 @@ instance gradedAlgebra : GradedAlgebra (evenOdd Q) :=
     (by apply graded_algebra.lift_ι_eq Q)
 #align clifford_algebra.graded_algebra CliffordAlgebra.gradedAlgebra
 
-theorem iSup_ι_range_eq_top : (⨆ i : ℕ, (ι Q).range ^ i) = ⊤ :=
-  by
+theorem iSup_ι_range_eq_top : (⨆ i : ℕ, (ι Q).range ^ i) = ⊤ := by
   rw [← (DirectSum.Decomposition.isInternal (even_odd Q)).submodule_iSup_eq_top, eq_comm]
   calc
     (⨆ (i : ZMod 2) (j : { n // ↑n = i }), (ι Q).range ^ ↑j) =
@@ -152,8 +145,7 @@ theorem iSup_ι_range_eq_top : (⨆ i : ℕ, (ι Q).range ^ i) = ⊤ :=
 #align clifford_algebra.supr_ι_range_eq_top CliffordAlgebra.iSup_ι_range_eq_top
 
 theorem evenOdd_isCompl : IsCompl (evenOdd Q 0) (evenOdd Q 1) :=
-  (DirectSum.Decomposition.isInternal (evenOdd Q)).IsCompl zero_ne_one <|
-    by
+  (DirectSum.Decomposition.isInternal (evenOdd Q)).IsCompl zero_ne_one <| by
     have : (Finset.univ : Finset (ZMod 2)) = {0, 1} := rfl
     simpa using congr_arg (coe : Finset (ZMod 2) → Set (ZMod 2)) this
 #align clifford_algebra.even_odd_is_compl CliffordAlgebra.evenOdd_isCompl
@@ -172,8 +164,7 @@ theorem evenOdd_induction (n : ZMod 2) {P : ∀ x, x ∈ evenOdd Q n → Prop}
         P x hx →
           P (ι Q m₁ * ι Q m₂ * x)
             (zero_add n ▸ SetLike.mul_mem_graded (ι_mul_ι_mem_evenOdd_zero Q m₁ m₂) hx))
-    (x : CliffordAlgebra Q) (hx : x ∈ evenOdd Q n) : P x hx :=
-  by
+    (x : CliffordAlgebra Q) (hx : x ∈ evenOdd Q n) : P x hx := by
   apply Submodule.iSup_induction' _ _ (hr 0 (Submodule.zero_mem _)) @hadd
   refine' Subtype.rec _
   simp_rw [Subtype.coe_mk, ZMod.nat_coe_zmod_eq_iff, add_comm n.val]
@@ -214,8 +205,7 @@ theorem even_induction {P : ∀ x, x ∈ evenOdd Q 0 → Prop}
         P x hx →
           P (ι Q m₁ * ι Q m₂ * x)
             (zero_add 0 ▸ SetLike.mul_mem_graded (ι_mul_ι_mem_evenOdd_zero Q m₁ m₂) hx))
-    (x : CliffordAlgebra Q) (hx : x ∈ evenOdd Q 0) : P x hx :=
-  by
+    (x : CliffordAlgebra Q) (hx : x ∈ evenOdd Q 0) : P x hx := by
   refine' even_odd_induction Q 0 (fun rx => _) (@hadd) hιι_mul x hx
   simp_rw [ZMod.val_zero, pow_zero]
   rintro ⟨r, rfl⟩
@@ -233,8 +223,7 @@ theorem odd_induction {P : ∀ x, x ∈ evenOdd Q 1 → Prop}
         P x hx →
           P (ι Q m₁ * ι Q m₂ * x)
             (zero_add (1 : ZMod 2) ▸ SetLike.mul_mem_graded (ι_mul_ι_mem_evenOdd_zero Q m₁ m₂) hx))
-    (x : CliffordAlgebra Q) (hx : x ∈ evenOdd Q 1) : P x hx :=
-  by
+    (x : CliffordAlgebra Q) (hx : x ∈ evenOdd Q 1) : P x hx := by
   refine' even_odd_induction Q 1 (fun ιv => _) (@hadd) hιι_mul x hx
   simp_rw [ZMod.val_one, pow_one]
   rintro ⟨v, rfl⟩

--- a/Mathlib/LinearAlgebra/CliffordAlgebra/Grading.lean
+++ b/Mathlib/LinearAlgebra/CliffordAlgebra/Grading.lean
@@ -33,7 +33,7 @@ variable (Q)
 /-- The even or odd submodule, defined as the supremum of the even or odd powers of
 `(ι Q).range`. `even_odd 0` is the even submodule, and `even_odd 1` is the odd submodule. -/
 def evenOdd (i : ZMod 2) : Submodule R (CliffordAlgebra Q) :=
-  ⨆ j : { n : ℕ // ↑n = i }, (ι Q).range ^ (j : ℕ)
+  ⨆ j : { n : ℕ // ↑n = i }, LinearMap.range (ι Q) ^ (j : ℕ)
 #align clifford_algebra.even_odd CliffordAlgebra.evenOdd
 
 theorem one_le_evenOdd_zero : 1 ≤ evenOdd Q 0 := by
@@ -41,7 +41,7 @@ theorem one_le_evenOdd_zero : 1 ≤ evenOdd Q 0 := by
   exact (pow_zero _).ge
 #align clifford_algebra.one_le_even_odd_zero CliffordAlgebra.one_le_evenOdd_zero
 
-theorem range_ι_le_evenOdd_one : (ι Q).range ≤ evenOdd Q 1 := by
+theorem range_ι_le_evenOdd_one : LinearMap.range (ι Q) ≤ evenOdd Q 1 := by
   refine' le_trans _ (le_iSup _ ⟨1, Nat.cast_one⟩)
   exact (pow_one _).ge
 #align clifford_algebra.range_ι_le_even_odd_one CliffordAlgebra.range_ι_le_evenOdd_one
@@ -60,13 +60,13 @@ theorem ι_mul_ι_mem_evenOdd_zero (m₁ m₂ : M) : ι Q m₁ * ι Q m₂ ∈ e
 #align clifford_algebra.ι_mul_ι_mem_even_odd_zero CliffordAlgebra.ι_mul_ι_mem_evenOdd_zero
 
 theorem evenOdd_mul_le (i j : ZMod 2) : evenOdd Q i * evenOdd Q j ≤ evenOdd Q (i + j) := by
-  simp_rw [even_odd, Submodule.iSup_eq_span, Submodule.span_mul_span]
+  simp_rw [evenOdd, Submodule.iSup_eq_span, Submodule.span_mul_span]
   apply Submodule.span_mono
   intro z hz
   obtain ⟨x, y, hx, hy, rfl⟩ := hz
-  obtain ⟨xi, hx'⟩ := set.mem_Union.mp hx
-  obtain ⟨yi, hy'⟩ := set.mem_Union.mp hy
-  refine' set.mem_Union.mpr ⟨⟨xi + yi, by simp only [Nat.cast_add, xi.prop, yi.prop]⟩, _⟩
+  obtain ⟨xi, hx'⟩ := Set.mem_iUnion.mp hx
+  obtain ⟨yi, hy'⟩ := Set.mem_iUnion.mp hy
+  refine' Set.mem_iUnion.mpr ⟨⟨xi + yi, by simp only [Nat.cast_add, xi.prop, yi.prop]⟩, _⟩
   simp only [Subtype.coe_mk, Nat.cast_add, pow_add]
   exact Submodule.mul_mem_mul hx' hy'
 #align clifford_algebra.even_odd_mul_le CliffordAlgebra.evenOdd_mul_le
@@ -78,7 +78,8 @@ instance evenOdd.gradedMonoid : SetLike.GradedMonoid (evenOdd Q) where
 
 /-- A version of `clifford_algebra.ι` that maps directly into the graded structure. This is
 primarily an auxiliary construction used to provide `clifford_algebra.graded_algebra`. -/
-def GradedAlgebra.ι : M →ₗ[R] ⨁ i : ZMod 2, evenOdd Q i :=
+-- porting note: added `protected`
+protected def GradedAlgebra.ι : M →ₗ[R] ⨁ i : ZMod 2, evenOdd Q i :=
   DirectSum.lof R (ZMod 2) (fun i => ↥(evenOdd Q i)) 1 ∘ₗ (ι Q).codRestrict _ (ι_mem_evenOdd_one Q)
 #align clifford_algebra.graded_algebra.ι CliffordAlgebra.GradedAlgebra.ι
 
@@ -87,35 +88,42 @@ theorem GradedAlgebra.ι_apply (m : M) :
   rfl
 #align clifford_algebra.graded_algebra.ι_apply CliffordAlgebra.GradedAlgebra.ι_apply
 
-theorem GradedAlgebra.ι_sq_scalar (m : M) :
+nonrec theorem GradedAlgebra.ι_sq_scalar (m : M) :
     GradedAlgebra.ι Q m * GradedAlgebra.ι Q m = algebraMap R _ (Q m) := by
-  rw [graded_algebra.ι_apply Q, DirectSum.of_mul_of, DirectSum.algebraMap_apply]
+  rw [GradedAlgebra.ι_apply Q, DirectSum.of_mul_of, DirectSum.algebraMap_apply]
   refine' DirectSum.of_eq_of_gradedMonoid_eq (Sigma.subtype_ext rfl <| ι_sq_scalar _ _)
 #align clifford_algebra.graded_algebra.ι_sq_scalar CliffordAlgebra.GradedAlgebra.ι_sq_scalar
 
 theorem GradedAlgebra.lift_ι_eq (i' : ZMod 2) (x' : evenOdd Q i') :
-    lift Q ⟨by apply graded_algebra.ι Q, GradedAlgebra.ι_sq_scalar Q⟩ x' =
+    -- porting note: added a second `by apply`
+    lift Q ⟨by apply GradedAlgebra.ι Q, by apply GradedAlgebra.ι_sq_scalar Q⟩ x' =
       DirectSum.of (fun i => evenOdd Q i) i' x' := by
   cases' x' with x' hx'
   dsimp only [Subtype.coe_mk, DirectSum.lof_eq_of]
-  refine' Submodule.iSup_induction' _ (fun i x hx => _) _ (fun x y hx hy ihx ihy => _) hx'
-  · obtain ⟨i, rfl⟩ := i
-    dsimp only [Subtype.coe_mk] at hx 
+  induction hx' using Submodule.iSup_induction' with
+  | hp i x hx =>
+  -- refine Submodule.iSup_induction' _ (@fun i x hx => ?_) _ (@fun x y hx hy ihx ihy => ?_) hx'
+    obtain ⟨i, rfl⟩ := i
+    rw [Subtype.coe_mk] at hx
+    induction hx using Submodule.pow_induction_on_left'
+    #exit
     refine'
       Submodule.pow_induction_on_left' _ (fun r => _) (fun x y i hx hy ihx ihy => _)
         (fun m hm i x hx ih => _) hx
     · rw [AlgHom.commutes, DirectSum.algebraMap_apply]; rfl
     · rw [AlgHom.map_add, ihx, ihy, ← map_add]; rfl
     · obtain ⟨_, rfl⟩ := hm
-      rw [AlgHom.map_mul, ih, lift_ι_apply, graded_algebra.ι_apply Q, DirectSum.of_mul_of]
+      rw [AlgHom.map_mul, ih, lift_ι_apply, GradedAlgebra.ι_apply Q, DirectSum.of_mul_of]
       refine' DirectSum.of_eq_of_gradedMonoid_eq (Sigma.subtype_ext _ _) <;>
         dsimp only [GradedMonoid.mk, Subtype.coe_mk]
       · rw [Nat.succ_eq_add_one, add_comm, Nat.cast_add, Nat.cast_one]
       rfl
-  · rw [AlgHom.map_zero]
+  | h0 =>
+    rw [AlgHom.map_zero]
     apply Eq.symm
-    apply dfinsupp.single_eq_zero.mpr; rfl
-  · rw [AlgHom.map_add, ihx, ihy, ← map_add]; rfl
+    apply Dfinsupp.single_eq_zero.mpr; rfl
+  | hadd x y hx hy ihx ihy =>
+    rw [AlgHom.map_add, ihx, ihy, ← map_add]; rfl
 #align clifford_algebra.graded_algebra.lift_ι_eq CliffordAlgebra.GradedAlgebra.lift_ι_eq
 
 /-- The clifford algebra is graded by the even and odd parts. -/
@@ -123,19 +131,19 @@ instance gradedAlgebra : GradedAlgebra (evenOdd Q) :=
   GradedAlgebra.ofAlgHom (evenOdd Q)
     (-- while not necessary, the `by apply` makes this elaborate faster
       lift
-      Q ⟨by apply graded_algebra.ι Q, GradedAlgebra.ι_sq_scalar Q⟩)
+      Q ⟨by apply GradedAlgebra.ι Q, GradedAlgebra.ι_sq_scalar Q⟩)
     (-- the proof from here onward is mostly similar to the `tensor_algebra` case, with some extra
     -- handling for the `supr` in `even_odd`.
     by
       ext m
       dsimp only [LinearMap.comp_apply, AlgHom.toLinearMap_apply, AlgHom.comp_apply,
         AlgHom.id_apply]
-      rw [lift_ι_apply, graded_algebra.ι_apply Q, DirectSum.coeAlgHom_of, Subtype.coe_mk])
-    (by apply graded_algebra.lift_ι_eq Q)
+      rw [lift_ι_apply, GradedAlgebra.ι_apply Q, DirectSum.coeAlgHom_of, Subtype.coe_mk])
+    (by apply GradedAlgebra.lift_ι_eq Q)
 #align clifford_algebra.graded_algebra CliffordAlgebra.gradedAlgebra
 
-theorem iSup_ι_range_eq_top : (⨆ i : ℕ, (ι Q).range ^ i) = ⊤ := by
-  rw [← (DirectSum.Decomposition.isInternal (even_odd Q)).submodule_iSup_eq_top, eq_comm]
+theorem iSup_ι_range_eq_top : (⨆ i : ℕ, LinearMap.range (ι Q) ^ i) = ⊤ := by
+  rw [← (DirectSum.Decomposition.isInternal (evenOdd Q)).submodule_iSup_eq_top, eq_comm]
   calc
     (⨆ (i : ZMod 2) (j : { n // ↑n = i }), (ι Q).range ^ ↑j) =
         ⨆ i : Σ i : ZMod 2, { n : ℕ // ↑n = i }, (ι Q).range ^ (i.2 : ℕ) :=
@@ -231,4 +239,3 @@ theorem odd_induction {P : ∀ x, x ∈ evenOdd Q 1 → Prop}
 #align clifford_algebra.odd_induction CliffordAlgebra.odd_induction
 
 end CliffordAlgebra
-

--- a/Mathlib/LinearAlgebra/CliffordAlgebra/Grading.lean
+++ b/Mathlib/LinearAlgebra/CliffordAlgebra/Grading.lean
@@ -1,0 +1,245 @@
+/-
+Copyright (c) 2021 Eric Wieser. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Eric Wieser
+
+! This file was ported from Lean 3 source module linear_algebra.clifford_algebra.grading
+! leanprover-community/mathlib commit 34020e531ebc4e8aac6d449d9eecbcd1508ea8d0
+! Please do not edit these lines, except to modify the commit id
+! if you have ported upstream changes.
+-/
+import Mathbin.LinearAlgebra.CliffordAlgebra.Basic
+import Mathbin.Data.Zmod.Basic
+import Mathbin.RingTheory.GradedAlgebra.Basic
+
+/-!
+# Results about the grading structure of the clifford algebra
+
+The main result is `clifford_algebra.graded_algebra`, which says that the clifford algebra is a
+ℤ₂-graded algebra (or "superalgebra").
+-/
+
+
+namespace CliffordAlgebra
+
+variable {R M : Type _} [CommRing R] [AddCommGroup M] [Module R M]
+
+variable {Q : QuadraticForm R M}
+
+open scoped DirectSum
+
+variable (Q)
+
+/-- The even or odd submodule, defined as the supremum of the even or odd powers of
+`(ι Q).range`. `even_odd 0` is the even submodule, and `even_odd 1` is the odd submodule. -/
+def evenOdd (i : ZMod 2) : Submodule R (CliffordAlgebra Q) :=
+  ⨆ j : { n : ℕ // ↑n = i }, (ι Q).range ^ (j : ℕ)
+#align clifford_algebra.even_odd CliffordAlgebra.evenOdd
+
+theorem one_le_evenOdd_zero : 1 ≤ evenOdd Q 0 :=
+  by
+  refine' le_trans _ (le_iSup _ ⟨0, Nat.cast_zero⟩)
+  exact (pow_zero _).ge
+#align clifford_algebra.one_le_even_odd_zero CliffordAlgebra.one_le_evenOdd_zero
+
+theorem range_ι_le_evenOdd_one : (ι Q).range ≤ evenOdd Q 1 :=
+  by
+  refine' le_trans _ (le_iSup _ ⟨1, Nat.cast_one⟩)
+  exact (pow_one _).ge
+#align clifford_algebra.range_ι_le_even_odd_one CliffordAlgebra.range_ι_le_evenOdd_one
+
+theorem ι_mem_evenOdd_one (m : M) : ι Q m ∈ evenOdd Q 1 :=
+  range_ι_le_evenOdd_one Q <| LinearMap.mem_range_self _ m
+#align clifford_algebra.ι_mem_even_odd_one CliffordAlgebra.ι_mem_evenOdd_one
+
+theorem ι_mul_ι_mem_evenOdd_zero (m₁ m₂ : M) : ι Q m₁ * ι Q m₂ ∈ evenOdd Q 0 :=
+  Submodule.mem_iSup_of_mem ⟨2, rfl⟩
+    (by
+      rw [Subtype.coe_mk, pow_two]
+      exact
+        Submodule.mul_mem_mul (LinearMap.mem_range_self (ι Q) m₁)
+          (LinearMap.mem_range_self (ι Q) m₂))
+#align clifford_algebra.ι_mul_ι_mem_even_odd_zero CliffordAlgebra.ι_mul_ι_mem_evenOdd_zero
+
+theorem evenOdd_mul_le (i j : ZMod 2) : evenOdd Q i * evenOdd Q j ≤ evenOdd Q (i + j) :=
+  by
+  simp_rw [even_odd, Submodule.iSup_eq_span, Submodule.span_mul_span]
+  apply Submodule.span_mono
+  intro z hz
+  obtain ⟨x, y, hx, hy, rfl⟩ := hz
+  obtain ⟨xi, hx'⟩ := set.mem_Union.mp hx
+  obtain ⟨yi, hy'⟩ := set.mem_Union.mp hy
+  refine' set.mem_Union.mpr ⟨⟨xi + yi, by simp only [Nat.cast_add, xi.prop, yi.prop]⟩, _⟩
+  simp only [Subtype.coe_mk, Nat.cast_add, pow_add]
+  exact Submodule.mul_mem_mul hx' hy'
+#align clifford_algebra.even_odd_mul_le CliffordAlgebra.evenOdd_mul_le
+
+instance evenOdd.gradedMonoid : SetLike.GradedMonoid (evenOdd Q)
+    where
+  one_mem := Submodule.one_le.mp (one_le_evenOdd_zero Q)
+  mul_mem i j p q hp hq := Submodule.mul_le.mp (evenOdd_mul_le Q _ _) _ hp _ hq
+#align clifford_algebra.even_odd.graded_monoid CliffordAlgebra.evenOdd.gradedMonoid
+
+/-- A version of `clifford_algebra.ι` that maps directly into the graded structure. This is
+primarily an auxiliary construction used to provide `clifford_algebra.graded_algebra`. -/
+def GradedAlgebra.ι : M →ₗ[R] ⨁ i : ZMod 2, evenOdd Q i :=
+  DirectSum.lof R (ZMod 2) (fun i => ↥(evenOdd Q i)) 1 ∘ₗ (ι Q).codRestrict _ (ι_mem_evenOdd_one Q)
+#align clifford_algebra.graded_algebra.ι CliffordAlgebra.GradedAlgebra.ι
+
+theorem GradedAlgebra.ι_apply (m : M) :
+    GradedAlgebra.ι Q m = DirectSum.of (fun i => ↥(evenOdd Q i)) 1 ⟨ι Q m, ι_mem_evenOdd_one Q m⟩ :=
+  rfl
+#align clifford_algebra.graded_algebra.ι_apply CliffordAlgebra.GradedAlgebra.ι_apply
+
+theorem GradedAlgebra.ι_sq_scalar (m : M) :
+    GradedAlgebra.ι Q m * GradedAlgebra.ι Q m = algebraMap R _ (Q m) :=
+  by
+  rw [graded_algebra.ι_apply Q, DirectSum.of_mul_of, DirectSum.algebraMap_apply]
+  refine' DirectSum.of_eq_of_gradedMonoid_eq (Sigma.subtype_ext rfl <| ι_sq_scalar _ _)
+#align clifford_algebra.graded_algebra.ι_sq_scalar CliffordAlgebra.GradedAlgebra.ι_sq_scalar
+
+theorem GradedAlgebra.lift_ι_eq (i' : ZMod 2) (x' : evenOdd Q i') :
+    lift Q ⟨by apply graded_algebra.ι Q, GradedAlgebra.ι_sq_scalar Q⟩ x' =
+      DirectSum.of (fun i => evenOdd Q i) i' x' :=
+  by
+  cases' x' with x' hx'
+  dsimp only [Subtype.coe_mk, DirectSum.lof_eq_of]
+  refine' Submodule.iSup_induction' _ (fun i x hx => _) _ (fun x y hx hy ihx ihy => _) hx'
+  · obtain ⟨i, rfl⟩ := i
+    dsimp only [Subtype.coe_mk] at hx 
+    refine'
+      Submodule.pow_induction_on_left' _ (fun r => _) (fun x y i hx hy ihx ihy => _)
+        (fun m hm i x hx ih => _) hx
+    · rw [AlgHom.commutes, DirectSum.algebraMap_apply]; rfl
+    · rw [AlgHom.map_add, ihx, ihy, ← map_add]; rfl
+    · obtain ⟨_, rfl⟩ := hm
+      rw [AlgHom.map_mul, ih, lift_ι_apply, graded_algebra.ι_apply Q, DirectSum.of_mul_of]
+      refine' DirectSum.of_eq_of_gradedMonoid_eq (Sigma.subtype_ext _ _) <;>
+        dsimp only [GradedMonoid.mk, Subtype.coe_mk]
+      · rw [Nat.succ_eq_add_one, add_comm, Nat.cast_add, Nat.cast_one]
+      rfl
+  · rw [AlgHom.map_zero]
+    apply Eq.symm
+    apply dfinsupp.single_eq_zero.mpr; rfl
+  · rw [AlgHom.map_add, ihx, ihy, ← map_add]; rfl
+#align clifford_algebra.graded_algebra.lift_ι_eq CliffordAlgebra.GradedAlgebra.lift_ι_eq
+
+/-- The clifford algebra is graded by the even and odd parts. -/
+instance gradedAlgebra : GradedAlgebra (evenOdd Q) :=
+  GradedAlgebra.ofAlgHom (evenOdd Q)
+    (-- while not necessary, the `by apply` makes this elaborate faster
+      lift
+      Q ⟨by apply graded_algebra.ι Q, GradedAlgebra.ι_sq_scalar Q⟩)
+    (-- the proof from here onward is mostly similar to the `tensor_algebra` case, with some extra
+    -- handling for the `supr` in `even_odd`.
+    by
+      ext m
+      dsimp only [LinearMap.comp_apply, AlgHom.toLinearMap_apply, AlgHom.comp_apply,
+        AlgHom.id_apply]
+      rw [lift_ι_apply, graded_algebra.ι_apply Q, DirectSum.coeAlgHom_of, Subtype.coe_mk])
+    (by apply graded_algebra.lift_ι_eq Q)
+#align clifford_algebra.graded_algebra CliffordAlgebra.gradedAlgebra
+
+theorem iSup_ι_range_eq_top : (⨆ i : ℕ, (ι Q).range ^ i) = ⊤ :=
+  by
+  rw [← (DirectSum.Decomposition.isInternal (even_odd Q)).submodule_iSup_eq_top, eq_comm]
+  calc
+    (⨆ (i : ZMod 2) (j : { n // ↑n = i }), (ι Q).range ^ ↑j) =
+        ⨆ i : Σ i : ZMod 2, { n : ℕ // ↑n = i }, (ι Q).range ^ (i.2 : ℕ) :=
+      by rw [iSup_sigma]
+    _ = ⨆ i : ℕ, (ι Q).range ^ i :=
+      Function.Surjective.iSup_congr (fun i => i.2) (fun i => ⟨⟨_, i, rfl⟩, rfl⟩) fun _ => rfl
+#align clifford_algebra.supr_ι_range_eq_top CliffordAlgebra.iSup_ι_range_eq_top
+
+theorem evenOdd_isCompl : IsCompl (evenOdd Q 0) (evenOdd Q 1) :=
+  (DirectSum.Decomposition.isInternal (evenOdd Q)).IsCompl zero_ne_one <|
+    by
+    have : (Finset.univ : Finset (ZMod 2)) = {0, 1} := rfl
+    simpa using congr_arg (coe : Finset (ZMod 2) → Set (ZMod 2)) this
+#align clifford_algebra.even_odd_is_compl CliffordAlgebra.evenOdd_isCompl
+
+/-- To show a property is true on the even or odd part, it suffices to show it is true on the
+scalars or vectors (respectively), closed under addition, and under left-multiplication by a pair
+of vectors. -/
+@[elab_as_elim]
+theorem evenOdd_induction (n : ZMod 2) {P : ∀ x, x ∈ evenOdd Q n → Prop}
+    (hr :
+      ∀ (v) (h : v ∈ (ι Q).range ^ n.val),
+        P v (Submodule.mem_iSup_of_mem ⟨n.val, n.nat_cast_zmod_val⟩ h))
+    (hadd : ∀ {x y hx hy}, P x hx → P y hy → P (x + y) (Submodule.add_mem _ hx hy))
+    (hιι_mul :
+      ∀ (m₁ m₂) {x hx},
+        P x hx →
+          P (ι Q m₁ * ι Q m₂ * x)
+            (zero_add n ▸ SetLike.mul_mem_graded (ι_mul_ι_mem_evenOdd_zero Q m₁ m₂) hx))
+    (x : CliffordAlgebra Q) (hx : x ∈ evenOdd Q n) : P x hx :=
+  by
+  apply Submodule.iSup_induction' _ _ (hr 0 (Submodule.zero_mem _)) @hadd
+  refine' Subtype.rec _
+  simp_rw [Subtype.coe_mk, ZMod.nat_coe_zmod_eq_iff, add_comm n.val]
+  rintro n' ⟨k, rfl⟩ xv
+  simp_rw [pow_add, pow_mul]
+  refine' Submodule.mul_induction_on' _ _
+  · intro a ha b hb
+    refine' Submodule.pow_induction_on_left' ((ι Q).range ^ 2) _ _ _ ha
+    · intro r
+      simp_rw [← Algebra.smul_def]
+      exact hr _ (Submodule.smul_mem _ _ hb)
+    · intro x y n hx hy
+      simp_rw [add_mul]
+      apply hadd
+    · intro x hx n y hy ihy
+      revert hx
+      simp_rw [pow_two]
+      refine' Submodule.mul_induction_on' _ _
+      · simp_rw [LinearMap.mem_range]
+        rintro _ ⟨m₁, rfl⟩ _ ⟨m₂, rfl⟩
+        simp_rw [mul_assoc _ y b]
+        refine' hιι_mul _ _ ihy
+      · intro x hx y hy ihx ihy
+        simp_rw [add_mul]
+        apply hadd ihx ihy
+  · intro x y hx hy
+    apply hadd
+#align clifford_algebra.even_odd_induction CliffordAlgebra.evenOdd_induction
+
+/-- To show a property is true on the even parts, it suffices to show it is true on the
+scalars, closed under addition, and under left-multiplication by a pair of vectors. -/
+@[elab_as_elim]
+theorem even_induction {P : ∀ x, x ∈ evenOdd Q 0 → Prop}
+    (hr : ∀ r : R, P (algebraMap _ _ r) (SetLike.algebraMap_mem_graded _ _))
+    (hadd : ∀ {x y hx hy}, P x hx → P y hy → P (x + y) (Submodule.add_mem _ hx hy))
+    (hιι_mul :
+      ∀ (m₁ m₂) {x hx},
+        P x hx →
+          P (ι Q m₁ * ι Q m₂ * x)
+            (zero_add 0 ▸ SetLike.mul_mem_graded (ι_mul_ι_mem_evenOdd_zero Q m₁ m₂) hx))
+    (x : CliffordAlgebra Q) (hx : x ∈ evenOdd Q 0) : P x hx :=
+  by
+  refine' even_odd_induction Q 0 (fun rx => _) (@hadd) hιι_mul x hx
+  simp_rw [ZMod.val_zero, pow_zero]
+  rintro ⟨r, rfl⟩
+  exact hr r
+#align clifford_algebra.even_induction CliffordAlgebra.even_induction
+
+/-- To show a property is true on the odd parts, it suffices to show it is true on the
+vectors, closed under addition, and under left-multiplication by a pair of vectors. -/
+@[elab_as_elim]
+theorem odd_induction {P : ∀ x, x ∈ evenOdd Q 1 → Prop}
+    (hι : ∀ v, P (ι Q v) (ι_mem_evenOdd_one _ _))
+    (hadd : ∀ {x y hx hy}, P x hx → P y hy → P (x + y) (Submodule.add_mem _ hx hy))
+    (hιι_mul :
+      ∀ (m₁ m₂) {x hx},
+        P x hx →
+          P (ι Q m₁ * ι Q m₂ * x)
+            (zero_add (1 : ZMod 2) ▸ SetLike.mul_mem_graded (ι_mul_ι_mem_evenOdd_zero Q m₁ m₂) hx))
+    (x : CliffordAlgebra Q) (hx : x ∈ evenOdd Q 1) : P x hx :=
+  by
+  refine' even_odd_induction Q 1 (fun ιv => _) (@hadd) hιι_mul x hx
+  simp_rw [ZMod.val_one, pow_one]
+  rintro ⟨v, rfl⟩
+  exact hι v
+#align clifford_algebra.odd_induction CliffordAlgebra.odd_induction
+
+end CliffordAlgebra
+

--- a/Mathlib/LinearAlgebra/CliffordAlgebra/Grading.lean
+++ b/Mathlib/LinearAlgebra/CliffordAlgebra/Grading.lean
@@ -73,7 +73,7 @@ theorem evenOdd_mul_le (i j : ZMod 2) : evenOdd Q i * evenOdd Q j ≤ evenOdd Q 
 
 instance evenOdd.gradedMonoid : SetLike.GradedMonoid (evenOdd Q) where
   one_mem := Submodule.one_le.mp (one_le_evenOdd_zero Q)
-  mul_mem i j p q hp hq := Submodule.mul_le.mp (evenOdd_mul_le Q _ _) _ hp _ hq
+  mul_mem _i _j _p _q hp hq := Submodule.mul_le.mp (evenOdd_mul_le Q _ _) _ hp _ hq
 #align clifford_algebra.even_odd.graded_monoid CliffordAlgebra.evenOdd.gradedMonoid
 
 /-- A version of `clifford_algebra.ι` that maps directly into the graded structure. This is
@@ -130,12 +130,11 @@ set_option maxHeartbeats 300000 in
 /-- The clifford algebra is graded by the even and odd parts. -/
 instance gradedAlgebra : GradedAlgebra (evenOdd Q) :=
   GradedAlgebra.ofAlgHom (evenOdd Q)
-    (-- while not necessary, the `by apply` makes this elaborate faster
-      lift
-      Q ⟨by apply GradedAlgebra.ι Q, by apply GradedAlgebra.ι_sq_scalar Q⟩)
-    (-- the proof from here onward is mostly similar to the `tensor_algebra` case, with some extra
+    -- while not necessary, the `by apply` makes this elaborate faster
+    (lift Q ⟨by apply GradedAlgebra.ι Q, by apply GradedAlgebra.ι_sq_scalar Q⟩)
+    -- the proof from here onward is mostly similar to the `tensor_algebra` case, with some extra
     -- handling for the `supr` in `even_odd`.
-    by
+    (by
       ext m
       dsimp only [LinearMap.comp_apply, AlgHom.toLinearMap_apply, AlgHom.comp_apply,
         AlgHom.id_apply]

--- a/Mathlib/LinearAlgebra/CliffordAlgebra/Grading.lean
+++ b/Mathlib/LinearAlgebra/CliffordAlgebra/Grading.lean
@@ -15,7 +15,7 @@ import Mathlib.RingTheory.GradedAlgebra.Basic
 /-!
 # Results about the grading structure of the clifford algebra
 
-The main result is `clifford_algebra.graded_algebra`, which says that the clifford algebra is a
+The main result is `CliffordAlgebra.gradedAlgebra`, which says that the clifford algebra is a
 ℤ₂-graded algebra (or "superalgebra").
 -/
 
@@ -76,8 +76,8 @@ instance evenOdd.gradedMonoid : SetLike.GradedMonoid (evenOdd Q) where
   mul_mem _i _j _p _q hp hq := Submodule.mul_le.mp (evenOdd_mul_le Q _ _) _ hp _ hq
 #align clifford_algebra.even_odd.graded_monoid CliffordAlgebra.evenOdd.gradedMonoid
 
-/-- A version of `clifford_algebra.ι` that maps directly into the graded structure. This is
-primarily an auxiliary construction used to provide `clifford_algebra.graded_algebra`. -/
+/-- A version of `CliffordAlgebra.ι` that maps directly into the graded structure. This is
+primarily an auxiliary construction used to provide `CliffordAlgebra.gradedAlgebra`. -/
 -- porting note: added `protected`
 protected def GradedAlgebra.ι : M →ₗ[R] ⨁ i : ZMod 2, evenOdd Q i :=
   DirectSum.lof R (ZMod 2) (fun i => ↥(evenOdd Q i)) 1 ∘ₗ (ι Q).codRestrict _ (ι_mem_evenOdd_one Q)
@@ -132,8 +132,8 @@ instance gradedAlgebra : GradedAlgebra (evenOdd Q) :=
   GradedAlgebra.ofAlgHom (evenOdd Q)
     -- while not necessary, the `by apply` makes this elaborate faster
     (lift Q ⟨by apply GradedAlgebra.ι Q, by apply GradedAlgebra.ι_sq_scalar Q⟩)
-    -- the proof from here onward is mostly similar to the `tensor_algebra` case, with some extra
-    -- handling for the `supr` in `even_odd`.
+    -- the proof from here onward is mostly similar to the `TensorAlgebra` case, with some extra
+    -- handling for the `iSup` in `even_odd`.
     (by
       ext m
       dsimp only [LinearMap.comp_apply, AlgHom.toLinearMap_apply, AlgHom.comp_apply,


### PR DESCRIPTION
Annoyingly, Lean 4 cannot work out that `reverse x` where `x : clifford_algebra Q` is referring to `reverse (Q := Q) x`, even though that's the only thing that type checks.

Otherwise the only difficulty when porting was the standard `LinearMap.range` dot notation failing thing.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
-->

- [x] depends on: #5349

Please rebase this to remove the #5349 commits before merging (I will likely not be around to do so)

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
