### PR TITLE
feat: Add simp lemmas for vectors, and a way to index vectors with Nats (Alternative)

### DIFF
--- a/Mathlib/Data/Vector.lean
+++ b/Mathlib/Data/Vector.lean
@@ -95,6 +95,11 @@ def get : ∀ _ : Vector α n, Fin n → α
   | ⟨l, h⟩, i => l.nthLe i.1 (by rw [h] ; exact i.2)
 #align vector.nth Vector.get
 
+/-- nth element of a vector, indexed by a `Nat`.
+Returns `none` if vector is not long enough-/
+def get? : ∀ _ : Vector α n, Nat → Option α
+  | v, i => if h : i < n then some (v.get ⟨i,h⟩) else none
+
 /-- Appending a vector to another. -/
 def append {n m : Nat} : Vector α n → Vector α m → Vector α (n + m)
   | ⟨l₁, h₁⟩, ⟨l₂, h₂⟩ => ⟨l₁ ++ l₂, by simp [*]⟩
@@ -137,6 +142,7 @@ theorem map_nil (f : α → β) : map f nil = nil :=
 #align vector.map_nil Vector.map_nil
 
 /-- `map` is natural with respect to `cons`. -/
+@[simp]
 theorem map_cons (f : α → β) (a : α) : ∀ v : Vector α n, map f (cons a v) = cons (f a) (map f v)
   | ⟨_, _⟩ => rfl
 #align vector.map_cons Vector.map_cons
@@ -257,5 +263,11 @@ theorem toList_take {n m : ℕ} (v : Vector α m) : toList (take n v) = List.tak
   cases v
   rfl
 #align vector.to_list_take Vector.toList_take
+
+instance {α : Type u} {n : Nat} : GetElem (Vector α n) (Fin n) α (fun _ _ => True) where
+  getElem := fun x i _ => get x i
+
+instance {α : Type u} {n : Nat} : GetElem (Vector α n) Nat α (fun _ i => i < n) where
+  getElem := fun x i h => get x ⟨i,h⟩
 
 end Vector

--- a/Mathlib/Data/Vector.lean
+++ b/Mathlib/Data/Vector.lean
@@ -89,17 +89,6 @@ def toList (v : Vector α n) : List α :=
   v.1
 #align vector.to_list Vector.toList
 
--- porting notes: align to `List` API
-/-- nth element of a vector, indexed by a `Fin` type. -/
-def get : ∀ _ : Vector α n, Fin n → α
-  | ⟨l, h⟩, i => l.nthLe i.1 (by rw [h] ; exact i.2)
-#align vector.nth Vector.get
-
-/-- nth element of a vector, indexed by a `Nat`.
-Returns `none` if vector is not long enough-/
-def get? : ∀ _ : Vector α n, Nat → Option α
-  | v, i => if h : i < n then some (v.get ⟨i,h⟩) else none
-
 /-- Appending a vector to another. -/
 def append {n m : Nat} : Vector α n → Vector α m → Vector α (n + m)
   | ⟨l₁, h₁⟩, ⟨l₂, h₂⟩ => ⟨l₁ ++ l₂, by simp [*]⟩
@@ -265,6 +254,13 @@ theorem toList_take {n m : ℕ} (v : Vector α m) : toList (take n v) = List.tak
 #align vector.to_list_take Vector.toList_take
 
 instance : GetElem (Vector α n) Nat α fun _ i => i < n where
-  getElem := fun x i h => get x ⟨i, h⟩
+  -- getElem := fun x i h => x.1.get ⟨i, by rcases x with ⟨_, ⟨⟩⟩; exact h⟩
+  getElem := fun ⟨l, hl⟩ i h => l.get ⟨i, by rw [hl] ; exact h⟩
+
+-- porting notes: align to `List` API
+/-- nth element of a vector, indexed by a `Fin` type. -/
+abbrev get (v : Vector α n)  (i : Fin n) : α :=
+  v[i]
+#align vector.nth Vector.get
 
 end Vector

--- a/Mathlib/Data/Vector.lean
+++ b/Mathlib/Data/Vector.lean
@@ -259,7 +259,7 @@ instance : GetElem (Vector α n) Nat α fun _ i => i < n where
 -- porting notes: align to `List` API
 /-- nth element of a vector, indexed by a `Fin` type. -/
 abbrev get (v : Vector α n)  (i : Fin n) : α :=
-  v[i]
+  v[i.1]
 #align vector.nth Vector.get
 
 end Vector

--- a/Mathlib/Data/Vector.lean
+++ b/Mathlib/Data/Vector.lean
@@ -18,6 +18,27 @@ import Mathlib.Init.Data.List.Lemmas
 The type `Vector` represents lists with fixed length.
 -/
 
+/-
+  Replace the exisiting instance for indexing a collection with `Fin n`.
+  The new instance is more strict, only allowing a `Vector _ n` to be indexed by `Fin n`, where the
+  older version allowed the same vector to be indexed by, say `Fin (n+1)` if it could be proven that
+  the actual value of the `Fin` was less than `n`.
+  This extra proof causes problems in rewrites.
+-/
+attribute [-instance] instGetElemFinVal
+section GetElem
+  variable (cont : ℕ → Type u)
+
+instance [GetElem (cont n) Nat elem (fun _ i => i < n)] : GetElem (cont n) (Fin n) elem fun _ _ => True where
+  getElem xs i _ := getElem xs i.1 i.2
+
+end GetElem
+
+-- Get rid of the following simp lemmas, so that we can keep `v[i]` as normal form, rather than
+-- `v[i.1]`, when `i : Fin n`
+-- TODO: remove this after https://github.com/leanprover/std4/pull/162 is merged
+attribute [-simp] getElem_fin getElem?_fin getElem!_fin
+
 universe u v w
 /-- `Vector α n` is the type of lists of length `n` with elements of type `α`. -/
 def Vector (α : Type u) (n : ℕ) :=
@@ -259,7 +280,7 @@ instance : GetElem (Vector α n) Nat α fun _ i => i < n where
 -- porting notes: align to `List` API
 /-- nth element of a vector, indexed by a `Fin` type. -/
 abbrev get (v : Vector α n)  (i : Fin n) : α :=
-  v[i.1]
+  v[i]
 #align vector.nth Vector.get
 
 end Vector

--- a/Mathlib/Data/Vector.lean
+++ b/Mathlib/Data/Vector.lean
@@ -25,12 +25,12 @@ The type `Vector` represents lists with fixed length.
   the actual value of the `Fin` was less than `n`.
   This extra proof causes problems in rewrites.
 -/
-attribute [-instance] instGetElemFinVal
 section GetElem
   variable (cont : ℕ → Type u)
 
-instance [GetElem (cont n) Nat elem (fun _ i => i < n)] : GetElem (cont n) (Fin n) elem fun _ _ => True where
-  getElem xs i _ := getElem xs i.1 i.2
+  instance [GetElem (cont n) Nat elem (fun _ i => i < n)] :
+      GetElem (cont n) (Fin n) elem fun _ _ => True where
+    getElem xs i _ := getElem xs i.1 i.2
 
 end GetElem
 

--- a/Mathlib/Data/Vector.lean
+++ b/Mathlib/Data/Vector.lean
@@ -264,9 +264,6 @@ theorem toList_take {n m : ℕ} (v : Vector α m) : toList (take n v) = List.tak
   rfl
 #align vector.to_list_take Vector.toList_take
 
-instance {α : Type u} {n : Nat} : GetElem (Vector α n) (Fin n) α (fun _ _ => True) where
-  getElem := fun x i _ => get x i
-
 instance : GetElem (Vector α n) Nat α fun _ i => i < n where
   getElem := fun x i h => get x ⟨i, h⟩
 

--- a/Mathlib/Data/Vector.lean
+++ b/Mathlib/Data/Vector.lean
@@ -267,7 +267,7 @@ theorem toList_take {n m : ℕ} (v : Vector α m) : toList (take n v) = List.tak
 instance {α : Type u} {n : Nat} : GetElem (Vector α n) (Fin n) α (fun _ _ => True) where
   getElem := fun x i _ => get x i
 
-instance {α : Type u} {n : Nat} : GetElem (Vector α n) Nat α (fun _ i => i < n) where
-  getElem := fun x i h => get x ⟨i,h⟩
+instance : GetElem (Vector α n) Nat α fun _ i => i < n where
+  getElem := fun x i h => get x ⟨i, h⟩
 
 end Vector

--- a/Mathlib/Data/Vector.lean
+++ b/Mathlib/Data/Vector.lean
@@ -254,7 +254,6 @@ theorem toList_take {n m : ℕ} (v : Vector α m) : toList (take n v) = List.tak
 #align vector.to_list_take Vector.toList_take
 
 instance : GetElem (Vector α n) Nat α fun _ i => i < n where
-  -- getElem := fun x i h => x.1.get ⟨i, by rcases x with ⟨_, ⟨⟩⟩; exact h⟩
   getElem := fun ⟨l, hl⟩ i h => l.get ⟨i, by rw [hl] ; exact h⟩
 
 -- porting notes: align to `List` API

--- a/Mathlib/Data/Vector.lean
+++ b/Mathlib/Data/Vector.lean
@@ -34,11 +34,6 @@ section GetElem
 
 end GetElem
 
--- Get rid of the following simp lemmas, so that we can keep `v[i]` as normal form, rather than
--- `v[i.1]`, when `i : Fin n`
--- TODO: remove this after https://github.com/leanprover/std4/pull/162 is merged
-attribute [-simp] getElem_fin getElem?_fin getElem!_fin
-
 universe u v w
 /-- `Vector α n` is the type of lists of length `n` with elements of type `α`. -/
 def Vector (α : Type u) (n : ℕ) :=

--- a/Mathlib/Data/Vector/Basic.lean
+++ b/Mathlib/Data/Vector/Basic.lean
@@ -137,6 +137,15 @@ theorem get_map {β : Type _} (v : Vector α n) (f : α → β) (i : Fin n) :
 #align vector.nth_map Vector.get_map
 
 @[simp]
+theorem Vector.map₂_nil (f : α → β → γ) : Vector.map₂ f nil nil = nil :=
+  rfl
+
+@[simp]
+theorem Vector.map₂_cons (hd₁ : α) (tl₁ : Vector α n) (hd₂ : β) (tl₂ : Vector β n) (f : α → β → γ) :
+    Vector.map₂ f (hd₁ ::ᵥ tl₁) (hd₂ ::ᵥ tl₂) = f hd₁ hd₂ ::ᵥ (Vector.map₂ f tl₁ tl₂) :=
+  rfl
+
+@[simp]
 theorem get_ofFn {n} (f : Fin n → α) (i) : get (ofFn f) i = f i := by
   cases' i with i hi
   conv_rhs => erw [← List.get_ofFn f ⟨i, by simpa using hi⟩]
@@ -735,5 +744,38 @@ instance : IsLawfulTraversable.{u} (flip Vector n) where
 --           reflected _ @Vector.cons.{u}).subst₄
 --       q(α) q(n) q(x) ih
 -- #align vector.reflect vector.reflect
+
+@[simp]
+theorem Vector.replicate_succ : replicate (n+1) val = val ::ᵥ (replicate n val) :=
+  rfl
+
+@[simp]
+theorem Vector.get_append_cons_zero : get (append (x ::ᵥ xs) ys) ⟨0, by simp⟩ = x :=
+  rfl
+
+@[simp]
+theorem Vector.get_append_cons_succ {i : Fin (n + m)} {h} :
+    get (append (x ::ᵥ xs) ys) ⟨i+1, h⟩ = get (append xs ys) i :=
+  rfl
+
+@[simp]
+theorem Vector.append_nil : (append xs Vector.nil) = xs :=
+  by cases xs; simp[append]
+
+
+@[simp]
+theorem Vector.get_map₂ (v₁ : Vector α n) (v₂ : Vector β n) (f : α → β → γ) (i : Fin n) :
+    Vector.get (Vector.map₂ f v₁ v₂) i = f (Vector.get v₁ i) (Vector.get v₂ i) := by
+  induction v₁, v₂ using Vector.inductionOn₂
+  case nil =>
+    exact Fin.elim0 i
+  case cons x xs y ys ih =>
+    rw [Vector.map₂_cons]
+    cases i using Fin.cases
+    . simp only [get_zero, head_cons]
+    . simp only [get_cons_succ, ih]
+
+theorem get_eq_val_eq {α : Type u} {n : Nat} (x x' : Vector α n) (i : Fin n) (h : x.toList = x'.toList) : (get x i) = (get x' i) := by
+  rw [Vector.eq x x' h]
 
 end Vector

--- a/Mathlib/Data/Vector/Basic.lean
+++ b/Mathlib/Data/Vector/Basic.lean
@@ -515,6 +515,34 @@ def inductionOn₃ {C : ∀ {n}, Vector α n → Vector β n → Vector γ n →
     apply ih
 #align vector.induction_on₃ Vector.inductionOn₃
 
+/-- Define `motive v` by case-analysis on `v : Vector α n` -/
+def casesOn {motive : ∀{n}, Vector α n → Sort _}
+            (v : Vector α m)
+            (nil : motive nil)
+            (cons : ∀{n}, (hd : α) → (tl : Vector α n) → motive (Vector.cons hd tl)) :
+              motive v :=
+    inductionOn (C:=motive) v nil @fun _ hd tl _ => cons hd tl
+
+/-- Define `motive v₁ v₂` by case-analysis on `v₁ : Vector α n` and `v₂ : Vector β n` -/
+def casesOn₂  {motive : ∀{n}, Vector α n → Vector β n → Sort _}
+              (v₁ : Vector α m) (v₂ : Vector β m)
+              (nil : motive nil nil)
+              (cons : ∀{n}, (x : α) → (y : β) → (xs : Vector α n) → (ys : Vector β n)
+                      → motive (x ::ᵥ xs) (y ::ᵥ ys)) :
+                motive v₁ v₂ :=
+    inductionOn₂ (C:=motive) v₁ v₂ nil @fun _ x y xs ys _ => cons x y xs ys
+
+/-- Define `motive v₁ v₂ v₃` by case-analysis on `v₁ : Vector α n`, `v₂ : Vector β n`, and
+    `v₃ : Vector γ n` -/
+def casesOn₃  {motive : ∀{n}, Vector α n → Vector β n → Vector γ n → Sort _}
+              (v₁ : Vector α m) (v₂ : Vector β m) (v₃ : Vector γ m)
+              (nil : motive nil nil nil)
+              (cons : ∀{n}, (x : α) → (y : β) → (z : γ) → (xs : Vector α n) → (ys : Vector β n)
+                        → (zs : Vector γ n)
+                        → motive (x ::ᵥ xs) (y ::ᵥ ys) (z ::ᵥ zs)) :
+                motive v₁ v₂ v₃ :=
+    inductionOn₃ (C:=motive) v₁ v₂ v₃ nil @fun _ x y z xs ys zs _ => cons x y z xs ys zs
+
 /-- Cast a vector to an array. -/
 def toArray : Vector α n → Array α
   | ⟨xs, _⟩ => cast (by rfl) xs.toArray

--- a/Mathlib/Data/Vector/Basic.lean
+++ b/Mathlib/Data/Vector/Basic.lean
@@ -803,7 +803,9 @@ theorem Vector.get_map₂ (v₁ : Vector α n) (v₂ : Vector β n) (f : α → 
     . simp only [get_zero, head_cons]
     . simp only [get_cons_succ, ih]
 
-theorem get_eq_val_eq {α : Type u} {n : Nat} (x x' : Vector α n) (i : Fin n) (h : x.toList = x'.toList) : (get x i) = (get x' i) := by
+theorem get_eq_val_eq {α : Type u} {n : Nat} (x x' : Vector α n) (i : Fin n)
+                      (h : x.toList = x'.toList) :
+    (get x i) = (get x' i) := by
   rw [Vector.eq x x' h]
 
 end Vector

--- a/Mathlib/Data/Vector/Basic.lean
+++ b/Mathlib/Data/Vector/Basic.lean
@@ -137,11 +137,11 @@ theorem get_map {β : Type _} (v : Vector α n) (f : α → β) (i : Fin n) :
 #align vector.nth_map Vector.get_map
 
 @[simp]
-theorem Vector.map₂_nil (f : α → β → γ) : Vector.map₂ f nil nil = nil :=
+theorem map₂_nil (f : α → β → γ) : Vector.map₂ f nil nil = nil :=
   rfl
 
 @[simp]
-theorem Vector.map₂_cons (hd₁ : α) (tl₁ : Vector α n) (hd₂ : β) (tl₂ : Vector β n) (f : α → β → γ) :
+theorem map₂_cons (hd₁ : α) (tl₁ : Vector α n) (hd₂ : β) (tl₂ : Vector β n) (f : α → β → γ) :
     Vector.map₂ f (hd₁ ::ᵥ tl₁) (hd₂ ::ᵥ tl₂) = f hd₁ hd₂ ::ᵥ (Vector.map₂ f tl₁ tl₂) :=
   rfl
 
@@ -774,31 +774,31 @@ instance : IsLawfulTraversable.{u} (flip Vector n) where
 -- #align vector.reflect vector.reflect
 
 @[simp]
-theorem Vector.replicate_succ : replicate (n+1) val = val ::ᵥ (replicate n val) :=
+theorem replicate_succ : replicate (n+1) val = val ::ᵥ (replicate n val) :=
   rfl
 
 @[simp]
-theorem Vector.get_append_cons_zero : get (append (x ::ᵥ xs) ys) ⟨0, by simp⟩ = x :=
+theorem get_append_cons_zero : get (append (x ::ᵥ xs) ys) ⟨0, by simp⟩ = x :=
   rfl
 
 @[simp]
-theorem Vector.get_append_cons_succ {i : Fin (n + m)} {h} :
+theorem get_append_cons_succ {i : Fin (n + m)} {h} :
     get (append (x ::ᵥ xs) ys) ⟨i+1, h⟩ = get (append xs ys) i :=
   rfl
 
 @[simp]
-theorem Vector.append_nil : (append xs Vector.nil) = xs :=
+theorem append_nil : (append xs nil) = xs :=
   by cases xs; simp[append]
 
 
 @[simp]
-theorem Vector.get_map₂ (v₁ : Vector α n) (v₂ : Vector β n) (f : α → β → γ) (i : Fin n) :
-    Vector.get (Vector.map₂ f v₁ v₂) i = f (Vector.get v₁ i) (Vector.get v₂ i) := by
-  induction v₁, v₂ using Vector.inductionOn₂
+theorem get_map₂ (v₁ : Vector α n) (v₂ : Vector β n) (f : α → β → γ) (i : Fin n) :
+    get (map₂ f v₁ v₂) i = f (get v₁ i) (get v₂ i) := by
+  induction v₁, v₂ using inductionOn₂
   case nil =>
     exact Fin.elim0 i
   case cons x xs y ys ih =>
-    rw [Vector.map₂_cons]
+    rw [map₂_cons]
     cases i using Fin.cases
     . simp only [get_zero, head_cons]
     . simp only [get_cons_succ, ih]

--- a/Mathlib/Data/Vector/Basic.lean
+++ b/Mathlib/Data/Vector/Basic.lean
@@ -166,7 +166,7 @@ def _root_.Equiv.vectorEquivFin (α : Type _) (n : ℕ) : Vector α n ≃ (Fin n
 #align equiv.vector_equiv_fin Equiv.vectorEquivFin
 
 theorem get_tail (x : Vector α n) (i : Fin (n-1)) :
-    x.tail[i.1] = x[i.succ.1]'(lt_tsub_iff_right.mp i.2)  := by
+    x.tail[i.1] = x[i.1+1]'(lt_tsub_iff_right.mp i.2)  := by
   cases' i with i ih ; dsimp
   rcases x with ⟨_ | _, h⟩ <;> try rfl
   rw [List.length] at h
@@ -176,9 +176,10 @@ theorem get_tail (x : Vector α n) (i : Fin (n-1)) :
 
 @[simp]
 theorem get_tail_succ_nat : ∀ (v : Vector α n.succ) (i : Nat) {h},
-    (tail v)[i]'h = v[i.succ]'(Nat.lt_succ.mpr h)
+    (tail v)[i]'h = v[i+1]'(Nat.lt_succ.mpr h)
   | ⟨a :: l, e⟩, i => by simp [get_eq_get] ; rfl
 
+@[simp]
 theorem get_tail_succ : ∀ (v : Vector α n.succ) (i : Fin n), (tail v)[i.1] = v[i.succ.1] :=
   fun _ _ => get_tail_succ_nat ..
 #align vector.nth_tail_succ Vector.get_tail_succ
@@ -205,7 +206,7 @@ theorem tail_ofFn {n : ℕ} (f : Fin n.succ → α) : tail (ofFn f) = ofFn fun i
   (ofFn_get _).symm.trans <| by
     congr
     funext i
-    rw [get, get_tail, get_ofFn]
+    rw[get, get_tail_succ, get_ofFn]
 #align vector.tail_of_fn Vector.tail_ofFn
 
 @[simp]
@@ -268,6 +269,7 @@ theorem reverse_reverse {v : Vector α n} : v.reverse.reverse = v := by
 theorem get_zero_nat : ∀ v : Vector α n.succ, v[0] = head v
   | ⟨_ :: _, _⟩ => rfl
 
+@[simp]
 theorem get_zero : ∀ v : Vector α n.succ, v[(0 : Fin n.succ).1] = head v :=
   get_zero_nat
 #align vector.nth_zero Vector.get_zero
@@ -295,7 +297,7 @@ theorem get_cons_nil : ∀ {ix : Fin 1} (x : α), (x ::ᵥ nil)[ix.1] = x
 #align vector.nth_cons_nil Vector.get_cons_nil
 
 @[simp]
-theorem get_cons_succ_nat (a : α) (v : Vector α n) (i : Nat) {h} : (a ::ᵥ v)[i.succ]'h = v[i]'(Nat.lt_succ.mp h) := by
+theorem get_cons_succ_nat (a : α) (v : Vector α n) (i : Nat) {h} : (a ::ᵥ v)[i + 1]'h = v[i]'(Nat.lt_succ.mp h) := by
   rw [← get_tail_succ_nat, tail_cons]; rfl
 
 @[simp]
@@ -396,31 +398,34 @@ theorem scanl_head : (scanl f b v).head = b := by
     simp only [←get_zero, get_eq_get, toList_scanl, toList_cons, List.scanl, List.get]
 #align vector.scanl_head Vector.scanl_head
 
-/-- For an index `i : Fin n`, the nth element of `scanl` of a
-vector `v : Vector α n` at `i.succ`, is equal to the application
-function `f : β → α → β` of the `castSucc i` element of
-`scanl f b v` and `get v i`.
+-- set_option pp.analyze true in
+-- /- For an index `i : Fin n`, the nth element of `scanl` of a
+-- vector `v : Vector α n` at `i.succ`, is equal to the application
+-- function `f : β → α → β` of the `castSucc i` element of
+-- `scanl f b v` and `get v i`.
 
-This lemma is the `get` version of `scanl_cons`.
--/
-@[simp]
-theorem scanl_get (i : Fin n) :
-    (scanl f b v)[i.succ.1] = f ((scanl f b v)[(Fin.castSucc i).1]) v[i.1] := by
-  cases' n with n
-  · exact i.elim0
-  induction' n with n hn generalizing b
-  · have i0 : i = 0 := Fin.eq_zero _
-    simp [scanl_singleton, get_zero, get_eq_get]
-  · rw [← cons_head_tail v, scanl_cons, get_cons_succ _ _ i]
-    refine' Fin.cases _ _ i
-    · simp [get_cons_zero_nat, scanl_head, Fin.castSucc_zero, head_cons]
-      -- Why does the following not work?
-      rw[get_zero_nat (@cons β (Nat.succ (n + 1) - 1 + 1) b (scanl f (f b (head v)) (tail v)))]
-      sorry
-    · intro i'
-      simp only [hn, Fin.castSucc_fin_succ, get_cons_succ]
-      sorry
-#align vector.scanl_nth Vector.scanl_get
+-- This lemma is the `get` version of `scanl_cons`.
+-- -/
+-- @[simp]
+-- theorem scanl_get (i : Fin n) :
+--     (scanl f b v)[i.succ.1] = f ((scanl f b v)[i.1]) v[i.1] := by
+--   cases' n with n
+--   · exact i.elim0
+--   simp
+--   induction' n with n hn generalizing b
+--   · have i0 : i = 0 := Fin.eq_zero _
+--     simp [scanl_singleton, get_zero, get_eq_get]
+--   · rw [← cons_head_tail v, scanl_cons, get_cons_succ _ _ i]
+--     refine' Fin.cases _ _ i
+--     · simp [get_zero_nat (n := n + 1), get_zero_nat (n := n + 2),
+--             scanl_head, head_cons]
+--     · intro i'
+--       simp
+--       rw[hn, get_tail_succ_nat (n:=n) _ i'.1]
+--       simp [get_cons_succ_nat (n := n + 2)]
+--       simp
+--       sorry
+-- #align vector.scanl_nth Vector.scanl_get
 
 end Scan
 

--- a/Mathlib/Data/Vector/Basic.lean
+++ b/Mathlib/Data/Vector/Basic.lean
@@ -803,9 +803,5 @@ theorem get_map₂ (v₁ : Vector α n) (v₂ : Vector β n) (f : α → β → 
     . simp only [get_zero, head_cons]
     . simp only [get_cons_succ, ih]
 
-theorem get_eq_val_eq {α : Type u} {n : Nat} (x x' : Vector α n) (i : Fin n)
-                      (h : x.toList = x'.toList) :
-    (get x i) = (get x' i) := by
-  rw [Vector.eq x x' h]
 
 end Vector

--- a/Mathlib/Data/Vector/Basic.lean
+++ b/Mathlib/Data/Vector/Basic.lean
@@ -516,7 +516,7 @@ def inductionOn₃ {C : ∀ {n}, Vector α n → Vector β n → Vector γ n →
 #align vector.induction_on₃ Vector.inductionOn₃
 
 /-- Define `motive v` by case-analysis on `v : Vector α n` -/
-def casesOn {motive : ∀{n}, Vector α n → Sort _}
+def casesOn {motive : ∀ {n}, Vector α n → Sort _}
             (v : Vector α m)
             (nil : motive nil)
             (cons : ∀{n}, (hd : α) → (tl : Vector α n) → motive (Vector.cons hd tl)) :
@@ -787,9 +787,8 @@ theorem get_append_cons_succ {i : Fin (n + m)} {h} :
   rfl
 
 @[simp]
-theorem append_nil : (append xs nil) = xs :=
-  by cases xs; simp[append]
-
+theorem append_nil : append xs nil = xs := by
+  cases xs; simp [append]
 
 @[simp]
 theorem get_map₂ (v₁ : Vector α n) (v₂ : Vector β n) (f : α → β → γ) (i : Fin n) :

--- a/Mathlib/Data/Vector/Basic.lean
+++ b/Mathlib/Data/Vector/Basic.lean
@@ -198,8 +198,6 @@ theorem singleton_tail : ∀ (v : Vector α 1), v.tail = Vector.nil
   | ⟨[_], _⟩ => rfl
 #align vector.singleton_tail Vector.singleton_tail
 
-set_option pp.analyze true
-
 @[simp]
 theorem tail_ofFn {n : ℕ} (f : Fin n.succ → α) : tail (ofFn f) = ofFn fun i => f i.succ :=
   (ofFn_get _).symm.trans <| by

--- a/Mathlib/Data/Vector/Basic.lean
+++ b/Mathlib/Data/Vector/Basic.lean
@@ -20,8 +20,6 @@ import Mathlib.Control.Traversable.Basic
 This file introduces the infix notation `::ᵥ` for `Vector.cons`.
 -/
 
-attribute [-instance] instGetElemFinVal
-
 universe u
 
 variable {n : ℕ}

--- a/Mathlib/Data/Vector/Basic.lean
+++ b/Mathlib/Data/Vector/Basic.lean
@@ -294,7 +294,8 @@ theorem get_cons_nil : ∀ {ix : Fin 1} (x : α), (x ::ᵥ nil)[ix.1] = x
 #align vector.nth_cons_nil Vector.get_cons_nil
 
 @[simp]
-theorem get_cons_succ_nat (a : α) (v : Vector α n) (i : Nat) {h} : (a ::ᵥ v)[i + 1]'h = v[i]'(Nat.lt_succ.mp h) := by
+theorem get_cons_succ_nat (a : α) (v : Vector α n) (i : Nat) {h} :
+    (a ::ᵥ v)[i + 1]'h = v[i]'(Nat.lt_succ.mp h) := by
   rw [← get_tail_succ_nat, tail_cons]; rfl
 
 theorem get_cons_succ (a : α) (v : Vector α n) (i : Fin n) : (a ::ᵥ v)[i.succ.1] = v[i.1] :=
@@ -394,7 +395,6 @@ theorem scanl_head : (scanl f b v).head = b := by
     simp only [←get_zero, get_eq_get, toList_scanl, toList_cons, List.scanl, List.get]
 #align vector.scanl_head Vector.scanl_head
 
-set_option pp.analyze true in
 /- For an index `i : Fin n`, the nth element of `scanl` of a
 vector `v : Vector α n` at `i.succ`, is equal to the application
 function `f : β → α → β` of the `castSucc i` element of
@@ -414,7 +414,7 @@ theorem scanl_get (i : Fin n) :
     · simp [get_zero_nat (n := n + 1), get_zero_nat (n := n + 2), scanl_head, head_cons]
     · intro i'
       simp only [Fin.val_succ, hn, get_cons_succ_nat (n := n + 2), get_cons_succ_nat (n := n + 1)]
--- #align vector.scanl_nth Vector.scanl_get
+#align vector.scanl_nth Vector.scanl_get
 
 end Scan
 

--- a/Mathlib/Data/Vector/Basic.lean
+++ b/Mathlib/Data/Vector/Basic.lean
@@ -391,7 +391,7 @@ theorem scanl_head : (scanl f b v).head = b := by
     simp only [←get_zero, get_eq_get, toList_scanl, toList_cons, List.scanl, List.get]
 #align vector.scanl_head Vector.scanl_head
 
-/- For an index `i : Fin n`, the nth element of `scanl` of a
+/-- For an index `i : Fin n`, the nth element of `scanl` of a
 vector `v : Vector α n` at `i.succ`, is equal to the application
 function `f : β → α → β` of the `castSucc i` element of
 `scanl f b v` and `get v i`.

--- a/Mathlib/Data/Vector/Basic.lean
+++ b/Mathlib/Data/Vector/Basic.lean
@@ -179,7 +179,6 @@ theorem get_tail_succ_nat : ∀ (v : Vector α n.succ) (i : Nat) {h},
     (tail v)[i]'h = v[i+1]'(Nat.lt_succ.mpr h)
   | ⟨a :: l, e⟩, i => by simp [get_eq_get] ; rfl
 
-@[simp]
 theorem get_tail_succ : ∀ (v : Vector α n.succ) (i : Fin n), (tail v)[i.1] = v[i.succ.1] :=
   fun _ _ => get_tail_succ_nat ..
 #align vector.nth_tail_succ Vector.get_tail_succ
@@ -269,7 +268,6 @@ theorem reverse_reverse {v : Vector α n} : v.reverse.reverse = v := by
 theorem get_zero_nat : ∀ v : Vector α n.succ, v[0] = head v
   | ⟨_ :: _, _⟩ => rfl
 
-@[simp]
 theorem get_zero : ∀ v : Vector α n.succ, v[(0 : Fin n.succ).1] = head v :=
   get_zero_nat
 #align vector.nth_zero Vector.get_zero
@@ -280,18 +278,17 @@ theorem head_ofFn {n : ℕ} (f : Fin n.succ → α) : head (ofFn f) = f 0 := by
   rw [← get_zero, get_ofFn]
 #align vector.head_of_fn Vector.head_ofFn
 
-@[simp] -- Porting note: simp can prove it
+-- @[simp] Porting note: simp can prove it
 theorem get_cons_zero_nat (a : α) (v : Vector α n) : (a ::ᵥ v)[0] = a := by
   simp only [get_zero_nat, head_cons]
 
-@[simp] -- Porting note: simp can prove it
+-- @[simp] Porting note: simp can prove it
 theorem get_cons_zero (a : α) (v : Vector α n) : (a ::ᵥ v)[(0 : Fin n.succ).1] = a :=
   get_cons_zero_nat ..
 #align vector.nth_cons_zero Vector.get_cons_zero
 
 /-- Accessing the nth element of a vector made up
 of one element `x : α` is `x` itself. -/
-@[simp]
 theorem get_cons_nil : ∀ {ix : Fin 1} (x : α), (x ::ᵥ nil)[ix.1] = x
   | ⟨0, _⟩, _ => rfl
 #align vector.nth_cons_nil Vector.get_cons_nil
@@ -300,7 +297,6 @@ theorem get_cons_nil : ∀ {ix : Fin 1} (x : α), (x ::ᵥ nil)[ix.1] = x
 theorem get_cons_succ_nat (a : α) (v : Vector α n) (i : Nat) {h} : (a ::ᵥ v)[i + 1]'h = v[i]'(Nat.lt_succ.mp h) := by
   rw [← get_tail_succ_nat, tail_cons]; rfl
 
-@[simp]
 theorem get_cons_succ (a : α) (v : Vector α n) (i : Fin n) : (a ::ᵥ v)[i.succ.1] = v[i.1] :=
   get_cons_succ_nat ..
 #align vector.nth_cons_succ Vector.get_cons_succ
@@ -398,33 +394,26 @@ theorem scanl_head : (scanl f b v).head = b := by
     simp only [←get_zero, get_eq_get, toList_scanl, toList_cons, List.scanl, List.get]
 #align vector.scanl_head Vector.scanl_head
 
--- set_option pp.analyze true in
--- /- For an index `i : Fin n`, the nth element of `scanl` of a
--- vector `v : Vector α n` at `i.succ`, is equal to the application
--- function `f : β → α → β` of the `castSucc i` element of
--- `scanl f b v` and `get v i`.
+set_option pp.analyze true in
+/- For an index `i : Fin n`, the nth element of `scanl` of a
+vector `v : Vector α n` at `i.succ`, is equal to the application
+function `f : β → α → β` of the `castSucc i` element of
+`scanl f b v` and `get v i`.
 
--- This lemma is the `get` version of `scanl_cons`.
--- -/
--- @[simp]
--- theorem scanl_get (i : Fin n) :
---     (scanl f b v)[i.succ.1] = f ((scanl f b v)[i.1]) v[i.1] := by
---   cases' n with n
---   · exact i.elim0
---   simp
---   induction' n with n hn generalizing b
---   · have i0 : i = 0 := Fin.eq_zero _
---     simp [scanl_singleton, get_zero, get_eq_get]
---   · rw [← cons_head_tail v, scanl_cons, get_cons_succ _ _ i]
---     refine' Fin.cases _ _ i
---     · simp [get_zero_nat (n := n + 1), get_zero_nat (n := n + 2),
---             scanl_head, head_cons]
---     · intro i'
---       simp
---       rw[hn, get_tail_succ_nat (n:=n) _ i'.1]
---       simp [get_cons_succ_nat (n := n + 2)]
---       simp
---       sorry
+This lemma is the `get` version of `scanl_cons`.
+-/
+@[simp]
+theorem scanl_get (i : Fin n) :
+    (scanl f b v)[i.1 + 1]'i.succ.2 = f ((scanl f b v)[i.1]) v[i.1] := by
+  cases' n with n
+  · exact i.elim0
+  induction' n with n hn generalizing b
+  · simp [scanl_singleton, get_zero, get_eq_get, get_cons_succ _ _ i]
+  · rw [← cons_head_tail v, scanl_cons, get_cons_succ_nat (n:=n+2) _ _ i.1]
+    refine' Fin.cases _ _ i
+    · simp [get_zero_nat (n := n + 1), get_zero_nat (n := n + 2), scanl_head, head_cons]
+    · intro i'
+      simp only [Fin.val_succ, hn, get_cons_succ_nat (n := n + 2), get_cons_succ_nat (n := n + 1)]
 -- #align vector.scanl_nth Vector.scanl_get
 
 end Scan

--- a/Mathlib/Data/Vector/Mem.lean
+++ b/Mathlib/Data/Vector/Mem.lean
@@ -26,12 +26,12 @@ namespace Vector
 variable {α β : Type _} {n : ℕ} (a a' : α)
 
 @[simp]
-theorem get_mem (i : Fin n) (v : Vector α n) : v.get i ∈ v.toList := by
+theorem get_mem (i : Fin n) (v : Vector α n) : v[i.1] ∈ v.toList := by
   rw [get_eq_get]
   exact List.get_mem _ _ _
 #align vector.nth_mem Vector.get_mem
 
-theorem mem_iff_get (v : Vector α n) : a ∈ v.toList ↔ ∃ i, v.get i = a := by
+theorem mem_iff_get (v : Vector α n) : a ∈ v.toList ↔ ∃ (i : Fin n), v[i.1] = a := by
   simp only [List.mem_iff_get, Fin.exists_iff, Vector.get_eq_get]
   exact
     ⟨fun ⟨i, hi, h⟩ => ⟨i, by rwa [toList_length] at hi, h⟩, fun ⟨i, hi, h⟩ =>

--- a/Mathlib/Data/Vector/Zip.lean
+++ b/Mathlib/Data/Vector/Zip.lean
@@ -33,11 +33,10 @@ theorem zipWith_toList (x : Vector α n) (y : Vector β n) :
 #align vector.zip_with_to_list Vector.zipWith_toList
 
 @[simp]
-theorem zipWith_get (x : Vector α n) (y : Vector β n) (i) :
-    (Vector.zipWith f x y).get i = f (x.get i) (y.get i) := by
-  dsimp only [Vector.zipWith, Vector.get]
+theorem zipWith_get (x : Vector α n) (y : Vector β n) (i : Nat) {h} :
+    (Vector.zipWith f x y)[i] = f x[i] y[i] := by
   cases x; cases y
-  simp only [List.nthLe_zipWith]
+  simp only [Vector.zipWith, (·[·]'·), List.get_zipWith]
 #align vector.zip_with_nth Vector.zipWith_get
 
 @[simp]


### PR DESCRIPTION


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

An alternative PR to #4994, which uses `v[i]` as the normal form, instead of the `v[i.1]` proposed in that PR.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
