### PR TITLE
[Merged by Bors] - bug: fix ci after #5396

### DIFF
--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -125,7 +125,7 @@ jobs:
         with:
           linters: gcc
           run: |
-            bash -c "env LEAN_ABORT_ON_PANIC=1 lake build | tee stdout.log"
+            bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build | tee stdout.log"
 
       - name: check for noisy stdout lines
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,7 +131,7 @@ jobs:
         with:
           linters: gcc
           run: |
-            bash -c "env LEAN_ABORT_ON_PANIC=1 lake build | tee stdout.log"
+            bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build | tee stdout.log"
 
       - name: check for noisy stdout lines
         run: |

--- a/.github/workflows/build.yml.in
+++ b/.github/workflows/build.yml.in
@@ -111,7 +111,7 @@ jobs:
         with:
           linters: gcc
           run: |
-            bash -c "env LEAN_ABORT_ON_PANIC=1 lake build | tee stdout.log"
+            bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build | tee stdout.log"
 
       - name: check for noisy stdout lines
         run: |

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -129,7 +129,7 @@ jobs:
         with:
           linters: gcc
           run: |
-            bash -c "env LEAN_ABORT_ON_PANIC=1 lake build | tee stdout.log"
+            bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build | tee stdout.log"
 
       - name: check for noisy stdout lines
         run: |


### PR DESCRIPTION
#5396 was a little too simplistic and caused ci not to fail if make build failed, fortunately this was always caught at the next step (build library search cache) anyway but we should restore the correct behaviour

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
