### PR TITLE
[Merged by Bors] - chore: don't use `simps`

### DIFF
--- a/Mathlib/FieldTheory/Minpoly/IsIntegrallyClosed.lean
+++ b/Mathlib/FieldTheory/Minpoly/IsIntegrallyClosed.lean
@@ -179,21 +179,43 @@ def equivAdjoin (hx : IsIntegral R x) : AdjoinRoot (minpoly R x) ≃ₐ[R] adjoi
 
 /-- The `PowerBasis` of `adjoin R {x}` given by `x`. See `Algebra.adjoin.powerBasis` for a version
 over a field. -/
-@[simps!]
-def Algebra.adjoin.powerBasis' (hx : IsIntegral R x) :
+def _root_.Algebra.adjoin.powerBasis' (hx : IsIntegral R x) :
     PowerBasis R (Algebra.adjoin R ({x} : Set S)) :=
   PowerBasis.map (AdjoinRoot.powerBasis' (minpoly.monic hx)) (minpoly.equivAdjoin hx)
-#align algebra.adjoin.power_basis' minpoly.Algebra.adjoin.powerBasis'
+#align algebra.adjoin.power_basis' Algebra.adjoin.powerBasis'
+
+@[simp]
+theorem _root_.Algebra.adjoin.powerBasis'_dim (hx : IsIntegral R x) :
+  (Algebra.adjoin.powerBasis' hx).dim = (minpoly R x).natDegree := rfl
+#align algebra.adjoin.power_basis'_dim Algebra.adjoin.powerBasis'_dim
+
+@[simp]
+theorem _root_.Algebra.adjoin.powerBasis'_gen (hx : IsIntegral R x) :
+    (adjoin.powerBasis' hx).gen = ⟨x, SetLike.mem_coe.1 <| subset_adjoin <| mem_singleton x⟩ := by
+  rw [Algebra.adjoin.powerBasis', PowerBasis.map_gen, AdjoinRoot.powerBasis'_gen, equivAdjoin,
+    AlgEquiv.ofBijective_apply, Minpoly.toAdjoin, liftHom_root]
+#align algebra.adjoin.power_basis'_gen Algebra.adjoin.powerBasis'_gen
 
 /-- The power basis given by `x` if `B.gen ∈ adjoin R {x}`. -/
-@[simps!]
-noncomputable def PowerBasis.ofGenMemAdjoin' (B : PowerBasis R S) (hint : IsIntegral R x)
+noncomputable def _root_.PowerBasis.ofGenMemAdjoin' (B : PowerBasis R S) (hint : IsIntegral R x)
     (hx : B.gen ∈ adjoin R ({x} : Set S)) : PowerBasis R S :=
   (Algebra.adjoin.powerBasis' hint).map <|
     (Subalgebra.equivOfEq _ _ <| PowerBasis.adjoin_eq_top_of_gen_mem_adjoin hx).trans
       Subalgebra.topEquiv
-#align power_basis.of_gen_mem_adjoin' minpoly.PowerBasis.ofGenMemAdjoin'
+#align power_basis.of_gen_mem_adjoin' PowerBasis.ofGenMemAdjoin'
 
+@[simp]
+theorem _root_.PowerBasis.ofGenMemAdjoin'_dim (B : PowerBasis R S) (hint : IsIntegral R x)
+    (hx : B.gen ∈ adjoin R ({x} : Set S)) :
+    (B.ofGenMemAdjoin' hint hx).dim = (minpoly R x).natDegree := rfl
+#align power_basis.of_gen_mem_adjoin'_dim PowerBasis.ofGenMemAdjoin'_dim
+
+@[simp]
+theorem _root_.PowerBasis.ofGenMemAdjoin'_gen (B : PowerBasis R S) (hint : IsIntegral R x)
+    (hx : B.gen ∈ adjoin R ({x} : Set S)) :
+    (B.ofGenMemAdjoin' hint hx).gen = x := by
+  simp [PowerBasis.ofGenMemAdjoin']
+#align power_basis.of_gen_mem_adjoin'_gen PowerBasis.ofGenMemAdjoin'_gen
 
 end AdjoinRoot
 


### PR DESCRIPTION
`simps` unfolds too much and it produces useless declarations. These are those present in mathlib3.

---

The same thing probably happens elsewhere, I only fixed here the declarations I need for the port.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
