### PR TITLE
[Merged by Bors] - chore: add porting headers to slim_check files

### DIFF
--- a/Mathlib/Control/Random.lean
+++ b/Mathlib/Control/Random.lean
@@ -2,7 +2,13 @@
 Copyright (c) 2022 Henrik Böving. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Henrik Böving
+
+! This file was ported from Lean 3 source module control.random
+! leanprover-community/mathlib commit fdc286cc6967a012f41b87f76dcd2797b53152af
+! Please do not edit these lines, except to modify the commit id
+! if you have ported upstream changes.
 -/
+
 import Mathlib.Init.Algebra.Order
 import Mathlib.Init.Data.Nat.Lemmas
 import Mathlib.Init.Data.Int.Order
@@ -11,17 +17,23 @@ import Mathlib.Data.Nat.Basic
 
 /-!
 # Rand Monad and Random Class
+
 This module provides tools for formulating computations guided by randomness and for
 defining objects that can be created randomly.
+
 ## Main definitions
-  * `Rand` and `RandG` monad for computations guided by randomness;
-  * `Random` class for objects that can be generated randomly;
-    * `random` to generate one object;
-  * `BoundedRandom` class for objects that can be generated randomly inside a range;
-    * `randomR` to generate one object inside a range;
-  * `IO.runRand` to run a randomized computation inside the `IO` monad;
+
+* `Rand` and `RandG` monad for computations guided by randomness;
+* `Random` class for objects that can be generated randomly;
+  * `random` to generate one object;
+* `BoundedRandom` class for objects that can be generated randomly inside a range;
+  * `randomR` to generate one object inside a range;
+* `IO.runRand` to run a randomized computation inside the `IO` monad;
+
 ## References
-  * Similar library in Haskell: https://hackage.haskell.org/package/MonadRandom
+
+* Similar library in Haskell: https://hackage.haskell.org/package/MonadRandom
+
 -/
 
 /-- A monad to generate random objects using the generic generator type `g` -/

--- a/Mathlib/Testing/SlimCheck/Gen.lean
+++ b/Mathlib/Testing/SlimCheck/Gen.lean
@@ -2,6 +2,11 @@
 Copyright (c) 2021 Henrik Böving. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Henrik Böving, Simon Hudon
+
+! This file was ported from Lean 3 source module testing.slim_check.testable
+! leanprover-community/mathlib commit fdc286cc6967a012f41b87f76dcd2797b53152af
+! Please do not edit these lines, except to modify the commit id
+! if you have ported upstream changes.
 -/
 import Mathlib.Control.Random
 import Mathlib.Data.List.Perm
@@ -10,19 +15,22 @@ import Mathlib.Data.Nat.Basic
 
 /-!
 # `Gen` Monad
+
 This monad is used to formulate randomized computations with a parameter
 to specify the desired size of the result.
 This is a port of the Haskell QuickCheck library.
 
 ## Main definitions
-  * `Gen` monad
+
+* `Gen` monad
 
 ## Tags
 
 random testing
 
 ## References
-  * https://hackage.haskell.org/package/QuickCheck
+
+* https://hackage.haskell.org/package/QuickCheck
 -/
 
 namespace SlimCheck

--- a/Mathlib/Testing/SlimCheck/Sampleable.lean
+++ b/Mathlib/Testing/SlimCheck/Sampleable.lean
@@ -2,16 +2,23 @@
 Copyright (c) 2022 Henrik Böving. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Henrik Böving, Simon Hudon
+
+! This file was ported from Lean 3 source module testing.slim_check.testable
+! leanprover-community/mathlib commit fdc286cc6967a012f41b87f76dcd2797b53152af
+! Please do not edit these lines, except to modify the commit id
+! if you have ported upstream changes.
 -/
 import Mathlib.Testing.SlimCheck.Gen
 import Qq
 
 /-!
 # `SampleableExt` Class
+
 This class permits the creation samples of a given type
 controlling the size of those values using the `Gen` monad.
 
 # `Shrinkable` Class
+
 This class helps minimize examples by creating smaller versions of
 given values.
 
@@ -29,10 +36,12 @@ the test passes and `SlimCheck` moves on to trying more examples.
 This is a port of the Haskell QuickCheck library.
 
 ## Main definitions
-  * `SampleableExt` class
-  * `Shrinkable` class
+
+* `SampleableExt` class
+* `Shrinkable` class
 
 ### `SampleableExt`
+
 `SampleableExt` can be used in two ways. The first (and most common)
 is to simply generate values of a type directly using the `Gen` monad,
 if this is what you want to do then `SampleableExt.mkSelfContained` is
@@ -49,10 +58,12 @@ are using it in the first way, this proxy type will simply be the type
 itself and the `interp` function `id`.
 
 ### `Shrinkable`
+
 Given an example `x : α`, `Shrinkable α` gives us a way to shrink it
 and suggest simpler examples.
 
 ## Shrinking
+
 Shrinking happens when `SlimCheck` find a counter-example to a
 property.  It is likely that the example will be more complicated than
 necessary so `SlimCheck` proceeds to shrink it as much as
@@ -72,7 +83,9 @@ argument, we know that `SlimCheck` is guaranteed to terminate.
 random testing
 
 ## References
-  * https://hackage.haskell.org/package/QuickCheck
+
+* https://hackage.haskell.org/package/QuickCheck
+
 -/
 
 namespace SlimCheck


### PR DESCRIPTION
Just so these get marked off the dashboard. These files have already been ported by hand.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
