### PR TITLE
feat: fix some bugs in rw?

### DIFF
--- a/Mathlib/Lean/Meta/DiscrTree.lean
+++ b/Mathlib/Lean/Meta/DiscrTree.lean
@@ -32,6 +32,20 @@ and amongst those we return more specific lemmas first.
 -/
 partial def getSubexpressionMatches (d : DiscrTree α s) (e : Expr) : MetaM (Array α) := do
   e.foldlM (fun a f => do pure <| a ++ (← d.getSubexpressionMatches f)) (← d.getMatch e).reverse
+/--
+Find keys which match the expression, or some subexpression, skipping those that have loose BVars.
+
+See also `getSubexpressionMatches`
+
+Implementation: we reverse the results from `getMatch`,
+so that we return lemmas matching larger subexpressions first,
+and amongst those we return more specific lemmas first.
+-/
+partial def getSubexpressionMatchesWithoutLooseBVars (d : DiscrTree α s) (e : Expr) :
+  MetaM (Array α) := do
+  let cu ← if e.hasLooseBVars then pure #[] else pure (← d.getMatch e).reverse
+  e.foldlM (fun a f => do pure <| a ++ (← d.getSubexpressionMatchesWithoutLooseBVars f)) cu
+
 variable {m : Type → Type} [Monad m]
 
 /-- Apply a monadic function to the array of values at each node in a `DiscrTree`. -/

--- a/Mathlib/Tactic/Rewrites.lean
+++ b/Mathlib/Tactic/Rewrites.lean
@@ -24,6 +24,8 @@ Suggestions are printed as `rw [h]` or `rw [←h]`.
 
 We could try discharging side goals via `assumption` or `solve_by_elim`.
 
+A conv mode version
+
 -/
 
 namespace Mathlib.Tactic.Rewrites
@@ -137,8 +139,8 @@ def rewritesCore (lemmas : DiscrTree (Name × Bool × Nat) s × DiscrTree (Name 
     (goal : MVarId) (target : Expr) : ListM MetaM RewriteResult := ListM.squash do
 
   -- Get all lemmas which could match some subexpression
-  let candidates := (← lemmas.1.getSubexpressionMatches target)
-    ++ (← lemmas.2.getSubexpressionMatches target)
+  let candidates := (← lemmas.1.getSubexpressionMatchesWithoutLooseBVars target)
+    ++ (← lemmas.2.getSubexpressionMatchesWithoutLooseBVars target)
 
   -- Sort them by our preferring weighting
   -- (length of discriminant key, doubled for the forward implication)
@@ -193,7 +195,7 @@ syntax (name := rewrites') "rw?" "!"? (ppSpace location)? : tactic
 
 open Elab.Tactic Elab Tactic in
 elab_rules : tactic |
-    `(tactic| rw?%$tk $[!%$lucky]? $[$loc]?) => do
+    `(tactic| rw?%$tk $[!%$lucky]? $[$loc]?) => withMainContext do
   let lems ← rewriteLemmas.get
   reportOutOfHeartbeats `rewrites tk
   let goal ← getMainGoal

--- a/test/rewrites.lean
+++ b/test/rewrites.lean
@@ -57,3 +57,18 @@ lemma prime_of_prime (n : ℕ) : Prime n ↔ Nat.Prime n := by
 example [Group G] (h : G) (hyp : g * 1 = h) : g = h := by
   rw?! at hyp
   assumption
+
+-- test that we can work with local context variables
+example : (fun x : Nat => x + 1) = fun x : Nat => x + 2 := by
+  ext a
+  rw?
+  sorry
+
+-- test that we don't panic when looking at terms with bvars
+example : (fun x : Nat => x) = id := by
+  rw?
+  sorry
+
+-- test that we do still find rw's under binders when they exist
+example : (fun x : Nat => x + 1) = (fun x : Nat => x + (1 + 0)) := by
+  rw?!


### PR DESCRIPTION
Fix a couple of bugs in the rewrite suggestion tactic `rw?`

- A missing local context meant that after ext the newly introduced local variable caused issues
- When trying to rewrite under binders a panic was caused when trying to whnf exprs with BVars in, we skip these when searching the discrimination tree (seeing as rewrite doesn't like to rewrite under binders anyway), being careful to still descend to subexpressions that rewrite may work on.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
