### PR TITLE
[Merged by Bors] - chore: cleanup porting notes about refine_struct

### DIFF
--- a/Archive/Imo/Imo1981Q3.lean
+++ b/Archive/Imo/Imo1981Q3.lean
@@ -74,7 +74,6 @@ theorem reduction {m n : ℤ} (h1 : ProblemPredicate N m n) (h2 : 1 < n) :
   obtain (rfl : m = n) | (h3 : m < n) := h1.m_le_n.eq_or_lt
   · have h4 : m = 1 := h1.eq_imp_1
     exact absurd h4.symm h2.ne
-  -- Porting note: Original proof used `refine_struct { n_range := h1.m_range .. }`
   exact
     { n_range := h1.m_range
       m_range := by

--- a/Mathlib/Algebra/Ring/Aut.lean
+++ b/Mathlib/Algebra/Ring/Aut.lean
@@ -81,30 +81,24 @@ instance : Inhabited (RingAut R) :=
   ⟨1⟩
 
 /-- Monoid homomorphism from ring automorphisms to additive automorphisms. -/
-def toAddAut : RingAut R →* AddAut R :=
+def toAddAut : RingAut R →* AddAut R := by
+  refine'
   { toFun := RingEquiv.toAddEquiv
-    map_one' := rfl
-    map_mul' := fun _ _ => rfl }
-  -- Porting note: old proof was
-  --`by refine_struct { toFun := RingEquiv.toAddEquiv } <;> intros <;> rfl`
+    .. } <;> (intros; rfl)
 #align ring_aut.to_add_aut RingAut.toAddAut
 
 /-- Monoid homomorphism from ring automorphisms to multiplicative automorphisms. -/
-def toMulAut : RingAut R →* MulAut R :=
+def toMulAut : RingAut R →* MulAut R := by
+  refine'
   { toFun := RingEquiv.toMulEquiv
-    map_one' := rfl
-    map_mul' := fun _ _ => rfl }
-  --Porting note: old proof was
-  --=`by refine_struct { toFun := RingEquiv.toMulEquiv } <;> intros <;> rfl`
+    .. } <;> (intros; rfl)
 #align ring_aut.to_mul_aut RingAut.toMulAut
 
 /-- Monoid homomorphism from ring automorphisms to permutations. -/
-def toPerm : RingAut R →* Equiv.Perm R :=
+def toPerm : RingAut R →* Equiv.Perm R :=by
+  refine'
   { toFun := RingEquiv.toEquiv
-    map_one' := rfl
-    map_mul' := fun _ _ => rfl }
-  -- Porting note: old proof was
-  --`by refine_struct { toFun := RingEquiv.toEquiv } <;> intros <;> rfl`
+    .. } <;> (intros; rfl)
 #align ring_aut.to_perm RingAut.toPerm
 
 end mul_add

--- a/Mathlib/Order/Basic.lean
+++ b/Mathlib/Order/Basic.lean
@@ -1352,7 +1352,6 @@ namespace PUnit
 
 variable (a b : PUnit.{u + 1})
 
--- Porting note: no `refine_struct` at time of port
 instance linearOrder: LinearOrder PUnit where
   le  := fun _ _ ↦ True
   lt  := fun _ _ ↦ False

--- a/Mathlib/Order/BooleanAlgebra.lean
+++ b/Mathlib/Order/BooleanAlgebra.lean
@@ -841,11 +841,7 @@ protected def Function.Injective.booleanAlgebra [Sup α] [Inf α] [Top α] [Bot 
 
 end lift
 
--- Porting note: when `refine_struct` is ported this can be by:
--- refine_struct { PUnit.biheytingAlgebra with } <;>
---   intros <;> first |trivial|exact Subsingleton.elim _ _
-instance PUnit.booleanAlgebra : BooleanAlgebra PUnit :=
+instance PUnit.booleanAlgebra : BooleanAlgebra PUnit := by
+  refine'
   { PUnit.biheytingAlgebra with
-    le_sup_inf := by intros; trivial
-    inf_compl_le_bot := by intros; trivial
-    top_le_sup_compl := by intros; trivial }
+    .. } <;> (intros; trivial)

--- a/Mathlib/Order/CompleteBooleanAlgebra.lean
+++ b/Mathlib/Order/CompleteBooleanAlgebra.lean
@@ -416,15 +416,13 @@ namespace PUnit
 
 variable (s : Set PUnit.{u + 1}) (x y : PUnit.{u + 1})
 
--- Porting note: we don't have `refine_struct` ported yet, so we do it by hand
 instance completeBooleanAlgebra : CompleteBooleanAlgebra PUnit := by
   refine'
     { PUnit.booleanAlgebra with
       sSup := fun _ => unit
       sInf := fun _ => unit
       .. } <;>
-  intros <;>
-  first|trivial
+  (intros; trivial)
 
 @[simp]
 theorem sSup_eq : sSup s = unit :=

--- a/test/linarith.lean
+++ b/test/linarith.lean
@@ -430,18 +430,6 @@ variable {E : Type _} [AddGroup E]
 example (f : ℤ → E) (h : 0 = f 0) : 1 ≤ 2 := by nlinarith
 example (a : E) (h : a = a) : 1 ≤ 2  := by nlinarith
 
--- -- test that the apply bug doesn't affect linarith preprocessing
-
--- constant α : Type
--- variable [fact false] -- we work in an inconsistent context below
--- def leα : α → α → Prop := λ a b, ∀ c : α, true
-
--- noncomputable instance : linear_ordered_field α :=
--- by refine_struct { le := leα }; exact (fact.out false).elim
-
--- example (a : α) (ha : a < 2) : a ≤ a :=
--- by linarith
-
 example (p q r s t u v w : ℕ) (h1 : p + u = q + t) (h2 : r + w = s + v) :
   p * r + q * s + (t * w + u * v) = p * s + q * r + (t * v + u * w) :=
 by nlinarith


### PR DESCRIPTION
Replace some porting notes about `refine_struct` with uses of `refine'`. We only really miss `refine_struct` in situations where we later used `pi_instance_derive_field`.

I also exercised some editorial discretion to remove some porting notes about `refine_struct` when the original usage was (in my opinion) obfuscatory relative to just writing out the fields. (We shouldn't be using alternatives to handle different fields!)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
