### PR TITLE
[Merged by Bors] - feat: simplification lemmas for Vector.map / Vector.mapAccumr

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1761,6 +1761,7 @@ import Mathlib.Data.ULift
 import Mathlib.Data.UnionFind
 import Mathlib.Data.Vector
 import Mathlib.Data.Vector.Basic
+import Mathlib.Data.Vector.MapLemmas
 import Mathlib.Data.Vector.Mem
 import Mathlib.Data.Vector.Snoc
 import Mathlib.Data.Vector.Zip

--- a/Mathlib/Data/Vector/Basic.lean
+++ b/Mathlib/Data/Vector/Basic.lean
@@ -810,8 +810,6 @@ theorem get_map₂ (v₁ : Vector α n) (v₂ : Vector β n) (f : α → β → 
     . simp only [get_zero, head_cons]
     . simp only [get_cons_succ, ih]
 
-
-
 @[simp]
 theorem mapAccumr_cons :
     mapAccumr f (x ::ᵥ xs) s

--- a/Mathlib/Data/Vector/MapLemmas.lean
+++ b/Mathlib/Data/Vector/MapLemmas.lean
@@ -338,8 +338,6 @@ theorem mapAccumr₂_redundant_pair (f : α → β → (σ × σ) → (σ × σ)
 
 end RedundantState
 
-
-
 /-!
 ## Unused input optimizations
 -/

--- a/Mathlib/Data/Vector/MapLemmas.lean
+++ b/Mathlib/Data/Vector/MapLemmas.lean
@@ -24,12 +24,11 @@ variable (xs : Vector α n) (f₁ : β → σ₁ → σ₁ × γ) (f₂ : α →
 @[simp]
 theorem mapAccumr_mapAccumr :
     mapAccumr f₁ (mapAccumr f₂ xs s₂).snd s₁
-    = let m := (mapAccumr (fun x s =>
-        let r₂ := f₂ x s.snd
-        let r₁ := f₁ r₂.snd s.fst
-        ((r₁.fst, r₂.fst), r₁.snd)
-      ) xs (s₁, s₂))
-      (m.fst.fst, m.snd) := by
+    = ((mapAccumr (fun x s =>
+        (((f₁ (f₂ x s.snd).snd s.fst).fst, (f₂ x s.snd).fst), (f₁ (f₂ x s.snd).snd s.fst).snd)
+      ) xs (s₁, s₂)).fst.fst, (mapAccumr (fun x s =>
+        (((f₁ (f₂ x s.snd).snd s.fst).fst, (f₂ x s.snd).fst), (f₁ (f₂ x s.snd).snd s.fst).snd)
+      ) xs (s₁, s₂)).snd) := by
   induction xs using Vector.revInductionOn generalizing s₁ s₂ <;> simp_all
 
 
@@ -41,7 +40,7 @@ theorem mapAccumr_map (f₂ : α → β) :
 @[simp]
 theorem map_mapAccumr (f₁ : β → γ) :
     (map f₁ (mapAccumr f₂ xs s).snd) = (mapAccumr (fun x s =>
-        let r := (f₂ x s); (r.fst, f₁ r.snd)
+        ((f₂ x s).fst, f₁ (f₂ x s).snd)
       ) xs s).snd := by
   induction xs using Vector.revInductionOn generalizing s <;> simp_all
 
@@ -60,12 +59,13 @@ variable (xs : Vector α n) (ys : Vector β n)
 @[simp]
 theorem mapAccumr₂_mapAccumr_left (f₁ : γ → β → σ₁ → σ₁ × ζ) (f₂ : α → σ₂ → σ₂ × γ) :
     (mapAccumr₂ f₁ (mapAccumr f₂ xs s₂).snd ys s₁)
-    = let m := (mapAccumr₂ (fun x y s =>
-          let r₂ := f₂ x s.snd
-          let r₁ := f₁ r₂.snd y s.fst
-          ((r₁.fst, r₂.fst), r₁.snd)
-        ) xs ys (s₁, s₂))
-      (m.fst.fst, m.snd) := by
+    = (
+        (mapAccumr₂ (fun x y s =>
+          (((f₁ (f₂ x s.snd).snd y s.fst).fst, (f₂ x s.snd).fst), (f₁ (f₂ x s.snd).snd y s.fst).snd)
+        ) xs ys (s₁, s₂)).fst.fst,
+        (mapAccumr₂ (fun x y s =>
+          (((f₁ (f₂ x s.snd).snd y s.fst).fst, (f₂ x s.snd).fst), (f₁ (f₂ x s.snd).snd y s.fst).snd)
+        ) xs ys (s₁, s₂)).snd) := by
   induction xs, ys using Vector.revInductionOn₂ generalizing s₁ s₂ <;> simp_all
 
 @[simp]
@@ -78,12 +78,16 @@ theorem map₂_map_left (f₁ : γ → β → ζ) (f₂ : α → γ) :
 @[simp]
 theorem mapAccumr₂_mapAccumr_right (f₁ : α → γ → σ₁ → σ₁ × ζ) (f₂ : β → σ₂ → σ₂ × γ) :
     (mapAccumr₂ f₁ xs (mapAccumr f₂ ys s₂).snd s₁)
-    = let m := (mapAccumr₂ (fun x y s =>
-          let r₂ := f₂ y s.snd
-          let r₁ := f₁ x r₂.snd s.fst
-          ((r₁.fst, r₂.fst), r₁.snd)
-        ) xs ys (s₁, s₂))
-      (m.fst.fst, m.snd) := by
+    = (
+      (mapAccumr₂ (fun x y s =>
+          (((f₁ x (f₂ y s.snd).snd s.fst).fst, (f₂ y s.snd).fst), (f₁ x (f₂ y s.snd).snd s.fst).snd)
+        ) xs ys (s₁, s₂)
+      ).fst.fst,
+      (mapAccumr₂ (fun x y s =>
+          (((f₁ x (f₂ y s.snd).snd s.fst).fst, (f₂ y s.snd).fst), (f₁ x (f₂ y s.snd).snd s.fst).snd)
+        ) xs ys (s₁, s₂)
+      ).snd
+    ) := by
   induction xs, ys using Vector.revInductionOn₂ generalizing s₁ s₂ <;> simp_all
 
 @[simp]
@@ -96,12 +100,18 @@ theorem map₂_map_right (f₁ : α → γ → ζ) (f₂ : β → γ) :
 @[simp]
 theorem mapAccumr_mapAccumr₂ (f₁ : γ → σ₁ → σ₁ × ζ) (f₂ : α → β → σ₂ → σ₂ × γ) :
     (mapAccumr f₁ (mapAccumr₂ f₂ xs ys s₂).snd s₁)
-    = let m := mapAccumr₂ (fun x y s =>
-          let r₂ := f₂ x y s.snd
-          let r₁ := f₁ r₂.snd s.fst
-          ((r₁.fst, r₂.fst), r₁.snd)
-        ) xs ys (s₁, s₂);
-      (m.fst.fst, m.snd) := by
+    = (
+        (mapAccumr₂ (fun x y s =>
+            (((f₁ (f₂ x y s.snd).snd s.fst).fst, (f₂ x y s.snd).fst),
+              (f₁ (f₂ x y s.snd).snd s.fst).snd)
+          ) xs ys (s₁, s₂)
+        ).fst.fst,
+        (mapAccumr₂ (fun x y s =>
+            (((f₁ (f₂ x y s.snd).snd s.fst).fst, (f₂ x y s.snd).fst),
+              (f₁ (f₂ x y s.snd).snd s.fst).snd)
+          ) xs ys (s₁, s₂)
+        ).snd
+      ) := by
   induction xs, ys using Vector.revInductionOn₂ generalizing s₁ s₂ <;> simp_all
 
 @[simp]

--- a/Mathlib/Data/Vector/MapLemmas.lean
+++ b/Mathlib/Data/Vector/MapLemmas.lean
@@ -31,7 +31,6 @@ theorem mapAccumr_mapAccumr :
       ) xs (s₁, s₂)).snd) := by
   induction xs using Vector.revInductionOn generalizing s₁ s₂ <;> simp_all
 
-
 @[simp]
 theorem mapAccumr_map (f₂ : α → β) :
     (mapAccumr f₁ (map f₂ xs) s) = (mapAccumr (fun x s => f₁ (f₂ x) s) xs s) := by
@@ -50,8 +49,6 @@ theorem map_map (f₁ : β → γ) (f₂ : α → β) :
   induction xs using Vector.inductionOn <;> simp_all
 
 end Unary
-
-
 
 section Binary
 variable (xs : Vector α n) (ys : Vector β n)
@@ -73,8 +70,6 @@ theorem map₂_map_left (f₁ : γ → β → ζ) (f₂ : α → γ) :
     map₂ f₁ (map f₂ xs) ys = map₂ (fun x y => f₁ (f₂ x) y) xs ys := by
   induction xs, ys using Vector.revInductionOn₂ <;> simp_all
 
-
-
 @[simp]
 theorem mapAccumr₂_mapAccumr_right (f₁ : α → γ → σ₁ → σ₁ × ζ) (f₂ : β → σ₂ → σ₂ × γ) :
     (mapAccumr₂ f₁ xs (mapAccumr f₂ ys s₂).snd s₁)
@@ -94,8 +89,6 @@ theorem mapAccumr₂_mapAccumr_right (f₁ : α → γ → σ₁ → σ₁ × ζ
 theorem map₂_map_right (f₁ : α → γ → ζ) (f₂ : β → γ) :
     map₂ f₁ xs (map f₂ ys) = map₂ (fun x y => f₁ x (f₂ y)) xs ys := by
   induction xs, ys using Vector.revInductionOn₂ <;> simp_all
-
-
 
 @[simp]
 theorem mapAccumr_mapAccumr₂ (f₁ : γ → σ₁ → σ₁ × ζ) (f₂ : α → β → σ₂ → σ₂ × γ) :
@@ -170,9 +163,7 @@ theorem mapAccumr₂_mapAccumr₂_right_right (f₁ : β → γ → σ₁ → σ
     (m.fst.fst, m.snd) := by
   induction xs, ys using Vector.revInductionOn₂ generalizing s₁ s₂ <;> simp_all
 
-
 end Binary
-
 
 end Fold
 
@@ -319,9 +310,6 @@ theorem mapAccumr₂_eq_map₂_of_unused_state (f : α → β → σ → σ × �
   mapAccumr₂_eq_map₂ (fun _ => true) rfl (fun _ _ _ _ => rfl) (fun a b s s' _ _ => h a b s s')
 
 
-
-
-
 /-- If `f` takes a pair of states, but always returns the same value for both elements of the
     pair, then we can simplify to just a single element of state
   -/
@@ -334,8 +322,6 @@ theorem mapAccumr_redundant_pair (f : α → (σ × σ) → (σ × σ) × β)
   mapAccumr_bisim_tail <| by
     use fun (s₁, s₂) s => s₂ = s ∧ s₁ = s
     simp_all
-
-
 
 /-- If `f` takes a pair of states, but always returns the same value for both elements of the
     pair, then we can simplify to just a single element of state
@@ -388,8 +374,6 @@ theorem mapAccumr₂_unused_input_right [Inhabited β] (f : α → β → σ →
 
 end UnusedInput
 
-
-
 /-!
 ## Commutativity
 -/
@@ -406,8 +390,6 @@ theorem mapAccumr₂_comm (f : α → α → σ → σ × γ) (comm : ∀ a₁ a
 
 end Comm
 
-
-
 /-!
 ## Argument Flipping
 -/
@@ -418,12 +400,10 @@ theorem map₂_flip (f : α → β → γ) :
     map₂ f xs ys = map₂ (flip f) ys xs := by
   induction xs, ys using Vector.inductionOn₂ <;> simp_all[flip]
 
-
 theorem mapAccumr₂_flip (f : α → β → σ → σ × γ) :
     mapAccumr₂ f xs ys s = mapAccumr₂ (flip f) ys xs s := by
   induction xs, ys using Vector.inductionOn₂ <;> simp_all[flip]
 
 end Flip
-
 
 end Vector

--- a/Mathlib/Data/Vector/MapLemmas.lean
+++ b/Mathlib/Data/Vector/MapLemmas.lean
@@ -24,11 +24,12 @@ variable (xs : Vector α n) (f₁ : β → σ₁ → σ₁ × γ) (f₂ : α →
 @[simp]
 theorem mapAccumr_mapAccumr :
     mapAccumr f₁ (mapAccumr f₂ xs s₂).snd s₁
-    = ((mapAccumr (fun x s =>
-        (((f₁ (f₂ x s.snd).snd s.fst).fst, (f₂ x s.snd).fst), (f₁ (f₂ x s.snd).snd s.fst).snd)
-      ) xs (s₁, s₂)).fst.fst, (mapAccumr (fun x s =>
-        (((f₁ (f₂ x s.snd).snd s.fst).fst, (f₂ x s.snd).fst), (f₁ (f₂ x s.snd).snd s.fst).snd)
-      ) xs (s₁, s₂)).snd) := by
+    = let m := (mapAccumr (fun x s =>
+        let r₂ := f₂ x s.snd
+        let r₁ := f₁ r₂.snd s.fst
+        ((r₁.fst, r₂.fst), r₁.snd)
+      ) xs (s₁, s₂))
+      (m.fst.fst, m.snd) := by
   induction xs using Vector.revInductionOn generalizing s₁ s₂ <;> simp_all
 
 @[simp]
@@ -39,7 +40,7 @@ theorem mapAccumr_map (f₂ : α → β) :
 @[simp]
 theorem map_mapAccumr (f₁ : β → γ) :
     (map f₁ (mapAccumr f₂ xs s).snd) = (mapAccumr (fun x s =>
-        ((f₂ x s).fst, f₁ (f₂ x s).snd)
+        let r := (f₂ x s); (r.fst, f₁ r.snd)
       ) xs s).snd := by
   induction xs using Vector.revInductionOn generalizing s <;> simp_all
 
@@ -56,13 +57,12 @@ variable (xs : Vector α n) (ys : Vector β n)
 @[simp]
 theorem mapAccumr₂_mapAccumr_left (f₁ : γ → β → σ₁ → σ₁ × ζ) (f₂ : α → σ₂ → σ₂ × γ) :
     (mapAccumr₂ f₁ (mapAccumr f₂ xs s₂).snd ys s₁)
-    = (
-        (mapAccumr₂ (fun x y s =>
-          (((f₁ (f₂ x s.snd).snd y s.fst).fst, (f₂ x s.snd).fst), (f₁ (f₂ x s.snd).snd y s.fst).snd)
-        ) xs ys (s₁, s₂)).fst.fst,
-        (mapAccumr₂ (fun x y s =>
-          (((f₁ (f₂ x s.snd).snd y s.fst).fst, (f₂ x s.snd).fst), (f₁ (f₂ x s.snd).snd y s.fst).snd)
-        ) xs ys (s₁, s₂)).snd) := by
+    = let m := (mapAccumr₂ (fun x y s =>
+          let r₂ := f₂ x s.snd
+          let r₁ := f₁ r₂.snd y s.fst
+          ((r₁.fst, r₂.fst), r₁.snd)
+        ) xs ys (s₁, s₂))
+      (m.fst.fst, m.snd) := by
   induction xs, ys using Vector.revInductionOn₂ generalizing s₁ s₂ <;> simp_all
 
 @[simp]
@@ -73,16 +73,12 @@ theorem map₂_map_left (f₁ : γ → β → ζ) (f₂ : α → γ) :
 @[simp]
 theorem mapAccumr₂_mapAccumr_right (f₁ : α → γ → σ₁ → σ₁ × ζ) (f₂ : β → σ₂ → σ₂ × γ) :
     (mapAccumr₂ f₁ xs (mapAccumr f₂ ys s₂).snd s₁)
-    = (
-      (mapAccumr₂ (fun x y s =>
-          (((f₁ x (f₂ y s.snd).snd s.fst).fst, (f₂ y s.snd).fst), (f₁ x (f₂ y s.snd).snd s.fst).snd)
-        ) xs ys (s₁, s₂)
-      ).fst.fst,
-      (mapAccumr₂ (fun x y s =>
-          (((f₁ x (f₂ y s.snd).snd s.fst).fst, (f₂ y s.snd).fst), (f₁ x (f₂ y s.snd).snd s.fst).snd)
-        ) xs ys (s₁, s₂)
-      ).snd
-    ) := by
+    = let m := (mapAccumr₂ (fun x y s =>
+          let r₂ := f₂ y s.snd
+          let r₁ := f₁ x r₂.snd s.fst
+          ((r₁.fst, r₂.fst), r₁.snd)
+        ) xs ys (s₁, s₂))
+      (m.fst.fst, m.snd) := by
   induction xs, ys using Vector.revInductionOn₂ generalizing s₁ s₂ <;> simp_all
 
 @[simp]
@@ -93,18 +89,12 @@ theorem map₂_map_right (f₁ : α → γ → ζ) (f₂ : β → γ) :
 @[simp]
 theorem mapAccumr_mapAccumr₂ (f₁ : γ → σ₁ → σ₁ × ζ) (f₂ : α → β → σ₂ → σ₂ × γ) :
     (mapAccumr f₁ (mapAccumr₂ f₂ xs ys s₂).snd s₁)
-    = (
-        (mapAccumr₂ (fun x y s =>
-            (((f₁ (f₂ x y s.snd).snd s.fst).fst, (f₂ x y s.snd).fst),
-              (f₁ (f₂ x y s.snd).snd s.fst).snd)
-          ) xs ys (s₁, s₂)
-        ).fst.fst,
-        (mapAccumr₂ (fun x y s =>
-            (((f₁ (f₂ x y s.snd).snd s.fst).fst, (f₂ x y s.snd).fst),
-              (f₁ (f₂ x y s.snd).snd s.fst).snd)
-          ) xs ys (s₁, s₂)
-        ).snd
-      ) := by
+    = let m := mapAccumr₂ (fun x y s =>
+          let r₂ := f₂ x y s.snd
+          let r₁ := f₁ r₂.snd s.fst
+          ((r₁.fst, r₂.fst), r₁.snd)
+        ) xs ys (s₁, s₂);
+      (m.fst.fst, m.snd) := by
   induction xs, ys using Vector.revInductionOn₂ generalizing s₁ s₂ <;> simp_all
 
 @[simp]

--- a/Mathlib/Data/Vector/MapLemmas.lean
+++ b/Mathlib/Data/Vector/MapLemmas.lean
@@ -139,8 +139,8 @@ theorem mapAccumr₂_mapAccumr₂_left_left (f₁ : γ → α → σ₁ → σ�
   induction xs, ys using Vector.revInductionOn₂ generalizing s₁ s₂ <;> simp_all
 
 @[simp]
-theorem mapAccumr₂_mapAccumr₂_left_right  (f₁ : γ → β → σ₁ → σ₁ × φ)
-                                          (f₂ : α → β → σ₂ → σ₂ × γ) :
+theorem mapAccumr₂_mapAccumr₂_left_right  
+  (f₁ : γ → β → σ₁ → σ₁ × φ) (f₂ : α → β → σ₂ → σ₂ × γ) :
     (mapAccumr₂ f₁ (mapAccumr₂ f₂ xs ys s₂).snd ys s₁)
     = let m := mapAccumr₂ (fun x y (s₁, s₂) =>
                 let r₂ := f₂ x y s₂

--- a/Mathlib/Data/Vector/MapLemmas.lean
+++ b/Mathlib/Data/Vector/MapLemmas.lean
@@ -1,0 +1,296 @@
+/-
+Copyright (c) 2023 Alex Keizer. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Alex Keizer
+-/
+import Mathlib.Data.Vector.Basic
+import Mathlib.Data.Vector.Snoc
+
+
+/-!
+  This file establishes a set of normalization lemmas for `map`/`mapAccumr` operations on vectors
+-/
+
+namespace Vector
+
+  /-!
+  ## Normalization
+  Rewrite applications of `map` in terms of `mapAccumr` with `Unit` state
+  -/
+  section Norm
+
+    theorem map_to_mapAccumr (xs : Vector α n) (f : α → β) :
+        map f xs = (mapAccumr (fun x _ => (⟨⟩, f x)) xs ()).snd := by
+      induction xs using revInductionOn <;> simp_all
+
+    theorem map₂_to_mapAccumr₂ (xs : Vector α n) (ys : Vector β n) (f : α → β → γ) :
+        map₂ f xs ys = (mapAccumr₂ (fun x y _ => (⟨⟩, f x y)) xs ys ()).snd := by
+      induction xs, ys using revInductionOn₂ <;> simp_all
+
+  end Norm
+
+
+  /-!
+  ## Fold nested `mapAccumr`s into one
+  -/
+  section Fold
+
+    section Unary
+      variable (xs : Vector α n) (f₁ : β → σ₁ → σ₁ × γ) (f₂ : α → σ₂ → σ₂ × β)
+
+      protected abbrev mapAccumr_mapAccumr.g (x : α) (s : σ₁ × σ₂) :=
+        let r₂ := f₂ x s.snd
+        let r₁ := f₁ r₂.snd s.fst
+        ((r₁.fst, r₂.fst), r₁.snd)
+
+      @[simp]
+      theorem mapAccumr_mapAccumr : (mapAccumr f₁ (mapAccumr f₂ xs s₂).snd s₁)
+                                    = let m := (mapAccumr (mapAccumr_mapAccumr.g f₁ f₂) xs (s₁, s₂))
+                                      (m.fst.fst, m.snd) := by
+        induction xs using Vector.revInductionOn generalizing s₁ s₂ <;> simp_all
+
+
+      @[simp]
+      theorem mapAccumr_map (f₂ : α → β) :
+          (mapAccumr f₁ (map f₂ xs) s) = (mapAccumr (fun x s => f₁ (f₂ x) s) xs s) := by
+        induction xs using Vector.revInductionOn generalizing s <;> simp_all
+
+      @[simp]
+      theorem map_mapAccumr (f₁ : β → γ) :
+          (map f₁ (mapAccumr f₂ xs s).snd) = (mapAccumr (fun x s =>
+              let r := (f₂ x s); (r.fst, f₁ r.snd)
+            ) xs s).snd := by
+        induction xs using Vector.revInductionOn generalizing s <;> simp_all
+
+      @[simp]
+      theorem map_map (f₁ : β → γ) (f₂ : α → β) :
+          map f₁ (map f₂ xs) = map (fun x => f₁ <| f₂ x) xs := by
+        induction xs using Vector.inductionOn <;> simp_all
+
+    end Unary
+
+
+
+    section Binary
+      variable (xs : Vector α n) (ys : Vector β n)
+      variable (f₁ : γ → β → σ₁ → σ₁ × ζ) (f₂ : α → σ₂ → σ₂ × γ)
+
+      protected abbrev mapAccumr₂_mapAccumr_left.g (x : α) (y : β) (s : σ₁ × σ₂) :=
+        let r₂ := f₂ x s.snd
+        let r₁ := f₁ r₂.snd y s.fst
+        ((r₁.fst, r₂.fst), r₁.snd)
+
+      @[simp]
+      theorem mapAccumr₂_mapAccumr_left :
+          (mapAccumr₂ f₁ (mapAccumr f₂ xs s₂).snd ys s₁)
+          = let m := (mapAccumr₂ (mapAccumr₂_mapAccumr_left.g f₁ f₂) xs ys (s₁, s₂))
+            (m.fst.fst, m.snd) := by
+        induction xs, ys using Vector.revInductionOn₂ generalizing s₁ s₂ <;> simp_all
+
+      @[simp]
+      theorem map₂_map_left (f₁ : γ → β → ζ) (f₂ : α → γ) :
+          map₂ f₁ (map f₂ xs) ys = map₂ (fun x y => f₁ (f₂ x) y) xs ys := by
+        induction xs, ys using Vector.revInductionOn₂ <;> simp_all
+
+
+
+      variable (f₁ : α → γ → σ₁ → σ₁ × ζ) (f₂ : β → σ₂ → σ₂ × γ)
+
+      protected abbrev mapAccumr₂_mapAccumr_right.g (x : α) (y : β) (s : σ₁ × σ₂) :=
+        let r₂ := f₂ y s.snd
+        let r₁ := f₁ x r₂.snd s.fst
+        ((r₁.fst, r₂.fst), r₁.snd)
+
+      @[simp]
+      theorem mapAccumr₂_mapAccumr_right :
+          (mapAccumr₂ f₁ xs (mapAccumr f₂ ys s₂).snd s₁)
+          = let m := (mapAccumr₂ (mapAccumr₂_mapAccumr_right.g f₁ f₂) xs ys (s₁, s₂))
+            (m.fst.fst, m.snd) := by
+        induction xs, ys using Vector.revInductionOn₂ generalizing s₁ s₂ <;> simp_all
+
+      @[simp]
+      theorem map₂_map_right (f₁ : α → γ → ζ) (f₂ : β → γ) :
+          map₂ f₁ xs (map f₂ ys) = map₂ (fun x y => f₁ x (f₂ y)) xs ys := by
+        induction xs, ys using Vector.revInductionOn₂ <;> simp_all
+
+
+      variable (f₁ : γ → σ₁ → σ₁ × ζ) (f₂ : α → β → σ₂ → σ₂ × γ)
+
+      protected abbrev mapAccumr_mapAccumr₂.g (x : α) (y : β) (s : σ₁ × σ₂) :=
+        let r₂ := f₂ x y s.snd
+        let r₁ := f₁ r₂.snd s.fst
+        ((r₁.fst, r₂.fst), r₁.snd)
+
+      @[simp]
+      theorem mapAccumr_mapAccumr₂ :
+          (mapAccumr f₁ (mapAccumr₂ f₂ xs ys s₂).snd s₁)
+          = let m := mapAccumr₂ (mapAccumr_mapAccumr₂.g f₁ f₂) xs ys (s₁, s₂);
+            (m.fst.fst, m.snd) := by
+        induction xs, ys using Vector.revInductionOn₂ generalizing s₁ s₂ <;> simp_all
+
+      @[simp]
+      theorem map_map₂ (f₁ : γ → ζ) (f₂ : α → β → γ) :
+          map f₁ (map₂ f₂ xs ys) = map₂ (fun x y => f₁ <| f₂ x y) xs ys := by
+        induction xs, ys using Vector.revInductionOn₂ <;> simp_all
+
+      @[simp]
+      theorem mapAccumr₂_mapAccumr₂_left_left (f₁ : γ → α → σ₁ → σ₁ × φ)
+                                              (f₂ : α → β → σ₂ → σ₂ × γ) :
+          (mapAccumr₂ f₁ (mapAccumr₂ f₂ xs ys s₂).snd xs s₁)
+          = let m := mapAccumr₂ (fun x y (s₁, s₂) =>
+                      let r₂ := f₂ x y s₂
+                      let r₁ := f₁ r₂.snd x s₁
+                      ((r₁.fst, r₂.fst), r₁.snd)
+                    )
+                  xs ys (s₁, s₂);
+          (m.fst.fst, m.snd) := by
+        induction xs, ys using Vector.revInductionOn₂ generalizing s₁ s₂ <;> simp_all
+
+      @[simp]
+      theorem mapAccumr₂_mapAccumr₂_left_right  (f₁ : γ → β → σ₁ → σ₁ × φ)
+                                                (f₂ : α → β → σ₂ → σ₂ × γ) :
+          (mapAccumr₂ f₁ (mapAccumr₂ f₂ xs ys s₂).snd ys s₁)
+          = let m := mapAccumr₂ (fun x y (s₁, s₂) =>
+                      let r₂ := f₂ x y s₂
+                      let r₁ := f₁ r₂.snd y s₁
+                      ((r₁.fst, r₂.fst), r₁.snd)
+                    )
+                  xs ys (s₁, s₂);
+          (m.fst.fst, m.snd) := by
+        induction xs, ys using Vector.revInductionOn₂ generalizing s₁ s₂ <;> simp_all
+
+      @[simp]
+      theorem mapAccumr₂_mapAccumr₂_right_left  (f₁ : α → γ → σ₁ → σ₁ × φ)
+                                                (f₂ : α → β → σ₂ → σ₂ × γ) :
+          (mapAccumr₂ f₁ xs (mapAccumr₂ f₂ xs ys s₂).snd s₁)
+          = let m := mapAccumr₂ (fun x y (s₁, s₂) =>
+                      let r₂ := f₂ x y s₂
+                      let r₁ := f₁ x r₂.snd s₁
+                      ((r₁.fst, r₂.fst), r₁.snd)
+                    )
+                  xs ys (s₁, s₂);
+          (m.fst.fst, m.snd) := by
+        induction xs, ys using Vector.revInductionOn₂ generalizing s₁ s₂ <;> simp_all
+
+      @[simp]
+      theorem mapAccumr₂_mapAccumr₂_right_right (f₁ : β → γ → σ₁ → σ₁ × φ)
+                                                (f₂ : α → β → σ₂ → σ₂ × γ) :
+          (mapAccumr₂ f₁ ys (mapAccumr₂ f₂ xs ys s₂).snd s₁)
+          = let m := mapAccumr₂ (fun x y (s₁, s₂) =>
+                      let r₂ := f₂ x y s₂
+                      let r₁ := f₁ y r₂.snd s₁
+                      ((r₁.fst, r₂.fst), r₁.snd)
+                    )
+                  xs ys (s₁, s₂);
+          (m.fst.fst, m.snd) := by
+        induction xs, ys using Vector.revInductionOn₂ generalizing s₁ s₂ <;> simp_all
+
+
+    end Binary
+
+
+  end Fold
+
+
+  /-!
+  ## Redundant state or input optimizations
+
+  The following section are collection of rewrites to simplify, or even get rid, redundant
+  accumulation state, or redundant inputs
+  -/
+  section RedundantState
+    variable (xs : Vector α n) (ys : Vector β n)
+
+    /--
+      If an accumulation function `f`, given an initial state `s`, produces `s` as its output state
+      for all possible input bits, then the state is redundant and can be optimized out
+    -/
+    @[simp]
+    theorem mapAccumr_redundant_state (f : α → σ → σ × β) (s : σ) (h : ∀ a, (f a s).fst = s) :
+        mapAccumr f xs s = (s, (map (fun x => (f x s).snd) xs)) := by
+      clear ys
+      induction xs using revInductionOn <;> simp_all
+
+    /--
+      If an accumulation function `f`, given an initial state `s`, produces `s` as its output state
+      for all possible input bits, then the state is redundant and can be optimized out
+    -/
+    @[simp]
+    theorem mapAccumr₂_redundant_state (f : α → β → σ → σ × γ) (s : σ) (h : ∀ a b, (f a b s).fst = s) :
+        mapAccumr₂ f xs ys s = (s, (map₂ (fun x y => (f x y s).snd) xs ys)) := by
+      induction xs, ys using revInductionOn₂ <;> simp_all
+
+    /-- If `f` takes a pair of states, but always returns the same value for both elements of the
+        pair, then we can simplify to just a single element of state
+     -/
+    @[simp]
+    theorem mapAccumr_redundant_pair (f : α → (σ × σ) → (σ × σ) × β)
+                                  (h : ∀ x s, let s' := (f x (s, s)).fst; s'.fst = s'.snd)
+                                : mapAccumr f xs (s, s) = (
+                                    let m := mapAccumr (fun x s => let r := f x (s, s);
+                                                                  (r.fst.fst, r.snd)
+                                                        ) xs s
+                                    ((m.fst, m.fst), m.snd)
+                                  ) := by
+      clear ys
+      induction xs using Vector.revInductionOn generalizing s
+      case nil => rfl
+      case snoc xs x ih =>
+        specialize h x s
+        revert h
+        simp_all
+        rcases (f x (s, s)) with ⟨⟨s₁, s₂⟩, y⟩
+        simp_all
+
+    /-- If `f` takes a pair of states, but always returns the same value for both elements of the
+        pair, then we can simplify to just a single element of state
+     -/
+    @[simp]
+    theorem mapAccumr₂_redundant_pair (f : α → β → (σ × σ) → (σ × σ) × γ)
+                                  (h : ∀ x y s, let s' := (f x y (s, s)).fst; s'.fst = s'.snd)
+                                : mapAccumr₂ f xs ys (s, s) = (
+                                    let m := mapAccumr₂ (fun x y s => let r := f x y (s, s);
+                                                                      (r.fst.fst, r.snd)
+                                                        ) xs ys s
+                                    ((m.fst, m.fst), m.snd)
+                                  ) := by
+      induction xs, ys using Vector.revInductionOn₂ generalizing s
+      case nil => rfl
+      case snoc xs ys x y ih =>
+        specialize h x y s
+        revert h
+        simp_all
+        rcases (f x y (s, s)) with ⟨⟨s₁, s₂⟩, y⟩
+        simp_all
+
+
+    /--
+      If `f` returns the same output and next state for every value of it's first argument, then
+      `xs : Vector` is ignored, and we can rewrite `mapAccumr₂` into `map`
+    -/
+    @[simp]
+    theorem mapAccumr₂_unused_input_left  [Inhabited α]
+                                          (f : α → β → σ → σ × γ)
+                                          (h : ∀ a b s, f Inhabited.default b s = f a b s) :
+        mapAccumr₂ f xs ys s = mapAccumr (fun b s => f Inhabited.default b s) ys s := by
+      induction xs, ys using Vector.revInductionOn₂ generalizing s
+      case nil => rfl
+      case snoc xs ys x y ih =>
+        simp[h x y s, ih]
+
+    /--
+      If `f` returns the same output and next state for every value of it's second argument, then
+      `ys : Vector` is ignored, and we can rewrite `mapAccumr₂` into `map`
+    -/
+    @[simp]
+    theorem mapAccumr₂_unused_input_right [Inhabited β]
+                                          (f : α → β → σ → σ × γ)
+                                          (h : ∀ a b s, f a Inhabited.default s = f a b s) :
+        mapAccumr₂ f xs ys s = mapAccumr (fun a s => f a Inhabited.default s) xs s := by
+      induction xs, ys using Vector.revInductionOn₂ generalizing s
+      case nil => rfl
+      case snoc xs ys x y ih =>
+        simp[h x y s, ih]
+
+  end RedundantState
+end Vector

--- a/Mathlib/Data/Vector/MapLemmas.lean
+++ b/Mathlib/Data/Vector/MapLemmas.lean
@@ -13,284 +13,286 @@ import Mathlib.Data.Vector.Snoc
 
 namespace Vector
 
-  /-!
-  ## Normalization
-  Rewrite applications of `map` in terms of `mapAccumr` with `Unit` state
+/-!
+## Normalization
+Rewrite applications of `map` in terms of `mapAccumr` with `Unit` state
+-/
+section Norm
+
+  theorem map_to_mapAccumr (xs : Vector α n) (f : α → β) :
+      map f xs = (mapAccumr (fun x _ => (⟨⟩, f x)) xs ()).snd := by
+    induction xs using revInductionOn <;> simp_all
+
+  theorem map₂_to_mapAccumr₂ (xs : Vector α n) (ys : Vector β n) (f : α → β → γ) :
+      map₂ f xs ys = (mapAccumr₂ (fun x y _ => (⟨⟩, f x y)) xs ys ()).snd := by
+    induction xs, ys using revInductionOn₂ <;> simp_all
+
+end Norm
+
+
+/-!
+## Fold nested `mapAccumr`s into one
+-/
+section Fold
+
+section Unary
+variable (xs : Vector α n) (f₁ : β → σ₁ → σ₁ × γ) (f₂ : α → σ₂ → σ₂ × β)
+
+protected abbrev mapAccumr_mapAccumr.g (x : α) (s : σ₁ × σ₂) :=
+  let r₂ := f₂ x s.snd
+  let r₁ := f₁ r₂.snd s.fst
+  ((r₁.fst, r₂.fst), r₁.snd)
+
+@[simp]
+theorem mapAccumr_mapAccumr : (mapAccumr f₁ (mapAccumr f₂ xs s₂).snd s₁)
+                              = let m := (mapAccumr (mapAccumr_mapAccumr.g f₁ f₂) xs (s₁, s₂))
+                                (m.fst.fst, m.snd) := by
+  induction xs using Vector.revInductionOn generalizing s₁ s₂ <;> simp_all
+
+
+@[simp]
+theorem mapAccumr_map (f₂ : α → β) :
+    (mapAccumr f₁ (map f₂ xs) s) = (mapAccumr (fun x s => f₁ (f₂ x) s) xs s) := by
+  induction xs using Vector.revInductionOn generalizing s <;> simp_all
+
+@[simp]
+theorem map_mapAccumr (f₁ : β → γ) :
+    (map f₁ (mapAccumr f₂ xs s).snd) = (mapAccumr (fun x s =>
+        let r := (f₂ x s); (r.fst, f₁ r.snd)
+      ) xs s).snd := by
+  induction xs using Vector.revInductionOn generalizing s <;> simp_all
+
+@[simp]
+theorem map_map (f₁ : β → γ) (f₂ : α → β) :
+    map f₁ (map f₂ xs) = map (fun x => f₁ <| f₂ x) xs := by
+  induction xs using Vector.inductionOn <;> simp_all
+
+end Unary
+
+
+
+section Binary
+variable (xs : Vector α n) (ys : Vector β n)
+variable (f₁ : γ → β → σ₁ → σ₁ × ζ) (f₂ : α → σ₂ → σ₂ × γ)
+
+protected abbrev mapAccumr₂_mapAccumr_left.g (x : α) (y : β) (s : σ₁ × σ₂) :=
+  let r₂ := f₂ x s.snd
+  let r₁ := f₁ r₂.snd y s.fst
+  ((r₁.fst, r₂.fst), r₁.snd)
+
+@[simp]
+theorem mapAccumr₂_mapAccumr_left :
+    (mapAccumr₂ f₁ (mapAccumr f₂ xs s₂).snd ys s₁)
+    = let m := (mapAccumr₂ (mapAccumr₂_mapAccumr_left.g f₁ f₂) xs ys (s₁, s₂))
+      (m.fst.fst, m.snd) := by
+  induction xs, ys using Vector.revInductionOn₂ generalizing s₁ s₂ <;> simp_all
+
+@[simp]
+theorem map₂_map_left (f₁ : γ → β → ζ) (f₂ : α → γ) :
+    map₂ f₁ (map f₂ xs) ys = map₂ (fun x y => f₁ (f₂ x) y) xs ys := by
+  induction xs, ys using Vector.revInductionOn₂ <;> simp_all
+
+
+
+variable (f₁ : α → γ → σ₁ → σ₁ × ζ) (f₂ : β → σ₂ → σ₂ × γ)
+
+protected abbrev mapAccumr₂_mapAccumr_right.g (x : α) (y : β) (s : σ₁ × σ₂) :=
+  let r₂ := f₂ y s.snd
+  let r₁ := f₁ x r₂.snd s.fst
+  ((r₁.fst, r₂.fst), r₁.snd)
+
+@[simp]
+theorem mapAccumr₂_mapAccumr_right :
+    (mapAccumr₂ f₁ xs (mapAccumr f₂ ys s₂).snd s₁)
+    = let m := (mapAccumr₂ (mapAccumr₂_mapAccumr_right.g f₁ f₂) xs ys (s₁, s₂))
+      (m.fst.fst, m.snd) := by
+  induction xs, ys using Vector.revInductionOn₂ generalizing s₁ s₂ <;> simp_all
+
+@[simp]
+theorem map₂_map_right (f₁ : α → γ → ζ) (f₂ : β → γ) :
+    map₂ f₁ xs (map f₂ ys) = map₂ (fun x y => f₁ x (f₂ y)) xs ys := by
+  induction xs, ys using Vector.revInductionOn₂ <;> simp_all
+
+
+variable (f₁ : γ → σ₁ → σ₁ × ζ) (f₂ : α → β → σ₂ → σ₂ × γ)
+
+protected abbrev mapAccumr_mapAccumr₂.g (x : α) (y : β) (s : σ₁ × σ₂) :=
+  let r₂ := f₂ x y s.snd
+  let r₁ := f₁ r₂.snd s.fst
+  ((r₁.fst, r₂.fst), r₁.snd)
+
+@[simp]
+theorem mapAccumr_mapAccumr₂ :
+    (mapAccumr f₁ (mapAccumr₂ f₂ xs ys s₂).snd s₁)
+    = let m := mapAccumr₂ (mapAccumr_mapAccumr₂.g f₁ f₂) xs ys (s₁, s₂);
+      (m.fst.fst, m.snd) := by
+  induction xs, ys using Vector.revInductionOn₂ generalizing s₁ s₂ <;> simp_all
+
+@[simp]
+theorem map_map₂ (f₁ : γ → ζ) (f₂ : α → β → γ) :
+    map f₁ (map₂ f₂ xs ys) = map₂ (fun x y => f₁ <| f₂ x y) xs ys := by
+  induction xs, ys using Vector.revInductionOn₂ <;> simp_all
+
+@[simp]
+theorem mapAccumr₂_mapAccumr₂_left_left (f₁ : γ → α → σ₁ → σ₁ × φ)
+                                        (f₂ : α → β → σ₂ → σ₂ × γ) :
+    (mapAccumr₂ f₁ (mapAccumr₂ f₂ xs ys s₂).snd xs s₁)
+    = let m := mapAccumr₂ (fun x y (s₁, s₂) =>
+                let r₂ := f₂ x y s₂
+                let r₁ := f₁ r₂.snd x s₁
+                ((r₁.fst, r₂.fst), r₁.snd)
+              )
+            xs ys (s₁, s₂);
+    (m.fst.fst, m.snd) := by
+  induction xs, ys using Vector.revInductionOn₂ generalizing s₁ s₂ <;> simp_all
+
+@[simp]
+theorem mapAccumr₂_mapAccumr₂_left_right  (f₁ : γ → β → σ₁ → σ₁ × φ)
+                                          (f₂ : α → β → σ₂ → σ₂ × γ) :
+    (mapAccumr₂ f₁ (mapAccumr₂ f₂ xs ys s₂).snd ys s₁)
+    = let m := mapAccumr₂ (fun x y (s₁, s₂) =>
+                let r₂ := f₂ x y s₂
+                let r₁ := f₁ r₂.snd y s₁
+                ((r₁.fst, r₂.fst), r₁.snd)
+              )
+            xs ys (s₁, s₂);
+    (m.fst.fst, m.snd) := by
+  induction xs, ys using Vector.revInductionOn₂ generalizing s₁ s₂ <;> simp_all
+
+@[simp]
+theorem mapAccumr₂_mapAccumr₂_right_left  (f₁ : α → γ → σ₁ → σ₁ × φ)
+                                          (f₂ : α → β → σ₂ → σ₂ × γ) :
+    (mapAccumr₂ f₁ xs (mapAccumr₂ f₂ xs ys s₂).snd s₁)
+    = let m := mapAccumr₂ (fun x y (s₁, s₂) =>
+                let r₂ := f₂ x y s₂
+                let r₁ := f₁ x r₂.snd s₁
+                ((r₁.fst, r₂.fst), r₁.snd)
+              )
+            xs ys (s₁, s₂);
+    (m.fst.fst, m.snd) := by
+  induction xs, ys using Vector.revInductionOn₂ generalizing s₁ s₂ <;> simp_all
+
+@[simp]
+theorem mapAccumr₂_mapAccumr₂_right_right (f₁ : β → γ → σ₁ → σ₁ × φ)
+                                          (f₂ : α → β → σ₂ → σ₂ × γ) :
+    (mapAccumr₂ f₁ ys (mapAccumr₂ f₂ xs ys s₂).snd s₁)
+    = let m := mapAccumr₂ (fun x y (s₁, s₂) =>
+                let r₂ := f₂ x y s₂
+                let r₁ := f₁ y r₂.snd s₁
+                ((r₁.fst, r₂.fst), r₁.snd)
+              )
+            xs ys (s₁, s₂);
+    (m.fst.fst, m.snd) := by
+  induction xs, ys using Vector.revInductionOn₂ generalizing s₁ s₂ <;> simp_all
+
+
+end Binary
+
+
+end Fold
+
+
+/-!
+## Redundant state or input optimizations
+
+The following section are collection of rewrites to simplify, or even get rid, redundant
+accumulation state, or redundant inputs
+-/
+section RedundantState
+variable (xs : Vector α n) (ys : Vector β n)
+
+/--
+  If an accumulation function `f`, given an initial state `s`, produces `s` as its output state
+  for all possible input bits, then the state is redundant and can be optimized out
+-/
+@[simp]
+theorem mapAccumr_redundant_state (f : α → σ → σ × β) (s : σ) (h : ∀ a, (f a s).fst = s) :
+    mapAccumr f xs s = (s, (map (fun x => (f x s).snd) xs)) := by
+  clear ys
+  induction xs using revInductionOn <;> simp_all
+
+/--
+  If an accumulation function `f`, given an initial state `s`, produces `s` as its output state
+  for all possible input bits, then the state is redundant and can be optimized out
+-/
+@[simp]
+theorem mapAccumr₂_redundant_state (f : α → β → σ → σ × γ) (s : σ) (h : ∀ a b, (f a b s).fst = s) :
+    mapAccumr₂ f xs ys s = (s, (map₂ (fun x y => (f x y s).snd) xs ys)) := by
+  induction xs, ys using revInductionOn₂ <;> simp_all
+
+/-- If `f` takes a pair of states, but always returns the same value for both elements of the
+    pair, then we can simplify to just a single element of state
   -/
-  section Norm
+@[simp]
+theorem mapAccumr_redundant_pair (f : α → (σ × σ) → (σ × σ) × β)
+                              (h : ∀ x s, let s' := (f x (s, s)).fst; s'.fst = s'.snd)
+                            : mapAccumr f xs (s, s) = (
+                                let m := mapAccumr (fun x s => let r := f x (s, s);
+                                                              (r.fst.fst, r.snd)
+                                                    ) xs s
+                                ((m.fst, m.fst), m.snd)
+                              ) := by
+  clear ys
+  induction xs using Vector.revInductionOn generalizing s
+  case nil => rfl
+  case snoc xs x ih =>
+    specialize h x s
+    revert h
+    simp_all
+    rcases (f x (s, s)) with ⟨⟨s₁, s₂⟩, y⟩
+    simp_all
 
-    theorem map_to_mapAccumr (xs : Vector α n) (f : α → β) :
-        map f xs = (mapAccumr (fun x _ => (⟨⟩, f x)) xs ()).snd := by
-      induction xs using revInductionOn <;> simp_all
-
-    theorem map₂_to_mapAccumr₂ (xs : Vector α n) (ys : Vector β n) (f : α → β → γ) :
-        map₂ f xs ys = (mapAccumr₂ (fun x y _ => (⟨⟩, f x y)) xs ys ()).snd := by
-      induction xs, ys using revInductionOn₂ <;> simp_all
-
-  end Norm
-
-
-  /-!
-  ## Fold nested `mapAccumr`s into one
+/-- If `f` takes a pair of states, but always returns the same value for both elements of the
+    pair, then we can simplify to just a single element of state
   -/
-  section Fold
-
-    section Unary
-      variable (xs : Vector α n) (f₁ : β → σ₁ → σ₁ × γ) (f₂ : α → σ₂ → σ₂ × β)
-
-      protected abbrev mapAccumr_mapAccumr.g (x : α) (s : σ₁ × σ₂) :=
-        let r₂ := f₂ x s.snd
-        let r₁ := f₁ r₂.snd s.fst
-        ((r₁.fst, r₂.fst), r₁.snd)
-
-      @[simp]
-      theorem mapAccumr_mapAccumr : (mapAccumr f₁ (mapAccumr f₂ xs s₂).snd s₁)
-                                    = let m := (mapAccumr (mapAccumr_mapAccumr.g f₁ f₂) xs (s₁, s₂))
-                                      (m.fst.fst, m.snd) := by
-        induction xs using Vector.revInductionOn generalizing s₁ s₂ <;> simp_all
-
-
-      @[simp]
-      theorem mapAccumr_map (f₂ : α → β) :
-          (mapAccumr f₁ (map f₂ xs) s) = (mapAccumr (fun x s => f₁ (f₂ x) s) xs s) := by
-        induction xs using Vector.revInductionOn generalizing s <;> simp_all
-
-      @[simp]
-      theorem map_mapAccumr (f₁ : β → γ) :
-          (map f₁ (mapAccumr f₂ xs s).snd) = (mapAccumr (fun x s =>
-              let r := (f₂ x s); (r.fst, f₁ r.snd)
-            ) xs s).snd := by
-        induction xs using Vector.revInductionOn generalizing s <;> simp_all
-
-      @[simp]
-      theorem map_map (f₁ : β → γ) (f₂ : α → β) :
-          map f₁ (map f₂ xs) = map (fun x => f₁ <| f₂ x) xs := by
-        induction xs using Vector.inductionOn <;> simp_all
-
-    end Unary
-
-
-
-    section Binary
-      variable (xs : Vector α n) (ys : Vector β n)
-      variable (f₁ : γ → β → σ₁ → σ₁ × ζ) (f₂ : α → σ₂ → σ₂ × γ)
-
-      protected abbrev mapAccumr₂_mapAccumr_left.g (x : α) (y : β) (s : σ₁ × σ₂) :=
-        let r₂ := f₂ x s.snd
-        let r₁ := f₁ r₂.snd y s.fst
-        ((r₁.fst, r₂.fst), r₁.snd)
-
-      @[simp]
-      theorem mapAccumr₂_mapAccumr_left :
-          (mapAccumr₂ f₁ (mapAccumr f₂ xs s₂).snd ys s₁)
-          = let m := (mapAccumr₂ (mapAccumr₂_mapAccumr_left.g f₁ f₂) xs ys (s₁, s₂))
-            (m.fst.fst, m.snd) := by
-        induction xs, ys using Vector.revInductionOn₂ generalizing s₁ s₂ <;> simp_all
-
-      @[simp]
-      theorem map₂_map_left (f₁ : γ → β → ζ) (f₂ : α → γ) :
-          map₂ f₁ (map f₂ xs) ys = map₂ (fun x y => f₁ (f₂ x) y) xs ys := by
-        induction xs, ys using Vector.revInductionOn₂ <;> simp_all
-
-
-
-      variable (f₁ : α → γ → σ₁ → σ₁ × ζ) (f₂ : β → σ₂ → σ₂ × γ)
-
-      protected abbrev mapAccumr₂_mapAccumr_right.g (x : α) (y : β) (s : σ₁ × σ₂) :=
-        let r₂ := f₂ y s.snd
-        let r₁ := f₁ x r₂.snd s.fst
-        ((r₁.fst, r₂.fst), r₁.snd)
-
-      @[simp]
-      theorem mapAccumr₂_mapAccumr_right :
-          (mapAccumr₂ f₁ xs (mapAccumr f₂ ys s₂).snd s₁)
-          = let m := (mapAccumr₂ (mapAccumr₂_mapAccumr_right.g f₁ f₂) xs ys (s₁, s₂))
-            (m.fst.fst, m.snd) := by
-        induction xs, ys using Vector.revInductionOn₂ generalizing s₁ s₂ <;> simp_all
-
-      @[simp]
-      theorem map₂_map_right (f₁ : α → γ → ζ) (f₂ : β → γ) :
-          map₂ f₁ xs (map f₂ ys) = map₂ (fun x y => f₁ x (f₂ y)) xs ys := by
-        induction xs, ys using Vector.revInductionOn₂ <;> simp_all
-
-
-      variable (f₁ : γ → σ₁ → σ₁ × ζ) (f₂ : α → β → σ₂ → σ₂ × γ)
-
-      protected abbrev mapAccumr_mapAccumr₂.g (x : α) (y : β) (s : σ₁ × σ₂) :=
-        let r₂ := f₂ x y s.snd
-        let r₁ := f₁ r₂.snd s.fst
-        ((r₁.fst, r₂.fst), r₁.snd)
-
-      @[simp]
-      theorem mapAccumr_mapAccumr₂ :
-          (mapAccumr f₁ (mapAccumr₂ f₂ xs ys s₂).snd s₁)
-          = let m := mapAccumr₂ (mapAccumr_mapAccumr₂.g f₁ f₂) xs ys (s₁, s₂);
-            (m.fst.fst, m.snd) := by
-        induction xs, ys using Vector.revInductionOn₂ generalizing s₁ s₂ <;> simp_all
-
-      @[simp]
-      theorem map_map₂ (f₁ : γ → ζ) (f₂ : α → β → γ) :
-          map f₁ (map₂ f₂ xs ys) = map₂ (fun x y => f₁ <| f₂ x y) xs ys := by
-        induction xs, ys using Vector.revInductionOn₂ <;> simp_all
-
-      @[simp]
-      theorem mapAccumr₂_mapAccumr₂_left_left (f₁ : γ → α → σ₁ → σ₁ × φ)
-                                              (f₂ : α → β → σ₂ → σ₂ × γ) :
-          (mapAccumr₂ f₁ (mapAccumr₂ f₂ xs ys s₂).snd xs s₁)
-          = let m := mapAccumr₂ (fun x y (s₁, s₂) =>
-                      let r₂ := f₂ x y s₂
-                      let r₁ := f₁ r₂.snd x s₁
-                      ((r₁.fst, r₂.fst), r₁.snd)
-                    )
-                  xs ys (s₁, s₂);
-          (m.fst.fst, m.snd) := by
-        induction xs, ys using Vector.revInductionOn₂ generalizing s₁ s₂ <;> simp_all
-
-      @[simp]
-      theorem mapAccumr₂_mapAccumr₂_left_right  (f₁ : γ → β → σ₁ → σ₁ × φ)
-                                                (f₂ : α → β → σ₂ → σ₂ × γ) :
-          (mapAccumr₂ f₁ (mapAccumr₂ f₂ xs ys s₂).snd ys s₁)
-          = let m := mapAccumr₂ (fun x y (s₁, s₂) =>
-                      let r₂ := f₂ x y s₂
-                      let r₁ := f₁ r₂.snd y s₁
-                      ((r₁.fst, r₂.fst), r₁.snd)
-                    )
-                  xs ys (s₁, s₂);
-          (m.fst.fst, m.snd) := by
-        induction xs, ys using Vector.revInductionOn₂ generalizing s₁ s₂ <;> simp_all
-
-      @[simp]
-      theorem mapAccumr₂_mapAccumr₂_right_left  (f₁ : α → γ → σ₁ → σ₁ × φ)
-                                                (f₂ : α → β → σ₂ → σ₂ × γ) :
-          (mapAccumr₂ f₁ xs (mapAccumr₂ f₂ xs ys s₂).snd s₁)
-          = let m := mapAccumr₂ (fun x y (s₁, s₂) =>
-                      let r₂ := f₂ x y s₂
-                      let r₁ := f₁ x r₂.snd s₁
-                      ((r₁.fst, r₂.fst), r₁.snd)
-                    )
-                  xs ys (s₁, s₂);
-          (m.fst.fst, m.snd) := by
-        induction xs, ys using Vector.revInductionOn₂ generalizing s₁ s₂ <;> simp_all
-
-      @[simp]
-      theorem mapAccumr₂_mapAccumr₂_right_right (f₁ : β → γ → σ₁ → σ₁ × φ)
-                                                (f₂ : α → β → σ₂ → σ₂ × γ) :
-          (mapAccumr₂ f₁ ys (mapAccumr₂ f₂ xs ys s₂).snd s₁)
-          = let m := mapAccumr₂ (fun x y (s₁, s₂) =>
-                      let r₂ := f₂ x y s₂
-                      let r₁ := f₁ y r₂.snd s₁
-                      ((r₁.fst, r₂.fst), r₁.snd)
-                    )
-                  xs ys (s₁, s₂);
-          (m.fst.fst, m.snd) := by
-        induction xs, ys using Vector.revInductionOn₂ generalizing s₁ s₂ <;> simp_all
-
-
-    end Binary
-
-
-  end Fold
-
-
-  /-!
-  ## Redundant state or input optimizations
-
-  The following section are collection of rewrites to simplify, or even get rid, redundant
-  accumulation state, or redundant inputs
-  -/
-  section RedundantState
-    variable (xs : Vector α n) (ys : Vector β n)
-
-    /--
-      If an accumulation function `f`, given an initial state `s`, produces `s` as its output state
-      for all possible input bits, then the state is redundant and can be optimized out
-    -/
-    @[simp]
-    theorem mapAccumr_redundant_state (f : α → σ → σ × β) (s : σ) (h : ∀ a, (f a s).fst = s) :
-        mapAccumr f xs s = (s, (map (fun x => (f x s).snd) xs)) := by
-      clear ys
-      induction xs using revInductionOn <;> simp_all
-
-    /--
-      If an accumulation function `f`, given an initial state `s`, produces `s` as its output state
-      for all possible input bits, then the state is redundant and can be optimized out
-    -/
-    @[simp]
-    theorem mapAccumr₂_redundant_state (f : α → β → σ → σ × γ) (s : σ) (h : ∀ a b, (f a b s).fst = s) :
-        mapAccumr₂ f xs ys s = (s, (map₂ (fun x y => (f x y s).snd) xs ys)) := by
-      induction xs, ys using revInductionOn₂ <;> simp_all
-
-    /-- If `f` takes a pair of states, but always returns the same value for both elements of the
-        pair, then we can simplify to just a single element of state
-     -/
-    @[simp]
-    theorem mapAccumr_redundant_pair (f : α → (σ × σ) → (σ × σ) × β)
-                                  (h : ∀ x s, let s' := (f x (s, s)).fst; s'.fst = s'.snd)
-                                : mapAccumr f xs (s, s) = (
-                                    let m := mapAccumr (fun x s => let r := f x (s, s);
+@[simp]
+theorem mapAccumr₂_redundant_pair (f : α → β → (σ × σ) → (σ × σ) × γ)
+                              (h : ∀ x y s, let s' := (f x y (s, s)).fst; s'.fst = s'.snd)
+                            : mapAccumr₂ f xs ys (s, s) = (
+                                let m := mapAccumr₂ (fun x y s => let r := f x y (s, s);
                                                                   (r.fst.fst, r.snd)
-                                                        ) xs s
-                                    ((m.fst, m.fst), m.snd)
-                                  ) := by
-      clear ys
-      induction xs using Vector.revInductionOn generalizing s
-      case nil => rfl
-      case snoc xs x ih =>
-        specialize h x s
-        revert h
-        simp_all
-        rcases (f x (s, s)) with ⟨⟨s₁, s₂⟩, y⟩
-        simp_all
-
-    /-- If `f` takes a pair of states, but always returns the same value for both elements of the
-        pair, then we can simplify to just a single element of state
-     -/
-    @[simp]
-    theorem mapAccumr₂_redundant_pair (f : α → β → (σ × σ) → (σ × σ) × γ)
-                                  (h : ∀ x y s, let s' := (f x y (s, s)).fst; s'.fst = s'.snd)
-                                : mapAccumr₂ f xs ys (s, s) = (
-                                    let m := mapAccumr₂ (fun x y s => let r := f x y (s, s);
-                                                                      (r.fst.fst, r.snd)
-                                                        ) xs ys s
-                                    ((m.fst, m.fst), m.snd)
-                                  ) := by
-      induction xs, ys using Vector.revInductionOn₂ generalizing s
-      case nil => rfl
-      case snoc xs ys x y ih =>
-        specialize h x y s
-        revert h
-        simp_all
-        rcases (f x y (s, s)) with ⟨⟨s₁, s₂⟩, y⟩
-        simp_all
+                                                    ) xs ys s
+                                ((m.fst, m.fst), m.snd)
+                              ) := by
+  induction xs, ys using Vector.revInductionOn₂ generalizing s
+  case nil => rfl
+  case snoc xs ys x y ih =>
+    specialize h x y s
+    revert h
+    simp_all
+    rcases (f x y (s, s)) with ⟨⟨s₁, s₂⟩, y⟩
+    simp_all
 
 
-    /--
-      If `f` returns the same output and next state for every value of it's first argument, then
-      `xs : Vector` is ignored, and we can rewrite `mapAccumr₂` into `map`
-    -/
-    @[simp]
-    theorem mapAccumr₂_unused_input_left  [Inhabited α]
-                                          (f : α → β → σ → σ × γ)
-                                          (h : ∀ a b s, f Inhabited.default b s = f a b s) :
-        mapAccumr₂ f xs ys s = mapAccumr (fun b s => f Inhabited.default b s) ys s := by
-      induction xs, ys using Vector.revInductionOn₂ generalizing s
-      case nil => rfl
-      case snoc xs ys x y ih =>
-        simp[h x y s, ih]
+/--
+  If `f` returns the same output and next state for every value of it's first argument, then
+  `xs : Vector` is ignored, and we can rewrite `mapAccumr₂` into `map`
+-/
+@[simp]
+theorem mapAccumr₂_unused_input_left  [Inhabited α]
+                                      (f : α → β → σ → σ × γ)
+                                      (h : ∀ a b s, f Inhabited.default b s = f a b s) :
+    mapAccumr₂ f xs ys s = mapAccumr (fun b s => f Inhabited.default b s) ys s := by
+  induction xs, ys using Vector.revInductionOn₂ generalizing s
+  case nil => rfl
+  case snoc xs ys x y ih =>
+    simp[h x y s, ih]
 
-    /--
-      If `f` returns the same output and next state for every value of it's second argument, then
-      `ys : Vector` is ignored, and we can rewrite `mapAccumr₂` into `map`
-    -/
-    @[simp]
-    theorem mapAccumr₂_unused_input_right [Inhabited β]
-                                          (f : α → β → σ → σ × γ)
-                                          (h : ∀ a b s, f a Inhabited.default s = f a b s) :
-        mapAccumr₂ f xs ys s = mapAccumr (fun a s => f a Inhabited.default s) xs s := by
-      induction xs, ys using Vector.revInductionOn₂ generalizing s
-      case nil => rfl
-      case snoc xs ys x y ih =>
-        simp[h x y s, ih]
+/--
+  If `f` returns the same output and next state for every value of it's second argument, then
+  `ys : Vector` is ignored, and we can rewrite `mapAccumr₂` into `map`
+-/
+@[simp]
+theorem mapAccumr₂_unused_input_right [Inhabited β]
+                                      (f : α → β → σ → σ × γ)
+                                      (h : ∀ a b s, f a Inhabited.default s = f a b s) :
+    mapAccumr₂ f xs ys s = mapAccumr (fun a s => f a Inhabited.default s) xs s := by
+  induction xs, ys using Vector.revInductionOn₂ generalizing s
+  case nil => rfl
+  case snoc xs ys x y ih =>
+    simp[h x y s, ih]
 
-  end RedundantState
+end RedundantState
+
+
 end Vector

--- a/Mathlib/Data/Vector/MapLemmas.lean
+++ b/Mathlib/Data/Vector/MapLemmas.lean
@@ -19,13 +19,13 @@ Rewrite applications of `map` in terms of `mapAccumr` with `Unit` state
 -/
 section Norm
 
-  theorem map_to_mapAccumr (xs : Vector α n) (f : α → β) :
-      map f xs = (mapAccumr (fun x _ => (⟨⟩, f x)) xs ()).snd := by
-    induction xs using revInductionOn <;> simp_all
+theorem map_to_mapAccumr (xs : Vector α n) (f : α → β) :
+    map f xs = (mapAccumr (fun x _ => (⟨⟩, f x)) xs ()).snd := by
+  induction xs using revInductionOn <;> simp_all
 
-  theorem map₂_to_mapAccumr₂ (xs : Vector α n) (ys : Vector β n) (f : α → β → γ) :
-      map₂ f xs ys = (mapAccumr₂ (fun x y _ => (⟨⟩, f x y)) xs ys ()).snd := by
-    induction xs, ys using revInductionOn₂ <;> simp_all
+theorem map₂_to_mapAccumr₂ (xs : Vector α n) (ys : Vector β n) (f : α → β → γ) :
+    map₂ f xs ys = (mapAccumr₂ (fun x y _ => (⟨⟩, f x y)) xs ys ()).snd := by
+  induction xs, ys using revInductionOn₂ <;> simp_all
 
 end Norm
 
@@ -293,6 +293,42 @@ theorem mapAccumr₂_unused_input_right [Inhabited β]
     simp[h x y s, ih]
 
 end RedundantState
+
+
+/-!
+## Commutativity
+-/
+section Comm
+variable (xs ys : Vector α n)
+
+theorem map₂_comm (f : α → α → β) (comm : ∀ a₁ a₂, f a₁ a₂ = f a₂ a₁) :
+    map₂ f xs ys = map₂ f ys xs := by
+  induction xs, ys using Vector.inductionOn₂ <;> simp_all
+
+theorem mapAccumr₂_comm (f : α → α → σ → σ × γ) (comm : ∀ a₁ a₂ s, f a₁ a₂ s = f a₂ a₁ s) :
+    mapAccumr₂ f xs ys s = mapAccumr₂ f ys xs s := by
+  induction xs, ys using Vector.inductionOn₂ generalizing s <;> simp_all
+
+end Comm
+
+
+
+/-!
+## Argument Flipping
+-/
+section Flip
+variable (xs : Vector α n) (ys : Vector β n)
+
+theorem map₂_flip (f : α → β → γ) :
+    map₂ f xs ys = map₂ (flip f) ys xs := by
+  induction xs, ys using Vector.inductionOn₂ <;> simp_all[flip]
+
+
+theorem mapAccumr₂_flip (f : α → β → σ → σ × γ) :
+    mapAccumr₂ f xs ys s = mapAccumr₂ (flip f) ys xs s := by
+  induction xs, ys using Vector.inductionOn₂ <;> simp_all[flip]
+
+end Flip
 
 
 end Vector

--- a/Mathlib/Data/Vector/MapLemmas.lean
+++ b/Mathlib/Data/Vector/MapLemmas.lean
@@ -262,8 +262,8 @@ theorem mapAccumr₂_redundant_pair (f : α → β → (σ × σ) → (σ × σ)
 -/
 @[simp]
 theorem mapAccumr₂_unused_input_left [Inhabited α] (f : α → β → σ → σ × γ)
-    (h : ∀ a b s, f Inhabited.default b s = f a b s) :
-    mapAccumr₂ f xs ys s = mapAccumr (fun b s => f Inhabited.default b s) ys s := by
+    (h : ∀ a b s, f default b s = f a b s) :
+    mapAccumr₂ f xs ys s = mapAccumr (fun b s => f default b s) ys s := by
   induction xs, ys using Vector.revInductionOn₂ generalizing s
   case nil => rfl
   case snoc xs ys x y ih =>
@@ -275,8 +275,8 @@ theorem mapAccumr₂_unused_input_left [Inhabited α] (f : α → β → σ → 
 -/
 @[simp]
 theorem mapAccumr₂_unused_input_right [Inhabited β] (f : α → β → σ → σ × γ)
-    (h : ∀ a b s, f a Inhabited.default s = f a b s) :
-    mapAccumr₂ f xs ys s = mapAccumr (fun a s => f a Inhabited.default s) xs s := by
+    (h : ∀ a b s, f a default s = f a b s) :
+    mapAccumr₂ f xs ys s = mapAccumr (fun a s => f a default s) xs s := by
   induction xs, ys using Vector.revInductionOn₂ generalizing s
   case nil => rfl
   case snoc xs ys x y ih =>

--- a/Mathlib/Data/Vector/MapLemmas.lean
+++ b/Mathlib/Data/Vector/MapLemmas.lean
@@ -38,15 +38,15 @@ section Fold
 section Unary
 variable (xs : Vector α n) (f₁ : β → σ₁ → σ₁ × γ) (f₂ : α → σ₂ → σ₂ × β)
 
-protected abbrev mapAccumr_mapAccumr.g (x : α) (s : σ₁ × σ₂) :=
-  let r₂ := f₂ x s.snd
-  let r₁ := f₁ r₂.snd s.fst
-  ((r₁.fst, r₂.fst), r₁.snd)
-
 @[simp]
-theorem mapAccumr_mapAccumr : (mapAccumr f₁ (mapAccumr f₂ xs s₂).snd s₁)
-                              = let m := (mapAccumr (mapAccumr_mapAccumr.g f₁ f₂) xs (s₁, s₂))
-                                (m.fst.fst, m.snd) := by
+theorem mapAccumr_mapAccumr :
+    mapAccumr f₁ (mapAccumr f₂ xs s₂).snd s₁
+    = let m := (mapAccumr (fun x s =>
+        let r₂ := f₂ x s.snd
+        let r₁ := f₁ r₂.snd s.fst
+        ((r₁.fst, r₂.fst), r₁.snd)
+      ) xs (s₁, s₂))
+      (m.fst.fst, m.snd) := by
   induction xs using Vector.revInductionOn generalizing s₁ s₂ <;> simp_all
 
 
@@ -73,17 +73,15 @@ end Unary
 
 section Binary
 variable (xs : Vector α n) (ys : Vector β n)
-variable (f₁ : γ → β → σ₁ → σ₁ × ζ) (f₂ : α → σ₂ → σ₂ × γ)
-
-protected abbrev mapAccumr₂_mapAccumr_left.g (x : α) (y : β) (s : σ₁ × σ₂) :=
-  let r₂ := f₂ x s.snd
-  let r₁ := f₁ r₂.snd y s.fst
-  ((r₁.fst, r₂.fst), r₁.snd)
 
 @[simp]
-theorem mapAccumr₂_mapAccumr_left :
+theorem mapAccumr₂_mapAccumr_left (f₁ : γ → β → σ₁ → σ₁ × ζ) (f₂ : α → σ₂ → σ₂ × γ) :
     (mapAccumr₂ f₁ (mapAccumr f₂ xs s₂).snd ys s₁)
-    = let m := (mapAccumr₂ (mapAccumr₂_mapAccumr_left.g f₁ f₂) xs ys (s₁, s₂))
+    = let m := (mapAccumr₂ (fun x y s =>
+          let r₂ := f₂ x s.snd
+          let r₁ := f₁ r₂.snd y s.fst
+          ((r₁.fst, r₂.fst), r₁.snd)
+        ) xs ys (s₁, s₂))
       (m.fst.fst, m.snd) := by
   induction xs, ys using Vector.revInductionOn₂ generalizing s₁ s₂ <;> simp_all
 
@@ -94,17 +92,14 @@ theorem map₂_map_left (f₁ : γ → β → ζ) (f₂ : α → γ) :
 
 
 
-variable (f₁ : α → γ → σ₁ → σ₁ × ζ) (f₂ : β → σ₂ → σ₂ × γ)
-
-protected abbrev mapAccumr₂_mapAccumr_right.g (x : α) (y : β) (s : σ₁ × σ₂) :=
-  let r₂ := f₂ y s.snd
-  let r₁ := f₁ x r₂.snd s.fst
-  ((r₁.fst, r₂.fst), r₁.snd)
-
 @[simp]
-theorem mapAccumr₂_mapAccumr_right :
+theorem mapAccumr₂_mapAccumr_right (f₁ : α → γ → σ₁ → σ₁ × ζ) (f₂ : β → σ₂ → σ₂ × γ) :
     (mapAccumr₂ f₁ xs (mapAccumr f₂ ys s₂).snd s₁)
-    = let m := (mapAccumr₂ (mapAccumr₂_mapAccumr_right.g f₁ f₂) xs ys (s₁, s₂))
+    = let m := (mapAccumr₂ (fun x y s =>
+          let r₂ := f₂ y s.snd
+          let r₁ := f₁ x r₂.snd s.fst
+          ((r₁.fst, r₂.fst), r₁.snd)
+        ) xs ys (s₁, s₂))
       (m.fst.fst, m.snd) := by
   induction xs, ys using Vector.revInductionOn₂ generalizing s₁ s₂ <;> simp_all
 
@@ -114,17 +109,15 @@ theorem map₂_map_right (f₁ : α → γ → ζ) (f₂ : β → γ) :
   induction xs, ys using Vector.revInductionOn₂ <;> simp_all
 
 
-variable (f₁ : γ → σ₁ → σ₁ × ζ) (f₂ : α → β → σ₂ → σ₂ × γ)
-
-protected abbrev mapAccumr_mapAccumr₂.g (x : α) (y : β) (s : σ₁ × σ₂) :=
-  let r₂ := f₂ x y s.snd
-  let r₁ := f₁ r₂.snd s.fst
-  ((r₁.fst, r₂.fst), r₁.snd)
 
 @[simp]
-theorem mapAccumr_mapAccumr₂ :
+theorem mapAccumr_mapAccumr₂ (f₁ : γ → σ₁ → σ₁ × ζ) (f₂ : α → β → σ₂ → σ₂ × γ) :
     (mapAccumr f₁ (mapAccumr₂ f₂ xs ys s₂).snd s₁)
-    = let m := mapAccumr₂ (mapAccumr_mapAccumr₂.g f₁ f₂) xs ys (s₁, s₂);
+    = let m := mapAccumr₂ (fun x y s =>
+          let r₂ := f₂ x y s.snd
+          let r₁ := f₁ r₂.snd s.fst
+          ((r₁.fst, r₂.fst), r₁.snd)
+        ) xs ys (s₁, s₂);
       (m.fst.fst, m.snd) := by
   induction xs, ys using Vector.revInductionOn₂ generalizing s₁ s₂ <;> simp_all
 
@@ -134,8 +127,7 @@ theorem map_map₂ (f₁ : γ → ζ) (f₂ : α → β → γ) :
   induction xs, ys using Vector.revInductionOn₂ <;> simp_all
 
 @[simp]
-theorem mapAccumr₂_mapAccumr₂_left_left (f₁ : γ → α → σ₁ → σ₁ × φ)
-                                        (f₂ : α → β → σ₂ → σ₂ × γ) :
+theorem mapAccumr₂_mapAccumr₂_left_left (f₁ : γ → α → σ₁ → σ₁ × φ) (f₂ : α → β → σ₂ → σ₂ × γ) :
     (mapAccumr₂ f₁ (mapAccumr₂ f₂ xs ys s₂).snd xs s₁)
     = let m := mapAccumr₂ (fun x y (s₁, s₂) =>
                 let r₂ := f₂ x y s₂

--- a/Mathlib/Data/Vector/MapLemmas.lean
+++ b/Mathlib/Data/Vector/MapLemmas.lean
@@ -14,23 +14,6 @@ import Mathlib.Data.Vector.Snoc
 namespace Vector
 
 /-!
-## Normalization
-Rewrite applications of `map` in terms of `mapAccumr` with `Unit` state
--/
-section Norm
-
-theorem map_to_mapAccumr (xs : Vector α n) (f : α → β) :
-    map f xs = (mapAccumr (fun x _ => (⟨⟩, f x)) xs ()).snd := by
-  induction xs using revInductionOn <;> simp_all
-
-theorem map₂_to_mapAccumr₂ (xs : Vector α n) (ys : Vector β n) (f : α → β → γ) :
-    map₂ f xs ys = (mapAccumr₂ (fun x y _ => (⟨⟩, f x y)) xs ys ()).snd := by
-  induction xs, ys using revInductionOn₂ <;> simp_all
-
-end Norm
-
-
-/-!
 ## Fold nested `mapAccumr`s into one
 -/
 section Fold
@@ -139,7 +122,7 @@ theorem mapAccumr₂_mapAccumr₂_left_left (f₁ : γ → α → σ₁ → σ�
   induction xs, ys using Vector.revInductionOn₂ generalizing s₁ s₂ <;> simp_all
 
 @[simp]
-theorem mapAccumr₂_mapAccumr₂_left_right  
+theorem mapAccumr₂_mapAccumr₂_left_right
   (f₁ : γ → β → σ₁ → σ₁ × φ) (f₂ : α → β → σ₂ → σ₂ × γ) :
     (mapAccumr₂ f₁ (mapAccumr₂ f₂ xs ys s₂).snd ys s₁)
     = let m := mapAccumr₂ (fun x y (s₁, s₂) =>

--- a/Mathlib/Data/Vector/MapLemmas.lean
+++ b/Mathlib/Data/Vector/MapLemmas.lean
@@ -217,13 +217,13 @@ theorem mapAccumr₂_redundant_state (f : α → β → σ → σ × γ) (s : σ
   -/
 @[simp]
 theorem mapAccumr_redundant_pair (f : α → (σ × σ) → (σ × σ) × β)
-                              (h : ∀ x s, let s' := (f x (s, s)).fst; s'.fst = s'.snd)
-                            : mapAccumr f xs (s, s) = (
-                                let m := mapAccumr (fun x s => let r := f x (s, s);
-                                                              (r.fst.fst, r.snd)
-                                                    ) xs s
-                                ((m.fst, m.fst), m.snd)
-                              ) := by
+    (h : ∀ x s, let s' := (f x (s, s)).fst; s'.fst = s'.snd) :
+    mapAccumr f xs (s, s)
+    = let m := mapAccumr (fun x s =>
+          let r := f x (s, s);
+          (r.fst.fst, r.snd)
+        ) xs s
+      ((m.fst, m.fst), m.snd) := by
   clear ys
   induction xs using Vector.revInductionOn generalizing s
   case nil => rfl
@@ -239,13 +239,13 @@ theorem mapAccumr_redundant_pair (f : α → (σ × σ) → (σ × σ) × β)
   -/
 @[simp]
 theorem mapAccumr₂_redundant_pair (f : α → β → (σ × σ) → (σ × σ) × γ)
-                              (h : ∀ x y s, let s' := (f x y (s, s)).fst; s'.fst = s'.snd)
-                            : mapAccumr₂ f xs ys (s, s) = (
-                                let m := mapAccumr₂ (fun x y s => let r := f x y (s, s);
-                                                                  (r.fst.fst, r.snd)
-                                                    ) xs ys s
-                                ((m.fst, m.fst), m.snd)
-                              ) := by
+    (h : ∀ x y s, let s' := (f x y (s, s)).fst; s'.fst = s'.snd) :
+    mapAccumr₂ f xs ys (s, s) =
+      let m := mapAccumr₂ (fun x y s =>
+        let r := f x y (s, s);
+        (r.fst.fst, r.snd)
+      ) xs ys s
+      ((m.fst, m.fst), m.snd) := by
   induction xs, ys using Vector.revInductionOn₂ generalizing s
   case nil => rfl
   case snoc xs ys x y ih =>
@@ -261,9 +261,8 @@ theorem mapAccumr₂_redundant_pair (f : α → β → (σ × σ) → (σ × σ)
   `xs : Vector` is ignored, and we can rewrite `mapAccumr₂` into `map`
 -/
 @[simp]
-theorem mapAccumr₂_unused_input_left  [Inhabited α]
-                                      (f : α → β → σ → σ × γ)
-                                      (h : ∀ a b s, f Inhabited.default b s = f a b s) :
+theorem mapAccumr₂_unused_input_left [Inhabited α] (f : α → β → σ → σ × γ)
+    (h : ∀ a b s, f Inhabited.default b s = f a b s) :
     mapAccumr₂ f xs ys s = mapAccumr (fun b s => f Inhabited.default b s) ys s := by
   induction xs, ys using Vector.revInductionOn₂ generalizing s
   case nil => rfl
@@ -275,9 +274,8 @@ theorem mapAccumr₂_unused_input_left  [Inhabited α]
   `ys : Vector` is ignored, and we can rewrite `mapAccumr₂` into `map`
 -/
 @[simp]
-theorem mapAccumr₂_unused_input_right [Inhabited β]
-                                      (f : α → β → σ → σ × γ)
-                                      (h : ∀ a b s, f a Inhabited.default s = f a b s) :
+theorem mapAccumr₂_unused_input_right [Inhabited β] (f : α → β → σ → σ × γ)
+    (h : ∀ a b s, f a Inhabited.default s = f a b s) :
     mapAccumr₂ f xs ys s = mapAccumr (fun a s => f a Inhabited.default s) xs s := by
   induction xs, ys using Vector.revInductionOn₂ generalizing s
   case nil => rfl

--- a/Mathlib/Data/Vector/Snoc.lean
+++ b/Mathlib/Data/Vector/Snoc.lean
@@ -22,7 +22,6 @@ namespace Vector
 def snoc : Vector α n → α → Vector α (n+1) :=
   fun xs x => append xs (x ::ᵥ Vector.nil)
 
-
 /-!
 ## Simplification lemmas
 -/
@@ -51,7 +50,6 @@ theorem reverse_snoc : reverse (xs.snoc x) = x ::ᵥ (reverse xs) := by
   simp [toList, (·++·), Vector.append, Append.append]
   rfl
 
-
 theorem replicate_succ_to_snoc (val : α) :
     replicate (n+1) val = (replicate n val).snoc val := by
   clear xs
@@ -65,7 +63,6 @@ theorem replicate_succ_to_snoc (val : α) :
     rw[snoc_cons, ih]
 
 end Simp
-
 
 /-!
 ## Reverse induction principle
@@ -115,7 +112,7 @@ def revCasesOn {C : ∀ {n : ℕ}, Vector α n → Sort _} {n : ℕ} (v : Vector
     (snoc : ∀ {n : ℕ} (xs : Vector α n) (x : α), C (xs.snoc x)) :
     C v :=
   revInductionOn v nil fun xs x _ => snoc xs x
-  
+
 end Induction
 
 /-!


### PR DESCRIPTION
Primarily focused on folding nested applications of `mapAccumr` into a single `mapAccumr`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
