### PR TITLE
[Merged by Bors] - feat: unexpander for `abs` notation

### DIFF
--- a/Mathlib/Algebra/Abs.lean
+++ b/Mathlib/Algebra/Abs.lean
@@ -65,6 +65,16 @@ class NegPart (α : Type _) where
 @[inherit_doc Abs.abs]
 macro atomic("|" noWs) a:term noWs "|" : term => `(abs $a)
 
+/-- Unexpander for the notation `|a|` for `abs a`.
+Tries to add discretionary parentheses in unparseable cases. -/
+@[app_unexpander Abs.abs]
+def Abs.abs.unexpander : Lean.PrettyPrinter.Unexpander
+  | `($_ $a) =>
+    match a with
+    | `(|$_|) | `(-$_) => `(|($a)|)
+    | _ => `(|$a|)
+  | _ => throw ()
+
 @[inherit_doc]
 postfix:1000 "⁺" => PosPart.pos
 


### PR DESCRIPTION
Pretty prints `abs a` as `|a|`. It adds discretionary parentheses in known unparseable cases, like `|(|x|)|` rather than `||x||`. It also uses discretionary parentheses in`|(-x)|` since currently `|-x|` does not parse.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
