### PR TITLE
experiment: replacing Nat.rec

### DIFF
--- a/Mathlib/Data/Int/Cast/Basic.lean
+++ b/Mathlib/Data/Int/Cast/Basic.lean
@@ -95,7 +95,7 @@ theorem cast_subNatNat (m n) : ((Int.subNatNat m n : ℤ) : R) = m - n := by
   cases e : n - m
   · simp only [ofNat_eq_coe]
     simp [e, Nat.le_of_sub_eq_zero e]
-  · rw [cast_negSucc, Nat.add_one, ← e, Nat.cast_sub <| _root_.le_of_lt <| Nat.lt_of_sub_eq_succ e,
+  · rw [cast_negSucc, ← e, Nat.cast_sub <| _root_.le_of_lt <| Nat.lt_of_sub_eq_succ e,
       neg_sub]
 #align int.cast_sub_nat_nat Int.cast_subNatNatₓ
 -- type had `HasLiftT`

--- a/Mathlib/Data/List/Func.lean
+++ b/Mathlib/Data/List/Func.lean
@@ -26,7 +26,7 @@ as a list `m` as an index, and `a` as a new element, the notation is `as {m ↦ 
 So, for example
 `[1, 3, 5] {1 ↦ 9}` would result in `[1, 9, 5]`
 
-This notation is in the locale `list.func`.
+This notation is in the locale `List.Func`.
 -/
 
 

--- a/Mathlib/Data/Nat/Basic.lean
+++ b/Mathlib/Data/Nat/Basic.lean
@@ -401,6 +401,8 @@ theorem leRecOn_self {C : ℕ → Sort u} {n} {h : n ≤ n} {next : ∀ {k}, C k
   cases n <;> unfold leRecOn Eq.recOn
   · simp
   · unfold Or.by_cases
+    -- FIXME I can't work out where this `Nat.add` came from!
+    simp only [add_eq, add_zero]
     rw [dif_neg (Nat.not_succ_le_self _)]
 #align nat.le_rec_on_self Nat.leRecOn_self
 

--- a/Mathlib/Data/Nat/Cast/Defs.lean
+++ b/Mathlib/Data/Nat/Cast/Defs.lean
@@ -158,10 +158,10 @@ theorem binCast_eq [AddMonoidWithOne R] (n : ℕ) : (Nat.binCast n : R) = ((n : 
   | succ k =>
       rw [Nat.binCast]
       by_cases h : (k + 1) % 2 = 0
-      · rw [←Nat.mod_add_div (succ k) 2]
+      · conv_rhs => rw [←Nat.mod_add_div (k + 1) 2]
         rw [if_pos h, hk _ $ Nat.div_lt_self (Nat.succ_pos k) (Nat.le_refl 2), ←Nat.cast_add]
-        rw [Nat.succ_eq_add_one, h, Nat.zero_add, Nat.succ_mul, Nat.one_mul]
-      · rw [←Nat.mod_add_div (succ k) 2]
+        rw [h, Nat.zero_add, Nat.succ_mul, Nat.one_mul]
+      · conv_rhs => rw [←Nat.mod_add_div (k + 1) 2]
         rw [if_neg h, hk _ $ Nat.div_lt_self (Nat.succ_pos k) (Nat.le_refl 2), ←Nat.cast_add]
         have h1 := Or.resolve_left (Nat.mod_two_eq_zero_or_one (succ k)) h
         rw [h1, Nat.add_comm 1, Nat.succ_mul, Nat.one_mul]

--- a/Mathlib/Data/Nat/Set.lean
+++ b/Mathlib/Data/Nat/Set.lean
@@ -9,6 +9,7 @@ Authors: Yury Kudryashov
 ! if you have ported upstream changes.
 -/
 import Mathlib.Data.Set.Image
+import Mathlib.Data.Nat.Basic
 
 /-!
 ### Recursion on the natural numbers and `Set.range`

--- a/Mathlib/Data/PNat/Basic.lean
+++ b/Mathlib/Data/PNat/Basic.lean
@@ -318,7 +318,7 @@ def caseStrongInductionOn {p : ℕ+ → Sort _} (a : ℕ+) (hz : p 1)
   exact hi ⟨k.succ, Nat.succ_pos _⟩ fun m hm => hk _ (lt_succ_iff.2 hm)
 #align pnat.case_strong_induction_on PNat.caseStrongInductionOn
 
-/-- An induction principle for `ℕ+`: it takes values in `Sort*`, so it applies also to Types,
+/-- An induction principle for `ℕ+`: it takes values in `Sort _`, so it applies also to Types,
 not only to `Prop`. -/
 @[elab_as_elim]
 def recOn (n : ℕ+) {p : ℕ+ → Sort _} (p1 : p 1) (hp : ∀ n, p n → p (n + 1)) : p n := by

--- a/Mathlib/Init/Data/Nat/Lemmas.lean
+++ b/Mathlib/Init/Data/Nat/Lemmas.lean
@@ -310,7 +310,7 @@ lemma to_digits_core_lens_eq_aux (b f : Nat) :
 
 lemma to_digits_core_lens_eq (b f : Nat) : ∀ (n : Nat) (c : Char) (tl : List Char),
     (Nat.toDigitsCore b f n (c :: tl)).length = (Nat.toDigitsCore b f n tl).length + 1 := by
-  induction f with (intro n c tl; simp only [Nat.toDigitsCore, List.length])
+  induction f with (intro n c tl; simp only [toDigitsCore, add_eq, Nat.add_zero, List.length])
   | succ f ih =>
     by_cases hnb : (n / b) = 0
     case pos => simp only [hnb, if_true, List.length]
@@ -334,7 +334,7 @@ than one, it can be used for binary, decimal, and hex. -/
 lemma to_digits_core_length (b : Nat) (h : 2 <= b) (f n e : Nat)
     (hlt : n < b ^ e) (h_e_pos: 0 < e) : (Nat.toDigitsCore b f n []).length <= e := by
   induction f generalizing n e hlt h_e_pos with
-    simp only [Nat.toDigitsCore, List.length, Nat.zero_le]
+    simp only [Nat.toDigitsCore, add_eq, Nat.add_zero, List.length, Nat.zero_le]
   | succ f ih =>
     cases e with
     | zero => exact False.elim (Nat.lt_irrefl 0 h_e_pos)

--- a/Mathlib/Init/Data/Nat/Notation.lean
+++ b/Mathlib/Init/Data/Nat/Notation.lean
@@ -9,3 +9,11 @@ Authors: Floris van Doorn, Leonardo de Moura
 -/
 
 notation "ℕ" => Nat
+
+/-- We replace the default recursion principle for the natural numbers. -/
+-- TODO: Rename `succ` to `add_one`?
+@[eliminator]
+def Nat.rec' {motive : ℕ → Sort u}
+    (zero : motive 0) (succ : (n : ℕ) → motive n → motive (n + 1)) : (t : ℕ) → motive t
+  | 0 => zero
+  | (t + 1) => succ t (Nat.rec' zero succ t)

--- a/Mathlib/Logic/Function/Iterate.lean
+++ b/Mathlib/Logic/Function/Iterate.lean
@@ -114,7 +114,7 @@ theorem iterate_left {g : ℕ → α → α} (H : ∀ n, Semiconj f (g n) (g <| 
   induction' n with n ihn generalizing k
   · rw [Nat.zero_add]
     exact id_left
-  · rw [Nat.succ_eq_add_one, Nat.add_right_comm, Nat.add_assoc]
+  · rw [Nat.add_right_comm, Nat.add_assoc]
     exact (H k).comp_left (ihn (k + 1))
 #align function.semiconj.iterate_left Function.Semiconj.iterate_left
 


### PR DESCRIPTION
The `cases` tactic generates bad goals, I'm not sure why. If anyone would like to investigate / adopt this, please do!

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
