### PR TITLE
[Merged by Bors] - feat: pretty-print `Ordinal.{u}`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2897,6 +2897,7 @@ import Mathlib.Tactic.Polyrith
 import Mathlib.Tactic.Positivity
 import Mathlib.Tactic.Positivity.Basic
 import Mathlib.Tactic.Positivity.Core
+import Mathlib.Tactic.PpWithUniv
 import Mathlib.Tactic.PrintPrefix
 import Mathlib.Tactic.ProjectionNotation
 import Mathlib.Tactic.Propose

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2892,12 +2892,12 @@ import Mathlib.Tactic.NormNum.NatFib
 import Mathlib.Tactic.NormNum.NatSqrt
 import Mathlib.Tactic.NormNum.Prime
 import Mathlib.Tactic.NthRewrite
+import Mathlib.Tactic.PPWithUniv
 import Mathlib.Tactic.PermuteGoals
 import Mathlib.Tactic.Polyrith
 import Mathlib.Tactic.Positivity
 import Mathlib.Tactic.Positivity.Basic
 import Mathlib.Tactic.Positivity.Core
-import Mathlib.Tactic.PPWithUniv
 import Mathlib.Tactic.PrintPrefix
 import Mathlib.Tactic.ProjectionNotation
 import Mathlib.Tactic.Propose

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2897,7 +2897,7 @@ import Mathlib.Tactic.Polyrith
 import Mathlib.Tactic.Positivity
 import Mathlib.Tactic.Positivity.Basic
 import Mathlib.Tactic.Positivity.Core
-import Mathlib.Tactic.PpWithUniv
+import Mathlib.Tactic.PPWithUniv
 import Mathlib.Tactic.PrintPrefix
 import Mathlib.Tactic.ProjectionNotation
 import Mathlib.Tactic.Propose

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -17,7 +17,7 @@ import Mathlib.Order.ConditionallyCompleteLattice.Basic
 import Mathlib.Order.SuccPred.Limit
 import Mathlib.SetTheory.Cardinal.SchroederBernstein
 import Mathlib.Tactic.Positivity
-import Mathlib.Tactic.PpWithUniv
+import Mathlib.Tactic.PPWithUniv
 
 /-!
 # Cardinal Numbers

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -17,6 +17,7 @@ import Mathlib.Order.ConditionallyCompleteLattice.Basic
 import Mathlib.Order.SuccPred.Limit
 import Mathlib.SetTheory.Cardinal.SchroederBernstein
 import Mathlib.Tactic.Positivity
+import Mathlib.Tactic.PpWithUniv
 
 /-!
 # Cardinal Numbers
@@ -109,6 +110,7 @@ instance Cardinal.isEquivalent : Setoid (Type u) where
 def Cardinal : Type (u + 1) :=
   Quotient Cardinal.isEquivalent
 #align cardinal Cardinal
+pp_with_univ Cardinal
 
 namespace Cardinal
 

--- a/Mathlib/SetTheory/Ordinal/Basic.lean
+++ b/Mathlib/SetTheory/Ordinal/Basic.lean
@@ -11,7 +11,7 @@ Authors: Mario Carneiro, Floris van Doorn
 import Mathlib.Data.Sum.Order
 import Mathlib.Order.InitialSeg
 import Mathlib.SetTheory.Cardinal.Basic
-import Mathlib.Tactic.PpWithUniv
+import Mathlib.Tactic.PPWithUniv
 
 /-!
 # Ordinals

--- a/Mathlib/SetTheory/Ordinal/Basic.lean
+++ b/Mathlib/SetTheory/Ordinal/Basic.lean
@@ -11,6 +11,7 @@ Authors: Mario Carneiro, Floris van Doorn
 import Mathlib.Data.Sum.Order
 import Mathlib.Order.InitialSeg
 import Mathlib.SetTheory.Cardinal.Basic
+import Mathlib.Tactic.PpWithUniv
 
 /-!
 # Ordinals
@@ -153,6 +154,7 @@ instance Ordinal.isEquivalent : Setoid WellOrder
 def Ordinal : Type (u + 1) :=
   Quotient Ordinal.isEquivalent
 #align ordinal Ordinal
+pp_with_univ Ordinal
 
 instance hasWellFoundedOut (o : Ordinal) : WellFoundedRelation o.out.α :=
   ⟨o.out.r, o.out.wo.wf⟩

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -92,12 +92,12 @@ import Mathlib.Tactic.NormNum.NatFib
 import Mathlib.Tactic.NormNum.NatSqrt
 import Mathlib.Tactic.NormNum.Prime
 import Mathlib.Tactic.NthRewrite
+import Mathlib.Tactic.PPWithUniv
 import Mathlib.Tactic.PermuteGoals
 import Mathlib.Tactic.Polyrith
 import Mathlib.Tactic.Positivity
 import Mathlib.Tactic.Positivity.Basic
 import Mathlib.Tactic.Positivity.Core
-import Mathlib.Tactic.PPWithUniv
 import Mathlib.Tactic.PrintPrefix
 import Mathlib.Tactic.ProjectionNotation
 import Mathlib.Tactic.Propose

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -97,7 +97,7 @@ import Mathlib.Tactic.Polyrith
 import Mathlib.Tactic.Positivity
 import Mathlib.Tactic.Positivity.Basic
 import Mathlib.Tactic.Positivity.Core
-import Mathlib.Tactic.PpWithUniv
+import Mathlib.Tactic.PPWithUniv
 import Mathlib.Tactic.PrintPrefix
 import Mathlib.Tactic.ProjectionNotation
 import Mathlib.Tactic.Propose

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -97,6 +97,7 @@ import Mathlib.Tactic.Polyrith
 import Mathlib.Tactic.Positivity
 import Mathlib.Tactic.Positivity.Basic
 import Mathlib.Tactic.Positivity.Core
+import Mathlib.Tactic.PpWithUniv
 import Mathlib.Tactic.PrintPrefix
 import Mathlib.Tactic.ProjectionNotation
 import Mathlib.Tactic.Propose

--- a/Mathlib/Tactic/PPWithUniv.lean
+++ b/Mathlib/Tactic/PPWithUniv.lean
@@ -13,7 +13,7 @@ of universe parameters for the specified definition.  This is helpful for defini
 `Ordinal`, where the universe levels are both relevant and not deducible from the arguments.
 -/
 
-namespace Mathlib.PpWithUniv
+namespace Mathlib.PPWithUniv
 
 open Lean PrettyPrinter Delaborator SubExpr Elab Command
 

--- a/Mathlib/Tactic/PpWithUniv.lean
+++ b/Mathlib/Tactic/PpWithUniv.lean
@@ -1,0 +1,40 @@
+/-
+Copyright (c) 2023 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Gabriel Ebner
+-/
+import Lean
+
+/-!
+# Command to pretty-print universe level parameters by default
+
+This module contains the `pp_with_univ` command, which enables pretty-printing
+of universe parameters for the specified definition.  This is helpful for definitions like
+`Ordinal`, where the universe levels are both relevant and not deducible from the arguments.
+-/
+
+namespace Mathlib.PpWithUniv
+
+open Lean PrettyPrinter Delaborator SubExpr Elab Command
+
+/--
+Delaborator that prints the current application with universe parameters on the head symbol,
+unless `pp.universes` is explicitly set to `false`.
+-/
+def delabWithUniv : Delab :=
+  whenPPOption (·.get pp.universes.name true) <|
+  let enablePPUnivOnHead subExpr :=
+    let expr := subExpr.expr
+    let expr := mkAppN (expr.getAppFn.setOption pp.universes.name true) expr.getAppArgs
+    { subExpr with expr }
+  withTheReader SubExpr enablePPUnivOnHead <|
+    delabAppImplicit <|> delabAppExplicit
+
+/--
+`pp_with_univ Ordinal` instructs the pretty-printer to
+print `Ordinal.{u}` with universe parameters by default
+(unless `pp.universes` is explicitly set to `false`).
+-/
+elab "pp_with_univ " id:ident : command => do
+  let id ← resolveGlobalConstNoOverloadWithInfo id
+  elabCommand <| ← `(@[delab $(mkIdent <| `app ++ id)] def delab := delabWithUniv)


### PR DESCRIPTION
Adds a `pp_with_univ` command that pretty-prints the universe parameters for the specified constant by default.  Just like `Type u`, we should include the universe parameter in `Ordinal.{u}` since you would otherwise have to guess it (and several lemmas require level inequalities, so it's important to know whether you have an `Ordinal.{u}` or merely an `Ordinal.{max u v}`).

It might be cute to pretty-print `Category.{v}` as well, but that is much more involved since the pretty-printer for constants is hardcoded.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
