### PR TITLE
[Merged by Bors] - feat(Analysis/Asymptotics/AsymptoticEquivalent): add `Trans` instances for `IsEquivalent`

### DIFF
--- a/Mathlib/Analysis/Asymptotics/AsymptoticEquivalent.lean
+++ b/Mathlib/Analysis/Asymptotics/AsymptoticEquivalent.lean
@@ -345,7 +345,7 @@ open Filter Asymptotics
 
 open Asymptotics
 
-variable {α β β₂ : Type _} [NormedAddCommGroup β] [Norm β₂] [Norm β₃]
+variable {α β β₂ : Type _} [NormedAddCommGroup β] [Norm β₂] {l : Filter α}
 
 theorem Filter.EventuallyEq.isEquivalent {u v : α → β} {l : Filter α} (h : u =ᶠ[l] v) : u ~[l] v :=
   IsEquivalent.congr_right (isLittleO_refl_left _ _) h

--- a/Mathlib/Analysis/Asymptotics/AsymptoticEquivalent.lean
+++ b/Mathlib/Analysis/Asymptotics/AsymptoticEquivalent.lean
@@ -347,7 +347,7 @@ open Asymptotics
 
 variable {α β β₂ : Type _} [NormedAddCommGroup β] [Norm β₂] {l : Filter α}
 
-theorem Filter.EventuallyEq.isEquivalent {u v : α → β} {l : Filter α} (h : u =ᶠ[l] v) : u ~[l] v :=
+theorem Filter.EventuallyEq.isEquivalent {u v : α → β} (h : u =ᶠ[l] v) : u ~[l] v :=
   IsEquivalent.congr_right (isLittleO_refl_left _ _) h
 #align filter.eventually_eq.is_equivalent Filter.EventuallyEq.isEquivalent
 

--- a/Mathlib/Analysis/Asymptotics/AsymptoticEquivalent.lean
+++ b/Mathlib/Analysis/Asymptotics/AsymptoticEquivalent.lean
@@ -9,6 +9,7 @@ Authors: Anatole Dedecker
 ! if you have ported upstream changes.
 -/
 import Mathlib.Analysis.Asymptotics.Asymptotics
+import Mathlib.Analysis.Asymptotics.Theta
 import Mathlib.Analysis.Normed.Order.Basic
 
 /-!
@@ -93,6 +94,12 @@ theorem IsEquivalent.isBigO_symm (h : u ~[l] v) : v =O[l] u := by
   simp
 set_option linter.uppercaseLean3 false in
 #align asymptotics.is_equivalent.is_O_symm Asymptotics.IsEquivalent.isBigO_symm
+
+theorem IsEquivalent.isTheta (h : u ~[l] v) : u =Θ[l] v :=
+  ⟨h.isBigO, h.isBigO_symm⟩
+
+theorem IsEquivalent.isTheta_symm (h : u ~[l] v) : v =Θ[l] u :=
+  ⟨h.isBigO_symm, h.isBigO⟩
 
 @[refl]
 theorem IsEquivalent.refl : u ~[l] u := by
@@ -338,8 +345,88 @@ open Filter Asymptotics
 
 open Asymptotics
 
-variable {α β : Type _} [NormedAddCommGroup β]
+variable {α β β₂ : Type _} [NormedAddCommGroup β] [Norm β₂] [Norm β₃]
 
 theorem Filter.EventuallyEq.isEquivalent {u v : α → β} {l : Filter α} (h : u =ᶠ[l] v) : u ~[l] v :=
   IsEquivalent.congr_right (isLittleO_refl_left _ _) h
 #align filter.eventually_eq.is_equivalent Filter.EventuallyEq.isEquivalent
+
+@[trans]
+theorem Filter.EventuallyEq.trans_isEquivalent {f g₁ g₂ : α → β} (h : f =ᶠ[l] g₁)
+    (h₂ : g₁ ~[l] g₂) : f ~[l] g₂ :=
+  h.isEquivalent.trans h₂
+
+namespace Asymptotics
+
+instance transIsEquivalentIsEquivalent :
+    @Trans (α → β) (α → β) (α → β) (· ~[l] ·) (· ~[l] ·) (· ~[l] ·) where
+  trans := IsEquivalent.trans
+
+instance transEventuallyEqIsEquivalent :
+    @Trans (α → β) (α → β) (α → β) (· =ᶠ[l] ·) (· ~[l] ·) (· ~[l] ·) where
+  trans := EventuallyEq.trans_isEquivalent
+
+@[trans]
+theorem IsEquivalent.trans_eventuallyEq {f g₁ g₂ : α → β} (h : f ~[l] g₁)
+    (h₂ : g₁ =ᶠ[l] g₂) : f ~[l] g₂ :=
+  h.trans h₂.isEquivalent
+
+instance transIsEquivalentEventuallyEq :
+    @Trans (α → β) (α → β) (α → β) (· ~[l] ·) (· =ᶠ[l] ·) (· ~[l] ·) where
+  trans := IsEquivalent.trans_eventuallyEq
+
+@[trans]
+theorem IsEquivalent.trans_isBigO {f g₁ : α → β} {g₂ : α → β₂} (h : f ~[l] g₁) (h₂ : g₁ =O[l] g₂) :
+    f =O[l] g₂ :=
+  IsBigO.trans h.isBigO h₂
+
+instance transIsEquivalentIsBigO :
+    @Trans (α → β) (α → β) (α → β₂) (· ~[l] ·) (· =O[l] ·) (· =O[l] ·) where
+  trans := IsEquivalent.trans_isBigO
+
+@[trans]
+theorem IsBigO.trans_isEquivalent {f : α → β₂} {g₁ g₂ : α → β} (h : f =O[l] g₁) (h₂ : g₁ ~[l] g₂) :
+    f =O[l] g₂ :=
+  IsBigO.trans h h₂.isBigO
+
+instance transIsBigOIsEquivalent :
+    @Trans (α → β₂) (α → β) (α → β) (· =O[l] ·) (· ~[l] ·) (· =O[l] ·) where
+  trans := IsBigO.trans_isEquivalent
+
+@[trans]
+theorem IsEquivalent.trans_isLittleO {f g₁ : α → β} {g₂ : α → β₂} (h : f ~[l] g₁)
+    (h₂ : g₁ =o[l] g₂) : f =o[l] g₂ :=
+  IsBigO.trans_isLittleO h.isBigO h₂
+
+instance transIsEquivalentIsLittleO :
+    @Trans (α → β) (α → β) (α → β₂) (· ~[l] ·) (· =o[l] ·) (· =o[l] ·) where
+  trans := IsEquivalent.trans_isLittleO
+
+@[trans]
+theorem IsLittleO.trans_isEquivalent {f : α → β₂} {g₁ g₂ : α → β} (h : f =o[l] g₁)
+    (h₂ : g₁ ~[l] g₂) : f =o[l] g₂ :=
+  IsLittleO.trans_isBigO h h₂.isBigO
+
+instance transIsLittleOIsEquivalent :
+    @Trans (α → β₂) (α → β) (α → β) (· =o[l] ·) (· ~[l] ·) (· =o[l] ·) where
+  trans := IsLittleO.trans_isEquivalent
+
+@[trans]
+theorem IsEquivalent.trans_isTheta {f g₁ : α → β} {g₂ : α → β₂} (h : f ~[l] g₁)
+    (h₂ : g₁ =Θ[l] g₂) : f =Θ[l] g₂ :=
+  IsTheta.trans h.isTheta h₂
+
+instance transIsEquivalentIsTheta :
+    @Trans (α → β) (α → β) (α → β₂) (· ~[l] ·) (· =Θ[l] ·) (· =Θ[l] ·) where
+  trans := IsEquivalent.trans_isTheta
+
+@[trans]
+theorem IsTheta.trans_isEquivalent {f : α → β₂} {g₁ g₂ : α → β} (h : f =Θ[l] g₁)
+    (h₂ : g₁ ~[l] g₂) : f =Θ[l] g₂ :=
+  IsTheta.trans h h₂.isTheta
+
+instance transIsThetaIsEquivalent :
+    @Trans (α → β₂) (α → β) (α → β) (· =Θ[l] ·) (· ~[l] ·) (· =Θ[l] ·) where
+  trans := IsTheta.trans_isEquivalent
+
+end Asymptotics

--- a/Mathlib/Analysis/Asymptotics/AsymptoticEquivalent.lean
+++ b/Mathlib/Analysis/Asymptotics/AsymptoticEquivalent.lean
@@ -372,7 +372,7 @@ theorem IsEquivalent.trans_eventuallyEq {f g₁ g₂ : α → β} (h : f ~[l] g�
   h.trans h₂.isEquivalent
 
 instance transIsEquivalentEventuallyEq :
-    @Trans (α → β) (α → β) (α → β) (· ~[l] ·) (· =ᶠ[l] ·) (· ~[l] ·) where
+    @Trans (α → β) (α → β) (α → β) (IsEquivalent l) (EventuallyEq l) (IsEquivalent l) where
   trans := IsEquivalent.trans_eventuallyEq
 
 @[trans]
@@ -381,7 +381,7 @@ theorem IsEquivalent.trans_isBigO {f g₁ : α → β} {g₂ : α → β₂} (h 
   IsBigO.trans h.isBigO h₂
 
 instance transIsEquivalentIsBigO :
-    @Trans (α → β) (α → β) (α → β₂) (· ~[l] ·) (· =O[l] ·) (· =O[l] ·) where
+    @Trans (α → β) (α → β) (α → β₂) (IsEquivalent l) (IsBigO l) (IsBigO l) where
   trans := IsEquivalent.trans_isBigO
 
 @[trans]
@@ -390,7 +390,7 @@ theorem IsBigO.trans_isEquivalent {f : α → β₂} {g₁ g₂ : α → β} (h 
   IsBigO.trans h h₂.isBigO
 
 instance transIsBigOIsEquivalent :
-    @Trans (α → β₂) (α → β) (α → β) (· =O[l] ·) (· ~[l] ·) (· =O[l] ·) where
+    @Trans (α → β₂) (α → β) (α → β) (IsBigO l) (IsEquivalent l) (IsBigO l) where
   trans := IsBigO.trans_isEquivalent
 
 @[trans]
@@ -399,7 +399,7 @@ theorem IsEquivalent.trans_isLittleO {f g₁ : α → β} {g₂ : α → β₂} 
   IsBigO.trans_isLittleO h.isBigO h₂
 
 instance transIsEquivalentIsLittleO :
-    @Trans (α → β) (α → β) (α → β₂) (· ~[l] ·) (· =o[l] ·) (· =o[l] ·) where
+    @Trans (α → β) (α → β) (α → β₂) (IsEquivalent l) (IsLittleO l) (IsLittleO l) where
   trans := IsEquivalent.trans_isLittleO
 
 @[trans]
@@ -408,7 +408,7 @@ theorem IsLittleO.trans_isEquivalent {f : α → β₂} {g₁ g₂ : α → β} 
   IsLittleO.trans_isBigO h h₂.isBigO
 
 instance transIsLittleOIsEquivalent :
-    @Trans (α → β₂) (α → β) (α → β) (· =o[l] ·) (· ~[l] ·) (· =o[l] ·) where
+    @Trans (α → β₂) (α → β) (α → β) (IsLittleO l) (IsEquivalent l) (IsLittleO l) where
   trans := IsLittleO.trans_isEquivalent
 
 @[trans]
@@ -417,7 +417,7 @@ theorem IsEquivalent.trans_isTheta {f g₁ : α → β} {g₂ : α → β₂} (h
   IsTheta.trans h.isTheta h₂
 
 instance transIsEquivalentIsTheta :
-    @Trans (α → β) (α → β) (α → β₂) (· ~[l] ·) (· =Θ[l] ·) (· =Θ[l] ·) where
+    @Trans (α → β) (α → β) (α → β₂) (IsEquivalent l) (IsTheta l) (IsTheta l) where
   trans := IsEquivalent.trans_isTheta
 
 @[trans]
@@ -426,7 +426,7 @@ theorem IsTheta.trans_isEquivalent {f : α → β₂} {g₁ g₂ : α → β} (h
   IsTheta.trans h h₂.isTheta
 
 instance transIsThetaIsEquivalent :
-    @Trans (α → β₂) (α → β) (α → β) (· =Θ[l] ·) (· ~[l] ·) (· =Θ[l] ·) where
+    @Trans (α → β₂) (α → β) (α → β) (IsTheta l) (IsEquivalent l) (IsTheta l) where
   trans := IsTheta.trans_isEquivalent
 
 end Asymptotics

--- a/Mathlib/Analysis/Asymptotics/AsymptoticEquivalent.lean
+++ b/Mathlib/Analysis/Asymptotics/AsymptoticEquivalent.lean
@@ -363,7 +363,7 @@ instance transIsEquivalentIsEquivalent :
   trans := IsEquivalent.trans
 
 instance transEventuallyEqIsEquivalent :
-    @Trans (α → β) (α → β) (α → β) (· =ᶠ[l] ·) (· ~[l] ·) (· ~[l] ·) where
+    @Trans (α → β) (α → β) (α → β) (EventuallyEq l) (IsEquivalent l) (IsEquivalent l) where
   trans := EventuallyEq.trans_isEquivalent
 
 @[trans]

--- a/Mathlib/Analysis/Asymptotics/AsymptoticEquivalent.lean
+++ b/Mathlib/Analysis/Asymptotics/AsymptoticEquivalent.lean
@@ -359,7 +359,7 @@ theorem Filter.EventuallyEq.trans_isEquivalent {f g₁ g₂ : α → β} (h : f 
 namespace Asymptotics
 
 instance transIsEquivalentIsEquivalent :
-    @Trans (α → β) (α → β) (α → β) (· ~[l] ·) (· ~[l] ·) (· ~[l] ·) where
+    @Trans (α → β) (α → β) (α → β) (IsEquivalent l) (IsEquivalent l) (IsEquivalent l) where
   trans := IsEquivalent.trans
 
 instance transEventuallyEqIsEquivalent :


### PR DESCRIPTION
This PR adds several `Trans` instances for the `IsEquivalent` relation, and a few missing lemmas on the same topic.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
