### PR TITLE
[Merged by Bors] - chore: restore simp lemmas in Logic.Equiv.Set

### DIFF
--- a/Mathlib/Logic/Equiv/Set.lean
+++ b/Mathlib/Logic/Equiv/Set.lean
@@ -61,12 +61,14 @@ theorem _root_.Set.preimage_equiv_eq_image_symm {α β} (S : Set α) (f : β ≃
   (f.symm.image_eq_preimage S).symm
 #align set.preimage_equiv_eq_image_symm Set.preimage_equiv_eq_image_symm
 
-/- Porting note: Removed `simp` attribute. LHS not in normal form -/
+-- Porting note: increased priority so this fires before `image_subset_iff`
+@[simp 1001]
 protected theorem subset_image {α β} (e : α ≃ β) (s : Set α) (t : Set β) :
     e.symm '' t ⊆ s ↔ t ⊆ e '' s := by rw [image_subset_iff, e.image_eq_preimage]
 #align equiv.subset_image Equiv.subset_image
 
-/- Porting note: Removed `simp` attribute. LHS not in normal form  -/
+-- Porting note: increased priority so this fires before `image_subset_iff`
+@[simp 1001]
 protected theorem subset_image' {α β} (e : α ≃ β) (s : Set α) (t : Set β) :
     s ⊆ e.symm '' t ↔ e '' s ⊆ t :=
   calc
@@ -663,6 +665,7 @@ theorem preimage_piEquivPiSubtypeProd_symm_pi {α : Type _} {β : α → Type _}
   refine' forall_congr' fun i => _
   dsimp only [Subtype.coe_mk]
   -- Porting note: Two lines below were `by_cases hi <;> simp [hi]`
+  -- This regression is https://github.com/leanprover/lean4/issues/1926
   by_cases hi : p i
   . simp [forall_prop_of_true hi, forall_prop_of_false (not_not.2 hi), hi]
   . simp [forall_prop_of_false hi, hi, forall_prop_of_true hi]

--- a/Mathlib/Logic/Equiv/Set.lean
+++ b/Mathlib/Logic/Equiv/Set.lean
@@ -62,13 +62,13 @@ theorem _root_.Set.preimage_equiv_eq_image_symm {α β} (S : Set α) (f : β ≃
 #align set.preimage_equiv_eq_image_symm Set.preimage_equiv_eq_image_symm
 
 -- Porting note: increased priority so this fires before `image_subset_iff`
-@[simp 1001]
+@[simp high]
 protected theorem subset_image {α β} (e : α ≃ β) (s : Set α) (t : Set β) :
     e.symm '' t ⊆ s ↔ t ⊆ e '' s := by rw [image_subset_iff, e.image_eq_preimage]
 #align equiv.subset_image Equiv.subset_image
 
 -- Porting note: increased priority so this fires before `image_subset_iff`
-@[simp 1001]
+@[simp high]
 protected theorem subset_image' {α β} (e : α ≃ β) (s : Set α) (t : Set β) :
     s ⊆ e.symm '' t ↔ e '' s ⊆ t :=
   calc


### PR DESCRIPTION
Two simp lemmas were removed with porting notes because the LHS already simplified. I think instead they should have had their priority increased.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
