### PR TITLE
[Merged by Bors] - feat: add lemma tendsto_pow_atTop_nhds_0_iff_lt_1

### DIFF
--- a/Mathlib/Analysis/SpecificLimits/Basic.lean
+++ b/Mathlib/Analysis/SpecificLimits/Basic.lean
@@ -111,7 +111,7 @@ theorem tendsto_pow_atTop_nhds_0_of_lt_1 {𝕜 : Type _} [LinearOrderedField �
 #align tendsto_pow_at_top_nhds_0_of_lt_1 tendsto_pow_atTop_nhds_0_of_lt_1
 
 @[simp] theorem tendsto_pow_atTop_nhds_0_iff {𝕜 : Type _} [LinearOrderedField 𝕜] [Archimedean 𝕜]
-    [TopologicalSpace 𝕜] [OrderTopology 𝕜] {r : 𝕜} : --(h₁ : 0 ≤ r) :
+    [TopologicalSpace 𝕜] [OrderTopology 𝕜] {r : 𝕜} :
     Tendsto (fun n : ℕ => r ^ n) atTop (𝓝 0) ↔ |r| < 1 := by
     rw [tendsto_zero_iff_abs_tendsto_zero]
     refine ⟨fun h ↦ by_contra (fun hr_le ↦ ?_), fun h ↦ ?_⟩

--- a/Mathlib/Analysis/SpecificLimits/Basic.lean
+++ b/Mathlib/Analysis/SpecificLimits/Basic.lean
@@ -110,18 +110,23 @@ theorem tendsto_pow_atTop_nhds_0_of_lt_1 {𝕜 : Type _} [LinearOrderedField �
       (tendsto_inv_atTop_zero.comp this).congr fun n => by simp)
 #align tendsto_pow_at_top_nhds_0_of_lt_1 tendsto_pow_atTop_nhds_0_of_lt_1
 
-theorem tendsto_pow_atTop_nhds_0_iff_lt_1 {𝕜 : Type _} [LinearOrderedField 𝕜] [Archimedean 𝕜]
-    [TopologicalSpace 𝕜] [OrderTopology 𝕜] {r : 𝕜} (h₁ : 0 ≤ r) :
-    r < 1 ↔ Tendsto (fun n : ℕ => r ^ n) atTop (𝓝 0) := by
-    refine ⟨tendsto_pow_atTop_nhds_0_of_lt_1 h₁, fun h ↦ by_contra (fun hr_le ↦ ?_) ⟩
-    · by_cases hr : 1 = r
-      · simp only [hr.symm, one_pow] at h
+theorem tendsto_pow_atTop_nhds_0_iff {𝕜 : Type _} [LinearOrderedField 𝕜] [Archimedean 𝕜]
+    [TopologicalSpace 𝕜] [OrderTopology 𝕜] {r : 𝕜} : --(h₁ : 0 ≤ r) :
+    Tendsto (fun n : ℕ => r ^ n) atTop (𝓝 0) ↔ |r| < 1 := by
+    rw [tendsto_zero_iff_abs_tendsto_zero]
+    refine ⟨fun h ↦ by_contra (fun hr_le ↦ ?_), fun h ↦ ?_⟩
+    · by_cases hr : 1 = |r|
+      · replace h : Tendsto (fun n : ℕ ↦ |r|^n) atTop (𝓝 0) := by simpa only [← abs_pow, h]
+        simp only [hr.symm, one_pow] at h
         exact zero_ne_one <| tendsto_nhds_unique h tendsto_const_nhds
-      · apply @not_tendsto_nhds_of_tendsto_atTop 𝕜 ℕ _ _ _ _ atTop _ (fun n ↦ r ^ n) _ 0 _
-        refine (pow_strictMono_right $ lt_of_le_of_ne
-          (le_of_not_lt hr_le) hr).monotone.tendsto_atTop_atTop (fun b ↦ ?_)
+      · apply @not_tendsto_nhds_of_tendsto_atTop 𝕜 ℕ _ _ _ _ atTop _ (fun n ↦ |r| ^ n) _ 0 _
+        refine (pow_strictMono_right $ lt_of_le_of_ne (le_of_not_lt hr_le)
+          hr).monotone.tendsto_atTop_atTop (fun b ↦ ?_)
         obtain ⟨n, hn⟩ := (pow_unbounded_of_one_lt b (lt_of_le_of_ne (le_of_not_lt hr_le) hr))
-        exacts [⟨n, le_of_lt hn⟩, h]
+        exacts [⟨n, le_of_lt hn⟩, by simpa only [← abs_pow]]
+    · have := (tendsto_pow_atTop_nhds_0_of_lt_1 (abs_nonneg r)) h
+      simp only [← abs_pow] at this
+      exact this
 
 theorem tendsto_pow_atTop_nhdsWithin_0_of_lt_1 {𝕜 : Type _} [LinearOrderedField 𝕜] [Archimedean 𝕜]
     [TopologicalSpace 𝕜] [OrderTopology 𝕜] {r : 𝕜} (h₁ : 0 < r) (h₂ : r < 1) :

--- a/Mathlib/Analysis/SpecificLimits/Basic.lean
+++ b/Mathlib/Analysis/SpecificLimits/Basic.lean
@@ -110,7 +110,7 @@ theorem tendsto_pow_atTop_nhds_0_of_lt_1 {𝕜 : Type _} [LinearOrderedField �
       (tendsto_inv_atTop_zero.comp this).congr fun n => by simp)
 #align tendsto_pow_at_top_nhds_0_of_lt_1 tendsto_pow_atTop_nhds_0_of_lt_1
 
-theorem tendsto_pow_atTop_nhds_0_iff {𝕜 : Type _} [LinearOrderedField 𝕜] [Archimedean 𝕜]
+@[simp] theorem tendsto_pow_atTop_nhds_0_iff {𝕜 : Type _} [LinearOrderedField 𝕜] [Archimedean 𝕜]
     [TopologicalSpace 𝕜] [OrderTopology 𝕜] {r : 𝕜} : --(h₁ : 0 ≤ r) :
     Tendsto (fun n : ℕ => r ^ n) atTop (𝓝 0) ↔ |r| < 1 := by
     rw [tendsto_zero_iff_abs_tendsto_zero]

--- a/Mathlib/Analysis/SpecificLimits/Basic.lean
+++ b/Mathlib/Analysis/SpecificLimits/Basic.lean
@@ -110,6 +110,19 @@ theorem tendsto_pow_atTop_nhds_0_of_lt_1 {𝕜 : Type _} [LinearOrderedField �
       (tendsto_inv_atTop_zero.comp this).congr fun n => by simp)
 #align tendsto_pow_at_top_nhds_0_of_lt_1 tendsto_pow_atTop_nhds_0_of_lt_1
 
+theorem tendsto_pow_atTop_nhds_0_iff_lt_1 {𝕜 : Type _} [LinearOrderedField 𝕜] [Archimedean 𝕜]
+    [TopologicalSpace 𝕜] [OrderTopology 𝕜] {r : 𝕜} (h₁ : 0 ≤ r) :
+    r < 1 ↔ Tendsto (fun n : ℕ => r ^ n) atTop (𝓝 0) := by
+    refine ⟨tendsto_pow_atTop_nhds_0_of_lt_1 h₁, fun h ↦ by_contra (fun hr_le ↦ ?_) ⟩
+    · by_cases hr : 1 = r
+      · simp only [hr.symm, one_pow] at h
+        exact zero_ne_one <| tendsto_nhds_unique h tendsto_const_nhds
+      · apply @not_tendsto_nhds_of_tendsto_atTop 𝕜 ℕ _ _ _ _ atTop _ (fun n ↦ r ^ n) _ 0 _
+        refine (pow_strictMono_right $ lt_of_le_of_ne
+          (le_of_not_lt hr_le) hr).monotone.tendsto_atTop_atTop (fun b ↦ ?_)
+        obtain ⟨n, hn⟩ := (pow_unbounded_of_one_lt b (lt_of_le_of_ne (le_of_not_lt hr_le) hr))
+        exacts [⟨n, le_of_lt hn⟩, h]
+
 theorem tendsto_pow_atTop_nhdsWithin_0_of_lt_1 {𝕜 : Type _} [LinearOrderedField 𝕜] [Archimedean 𝕜]
     [TopologicalSpace 𝕜] [OrderTopology 𝕜] {r : 𝕜} (h₁ : 0 < r) (h₂ : r < 1) :
     Tendsto (fun n : ℕ => r ^ n) atTop (𝓝[>] 0) :=

--- a/Mathlib/Analysis/SpecificLimits/Basic.lean
+++ b/Mathlib/Analysis/SpecificLimits/Basic.lean
@@ -113,20 +113,20 @@ theorem tendsto_pow_atTop_nhds_0_of_lt_1 {𝕜 : Type _} [LinearOrderedField �
 @[simp] theorem tendsto_pow_atTop_nhds_0_iff {𝕜 : Type _} [LinearOrderedField 𝕜] [Archimedean 𝕜]
     [TopologicalSpace 𝕜] [OrderTopology 𝕜] {r : 𝕜} :
     Tendsto (fun n : ℕ => r ^ n) atTop (𝓝 0) ↔ |r| < 1 := by
-    rw [tendsto_zero_iff_abs_tendsto_zero]
-    refine ⟨fun h ↦ by_contra (fun hr_le ↦ ?_), fun h ↦ ?_⟩
-    · by_cases hr : 1 = |r|
-      · replace h : Tendsto (fun n : ℕ ↦ |r|^n) atTop (𝓝 0) := by simpa only [← abs_pow, h]
-        simp only [hr.symm, one_pow] at h
-        exact zero_ne_one <| tendsto_nhds_unique h tendsto_const_nhds
-      · apply @not_tendsto_nhds_of_tendsto_atTop 𝕜 ℕ _ _ _ _ atTop _ (fun n ↦ |r| ^ n) _ 0 _
-        refine (pow_strictMono_right $ lt_of_le_of_ne (le_of_not_lt hr_le)
-          hr).monotone.tendsto_atTop_atTop (fun b ↦ ?_)
-        obtain ⟨n, hn⟩ := (pow_unbounded_of_one_lt b (lt_of_le_of_ne (le_of_not_lt hr_le) hr))
-        exacts [⟨n, le_of_lt hn⟩, by simpa only [← abs_pow]]
-    · have := (tendsto_pow_atTop_nhds_0_of_lt_1 (abs_nonneg r)) h
-      simp only [← abs_pow] at this
-      exact this
+  rw [tendsto_zero_iff_abs_tendsto_zero]
+  refine ⟨fun h ↦ by_contra (fun hr_le ↦ ?_), fun h ↦ ?_⟩
+  · by_cases hr : 1 = |r|
+    · replace h : Tendsto (fun n : ℕ ↦ |r|^n) atTop (𝓝 0) := by simpa only [← abs_pow, h]
+      simp only [hr.symm, one_pow] at h
+      exact zero_ne_one <| tendsto_nhds_unique h tendsto_const_nhds
+    · apply @not_tendsto_nhds_of_tendsto_atTop 𝕜 ℕ _ _ _ _ atTop _ (fun n ↦ |r| ^ n) _ 0 _
+      refine (pow_strictMono_right $ lt_of_le_of_ne (le_of_not_lt hr_le)
+        hr).monotone.tendsto_atTop_atTop (fun b ↦ ?_)
+      obtain ⟨n, hn⟩ := (pow_unbounded_of_one_lt b (lt_of_le_of_ne (le_of_not_lt hr_le) hr))
+      exacts [⟨n, le_of_lt hn⟩, by simpa only [← abs_pow]]
+  · have := (tendsto_pow_atTop_nhds_0_of_lt_1 (abs_nonneg r)) h
+    simp only [← abs_pow] at this
+    exact this
 
 theorem tendsto_pow_atTop_nhdsWithin_0_of_lt_1 {𝕜 : Type _} [LinearOrderedField 𝕜] [Archimedean 𝕜]
     [TopologicalSpace 𝕜] [OrderTopology 𝕜] {r : 𝕜} (h₁ : 0 < r) (h₂ : r < 1) :

--- a/Mathlib/Analysis/SpecificLimits/Basic.lean
+++ b/Mathlib/Analysis/SpecificLimits/Basic.lean
@@ -124,9 +124,7 @@ theorem tendsto_pow_atTop_nhds_0_of_lt_1 {𝕜 : Type _} [LinearOrderedField �
           hr).monotone.tendsto_atTop_atTop (fun b ↦ ?_)
         obtain ⟨n, hn⟩ := (pow_unbounded_of_one_lt b (lt_of_le_of_ne (le_of_not_lt hr_le) hr))
         exacts [⟨n, le_of_lt hn⟩, by simpa only [← abs_pow]]
-    · have := (tendsto_pow_atTop_nhds_0_of_lt_1 (abs_nonneg r)) h
-      simp only [← abs_pow] at this
-      exact this
+    · simpa only [← abs_pow] using (tendsto_pow_atTop_nhds_0_of_lt_1 (abs_nonneg r)) h
 
 theorem tendsto_pow_atTop_nhdsWithin_0_of_lt_1 {𝕜 : Type _} [LinearOrderedField 𝕜] [Archimedean 𝕜]
     [TopologicalSpace 𝕜] [OrderTopology 𝕜] {r : 𝕜} (h₁ : 0 < r) (h₂ : r < 1) :


### PR DESCRIPTION
Add lemma `tendsto_pow_atTop_nhds_0_iff_lt_1` showing the reverse implication of `tendsto_pow_atTop_nhds_0_of_lt_1`: if the geometric progression of an element in an Archimedean field tends to `0`, the element is strictly less than `1`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
