### PR TITLE
[Merged by Bors] - doc: fix a description about HashMap/RBMap

### DIFF
--- a/Mathlib/Data/HashMap.lean
+++ b/Mathlib/Data/HashMap.lean
@@ -7,7 +7,7 @@ import Std.Data.HashMap
 import Std.Data.RBMap
 
 /-!
-# Additional API for `RBMap`.
+# Additional API for `HashMap` and `RBSet`.
 
 These should be replaced by proper implementations in Std.
 -/


### PR DESCRIPTION
From source code, the code seems like to extend `HashMap` and `RBSet`, not `RBMap`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
