### PR TITLE
[Merged by Bors] - chore: remove occurrences of semicolon after space

### DIFF
--- a/Archive/Arithcc.lean
+++ b/Archive/Arithcc.lean
@@ -352,7 +352,7 @@ theorem compiler_correctness :
       intro x
       calc
         read (loc x map) ζ₂ = read (loc x map) (write t ν₁ η) := hζ₂ _ (ht' _)
-        _ = read (loc x map) η := by simp only [loc] at ht ; simp [(ht _).ne]
+        _ = read (loc x map) η := by simp only [loc] at ht; simp [(ht _).ne]
         _ = ξ x := hmap x
     have hζ₃ : ζ₃ ≃[t + 1] { write t ν₁ η with ac := ν₂ }
     calc

--- a/Archive/Imo/Imo1981Q3.lean
+++ b/Archive/Imo/Imo1981Q3.lean
@@ -180,7 +180,7 @@ variable {M : ℕ} (HM : M = fib K ^ 2 + fib (K + 1) ^ 2)
 theorem k_bound {m n : ℤ} (h1 : ProblemPredicate N m n) : m ^ 2 + n ^ 2 ≤ M := by
   have h2 : 0 ≤ m := h1.m_range.left.le
   have h3 : 0 ≤ n := h1.n_range.left.le
-  rw [← natAbs_of_nonneg h2, ← natAbs_of_nonneg h3] at h1 ; clear h2 h3
+  rw [← natAbs_of_nonneg h2, ← natAbs_of_nonneg h3] at h1; clear h2 h3
   obtain ⟨h4 : m.natAbs ≤ fib K, h5 : n.natAbs ≤ fib (K + 1)⟩ := m_n_bounds HK h1
   have h6 : m ^ 2 ≤ (fib K : ℤ) ^ 2 := Int.natAbs_le_iff_sq_le.mp h4
   have h7 : n ^ 2 ≤ (fib (K + 1) : ℤ) ^ 2 := Int.natAbs_le_iff_sq_le.mp h5

--- a/Archive/Imo/Imo1998Q2.lean
+++ b/Archive/Imo/Imo1998Q2.lean
@@ -165,7 +165,7 @@ theorem A_card_upper_bound {k : ℕ}
   rw [← Finset.offDiag_card]
   apply Finset.card_le_mul_card_image_of_maps_to (A_maps_to_offDiag_judgePair r)
   intro p hp
-  have hp' : p.Distinct := by simp [Finset.mem_offDiag] at hp ; exact hp
+  have hp' : p.Distinct := by simp [Finset.mem_offDiag] at hp; exact hp
   rw [← A_fibre_over_judgePair_card r hp']; apply hk; exact hp'
 #align imo1998_q2.A_card_upper_bound Imo1998Q2.A_card_upper_bound
 
@@ -213,7 +213,7 @@ theorem distinct_judge_pairs_card_lower_bound {z : ℕ} (hJ : Fintype.card J = 2
       aesop
   have hst' : (s \ t).card = 2 * z + 1 := by rw [hst, Finset.diag_card, ← hJ]; rfl
   rw [Finset.filter_and, ← Finset.sdiff_sdiff_self_left s t, Finset.card_sdiff]
-  · rw [hst']; rw [add_assoc] at hs ; apply le_tsub_of_add_le_right hs
+  · rw [hst']; rw [add_assoc] at hs; apply le_tsub_of_add_le_right hs
   · apply Finset.sdiff_subset
 #align imo1998_q2.distinct_judge_pairs_card_lower_bound Imo1998Q2.distinct_judge_pairs_card_lower_bound
 
@@ -249,7 +249,7 @@ theorem imo1998_q2 [Fintype J] [Fintype C] (a b k : ℕ) (hC : Fintype.card C = 
     (hk : ∀ p : JudgePair J, p.Distinct → (agreedContestants r p).card ≤ k) :
     (b - 1 : ℚ) / (2 * b) ≤ k / a := by
   rw [clear_denominators ha hb.pos]
-  obtain ⟨z, hz⟩ := hb; rw [hz] at hJ ; rw [hz]
+  obtain ⟨z, hz⟩ := hb; rw [hz] at hJ; rw [hz]
   have h := le_trans (A_card_lower_bound r hJ) (A_card_upper_bound r hk)
   rw [hC, hJ] at h
   -- We are now essentially done; we just need to bash `h` into exactly the right shape.

--- a/Archive/Imo/Imo2008Q4.lean
+++ b/Archive/Imo/Imo2008Q4.lean
@@ -93,7 +93,7 @@ theorem imo2008_q4 (f : ℝ → ℝ) (H₁ : ∀ x > 0, f x > 0) :
     field_simp [ne_of_gt hb] at H₂
     have hb₁ : b ^ 4 = 1 := by linear_combination -H₂
     obtain hb₂ := abs_eq_one_of_pow_eq_one b 4 (show 4 ≠ 0 by norm_num) hb₁
-    rw [abs_of_pos hb] at hb₂ ; rw [hb₂] at hfb₁ ; exact hfb₁ h₁
+    rw [abs_of_pos hb] at hb₂; rw [hb₂] at hfb₁; exact hfb₁ h₁
   -- f(ab) = 1/ab → a^4 = 1 → a = 1 → f(a) = 1/a → false
   · have hb_ne_0 : b ≠ 0 := ne_of_gt hb
     field_simp [hab₂] at H₂

--- a/Archive/Imo/Imo2013Q1.lean
+++ b/Archive/Imo/Imo2013Q1.lean
@@ -62,7 +62,7 @@ theorem imo2013_q1 (n : ℕ+) (k : ℕ) :
     rw [← two_mul] at ht
     cases' t with t
     -- Eliminate the zero case to simplify later calculations.
-    · exfalso; rw [Nat.mul_zero] at ht ; exact PNat.ne_zero n ht
+    · exfalso; rw [Nat.mul_zero] at ht; exact PNat.ne_zero n ht
     -- Now we have ht : ↑n = 2 * (t + 1).
     let t_succ : ℕ+ := ⟨t + 1, t.succ_pos⟩
     obtain ⟨pm, hpm⟩ := hpk t_succ

--- a/Archive/Imo/Imo2013Q5.lean
+++ b/Archive/Imo/Imo2013Q5.lean
@@ -172,7 +172,7 @@ theorem fixed_point_of_gt_1 {f : ℚ → ℝ} {x : ℚ} (hx : 1 < x)
       (x : ℝ) + (a ^ N - x : ℚ) ≤ f x + (a ^ N - x : ℚ) := add_le_add_right (H5 x hx) _
       _ ≤ f x + f (a ^ N - x) := add_le_add_left (H5 _ h_big_enough) _
   have hxp : 0 < x := by positivity
-  have hNp : 0 < N := by by_contra' H; rw [le_zero_iff.mp H] at hN ; linarith
+  have hNp : 0 < N := by by_contra' H; rw [le_zero_iff.mp H] at hN; linarith
   have h2 :=
     calc
       f x + f (a ^ N - x) ≤ f (x + (a ^ N - x)) :=

--- a/Archive/MiuLanguage/DecisionSuf.lean
+++ b/Archive/MiuLanguage/DecisionSuf.lean
@@ -299,7 +299,7 @@ relate to `count U`.
 
 theorem mem_of_count_U_eq_succ {xs : Miustr} {k : ℕ} (h : count U xs = succ k) : U ∈ xs := by
   induction' xs with z zs hzs
-  · exfalso; rw [count] at h ; contradiction
+  · exfalso; rw [count] at h; contradiction
   · rw [mem_cons]
     cases z <;> try exact Or.inl rfl
     all_goals right; simp only [count_cons, if_false] at h; exact hzs h

--- a/Archive/Sensitivity.lean
+++ b/Archive/Sensitivity.lean
@@ -230,7 +230,7 @@ theorem duality (p q : Q n) : ε p (e q) = if p = q then 1 else 0 := by
 /-- Any vector in `V n` annihilated by all `ε p`'s is zero. -/
 theorem epsilon_total {v : V n} (h : ∀ p : Q n, (ε p) v = 0) : v = 0 := by
   induction' n with n ih
-  · dsimp [ε] at h ; exact h fun _ => true
+  · dsimp [ε] at h; exact h fun _ => true
   · cases' v with v₁ v₂
     ext <;> change _ = (0 : V n) <;> simp only <;> apply ih <;> intro p <;>
       [let q : Q n.succ := fun i => if h : i = 0 then true else p (i.pred h);

--- a/Archive/Wiedijk100Theorems/Partition.lean
+++ b/Archive/Wiedijk100Theorems/Partition.lean
@@ -292,7 +292,7 @@ theorem num_series' [Field α] (i : ℕ) :
           rw [Nat.mul_sub_left_distrib, ← hp, ← a_left, mul_one, Nat.add_sub_cancel]
         · rintro ⟨rfl, rfl⟩
           match p with
-          | 0 => rw [MulZeroClass.mul_zero] at hp ; cases hp
+          | 0 => rw [MulZeroClass.mul_zero] at hp; cases hp
           | p + 1 => rw [hp]; simp [mul_add]
       · suffices
           (filter (fun a : ℕ × ℕ => i + 1 ∣ a.fst ∧ a.snd = i + 1) (Nat.antidiagonal n.succ)).card =

--- a/Archive/Wiedijk100Theorems/SolutionOfCubic.lean
+++ b/Archive/Wiedijk100Theorems/SolutionOfCubic.lean
@@ -134,7 +134,7 @@ theorem cubic_eq_zero_iff_of_p_eq_zero (ha : a ≠ 0) (hω : IsPrimitiveRoot ω 
   have hi2 : (2 : K) ≠ 0 := nonzero_of_invertible _
   have hi3 : (3 : K) ≠ 0 := nonzero_of_invertible _
   have h54 : (54 : K) = 2 * 3 ^ 3 := by norm_num
-  have hb2 : b ^ 2 = 3 * a * c := by rw [sub_eq_zero] at hpz ; rw [hpz]
+  have hb2 : b ^ 2 = 3 * a * c := by rw [sub_eq_zero] at hpz; rw [hpz]
   have hb3 : b ^ 3 = 3 * a * b * c := by rw [pow_succ, hb2]; ring
   have h₂ :=
     calc

--- a/Mathlib/Algebra/Associated.lean
+++ b/Mathlib/Algebra/Associated.lean
@@ -531,7 +531,7 @@ theorem Associated.mul_right [CommMonoid α] {a b : α} (h : a ~ᵤ b) (c : α) 
 
 theorem Associated.pow_pow [CommMonoid α] {a b : α} {n : ℕ} (h : a ~ᵤ b) : a ^ n ~ᵤ b ^ n := by
   induction' n with n ih;
-  · simp [h] ; rfl
+  · simp [h]; rfl
   convert h.mul_mul ih <;> rw [pow_succ]
 #align associated.pow_pow Associated.pow_pow
 
@@ -641,7 +641,7 @@ protected theorem Associated.irreducible [Monoid α] {p q : α} (h : p ~ᵤ q) (
     have hpab : p = a * (b * (u⁻¹ : αˣ)) :=
       calc
         p = p * u * (u⁻¹ : αˣ) := by simp
-        _ = _ := by rw [hu] ; simp [hab, mul_assoc]
+        _ = _ := by rw [hu]; simp [hab, mul_assoc]
 
     (hp.isUnit_or_isUnit hpab).elim Or.inl fun ⟨v, hv⟩ => Or.inr ⟨v * u, by simp [hv]⟩⟩
 #align associated.irreducible Associated.irreducible
@@ -664,7 +664,7 @@ theorem Associated.of_mul_left [CancelCommMonoidWithZero α] {a b c d : α} (h :
 
 theorem Associated.of_mul_right [CancelCommMonoidWithZero α] {a b c d : α} :
     a * b ~ᵤ c * d → b ~ᵤ d → b ≠ 0 → a ~ᵤ c := by
-  rw [mul_comm a, mul_comm c] ; exact Associated.of_mul_left
+  rw [mul_comm a, mul_comm c]; exact Associated.of_mul_left
 #align associated.of_mul_right Associated.of_mul_right
 
 theorem Associated.of_pow_associated_of_prime [CancelCommMonoidWithZero α] {p₁ p₂ : α} {k₁ k₂ : ℕ}
@@ -913,7 +913,7 @@ theorem le_mul_right {a b : Associates α} : a ≤ a * b :=
   ⟨b, rfl⟩
 #align associates.le_mul_right Associates.le_mul_right
 
-theorem le_mul_left {a b : Associates α} : a ≤ b * a := by rw [mul_comm] ; exact le_mul_right
+theorem le_mul_left {a b : Associates α} : a ≤ b * a := by rw [mul_comm]; exact le_mul_right
 #align associates.le_mul_left Associates.le_mul_left
 
 instance : OrderBot (Associates α) where
@@ -937,7 +937,7 @@ theorem dvd_of_mk_le_mk {a b : α} : Associates.mk a ≤ Associates.mk b → a �
 #align associates.dvd_of_mk_le_mk Associates.dvd_of_mk_le_mk
 
 theorem mk_le_mk_of_dvd {a b : α} : a ∣ b → Associates.mk a ≤ Associates.mk b := fun ⟨c, hc⟩ =>
-  ⟨Associates.mk c, by simp [hc] ; rfl⟩
+  ⟨Associates.mk c, by simp [hc]; rfl⟩
 #align associates.mk_le_mk_of_dvd Associates.mk_le_mk_of_dvd
 
 theorem mk_le_mk_iff_dvd_iff {a b : α} : Associates.mk a ≤ Associates.mk b ↔ a ∣ b :=

--- a/Mathlib/Algebra/BigOperators/Order.lean
+++ b/Mathlib/Algebra/BigOperators/Order.lean
@@ -425,7 +425,7 @@ theorem prod_le_prod_of_ne_one' (h : ∀ x ∈ s, f x ≠ 1 → x ∈ t) :
       exact disjoint_filter.2 fun _ _ h n_h ↦ n_h h
     _ ≤ ∏ x in t, f x :=
       mul_le_of_le_one_of_le
-        (prod_le_one' <| by simp only [mem_filter, and_imp] ; exact fun _ _ ↦ le_of_eq)
+        (prod_le_one' <| by simp only [mem_filter, and_imp]; exact fun _ _ ↦ le_of_eq)
         (prod_le_prod_of_subset' <| by simpa only [subset_iff, mem_filter, and_imp] )
 #align finset.prod_le_prod_of_ne_one' Finset.prod_le_prod_of_ne_one'
 #align finset.sum_le_sum_of_ne_zero Finset.sum_le_sum_of_ne_zero

--- a/Mathlib/Algebra/Category/GroupCat/Limits.lean
+++ b/Mathlib/Algebra/Category/GroupCat/Limits.lean
@@ -453,7 +453,7 @@ set_option linter.uppercaseLean3 false in
 
 @[simp]
 theorem kernelIsoKer_hom_comp_subtype {G H : AddCommGroupCat.{u}} (f : G ⟶ H) :
-    (kernelIsoKer f).hom ≫ AddSubgroup.subtype f.ker = kernel.ι f := by ext ; rfl
+    (kernelIsoKer f).hom ≫ AddSubgroup.subtype f.ker = kernel.ι f := by ext; rfl
 set_option linter.uppercaseLean3 false in
 #align AddCommGroup.kernel_iso_ker_hom_comp_subtype AddCommGroupCat.kernelIsoKer_hom_comp_subtype
 

--- a/Mathlib/Algebra/Category/ModuleCat/Abelian.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Abelian.lean
@@ -51,7 +51,7 @@ def normalMono (hf : Mono f) : NormalMono f where
           (LinearEquiv.toModuleIso'
             ((Submodule.quotEquivOfEqBot _ (ker_eq_bot_of_mono _)).symm ≪≫ₗ
               (LinearMap.quotKerEquivRange f ≪≫ₗ
-              LinearEquiv.ofEq _ _ (Submodule.ker_mkQ _).symm))) <| by ext ; rfl
+              LinearEquiv.ofEq _ _ (Submodule.ker_mkQ _).symm))) <| by ext; rfl
 set_option linter.uppercaseLean3 false in
 #align Module.normal_mono ModuleCat.normalMono
 
@@ -73,7 +73,7 @@ def normalEpi (hf : Epi f) : NormalEpi f where
           (LinearEquiv.toModuleIso'
             (Submodule.quotEquivOfEq _ _ (Submodule.range_subtype _) ≪≫ₗ
                 LinearMap.quotKerEquivRange f ≪≫ₗ
-              LinearEquiv.ofTop _ (range_eq_top_of_epi _))) <| by ext ; rfl
+              LinearEquiv.ofTop _ (range_eq_top_of_epi _))) <| by ext; rfl
 set_option linter.uppercaseLean3 false in
 #align Module.normal_epi ModuleCat.normalEpi
 

--- a/Mathlib/Algebra/Category/ModuleCat/Adjunctions.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Adjunctions.lean
@@ -45,8 +45,8 @@ free `R`-module with generators `x : X`, implemented as the type `X →₀ R`.
 def free : Type u ⥤ ModuleCat R where
   obj X := ModuleCat.of R (X →₀ R)
   map {X Y} f := Finsupp.lmapDomain _ _ f
-  map_id := by intros ; exact Finsupp.lmapDomain_id _ _
-  map_comp := by intros ; exact Finsupp.lmapDomain_comp _ _ _ _
+  map_id := by intros; exact Finsupp.lmapDomain_id _ _
+  map_comp := by intros; exact Finsupp.lmapDomain_comp _ _ _ _
 #align Module.free ModuleCat.free
 
 /-- The free-forgetful adjunction for R-modules.
@@ -348,10 +348,10 @@ def lift (F : C ⥤ D) : Free R C ⥤ D where
       dsimp at *
       rw [Finsupp.sum_add_index', Finsupp.sum_add_index']
       · simp only [w₁, w₂, add_comp]
-      · intros ; rw [zero_smul]
-      · intros ; simp only [add_smul]
-      · intros ; rw [zero_smul]
-      · intros ; simp only [add_smul]
+      · intros; rw [zero_smul]
+      · intros; simp only [add_smul]
+      · intros; rw [zero_smul]
+      · intros; simp only [add_smul]
     · intro f' r
       apply Finsupp.induction_linear g
       · -- Porting note: simp used to be able to close this goal
@@ -362,10 +362,10 @@ def lift (F : C ⥤ D) : Free R C ⥤ D where
         dsimp at *
         rw [Finsupp.sum_add_index', Finsupp.sum_add_index']
         · simp only [w₁, w₂, comp_add]
-        · intros ; rw [zero_smul]
-        · intros ; simp only [add_smul]
-        · intros ; rw [zero_smul]
-        · intros ; simp only [add_smul]
+        · intros; rw [zero_smul]
+        · intros; simp only [add_smul]
+        · intros; rw [zero_smul]
+        · intros; simp only [add_smul]
       · intro g' s
         rw [single_comp_single _ _ f' g' r s]
         simp [mul_comm r s, mul_smul]

--- a/Mathlib/Algebra/Category/ModuleCat/Colimits.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Colimits.lean
@@ -242,8 +242,8 @@ set_option linter.uppercaseLean3 false in
 /-- The group homomorphism from a given module in the diagram to the colimit module. -/
 def coconeMorphism (j : J) : F.obj j ⟶ colimit F where
   toFun := coconeFun F j
-  map_smul' := by intros ; apply Quot.sound ; apply Relation.smul
-  map_add' := by intros ; apply Quot.sound ; apply Relation.add
+  map_smul' := by intros; apply Quot.sound; apply Relation.smul
+  map_add' := by intros; apply Quot.sound; apply Relation.add
 set_option linter.uppercaseLean3 false in
 #align Module.colimits.cocone_morphism ModuleCat.Colimits.coconeMorphism
 
@@ -341,8 +341,8 @@ set_option linter.uppercaseLean3 false in
 /-- The group homomorphism from the colimit module to the cone point of any other cocone. -/
 def descMorphism (s : Cocone F) : colimit F ⟶ s.pt where
   toFun := descFun F s
-  map_smul' s x := by rcases x ; rfl
-  map_add' x y := by rcases x ; rcases y ; rfl
+  map_smul' s x := by rcases x; rfl
+  map_add' x y := by rcases x; rcases y; rfl
 set_option linter.uppercaseLean3 false in
 #align Module.colimits.desc_morphism ModuleCat.Colimits.descMorphism
 

--- a/Mathlib/Algebra/Category/ModuleCat/Kernels.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Kernels.lean
@@ -46,7 +46,7 @@ def kernelIsLimit : IsLimit (kernelCone f) :=
             HasZeroMorphisms.comp_zero (Fork.ι s) N]
           rfl)
     (fun s => LinearMap.subtype_comp_codRestrict _ _ _) fun s m h =>
-    LinearMap.ext fun x => Subtype.ext_iff_val.2 (by simp [← h] ; rfl)
+    LinearMap.ext fun x => Subtype.ext_iff_val.2 (by simp [← h]; rfl)
 #align Module.kernel_is_limit ModuleCat.kernelIsLimit
 
 /-- The cokernel cocone induced by the projection onto the quotient. -/

--- a/Mathlib/Algebra/Category/Ring/Basic.lean
+++ b/Mathlib/Algebra/Category/Ring/Basic.lean
@@ -522,8 +522,8 @@ def ringCatIsoToRingEquiv {X Y : RingCat} (i : X ≅ Y) : X ≃+* Y
   -- Porting note: All these proofs were much easier in lean3.
   left_inv := fun x => show (i.hom ≫ i.inv) x = x by rw [i.hom_inv_id]; rfl
   right_inv := fun x => show (i.inv ≫ i.hom) x = x by rw [i.inv_hom_id]; rfl
-  map_add' := fun x y => let ii : X →+* Y := i.hom ; ii.map_add x y
-  map_mul' := fun x y => let ii : X →+* Y := i.hom ; ii.map_mul x y
+  map_add' := fun x y => let ii : X →+* Y := i.hom; ii.map_add x y
+  map_mul' := fun x y => let ii : X →+* Y := i.hom; ii.map_mul x y
 set_option linter.uppercaseLean3 false in
 #align category_theory.iso.Ring_iso_to_ring_equiv CategoryTheory.Iso.ringCatIsoToRingEquiv
 
@@ -535,8 +535,8 @@ def commRingCatIsoToRingEquiv {X Y : CommRingCat} (i : X ≅ Y) : X ≃+* Y
   -- Porting note: All these proofs were much easier in lean3.
   left_inv := fun x => show (i.hom ≫ i.inv) x = x by rw [i.hom_inv_id]; rfl
   right_inv := fun x => show (i.inv ≫ i.hom) x = x by rw [i.inv_hom_id]; rfl
-  map_add' := fun x y => let ii : X →+* Y := i.hom ; ii.map_add x y
-  map_mul' := fun x y => let ii : X →+* Y := i.hom ; ii.map_mul x y
+  map_add' := fun x y => let ii : X →+* Y := i.hom; ii.map_add x y
+  map_mul' := fun x y => let ii : X →+* Y := i.hom; ii.map_mul x y
 set_option linter.uppercaseLean3 false in
 #align category_theory.iso.CommRing_iso_to_ring_equiv CategoryTheory.Iso.commRingCatIsoToRingEquiv
 

--- a/Mathlib/Algebra/Category/Ring/Colimits.lean
+++ b/Mathlib/Algebra/Category/Ring/Colimits.lean
@@ -253,10 +253,10 @@ def coconeFun (j : J) (x : F.obj j) : ColimitType F :=
 ring. -/
 def coconeMorphism (j : J) : F.obj j ⟶ colimit F where
   toFun := coconeFun F j
-  map_one' := by apply Quot.sound ; apply Relation.one
-  map_mul' := by intros ; apply Quot.sound ; apply Relation.mul
-  map_zero' := by apply Quot.sound ; apply Relation.zero
-  map_add' := by intros ; apply Quot.sound ; apply Relation.add
+  map_one' := by apply Quot.sound; apply Relation.one
+  map_mul' := by intros; apply Quot.sound; apply Relation.mul
+  map_zero' := by apply Quot.sound; apply Relation.zero
+  map_add' := by intros; apply Quot.sound; apply Relation.add
 #align CommRing.colimits.cocone_morphism CommRingCat.Colimits.coconeMorphism
 
 @[simp]

--- a/Mathlib/Algebra/DirectLimit.lean
+++ b/Mathlib/Algebra/DirectLimit.lean
@@ -436,7 +436,7 @@ theorem exists_of [Nonempty ι] [IsDirected ι (· ≤ ·)] (z : DirectLimit G f
           rfl⟩)
         fun p q ⟨i, x, ihx⟩ ⟨j, y, ihy⟩ =>
         let ⟨k, hik, hjk⟩ := exists_ge_ge i j
-        ⟨k, f i k hik x + f j k hjk y, by rw [(of _ _ _).map_add, of_f, of_f, ihx, ihy] ; rfl⟩
+        ⟨k, f i k hik x + f j k hjk y, by rw [(of _ _ _).map_add, of_f, of_f, ihx, ihy]; rfl⟩
 #align ring.direct_limit.exists_of Ring.DirectLimit.exists_of
 
 section

--- a/Mathlib/Algebra/Free.lean
+++ b/Mathlib/Algebra/Free.lean
@@ -84,7 +84,7 @@ def recOnMul {C : FreeMagma α → Sort l} (x) (ih1 : ∀ x, C (of x))
 
 @[to_additive (attr := ext 1100)]
 theorem hom_ext {β : Type v} [Mul β] {f g : FreeMagma α →ₙ* β} (h : f ∘ of = g ∘ of) : f = g :=
-  (FunLike.ext _ _) fun x ↦ recOnMul x (congr_fun h) <| by intros ; simp only [map_mul, *]
+  (FunLike.ext _ _) fun x ↦ recOnMul x (congr_fun h) <| by intros; simp only [map_mul, *]
 #align free_magma.hom_ext FreeMagma.hom_ext
 
 end FreeMagma
@@ -661,7 +661,7 @@ theorem traverse_mul (x y : FreeSemigroup α) :
     (fun hd tl ih x ↦ show
         (· * ·) <$> pure <$> F x <*> traverse F (mk hd tl * mk y L2) =
           (· * ·) <$> ((· * ·) <$> pure <$> F x <*> traverse F (mk hd tl)) <*> traverse F (mk y L2)
-        by rw [ih] ; simp only [(· ∘ ·), (mul_assoc _ _ _).symm, functor_norm])
+        by rw [ih]; simp only [(· ∘ ·), (mul_assoc _ _ _).symm, functor_norm])
     x
 #align free_semigroup.traverse_mul FreeSemigroup.traverse_mul
 

--- a/Mathlib/Algebra/Homology/DifferentialObject.lean
+++ b/Mathlib/Algebra/Homology/DifferentialObject.lean
@@ -94,9 +94,9 @@ def dgoToHomologicalComplex :
     { X := fun i => X.obj i
       d := fun i j =>
         if h : i + b = j then X.d i ≫ X.objEqToHom (show i + (1 : ℤ) • b = j by simp [h]) else 0
-      shape := fun i j w => by dsimp at w ; convert dif_neg w
+      shape := fun i j w => by dsimp at w; convert dif_neg w
       d_comp_d' := fun i j k hij hjk => by
-        dsimp at hij hjk ; substs hij hjk
+        dsimp at hij hjk; substs hij hjk
         simp }
   map {X Y} f :=
     { f := f.f

--- a/Mathlib/Algebra/Homology/Homotopy.lean
+++ b/Mathlib/Algebra/Homology/Homotopy.lean
@@ -203,7 +203,7 @@ def add {f₁ g₁ f₂ g₂ : C ⟶ D} (h₁ : Homotopy f₁ g₁) (h₂ : Homo
 @[simps]
 def compRight {e f : C ⟶ D} (h : Homotopy e f) (g : D ⟶ E) : Homotopy (e ≫ g) (f ≫ g) where
   hom i j := h.hom i j ≫ g.f j
-  zero i j w := by dsimp ; rw [h.zero i j w, zero_comp]
+  zero i j w := by dsimp; rw [h.zero i j w, zero_comp]
   comm i := by rw [comp_f, h.comm i, dNext_comp_right, prevD_comp_right, Preadditive.add_comp,
     comp_f, Preadditive.add_comp]
 #align homotopy.comp_right Homotopy.compRight
@@ -212,7 +212,7 @@ def compRight {e f : C ⟶ D} (h : Homotopy e f) (g : D ⟶ E) : Homotopy (e ≫
 @[simps]
 def compLeft {f g : D ⟶ E} (h : Homotopy f g) (e : C ⟶ D) : Homotopy (e ≫ f) (e ≫ g) where
   hom i j := e.f i ≫ h.hom i j
-  zero i j w := by dsimp ; rw [h.zero i j w, comp_zero]
+  zero i j w := by dsimp; rw [h.zero i j w, comp_zero]
   comm i := by rw [comp_f, h.comm i, dNext_comp_left, prevD_comp_left, comp_f,
     Preadditive.comp_add, Preadditive.comp_add]
 #align homotopy.comp_left Homotopy.compLeft
@@ -549,7 +549,7 @@ def mkInductive : Homotopy e 0 where
     if h : i + 1 = j then
       (mkInductiveAux₂ e zero comm_zero one comm_one succ i).2.1 ≫ (Q.xPrevIso h).hom
     else 0
-  zero i j w := by dsimp ; rw [dif_neg] ; exact w
+  zero i j w := by dsimp; rw [dif_neg]; exact w
   comm i := by
     dsimp
     simp only [add_zero]
@@ -673,7 +673,7 @@ def mkCoinductive : Homotopy e 0 where
     if h : j + 1 = i then
       (P.xNextIso h).inv ≫ (mkCoinductiveAux₂ e zero comm_zero one comm_one succ j).2.1
     else 0
-  zero i j w := by dsimp ; rw [dif_neg] ; exact w
+  zero i j w := by dsimp; rw [dif_neg]; exact w
   comm i := by
     dsimp
     simp only [add_zero]
@@ -802,7 +802,7 @@ variable {W : Type _} [Category W] [Preadditive W]
 def Functor.mapHomotopy (F : V ⥤ W) [F.Additive] {f g : C ⟶ D} (h : Homotopy f g) :
     Homotopy ((F.mapHomologicalComplex c).map f) ((F.mapHomologicalComplex c).map g) where
   hom i j := F.map (h.hom i j)
-  zero i j w := by dsimp ; rw [h.zero i j w, F.map_zero]
+  zero i j w := by dsimp; rw [h.zero i j w, F.map_zero]
   comm i := by
     have H := h.comm i
     dsimp [dNext, prevD] at H ⊢

--- a/Mathlib/Algebra/Homology/ShortComplex/Basic.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/Basic.lean
@@ -224,7 +224,7 @@ lemma isIso_of_isIso (f : S₁ ⟶ S₂) [IsIso f.τ₁] [IsIso f.τ₂] [IsIso 
 /-- The opposite `ShortComplex` in `Cᵒᵖ` associated to a short complex in `C`. -/
 @[simps]
 def op : ShortComplex Cᵒᵖ :=
-  mk S.g.op S.f.op (by simp only [← op_comp, S.zero] ; rfl)
+  mk S.g.op S.f.op (by simp only [← op_comp, S.zero]; rfl)
 
 /-- The opposite morphism in `ShortComplex Cᵒᵖ` associated to a morphism in `ShortComplex C` -/
 @[simps]
@@ -245,7 +245,7 @@ lemma opMap_id : opMap (𝟙 S) = 𝟙 S.op := rfl
 /-- The `ShortComplex` in `C` associated to a short complex in `Cᵒᵖ`. -/
 @[simps]
 def unop (S : ShortComplex Cᵒᵖ) : ShortComplex C :=
-  mk S.g.unop S.f.unop (by simp only [← unop_comp, S.zero] ; rfl)
+  mk S.g.unop S.f.unop (by simp only [← unop_comp, S.zero]; rfl)
 
 /-- The morphism in `ShortComplex C` associated to a morphism in `ShortComplex Cᵒᵖ` -/
 @[simps]

--- a/Mathlib/Algebra/Homology/Single.lean
+++ b/Mathlib/Algebra/Homology/Single.lean
@@ -55,8 +55,8 @@ def single (j : ι) : V ⥤ HomologicalComplex V c where
     { X := fun i => if i = j then A else 0
       d := fun i j => 0 }
   map f :=
-    { f := fun i => if h : i = j then eqToHom (by dsimp ; rw [if_pos h]) ≫ f ≫
-              eqToHom (by dsimp ; rw [if_pos h]) else 0 }
+    { f := fun i => if h : i = j then eqToHom (by dsimp; rw [if_pos h]) ≫ f ≫
+              eqToHom (by dsimp; rw [if_pos h]) else 0 }
   map_id A := by
     ext
     dsimp

--- a/Mathlib/Algebra/Invertible.lean
+++ b/Mathlib/Algebra/Invertible.lean
@@ -504,7 +504,7 @@ theorem map_invOf {R : Type _} {S : Type _} {F : Type _} [MulOneClass R] [Monoid
     [MonoidHomClass F R S] (f : F) (r : R) [Invertible r] [ifr : Invertible (f r)] :
     f (⅟ r) = ⅟ (f r) :=
   have h : ifr = Invertible.map f r := Subsingleton.elim _ _
-  by subst h ; rfl
+  by subst h; rfl
 #align map_inv_of map_invOf
 
 /-- If a function `f : R → S` has a left-inverse that is a monoid hom,

--- a/Mathlib/Algebra/Lie/Abelian.lean
+++ b/Mathlib/Algebra/Lie/Abelian.lean
@@ -302,7 +302,7 @@ variable (N N' : LieSubmodule R L M) (I J : LieIdeal R L)
 theorem LieSubmodule.trivial_lie_oper_zero [LieModule.IsTrivial L M] : ⁅I, N⁆ = ⊥ := by
   suffices : ⁅I, N⁆ ≤ ⊥; exact le_bot_iff.mp this
   rw [lieIdeal_oper_eq_span, LieSubmodule.lieSpan_le]
-  rintro m ⟨x, n, h⟩; rw [trivial_lie_zero] at h ; simp [← h]
+  rintro m ⟨x, n, h⟩; rw [trivial_lie_zero] at h; simp [← h]
 #align lie_submodule.trivial_lie_oper_zero LieSubmodule.trivial_lie_oper_zero
 
 theorem LieSubmodule.lie_abelian_iff_lie_self_eq_bot : IsLieAbelian I ↔ ⁅I, I⁆ = ⊥ := by

--- a/Mathlib/Algebra/Lie/IdealOperations.lean
+++ b/Mathlib/Algebra/Lie/IdealOperations.lean
@@ -142,7 +142,7 @@ theorem lie_bot : ⁅I, (⊥ : LieSubmodule R L M)⁆ = ⊥ := by rw [eq_bot_iff
 theorem bot_lie : ⁅(⊥ : LieIdeal R L), N⁆ = ⊥ := by
   suffices ⁅(⊥ : LieIdeal R L), N⁆ ≤ ⊥ by exact le_bot_iff.mp this
   rw [lieIdeal_oper_eq_span, lieSpan_le]; rintro m ⟨⟨x, hx⟩, n, hn⟩; rw [← hn]
-  change x ∈ (⊥ : LieIdeal R L) at hx ; rw [mem_bot] at hx ; simp [hx]
+  change x ∈ (⊥ : LieIdeal R L) at hx; rw [mem_bot] at hx; simp [hx]
 #align lie_submodule.bot_lie LieSubmodule.bot_lie
 
 theorem lie_eq_bot_iff : ⁅I, N⁆ = ⊥ ↔ ∀ x ∈ I, ∀ m ∈ N, ⁅(x : L), m⁆ = 0 := by
@@ -154,7 +154,7 @@ theorem lie_eq_bot_iff : ⁅I, N⁆ = ⊥ ↔ ∀ x ∈ I, ∀ m ∈ N, ⁅(x : 
 
 theorem mono_lie (h₁ : I ≤ J) (h₂ : N ≤ N') : ⁅I, N⁆ ≤ ⁅J, N'⁆ := by
   intro m h
-  rw [lieIdeal_oper_eq_span, mem_lieSpan] at h ; rw [lieIdeal_oper_eq_span, mem_lieSpan]
+  rw [lieIdeal_oper_eq_span, mem_lieSpan] at h; rw [lieIdeal_oper_eq_span, mem_lieSpan]
   intro N hN; apply h; rintro m' ⟨⟨x, hx⟩, ⟨n, hn⟩, hm⟩; rw [← hm]; apply hN
   use ⟨x, h₁ hx⟩, ⟨n, h₂ hn⟩
 #align lie_submodule.mono_lie LieSubmodule.mono_lie
@@ -174,7 +174,7 @@ theorem lie_sup : ⁅I, N ⊔ N'⁆ = ⁅I, N⁆ ⊔ ⁅I, N'⁆ := by
     apply mono_lie_right <;> [exact le_sup_left; exact le_sup_right]
   suffices ⁅I, N ⊔ N'⁆ ≤ ⁅I, N⁆ ⊔ ⁅I, N'⁆ by exact le_antisymm this h
   rw [lieIdeal_oper_eq_span, lieSpan_le]; rintro m ⟨x, ⟨n, hn⟩, h⟩; erw [LieSubmodule.mem_sup]
-  erw [LieSubmodule.mem_sup] at hn ; rcases hn with ⟨n₁, hn₁, n₂, hn₂, hn'⟩
+  erw [LieSubmodule.mem_sup] at hn; rcases hn with ⟨n₁, hn₁, n₂, hn₂, hn'⟩
   use ⁅(x : L), (⟨n₁, hn₁⟩ : N)⁆; constructor; · apply lie_coe_mem_lie
   use ⁅(x : L), (⟨n₂, hn₂⟩ : N')⁆; constructor; · apply lie_coe_mem_lie
   simp [← h, ← hn']
@@ -187,7 +187,7 @@ theorem sup_lie : ⁅I ⊔ J, N⁆ = ⁅I, N⁆ ⊔ ⁅J, N⁆ := by
     apply mono_lie_left <;> [exact le_sup_left; exact le_sup_right]
   suffices ⁅I ⊔ J, N⁆ ≤ ⁅I, N⁆ ⊔ ⁅J, N⁆ by exact le_antisymm this h
   rw [lieIdeal_oper_eq_span, lieSpan_le]; rintro m ⟨⟨x, hx⟩, n, h⟩; erw [LieSubmodule.mem_sup]
-  erw [LieSubmodule.mem_sup] at hx ; rcases hx with ⟨x₁, hx₁, x₂, hx₂, hx'⟩
+  erw [LieSubmodule.mem_sup] at hx; rcases hx with ⟨x₁, hx₁, x₂, hx₂, hx'⟩
   use ⁅((⟨x₁, hx₁⟩ : I) : L), (n : N)⁆; constructor; · apply lie_coe_mem_lie
   use ⁅((⟨x₂, hx₂⟩ : J) : L), (n : N)⁆; constructor; · apply lie_coe_mem_lie
   simp [← h, ← hx']
@@ -345,7 +345,7 @@ theorem comap_bracket_incl {I₁ I₂ : LieIdeal R L} :
 Lie bracket operation on ideals, subject to the conditions shown. -/
 theorem comap_bracket_incl_of_le {I₁ I₂ : LieIdeal R L} (h₁ : I₁ ≤ I) (h₂ : I₂ ≤ I) :
     ⁅comap I.incl I₁, comap I.incl I₂⁆ = comap I.incl ⁅I₁, I₂⁆ := by
-    rw [comap_bracket_incl]; rw [← inf_eq_right] at h₁ h₂ ; rw [h₁, h₂]
+    rw [comap_bracket_incl]; rw [← inf_eq_right] at h₁ h₂; rw [h₁, h₂]
 #align lie_ideal.comap_bracket_incl_of_le LieIdeal.comap_bracket_incl_of_le
 
 end LieIdeal

--- a/Mathlib/Algebra/Lie/Nilpotent.lean
+++ b/Mathlib/Algebra/Lie/Nilpotent.lean
@@ -140,7 +140,7 @@ theorem antitone_lowerCentralSeries : Antitone <| lowerCentralSeries R L M := by
 theorem trivial_iff_lower_central_eq_bot : IsTrivial L M ↔ lowerCentralSeries R L M 1 = ⊥ := by
   constructor <;> intro h
   · erw [eq_bot_iff, LieSubmodule.lieSpan_le]; rintro m ⟨x, n, hn⟩; rw [← hn, h.trivial]; simp
-  · rw [LieSubmodule.eq_bot_iff] at h ; apply IsTrivial.mk; intro x m; apply h
+  · rw [LieSubmodule.eq_bot_iff] at h; apply IsTrivial.mk; intro x m; apply h
     apply LieSubmodule.subset_lieSpan
     -- Porting note: was `use x, m; rfl`
     simp only [LieSubmodule.top_coe, Subtype.exists, LieSubmodule.mem_top, exists_prop, true_and,

--- a/Mathlib/Algebra/Lie/OfAssociative.lean
+++ b/Mathlib/Algebra/Lie/OfAssociative.lean
@@ -305,7 +305,7 @@ def lieSubalgebraOfSubalgebra (R : Type u) [CommRing R] (A : Type v) [Ring A] [A
     (A' : Subalgebra R A) : LieSubalgebra R A :=
   { Subalgebra.toSubmodule A' with
     lie_mem' := fun {x y} hx hy => by
-      change ⁅x, y⁆ ∈ A'; change x ∈ A' at hx ; change y ∈ A' at hy
+      change ⁅x, y⁆ ∈ A'; change x ∈ A' at hx; change y ∈ A' at hy
       rw [LieRing.of_associative_ring_bracket]
       have hxy := A'.mul_mem hx hy
       have hyx := A'.mul_mem hy hx

--- a/Mathlib/Algebra/Lie/Solvable.lean
+++ b/Mathlib/Algebra/Lie/Solvable.lean
@@ -94,7 +94,7 @@ theorem derivedSeriesOfIdeal_add (k l : ℕ) : D (k + l) I = D k (D l I) := by
 theorem derivedSeriesOfIdeal_le {I J : LieIdeal R L} {k l : ℕ} (h₁ : I ≤ J) (h₂ : l ≤ k) :
     D k I ≤ D l J := by
   revert l; induction' k with k ih <;> intro l h₂
-  · rw [Nat.zero_eq, le_zero_iff] at h₂ ; rw [h₂, derivedSeriesOfIdeal_zero]; exact h₁
+  · rw [Nat.zero_eq, le_zero_iff] at h₂; rw [h₂, derivedSeriesOfIdeal_zero]; exact h₁
   · have h : l = k.succ ∨ l ≤ k := by rwa [le_iff_eq_or_lt, Nat.lt_succ_iff] at h₂
     cases' h with h h
     · rw [h, derivedSeriesOfIdeal_succ, derivedSeriesOfIdeal_succ]
@@ -175,7 +175,7 @@ theorem derivedSeries_add_eq_bot {k l : ℕ} {I J : LieIdeal R L} (hI : derivedS
     (hJ : derivedSeries R J l = ⊥) : derivedSeries R (I + J) (k + l) = ⊥ := by
   rw [LieIdeal.derivedSeries_eq_bot_iff] at hI hJ ⊢
   rw [← le_bot_iff]
-  let D := derivedSeriesOfIdeal R L; change D k I = ⊥ at hI ; change D l J = ⊥ at hJ
+  let D := derivedSeriesOfIdeal R L; change D k I = ⊥ at hI; change D l J = ⊥ at hJ
   calc
     D (k + l) (I + J) ≤ D k I + D l J := derivedSeriesOfIdeal_add_le_add I J k l
     _ ≤ ⊥ := by rw [hI, hJ]; simp
@@ -318,7 +318,7 @@ theorem derivedSeries_of_derivedLength_succ (I : LieIdeal R L) (k : ℕ) :
   have hs : ∀ k₁ k₂ : ℕ, k₁ ≤ k₂ → k₁ ∈ s → k₂ ∈ s := by
     intro k₁ k₂ h₁₂ h₁
     suffices derivedSeriesOfIdeal R L k₂ I ≤ ⊥ by exact eq_bot_iff.mpr this
-    change derivedSeriesOfIdeal R L k₁ I = ⊥ at h₁ ; rw [← h₁]
+    change derivedSeriesOfIdeal R L k₁ I = ⊥ at h₁; rw [← h₁]
     exact derivedSeriesOfIdeal_antitone I h₁₂
   exact Nat.sInf_upward_closed_eq_succ_iff hs k
 #align lie_algebra.derived_series_of_derived_length_succ LieAlgebra.derivedSeries_of_derivedLength_succ
@@ -348,7 +348,7 @@ theorem abelian_derivedAbelianOfIdeal (I : LieIdeal R L) :
   dsimp only [derivedAbelianOfIdeal]
   cases' h : derivedLengthOfIdeal R L I with k
   · exact isLieAbelian_bot R L
-  · rw [derivedSeries_of_derivedLength_succ] at h ; exact h.1
+  · rw [derivedSeries_of_derivedLength_succ] at h; exact h.1
 #align lie_algebra.abelian_derived_abelian_of_ideal LieAlgebra.abelian_derivedAbelianOfIdeal
 
 theorem derivedLength_zero (I : LieIdeal R L) [hI : IsSolvable R I] :
@@ -358,7 +358,7 @@ theorem derivedLength_zero (I : LieIdeal R L) [hI : IsSolvable R I] :
   have hne : s ≠ ∅ := by
     obtain ⟨k, hk⟩ := id hI
     refine' Set.Nonempty.ne_empty ⟨k, _⟩
-    rw [derivedSeries_def, LieIdeal.derivedSeries_eq_bot_iff] at hk ; exact hk
+    rw [derivedSeries_def, LieIdeal.derivedSeries_eq_bot_iff] at hk; exact hk
   simp [hne]
 #align lie_algebra.derived_length_zero LieAlgebra.derivedLength_zero
 

--- a/Mathlib/Algebra/Module/DedekindDomain.lean
+++ b/Mathlib/Algebra/Module/DedekindDomain.lean
@@ -73,7 +73,7 @@ theorem isInternal_prime_power_torsion [Module.Finite R M] (hM : Module.IsTorsio
   have hM' := Module.isTorsionBySet_annihilator_top R M
   have hI := Submodule.annihilator_top_inter_nonZeroDivisors hM
   refine' isInternal_prime_power_torsion_of_is_torsion_by_ideal _ hM'
-  rw [← Set.nonempty_iff_ne_empty] at hI ; rw [Submodule.ne_bot_iff]
+  rw [← Set.nonempty_iff_ne_empty] at hI; rw [Submodule.ne_bot_iff]
   obtain ⟨x, H, hx⟩ := hI; exact ⟨x, H, nonZeroDivisors.ne_zero hx⟩
 #align submodule.is_internal_prime_power_torsion Submodule.isInternal_prime_power_torsion
 

--- a/Mathlib/Algebra/Module/GradedModule.lean
+++ b/Mathlib/Algebra/Module/GradedModule.lean
@@ -225,7 +225,7 @@ def isModule [DecidableEq ι] [GradedRing 𝓐] : Module A (⨁ i, 𝓜 i) :=
 -/
 def linearEquiv [DecidableEq ι] [GradedRing 𝓐] [DirectSum.Decomposition 𝓜] :
     @LinearEquiv A A _ _ (RingHom.id A) (RingHom.id A) _ _ M (⨁ i, 𝓜 i) _
-    _ _ (by letI := isModule 𝓐 𝓜 ; infer_instance) := by
+    _ _ (by letI := isModule 𝓐 𝓜; infer_instance) := by
   letI h := isModule 𝓐 𝓜
   refine ⟨⟨(DirectSum.decomposeAddEquiv 𝓜).toAddHom, ?_⟩,
     (DirectSum.decomposeAddEquiv 𝓜).symm.toFun, (DirectSum.decomposeAddEquiv 𝓜).left_inv,

--- a/Mathlib/Algebra/Module/LinearMap.lean
+++ b/Mathlib/Algebra/Module/LinearMap.lean
@@ -579,7 +579,7 @@ def inverse [Module R M] [Module S M₂] {σ : R →+* S} {σ' : S →+* R} [Rin
   dsimp [LeftInverse, Function.RightInverse] at h₁ h₂
   exact
     { toFun := g
-      map_add' := fun x y ↦ by rw [← h₁ (g (x + y)), ← h₁ (g x + g y)] ; simp [h₂]
+      map_add' := fun x y ↦ by rw [← h₁ (g (x + y)), ← h₁ (g x + g y)]; simp [h₂]
       map_smul' := fun a b ↦ by
         dsimp only
         rw [← h₁ (g (a • b)), ← h₁ (σ' a • g b)]

--- a/Mathlib/Algebra/Module/Submodule/Lattice.lean
+++ b/Mathlib/Algebra/Module/Submodule/Lattice.lean
@@ -256,7 +256,7 @@ theorem finset_inf_coe {ι} (s : Finset ι) (p : ι → Submodule R M) :
 
 @[simp]
 theorem iInf_coe {ι} (p : ι → Submodule R M) : (↑(⨅ i, p i) : Set M) = ⋂ i, ↑(p i) := by
-  rw [iInf, sInf_coe] ; simp only [Set.mem_range, Set.iInter_exists, Set.iInter_iInter_eq']
+  rw [iInf, sInf_coe]; simp only [Set.mem_range, Set.iInter_exists, Set.iInter_iInter_eq']
 #align submodule.infi_coe Submodule.iInf_coe
 
 @[simp]
@@ -266,7 +266,7 @@ theorem mem_sInf {S : Set (Submodule R M)} {x : M} : x ∈ sInf S ↔ ∀ p ∈ 
 
 @[simp]
 theorem mem_iInf {ι} (p : ι → Submodule R M) {x} : (x ∈ ⨅ i, p i) ↔ ∀ i, x ∈ p i := by
-  rw [← SetLike.mem_coe, iInf_coe, Set.mem_iInter] ; rfl
+  rw [← SetLike.mem_coe, iInf_coe, Set.mem_iInter]; rfl
 #align submodule.mem_infi Submodule.mem_iInf
 
 @[simp]

--- a/Mathlib/Algebra/Order/Floor.lean
+++ b/Mathlib/Algebra/Order/Floor.lean
@@ -919,7 +919,7 @@ theorem fract_floor (a : α) : fract (⌊a⌋ : α) = 0 :=
 
 @[simp]
 theorem floor_fract (a : α) : ⌊fract a⌋ = 0 := by
-  rw [floor_eq_iff, Int.cast_zero, zero_add] ; exact ⟨fract_nonneg _, fract_lt_one _⟩
+  rw [floor_eq_iff, Int.cast_zero, zero_add]; exact ⟨fract_nonneg _, fract_lt_one _⟩
 #align int.floor_fract Int.floor_fract
 
 theorem fract_eq_iff {a b : α} : fract a = b ↔ 0 ≤ b ∧ b < 1 ∧ ∃ z : ℤ, a - b = z :=

--- a/Mathlib/Algebra/Parity.lean
+++ b/Mathlib/Algebra/Parity.lean
@@ -468,19 +468,19 @@ set_option linter.deprecated false
 variable [LinearOrderedRing R] {a : R} {n : ℕ}
 
 theorem Even.pow_nonneg (hn : Even n) (a : R) : 0 ≤ a ^ n := by
-  cases' hn with k hk ; simpa only [hk, two_mul] using pow_bit0_nonneg a k
+  cases' hn with k hk; simpa only [hk, two_mul] using pow_bit0_nonneg a k
 #align even.pow_nonneg Even.pow_nonneg
 
 theorem Even.pow_pos (hn : Even n) (ha : a ≠ 0) : 0 < a ^ n := by
-  cases' hn with k hk ; simpa only [hk, two_mul] using pow_bit0_pos ha k
+  cases' hn with k hk; simpa only [hk, two_mul] using pow_bit0_pos ha k
 #align even.pow_pos Even.pow_pos
 
 theorem Odd.pow_nonpos (hn : Odd n) (ha : a ≤ 0) : a ^ n ≤ 0 := by
-  cases' hn with k hk ; simpa only [hk, two_mul] using pow_bit1_nonpos_iff.mpr ha
+  cases' hn with k hk; simpa only [hk, two_mul] using pow_bit1_nonpos_iff.mpr ha
 #align odd.pow_nonpos Odd.pow_nonpos
 
 theorem Odd.pow_neg (hn : Odd n) (ha : a < 0) : a ^ n < 0 := by
-  cases' hn with k hk ; simpa only [hk, two_mul] using pow_bit1_neg_iff.mpr ha
+  cases' hn with k hk; simpa only [hk, two_mul] using pow_bit1_neg_iff.mpr ha
 #align odd.pow_neg Odd.pow_neg
 
 theorem Odd.pow_nonneg_iff (hn : Odd n) : 0 ≤ a ^ n ↔ 0 ≤ a :=
@@ -516,7 +516,7 @@ theorem pow_bit0_abs (a : R) (p : ℕ) : |a| ^ bit0 p = a ^ bit0 p :=
 #align pow_bit0_abs pow_bit0_abs
 
 theorem Odd.strictMono_pow (hn : Odd n) : StrictMono fun a : R => a ^ n := by
-  cases' hn with k hk ; simpa only [hk, two_mul] using strictMono_pow_bit1 _
+  cases' hn with k hk; simpa only [hk, two_mul] using strictMono_pow_bit1 _
 #align odd.strict_mono_pow Odd.strictMono_pow
 
 end Powers

--- a/Mathlib/Algebra/Polynomial/BigOperators.lean
+++ b/Mathlib/Algebra/Polynomial/BigOperators.lean
@@ -274,7 +274,7 @@ theorem multiset_prod_X_sub_C_coeff_card_pred (t : Multiset R) (ht : 0 < Multise
     contrapose! h
     obtain ⟨x, hx⟩ := card_pos_iff_exists_mem.mp ht
     exact ⟨_, ⟨_, ⟨x, hx, rfl⟩, natDegree_X_sub_C _⟩, one_ne_zero⟩
-  congr ; rw [natDegree_multiset_prod_of_monic] <;> · simp [natDegree_X_sub_C, monic_X_sub_C]
+  congr; rw [natDegree_multiset_prod_of_monic] <;> · simp [natDegree_X_sub_C, monic_X_sub_C]
 set_option linter.uppercaseLean3 false in
 #align polynomial.multiset_prod_X_sub_C_coeff_card_pred Polynomial.multiset_prod_X_sub_C_coeff_card_pred
 

--- a/Mathlib/Algebra/Quandle.lean
+++ b/Mathlib/Algebra/Quandle.lean
@@ -760,7 +760,7 @@ def toEnvelGroup.map {R : Type _} [Rack R] {G : Type _} [Group G] :
           change Quotient.liftOn ⟦mul x y⟧ (toEnvelGroup.mapAux f) _ = _
           simp [toEnvelGroup.mapAux] }
   invFun F := (Quandle.Conj.map F).comp (toEnvelGroup R)
-  left_inv f := by ext ; rfl
+  left_inv f := by ext; rfl
   right_inv F :=
     MonoidHom.ext fun x =>
       Quotient.inductionOn x fun x => by

--- a/Mathlib/Algebra/RingQuot.lean
+++ b/Mathlib/Algebra/RingQuot.lean
@@ -591,7 +591,7 @@ variable (S)
 -/
 irreducible_def mkAlgHom (s : A → A → Prop) : A →ₐ[S] RingQuot s :=
   { mkRingHom s with
-    commutes' := fun _ ↦ by simp [mkRingHom_def] ; rfl }
+    commutes' := fun _ ↦ by simp [mkRingHom_def]; rfl }
 #align ring_quot.mk_alg_hom RingQuot.mkAlgHom
 
 @[simp]

--- a/Mathlib/Algebra/SMulWithZero.lean
+++ b/Mathlib/Algebra/SMulWithZero.lean
@@ -117,7 +117,7 @@ variable (M)
 def SMulWithZero.compHom (f : ZeroHom R' R) : SMulWithZero R' M where
   smul := (· • ·) ∘ f
   smul_zero m := smul_zero (f m)
-  zero_smul m := by show (f 0) • m = 0 ; rw [map_zero, zero_smul]
+  zero_smul m := by show (f 0) • m = 0; rw [map_zero, zero_smul]
 #align smul_with_zero.comp_hom SMulWithZero.compHom
 
 end Zero

--- a/Mathlib/AlgebraicGeometry/GammaSpecAdjunction.lean
+++ b/Mathlib/AlgebraicGeometry/GammaSpecAdjunction.lean
@@ -217,7 +217,7 @@ theorem toStalk_stalkMap_toΓSpec (x : X) :
     toStalk _ _ ≫ PresheafedSpace.stalkMap X.toΓSpecSheafedSpace x = X.ΓToStalk x := by
   rw [PresheafedSpace.stalkMap]
   erw [← toOpen_germ _ (basicOpen (1 : Γ.obj (op X)))
-      ⟨X.toΓSpecFun x, by rw [basicOpen_one] ; trivial⟩]
+      ⟨X.toΓSpecFun x, by rw [basicOpen_one]; trivial⟩]
   rw [← Category.assoc, Category.assoc (toOpen _ _)]
   erw [stalkFunctor_map_germ]
   -- Porting note : was `rw [←assoc, toΓSpecSheafedSpace_app_spec]`, but Lean did not like it.

--- a/Mathlib/AlgebraicGeometry/OpenImmersion/Scheme.lean
+++ b/Mathlib/AlgebraicGeometry/OpenImmersion/Scheme.lean
@@ -272,7 +272,7 @@ theorem affineBasisCover_is_basis (X : Scheme) :
   · rintro a U haU hU
     rcases X.affineCover.Covers a with ⟨x, e⟩
     let U' := (X.affineCover.map (X.affineCover.f a)).1.base ⁻¹' U
-    have hxU' : x ∈ U' := by rw [← e] at haU ; exact haU
+    have hxU' : x ∈ U' := by rw [← e] at haU; exact haU
     rcases PrimeSpectrum.isBasis_basic_opens.exists_subset_of_mem_open hxU'
         ((X.affineCover.map (X.affineCover.f a)).1.base.continuous_toFun.isOpen_preimage _
           hU) with

--- a/Mathlib/AlgebraicGeometry/PresheafedSpace.lean
+++ b/Mathlib/AlgebraicGeometry/PresheafedSpace.lean
@@ -252,7 +252,7 @@ set_option linter.uppercaseLean3 false in
 #align algebraic_geometry.PresheafedSpace.comp_c_app AlgebraicGeometry.PresheafedSpace.comp_c_app
 
 theorem congr_app {X Y : PresheafedSpace C} {α β : X ⟶ Y} (h : α = β) (U) :
-    α.c.app U = β.c.app U ≫ X.presheaf.map (eqToHom (by subst h ; rfl)) := by
+    α.c.app U = β.c.app U ≫ X.presheaf.map (eqToHom (by subst h; rfl)) := by
   subst h
   simp
 set_option linter.uppercaseLean3 false in

--- a/Mathlib/AlgebraicGeometry/PrimeSpectrum/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/PrimeSpectrum/Basic.lean
@@ -398,7 +398,7 @@ theorem sup_vanishingIdeal_le (t t' : Set (PrimeSpectrum R)) :
 
 theorem mem_compl_zeroLocus_iff_not_mem {f : R} {I : PrimeSpectrum R} :
     I ∈ (zeroLocus {f} : Set (PrimeSpectrum R))ᶜ ↔ f ∉ I.asIdeal := by
-  rw [Set.mem_compl_iff, mem_zeroLocus, Set.singleton_subset_iff] ; rfl
+  rw [Set.mem_compl_iff, mem_zeroLocus, Set.singleton_subset_iff]; rfl
 #align prime_spectrum.mem_compl_zero_locus_iff_not_mem PrimeSpectrum.mem_compl_zeroLocus_iff_not_mem
 
 /-- The Zariski topology on the prime spectrum of a commutative ring is defined via the closed sets
@@ -415,7 +415,7 @@ instance zariskiTopology : TopologicalSpace (PrimeSpectrum R) :=
 #align prime_spectrum.zariski_topology PrimeSpectrum.zariskiTopology
 
 theorem isOpen_iff (U : Set (PrimeSpectrum R)) : IsOpen U ↔ ∃ s, Uᶜ = zeroLocus s := by
-  simp only [@eq_comm _ Uᶜ] ; rfl
+  simp only [@eq_comm _ Uᶜ]; rfl
 #align prime_spectrum.is_open_iff PrimeSpectrum.isOpen_iff
 
 theorem isClosed_iff_zeroLocus (Z : Set (PrimeSpectrum R)) : IsClosed Z ↔ ∃ s, Z = zeroLocus s := by

--- a/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Topology.lean
+++ b/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Topology.lean
@@ -247,7 +247,7 @@ theorem zeroLocus_union (s s' : Set A) : zeroLocus 𝒜 (s ∪ s') = zeroLocus _
 
 theorem vanishingIdeal_union (t t' : Set (ProjectiveSpectrum 𝒜)) :
     vanishingIdeal (t ∪ t') = vanishingIdeal t ⊓ vanishingIdeal t' := by
-  ext1 ; exact (gc_ideal 𝒜).u_inf
+  ext1; exact (gc_ideal 𝒜).u_inf
 #align projective_spectrum.vanishing_ideal_union ProjectiveSpectrum.vanishingIdeal_union
 
 theorem zeroLocus_iSup_ideal {γ : Sort _} (I : γ → Ideal A) :
@@ -273,7 +273,7 @@ theorem zeroLocus_bUnion (s : Set (Set A)) :
 theorem vanishingIdeal_iUnion {γ : Sort _} (t : γ → Set (ProjectiveSpectrum 𝒜)) :
     vanishingIdeal (⋃ i, t i) = ⨅ i, vanishingIdeal (t i) :=
   HomogeneousIdeal.toIdeal_injective <| by
-    convert(gc_ideal 𝒜).u_iInf ; exact HomogeneousIdeal.toIdeal_iInf _
+    convert(gc_ideal 𝒜).u_iInf; exact HomogeneousIdeal.toIdeal_iInf _
 #align projective_spectrum.vanishing_ideal_Union ProjectiveSpectrum.vanishingIdeal_iUnion
 
 theorem zeroLocus_inf (I J : Ideal A) :
@@ -320,7 +320,7 @@ theorem sup_vanishingIdeal_le (t t' : Set (ProjectiveSpectrum 𝒜)) :
 
 theorem mem_compl_zeroLocus_iff_not_mem {f : A} {I : ProjectiveSpectrum 𝒜} :
     I ∈ (zeroLocus 𝒜 {f} : Set (ProjectiveSpectrum 𝒜))ᶜ ↔ f ∉ I.asHomogeneousIdeal := by
-  rw [Set.mem_compl_iff, mem_zeroLocus, Set.singleton_subset_iff] ; rfl
+  rw [Set.mem_compl_iff, mem_zeroLocus, Set.singleton_subset_iff]; rfl
 #align projective_spectrum.mem_compl_zero_locus_iff_not_mem ProjectiveSpectrum.mem_compl_zeroLocus_iff_not_mem
 
 /-- The Zariski topology on the prime spectrum of a commutative ring is defined via the closed sets
@@ -348,7 +348,7 @@ set_option linter.uppercaseLean3 false in
 #align projective_spectrum.Top ProjectiveSpectrum.top
 
 theorem isOpen_iff (U : Set (ProjectiveSpectrum 𝒜)) : IsOpen U ↔ ∃ s, Uᶜ = zeroLocus 𝒜 s := by
-  simp only [@eq_comm _ Uᶜ] ; rfl
+  simp only [@eq_comm _ Uᶜ]; rfl
 #align projective_spectrum.is_open_iff ProjectiveSpectrum.isOpen_iff
 
 theorem isClosed_iff_zeroLocus (Z : Set (ProjectiveSpectrum 𝒜)) :
@@ -406,7 +406,7 @@ theorem isOpen_basicOpen {a : A} : IsOpen (basicOpen 𝒜 a : Set (ProjectiveSpe
 @[simp]
 theorem basicOpen_eq_zeroLocus_compl (r : A) :
     (basicOpen 𝒜 r : Set (ProjectiveSpectrum 𝒜)) = (zeroLocus 𝒜 {r})ᶜ :=
-  Set.ext fun x => by simp only [Set.mem_compl_iff, mem_zeroLocus, Set.singleton_subset_iff] ; rfl
+  Set.ext fun x => by simp only [Set.mem_compl_iff, mem_zeroLocus, Set.singleton_subset_iff]; rfl
 #align projective_spectrum.basic_open_eq_zero_locus_compl ProjectiveSpectrum.basicOpen_eq_zeroLocus_compl
 
 @[simp]

--- a/Mathlib/AlgebraicTopology/CechNerve.lean
+++ b/Mathlib/AlgebraicTopology/CechNerve.lean
@@ -184,8 +184,8 @@ def cechNerveEquiv (X : SimplicialObject.Augmented C) (F : Arrow C) :
 abbrev cechNerveAdjunction : (Augmented.toArrow : _ ⥤ Arrow C) ⊣ augmentedCechNerve :=
   Adjunction.mkOfHomEquiv
     { homEquiv := cechNerveEquiv
-      homEquiv_naturality_left_symm := by dsimp [cechNerveEquiv] ; aesop_cat
-      homEquiv_naturality_right := by dsimp [cechNerveEquiv] ; aesop_cat }
+      homEquiv_naturality_left_symm := by dsimp [cechNerveEquiv]; aesop_cat
+      homEquiv_naturality_right := by dsimp [cechNerveEquiv]; aesop_cat }
 #align category_theory.simplicial_object.cech_nerve_adjunction CategoryTheory.SimplicialObject.cechNerveAdjunction
 
 end SimplicialObject
@@ -270,7 +270,7 @@ def equivalenceLeftToRight (F : Arrow C) (X : CosimplicialObject.Augmented C)
   w := by
     dsimp
     rw [@WidePushout.arrow_ι_assoc _ _ _ _ _ (fun (_ : Fin 1) => F.hom)
-      (by dsimp ; infer_instance)]
+      (by dsimp; infer_instance)]
     exact congr_app G.w (SimplexCategory.mk 0)
 #align category_theory.cosimplicial_object.equivalence_left_to_right CategoryTheory.CosimplicialObject.equivalenceLeftToRight
 

--- a/Mathlib/AlgebraicTopology/DoldKan/Decomposition.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/Decomposition.lean
@@ -121,7 +121,7 @@ theorem id_φ : (id X n).φ = 𝟙 _ := by
   simp only [← P_add_Q_f (n + 1) (n + 1), φ]
   congr 1
   · simp only [id, PInfty_f, P_f_idem]
-  · exact Eq.trans (by congr ; simp) (decomposition_Q n (n + 1)).symm
+  · exact Eq.trans (by congr; simp) (decomposition_Q n (n + 1)).symm
 #align algebraic_topology.dold_kan.morph_components.id_φ AlgebraicTopology.DoldKan.MorphComponents.id_φ
 
 variable {X n}

--- a/Mathlib/AlgebraicTopology/DoldKan/Faces.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/Faces.lean
@@ -86,7 +86,7 @@ theorem comp_Hσ_eq {Y : C} {n a q : ℕ} {φ : Y ⟶ X _[n + 1]} (v : HigherFac
   · rintro ⟨k, hk⟩
     suffices φ ≫ X.δ (⟨a + 2 + k, by linarith⟩ : Fin (n + 2)) = 0 by
       simp only [this, Fin.natAdd_mk, Fin.cast_mk, zero_comp, smul_zero]
-    convert v ⟨a + k + 1, by linarith⟩ (by rw [Fin.val_mk] ; linarith)
+    convert v ⟨a + k + 1, by linarith⟩ (by rw [Fin.val_mk]; linarith)
     dsimp
     linarith
   -- cleaning up the second sum

--- a/Mathlib/AlgebraicTopology/DoldKan/FunctorGamma.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/FunctorGamma.lean
@@ -58,7 +58,7 @@ theorem iff {j : ℕ} {i : Fin (j + 2)} : Isδ₀ (SimplexCategory.δ i) ↔ i =
     by_contra h
     exact h₂ (Fin.succAbove_ne_zero_zero h)
   · rintro rfl
-    exact ⟨rfl, by dsimp ; exact Fin.succ_ne_zero (0 : Fin (j + 1))⟩
+    exact ⟨rfl, by dsimp; exact Fin.succ_ne_zero (0 : Fin (j + 1))⟩
 #align algebraic_topology.dold_kan.is_δ₀.iff AlgebraicTopology.DoldKan.Isδ₀.iff
 
 theorem eq_δ₀ {n : ℕ} {i : ([n] : SimplexCategory) ⟶ [n + 1]} [Mono i] (hi : Isδ₀ i) :

--- a/Mathlib/AlgebraicTopology/DoldKan/NCompGamma.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/NCompGamma.lean
@@ -76,7 +76,7 @@ theorem PInfty_comp_map_mono_eq_zero (X : SimplicialObject C) {n : ℕ} {Δ' : S
     · simp only [op_comp, X.map_comp, assoc, PInfty_f]
       erw [(HigherFacesVanish.of_P _ _).comp_δ_eq_zero_assoc _ hj₁, zero_comp]
       by_contra
-      exact hj₁ (by simp only [Fin.ext_iff, Fin.val_zero] ; linarith)
+      exact hj₁ (by simp only [Fin.ext_iff, Fin.val_zero]; linarith)
 set_option linter.uppercaseLean3 false in
 #align algebraic_topology.dold_kan.P_infty_comp_map_mono_eq_zero AlgebraicTopology.DoldKan.PInfty_comp_map_mono_eq_zero
 

--- a/Mathlib/AlgebraicTopology/DoldKan/SplitSimplicialObject.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/SplitSimplicialObject.lean
@@ -40,7 +40,7 @@ noncomputable def πSummand [HasZeroMorphisms C] {Δ : SimplexCategoryᵒᵖ} (A
     X.obj Δ ⟶ s.N A.1.unop.len := by
   refine' (s.iso Δ).inv ≫ Sigma.desc fun B => _
   by_cases B = A
-  · exact eqToHom (by subst h ; rfl)
+  · exact eqToHom (by subst h; rfl)
   · exact 0
 #align simplicial_object.splitting.π_summand SimplicialObject.Splitting.πSummand
 

--- a/Mathlib/AlgebraicTopology/SimplexCategory.lean
+++ b/Mathlib/AlgebraicTopology/SimplexCategory.lean
@@ -345,7 +345,7 @@ theorem σ_comp_σ {n} {i j : Fin (n + 1)} (H : i ≤ j) :
   simp [Fin.lt_iff_val_lt_val, Fin.ite_val]
   split_ifs
   all_goals try linarith
-  all_goals cases k <;> simp at * ; linarith
+  all_goals cases k <;> simp at *; linarith
 #align simplex_category.σ_comp_σ SimplexCategory.σ_comp_σ
 
 end Generators
@@ -466,7 +466,7 @@ instance : ConcreteCategory.{0} SimplexCategory where
   forget :=
     { obj := fun i => Fin (i.len + 1)
       map := fun f => f.toOrderHom }
-  forget_faithful := ⟨fun h => by ext : 2 ; exact h⟩
+  forget_faithful := ⟨fun h => by ext : 2; exact h⟩
 
 end Concrete
 
@@ -610,7 +610,7 @@ theorem eq_σ_comp_of_not_injective' {n : ℕ} {Δ' : SimplexCategory} (θ : mk 
     · rwa [eq, ← Fin.le_castSucc_iff]
     rw [eq]
   · simp only [not_le] at h'
-    let y := x.pred (by rintro rfl ; simp at h')
+    let y := x.pred (by rintro rfl; simp at h')
     have hy : x = y.succ := (Fin.succ_pred x _).symm
     rw [hy] at h' ⊢
     rw [Fin.predAbove_above i y.succ h', Fin.pred_succ]
@@ -760,7 +760,7 @@ theorem len_lt_of_mono {Δ' Δ : SimplexCategory} (i : Δ' ⟶ Δ) [hi : Mono i]
   rcases lt_or_eq_of_le (len_le_of_mono hi) with (h | h)
   · exact h
   · exfalso
-    exact hi' (by ext ; exact h.symm)
+    exact hi' (by ext; exact h.symm)
 #align simplex_category.len_lt_of_mono SimplexCategory.len_lt_of_mono
 
 noncomputable instance : SplitEpiCategory SimplexCategory :=

--- a/Mathlib/Analysis/Analytic/Basic.lean
+++ b/Mathlib/Analysis/Analytic/Basic.lean
@@ -1002,7 +1002,7 @@ theorem HasFPowerSeriesAt.apply_eq_zero {p : FormalMultilinearSeries 𝕜 E F} {
 /-- A one-dimensional formal multilinear series representing the zero function is zero. -/
 theorem HasFPowerSeriesAt.eq_zero {p : FormalMultilinearSeries 𝕜 𝕜 E} {x : 𝕜}
     (h : HasFPowerSeriesAt 0 p x) : p = 0 := by
-  -- porting note: `funext ; ext` was `ext (n x)`
+  -- porting note: `funext; ext` was `ext (n x)`
   funext n
   ext x
   rw [← mkPiField_apply_one_eq_self (p n)]

--- a/Mathlib/Analysis/Analytic/Composition.lean
+++ b/Mathlib/Analysis/Analytic/Composition.lean
@@ -350,7 +350,7 @@ theorem compAlongComposition_norm {n : ℕ} (q : FormalMultilinearSeries 𝕜 F 
 theorem compAlongComposition_nnnorm {n : ℕ} (q : FormalMultilinearSeries 𝕜 F G)
     (p : FormalMultilinearSeries 𝕜 E F) (c : Composition n) :
     ‖q.compAlongComposition p c‖₊ ≤ ‖q c.length‖₊ * ∏ i, ‖p (c.blocksFun i)‖₊ := by
-  rw [← NNReal.coe_le_coe]; push_cast ; exact q.compAlongComposition_norm p c
+  rw [← NNReal.coe_le_coe]; push_cast; exact q.compAlongComposition_norm p c
 #align formal_multilinear_series.comp_along_composition_nnnorm FormalMultilinearSeries.compAlongComposition_nnnorm
 
 /-!

--- a/Mathlib/Analysis/BoxIntegral/Basic.lean
+++ b/Mathlib/Analysis/BoxIntegral/Basic.lean
@@ -762,7 +762,7 @@ theorem HasIntegral.of_bRiemann_eq_false_of_forall_isLittleO (hl : l.bRiemann = 
     specialize hlH hsne
     have : ∀ J ∈ π.boxes.filter fun J => π.tag J ∈ s,
         dist (vol J (f <| π.tag J)) (g J) ≤ εs (π.tag J) := fun J hJ ↦ by
-      rw [Finset.mem_filter] at hJ ; cases' hJ with hJ hJs
+      rw [Finset.mem_filter] at hJ; cases' hJ with hJ hJs
       refine' Hδ₁ c _ ⟨π.tag_mem_Icc _, hJs⟩ _ (hεs0 _) _ (π.le_of_mem' _ hJ) _
         (hπδ.2 hlH J hJ) fun hD => (Finset.le_sup hJ).trans (hπδ.3 hD)
       convert hπδ.1 J hJ using 3; exact (if_pos hJs).symm

--- a/Mathlib/Analysis/BoxIntegral/Integrability.lean
+++ b/Mathlib/Analysis/BoxIntegral/Integrability.lean
@@ -225,7 +225,7 @@ theorem IntegrableOn.hasBoxIntegral [CompleteSpace E] {f : (ι → ℝ) → E} {
   /- Now consider `ε > 0`. We need to find `r` such that for any tagged partition subordinate
     to `r`, the integral sum is `(μ I + 1 + 1) * ε`-close to the Bochner integral. -/
   refine' HasIntegral.of_mul ((μ I).toReal + 1 + 1) fun ε ε0 => _
-  lift ε to ℝ≥0 using ε0.le; rw [NNReal.coe_pos] at ε0 ; have ε0' := ENNReal.coe_pos.2 ε0
+  lift ε to ℝ≥0 using ε0.le; rw [NNReal.coe_pos] at ε0; have ε0' := ENNReal.coe_pos.2 ε0
   -- Choose `N` such that the integral of `‖f N x - g x‖` is less than or equal to `ε`.
   obtain ⟨N₀, hN₀⟩ : ∃ N : ℕ, ∫ x in I, ‖f N x - g x‖ ∂μ ≤ ε := by
     have : Tendsto (fun n => ∫⁻ x in I, ‖f n x - g x‖₊ ∂μ) atTop (𝓝 0) :=

--- a/Mathlib/Analysis/Calculus/ExtendDeriv.lean
+++ b/Mathlib/Analysis/Calculus/ExtendDeriv.lean
@@ -46,7 +46,7 @@ theorem has_fderiv_at_boundary_of_tendsto_fderiv {f : E → F} {s : Set E} {x : 
     -- one can assume without loss of generality that `x` belongs to the closure of `s`, as the
     -- statement is empty otherwise
     by_cases hx : x ∉ closure s
-    · rw [← closure_closure] at hx ; exact hasFDerivWithinAt_of_not_mem_closure hx
+    · rw [← closure_closure] at hx; exact hasFDerivWithinAt_of_not_mem_closure hx
     push_neg at hx
     rw [HasFDerivWithinAt, HasFDerivAtFilter, Asymptotics.isLittleO_iff]
     /- One needs to show that `‖f y - f x - f' (y - x)‖ ≤ ε ‖y - x‖` for `y` close to `x` in

--- a/Mathlib/Analysis/Calculus/FDerivMeasurable.lean
+++ b/Mathlib/Analysis/Calculus/FDerivMeasurable.lean
@@ -295,7 +295,7 @@ theorem d_subset_differentiable_set {K : Set (E →L[𝕜] F)} (hK : IsComplete 
     calc
       ‖L0 e - L0 e'‖ ≤ 12 * ‖c‖ * (1 / 2) ^ e := M _ _ _ _ _ _ le_rfl le_rfl le_rfl le_rfl he'
       _ < 12 * ‖c‖ * (ε / (12 * ‖c‖)) := by gcongr
-      _ = ε := by field_simp [(by norm_num : (12 : ℝ) ≠ 0), ne_of_gt cpos] ; ring
+      _ = ε := by field_simp [(by norm_num : (12 : ℝ) ≠ 0), ne_of_gt cpos]; ring
   -- As it is Cauchy, the sequence `L0` converges, to a limit `f'` in `K`.
   obtain ⟨f', f'K, hf'⟩ : ∃ f' ∈ K, Tendsto L0 atTop (𝓝 f') :=
     cauchySeq_tendsto_of_isComplete hK (fun e => (hn e (n e) (n e) le_rfl le_rfl).1) this
@@ -657,7 +657,7 @@ theorem d_subset_differentiable_set {K : Set F} (hK : IsComplete K) :
     calc
       ‖L0 e - L0 e'‖ ≤ 12 * (1 / 2) ^ e := M _ _ _ _ _ _ le_rfl le_rfl le_rfl le_rfl he'
       _ < 12 * (ε / 12) := (mul_lt_mul' le_rfl he (le_of_lt P) (by norm_num))
-      _ = ε := by field_simp [(by norm_num : (12 : ℝ) ≠ 0)] ; ring
+      _ = ε := by field_simp [(by norm_num : (12 : ℝ) ≠ 0)]; ring
 
   -- As it is Cauchy, the sequence `L0` converges, to a limit `f'` in `K`.
   obtain ⟨f', f'K, hf'⟩ : ∃ f' ∈ K, Tendsto L0 atTop (𝓝 f') :=

--- a/Mathlib/Analysis/Complex/CauchyIntegral.lean
+++ b/Mathlib/Analysis/Complex/CauchyIntegral.lean
@@ -189,7 +189,7 @@ theorem integral_boundary_rect_of_hasFDerivAt_real_off_countable (f : ℂ → E)
       neg_sub]
   set R : Set (ℝ × ℝ) := [[z.re, w.re]] ×ˢ [[w.im, z.im]]
   set t : Set (ℝ × ℝ) := e ⁻¹' s
-  rw [uIcc_comm z.im] at Hc Hi ; rw [min_comm z.im, max_comm z.im] at Hd
+  rw [uIcc_comm z.im] at Hc Hi; rw [min_comm z.im, max_comm z.im] at Hd
   have hR : e ⁻¹' ([[z.re, w.re]] ×ℂ [[w.im, z.im]]) = R := rfl
   have htc : ContinuousOn F R := Hc.comp e.continuousOn hR.ge
   have htd :

--- a/Mathlib/Analysis/Convex/Integral.lean
+++ b/Mathlib/Analysis/Convex/Integral.lean
@@ -257,7 +257,7 @@ of `f` over the whole space belongs to the interior of `s`. -/
 theorem Convex.average_mem_interior_of_set [IsFiniteMeasure μ] (hs : Convex ℝ s) (h0 : μ t ≠ 0)
     (hfs : ∀ᵐ x ∂μ, f x ∈ s) (hfi : Integrable f μ) (ht : (⨍ x in t, f x ∂μ) ∈ interior s) :
     (⨍ x, f x ∂μ) ∈ interior s := by
-  rw [← measure_toMeasurable] at h0 ; rw [← restrict_toMeasurable (measure_ne_top μ t)] at ht
+  rw [← measure_toMeasurable] at h0; rw [← restrict_toMeasurable (measure_ne_top μ t)] at ht
   by_cases h0' : μ (toMeasurable μ t)ᶜ = 0
   · rw [← ae_eq_univ] at h0'
     rwa [restrict_congr_set h0', restrict_univ] at ht

--- a/Mathlib/Analysis/NormedSpace/Exponential.lean
+++ b/Mathlib/Analysis/NormedSpace/Exponential.lean
@@ -255,7 +255,7 @@ theorem continuousOn_exp : ContinuousOn (exp 𝕂 : 𝔸 → 𝔸) (EMetric.ball
 theorem analyticAt_exp_of_mem_ball (x : 𝔸) (hx : x ∈ EMetric.ball (0 : 𝔸) (expSeries 𝕂 𝔸).radius) :
     AnalyticAt 𝕂 (exp 𝕂) x := by
   by_cases h : (expSeries 𝕂 𝔸).radius = 0
-  · rw [h] at hx ; exact (ENNReal.not_lt_zero hx).elim
+  · rw [h] at hx; exact (ENNReal.not_lt_zero hx).elim
   · have h := pos_iff_ne_zero.mpr h
     exact (hasFPowerSeriesOnBall_exp_of_radius_pos h).analyticAt_of_mem hx
 #align analytic_at_exp_of_mem_ball analyticAt_exp_of_mem_ball

--- a/Mathlib/Analysis/Seminorm.lean
+++ b/Mathlib/Analysis/Seminorm.lean
@@ -483,7 +483,7 @@ variable [NormedField 𝕜] [AddCommGroup E] [Module 𝕜 E] {p q : Seminorm �
 theorem bddBelow_range_add : BddBelow (range fun u => p u + q (x - u)) :=
   ⟨0, by
     rintro _ ⟨x, rfl⟩
-    dsimp ; positivity⟩
+    dsimp; positivity⟩
 #align seminorm.bdd_below_range_add Seminorm.bddBelow_range_add
 
 noncomputable instance instInf : Inf (Seminorm 𝕜 E) where

--- a/Mathlib/Analysis/SpecialFunctions/CompareExp.lean
+++ b/Mathlib/Analysis/SpecialFunctions/CompareExp.lean
@@ -64,7 +64,7 @@ theorem of_isBigO_im_re_rpow (hre : Tendsto re l atTop) (r : ℝ) (hr : im =O[l]
   ⟨hre, fun n =>
     IsLittleO.isBigO <|
       calc
-        (fun z : ℂ => z.im ^ n) =O[l] fun z => (z.re ^ r) ^ n := by norm_cast ; exact hr.pow n
+        (fun z : ℂ => z.im ^ n) =O[l] fun z => (z.re ^ r) ^ n := by norm_cast; exact hr.pow n
         _ =ᶠ[l] fun z => z.re ^ (r * n) :=
           ((hre.eventually_ge_atTop 0).mono fun z hz => by
             simp only [Real.rpow_mul hz r n, Real.rpow_nat_cast])
@@ -74,7 +74,7 @@ set_option linter.uppercaseLean3 false in
 
 theorem of_isBigO_im_re_pow (hre : Tendsto re l atTop) (n : ℕ) (hr : im =O[l] fun z => z.re ^ n) :
     IsExpCmpFilter l :=
-  of_isBigO_im_re_rpow hre n <| by norm_cast at hr ; simpa only [Real.rpow_nat_cast]
+  of_isBigO_im_re_rpow hre n <| by norm_cast at hr; simpa only [Real.rpow_nat_cast]
 set_option linter.uppercaseLean3 false in
 #align complex.is_exp_cmp_filter.of_is_O_im_re_pow Complex.IsExpCmpFilter.of_isBigO_im_re_pow
 
@@ -116,9 +116,9 @@ theorem isLittleO_im_pow_exp_re (hl : IsExpCmpFilter l) (n : ℕ) :
   flip IsLittleO.of_pow two_ne_zero <|
     calc
       ((fun z : ℂ => (z.im ^ n)) ^ 2) = (fun z : ℂ => (z.im ^ n) ^ 2) := funext <| by simp
-      _ = fun z => (Complex.im z) ^ (2 * n) := funext <| fun _ => by norm_cast ; rw [pow_mul']
-      _ =O[l] fun z => Real.exp z.re := by have := hl.isBigO_im_pow_re (2 * n) ; norm_cast at *
-      _ = fun z => Real.exp z.re ^ 1 := funext <| fun _ => by norm_cast ; rw [pow_one]
+      _ = fun z => (Complex.im z) ^ (2 * n) := funext <| fun _ => by norm_cast; rw [pow_mul']
+      _ =O[l] fun z => Real.exp z.re := by have := hl.isBigO_im_pow_re (2 * n); norm_cast at *
+      _ = fun z => Real.exp z.re ^ 1 := funext <| fun _ => by norm_cast; rw [pow_one]
       _ =o[l] fun z => Real.exp z.re ^ 2 := by
         have := (isLittleO_pow_pow_atTop_of_lt one_lt_two).comp_tendsto <|
           Real.tendsto_exp_atTop.comp hl.tendsto_re

--- a/Mathlib/Analysis/SpecialFunctions/Gamma/Basic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Gamma/Basic.lean
@@ -232,7 +232,7 @@ theorem partialGamma_add_one {s : ℂ} (hs : 0 < s.re) {X : ℝ} (hX : 0 ≤ X) 
       (fun x => s * (-x).exp * x ^ (s - 1) : ℝ → ℂ) := by ext1; ring
   rw [this]
   have t := @integral_const_mul 0 X volume _ _ s fun x : ℝ => (-x).exp * x ^ (s - 1)
-  dsimp at t ; rw [← t, ofReal_zero, zero_cpow]
+  dsimp at t; rw [← t, ofReal_zero, zero_cpow]
   · rw [MulZeroClass.mul_zero, add_zero]; congr 2; ext1; ring
   · contrapose! hs; rw [hs, zero_re]
 #align complex.partial_Gamma_add_one Complex.partialGamma_add_one
@@ -418,7 +418,7 @@ theorem differentiableAt_GammaAux (s : ℂ) (n : ℕ) (h1 : 1 - s.re < n) (h2 : 
     DifferentiableAt ℂ (GammaAux n) s := by
   induction' n with n hn generalizing s
   · refine' (hasDerivAt_GammaIntegral _).differentiableAt
-    rw [Nat.cast_zero] at h1 ; linarith
+    rw [Nat.cast_zero] at h1; linarith
   · dsimp only [GammaAux]
     specialize hn (s + 1)
     have a : 1 - (s + 1).re < ↑n := by

--- a/Mathlib/Analysis/SpecialFunctions/Gamma/BohrMollerup.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Gamma/BohrMollerup.lean
@@ -219,7 +219,7 @@ theorem f_add_nat_eq (hf_feq : ∀ {y : ℝ}, 0 < y → f (y + 1) = f y + log y)
     f (x + n) = f x + ∑ m : ℕ in Finset.range n, log (x + m) := by
   induction' n with n hn
   · simp
-  · have : x + n.succ = x + n + 1 := by push_cast ; ring
+  · have : x + n.succ = x + n + 1 := by push_cast; ring
     rw [this, hf_feq, hn]
     rw [Finset.range_succ, Finset.sum_insert Finset.not_mem_range_self]
     abel

--- a/Mathlib/Analysis/SpecialFunctions/Gaussian.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Gaussian.lean
@@ -547,7 +547,7 @@ theorem _root_.fourier_transform_gaussian_pi (hb : 0 < b.re) :
   convert _root_.fourier_transform_gaussian h1 (-2 * π * t) using 1
   · congr 1 with x : 1
     congr 2
-    all_goals push_cast ; ring
+    all_goals push_cast; ring
   · conv_lhs => rw [mul_comm]
     congr 2
     · field_simp [ofReal_ne_zero.mpr pi_ne_zero]; ring

--- a/Mathlib/Analysis/SpecialFunctions/Pow/Real.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Real.lean
@@ -49,7 +49,7 @@ theorem rpow_def (x y : ℝ) : x ^ y = ((x : ℂ) ^ (y : ℂ)).re := rfl
 
 theorem rpow_def_of_nonneg {x : ℝ} (hx : 0 ≤ x) (y : ℝ) :
     x ^ y = if x = 0 then if y = 0 then 1 else 0 else exp (log x * y) := by
-  simp only [rpow_def, Complex.cpow_def] ; split_ifs <;>
+  simp only [rpow_def, Complex.cpow_def]; split_ifs <;>
   simp_all [(Complex.ofReal_log hx).symm, -Complex.ofReal_mul, -IsROrC.ofReal_mul,
       (Complex.ofReal_mul _ _).symm, Complex.exp_ofReal_re, Complex.ofReal_eq_zero]
 #align real.rpow_def_of_nonneg Real.rpow_def_of_nonneg
@@ -89,11 +89,11 @@ theorem rpow_def_of_neg {x : ℝ} (hx : x < 0) (y : ℝ) : x ^ y = exp (log x * 
 
 theorem rpow_def_of_nonpos {x : ℝ} (hx : x ≤ 0) (y : ℝ) :
     x ^ y = if x = 0 then if y = 0 then 1 else 0 else exp (log x * y) * cos (y * π) := by
-  split_ifs with h <;> simp [rpow_def, *] ; exact rpow_def_of_neg (lt_of_le_of_ne hx h) _
+  split_ifs with h <;> simp [rpow_def, *]; exact rpow_def_of_neg (lt_of_le_of_ne hx h) _
 #align real.rpow_def_of_nonpos Real.rpow_def_of_nonpos
 
 theorem rpow_pos_of_pos {x : ℝ} (hx : 0 < x) (y : ℝ) : 0 < x ^ y := by
-  rw [rpow_def_of_pos hx] ; apply exp_pos
+  rw [rpow_def_of_pos hx]; apply exp_pos
 #align real.rpow_pos_of_pos Real.rpow_pos_of_pos
 
 @[simp]
@@ -142,7 +142,7 @@ theorem zero_rpow_nonneg (x : ℝ) : 0 ≤ (0 : ℝ) ^ x := by
 #align real.zero_rpow_nonneg Real.zero_rpow_nonneg
 
 theorem rpow_nonneg_of_nonneg {x : ℝ} (hx : 0 ≤ x) (y : ℝ) : 0 ≤ x ^ y := by
-  rw [rpow_def_of_nonneg hx] ; split_ifs <;>
+  rw [rpow_def_of_nonneg hx]; split_ifs <;>
     simp only [zero_le_one, le_refl, le_of_lt (exp_pos _)]
 #align real.rpow_nonneg_of_nonneg Real.rpow_nonneg_of_nonneg
 
@@ -222,7 +222,7 @@ theorem rpow_sum_of_nonneg {ι : Type _} {a : ℝ} (ha : 0 ≤ a) {s : Finset ι
 #align real.rpow_sum_of_nonneg Real.rpow_sum_of_nonneg
 
 theorem rpow_neg {x : ℝ} (hx : 0 ≤ x) (y : ℝ) : x ^ (-y) = (x ^ y)⁻¹ := by
-  simp only [rpow_def_of_nonneg hx] ; split_ifs <;> simp_all [exp_neg]
+  simp only [rpow_def_of_nonneg hx]; split_ifs <;> simp_all [exp_neg]
 #align real.rpow_neg Real.rpow_neg
 
 theorem rpow_sub {x : ℝ} (hx : 0 < x) (y z : ℝ) : x ^ (y - z) = x ^ y / x ^ z := by
@@ -244,7 +244,7 @@ end Real
 namespace Complex
 
 theorem ofReal_cpow {x : ℝ} (hx : 0 ≤ x) (y : ℝ) : ((x ^ y : ℝ) : ℂ) = (x : ℂ) ^ (y : ℂ) := by
-  simp only [Real.rpow_def_of_nonneg hx, Complex.cpow_def, ofReal_eq_zero] ; split_ifs <;>
+  simp only [Real.rpow_def_of_nonneg hx, Complex.cpow_def, ofReal_eq_zero]; split_ifs <;>
     simp [Complex.ofReal_log hx]
 #align complex.of_real_cpow Complex.ofReal_cpow
 
@@ -288,7 +288,7 @@ theorem abs_cpow_real (x : ℂ) (y : ℝ) : abs (x ^ (y : ℂ)) = Complex.abs x 
 
 @[simp]
 theorem abs_cpow_inv_nat (x : ℂ) (n : ℕ) : abs (x ^ (n⁻¹ : ℂ)) = Complex.abs x ^ (n⁻¹ : ℝ) := by
-  rw [← abs_cpow_real] ; simp [-abs_cpow_real]
+  rw [← abs_cpow_real]; simp [-abs_cpow_real]
 #align complex.abs_cpow_inv_nat Complex.abs_cpow_inv_nat
 
 theorem abs_cpow_eq_rpow_re_of_pos {x : ℝ} (hx : 0 < x) (y : ℂ) : abs (x ^ y) = x ^ y.re := by

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Basic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Basic.lean
@@ -730,7 +730,7 @@ theorem cos_pi_over_two_pow : ∀ n : ℕ, cos (π / 2 ^ (n + 1)) = sqrtTwoAddSe
     symm; rw [div_eq_iff_mul_eq this]; symm
     rw [sqrtTwoAddSeries, sqrt_eq_iff_sq_eq, mul_pow, cos_sq, ← mul_div_assoc, Nat.add_succ,
       pow_succ, mul_div_mul_left _ _ this, cos_pi_over_two_pow _, add_mul]
-    congr ; · norm_num
+    congr; · norm_num
     rw [mul_comm, sq, mul_assoc, ← mul_div_assoc, mul_div_cancel_left, ← mul_div_assoc,
         mul_div_cancel_left] <;>
       try exact this
@@ -755,7 +755,7 @@ theorem sin_sq_pi_over_two_pow (n : ℕ) :
 theorem sin_sq_pi_over_two_pow_succ (n : ℕ) :
     sin (π / 2 ^ (n + 2)) ^ 2 = 1 / 2 - sqrtTwoAddSeries 0 n / 4 := by
   rw [sin_sq_pi_over_two_pow, sqrtTwoAddSeries, div_pow, sq_sqrt, add_div, ← sub_sub]
-  congr ; norm_num; norm_num; apply add_nonneg; norm_num; apply sqrtTwoAddSeries_zero_nonneg
+  congr; norm_num; norm_num; apply add_nonneg; norm_num; apply sqrtTwoAddSeries_zero_nonneg
 #align real.sin_sq_pi_over_two_pow_succ Real.sin_sq_pi_over_two_pow_succ
 
 @[simp]

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Deriv.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Deriv.lean
@@ -723,7 +723,7 @@ theorem abs_sinh (x : ℝ) : |sinh x| = sinh |x| := by
 
 theorem cosh_strictMonoOn : StrictMonoOn cosh (Ici 0) :=
   (convex_Ici _).strictMonoOn_of_deriv_pos continuous_cosh.continuousOn fun x hx => by
-    rw [interior_Ici, mem_Ioi] at hx ; rwa [deriv_cosh, sinh_pos_iff]
+    rw [interior_Ici, mem_Ioi] at hx; rwa [deriv_cosh, sinh_pos_iff]
 #align real.cosh_strict_mono_on Real.cosh_strictMonoOn
 
 @[simp]

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/EulerSineProd.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/EulerSineProd.lean
@@ -161,7 +161,7 @@ theorem integral_cos_mul_cos_pow (hn : 2 ≤ n) (hz : z ≠ 0) :
       (n - 1 : ℂ) / n *
         ∫ x in (0 : ℝ)..π / 2, Complex.cos (2 * z * x) * (cos x : ℂ) ^ (n - 2) := by
   have nne : (n : ℂ) ≠ 0 := by
-    contrapose! hn; rw [Nat.cast_eq_zero] at hn ; rw [hn]; exact zero_lt_two
+    contrapose! hn; rw [Nat.cast_eq_zero] at hn; rw [hn]; exact zero_lt_two
   have := integral_cos_mul_cos_pow_aux hn hz
   rw [integral_sin_mul_sin_mul_cos_pow_eq hn hz, sub_eq_neg_add, mul_add, ← sub_eq_iff_eq_add]
     at this
@@ -179,8 +179,8 @@ theorem integral_cos_mul_cos_pow_even (n : ℕ) (hz : z ≠ 0) :
     nth_rw 2 [← mul_one (2 : ℂ)]
     rw [← mul_add, mul_pow, ← div_div]
     ring
-  · push_cast ; ring
-  · push_cast ; ring
+  · push_cast; ring
+  · push_cast; ring
 #align euler_sine.integral_cos_mul_cos_pow_even EulerSine.integral_cos_mul_cos_pow_even
 
 /-- Relate the integral `cos x ^ n` over `[0, π/2]` to the integral of `sin x ^ n` over `[0, π]`,
@@ -224,7 +224,7 @@ theorem sin_pi_mul_eq (z : ℂ) (n : ℕ) :
       integral_one, sub_zero]
     rw [integral_cos_mul_complex (mul_ne_zero two_ne_zero hz), Complex.ofReal_zero,
       MulZeroClass.mul_zero, Complex.sin_zero, zero_div, sub_zero,
-      (by push_cast ; field_simp; ring : 2 * z * ↑(π / 2) = π * z)]
+      (by push_cast; field_simp; ring : 2 * z * ↑(π / 2) = π * z)]
     field_simp [Complex.ofReal_ne_zero.mpr pi_pos.ne']
     ring
   · rw [hn, Finset.prod_range_succ]
@@ -265,7 +265,7 @@ theorem sin_pi_mul_eq (z : ℂ) (n : ℕ) :
         simp
       have : 2 * (n : ℂ) + 2 ≠ 0 := by
         convert (Nat.cast_add_one_ne_zero (2 * n + 1) : (↑(2 * n + 1) + 1 : ℂ) ≠ 0) using 1
-        push_cast ; ring
+        push_cast; ring
       field_simp; ring
     convert integral_cos_mul_cos_pow_even n hz
     rw [Nat.cast_succ]

--- a/Mathlib/CategoryTheory/Action.lean
+++ b/Mathlib/CategoryTheory/Action.lean
@@ -89,7 +89,7 @@ theorem coe_back (x : X) : ActionCategory.back (x : ActionCategory M X) = x :=
 #align category_theory.action_category.coe_back CategoryTheory.ActionCategory.coe_back
 
 @[simp]
-theorem back_coe (x : ActionCategory M X) : ↑x.back = x := by cases x ; rfl
+theorem back_coe (x : ActionCategory M X) : ↑x.back = x := by cases x; rfl
 #align category_theory.action_category.back_coe CategoryTheory.ActionCategory.back_coe
 
 variable (M X)

--- a/Mathlib/CategoryTheory/Adjunction/Basic.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Basic.lean
@@ -279,23 +279,23 @@ variable {F : C ⥤ D} {G : D ⥤ C} (adj : CoreHomEquiv F G) {X' X : C} {Y Y' :
 @[simp]
 theorem homEquiv_naturality_left_aux (f : X' ⟶ X) (g : F.obj X ⟶ Y) :
     (adj.homEquiv X' (F.obj X)) (F.map f) ≫ G.map g = f ≫ (adj.homEquiv X Y) g := by
-  rw [← homEquiv_naturality_right, ← Equiv.eq_symm_apply] ; simp
+  rw [← homEquiv_naturality_right, ← Equiv.eq_symm_apply]; simp
 
 -- @[simp] -- Porting note: LHS simplifies, added aux lemma above
 theorem homEquiv_naturality_left (f : X' ⟶ X) (g : F.obj X ⟶ Y) :
     (adj.homEquiv X' Y) (F.map f ≫ g) = f ≫ (adj.homEquiv X Y) g := by
-  rw [← Equiv.eq_symm_apply] ; simp
+  rw [← Equiv.eq_symm_apply]; simp
 #align category_theory.adjunction.core_hom_equiv.hom_equiv_naturality_left CategoryTheory.Adjunction.CoreHomEquiv.homEquiv_naturality_left
 
 @[simp]
 theorem homEquiv_naturality_right_symm_aux (f : X ⟶ G.obj Y) (g : Y ⟶ Y') :
     F.map f ≫ (adj.homEquiv (G.obj Y) Y').symm (G.map g) = (adj.homEquiv X Y).symm f ≫ g := by
-  rw [← homEquiv_naturality_left_symm, Equiv.symm_apply_eq] ; simp
+  rw [← homEquiv_naturality_left_symm, Equiv.symm_apply_eq]; simp
 
 -- @[simp] -- Porting note: LHS simplifies, added aux lemma above
 theorem homEquiv_naturality_right_symm (f : X ⟶ G.obj Y) (g : Y ⟶ Y') :
     (adj.homEquiv X Y').symm (f ≫ G.map g) = (adj.homEquiv X Y).symm f ≫ g := by
-  rw [Equiv.symm_apply_eq] ; simp
+  rw [Equiv.symm_apply_eq]; simp
 #align category_theory.adjunction.core_hom_equiv.hom_equiv_naturality_right_symm CategoryTheory.Adjunction.CoreHomEquiv.homEquiv_naturality_right_symm
 
 end CoreHomEquiv
@@ -499,7 +499,7 @@ variable (e : ∀ X Y, (F_obj X ⟶ Y) ≃ (X ⟶ G.obj Y))
 variable (he : ∀ X Y Y' g h, e X Y' (h ≫ g) = e X Y h ≫ G.map g)
 
 private theorem he' {X Y Y'} (f g) : (e X Y').symm (f ≫ G.map g) = (e X Y).symm f ≫ g := by
-  intros ; rw [Equiv.symm_apply_eq, he] ; simp
+  intros; rw [Equiv.symm_apply_eq, he]; simp
 -- #align category_theory.adjunction.he' category_theory.adjunction.he'
 
 /-- Construct a left adjoint functor to `G`, given the functor's value on objects `F_obj` and
@@ -546,7 +546,7 @@ variable (e : ∀ X Y, (F.obj X ⟶ Y) ≃ (X ⟶ G_obj Y))
 variable (he : ∀ X' X Y f g, e X' Y (F.map f ≫ g) = f ≫ e X Y g)
 
 private theorem he'' {X' X Y} (f g) : F.map f ≫ (e X Y).symm g = (e X' Y).symm (f ≫ g) := by
-  intros ; rw [Equiv.eq_symm_apply, he] ; simp
+  intros; rw [Equiv.eq_symm_apply, he]; simp
 -- #align category_theory.adjunction.he' category_theory.adjunction.he'
 
 /-- Construct a right adjoint functor to `F`, given the functor's value on objects `G_obj` and

--- a/Mathlib/CategoryTheory/Adjunction/Opposites.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Opposites.lean
@@ -160,7 +160,7 @@ theorem unit_leftAdjointUniq_hom {F F' : C ⥤ D} {G : D ⥤ C} (adj1 : F ⊣ G)
 @[reassoc (attr := simp)]
 theorem unit_leftAdjointUniq_hom_app {F F' : C ⥤ D} {G : D ⥤ C} (adj1 : F ⊣ G) (adj2 : F' ⊣ G)
     (x : C) : adj1.unit.app x ≫ G.map ((leftAdjointUniq adj1 adj2).hom.app x) = adj2.unit.app x :=
-  by rw [← unit_leftAdjointUniq_hom adj1 adj2] ; rfl
+  by rw [← unit_leftAdjointUniq_hom adj1 adj2]; rfl
 #align category_theory.adjunction.unit_left_adjoint_uniq_hom_app CategoryTheory.Adjunction.unit_leftAdjointUniq_hom_app
 
 @[reassoc (attr := simp)]

--- a/Mathlib/CategoryTheory/Category/Grpd.lean
+++ b/Mathlib/CategoryTheory/Category/Grpd.lean
@@ -75,7 +75,7 @@ instance category : LargeCategory.{max v u} Grpd.{v, u} where
   comp F G := F ⋙ G
   id_comp _ := by rfl
   comp_id _ := by rfl
-  assoc := by intros ; rfl
+  assoc := by intros; rfl
 set_option linter.uppercaseLean3 false in
 #align category_theory.Groupoid.category CategoryTheory.Grpd.category
 

--- a/Mathlib/CategoryTheory/Enriched/Basic.lean
+++ b/Mathlib/CategoryTheory/Enriched/Basic.lean
@@ -334,7 +334,7 @@ def EnrichedFunctor.forget {C : Type u₁} {D : Type u₂} [EnrichedCategory W C
     · simp only [Iso.cancel_iso_inv_left, Category.assoc, tensor_comp,
         ForgetEnrichment.homTo_homOf, EnrichedFunctor.map_comp, forgetEnrichment_comp]
       rfl
-    · intro f g w; apply_fun ForgetEnrichment.homOf W at w ; simpa using w
+    · intro f g w; apply_fun ForgetEnrichment.homOf W at w; simpa using w
 #align category_theory.enriched_functor.forget CategoryTheory.EnrichedFunctor.forget
 
 end

--- a/Mathlib/CategoryTheory/Functor/Basic.lean
+++ b/Mathlib/CategoryTheory/Functor/Basic.lean
@@ -116,7 +116,7 @@ variable {C : Type u₁} [Category.{v₁} C] {D : Type u₂} [Category.{v₂} D]
 def comp (F : C ⥤ D) (G : D ⥤ E) : C ⥤ E where
   obj X := G.obj (F.obj X)
   map f := G.map (F.map f)
-  map_comp := by intros ; dsimp ; rw [F.map_comp, G.map_comp]
+  map_comp := by intros; dsimp; rw [F.map_comp, G.map_comp]
 #align category_theory.functor.comp CategoryTheory.Functor.comp
 #align category_theory.functor.comp_obj CategoryTheory.Functor.comp_obj
 

--- a/Mathlib/CategoryTheory/Functor/Flat.lean
+++ b/Mathlib/CategoryTheory/Functor/Flat.lean
@@ -290,7 +290,7 @@ theorem uniq {K : J ⥤ C} {c : Cone K} (hc : IsLimit c) (s : Cone (K ⋙ F))
       apply hc.uniq (c.extend _)
       -- Porting note: was `by tidy`, but `aesop` only works if max heartbeats
       -- is increased, so we replace it by the output of `tidy?`
-      intro j ; rfl
+      intro j; rfl
     _ = hc.lift (c.extend g₂.right) := by
       congr
     _ = g₂.right := by
@@ -298,7 +298,7 @@ theorem uniq {K : J ⥤ C} {c : Cone K} (hc : IsLimit c) (s : Cone (K ⋙ F))
       apply hc.uniq (c.extend _)
       -- Porting note: was `by tidy`, but `aesop` only works if max heartbeats
       -- is increased, so we replace it by the output of `tidy?`
-      intro _ ; rfl
+      intro _; rfl
 
   -- Finally, since `fᵢ` factors through `F(gᵢ)`, the result follows.
   calc
@@ -427,7 +427,7 @@ theorem flat_iff_lan_flat (F : C ⥤ D) :
     haveI := preservesFiniteLimitsOfFlat (lan F.op : _ ⥤ Dᵒᵖ ⥤ Type u₁)
     haveI : PreservesFiniteLimits F := by
       apply preservesFiniteLimitsOfPreservesFiniteLimitsOfSize.{u₁}
-      intros ; skip; apply preservesLimitOfLanPreservesLimit
+      intros; skip; apply preservesLimitOfLanPreservesLimit
     apply flat_of_preservesFiniteLimits⟩
 set_option linter.uppercaseLean3 false in
 #align category_theory.flat_iff_Lan_flat CategoryTheory.flat_iff_lan_flat
@@ -440,7 +440,7 @@ noncomputable def preservesFiniteLimitsIffLanPreservesFiniteLimits (F : C ⥤ D)
   toFun _ := inferInstance
   invFun _ := by
     apply preservesFiniteLimitsOfPreservesFiniteLimitsOfSize.{u₁}
-    intros ; apply preservesLimitOfLanPreservesLimit
+    intros; apply preservesLimitOfLanPreservesLimit
   left_inv x := by
     -- porting note: `cases x` and an `unfold` not necessary in lean 4.
     -- Remark : in mathlib3 we had `unfold preservesFiniteLimitsOfFlat`

--- a/Mathlib/CategoryTheory/Functor/FullyFaithful.lean
+++ b/Mathlib/CategoryTheory/Functor/FullyFaithful.lean
@@ -355,8 +355,8 @@ theorem Faithful.div_comp (F : C ⥤ E) [Faithful F] (G : D ⥤ E) [Faithful G] 
     Faithful.div F G obj @h_obj @map @h_map ⋙ G = F := by
   -- Porting note: Have to unfold the structure twice because the first one recovers only the
   -- prefunctor `F_pre`
-  cases' F with F_pre _ _ ; cases' G with G_pre _ _
-  cases' F_pre with F_obj _ ; cases' G_pre with G_obj _
+  cases' F with F_pre _ _; cases' G with G_pre _ _
+  cases' F_pre with F_obj _; cases' G_pre with G_obj _
   unfold Faithful.div Functor.comp
   -- Porting note: unable to find the lean4 analogue to `unfold_projs`, works without it
   have : F_obj = G_obj ∘ obj := (funext h_obj).symm

--- a/Mathlib/CategoryTheory/GradedObject.lean
+++ b/Mathlib/CategoryTheory/GradedObject.lean
@@ -100,8 +100,8 @@ pulling back along two propositionally equal functions.
 -/
 @[simps]
 def comapEq {β γ : Type w} {f g : β → γ} (h : f = g) : comap C f ≅ comap C g where
-  hom := { app := fun X b => eqToHom (by dsimp ; simp only [h]) }
-  inv := { app := fun X b => eqToHom (by dsimp ; simp only [h]) }
+  hom := { app := fun X b => eqToHom (by dsimp; simp only [h]) }
+  inv := { app := fun X b => eqToHom (by dsimp; simp only [h]) }
 #align category_theory.graded_object.comap_eq CategoryTheory.GradedObject.comapEq
 
 theorem comapEq_symm {β γ : Type w} {f g : β → γ} (h : f = g) :
@@ -127,9 +127,9 @@ def comapEquiv {β γ : Type w} (e : β ≃ γ) : GradedObject β C ≌ GradedOb
   functor := comap C (e.symm : γ → β)
   inverse := comap C (e : β → γ)
   counitIso :=
-    (Pi.comapComp (fun _ => C) _ _).trans (comapEq C (by ext ; simp))
+    (Pi.comapComp (fun _ => C) _ _).trans (comapEq C (by ext; simp))
   unitIso :=
-    (comapEq C (by ext ; simp)).trans (Pi.comapComp _ _ _).symm
+    (comapEq C (by ext; simp)).trans (Pi.comapComp _ _ _).symm
 #align category_theory.graded_object.comap_equiv CategoryTheory.GradedObject.comapEquiv
 
 -- See note [dsimp, simp].
@@ -139,7 +139,7 @@ instance hasShift {β : Type _} [AddCommGroup β] (s : β) : HasShift (GradedObj
   hasShiftMk _ _
     { F := fun n => comap C fun b : β => b + n • s
       zero := comapEq C (by aesop_cat) ≪≫ Pi.comapId β fun _ => C
-      add := fun m n => comapEq C (by ext ; dsimp ; rw [add_comm m n, add_zsmul, add_assoc]) ≪≫
+      add := fun m n => comapEq C (by ext; dsimp; rw [add_comm m n, add_zsmul, add_assoc]) ≪≫
           (Pi.comapComp _ _ _).symm }
 #align category_theory.graded_object.has_shift CategoryTheory.GradedObject.hasShift
 

--- a/Mathlib/CategoryTheory/Groupoid/Subgroupoid.lean
+++ b/Mathlib/CategoryTheory/Groupoid/Subgroupoid.lean
@@ -538,7 +538,7 @@ theorem mem_map_objs_iff (hφ : Function.Injective φ.obj) (d : D) :
   dsimp [objs, map]
   constructor
   · rintro ⟨f, hf⟩
-    change Map.Arrows φ hφ S d d f at hf ; rw [Map.arrows_iff] at hf
+    change Map.Arrows φ hφ S d d f at hf; rw [Map.arrows_iff] at hf
     obtain ⟨c, d, g, ec, ed, eg, gS, eg⟩ := hf
     exact ⟨c, ⟨mem_objs_of_src S eg, ec⟩⟩
   · rintro ⟨c, ⟨γ, γS⟩, rfl⟩
@@ -592,7 +592,7 @@ theorem isNormal_map (hφ : Function.Injective φ.obj) (hφ' : im φ hφ = ⊤) 
       change Map.Arrows φ hφ S (φ.obj c') (φ.obj c') _
       simp only [eqToHom_refl, Category.comp_id, Category.id_comp, inv_eq_inv]
       suffices Map.Arrows φ hφ S (φ.obj c') (φ.obj c') (φ.map <| Groupoid.inv f ≫ γ ≫ f) by
-        simp only [inv_eq_inv, Functor.map_comp, Functor.map_inv] at this ; exact this
+        simp only [inv_eq_inv, Functor.map_comp, Functor.map_inv] at this; exact this
       · constructor; apply Sn.conj f γS }
 #align category_theory.subgroupoid.is_normal_map CategoryTheory.Subgroupoid.isNormal_map
 

--- a/Mathlib/CategoryTheory/Limits/HasLimits.lean
+++ b/Mathlib/CategoryTheory/Limits/HasLimits.lean
@@ -495,7 +495,7 @@ theorem limit.pre_post {D : Type u'} [Category.{v'} D] (E : K ⥤ J) (F : J ⥤ 
     haveI : HasLimit (E ⋙  F ⋙  G) := h
     G.map (limit.pre F E) ≫ limit.post (E ⋙ F) G = limit.post F G ≫ limit.pre (F ⋙ G) E := by
   haveI : HasLimit (E ⋙  F ⋙  G) := h
-  ext ; erw [assoc, limit.post_π, ← G.map_comp, limit.pre_π, assoc, limit.pre_π, limit.post_π]
+  ext; erw [assoc, limit.post_π, ← G.map_comp, limit.pre_π, assoc, limit.pre_π, limit.post_π]
 #align category_theory.limits.limit.pre_post CategoryTheory.Limits.limit.pre_post
 
 open CategoryTheory.Equivalence

--- a/Mathlib/CategoryTheory/Limits/IsLimit.lean
+++ b/Mathlib/CategoryTheory/Limits/IsLimit.lean
@@ -77,7 +77,7 @@ attribute [reassoc (attr := simp)] IsLimit.fac
 namespace IsLimit
 
 instance subsingleton {t : Cone F} : Subsingleton (IsLimit t) :=
-  ⟨by intro P Q ; cases P ; cases Q ; congr ; aesop_cat⟩
+  ⟨by intro P Q; cases P; cases Q; congr; aesop_cat⟩
 #align category_theory.limits.is_limit.subsingleton CategoryTheory.Limits.IsLimit.subsingleton
 
 /-- Given a natural transformation `α : F ⟶ G`, we give a morphism from the cone point
@@ -580,7 +580,7 @@ attribute [-simp, nolint simpNF] IsColimit.mk.injEq
 namespace IsColimit
 
 instance subsingleton {t : Cocone F} : Subsingleton (IsColimit t) :=
-  ⟨by intro P Q ; cases P ; cases Q ; congr ; aesop_cat⟩
+  ⟨by intro P Q; cases P; cases Q; congr; aesop_cat⟩
 #align category_theory.limits.is_colimit.subsingleton CategoryTheory.Limits.IsColimit.subsingleton
 
 /-- Given a natural transformation `α : F ⟶ G`, we give a morphism from the cocone point
@@ -956,7 +956,7 @@ def ofFaithful {t : Cocone F} {D : Type u₄} [Category.{v₄} D] (G : C ⥤ D) 
     (ht : IsColimit (mapCocone G t)) (desc : ∀ s : Cocone F, t.pt ⟶ s.pt)
     (h : ∀ s, G.map (desc s) = ht.desc (mapCocone G s)) : IsColimit t :=
   { desc
-    fac := fun s j => by apply G.map_injective ; rw [G.map_comp, h] ; apply ht.fac
+    fac := fun s j => by apply G.map_injective; rw [G.map_comp, h]; apply ht.fac
     uniq := fun s m w => by
       apply G.map_injective; rw [h]
       refine' ht.uniq (mapCocone G s) _ fun j => _
@@ -1005,7 +1005,7 @@ def homOfCocone (s : Cocone F) : X ⟶ s.pt :=
 theorem coconeOfHom_homOfCocone (s : Cocone F) : coconeOfHom h (homOfCocone h s) = s := by
   dsimp [coconeOfHom, homOfCocone];
   have ⟨s_pt,s_ι⟩ := s
-  congr ; dsimp
+  congr; dsimp
   convert congrFun (congrFun (congrArg NatTrans.app h.inv_hom_id) s_pt) s_ι using 1
 #align category_theory.limits.is_colimit.of_nat_iso.cocone_of_hom_of_cocone CategoryTheory.Limits.IsColimit.OfNatIso.coconeOfHom_homOfCocone
 

--- a/Mathlib/CategoryTheory/Limits/Preserves/Basic.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Basic.lean
@@ -188,8 +188,8 @@ instance idPreservesColimits : PreservesColimitsOfSize.{w', w} (𝟭 C) where
       preservesColimit := fun {K} =>
         ⟨fun {c} h =>
           ⟨fun s => h.desc ⟨s.pt, fun j => s.ι.app j, fun j j' f => s.ι.naturality f⟩, by
-            cases K ; rcases c with ⟨_, _, _⟩ ; intro s j ; cases s ; exact h.fac _ j, by
-            cases K ; rcases c with ⟨_, _, _⟩ ; intro s m w ; rcases s with ⟨_, _, _⟩ ;
+            cases K; rcases c with ⟨_, _, _⟩; intro s j; cases s; exact h.fac _ j, by
+            cases K; rcases c with ⟨_, _, _⟩; intro s m w; rcases s with ⟨_, _, _⟩ ;
               exact h.uniq _ m w⟩⟩ }
 #align category_theory.limits.id_preserves_colimits CategoryTheory.Limits.idPreservesColimits
 
@@ -516,8 +516,8 @@ instance idReflectsLimits : ReflectsLimitsOfSize.{w, w'} (𝟭 C) where
       reflectsLimit := fun {K} =>
         ⟨fun {c} h =>
           ⟨fun s => h.lift ⟨s.pt, fun j => s.π.app j, fun j j' f => s.π.naturality f⟩, by
-            cases K ; rcases c with ⟨_, _, _⟩ ; intro s j ; cases s ; exact h.fac _ j, by
-            cases K ; rcases c with ⟨_, _, _⟩ ; intro s m w ; rcases s with ⟨_, _, _⟩ ;
+            cases K; rcases c with ⟨_, _, _⟩; intro s j; cases s; exact h.fac _ j, by
+            cases K; rcases c with ⟨_, _, _⟩; intro s m w; rcases s with ⟨_, _, _⟩ ;
               exact h.uniq _ m w⟩⟩ }
 #align category_theory.limits.id_reflects_limits CategoryTheory.Limits.idReflectsLimits
 
@@ -527,8 +527,8 @@ instance idReflectsColimits : ReflectsColimitsOfSize.{w, w'} (𝟭 C) where
       reflectsColimit := fun {K} =>
         ⟨fun {c} h =>
           ⟨fun s => h.desc ⟨s.pt, fun j => s.ι.app j, fun j j' f => s.ι.naturality f⟩, by
-            cases K ; rcases c with ⟨_, _, _⟩ ; intro s j ; cases s ; exact h.fac _ j, by
-            cases K ; rcases c with ⟨_, _, _⟩ ; intro s m w ; rcases s with ⟨_, _, _⟩ ;
+            cases K; rcases c with ⟨_, _, _⟩; intro s j; cases s; exact h.fac _ j, by
+            cases K; rcases c with ⟨_, _, _⟩; intro s m w; rcases s with ⟨_, _, _⟩ ;
               exact h.uniq _ m w⟩⟩ }
 #align category_theory.limits.id_reflects_colimits CategoryTheory.Limits.idReflectsColimits
 

--- a/Mathlib/CategoryTheory/Limits/Preserves/Basic.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Basic.lean
@@ -189,7 +189,7 @@ instance idPreservesColimits : PreservesColimitsOfSize.{w', w} (𝟭 C) where
         ⟨fun {c} h =>
           ⟨fun s => h.desc ⟨s.pt, fun j => s.ι.app j, fun j j' f => s.ι.naturality f⟩, by
             cases K; rcases c with ⟨_, _, _⟩; intro s j; cases s; exact h.fac _ j, by
-            cases K; rcases c with ⟨_, _, _⟩; intro s m w; rcases s with ⟨_, _, _⟩ ;
+            cases K; rcases c with ⟨_, _, _⟩; intro s m w; rcases s with ⟨_, _, _⟩;
               exact h.uniq _ m w⟩⟩ }
 #align category_theory.limits.id_preserves_colimits CategoryTheory.Limits.idPreservesColimits
 
@@ -517,7 +517,7 @@ instance idReflectsLimits : ReflectsLimitsOfSize.{w, w'} (𝟭 C) where
         ⟨fun {c} h =>
           ⟨fun s => h.lift ⟨s.pt, fun j => s.π.app j, fun j j' f => s.π.naturality f⟩, by
             cases K; rcases c with ⟨_, _, _⟩; intro s j; cases s; exact h.fac _ j, by
-            cases K; rcases c with ⟨_, _, _⟩; intro s m w; rcases s with ⟨_, _, _⟩ ;
+            cases K; rcases c with ⟨_, _, _⟩; intro s m w; rcases s with ⟨_, _, _⟩;
               exact h.uniq _ m w⟩⟩ }
 #align category_theory.limits.id_reflects_limits CategoryTheory.Limits.idReflectsLimits
 
@@ -528,7 +528,7 @@ instance idReflectsColimits : ReflectsColimitsOfSize.{w, w'} (𝟭 C) where
         ⟨fun {c} h =>
           ⟨fun s => h.desc ⟨s.pt, fun j => s.ι.app j, fun j j' f => s.ι.naturality f⟩, by
             cases K; rcases c with ⟨_, _, _⟩; intro s j; cases s; exact h.fac _ j, by
-            cases K; rcases c with ⟨_, _, _⟩; intro s m w; rcases s with ⟨_, _, _⟩ ;
+            cases K; rcases c with ⟨_, _, _⟩; intro s m w; rcases s with ⟨_, _, _⟩;
               exact h.uniq _ m w⟩⟩ }
 #align category_theory.limits.id_reflects_colimits CategoryTheory.Limits.idReflectsColimits
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/Images.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Images.lean
@@ -110,7 +110,7 @@ determined. -/
 @[ext]
 theorem ext {F F' : MonoFactorisation f} (hI : F.I = F'.I)
   (hm : F.m = eqToHom hI ≫ F'.m) : F = F' := by
-  cases' F with _ Fm _ _ Ffac ; cases' F' with _ Fm' _ _ Ffac'
+  cases' F with _ Fm _ _ Ffac; cases' F' with _ Fm' _ _ Ffac'
   cases' hI
   simp at hm
   dsimp at Ffac Ffac'

--- a/Mathlib/CategoryTheory/Limits/Shapes/Multiequalizer.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Multiequalizer.lean
@@ -644,7 +644,7 @@ noncomputable def ofSigmaCofork (c : Cofork I.fstSigmaMap I.sndSigmaMap) : Multi
         rintro (_ | _) (_ | _) (_ | _ | _) <;> dsimp
         · simp
         · simp
-        · dsimp ; rw [c.condition] ; simp
+        · dsimp; rw [c.condition]; simp
         · simp }
 #align category_theory.limits.multicofork.of_sigma_cofork CategoryTheory.Limits.Multicofork.ofSigmaCofork
 

--- a/Mathlib/CategoryTheory/Monoidal/CommMon_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/CommMon_.lean
@@ -154,7 +154,7 @@ def mapCommMonFunctor : LaxBraidedFunctor C D ⥤ CommMon_ C ⥤ CommMon_ D wher
   obj := mapCommMon
   map α :=
     { app := fun A => { hom := α.app A.X }
-      naturality := by intros ; ext ; simp }
+      naturality := by intros; ext; simp }
 set_option linter.uppercaseLean3 false in
 #align category_theory.lax_braided_functor.map_CommMon_functor CategoryTheory.LaxBraidedFunctor.mapCommMonFunctor
 
@@ -202,7 +202,7 @@ def unitIso :
       LaxBraidedFunctor.mkIso
         (MonoidalNatIso.ofComponents
           (fun _ => F.toLaxMonoidalFunctor.toFunctor.mapIso (eqToIso (by ext)))
-          (by rintro ⟨⟩ ⟨⟩ f ; aesop_cat) (by aesop_cat) (by aesop_cat)))
+          (by rintro ⟨⟩ ⟨⟩ f; aesop_cat) (by aesop_cat) (by aesop_cat)))
 set_option linter.uppercaseLean3 false in
 #align CommMon_.equiv_lax_braided_functor_punit.unit_iso CommMon_.EquivLaxBraidedFunctorPunit.unitIso
 

--- a/Mathlib/CategoryTheory/Monoidal/Free/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Free/Basic.lean
@@ -281,23 +281,23 @@ def projectMap (X Y : F C) : (X ⟶ Y) → (projectObj f X ⟶ projectObj f Y) :
     | refl => rfl
     | symm _ _ _ hfg' => exact hfg'.symm
     | trans _ _  hfg hgh => exact hfg.trans hgh
-    | comp _ _  hf hg => dsimp only [projectMapAux] ; rw [hf, hg]
-    | tensor _ _ hfg hfg' => dsimp only [projectMapAux] ; rw [hfg, hfg']
-    | comp_id => dsimp only [projectMapAux] ; rw [Category.comp_id]
-    | id_comp => dsimp only [projectMapAux] ; rw [Category.id_comp]
-    | assoc => dsimp only [projectMapAux] ; rw [Category.assoc]
-    | tensor_id => dsimp only [projectMapAux] ; rw [MonoidalCategory.tensor_id] ; rfl
-    | tensor_comp => dsimp only [projectMapAux] ; rw [MonoidalCategory.tensor_comp]
-    | α_hom_inv => dsimp only [projectMapAux] ; rw [Iso.hom_inv_id]
-    | α_inv_hom => dsimp only [projectMapAux] ; rw [Iso.inv_hom_id]
+    | comp _ _  hf hg => dsimp only [projectMapAux]; rw [hf, hg]
+    | tensor _ _ hfg hfg' => dsimp only [projectMapAux]; rw [hfg, hfg']
+    | comp_id => dsimp only [projectMapAux]; rw [Category.comp_id]
+    | id_comp => dsimp only [projectMapAux]; rw [Category.id_comp]
+    | assoc => dsimp only [projectMapAux]; rw [Category.assoc]
+    | tensor_id => dsimp only [projectMapAux]; rw [MonoidalCategory.tensor_id]; rfl
+    | tensor_comp => dsimp only [projectMapAux]; rw [MonoidalCategory.tensor_comp]
+    | α_hom_inv => dsimp only [projectMapAux]; rw [Iso.hom_inv_id]
+    | α_inv_hom => dsimp only [projectMapAux]; rw [Iso.inv_hom_id]
     | associator_naturality =>
-        dsimp only [projectMapAux] ; rw [MonoidalCategory.associator_naturality]
-    | ρ_hom_inv => dsimp only [projectMapAux] ; rw [Iso.hom_inv_id]
-    | ρ_inv_hom => dsimp only [projectMapAux] ; rw [Iso.inv_hom_id]
+        dsimp only [projectMapAux]; rw [MonoidalCategory.associator_naturality]
+    | ρ_hom_inv => dsimp only [projectMapAux]; rw [Iso.hom_inv_id]
+    | ρ_inv_hom => dsimp only [projectMapAux]; rw [Iso.inv_hom_id]
     | ρ_naturality =>
-        dsimp only [projectMapAux, projectObj] ; rw [MonoidalCategory.rightUnitor_naturality]
-    | l_hom_inv => dsimp only [projectMapAux] ; rw [Iso.hom_inv_id]
-    | l_inv_hom => dsimp only [projectMapAux] ; rw [Iso.inv_hom_id]
+        dsimp only [projectMapAux, projectObj]; rw [MonoidalCategory.rightUnitor_naturality]
+    | l_hom_inv => dsimp only [projectMapAux]; rw [Iso.hom_inv_id]
+    | l_inv_hom => dsimp only [projectMapAux]; rw [Iso.inv_hom_id]
     | l_naturality =>
         dsimp only [projectMapAux, projectObj]
         exact MonoidalCategory.leftUnitor_naturality _
@@ -319,7 +319,7 @@ def project : MonoidalFunctor (F C) D where
   -- Porting note: `map_comp` and `μ_natural` were proved in mathlib3 by tidy, using induction.
   -- We probably don't expect `aesop_cat` to handle this yet, see https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Aesop.20and.20cases
   -- In any case I don't understand why we need to specify `using Quotient.recOn`.
-  map_comp := by rintro _ _ _ ⟨_⟩ ⟨_⟩ ; rfl
+  map_comp := by rintro _ _ _ ⟨_⟩ ⟨_⟩; rfl
   ε := 𝟙 _
   μ X Y := 𝟙 _
   μ_natural := @fun _ _ _ _ f g => by

--- a/Mathlib/CategoryTheory/Monoidal/Free/Coherence.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Free/Coherence.lean
@@ -243,7 +243,7 @@ def normalizeIso : tensorFunc C ≅ normalize' C :=
   NatIso.ofComponents (normalizeIsoAux C)
     (by -- porting note: the proof has been mostly rewritten
       rintro X Y f
-      induction' f using Quotient.recOn with f ; swap ; rfl
+      induction' f using Quotient.recOn with f; swap; rfl
       induction' f with _ X₁ X₂ X₃ _ _ _ _ _ _ _ _ _ _ _ _ h₁ h₂ X₁ X₂ Y₁ Y₂ f g h₁ h₂
       · simp only [mk_id, Functor.map_id, Category.comp_id, Category.id_comp]
       · ext n

--- a/Mathlib/CategoryTheory/Monoidal/NaturalTransformation.lean
+++ b/Mathlib/CategoryTheory/Monoidal/NaturalTransformation.lean
@@ -211,7 +211,7 @@ def monoidalUnit (F : MonoidalFunctor C D) [IsEquivalence F.toFunctor] :
 
 instance (F : MonoidalFunctor C D) [IsEquivalence F.toFunctor] : IsIso (monoidalUnit F) :=
   haveI : ∀ X : C, IsIso ((monoidalUnit F).toNatTrans.app X) := by
-    dsimp ; infer_instance
+    dsimp; infer_instance
   MonoidalNatIso.isIso_of_isIso_app _
 
 /-- The counit of a monoidal equivalence can be upgraded to a monoidal natural transformation. -/
@@ -244,7 +244,7 @@ def monoidalCounit (F : MonoidalFunctor C D) [IsEquivalence F.toFunctor] :
 
 instance (F : MonoidalFunctor C D) [IsEquivalence F.toFunctor] : IsIso (monoidalCounit F) :=
   haveI : ∀ X : D, IsIso ((monoidalCounit F).toNatTrans.app X) :=
-    by dsimp ; infer_instance
+    by dsimp; infer_instance
   MonoidalNatIso.isIso_of_isIso_app _
 
 end

--- a/Mathlib/CategoryTheory/Monoidal/Subcategory.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Subcategory.lean
@@ -58,7 +58,7 @@ instance fullMonoidalSubcategory : MonoidalCategory (FullSubcategory P) where
   tensorObj X Y := ⟨X.1 ⊗ Y.1, prop_tensor X.2 Y.2⟩
   tensorHom := @fun X₁ Y₁ X₂ Y₂ f g => by
     change X₁.1 ⊗ X₂.1 ⟶ Y₁.1 ⊗ Y₂.1
-    change X₁.1 ⟶ Y₁.1 at f ; change X₂.1 ⟶ Y₂.1 at g ; exact f ⊗ g
+    change X₁.1 ⟶ Y₁.1 at f; change X₂.1 ⟶ Y₂.1 at g; exact f ⊗ g
   tensorUnit' := ⟨𝟙_ C, prop_id⟩
   associator X Y Z :=
     ⟨(α_ X.1 Y.1 Z.1).hom, (α_ X.1 Y.1 Z.1).inv, hom_inv_id (α_ X.1 Y.1 Z.1),

--- a/Mathlib/CategoryTheory/Preadditive/Mat.lean
+++ b/Mathlib/CategoryTheory/Preadditive/Mat.lean
@@ -230,14 +230,14 @@ instance hasFiniteBiproducts : HasFiniteBiproducts (Mat_ C)
             rintro ⟨i', j'⟩
             rw [Finset.sum_apply, Finset.sum_apply]
             dsimp
-            rw [Finset.sum_eq_single i] ; rotate_left
+            rw [Finset.sum_eq_single i]; rotate_left
             · intro b _ hb
               apply Finset.sum_eq_zero
               intro x _
               rw [dif_neg hb.symm, zero_comp]
             · intro hi
               simp at hi
-            rw [Finset.sum_eq_single j] ; rotate_left
+            rw [Finset.sum_eq_single j]; rotate_left
             · intro b _ hb
               rw [dif_pos rfl, dif_neg, zero_comp]
               simp only
@@ -342,7 +342,7 @@ def isoBiproductEmbedding (M : Mat_ C) : M ≅ ⨁ fun i => (embedding C).obj (M
     simp only [biproduct.lift_desc]
     funext i j
     dsimp [id_def]
-    rw [Finset.sum_apply, Finset.sum_apply, Finset.sum_eq_single i] ; rotate_left
+    rw [Finset.sum_apply, Finset.sum_apply, Finset.sum_eq_single i]; rotate_left
     · intro b _ hb
       dsimp
       simp only [Finset.sum_const, Finset.card_singleton, one_smul]

--- a/Mathlib/CategoryTheory/Preadditive/Yoneda/Basic.lean
+++ b/Mathlib/CategoryTheory/Preadditive/Yoneda/Basic.lean
@@ -64,8 +64,8 @@ def preadditiveYoneda : C ⥤ Cᵒᵖ ⥤ AddCommGroupCat.{v} where
           map_zero' := Limits.zero_comp
           map_add' := fun g g' => add_comp _ _ _ _ _ _ }
       naturality := fun X X' g => AddCommGroupCat.ext fun x => Category.assoc _ _ _ }
-  map_id _ := by ext ; dsimp ; simp
-  map_comp f g := by ext ; dsimp ; simp
+  map_id _ := by ext; dsimp; simp
+  map_comp f g := by ext; dsimp; simp
 #align category_theory.preadditive_yoneda CategoryTheory.preadditiveYoneda
 
 /-- The Yoneda embedding for preadditive categories sends an object `X` to the copresheaf sending an
@@ -94,8 +94,8 @@ def preadditiveCoyoneda : Cᵒᵖ ⥤ C ⥤ AddCommGroupCat.{v} where
           map_add' := fun g g' => comp_add _ _ _ _ _ _ }
       naturality := fun Y Y' g =>
         AddCommGroupCat.ext fun x => Eq.symm <| Category.assoc _ _ _ }
-  map_id _ := by ext ; dsimp ; simp
-  map_comp f g := by ext ; dsimp ; simp
+  map_id _ := by ext; dsimp; simp
+  map_comp f g := by ext; dsimp; simp
 #align category_theory.preadditive_coyoneda CategoryTheory.preadditiveCoyoneda
 
 instance additive_yonedaObj (X : C) : Functor.Additive (preadditiveYonedaObj X) where

--- a/Mathlib/CategoryTheory/Sites/Canonical.lean
+++ b/Mathlib/CategoryTheory/Sites/Canonical.lean
@@ -101,7 +101,7 @@ theorem isSheafFor_bind (P : Cᵒᵖ ⥤ Type v) (U : Sieve X) (B : ∀ ⦃Y⦄ 
       simp only [assoc]
     · have h : s _ _ = _ := (ht hf _ hm).symm
       -- porting note: this was done by `simp only [assoc] at`
-      conv_lhs at h => congr ; rw [assoc, assoc]
+      conv_lhs at h => congr; rw [assoc, assoc]
       rw [h]
       simp only [op_comp, assoc, FunctorToTypes.map_comp_apply]
   refine' ⟨hU.amalgamate t hT, _, _⟩

--- a/Mathlib/CategoryTheory/Sites/Coverage.lean
+++ b/Mathlib/CategoryTheory/Sites/Coverage.lean
@@ -273,10 +273,10 @@ it is the infimum of all Grothendieck topologies whose associated coverage conta
 theorem toGrothendieck_eq_sInf (K : Coverage C) : toGrothendieck _ K =
     sInf {J | K ≤ ofGrothendieck _ J } := by
   apply le_antisymm
-  · apply le_sInf ; intro J hJ
+  · apply le_sInf; intro J hJ
     intro X S hS
     induction hS with
-    | of X S hS => apply hJ ; assumption
+    | of X S hS => apply hJ; assumption
     | top => apply J.top_mem
     | transitive X R S _ _ H1 H2 => exact J.transitive H1 _ H2
   · apply sInf_le
@@ -314,11 +314,11 @@ theorem isSheaf_coverage (K : Coverage C) (P : Cᵒᵖ ⥤ Type w) :
       · intro Z g hg
         obtain ⟨W, i, e, h1, h2⟩ := hT2 hg
         exact ⟨Z, 𝟙 _, g, ⟨W, i, e, h1, h2⟩, by simp⟩
-      · apply H ; assumption
+      · apply H; assumption
       · intro Z g _
         obtain ⟨R, hR1, hR2⟩ := K.pullback g _ hT1
         refine ⟨R, (H _ hR1).isSeparatedFor, hR2⟩
-    | top => intros ; simpa using Presieve.isSheafFor_top_sieve _
+    | top => intros; simpa using Presieve.isSheafFor_top_sieve _
     | transitive X R S _ _ H1 H2 =>
       intro Y f
       simp only [← Presieve.isSeparatedFor_and_exists_isAmalgamation_iff_isSheafFor] at *
@@ -348,17 +348,17 @@ theorem isSheaf_coverage (K : Coverage C) (P : Cᵒᵖ ⥤ Type w) :
         intro ZZ gg hgg
         simp only [← types_comp_apply]
         rw [← P.map_comp, ← P.map_comp, ← op_comp, ← op_comp, hz, hz]
-        · dsimp ; congr 1 ; simp only [Category.assoc, h]
+        · dsimp; congr 1; simp only [Category.assoc, h]
         · simpa [reassoc_of% h] using hgg
         · simpa using hgg
       obtain ⟨t, ht⟩ := H1' f q hq
       refine ⟨t, fun Z g hg => ?_⟩
       refine (H1 (g ≫ f)).ext (fun ZZ gg hgg => ?_)
       rw [← types_comp_apply _ (P.map gg.op), ← P.map_comp, ← op_comp, ht]
-      swap ; simpa using hgg
+      swap; simpa using hgg
       refine (H2 hgg (𝟙 _)).ext (fun ZZZ ggg hggg => ?_)
       rw [← types_comp_apply _ (P.map ggg.op), ← P.map_comp, ← op_comp, hz]
-      swap ; simpa using hggg
+      swap; simpa using hggg
       refine (H2 hgg ggg).ext (fun ZZZZ gggg _ => ?_)
       rw [← types_comp_apply _ (P.map gggg.op), ← P.map_comp, ← op_comp]
       apply hx

--- a/Mathlib/CategoryTheory/Sites/EffectiveEpimorphic.lean
+++ b/Mathlib/CategoryTheory/Sites/EffectiveEpimorphic.lean
@@ -178,7 +178,7 @@ def effectiveEpiStructOfIsColimit {X Y : C} (f : Y ⟶ X)
         app := fun ⟨T,hT⟩ => hT.choose ≫ e
         naturality := by
           rintro ⟨A,hA⟩ ⟨B,hB⟩ (q : A ⟶ B)
-          dsimp ; simp only [← Category.assoc, Category.comp_id]
+          dsimp; simp only [← Category.assoc, Category.comp_id]
           apply h
           rw [Category.assoc, hB.choose_spec, hA.choose_spec, Over.w] } }
   { desc := fun {W} e h => Hf.desc (aux e h)
@@ -186,7 +186,7 @@ def effectiveEpiStructOfIsColimit {X Y : C} (f : Y ⟶ X)
       intro W e h
       dsimp
       have := Hf.fac (aux e h) ⟨Over.mk f, 𝟙 _, by simp⟩
-      dsimp at this ; rw [this] ; clear this
+      dsimp at this; rw [this]; clear this
       nth_rewrite 2 [← Category.id_comp e]
       apply h
       generalize_proofs hh
@@ -327,7 +327,7 @@ lemma EffectiveEpiFamily.hom_ext {B W : C} {α : Type _} (X : α → C) (π : (a
     m₁ = m₂ := by
   have : m₂ = EffectiveEpiFamily.desc X π (fun a => π a ≫ m₂)
       (fun a₁ a₂ g₁ g₂ h => by simp only [← Category.assoc, h]) := by
-    apply EffectiveEpiFamily.uniq ; intro ; rfl
+    apply EffectiveEpiFamily.uniq; intro; rfl
   rw [this]
   exact EffectiveEpiFamily.uniq _ _ _ _ _ h
 
@@ -373,7 +373,7 @@ def isColimitOfEffectiveEpiFamilyStruct {B : C} {α : Type _}
       rw [S.w]
       rfl
     uniq := by
-      intro S m hm ; dsimp
+      intro S m hm; dsimp
       apply H.uniq
       intro a
       exact hm ⟨Over.mk (π a), a, 𝟙 _, by simp⟩ }
@@ -397,8 +397,8 @@ def effectiveEpiFamilyStructOfIsColimit {B : C} {α : Type _}
         app := fun ⟨T,hT⟩ => hT.choose_spec.choose ≫ e hT.choose
         naturality := by
           intro ⟨A,a,(g₁ : A.left ⟶ _),ha⟩ ⟨B,b,(g₂ : B.left ⟶ _),hb⟩ (q : A ⟶ B)
-          dsimp ; rw [Category.comp_id, ← Category.assoc]
-          apply h ; rw [Category.assoc]
+          dsimp; rw [Category.comp_id, ← Category.assoc]
+          apply h; rw [Category.assoc]
           generalize_proofs h1 h2 h3 h4
           rw [h2.choose_spec, h4.choose_spec, Over.w] } }
   { desc := fun {W} e h => H.desc (aux e h)
@@ -406,7 +406,7 @@ def effectiveEpiFamilyStructOfIsColimit {B : C} {α : Type _}
       intro W e h a
       dsimp
       have := H.fac (aux e h) ⟨Over.mk (π a), a, 𝟙 _, by simp⟩
-      dsimp at this ; rw [this] ; clear this
+      dsimp at this; rw [this]; clear this
       conv_rhs => rw [← Category.id_comp (e a)]
       apply h
       generalize_proofs h1 h2

--- a/Mathlib/CategoryTheory/Sites/Plus.lean
+++ b/Mathlib/CategoryTheory/Sites/Plus.lean
@@ -57,7 +57,7 @@ def diagramPullback {X Y : C} (f : X ⟶ Y) : J.diagram P Y ⟶ (J.pullback f).o
   app S :=
     Multiequalizer.lift _ _ (fun I => Multiequalizer.ι (S.unop.index P) I.base) fun I =>
       Multiequalizer.condition (S.unop.index P) I.base
-  naturality S T f := Multiequalizer.hom_ext _ _ _ (fun I => by dsimp ; simp ; rfl)
+  naturality S T f := Multiequalizer.hom_ext _ _ _ (fun I => by dsimp; simp; rfl)
 #align category_theory.grothendieck_topology.diagram_pullback CategoryTheory.GrothendieckTopology.diagramPullback
 
 /-- A natural transformation `P ⟶ Q` induces a natural transformation
@@ -164,7 +164,7 @@ def plusMap {P Q : Cᵒᵖ ⥤ D} (η : P ⟶ Q) : J.plusObj P ⟶ J.plusObj Q w
       ι_colimMap_assoc, Category.assoc]
     simp_rw [← Category.assoc]
     congr 1
-    exact Multiequalizer.hom_ext _ _ _ (fun I => by dsimp ; simp)
+    exact Multiequalizer.hom_ext _ _ _ (fun I => by dsimp; simp)
 #align category_theory.grothendieck_topology.plus_map CategoryTheory.GrothendieckTopology.plusMap
 
 @[simp]
@@ -231,7 +231,7 @@ theorem toPlus_naturality {P Q : Cᵒᵖ ⥤ D} (η : P ⟶ Q) :
   simp only [ι_colimMap, Category.assoc]
   simp_rw [← Category.assoc]
   congr 1
-  exact Multiequalizer.hom_ext _ _ _ (fun I => by dsimp ; simp)
+  exact Multiequalizer.hom_ext _ _ _ (fun I => by dsimp; simp)
 #align category_theory.grothendieck_topology.to_plus_naturality CategoryTheory.GrothendieckTopology.toPlus_naturality
 
 variable (D)
@@ -288,7 +288,7 @@ theorem isIso_toPlus_of_isSheaf (hP : Presheaf.IsSheaf J P) : IsIso (J.toPlus P)
   · apply isIso_ι_of_isInitial (initialOpOfTerminal isTerminalTop)
   intro S T e
   have : S.unop.toMultiequalizer P ≫ (J.diagram P X.unop).map e = T.unop.toMultiequalizer P :=
-    Multiequalizer.hom_ext _ _ _ (fun II => by dsimp ; simp)
+    Multiequalizer.hom_ext _ _ _ (fun II => by dsimp; simp)
   have :
     (J.diagram P X.unop).map e = inv (S.unop.toMultiequalizer P) ≫ T.unop.toMultiequalizer P := by
     simp [← this]

--- a/Mathlib/CategoryTheory/StructuredArrow.lean
+++ b/Mathlib/CategoryTheory/StructuredArrow.lean
@@ -83,7 +83,7 @@ theorem mk_hom_eq_self (f : S ⟶ T.obj Y) : (mk f).hom = f :=
 
 @[reassoc (attr := simp)]
 theorem w {A B : StructuredArrow S T} (f : A ⟶ B) : A.hom ≫ T.map f.right = B.hom := by
-  have := f.w ; aesop_cat
+  have := f.w; aesop_cat
 #align category_theory.structured_arrow.w CategoryTheory.StructuredArrow.w
 
 @[simp]
@@ -577,12 +577,12 @@ def structuredArrowOpEquivalence (F : C ⥤ D) (d : D) :
       (fun X => (StructuredArrow.isoMk (Iso.refl _)).op)
       fun {X Y} f => Quiver.Hom.unop_inj <| by
         apply CommaMorphism.ext <;>
-          dsimp [StructuredArrow.isoMk, Comma.isoMk,StructuredArrow.homMk] ; simp )
+          dsimp [StructuredArrow.isoMk, Comma.isoMk,StructuredArrow.homMk]; simp )
     (NatIso.ofComponents
       (fun X => CostructuredArrow.isoMk (Iso.refl _))
       fun {X Y} f => by
         apply CommaMorphism.ext <;>
-          dsimp [CostructuredArrow.isoMk, Comma.isoMk, CostructuredArrow.homMk] ; simp )
+          dsimp [CostructuredArrow.isoMk, Comma.isoMk, CostructuredArrow.homMk]; simp )
 #align category_theory.structured_arrow_op_equivalence CategoryTheory.structuredArrowOpEquivalence
 
 /-- For a functor `F : C ⥤ D` and an object `d : D`, the category of costructured arrows
@@ -597,12 +597,12 @@ def costructuredArrowOpEquivalence (F : C ⥤ D) (d : D) :
       (fun X => (CostructuredArrow.isoMk (Iso.refl _)).op)
       fun {X Y} f => Quiver.Hom.unop_inj <| by
         apply CommaMorphism.ext <;>
-          dsimp [CostructuredArrow.isoMk, CostructuredArrow.homMk, Comma.isoMk] ; simp )
+          dsimp [CostructuredArrow.isoMk, CostructuredArrow.homMk, Comma.isoMk]; simp )
     (NatIso.ofComponents
       (fun X => StructuredArrow.isoMk (Iso.refl _))
       fun {X Y} f => by
         apply CommaMorphism.ext <;>
-          dsimp [StructuredArrow.isoMk, StructuredArrow.homMk, Comma.isoMk] ; simp )
+          dsimp [StructuredArrow.isoMk, StructuredArrow.homMk, Comma.isoMk]; simp )
 #align category_theory.costructured_arrow_op_equivalence CategoryTheory.costructuredArrowOpEquivalence
 
 end CategoryTheory

--- a/Mathlib/Combinatorics/Composition.lean
+++ b/Mathlib/Combinatorics/Composition.lean
@@ -452,7 +452,7 @@ def blocksFinEquiv : (Σi : Fin c.length, Fin (c.blocksFun i)) ≃ Fin n
   left_inv x := by
     rcases x with ⟨i, y⟩
     dsimp
-    congr ; · exact c.index_embedding _ _
+    congr; · exact c.index_embedding _ _
     rw [Fin.heq_ext_iff]
     · exact c.invEmbedding_comp _ _
     · rw [c.index_embedding]
@@ -695,7 +695,7 @@ theorem map_length_splitWrtCompositionAux {ns : List ℕ} :
   induction' ns with n ns IH <;> intro l h <;> simp at h
   · simp
   have := le_trans (Nat.le_add_right _ _) h
-  simp only [splitWrtCompositionAux_cons, this] ; dsimp
+  simp only [splitWrtCompositionAux_cons, this]; dsimp
   rw [length_take, IH] <;> simp [length_drop]
   · assumption
   · exact le_tsub_of_add_le_left h
@@ -760,7 +760,7 @@ theorem join_splitWrtCompositionAux {ns : List ℕ} :
     ∀ {l : List α}, ns.sum = l.length → (l.splitWrtCompositionAux ns).join = l := by
   induction' ns with n ns IH <;> intro l h <;> simp at h
   · exact (length_eq_zero.1 h.symm).symm
-  simp only [splitWrtCompositionAux_cons] ; dsimp
+  simp only [splitWrtCompositionAux_cons]; dsimp
   rw [IH]
   · simp
   · rw [length_drop, ← h, add_tsub_cancel_left]

--- a/Mathlib/Computability/Partrec.lean
+++ b/Mathlib/Computability/Partrec.lean
@@ -475,7 +475,7 @@ theorem nat_rec {f : α → ℕ} {g : α →. σ} {h : α → ℕ × σ →. σ}
     cases' e : decode (α := α) n with a <;> simp [e]
     induction' f a with m IH <;> simp
     rw [IH, Part.bind_map]
-    congr ; funext s
+    congr; funext s
     simp [encodek]
 #align partrec.nat_elim Partrec.nat_rec
 
@@ -569,7 +569,7 @@ theorem rfind {p : α → ℕ →. Bool} (hp : Partrec₂ p) : Partrec fun a => 
         hp.map ((Primrec.dom_bool fun b => cond b 0 1).comp Primrec.snd).to₂.to_comp).of_eq
     fun n => by
     cases' e : decode (α := α) n with a <;> simp [e, Nat.rfind_zero_none, map_id']
-    congr ; funext n
+    congr; funext n
     simp [Part.map_map, (· ∘ ·)]
     refine map_id' (fun b => ?_) _
     cases b <;> rfl

--- a/Mathlib/Computability/Primrec.lean
+++ b/Mathlib/Computability/Primrec.lean
@@ -1499,7 +1499,7 @@ theorem sqrt : @Primrec' 1 fun v => v.head.sqrt := by
     have x1 : @Primrec' 3 fun v => v.head.succ := succ.comp₁ _ head
     have y1 : @Primrec' 3 fun v => v.tail.head.succ := succ.comp₁ _ (tail head)
     exact if_lt x1 (mul.comp₂ _ y1 y1) (tail head) y1
-  introv ; symm
+  introv; symm
   induction' n with n IH; · simp
   dsimp; rw [IH]; split_ifs with h
   · exact le_antisymm (Nat.sqrt_le_sqrt (Nat.le_succ _)) (Nat.lt_succ_iff.1 <| Nat.sqrt_lt.2 h)

--- a/Mathlib/Computability/RegularExpressions.lean
+++ b/Mathlib/Computability/RegularExpressions.lean
@@ -323,7 +323,7 @@ theorem star_rmatch_iff (P : RegularExpression α) :
             simp only [ne_eq, not_false_iff, true_and, rmatch]
             exact ht
           case tail ht' => exact helem t' ht'
-    · rintro ⟨S, hsum, helem⟩ ; dsimp
+    · rintro ⟨S, hsum, helem⟩; dsimp
       cases' x with a x
       · rfl
       · rw [rmatch, deriv, mul_rmatch_iff]

--- a/Mathlib/Computability/TMToPartrec.lean
+++ b/Mathlib/Computability/TMToPartrec.lean
@@ -609,7 +609,7 @@ def Code.Ok (c : Code) :=
 
 theorem Code.Ok.zero {c} (h : Code.Ok c) {v} :
     Turing.eval step (stepNormal c Cont.halt v) = Cfg.halt <$> Code.eval c v := by
-  rw [h, ← bind_pure_comp]; congr ; funext v
+  rw [h, ← bind_pure_comp]; congr; funext v
   exact Part.eq_some_iff.2 (mem_eval.2 ⟨ReflTransGen.single rfl, rfl⟩)
 #align turing.to_partrec.code.ok.zero Turing.ToPartrec.Code.Ok.zero
 
@@ -703,13 +703,13 @@ theorem code_is_ok (c) : Code.Ok c := by
   iterate 3 simp only [Code.eval, pure_bind]
   case cons f fs IHf IHfs =>
     rw [Code.eval, IHf]
-    simp only [bind_assoc, Cont.eval, pure_bind]; congr ; funext v
+    simp only [bind_assoc, Cont.eval, pure_bind]; congr; funext v
     rw [reaches_eval]; swap; exact ReflTransGen.single rfl
-    rw [stepRet, IHfs]; congr ; funext v'
+    rw [stepRet, IHfs]; congr; funext v'
     refine' Eq.trans _ (Eq.symm _) <;> try exact reaches_eval (ReflTransGen.single rfl)
   case comp f g IHf IHg =>
     rw [Code.eval, IHg]
-    simp only [bind_assoc, Cont.eval, pure_bind]; congr ; funext v
+    simp only [bind_assoc, Cont.eval, pure_bind]; congr; funext v
     rw [reaches_eval]; swap; exact ReflTransGen.single rfl
     rw [stepRet, IHf]
   case case f g IHf IHg =>
@@ -729,20 +729,20 @@ theorem stepRet_eval {k v} : eval step (stepRet k v) = Cfg.halt <$> k.eval v := 
     exact Part.eq_some_iff.2 (mem_eval.2 ⟨ReflTransGen.refl, rfl⟩)
   case cons₁ fs as k IH =>
     rw [Cont.eval, stepRet, code_is_ok]
-    simp only [← bind_pure_comp, bind_assoc]; congr ; funext v'
+    simp only [← bind_pure_comp, bind_assoc]; congr; funext v'
     rw [reaches_eval]; swap; exact ReflTransGen.single rfl
     rw [stepRet, IH, bind_pure_comp]
   case cons₂ ns k IH => rw [Cont.eval, stepRet]; exact IH
   case comp f k IH =>
     rw [Cont.eval, stepRet, code_is_ok]
-    simp only [← bind_pure_comp, bind_assoc]; congr ; funext v'
+    simp only [← bind_pure_comp, bind_assoc]; congr; funext v'
     rw [reaches_eval]; swap; exact ReflTransGen.single rfl
     rw [IH, bind_pure_comp]
   case fix f k IH =>
     rw [Cont.eval, stepRet]; simp only [bind_pure_comp]
     split_ifs; · exact IH
     simp only [← bind_pure_comp, bind_assoc, cont_eval_fix (code_is_ok _)]
-    congr ; funext; rw [bind_pure_comp, ← IH]
+    congr; funext; rw [bind_pure_comp, ← IH]
     exact reaches_eval (ReflTransGen.single rfl)
 #align turing.to_partrec.step_ret_eval Turing.ToPartrec.stepRet_eval
 
@@ -1360,7 +1360,7 @@ theorem move_ok {p k₁ k₂ q s L₁ o L₂} {S : K' → List Γ'} (h₁ : k₁
       rfl
     refine' TransGen.head' rfl _
     simp
-    revert e ; cases' S k₁ with a Sk <;> intro e
+    revert e; cases' S k₁ with a Sk <;> intro e
     · cases e
       rfl
     simp only [splitAtPred, Option.elim, List.head?, List.tail_cons, Option.iget_some] at e ⊢
@@ -1984,7 +1984,7 @@ theorem trStmts₁_supports' {S q K} (H₁ : (q : Λ').Supports S) (H₂ : trStm
 theorem trNormal_supports {S c k} (Hk : codeSupp c k ⊆ S) : (trNormal c k).Supports S := by
   induction c generalizing k <;> simp [Λ'.Supports, head]
   case zero' => exact Finset.union_subset_right Hk
-  case succ => intro ; split_ifs <;> exact Finset.union_subset_right Hk
+  case succ => intro; split_ifs <;> exact Finset.union_subset_right Hk
   case tail => exact Finset.union_subset_right Hk
   case cons f fs IHf _ =>
     apply IHf

--- a/Mathlib/Computability/TuringMachine.lean
+++ b/Mathlib/Computability/TuringMachine.lean
@@ -2384,7 +2384,7 @@ theorem addBottom_modifyNth (f : (∀ k, Option (Γ k)) → ∀ k, Option (Γ k)
     (addBottom L).modifyNth (fun a ↦ (a.1, f a.2)) n = addBottom (L.modifyNth f n) := by
   cases n <;>
     simp only [addBottom, ListBlank.head_cons, ListBlank.modifyNth, ListBlank.tail_cons]
-  congr ; symm; apply ListBlank.map_modifyNth; intro ; rfl
+  congr; symm; apply ListBlank.map_modifyNth; intro; rfl
 #align turing.TM2to1.add_bottom_modify_nth Turing.TM2to1.addBottom_modifyNth
 
 theorem addBottom_nth_snd (L : ListBlank (∀ k, Option (Γ k))) (n : ℕ) :

--- a/Mathlib/Control/LawfulFix.lean
+++ b/Mathlib/Control/LawfulFix.lean
@@ -60,7 +60,7 @@ variable (f : ((a : _) → Part <| β a) →o (a : _) → Part <| β a)
 theorem approx_mono' {i : ℕ} : Fix.approx f i ≤ Fix.approx f (succ i) := by
   induction i with
   | zero => dsimp [approx]; apply @bot_le _ _ _ (f ⊥)
-  | succ _ i_ih => intro ; apply f.monotone; apply i_ih
+  | succ _ i_ih => intro; apply f.monotone; apply i_ih
 #align part.fix.approx_mono' Part.Fix.approx_mono'
 
 theorem approx_mono ⦃i j : ℕ⦄ (hij : i ≤ j) : approx f i ≤ approx f j := by
@@ -170,7 +170,7 @@ theorem fix_le {X : (a : _) → Part <| β a} (hX : f X ≤ X) : Part.fix f ≤ 
   intro i
   induction i with
   | zero => dsimp [Fix.approx]; apply bot_le
-  | succ _ i_ih => trans f X; apply f.monotone i_ih ; apply hX
+  | succ _ i_ih => trans f X; apply f.monotone i_ih; apply hX
 #align part.fix_le Part.fix_le
 
 variable {f} (hc : Continuous f)

--- a/Mathlib/Control/Traversable/Lemmas.lean
+++ b/Mathlib/Control/Traversable/Lemmas.lean
@@ -81,14 +81,14 @@ theorem map_eq_traverse_id : map (f := t) f = traverse (m := Id) (pure ∘ f) :=
 theorem map_traverse (x : t α) : map f <$> traverse g x = traverse (map f ∘ g) x := by
   rw [map_eq_traverse_id f]
   refine' (comp_traverse (pure ∘ f) g x).symm.trans _
-  congr ; apply Comp.applicative_comp_id
+  congr; apply Comp.applicative_comp_id
 #align traversable.map_traverse Traversable.map_traverse
 
 theorem traverse_map (f : β → F γ) (g : α → β) (x : t α) :
     traverse f (g <$> x) = traverse (f ∘ g) x := by
   rw [@map_eq_traverse_id t _ _ _ _ g]
   refine' (comp_traverse (G := Id) f (pure ∘ g) x).symm.trans _
-  congr ; apply Comp.applicative_id_comp
+  congr; apply Comp.applicative_id_comp
 #align traversable.traverse_map Traversable.traverse_map
 
 theorem pure_traverse (x : t α) : traverse pure x = (pure x : F (t α)) := by

--- a/Mathlib/Data/Analysis/Filter.lean
+++ b/Mathlib/Data/Analysis/Filter.lean
@@ -75,7 +75,7 @@ def ofEquiv (E : σ ≃ τ) : CFilter α σ → CFilter α τ
 
 @[simp]
 theorem ofEquiv_val (E : σ ≃ τ) (F : CFilter α σ) (a : τ) : F.ofEquiv E a = F (E.symm a) := by
-  cases F ; rfl
+  cases F; rfl
 #align cfilter.of_equiv_val CFilter.ofEquiv_val
 
 end
@@ -113,7 +113,7 @@ protected def CFilter.toRealizer (F : CFilter (Set α) σ) : F.toFilter.Realizer
 namespace Filter.Realizer
 
 theorem mem_sets {f : Filter α} (F : f.Realizer) {a : Set α} : a ∈ f ↔ ∃ b, F.F b ⊆ a := by
-  cases F ; subst f ; rfl
+  cases F; subst f; rfl
 #align filter.realizer.mem_sets Filter.Realizer.mem_sets
 
 /-- Transfer a realizer along an equality of filter. This has better definitional equalities than
@@ -242,7 +242,7 @@ protected def comap (m : α → β) {f : Filter β} (F : f.Realizer) : (comap m 
       inf_le_left := fun _ _ ↦ preimage_mono (F.F.inf_le_left _ _)
       inf_le_right := fun _ _ ↦ preimage_mono (F.F.inf_le_right _ _) },
     filter_eq <| Set.ext fun _ ↦ by
-      cases F ; subst f
+      cases F; subst f
       exact ⟨fun ⟨s, h⟩ ↦ ⟨_, ⟨s, Subset.refl _⟩, h⟩,
         fun ⟨_, ⟨s, h⟩, h₂⟩ ↦ ⟨s, Subset.trans (preimage_mono h) h₂⟩⟩⟩
 #align filter.realizer.comap Filter.Realizer.comap
@@ -255,7 +255,7 @@ protected def sup {f g : Filter α} (F : f.Realizer) (G : g.Realizer) : (f ⊔ g
       inf := fun ⟨a, a'⟩ ⟨b, b'⟩ ↦ (F.F.inf a b, G.F.inf a' b')
       inf_le_left := fun _ _ ↦ union_subset_union (F.F.inf_le_left _ _) (G.F.inf_le_left _ _)
       inf_le_right := fun _ _ ↦ union_subset_union (F.F.inf_le_right _ _) (G.F.inf_le_right _ _) },
-    filter_eq <| Set.ext fun _ ↦ by cases F ; cases G ; substs f g ; simp [CFilter.toFilter]⟩
+    filter_eq <| Set.ext fun _ ↦ by cases F; cases G; substs f g; simp [CFilter.toFilter]⟩
 #align filter.realizer.sup Filter.Realizer.sup
 
 /-- Construct a realizer for the inf of two filters -/
@@ -307,7 +307,7 @@ protected def bind {f : Filter α} {m : α → Filter β} (F : f.Realizer) (G : 
         simp only [mem_iUnion, forall_exists_index]
         exact fun i h₁ h₂ ↦ ⟨i, F.F.inf_le_right _ _ h₁, (G i).F.inf_le_right _ _ h₂⟩ },
     filter_eq <| Set.ext fun _ ↦ by
-      cases' F with _ F _ ; subst f
+      cases' F with _ F _; subst f
       simp only [CFilter.toFilter, iUnion_subset_iff, Sigma.exists, Filter.mem_sets, mem_bind]
       exact
         ⟨fun ⟨s, f, h⟩ ↦

--- a/Mathlib/Data/Analysis/Topology.lean
+++ b/Mathlib/Data/Analysis/Topology.lean
@@ -148,8 +148,8 @@ theorem isClosed_iff [TopologicalSpace α] (F : Realizer α) {s : Set α} :
     F.isOpen_iff.trans <|
       forall_congr' fun a ↦
         show (a ∉ s → ∃ b : F.σ, a ∈ F.F b ∧ ∀ z ∈ F.F b, z ∉ s) ↔ _ by
-          haveI := Classical.propDecidable; rw [not_imp_comm] ;
-            simp [not_exists, not_and, not_forall, and_comm]
+          haveI := Classical.propDecidable; rw [not_imp_comm]
+          simp [not_exists, not_and, not_forall, and_comm]
 #align ctop.realizer.is_closed_iff Ctop.Realizer.isClosed_iff
 
 theorem mem_interior_iff [TopologicalSpace α] (F : Realizer α) {s : Set α} {a : α} :

--- a/Mathlib/Data/Analysis/Topology.lean
+++ b/Mathlib/Data/Analysis/Topology.lean
@@ -80,7 +80,7 @@ def ofEquiv (E : σ ≃ τ) : Ctop α σ → Ctop α τ
 
 @[simp]
 theorem ofEquiv_val (E : σ ≃ τ) (F : Ctop α σ) (a : τ) : F.ofEquiv E a = F (E.symm a) := by
-  cases F ; rfl
+  cases F; rfl
 #align ctop.of_equiv_val Ctop.ofEquiv_val
 
 end
@@ -129,12 +129,12 @@ namespace Ctop.Realizer
 
 protected theorem is_basis [T : TopologicalSpace α] (F : Realizer α) :
     TopologicalSpace.IsTopologicalBasis (Set.range F.F.f) := by
-  have := toTopsp_isTopologicalBasis F.F ; rwa [F.eq] at this
+  have := toTopsp_isTopologicalBasis F.F; rwa [F.eq] at this
 #align ctop.realizer.is_basis Ctop.Realizer.is_basis
 
 protected theorem mem_nhds [T : TopologicalSpace α] (F : Realizer α) {s : Set α} {a : α} :
   s ∈ 𝓝 a ↔ ∃ b, a ∈ F.F b ∧ F.F b ⊆ s := by
-  have := @mem_nhds_toTopsp _ _ F.F s a ; rwa [F.eq] at this
+  have := @mem_nhds_toTopsp _ _ F.F s a; rwa [F.eq] at this
 #align ctop.realizer.mem_nhds Ctop.Realizer.mem_nhds
 
 theorem isOpen_iff [TopologicalSpace α] (F : Realizer α) {s : Set α} :
@@ -148,7 +148,7 @@ theorem isClosed_iff [TopologicalSpace α] (F : Realizer α) {s : Set α} :
     F.isOpen_iff.trans <|
       forall_congr' fun a ↦
         show (a ∉ s → ∃ b : F.σ, a ∈ F.F b ∧ ∀ z ∈ F.F b, z ∉ s) ↔ _ by
-          haveI := Classical.propDecidable ; rw [not_imp_comm] ;
+          haveI := Classical.propDecidable; rw [not_imp_comm] ;
             simp [not_exists, not_and, not_forall, and_comm]
 #align ctop.realizer.is_closed_iff Ctop.Realizer.isClosed_iff
 
@@ -205,7 +205,7 @@ theorem ofEquiv_σ (F : Realizer α) (E : F.σ ≃ τ) : (F.ofEquiv E).σ = τ :
 
 @[simp]
 theorem ofEquiv_F (F : Realizer α) (E : F.σ ≃ τ) (s : τ) : (F.ofEquiv E).F s = F.F (E.symm s) := by
-  delta ofEquiv ; simp
+  delta ofEquiv; simp
 set_option linter.uppercaseLean3 false in
 #align ctop.realizer.of_equiv_F Ctop.Realizer.ofEquiv_F
 
@@ -281,6 +281,6 @@ def Compact.Realizer [TopologicalSpace α] (s : Set α) :=
 
 instance [TopologicalSpace α] : Inhabited (Compact.Realizer (∅ : Set α)) :=
   ⟨fun {f} F x h hF ↦ by
-    suffices : f = ⊥ ; exact absurd this h
+    suffices : f = ⊥; exact absurd this h
     rw [← F.eq, eq_bot_iff]
     exact λ s _ ↦ ⟨x, hF.trans s.empty_subset⟩⟩

--- a/Mathlib/Data/Complex/Basic.lean
+++ b/Mathlib/Data/Complex/Basic.lean
@@ -449,7 +449,7 @@ instance commRing : CommRing ℂ :=
     mul_assoc := by intros; ext <;> simp [mul_assoc] <;> ring
     one_mul := by intros; ext <;> simp [one_mul]
     mul_one := by intros; ext <;> simp [mul_one]
-    mul_comm := by intros; ext <;> simp [mul_comm] ; ring }
+    mul_comm := by intros; ext <;> simp [mul_comm]; ring }
 
 /-- This shortcut instance ensures we do not find `Ring` via the noncomputable `Complex.field`
 instance. -/
@@ -574,7 +574,7 @@ theorem conj_eq_iff_real {z : ℂ} : conj z = z ↔ ∃ r : ℝ, z = r :=
 #align complex.conj_eq_iff_real Complex.conj_eq_iff_real
 
 theorem conj_eq_iff_re {z : ℂ} : conj z = z ↔ (z.re : ℂ) = z :=
-  conj_eq_iff_real.trans ⟨by rintro ⟨r, rfl⟩ ; simp [ofReal'], fun h => ⟨_, h.symm⟩⟩
+  conj_eq_iff_real.trans ⟨by rintro ⟨r, rfl⟩; simp [ofReal'], fun h => ⟨_, h.symm⟩⟩
 #align complex.conj_eq_iff_re Complex.conj_eq_iff_re
 
 theorem conj_eq_iff_im {z : ℂ} : conj z = z ↔ z.im = 0 :=
@@ -682,7 +682,7 @@ theorem normSq_mul (z w : ℂ) : normSq (z * w) = normSq z * normSq w :=
 #align complex.norm_sq_mul Complex.normSq_mul
 
 theorem normSq_add (z w : ℂ) : normSq (z + w) = normSq z + normSq w + 2 * (z * conj w).re := by
-  dsimp [normSq] ; ring
+  dsimp [normSq]; ring
 #align complex.norm_sq_add Complex.normSq_add
 
 theorem re_sq_le_normSq (z : ℂ) : z.re * z.re ≤ normSq z :=
@@ -1331,18 +1331,18 @@ theorem lim_eq_lim_im_add_lim_re (f : CauSeq ℂ Complex.abs) :
 #align complex.lim_eq_lim_im_add_lim_re Complex.lim_eq_lim_im_add_lim_re
 
 theorem lim_re (f : CauSeq ℂ Complex.abs) : lim (cauSeqRe f) = (lim f).re := by
-  rw [lim_eq_lim_im_add_lim_re] ; simp [ofReal']
+  rw [lim_eq_lim_im_add_lim_re]; simp [ofReal']
 #align complex.lim_re Complex.lim_re
 
 theorem lim_im (f : CauSeq ℂ Complex.abs) : lim (cauSeqIm f) = (lim f).im := by
-  rw [lim_eq_lim_im_add_lim_re] ; simp [ofReal']
+  rw [lim_eq_lim_im_add_lim_re]; simp [ofReal']
 #align complex.lim_im Complex.lim_im
 
 theorem isCauSeq_conj (f : CauSeq ℂ Complex.abs) :
   IsCauSeq Complex.abs fun n => conj (f n) := fun ε ε0 =>
   let ⟨i, hi⟩ := f.2 ε ε0
   ⟨i, fun j hj => by
-    rw [← RingHom.map_sub, abs_conj] ; exact hi j hj⟩
+    rw [← RingHom.map_sub, abs_conj]; exact hi j hj⟩
 #align complex.is_cau_seq_conj Complex.isCauSeq_conj
 
 /-- The complex conjugate of a complex Cauchy sequence, as a complex Cauchy sequence. -/
@@ -1352,7 +1352,7 @@ noncomputable def cauSeqConj (f : CauSeq ℂ Complex.abs) : CauSeq ℂ Complex.a
 
 theorem lim_conj (f : CauSeq ℂ Complex.abs) : lim (cauSeqConj f) = conj (lim f) :=
   Complex.ext (by simp [cauSeqConj, (lim_re _).symm, cauSeqRe])
-    (by simp [cauSeqConj, (lim_im _).symm, cauSeqIm, (lim_neg _).symm] ; rfl)
+    (by simp [cauSeqConj, (lim_im _).symm, cauSeqIm, (lim_neg _).symm]; rfl)
 #align complex.lim_conj Complex.lim_conj
 
 /-- The absolute value of a complex Cauchy sequence, as a real Cauchy sequence. -/

--- a/Mathlib/Data/Erased.lean
+++ b/Mathlib/Data/Erased.lean
@@ -65,7 +65,7 @@ theorem out_mk {α} (a : α) : (mk a).out = a := by
 
 @[simp]
 theorem mk_out {α} : ∀ a : Erased α, mk (out a) = a
-  | ⟨s, h⟩ => by simp [mk] ; congr ; exact Classical.choose_spec h
+  | ⟨s, h⟩ => by simp [mk]; congr; exact Classical.choose_spec h
 #align erased.mk_out Erased.mk_out
 
 @[ext]
@@ -159,14 +159,14 @@ theorem map_def {α β} : ((· <$> ·) : (α → β) → Erased α → Erased β
 --Porting note: Old proof `by refine' { .. } <;> intros <;> ext <;> simp`
 protected instance LawfulMonad : LawfulMonad Erased :=
   { Erased.Monad with
-    id_map := by intros ; ext ; simp
-    map_const := by intros ; ext ; simp [Functor.mapConst]
-    pure_bind := by intros ; ext ; simp
-    bind_assoc := by intros ; ext ; simp
-    bind_pure_comp := by intros ; ext ; simp
-    bind_map := by intros ; ext ; simp [Seq.seq]
-    seqLeft_eq := by intros ; ext ; simp [Seq.seq, Functor.mapConst, SeqLeft.seqLeft]
-    seqRight_eq := by intros ; ext ; simp [Seq.seq, Functor.mapConst, SeqRight.seqRight]
-    pure_seq := by intros ; ext ; simp [Seq.seq, Functor.mapConst, SeqRight.seqRight] }
+    id_map := by intros; ext; simp
+    map_const := by intros; ext; simp [Functor.mapConst]
+    pure_bind := by intros; ext; simp
+    bind_assoc := by intros; ext; simp
+    bind_pure_comp := by intros; ext; simp
+    bind_map := by intros; ext; simp [Seq.seq]
+    seqLeft_eq := by intros; ext; simp [Seq.seq, Functor.mapConst, SeqLeft.seqLeft]
+    seqRight_eq := by intros; ext; simp [Seq.seq, Functor.mapConst, SeqRight.seqRight]
+    pure_seq := by intros; ext; simp [Seq.seq, Functor.mapConst, SeqRight.seqRight] }
 
 end Erased

--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -1800,7 +1800,7 @@ termination_by _ => n + 1 - i
 theorem reverse_induction_last {n : ℕ} {C : Fin (n + 1) → Sort _} (h0 : C (Fin.last n))
     (hs : ∀ i : Fin n, C i.succ → C (castSucc i)) :
     (reverseInduction h0 hs (Fin.last n) : C (Fin.last n)) = h0 := by
-  rw [reverseInduction] ; simp
+  rw [reverseInduction]; simp
 #align fin.reverse_induction_last Fin.reverse_induction_last
 
 @[simp]

--- a/Mathlib/Data/Fin/Tuple/Basic.lean
+++ b/Mathlib/Data/Fin/Tuple/Basic.lean
@@ -886,7 +886,7 @@ theorem isSome_find_iff :
 
 /-- `find p` returns `none` if and only if `p i` never holds. -/
 theorem find_eq_none_iff {n : ℕ} {p : Fin n → Prop} [DecidablePred p] :
-    find p = none ↔ ∀ i, ¬p i := by rw [← not_exists, ← isSome_find_iff] ; cases find p <;> simp
+    find p = none ↔ ∀ i, ¬p i := by rw [← not_exists, ← isSome_find_iff]; cases find p <;> simp
 #align fin.find_eq_none_iff Fin.find_eq_none_iff
 
 /-- If `find p` returns `some i`, then `p j` does not hold for `j < i`, i.e., `i` is minimal among

--- a/Mathlib/Data/FinEnum.lean
+++ b/Mathlib/Data/FinEnum.lean
@@ -55,7 +55,7 @@ def ofNodupList [DecidableEq α] (xs : List α) (h : ∀ x : α, x ∈ xs) (h' :
     where
   card := xs.length
   Equiv :=
-    ⟨fun x => ⟨xs.indexOf x, by rw [List.indexOf_lt_length] ; apply h⟩, fun ⟨i, h⟩ =>
+    ⟨fun x => ⟨xs.indexOf x, by rw [List.indexOf_lt_length]; apply h⟩, fun ⟨i, h⟩ =>
       xs.nthLe _ h, fun x => by simp, fun ⟨i, h⟩ => by
       simp [*]⟩
 #align fin_enum.of_nodup_list FinEnum.ofNodupList
@@ -74,17 +74,17 @@ open Function
 
 @[simp]
 theorem mem_toList [FinEnum α] (x : α) : x ∈ toList α := by
-  simp [toList] ; exists Equiv x ; simp
+  simp [toList]; exists Equiv x; simp
 #align fin_enum.mem_to_list FinEnum.mem_toList
 
 @[simp]
 theorem nodup_toList [FinEnum α] : List.Nodup (toList α) := by
-  simp [toList] ; apply List.Nodup.map <;> [apply Equiv.injective; apply List.nodup_finRange]
+  simp [toList]; apply List.Nodup.map <;> [apply Equiv.injective; apply List.nodup_finRange]
 #align fin_enum.nodup_to_list FinEnum.nodup_toList
 
 /-- create a `FinEnum` instance using a surjection -/
 def ofSurjective {β} (f : β → α) [DecidableEq α] [FinEnum β] (h : Surjective f) : FinEnum α :=
-  ofList ((toList β).map f) (by intro ; simp ; exact h _)
+  ofList ((toList β).map f) (by intro; simp; exact h _)
 #align fin_enum.of_surjective FinEnum.ofSurjective
 
 /-- create a `FinEnum` instance using an injection -/
@@ -107,12 +107,12 @@ instance empty : FinEnum Empty :=
 #align fin_enum.empty FinEnum.empty
 
 instance punit : FinEnum PUnit :=
-  ofList [PUnit.unit] fun x => by cases x ; simp
+  ofList [PUnit.unit] fun x => by cases x; simp
 #align fin_enum.punit FinEnum.punit
 
 /- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
 instance prod {β} [FinEnum α] [FinEnum β] : FinEnum (α × β) :=
-  ofList (toList α ×ˢ toList β) fun x => by cases x ; simp
+  ofList (toList α ×ˢ toList β) fun x => by cases x; simp
 #align fin_enum.prod FinEnum.prod
 
 instance sum {β} [FinEnum α] [FinEnum β] : FinEnum (Sum α β) :=
@@ -172,17 +172,17 @@ theorem Finset.mem_enum [DecidableEq α] (s : Finset α) (xs : List α) :
 #align fin_enum.finset.mem_enum FinEnum.Finset.mem_enum
 
 instance Finset.finEnum [FinEnum α] : FinEnum (Finset α) :=
-  ofList (Finset.enum (toList α)) (by intro ; simp)
+  ofList (Finset.enum (toList α)) (by intro; simp)
 #align fin_enum.finset.fin_enum FinEnum.Finset.finEnum
 
 instance Subtype.finEnum [FinEnum α] (p : α → Prop) [DecidablePred p] : FinEnum { x // p x } :=
   ofList ((toList α).filterMap fun x => if h : p x then some ⟨_, h⟩ else none)
-    (by rintro ⟨x, h⟩ ; simp ; exists x ; simp [*])
+    (by rintro ⟨x, h⟩; simp; exists x; simp [*])
 #align fin_enum.subtype.fin_enum FinEnum.Subtype.finEnum
 
 instance (β : α → Type v) [FinEnum α] [∀ a, FinEnum (β a)] : FinEnum (Sigma β) :=
   ofList ((toList α).bind fun a => (toList (β a)).map <| Sigma.mk a)
-    (by intro x ; cases x ; simp)
+    (by intro x; cases x; simp)
 
 instance PSigma.finEnum [FinEnum α] [∀ a, FinEnum (β a)] : FinEnum (Σ'a, β a) :=
   FinEnum.ofEquiv _ (Equiv.psigmaEquivSigma _)
@@ -202,13 +202,13 @@ instance PSigma.finEnumPropRight {β : α → Prop} [FinEnum α] [∀ a, Decidab
 
 instance PSigma.finEnumPropProp {α : Prop} {β : α → Prop} [Decidable α] [∀ a, Decidable (β a)] :
     FinEnum (Σ'a, β a) :=
-  if h : ∃ a, β a then ofList [⟨h.fst, h.snd⟩] (by rintro ⟨⟩ ; simp)
+  if h : ∃ a, β a then ofList [⟨h.fst, h.snd⟩] (by rintro ⟨⟩; simp)
   else ofList [] fun a => (h ⟨a.fst, a.snd⟩).elim
 #align fin_enum.psigma.fin_enum_prop_prop FinEnum.PSigma.finEnumPropProp
 
 instance (priority := 100) [FinEnum α] : Fintype α where
   elems := univ.map (Equiv).symm.toEmbedding
-  complete := by intros ; simp
+  complete := by intros; simp
 
 /-- For `Pi.cons x xs y f` create a function where every `i ∈ xs` is mapped to `f i` and
 `x` is mapped to `y`  -/
@@ -254,7 +254,7 @@ def pi.enum (β : α → Type (max u v)) [FinEnum α] [∀ a, FinEnum (β a)] : 
 #align fin_enum.pi.enum FinEnum.pi.enum
 
 theorem pi.mem_enum {β : α → Type (max u v)} [FinEnum α] [∀ a, FinEnum (β a)] (f : ∀ a, β a) :
-    f ∈ pi.enum.{u, v} β := by simp [pi.enum] ; refine' ⟨fun a _ => f a, mem_pi _ _, rfl⟩
+    f ∈ pi.enum.{u, v} β := by simp [pi.enum]; refine' ⟨fun a _ => f a, mem_pi _ _, rfl⟩
 #align fin_enum.pi.mem_enum FinEnum.pi.mem_enum
 
 instance pi.finEnum {β : α → Type (max u v)} [FinEnum α] [∀ a, FinEnum (β a)] :
@@ -265,8 +265,8 @@ instance pi.finEnum {β : α → Type (max u v)} [FinEnum α] [∀ a, FinEnum (�
 instance pfunFinEnum (p : Prop) [Decidable p] (α : p → Type) [∀ hp, FinEnum (α hp)] :
     FinEnum (∀ hp : p, α hp) :=
   if hp : p then
-    ofList ((toList (α hp)).map fun x _ => x) (by intro x ; simp ; exact ⟨x hp, rfl⟩)
-  else ofList [fun hp' => (hp hp').elim] (by intro ; simp ; ext hp' ; cases hp hp')
+    ofList ((toList (α hp)).map fun x _ => x) (by intro x; simp; exact ⟨x hp, rfl⟩)
+  else ofList [fun hp' => (hp hp').elim] (by intro; simp; ext hp'; cases hp hp')
 #align fin_enum.pfun_fin_enum FinEnum.pfunFinEnum
 
 end FinEnum

--- a/Mathlib/Data/Finmap.lean
+++ b/Mathlib/Data/Finmap.lean
@@ -136,14 +136,14 @@ def liftOn₂ {γ} (s₁ s₂ : Finmap β) (f : AList β → AList β → γ)
 @[simp]
 theorem liftOn₂_toFinmap {γ} (s₁ s₂ : AList β) (f : AList β → AList β → γ) (H) :
     liftOn₂ ⟦s₁⟧ ⟦s₂⟧ f H = f s₁ s₂ :=
-      by cases s₁ ; cases s₂ ; rfl
+      by cases s₁; cases s₂; rfl
 #align finmap.lift_on₂_to_finmap Finmap.liftOn₂_toFinmap
 
 /-! ### Induction -/
 
 @[elab_as_elim]
 theorem induction_on {C : Finmap β → Prop} (s : Finmap β) (H : ∀ a : AList β, C ⟦a⟧) : C s := by
-  rcases s with ⟨⟨a⟩, h⟩ ; exact H ⟨a, h⟩
+  rcases s with ⟨⟨a⟩, h⟩; exact H ⟨a, h⟩
 #align finmap.induction_on Finmap.induction_on
 
 @[elab_as_elim]
@@ -248,7 +248,7 @@ theorem keys_singleton (a : α) (b : β a) : (singleton a b).keys = {a} :=
 
 @[simp]
 theorem mem_singleton (x y : α) (b : β y) : x ∈ singleton y b ↔ x = y := by
-  simp only [singleton] ; erw [mem_cons, mem_nil_iff, or_false_iff]
+  simp only [singleton]; erw [mem_cons, mem_nil_iff, or_false_iff]
 #align finmap.mem_singleton Finmap.mem_singleton
 
 section

--- a/Mathlib/Data/Finset/NatAntidiagonal.lean
+++ b/Mathlib/Data/Finset/NatAntidiagonal.lean
@@ -124,7 +124,7 @@ theorem filter_fst_eq_antidiagonal (n m : ℕ) :
 theorem filter_snd_eq_antidiagonal (n m : ℕ) :
     filter (fun x : ℕ × ℕ ↦ x.snd = m) (antidiagonal n) = if m ≤ n then {(n - m, m)} else ∅ := by
   have : (fun x : ℕ × ℕ ↦ (x.snd = m)) ∘ Prod.swap = fun x : ℕ × ℕ ↦ x.fst = m := by
-    ext ; simp
+    ext; simp
   rw [← map_swap_antidiagonal]
   simp [filter_map, this, filter_fst_eq_antidiagonal, apply_ite (Finset.map _)]
 #align finset.nat.filter_snd_eq_antidiagonal Finset.Nat.filter_snd_eq_antidiagonal

--- a/Mathlib/Data/Finset/Pi.lean
+++ b/Mathlib/Data/Finset/Pi.lean
@@ -107,7 +107,7 @@ theorem pi_insert [∀ a, DecidableEq (β a)] {s : Finset α} {t : ∀ a : α, F
                     Multiset.Pi.cons s.1 a b f a' (h ▸ h'))))
       _ (insert_val_of_not_mem ha)
   subst s'; rw [pi_cons]
-  congr ; funext b
+  congr; funext b
   exact ((pi s t).nodup.map <| Multiset.Pi.cons_injective ha).dedup.symm
 #align finset.pi_insert Finset.pi_insert
 

--- a/Mathlib/Data/Finsupp/AList.lean
+++ b/Mathlib/Data/Finsupp/AList.lean
@@ -65,8 +65,8 @@ absent keys to zero. -/
 noncomputable def lookupFinsupp (l : AList fun _x : α => M) : α →₀ M
     where
   support := by
-    haveI := Classical.decEq α; haveI := Classical.decEq M ;
-      exact (l.1.filter fun x => Sigma.snd x ≠ 0).keys.toFinset
+    haveI := Classical.decEq α; haveI := Classical.decEq M
+    exact (l.1.filter fun x => Sigma.snd x ≠ 0).keys.toFinset
   toFun a :=
     haveI := Classical.decEq α
     (l.lookup a).getD 0

--- a/Mathlib/Data/Finsupp/AList.lean
+++ b/Mathlib/Data/Finsupp/AList.lean
@@ -65,7 +65,7 @@ absent keys to zero. -/
 noncomputable def lookupFinsupp (l : AList fun _x : α => M) : α →₀ M
     where
   support := by
-    haveI := Classical.decEq α ; haveI := Classical.decEq M ;
+    haveI := Classical.decEq α; haveI := Classical.decEq M ;
       exact (l.1.filter fun x => Sigma.snd x ≠ 0).keys.toFinset
   toFun a :=
     haveI := Classical.decEq α
@@ -89,7 +89,7 @@ theorem lookupFinsupp_support [DecidableEq α] [DecidableEq M] (l : AList fun _x
     -- porting note: was `convert rfl`
      simp only [lookupFinsupp, ne_eq, Finsupp.coe_mk]; congr
      · apply Subsingleton.elim
-     · funext ; congr
+     · funext; congr
 #align alist.lookup_finsupp_support AList.lookupFinsupp_support
 
 theorem lookupFinsupp_eq_iff_of_ne_zero [DecidableEq α] {l : AList fun _x : α => M} {a : α} {x : M}

--- a/Mathlib/Data/Finsupp/Basic.lean
+++ b/Mathlib/Data/Finsupp/Basic.lean
@@ -1226,7 +1226,7 @@ theorem sum_curry_index (f : α × β →₀ M) (g : α → β → M → N) (hg�
   · exact
       sum_sum_index (fun a => sum_zero_index) fun a b₀ b₁ =>
         sum_add_index' (fun a => hg₀ _ _) fun c d₀ d₁ => hg₁ _ _ _ _
-  congr ; funext p c
+  congr; funext p c
   trans
   · exact sum_single_index sum_zero_index
   exact sum_single_index (hg₀ _ _)

--- a/Mathlib/Data/Finsupp/BigOperators.lean
+++ b/Mathlib/Data/Finsupp/BigOperators.lean
@@ -56,7 +56,7 @@ theorem Multiset.support_sum_subset [AddCommMonoid M] (s : Multiset (ι →₀ M
 
 theorem Finset.support_sum_subset [AddCommMonoid M] (s : Finset (ι →₀ M)) :
     (s.sum id).support ⊆ Finset.sup s Finsupp.support := by
-  classical convert Multiset.support_sum_subset s.1 ; simp
+  classical convert Multiset.support_sum_subset s.1; simp
 #align finset.support_sum_subset Finset.support_sum_subset
 
 theorem List.mem_foldr_sup_support_iff [Zero M] {l : List (ι →₀ M)} {x : ι} :

--- a/Mathlib/Data/Finsupp/Pointwise.lean
+++ b/Mathlib/Data/Finsupp/Pointwise.lean
@@ -60,7 +60,7 @@ theorem support_mul [DecidableEq α] {g₁ g₂ : α →₀ β} :
   rw [← not_or]
   intro w
   apply h
-  cases' w with w w <;> (rw [w] ; simp)
+  cases' w with w w <;> (rw [w]; simp)
 #align finsupp.support_mul Finsupp.support_mul
 
 instance : MulZeroClass (α →₀ β) :=

--- a/Mathlib/Data/Fintype/Perm.lean
+++ b/Mathlib/Data/Fintype/Perm.lean
@@ -142,11 +142,11 @@ def permsOfFinset (s : Finset α) : Finset (Perm α) :=
 
 theorem mem_perms_of_finset_iff :
     ∀ {s : Finset α} {f : Perm α}, f ∈ permsOfFinset s ↔ ∀ {x}, f x ≠ x → x ∈ s := by
-  rintro ⟨⟨l⟩, hs⟩ f ; exact mem_permsOfList_iff
+  rintro ⟨⟨l⟩, hs⟩ f; exact mem_permsOfList_iff
 #align mem_perms_of_finset_iff mem_perms_of_finset_iff
 
 theorem card_perms_of_finset : ∀ s : Finset α, (permsOfFinset s).card = s.card ! := by
-  rintro ⟨⟨l⟩, hs⟩ ; exact length_permsOfList l
+  rintro ⟨⟨l⟩, hs⟩; exact length_permsOfList l
 #align card_perms_of_finset card_perms_of_finset
 
 /-- The collection of permutations of a fintype is a fintype. -/

--- a/Mathlib/Data/Int/Order/Basic.lean
+++ b/Mathlib/Data/Int/Order/Basic.lean
@@ -68,7 +68,7 @@ lemma _root_.Nat.cast_natAbs {α : Type _} [AddGroupWithOne α] (n : ℤ) : (n.n
   by rw [←coe_natAbs, Int.cast_ofNat]
 #align nat.cast_nat_abs Nat.cast_natAbs
 
-theorem natAbs_abs (a : ℤ) : natAbs |a| = natAbs a := by rw [abs_eq_natAbs] ; rfl
+theorem natAbs_abs (a : ℤ) : natAbs |a| = natAbs a := by rw [abs_eq_natAbs]; rfl
 #align int.nat_abs_abs Int.natAbs_abs
 
 theorem sign_mul_abs (a : ℤ) : sign a * |a| = a := by

--- a/Mathlib/Data/List/AList.lean
+++ b/Mathlib/Data/List/AList.lean
@@ -319,7 +319,7 @@ theorem lookup_to_alist {a} (s : List (Sigma β)) : lookup a s.toAList = s.dlook
 @[simp]
 theorem insert_insert {a} {b b' : β a} (s : AList β) :
     (s.insert a b).insert a b' = s.insert a b' := by
-  ext : 1 ; simp only [AList.insert_entries, List.kerase_cons_eq]
+  ext : 1; simp only [AList.insert_entries, List.kerase_cons_eq]
 #align alist.insert_insert AList.insert_insert
 
 theorem insert_insert_of_ne {a a'} {b : β a} {b' : β a'} (s : AList β) (h : a ≠ a') :
@@ -504,7 +504,7 @@ theorem union_comm_of_disjoint {s₁ s₂ : AList β} (h : Disjoint s₁ s₂) :
     (s₁ ∪ s₂).entries ~ (s₂ ∪ s₁).entries :=
   lookup_ext (AList.nodupKeys _) (AList.nodupKeys _)
     (by
-      intros ; simp
+      intros; simp
       constructor <;> intro h'
       · cases' h' with h' h'
         · right

--- a/Mathlib/Data/List/Indexes.lean
+++ b/Mathlib/Data/List/Indexes.lean
@@ -153,7 +153,7 @@ theorem map_enumFrom_eq_zipWith : ∀ (l : List α) (n : ℕ) (f : ℕ → α �
   revert l
   induction' len with len ih <;> intros l e n f
   · have : l = [] := by cases l; rfl; contradiction
-    rw [this] ; rfl
+    rw [this]; rfl
   · cases' l with head tail
     · contradiction
     · simp only [map, uncurry_apply_pair, range_succ_eq_map, zipWith, zero_add, zipWith_map_left]

--- a/Mathlib/Data/List/OfFn.lean
+++ b/Mathlib/Data/List/OfFn.lean
@@ -96,7 +96,7 @@ theorem map_ofFn {β : Type _} {n : ℕ} (f : Fin n → α) (g : α → β) :
 --   suffices ∀ {m h l}, DArray.revIterateAux a (fun i => cons) m h l =
 --      ofFnAux (DArray.read a) m h l
 --     from this
---   intros ; induction' m with m IH generalizing l; · rfl
+--   intros; induction' m with m IH generalizing l; · rfl
 --   simp only [DArray.revIterateAux, of_fn_aux, IH]
 -- #align list.array_eq_of_fn List.array_eq_of_fn
 

--- a/Mathlib/Data/List/Pairwise.lean
+++ b/Mathlib/Data/List/Pairwise.lean
@@ -247,7 +247,7 @@ theorem Pairwise.pmap {l : List α} (hl : Pairwise R l) {p : α → Prop} {f : �
     (hS : ∀ ⦃x⦄ (hx : p x) ⦃y⦄ (hy : p y), R x y → S (f x hx) (f y hy)) :
     Pairwise S (l.pmap f h) := by
   refine' (pairwise_pmap h).2 (Pairwise.imp_of_mem _ hl)
-  intros ; apply hS; assumption
+  intros; apply hS; assumption
 #align list.pairwise.pmap List.Pairwise.pmap
 
 theorem pairwise_join {L : List (List α)} :

--- a/Mathlib/Data/List/Perm.lean
+++ b/Mathlib/Data/List/Perm.lean
@@ -272,7 +272,7 @@ theorem Perm.pmap {p : α → Prop} (f : ∀ a, p a → β) {l₁ l₂ : List α
 #align list.perm.pmap List.Perm.pmap
 
 theorem Perm.filter (p : α → Bool) {l₁ l₂ : List α} (s : l₁ ~ l₂) :
-    filter p l₁ ~ filter p l₂ := by rw [← filterMap_eq_filter] ; apply s.filterMap _
+    filter p l₁ ~ filter p l₂ := by rw [← filterMap_eq_filter]; apply s.filterMap _
 #align list.perm.filter List.Perm.filter
 
 theorem filter_append_perm (p : α → Bool) (l : List α) :
@@ -471,7 +471,7 @@ theorem Sublist.exists_perm_append : ∀ {l₁ l₂ : List α}, l₁ <+ l₂ →
 
 theorem Perm.countp_eq (p : α → Bool) {l₁ l₂ : List α} (s : l₁ ~ l₂) :
     countp p l₁ = countp p l₂ := by
-  rw [countp_eq_length_filter, countp_eq_length_filter] ; exact (s.filter _).length_eq
+  rw [countp_eq_length_filter, countp_eq_length_filter]; exact (s.filter _).length_eq
 #align list.perm.countp_eq List.Perm.countp_eq
 
 theorem Subperm.countp_le (p : α → Bool) {l₁ l₂ : List α} :
@@ -524,8 +524,8 @@ theorem Perm.foldl_eq {f : β → α → β} {l₁ l₂ : List α} (rcomm : Righ
 
 theorem Perm.foldr_eq {f : α → β → β} {l₁ l₂ : List α} (lcomm : LeftCommutative f) (p : l₁ ~ l₂) :
     ∀ b, foldr f b l₁ = foldr f b l₂ :=
-  perm_induction_on p (fun b => rfl) (fun x t₁ t₂ _p r b => by simp ; rw [r b])
-    (fun x y t₁ t₂ _p r b => by simp ; rw [lcomm, r b]) fun t₁ t₂ t₃ _p₁ _p₂ r₁ r₂ a =>
+  perm_induction_on p (fun b => rfl) (fun x t₁ t₂ _p r b => by simp; rw [r b])
+    (fun x y t₁ t₂ _p r b => by simp; rw [lcomm, r b]) fun t₁ t₂ t₃ _p₁ _p₂ r₁ r₂ a =>
     Eq.trans (r₁ a) (r₂ a)
 #align list.perm.foldr_eq List.Perm.foldr_eq
 
@@ -774,7 +774,7 @@ theorem Perm.erase (a : α) {l₁ l₂ : List α} (p : l₁ ~ l₂) : l₁.erase
     Perm.cons_inv <| (perm_cons_erase h₁).symm.trans <| p.trans (perm_cons_erase h₂)
   else by
     have h₂ : a ∉ l₂ := mt p.mem_iff.2 h₁
-    rw [erase_of_not_mem h₁, erase_of_not_mem h₂] ; exact p
+    rw [erase_of_not_mem h₁, erase_of_not_mem h₂]; exact p
 #align list.perm.erase List.Perm.erase
 
 theorem subperm_cons_erase (a : α) (l : List α) : l <+~ a :: l.erase a := by

--- a/Mathlib/Data/List/Prime.lean
+++ b/Mathlib/Data/List/Prime.lean
@@ -73,7 +73,7 @@ theorem perm_of_prod_eq_prod :
       have hl₂' : ∀ p ∈ (b :: l₂).erase a, Prime p := fun p hp => hl₂ p (mem_of_mem_erase hp)
       have ha : a ∈ b :: l₂ :=
         mem_list_primes_of_dvd_prod (hl₁ a (mem_cons_self _ _)) hl₂
-          (h ▸ by rw [prod_cons] ; exact dvd_mul_right _ _)
+          (h ▸ by rw [prod_cons]; exact dvd_mul_right _ _)
       have hb : b :: l₂ ~ a :: (b :: l₂).erase a := perm_cons_erase ha
       have hl : prod l₁ = prod ((b :: l₂).erase a) :=
         (mul_right_inj' (hl₁ a (mem_cons_self _ _)).ne_zero).1 <| by

--- a/Mathlib/Data/Multiset/Antidiagonal.lean
+++ b/Mathlib/Data/Multiset/Antidiagonal.lean
@@ -84,7 +84,7 @@ theorem antidiagonal_cons (a : α) (s) :
     simp only [revzip, reverse_append, quot_mk_to_coe, coe_eq_coe, powersetAux'_cons, cons_coe,
       coe_map, antidiagonal_coe', coe_add]
     rw [← zip_map, ← zip_map, zip_append, (_ : _ ++ _ = _)]
-    · congr ; simp ; rw [map_reverse] ; simp
+    · congr; simp; rw [map_reverse]; simp
     · simp
 #align multiset.antidiagonal_cons Multiset.antidiagonal_cons
 

--- a/Mathlib/Data/Multiset/Basic.lean
+++ b/Mathlib/Data/Multiset/Basic.lean
@@ -1468,7 +1468,7 @@ nonrec def pmap {p : α → Prop} (f : ∀ a, p a → β) (s : Multiset α) : (�
       have H₁ : ∀ a ∈ l₁, p a := fun a h => H₂ a (pp.subset h)
       have : ∀ {s₂ e H}, @Eq.ndrec (Multiset α) l₁ (fun s => (∀ a ∈ s, p a) → Multiset β)
           (fun _ => ↑(pmap f l₁ H₁)) s₂ e H = ↑(pmap f l₁ H₁) := by
-        intro s₂ e _ ; subst e; rfl
+        intro s₂ e _; subst e; rfl
       this.trans <| Quot.sound <| pp.pmap f
 #align multiset.pmap Multiset.pmap
 

--- a/Mathlib/Data/Multiset/Functor.lean
+++ b/Mathlib/Data/Multiset/Functor.lean
@@ -30,7 +30,7 @@ theorem fmap_def {α' β'} {s : Multiset α'} (f : α' → β') : f <$> s = s.ma
   rfl
 #align multiset.fmap_def Multiset.fmap_def
 
-instance : LawfulFunctor Multiset := by refine' { .. } <;> intros <;> simp ; rfl
+instance : LawfulFunctor Multiset := by refine' { .. } <;> intros <;> simp; rfl
 
 open IsLawfulTraversable CommApplicative
 
@@ -97,7 +97,7 @@ theorem lift_coe {α β : Type _} (x : List α) (f : List α → β)
 @[simp]
 theorem map_comp_coe {α β} (h : α → β) :
     Functor.map h ∘ Coe.coe = (Coe.coe ∘ Functor.map h : List α → Multiset β) := by
-  funext ; simp only [Function.comp_apply, Coe.coe, fmap_def, coe_map, List.map_eq_map]
+  funext; simp only [Function.comp_apply, Coe.coe, fmap_def, coe_map, List.map_eq_map]
 #align multiset.map_comp_coe Multiset.map_comp_coe
 
 theorem id_traverse {α : Type _} (x : Multiset α) : traverse (pure : α → Id α) x = x := by

--- a/Mathlib/Data/MvPolynomial/Basic.lean
+++ b/Mathlib/Data/MvPolynomial/Basic.lean
@@ -61,7 +61,7 @@ In the definitions below, we use the following notation:
 
 Recall that if `Y` has a zero, then `X →₀ Y` is the type of functions from `X` to `Y` with finite
 support, i.e. such that only finitely many elements of `X` get sent to non-zero terms in `Y`.
-The definition of `MvPolynomial σ R` is `(σ →₀ ℕ) →₀ R` ; here `σ →₀ ℕ` denotes the space of all
+The definition of `MvPolynomial σ R` is `(σ →₀ ℕ) →₀ R`; here `σ →₀ ℕ` denotes the space of all
 monomials in the variables, and the function to `R` sends a monomial to its coefficient in
 the polynomial being represented.
 

--- a/Mathlib/Data/MvPolynomial/PDeriv.lean
+++ b/Mathlib/Data/MvPolynomial/PDeriv.lean
@@ -78,7 +78,7 @@ theorem pderiv_monomial {i : σ} :
       ← (monomial _).map_smul]
     refine' (Finset.sum_eq_single i (fun j _ hne => _) fun hi => _).trans _
     · simp [Pi.single_eq_of_ne hne]
-    · rw [Finsupp.not_mem_support_iff] at hi ; simp [hi]
+    · rw [Finsupp.not_mem_support_iff] at hi; simp [hi]
     · simp
 #align mv_polynomial.pderiv_monomial MvPolynomial.pderiv_monomial
 

--- a/Mathlib/Data/MvPolynomial/Variables.lean
+++ b/Mathlib/Data/MvPolynomial/Variables.lean
@@ -597,7 +597,7 @@ def totalDegree (p : MvPolynomial σ R) : ℕ :=
 theorem totalDegree_eq (p : MvPolynomial σ R) :
     p.totalDegree = p.support.sup fun m => Multiset.card (toMultiset m) := by
   rw [totalDegree]
-  congr ; funext m
+  congr; funext m
   exact (Finsupp.card_toMultiset _).symm
 #align mv_polynomial.total_degree_eq MvPolynomial.totalDegree_eq
 

--- a/Mathlib/Data/Nat/Bitwise.lean
+++ b/Mathlib/Data/Nat/Bitwise.lean
@@ -302,7 +302,7 @@ theorem lxor'_trichotomy {a b c : ℕ} (h : a ≠ lxor' b c) :
   -- If, say, `a` has a one bit at position `i`, then `a xor v` has a zero bit at position `i`, but
   -- the same bits as `a` in positions greater than `j`, so `a xor v < a`.
   rcases this with (h | h | h)
-  on_goal 1 => left ; rw [hbc]
+  on_goal 1 => left; rw [hbc]
   on_goal 2 => right; left; rw [hac]
   on_goal 3 => right; right; rw [hab]
   all_goals

--- a/Mathlib/Data/Nat/GCD/Basic.lean
+++ b/Mathlib/Data/Nat/GCD/Basic.lean
@@ -239,7 +239,7 @@ def prodDvdAndDvdOfDvdProd {m n k : ℕ} (H : k ∣ m * n) :
     obtain rfl : m = 0 := eq_zero_of_gcd_eq_zero_right h0
     exact ⟨⟨⟨0, dvd_refl 0⟩, ⟨n, dvd_refl n⟩⟩, (zero_mul n).symm⟩
   case succ tmp =>
-    have hpos : 0 < gcd k m := h0.symm ▸ Nat.zero_lt_succ _ ; clear h0 tmp
+    have hpos : 0 < gcd k m := h0.symm ▸ Nat.zero_lt_succ _; clear h0 tmp
     have hd : gcd k m * (k / gcd k m) = k := Nat.mul_div_cancel' (gcd_dvd_left k m)
     refine' ⟨⟨⟨gcd k m, gcd_dvd_right k m⟩, ⟨k / gcd k m, _⟩⟩, hd.symm⟩
     apply Nat.dvd_of_mul_dvd_mul_left hpos

--- a/Mathlib/Data/Nat/Lattice.lean
+++ b/Mathlib/Data/Nat/Lattice.lean
@@ -126,11 +126,11 @@ noncomputable instance : ConditionallyCompleteLinearOrderBot ℕ :=
     (inferInstance : LinearOrder ℕ) with
     -- sup := sSup -- Porting note: removed, unnecessary?
     -- inf := sInf -- Porting note: removed, unnecessary?
-    le_csSup := fun s a hb ha ↦ by rw [sSup_def hb] ; revert a ha ; exact @Nat.find_spec _ _ hb
-    csSup_le := fun s a _ ha ↦ by rw [sSup_def ⟨a, ha⟩] ; exact Nat.find_min' _ ha
+    le_csSup := fun s a hb ha ↦ by rw [sSup_def hb]; revert a ha; exact @Nat.find_spec _ _ hb
+    csSup_le := fun s a _ ha ↦ by rw [sSup_def ⟨a, ha⟩]; exact Nat.find_min' _ ha
     le_csInf := fun s a hs hb ↦ by
-      rw [sInf_def hs] ; exact hb (@Nat.find_spec (fun n ↦ n ∈ s) _ _)
-    csInf_le := fun s a _ ha ↦ by rw [sInf_def ⟨a, ha⟩] ; exact Nat.find_min' _ ha
+      rw [sInf_def hs]; exact hb (@Nat.find_spec (fun n ↦ n ∈ s) _ _)
+    csInf_le := fun s a _ ha ↦ by rw [sInf_def ⟨a, ha⟩]; exact Nat.find_min' _ ha
     csSup_empty := by
       simp only [sSup_def, Set.mem_empty_iff_false, forall_const, forall_prop_of_false,
         not_false_iff, exists_const]

--- a/Mathlib/Data/Nat/Order/Basic.lean
+++ b/Mathlib/Data/Nat/Order/Basic.lean
@@ -378,7 +378,7 @@ theorem set_induction {S : Set ℕ} (hb : 0 ∈ S) (h_ind : ∀ k : ℕ, k ∈ S
 
 
 protected theorem div_le_of_le_mul' (h : m ≤ k * n) : m / k ≤ n :=
-  (Nat.eq_zero_or_pos k).elim (fun k0 => by rw [k0, Nat.div_zero] ; apply zero_le) fun k0 =>
+  (Nat.eq_zero_or_pos k).elim (fun k0 => by rw [k0, Nat.div_zero]; apply zero_le) fun k0 =>
     le_of_mul_le_mul_left
       (calc
         k * (m / k) ≤ m % k + k * (m / k) := Nat.le_add_left _ _
@@ -414,7 +414,7 @@ theorem div_mul_div_le_div (m n k : ℕ) : m / k * n / m ≤ n / k :=
   else
     calc
       m / k * n / m ≤ n * m / k / m :=
-        Nat.div_le_div_right (by rw [mul_comm] ; exact mul_div_le_mul_div_assoc _ _ _)
+        Nat.div_le_div_right (by rw [mul_comm]; exact mul_div_le_mul_div_assoc _ _ _)
       _ = n / k := by
         { rw [Nat.div_div_eq_div_mul, mul_comm n, mul_comm k,
             Nat.mul_div_mul_left _ _ (Nat.pos_of_ne_zero hm0)] }

--- a/Mathlib/Data/Nat/Pairing.lean
+++ b/Mathlib/Data/Nat/Pairing.lean
@@ -56,7 +56,7 @@ theorem pair_unpair (n : ℕ) : pair (unpair n).1 (unpair n).2 = n := by
   split_ifs with h
   · simp [pair, h, sm]
   · have hl : n - s * s - s ≤ s :=
-      tsub_le_iff_left.mpr (tsub_le_iff_left.mpr <| by rw [← add_assoc] ; apply sqrt_le_add)
+      tsub_le_iff_left.mpr (tsub_le_iff_left.mpr <| by rw [← add_assoc]; apply sqrt_le_add)
     simp [pair, hl.not_lt, add_assoc, add_tsub_cancel_of_le (le_of_not_gt h), sm]
 #align nat.mkpair_unpair Nat.pair_unpair
 
@@ -138,7 +138,7 @@ theorem pair_lt_pair_left {a₁ a₂} (b) (h : a₁ < a₂) : pair a₁ b < pair
     simp [not_lt_of_gt (lt_of_le_of_lt h₁ h)]
     apply add_lt_add
     exact mul_self_lt_mul_self h
-    apply add_lt_add_right ; assumption
+    apply add_lt_add_right; assumption
 #align nat.mkpair_lt_mkpair_left Nat.pair_lt_pair_left
 
 theorem pair_lt_pair_right (a) {b₁ b₂} (h : b₁ < b₂) : pair a b₁ < pair a b₂ := by

--- a/Mathlib/Data/Nat/Prime.lean
+++ b/Mathlib/Data/Nat/Prime.lean
@@ -357,7 +357,7 @@ theorem le_minFac {m n : ℕ} : n = 1 ∨ m ≤ minFac n ↔ ∀ p, Prime p → 
 
 theorem le_minFac' {m n : ℕ} : n = 1 ∨ m ≤ minFac n ↔ ∀ p, 2 ≤ p → p ∣ n → m ≤ p :=
   ⟨fun h p (pp : 1 < p) d =>
-    h.elim (by rintro rfl ; cases not_le_of_lt pp (le_of_dvd (by decide) d)) fun h =>
+    h.elim (by rintro rfl; cases not_le_of_lt pp (le_of_dvd (by decide) d)) fun h =>
       le_trans h <| minFac_le_of_dvd pp d,
     fun H => le_minFac.2 fun p pp d => H p pp.two_le d⟩
 #align nat.le_min_fac' Nat.le_minFac'
@@ -681,7 +681,7 @@ theorem coprime_pow_primes {p q : ℕ} (n m : ℕ) (pp : Prime p) (pq : Prime q)
 #align nat.coprime_pow_primes Nat.coprime_pow_primes
 
 theorem coprime_or_dvd_of_prime {p} (pp : Prime p) (i : ℕ) : coprime p i ∨ p ∣ i := by
-  rw [pp.dvd_iff_not_coprime] ; apply em
+  rw [pp.dvd_iff_not_coprime]; apply em
 #align nat.coprime_or_dvd_of_prime Nat.coprime_or_dvd_of_prime
 
 theorem coprime_of_lt_prime {n p} (n_pos : 0 < n) (hlt : n < p) (pp : Prime p) : coprime p n :=

--- a/Mathlib/Data/Nat/Prime.lean
+++ b/Mathlib/Data/Nat/Prime.lean
@@ -746,8 +746,8 @@ theorem succ_dvd_or_succ_dvd_of_succ_sum_dvd_mul {p : ℕ} (p_prime : Prime p) {
 theorem prime_iff_prime_int {p : ℕ} : p.Prime ↔ _root_.Prime (p : ℤ) :=
   ⟨fun hp =>
     ⟨Int.coe_nat_ne_zero_iff_pos.2 hp.pos, mt Int.isUnit_iff_natAbs_eq.1 hp.ne_one, fun a b h => by
-      rw [← Int.dvd_natAbs, Int.coe_nat_dvd, Int.natAbs_mul, hp.dvd_mul] at h ;
-        rwa [← Int.dvd_natAbs, Int.coe_nat_dvd, ← Int.dvd_natAbs, Int.coe_nat_dvd]⟩,
+      rw [← Int.dvd_natAbs, Int.coe_nat_dvd, Int.natAbs_mul, hp.dvd_mul] at h
+      rwa [← Int.dvd_natAbs, Int.coe_nat_dvd, ← Int.dvd_natAbs, Int.coe_nat_dvd]⟩,
     fun hp =>
     Nat.prime_iff.2
       ⟨Int.coe_nat_ne_zero.1 hp.1,

--- a/Mathlib/Data/Num/Bitwise.lean
+++ b/Mathlib/Data/Num/Bitwise.lean
@@ -345,7 +345,7 @@ open SNum
       `0 : SNum` and `(-1) : SNum`. -/
 def drec' {C : SNum → Sort _} (z : ∀ b, C (SNum.zero b)) (s : ∀ b p, C p → C (b :: p)) :
     ∀ p : NzsNum, C p
-  | msb b => by rw [← bit_one] ; exact s b (SNum.zero (Not b)) (z (Not b))
+  | msb b => by rw [← bit_one]; exact s b (SNum.zero (Not b)) (z (Not b))
   | bit b p => s b p (drec' z s p)
 #align nzsnum.drec' NzsNum.drec'
 

--- a/Mathlib/Data/Num/Lemmas.lean
+++ b/Mathlib/Data/Num/Lemmas.lean
@@ -614,7 +614,7 @@ instance commMonoid : CommMonoid PosNum := by
     { mul := (· * ·)
       one := (1 : PosNum)
       npow := @npowRec PosNum ⟨1⟩ ⟨(· * ·)⟩,.. } <;>
-  try { intros ; rfl } <;>
+  try { intros; rfl } <;>
   transfer
 #align pos_num.comm_monoid PosNum.commMonoid
 

--- a/Mathlib/Data/Ordmap/Ordset.lean
+++ b/Mathlib/Data/Ordmap/Ordset.lean
@@ -1246,7 +1246,7 @@ theorem Valid'.rotateL {l} {x : α} {r o₁ o₂} (hl : Valid' o₁ l x) (hr : V
       (or_iff_right_of_imp fun h => (mul_le_mul_left (by decide)).1 (le_trans h (by decide))).1 H3
   have H3p : size l > 0 → 2 * (size rl + size rr) ≤ 9 * size l + 3 := fun l0 : 1 ≤ size l =>
     (or_iff_left_of_imp <| by intro; linarith).1 H3
-  have ablem : ∀ {a b : ℕ}, 1 ≤ a → a + b ≤ 2 → b ≤ 1 := by intros ; linarith
+  have ablem : ∀ {a b : ℕ}, 1 ≤ a → a + b ≤ 2 → b ≤ 1 := by intros; linarith
   have hlp : size l > 0 → ¬size rl + size rr ≤ 1 := fun l0 hb =>
     absurd (le_trans (le_trans (Nat.mul_le_mul_left _ l0) H2) hb) (by decide)
   rw [rotateL]; split_ifs with h

--- a/Mathlib/Data/PFun.lean
+++ b/Mathlib/Data/PFun.lean
@@ -126,7 +126,7 @@ def asSubtype (f : α →. β) (s : f.Dom) : β :=
 the type of pairs `(p : α → Prop, f : Subtype p → β)`. -/
 def equivSubtype : (α →. β) ≃ Σp : α → Prop, Subtype p → β :=
   ⟨fun f => ⟨fun a => (f a).Dom, asSubtype f⟩, fun f x => ⟨f.1 x, fun h => f.2 ⟨x, h⟩⟩, fun f =>
-    funext fun a => Part.eta _, fun ⟨p, f⟩ => by dsimp ; congr ⟩
+    funext fun a => Part.eta _, fun ⟨p, f⟩ => by dsimp; congr ⟩
 #align pfun.equiv_subtype PFun.equivSubtype
 
 theorem asSubtype_eq_of_mem {f : α →. β} {x : α} {y : β} (fxy : y ∈ f x) (domx : x ∈ f.Dom) :
@@ -230,7 +230,7 @@ instance monad : Monad (PFun α) where
 
 instance lawfulMonad : LawfulMonad (PFun α) := LawfulMonad.mk'
   (bind_pure_comp := fun f x => funext fun a => Part.bind_some_eq_map _ _)
-  (id_map := fun f => by funext a ; dsimp [Functor.map, PFun.map] ; cases f a; rfl)
+  (id_map := fun f => by funext a; dsimp [Functor.map, PFun.map]; cases f a; rfl)
   (pure_bind := fun x f => funext fun a => Part.bind_some _ (f x))
   (bind_assoc := fun f g k => funext fun a => (f a).bind_assoc (fun b => g b a) fun b => k b a)
 #align pfun.is_lawful_monad PFun.lawfulMonad
@@ -263,7 +263,7 @@ def fix (f : α →. Sum β α) : α →. β := fun a =>
 
 theorem dom_of_mem_fix {f : α →. Sum β α} {a : α} {b : β} (h : b ∈ f.fix a) : (f a).Dom := by
   let ⟨h₁, h₂⟩ := Part.mem_assert_iff.1 h
-  rw [WellFounded.fixFEq] at h₂ ; exact h₂.fst.fst
+  rw [WellFounded.fixFEq] at h₂; exact h₂.fst.fst
 #align pfun.dom_of_mem_fix PFun.dom_of_mem_fix
 
 theorem mem_fix_iff {f : α →. Sum β α} {a : α} {b : β} :
@@ -451,10 +451,10 @@ theorem preimage_union (s t : Set β) : f.preimage (s ∪ t) = f.preimage s ∪ 
   Rel.preimage_union _ s t
 #align pfun.preimage_union PFun.preimage_union
 
-theorem preimage_univ : f.preimage Set.univ = f.Dom := by ext ; simp [mem_preimage, mem_dom]
+theorem preimage_univ : f.preimage Set.univ = f.Dom := by ext; simp [mem_preimage, mem_dom]
 #align pfun.preimage_univ PFun.preimage_univ
 
-theorem coe_preimage (f : α → β) (s : Set β) : (f : α →. β).preimage s = f ⁻¹' s := by ext ; simp
+theorem coe_preimage (f : α → β) (s : Set β) : (f : α →. β).preimage s = f ⁻¹' s := by ext; simp
 #align pfun.coe_preimage PFun.coe_preimage
 
 /-- Core of a set `s : Set β` with respect to a partial function `f : α →. β`. Set of all `a : α`
@@ -501,7 +501,7 @@ theorem core_res (f : α → β) (s : Set α) (t : Set β) : (res f s).core t = 
 end
 
 theorem core_restrict (f : α → β) (s : Set β) : (f : α →. β).core s = s.preimage f := by
-  ext x ; simp [core_def]
+  ext x; simp [core_def]
 #align pfun.core_restrict PFun.core_restrict
 
 theorem preimage_subset_core (f : α →. β) (s : Set β) : f.preimage s ⊆ f.core s :=

--- a/Mathlib/Data/PFunctor/Multivariate/W.lean
+++ b/Mathlib/Data/PFunctor/Multivariate/W.lean
@@ -111,14 +111,14 @@ set_option linter.uppercaseLean3 false in
 
 theorem wPathCasesOn_eta {α : TypeVec n} {a : P.A} {f : P.last.B a → P.last.W}
     (h : P.WPath ⟨a, f⟩ ⟹ α) : P.wPathCasesOn (P.wPathDestLeft h) (P.wPathDestRight h) = h := by
-  ext i x ; cases x <;> rfl
+  ext i x; cases x <;> rfl
 set_option linter.uppercaseLean3 false in
 #align mvpfunctor.W_path_cases_on_eta MvPFunctor.wPathCasesOn_eta
 
 theorem comp_wPathCasesOn {α β : TypeVec n} (h : α ⟹ β) {a : P.A} {f : P.last.B a → P.last.W}
     (g' : P.drop.B a ⟹ α) (g : ∀ j : P.last.B a, P.WPath (f j) ⟹ α) :
     h ⊚ P.wPathCasesOn g' g = P.wPathCasesOn (h ⊚ g') fun i => h ⊚ g i := by
-  ext i x ; cases x <;> rfl
+  ext i x; cases x <;> rfl
 set_option linter.uppercaseLean3 false in
 #align mvpfunctor.comp_W_path_cases_on MvPFunctor.comp_wPathCasesOn
 
@@ -139,7 +139,7 @@ def W (α : TypeVec n) : Type _ :=
 set_option linter.uppercaseLean3 false in
 #align mvpfunctor.W MvPFunctor.W
 
-instance mvfunctorW : MvFunctor P.W := by delta MvPFunctor.W ; infer_instance
+instance mvfunctorW : MvFunctor P.W := by delta MvPFunctor.W; infer_instance
 set_option linter.uppercaseLean3 false in
 #align mvpfunctor.mvfunctor_W MvPFunctor.mvfunctorW
 
@@ -284,7 +284,7 @@ theorem map_objAppend1 {α γ : TypeVec n} (g : α ⟹ γ) (a : P.A) (f' : P.dro
     (f : P.last.B a → P.W α) :
     appendFun g (P.wMap g) <$$> P.objAppend1 a f' f =
       P.objAppend1 a (g ⊚ f') fun x => P.wMap g (f x) :=
-  by rw [objAppend1, objAppend1, map_eq, appendFun, ← splitFun_comp] ; rfl
+  by rw [objAppend1, objAppend1, map_eq, appendFun, ← splitFun_comp]; rfl
 #align mvpfunctor.map_obj_append1 MvPFunctor.map_objAppend1
 
 /-!
@@ -312,7 +312,7 @@ set_option linter.uppercaseLean3 false in
 #align mvpfunctor.W_dest'_W_mk MvPFunctor.wDest'_wMk
 
 theorem wDest'_wMk' {α : TypeVec n} (x : P.Obj (α.append1 (P.W α))) : P.wDest' (P.wMk' x) = x := by
-  cases' x with a f ; rw [wMk', wDest'_wMk, split_dropFun_lastFun]
+  cases' x with a f; rw [wMk', wDest'_wMk, split_dropFun_lastFun]
 set_option linter.uppercaseLean3 false in
 #align mvpfunctor.W_dest'_W_mk' MvPFunctor.wDest'_wMk'
 

--- a/Mathlib/Data/PNat/Factors.lean
+++ b/Mathlib/Data/PNat/Factors.lean
@@ -369,7 +369,7 @@ namespace PNat
 theorem factorMultiset_gcd (m n : ℕ+) :
     factorMultiset (gcd m n) = factorMultiset m ⊓ factorMultiset n := by
   apply le_antisymm
-  · apply le_inf_iff.mpr ; constructor <;> apply factorMultiset_le_iff.mpr
+  · apply le_inf_iff.mpr; constructor <;> apply factorMultiset_le_iff.mpr
     exact gcd_dvd_left m n
     exact gcd_dvd_right m n
   · rw [← PrimeMultiset.prod_dvd_iff, prod_factorMultiset]
@@ -385,7 +385,7 @@ theorem factorMultiset_lcm (m n : ℕ+) :
     apply lcm_dvd <;> rw [← factorMultiset_le_iff']
     exact le_sup_left
     exact le_sup_right
-  · apply sup_le_iff.mpr ; constructor <;> apply factorMultiset_le_iff.mpr
+  · apply sup_le_iff.mpr; constructor <;> apply factorMultiset_le_iff.mpr
     exact dvd_lcm_left m n
     exact dvd_lcm_right m n
 #align pnat.factor_multiset_lcm PNat.factorMultiset_lcm

--- a/Mathlib/Data/Polynomial/Lifts.lean
+++ b/Mathlib/Data/Polynomial/Lifts.lean
@@ -184,7 +184,7 @@ theorem mem_lifts_and_degree_eq {p : S[X]} (hlifts : p ∈ lifts f) :
     rw [habs, eraseLead_zero, eq_self_iff_true, not_true] at erase_zero
     exact erase_zero
   have lead_zero : p.coeff p.natDegree ≠ 0 := by
-    rw [← leadingCoeff, Ne.def, leadingCoeff_eq_zero] ; exact pzero
+    rw [← leadingCoeff, Ne.def, leadingCoeff_eq_zero]; exact pzero
   obtain ⟨lead, hlead⟩ :=
     monomial_mem_lifts_and_degree_eq
       (monomial_mem_lifts p.natDegree ((lifts_iff_coeff_lifts p).1 hlifts p.natDegree))

--- a/Mathlib/Data/Polynomial/RingDivision.lean
+++ b/Mathlib/Data/Polynomial/RingDivision.lean
@@ -1207,7 +1207,7 @@ theorem count_map_roots [IsDomain A] [DecidableEq B] {p : A[X]} {f : A →+* B} 
     (Multiset.prod_dvd_prod_of_le <| Multiset.map_le_map <| Multiset.filter_le (Eq b) _).trans ?_
   convert Polynomial.map_dvd f p.prod_multiset_X_sub_C_dvd
   simp only [Polynomial.map_multiset_prod, Multiset.map_map]
-  congr ; ext1
+  congr; ext1
   simp only [Function.comp_apply, Polynomial.map_sub, map_X, map_C]
 #align polynomial.count_map_roots Polynomial.count_map_roots
 

--- a/Mathlib/Data/QPF/Multivariate/Basic.lean
+++ b/Mathlib/Data/QPF/Multivariate/Basic.lean
@@ -181,7 +181,7 @@ theorem mem_supp {α : TypeVec n} (x : F α) (i) (u : α i) :
 #align mvqpf.mem_supp MvQPF.mem_supp
 
 theorem supp_eq {α : TypeVec n} {i} (x : F α) :
-    supp x i = { u | ∀ a f, abs ⟨a, f⟩ = x → u ∈ f i '' univ } := by ext ; apply mem_supp
+    supp x i = { u | ∀ a f, abs ⟨a, f⟩ = x → u ∈ f i '' univ } := by ext; apply mem_supp
 #align mvqpf.supp_eq MvQPF.supp_eq
 
 theorem has_good_supp_iff {α : TypeVec n} (x : F α) :
@@ -195,7 +195,7 @@ theorem has_good_supp_iff {α : TypeVec n} (x : F α) :
     refine' ⟨a, f, xeq.symm, _⟩
     intro a' f' h''
     rintro hu u ⟨j, _h₂, hfi⟩
-    have hh : u ∈ supp x a' := by rw [← hfi] ; apply h'
+    have hh : u ∈ supp x a' := by rw [← hfi]; apply h'
     refine' (mem_supp x _ u).mp hh _ _ hu
   rintro ⟨a, f, xeq, h⟩ p; rw [liftP_iff]; constructor
   · rintro ⟨a', f', xeq', h'⟩ i u usuppx
@@ -229,7 +229,7 @@ def SuppPreservation : Prop :=
 
 theorem supp_eq_of_isUniform (h : q.IsUniform) {α : TypeVec n} (a : q.P.A) (f : q.P.B a ⟹ α) :
     ∀ i, supp (abs ⟨a, f⟩) i = f i '' univ := by
-  intro ; ext u; rw [mem_supp]; constructor
+  intro; ext u; rw [mem_supp]; constructor
   · intro h'
     apply h' _ _ rfl
   intro h' a' f' e

--- a/Mathlib/Data/QPF/Multivariate/Constructions/Prj.lean
+++ b/Mathlib/Data/QPF/Multivariate/Constructions/Prj.lean
@@ -62,7 +62,7 @@ instance Prj.mvqpf : MvQPF (Prj i) where
   abs := @Prj.abs _ i
   repr := @Prj.repr _ i
   abs_repr := by intros; rfl
-  abs_map := by intros α β f P ; cases P ; rfl
+  abs_map := by intros α β f P; cases P; rfl
 #align mvqpf.prj.mvqpf MvQPF.Prj.mvqpf
 
 end MvQPF

--- a/Mathlib/Data/Rat/Cast.lean
+++ b/Mathlib/Data/Rat/Cast.lean
@@ -106,9 +106,9 @@ theorem cast_add_of_ne_zero :
     ∀ {m n : ℚ}, (m.den : α) ≠ 0 → (n.den : α) ≠ 0 → ((m + n : ℚ) : α) = m + n
   | ⟨n₁, d₁, h₁, c₁⟩, ⟨n₂, d₂, h₂, c₂⟩ => fun (d₁0 : (d₁ : α) ≠ 0) (d₂0 : (d₂ : α) ≠ 0) => by
     have d₁0' : (d₁ : ℤ) ≠ 0 :=
-      Int.coe_nat_ne_zero.2 fun e => by rw [e] at d₁0 ; exact d₁0 Nat.cast_zero
+      Int.coe_nat_ne_zero.2 fun e => by rw [e] at d₁0; exact d₁0 Nat.cast_zero
     have d₂0' : (d₂ : ℤ) ≠ 0 :=
-      Int.coe_nat_ne_zero.2 fun e => by rw [e] at d₂0 ; exact d₂0 Nat.cast_zero
+      Int.coe_nat_ne_zero.2 fun e => by rw [e] at d₂0; exact d₂0 Nat.cast_zero
     rw [num_den', num_den', add_def'' d₁0' d₂0']
     suffices (n₁ * (d₂ * ((d₂ : α)⁻¹ * (d₁ : α)⁻¹)) + n₂ * (d₁ * (d₂ : α)⁻¹) * (d₁ : α)⁻¹ : α)
         = n₁ * (d₁ : α)⁻¹ + n₂ * (d₂ : α)⁻¹ by
@@ -130,7 +130,7 @@ theorem cast_neg : ∀ n, ((-n : ℚ) : α) = -n
 @[norm_cast]
 theorem cast_sub_of_ne_zero {m n : ℚ} (m0 : (m.den : α) ≠ 0) (n0 : (n.den : α) ≠ 0) :
     ((m - n : ℚ) : α) = m - n := by
-  have : ((-n).den : α) ≠ 0 := by cases n ; exact n0
+  have : ((-n).den : α) ≠ 0 := by cases n; exact n0
   simp [sub_eq_add_neg, cast_add_of_ne_zero m0 this]
 #align rat.cast_sub_of_ne_zero Rat.cast_sub_of_ne_zero
 
@@ -139,9 +139,9 @@ theorem cast_mul_of_ne_zero :
     ∀ {m n : ℚ}, (m.den : α) ≠ 0 → (n.den : α) ≠ 0 → ((m * n : ℚ) : α) = m * n
   | ⟨n₁, d₁, h₁, c₁⟩, ⟨n₂, d₂, h₂, c₂⟩ => fun (d₁0 : (d₁ : α) ≠ 0) (d₂0 : (d₂ : α) ≠ 0) => by
     have d₁0' : (d₁ : ℤ) ≠ 0 :=
-      Int.coe_nat_ne_zero.2 fun e => by rw [e] at d₁0 ; exact d₁0 Nat.cast_zero
+      Int.coe_nat_ne_zero.2 fun e => by rw [e] at d₁0; exact d₁0 Nat.cast_zero
     have d₂0' : (d₂ : ℤ) ≠ 0 :=
-      Int.coe_nat_ne_zero.2 fun e => by rw [e] at d₂0 ; exact d₂0 Nat.cast_zero
+      Int.coe_nat_ne_zero.2 fun e => by rw [e] at d₂0; exact d₂0 Nat.cast_zero
     rw [num_den', num_den', mul_def' d₁0' d₂0']
     suffices (n₁ * (n₂ * (d₂ : α)⁻¹ * (d₁ : α)⁻¹) : α) = n₁ * ((d₁ : α)⁻¹ * (n₂ * (d₂ : α)⁻¹)) by
       rw [cast_mk_of_ne_zero, cast_mk_of_ne_zero, cast_mk_of_ne_zero]
@@ -171,9 +171,9 @@ theorem cast_inv_int (n : ℤ) : ((n⁻¹ : ℚ) : α) = (n : α)⁻¹ := by
 theorem cast_inv_of_ne_zero :
   ∀ {n : ℚ}, (n.num : α) ≠ 0 → (n.den : α) ≠ 0 → ((n⁻¹ : ℚ) : α) = (n : α)⁻¹
   | ⟨n, d, h, c⟩ => fun (n0 : (n : α) ≠ 0) (d0 : (d : α) ≠ 0) => by
-    have _ : (n : ℤ) ≠ 0 := fun e => by rw [e] at n0 ; exact n0 Int.cast_zero
+    have _ : (n : ℤ) ≠ 0 := fun e => by rw [e] at n0; exact n0 Int.cast_zero
     have _ : (d : ℤ) ≠ 0 :=
-      Int.coe_nat_ne_zero.2 fun e => by rw [e] at d0 ; exact d0 Nat.cast_zero
+      Int.coe_nat_ne_zero.2 fun e => by rw [e] at d0; exact d0 Nat.cast_zero
     rw [num_den', inv_def']
     rw [cast_mk_of_ne_zero, cast_mk_of_ne_zero, inv_div] <;> simp [n0, d0]
 #align rat.cast_inv_of_ne_zero Rat.cast_inv_of_ne_zero
@@ -186,7 +186,7 @@ theorem cast_div_of_ne_zero {m n : ℚ} (md : (m.den : α) ≠ 0) (nn : (n.num :
     apply den_dvd
   have : (n⁻¹.den : α) = 0 → (n.num : α) = 0 := fun h => by
     let ⟨k, e⟩ := this
-    have := congr_arg ((↑) : ℤ → α) e ; rwa [Int.cast_mul, Int.cast_ofNat, h, zero_mul] at this
+    have := congr_arg ((↑) : ℤ → α) e; rwa [Int.cast_mul, Int.cast_ofNat, h, zero_mul] at this
   rw [division_def, cast_mul_of_ne_zero md (mt this nn), cast_inv_of_ne_zero nn nd, division_def]
 #align rat.cast_div_of_ne_zero Rat.cast_div_of_ne_zero
 
@@ -241,7 +241,7 @@ theorem cast_bit0 [CharZero α] (n : ℚ) : ((bit0 n : ℚ) : α) = (bit0 n : α
 
 @[simp, norm_cast]
 theorem cast_bit1 [CharZero α] (n : ℚ) : ((bit1 n : ℚ) : α) = (bit1 n : α) := by
-  rw [bit1, cast_add, cast_one, cast_bit0] ; rfl
+  rw [bit1, cast_add, cast_one, cast_bit0]; rfl
 #align rat.cast_bit1 Rat.cast_bit1
 
 end

--- a/Mathlib/Data/Rat/Defs.lean
+++ b/Mathlib/Data/Rat/Defs.lean
@@ -117,7 +117,7 @@ numbers of the form `n /. d` with `0 < d` and coprime `n`, `d`. -/
 @[elab_as_elim]
 def numDenCasesOn.{u} {C : ℚ → Sort u} :
     ∀ (a : ℚ) (_ : ∀ n d, 0 < d → (Int.natAbs n).coprime d → C (n /. d)), C a
-  | ⟨n, d, h, c⟩, H => by rw [num_den'] ; exact H n d (Nat.pos_of_ne_zero h) c
+  | ⟨n, d, h, c⟩, H => by rw [num_den']; exact H n d (Nat.pos_of_ne_zero h) c
 #align rat.num_denom_cases_on Rat.numDenCasesOn
 
 /-- Define a (dependent) function or prove `∀ r : ℚ, p r` by dealing with rational

--- a/Mathlib/Data/Rat/Lemmas.lean
+++ b/Mathlib/Data/Rat/Lemmas.lean
@@ -188,7 +188,7 @@ protected theorem inv_neg (q : ℚ) : (-q)⁻¹ = -q⁻¹ := by
 @[simp]
 theorem mul_den_eq_num {q : ℚ} : q * q.den = q.num := by
   suffices (q.num /. ↑q.den) * (↑q.den /. 1) = q.num /. 1 by
-    conv => pattern (occs := 1)q ; (rw [← @num_den q])
+    conv => pattern (occs := 1)q; (rw [← @num_den q])
     simp only [coe_int_eq_divInt, coe_nat_eq_divInt, num_den] at this ⊢; assumption
   have : (q.den : ℤ) ≠ 0 := ne_of_gt (by exact_mod_cast q.pos)
   rw [Rat.mul_def' this one_ne_zero, mul_comm (q.den : ℤ) 1, divInt_mul_right this]

--- a/Mathlib/Data/Semiquot.lean
+++ b/Mathlib/Data/Semiquot.lean
@@ -177,10 +177,9 @@ instance : LawfulMonad Semiquot := LawfulMonad.mk'
   (pure_bind := fun {α β} x f => ext.2 <| by simp)
   (bind_assoc := fun {α β} γ s f g =>
     ext.2 <| by
-    simp only [bind_def, mem_bind] ;
-     exact fun c =>
-          ⟨fun ⟨b, ⟨a, as, bf⟩, cg⟩ => ⟨a, as, b, bf, cg⟩, fun ⟨a, as, b, bf, cg⟩ =>
-            ⟨b, ⟨a, as, bf⟩, cg⟩⟩)
+    simp only [bind_def, mem_bind]
+    exact fun c => ⟨fun ⟨b, ⟨a, as, bf⟩, cg⟩ => ⟨a, as, b, bf, cg⟩,
+      fun ⟨a, as, b, bf, cg⟩ => ⟨b, ⟨a, as, bf⟩, cg⟩⟩)
   (id_map := fun {α} q => ext.2 <| by simp)
   (bind_pure_comp := fun {α β} f s => ext.2 <| by simp [eq_comm])
 

--- a/Mathlib/Data/Semiquot.lean
+++ b/Mathlib/Data/Semiquot.lean
@@ -49,7 +49,7 @@ def mk {a : α} {s : Set α} (h : a ∈ s) : Semiquot α :=
 
 theorem ext_s {q₁ q₂ : Semiquot α} : q₁ = q₂ ↔ q₁.s = q₂.s := by
   refine' ⟨congr_arg _, fun h => _⟩
-  cases' q₁ with _ v₁ ; cases' q₂ with _ v₂ ; congr
+  cases' q₁ with _ v₁; cases' q₂ with _ v₂; congr
   exact Subsingleton.helim (congrArg Trunc (congrArg Set.Elem h)) v₁ v₂
 #align semiquot.ext_s Semiquot.ext_s
 
@@ -91,7 +91,7 @@ def blur (s : Set α) (q : Semiquot α) : Semiquot α :=
 #align semiquot.blur Semiquot.blur
 
 theorem blur_eq_blur' (q : Semiquot α) (s : Set α) (h : q.s ⊆ s) : blur s q = blur' q h := by
-  unfold blur ; congr ; exact Set.union_eq_self_of_subset_right h
+  unfold blur; congr; exact Set.union_eq_self_of_subset_right h
 #align semiquot.blur_eq_blur' Semiquot.blur_eq_blur'
 
 @[simp]
@@ -121,7 +121,7 @@ def liftOn (q : Semiquot α) (f : α → β) (h : ∀ (a) (_ : a ∈ q) (b) (_ :
 warning: expanding binder collection (a b «expr ∈ » q) -/
 theorem liftOn_ofMem (q : Semiquot α) (f : α → β)
     (h : ∀ (a) (_ : a ∈ q) (b) (_ : b ∈ q), f a = f b) (a : α) (aq : a ∈ q) : liftOn q f h = f a :=
-  by revert h ; rw [eq_mk_of_mem aq] ; intro ; rfl
+  by revert h; rw [eq_mk_of_mem aq]; intro; rfl
 #align semiquot.lift_on_of_mem Semiquot.liftOn_ofMem
 
 /-- Apply a function to the unknown value stored in a `Semiquot α`. -/
@@ -219,11 +219,11 @@ def get (q : Semiquot α) (h : q.IsPure) : α :=
 
 theorem get_mem {q : Semiquot α} (p) : get q p ∈ q := by
   let ⟨a, h⟩ := exists_mem q
-  unfold get ; rw [liftOn_ofMem q _ _ a h] ; exact h
+  unfold get; rw [liftOn_ofMem q _ _ a h]; exact h
 #align semiquot.get_mem Semiquot.get_mem
 
 theorem eq_pure {q : Semiquot α} (p) : q = pure (get q p) :=
-  ext.2 fun a => by simp ; exact ⟨fun h => p _ h _ (get_mem _), fun e => e.symm ▸ get_mem _⟩
+  ext.2 fun a => by simp; exact ⟨fun h => p _ h _ (get_mem _), fun e => e.symm ▸ get_mem _⟩
 #align semiquot.eq_pure Semiquot.eq_pure
 
 @[simp]
@@ -244,7 +244,7 @@ theorem IsPure.mono {s t : Semiquot α} (st : s ≤ t) (h : IsPure t) : IsPure s
 theorem IsPure.min {s t : Semiquot α} (h : IsPure t) : s ≤ t ↔ s = t :=
   ⟨fun st =>
     le_antisymm st <| by
-      rw [eq_pure h, eq_pure (h.mono st)] ; simp ; exact h _ (get_mem _) _ (st <| get_mem _),
+      rw [eq_pure h, eq_pure (h.mono st)]; simp; exact h _ (get_mem _) _ (st <| get_mem _),
     le_of_eq⟩
 #align semiquot.is_pure.min Semiquot.IsPure.min
 

--- a/Mathlib/Data/Seq/Computation.lean
+++ b/Mathlib/Data/Seq/Computation.lean
@@ -894,10 +894,10 @@ theorem mem_map (f : α → β) {a} {s : Computation α} (m : a ∈ s) : f a ∈
 
 theorem exists_of_mem_map {f : α → β} {b : β} {s : Computation α} (h : b ∈ map f s) :
     ∃ a, a ∈ s ∧ f a = b := by
-  rw [← bind_pure] at h ;
-    exact
-      let ⟨a, as, fb⟩ := exists_of_mem_bind h
-      ⟨a, as, mem_unique (ret_mem _) fb⟩
+  rw [← bind_pure] at h
+  exact
+    let ⟨a, as, fb⟩ := exists_of_mem_bind h
+    ⟨a, as, mem_unique (ret_mem _) fb⟩
 #align computation.exists_of_mem_map Computation.exists_of_mem_map
 
 instance terminates_map (f : α → β) (s : Computation α) [Terminates s] : Terminates (map f s) := by
@@ -1193,8 +1193,8 @@ theorem liftRel_pure_right (R : α → β → Prop) (ca : Computation α) (b : �
 @[simp, nolint simpNF]
 theorem liftRel_pure (R : α → β → Prop) (a : α) (b : β) :
     LiftRel R (pure a) (pure b) ↔ R a b := by
-  rw [liftRel_pure_left] ;
-    exact ⟨fun ⟨b', mb', ab'⟩ => by rwa [eq_of_pure_mem mb'] at ab', fun ab => ⟨_, ret_mem _, ab⟩⟩
+  rw [liftRel_pure_left]
+  exact ⟨fun ⟨b', mb', ab'⟩ => by rwa [eq_of_pure_mem mb'] at ab', fun ab => ⟨_, ret_mem _, ab⟩⟩
 #align computation.lift_rel_return Computation.liftRel_pure
 
 @[simp]
@@ -1237,8 +1237,8 @@ theorem liftRel_map {δ} (R : α → β → Prop) (S : γ → δ → Prop) {s1 :
 -- porting notes: deleted initial arguments `(_R : α → α → Prop) (_S : β → β → Prop)`: unused
 theorem map_congr {s1 s2 : Computation α} {f : α → β}
     (h1 : s1 ~ s2) : map f s1 ~ map f s2 := by
-  rw [← lift_eq_iff_equiv] ;
-    exact liftRel_map Eq _ ((lift_eq_iff_equiv _ _).2 h1) fun {a} b => congr_arg _
+  rw [← lift_eq_iff_equiv]
+  exact liftRel_map Eq _ ((lift_eq_iff_equiv _ _).2 h1) fun {a} b => congr_arg _
 #align computation.map_congr Computation.map_congr
 
 /-- Alternate definition of `LiftRel` over relations between `Computation`s-/

--- a/Mathlib/Data/Seq/Computation.lean
+++ b/Mathlib/Data/Seq/Computation.lean
@@ -178,7 +178,7 @@ theorem tail_pure (a : α) : tail (pure a) = pure a :=
 
 @[simp]
 theorem tail_think (s : Computation α) : tail (think s) = s := by
-  cases' s with f al ; apply Subtype.eq ; dsimp [tail, think]
+  cases' s with f al; apply Subtype.eq; dsimp [tail, think]
 #align computation.tail_think Computation.tail_think
 
 @[simp]
@@ -407,7 +407,7 @@ theorem not_terminates_empty : ¬Terminates (empty α) := fun ⟨⟨a, h⟩⟩ =
 
 theorem eq_empty_of_not_terminates {s} (H : ¬Terminates s) : s = empty α := by
   apply Subtype.eq; funext n
-  induction' h : s.val n with _ ; · rfl
+  induction' h : s.val n with _; · rfl
   refine' absurd _ H; exact ⟨⟨_, _, h.symm⟩⟩
 #align computation.eq_empty_of_not_terminates Computation.eq_empty_of_not_terminates
 
@@ -469,7 +469,7 @@ theorem get_eq_of_mem {a} : a ∈ s → get s = a :=
   mem_unique (get_mem _)
 #align computation.get_eq_of_mem Computation.get_eq_of_mem
 
-theorem mem_of_get_eq {a} : get s = a → a ∈ s := by intro h ; rw [← h] ; apply get_mem
+theorem mem_of_get_eq {a} : get s = a → a ∈ s := by intro h; rw [← h]; apply get_mem
 #align computation.mem_of_get_eq Computation.mem_of_get_eq
 
 @[simp]
@@ -513,7 +513,7 @@ theorem results_of_terminates (s : Computation α) [_T : Terminates s] :
 #align computation.results_of_terminates Computation.results_of_terminates
 
 theorem results_of_terminates' (s : Computation α) [T : Terminates s] {a} (h : a ∈ s) :
-    Results s a (length s) := by rw [← get_eq_of_mem _ h] ; apply results_of_terminates
+    Results s a (length s) := by rw [← get_eq_of_mem _ h]; apply results_of_terminates
 #align computation.results_of_terminates' Computation.results_of_terminates'
 
 theorem Results.mem {s : Computation α} {a n} : Results s a n → a ∈ s
@@ -534,7 +534,7 @@ theorem Results.val_unique {s : Computation α} {a b m n} (h1 : Results s a m) (
 #align computation.results.val_unique Computation.Results.val_unique
 
 theorem Results.len_unique {s : Computation α} {a b m n} (h1 : Results s a m) (h2 : Results s b n) :
-    m = n := by haveI := h1.terminates ; haveI := h2.terminates ; rw [← h1.length, h2.length]
+    m = n := by haveI := h1.terminates; haveI := h2.terminates; rw [← h1.length, h2.length]
 #align computation.results.len_unique Computation.Results.len_unique
 
 theorem exists_results_of_mem {s : Computation α} {a} (h : a ∈ s) : ∃ n, Results s a n :=
@@ -563,7 +563,7 @@ theorem length_think (s : Computation α) [h : Terminates s] : length (think s) 
   · exact Nat.find_min' _ (Nat.find_spec ((terminates_def _).1 h))
   · have : (Option.isSome ((think s).val (length (think s))) : Prop) :=
       Nat.find_spec ((terminates_def _).1 s.think_terminates)
-    revert this ; cases' length (think s) with n <;> intro this
+    revert this; cases' length (think s) with n <;> intro this
     · simp [think, Stream'.cons] at this
     · apply Nat.succ_le_succ
       apply Nat.find_min'
@@ -586,7 +586,7 @@ theorem of_results_think {s : Computation α} {a n} (h : Results (think s) a n) 
 theorem results_think_iff {s : Computation α} {a n} : Results (think s) a (n + 1) ↔ Results s a n :=
   ⟨fun h => by
     let ⟨n', r, e⟩ := of_results_think h
-    injection e with h' ; rw [Nat.add, Nat.add] at h'; rwa [h'], results_think⟩
+    injection e with h'; rw [Nat.add, Nat.add] at h'; rwa [h'], results_think⟩
 #align computation.results_think_iff Computation.results_think_iff
 
 theorem results_thinkN {s : Computation α} {a m} :
@@ -597,7 +597,7 @@ set_option linter.uppercaseLean3 false in
 #align computation.results_thinkN Computation.results_thinkN
 
 theorem results_thinkN_pure (a : α) (n) : Results (thinkN (pure a) n) a n := by
-  have := results_thinkN n (results_pure a) ; rwa [Nat.zero_add] at this
+  have := results_thinkN n (results_pure a); rwa [Nat.zero_add] at this
 set_option linter.uppercaseLean3 false in
 #align computation.results_thinkN_ret Computation.results_thinkN_pure
 
@@ -699,7 +699,7 @@ theorem map_pure (f : α → β) (a) : map f (pure a) = pure (f a) :=
 
 @[simp]
 theorem map_think (f : α → β) : ∀ s, map f (think s) = think (map f s)
-  | ⟨s, al⟩ => by apply Subtype.eq ; dsimp [think, map] ; rw [Stream'.map_cons]
+  | ⟨s, al⟩ => by apply Subtype.eq; dsimp [think, map]; rw [Stream'.map_cons]
 #align computation.map_think Computation.map_think
 
 @[simp]
@@ -710,7 +710,7 @@ theorem destruct_map (f : α → β) (s) : destruct (map f s) = lmap f (rmap (ma
 @[simp]
 theorem map_id : ∀ s : Computation α, map id s = s
   | ⟨f, al⟩ => by
-    apply Subtype.eq ; simp [map, Function.comp]
+    apply Subtype.eq; simp [map, Function.comp]
     have e : @Option.rec α (fun _ => Option α) none some = id := by ext ⟨⟩ <;> rfl
     have h : ((fun x: Option α => x) = id) := by rfl
     simp [e, h, Stream'.map_id]
@@ -718,7 +718,7 @@ theorem map_id : ∀ s : Computation α, map id s = s
 
 theorem map_comp (f : α → β) (g : β → γ) : ∀ s : Computation α, map (g ∘ f) s = map g (map f s)
   | ⟨s, al⟩ => by
-    apply Subtype.eq ; dsimp [map]
+    apply Subtype.eq; dsimp [map]
     apply congr_arg fun f : _ → Option γ => Stream'.map f s
     ext ⟨⟩ <;> rfl
 #align computation.map_comp Computation.map_comp
@@ -842,7 +842,7 @@ theorem of_results_bind {s : Computation α} {f : α → Computation β} {b k} :
   · simp at h
     exact by
       let ⟨a, m, n', h1, h2, e'⟩ := IH h
-      rw [e'] ; exact ⟨a, m.succ, n', results_think h1, h2, rfl⟩
+      rw [e']; exact ⟨a, m.succ, n', results_think h1, h2, rfl⟩
 #align computation.of_results_bind Computation.of_results_bind
 
 theorem exists_of_mem_bind {s : Computation α} {f : α → Computation β} {b} (h : b ∈ bind s f) :
@@ -889,7 +889,7 @@ theorem map_think' {α β} : ∀ (f : α → β) (s), f <$> think s = think (f <
 #align computation.map_think' Computation.map_think'
 
 theorem mem_map (f : α → β) {a} {s : Computation α} (m : a ∈ s) : f a ∈ map f s := by
-  rw [← bind_pure] ; apply mem_bind m ; apply ret_mem
+  rw [← bind_pure]; apply mem_bind m; apply ret_mem
 #align computation.mem_map Computation.mem_map
 
 theorem exists_of_mem_map {f : α → β} {b : β} {s : Computation α} (h : b ∈ map f s) :
@@ -901,7 +901,7 @@ theorem exists_of_mem_map {f : α → β} {b : β} {s : Computation α} (h : b �
 #align computation.exists_of_mem_map Computation.exists_of_mem_map
 
 instance terminates_map (f : α → β) (s : Computation α) [Terminates s] : Terminates (map f s) := by
-  rw [← bind_pure] ;  exact terminates_of_mem (mem_bind (get_mem s) (get_mem (f (get s))))
+  rw [← bind_pure];  exact terminates_of_mem (mem_bind (get_mem s) (get_mem (f (get s))))
 #align computation.terminates_map Computation.terminates_map
 
 theorem terminates_map_iff (f : α → β) (s : Computation α) : Terminates (map f s) ↔ Terminates s :=
@@ -1002,7 +1002,7 @@ theorem Equiv.equivalence : Equivalence (@Equiv α) :=
 #align computation.equiv.equivalence Computation.Equiv.equivalence
 
 theorem equiv_of_mem {s t : Computation α} {a} (h1 : a ∈ s) (h2 : a ∈ t) : s ~ t := fun a' =>
-  ⟨fun ma => by rw [mem_unique ma h1] ; exact h2, fun ma => by rw [mem_unique ma h2] ; exact h1⟩
+  ⟨fun ma => by rw [mem_unique ma h1]; exact h2, fun ma => by rw [mem_unique ma h2]; exact h1⟩
 #align computation.equiv_of_mem Computation.equiv_of_mem
 
 theorem terminates_congr {c₁ c₂ : Computation α} (h : c₁ ~ c₂) : Terminates c₁ ↔ Terminates c₂ := by
@@ -1123,13 +1123,13 @@ theorem rel_of_LiftRel {R : α → β → Prop} {ca cb} :
     LiftRel R ca cb → ∀ {a b}, a ∈ ca → b ∈ cb → R a b
   | ⟨l, _⟩, a, b, ma, mb => by
     let ⟨b', mb', ab'⟩ := l ma
-    rw [mem_unique mb mb'] ; exact ab'
+    rw [mem_unique mb mb']; exact ab'
 #align computation.rel_of_lift_rel Computation.rel_of_LiftRel
 
 theorem liftRel_of_mem {R : α → β → Prop} {a b ca cb} (ma : a ∈ ca) (mb : b ∈ cb) (ab : R a b) :
     LiftRel R ca cb :=
-  ⟨fun {a'} ma' => by rw [mem_unique ma' ma] ; exact ⟨b, mb, ab⟩, fun {b'} mb' => by
-    rw [mem_unique mb' mb] ; exact ⟨a, ma, ab⟩⟩
+  ⟨fun {a'} ma' => by rw [mem_unique ma' ma]; exact ⟨b, mb, ab⟩, fun {b'} mb' => by
+    rw [mem_unique mb' mb]; exact ⟨a, ma, ab⟩⟩
 #align computation.lift_rel_of_mem Computation.liftRel_of_mem
 
 theorem exists_of_LiftRel_left {R : α → β → Prop} {ca cb} (H : LiftRel R ca cb) {a} (h : a ∈ ca) :
@@ -1179,8 +1179,8 @@ theorem liftRel_bind {δ} (R : α → β → Prop) (S : γ → δ → Prop) {s1 
 theorem liftRel_pure_left (R : α → β → Prop) (a : α) (cb : Computation β) :
     LiftRel R (pure a) cb ↔ ∃ b, b ∈ cb ∧ R a b :=
   ⟨fun ⟨l, _⟩ => l (ret_mem _), fun ⟨b, mb, ab⟩ =>
-    ⟨fun {a'} ma' => by rw [eq_of_pure_mem ma'] ; exact ⟨b, mb, ab⟩, fun {b'} mb' =>
-      ⟨_, ret_mem _, by rw [mem_unique mb' mb] ; exact ab⟩⟩⟩
+    ⟨fun {a'} ma' => by rw [eq_of_pure_mem ma']; exact ⟨b, mb, ab⟩, fun {b'} mb' =>
+      ⟨_, ret_mem _, by rw [mem_unique mb' mb]; exact ab⟩⟩⟩
 #align computation.lift_rel_return_left Computation.liftRel_pure_left
 
 @[simp]
@@ -1208,7 +1208,7 @@ theorem liftRel_think_left (R : α → β → Prop) (ca : Computation α) (cb : 
 @[simp]
 theorem liftRel_think_right (R : α → β → Prop) (ca : Computation α) (cb : Computation β) :
     LiftRel R ca (think cb) ↔ LiftRel R ca cb := by
-  rw [← LiftRel.swap R, ← LiftRel.swap R] ; apply liftRel_think_left
+  rw [← LiftRel.swap R, ← LiftRel.swap R]; apply liftRel_think_left
 #align computation.lift_rel_think_right Computation.liftRel_think_right
 
 theorem liftRel_mem_cases {R : α → β → Prop} {ca cb} (Ha : ∀ a ∈ ca, LiftRel R ca cb)
@@ -1269,7 +1269,7 @@ theorem LiftRelAux.ret_left (R : α → β → Prop) (C : Computation α → Com
   apply cb.recOn (fun b => _) fun cb => _
   · intro b
     exact
-      ⟨fun h => ⟨_, ret_mem _, h⟩, fun ⟨b', mb, h⟩ => by rw [mem_unique (ret_mem _) mb] ; exact h⟩
+      ⟨fun h => ⟨_, ret_mem _, h⟩, fun ⟨b', mb, h⟩ => by rw [mem_unique (ret_mem _) mb]; exact h⟩
   · intro
     rw [destruct_think]
     exact ⟨fun ⟨b, h, r⟩ => ⟨b, think_mem h, r⟩, fun ⟨b, h, r⟩ => ⟨b, of_think_mem h, r⟩⟩

--- a/Mathlib/Data/Seq/Seq.lean
+++ b/Mathlib/Data/Seq/Seq.lean
@@ -124,7 +124,7 @@ def TerminatedAt (s : Seq α) (n : ℕ) : Prop :=
 
 /-- It is decidable whether a sequence terminates at a given position. -/
 instance terminatedAtDecidable (s : Seq α) (n : ℕ) : Decidable (s.TerminatedAt n) :=
-  decidable_of_iff' (s.get? n).isNone <| by unfold TerminatedAt ; cases s.get? n <;> simp
+  decidable_of_iff' (s.get? n).isNone <| by unfold TerminatedAt; cases s.get? n <;> simp
 #align stream.seq.terminated_at_decidable Stream'.Seq.terminatedAtDecidable
 
 /-- A sequence terminates if there is some position `n` at which it has terminated. -/
@@ -249,7 +249,7 @@ theorem destruct_cons (a : α) : ∀ s, destruct (cons a s) = some (a, s)
 
 -- porting note: needed universe annotation to avoid universe issues
 theorem head_eq_destruct (s : Seq α) : head.{u} s = Prod.fst.{u} <$> destruct.{u} s := by
-  unfold destruct head ; cases get? s 0 <;> rfl
+  unfold destruct head; cases get? s 0 <;> rfl
 #align stream.seq.head_eq_destruct Stream'.Seq.head_eq_destruct
 
 @[simp]
@@ -305,7 +305,7 @@ theorem mem_rec_on {C : Seq α → Prop} {a s} (M : a ∈ s)
   revert e; apply s.recOn _ fun b s' => _
   · intro e; injection e
   · intro b s' e
-    have h_eq : (cons b s').val (Nat.succ k) = s'.val k := by cases s' ; rfl
+    have h_eq : (cons b s').val (Nat.succ k) = s'.val k := by cases s'; rfl
     rw [h_eq] at e
     apply h1 _ _ (Or.inr (IH e))
 #align stream.seq.mem_rec_on Stream'.Seq.mem_rec_on
@@ -389,7 +389,7 @@ theorem eq_of_bisim (bisim : IsBisimulation R) {s₁ s₂} (r : s₁ ~ s₂) : s
     match t₁, t₂, e with
     | _, _, ⟨s, s', rfl, rfl, r⟩ => by
       suffices head s = head s' ∧ R (tail s) (tail s') from
-        And.imp id (fun r => ⟨tail s, tail s', by cases s ; rfl, by cases s' ; rfl, r⟩) this
+        And.imp id (fun r => ⟨tail s, tail s', by cases s; rfl, by cases s'; rfl, r⟩) this
       have := bisim r; revert r this
       apply recOn s _ _ <;> apply recOn s' _ _
       · intro r _
@@ -697,24 +697,24 @@ theorem map_nil (f : α → β) : map f nil = nil :=
 
 @[simp]
 theorem map_cons (f : α → β) (a) : ∀ s, map f (cons a s) = cons (f a) (map f s)
-  | ⟨s, al⟩ => by apply Subtype.eq ; dsimp [cons, map] ; rw [Stream'.map_cons] ; rfl
+  | ⟨s, al⟩ => by apply Subtype.eq; dsimp [cons, map]; rw [Stream'.map_cons]; rfl
 #align stream.seq.map_cons Stream'.Seq.map_cons
 
 @[simp]
 theorem map_id : ∀ s : Seq α, map id s = s
   | ⟨s, al⟩ => by
-    apply Subtype.eq ; dsimp [map]
+    apply Subtype.eq; dsimp [map]
     rw [Option.map_id, Stream'.map_id]
 #align stream.seq.map_id Stream'.Seq.map_id
 
 @[simp]
 theorem map_tail (f : α → β) : ∀ s, map f (tail s) = tail (map f s)
-  | ⟨s, al⟩ => by apply Subtype.eq ; dsimp [tail, map]
+  | ⟨s, al⟩ => by apply Subtype.eq; dsimp [tail, map]
 #align stream.seq.map_tail Stream'.Seq.map_tail
 
 theorem map_comp (f : α → β) (g : β → γ) : ∀ s : Seq α, map (g ∘ f) s = map g (map f s)
   | ⟨s, al⟩ => by
-    apply Subtype.eq ; dsimp [map]
+    apply Subtype.eq; dsimp [map]
     apply congr_arg fun f : _ → Option γ => Stream'.map f s
     ext ⟨⟩ <;> rfl
 #align stream.seq.map_comp Stream'.Seq.map_comp
@@ -800,10 +800,10 @@ theorem join_append (S T : Seq (Seq1 α)) : join (append S T) = append (join S) 
           · apply recOn T
             · simp
             · intro s T
-              cases' s with a s ; simp
+              cases' s with a s; simp
               refine' ⟨s, nil, T, _, _⟩ <;> simp
           · intro s S
-            cases' s with a s ; simp
+            cases' s with a s; simp
             exact ⟨s, S, T, rfl, rfl⟩
         · intro _ s
           exact ⟨s, S, T, rfl, rfl⟩
@@ -812,7 +812,7 @@ theorem join_append (S T : Seq (Seq1 α)) : join (append S T) = append (join S) 
 
 @[simp]
 theorem ofStream_cons (a : α) (s) : ofStream (a::s) = cons a (ofStream s) := by
-  apply Subtype.eq ; simp [ofStream, cons] ; rw [Stream'.map_cons]
+  apply Subtype.eq; simp [ofStream, cons]; rw [Stream'.map_cons]
 #align stream.seq.of_stream_cons Stream'.Seq.ofStream_cons
 
 @[simp]
@@ -844,7 +844,7 @@ theorem dropn_add (s : Seq α) (m) : ∀ n, drop s (m + n) = drop (drop s m) n
 #align stream.seq.dropn_add Stream'.Seq.dropn_add
 
 theorem dropn_tail (s : Seq α) (n) : drop (tail s) n = drop s (n + 1) := by
-  rw [add_comm] ; symm ; apply dropn_add
+  rw [add_comm]; symm; apply dropn_add
 #align stream.seq.dropn_tail Stream'.Seq.dropn_tail
 
 @[simp]
@@ -863,7 +863,7 @@ theorem exists_of_mem_map {f} {b : β} : ∀ {s : Seq α}, b ∈ map f s → ∃
     let ⟨o, om, oe⟩ := @Stream'.exists_of_mem_map _ _ (Option.map f) (some b) g h
     cases' o with a
     · injection oe
-    · injection oe with h' ; exact ⟨a, om, h'⟩
+    · injection oe with h'; exact ⟨a, om, h'⟩
 #align stream.seq.exists_of_mem_map Stream'.Seq.exists_of_mem_map
 
 theorem of_mem_append {s₁ s₂ : Seq α} {a : α} (h : a ∈ append s₁ s₂) : a ∈ s₁ ∨ a ∈ s₂ := by
@@ -887,7 +887,7 @@ theorem of_mem_append {s₁ s₂ : Seq α} {a : α} (h : a ∈ append s₁ s₂)
 #align stream.seq.of_mem_append Stream'.Seq.of_mem_append
 
 theorem mem_append_left {s₁ s₂ : Seq α} {a : α} (h : a ∈ s₁) : a ∈ append s₁ s₂ := by
-  apply mem_rec_on h ; intros ; simp [*]
+  apply mem_rec_on h; intros; simp [*]
 #align stream.seq.mem_append_left Stream'.Seq.mem_append_left
 
 @[simp]
@@ -944,7 +944,7 @@ theorem join_nil (a : α) (S) : join ((a, nil), S) = (a, Seq.join S) :=
 @[simp]
 theorem join_cons (a b : α) (s S) :
     join ((a, Seq.cons b s), S) = (a, Seq.join (Seq.cons (b, s) S)) := by
-  dsimp [join] ; rw [destruct_cons]
+  dsimp [join]; rw [destruct_cons]
 #align stream.seq1.join_cons Stream'.Seq1.join_cons
 
 /-- The `return` operator for the `Seq1` monad,
@@ -966,7 +966,7 @@ def bind (s : Seq1 α) (f : α → Seq1 β) : Seq1 β :=
 
 @[simp]
 theorem join_map_ret (s : Seq α) : Seq.join (Seq.map ret s) = s := by
-  apply coinduction2 s ; intro s ; apply recOn s <;> simp [ret]
+  apply coinduction2 s; intro s; apply recOn s <;> simp [ret]
 #align stream.seq1.join_map_ret Stream'.Seq1.join_map_ret
 
 @[simp]
@@ -998,7 +998,7 @@ theorem map_join' (f : α → β) (S) : Seq.map f (Seq.join S) = Seq.join (Seq.m
         apply recOn s <;> simp
         · apply recOn S <;> simp
           · intro x S
-            cases' x with a s ; simp [map]
+            cases' x with a s; simp [map]
             exact ⟨_, _, rfl, rfl⟩
         · intro _ s
           refine' ⟨s, S, rfl, rfl⟩
@@ -1024,7 +1024,7 @@ theorem join_join (SS : Seq (Seq1 (Seq1 α))) :
         apply recOn s <;> simp
         · apply recOn SS <;> simp
           · intro S SS
-            cases' S with s S ; cases' s with x s ; simp [map]
+            cases' S with s S; cases' s with x s; simp [map]
             apply recOn s <;> simp
             · exact ⟨_, _, rfl, rfl⟩
             · intro x s

--- a/Mathlib/Data/Set/Basic.lean
+++ b/Mathlib/Data/Set/Basic.lean
@@ -226,7 +226,7 @@ theorem Subtype.mem {α : Type _} {s : Set α} (p : s) : (p : α) ∈ s :=
 
 /-- Duplicate of `Eq.subset'`, which currently has elaboration problems. -/
 theorem Eq.subset {α} {s t : Set α} : s = t → s ⊆ t :=
-  fun h₁ _ h₂ => by rw [← h₁] ; exact h₂
+  fun h₁ _ h₂ => by rw [← h₁]; exact h₂
 #align eq.subset Eq.subset
 
 namespace Set

--- a/Mathlib/Data/Set/Finite.lean
+++ b/Mathlib/Data/Set/Finite.lean
@@ -1221,7 +1221,7 @@ theorem card_fintypeInsertOfNotMem {a : α} (s : Set α) [Fintype s] (h : a ∉ 
 @[simp]
 theorem card_insert {a : α} (s : Set α) [Fintype s] (h : a ∉ s)
     {d : Fintype.{u} (insert a s : Set α)} : @Fintype.card _ d = Fintype.card s + 1 := by
-  rw [← card_fintypeInsertOfNotMem s h] ; congr; exact Subsingleton.elim _ _
+  rw [← card_fintypeInsertOfNotMem s h]; congr; exact Subsingleton.elim _ _
 #align set.card_insert Set.card_insert
 
 theorem card_image_of_inj_on {s : Set α} [Fintype s] {f : α → β} [Fintype (f '' s)]

--- a/Mathlib/Data/Set/Ncard.lean
+++ b/Mathlib/Data/Set/Ncard.lean
@@ -642,7 +642,7 @@ theorem exists_eq_insert_iff_ncard (hs : s.Finite := by toFinite_tac) :
   cases' t.finite_or_infinite with ht ht
   · rw [ncard_eq_toFinset_card _ hs, ncard_eq_toFinset_card _ ht,
       ←@Finite.toFinset_subset_toFinset _ _ _ hs ht, ←Finset.exists_eq_insert_iff]
-    convert Iff.rfl using 2 ; simp
+    convert Iff.rfl using 2; simp
     ext x
     simp [Finset.ext_iff, Set.ext_iff]
   simp only [ht.ncard, exists_prop, add_eq_zero, and_false, iff_false, not_exists, not_and]

--- a/Mathlib/Data/Stream/Init.lean
+++ b/Mathlib/Data/Stream/Init.lean
@@ -667,7 +667,7 @@ theorem cycle_singleton (a : α) : cycle [a] (by simp) = const a :=
 #align stream.cycle_singleton Stream'.cycle_singleton
 
 theorem tails_eq (s : Stream' α) : tails s = tail s::tails (tail s) := by
-  unfold tails ; rw [corec_eq] ; rfl
+  unfold tails; rw [corec_eq]; rfl
 #align stream.tails_eq Stream'.tails_eq
 
 @[simp]

--- a/Mathlib/Data/Vector.lean
+++ b/Mathlib/Data/Vector.lean
@@ -92,7 +92,7 @@ def toList (v : Vector α n) : List α :=
 -- porting notes: align to `List` API
 /-- nth element of a vector, indexed by a `Fin` type. -/
 def get : ∀ _ : Vector α n, Fin n → α
-  | ⟨l, h⟩, i => l.nthLe i.1 (by rw [h] ; exact i.2)
+  | ⟨l, h⟩, i => l.nthLe i.1 (by rw [h]; exact i.2)
 #align vector.nth Vector.get
 
 /-- Appending a vector to another. -/
@@ -164,7 +164,7 @@ def take (i : ℕ) : Vector α n → Vector α (min i n)
 
 /-- Remove the element at position `i` from a vector of length `n`. -/
 def removeNth (i : Fin n) : Vector α n → Vector α (n - 1)
-  | ⟨l, p⟩ => ⟨List.removeNth l i.1, by rw [l.length_removeNth] <;> rw [p] ; exact i.2⟩
+  | ⟨l, p⟩ => ⟨List.removeNth l i.1, by rw [l.length_removeNth] <;> rw [p]; exact i.2⟩
 #align vector.remove_nth Vector.removeNth
 
 /-- Vector of length `n` from a function on `Fin n`. -/
@@ -233,7 +233,7 @@ theorem toList_length (v : Vector α n) : (toList v).length = n :=
 the `cons` of the list obtained by `toList` and the element -/
 @[simp]
 theorem toList_cons (a : α) (v : Vector α n) : toList (cons a v) = a :: toList v := by
-  cases v ; rfl
+  cases v; rfl
 #align vector.to_list_cons Vector.toList_cons
 
 /-- Appending of vectors corresponds under `toList` to appending of lists. -/

--- a/Mathlib/Data/Vector/Basic.lean
+++ b/Mathlib/Data/Vector/Basic.lean
@@ -98,7 +98,7 @@ theorem mk_toList : ∀ (v : Vector α n) (h), (⟨toList v, h⟩ : Vector α n)
 
 @[simp]
 theorem toList_map {β : Type _} (v : Vector α n) (f : α → β) : (v.map f).toList = v.toList.map f :=
-  by cases v ; rfl
+  by cases v; rfl
 #align vector.to_list_map Vector.toList_map
 
 @[simp]
@@ -122,7 +122,7 @@ theorem get_eq_get (v : Vector α n) (i : Fin n) :
 -- porting notes: `nthLe` deprecated for `get`
 @[deprecated get_eq_get]
 theorem nth_eq_nthLe :
-    ∀ (v : Vector α n) (i), get v i = v.toList.nthLe i.1 (by rw [toList_length] ; exact i.2)
+    ∀ (v : Vector α n) (i), get v i = v.toList.nthLe i.1 (by rw [toList_length]; exact i.2)
   | ⟨_, _⟩, _ => rfl
 
 @[simp]
@@ -167,7 +167,7 @@ def _root_.Equiv.vectorEquivFin (α : Type _) (n : ℕ) : Vector α n ≃ (Fin n
 
 theorem get_tail (x : Vector α n) (i) :
     x.tail.get i = x.get ⟨i.1 + 1, lt_tsub_iff_right.mp i.2⟩ := by
-  cases' i with i ih ; dsimp
+  cases' i with i ih; dsimp
   rcases x with ⟨_ | _, h⟩ <;> try rfl
   rw [List.length] at h
   rw [←h] at ih
@@ -176,7 +176,7 @@ theorem get_tail (x : Vector α n) (i) :
 
 @[simp]
 theorem get_tail_succ : ∀ (v : Vector α n.succ) (i : Fin n), get (tail v) i = get v i.succ
-  | ⟨a :: l, e⟩, ⟨i, h⟩ => by simp [get_eq_get] ; rfl
+  | ⟨a :: l, e⟩, ⟨i, h⟩ => by simp [get_eq_get]; rfl
 #align vector.nth_tail_succ Vector.get_tail_succ
 
 @[simp]
@@ -637,7 +637,7 @@ theorem get_set_of_ne {v : Vector α n} {i j : Fin n} (h : i ≠ j) (a : α) :
 
 theorem get_set_eq_if {v : Vector α n} {i j : Fin n} (a : α) :
     (v.set i a).get j = if i = j then a else v.get j := by
-  split_ifs <;> try simp [*] <;> try rw [get_set_of_ne] ; assumption
+  split_ifs <;> try simp [*] <;> try rw [get_set_of_ne]; assumption
 #align vector.nth_update_nth_eq_if Vector.get_set_eq_if
 
 @[to_additive]
@@ -688,7 +688,7 @@ variable {α β : Type u}
 @[simp]
 protected theorem traverse_def (f : α → F β) (x : α) :
     ∀ xs : Vector α n, (x ::ᵥ xs).traverse f = cons <$> f x <*> xs.traverse f := by
-  rintro ⟨xs, rfl⟩ ; rfl
+  rintro ⟨xs, rfl⟩; rfl
 #align vector.traverse_def Vector.traverse_def
 
 protected theorem id_traverse : ∀ x : Vector α n, x.traverse (pure : _ → Id _) = x := by
@@ -720,7 +720,7 @@ protected theorem comp_traverse (f : β → F γ) (g : α → G β) (x : Vector 
 
 protected theorem traverse_eq_map_id {α β} (f : α → β) :
     ∀ x : Vector α n, x.traverse ((pure: _ → Id _) ∘ f) = (pure: _ → Id _) (map f x) := by
-  rintro ⟨x, rfl⟩ ; simp! ; induction x <;> simp! [*, functor_norm] <;> rfl
+  rintro ⟨x, rfl⟩; simp!; induction x <;> simp! [*, functor_norm] <;> rfl
 #align vector.traverse_eq_map_id Vector.traverse_eq_map_id
 
 variable (η : ApplicativeTransformation F G)

--- a/Mathlib/Dynamics/Ergodic/AddCircle.lean
+++ b/Mathlib/Dynamics/Ergodic/AddCircle.lean
@@ -133,7 +133,7 @@ theorem ergodic_zsmul_add (x : AddCircle T) {n : ℤ} (h : 1 < |n|) : Ergodic fu
   suffices e ∘ f ∘ e.symm = fun y => n • y by
     rw [← he.ergodic_conjugate_iff, this]; exact ergodic_zsmul h
   replace h : n - 1 ≠ 0
-  · rw [← abs_one] at h ; rw [sub_ne_zero]; exact ne_of_apply_ne _ (ne_of_gt h)
+  · rw [← abs_one] at h; rw [sub_ne_zero]; exact ne_of_apply_ne _ (ne_of_gt h)
   have hnx : n • DivisibleBy.div x (n - 1) = x + DivisibleBy.div x (n - 1) := by
     conv_rhs => congr; rw [← DivisibleBy.div_cancel x h]
     rw [sub_smul, one_smul, sub_add_cancel]

--- a/Mathlib/FieldTheory/Finite/Basic.lean
+++ b/Mathlib/FieldTheory/Finite/Basic.lean
@@ -189,7 +189,7 @@ theorem sum_pow_units [Fintype Kˣ] (i : ℕ) :
   let φ : Kˣ →* K :=
     { toFun := fun x => x ^ i
       map_one' := by simp
-      map_mul' := by intros ; simp [mul_pow] }
+      map_mul' := by intros; simp [mul_pow] }
   have : Decidable (φ = 1) := by classical infer_instance
   calc (∑ x : Kˣ, φ x) = if φ = 1 then Fintype.card Kˣ else 0 := sum_hom_units φ
       _ = if q - 1 ∣ i then -1 else 0 := by

--- a/Mathlib/FieldTheory/Fixed.lean
+++ b/Mathlib/FieldTheory/Fixed.lean
@@ -133,7 +133,7 @@ theorem linearIndependent_smul_of_linearIndependent {s : Finset F} :
   rw [coe_insert] at hs ⊢
   rw [linearIndependent_insert (mt mem_coe.1 has)] at hs
   rw [linearIndependent_insert' (mt mem_coe.1 has)]; refine' ⟨ih hs.1, fun ha => _⟩
-  rw [Finsupp.mem_span_image_iff_total] at ha ; rcases ha with ⟨l, hl, hla⟩
+  rw [Finsupp.mem_span_image_iff_total] at ha; rcases ha with ⟨l, hl, hla⟩
   rw [Finsupp.total_apply_of_mem_supported F hl] at hla
   suffices ∀ i ∈ s, l i ∈ FixedPoints.subfield G F by
     replace hla := (sum_apply _ _ fun i => l i • toFun G F i).symm.trans (congr_fun hla 1)

--- a/Mathlib/FieldTheory/IsAlgClosed/Spectrum.lean
+++ b/Mathlib/FieldTheory/IsAlgClosed/Spectrum.lean
@@ -160,7 +160,7 @@ over an algebraically closed field `𝕜` has non-empty spectrum. -/
 theorem nonempty_of_isAlgClosed_of_finiteDimensional [IsAlgClosed 𝕜] [Nontrivial A]
     [I : FiniteDimensional 𝕜 A] (a : A) : (σ a).Nonempty := by
   obtain ⟨p, ⟨h_mon, h_eval_p⟩⟩ := isIntegral_of_noetherian (IsNoetherian.iff_fg.2 I) a
-  have nu : ¬IsUnit (aeval a p) := by rw [← aeval_def] at h_eval_p ; rw [h_eval_p]; simp
+  have nu : ¬IsUnit (aeval a p) := by rw [← aeval_def] at h_eval_p; rw [h_eval_p]; simp
   rw [eq_prod_roots_of_monic_of_splits_id h_mon (IsAlgClosed.splits p)] at nu
   obtain ⟨k, hk, _⟩ := exists_mem_of_not_isUnit_aeval_prod nu
   exact ⟨k, hk⟩

--- a/Mathlib/FieldTheory/SplittingField/Construction.lean
+++ b/Mathlib/FieldTheory/SplittingField/Construction.lean
@@ -186,7 +186,7 @@ protected theorem splits (n : ℕ) :
         (le_trans degree_le_natDegree <| hf.symm ▸ WithBot.coe_le_coe.2 zero_le_one))
     fun n ih {K} _ f hf => by
     rw [← splits_id_iff_splits, algebraMap_succ, ← map_map, splits_id_iff_splits,
-      ← X_sub_C_mul_removeFactor f fun h => by rw [h] at hf ; cases hf]
+      ← X_sub_C_mul_removeFactor f fun h => by rw [h] at hf; cases hf]
     exact splits_mul _ (splits_X_sub_C _) (ih _ (natDegree_removeFactor' hf))
 #align polynomial.splitting_field_aux.splits Polynomial.SplittingFieldAux.splits
 
@@ -202,8 +202,8 @@ theorem adjoin_rootSet (n : ℕ) :
               Set (SplittingFieldAux n f)) = ⊤)
     n (fun {K} _ f _hf => Algebra.eq_top_iff.2 fun x => Subalgebra.range_le _ ⟨x, rfl⟩)
     fun n ih {K} _ f hfn => by
-    have hndf : f.natDegree ≠ 0 := by intro h; rw [h] at hfn ; cases hfn
-    have hfn0 : f ≠ 0 := by intro h; rw [h] at hndf ; exact hndf rfl
+    have hndf : f.natDegree ≠ 0 := by intro h; rw [h] at hfn; cases hfn
+    have hfn0 : f ≠ 0 := by intro h; rw [h] at hndf; exact hndf rfl
     have hmf0 : map (algebraMap K (SplittingFieldAux n.succ f)) f ≠ 0 := map_ne_zero hfn0
     rw [algebraMap_succ, ←map_map, ←X_sub_C_mul_removeFactor _ hndf, Polynomial.map_mul] at hmf0 ⊢
     rw [roots_mul hmf0, Polynomial.map_sub, map_X, map_C, roots_X_sub_C, Multiset.toFinset_add,

--- a/Mathlib/FieldTheory/Subfield.lean
+++ b/Mathlib/FieldTheory/Subfield.lean
@@ -122,7 +122,7 @@ variable (S)
 /-- A subfield inherits a field structure -/
 instance (priority := 75) toField (s : S) : Field s :=
   Subtype.coe_injective.field ((↑) : s → K)
-    (by rfl) (by rfl) (by intros _ _; rfl) (by intros _ _; rfl) (by intros _ ; rfl)
+    (by rfl) (by rfl) (by intros _ _; rfl) (by intros _ _; rfl) (by intros _; rfl)
     (by intros _ _; rfl) (by intros _; rfl) (by intros _ _; rfl) (by intros _ _; rfl)
     (by intros _ _; rfl) (by intros _ _; rfl) (by intros _ _; rfl) (by intros _ _; rfl)
     (by intros _; rfl) (by intros _; rfl) (by intros _; rfl)

--- a/Mathlib/Geometry/Euclidean/Angle/Oriented/Affine.lean
+++ b/Mathlib/Geometry/Euclidean/Angle/Oriented/Affine.lean
@@ -552,7 +552,7 @@ same ray. -/
 theorem _root_.Wbtw.oangle_eq_left {p₁ p₁' p₂ p₃ : P} (h : Wbtw ℝ p₂ p₁ p₁') (hp₁p₂ : p₁ ≠ p₂) :
     ∡ p₁ p₂ p₃ = ∡ p₁' p₂ p₃ := by
   by_cases hp₃p₂ : p₃ = p₂; · simp [hp₃p₂]
-  by_cases hp₁'p₂ : p₁' = p₂; · rw [hp₁'p₂, wbtw_self_iff] at h ; exact False.elim (hp₁p₂ h)
+  by_cases hp₁'p₂ : p₁' = p₂; · rw [hp₁'p₂, wbtw_self_iff] at h; exact False.elim (hp₁p₂ h)
   rw [← oangle_add hp₁'p₂ hp₁p₂ hp₃p₂, h.oangle₃₁₂_eq_zero, zero_add]
 #align wbtw.oangle_eq_left Wbtw.oangle_eq_left
 

--- a/Mathlib/Geometry/Manifold/ContMDiff.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiff.lean
@@ -156,7 +156,7 @@ theorem contDiffWithinAt_localInvariantProp (n : ℕ∞) :
     have := (mem_groupoid_of_pregroupoid.2 he').1.contDiffWithinAt A
     convert (this.of_le le_top).comp _ h _
     · ext y; simp only [mfld_simps]
-    · intro y hy; simp only [mfld_simps] at hy ; simpa only [hy, mfld_simps] using hs hy.1
+    · intro y hy; simp only [mfld_simps] at hy; simpa only [hy, mfld_simps] using hs hy.1
 #align cont_diff_within_at_local_invariant_prop contDiffWithinAt_localInvariantProp
 
 theorem contDiffWithinAtProp_mono_of_mem (n : ℕ∞) ⦃s x t⦄ ⦃f : H → H'⦄ (hts : s ∈ 𝓝[t] x)

--- a/Mathlib/Geometry/Manifold/Instances/Real.lean
+++ b/Mathlib/Geometry/Manifold/Instances/Real.lean
@@ -177,7 +177,7 @@ def IccLeftChart (x y : ℝ) [h : Fact (x < y)] :
   map_source' := by simp only [imp_self, sub_lt_sub_iff_right, mem_setOf_eq, forall_true_iff]
   map_target' := by
     simp only [min_lt_iff, mem_setOf_eq]; intro z hz; left
-    dsimp at hz ; linarith
+    dsimp at hz; linarith
   left_inv' := by
     rintro ⟨z, hz⟩ h'z
     simp only [mem_setOf_eq, mem_Icc] at hz h'z
@@ -226,7 +226,7 @@ def IccRightChart (x y : ℝ) [h : Fact (x < y)] :
   map_source' := by simp only [imp_self, mem_setOf_eq, sub_lt_sub_iff_left, forall_true_iff]
   map_target' := by
     simp only [lt_max_iff, mem_setOf_eq]; intro z hz; left
-    dsimp at hz ; linarith
+    dsimp at hz; linarith
   left_inv' := by
     rintro ⟨z, hz⟩ h'z
     simp only [mem_setOf_eq, mem_Icc] at hz h'z

--- a/Mathlib/Geometry/Manifold/MFDeriv.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv.lean
@@ -176,7 +176,7 @@ theorem differentiable_within_at_localInvariantProp :
       have := (mem_groupoid_of_pregroupoid.2 he').1.contDiffWithinAt A
       convert (this.differentiableWithinAt le_top).comp _ h _
       · ext y; simp only [mfld_simps]
-      · intro y hy; simp only [mfld_simps] at hy ; simpa only [hy, mfld_simps] using hs hy.1 }
+      · intro y hy; simp only [mfld_simps] at hy; simpa only [hy, mfld_simps] using hs hy.1 }
 #align differentiable_within_at_local_invariant_prop differentiable_within_at_localInvariantProp
 
 /-- Predicate ensuring that, at a point and within a set, a function can have at most one
@@ -1671,7 +1671,7 @@ theorem mfderiv_neg (f : M → E') (x : M) :
   simp_rw [mfderiv]
   by_cases hf : MDifferentiableAt I 𝓘(𝕜, E') f x
   · exact hf.hasMFDerivAt.neg.mfderiv
-  · rw [if_neg hf]; rw [← mdifferentiableAt_neg] at hf ; rw [if_neg hf, neg_zero]
+  · rw [if_neg hf]; rw [← mdifferentiableAt_neg] at hf; rw [if_neg hf, neg_zero]
 #align mfderiv_neg mfderiv_neg
 
 theorem HasMFDerivAt.sub (hf : HasMFDerivAt I 𝓘(𝕜, E') f z f')

--- a/Mathlib/Geometry/Manifold/SmoothManifoldWithCorners.lean
+++ b/Mathlib/Geometry/Manifold/SmoothManifoldWithCorners.lean
@@ -345,7 +345,7 @@ theorem symm_continuousWithinAt_comp_right_iff {X} [TopologicalSpace X] {f : H �
     simp_rw [preimage_inter, preimage_preimage, I.left_inv, preimage_id', preimage_range,
       inter_univ] at this 
     rwa [Function.comp.assoc, I.symm_comp_self] at this 
-  · rw [← I.left_inv x] at h ; exact h.comp I.continuousWithinAt_symm (inter_subset_left _ _)
+  · rw [← I.left_inv x] at h; exact h.comp I.continuousWithinAt_symm (inter_subset_left _ _)
 #align model_with_corners.symm_continuous_within_at_comp_right_iff ModelWithCorners.symm_continuousWithinAt_comp_right_iff
 
 protected theorem locally_compact [LocallyCompactSpace E] (I : ModelWithCorners 𝕜 E H) :

--- a/Mathlib/GroupTheory/Finiteness.lean
+++ b/Mathlib/GroupTheory/Finiteness.lean
@@ -136,7 +136,7 @@ instance Monoid.fg_of_addMonoid_fg [AddMonoid.FG N] : Monoid.FG (Multiplicative 
 @[to_additive]
 instance (priority := 100) Monoid.fg_of_finite [Finite M] : Monoid.FG M := by
   cases nonempty_fintype M
-  exact ⟨⟨Finset.univ, by rw [Finset.coe_univ] ; exact Submonoid.closure_univ⟩⟩
+  exact ⟨⟨Finset.univ, by rw [Finset.coe_univ]; exact Submonoid.closure_univ⟩⟩
 #align monoid.fg_of_finite Monoid.fg_of_finite
 #align add_monoid.fg_of_finite AddMonoid.fg_of_finite
 
@@ -345,7 +345,7 @@ instance Group.fg_of_mul_group_fg [AddGroup.FG H] : Group.FG (Multiplicative H) 
 @[to_additive]
 instance (priority := 100) Group.fg_of_finite [Finite G] : Group.FG G := by
   cases nonempty_fintype G
-  exact ⟨⟨Finset.univ, by rw [Finset.coe_univ] ; exact Subgroup.closure_univ⟩⟩
+  exact ⟨⟨Finset.univ, by rw [Finset.coe_univ]; exact Subgroup.closure_univ⟩⟩
 #align group.fg_of_finite Group.fg_of_finite
 #align add_group.fg_of_finite AddGroup.fg_of_finite
 

--- a/Mathlib/GroupTheory/FreeGroup.lean
+++ b/Mathlib/GroupTheory/FreeGroup.lean
@@ -201,13 +201,13 @@ theorem Step.diamond_aux :
     ∀ {L₁ L₂ L₃ L₄ : List (α × Bool)} {x1 b1 x2 b2},
       L₁ ++ (x1, b1) :: (x1, !b1) :: L₂ = L₃ ++ (x2, b2) :: (x2, !b2) :: L₄ →
         L₁ ++ L₂ = L₃ ++ L₄ ∨ ∃ L₅, Red.Step (L₁ ++ L₂) L₅ ∧ Red.Step (L₃ ++ L₄) L₅
-  | [], _, [], _, _, _, _, _, H => by injections ; subst_vars ; simp
-  | [], _, [(x3, b3)], _, _, _, _, _, H => by injections ; subst_vars ; simp
-  | [(x3, b3)], _, [], _, _, _, _, _, H => by injections ; subst_vars ; simp
+  | [], _, [], _, _, _, _, _, H => by injections; subst_vars; simp
+  | [], _, [(x3, b3)], _, _, _, _, _, H => by injections; subst_vars; simp
+  | [(x3, b3)], _, [], _, _, _, _, _, H => by injections; subst_vars; simp
   | [], _, (x3, b3) :: (x4, b4) :: tl, _, _, _, _, _, H => by
-    injections ; subst_vars ; simp ; right ; exact ⟨_, Red.Step.not, Red.Step.cons_not⟩
+    injections; subst_vars; simp; right; exact ⟨_, Red.Step.not, Red.Step.cons_not⟩
   | (x3, b3) :: (x4, b4) :: tl, _, [], _, _, _, _, _, H => by
-    injections ; subst_vars ; simp ; right ; exact ⟨_, Red.Step.cons_not, Red.Step.not⟩
+    injections; subst_vars; simp; right; exact ⟨_, Red.Step.cons_not, Red.Step.not⟩
   | (x3, b3) :: tl, _, (x4, b4) :: tl2, _, _, _, _, _, H =>
     let ⟨H1, H2⟩ := List.cons.inj H
     match Step.diamond_aux H2 with
@@ -673,7 +673,7 @@ theorem Red.exact : mk L₁ = mk L₂ ↔ Join Red L₁ L₂ :=
 @[to_additive "The canonical map from the type to the additive free group is an injection."]
 theorem of_injective : Function.Injective (@of α) := fun _ _ H => by
   let ⟨L₁, hx, hy⟩ := Red.exact.1 H
-  simp [Red.singleton_iff] at hx hy ; aesop
+  simp [Red.singleton_iff] at hx hy; aesop
 #align free_group.of_injective FreeGroup.of_injective
 #align free_add_group.of_injective FreeAddGroup.of_injective
 
@@ -791,7 +791,7 @@ variable {β : Type v} (f : α → β) {x y : FreeGroup α}
   the additive free group over `α` to the additive free group over `β`."]
 def map : FreeGroup α →* FreeGroup β :=
   MonoidHom.mk'
-    (Quot.map (List.map fun x => (f x.1, x.2)) fun L₁ L₂ H => by cases H ; simp)
+    (Quot.map (List.map fun x => (f x.1, x.2)) fun L₁ L₂ H => by cases H; simp)
     (by rintro ⟨L₁⟩ ⟨L₂⟩; simp)
 #align free_group.map FreeGroup.map
 #align free_add_group.map FreeAddGroup.map

--- a/Mathlib/GroupTheory/IsFreeGroup.lean
+++ b/Mathlib/GroupTheory/IsFreeGroup.lean
@@ -145,7 +145,7 @@ def ofLift {G : Type u} [Group G] (X : Type u) (of : X → G)
           lift_of])
       (by
         let lift_symm_of : ∀ {H : Type u} [Group H], ∀ (f : G →* H) (a), lift.symm f a = f (of a) :=
-          by intro H _ f a ; simp [← lift_of (lift.symm f)]
+          by intro H _ f a; simp [← lift_of (lift.symm f)]
         apply lift.symm.injective; ext x
         simp only [MonoidHom.coe_comp, Function.comp_apply, MonoidHom.id_apply, FreeGroup.lift.of,
           lift_of, lift_symm_of])

--- a/Mathlib/GroupTheory/MonoidLocalization.lean
+++ b/Mathlib/GroupTheory/MonoidLocalization.lean
@@ -171,13 +171,13 @@ def r' : Con (M × S) := by
     simp only [Submonoid.coe_mul]
     calc
       (t₂ * t₁ * b.2 : M) * (c.2 * a.1) = t₂ * c.2 * (t₁ * (b.2 * a.1)) := by ac_rfl
-      _ = t₁ * a.2 * (t₂ * (c.2 * b.1)) := by rw [ht₁] ; ac_rfl
-      _ = t₂ * t₁ * b.2 * (a.2 * c.1) := by rw [ht₂] ; ac_rfl
+      _ = t₁ * a.2 * (t₂ * (c.2 * b.1)) := by rw [ht₁]; ac_rfl
+      _ = t₂ * t₁ * b.2 * (a.2 * c.1) := by rw [ht₂]; ac_rfl
   · rintro a b c d ⟨t₁, ht₁⟩ ⟨t₂, ht₂⟩
     use t₂ * t₁
     calc
       (t₂ * t₁ : M) * (b.2 * d.2 * (a.1 * c.1)) = t₂ * (d.2 * c.1) * (t₁ * (b.2 * a.1)) := by ac_rfl
-      _ = (t₂ * t₁ : M) * (a.2 * c.2 * (b.1 * d.1)) := by rw [ht₁, ht₂] ; ac_rfl
+      _ = (t₂ * t₁ : M) * (a.2 * c.2 * (b.1 * d.1)) := by rw [ht₁, ht₂]; ac_rfl
 #align localization.r' Localization.r'
 #align add_localization.r' AddLocalization.r'
 
@@ -203,7 +203,7 @@ variable {S}
 
 @[to_additive AddLocalization.r_iff_exists]
 theorem r_iff_exists {x y : M × S} : r S x y ↔ ∃ c : S, ↑c * (↑y.2 * x.1) = c * (x.2 * y.1) := by
-  rw [r_eq_r' S] ; rfl
+  rw [r_eq_r' S]; rfl
 #align localization.r_iff_exists Localization.r_iff_exists
 #align add_localization.r_iff_exists AddLocalization.r_iff_exists
 
@@ -307,7 +307,7 @@ then `f` is defined on the whole `AddLocalization S`."]
 def rec {p : Localization S → Sort u} (f : ∀ (a : M) (b : S), p (mk a b))
     (H : ∀ {a c : M} {b d : S} (h : r S (a, b) (c, d)),
       (Eq.ndrec (f a b) (mk_eq_mk_iff.mpr h) : p (mk c d)) = f c d) (x) : p x :=
-  Quot.rec (fun y ↦ Eq.ndrec (f y.1 y.2) (by rfl)) (fun y z h ↦ by cases y ; cases z ; exact H h) x
+  Quot.rec (fun y ↦ Eq.ndrec (f y.1 y.2) (by rfl)) (fun y z h ↦ by cases y; cases z; exact H h) x
 #align localization.rec Localization.rec
 #align add_localization.rec AddLocalization.rec
 
@@ -925,13 +925,13 @@ induced from `N` to `P` sending `z : N` to `g x - g y`, where `(x, y) : M × S` 
 `z = f x - f y`."]
 noncomputable def lift : N →* P where
   toFun z := g (f.sec z).1 * (IsUnit.liftRight (g.restrict S) hg (f.sec z).2)⁻¹
-  map_one' := by rw [mul_inv_left, mul_one] ; exact f.eq_of_eq hg (by rw [← sec_spec, one_mul])
+  map_one' := by rw [mul_inv_left, mul_one]; exact f.eq_of_eq hg (by rw [← sec_spec, one_mul])
   map_mul' x y := by
     dsimp only
     rw [mul_inv_left hg, ← mul_assoc, ← mul_assoc, mul_inv_right hg, mul_comm _ (g (f.sec y).1), ←
       mul_assoc, ← mul_assoc, mul_inv_right hg]
     repeat' rw [← g.map_mul]
-    exact f.eq_of_eq hg (by simp_rw [f.toMap.map_mul, sec_spec'] ; ac_rfl)
+    exact f.eq_of_eq hg (by simp_rw [f.toMap.map_mul, sec_spec']; ac_rfl)
 #align submonoid.localization_map.lift Submonoid.LocalizationMap.lift
 #align add_submonoid.localization_map.lift AddSubmonoid.LocalizationMap.lift
 
@@ -978,7 +978,7 @@ theorem lift_spec_mul (z w v) : f.lift hg z * w = v ↔ g (f.sec z).1 * w = g (f
 
 @[to_additive]
 theorem lift_mk'_spec (x v) (y : S) : f.lift hg (f.mk' x y) = v ↔ g x = g y * v := by
-  rw [f.lift_mk' hg] ; exact mul_inv_left hg _ _ _
+  rw [f.lift_mk' hg]; exact mul_inv_left hg _ _ _
 #align submonoid.localization_map.lift_mk'_spec Submonoid.LocalizationMap.lift_mk'_spec
 #align add_submonoid.localization_map.lift_mk'_spec AddSubmonoid.LocalizationMap.lift_mk'_spec
 
@@ -1008,7 +1008,7 @@ theorem lift_mul_left (z) : g (f.sec z).2 * f.lift hg z = g (f.sec z).1 := by
 
 @[to_additive (attr := simp)]
 theorem lift_eq (x : M) : f.lift hg (f.toMap x) = g x := by
-  rw [lift_spec, ← g.map_mul] ; exact f.eq_of_eq hg (by rw [sec_spec', f.toMap.map_mul])
+  rw [lift_spec, ← g.map_mul]; exact f.eq_of_eq hg (by rw [sec_spec', f.toMap.map_mul])
 #align submonoid.localization_map.lift_eq Submonoid.LocalizationMap.lift_eq
 #align add_submonoid.localization_map.lift_eq AddSubmonoid.LocalizationMap.lift_eq
 
@@ -1020,7 +1020,7 @@ theorem lift_eq_iff {x y : M × S} :
 #align add_submonoid.localization_map.lift_eq_iff AddSubmonoid.LocalizationMap.lift_eq_iff
 
 @[to_additive (attr := simp)]
-theorem lift_comp : (f.lift hg).comp f.toMap = g := by ext ; exact f.lift_eq hg _
+theorem lift_comp : (f.lift hg).comp f.toMap = g := by ext; exact f.lift_eq hg _
 #align submonoid.localization_map.lift_comp Submonoid.LocalizationMap.lift_comp
 #align add_submonoid.localization_map.lift_comp AddSubmonoid.LocalizationMap.lift_comp
 
@@ -1398,7 +1398,7 @@ def ofMulEquivOfLocalizations (k : N ≃* P) : LocalizationMap S P :=
     (fun v ↦
       let ⟨z, hz⟩ := k.toEquiv.surjective v
       let ⟨x, hx⟩ := f.surj z
-      ⟨x, show v * k _ = k _ by rw [← hx, k.map_mul, ← hz] ; rfl⟩)
+      ⟨x, show v * k _ = k _ by rw [← hx, k.map_mul, ← hz]; rfl⟩)
     fun x y ↦ k.apply_eq_iff_eq.trans f.eq_iff_exists
 #align submonoid.localization_map.of_mul_equiv_of_localizations Submonoid.LocalizationMap.ofMulEquivOfLocalizations
 #align add_submonoid.localization_map.of_add_equiv_of_localizations AddSubmonoid.LocalizationMap.ofAddEquivOfLocalizations
@@ -1464,7 +1464,7 @@ theorem mulEquivOfLocalizations_left_inv_apply {k : N ≃* P} (x) :
 
 @[to_additive (attr := simp)]
 theorem ofMulEquivOfLocalizations_id : f.ofMulEquivOfLocalizations (MulEquiv.refl N) = f := by
-  ext ; rfl
+  ext; rfl
 #align submonoid.localization_map.of_mul_equiv_of_localizations_id Submonoid.LocalizationMap.ofMulEquivOfLocalizations_id
 #align add_submonoid.localization_map.of_add_equiv_of_localizations_id AddSubmonoid.LocalizationMap.ofAddEquivOfLocalizations_id
 
@@ -1472,7 +1472,7 @@ theorem ofMulEquivOfLocalizations_id : f.ofMulEquivOfLocalizations (MulEquiv.ref
 theorem ofMulEquivOfLocalizations_comp {k : N ≃* P} {j : P ≃* Q} :
     (f.ofMulEquivOfLocalizations (k.trans j)).toMap =
       j.toMonoidHom.comp (f.ofMulEquivOfLocalizations k).toMap :=
-  by ext ; rfl
+  by ext; rfl
 #align submonoid.localization_map.of_mul_equiv_of_localizations_comp Submonoid.LocalizationMap.ofMulEquivOfLocalizations_comp
 #align add_submonoid.localization_map.of_add_equiv_of_localizations_comp AddSubmonoid.LocalizationMap.ofAddEquivOfLocalizations_comp
 
@@ -1503,10 +1503,10 @@ def ofMulEquivOfDom {k : P ≃* M} (H : T.map k.toMonoidHom = S) : LocalizationM
           ⟨fun ⟨c, hc⟩ ↦
             let ⟨d, hd⟩ := k.toEquiv.surjective c
             ⟨⟨d, H' ▸ show k d ∈ S from hd.symm ▸ c.2⟩, by
-              erw [← hd, ← k.map_mul, ← k.map_mul] at hc ; exact k.toEquiv.injective hc⟩,
+              erw [← hd, ← k.map_mul, ← k.map_mul] at hc; exact k.toEquiv.injective hc⟩,
             fun ⟨c, hc⟩ ↦
             ⟨⟨k c, H ▸ Set.mem_image_of_mem k c.2⟩, by
-              erw [← k.map_mul] ; rw [hc, k.map_mul] ; rfl⟩⟩
+              erw [← k.map_mul]; rw [hc, k.map_mul]; rfl⟩⟩
 #align submonoid.localization_map.of_mul_equiv_of_dom Submonoid.LocalizationMap.ofMulEquivOfDom
 #align add_submonoid.localization_map.of_add_equiv_of_dom AddSubmonoid.LocalizationMap.ofAddEquivOfDom
 
@@ -1541,7 +1541,7 @@ theorem ofMulEquivOfDom_id :
     f.ofMulEquivOfDom
         (show S.map (MulEquiv.refl M).toMonoidHom = S from
           Submonoid.ext fun x ↦ ⟨fun ⟨_, hy, h⟩ ↦ h ▸ hy, fun h ↦ ⟨x, h, rfl⟩⟩) = f :=
-  by ext ; rfl
+  by ext; rfl
 #align submonoid.localization_map.of_mul_equiv_of_dom_id Submonoid.LocalizationMap.ofMulEquivOfDom_id
 #align add_submonoid.localization_map.of_add_equiv_of_dom_id AddSubmonoid.LocalizationMap.ofAddEquivOfDom_id
 
@@ -1645,7 +1645,7 @@ theorem mk_eq_monoidOf_mk'_apply (x y) : mk x y = (monoidOf S).mk' x y :=
   show _ = _ * _ from
     (Submonoid.LocalizationMap.mul_inv_right (monoidOf S).map_units _ _ _).2 <| by
       rw [← mk_one_eq_monoidOf_mk, ← mk_one_eq_monoidOf_mk, mk_mul x y y 1, mul_comm y 1]
-      conv => rhs ; rw [← mul_one 1] ; rw [← mul_one x]
+      conv => rhs; rw [← mul_one 1]; rw [← mul_one x]
       exact mk_eq_mk_iff.2 (Con.symm _ <| (Localization.r S).mul (Con.refl _ (x, 1)) <| one_rel _)
 #align localization.mk_eq_monoid_of_mk'_apply Localization.mk_eq_monoidOf_mk'_apply
 #align add_localization.mk_eq_add_monoid_of_mk'_apply AddLocalization.mk_eq_addMonoidOf_mk'_apply
@@ -1700,7 +1700,7 @@ theorem mulEquivOfQuotient_mk' (x y) : mulEquivOfQuotient f ((monoidOf S).mk' x 
 
 @[to_additive]
 theorem mulEquivOfQuotient_mk (x y) : mulEquivOfQuotient f (mk x y) = f.mk' x y := by
-  rw [mk_eq_monoidOf_mk'_apply] ; exact mulEquivOfQuotient_mk' _ _
+  rw [mk_eq_monoidOf_mk'_apply]; exact mulEquivOfQuotient_mk' _ _
 #align localization.mul_equiv_of_quotient_mk Localization.mulEquivOfQuotient_mk
 #align add_localization.add_equiv_of_quotient_mk AddLocalization.addEquivOfQuotient_mk
 
@@ -1720,7 +1720,7 @@ theorem mulEquivOfQuotient_symm_mk' (x y) :
 
 @[to_additive]
 theorem mulEquivOfQuotient_symm_mk (x y) : (mulEquivOfQuotient f).symm (f.mk' x y) = mk x y := by
-  rw [mk_eq_monoidOf_mk'_apply] ; exact mulEquivOfQuotient_symm_mk' _ _
+  rw [mk_eq_monoidOf_mk'_apply]; exact mulEquivOfQuotient_symm_mk' _ _
 #align localization.mul_equiv_of_quotient_symm_mk Localization.mulEquivOfQuotient_symm_mk
 #align add_localization.add_equiv_of_quotient_symm_mk AddLocalization.addEquivOfQuotient_symm_mk
 
@@ -1973,7 +1973,7 @@ instance partialOrder : PartialOrder (Localization s) where
     induction' b using Localization.rec with b₁ b₂
     simp_rw [mk_le_mk, mk_eq_mk_iff, r_iff_exists]
     exact fun hab hba => ⟨1, by rw [hab.antisymm hba]⟩
-    all_goals intros ; rfl
+    all_goals intros; rfl
   lt_iff_le_not_le a b := Localization.induction_on₂ a b fun a b => lt_iff_le_not_le
 
 @[to_additive]

--- a/Mathlib/GroupTheory/MonoidLocalization.lean
+++ b/Mathlib/GroupTheory/MonoidLocalization.lean
@@ -1498,15 +1498,15 @@ def ofMulEquivOfDom {k : P ≃* M} (H : T.map k.toMonoidHom = S) : LocalizationM
         show z * f.toMap (k.toEquiv w) = f.toMap (k.toEquiv v) by erw [hv, hw, hx]⟩)
     fun x y ↦
     show f.toMap _ = f.toMap _ ↔ _ by
-      erw [f.eq_iff_exists] ;
-        exact
-          ⟨fun ⟨c, hc⟩ ↦
-            let ⟨d, hd⟩ := k.toEquiv.surjective c
-            ⟨⟨d, H' ▸ show k d ∈ S from hd.symm ▸ c.2⟩, by
-              erw [← hd, ← k.map_mul, ← k.map_mul] at hc; exact k.toEquiv.injective hc⟩,
-            fun ⟨c, hc⟩ ↦
-            ⟨⟨k c, H ▸ Set.mem_image_of_mem k c.2⟩, by
-              erw [← k.map_mul]; rw [hc, k.map_mul]; rfl⟩⟩
+      erw [f.eq_iff_exists]
+      exact
+        ⟨fun ⟨c, hc⟩ ↦
+          let ⟨d, hd⟩ := k.toEquiv.surjective c
+          ⟨⟨d, H' ▸ show k d ∈ S from hd.symm ▸ c.2⟩, by
+            erw [← hd, ← k.map_mul, ← k.map_mul] at hc; exact k.toEquiv.injective hc⟩,
+          fun ⟨c, hc⟩ ↦
+          ⟨⟨k c, H ▸ Set.mem_image_of_mem k c.2⟩, by
+            erw [← k.map_mul]; rw [hc, k.map_mul]; rfl⟩⟩
 #align submonoid.localization_map.of_mul_equiv_of_dom Submonoid.LocalizationMap.ofMulEquivOfDom
 #align add_submonoid.localization_map.of_add_equiv_of_dom AddSubmonoid.LocalizationMap.ofAddEquivOfDom
 

--- a/Mathlib/GroupTheory/NielsenSchreier.lean
+++ b/Mathlib/GroupTheory/NielsenSchreier.lean
@@ -284,7 +284,7 @@ theorem path_nonempty_of_hom {G} [Groupoid.{u, u} G] [IsFreeGroupoid G] {a b : G
   let f : G → X := fun g => FreeGroup.of (WeaklyConnectedComponent.mk g)
   let F : G ⥤ CategoryTheory.SingleObj.{u} (X : Type u) := SingleObj.differenceFunctor f
   change (F.map p) = ((@CategoryTheory.Functor.const G _ _ (SingleObj.category X)).obj ()).map p
-  congr ; ext
+  congr; ext
   rw [Functor.const_obj_map, id_as_one, differenceFunctor_map, @mul_inv_eq_one _ _ (f _)]
   apply congr_arg FreeGroup.of
   apply (WeaklyConnectedComponent.eq _ _).mpr

--- a/Mathlib/GroupTheory/SemidirectProduct.lean
+++ b/Mathlib/GroupTheory/SemidirectProduct.lean
@@ -113,7 +113,7 @@ instance : Inhabited (N ⋊[φ] G) := ⟨1⟩
 def inl : N →* N ⋊[φ] G where
   toFun n := ⟨n, 1⟩
   map_one' := rfl
-  map_mul' := by intros ; ext <;>
+  map_mul' := by intros; ext <;>
     simp only [mul_left, map_one, MulAut.one_apply, mul_right, mul_one]
 #align semidirect_product.inl SemidirectProduct.inl
 
@@ -138,7 +138,7 @@ theorem inl_inj {n₁ n₂ : N} : (inl n₁ : N ⋊[φ] G) = inl n₂ ↔ n₁ =
 def inr : G →* N ⋊[φ] G where
   toFun g := ⟨1, g⟩
   map_one' := rfl
-  map_mul' := by intros ; ext <;> simp
+  map_mul' := by intros; ext <;> simp
 #align semidirect_product.inr SemidirectProduct.inr
 
 @[simp]
@@ -186,12 +186,12 @@ theorem rightHom_eq_right : (rightHom : N ⋊[φ] G → G) = right := rfl
 #align semidirect_product.right_hom_eq_right SemidirectProduct.rightHom_eq_right
 
 @[simp]
-theorem rightHom_comp_inl : (rightHom : N ⋊[φ] G →* G).comp inl = 1 := by ext ; simp [rightHom]
+theorem rightHom_comp_inl : (rightHom : N ⋊[φ] G →* G).comp inl = 1 := by ext; simp [rightHom]
 #align semidirect_product.right_hom_comp_inl SemidirectProduct.rightHom_comp_inl
 
 @[simp]
 theorem rightHom_comp_inr : (rightHom : N ⋊[φ] G →* G).comp inr = MonoidHom.id _ := by
-  ext ; simp [rightHom]
+  ext; simp [rightHom]
 #align semidirect_product.right_hom_comp_inr SemidirectProduct.rightHom_comp_inr
 
 @[simp]
@@ -233,7 +233,7 @@ theorem lift_inl (n : N) : lift f₁ f₂ h (inl n) = f₁ n := by simp [lift]
 #align semidirect_product.lift_inl SemidirectProduct.lift_inl
 
 @[simp]
-theorem lift_comp_inl : (lift f₁ f₂ h).comp inl = f₁ := by ext ; simp
+theorem lift_comp_inl : (lift f₁ f₂ h).comp inl = f₁ := by ext; simp
 #align semidirect_product.lift_comp_inl SemidirectProduct.lift_comp_inl
 
 @[simp]
@@ -241,11 +241,11 @@ theorem lift_inr (g : G) : lift f₁ f₂ h (inr g) = f₂ g := by simp [lift]
 #align semidirect_product.lift_inr SemidirectProduct.lift_inr
 
 @[simp]
-theorem lift_comp_inr : (lift f₁ f₂ h).comp inr = f₂ := by ext ; simp
+theorem lift_comp_inr : (lift f₁ f₂ h).comp inr = f₂ := by ext; simp
 #align semidirect_product.lift_comp_inr SemidirectProduct.lift_comp_inr
 
 theorem lift_unique (F : N ⋊[φ] G →* H) :
-    F = lift (F.comp inl) (F.comp inr) fun _ ↦ by ext ; simp [inl_aut] := by
+    F = lift (F.comp inl) (F.comp inr) fun _ ↦ by ext; simp [inl_aut] := by
   rw [FunLike.ext_iff]
   simp only [lift, MonoidHom.comp_apply, MonoidHom.coe_mk, OneHom.coe_mk, ← map_mul,
     inl_left_mul_inr_right, forall_const]

--- a/Mathlib/GroupTheory/Submonoid/Inverses.lean
+++ b/Mathlib/GroupTheory/Submonoid/Inverses.lean
@@ -169,7 +169,7 @@ noncomputable def leftInvEquiv : S.leftInv ≃* S :=
     left_inv := fun x ↦
       Subtype.eq <| by
         dsimp only; generalize_proofs h; rw [← h.choose.mul_left_inj]
-        conv => rhs ; rw [h.choose_spec]
+        conv => rhs; rw [h.choose_spec]
         exact h.choose.inv_val.trans (S.mul_fromLeftInv x).symm
     right_inv := fun x ↦ by
       dsimp only [fromCommLeftInv]

--- a/Mathlib/Init/Data/Nat/Bitwise.lean
+++ b/Mathlib/Init/Data/Nat/Bitwise.lean
@@ -380,7 +380,7 @@ theorem binaryRec_eq {C : Nat → Sort u} {z : C 0} {f : ∀ b n, C n → C (bit
       (Eq.symm (bit_decomp (bit b n)) ▸ Eq.refl (C (bit b n))) = e
     revert e
     rw [bodd_bit, div2_bit]
-    intros ; rfl
+    intros; rfl
 #align nat.binary_rec_eq Nat.binaryRec_eq
 
 theorem bitwise'_bit_aux {f : Bool → Bool → Bool} (h : f false false = false) :

--- a/Mathlib/LinearAlgebra/Matrix/Block.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Block.lean
@@ -169,7 +169,7 @@ theorem det_toBlock (M : Matrix m m R) (p : m → Prop) [DecidablePred p] :
           toBlock M (fun j => ¬p j) fun j => ¬p j).det := by
   rw [← Matrix.det_reindex_self (Equiv.sumCompl p).symm M]
   rw [det_apply', det_apply']
-  congr; ext σ; congr ; ext x
+  congr; ext σ; congr; ext x
   generalize hy : σ x = y
   cases x <;> cases y <;>
     simp only [Matrix.reindex_apply, toBlock_apply, Equiv.symm_symm, Equiv.sumCompl_apply_inr,

--- a/Mathlib/LinearAlgebra/Matrix/Diagonal.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Diagonal.lean
@@ -73,7 +73,7 @@ theorem range_diagonal [DecidableEq m] (w : m → K) :
       ⨆ i ∈ { i | w i ≠ 0 }, LinearMap.range (LinearMap.stdBasis K (fun _ => K) i) := by
   dsimp only [mem_setOf_eq]
   rw [← Submodule.map_top, ← iSup_range_stdBasis, Submodule.map_iSup]
-  congr ; funext i
+  congr; funext i
   rw [← LinearMap.range_comp, diagonal_comp_stdBasis, ← range_smul']
 #align matrix.range_diagonal Matrix.range_diagonal
 

--- a/Mathlib/LinearAlgebra/TensorProduct.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct.lean
@@ -730,7 +730,7 @@ theorem map_range_eq_span_tmul (f : M →ₗ[R] P) (g : N →ₗ[R] Q) :
     range (map f g) = Submodule.span R { t | ∃ m n, f m ⊗ₜ g n = t } := by
   simp only [← Submodule.map_top, ← span_tmul_eq_top, Submodule.map_span, Set.mem_image,
     Set.mem_setOf_eq]
-  congr ; ext t
+  congr; ext t
   constructor
   · rintro ⟨_, ⟨⟨m, n, rfl⟩, rfl⟩⟩
     use m, n

--- a/Mathlib/Logic/Embedding/Set.lean
+++ b/Mathlib/Logic/Embedding/Set.lean
@@ -55,8 +55,8 @@ def optionElim {α β} (f : α ↪ β) (x : β) (h : x ∉ Set.range f) : Option
 def optionEmbeddingEquiv (α β) : (Option α ↪ β) ≃ Σ f : α ↪ β, ↥(Set.range f)ᶜ where
   toFun f := ⟨coeWithTop.trans f, f none, fun ⟨x, hx⟩ ↦ Option.some_ne_none x <| f.injective hx⟩
   invFun f := f.1.optionElim f.2 f.2.2
-  left_inv f := ext <| by rintro (_ | _) <;> simp [Option.coe_def] ; rfl
-  right_inv := fun ⟨f, y, hy⟩ ↦ by ext <;> simp [Option.coe_def] ; rfl
+  left_inv f := ext <| by rintro (_ | _) <;> simp [Option.coe_def]; rfl
+  right_inv := fun ⟨f, y, hy⟩ ↦ by ext <;> simp [Option.coe_def]; rfl
 #align function.embedding.option_embedding_equiv Function.Embedding.optionEmbeddingEquiv
 #align function.embedding.option_embedding_equiv_apply_snd_coe Function.Embedding.optionEmbeddingEquiv_apply_snd_coe
 #align function.embedding.option_embedding_equiv_symm_apply Function.Embedding.optionEmbeddingEquiv_symm_apply

--- a/Mathlib/Logic/Encodable/Basic.lean
+++ b/Mathlib/Logic/Encodable/Basic.lean
@@ -161,7 +161,7 @@ theorem decode_unit_succ (n) : decode (succ n) = (none : Option PUnit) :=
 instance _root_.Option.encodable {α : Type _} [h : Encodable α] : Encodable (Option α) :=
   ⟨fun o => Option.casesOn o Nat.zero fun a => succ (encode a), fun n =>
     Nat.casesOn n (some none) fun m => (decode m).map some, fun o => by
-    cases o <;> dsimp ; simp [encodek, Nat.succ_ne_zero]⟩
+    cases o <;> dsimp; simp [encodek, Nat.succ_ne_zero]⟩
 #align option.encodable Option.encodable
 
 @[simp]
@@ -194,7 +194,7 @@ def decode₂ (α) [Encodable α] (n : ℕ) : Option α :=
 
 theorem mem_decode₂' [Encodable α] {n : ℕ} {a : α} :
     a ∈ decode₂ α n ↔ a ∈ decode n ∧ encode a = n := by
-  simp [decode₂] ; exact ⟨fun ⟨_, h₁, rfl, h₂⟩ => ⟨h₁, h₂⟩, fun ⟨h₁, h₂⟩ => ⟨_, h₁, rfl, h₂⟩⟩
+  simp [decode₂]; exact ⟨fun ⟨_, h₁, rfl, h₂⟩ => ⟨h₁, h₂⟩, fun ⟨h₁, h₂⟩ => ⟨_, h₁, rfl, h₂⟩⟩
 #align encodable.mem_decode₂' Encodable.mem_decode₂'
 
 theorem mem_decode₂ [Encodable α] {n : ℕ} {a : α} : a ∈ decode₂ α n ↔ encode a = n :=
@@ -235,7 +235,7 @@ def decidableRangeEncode (α : Type _) [Encodable α] : DecidablePred (· ∈ Se
   fun x =>
   decidable_of_iff (Option.isSome (decode₂ α x))
     ⟨fun h => ⟨Option.get _ h, by rw [← decode₂_is_partial_inv (Option.get _ h), Option.some_get]⟩,
-      fun ⟨n, hn⟩ => by rw [← hn, encodek₂] ; exact rfl⟩
+      fun ⟨n, hn⟩ => by rw [← hn, encodek₂]; exact rfl⟩
 #align encodable.decidable_range_encode Encodable.decidableRangeEncode
 
 /-- An encodable type is equivalent to the range of its encoding function. -/
@@ -244,8 +244,8 @@ def equivRangeEncode (α : Type _) [Encodable α] : α ≃ Set.range (@encode α
   toFun := fun a : α => ⟨encode a, Set.mem_range_self _⟩
   invFun n :=
     Option.get _
-      (show isSome (decode₂ α n.1) by cases' n.2 with x hx ; rw [← hx, encodek₂] ; exact rfl)
-  left_inv a := by dsimp ; rw [← Option.some_inj, Option.some_get, encodek₂]
+      (show isSome (decode₂ α n.1) by cases' n.2 with x hx; rw [← hx, encodek₂]; exact rfl)
+  left_inv a := by dsimp; rw [← Option.some_inj, Option.some_get, encodek₂]
   right_inv := fun ⟨n, x, hx⟩ => by
     apply Subtype.eq
     dsimp
@@ -425,7 +425,7 @@ instance _root_.Subtype.encodable : Encodable { a : α // P a } :=
   ⟨encodeSubtype, decodeSubtype, fun ⟨v, h⟩ => by simp [encodeSubtype, decodeSubtype, encodek, h]⟩
 #align subtype.encodable Subtype.encodable
 
-theorem Subtype.encode_eq (a : Subtype P) : encode a = encode a.val := by cases a ; rfl
+theorem Subtype.encode_eq (a : Subtype P) : encode a = encode a.val := by cases a; rfl
 #align encodable.subtype.encode_eq Encodable.Subtype.encode_eq
 
 end Subtype
@@ -689,7 +689,7 @@ theorem Quotient.rep_spec (q : Quotient s) : ⟦q.rep⟧ = q :=
 /-- The quotient of an encodable space by a decidable equivalence relation is encodable. -/
 def encodableQuotient : Encodable (Quotient s) :=
   ⟨fun q => encode q.rep, fun n => Quotient.mk'' <$> decode n, by
-    rintro ⟨l⟩ ; dsimp ; rw [encodek] ; exact congr_arg some ⟦l⟧.rep_spec⟩
+    rintro ⟨l⟩; dsimp; rw [encodek]; exact congr_arg some ⟦l⟧.rep_spec⟩
 #align encodable_quotient encodableQuotient
 
 end Quotient

--- a/Mathlib/MeasureTheory/Constructions/Prod/Integral.lean
+++ b/Mathlib/MeasureTheory/Constructions/Prod/Integral.lean
@@ -127,7 +127,7 @@ theorem MeasureTheory.StronglyMeasurable.integral_prod_right [SigmaFinite ν] �
   Fubini's theorem is measurable. -/
 theorem MeasureTheory.StronglyMeasurable.integral_prod_right' [SigmaFinite ν] ⦃f : α × β → E⦄
     (hf : StronglyMeasurable f) : StronglyMeasurable fun x => ∫ y, f (x, y) ∂ν := by
-  rw [← uncurry_curry f] at hf ; exact hf.integral_prod_right
+  rw [← uncurry_curry f] at hf; exact hf.integral_prod_right
 #align measure_theory.strongly_measurable.integral_prod_right' MeasureTheory.StronglyMeasurable.integral_prod_right'
 
 /-- The Bochner integral is measurable. This shows that the integrand of (the right-hand-side of)
@@ -165,7 +165,7 @@ theorem integrable_measure_prod_mk_left {s : Set (α × β)} (hs : MeasurableSet
   rw [prod_apply hs]
   apply lintegral_congr_ae
   refine' (ae_measure_lt_top hs h2s).mp _; apply eventually_of_forall; intro x hx
-  rw [lt_top_iff_ne_top] at hx ; simp [ofReal_toReal, hx]
+  rw [lt_top_iff_ne_top] at hx; simp [ofReal_toReal, hx]
 #align measure_theory.measure.integrable_measure_prod_mk_left MeasureTheory.Measure.integrable_measure_prod_mk_left
 
 end Measure

--- a/Mathlib/MeasureTheory/Covering/Besicovitch.lean
+++ b/Mathlib/MeasureTheory/Covering/Besicovitch.lean
@@ -669,7 +669,7 @@ theorem exist_finset_disjoint_balls_large_measure (μ : Measure α) [IsFiniteMea
       simpa only [mem_image, Finset.mem_coe, Finset.coe_image] using hk
     obtain ⟨l', _, rfl⟩ : ∃ l' : u i, l' ∈ w ∧ ↑l' = l := by
       simpa only [mem_image, Finset.mem_coe, Finset.coe_image] using hl
-    have k'nel' : (k' : s) ≠ l' := by intro h; rw [h] at hkl ; exact hkl rfl
+    have k'nel' : (k' : s) ≠ l' := by intro h; rw [h] at hkl; exact hkl rfl
     exact hu i k'.2 l'.2 k'nel'
 #align besicovitch.exist_finset_disjoint_balls_large_measure Besicovitch.exist_finset_disjoint_balls_large_measure
 

--- a/Mathlib/MeasureTheory/Covering/BesicovitchVectorSpace.lean
+++ b/Mathlib/MeasureTheory/Covering/BesicovitchVectorSpace.lean
@@ -275,7 +275,7 @@ theorem exists_goodδ :
     simp only [forall_apply_eq_imp_iff', forall_exists_index, Finset.mem_univ, Finset.mem_image,
       Ne.def, exists_true_left, forall_apply_eq_imp_iff', forall_true_left, true_and]
     intro i j hij
-    have : i ≠ j := fun h => by rw [h] at hij ; exact hij rfl
+    have : i ≠ j := fun h => by rw [h] at hij; exact hij rfl
     exact h'f i j this
   have : s.card ≤ multiplicity E := card_le_multiplicity hs h's
   rw [s_card, hN] at this
@@ -328,7 +328,7 @@ theorem le_multiplicity_of_δ_of_fin {n : ℕ} (f : Fin n → E) (h : ∀ i, ‖
     simp only [forall_apply_eq_imp_iff', forall_exists_index, Finset.mem_univ, Finset.mem_image,
       Ne.def, exists_true_left, forall_apply_eq_imp_iff', forall_true_left, true_and]
     intro i j hij
-    have : i ≠ j := fun h => by rw [h] at hij ; exact hij rfl
+    have : i ≠ j := fun h => by rw [h] at hij; exact hij rfl
     exact h' i j this
   have : s.card ≤ multiplicity E := card_le_multiplicity_of_δ hs h's
   rwa [s_card] at this

--- a/Mathlib/MeasureTheory/Decomposition/SignedHahn.lean
+++ b/Mathlib/MeasureTheory/Decomposition/SignedHahn.lean
@@ -254,7 +254,7 @@ private theorem exists_subset_restrict_nonpos' (hi₁ : MeasurableSet i) (hi₂ 
     · convert le_of_eq s.empty.symm
       ext; simp only [exists_prop, Set.mem_empty_iff_false, Set.mem_iUnion, not_and, iff_false_iff]
       exact fun h' => False.elim (h h')
-  · intro ; exact MeasurableSet.iUnion fun _ => restrictNonposSeq_measurableSet _
+  · intro; exact MeasurableSet.iUnion fun _ => restrictNonposSeq_measurableSet _
   · intro a b hab
     refine' Set.disjoint_iUnion_left.mpr fun _ => _
     refine' Set.disjoint_iUnion_right.mpr fun _ => _

--- a/Mathlib/MeasureTheory/Decomposition/UnsignedHahn.lean
+++ b/Mathlib/MeasureTheory/Decomposition/UnsignedHahn.lean
@@ -118,7 +118,7 @@ theorem hahn_decomposition [IsFiniteMeasure μ] [IsFiniteMeasure ν] :
             simp only [pow_add, pow_one, le_sub_iff_add_le]
             linarith
           _ = γ - (1 / 2) ^ (n + 1) + (γ - 2 * (1 / 2) ^ m + (1 / 2) ^ n) := by
-            simp only [sub_eq_add_neg] ; abel
+            simp only [sub_eq_add_neg]; abel
           _ ≤ d (e (n + 1)) + d (f m n) := (add_le_add (le_of_lt <| he₂ _) ih)
           _ ≤ d (e (n + 1)) + d (f m n \ e (n + 1)) + d (f m (n + 1)) := by
             rw [f_succ _ _ hmn, d_split (f m n) (e (n + 1)) (hf _ _) (he₁ _), add_assoc]
@@ -161,7 +161,7 @@ theorem hahn_decomposition [IsFiniteMeasure μ] [IsFiniteMeasure ν] :
     have : 0 ≤ d t :=
       (add_le_add_iff_left γ).1 <|
         calc
-          γ + 0 ≤ d s := by rw [add_zero] ; exact γ_le_d_s
+          γ + 0 ≤ d s := by rw [add_zero]; exact γ_le_d_s
           _ = d (s \ t) + d t := by rw [d_split _ _ hs ht, inter_eq_self_of_subset_right hts]
           _ ≤ γ + d t := add_le_add (d_le_γ _ (hs.diff ht)) le_rfl
 
@@ -175,7 +175,7 @@ theorem hahn_decomposition [IsFiniteMeasure μ] [IsFiniteMeasure ν] :
           _ = d (s ∪ t) := by
             rw [d_split _ _ (hs.union ht) ht, union_diff_right, union_inter_cancel_right,
               (subset_compl_iff_disjoint_left.1 hts).sdiff_eq_left]
-          _ ≤ γ + 0 := by rw [add_zero] ; exact d_le_γ _ (hs.union ht)
+          _ ≤ γ + 0 := by rw [add_zero]; exact d_le_γ _ (hs.union ht)
 
     rw [← to_nnreal_μ, ← to_nnreal_ν, ENNReal.coe_le_coe, ← NNReal.coe_le_coe]
     simpa only [sub_le_iff_le_add, zero_add] using this

--- a/Mathlib/MeasureTheory/Function/ConditionalExpectation/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/ConditionalExpectation/Basic.lean
@@ -230,7 +230,7 @@ theorem set_integral_condexp (hm : m ≤ m0) [SigmaFinite (μ.trim hm)] (hf : In
 theorem integral_condexp (hm : m ≤ m0) [hμm : SigmaFinite (μ.trim hm)] (hf : Integrable f μ) :
     ∫ x, (μ[f|m]) x ∂μ = ∫ x, f x ∂μ := by
   suffices ∫ x in Set.univ, (μ[f|m]) x ∂μ = ∫ x in Set.univ, f x ∂μ by
-    simp_rw [integral_univ] at this ; exact this
+    simp_rw [integral_univ] at this; exact this
   exact set_integral_condexp hm hf (@MeasurableSet.univ _ m)
 #align measure_theory.integral_condexp MeasureTheory.integral_condexp
 

--- a/Mathlib/MeasureTheory/Function/Jacobian.lean
+++ b/Mathlib/MeasureTheory/Function/Jacobian.lean
@@ -546,7 +546,7 @@ theorem _root_.ApproximatesLinearOn.norm_fderiv_sub_le {A : E →L[ℝ] E} {δ :
       _ ≤ ‖(f' x - A) a‖ + ‖(f' x - A) (z - a)‖ := (norm_add_le _ _)
       _ ≤ (δ + ε) * (‖z‖ + ε) + ‖f' x - A‖ * ‖z - a‖ := by
         apply add_le_add
-        · rw [mul_assoc] at I ; exact (mul_le_mul_left rpos).1 I
+        · rw [mul_assoc] at I; exact (mul_le_mul_left rpos).1 I
         · apply ContinuousLinearMap.le_op_norm
       _ ≤ (δ + ε) * (‖z‖ + ε) + ‖f' x - A‖ * ε :=
         add_le_add le_rfl

--- a/Mathlib/MeasureTheory/Integral/Bochner.lean
+++ b/Mathlib/MeasureTheory/Integral/Bochner.lean
@@ -1192,7 +1192,7 @@ theorem integral_toReal {f : α → ℝ≥0∞} (hfm : AEMeasurable f μ) (hf : 
     ∫ a, (f a).toReal ∂μ = (∫⁻ a, f a ∂μ).toReal := by
   rw [integral_eq_lintegral_of_nonneg_ae _ hfm.ennreal_toReal.aestronglyMeasurable]
   · rw [lintegral_congr_ae]; refine' hf.mp (eventually_of_forall _)
-    intro x hx; rw [lt_top_iff_ne_top] at hx ; simp [hx]
+    intro x hx; rw [lt_top_iff_ne_top] at hx; simp [hx]
   · exact eventually_of_forall fun x => ENNReal.toReal_nonneg
 #align measure_theory.integral_to_real MeasureTheory.integral_toReal
 

--- a/Mathlib/MeasureTheory/Integral/CircleIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/CircleIntegral.lean
@@ -306,7 +306,7 @@ theorem circleIntegrable_sub_zpow_iff {c w : ℂ} {R : ℝ} {n : ℤ} :
   constructor
   · intro h; contrapose! h; rcases h with ⟨hR, hn, hw⟩
     simp only [circleIntegrable_iff R, deriv_circleMap]
-    rw [← image_circleMap_Ioc] at hw ; rcases hw with ⟨θ, hθ, rfl⟩
+    rw [← image_circleMap_Ioc] at hw; rcases hw with ⟨θ, hθ, rfl⟩
     replace hθ : θ ∈ [[0, 2 * π]]; exact Icc_subset_uIcc (Ioc_subset_Icc_self hθ)
     refine' not_intervalIntegrable_of_sub_inv_isBigO_punctured _ Real.two_pi_pos.ne hθ
     set f : ℝ → ℂ := fun θ' => circleMap c R θ' - circleMap c R θ

--- a/Mathlib/MeasureTheory/Integral/IntegralEqImproper.lean
+++ b/Mathlib/MeasureTheory/Integral/IntegralEqImproper.lean
@@ -863,7 +863,7 @@ theorem integral_comp_rpow_Ioi (g : ℝ → E) {p : ℝ} (hp : p ≠ 0) :
     · intro hx; refine' ⟨x ^ (1 / p), rpow_pos_of_pos hx _, _⟩
       rw [← rpow_mul (le_of_lt hx), one_div_mul_cancel hp, rpow_one]
   have := integral_image_eq_integral_abs_deriv_smul measurableSet_Ioi a1 a2 g
-  rw [a3] at this ; rw [this]
+  rw [a3] at this; rw [this]
   refine' set_integral_congr measurableSet_Ioi _
   intro x hx; dsimp only
   rw [abs_mul, abs_of_nonneg (rpow_nonneg_of_nonneg (le_of_lt hx) _)]

--- a/Mathlib/MeasureTheory/Integral/Lebesgue.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue.lean
@@ -543,7 +543,7 @@ theorem lintegral_add_aux {f g : α → ℝ≥0∞} (hf : Measurable f) (hg : Me
         ∫⁻ a, (⨆ n, (eapprox f n : α → ℝ≥0∞) a) + ⨆ n, (eapprox g n : α → ℝ≥0∞) a ∂μ :=
       by simp only [iSup_eapprox_apply, hf, hg]
     _ = ∫⁻ a, ⨆ n, (eapprox f n + eapprox g n : α → ℝ≥0∞) a ∂μ := by
-      congr ; funext a
+      congr; funext a
       rw [ENNReal.iSup_add_iSup_of_monotone]; · rfl
       · intro i j h
         exact monotone_eapprox _ h a
@@ -612,7 +612,7 @@ theorem lintegral_sum_measure {m : MeasurableSpace α} {ι} (f : α → ℝ≥0�
     ∫⁻ a, f a ∂Measure.sum μ = ∑' i, ∫⁻ a, f a ∂μ i := by
   simp only [lintegral, iSup_subtype', SimpleFunc.lintegral_sum, ENNReal.tsum_eq_iSup_sum]
   rw [iSup_comm]
-  congr ; funext s
+  congr; funext s
   induction' s using Finset.induction_on with i s hi hs;
   · apply bot_unique
     simp

--- a/Mathlib/MeasureTheory/Integral/SetToL1.lean
+++ b/Mathlib/MeasureTheory/Integral/SetToL1.lean
@@ -1426,7 +1426,7 @@ theorem setToFun_congr_ae (hT : DominatedFinMeasAdditive μ T C) (h : f =ᵐ[μ]
   by_cases hfi : Integrable f μ
   · have hgi : Integrable g μ := hfi.congr h
     rw [setToFun_eq hT hfi, setToFun_eq hT hgi, (Integrable.toL1_eq_toL1_iff f g hfi hgi).2 h]
-  · have hgi : ¬Integrable g μ := by rw [integrable_congr h] at hfi ; exact hfi
+  · have hgi : ¬Integrable g μ := by rw [integrable_congr h] at hfi; exact hfi
     rw [setToFun_undef hT hfi, setToFun_undef hT hgi]
 #align measure_theory.set_to_fun_congr_ae MeasureTheory.setToFun_congr_ae
 

--- a/Mathlib/MeasureTheory/Integral/VitaliCaratheodory.lean
+++ b/Mathlib/MeasureTheory/Integral/VitaliCaratheodory.lean
@@ -249,7 +249,7 @@ theorem exists_lt_lowerSemicontinuous_lintegral_ge_of_aemeasurable [SigmaFinite 
     · have := le_g1 x
       simp only [h, Set.indicator_of_mem, top_le_iff] at this
       simp [this]
-    · have : f x = fmeas.mk f x := by rw [Set.compl_subset_comm] at hs ; exact hs h
+    · have : f x = fmeas.mk f x := by rw [Set.compl_subset_comm] at hs; exact hs h
       rw [this]
       exact (f_lt_g0 x).trans_le le_self_add
   · calc

--- a/Mathlib/MeasureTheory/Measure/Complex.lean
+++ b/Mathlib/MeasureTheory/Measure/Complex.lean
@@ -67,7 +67,7 @@ def _root_.MeasureTheory.SignedMeasure.toComplexMeasure (s t : SignedMeasure α)
     ComplexMeasure α where
   measureOf' i := ⟨s i, t i⟩
   empty' := by dsimp only; rw [s.empty, t.empty]; rfl
-  not_measurable' i hi := by dsimp only ; rw [s.not_measurable hi, t.not_measurable hi]; rfl
+  not_measurable' i hi := by dsimp only; rw [s.not_measurable hi, t.not_measurable hi]; rfl
   m_iUnion' f hf hfdisj := (Complex.hasSum_iff _ _).2 ⟨s.m_iUnion hf hfdisj, t.m_iUnion hf hfdisj⟩
 #align measure_theory.signed_measure.to_complex_measure MeasureTheory.SignedMeasure.toComplexMeasure
 

--- a/Mathlib/MeasureTheory/Measure/Hausdorff.lean
+++ b/Mathlib/MeasureTheory/Measure/Hausdorff.lean
@@ -523,7 +523,7 @@ theorem mkMetric_apply (m : ℝ≥0∞ → ℝ≥0∞) (s : Set X) :
     congr 1 with n : 1
     simp only [iInf_eq_if, htr n, id, if_true, iSup_and']
   · rw [iInf_eq_if, if_neg htr]
-    push_neg at htr ; rcases htr with ⟨n, hn⟩
+    push_neg at htr; rcases htr with ⟨n, hn⟩
     refine' ENNReal.tsum_eq_top_of_eq_top ⟨n, _⟩
     rw [iSup_eq_if, if_pos, iInf_eq_if, if_neg]
     exact hn.not_le

--- a/Mathlib/NumberTheory/ArithmeticFunction.lean
+++ b/Mathlib/NumberTheory/ArithmeticFunction.lean
@@ -238,8 +238,8 @@ instance instAddMonoidWithOne [AddMonoidWithOne R] : AddMonoidWithOne (Arithmeti
   { ArithmeticFunction.instAddMonoid,
     ArithmeticFunction.one with
     natCast := fun n => ⟨fun x => if x = 1 then (n : R) else 0, by simp⟩
-    natCast_zero := by ext ; simp  ;
-    natCast_succ := fun n => by ext x ; by_cases h : x = 1 <;> simp [h] }
+    natCast_zero := by ext; simp  ;
+    natCast_succ := fun n => by ext x; by_cases h : x = 1 <;> simp [h] }
 -- porting note: have I aligned this correctly?
 #align nat.arithmetic_function.add_monoid_with_one Nat.ArithmeticFunction.instAddMonoidWithOne
 
@@ -619,19 +619,19 @@ theorem map_prod {ι : Type _} [CommMonoidWithZero R] (g : ι → ℕ) {f : Nat.
 theorem nat_cast {f : ArithmeticFunction ℕ} [Semiring R] (h : f.IsMultiplicative) :
     IsMultiplicative (f : ArithmeticFunction R) :=
                                  -- porting note: was `by simp [cop, h]`
-  ⟨by simp [h], fun {m n} cop => by cases h ; rename_i j h; simp [h cop]⟩
+  ⟨by simp [h], fun {m n} cop => by cases h; rename_i j h; simp [h cop]⟩
 #align nat.arithmetic_function.is_multiplicative.nat_cast Nat.ArithmeticFunction.IsMultiplicative.nat_cast
 
 theorem int_cast {f : ArithmeticFunction ℤ} [Ring R] (h : f.IsMultiplicative) :
     IsMultiplicative (f : ArithmeticFunction R) :=
                                  -- porting note: was `by simp [cop, h]`
-  ⟨by simp [h], fun {m n} cop => by cases h ; rename_i j h; simp [h cop]⟩
+  ⟨by simp [h], fun {m n} cop => by cases h; rename_i j h; simp [h cop]⟩
 #align nat.arithmetic_function.is_multiplicative.int_cast Nat.ArithmeticFunction.IsMultiplicative.int_cast
 
 theorem mul [CommSemiring R] {f g : ArithmeticFunction R} (hf : f.IsMultiplicative)
     (hg : g.IsMultiplicative) : IsMultiplicative (f * g) :=
   ⟨by -- porting note was `simp [hf, hg]`.
-      have f1 := hf.left ; have g1 := hg.left
+      have f1 := hf.left; have g1 := hg.left
       simp only [mul_apply, divisorsAntidiagonal_one, ZeroHom.toFun_eq_coe, sum_singleton]
       rw [f1, g1, mul_one], by
     simp only [mul_apply]

--- a/Mathlib/NumberTheory/ArithmeticFunction.lean
+++ b/Mathlib/NumberTheory/ArithmeticFunction.lean
@@ -238,7 +238,7 @@ instance instAddMonoidWithOne [AddMonoidWithOne R] : AddMonoidWithOne (Arithmeti
   { ArithmeticFunction.instAddMonoid,
     ArithmeticFunction.one with
     natCast := fun n => ⟨fun x => if x = 1 then (n : R) else 0, by simp⟩
-    natCast_zero := by ext; simp  ;
+    natCast_zero := by ext; simp
     natCast_succ := fun n => by ext x; by_cases h : x = 1 <;> simp [h] }
 -- porting note: have I aligned this correctly?
 #align nat.arithmetic_function.add_monoid_with_one Nat.ArithmeticFunction.instAddMonoidWithOne

--- a/Mathlib/NumberTheory/Bertrand.lean
+++ b/Mathlib/NumberTheory/Bertrand.lean
@@ -95,21 +95,21 @@ theorem real_main_inequality {x : ℝ} (n_large : (512 : ℝ) ≤ x) :
     rw [one_le_div] <;> norm_num1
     apply le_trans _ (le_mul_of_one_le_left _ _) <;> norm_num1
     apply Real.rpow_le_rpow <;> norm_num1
-    apply rpow_nonneg_of_nonneg ; norm_num1
-    apply rpow_pos_of_pos ; norm_num1
-    apply hf' 18 ; norm_num1
+    apply rpow_nonneg_of_nonneg; norm_num1
+    apply rpow_pos_of_pos; norm_num1
+    apply hf' 18; norm_num1
     norm_num1
   · have : sqrt (2 * 512) = 32 :=
       (sqrt_eq_iff_mul_self_eq_of_pos (by norm_num1)).mpr (by norm_num1)
     rw [hf, log_nonpos_iff (hf' _ _), this, div_le_one] <;> norm_num1
     have : (512 : ℝ) = 2 ^ (9 : ℕ)
-    · rw [rpow_nat_cast 2 9] ; norm_num1
+    · rw [rpow_nat_cast 2 9]; norm_num1
     conv_lhs => rw [this]
     have : (1024 : ℝ) = 2 ^ (10 : ℕ)
-    · rw [rpow_nat_cast 2 10] ; norm_num1
+    · rw [rpow_nat_cast 2 10]; norm_num1
     rw [this, ← rpow_mul, ← rpow_add] <;> norm_num1
     have : (4 : ℝ) = 2 ^ (2 : ℕ)
-    · rw [rpow_nat_cast 2 2] ; norm_num1
+    · rw [rpow_nat_cast 2 2]; norm_num1
     rw [this, ← rpow_mul] <;> norm_num1
     apply rpow_le_rpow_of_exponent_le <;> norm_num1
     apply rpow_pos_of_pos four_pos
@@ -215,7 +215,7 @@ theorem exists_prime_lt_and_le_two_mul_eventually (n : ℕ) (n_big : 512 ≤ n) 
     Nat.four_pow_lt_mul_centralBinom n (le_trans (by norm_num1) n_big)
   have H3 : n.centralBinom ≤ (2 * n) ^ sqrt (2 * n) * 4 ^ (2 * n / 3) :=
     centralBinom_le_of_no_bertrand_prime n (lt_of_lt_of_le (by norm_num1) n_big) no_prime
-  rw [mul_assoc] at H1 ; exact not_le.2 H2 ((mul_le_mul_left' H3 n).trans H1)
+  rw [mul_assoc] at H1; exact not_le.2 H2 ((mul_le_mul_left' H3 n).trans H1)
 #align nat.exists_prime_lt_and_le_two_mul_eventually Nat.exists_prime_lt_and_le_two_mul_eventually
 
 /-- Proves that Bertrand's postulate holds over all positive naturals less than n by identifying a

--- a/Mathlib/NumberTheory/LegendreSymbol/JacobiSymbol.lean
+++ b/Mathlib/NumberTheory/LegendreSymbol/JacobiSymbol.lean
@@ -183,9 +183,9 @@ protected theorem ne_zero {a : ℤ} {b : ℕ} (h : a.gcd b = 1) : J(a | b) ≠ 0
 theorem eq_zero_iff {a : ℤ} {b : ℕ} : J(a | b) = 0 ↔ b ≠ 0 ∧ a.gcd b ≠ 1 :=
   ⟨fun h => by
     cases' eq_or_ne b 0 with hb hb
-    · rw [hb, zero_right] at h ; cases h
+    · rw [hb, zero_right] at h; cases h
     exact ⟨hb, mt jacobiSym.ne_zero <| Classical.not_not.2 h⟩, fun ⟨hb, h⟩ => by
-    rw [← neZero_iff] at hb ; exact eq_zero_iff_not_coprime.2 h⟩
+    rw [← neZero_iff] at hb; exact eq_zero_iff_not_coprime.2 h⟩
 #align jacobi_sym.eq_zero_iff jacobiSym.eq_zero_iff
 
 /-- The symbol `J(0 | b)` vanishes when `b > 1`. -/

--- a/Mathlib/NumberTheory/LegendreSymbol/QuadraticChar/Basic.lean
+++ b/Mathlib/NumberTheory/LegendreSymbol/QuadraticChar/Basic.lean
@@ -237,7 +237,7 @@ variable {F}
 when the domain has odd characteristic. -/
 theorem quadraticChar_isNontrivial (hF : ringChar F ≠ 2) : (quadraticChar F).IsNontrivial := by
   rcases quadraticChar_exists_neg_one hF with ⟨a, ha⟩
-  have hu : IsUnit a := by by_contra hf; rw [MulChar.map_nonunit _ hf] at ha ; norm_num at ha
+  have hu : IsUnit a := by by_contra hf; rw [MulChar.map_nonunit _ hf] at ha; norm_num at ha
   refine' ⟨hu.unit, (_ : quadraticChar F a ≠ 1)⟩
   rw [ha]
   norm_num

--- a/Mathlib/NumberTheory/Liouville/LiouvilleWith.lean
+++ b/Mathlib/NumberTheory/Liouville/LiouvilleWith.lean
@@ -362,7 +362,7 @@ theorem frequently_exists_num (hx : Liouville x) (n : ℕ) :
     (finite_lt_nat N).eventually_all.2 fun b _hb => eventually_imp_distrib_left.2 (this b)
   rcases(this.and (eventually_ge_atTop n)).exists with ⟨m, hm, hnm⟩
   rcases hx m with ⟨a, b, hb, hne, hlt⟩
-  lift b to ℕ using zero_le_one.trans hb.le; norm_cast at hb ; push_cast at hne hlt
+  lift b to ℕ using zero_le_one.trans hb.le; norm_cast at hb; push_cast at hne hlt
   cases' le_or_lt N b with h h
   · refine' (hN b h a hne).not_lt (hlt.trans_le _)
     replace hb : (1 : ℝ) < b := Nat.one_lt_cast.2 hb

--- a/Mathlib/NumberTheory/Liouville/Residual.lean
+++ b/Mathlib/NumberTheory/Liouville/Residual.lean
@@ -65,7 +65,7 @@ theorem eventually_residual_liouville : ∀ᶠ x in residual ℝ, Liouville x :=
   · rintro _ ⟨r, rfl⟩
     simp only [mem_iInter, mem_iUnion]
     refine fun n => ⟨r.num * 2, r.den * 2, ?_, ?_⟩
-    · have := Int.ofNat_le.2 r.pos; rw [Int.ofNat_one] at this ; linarith
+    · have := Int.ofNat_le.2 r.pos; rw [Int.ofNat_one] at this; linarith
     · convert @mem_ball_self ℝ _ (r : ℝ) _ _
       · push_cast; norm_cast; simp [Rat.divInt_mul_right (two_ne_zero), Rat.mkRat_self]
       · refine' one_div_pos.2 (pow_pos (Int.cast_pos.2 _) _)

--- a/Mathlib/NumberTheory/Modular.lean
+++ b/Mathlib/NumberTheory/Modular.lean
@@ -353,7 +353,7 @@ variable {z}
 theorem exists_eq_T_zpow_of_c_eq_zero (hc : (↑ₘg) 1 0 = 0) :
     ∃ n : ℤ, ∀ z : ℍ, g • z = T ^ n • z := by
   have had := g.det_coe
-  replace had : (↑ₘg) 0 0 * (↑ₘg) 1 1 = 1; · rw [det_fin_two, hc] at had ; linarith
+  replace had : (↑ₘg) 0 0 * (↑ₘg) 1 1 = 1; · rw [det_fin_two, hc] at had; linarith
   rcases Int.eq_one_or_neg_one_of_mul_eq_one' had with (⟨ha, hd⟩ | ⟨ha, hd⟩)
   · use (↑ₘg) 0 1
     suffices g = T ^ (↑ₘg) 0 1 by intro z; conv_lhs => rw [this]

--- a/Mathlib/NumberTheory/NumberField/Embeddings.lean
+++ b/Mathlib/NumberTheory/NumberField/Embeddings.lean
@@ -129,7 +129,7 @@ theorem pow_eq_one_of_norm_eq_one {x : K} (hxi : IsIntegral ℤ x) (hx : ∀ φ 
     rw [← Nat.sub_add_cancel hlt.le, pow_add, mul_left_eq_self₀] at h
     refine h.resolve_right fun hp => ?_
     specialize hx (IsAlgClosed.lift (NumberField.isAlgebraic K)).toRingHom
-    rw [pow_eq_zero hp, map_zero, norm_zero] at hx ; norm_num at hx
+    rw [pow_eq_zero hp, map_zero, norm_zero] at hx; norm_num at hx
 #align number_field.embeddings.pow_eq_one_of_norm_eq_one NumberField.Embeddings.pow_eq_one_of_norm_eq_one
 
 end Bounded

--- a/Mathlib/NumberTheory/Padics/RingHoms.lean
+++ b/Mathlib/NumberTheory/Padics/RingHoms.lean
@@ -663,7 +663,7 @@ theorem lift_unique (g : R →+* ℤ_[p]) (hg : ∀ n, (toZModPow n).comp g = f 
 theorem lift_self (z : ℤ_[p]) : @lift p _ ℤ_[p] _ toZModPow zmod_cast_comp_toZModPow z = z := by
   show _ = RingHom.id _ z
   rw [@lift_unique p _ ℤ_[p] _ _ zmod_cast_comp_toZModPow (RingHom.id ℤ_[p])]
-  intro ; rw [RingHom.comp_id]
+  intro; rw [RingHom.comp_id]
 #align padic_int.lift_self PadicInt.lift_self
 
 end lift

--- a/Mathlib/NumberTheory/PellMatiyasevic.lean
+++ b/Mathlib/NumberTheory/PellMatiyasevic.lean
@@ -664,7 +664,7 @@ theorem eq_of_xn_modEq_lem2 {n} (h : 2 * xn a1 n = xn a1 (n + 1)) : a = 2 ∧ n 
         (lt_of_le_of_lt (Nat.mul_le_mul_left _ a1)
           (Nat.lt_add_of_pos_right <| mul_pos (d_pos a1) (strictMono_y a1 np)))
         h
-  cases this ; simp at h; exact ⟨h.symm, rfl⟩
+  cases this; simp at h; exact ⟨h.symm, rfl⟩
 #align pell.eq_of_xn_modeq_lem2 Pell.eq_of_xn_modEq_lem2
 
 theorem eq_of_xn_modEq_lem3 {i n} (npos : 0 < n) :

--- a/Mathlib/NumberTheory/ZetaFunction.lean
+++ b/Mathlib/NumberTheory/ZetaFunction.lean
@@ -124,7 +124,7 @@ theorem summable_exp_neg_pi_mul_nat_sq {t : ℝ} (ht : 0 < t) :
   ext1 n
   rw [Complex.norm_eq_abs, Complex.abs_exp]
   rw [show ↑π * I * ((n : ℂ) + 1) ^ 2 * (↑t * I) = ((π * t * ((n : ℝ) + 1) ^ 2) : ℝ) * I ^ 2 by
-    push_cast ; ring]
+    push_cast; ring]
   rw [I_sq, mul_neg_one, ← ofReal_neg, ofReal_re, neg_mul, neg_mul]
 #align summable_exp_neg_pi_mul_nat_sq summable_exp_neg_pi_mul_nat_sq
 
@@ -414,7 +414,7 @@ theorem riemannZeta_neg_two_mul_nat_add_one (n : ℕ) : riemannZeta (-2 * (n + 1
   have : (-2 : ℂ) * (n + 1) ≠ 0 :=
     mul_ne_zero (neg_ne_zero.mpr two_ne_zero) (Nat.cast_add_one_ne_zero n)
   rw [riemannZeta, Function.update_noteq this,
-    show -2 * ((n : ℂ) + 1) / 2 = -↑(n + 1) by push_cast ; ring, Complex.Gamma_neg_nat_eq_zero,
+    show -2 * ((n : ℂ) + 1) / 2 = -↑(n + 1) by push_cast; ring, Complex.Gamma_neg_nat_eq_zero,
     div_zero]
 #align riemann_zeta_neg_two_mul_nat_add_one riemannZeta_neg_two_mul_nat_add_one
 
@@ -473,7 +473,7 @@ theorem mellin_zetaKernel₂_eq_of_lt_re {s : ℂ} (hs : 1 / 2 < s.re) :
 theorem completed_zeta_eq_mellin_of_one_lt_re {s : ℂ} (hs : 1 < re s) :
     riemannCompletedZeta s = mellin zetaKernel₁ (s / 2) := by
   have : 1 / 2 < (s / 2).re := by
-    rw [show s / 2 = ↑(2⁻¹ : ℝ) * s by push_cast ; rw [mul_comm]; rfl]
+    rw [show s / 2 = ↑(2⁻¹ : ℝ) * s by push_cast; rw [mul_comm]; rfl]
     rwa [ofReal_mul_re, ← div_eq_inv_mul, div_lt_div_right (zero_lt_two' ℝ)]
   rw [riemannCompletedZeta, riemannCompletedZeta₀, mellin_zetaKernel₂_eq_of_lt_re this, sub_add,
     sub_sub, ← add_sub]
@@ -562,7 +562,7 @@ theorem completed_zeta_eq_tsum_of_one_lt_re {s : ℂ} (hs : 1 < re s) :
       (π : ℂ) ^ (-s / 2) * Gamma (s / 2) * ∑' n : ℕ, 1 / ((n : ℂ) + 1) ^ s := by
   rw [completed_zeta_eq_mellin_of_one_lt_re hs, mellin_zetaKernel₁_eq_tsum, neg_div,
     mul_div_cancel' _ (two_ne_zero' ℂ)]
-  rw [show s / 2 = ↑(2⁻¹ : ℝ) * s by push_cast ; rw [mul_comm]; rfl]
+  rw [show s / 2 = ↑(2⁻¹ : ℝ) * s by push_cast; rw [mul_comm]; rfl]
   rwa [ofReal_mul_re, ← div_eq_inv_mul, div_lt_div_right (zero_lt_two' ℝ)]
 #align completed_zeta_eq_tsum_of_one_lt_re completed_zeta_eq_tsum_of_one_lt_re
 
@@ -705,7 +705,7 @@ theorem riemannZeta_one_sub {s : ℂ} (hs : ∀ n : ℕ, s ≠ -n) (hs' : s ≠ 
     have : (1 - (1 + 2 * (n : ℂ))) / 2 = -↑n := by
       rw [← sub_sub, sub_self, zero_sub, neg_div, mul_div_cancel_left _ (two_ne_zero' ℂ)]
     rw [this, Complex.Gamma_neg_nat_eq_zero, div_zero]
-    have : (π : ℂ) * (1 - (1 + 2 * ↑n)) / 2 = ↑(-n : ℤ) * π := by push_cast ; field_simp; ring
+    have : (π : ℂ) * (1 - (1 + 2 * ↑n)) / 2 = ↑(-n : ℤ) * π := by push_cast; field_simp; ring
     rw [this, Complex.sin_int_mul_pi, MulZeroClass.mul_zero, MulZeroClass.zero_mul]
   have h_Ga_ne4 : Gamma ((1 - s) / 2) ≠ 0 := by
     rw [Ne.def, Complex.Gamma_eq_zero_iff]
@@ -746,7 +746,7 @@ theorem riemannZeta_neg_nat_eq_bernoulli (k : ℕ) :
         zero_div]
   · -- k = 2 * m + 1 : the interesting case
     rw [Odd.neg_one_pow ⟨m, rfl⟩]
-    rw [show -(↑(2 * m + 1) : ℂ) = 1 - (2 * m + 2) by push_cast ; ring]
+    rw [show -(↑(2 * m + 1) : ℂ) = 1 - (2 * m + 2) by push_cast; ring]
     rw [riemannZeta_one_sub]
     rotate_left
     · intro n
@@ -762,10 +762,10 @@ theorem riemannZeta_neg_nat_eq_bernoulli (k : ℕ) :
         rcases Nat.even_or_odd' m with ⟨t, rfl | rfl⟩
         · rw [pow_mul, neg_one_sq, one_pow]
           convert Complex.cos_nat_mul_two_pi t using 2
-          push_cast ; ring_nf
+          push_cast; ring_nf
         · rw [pow_add, pow_one, pow_mul, neg_one_sq, one_pow, one_mul]
           convert Complex.cos_nat_mul_two_pi_add_pi t using 2
-          push_cast ; ring_nf]
+          push_cast; ring_nf]
     -- substitute in what we know about zeta values at positive integers
     have step1 := congr_arg ((↑) : ℝ → ℂ) (hasSum_zeta_nat (by norm_num : m + 1 ≠ 0)).tsum_eq
     have step2 := zeta_nat_eq_tsum_of_gt_one (by rw [mul_add]; norm_num : 1 < 2 * (m + 1))
@@ -774,7 +774,7 @@ theorem riemannZeta_neg_nat_eq_bernoulli (k : ℕ) :
     rw [step2, mul_div]
     -- now the rest is just a lengthy but elementary rearrangement
     rw [show ((2 * (m + 1))! : ℂ) = Complex.Gamma (2 * m + 2) * (↑(2 * m + 1) + 1) by
-        rw [(by push_cast ; ring : (2 * m + 2 : ℂ) = ↑(2 * m + 1) + 1),
+        rw [(by push_cast; ring : (2 * m + 2 : ℂ) = ↑(2 * m + 1) + 1),
           Complex.Gamma_nat_eq_factorial, (by ring : 2 * (m + 1) = 2 * m + 1 + 1),
           Nat.factorial_succ, Nat.cast_mul, mul_comm]
         norm_num]
@@ -796,7 +796,7 @@ theorem riemannZeta_neg_nat_eq_bernoulli (k : ℕ) :
         congr 1
         rw [Nat.add_sub_assoc one_le_two, Nat.cast_add, Nat.cast_mul, Nat.cast_two,
           (by norm_num : 2 - 1 = 1)]
-        push_cast ; ring]
+        push_cast; ring]
     rw [show (π : ℂ) ^ (-(2 * (m : ℂ) + 2)) = (↑(π ^ (2 * m + 2)))⁻¹ by
         rw [ofReal_pow, ← cpow_nat_cast, ← cpow_neg, Nat.cast_add, Nat.cast_mul, Nat.cast_two]]
     rw [(by intros; ring : ∀ a b c d e : ℂ, a * b * c * d * e = a * d * (b * e) * c)]

--- a/Mathlib/Order/CompleteLattice.lean
+++ b/Mathlib/Order/CompleteLattice.lean
@@ -1265,9 +1265,9 @@ theorem inf_iInf [Nonempty ι] {f : ι → α} {a : α} : (a ⊓ ⨅ x, f x) = �
 theorem biSup_sup {p : ι → Prop} {f : ∀ i, p i → α} {a : α} (h : ∃ i, p i) :
     (⨆ (i) (h : p i), f i h) ⊔ a = ⨆ (i) (h : p i), f i h ⊔ a := by
   haveI : Nonempty { i // p i } :=
-      let ⟨i, hi⟩ := h
-      ⟨⟨i, hi⟩⟩ ;
-    rw [iSup_subtype', iSup_subtype', iSup_sup]
+    let ⟨i, hi⟩ := h
+    ⟨⟨i, hi⟩⟩
+  rw [iSup_subtype', iSup_subtype', iSup_sup]
 #align bsupr_sup biSup_sup
 
 theorem sup_biSup {p : ι → Prop} {f : ∀ i, p i → α} {a : α} (h : ∃ i, p i) :

--- a/Mathlib/Order/CompleteLattice.lean
+++ b/Mathlib/Order/CompleteLattice.lean
@@ -954,7 +954,7 @@ theorem Antitone.le_map_iInf₂ [CompleteLattice β] {f : α → β} (hf : Antit
 #align antitone.le_map_infi₂ Antitone.le_map_iInf₂
 
 theorem Monotone.le_map_sSup [CompleteLattice β] {s : Set α} {f : α → β} (hf : Monotone f) :
-    ⨆ a ∈ s, f a ≤ f (sSup s) := by rw [sSup_eq_iSup] ; exact hf.le_map_iSup₂ _
+    ⨆ a ∈ s, f a ≤ f (sSup s) := by rw [sSup_eq_iSup]; exact hf.le_map_iSup₂ _
 #align monotone.le_map_Sup Monotone.le_map_sSup
 
 theorem Antitone.le_map_sInf [CompleteLattice β] {s : Set α} {f : α → β} (hf : Antitone f) :
@@ -1471,7 +1471,7 @@ theorem iInf_pair {f : β → α} {a b : β} : ⨅ x ∈ ({a, b} : Set β), f x 
 #align infi_pair iInf_pair
 
 theorem iSup_image {γ} {f : β → γ} {g : γ → α} {t : Set β} :
-    ⨆ c ∈ f '' t, g c = ⨆ b ∈ t, g (f b) := by rw [← sSup_image, ← sSup_image, ← image_comp] ; rfl
+    ⨆ c ∈ f '' t, g c = ⨆ b ∈ t, g (f b) := by rw [← sSup_image, ← sSup_image, ← image_comp]; rfl
 #align supr_image iSup_image
 
 theorem iInf_image :
@@ -1769,7 +1769,7 @@ theorem sInf_apply {α : Type _} {β : α → Type _} [∀ i, InfSet (β i)] {s 
 theorem iSup_apply {α : Type _} {β : α → Type _} {ι : Sort _} [∀ i, SupSet (β i)] {f : ι → ∀ a, β a}
     {a : α} : (⨆ i, f i) a = ⨆ i, f i a := by
   rw [iSup, sSup_apply, iSup, iSup, ← image_eq_range (fun f : ∀ i, β i => f a) (range f), ←
-    range_comp] ; rfl
+    range_comp]; rfl
 #align supr_apply iSup_apply
 
 @[simp]

--- a/Mathlib/Order/Directed.lean
+++ b/Mathlib/Order/Directed.lean
@@ -57,7 +57,7 @@ def DirectedOn (s : Set α) :=
 variable {r r'}
 
 theorem directedOn_iff_directed {s} : @DirectedOn α r s ↔ Directed r (Subtype.val : s → α) := by
-  simp [Directed, DirectedOn] ; refine' ball_congr fun x _ => by simp [And.comm, and_assoc]
+  simp [Directed, DirectedOn]; refine' ball_congr fun x _ => by simp [And.comm, and_assoc]
 #align directed_on_iff_directed directedOn_iff_directed
 
 alias directedOn_iff_directed ↔ DirectedOn.directed_val _

--- a/Mathlib/Order/LiminfLimsup.lean
+++ b/Mathlib/Order/LiminfLimsup.lean
@@ -996,7 +996,7 @@ theorem bliminf_or_eq_inf : (bliminf u f fun x => p x ∨ q x) = bliminf u f p �
 
 theorem sup_limsup [NeBot f] (a : α) : a ⊔ limsup u f = limsup (fun x => a ⊔ u x) f := by
   simp only [limsup_eq_iInf_iSup, iSup_sup_eq, sup_iInf₂_eq]
-  congr ; ext s; congr ; ext hs; congr
+  congr; ext s; congr; ext hs; congr
   exact (biSup_const (nonempty_of_mem hs)).symm
 #align filter.sup_limsup Filter.sup_limsup
 

--- a/Mathlib/Order/RelIso/Basic.lean
+++ b/Mathlib/Order/RelIso/Basic.lean
@@ -843,7 +843,7 @@ lexicographic orders on the sum.
 def sumLexCongr {α₁ α₂ β₁ β₂ r₁ r₂ s₁ s₂} (e₁ : @RelIso α₁ β₁ r₁ s₁) (e₂ : @RelIso α₂ β₂ r₂ s₂) :
     Sum.Lex r₁ r₂ ≃r Sum.Lex s₁ s₂ :=
   ⟨Equiv.sumCongr e₁.toEquiv e₂.toEquiv, @fun a b => by
-    cases' e₁ with f hf ; cases' e₂ with g hg ; cases a <;> cases b <;> simp [hf, hg]⟩
+    cases' e₁ with f hf; cases' e₂ with g hg; cases a <;> cases b <;> simp [hf, hg]⟩
 #align rel_iso.sum_lex_congr RelIso.sumLexCongr
 
 /-- Given relation isomorphisms `r₁ ≃r s₁` and `r₂ ≃r s₂`, construct a relation isomorphism for the

--- a/Mathlib/Order/SuccPred/LinearLocallyFinite.lean
+++ b/Mathlib/Order/SuccPred/LinearLocallyFinite.lean
@@ -373,7 +373,7 @@ variable [SuccOrder ι] [PredOrder ι] [IsSuccArchimedean ι]
 noncomputable def orderIsoRangeToZOfLinearSuccPredArch [hι : Nonempty ι] :
     ι ≃o Set.range (toZ hι.some) where
   toEquiv := Equiv.ofInjective _ injective_toZ
-  map_rel_iff' := by intro i j ; exact toZ_le_iff i j
+  map_rel_iff' := by intro i j; exact toZ_le_iff i j
 set_option linter.uppercaseLean3 false in
 #align order_iso_range_to_Z_of_linear_succ_pred_arch orderIsoRangeToZOfLinearSuccPredArch
 
@@ -404,7 +404,7 @@ noncomputable def orderIsoIntOfLinearSuccPredArch [NoMaxOrder ι] [NoMinOrder ι
     · simp_rw [if_neg (not_le.mpr hn)]
       rw [toZ_iterate_pred]
       simp only [hn.le, Int.toNat_of_nonneg, Right.nonneg_neg_iff, neg_neg]
-  map_rel_iff' := by intro i j ; exact toZ_le_iff i j
+  map_rel_iff' := by intro i j; exact toZ_le_iff i j
 #align order_iso_int_of_linear_succ_pred_arch orderIsoIntOfLinearSuccPredArch
 
 /-- If the order has a bot but no top, `toZ` defines an `OrderIso` between `ι` and `ℕ`. -/

--- a/Mathlib/Order/WithBot.lean
+++ b/Mathlib/Order/WithBot.lean
@@ -218,7 +218,7 @@ instance orderBot : OrderBot (WithBot α) :=
 
 instance orderTop [OrderTop α] : OrderTop (WithBot α) where
   top := some ⊤
-  le_top o a ha := by cases ha ; exact ⟨_, rfl, le_top⟩
+  le_top o a ha := by cases ha; exact ⟨_, rfl, le_top⟩
 
 instance [OrderTop α] : BoundedOrder (WithBot α) :=
   { WithBot.orderBot, WithBot.orderTop with }
@@ -304,7 +304,7 @@ instance preorder [Preorder α] : Preorder (WithBot α) where
   lt := (· < ·)
   lt_iff_le_not_le := by
     intros a b
-    cases a <;> cases b <;> simp [lt_iff_le_not_le] ; simp [LE.le, LT.lt]
+    cases a <;> cases b <;> simp [lt_iff_le_not_le]; simp [LE.le, LT.lt]
   le_refl o a ha := ⟨a, ha, le_rfl⟩
   le_trans o₁ o₂ o₃ h₁ h₂ a ha :=
     let ⟨b, hb, ab⟩ := h₁ a ha
@@ -399,8 +399,8 @@ theorem unbot'_lt_iff [LT α] {a : WithBot α} {b c : α} (ha : a ≠ ⊥) : a.u
 instance semilatticeSup [SemilatticeSup α] : SemilatticeSup (WithBot α) :=
   { WithBot.partialOrder, @WithBot.orderBot α _ with
     sup := Option.liftOrGet (· ⊔ ·),
-    le_sup_left := fun o₁ o₂ a ha => by cases ha ; cases o₂ <;> simp [Option.liftOrGet],
-    le_sup_right := fun o₁ o₂ a ha => by cases ha ; cases o₁ <;> simp [Option.liftOrGet],
+    le_sup_left := fun o₁ o₂ a ha => by cases ha; cases o₂ <;> simp [Option.liftOrGet],
+    le_sup_right := fun o₁ o₂ a ha => by cases ha; cases o₁ <;> simp [Option.liftOrGet],
     sup_le := fun o₁ o₂ o₃ h₁ h₂ a ha => by
       cases' o₁ with b <;> cases' o₂ with c <;> cases ha
       · exact h₂ a rfl
@@ -462,7 +462,7 @@ instance decidableLE [LE α] [@DecidableRel α (· ≤ ·)] : @DecidableRel (Wit
 #align with_bot.decidable_le WithBot.decidableLE
 
 instance decidableLT [LT α] [@DecidableRel α (· < ·)] : @DecidableRel (WithBot α) (· < ·)
-  | none, Option.some x => isTrue <| by exists x, rfl ; rintro _ ⟨⟩
+  | none, Option.some x => isTrue <| by exists x, rfl; rintro _ ⟨⟩
   | Option.some x, Option.some y =>
       if h : x < y then isTrue <| by simp [*] else isFalse <| by simp [*]
   | x, none => isFalse <| by rintro ⟨a, ⟨⟨⟩⟩⟩
@@ -835,7 +835,7 @@ instance orderTop : OrderTop (WithTop α) :=
 
 instance orderBot [OrderBot α] : OrderBot (WithTop α) where
   bot := some ⊥
-  bot_le o a ha := by cases ha ; exact ⟨_, rfl, bot_le⟩
+  bot_le o a ha := by cases ha; exact ⟨_, rfl, bot_le⟩
 #align with_top.order_bot WithTop.orderBot
 
 instance boundedOrder [OrderBot α] : BoundedOrder (WithTop α) :=
@@ -1156,8 +1156,8 @@ theorem map_le_iff [Preorder α] [Preorder β] (f : α → β) (a b : WithTop α
 instance semilatticeInf [SemilatticeInf α] : SemilatticeInf (WithTop α) :=
   { WithTop.partialOrder with
     inf := Option.liftOrGet (· ⊓ ·),
-    inf_le_left := fun o₁ o₂ a ha => by cases ha ; cases o₂ <;> simp [Option.liftOrGet],
-    inf_le_right := fun o₁ o₂ a ha => by cases ha ; cases o₁ <;> simp [Option.liftOrGet],
+    inf_le_left := fun o₁ o₂ a ha => by cases ha; cases o₂ <;> simp [Option.liftOrGet],
+    inf_le_right := fun o₁ o₂ a ha => by cases ha; cases o₁ <;> simp [Option.liftOrGet],
     le_inf := fun o₁ o₂ o₃ h₁ h₂ a ha => by
       cases' o₂ with b <;> cases' o₃ with c <;> cases ha
       · exact h₂ a rfl

--- a/Mathlib/Probability/IdentDistrib.lean
+++ b/Mathlib/Probability/IdentDistrib.lean
@@ -104,7 +104,7 @@ protected theorem trans {ρ : Measure δ} {h : δ → γ} (h₁ : IdentDistrib f
 protected theorem comp_of_aemeasurable {u : γ → δ} (h : IdentDistrib f g μ ν)
     (hu : AEMeasurable u (Measure.map f μ)) : IdentDistrib (u ∘ f) (u ∘ g) μ ν :=
   { aemeasurable_fst := hu.comp_aemeasurable h.aemeasurable_fst
-    aemeasurable_snd := by rw [h.map_eq] at hu ; exact hu.comp_aemeasurable h.aemeasurable_snd
+    aemeasurable_snd := by rw [h.map_eq] at hu; exact hu.comp_aemeasurable h.aemeasurable_snd
     map_eq := by
       rw [← AEMeasurable.map_map_of_aemeasurable hu h.aemeasurable_fst, ←
         AEMeasurable.map_map_of_aemeasurable _ h.aemeasurable_snd, h.map_eq]

--- a/Mathlib/Probability/Kernel/CondCdf.lean
+++ b/Mathlib/Probability/Kernel/CondCdf.lean
@@ -265,7 +265,7 @@ theorem tendsto_IicSnd_atBot [IsFiniteMeasure ρ] {s : Set α} (hs : MeasurableS
       ext1 x
       simp only [Rat.cast_eq_id, id.def, mem_iInter, mem_prod, mem_Iic]
       refine' ⟨fun h i => ⟨(h i).1, _⟩, fun h i => ⟨(h i).1, _⟩⟩ <;> have h' := h (-i)
-      · rw [neg_neg] at h' ; exact h'.2
+      · rw [neg_neg] at h'; exact h'.2
       · exact h'.2
     rw [h_inter_eq] at h_neg
     have h_fun_eq : (fun r : ℚ => ρ (s ×ˢ Iic (r : ℝ))) = fun r : ℚ => ρ (s ×ˢ Iic ↑(- -r)) := by

--- a/Mathlib/Probability/Process/Filtration.lean
+++ b/Mathlib/Probability/Process/Filtration.lean
@@ -303,7 +303,7 @@ theorem filtrationOfSet_eq_natural [MulZeroOneClass β] [Nontrivial β] {s : ι 
     rintro t ⟨hn, u, _, hu'⟩
     obtain heq | heq | heq | heq := Set.indicator_const_preimage (s n) u (1 : β)
     pick_goal 4; rw [Set.mem_singleton_iff] at heq
-    all_goals rw [heq] at hu' ; rw [← hu']
+    all_goals rw [heq] at hu'; rw [← hu']
     exacts [measurableSet_empty _, MeasurableSet.univ, measurableSet_generateFrom ⟨n, hn, rfl⟩,
       MeasurableSet.compl (measurableSet_generateFrom ⟨n, hn, rfl⟩)]
 #align measure_theory.filtration.filtration_of_set_eq_natural MeasureTheory.Filtration.filtrationOfSet_eq_natural

--- a/Mathlib/Probability/Process/Stopping.lean
+++ b/Mathlib/Probability/Process/Stopping.lean
@@ -704,7 +704,7 @@ theorem measurableSet_stopping_time_le [TopologicalSpace ι] [SecondCountableTop
     [OrderTopology ι] [MeasurableSpace ι] [BorelSpace ι] (hτ : IsStoppingTime f τ)
     (hπ : IsStoppingTime f π) : MeasurableSet[hπ.measurableSpace] {ω | τ ω ≤ π ω} := by
   suffices MeasurableSet[(hτ.min hπ).measurableSpace] {ω : Ω | τ ω ≤ π ω} by
-    rw [measurableSet_min_iff hτ hπ] at this ; exact this.2
+    rw [measurableSet_min_iff hτ hπ] at this; exact this.2
   rw [← Set.univ_inter {ω : Ω | τ ω ≤ π ω}, ← hτ.measurableSet_inter_le_iff hπ, Set.univ_inter]
   exact measurableSet_le_stopping_time hτ hπ
 #align measure_theory.is_stopping_time.measurable_set_stopping_time_le MeasureTheory.IsStoppingTime.measurableSet_stopping_time_le

--- a/Mathlib/RepresentationTheory/Action.lean
+++ b/Mathlib/RepresentationTheory/Action.lean
@@ -172,7 +172,7 @@ def mkIso {M N : Action V G} (f : M.V ≅ N.V)
       comm := comm }
   inv :=
     { hom := f.inv
-      comm := fun g => by have w := comm g =≫ f.inv; simp at w ; simp [w] }
+      comm := fun g => by have w := comm g =≫ f.inv; simp at w; simp [w] }
 set_option linter.uppercaseLean3 false in
 #align Action.mk_iso Action.mkIso
 

--- a/Mathlib/RingTheory/Algebraic.lean
+++ b/Mathlib/RingTheory/Algebraic.lean
@@ -155,7 +155,7 @@ theorem isAlgebraic_algHom_of_isAlgebraic {B} [Ring B] [Algebra R B] (f : A →�
 /-- Transfer `Algebra.IsAlgebraic` across an `AlgEquiv`. -/
 theorem AlgEquiv.isAlgebraic {B} [Ring B] [Algebra R B] (e : A ≃ₐ[R] B)
     (h : Algebra.IsAlgebraic R A) : Algebra.IsAlgebraic R B := fun b => by
-  convert← isAlgebraic_algHom_of_isAlgebraic e.toAlgHom (h _) ; refine e.apply_symm_apply ?_
+  convert← isAlgebraic_algHom_of_isAlgebraic e.toAlgHom (h _); refine e.apply_symm_apply ?_
 #align alg_equiv.is_algebraic AlgEquiv.isAlgebraic
 
 theorem AlgEquiv.isAlgebraic_iff {B} [Ring B] [Algebra R B] (e : A ≃ₐ[R] B) :

--- a/Mathlib/RingTheory/DedekindDomain/FiniteAdeleRing.lean
+++ b/Mathlib/RingTheory/DedekindDomain/FiniteAdeleRing.lean
@@ -213,7 +213,7 @@ theorem zero : (0 : K_hat R K).IsFiniteAdele := by
   have h_empty :
     {v : HeightOneSpectrum R | ¬(0 : v.adicCompletion K) ∈ v.adicCompletionIntegers K} = ∅ := by
     ext v; rw [mem_empty_iff_false, iff_false_iff]; intro hv
-    rw [mem_setOf] at hv ; apply hv; rw [mem_adicCompletionIntegers]
+    rw [mem_setOf] at hv; apply hv; rw [mem_adicCompletionIntegers]
     have h_zero : (Valued.v (0 : v.adicCompletion K) : WithZero (Multiplicative ℤ)) = 0 :=
       Valued.v.map_zero'
     rw [h_zero]; exact zero_le_one' _
@@ -263,7 +263,7 @@ theorem one : (1 : K_hat R K).IsFiniteAdele := by
   have h_empty :
     {v : HeightOneSpectrum R | ¬(1 : v.adicCompletion K) ∈ v.adicCompletionIntegers K} = ∅ := by
     ext v; rw [mem_empty_iff_false, iff_false_iff]; intro hv
-    rw [mem_setOf] at hv ; apply hv; rw [mem_adicCompletionIntegers]
+    rw [mem_setOf] at hv; apply hv; rw [mem_adicCompletionIntegers]
     exact le_of_eq Valued.v.map_one'
   simp_rw [Pi.one_apply, h_empty]
   -- Porting note: was `exact`, but `OfNat` got in the way.

--- a/Mathlib/RingTheory/DiscreteValuationRing/TFAE.lean
+++ b/Mathlib/RingTheory/DiscreteValuationRing/TFAE.lean
@@ -115,7 +115,7 @@ theorem maximalIdeal_isPrincipal_of_isDedekindDomain [LocalRing R] [IsDomain R]
     rw [hn, pow_zero, Ideal.one_eq_top] at this
     exact (Ideal.IsMaximal.ne_top inferInstance (eq_top_iff.mpr <| this.trans hle)).elim
   obtain ⟨b, hb₁, hb₂⟩ : ∃ b ∈ maximalIdeal R ^ n, ¬b ∈ Ideal.span {a} := by
-    by_contra' h'; rw [Nat.find_eq_iff] at hn ; exact hn.2 n n.lt_succ_self fun x hx => h' x hx
+    by_contra' h'; rw [Nat.find_eq_iff] at hn; exact hn.2 n n.lt_succ_self fun x hx => h' x hx
   have hb₃ : ∀ m ∈ maximalIdeal R, ∃ k : R, k * a = b * m := by
     intro m hm; rw [← Ideal.mem_span_singleton']; apply Nat.find_spec this
     rw [hn, pow_succ']; exact Ideal.mul_mem_mul hb₁ hm

--- a/Mathlib/RingTheory/IsAdjoinRoot.lean
+++ b/Mathlib/RingTheory/IsAdjoinRoot.lean
@@ -715,7 +715,7 @@ theorem ofEquiv_root (h : IsAdjoinRoot S f) (e : S ≃ₐ[R] T) : (h.ofEquiv e).
 @[simp]
 theorem aequiv_ofEquiv {U : Type _} [CommRing U] [Algebra R U] (h : IsAdjoinRoot S f)
     (h' : IsAdjoinRoot T f) (e : T ≃ₐ[R] U) : h.aequiv (h'.ofEquiv e) = (h.aequiv h').trans e := by
-  ext a ; rw [← h.map_repr a, aequiv_map, AlgEquiv.trans_apply, aequiv_map, ofEquiv_map_apply]
+  ext a; rw [← h.map_repr a, aequiv_map, AlgEquiv.trans_apply, aequiv_map, ofEquiv_map_apply]
 #align is_adjoin_root.aequiv_of_equiv IsAdjoinRoot.aequiv_ofEquiv
 
 @[simp]

--- a/Mathlib/RingTheory/Polynomial/Basic.lean
+++ b/Mathlib/RingTheory/Polynomial/Basic.lean
@@ -957,7 +957,7 @@ protected theorem Polynomial.isNoetherianRing [inst : IsNoetherianRing R] : IsNo
           Classical.by_contradiction fun hxm =>
             haveI : IsNoetherian R R := inst
             have : ¬M < I.leadingCoeffNth k := by
-              refine' WellFounded.not_lt_min (wellFounded_submodule_gt R R) _ _ _ ; exact ⟨k, rfl⟩
+              refine' WellFounded.not_lt_min (wellFounded_submodule_gt R R) _ _ _; exact ⟨k, rfl⟩
             this ⟨HN ▸ I.leadingCoeffNth_mono (le_of_lt h), fun H => hxm (H hx)⟩
       have hs2 : ∀ {x}, x ∈ I.degreeLE N → x ∈ Ideal.span (↑s : Set R[X]) :=
         hs ▸ fun hx =>

--- a/Mathlib/RingTheory/RootsOfUnity/Minpoly.lean
+++ b/Mathlib/RingTheory/RootsOfUnity/Minpoly.lean
@@ -165,7 +165,7 @@ theorem minpoly_eq_pow {p : ℕ} [hprime : Fact p.Prime] (hdiv : ¬p ∣ n) :
     (multiplicity.squarefree_iff_multiplicity_le_one (X ^ n - 1)).1 hfree
       (map (Int.castRingHom (ZMod p)) P) with
     hle hunit
-  · rw [Nat.cast_one] at habs ; exact hle.not_lt habs
+  · rw [Nat.cast_one] at habs; exact hle.not_lt habs
   · replace hunit := degree_eq_zero_of_isUnit hunit
     rw [degree_map_eq_of_leadingCoeff_ne_zero (Int.castRingHom (ZMod p)) _] at hunit
     · exact (minpoly.degree_pos (isIntegral h hpos)).ne' hunit

--- a/Mathlib/RingTheory/Valuation/ValuationSubring.lean
+++ b/Mathlib/RingTheory/Valuation/ValuationSubring.lean
@@ -375,7 +375,7 @@ theorem idealOfLE_le_of_le (R S : ValuationSubring K) (hR : A ≤ R) (hS : A ≤
     idealOfLE A S hS ≤ idealOfLE A R hR := fun x hx =>
   (valuation_lt_one_iff R _).2
     (by
-      by_contra c; push_neg at c ; replace c := monotone_mapOfLE R S h c
+      by_contra c; push_neg at c; replace c := monotone_mapOfLE R S h c
       rw [(mapOfLE _ _ _).map_one, mapOfLE_valuation_apply] at c
       apply not_le_of_lt ((valuation_lt_one_iff S _).1 hx) c)
 #align valuation_subring.ideal_of_le_le_of_le ValuationSubring.idealOfLE_le_of_le

--- a/Mathlib/RingTheory/WittVector/Compare.lean
+++ b/Mathlib/RingTheory/WittVector/Compare.lean
@@ -104,7 +104,7 @@ theorem commutes {m : ℕ} (hm : n ≤ m) :
 
 theorem commutes' {m : ℕ} (hm : n ≤ m) (x : ZMod (p ^ m)) :
     truncate hm (zmodEquivTrunc p m x) = zmodEquivTrunc p n (ZMod.castHom (pow_dvd_pow p hm) _ x) :=
-  show (truncate hm).comp (zmodEquivTrunc p m).toRingHom x = _ by rw [commutes _ _ hm] ; rfl
+  show (truncate hm).comp (zmodEquivTrunc p m).toRingHom x = _ by rw [commutes _ _ hm]; rfl
 #align truncated_witt_vector.commutes' TruncatedWittVector.commutes'
 
 theorem commutes_symm' {m : ℕ} (hm : n ≤ m) (x : TruncatedWittVector p m (ZMod p)) :
@@ -130,7 +130,7 @@ and the horizontal arrow at the bottom is `TruncatedWittVector.truncate`.
 theorem commutes_symm {m : ℕ} (hm : n ≤ m) :
     (zmodEquivTrunc p n).symm.toRingHom.comp (truncate hm) =
       (ZMod.castHom (pow_dvd_pow p hm) _).comp (zmodEquivTrunc p m).symm.toRingHom :=
-  by ext ; apply commutes_symm'
+  by ext; apply commutes_symm'
 #align truncated_witt_vector.commutes_symm TruncatedWittVector.commutes_symm
 
 end Iso

--- a/Mathlib/RingTheory/WittVector/WittPolynomial.lean
+++ b/Mathlib/RingTheory/WittVector/WittPolynomial.lean
@@ -226,7 +226,7 @@ set_option linter.uppercaseLean3 false in
 @[simp]
 theorem constantCoeff_xInTermsOfW [hp : Fact p.Prime] [Invertible (p : R)] (n : ℕ) :
     constantCoeff (xInTermsOfW p R n) = 0 := by
-  apply Nat.strongInductionOn n ; clear n
+  apply Nat.strongInductionOn n; clear n
   intro n IH
   rw [xInTermsOfW_eq, mul_comm, RingHom.map_mul, RingHom.map_sub, map_sum, constantCoeff_C,
     constantCoeff_X, zero_sub, mul_neg, neg_eq_zero]

--- a/Mathlib/SetTheory/Cardinal/Ordinal.lean
+++ b/Mathlib/SetTheory/Cardinal/Ordinal.lean
@@ -1193,7 +1193,7 @@ theorem mk_compl_eq_mk_compl_finite_same {α : Type u} [Finite α] {s t : Set α
 
 theorem extend_function {α β : Type _} {s : Set α} (f : s ↪ β)
     (h : Nonempty ((sᶜ : Set α) ≃ ((range f)ᶜ : Set β))) : ∃ g : α ≃ β, ∀ x : s, g x = f x := by
-  intros ; have := h; cases' this with g
+  intros; have := h; cases' this with g
   let h : α ≃ β :=
     (Set.sumCompl (s : Set α)).symm.trans
       ((sumCongr (Equiv.ofInjective f f.2) g).trans (Set.sumCompl (range f)))

--- a/Mathlib/SetTheory/Game/State.lean
+++ b/Mathlib/SetTheory/Game/State.lean
@@ -94,23 +94,23 @@ def ofStateAuxRelabelling :
   | s, 0, 0, hn, hm => by
     dsimp [PGame.ofStateAux]
     fconstructor; rfl; rfl
-    · intro i; dsimp at i ; exfalso
+    · intro i; dsimp at i; exfalso
       exact turnBound_ne_zero_of_left_move i.2 (nonpos_iff_eq_zero.mp hn)
-    · intro j; dsimp at j ; exfalso
+    · intro j; dsimp at j; exfalso
       exact turnBound_ne_zero_of_right_move j.2 (nonpos_iff_eq_zero.mp hm)
   | s, 0, m + 1, hn, hm => by
     dsimp [PGame.ofStateAux]
     fconstructor; rfl; rfl
-    · intro i; dsimp at i ; exfalso
+    · intro i; dsimp at i; exfalso
       exact turnBound_ne_zero_of_left_move i.2 (nonpos_iff_eq_zero.mp hn)
-    · intro j; dsimp at j ; exfalso
+    · intro j; dsimp at j; exfalso
       exact turnBound_ne_zero_of_right_move j.2 (nonpos_iff_eq_zero.mp hn)
   | s, n + 1, 0, hn, hm => by
     dsimp [PGame.ofStateAux]
     fconstructor; rfl; rfl
-    · intro i; dsimp at i ; exfalso
+    · intro i; dsimp at i; exfalso
       exact turnBound_ne_zero_of_left_move i.2 (nonpos_iff_eq_zero.mp hm)
-    · intro j; dsimp at j ; exfalso
+    · intro j; dsimp at j; exfalso
       exact turnBound_ne_zero_of_right_move j.2 (nonpos_iff_eq_zero.mp hm)
   | s, n + 1, m + 1, hn, hm => by
     dsimp [PGame.ofStateAux]

--- a/Mathlib/SetTheory/Ordinal/Arithmetic.lean
+++ b/Mathlib/SetTheory/Ordinal/Arithmetic.lean
@@ -2189,7 +2189,7 @@ theorem enumOrd_strictMono (hS : Unbounded (· < ·) S) : StrictMono (enumOrd S)
 /-- A more workable definition for `enumOrd`. -/
 theorem enumOrd_def (o) : enumOrd S o = sInf (S ∩ { b | ∀ c, c < o → enumOrd S c < b }) := by
   rw [enumOrd_def']
-  congr ; ext
+  congr; ext
   exact ⟨fun h a hao => (lt_blsub.{u, u} _ _ hao).trans_le h, blsub_le⟩
 #align ordinal.enum_ord_def Ordinal.enumOrd_def
 

--- a/Mathlib/SetTheory/Ordinal/FixedPoint.lean
+++ b/Mathlib/SetTheory/Ordinal/FixedPoint.lean
@@ -567,7 +567,7 @@ end
 @[simp]
 theorem nfp_add_zero (a) : nfp (a + ·) 0 = a * omega := by
   simp_rw [← sup_iterate_eq_nfp, ← sup_mul_nat]
-  congr ; funext n
+  congr; funext n
   induction' n with n hn
   · rw [Nat.cast_zero, mul_zero, iterate_zero_apply]
   · nth_rw 2 [Nat.succ_eq_one_add]

--- a/Mathlib/SetTheory/Ordinal/Notation.lean
+++ b/Mathlib/SetTheory/Ordinal/Notation.lean
@@ -710,7 +710,7 @@ theorem opow_def (o₁ o₂ : ONote) : o₁ ^ o₂ = opowAux2 o₂ (split o₁) 
 #align onote.opow_def ONote.opow_def
 
 theorem split_eq_scale_split' : ∀ {o o' m} [NF o], split' o = (o', m) → split o = (scale 1 o', m)
-  | 0, o', m, _, p => by injection p ; substs o' m ; rfl
+  | 0, o', m, _, p => by injection p; substs o' m; rfl
   | oadd e n a, o', m, h, p => by
     by_cases e0 : e = 0 <;> simp [e0, split, split'] at p ⊢
     · rcases p with ⟨rfl, rfl⟩
@@ -733,7 +733,7 @@ theorem split_eq_scale_split' : ∀ {o o' m} [NF o], split' o = (o', m) → spli
 #align onote.split_eq_scale_split' ONote.split_eq_scale_split'
 
 theorem nf_repr_split' : ∀ {o o' m} [NF o], split' o = (o', m) → NF o' ∧ repr o = ω * repr o' + m
-  | 0, o', m, _, p => by injection p ; substs o' m ; simp [NF.zero]
+  | 0, o', m, _, p => by injection p; substs o' m; simp [NF.zero]
   | oadd e n a, o', m, h, p => by
     by_cases e0 : e = 0 <;> simp [e0, split, split'] at p ⊢
     · rcases p with ⟨rfl, rfl⟩
@@ -810,7 +810,7 @@ theorem split_add_lt {o e n a m} [NF o] (h : split o = (oadd e n a, m)) :
 theorem mulNat_eq_mul (n o) : mulNat o n = o * ofNat n := by cases o <;> cases n <;> rfl
 #align onote.mul_nat_eq_mul ONote.mulNat_eq_mul
 
-instance nf_mulNat (o) [NF o] (n) : NF (mulNat o n) := by simp ; exact ONote.mul_nf o (ofNat n)
+instance nf_mulNat (o) [NF o] (n) : NF (mulNat o n) := by simp; exact ONote.mul_nf o (ofNat n)
 #align onote.NF_mul_nat ONote.nf_mulNat
 
 instance nf_opowAux (e a0 a) [NF e] [NF a0] [NF a] : ∀ k m, NF (opowAux e a0 a k m) := by
@@ -821,7 +821,7 @@ instance nf_opowAux (e a0 a) [NF e] [NF a0] [NF a] : ∀ k m, NF (opowAux e a0 a
   cases' k with k k
   · exact NF.oadd_zero _ _
   · haveI := nf_opowAux e a0 a k
-    simp only [Nat.succ_ne_zero m] ; infer_instance
+    simp only [Nat.succ_ne_zero m]; infer_instance
 #align onote.NF_opow_aux ONote.nf_opowAux
 
 instance nf_opow (o₁ o₂) [NF o₁] [NF o₂] : NF (o₁ ^ o₂) := by
@@ -1245,7 +1245,7 @@ def NONote :=
   { o : ONote // o.NF }
 #align nonote NONote
 
-instance : DecidableEq NONote := by unfold NONote ; infer_instance
+instance : DecidableEq NONote := by unfold NONote; infer_instance
 
 namespace NONote
 

--- a/Mathlib/SetTheory/Surreal/Dyadic.lean
+++ b/Mathlib/SetTheory/Surreal/Dyadic.lean
@@ -216,7 +216,7 @@ theorem dyadic_aux {m₁ m₂ : ℤ} {y₁ y₂ : ℕ} (h₂ : m₁ * 2 ^ y₁ =
   cases' h₂ with h₂ h₂
   · rw [h₂, add_comm, zsmul_pow_two_powHalf m₂ c y₁]
   · have := Nat.one_le_pow y₁ 2 Nat.succ_pos'
-    norm_cast at h₂ ; linarith
+    norm_cast at h₂; linarith
 #align surreal.dyadic_aux Surreal.dyadic_aux
 
 /-- The additive monoid morphism `dyadicMap` sends ⟦⟨m, 2^n⟩⟧ to m • half ^ n. -/

--- a/Mathlib/Topology/Algebra/Equicontinuity.lean
+++ b/Mathlib/Topology/Algebra/Equicontinuity.lean
@@ -29,8 +29,8 @@ theorem equicontinuous_of_equicontinuousAt_one {ι G M hom : Type _} [Topologica
   rw [equicontinuousAt_iff_continuousAt] at hf
   let φ : G →* (ι →ᵤ M) :=
     { toFun := swap ((↑) ∘ F)
-      map_one' := by dsimp [UniformFun] ; ext ; exact map_one _
-      map_mul' := fun a b => by dsimp [UniformFun] ; ext ; exact map_mul _ _ _ }
+      map_one' := by dsimp [UniformFun]; ext; exact map_one _
+      map_mul' := fun a b => by dsimp [UniformFun]; ext; exact map_mul _ _ _ }
   exact continuous_of_continuousAt_one φ hf
 #align equicontinuous_of_equicontinuous_at_one equicontinuous_of_equicontinuousAt_one
 #align equicontinuous_of_equicontinuous_at_zero equicontinuous_of_equicontinuousAt_zero
@@ -44,8 +44,8 @@ theorem uniformEquicontinuous_of_equicontinuousAt_one {ι G M hom : Type _} [Uni
   rw [equicontinuousAt_iff_continuousAt] at hf
   let φ : G →* (ι →ᵤ M) :=
     { toFun := swap ((↑) ∘ F)
-      map_one' := by dsimp [UniformFun] ; ext ; exact map_one _
-      map_mul' := fun a b => by dsimp [UniformFun] ; ext ; exact map_mul _ _ _ }
+      map_one' := by dsimp [UniformFun]; ext; exact map_one _
+      map_mul' := fun a b => by dsimp [UniformFun]; ext; exact map_mul _ _ _ }
   exact uniformContinuous_of_continuousAt_one φ hf
 #align uniform_equicontinuous_of_equicontinuous_at_one uniformEquicontinuous_of_equicontinuousAt_one
 #align uniform_equicontinuous_of_equicontinuous_at_zero uniformEquicontinuous_of_equicontinuousAt_zero

--- a/Mathlib/Topology/Category/CompHaus/Basic.lean
+++ b/Mathlib/Topology/Category/CompHaus/Basic.lean
@@ -167,7 +167,7 @@ instance (X : CompHaus) : T2Space (compHausToTop.obj X) :=
   show T2Space X.toTop from inferInstance
 
 instance CompHaus.forget_reflectsIsomorphisms : ReflectsIsomorphisms (forget CompHaus.{u}) :=
-  ⟨by intro A B f hf ; exact CompHaus.isIso_of_bijective _ ((isIso_iff_bijective f).mp hf)⟩
+  ⟨by intro A B f hf; exact CompHaus.isIso_of_bijective _ ((isIso_iff_bijective f).mp hf)⟩
 set_option linter.uppercaseLean3 false in
 #align CompHaus.forget_reflects_isomorphisms CompHaus.forget_reflectsIsomorphisms
 

--- a/Mathlib/Topology/Category/CompHaus/EffectiveEpi.lean
+++ b/Mathlib/Topology/Category/CompHaus/EffectiveEpi.lean
@@ -85,7 +85,7 @@ lemma ιFun_injective : (ιFun π).Injective := by
   rintro ⟨⟨a,x⟩⟩ ⟨⟨b,y⟩⟩ (h : π _ _ = π _ _)
   apply Quotient.sound'
   refine ⟨pullback (π a) (π b), ⟨⟨x,y⟩,h⟩, pullback.fst _ _, pullback.snd _ _, ?_, rfl, rfl⟩
-  ext ⟨_, h⟩ ; exact h
+  ext ⟨_, h⟩; exact h
 
 /--
 Implementation: The quotient of `relation π`, considered as an object of `CompHaus`.
@@ -127,7 +127,7 @@ Implementation: The family of morphisms `X a ⟶ QB` is an effective epi.
 def structAux : EffectiveEpiFamilyStruct X (π' π) where
   desc := fun {W} e h => {
     toFun := Quotient.lift (fun ⟨a,x⟩ => e a x) <| by
-      rintro ⟨a,x⟩ ⟨b,y⟩ ⟨Z,z,fst,snd,hh,hx,hy⟩ ; dsimp at *
+      rintro ⟨a,x⟩ ⟨b,y⟩ ⟨Z,z,fst,snd,hh,hx,hy⟩; dsimp at *
       rw [← hx, ← hy]
       specialize h _ _ fst snd ?_
       · ext z
@@ -141,7 +141,7 @@ def structAux : EffectiveEpiFamilyStruct X (π' π) where
       apply continuous_sigma
       intro a
       exact (e a).continuous }
-  fac := by intro Z e h a ; ext ; rfl
+  fac := by intro Z e h a; ext; rfl
   uniq := by
     intro Z e h m hm
     ext ⟨⟨a,x⟩⟩
@@ -150,7 +150,7 @@ def structAux : EffectiveEpiFamilyStruct X (π' π) where
     exact hm
 
 @[reassoc]
-lemma π'_comp_ι_hom (a : α) : π' π a ≫ (ι _ surj).hom = π a := by ext ; rfl
+lemma π'_comp_ι_hom (a : α) : π' π a ≫ (ι _ surj).hom = π a := by ext; rfl
 
 @[reassoc]
 lemma π_comp_ι_inv (a : α) : π a ≫ (ι _ surj).inv = π' π a :=  by
@@ -200,26 +200,26 @@ theorem effectiveEpiFamily_tfae
     , ∀ b : B, ∃ (a : α) (x : X a), π a x = b
     ] := by
   tfae_have 1 → 2
-  · intro ; infer_instance
+  · intro; infer_instance
   tfae_have 2 → 3
-  · intro e ; rw [epi_iff_surjective] at e
+  · intro e; rw [epi_iff_surjective] at e
     let i : ∐ X ≅ finiteCoproduct X :=
       (colimit.isColimit _).coconePointUniqueUpToIso (finiteCoproduct.isColimit _)
     intro b
     obtain ⟨t,rfl⟩ := e b
     let q := i.hom t
     refine ⟨q.1,q.2,?_⟩
-    have : t = i.inv (i.hom t) := show t = (i.hom ≫ i.inv) t by simp only [i.hom_inv_id] ; rfl
+    have : t = i.inv (i.hom t) := show t = (i.hom ≫ i.inv) t by simp only [i.hom_inv_id]; rfl
     rw [this]
     show _ = (i.inv ≫ Sigma.desc π) (i.hom t)
     suffices i.inv ≫ Sigma.desc π = finiteCoproduct.desc X π by
-      rw [this] ; rfl
+      rw [this]; rfl
     rw [Iso.inv_comp_eq]
     apply colimit.hom_ext
     rintro ⟨a⟩
     simp only [Discrete.functor_obj, colimit.ι_desc, Cofan.mk_pt, Cofan.mk_ι_app,
       colimit.comp_coconePointUniqueUpToIso_hom_assoc]
-    ext ; rfl
+    ext; rfl
   tfae_have 3 → 1
   · apply effectiveEpiFamily_of_jointly_surjective
   tfae_finish
@@ -229,9 +229,9 @@ instance precoherent : Precoherent CompHaus.{u} := by
   intro B₁ B₂ f α _ X₁ π₁ h₁
   refine ⟨α, inferInstance, fun a => pullback f (π₁ a), fun a => pullback.fst _ _, ?_,
     id, fun a => pullback.snd _ _, ?_⟩
-  · have := (effectiveEpiFamily_tfae _ π₁).out 0 2 ; rw [this] at h₁ ; clear this
+  · have := (effectiveEpiFamily_tfae _ π₁).out 0 2; rw [this] at h₁; clear this
     have := (effectiveEpiFamily_tfae _ (fun a => pullback.fst f (π₁ a))).out 0 2
-    rw [this] ; clear this
+    rw [this]; clear this
     intro b₂
     obtain ⟨a,x,h⟩ := h₁ (f b₂)
     refine ⟨a, ⟨⟨b₂, x⟩, h.symm⟩, rfl⟩

--- a/Mathlib/Topology/Category/CompHaus/ExplicitLimits.lean
+++ b/Mathlib/Topology/Category/CompHaus/ExplicitLimits.lean
@@ -58,7 +58,7 @@ def pullback.snd : pullback f g ⟶ Y where
 
 @[reassoc]
 lemma pullback.condition : pullback.fst f g ≫ f = pullback.snd f g ≫ g := by
-  ext ⟨_,h⟩ ; exact h
+  ext ⟨_,h⟩; exact h
 
 /--
 Construct a morphism to the explicit pullback given morphisms to the factors
@@ -67,7 +67,7 @@ This is essentially the universal property of the pullback.
 -/
 def pullback.lift {Z : CompHaus.{u}} (a : Z ⟶ X) (b : Z ⟶ Y) (w : a ≫ f = b ≫ g) :
     Z ⟶ pullback f g where
-  toFun := fun z => ⟨⟨a z, b z⟩, by apply_fun (fun q => q z) at w ; exact w⟩
+  toFun := fun z => ⟨⟨a z, b z⟩, by apply_fun (fun q => q z) at w; exact w⟩
   continuous_toFun := by
     apply Continuous.subtype_mk
     rw [continuous_prod_mk]
@@ -138,7 +138,7 @@ def finiteCoproduct.desc {B : CompHaus.{u}} (e : (a : α) → (X a ⟶ B)) :
   toFun := fun ⟨a,x⟩ => e a x
   continuous_toFun := by
     apply continuous_sigma
-    intro a ; exact (e a).continuous
+    intro a; exact (e a).continuous
 
 @[reassoc (attr := simp)]
 lemma finiteCoproduct.ι_desc {B : CompHaus.{u}} (e : (a : α) → (X a ⟶ B)) (a : α) :

--- a/Mathlib/Topology/Category/TopCat/Limits/Basic.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Basic.lean
@@ -99,7 +99,7 @@ def limitConeIsLimit (F : J ⥤ TopCatMax.{v, u}) : IsLimit (limitCone.{v,u} F) 
           rw [← S.w f]
           rfl }
   uniq S m h := by
-    apply ContinuousMap.ext ; intros a ; apply Subtype.ext ; funext j
+    apply ContinuousMap.ext; intros a; apply Subtype.ext; funext j
     dsimp
     rw [← h]
     rfl

--- a/Mathlib/Topology/Category/TopCat/Opens.lean
+++ b/Mathlib/Topology/Category/TopCat/Opens.lean
@@ -405,7 +405,7 @@ theorem map_functor_eq {X : TopCat} {U : Opens X} (V : Opens U) :
 @[simp]
 theorem adjunction_counit_map_functor {X : TopCat} {U : Opens X} (V : Opens U) :
     U.openEmbedding.isOpenMap.adjunction.counit.app (U.openEmbedding.isOpenMap.functor.obj V) =
-      eqToHom (by dsimp ; rw [map_functor_eq V]) :=
+      eqToHom (by dsimp; rw [map_functor_eq V]) :=
   by apply Subsingleton.elim
 #align topological_space.opens.adjunction_counit_map_functor TopologicalSpace.Opens.adjunction_counit_map_functor
 

--- a/Mathlib/Topology/Homotopy/Path.lean
+++ b/Mathlib/Topology/Homotopy/Path.lean
@@ -340,7 +340,7 @@ theorem hpath_hext {p₁ : Path x₀ x₁} {p₂ : Path x₂ x₃} (hp : ∀ t, 
     @HEq (Path.Homotopic.Quotient _ _) ⟦p₁⟧ (Path.Homotopic.Quotient _ _) ⟦p₂⟧ := by
   obtain rfl : x₀ = x₂ := by convert hp 0 <;> simp
   obtain rfl : x₁ = x₃ := by convert hp 1 <;> simp
-  rw [heq_iff_eq]; congr ; ext t; exact hp t
+  rw [heq_iff_eq]; congr; ext t; exact hp t
 #align path.homotopic.hpath_hext Path.Homotopic.hpath_hext
 
 end Homotopic

--- a/Mathlib/Topology/IsLocallyHomeomorph.lean
+++ b/Mathlib/Topology/IsLocallyHomeomorph.lean
@@ -49,9 +49,9 @@ theorem mk (h : ∀ x ∈ s, ∃ e : LocalHomeomorph X Y, x ∈ e.source ∧ ∀
   exact
     ⟨{ e with
         toFun := f
-        map_source' := fun x hx => by rw [he x hx] ; exact e.map_source' hx
-        left_inv' := fun x hx => by rw [he x hx] ; exact e.left_inv' hx
-        right_inv' := fun y hy => by rw [he _ (e.map_target' hy)] ; exact e.right_inv' hy
+        map_source' := fun x hx => by rw [he x hx]; exact e.map_source' hx
+        left_inv' := fun x hx => by rw [he x hx]; exact e.left_inv' hx
+        right_inv' := fun y hy => by rw [he _ (e.map_target' hy)]; exact e.right_inv' hy
         continuous_toFun := (continuousOn_congr he).mpr e.continuous_toFun },
       hx, rfl⟩
 #align is_locally_homeomorph_on.mk IsLocallyHomeomorphOn.mk

--- a/Mathlib/Topology/List.lean
+++ b/Mathlib/Topology/List.lean
@@ -93,7 +93,7 @@ theorem tendsto_cons_iff {β : Type _} {f : List α → β} {b : Filter β} {a :
     simp only [nhds_cons, Filter.prod_eq, (Filter.map_def _ _).symm,
       (Filter.seq_eq_filter_seq _ _).symm]
     simp [-Filter.map_def, (· ∘ ·), functor_norm]
-  rw [this, Filter.tendsto_map'_iff] ; dsimp; rfl
+  rw [this, Filter.tendsto_map'_iff]; dsimp; rfl
 #align list.tendsto_cons_iff List.tendsto_cons_iff
 
 theorem continuous_cons : Continuous fun x : α × List α => (x.1::x.2 : List α) :=

--- a/Mathlib/Topology/MetricSpace/EMetricSpace.lean
+++ b/Mathlib/Topology/MetricSpace/EMetricSpace.lean
@@ -517,8 +517,8 @@ instance pseudoEMetricSpacePi [∀ b, PseudoEMetricSpace (π b)] : PseudoEMetric
   uniformity_edist := by
     simp only [Pi.uniformity, PseudoEMetricSpace.uniformity_edist, comap_iInf, gt_iff_lt,
       preimage_setOf_eq, comap_principal, edist_pi_def]
-    rw [iInf_comm]; congr ; funext ε
-    rw [iInf_comm]; congr ; funext εpos
+    rw [iInf_comm]; congr; funext ε
+    rw [iInf_comm]; congr; funext εpos
     simp [setOf_forall, εpos]
 #align pseudo_emetric_space_pi pseudoEMetricSpacePi
 

--- a/Mathlib/Topology/MetricSpace/Infsep.lean
+++ b/Mathlib/Topology/MetricSpace/Infsep.lean
@@ -159,7 +159,7 @@ theorem einfsep_pair_le_left (hxy : x ≠ y) : ({x, y} : Set α).einfsep ≤ edi
 #align set.einfsep_pair_le_left Set.einfsep_pair_le_left
 
 theorem einfsep_pair_le_right (hxy : x ≠ y) : ({x, y} : Set α).einfsep ≤ edist y x := by
-  rw [pair_comm] ; exact einfsep_pair_le_left hxy.symm
+  rw [pair_comm]; exact einfsep_pair_le_left hxy.symm
 #align set.einfsep_pair_le_right Set.einfsep_pair_le_right
 
 theorem einfsep_pair_eq_inf (hxy : x ≠ y) : ({x, y} : Set α).einfsep = edist x y ⊓ edist y x :=

--- a/Mathlib/Topology/Sheaves/Functors.lean
+++ b/Mathlib/Topology/Sheaves/Functors.lean
@@ -83,7 +83,7 @@ open Presheaf
 /-- The pushforward of a sheaf (by a continuous map) is a sheaf.
 -/
 theorem pushforward_sheaf_of_sheaf {F : X.Presheaf C} (h : F.IsSheaf) : (f _* F).IsSheaf := by
-  rw [isSheaf_iff_isSheafPairwiseIntersections] at h ⊢ ;
+  rw [isSheaf_iff_isSheafPairwiseIntersections] at h ⊢
   exact SheafConditionPairwiseIntersections.pushforward_sheaf_of_sheaf f h
 set_option linter.uppercaseLean3 false in
 #align Top.sheaf.pushforward_sheaf_of_sheaf TopCat.Sheaf.pushforward_sheaf_of_sheaf

--- a/Mathlib/Topology/Sheaves/Sheafify.lean
+++ b/Mathlib/Topology/Sheaves/Sheafify.lean
@@ -106,9 +106,9 @@ theorem stalkToFiber_injective (x : X) : Function.Injective (F.stalkToFiber x) :
   rcases hU ⟨x, U.2⟩ with ⟨U', mU, iU, gU, wU⟩
   rcases hV ⟨x, V.2⟩ with ⟨V', mV, iV, gV, wV⟩
   have wUx := wU ⟨x, mU⟩
-  dsimp at wUx ; erw [wUx] at e ; clear wUx
+  dsimp at wUx; erw [wUx] at e; clear wUx
   have wVx := wV ⟨x, mV⟩
-  dsimp at wVx ; erw [wVx] at e ; clear wVx
+  dsimp at wVx; erw [wVx] at e; clear wVx
   rcases F.germ_eq x mU mV gU gV e with ⟨W, mW, iU', iV', (e' : F.map iU'.op gU = F.map iV'.op gV)⟩
   use ⟨W ⊓ (U' ⊓ V'), ⟨mW, mU, mV⟩⟩
   refine' ⟨_, _, _⟩

--- a/Mathlib/Topology/UniformSpace/Completion.lean
+++ b/Mathlib/Topology/UniformSpace/Completion.lean
@@ -188,7 +188,7 @@ theorem denseRange_pureCauchy : DenseRange (pureCauchy : α → CauchyFilter α)
         ⟨t, ht, { y : α | (x, y) ∈ t' }, h <| mk_mem_prod hx hx,
           fun ⟨a, b⟩ ⟨(h₁ : a ∈ t), (h₂ : (x, b) ∈ t')⟩ =>
           ht'₂ <| prod_mk_mem_compRel (@h (a, x) ⟨h₁, hx⟩) h₂⟩
-    ⟨x, ht''₂ <| by dsimp [gen] ; exact this⟩
+    ⟨x, ht''₂ <| by dsimp [gen]; exact this⟩
   simp only [closure_eq_cluster_pts, ClusterPt, nhds_eq_uniformity, lift'_inf_principal_eq,
     Set.inter_comm _ (range pureCauchy), mem_setOf_eq]
   refine (lift'_neBot_iff ?_).mpr (fun s hs => ?_)
@@ -236,7 +236,7 @@ instance : CompleteSpace (CauchyFilter α) :=
         have : t' ⊆ { y : α | (f', pureCauchy y) ∈ gen t } := fun x hx =>
           (f ×ˢ pure x).sets_of_superset (prod_mem_prod ht' hx) h
         f.sets_of_superset ht' <| Subset.trans this (preimage_mono ht₂)
-    ⟨f', by simp [nhds_eq_uniformity] ; assumption⟩
+    ⟨f', by simp [nhds_eq_uniformity]; assumption⟩
 
 end
 

--- a/scripts/lint-style.py
+++ b/scripts/lint-style.py
@@ -48,6 +48,7 @@ ERR_TAC = 9 # imported Mathlib.Tactic
 ERR_UNF = 10 # unfreeze_local_instances
 ERR_IBY = 11 # isolated by
 ERR_DOT = 12 # isolated or low focusing dot
+ERR_SEM = 13 # the substring " ;"
 
 exceptions = []
 
@@ -232,7 +233,7 @@ def banned_import_check(lines, path):
             errors += [(ERR_TAC, line_nr, path)]
     return errors
 
-def isolated_by_dot_check(lines, path):
+def isolated_by_dot_semicolon_check(lines, path):
     errors = []
     for line_nr, line in enumerate(lines, 1):
         if line.strip() == "by":
@@ -244,6 +245,8 @@ def isolated_by_dot_check(lines, path):
                 errors += [(ERR_IBY, line_nr, path)]
         if line.lstrip().startswith(". ") or line.strip() in (".", "·"):
             errors += [(ERR_DOT, line_nr, path)]
+        if " ;" in line:
+            errors += [(ERR_SEM, line_nr, path)]
     return errors
 
 def output_message(path, line_nr, code, msg):
@@ -288,13 +291,15 @@ def format_errors(errors):
             output_message(path, line_nr, "ERR_IBY", "Line is an isolated 'by'")
         if errno == ERR_DOT:
             output_message(path, line_nr, "ERR_DOT", "Line is an isolated focusing dot or uses . instead of ·")
+        if errno == ERR_SEM:
+            output_message(path, line_nr, "ERR_SEM", "Line contains a space before a semicolon")
 
 def lint(path):
     with path.open(encoding="utf-8") as f:
         lines = f.readlines()
         errs = long_lines_check(lines, path)
         format_errors(errs)
-        errs = isolated_by_dot_check(lines, path)
+        errs = isolated_by_dot_semicolon_check(lines, path)
         format_errors(errs)
         (b, errs) = import_only_check(lines, path)
         if b:

--- a/test/Monotonicity.lean
+++ b/test/Monotonicity.lean
@@ -65,7 +65,7 @@ example {x y z : ℕ} : true := by
   trivial
 
 example {x y z : ℕ} : true := by
-  suffices : x + y ≤ z + y ; trivial
+  suffices : x + y ≤ z + y; trivial
   mono
   guard_target = x ≤ z
   admit
@@ -73,8 +73,8 @@ example {x y z : ℕ} : true := by
 example {x y z w : ℕ} : true := by
   have : x + y ≤ z + w := by
     mono
-    guard_target = x ≤ z ; admit
-    guard_target = y ≤ w ; admit
+    guard_target = x ≤ z; admit
+    guard_target = y ≤ w; admit
   trivial
 
 -- example
@@ -137,10 +137,10 @@ example {x y z w : ℕ} : true := by
 --     xs ≤ zs := by
 --   revert ys zs
 --   induction' xs with x xs
---   ; intros ys zs h h'
---   ; cases ys with y ys
---   ; cases zs with z zs
---   ; try { cases h ; cases h' ; done },
+--  ; intros ys zs h h'
+--  ; cases ys with y ys
+--  ; cases zs with z zs
+--  ; try { cases h; cases h'; done },
 --   { apply list.le_refl },
 --   { simp [has_le.le,list.le],
 --     split,
@@ -152,10 +152,10 @@ example {x y z w : ℕ} : true := by
 --     (h : xs ≤ ys) :
 --     xs ++ zs ≤ ys ++ zs := by
 --   revert ys
---   induction xs with x xs ; intros ys h
---   · cases ys ; apply list.le_refl ; cases h
---   · cases ys with y ys ; cases h ; simp [has_le.le,list.le] at *
---     revert h ; apply and.imp_right
+--   induction xs with x xs; intros ys h
+--   · cases ys; apply list.le_refl; cases h
+--   · cases ys with y ys; cases h; simp [has_le.le,list.le] at *
+--     revert h; apply and.imp_right
 --     apply xs_ih
 
 -- @[mono]
@@ -163,18 +163,18 @@ example {x y z w : ℕ} : true := by
 --     (h : xs ≤ ys) :
 --     zs ++ xs ≤ zs ++ ys := by
 --   revert ys zs
---   induction xs with x xs ; intros ys zs h
+--   induction xs with x xs; intros ys zs h
 --   · cases ys
---     · simp ; apply list.le_refl
+--     · simp; apply list.le_refl
 --     · cases h
---   · cases ys with y ys ; cases h ; simp [has_le.le,list.le] at *
+--   · cases ys with y ys; cases h; simp [has_le.le,list.le] at *
 --     suffices : list.le' ((zs ++ [x]) ++ xs) ((zs ++ [y]) ++ ys)
---     · refine cast _ this ; simp
+--     · refine cast _ this; simp
 --     apply list.le_trans (zs ++ [y] ++ xs)
 --     · apply list_le_mono_left
 --       induction zs with z zs
---       · simp [has_le.le,list.le] ; apply h.left
---       · simp [has_le.le,list.le] ; split ; exact le_rfl
+--       · simp [has_le.le,list.le]; apply h.left
+--       · simp [has_le.le,list.le]; split; exact le_rfl
 --         apply zs_ih
 --     · apply xs_ih h.right
 
@@ -281,7 +281,7 @@ example {x y z w : ℕ} : true := by
 -- : (m + x + n) * z + k ≤ z * (y + n + m) + k :=
 -- begin
 --   ac_mono* : m + x + n ≤ y + n + m,
---   transitivity ; [ skip , apply h₁ ],
+--   transitivity; [ skip , apply h₁ ],
 --   apply le_of_eq,
 --   ac_refl,
 -- end
@@ -356,39 +356,39 @@ example {x y z w : ℕ} : true := by
 -- example {x y z w : ℕ} : true := by
 --   have : x * y ≤ z * w := by
 --     mono with [0 ≤ z,0 ≤ y]
---     · guard_target = 0 ≤ z ; admit
---     · guard_target = 0 ≤ y ; admit
---     guard_target' = x ≤ z ; admit
---     guard_target' = y ≤ w ; admit
+--     · guard_target = 0 ≤ z; admit
+--     · guard_target = 0 ≤ y; admit
+--     guard_target' = x ≤ z; admit
+--     guard_target' = y ≤ w; admit
 --   trivial
 
 -- example {x y z w : Prop} : true := by
 --   have : x ∧ y → z ∧ w := by
 --     mono
---     guard_target = x → z ; admit
---     guard_target = y → w ; admit
+--     guard_target = x → z; admit
+--     guard_target = y → w; admit
 --   trivial
 
 -- example {x y z w : Prop} : true := by
 --   have : x ∨ y → z ∨ w := by
 --     mono
---     guard_target = x → z ; admit
---     guard_target = y → w ; admit
+--     guard_target = x → z; admit
+--     guard_target = y → w; admit
 --   trivial
 
 -- example {x y z w : ℤ} : true := by
---   suffices : x + y < w + z ; trivial
---   have : x < w ; admit
---   have : y ≤ z ; admit
+--   suffices : x + y < w + z; trivial
+--   have : x < w; admit
+--   have : y ≤ z; admit
 --   mono right
 
 -- example {x y z w : ℤ} : true := by
---   suffices : x * y < w * z ; trivial
---   have : x < w ; admit
---   have : y ≤ z ; admit
+--   suffices : x * y < w * z; trivial
+--   have : x < w; admit
+--   have : y ≤ z; admit
 --   mono right
---   · guard_target = 0 < y ; admit
---   · guard_target = 0 ≤ w ; admit
+--   · guard_target = 0 < y; admit
+--   · guard_target = 0 ≤ w; admit
 
 -- example (x y : ℕ)
 --   (h : x ≤ y)

--- a/test/recover.lean
+++ b/test/recover.lean
@@ -14,7 +14,7 @@ example : 3 < 4 := by
     recover decide
 
 example : 1 = 1 := by
-    recover skip ; rfl
+    recover skip; rfl
 
 example : 2 = 2 := by
     recover skip


### PR DESCRIPTION
This is the second half of the changes originally in #5699, removing all occurrences of `;` _after_ a space and implementing a linter rule to enforce it.

In most cases this 2-character substring has a space after it, so the following command was run first:
```
find . -type f -name "*.lean" -exec sed -i -E 's/ ; /; /g' {} \;
```
The remaining cases were few enough in number that they were done manually.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
