### PR TITLE
[Merged by Bors] - fix(Tactic.NormNum.LegendreSymbol): not `a % 0` but `a % 2`

### DIFF
--- a/Mathlib/Tactic/NormNum/LegendreSymbol.lean
+++ b/Mathlib/Tactic/NormNum/LegendreSymbol.lean
@@ -346,7 +346,7 @@ partial def proveJacobiSymNat (ea eb : Q(ℕ)) : (er : Q(ℤ)) × Q(jacobiSymNat
         show (er : Q(ℤ)) × Q(jacobiSymNat 1 $eb = $er) from
           ⟨mkRawIntLit 1, q(jacobiSymNat.one_left $eb)⟩
       | a =>
-        match a % 0 with
+        match a % 2 with
         | 0 =>
           have hb₀ : Q(Nat.beq ($eb / 2) 0 = false) := (q(Eq.refl false) : Expr)
           have ha : Q(Nat.mod $ea 2 = 0) := (q(Eq.refl 0) : Expr)


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
