### PR TITLE
feat: a tactic to consume type annotations, and make constructor nicer

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2882,6 +2882,7 @@ import Mathlib.Tactic.Coe
 import Mathlib.Tactic.Common
 import Mathlib.Tactic.Congr!
 import Mathlib.Tactic.Constructor
+import Mathlib.Tactic.Consume
 import Mathlib.Tactic.Continuity
 import Mathlib.Tactic.Continuity.Init
 import Mathlib.Tactic.Contrapose

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -25,6 +25,7 @@ import Mathlib.Tactic.Clear_
 import Mathlib.Tactic.Coe
 import Mathlib.Tactic.Common
 import Mathlib.Tactic.Congr!
+import Mathlib.Tactic.Consume
 import Mathlib.Tactic.Constructor
 import Mathlib.Tactic.Continuity
 import Mathlib.Tactic.Continuity.Init

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -25,8 +25,8 @@ import Mathlib.Tactic.Clear_
 import Mathlib.Tactic.Coe
 import Mathlib.Tactic.Common
 import Mathlib.Tactic.Congr!
-import Mathlib.Tactic.Consume
 import Mathlib.Tactic.Constructor
+import Mathlib.Tactic.Consume
 import Mathlib.Tactic.Continuity
 import Mathlib.Tactic.Continuity.Init
 import Mathlib.Tactic.Contrapose

--- a/Mathlib/Tactic/Consume.lean
+++ b/Mathlib/Tactic/Consume.lean
@@ -17,6 +17,8 @@ to infer the argument from optional or auto parameters, and if this fails consum
 -/
 
 open Lean Elab Tactic
+/-- `consume` clears type annotations of the form `autoParam` and `optParam` by simply removing
+them, see `infer_param` to attempt to use them to fill in the goal instead.  -/
 elab "consume" : tactic => do
   withMainContext do
     let mvarIds ← getMainGoal

--- a/Mathlib/Tactic/Consume.lean
+++ b/Mathlib/Tactic/Consume.lean
@@ -1,0 +1,26 @@
+/-
+Copyright (c) 2023 Alex J. Best. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Alex J. Best
+-/
+import Lean
+import Mathlib.Tactic.InferParam
+
+/-!
+# Consume
+
+Introduces a tactic `consume` that consumes type annotations of the form `autoParam` and `optParam`.
+
+Also add a macro that makes constructor behave more like the `where ...` syntax, attempting
+to infer the argument from optional or auto parameters, and if this fails consumes the annotations.
+
+-/
+
+open Lean Elab Tactic
+elab "consume" : tactic => do
+  withMainContext do
+    let mvarIds ← getMainGoal
+    mvarIds.setType (← mvarIds.getType).consumeTypeAnnotations
+
+macro "constructor" : tactic =>
+  `(tactic| constructor <;> ((try infer_param) <;> consume))

--- a/test/consume.lean
+++ b/test/consume.lean
@@ -6,6 +6,6 @@ structure a where
 
 example : a := by
   constructor
-  guard_target = Nat
+  guard_target =ₛ Nat
   sorry
   done

--- a/test/consume.lean
+++ b/test/consume.lean
@@ -1,0 +1,11 @@
+import Mathlib.Tactic.Consume
+
+structure a where
+  l : Nat := by fail
+  k : Nat := by exact 2
+
+example : a := by
+  constructor
+  guard_target = Nat
+  sorry
+  done


### PR DESCRIPTION
During the copenhagen masterclass I found some situations where applying the constructor tactic left the goal in a difficult to read state when autoParams were present.

We add a simple tactic to clean these up, and a macro for `constructor` to behave more like the constructor notation and do this automatically (constructor is in core)

It seems that these things should be cleaned up by simp, but a simp lemma to remove these annotations is not accepted by lean as the types are too similar.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
