### PR TITLE
[Merged by Bors] - feat: for an open-positive measure, an open/closed subset is almost empty/full iff it is actually empty/full

### DIFF
--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Basic.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Basic.lean
@@ -843,7 +843,7 @@ theorem Continuous.isOpenPosMeasure_map {f : β → γ} (hf : Continuous f)
   exact (hUo.preimage hf).measure_ne_zero μ (hf_surj.nonempty_preimage.mpr hUne)
 #align continuous.is_open_pos_measure_map Continuous.isOpenPosMeasure_map
 
-theorem IsClosed.ae_univ_iff_eq {μ : Measure α} [μ.IsOpenPosMeasure]
+theorem IsClosed.ae_eq_univ_iff_eq {μ : Measure α} [μ.IsOpenPosMeasure]
     {F : Set α} (hF : IsClosed F) :
     F =ᵐ[μ] univ ↔ F = univ := by
   refine' ⟨fun h ↦ _, fun h ↦ by rw [h]⟩

--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Basic.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Basic.lean
@@ -843,6 +843,17 @@ theorem Continuous.isOpenPosMeasure_map {f : β → γ} (hf : Continuous f)
   exact (hUo.preimage hf).measure_ne_zero μ (hf_surj.nonempty_preimage.mpr hUne)
 #align continuous.is_open_pos_measure_map Continuous.isOpenPosMeasure_map
 
+theorem IsClosed.ae_univ_iff_eq {μ : Measure α} [μ.IsOpenPosMeasure]
+    {F : Set α} (hF : IsClosed F) :
+    F =ᵐ[μ] univ ↔ F = univ := by
+  refine' ⟨fun h ↦ _, fun h ↦ by rw [h]⟩
+  rwa [ae_eq_univ, hF.isOpen_compl.measure_eq_zero_iff μ, compl_empty_iff] at h
+
+theorem IsClosed.measure_eq_univ_iff_eq {μ : Measure α} [μ.IsOpenPosMeasure] [IsFiniteMeasure μ]
+    {F : Set α} (hF : IsClosed F) :
+    μ F = μ univ ↔ F = univ := by
+  rw [← ae_eq_univ_iff_measure_eq hF.measurableSet.nullMeasurableSet, hF.ae_univ_iff_eq]
+
 /-- If a function is defined piecewise in terms of functions which are continuous on their
 respective pieces, then it is measurable. -/
 theorem ContinuousOn.measurable_piecewise {f g : α → γ} {s : Set α} [∀ j : α, Decidable (j ∈ s)]

--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Basic.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Basic.lean
@@ -12,7 +12,6 @@ import Mathlib.Analysis.Normed.Group.Basic
 import Mathlib.MeasureTheory.Function.AEMeasurableSequence
 import Mathlib.MeasureTheory.Group.Arithmetic
 import Mathlib.MeasureTheory.Lattice
-import Mathlib.MeasureTheory.Measure.OpenPos
 import Mathlib.Topology.Algebra.Order.LiminfLimsup
 import Mathlib.Topology.ContinuousFunction.Basic
 import Mathlib.Topology.Instances.EReal
@@ -834,25 +833,6 @@ theorem Continuous.aemeasurable {f : α → γ} (h : Continuous f) {μ : Measure
 theorem ClosedEmbedding.measurable {f : α → γ} (hf : ClosedEmbedding f) : Measurable f :=
   hf.continuous.measurable
 #align closed_embedding.measurable ClosedEmbedding.measurable
-
-theorem Continuous.isOpenPosMeasure_map {f : β → γ} (hf : Continuous f)
-    (hf_surj : Function.Surjective f) {μ : Measure β} [μ.IsOpenPosMeasure] :
-    (Measure.map f μ).IsOpenPosMeasure := by
-  refine' ⟨fun U hUo hUne => _⟩
-  rw [Measure.map_apply hf.measurable hUo.measurableSet]
-  exact (hUo.preimage hf).measure_ne_zero μ (hf_surj.nonempty_preimage.mpr hUne)
-#align continuous.is_open_pos_measure_map Continuous.isOpenPosMeasure_map
-
-theorem IsClosed.ae_eq_univ_iff_eq {μ : Measure α} [μ.IsOpenPosMeasure]
-    {F : Set α} (hF : IsClosed F) :
-    F =ᵐ[μ] univ ↔ F = univ := by
-  refine' ⟨fun h ↦ _, fun h ↦ by rw [h]⟩
-  rwa [ae_eq_univ, hF.isOpen_compl.measure_eq_zero_iff μ, compl_empty_iff] at h
-
-theorem IsClosed.measure_eq_univ_iff_eq {μ : Measure α} [μ.IsOpenPosMeasure] [IsFiniteMeasure μ]
-    {F : Set α} (hF : IsClosed F) :
-    μ F = μ univ ↔ F = univ := by
-  rw [← ae_eq_univ_iff_measure_eq hF.measurableSet.nullMeasurableSet, hF.ae_eq_univ_iff_eq]
 
 /-- If a function is defined piecewise in terms of functions which are continuous on their
 respective pieces, then it is measurable. -/

--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Basic.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Basic.lean
@@ -852,7 +852,7 @@ theorem IsClosed.ae_eq_univ_iff_eq {μ : Measure α} [μ.IsOpenPosMeasure]
 theorem IsClosed.measure_eq_univ_iff_eq {μ : Measure α} [μ.IsOpenPosMeasure] [IsFiniteMeasure μ]
     {F : Set α} (hF : IsClosed F) :
     μ F = μ univ ↔ F = univ := by
-  rw [← ae_eq_univ_iff_measure_eq hF.measurableSet.nullMeasurableSet, hF.ae_univ_iff_eq]
+  rw [← ae_eq_univ_iff_measure_eq hF.measurableSet.nullMeasurableSet, hF.ae_eq_univ_iff_eq]
 
 /-- If a function is defined piecewise in terms of functions which are continuous on their
 respective pieces, then it is measurable. -/

--- a/Mathlib/MeasureTheory/Function/LpSpace.lean
+++ b/Mathlib/MeasureTheory/Function/LpSpace.lean
@@ -10,6 +10,7 @@ Authors: Rémy Degenne, Sébastien Gouëzel
 -/
 import Mathlib.Analysis.Normed.Group.Hom
 import Mathlib.MeasureTheory.Function.LpSeminorm
+import Mathlib.MeasureTheory.Measure.OpenPos
 import Mathlib.Topology.ContinuousFunction.Compact
 
 /-!

--- a/Mathlib/MeasureTheory/Measure/OpenPos.lean
+++ b/Mathlib/MeasureTheory/Measure/OpenPos.lean
@@ -90,7 +90,7 @@ theorem _root_.IsOpen.ae_eq_empty_iff_eq (hU : IsOpen U) :
   rw [ae_eq_empty, hU.measure_zero_iff_eq_empty]
 
 theorem _root_.IsOpen.eq_empty_of_measure_zero (hU : IsOpen U) (h₀ : μ U = 0) : U = ∅ :=
-  hU.measure_zero_iff_eq_empty.mp h₀
+  (hU.measure_eq_zero_iff μ).mp h₀
 #align is_open.eq_empty_of_measure_zero IsOpen.eq_empty_of_measure_zero
 
 theorem _root_.IsClosed.ae_eq_univ_iff_eq (hF : IsClosed F) :

--- a/Mathlib/MeasureTheory/Measure/OpenPos.lean
+++ b/Mathlib/MeasureTheory/Measure/OpenPos.lean
@@ -103,6 +103,11 @@ theorem _root_.IsClosed.measure_eq_univ_iff_eq [OpensMeasurableSpace X] [IsFinit
     μ F = μ univ ↔ F = univ := by
   rw [← ae_eq_univ_iff_measure_eq hF.measurableSet.nullMeasurableSet, hF.ae_eq_univ_iff_eq]
 
+theorem _root_.IsClosed.measure_eq_one_iff_eq_univ [OpensMeasurableSpace X] [IsProbabilityMeasure μ]
+    (hF : IsClosed F) :
+    μ F = 1 ↔ F = univ := by
+  rw [← measure_univ (μ := μ), hF.measure_eq_univ_iff_eq]
+
 theorem interior_eq_empty_of_null (hs : μ s = 0) : interior s = ∅ :=
   isOpen_interior.eq_empty_of_measure_zero <| measure_mono_null interior_subset hs
 #align measure_theory.measure.interior_eq_empty_of_null MeasureTheory.Measure.interior_eq_empty_of_null

--- a/Mathlib/MeasureTheory/Measure/OpenPos.lean
+++ b/Mathlib/MeasureTheory/Measure/OpenPos.lean
@@ -9,6 +9,7 @@ Authors: Yury Kudryashov
 ! if you have ported upstream changes.
 -/
 import Mathlib.MeasureTheory.Measure.MeasureSpace
+import Mathlib.MeasureTheory.Constructions.BorelSpace.Basic
 
 /-!
 # Measures positive on nonempty opens
@@ -39,7 +40,7 @@ class IsOpenPosMeasure : Prop where
   open_pos : ∀ U : Set X, IsOpen U → U.Nonempty → μ U ≠ 0
 #align measure_theory.measure.is_open_pos_measure MeasureTheory.Measure.IsOpenPosMeasure
 
-variable [IsOpenPosMeasure μ] {s U : Set X} {x : X}
+variable [IsOpenPosMeasure μ] {s U F : Set X} {x : X}
 
 theorem _root_.IsOpen.measure_ne_zero (hU : IsOpen U) (hne : U.Nonempty) : μ U ≠ 0 :=
   IsOpenPosMeasure.open_pos U hU hne
@@ -80,9 +81,27 @@ theorem _root_.LE.le.isOpenPosMeasure (h : μ ≤ ν) : IsOpenPosMeasure ν :=
   h.absolutelyContinuous.isOpenPosMeasure
 #align has_le.le.is_open_pos_measure LE.le.isOpenPosMeasure
 
+theorem _root_.IsOpen.measure_zero_iff_eq_empty (hU : IsOpen U) :
+    μ U = 0 ↔ U = ∅ :=
+  ⟨fun h ↦ (hU.measure_eq_zero_iff μ).mp h, fun h ↦ by simp [h]⟩
+
+theorem _root_.IsOpen.ae_eq_empty_iff_eq (hU : IsOpen U) :
+    U =ᵐ[μ] (∅ : Set X) ↔ U = ∅ := by
+  rw [ae_eq_empty, hU.measure_zero_iff_eq_empty]
+
 theorem _root_.IsOpen.eq_empty_of_measure_zero (hU : IsOpen U) (h₀ : μ U = 0) : U = ∅ :=
-  (hU.measure_eq_zero_iff μ).mp h₀
+  hU.measure_zero_iff_eq_empty.mp h₀
 #align is_open.eq_empty_of_measure_zero IsOpen.eq_empty_of_measure_zero
+
+theorem _root_.IsClosed.ae_eq_univ_iff_eq (hF : IsClosed F) :
+    F =ᵐ[μ] univ ↔ F = univ := by
+  refine' ⟨fun h ↦ _, fun h ↦ by rw [h]⟩
+  rwa [ae_eq_univ, hF.isOpen_compl.measure_eq_zero_iff μ, compl_empty_iff] at h
+
+theorem _root_.IsClosed.measure_eq_univ_iff_eq [OpensMeasurableSpace X] [IsFiniteMeasure μ]
+    (hF : IsClosed F) :
+    μ F = μ univ ↔ F = univ := by
+  rw [← ae_eq_univ_iff_measure_eq hF.measurableSet.nullMeasurableSet, hF.ae_eq_univ_iff_eq]
 
 theorem interior_eq_empty_of_null (hs : μ s = 0) : interior s = ∅ :=
   isOpen_interior.eq_empty_of_measure_zero <| measure_mono_null interior_subset hs
@@ -124,6 +143,17 @@ theorem _root_.Continuous.ae_eq_iff_eq {f g : X → Y} (hf : Continuous f) (hg :
     f =ᵐ[μ] g ↔ f = g :=
   ⟨fun h => eq_of_ae_eq h hf hg, fun h => h ▸ EventuallyEq.rfl⟩
 #align continuous.ae_eq_iff_eq Continuous.ae_eq_iff_eq
+
+variable {μ}
+
+theorem _root_.Continuous.isOpenPosMeasure_map [OpensMeasurableSpace X]
+    {Z : Type _} [TopologicalSpace Z] [MeasurableSpace Z] [BorelSpace Z]
+    {f : X → Z} (hf : Continuous f) (hf_surj : Function.Surjective f) :
+    (Measure.map f μ).IsOpenPosMeasure := by
+  refine' ⟨fun U hUo hUne => _⟩
+  rw [Measure.map_apply hf.measurable hUo.measurableSet]
+  exact (hUo.preimage hf).measure_ne_zero μ (hf_surj.nonempty_preimage.mpr hUne)
+#align continuous.is_open_pos_measure_map Continuous.isOpenPosMeasure_map
 
 end Basic
 


### PR DESCRIPTION
Also invert the import order so that `MeasureTheory.Measure.OpenPos` imports `MeasureTheory.Constructions.BorelSpace.Basic` rather than the other way around.

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
