### PR TITLE
fix: recover smul notation in `Analysis.Complex.UpperHalfPlane.Basic`

### DIFF
--- a/Mathlib/Analysis/Complex/UpperHalfPlane/Basic.lean
+++ b/Mathlib/Analysis/Complex/UpperHalfPlane/Basic.lean
@@ -272,7 +272,7 @@ instance SLAction {R : Type _} [CommRing R] [Algebra R ℝ] : MulAction SL(2, R)
 
 instance : Coe SL(2, ℤ) GL(2, ℝ)⁺ := ⟨coeSLZToGLPos⟩
 
-@[simp] lemma coe_SLZ_GLPos (g : SL(2, ℤ)) : ((g : SL(2, ℝ)) : GL(2, ℝ)⁺) = g := rfl
+@[simp] lemma coe_SLR_coe_GLPos (g : SL(2, ℤ)) : g = ((g : SL(2, ℝ)) : GL(2, ℝ)⁺) := rfl
 
 instance SLOnGLPos : SMul SL(2, ℤ) GL(2, ℝ)⁺ :=
   ⟨fun s g => s * g⟩
@@ -384,7 +384,7 @@ theorem subgroup_to_sl_moeb (A : Γ) (z : ℍ) : A • z = (A : SL(2, ℤ)) • 
 #align upper_half_plane.subgroup_to_sl_moeb UpperHalfPlane.subgroup_to_sl_moeb
 
 @[simp] lemma neg_coe_SLZ_GLPos (g : SL(2, ℤ)) : (-g : SL(2, ℤ)) = (-g : GL(2, ℝ)⁺) := by
-  rw [← coe_SLZ_GLPos, coe_int_neg, coe_GLPos_neg, coe_SLZ_GLPos]
+  rw [coe_SLR_coe_GLPos, coe_int_neg, coe_GLPos_neg, coe_SLR_coe_GLPos]
 
 @[simp]
 theorem SL_neg_smul (g : SL(2, ℤ)) (z : ℍ) : -g • z = g • z := by
@@ -403,17 +403,13 @@ theorem c_mul_im_sq_le_normSq_denom (z : ℍ) (g : SL(2, ℝ)) :
 nonrec theorem SpecialLinearGroup.im_smul_eq_div_normSq :
     (g • z).im = z.im / Complex.normSq (denom g z) := by
   convert im_smul_eq_div_normSq g z
-  -- Porting note: needed to rw with this coercion lemma
-  rw [← coe_SLZ_GLPos]
-  simp only [GeneralLinearGroup.det_apply_val, coe_GLPos_coe_GL_coe_matrix,
+  simp only [coe_SLR_coe_GLPos, GeneralLinearGroup.det_apply_val, coe_GLPos_coe_GL_coe_matrix,
     Int.coe_castRingHom, (g : SL(2, ℝ)).prop, one_mul]
 #align upper_half_plane.special_linear_group.im_smul_eq_div_norm_sq UpperHalfPlane.SpecialLinearGroup.im_smul_eq_div_normSq
 
 theorem denom_apply (g : SL(2, ℤ)) (z : ℍ) :
     denom g z = (g : Matrix (Fin 2) (Fin 2) ℤ) 1 0 * z + (g : Matrix (Fin 2) (Fin 2) ℤ) 1 1 := by
-  -- Porting note: needed this coercion lemma
-  rw [← coe_SLZ_GLPos]
-  simp [-coe_SLZ_GLPos, denom]
+  simp [denom]
 #align upper_half_plane.denom_apply UpperHalfPlane.denom_apply
 
 end SLModularAction

--- a/Mathlib/NumberTheory/Modular.lean
+++ b/Mathlib/NumberTheory/Modular.lean
@@ -248,8 +248,7 @@ theorem smul_eq_lcRow0_add {p : Fin 2 → ℤ} (hp : IsCoprime (p 0) (p 1)) (hg 
   have nonZ1 : (p 0 : ℂ) ^ 2 + (p 1 : ℂ) ^ 2 ≠ 0 := by exact_mod_cast hp.sq_add_sq_ne_zero
   have : ((↑) : ℤ → ℝ) ∘ p ≠ 0 := fun h => hp.ne_zero (by ext i; simpa using congr_fun h i)
   have nonZ2 : (p 0 : ℂ) * z + p 1 ≠ 0 := by simpa using linear_ne_zero _ z this
-  -- Porting note: `SMul.smul, smulAux, smulAux'` are required to unfold `SMul.smul` in `sl_moeb`.
-  field_simp [nonZ1, nonZ2, denom_ne_zero, SMul.smul, smulAux, smulAux', num]
+  field_simp [nonZ1, nonZ2, denom_ne_zero, num]
   rw [(by simp :
     (p 1 : ℂ) * z - p 0 = (p 1 * z - p 0) * ↑(Matrix.det (↑g : Matrix (Fin 2) (Fin 2) ℤ)))]
   rw [← hg, det_fin_two]
@@ -322,8 +321,6 @@ theorem exists_row_one_eq_and_min_re {cd : Fin 2 → ℤ} (hcd : IsCoprime (cd 0
 #align modular_group.exists_row_one_eq_and_min_re ModularGroup.exists_row_one_eq_and_min_re
 
 theorem coe_T_zpow_smul_eq {n : ℤ} : (↑(T ^ n • z) : ℂ) = z + n := by
-  -- Porting note: This line is required due to `SMul.smul` in `sl_moeb`.
-  erw [sl_moeb, UpperHalfPlane.coe_smul]
   simp [coe_T_zpow, denom, num, -map_zpow]
 #align modular_group.coe_T_zpow_smul_eq ModularGroup.coe_T_zpow_smul_eq
 
@@ -380,8 +377,7 @@ theorem g_eq_of_c_eq_one (hc : (↑ₘg) 1 0 = 1) : g = T ^ (↑ₘg) 0 0 * S * 
 set_option maxHeartbeats 250000 in
 /-- If `1 < |z|`, then `|S • z| < 1`. -/
 theorem normSq_S_smul_lt_one (h : 1 < normSq z) : normSq ↑(S • z) < 1 := by
-  -- Porting note: `SMul.smul, smulAux, smulAux'` are required to unfold `SMul.smul` in `sl_moeb`.
-  simpa [coe_S, SMul.smul, smulAux, smulAux', num, denom]
+  simpa [coe_S, num, denom]
     using (inv_lt_inv z.normSq_pos zero_lt_one).mpr h
 #align modular_group.norm_sq_S_smul_lt_one ModularGroup.normSq_S_smul_lt_one
 
@@ -431,8 +427,7 @@ theorem one_lt_normSq_T_zpow_smul (hz : z ∈ 𝒟ᵒ) (n : ℤ) : 1 < normSq (T
   have hz₁ : 1 < z.re * z.re + z.im * z.im := hz.1
   have hzn := Int.nneg_mul_add_sq_of_abs_le_one n (abs_two_mul_re_lt_one_of_mem_fdo hz).le
   have : 1 < (z.re + ↑n) * (z.re + ↑n) + z.im * z.im := by linarith
-  -- Porting note: `SMul.smul, smulAux, smulAux'` are required to unfold `SMul.smul` in `sl_moeb`.
-  simpa [coe_T_zpow, normSq, SMul.smul, smulAux, smulAux', num, denom, -map_zpow]
+  simpa [coe_T_zpow, normSq, num, denom, -map_zpow]
 #align modular_group.one_lt_norm_sq_T_zpow_smul ModularGroup.one_lt_normSq_T_zpow_smul
 
 theorem eq_zero_of_mem_fdo_of_T_zpow_mem_fdo {n : ℤ} (hz : z ∈ 𝒟ᵒ) (hg : T ^ n • z ∈ 𝒟ᵒ) :


### PR DESCRIPTION
Giving the `Coe SL(2, ℤ) GL(2, ℝ)⁺` instance an auxiliary definition lets `SMul.smul ((s : GL(2, ℝ)⁺) * g) z` be written as `(s * g) • z`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
