### PR TITLE
[Merged by Bors] - feat: forward-port leanprover-community/mathlib#19105

### DIFF
--- a/Mathlib/Algebra/Homology/LocalCohomology.lean
+++ b/Mathlib/Algebra/Homology/LocalCohomology.lean
@@ -238,16 +238,16 @@ radical containing `J`. This uses noetherianness. -/
 instance ideal_powers_initial [hR : IsNoetherian R R] :
     Functor.Initial (idealPowersToSelfLERadical J) where
   out J' := by
-    { apply (config := {allowSynthFailures := true }) zigzag_isConnected
-      · obtain ⟨k, hk⟩ := Ideal.exists_pow_le_of_le_radical_of_fG J'.2 (isNoetherian_def.mp hR _)
-        exact ⟨CostructuredArrow.mk (⟨⟨hk⟩⟩ : (idealPowersToSelfLERadical J).obj (op k) ⟶ J')⟩
-      · intro j1 j2
-        apply Relation.ReflTransGen.single
-        -- The inclusions `J^n1 ≤ J'` and `J^n2 ≤ J'` always form a triangle, based on
-        -- which exponent is larger.
-        cases' le_total (unop j1.left) (unop j2.left) with h h
-        right; exact ⟨CostructuredArrow.homMk (homOfLE h).op (AsTrue.get trivial)⟩
-        left; exact ⟨CostructuredArrow.homMk (homOfLE h).op (AsTrue.get trivial)⟩ }
+    apply (config := {allowSynthFailures := true }) zigzag_isConnected
+    · obtain ⟨k, hk⟩ := Ideal.exists_pow_le_of_le_radical_of_fG J'.2 (isNoetherian_def.mp hR _)
+      exact ⟨CostructuredArrow.mk (⟨⟨hk⟩⟩ : (idealPowersToSelfLERadical J).obj (op k) ⟶ J')⟩
+    · intro j1 j2
+      apply Relation.ReflTransGen.single
+      -- The inclusions `J^n1 ≤ J'` and `J^n2 ≤ J'` always form a triangle, based on
+      -- which exponent is larger.
+      cases' le_total (unop j1.left) (unop j2.left) with h h
+      right; exact ⟨CostructuredArrow.homMk (homOfLE h).op (AsTrue.get trivial)⟩
+      left; exact ⟨CostructuredArrow.homMk (homOfLE h).op (AsTrue.get trivial)⟩
 #align local_cohomology.ideal_powers_initial localCohomology.ideal_powers_initial
 
 -- FIXME again, this instance is not found by `inferInstance`, but `#synth` finds it just fine.

--- a/Mathlib/Algebra/Homology/LocalCohomology.lean
+++ b/Mathlib/Algebra/Homology/LocalCohomology.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Emily Witt, Scott Morrison, Jake Levinson, Sam van Gool
 
 ! This file was ported from Lean 3 source module algebra.homology.local_cohomology
-! leanprover-community/mathlib commit 5a684ce82399d820475609907c6ef8dba5b1b97c
+! leanprover-community/mathlib commit 893964fc28cefbcffc7cb784ed00a2895b4e65cf
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.
 -/
@@ -13,6 +13,9 @@ import Mathlib.Algebra.Category.ModuleCat.Colimits
 import Mathlib.Algebra.Category.ModuleCat.Projective
 import Mathlib.CategoryTheory.Abelian.Ext
 import Mathlib.RingTheory.Finiteness
+import Mathlib.CategoryTheory.Limits.Final
+import Mathlib.RingTheory.Noetherian
+
 
 /-!
 # Local cohomology.
@@ -44,7 +47,6 @@ local cohomology, local cohomology modules
     * the right-derived functor definition
     * the characterization as the limit of Koszul homology
     * the characterization as the cohomology of a Cech-like complex
-* Prove that local cohomology depends only on the radical of the ideal
 * Establish long exact sequence(s) in local cohomology
 -/
 
@@ -57,7 +59,7 @@ open CategoryTheory.Limits
 
 noncomputable section
 
-universe u v
+universe u v v'
 
 namespace localCohomology
 
@@ -75,11 +77,11 @@ def ringModIdeals (I : D ⥤ Ideal R) : D ⥤ ModuleCat.{u} R where
   map_comp f g := by apply Submodule.linearMap_qext; rfl
 #align local_cohomology.ring_mod_ideals localCohomology.ringModIdeals
 
--- Porting note: TODO:  Once this file is ported, move this instance to the right location.
-instance moduleCat_enoughProjectives' : EnoughProjectives (ModuleCat.{u} R) :=
+-- TODO:  Once this file is ported, move this file to the right location.
+instance moduleCat_enough_projectives' : EnoughProjectives (ModuleCat.{u} R) :=
   ModuleCat.moduleCat_enoughProjectives.{u}
 set_option linter.uppercaseLean3 false in
-#align local_cohomology.Module_enough_projectives' localCohomology.moduleCat_enoughProjectives'
+#align local_cohomology.Module_enough_projectives' localCohomology.moduleCat_enough_projectives'
 
 /-- The diagram we will take the colimit of to define local cohomology, corresponding to the
 directed system determined by the functor `I` -/
@@ -99,17 +101,36 @@ variable {R : Type max u v} [CommRing R] {D : Type v} [SmallCategory D]
 In this definition we do not assume any special property of the diagram `I`, but the relevant case
 will be where `I` is (cofinal with) the diagram of powers of a single given ideal.
 
-Below, we give two equivalent (to be shown) definitions of the usual local cohomology with support
-in an ideal `J`, `localCohomology` and `localCohomology.ofSelfLERadical`.
-
-TODO: Show that any functor cofinal with `I` gives the same result.
+Below, we give two equivalent definitions of the usual local cohomology with support
+in an ideal `J`, `local_cohomology` and `local_cohomology.of_self_le_radical`.
  -/
-/-- `localCohomology.ofDiagram I i` is the functor sending a module `M` over a commutative
+/-- `local_cohomology.of_diagram I i` is the functor sending a module `M` over a commutative
 ring `R` to the direct limit of `Ext^i(R/J, M)`, where `J` ranges over a collection of ideals
 of `R`, represented as a functor `I`. -/
 def ofDiagram (I : D ⥤ Ideal R) (i : ℕ) : ModuleCat.{max u v} R ⥤ ModuleCat.{max u v} R :=
   colimit (diagram.{max u v, v} I i)
 #align local_cohomology.of_diagram localCohomology.ofDiagram
+
+end
+
+section
+
+variable {R : Type max u v v'} [CommRing R] {D : Type v} [SmallCategory D]
+
+variable {E : Type v'} [SmallCategory E] (I' : E ⥤ D) (I : D ⥤ Ideal R)
+
+set_option maxHeartbeats 400000 in
+/-- Local cohomology along a composition of diagrams. -/
+def diagramComp (i : ℕ) : diagram (I' ⋙ I) i ≅ I'.op ⋙ diagram I i :=
+  Iso.refl _
+#align local_cohomology.diagram_comp localCohomology.diagramComp
+
+set_option pp.universes true in
+/-- Local cohomology agrees along precomposition with a cofinal diagram. -/
+def isoOfFinal [Functor.Initial I'] (i : ℕ) :
+    ofDiagram.{max u v, v'} (I' ⋙ I) i ≅ ofDiagram.{max u v', v} I i :=
+  HasColimit.isoOfNatIso (diagramComp.{u} _ _ _) ≪≫ Functor.Final.colimitIso _ _
+#align local_cohomology.iso_of_final localCohomology.isoOfFinal
 
 end
 
@@ -124,25 +145,25 @@ def idealPowersDiagram (J : Ideal R) : ℕᵒᵖ ⥤ Ideal R where
 #align local_cohomology.ideal_powers_diagram localCohomology.idealPowersDiagram
 
 /-- The full subcategory of all ideals with radical containing `J` -/
-def SelfLERadical (J : Ideal R) : Type u :=
+def SelfLeRadical (J : Ideal R) : Type u :=
   FullSubcategory fun J' : Ideal R => J ≤ J'.radical
 --deriving Category
 
 -- Porting note: `deriving Category` is not able to derive this instance
-instance (J : Ideal R) : Category (SelfLERadical J) :=
+instance (J : Ideal R) : Category (SelfLeRadical J) :=
   (FullSubcategory.category _)
 
-#align local_cohomology.self_le_radical localCohomology.SelfLERadical
+#align local_cohomology.self_le_radical localCohomology.SelfLeRadical
 
-instance SelfLERadical.inhabited (J : Ideal R) : Inhabited (SelfLERadical J)
+instance SelfLeRadical.inhabited (J : Ideal R) : Inhabited (SelfLeRadical J)
     where default := ⟨J, Ideal.le_radical⟩
-#align local_cohomology.self_le_radical.inhabited localCohomology.SelfLERadical.inhabited
+#align local_cohomology.self_le_radical.inhabited localCohomology.SelfLeRadical.inhabited
 
 /-- The diagram of all ideals with radical containing `J`, represented as a functor.
 This is the "largest" diagram that computes local cohomology with support in `J`. -/
-def selfLERadicalDiagram (J : Ideal R) : SelfLERadical J ⥤ Ideal R :=
+def selfLeRadicalDiagram (J : Ideal R) : SelfLeRadical J ⥤ Ideal R :=
   fullSubcategoryInclusion _
-#align local_cohomology.self_le_radical_diagram localCohomology.selfLERadicalDiagram
+#align local_cohomology.self_le_radical_diagram localCohomology.selfLeRadicalDiagram
 
 end Diagrams
 
@@ -150,7 +171,7 @@ end localCohomology
 
 /-! We give two models for the local cohomology with support in an ideal `J`: first in terms of
 the powers of `J` (`local_cohomology`), then in terms of *all* ideals with radical
-containing `J` (`local_cohomology.ofSelfLERadical`). -/
+containing `J` (`local_cohomology.of_self_le_radical`). -/
 
 
 section ModelsForLocalCohomology
@@ -159,7 +180,7 @@ open localCohomology
 
 variable {R : Type u} [CommRing R]
 
-/-- `localCohomology J i` is `i`-th the local cohomology module of a module `M` over
+/-- `local_cohomology J i` is `i`-th the local cohomology module of a module `M` over
 a commutative ring `R` with support in the ideal `J` of `R`, defined as the direct limit
 of `Ext^i(R/J^t, M)` over all powers `t : ℕ`. -/
 def localCohomology (J : Ideal R) (i : ℕ) : ModuleCat.{u} R ⥤ ModuleCat.{u} R :=
@@ -168,48 +189,111 @@ def localCohomology (J : Ideal R) (i : ℕ) : ModuleCat.{u} R ⥤ ModuleCat.{u} 
 
 /-- Local cohomology as the direct limit of `Ext^i(R/J', M)` over *all* ideals `J'` with radical
 containing `J`. -/
-def localCohomology.ofSelfLERadical (J : Ideal R) (i : ℕ) : ModuleCat.{u} R ⥤ ModuleCat.{u} R :=
-  ofDiagram.{u} (selfLERadicalDiagram.{u} J) i
-#align local_cohomology.of_self_le_radical localCohomology.ofSelfLERadical
+def localCohomology.ofSelfLeRadical (J : Ideal R) (i : ℕ) : ModuleCat.{u} R ⥤ ModuleCat.{u} R :=
+  ofDiagram.{u} (selfLeRadicalDiagram.{u} J) i
+#align local_cohomology.of_self_le_radical localCohomology.ofSelfLeRadical
 
-/- TODO: Construct `localCohomology J i ≅ localCohomology.ofSelfLERadical J i`. Use this to
-show that local cohomology depends only on `J.radical`. -/
 end ModelsForLocalCohomology
+
+namespace localCohomology
+
+/-!
+Showing equivalence of different definitions of local cohomology.
+  * `localCohomology.isoSelfLeRadical` gives the isomorphism
+      `localCohomology J i ≅ localCohomology.ofSelfLeRadical J i`
+  * `localCohomology.isoOfSameRadical` gives the isomorphism
+      `localCohomology J i ≅ localCohomology K i` when `J.radical = K.radical`.
+-/
 
 section LocalCohomologyEquiv
 
-open localCohomology
+variable {R : Type u} [CommRing R]
 
-variable {R : Type u} [CommRing R] (I J : Ideal R)
-
-/-- Lifting `idealPowersDiagram J` from a diagram valued in `ideals R` to a diagram
-valued in `SelfLERadical J`. -/
-def localCohomology.idealPowersToSelfLERadical (J : Ideal R) : ℕᵒᵖ ⥤ SelfLERadical J :=
+/-- Lifting `ideal_powers_diagram J` from a diagram valued in `ideals R` to a diagram
+valued in `self_le_radical J`. -/
+def idealPowersToSelfLeRadical (J : Ideal R) : ℕᵒᵖ ⥤ SelfLeRadical J :=
   FullSubcategory.lift _ (idealPowersDiagram J) fun k => by
     change _ ≤ (J ^ unop k).radical
     cases' unop k with n
     · simp [Ideal.radical_top, pow_zero, Ideal.one_eq_top, le_top, Nat.zero_eq]
     · simp only [J.radical_pow _ n.succ_pos, Ideal.le_radical]
-#align local_cohomology.ideal_powers_to_self_le_radical localCohomology.idealPowersToSelfLERadical
+#align local_cohomology.ideal_powers_to_self_le_radical localCohomology.idealPowersToSelfLeRadical
 
-/-- The composition with the inclusion into `ideals R` is isomorphic to `idealPowersDiagram J`. -/
-def localCohomology.idealPowersToSelfLERadicalCompInclusion (J : Ideal R) :
-    localCohomology.idealPowersToSelfLERadical J ⋙ selfLERadicalDiagram J ≅ idealPowersDiagram J :=
-  FullSubcategory.lift_comp_inclusion _ _ _
-#align local_cohomology.ideal_powers_to_self_le_radical_comp_inclusion localCohomology.idealPowersToSelfLERadicalCompInclusion
+variable {I J K : Ideal R}
 
-/-- The lemma below essentially says that `idealPowersToSelfLERadical I` is initial in
-`selfLERadicalDiagram I`.
+/-- The lemma below essentially says that `ideal_powers_to_self_le_radical I` is initial in
+`self_le_radical_diagram I`.
 
-Porting note: This lemma should probably be moved to `Mathlib/RingTheory/Finiteness.lean`
-to be near `Ideal.exists_radical_pow_le_of_fg`, which it generalizes. -/
-theorem Ideal.exists_pow_le_of_le_radical_of_fg (hIJ : I ≤ J.radical) (hJ : J.radical.FG) :
+PORTING NOTE: This lemma should probably be moved to `ring_theory/finiteness.lean`
+to be near `ideal.exists_radical_pow_le_of_fg`, which it generalizes. -/
+theorem Ideal.exists_pow_le_of_le_radical_of_fG (hIJ : I ≤ J.radical) (hJ : J.radical.FG) :
     ∃ k : ℕ, I ^ k ≤ J := by
   obtain ⟨k, hk⟩ := J.exists_radical_pow_le_of_fg hJ
   use k
   calc
     I ^ k ≤ J.radical ^ k := Ideal.pow_mono hIJ _
     _ ≤ J := hk
-#align ideal.exists_pow_le_of_le_radical_of_fg Ideal.exists_pow_le_of_le_radical_of_fg
+
+#align local_cohomology.ideal.exists_pow_le_of_le_radical_of_fg localCohomology.Ideal.exists_pow_le_of_le_radical_of_fG
+#check zigzag_isConnected
+/-- The diagram of powers of `J` is initial in the diagram of all ideals with
+radical containing `J`. This uses noetherianness. -/
+instance ideal_powers_initial [hR : IsNoetherian R R] : Functor.Initial (idealPowersToSelfLeRadical J)
+    where out J' := by
+    { apply @zigzag_isConnected _ _ _
+      . intro j1 j2
+        apply Relation.ReflTransGen.single
+        -- The inclusions `J^n1 ≤ J'` and `J^n2 ≤ J'` always form a triangle, based on
+        -- which exponent is larger.
+        cases' le_total (unop j1.left) (unop j2.left) with h h
+        right; exact ⟨CostructuredArrow.homMk (homOfLE h).op (AsTrue.get trivial)⟩
+        left; exact ⟨CostructuredArrow.homMk (homOfLE h).op (AsTrue.get trivial)⟩
+      . obtain ⟨k, hk⟩ := Ideal.exists_pow_le_of_le_radical_of_fG J'.2 (isNoetherian_def.mp hR _)
+        exact ⟨CostructuredArrow.mk (⟨⟨hk⟩⟩ : (idealPowersToSelfLeRadical J).obj (op k) ⟶ J')⟩
+    }
+#align local_cohomology.ideal_powers_initial localCohomology.ideal_powers_initial
+
+set_option pp.universes true in
+/-- Local cohomology (defined in terms of powers of `J`) agrees with local
+cohomology computed over all ideals with radical containing `J`. -/
+def isoSelfLeRadical (J : Ideal.{u} R) [IsNoetherian.{u,u} R R] (i : ℕ) :
+    localCohomology.ofSelfLeRadical.{u} J i ≅ localCohomology.{u} J i :=
+  (localCohomology.isoOfFinal.{u, u, 0} (idealPowersToSelfLeRadical.{u} J) (selfLeRadicalDiagram.{u} J)
+        i).symm ≪≫
+    HasColimit.isoOfNatIso.{0,0,u+1,u+1} (Iso.refl.{u+1,u+1} _)
+#align local_cohomology.iso_self_le_radical localCohomology.isoSelfLeRadical
+
+/-- Casting from the full subcategory of ideals with radical containing `J` to the full
+subcategory of ideals with radical containing `K`. -/
+def SelfLeRadical.cast (hJK : J.radical = K.radical) : SelfLeRadical J ⥤ SelfLeRadical K :=
+  FullSubcategory.map fun L hL =>
+    by
+    rw [← Ideal.radical_le_radical_iff] at hL ⊢
+    exact hJK.symm.trans_le hL
+#align local_cohomology.self_le_radical.cast localCohomology.SelfLeRadical.cast
+
+-- TODO generalize this to the equivalence of full categories for any `iff`.
+instance SelfLeRadical.castIsEquivalence (hJK : J.radical = K.radical) :
+    IsEquivalence (SelfLeRadical.cast hJK)
+    where
+  inverse := SelfLeRadical.cast hJK.symm
+  unitIso := by sorry -- was "by tidy"
+  counitIso := by sorry -- was "by tidy"
+#align local_cohomology.self_le_radical.cast_is_equivalence localCohomology.SelfLeRadical.castIsEquivalence
+
+/-- The natural isomorphism between local cohomology defined using the `of_self_le_radical`
+diagram, assuming `J.radical = K.radical`. -/
+def SelfLeRadical.isoOfSameRadical (hJK : J.radical = K.radical) (i : ℕ) :
+    ofSelfLeRadical J i ≅ ofSelfLeRadical K i :=
+  (isoOfFinal.{u, u, u} (SelfLeRadical.cast hJK.symm) _ _).symm
+#align local_cohomology.self_le_radical.iso_of_same_radical localCohomology.SelfLeRadical.isoOfSameRadical
+
+/-- Local cohomology agrees on ideals with the same radical. -/
+def isoOfSameRadical [IsNoetherian R R] (hJK : J.radical = K.radical) (i : ℕ) :
+    localCohomology J i ≅ localCohomology K i :=
+  (isoSelfLeRadical J i).symm ≪≫ SelfLeRadical.isoOfSameRadical hJK i ≪≫ isoSelfLeRadical K i
+#align local_cohomology.iso_of_same_radical localCohomology.isoOfSameRadical
 
 end LocalCohomologyEquiv
+
+end localCohomology

--- a/Mathlib/Algebra/Homology/LocalCohomology.lean
+++ b/Mathlib/Algebra/Homology/LocalCohomology.lean
@@ -171,7 +171,7 @@ end localCohomology
 
 /-! We give two models for the local cohomology with support in an ideal `J`: first in terms of
 the powers of `J` (`localCohomology`), then in terms of *all* ideals with radical
-containing `J` (`localCohomology.of_self_le_radical`). -/
+containing `J` (`localCohomology.ofSelfLERadical`). -/
 
 
 section ModelsForLocalCohomology
@@ -209,8 +209,8 @@ section LocalCohomologyEquiv
 
 variable {R : Type u} [CommRing R]
 
-/-- Lifting `ideal_powers_diagram J` from a diagram valued in `ideals R` to a diagram
-valued in `self_le_radical J`. -/
+/-- Lifting `idealPowersDiagram J` from a diagram valued in `ideals R` to a diagram
+valued in `SelfLERadical J`. -/
 def idealPowersToSelfLERadical (J : Ideal R) : ℕᵒᵖ ⥤ SelfLERadical J :=
   FullSubcategory.lift _ (idealPowersDiagram J) fun k => by
     change _ ≤ (J ^ unop k).radical
@@ -221,10 +221,10 @@ def idealPowersToSelfLERadical (J : Ideal R) : ℕᵒᵖ ⥤ SelfLERadical J :=
 
 variable {I J K : Ideal R}
 
-/-- The lemma below essentially says that `ideal_powers_to_self_le_radical I` is initial in
-`self_le_radical_diagram I`.
+/-- The lemma below essentially says that `idealPowersToSelfLERadical I` is initial in
+`selfLERadicalDiagram I`.
 
-PORTING NOTE: This lemma should probably be moved to `ring_theory/finiteness.lean`
+PORTING NOTE: This lemma should probably be moved to `Mathlib/RingTheory/Finiteness`
 to be near `ideal.exists_radical_pow_le_of_fg`, which it generalizes. -/
 theorem Ideal.exists_pow_le_of_le_radical_of_fG (hIJ : I ≤ J.radical) (hJ : J.radical.FG) :
     ∃ k : ℕ, I ^ k ≤ J := by

--- a/Mathlib/Algebra/Homology/LocalCohomology.lean
+++ b/Mathlib/Algebra/Homology/LocalCohomology.lean
@@ -225,7 +225,7 @@ variable {I J K : Ideal R}
 `selfLERadicalDiagram I`.
 
 PORTING NOTE: This lemma should probably be moved to `Mathlib/RingTheory/Finiteness`
-to be near `ideal.exists_radical_pow_le_of_fg`, which it generalizes. -/
+to be near `Ideal.exists_radical_pow_le_of_fg`, which it generalizes. -/
 theorem Ideal.exists_pow_le_of_le_radical_of_fG (hIJ : I ≤ J.radical) (hJ : J.radical.FG) :
     ∃ k : ℕ, I ^ k ≤ J := by
   obtain ⟨k, hk⟩ := J.exists_radical_pow_le_of_fg hJ

--- a/Mathlib/Algebra/Homology/LocalCohomology.lean
+++ b/Mathlib/Algebra/Homology/LocalCohomology.lean
@@ -249,7 +249,12 @@ instance ideal_powers_initial [hR : IsNoetherian R R] : Functor.Initial (idealPo
         left; exact ⟨CostructuredArrow.homMk (homOfLE h).op (AsTrue.get trivial)⟩ }
 #align local_cohomology.ideal_powers_initial localCohomology.ideal_powers_initial
 
-set_option pp.universes true in
+-- FIXME again, this instance is not found by `inferInstance`, but `#synth` finds it just fine.
+-- #synth HasColimitsOfSize.{0, 0, u, u + 1} (ModuleCat.{u, u} R)
+instance : HasColimitsOfSize.{0, 0, u, u + 1} (ModuleCat.{u, u} R) :=
+  ModuleCat.Colimits.hasColimitsOfSize_zero_moduleCat.{u, u}
+
+example : HasColimitsOfSize.{0, 0, u, u + 1} (ModuleCat.{u, u} R) := inferInstance
 /-- Local cohomology (defined in terms of powers of `J`) agrees with local
 cohomology computed over all ideals with radical containing `J`. -/
 def isoSelfLERadical (J : Ideal.{u} R) [IsNoetherian.{u,u} R R] (i : ℕ) :

--- a/Mathlib/Algebra/Homology/LocalCohomology.lean
+++ b/Mathlib/Algebra/Homology/LocalCohomology.lean
@@ -77,7 +77,7 @@ def ringModIdeals (I : D ⥤ Ideal R) : D ⥤ ModuleCat.{u} R where
   map_comp f g := by apply Submodule.linearMap_qext; rfl
 #align local_cohomology.ring_mod_ideals localCohomology.ringModIdeals
 
--- TODO:  Once this file is ported, move this file to the right location.
+-- Porting note: TODO:  Once this file is ported, move this instance to the right location.
 instance moduleCat_enough_projectives' : EnoughProjectives (ModuleCat.{u} R) :=
   ModuleCat.moduleCat_enoughProjectives.{u}
 set_option linter.uppercaseLean3 false in
@@ -102,9 +102,9 @@ In this definition we do not assume any special property of the diagram `I`, but
 will be where `I` is (cofinal with) the diagram of powers of a single given ideal.
 
 Below, we give two equivalent definitions of the usual local cohomology with support
-in an ideal `J`, `local_cohomology` and `local_cohomology.of_self_le_radical`.
+in an ideal `J`, `localCohomology` and `localCohomology.ofSelfLERadical`.
  -/
-/-- `local_cohomology.of_diagram I i` is the functor sending a module `M` over a commutative
+/-- `localCohomology.ofDiagram I i` is the functor sending a module `M` over a commutative
 ring `R` to the direct limit of `Ext^i(R/J, M)`, where `J` ranges over a collection of ideals
 of `R`, represented as a functor `I`. -/
 def ofDiagram (I : D ⥤ Ideal R) (i : ℕ) : ModuleCat.{max u v} R ⥤ ModuleCat.{max u v} R :=
@@ -145,25 +145,25 @@ def idealPowersDiagram (J : Ideal R) : ℕᵒᵖ ⥤ Ideal R where
 #align local_cohomology.ideal_powers_diagram localCohomology.idealPowersDiagram
 
 /-- The full subcategory of all ideals with radical containing `J` -/
-def SelfLeRadical (J : Ideal R) : Type u :=
+def SelfLERadical (J : Ideal R) : Type u :=
   FullSubcategory fun J' : Ideal R => J ≤ J'.radical
 --deriving Category
 
 -- Porting note: `deriving Category` is not able to derive this instance
-instance (J : Ideal R) : Category (SelfLeRadical J) :=
+instance (J : Ideal R) : Category (SelfLERadical J) :=
   (FullSubcategory.category _)
 
-#align local_cohomology.self_le_radical localCohomology.SelfLeRadical
+#align local_cohomology.self_le_radical localCohomology.SelfLERadical
 
-instance SelfLeRadical.inhabited (J : Ideal R) : Inhabited (SelfLeRadical J)
+instance SelfLERadical.inhabited (J : Ideal R) : Inhabited (SelfLERadical J)
     where default := ⟨J, Ideal.le_radical⟩
-#align local_cohomology.self_le_radical.inhabited localCohomology.SelfLeRadical.inhabited
+#align local_cohomology.self_le_radical.inhabited localCohomology.SelfLERadical.inhabited
 
 /-- The diagram of all ideals with radical containing `J`, represented as a functor.
 This is the "largest" diagram that computes local cohomology with support in `J`. -/
-def selfLeRadicalDiagram (J : Ideal R) : SelfLeRadical J ⥤ Ideal R :=
+def SelfLERadicalDiagram (J : Ideal R) : SelfLERadical J ⥤ Ideal R :=
   fullSubcategoryInclusion _
-#align local_cohomology.self_le_radical_diagram localCohomology.selfLeRadicalDiagram
+#align local_cohomology.self_le_radical_diagram localCohomology.SelfLERadicalDiagram
 
 end Diagrams
 
@@ -189,9 +189,9 @@ def localCohomology (J : Ideal R) (i : ℕ) : ModuleCat.{u} R ⥤ ModuleCat.{u} 
 
 /-- Local cohomology as the direct limit of `Ext^i(R/J', M)` over *all* ideals `J'` with radical
 containing `J`. -/
-def localCohomology.ofSelfLeRadical (J : Ideal R) (i : ℕ) : ModuleCat.{u} R ⥤ ModuleCat.{u} R :=
-  ofDiagram.{u} (selfLeRadicalDiagram.{u} J) i
-#align local_cohomology.of_self_le_radical localCohomology.ofSelfLeRadical
+def localCohomology.ofSelfLERadical (J : Ideal R) (i : ℕ) : ModuleCat.{u} R ⥤ ModuleCat.{u} R :=
+  ofDiagram.{u} (SelfLERadicalDiagram.{u} J) i
+#align local_cohomology.of_self_le_radical localCohomology.ofSelfLERadical
 
 end ModelsForLocalCohomology
 
@@ -199,8 +199,8 @@ namespace localCohomology
 
 /-!
 Showing equivalence of different definitions of local cohomology.
-  * `localCohomology.isoSelfLeRadical` gives the isomorphism
-      `localCohomology J i ≅ localCohomology.ofSelfLeRadical J i`
+  * `localCohomology.isoSelfLERadical` gives the isomorphism
+      `localCohomology J i ≅ localCohomology.ofSelfLERadical J i`
   * `localCohomology.isoOfSameRadical` gives the isomorphism
       `localCohomology J i ≅ localCohomology K i` when `J.radical = K.radical`.
 -/
@@ -211,13 +211,13 @@ variable {R : Type u} [CommRing R]
 
 /-- Lifting `ideal_powers_diagram J` from a diagram valued in `ideals R` to a diagram
 valued in `self_le_radical J`. -/
-def idealPowersToSelfLeRadical (J : Ideal R) : ℕᵒᵖ ⥤ SelfLeRadical J :=
+def idealPowersToSelfLERadical (J : Ideal R) : ℕᵒᵖ ⥤ SelfLERadical J :=
   FullSubcategory.lift _ (idealPowersDiagram J) fun k => by
     change _ ≤ (J ^ unop k).radical
     cases' unop k with n
     · simp [Ideal.radical_top, pow_zero, Ideal.one_eq_top, le_top, Nat.zero_eq]
     · simp only [J.radical_pow _ n.succ_pos, Ideal.le_radical]
-#align local_cohomology.ideal_powers_to_self_le_radical localCohomology.idealPowersToSelfLeRadical
+#align local_cohomology.ideal_powers_to_self_le_radical localCohomology.idealPowersToSelfLERadical
 
 variable {I J K : Ideal R}
 
@@ -238,7 +238,7 @@ theorem Ideal.exists_pow_le_of_le_radical_of_fG (hIJ : I ≤ J.radical) (hJ : J.
 #check zigzag_isConnected
 /-- The diagram of powers of `J` is initial in the diagram of all ideals with
 radical containing `J`. This uses noetherianness. -/
-instance ideal_powers_initial [hR : IsNoetherian R R] : Functor.Initial (idealPowersToSelfLeRadical J)
+instance ideal_powers_initial [hR : IsNoetherian R R] : Functor.Initial (idealPowersToSelfLERadical J)
     where out J' := by
     { apply @zigzag_isConnected _ _ _
       . intro j1 j2
@@ -249,49 +249,49 @@ instance ideal_powers_initial [hR : IsNoetherian R R] : Functor.Initial (idealPo
         right; exact ⟨CostructuredArrow.homMk (homOfLE h).op (AsTrue.get trivial)⟩
         left; exact ⟨CostructuredArrow.homMk (homOfLE h).op (AsTrue.get trivial)⟩
       . obtain ⟨k, hk⟩ := Ideal.exists_pow_le_of_le_radical_of_fG J'.2 (isNoetherian_def.mp hR _)
-        exact ⟨CostructuredArrow.mk (⟨⟨hk⟩⟩ : (idealPowersToSelfLeRadical J).obj (op k) ⟶ J')⟩
+        exact ⟨CostructuredArrow.mk (⟨⟨hk⟩⟩ : (idealPowersToSelfLERadical J).obj (op k) ⟶ J')⟩
     }
 #align local_cohomology.ideal_powers_initial localCohomology.ideal_powers_initial
 
 set_option pp.universes true in
 /-- Local cohomology (defined in terms of powers of `J`) agrees with local
 cohomology computed over all ideals with radical containing `J`. -/
-def isoSelfLeRadical (J : Ideal.{u} R) [IsNoetherian.{u,u} R R] (i : ℕ) :
-    localCohomology.ofSelfLeRadical.{u} J i ≅ localCohomology.{u} J i :=
-  (localCohomology.isoOfFinal.{u, u, 0} (idealPowersToSelfLeRadical.{u} J) (selfLeRadicalDiagram.{u} J)
+def isoSelfLERadical (J : Ideal.{u} R) [IsNoetherian.{u,u} R R] (i : ℕ) :
+    localCohomology.ofSelfLERadical.{u} J i ≅ localCohomology.{u} J i :=
+  (localCohomology.isoOfFinal.{u, u, 0} (idealPowersToSelfLERadical.{u} J) (SelfLERadicalDiagram.{u} J)
         i).symm ≪≫
     HasColimit.isoOfNatIso.{0,0,u+1,u+1} (Iso.refl.{u+1,u+1} _)
-#align local_cohomology.iso_self_le_radical localCohomology.isoSelfLeRadical
+#align local_cohomology.iso_self_le_radical localCohomology.isoSelfLERadical
 
 /-- Casting from the full subcategory of ideals with radical containing `J` to the full
 subcategory of ideals with radical containing `K`. -/
-def SelfLeRadical.cast (hJK : J.radical = K.radical) : SelfLeRadical J ⥤ SelfLeRadical K :=
+def SelfLERadical.cast (hJK : J.radical = K.radical) : SelfLERadical J ⥤ SelfLERadical K :=
   FullSubcategory.map fun L hL =>
     by
     rw [← Ideal.radical_le_radical_iff] at hL ⊢
     exact hJK.symm.trans_le hL
-#align local_cohomology.self_le_radical.cast localCohomology.SelfLeRadical.cast
+#align local_cohomology.self_le_radical.cast localCohomology.SelfLERadical.cast
 
 -- TODO generalize this to the equivalence of full categories for any `iff`.
-instance SelfLeRadical.castIsEquivalence (hJK : J.radical = K.radical) :
-    IsEquivalence (SelfLeRadical.cast hJK)
+instance SelfLERadical.castIsEquivalence (hJK : J.radical = K.radical) :
+    IsEquivalence (SelfLERadical.cast hJK)
     where
-  inverse := SelfLeRadical.cast hJK.symm
+  inverse := SelfLERadical.cast hJK.symm
   unitIso := by sorry -- was "by tidy"
   counitIso := by sorry -- was "by tidy"
-#align local_cohomology.self_le_radical.cast_is_equivalence localCohomology.SelfLeRadical.castIsEquivalence
+#align local_cohomology.self_le_radical.cast_is_equivalence localCohomology.SelfLERadical.castIsEquivalence
 
 /-- The natural isomorphism between local cohomology defined using the `of_self_le_radical`
 diagram, assuming `J.radical = K.radical`. -/
-def SelfLeRadical.isoOfSameRadical (hJK : J.radical = K.radical) (i : ℕ) :
-    ofSelfLeRadical J i ≅ ofSelfLeRadical K i :=
-  (isoOfFinal.{u, u, u} (SelfLeRadical.cast hJK.symm) _ _).symm
-#align local_cohomology.self_le_radical.iso_of_same_radical localCohomology.SelfLeRadical.isoOfSameRadical
+def SelfLERadical.isoOfSameRadical (hJK : J.radical = K.radical) (i : ℕ) :
+    ofSelfLERadical J i ≅ ofSelfLERadical K i :=
+  (isoOfFinal.{u, u, u} (SelfLERadical.cast hJK.symm) _ _).symm
+#align local_cohomology.self_le_radical.iso_of_same_radical localCohomology.SelfLERadical.isoOfSameRadical
 
 /-- Local cohomology agrees on ideals with the same radical. -/
 def isoOfSameRadical [IsNoetherian R R] (hJK : J.radical = K.radical) (i : ℕ) :
     localCohomology J i ≅ localCohomology K i :=
-  (isoSelfLeRadical J i).symm ≪≫ SelfLeRadical.isoOfSameRadical hJK i ≪≫ isoSelfLeRadical K i
+  (isoSelfLERadical J i).symm ≪≫ SelfLERadical.isoOfSameRadical hJK i ≪≫ isoSelfLERadical K i
 #align local_cohomology.iso_of_same_radical localCohomology.isoOfSameRadical
 
 end LocalCohomologyEquiv

--- a/Mathlib/Algebra/Homology/LocalCohomology.lean
+++ b/Mathlib/Algebra/Homology/LocalCohomology.lean
@@ -235,12 +235,13 @@ theorem Ideal.exists_pow_le_of_le_radical_of_fG (hIJ : I ≤ J.radical) (hJ : J.
 
 /-- The diagram of powers of `J` is initial in the diagram of all ideals with
 radical containing `J`. This uses noetherianness. -/
-instance ideal_powers_initial [hR : IsNoetherian R R] : Functor.Initial (idealPowersToSelfLERadical J)
-    where out J' := by
+instance ideal_powers_initial [hR : IsNoetherian R R] :
+    Functor.Initial (idealPowersToSelfLERadical J) where
+  out J' := by
     { apply (config := {allowSynthFailures := true }) zigzag_isConnected
-      . obtain ⟨k, hk⟩ := Ideal.exists_pow_le_of_le_radical_of_fG J'.2 (isNoetherian_def.mp hR _)
+      · obtain ⟨k, hk⟩ := Ideal.exists_pow_le_of_le_radical_of_fG J'.2 (isNoetherian_def.mp hR _)
         exact ⟨CostructuredArrow.mk (⟨⟨hk⟩⟩ : (idealPowersToSelfLERadical J).obj (op k) ⟶ J')⟩
-      . intro j1 j2
+      · intro j1 j2
         apply Relation.ReflTransGen.single
         -- The inclusions `J^n1 ≤ J'` and `J^n2 ≤ J'` always form a triangle, based on
         -- which exponent is larger.
@@ -259,15 +260,15 @@ example : HasColimitsOfSize.{0, 0, u, u + 1} (ModuleCat.{u, u} R) := inferInstan
 cohomology computed over all ideals with radical containing `J`. -/
 def isoSelfLERadical (J : Ideal.{u} R) [IsNoetherian.{u,u} R R] (i : ℕ) :
     localCohomology.ofSelfLERadical.{u} J i ≅ localCohomology.{u} J i :=
-  (localCohomology.isoOfFinal.{u, u, 0} (idealPowersToSelfLERadical.{u} J) (selfLERadicalDiagram.{u} J) i).symm ≪≫
-    HasColimit.isoOfNatIso.{0,0,u+1,u+1} (Iso.refl.{u+1,u+1} _)
+  (localCohomology.isoOfFinal.{u, u, 0} (idealPowersToSelfLERadical.{u} J)
+    (selfLERadicalDiagram.{u} J) i).symm ≪≫
+      HasColimit.isoOfNatIso.{0,0,u+1,u+1} (Iso.refl.{u+1,u+1} _)
 #align local_cohomology.iso_self_le_radical localCohomology.isoSelfLERadical
 
 /-- Casting from the full subcategory of ideals with radical containing `J` to the full
 subcategory of ideals with radical containing `K`. -/
 def SelfLERadical.cast (hJK : J.radical = K.radical) : SelfLERadical J ⥤ SelfLERadical K :=
-  FullSubcategory.map fun L hL =>
-    by
+  FullSubcategory.map fun L hL => by
     rw [← Ideal.radical_le_radical_iff] at hL ⊢
     exact hJK.symm.trans_le hL
 #align local_cohomology.self_le_radical.cast localCohomology.SelfLERadical.cast

--- a/Mathlib/Algebra/Homology/LocalCohomology.lean
+++ b/Mathlib/Algebra/Homology/LocalCohomology.lean
@@ -78,10 +78,10 @@ def ringModIdeals (I : D ⥤ Ideal R) : D ⥤ ModuleCat.{u} R where
 #align local_cohomology.ring_mod_ideals localCohomology.ringModIdeals
 
 -- Porting note: TODO:  Once this file is ported, move this instance to the right location.
-instance moduleCat_enough_projectives' : EnoughProjectives (ModuleCat.{u} R) :=
+instance moduleCat_enoughProjectives' : EnoughProjectives (ModuleCat.{u} R) :=
   ModuleCat.moduleCat_enoughProjectives.{u}
 set_option linter.uppercaseLean3 false in
-#align local_cohomology.Module_enough_projectives' localCohomology.moduleCat_enough_projectives'
+#align local_cohomology.Module_enough_projectives' localCohomology.moduleCat_enoughProjectives'
 
 /-- The diagram we will take the colimit of to define local cohomology, corresponding to the
 directed system determined by the functor `I` -/
@@ -161,17 +161,17 @@ instance SelfLERadical.inhabited (J : Ideal R) : Inhabited (SelfLERadical J)
 
 /-- The diagram of all ideals with radical containing `J`, represented as a functor.
 This is the "largest" diagram that computes local cohomology with support in `J`. -/
-def SelfLERadicalDiagram (J : Ideal R) : SelfLERadical J ⥤ Ideal R :=
+def selfLERadicalDiagram (J : Ideal R) : SelfLERadical J ⥤ Ideal R :=
   fullSubcategoryInclusion _
-#align local_cohomology.self_le_radical_diagram localCohomology.SelfLERadicalDiagram
+#align local_cohomology.self_le_radical_diagram localCohomology.selfLERadicalDiagram
 
 end Diagrams
 
 end localCohomology
 
 /-! We give two models for the local cohomology with support in an ideal `J`: first in terms of
-the powers of `J` (`local_cohomology`), then in terms of *all* ideals with radical
-containing `J` (`local_cohomology.of_self_le_radical`). -/
+the powers of `J` (`localCohomology`), then in terms of *all* ideals with radical
+containing `J` (`localCohomology.of_self_le_radical`). -/
 
 
 section ModelsForLocalCohomology
@@ -180,7 +180,7 @@ open localCohomology
 
 variable {R : Type u} [CommRing R]
 
-/-- `local_cohomology J i` is `i`-th the local cohomology module of a module `M` over
+/-- `localCohomology J i` is `i`-th the local cohomology module of a module `M` over
 a commutative ring `R` with support in the ideal `J` of `R`, defined as the direct limit
 of `Ext^i(R/J^t, M)` over all powers `t : ℕ`. -/
 def localCohomology (J : Ideal R) (i : ℕ) : ModuleCat.{u} R ⥤ ModuleCat.{u} R :=
@@ -190,7 +190,7 @@ def localCohomology (J : Ideal R) (i : ℕ) : ModuleCat.{u} R ⥤ ModuleCat.{u} 
 /-- Local cohomology as the direct limit of `Ext^i(R/J', M)` over *all* ideals `J'` with radical
 containing `J`. -/
 def localCohomology.ofSelfLERadical (J : Ideal R) (i : ℕ) : ModuleCat.{u} R ⥤ ModuleCat.{u} R :=
-  ofDiagram.{u} (SelfLERadicalDiagram.{u} J) i
+  ofDiagram.{u} (selfLERadicalDiagram.{u} J) i
 #align local_cohomology.of_self_le_radical localCohomology.ofSelfLERadical
 
 end ModelsForLocalCohomology
@@ -258,7 +258,7 @@ set_option pp.universes true in
 cohomology computed over all ideals with radical containing `J`. -/
 def isoSelfLERadical (J : Ideal.{u} R) [IsNoetherian.{u,u} R R] (i : ℕ) :
     localCohomology.ofSelfLERadical.{u} J i ≅ localCohomology.{u} J i :=
-  (localCohomology.isoOfFinal.{u, u, 0} (idealPowersToSelfLERadical.{u} J) (SelfLERadicalDiagram.{u} J)
+  (localCohomology.isoOfFinal.{u, u, 0} (idealPowersToSelfLERadical.{u} J) (selfLERadicalDiagram.{u} J)
         i).symm ≪≫
     HasColimit.isoOfNatIso.{0,0,u+1,u+1} (Iso.refl.{u+1,u+1} _)
 #align local_cohomology.iso_self_le_radical localCohomology.isoSelfLERadical


### PR DESCRIPTION
This is Jake Levinson's work. It's a proof that local cohomology agrees for ideals with equal radicals.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

Forward-port leanprover-community/mathlib#19105 which contains a proof that local cohomology agrees for ideals with equal radicals.

Note: this is Jake Levinson's work. He opened #5435 which sat for two weeks with merge conflicts. I fixed up a couple of the remaining errors in the file and then tried to merge master and managed to bork the history. I've opened this second PR with just Jake's and my changes to the one file this PR should be about.