### PR TITLE
[Merged by Bors] - fix: `at` notation for ProjectiveSpectrum.StructureSheaf

### DIFF
--- a/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/StructureSheaf.lean
+++ b/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/StructureSheaf.lean
@@ -65,8 +65,9 @@ variable [CommRing R] [CommRing A] [Algebra R A]
 
 variable (𝒜 : ℕ → Submodule R A) [GradedAlgebra 𝒜]
 
-local macro "at " x:term : term => `(HomogeneousLocalization.AtPrime 𝒜
-  ($x : ProjectiveSpectrum.top 𝒜).asHomogeneousIdeal.toIdeal)
+local notation3 "at " x =>
+  HomogeneousLocalization.AtPrime 𝒜
+    (HomogeneousIdeal.toIdeal (ProjectiveSpectrum.asHomogeneousIdeal x))
 
 namespace ProjectiveSpectrum.StructureSheaf
 


### PR DESCRIPTION
Switches to `notation3` and eliminates dot notation so it can generate a pretty printer.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
