### PR TITLE
[Merged by Bors] - fix: make `lift_lets` not descend into proofs or `let`-less subexpressions

### DIFF
--- a/Mathlib/LinearAlgebra/CliffordAlgebra/EvenEquiv.lean
+++ b/Mathlib/LinearAlgebra/CliffordAlgebra/EvenEquiv.lean
@@ -182,12 +182,8 @@ theorem ofEven_ι (x y : M × R) :
       (ι Q x.1 + algebraMap R _ x.2) * (ι Q y.1 - algebraMap R _ y.2) := by
   -- porting note: entire proof was the term-mode `even.lift_ι (Q' Q) _ x y`
   unfold ofEven
-  -- TODO: `lift_lets` gives a deep recursion error if we try to use it here
-  let f : M × R →ₗ[R] M × R →ₗ[R] CliffordAlgebra Q :=
-    ((Algebra.lmul R (CliffordAlgebra Q)).toLinearMap.comp <|
-          (ι Q).comp (LinearMap.fst _ _ _) +
-            (Algebra.linearMap R _).comp (LinearMap.snd _ _ _)).compl₂
-      ((ι Q).comp (LinearMap.fst _ _ _) - (Algebra.linearMap R _).comp (LinearMap.snd _ _ _))
+  lift_lets
+  intro f
   -- TODO: replacing `?_` with `_` takes way longer?
   refine @even.lift_ι R (M × R) _ _ _ (Q' Q) _ _ _ ⟨f, ?_, ?_⟩ x y
 #align clifford_algebra.of_even_ι CliffordAlgebra.ofEven_ι

--- a/Mathlib/Tactic/LiftLets.lean
+++ b/Mathlib/Tactic/LiftLets.lean
@@ -21,6 +21,10 @@ This list is used during the computation to merge let bindings.
 -/
 private partial def Lean.Expr.liftLetsAux (e : Expr) (fvars : Array Expr)
     (f : Array Expr → Expr → MetaM Expr) : MetaM Expr := do
+  if (e.find? Expr.isLet).isNone then
+    return ← f fvars e
+  if ← Meta.isProof e then
+    return ← f fvars e
   match e with
   | .letE n t v b _ =>
     t.liftLetsAux fvars fun fvars t' =>

--- a/Mathlib/Tactic/LiftLets.lean
+++ b/Mathlib/Tactic/LiftLets.lean
@@ -12,40 +12,52 @@ This module defines a tactic `lift_lets` that can be used to pull `let` bindings
 of an expression as possible.
 -/
 
-
 open Lean Elab Parser Meta Tactic
+
+/-- Configuration for `Lean.Expr.liftLets` and the `lift_lets` tactic. -/
+structure Lean.Expr.LiftLetsConfig where
+  /-- Whether to lift lets out of proofs. The default is not to. -/
+  proofs : Bool := false
+  /-- Whether to merge let bindings if they have the same type and value.
+  This test is by syntactic equality, not definitional equality.
+  The default is to merge. -/
+  merge : Bool := true
 
 /--
 Auxiliary definition for `Lean.Expr.liftLets`. Takes a list of the accumulated fvars.
 This list is used during the computation to merge let bindings.
 -/
-private partial def Lean.Expr.liftLetsAux (e : Expr) (fvars : Array Expr)
+private partial def Lean.Expr.liftLetsAux (config : LiftLetsConfig) (e : Expr) (fvars : Array Expr)
     (f : Array Expr → Expr → MetaM Expr) : MetaM Expr := do
   if (e.find? Expr.isLet).isNone then
+    -- If `e` contains no `let` expressions, then we can avoid recursing into it.
     return ← f fvars e
-  if ← Meta.isProof e then
-    return ← f fvars e
+  if !config.proofs then
+    if ← Meta.isProof e then
+      return ← f fvars e
   match e with
   | .letE n t v b _ =>
-    t.liftLetsAux fvars fun fvars t' =>
-      v.liftLetsAux fvars fun fvars v' => do
-        -- Eliminate the let binding if there is already one of the same type and value.
-        let fvar? ← fvars.findM? (fun fvar => do
-          let decl ← fvar.fvarId!.getDecl
-          return decl.type == t' && decl.value? == some v')
-        if let some fvar' := fvar? then
-          (b.instantiate1 fvar').liftLetsAux fvars f
-        else
-          withLetDecl n t' v' fun fvar => (b.instantiate1 fvar).liftLetsAux (fvars.push fvar) f
+    t.liftLetsAux config fvars fun fvars t' =>
+      v.liftLetsAux config fvars fun fvars v' => do
+        if config.merge then
+          -- Eliminate the let binding if there is already one of the same type and value.
+          let fvar? ← fvars.findM? (fun fvar => do
+            let decl ← fvar.fvarId!.getDecl
+            return decl.type == t' && decl.value? == some v')
+          if let some fvar' := fvar? then
+            return ← (b.instantiate1 fvar').liftLetsAux config fvars f
+        withLetDecl n t' v' fun fvar =>
+          (b.instantiate1 fvar).liftLetsAux config (fvars.push fvar) f
   | .app x y =>
-    x.liftLetsAux fvars fun fvars x' => y.liftLetsAux fvars fun fvars y' => f fvars (.app x' y')
+    x.liftLetsAux config fvars fun fvars x' => y.liftLetsAux config fvars fun fvars y' =>
+      f fvars (.app x' y')
   | .proj n idx s =>
-    s.liftLetsAux fvars fun fvars s' => f fvars (.proj n idx s')
+    s.liftLetsAux config fvars fun fvars s' => f fvars (.proj n idx s')
   | .lam n t b i =>
-    t.liftLetsAux fvars fun fvars t => do
+    t.liftLetsAux config fvars fun fvars t => do
       -- Enter the binding, do liftLets, and lift out liftable lets
       let e' ← withLocalDecl n i t fun fvar => do
-        (b.instantiate1 fvar).liftLetsAux fvars fun fvars2 b => do
+        (b.instantiate1 fvar).liftLetsAux config fvars fun fvars2 b => do
           -- See which bindings can't be migrated out
           let deps ← collectForwardDeps #[fvar] false
           let fvars2 := fvars2[fvars.size:].toArray
@@ -54,10 +66,10 @@ private partial def Lean.Expr.liftLetsAux (e : Expr) (fvars : Array Expr)
       -- Re-enter the new lets; we do it this way to keep the local context clean
       insideLets e' fvars fun fvars e'' => f fvars e''
   | .forallE n t b i =>
-    t.liftLetsAux fvars fun fvars t => do
+    t.liftLetsAux config fvars fun fvars t => do
       -- Enter the binding, do liftLets, and lift out liftable lets
       let e' ← withLocalDecl n i t fun fvar => do
-        (b.instantiate1 fvar).liftLetsAux fvars fun fvars2 b => do
+        (b.instantiate1 fvar).liftLetsAux config fvars fun fvars2 b => do
           -- See which bindings can't be migrated out
           let deps ← collectForwardDeps #[fvar] false
           let fvars2 := fvars2[fvars.size:].toArray
@@ -65,7 +77,7 @@ private partial def Lean.Expr.liftLetsAux (e : Expr) (fvars : Array Expr)
           mkLetFVars fvars2' (← mkForallFVars #[fvar] (← mkLetFVars fvars2 b))
       -- Re-enter the new lets; we do it this way to keep the local context clean
       insideLets e' fvars fun fvars e'' => f fvars e''
-  | .mdata _ e => e.liftLetsAux fvars f
+  | .mdata _ e => e.liftLetsAux config fvars f
   | _ => f fvars e
 where
   -- Like the whole `Lean.Expr.liftLets`, but only handles lets
@@ -82,10 +94,13 @@ of local bindings (each an fvar) and the new expression.
 Let bindings are merged if they have the same type and value.
 
 Use `e.liftLets mkLetFVars` to get a defeq expression with all `let`s lifted as far as possible. -/
-def Lean.Expr.liftLets (e : Expr) (f : Array Expr → Expr → MetaM Expr) : MetaM Expr :=
-  e.liftLetsAux #[] f
+def Lean.Expr.liftLets (e : Expr) (f : Array Expr → Expr → MetaM Expr)
+    (config : LiftLetsConfig := {}) : MetaM Expr :=
+  e.liftLetsAux config #[] f
 
-namespace Mathlib
+namespace Mathlib.Tactic
+
+declare_config_elab elabConfig Lean.Expr.LiftLetsConfig
 
 /--
 Lift all the `let` bindings in the type of an expression as far out as possible.
@@ -102,17 +117,18 @@ example : (let x := 1; x) = 1 := by
 
 During the lifting process, let bindings are merged if they have the same type and value.
 -/
-syntax (name := lift_lets) "lift_lets" (ppSpace location)? : tactic
+syntax (name := lift_lets) "lift_lets" (Parser.Tactic.config)? (ppSpace location)? : tactic
 
 elab_rules : tactic
-  | `(tactic| lift_lets $[$loc:location]?) => do
+  | `(tactic| lift_lets $[$cfg:config]? $[$loc:location]?) => do
+    let config ← elabConfig (mkOptionalNode cfg)
     withLocation (expandOptLocation (Lean.mkOptionalNode loc))
       (atLocal := fun h ↦ liftMetaTactic1 fun mvarId ↦ do
         let hTy ← instantiateMVars (← h.getType)
-        mvarId.changeLocalDecl' h (← hTy.liftLets mkLetFVars))
+        mvarId.changeLocalDecl' h (← hTy.liftLets mkLetFVars config))
       (atTarget := liftMetaTactic1 fun mvarId ↦ do
         let ty ← instantiateMVars (← mvarId.getType)
-        mvarId.change (← ty.liftLets mkLetFVars))
+        mvarId.change (← ty.liftLets mkLetFVars config))
       (failed := fun _ ↦ throwError "lift_lets tactic failed")
 
-end Mathlib
+end Mathlib.Tactic

--- a/test/LiftLets.lean
+++ b/test/LiftLets.lean
@@ -90,3 +90,11 @@ example : let x := 1; ∀ n, let y := 1; x + n = y + n := by
   guard_target =ₛ let x := 1; ∀ n, x + n = x + n
   intros x n
   rfl
+
+example (m : Nat) (h : ∃ n, n + 1 = m) (x : Fin m) (y : Fin _) :
+    cast (let h' := h.choose_spec.symm; congrArg Fin h') x = y := by
+  lift_lets (config := {proofs := true})
+  intro h'
+  clear_value h'
+  guard_hyp h' : m = Exists.choose h + 1
+  sorry

--- a/test/LiftLets.lean
+++ b/test/LiftLets.lean
@@ -13,6 +13,12 @@ example : (let x := 1; x) = (let y := 1; y) := by
   intro _x
   rfl
 
+example : (let x := 1; x) = (let y := 1; y) := by
+  lift_lets (config := {merge := false})
+  guard_target =ₛ let x := 1; let y := 1; x = y
+  intros _x _y
+  rfl
+
 example : (let x := (let y := 1; y + 1); x + 1) = 3 := by
   lift_lets
   guard_target =ₛ let y := 1; let x := y + 1; x + 1 = 3


### PR DESCRIPTION
This helps keep `lift_lets` from unnecessarily doing deep recursion on deep expressions. Whether to descend into proofs is put behind a configuration option.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
