### PR TITLE
[Merged by Bors] - fix: incorrect module name in source header

### DIFF
--- a/Mathlib/Init/Data/List/Instances.lean
+++ b/Mathlib/Init/Data/List/Instances.lean
@@ -3,7 +3,7 @@ Copyright (c) 2016 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura
 
-! This file was ported from Lean 3 source module lean_core.init.data.list.instances
+! This file was ported from Lean 3 source module init.data.list.instances
 ! leanprover-community/lean commit 9af482290ef68e8aaa5ead01aa7b09b7be7019fd
 ! Please do not edit these lines, except to modify the commit id
 ! if you have ported upstream changes.


### PR DESCRIPTION
As a result this did not show as ported on the dashboard

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
