### PR TITLE
[Merged by Bors] - feat: `conv in ... => ...` conv tactic

### DIFF
--- a/Mathlib/Tactic/Conv.lean
+++ b/Mathlib/Tactic/Conv.lean
@@ -27,6 +27,22 @@ macro_rules
 macro "run_conv" e:doSeq : conv => `(conv| tactic' => run_tac $e)
 
 /--
+`conv in pat => cs` runs the `conv` tactic sequence `cs`
+on the first subexpression matching the pattern `pat` in the target.
+The converted expression becomes the new target subgoal, like `conv => cs`.
+
+The arguments `in` are the same as those as the in `pattern`.
+In fact, `conv in pat => cs` is a macro for `conv => pattern pat; cs`.
+
+The syntax also supports the `occs` clause. Example:
+```lean
+conv in (occs := *) x + y => rw [add_comm]
+```
+-/
+macro "conv" " in " occs?:(occs)? p:term " => " code:convSeq : conv =>
+  `(conv| conv => pattern $[$occs?]? $p; ($code:convSeq))
+
+/--
 * `discharge => tac` is a conv tactic which rewrites target `p` to `True` if `tac` is a tactic
   which proves the goal `⊢ p`.
 * `discharge` without argument returns `⊢ p` as a subgoal.

--- a/test/conv.lean
+++ b/test/conv.lean
@@ -1,0 +1,21 @@
+import Mathlib.Tactic.Conv
+import Std.Tactic.GuardExpr
+
+/-- Testing nested `conv in ... => ...` -/
+example (a b c : Nat) : a + b + c = c + a + b := by
+  conv =>
+    conv in a + b =>
+      rw [Nat.add_comm]
+    guard_target = b + a + c = c + a + b
+    rw [Nat.add_comm, Nat.add_assoc]
+    conv in (occs := 4) _ + _ =>
+      guard_target = a + b
+      rw [Nat.add_comm]
+
+/-- Testing nested `conv in ... => ...` -/
+example (a b : Nat) : (a + b) + (a + b) = (b + a) + (b + a) := by
+  conv =>
+    lhs
+    conv in (occs := *) a + b =>
+      rw [Nat.add_comm]
+    guard_target = b + a + (b + a)


### PR DESCRIPTION
This is mean to be a substitute for the `for` tactic used in mathlib3. It's just copying the `conv` syntax for `conv`-the-tactic, which provides a convenient way to immediately apply the `pattern` conv tactic.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
