### PR TITLE
[Merged by Bors] - fix: include leaf core files in port status

### DIFF
--- a/scripts/make_port_status.py
+++ b/scripts/make_port_status.py
@@ -58,7 +58,7 @@ for path in paths:
                 if imported + '.default' in graph.nodes:
                     imported = imported + '.default'
                 else:
-                    imported = 'lean_core.' + imported
+                    imported = imported
             graph.add_edge(imported, label)
 
 def get_mathlib4_module_commit_info(contents):
@@ -104,6 +104,8 @@ for path4 in Path(mathlib4_root).glob('**/*.lean'):
         'mathlib4_pr': mathlib4_pr,
         'source': dict(repo=repo, commit=commit)
     }
+
+    graph.add_node(module)
 
 prs = {}
 fetch_args = ['git', 'fetch', 'origin']


### PR DESCRIPTION
Previously we only recorded the status of files if they appeared in the dependency graph; we should therefore ensure that every file mentioned in the header has a node in the graph.

This also does away with the `lean_core` nonsense, as this just makes canonization harder.

Upon testing this doesn't actually seem to make any difference, but it still seems like the right thing to do.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
