### PR TITLE
[Merged by Bors] - fix: correct universe polymorphism in SlimCheck

### DIFF
--- a/Mathlib/Control/ULiftable.lean
+++ b/Mathlib/Control/ULiftable.lean
@@ -110,6 +110,9 @@ open ULift
 instance : ULiftable id id where
   congr F := F
 
+instance : ULiftable Id Id where
+  congr F := F
+
 /-- for specific state types, this function helps to create a uliftable instance -/
 def StateT.uliftable' {m : Type u₀ → Type v₀} {m' : Type u₁ → Type v₁} [ULiftable m m']
     (F : s ≃ s') : ULiftable (StateT s m) (StateT s' m') where
@@ -120,6 +123,10 @@ def StateT.uliftable' {m : Type u₀ → Type v₀} {m' : Type u₁ → Type v�
 instance {m m'} [ULiftable m m'] : ULiftable (StateT s m) (StateT (ULift s) m') :=
   StateT.uliftable' Equiv.ulift.symm
 
+instance StateT.instULiftableULiftULift {m m'} [ULiftable m m'] :
+    ULiftable (StateT (ULift.{max v₀ u₀} s) m) (StateT (ULift.{max v₁ u₀} s) m') :=
+  StateT.uliftable' <| Equiv.ulift.trans Equiv.ulift.symm
+
 /-- for specific reader monads, this function helps to create a uliftable instance -/
 def ReaderT.uliftable' {m m'} [ULiftable m m'] (F : s ≃ s') :
     ULiftable (ReaderT s m) (ReaderT s' m') where
@@ -128,6 +135,10 @@ def ReaderT.uliftable' {m m'} [ULiftable m m'] (F : s ≃ s') :
 
 instance {m m'} [ULiftable m m'] : ULiftable (ReaderT s m) (ReaderT (ULift s) m') :=
   ReaderT.uliftable' Equiv.ulift.symm
+
+instance ReaderT.instULiftableULiftULift {m m'} [ULiftable m m'] :
+    ULiftable (ReaderT (ULift.{max v₀ u₀} s) m) (ReaderT (ULift.{max v₁ u₀} s) m') :=
+  ReaderT.uliftable' <| Equiv.ulift.trans Equiv.ulift.symm
 
 /-- for specific continuation passing monads, this function helps to create a uliftable instance -/
 def ContT.uliftable' {m m'} [ULiftable m m'] (F : r ≃ r') :
@@ -138,6 +149,10 @@ def ContT.uliftable' {m m'} [ULiftable m m'] (F : r ≃ r') :
 instance {s m m'} [ULiftable m m'] : ULiftable (ContT s m) (ContT (ULift s) m') :=
   ContT.uliftable' Equiv.ulift.symm
 
+instance ContT.instULiftableULiftULift {m m'} [ULiftable m m'] :
+    ULiftable (ContT (ULift.{max v₀ u₀} s) m) (ContT (ULift.{max v₁ u₀} s) m') :=
+  ContT.uliftable' <| Equiv.ulift.trans Equiv.ulift.symm
+
 /-- for specific writer monads, this function helps to create a uliftable instance -/
 def WriterT.uliftable' {m m'} [ULiftable m m'] (F : w ≃ w') :
     ULiftable (WriterT w m) (WriterT w' m') where
@@ -146,3 +161,7 @@ def WriterT.uliftable' {m m'} [ULiftable m m'] (F : w ≃ w') :
 
 instance {m m'} [ULiftable m m'] : ULiftable (WriterT s m) (WriterT (ULift s) m') :=
   WriterT.uliftable' Equiv.ulift.symm
+
+instance WriterT.instULiftableULiftULift {m m'} [ULiftable m m'] :
+    ULiftable (WriterT (ULift.{max v₀ u₀} s) m) (WriterT (ULift.{max v₁ u₀} s) m') :=
+  WriterT.uliftable' <| Equiv.ulift.trans Equiv.ulift.symm

--- a/Mathlib/Control/ULiftable.lean
+++ b/Mathlib/Control/ULiftable.lean
@@ -107,11 +107,9 @@ end ULiftable
 
 open ULift
 
-instance : ULiftable id id where
+instance instULiftableId : ULiftable Id Id where
   congr F := F
-
-instance : ULiftable Id Id where
-  congr F := F
+#align id.uliftable instULiftableId
 
 /-- for specific state types, this function helps to create a uliftable instance -/
 def StateT.uliftable' {m : Type u₀ → Type v₀} {m' : Type u₁ → Type v₁} [ULiftable m m']

--- a/Mathlib/Testing/SlimCheck/Gen.lean
+++ b/Mathlib/Testing/SlimCheck/Gen.lean
@@ -78,7 +78,7 @@ variable {α : Type u}
 
 /-- Create an `Array` of examples using `x`. The size is controlled
 by the size parameter of `Gen`. -/
-def arrayOf (x : Gen α) : Gen (Array α) :=do
+def arrayOf (x : Gen α) : Gen (Array α) := do
   let ⟨sz⟩ ← (ULiftable.up <| do choose Nat 0 (←getSize) (Nat.zero_le _) : Gen (ULift ℕ))
   let mut res := #[]
   for _ in [0:sz] do

--- a/Mathlib/Testing/SlimCheck/Gen.lean
+++ b/Mathlib/Testing/SlimCheck/Gen.lean
@@ -9,6 +9,7 @@ Authors: Henrik Böving, Simon Hudon
 ! if you have ported upstream changes.
 -/
 import Mathlib.Control.Random
+import Mathlib.Control.ULiftable
 import Mathlib.Data.List.Perm
 import Mathlib.Data.Subtype
 import Mathlib.Data.Nat.Basic
@@ -73,10 +74,12 @@ def getSize : Gen Nat :=
 def resize (f : Nat → Nat) (x : Gen α) : Gen α :=
   withReader (ULift.up ∘ f ∘ ULift.down) x
 
+variable {α : Type u}
+
 /-- Create an `Array` of examples using `x`. The size is controlled
 by the size parameter of `Gen`. -/
-def arrayOf (x : Gen α) : Gen (Array α) := do
-  let sz ← choose Nat 0 (←getSize) (Nat.zero_le _)
+def arrayOf (x : Gen α) : Gen (Array α) :=do
+  let ⟨sz⟩ ← (ULiftable.up <| do choose Nat 0 (←getSize) (Nat.zero_le _) : Gen (ULift ℕ))
   let mut res := #[]
   for _ in [0:sz] do
     res := res.push (← x)
@@ -89,26 +92,28 @@ def listOf (x : Gen α) : Gen (List α) :=
 
 /-- Given a list of example generators, choose one to create an example. -/
 def oneOf (xs : Array (Gen α)) (pos : 0 < xs.size := by decide) : Gen α := do
-  let ⟨x, _, h2⟩ ← chooseNatLt 0 xs.size pos
+  let ⟨x, _, h2⟩ ← ULiftable.up <| chooseNatLt 0 xs.size pos
   xs.get ⟨x, h2⟩
 
 /-- Given a list of examples, choose one to create an example. -/
 def elements (xs : List α) (pos : 0 < xs.length) : Gen α := do
-  let ⟨x, _, h2⟩ ← chooseNatLt 0 xs.length pos
+  let ⟨x, _, h2⟩ ← ULiftable.up <| chooseNatLt 0 xs.length pos
   pure $ xs.get ⟨x, h2⟩
 
 open List in
 /-- Generate a random permutation of a given list. -/
-def permutationOf : (xs : List α) → Gen { ys // ys ~ xs }
+def permutationOf : (xs : List α) → Gen { ys // xs ~ ys }
   | [] => pure ⟨[], Perm.nil⟩
   | x::xs => do
     let ⟨ys, h1⟩ ← permutationOf xs
-    let ⟨n, _, h3⟩ ← choose Nat 0 ys.length (Nat.zero_le _)
-    pure ⟨insertNth n x ys, Perm.trans (perm_insertNth _ _ h3) (Perm.cons _ h1)⟩
+    let ⟨n, _, h3⟩ ← ULiftable.up <| choose Nat 0 ys.length (Nat.zero_le _)
+    pure ⟨insertNth n x ys, Perm.trans (Perm.cons _ h1) (perm_insertNth _ _ h3).symm⟩
 
 /-- Given two generators produces a tuple consisting out of the result of both -/
-def prodOf {α β : Type u} (x : Gen α) (y : Gen β) : Gen (α × β) := do
-  pure (←x, ←y)
+def prodOf {α : Type u} {β : Type v} (x : Gen α) (y : Gen β) : Gen (α × β) := do
+  let ⟨a⟩ ← (ULiftable.up x : Gen (ULift.{max u v} α))
+  let ⟨b⟩ ← (ULiftable.up y : Gen (ULift.{max u v} β))
+  pure (a, b)
 
 end Gen
 

--- a/Mathlib/Testing/SlimCheck/Sampleable.lean
+++ b/Mathlib/Testing/SlimCheck/Sampleable.lean
@@ -218,7 +218,7 @@ def Char.sampleable (length : Nat) (chars : List Char) (pos : 0 < chars.length) 
 instance Char.sampleableDefault : SampleableExt Char :=
   Char.sampleable 3 " 0123abcABC:,;`\\/".toList (by decide)
 
-instance Prod.sampleableExt {α β : Type u} [SampleableExt α] [SampleableExt β] :
+instance Prod.sampleableExt {α : Type u} {β : Type v} [SampleableExt α] [SampleableExt β] :
     SampleableExt (α × β) where
   proxy := Prod (proxy α) (proxy β)
   proxyRepr := inferInstance


### PR DESCRIPTION
The use of auto-implicits was introducing a universe metavariable where we wanted a free variable.

The new `ULiftable` instances handle the common case of a universe polymorphic monad with a universe-lifted state from `Type`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
