### PR TITLE
[Merged by Bors] - feat(Algebra/BigOperators/Ring): parameterise `DecidableEq` instance for `Finset.prod_add`

### DIFF
--- a/Mathlib/Algebra/BigOperators/Ring.lean
+++ b/Mathlib/Algebra/BigOperators/Ring.lean
@@ -205,8 +205,7 @@ theorem prod_one_sub_ordered {ι R : Type _} [CommRing R] [LinearOrder ι] (s : 
 
 /-- Summing `a^s.card * b^(n-s.card)` over all finite subsets `s` of a `Finset`
 gives `(a + b)^s.card`.-/
-theorem sum_pow_mul_eq_add_pow {α R : Type _} [CommSemiring R] (a b : R)
-  (s : Finset α) :
+theorem sum_pow_mul_eq_add_pow {α R : Type _} [CommSemiring R] (a b : R) (s : Finset α) :
     (∑ t in s.powerset, a ^ t.card * b ^ (s.card - t.card)) = (a + b) ^ s.card := by
   classical
   rw [← prod_const, prod_add]

--- a/Mathlib/Algebra/BigOperators/Ring.lean
+++ b/Mathlib/Algebra/BigOperators/Ring.lean
@@ -205,9 +205,10 @@ theorem prod_one_sub_ordered {ι R : Type _} [CommRing R] [LinearOrder ι] (s : 
 
 /-- Summing `a^s.card * b^(n-s.card)` over all finite subsets `s` of a `Finset`
 gives `(a + b)^s.card`.-/
-theorem sum_pow_mul_eq_add_pow {α R : Type _} [DecidableEq α] [CommSemiring R] (a b : R)
+theorem sum_pow_mul_eq_add_pow {α R : Type _} [CommSemiring R] (a b : R)
   (s : Finset α) :
     (∑ t in s.powerset, a ^ t.card * b ^ (s.card - t.card)) = (a + b) ^ s.card := by
+  classical
   rw [← prod_const, prod_add]
   refine' Finset.sum_congr rfl fun t ht => _
   rw [prod_const, prod_const, ← card_sdiff (mem_powerset.1 ht)]

--- a/Mathlib/Algebra/BigOperators/Ring.lean
+++ b/Mathlib/Algebra/BigOperators/Ring.lean
@@ -1,5 +1,5 @@
 /-
-Coypright (c) 2017 Johannes Hölzl. All rights reserved.
+Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl
 
@@ -211,7 +211,8 @@ theorem prod_one_sub_ordered {ι R : Type _} [CommRing R] [LinearOrder ι] (s : 
 
 /-- Summing `a^s.card * b^(n-s.card)` over all finite subsets `s` of a `Finset`
 gives `(a + b)^s.card`.-/
-theorem sum_pow_mul_eq_add_pow {α R : Type _} [DecidableEq α] [CommSemiring R] (a b : R) (s : Finset α) :
+theorem sum_pow_mul_eq_add_pow {α R : Type _} [DecidableEq α] [CommSemiring R] (a b : R)
+  (s : Finset α) :
     (∑ t in s.powerset, a ^ t.card * b ^ (s.card - t.card)) = (a + b) ^ s.card := by
   rw [← prod_const, prod_add]
   refine' Finset.sum_congr rfl fun t ht => _

--- a/Mathlib/Algebra/BigOperators/Ring.lean
+++ b/Mathlib/Algebra/BigOperators/Ring.lean
@@ -128,18 +128,18 @@ theorem prod_sum {δ : α → Type _} [DecidableEq α] [∀ a, DecidableEq (δ a
   over the powerset of `s` of the product of `f` over a subset `t` times
   the product of `g` over the complement of `t`  -/
 theorem prod_add [DecidableEq α] (f g : α → β) (s : Finset α) :
-    ∏ a in s, (f a + g a) = ∑ t in s.powerset, (∏ a in t, f a) * ∏ a in s \ t, g a :=
+    ∏ a in s, (f a + g a) = ∑ t in s.powerset, (∏ a in t, f a) * ∏ a in s \ t, g a := by
+  classical
   calc
     ∏ a in s, (f a + g a) =
-        ∏ a in s, ∑ p in ({true, false} : Finset Bool), if p then f a else g a :=
+        ∏ a in s, ∑ p in ({True, False} : Finset Prop), if p then f a else g a :=
       by simp
-    _ = ∑ p in (s.pi fun _ => {true, false} : Finset (∀ a ∈ s, Bool)),
+    _ = ∑ p in (s.pi fun _ => {True, False} : Finset (∀ a ∈ s, Prop)),
           ∏ a in s.attach, if p a.1 a.2 then f a.1 else g a.1 :=
       prod_sum
     _ = ∑ t in s.powerset, (∏ a in t, f a) * ∏ a in s \ t, g a :=
       sum_bij'
-        (fun (f: ∀ a ∈ s, Bool) _ =>
-          s.filter (fun a : α => ∀ h : a ∈ s, f a h))
+        (fun f _ => s.filter (fun a => ∀ h : a ∈ s, f a h))
         (by simp)
         (fun a _ => by
           rw [prod_ite]
@@ -152,19 +152,11 @@ theorem prod_add [DecidableEq α] (f g : α → β) (s : Finset α) :
             (fun a _ => a.1) (by simp) (by simp)
             (fun a ha => ⟨a, (mem_sdiff.1 ha).1⟩) (fun a ha => by simp at ha; simp; tauto)
             (by simp) (by simp))
-        (fun t _ a  _ => if a ∈ t then true else false)
-        (by
-          simp_rw [mem_singleton, mem_pi, mem_insert, ite_eq_left_iff, mem_singleton,
-            ite_eq_right_iff, mem_powerset]; tauto)
-        (by
-          simp [Function.funext_iff];
-          intro a _ a1 ha1
-          by_cases h : a a1 ha1
-          · rw [h, if_pos]
-            exact ⟨ ha1, fun _ => h ⟩
-          · rw [Bool.eq_false_of_ne_true h, if_neg]
-            tauto)
-        (by simp_rw [ite_eq_left_iff, ext_iff, mem_filter, mem_powerset]; tauto)
+        (fun t _ a  _ => a ∈ t)
+        (by simp [Classical.em])
+        (by simp_rw [mem_filter, Function.funext_iff, eq_iff_iff, mem_singleton, mem_pi,
+          mem_insert, iff_true, iff_false]; tauto)
+        (by simp_rw [ext_iff, @mem_filter _ _ (id _), mem_powerset]; tauto)
 #align finset.prod_add Finset.prod_add
 
 /-- `∏ i, (f i + g i) = (∏ i, f i) + ∑ i, g i * (∏ j < i, f j + g j) * (∏ j > i, f j)`. -/

--- a/Mathlib/Algebra/BigOperators/Ring.lean
+++ b/Mathlib/Algebra/BigOperators/Ring.lean
@@ -153,7 +153,9 @@ theorem prod_add [DecidableEq α] (f g : α → β) (s : Finset α) :
             (fun a ha => ⟨a, (mem_sdiff.1 ha).1⟩) (fun a ha => by simp at ha; simp; tauto)
             (by simp) (by simp))
         (fun t _ a  _ => if a ∈ t then true else false)
-        (by simp; tauto)
+        (by
+          simp_rw [mem_singleton, mem_pi, mem_insert, ite_eq_left_iff, mem_singleton,
+            ite_eq_right_iff, mem_powerset]; tauto)
         (by
           simp [Function.funext_iff];
           intro a _ a1 ha1
@@ -162,7 +164,7 @@ theorem prod_add [DecidableEq α] (f g : α → β) (s : Finset α) :
             exact ⟨ ha1, fun _ => h ⟩
           · rw [Bool.eq_false_of_ne_true h, if_neg]
             tauto)
-        (by simp [Finset.ext_iff, @mem_filter _ _ (id _)]; tauto)
+        (by simp_rw [ite_eq_left_iff, ext_iff, mem_filter, mem_powerset]; tauto)
 #align finset.prod_add Finset.prod_add
 
 /-- `∏ i, (f i + g i) = (∏ i, f i) + ∑ i, g i * (∏ j < i, f j + g j) * (∏ j > i, f j)`. -/

--- a/Mathlib/Data/Fintype/BigOperators.lean
+++ b/Mathlib/Data/Fintype/BigOperators.lean
@@ -198,7 +198,8 @@ theorem Finset.prod_univ_sum [DecidableEq α] [Fintype α] [CommSemiring β] {δ
 gives `(a + b)^n`. The "good" proof involves expanding along all coordinates using the fact that
 `x^n` is multilinear, but multilinear maps are only available now over rings, so we give instead
 a proof reducing to the usual binomial theorem to have a result over semirings. -/
-theorem Fintype.sum_pow_mul_eq_add_pow (α : Type _) [Fintype α] {R : Type _} [CommSemiring R]
+theorem Fintype.sum_pow_mul_eq_add_pow (α : Type _) [DecidableEq α] [Fintype α] {R : Type _}
+  [CommSemiring R]
     (a b : R) :
     (∑ s : Finset α, a ^ s.card * b ^ (Fintype.card α - s.card)) = (a + b) ^ Fintype.card α :=
   Finset.sum_pow_mul_eq_add_pow _ _ _

--- a/Mathlib/Data/Fintype/BigOperators.lean
+++ b/Mathlib/Data/Fintype/BigOperators.lean
@@ -198,11 +198,11 @@ theorem Finset.prod_univ_sum [DecidableEq α] [Fintype α] [CommSemiring β] {δ
 gives `(a + b)^n`. The "good" proof involves expanding along all coordinates using the fact that
 `x^n` is multilinear, but multilinear maps are only available now over rings, so we give instead
 a proof reducing to the usual binomial theorem to have a result over semirings. -/
-theorem Fintype.sum_pow_mul_eq_add_pow (α : Type _) [DecidableEq α] [Fintype α] {R : Type _}
-  [CommSemiring R]
+theorem Fintype.sum_pow_mul_eq_add_pow (α : Type _) [Fintype α] {R : Type _} [CommSemiring R]
     (a b : R) :
-    (∑ s : Finset α, a ^ s.card * b ^ (Fintype.card α - s.card)) = (a + b) ^ Fintype.card α :=
-  Finset.sum_pow_mul_eq_add_pow _ _ _
+    (∑ s : Finset α, a ^ s.card * b ^ (Fintype.card α - s.card)) = (a + b) ^ Fintype.card α := by
+  classical
+  exact Finset.sum_pow_mul_eq_add_pow _ _ _
 #align fintype.sum_pow_mul_eq_add_pow Fintype.sum_pow_mul_eq_add_pow
 
 @[to_additive]

--- a/Mathlib/Data/Fintype/BigOperators.lean
+++ b/Mathlib/Data/Fintype/BigOperators.lean
@@ -200,9 +200,8 @@ gives `(a + b)^n`. The "good" proof involves expanding along all coordinates usi
 a proof reducing to the usual binomial theorem to have a result over semirings. -/
 theorem Fintype.sum_pow_mul_eq_add_pow (α : Type _) [Fintype α] {R : Type _} [CommSemiring R]
     (a b : R) :
-    (∑ s : Finset α, a ^ s.card * b ^ (Fintype.card α - s.card)) = (a + b) ^ Fintype.card α := by
-  classical
-  exact Finset.sum_pow_mul_eq_add_pow _ _ _
+    (∑ s : Finset α, a ^ s.card * b ^ (Fintype.card α - s.card)) = (a + b) ^ Fintype.card α :=
+  Finset.sum_pow_mul_eq_add_pow _ _ _
 #align fintype.sum_pow_mul_eq_add_pow Fintype.sum_pow_mul_eq_add_pow
 
 @[to_additive]


### PR DESCRIPTION
Remove the use of a classical `DecidableEq` instance from `Finset.prod_add`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
[Zulip](https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/Finset.2Eprod_add.20decidability.20diamond)
This will have to wait until after the port as it affects the existing api.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
