### PR TITLE
[Merged by Bors] - fix: remove unneeded import

### DIFF
--- a/Mathlib/LinearAlgebra/BilinearForm.lean
+++ b/Mathlib/LinearAlgebra/BilinearForm.lean
@@ -9,7 +9,6 @@ Authors: Andreas Swerdlow, Kexing Ying
 ! if you have ported upstream changes.
 -/
 import Mathlib.LinearAlgebra.Dual
---import Mathlib.LinearAlgebra.FreeModule.Finite.Matrix
 
 /-!
 # Bilinear form

--- a/Mathlib/LinearAlgebra/BilinearForm.lean
+++ b/Mathlib/LinearAlgebra/BilinearForm.lean
@@ -9,7 +9,7 @@ Authors: Andreas Swerdlow, Kexing Ying
 ! if you have ported upstream changes.
 -/
 import Mathlib.LinearAlgebra.Dual
-import Mathlib.LinearAlgebra.FreeModule.Finite.Matrix
+--import Mathlib.LinearAlgebra.FreeModule.Finite.Matrix
 
 /-!
 # Bilinear form


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

I was optimistic that we had the matrix associated to a bilinear form until I found that the import was not used :-/