### PR TITLE
feat: add `rw_equiv` tactic

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2996,6 +2996,7 @@ import Mathlib.Tactic.Rename
 import Mathlib.Tactic.RenameBVar
 import Mathlib.Tactic.Replace
 import Mathlib.Tactic.RestateAxiom
+import Mathlib.Tactic.RewriteEquiv
 import Mathlib.Tactic.Rewrites
 import Mathlib.Tactic.Ring
 import Mathlib.Tactic.Ring.Basic

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -119,8 +119,8 @@ import Mathlib.Tactic.Rename
 import Mathlib.Tactic.RenameBVar
 import Mathlib.Tactic.Replace
 import Mathlib.Tactic.RestateAxiom
-import Mathlib.Tactic.Rewrites
 import Mathlib.Tactic.RewriteEquiv
+import Mathlib.Tactic.Rewrites
 import Mathlib.Tactic.Ring
 import Mathlib.Tactic.Ring.Basic
 import Mathlib.Tactic.Ring.RingNF

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -120,6 +120,7 @@ import Mathlib.Tactic.RenameBVar
 import Mathlib.Tactic.Replace
 import Mathlib.Tactic.RestateAxiom
 import Mathlib.Tactic.Rewrites
+import Mathlib.Tactic.RewriteEquiv
 import Mathlib.Tactic.Ring
 import Mathlib.Tactic.Ring.Basic
 import Mathlib.Tactic.Ring.RingNF

--- a/Mathlib/Tactic/RewriteEquiv.lean
+++ b/Mathlib/Tactic/RewriteEquiv.lean
@@ -1,0 +1,65 @@
+/-
+Copyright (c) 2023 Alex Keizer. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Alex Keizer
+-/
+import Lean
+import Qq
+import Mathlib.Logic.Equiv.Defs
+
+/-!
+# The `rw_equiv` tactic
+
+Given an equivalence `α ≃ β`, rewrite the type of variables `x : α` in the local context to `x : β`.
+The tactic performs roughly the following steps:
+  * rewrite `x` to `invFun (toFun x)`
+  * `generalize toFun x = x`
+  * Clear the original, now-shadowed, declaration of `x` from the context
+-/
+
+namespace Mathlib.Tactic.RewriteEquiv
+open Lean Elab Meta Tactic
+open Qq
+
+/-- Rewrite the type of variables `x : α` in the local context along an equivalence `α ≃ β` -/
+def rewriteEquiv (α : Q(Sort u)) (β : Q(Sort v)) (eqv : Q($α ≃ $β)) : TacticM Unit := do
+  let mut genArgs : Array GeneralizeArg := #[]
+  let mut clearIds : Array FVarId := #[]
+  for decl in ←getLCtx do
+    if ←isDefEq decl.type α then
+      -- HACK: `Qq` doesn't like it if the following is `let` instead of `have`
+      have var : Q($α) := decl.toExpr
+
+      -- Rewrite `$var` to `invFun <| toFun $var`
+      let newVar : Q($β) := q(Equiv.toFun $eqv <| $var)
+      let eq : Q($var = (Equiv.invFun $eqv $newVar)) :=
+        q(Eq.symm <| Equiv.left_inv $eqv $var)
+      let r ← (← getMainGoal).rewrite (← getMainTarget) eq false
+      let mvarId' ← (← getMainGoal).replaceTargetEq r.eNew r.eqProof
+      replaceMainGoal (mvarId' :: r.mvarIds)
+
+      -- Record the arguments needed to generalize `toFun $var`
+      genArgs := genArgs.push {
+        expr    := newVar
+        xName?  := decl.userName
+      }
+      clearIds := clearIds.push decl.fvarId
+
+  -- Perform the generalizations recorded in `genArgs`, and clear the variables in `clear`
+  withMainContext <| do
+    let (_, _, mvarId) ← (←getMainGoal).generalizeHyp genArgs (←getLCtx).getFVarIds
+    let mvarId ← mvarId.tryClearMany clearIds
+    replaceMainGoal [mvarId]
+
+/-- Rewrite the type of variables `x : α` in the local context along an equivalence `α ≃ β` -/
+elab "rw_equiv " "[" eqvs:term,* "]" : tactic => do
+  for eqv in eqvs.getElems do
+    withMainContext <| do
+      let u ← mkFreshLevelMVar;
+      let v ← mkFreshLevelMVar;
+      let α : Q(Sort u) ← mkFreshExprMVarQ q(Sort u);
+      let β : Q(Sort v) ← mkFreshExprMVarQ q(Sort v);
+      let eqv : Q($α ≃ $β) ← elabTermEnsuringTypeQ eqv q($α ≃ $β)
+      rewriteEquiv α β eqv
+
+end Mathlib.Tactic.RewriteEquiv


### PR DESCRIPTION
Given an equivalence `eqv : α ≃ β`, the `rw_equiv` tactic rewrites the type of variables `x : α` in the local context to `x : β`.
The tactic performs roughly the following steps:
  * rewrite `x` to `eqv.invFun (eqv.toFun x)`
  * `generalize eqv.toFun x = x`
  * Clear the original, now-shadowed, declaration of `x` from the context

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

I've been in a few discussions over the past weeks centred on the question whether representation Foo or Bar is more appropriate for some type, where Foo and Bar are equivalent types.

This tactic aims to make that choice less important, by making it easier to context switch between a goal stated in terms of `Foo` to a goal in terms of `Bar`.

The current PR only adds a tactic to change the type of variable in the context, but I also intend to develop a slightly more advanced `simp_equiv` tactic in a subsequent PR, which will allow us to register structure-preservation lemmas along the line of the following
```lean
def Foo.ofBar : Foo -> Bar
  := sorry

def Foo.add : Foo -> Foo -> Foo
  := sorry

def Bar.add : Bar -> Bar-> Bar
  := sorry

@[simp_equiv] -- register the following theorem as "structure-preservation" simp-lemma
theorem Foo.add_ofBar (x y : Bar) :
  add (ofBar x) (ofBar y) = ofBar (Bar.add x y)
```

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
