### PR TITLE
[Merged by Bors] - chore (CategoryTheory.Monad.Monadicity): un-leak notation

### DIFF
--- a/Mathlib/CategoryTheory/Monad/Monadicity.lean
+++ b/Mathlib/CategoryTheory/Monad/Monadicity.lean
@@ -55,18 +55,16 @@ noncomputable section
 namespace MonadicityInternal
 
 variable {C : Type u₁} {D : Type u₂}
-
 variable [Category.{v₁} C] [Category.{v₁} D]
-
 variable {G : D ⥤ C} [IsRightAdjoint G]
 
--- Porting note: had to turn off hygiene
--- These notations still require parentheses around them, unlike in mathlib3.
-set_option hygiene false in
-scoped notation "F" => leftAdjoint G
-
-set_option hygiene false in
-scoped notation "adj" => Adjunction.ofRightAdjoint G
+-- An unfortunate consequence of the local notation is that it is only recognised if there
+-- is some syntax to separate it from dot notation.
+-- Porting note: in Lean 3 you could write `F .map A.a` for example, but in Lean 4 that would
+-- mean passing two arguments to `F` (`.map` and `A.a`). We write `(F).map A.a` instead.
+-- As a warning, this pretty prints as `F.map A.a`.
+local notation3 "F" => leftAdjoint G
+local notation3 "adj" => Adjunction.ofRightAdjoint G
 
 /-- The "main pair" for an algebra `(A, α)` is the pair of morphisms `(F α, ε_FA)`. It is always a
 reflexive pair, and will be used to construct the left adjoint to the comparison functor and show it
@@ -247,18 +245,10 @@ theorem comparisonAdjunction_counit_app
 
 end MonadicityInternal
 
-open CategoryTheory
-
-open Adjunction
-
-open Monad
-
-open MonadicityInternal
+open CategoryTheory Adjunction Monad MonadicityInternal
 
 variable {C : Type u₁} {D : Type u₂}
-
 variable [Category.{v₁} C] [Category.{v₁} D]
-
 variable {G : D ⥤ C}
 
 /--
@@ -281,6 +271,10 @@ set_option linter.uppercaseLean3 false in
 variable [IsRightAdjoint G]
 
 section BeckMonadicity
+
+-- Porting note: these local notations were not used in this section before
+local notation3 "F" => leftAdjoint G
+local notation3 "adj" => Adjunction.ofRightAdjoint G
 
 -- Porting note: added these to replace parametric instances lean4#2311
 -- When this is fixed the proofs below that struggle with instances should be reviewed.
@@ -415,6 +409,10 @@ end BeckMonadicity
 section ReflexiveMonadicity
 
 variable [HasReflexiveCoequalizers D] [ReflectsIsomorphisms G]
+
+-- Porting note: these local notations were not used in this section before
+local notation3 "F" => leftAdjoint G
+local notation3 "adj" => Adjunction.ofRightAdjoint G
 
 -- Porting note: added these to replace parametric instances lean4#2311
 -- [∀ ⦃A B⦄ (f g : A ⟶ B) [G.IsReflexivePair f g], PreservesColimit (parallelPair f g) G] :

--- a/Mathlib/CategoryTheory/Monad/Monadicity.lean
+++ b/Mathlib/CategoryTheory/Monad/Monadicity.lean
@@ -272,10 +272,6 @@ variable [IsRightAdjoint G]
 
 section BeckMonadicity
 
--- Porting note: these local notations were not used in this section before
-local notation3 "F" => leftAdjoint G
-local notation3 "adj" => Adjunction.ofRightAdjoint G
-
 -- Porting note: added these to replace parametric instances lean4#2311
 -- When this is fixed the proofs below that struggle with instances should be reviewed.
 -- [∀ ⦃A B⦄ (f g : A ⟶ B) [G.IsSplitPair f g], HasCoequalizer f g]
@@ -287,8 +283,8 @@ class HasCoequalizerOfIsSplitPair (G : D ⥤ C) where
 --     HasCoequalizer f g := HasCoequalizerOfIsSplitPair.out f g
 
 instance [HasCoequalizerOfIsSplitPair G] : ∀ (A : Algebra (toMonad (ofRightAdjoint G))),
-    HasCoequalizer ((F).map A.a)
-      ((ofRightAdjoint G).counit.app ((F).obj A.A)) :=
+    HasCoequalizer ((leftAdjoint G).map A.a)
+      ((ofRightAdjoint G).counit.app ((leftAdjoint G).obj A.A)) :=
   fun _ => HasCoequalizerOfIsSplitPair.out G _ _
 
 -- Porting note: added these to replace parametric instances lean4#2311
@@ -300,8 +296,8 @@ instance {A B} (f g : A ⟶  B) [G.IsSplitPair f g] [PreservesColimitOfIsSplitPa
     PreservesColimit (parallelPair f g) G := PreservesColimitOfIsSplitPair.out f g
 
 instance [PreservesColimitOfIsSplitPair G] : ∀ (A: Algebra (toMonad (ofRightAdjoint G))),
-   PreservesColimit (parallelPair ((F).map A.a)
-      (NatTrans.app (adj).counit ((F).obj A.A))) G :=
+   PreservesColimit (parallelPair ((leftAdjoint G).map A.a)
+      (NatTrans.app (Adjunction.ofRightAdjoint G).counit ((leftAdjoint G).obj A.A))) G :=
   fun _ => PreservesColimitOfIsSplitPair.out _ _
 
 -- Porting note: added these to replace parametric instances lean4#2311
@@ -313,8 +309,8 @@ instance {A B} (f g : A ⟶  B) [G.IsSplitPair f g] [ReflectsColimitOfIsSplitPai
     ReflectsColimit (parallelPair f g) G := ReflectsColimitOfIsSplitPair.out f g
 
 instance [ReflectsColimitOfIsSplitPair G] : ∀ (A: Algebra (toMonad (ofRightAdjoint G))),
-    ReflectsColimit (parallelPair ((F).map A.a)
-      (NatTrans.app (adj).counit ((F).obj A.A))) G :=
+    ReflectsColimit (parallelPair ((leftAdjoint G).map A.a)
+      (NatTrans.app (Adjunction.ofRightAdjoint G).counit ((leftAdjoint G).obj A.A))) G :=
   fun _ => ReflectsColimitOfIsSplitPair.out _ _
 
 /-- To show `G` is a monadic right adjoint, we can show it preserves and reflects `G`-split
@@ -346,9 +342,9 @@ def monadicOfHasPreservesReflectsGSplitCoequalizers [HasCoequalizerOfIsSplitPair
     -- Porting note: passing instances through
     apply @counitCoequalizerOfReflectsCoequalizer _ _ _ _ _ _ _ ?_
     letI _ :
-      G.IsSplitPair ((F).map (G.map ((adj).counit.app Y)))
-        ((adj).counit.app ((F).obj (G.obj Y))) :=
-      MonadicityInternal.main_pair_G_split ((comparison (adj)).obj Y)
+      G.IsSplitPair ((leftAdjoint G).map (G.map ((Adjunction.ofRightAdjoint G).counit.app Y)))
+        ((Adjunction.ofRightAdjoint G).counit.app ((leftAdjoint G).obj (G.obj Y))) :=
+      MonadicityInternal.main_pair_G_split ((comparison (Adjunction.ofRightAdjoint G)).obj Y)
     infer_instance
   exact Adjunction.isRightAdjointToIsEquivalence
 set_option linter.uppercaseLean3 false in
@@ -363,8 +359,8 @@ instance {A B} (f g : A ⟶  B) [G.IsSplitPair f g] [CreatesColimitOfIsSplitPair
     CreatesColimit (parallelPair f g) G := CreatesColimitOfIsSplitPair.out f g
 
 instance [CreatesColimitOfIsSplitPair G] : ∀ (A: Algebra (toMonad (ofRightAdjoint G))),
-    CreatesColimit (parallelPair ((F).map A.a)
-      (NatTrans.app (adj).counit ((F).obj A.A))) G :=
+    CreatesColimit (parallelPair ((leftAdjoint G).map A.a)
+      (NatTrans.app (Adjunction.ofRightAdjoint G).counit ((leftAdjoint G).obj A.A))) G :=
   fun _ => CreatesColimitOfIsSplitPair.out _ _
 
 /--
@@ -410,10 +406,6 @@ section ReflexiveMonadicity
 
 variable [HasReflexiveCoequalizers D] [ReflectsIsomorphisms G]
 
--- Porting note: these local notations were not used in this section before
-local notation3 "F" => leftAdjoint G
-local notation3 "adj" => Adjunction.ofRightAdjoint G
-
 -- Porting note: added these to replace parametric instances lean4#2311
 -- [∀ ⦃A B⦄ (f g : A ⟶ B) [G.IsReflexivePair f g], PreservesColimit (parallelPair f g) G] :
 class PreservesColimitOfIsReflexivePair (G : C ⥤ D) where
@@ -423,8 +415,8 @@ instance {A B} (f g : A ⟶  B) [IsReflexivePair f g] [PreservesColimitOfIsRefle
   PreservesColimit (parallelPair f g) G := PreservesColimitOfIsReflexivePair.out f g
 
 instance [PreservesColimitOfIsReflexivePair G] : ∀ X : Algebra (toMonad (ofRightAdjoint G)),
-    PreservesColimit (parallelPair ((F).map X.a)
-      (NatTrans.app (adj).counit ((F).obj X.A))) G :=
+    PreservesColimit (parallelPair ((leftAdjoint G).map X.a)
+      (NatTrans.app (Adjunction.ofRightAdjoint G).counit ((leftAdjoint G).obj X.A))) G :=
  fun _ => PreservesColimitOfIsReflexivePair.out _ _
 
 variable [PreservesColimitOfIsReflexivePair G]
@@ -433,13 +425,13 @@ variable [PreservesColimitOfIsReflexivePair G]
 reflexive coequalizers and `G` reflects isomorphisms, then `G` is monadic.
 -/
 def monadicOfHasPreservesReflexiveCoequalizersOfReflectsIsomorphisms : MonadicRightAdjoint G := by
-  letI i : IsRightAdjoint (comparison (adj)) :=
+  letI i : IsRightAdjoint (comparison (Adjunction.ofRightAdjoint G)) :=
     ⟨_, comparisonAdjunction⟩
   constructor
-  let _ : ∀ X : (adj).toMonad.Algebra,
-      IsIso ((Adjunction.ofRightAdjoint (comparison (adj))).unit.app X) := by
+  let _ : ∀ X : (Adjunction.ofRightAdjoint G).toMonad.Algebra,
+      IsIso ((Adjunction.ofRightAdjoint (comparison (Adjunction.ofRightAdjoint G))).unit.app X) := by
     intro X
-    apply @isIso_of_reflects_iso _ _ _ _ _ _ _ (Monad.forget (adj).toMonad) ?_ _
+    apply @isIso_of_reflects_iso _ _ _ _ _ _ _ (Monad.forget (Adjunction.ofRightAdjoint G).toMonad) ?_ _
     · change IsIso (comparisonAdjunction.unit.app X).f
       rw [comparisonAdjunction_unit_f]
       change
@@ -447,7 +439,7 @@ def monadicOfHasPreservesReflexiveCoequalizersOfReflectsIsomorphisms : MonadicRi
           (IsColimit.coconePointUniqueUpToIso (beckCoequalizer X)
               (unitColimitOfPreservesCoequalizer X)).hom
       apply IsIso.of_iso (IsColimit.coconePointUniqueUpToIso _ _)
-  let _ : ∀ Y : D, IsIso ((ofRightAdjoint (comparison (adj))).counit.app Y) := by
+  let _ : ∀ Y : D, IsIso ((ofRightAdjoint (comparison (Adjunction.ofRightAdjoint G))).counit.app Y) := by
     intro Y
     change IsIso (comparisonAdjunction.counit.app Y)
     rw [comparisonAdjunction_counit_app]

--- a/Mathlib/CategoryTheory/Monad/Monadicity.lean
+++ b/Mathlib/CategoryTheory/Monad/Monadicity.lean
@@ -429,9 +429,11 @@ def monadicOfHasPreservesReflexiveCoequalizersOfReflectsIsomorphisms : MonadicRi
     ⟨_, comparisonAdjunction⟩
   constructor
   let _ : ∀ X : (Adjunction.ofRightAdjoint G).toMonad.Algebra,
-      IsIso ((Adjunction.ofRightAdjoint (comparison (Adjunction.ofRightAdjoint G))).unit.app X) := by
+      IsIso ((Adjunction.ofRightAdjoint (comparison (Adjunction.ofRightAdjoint G))).unit.app X)
+    := by
     intro X
-    apply @isIso_of_reflects_iso _ _ _ _ _ _ _ (Monad.forget (Adjunction.ofRightAdjoint G).toMonad) ?_ _
+    apply
+      @isIso_of_reflects_iso _ _ _ _ _ _ _ (Monad.forget (Adjunction.ofRightAdjoint G).toMonad) ?_ _
     · change IsIso (comparisonAdjunction.unit.app X).f
       rw [comparisonAdjunction_unit_f]
       change
@@ -439,7 +441,8 @@ def monadicOfHasPreservesReflexiveCoequalizersOfReflectsIsomorphisms : MonadicRi
           (IsColimit.coconePointUniqueUpToIso (beckCoequalizer X)
               (unitColimitOfPreservesCoequalizer X)).hom
       apply IsIso.of_iso (IsColimit.coconePointUniqueUpToIso _ _)
-  let _ : ∀ Y : D, IsIso ((ofRightAdjoint (comparison (Adjunction.ofRightAdjoint G))).counit.app Y) := by
+  let _ : ∀ Y : D,
+      IsIso ((ofRightAdjoint (comparison (Adjunction.ofRightAdjoint G))).counit.app Y) := by
     intro Y
     change IsIso (comparisonAdjunction.counit.app Y)
     rw [comparisonAdjunction_counit_app]


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

- [x] depends on: #5826

Notation had leaked from `MonadicityInternal` (in #5088) into other sections  and should not have.
This removes the leaked notation.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
