### PR TITLE
[Merged by Bors] - fix: control flow errors in `congr!`, and add closePre and closePost for feature parity with `congr`

### DIFF
--- a/Mathlib/Tactic/Congr!.lean
+++ b/Mathlib/Tactic/Congr!.lean
@@ -26,10 +26,18 @@ initialize registerTraceClass `congr!.synthesize
 
 /-- The configuration for the `congr!` tactic. -/
 structure Congr!.Config where
+  /-- If `closePre := true`, then try to close goals before applying congruence lemmas
+  using tactics such as `rfl` and `assumption.  These tactics are applied with the
+  transparency level specified by `preTransparency`, which is `.reducible` by default. -/
+  closePre : Bool := true
+  /-- If `closePost := true`, then try to close goals that remain after no more congruence
+  lemmas can be applied, using the same tactics as `closePre`. These tactics are applied
+  with current tactic transparency level. -/
+  closePost : Bool := true
   /-- The transparency level to use when applying a congruence theorem.
   By default this is `.reducible`, which prevents unfolding of most definitions. -/
   transparency : TransparencyMode := TransparencyMode.reducible
-  /-- The transparency level to use when doing transformations before applying congruence lemmas.
+  /-- The transparency level to use when trying to close goals before applying congruence lemmas.
   This includes trying to prove the goal by `rfl` and using the `assumption` tactic.
   By default this is `.reducible`, which prevents unfolding of most definitions. -/
   preTransparency : TransparencyMode := TransparencyMode.reducible
@@ -40,7 +48,7 @@ structure Congr!.Config where
   This can be used to control which side's definitions are expanded when applying the
   congruence lemma (if `preferLHS = true` then the RHS can be expanded). -/
   preferLHS : Bool := true
-  /-- Allow both sides to be a partial applications.
+  /-- Allow both sides to be partial applications.
   When false, given an equality `f a b = g x y z` this means we never consider
   proving `f a = g x y`.
 
@@ -48,7 +56,7 @@ structure Congr!.Config where
   left-hand side. Use `sameFun := true` to ensure both sides are applications
   of the same function (making it be similar to the `congr` tactic). -/
   partialApp : Bool := true
-  /-- Whether to require that both sides of an equality are applications of defeq functions.
+  /-- Whether to require that both sides of an equality be applications of defeq functions.
   That is, if true, `f a = g x` is only considered if `f` and `g` are defeq (making it be similar
   to the `congr` tactic). -/
   sameFun : Bool := false
@@ -281,7 +289,7 @@ partial def Congr!.mkHCongrThm (fType : Expr) (info : FunInfo)
 where
   /-- Similar to doing `forallBoundedTelescope` twice, but makes use of the `fixed` array, which
   is used as a hint for whether both variables should be the same. This is only a hint though,
-  since we only respect it if the binding domains are equal.
+  since we only respect it only if the binding domains are equal.
   We affix `'` to the second list of variables, and all the variables are introduced
   with default binder info. Calls `k` with the xs, ys, and a revised `fixed` array -/
   doubleTelescope {α} (fty : Expr) (numVars : Nat) (fixed : Array Bool)
@@ -748,8 +756,9 @@ where
         let mvarId := (← eqImpOfIffImp mvarId).getD mvarId
         let ty ← withReducible <| mvarId.getType'
         if ty.isArrow then
-          if (← isTrivialType ty.bindingDomain!)
-              || (← getLCtx).any (fun decl => decl.type == ty.bindingDomain!) then
+          if ← (isTrivialType ty.bindingDomain!
+                <||> (← getLCtx).anyM (fun decl => do
+                        return (← instantiateMVars decl.type) == ty.bindingDomain!)) then
             -- Don't intro, clear it
             let mvar ← mkFreshExprSyntheticOpaqueMVar ty.bindingBody! (← mvarId.getTag)
             mvarId.assign <| .lam .anonymous ty.bindingDomain! mvar .default
@@ -763,9 +772,9 @@ where
       else
         return [mvarId]
   isTrivialType (ty : Expr) : MetaM Bool := do
-    let ty ← instantiateMVars ty
     unless ← Meta.isProp ty do
       return false
+    let ty ← instantiateMVars ty
     if let some (lhs, rhs) := ty.eqOrIff? then
       if lhs.cleanupAnnotations == rhs.cleanupAnnotations then
         return true
@@ -776,28 +785,31 @@ where
     return false
 
 /-- Convert a goal into an `Eq` goal if possible (since we have a better shot at those).
-Also try to dispatch the goal using an assumption, `Subsingleton.Elim`, or definitional equality. -/
-def Lean.MVarId.preCongr! (mvarId : MVarId) : MetaM (Option MVarId) := do
+Also, if `tryClose := true`, then try to close the goal using an assumption, `Subsingleton.Elim`,
+or definitional equality. -/
+def Lean.MVarId.preCongr! (mvarId : MVarId) (tryClose : Bool) : MetaM (Option MVarId) := do
   -- Next, turn `HEq` and `Iff` into `Eq`
   let mvarId ← mvarId.heqOfEq
-  -- This is a good time to check whether we have a relevant hypothesis.
-  if ← mvarId.assumptionCore then return none
+  if tryClose then
+    -- This is a good time to check whether we have a relevant hypothesis.
+    if ← mvarId.assumptionCore then return none
   let mvarId ← mvarId.iffOfEq
-  -- Now try definitional equality. No need to try `mvarId.hrefl` since we already did `heqOfEq`.
-  -- We allow synthetic opaque metavariables to be assigned to fill in `x = _` goals that might
-  -- appear (for example, due to using `convert` with placeholders).
-  try withAssignableSyntheticOpaque mvarId.refl; return none catch _ => pure ()
-  -- Now we go for (heterogenous) equality via subsingleton considerations
-  if ← mvarId.subsingletonElim then return none
-  if ← mvarId.proofIrrelHeq then return none
+  if tryClose then
+    -- Now try definitional equality. No need to try `mvarId.hrefl` since we already did `heqOfEq`.
+    -- We allow synthetic opaque metavariables to be assigned to fill in `x = _` goals that might
+    -- appear (for example, due to using `convert` with placeholders).
+    try withAssignableSyntheticOpaque mvarId.refl; return none catch _ => pure ()
+    -- Now we go for (heterogenous) equality via subsingleton considerations
+    if ← mvarId.subsingletonElim then return none
+    if ← mvarId.proofIrrelHeq then return none
   return some mvarId
 
 def Lean.MVarId.congrCore! (config : Congr!.Config) (mvarId : MVarId) :
     MetaM (Option (List MVarId)) := do
-  /- We do `liftReflToEq` here rather than in `preCongr!` since we don't want it to stick
-     if there are no relevant congr lemmas. -/
   mvarId.checkNotAssigned `congr!
   let s ← saveState
+  /- We do `liftReflToEq` here rather than in `preCongr!` since we don't want to commit to it
+     if there are no relevant congr lemmas. -/
   let mvarId ← mvarId.liftReflToEq
   for (passName, pass) in congrPasses! do
     try
@@ -815,12 +827,14 @@ def Lean.MVarId.congrCore! (config : Congr!.Config) (mvarId : MVarId) :
   return none
 
 /-- A pass to clean up after `Lean.MVarId.preCongr!` and `Lean.MVarId.congrCore!`. -/
-def Lean.MVarId.postCongr! (option : Congr!.Config) (mvarId : MVarId) : MetaM (Option MVarId) := do
-  let some mvarId ← mvarId.preCongr! | return none
+def Lean.MVarId.postCongr! (config : Congr!.Config) (mvarId : MVarId) : MetaM (Option MVarId) := do
+  let some mvarId ← mvarId.preCongr! config.closePost | return none
   -- Convert `p = q` to `p ↔ q`, which is likely the more useful form:
   let mvarId ← mvarId.propext
-  if ← mvarId.assumptionCore then return none
-  if option.etaExpand then
+  if config.closePost then
+    -- `preCongr` sees `p = q`, but now we've put it back into `p ↔ q` form.
+    if ← mvarId.assumptionCore then return none
+  if config.etaExpand then
     if let some (_, lhs, rhs) := (← withReducible mvarId.getType').eq? then
       let lhs' ← Meta.etaExpand lhs
       let rhs' ← Meta.etaExpand rhs
@@ -838,29 +852,31 @@ def Lean.MVarId.congrN! (mvarId : MVarId)
     MetaM (List MVarId) := do
   let ty ← withReducible <| mvarId.getType'
   -- A reasonably large yet practically bounded default recursion depth.
-  let defaultDepth := max 1000000 (8 * (1 + ty.approxDepth.toNat))
+  let defaultDepth := min 1000000 (8 * (1 + ty.approxDepth.toNat))
   let depth := depth?.getD defaultDepth
   let (_, s) ← go depth depth mvarId |>.run {goals := #[], patterns := patterns}
   return s.goals.toList
 where
   post (mvarId : MVarId) : CongrMetaM Unit := do
     for mvarId in ← mvarId.introsClean do
-      let some mvarId ← mvarId.postCongr! config
-          | do trace[congr!] "Dispatched goal by post-processing step."
-              return
-      modify (fun s => {s with goals := s.goals.push mvarId})
+      if let some mvarId ← mvarId.postCongr! config then
+        modify (fun s => {s with goals := s.goals.push mvarId})
+      else
+        trace[congr!] "Dispatched goal by post-processing step."
   go (depth : Nat) (n : Nat) (mvarId : MVarId) : CongrMetaM Unit := do
     for mvarId in ← mvarId.introsClean do
-      let some mvarId ← withTransparency config.preTransparency mvarId.preCongr! | return
-      match n with
-        | 0 =>
-          trace[congr!] "At level {depth - n}, doing post-processing. {mvarId}"
-          post mvarId
-        | n + 1 =>
-          trace[congr!] "At level {depth - n}, trying congrCore!. {mvarId}"
-          let some mvarIds ← mvarId.congrCore! config
-            | post mvarId
-          mvarIds.forM (go depth n)
+      if let some mvarId ← withTransparency config.preTransparency <|
+                              mvarId.preCongr! config.closePre then
+        match n with
+          | 0 =>
+            trace[congr!] "At level {depth - n}, doing post-processing. {mvarId}"
+            post mvarId
+          | n + 1 =>
+            trace[congr!] "At level {depth - n}, trying congrCore!. {mvarId}"
+            if let some mvarIds ← mvarId.congrCore! config then
+              mvarIds.forM (go depth n)
+            else
+              post mvarId
 
 namespace Congr!
 

--- a/Mathlib/Tactic/Congr!.lean
+++ b/Mathlib/Tactic/Congr!.lean
@@ -289,7 +289,7 @@ partial def Congr!.mkHCongrThm (fType : Expr) (info : FunInfo)
 where
   /-- Similar to doing `forallBoundedTelescope` twice, but makes use of the `fixed` array, which
   is used as a hint for whether both variables should be the same. This is only a hint though,
-  since we only respect it only if the binding domains are equal.
+  since we respect it only if the binding domains are equal.
   We affix `'` to the second list of variables, and all the variables are introduced
   with default binder info. Calls `k` with the xs, ys, and a revised `fixed` array -/
   doubleTelescope {α} (fty : Expr) (numVars : Nat) (fixed : Array Bool)

--- a/test/congr.lean
+++ b/test/congr.lean
@@ -242,3 +242,22 @@ example : n = m → 3 + n = m + 3 := by
   congr! 0 with rfl
   guard_target = 3 + n = n + 3
   apply add_comm
+
+example (x y x' y' : Nat) (hx : x = x') (hy : y = y') : x + y = x' + y' := by
+  congr! (config := { closePre := false, closePost := false })
+  exact hx
+  exact hy
+
+example (x y x' : Nat) (hx : id x = id x') : x + y = x' + y := by
+  congr!
+
+example (x y x' : Nat) (hx : id x = id x') : x + y = x' + y := by
+  congr! (config := { closePost := false })
+  exact hx
+
+example : { f : Nat → Nat // f = id } :=
+  ⟨?_, by
+    -- prevents `rfl` from solving for `?m` in `?m = id`:
+    congr! (config := { closePre := false, closePost := false })
+    ext x
+    exact Nat.zero_add x⟩

--- a/test/congr.lean
+++ b/test/congr.lean
@@ -261,3 +261,7 @@ example : { f : Nat → Nat // f = id } :=
     congr! (config := { closePre := false, closePost := false })
     ext x
     exact Nat.zero_add x⟩
+
+-- Regression test. From fixing a "declaration has metavariables" bug
+example (h : z = y) : (x = y ∨ x = z) → x = y := by
+  congr! with (rfl|rfl)


### PR DESCRIPTION
There were some accidental early `return`s due to adding `for` loops later, a missing `instantiateMVars`, and a `max` instead of a `min` for choosing the default iteration depth. I'm also slipping in `closePre` and `closePost` configurations to be able to turn off trying to apply `rfl`/`Subsingleton.elim`/etc., which is a feature that also exists in the core `congr` meta tactic.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
