### PR TITLE
[Merged by Bors] - refactor: make IsDedekindDomain extend the other classes

### DIFF
--- a/Mathlib/RingTheory/DedekindDomain/Basic.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Basic.lean
@@ -90,8 +90,6 @@ theorem DimensionLEOne.eq_bot_of_lt [Ring.DimensionLEOne R] (p P : Ideal R) [p.I
 
 end Ring
 
-variable [IsDomain A]
-
 /-- A Dedekind domain is an integral domain that is Noetherian, integrally closed, and
 has Krull dimension at most one.
 
@@ -104,30 +102,26 @@ This is the default implementation, but there are equivalent definitions,
 `is_dedekind_domain_dvr` and `is_dedekind_domain_inv`.
 TODO: Prove that these are actually equivalent definitions.
 -/
-class IsDedekindDomain : Prop where
-  isNoetherianRing : IsNoetherianRing A
-  dimensionLEOne : DimensionLEOne A
-  isIntegrallyClosed : IsIntegrallyClosed A
+class IsDedekindDomain
+  extends IsDomain A, IsNoetherian A A, DimensionLEOne A, IsIntegrallyClosed A : Prop
 #align is_dedekind_domain IsDedekindDomain
-
--- See library note [lower instance priority]
-attribute [instance 100] IsDedekindDomain.dimensionLEOne IsDedekindDomain.isNoetherianRing
-  IsDedekindDomain.isIntegrallyClosed
 
 /-- An integral domain is a Dedekind domain iff and only if it is
 Noetherian, has dimension ≤ 1, and is integrally closed in a given fraction field.
 In particular, this definition does not depend on the choice of this fraction field. -/
 theorem isDedekindDomain_iff (K : Type _) [Field K] [Algebra A K] [IsFractionRing A K] :
     IsDedekindDomain A ↔
-      IsNoetherianRing A ∧
-        DimensionLEOne A ∧ ∀ {x : K}, IsIntegral A x → ∃ y, algebraMap A K y = x :=
-  ⟨fun ⟨hr, hd, hi⟩ => ⟨hr, hd, fun {_} => (isIntegrallyClosed_iff K).mp hi⟩, fun ⟨hr, hd, hi⟩ =>
-    ⟨hr, hd, (isIntegrallyClosed_iff K).mpr @hi⟩⟩
+      IsDomain A ∧ IsNoetherianRing A ∧ DimensionLEOne A ∧
+        ∀ {x : K}, IsIntegral A x → ∃ y, algebraMap A K y = x :=
+  ⟨fun _ => ⟨inferInstance, inferInstance, inferInstance,
+             fun {_} => (isIntegrallyClosed_iff K).mp inferInstance⟩,
+   fun ⟨hid, hr, hd, hi⟩ => { hid, hr, hd, (isIntegrallyClosed_iff K).mpr @hi with }⟩
 #align is_dedekind_domain_iff isDedekindDomain_iff
 
 -- See library note [lower instance priority]
-instance (priority := 100) IsPrincipalIdealRing.isDedekindDomain [IsPrincipalIdealRing A] :
+instance (priority := 100) IsPrincipalIdealRing.isDedekindDomain
+    [IsDomain A] [IsPrincipalIdealRing A] :
     IsDedekindDomain A :=
-  ⟨PrincipalIdealRing.isNoetherianRing, Ring.DimensionLEOne.principal_ideal_ring A,
-    UniqueFactorizationMonoid.instIsIntegrallyClosed⟩
+  { PrincipalIdealRing.isNoetherianRing, Ring.DimensionLEOne.principal_ideal_ring A,
+    UniqueFactorizationMonoid.instIsIntegrallyClosed with }
 #align is_principal_ideal_ring.is_dedekind_domain IsPrincipalIdealRing.isDedekindDomain

--- a/Mathlib/RingTheory/DedekindDomain/Dvr.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Dvr.lean
@@ -70,7 +70,7 @@ once we have a suitable definition.
 -/
 theorem Ring.DimensionLEOne.localization {R : Type _} (Rₘ : Type _) [CommRing R] [IsDomain R]
     [CommRing Rₘ] [Algebra R Rₘ] {M : Submonoid R} [IsLocalization M Rₘ] (hM : M ≤ R⁰)
-    (h : Ring.DimensionLEOne R) : Ring.DimensionLEOne Rₘ := ⟨by
+    [h : Ring.DimensionLEOne R] : Ring.DimensionLEOne Rₘ := ⟨by
   intro p hp0 hpp
   refine' Ideal.isMaximal_def.mpr ⟨hpp.ne_top, Ideal.maximal_of_no_maximal fun P hpP hPm => _⟩
   have hpP' : (⟨p, hpp⟩ : { p : Ideal Rₘ // p.IsPrime }) < ⟨P, hPm.isPrime⟩ := hpP
@@ -97,11 +97,12 @@ theorem IsLocalization.isDedekindDomain [IsDedekindDomain A] {M : Submonoid A} (
   haveI : IsFractionRing Aₘ (FractionRing A) :=
     IsFractionRing.isFractionRing_of_isDomain_of_isLocalization M _ _
   refine' (isDedekindDomain_iff _ (FractionRing A)).mpr ⟨_, _, _, _⟩
+  · infer_instance
   · exact IsLocalization.isNoetherianRing M _ (by infer_instance)
-  · exact IsDedekindDomain.dimensionLEOne.localization Aₘ hM
+  · exact Ring.DimensionLEOne.localization Aₘ hM
   · intro x hx
     obtain ⟨⟨y, y_mem⟩, hy⟩ := hx.exists_multiple_integral_of_isLocalization M _
-    obtain ⟨z, hz⟩ := (isIntegrallyClosed_iff _).mp IsDedekindDomain.isIntegrallyClosed hy
+    obtain ⟨z, hz⟩ := (isIntegrallyClosed_iff _).mp IsDedekindDomain.toIsIntegrallyClosed hy
     refine' ⟨IsLocalization.mk' Aₘ z ⟨y, y_mem⟩, (IsLocalization.lift_mk'_spec _ _ _ _).mpr _⟩
     rw [hz, ← Algebra.smul_def]
     rfl
@@ -135,7 +136,7 @@ theorem IsLocalization.AtPrime.discreteValuationRing_of_dedekind_domain [IsDedek
     [Algebra A Aₘ] [IsLocalization.AtPrime Aₘ P] : DiscreteValuationRing Aₘ := by
   classical
   letI : IsNoetherianRing Aₘ :=
-    IsLocalization.isNoetherianRing P.primeCompl _ IsDedekindDomain.isNoetherianRing
+    IsLocalization.isNoetherianRing P.primeCompl _ IsDedekindDomain.toIsNoetherian
   letI : LocalRing Aₘ := IsLocalization.AtPrime.localRing Aₘ P
   have hnf := IsLocalization.AtPrime.not_isField A hP Aₘ
   exact
@@ -147,7 +148,7 @@ theorem IsLocalization.AtPrime.discreteValuationRing_of_dedekind_domain [IsDedek
 are also Dedekind domains in the sense of Noetherian domains where the localization at every
 nonzero prime ideal is a DVR. -/
 theorem IsDedekindDomain.isDedekindDomainDvr [IsDedekindDomain A] : IsDedekindDomainDvr A :=
-  { isNoetherianRing := IsDedekindDomain.isNoetherianRing
+  { isNoetherianRing := IsDedekindDomain.toIsNoetherian
     is_dvr_at_nonzero_prime := fun _ hP _ =>
       IsLocalization.AtPrime.discreteValuationRing_of_dedekind_domain A hP _ }
 #align is_dedekind_domain.is_dedekind_domain_dvr IsDedekindDomain.isDedekindDomainDvr

--- a/Mathlib/RingTheory/DedekindDomain/Dvr.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Dvr.lean
@@ -96,7 +96,7 @@ theorem IsLocalization.isDedekindDomain [IsDedekindDomain A] {M : Submonoid A} (
     IsScalarTower.of_algebraMap_eq fun x => (IsLocalization.lift_eq h x).symm
   haveI : IsFractionRing Aₘ (FractionRing A) :=
     IsFractionRing.isFractionRing_of_isDomain_of_isLocalization M _ _
-  refine' (isDedekindDomain_iff _ (FractionRing A)).mpr ⟨_, _, _⟩
+  refine' (isDedekindDomain_iff _ (FractionRing A)).mpr ⟨_, _, _, _⟩
   · exact IsLocalization.isNoetherianRing M _ (by infer_instance)
   · exact IsDedekindDomain.dimensionLEOne.localization Aₘ hM
   · intro x hx

--- a/Mathlib/RingTheory/DedekindDomain/Ideal.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Ideal.lean
@@ -346,7 +346,7 @@ theorem dimensionLEOne : DimensionLEOne A := ⟨by
 /-- Showing one side of the equivalence between the definitions
 `IsDedekindDomainInv` and `IsDedekindDomain` of Dedekind domains. -/
 theorem isDedekindDomain : IsDedekindDomain A :=
-  ⟨h.isNoetherianRing, h.dimensionLEOne, h.integrallyClosed⟩
+  { h.isNoetherianRing, h.dimensionLEOne, h.integrallyClosed with }
 #align is_dedekind_domain_inv.is_dedekind_domain IsDedekindDomainInv.isDedekindDomain
 
 end IsDedekindDomainInv
@@ -668,7 +668,7 @@ theorem Ideal.dvdNotUnit_iff_lt {I J : Ideal A} : DvdNotUnit I J ↔ J < I :=
 instance : WfDvdMonoid (Ideal A) where
   wellFounded_dvdNotUnit := by
     have : WellFounded ((· > ·) : Ideal A → Ideal A → Prop) :=
-      isNoetherian_iff_wellFounded.mp (isNoetherianRing_iff.mp IsDedekindDomain.isNoetherianRing)
+      isNoetherian_iff_wellFounded.mp (isNoetherianRing_iff.mp IsDedekindDomain.toIsNoetherian)
     convert this
     ext
     rw [Ideal.dvdNotUnit_iff_lt]

--- a/Mathlib/RingTheory/DedekindDomain/IntegralClosure.lean
+++ b/Mathlib/RingTheory/DedekindDomain/IntegralClosure.lean
@@ -251,12 +251,13 @@ Can't be an instance since `A`, `K` or `L` can't be inferred. See also the insta
 `integralClosure.isDedekindDomain_fractionRing` where `K := FractionRing A`
 and `C := integralClosure A L`.
 -/
-theorem IsIntegralClosure.isDedekindDomain [h : IsDedekindDomain A] : IsDedekindDomain C :=
-  haveI : IsFractionRing C L := IsIntegralClosure.isFractionRing_of_finite_extension A K L C
-  ⟨IsIntegralClosure.isNoetherianRing A K L C, h.dimensionLEOne.isIntegralClosure L _,
+theorem IsIntegralClosure.isDedekindDomain [IsDedekindDomain A] : IsDedekindDomain C :=
+  have : IsFractionRing C L := IsIntegralClosure.isFractionRing_of_finite_extension A K L C
+  { IsIntegralClosure.isNoetherianRing A K L C,
+    Ring.DimensionLEOne.isIntegralClosure A L C,
     (isIntegrallyClosed_iff L).mpr fun {x} hx =>
       ⟨IsIntegralClosure.mk' C x (isIntegral_trans (IsIntegralClosure.isIntegral_algebra A L) _ hx),
-        IsIntegralClosure.algebraMap_mk' _ _ _⟩⟩
+        IsIntegralClosure.algebraMap_mk' _ _ _⟩ with : IsDedekindDomain C }
 #align is_integral_closure.is_dedekind_domain IsIntegralClosure.isDedekindDomain
 
 /- If `L` is a finite separable extension of `K = Frac(A)`, where `A` is a Dedekind domain,

--- a/Mathlib/RingTheory/DedekindDomain/SelmerGroup.lean
+++ b/Mathlib/RingTheory/DedekindDomain/SelmerGroup.lean
@@ -215,10 +215,10 @@ theorem fromUnit_ker [hn : Fact <| 0 < n] :
     have hi : ↑(_ ^ n : Kˣ)⁻¹ = algebraMap R K _ := by exact congr_arg Units.inv hx
     rw [Units.val_pow_eq_pow_val] at hv
     rw [← inv_pow, Units.inv_mk, Units.val_pow_eq_pow_val] at hi
-    rcases@IsIntegrallyClosed.exists_algebraMap_eq_of_isIntegral_pow R _ _ _ _ _ _ _ v _ hn.out
+    rcases IsIntegrallyClosed.exists_algebraMap_eq_of_isIntegral_pow (R := R) (x := v) hn.out
         (hv.symm ▸ isIntegral_algebraMap) with
       ⟨v', rfl⟩
-    rcases@IsIntegrallyClosed.exists_algebraMap_eq_of_isIntegral_pow R _ _ _ _ _ _ _ i _ hn.out
+    rcases IsIntegrallyClosed.exists_algebraMap_eq_of_isIntegral_pow (R := R) (x := i) hn.out
         (hi.symm ▸ isIntegral_algebraMap) with
       ⟨i', rfl⟩
     rw [← map_mul, map_eq_one_iff _ <| NoZeroSMulDivisors.algebraMap_injective R K] at vi

--- a/Mathlib/RingTheory/DiscreteValuationRing/TFAE.lean
+++ b/Mathlib/RingTheory/DiscreteValuationRing/TFAE.lean
@@ -176,9 +176,9 @@ theorem DiscreteValuationRing.TFAE [IsNoetherianRing R] [LocalRing R] [IsDomain 
     exact ⟨inferInstance, ((DiscreteValuationRing.iff_pid_with_one_nonzero_prime R).mp H).2⟩
   tfae_have 4 → 3
   · rintro ⟨h₁, h₂⟩;
-    exact
-      ⟨inferInstance, ⟨fun hI hI' =>
-        ExistsUnique.unique h₂ ⟨ne_bot, inferInstance⟩ ⟨hI, hI'⟩ ▸ maximalIdeal.isMaximal R⟩, h₁⟩
+    exact { h₁ with
+      maximalOfPrime := fun hI hI' => ExistsUnique.unique h₂ ⟨ne_bot, inferInstance⟩ ⟨hI, hI'⟩ ▸
+        maximalIdeal.isMaximal R, }
   tfae_have 3 → 5
   · intro h; exact maximalIdeal_isPrincipal_of_isDedekindDomain R
   tfae_have 5 → 6
@@ -236,8 +236,11 @@ theorem DiscreteValuationRing.TFAE [IsNoetherianRing R] [LocalRing R] [IsDomain 
     intro H
     constructor
     intro I J
-    by_cases hI : I = ⊥; · subst hI; left; exact bot_le
-    by_cases hJ : J = ⊥; · subst hJ; right; exact bot_le
+    -- FIXME: by_cases gives an error "could not synthesize `Ideal R → Ideal R → LinearOrder (Ideal R)`"???
+    cases' eq_or_ne I ⊥ with hI hI
+    · subst hI; left; exact bot_le
+    cases' eq_or_ne J ⊥ with hJ hJ
+    · subst hJ; right; exact bot_le
     obtain ⟨n, rfl⟩ := H I hI
     obtain ⟨m, rfl⟩ := H J hJ
     cases' le_total m n with h' h'

--- a/Mathlib/RingTheory/DiscreteValuationRing/TFAE.lean
+++ b/Mathlib/RingTheory/DiscreteValuationRing/TFAE.lean
@@ -236,11 +236,14 @@ theorem DiscreteValuationRing.TFAE [IsNoetherianRing R] [LocalRing R] [IsDomain 
     intro H
     constructor
     intro I J
-    -- FIXME: by_cases gives an error "could not synthesize `Ideal R → Ideal R → LinearOrder (Ideal R)`"???
-    cases' eq_or_ne I ⊥ with hI hI
-    · subst hI; left; exact bot_le
-    cases' eq_or_ne J ⊥ with hJ hJ
-    · subst hJ; right; exact bot_le
+    -- `by_cases` should invoke `classical` by itself if it can't find a `Decidable` instance,
+    -- however the `tfae` hypotheses trigger a looping instance search.
+    -- See also:
+    -- https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/.60by_cases.60.20trying.20to.20find.20a.20weird.20instance
+    -- As a workaround, add the desired instance ourselves.
+    let _ := Classical.decEq (Ideal R)
+    by_cases hI : I = ⊥; · subst hI; left; exact bot_le
+    by_cases hJ : J = ⊥; · subst hJ; right; exact bot_le
     obtain ⟨n, rfl⟩ := H I hI
     obtain ⟨m, rfl⟩ := H J hJ
     cases' le_total m n with h' h'


### PR DESCRIPTION
This redefines the `IsDedekindDomain` class to be the conjunction through `extends` of the classes `IsDomain`, `IsNoetherianRing`, `DimensionLEOne` and `IsIntegrallyClosed`.

Zulip thread: https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Should.20.60IsDedekindDomain.60.20extend.20.60IsDomain.60.3F

---

- [x] depends on: #5833 
- [x] depends on: #6145

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
