### PR TITLE
[Merged by Bors] - feat: add cancel lemmas in WithTop

### DIFF
--- a/Mathlib/Algebra/Order/Monoid/WithTop.lean
+++ b/Mathlib/Algebra/Order/Monoid/WithTop.lean
@@ -183,6 +183,28 @@ theorem coe_add_eq_top_iff {y : WithTop α} : ↑x + y = ⊤ ↔ y = ⊤ := by
   induction y using WithTop.recTopCoe <;> simp [← coe_add]
 #align with_top.coe_add_eq_top_iff WithTop.coe_add_eq_top_iff
 
+theorem add_right_cancel_iff [IsRightCancelAdd α] (ha : a ≠ ⊤) : b + a = c + a ↔ b = c := by
+  lift a to α using ha
+  obtain rfl | hb := (eq_or_ne b ⊤)
+  · rw [top_add, eq_comm, WithTop.add_coe_eq_top_iff, eq_comm]
+  lift b to α using hb
+  simp_rw [←WithTop.coe_add, eq_comm, WithTop.add_eq_coe, coe_eq_coe, exists_and_left,
+    exists_eq_left, add_left_inj, exists_eq_right, eq_comm]
+
+theorem add_right_cancel [IsRightCancelAdd α] (ha : a ≠ ⊤) (hle : b + a = c + a) : b = c :=
+  (WithTop.add_right_cancel_iff ha).1 hle
+
+theorem add_left_cancel_iff [IsLeftCancelAdd α] (ha : a ≠ ⊤) : a + b = a + c ↔ b = c := by
+  lift a to α using ha
+  obtain rfl | hb := (eq_or_ne b ⊤)
+  · rw [add_top, eq_comm, WithTop.coe_add_eq_top_iff, eq_comm]
+  lift b to α using hb
+  simp_rw [←WithTop.coe_add, eq_comm, WithTop.add_eq_coe, eq_comm, coe_eq_coe,
+    exists_and_left, exists_eq_left', add_right_inj, exists_eq_right']
+
+theorem add_left_cancel [IsLeftCancelAdd α] (ha : a ≠ ⊤) (hle : a + b = a + c) : b = c :=
+  (WithTop.add_left_cancel_iff ha).1 hle
+
 instance covariantClass_add_le [LE α] [CovariantClass α α (· + ·) (· ≤ ·)] :
     CovariantClass (WithTop α) (WithTop α) (· + ·) (· ≤ ·) :=
   ⟨fun a b c h => by


### PR DESCRIPTION
This PR adds four lemmas that allow cancelling addition in `WithTop α` when the term being cancelled is not `⊤`. They complement the existing `le`/`lt` versions. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
