### PR TITLE
[Merged by Bors] - feat: `Encodable` and `Countable` instances for `Π₀ i, α i` and `α →₀ β`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1296,6 +1296,7 @@ import Mathlib.Data.Countable.Basic
 import Mathlib.Data.Countable.Defs
 import Mathlib.Data.Countable.Small
 import Mathlib.Data.DFinsupp.Basic
+import Mathlib.Data.DFinsupp.Encodable
 import Mathlib.Data.DFinsupp.Interval
 import Mathlib.Data.DFinsupp.Lex
 import Mathlib.Data.DFinsupp.Multiset
@@ -1362,6 +1363,7 @@ import Mathlib.Data.Finsupp.Antidiagonal
 import Mathlib.Data.Finsupp.Basic
 import Mathlib.Data.Finsupp.BigOperators
 import Mathlib.Data.Finsupp.Defs
+import Mathlib.Data.Finsupp.Encodable
 import Mathlib.Data.Finsupp.Fin
 import Mathlib.Data.Finsupp.Fintype
 import Mathlib.Data.Finsupp.Indicator

--- a/Mathlib/Data/DFinsupp/Basic.lean
+++ b/Mathlib/Data/DFinsupp/Basic.lean
@@ -1149,7 +1149,7 @@ def subtypeSupportEqEquiv (s : Finset ι) :
     ext1
     simp [Subtype.eta]; rfl
 
-/-- Equivalence between all dependent finitely supported functions `f : Π₀ i, β i` and type type
+/-- Equivalence between all dependent finitely supported functions `f : Π₀ i, β i` and type
 of pairs `⟨s : Finset ι, f : ∀ i : s, {x : β i // x ≠ 0}⟩`. -/
 @[simps! apply_fst apply_snd_coe]
 def equivSigmaFinsetFun : (Π₀ i, β i) ≃ Σ s : Finset ι, ∀ i : s, {x : β i // x ≠ 0} :=

--- a/Mathlib/Data/DFinsupp/Basic.lean
+++ b/Mathlib/Data/DFinsupp/Basic.lean
@@ -1152,7 +1152,7 @@ def subtypeSupportEqEquiv (s : Finset ι) :
 /-- Equivalence between all dependent finitely supported functions `f : Π₀ i, β i` and type
 of pairs `⟨s : Finset ι, f : ∀ i : s, {x : β i // x ≠ 0}⟩`. -/
 @[simps! apply_fst apply_snd_coe]
-def equivSigmaFinsetFun : (Π₀ i, β i) ≃ Σ s : Finset ι, ∀ i : s, {x : β i // x ≠ 0} :=
+def sigmaFinsetFunEquiv : (Π₀ i, β i) ≃ Σ s : Finset ι, ∀ i : s, {x : β i // x ≠ 0} :=
   (Equiv.sigmaFiberEquiv DFinsupp.support).symm.trans (.sigmaCongrRight subtypeSupportEqEquiv)
 
 @[simp]

--- a/Mathlib/Data/DFinsupp/Encodable.lean
+++ b/Mathlib/Data/DFinsupp/Encodable.lean
@@ -18,7 +18,7 @@ instance [Encodable ι] [∀ i, Encodable (α i)] [∀ i (x : α i), Decidable (
   letI : DecidableEq ι := Encodable.decidableEqOfEncodable _
   letI : ∀ s : Finset ι, Encodable (∀ i : s, {x : α i // x ≠ 0}) := fun _ ↦
     .ofEquiv _ <| .piCongrLeft' _ Encodable.fintypeEquivFin
-  .ofEquiv _ DFinsupp.equivSigmaFinsetFun
+  .ofEquiv _ DFinsupp.sigmaFinsetFunEquiv
 
 instance [Countable ι] [∀ i, Countable (α i)] : Countable (Π₀ i, α i) := by
   classical

--- a/Mathlib/Data/DFinsupp/Encodable.lean
+++ b/Mathlib/Data/DFinsupp/Encodable.lean
@@ -1,0 +1,27 @@
+/-
+Copyright (c) 2023 Yury Kudryashov. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yury Kudryashov
+-/
+import Mathlib.Data.DFinsupp.Basic
+import Mathlib.Logic.Equiv.List
+/-!
+# `Encodable` and `Countable` instances for `Π₀ i, α i`
+
+In this file we provide instances for `Encodable (Π₀ i, α i)` and `Countable (Π₀ i, α i)`.
+-/
+
+variable {ι : Type _} {α : ι → Type _} [∀ i, Zero (α i)]
+
+instance [Encodable ι] [∀ i, Encodable (α i)] [∀ i (x : α i), Decidable (x ≠ 0)] :
+    Encodable (Π₀ i, α i) :=
+  letI : DecidableEq ι := Encodable.decidableEqOfEncodable _
+  letI : ∀ s : Finset ι, Encodable (∀ i : s, {x : α i // x ≠ 0}) := fun _ ↦
+    .ofEquiv _ <| .piCongrLeft' _ Encodable.fintypeEquivFin
+  .ofEquiv _ DFinsupp.equivSigmaFinsetFun
+
+instance [Countable ι] [∀ i, Countable (α i)] : Countable (Π₀ i, α i) := by
+  classical
+    let _ := Encodable.ofCountable ι
+    let _ := fun i ↦ Encodable.ofCountable (α i)
+    infer_instance

--- a/Mathlib/Data/Finsupp/Encodable.lean
+++ b/Mathlib/Data/Finsupp/Encodable.lean
@@ -1,0 +1,19 @@
+/-
+Copyright (c) 2023 Yury Kudryashov. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yury Kudryashov
+-/
+import Mathlib.Data.Finsupp.ToDFinsupp
+import Mathlib.Data.DFinsupp.Encodable
+/-!
+# `Encodable` and `Countable` instances for `α →₀ β`
+
+In this file we provide instances for `Encodable (α →₀ β)` and `Countable (α →₀ β)`.
+-/
+
+instance [Encodable α] [Encodable β] [Zero β] [∀ x : β, Decidable (x ≠ 0)] : Encodable (α →₀ β) :=
+  letI : DecidableEq α := Encodable.decidableEqOfEncodable _
+  .ofEquiv _ finsuppEquivDFinsupp
+
+instance [Countable α] [Countable β] [Zero β] : Countable (α →₀ β) := by
+  classical exact .of_equiv _ finsuppEquivDFinsupp.symm


### PR DESCRIPTION
Fixes #5776

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)