### PR TITLE
golf: use `compute_degree_le` to simplify two proofs

### DIFF
--- a/Mathlib/Data/Polynomial/CancelLeads.lean
+++ b/Mathlib/Data/Polynomial/CancelLeads.lean
@@ -3,8 +3,8 @@ Copyright (c) 2020 Aaron Anderson. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Aaron Anderson
 -/
-import Mathlib.Data.Polynomial.Degree.Definitions
 import Mathlib.Data.Polynomial.Degree.Lemmas
+import Mathlib.Tactic.ComputeDegree
 
 #align_import data.polynomial.cancel_leads from "leanprover-community/mathlib"@"70fd9563a21e7b963887c9360bd29b2393e6225a"
 
@@ -60,11 +60,8 @@ theorem natDegree_cancelLeads_lt_of_natDegree_le_natDegree_of_comm
     C p.leadingCoeff * q + -(C q.leadingCoeff * X ^ (q.natDegree - p.natDegree) * p) = 0
   · exact (le_of_eq (by simp only [h0, natDegree_zero])).trans_lt hq
   apply lt_of_le_of_ne
-  · -- porting note: was compute_degree_le; repeat' rwa [Nat.sub_add_cancel]
-    rw [natDegree_add_le_iff_left]
-    · apply natDegree_C_mul_le
-    refine (natDegree_neg (C q.leadingCoeff * X ^ (q.natDegree - p.natDegree) * p)).le.trans ?_
-    exact natDegree_mul_le.trans <| Nat.add_le_of_le_sub h <| natDegree_C_mul_X_pow_le _ _
+  · compute_degree_le!
+    repeat' rwa [Nat.sub_add_cancel]
   · contrapose! h0
     rw [← leadingCoeff_eq_zero, leadingCoeff, h0, mul_assoc, X_pow_mul, ← tsub_add_cancel_of_le h,
       add_comm _ p.natDegree]

--- a/Mathlib/LinearAlgebra/Matrix/Polynomial.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Polynomial.lean
@@ -6,6 +6,7 @@ Authors: Yakov Pechersky
 import Mathlib.Algebra.Polynomial.BigOperators
 import Mathlib.Data.Polynomial.Degree.Lemmas
 import Mathlib.LinearAlgebra.Matrix.Determinant
+import Mathlib.Tactic.ComputeDegree
 
 #align_import linear_algebra.matrix.polynomial from "leanprover-community/mathlib"@"70fd9563a21e7b963887c9360bd29b2393e6225a"
 
@@ -53,17 +54,8 @@ theorem natDegree_det_X_add_C_le (A B : Matrix n n α) :
       (natDegree_prod_le (Finset.univ : Finset n) fun i : n => (X • A.map C + B.map C) (g i) i)
     _ ≤ Finset.univ.card • 1 := (Finset.sum_le_card_nsmul _ _ 1 fun (i : n) _ => ?_)
     _ ≤ Fintype.card n := by simp [mul_one, Algebra.id.smul_eq_mul, Finset.card_univ]
-
-  calc
-    natDegree (((X : α[X]) • A.map C + B.map C) (g i) i) =
-        natDegree ((X : α[X]) * C (A (g i) i) + C (B (g i) i)) :=
-      by simp
-    _ ≤ max (natDegree ((X : α[X]) * C (A (g i) i))) (natDegree (C (B (g i) i))) :=
-      (natDegree_add_le _ _)
-    _ = natDegree ((X : α[X]) * C (A (g i) i)) :=
-      (max_eq_left ((natDegree_C _).le.trans (zero_le _)))
-    _ ≤ natDegree (X : α[X]) := (natDegree_mul_C_le _ _)
-    _ ≤ 1 := natDegree_X_le
+  dsimp only [add_apply, smul_apply, map_apply, smul_eq_mul]
+  compute_degree_le
 #align polynomial.nat_degree_det_X_add_C_le Polynomial.natDegree_det_X_add_C_le
 
 theorem coeff_det_X_add_C_zero (A B : Matrix n n α) :
@@ -89,9 +81,8 @@ theorem coeff_det_X_add_C_card (A B : Matrix n n α) :
   convert (coeff_prod_of_natDegree_le (R := α) _ _ _ _).symm
   · simp [coeff_C]
   · rintro p -
-    refine' (natDegree_add_le _ _).trans _
-    simpa [Pi.smul_apply, map_apply, Algebra.id.smul_eq_mul, X_mul_C, natDegree_C,
-      max_eq_left, zero_le'] using (natDegree_C_mul_le _ _).trans (natDegree_X_le (R := α))
+    dsimp only [add_apply, smul_apply, map_apply, smul_eq_mul]
+    compute_degree_le
 #align polynomial.coeff_det_X_add_C_card Polynomial.coeff_det_X_add_C_card
 
 theorem leadingCoeff_det_X_one_add_C (A : Matrix n n α) :

--- a/Mathlib/Tactic/ComputeDegree.lean
+++ b/Mathlib/Tactic/ComputeDegree.lean
@@ -34,25 +34,14 @@ The recursion into `f` first converts `f` to a term of Type `DegInfo`.
 This conversion preserves enough information of `f` to guide `compute_degree_le` into a proof.
 -/
 
+namespace Mathlib.Tactic.ComputeDegree
+
 open Polynomial
 
 section mylemmas
-namespace Polynomial
 
 /-!
 ###  Simple lemmas about `natDegree` and `degree`
-
-The lemmas in this section deduce inequalities of the form `natDegree f ≤ d` and `degree f ≤ d`,
-using inequalities of the same shape.
-This allows a recursive application of the `compute_degree_le` tactic on a goal,
-and on all the resulting subgoals.
--/
-
-open Polynomial
-
-namespace Mathlib.Tactic.ComputeDegree
-
-section mylemmas
 
 The lemmas in this section all have the form `natDegree <some form of cast> ≤ 0`.
 Their proofs are weakenings of the stronger lemmas `natDegree <same> = 0`.
@@ -64,44 +53,6 @@ variable {R : Type _}
 section semiring
 variable [Semiring R]
 
-section Lemmas__in_a_dependent_PR
-
-theorem natDegree_add_le_of_le {a b : Nat} {f g : R[X]} (hf : natDegree f ≤ a) (hg : natDegree g ≤ b) :
-    natDegree (f + g) ≤ max a b :=
-(f.natDegree_add_le g).trans $ max_le_max ‹_› ‹_›
-
-theorem natDegree_mul_le_of_le {a b : Nat} {f g : R[X]} (hf : natDegree f ≤ a) (hg : natDegree g ≤ b) :
-    natDegree (f * g) ≤ a + b :=
-natDegree_mul_le.trans $ add_le_add ‹_› ‹_›
-
-theorem natDegree_pow_le_of_le {a : Nat} (b : Nat) {f : R[X]} (hf : natDegree f ≤ a) :
-    natDegree (f ^ b) ≤ b * a :=
-natDegree_pow_le.trans (Nat.mul_le_mul rfl.le ‹_›)
-
-theorem degree_add_le_of_le {a b : WithBot Nat} {f g : R[X]} (hf : degree f ≤ a) (hg : degree g ≤ b) :
-    degree (f + g) ≤ max a b :=
-(f.degree_add_le g).trans $ max_le_max ‹_› ‹_›
-
-theorem degree_mul_le_of_le {a b : WithBot Nat} {f g : R[X]} (hf : degree f ≤ a) (hg : degree g ≤ b) :
-    degree (f * g) ≤ a + b :=
-(f.degree_mul_le _).trans $ add_le_add ‹_› ‹_›
-
-theorem degree_pow_le_of_le {a : WithBot Nat} (b : Nat) {f : R[X]} (hf : degree f ≤ a) :
-    degree (f ^ b) ≤ b * a := by
-  apply (degree_pow_le _ _).trans
-  rw [nsmul_eq_mul]
-  induction b with
-    | zero => simp [degree_one_le]
-    | succ n hn =>
-      rw [Nat.cast_succ, add_mul, add_mul, one_mul, one_mul]
-      exact (add_le_add_left hf _).trans (add_le_add_right hn _)
-
-theorem degree_nat_cast_le (n : Nat) : degree (n : R[X]) ≤ 0 := degree_le_of_natDegree_le (by simp)
-
-theorem degree_zero_le : degree (0 : R[X]) ≤ 0 := natDegree_eq_zero_iff_degree_le_zero.mp rfl
-
-end Lemmas__in_a_dependent_PR
-
 theorem natDegree_C_le (a : R) : natDegree (C a) ≤ 0 := (natDegree_C a).le
 theorem natDegree_nat_cast_le (n : Nat) : natDegree (n : R[X]) ≤ 0 := (natDegree_nat_cast _).le
 theorem natDegree_zero_le : natDegree (0 : R[X]) ≤ 0 := natDegree_zero.le
@@ -112,35 +63,11 @@ end semiring
 section ring
 variable [Ring R]
 
-section Lemmas__in_a_dependent_PR
-
-theorem natDegree_neg_le_of_le {a : Nat} {f : R[X]} (hf : natDegree f ≤ a) : natDegree (- f) ≤ a :=
-f.natDegree_neg.le.trans ‹_›
-
-theorem natDegree_sub_le_of_le {a b : Nat} {f g : R[X]} (hf : natDegree f ≤ a) (hg : natDegree g ≤ b) :
-    natDegree (f - g) ≤ max a b :=
-(f.natDegree_sub_le g).trans $ max_le_max ‹_› ‹_›
-
-theorem degree_neg_le_of_le {a : WithBot Nat} {f : R[X]} (hf : degree f ≤ a) : degree (- f) ≤ a :=
-f.degree_neg.le.trans ‹_›
-
-theorem degree_sub_le_of_le {a b : WithBot Nat} {f g : R[X]} (hf : degree f ≤ a) (hg : degree g ≤ b) :
-    degree (f - g) ≤ max a b :=
-(f.degree_sub_le g).trans $ max_le_max ‹_› ‹_›
-
-theorem degree_int_cast_le (n : Int) : degree (n : R[X]) ≤ 0 := degree_le_of_natDegree_le (by simp)
-
-end Lemmas__in_a_dependent_PR
-
 theorem natDegree_int_cast_le (n : Int) : natDegree (n : R[X]) ≤ 0 := (natDegree_int_cast _).le
 
 end ring
 
-end Polynomial
-
 end mylemmas
-
-namespace Mathlib.Tactic.ComputeDegree
 
 section Tactic
 

--- a/Mathlib/Tactic/ComputeDegree.lean
+++ b/Mathlib/Tactic/ComputeDegree.lean
@@ -7,34 +7,354 @@ Authors: Damiano Testa
 import Mathlib.Data.Polynomial.Degree.Definitions
 
 /-!
-###  Simple lemmas about `natDegree`
 
-The lemmas in this section all have the form `natDegree <some form of cast> ≤ 0`.
-Their proofs are weakenings of the stronger lemmas `natDegree <same> = 0`.
-These are the lemmas called by `compute_degree_le` on (almost) all the leaves of its recursion.
+# `compute_degree_le` a tactic for computing degrees of polynomials
+
+This file defines the tactic `compute_degree_le`.
+
+Using `compute_degree_le` when the goal is of the form `natDegree f ≤ d` or `degree f ≤ d`,
+tries to solve the goal.
+It leaves a side-goal of the form `d' ≤ d`, in case it is not entirely successful.
+
+See the doc-string for more details.
+
+##  Future work
+
+* Deal with equalities, instead of inequalities (i.e. implement `compute_degree`).
+* Add support for proving goals of the from `natDegree f ≠ 0` and `degree f ≠ 0`.
+* Make sure that `degree` and `natDegree` are equally supported.
+
+##  Implementation details
+
+We start with a goal of the form `natDegree f ≤ d` or `degree f ≤ d`.
+Recurse into `f` breaking apart sums, products and powers.  Take care of numerals,
+`C a, X (^ n), monomial a n` separately.
+
+The recursion into `f` first converts `f` to a term of Type `DegInfo`.
+This conversion preserves enough information of `f` to guide `compute_degree_le` into a proof.
+-/
+
+open Polynomial
+
+section mylemmas
+namespace Polynomial
+
+/-!
+###  Simple lemmas about `natDegree` and `degree`
+
+The lemmas in this section deduce inequalities of the form `natDegree f ≤ d` and `degree f ≤ d`,
+using inequalities of the same shape.
+This allows a recursive application of the `compute_degree_le` tactic on a goal,
+and on all the resulting subgoals.
 -/
 
 open Polynomial
 
 namespace Mathlib.Tactic.ComputeDegree
 
-section leaf_lemmas
+section mylemmas
+
+The lemmas in this section all have the form `natDegree <some form of cast> ≤ 0`.
+Their proofs are weakenings of the stronger lemmas `natDegree <same> = 0`.
+These are the lemmas called by `compute_degree_le` on (almost) all the leaves of its recursion.
+-/
 
 variable {R : Type _}
 
 section semiring
 variable [Semiring R]
 
+section Lemmas__in_a_dependent_PR
+
+theorem natDegree_add_le_of_le {a b : Nat} {f g : R[X]} (hf : natDegree f ≤ a) (hg : natDegree g ≤ b) :
+    natDegree (f + g) ≤ max a b :=
+(f.natDegree_add_le g).trans $ max_le_max ‹_› ‹_›
+
+theorem natDegree_mul_le_of_le {a b : Nat} {f g : R[X]} (hf : natDegree f ≤ a) (hg : natDegree g ≤ b) :
+    natDegree (f * g) ≤ a + b :=
+natDegree_mul_le.trans $ add_le_add ‹_› ‹_›
+
+theorem natDegree_pow_le_of_le {a : Nat} (b : Nat) {f : R[X]} (hf : natDegree f ≤ a) :
+    natDegree (f ^ b) ≤ b * a :=
+natDegree_pow_le.trans (Nat.mul_le_mul rfl.le ‹_›)
+
+theorem degree_add_le_of_le {a b : WithBot Nat} {f g : R[X]} (hf : degree f ≤ a) (hg : degree g ≤ b) :
+    degree (f + g) ≤ max a b :=
+(f.degree_add_le g).trans $ max_le_max ‹_› ‹_›
+
+theorem degree_mul_le_of_le {a b : WithBot Nat} {f g : R[X]} (hf : degree f ≤ a) (hg : degree g ≤ b) :
+    degree (f * g) ≤ a + b :=
+(f.degree_mul_le _).trans $ add_le_add ‹_› ‹_›
+
+theorem degree_pow_le_of_le {a : WithBot Nat} (b : Nat) {f : R[X]} (hf : degree f ≤ a) :
+    degree (f ^ b) ≤ b * a := by
+  apply (degree_pow_le _ _).trans
+  rw [nsmul_eq_mul]
+  induction b with
+    | zero => simp [degree_one_le]
+    | succ n hn =>
+      rw [Nat.cast_succ, add_mul, add_mul, one_mul, one_mul]
+      exact (add_le_add_left hf _).trans (add_le_add_right hn _)
+
+theorem degree_nat_cast_le (n : Nat) : degree (n : R[X]) ≤ 0 := degree_le_of_natDegree_le (by simp)
+
+theorem degree_zero_le : degree (0 : R[X]) ≤ 0 := natDegree_eq_zero_iff_degree_le_zero.mp rfl
+
+end Lemmas__in_a_dependent_PR
+
 theorem natDegree_C_le (a : R) : natDegree (C a) ≤ 0 := (natDegree_C a).le
-theorem natDegree_nat_cast_le (n : ℕ) : natDegree (n : R[X]) ≤ 0 := (natDegree_nat_cast _).le
+theorem natDegree_nat_cast_le (n : Nat) : natDegree (n : R[X]) ≤ 0 := (natDegree_nat_cast _).le
 theorem natDegree_zero_le : natDegree (0 : R[X]) ≤ 0 := natDegree_zero.le
 theorem natDegree_one_le : natDegree (1 : R[X]) ≤ 0 := natDegree_one.le
 
 end semiring
 
-variable [Ring R] in
-theorem natDegree_int_cast_le (n : ℤ) : natDegree (n : R[X]) ≤ 0 := (natDegree_int_cast _).le
+section ring
+variable [Ring R]
 
-end leaf_lemmas
+section Lemmas__in_a_dependent_PR
+
+theorem natDegree_neg_le_of_le {a : Nat} {f : R[X]} (hf : natDegree f ≤ a) : natDegree (- f) ≤ a :=
+f.natDegree_neg.le.trans ‹_›
+
+theorem natDegree_sub_le_of_le {a b : Nat} {f g : R[X]} (hf : natDegree f ≤ a) (hg : natDegree g ≤ b) :
+    natDegree (f - g) ≤ max a b :=
+(f.natDegree_sub_le g).trans $ max_le_max ‹_› ‹_›
+
+theorem degree_neg_le_of_le {a : WithBot Nat} {f : R[X]} (hf : degree f ≤ a) : degree (- f) ≤ a :=
+f.degree_neg.le.trans ‹_›
+
+theorem degree_sub_le_of_le {a b : WithBot Nat} {f g : R[X]} (hf : degree f ≤ a) (hg : degree g ≤ b) :
+    degree (f - g) ≤ max a b :=
+(f.degree_sub_le g).trans $ max_le_max ‹_› ‹_›
+
+theorem degree_int_cast_le (n : Int) : degree (n : R[X]) ≤ 0 := degree_le_of_natDegree_le (by simp)
+
+end Lemmas__in_a_dependent_PR
+
+theorem natDegree_int_cast_le (n : Int) : natDegree (n : R[X]) ≤ 0 := (natDegree_int_cast _).le
+
+end ring
+
+end Polynomial
+
+end mylemmas
+
+namespace Mathlib.Tactic.ComputeDegree
+
+section Tactic
+
+open Lean
+
+/-- `isDegLE e` checks whether `e` is an `Expr`ession representing an inequality whose LHS is
+the `natDegree/degree` of a polynomial with coefficients in a semiring `R`.
+If `e` represents
+*  `natDegree f ≤ d`, then it returns `(true,  f)`;
+*  `degree f ≤ d`,    then it returns `(false, f)`;
+*  anything else, then it throws an error.
+-/
+def isDegLE (e : Expr) : CoreM (Bool × Expr) := do
+  match e.consumeMData.getAppFnArgs with
+    -- check that the target is an inequality `≤`...
+    | (``LE.le, #[_, _, lhs, _rhs]) => match lhs.getAppFnArgs with
+      -- and that the LHS is `natDegree ...` or `degree ...`
+      | (``degree, #[_R, _iSR, pol])    => return (false, pol)
+      | (``natDegree, #[_R, _iSR, pol]) => return (true, pol)
+      | (na, _) => throwError (m!"Expected an inequality of the form\n\n" ++
+        f!"  'f.natDegree ≤ d'  or  'f.degree ≤ d',\n\ninstead, {na} appears on the LHS")
+    |  (na, _)  => throwError m!"Expected an inequality instead of '{na}', '{e}'"
+
+/--
+`DegInfo` is a type whose terms encode the part of the syntax tree of a polynomial that currently
+plays a role in the computation of its degree.
+-/
+inductive DegInfo where
+  /-- `.rest` is the leaf usually associated to an `fvar`. -/
+  | rest     : DegInfo
+  /-- `.X` is the leaf associated to `Polynomial.X`. -/
+  | X        : DegInfo
+  /-- `.natCast` is a leaf associated to a term of type `ℕ`. -/
+  | natCast  : DegInfo
+  /-- `.intCast` is a leaf associated to a term of type `ℤ`. -/
+  | intCast  : DegInfo
+  /-- `.ofNat0` is a leaf associated to the constant polynomial `0`. -/
+  | ofNat0   : DegInfo
+  /-- `.ofNat1` is a leaf associated to the constant polynomial `1`. -/
+  | ofNat1   : DegInfo
+  /-- `.ofNatN` is a leaf associated to the constant polynomial with value `n ≠ 0, 1` in `ℕ`. -/
+  | ofNatN   : DegInfo
+  /-- `.C` is the leaf associated to `Polynomial.C x`. -/
+  | C        : DegInfo
+  /-- `.monomial` is the leaf associated to `↑(monomial n) _`. -/
+  | monomial : DegInfo
+  /-- `.neg` is a node associated to the opposite of a polynomial. -/
+  | neg      : DegInfo → DegInfo
+  /-- `.add f g` is a node associated to `f + g`. -/
+  | add      : DegInfo → DegInfo → DegInfo
+  /-- `.sub f g` is a node associated to `f - g`. -/
+  | sub      : DegInfo → DegInfo → DegInfo
+  /-- `.mul f g` is a node associated to `f * g`. -/
+  | mul      : DegInfo → DegInfo → DegInfo
+  /-- `.pow f` is a node associated to `f ^ n`. -/
+  | pow      : DegInfo → DegInfo
+  /-- `.err e` is a leaf for error-management. The `Expr`ession `e` is used to report an error. -/
+  | err      : Expr → DegInfo
+  deriving BEq, Inhabited, ToExpr
+
+namespace DegInfo
+
+/-- `getArgs di` takes as input `di : DegInfo` and returns the list of arguments of `di` with
+Type `DegInfo`. -/
+def getArgs : DegInfo → List DegInfo
+  | neg f    => [f]
+  | add f g  => [f, g]
+  | sub f g  => [f, g]
+  | mul f g  => [f, g]
+  | pow f    => [f]
+  | _  => []
+
+/-- `getErr? di` extracts the `Expr`ession `e` embedded in `di : DegInfo`, if `di = .err e`. -/
+def getErr? : DegInfo → Option Expr
+  | err e => some e
+  | _ => none
+
+/-- `ctorName di` reports the name of the head-constructor of `di : DegInfo`. -/
+def ctorName : DegInfo → String
+  | rest     => "rest"
+  | X        => "X"
+  | natCast  => "natCast"
+  | intCast  => "intCast"
+  | ofNat0   => "ofNat0"
+  | ofNat1   => "ofNat1"
+  | ofNatN   => "ofNatN"
+  | C        => "C"
+  | monomial => "monomial"
+  | neg ..   => "neg"
+  | add ..   => "add"
+  | sub ..   => "sub"
+  | mul ..   => "mul"
+  | pow ..   => "pow"
+  | err ..   => "err"
+
+/-- `expand di` converts `di : DegInfo` into a `String` for printing the tree-structure.
+Mostly useful for debugging. -/
+partial
+def expand (di : DegInfo) (n : Nat := 0) (indent: String := "") (sep : String := "-|") : String :=
+let expandArgs := di.getArgs.map (expand · (n + 1) (indent ++ sep))
+(if n == 0 then "" else "\n") ++ indent ++ di.ctorName ++ String.join expandArgs
+
+instance : ToString DegInfo where
+  toString := expand
+
+/-- `toLemmas di` assigns to `di : DegInfo` the pair of lemma names that apply for a polynomial
+whose head symbol matches the head symbol of `di`. -/
+def toLemmas : DegInfo → Name × Name
+  | rest     => (``le_rfl, ``le_rfl)
+  | X        => (``natDegree_X_le,         ``degree_X_le)
+  | natCast  => (``natDegree_nat_cast_le,  ``degree_nat_cast_le)
+  | intCast  => (``natDegree_int_cast_le,  ``degree_int_cast_le)
+  | ofNat0   => (``natDegree_zero_le,      ``degree_zero_le)
+  | ofNat1   => (``natDegree_one_le,       ``degree_one_le)
+  | ofNatN   => (``natDegree_nat_cast_le,  ``degree_nat_cast_le)
+  | C        => (``natDegree_C_le,         ``degree_C_le)
+  | monomial => (``natDegree_monomial_le,  ``degree_monomial_le)
+  | neg ..   => (``natDegree_neg_le_of_le, ``degree_neg_le_of_le)
+  | add ..   => (``natDegree_add_le_of_le, ``degree_add_le_of_le)
+  | sub ..   => (``natDegree_sub_le_of_le, ``degree_sub_le_of_le)
+  | mul ..   => (``natDegree_mul_le_of_le, ``degree_mul_le_of_le)
+  | pow ..   => (``natDegree_pow_le_of_le, ``degree_pow_le_of_le)
+  | err ..   => (.anonymous, .anonymous)
+
+end DegInfo
+
+/-- `toDegInfo pol` convert the `Expr`ession `pol` into a term of Type `DegInfo`.
+It recurses into `pol`, adapting the subexpressions of `pol` to the constructors of `DegInfo`. -/
+partial
+def toDegInfo (pol : Expr) : DegInfo :=
+match pol.numeral? with
+  -- can I avoid the tri-splitting `n = 0`, `n = 1`, and generic `n`?
+  | some 0 => .ofNat0
+  | some 1 => .ofNat1
+  | some _ => .ofNatN
+  | none => match pol.getAppFnArgs with
+    | (``HAdd.hAdd, #[_, _, _, _, f, g]) => .add (toDegInfo f) (toDegInfo g)
+    | (``HSub.hSub, #[_, _, _, _, f, g]) => .sub (toDegInfo f) (toDegInfo g)
+    | (``HMul.hMul, #[_, _, _, _, f, g]) => .mul (toDegInfo f) (toDegInfo g)
+    | (``HPow.hPow, #[_, _, _, _, f, _]) => .pow (toDegInfo f)
+    | (``Neg.neg,   #[_, _, f]) => .neg (toDegInfo f)
+    | (``Polynomial.X, _) => .X
+    | (``Nat.cast, _) => .natCast
+    | (``NatCast.natCast, _) => .natCast
+    | (``Int.cast, _) => .intCast
+    | (``IntCast.intCast, _) => .intCast
+    -- deal with `monomial` and `C`
+    | (``FunLike.coe, #[_, _, _, _, polFun, _]) => match polFun.getAppFnArgs with
+      | (``Polynomial.monomial, _) => .monomial
+      | (``Polynomial.C, _) => .C
+      | _ => .err polFun
+    -- possibly, all that's left is the case where `pol` is an `fvar` and its `Name` is `.anonymous`
+    | _ => .rest
+
+/-- `cDegCore (di, mv) π` takes as input
+*  a pair consisting of `di : DegInfo` and `mv : MVarId`;
+*  a function `π : Name × Name → Name`, typically `π` equals
+*  *  `Prod.fst` for a goal of type `natDegree f ≤ d` and
+*  *  `π` equals `Prod.snd` for a goal of type `degree f ≤ d`.
+
+`cDegCore` assumes that `mv` has type `natDegree f ≤ ?_` or `degree f ≤ ?_`.
+The RHS of the inequality is a meta-variable: the exact value of `?_` is determined along the way.
+`cDegCore` recurses into `di` to produce a proof of `natDegree f ≤ d` or of `degree f ≤ d`,
+where `d` is an appropriately constructed element of `ℕ` or `WithBot ℕ`.
+
+The optional `db` flag is for debugging: if `db = true`, then the tactic prints useful information.
+-/
+-- the tactic should not really fail when the inputs are as specified.
+partial
+def cDegCore (polMV : DegInfo × MVarId) (π : Name × Name → Name) (db : Bool := false) :
+    MetaM (List (Expr × MVarId)) := do
+let (di, mv) := polMV
+let na := π di.toLemmas
+if na.isAnonymous then throwError m!"'compute_degree_le' is undefined for '{di.getErr?.get!}'"
+let once := di.getArgs.zip (← mv.applyConst na)
+return (← once.mapM fun x => cDegCore x π db).join
+
+/-- Allows the syntax expression `compute_degree_le ! -debug`, with `!` and `-debug` independently
+optional. -/
+syntax (name := computeDegreeLE) "compute_degree_le" "!"? "-debug"? : tactic
+
+/-- Allows writing `compute_degree_le!` with no space preceding `!`. -/
+macro "compute_degree_le!" dbg:"-debug"? : tactic => `(tactic| compute_degree_le ! $[-debug%$dbg]?)
+
+open Elab.Tactic in
+/--
+`compute_degree_le` is a tactic to solve goals of the form `natDegree f ≤ d` or `degree f ≤ d`.
+
+The tactic first replaces `natDegree f ≤ d` with `d' ≤ d`,
+where `d'` is an internally computed guess for which the tactic proves the inequality
+`natDegree f ≤ d'`.
+
+Next, it applies `norm_num` to `d'`, in the hope of closing also the `d' ≤ d` goal.
+
+The variant `compute_degree_le!` first applies `compute_degree_le`.
+Then it uses `norm_num` on the whole inequality `d' ≤ d` and tries `assumption`.
+
+There is also a "debug-mode", where the tactic prints some information.
+This is activated by using `compute_degree_le -debug` or `compute_degree_le! -debug`.
+-/
+elab_rules : tactic | `(tactic| compute_degree_le $[!%$str]? $[-debug%$debug]?) => focus do
+  let (isNatDeg?, lhs) := ← isDegLE (← getMainTarget)
+  let π := if isNatDeg? then Prod.fst else Prod.snd
+  -- if the goal is `natDegree f ≤ d`, then `le_goals = [natDegree f ≤ ?m,  ?m ≤ d,  ℕ]`
+  -- if the goal is `degree f ≤ d`,    then `le_goals = [degree f ≤ ?m,     ?m ≤ d,  WithBot ℕ]`
+  let le_goals := ← (← getMainGoal).applyConst ``le_trans
+  let di := toDegInfo (← instantiateMVars lhs)
+  if debug.isSome then logInfo m!"{di}"
+  let nfle_pf := ← cDegCore (di, le_goals[0]!) π (db := debug.isSome)
+  guard (nfle_pf == []) <|> throwError m!"'compute_degree_le' should have closed {nfle_pf}"
+  setGoals [le_goals[1]!]
+  if str.isSome then evalTactic (← `(tactic| norm_num <;> try assumption))
+  else evalTactic (← `(tactic| conv_lhs => norm_num))
+
+end Tactic
 
 end Mathlib.Tactic.ComputeDegree

--- a/test/ComputeDegree.lean
+++ b/test/ComputeDegree.lean
@@ -1,0 +1,200 @@
+import Mathlib.Tactic.ComputeDegree
+
+open Polynomial
+
+section native_mathlib4_tests
+
+variable {n : Nat} {z : Int} {f : Int[X]} (hn : natDegree f ≤ 5) (hd : degree f ≤ 5)
+
+/--  This example flows through all the matches in `direct` with a `natDegree` goal. -/
+example : natDegree (- C z * X ^ 5 + (monomial 2 5) ^ 2 - 0 + 1 + IntCast.intCast 1 +
+    NatCast.natCast 1 + (z : Int[X]) + (n : Int[X]) + f) ≤ 5 := by
+  compute_degree_le!
+
+example [Semiring R] : natDegree (OfNat.ofNat (OfNat.ofNat 0) : R[X]) ≤ 0 := by
+  compute_degree_le
+
+/--  This example flows through all the matches in `direct` with a `degree` goal. -/
+example : degree (- C z * X ^ 5 + (monomial 2 5) ^ 2 - 0 + 1 + IntCast.intCast 1 +
+    NatCast.natCast 1 + (z : Int[X]) + (n : Int[X]) + f) ≤ 5 := by
+  set k := f with _h₀
+  compute_degree_le!
+
+example {N : WithBot Nat} (nN : n ≤ N) : degree (- C z * X ^ n) ≤ N := by
+  compute_degree_le!
+
+/-!  The following examples exhaust all the match-leaves in `direct`. -/
+
+--  OfNat.ofNat 0
+example : natDegree (0 : Int[X]) ≤ 5 := by
+  compute_degree_le!
+
+--  OfNat.ofNat (non-zero)
+example : natDegree (1 : Int[X]) ≤ 5 := by
+  compute_degree_le!
+
+--  NatCast.natCast
+example : natDegree (NatCast.natCast 4 : Int[X]) ≤ 5 := by
+  compute_degree_le!
+
+--  Nat.cast
+example : natDegree (n : Int[X]) ≤ 5 := by
+  compute_degree_le!
+
+--  IntCast.intCast
+example : natDegree (IntCast.intCast 4 : Int[X]) ≤ 5 := by
+  compute_degree_le!
+
+--  Int.cast
+example : natDegree (z : Int[X]) ≤ 5 := by
+  compute_degree_le!
+
+--  Polynomial.X
+example : natDegree (X : Int[X]) ≤ 5 := by
+  compute_degree_le!
+
+--  Polynomial.C
+example : natDegree (C n) ≤ 5 := by
+  compute_degree_le!
+
+--  Polynomial.monomial
+example (h : n ≤ 5) : natDegree (monomial n (5 + n)) ≤ 5 := by
+  compute_degree_le!
+
+--  Expr.fvar
+example {f : Nat[X]} : natDegree f ≤ natDegree f := by
+  compute_degree_le
+
+variable [Ring R]
+
+--  OfNat.ofNat 0
+example : natDegree (0 : R[X]) ≤ 5 := by
+  compute_degree_le!
+
+--  OfNat.ofNat (non-zero)
+example : natDegree (1 : R[X]) ≤ 5 := by
+  compute_degree_le!
+
+--  NatCast.natCast
+example : natDegree (NatCast.natCast 4 : R[X]) ≤ 5 := by
+  compute_degree_le!
+
+--  Nat.cast
+example : natDegree (n : R[X]) ≤ 5 := by
+  compute_degree_le!
+
+--  IntCast.intCast
+example : natDegree (IntCast.intCast 4 : R[X]) ≤ 5 := by
+  compute_degree_le!
+
+--  Int.cast
+example : natDegree (z : R[X]) ≤ 5 := by
+  compute_degree_le!
+
+--  Polynomial.X
+example : natDegree (X : R[X]) ≤ 5 := by
+  compute_degree_le!
+
+--  Polynomial.C
+example : natDegree (C n) ≤ 5 := by
+  compute_degree_le!
+
+--  Polynomial.monomial
+example (h : n ≤ 5) : natDegree (monomial n (5 + n : R)) ≤ 5 := by
+  compute_degree_le!
+
+--  Expr.fvar
+example {f : R[X]} : natDegree f ≤ natDegree f := by
+  compute_degree_le
+
+end native_mathlib4_tests
+
+section tests_from_mathlib3
+variable {R : Type _} [Semiring R] {a b c d e : R}
+
+-- test that `mdata` does not get in the way of the tactic
+example : natDegree (7 * X : R[X]) ≤ 1 := by
+  have : 0 ≤ 1 := zero_le_one
+  compute_degree_le
+
+-- possibly only a vestigial test from mathlib3: maybe to check for `instantiateMVars`?
+example {R : Type _} [Ring R] (h : ∀ {p q : R[X]}, p.natDegree ≤ 0 → (p * q).natDegree = 0) :
+    natDegree (- 1 * 1 : R[X]) = 0 := by
+  apply h _
+  compute_degree_le
+
+-- check for making sure that `compute_degree_le` is `focus`ed
+example : Polynomial.natDegree (Polynomial.C 4) ≤ 1 ∧ True := by
+  constructor
+  compute_degree_le!
+  trivial
+
+example {R : Type _} [Ring R] :
+    natDegree (- 1 * 1 : R[X]) ≤ 0 := by
+  compute_degree_le
+
+example {F} [Ring F] {a : F} :
+    natDegree (X ^ 9 - C a * X ^ 10 : F[X]) ≤ 10 := by
+  compute_degree_le
+
+example :
+    degree (X + (X * monomial 2 1 + X * X) ^ 2) ≤ 10 := by
+  compute_degree_le!
+
+example : natDegree (7 * X : R[X]) ≤ 1 := by
+  compute_degree_le
+
+example : natDegree (0 : R[X]) ≤ 0 := by
+  compute_degree_le
+
+example : natDegree (1 : R[X]) ≤ 0 := by
+  compute_degree_le
+
+example : natDegree (2 : R[X]) ≤ 0 := by
+  compute_degree_le
+
+example : natDegree ((n : Nat) : R[X]) ≤ 0 := by
+  compute_degree_le
+
+example {R} [Ring R] {n : Int} : natDegree ((n : Int) : R[X]) ≤ 0 := by
+  compute_degree_le
+
+example {R} [Ring R] {n : Nat} : natDegree ((- n : Int) : R[X]) ≤ 0 := by
+  compute_degree_le
+
+example : natDegree (monomial 5 c * monomial 1 c + monomial 7 d +
+    C a * X ^ 0 + C b * X ^ 5 + C c * X ^ 2 + X ^ 10 + C e * X) ≤ 10 := by
+  compute_degree_le
+
+example :
+    natDegree (monomial 0 c * (monomial 0 c * C 1) + monomial 0 d + C 1 + C a * X ^ 0) ≤ 0 := by
+  compute_degree_le
+
+example {F} [Ring F] : natDegree (X ^ 4 + 3 : F[X]) ≤ 4 := by
+  compute_degree_le
+
+example : natDegree ((5 * X * C 3 : _root_.Rat[X]) ^ 4) ≤ 4 := by
+  compute_degree_le
+
+example : natDegree ((C a * X) ^ 4) ≤ 4 := by
+  compute_degree_le
+
+example : degree ((X : Int[X]) ^ 4) ≤ 4 := by
+  compute_degree_le
+
+example : natDegree ((X : Int[X]) ^ 4) ≤ 40 := by
+  compute_degree_le!
+
+example : natDegree (C a * C b + X + monomial 3 4 * X) ≤ 4 := by
+  compute_degree_le
+
+variable {R : Type _} [Semiring R] {a b c d e : R}
+
+example {F} [Ring F] {a : F} :
+    natDegree (X ^ 3 + C a * X ^ 10 : F[X]) ≤ 10 := by
+    compute_degree_le
+
+example : natDegree (7 * X : R[X]) ≤ 1 := by
+  compute_degree_le
+
+end tests_from_mathlib3


### PR DESCRIPTION
This PR simply uses the tactic `compute_degree_le` from #5882 to remove golf two proofs.

One of the two proofs was the only `mathlib3` use of `compute_degree_le` and the new tactic removes a porting note.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

- [x] depends on: #5882, where the tactic `compute_degree_le` is defined

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
