### PR TITLE
[Merged by Bors] - chore: cleanup universes in tensor product basis

### DIFF
--- a/Mathlib/RingTheory/TensorProduct.lean
+++ b/Mathlib/RingTheory/TensorProduct.lean
@@ -1018,15 +1018,15 @@ end
 section Basis
 
 -- porting note: need to make a universe explicit for some reason in the next declaration
-universe u_5
-variable {k : Type _} [CommRing k] (R : Type _) [Ring R] [Algebra k R] {M : Type _}
-  [AddCommMonoid M] [Module k M] {ι : Type u_5} (b : Basis ι k M)
+universe uk uR uM uι
+variable {k : Type uk} [CommRing k] (R : Type uR) [Ring R] [Algebra k R] {M : Type uM}
+  [AddCommMonoid M] [Module k M] {ι : Type uι} (b : Basis ι k M)
 
 
 /-- Given a `k`-algebra `R` and a `k`-basis of `M,` this is a `k`-linear isomorphism
 `R ⊗[k] M ≃ (ι →₀ R)` (which is in fact `R`-linear). -/
 noncomputable def basisAux : R ⊗[k] M ≃ₗ[k] ι →₀ R :=
-  _root_.TensorProduct.congr (Finsupp.LinearEquiv.finsuppUnique k R PUnit.{u_5+1}).symm b.repr ≪≫ₗ
+  _root_.TensorProduct.congr (Finsupp.LinearEquiv.finsuppUnique k R PUnit.{uι+1}).symm b.repr ≪≫ₗ
     (finsuppTensorFinsupp k R k PUnit ι).trans
       (Finsupp.lcongr (Equiv.uniqueProd ι PUnit) (_root_.TensorProduct.rid k R))
 #align algebra.tensor_product.basis_aux Algebra.TensorProduct.basisAux

--- a/Mathlib/RingTheory/TensorProduct.lean
+++ b/Mathlib/RingTheory/TensorProduct.lean
@@ -1017,11 +1017,11 @@ end
 
 section Basis
 
-variable {k : Type _} [CommRing k] (R : Type _) [Ring R] [Algebra k R] {M : Type _}
-  [AddCommMonoid M] [Module k M] {ι : Type _} (b : Basis ι k M)
-
 -- porting note: need to make a universe explicit for some reason in the next declaration
 universe u_5
+variable {k : Type _} [CommRing k] (R : Type _) [Ring R] [Algebra k R] {M : Type _}
+  [AddCommMonoid M] [Module k M] {ι : Type u_5} (b : Basis ι k M)
+
 
 /-- Given a `k`-algebra `R` and a `k`-basis of `M,` this is a `k`-linear isomorphism
 `R ⊗[k] M ≃ (ι →₀ R)` (which is in fact `R`-linear). -/
@@ -1047,10 +1047,9 @@ theorem basisAux_map_smul (r : R) (x : R ⊗[k] M) : basisAux R b (r • x) = r 
 
 variable (R)
 
--- porting note: need to make a universe explicit. Is there a problem with `basisAux`?
 /-- Given a `k`-algebra `R`, this is the `R`-basis of `R ⊗[k] M` induced by a `k`-basis of `M`. -/
 noncomputable def basis : Basis ι R (R ⊗[k] M) where
-  repr := { basisAux.{u_5} R b with map_smul' := basisAux_map_smul b }
+  repr := { basisAux R b with map_smul' := basisAux_map_smul b }
 #align algebra.tensor_product.basis Algebra.TensorProduct.basis
 
 variable {R}


### PR DESCRIPTION
During the Leiden workshop we hit a problem showing that the dimension of a tensor product is preserved under base extension, this is due to `Algebra.TensorProduct.basis` having a loose universe variable.
We fix this, which makes the following code work.
I'm not 100% sure this is the right variable to set, but it seemed somewhat appropriate
```lean
section basis
variable [Field k] [AddCommGroup M] [Module k M] [Ring A] [Algebra k A] [Module A M] [IsScalarTower k A M] 
  [StrongRankCondition A] [Module.Free k M] [Module.Free A M] [Module.Free k A]

open TensorProduct -- for notation

noncomputable
def _root_.Basis.base_change (h : Basis ι k M) : Basis ι A (A ⊗[k] M) :=
Algebra.TensorProduct.basis A h -- needs a mathlib change for this to work!

lemma base_change_module_rank_preserved : Module.rank k M = Module.rank A (A ⊗[k] M) := by 
  obtain ⟨⟨_, bM⟩⟩ := Module.Free.exists_basis (R := k) (M := M)
  rw [← bM.mk_eq_rank'', (bM.base_change (A := A)).mk_eq_rank'']
end basis

```
---
cc @kbuzzard who ported that file in #4004 and was also involved in the project


<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
