### PR TITLE
[Merged by Bors] - feat(MeasureTheory.Integral.Bochner): drop completeness requirement from the definition

### DIFF
--- a/Mathlib/Analysis/Convolution.lean
+++ b/Mathlib/Analysis/Convolution.lean
@@ -471,7 +471,7 @@ theorem convolution_lsmul [Sub G] {f : G → 𝕜} {g : G → F} :
 #align convolution_lsmul convolution_lsmul
 
 /-- The definition of convolution where the bilinear operator is multiplication. -/
-theorem convolution_mul [Sub G] [NormedSpace ℝ 𝕜] [CompleteSpace 𝕜] {f : G → 𝕜} {g : G → 𝕜} :
+theorem convolution_mul [Sub G] [NormedSpace ℝ 𝕜] {f : G → 𝕜} {g : G → 𝕜} :
     (f ⋆[mul 𝕜 𝕜, μ] g) x = ∫ t, f t * g (x - t) ∂μ :=
   rfl
 #align convolution_mul convolution_mul
@@ -793,7 +793,7 @@ theorem convolution_lsmul_swap {f : G → 𝕜} {g : G → F} :
 #align convolution_lsmul_swap convolution_lsmul_swap
 
 /-- The symmetric definition of convolution where the bilinear operator is multiplication. -/
-theorem convolution_mul_swap [NormedSpace ℝ 𝕜] [CompleteSpace 𝕜] {f : G → 𝕜} {g : G → 𝕜} :
+theorem convolution_mul_swap [NormedSpace ℝ 𝕜] {f : G → 𝕜} {g : G → 𝕜} :
     (f ⋆[mul 𝕜 𝕜, μ] g) x = ∫ t, f (x - t) * g t ∂μ :=
   convolution_eq_swap _
 #align convolution_mul_swap convolution_mul_swap

--- a/Mathlib/Analysis/Fourier/FourierTransform.lean
+++ b/Mathlib/Analysis/Fourier/FourierTransform.lean
@@ -73,8 +73,6 @@ variable {𝕜 : Type _} [CommRing 𝕜] {V : Type _} [AddCommGroup V] [Module �
 
 section Defs
 
-variable [CompleteSpace E]
-
 /-- The Fourier transform integral for `f : V → E`, with respect to a bilinear form `L : V × W → 𝕜`
 and an additive character `e`. -/
 def fourierIntegral (e : Multiplicative 𝕜 →* 𝕊) (μ : Measure V) (L : V →ₗ[𝕜] W →ₗ[𝕜] 𝕜) (f : V → E)
@@ -249,7 +247,7 @@ theorem continuous_fourierChar : Continuous Real.fourierChar :=
   (map_continuous expMapCircle).comp (continuous_const.mul continuous_toAdd)
 #align real.continuous_fourier_char Real.continuous_fourierChar
 
-variable {E : Type _} [NormedAddCommGroup E] [CompleteSpace E] [NormedSpace ℂ E]
+variable {E : Type _} [NormedAddCommGroup E] [NormedSpace ℂ E]
 
 theorem vector_fourierIntegral_eq_integral_exp_smul {V : Type _} [AddCommGroup V] [Module ℝ V]
     [MeasurableSpace V] {W : Type _} [AddCommGroup W] [Module ℝ W] (L : V →ₗ[ℝ] W →ₗ[ℝ] ℝ)
@@ -272,8 +270,8 @@ theorem fourierIntegral_def (f : ℝ → E) (w : ℝ) :
 
 scoped[FourierTransform] notation "𝓕" => Real.fourierIntegral
 
-theorem fourierIntegral_eq_integral_exp_smul {E : Type _} [NormedAddCommGroup E] [CompleteSpace E]
-    [NormedSpace ℂ E] (f : ℝ → E) (w : ℝ) :
+theorem fourierIntegral_eq_integral_exp_smul {E : Type _} [NormedAddCommGroup E] [NormedSpace ℂ E]
+    (f : ℝ → E) (w : ℝ) :
     𝓕 f w = ∫ v : ℝ, Complex.exp (↑(-2 * π * v * w) * Complex.I) • f v := by
   simp_rw [fourierIntegral_def, Real.fourierChar_apply, mul_neg, neg_mul, mul_assoc]
 #align real.fourier_integral_eq_integral_exp_smul Real.fourierIntegral_eq_integral_exp_smul

--- a/Mathlib/Analysis/Fourier/RiemannLebesgueLemma.lean
+++ b/Mathlib/Analysis/Fourier/RiemannLebesgueLemma.lean
@@ -100,7 +100,7 @@ theorem fourier_integral_half_period_translate {w : V} (hw : w ≠ 0) :
   -- rw [integral_add_right_eq_self (fun (x : V) ↦ -(e[-⟪x, w⟫]) • f x)
   --       ((fun w ↦ (1 / (2 * ‖w‖ ^ (2 : ℕ))) • w) w)]
   -- Unfortunately now we need to specify `volume`, and call `dsimp`.
-  have := @integral_add_right_eq_self _ _ _ _ _ _ volume _ _ _ (fun (x : V) ↦ -(e[-⟪x, w⟫]) • f x)
+  have := @integral_add_right_eq_self _ _ _ _ _ volume _ _ _ (fun (x : V) ↦ -(e[-⟪x, w⟫]) • f x)
     ((fun w ↦ (1 / (2 * ‖w‖ ^ (2 : ℕ))) • w) w)
   erw [this] -- Porting note, we can avoid `erw` by first calling `dsimp at this ⊢`.
   simp only [neg_smul, integral_neg]

--- a/Mathlib/Analysis/SpecialFunctions/Gamma/Beta.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Gamma/Beta.lean
@@ -272,7 +272,7 @@ theorem GammaSeq_eq_approx_Gamma_integral {s : ℂ} (hs : 0 < re s) {n : ℕ} (h
   have : ∀ x : ℝ, x = x / n * n := by intro x; rw [div_mul_cancel]; exact Nat.cast_ne_zero.mpr hn
   conv_rhs => enter [1, x, 2, 1]; rw [this x]
   rw [GammaSeq_eq_betaIntegral_of_re_pos hs]
-  have := @intervalIntegral.integral_comp_div _ _ _ _ 0 n _
+  have := intervalIntegral.integral_comp_div (a := 0) (b := n)
     (fun x => ↑((1 - x) ^ n) * ↑(x * ↑n) ^ (s - 1) : ℝ → ℂ) (Nat.cast_ne_zero.mpr hn)
   dsimp only at this
   rw [betaIntegral, this, real_smul, zero_div, div_self, add_sub_cancel,

--- a/Mathlib/Analysis/SpecialFunctions/Gaussian.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Gaussian.lean
@@ -299,8 +299,8 @@ theorem integral_gaussian_complex_Ioi {b : ℂ} (hb : 0 < re b) :
   have : ∀ c : ℝ, ∫ x in (0 : ℝ)..c, cexp (-b * (x : ℂ) ^ 2) =
       ∫ x in -c..0, cexp (-b * (x : ℂ) ^ 2) := by
     intro c
-    have :=
-      @intervalIntegral.integral_comp_sub_left _ _ _ _ 0 c (fun x => cexp (-b * (x : ℂ) ^ 2)) 0
+    have := intervalIntegral.integral_comp_sub_left (a := 0) (b := c)
+      (fun x => cexp (-b * (x : ℂ) ^ 2)) 0
     simpa [zero_sub, neg_sq, neg_zero] using this
   have t1 :=
     intervalIntegral_tendsto_integral_Ioi 0 (integrable_cexp_neg_mul_sq hb).integrableOn tendsto_id

--- a/Mathlib/MeasureTheory/Integral/Bochner.lean
+++ b/Mathlib/MeasureTheory/Integral/Bochner.lean
@@ -1458,7 +1458,8 @@ theorem integral_add_measure {f : α → G} (hμ : Integrable f μ) (hν : Integ
     have hν_dfma : DominatedFinMeasAdditive (μ + ν) (weightedSMul ν : Set α → G →L[ℝ] G) 1 :=
       DominatedFinMeasAdditive.add_measure_left μ ν (dominatedFinMeasAdditive_weightedSMul ν)
         zero_le_one
-    rw [← setToFun_congr_measure_of_add_right hμ_dfma (dominatedFinMeasAdditive_weightedSMul μ) f hfi,
+    rw [← setToFun_congr_measure_of_add_right hμ_dfma
+          (dominatedFinMeasAdditive_weightedSMul μ) f hfi,
       ← setToFun_congr_measure_of_add_left hν_dfma (dominatedFinMeasAdditive_weightedSMul ν) f hfi]
     refine' setToFun_add_left' _ _ _ (fun s _ hμνs => _) f
     rw [Measure.coe_add, Pi.add_apply, add_lt_top] at hμνs

--- a/Mathlib/MeasureTheory/Integral/Bochner.lean
+++ b/Mathlib/MeasureTheory/Integral/Bochner.lean
@@ -779,20 +779,20 @@ end L1
 
 Define the Bochner integral on functions generally to be the `L1` Bochner integral, for integrable
 functions, and 0 otherwise; prove its basic properties.
-
 -/
 
-
-variable [NormedAddCommGroup E] [NormedSpace ℝ E] [CompleteSpace E] [NontriviallyNormedField 𝕜]
+variable [NormedAddCommGroup E] [NormedSpace ℝ E] [hE : CompleteSpace E] [NontriviallyNormedField 𝕜]
   [NormedSpace 𝕜 E] [SMulCommClass ℝ 𝕜 E] [NormedAddCommGroup F] [NormedSpace ℝ F] [CompleteSpace F]
-
+  {G : Type _} [NormedAddCommGroup G] [NormedSpace ℝ G]
 section
 
 open scoped Classical
 
 /-- The Bochner integral -/
-irreducible_def integral {_ : MeasurableSpace α} (μ : Measure α) (f : α → E) : E :=
-  if hf : Integrable f μ then L1.integral (hf.toL1 f) else 0
+irreducible_def integral {_ : MeasurableSpace α} (μ : Measure α) (f : α → G) : G :=
+  if _ : CompleteSpace G then
+    (if hf : Integrable f μ then L1.integral (hf.toL1 f) else 0)
+  else 0
 #align measure_theory.integral MeasureTheory.integral
 
 end
@@ -800,7 +800,6 @@ end
 /-! In the notation for integrals, an expression like `∫ x, g ‖x‖ ∂μ` will not be parsed correctly,
   and needs parentheses. We do not set the binding power of `r` to `0`, because then
   `∫ x, f x = 0` will be parsed incorrectly. -/
-
 
 @[inherit_doc MeasureTheory.integral]
 notation3 "∫ "(...)", "r:60:(scoped f => f)" ∂"μ:70 => integral μ r
@@ -820,13 +819,13 @@ open ContinuousLinearMap MeasureTheory.SimpleFunc
 
 variable {f g : α → E} {m : MeasurableSpace α} {μ : Measure α}
 
-theorem integral_eq (f : α → E) (hf : Integrable f μ) : ∫ a, f a ∂μ = L1.integral (hf.toL1 f) :=
-  by rw [integral]; exact @dif_pos _ (id _) hf _ _ _
+theorem integral_eq (f : α → E) (hf : Integrable f μ) : ∫ a, f a ∂μ = L1.integral (hf.toL1 f) := by
+  simp [integral, hE, hf]
 #align measure_theory.integral_eq MeasureTheory.integral_eq
 
 theorem integral_eq_setToFun (f : α → E) :
     ∫ a, f a ∂μ = setToFun μ (weightedSMul μ) (dominatedFinMeasAdditive_weightedSMul μ) f := by
-  simp only [integral, L1.integral]; rfl
+  simp only [integral, hE, L1.integral]; rfl
 #align measure_theory.integral_eq_set_to_fun MeasureTheory.integral_eq_setToFun
 
 theorem L1.integral_eq_integral (f : α →₁[μ] E) : L1.integral f = ∫ a, f a ∂μ := by
@@ -835,74 +834,90 @@ theorem L1.integral_eq_integral (f : α →₁[μ] E) : L1.integral f = ∫ a, f
 set_option linter.uppercaseLean3 false in
 #align measure_theory.L1.integral_eq_integral MeasureTheory.L1.integral_eq_integral
 
-theorem integral_undef (h : ¬Integrable f μ) : ∫ a, f a ∂μ = 0 := by
-  rw [integral]; exact @dif_neg _ (id _) h _ _ _
+theorem integral_undef {f : α → G} (h : ¬Integrable f μ) : ∫ a, f a ∂μ = 0 := by
+  by_cases hG : CompleteSpace G
+  · simp [integral, hG]; exact @dif_neg _ (id _) h _ _ _
+  · simp [integral, hG]
 #align measure_theory.integral_undef MeasureTheory.integral_undef
 
-theorem integral_non_aestronglyMeasurable (h : ¬AEStronglyMeasurable f μ) : ∫ a, f a ∂μ = 0 :=
+theorem integral_non_aestronglyMeasurable {f : α → G} (h : ¬AEStronglyMeasurable f μ) :
+    ∫ a, f a ∂μ = 0 :=
   integral_undef <| not_and_of_not_left _ h
 #align measure_theory.integral_non_ae_strongly_measurable MeasureTheory.integral_non_aestronglyMeasurable
 
-variable (α E)
+variable (α G)
 
-theorem integral_zero : ∫ _ : α, (0 : E) ∂μ = 0 := by
-  simp only [integral, L1.integral]
-  exact setToFun_zero (dominatedFinMeasAdditive_weightedSMul μ)
+theorem integral_zero : ∫ _ : α, (0 : G) ∂μ = 0 := by
+  by_cases hG : CompleteSpace G
+  · simp only [integral, hG, L1.integral]
+    exact setToFun_zero (dominatedFinMeasAdditive_weightedSMul μ)
+  · simp [integral, hG]
 #align measure_theory.integral_zero MeasureTheory.integral_zero
 
 @[simp]
-theorem integral_zero' : integral μ (0 : α → E) = 0 :=
-  integral_zero α E
+theorem integral_zero' : integral μ (0 : α → G) = 0 :=
+  integral_zero α G
 #align measure_theory.integral_zero' MeasureTheory.integral_zero'
 
-variable {α E}
+variable {α G}
 
 theorem integrable_of_integral_eq_one {f : α → ℝ} (h : ∫ x, f x ∂μ = 1) : Integrable f μ := by
   contrapose h; rw [integral_undef h]; exact zero_ne_one
 #align measure_theory.integrable_of_integral_eq_one MeasureTheory.integrable_of_integral_eq_one
 
-theorem integral_add (hf : Integrable f μ) (hg : Integrable g μ) :
+theorem integral_add {f g : α → G} (hf : Integrable f μ) (hg : Integrable g μ) :
     ∫ a, f a + g a ∂μ = ∫ a, f a ∂μ + ∫ a, g a ∂μ := by
-  simp only [integral, L1.integral]
-  exact setToFun_add (dominatedFinMeasAdditive_weightedSMul μ) hf hg
+  by_cases hG : CompleteSpace G
+  · simp only [integral, hG, L1.integral]
+    exact setToFun_add (dominatedFinMeasAdditive_weightedSMul μ) hf hg
+  · simp [integral, hG]
 #align measure_theory.integral_add MeasureTheory.integral_add
 
-theorem integral_add' (hf : Integrable f μ) (hg : Integrable g μ) :
+theorem integral_add' {f g : α → G} (hf : Integrable f μ) (hg : Integrable g μ) :
     ∫ a, (f + g) a ∂μ = ∫ a, f a ∂μ + ∫ a, g a ∂μ :=
   integral_add hf hg
 #align measure_theory.integral_add' MeasureTheory.integral_add'
 
-theorem integral_finset_sum {ι} (s : Finset ι) {f : ι → α → E} (hf : ∀ i ∈ s, Integrable (f i) μ) :
+theorem integral_finset_sum {ι} (s : Finset ι) {f : ι → α → G} (hf : ∀ i ∈ s, Integrable (f i) μ) :
     ∫ a, ∑ i in s, f i a ∂μ = ∑ i in s, ∫ a, f i a ∂μ := by
-  simp only [integral, L1.integral]
-  exact setToFun_finset_sum (dominatedFinMeasAdditive_weightedSMul _) s hf
+  by_cases hG : CompleteSpace G
+  · simp only [integral, hG, L1.integral]
+    exact setToFun_finset_sum (dominatedFinMeasAdditive_weightedSMul _) s hf
+  · simp [integral, hG]
 #align measure_theory.integral_finset_sum MeasureTheory.integral_finset_sum
 
 @[integral_simps]
-theorem integral_neg (f : α → E) : ∫ a, -f a ∂μ = -∫ a, f a ∂μ := by
-  simp only [integral, L1.integral]
-  exact setToFun_neg (dominatedFinMeasAdditive_weightedSMul μ) f
+theorem integral_neg (f : α → G) : ∫ a, -f a ∂μ = -∫ a, f a ∂μ := by
+  by_cases hG : CompleteSpace G
+  · simp only [integral, hG, L1.integral]
+    exact setToFun_neg (dominatedFinMeasAdditive_weightedSMul μ) f
+  · simp [integral, hG]
 #align measure_theory.integral_neg MeasureTheory.integral_neg
 
-theorem integral_neg' (f : α → E) : ∫ a, (-f) a ∂μ = -∫ a, f a ∂μ :=
+theorem integral_neg' (f : α → G) : ∫ a, (-f) a ∂μ = -∫ a, f a ∂μ :=
   integral_neg f
 #align measure_theory.integral_neg' MeasureTheory.integral_neg'
 
-theorem integral_sub (hf : Integrable f μ) (hg : Integrable g μ) :
+theorem integral_sub {f g : α → G} (hf : Integrable f μ) (hg : Integrable g μ) :
     ∫ a, f a - g a ∂μ = ∫ a, f a ∂μ - ∫ a, g a ∂μ := by
-  simp only [integral, L1.integral]
-  exact setToFun_sub (dominatedFinMeasAdditive_weightedSMul μ) hf hg
+  by_cases hG : CompleteSpace G
+  · simp only [integral, hG, L1.integral]
+    exact setToFun_sub (dominatedFinMeasAdditive_weightedSMul μ) hf hg
+  · simp [integral, hG]
 #align measure_theory.integral_sub MeasureTheory.integral_sub
 
-theorem integral_sub' (hf : Integrable f μ) (hg : Integrable g μ) :
+theorem integral_sub' {f g : α → G} (hf : Integrable f μ) (hg : Integrable g μ) :
     ∫ a, (f - g) a ∂μ = ∫ a, f a ∂μ - ∫ a, g a ∂μ :=
   integral_sub hf hg
 #align measure_theory.integral_sub' MeasureTheory.integral_sub'
 
 @[integral_simps]
-theorem integral_smul (c : 𝕜) (f : α → E) : ∫ a, c • f a ∂μ = c • ∫ a, f a ∂μ := by
-  simp only [integral, L1.integral]
-  exact setToFun_smul (dominatedFinMeasAdditive_weightedSMul μ) weightedSMul_smul c f
+theorem integral_smul [NormedSpace 𝕜 G] [SMulCommClass ℝ 𝕜 G] (c : 𝕜) (f : α → G) :
+    ∫ a, c • f a ∂μ = c • ∫ a, f a ∂μ := by
+  by_cases hG : CompleteSpace G
+  · simp only [integral, hG, L1.integral]
+    exact setToFun_smul (dominatedFinMeasAdditive_weightedSMul μ) weightedSMul_smul c f
+  · simp [integral, hG]
 #align measure_theory.integral_smul MeasureTheory.integral_smul
 
 theorem integral_mul_left {L : Type _} [IsROrC L] (r : L) (f : α → L) :
@@ -920,47 +935,55 @@ theorem integral_div {L : Type _} [IsROrC L] (r : L) (f : α → L) :
   simpa only [← div_eq_mul_inv] using integral_mul_right r⁻¹ f
 #align measure_theory.integral_div MeasureTheory.integral_div
 
-theorem integral_congr_ae (h : f =ᵐ[μ] g) : ∫ a, f a ∂μ = ∫ a, g a ∂μ := by
-  simp only [integral, L1.integral]
-  exact setToFun_congr_ae (dominatedFinMeasAdditive_weightedSMul μ) h
+theorem integral_congr_ae {f g : α → G} (h : f =ᵐ[μ] g) : ∫ a, f a ∂μ = ∫ a, g a ∂μ := by
+  by_cases hG : CompleteSpace G
+  · simp only [integral, hG, L1.integral]
+    exact setToFun_congr_ae (dominatedFinMeasAdditive_weightedSMul μ) h
+  · simp [integral, hG]
 #align measure_theory.integral_congr_ae MeasureTheory.integral_congr_ae
 
 -- Porting note: `nolint simpNF` added because simplify fails on left-hand side
 @[simp, nolint simpNF]
-theorem L1.integral_of_fun_eq_integral {f : α → E} (hf : Integrable f μ) :
+theorem L1.integral_of_fun_eq_integral {f : α → G} (hf : Integrable f μ) :
     ∫ a, (hf.toL1 f) a ∂μ = ∫ a, f a ∂μ := by
-  simp only [MeasureTheory.integral, L1.integral]
-  exact setToFun_toL1 (dominatedFinMeasAdditive_weightedSMul μ) hf
+  by_cases hG : CompleteSpace G
+  · simp only [MeasureTheory.integral, hG, L1.integral]
+    exact setToFun_toL1 (dominatedFinMeasAdditive_weightedSMul μ) hf
+  · simp [MeasureTheory.integral, hG]
 set_option linter.uppercaseLean3 false in
 #align measure_theory.L1.integral_of_fun_eq_integral MeasureTheory.L1.integral_of_fun_eq_integral
 
 @[continuity]
-theorem continuous_integral : Continuous fun f : α →₁[μ] E => ∫ a, f a ∂μ := by
-  simp only [integral, L1.integral]
-  exact continuous_setToFun (dominatedFinMeasAdditive_weightedSMul μ)
+theorem continuous_integral : Continuous fun f : α →₁[μ] G => ∫ a, f a ∂μ := by
+  by_cases hG : CompleteSpace G
+  · simp only [integral, hG, L1.integral]
+    exact continuous_setToFun (dominatedFinMeasAdditive_weightedSMul μ)
+  · simp [integral, hG, continuous_const]
 #align measure_theory.continuous_integral MeasureTheory.continuous_integral
 
-theorem norm_integral_le_lintegral_norm (f : α → E) :
+theorem norm_integral_le_lintegral_norm (f : α → G) :
     ‖∫ a, f a ∂μ‖ ≤ ENNReal.toReal (∫⁻ a, ENNReal.ofReal ‖f a‖ ∂μ) := by
-  by_cases hf : Integrable f μ
-  · rw [integral_eq f hf, ← Integrable.norm_toL1_eq_lintegral_norm f hf]
-    exact L1.norm_integral_le _
-  · rw [integral_undef hf, norm_zero]; exact toReal_nonneg
+  by_cases hG : CompleteSpace G
+  · by_cases hf : Integrable f μ
+    · rw [integral_eq f hf, ← Integrable.norm_toL1_eq_lintegral_norm f hf]
+      exact L1.norm_integral_le _
+    · rw [integral_undef hf, norm_zero]; exact toReal_nonneg
+  · simp [integral, hG]
 #align measure_theory.norm_integral_le_lintegral_norm MeasureTheory.norm_integral_le_lintegral_norm
 
-theorem ennnorm_integral_le_lintegral_ennnorm (f : α → E) :
+theorem ennnorm_integral_le_lintegral_ennnorm (f : α → G) :
     (‖∫ a, f a ∂μ‖₊ : ℝ≥0∞) ≤ ∫⁻ a, ‖f a‖₊ ∂μ := by
   simp_rw [← ofReal_norm_eq_coe_nnnorm]; apply ENNReal.ofReal_le_of_le_toReal
   exact norm_integral_le_lintegral_norm f
 #align measure_theory.ennnorm_integral_le_lintegral_ennnorm MeasureTheory.ennnorm_integral_le_lintegral_ennnorm
 
-theorem integral_eq_zero_of_ae {f : α → E} (hf : f =ᵐ[μ] 0) : ∫ a, f a ∂μ = 0 := by
+theorem integral_eq_zero_of_ae {f : α → G} (hf : f =ᵐ[μ] 0) : ∫ a, f a ∂μ = 0 := by
   simp [integral_congr_ae hf, integral_zero]
 #align measure_theory.integral_eq_zero_of_ae MeasureTheory.integral_eq_zero_of_ae
 
 /-- If `f` has finite integral, then `∫ x in s, f x ∂μ` is absolutely continuous in `s`: it tends
 to zero as `μ s` tends to zero. -/
-theorem HasFiniteIntegral.tendsto_set_integral_nhds_zero {ι} {f : α → E}
+theorem HasFiniteIntegral.tendsto_set_integral_nhds_zero {ι} {f : α → G}
     (hf : HasFiniteIntegral f μ) {l : Filter ι} {s : ι → Set α} (hs : Tendsto (μ ∘ s) l (𝓝 0)) :
     Tendsto (fun i => ∫ x in s i, f x ∂μ) l (𝓝 0) := by
   rw [tendsto_zero_iff_norm_tendsto_zero]
@@ -973,19 +996,21 @@ theorem HasFiniteIntegral.tendsto_set_integral_nhds_zero {ι} {f : α → E}
 
 /-- If `f` is integrable, then `∫ x in s, f x ∂μ` is absolutely continuous in `s`: it tends
 to zero as `μ s` tends to zero. -/
-theorem Integrable.tendsto_set_integral_nhds_zero {ι} {f : α → E} (hf : Integrable f μ)
+theorem Integrable.tendsto_set_integral_nhds_zero {ι} {f : α → G} (hf : Integrable f μ)
     {l : Filter ι} {s : ι → Set α} (hs : Tendsto (μ ∘ s) l (𝓝 0)) :
     Tendsto (fun i => ∫ x in s i, f x ∂μ) l (𝓝 0) :=
   hf.2.tendsto_set_integral_nhds_zero hs
 #align measure_theory.integrable.tendsto_set_integral_nhds_zero MeasureTheory.Integrable.tendsto_set_integral_nhds_zero
 
 /-- If `F i → f` in `L1`, then `∫ x, F i x ∂μ → ∫ x, f x ∂μ`. -/
-theorem tendsto_integral_of_L1 {ι} (f : α → E) (hfi : Integrable f μ) {F : ι → α → E} {l : Filter ι}
+theorem tendsto_integral_of_L1 {ι} (f : α → G) (hfi : Integrable f μ) {F : ι → α → G} {l : Filter ι}
     (hFi : ∀ᶠ i in l, Integrable (F i) μ)
     (hF : Tendsto (fun i => ∫⁻ x, ‖F i x - f x‖₊ ∂μ) l (𝓝 0)) :
     Tendsto (fun i => ∫ x, F i x ∂μ) l (𝓝 <| ∫ x, f x ∂μ) := by
-  simp only [integral, L1.integral]
-  exact tendsto_setToFun_of_L1 (dominatedFinMeasAdditive_weightedSMul μ) f hfi hFi hF
+  by_cases hG : CompleteSpace G
+  · simp only [integral, hG, L1.integral]
+    exact tendsto_setToFun_of_L1 (dominatedFinMeasAdditive_weightedSMul μ) f hfi hFi hF
+  · simp [integral, hG, tendsto_const_nhds]
 set_option linter.uppercaseLean3 false in
 #align measure_theory.tendsto_integral_of_L1 MeasureTheory.tendsto_integral_of_L1
 
@@ -994,29 +1019,33 @@ set_option linter.uppercaseLean3 false in
   We could weaken the condition `bound_integrable` to require `HasFiniteIntegral bound μ` instead
   (i.e. not requiring that `bound` is measurable), but in all applications proving integrability
   is easier. -/
-theorem tendsto_integral_of_dominated_convergence {F : ℕ → α → E} {f : α → E} (bound : α → ℝ)
+theorem tendsto_integral_of_dominated_convergence {F : ℕ → α → G} {f : α → G} (bound : α → ℝ)
     (F_measurable : ∀ n, AEStronglyMeasurable (F n) μ) (bound_integrable : Integrable bound μ)
     (h_bound : ∀ n, ∀ᵐ a ∂μ, ‖F n a‖ ≤ bound a)
     (h_lim : ∀ᵐ a ∂μ, Tendsto (fun n => F n a) atTop (𝓝 (f a))) :
     Tendsto (fun n => ∫ a, F n a ∂μ) atTop (𝓝 <| ∫ a, f a ∂μ) := by
-  simp only [integral, L1.integral]
-  exact tendsto_setToFun_of_dominated_convergence (dominatedFinMeasAdditive_weightedSMul μ)
-    bound F_measurable bound_integrable h_bound h_lim
+  by_cases hG : CompleteSpace G
+  · simp only [integral, hG, L1.integral]
+    exact tendsto_setToFun_of_dominated_convergence (dominatedFinMeasAdditive_weightedSMul μ)
+      bound F_measurable bound_integrable h_bound h_lim
+  · simp [integral, hG]
 #align measure_theory.tendsto_integral_of_dominated_convergence MeasureTheory.tendsto_integral_of_dominated_convergence
 
 /-- Lebesgue dominated convergence theorem for filters with a countable basis -/
 theorem tendsto_integral_filter_of_dominated_convergence {ι} {l : Filter ι} [l.IsCountablyGenerated]
-    {F : ι → α → E} {f : α → E} (bound : α → ℝ) (hF_meas : ∀ᶠ n in l, AEStronglyMeasurable (F n) μ)
+    {F : ι → α → G} {f : α → G} (bound : α → ℝ) (hF_meas : ∀ᶠ n in l, AEStronglyMeasurable (F n) μ)
     (h_bound : ∀ᶠ n in l, ∀ᵐ a ∂μ, ‖F n a‖ ≤ bound a) (bound_integrable : Integrable bound μ)
     (h_lim : ∀ᵐ a ∂μ, Tendsto (fun n => F n a) l (𝓝 (f a))) :
     Tendsto (fun n => ∫ a, F n a ∂μ) l (𝓝 <| ∫ a, f a ∂μ) := by
-  simp only [integral, L1.integral]
-  exact tendsto_setToFun_filter_of_dominated_convergence (dominatedFinMeasAdditive_weightedSMul μ)
-    bound hF_meas h_bound bound_integrable h_lim
+  by_cases hG : CompleteSpace G
+  · simp only [integral, hG, L1.integral]
+    exact tendsto_setToFun_filter_of_dominated_convergence (dominatedFinMeasAdditive_weightedSMul μ)
+      bound hF_meas h_bound bound_integrable h_lim
+  · simp [integral, hG, tendsto_const_nhds]
 #align measure_theory.tendsto_integral_filter_of_dominated_convergence MeasureTheory.tendsto_integral_filter_of_dominated_convergence
 
 /-- Lebesgue dominated convergence theorem for series. -/
-theorem hasSum_integral_of_dominated_convergence {ι} [Countable ι] {F : ι → α → E} {f : α → E}
+theorem hasSum_integral_of_dominated_convergence {ι} [Countable ι] {F : ι → α → G} {f : α → G}
     (bound : ι → α → ℝ) (hF_meas : ∀ n, AEStronglyMeasurable (F n) μ)
     (h_bound : ∀ n, ∀ᵐ a ∂μ, ‖F n a‖ ≤ bound n a)
     (bound_summable : ∀ᵐ a ∂μ, Summable fun n => bound n a)
@@ -1046,43 +1075,51 @@ theorem hasSum_integral_of_dominated_convergence {ι} [Countable ι] {F : ι →
 
 variable {X : Type _} [TopologicalSpace X] [FirstCountableTopology X]
 
-theorem continuousWithinAt_of_dominated {F : X → α → E} {x₀ : X} {bound : α → ℝ} {s : Set X}
+theorem continuousWithinAt_of_dominated {F : X → α → G} {x₀ : X} {bound : α → ℝ} {s : Set X}
     (hF_meas : ∀ᶠ x in 𝓝[s] x₀, AEStronglyMeasurable (F x) μ)
     (h_bound : ∀ᶠ x in 𝓝[s] x₀, ∀ᵐ a ∂μ, ‖F x a‖ ≤ bound a) (bound_integrable : Integrable bound μ)
     (h_cont : ∀ᵐ a ∂μ, ContinuousWithinAt (fun x => F x a) s x₀) :
     ContinuousWithinAt (fun x => ∫ a, F x a ∂μ) s x₀ := by
-  simp only [integral, L1.integral]
-  exact continuousWithinAt_setToFun_of_dominated (dominatedFinMeasAdditive_weightedSMul μ)
-    hF_meas h_bound bound_integrable h_cont
+  by_cases hG : CompleteSpace G
+  · simp only [integral, hG, L1.integral]
+    exact continuousWithinAt_setToFun_of_dominated (dominatedFinMeasAdditive_weightedSMul μ)
+      hF_meas h_bound bound_integrable h_cont
+  · simp [integral, hG, continuousWithinAt_const]
 #align measure_theory.continuous_within_at_of_dominated MeasureTheory.continuousWithinAt_of_dominated
 
-theorem continuousAt_of_dominated {F : X → α → E} {x₀ : X} {bound : α → ℝ}
+theorem continuousAt_of_dominated {F : X → α → G} {x₀ : X} {bound : α → ℝ}
     (hF_meas : ∀ᶠ x in 𝓝 x₀, AEStronglyMeasurable (F x) μ)
     (h_bound : ∀ᶠ x in 𝓝 x₀, ∀ᵐ a ∂μ, ‖F x a‖ ≤ bound a) (bound_integrable : Integrable bound μ)
     (h_cont : ∀ᵐ a ∂μ, ContinuousAt (fun x => F x a) x₀) :
     ContinuousAt (fun x => ∫ a, F x a ∂μ) x₀ := by
-  simp only [integral, L1.integral]
-  exact continuousAt_setToFun_of_dominated (dominatedFinMeasAdditive_weightedSMul μ)
-    hF_meas h_bound bound_integrable h_cont
+  by_cases hG : CompleteSpace G
+  · simp only [integral, hG, L1.integral]
+    exact continuousAt_setToFun_of_dominated (dominatedFinMeasAdditive_weightedSMul μ)
+      hF_meas h_bound bound_integrable h_cont
+  · simp [integral, hG, continuousAt_const]
 #align measure_theory.continuous_at_of_dominated MeasureTheory.continuousAt_of_dominated
 
-theorem continuousOn_of_dominated {F : X → α → E} {bound : α → ℝ} {s : Set X}
+theorem continuousOn_of_dominated {F : X → α → G} {bound : α → ℝ} {s : Set X}
     (hF_meas : ∀ x ∈ s, AEStronglyMeasurable (F x) μ)
     (h_bound : ∀ x ∈ s, ∀ᵐ a ∂μ, ‖F x a‖ ≤ bound a) (bound_integrable : Integrable bound μ)
     (h_cont : ∀ᵐ a ∂μ, ContinuousOn (fun x => F x a) s) :
     ContinuousOn (fun x => ∫ a, F x a ∂μ) s := by
-  simp only [integral, L1.integral]
-  exact continuousOn_setToFun_of_dominated (dominatedFinMeasAdditive_weightedSMul μ)
-    hF_meas h_bound bound_integrable h_cont
+  by_cases hG : CompleteSpace G
+  · simp only [integral, hG, L1.integral]
+    exact continuousOn_setToFun_of_dominated (dominatedFinMeasAdditive_weightedSMul μ)
+      hF_meas h_bound bound_integrable h_cont
+  · simp [integral, hG, continuousOn_const]
 #align measure_theory.continuous_on_of_dominated MeasureTheory.continuousOn_of_dominated
 
-theorem continuous_of_dominated {F : X → α → E} {bound : α → ℝ}
+theorem continuous_of_dominated {F : X → α → G} {bound : α → ℝ}
     (hF_meas : ∀ x, AEStronglyMeasurable (F x) μ) (h_bound : ∀ x, ∀ᵐ a ∂μ, ‖F x a‖ ≤ bound a)
     (bound_integrable : Integrable bound μ) (h_cont : ∀ᵐ a ∂μ, Continuous fun x => F x a) :
     Continuous fun x => ∫ a, F x a ∂μ := by
-  simp only [integral, L1.integral]
-  exact continuous_setToFun_of_dominated (dominatedFinMeasAdditive_weightedSMul μ)
-    hF_meas h_bound bound_integrable h_cont
+  by_cases hG : CompleteSpace G
+  · simp only [integral, hG, L1.integral]
+    exact continuous_setToFun_of_dominated (dominatedFinMeasAdditive_weightedSMul μ)
+      hF_meas h_bound bound_integrable h_cont
+  · simp [integral, hG, continuous_const]
 #align measure_theory.continuous_of_dominated MeasureTheory.continuous_of_dominated
 
 /-- The Bochner integral of a real-valued function `f : α → ℝ` is the difference between the
@@ -1113,7 +1150,7 @@ theorem integral_eq_lintegral_pos_part_sub_lintegral_neg_part {f : α → ℝ} (
     apply NNReal.eq
     simp only [Real.coe_toNNReal', coe_nnnorm, nnnorm_neg]
     rw [Real.norm_of_nonpos (min_le_right _ _), ← max_neg_neg, neg_zero]
-  rw [eq₁, eq₂, integral, dif_pos]
+  rw [eq₁, eq₂, integral, dif_pos, dif_pos]
   exact L1.integral_eq_norm_posPart_sub _
 #align measure_theory.integral_eq_lintegral_pos_part_sub_lintegral_neg_part MeasureTheory.integral_eq_lintegral_pos_part_sub_lintegral_neg_part
 
@@ -1140,14 +1177,14 @@ theorem integral_eq_lintegral_of_nonneg_ae {f : α → ℝ} (hf : 0 ≤ᵐ[μ] f
     rw [this, hfi]; rfl
 #align measure_theory.integral_eq_lintegral_of_nonneg_ae MeasureTheory.integral_eq_lintegral_of_nonneg_ae
 
-theorem integral_norm_eq_lintegral_nnnorm {G} [NormedAddCommGroup G] {f : α → G}
+theorem integral_norm_eq_lintegral_nnnorm {P : Type _} [NormedAddCommGroup P] {f : α → P}
     (hf : AEStronglyMeasurable f μ) : ∫ x, ‖f x‖ ∂μ = ENNReal.toReal (∫⁻ x, ‖f x‖₊ ∂μ) := by
   rw [integral_eq_lintegral_of_nonneg_ae _ hf.norm]
   · simp_rw [ofReal_norm_eq_coe_nnnorm]
   · refine' ae_of_all _ _; simp_rw [Pi.zero_apply, norm_nonneg, imp_true_iff]
 #align measure_theory.integral_norm_eq_lintegral_nnnorm MeasureTheory.integral_norm_eq_lintegral_nnnorm
 
-theorem ofReal_integral_norm_eq_lintegral_nnnorm {G} [NormedAddCommGroup G] {f : α → G}
+theorem ofReal_integral_norm_eq_lintegral_nnnorm {P : Type _} [NormedAddCommGroup P] {f : α → P}
     (hf : Integrable f μ) : ENNReal.ofReal (∫ x, ‖f x‖ ∂μ) = ∫⁻ x, ‖f x‖₊ ∂μ := by
   rw [integral_norm_eq_lintegral_nnnorm hf.aestronglyMeasurable,
     ENNReal.ofReal_toReal (lt_top_iff_ne_top.mp hf.2)]
@@ -1161,7 +1198,8 @@ theorem integral_eq_integral_pos_part_sub_integral_neg_part {f : α → ℝ} (hf
 #align measure_theory.integral_eq_integral_pos_part_sub_integral_neg_part MeasureTheory.integral_eq_integral_pos_part_sub_integral_neg_part
 
 theorem integral_nonneg_of_ae {f : α → ℝ} (hf : 0 ≤ᵐ[μ] f) : 0 ≤ ∫ a, f a ∂μ := by
-  simp only [integral, L1.integral]
+  have A : CompleteSpace ℝ := by infer_instance
+  simp [integral, L1.integral, A]
   exact setToFun_nonneg (dominatedFinMeasAdditive_weightedSMul μ)
     (fun s _ _ => weightedSMul_nonneg s) hf
 #align measure_theory.integral_nonneg_of_ae MeasureTheory.integral_nonneg_of_ae
@@ -1302,7 +1340,8 @@ end NormedAddCommGroup
 
 theorem integral_mono_ae {f g : α → ℝ} (hf : Integrable f μ) (hg : Integrable g μ) (h : f ≤ᵐ[μ] g) :
     ∫ a, f a ∂μ ≤ ∫ a, g a ∂μ := by
-  simp only [integral, L1.integral]
+  have A : CompleteSpace ℝ := by infer_instance
+  simp only [integral, A, L1.integral]
   exact setToFun_mono (dominatedFinMeasAdditive_weightedSMul μ)
     (fun s _ _ => weightedSMul_nonneg s) hf hg h
 #align measure_theory.integral_mono_ae MeasureTheory.integral_mono_ae
@@ -1333,7 +1372,7 @@ theorem integral_mono_measure {f : α → ℝ} {ν} (hle : μ ≤ ν) (hf : 0 �
     ((hasFiniteIntegral_iff_ofReal hf).1 hfi.2).ne]
 #align measure_theory.integral_mono_measure MeasureTheory.integral_mono_measure
 
-theorem norm_integral_le_integral_norm (f : α → E) : ‖∫ a, f a ∂μ‖ ≤ ∫ a, ‖f a‖ ∂μ :=
+theorem norm_integral_le_integral_norm (f : α → G) : ‖∫ a, f a ∂μ‖ ≤ ∫ a, ‖f a‖ ∂μ :=
   have le_ae : ∀ᵐ a ∂μ, 0 ≤ ‖f a‖ := eventually_of_forall fun a => norm_nonneg _
   by_cases
     (fun h : AEStronglyMeasurable f μ =>
@@ -1346,7 +1385,7 @@ theorem norm_integral_le_integral_norm (f : α → E) : ‖∫ a, f a ∂μ‖ �
       exact integral_nonneg_of_ae le_ae
 #align measure_theory.norm_integral_le_integral_norm MeasureTheory.norm_integral_le_integral_norm
 
-theorem norm_integral_le_of_norm_le {f : α → E} {g : α → ℝ} (hg : Integrable g μ)
+theorem norm_integral_le_of_norm_le {f : α → G} {g : α → ℝ} (hg : Integrable g μ)
     (h : ∀ᵐ x ∂μ, ‖f x‖ ≤ g x) : ‖∫ x, f x ∂μ‖ ≤ ∫ x, g x ∂μ :=
   calc
     ‖∫ x, f x ∂μ‖ ≤ ∫ x, ‖f x‖ ∂μ := norm_integral_le_integral_norm f
@@ -1369,7 +1408,7 @@ theorem SimpleFunc.integral_eq_sum (f : α →ₛ E) (hfi : Integrable f μ) :
 theorem integral_const (c : E) : ∫ _ : α, c ∂μ = (μ univ).toReal • c := by
   cases' (@le_top _ _ _ (μ univ)).lt_or_eq with hμ hμ
   · haveI : IsFiniteMeasure μ := ⟨hμ⟩
-    simp only [integral, L1.integral]
+    simp only [integral, hE, L1.integral]
     exact setToFun_const (dominatedFinMeasAdditive_weightedSMul _) _
   · by_cases hc : c = 0
     · simp [hc, integral_zero]
@@ -1379,7 +1418,7 @@ theorem integral_const (c : E) : ∫ _ : α, c ∂μ = (μ univ).toReal • c :=
       simp [integral_undef, *]
 #align measure_theory.integral_const MeasureTheory.integral_const
 
-theorem norm_integral_le_of_norm_le_const [IsFiniteMeasure μ] {f : α → E} {C : ℝ}
+theorem norm_integral_le_of_norm_le_const [IsFiniteMeasure μ] {f : α → G} {C : ℝ}
     (h : ∀ᵐ x ∂μ, ‖f x‖ ≤ C) : ‖∫ x, f x ∂μ‖ ≤ C * (μ univ).toReal :=
   calc
     ‖∫ x, f x ∂μ‖ ≤ ∫ _, C ∂μ := norm_integral_le_of_norm_le (integrable_const C) h
@@ -1392,7 +1431,7 @@ theorem tendsto_integral_approxOn_of_measurable [MeasurableSpace E] [BorelSpace 
     Tendsto (fun n => (SimpleFunc.approxOn f hfm s y₀ h₀ n).integral μ)
       atTop (𝓝 <| ∫ x, f x ∂μ) := by
   have hfi' := SimpleFunc.integrable_approxOn hfm hfi h₀ h₀i
-  simp only [SimpleFunc.integral_eq_integral _ (hfi' _), integral, L1.integral]
+  simp only [SimpleFunc.integral_eq_integral _ (hfi' _), integral, hE, L1.integral]
   exact tendsto_setToFun_approxOn_of_measurable (dominatedFinMeasAdditive_weightedSMul μ)
     hfi hfm hs h₀ h₀i
 #align measure_theory.tendsto_integral_approx_on_of_measurable MeasureTheory.tendsto_integral_approxOn_of_measurable
@@ -1408,32 +1447,36 @@ theorem tendsto_integral_approxOn_of_measurable_of_range_subset [MeasurableSpace
 
 variable {ν : Measure α}
 
-theorem integral_add_measure {f : α → E} (hμ : Integrable f μ) (hν : Integrable f ν) :
+theorem integral_add_measure {f : α → G} (hμ : Integrable f μ) (hν : Integrable f ν) :
     ∫ x, f x ∂(μ + ν) = ∫ x, f x ∂μ + ∫ x, f x ∂ν := by
-  have hfi := hμ.add_measure hν
-  simp_rw [integral_eq_setToFun]
-  have hμ_dfma : DominatedFinMeasAdditive (μ + ν) (weightedSMul μ : Set α → E →L[ℝ] E) 1 :=
-    DominatedFinMeasAdditive.add_measure_right μ ν (dominatedFinMeasAdditive_weightedSMul μ)
-      zero_le_one
-  have hν_dfma : DominatedFinMeasAdditive (μ + ν) (weightedSMul ν : Set α → E →L[ℝ] E) 1 :=
-    DominatedFinMeasAdditive.add_measure_left μ ν (dominatedFinMeasAdditive_weightedSMul ν)
-      zero_le_one
-  rw [← setToFun_congr_measure_of_add_right hμ_dfma (dominatedFinMeasAdditive_weightedSMul μ) f hfi,
-    ← setToFun_congr_measure_of_add_left hν_dfma (dominatedFinMeasAdditive_weightedSMul ν) f hfi]
-  refine' setToFun_add_left' _ _ _ (fun s _ hμνs => _) f
-  rw [Measure.coe_add, Pi.add_apply, add_lt_top] at hμνs
-  rw [weightedSMul, weightedSMul, weightedSMul, ← add_smul, Measure.coe_add, Pi.add_apply,
+  by_cases hG : CompleteSpace G
+  · have hfi := hμ.add_measure hν
+    simp_rw [integral_eq_setToFun]
+    have hμ_dfma : DominatedFinMeasAdditive (μ + ν) (weightedSMul μ : Set α → G →L[ℝ] G) 1 :=
+      DominatedFinMeasAdditive.add_measure_right μ ν (dominatedFinMeasAdditive_weightedSMul μ)
+        zero_le_one
+    have hν_dfma : DominatedFinMeasAdditive (μ + ν) (weightedSMul ν : Set α → G →L[ℝ] G) 1 :=
+      DominatedFinMeasAdditive.add_measure_left μ ν (dominatedFinMeasAdditive_weightedSMul ν)
+        zero_le_one
+    rw [← setToFun_congr_measure_of_add_right hμ_dfma (dominatedFinMeasAdditive_weightedSMul μ) f hfi,
+      ← setToFun_congr_measure_of_add_left hν_dfma (dominatedFinMeasAdditive_weightedSMul ν) f hfi]
+    refine' setToFun_add_left' _ _ _ (fun s _ hμνs => _) f
+    rw [Measure.coe_add, Pi.add_apply, add_lt_top] at hμνs
+    rw [weightedSMul, weightedSMul, weightedSMul, ← add_smul, Measure.coe_add, Pi.add_apply,
     toReal_add hμνs.1.ne hμνs.2.ne]
+  · simp [integral, hG]
 #align measure_theory.integral_add_measure MeasureTheory.integral_add_measure
 
 @[simp]
-theorem integral_zero_measure {m : MeasurableSpace α} (f : α → E) :
+theorem integral_zero_measure {m : MeasurableSpace α} (f : α → G) :
     (∫ x, f x ∂(0 : Measure α)) = 0 := by
-  simp only [integral, L1.integral]
-  exact setToFun_measure_zero (dominatedFinMeasAdditive_weightedSMul _) rfl
+  by_cases hG : CompleteSpace G
+  · simp only [integral, hG, L1.integral]
+    exact setToFun_measure_zero (dominatedFinMeasAdditive_weightedSMul _) rfl
+  · simp [integral, hG]
 #align measure_theory.integral_zero_measure MeasureTheory.integral_zero_measure
 
-theorem integral_finset_sum_measure {ι} {m : MeasurableSpace α} {f : α → E} {μ : ι → Measure α}
+theorem integral_finset_sum_measure {ι} {m : MeasurableSpace α} {f : α → G} {μ : ι → Measure α}
     {s : Finset ι} (hf : ∀ i ∈ s, Integrable f (μ i)) :
     ∫ a, f a ∂(∑ i in s, μ i) = ∑ i in s, ∫ a, f a ∂μ i := by
   induction s using Finset.cons_induction_on with
@@ -1444,13 +1487,14 @@ theorem integral_finset_sum_measure {ι} {m : MeasurableSpace α} {f : α → E}
     exact integral_add_measure hf.1 (integrable_finset_sum_measure.2 hf.2)
 #align measure_theory.integral_finset_sum_measure MeasureTheory.integral_finset_sum_measure
 
-theorem nndist_integral_add_measure_le_lintegral (h₁ : Integrable f μ) (h₂ : Integrable f ν) :
+theorem nndist_integral_add_measure_le_lintegral
+    {f : α → G} (h₁ : Integrable f μ) (h₂ : Integrable f ν) :
     (nndist (∫ x, f x ∂μ) (∫ x, f x ∂(μ + ν)) : ℝ≥0∞) ≤ ∫⁻ x, ‖f x‖₊ ∂ν := by
   rw [integral_add_measure h₁ h₂, nndist_comm, nndist_eq_nnnorm, add_sub_cancel']
   exact ennnorm_integral_le_lintegral_ennnorm _
 #align measure_theory.nndist_integral_add_measure_le_lintegral MeasureTheory.nndist_integral_add_measure_le_lintegral
 
-theorem hasSum_integral_measure {ι} {m : MeasurableSpace α} {f : α → E} {μ : ι → Measure α}
+theorem hasSum_integral_measure {ι} {m : MeasurableSpace α} {f : α → G} {μ : ι → Measure α}
     (hf : Integrable f (Measure.sum μ)) :
     HasSum (fun i => ∫ a, f a ∂μ i) (∫ a, f a ∂Measure.sum μ) := by
   have hfi : ∀ i, Integrable f (μ i) := fun i => hf.mono_measure (Measure.le_sum _ _)
@@ -1472,79 +1516,85 @@ theorem hasSum_integral_measure {ι} {m : MeasurableSpace α} {f : α → E} {μ
   exact lt_of_add_lt_add_left hs
 #align measure_theory.has_sum_integral_measure MeasureTheory.hasSum_integral_measure
 
-theorem integral_sum_measure {ι} {_ : MeasurableSpace α} {f : α → E} {μ : ι → Measure α}
+theorem integral_sum_measure {ι} {_ : MeasurableSpace α} {f : α → G} {μ : ι → Measure α}
     (hf : Integrable f (Measure.sum μ)) : ∫ a, f a ∂Measure.sum μ = ∑' i, ∫ a, f a ∂μ i :=
   (hasSum_integral_measure hf).tsum_eq.symm
 #align measure_theory.integral_sum_measure MeasureTheory.integral_sum_measure
 
-theorem integral_tsum {ι} [Countable ι] {f : ι → α → E} (hf : ∀ i, AEStronglyMeasurable (f i) μ)
+theorem integral_tsum {ι} [Countable ι] {f : ι → α → G} (hf : ∀ i, AEStronglyMeasurable (f i) μ)
     (hf' : ∑' i, ∫⁻ a : α, ‖f i a‖₊ ∂μ ≠ ∞) :
     ∫ a : α, ∑' i, f i a ∂μ = ∑' i, ∫ a : α, f i a ∂μ := by
-  have hf'' : ∀ i, AEMeasurable (fun x => (‖f i x‖₊ : ℝ≥0∞)) μ := fun i => (hf i).ennnorm
-  have hhh : ∀ᵐ a : α ∂μ, Summable fun n => (‖f n a‖₊ : ℝ) := by
-    rw [← lintegral_tsum hf''] at hf'
-    refine' (ae_lt_top' (AEMeasurable.ennreal_tsum hf'') hf').mono _
-    intro x hx
-    rw [← ENNReal.tsum_coe_ne_top_iff_summable_coe]
-    exact hx.ne
-  convert (MeasureTheory.hasSum_integral_of_dominated_convergence (fun i a => ‖f i a‖₊) hf _ hhh
-          ⟨_, _⟩ _).tsum_eq.symm
-  · intro n
-    filter_upwards with x
-    rfl
-  · simp_rw [← coe_nnnorm, ← NNReal.coe_tsum]
-    rw [aestronglyMeasurable_iff_aemeasurable]
-    apply AEMeasurable.coe_nnreal_real
-    apply AEMeasurable.nnreal_tsum
-    exact fun i => (hf i).nnnorm.aemeasurable
-  · dsimp [HasFiniteIntegral]
-    have : ∫⁻ a, ∑' n, ‖f n a‖₊ ∂μ < ⊤ := by rwa [lintegral_tsum hf'', lt_top_iff_ne_top]
-    convert this using 1
-    apply lintegral_congr_ae
-    simp_rw [← coe_nnnorm, ← NNReal.coe_tsum, NNReal.nnnorm_eq]
-    filter_upwards [hhh]with a ha
-    exact ENNReal.coe_tsum (NNReal.summable_coe.mp ha)
-  · filter_upwards [hhh]with x hx
-    exact (summable_of_summable_norm hx).hasSum
+  by_cases hG : CompleteSpace G
+  · have hf'' : ∀ i, AEMeasurable (fun x => (‖f i x‖₊ : ℝ≥0∞)) μ := fun i => (hf i).ennnorm
+    have hhh : ∀ᵐ a : α ∂μ, Summable fun n => (‖f n a‖₊ : ℝ) := by
+      rw [← lintegral_tsum hf''] at hf'
+      refine' (ae_lt_top' (AEMeasurable.ennreal_tsum hf'') hf').mono _
+      intro x hx
+      rw [← ENNReal.tsum_coe_ne_top_iff_summable_coe]
+      exact hx.ne
+    convert (MeasureTheory.hasSum_integral_of_dominated_convergence (fun i a => ‖f i a‖₊) hf _ hhh
+            ⟨_, _⟩ _).tsum_eq.symm
+    · intro n
+      filter_upwards with x
+      rfl
+    · simp_rw [← coe_nnnorm, ← NNReal.coe_tsum]
+      rw [aestronglyMeasurable_iff_aemeasurable]
+      apply AEMeasurable.coe_nnreal_real
+      apply AEMeasurable.nnreal_tsum
+      exact fun i => (hf i).nnnorm.aemeasurable
+    · dsimp [HasFiniteIntegral]
+      have : ∫⁻ a, ∑' n, ‖f n a‖₊ ∂μ < ⊤ := by rwa [lintegral_tsum hf'', lt_top_iff_ne_top]
+      convert this using 1
+      apply lintegral_congr_ae
+      simp_rw [← coe_nnnorm, ← NNReal.coe_tsum, NNReal.nnnorm_eq]
+      filter_upwards [hhh]with a ha
+      exact ENNReal.coe_tsum (NNReal.summable_coe.mp ha)
+    · filter_upwards [hhh]with x hx
+      exact (summable_of_summable_norm hx).hasSum
+  · simp [integral, hG]
 #align measure_theory.integral_tsum MeasureTheory.integral_tsum
 
 @[simp]
-theorem integral_smul_measure (f : α → E) (c : ℝ≥0∞) :
+theorem integral_smul_measure (f : α → G) (c : ℝ≥0∞) :
     ∫ x, f x ∂c • μ = c.toReal • ∫ x, f x ∂μ := by
-  -- First we consider the “degenerate” case `c = ∞`
-  rcases eq_or_ne c ∞ with (rfl | hc)
-  · rw [ENNReal.top_toReal, zero_smul, integral_eq_setToFun, setToFun_top_smul_measure]
-  -- Main case: `c ≠ ∞`
-  simp_rw [integral_eq_setToFun, ← setToFun_smul_left]
-  have hdfma : DominatedFinMeasAdditive μ (weightedSMul (c • μ) : Set α → E →L[ℝ] E) c.toReal :=
-    mul_one c.toReal ▸ (dominatedFinMeasAdditive_weightedSMul (c • μ)).of_smul_measure c hc
-  have hdfma_smul := dominatedFinMeasAdditive_weightedSMul (F := E) (c • μ)
-  rw [← setToFun_congr_smul_measure c hc hdfma hdfma_smul f]
-  exact setToFun_congr_left' _ _ (fun s _ _ => weightedSMul_smul_measure μ c) f
+  by_cases hG : CompleteSpace G
+  · -- First we consider the “degenerate” case `c = ∞`
+    rcases eq_or_ne c ∞ with (rfl | hc)
+    · rw [ENNReal.top_toReal, zero_smul, integral_eq_setToFun, setToFun_top_smul_measure]
+    -- Main case: `c ≠ ∞`
+    simp_rw [integral_eq_setToFun, ← setToFun_smul_left]
+    have hdfma : DominatedFinMeasAdditive μ (weightedSMul (c • μ) : Set α → G →L[ℝ] G) c.toReal :=
+      mul_one c.toReal ▸ (dominatedFinMeasAdditive_weightedSMul (c • μ)).of_smul_measure c hc
+    have hdfma_smul := dominatedFinMeasAdditive_weightedSMul (F := G) (c • μ)
+    rw [← setToFun_congr_smul_measure c hc hdfma hdfma_smul f]
+    exact setToFun_congr_left' _ _ (fun s _ _ => weightedSMul_smul_measure μ c) f
+  · simp [integral, hG]
 #align measure_theory.integral_smul_measure MeasureTheory.integral_smul_measure
 
 theorem integral_map_of_stronglyMeasurable {β} [MeasurableSpace β] {φ : α → β} (hφ : Measurable φ)
-    {f : β → E} (hfm : StronglyMeasurable f) : ∫ y, f y ∂Measure.map φ μ = ∫ x, f (φ x) ∂μ := by
-  by_cases hfi : Integrable f (Measure.map φ μ); swap
-  · rw [integral_undef hfi, integral_undef]
-    exact fun hfφ => hfi ((integrable_map_measure hfm.aestronglyMeasurable hφ.aemeasurable).2 hfφ)
-  borelize E
-  haveI : SeparableSpace (range f ∪ {0} : Set E) := hfm.separableSpace_range_union_singleton
-  refine' tendsto_nhds_unique
-    (tendsto_integral_approxOn_of_measurable_of_range_subset hfm.measurable hfi _ Subset.rfl) _
-  convert tendsto_integral_approxOn_of_measurable_of_range_subset (hfm.measurable.comp hφ)
-    ((integrable_map_measure hfm.aestronglyMeasurable hφ.aemeasurable).1 hfi) (range f ∪ {0})
-    (by simp [insert_subset_insert, Set.range_comp_subset_range]) using 1
-  ext1 i
-  simp only [SimpleFunc.approxOn_comp, SimpleFunc.integral_eq, Measure.map_apply, hφ,
-    SimpleFunc.measurableSet_preimage, ← preimage_comp, SimpleFunc.coe_comp]
-  refine' (Finset.sum_subset (SimpleFunc.range_comp_subset_range _ hφ) fun y _ hy => _).symm
-  rw [SimpleFunc.mem_range, ← Set.preimage_singleton_eq_empty, SimpleFunc.coe_comp] at hy
-  rw [hy]
-  simp
+    {f : β → G} (hfm : StronglyMeasurable f) : ∫ y, f y ∂Measure.map φ μ = ∫ x, f (φ x) ∂μ := by
+  by_cases hG : CompleteSpace G
+  · by_cases hfi : Integrable f (Measure.map φ μ); swap
+    · rw [integral_undef hfi, integral_undef]
+      exact fun hfφ => hfi ((integrable_map_measure hfm.aestronglyMeasurable hφ.aemeasurable).2 hfφ)
+    borelize G
+    have : SeparableSpace (range f ∪ {0} : Set G) := hfm.separableSpace_range_union_singleton
+    refine' tendsto_nhds_unique
+      (tendsto_integral_approxOn_of_measurable_of_range_subset hfm.measurable hfi _ Subset.rfl) _
+    convert tendsto_integral_approxOn_of_measurable_of_range_subset (hfm.measurable.comp hφ)
+      ((integrable_map_measure hfm.aestronglyMeasurable hφ.aemeasurable).1 hfi) (range f ∪ {0})
+      (by simp [insert_subset_insert, Set.range_comp_subset_range]) using 1
+    ext1 i
+    simp only [SimpleFunc.approxOn_comp, SimpleFunc.integral_eq, Measure.map_apply, hφ,
+      SimpleFunc.measurableSet_preimage, ← preimage_comp, SimpleFunc.coe_comp]
+    refine' (Finset.sum_subset (SimpleFunc.range_comp_subset_range _ hφ) fun y _ hy => _).symm
+    rw [SimpleFunc.mem_range, ← Set.preimage_singleton_eq_empty, SimpleFunc.coe_comp] at hy
+    rw [hy]
+    simp
+  · simp [integral, hG]
 #align measure_theory.integral_map_of_strongly_measurable MeasureTheory.integral_map_of_stronglyMeasurable
 
-theorem integral_map {β} [MeasurableSpace β] {φ : α → β} (hφ : AEMeasurable φ μ) {f : β → E}
+theorem integral_map {β} [MeasurableSpace β] {φ : α → β} (hφ : AEMeasurable φ μ) {f : β → G}
     (hfm : AEStronglyMeasurable f (Measure.map φ μ)) :
     ∫ y, f y ∂Measure.map φ μ = ∫ x, f (φ x) ∂μ :=
   let g := hfm.mk f
@@ -1558,7 +1608,7 @@ theorem integral_map {β} [MeasurableSpace β] {φ : α → β} (hφ : AEMeasura
 #align measure_theory.integral_map MeasureTheory.integral_map
 
 theorem _root_.MeasurableEmbedding.integral_map {β} {_ : MeasurableSpace β} {f : α → β}
-    (hf : MeasurableEmbedding f) (g : β → E) : ∫ y, g y ∂Measure.map f μ = ∫ x, g (f x) ∂μ := by
+    (hf : MeasurableEmbedding f) (g : β → G) : ∫ y, g y ∂Measure.map f μ = ∫ x, g (f x) ∂μ := by
   by_cases hgm : AEStronglyMeasurable g (Measure.map f μ)
   · exact MeasureTheory.integral_map hf.measurable.aemeasurable hgm
   · rw [integral_non_aestronglyMeasurable hgm, integral_non_aestronglyMeasurable]
@@ -1567,23 +1617,23 @@ theorem _root_.MeasurableEmbedding.integral_map {β} {_ : MeasurableSpace β} {f
 
 theorem _root_.ClosedEmbedding.integral_map {β} [TopologicalSpace α] [BorelSpace α]
     [TopologicalSpace β] [MeasurableSpace β] [BorelSpace β] {φ : α → β} (hφ : ClosedEmbedding φ)
-    (f : β → E) : ∫ y, f y ∂Measure.map φ μ = ∫ x, f (φ x) ∂μ :=
+    (f : β → G) : ∫ y, f y ∂Measure.map φ μ = ∫ x, f (φ x) ∂μ :=
   hφ.measurableEmbedding.integral_map _
 #align closed_embedding.integral_map ClosedEmbedding.integral_map
 
-theorem integral_map_equiv {β} [MeasurableSpace β] (e : α ≃ᵐ β) (f : β → E) :
+theorem integral_map_equiv {β} [MeasurableSpace β] (e : α ≃ᵐ β) (f : β → G) :
     ∫ y, f y ∂Measure.map e μ = ∫ x, f (e x) ∂μ :=
   e.measurableEmbedding.integral_map f
 #align measure_theory.integral_map_equiv MeasureTheory.integral_map_equiv
 
 theorem MeasurePreserving.integral_comp {β} {_ : MeasurableSpace β} {f : α → β} {ν}
-    (h₁ : MeasurePreserving f μ ν) (h₂ : MeasurableEmbedding f) (g : β → E) :
+    (h₁ : MeasurePreserving f μ ν) (h₂ : MeasurableEmbedding f) (g : β → G) :
     ∫ x, g (f x) ∂μ = ∫ y, g y ∂ν :=
   h₁.map_eq ▸ (h₂.integral_map g).symm
 #align measure_theory.measure_preserving.integral_comp MeasureTheory.MeasurePreserving.integral_comp
 
 theorem set_integral_eq_subtype {α} [MeasureSpace α] {s : Set α} (hs : MeasurableSet s)
-    (f : α → E) : ∫ x in s, f x = ∫ x : s, f x := by
+    (f : α → G) : ∫ x in s, f x = ∫ x : s, f x := by
   rw [← map_comap_subtype_coe hs]
   exact (MeasurableEmbedding.subtype_coe hs).integral_map _
 #align measure_theory.set_integral_eq_subtype MeasureTheory.set_integral_eq_subtype
@@ -1762,37 +1812,39 @@ theorem integral_trim_simpleFunc (hm : m ≤ m0) (f : @SimpleFunc β m F) (hf_in
   exact (trim_measurableSet_eq hm (@SimpleFunc.measurableSet_fiber β F m f x)).symm
 #align measure_theory.integral_trim_simple_func MeasureTheory.integral_trim_simpleFunc
 
-theorem integral_trim (hm : m ≤ m0) {f : β → F} (hf : StronglyMeasurable[m] f) :
+theorem integral_trim (hm : m ≤ m0) {f : β → G} (hf : StronglyMeasurable[m] f) :
     ∫ x, f x ∂μ = ∫ x, f x ∂μ.trim hm := by
-  borelize F
-  by_cases hf_int : Integrable f μ
-  swap
-  · have hf_int_m : ¬Integrable f (μ.trim hm) := fun hf_int_m =>
-      hf_int (integrable_of_integrable_trim hm hf_int_m)
-    rw [integral_undef hf_int, integral_undef hf_int_m]
-  haveI : SeparableSpace (range f ∪ {0} : Set F) := hf.separableSpace_range_union_singleton
-  let f_seq := @SimpleFunc.approxOn F β _ _ _ m _ hf.measurable (range f ∪ {0}) 0 (by simp) _
-  have hf_seq_meas : ∀ n, StronglyMeasurable[m] (f_seq n) := fun n =>
-    @SimpleFunc.stronglyMeasurable β F m _ (f_seq n)
-  have hf_seq_int : ∀ n, Integrable (f_seq n) μ :=
-    SimpleFunc.integrable_approxOn_range (hf.mono hm).measurable hf_int
-  have hf_seq_int_m : ∀ n, Integrable (f_seq n) (μ.trim hm) := fun n =>
-    (hf_seq_int n).trim hm (hf_seq_meas n)
-  have hf_seq_eq : ∀ n, ∫ x, f_seq n x ∂μ = ∫ x, f_seq n x ∂μ.trim hm := fun n =>
-    integral_trim_simpleFunc hm (f_seq n) (hf_seq_int n)
-  have h_lim_1 : atTop.Tendsto (fun n => ∫ x, f_seq n x ∂μ) (𝓝 (∫ x, f x ∂μ)) := by
-    refine' tendsto_integral_of_L1 f hf_int (eventually_of_forall hf_seq_int) _
-    exact SimpleFunc.tendsto_approxOn_range_L1_nnnorm (hf.mono hm).measurable hf_int
-  have h_lim_2 : atTop.Tendsto (fun n => ∫ x, f_seq n x ∂μ) (𝓝 (∫ x, f x ∂μ.trim hm)) := by
-    simp_rw [hf_seq_eq]
-    refine' @tendsto_integral_of_L1 β F _ _ _ m (μ.trim hm) _ f (hf_int.trim hm hf) _ _
-      (eventually_of_forall hf_seq_int_m) _
-    exact @SimpleFunc.tendsto_approxOn_range_L1_nnnorm β F m _ _ _ f _ _ hf.measurable
-      (hf_int.trim hm hf)
-  exact tendsto_nhds_unique h_lim_1 h_lim_2
+  by_cases hG : CompleteSpace G
+  · borelize G
+    by_cases hf_int : Integrable f μ
+    swap
+    · have hf_int_m : ¬Integrable f (μ.trim hm) := fun hf_int_m =>
+        hf_int (integrable_of_integrable_trim hm hf_int_m)
+      rw [integral_undef hf_int, integral_undef hf_int_m]
+    haveI : SeparableSpace (range f ∪ {0} : Set G) := hf.separableSpace_range_union_singleton
+    let f_seq := @SimpleFunc.approxOn G β _ _ _ m _ hf.measurable (range f ∪ {0}) 0 (by simp) _
+    have hf_seq_meas : ∀ n, StronglyMeasurable[m] (f_seq n) := fun n =>
+      @SimpleFunc.stronglyMeasurable β G m _ (f_seq n)
+    have hf_seq_int : ∀ n, Integrable (f_seq n) μ :=
+      SimpleFunc.integrable_approxOn_range (hf.mono hm).measurable hf_int
+    have hf_seq_int_m : ∀ n, Integrable (f_seq n) (μ.trim hm) := fun n =>
+      (hf_seq_int n).trim hm (hf_seq_meas n)
+    have hf_seq_eq : ∀ n, ∫ x, f_seq n x ∂μ = ∫ x, f_seq n x ∂μ.trim hm := fun n =>
+      integral_trim_simpleFunc hm (f_seq n) (hf_seq_int n)
+    have h_lim_1 : atTop.Tendsto (fun n => ∫ x, f_seq n x ∂μ) (𝓝 (∫ x, f x ∂μ)) := by
+      refine' tendsto_integral_of_L1 f hf_int (eventually_of_forall hf_seq_int) _
+      exact SimpleFunc.tendsto_approxOn_range_L1_nnnorm (hf.mono hm).measurable hf_int
+    have h_lim_2 : atTop.Tendsto (fun n => ∫ x, f_seq n x ∂μ) (𝓝 (∫ x, f x ∂μ.trim hm)) := by
+      simp_rw [hf_seq_eq]
+      refine' @tendsto_integral_of_L1 β G _ _ m (μ.trim hm) _ f (hf_int.trim hm hf) _ _
+        (eventually_of_forall hf_seq_int_m) _
+      exact @SimpleFunc.tendsto_approxOn_range_L1_nnnorm β G m _ _ _ f _ _ hf.measurable
+        (hf_int.trim hm hf)
+    exact tendsto_nhds_unique h_lim_1 h_lim_2
+  · simp [integral, hG]
 #align measure_theory.integral_trim MeasureTheory.integral_trim
 
-theorem integral_trim_ae (hm : m ≤ m0) {f : β → F} (hf : AEStronglyMeasurable f (μ.trim hm)) :
+theorem integral_trim_ae (hm : m ≤ m0) {f : β → G} (hf : AEStronglyMeasurable f (μ.trim hm)) :
     ∫ x, f x ∂μ = ∫ x, f x ∂μ.trim hm := by
   rw [integral_congr_ae (ae_eq_of_ae_eq_trim hf.ae_eq_mk), integral_congr_ae hf.ae_eq_mk]
   exact integral_trim hm hf.stronglyMeasurable_mk

--- a/Mathlib/MeasureTheory/Integral/Bochner.lean
+++ b/Mathlib/MeasureTheory/Integral/Bochner.lean
@@ -847,6 +847,7 @@ theorem integral_non_aestronglyMeasurable {f : α → G} (h : ¬AEStronglyMeasur
 
 variable (α G)
 
+@[simp]
 theorem integral_zero : ∫ _ : α, (0 : G) ∂μ = 0 := by
   by_cases hG : CompleteSpace G
   · simp only [integral, hG, L1.integral]

--- a/Mathlib/MeasureTheory/Integral/Bochner.lean
+++ b/Mathlib/MeasureTheory/Integral/Bochner.lean
@@ -784,6 +784,7 @@ functions, and 0 otherwise; prove its basic properties.
 variable [NormedAddCommGroup E] [NormedSpace ℝ E] [hE : CompleteSpace E] [NontriviallyNormedField 𝕜]
   [NormedSpace 𝕜 E] [SMulCommClass ℝ 𝕜 E] [NormedAddCommGroup F] [NormedSpace ℝ F] [CompleteSpace F]
   {G : Type _} [NormedAddCommGroup G] [NormedSpace ℝ G]
+
 section
 
 open scoped Classical
@@ -791,7 +792,7 @@ open scoped Classical
 /-- The Bochner integral -/
 irreducible_def integral {_ : MeasurableSpace α} (μ : Measure α) (f : α → G) : G :=
   if _ : CompleteSpace G then
-    (if hf : Integrable f μ then L1.integral (hf.toL1 f) else 0)
+    if hf : Integrable f μ then L1.integral (hf.toL1 f) else 0
   else 0
 #align measure_theory.integral MeasureTheory.integral
 
@@ -836,7 +837,7 @@ set_option linter.uppercaseLean3 false in
 
 theorem integral_undef {f : α → G} (h : ¬Integrable f μ) : ∫ a, f a ∂μ = 0 := by
   by_cases hG : CompleteSpace G
-  · simp [integral, hG]; exact @dif_neg _ (id _) h _ _ _
+  · simp [integral, hG, h]
   · simp [integral, hG]
 #align measure_theory.integral_undef MeasureTheory.integral_undef
 
@@ -1200,7 +1201,7 @@ theorem integral_eq_integral_pos_part_sub_integral_neg_part {f : α → ℝ} (hf
 
 theorem integral_nonneg_of_ae {f : α → ℝ} (hf : 0 ≤ᵐ[μ] f) : 0 ≤ ∫ a, f a ∂μ := by
   have A : CompleteSpace ℝ := by infer_instance
-  simp [integral, L1.integral, A]
+  simp only [integral_def, A, L1.integral_def, dite_true, ge_iff_le]
   exact setToFun_nonneg (dominatedFinMeasAdditive_weightedSMul μ)
     (fun s _ _ => weightedSMul_nonneg s) hf
 #align measure_theory.integral_nonneg_of_ae MeasureTheory.integral_nonneg_of_ae
@@ -1450,23 +1451,23 @@ variable {ν : Measure α}
 
 theorem integral_add_measure {f : α → G} (hμ : Integrable f μ) (hν : Integrable f ν) :
     ∫ x, f x ∂(μ + ν) = ∫ x, f x ∂μ + ∫ x, f x ∂ν := by
-  by_cases hG : CompleteSpace G
-  · have hfi := hμ.add_measure hν
-    simp_rw [integral_eq_setToFun]
-    have hμ_dfma : DominatedFinMeasAdditive (μ + ν) (weightedSMul μ : Set α → G →L[ℝ] G) 1 :=
-      DominatedFinMeasAdditive.add_measure_right μ ν (dominatedFinMeasAdditive_weightedSMul μ)
-        zero_le_one
-    have hν_dfma : DominatedFinMeasAdditive (μ + ν) (weightedSMul ν : Set α → G →L[ℝ] G) 1 :=
-      DominatedFinMeasAdditive.add_measure_left μ ν (dominatedFinMeasAdditive_weightedSMul ν)
-        zero_le_one
-    rw [← setToFun_congr_measure_of_add_right hμ_dfma
-          (dominatedFinMeasAdditive_weightedSMul μ) f hfi,
-      ← setToFun_congr_measure_of_add_left hν_dfma (dominatedFinMeasAdditive_weightedSMul ν) f hfi]
-    refine' setToFun_add_left' _ _ _ (fun s _ hμνs => _) f
-    rw [Measure.coe_add, Pi.add_apply, add_lt_top] at hμνs
-    rw [weightedSMul, weightedSMul, weightedSMul, ← add_smul, Measure.coe_add, Pi.add_apply,
-    toReal_add hμνs.1.ne hμνs.2.ne]
+  by_cases hG : CompleteSpace G; swap
   · simp [integral, hG]
+  have hfi := hμ.add_measure hν
+  simp_rw [integral_eq_setToFun]
+  have hμ_dfma : DominatedFinMeasAdditive (μ + ν) (weightedSMul μ : Set α → G →L[ℝ] G) 1 :=
+    DominatedFinMeasAdditive.add_measure_right μ ν (dominatedFinMeasAdditive_weightedSMul μ)
+      zero_le_one
+  have hν_dfma : DominatedFinMeasAdditive (μ + ν) (weightedSMul ν : Set α → G →L[ℝ] G) 1 :=
+    DominatedFinMeasAdditive.add_measure_left μ ν (dominatedFinMeasAdditive_weightedSMul ν)
+      zero_le_one
+  rw [← setToFun_congr_measure_of_add_right hμ_dfma
+        (dominatedFinMeasAdditive_weightedSMul μ) f hfi,
+    ← setToFun_congr_measure_of_add_left hν_dfma (dominatedFinMeasAdditive_weightedSMul ν) f hfi]
+  refine' setToFun_add_left' _ _ _ (fun s _ hμνs => _) f
+  rw [Measure.coe_add, Pi.add_apply, add_lt_top] at hμνs
+  rw [weightedSMul, weightedSMul, weightedSMul, ← add_smul, Measure.coe_add, Pi.add_apply,
+  toReal_add hμνs.1.ne hμνs.2.ne]
 #align measure_theory.integral_add_measure MeasureTheory.integral_add_measure
 
 @[simp]
@@ -1526,74 +1527,74 @@ theorem integral_sum_measure {ι} {_ : MeasurableSpace α} {f : α → G} {μ : 
 theorem integral_tsum {ι} [Countable ι] {f : ι → α → G} (hf : ∀ i, AEStronglyMeasurable (f i) μ)
     (hf' : ∑' i, ∫⁻ a : α, ‖f i a‖₊ ∂μ ≠ ∞) :
     ∫ a : α, ∑' i, f i a ∂μ = ∑' i, ∫ a : α, f i a ∂μ := by
-  by_cases hG : CompleteSpace G
-  · have hf'' : ∀ i, AEMeasurable (fun x => (‖f i x‖₊ : ℝ≥0∞)) μ := fun i => (hf i).ennnorm
-    have hhh : ∀ᵐ a : α ∂μ, Summable fun n => (‖f n a‖₊ : ℝ) := by
-      rw [← lintegral_tsum hf''] at hf'
-      refine' (ae_lt_top' (AEMeasurable.ennreal_tsum hf'') hf').mono _
-      intro x hx
-      rw [← ENNReal.tsum_coe_ne_top_iff_summable_coe]
-      exact hx.ne
-    convert (MeasureTheory.hasSum_integral_of_dominated_convergence (fun i a => ‖f i a‖₊) hf _ hhh
-            ⟨_, _⟩ _).tsum_eq.symm
-    · intro n
-      filter_upwards with x
-      rfl
-    · simp_rw [← coe_nnnorm, ← NNReal.coe_tsum]
-      rw [aestronglyMeasurable_iff_aemeasurable]
-      apply AEMeasurable.coe_nnreal_real
-      apply AEMeasurable.nnreal_tsum
-      exact fun i => (hf i).nnnorm.aemeasurable
-    · dsimp [HasFiniteIntegral]
-      have : ∫⁻ a, ∑' n, ‖f n a‖₊ ∂μ < ⊤ := by rwa [lintegral_tsum hf'', lt_top_iff_ne_top]
-      convert this using 1
-      apply lintegral_congr_ae
-      simp_rw [← coe_nnnorm, ← NNReal.coe_tsum, NNReal.nnnorm_eq]
-      filter_upwards [hhh]with a ha
-      exact ENNReal.coe_tsum (NNReal.summable_coe.mp ha)
-    · filter_upwards [hhh]with x hx
-      exact (summable_of_summable_norm hx).hasSum
+  by_cases hG : CompleteSpace G; swap
   · simp [integral, hG]
+  have hf'' : ∀ i, AEMeasurable (fun x => (‖f i x‖₊ : ℝ≥0∞)) μ := fun i => (hf i).ennnorm
+  have hhh : ∀ᵐ a : α ∂μ, Summable fun n => (‖f n a‖₊ : ℝ) := by
+    rw [← lintegral_tsum hf''] at hf'
+    refine' (ae_lt_top' (AEMeasurable.ennreal_tsum hf'') hf').mono _
+    intro x hx
+    rw [← ENNReal.tsum_coe_ne_top_iff_summable_coe]
+    exact hx.ne
+  convert (MeasureTheory.hasSum_integral_of_dominated_convergence (fun i a => ‖f i a‖₊) hf _ hhh
+          ⟨_, _⟩ _).tsum_eq.symm
+  · intro n
+    filter_upwards with x
+    rfl
+  · simp_rw [← coe_nnnorm, ← NNReal.coe_tsum]
+    rw [aestronglyMeasurable_iff_aemeasurable]
+    apply AEMeasurable.coe_nnreal_real
+    apply AEMeasurable.nnreal_tsum
+    exact fun i => (hf i).nnnorm.aemeasurable
+  · dsimp [HasFiniteIntegral]
+    have : ∫⁻ a, ∑' n, ‖f n a‖₊ ∂μ < ⊤ := by rwa [lintegral_tsum hf'', lt_top_iff_ne_top]
+    convert this using 1
+    apply lintegral_congr_ae
+    simp_rw [← coe_nnnorm, ← NNReal.coe_tsum, NNReal.nnnorm_eq]
+    filter_upwards [hhh]with a ha
+    exact ENNReal.coe_tsum (NNReal.summable_coe.mp ha)
+  · filter_upwards [hhh]with x hx
+    exact (summable_of_summable_norm hx).hasSum
 #align measure_theory.integral_tsum MeasureTheory.integral_tsum
 
 @[simp]
 theorem integral_smul_measure (f : α → G) (c : ℝ≥0∞) :
     ∫ x, f x ∂c • μ = c.toReal • ∫ x, f x ∂μ := by
-  by_cases hG : CompleteSpace G
-  · -- First we consider the “degenerate” case `c = ∞`
-    rcases eq_or_ne c ∞ with (rfl | hc)
-    · rw [ENNReal.top_toReal, zero_smul, integral_eq_setToFun, setToFun_top_smul_measure]
-    -- Main case: `c ≠ ∞`
-    simp_rw [integral_eq_setToFun, ← setToFun_smul_left]
-    have hdfma : DominatedFinMeasAdditive μ (weightedSMul (c • μ) : Set α → G →L[ℝ] G) c.toReal :=
-      mul_one c.toReal ▸ (dominatedFinMeasAdditive_weightedSMul (c • μ)).of_smul_measure c hc
-    have hdfma_smul := dominatedFinMeasAdditive_weightedSMul (F := G) (c • μ)
-    rw [← setToFun_congr_smul_measure c hc hdfma hdfma_smul f]
-    exact setToFun_congr_left' _ _ (fun s _ _ => weightedSMul_smul_measure μ c) f
+  by_cases hG : CompleteSpace G; swap
   · simp [integral, hG]
+  -- First we consider the “degenerate” case `c = ∞`
+  rcases eq_or_ne c ∞ with (rfl | hc)
+  · rw [ENNReal.top_toReal, zero_smul, integral_eq_setToFun, setToFun_top_smul_measure]
+  -- Main case: `c ≠ ∞`
+  simp_rw [integral_eq_setToFun, ← setToFun_smul_left]
+  have hdfma : DominatedFinMeasAdditive μ (weightedSMul (c • μ) : Set α → G →L[ℝ] G) c.toReal :=
+    mul_one c.toReal ▸ (dominatedFinMeasAdditive_weightedSMul (c • μ)).of_smul_measure c hc
+  have hdfma_smul := dominatedFinMeasAdditive_weightedSMul (F := G) (c • μ)
+  rw [← setToFun_congr_smul_measure c hc hdfma hdfma_smul f]
+  exact setToFun_congr_left' _ _ (fun s _ _ => weightedSMul_smul_measure μ c) f
 #align measure_theory.integral_smul_measure MeasureTheory.integral_smul_measure
 
 theorem integral_map_of_stronglyMeasurable {β} [MeasurableSpace β] {φ : α → β} (hφ : Measurable φ)
     {f : β → G} (hfm : StronglyMeasurable f) : ∫ y, f y ∂Measure.map φ μ = ∫ x, f (φ x) ∂μ := by
-  by_cases hG : CompleteSpace G
-  · by_cases hfi : Integrable f (Measure.map φ μ); swap
-    · rw [integral_undef hfi, integral_undef]
-      exact fun hfφ => hfi ((integrable_map_measure hfm.aestronglyMeasurable hφ.aemeasurable).2 hfφ)
-    borelize G
-    have : SeparableSpace (range f ∪ {0} : Set G) := hfm.separableSpace_range_union_singleton
-    refine' tendsto_nhds_unique
-      (tendsto_integral_approxOn_of_measurable_of_range_subset hfm.measurable hfi _ Subset.rfl) _
-    convert tendsto_integral_approxOn_of_measurable_of_range_subset (hfm.measurable.comp hφ)
-      ((integrable_map_measure hfm.aestronglyMeasurable hφ.aemeasurable).1 hfi) (range f ∪ {0})
-      (by simp [insert_subset_insert, Set.range_comp_subset_range]) using 1
-    ext1 i
-    simp only [SimpleFunc.approxOn_comp, SimpleFunc.integral_eq, Measure.map_apply, hφ,
-      SimpleFunc.measurableSet_preimage, ← preimage_comp, SimpleFunc.coe_comp]
-    refine' (Finset.sum_subset (SimpleFunc.range_comp_subset_range _ hφ) fun y _ hy => _).symm
-    rw [SimpleFunc.mem_range, ← Set.preimage_singleton_eq_empty, SimpleFunc.coe_comp] at hy
-    rw [hy]
-    simp
+  by_cases hG : CompleteSpace G; swap
   · simp [integral, hG]
+  by_cases hfi : Integrable f (Measure.map φ μ); swap
+  · rw [integral_undef hfi, integral_undef]
+    exact fun hfφ => hfi ((integrable_map_measure hfm.aestronglyMeasurable hφ.aemeasurable).2 hfφ)
+  borelize G
+  have : SeparableSpace (range f ∪ {0} : Set G) := hfm.separableSpace_range_union_singleton
+  refine' tendsto_nhds_unique
+    (tendsto_integral_approxOn_of_measurable_of_range_subset hfm.measurable hfi _ Subset.rfl) _
+  convert tendsto_integral_approxOn_of_measurable_of_range_subset (hfm.measurable.comp hφ)
+    ((integrable_map_measure hfm.aestronglyMeasurable hφ.aemeasurable).1 hfi) (range f ∪ {0})
+    (by simp [insert_subset_insert, Set.range_comp_subset_range]) using 1
+  ext1 i
+  simp only [SimpleFunc.approxOn_comp, SimpleFunc.integral_eq, Measure.map_apply, hφ,
+    SimpleFunc.measurableSet_preimage, ← preimage_comp, SimpleFunc.coe_comp]
+  refine' (Finset.sum_subset (SimpleFunc.range_comp_subset_range _ hφ) fun y _ hy => _).symm
+  rw [SimpleFunc.mem_range, ← Set.preimage_singleton_eq_empty, SimpleFunc.coe_comp] at hy
+  rw [hy]
+  simp
 #align measure_theory.integral_map_of_strongly_measurable MeasureTheory.integral_map_of_stronglyMeasurable
 
 theorem integral_map {β} [MeasurableSpace β] {φ : α → β} (hφ : AEMeasurable φ μ) {f : β → G}
@@ -1816,34 +1817,34 @@ theorem integral_trim_simpleFunc (hm : m ≤ m0) (f : @SimpleFunc β m F) (hf_in
 
 theorem integral_trim (hm : m ≤ m0) {f : β → G} (hf : StronglyMeasurable[m] f) :
     ∫ x, f x ∂μ = ∫ x, f x ∂μ.trim hm := by
-  by_cases hG : CompleteSpace G
-  · borelize G
-    by_cases hf_int : Integrable f μ
-    swap
-    · have hf_int_m : ¬Integrable f (μ.trim hm) := fun hf_int_m =>
-        hf_int (integrable_of_integrable_trim hm hf_int_m)
-      rw [integral_undef hf_int, integral_undef hf_int_m]
-    haveI : SeparableSpace (range f ∪ {0} : Set G) := hf.separableSpace_range_union_singleton
-    let f_seq := @SimpleFunc.approxOn G β _ _ _ m _ hf.measurable (range f ∪ {0}) 0 (by simp) _
-    have hf_seq_meas : ∀ n, StronglyMeasurable[m] (f_seq n) := fun n =>
-      @SimpleFunc.stronglyMeasurable β G m _ (f_seq n)
-    have hf_seq_int : ∀ n, Integrable (f_seq n) μ :=
-      SimpleFunc.integrable_approxOn_range (hf.mono hm).measurable hf_int
-    have hf_seq_int_m : ∀ n, Integrable (f_seq n) (μ.trim hm) := fun n =>
-      (hf_seq_int n).trim hm (hf_seq_meas n)
-    have hf_seq_eq : ∀ n, ∫ x, f_seq n x ∂μ = ∫ x, f_seq n x ∂μ.trim hm := fun n =>
-      integral_trim_simpleFunc hm (f_seq n) (hf_seq_int n)
-    have h_lim_1 : atTop.Tendsto (fun n => ∫ x, f_seq n x ∂μ) (𝓝 (∫ x, f x ∂μ)) := by
-      refine' tendsto_integral_of_L1 f hf_int (eventually_of_forall hf_seq_int) _
-      exact SimpleFunc.tendsto_approxOn_range_L1_nnnorm (hf.mono hm).measurable hf_int
-    have h_lim_2 : atTop.Tendsto (fun n => ∫ x, f_seq n x ∂μ) (𝓝 (∫ x, f x ∂μ.trim hm)) := by
-      simp_rw [hf_seq_eq]
-      refine' @tendsto_integral_of_L1 β G _ _ m (μ.trim hm) _ f (hf_int.trim hm hf) _ _
-        (eventually_of_forall hf_seq_int_m) _
-      exact @SimpleFunc.tendsto_approxOn_range_L1_nnnorm β G m _ _ _ f _ _ hf.measurable
-        (hf_int.trim hm hf)
-    exact tendsto_nhds_unique h_lim_1 h_lim_2
+  by_cases hG : CompleteSpace G; swap
   · simp [integral, hG]
+  borelize G
+  by_cases hf_int : Integrable f μ
+  swap
+  · have hf_int_m : ¬Integrable f (μ.trim hm) := fun hf_int_m =>
+      hf_int (integrable_of_integrable_trim hm hf_int_m)
+    rw [integral_undef hf_int, integral_undef hf_int_m]
+  haveI : SeparableSpace (range f ∪ {0} : Set G) := hf.separableSpace_range_union_singleton
+  let f_seq := @SimpleFunc.approxOn G β _ _ _ m _ hf.measurable (range f ∪ {0}) 0 (by simp) _
+  have hf_seq_meas : ∀ n, StronglyMeasurable[m] (f_seq n) := fun n =>
+    @SimpleFunc.stronglyMeasurable β G m _ (f_seq n)
+  have hf_seq_int : ∀ n, Integrable (f_seq n) μ :=
+    SimpleFunc.integrable_approxOn_range (hf.mono hm).measurable hf_int
+  have hf_seq_int_m : ∀ n, Integrable (f_seq n) (μ.trim hm) := fun n =>
+    (hf_seq_int n).trim hm (hf_seq_meas n)
+  have hf_seq_eq : ∀ n, ∫ x, f_seq n x ∂μ = ∫ x, f_seq n x ∂μ.trim hm := fun n =>
+    integral_trim_simpleFunc hm (f_seq n) (hf_seq_int n)
+  have h_lim_1 : atTop.Tendsto (fun n => ∫ x, f_seq n x ∂μ) (𝓝 (∫ x, f x ∂μ)) := by
+    refine' tendsto_integral_of_L1 f hf_int (eventually_of_forall hf_seq_int) _
+    exact SimpleFunc.tendsto_approxOn_range_L1_nnnorm (hf.mono hm).measurable hf_int
+  have h_lim_2 : atTop.Tendsto (fun n => ∫ x, f_seq n x ∂μ) (𝓝 (∫ x, f x ∂μ.trim hm)) := by
+    simp_rw [hf_seq_eq]
+    refine' @tendsto_integral_of_L1 β G _ _ m (μ.trim hm) _ f (hf_int.trim hm hf) _ _
+      (eventually_of_forall hf_seq_int_m) _
+    exact @SimpleFunc.tendsto_approxOn_range_L1_nnnorm β G m _ _ _ f _ _ hf.measurable
+      (hf_int.trim hm hf)
+  exact tendsto_nhds_unique h_lim_1 h_lim_2
 #align measure_theory.integral_trim MeasureTheory.integral_trim
 
 theorem integral_trim_ae (hm : m ≤ m0) {f : β → G} (hf : AEStronglyMeasurable f (μ.trim hm)) :

--- a/Mathlib/MeasureTheory/Integral/CircleTransform.lean
+++ b/Mathlib/MeasureTheory/Integral/CircleTransform.lean
@@ -70,7 +70,7 @@ theorem circleTransformDeriv_eq (f : ℂ → E) : circleTransformDeriv R z w f =
   ring
 #align complex.circle_transform_deriv_eq Complex.circleTransformDeriv_eq
 
-theorem integral_circleTransform [CompleteSpace E] (f : ℂ → E) :
+theorem integral_circleTransform (f : ℂ → E) :
     (∫ θ : ℝ in (0)..2 * π, circleTransform R z w f θ) =
       (2 * ↑π * I)⁻¹ • ∮ z in C(z, R), (z - w)⁻¹ • f z := by
   simp_rw [circleTransform, circleIntegral, deriv_circleMap, circleMap]

--- a/Mathlib/MeasureTheory/Integral/SetIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/SetIntegral.lean
@@ -455,7 +455,7 @@ theorem integral_indicator_const [CompleteSpace E] (e : E) ⦃s : Set α⦄ (s_m
 #align measure_theory.integral_indicator_const MeasureTheory.integral_indicator_const
 
 @[simp]
-theorem integral_indicator_one [CompleteSpace E] ⦃s : Set α⦄ (hs : MeasurableSet s) :
+theorem integral_indicator_one ⦃s : Set α⦄ (hs : MeasurableSet s) :
     ∫ a, s.indicator 1 a ∂μ = (μ s).toReal :=
   (integral_indicator_const 1 hs).trans ((smul_eq_mul _).trans (mul_one _))
 #align measure_theory.integral_indicator_one MeasureTheory.integral_indicator_one

--- a/Mathlib/MeasureTheory/Integral/SetIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/SetIntegral.lean
@@ -70,7 +70,7 @@ section NormedAddCommGroup
 
 variable [NormedAddCommGroup E] {f g : α → E} {s t : Set α} {μ ν : Measure α} {l l' : Filter α}
 
-variable [CompleteSpace E] [NormedSpace ℝ E]
+variable [NormedSpace ℝ E]
 
 theorem set_integral_congr_ae₀ (hs : NullMeasurableSet s μ) (h : ∀ᵐ x ∂μ, x ∈ s → f x = g x) :
     ∫ x in s, f x ∂μ = ∫ x in s, g x ∂μ :=
@@ -444,24 +444,24 @@ theorem integral_norm_eq_pos_sub_neg {f : α → ℝ} (hfi : Integrable f μ) :
       rw [← set_integral_neg_eq_set_integral_nonpos hfi.1]; congr; ext1 x; simp
 #align measure_theory.integral_norm_eq_pos_sub_neg MeasureTheory.integral_norm_eq_pos_sub_neg
 
-theorem set_integral_const (c : E) : ∫ _ in s, c ∂μ = (μ s).toReal • c := by
+theorem set_integral_const [CompleteSpace E] (c : E) : ∫ _ in s, c ∂μ = (μ s).toReal • c := by
   rw [integral_const, Measure.restrict_apply_univ]
 #align measure_theory.set_integral_const MeasureTheory.set_integral_const
 
 @[simp]
-theorem integral_indicator_const (e : E) ⦃s : Set α⦄ (s_meas : MeasurableSet s) :
+theorem integral_indicator_const [CompleteSpace E] (e : E) ⦃s : Set α⦄ (s_meas : MeasurableSet s) :
     (∫ a : α, s.indicator (fun _ : α => e) a ∂μ) = (μ s).toReal • e := by
   rw [integral_indicator s_meas, ← set_integral_const]
 #align measure_theory.integral_indicator_const MeasureTheory.integral_indicator_const
 
 @[simp]
-theorem integral_indicator_one ⦃s : Set α⦄ (hs : MeasurableSet s) :
+theorem integral_indicator_one [CompleteSpace E] ⦃s : Set α⦄ (hs : MeasurableSet s) :
     ∫ a, s.indicator 1 a ∂μ = (μ s).toReal :=
   (integral_indicator_const 1 hs).trans ((smul_eq_mul _).trans (mul_one _))
 #align measure_theory.integral_indicator_one MeasureTheory.integral_indicator_one
 
-theorem set_integral_indicatorConstLp {p : ℝ≥0∞} (hs : MeasurableSet s) (ht : MeasurableSet t)
-    (hμt : μ t ≠ ∞) (x : E) :
+theorem set_integral_indicatorConstLp [CompleteSpace E]
+    {p : ℝ≥0∞} (hs : MeasurableSet s) (ht : MeasurableSet t) (hμt : μ t ≠ ∞) (x : E) :
     ∫ a in s, indicatorConstLp p ht hμt x a ∂μ = (μ (t ∩ s)).toReal • x :=
   calc
     ∫ a in s, indicatorConstLp p ht hμt x a ∂μ = ∫ a in s, t.indicator (fun _ => x) a ∂μ := by
@@ -470,7 +470,8 @@ theorem set_integral_indicatorConstLp {p : ℝ≥0∞} (hs : MeasurableSet s) (h
 set_option linter.uppercaseLean3 false in
 #align measure_theory.set_integral_indicator_const_Lp MeasureTheory.set_integral_indicatorConstLp
 
-theorem integral_indicatorConstLp {p : ℝ≥0∞} (ht : MeasurableSet t) (hμt : μ t ≠ ∞) (x : E) :
+theorem integral_indicatorConstLp [CompleteSpace E]
+    {p : ℝ≥0∞} (ht : MeasurableSet t) (hμt : μ t ≠ ∞) (x : E) :
     ∫ a, indicatorConstLp p ht hμt x a ∂μ = (μ t).toReal • x :=
   calc
     ∫ a, indicatorConstLp p ht hμt x a ∂μ = ∫ a in univ, indicatorConstLp p ht hμt x a ∂μ := by
@@ -933,7 +934,7 @@ set_option linter.uppercaseLean3 false in
 variable {𝕜}
 
 @[continuity]
-theorem continuous_set_integral [NormedSpace ℝ E] [CompleteSpace E] (s : Set α) :
+theorem continuous_set_integral [NormedSpace ℝ E] (s : Set α) :
     Continuous fun f : α →₁[μ] E => ∫ x in s, f x ∂μ := by
   haveI : Fact ((1 : ℝ≥0∞) ≤ 1) := ⟨le_rfl⟩
   have h_comp :

--- a/Mathlib/MeasureTheory/Measure/Lebesgue/Integral.lean
+++ b/Mathlib/MeasureTheory/Measure/Lebesgue/Integral.lean
@@ -92,7 +92,7 @@ of finite integrals, see `intervalIntegral.integral_comp_neg`.
 /- @[simp] Porting note: Linter complains it does not apply to itself. Although it does apply to
 itself, it does not apply when `f` is more complicated -/
 theorem integral_comp_neg_Iic {E : Type _} [NormedAddCommGroup E] [NormedSpace ℝ E]
-    [CompleteSpace E] (c : ℝ) (f : ℝ → E) : (∫ x in Iic c, f (-x)) = ∫ x in Ioi (-c), f x := by
+    (c : ℝ) (f : ℝ → E) : (∫ x in Iic c, f (-x)) = ∫ x in Ioi (-c), f x := by
   have A : MeasurableEmbedding fun x : ℝ => -x :=
     (Homeomorph.neg ℝ).closedEmbedding.measurableEmbedding
   have := MeasurableEmbedding.set_integral_map (μ := volume) A f (Ici (-c))
@@ -103,7 +103,7 @@ theorem integral_comp_neg_Iic {E : Type _} [NormedAddCommGroup E] [NormedSpace �
 /- @[simp] Porting note: Linter complains it does not apply to itself. Although it does apply to
 itself, it does not apply when `f` is more complicated -/
 theorem integral_comp_neg_Ioi {E : Type _} [NormedAddCommGroup E] [NormedSpace ℝ E]
-    [CompleteSpace E] (c : ℝ) (f : ℝ → E) : (∫ x in Ioi c, f (-x)) = ∫ x in Iic (-c), f x := by
+    (c : ℝ) (f : ℝ → E) : (∫ x in Ioi c, f (-x)) = ∫ x in Iic (-c), f x := by
   rw [← neg_neg c, ← integral_comp_neg_Iic]
   simp only [neg_neg]
 #align integral_comp_neg_Ioi integral_comp_neg_Ioi

--- a/Mathlib/MeasureTheory/Measure/Lebesgue/Integral.lean
+++ b/Mathlib/MeasureTheory/Measure/Lebesgue/Integral.lean
@@ -95,7 +95,7 @@ theorem integral_comp_neg_Iic {E : Type _} [NormedAddCommGroup E] [NormedSpace �
     [CompleteSpace E] (c : ℝ) (f : ℝ → E) : (∫ x in Iic c, f (-x)) = ∫ x in Ioi (-c), f x := by
   have A : MeasurableEmbedding fun x : ℝ => -x :=
     (Homeomorph.neg ℝ).closedEmbedding.measurableEmbedding
-  have := @MeasurableEmbedding.set_integral_map _ _ _ _ volume _ _ _ _ _  A f (Ici (-c))
+  have := MeasurableEmbedding.set_integral_map (μ := volume) A f (Ici (-c))
   rw [Measure.map_neg_eq_self (volume : Measure ℝ)] at this
   simp_rw [← integral_Ici_eq_integral_Ioi, this, neg_preimage, preimage_neg_Ici, neg_neg]
 #align integral_comp_neg_Iic integral_comp_neg_Iic

--- a/Mathlib/MeasureTheory/Measure/ProbabilityMeasure.lean
+++ b/Mathlib/MeasureTheory/Measure/ProbabilityMeasure.lean
@@ -387,7 +387,7 @@ theorem _root_.ProbabilityMeasure.toFiniteMeasure_normalize_eq_self {m0 : Measur
 /-- Averaging with respect to a finite measure is the same as integrating against
 `MeasureTheory.FiniteMeasure.normalize`. -/
 theorem average_eq_integral_normalize {E : Type _} [NormedAddCommGroup E] [NormedSpace ℝ E]
-    [CompleteSpace E] (nonzero : μ ≠ 0) (f : Ω → E) :
+    (nonzero : μ ≠ 0) (f : Ω → E) :
     average (μ : Measure Ω) f = ∫ ω, f ω ∂(μ.normalize : Measure Ω) := by
   rw [μ.toMeasure_normalize_eq_of_nonzero nonzero, average]
   congr

--- a/Mathlib/Probability/IdentDistrib.lean
+++ b/Mathlib/Probability/IdentDistrib.lean
@@ -181,7 +181,7 @@ theorem lintegral_eq {f : α → ℝ≥0∞} {g : β → ℝ≥0∞} (h : IdentD
     lintegral_map' aemeasurable_id h.aemeasurable_snd, h.map_eq]
 #align probability_theory.ident_distrib.lintegral_eq ProbabilityTheory.IdentDistrib.lintegral_eq
 
-theorem integral_eq [NormedAddCommGroup γ] [NormedSpace ℝ γ] [CompleteSpace γ] [BorelSpace γ]
+theorem integral_eq [NormedAddCommGroup γ] [NormedSpace ℝ γ] [BorelSpace γ]
     (h : IdentDistrib f g μ ν) : ∫ x, f x ∂μ = ∫ x, g x ∂ν := by
   by_cases hf : AEStronglyMeasurable f μ
   · have A : AEStronglyMeasurable id (Measure.map f μ) := by

--- a/Mathlib/Probability/Kernel/Basic.lean
+++ b/Mathlib/Probability/Kernel/Basic.lean
@@ -455,13 +455,13 @@ theorem set_lintegral_const {f : β → ℝ≥0∞} {μ : Measure β} {a : α} {
 #align probability_theory.kernel.set_lintegral_const ProbabilityTheory.kernel.set_lintegral_const
 
 @[simp]
-theorem integral_const {E : Type _} [NormedAddCommGroup E] [NormedSpace ℝ E] [CompleteSpace E]
+theorem integral_const {E : Type _} [NormedAddCommGroup E] [NormedSpace ℝ E]
     {f : β → E} {μ : Measure β} {a : α} : ∫ x, f x ∂kernel.const α μ a = ∫ x, f x ∂μ := by
   rw [kernel.const_apply]
 #align probability_theory.kernel.integral_const ProbabilityTheory.kernel.integral_const
 
 @[simp]
-theorem set_integral_const {E : Type _} [NormedAddCommGroup E] [NormedSpace ℝ E] [CompleteSpace E]
+theorem set_integral_const {E : Type _} [NormedAddCommGroup E] [NormedSpace ℝ E]
     {f : β → E} {μ : Measure β} {a : α} {s : Set β} :
     ∫ x in s, f x ∂kernel.const α μ a = ∫ x in s, f x ∂μ := by rw [kernel.const_apply]
 #align probability_theory.kernel.set_integral_const ProbabilityTheory.kernel.set_integral_const
@@ -518,7 +518,7 @@ theorem set_lintegral_restrict (κ : kernel α β) (hs : MeasurableSet s) (a : �
 
 @[simp]
 theorem set_integral_restrict {E : Type _} [NormedAddCommGroup E] [NormedSpace ℝ E]
-    [CompleteSpace E] {f : β → E} {a : α} (hs : MeasurableSet s) (t : Set β) :
+    {f : β → E} {a : α} (hs : MeasurableSet s) (t : Set β) :
     ∫ x in t, f x ∂kernel.restrict κ hs a = ∫ x in t ∩ s, f x ∂κ a := by
   rw [restrict_apply, Measure.restrict_restrict' hs]
 #align probability_theory.kernel.set_integral_restrict ProbabilityTheory.kernel.set_integral_restrict
@@ -655,14 +655,14 @@ theorem set_lintegral_piecewise (a : α) (g : β → ℝ≥0∞) (t : Set β) :
   by simp_rw [piecewise_apply]; split_ifs <;> rfl
 #align probability_theory.kernel.set_lintegral_piecewise ProbabilityTheory.kernel.set_lintegral_piecewise
 
-theorem integral_piecewise {E : Type _} [NormedAddCommGroup E] [NormedSpace ℝ E] [CompleteSpace E]
+theorem integral_piecewise {E : Type _} [NormedAddCommGroup E] [NormedSpace ℝ E]
     (a : α) (g : β → E) :
     ∫ b, g b ∂piecewise hs κ η a = if a ∈ s then ∫ b, g b ∂κ a else ∫ b, g b ∂η a := by
   simp_rw [piecewise_apply]; split_ifs <;> rfl
 #align probability_theory.kernel.integral_piecewise ProbabilityTheory.kernel.integral_piecewise
 
 theorem set_integral_piecewise {E : Type _} [NormedAddCommGroup E] [NormedSpace ℝ E]
-    [CompleteSpace E] (a : α) (g : β → E) (t : Set β) :
+    (a : α) (g : β → E) (t : Set β) :
     ∫ b in t, g b ∂piecewise hs κ η a =
       if a ∈ s then ∫ b in t, g b ∂κ a else ∫ b in t, g b ∂η a :=
   by simp_rw [piecewise_apply]; split_ifs <;> rfl
@@ -673,3 +673,5 @@ end Piecewise
 end kernel
 
 end ProbabilityTheory
+
+#lint

--- a/Mathlib/Probability/Kernel/Basic.lean
+++ b/Mathlib/Probability/Kernel/Basic.lean
@@ -673,5 +673,3 @@ end Piecewise
 end kernel
 
 end ProbabilityTheory
-
-#lint

--- a/Mathlib/Probability/Martingale/Convergence.lean
+++ b/Mathlib/Probability/Martingale/Convergence.lean
@@ -406,8 +406,8 @@ theorem Integrable.tendsto_ae_condexp (hg : Integrable g μ)
   · rintro t ⟨n, ht⟩ -
     exact this n _ ht
   · rintro t htmeas ht -
-    have hgeq := @integral_add_compl _ _ (⨆ n, ℱ n) _ _ _ _ _ _ htmeas (hg.trim hle hgmeas)
-    have hheq := @integral_add_compl _ _ (⨆ n, ℱ n) _ _ _ _ _ _ htmeas
+    have hgeq := @integral_add_compl _ _ (⨆ n, ℱ n) _ _ _ _ _ htmeas (hg.trim hle hgmeas)
+    have hheq := @integral_add_compl _ _ (⨆ n, ℱ n) _ _ _ _ _ htmeas
       (hlimint.trim hle stronglyMeasurable_limitProcess)
     rw [add_comm, ← eq_sub_iff_add_eq] at hgeq hheq
     rw [set_integral_trim hle hgmeas htmeas.compl,


### PR DESCRIPTION
The notion of Bochner integral of a function taking values in a normed space `E` requires that `E` is complete. This means that whenever we write down an integral, the term contains the assertion that `E` is complete.

In this PR, we remove the completeness requirement from the definition, using the junk value `0` when the space is not complete. Mathematically this does not make any difference, as all reasonable applications will be with a complete `E`. But it means that terms involving integrals become a little bit simpler and that completeness will not have to be checked by the system when applying a bunch of basic lemmas on integrals.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
