### PR TITLE
[Merged by Bors] - feat: infinite (preconnected, locally finite) graphs have nonempty ends

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Basic.lean
@@ -2027,4 +2027,11 @@ end Iso
 
 end Maps
 
+/-- The graph induced on `Set.univ` is isomorphic to the original graph. -/
+@[simps!]
+def induceUnivIso (G : SimpleGraph V) : G.induce Set.univ ≃g G where
+  toEquiv := Equiv.Set.univ V
+  map_rel_iff' := by simp only [Equiv.Set.univ, Equiv.coe_fn_mk, comap_Adj, Embedding.coe_subtype,
+                                Subtype.forall, Set.mem_univ, forall_true_left, implies_true]
+
 end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/Ends/Defs.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Ends/Defs.lean
@@ -10,7 +10,7 @@ Authors: Anand Rao, Rémi Bottinelli
 -/
 import Mathlib.CategoryTheory.CofilteredSystem
 import Mathlib.Combinatorics.SimpleGraph.Connectivity
-import Mathlib.Data.SetLike.Basic
+import Mathlib.Data.Finite.Set
 
 /-!
 # Ends
@@ -79,6 +79,12 @@ theorem componentComplMk_eq_of_adj (G : SimpleGraph V) {v w : V} (vK : v ∉ K) 
   apply Adj.reachable
   exact a
 #align simple_graph.component_compl_mk_eq_of_adj SimpleGraph.componentComplMk_eq_of_adj
+
+/-- In an infinite graph, the set of components out of a finite set is nonempty. -/
+instance componentCompl_nonempty_of_infinite (G : SimpleGraph V) [Infinite V] (K : Finset V) :
+    Nonempty (G.ComponentCompl K) :=
+  let ⟨_, kK⟩ := K.finite_toSet.infinite_compl.nonempty
+  ⟨componentComplMk _ kK⟩
 
 namespace ComponentCompl
 
@@ -244,6 +250,35 @@ theorem infinite_iff_in_all_ranges {K : Finset V} (C : G.ComponentCompl K) :
 #align simple_graph.component_compl.infinite_iff_in_all_ranges SimpleGraph.ComponentCompl.infinite_iff_in_all_ranges
 
 end ComponentCompl
+
+/- For a locally finite preconnected graph, the number of components outside of any finite set
+is finite. -/
+instance componentCompl_finite [LocallyFinite G] [Gpc : Fact G.Preconnected] (K : Finset V) :
+    Finite (G.ComponentCompl K) := by
+  classical
+  rcases K.eq_empty_or_nonempty with rfl | h
+  -- If K is empty, then removing K doesn't change the graph, which is connected, hence has a
+  -- single connected component
+  · dsimp [ComponentCompl]
+    rw [Finset.coe_empty, Set.compl_empty]
+    have := Gpc.out.subsingleton_connectedComponent
+    exact Finite.of_equiv _ (induceUnivIso G).connectedComponentEquiv.symm
+  -- Otherwise, we consider the function `touch` mapping a connected component to one of its
+  -- vertices adjacent to `K`.
+  · let touch (C : G.ComponentCompl K) : {v : V | ∃ k : V, k ∈ K ∧ G.Adj k v} :=
+      let p := C.exists_adj_boundary_pair Gpc.out h
+      ⟨p.choose.1, p.choose.2, p.choose_spec.2.1, p.choose_spec.2.2.symm⟩
+    -- `touch` is injective
+    have touch_inj : touch.Injective := fun C D h' => ComponentCompl.pairwise_disjoint.eq
+      (Set.not_disjoint_iff.mpr ⟨touch C, (C.exists_adj_boundary_pair Gpc.out h).choose_spec.1,
+                                 h'.symm ▸ (D.exists_adj_boundary_pair Gpc.out h).choose_spec.1⟩)
+    -- `touch` has finite range
+    have : Finite (Set.range touch) := by
+      refine @Subtype.finite _ (Set.Finite.to_subtype ?_) _
+      apply Set.Finite.ofFinset (K.biUnion (fun v => G.neighborFinset v))
+      simp only [Finset.mem_biUnion, mem_neighborFinset, Set.mem_setOf_eq, implies_true]
+    -- hence `touch` has a finite domain
+    apply Finite.of_injective_finite_range touch_inj
 
 section Ends
 

--- a/Mathlib/Combinatorics/SimpleGraph/Ends/Properties.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Ends/Properties.lean
@@ -9,6 +9,7 @@ Authors: Anand Rao, Rémi Bottinelli
 ! if you have ported upstream changes.
 -/
 import Mathlib.Combinatorics.SimpleGraph.Ends.Defs
+import Mathlib.CategoryTheory.CofilteredSystem
 
 /-!
 # Properties of the ends of graphs
@@ -30,5 +31,24 @@ instance [Finite V] : IsEmpty G.end :=
     exact
       Set.disjoint_iff.mp (s _).disjoint_right
         ⟨by simp only [Opposite.unop_op, Finset.coe_univ, Set.mem_univ], h⟩⟩
+
+/-- The `component_compl`s chosen by an end are all infinite. -/
+lemma end_componentCompl_infinite (e : G.end) (K : (Finset V)ᵒᵖ) :
+    ((e : (j : (Finset V)ᵒᵖ) → G.componentComplFunctor.obj j) K).supp.Infinite := by
+  refine (e.val K).infinite_iff_in_all_ranges.mpr (fun L h => ?_)
+  change Opposite.unop K ⊆ Opposite.unop (Opposite.op L) at h
+  exact ⟨e.val (Opposite.op L), (e.prop (CategoryTheory.opHomOfLE h))⟩
+
+instance compononentComplFunctor_nonempty_of_infinite [Infinite V] (K : (Finset V)ᵒᵖ) :
+  Nonempty (G.componentComplFunctor.obj K) := G.componentCompl_nonempty_of_infinite K.unop
+
+instance component_compl_functor_finite [LocallyFinite G] [Fact G.Preconnected]
+    (K : (Finset V)ᵒᵖ) : Finite (G.componentComplFunctor.obj K) := G.componentCompl_finite K.unop
+
+/-- A locally finite preconnected infinite graph has at least one end. -/
+lemma nonempty_ends_of_infinite [LocallyFinite G] [Fact G.Preconnected] [Infinite V] :
+    G.end.Nonempty := by
+  classical
+  apply nonempty_sections_of_finite_inverse_system G.componentComplFunctor
 
 end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/Ends/Properties.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Ends/Properties.lean
@@ -31,7 +31,7 @@ instance [Finite V] : IsEmpty G.end where
     exact Set.disjoint_iff.mp (s _).disjoint_right
         ⟨by simp only [Opposite.unop_op, Finset.coe_univ, Set.mem_univ], h⟩
 
-/-- The `component_compl`s chosen by an end are all infinite. -/
+/-- The `componentCompl`s chosen by an end are all infinite. -/
 lemma end_componentCompl_infinite (e : G.end) (K : (Finset V)ᵒᵖ) :
     ((e : (j : (Finset V)ᵒᵖ) → G.componentComplFunctor.obj j) K).supp.Infinite := by
   refine (e.val K).infinite_iff_in_all_ranges.mpr (fun L h => ?_)

--- a/Mathlib/Combinatorics/SimpleGraph/Ends/Properties.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Ends/Properties.lean
@@ -23,14 +23,13 @@ variable {V : Type} (G : SimpleGraph V)
 
 namespace SimpleGraph
 
-instance [Finite V] : IsEmpty G.end :=
-  ⟨by
+instance [Finite V] : IsEmpty G.end where
+  false := by
     rintro ⟨s, _⟩
     cases nonempty_fintype V
     obtain ⟨v, h⟩ := (s <| Opposite.op Finset.univ).nonempty
-    exact
-      Set.disjoint_iff.mp (s _).disjoint_right
-        ⟨by simp only [Opposite.unop_op, Finset.coe_univ, Set.mem_univ], h⟩⟩
+    exact Set.disjoint_iff.mp (s _).disjoint_right
+        ⟨by simp only [Opposite.unop_op, Finset.coe_univ, Set.mem_univ], h⟩
 
 /-- The `component_compl`s chosen by an end are all infinite. -/
 lemma end_componentCompl_infinite (e : G.end) (K : (Finset V)ᵒᵖ) :
@@ -40,7 +39,7 @@ lemma end_componentCompl_infinite (e : G.end) (K : (Finset V)ᵒᵖ) :
   exact ⟨e.val (Opposite.op L), (e.prop (CategoryTheory.opHomOfLE h))⟩
 
 instance compononentComplFunctor_nonempty_of_infinite [Infinite V] (K : (Finset V)ᵒᵖ) :
-  Nonempty (G.componentComplFunctor.obj K) := G.componentCompl_nonempty_of_infinite K.unop
+    Nonempty (G.componentComplFunctor.obj K) := G.componentCompl_nonempty_of_infinite K.unop
 
 instance component_compl_functor_finite [LocallyFinite G] [Fact G.Preconnected]
     (K : (Finset V)ᵒᵖ) : Finite (G.componentComplFunctor.obj K) := G.componentCompl_finite K.unop

--- a/Mathlib/Combinatorics/SimpleGraph/Ends/Properties.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Ends/Properties.lean
@@ -41,7 +41,7 @@ lemma end_componentCompl_infinite (e : G.end) (K : (Finset V)ᵒᵖ) :
 instance compononentComplFunctor_nonempty_of_infinite [Infinite V] (K : (Finset V)ᵒᵖ) :
     Nonempty (G.componentComplFunctor.obj K) := G.componentCompl_nonempty_of_infinite K.unop
 
-instance component_compl_functor_finite [LocallyFinite G] [Fact G.Preconnected]
+instance componentComplFunctor_finite [LocallyFinite G] [Fact G.Preconnected]
     (K : (Finset V)ᵒᵖ) : Finite (G.componentComplFunctor.obj K) := G.componentCompl_finite K.unop
 
 /-- A locally finite preconnected infinite graph has at least one end. -/


### PR DESCRIPTION
Port/review of [mathlib#18410](https://github.com/leanprover-community/mathlib/pull/18410) directly to Mathlib4.

Co-authored-by: Rémi Bottinelli <remi.bottinelli@bluewin.ch>
Co-authored-by: Anand Rao <anand.rao.art@gmail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
