### PR TITLE
[Merged by Bors] - feat: make start_port.sh work for core too

### DIFF
--- a/scripts/start_port.sh
+++ b/scripts/start_port.sh
@@ -26,12 +26,14 @@ case $mathlib4_path in
 esac
 
 MATHLIB3PORT_BASE_URL=https://raw.githubusercontent.com/leanprover-community/mathlib3port/master
+LEAN3PORT_BASE_URL=https://raw.githubusercontent.com/leanprover-community/lean3port/master
 PORT_STATUS_YAML=https://raw.githubusercontent.com/wiki/leanprover-community/mathlib/mathlib4-port-status.md
 
 # process path name
 mathlib4_mod=$(basename $(echo "$mathlib4_path" | tr / .) .lean)
 mathlib4_mod_tail=${mathlib4_mod#Mathlib.}
 mathlib3port_url=$MATHLIB3PORT_BASE_URL/${1/#Mathlib/Mathbin}
+lean3port_url=$LEAN3PORT_BASE_URL/${1/#Mathlib/Leanbin}
 
 # start the port from the latest master
 git fetch
@@ -54,7 +56,7 @@ echo "Downloading latest version from mathlib3port"
     cd $GIT_WORK_TREE;
     # download the file, but don't commit it yet
     mkdir -p "$(dirname "$mathlib4_path")"
-    curl --silent --show-error --fail -o "$mathlib4_path" "$mathlib3port_url"
+    curl --silent --show-error --fail -o "$mathlib4_path" "$lean3port_url" || curl --silent --show-error --fail -o "$mathlib4_path" "$mathlib3port_url"
 )
 
 # Empty commit with nice title. Used by gh and hub to suggest PR title.
@@ -69,6 +71,7 @@ echo "Applying automated fixes"
 
 pushd $GIT_WORK_TREE;
 sed -i 's/Mathbin\./Mathlib\./g' "$mathlib4_path"
+sed -i 's/Leanbin\./Mathlib\./g' "$mathlib4_path"
 sed -i '/^import/{s/[.]Gcd/.GCD/g; s/[.]Modeq/.ModEq/g; s/[.]Nary/.NAry/g; s/[.]Peq/.PEq/g; s/[.]Pfun/.PFun/g; s/[.]Pnat/.PNat/g; s/[.]Smul/.SMul/g; s/[.]Zmod/.ZMod/g; s/[.]Nnreal/.NNReal/g; s/[.]Ennreal/.ENNReal/g}' "$mathlib4_path"
 
 python3 "$root_path/scripts/fix-line-breaks.py" "$mathlib4_path" "$mathlib4_path.tmp"


### PR DESCRIPTION
Tested on core files as `start_port.sh Mathlib/Init/Core` and seems to do something reasonable.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
