### PR TITLE
feat: allow docstrings on `#align` to describe dubiousness

### DIFF
--- a/Mathlib/Analysis/NormedSpace/LpEquiv.lean
+++ b/Mathlib/Analysis/NormedSpace/LpEquiv.lean
@@ -111,8 +111,8 @@ noncomputable def lpPiLpₗᵢ [Fact (1 ≤ p)] : lp E p ≃ₗᵢ[𝕜] PiLp p 
   { AddEquiv.lpPiLp with
     map_smul' := fun _k _f => rfl
     norm_map' := equiv_lpPiLp_norm }
+/-- `E` is now explicit -/
 #align lp_pi_Lpₗᵢ lpPiLpₗᵢₓ
--- porting note: `#align`ed with an `ₓ` because `E` is now explicit, see above
 
 variable {𝕜 E}
 
@@ -172,8 +172,8 @@ noncomputable def lpBcfₗᵢ : lp (fun _ : α => E) ∞ ≃ₗᵢ[𝕜] α →�
   { AddEquiv.lpBcf with
     map_smul' := fun k f => rfl
     norm_map' := fun f => by simp only [norm_eq_iSup_norm, lp.norm_eq_ciSup]; rfl }
+/-- `E` is now explicit. -/
 #align lp_bcfₗᵢ lpBcfₗᵢₓ
--- porting note: `#align`ed with an `ₓ` because `E` is now explicit, see above
 
 variable {𝕜 E}
 


### PR DESCRIPTION
These docstrings are shown by `#lookup3`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
