### PR TITLE
[Merged by Bors] - feat(Tactic/ComputeDegree): add helper lemmas for `compute_degree_le`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2017,7 +2017,7 @@ import Mathlib.Init.Algebra.Classes
 import Mathlib.Init.Algebra.Functions
 import Mathlib.Init.Algebra.Order
 import Mathlib.Init.Align
-import Mathlib.Init.CCLemmas
+import Mathlib.Init.CcLemmas
 import Mathlib.Init.Classes.Order
 import Mathlib.Init.Classical
 import Mathlib.Init.Control.Combinators
@@ -2918,6 +2918,7 @@ import Mathlib.Tactic.ClearExcept
 import Mathlib.Tactic.Clear_
 import Mathlib.Tactic.Coe
 import Mathlib.Tactic.Common
+import Mathlib.Tactic.ComputeDegree
 import Mathlib.Tactic.Congr!
 import Mathlib.Tactic.Constructor
 import Mathlib.Tactic.Continuity
@@ -2948,7 +2949,6 @@ import Mathlib.Tactic.Group
 import Mathlib.Tactic.GuardGoalNums
 import Mathlib.Tactic.GuardHypNums
 import Mathlib.Tactic.Have
-import Mathlib.Tactic.HaveI
 import Mathlib.Tactic.HelpCmd
 import Mathlib.Tactic.HigherOrder
 import Mathlib.Tactic.InferParam

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2017,7 +2017,7 @@ import Mathlib.Init.Algebra.Classes
 import Mathlib.Init.Algebra.Functions
 import Mathlib.Init.Algebra.Order
 import Mathlib.Init.Align
-import Mathlib.Init.CcLemmas
+import Mathlib.Init.CCLemmas
 import Mathlib.Init.Classes.Order
 import Mathlib.Init.Classical
 import Mathlib.Init.Control.Combinators
@@ -2949,6 +2949,7 @@ import Mathlib.Tactic.Group
 import Mathlib.Tactic.GuardGoalNums
 import Mathlib.Tactic.GuardHypNums
 import Mathlib.Tactic.Have
+import Mathlib.Tactic.HaveI
 import Mathlib.Tactic.HelpCmd
 import Mathlib.Tactic.HigherOrder
 import Mathlib.Tactic.InferParam

--- a/Mathlib/Data/Polynomial/Degree/Definitions.lean
+++ b/Mathlib/Data/Polynomial/Degree/Definitions.lean
@@ -815,13 +815,11 @@ theorem degree_pow_le (p : R[X]) : ∀ n : ℕ, degree (p ^ n) ≤ n • degree 
 
 theorem degree_pow_le_of_le {a : WithBot ℕ} (b : ℕ) (hp : degree p ≤ a) :
     degree (p ^ b) ≤ b * a := by
-  apply (degree_pow_le _ _).trans
-  rw [nsmul_eq_mul]
   induction b with
-    | zero => simp [degree_one_le]
-    | succ n hn =>
-      rw [Nat.cast_succ, add_mul, add_mul, one_mul, one_mul]
-      exact (add_le_add_left hp _).trans (add_le_add_right hn _)
+  | zero => simp [degree_one_le]
+  | succ n hn =>
+      rw [Nat.cast_succ, add_mul, one_mul, pow_succ']
+      exact degree_mul_le_of_le hn hp
 
 @[simp]
 theorem leadingCoeff_monomial (a : R) (n : ℕ) : leadingCoeff (monomial n a) = a := by

--- a/Mathlib/Data/Polynomial/Degree/Definitions.lean
+++ b/Mathlib/Data/Polynomial/Degree/Definitions.lean
@@ -285,7 +285,7 @@ theorem natDegree_nat_cast (n : ℕ) : natDegree (n : R[X]) = 0 := by
   simp only [← C_eq_nat_cast, natDegree_C]
 #align polynomial.nat_degree_nat_cast Polynomial.natDegree_nat_cast
 
-theorem degree_nat_cast_le (n : Nat) : degree (n : R[X]) ≤ 0 := degree_le_of_natDegree_le (by simp)
+theorem degree_nat_cast_le (n : ℕ) : degree (n : R[X]) ≤ 0 := degree_le_of_natDegree_le (by simp)
 
 @[simp]
 theorem degree_monomial (n : ℕ) (ha : a ≠ 0) : degree (monomial n a) = n := by
@@ -539,7 +539,7 @@ theorem coeff_mul_X_sub_C {p : R[X]} {r : R} {a : ℕ} :
 theorem degree_neg (p : R[X]) : degree (-p) = degree p := by unfold degree; rw [support_neg]
 #align polynomial.degree_neg Polynomial.degree_neg
 
-theorem degree_neg_le_of_le {a : WithBot Nat} {p : R[X]} (hp : degree p ≤ a) : degree (- p) ≤ a :=
+theorem degree_neg_le_of_le {a : WithBot ℕ} {p : R[X]} (hp : degree p ≤ a) : degree (- p) ≤ a :=
 p.degree_neg.le.trans ‹_›
 
 @[simp]
@@ -653,7 +653,7 @@ theorem degree_add_le_of_degree_le {p q : R[X]} {n : ℕ} (hp : degree p ≤ n) 
   (degree_add_le p q).trans <| max_le hp hq
 #align polynomial.degree_add_le_of_degree_le Polynomial.degree_add_le_of_degree_le
 
-theorem degree_add_le_of_le {a b : WithBot Nat} (hp : degree p ≤ a) (hq : degree q ≤ b) :
+theorem degree_add_le_of_le {a b : WithBot ℕ} (hp : degree p ≤ a) (hq : degree q ≤ b) :
     degree (p + q) ≤ max a b :=
 (p.degree_add_le q).trans <| max_le_max ‹_› ‹_›
 
@@ -800,7 +800,7 @@ theorem degree_mul_le (p q : R[X]) : degree (p * q) ≤ degree p + degree q :=
       exact add_le_add (le_degree_of_ne_zero ha) (le_degree_of_ne_zero hb)
 #align polynomial.degree_mul_le Polynomial.degree_mul_le
 
-theorem degree_mul_le_of_le {a b : WithBot Nat} (hp : degree p ≤ a) (hq : degree q ≤ b) :
+theorem degree_mul_le_of_le {a b : WithBot ℕ} (hp : degree p ≤ a) (hq : degree q ≤ b) :
     degree (p * q) ≤ a + b :=
 (p.degree_mul_le _).trans <| add_le_add ‹_› ‹_›
 
@@ -813,7 +813,7 @@ theorem degree_pow_le (p : R[X]) : ∀ n : ℕ, degree (p ^ n) ≤ n • degree 
       _ ≤ _ := by rw [succ_nsmul]; exact add_le_add le_rfl (degree_pow_le _ _)
 #align polynomial.degree_pow_le Polynomial.degree_pow_le
 
-theorem degree_pow_le_of_le {a : WithBot Nat} (b : Nat) (hp : degree p ≤ a) :
+theorem degree_pow_le_of_le {a : WithBot ℕ} (b : ℕ) (hp : degree p ≤ a) :
     degree (p ^ b) ≤ b * a := by
   apply (degree_pow_le _ _).trans
   rw [nsmul_eq_mul]
@@ -1078,7 +1078,7 @@ theorem natDegree_pow_le {p : R[X]} {n : ℕ} : (p ^ n).natDegree ≤ n * p.natD
     exact add_le_add_left hi _
 #align polynomial.nat_degree_pow_le Polynomial.natDegree_pow_le
 
-theorem natDegree_pow_le_of_le (n : Nat) (hp : natDegree p ≤ m) :
+theorem natDegree_pow_le_of_le (n : ℕ) (hp : natDegree p ≤ m) :
     natDegree (p ^ n) ≤ n * m :=
 natDegree_pow_le.trans (Nat.mul_le_mul rfl.le ‹_›)
 
@@ -1336,7 +1336,7 @@ theorem degree_sub_le (p q : R[X]) : degree (p - q) ≤ max (degree p) (degree q
   simpa only [degree_neg q] using degree_add_le p (-q)
 #align polynomial.degree_sub_le Polynomial.degree_sub_le
 
-theorem degree_sub_le_of_le {a b : WithBot Nat} (hp : degree p ≤ a) (hq : degree q ≤ b) :
+theorem degree_sub_le_of_le {a b : WithBot ℕ} (hp : degree p ≤ a) (hq : degree q ≤ b) :
     degree (p - q) ≤ max a b :=
 (p.degree_sub_le q).trans <| max_le_max ‹_› ‹_›
 

--- a/Mathlib/Data/Polynomial/Degree/Definitions.lean
+++ b/Mathlib/Data/Polynomial/Degree/Definitions.lean
@@ -285,6 +285,8 @@ theorem natDegree_nat_cast (n : ℕ) : natDegree (n : R[X]) = 0 := by
   simp only [← C_eq_nat_cast, natDegree_C]
 #align polynomial.nat_degree_nat_cast Polynomial.natDegree_nat_cast
 
+theorem degree_nat_cast_le (n : Nat) : degree (n : R[X]) ≤ 0 := degree_le_of_natDegree_le (by simp)
+
 @[simp]
 theorem degree_monomial (n : ℕ) (ha : a ≠ 0) : degree (monomial n a) = n := by
   rw [degree, support_monomial n ha]; rfl
@@ -537,14 +539,22 @@ theorem coeff_mul_X_sub_C {p : R[X]} {r : R} {a : ℕ} :
 theorem degree_neg (p : R[X]) : degree (-p) = degree p := by unfold degree; rw [support_neg]
 #align polynomial.degree_neg Polynomial.degree_neg
 
+theorem degree_neg_le_of_le {a : WithBot Nat} {p : R[X]} (hp : degree p ≤ a) : degree (- p) ≤ a :=
+p.degree_neg.le.trans ‹_›
+
 @[simp]
 theorem natDegree_neg (p : R[X]) : natDegree (-p) = natDegree p := by simp [natDegree]
 #align polynomial.nat_degree_neg Polynomial.natDegree_neg
+
+theorem natDegree_neg_le_of_le {p : R[X]} (hp : natDegree p ≤ m) : natDegree (- p) ≤ m :=
+(natDegree_neg p).le.trans ‹_›
 
 @[simp]
 theorem natDegree_int_cast (n : ℤ) : natDegree (n : R[X]) = 0 := by
   rw [← C_eq_int_cast, natDegree_C]
 #align polynomial.nat_degree_int_cast Polynomial.natDegree_int_cast
+
+theorem degree_int_cast_le (n : ℤ) : degree (n : R[X]) ≤ 0 := degree_le_of_natDegree_le (by simp)
 
 @[simp]
 theorem leadingCoeff_neg (p : R[X]) : (-p).leadingCoeff = -p.leadingCoeff := by
@@ -643,6 +653,10 @@ theorem degree_add_le_of_degree_le {p q : R[X]} {n : ℕ} (hp : degree p ≤ n) 
   (degree_add_le p q).trans <| max_le hp hq
 #align polynomial.degree_add_le_of_degree_le Polynomial.degree_add_le_of_degree_le
 
+theorem degree_add_le_of_le {a b : WithBot Nat} (hp : degree p ≤ a) (hq : degree q ≤ b) :
+    degree (p + q) ≤ max a b :=
+(p.degree_add_le q).trans <| max_le_max ‹_› ‹_›
+
 theorem natDegree_add_le (p q : R[X]) : natDegree (p + q) ≤ max (natDegree p) (natDegree q) := by
   cases' le_max_iff.1 (degree_add_le p q) with h h <;> simp [natDegree_le_natDegree h]
 #align polynomial.nat_degree_add_le Polynomial.natDegree_add_le
@@ -651,6 +665,10 @@ theorem natDegree_add_le_of_degree_le {p q : R[X]} {n : ℕ} (hp : natDegree p �
     (hq : natDegree q ≤ n) : natDegree (p + q) ≤ n :=
   (natDegree_add_le p q).trans <| max_le hp hq
 #align polynomial.nat_degree_add_le_of_degree_le Polynomial.natDegree_add_le_of_degree_le
+
+theorem natDegree_add_le_of_le (hp : natDegree p ≤ m) (hq : natDegree q ≤ n) :
+    natDegree (p + q) ≤ max m n :=
+(p.natDegree_add_le q).trans <| max_le_max ‹_› ‹_›
 
 @[simp]
 theorem leadingCoeff_zero : leadingCoeff (0 : R[X]) = 0 :=
@@ -782,6 +800,10 @@ theorem degree_mul_le (p q : R[X]) : degree (p * q) ≤ degree p + degree q :=
       exact add_le_add (le_degree_of_ne_zero ha) (le_degree_of_ne_zero hb)
 #align polynomial.degree_mul_le Polynomial.degree_mul_le
 
+theorem degree_mul_le_of_le {a b : WithBot Nat} (hp : degree p ≤ a) (hq : degree q ≤ b) :
+    degree (p * q) ≤ a + b :=
+(p.degree_mul_le _).trans <| add_le_add ‹_› ‹_›
+
 theorem degree_pow_le (p : R[X]) : ∀ n : ℕ, degree (p ^ n) ≤ n • degree p
   | 0 => by rw [pow_zero, zero_nsmul]; exact degree_one_le
   | n + 1 =>
@@ -790,6 +812,16 @@ theorem degree_pow_le (p : R[X]) : ∀ n : ℕ, degree (p ^ n) ≤ n • degree 
         rw [pow_succ]; exact degree_mul_le _ _
       _ ≤ _ := by rw [succ_nsmul]; exact add_le_add le_rfl (degree_pow_le _ _)
 #align polynomial.degree_pow_le Polynomial.degree_pow_le
+
+theorem degree_pow_le_of_le {a : WithBot Nat} (b : Nat) (hp : degree p ≤ a) :
+    degree (p ^ b) ≤ b * a := by
+  apply (degree_pow_le _ _).trans
+  rw [nsmul_eq_mul]
+  induction b with
+    | zero => simp [degree_one_le]
+    | succ n hn =>
+      rw [Nat.cast_succ, add_mul, add_mul, one_mul, one_mul]
+      exact (add_le_add_left hp _).trans (add_le_add_right hn _)
 
 @[simp]
 theorem leadingCoeff_monomial (a : R) (n : ℕ) : leadingCoeff (monomial n a) = a := by
@@ -1034,6 +1066,10 @@ theorem natDegree_mul_le {p q : R[X]} : natDegree (p * q) ≤ natDegree p + natD
   refine' add_le_add _ _ <;> apply degree_le_natDegree
 #align polynomial.nat_degree_mul_le Polynomial.natDegree_mul_le
 
+theorem natDegree_mul_le_of_le (hp : natDegree p ≤ m) (hg : natDegree q ≤ n) :
+    natDegree (p * q) ≤ m + n :=
+natDegree_mul_le.trans <| add_le_add ‹_› ‹_›
+
 theorem natDegree_pow_le {p : R[X]} {n : ℕ} : (p ^ n).natDegree ≤ n * p.natDegree := by
   induction' n with i hi
   · simp
@@ -1041,6 +1077,10 @@ theorem natDegree_pow_le {p : R[X]} {n : ℕ} : (p ^ n).natDegree ≤ n * p.natD
     apply le_trans natDegree_mul_le
     exact add_le_add_left hi _
 #align polynomial.nat_degree_pow_le Polynomial.natDegree_pow_le
+
+theorem natDegree_pow_le_of_le (n : Nat) (hp : natDegree p ≤ m) :
+    natDegree (p ^ n) ≤ n * m :=
+natDegree_pow_le.trans (Nat.mul_le_mul rfl.le ‹_›)
 
 @[simp]
 theorem coeff_pow_mul_natDegree (p : R[X]) (n : ℕ) :
@@ -1074,6 +1114,8 @@ theorem natDegree_eq_zero_iff_degree_le_zero : p.natDegree = 0 ↔ p.degree ≤ 
   rw [← nonpos_iff_eq_zero, natDegree_le_iff_degree_le,
     Nat.cast_withBot, WithBot.coe_zero]
 #align polynomial.nat_degree_eq_zero_iff_degree_le_zero Polynomial.natDegree_eq_zero_iff_degree_le_zero
+
+theorem degree_zero_le : degree (0 : R[X]) ≤ 0 := natDegree_eq_zero_iff_degree_le_zero.mp rfl
 
 theorem degree_le_iff_coeff_zero (f : R[X]) (n : WithBot ℕ) :
     degree f ≤ n ↔ ∀ m : ℕ, n < m → coeff f m = 0 := by
@@ -1294,9 +1336,17 @@ theorem degree_sub_le (p q : R[X]) : degree (p - q) ≤ max (degree p) (degree q
   simpa only [degree_neg q] using degree_add_le p (-q)
 #align polynomial.degree_sub_le Polynomial.degree_sub_le
 
+theorem degree_sub_le_of_le {a b : WithBot Nat} (hp : degree p ≤ a) (hq : degree q ≤ b) :
+    degree (p - q) ≤ max a b :=
+(p.degree_sub_le q).trans <| max_le_max ‹_› ‹_›
+
 theorem natDegree_sub_le (p q : R[X]) : natDegree (p - q) ≤ max (natDegree p) (natDegree q) := by
   simpa only [← natDegree_neg q] using natDegree_add_le p (-q)
 #align polynomial.nat_degree_sub_le Polynomial.natDegree_sub_le
+
+theorem natDegree_sub_le_of_le (hp : natDegree p ≤ m) (hq : natDegree q ≤ n) :
+    natDegree (p - q) ≤ max m n :=
+(p.natDegree_sub_le q).trans <| max_le_max ‹_› ‹_›
 
 theorem degree_sub_lt (hd : degree p = degree q) (hp0 : p ≠ 0)
     (hlc : leadingCoeff p = leadingCoeff q) : degree (p - q) < degree p :=

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -24,6 +24,7 @@ import Mathlib.Tactic.ClearExcept
 import Mathlib.Tactic.Clear_
 import Mathlib.Tactic.Coe
 import Mathlib.Tactic.Common
+import Mathlib.Tactic.ComputeDegree
 import Mathlib.Tactic.Congr!
 import Mathlib.Tactic.Constructor
 import Mathlib.Tactic.Continuity
@@ -54,7 +55,6 @@ import Mathlib.Tactic.Group
 import Mathlib.Tactic.GuardGoalNums
 import Mathlib.Tactic.GuardHypNums
 import Mathlib.Tactic.Have
-import Mathlib.Tactic.HaveI
 import Mathlib.Tactic.HelpCmd
 import Mathlib.Tactic.HigherOrder
 import Mathlib.Tactic.InferParam

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -55,6 +55,7 @@ import Mathlib.Tactic.Group
 import Mathlib.Tactic.GuardGoalNums
 import Mathlib.Tactic.GuardHypNums
 import Mathlib.Tactic.Have
+import Mathlib.Tactic.HaveI
 import Mathlib.Tactic.HelpCmd
 import Mathlib.Tactic.HigherOrder
 import Mathlib.Tactic.InferParam

--- a/Mathlib/Tactic/ComputeDegree.lean
+++ b/Mathlib/Tactic/ComputeDegree.lean
@@ -7,88 +7,34 @@ Authors: Damiano Testa
 import Mathlib.Data.Polynomial.Degree.Definitions
 
 /-!
-###  Simple lemmas about `natDegree` and `degree`
+###  Simple lemmas about `natDegree`
 
-The lemmas in this section deduce inequalities of the form `natDegree f ≤ d` and `degree f ≤ d`,
-using inequalities of the same shape.
-This allows a recursive application of the `compute_degree_le` tactic on a goal,
-and on all the resulting subgoals.
+The lemmas in this section all have the form `natDegree <some form of cast> ≤ 0`.
+Their proofs are weakenings of the stronger lemmas `natDegree <same> = 0`.
+These are the lemmas called by `compute_degree_le` on (almost) all the leaves of its recursion.
 -/
 
 open Polynomial
 
 namespace Mathlib.Tactic.ComputeDegree
 
-section mylemmas
+section leaf_lemmas
 
 variable {R : Type _}
 
 section semiring
 variable [Semiring R]
 
-theorem add {a b : Nat} {f g : R[X]} (hf : natDegree f ≤ a) (hg : natDegree g ≤ b) :
-    natDegree (f + g) ≤ max a b :=
-(f.natDegree_add_le g).trans $ max_le_max ‹_› ‹_›
-
-theorem mul {a b : Nat} {f g : R[X]} (hf : natDegree f ≤ a) (hg : natDegree g ≤ b) :
-    natDegree (f * g) ≤ a + b :=
-natDegree_mul_le.trans $ add_le_add ‹_› ‹_›
-
-theorem pow {a : Nat} (b : Nat) {f : R[X]} (hf : natDegree f ≤ a) :
-    natDegree (f ^ b) ≤ b * a :=
-natDegree_pow_le.trans (Nat.mul_le_mul rfl.le ‹_›)
-
-theorem C_le (a : R) : natDegree (C a) ≤ 0 := (natDegree_C a).le
-theorem nat_cast_le (n : Nat) : natDegree (n : R[X]) ≤ 0 := (natDegree_nat_cast _).le
-theorem zero_le : natDegree (0 : R[X]) ≤ 0 := natDegree_zero.le
-theorem one_le : natDegree (1 : R[X]) ≤ 0 := natDegree_one.le
-
-theorem addD {a b : WithBot Nat} {f g : R[X]} (hf : degree f ≤ a) (hg : degree g ≤ b) :
-    degree (f + g) ≤ max a b :=
-(f.degree_add_le g).trans $ max_le_max ‹_› ‹_›
-
-theorem mulD {a b : WithBot Nat} {f g : R[X]} (hf : degree f ≤ a) (hg : degree g ≤ b) :
-    degree (f * g) ≤ a + b :=
-(f.degree_mul_le _).trans $ add_le_add ‹_› ‹_›
-
-theorem powD {a : WithBot Nat} (b : Nat) {f : R[X]} (hf : degree f ≤ a) :
-    degree (f ^ b) ≤ b * a := by
-  apply (degree_pow_le _ _).trans
-  rw [nsmul_eq_mul]
-  induction b with
-    | zero => simp [degree_one_le]
-    | succ n hn =>
-      rw [Nat.cast_succ, add_mul, add_mul, one_mul, one_mul]
-      exact (add_le_add_left hf _).trans (add_le_add_right hn _)
-
-theorem nat_cast_leD (n : Nat) : degree (n : R[X]) ≤ 0 := degree_le_of_natDegree_le (by simp)
-theorem zero_leD : degree (0 : R[X]) ≤ 0 := natDegree_eq_zero_iff_degree_le_zero.mp rfl
+theorem natDegree_C_le (a : R) : natDegree (C a) ≤ 0 := (natDegree_C a).le
+theorem natDegree_nat_cast_le (n : ℕ) : natDegree (n : R[X]) ≤ 0 := (natDegree_nat_cast _).le
+theorem natDegree_zero_le : natDegree (0 : R[X]) ≤ 0 := natDegree_zero.le
+theorem natDegree_one_le : natDegree (1 : R[X]) ≤ 0 := natDegree_one.le
 
 end semiring
 
-section ring
-variable [Ring R]
+variable [Ring R] in
+theorem natDegree_int_cast_le (n : ℤ) : natDegree (n : R[X]) ≤ 0 := (natDegree_int_cast _).le
 
-theorem neg {a : Nat} {f : R[X]} (hf : natDegree f ≤ a) : natDegree (- f) ≤ a :=
-(natDegree_neg f).le.trans ‹_›
-
-theorem sub {a b : Nat} {f g : R[X]} (hf : natDegree f ≤ a) (hg : natDegree g ≤ b) :
-    natDegree (f - g) ≤ max a b :=
-(f.natDegree_sub_le g).trans $ max_le_max ‹_› ‹_›
-
-theorem int_cast_le (n : Int) : natDegree (n : R[X]) ≤ 0 := (natDegree_int_cast _).le
-
-theorem negD {a : WithBot Nat} {f : R[X]} (hf : degree f ≤ a) : degree (- f) ≤ a :=
-(degree_neg f).le.trans ‹_›
-
-theorem subD {a b : WithBot Nat} {f g : R[X]} (hf : degree f ≤ a) (hg : degree g ≤ b) :
-    degree (f - g) ≤ max a b :=
-(f.degree_sub_le g).trans $ max_le_max ‹_› ‹_›
-
-theorem int_cast_leD (n : Int) : degree (n : R[X]) ≤ 0 := degree_le_of_natDegree_le (by simp)
-
-end ring
-
-end mylemmas
+end leaf_lemmas
 
 end Mathlib.Tactic.ComputeDegree

--- a/Mathlib/Tactic/ComputeDegree.lean
+++ b/Mathlib/Tactic/ComputeDegree.lean
@@ -1,0 +1,94 @@
+/-
+Copyright (c) 2023 Damiano Testa. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Damiano Testa
+-/
+
+import Mathlib.Data.Polynomial.Degree.Definitions
+
+/-!
+###  Simple lemmas about `natDegree` and `degree`
+
+The lemmas in this section deduce inequalities of the form `natDegree f ≤ d` and `degree f ≤ d`,
+using inequalities of the same shape.
+This allows a recursive application of the `compute_degree_le` tactic on a goal,
+and on all the resulting subgoals.
+-/
+
+open Polynomial
+
+namespace Mathlib.Tactic.ComputeDegree
+
+section mylemmas
+
+variable {R : Type _}
+
+section semiring
+variable [Semiring R]
+
+theorem add {a b : Nat} {f g : R[X]} (hf : natDegree f ≤ a) (hg : natDegree g ≤ b) :
+    natDegree (f + g) ≤ max a b :=
+(f.natDegree_add_le g).trans $ max_le_max ‹_› ‹_›
+
+theorem mul {a b : Nat} {f g : R[X]} (hf : natDegree f ≤ a) (hg : natDegree g ≤ b) :
+    natDegree (f * g) ≤ a + b :=
+natDegree_mul_le.trans $ add_le_add ‹_› ‹_›
+
+theorem pow {a : Nat} (b : Nat) {f : R[X]} (hf : natDegree f ≤ a) :
+    natDegree (f ^ b) ≤ b * a :=
+natDegree_pow_le.trans (Nat.mul_le_mul rfl.le ‹_›)
+
+theorem C_le (a : R) : natDegree (C a) ≤ 0 := (natDegree_C a).le
+theorem nat_cast_le (n : Nat) : natDegree (n : R[X]) ≤ 0 := (natDegree_nat_cast _).le
+theorem zero_le : natDegree (0 : R[X]) ≤ 0 := natDegree_zero.le
+theorem one_le : natDegree (1 : R[X]) ≤ 0 := natDegree_one.le
+
+theorem addD {a b : WithBot Nat} {f g : R[X]} (hf : degree f ≤ a) (hg : degree g ≤ b) :
+    degree (f + g) ≤ max a b :=
+(f.degree_add_le g).trans $ max_le_max ‹_› ‹_›
+
+theorem mulD {a b : WithBot Nat} {f g : R[X]} (hf : degree f ≤ a) (hg : degree g ≤ b) :
+    degree (f * g) ≤ a + b :=
+(f.degree_mul_le _).trans $ add_le_add ‹_› ‹_›
+
+theorem powD {a : WithBot Nat} (b : Nat) {f : R[X]} (hf : degree f ≤ a) :
+    degree (f ^ b) ≤ b * a := by
+  apply (degree_pow_le _ _).trans
+  rw [nsmul_eq_mul]
+  induction b with
+    | zero => simp [degree_one_le]
+    | succ n hn =>
+      rw [Nat.cast_succ, add_mul, add_mul, one_mul, one_mul]
+      exact (add_le_add_left hf _).trans (add_le_add_right hn _)
+
+theorem nat_cast_leD (n : Nat) : degree (n : R[X]) ≤ 0 := degree_le_of_natDegree_le (by simp)
+theorem zero_leD : degree (0 : R[X]) ≤ 0 := natDegree_eq_zero_iff_degree_le_zero.mp rfl
+
+end semiring
+
+section ring
+variable [Ring R]
+
+theorem neg {a : Nat} {f : R[X]} (hf : natDegree f ≤ a) : natDegree (- f) ≤ a :=
+(natDegree_neg f).le.trans ‹_›
+
+theorem sub {a b : Nat} {f g : R[X]} (hf : natDegree f ≤ a) (hg : natDegree g ≤ b) :
+    natDegree (f - g) ≤ max a b :=
+(f.natDegree_sub_le g).trans $ max_le_max ‹_› ‹_›
+
+theorem int_cast_le (n : Int) : natDegree (n : R[X]) ≤ 0 := (natDegree_int_cast _).le
+
+theorem negD {a : WithBot Nat} {f : R[X]} (hf : degree f ≤ a) : degree (- f) ≤ a :=
+(degree_neg f).le.trans ‹_›
+
+theorem subD {a b : WithBot Nat} {f g : R[X]} (hf : degree f ≤ a) (hg : degree g ≤ b) :
+    degree (f - g) ≤ max a b :=
+(f.degree_sub_le g).trans $ max_le_max ‹_› ‹_›
+
+theorem int_cast_leD (n : Int) : degree (n : R[X]) ≤ 0 := degree_le_of_natDegree_le (by simp)
+
+end ring
+
+end mylemmas
+
+end Mathlib.Tactic.ComputeDegree


### PR DESCRIPTION
This PR is a prequel to #5882: it simply adds the helper lemmas about polynomials that the tactic uses.

[Zulip discussion ](https://leanprover.zulipchat.com/#narrow/stream/144837-PR-reviews/topic/.235882.20.60compute_degree_le.60)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
