### PR TITLE
[Merged by Bors] - feat: says tactic combinator

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3021,6 +3021,7 @@ import Mathlib.Tactic.Ring.Basic
 import Mathlib.Tactic.Ring.RingNF
 import Mathlib.Tactic.RunCmd
 import Mathlib.Tactic.Sat.FromLRAT
+import Mathlib.Tactic.Says
 import Mathlib.Tactic.ScopedNS
 import Mathlib.Tactic.Set
 import Mathlib.Tactic.SimpIntro

--- a/Mathlib/CategoryTheory/Limits/Fubini.lean
+++ b/Mathlib/CategoryTheory/Limits/Fubini.lean
@@ -94,8 +94,8 @@ def coneOfConeUncurry {D : DiagramOfCones F} (Q : ∀ j, IsLimit (D.obj j))
                   dsimp; simp only [Category.id_comp]
                   have := @NatTrans.naturality _ _ _ _ _ _ c.π (j, k) (j, k') (𝟙 j, f)
                   dsimp at this
-                  simp only [Category.id_comp, CategoryTheory.Functor.map_id, NatTrans.id_app]
-                    at this
+                  simp? at this says
+                    simp only [Category.id_comp, Functor.map_id, NatTrans.id_app] at this
                   exact this } }
       naturality := fun j j' f =>
         (Q j').hom_ext

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -127,6 +127,7 @@ import Mathlib.Tactic.Ring.Basic
 import Mathlib.Tactic.Ring.RingNF
 import Mathlib.Tactic.RunCmd
 import Mathlib.Tactic.Sat.FromLRAT
+import Mathlib.Tactic.Says
 import Mathlib.Tactic.ScopedNS
 import Mathlib.Tactic.Set
 import Mathlib.Tactic.SimpIntro

--- a/Mathlib/Tactic/Common.lean
+++ b/Mathlib/Tactic/Common.lean
@@ -79,6 +79,7 @@ import Mathlib.Tactic.Replace
 import Mathlib.Tactic.Rewrites
 import Mathlib.Tactic.RSuffices
 import Mathlib.Tactic.RunCmd
+import Mathlib.Tactic.Says
 import Mathlib.Tactic.ScopedNS
 import Mathlib.Tactic.Set
 import Mathlib.Tactic.SimpIntro

--- a/Mathlib/Tactic/Says.lean
+++ b/Mathlib/Tactic/Says.lean
@@ -1,0 +1,63 @@
+/-
+Copyright (c) 2023 Kim Liesinger. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Liesinger
+-/
+import Lean.Elab.Command
+import Std.Tactic.TryThis
+import Std.Tactic.ShowTerm
+import Std.Data.String.Basic
+import Std.Tactic.GuardMsgs
+import Mathlib.Util.WhatsNew
+
+open Lean Elab Tactic
+open Std.Tactic.TryThis
+
+namespace Mathlib.Tactic.Says
+
+/-- Run `evalTactic`, capturing any new messages.-/
+def evalTacticCapturingMessages (tac : TSyntax `tactic) : TacticM MessageLog := do
+  let initMsgs ← modifyGetThe Core.State fun st => (st.messages, { st with messages := {} })
+  evalTactic tac
+  let msgs := (← getThe Core.State).messages
+  modifyThe Core.State fun st => { st with messages := initMsgs }
+  return msgs
+
+open Parser Tactic
+
+/-- This is a slight modification of `Parser.runParserCategory`. -/
+def parseAsTacticSeq (env : Environment) (input : String) (fileName := "<input>") :
+    Except String (TSyntax ``tacticSeq) :=
+  let p := andthenFn whitespace Tactic.tacticSeq.fn
+  let ictx := mkInputContext input fileName
+  let s := p.run ictx { env, options := {} } (getTokenTable env) (mkParserState input)
+  if s.hasError then
+    Except.error (s.toErrorMsg ictx)
+  else if input.atEnd s.pos then
+    Except.ok ⟨s.stxStack.back⟩
+  else
+    Except.error ((s.mkError "end of input").toErrorMsg ictx)
+
+syntax (name := says) tactic " says" (tacticSeq)? : tactic
+
+elab_rules : tactic
+  | `(tactic| $tac:tactic says%$tk $[$result:tacticSeq]?) => do
+  match result with
+  | none =>
+    let msgs ← evalTacticCapturingMessages tac
+    let S ← match msgs.toList with
+    | [] => throwError m!"Tactic `{tac}` did not produce any message."
+    | [S] => S.toString
+    | _ => throwError m!"Tactic `{tac}` produced multiple messages."
+    let S ← match S.dropPrefix? "Try this: " with
+    | none => throwError m!"Tactic output did not begin with 'Try this:': {S}"
+    | some S => pure S.toString
+    let stx ← match parseAsTacticSeq (← getEnv) S with
+    | .ok stx => pure stx
+    | .error msg => throwError m!"Failed to parse tactic output: {S}\n{msg}"
+    let stx : TSyntax ``tacticSeq := ⟨stx⟩
+    addSuggestion tk (← `(tactic| $tac says $stx)) (origSpan? := (← `(tactic| $tac says)))
+  | some result =>
+    evalTactic result
+
+initialize Std.Linter.UnreachableTactic.addIgnoreTacticKind `Mathlib.Tactic.Says.says

--- a/Mathlib/Tactic/Says.lean
+++ b/Mathlib/Tactic/Says.lean
@@ -31,14 +31,6 @@ register_option says.verify : Bool :=
     descr := "For every appearance of the `X says Y` combinator," ++
       " re-verify that running `X` produces `Try this: Y`." }
 
-/-- Run `evalTactic`, capturing any new messages.-/
-def evalTacticCapturingMessages (tac : TSyntax `tactic) : TacticM MessageLog := do
-  let initMsgs ← modifyGetThe Core.State fun st => (st.messages, { st with messages := {} })
-  evalTactic tac
-  let msgs := (← getThe Core.State).messages
-  modifyThe Core.State fun st => { st with messages := initMsgs }
-  return msgs
-
 open Parser Tactic
 
 /-- This is a slight modification of `Parser.runParserCategory`. -/
@@ -54,6 +46,46 @@ def parseAsTacticSeq (env : Environment) (input : String) (fileName := "<input>"
   else
     Except.error ((s.mkError "end of input").toErrorMsg ictx)
 
+/--
+Run `evalTactic`, capturing any new messages.
+The optional `only` argument allows selecting which messages should be captured,
+or left in the message log.
+-/
+def evalTacticCapturingMessages (tac : TSyntax `tactic) (only : Message → Bool := fun _ => true) :
+    TacticM (List Message) := do
+  let mut msgs ← modifyGetThe Core.State fun st => (st.messages, { st with messages := {} })
+  try
+    evalTactic tac
+    let (capture, leave) := (← getThe Core.State).messages.msgs.toList.partition only
+    msgs := ⟨leave.foldl (fun m => m.push) msgs.msgs⟩
+    return capture
+  catch e =>
+    msgs := msgs ++ (← getThe Core.State).messages
+    throw e
+  finally
+    modifyThe Core.State fun st => { st with messages := msgs }
+
+/--
+Run `evalTactic`, capturing any new info messages.
+-/
+def evalTacticCapturingInfo (tac : TSyntax `tactic) : TacticM (List Message) :=
+  evalTacticCapturingMessages tac fun m => match m.severity with | .information => true | _ => false
+
+/--
+Run `evalTactic`, capturing a "Try this:" message and converting it back to syntax.
+-/
+def evalTacticCapturingTryThis (tac : TSyntax `tactic) : TacticM (TSyntax ``tacticSeq) := do
+  let msg ← match ← evalTacticCapturingInfo tac with
+  | [] => throwError m!"Tactic `{tac}` did not produce any messages."
+  | [msg] => msg.toString
+  | _ => throwError m!"Tactic `{tac}` produced multiple messages."
+  let tryThis ← match msg.dropPrefix? "Try this: " with
+  | none => throwError m!"Tactic output did not begin with 'Try this:': {msg}"
+  | some S => pure S.toString
+  match parseAsTacticSeq (← getEnv) tryThis with
+  | .ok stx => return stx
+  | .error err => throwError m!"Failed to parse tactic output: {tryThis}\n{err}"
+
 syntax (name := says) tactic " says" (tacticSeq)? : tactic
 
 elab_rules : tactic
@@ -62,25 +94,14 @@ elab_rules : tactic
   match result, verify with
   | some _, true
   | none, _ =>
-    let msgs ← evalTacticCapturingMessages tac
-    let S ← match msgs.toList with
-    | [] => throwError m!"Tactic `{tac}` did not produce any message."
-    | [S] => S.toString
-    | _ => throwError m!"Tactic `{tac}` produced multiple messages."
-    let S ← match S.dropPrefix? "Try this: " with
-    | none => throwError m!"Tactic output did not begin with 'Try this:': {S}"
-    | some S => pure S.toString
-    let stx ← match parseAsTacticSeq (← getEnv) S with
-    | .ok stx => pure stx
-    | .error msg => throwError m!"Failed to parse tactic output: {S}\n{msg}"
+    let stx ← evalTacticCapturingTryThis tac
     match result with
     | some r =>
         let stx' := (← Lean.PrettyPrinter.ppTactic ⟨stx⟩).pretty
         let r' := (← Lean.PrettyPrinter.ppTactic ⟨r⟩).pretty
         if stx' != r' then
-          throwError m!"Tactic `{tac}` produced `{stx'}`, but was expecting it to produce `{r'}`!"
+          throwError m!"Tactic `{tac}` produced `{stx'}`,\nbut was expecting it to produce `{r'}`!"
     | none =>
-    let stx : TSyntax ``tacticSeq := ⟨stx⟩
     addSuggestion tk (← `(tactic| $tac says $stx)) (origSpan? := (← `(tactic| $tac says)))
   | some result, false =>
     evalTactic result

--- a/Mathlib/Tactic/Says.lean
+++ b/Mathlib/Tactic/Says.lean
@@ -3,12 +3,22 @@ Copyright (c) 2023 Kim Liesinger. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Liesinger
 -/
-import Lean.Elab.Command
-import Std.Tactic.TryThis
-import Std.Tactic.ShowTerm
 import Std.Data.String.Basic
 import Std.Tactic.GuardMsgs
-import Mathlib.Util.WhatsNew
+
+/-!
+# The `says` tactic combinator.
+
+If you write `X says`, where `X` is a tactic that produces a "Try this: Y" message,
+then you will get a message "Try this: X says Y".
+Once you've clicked to replace `X says` with `X says Y`,
+afterwards `X says Y` will only run `Y`.
+
+The typical usage case is:
+```
+simp? [X] says simp only [X, Y, Z]
+```
+-/
 
 open Lean Elab Tactic
 open Std.Tactic.TryThis

--- a/Mathlib/Tactic/Says.lean
+++ b/Mathlib/Tactic/Says.lean
@@ -86,7 +86,7 @@ def evalTacticCapturingTryThis (tac : TSyntax `tactic) : TacticM (TSyntax ``tact
   | .ok stx => return stx
   | .error err => throwError m!"Failed to parse tactic output: {tryThis}\n{err}"
 
-syntax (name := says) tactic " says" (tacticSeq)? : tactic
+syntax (name := says) tactic " says" (colGt tacticSeq)? : tactic
 
 elab_rules : tactic
   | `(tactic| $tac:tactic says%$tk $[$result:tacticSeq]?) => do

--- a/test/says.lean
+++ b/test/says.lean
@@ -23,7 +23,7 @@ example (x y : List α) : (x ++ y).length = x.length + y.length := by
   simp? says simp only [List.length_append]
 
 /--
-error: Tactic `have := 0` did not produce any message.
+error: Tactic `have := 0` did not produce any messages.
 -/
 #guard_msgs in
 example : true := by
@@ -41,10 +41,13 @@ example (x y : List α) : (x ++ y).length = x.length + y.length := by
   simp? says simp only []
   simp
 
+-- Now that with `says.verify` `says` will reverify that the left-hand-side constructs
+-- the right-hand-side.
 set_option says.verify true
 
 /--
-error: Tactic `simp?` produced `simp only [List.length_append]`, but was expecting it to produce `simp only []`!
+error: Tactic `simp?` produced `simp only [List.length_append]`,
+but was expecting it to produce `simp only []`!
 -/
 #guard_msgs in
 example (x y : List α) : (x ++ y).length = x.length + y.length := by

--- a/test/says.lean
+++ b/test/says.lean
@@ -43,8 +43,7 @@ example (x y : List α) : (x ++ y).length = x.length + y.length := by
 
 -- Now that with `says.verify` `says` will reverify that the left-hand-side constructs
 -- the right-hand-side.
-set_option says.verify true
-
+set_option says.verify true in
 /--
 error: Tactic `simp?` produced `simp only [List.length_append]`,
 but was expecting it to produce `simp only []`!
@@ -52,3 +51,26 @@ but was expecting it to produce `simp only []`!
 #guard_msgs in
 example (x y : List α) : (x ++ y).length = x.length + y.length := by
   simp? says simp only []
+
+/- Now we check that `says` does not consume following tactics unless they are indented. -/
+set_option linter.unreachableTactic false
+/--
+error: Tactic `simp` did not produce any messages.
+-/
+#guard_msgs in
+example : True := by
+  simp says
+  trivial
+
+example : True := by
+  simp says
+    trivial
+
+set_option says.verify true in
+/--
+error: Tactic `simp` did not produce any messages.
+-/
+#guard_msgs in
+example : True := by
+  simp says
+    trivial

--- a/test/says.lean
+++ b/test/says.lean
@@ -35,3 +35,17 @@ error: Tactic output did not begin with 'Try this:': hi!
 #guard_msgs in
 example : true := by
   (run_tac do Lean.logInfo "hi!") says
+
+-- Check that with the default settings `says` does not reverify the right-hand-side.
+example (x y : List α) : (x ++ y).length = x.length + y.length := by
+  simp? says simp only []
+  simp
+
+set_option says.verify true
+
+/--
+error: Tactic `simp?` produced `simp only [List.length_append]`, but was expecting it to produce `simp only []`!
+-/
+#guard_msgs in
+example (x y : List α) : (x ++ y).length = x.length + y.length := by
+  simp? says simp only []

--- a/test/says.lean
+++ b/test/says.lean
@@ -1,0 +1,37 @@
+import Mathlib.Tactic.Says
+import Mathlib.Tactic.RunCmd
+
+/--
+info: Try this: (show_term exact 37) says exact 37
+-/
+#guard_msgs in
+example : Nat := by
+  (show_term exact 37) says
+
+-- Note that this implicitly tests that we have turned off `linter.unreachableTactic`.
+example : Nat := by
+  (show_term exact 37) says exact 37
+
+/--
+info: Try this: simp? says simp only [List.length_append]
+-/
+#guard_msgs in
+example (x y : List α) : (x ++ y).length = x.length + y.length := by
+  simp? says
+
+example (x y : List α) : (x ++ y).length = x.length + y.length := by
+  simp? says simp only [List.length_append]
+
+/--
+error: Tactic `have := 0` did not produce any message.
+-/
+#guard_msgs in
+example : true := by
+  have := 0 says
+
+/--
+error: Tactic output did not begin with 'Try this:': hi!
+-/
+#guard_msgs in
+example : true := by
+  (run_tac do Lean.logInfo "hi!") says

--- a/test/says.lean
+++ b/test/says.lean
@@ -36,12 +36,13 @@ error: Tactic output did not begin with 'Try this:': hi!
 example : true := by
   (run_tac do Lean.logInfo "hi!") says
 
--- Check that with the default settings `says` does not reverify the right-hand-side.
+-- Check that `says` does not reverify the right-hand-side.
+set_option says.no_verify_in_CI true in
 example (x y : List α) : (x ++ y).length = x.length + y.length := by
   simp? says simp only []
   simp
 
--- Now that with `says.verify` `says` will reverify that the left-hand-side constructs
+-- Check that with `says.verify` `says` will reverify that the left-hand-side constructs
 -- the right-hand-side.
 set_option says.verify true in
 /--
@@ -52,8 +53,8 @@ but was expecting it to produce `simp only []`!
 example (x y : List α) : (x ++ y).length = x.length + y.length := by
   simp? says simp only []
 
-/- Now we check that `says` does not consume following tactics unless they are indented. -/
 set_option linter.unreachableTactic false
+-- Now we check that `says` does not consume following tactics unless they are indented.
 /--
 error: Tactic `simp` did not produce any messages.
 -/
@@ -62,6 +63,7 @@ example : True := by
   simp says
   trivial
 
+set_option says.no_verify_in_CI true in
 example : True := by
   simp says
     trivial
@@ -74,3 +76,10 @@ error: Tactic `simp` did not produce any messages.
 example : True := by
   simp says
     trivial
+
+-- Check that if the CI environment variable is set, we reverify all `says` statements.
+example : True := by
+  fail_if_success
+    run_tac do guard (← IO.getEnv "CI").isSome
+    simp says trivial
+  trivial


### PR DESCRIPTION
This is a primitive implementation of the `says` combinator discussed at today's porting meeting.

If you write `X says`, where `X` is a tactic that produces a "Try this: Y" message, then you will get a message "Try this: X says Y". Once you've clicked to replace `X says` with `X says Y`, after then `X says Y` will only run `Y`.

I think this is already potentially useful.

Possible additions:
* a CI mode that re-verifies that `X` really does still say `Y`. (Edit: DONE)
* If `X` doesn't say anything, perhaps implicitly wrap it with `show_term`?
* Add an extra `suggest` flag to the `TacticM` state, so we can instruct tactics to print "Try this:" suggestions without adding `?` directly.

Very happy if anyone wants to hack on this / replace with a better implementation, etc.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
