### PR TITLE
[Merged by Bors] - fix: coercions in ZMod.coe_add_eq_ite

### DIFF
--- a/Mathlib/Data/ZMod/Basic.lean
+++ b/Mathlib/Data/ZMod/Basic.lean
@@ -271,7 +271,7 @@ theorem coe_add_eq_ite {n : ℕ} (a b : ZMod n) :
   · simp; rfl
   change Fin (n + 1) at a b
   change ((((a + b) : Fin (n + 1)) : ℕ) : ℤ) = if ((n + 1 : ℕ) : ℤ) ≤ (a : ℕ) + b then _ else _
-  simp only [Fin.val_add_eq_ite, Int.ofNat_succ, Int.ofNat_le]--, ← Int.ofNat_add, ← Int.ofNat_succ, Int.ofNat_le]
+  simp only [Fin.val_add_eq_ite, Int.ofNat_succ, Int.ofNat_le]
   norm_cast
   split_ifs with h
   · rw [Nat.cast_sub h]

--- a/Mathlib/Data/ZMod/Basic.lean
+++ b/Mathlib/Data/ZMod/Basic.lean
@@ -266,14 +266,16 @@ theorem int_cast_cast (i : ZMod n) : ((i : ℤ) : R) = i :=
 #align zmod.int_cast_cast ZMod.int_cast_cast
 
 theorem coe_add_eq_ite {n : ℕ} (a b : ZMod n) :
-    (↑(a + b) : ℤ) = if (n : ℤ) ≤ a + b then a + b - n else a + b := by
-  cases n
-  · simp
-  simp only [Fin.val_add_eq_ite, ← Int.ofNat_add, ← Int.ofNat_succ, Int.ofNat_le]
+    (↑(a + b) : ℤ) = if (n : ℤ) ≤ a + b then (a : ℤ) + b - n else a + b := by
+  cases' n with n
+  · simp; rfl
+  change Fin (n + 1) at a b
+  change ((((a + b) : Fin (n + 1)) : ℕ) : ℤ) = if ((n + 1 : ℕ) : ℤ) ≤ (a : ℕ) + b then _ else _
+  simp only [Fin.val_add_eq_ite, Int.ofNat_succ, Int.ofNat_le]--, ← Int.ofNat_add, ← Int.ofNat_succ, Int.ofNat_le]
+  norm_cast
   split_ifs with h
-  · norm_cast
+  · rw [Nat.cast_sub h]
     congr
-    simp
   · rfl
 #align zmod.coe_add_eq_ite ZMod.coe_add_eq_ite
 


### PR DESCRIPTION
The change in behaviour of coercions in mathlib4 meant that this lemma was translated incorrectly (into a much simpler statement).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

The fact that `simp` succeeds when it does nothing means that the mistranslation wasn't noticed because the proof still worked. The Lean 3 proof seemed to abuse defeq in a way which doesn't seem to work in lean 4. Details [here](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/ZMod.2Ecoe_add_eq_ite.20changed/near/376336398).