### PR TITLE
[Merged by Bors] - docs: fix links in conv guides and other typos

### DIFF
--- a/docs/Conv/Guide.lean
+++ b/docs/Conv/Guide.lean
@@ -185,7 +185,7 @@ in Lean 4 core.
   than the congruence lemma that the `congr` tactic might generate. (Mathlib)
 
 * `slice i j` (for category theory) reassociates a composition of morphisms to focus on
-  the composition of morphisms `i` through `j`.
+  the composition of morphisms `i` through `j`. (Mathlib)
 
 ### Reductions
 

--- a/docs/Conv/Guide.lean
+++ b/docs/Conv/Guide.lean
@@ -8,7 +8,7 @@ Authors: Kyle Miller
 
 This is a curated guide to point you toward how `conv` mode works and what tactics are available.
 It is not meant to be comprehesive, but rather a "cheat sheet." See also the
-[`conv` introduction](https://leanprover-community.github.io/mathlib4_docs/Docs/Conv/Introduction.html).
+[`conv` introduction](https://leanprover-community.github.io/mathlib4_docs/docs/Conv/Introduction.html).
 
 ## Syntax
 
@@ -143,7 +143,7 @@ in Lean 4 core.
   * `enter [i]` (where `i` is a natural number) is equivalent to `arg i`.
   * `enter [@i]` is equivalent to `arg @i`.
   * `enter [x]` (where `x` is an identifier) is equivalent to `ext x`.
-  * `enter [a,b,c,...]` is `enter [a]; enter[b]; enter[c]; enter [...]`.
+  * `enter [a,b,c,...]` is `enter [a]; enter [b]; enter [c]; enter [...]`.
 
 * `pattern` is for navigating into subexpressions that match a given pattern
   * `pattern pat` traverses to the first subterm of the target that matches `pat`.

--- a/docs/Conv/Introduction.lean
+++ b/docs/Conv/Introduction.lean
@@ -83,7 +83,7 @@ Here are a more ways to navigate expressions:
 * `arg @i` navigates to the `i`th argument, counting both explicit and implicit arguments.
 * `enter [...]`, where the `...` consists of a list of arguments appropriate for `arg` or `ext`,
   and then runs the corresponding `arg` and `ext` commands.
-  For example, `enter [1,@2,x,3]` is the same as `arg 1, arg @2, ext x, arg 3`.
+  For example, `enter [1,@2,x,3]` is the same as `arg 1; arg @2; ext x; arg 3`.
 
 ## Pattern matching
 
@@ -158,7 +158,7 @@ example (a b : ℕ) :
 Besides rewriting using `rw`, one can use `simp`, `dsimp`, `change`, `ring`, `norm_num`,
 `push_neg`, `unfold`, among others.
 
-See the [`conv` guide](https://leanprover-community.github.io/mathlib4_docs/Docs/Conv/Guide.html)
+See the [`conv` guide](https://leanprover-community.github.io/mathlib4_docs/docs/Conv/Guide.html)
 for a more in-depth overview.
 
 -/


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
