### PR TITLE
[Merged by Bors] - feat: make `lake exe cache get!` unpack everything

### DIFF
--- a/Cache/IO.lean
+++ b/Cache/IO.lean
@@ -61,7 +61,7 @@ def CURLBIN :=
 
 /-- leantar version at https://github.com/digama0/leangz -/
 def LEANTARVERSION :=
-  "0.1.3"
+  "0.1.4"
 
 def LEANTARBIN :=
   -- change file name if we ever need a more recent version to trigger re-download
@@ -274,15 +274,15 @@ def isPathFromMathlib (path : FilePath) : Bool :=
   | _ => false
 
 /-- Decompresses build files into their respective folders -/
-def unpackCache (hashMap : HashMap) : IO Unit := do
+def unpackCache (hashMap : HashMap) (force : Bool) : IO Unit := do
   let hashMap := hashMap.filter (← getLocalCacheSet) true
   let size := hashMap.size
   if size > 0 then
     let now ← IO.monoMsNow
     IO.println s!"Decompressing {size} file(s)"
     let isMathlibRoot ← isMathlibRoot
-    let child ← IO.Process.spawn
-      { cmd := ← getLeanTar, args := #["-x", "-j", "-"], stdin := .piped }
+    let args := (if force then #["-f"] else #[]) ++ #["-x", "-j", "-"]
+    let child ← IO.Process.spawn { cmd := ← getLeanTar, args, stdin := .piped }
     let (stdin, child) ← child.takeStdin
     let config : Array Lean.Json := hashMap.fold (init := #[]) fun config path hash =>
       let pathStr := s!"{CACHEDIR / hash.asLTar}"

--- a/Cache/Main.lean
+++ b/Cache/Main.lean
@@ -17,6 +17,7 @@ Commands:
   pack         Compress non-compressed build files into the local cache
   pack!        Compress build files into the local cache (no skipping)
   unpack       Decompress linked already downloaded files
+  unpack!      Decompress linked already downloaded files (no skipping)
   clean        Delete non-linked files
   clean!       Delete everything on the local cache
 
@@ -63,15 +64,19 @@ def main (args : List String) : IO Unit := do
   let goodCurl ← pure !curlArgs.contains (args.headD "") <||> validateCurl
   if leanTarArgs.contains (args.headD "") then validateLeanTar
   match args with
-  | ["get"] => getFiles hashMap false goodCurl true
-  | ["get!"] => getFiles hashMap true goodCurl true
-  | ["get-"] => getFiles hashMap false goodCurl false
-  | "get"  :: args => getFiles (← hashMemo.filterByFilePaths (toPaths args)) false goodCurl true
-  | "get!" :: args => getFiles (← hashMemo.filterByFilePaths (toPaths args)) true goodCurl true
-  | "get-"  :: args => getFiles (← hashMemo.filterByFilePaths (toPaths args)) false goodCurl false
+  | ["get"] => getFiles hashMap false false goodCurl true
+  | ["get!"] => getFiles hashMap true true goodCurl true
+  | ["get-"] => getFiles hashMap false false goodCurl false
+  | "get"  :: args =>
+    getFiles (← hashMemo.filterByFilePaths (toPaths args)) false false goodCurl true
+  | "get!" :: args =>
+    getFiles (← hashMemo.filterByFilePaths (toPaths args)) true true goodCurl true
+  | "get-" :: args =>
+    getFiles (← hashMemo.filterByFilePaths (toPaths args)) false false goodCurl false
   | ["pack"] => discard $ packCache hashMap false
   | ["pack!"] => discard $ packCache hashMap true
-  | ["unpack"] => unpackCache hashMap
+  | ["unpack"] => unpackCache hashMap false
+  | ["unpack!"] => unpackCache hashMap true
   | ["clean"] =>
     cleanCache $ hashMap.fold (fun acc _ hash => acc.insert $ CACHEDIR / hash.asLTar) .empty
   | ["clean!"] => cleanCache

--- a/Cache/Requests.lean
+++ b/Cache/Requests.lean
@@ -118,11 +118,11 @@ def downloadFiles (hashMap : IO.HashMap) (forceDownload : Bool) (parallel : Bool
   else IO.println "No files to download"
 
 /-- Downloads missing files, and unpacks files. -/
-def getFiles (hashMap : IO.HashMap) (forceDownload : Bool) (parallel : Bool) (decompress : Bool) :
+def getFiles (hashMap : IO.HashMap) (forceDownload forceUnpack parallel decompress : Bool) :
     IO Unit := do
   downloadFiles hashMap forceDownload parallel
   if decompress then
-    IO.unpackCache hashMap
+    IO.unpackCache hashMap forceUnpack
 
 end Get
 


### PR DESCRIPTION
Previously `lake exe cache get!` would download all files from the server, which fixes corrupted files in the `.cache` directory, but it would still skip files up to date according to the `.trace` files, so corrupted files in the `build` directory would not be fixed. (Before `leantar` all files would be unpacked regardless.) Now all files are unpacked when using `get!`. (This could be a separate option, but `get!!` is probably too confusing.)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
