### PR TITLE
feat: a minimalistic port of `compute_degree_le`

### DIFF
--- a/Mathlib/Tactic/ComputeDegree.lean
+++ b/Mathlib/Tactic/ComputeDegree.lean
@@ -7,11 +7,31 @@ Authors: Damiano Testa
 import Mathlib.Data.Polynomial.Degree.Definitions
 
 /-!
-###  Simple lemmas about `natDegree`
 
-The lemmas in this section all have the form `natDegree <some form of cast> ≤ 0`.
-Their proofs are weakenings of the stronger lemmas `natDegree <same> = 0`.
-These are the lemmas called by `compute_degree_le` on (almost) all the leaves of its recursion.
+# `compute_degree_le` a tactic for computing degrees of polynomials
+
+This file defines the tactic `compute_degree_le`.
+
+Using `compute_degree_le` when the goal is of the form `natDegree f ≤ d` or `degree f ≤ d`,
+tries to solve the goal.
+It leaves a side-goal of the form `d' ≤ d`, in case it is not entirely successful.
+
+See the doc-string for more details.
+
+##  Future work
+
+* Deal with equalities, instead of inequalities (i.e. implement `compute_degree`).
+* Add support for proving goals of the from `natDegree f ≠ 0` and `degree f ≠ 0`.
+* Make sure that `degree` and `natDegree` are equally supported.
+
+##  Implementation details
+
+We start with a goal of the form `natDegree f ≤ d` or `degree f ≤ d`.
+Recurse into `f` breaking apart sums, products and powers.  Take care of numerals,
+`C a, X (^ n), monomial a n` separately.
+
+The recursion into `f` first converts `f` to a term of Type `DegInfo`.
+This conversion preserves enough information of `f` to guide `compute_degree_le` into a proof.
 -/
 
 open Polynomial
@@ -19,6 +39,13 @@ open Polynomial
 namespace Mathlib.Tactic.ComputeDegree
 
 section leaf_lemmas
+/-!
+###  Simple lemmas about `natDegree`
+
+The lemmas in this section all have the form `natDegree <some form of cast> ≤ 0`.
+Their proofs are weakenings of the stronger lemmas `natDegree <same> = 0`.
+These are the lemmas called by `compute_degree_le` on (almost) all the leaves of its recursion.
+-/
 
 variable {R : Type _}
 
@@ -36,5 +63,116 @@ variable [Ring R] in
 theorem natDegree_int_cast_le (n : ℤ) : natDegree (n : R[X]) ≤ 0 := (natDegree_int_cast _).le
 
 end leaf_lemmas
+
+section Tactic
+
+open Lean Elab Tactic Meta
+
+/-- `isDegLE e` checks whether `e` is an `Expr`ession representing an inequality whose LHS is
+the `natDegree/degree` of a polynomial with coefficients in a semiring `R`.
+If `e` represents
+*  `natDegree f ≤ d`, then it returns `(true,  f)`;
+*  `degree f ≤ d`,    then it returns `(false, f)`;
+*  anything else, then it throws an error.
+-/
+def isDegLE (e : Expr) : CoreM (Bool × Expr) := do
+  match e.consumeMData.getAppFnArgs with
+    -- check that the target is an inequality `≤`...
+    | (``LE.le, #[_, _, lhs, _rhs]) => match lhs.getAppFnArgs with
+      -- and that the LHS is `natDegree ...` or `degree ...`
+      | (``degree, #[_R, _iSR, pol])    => return (false, pol)
+      | (``natDegree, #[_R, _iSR, pol]) => return (true, pol)
+      | (na, _) => throwError (m!"Expected an inequality of the form\n\n" ++
+        f!"  'f.natDegree ≤ d'  or  'f.degree ≤ d',\n\ninstead, {na} appears on the LHS")
+    | (na, _)  => throwError m!"Expected an inequality instead of '{na}', '{e}'"
+
+/-- `computeDegreeLECore pol mv π` takes as input
+* an `Expr`ession `pol` representing a polynomial;
+* an `MVarId` `mv`;
+* a function `π : Name × Name → Name`, typically
+* * `pi = Prod.fst` if the goal is `natDegree f ≤ d`,
+* * `pi = Prod.snd` if the goal is `degree f ≤ d`.
+
+It recurses into `pol` matching each step with the appropriate pair of lemmas:
+the first if the goal involves `natDegree`, the second if it involves `degree`.
+It applies the lemma at each stage and continues until it reaches a "leaf":
+either the final goal asks for the degree of a "cast" of some sort, of `X`, of `monomial n r`
+or of an `fvar`.
+In each case it closes the goal, assuming that the goal is `natDegree f ≤ natDegree f` or
+`degree f ≤ degree f`, in the case of an `fvar`.
+-/
+partial
+def computeDegreeLECore (pol : Expr) (mv : MVarId) (π : Name × Name → Name) :
+    MetaM (List (Expr × MVarId)) := do
+let (fg, names) := match pol.numeral? with
+-- can I avoid the tri-splitting `n = 0`, `n = 1`, and generic `n`?
+| some 0 => ([], (``natDegree_zero_le, ``degree_zero_le))
+| some 1 => ([], (``natDegree_one_le, ``degree_one_le))
+| some _ => ([], (``natDegree_nat_cast_le, ``degree_nat_cast_le))
+| none => match pol.getAppFnArgs with
+  | (``HAdd.hAdd, #[_, _, _, _, f, g]) =>
+    ([f, g], (``natDegree_add_le_of_le, ``degree_add_le_of_le))
+  | (``HSub.hSub, #[_, _, _, _, f, g]) =>
+    ([f, g], (``natDegree_sub_le_of_le, ``degree_sub_le_of_le))
+  | (``HMul.hMul, #[_, _, _, _, f, g]) =>
+    ([f, g], (``natDegree_mul_le_of_le, ``degree_mul_le_of_le))
+  | (``HPow.hPow, #[_, _, _, _, f, _]) =>
+    ([f], (``natDegree_pow_le_of_le, ``degree_pow_le_of_le))
+  | (``Neg.neg,   #[_, _, f]) =>
+    ([f], (``natDegree_neg_le_of_le, ``degree_neg_le_of_le))
+  | (``Polynomial.X, _) =>
+    ([], (``natDegree_X_le, ``degree_X_le))
+  | (``Nat.cast, _) =>
+    ([], (``natDegree_nat_cast_le, ``degree_nat_cast_le))
+  | (``NatCast.natCast, _) =>
+    ([], (``natDegree_nat_cast_le, ``degree_nat_cast_le))
+  | (``Int.cast, _) =>
+    ([], (``natDegree_int_cast_le, ``degree_int_cast_le))
+  | (``IntCast.intCast, _) =>
+    ([], (``natDegree_int_cast_le, ``degree_int_cast_le))
+  | (``FunLike.coe, #[_, _, _, _, polFun, _]) => match polFun.getAppFnArgs with
+    | (``Polynomial.monomial, #[_, _, _]) =>
+      ([], (``natDegree_monomial_le, ``degree_monomial_le))
+    | (``Polynomial.C, _) =>
+      ([], (``natDegree_C_le, ``degree_C_le))
+    | _ =>
+      ([polFun], (.anonymous, .anonymous))
+  | _ => ([], (``le_rfl, ``le_rfl))
+if π names == .anonymous then
+  throwError m!"'compute_degree_le' is not implemented for {← ppExpr fg[0]!}"
+return (← (fg.zip (← mv.applyConst (π names))).mapM fun (p, m) => computeDegreeLECore p m π).join
+
+/-- Allows the syntax expression `compute_degree_le !`, with optional `!`. -/
+syntax (name := computeDegreeLE) "compute_degree_le" "!"? : tactic
+
+/-- Allows writing `compute_degree_le!` with no space preceding `!`. -/
+macro "compute_degree_le!" : tactic => `(tactic| compute_degree_le !)
+
+open Elab.Tactic in
+/--
+`compute_degree_le` is a tactic to solve goals of the form `natDegree f ≤ d` or `degree f ≤ d`.
+
+The tactic first replaces `natDegree f ≤ d` with `d' ≤ d`,
+where `d'` is an internally computed guess for which the tactic proves the inequality
+`natDegree f ≤ d'`.
+
+Next, it applies `norm_num` to `d'`, in the hope of closing also the `d' ≤ d` goal.
+
+The variant `compute_degree_le!` first applies `compute_degree_le`.
+Then it uses `norm_num` on the whole inequality `d' ≤ d` and tries `assumption`.
+-/
+elab_rules : tactic | `(tactic| compute_degree_le $[!%$str]?) => focus do
+  let (isNatDeg?, lhs) := ← isDegLE (← getMainTarget)
+  let π := if isNatDeg? then Prod.fst else Prod.snd
+  -- if the goal is `natDegree f ≤ d`, then `le_goals = [natDegree f ≤ ?m,  ?m ≤ d,  ℕ]`
+  -- if the goal is `degree f ≤ d`,    then `le_goals = [degree f ≤ ?m,     ?m ≤ d,  WithBot ℕ]`
+  let le_goals := ← (← getMainGoal).applyConst ``le_trans
+  let prf := ← computeDegreeLECore lhs (le_goals[0]!) π
+  guard (prf == []) <|> throwError m!"'compute_degree_le' should have closed {prf}"
+  setGoals [le_goals[1]!]
+  if str.isSome then evalTactic (← `(tactic| norm_num <;> try assumption))
+  else evalTactic (← `(tactic| conv_lhs => norm_num))
+
+end Tactic
 
 end Mathlib.Tactic.ComputeDegree

--- a/Mathlib/Tactic/ComputeDegree.lean
+++ b/Mathlib/Tactic/ComputeDegree.lean
@@ -75,7 +75,7 @@ If `e` represents
 *  `degree f ≤ d`,    then it returns `(false, f)`;
 *  anything else, then it throws an error.
 -/
-def isDegLE (e : Expr) : CoreM (Bool × Expr) := do
+def isDegLE (e : Expr) : MetaM (Bool × Expr) := do
   match e.consumeMData.getAppFnArgs with
     -- check that the target is an inequality `≤`...
     | (``LE.le, #[_, _, lhs, _rhs]) => match lhs.getAppFnArgs with
@@ -83,8 +83,8 @@ def isDegLE (e : Expr) : CoreM (Bool × Expr) := do
       | (``degree, #[_R, _iSR, pol])    => return (false, pol)
       | (``natDegree, #[_R, _iSR, pol]) => return (true, pol)
       | (na, _) => throwError (m!"Expected an inequality of the form\n\n" ++
-        f!"  'f.natDegree ≤ d'  or  'f.degree ≤ d',\n\ninstead, {na} appears on the LHS")
-    | (na, _)  => throwError m!"Expected an inequality instead of '{na}', '{e}'"
+        f!"  'f.natDegree ≤ d'  or  'f.degree ≤ d',\n\ninstead, '{na}' appears on the LHS")
+    | (na, _)  => throwError m!"Expected an inequality instead of '{na}': '{← ppExpr e}'"
 
 /-- `computeDegreeLECore pol mv π` takes as input
 * an `Expr`ession `pol` representing a polynomial;

--- a/Mathlib/Tactic/ComputeDegree.lean
+++ b/Mathlib/Tactic/ComputeDegree.lean
@@ -142,13 +142,6 @@ if π names == .anonymous then
   throwError m!"'compute_degree_le' is not implemented for {← ppExpr fg[0]!}"
 return (← (fg.zip (← mv.applyConst (π names))).mapM fun (p, m) => computeDegreeLECore p m π).join
 
-/-- Allows the syntax expression `compute_degree_le !`, with optional `!`. -/
-syntax (name := computeDegreeLE) "compute_degree_le" "!"? : tactic
-
-/-- Allows writing `compute_degree_le!` with no space preceding `!`. -/
-macro "compute_degree_le!" : tactic => `(tactic| compute_degree_le !)
-
-open Elab.Tactic in
 /--
 `compute_degree_le` is a tactic to solve goals of the form `natDegree f ≤ d` or `degree f ≤ d`.
 
@@ -161,6 +154,13 @@ Next, it applies `norm_num` to `d'`, in the hope of closing also the `d' ≤ d` 
 The variant `compute_degree_le!` first applies `compute_degree_le`.
 Then it uses `norm_num` on the whole inequality `d' ≤ d` and tries `assumption`.
 -/
+syntax (name := computeDegreeLE) "compute_degree_le" "!"? : tactic
+
+@[inherit_doc computeDegreeLE]
+macro "compute_degree_le!" : tactic => `(tactic| compute_degree_le !)
+
+open Elab.Tactic in
+
 elab_rules : tactic | `(tactic| compute_degree_le $[!%$str]?) => focus do
   let (isNatDeg?, lhs) := ← isDegLE (← getMainTarget)
   let π := if isNatDeg? then Prod.fst else Prod.snd

--- a/test/ComputeDegree.lean
+++ b/test/ComputeDegree.lean
@@ -1,0 +1,200 @@
+import Mathlib.Tactic.ComputeDegree
+
+open Polynomial
+
+section native_mathlib4_tests
+
+variable {n : ℕ} {z : ℤ} {f : ℤ[X]} (hn : natDegree f ≤ 5) (hd : degree f ≤ 5)
+
+/--  This example flows through all the matches in `direct` with a `natDegree` goal. -/
+example : natDegree (- C z * X ^ 5 + (monomial 2 5) ^ 2 - 0 + 1 + IntCast.intCast 1 +
+    NatCast.natCast 1 + (z : ℤ[X]) + (n : ℤ[X]) + f) ≤ 5 := by
+  compute_degree_le! -debug
+
+example [Semiring R] : natDegree (OfNat.ofNat (OfNat.ofNat 0) : R[X]) ≤ 0 := by
+  compute_degree_le
+
+/--  This example flows through all the matches in `direct` with a `degree` goal. -/
+example : degree (- C z * X ^ 5 + (monomial 2 5) ^ 2 - 0 + 1 + IntCast.intCast 1 +
+    NatCast.natCast 1 + (z : ℤ[X]) + (n : ℤ[X]) + f) ≤ 5 := by
+  set k := f with _h₀
+  compute_degree_le!
+
+example {N : WithBot ℕ} (nN : n ≤ N) : degree (- C z * X ^ n) ≤ N := by
+  compute_degree_le!
+
+/-!  The following examples exhaust all the match-leaves in `direct`. -/
+
+--  OfNat.ofNat 0
+example : natDegree (0 : ℤ[X]) ≤ 5 := by
+  compute_degree_le!
+
+--  OfNat.ofNat (non-zero)
+example : natDegree (1 : ℤ[X]) ≤ 5 := by
+  compute_degree_le!
+
+--  NatCast.natCast
+example : natDegree (NatCast.natCast 4 : ℤ[X]) ≤ 5 := by
+  compute_degree_le!
+
+--  Nat.cast
+example : natDegree (Nat.cast n : ℤ[X]) ≤ 5 := by
+  compute_degree_le!
+
+--  IntCast.intCast
+example : natDegree (IntCast.intCast 4 : ℤ[X]) ≤ 5 := by
+  compute_degree_le!
+
+--  Int.cast
+example : natDegree (Int.cast z : ℤ[X]) ≤ 5 := by
+  compute_degree_le!
+
+--  Polynomial.X
+example : natDegree (X : ℤ[X]) ≤ 5 := by
+  compute_degree_le!
+
+--  Polynomial.C
+example : natDegree (C n) ≤ 5 := by
+  compute_degree_le!
+
+--  Polynomial.monomial
+example (h : n ≤ 5) : natDegree (monomial n (5 + n)) ≤ 5 := by
+  compute_degree_le!
+
+--  Expr.fvar
+example {f : ℕ[X]} : natDegree f ≤ natDegree f := by
+  compute_degree_le
+
+variable [Ring R]
+
+--  OfNat.ofNat 0
+example : natDegree (0 : R[X]) ≤ 5 := by
+  compute_degree_le!
+
+--  OfNat.ofNat (non-zero)
+example : natDegree (1 : R[X]) ≤ 5 := by
+  compute_degree_le!
+
+--  NatCast.natCast
+example : natDegree (NatCast.natCast 4 : R[X]) ≤ 5 := by
+  compute_degree_le!
+
+--  Nat.cast
+example : natDegree (n : R[X]) ≤ 5 := by
+  compute_degree_le!
+
+--  IntCast.intCast
+example : natDegree (IntCast.intCast 4 : R[X]) ≤ 5 := by
+  compute_degree_le!
+
+--  Int.cast
+example : natDegree (z : R[X]) ≤ 5 := by
+  compute_degree_le!
+
+--  Polynomial.X
+example : natDegree (X : R[X]) ≤ 5 := by
+  compute_degree_le!
+
+--  Polynomial.C
+example : natDegree (C n) ≤ 5 := by
+  compute_degree_le!
+
+--  Polynomial.monomial
+example (h : n ≤ 5) : natDegree (monomial n (5 + n : R)) ≤ 5 := by
+  compute_degree_le!
+
+--  Expr.fvar
+example {f : R[X]} : natDegree f ≤ natDegree f := by
+  compute_degree_le
+
+end native_mathlib4_tests
+
+section tests_from_mathlib3
+variable {R : Type _} [Semiring R] {a b c d e : R}
+
+-- test that `mdata` does not get in the way of the tactic
+example : natDegree (7 * X : R[X]) ≤ 1 := by
+  have : 0 ≤ 1 := zero_le_one
+  compute_degree_le
+
+-- possibly only a vestigial test from mathlib3: maybe to check for `instantiateMVars`?
+example {R : Type _} [Ring R] (h : ∀ {p q : R[X]}, p.natDegree ≤ 0 → (p * q).natDegree = 0) :
+    natDegree (- 1 * 1 : R[X]) = 0 := by
+  apply h _
+  compute_degree_le
+
+-- check for making sure that `compute_degree_le` is `focus`ed
+example : Polynomial.natDegree (Polynomial.C 4) ≤ 1 ∧ True := by
+  constructor
+  compute_degree_le!
+  trivial
+
+example {R : Type _} [Ring R] :
+    natDegree (- 1 * 1 : R[X]) ≤ 0 := by
+  compute_degree_le
+
+example {F} [Ring F] {a : F} :
+    natDegree (X ^ 9 - C a * X ^ 10 : F[X]) ≤ 10 := by
+  compute_degree_le
+
+example :
+    degree (X + (X * monomial 2 1 + X * X) ^ 2) ≤ 10 := by
+  compute_degree_le!
+
+example : natDegree (7 * X : R[X]) ≤ 1 := by
+  compute_degree_le
+
+example : natDegree (0 : R[X]) ≤ 0 := by
+  compute_degree_le
+
+example : natDegree (1 : R[X]) ≤ 0 := by
+  compute_degree_le
+
+example : natDegree (2 : R[X]) ≤ 0 := by
+  compute_degree_le
+
+example : natDegree ((n : Nat) : R[X]) ≤ 0 := by
+  compute_degree_le
+
+example {R} [Ring R] {n : ℤ} : natDegree ((n : ℤ) : R[X]) ≤ 0 := by
+  compute_degree_le
+
+example {R} [Ring R] {n : ℕ} : natDegree ((- n : ℤ) : R[X]) ≤ 0 := by
+  compute_degree_le
+
+example : natDegree (monomial 5 c * monomial 1 c + monomial 7 d +
+    C a * X ^ 0 + C b * X ^ 5 + C c * X ^ 2 + X ^ 10 + C e * X) ≤ 10 := by
+  compute_degree_le
+
+example :
+    natDegree (monomial 0 c * (monomial 0 c * C 1) + monomial 0 d + C 1 + C a * X ^ 0) ≤ 0 := by
+  compute_degree_le
+
+example {F} [Ring F] : natDegree (X ^ 4 + 3 : F[X]) ≤ 4 := by
+  compute_degree_le
+
+example : natDegree ((5 * X * C 3 : _root_.Rat[X]) ^ 4) ≤ 4 := by
+  compute_degree_le
+
+example : natDegree ((C a * X) ^ 4) ≤ 4 := by
+  compute_degree_le
+
+example : degree ((X : ℤ[X]) ^ 4) ≤ 4 := by
+  compute_degree_le
+
+example : natDegree ((X : ℤ[X]) ^ 4) ≤ 40 := by
+  compute_degree_le!
+
+example : natDegree (C a * C b + X + monomial 3 4 * X) ≤ 4 := by
+  compute_degree_le
+
+variable {R : Type _} [Semiring R] {a b c d e : R}
+
+example {F} [Ring F] {a : F} :
+    natDegree (X ^ 3 + C a * X ^ 10 : F[X]) ≤ 10 := by
+    compute_degree_le
+
+example : natDegree (7 * X : R[X]) ≤ 1 := by
+  compute_degree_le
+
+end tests_from_mathlib3

--- a/test/ComputeDegree.lean
+++ b/test/ComputeDegree.lean
@@ -9,7 +9,7 @@ variable {n : ℕ} {z : ℤ} {f : ℤ[X]} (hn : natDegree f ≤ 5) (hd : degree 
 /--  This example flows through all the matches in `direct` with a `natDegree` goal. -/
 example : natDegree (- C z * X ^ 5 + (monomial 2 5) ^ 2 - 0 + 1 + IntCast.intCast 1 +
     NatCast.natCast 1 + (z : ℤ[X]) + (n : ℤ[X]) + f) ≤ 5 := by
-  compute_degree_le! -debug
+  compute_degree_le!
 
 example [Semiring R] : natDegree (OfNat.ofNat (OfNat.ofNat 0) : R[X]) ≤ 0 := by
   compute_degree_le


### PR DESCRIPTION
This PR is an alternative to #5882.  It gives a "minimalistic" port of the `compute_degree_le` tactic.

This very short tactic works on all tests.  ~~The other PR is more structured and is probably further along the direction of a more complete implementation of a `compute_degree` tactic.~~

~~In the long run, I think that the definitions in the other tactic will likely make up the `compute_degree` tactic, but they are not needed for the easier `compute_degree_le` tactic.~~

PR #6221 implements the full `compute_degree` tactic with a method similar to the one in this PR.  I am tempted to close this PR, except for the fact that it might be a possible stepping stone to get to the full implementation.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
