### PR TITLE
[Merged by Bors] - chore: remove 'Ported by' headers

### DIFF
--- a/Mathlib/Algebra/Divisibility/Basic.lean
+++ b/Mathlib/Algebra/Divisibility/Basic.lean
@@ -3,7 +3,6 @@ Copyright (c) 2014 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura, Floris van Doorn, Amelia Livingston, Yury Kudryashov,
 Neil Strickland, Aaron Anderson
-Ported by: Matej Penciak
 -/
 import Mathlib.Algebra.Hom.Group
 

--- a/Mathlib/Algebra/Divisibility/Units.lean
+++ b/Mathlib/Algebra/Divisibility/Units.lean
@@ -3,7 +3,6 @@ Copyright (c) 2014 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura, Floris van Doorn, Amelia Livingston, Yury Kudryashov,
 Neil Strickland, Aaron Anderson
-Ported by: Joël Riou
 -/
 import Mathlib.Algebra.Divisibility.Basic
 import Mathlib.Algebra.Group.Units

--- a/Mathlib/Algebra/GroupPower/Ring.lean
+++ b/Mathlib/Algebra/GroupPower/Ring.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2015 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Robert Y. Lewis
-Ported by: Joël Riou
 -/
 
 import Mathlib.Algebra.GroupPower.Basic

--- a/Mathlib/Algebra/Hom/Commute.lean
+++ b/Mathlib/Algebra/Hom/Commute.lean
@@ -3,7 +3,6 @@ Copyright (c) 2018 Patrick Massot. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Patrick Massot, Kevin Buzzard, Scott Morrison, Johan Commelin, Chris Hughes,
   Johannes Hölzl, Yury Kudryashov
-Ported by: Frédéric Dupuis
 -/
 import Mathlib.Algebra.Hom.Group
 import Mathlib.Algebra.Group.Commute

--- a/Mathlib/Algebra/Hom/Equiv/Basic.lean
+++ b/Mathlib/Algebra/Hom/Equiv/Basic.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2018 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Callum Sutton, Yury Kudryashov
-Ported by: Winston Yin
 -/
 import Mathlib.Algebra.Hom.Group
 import Mathlib.Data.FunLike.Equiv

--- a/Mathlib/Algebra/Hom/Equiv/TypeTags.lean
+++ b/Mathlib/Algebra/Hom/Equiv/TypeTags.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2018 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Callum Sutton, Yury Kudryashov
-Ported by: Frédéric Dupuis
 -/
 import Mathlib.Algebra.Hom.Equiv.Basic
 import Mathlib.Algebra.Group.TypeTags

--- a/Mathlib/Algebra/Hom/Equiv/Units/Basic.lean
+++ b/Mathlib/Algebra/Hom/Equiv/Units/Basic.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2018 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Callum Sutton, Yury Kudryashov
-Ported by: Scott Morrison
 -/
 import Mathlib.Algebra.Hom.Equiv.Basic
 import Mathlib.Algebra.Hom.Units

--- a/Mathlib/Algebra/Hom/Group.lean
+++ b/Mathlib/Algebra/Hom/Group.lean
@@ -3,7 +3,6 @@ Copyright (c) 2018 Patrick Massot. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Patrick Massot, Kevin Buzzard, Scott Morrison, Johan Commelin, Chris Hughes,
   Johannes Hölzl, Yury Kudryashov
-Ported by: Winston Yin
 -/
 import Mathlib.Init.CCLemmas
 import Mathlib.Algebra.NeZero

--- a/Mathlib/Algebra/Hom/Ring.lean
+++ b/Mathlib/Algebra/Hom/Ring.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2019 Amelia Livingston. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Amelia Livingston, Jireh Loreaux
-Ported by: Winston Yin
 -/
 import Mathlib.Algebra.GroupWithZero.InjSurj
 import Mathlib.Algebra.Ring.Basic

--- a/Mathlib/Algebra/Hom/Units.lean
+++ b/Mathlib/Algebra/Hom/Units.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2018 Johan Commelin All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin, Chris Hughes, Kevin Buzzard
-Ported by: Winston Yin
 -/
 import Mathlib.Algebra.Hom.Group
 import Mathlib.Algebra.Group.Units

--- a/Mathlib/Algebra/Order/Field/Canonical/Defs.lean
+++ b/Mathlib/Algebra/Order/Field/Canonical/Defs.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2014 Robert Lewis. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Lewis, Leonardo de Moura, Mario Carneiro, Floris van Doorn
-Ported by: Rémy Degenne
 -/
 import Mathlib.Algebra.Order.Field.Defs
 import Mathlib.Algebra.Order.Ring.Canonical

--- a/Mathlib/Algebra/Order/Field/Defs.lean
+++ b/Mathlib/Algebra/Order/Field/Defs.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2014 Robert Lewis. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Lewis, Leonardo de Moura, Mario Carneiro, Floris van Doorn
-Ported by: Scott Morrison
 -/
 import Mathlib.Algebra.Field.Defs
 import Mathlib.Algebra.Order.Ring.Defs

--- a/Mathlib/Algebra/Order/Group/OrderIso.lean
+++ b/Mathlib/Algebra/Order/Group/OrderIso.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2016 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro, Johannes Hölzl
-Ported by: Scott Morrison
 -/
 import Mathlib.Algebra.Order.Group.Defs
 import Mathlib.Algebra.Hom.Equiv.Units.Basic

--- a/Mathlib/Algebra/Order/Hom/Monoid.lean
+++ b/Mathlib/Algebra/Order/Hom/Monoid.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2022 Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
-Ported by: Frédéric Dupuis
 -/
 import Mathlib.Data.Pi.Algebra
 import Mathlib.Algebra.Hom.Group

--- a/Mathlib/Algebra/Order/Monoid/Prod.lean
+++ b/Mathlib/Algebra/Order/Monoid/Prod.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2016 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro, Johannes Hölzl
-Ported by: Joël Riou
 -/
 import Mathlib.Algebra.Group.Prod
 import Mathlib.Algebra.Order.Monoid.Cancel.Defs

--- a/Mathlib/Algebra/Order/Monoid/WithTop.lean
+++ b/Mathlib/Algebra/Order/Monoid/WithTop.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2016 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro, Johannes Hölzl
-Ported by: Jon Eugster
 -/
 import Mathlib.Algebra.Hom.Group
 import Mathlib.Algebra.Order.Monoid.OrderDual

--- a/Mathlib/Algebra/Order/Ring/Canonical.lean
+++ b/Mathlib/Algebra/Order/Ring/Canonical.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2016 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro
-Ported by: Scott Morrison
 -/
 import Mathlib.Algebra.Order.Ring.Defs
 import Mathlib.Algebra.Order.Sub.Canonical

--- a/Mathlib/Algebra/Order/Ring/CharZero.lean
+++ b/Mathlib/Algebra/Order/Ring/CharZero.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2016 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro
-Ported by: Scott Morrison
 -/
 import Mathlib.Algebra.CharZero.Defs
 import Mathlib.Algebra.Order.Ring.Defs

--- a/Mathlib/Algebra/Order/Ring/Defs.lean
+++ b/Mathlib/Algebra/Order/Ring/Defs.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2016 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro, Yaël Dillies
-Ported by: Scott Morrison
 -/
 import Mathlib.Algebra.Order.Group.Defs
 import Mathlib.Algebra.Order.Monoid.Cancel.Defs

--- a/Mathlib/Algebra/Ring/Basic.lean
+++ b/Mathlib/Algebra/Ring/Basic.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2014 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura, Floris van Doorn, Yury Kudryashov, Neil Strickland
-Ported by: Moritz Doll
 -/
 import Mathlib.Algebra.Ring.Defs
 import Mathlib.Algebra.Hom.Group

--- a/Mathlib/Algebra/Ring/Divisibility.lean
+++ b/Mathlib/Algebra/Ring/Divisibility.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2014 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura, Floris van Doorn, Yury Kudryashov, Neil Strickland
-Ported by: Matej Penciak
 -/
 import Mathlib.Algebra.Divisibility.Basic
 import Mathlib.Algebra.Hom.Equiv.Basic

--- a/Mathlib/Algebra/Ring/Equiv.lean
+++ b/Mathlib/Algebra/Ring/Equiv.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2018 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Callum Sutton, Yury Kudryashov
-Ported by: Anatole Dedecker
 -/
 import Mathlib.Algebra.Group.Opposite
 import Mathlib.Algebra.Hom.Ring

--- a/Mathlib/CategoryTheory/Category/Basic.lean
+++ b/Mathlib/CategoryTheory/Category/Basic.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2017 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Stephen Morgan, Scott Morrison, Johannes Hölzl, Reid Barton
-Ported by: Scott Morrison
 -/
 import Mathlib.CategoryTheory.Category.Init
 import Mathlib.Combinatorics.Quiver.Basic

--- a/Mathlib/CategoryTheory/EssentialImage.lean
+++ b/Mathlib/CategoryTheory/EssentialImage.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2020 Bhavik Mehta. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta
-Ported by: Joël Riou
 -/
 import Mathlib.CategoryTheory.NatIso
 import Mathlib.CategoryTheory.FullSubcategory

--- a/Mathlib/CategoryTheory/Functor/Basic.lean
+++ b/Mathlib/CategoryTheory/Functor/Basic.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2017 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Tim Baumann, Stephen Morgan, Scott Morrison
-Ported by: Scott Morrison
 -/
 import Mathlib.CategoryTheory.Category.Basic
 

--- a/Mathlib/CategoryTheory/Iso.lean
+++ b/Mathlib/CategoryTheory/Iso.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2017 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Tim Baumann, Stephen Morgan, Scott Morrison, Floris van Doorn
-Ported by: Scott Morrison
 -/
 import Mathlib.Tactic.CategoryTheory.Reassoc
 

--- a/Mathlib/CategoryTheory/NatTrans.lean
+++ b/Mathlib/CategoryTheory/NatTrans.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2017 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Tim Baumann, Stephen Morgan, Scott Morrison, Floris van Doorn
-Ported by: Scott Morrison
 -/
 import Mathlib.Tactic.CategoryTheory.Reassoc
 

--- a/Mathlib/CategoryTheory/Whiskering.lean
+++ b/Mathlib/CategoryTheory/Whiskering.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2018 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
-Ported by: Joël Riou
 -/
 import Mathlib.CategoryTheory.Iso
 import Mathlib.CategoryTheory.Functor.Category

--- a/Mathlib/Combinatorics/Quiver/Basic.lean
+++ b/Mathlib/Combinatorics/Quiver/Basic.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2021 David Wärn. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: David Wärn, Scott Morrison
-Ported by: Scott Morrison
 -/
 import Mathlib.Data.Opposite
 

--- a/Mathlib/Combinatorics/Quiver/ConnectedComponent.lean
+++ b/Mathlib/Combinatorics/Quiver/ConnectedComponent.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2021 David Wärn. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: David Wärn
-Ported by: Joël Riou
 -/
 import Mathlib.Combinatorics.Quiver.Subquiver
 import Mathlib.Combinatorics.Quiver.Path

--- a/Mathlib/Combinatorics/Quiver/Path.lean
+++ b/Mathlib/Combinatorics/Quiver/Path.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2021 David Wärn,. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: David Wärn, Scott Morrison
-Ported by: Joël Riou
 -/
 import Mathlib.Combinatorics.Quiver.Basic
 import Mathlib.Logic.Lemmas

--- a/Mathlib/Combinatorics/Quiver/Subquiver.lean
+++ b/Mathlib/Combinatorics/Quiver/Subquiver.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2021 David Wärn. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: David Wärn
-Ported by: Joël Riou
 -/
 import Mathlib.Order.BoundedOrder
 import Mathlib.Combinatorics.Quiver.Basic

--- a/Mathlib/Combinatorics/Quiver/Symmetric.lean
+++ b/Mathlib/Combinatorics/Quiver/Symmetric.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2021 David Wärn. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: David Wärn, Antoine Labelle, Rémi Bottinelli
-Ported by: Joël Riou, Rémi Bottinelli
 -/
 import Mathlib.Combinatorics.Quiver.Path
 import Mathlib.Combinatorics.Quiver.Push

--- a/Mathlib/Data/Int/Cast/Lemmas.lean
+++ b/Mathlib/Data/Int/Cast/Lemmas.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2017 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
-Ported by: Scott Morrison
 -/
 import Mathlib.Data.Int.Order.Basic
 import Mathlib.Data.Nat.Cast.Basic

--- a/Mathlib/Data/Int/Dvd/Basic.lean
+++ b/Mathlib/Data/Int/Dvd/Basic.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2016 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad
-Ported by: Scott Morrison
 -/
 import Mathlib.Data.Int.Order.Basic
 import Mathlib.Data.Nat.Cast.Basic

--- a/Mathlib/Data/Int/Order/Lemmas.lean
+++ b/Mathlib/Data/Int/Order/Lemmas.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2016 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad
-Ported by: Matej Penciak
 -/
 import Mathlib.Data.Int.Order.Basic
 import Mathlib.Algebra.GroupWithZero.Divisibility

--- a/Mathlib/Data/Nat/Choose/Central.lean
+++ b/Mathlib/Data/Nat/Choose/Central.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2021 Patrick Stevens. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Patrick Stevens, Thomas Browning
-Ported by: Frédéric Dupuis
 -/
 import Mathlib.Data.Nat.Choose.Basic
 import Mathlib.Tactic.Linarith

--- a/Mathlib/Data/Nat/ForSqrt.lean
+++ b/Mathlib/Data/Nat/ForSqrt.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2015 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura, Johannes Hölzl, Mario Carneiro
-Ported by: Kevin Buzzard, Johan Commelin, Siddhartha Gadgil, Anand Rao
 -/
 
 import Mathlib.Data.Nat.Size

--- a/Mathlib/Data/Nat/Log.lean
+++ b/Mathlib/Data/Nat/Log.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2020 Simon Hudon. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Simon Hudon, Yaël Dillies
-Ported by: Rémy Degenne
 -/
 import Mathlib.Data.Nat.Pow
 

--- a/Mathlib/Data/Pi/Algebra.lean
+++ b/Mathlib/Data/Pi/Algebra.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2020 Eric Wieser. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Simon Hudon, Patrick Massot, Eric Wieser
-Ported by: Jon Eugster
 -/
 import Mathlib.Algebra.Group.Defs
 import Mathlib.Data.Prod.Basic

--- a/Mathlib/Data/Set/Accumulate.lean
+++ b/Mathlib/Data/Set/Accumulate.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2020 Floris van Doorn. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn
-Ported by: Anatole Dedecker
 -/
 import Mathlib.Data.Set.Lattice
 

--- a/Mathlib/Data/Set/Image.lean
+++ b/Mathlib/Data/Set/Image.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2014 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura
-Ported by: Winston Yin
 -/
 import Mathlib.Data.Set.Basic
 

--- a/Mathlib/Data/Set/Intervals/Basic.lean
+++ b/Mathlib/Data/Set/Intervals/Basic.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro, Patrick Massot, Yury Kudryashov, Rémy Degenne
-Ported by: Winston Yin, Arien Malec
 -/
 import Mathlib.Order.MinMax
 import Mathlib.Data.Set.Prod

--- a/Mathlib/Data/Set/Intervals/Group.lean
+++ b/Mathlib/Data/Set/Intervals/Group.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro, Patrick Massot, Yury Kudryashov, Rémy Degenne
-Ported by: Winston Yin
 -/
 import Mathlib.Data.Set.Intervals.Basic
 import Mathlib.Data.Set.Pairwise.Basic

--- a/Mathlib/Data/Set/Intervals/SurjOn.lean
+++ b/Mathlib/Data/Set/Intervals/SurjOn.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2020 Heather Macbeth. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Heather Macbeth
-Ported by: Joël Riou
 -/
 import Mathlib.Data.Set.Intervals.Basic
 import Mathlib.Data.Set.Function

--- a/Mathlib/Data/Set/Opposite.lean
+++ b/Mathlib/Data/Set/Opposite.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2022 Markus Himmel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus Himmel
-Ported by: Joël Riou
 -/
 import Mathlib.Data.Opposite
 import Mathlib.Data.Set.Image

--- a/Mathlib/Data/TwoPointing.lean
+++ b/Mathlib/Data/TwoPointing.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2022 Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
-Ported by: Joël Riou
 -/
 import Mathlib.Data.Sum.Basic
 import Mathlib.Logic.Nontrivial

--- a/Mathlib/GroupTheory/Submonoid/Basic.lean
+++ b/Mathlib/GroupTheory/Submonoid/Basic.lean
@@ -3,7 +3,6 @@ Copyright (c) 2018 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Kenny Lau, Johan Commelin, Mario Carneiro, Kevin Buzzard,
 Amelia Livingston, Yury Kudryashov
-Ported by: Anatole Dedecker
 -/
 import Mathlib.Algebra.Hom.Group
 import Mathlib.Algebra.Group.Units

--- a/Mathlib/Init/Data/Sigma/Basic.lean
+++ b/Mathlib/Init/Data/Sigma/Basic.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2014 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura, Jeremy Avigad, Floris van Doorn
-Ported by: Scott Morrison
 -/
 import Mathlib.Init.Logic
 

--- a/Mathlib/Logic/Equiv/Basic.lean
+++ b/Mathlib/Logic/Equiv/Basic.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2015 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura, Mario Carneiro
-Ported by: Kevin Buzzard, Ruben Vorster, Scott Morrison, Eric Rodriguez
 -/
 import Mathlib.Data.Bool.Basic
 import Mathlib.Data.Prod.Basic

--- a/Mathlib/Logic/Equiv/Nat.lean
+++ b/Mathlib/Logic/Equiv/Nat.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2018 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
-Ported by: Anatole Dedecker
 -/
 import Mathlib.Data.Nat.Pairing
 

--- a/Mathlib/Order/Chain.lean
+++ b/Mathlib/Order/Chain.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl
-Ported by: Anatole Dedecker
 -/
 import Mathlib.Data.Set.Pairwise.Basic
 import Mathlib.Data.Set.Lattice

--- a/Mathlib/Order/ConditionallyCompleteLattice/Group.lean
+++ b/Mathlib/Order/ConditionallyCompleteLattice/Group.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2018 Sébastien Gouëzel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel
-Ported by: Anatole Dedecker
 -/
 import Mathlib.Order.ConditionallyCompleteLattice.Basic
 import Mathlib.Algebra.Order.Group.TypeTags

--- a/Mathlib/Order/SymmDiff.lean
+++ b/Mathlib/Order/SymmDiff.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2021 Bryan Gin-ge Chen. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Adam Topaz, Bryan Gin-ge Chen, Yaël Dillies
-Ported by: Frédéric Dupuis
 -/
 import Mathlib.Order.BooleanAlgebra
 import Mathlib.Logic.Equiv.Basic

--- a/Mathlib/Tactic/Lift.lean
+++ b/Mathlib/Tactic/Lift.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2019 Floris van Doorn. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn
-Ported by: Yury Kudryashov, Frédéric Dupuis
 -/
 import Mathlib.Tactic.Cases
 import Mathlib.Tactic.PermuteGoals

--- a/Mathlib/Tactic/Linarith/Datatypes.lean
+++ b/Mathlib/Tactic/Linarith/Datatypes.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2020 Robert Y. Lewis. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Y. Lewis
-Ported by: Scott Morrison
 -/
 import Mathlib.Tactic.Linarith.Lemmas
 import Mathlib.Tactic.Ring

--- a/Mathlib/Tactic/Linarith/Elimination.lean
+++ b/Mathlib/Tactic/Linarith/Elimination.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2020 Robert Y. Lewis. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Y. Lewis
-Ported by: Scott Morrison
 -/
 import Mathlib.Tactic.Linarith.Datatypes
 

--- a/Mathlib/Tactic/Linarith/Frontend.lean
+++ b/Mathlib/Tactic/Linarith/Frontend.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2018 Robert Y. Lewis. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Y. Lewis
-Ported by: Scott Morrison
 -/
 import Mathlib.Control.Basic
 import Mathlib.Data.HashMap

--- a/Mathlib/Tactic/Linarith/Lemmas.lean
+++ b/Mathlib/Tactic/Linarith/Lemmas.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2020 Robert Y. Lewis. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Y. Lewis
-Ported by: Scott Morrison
 -/
 import Std.Tactic.Simpa
 import Std.Tactic.Lint.Basic

--- a/Mathlib/Tactic/Linarith/Parsing.lean
+++ b/Mathlib/Tactic/Linarith/Parsing.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2020 Robert Y. Lewis. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Y. Lewis
-Ported by: Scott Morrison
 -/
 
 import Std.Data.RBMap.Basic

--- a/Mathlib/Tactic/Linarith/Preprocessing.lean
+++ b/Mathlib/Tactic/Linarith/Preprocessing.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2020 Robert Y. Lewis. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Y. Lewis
-Ported by: Scott Morrison
 -/
 import Mathlib.Tactic.Linarith.Datatypes
 import Mathlib.Tactic.Zify

--- a/Mathlib/Tactic/Linarith/Verification.lean
+++ b/Mathlib/Tactic/Linarith/Verification.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2020 Robert Y. Lewis. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Y. Lewis
-Ported by: Scott Morrison
 -/
 
 import Mathlib.Tactic.Linarith.Elimination

--- a/Mathlib/Tactic/Monotonicity/Basic.lean
+++ b/Mathlib/Tactic/Monotonicity/Basic.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2019 Simon Hudon. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Simon Hudon
-Ported by: Heather Macbeth
 -/
 import Mathlib.Tactic.Monotonicity.Attr
 import Mathlib.Tactic.SolveByElim

--- a/Mathlib/Tactic/Monotonicity/Lemmas.lean
+++ b/Mathlib/Tactic/Monotonicity/Lemmas.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2019 Simon Hudon. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Simon Hudon
-Ported by: Heather Macbeth
 -/
 import Mathlib.Algebra.Order.Group.Abs
 import Mathlib.Algebra.Order.Ring.Defs

--- a/Mathlib/Tactic/RestateAxiom.lean
+++ b/Mathlib/Tactic/RestateAxiom.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2017 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
-Ported by: E.W.Ayers
 -/
 import Lean
 import Lean.Data

--- a/Mathlib/Tactic/ToAdditive.lean
+++ b/Mathlib/Tactic/ToAdditive.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2017 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Yury Kudryashov, Floris van Doorn, Jon Eugster
-Ported by: E.W.Ayers
 -/
 import Mathlib.Init.Data.Nat.Notation
 import Mathlib.Data.String.Defs


### PR DESCRIPTION
Briefly during the port we were adding "Ported by" headers, but only ~60 / 3000 files ended up with such a header.

I propose deleting them.

We could consider adding these uniformly via a script, as part of the great history rewrite...?

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
