### PR TITLE
[Merged by Bors] - feat: restore field_simp [*]

### DIFF
--- a/Archive/Imo/Imo2008Q2.lean
+++ b/Archive/Imo/Imo2008Q2.lean
@@ -38,8 +38,7 @@ theorem subst_abc {x y z : ℝ} (h : x * y * z = 1) :
     have := h.symm ▸ one_ne_zero
     simpa [not_or] using this
   have : z * (y * x) = 1 := by rw [← h]; ac_rfl
-  -- Porting note: Originally `field_simp [*]`, but `*` doesn't work (see #5689)
-  field_simp [hx, this]
+  field_simp [*]
 #align imo2008_q2.subst_abc Imo2008Q2.subst_abc
 
 theorem imo2008_q2a (x y z : ℝ) (h : x * y * z = 1) (hx : x ≠ 1) (hy : y ≠ 1) (hz : z ≠ 1) :

--- a/Mathlib/Analysis/SpecialFunctions/Complex/Arg.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Arg.lean
@@ -44,13 +44,13 @@ theorem cos_arg {x : ℂ} (hx : x ≠ 0) : Real.cos (arg x) = x.re / abs x := by
   rw [arg]
   split_ifs with h₁ h₂
   · rw [Real.cos_arcsin]
-    simp [Real.sqrt_sq, (abs.pos hx).le, *, one_sub_div]
+    field_simp [Real.sqrt_sq, (abs.pos hx).le, *]
   · rw [Real.cos_add_pi, Real.cos_arcsin]
-    simp [Real.sqrt_div (sq_nonneg _), Real.sqrt_sq_eq_abs, _root_.abs_of_neg (not_le.1 h₁),
-      *, one_sub_div, neg_div]
+    field_simp [Real.sqrt_div (sq_nonneg _), Real.sqrt_sq_eq_abs,
+      _root_.abs_of_neg (not_le.1 h₁), *]
   · rw [Real.cos_sub_pi, Real.cos_arcsin]
-    simp [Real.sqrt_div (sq_nonneg _), Real.sqrt_sq_eq_abs, _root_.abs_of_neg (not_le.1 h₁),
-      *, one_sub_div, neg_div]
+    field_simp [Real.sqrt_div (sq_nonneg _), Real.sqrt_sq_eq_abs,
+      _root_.abs_of_neg (not_le.1 h₁), *]
 #align complex.cos_arg Complex.cos_arg
 
 @[simp]

--- a/Mathlib/Tactic/FieldSimp.lean
+++ b/Mathlib/Tactic/FieldSimp.lean
@@ -29,7 +29,7 @@ private def dischargerTraceMessage (prop: Expr) : Except ε (Option Expr) → Si
 | .error _ | .ok none => return m!"{crossEmoji} discharge {prop}"
 | .ok (some _) => return m!"{checkEmoji} discharge {prop}"
 
-/-- Discharge strategy for the field_simp tactic. -/
+/-- Discharge strategy for the `field_simp` tactic. -/
 partial def discharge (prop : Expr) : SimpM (Option Expr) :=
   withTraceNode `Tactic.field_simp (dischargerTraceMessage prop) do
     if let some r ← Simp.dischargeUsingAssumption? prop then
@@ -133,7 +133,7 @@ syntax (name := fieldSimp) "field_simp" (config)? (discharger)? (&" only")?
 
 elab_rules : tactic
 | `(tactic| field_simp $[$cfg:config]? $[$dis:discharger]? $[only%$only?]?
-    $[$sa:simpArgs]? $[$loc:location]?) => do
+    $[$sa:simpArgs]? $[$loc:location]?) => withMainContext do
   let cfg ← elabSimpConfig (cfg.getD ⟨.missing⟩) .simp
   let loc := expandOptLocation (mkOptionalNode loc)
 
@@ -159,6 +159,16 @@ elab_rules : tactic
      congrTheorems := (← getSimpCongrTheorems)
      config := cfg
   }
-  let r ← elabSimpArgs (sa.getD ⟨.missing⟩) ctx (eraseLocal := false) .simp
+  let mut r ← elabSimpArgs (sa.getD ⟨.missing⟩) ctx (eraseLocal := false) .simp
+  if r.starArg then
+    r ← do
+      let ctx := r.ctx
+      let mut simpTheorems := ctx.simpTheorems
+      let hs ← getPropHyps
+      for h in hs do
+        unless simpTheorems.isErased (.fvar h) do
+          simpTheorems ← simpTheorems.addTheorem (.fvar h) (← h.getDecl).toExpr
+      let ctx := { ctx with simpTheorems }
+      pure { ctx }
 
   _ ← simpLocation r.ctx dis loc


### PR DESCRIPTION
fixes #5689

to do this we basically copy the missing functionality over from the simp internals
 
---
To be honest the implementation of field simp seems a bit unwieldy to me right now, I'd be much happier to see it reimplemented as a macro or something closer to that if possible and reusing more of the original simp internals

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
