### PR TITLE
[Merged by Bors] - fix(Algebra.Category.ModuleCat.Basic): remove `CoeOut (Submodule R M) (ModuleCat R)` instance

### DIFF
--- a/Mathlib/Algebra/Category/ModuleCat/Basic.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Basic.lean
@@ -379,6 +379,3 @@ theorem Iso.conj_eq_conj (i : X ≅ X') (f : End X) :
 end
 
 end ModuleCat
-
-instance (M : Type u) [AddCommGroup M] [Module R M] : CoeOut (Submodule R M) (ModuleCat R) :=
-  ⟨fun N => ModuleCat.of R N⟩


### PR DESCRIPTION
---

This instance creates a path `Submodule R M` -> `ModuleCat R` -> `Type` that isn't syntactically equal to the `Submodule R M` -> `Type` coercion, causing the issue seen [here](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/CoeOut.20instance.20from.20Submodule.20R.20M.20to.20ModuleCat.20R).

The instance was added to mathlib3 in [this PR](https://github.com/leanprover-community/mathlib/pull/1420).
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
