### PR TITLE
[Merged by Bors] - feat: let `convert` infer instances from goal and allow tc failure

### DIFF
--- a/Mathlib/AlgebraicGeometry/Morphisms/RingHomProperties.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/RingHomProperties.lean
@@ -221,15 +221,15 @@ theorem affineLocally_iff_affineOpens_le (hP : RingHom.RespectsIso @P) {X Y : Sc
     rw [← hP.cancel_right_isIso _ (X.presheaf.map (eqToHom _)), Category.assoc, ←
       X.presheaf.map_comp]
     convert this using 1
+    · -- Porting note: makes instance metavariable like in Lean 3
+      apply
+        (@isAffineOpen_iff_of_isOpenImmersion _ _ (@Scheme.ofRestrict _ X U'.inclusion _) ?_ _).mp
+      -- Porting note: was convert V.2
+      erw [e']
+      apply V.2
+      infer_instance
     · dsimp only [Functor.op, unop_op]; rw [Opens.openEmbedding_obj_top]
-      · congr 1; apply e'.symm
-      · -- Porting note: makes instance metavariable like in Lean 3
-        apply
-          (@isAffineOpen_iff_of_isOpenImmersion _ _ (@Scheme.ofRestrict _ X U'.inclusion _) ?_ _).mp
-        -- Porting note: was convert V.2
-        erw [e']
-        apply V.2
-        infer_instance
+      congr 1; apply e'.symm
   · intro H V
     specialize H ⟨_, V.2.imageIsOpenImmersion (X.ofRestrict _)⟩ (Subtype.coe_image_subset _ _)
     erw [← X.presheaf.map_comp]

--- a/Mathlib/Data/Finset/Image.lean
+++ b/Mathlib/Data/Finset/Image.lean
@@ -603,8 +603,7 @@ theorem map_eq_image (f : α ↪ β) (s : Finset α) : s.map f = s.image f :=
 @[simp]
 theorem disjoint_image {s t : Finset α} {f : α → β} (hf : Injective f) :
     Disjoint (s.image f) (t.image f) ↔ Disjoint s t := by
-  -- Porting note: was `convert`
-  rw [←disjoint_map ⟨_, hf⟩]
+  convert disjoint_map ⟨_, hf⟩ using 1
   simp [map_eq_image]
 #align finset.disjoint_image Finset.disjoint_image
 

--- a/Mathlib/Data/Set/Ncard.lean
+++ b/Mathlib/Data/Set/Ncard.lean
@@ -413,7 +413,7 @@ theorem surj_on_of_inj_on_of_ncard_le {t : Set β} (f : ∀ a ∈ s, β) (hf : �
   have hft' := Fintype.ofInjective f' finj
   simp_rw [ncard_eq_toFinset_card] at hst
   set f'' : ∀ a, a ∈ s.toFinset → β := fun a h ↦ f a (by simpa using h)
-  convert @Finset.surj_on_of_inj_on_of_card_le _ _ _ t.toFinset f'' _ _ _ (by simpa) (by simpa)
+  convert @Finset.surj_on_of_inj_on_of_card_le _ _ _ t.toFinset f'' _ _ _ _ (by simpa)
   · simp
   · simp [hf]
   · intros a₁ a₂ ha₁ ha₂ h

--- a/Mathlib/GroupTheory/NoncommPiCoprod.lean
+++ b/Mathlib/GroupTheory/NoncommPiCoprod.lean
@@ -115,14 +115,11 @@ def noncommPiCoprod : (∀ i : ι, N i) →* M
     simp
   map_mul' f g := by
     classical
-      simp only
-      have := @Finset.noncommProd_mul_distrib _ _ _ Finset.univ (fun i => ϕ i (f i))
-        (fun i => ϕ i (g i)) ?_ ?_ ?_
-      · convert this
-        exact map_mul _ _ _
-      · exact fun i _ j _ hij => hcomm hij _ _
-      · exact fun i _ j _ hij => hcomm hij _ _
-      · exact fun i _ j _ hij => hcomm hij _ _
+    simp only
+    convert @Finset.noncommProd_mul_distrib _ _ _ _ (fun i => ϕ i (f i)) (fun i => ϕ i (g i)) _ _ _
+    · exact map_mul _ _ _
+    · rintro i - j - h
+      exact hcomm h _ _
 #align monoid_hom.noncomm_pi_coprod MonoidHom.noncommPiCoprod
 #align add_monoid_hom.noncomm_pi_coprod AddMonoidHom.noncommPiCoprod
 

--- a/Mathlib/MeasureTheory/MeasurableSpace.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace.lean
@@ -271,7 +271,7 @@ for functions between empty types. -/
 theorem measurable_const' {f : β → α} (hf : ∀ x y, f x = f y) : Measurable f := by
   nontriviality β
   inhabit β
-  convert @measurable_const α β ‹_› ‹_› (f default) using 2
+  convert @measurable_const α β _ _ (f default) using 2
   apply hf
 #align measurable_const' measurable_const'
 

--- a/Mathlib/Probability/Variance.lean
+++ b/Mathlib/Probability/Variance.lean
@@ -84,7 +84,9 @@ theorem evariance_eq_top [IsFiniteMeasure μ] (hXm : AEStronglyMeasurable X μ) 
     simp only [coe_two, ENNReal.one_toReal, ENNReal.rpow_two, Ne.def]
     exact ENNReal.rpow_lt_top_of_nonneg (by linarith) h.ne
   refine' hX _
-  convert this.add (memℒp_const <| μ[X])
+  -- Porting note: `μ[X]` without whitespace is ambiguous as it could be GetElem,
+  -- and `convert` cannot disambiguate based on typeclass inference failure.
+  convert this.add (memℒp_const <| μ [X])
   ext ω
   rw [Pi.add_apply, sub_add_cancel]
 #align probability_theory.evariance_eq_top ProbabilityTheory.evariance_eq_top

--- a/Mathlib/Probability/Variance.lean
+++ b/Mathlib/Probability/Variance.lean
@@ -134,7 +134,9 @@ theorem _root_.MeasureTheory.Memℒp.variance_eq [IsFiniteMeasure μ] (hX : Mem�
     ENNReal.toReal_ofReal]
   · rfl
   · exact integral_nonneg fun ω => pow_two_nonneg _
-  · convert (hX.sub <| memℒp_const (μ[X])).integrable_norm_rpow two_ne_zero ENNReal.two_ne_top
+  · -- Porting note: `μ[X]` without whitespace is ambiguous as it could be GetElem,
+    -- and `convert` cannot disambiguate based on typeclass inference failure.
+    convert (hX.sub <| memℒp_const (μ [X])).integrable_norm_rpow two_ne_zero ENNReal.two_ne_top
       with ω
     simp only [Pi.sub_apply, Real.norm_eq_abs, coe_two, ENNReal.one_toReal,
       Real.rpow_two, sq_abs, abs_pow]

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -2402,10 +2402,9 @@ theorem zero_powerlt {a : Cardinal} (h : a ≠ 0) : 0 ^< a = 1 := by
 #align cardinal.zero_powerlt Cardinal.zero_powerlt
 
 @[simp]
-theorem powerlt_zero {a : Cardinal} : a ^< 0 = 0 :=
-  -- Porting note: used to expect that `convert` would leave an instance argument as a goal
-  @Cardinal.iSup_of_empty _ _
-    (Subtype.isEmpty_of_false fun x => mem_Iio.not.mpr (Cardinal.zero_le x).not_lt)
+theorem powerlt_zero {a : Cardinal} : a ^< 0 = 0 := by
+  convert Cardinal.iSup_of_empty _
+  exact Subtype.isEmpty_of_false fun x => mem_Iio.not.mpr (Cardinal.zero_le x).not_lt
 #align cardinal.powerlt_zero Cardinal.powerlt_zero
 
 end Cardinal

--- a/Mathlib/Topology/Gluing.lean
+++ b/Mathlib/Topology/Gluing.lean
@@ -356,8 +356,12 @@ structure MkCore where
 set_option linter.uppercaseLean3 false in
 #align Top.glue_data.mk_core TopCat.GlueData.MkCore
 
-theorem MkCore.t_inv (h : MkCore) (i j : h.J) (x : h.V j i) : h.t i j ((h.t j i) x) = x :=
-Subtype.eq <| by convert h.t_id j ▸ (h.cocycle j i j x <| h.V_id j ▸ ⟨⟩) using 1
+theorem MkCore.t_inv (h : MkCore) (i j : h.J) (x : h.V j i) : h.t i j ((h.t j i) x) = x := by
+  have := h.cocycle j i j x ?_
+  rw [h.t_id] at this
+  convert Subtype.eq this
+  rw [h.V_id]
+  trivial
 set_option linter.uppercaseLean3 false in
 #align Top.glue_data.mk_core.t_inv TopCat.GlueData.MkCore.t_inv
 

--- a/test/convert.lean
+++ b/test/convert.lean
@@ -3,6 +3,8 @@ import Std.Tactic.GuardExpr
 import Mathlib.Algebra.Group.Basic
 import Mathlib.Data.Set.Image
 
+namespace Tests
+
 example (P : Prop) (h : P) : P := by convert h
 
 example (α β : Type) (h : α = β) (b : β) : α := by
@@ -13,7 +15,7 @@ example (α β : Type) (h : ∀ α β : Type, α = β) (b : β) : α := by
   apply h
 
 example (m n : Nat) (h : m = n) (b : Fin n) : Nat × Nat × Nat × Fin m := by
-  convert (37, 57, 2, b)
+  convert (config := { typeEqs := true }) (37, 57, 2, b)
 
 example (α β : Type) (h : α = β) (b : β) : Nat × α := by
   convert (config := { typeEqs := true }) (37, b)
@@ -76,3 +78,24 @@ example (p q : Nat → Prop) (h : ∀ ε > 0, p ε) :
   guard_hyp hε : ε > 0
   guard_target = q ε ↔ p ε
   sorry
+
+class Fintype (α : Type _) where
+  card : Nat
+
+axiom Fintype.foo (α : Type _) [Fintype α] : Fintype.card α = 2
+
+axiom instFintypeBool : Fintype Bool
+
+/- Would be "failed to synthesize instance Fintype ?m" without the special handling to
+remove unsolved-for typeclass metavariables from the pendingMVars list. -/
+example : @Fintype.card Bool instFintypeBool = 2 := by
+  convert Fintype.foo _
+
+example : True := by
+  convert_to ?x + ?y = ?z
+  case x => exact 1
+  case y => exact 2
+  case z => exact 3
+  all_goals try infer_instance
+  · simp
+  · simp

--- a/test/convert.lean
+++ b/test/convert.lean
@@ -84,12 +84,18 @@ class Fintype (α : Type _) where
 
 axiom Fintype.foo (α : Type _) [Fintype α] : Fintype.card α = 2
 
+axiom Fintype.foo' (α : Type _) [Fintype α] [Fintype (Option α)] : Fintype.card α = 2
+
 axiom instFintypeBool : Fintype Bool
 
-/- Would be "failed to synthesize instance Fintype ?m" without the special handling to
-remove unsolved-for typeclass metavariables from the pendingMVars list. -/
+/- Would be "failed to synthesize instance Fintype ?m" without allowing TC failure. -/
 example : @Fintype.card Bool instFintypeBool = 2 := by
   convert Fintype.foo _
+
+example : @Fintype.card Bool instFintypeBool = 2 := by
+  convert Fintype.foo' _ using 1
+  guard_target = Fintype (Option Bool)
+  sorry
 
 example : True := by
   convert_to ?x + ?y = ?z


### PR DESCRIPTION
Changes the way the term is elaborated so that typeclass inference is tolerated and so that instances are allowed to come from the goal without re-inferring them.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
