### PR TITLE
[Merged by Bors] - feat (Mathlib.Topology.MetricSpace.ThickenedIndicator): Add convergence of plain old indicators.

### DIFF
--- a/Mathlib/Topology/MetricSpace/HausdorffDistance.lean
+++ b/Mathlib/Topology/MetricSpace/HausdorffDistance.lean
@@ -909,26 +909,10 @@ theorem mem_thickening_iff_infEdist_lt : x ∈ thickening δ s ↔ infEdist x s 
 (open) thickening `δ`-thickening of `E` for small enough positive `δ`. -/
 lemma eventually_not_mem_thickening_of_infEdist_pos {E : Set α} {x : α} (h : x ∉ closure E) :
     ∀ᶠ δ in 𝓝 (0 : ℝ), x ∉ Metric.thickening δ E := by
---sgouezel Dec 16, 2022
---Suggested change
---  ∀ᶠ δ in 𝓝[>] (0 : ℝ), x ∉ metric.thickening δ E :=
---  ∀ᶠ δ in 𝓝 (0 : ℝ), x ∉ metric.thickening δ E :=
---
---This is a stronger statement, and also true as far as I can tell.
   obtain ⟨ε, ⟨ε_pos, ε_lt⟩⟩ := exists_real_pos_lt_infEdist_of_not_mem_closure h
-  --have obs := Ioo_mem_nhdsWithin_Ioi (show (0 : ℝ) ∈ Ico 0 ε by constructor <;> linarith)
-  --filter_upwards [obs] with δ hδ
-  --simp [thickening, (((ENNReal.ofReal_lt_ofReal_iff ε_pos).mpr hδ.2).trans ε_lt).le]
-  sorry
-
-/-
-lemma eventually_not_mem_thickening_of_infEdist_pos {E : Set α} {x : α} (h : x ∉ closure E) :
-    ∀ᶠ δ in 𝓝[>] (0 : ℝ), x ∉ Metric.thickening δ E := by
-  obtain ⟨ε, ⟨ε_pos, ε_lt⟩⟩ := exists_real_pos_lt_infEdist_of_not_mem_closure h
-  have obs := Ioo_mem_nhdsWithin_Ioi (show (0 : ℝ) ∈ Ico 0 ε by constructor <;> linarith)
-  filter_upwards [obs] with δ hδ
-  simp [thickening, (((ENNReal.ofReal_lt_ofReal_iff ε_pos).mpr hδ.2).trans ε_lt).le]
- -/
+  filter_upwards [Iio_mem_nhds ε_pos] with δ hδ
+  simp only [thickening, mem_setOf_eq, not_lt]
+  exact (((ENNReal.ofReal_lt_ofReal_iff ε_pos).mpr hδ).trans ε_lt).le
 
 /-- The (open) thickening equals the preimage of an open interval under `EMetric.infEdist`. -/
 theorem thickening_eq_preimage_infEdist (δ : ℝ) (E : Set α) :

--- a/Mathlib/Topology/MetricSpace/HausdorffDistance.lean
+++ b/Mathlib/Topology/MetricSpace/HausdorffDistance.lean
@@ -905,6 +905,31 @@ theorem mem_thickening_iff_infEdist_lt : x ∈ thickening δ s ↔ infEdist x s 
   Iff.rfl
 #align metric.mem_thickening_iff_inf_edist_lt Metric.mem_thickening_iff_infEdist_lt
 
+/-- An exterior point of a subset `E` (i.e., a point outside the closure of `E`) is not in the
+(open) thickening `δ`-thickening of `E` for small enough positive `δ`. -/
+lemma eventually_not_mem_thickening_of_infEdist_pos {E : Set α} {x : α} (h : x ∉ closure E) :
+    ∀ᶠ δ in 𝓝 (0 : ℝ), x ∉ Metric.thickening δ E := by
+--sgouezel Dec 16, 2022
+--Suggested change
+--  ∀ᶠ δ in 𝓝[>] (0 : ℝ), x ∉ metric.thickening δ E :=
+--  ∀ᶠ δ in 𝓝 (0 : ℝ), x ∉ metric.thickening δ E :=
+--
+--This is a stronger statement, and also true as far as I can tell.
+  obtain ⟨ε, ⟨ε_pos, ε_lt⟩⟩ := exists_real_pos_lt_infEdist_of_not_mem_closure h
+  --have obs := Ioo_mem_nhdsWithin_Ioi (show (0 : ℝ) ∈ Ico 0 ε by constructor <;> linarith)
+  --filter_upwards [obs] with δ hδ
+  --simp [thickening, (((ENNReal.ofReal_lt_ofReal_iff ε_pos).mpr hδ.2).trans ε_lt).le]
+  sorry
+
+/-
+lemma eventually_not_mem_thickening_of_infEdist_pos {E : Set α} {x : α} (h : x ∉ closure E) :
+    ∀ᶠ δ in 𝓝[>] (0 : ℝ), x ∉ Metric.thickening δ E := by
+  obtain ⟨ε, ⟨ε_pos, ε_lt⟩⟩ := exists_real_pos_lt_infEdist_of_not_mem_closure h
+  have obs := Ioo_mem_nhdsWithin_Ioi (show (0 : ℝ) ∈ Ico 0 ε by constructor <;> linarith)
+  filter_upwards [obs] with δ hδ
+  simp [thickening, (((ENNReal.ofReal_lt_ofReal_iff ε_pos).mpr hδ.2).trans ε_lt).le]
+ -/
+
 /-- The (open) thickening equals the preimage of an open interval under `EMetric.infEdist`. -/
 theorem thickening_eq_preimage_infEdist (δ : ℝ) (E : Set α) :
     thickening δ E = (infEdist · E) ⁻¹' Iio (ENNReal.ofReal δ) :=
@@ -1025,6 +1050,25 @@ def cthickening (δ : ℝ) (E : Set α) : Set α :=
 theorem mem_cthickening_iff : x ∈ cthickening δ s ↔ infEdist x s ≤ ENNReal.ofReal δ :=
   Iff.rfl
 #align metric.mem_cthickening_iff Metric.mem_cthickening_iff
+
+/-- An exterior point of a subset `E` (i.e., a point outside the closure of `E`) is not in the
+closed thickening `δ`-thickening of `E` for small enough positive `δ`. -/
+lemma eventually_not_mem_cthickening_of_inf_edist_pos {E : Set α} {x : α} (h : x ∉ closure E) :
+    ∀ᶠ δ in 𝓝 (0 : ℝ), x ∉ Metric.cthickening δ E := by
+-- sgouezel Dec 16, 2022
+-- ditto
+  obtain ⟨ε, ⟨ε_pos, ε_lt⟩⟩ := exists_real_pos_lt_infEdist_of_not_mem_closure h
+  sorry
+
+
+/-
+lemma eventually_not_mem_cthickening_of_inf_edist_pos {E : Set α} {x : α} (h : x ∉ closure E) :
+    ∀ᶠ δ in 𝓝[>] (0 : ℝ), x ∉ Metric.cthickening δ E := by
+  obtain ⟨ε, ⟨ε_pos, ε_lt⟩⟩ := exists_real_pos_lt_infEdist_of_not_mem_closure h
+  have obs := Ioo_mem_nhdsWithin_Ioi (show (0 : ℝ) ∈ Ico 0 ε by constructor <;> linarith)
+  filter_upwards [obs] with δ hδ
+  simp [cthickening, ((ENNReal.ofReal_lt_ofReal_iff ε_pos).mpr hδ.2).trans ε_lt]
+ -/
 
 theorem mem_cthickening_of_edist_le (x y : α) (δ : ℝ) (E : Set α) (h : y ∈ E)
     (h' : edist x y ≤ ENNReal.ofReal δ) : x ∈ cthickening δ E :=

--- a/Mathlib/Topology/MetricSpace/HausdorffDistance.lean
+++ b/Mathlib/Topology/MetricSpace/HausdorffDistance.lean
@@ -906,7 +906,7 @@ theorem mem_thickening_iff_infEdist_lt : x ∈ thickening δ s ↔ infEdist x s 
 #align metric.mem_thickening_iff_inf_edist_lt Metric.mem_thickening_iff_infEdist_lt
 
 /-- An exterior point of a subset `E` (i.e., a point outside the closure of `E`) is not in the
-(open) thickening `δ`-thickening of `E` for small enough positive `δ`. -/
+(open) `δ`-thickening of `E` for small enough positive `δ`. -/
 lemma eventually_not_mem_thickening_of_infEdist_pos {E : Set α} {x : α} (h : x ∉ closure E) :
     ∀ᶠ δ in 𝓝 (0 : ℝ), x ∉ Metric.thickening δ E := by
   obtain ⟨ε, ⟨ε_pos, ε_lt⟩⟩ := exists_real_pos_lt_infEdist_of_not_mem_closure h
@@ -1036,7 +1036,7 @@ theorem mem_cthickening_iff : x ∈ cthickening δ s ↔ infEdist x s ≤ ENNRea
 #align metric.mem_cthickening_iff Metric.mem_cthickening_iff
 
 /-- An exterior point of a subset `E` (i.e., a point outside the closure of `E`) is not in the
-closed thickening `δ`-thickening of `E` for small enough positive `δ`. -/
+closed `δ`-thickening of `E` for small enough positive `δ`. -/
 lemma eventually_not_mem_cthickening_of_infEdist_pos {E : Set α} {x : α} (h : x ∉ closure E) :
     ∀ᶠ δ in 𝓝 (0 : ℝ), x ∉ Metric.cthickening δ E := by
   obtain ⟨ε, ⟨ε_pos, ε_lt⟩⟩ := exists_real_pos_lt_infEdist_of_not_mem_closure h

--- a/Mathlib/Topology/MetricSpace/HausdorffDistance.lean
+++ b/Mathlib/Topology/MetricSpace/HausdorffDistance.lean
@@ -1037,7 +1037,7 @@ theorem mem_cthickening_iff : x ∈ cthickening δ s ↔ infEdist x s ≤ ENNRea
 
 /-- An exterior point of a subset `E` (i.e., a point outside the closure of `E`) is not in the
 closed thickening `δ`-thickening of `E` for small enough positive `δ`. -/
-lemma eventually_not_mem_cthickening_of_inf_edist_pos {E : Set α} {x : α} (h : x ∉ closure E) :
+lemma eventually_not_mem_cthickening_of_infEdist_pos {E : Set α} {x : α} (h : x ∉ closure E) :
     ∀ᶠ δ in 𝓝 (0 : ℝ), x ∉ Metric.cthickening δ E := by
   obtain ⟨ε, ⟨ε_pos, ε_lt⟩⟩ := exists_real_pos_lt_infEdist_of_not_mem_closure h
   filter_upwards [Iio_mem_nhds ε_pos] with δ hδ

--- a/Mathlib/Topology/MetricSpace/HausdorffDistance.lean
+++ b/Mathlib/Topology/MetricSpace/HausdorffDistance.lean
@@ -910,9 +910,9 @@ theorem mem_thickening_iff_infEdist_lt : x ∈ thickening δ s ↔ infEdist x s 
 lemma eventually_not_mem_thickening_of_infEdist_pos {E : Set α} {x : α} (h : x ∉ closure E) :
     ∀ᶠ δ in 𝓝 (0 : ℝ), x ∉ Metric.thickening δ E := by
   obtain ⟨ε, ⟨ε_pos, ε_lt⟩⟩ := exists_real_pos_lt_infEdist_of_not_mem_closure h
-  filter_upwards [Iio_mem_nhds ε_pos] with δ hδ
+  filter_upwards [eventually_lt_nhds ε_pos] with δ hδ
   simp only [thickening, mem_setOf_eq, not_lt]
-  exact (((ENNReal.ofReal_lt_ofReal_iff ε_pos).mpr hδ).trans ε_lt).le
+  exact (ENNReal.ofReal_le_ofReal hδ.le).trans ε_lt.le
 
 /-- The (open) thickening equals the preimage of an open interval under `EMetric.infEdist`. -/
 theorem thickening_eq_preimage_infEdist (δ : ℝ) (E : Set α) :
@@ -1040,9 +1040,9 @@ closed `δ`-thickening of `E` for small enough positive `δ`. -/
 lemma eventually_not_mem_cthickening_of_infEdist_pos {E : Set α} {x : α} (h : x ∉ closure E) :
     ∀ᶠ δ in 𝓝 (0 : ℝ), x ∉ Metric.cthickening δ E := by
   obtain ⟨ε, ⟨ε_pos, ε_lt⟩⟩ := exists_real_pos_lt_infEdist_of_not_mem_closure h
-  filter_upwards [Iio_mem_nhds ε_pos] with δ hδ
+  filter_upwards [eventually_lt_nhds ε_pos] with δ hδ
   simp only [cthickening, mem_setOf_eq, not_le]
-  exact ((ENNReal.ofReal_lt_ofReal_iff ε_pos).mpr hδ).trans ε_lt
+  exact ((ofReal_lt_ofReal_iff ε_pos).mpr hδ).trans ε_lt
 
 theorem mem_cthickening_of_edist_le (x y : α) (δ : ℝ) (E : Set α) (h : y ∈ E)
     (h' : edist x y ≤ ENNReal.ofReal δ) : x ∈ cthickening δ E :=

--- a/Mathlib/Topology/MetricSpace/HausdorffDistance.lean
+++ b/Mathlib/Topology/MetricSpace/HausdorffDistance.lean
@@ -1039,20 +1039,10 @@ theorem mem_cthickening_iff : x ∈ cthickening δ s ↔ infEdist x s ≤ ENNRea
 closed thickening `δ`-thickening of `E` for small enough positive `δ`. -/
 lemma eventually_not_mem_cthickening_of_inf_edist_pos {E : Set α} {x : α} (h : x ∉ closure E) :
     ∀ᶠ δ in 𝓝 (0 : ℝ), x ∉ Metric.cthickening δ E := by
--- sgouezel Dec 16, 2022
--- ditto
   obtain ⟨ε, ⟨ε_pos, ε_lt⟩⟩ := exists_real_pos_lt_infEdist_of_not_mem_closure h
-  sorry
-
-
-/-
-lemma eventually_not_mem_cthickening_of_inf_edist_pos {E : Set α} {x : α} (h : x ∉ closure E) :
-    ∀ᶠ δ in 𝓝[>] (0 : ℝ), x ∉ Metric.cthickening δ E := by
-  obtain ⟨ε, ⟨ε_pos, ε_lt⟩⟩ := exists_real_pos_lt_infEdist_of_not_mem_closure h
-  have obs := Ioo_mem_nhdsWithin_Ioi (show (0 : ℝ) ∈ Ico 0 ε by constructor <;> linarith)
-  filter_upwards [obs] with δ hδ
-  simp [cthickening, ((ENNReal.ofReal_lt_ofReal_iff ε_pos).mpr hδ.2).trans ε_lt]
- -/
+  filter_upwards [Iio_mem_nhds ε_pos] with δ hδ
+  simp only [cthickening, mem_setOf_eq, not_le]
+  exact ((ENNReal.ofReal_lt_ofReal_iff ε_pos).mpr hδ).trans ε_lt
 
 theorem mem_cthickening_of_edist_le (x y : α) (δ : ℝ) (E : Set α) (h : y ∈ E)
     (h' : edist x y ≤ ENNReal.ofReal δ) : x ∈ cthickening δ E :=

--- a/Mathlib/Topology/MetricSpace/ThickenedIndicator.lean
+++ b/Mathlib/Topology/MetricSpace/ThickenedIndicator.lean
@@ -263,11 +263,12 @@ lemma mulIndicator_thickening_eventually_eq_mulIndicator_closure (f : α → β)
   by_cases x_mem_closure : x ∈ closure E
   · filter_upwards [self_mem_nhdsWithin] with δ δ_pos
     simp only [closure_subset_thickening δ_pos E x_mem_closure, mulIndicator_of_mem, x_mem_closure]
-  · have obs := (eventually_not_mem_thickening_of_infEdist_pos x_mem_closure)
+  · have obs := eventually_not_mem_thickening_of_infEdist_pos x_mem_closure
     filter_upwards [inter_mem (mem_nhdsWithin_of_mem_nhds obs) self_mem_nhdsWithin]
       with δ ⟨x_notin_thE, δ_pos⟩
     simp only [mem_setOf_eq] at x_notin_thE
-    have x_notin_clE : x ∉ closure E := fun con ↦ x_notin_thE (closure_subset_thickening δ_pos E con)
+    have x_notin_clE : x ∉ closure E :=
+      fun con ↦ x_notin_thE (closure_subset_thickening δ_pos E con)
     simp only [x_notin_thE, not_false_eq_true, mulIndicator_of_not_mem, x_notin_clE]
 
 /-- Pointwise, the (mul)indicators of closed δ-thickenings of a set eventually coincide with the

--- a/Mathlib/Topology/MetricSpace/ThickenedIndicator.lean
+++ b/Mathlib/Topology/MetricSpace/ThickenedIndicator.lean
@@ -254,9 +254,9 @@ section indicator
 
 variable {α : Type _} [PseudoEMetricSpace α] {β : Type _} [One β]
 
-/-- Pointwise, the multiplicative indicators of δ-thickenings of a set eventually coincide 
+/-- Pointwise, the multiplicative indicators of δ-thickenings of a set eventually coincide
 with the multiplicative indicator of the set as δ>0 tends to zero. -/
-@[to_additive "Pointwise, the indicators of δ-thickenings of a set eventually coincide 
+@[to_additive "Pointwise, the indicators of δ-thickenings of a set eventually coincide
 with the indicator of the set as δ>0 tends to zero."]
 lemma mulIndicator_thickening_eventually_eq_mulIndicator_closure (f : α → β) (E : Set α) (x : α) :
     ∀ᶠ δ in 𝓝[>] (0 : ℝ),
@@ -272,9 +272,10 @@ lemma mulIndicator_thickening_eventually_eq_mulIndicator_closure (f : α → β)
       fun con ↦ x_notin_thE (closure_subset_thickening δ_pos E con)
     simp only [x_notin_thE, not_false_eq_true, mulIndicator_of_not_mem, x_notin_clE]
 
-/-- Pointwise, the (mul)indicators of closed δ-thickenings of a set eventually coincide with the
-(mul)indicator of the set as δ tends to zero. -/
-@[to_additive]
+/-- Pointwise, the multiplicative indicators of closed δ-thickenings of a set eventually coincide
+with the multiplicative indicator of the set as δ tends to zero. -/
+@[to_additive "Pointwise, the indicators of closed δ-thickenings of a set eventually coincide
+with the indicator of the set as δ tends to zero."]
 lemma mulIndicator_cthickening_eventually_eq_mulIndicator_closure (f : α → β) (E : Set α) (x : α) :
     ∀ᶠ δ in 𝓝 (0 : ℝ),
       (Metric.cthickening δ E).mulIndicator f x = (closure E).mulIndicator f x := by
@@ -288,9 +289,10 @@ lemma mulIndicator_cthickening_eventually_eq_mulIndicator_closure (f : α → β
 
 variable [TopologicalSpace β]
 
-/-- The (mul)indicators of δ-thickenings of a set tend pointwise to the (mul)-indicator of
-the set, as δ>0 tends to zero. -/
-@[to_additive]
+/-- The multiplicative indicators of δ-thickenings of a set tend pointwise to the multiplicative
+indicator of the set, as δ>0 tends to zero. -/
+@[to_additive "The indicators of δ-thickenings of a set tend pointwise to the indicator of the
+set, as δ>0 tends to zero."]
 lemma tendsto_mulIndicator_thickening_mulIndicator_closure (f : α → β) (E : Set α) :
     Tendsto (fun δ ↦ (Metric.thickening δ E).mulIndicator f) (𝓝[>] 0)
       (𝓝 ((closure E).mulIndicator f)) := by
@@ -299,9 +301,10 @@ lemma tendsto_mulIndicator_thickening_mulIndicator_closure (f : α → β) (E : 
   rw [tendsto_congr' (mulIndicator_thickening_eventually_eq_mulIndicator_closure f E x)]
   apply tendsto_const_nhds
 
-/-- The (mul)indicators of closed δ-thickenings of a set tend pointwise to the
-(mul)-indicator of the set, as δ tends to zero. -/
-@[to_additive]
+/-- The multiplicative indicators of closed δ-thickenings of a set tend pointwise to the
+multiplicative indicator of the set, as δ tends to zero. -/
+@[to_additive "The indicators of closed δ-thickenings of a set tend pointwise to the indicator
+of the set, as δ tends to zero."]
 lemma tendsto_mulIndicator_cthickening_mulIndicator_closure (f : α → β) (E : Set α) :
     Tendsto (fun δ ↦ (Metric.cthickening δ E).mulIndicator f) (𝓝 0)
       (𝓝 ((closure E).mulIndicator f)) := by

--- a/Mathlib/Topology/MetricSpace/ThickenedIndicator.lean
+++ b/Mathlib/Topology/MetricSpace/ThickenedIndicator.lean
@@ -301,7 +301,7 @@ lemma tendsto_mulIndicator_thickening_mulIndicator_closure (f : α → β) (E : 
 /-- The (mul)indicators of closed δ-thickenings of a set tend pointwise to the
 (mul)-indicator of the set, as δ tends to zero. -/
 @[to_additive]
-lemma tendsto_mul_indicator_cthickening_mulIndicator_closure (f : α → β) (E : Set α) :
+lemma tendsto_mulIndicator_cthickening_mulIndicator_closure (f : α → β) (E : Set α) :
     Tendsto (fun δ ↦ (Metric.cthickening δ E).mulIndicator f) (𝓝 0)
       (𝓝 ((closure E).mulIndicator f)) := by
   rw [tendsto_pi_nhds]

--- a/Mathlib/Topology/MetricSpace/ThickenedIndicator.lean
+++ b/Mathlib/Topology/MetricSpace/ThickenedIndicator.lean
@@ -254,9 +254,10 @@ section indicator
 
 variable {α : Type _} [PseudoEMetricSpace α] {β : Type _} [One β]
 
-/-- Pointwise, the (mul)indicators of δ-thickenings of a set eventually coincide with the
-(mul)indicator of the set as δ>0 tends to zero. -/
-@[to_additive]
+/-- Pointwise, the multiplicative indicators of δ-thickenings of a set eventually coincide 
+with the multiplicative indicator of the set as δ>0 tends to zero. -/
+@[to_additive "Pointwise, the indicators of δ-thickenings of a set eventually coincide 
+with the indicator of the set as δ>0 tends to zero."]
 lemma mulIndicator_thickening_eventually_eq_mulIndicator_closure (f : α → β) (E : Set α) (x : α) :
     ∀ᶠ δ in 𝓝[>] (0 : ℝ),
       (Metric.thickening δ E).mulIndicator f x = (closure E).mulIndicator f x := by

--- a/Mathlib/Topology/MetricSpace/ThickenedIndicator.lean
+++ b/Mathlib/Topology/MetricSpace/ThickenedIndicator.lean
@@ -266,11 +266,8 @@ lemma mulIndicator_thickening_eventually_eq_mulIndicator_closure (f : α → β)
     simp only [closure_subset_thickening δ_pos E x_mem_closure, mulIndicator_of_mem, x_mem_closure]
   · have obs := eventually_not_mem_thickening_of_infEdist_pos x_mem_closure
     filter_upwards [mem_nhdsWithin_of_mem_nhds obs, self_mem_nhdsWithin]
-      with δ x_notin_thE δ_pos
-    simp only [mem_setOf_eq] at x_notin_thE
-    have x_notin_clE : x ∉ closure E :=
-      fun con ↦ x_notin_thE (closure_subset_thickening δ_pos E con)
-    simp only [x_notin_thE, not_false_eq_true, mulIndicator_of_not_mem, x_notin_clE]
+      with δ x_notin_thE _
+    simp only [x_notin_thE, not_false_eq_true, mulIndicator_of_not_mem, x_mem_closure]
 
 /-- Pointwise, the multiplicative indicators of closed δ-thickenings of a set eventually coincide
 with the multiplicative indicator of the set as δ tends to zero. -/
@@ -284,8 +281,7 @@ lemma mulIndicator_cthickening_eventually_eq_mulIndicator_closure (f : α → β
     have obs : x ∈ cthickening δ E := closure_subset_cthickening δ E x_mem_closure
     rw [mulIndicator_of_mem obs f, mulIndicator_of_mem x_mem_closure f]
   · filter_upwards [eventually_not_mem_cthickening_of_infEdist_pos x_mem_closure] with δ hδ
-    have x_notin_clE : x ∉ closure E := fun con ↦ hδ (closure_subset_cthickening δ E con)
-    simp only [hδ, not_false_eq_true, mulIndicator_of_not_mem, x_notin_clE]
+    simp only [hδ, not_false_eq_true, mulIndicator_of_not_mem, x_mem_closure]
 
 variable [TopologicalSpace β]
 

--- a/Mathlib/Topology/MetricSpace/ThickenedIndicator.lean
+++ b/Mathlib/Topology/MetricSpace/ThickenedIndicator.lean
@@ -6,6 +6,7 @@ Authors: Kalle Kytölä
 import Mathlib.Data.Real.ENNReal
 import Mathlib.Topology.ContinuousFunction.Bounded
 import Mathlib.Topology.MetricSpace.HausdorffDistance
+import Mathlib.Order.Filter.IndicatorFunction
 
 #align_import topology.metric_space.thickened_indicator from "leanprover-community/mathlib"@"f2ce6086713c78a7f880485f7917ea547a215982"
 
@@ -248,3 +249,86 @@ theorem thickenedIndicator_tendsto_indicator_closure {δseq : ℕ → ℝ} (δse
 #align thickened_indicator_tendsto_indicator_closure thickenedIndicator_tendsto_indicator_closure
 
 end thickenedIndicator
+
+
+section indicator
+
+variable {α : Type _} [PseudoEMetricSpace α] {β : Type _} [One β]
+
+@[to_additive]
+--Collaborator
+--@sgouezel sgouezel Dec 16, 2022
+--
+--add a docstring to this one?
+--@kkytola
+
+lemma mul_indicator_thickening_eventually_eq_mul_indicator_closure (f : α → β) (E : Set α) (x : α) :
+    ∀ᶠ δ in 𝓝[>] (0 : ℝ),
+      (Metric.thickening δ E).mulIndicator f x = (closure E).mulIndicator f x := by
+  --by_cases x_mem_closure : x ∈ closure E,
+  --{ filter_upwards [self_mem_nhds_within] with δ δ_pos,
+  --  simp only [x_mem_closure, closure_subset_thickening δ_pos E x_mem_closure,
+  --             mul_indicator_of_mem], },
+  --{ have obs := eventually_not_mem_thickening_of_inf_edist_pos x_mem_closure,
+  --  filter_upwards [obs] with δ hδ,
+  --  simp only [hδ, x_mem_closure, mul_indicator_of_not_mem, not_false_iff], },
+  sorry
+
+@[to_additive]
+lemma mulIndicator_cthickening_eventually_eq_mulIndicator_closure
+  (f : α → β) (E : Set α) (x : α) :
+  ∀ᶠ δ in 𝓝[>] (0 : ℝ), ∀ᶠ δ in 𝓝[>] (0 : ℝ),
+--Collaborator
+--@sgouezel sgouezel Dec 16, 2022
+--Suggested change
+--  ∀ᶠ δ in 𝓝[>] (0 : ℝ),
+--  ∀ᶠ δ in 𝓝 (0 : ℝ),
+--
+--?? Is this stronger version true?
+--@kkytola
+    (Metric.cthickening δ E).mulIndicator f x = (closure E).mulIndicator f x := by
+  --by_cases x_mem_closure : x ∈ closure E,
+  --{ filter_upwards [univ_mem] with δ rubbish,
+  --  simp only [x_mem_closure, closure_subset_cthickening δ E x_mem_closure,
+  --             mul_indicator_of_mem], },
+  --{ have obs := eventually_not_mem_cthickening_of_inf_edist_pos x_mem_closure,
+  --  filter_upwards [obs] with δ hδ,
+  --  simp only [hδ, x_mem_closure, mul_indicator_of_not_mem, not_false_iff], },
+  sorry
+
+variable [TopologicalSpace β]
+
+@[to_additive]
+lemma tendsto_mulIndicator_thickening_mulIndicator_closure (f : α → β) (E : Set α) :
+  Tendsto (fun δ ↦ (Metric.thickening δ E).mulIndicator f) (𝓝[>] 0)
+    (𝓝 (mulIndicator (closure E) f)) := by
+  --rw tendsto_pi_nhds,
+  --intro x,
+  --rw tendsto_congr' (mul_indicator_thickening_eventually_eq_mul_indicator_closure f E x),
+  --apply tendsto_const_nhds,
+  sorry
+
+@[to_additive]
+lemma tendsto_mul_indicator_cthickening_mul_indicator_closure (f : α → β) (E : Set α) :
+    Tendsto (fun δ ↦ (Metric.cthickening δ E).mulIndicator f) (𝓝[>] 0)
+      (𝓝 (mulIndicator (closure E) f)) := by
+--Collaborator
+--@sgouezel sgouezel Dec 16, 2022
+--Suggested change
+--  tendsto (λ δ, (metric.cthickening δ E).mul_indicator f) (𝓝[>] 0)
+--  tendsto (λ δ, (metric.cthickening δ E).mul_indicator f) (𝓝 0)
+--
+--??
+--@kkytola
+--Collaborator
+--@sgouezel sgouezel Dec 16, 2022
+--
+--In the rest of the file, you use dot notation for the mul_indicator, so you might as well do it here.
+--@kkytola
+  --rw tendsto_pi_nhds,
+  --intro x,
+  --rw tendsto_congr' (mul_indicator_cthickening_eventually_eq_mul_indicator_closure f E x),
+  --apply tendsto_const_nhds,
+  sorry
+
+end indicator

--- a/Mathlib/Topology/MetricSpace/ThickenedIndicator.lean
+++ b/Mathlib/Topology/MetricSpace/ThickenedIndicator.lean
@@ -255,80 +255,58 @@ section indicator
 
 variable {α : Type _} [PseudoEMetricSpace α] {β : Type _} [One β]
 
+/-- Pointwise, the (mul)indicators of δ-thickenings of a set eventually coincide with the
+(mul)-indicator of the set as δ>0 tends to zero. -/
 @[to_additive]
---Collaborator
---@sgouezel sgouezel Dec 16, 2022
---
---add a docstring to this one?
---@kkytola
-
-lemma mul_indicator_thickening_eventually_eq_mul_indicator_closure (f : α → β) (E : Set α) (x : α) :
+lemma mulIndicator_thickening_eventually_eq_mulIndicator_closure (f : α → β) (E : Set α) (x : α) :
     ∀ᶠ δ in 𝓝[>] (0 : ℝ),
       (Metric.thickening δ E).mulIndicator f x = (closure E).mulIndicator f x := by
-  --by_cases x_mem_closure : x ∈ closure E,
-  --{ filter_upwards [self_mem_nhds_within] with δ δ_pos,
-  --  simp only [x_mem_closure, closure_subset_thickening δ_pos E x_mem_closure,
-  --             mul_indicator_of_mem], },
-  --{ have obs := eventually_not_mem_thickening_of_inf_edist_pos x_mem_closure,
-  --  filter_upwards [obs] with δ hδ,
-  --  simp only [hδ, x_mem_closure, mul_indicator_of_not_mem, not_false_iff], },
-  sorry
+  by_cases x_mem_closure : x ∈ closure E
+  · filter_upwards [self_mem_nhdsWithin] with δ δ_pos
+    simp only [closure_subset_thickening δ_pos E x_mem_closure, mulIndicator_of_mem, x_mem_closure]
+  · have obs := (eventually_not_mem_thickening_of_infEdist_pos x_mem_closure)
+    filter_upwards [inter_mem (mem_nhdsWithin_of_mem_nhds obs) self_mem_nhdsWithin]
+      with δ ⟨x_notin_thE, δ_pos⟩
+    simp only [mem_setOf_eq] at x_notin_thE
+    have x_notin_clE : x ∉ closure E := fun con ↦ x_notin_thE (closure_subset_thickening δ_pos E con)
+    simp only [x_notin_thE, not_false_eq_true, mulIndicator_of_not_mem, x_notin_clE]
 
+/-- Pointwise, the (mul)indicators of closed δ-thickenings of a set eventually coincide with the
+(mul)-indicator of the set as δ tends to zero. -/
 @[to_additive]
-lemma mulIndicator_cthickening_eventually_eq_mulIndicator_closure
-  (f : α → β) (E : Set α) (x : α) :
-  ∀ᶠ δ in 𝓝[>] (0 : ℝ), ∀ᶠ δ in 𝓝[>] (0 : ℝ),
---Collaborator
---@sgouezel sgouezel Dec 16, 2022
---Suggested change
---  ∀ᶠ δ in 𝓝[>] (0 : ℝ),
---  ∀ᶠ δ in 𝓝 (0 : ℝ),
---
---?? Is this stronger version true?
---@kkytola
-    (Metric.cthickening δ E).mulIndicator f x = (closure E).mulIndicator f x := by
-  --by_cases x_mem_closure : x ∈ closure E,
-  --{ filter_upwards [univ_mem] with δ rubbish,
-  --  simp only [x_mem_closure, closure_subset_cthickening δ E x_mem_closure,
-  --             mul_indicator_of_mem], },
-  --{ have obs := eventually_not_mem_cthickening_of_inf_edist_pos x_mem_closure,
-  --  filter_upwards [obs] with δ hδ,
-  --  simp only [hδ, x_mem_closure, mul_indicator_of_not_mem, not_false_iff], },
-  sorry
+lemma mulIndicator_cthickening_eventually_eq_mulIndicator_closure (f : α → β) (E : Set α) (x : α) :
+    ∀ᶠ δ in 𝓝 (0 : ℝ),
+      (Metric.cthickening δ E).mulIndicator f x = (closure E).mulIndicator f x := by
+  by_cases x_mem_closure : x ∈ closure E
+  · filter_upwards [univ_mem] with δ _
+    have obs : x ∈ cthickening δ E := closure_subset_cthickening δ E x_mem_closure
+    rw [mulIndicator_of_mem obs f, mulIndicator_of_mem x_mem_closure f]
+  · filter_upwards [eventually_not_mem_cthickening_of_infEdist_pos x_mem_closure] with δ hδ
+    have x_notin_clE : x ∉ closure E := fun con ↦ hδ (closure_subset_cthickening δ E con)
+    simp only [hδ, not_false_eq_true, mulIndicator_of_not_mem, x_notin_clE]
 
 variable [TopologicalSpace β]
 
+/-- The (mul)indicators of δ-thickenings of a set tend pointwise to the (mul)-indicator of
+the set, as δ>0 tends to zero. -/
 @[to_additive]
 lemma tendsto_mulIndicator_thickening_mulIndicator_closure (f : α → β) (E : Set α) :
-  Tendsto (fun δ ↦ (Metric.thickening δ E).mulIndicator f) (𝓝[>] 0)
-    (𝓝 (mulIndicator (closure E) f)) := by
-  --rw tendsto_pi_nhds,
-  --intro x,
-  --rw tendsto_congr' (mul_indicator_thickening_eventually_eq_mul_indicator_closure f E x),
-  --apply tendsto_const_nhds,
-  sorry
+    Tendsto (fun δ ↦ (Metric.thickening δ E).mulIndicator f) (𝓝[>] 0)
+      (𝓝 ((closure E).mulIndicator f)) := by
+  rw [tendsto_pi_nhds]
+  intro x
+  rw [tendsto_congr' (mulIndicator_thickening_eventually_eq_mulIndicator_closure f E x)]
+  apply tendsto_const_nhds
 
+/-- The (mul)indicators of closed δ-thickenings of a set tend pointwise to the
+(mul)-indicator of the set, as δ tends to zero. -/
 @[to_additive]
-lemma tendsto_mul_indicator_cthickening_mul_indicator_closure (f : α → β) (E : Set α) :
-    Tendsto (fun δ ↦ (Metric.cthickening δ E).mulIndicator f) (𝓝[>] 0)
-      (𝓝 (mulIndicator (closure E) f)) := by
---Collaborator
---@sgouezel sgouezel Dec 16, 2022
---Suggested change
---  tendsto (λ δ, (metric.cthickening δ E).mul_indicator f) (𝓝[>] 0)
---  tendsto (λ δ, (metric.cthickening δ E).mul_indicator f) (𝓝 0)
---
---??
---@kkytola
---Collaborator
---@sgouezel sgouezel Dec 16, 2022
---
---In the rest of the file, you use dot notation for the mul_indicator, so you might as well do it here.
---@kkytola
-  --rw tendsto_pi_nhds,
-  --intro x,
-  --rw tendsto_congr' (mul_indicator_cthickening_eventually_eq_mul_indicator_closure f E x),
-  --apply tendsto_const_nhds,
-  sorry
+lemma tendsto_mul_indicator_cthickening_mulIndicator_closure (f : α → β) (E : Set α) :
+    Tendsto (fun δ ↦ (Metric.cthickening δ E).mulIndicator f) (𝓝 0)
+      (𝓝 ((closure E).mulIndicator f)) := by
+  rw [tendsto_pi_nhds]
+  intro x
+  rw [tendsto_congr' (mulIndicator_cthickening_eventually_eq_mulIndicator_closure f E x)]
+  apply tendsto_const_nhds
 
 end indicator

--- a/Mathlib/Topology/MetricSpace/ThickenedIndicator.lean
+++ b/Mathlib/Topology/MetricSpace/ThickenedIndicator.lean
@@ -250,13 +250,12 @@ theorem thickenedIndicator_tendsto_indicator_closure {δseq : ℕ → ℝ} (δse
 
 end thickenedIndicator
 
-
 section indicator
 
 variable {α : Type _} [PseudoEMetricSpace α] {β : Type _} [One β]
 
 /-- Pointwise, the (mul)indicators of δ-thickenings of a set eventually coincide with the
-(mul)-indicator of the set as δ>0 tends to zero. -/
+(mul)indicator of the set as δ>0 tends to zero. -/
 @[to_additive]
 lemma mulIndicator_thickening_eventually_eq_mulIndicator_closure (f : α → β) (E : Set α) (x : α) :
     ∀ᶠ δ in 𝓝[>] (0 : ℝ),
@@ -272,7 +271,7 @@ lemma mulIndicator_thickening_eventually_eq_mulIndicator_closure (f : α → β)
     simp only [x_notin_thE, not_false_eq_true, mulIndicator_of_not_mem, x_notin_clE]
 
 /-- Pointwise, the (mul)indicators of closed δ-thickenings of a set eventually coincide with the
-(mul)-indicator of the set as δ tends to zero. -/
+(mul)indicator of the set as δ tends to zero. -/
 @[to_additive]
 lemma mulIndicator_cthickening_eventually_eq_mulIndicator_closure (f : α → β) (E : Set α) (x : α) :
     ∀ᶠ δ in 𝓝 (0 : ℝ),

--- a/Mathlib/Topology/MetricSpace/ThickenedIndicator.lean
+++ b/Mathlib/Topology/MetricSpace/ThickenedIndicator.lean
@@ -265,8 +265,8 @@ lemma mulIndicator_thickening_eventually_eq_mulIndicator_closure (f : α → β)
   · filter_upwards [self_mem_nhdsWithin] with δ δ_pos
     simp only [closure_subset_thickening δ_pos E x_mem_closure, mulIndicator_of_mem, x_mem_closure]
   · have obs := eventually_not_mem_thickening_of_infEdist_pos x_mem_closure
-    filter_upwards [inter_mem (mem_nhdsWithin_of_mem_nhds obs) self_mem_nhdsWithin]
-      with δ ⟨x_notin_thE, δ_pos⟩
+    filter_upwards [mem_nhdsWithin_of_mem_nhds obs, self_mem_nhdsWithin]
+      with δ x_notin_thE δ_pos
     simp only [mem_setOf_eq] at x_notin_thE
     have x_notin_clE : x ∉ closure E :=
       fun con ↦ x_notin_thE (closure_subset_thickening δ_pos E con)


### PR DESCRIPTION
Add lemmas `tendsto_indicator_thickening_indicator_closure` and `tendsto_indicator_cthickening_indicator_closure`.

Co-authored-by: @sgouezel and @urkud

---

This was PR [mathlib3#17648](https://github.com/leanprover-community/mathlib/pull/17648). There were reviews by @sgouezel and @urkud, but I temporarily abandoned the PR during the semester and the ongoing port to Mathlib4. This Mathlib4 PR takes into account the review comments from the mathlib3 PR.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: @sgouezel and @urkud

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
