### PR TITLE
[Merged by Bors] - feat: (Mathlib.Data.Matrix.Rank): rank of a matrix unaffected by multiplication with invertible matrices

### DIFF
--- a/Mathlib/Data/Matrix/Rank.lean
+++ b/Mathlib/Data/Matrix/Rank.lean
@@ -280,22 +280,19 @@ section MulNonsingInv
 /-! ### Lemmas about pre or post multiplying by an invertible matrix. -/
 
 /-- Pre (Left) multiplying by an invertible matrix does not change the rank -/
-lemma rank_mul_IsUnit {m n R: Type}
-  [Fintype n][DecidableEq n][CommRing R]
-  (A: Matrix n n R)(B: Matrix m n R)(hA: IsUnit A.det):
-  (B⬝A).rank = B.rank := by
+lemma rank_mul_IsUnit {m n R: Type} [Fintype n] [DecidableEq n] [CommRing R]
+    (A: Matrix n n R) (B: Matrix m n R) (hA: IsUnit A.det) :
+    (B ⬝ A).rank = B.rank := by
   rw [Matrix.rank, mulVecLin_mul, LinearMap.range_comp_of_range_eq_top, ←Matrix.rank ]
-  rw [LinearMap.range_eq_top]
-  intros x
+  rw [LinearMap.range_eq_top] -- On separate line since implicit rfl works in prev line
+  intro x
   use ((A⁻¹).mulVecLin x)
-  rw [mulVecLin_apply, mulVecLin_apply, mulVec_mulVec, mul_nonsing_inv, one_mulVec]
-  exact hA
+  rwa [mulVecLin_apply, mulVecLin_apply, mulVec_mulVec, mul_nonsing_inv, one_mulVec]
 
 /-- Post (right) multiplying by an invertible matrix does not change the rank -/
-lemma rank_IsUnit_mul {m n R: Type}
-  [Fintype m][Fintype n][DecidableEq m][Field R]
-  (A: Matrix m m R)(B: Matrix m n R)(hA: IsUnit A.det):
-  (A⬝B).rank = B.rank := by
+lemma rank_IsUnit_mul {m n R: Type} [Fintype m] [Fintype n] [DecidableEq m] [Field R]
+    (A: Matrix m m R) (B: Matrix m n R) (hA: IsUnit A.det):
+    (A ⬝ B).rank = B.rank := by
   suffices h: LinearMap.ker ((A⬝B).mulVecLin) = LinearMap.ker (B.mulVecLin)
   have hB := LinearMap.finrank_range_add_finrank_ker (B.mulVecLin)
   rw [← LinearMap.finrank_range_add_finrank_ker ((A⬝B).mulVecLin), h, add_left_inj] at hB
@@ -304,9 +301,8 @@ lemma rank_IsUnit_mul {m n R: Type}
   rw [LinearMap.ker_eq_bot]
   simp_rw [Function.Injective, mulVecLin_apply]
   intros x y h
-  replace h := congr_arg (fun x => Matrix.mulVec (A⁻¹) x)  h
-  simp_rw [mulVec_mulVec, nonsing_inv_mul A hA, one_mulVec] at h
-  exact h
+  apply_fun Matrix.mulVec (A⁻¹) at h
+  simpa [mulVec_mulVec, nonsing_inv_mul A hA, one_mulVec] using h
 
 end MulNonsingInv
 

--- a/Mathlib/Data/Matrix/Rank.lean
+++ b/Mathlib/Data/Matrix/Rank.lean
@@ -278,7 +278,7 @@ theorem rank_eq_finrank_span_row [LinearOrderedField R] [Finite m] (A : Matrix m
 /-! ### Lemmas about left or right multiplying by an invertible matrix. -/
 
 /-- Right multiplying by an invertible matrix does not change the rank -/
-lemma rank_mul_eq_left_of_isUnitDet [DecidableEq n] [CommRing R]
+lemma rank_mul_eq_left_of_isUnit_det [DecidableEq n] [CommRing R]
     (A : Matrix n n R) (B : Matrix m n R) (hA : IsUnit A.det) :
     (B ⬝ A).rank = B.rank := by
   suffices : Function.Surjective A.mulVecLin

--- a/Mathlib/Data/Matrix/Rank.lean
+++ b/Mathlib/Data/Matrix/Rank.lean
@@ -281,7 +281,7 @@ section MulNonsingInv
 
 /-- Pre (Left) multiplying by an invertible matrix does not change the rank -/
 lemma rank_mul_isUnit [DecidableEq n] [CommRing R]
-    (A: Matrix n n R) (B: Matrix m n R) (hA: IsUnit A.det) :
+    (A : Matrix n n R) (B : Matrix m n R) (hA : IsUnit A.det) :
     (B ⬝ A).rank = B.rank := by
   rw [Matrix.rank, mulVecLin_mul, LinearMap.range_comp_of_range_eq_top, ←Matrix.rank ]
   rw [LinearMap.range_eq_top] -- On separate line since implicit rfl works in prev line

--- a/Mathlib/Data/Matrix/Rank.lean
+++ b/Mathlib/Data/Matrix/Rank.lean
@@ -283,11 +283,12 @@ section MulNonsingInv
 lemma rank_mul_isUnit [DecidableEq n] [CommRing R]
     (A : Matrix n n R) (B : Matrix m n R) (hA : IsUnit A.det) :
     (B ⬝ A).rank = B.rank := by
-  rw [Matrix.rank, mulVecLin_mul, LinearMap.range_comp_of_range_eq_top, ←Matrix.rank]
-  · rw [LinearMap.range_eq_top]
+  have hlT : LinearMap.range (mulVecLin A) = ⊤ := by
+    rw [LinearMap.range_eq_top]
     intro x
     use ((A⁻¹).mulVecLin x)
-    rwa [mulVecLin_apply, mulVecLin_apply, mulVec_mulVec, mul_nonsing_inv, one_mulVec]
+    rw [mulVecLin_apply, mulVecLin_apply, mulVec_mulVec, mul_nonsing_inv _ hA, one_mulVec]
+  rw [Matrix.rank, mulVecLin_mul, LinearMap.range_comp_of_range_eq_top _ hlT, ←Matrix.rank]
 
 /-- Post (right) multiplying by an invertible matrix does not change the rank -/
 lemma rank_isUnit_mul [DecidableEq m] [Field R]

--- a/Mathlib/Data/Matrix/Rank.lean
+++ b/Mathlib/Data/Matrix/Rank.lean
@@ -284,10 +284,10 @@ lemma rank_mul_isUnit [DecidableEq n] [CommRing R]
     (A : Matrix n n R) (B : Matrix m n R) (hA : IsUnit A.det) :
     (B ⬝ A).rank = B.rank := by
   rw [Matrix.rank, mulVecLin_mul, LinearMap.range_comp_of_range_eq_top, ←Matrix.rank]
-  rw [LinearMap.range_eq_top] -- On separate line since implicit rfl works in prev line
-  intro x
-  use ((A⁻¹).mulVecLin x)
-  rwa [mulVecLin_apply, mulVecLin_apply, mulVec_mulVec, mul_nonsing_inv, one_mulVec]
+  · rw [LinearMap.range_eq_top] 
+    intro x
+    use ((A⁻¹).mulVecLin x)
+    rwa [mulVecLin_apply, mulVecLin_apply, mulVec_mulVec, mul_nonsing_inv, one_mulVec]
 
 /-- Post (right) multiplying by an invertible matrix does not change the rank -/
 lemma rank_isUnit_mul [DecidableEq m] [Field R]

--- a/Mathlib/Data/Matrix/Rank.lean
+++ b/Mathlib/Data/Matrix/Rank.lean
@@ -275,8 +275,6 @@ theorem rank_eq_finrank_span_row [LinearOrderedField R] [Finite m] (A : Matrix m
   rw [← rank_transpose, rank_eq_finrank_span_cols, transpose_transpose]
 #align matrix.rank_eq_finrank_span_row Matrix.rank_eq_finrank_span_row
 
-section MulNonsingInv
-
 /-! ### Lemmas about left or right multiplying by an invertible matrix. -/
 
 /-- Right multiplying by an invertible matrix does not change the rank -/
@@ -298,7 +296,5 @@ lemma rank_mul_eq_right_of_isUnitDet [DecidableEq m] [CommRing R]
     convert hA; rw [← LinearEquiv.eq_symm_apply]; rfl
   have hAB : mulVecLin (A ⬝ B) = (LinearEquiv.ofIsUnitDet hA).comp (mulVecLin B) := by ext; simp
   rw [rank, rank, hAB, LinearMap.range_comp, LinearEquiv.finrank_map_eq]
-
-end MulNonsingInv
 
 end Matrix

--- a/Mathlib/Data/Matrix/Rank.lean
+++ b/Mathlib/Data/Matrix/Rank.lean
@@ -292,7 +292,7 @@ lemma rank_mul_isUnit [DecidableEq n] [CommRing R]
 
 /-- Post (right) multiplying by an invertible matrix does not change the rank -/
 lemma rank_isUnit_mul [DecidableEq m] [Field R]
-    (A : Matrix m m R) (B : Matrix m n R) (hA : IsUnit A.det):
+    (A : Matrix m m R) (B : Matrix m n R) (hA : IsUnit A.det) :
     (A ⬝ B).rank = B.rank := by
   suffices h: LinearMap.ker ((A⬝B).mulVecLin) = LinearMap.ker (B.mulVecLin)
   · have hB := LinearMap.finrank_range_add_finrank_ker (B.mulVecLin)

--- a/Mathlib/Data/Matrix/Rank.lean
+++ b/Mathlib/Data/Matrix/Rank.lean
@@ -281,7 +281,6 @@ section MulNonsingInv
 
 /-- Pre (Left) multiplying by an invertible matrix does not change the rank -/
 lemma rank_mul_IsUnit {m n R: Type}
-  -- [Fintype m] -- not needed according to linter
   [Fintype n][DecidableEq n][CommRing R]
   (A: Matrix n n R)(B: Matrix m n R)(hA: IsUnit A.det):
   (B⬝A).rank = B.rank := by

--- a/Mathlib/Data/Matrix/Rank.lean
+++ b/Mathlib/Data/Matrix/Rank.lean
@@ -284,24 +284,24 @@ lemma rank_mul_isUnit [DecidableEq n] [CommRing R]
     (A : Matrix n n R) (B : Matrix m n R) (hA : IsUnit A.det) :
     (B ⬝ A).rank = B.rank := by
   rw [Matrix.rank, mulVecLin_mul, LinearMap.range_comp_of_range_eq_top, ←Matrix.rank]
-  · rw [LinearMap.range_eq_top] 
+  · rw [LinearMap.range_eq_top]
     intro x
     use ((A⁻¹).mulVecLin x)
     rwa [mulVecLin_apply, mulVecLin_apply, mulVec_mulVec, mul_nonsing_inv, one_mulVec]
 
 /-- Post (right) multiplying by an invertible matrix does not change the rank -/
 lemma rank_isUnit_mul [DecidableEq m] [Field R]
-    (A: Matrix m m R) (B: Matrix m n R) (hA: IsUnit A.det):
+    (A : Matrix m m R) (B : Matrix m n R) (hA : IsUnit A.det):
     (A ⬝ B).rank = B.rank := by
   suffices h: LinearMap.ker ((A⬝B).mulVecLin) = LinearMap.ker (B.mulVecLin)
-  have hB := LinearMap.finrank_range_add_finrank_ker (B.mulVecLin)
-  rw [← LinearMap.finrank_range_add_finrank_ker ((A⬝B).mulVecLin), h, add_left_inj] at hB
-  rw [Matrix.rank, Matrix.rank, hB]
-  rw [mulVecLin_mul, LinearMap.ker_comp_of_ker_eq_bot]
-  simp_rw [LinearMap.ker_eq_bot, Function.Injective, mulVecLin_apply]
-  intros x y h
-  apply_fun Matrix.mulVec (A⁻¹) at h
-  simpa [mulVec_mulVec, nonsing_inv_mul A hA, one_mulVec] using h
+  · have hB := LinearMap.finrank_range_add_finrank_ker (B.mulVecLin)
+    rw [← LinearMap.finrank_range_add_finrank_ker ((A⬝B).mulVecLin), h, add_left_inj] at hB
+    rw [Matrix.rank, Matrix.rank, hB]
+  · rw [mulVecLin_mul, LinearMap.ker_comp_of_ker_eq_bot]
+    simp_rw [LinearMap.ker_eq_bot, Function.Injective, mulVecLin_apply]
+    intros x y h
+    apply_fun Matrix.mulVec (A⁻¹) at h
+    simpa [mulVec_mulVec, nonsing_inv_mul A hA, one_mulVec] using h
 
 end MulNonsingInv
 

--- a/Mathlib/Data/Matrix/Rank.lean
+++ b/Mathlib/Data/Matrix/Rank.lean
@@ -281,7 +281,7 @@ section MulNonsingInv
 
 /-- Right multiplying by an invertible matrix does not change the rank -/
 lemma rank_mul_eq_left_of_isUnit  [DecidableEq n] [CommRing R]
-    (A: Matrix n n R) (B: Matrix m n R) (hA: IsUnit A.det) :
+    (A : Matrix n n R) (B : Matrix m n R) (hA : IsUnit A.det) :
     (B ⬝ A).rank = B.rank := by
   have hlT : LinearMap.range (mulVecLin A) = ⊤ := by
     rw [LinearMap.range_eq_top]
@@ -292,7 +292,7 @@ lemma rank_mul_eq_left_of_isUnit  [DecidableEq n] [CommRing R]
 
 /-- Left multiplying by an invertible matrix does not change the rank -/
 lemma rank_mul_eq_right_of_isUnit  [DecidableEq m] [Field R]
-    (A: Matrix m m R) (B: Matrix m n R) (hA: IsUnit A.det):
+    (A : Matrix m m R) (B : Matrix m n R) (hA : IsUnit A.det):
     (A ⬝ B).rank = B.rank := by
   suffices h: LinearMap.ker ((A⬝B).mulVecLin) = LinearMap.ker (B.mulVecLin)
   · have hB := LinearMap.finrank_range_add_finrank_ker (B.mulVecLin)

--- a/Mathlib/Data/Matrix/Rank.lean
+++ b/Mathlib/Data/Matrix/Rank.lean
@@ -280,7 +280,7 @@ section MulNonsingInv
 /-! ### Lemmas about pre or post multiplying by an invertible matrix. -/
 
 /-- Pre (Left) multiplying by an invertible matrix does not change the rank -/
-lemma rank_mul_IsUnit {m n R: Type} [Fintype n] [DecidableEq n] [CommRing R]
+lemma rank_mul_isUnit [DecidableEq n] [CommRing R]
     (A: Matrix n n R) (B: Matrix m n R) (hA: IsUnit A.det) :
     (B ⬝ A).rank = B.rank := by
   rw [Matrix.rank, mulVecLin_mul, LinearMap.range_comp_of_range_eq_top, ←Matrix.rank ]
@@ -290,7 +290,7 @@ lemma rank_mul_IsUnit {m n R: Type} [Fintype n] [DecidableEq n] [CommRing R]
   rwa [mulVecLin_apply, mulVecLin_apply, mulVec_mulVec, mul_nonsing_inv, one_mulVec]
 
 /-- Post (right) multiplying by an invertible matrix does not change the rank -/
-lemma rank_IsUnit_mul {m n R: Type} [Fintype m] [Fintype n] [DecidableEq m] [Field R]
+lemma rank_isUnit_mul [DecidableEq m] [Field R]
     (A: Matrix m m R) (B: Matrix m n R) (hA: IsUnit A.det):
     (A ⬝ B).rank = B.rank := by
   suffices h: LinearMap.ker ((A⬝B).mulVecLin) = LinearMap.ker (B.mulVecLin)

--- a/Mathlib/Data/Matrix/Rank.lean
+++ b/Mathlib/Data/Matrix/Rank.lean
@@ -7,6 +7,7 @@ import Mathlib.LinearAlgebra.FreeModule.Finite.Rank
 import Mathlib.LinearAlgebra.Matrix.ToLin
 import Mathlib.LinearAlgebra.FiniteDimensional
 import Mathlib.LinearAlgebra.Matrix.DotProduct
+import Mathlib.LinearAlgebra.Matrix.NonsingularInverse
 import Mathlib.Data.Complex.Module
 
 #align_import data.matrix.rank from "leanprover-community/mathlib"@"17219820a8aa8abe85adf5dfde19af1dd1bd8ae7"
@@ -273,5 +274,41 @@ theorem rank_eq_finrank_span_row [LinearOrderedField R] [Finite m] (A : Matrix m
   cases nonempty_fintype m
   rw [← rank_transpose, rank_eq_finrank_span_cols, transpose_transpose]
 #align matrix.rank_eq_finrank_span_row Matrix.rank_eq_finrank_span_row
+
+section MulNonsingInv
+
+/-! ### Lemmas about pre or post multiplying by an invertible matrix. -/
+
+/-- Pre (Left) multiplying by an invertible matrix does not change the rank -/
+lemma rank_mul_IsUnit {m n R: Type}
+  -- [Fintype m] -- not needed according to linter
+  [Fintype n][DecidableEq n][CommRing R]
+  (A: Matrix n n R)(B: Matrix m n R)(hA: IsUnit A.det):
+  (B⬝A).rank = B.rank := by
+  rw [Matrix.rank, mulVecLin_mul, LinearMap.range_comp_of_range_eq_top, ←Matrix.rank ]
+  rw [LinearMap.range_eq_top]
+  intros x
+  use ((A⁻¹).mulVecLin x)
+  rw [mulVecLin_apply, mulVecLin_apply, mulVec_mulVec, mul_nonsing_inv, one_mulVec]
+  exact hA
+
+/-- Post (right) multiplying by an invertible matrix does not change the rank -/
+lemma rank_IsUnit_mul {m n R: Type}
+  [Fintype m][Fintype n][DecidableEq m][Field R]
+  (A: Matrix m m R)(B: Matrix m n R)(hA: IsUnit A.det):
+  (A⬝B).rank = B.rank := by
+  suffices h: LinearMap.ker ((A⬝B).mulVecLin) = LinearMap.ker (B.mulVecLin)
+  have hB := LinearMap.finrank_range_add_finrank_ker (B.mulVecLin)
+  rw [← LinearMap.finrank_range_add_finrank_ker ((A⬝B).mulVecLin), h, add_left_inj] at hB
+  rw [Matrix.rank, Matrix.rank, hB]
+  rw [mulVecLin_mul, LinearMap.ker_comp_of_ker_eq_bot]
+  rw [LinearMap.ker_eq_bot]
+  simp_rw [Function.Injective, mulVecLin_apply]
+  intros x y h
+  replace h := congr_arg (fun x => Matrix.mulVec (A⁻¹) x)  h
+  simp_rw [mulVec_mulVec, nonsing_inv_mul A hA, one_mulVec] at h
+  exact h
+
+end MulNonsingInv
 
 end Matrix

--- a/Mathlib/Data/Matrix/Rank.lean
+++ b/Mathlib/Data/Matrix/Rank.lean
@@ -288,7 +288,7 @@ lemma rank_mul_eq_left_of_isUnit_det [DecidableEq n] [CommRing R]
   exact ⟨(A⁻¹).mulVecLin v, by simp [mul_nonsing_inv _ hA]⟩
 
 /-- Left multiplying by an invertible matrix does not change the rank -/
-lemma rank_mul_eq_right_of_isUnitDet [DecidableEq m] [CommRing R]
+lemma rank_mul_eq_right_of_isUnit_det [DecidableEq m] [CommRing R]
     (A : Matrix m m R) (B : Matrix m n R) (hA : IsUnit A.det) :
     (A ⬝ B).rank = B.rank := by
   let b : Basis m R (m → R) := Pi.basisFun R m

--- a/Mathlib/Data/Matrix/Rank.lean
+++ b/Mathlib/Data/Matrix/Rank.lean
@@ -283,7 +283,7 @@ section MulNonsingInv
 lemma rank_mul_isUnit [DecidableEq n] [CommRing R]
     (A : Matrix n n R) (B : Matrix m n R) (hA : IsUnit A.det) :
     (B ⬝ A).rank = B.rank := by
-  rw [Matrix.rank, mulVecLin_mul, LinearMap.range_comp_of_range_eq_top, ←Matrix.rank ]
+  rw [Matrix.rank, mulVecLin_mul, LinearMap.range_comp_of_range_eq_top, ←Matrix.rank]
   rw [LinearMap.range_eq_top] -- On separate line since implicit rfl works in prev line
   intro x
   use ((A⁻¹).mulVecLin x)

--- a/Mathlib/Data/Matrix/Rank.lean
+++ b/Mathlib/Data/Matrix/Rank.lean
@@ -298,11 +298,11 @@ lemma rank_isUnit_mul [DecidableEq m] [Field R]
   · have hB := LinearMap.finrank_range_add_finrank_ker (B.mulVecLin)
     rw [← LinearMap.finrank_range_add_finrank_ker ((A⬝B).mulVecLin), h, add_left_inj] at hB
     rw [Matrix.rank, Matrix.rank, hB]
-  · rw [mulVecLin_mul, LinearMap.ker_comp_of_ker_eq_bot]
-    simp_rw [LinearMap.ker_eq_bot, Function.Injective, mulVecLin_apply]
-    intros x y h
-    apply_fun Matrix.mulVec (A⁻¹) at h
-    simpa [mulVec_mulVec, nonsing_inv_mul A hA, one_mulVec] using h
+  rw [mulVecLin_mul, LinearMap.ker_comp_of_ker_eq_bot]
+  simp_rw [LinearMap.ker_eq_bot, Function.Injective, mulVecLin_apply]
+  intros x y h
+  apply_fun Matrix.mulVec (A⁻¹) at h
+  simpa [mulVec_mulVec, nonsing_inv_mul A hA, one_mulVec] using h
 
 end MulNonsingInv
 

--- a/Mathlib/Data/Matrix/Rank.lean
+++ b/Mathlib/Data/Matrix/Rank.lean
@@ -279,8 +279,8 @@ section MulNonsingInv
 
 /-! ### Lemmas about pre or post multiplying by an invertible matrix. -/
 
-/-- Pre (Left) multiplying by an invertible matrix does not change the rank -/
-lemma rank_mul_isUnit [DecidableEq n] [CommRing R]
+/-- Right multiplying by an invertible matrix does not change the rank -/
+lemma rank_mul_eq_left_of_isUnit  [DecidableEq n] [CommRing R]
     (A: Matrix n n R) (B: Matrix m n R) (hA: IsUnit A.det) :
     (B ⬝ A).rank = B.rank := by
   rw [Matrix.rank, mulVecLin_mul, LinearMap.range_comp_of_range_eq_top, ←Matrix.rank ]
@@ -289,8 +289,8 @@ lemma rank_mul_isUnit [DecidableEq n] [CommRing R]
   use ((A⁻¹).mulVecLin x)
   rwa [mulVecLin_apply, mulVecLin_apply, mulVec_mulVec, mul_nonsing_inv, one_mulVec]
 
-/-- Post (right) multiplying by an invertible matrix does not change the rank -/
-lemma rank_isUnit_mul [DecidableEq m] [Field R]
+/-- Left multiplying by an invertible matrix does not change the rank -/
+lemma rank_mul_eq_right_of_isUnit  [DecidableEq m] [Field R]
     (A: Matrix m m R) (B: Matrix m n R) (hA: IsUnit A.det):
     (A ⬝ B).rank = B.rank := by
   suffices h: LinearMap.ker ((A⬝B).mulVecLin) = LinearMap.ker (B.mulVecLin)

--- a/Mathlib/Data/Matrix/Rank.lean
+++ b/Mathlib/Data/Matrix/Rank.lean
@@ -298,8 +298,7 @@ lemma rank_IsUnit_mul {m n R: Type} [Fintype m] [Fintype n] [DecidableEq m] [Fie
   rw [← LinearMap.finrank_range_add_finrank_ker ((A⬝B).mulVecLin), h, add_left_inj] at hB
   rw [Matrix.rank, Matrix.rank, hB]
   rw [mulVecLin_mul, LinearMap.ker_comp_of_ker_eq_bot]
-  rw [LinearMap.ker_eq_bot]
-  simp_rw [Function.Injective, mulVecLin_apply]
+  simp_rw [LinearMap.ker_eq_bot, Function.Injective, mulVecLin_apply]
   intros x y h
   apply_fun Matrix.mulVec (A⁻¹) at h
   simpa [mulVec_mulVec, nonsing_inv_mul A hA, one_mulVec] using h

--- a/Mathlib/Data/Matrix/Rank.lean
+++ b/Mathlib/Data/Matrix/Rank.lean
@@ -102,6 +102,26 @@ theorem rank_of_isUnit [StrongRankCondition R] [DecidableEq n] (A : Matrix n n R
   exact rank_unit A
 #align matrix.rank_of_is_unit Matrix.rank_of_isUnit
 
+/-- Right multiplying by an invertible matrix does not change the rank -/
+lemma rank_mul_eq_left_of_isUnit_det [DecidableEq n]
+    (A : Matrix n n R) (B : Matrix m n R) (hA : IsUnit A.det) :
+    (B ⬝ A).rank = B.rank := by
+  suffices : Function.Surjective A.mulVecLin
+  · rw [rank, mulVecLin_mul, LinearMap.range_comp_of_range_eq_top _
+    (LinearMap.range_eq_top.mpr this), ← rank]
+  intro v
+  exact ⟨(A⁻¹).mulVecLin v, by simp [mul_nonsing_inv _ hA]⟩
+
+/-- Left multiplying by an invertible matrix does not change the rank -/
+lemma rank_mul_eq_right_of_isUnit_det [DecidableEq m]
+    (A : Matrix m m R) (B : Matrix m n R) (hA : IsUnit A.det) :
+    (A ⬝ B).rank = B.rank := by
+  let b : Basis m R (m → R) := Pi.basisFun R m
+  replace hA : IsUnit (LinearMap.toMatrix b b A.mulVecLin).det := by
+    convert hA; rw [← LinearEquiv.eq_symm_apply]; rfl
+  have hAB : mulVecLin (A ⬝ B) = (LinearEquiv.ofIsUnitDet hA).comp (mulVecLin B) := by ext; simp
+  rw [rank, rank, hAB, LinearMap.range_comp, LinearEquiv.finrank_map_eq]
+
 /-- Taking a subset of the rows and permuting the columns reduces the rank. -/
 theorem rank_submatrix_le [StrongRankCondition R] [Fintype m] (f : n → m) (e : n ≃ m)
     (A : Matrix m m R) : rank (A.submatrix f e) ≤ rank A := by
@@ -274,27 +294,5 @@ theorem rank_eq_finrank_span_row [LinearOrderedField R] [Finite m] (A : Matrix m
   cases nonempty_fintype m
   rw [← rank_transpose, rank_eq_finrank_span_cols, transpose_transpose]
 #align matrix.rank_eq_finrank_span_row Matrix.rank_eq_finrank_span_row
-
-/-! ### Lemmas about left or right multiplying by an invertible matrix. -/
-
-/-- Right multiplying by an invertible matrix does not change the rank -/
-lemma rank_mul_eq_left_of_isUnit_det [DecidableEq n] [CommRing R]
-    (A : Matrix n n R) (B : Matrix m n R) (hA : IsUnit A.det) :
-    (B ⬝ A).rank = B.rank := by
-  suffices : Function.Surjective A.mulVecLin
-  · rw [rank, mulVecLin_mul, LinearMap.range_comp_of_range_eq_top _
-    (LinearMap.range_eq_top.mpr this), ← rank]
-  intro v
-  exact ⟨(A⁻¹).mulVecLin v, by simp [mul_nonsing_inv _ hA]⟩
-
-/-- Left multiplying by an invertible matrix does not change the rank -/
-lemma rank_mul_eq_right_of_isUnit_det [DecidableEq m] [CommRing R]
-    (A : Matrix m m R) (B : Matrix m n R) (hA : IsUnit A.det) :
-    (A ⬝ B).rank = B.rank := by
-  let b : Basis m R (m → R) := Pi.basisFun R m
-  replace hA : IsUnit (LinearMap.toMatrix b b A.mulVecLin).det := by
-    convert hA; rw [← LinearEquiv.eq_symm_apply]; rfl
-  have hAB : mulVecLin (A ⬝ B) = (LinearEquiv.ofIsUnitDet hA).comp (mulVecLin B) := by ext; simp
-  rw [rank, rank, hAB, LinearMap.range_comp, LinearEquiv.finrank_map_eq]
 
 end Matrix


### PR DESCRIPTION
This PR provides two lemmas:

- `Matrix.rank_mul_eq_left_of_isUnit_det` in a commutative ring R post multiplication (multiplication from the right) by an invertible matrix does not change the rank of a matrix. With $A$ an invertible matrix:
$$\text{rank}(BA) = \text{rank}(B)$$

- `Matrix.rank_mul_eq_right_of_isUnit_det` in a commutative ring R pre-multiplication (multiplication from the left) by an invertible matrix does not change the rank of a matrix. With $A$ an invertible matrix:
$$\text{rank}(AB) = \text{rank}(B)$$

Co-authored-by: Mohanad Ahmed <m.a.m.elhassan@gmail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
