### PR TITLE
[Merged by Bors] - feat: column and row partitioned matrices

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1505,6 +1505,7 @@ import Mathlib.Data.Matrix.Auto
 import Mathlib.Data.Matrix.Basic
 import Mathlib.Data.Matrix.Basis
 import Mathlib.Data.Matrix.Block
+import Mathlib.Data.Matrix.ColumnRowPartitioned
 import Mathlib.Data.Matrix.CharP
 import Mathlib.Data.Matrix.DMatrix
 import Mathlib.Data.Matrix.DualNumber

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1505,8 +1505,8 @@ import Mathlib.Data.Matrix.Auto
 import Mathlib.Data.Matrix.Basic
 import Mathlib.Data.Matrix.Basis
 import Mathlib.Data.Matrix.Block
-import Mathlib.Data.Matrix.ColumnRowPartitioned
 import Mathlib.Data.Matrix.CharP
+import Mathlib.Data.Matrix.ColumnRowPartitioned
 import Mathlib.Data.Matrix.DMatrix
 import Mathlib.Data.Matrix.DualNumber
 import Mathlib.Data.Matrix.Hadamard

--- a/Mathlib/Data/Matrix/ColumnRowPartitioned.lean
+++ b/Mathlib/Data/Matrix/ColumnRowPartitioned.lean
@@ -114,6 +114,46 @@ lemma fromColumns_apply_inr (A₁ : Matrix m n₁ R) (A₂ : Matrix m n₂ R) (i
   unfold fromColumns
   simp only [of_apply, Sum.elim_inr]
 
+@[simp]
+lemma toRows₁_apply (A : Matrix (m₁ ⊕ m₂) n R) (i : m₁) (j : n) :
+    (toRows₁ A) i j = A (Sum.inl i) j := by rw [toRows₁, of_apply]
+
+@[simp]
+lemma toRows₂_apply (A : Matrix (m₁ ⊕ m₂) n R) (i : m₂) (j : n) :
+    (toRows₂ A) i j = A (Sum.inr i) j := by rw [toRows₂, of_apply]
+
+@[simp]
+lemma toRows₁_fromRows  (A₁ : Matrix m₁ n R) (A₂ : Matrix m₂ n R) :
+    toRows₁ (fromRows A₁ A₂) = A₁ := by
+  funext i j
+  simp only [toRows₁_apply, fromRows_apply_inl]
+
+@[simp]
+lemma toRows₂_fromRows  (A₁ : Matrix m₁ n R) (A₂ : Matrix m₂ n R) :
+    toRows₂ (fromRows A₁ A₂) = A₂ := by
+  funext i j
+  simp only [toRows₂_apply, fromRows_apply_inr]
+
+@[simp]
+lemma toColumns₁_apply (A : Matrix m (n₁ ⊕ n₂) R) (i : m) (j : n₁) :
+    (toColumns₁ A) i j = A i (Sum.inl j) := by rw [toColumns₁, of_apply]
+
+@[simp]
+lemma toColumns₂_apply (A : Matrix m (n₁ ⊕ n₂) R) (i : m) (j : n₂) :
+    (toColumns₂ A) i j = A i (Sum.inr j) := by rw [toColumns₂, of_apply]
+
+@[simp]
+lemma toColumns₁_fromColumns  (A₁ : Matrix m n₁ R) (A₂ : Matrix m n₂ R) :
+    toColumns₁ (fromColumns A₁ A₂) = A₁ := by
+    funext i j
+    simp only [toColumns₁_apply, fromColumns_apply_inl]
+
+@[simp]
+lemma toColumns₂_fromColumns  (A₁ : Matrix m n₁ R) (A₂ : Matrix m n₂ R) :
+    toColumns₂ (fromColumns A₁ A₂) = A₂ := by
+    ext i j
+    simp only [toColumns₂_apply, fromColumns_apply_inr]
+
 /- A column partioned matrix when transposed gives a row partioned matrix with columns of the
 initial matrix tranposed to become rows. -/
 lemma transpose_fromColumns (A₁ : Matrix m n₁ R) (A₂ : Matrix m n₂ R) :

--- a/Mathlib/Data/Matrix/ColumnRowPartitioned.lean
+++ b/Mathlib/Data/Matrix/ColumnRowPartitioned.lean
@@ -135,23 +135,20 @@ lemma transpose_fromRows (A₁ : Matrix m₁ n R) (A₂ : Matrix m₂ n R) :
 section Semiring
 
 variable [Semiring R]
-/- The proofs are "shorter" with the unfolds instead of the simp lemmas above so I will continue
-with them for the next lemmas -/
+
 @[simp]
 lemma fromRows_mul (A₁ : Matrix m₁ n R) (A₂ : Matrix m₂ n R) (B : Matrix n m R) :
     (fromRows A₁ A₂) ⬝ B = fromRows (A₁ ⬝ B) (A₂ ⬝ B) := by
-  unfold fromRows
   funext i j
   cases' i with i i
-  all_goals (simp only [mul_apply, of_apply, Sum.elim_inl, Sum.elim_inr] )
+  all_goals (simp only [mul_apply, fromRows_apply_inl, fromRows_apply_inr])
 
 @[simp]
 lemma mul_fromColumns (A : Matrix m n R) (B₁ : Matrix n n₁ R) (B₂ : Matrix n n₂ R) :
     A ⬝ (fromColumns B₁ B₂) = fromColumns (A ⬝ B₁) (A ⬝ B₂) := by
-  unfold fromColumns
   funext i j
   cases' j with j j
-  all_goals (simp only [mul_apply, of_apply, Sum.elim_inl, Sum.elim_inr] )
+  all_goals (simp only [mul_apply, fromColumns_apply_inl, fromColumns_apply_inr] )
 
 @[simp]
 lemma fromRows_zero : fromRows (0 : Matrix m₁ n R) (0 : Matrix m₂ n R) = 0 := by
@@ -162,33 +159,31 @@ lemma fromRows_zero : fromRows (0 : Matrix m₁ n R) (0 : Matrix m₂ n R) = 0 :
 @[simp]
 lemma fromColumns_zero : fromColumns (0 : Matrix m n₁ R) (0 : Matrix m n₂ R) = 0 := by
   funext i j
-  unfold fromColumns
   cases' j with j j
-  all_goals (simp only [of_apply, Sum.elim_inl, Sum.elim_inr, zero_apply])
+  all_goals (simp only [fromColumns_apply_inl, fromColumns_apply_inr, zero_apply])
 
 @[simp]
 lemma fromColumns_fromRows_eq_fromBlocks (B₁₁ : Matrix m₁ n₁ R) (B₁₂ : Matrix m₁ n₂ R)
     (B₂₁ : Matrix m₂ n₁ R) (B₂₂ : Matrix m₂ n₂ R) :
     fromColumns (fromRows B₁₁ B₂₁) (fromRows B₁₂ B₂₂) = fromBlocks B₁₁ B₁₂ B₂₁ B₂₂ := by
-    unfold fromRows fromColumns
-    funext i j
-    cases' i with i i
-    all_goals (
-      cases' j with j j;
-      all_goals ( simp only [of_apply, Sum.elim_inl, Sum.elim_inr, fromBlocks_apply₁₁,
-        fromBlocks_apply₁₂, fromBlocks_apply₂₁, fromBlocks_apply₂₂] ) )
+  funext i j
+  cases' i with i i
+  all_goals (
+    cases' j with j j
+    all_goals (simp only [fromColumns_apply_inl, fromColumns_apply_inr,
+      fromRows_apply_inl, fromRows_apply_inr, fromBlocks_apply₁₁, fromBlocks_apply₁₂,
+      fromBlocks_apply₂₁,  fromBlocks_apply₂₂] ) )
 
 @[simp]
 lemma fromRows_fromColumn_eq_fromBlocks (B₁₁ : Matrix m₁ n₁ R) (B₁₂ : Matrix m₁ n₂ R)
     (B₂₁ : Matrix m₂ n₁ R) (B₂₂ : Matrix m₂ n₂ R) :
     fromRows (fromColumns B₁₁ B₁₂) (fromColumns B₂₁ B₂₂) = fromBlocks B₁₁ B₁₂ B₂₁ B₂₂ := by
-    unfold fromRows fromColumns
-    funext i j
-    cases' i with i i
-    all_goals (
-      cases' j with j j;
-      all_goals ( simp only [of_apply, Sum.elim_inl, Sum.elim_inr, fromBlocks_apply₁₁,
-        fromBlocks_apply₁₂, fromBlocks_apply₂₁, fromBlocks_apply₂₂] ) )
+  funext i j
+  cases' i with i i
+  all_goals (cases' j with j j)
+  all_goals (simp only [fromColumns_apply_inl, fromColumns_apply_inr,
+    fromRows_apply_inl, fromRows_apply_inr, fromBlocks_apply₁₁, fromBlocks_apply₁₂,
+    fromBlocks_apply₂₁,  fromBlocks_apply₂₂] )
 
 /-- A row partitioned matrix multiplied by a column partioned matrix gives a 2 by 2 block matrix -/
 lemma fromRows_mul_fromColumns (A₁ : Matrix m₁ n R) (A₂ : Matrix m₂ n R)
@@ -196,11 +191,11 @@ lemma fromRows_mul_fromColumns (A₁ : Matrix m₁ n R) (A₂ : Matrix m₂ n R)
     (fromRows A₁ A₂) ⬝ (fromColumns B₁ B₂) =
       fromBlocks (A₁ ⬝ B₁) (A₁ ⬝ B₂) (A₂ ⬝ B₁) (A₂ ⬝ B₂) := by
   funext i j
-  rw [fromRows, fromColumns]
-  cases i;
-  all_goals (cases j)
-  all_goals (simp only [fromBlocks_apply₁₁, fromBlocks_apply₁₂, fromBlocks_apply₂₁,
-    fromBlocks_apply₂₂, mul_apply, of_apply, Sum.elim_inl, Sum.elim_inr] )
+  cases' i with i i;
+  all_goals (cases' j with j j)
+  all_goals ( simp only [mul_fromColumns, fromRows_mul, fromColumns_apply_inl,
+    fromColumns_apply_inr, fromRows_apply_inl, fromRows_apply_inr, fromBlocks_apply₁₁,
+    fromBlocks_apply₁₂, fromBlocks_apply₂₁, fromBlocks_apply₂₂] )
 
 /-- A column partitioned matrix mulitplied by a row partitioned matrix gives the sum of the "outer"
 products of the block matrices -/
@@ -276,16 +271,17 @@ with the columns of the initial matrix conjugate transposed to become rows. -/
 lemma conjTranspose_fromColumns_eq_fromRows_conjTranspose (A₁ : Matrix m n₁ R)
     (A₂ : Matrix m n₂ R) :
     conjTranspose (fromColumns A₁ A₂) = fromRows (conjTranspose A₁) (conjTranspose A₂) := by
-  rw [fromColumns, fromRows]
   funext i j
   cases' i with i i
-  all_goals (simp only [conjTranspose_apply, of_apply, Sum.elim_inl, Sum.elim_inr])
+  all_goals (simp only [conjTranspose_apply, fromColumns_apply_inl, fromRows_apply_inl,
+    fromColumns_apply_inr, fromRows_apply_inr] )
 
 /- A row partioned matrix in a Star ring when conjugate transposed gives a column partitioned matrix
 with the rows of the initial matrix conjugate transposed to become columns. -/
 lemma conjTranspose_fromRows_eq_fromColumns_conjTranspose (A₁ : Matrix m₁ n R)
     (A₂ : Matrix m₂ n R) : conjTranspose (fromRows A₁ A₂) =
       fromColumns (conjTranspose A₁) (conjTranspose A₂) := by
+  /- I left this one for comparison. I think this proof looks more compact (nice)! -/
   rw [fromColumns, fromRows]
   funext j i
   cases' i with i i

--- a/Mathlib/Data/Matrix/ColumnRowPartitioned.lean
+++ b/Mathlib/Data/Matrix/ColumnRowPartitioned.lean
@@ -192,7 +192,8 @@ lemma fromRows_fromColumn_eq_fromBlocks (B₁₁ : Matrix m₁ n₁ R) (B₁₂ 
 
 /-- A row partitioned matrix multiplied by a column partioned matrix gives a 2 by 2 block matrix -/
 lemma fromRows_mul_fromColumns (A₁ : Matrix m₁ n R) (A₂ : Matrix m₂ n R)
-    (B₁ : Matrix n n₁ R) (B₂ : Matrix n n₂ R) : (fromRows A₁ A₂) ⬝ (fromColumns B₁ B₂) =
+    (B₁ : Matrix n n₁ R) (B₂ : Matrix n n₂ R) :
+    (fromRows A₁ A₂) ⬝ (fromColumns B₁ B₂) =
       fromBlocks (A₁ ⬝ B₁) (A₁ ⬝ B₂) (A₂ ⬝ B₁) (A₂ ⬝ B₂) := by
   funext i j
   rw [fromRows, fromColumns]
@@ -273,8 +274,8 @@ variable [Star R]
 /- A column partioned matrix in a Star ring when conjugate transposed gives a row partitioned matrix
 with the columns of the initial matrix conjugate transposed to become rows. -/
 lemma conjTranspose_fromColumns_eq_fromRows_conjTranspose (A₁ : Matrix m n₁ R)
-    (A₂ : Matrix m n₂ R) : conjTranspose (fromColumns A₁ A₂) =
-      fromRows (conjTranspose A₁) (conjTranspose A₂) := by
+    (A₂ : Matrix m n₂ R) :
+    conjTranspose (fromColumns A₁ A₂) = fromRows (conjTranspose A₁) (conjTranspose A₂) := by
   rw [fromColumns, fromRows]
   funext i j
   cases' i with i i

--- a/Mathlib/Data/Matrix/ColumnRowPartitioned.lean
+++ b/Mathlib/Data/Matrix/ColumnRowPartitioned.lean
@@ -24,44 +24,46 @@ column matrices, row matrices, column row block matrices
 
 namespace Matrix
 
-variable {R: Type _}
-variable {M M₁ M₂ N N₁ N₂: Type _}
-variable [Fintype M][Fintype M₁][Fintype M₂]
-variable [Fintype N][Fintype N₁][Fintype N₂]
-variable [DecidableEq M][DecidableEq M₁][DecidableEq M₂]
-variable [DecidableEq N][DecidableEq N₁][DecidableEq N₂]
+variable {R : Type _}
+variable {M M₁ M₂ N N₁ N₂ : Type _}
+variable [Fintype M] [Fintype M₁] [Fintype M₂]
+variable [Fintype N] [Fintype N₁] [Fintype N₂]
+variable [DecidableEq M] [DecidableEq M₁] [DecidableEq M₂]
+variable [DecidableEq N] [DecidableEq N₁] [DecidableEq N₂]
 
 /-- Concatenate together two matrices A₁[M₁ × N] and A₂[M₂ × N] with the same columns (N) to get a
 bigger matrix indexed by [(M₁ ⊕ M₂) × N] -/
 def fromRows (A₁ : Matrix M₁ N R) (A₂ : Matrix M₂ N R) : Matrix (M₁ ⊕ M₂) N R :=
-  Matrix.of (Sum.elim A₁ A₂)
+  of (Sum.elim A₁ A₂)
 
-/-- Concatenate together two matrices B₁[M × N₁] and B₂[M × N₂] with the same Rows (M) to get a
+/-- Concatenate together two matrices B₁[M × N₁] and B₂[M × N₂] with the same rows (M) to get a
 bigger matrix indexed by [M × (N₁ ⊕ N₂)] -/
 def fromColumns (B₁ : Matrix M N₁ R) (B₂ : Matrix M N₂ R) : Matrix M (N₁ ⊕ N₂) R :=
-  Matrix.of fun i => Sum.elim (B₁ i) (B₂ i)
+  of fun i => Sum.elim (B₁ i) (B₂ i)
 
 /-- Given a column partitioned matrix extract the first column -/
-def toColumns₁ (A : Matrix M (N₁ ⊕ N₂) R) : Matrix M N₁ R :=  of fun i j => (A i (Sum.inl j))
+def toColumns₁ (A : Matrix M (N₁ ⊕ N₂) R) : Matrix M N₁ R := of fun i j => (A i (Sum.inl j))
 
 /-- Given a column partitioned matrix extract the second column -/
-def toColumns₂ (A : Matrix M (N₁ ⊕ N₂) R) : Matrix M N₂ R :=  of fun i j => (A i (Sum.inr j))
+def toColumns₂ (A : Matrix M (N₁ ⊕ N₂) R) : Matrix M N₂ R := of fun i j => (A i (Sum.inr j))
 
 /-- Given a row partitioned matrix extract the first row -/
-def toRows₁ (A : Matrix (M₁ ⊕ M₂) N R) : Matrix M₁ N R :=  of fun i j => (A (Sum.inl i) j)
+def toRows₁ (A : Matrix (M₁ ⊕ M₂) N R) : Matrix M₁ N R := of fun i j => (A (Sum.inl i) j)
 
 /-- Given a row partitioned matrix extract the second row -/
-def toRows₂ (A : Matrix (M₁ ⊕ M₂) N R) : Matrix M₂ N R :=  of fun i j => (A (Sum.inr i) j)
+def toRows₂ (A : Matrix (M₁ ⊕ M₂) N R) : Matrix M₂ N R := of fun i j => (A (Sum.inr i) j)
 
+@[simp]
 lemma fromColumns_toColumns (A : Matrix M (N₁ ⊕ N₂) R) :
-    A = fromColumns A.toColumns₁ A.toColumns₂ := by
+    fromColumns A.toColumns₁ A.toColumns₂ = A := by
   unfold fromColumns toColumns₁ toColumns₂
   funext i j
   cases' j
   all_goals (simp only [of_apply, Sum.elim_inl, Sum.elim_inr])
 
 lemma fromColumns_ext_iff (A₁ : Matrix M N₁ R) (A₂ : Matrix M N₂ R) (B₁ : Matrix M N₁ R)
-    (B₂ : Matrix M N₂ R) : fromColumns A₁ A₂ = fromColumns B₁ B₂ ↔ A₁ = B₁ ∧ A₂ = B₂ := by
+    (B₂ : Matrix M N₂ R) :
+    fromColumns A₁ A₂ = fromColumns B₁ B₂ ↔ A₁ = B₁ ∧ A₂ = B₂ := by
   simp_rw [fromColumns, ← Matrix.ext_iff, of_apply, Sum.forall, Sum.elim_inl, Sum.elim_inr]
   exact ⟨(fun h => ⟨fun i j => (h i).1 j, fun _ _ => (h _).2 _⟩),
     (fun h => (fun _ => ⟨(h.1 _), (h.2 _)⟩))⟩
@@ -78,7 +80,7 @@ lemma fromRows_ext_iff (A₁ : Matrix M₁ N R) (A₂ : Matrix M₂ N R) (B₁ :
 
 /- A column partioned matrix when transposed gives a row partioned matrix with columns of the
 initial matrix tranposed to become rows. -/
-lemma transpose_fromColumns_eq_fromRows_transpose (A₁ : Matrix M N₁ R) (A₂ : Matrix M N₂ R) :
+lemma transpose_fromColumns (A₁ : Matrix M N₁ R) (A₂ : Matrix M N₂ R) :
     transpose (fromColumns A₁ A₂) = fromRows (transpose A₁) (transpose A₂) := by
   rw [fromColumns, fromRows]
   funext i j
@@ -99,14 +101,14 @@ section Semiring
 variable [Semiring R]
 
 lemma fromRows_mul (A₁ : Matrix M₁ N R) (A₂ : Matrix M₂ N R) (B : Matrix N M R) :
-    (fromRows A₁ A₂) ⬝ B = fromRows (A₁⬝B) (A₂⬝B) := by
+    (fromRows A₁ A₂) ⬝ B = fromRows (A₁ ⬝ B) (A₂ ⬝ B) := by
   unfold fromRows
   funext i j
   cases' i with i i
   all_goals (simp only [mul_apply, of_apply, Sum.elim_inl, Sum.elim_inr] )
 
 lemma mul_fromColumns (A : Matrix M N R) (B₁ : Matrix N N₁ R) (B₂ : Matrix N N₂ R) :
-    A ⬝ (fromColumns B₁ B₂) = fromColumns (A⬝B₁) (A⬝B₂) := by
+    A ⬝ (fromColumns B₁ B₂) = fromColumns (A ⬝ B₁) (A ⬝ B₂) := by
   unfold fromColumns
   funext i j
   cases' j with j j
@@ -126,7 +128,7 @@ lemma fromColumns_zero : fromColumns (0 : Matrix M N₁ R) (0 : Matrix M N₂ R)
 /-- A row partitioned matrix multiplied by a column partioned matrix gives a 2 by 2 block matrix -/
 lemma fromRows_mul_fromColumns (A₁ : Matrix M₁ N R) (A₂ : Matrix M₂ N R)
     (B₁ : Matrix N N₁ R) (B₂ : Matrix N N₂ R) :
-    (fromRows A₁ A₂) ⬝ (fromColumns B₁ B₂) = fromBlocks (A₁⬝B₁) (A₁⬝B₂) (A₂⬝B₁) (A₂⬝B₂) := by
+    (fromRows A₁ A₂) ⬝ (fromColumns B₁ B₂) = fromBlocks (A₁ ⬝ B₁) (A₁ ⬝ B₂) (A₂ ⬝ B₁) (A₂ ⬝ B₂) := by
   funext i j
   rw [fromRows, fromColumns]
   cases i;
@@ -139,7 +141,7 @@ lemma fromRows_mul_fromColumns (A₁ : Matrix M₁ N R) (A₂ : Matrix M₂ N R)
 products of the block matrices -/
 lemma fromColumns_mul_fromRows (A₁ : Matrix M N₁ R) (A₂ : Matrix M N₂ R)
     (B₁ : Matrix N₁ N R) (B₂ : Matrix N₂ N R) :
-    fromColumns A₁ A₂ ⬝ fromRows B₁ B₂ = (A₁⬝B₁ + A₂⬝B₂) := by
+    fromColumns A₁ A₂ ⬝ fromRows B₁ B₂ = (A₁ ⬝ B₁ + A₂ ⬝ B₂) := by
   funext i j
   rw [fromRows, fromColumns]
   simp only [add_apply, mul_apply, of_apply, Fintype.sum_sum_type, Sum.elim_inl, Sum.elim_inr]
@@ -148,7 +150,7 @@ lemma fromColumns_mul_fromRows (A₁ : Matrix M N₁ R) (A₂ : Matrix M N₂ R)
 lemma fromColumns_mul_fromBlocks (A₁ : Matrix M M₁ R) (A₂ : Matrix M M₂ R)
     (B₁₁ : Matrix M₁ N₁ R) (B₁₂ : Matrix M₁ N₂ R) (B₂₁ : Matrix M₂ N₁ R) (B₂₂ : Matrix M₂ N₂ R) :
     (fromColumns A₁ A₂) ⬝ fromBlocks B₁₁ B₁₂ B₂₁ B₂₂ =
-      fromColumns (A₁⬝B₁₁ + A₂⬝B₂₁) (A₁⬝B₁₂ + A₂⬝B₂₂) := by
+      fromColumns (A₁ ⬝ B₁₁ + A₂ ⬝ B₂₁) (A₁ ⬝ B₁₂ + A₂ ⬝ B₂₂) := by
   funext i j
   rw [fromColumns, fromColumns, fromBlocks]
   cases j
@@ -159,7 +161,7 @@ lemma fromColumns_mul_fromBlocks (A₁ : Matrix M M₁ R) (A₂ : Matrix M M₂ 
 lemma fromBlocks_mul_fromRows (A₁ : Matrix N₁ N R) (A₂ : Matrix N₂ N R)
     (B₁₁ : Matrix M₁ N₁ R) (B₁₂ : Matrix M₁ N₂ R) (B₂₁ : Matrix M₂ N₁ R) (B₂₂ : Matrix M₂ N₂ R) :
     fromBlocks B₁₁ B₁₂ B₂₁ B₂₂ ⬝ (fromRows A₁ A₂) =
-      fromRows (B₁₁⬝A₁ + B₁₂⬝A₂) (B₂₁⬝A₁ + B₂₂⬝A₂) := by
+      fromRows (B₁₁ ⬝ A₁ + B₁₂ ⬝ A₂) (B₂₁ ⬝ A₁ + B₂₂ ⬝ A₂) := by
   funext i j
   rw [fromRows, fromRows, fromBlocks]
   cases i
@@ -172,11 +174,11 @@ section CommRing
 
 variable [CommRing R]
 
-/- Given that the index set N and the direct sum of the index sets N₁ and N₂ are in bijection then
-the matrix A : N × (N₁ ⊕ N₂) := Cols[A₁ A₂] is actually a "square". Hence, if its product with
-another matrix B : (N₁ ⊕ N₂) × N := Rows[B₁ B₂] matrix is one, the other matrix must be its inverse
-Mulitplication of a matrix by its inverse is commutative. This is column(row) partioned matrix form
-of `mul_eq_one_comm` -/
+/-- Multiplication of a matrix by its inverse is commutative.
+This is the column and row partitioned matrix form of `Matrix.mul_eq_one_comm`.
+
+The condition `e : N ≃ N₁ ⊕ N₂` states that `fromColumns A₁ A₂` and `fromRows B₁ B₂` are "square".
+-/
 lemma fromColumns_mul_fromRows_eq_one_comm (e : N ≃ N₁ ⊕ N₂)
     (A₁ : Matrix N N₁ R) (A₂ : Matrix N N₂ R) (B₁ : Matrix N₁ N R) (B₂ : Matrix N₂ N R) :
     fromColumns A₁ A₂ ⬝ fromRows B₁ B₂ = 1 ↔ fromRows B₁ B₂ ⬝ fromColumns A₁ A₂ = 1 := by

--- a/Mathlib/Data/Matrix/ColumnRowPartitioned.lean
+++ b/Mathlib/Data/Matrix/ColumnRowPartitioned.lean
@@ -25,130 +25,194 @@ column matrices, row matrices, column row block matrices
 namespace Matrix
 
 variable {R : Type _}
-variable {M M₁ M₂ N N₁ N₂ : Type _}
-variable [Fintype M] [Fintype M₁] [Fintype M₂]
-variable [Fintype N] [Fintype N₁] [Fintype N₂]
-variable [DecidableEq M] [DecidableEq M₁] [DecidableEq M₂]
-variable [DecidableEq N] [DecidableEq N₁] [DecidableEq N₂]
+variable {m m₁ m₂ n n₁ n₂ : Type _}
+variable [Fintype m] [Fintype m₁] [Fintype m₂]
+variable [Fintype n] [Fintype n₁] [Fintype n₂]
+variable [DecidableEq m] [DecidableEq m₁] [DecidableEq m₂]
+variable [DecidableEq n] [DecidableEq n₁] [DecidableEq n₂]
 
-/-- Concatenate together two matrices A₁[M₁ × N] and A₂[M₂ × N] with the same columns (N) to get a
-bigger matrix indexed by [(M₁ ⊕ M₂) × N] -/
-def fromRows (A₁ : Matrix M₁ N R) (A₂ : Matrix M₂ N R) : Matrix (M₁ ⊕ M₂) N R :=
+/-- Concatenate together two matrices A₁[m₁ × N] and A₂[m₂ × N] with the same columns (N) to get a
+bigger matrix indexed by [(m₁ ⊕ m₂) × N] -/
+def fromRows (A₁ : Matrix m₁ n R) (A₂ : Matrix m₂ n R) : Matrix (m₁ ⊕ m₂) n R :=
   of (Sum.elim A₁ A₂)
 
-/-- Concatenate together two matrices B₁[M × N₁] and B₂[M × N₂] with the same rows (M) to get a
-bigger matrix indexed by [M × (N₁ ⊕ N₂)] -/
-def fromColumns (B₁ : Matrix M N₁ R) (B₂ : Matrix M N₂ R) : Matrix M (N₁ ⊕ N₂) R :=
+/-- Concatenate together two matrices B₁[m × n₁] and B₂[m × n₂] with the same rows (M) to get a
+bigger matrix indexed by [m × (n₁ ⊕ n₂)] -/
+def fromColumns (B₁ : Matrix m n₁ R) (B₂ : Matrix m n₂ R) : Matrix m (n₁ ⊕ n₂) R :=
   of fun i => Sum.elim (B₁ i) (B₂ i)
 
 /-- Given a column partitioned matrix extract the first column -/
-def toColumns₁ (A : Matrix M (N₁ ⊕ N₂) R) : Matrix M N₁ R := of fun i j => (A i (Sum.inl j))
+def toColumns₁ (A : Matrix m (n₁ ⊕ n₂) R) : Matrix m n₁ R := of fun i j => (A i (Sum.inl j))
 
 /-- Given a column partitioned matrix extract the second column -/
-def toColumns₂ (A : Matrix M (N₁ ⊕ N₂) R) : Matrix M N₂ R := of fun i j => (A i (Sum.inr j))
+def toColumns₂ (A : Matrix m (n₁ ⊕ n₂) R) : Matrix m n₂ R := of fun i j => (A i (Sum.inr j))
 
 /-- Given a row partitioned matrix extract the first row -/
-def toRows₁ (A : Matrix (M₁ ⊕ M₂) N R) : Matrix M₁ N R := of fun i j => (A (Sum.inl i) j)
+def toRows₁ (A : Matrix (m₁ ⊕ m₂) n R) : Matrix m₁ n R := of fun i j => (A (Sum.inl i) j)
 
 /-- Given a row partitioned matrix extract the second row -/
-def toRows₂ (A : Matrix (M₁ ⊕ M₂) N R) : Matrix M₂ N R := of fun i j => (A (Sum.inr i) j)
+def toRows₂ (A : Matrix (m₁ ⊕ m₂) n R) : Matrix m₂ n R := of fun i j => (A (Sum.inr i) j)
 
 @[simp]
-lemma fromColumns_toColumns (A : Matrix M (N₁ ⊕ N₂) R) :
+lemma fromColumns_toColumns (A : Matrix m (n₁ ⊕ n₂) R) :
     fromColumns A.toColumns₁ A.toColumns₂ = A := by
   unfold fromColumns toColumns₁ toColumns₂
   funext i j
   cases' j
   all_goals (simp only [of_apply, Sum.elim_inl, Sum.elim_inr])
 
-lemma fromColumns_ext_iff (A₁ : Matrix M N₁ R) (A₂ : Matrix M N₂ R) (B₁ : Matrix M N₁ R)
-    (B₂ : Matrix M N₂ R) :
-    fromColumns A₁ A₂ = fromColumns B₁ B₂ ↔ A₁ = B₁ ∧ A₂ = B₂ := by
-  simp_rw [fromColumns, ← Matrix.ext_iff, of_apply, Sum.forall, Sum.elim_inl, Sum.elim_inr]
-  exact ⟨(fun h => ⟨fun i j => (h i).1 j, fun _ _ => (h _).2 _⟩),
-    (fun h => (fun _ => ⟨(h.1 _), (h.2 _)⟩))⟩
-
-lemma fromRows_toRows (A : Matrix (M₁ ⊕ M₂) N R) : A = fromRows A.toRows₁ A.toRows₂ := by
+@[simp]
+lemma fromRows_toRows (A : Matrix (m₁ ⊕ m₂) n R) : fromRows A.toRows₁ A.toRows₂ = A := by
   unfold fromRows toRows₁ toRows₂
   funext i j
   cases' i
   all_goals (simp only [of_apply, Sum.elim_inl, Sum.elim_inr])
 
-lemma fromRows_ext_iff (A₁ : Matrix M₁ N R) (A₂ : Matrix M₂ N R) (B₁ : Matrix M₁ N R)
-    (B₂ : Matrix M₂ N R) : fromRows A₁ A₂ = fromRows B₁ B₂ ↔ A₁ = B₁ ∧ A₂ = B₂ := by
-  simp_rw [fromRows, ← Matrix.ext_iff, of_apply, Sum.forall, Sum.elim_inl, Sum.elim_inr]
+lemma fromRows_inj : Function.Injective2 (@fromRows R m₁ m₂ n) := by
+  intros x1 x2 y1 y2
+  unfold fromRows
+  simp_rw [Function.funext_iff, ← Matrix.ext_iff, EmbeddingLike.apply_eq_iff_eq,
+    of_apply, Sum.forall, Sum.elim_inl, Sum.elim_inr]
+  exact (fun h => ⟨ fun _ _ => h.1 _ _ , fun _ _ => h.2 _ _ ⟩)
+
+lemma fromColumns_inj : Function.Injective2 (@fromColumns R m n₁ n₂) := by
+  intros x1 x2 y1 y2
+  unfold fromColumns
+  simp_rw [Function.funext_iff, ← Matrix.ext_iff, EmbeddingLike.apply_eq_iff_eq,
+    of_apply, Sum.forall, Sum.elim_inl, Sum.elim_inr]
+  exact (fun h => ⟨fun _ _ => (h _).1 _, fun _ _ => (h _).2 _⟩)
+
+lemma fromColumns_ext_iff (A₁ : Matrix m n₁ R) (A₂ : Matrix m n₂ R) (B₁ : Matrix m n₁ R)
+    (B₂ : Matrix m n₂ R) :
+    fromColumns A₁ A₂ = fromColumns B₁ B₂ ↔ A₁ = B₁ ∧ A₂ = B₂ := fromColumns_inj.eq_iff
+
+lemma fromRows_ext_iff (A₁ : Matrix m₁ n R) (A₂ : Matrix m₂ n R) (B₁ : Matrix m₁ n R)
+    (B₂ : Matrix m₂ n R) :
+    fromRows A₁ A₂ = fromRows B₁ B₂ ↔ A₁ = B₁ ∧ A₂ = B₂ := fromRows_inj.eq_iff
+
+@[simp]
+lemma fromRows_apply_inl (A₁ : Matrix m₁ n R) (A₂ : Matrix m₂ n R) (i : m₁) (j : n) :
+    (fromRows A₁ A₂) (Sum.inl i) j = A₁ i j := by
+  unfold fromRows
+  simp only [of_apply, Sum.elim_inl]
+
+@[simp]
+lemma fromRows_apply_inr (A₁ : Matrix m₁ n R) (A₂ : Matrix m₂ n R) (i : m₂) (j : n) :
+    (fromRows A₁ A₂) (Sum.inr i) j = A₂ i j := by
+  unfold fromRows
+  simp only [of_apply, Sum.elim_inr]
+
+@[simp]
+lemma fromColumns_apply_inl (A₁ : Matrix m n₁ R) (A₂ : Matrix m n₂ R) (i : m) (j : n₁) :
+    (fromColumns A₁ A₂) i (Sum.inl j) = A₁ i j := by
+  unfold fromColumns
+  simp only [of_apply, Sum.elim_inl]
+
+@[simp]
+lemma fromColumns_apply_inr (A₁ : Matrix m n₁ R) (A₂ : Matrix m n₂ R) (i : m) (j : n₂) :
+    (fromColumns A₁ A₂) i (Sum.inr j) = A₂ i j := by
+  unfold fromColumns
+  simp only [of_apply, Sum.elim_inr]
 
 /- A column partioned matrix when transposed gives a row partioned matrix with columns of the
 initial matrix tranposed to become rows. -/
-lemma transpose_fromColumns (A₁ : Matrix M N₁ R) (A₂ : Matrix M N₂ R) :
+lemma transpose_fromColumns (A₁ : Matrix m n₁ R) (A₂ : Matrix m n₂ R) :
     transpose (fromColumns A₁ A₂) = fromRows (transpose A₁) (transpose A₂) := by
-  rw [fromColumns, fromRows]
   funext i j
   cases' i with i i
-  all_goals (simp only [transpose_apply, of_apply, Sum.elim_inl, Sum.elim_inr] )
+  all_goals (simp only [transpose_apply, fromColumns_apply_inl, fromRows_apply_inl,
+    fromColumns_apply_inr, fromRows_apply_inr])
 
 /- A row partioned matrix when transposed gives a column partioned matrix with rows of the initial
 matrix tranposed to become columns. -/
-lemma transpose_fromRows_eq_fromColumns_transpose (A₁ : Matrix M₁ N R) (A₂ : Matrix M₂ N R) :
+lemma transpose_fromRows (A₁ : Matrix m₁ n R) (A₂ : Matrix m₂ n R) :
     transpose (fromRows A₁ A₂) = fromColumns (transpose A₁) (transpose A₂) := by
-  rw [fromColumns, fromRows]
   funext i j
   cases' j with j j
-  all_goals (simp only [transpose_apply, of_apply, Sum.elim_inl, Sum.elim_inr] )
+  all_goals (simp only [transpose_apply, fromRows_apply_inl, fromColumns_apply_inl,
+    fromColumns_apply_inr, fromRows_apply_inr])
 
 section Semiring
 
 variable [Semiring R]
-
-lemma fromRows_mul (A₁ : Matrix M₁ N R) (A₂ : Matrix M₂ N R) (B : Matrix N M R) :
+/- The proofs are "shorter" with the unfolds instead of the simp lemmas above so I will continue
+with them for the next lemmas -/
+@[simp]
+lemma fromRows_mul (A₁ : Matrix m₁ n R) (A₂ : Matrix m₂ n R) (B : Matrix n m R) :
     (fromRows A₁ A₂) ⬝ B = fromRows (A₁ ⬝ B) (A₂ ⬝ B) := by
   unfold fromRows
   funext i j
   cases' i with i i
   all_goals (simp only [mul_apply, of_apply, Sum.elim_inl, Sum.elim_inr] )
 
-lemma mul_fromColumns (A : Matrix M N R) (B₁ : Matrix N N₁ R) (B₂ : Matrix N N₂ R) :
+@[simp]
+lemma mul_fromColumns (A : Matrix m n R) (B₁ : Matrix n n₁ R) (B₂ : Matrix n n₂ R) :
     A ⬝ (fromColumns B₁ B₂) = fromColumns (A ⬝ B₁) (A ⬝ B₂) := by
   unfold fromColumns
   funext i j
   cases' j with j j
   all_goals (simp only [mul_apply, of_apply, Sum.elim_inl, Sum.elim_inr] )
 
-lemma fromRows_zero : fromRows (0 : Matrix M₁ N R) (0 : Matrix M₂ N R) = 0 := by
+@[simp]
+lemma fromRows_zero : fromRows (0 : Matrix m₁ n R) (0 : Matrix m₂ n R) = 0 := by
   funext i j
   unfold fromRows
   simp only [Sum.elim_zero_zero, of_apply, Pi.zero_apply, zero_apply]
 
-lemma fromColumns_zero : fromColumns (0 : Matrix M N₁ R) (0 : Matrix M N₂ R) = 0 := by
+@[simp]
+lemma fromColumns_zero : fromColumns (0 : Matrix m n₁ R) (0 : Matrix m n₂ R) = 0 := by
   funext i j
   unfold fromColumns
   cases' j with j j
   all_goals (simp only [of_apply, Sum.elim_inl, Sum.elim_inr, zero_apply])
 
+@[simp]
+lemma fromColumns_fromRows_eq_fromBlocks (B₁₁ : Matrix m₁ n₁ R) (B₁₂ : Matrix m₁ n₂ R)
+    (B₂₁ : Matrix m₂ n₁ R) (B₂₂ : Matrix m₂ n₂ R) :
+    fromColumns (fromRows B₁₁ B₂₁) (fromRows B₁₂ B₂₂) = fromBlocks B₁₁ B₁₂ B₂₁ B₂₂ := by
+    unfold fromRows fromColumns
+    funext i j
+    cases' i with i i
+    all_goals (
+      cases' j with j j;
+      all_goals ( simp only [of_apply, Sum.elim_inl, Sum.elim_inr, fromBlocks_apply₁₁,
+        fromBlocks_apply₁₂, fromBlocks_apply₂₁, fromBlocks_apply₂₂] ) )
+
+@[simp]
+lemma fromRows_fromColumn_eq_fromBlocks (B₁₁ : Matrix m₁ n₁ R) (B₁₂ : Matrix m₁ n₂ R)
+    (B₂₁ : Matrix m₂ n₁ R) (B₂₂ : Matrix m₂ n₂ R) :
+    fromRows (fromColumns B₁₁ B₁₂) (fromColumns B₂₁ B₂₂) = fromBlocks B₁₁ B₁₂ B₂₁ B₂₂ := by
+    unfold fromRows fromColumns
+    funext i j
+    cases' i with i i
+    all_goals (
+      cases' j with j j;
+      all_goals ( simp only [of_apply, Sum.elim_inl, Sum.elim_inr, fromBlocks_apply₁₁,
+        fromBlocks_apply₁₂, fromBlocks_apply₂₁, fromBlocks_apply₂₂] ) )
+
 /-- A row partitioned matrix multiplied by a column partioned matrix gives a 2 by 2 block matrix -/
-lemma fromRows_mul_fromColumns (A₁ : Matrix M₁ N R) (A₂ : Matrix M₂ N R)
-    (B₁ : Matrix N N₁ R) (B₂ : Matrix N N₂ R) :
-    (fromRows A₁ A₂) ⬝ (fromColumns B₁ B₂) = fromBlocks (A₁ ⬝ B₁) (A₁ ⬝ B₂) (A₂ ⬝ B₁) (A₂ ⬝ B₂) := by
+lemma fromRows_mul_fromColumns (A₁ : Matrix m₁ n R) (A₂ : Matrix m₂ n R)
+    (B₁ : Matrix n n₁ R) (B₂ : Matrix n n₂ R) : (fromRows A₁ A₂) ⬝ (fromColumns B₁ B₂) =
+      fromBlocks (A₁ ⬝ B₁) (A₁ ⬝ B₂) (A₂ ⬝ B₁) (A₂ ⬝ B₂) := by
   funext i j
   rw [fromRows, fromColumns]
   cases i;
   all_goals (cases j)
-  all_goals (simp only [
-    fromBlocks_apply₁₁, fromBlocks_apply₁₂, fromBlocks_apply₂₁, fromBlocks_apply₂₂,
-      mul_apply, of_apply, Sum.elim_inl, Sum.elim_inr] )
+  all_goals (simp only [fromBlocks_apply₁₁, fromBlocks_apply₁₂, fromBlocks_apply₂₁,
+    fromBlocks_apply₂₂, mul_apply, of_apply, Sum.elim_inl, Sum.elim_inr] )
 
 /-- A column partitioned matrix mulitplied by a row partitioned matrix gives the sum of the "outer"
 products of the block matrices -/
-lemma fromColumns_mul_fromRows (A₁ : Matrix M N₁ R) (A₂ : Matrix M N₂ R)
-    (B₁ : Matrix N₁ N R) (B₂ : Matrix N₂ N R) :
+lemma fromColumns_mul_fromRows (A₁ : Matrix m n₁ R) (A₂ : Matrix m n₂ R)
+    (B₁ : Matrix n₁ n R) (B₂ : Matrix n₂ n R) :
     fromColumns A₁ A₂ ⬝ fromRows B₁ B₂ = (A₁ ⬝ B₁ + A₂ ⬝ B₂) := by
   funext i j
   rw [fromRows, fromColumns]
   simp only [add_apply, mul_apply, of_apply, Fintype.sum_sum_type, Sum.elim_inl, Sum.elim_inr]
 
 /-- A column partitioned matrix multipiled by a block matrix results in a column partioned matrix -/
-lemma fromColumns_mul_fromBlocks (A₁ : Matrix M M₁ R) (A₂ : Matrix M M₂ R)
-    (B₁₁ : Matrix M₁ N₁ R) (B₁₂ : Matrix M₁ N₂ R) (B₂₁ : Matrix M₂ N₁ R) (B₂₂ : Matrix M₂ N₂ R) :
+lemma fromColumns_mul_fromBlocks (A₁ : Matrix m m₁ R) (A₂ : Matrix m m₂ R)
+    (B₁₁ : Matrix m₁ n₁ R) (B₁₂ : Matrix m₁ n₂ R) (B₂₁ : Matrix m₂ n₁ R) (B₂₂ : Matrix m₂ n₂ R) :
     (fromColumns A₁ A₂) ⬝ fromBlocks B₁₁ B₁₂ B₂₁ B₂₂ =
       fromColumns (A₁ ⬝ B₁₁ + A₂ ⬝ B₂₁) (A₁ ⬝ B₁₂ + A₂ ⬝ B₂₂) := by
   funext i j
@@ -158,8 +222,8 @@ lemma fromColumns_mul_fromBlocks (A₁ : Matrix M M₁ R) (A₂ : Matrix M M₂ 
     Sum.elim_inr, mul_apply]
 
 /-- A block matrix mulitplied by a row partitioned matrix gives a row partitioned matrix -/
-lemma fromBlocks_mul_fromRows (A₁ : Matrix N₁ N R) (A₂ : Matrix N₂ N R)
-    (B₁₁ : Matrix M₁ N₁ R) (B₁₂ : Matrix M₁ N₂ R) (B₂₁ : Matrix M₂ N₁ R) (B₂₂ : Matrix M₂ N₂ R) :
+lemma fromBlocks_mul_fromRows (A₁ : Matrix n₁ n R) (A₂ : Matrix n₂ n R)
+    (B₁₁ : Matrix m₁ n₁ R) (B₁₂ : Matrix m₁ n₂ R) (B₂₁ : Matrix m₂ n₁ R) (B₂₂ : Matrix m₂ n₂ R) :
     fromBlocks B₁₁ B₁₂ B₂₁ B₂₂ ⬝ (fromRows A₁ A₂) =
       fromRows (B₁₁ ⬝ A₁ + B₁₂ ⬝ A₂) (B₂₁ ⬝ A₁ + B₂₂ ⬝ A₂) := by
   funext i j
@@ -177,10 +241,10 @@ variable [CommRing R]
 /-- Multiplication of a matrix by its inverse is commutative.
 This is the column and row partitioned matrix form of `Matrix.mul_eq_one_comm`.
 
-The condition `e : N ≃ N₁ ⊕ N₂` states that `fromColumns A₁ A₂` and `fromRows B₁ B₂` are "square".
+The condition `e : n ≃ n₁ ⊕ n₂` states that `fromColumns A₁ A₂` and `fromRows B₁ B₂` are "square".
 -/
-lemma fromColumns_mul_fromRows_eq_one_comm (e : N ≃ N₁ ⊕ N₂)
-    (A₁ : Matrix N N₁ R) (A₂ : Matrix N N₂ R) (B₁ : Matrix N₁ N R) (B₂ : Matrix N₂ N R) :
+lemma fromColumns_mul_fromRows_eq_one_comm (e : n ≃ n₁ ⊕ n₂)
+    (A₁ : Matrix n n₁ R) (A₂ : Matrix n n₂ R) (B₁ : Matrix n₁ n R) (B₂ : Matrix n₂ n R) :
     fromColumns A₁ A₂ ⬝ fromRows B₁ B₂ = 1 ↔ fromRows B₁ B₂ ⬝ fromColumns A₁ A₂ = 1 := by
   constructor
   intro h
@@ -194,11 +258,11 @@ lemma fromColumns_mul_fromRows_eq_one_comm (e : N ≃ N₁ ⊕ N₂)
   ( rw [mul_eq_one_comm, ← Matrix.submatrix_mul, h, submatrix_one_equiv]
     exact Function.bijective_id )
 
-/- The lemma `fromColumns_mul_fromRows_eq_one_comm` specialized to the case where the index sets N₁
-and N₂, are the result of subtyping by a predicate and its complement. -/
-lemma equiv_compl_fromColumns_mul_fromRows_eq_one_comm (p : N → Prop)[DecidablePred p]
-    (A₁ : Matrix N {i // p i} R) (A₂ : Matrix N {i // ¬p i} R)
-    (B₁ : Matrix {i // p i} N R) (B₂ : Matrix {i // ¬p i} N R) :
+/- The lemma `fromColumns_mul_fromRows_eq_one_comm` specialized to the case where the index sets n₁
+and n₂, are the result of subtyping by a predicate and its complement. -/
+lemma equiv_compl_fromColumns_mul_fromRows_eq_one_comm (p : n → Prop)[DecidablePred p]
+    (A₁ : Matrix n {i // p i} R) (A₂ : Matrix n {i // ¬p i} R)
+    (B₁ : Matrix {i // p i} n R) (B₂ : Matrix {i // ¬p i} n R) :
     fromColumns A₁ A₂ ⬝ fromRows B₁ B₂ = 1 ↔ fromRows B₁ B₂ ⬝ fromColumns A₁ A₂ = 1 :=
   fromColumns_mul_fromRows_eq_one_comm (id (Equiv.sumCompl p).symm) A₁ A₂ B₁ B₂
 
@@ -208,8 +272,8 @@ section Star
 variable [Star R]
 /- A column partioned matrix in a Star ring when conjugate transposed gives a row partitioned matrix
 with the columns of the initial matrix conjugate transposed to become rows. -/
-lemma conjTranspose_fromColumns_eq_fromRows_conjTranspose (A₁ : Matrix M N₁ R)
-    (A₂ : Matrix M N₂ R) : conjTranspose (fromColumns A₁ A₂) =
+lemma conjTranspose_fromColumns_eq_fromRows_conjTranspose (A₁ : Matrix m n₁ R)
+    (A₂ : Matrix m n₂ R) : conjTranspose (fromColumns A₁ A₂) =
       fromRows (conjTranspose A₁) (conjTranspose A₂) := by
   rw [fromColumns, fromRows]
   funext i j
@@ -218,8 +282,8 @@ lemma conjTranspose_fromColumns_eq_fromRows_conjTranspose (A₁ : Matrix M N₁ 
 
 /- A row partioned matrix in a Star ring when conjugate transposed gives a column partitioned matrix
 with the rows of the initial matrix conjugate transposed to become columns. -/
-lemma conjTranspose_fromRows_eq_fromColumns_conjTranspose (A₁ : Matrix M₁ N R)
-    (A₂ : Matrix M₂ N R) : conjTranspose (fromRows A₁ A₂) =
+lemma conjTranspose_fromRows_eq_fromColumns_conjTranspose (A₁ : Matrix m₁ n R)
+    (A₂ : Matrix m₂ n R) : conjTranspose (fromRows A₁ A₂) =
       fromColumns (conjTranspose A₁) (conjTranspose A₂) := by
   rw [fromColumns, fromRows]
   funext j i

--- a/Mathlib/Data/Matrix/ColumnRowPartitioned.lean
+++ b/Mathlib/Data/Matrix/ColumnRowPartitioned.lean
@@ -24,79 +24,103 @@ column matrices, row matrices, column row block matrices
 
 namespace Matrix
 
-variable {R: Type}[CommRing R]
+variable {R: Type}
 variable {M M₁ M₂ N N₁ N₂: Type}
 variable [Fintype M][Fintype M₁][Fintype M₂]
 variable [Fintype N][Fintype N₁][Fintype N₂]
 variable [DecidableEq M][DecidableEq M₁][DecidableEq M₂]
 variable [DecidableEq N][DecidableEq N₁][DecidableEq N₂]
 
-/- Concatenate together two matrices A₁[M₁ × N] and A₂[M₂ × N] with the same columns (N) to get a
+/-- Concatenate together two matrices A₁[M₁ × N] and A₂[M₂ × N] with the same columns (N) to get a
 bigger matrix indexed by [(M₁ ⊕ M₂) × N] -/
-def fromRows (A₁: Matrix M₁ N R) (A₂: Matrix M₂ N R) : Matrix (M₁ ⊕ M₂) N R :=
+def fromRows (A₁ : Matrix M₁ N R) (A₂ : Matrix M₂ N R) : Matrix (M₁ ⊕ M₂) N R :=
   Matrix.of (Sum.elim A₁ A₂)
 
-/- Concatenate together two matrices B₁[M × N₁] and B₂[M × N₂] with the same Rows (M) to get a
+/-- Concatenate together two matrices B₁[M × N₁] and B₂[M × N₂] with the same Rows (M) to get a
 bigger matrix indexed by [M × (N₁ ⊕ N₂)] -/
-def fromColumns (B₁: Matrix M N₁ R) (B₂: Matrix M N₂ R) : Matrix M (N₁ ⊕ N₂) R :=
+def fromColumns (B₁ : Matrix M N₁ R) (B₂ : Matrix M N₂ R) : Matrix M (N₁ ⊕ N₂) R :=
   Matrix.of fun i => Sum.elim (B₁ i) (B₂ i)
 
-/- Given a column(row) partitioned matrix extract the first or second column(row) -/
-def toColumns₁ (A: Matrix M (N₁ ⊕ N₂) R): Matrix M N₁ R :=  of fun i j => (A i (Sum.inl j))
-def toColumns₂ (A: Matrix M (N₁ ⊕ N₂) R): Matrix M N₂ R :=  of fun i j => (A i (Sum.inr j))
-def toRows₁ (A: Matrix (M₁ ⊕ M₂) N R): Matrix M₁ N R :=  of fun i j => (A (Sum.inl i) j)
-def toRows₂ (A: Matrix (M₁ ⊕ M₂) N R): Matrix M₂ N R :=  of fun i j => (A (Sum.inr i) j)
+/-- Given a column partitioned matrix extract the first column -/
+def toColumns₁ (A : Matrix M (N₁ ⊕ N₂) R) : Matrix M N₁ R :=  of fun i j => (A i (Sum.inl j))
+/-- Given a column partitioned matrix extract the second column -/
+def toColumns₂ (A : Matrix M (N₁ ⊕ N₂) R) : Matrix M N₂ R :=  of fun i j => (A i (Sum.inr j))
+/-- Given a row partitioned matrix extract the first row -/
+def toRows₁ (A : Matrix (M₁ ⊕ M₂) N R) : Matrix M₁ N R :=  of fun i j => (A (Sum.inl i) j)
+/-- Given a row partitioned matrix extract the second row -/
+def toRows₂ (A : Matrix (M₁ ⊕ M₂) N R) : Matrix M₂ N R :=  of fun i j => (A (Sum.inr i) j)
 
-lemma fromColumns_toColumns (A: Matrix M (N₁ ⊕ N₂) R) :
+lemma fromColumns_toColumns (A : Matrix M (N₁ ⊕ N₂) R) :
     A = fromColumns A.toColumns₁ A.toColumns₂ := by
   unfold fromColumns toColumns₁ toColumns₂
   funext i j
   cases' j
   all_goals (simp only [of_apply, Sum.elim_inl, Sum.elim_inr])
 
-lemma fromColumns_ext_iff (A₁: Matrix M N₁ R) (A₂: Matrix M N₂ R) (B₁: Matrix M N₁ R)
-    (B₂: Matrix M N₂ R) : fromColumns A₁ A₂ = fromColumns B₁ B₂ ↔ A₁ = B₁ ∧ A₂ = B₂ := by
-  simp_rw [fromColumns, ← Matrix.ext_iff, of_apply]
-  simp only [Sum.forall, Sum.elim_inl, Sum.elim_inr]
-  exact ⟨ -- Just practicing term mode proofs !!
-    (fun h => ⟨fun i j => (h i).1 j, fun _ _ => (h _).2 _⟩),
-    (fun h => (fun _ => ⟨(h.1 _), (h.2 _)⟩))
-  ⟩
+lemma fromColumns_ext_iff (A₁ : Matrix M N₁ R) (A₂ : Matrix M N₂ R) (B₁ : Matrix M N₁ R)
+    (B₂ : Matrix M N₂ R) : fromColumns A₁ A₂ = fromColumns B₁ B₂ ↔ A₁ = B₁ ∧ A₂ = B₂ := by
+  simp_rw [fromColumns, ← Matrix.ext_iff, of_apply, Sum.forall, Sum.elim_inl, Sum.elim_inr]
+  exact ⟨(fun h => ⟨fun i j => (h i).1 j, fun _ _ => (h _).2 _⟩),
+    (fun h => (fun _ => ⟨(h.1 _), (h.2 _)⟩))⟩
 
-lemma fromRows_toRows (A: Matrix (M₁ ⊕ M₂) N R) : A = fromRows A.toRows₁ A.toRows₂ := by
+lemma fromRows_toRows (A : Matrix (M₁ ⊕ M₂) N R) : A = fromRows A.toRows₁ A.toRows₂ := by
   unfold fromRows toRows₁ toRows₂
   funext i j
   cases' i
   all_goals (simp only [of_apply, Sum.elim_inl, Sum.elim_inr])
 
-lemma fromRows_mul (A₁: Matrix M₁ N R) (A₂: Matrix M₂ N R) (B: Matrix N M R) :
+/- A column partioned matrix when transposed gives a row partioned matrix with columns of the
+initial matrix tranposed to become rows. -/
+lemma transpose_fromColumns_eq_fromRows_transpose
+    (A₁ : Matrix M N₁ R) (A₂ : Matrix M N₂ R) :
+    transpose (fromColumns A₁ A₂) = fromRows (transpose A₁) (transpose A₂) := by
+  rw [fromColumns, fromRows]
+  funext i j
+  cases' i with i i
+  all_goals (simp only [transpose_apply, of_apply, Sum.elim_inl, Sum.elim_inr] )
+
+/- A row partioned matrix when transposed gives a column partioned matrix with rows of the initial
+matrix tranposed to become columns. -/
+lemma transpose_fromRows_eq_fromColumns_transpose
+    (A₁ : Matrix M₁ N R) (A₂ : Matrix M₂ N R):
+    transpose (fromRows A₁ A₂) = fromColumns (transpose A₁) (transpose A₂) := by
+  rw [fromColumns, fromRows]
+  funext i j
+  cases' j with j j
+  all_goals (simp only [transpose_apply, of_apply, Sum.elim_inl, Sum.elim_inr] )
+
+section Semiring
+
+variable [Semiring R]
+
+lemma fromRows_mul (A₁ : Matrix M₁ N R) (A₂ : Matrix M₂ N R) (B : Matrix N M R) :
     (fromRows A₁ A₂) ⬝ B = fromRows (A₁⬝B) (A₂⬝B) := by
   unfold fromRows
   funext i j
   cases' i with i i
   all_goals (simp only [mul_apply, of_apply, Sum.elim_inl, Sum.elim_inr] )
 
-lemma mul_fromColumns (A: Matrix M N R) (B₁: Matrix N N₁ R) (B₂: Matrix N N₂ R) :
+lemma mul_fromColumns (A : Matrix M N R) (B₁ : Matrix N N₁ R) (B₂ : Matrix N N₂ R) :
     A ⬝ (fromColumns B₁ B₂) = fromColumns (A⬝B₁) (A⬝B₂) := by
   unfold fromColumns
   funext i j
   cases' j with j j
   all_goals (simp only [mul_apply, of_apply, Sum.elim_inl, Sum.elim_inr] )
 
-lemma fromRows_zero: fromRows (0: Matrix M₁ N R) (0: Matrix M₂ N R) = 0 := by
+lemma fromRows_zero : fromRows (0 : Matrix M₁ N R) (0 : Matrix M₂ N R) = 0 := by
   funext i j
   unfold fromRows
   simp only [Sum.elim_zero_zero, of_apply, Pi.zero_apply, zero_apply]
 
-lemma fromColumns_zero: fromColumns (0: Matrix M N₁ R) (0: Matrix M N₂ R) = 0 := by
+lemma fromColumns_zero : fromColumns (0 : Matrix M N₁ R) (0 : Matrix M N₂ R) = 0 := by
   funext i j
   unfold fromColumns
   cases' j with j j
   all_goals (simp only [of_apply, Sum.elim_inl, Sum.elim_inr, zero_apply])
 
-/- A row partitioned matrix multiplied by a column partioned matrix gives a 2 by 2 block matrix -/
-lemma fromRows_mul_fromColumns (A₁: Matrix M₁ N R) (A₂: Matrix M₂ N R)
-    (B₁: Matrix N N₁ R) (B₂: Matrix N N₂ R) :
+/-- A row partitioned matrix multiplied by a column partioned matrix gives a 2 by 2 block matrix -/
+lemma fromRows_mul_fromColumns (A₁ : Matrix M₁ N R) (A₂ : Matrix M₂ N R)
+    (B₁ : Matrix N N₁ R) (B₂ : Matrix N N₂ R) :
     (fromRows A₁ A₂) ⬝ (fromColumns B₁ B₂) = fromBlocks (A₁⬝B₁) (A₁⬝B₂) (A₂⬝B₁) (A₂⬝B₂) := by
   funext i j
   rw [fromRows, fromColumns]
@@ -106,18 +130,18 @@ lemma fromRows_mul_fromColumns (A₁: Matrix M₁ N R) (A₂: Matrix M₂ N R)
     fromBlocks_apply₁₁, fromBlocks_apply₁₂, fromBlocks_apply₂₁, fromBlocks_apply₂₂,
       mul_apply, of_apply, Sum.elim_inl, Sum.elim_inr] )
 
-/- A column partitioned matrix mulitplied by a row partitioned matrix gives the sum of the "outer"
+/-- A column partitioned matrix mulitplied by a row partitioned matrix gives the sum of the "outer"
 products of the block matrices -/
-lemma fromColumns_mul_fromRows (A₁: Matrix M N₁ R) (A₂: Matrix M N₂ R)
-    (B₁: Matrix N₁ N R)(B₂: Matrix N₂ N R) :
+lemma fromColumns_mul_fromRows (A₁ : Matrix M N₁ R) (A₂ : Matrix M N₂ R)
+    (B₁ : Matrix N₁ N R) (B₂ : Matrix N₂ N R) :
     fromColumns A₁ A₂ ⬝ fromRows B₁ B₂ = (A₁⬝B₁ + A₂⬝B₂) := by
   funext i j
   rw [fromRows, fromColumns]
   simp only [add_apply, mul_apply, of_apply, Fintype.sum_sum_type, Sum.elim_inl, Sum.elim_inr]
 
-/- A column partitioned matrix multipiled by a block matrix results in a column partioned matrix -/
-lemma fromColumns_mul_fromBlocks (A₁: Matrix M M₁ R) (A₂: Matrix M M₂ R)
-    (B₁₁: Matrix M₁ N₁ R)(B₁₂: Matrix M₁ N₂ R)(B₂₁: Matrix M₂ N₁ R)(B₂₂: Matrix M₂ N₂ R):
+/-- A column partitioned matrix multipiled by a block matrix results in a column partioned matrix -/
+lemma fromColumns_mul_fromBlocks (A₁ : Matrix M M₁ R) (A₂ : Matrix M M₂ R)
+    (B₁₁ : Matrix M₁ N₁ R) (B₁₂ : Matrix M₁ N₂ R) (B₂₁ : Matrix M₂ N₁ R) (B₂₂ : Matrix M₂ N₂ R) :
     (fromColumns A₁ A₂) ⬝ fromBlocks B₁₁ B₁₂ B₂₁ B₂₂ =
       fromColumns (A₁⬝B₁₁ + A₂⬝B₂₁) (A₁⬝B₁₂ + A₂⬝B₂₂) := by
   funext i j
@@ -126,9 +150,9 @@ lemma fromColumns_mul_fromBlocks (A₁: Matrix M M₁ R) (A₂: Matrix M M₂ R)
   all_goals simp only [of_apply, add_apply, Fintype.sum_sum_type, Sum.elim_inl,
     Sum.elim_inr, mul_apply]
 
-/- A block matrix mulitplied by a row partitioned matrix gives a row partitioned matrix -/
-lemma fromBlocks_mul_fromRows (A₁: Matrix N₁ N R) (A₂: Matrix N₂ N R)
-    (B₁₁: Matrix M₁ N₁ R) (B₁₂: Matrix M₁ N₂ R) (B₂₁: Matrix M₂ N₁ R) (B₂₂: Matrix M₂ N₂ R):
+/-- A block matrix mulitplied by a row partitioned matrix gives a row partitioned matrix -/
+lemma fromBlocks_mul_fromRows (A₁ : Matrix N₁ N R) (A₂ : Matrix N₂ N R)
+    (B₁₁ : Matrix M₁ N₁ R) (B₁₂ : Matrix M₁ N₂ R) (B₂₁ : Matrix M₂ N₁ R) (B₂₂ : Matrix M₂ N₂ R) :
     fromBlocks B₁₁ B₁₂ B₂₁ B₂₂ ⬝ (fromRows A₁ A₂) =
       fromRows (B₁₁⬝A₁ + B₁₂⬝A₂) (B₂₁⬝A₁ + B₂₂⬝A₂) := by
   funext i j
@@ -137,14 +161,20 @@ lemma fromBlocks_mul_fromRows (A₁: Matrix N₁ N R) (A₂: Matrix N₂ N R)
   all_goals simp only [of_apply, add_apply, Fintype.sum_sum_type, Sum.elim_inl, Sum.elim_inr,
     mul_apply]
 
+end Semiring
+
+section CommRing
+
+variable [CommRing R]
+
 /- Given that the index set N and the direct sum of the index sets N₁ and N₂ are in bijection then
 the matrix A : N × (N₁ ⊕ N₂) := Cols[A₁ A₂] is actually a "square". Hence, if its product with
 another matrix B : (N₁ ⊕ N₂) × N := Rows[B₁ B₂] matrix is one, the other matrix must be its inverse
 Mulitplication of a matrix by its inverse is commutative. This is column partioned matrix form of
 `mul_eq_one_comm` -/
-lemma fromColumns_mul_fromRows_eq_one_comm (e: N ≃ N₁ ⊕ N₂)
-  (A₁: Matrix N N₁ R) (A₂: Matrix N N₂ R) (B₁: Matrix N₁ N R) (B₂: Matrix N₂ N R):
-  fromColumns A₁ A₂ ⬝ fromRows B₁ B₂ = 1 ↔ fromRows B₁ B₂ ⬝ fromColumns A₁ A₂ = 1 := by
+lemma fromColumns_mul_fromRows_eq_one_comm (e : N ≃ N₁ ⊕ N₂)
+    (A₁ : Matrix N N₁ R) (A₂ : Matrix N N₂ R) (B₁ : Matrix N₁ N R) (B₂ : Matrix N₂ N R) :
+    fromColumns A₁ A₂ ⬝ fromRows B₁ B₂ = 1 ↔ fromRows B₁ B₂ ⬝ fromColumns A₁ A₂ = 1 := by
   constructor
   intro h
   rw [← Matrix.submatrix_id_id (fromRows B₁ B₂ ⬝ fromColumns A₁ A₂),
@@ -159,51 +189,36 @@ lemma fromColumns_mul_fromRows_eq_one_comm (e: N ≃ N₁ ⊕ N₂)
 
 /- The lemma `fromColumns_mul_fromRows_eq_one_comm` specialized to the case where the index sets N₁
 and N₂, are the result of subtyping by a predicate and its complement. -/
-lemma equiv_compl_fromColumns_mul_fromRows_eq_one_comm (p: N → Prop)[DecidablePred p]
-  (A₁: Matrix N {i // p i} R) (A₂: Matrix N {i // ¬p i} R)
-    (B₁: Matrix {i // p i} N R) (B₂: Matrix {i // ¬p i} N R):
-  fromColumns A₁ A₂ ⬝ fromRows B₁ B₂ = 1 ↔ fromRows B₁ B₂ ⬝ fromColumns A₁ A₂ = 1 := by
-  let e := Equiv.sumCompl p
-  exact fromColumns_mul_fromRows_eq_one_comm (id e.symm) A₁ A₂ B₁ B₂
+lemma equiv_compl_fromColumns_mul_fromRows_eq_one_comm (p : N → Prop)[DecidablePred p]
+    (A₁ : Matrix N {i // p i} R) (A₂ : Matrix N {i // ¬p i} R)
+    (B₁ : Matrix {i // p i} N R) (B₂ : Matrix {i // ¬p i} N R) :
+    fromColumns A₁ A₂ ⬝ fromRows B₁ B₂ = 1 ↔ fromRows B₁ B₂ ⬝ fromColumns A₁ A₂ = 1 :=
+  fromColumns_mul_fromRows_eq_one_comm (id (Equiv.sumCompl p).symm) A₁ A₂ B₁ B₂
 
-/- A column partioned matrix when transposed gives a row partioned matrix with columns of the
-initial matrix tranposed to become rows. -/
-lemma transpose_fromColumns_eq_fromRows_transpose {α: Type}
-    (A₁: Matrix M N₁ α) (A₂: Matrix M N₂ α) :
-    transpose (fromColumns A₁ A₂) = fromRows (transpose A₁) (transpose A₂) := by
-  rw [fromColumns, fromRows]
-  funext i j
-  cases' i with i i
-  all_goals (simp only [transpose_apply, of_apply, Sum.elim_inl, Sum.elim_inr] )
+end CommRing
 
+section Star
+variable {R : Type _}[Star R]
 /- A column partioned matrix in a Star ring when conjugate transposed gives a row partitioned matrix
 with the columns of the initial matrix conjugate transposed to become rows. -/
-lemma conjTranspose_fromColumns_eq_fromRows_conjTranspose {α: Type}[Star α]
-    (A₁: Matrix M N₁ α) (A₂: Matrix M N₂ α) :
-    conjTranspose (fromColumns A₁ A₂) = fromRows (conjTranspose A₁) (conjTranspose A₂) := by
+lemma conjTranspose_fromColumns_eq_fromRows_conjTranspose (A₁ : Matrix M N₁ R)
+    (A₂ : Matrix M N₂ R) : conjTranspose (fromColumns A₁ A₂) =
+      fromRows (conjTranspose A₁) (conjTranspose A₂) := by
   rw [fromColumns, fromRows]
   funext i j
   cases' i with i i
   all_goals (simp only [conjTranspose_apply, of_apply, Sum.elim_inl, Sum.elim_inr])
 
-/- A row partioned matrix when transposed gives a column partioned matrix with rows of the initial
-matrix tranposed to become columns. -/
-lemma transpose_fromRows_eq_fromColumns_transpose {α: Type}
-    (A₁: Matrix M₁ N α) (A₂: Matrix M₂ N α):
-    transpose (fromRows A₁ A₂) = fromColumns (transpose A₁) (transpose A₂) := by
-  rw [fromColumns, fromRows]
-  funext i j
-  cases' j with j j
-  all_goals (simp only [transpose_apply, of_apply, Sum.elim_inl, Sum.elim_inr] )
-
 /- A row partioned matrix in a Star ring when conjugate transposed gives a column partitioned matrix
 with the rows of the initial matrix conjugate transposed to become columns. -/
-lemma conjTranspose_fromRows_eq_fromColumns_conjTranspose {α: Type}[Star α]
-    (A₁: Matrix M₁ N α) (A₂: Matrix M₂ N α):
-    conjTranspose (fromRows A₁ A₂) = fromColumns (conjTranspose A₁) (conjTranspose A₂) := by
+lemma conjTranspose_fromRows_eq_fromColumns_conjTranspose (A₁ : Matrix M₁ N R)
+    (A₂ : Matrix M₂ N R) : conjTranspose (fromRows A₁ A₂) =
+      fromColumns (conjTranspose A₁) (conjTranspose A₂) := by
   rw [fromColumns, fromRows]
   funext j i
   cases' i with i i
   all_goals (simp only [conjTranspose_apply, of_apply, Sum.elim_inl, Sum.elim_inr])
+
+end Star
 
 end Matrix

--- a/Mathlib/Data/Matrix/ColumnRowPartitioned.lean
+++ b/Mathlib/Data/Matrix/ColumnRowPartitioned.lean
@@ -84,13 +84,11 @@ lemma mul_fromColumns (A: Matrix M N R)(B₁: Matrix N N₁ R)(B₂: Matrix N N�
   cases' j with j j
   all_goals (simp only [mul_apply, of_apply, Sum.elim_inl, Sum.elim_inr] )
 
--- @[simp]
 lemma fromRows_zero: fromRows (0: Matrix M₁ N R) (0: Matrix M₂ N R) = 0 := by
   funext i j
   unfold fromRows
   simp only [Sum.elim_zero_zero, of_apply, Pi.zero_apply, zero_apply]
 
--- @[simp]
 lemma fromColumns_zero: fromColumns (0: Matrix M N₁ R) (0: Matrix M N₂ R) = 0 := by
   funext i j
   unfold fromColumns

--- a/Mathlib/Data/Matrix/ColumnRowPartitioned.lean
+++ b/Mathlib/Data/Matrix/ColumnRowPartitioned.lean
@@ -33,12 +33,12 @@ variable [DecidableEq N][DecidableEq N₁][DecidableEq N₂]
 
 /- Concatenate together two matrices A₁[M₁ × N] and A₂[M₂ × N] with the same columns (N) to get a
 bigger matrix indexed by [(M₁ ⊕ M₂) × N] -/
-def fromRows (A₁: Matrix M₁ N R)(A₂: Matrix M₂ N R): Matrix (M₁ ⊕ M₂) N R :=
+def fromRows (A₁: Matrix M₁ N R) (A₂: Matrix M₂ N R) : Matrix (M₁ ⊕ M₂) N R :=
   Matrix.of (Sum.elim A₁ A₂)
 
 /- Concatenate together two matrices B₁[M × N₁] and B₂[M × N₂] with the same Rows (M) to get a
 bigger matrix indexed by [M × (N₁ ⊕ N₂)] -/
-def fromColumns (B₁: Matrix M N₁ R)(B₂: Matrix M N₂ R): Matrix M (N₁ ⊕ N₂) R :=
+def fromColumns (B₁: Matrix M N₁ R) (B₂: Matrix M N₂ R) : Matrix M (N₁ ⊕ N₂) R :=
   Matrix.of fun i => Sum.elim (B₁ i) (B₂ i)
 
 /- Given a column(row) partitioned matrix extract the first or second column(row) -/
@@ -47,15 +47,15 @@ def toColumns₂ (A: Matrix M (N₁ ⊕ N₂) R): Matrix M N₂ R :=  of fun i j
 def toRows₁ (A: Matrix (M₁ ⊕ M₂) N R): Matrix M₁ N R :=  of fun i j => (A (Sum.inl i) j)
 def toRows₂ (A: Matrix (M₁ ⊕ M₂) N R): Matrix M₂ N R :=  of fun i j => (A (Sum.inr i) j)
 
-lemma fromColumns_toColumns (A: Matrix M (N₁ ⊕ N₂) R):
-  A = fromColumns A.toColumns₁ A.toColumns₂ := by
+lemma fromColumns_toColumns (A: Matrix M (N₁ ⊕ N₂) R) :
+    A = fromColumns A.toColumns₁ A.toColumns₂ := by
   unfold fromColumns toColumns₁ toColumns₂
   funext i j
   cases' j
   all_goals (simp only [of_apply, Sum.elim_inl, Sum.elim_inr])
 
 lemma fromColumns_ext_iff (A₁: Matrix M N₁ R) (A₂: Matrix M N₂ R) (B₁: Matrix M N₁ R)
-  (B₂: Matrix M N₂ R): fromColumns A₁ A₂ = fromColumns B₁ B₂ ↔ A₁ = B₁ ∧ A₂ = B₂ := by
+    (B₂: Matrix M N₂ R) : fromColumns A₁ A₂ = fromColumns B₁ B₂ ↔ A₁ = B₁ ∧ A₂ = B₂ := by
   simp_rw [fromColumns, ← Matrix.ext_iff, of_apply]
   simp only [Sum.forall, Sum.elim_inl, Sum.elim_inr]
   exact ⟨ -- Just practicing term mode proofs !!
@@ -63,22 +63,21 @@ lemma fromColumns_ext_iff (A₁: Matrix M N₁ R) (A₂: Matrix M N₂ R) (B₁:
     (fun h => (fun _ => ⟨(h.1 _), (h.2 _)⟩))
   ⟩
 
-lemma fromRows_toRows (A: Matrix (M₁ ⊕ M₂) N R):
-  A = fromRows A.toRows₁ A.toRows₂ := by
+lemma fromRows_toRows (A: Matrix (M₁ ⊕ M₂) N R) : A = fromRows A.toRows₁ A.toRows₂ := by
   unfold fromRows toRows₁ toRows₂
   funext i j
   cases' i
   all_goals (simp only [of_apply, Sum.elim_inl, Sum.elim_inr])
 
-lemma fromRows_mul (A₁: Matrix M₁ N R)(A₂: Matrix M₂ N R)(B: Matrix N M R):
-  (fromRows A₁ A₂) ⬝ B = fromRows (A₁⬝B) (A₂⬝B) := by
+lemma fromRows_mul (A₁: Matrix M₁ N R) (A₂: Matrix M₂ N R) (B: Matrix N M R) :
+    (fromRows A₁ A₂) ⬝ B = fromRows (A₁⬝B) (A₂⬝B) := by
   unfold fromRows
   funext i j
   cases' i with i i
   all_goals (simp only [mul_apply, of_apply, Sum.elim_inl, Sum.elim_inr] )
 
-lemma mul_fromColumns (A: Matrix M N R)(B₁: Matrix N N₁ R)(B₂: Matrix N N₂ R):
-  A ⬝ (fromColumns B₁ B₂) = fromColumns (A⬝B₁) (A⬝B₂) := by
+lemma mul_fromColumns (A: Matrix M N R) (B₁: Matrix N N₁ R) (B₂: Matrix N N₂ R) :
+    A ⬝ (fromColumns B₁ B₂) = fromColumns (A⬝B₁) (A⬝B₂) := by
   unfold fromColumns
   funext i j
   cases' j with j j
@@ -97,8 +96,8 @@ lemma fromColumns_zero: fromColumns (0: Matrix M N₁ R) (0: Matrix M N₂ R) = 
 
 /- A row partitioned matrix multiplied by a column partioned matrix gives a 2 by 2 block matrix -/
 lemma fromRows_mul_fromColumns (A₁: Matrix M₁ N R) (A₂: Matrix M₂ N R)
-  (B₁: Matrix N N₁ R) (B₂: Matrix N N₂ R) :
-  (fromRows A₁ A₂) ⬝ (fromColumns B₁ B₂) = fromBlocks (A₁⬝B₁) (A₁⬝B₂) (A₂⬝B₁) (A₂⬝B₂) := by
+    (B₁: Matrix N N₁ R) (B₂: Matrix N N₂ R) :
+    (fromRows A₁ A₂) ⬝ (fromColumns B₁ B₂) = fromBlocks (A₁⬝B₁) (A₁⬝B₂) (A₂⬝B₁) (A₂⬝B₂) := by
   funext i j
   rw [fromRows, fromColumns]
   cases i;
@@ -109,18 +108,18 @@ lemma fromRows_mul_fromColumns (A₁: Matrix M₁ N R) (A₂: Matrix M₂ N R)
 
 /- A column partitioned matrix mulitplied by a row partitioned matrix gives the sum of the "outer"
 products of the block matrices -/
-lemma fromColumns_mul_fromRows (A₁: Matrix M N₁ R)(A₂: Matrix M N₂ R)
-  (B₁: Matrix N₁ N R)(B₂: Matrix N₂ N R) :
-  fromColumns A₁ A₂ ⬝ fromRows B₁ B₂ = (A₁⬝B₁ + A₂⬝B₂) := by
+lemma fromColumns_mul_fromRows (A₁: Matrix M N₁ R) (A₂: Matrix M N₂ R)
+    (B₁: Matrix N₁ N R)(B₂: Matrix N₂ N R) :
+    fromColumns A₁ A₂ ⬝ fromRows B₁ B₂ = (A₁⬝B₁ + A₂⬝B₂) := by
   funext i j
   rw [fromRows, fromColumns]
   simp only [add_apply, mul_apply, of_apply, Fintype.sum_sum_type, Sum.elim_inl, Sum.elim_inr]
 
 /- A column partitioned matrix multipiled by a block matrix results in a column partioned matrix -/
 lemma fromColumns_mul_fromBlocks (A₁: Matrix M M₁ R) (A₂: Matrix M M₂ R)
-  (B₁₁: Matrix M₁ N₁ R)(B₁₂: Matrix M₁ N₂ R)(B₂₁: Matrix M₂ N₁ R)(B₂₂: Matrix M₂ N₂ R):
-  (fromColumns A₁ A₂) ⬝ fromBlocks B₁₁ B₁₂ B₂₁ B₂₂ =
-    fromColumns (A₁⬝B₁₁ + A₂⬝B₂₁) (A₁⬝B₁₂ + A₂⬝B₂₂) := by
+    (B₁₁: Matrix M₁ N₁ R)(B₁₂: Matrix M₁ N₂ R)(B₂₁: Matrix M₂ N₁ R)(B₂₂: Matrix M₂ N₂ R):
+    (fromColumns A₁ A₂) ⬝ fromBlocks B₁₁ B₁₂ B₂₁ B₂₂ =
+      fromColumns (A₁⬝B₁₁ + A₂⬝B₂₁) (A₁⬝B₁₂ + A₂⬝B₂₂) := by
   funext i j
   rw [fromColumns, fromColumns, fromBlocks]
   cases j
@@ -129,8 +128,9 @@ lemma fromColumns_mul_fromBlocks (A₁: Matrix M M₁ R) (A₂: Matrix M M₂ R)
 
 /- A block matrix mulitplied by a row partitioned matrix gives a row partitioned matrix -/
 lemma fromBlocks_mul_fromRows (A₁: Matrix N₁ N R) (A₂: Matrix N₂ N R)
-  (B₁₁: Matrix M₁ N₁ R)(B₁₂: Matrix M₁ N₂ R)(B₂₁: Matrix M₂ N₁ R)(B₂₂: Matrix M₂ N₂ R):
-  fromBlocks B₁₁ B₁₂ B₂₁ B₂₂ ⬝ (fromRows A₁ A₂) = fromRows (B₁₁⬝A₁ + B₁₂⬝A₂) (B₂₁⬝A₁ + B₂₂⬝A₂) := by
+    (B₁₁: Matrix M₁ N₁ R) (B₁₂: Matrix M₁ N₂ R) (B₂₁: Matrix M₂ N₁ R) (B₂₂: Matrix M₂ N₂ R):
+    fromBlocks B₁₁ B₁₂ B₂₁ B₂₂ ⬝ (fromRows A₁ A₂) =
+      fromRows (B₁₁⬝A₁ + B₁₂⬝A₂) (B₂₁⬝A₁ + B₂₂⬝A₂) := by
   funext i j
   rw [fromRows, fromRows, fromBlocks]
   cases i
@@ -143,7 +143,7 @@ another matrix B : (N₁ ⊕ N₂) × N := Rows[B₁ B₂] matrix is one, the ot
 Mulitplication of a matrix by its inverse is commutative. This is column partioned matrix form of
 `mul_eq_one_comm` -/
 lemma fromColumns_mul_fromRows_eq_one_comm (e: N ≃ N₁ ⊕ N₂)
-  (A₁: Matrix N N₁ R)(A₂: Matrix N N₂ R)(B₁: Matrix N₁ N R)(B₂: Matrix N₂ N R):
+  (A₁: Matrix N N₁ R) (A₂: Matrix N N₂ R) (B₁: Matrix N₁ N R) (B₂: Matrix N₂ N R):
   fromColumns A₁ A₂ ⬝ fromRows B₁ B₂ = 1 ↔ fromRows B₁ B₂ ⬝ fromColumns A₁ A₂ = 1 := by
   constructor
   intro h
@@ -169,8 +169,8 @@ lemma equiv_compl_fromColumns_mul_fromRows_eq_one_comm (p: N → Prop)[Decidable
 /- A column partioned matrix when transposed gives a row partioned matrix with columns of the
 initial matrix tranposed to become rows. -/
 lemma transpose_fromColumns_eq_fromRows_transpose {α: Type}
-  (A₁: Matrix M N₁ α)(A₂: Matrix M N₂ α):
-  transpose (fromColumns A₁ A₂) = fromRows (transpose A₁) (transpose A₂) := by
+    (A₁: Matrix M N₁ α) (A₂: Matrix M N₂ α) :
+    transpose (fromColumns A₁ A₂) = fromRows (transpose A₁) (transpose A₂) := by
   rw [fromColumns, fromRows]
   funext i j
   cases' i with i i
@@ -179,8 +179,8 @@ lemma transpose_fromColumns_eq_fromRows_transpose {α: Type}
 /- A column partioned matrix in a Star ring when conjugate transposed gives a row partitioned matrix
 with the columns of the initial matrix conjugate transposed to become rows. -/
 lemma conjTranspose_fromColumns_eq_fromRows_conjTranspose {α: Type}[Star α]
-  (A₁: Matrix M N₁ α)(A₂: Matrix M N₂ α):
-  conjTranspose (fromColumns A₁ A₂) = fromRows (conjTranspose A₁) (conjTranspose A₂) := by
+    (A₁: Matrix M N₁ α) (A₂: Matrix M N₂ α) :
+    conjTranspose (fromColumns A₁ A₂) = fromRows (conjTranspose A₁) (conjTranspose A₂) := by
   rw [fromColumns, fromRows]
   funext i j
   cases' i with i i
@@ -189,8 +189,8 @@ lemma conjTranspose_fromColumns_eq_fromRows_conjTranspose {α: Type}[Star α]
 /- A row partioned matrix when transposed gives a column partioned matrix with rows of the initial
 matrix tranposed to become columns. -/
 lemma transpose_fromRows_eq_fromColumns_transpose {α: Type}
-  (A₁: Matrix M₁ N α)(A₂: Matrix M₂ N α):
-  transpose (fromRows A₁ A₂) = fromColumns (transpose A₁) (transpose A₂) := by
+    (A₁: Matrix M₁ N α) (A₂: Matrix M₂ N α):
+    transpose (fromRows A₁ A₂) = fromColumns (transpose A₁) (transpose A₂) := by
   rw [fromColumns, fromRows]
   funext i j
   cases' j with j j
@@ -199,8 +199,8 @@ lemma transpose_fromRows_eq_fromColumns_transpose {α: Type}
 /- A row partioned matrix in a Star ring when conjugate transposed gives a column partitioned matrix
 with the rows of the initial matrix conjugate transposed to become columns. -/
 lemma conjTranspose_fromRows_eq_fromColumns_conjTranspose {α: Type}[Star α]
-  (A₁: Matrix M₁ N α)(A₂: Matrix M₂ N α):
-  conjTranspose (fromRows A₁ A₂) = fromColumns (conjTranspose A₁) (conjTranspose A₂) := by
+    (A₁: Matrix M₁ N α) (A₂: Matrix M₂ N α):
+    conjTranspose (fromRows A₁ A₂) = fromColumns (conjTranspose A₁) (conjTranspose A₂) := by
   rw [fromColumns, fromRows]
   funext j i
   cases' i with i i

--- a/Mathlib/Data/Matrix/ColumnRowPartitioned.lean
+++ b/Mathlib/Data/Matrix/ColumnRowPartitioned.lean
@@ -54,33 +54,71 @@ def toRows₁ (A : Matrix (m₁ ⊕ m₂) n R) : Matrix m₁ n R := of fun i j =
 def toRows₂ (A : Matrix (m₁ ⊕ m₂) n R) : Matrix m₂ n R := of fun i j => (A (Sum.inr i) j)
 
 @[simp]
+lemma fromRows_apply_inl (A₁ : Matrix m₁ n R) (A₂ : Matrix m₂ n R) (i : m₁) (j : n) :
+    (fromRows A₁ A₂) (Sum.inl i) j = A₁ i j := rfl
+
+@[simp]
+lemma fromRows_apply_inr (A₁ : Matrix m₁ n R) (A₂ : Matrix m₂ n R) (i : m₂) (j : n) :
+    (fromRows A₁ A₂) (Sum.inr i) j = A₂ i j := rfl
+
+@[simp]
+lemma fromColumns_apply_inl (A₁ : Matrix m n₁ R) (A₂ : Matrix m n₂ R) (i : m) (j : n₁) :
+    (fromColumns A₁ A₂) i (Sum.inl j) = A₁ i j := rfl
+
+@[simp]
+lemma fromColumns_apply_inr (A₁ : Matrix m n₁ R) (A₂ : Matrix m n₂ R) (i : m) (j : n₂) :
+    (fromColumns A₁ A₂) i (Sum.inr j) = A₂ i j := rfl
+
+@[simp]
+lemma toRows₁_apply (A : Matrix (m₁ ⊕ m₂) n R) (i : m₁) (j : n) :
+    (toRows₁ A) i j = A (Sum.inl i) j := rfl
+
+@[simp]
+lemma toRows₂_apply (A : Matrix (m₁ ⊕ m₂) n R) (i : m₂) (j : n) :
+    (toRows₂ A) i j = A (Sum.inr i) j := rfl
+
+@[simp]
+lemma toRows₁_fromRows  (A₁ : Matrix m₁ n R) (A₂ : Matrix m₂ n R) :
+    toRows₁ (fromRows A₁ A₂) = A₁ := rfl
+
+@[simp]
+lemma toRows₂_fromRows  (A₁ : Matrix m₁ n R) (A₂ : Matrix m₂ n R) :
+    toRows₂ (fromRows A₁ A₂) = A₂ := rfl
+
+@[simp]
+lemma toColumns₁_apply (A : Matrix m (n₁ ⊕ n₂) R) (i : m) (j : n₁) :
+    (toColumns₁ A) i j = A i (Sum.inl j) := rfl
+
+@[simp]
+lemma toColumns₂_apply (A : Matrix m (n₁ ⊕ n₂) R) (i : m) (j : n₂) :
+    (toColumns₂ A) i j = A i (Sum.inr j) := rfl
+
+@[simp]
+lemma toColumns₁_fromColumns  (A₁ : Matrix m n₁ R) (A₂ : Matrix m n₂ R) :
+    toColumns₁ (fromColumns A₁ A₂) = A₁ := rfl
+
+@[simp]
+lemma toColumns₂_fromColumns  (A₁ : Matrix m n₁ R) (A₂ : Matrix m n₂ R) :
+    toColumns₂ (fromColumns A₁ A₂) = A₂ := rfl
+
+@[simp]
 lemma fromColumns_toColumns (A : Matrix m (n₁ ⊕ n₂) R) :
     fromColumns A.toColumns₁ A.toColumns₂ = A := by
-  unfold fromColumns toColumns₁ toColumns₂
-  funext i j
-  cases' j
-  all_goals (simp only [of_apply, Sum.elim_inl, Sum.elim_inr])
+  ext i (j | j) <;> simp
 
 @[simp]
 lemma fromRows_toRows (A : Matrix (m₁ ⊕ m₂) n R) : fromRows A.toRows₁ A.toRows₂ = A := by
-  unfold fromRows toRows₁ toRows₂
-  funext i j
-  cases' i
-  all_goals (simp only [of_apply, Sum.elim_inl, Sum.elim_inr])
+  ext (i | i) j <;> simp
 
 lemma fromRows_inj : Function.Injective2 (@fromRows R m₁ m₂ n) := by
   intros x1 x2 y1 y2
-  unfold fromRows
-  simp_rw [Function.funext_iff, ← Matrix.ext_iff, EmbeddingLike.apply_eq_iff_eq,
-    of_apply, Sum.forall, Sum.elim_inl, Sum.elim_inr]
-  exact (fun h => ⟨ fun _ _ => h.1 _ _ , fun _ _ => h.2 _ _ ⟩)
+  simp only [Function.funext_iff, ← Matrix.ext_iff]
+  aesop
 
 lemma fromColumns_inj : Function.Injective2 (@fromColumns R m n₁ n₂) := by
   intros x1 x2 y1 y2
-  unfold fromColumns
-  simp_rw [Function.funext_iff, ← Matrix.ext_iff, EmbeddingLike.apply_eq_iff_eq,
-    of_apply, Sum.forall, Sum.elim_inl, Sum.elim_inr]
-  exact (fun h => ⟨fun _ _ => (h _).1 _, fun _ _ => (h _).2 _⟩)
+  simp only [Function.funext_iff, ← Matrix.ext_iff]
+  aesop
 
 lemma fromColumns_ext_iff (A₁ : Matrix m n₁ R) (A₂ : Matrix m n₂ R) (B₁ : Matrix m n₁ R)
     (B₂ : Matrix m n₂ R) :
@@ -90,87 +128,17 @@ lemma fromRows_ext_iff (A₁ : Matrix m₁ n R) (A₂ : Matrix m₂ n R) (B₁ :
     (B₂ : Matrix m₂ n R) :
     fromRows A₁ A₂ = fromRows B₁ B₂ ↔ A₁ = B₁ ∧ A₂ = B₂ := fromRows_inj.eq_iff
 
-@[simp]
-lemma fromRows_apply_inl (A₁ : Matrix m₁ n R) (A₂ : Matrix m₂ n R) (i : m₁) (j : n) :
-    (fromRows A₁ A₂) (Sum.inl i) j = A₁ i j := by
-  unfold fromRows
-  simp only [of_apply, Sum.elim_inl]
-
-@[simp]
-lemma fromRows_apply_inr (A₁ : Matrix m₁ n R) (A₂ : Matrix m₂ n R) (i : m₂) (j : n) :
-    (fromRows A₁ A₂) (Sum.inr i) j = A₂ i j := by
-  unfold fromRows
-  simp only [of_apply, Sum.elim_inr]
-
-@[simp]
-lemma fromColumns_apply_inl (A₁ : Matrix m n₁ R) (A₂ : Matrix m n₂ R) (i : m) (j : n₁) :
-    (fromColumns A₁ A₂) i (Sum.inl j) = A₁ i j := by
-  unfold fromColumns
-  simp only [of_apply, Sum.elim_inl]
-
-@[simp]
-lemma fromColumns_apply_inr (A₁ : Matrix m n₁ R) (A₂ : Matrix m n₂ R) (i : m) (j : n₂) :
-    (fromColumns A₁ A₂) i (Sum.inr j) = A₂ i j := by
-  unfold fromColumns
-  simp only [of_apply, Sum.elim_inr]
-
-@[simp]
-lemma toRows₁_apply (A : Matrix (m₁ ⊕ m₂) n R) (i : m₁) (j : n) :
-    (toRows₁ A) i j = A (Sum.inl i) j := by rw [toRows₁, of_apply]
-
-@[simp]
-lemma toRows₂_apply (A : Matrix (m₁ ⊕ m₂) n R) (i : m₂) (j : n) :
-    (toRows₂ A) i j = A (Sum.inr i) j := by rw [toRows₂, of_apply]
-
-@[simp]
-lemma toRows₁_fromRows  (A₁ : Matrix m₁ n R) (A₂ : Matrix m₂ n R) :
-    toRows₁ (fromRows A₁ A₂) = A₁ := by
-  funext i j
-  simp only [toRows₁_apply, fromRows_apply_inl]
-
-@[simp]
-lemma toRows₂_fromRows  (A₁ : Matrix m₁ n R) (A₂ : Matrix m₂ n R) :
-    toRows₂ (fromRows A₁ A₂) = A₂ := by
-  funext i j
-  simp only [toRows₂_apply, fromRows_apply_inr]
-
-@[simp]
-lemma toColumns₁_apply (A : Matrix m (n₁ ⊕ n₂) R) (i : m) (j : n₁) :
-    (toColumns₁ A) i j = A i (Sum.inl j) := by rw [toColumns₁, of_apply]
-
-@[simp]
-lemma toColumns₂_apply (A : Matrix m (n₁ ⊕ n₂) R) (i : m) (j : n₂) :
-    (toColumns₂ A) i j = A i (Sum.inr j) := by rw [toColumns₂, of_apply]
-
-@[simp]
-lemma toColumns₁_fromColumns  (A₁ : Matrix m n₁ R) (A₂ : Matrix m n₂ R) :
-    toColumns₁ (fromColumns A₁ A₂) = A₁ := by
-    funext i j
-    simp only [toColumns₁_apply, fromColumns_apply_inl]
-
-@[simp]
-lemma toColumns₂_fromColumns  (A₁ : Matrix m n₁ R) (A₂ : Matrix m n₂ R) :
-    toColumns₂ (fromColumns A₁ A₂) = A₂ := by
-    ext i j
-    simp only [toColumns₂_apply, fromColumns_apply_inr]
-
 /- A column partioned matrix when transposed gives a row partioned matrix with columns of the
 initial matrix tranposed to become rows. -/
 lemma transpose_fromColumns (A₁ : Matrix m n₁ R) (A₂ : Matrix m n₂ R) :
     transpose (fromColumns A₁ A₂) = fromRows (transpose A₁) (transpose A₂) := by
-  funext i j
-  cases' i with i i
-  all_goals (simp only [transpose_apply, fromColumns_apply_inl, fromRows_apply_inl,
-    fromColumns_apply_inr, fromRows_apply_inr])
+  ext (i | i) j <;> simp
 
 /- A row partioned matrix when transposed gives a column partioned matrix with rows of the initial
 matrix tranposed to become columns. -/
 lemma transpose_fromRows (A₁ : Matrix m₁ n R) (A₂ : Matrix m₂ n R) :
     transpose (fromRows A₁ A₂) = fromColumns (transpose A₁) (transpose A₂) := by
-  funext i j
-  cases' j with j j
-  all_goals (simp only [transpose_apply, fromRows_apply_inl, fromColumns_apply_inl,
-    fromColumns_apply_inr, fromRows_apply_inr])
+  ext i (j | j) <;> simp
 
 section Semiring
 
@@ -179,94 +147,61 @@ variable [Semiring R]
 @[simp]
 lemma fromRows_mul (A₁ : Matrix m₁ n R) (A₂ : Matrix m₂ n R) (B : Matrix n m R) :
     (fromRows A₁ A₂) ⬝ B = fromRows (A₁ ⬝ B) (A₂ ⬝ B) := by
-  funext i j
-  cases' i with i i
-  all_goals (simp only [mul_apply, fromRows_apply_inl, fromRows_apply_inr])
+  ext (_ | _) _ <;> simp [mul_apply]
 
 @[simp]
 lemma mul_fromColumns (A : Matrix m n R) (B₁ : Matrix n n₁ R) (B₂ : Matrix n n₂ R) :
     A ⬝ (fromColumns B₁ B₂) = fromColumns (A ⬝ B₁) (A ⬝ B₂) := by
-  funext i j
-  cases' j with j j
-  all_goals (simp only [mul_apply, fromColumns_apply_inl, fromColumns_apply_inr] )
+  ext _ (_ | _) <;> simp [mul_apply]
 
 @[simp]
 lemma fromRows_zero : fromRows (0 : Matrix m₁ n R) (0 : Matrix m₂ n R) = 0 := by
-  funext i j
-  unfold fromRows
-  simp only [Sum.elim_zero_zero, of_apply, Pi.zero_apply, zero_apply]
+  ext (_ | _) _ <;> simp
 
 @[simp]
 lemma fromColumns_zero : fromColumns (0 : Matrix m n₁ R) (0 : Matrix m n₂ R) = 0 := by
-  funext i j
-  cases' j with j j
-  all_goals (simp only [fromColumns_apply_inl, fromColumns_apply_inr, zero_apply])
+  ext _ (_ | _) <;> simp
 
 @[simp]
 lemma fromColumns_fromRows_eq_fromBlocks (B₁₁ : Matrix m₁ n₁ R) (B₁₂ : Matrix m₁ n₂ R)
     (B₂₁ : Matrix m₂ n₁ R) (B₂₂ : Matrix m₂ n₂ R) :
     fromColumns (fromRows B₁₁ B₂₁) (fromRows B₁₂ B₂₂) = fromBlocks B₁₁ B₁₂ B₂₁ B₂₂ := by
-  funext i j
-  cases' i with i i
-  all_goals (
-    cases' j with j j
-    all_goals (simp only [fromColumns_apply_inl, fromColumns_apply_inr,
-      fromRows_apply_inl, fromRows_apply_inr, fromBlocks_apply₁₁, fromBlocks_apply₁₂,
-      fromBlocks_apply₂₁,  fromBlocks_apply₂₂] ) )
+  ext (_ | _) (_ | _) <;> simp
 
 @[simp]
 lemma fromRows_fromColumn_eq_fromBlocks (B₁₁ : Matrix m₁ n₁ R) (B₁₂ : Matrix m₁ n₂ R)
     (B₂₁ : Matrix m₂ n₁ R) (B₂₂ : Matrix m₂ n₂ R) :
     fromRows (fromColumns B₁₁ B₁₂) (fromColumns B₂₁ B₂₂) = fromBlocks B₁₁ B₁₂ B₂₁ B₂₂ := by
-  funext i j
-  cases' i with i i
-  all_goals (cases' j with j j)
-  all_goals (simp only [fromColumns_apply_inl, fromColumns_apply_inr,
-    fromRows_apply_inl, fromRows_apply_inr, fromBlocks_apply₁₁, fromBlocks_apply₁₂,
-    fromBlocks_apply₂₁,  fromBlocks_apply₂₂] )
+  ext (_ | _) (_ | _) <;> simp
 
 /-- A row partitioned matrix multiplied by a column partioned matrix gives a 2 by 2 block matrix -/
 lemma fromRows_mul_fromColumns (A₁ : Matrix m₁ n R) (A₂ : Matrix m₂ n R)
     (B₁ : Matrix n n₁ R) (B₂ : Matrix n n₂ R) :
     (fromRows A₁ A₂) ⬝ (fromColumns B₁ B₂) =
       fromBlocks (A₁ ⬝ B₁) (A₁ ⬝ B₂) (A₂ ⬝ B₁) (A₂ ⬝ B₂) := by
-  funext i j
-  cases' i with i i;
-  all_goals (cases' j with j j)
-  all_goals ( simp only [mul_fromColumns, fromRows_mul, fromColumns_apply_inl,
-    fromColumns_apply_inr, fromRows_apply_inl, fromRows_apply_inr, fromBlocks_apply₁₁,
-    fromBlocks_apply₁₂, fromBlocks_apply₂₁, fromBlocks_apply₂₂] )
+  ext (_ | _) (_ | _) <;> simp
 
 /-- A column partitioned matrix mulitplied by a row partitioned matrix gives the sum of the "outer"
 products of the block matrices -/
 lemma fromColumns_mul_fromRows (A₁ : Matrix m n₁ R) (A₂ : Matrix m n₂ R)
     (B₁ : Matrix n₁ n R) (B₂ : Matrix n₂ n R) :
     fromColumns A₁ A₂ ⬝ fromRows B₁ B₂ = (A₁ ⬝ B₁ + A₂ ⬝ B₂) := by
-  funext i j
-  rw [fromRows, fromColumns]
-  simp only [add_apply, mul_apply, of_apply, Fintype.sum_sum_type, Sum.elim_inl, Sum.elim_inr]
+  ext
+  simp [mul_apply]
 
 /-- A column partitioned matrix multipiled by a block matrix results in a column partioned matrix -/
 lemma fromColumns_mul_fromBlocks (A₁ : Matrix m m₁ R) (A₂ : Matrix m m₂ R)
     (B₁₁ : Matrix m₁ n₁ R) (B₁₂ : Matrix m₁ n₂ R) (B₂₁ : Matrix m₂ n₁ R) (B₂₂ : Matrix m₂ n₂ R) :
     (fromColumns A₁ A₂) ⬝ fromBlocks B₁₁ B₁₂ B₂₁ B₂₂ =
       fromColumns (A₁ ⬝ B₁₁ + A₂ ⬝ B₂₁) (A₁ ⬝ B₁₂ + A₂ ⬝ B₂₂) := by
-  funext i j
-  rw [fromColumns, fromColumns, fromBlocks]
-  cases j
-  all_goals simp only [of_apply, add_apply, Fintype.sum_sum_type, Sum.elim_inl,
-    Sum.elim_inr, mul_apply]
+  ext _ (_ | _) <;> simp [mul_apply]
 
 /-- A block matrix mulitplied by a row partitioned matrix gives a row partitioned matrix -/
 lemma fromBlocks_mul_fromRows (A₁ : Matrix n₁ n R) (A₂ : Matrix n₂ n R)
     (B₁₁ : Matrix m₁ n₁ R) (B₁₂ : Matrix m₁ n₂ R) (B₂₁ : Matrix m₂ n₁ R) (B₂₂ : Matrix m₂ n₂ R) :
     fromBlocks B₁₁ B₁₂ B₂₁ B₂₂ ⬝ (fromRows A₁ A₂) =
       fromRows (B₁₁ ⬝ A₁ + B₁₂ ⬝ A₂) (B₂₁ ⬝ A₁ + B₂₂ ⬝ A₂) := by
-  funext i j
-  rw [fromRows, fromRows, fromBlocks]
-  cases i
-  all_goals simp only [of_apply, add_apply, Fintype.sum_sum_type, Sum.elim_inl, Sum.elim_inr,
-    mul_apply]
+  ext (_ | _) _ <;> simp [mul_apply]
 
 end Semiring
 
@@ -282,17 +217,16 @@ The condition `e : n ≃ n₁ ⊕ n₂` states that `fromColumns A₁ A₂` and 
 lemma fromColumns_mul_fromRows_eq_one_comm (e : n ≃ n₁ ⊕ n₂)
     (A₁ : Matrix n n₁ R) (A₂ : Matrix n n₂ R) (B₁ : Matrix n₁ n R) (B₂ : Matrix n₂ n R) :
     fromColumns A₁ A₂ ⬝ fromRows B₁ B₂ = 1 ↔ fromRows B₁ B₂ ⬝ fromColumns A₁ A₂ = 1 := by
-  constructor
-  intro h
-  rw [← Matrix.submatrix_id_id (fromRows B₁ B₂ ⬝ fromColumns A₁ A₂),
-    ← Matrix.submatrix_mul_equiv (fromRows B₁ B₂) (fromColumns A₁ A₂) _ e.symm _]
-  swap
-  intro h
-  rw [← Matrix.submatrix_id_id (fromColumns A₁ A₂ ⬝ fromRows B₁ B₂),
-    ← Matrix.submatrix_mul_equiv (fromColumns A₁ A₂) (fromRows B₁ B₂) _ e _]
-  all_goals
-  ( rw [mul_eq_one_comm, ← Matrix.submatrix_mul, h, submatrix_one_equiv]
-    exact Function.bijective_id )
+  calc fromColumns A₁ A₂ ⬝ fromRows B₁ B₂ = 1
+  _ ↔ submatrix (fromColumns A₁ A₂) id e ⬝ submatrix (fromRows B₁ B₂) e id = 1 := by
+    simp
+  _ ↔ submatrix (fromRows B₁ B₂) e id ⬝ submatrix (fromColumns A₁ A₂) id e = 1 :=
+    mul_eq_one_comm
+  _ ↔ reindex e.symm e.symm (fromRows B₁ B₂ ⬝ fromColumns A₁ A₂) = reindex e.symm e.symm 1 := by
+    simp only [reindex_apply, Equiv.symm_symm, submatrix_one_equiv,
+        submatrix_mul (he₂ := Function.bijective_id)]
+  _ ↔ fromRows B₁ B₂ ⬝ fromColumns A₁ A₂ = 1 :=
+    (reindex _ _).injective.eq_iff
 
 /- The lemma `fromColumns_mul_fromRows_eq_one_comm` specialized to the case where the index sets n₁
 and n₂, are the result of subtyping by a predicate and its complement. -/
@@ -306,26 +240,20 @@ end CommRing
 
 section Star
 variable [Star R]
+
 /- A column partioned matrix in a Star ring when conjugate transposed gives a row partitioned matrix
 with the columns of the initial matrix conjugate transposed to become rows. -/
 lemma conjTranspose_fromColumns_eq_fromRows_conjTranspose (A₁ : Matrix m n₁ R)
     (A₂ : Matrix m n₂ R) :
     conjTranspose (fromColumns A₁ A₂) = fromRows (conjTranspose A₁) (conjTranspose A₂) := by
-  funext i j
-  cases' i with i i
-  all_goals (simp only [conjTranspose_apply, fromColumns_apply_inl, fromRows_apply_inl,
-    fromColumns_apply_inr, fromRows_apply_inr] )
+  ext (_ | _) _ <;> simp
 
 /- A row partioned matrix in a Star ring when conjugate transposed gives a column partitioned matrix
 with the rows of the initial matrix conjugate transposed to become columns. -/
 lemma conjTranspose_fromRows_eq_fromColumns_conjTranspose (A₁ : Matrix m₁ n R)
     (A₂ : Matrix m₂ n R) : conjTranspose (fromRows A₁ A₂) =
       fromColumns (conjTranspose A₁) (conjTranspose A₂) := by
-  /- I left this one for comparison. I think this proof looks more compact (nice)! -/
-  rw [fromColumns, fromRows]
-  funext j i
-  cases' i with i i
-  all_goals (simp only [conjTranspose_apply, of_apply, Sum.elim_inl, Sum.elim_inr])
+  ext _ (_ | _) <;> simp
 
 end Star
 

--- a/Mathlib/Data/Matrix/ColumnRowPartitioned.lean
+++ b/Mathlib/Data/Matrix/ColumnRowPartitioned.lean
@@ -87,7 +87,7 @@ lemma transpose_fromColumns_eq_fromRows_transpose (A₁ : Matrix M N₁ R) (A₂
 
 /- A row partioned matrix when transposed gives a column partioned matrix with rows of the initial
 matrix tranposed to become columns. -/
-lemma transpose_fromRows_eq_fromColumns_transpose (A₁ : Matrix M₁ N R) (A₂ : Matrix M₂ N R):
+lemma transpose_fromRows_eq_fromColumns_transpose (A₁ : Matrix M₁ N R) (A₂ : Matrix M₂ N R) :
     transpose (fromRows A₁ A₂) = fromColumns (transpose A₁) (transpose A₂) := by
   rw [fromColumns, fromRows]
   funext i j
@@ -175,8 +175,8 @@ variable [CommRing R]
 /- Given that the index set N and the direct sum of the index sets N₁ and N₂ are in bijection then
 the matrix A : N × (N₁ ⊕ N₂) := Cols[A₁ A₂] is actually a "square". Hence, if its product with
 another matrix B : (N₁ ⊕ N₂) × N := Rows[B₁ B₂] matrix is one, the other matrix must be its inverse
-Mulitplication of a matrix by its inverse is commutative. This is column partioned matrix form of
-`mul_eq_one_comm` -/
+Mulitplication of a matrix by its inverse is commutative. This is column(row) partioned matrix form
+of `mul_eq_one_comm` -/
 lemma fromColumns_mul_fromRows_eq_one_comm (e : N ≃ N₁ ⊕ N₂)
     (A₁ : Matrix N N₁ R) (A₂ : Matrix N N₂ R) (B₁ : Matrix N₁ N R) (B₂ : Matrix N₂ N R) :
     fromColumns A₁ A₂ ⬝ fromRows B₁ B₂ = 1 ↔ fromRows B₁ B₂ ⬝ fromColumns A₁ A₂ = 1 := by

--- a/Mathlib/Data/Matrix/ColumnRowPartitioned.lean
+++ b/Mathlib/Data/Matrix/ColumnRowPartitioned.lean
@@ -43,10 +43,13 @@ def fromColumns (B₁ : Matrix M N₁ R) (B₂ : Matrix M N₂ R) : Matrix M (N�
 
 /-- Given a column partitioned matrix extract the first column -/
 def toColumns₁ (A : Matrix M (N₁ ⊕ N₂) R) : Matrix M N₁ R :=  of fun i j => (A i (Sum.inl j))
+
 /-- Given a column partitioned matrix extract the second column -/
 def toColumns₂ (A : Matrix M (N₁ ⊕ N₂) R) : Matrix M N₂ R :=  of fun i j => (A i (Sum.inr j))
+
 /-- Given a row partitioned matrix extract the first row -/
 def toRows₁ (A : Matrix (M₁ ⊕ M₂) N R) : Matrix M₁ N R :=  of fun i j => (A (Sum.inl i) j)
+
 /-- Given a row partitioned matrix extract the second row -/
 def toRows₂ (A : Matrix (M₁ ⊕ M₂) N R) : Matrix M₂ N R :=  of fun i j => (A (Sum.inr i) j)
 
@@ -69,10 +72,13 @@ lemma fromRows_toRows (A : Matrix (M₁ ⊕ M₂) N R) : A = fromRows A.toRows�
   cases' i
   all_goals (simp only [of_apply, Sum.elim_inl, Sum.elim_inr])
 
+lemma fromRows_ext_iff (A₁ : Matrix M₁ N R) (A₂ : Matrix M₂ N R) (B₁ : Matrix M₁ N R)
+    (B₂ : Matrix M₂ N R) : fromRows A₁ A₂ = fromRows B₁ B₂ ↔ A₁ = B₁ ∧ A₂ = B₂ := by
+  simp_rw [fromRows, ← Matrix.ext_iff, of_apply, Sum.forall, Sum.elim_inl, Sum.elim_inr]
+
 /- A column partioned matrix when transposed gives a row partioned matrix with columns of the
 initial matrix tranposed to become rows. -/
-lemma transpose_fromColumns_eq_fromRows_transpose
-    (A₁ : Matrix M N₁ R) (A₂ : Matrix M N₂ R) :
+lemma transpose_fromColumns_eq_fromRows_transpose (A₁ : Matrix M N₁ R) (A₂ : Matrix M N₂ R) :
     transpose (fromColumns A₁ A₂) = fromRows (transpose A₁) (transpose A₂) := by
   rw [fromColumns, fromRows]
   funext i j
@@ -81,8 +87,7 @@ lemma transpose_fromColumns_eq_fromRows_transpose
 
 /- A row partioned matrix when transposed gives a column partioned matrix with rows of the initial
 matrix tranposed to become columns. -/
-lemma transpose_fromRows_eq_fromColumns_transpose
-    (A₁ : Matrix M₁ N R) (A₂ : Matrix M₂ N R):
+lemma transpose_fromRows_eq_fromColumns_transpose (A₁ : Matrix M₁ N R) (A₂ : Matrix M₂ N R):
     transpose (fromRows A₁ A₂) = fromColumns (transpose A₁) (transpose A₂) := by
   rw [fromColumns, fromRows]
   funext i j

--- a/Mathlib/Data/Matrix/ColumnRowPartitioned.lean
+++ b/Mathlib/Data/Matrix/ColumnRowPartitioned.lean
@@ -24,8 +24,8 @@ column matrices, row matrices, column row block matrices
 
 namespace Matrix
 
-variable {R: Type}
-variable {M M₁ M₂ N N₁ N₂: Type}
+variable {R: Type _}
+variable {M M₁ M₂ N N₁ N₂: Type _}
 variable [Fintype M][Fintype M₁][Fintype M₂]
 variable [Fintype N][Fintype N₁][Fintype N₂]
 variable [DecidableEq M][DecidableEq M₁][DecidableEq M₂]
@@ -203,7 +203,7 @@ lemma equiv_compl_fromColumns_mul_fromRows_eq_one_comm (p : N → Prop)[Decidabl
 end CommRing
 
 section Star
-variable {R : Type _}[Star R]
+variable [Star R]
 /- A column partioned matrix in a Star ring when conjugate transposed gives a row partitioned matrix
 with the columns of the initial matrix conjugate transposed to become rows. -/
 lemma conjTranspose_fromColumns_eq_fromRows_conjTranspose (A₁ : Matrix M N₁ R)

--- a/Mathlib/Data/Matrix/ColumnRowPartitioned.lean
+++ b/Mathlib/Data/Matrix/ColumnRowPartitioned.lean
@@ -1,0 +1,211 @@
+/-
+Copyright (c) 2023 Mohanad ahmed. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mohanad Ahmed
+-/
+
+import Mathlib.Data.Matrix.Basic
+import Mathlib.Data.Matrix.Block
+import Mathlib.LinearAlgebra.Matrix.NonsingularInverse
+
+/-! # Block Matrices from Rows and Columns
+
+This file provides the basic definitions of matrices composed from columns and rows.
+The concatenation of two matrices with the same row indices can be expressed as
+`A = fromColumns A₁ A₂` the concatenation of two matrices with the same column indices
+can be expressed as `B = fromRows B₁ B₂`.
+
+We then provide a few lemmas that deal with the products of these with each other and
+with block matrices
+
+## Tags
+column matrices, row matrices, column row block matrices
+-/
+
+namespace Matrix
+
+variable {R: Type}[CommRing R]
+variable {M M₁ M₂ N N₁ N₂: Type}
+variable [Fintype M][Fintype M₁][Fintype M₂]
+variable [Fintype N][Fintype N₁][Fintype N₂]
+variable [DecidableEq M][DecidableEq M₁][DecidableEq M₂]
+variable [DecidableEq N][DecidableEq N₁][DecidableEq N₂]
+
+/- Concatenate together two matrices A₁[M₁ × N] and A₂[M₂ × N] with the same columns (N) to get a
+bigger matrix indexed by [(M₁ ⊕ M₂) × N] -/
+def fromRows (A₁: Matrix M₁ N R)(A₂: Matrix M₂ N R): Matrix (M₁ ⊕ M₂) N R :=
+  Matrix.of (Sum.elim A₁ A₂)
+
+/- Concatenate together two matrices B₁[M × N₁] and B₂[M × N₂] with the same Rows (M) to get a
+bigger matrix indexed by [M × (N₁ ⊕ N₂)] -/
+def fromColumns (B₁: Matrix M N₁ R)(B₂: Matrix M N₂ R): Matrix M (N₁ ⊕ N₂) R :=
+  Matrix.of fun i => Sum.elim (B₁ i) (B₂ i)
+
+/- Given a column(row) partitioned matrix extract the first or second column(row) -/
+def toColumns₁ (A: Matrix M (N₁ ⊕ N₂) R): Matrix M N₁ R :=  of fun i j => (A i (Sum.inl j))
+def toColumns₂ (A: Matrix M (N₁ ⊕ N₂) R): Matrix M N₂ R :=  of fun i j => (A i (Sum.inr j))
+def toRows₁ (A: Matrix (M₁ ⊕ M₂) N R): Matrix M₁ N R :=  of fun i j => (A (Sum.inl i) j)
+def toRows₂ (A: Matrix (M₁ ⊕ M₂) N R): Matrix M₂ N R :=  of fun i j => (A (Sum.inr i) j)
+
+lemma fromColumns_toColumns (A: Matrix M (N₁ ⊕ N₂) R):
+  A = fromColumns A.toColumns₁ A.toColumns₂ := by
+  unfold fromColumns toColumns₁ toColumns₂
+  funext i j
+  cases' j
+  all_goals (simp only [of_apply, Sum.elim_inl, Sum.elim_inr])
+
+lemma fromColumns_ext_iff (A₁: Matrix M N₁ R) (A₂: Matrix M N₂ R) (B₁: Matrix M N₁ R)
+  (B₂: Matrix M N₂ R): fromColumns A₁ A₂ = fromColumns B₁ B₂ ↔ A₁ = B₁ ∧ A₂ = B₂ := by
+  simp_rw [fromColumns, ← Matrix.ext_iff, of_apply]
+  simp only [Sum.forall, Sum.elim_inl, Sum.elim_inr]
+  exact ⟨ -- Just practicing term mode proofs !!
+    (fun h => ⟨fun i j => (h i).1 j, fun _ _ => (h _).2 _⟩),
+    (fun h => (fun _ => ⟨(h.1 _), (h.2 _)⟩))
+  ⟩
+
+lemma fromRows_toRows (A: Matrix (M₁ ⊕ M₂) N R):
+  A = fromRows A.toRows₁ A.toRows₂ := by
+  unfold fromRows toRows₁ toRows₂
+  funext i j
+  cases' i
+  all_goals (simp only [of_apply, Sum.elim_inl, Sum.elim_inr])
+
+lemma fromRows_mul (A₁: Matrix M₁ N R)(A₂: Matrix M₂ N R)(B: Matrix N M R):
+  (fromRows A₁ A₂) ⬝ B = fromRows (A₁⬝B) (A₂⬝B) := by
+  unfold fromRows
+  funext i j
+  cases' i with i i
+  all_goals (simp only [mul_apply, of_apply, Sum.elim_inl, Sum.elim_inr] )
+
+lemma mul_fromColumns (A: Matrix M N R)(B₁: Matrix N N₁ R)(B₂: Matrix N N₂ R):
+  A ⬝ (fromColumns B₁ B₂) = fromColumns (A⬝B₁) (A⬝B₂) := by
+  unfold fromColumns
+  funext i j
+  cases' j with j j
+  all_goals (simp only [mul_apply, of_apply, Sum.elim_inl, Sum.elim_inr] )
+
+-- @[simp]
+lemma fromRows_zero: fromRows (0: Matrix M₁ N R) (0: Matrix M₂ N R) = 0 := by
+  funext i j
+  unfold fromRows
+  simp only [Sum.elim_zero_zero, of_apply, Pi.zero_apply, zero_apply]
+
+-- @[simp]
+lemma fromColumns_zero: fromColumns (0: Matrix M N₁ R) (0: Matrix M N₂ R) = 0 := by
+  funext i j
+  unfold fromColumns
+  cases' j with j j
+  all_goals (simp only [of_apply, Sum.elim_inl, Sum.elim_inr, zero_apply])
+
+/- A row partitioned matrix multiplied by a column partioned matrix gives a 2 by 2 block matrix -/
+lemma fromRows_mul_fromColumns (A₁: Matrix M₁ N R) (A₂: Matrix M₂ N R)
+  (B₁: Matrix N N₁ R) (B₂: Matrix N N₂ R) :
+  (fromRows A₁ A₂) ⬝ (fromColumns B₁ B₂) = fromBlocks (A₁⬝B₁) (A₁⬝B₂) (A₂⬝B₁) (A₂⬝B₂) := by
+  funext i j
+  rw [fromRows, fromColumns]
+  cases i;
+  all_goals (cases j)
+  all_goals (simp only [
+    fromBlocks_apply₁₁, fromBlocks_apply₁₂, fromBlocks_apply₂₁, fromBlocks_apply₂₂,
+      mul_apply, of_apply, Sum.elim_inl, Sum.elim_inr] )
+
+/- A column partitioned matrix mulitplied by a row partitioned matrix gives the sum of the "outer"
+products of the block matrices -/
+lemma fromColumns_mul_fromRows (A₁: Matrix M N₁ R)(A₂: Matrix M N₂ R)
+  (B₁: Matrix N₁ N R)(B₂: Matrix N₂ N R) :
+  fromColumns A₁ A₂ ⬝ fromRows B₁ B₂ = (A₁⬝B₁ + A₂⬝B₂) := by
+  funext i j
+  rw [fromRows, fromColumns]
+  simp only [add_apply, mul_apply, of_apply, Fintype.sum_sum_type, Sum.elim_inl, Sum.elim_inr]
+
+/- A column partitioned matrix multipiled by a block matrix results in a column partioned matrix -/
+lemma fromColumns_mul_fromBlocks (A₁: Matrix M M₁ R) (A₂: Matrix M M₂ R)
+  (B₁₁: Matrix M₁ N₁ R)(B₁₂: Matrix M₁ N₂ R)(B₂₁: Matrix M₂ N₁ R)(B₂₂: Matrix M₂ N₂ R):
+  (fromColumns A₁ A₂) ⬝ fromBlocks B₁₁ B₁₂ B₂₁ B₂₂ =
+    fromColumns (A₁⬝B₁₁ + A₂⬝B₂₁) (A₁⬝B₁₂ + A₂⬝B₂₂) := by
+  funext i j
+  rw [fromColumns, fromColumns, fromBlocks]
+  cases j
+  all_goals simp only [of_apply, add_apply, Fintype.sum_sum_type, Sum.elim_inl,
+    Sum.elim_inr, mul_apply]
+
+/- A block matrix mulitplied by a row partitioned matrix gives a row partitioned matrix -/
+lemma fromBlocks_mul_fromRows (A₁: Matrix N₁ N R) (A₂: Matrix N₂ N R)
+  (B₁₁: Matrix M₁ N₁ R)(B₁₂: Matrix M₁ N₂ R)(B₂₁: Matrix M₂ N₁ R)(B₂₂: Matrix M₂ N₂ R):
+  fromBlocks B₁₁ B₁₂ B₂₁ B₂₂ ⬝ (fromRows A₁ A₂) = fromRows (B₁₁⬝A₁ + B₁₂⬝A₂) (B₂₁⬝A₁ + B₂₂⬝A₂) := by
+  funext i j
+  rw [fromRows, fromRows, fromBlocks]
+  cases i
+  all_goals simp only [of_apply, add_apply, Fintype.sum_sum_type, Sum.elim_inl, Sum.elim_inr,
+    mul_apply]
+
+/- Given that the index set N and the direct sum of the index sets N₁ and N₂ are in bijection then
+the matrix A : N × (N₁ ⊕ N₂) := Cols[A₁ A₂] is actually a "square". Hence, if its product with
+another matrix B : (N₁ ⊕ N₂) × N := Rows[B₁ B₂] matrix is one, the other matrix must be its inverse
+Mulitplication of a matrix by its inverse is commutative. This is column partioned matrix form of
+`mul_eq_one_comm` -/
+lemma fromColumns_mul_fromRows_eq_one_comm (e: N ≃ N₁ ⊕ N₂)
+  (A₁: Matrix N N₁ R)(A₂: Matrix N N₂ R)(B₁: Matrix N₁ N R)(B₂: Matrix N₂ N R):
+  fromColumns A₁ A₂ ⬝ fromRows B₁ B₂ = 1 ↔ fromRows B₁ B₂ ⬝ fromColumns A₁ A₂ = 1 := by
+  constructor
+  intro h
+  rw [← Matrix.submatrix_id_id (fromRows B₁ B₂ ⬝ fromColumns A₁ A₂),
+    ← Matrix.submatrix_mul_equiv (fromRows B₁ B₂) (fromColumns A₁ A₂) _ e.symm _]
+  swap
+  intro h
+  rw [← Matrix.submatrix_id_id (fromColumns A₁ A₂ ⬝ fromRows B₁ B₂),
+    ← Matrix.submatrix_mul_equiv (fromColumns A₁ A₂) (fromRows B₁ B₂) _ e _]
+  all_goals
+  ( rw [mul_eq_one_comm, ← Matrix.submatrix_mul, h, submatrix_one_equiv]
+    exact Function.bijective_id )
+
+/- The lemma `fromColumns_mul_fromRows_eq_one_comm` specialized to the case where the index sets N₁
+and N₂, are the result of subtyping by a predicate and its complement. -/
+lemma equiv_compl_fromColumns_mul_fromRows_eq_one_comm (p: N → Prop)[DecidablePred p]
+  (A₁: Matrix N {i // p i} R) (A₂: Matrix N {i // ¬p i} R)
+    (B₁: Matrix {i // p i} N R) (B₂: Matrix {i // ¬p i} N R):
+  fromColumns A₁ A₂ ⬝ fromRows B₁ B₂ = 1 ↔ fromRows B₁ B₂ ⬝ fromColumns A₁ A₂ = 1 := by
+  let e := Equiv.sumCompl p
+  exact fromColumns_mul_fromRows_eq_one_comm (id e.symm) A₁ A₂ B₁ B₂
+
+/- A column partioned matrix when transposed gives a row partioned matrix with columns of the
+initial matrix tranposed to become rows. -/
+lemma transpose_fromColumns_eq_fromRows_transpose {α: Type}
+  (A₁: Matrix M N₁ α)(A₂: Matrix M N₂ α):
+  transpose (fromColumns A₁ A₂) = fromRows (transpose A₁) (transpose A₂) := by
+  rw [fromColumns, fromRows]
+  funext i j
+  cases' i with i i
+  all_goals (simp only [transpose_apply, of_apply, Sum.elim_inl, Sum.elim_inr] )
+
+/- A column partioned matrix in a Star ring when conjugate transposed gives a row partitioned matrix
+with the columns of the initial matrix conjugate transposed to become rows. -/
+lemma conjTranspose_fromColumns_eq_fromRows_conjTranspose {α: Type}[Star α]
+  (A₁: Matrix M N₁ α)(A₂: Matrix M N₂ α):
+  conjTranspose (fromColumns A₁ A₂) = fromRows (conjTranspose A₁) (conjTranspose A₂) := by
+  rw [fromColumns, fromRows]
+  funext i j
+  cases' i with i i
+  all_goals (simp only [conjTranspose_apply, of_apply, Sum.elim_inl, Sum.elim_inr])
+
+/- A row partioned matrix when transposed gives a column partioned matrix with rows of the initial
+matrix tranposed to become columns. -/
+lemma transpose_fromRows_eq_fromColumns_transpose {α: Type}
+  (A₁: Matrix M₁ N α)(A₂: Matrix M₂ N α):
+  transpose (fromRows A₁ A₂) = fromColumns (transpose A₁) (transpose A₂) := by
+  rw [fromColumns, fromRows]
+  funext i j
+  cases' j with j j
+  all_goals (simp only [transpose_apply, of_apply, Sum.elim_inl, Sum.elim_inr] )
+
+/- A row partioned matrix in a Star ring when conjugate transposed gives a column partitioned matrix
+with the rows of the initial matrix conjugate transposed to become columns. -/
+lemma conjTranspose_fromRows_eq_fromColumns_conjTranspose {α: Type}[Star α]
+  (A₁: Matrix M₁ N α)(A₂: Matrix M₂ N α):
+  conjTranspose (fromRows A₁ A₂) = fromColumns (conjTranspose A₁) (conjTranspose A₂) := by
+  rw [fromColumns, fromRows]
+  funext j i
+  cases' i with i i
+  all_goals (simp only [conjTranspose_apply, of_apply, Sum.elim_inl, Sum.elim_inr])
+
+end Matrix


### PR DESCRIPTION
This file provides the basic definitions of matrices composed from columns and rows. The concatenation of two matrices with the same row indices can be expressed as `A = fromColumns A₁ A₂` the concatenation of two matrices with the same column indices can be expressed as `B = fromRows B₁ B₂`.

We then provide a few lemmas that deal with the products of these with each other and with block matrices. Two particular lemmas `fromColumns_mul_fromRows_eq_one_comm` and `equiv_compl_fromColumns_mul_fromRows_eq_one_comm` deal with the case of matrix multiplication that gives one as a result. This gives a crude (but usable) replacement for the `Invertible` type which can only be applied to square matrices (with the same index type for rows and columns).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
