### PR TITLE
[Merged by Bors] - feat(Analysis/Convex/Cone/Proper): define ProperCone.positive extending ConvexCone.positive

### DIFF
--- a/Mathlib/Analysis/Convex/Cone/Proper.lean
+++ b/Mathlib/Analysis/Convex/Cone/Proper.lean
@@ -126,7 +126,8 @@ end SMul
 
 section PositiveCone
 
-variable (𝕜 E) [OrderedSemiring 𝕜] [OrderedAddCommGroup E] [Module 𝕜 E] [OrderedSMul 𝕜 E]
+variable (𝕜 E) 
+variable [OrderedSemiring 𝕜] [OrderedAddCommGroup E] [Module 𝕜 E] [OrderedSMul 𝕜 E]
   [TopologicalSpace E] [OrderClosedTopology E]
 
 /-- The positive cone is the proper cone formed by the set of nonnegative elements in an ordered

--- a/Mathlib/Analysis/Convex/Cone/Proper.lean
+++ b/Mathlib/Analysis/Convex/Cone/Proper.lean
@@ -21,7 +21,6 @@ linear programs, the results from this file can be used to prove duality theorem
 
 The next steps are:
 - Add convex_cone_class that extends set_like and replace the below instance
-- Define the positive cone as a proper cone.
 - Define primal and dual cone programs and prove weak duality.
 - Prove regular and strong duality for cone programs using Farkas' lemma (see reference).
 - Define linear programs and prove LP duality as a special case of cone duality.

--- a/Mathlib/Analysis/Convex/Cone/Proper.lean
+++ b/Mathlib/Analysis/Convex/Cone/Proper.lean
@@ -127,7 +127,8 @@ end SMul
 
 section PositiveCone
 
-variable (𝕜 E) [OrderedSemiring 𝕜] [OrderedAddCommGroup E] [Module 𝕜 E] [OrderedSMul 𝕜 E]  [TopologicalSpace E] [OrderClosedTopology E]
+variable (𝕜 E) [OrderedSemiring 𝕜] [OrderedAddCommGroup E] [Module 𝕜 E] [OrderedSMul 𝕜 E]
+  [TopologicalSpace E] [OrderClosedTopology E]
 
 /-- The positive cone is the proper cone formed by the set of nonnegative elements in an ordered
 module.

--- a/Mathlib/Analysis/Convex/Cone/Proper.lean
+++ b/Mathlib/Analysis/Convex/Cone/Proper.lean
@@ -125,6 +125,28 @@ protected theorem isClosed (K : ProperCone 𝕜 E) : IsClosed (K : Set E) :=
 
 end SMul
 
+section PositiveCone
+
+variable (𝕜 E) [OrderedSemiring 𝕜] [OrderedAddCommGroup E] [Module 𝕜 E] [OrderedSMul 𝕜 E]  [TopologicalSpace E] [OrderClosedTopology E]
+
+/-- The positive cone is the proper cone formed by the set of nonnegative elements in an ordered
+module.
+-/
+def positive : ProperCone 𝕜 E where
+  toConvexCone := ConvexCone.positive 𝕜 E
+  nonempty' := ⟨0, ConvexCone.pointed_positive _ _⟩
+  is_closed' := isClosed_Ici
+
+@[simp]
+theorem mem_positive {x : E} : x ∈ positive 𝕜 E ↔ 0 ≤ x :=
+  Iff.rfl
+
+@[simp]
+theorem coe_positive : ↑(positive 𝕜 E) = ConvexCone.positive 𝕜 E :=
+  rfl
+
+end PositiveCone
+
 section Module
 
 variable {𝕜 : Type _} [OrderedSemiring 𝕜]

--- a/Mathlib/Analysis/Convex/Cone/Proper.lean
+++ b/Mathlib/Analysis/Convex/Cone/Proper.lean
@@ -131,8 +131,7 @@ variable (𝕜 E) [OrderedSemiring 𝕜] [OrderedAddCommGroup E] [Module 𝕜 E]
   [TopologicalSpace E] [OrderClosedTopology E]
 
 /-- The positive cone is the proper cone formed by the set of nonnegative elements in an ordered
-module.
--/
+module. -/
 def positive : ProperCone 𝕜 E where
   toConvexCone := ConvexCone.positive 𝕜 E
   nonempty' := ⟨0, ConvexCone.pointed_positive _ _⟩


### PR DESCRIPTION
Defines `ProperCone.positive` extending `ConvexCone.positive`.

Part of #6058

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
