### PR TITLE
[Merged by Bors] - feat: parameter equality of strongly regular graphs

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/StronglyRegular.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/StronglyRegular.lean
@@ -195,8 +195,8 @@ theorem IsSRGWith.param_eq (h : G.IsSRGWith n k ℓ μ) (hn : 0 < n) :
       card_singleton, ← sdiff_inter_self_left, card_sdiff (by apply inter_subset_left)]
     congr
     · simp [h.regular w]
-    · simp_rw [neighborFinset_def, ← Set.toFinset_inter, ← h.of_adj v w hw, ← Set.toFinset_card,
-        Set.inter_comm]
+    · simp_rw [inter_comm, neighborFinset_def, ← Set.toFinset_inter, ← h.of_adj v w hw,
+        ← Set.toFinset_card]
       congr!
   · intro w hw
     simp_rw [neighborFinset_compl, mem_sdiff, mem_compl, mem_singleton, mem_neighborFinset,

--- a/Mathlib/Combinatorics/SimpleGraph/StronglyRegular.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/StronglyRegular.lean
@@ -5,6 +5,7 @@ Authors: Alena Gusakov
 -/
 import Mathlib.Combinatorics.SimpleGraph.Basic
 import Mathlib.Data.Set.Finite
+import Mathlib.Combinatorics.DoubleCounting
 
 #align_import combinatorics.simple_graph.strongly_regular from "leanprover-community/mathlib"@"2b35fc7bea4640cb75e477e83f32fbd538920822"
 
@@ -21,8 +22,6 @@ import Mathlib.Data.Set.Finite
   * The number of common neighbors between any two nonadjacent vertices in `G` is `μ`
 
 ## TODO
-- Prove that the parameters of a strongly regular graph
-  obey the relation `(n - k - 1) * μ = k * (k - ℓ - 1)`
 - Prove that if `I` is the identity matrix and `J` is the all-one matrix,
   then the adj matrix `A` of SRG obeys relation `A^2 = kI + ℓA + μ(J - I - A)`
 -/
@@ -139,7 +138,7 @@ set_option linter.uppercaseLean3 false in
 #align simple_graph.is_SRG_with.compl_is_regular SimpleGraph.IsSRGWith.compl_is_regular
 
 theorem IsSRGWith.card_commonNeighbors_eq_of_adj_compl (h : G.IsSRGWith n k ℓ μ) {v w : V}
-    (ha : Gᶜ.Adj v w) : Fintype.card (↥(Gᶜ.commonNeighbors v w)) = n - (2 * k - μ) - 2 := by
+    (ha : Gᶜ.Adj v w) : Fintype.card (Gᶜ.commonNeighbors v w) = n - (2 * k - μ) - 2 := by
   simp only [← Set.toFinset_card, commonNeighbors, Set.toFinset_inter, neighborSet_compl,
     Set.toFinset_diff, Set.toFinset_singleton, Set.toFinset_compl, ← neighborFinset_def]
   simp_rw [compl_neighborFinset_sdiff_inter_eq]
@@ -156,7 +155,7 @@ set_option linter.uppercaseLean3 false in
 
 theorem IsSRGWith.card_commonNeighbors_eq_of_not_adj_compl (h : G.IsSRGWith n k ℓ μ) {v w : V}
     (hn : v ≠ w) (hna : ¬Gᶜ.Adj v w) :
-    Fintype.card (↥Gᶜ.commonNeighbors v w) = n - (2 * k - ℓ) := by
+    Fintype.card (Gᶜ.commonNeighbors v w) = n - (2 * k - ℓ) := by
   simp only [← Set.toFinset_card, commonNeighbors, Set.toFinset_inter, neighborSet_compl,
     Set.toFinset_diff, Set.toFinset_singleton, Set.toFinset_compl, ← neighborFinset_def]
   simp only [not_and, Classical.not_not, compl_adj] at hna
@@ -175,5 +174,36 @@ theorem IsSRGWith.compl (h : G.IsSRGWith n k ℓ μ) :
   of_not_adj := fun _v _w hn hna => h.card_commonNeighbors_eq_of_not_adj_compl hn hna
 set_option linter.uppercaseLean3 false in
 #align simple_graph.is_SRG_with.compl SimpleGraph.IsSRGWith.compl
+
+/-- The parameters of a strongly regular graph with at least one vertex satisfy
+`k * (k - ℓ - 1) = (n - k - 1) * μ`. -/
+theorem IsSRGWith.param_eq (h : G.IsSRGWith n k ℓ μ) (hn : 0 < n) :
+    k * (k - ℓ - 1) = (n - k - 1) * μ := by
+  rw [← h.card, Fintype.card_pos_iff] at hn
+  have v := Classical.choice hn
+  convert card_mul_eq_card_mul G.Adj (s := G.neighborFinset v) (t := Gᶜ.neighborFinset v) _ _
+  · simp [h.regular.degree_eq]
+  · simp [h.compl.regular.degree_eq]
+  · intro w hw
+    rw [mem_neighborFinset] at hw
+    simp_rw [bipartiteAbove, show G.Adj w = fun a => G.Adj w a by rfl, ← mem_neighborFinset,
+      filter_mem_eq_inter]
+    have s : {v} ⊆ G.neighborFinset w \ G.neighborFinset v := by
+      rw [singleton_subset_iff, mem_sdiff, mem_neighborFinset]
+      exact ⟨hw.symm, G.not_mem_neighborFinset_self v⟩
+    rw [inter_comm, neighborFinset_compl, inter_sdiff, ← sdiff_eq_inter_compl, card_sdiff s,
+      card_singleton, ← sdiff_inter_self_left, card_sdiff (by apply inter_subset_left)]
+    congr
+    · simp [h.regular w]
+    · simp_rw [neighborFinset_def, ← Set.toFinset_inter, ← h.of_adj v w hw, ← Set.toFinset_card,
+        Set.inter_comm]
+      congr!
+  · intro w hw
+    simp_rw [neighborFinset_compl, mem_sdiff, mem_compl, mem_singleton, mem_neighborFinset,
+      ← Ne.def] at hw
+    simp_rw [bipartiteBelow, adj_comm, ← mem_neighborFinset, filter_mem_eq_inter,
+      neighborFinset_def, ← Set.toFinset_inter, ← h.of_not_adj v w hw.2.symm hw.1,
+      ← Set.toFinset_card]
+    congr!
 
 end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/StronglyRegular.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/StronglyRegular.lean
@@ -182,8 +182,8 @@ theorem IsSRGWith.param_eq (h : G.IsSRGWith n k ℓ μ) (hn : 0 < n) :
   rw [← h.card, Fintype.card_pos_iff] at hn
   obtain ⟨v⟩ := hn
   convert card_mul_eq_card_mul G.Adj (s := G.neighborFinset v) (t := Gᶜ.neighborFinset v) _ _
-  · simp [h.regular.degree_eq]
-  · simp [h.compl.regular.degree_eq]
+  · simp [h.regular v]
+  · simp [h.compl.regular v]
   · intro w hw
     rw [mem_neighborFinset] at hw
     simp_rw [bipartiteAbove, show G.Adj w = fun a => G.Adj w a by rfl, ← mem_neighborFinset,

--- a/Mathlib/Combinatorics/SimpleGraph/StronglyRegular.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/StronglyRegular.lean
@@ -180,7 +180,7 @@ set_option linter.uppercaseLean3 false in
 theorem IsSRGWith.param_eq (h : G.IsSRGWith n k ℓ μ) (hn : 0 < n) :
     k * (k - ℓ - 1) = (n - k - 1) * μ := by
   rw [← h.card, Fintype.card_pos_iff] at hn
-  have v := Classical.choice hn
+  obtain ⟨v⟩ := hn
   convert card_mul_eq_card_mul G.Adj (s := G.neighborFinset v) (t := Gᶜ.neighborFinset v) _ _
   · simp [h.regular.degree_eq]
   · simp [h.compl.regular.degree_eq]


### PR DESCRIPTION
i.e. $k(k-l-1)=(n-k-1)μ$. An extra condition $n>0$ is required because the proof (a standard double counting argument) sets itself around an arbitrary vertex of the graph, and furthermore the null graph ($n=0$) can vacuously be made to be strongly regular with any parameters you like.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
