### PR TITLE
[Merged by Bors] - feat: lemmas about List.maximum

### DIFF
--- a/Mathlib/Data/List/MinMax.lean
+++ b/Mathlib/Data/List/MinMax.lean
@@ -400,6 +400,18 @@ theorem minimum_le_coe_iff : l.minimum ≤ a ↔ ∃ b, b ∈ l ∧ b ≤ a := b
   | cons h t ih =>
     simp [List.minimum_cons, ih]
 
+theorem maximum_ne_bot_of_ne_nil {l : List α} (h : l ≠ []) : l.maximum ≠ ⊥ :=
+  match l, h with | _ :: _, _ => by simp [List.maximum_cons]
+
+theorem minimum_ne_top_of_ne_nil {l : List α} (h : l ≠ []) : l.minimum ≠ ⊤ :=
+  @List.maximum_ne_bot_of_ne_nil αᵒᵈ _ _ h
+
+theorem maximum_ne_bot_of_length_pos {l : List α} (h : 0 < l.length) : l.maximum ≠ ⊥ :=
+  match l, h with | _ :: _, _ => by simp [List.maximum_cons]
+
+theorem minimum_ne_top_of_length_pos {l : List α} (h : 0 < l.length) : l.minimum ≠ ⊤ :=
+  @List.maximum_ne_bot_of_length_pos αᵒᵈ _ _ h
+
 end LinearOrder
 
 end MaximumMinimum


### PR DESCRIPTION
No particular objection if we only want one out of the `_ne_nil` and `_length_pos` pairs, but I like wall-to-wall coverage so `exact?` always works. :-)

(For context, the place I needed these more naturally wanted the `_length_pos` lemmas.)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
