### PR TITLE
[Merged by Bors] - ci: do not let bors run if the awaiting-CI label is present

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,7 +1,7 @@
 status = ["Build", "Lint style", "Check all files imported"]
 use_squash_merge = true
 timeout_sec = 28800
-block_labels = ["not-ready-to-merge", "WIP", "blocked-by-other-PR", "merge-conflict"]
+block_labels = ["not-ready-to-merge", "WIP", "blocked-by-other-PR", "merge-conflict", "awaiting-CI"]
 delete_merged_branches = true
 update_base_for_deletes = true
 cut_body_after = "---"


### PR DESCRIPTION
We already did this in mathlib3.

This forward-ports https://github.com/leanprover-community/mathlib/pull/9478, which was created a few days after this file was ported in #52.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
