### PR TITLE
[Merged by Bors] - feat: Self-adjoint LinearPMaps are densely defined

### DIFF
--- a/Mathlib/Analysis/InnerProductSpace/LinearPMap.lean
+++ b/Mathlib/Analysis/InnerProductSpace/LinearPMap.lean
@@ -243,3 +243,32 @@ theorem toPMap_adjoint_eq_adjoint_toPMap_of_dense (hp : Dense (p : Set E)) :
 #align continuous_linear_map.to_pmap_adjoint_eq_adjoint_to_pmap_of_dense ContinuousLinearMap.toPMap_adjoint_eq_adjoint_toPMap_of_dense
 
 end ContinuousLinearMap
+
+section Star
+
+namespace LinearPMap
+
+variable [CompleteSpace E]
+
+instance instStar : Star (E →ₗ.[𝕜] E) where
+  star := fun A ↦ A.adjoint
+
+variable {A : E →ₗ.[𝕜] E}
+
+theorem isSelfAdjoint_def : IsSelfAdjoint A ↔ A† = A := by
+  rfl
+
+theorem _root_.IsSelfAdjoint.dense_domain (hA : IsSelfAdjoint A) : Dense (A.domain : Set E) := by
+  by_contra h
+  rw [isSelfAdjoint_def] at hA
+  have h' : A.domain = ⊤ := by
+    rw [← hA, Submodule.eq_top_iff']
+    intro x
+    rw [mem_adjoint_domain_iff, ← hA]
+    refine (innerSL 𝕜 x).cont.comp ?_
+    simp [adjoint, h, continuous_const]
+  simp [h'] at h
+
+end LinearPMap
+
+end Star

--- a/Mathlib/Analysis/InnerProductSpace/LinearPMap.lean
+++ b/Mathlib/Analysis/InnerProductSpace/LinearPMap.lean
@@ -255,9 +255,13 @@ instance instStar : Star (E →ₗ.[𝕜] E) where
 
 variable {A : E →ₗ.[𝕜] E}
 
-theorem isSelfAdjoint_def : IsSelfAdjoint A ↔ A† = A := by
-  rfl
+theorem isSelfAdjoint_def : IsSelfAdjoint A ↔ A† = A := Iff.rfl
 
+/-- Every self-adjoint `LinearPMap` has dense domain.
+
+This is not true by definition since we define the adjoint without the assumption that the
+domain is dense, but the choice of the junk value implies that a `LinearPMap` cannot be self-adjoint
+if it does not have dense domain. -/
 theorem _root_.IsSelfAdjoint.dense_domain (hA : IsSelfAdjoint A) : Dense (A.domain : Set E) := by
   by_contra h
   rw [isSelfAdjoint_def] at hA


### PR DESCRIPTION
Define the star on `LinearPMap` as the adjoint and prove that every self-adjoint operator is automatically densely defined.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
