### PR TITLE
[Merged by Bors] - feat: Compositum of two normal field extensions is normal

### DIFF
--- a/Mathlib/FieldTheory/Normal.lean
+++ b/Mathlib/FieldTheory/Normal.lean
@@ -264,9 +264,12 @@ instance normal_iSup {ι : Type _} (t : ι → IntermediateField F K) [h : ∀ i
   exact Polynomial.splits_comp_of_splits _ (inclusion hE).toRingHom this
 #align intermediate_field.normal_supr IntermediateField.normal_iSup
 
--- Porting note `[Field F] [Field K] [Algebra F K]` added by hand.
-variable {F K} {L : Type _} [Field F] [Field K] [Field L] [Algebra F L] [Algebra K L]
-  [Algebra F K] [IsScalarTower F K L]
+instance normal_sup
+    (E E' : IntermediateField F K) [Normal F E] [Normal F E'] :
+    Normal F (E ⊔ E' : IntermediateField F K) :=
+  iSup_bool_eq (f := Bool.rec E' E) ▸ normal_iSup (h := by intro i; cases i <;> infer_instance)
+
+variable [Field L] [Algebra F L] [Algebra K L] [IsScalarTower F K L]
 
 @[simp]
 theorem restrictScalars_normal {E : IntermediateField K L} :

--- a/Mathlib/FieldTheory/Normal.lean
+++ b/Mathlib/FieldTheory/Normal.lean
@@ -269,7 +269,9 @@ instance normal_sup
     Normal F (E ⊔ E' : IntermediateField F K) :=
   iSup_bool_eq (f := Bool.rec E' E) ▸ normal_iSup (h := by intro i; cases i <;> infer_instance)
 
-variable [Field L] [Algebra F L] [Algebra K L] [IsScalarTower F K L]
+-- Porting note `[Field F] [Field K] [Algebra F K]` added by hand.
+variable {F K} {L : Type _} [Field F] [Field K] [Field L] [Algebra F L] [Algebra K L]
+  [Algebra F K] [IsScalarTower F K L]
 
 @[simp]
 theorem restrictScalars_normal {E : IntermediateField K L} :


### PR DESCRIPTION
This is a quick consequence of `normal_iSup` which states than an arbitrary compositum of normal field extensions is normal.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
