### PR TITLE
[Merged by Bors] - feat: `DihedralGroup 0` is infinite

### DIFF
--- a/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
@@ -114,6 +114,9 @@ private def fintypeHelper : Sum (ZMod n) (ZMod n) ≃ DihedralGroup n where
 instance [NeZero n] : Fintype (DihedralGroup n) :=
   Fintype.ofEquiv _ fintypeHelper
 
+instance : Infinite (DihedralGroup 0) :=
+  DihedralGroup.fintypeHelper.infinite_iff.mp inferInstance
+
 instance : Nontrivial (DihedralGroup n) :=
   ⟨⟨r 0, sr 0, by simp_rw [ne_eq]⟩⟩
 


### PR DESCRIPTION
This PR adds an instance stating that `DihedralGroup 0` is infinite.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
