### PR TITLE
fix: correct #align for thunk.mk

### DIFF
--- a/Mathlib/Data/LazyList/Basic.lean
+++ b/Mathlib/Data/LazyList/Basic.lean
@@ -6,6 +6,7 @@ Authors: Simon Hudon
 import Mathlib.Control.Traversable.Equiv
 import Mathlib.Control.Traversable.Instances
 import Mathlib.Data.LazyList
+import Mathlib.Lean.Thunk
 
 #align_import data.lazy_list.basic from "leanprover-community/mathlib"@"1f0096e6caa61e9c849ec2adbd227e960e9dff58"
 
@@ -19,27 +20,6 @@ TODO: move the `LazyList.lean` file from core to mathlib.
 
 
 universe u
-
-namespace Thunk
-
--- Porting note: `Thunk.pure` appears to do the same thing.
-#align thunk.mk Thunk.pure
-
--- Porting note: Added `Thunk.ext` to get `ext` tactic to work.
-@[ext]
-theorem ext {α : Type u} {a b : Thunk α} (eq : a.get = b.get) : a = b := by
-  have ⟨_⟩ := a
-  have ⟨_⟩ := b
-  congr
-  exact funext fun _ ↦ eq
-
-instance {α : Type u} [DecidableEq α] : DecidableEq (Thunk α) := by
-  intro a b
-  have : a = b ↔ a.get = b.get := ⟨by intro x; rw [x], by intro; ext; assumption⟩
-  rw [this]
-  infer_instance
-
-end Thunk
 
 namespace LazyList
 

--- a/Mathlib/Lean/Thunk.lean
+++ b/Mathlib/Lean/Thunk.lean
@@ -25,9 +25,9 @@ instance {α : Type u} [DecidableEq α] : DecidableEq (Thunk α) := by
   infer_instance
 
 /-- The product of two thunks. -/
-def Thunk.prod (a : Thunk α) (b : Thunk β) : Thunk (α × β) := Thunk.mk fun _ => (a.get, b.get)
+def prod (a : Thunk α) (b : Thunk β) : Thunk (α × β) := Thunk.mk fun _ => (a.get, b.get)
 
-@[simp] theorem Thunk.prod_get_fst : (Thunk.prod a b).get.1 = a.get := rfl
-@[simp] theorem Thunk.prod_get_snd : (Thunk.prod a b).get.2 = b.get := rfl
+@[simp] theorem prod_get_fst : (prod a b).get.1 = a.get := rfl
+@[simp] theorem prod_get_snd : (prod a b).get.2 = b.get := rfl
 
 end Thunk

--- a/Mathlib/Lean/Thunk.lean
+++ b/Mathlib/Lean/Thunk.lean
@@ -6,6 +6,10 @@ Authors: Simon Hudon
 import Mathlib.Mathport.Rename
 import Std.Tactic.Ext
 
+/-!
+# Basic facts about `Thunk`.
+-/
+
 namespace Thunk
 
 #align thunk.mk Thunk.mk

--- a/Mathlib/Lean/Thunk.lean
+++ b/Mathlib/Lean/Thunk.lean
@@ -1,0 +1,33 @@
+/-
+Copyright (c) 2018 Simon Hudon. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Simon Hudon
+-/
+import Mathlib.Mathport.Rename
+import Std.Tactic.Ext
+
+namespace Thunk
+
+#align thunk.mk Thunk.mk
+
+-- Porting note: Added `Thunk.ext` to get `ext` tactic to work.
+@[ext]
+theorem ext {α : Type u} {a b : Thunk α} (eq : a.get = b.get) : a = b := by
+  have ⟨_⟩ := a
+  have ⟨_⟩ := b
+  congr
+  exact funext fun _ ↦ eq
+
+instance {α : Type u} [DecidableEq α] : DecidableEq (Thunk α) := by
+  intro a b
+  have : a = b ↔ a.get = b.get := ⟨by intro x; rw [x], by intro; ext; assumption⟩
+  rw [this]
+  infer_instance
+
+/-- The product of two thunks. -/
+def Thunk.prod (a : Thunk α) (b : Thunk β) : Thunk (α × β) := Thunk.mk fun _ => (a.get, b.get)
+
+@[simp] theorem Thunk.prod_get_fst : (Thunk.prod a b).get.1 = a.get := rfl
+@[simp] theorem Thunk.prod_get_snd : (Thunk.prod a b).get.2 = b.get := rfl
+
+end Thunk


### PR DESCRIPTION
`Thunk.pure` is not lazy.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
