### PR TITLE
[Merged by Bors] - feat: Lemmas about commuting probabilities of groups

### DIFF
--- a/Mathlib/GroupTheory/CommutingProbability.lean
+++ b/Mathlib/GroupTheory/CommutingProbability.lean
@@ -16,7 +16,7 @@ import Mathlib.GroupTheory.Index
 This file introduces the commuting probability of finite groups.
 
 ## Main definitions
-* `commProb`: The commuting probability of a type with a multiplication operation.
+* `commProb`: The commuting probability of a finite type with a multiplication operation.
 
 ## Todo
 * Neumann's theorem.
@@ -31,7 +31,7 @@ open Fintype
 
 variable (M : Type _) [Mul M]
 
-/-- The commuting probability of a type with a multiplication operation. -/
+/-- The commuting probability of a finite type with a multiplication operation. -/
 def commProb : ℚ :=
   Nat.card { p : M × M // Commute p.1 p.2 } / (Nat.card M : ℚ) ^ 2
 #align comm_prob commProb

--- a/Mathlib/GroupTheory/CommutingProbability.lean
+++ b/Mathlib/GroupTheory/CommutingProbability.lean
@@ -16,7 +16,7 @@ import Mathlib.GroupTheory.Index
 This file introduces the commuting probability of finite groups.
 
 ## Main definitions
-* `commProb`: The commuting probability of a finite type with a multiplication operation.
+* `commProb`: The commuting probability of a type with a multiplication operation.
 
 ## Todo
 * Neumann's theorem.
@@ -31,7 +31,7 @@ open Fintype
 
 variable (M : Type _) [Mul M]
 
-/-- The commuting probability of a finite type with a multiplication operation. -/
+/-- The commuting probability of a type with a multiplication operation. -/
 def commProb : ℚ :=
   Nat.card { p : M × M // Commute p.1 p.2 } / (Nat.card M : ℚ) ^ 2
 #align comm_prob commProb

--- a/Mathlib/GroupTheory/CommutingProbability.lean
+++ b/Mathlib/GroupTheory/CommutingProbability.lean
@@ -33,17 +33,17 @@ variable (M : Type _) [Mul M]
 
 /-- The commuting probability of a finite type with a multiplication operation. -/
 def commProb : ℚ :=
-  Nat.card { p : M × M // p.1 * p.2 = p.2 * p.1 } / (Nat.card M : ℚ) ^ 2
+  Nat.card { p : M × M // Commute p.1 p.2 } / (Nat.card M : ℚ) ^ 2
 #align comm_prob commProb
 
 theorem commProb_def :
-    commProb M = Nat.card { p : M × M // p.1 * p.2 = p.2 * p.1 } / (Nat.card M : ℚ) ^ 2 :=
+    commProb M = Nat.card { p : M × M // Commute p.1 p.2 } / (Nat.card M : ℚ) ^ 2 :=
   rfl
 #align comm_prob_def commProb_def
 
 theorem commProb_prod (M' : Type _) [Mul M'] : commProb (M × M') = commProb M * commProb M' := by
   simp_rw [commProb_def, div_mul_div_comm, Nat.card_prod, Nat.cast_mul, mul_pow, ←Nat.cast_mul,
-    ←Nat.card_prod, Prod.ext_iff]
+    ←Nat.card_prod, Commute, SemiconjBy, Prod.ext_iff]
   congr 2
   exact Nat.card_congr ⟨fun x => ⟨⟨⟨x.1.1.1, x.1.2.1⟩, x.2.1⟩, ⟨⟨x.1.1.2, x.1.2.2⟩, x.2.2⟩⟩,
     fun x => ⟨⟨⟨x.1.1.1, x.2.1.1⟩, ⟨x.1.1.2, x.2.1.2⟩⟩, ⟨x.1.2, x.2.2⟩⟩, fun x => rfl, fun x => rfl⟩
@@ -51,7 +51,7 @@ theorem commProb_prod (M' : Type _) [Mul M'] : commProb (M × M') = commProb M *
 theorem commProb_pi (i : α → Type _) [Fintype α] [∀ a, Mul (i a)] :
     commProb (∀ a, i a) = ∏ a, commProb (i a) := by
   simp_rw [commProb_def, Finset.prod_div_distrib, Finset.prod_pow, ←Nat.cast_prod,
-    ←Nat.card_pi, Function.funext_iff]
+    ←Nat.card_pi, Commute, SemiconjBy, Function.funext_iff]
   congr 2
   exact Nat.card_congr ⟨fun x a => ⟨⟨x.1.1 a, x.1.2 a⟩, x.2 a⟩, fun x => ⟨⟨fun a => (x a).1.1,
     fun a => (x a).1.2⟩, fun a => (x a).2⟩, fun x => rfl, fun x => rfl⟩
@@ -60,9 +60,10 @@ theorem commProb_function [Fintype α] [Mul β] :
     commProb (α → β) = (commProb β) ^ Fintype.card α := by
   rw [commProb_pi, Finset.prod_const, Finset.card_univ]
 
-instance commProbInfinite [Infinite M] : Infinite { p : M × M // p.1 * p.2 = p.2 * p.1 } :=
+instance instInfiniteProdSubtypeCommute [Infinite M] : Infinite { p : M × M // Commute p.1 p.2 } :=
   Infinite.of_injective (fun m => ⟨⟨m, m⟩, rfl⟩) (by intro; simp)
 
+@[simp]
 theorem commProb_eq_zero_of_infinite [Infinite M] : commProb M = 0 :=
   div_eq_zero_iff.2 (Or.inl (Nat.cast_eq_zero.2 Nat.card_eq_zero_of_infinite))
 
@@ -95,12 +96,12 @@ theorem commProb_eq_one_iff [h : Nonempty M] :
 variable (G : Type _) [Group G] [Finite G]
 
 theorem card_comm_eq_card_conjClasses_mul_card :
-    Nat.card { p : G × G // p.1 * p.2 = p.2 * p.1 } = Nat.card (ConjClasses G) * Nat.card G := by
+    Nat.card { p : G × G // Commute p.1 p.2 } = Nat.card (ConjClasses G) * Nat.card G := by
   haveI := Fintype.ofFinite G
   simp only [Nat.card_eq_fintype_card]
   -- Porting note: Changed `calc` proof into a `rw` proof.
-  rw [card_congr (Equiv.subtypeProdEquivSigmaSubtype fun g h : G ↦ g * h = h * g), card_sigma,
-    sum_equiv ConjAct.toConjAct.toEquiv (fun a ↦ card { b // a * b = b * a })
+  rw [card_congr (Equiv.subtypeProdEquivSigmaSubtype fun g h : G ↦ Commute g h), card_sigma,
+    sum_equiv ConjAct.toConjAct.toEquiv (fun a ↦ card { b // Commute a b })
       (fun g ↦ card (MulAction.fixedBy (ConjAct G) G g))
       fun g ↦ card_congr' <| congr_arg _ <| funext fun h ↦ mul_inv_eq_iff_eq_mul.symm.to_eq,
     MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group, ConjAct.card,

--- a/Mathlib/GroupTheory/CommutingProbability.lean
+++ b/Mathlib/GroupTheory/CommutingProbability.lean
@@ -41,6 +41,27 @@ theorem commProb_def :
   rfl
 #align comm_prob_def commProb_def
 
+theorem commProb_prod (M' : Type _) [Mul M'] : commProb (M × M') = commProb M * commProb M' := by
+  simp_rw [commProb_def, div_mul_div_comm, Nat.card_prod, Nat.cast_mul, mul_pow, ←Nat.cast_mul,
+    ←Nat.card_prod, Prod.ext_iff]
+  congr 2
+  exact Nat.card_congr ⟨fun x => ⟨⟨⟨x.1.1.1, x.1.2.1⟩, x.2.1⟩, ⟨⟨x.1.1.2, x.1.2.2⟩, x.2.2⟩⟩,
+    fun x => ⟨⟨⟨x.1.1.1, x.2.1.1⟩, ⟨x.1.1.2, x.2.1.2⟩⟩, ⟨x.1.2, x.2.2⟩⟩, fun x => rfl, fun x => rfl⟩
+
+theorem commProb_pi (i : α → Type _) [Fintype α] [∀ a, Mul (i a)] :
+    commProb (∀ a, i a) = ∏ a, commProb (i a) := by
+  simp_rw [commProb_def, Finset.prod_div_distrib, Finset.prod_pow, ←Nat.cast_prod,
+    ←Nat.card_pi, Function.funext_iff]
+  congr 2
+  exact Nat.card_congr ⟨fun x a => ⟨⟨x.1.1 a, x.1.2 a⟩, x.2 a⟩, fun x => ⟨⟨fun a => (x a).1.1,
+    fun a => (x a).1.2⟩, fun a => (x a).2⟩, fun x => rfl, fun x => rfl⟩
+
+instance [Infinite M] : Infinite { p : M × M // p.1 * p.2 = p.2 * p.1 } :=
+  Infinite.of_injective (fun m => ⟨⟨m, m⟩, rfl⟩) (by intro; simp)
+
+theorem commProb_eq_zero_of_infinite [Infinite M] : commProb M = 0 :=
+  div_eq_zero_iff.2 (Or.inl (Nat.cast_eq_zero.2 Nat.card_eq_zero_of_infinite))
+
 variable [Finite M]
 
 theorem commProb_pos [h : Nonempty M] : 0 < commProb M :=

--- a/Mathlib/GroupTheory/CommutingProbability.lean
+++ b/Mathlib/GroupTheory/CommutingProbability.lean
@@ -56,7 +56,11 @@ theorem commProb_pi (i : α → Type _) [Fintype α] [∀ a, Mul (i a)] :
   exact Nat.card_congr ⟨fun x a => ⟨⟨x.1.1 a, x.1.2 a⟩, x.2 a⟩, fun x => ⟨⟨fun a => (x a).1.1,
     fun a => (x a).1.2⟩, fun a => (x a).2⟩, fun x => rfl, fun x => rfl⟩
 
-instance [Infinite M] : Infinite { p : M × M // p.1 * p.2 = p.2 * p.1 } :=
+theorem commProb_function [Fintype α] [Mul β] :
+    commProb (α → β) = (commProb β) ^ Fintype.card α := by
+  rw [commProb_pi, Finset.prod_const, Finset.card_univ]
+
+instance commProbInfinite [Infinite M] : Infinite { p : M × M // p.1 * p.2 = p.2 * p.1 } :=
   Infinite.of_injective (fun m => ⟨⟨m, m⟩, rfl⟩) (by intro; simp)
 
 theorem commProb_eq_zero_of_infinite [Infinite M] : commProb M = 0 :=


### PR DESCRIPTION
This PR adds lemmas about commuting probabilities of products of groups and about commuting probabilities of infinite groups.

It also changes some definitions and lemmas to use `Commute`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
