### PR TITLE
[Merged by Bors] - fix: shorter names for some instances

### DIFF
--- a/Mathlib/RingTheory/TensorProduct.lean
+++ b/Mathlib/RingTheory/TensorProduct.lean
@@ -459,8 +459,6 @@ instance instSemiring : Semiring (A ⊗[R] B) :=
     right_distrib := fun a b c => show mul (a + b) c = mul a c + mul b c
       by rw [map_add, LinearMap.add_apply] }
 
---set_option pp.all true in
-#print instSemiring
 theorem one_def : (1 : A ⊗[R] B) = (1 : A) ⊗ₜ (1 : B) :=
   rfl
 #align algebra.tensor_product.one_def Algebra.TensorProduct.one_def
@@ -614,8 +612,7 @@ instance instCommRing : CommRing (A ⊗[R] B) :=
       · intro x₁ x₂ h₁ h₂
         -- porting note: was `simp` not `rw`
         rw [mul_add, add_mul, h₁, h₂] }
-set_option pp.all true in
-#print instCommRing
+
 section RightAlgebra
 
 /-- `S ⊗[R] T` has a `T`-algebra structure. This is not a global instance or else the action of

--- a/Mathlib/RingTheory/TensorProduct.lean
+++ b/Mathlib/RingTheory/TensorProduct.lean
@@ -436,7 +436,7 @@ instance : AddMonoidWithOne (A ⊗[R] B) :=
 
 instance : AddCommMonoid (A ⊗[R] B) := by infer_instance
 
-instance : Semiring (A ⊗[R] B) :=
+instance instSemiring : Semiring (A ⊗[R] B) :=
   { (by infer_instance : AddMonoidWithOne (A ⊗[R] B)),
     (by infer_instance : AddCommMonoid (A ⊗[R] B)) with
     zero := 0
@@ -596,8 +596,8 @@ variable {A : Type v₁} [CommRing A] [Algebra R A]
 
 variable {B : Type v₂} [CommRing B] [Algebra R B]
 
-instance : CommRing (A ⊗[R] B) :=
-  { (by infer_instance : Ring (A ⊗[R] B)) with
+instance instCommRing : CommRing (A ⊗[R] B) :=
+  { toRing := inferInstance
     mul_comm := fun x y => by
       refine TensorProduct.induction_on x ?_ ?_ ?_
       · simp

--- a/Mathlib/RingTheory/TensorProduct.lean
+++ b/Mathlib/RingTheory/TensorProduct.lean
@@ -515,7 +515,7 @@ instance leftAlgebra [SMulCommClass R S A] : Algebra S (A ⊗[R] B) :=
 
 -- This is for the `undergrad.yaml` list.
 /-- The tensor product of two `R`-algebras is an `R`-algebra. -/
-instance : Algebra R (A ⊗[R] B) :=
+instance instAlgebra : Algebra R (A ⊗[R] B) :=
   inferInstance
 
 @[simp]

--- a/Mathlib/RingTheory/TensorProduct.lean
+++ b/Mathlib/RingTheory/TensorProduct.lean
@@ -459,6 +459,8 @@ instance instSemiring : Semiring (A ⊗[R] B) :=
     right_distrib := fun a b c => show mul (a + b) c = mul a c + mul b c
       by rw [map_add, LinearMap.add_apply] }
 
+--set_option pp.all true in
+#print instSemiring
 theorem one_def : (1 : A ⊗[R] B) = (1 : A) ⊗ₜ (1 : B) :=
   rfl
 #align algebra.tensor_product.one_def Algebra.TensorProduct.one_def
@@ -582,7 +584,7 @@ variable {A : Type v₁} [Ring A] [Algebra R A]
 
 variable {B : Type v₂} [Ring B] [Algebra R B]
 
-instance : Ring (A ⊗[R] B) :=
+instance instRing : Ring (A ⊗[R] B) :=
   { (by infer_instance : Semiring (A ⊗[R] B)) with
     add_left_neg := add_left_neg }
 
@@ -612,7 +614,8 @@ instance instCommRing : CommRing (A ⊗[R] B) :=
       · intro x₁ x₂ h₁ h₂
         -- porting note: was `simp` not `rw`
         rw [mul_add, add_mul, h₁, h₂] }
-
+set_option pp.all true in
+#print instCommRing
 section RightAlgebra
 
 /-- `S ⊗[R] T` has a `T`-algebra structure. This is not a global instance or else the action of

--- a/Mathlib/RingTheory/TensorProduct.lean
+++ b/Mathlib/RingTheory/TensorProduct.lean
@@ -583,7 +583,7 @@ variable {A : Type v₁} [Ring A] [Algebra R A]
 variable {B : Type v₂} [Ring B] [Algebra R B]
 
 instance instRing : Ring (A ⊗[R] B) :=
-  { (by infer_instance : Semiring (A ⊗[R] B)) with
+  { toSemiring := inferInstance
     add_left_neg := add_left_neg }
 
 end Ring

--- a/docs/overview.yaml
+++ b/docs/overview.yaml
@@ -97,7 +97,7 @@ General algebra:
     associative algebra over a commutative ring: 'Algebra'
     the category of algebras over a ring: 'AlgebraCat'
     free algebra of a commutative ring: 'FreeAlgebra'
-    tensor product of algebras: 'Algebra.TensorProduct.instAlgebraTensorProductToAddCommMonoidToNonUnitalNonAssocSemiringToNonAssocSemiringToAddCommMonoidToNonUnitalNonAssocSemiringToNonAssocSemiringToModuleToModuleInstSemiringTensorProductToAddCommMonoidToNonUnitalNonAssocSemiringToNonAssocSemiringToAddCommMonoidToNonUnitalNonAssocSemiringToNonAssocSemiringToModuleToModule'
+    tensor product of algebras: 'Algebra.TensorProduct.instAlgebraTensorProductToAddCommMonoidToNonUnitalNonAssocSemiringToNonAssocSemiringToAddCommMonoidToNonUnitalNonAssocSemiringToNonAssocSemiringToModuleToModuleInstSemiring'
     tensor algebra of a commutative ring: 'TensorAlgebra'
     Lie algebra: 'LieAlgebra'
     exterior algebra: 'ExteriorAlgebra'

--- a/docs/overview.yaml
+++ b/docs/overview.yaml
@@ -97,7 +97,7 @@ General algebra:
     associative algebra over a commutative ring: 'Algebra'
     the category of algebras over a ring: 'AlgebraCat'
     free algebra of a commutative ring: 'FreeAlgebra'
-    tensor product of algebras: 'Algebra.TensorProduct.instAlgebraTensorProductToAddCommMonoidToNonUnitalNonAssocSemiringToNonAssocSemiringToAddCommMonoidToNonUnitalNonAssocSemiringToNonAssocSemiringToModuleToModuleInstSemiring'
+    tensor product of algebras: 'Algebra.TensorProduct.instAlgebra'
     tensor algebra of a commutative ring: 'TensorAlgebra'
     Lie algebra: 'LieAlgebra'
     exterior algebra: 'ExteriorAlgebra'


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

This is two changes. 

1) Firstly I manually name some instances (because I am debugging some tensor product stuff and it's getting annoying). For example 

`Algebra.TensorProduct.instCommRingTensorProductToCommSemiringToAddCommMonoidToNonUnitalNonAssocSemiringToNonUnitalNonAssocRingToNonAssocRingToRingToAddCommMonoidToNonUnitalNonAssocSemiringToNonUnitalNonAssocRingToNonAssocRingToRingToModuleToSemiringToCommSemiringToModuleToSemiringToCommSemiring : CommRing (A ⊗[R] B)`

now becomes `Algebra.TensorProduct.InstCommRing : CommRing (A ⊗[R] B)`

2) `toRing := blah` generates a slightly less convoluted term than `blah: ring with`.