### PR TITLE
[Merged by Bors] - refactor: remove `IsDomain` hypothesis from `IsIntegrallyClosed`

### DIFF
--- a/Mathlib/RingTheory/Discriminant.lean
+++ b/Mathlib/RingTheory/Discriminant.lean
@@ -330,7 +330,7 @@ theorem discr_eq_discr_of_toMatrix_coeff_isIntegral [NumberField K] {b : Basis �
 separable extension of `K`. Let `B : PowerBasis K L` be such that `IsIntegral R B.gen`.
 Then for all, `z : L` that are integral over `R`, we have
 `(discr K B.basis) • z ∈ adjoin R ({B.gen} : set L)`. -/
-theorem discr_mul_isIntegral_mem_adjoin [IsDomain R] [IsSeparable K L] [IsIntegrallyClosed R]
+theorem discr_mul_isIntegral_mem_adjoin [IsSeparable K L] [IsIntegrallyClosed R]
     [IsFractionRing R K] {B : PowerBasis K L} (hint : IsIntegral R B.gen) {z : L}
     (hz : IsIntegral R z) : discr K B.basis • z ∈ adjoin R ({B.gen} : Set L) := by
   have hinv : IsUnit (traceMatrix K B.basis).det := by

--- a/Mathlib/RingTheory/IntegrallyClosed.lean
+++ b/Mathlib/RingTheory/IntegrallyClosed.lean
@@ -11,8 +11,8 @@ import Mathlib.RingTheory.Localization.Integral
 /-!
 # Integrally closed rings
 
-An integrally closed domain `R` contains all the elements of `Frac(R)` that are
-integral over `R`. A special case of integrally closed domains are the Dedekind domains.
+An integrally closed ring `R` contains all the elements of `Frac(R)` that are
+integral over `R`. A special case of integrally closed rings are the Dedekind domains.
 
 ## Main definitions
 
@@ -34,7 +34,7 @@ open Polynomial
 This definition uses `FractionRing R` to denote `Frac(R)`. See `isIntegrallyClosed_iff`
 if you want to choose another field of fractions for `R`.
 -/
-class IsIntegrallyClosed (R : Type*) [CommRing R] [IsDomain R] : Prop where
+class IsIntegrallyClosed (R : Type*) [CommRing R] : Prop where
   /-- All integral elements of `Frac(R)` are also elements of `R`. -/
   algebraMap_eq_of_integral :
     ∀ {x : FractionRing R}, IsIntegral R x → ∃ y, algebraMap R (FractionRing R) y = x
@@ -42,7 +42,7 @@ class IsIntegrallyClosed (R : Type*) [CommRing R] [IsDomain R] : Prop where
 
 section Iff
 
-variable {R : Type*} [CommRing R] [IsDomain R]
+variable {R : Type*} [CommRing R]
 
 variable (K : Type*) [Field K] [Algebra R K] [IsFractionRing R K]
 
@@ -131,12 +131,12 @@ variable {R : Type*} [CommRing R]
 
 variable (K : Type*) [Field K] [Algebra R K]
 
-variable [IsDomain R] [IsFractionRing R K]
+variable [IsFractionRing R K]
 
 variable {L : Type*} [Field L] [Algebra K L] [Algebra R L] [IsScalarTower R K L]
 
 -- Can't be an instance because you need to supply `K`.
-theorem isIntegrallyClosedOfFiniteExtension [FiniteDimensional K L] :
+theorem isIntegrallyClosedOfFiniteExtension [IsDomain R] [FiniteDimensional K L] :
     IsIntegrallyClosed (integralClosure R L) :=
   letI : IsFractionRing (integralClosure R L) L := isFractionRing_of_finite_extension K L
   (integralClosure_eq_bot_iff L).mp integralClosure_idem


### PR DESCRIPTION
This PR modifies the definition of `IsIntegrallyClosed` to drop the `IsDomain` hypothesis. This change came out of the discussions of modifying `IsDedekindDomain` to either extend `IsDomain` or to drop `IsDomain` entirely and change it to `IsDedekindRing`. (The former being a dependency of this PR, the latter a follow-up.)

Zulip thread: https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Should.20.60IsDedekindDomain.60.20extend.20.60IsDomain.60.3F

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

- [x] depends on: #5834 

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
