### PR TITLE
[Merged by Bors] - feat: `IsDedekindRing` is `IsDedekindDomain` minus `IsDomain`

### DIFF
--- a/Mathlib/RingTheory/DedekindDomain/Basic.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Basic.lean
@@ -9,14 +9,17 @@ import Mathlib.RingTheory.Polynomial.RationalRoot
 #align_import ring_theory.dedekind_domain.basic from "leanprover-community/mathlib"@"926daa81fd8acb2a04e15572c4ff20af2753c2ae"
 
 /-!
-# Dedekind domains
+# Dedekind rings and domains
 
-This file defines the notion of a Dedekind domain (or Dedekind ring),
-as a Noetherian integrally closed commutative ring of Krull dimension at most one.
+This file defines the notion of a Dedekind ring (domain),
+as a Noetherian integrally closed commutative ring (domain) of Krull dimension at most one.
 
 ## Main definitions
 
- - `IsDedekindDomain` defines a Dedekind domain as a commutative ring that is
+ - `IsDedekindRing` defines a Dedekind domain as a commutative ring that is
+   Noetherian, integrally closed in its field of fractions and has Krull dimension at most one.
+   `isDedekindRing_iff` shows that this does not depend on the choice of field of fractions.
+ - `IsDedekindDomain` defines a Dedekind domain as an integral domain that is
    Noetherian, integrally closed in its field of fractions and has Krull dimension at most one.
    `isDedekindDomain_iff` shows that this does not depend on the choice of field of fractions.
 
@@ -25,7 +28,12 @@ as a Noetherian integrally closed commutative ring of Krull dimension at most on
 The definitions that involve a field of fractions choose a canonical field of fractions,
 but are independent of that choice. The `..._iff` lemmas express this independence.
 
-Often, definitions assume that Dedekind domains are not fields. We found it more practical
+`IsDedekindRing` and `IsDedekindDomain` form a cycle in the typeclass hierarchy:
+`IsDedekindRing R + IsDomain R` imply `IsDedekindDomain R`, which implies `IsDedekindRing R`.
+This should be safe since the start and end point is the literal same expression,
+which the tabled typeclass synthesis algorithm can deal with.
+
+Often, definitions assume that Dedekind rings are not fields. We found it more practical
 to add a `(h : ¬ IsField A)` assumption whenever this is explicitly needed.
 
 ## References
@@ -90,10 +98,34 @@ theorem DimensionLEOne.eq_bot_of_lt [Ring.DimensionLEOne R] (p P : Ideal R) [p.I
 
 end Ring
 
+/-- A Dedekind ring is a commutative ring that is Noetherian, integrally closed, and
+has Krull dimension at most one.
+
+This is exactly `IsDedekindDomain` minus the `IsDomain` hypothesis.
+
+The integral closure condition is independent of the choice of field of fractions:
+use `isDedekindRing_iff` to prove `IsDedekindRing` for a given `fraction_map`.
+-/
+class IsDedekindRing
+  extends IsNoetherian A A, DimensionLEOne A, IsIntegrallyClosed A : Prop
+
+/-- An integral domain is a Dedekind domain iff and only if it is
+Noetherian, has dimension ≤ 1, and is integrally closed in a given fraction field.
+In particular, this definition does not depend on the choice of this fraction field. -/
+theorem isDedekindRing_iff (K : Type _) [CommRing K] [Algebra A K] [IsFractionRing A K] :
+    IsDedekindRing A ↔
+      IsNoetherianRing A ∧ DimensionLEOne A ∧
+        ∀ {x : K}, IsIntegral A x → ∃ y, algebraMap A K y = x :=
+  ⟨fun _ => ⟨inferInstance, inferInstance,
+             fun {_} => (isIntegrallyClosed_iff K).mp inferInstance⟩,
+   fun ⟨hr, hd, hi⟩ => { hr, hd, (isIntegrallyClosed_iff K).mpr @hi with }⟩
+
 /-- A Dedekind domain is an integral domain that is Noetherian, integrally closed, and
 has Krull dimension at most one.
 
 This is definition 3.2 of [Neukirch1992].
+
+This is exactly `IsDedekindRing` plus the `IsDomain` hypothesis.
 
 The integral closure condition is independent of the choice of field of fractions:
 use `isDedekindDomain_iff` to prove `IsDedekindDomain` for a given `fraction_map`.
@@ -103,8 +135,17 @@ This is the default implementation, but there are equivalent definitions,
 TODO: Prove that these are actually equivalent definitions.
 -/
 class IsDedekindDomain
-  extends IsDomain A, IsNoetherian A A, DimensionLEOne A, IsIntegrallyClosed A : Prop
+  extends IsDomain A, IsDedekindRing A : Prop
 #align is_dedekind_domain IsDedekindDomain
+
+/-- A Dedekind domain is exactly a Dedekind ring with an extra `IsDomain` hypothesis.
+
+`IsDedekindRing` and `IsDedekindDomain` form a cycle in the typeclass hierarchy:
+`IsDedekindRing R + IsDomain R` imply `IsDedekindDomain R`, which implies `IsDedekindRing R`.
+This should be safe since the start and end point is the literal same expression,
+which the tabled typeclass synthesis algorithm can deal with.
+-/
+instance [IsDomain A] [IsDedekindRing A] : IsDedekindDomain A where
 
 /-- An integral domain is a Dedekind domain iff and only if it is
 Noetherian, has dimension ≤ 1, and is integrally closed in a given fraction field.

--- a/Mathlib/RingTheory/DedekindDomain/Basic.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Basic.lean
@@ -107,7 +107,7 @@ use `isDedekindRing_iff` to prove `IsDedekindRing` for a given `fraction_map`.
 class IsDedekindRing
   extends IsNoetherian A A, DimensionLEOne A, IsIntegrallyClosed A : Prop
 
-/-- An integral domain is a Dedekind domain iff and only if it is
+/-- An integral domain is a Dedekind domain if and only if it is
 Noetherian, has dimension ≤ 1, and is integrally closed in a given fraction field.
 In particular, this definition does not depend on the choice of this fraction field. -/
 theorem isDedekindRing_iff (K : Type _) [CommRing K] [Algebra A K] [IsFractionRing A K] :
@@ -136,7 +136,7 @@ class IsDedekindDomain
   extends IsDomain A, IsDedekindRing A : Prop
 #align is_dedekind_domain IsDedekindDomain
 
-/-- A Dedekind domain is exactly a Dedekind ring with an extra `IsDomain` hypothesis.
+/-- Make a Dedekind domain from a Dedekind ring given that it is a domain.
 
 `IsDedekindRing` and `IsDedekindDomain` form a cycle in the typeclass hierarchy:
 `IsDedekindRing R + IsDomain R` imply `IsDedekindDomain R`, which implies `IsDedekindRing R`.

--- a/Mathlib/RingTheory/DedekindDomain/Basic.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Basic.lean
@@ -16,12 +16,10 @@ as a Noetherian integrally closed commutative ring (domain) of Krull dimension a
 
 ## Main definitions
 
- - `IsDedekindRing` defines a Dedekind domain as a commutative ring that is
+ - `IsDedekindRing` defines a Dedekind ring as a commutative ring that is
    Noetherian, integrally closed in its field of fractions and has Krull dimension at most one.
    `isDedekindRing_iff` shows that this does not depend on the choice of field of fractions.
- - `IsDedekindDomain` defines a Dedekind domain as an integral domain that is
-   Noetherian, integrally closed in its field of fractions and has Krull dimension at most one.
-   `isDedekindDomain_iff` shows that this does not depend on the choice of field of fractions.
+ - `IsDedekindDomain` defines a Dedekind domain as a Dedekind ring that is a domain.
 
 ## Implementation notes
 
@@ -107,7 +105,7 @@ The integral closure condition is independent of the choice of field of fraction
 use `isDedekindRing_iff` to prove `IsDedekindRing` for a given `fraction_map`.
 -/
 class IsDedekindRing
-  extends IsNoetherian A A, DimensionLEOne A, IsIntegrallyClosed A : Prop
+  extends IsNoetherianRing A, DimensionLEOne A, IsIntegrallyClosed A : Prop
 
 /-- An integral domain is a Dedekind domain iff and only if it is
 Noetherian, has dimension ≤ 1, and is integrally closed in a given fraction field.

--- a/Mathlib/RingTheory/DedekindDomain/Basic.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Basic.lean
@@ -105,7 +105,7 @@ The integral closure condition is independent of the choice of field of fraction
 use `isDedekindRing_iff` to prove `IsDedekindRing` for a given `fraction_map`.
 -/
 class IsDedekindRing
-  extends IsNoetherianRing A, DimensionLEOne A, IsIntegrallyClosed A : Prop
+  extends IsNoetherian A A, DimensionLEOne A, IsIntegrallyClosed A : Prop
 
 /-- An integral domain is a Dedekind domain iff and only if it is
 Noetherian, has dimension ≤ 1, and is integrally closed in a given fraction field.

--- a/Mathlib/RingTheory/DedekindDomain/Dvr.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Dvr.lean
@@ -102,7 +102,7 @@ theorem IsLocalization.isDedekindDomain [IsDedekindDomain A] {M : Submonoid A} (
   · exact Ring.DimensionLEOne.localization Aₘ hM
   · intro x hx
     obtain ⟨⟨y, y_mem⟩, hy⟩ := hx.exists_multiple_integral_of_isLocalization M _
-    obtain ⟨z, hz⟩ := (isIntegrallyClosed_iff _).mp IsDedekindDomain.toIsIntegrallyClosed hy
+    obtain ⟨z, hz⟩ := (isIntegrallyClosed_iff _).mp IsDedekindRing.toIsIntegrallyClosed hy
     refine' ⟨IsLocalization.mk' Aₘ z ⟨y, y_mem⟩, (IsLocalization.lift_mk'_spec _ _ _ _).mpr _⟩
     rw [hz, ← Algebra.smul_def]
     rfl
@@ -136,7 +136,7 @@ theorem IsLocalization.AtPrime.discreteValuationRing_of_dedekind_domain [IsDedek
     [Algebra A Aₘ] [IsLocalization.AtPrime Aₘ P] : DiscreteValuationRing Aₘ := by
   classical
   letI : IsNoetherianRing Aₘ :=
-    IsLocalization.isNoetherianRing P.primeCompl _ IsDedekindDomain.toIsNoetherian
+    IsLocalization.isNoetherianRing P.primeCompl _ IsDedekindRing.toIsNoetherian
   letI : LocalRing Aₘ := IsLocalization.AtPrime.localRing Aₘ P
   have hnf := IsLocalization.AtPrime.not_isField A hP Aₘ
   exact
@@ -148,7 +148,7 @@ theorem IsLocalization.AtPrime.discreteValuationRing_of_dedekind_domain [IsDedek
 are also Dedekind domains in the sense of Noetherian domains where the localization at every
 nonzero prime ideal is a DVR. -/
 theorem IsDedekindDomain.isDedekindDomainDvr [IsDedekindDomain A] : IsDedekindDomainDvr A :=
-  { isNoetherianRing := IsDedekindDomain.toIsNoetherian
+  { isNoetherianRing := IsDedekindRing.toIsNoetherian
     is_dvr_at_nonzero_prime := fun _ hP _ =>
       IsLocalization.AtPrime.discreteValuationRing_of_dedekind_domain A hP _ }
 #align is_dedekind_domain.is_dedekind_domain_dvr IsDedekindDomain.isDedekindDomainDvr

--- a/Mathlib/RingTheory/DedekindDomain/Ideal.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Ideal.lean
@@ -663,7 +663,7 @@ theorem Ideal.dvdNotUnit_iff_lt {I J : Ideal A} : DvdNotUnit I J ↔ J < I :=
 instance : WfDvdMonoid (Ideal A) where
   wellFounded_dvdNotUnit := by
     have : WellFounded ((· > ·) : Ideal A → Ideal A → Prop) :=
-      isNoetherian_iff_wellFounded.mp (isNoetherianRing_iff.mp IsDedekindDomain.toIsNoetherian)
+      isNoetherian_iff_wellFounded.mp (isNoetherianRing_iff.mp IsDedekindRing.toIsNoetherian)
     convert this
     ext
     rw [Ideal.dvdNotUnit_iff_lt]

--- a/Mathlib/RingTheory/IntegrallyClosed.lean
+++ b/Mathlib/RingTheory/IntegrallyClosed.lean
@@ -44,7 +44,7 @@ section Iff
 
 variable {R : Type*} [CommRing R]
 
-variable (K : Type*) [Field K] [Algebra R K] [IsFractionRing R K]
+variable (K : Type*) [CommRing K] [Algebra R K] [IsFractionRing R K]
 
 /-- `R` is integrally closed iff all integral elements of its fraction field `K`
 are also elements of `R`. -/
@@ -81,7 +81,7 @@ namespace IsIntegrallyClosed
 
 variable {R : Type*} [CommRing R] [id : IsDomain R] [iic : IsIntegrallyClosed R]
 
-variable {K : Type*} [Field K] [Algebra R K] [ifr : IsFractionRing R K]
+variable {K : Type*} [CommRing K] [Algebra R K] [ifr : IsFractionRing R K]
 
 instance : IsIntegralClosure R R K :=
   (isIntegrallyClosed_iff_isIntegralClosure K).mp iic
@@ -95,7 +95,7 @@ theorem exists_algebraMap_eq_of_isIntegral_pow {x : K} {n : ℕ} (hn : 0 < n)
   isIntegral_iff.mp <| isIntegral_of_pow hn hx
 #align is_integrally_closed.exists_algebra_map_eq_of_is_integral_pow IsIntegrallyClosed.exists_algebraMap_eq_of_isIntegral_pow
 
-theorem exists_algebraMap_eq_of_pow_mem_subalgebra {K : Type*} [Field K] [Algebra R K]
+theorem exists_algebraMap_eq_of_pow_mem_subalgebra {K : Type*} [CommRing K] [Algebra R K]
     {S : Subalgebra R K} [IsIntegrallyClosed S] [IsFractionRing S K] {x : K} {n : ℕ} (hn : 0 < n)
     (hx : x ^ n ∈ S) : ∃ y : S, algebraMap S K y = x :=
   exists_algebraMap_eq_of_isIntegral_pow hn <| isIntegral_iff.mpr ⟨⟨x ^ n, hx⟩, rfl⟩


### PR DESCRIPTION
This PR defines `IsDedekindRing` as `IsDedekindDomain` without the bundled `IsDomain` hypothesis.

Zulip thread: https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Should.20.60IsDedekindDomain.60.20extend.20.60IsDomain.60.3F

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

 - [x] depends on: #6126

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
