### PR TITLE
[Merged by Bors] - fix: redefine semiring instance on tensor product

### DIFF
--- a/Mathlib/RingTheory/Kaehler.lean
+++ b/Mathlib/RingTheory/Kaehler.lean
@@ -69,8 +69,8 @@ theorem Derivation.tensorProductTo_tmul (D : Derivation R S M) (s t : S) :
 
 theorem Derivation.tensorProductTo_mul (D : Derivation R S M) (x y : S ⊗[R] S) :
     D.tensorProductTo (x * y) =
-      TensorProduct.lmul' R x • D.tensorProductTo y +
-        TensorProduct.lmul' R y • D.tensorProductTo x := by
+      TensorProduct.lmul' (S := S) R x • D.tensorProductTo y +
+        TensorProduct.lmul' (S := S) R y • D.tensorProductTo x := by
   refine TensorProduct.induction_on x ?_ ?_ ?_
   · rw [MulZeroClass.zero_mul, map_zero, map_zero, zero_smul, smul_zero, add_zero]
   swap
@@ -102,7 +102,7 @@ theorem KaehlerDifferential.submodule_span_range_eq_ideal :
     rintro _ ⟨s, rfl⟩
     exact KaehlerDifferential.one_smul_sub_smul_one_mem_ideal _ _
   · rintro x (hx : _ = _)
-    have : x - TensorProduct.lmul' R x ⊗ₜ[R] (1 : S) = x := by
+    have : x - TensorProduct.lmul' (S := S) R x ⊗ₜ[R] (1 : S) = x := by
       rw [hx, TensorProduct.zero_tmul, sub_zero]
     rw [← this]
     clear this hx
@@ -157,7 +157,6 @@ notation:100 "Ω[" S "⁄" R "]" => KaehlerDifferential R S
 
 instance : Nonempty (Ω[S⁄R]) := ⟨0⟩
 
-set_option synthInstance.maxHeartbeats 40000 in
 instance KaehlerDifferential.module' {R' : Type _} [CommRing R'] [Algebra R' S]
   [SMulCommClass R R' S] :
     Module R' (Ω[S⁄R]) :=
@@ -167,7 +166,6 @@ instance KaehlerDifferential.module' {R' : Type _} [CommRing R'] [Algebra R' S]
 instance : IsScalarTower S (S ⊗[R] S) (Ω[S⁄R]) :=
   Ideal.Cotangent.isScalarTower _
 
-set_option synthInstance.maxHeartbeats 40000 in
 instance KaehlerDifferential.isScalarTower_of_tower {R₁ R₂ : Type _} [CommRing R₁] [CommRing R₂]
     [Algebra R₁ S] [Algebra R₂ S] [SMul R₁ R₂]
     [SMulCommClass R R₁ S] [SMulCommClass R R₂ S] [IsScalarTower R₁ R₂ S] :
@@ -203,7 +201,6 @@ theorem KaehlerDifferential.DLinearMap_apply (s : S) :
 set_option linter.uppercaseLean3 false in
 #align kaehler_differential.D_linear_map_apply KaehlerDifferential.DLinearMap_apply
 
-set_option maxHeartbeats 300000 in -- Porting note: Added to prevent timeout
 /-- The universal derivation into `Ω[S⁄R]`. -/
 def KaehlerDifferential.D : Derivation R S (Ω[S⁄R]) :=
   { toLinearMap := KaehlerDifferential.DLinearMap R S
@@ -256,10 +253,6 @@ theorem KaehlerDifferential.span_range_derivation :
 
 variable {R S}
 
--- Porting note: this def is really slow
--- See https://github.com/leanprover-community/mathlib4/issues/5028
-set_option maxHeartbeats 800000 in
-set_option synthInstance.maxHeartbeats 30000 in
 /-- The linear map from `Ω[S⁄R]`, associated with a derivation. -/
 def Derivation.liftKaehlerDifferential (D : Derivation R S M) : Ω[S⁄R] →ₗ[S] M := by
   refine LinearMap.comp ((((KaehlerDifferential.ideal R S) •
@@ -356,7 +349,7 @@ def KaehlerDifferential.linearMapEquivDerivation : (Ω[S⁄R] →ₗ[S] M) ≃�
 def KaehlerDifferential.quotientCotangentIdealRingEquiv :
     (S ⊗ S ⧸ KaehlerDifferential.ideal R S ^ 2) ⧸ (KaehlerDifferential.ideal R S).cotangentIdeal ≃+*
       S := by
-  have : Function.RightInverse TensorProduct.includeLeft
+  have : Function.RightInverse (TensorProduct.includeLeft (R := R) (A := S) (B := S))
       (↑(TensorProduct.lmul' R : S ⊗[R] S →ₐ[R] S) : S ⊗[R] S →+* S) := by
     intro x; rw [AlgHom.coe_toRingHom, ← AlgHom.comp_apply, TensorProduct.lmul'_comp_includeLeft]
     rfl
@@ -373,12 +366,6 @@ def KaehlerDifferential.quotientCotangentIdeal :
     commutes' := (KaehlerDifferential.quotientCotangentIdealRingEquiv R S).apply_symm_apply }
 #align kaehler_differential.quotient_cotangent_ideal KaehlerDifferential.quotientCotangentIdeal
 
--- Porting note: this proof is really slow
--- See https://github.com/leanprover-community/mathlib4/issues/5028
-set_option maxHeartbeats 600000 in
--- Porting note: extra heartbeats are needed to infer the instance
--- IsScalarTower R S ((S ⊗[R] S ⧸ ideal R S ^ 2) ⧸ Ideal.cotangentIdeal (ideal R S))
-set_option synthInstance.maxHeartbeats 23000 in
 theorem KaehlerDifferential.End_equiv_aux (f : S →ₐ[R] S ⊗ S ⧸ KaehlerDifferential.ideal R S ^ 2) :
     (Ideal.Quotient.mkₐ R (KaehlerDifferential.ideal R S).cotangentIdeal).comp f =
         IsScalarTower.toAlgHom R S _ ↔
@@ -415,8 +402,6 @@ noncomputable def KaehlerDifferential.endEquivDerivation' :=
     _ _ _ _ _ ((KaehlerDifferential.ideal R S).cotangentEquivIdeal.restrictScalars S)
 #align kaehler_differential.End_equiv_derivation' KaehlerDifferential.endEquivDerivation'
 
-set_option maxHeartbeats 400000 in
-set_option synthInstance.maxHeartbeats 40000 in
 /-- (Implementation) An `Equiv` version of `KaehlerDifferential.End_equiv_aux`.
 Used in `KaehlerDifferential.endEquiv`. -/
 def KaehlerDifferential.endEquivAuxEquiv :
@@ -545,7 +530,7 @@ theorem KaehlerDifferential.total_surjective :
   rw [← LinearMap.range_eq_top, Finsupp.range_total, KaehlerDifferential.span_range_derivation]
 #align kaehler_differential.total_surjective KaehlerDifferential.total_surjective
 
-set_option maxHeartbeats 3200000 in -- 2569452
+set_option maxHeartbeats 400000 in -- 2569452
 /-- `Ω[S⁄R]` is isomorphic to `S` copies of `S` with kernel `KaehlerDifferential.kerTotal`. -/
 @[simps!]
 noncomputable def KaehlerDifferential.quotKerTotalEquiv :
@@ -651,7 +636,6 @@ theorem KaehlerDifferential.map_compDer :
   Derivation.liftKaehlerDifferential_comp _
 #align kaehler_differential.map_comp_der KaehlerDifferential.map_compDer
 
-set_option maxHeartbeats 2400000 in -- 1692832
 theorem KaehlerDifferential.map_D (x : A) :
     KaehlerDifferential.map R S A B (KaehlerDifferential.D R A x) =
       KaehlerDifferential.D S B (algebraMap A B x) :=

--- a/Mathlib/RingTheory/Kaehler.lean
+++ b/Mathlib/RingTheory/Kaehler.lean
@@ -530,7 +530,7 @@ theorem KaehlerDifferential.total_surjective :
   rw [← LinearMap.range_eq_top, Finsupp.range_total, KaehlerDifferential.span_range_derivation]
 #align kaehler_differential.total_surjective KaehlerDifferential.total_surjective
 
-set_option maxHeartbeats 400000 in -- 2569452
+set_option maxHeartbeats 400000 in
 /-- `Ω[S⁄R]` is isomorphic to `S` copies of `S` with kernel `KaehlerDifferential.kerTotal`. -/
 @[simps!]
 noncomputable def KaehlerDifferential.quotKerTotalEquiv :

--- a/Mathlib/RingTheory/PolynomialAlgebra.lean
+++ b/Mathlib/RingTheory/PolynomialAlgebra.lean
@@ -143,8 +143,9 @@ theorem invFun_add {p q} : invFun R A (p + q) = invFun R A p + invFun R A q := b
   simp only [invFun, eval₂_add]
 #align poly_equiv_tensor.inv_fun_add PolyEquivTensor.invFun_add
 
-theorem invFun_monomial (n : ℕ) (a : A) : invFun R A (monomial n a) =
-    includeLeft (R := R) (A := A) (B := R[X]) a * (1 : A) ⊗ₜ[R] (X : R[X]) ^ n :=
+theorem invFun_monomial (n : ℕ) (a : A) :
+    invFun R A (monomial n a) =
+      includeLeft (R := R) (A := A) (B := R[X]) a * (1 : A) ⊗ₜ[R] (X : R[X]) ^ n :=
   eval₂_monomial _ _
 #align poly_equiv_tensor.inv_fun_monomial PolyEquivTensor.invFun_monomial
 

--- a/Mathlib/RingTheory/PolynomialAlgebra.lean
+++ b/Mathlib/RingTheory/PolynomialAlgebra.lean
@@ -143,8 +143,8 @@ theorem invFun_add {p q} : invFun R A (p + q) = invFun R A p + invFun R A q := b
   simp only [invFun, eval₂_add]
 #align poly_equiv_tensor.inv_fun_add PolyEquivTensor.invFun_add
 
-theorem invFun_monomial (n : ℕ) (a : A) :
-    invFun R A (monomial n a) = includeLeft a * (1 : A) ⊗ₜ[R] (X : R[X]) ^ n :=
+theorem invFun_monomial (n : ℕ) (a : A) : invFun R A (monomial n a) =
+    includeLeft (R := R) (A := A) (B := R[X]) a * (1 : A) ⊗ₜ[R] (X : R[X]) ^ n :=
   eval₂_monomial _ _
 #align poly_equiv_tensor.inv_fun_monomial PolyEquivTensor.invFun_monomial
 

--- a/Mathlib/RingTheory/TensorProduct.lean
+++ b/Mathlib/RingTheory/TensorProduct.lean
@@ -438,24 +438,21 @@ instance : AddCommMonoid (A ⊗[R] B) := by infer_instance
 
 instance instMul : Mul (A ⊗[R] B) := ⟨fun a b ↦ mul a b⟩
 
-instance : NonUnitalNonAssocSemiring (A ⊗[R] B) := {
+instance : NonUnitalNonAssocSemiring (A ⊗[R] B) where
   -- porting note : `left_distrib` and `right_distrib` are proved by `simp` in mathlib3
   -- See https://github.com/leanprover-community/mathlib4/issues/5026
   -- Probably because `mul` is defined to be bi-R-linear and then coerced to function?
-  left_distrib := fun a b c => show mul a (b + c) = mul a b + mul a c by simp
-  right_distrib := fun a b c => show mul (a + b) c = mul a c + mul b c by simp
-  zero_mul := fun a => show mul 0 a = 0 by simp
-  mul_zero := fun a => show mul a 0 = 0 by simp
-}
+  left_distrib a b c := show mul a (b + c) = mul a b + mul a c by simp
+  right_distrib a b c := show mul (a + b) c = mul a c + mul b c by simp
+  zero_mul a := show mul 0 a = 0 by simp
+  mul_zero a := show mul a 0 = 0 by simp
 
-instance instNonUnitalSemiring : NonUnitalSemiring (A ⊗[R] B) := {
+instance instNonUnitalSemiring : NonUnitalSemiring (A ⊗[R] B) where
   mul_assoc := mul_assoc
-}
 
-instance instSemiring : Semiring (A ⊗[R] B) :=
-  { one_mul := one_mul
-    mul_one := mul_one
-  }
+instance instSemiring : Semiring (A ⊗[R] B) where
+  one_mul := one_mul
+  mul_one := mul_one
 
 theorem one_def : (1 : A ⊗[R] B) = (1 : A) ⊗ₜ (1 : B) :=
   rfl

--- a/Mathlib/RingTheory/TensorProduct.lean
+++ b/Mathlib/RingTheory/TensorProduct.lean
@@ -436,28 +436,27 @@ instance : AddMonoidWithOne (A ⊗[R] B) :=
 
 instance : AddCommMonoid (A ⊗[R] B) := by infer_instance
 
+instance instMul : Mul (A ⊗[R] B) := ⟨fun a b ↦ mul a b⟩
+
+instance : NonUnitalNonAssocSemiring (A ⊗[R] B) := {
+  -- porting note : `left_distrib` and `right_distrib` are proved by `simp` in mathlib3
+  -- See https://github.com/leanprover-community/mathlib4/issues/5026
+  -- Probably because `mul` is defined to be bi-R-linear and then coerced to function?
+  left_distrib := fun a b c => show mul a (b + c) = mul a b + mul a c by simp
+  right_distrib := fun a b c => show mul (a + b) c = mul a c + mul b c by simp
+  zero_mul := fun a => show mul 0 a = 0 by simp
+  mul_zero := fun a => show mul a 0 = 0 by simp
+}
+
+instance instNonUnitalSemiring : NonUnitalSemiring (A ⊗[R] B) := {
+  mul_assoc := mul_assoc
+}
+
 instance instSemiring : Semiring (A ⊗[R] B) :=
-  { (by infer_instance : AddMonoidWithOne (A ⊗[R] B)),
-    (by infer_instance : AddCommMonoid (A ⊗[R] B)) with
-    zero := 0
-    add := (· + ·)
-    one := 1
-    mul := fun a b => mul a b
-    one_mul := one_mul
+  { one_mul := one_mul
     mul_one := mul_one
-    mul_assoc := mul_assoc
-    add_assoc := add_assoc
-    zero_add := zero_add
-    add_zero := add_zero
-    add_comm := add_comm
-    nsmul_succ := AddMonoid.nsmul_succ
     natCast_succ := AddMonoidWithOne.natCast_succ
-    zero_mul := fun a => show mul 0 a = 0 by rw [map_zero, LinearMap.zero_apply]
-    mul_zero := fun a => show mul a 0 = 0 by rw [map_zero]
-    -- port note : `left_distrib` and `right_distrib` are proved by `simp` in mathlib3
-    left_distrib := fun a b c => show mul a (b + c) = mul a b + mul a c by rw [map_add]
-    right_distrib := fun a b c => show mul (a + b) c = mul a c + mul b c
-      by rw [map_add, LinearMap.add_apply] }
+  }
 
 theorem one_def : (1 : A ⊗[R] B) = (1 : A) ⊗ₜ (1 : B) :=
   rfl
@@ -729,11 +728,11 @@ algEquivOfLinearEquivTensorProduct f (fun x₁ x₂ c₁ c₂ => by
     intros
     trivial
   · intros ab₁ ab₂ h₁ h₂ a b
-    rw [mul_add, add_tmul, map_add, h₁, h₂, map_add, mul_add]
+    rw [h₁, h₂]
   · intros a b ab₁ ab₂ h₁ h₂
-    rw [add_mul, add_tmul, map_add, h₁, h₂, map_add, add_mul]
+    rw [h₁, h₂]
   · intros ab₁ ab₂ _ _ x y hx hy
-    rw [add_mul, add_tmul, map_add, hx, hy, map_add, map_add, mul_add, mul_add, add_mul, mul_add])
+    rw [add_add_add_comm, hx, hy]; ac_rfl)--, map_add, map_add, mul_add, mul_add, add_mul, mul_add])
   w₂
 #align algebra.tensor_product.alg_equiv_of_linear_equiv_triple_tensor_product Algebra.TensorProduct.algEquivOfLinearEquivTripleTensorProduct
 
@@ -938,7 +937,7 @@ theorem lmul'_toLinearMap : (lmul' R : _ →ₐ[R] S).toLinearMap = LinearMap.mu
 #align algebra.tensor_product.lmul'_to_linear_map Algebra.TensorProduct.lmul'_toLinearMap
 
 @[simp]
-theorem lmul'_apply_tmul (a b : S) : lmul' R (a ⊗ₜ[R] b) = a * b :=
+theorem lmul'_apply_tmul (a b : S) : lmul' (S := S) R (a ⊗ₜ[R] b) = a * b :=
   rfl
 #align algebra.tensor_product.lmul'_apply_tmul Algebra.TensorProduct.lmul'_apply_tmul
 
@@ -974,7 +973,8 @@ theorem productMap_left : (productMap f g).comp includeLeft = f :=
   AlgHom.ext <| by simp
 #align algebra.tensor_product.product_map_left Algebra.TensorProduct.productMap_left
 
-theorem productMap_right_apply (b : B) : productMap f g (includeRight b) = g b := by simp
+theorem productMap_right_apply (b : B) :
+    productMap f g (includeRight (R := R) (A := A) (B := B) b) = g b := by simp
 #align algebra.tensor_product.product_map_right_apply Algebra.TensorProduct.productMap_right_apply
 
 @[simp]
@@ -1095,7 +1095,7 @@ def endTensorEndAlgHom : End R M ⊗[R] End R N →ₐ[R] End R (M ⊗[R] N) := 
 #align module.End_tensor_End_alg_hom Module.endTensorEndAlgHom
 
 theorem endTensorEndAlgHom_apply (f : End R M) (g : End R N) :
-    endTensorEndAlgHom (f ⊗ₜ[R] g) = TensorProduct.map f g := by
+    endTensorEndAlgHom (R := R) (M := M) (N := N) (f ⊗ₜ[R] g) = TensorProduct.map f g := by
   simp only [endTensorEndAlgHom, Algebra.TensorProduct.algHomOfLinearMapTensorProduct_apply,
     homTensorHomMap_apply]
 #align module.End_tensor_End_alg_hom_apply Module.endTensorEndAlgHom_apply
@@ -1188,11 +1188,7 @@ protected def module : Module (A ⊗[R] B) M where
       simp only [(· • ·), MulZeroClass.mul_zero, map_zero, LinearMap.zero_apply]
     · intro a b z w hz hw
       simp only [(· • ·)] at hz hw
-      -- porting note: again I can't get `simp only` to do this
-      -- and I changed `map_add` to `LinearMap.map_add` here (and above)
       simp only [(· • ·), LinearMap.map_add, add_mul, LinearMap.add_apply, hz, hw]
-      rw [add_mul, LinearMap.map_add]
-      simp only [(· • ·), add_mul, LinearMap.add_apply, hz, hw]
     · intro u v _ _ z w hz hw
       simp only [(· • ·)] at hz hw
       -- porting note: no idea why this is such a struggle

--- a/Mathlib/RingTheory/TensorProduct.lean
+++ b/Mathlib/RingTheory/TensorProduct.lean
@@ -726,7 +726,7 @@ algEquivOfLinearEquivTensorProduct f (fun x₁ x₂ c₁ c₂ => by
   · intros a b ab₁ ab₂ h₁ h₂
     rw [h₁, h₂]
   · intros ab₁ ab₂ _ _ x y hx hy
-    rw [add_add_add_comm, hx, hy]; ac_rfl)--, map_add, map_add, mul_add, mul_add, add_mul, mul_add])
+    rw [add_add_add_comm, hx, hy, add_add_add_comm])
   w₂
 #align algebra.tensor_product.alg_equiv_of_linear_equiv_triple_tensor_product Algebra.TensorProduct.algEquivOfLinearEquivTripleTensorProduct
 

--- a/Mathlib/RingTheory/TensorProduct.lean
+++ b/Mathlib/RingTheory/TensorProduct.lean
@@ -436,18 +436,17 @@ instance : AddMonoidWithOne (A ⊗[R] B) :=
 
 instance : AddCommMonoid (A ⊗[R] B) := by infer_instance
 
+-- providing this instance separately makes some downstream code substantially faster
 instance instMul : Mul (A ⊗[R] B) where
-  mul := fun a b ↦ mul a b
+  mul a b := mul a b
 
--- note: we deliberately do not provide any fields that overlap with base class fields
+-- note: we deliberately do not provide any fields that overlap with `AddMonoidWithOne` as this
+-- appears to help performance.
 instance instSemiring : Semiring (A ⊗[R] B) where
-  -- porting note : `left_distrib` and `right_distrib` are proved by `simp` in mathlib3
-  -- See https://github.com/leanprover-community/mathlib4/issues/5026
-  -- Probably because `mul` is defined to be bi-R-linear and then coerced to function?
-  left_distrib a b c := show mul a (b + c) = mul a b + mul a c by simp
-  right_distrib a b c := show mul (a + b) c = mul a c + mul b c by simp
-  zero_mul a := show mul 0 a = 0 by simp
-  mul_zero a := show mul a 0 = 0 by simp
+  left_distrib a b c := by simp [HMul.hMul, Mul.mul]
+  right_distrib a b c := by simp [HMul.hMul, Mul.mul]
+  zero_mul a := by simp [HMul.hMul, Mul.mul]
+  mul_zero a := by simp [HMul.hMul, Mul.mul]
   mul_assoc := mul_assoc
   one_mul := one_mul
   mul_one := mul_one

--- a/Mathlib/RingTheory/TensorProduct.lean
+++ b/Mathlib/RingTheory/TensorProduct.lean
@@ -436,6 +436,9 @@ instance : AddMonoidWithOne (A ⊗[R] B) :=
 
 instance : AddCommMonoid (A ⊗[R] B) := by infer_instance
 
+instance instMul : Mul (A ⊗[R] B) where
+  mul := fun a b ↦ mul a b
+
 -- note: we deliberately do not provide any fields that overlap with base class fields
 instance instSemiring : Semiring (A ⊗[R] B) where
   -- porting note : `left_distrib` and `right_distrib` are proved by `simp` in mathlib3
@@ -448,7 +451,6 @@ instance instSemiring : Semiring (A ⊗[R] B) where
   mul_assoc := mul_assoc
   one_mul := one_mul
   mul_one := mul_one
-  mul := fun a b ↦ mul a b
 
 theorem one_def : (1 : A ⊗[R] B) = (1 : A) ⊗ₜ (1 : B) :=
   rfl

--- a/Mathlib/RingTheory/TensorProduct.lean
+++ b/Mathlib/RingTheory/TensorProduct.lean
@@ -455,7 +455,6 @@ instance instNonUnitalSemiring : NonUnitalSemiring (A ⊗[R] B) := {
 instance instSemiring : Semiring (A ⊗[R] B) :=
   { one_mul := one_mul
     mul_one := mul_one
-    natCast_succ := AddMonoidWithOne.natCast_succ
   }
 
 theorem one_def : (1 : A ⊗[R] B) = (1 : A) ⊗ₜ (1 : B) :=

--- a/Mathlib/RingTheory/TensorProduct.lean
+++ b/Mathlib/RingTheory/TensorProduct.lean
@@ -436,9 +436,8 @@ instance : AddMonoidWithOne (A ⊗[R] B) :=
 
 instance : AddCommMonoid (A ⊗[R] B) := by infer_instance
 
-instance instMul : Mul (A ⊗[R] B) := ⟨fun a b ↦ mul a b⟩
-
-instance : NonUnitalNonAssocSemiring (A ⊗[R] B) where
+-- note: we deliberately do not provide any fields that overlap with base class fields
+instance instSemiring : Semiring (A ⊗[R] B) where
   -- porting note : `left_distrib` and `right_distrib` are proved by `simp` in mathlib3
   -- See https://github.com/leanprover-community/mathlib4/issues/5026
   -- Probably because `mul` is defined to be bi-R-linear and then coerced to function?
@@ -446,13 +445,10 @@ instance : NonUnitalNonAssocSemiring (A ⊗[R] B) where
   right_distrib a b c := show mul (a + b) c = mul a c + mul b c by simp
   zero_mul a := show mul 0 a = 0 by simp
   mul_zero a := show mul a 0 = 0 by simp
-
-instance instNonUnitalSemiring : NonUnitalSemiring (A ⊗[R] B) where
   mul_assoc := mul_assoc
-
-instance instSemiring : Semiring (A ⊗[R] B) where
   one_mul := one_mul
   mul_one := mul_one
+  mul := fun a b ↦ mul a b
 
 theorem one_def : (1 : A ⊗[R] B) = (1 : A) ⊗ₜ (1 : B) :=
   rfl


### PR DESCRIPTION
By providing the `Mul` instance up front, this seems to make future typeclass search much easier.

This comes at the expense of causing minor elaboration problem in various tensor definitions, which now require the implicit type arguments to be provided explicitly.

This also simplifies some proofs, removing a porting note.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

This is a test to try and work out what's going on in #6134.

This skips out some intermediate instances to try and answer the question of whether they matter.

