### PR TITLE
[Merged by Bors] - feat(ImportGraph): add option to exclude imports from other packages

### DIFF
--- a/ImportGraph/Main.lean
+++ b/ImportGraph/Main.lean
@@ -63,9 +63,10 @@ def importGraphCLI (args : Cli.Parsed) : IO UInt32 := do
     let mut graph := env.importGraph
     if let .some f := from? then
       graph := graph.dependenciesOf (NameSet.empty.insert f)
-    if args.hasFlag "noDep" then
+    if ¬(args.hasFlag "include-deps") then
       let p := getModule to
-      graph := graph.filter (isPrefixOf p) (.filter (isPrefixOf p))
+      graph := graph.filterMap (fun n i =>
+        if p.isPrefixOf n then (i.filter (isPrefixOf p)) else none)
     if args.hasFlag "reduce" then
       graph := graph.transitiveReduction
     return asDotGraph graph
@@ -88,7 +89,7 @@ def graph : Cmd := `[Cli|
     reduce;         "Remove transitively redundant edges."
     to : Name;      "Only show the upstream imports of the specified module."
     "from" : Name;  "Only show the downstream dependencies of the specified module."
-    noDep; "Do not include any imports from other packages."
+    "include-deps"; "Include used files from other projects (e.g. lake packages)"
 
   ARGS:
     ...outputs : String;  "Filename(s) for the output. " ++

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2071,6 +2071,7 @@ import Mathlib.Init.Quot
 import Mathlib.Init.Set
 import Mathlib.Init.ZeroOne
 import Mathlib.Lean.CoreM
+import Mathlib.Lean.Data.NameMap
 import Mathlib.Lean.Elab.Tactic.Basic
 import Mathlib.Lean.EnvExtension
 import Mathlib.Lean.Exception

--- a/Mathlib/Lean/Data/NameMap.lean
+++ b/Mathlib/Lean/Data/NameMap.lean
@@ -8,17 +8,40 @@ import Lean.Data.NameMap
 /-!
 # Additional functions on `Lean.NameMap`.
 
-We provide `NameMap.filter`.
+We provide `NameMap.filter` and `NameMap.filterMap`.
 -/
 
 namespace Lean.NameMap
 
 /--
-Filter a `NameMap`. Takes a second optional argument `modify : α → α` which allows
-to modify/filter the value of each (key, value)-pair simultaneously.
+`filter f m` returns the `NameMap` consisting of all
+"`key`/`val`"-pairs in `m` where `f key val` returns `true`.
 -/
-def filter (m : NameMap α) (f : Name → Bool) (modify : α → α := id) : NameMap α :=
+def filter (f : Name → α → Bool) (m : NameMap α) : NameMap α :=
   m.fold process {}
 where
   process (r : NameMap α) (n : Name) (i : α) :=
-    if f n then r.insert n (modify i) else r
+    if f n i then r.insert n i else r
+
+/--
+`filterName f m` returns the `NameMap` consisting of all
+"`key`/`val`"-pairs in `m` where `f key` returns `true`.
+
+Shorthand for `NameMap.filter (fun n _ => f n) m`.
+-/
+def filterName (f : Name → Bool) (m : NameMap α) : NameMap α :=
+  filter (fun n _ => f n) m
+
+/--
+`filterMap f m` allows to filter a `NameMap` and simultaneously modify the filtered values.
+
+It takes a function `f : Name → α → Option β` and applies `f name` to the value with key `name`.
+The resulting entries with non-`none` value are collected to form the output `NameMap`.
+-/
+def filterMap (f : Name → α → Option β) (m : NameMap α) : NameMap β :=
+  m.fold process {}
+where
+  process (r : NameMap β) (n : Name) (i : α) :=
+    match f n i with
+    | none => r
+    | some b => r.insert n b

--- a/Mathlib/Lean/Data/NameMap.lean
+++ b/Mathlib/Lean/Data/NameMap.lean
@@ -1,0 +1,24 @@
+/-
+Copyright (c) 2023 Jon Eugster. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jon Eugster
+-/
+import Lean.Data.NameMap
+
+/-!
+# Additional functions on `Lean.NameMap`.
+
+We provide `NameMap.filter`.
+-/
+
+namespace Lean.NameMap
+
+/--
+Filter a `NameMap`. Takes a second optional argument `modify : α → α` which allows
+to modify/filter the value of each (key, value)-pair simultaneously.
+-/
+def filter (m : NameMap α) (f : Name → Bool) (modify : α → α := id) : NameMap α :=
+  m.fold process {}
+where
+  process (r : NameMap α) (n : Name) (i : α) :=
+    if f n then r.insert n (modify i) else r

--- a/Mathlib/Lean/Data/NameMap.lean
+++ b/Mathlib/Lean/Data/NameMap.lean
@@ -24,15 +24,6 @@ where
     if f n i then r.insert n i else r
 
 /--
-`filterName f m` returns the `NameMap` consisting of all
-"`key`/`val`"-pairs in `m` where `f key` returns `true`.
-
-Shorthand for `NameMap.filter (fun n _ => f n) m`.
--/
-def filterName (f : Name → Bool) (m : NameMap α) : NameMap α :=
-  filter (fun n _ => f n) m
-
-/--
 `filterMap f m` allows to filter a `NameMap` and simultaneously modify the filtered values.
 
 It takes a function `f : Name → α → Option β` and applies `f name` to the value with key `name`.

--- a/Mathlib/Lean/Name.lean
+++ b/Mathlib/Lean/Name.lean
@@ -10,7 +10,7 @@ import Mathlib.Lean.Expr.Basic
 /-!
 # Additional functions on `Lean.Name`.
 
-We provide `Name.getModule : Name → CoreM (Option Name)`,
+We provide `Name.getModule`,
 and `allNames` and `allNamesByModule`.
 -/
 
@@ -48,3 +48,10 @@ def allNamesByModule (p : Name → Bool) : CoreM (Std.HashMap Name (Array Name))
       | none => return names.insert m #[n]
     else
       return names
+
+/-- Returns the very first part of a name: for `Mathlib.Data.Set.Basic` it returns `Mathlib`. -/
+def getModule (name : Name) (s := ""): Name :=
+  match name with
+    | .anonymous => s
+    | .num _ _ => panic s!"panic in `getModule`: did not expect numerical name: {name}."
+    | .str pre s => getModule pre s

--- a/Mathlib/Lean/Name.lean
+++ b/Mathlib/Lean/Name.lean
@@ -50,7 +50,7 @@ def allNamesByModule (p : Name → Bool) : CoreM (Std.HashMap Name (Array Name))
       return names
 
 /-- Returns the very first part of a name: for `Mathlib.Data.Set.Basic` it returns `Mathlib`. -/
-def getModule (name : Name) (s := ""): Name :=
+def getModule (name : Name) (s := "") : Name :=
   match name with
     | .anonymous => s
     | .num _ _ => panic s!"panic in `getModule`: did not expect numerical name: {name}."


### PR DESCRIPTION
Add an option `lake exe graph --to MyProject.XY --noDep` which removes all nodes that do not start in `MyProject`.

---

Note that currently omitting `--to` is equivalent to specifying `--to Mathlib`, so there is no special case needed to handle this.

Happy to get a suggestion for a better name, maybe `--exclude-dependencies`?

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
