### PR TITLE
[Merged by Bors] - fix: fix a typo

### DIFF
--- a/Mathlib/Topology/LocallyFinite.lean
+++ b/Mathlib/Topology/LocallyFinite.lean
@@ -199,7 +199,7 @@ theorem preimage_continuous {g : Y → X} (hf : LocallyFinite f) (hg : Continuou
 theorem prod_right (hf : LocallyFinite f) (g : ι → Set Y) : LocallyFinite (fun i ↦ f i ×ˢ g i) :=
   (hf.preimage_continuous continuous_fst).subset fun _ ↦ prod_subset_preimage_fst _ _
 
-theorem prod_left {g : ι → Set Y} (hg : LocallyFinite g) (f : ι → Set Y) :
+theorem prod_left {g : ι → Set Y} (hg : LocallyFinite g) (f : ι → Set X) :
     LocallyFinite (fun i ↦ f i ×ˢ g i) :=
   (hg.preimage_continuous continuous_snd).subset fun _ ↦ prod_subset_preimage_snd _ _
 


### PR DESCRIPTION
A typo restricted `LocallyFinite.prod_left` to `(f g : ι → Set Y)`
instead of `(f : ι → Set X) (g : ι → Set Y)`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)