### PR TITLE
feat: LEIffExistsMul mixin

### DIFF
--- a/Mathlib/Algebra/Order/Monoid/Canonical/Defs.lean
+++ b/Mathlib/Algebra/Order/Monoid/Canonical/Defs.lean
@@ -99,6 +99,7 @@ section LEIffExistsMul
   added as an assumption for arbitrary `Mul`/`LE` typeclasses such as `CompleteLattice`,
   while avoiding diamonds. -/
 class LEIffExistsMul (α : Type _) [Mul α] [LE α] : Prop where
+  /-- `a ≤ b` if `b = a * c` for some `c` -/
   protected le_iff_exists_mul : ∀ {a b : α}, a ≤ b ↔ ∃ c, b = a * c
 
 /-- A mixin class stating that an ordering interacts canonically with addition
@@ -107,6 +108,7 @@ class LEIffExistsMul (α : Type _) [Mul α] [LE α] : Prop where
   added as an assumption for arbitrary `Add`/`LE` typeclasses such as `CompleteLattice`,
   while avoiding diamonds. -/
 class LEIffExistsAdd (α : Type _) [Add α] [LE α] : Prop where
+  /-- `a ≤ b` if `b = a + c` for some `c` -/
   protected le_iff_exists_add : ∀ {a b : α}, a ≤ b ↔ ∃ c, b = a + c
 
 attribute [to_additive] LEIffExistsMul
@@ -235,7 +237,7 @@ theorem eq_one_or_one_lt : a = 1 ∨ 1 < a :=
 #align eq_one_or_one_lt eq_one_or_one_lt
 #align eq_zero_or_pos eq_zero_or_pos
 
-@[to_additive (attr := simp)]
+@[to_additive]
 theorem mul_eq_one_iff : a * b = 1 ↔ a = 1 ∧ b = 1 :=
   mul_eq_one
 #align mul_eq_one_iff mul_eq_one_iff

--- a/Mathlib/Algebra/Order/Monoid/Canonical/Defs.lean
+++ b/Mathlib/Algebra/Order/Monoid/Canonical/Defs.lean
@@ -103,7 +103,7 @@ class LEIffExistsMul (α : Type _) [Mul α] [LE α] : Prop where
 
 /-- A mixin class stating that an ordering interacts canonically with addition
   in the sense that `a ≤ b` iff `b = a + c` for some `c`. This is essentially the
-  definition of a `CanonicallyOrderedMonoid`, but is decoupled so that it can be
+  definition of a `CanonicallyOrderedAddMonoid`, but is decoupled so that it can be
   added as an assumption for arbitrary `Add`/`LE` typeclasses such as `CompleteLattice`,
   while avoiding diamonds. -/
 class LEIffExistsAdd (α : Type _) [Add α] [LE α] : Prop where

--- a/Mathlib/Algebra/Order/Monoid/Canonical/Defs.lean
+++ b/Mathlib/Algebra/Order/Monoid/Canonical/Defs.lean
@@ -120,11 +120,11 @@ theorem le_iff_exists_mul [Mul α] [LE α] [LEIffExistsMul α] {a b : α} :
 instance [Mul α] [LE α] [LEIffExistsMul α] : ExistsMulOfLE α :=
   ⟨le_iff_exists_mul.1⟩
 
-variable [CommMonoid α] {a b c d : α}
+variable [CommMonoid α]
 
 section Preorder
 
-variable [Preorder α] [LEIffExistsMul α]
+variable [Preorder α] [LEIffExistsMul α] {a b c d : α}
 
 @[to_additive]
 theorem le_iff_exists_mul' : a ≤ b ↔ ∃ c, b = c * a := by
@@ -190,7 +190,7 @@ end Preorder
 
 section PartialOrder
 
-variable [PartialOrder α] [LEIffExistsMul α]
+variable [PartialOrder α] [LEIffExistsMul α] {a b c d : α}
 
 @[to_additive]
 instance : CovariantClass α α (· * ·) (· ≤ ·) where
@@ -273,7 +273,8 @@ theorem le_mul_right (h : a ≤ b) : a ≤ b * c :=
 #align le_add_right le_add_right
 
 @[to_additive]
-theorem lt_iff_exists_mul [CovariantClass α α (· * ·) (· < ·)] : a < b ↔ ∃ c > 1, b = a * c := by
+theorem lt_iff_exists_mul [CovariantClass α α (· * ·) (· < ·)] {a b : α} :
+    a < b ↔ ∃ c > 1, b = a * c := by
   rw [lt_iff_le_and_ne, le_iff_exists_mul, ←exists_and_right]
   apply exists_congr
   intro c

--- a/Mathlib/Algebra/Order/Monoid/TypeTags.lean
+++ b/Mathlib/Algebra/Order/Monoid/TypeTags.lean
@@ -98,12 +98,12 @@ instance Additive.existsAddOfLe [Mul α] [LE α] [ExistsMulOfLE α] : ExistsAddO
 instance Multiplicative.canonicallyOrderedMonoid [CanonicallyOrderedAddMonoid α] :
     CanonicallyOrderedMonoid (Multiplicative α) :=
   { Multiplicative.orderedCommMonoid, Multiplicative.orderBot,
-    Multiplicative.existsMulOfLe with le_self_mul := @le_self_add α _ }
+    Multiplicative.existsMulOfLe with le_self_mul := @le_self_add α _ _ _ }
 
 instance Additive.canonicallyOrderedAddMonoid [CanonicallyOrderedMonoid α] :
     CanonicallyOrderedAddMonoid (Additive α) :=
   { Additive.orderedAddCommMonoid, Additive.orderBot, Additive.existsAddOfLe with
-    le_self_add := @le_self_mul α _ }
+    le_self_add := @le_self_mul α _ _ _ }
 
 instance Multiplicative.canonicallyLinearOrderedMonoid [CanonicallyLinearOrderedAddMonoid α] :
     CanonicallyLinearOrderedMonoid (Multiplicative α) :=

--- a/Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean
@@ -75,7 +75,7 @@ theorem one_rpow (x : ℝ) : (1 : ℝ≥0) ^ x = 1 :=
 #align nnreal.one_rpow NNReal.one_rpow
 
 theorem rpow_add {x : ℝ≥0} (hx : x ≠ 0) (y z : ℝ) : x ^ (y + z) = x ^ y * x ^ z :=
-  NNReal.eq <| Real.rpow_add (pos_iff_ne_zero.2 hx) _ _
+  NNReal.eq <| Real.rpow_add ((pos_iff_ne_zero (α := ℝ≥0)).2 hx) _ _
 #align nnreal.rpow_add NNReal.rpow_add
 
 theorem rpow_add' (x : ℝ≥0) {y z : ℝ} (h : y + z ≠ 0) : x ^ (y + z) = x ^ y * x ^ z :=
@@ -94,7 +94,7 @@ theorem rpow_neg_one (x : ℝ≥0) : x ^ (-1 : ℝ) = x⁻¹ := by simp [rpow_ne
 #align nnreal.rpow_neg_one NNReal.rpow_neg_one
 
 theorem rpow_sub {x : ℝ≥0} (hx : x ≠ 0) (y z : ℝ) : x ^ (y - z) = x ^ y / x ^ z :=
-  NNReal.eq <| Real.rpow_sub (pos_iff_ne_zero.2 hx) y z
+  NNReal.eq <| Real.rpow_sub ((pos_iff_ne_zero (α := ℝ≥0)).2 hx) y z
 #align nnreal.rpow_sub NNReal.rpow_sub
 
 theorem rpow_sub' (x : ℝ≥0) {y z : ℝ} (h : y - z ≠ 0) : x ^ (y - z) = x ^ y / x ^ z :=

--- a/Mathlib/Data/Rat/Floor.lean
+++ b/Mathlib/Data/Rat/Floor.lean
@@ -55,7 +55,7 @@ protected theorem floor_def {q : ℚ} : ⌊q⌋ = q.num / q.den := Rat.floor_def
 
 theorem floor_int_div_nat_eq_div {n : ℤ} {d : ℕ} : ⌊(↑n : ℚ) / (↑d : ℚ)⌋ = n / (↑d : ℤ) := by
   rw [Rat.floor_def]
-  obtain rfl | hd := @eq_zero_or_pos _ _ d
+  obtain rfl | hd := eq_zero_or_pos (a := d)
   · simp
   set q := (n : ℚ) / d with q_eq
   obtain ⟨c, n_eq_c_mul_num, d_eq_c_mul_denom⟩ : ∃ c, n = c * q.num ∧ (d : ℤ) = c * q.den := by

--- a/Mathlib/Data/Real/NNReal.lean
+++ b/Mathlib/Data/Real/NNReal.lean
@@ -808,7 +808,7 @@ theorem div_le_iff {a b r : ℝ≥0} (hr : r ≠ 0) : a / r ≤ b ↔ a ≤ b * 
 #align nnreal.div_le_iff NNReal.div_le_iff
 
 nonrec theorem div_le_iff' {a b r : ℝ≥0} (hr : r ≠ 0) : a / r ≤ b ↔ a ≤ r * b :=
-  @div_le_iff' ℝ _ a r b <| pos_iff_ne_zero.2 hr
+  @div_le_iff' ℝ _ a r b <| (pos_iff_ne_zero (α := ℝ≥0)).2 hr
 #align nnreal.div_le_iff' NNReal.div_le_iff'
 
 theorem div_le_of_le_mul {a b c : ℝ≥0} (h : a ≤ b * c) : a / c ≤ b :=
@@ -820,11 +820,11 @@ theorem div_le_of_le_mul' {a b c : ℝ≥0} (h : a ≤ b * c) : a / b ≤ c :=
 #align nnreal.div_le_of_le_mul' NNReal.div_le_of_le_mul'
 
 nonrec theorem le_div_iff {a b r : ℝ≥0} (hr : r ≠ 0) : a ≤ b / r ↔ a * r ≤ b :=
-  @le_div_iff ℝ _ a b r <| pos_iff_ne_zero.2 hr
+  @le_div_iff ℝ _ a b r <| (pos_iff_ne_zero (α := ℝ≥0)).2 hr
 #align nnreal.le_div_iff NNReal.le_div_iff
 
 nonrec theorem le_div_iff' {a b r : ℝ≥0} (hr : r ≠ 0) : a ≤ b / r ↔ r * a ≤ b :=
-  @le_div_iff' ℝ _ a b r <| pos_iff_ne_zero.2 hr
+  @le_div_iff' ℝ _ a b r <| (pos_iff_ne_zero (α := ℝ≥0)).2 hr
 #align nnreal.le_div_iff' NNReal.le_div_iff'
 
 theorem div_lt_iff {a b r : ℝ≥0} (hr : r ≠ 0) : a / r < b ↔ a < b * r :=

--- a/Mathlib/Data/Set/Ncard.lean
+++ b/Mathlib/Data/Set/Ncard.lean
@@ -200,7 +200,7 @@ theorem ncard_diff_singleton_lt_of_mem (h : a ∈ s) (hs : s.Finite := by toFini
 theorem ncard_diff_singleton_le (s : Set α) (a : α) : (s \ {a}).ncard ≤ s.ncard := by
   obtain hs | hs := s.finite_or_infinite
   · apply ncard_le_of_subset (diff_subset _ _) hs
-  convert @zero_le ℕ _ _
+  convert @zero_le ℕ _ _ _ _
   exact (hs.diff (by simp : Set.Finite {a})).ncard
 #align set.ncard_diff_singleton_le Set.ncard_diff_singleton_le
 

--- a/Mathlib/NumberTheory/SumFourSquares.lean
+++ b/Mathlib/NumberTheory/SumFourSquares.lean
@@ -73,7 +73,7 @@ theorem lt_of_sum_four_squares_eq_mul {a b c d k m : ℕ}
     2 ^ 2 * (k * ↑m) = ∑ i : Fin 4, (2 * ![a, b, c, d] i) ^ 2 := by
       simp [← h, Fin.sum_univ_succ, mul_add, mul_pow, add_assoc]
     _ < ∑ _i : Fin 4, m ^ 2 := Finset.sum_lt_sum_of_nonempty Finset.univ_nonempty fun i _ ↦ by
-      refine pow_lt_pow_of_lt_left ?_ (zero_le _) two_pos
+      refine pow_lt_pow_of_lt_left ?_ (zero_le (α := ℕ) _) two_pos
       fin_cases i <;> assumption
     _ = 2 ^ 2 * (m * m) := by simp; ring
 

--- a/Mathlib/Probability/StrongLaw.lean
+++ b/Mathlib/Probability/StrongLaw.lean
@@ -468,7 +468,7 @@ theorem strong_law_aux1 {c : ℝ} (c_one : 1 < c) {ε : ℝ} (εpos : 0 < ε) : 
         · rintro ⟨i, j⟩ hij; rfl
       _ ≤ ∑ j in range (u (N - 1)), c ^ 5 * (c - 1)⁻¹ ^ 3 / ↑j ^ 2 * Var[Y j] := by
         apply sum_le_sum fun j hj => ?_
-        rcases @eq_zero_or_pos _ _ j with (rfl | hj)
+        rcases @eq_zero_or_pos _ _ _ _ j with (rfl | hj)
         · simp only [Nat.cast_zero, zero_pow', Ne.def, bit0_eq_zero, Nat.one_ne_zero,
             not_false_iff, div_zero, MulZeroClass.zero_mul]
           simp only [Nat.cast_zero, truncation_zero, variance_zero, mul_zero, le_rfl]


### PR DESCRIPTION
This PR provides a `LEIffExistsMul` mixin relating an ordering to a monoid structure, stating that `a ≤ b` iff `b = a * c` for some `c`. This is essentially the same assumption that defines a canonically ordered monoid, but it can be used as a mixin with arbitrary `LE` and `Mul` assumptions to define things that can't currently can't be expressed without diamonds; for example a monoid with both a canonical ordering and a complete lattice structure. 

(The additive version of this particular 'complete canonically ordered monoid' structure is the reason for the PR - it is the setting where every function has a well-defined `tsum`, giving a common generalization of `ENNReal` and `ENat`). 

The PR changes the hypotheses for a bunch `CanonicallyOrderedMonoid` lemmas to be phrased in terms of this new typeclass, and provides an instance for `CanonicallyOrderedMonoid` so that the lemmas still work in that setting. The actual definition of `CanonicallyOrderedMonoid` doesn't change. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
