### PR TITLE
[Merged by Bors] - doc: merge mathlib3 and mathlib4 `README`s

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,16 @@ Instead write permission for non-master branches should be requested on [Zulip](
 by introducing yourself, providing your GitHub handle and what contribution you are planning on doing.
 You may want to subscribe to the `mathlib4` stream
 
+* To obtain precompiled `olean` files, run `lake exe cache get`. (Skipping this step means the next step will be very slow.)
+* To build `mathlib4` run `lake build`.
+* To build and run all tests, run `make`.
+* You can use `lake build Mathlib.Import.Path` to build a particular file, e.g. `lake build Mathlib.Algebra.Group.Defs`.
+* If you added a new file, run the following command to update `Mathlib.lean`
+
+  ```shell
+  find Mathlib -name "*.lean" | env LC_ALL=C sort | sed 's/\.lean//;s,/,.,g;s/^/import /' > Mathlib.lean
+  ```
+
 ### Guidelines
 
 Mathlib has the following guidelines and conventions that must be followed

--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ Please refer to
 
 ## Maintainers:
 
+For a list containing more detailed information, see https://leanprover-community.github.io/teams/maintainers.html
+
 * Anne Baanen (@Vierkantor): algebra, number theory, tactics
 * Reid Barton (@rwbarton): category theory, topology
 * Riccardo Brasca (@riccardobrasca): algebra, number theory, algebraic geometry, category theory

--- a/README.md
+++ b/README.md
@@ -1,47 +1,77 @@
 # mathlib4
 
+![](https://github.com/leanprover-community/mathlib4/workflows/continuous%20integration/badge.svg?branch=master)
 ![GitHub CI](https://github.com/leanprover-community/mathlib4/workflows/continuous%20integration/badge.svg?branch=master)
 [![Bors enabled](https://bors.tech/images/badge_small.svg)](https://app.bors.tech/repositories/37904)
 [![project chat](https://img.shields.io/badge/zulip-join_chat-brightgreen.svg)](https://leanprover.zulipchat.com)
 
-This is the work in progress port of [mathlib](https://github.com/leanprover-community/mathlib) to [Lean 4](https://leanprover.github.io/).
+This is a complete port of [mathlib](https://github.com/leanprover-community/mathlib) to [Lean 4](https://leanprover.github.io/).
+Development of mathlib now takes place in this repository.
+
+[Mathlib](https://leanprover-community.github.io) is a user maintained library for the [Lean theorem prover](https://leanprover.github.io).
+It contains both programming infrastructure and mathematics,
+as well as tactics that use the former and allow to develop the latter.
+
+## Installation
+
+You can find detailed instructions to install Lean, mathlib, and supporting tools on [our website](https://leanprover-community.github.io/get_started.html).
+
+## Experimenting
+
+Got everything installed? Why not start with the [tutorial project](https://leanprover-community.github.io/install/project.html)?
+
+For more pointers, see [Learning Lean](https://leanprover-community.github.io/learn.html).
 
 ## Documentation
 
-The [mathlib4 docs](https://leanprover-community.github.io/mathlib4_docs/index.html) are
-[generated automatically](https://github.com/leanprover/doc-gen4) from the source `.lean` files.
+Besides the installation guides above and [Lean's general
+documentation](https://leanprover.github.io/documentation/), the documentation
+of mathlib consists of:
+
+- [The mathlib4 docs](https://leanprover-community.github.io/mathlib4_docs/index.html): documentation [generated
+  automatically](https://github.com/leanprover-community/doc-gen4) from the source `.lean` files.
+- A description of [currently covered theories](https://leanprover-community.github.io/theories.html),
+  as well as an [overview](https://leanprover-community.github.io/mathlib-overview.html) for mathematicians.
+- Some [extra Lean documentation](https://leanprover-community.github.io/learn.html) not specific to mathlib (see "Miscellaneous topics")
+- Documentation for people who would like to [contribute to mathlib](https://leanprover-community.github.io/contribute/index.html)
+
+Much of the discussion surrounding mathlib occurs in a
+[Zulip chat room](https://leanprover.zulipchat.com/). Since this
+chatroom is only visible to registered users, we provide an
+[openly accessible archive](https://leanprover-community.github.io/archive/)
+of the public discussions. This is useful for quick reference; for a
+better browsing interface, and to participate in the discussions, we strongly
+suggest joining the chat. Questions from users at all levels of expertise are
+welcomed.
+
+## Transitioning from Lean 3
+
+For users familiar with Lean 3 who want to get up to speed in Lean 4 and migrate their existing
+Lean 3 code we have:
+
+- A [survival guide](https://github.com/leanprover-community/mathlib4/wiki/Lean-4-survival-guide-for-Lean-3-users)
+  for Lean 3 users
+- [Instructions to run `mathport`](https://github.com/leanprover-community/mathport#running-on-a-project-other-than-mathlib)
+  on a project other than mathlib. `mathport` is the tool the community used to port the entirety
+  of `mathlib` from Lean 3 to Lean 4.
 
 ## Contributing
 
-A guide on how to port a file from mathlib3 to mathlib4 can be found in the [wiki](https://github.com/leanprover-community/mathlib4/wiki/Porting-wiki).
-The porting effort is coordinated through [zulip](https://leanprover.zulipchat.com/),
-if you want to contribute to the port please come to the `mathlib4` stream.
+The complete documentation for contributing to ``mathlib`` is located
+[on the community guide contribute to mathlib](https://leanprover-community.github.io/contribute/index.html)
 
-## Build instructions
+The process is different from other projects where one should not fork the repository.
+Instead write permission for non-master branches should be requested on [Zulip](https://leanprover.zulipchat.com)
+by introducing yourself, providing your GitHub handle and what contribution you are planning on doing.
+You may want to subscribe to the `mathlib4` stream
 
-* Make sure Lean is not running, and close all instances of VSCode running Lean processes.
-* Get the newest version of `elan`. If you already have installed a version of Lean, you can run
+### Guidelines
 
-  ```shell
-  elan self update
-  ```
+Mathlib has the following guidelines and conventions that must be followed
 
-  If the above command fails, or if you need to install `elan`, run
-
-  ```shell
-  curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh
-  ```
-
-  If this also fails, follow the instructions under `Regular install` [here](https://leanprover-community.github.io/get_started.html).
-* To obtain precompiled `olean` files, run `lake exe cache get`. (Skipping this step means the next step will be very slow.)
-* To build `mathlib4` run `lake build`.
-* To build and run all tests, run `make`.
-* You can use `lake build Mathlib.Import.Path` to build a particular file, e.g. `lake build Mathlib.Algebra.Group.Defs`.
-* If you added a new file, run the following command to update `Mathlib.lean`
-
-  ```shell
-  find Mathlib -name "*.lean" | env LC_ALL=C sort | sed 's/\.lean//;s,/,.,g;s/^/import /' > Mathlib.lean
-  ```
+ - The [style guide](https://leanprover-community.github.io/contribute/style.html)
+ - A guide on the [naming convention](https://leanprover-community.github.io/contribute/naming.html)
+ - The [documentation style](https://leanprover-community.github.io/contribute/doc.html)
 
 ### Downloading cached build files
 
@@ -53,7 +83,7 @@ Call `lake exe cache` to see its help menu.
 
 ### Building HTML documentation
 
-Building HTML documentation locally is straightforward:
+Building HTML documentation locally is straightforward, but it may take a while:
 
 ```shell
 lake -Kdoc=on build Mathlib:docs
@@ -71,3 +101,35 @@ You will need to make a PR after committing the changes to this file.
 
 Please refer to
 [https://github.com/leanprover-community/mathlib4/wiki/Using-mathlib4-as-a-dependency](https://github.com/leanprover-community/mathlib4/wiki/Using-mathlib4-as-a-dependency)
+
+## Maintainers:
+
+* Anne Baanen (@Vierkantor): algebra, number theory, tactics
+* Reid Barton (@rwbarton): category theory, topology
+* Riccardo Brasca (@riccardobrasca): algebra, number theory, algebraic geometry, category theory
+* Mario Carneiro (@digama0): lean formalization, tactics, type theory, proof engineering
+* Bryan Gin-ge Chen (@bryangingechen): documentation, infrastructure
+* Johan Commelin (@jcommelin): algebra, number theory, category theory, algebraic geometry
+* Rémy Degenne (@RemyDegenne): probability, measure theory, analysis
+* Floris van Doorn (@fpvandoorn): measure theory, model theory, tactics
+* Frédéric Dupuis (@dupuisf): linear algebra, functional analysis
+* Gabriel Ebner (@gebner): tactics, infrastructure, core, formal languages
+* Sébastien Gouëzel (@sgouezel): topology, calculus, geometry, analysis, measure theory
+* Markus Himmel (@TwoFX): category theory
+* Chris Hughes (@ChrisHughes24): algebra
+* Yury G. Kudryashov (@urkud): analysis, topology, measure theory
+* Robert Y. Lewis (@robertylewis): tactics, documentation
+* Heather Macbeth (@hrmacbeth): geometry, analysis
+* Patrick Massot (@patrickmassot): documentation, topology, geometry
+* Bhavik Mehta (@b-mehta): category theory, combinatorics
+* Kyle Miller (@kmill): combinatorics, documentation
+* Scott Morrison (@semorrison): category theory, tactics
+* Oliver Nash (@ocfnash): algebra, geometry, topology
+* Adam Topaz (@adamtopaz): algebra, category theory, algebraic geometry
+* Eric Wieser (@eric-wieser): algebra, infrastructure
+
+## Emeritus maintainers:
+
+* Jeremy Avigad (@avigad): analysis
+* Johannes Hölzl (@johoelzl): measure theory, topology
+* Simon Hudon (@cipher1024): tactics


### PR DESCRIPTION
This tries to merge the `README`s for mathlib3 and mathlib4 in a sensible way. Some irrelevant material about `leanproject` was removed, as well as a few mathlib3-specific items. Some of these should be replaced by mathlib4 counterparts in the future.

A section has been added about transitioning from Lean 3 to Lean 4 linking to the survival guide and running mathport on a project depending on mathlib.

---

some things that were deleted but need replacing in the future:

from the documentation section:

  In addition to the pages generated for each file in the library, the docs also include pages on:
  - [tactics](https://leanprover-community.github.io/mathlib_docs/tactics.html),
  - [commands](https://leanprover-community.github.io/mathlib_docs/commands.html),
  - [hole commands](https://leanprover-community.github.io/mathlib_docs/hole_commands.html), and
  - [attributes](https://leanprover-community.github.io/mathlib_docs/attributes.html).
- A couple of [tutorial Lean files](docs/tutorial/)

from the guidelines section:

 - The [commit naming conventions](https://github.com/leanprover-community/lean/blob/master/doc/commit_convention.md)


<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
