### PR TITLE
[Merged by Bors] - feat(Finset): add `IsDirected` instances

### DIFF
--- a/Mathlib/CategoryTheory/Limits/Constructions/Filtered.lean
+++ b/Mathlib/CategoryTheory/Limits/Constructions/Filtered.lean
@@ -48,7 +48,7 @@ def liftToFinset [HasFiniteCoproducts C] (F : Discrete α ⥤ C) : Finset (Discr
     type. -/
 @[simps!]
 def liftToFinsetColimitCocone [HasFiniteCoproducts C] [HasFilteredColimitsOfSize.{w, w} C]
-    [DecidableEq α] (F : Discrete α ⥤ C) : ColimitCocone F where
+    (F : Discrete α ⥤ C) : ColimitCocone F where
   cocone :=
     { pt := colimit (liftToFinset F)
       ι :=

--- a/Mathlib/Data/Finset/Basic.lean
+++ b/Mathlib/Data/Finset/Basic.lean
@@ -1849,8 +1849,10 @@ theorem disjoint_or_nonempty_inter (s t : Finset α) : Disjoint s t ∨ (s ∩ t
 
 end Lattice
 
-/-! ### erase -/
+instance isDirected_le : IsDirected (Finset α) (· ≤ ·) := by classical infer_instance
+instance isDirected_subset : IsDirected (Finset α) (· ⊆ ·) := isDirected_le
 
+/-! ### erase -/
 
 section Erase
 


### PR DESCRIPTION
This way `IsDirected (Finset α) (· ≤ ·)` doesn't need `[DecidableEq α]`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
