### PR TITLE
[Merged by Bors] - feat: factorization through full subcategories is definitional

### DIFF
--- a/Mathlib/CategoryTheory/FullSubcategory.lean
+++ b/Mathlib/CategoryTheory/FullSubcategory.lean
@@ -175,13 +175,16 @@ def FullSubcategory.lift (F : C ⥤ D) (hF : ∀ X, P (F.obj X)) : C ⥤ FullSub
 #align category_theory.full_subcategory.lift_obj_obj CategoryTheory.FullSubcategory.lift_obj_obj
 #align category_theory.full_subcategory.lift_map CategoryTheory.FullSubcategory.lift_map
 
+@[simp]
+theorem FullSubcategory.lift_comp_inclusion_eq (F : C ⥤ D) (hF : ∀ X, P (F.obj X)) :
+    FullSubcategory.lift P F hF ⋙ fullSubcategoryInclusion P = F :=
+  rfl
+
 /-- Composing the lift of a functor through a full subcategory with the inclusion yields the
-    original functor. Unfortunately, this is not true by definition, so we only get a natural
-    isomorphism, but it is pointwise definitionally true, see
-    `fullSubcategoryInclusion_obj_lift_obj` and `fullSubcategoryInclusion_map_lift_map`. -/
+    original functor. This is actually true definitionally. -/
 def FullSubcategory.lift_comp_inclusion (F : C ⥤ D) (hF : ∀ X, P (F.obj X)) :
     FullSubcategory.lift P F hF ⋙ fullSubcategoryInclusion P ≅ F :=
-  NatIso.ofComponents fun X => Iso.refl _
+  Iso.refl _
 #align category_theory.full_subcategory.lift_comp_inclusion CategoryTheory.FullSubcategory.lift_comp_inclusion
 
 @[simp]
@@ -190,6 +193,7 @@ theorem fullSubcategoryInclusion_obj_lift_obj (F : C ⥤ D) (hF : ∀ X, P (F.ob
   rfl
 #align category_theory.full_subcategory.inclusion_obj_lift_obj CategoryTheory.fullSubcategoryInclusion_obj_lift_obj
 
+@[simp]
 theorem fullSubcategoryInclusion_map_lift_map (F : C ⥤ D) (hF : ∀ X, P (F.obj X)) {X Y : C}
     (f : X ⟶ Y) :
     (fullSubcategoryInclusion P).map ((FullSubcategory.lift P F hF).map f) = F.map f :=


### PR DESCRIPTION
In Lean 3, the equality `FullSubcategory.lift P F hF ⋙ fullSubcategoryInclusion P = F` was evil because it was not definitional (though it was definitional on objects and maps). In Lean 4, it is definitional, so it should be fine to tell this to `dsimp`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
