### PR TITLE
[Merged by Bors] - feat: generalize tendsto_measure_cthickening from PseudoMetricSpace to PseudoEMetricSpace and add corresponding lemmas for open thickenings

### DIFF
--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Basic.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Basic.lean
@@ -1507,59 +1507,6 @@ theorem measure_eq_measure_preimage_add_measure_tsum_Ico_zpow [MeasurableSpace �
   rw [A, B, C, add_assoc]
 #align measure_eq_measure_preimage_add_measure_tsum_Ico_zpow measure_eq_measure_preimage_add_measure_tsum_Ico_zpow
 
-section PseudoEMetricSpace
-/-
-variable [PseudoEMetricSpace α] [MeasurableSpace α] [OpensMeasurableSpace α] [MeasurableSpace β]
-
-open Metric EMetric
-
-/-- If a set has a closed thickening with finite measure, then the measure of its `r`-closed
-thickenings converges to the measure of its closure as `r` tends to `0`. -/
-theorem tendsto_measure_cthickening {μ : Measure α} {s : Set α}
-    (hs : ∃ R > 0, μ (cthickening R s) ≠ ∞) :
-    Tendsto (fun r => μ (cthickening r s)) (𝓝 0) (𝓝 (μ (closure s))) := by
-  have A : Tendsto (fun r => μ (cthickening r s)) (𝓝[Ioi 0] 0) (𝓝 (μ (closure s))) := by
-    rw [closure_eq_iInter_cthickening]
-    exact
-      tendsto_measure_biInter_gt (fun r _ => isClosed_cthickening.measurableSet)
-        (fun i j _ ij => cthickening_mono ij _) hs
-  have B : Tendsto (fun r => μ (cthickening r s)) (𝓝[Iic 0] 0) (𝓝 (μ (closure s))) := by
-    apply Tendsto.congr' _ tendsto_const_nhds
-    filter_upwards [self_mem_nhdsWithin (α := ℝ)] with _ hr
-    rw [cthickening_of_nonpos hr]
-  convert B.sup A
-  exact (nhds_left_sup_nhds_right' 0).symm
-#align tendsto_measure_cthickening tendsto_measure_cthickening
-
-/-- If a closed set has a closed thickening with finite measure, then the measure of its closed
-`r`-thickenings converge to its measure as `r` tends to `0`. -/
-theorem tendsto_measure_cthickening_of_isClosed {μ : Measure α} {s : Set α}
-    (hs : ∃ R > 0, μ (cthickening R s) ≠ ∞) (h's : IsClosed s) :
-    Tendsto (fun r => μ (cthickening r s)) (𝓝 0) (𝓝 (μ s)) := by
-  convert tendsto_measure_cthickening hs
-  exact h's.closure_eq.symm
-#align tendsto_measure_cthickening_of_is_closed tendsto_measure_cthickening_of_isClosed
-
-/-- If a set has a thickening with finite measure, then the measures of its `r`-thickenings
-converge to the measure of its closure as `r > 0` tends to `0`. -/
-theorem tendsto_measure_thickening {μ : Measure α} {s : Set α}
-    (hs : ∃ R > 0, μ (thickening R s) ≠ ∞) :
-    Tendsto (fun r => μ (thickening r s)) (𝓝[>] 0) (𝓝 (μ (closure s))) := by
-  rw [closure_eq_iInter_thickening]
-  exact tendsto_measure_biInter_gt (fun r _ => isOpen_thickening.measurableSet)
-      (fun i j _ ij => thickening_mono ij _) hs
-
-@[measurability]
-theorem measurable_infEdist {s : Set α} : Measurable fun x => infEdist x s :=
-  (continuous_infEdist (s := s)).measurable
-
-@[measurability]
-theorem Measurable.infEdist {f : β → α} (hf : Measurable f) {s : Set α} :
-    Measurable fun x => infEdist (f x) s :=
-  measurable_infEdist.comp hf
- -/
-end PseudoEMetricSpace
-
 section PseudoMetricSpace
 
 variable [PseudoMetricSpace α] [MeasurableSpace α] [OpensMeasurableSpace α]

--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Basic.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Basic.lean
@@ -1649,6 +1649,14 @@ theorem tendsto_measure_thickening {μ : Measure α} {s : Set α}
   exact tendsto_measure_biInter_gt (fun r _ => isOpen_thickening.measurableSet)
       (fun i j _ ij => thickening_mono ij _) hs
 
+/-- If a closed set has a thickening with finite measure, then the measure of its
+`r`-thickenings converge to its measure as `r > 0` tends to `0`. -/
+theorem tendsto_measure_thickening_of_isClosed {μ : Measure α} {s : Set α}
+    (hs : ∃ R > 0, μ (thickening R s) ≠ ∞) (h's : IsClosed s) :
+    Tendsto (fun r => μ (thickening r s)) (𝓝[>] 0) (𝓝 (μ s)) := by
+  convert tendsto_measure_thickening hs
+  exact h's.closure_eq.symm
+
 variable [SecondCountableTopology α]
 
 @[measurability]

--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Basic.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Basic.lean
@@ -1611,8 +1611,6 @@ theorem Measurable.infEdist {f : β → α} (hf : Measurable f) {s : Set α} :
   measurable_infEdist.comp hf
 #align measurable.inf_edist Measurable.infEdist
 
---variable [PseudoEMetricSpace α] [MeasurableSpace α] [OpensMeasurableSpace α] [MeasurableSpace β]
-
 open Metric EMetric
 
 /-- If a set has a closed thickening with finite measure, then the measure of its `r`-closed

--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Basic.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Basic.lean
@@ -1619,33 +1619,6 @@ theorem Measurable.nndist {f g : β → α} (hf : Measurable f) (hg : Measurable
 
 end
 
-/-- If a set has a closed thickening with finite measure, then the measure of its `r`-closed
-thickenings converges to the measure of its closure as `r` tends to `0`. -/
-theorem tendsto_measure_cthickening'' {μ : Measure α} {s : Set α}
-    (hs : ∃ R > 0, μ (cthickening R s) ≠ ∞) :
-    Tendsto (fun r => μ (cthickening r s)) (𝓝 0) (𝓝 (μ (closure s))) := by
-  have A : Tendsto (fun r => μ (cthickening r s)) (𝓝[Ioi 0] 0) (𝓝 (μ (closure s))) := by
-    rw [closure_eq_iInter_cthickening]
-    exact
-      tendsto_measure_biInter_gt (fun r _ => isClosed_cthickening.measurableSet)
-        (fun i j _ ij => cthickening_mono ij _) hs
-  have B : Tendsto (fun r => μ (cthickening r s)) (𝓝[Iic 0] 0) (𝓝 (μ (closure s))) := by
-    apply Tendsto.congr' _ tendsto_const_nhds
-    filter_upwards [self_mem_nhdsWithin (α := ℝ)] with _ hr
-    rw [cthickening_of_nonpos hr]
-  convert B.sup A
-  exact (nhds_left_sup_nhds_right' 0).symm
---#align tendsto_measure_cthickening tendsto_measure_cthickening
-
-/-- If a closed set has a closed thickening with finite measure, then the measure of its `r`-closed
-thickenings converges to its measure as `r` tends to `0`. -/
-theorem tendsto_measure_cthickening_of_isClosed'' {μ : Measure α} {s : Set α}
-    (hs : ∃ R > 0, μ (cthickening R s) ≠ ∞) (h's : IsClosed s) :
-    Tendsto (fun r => μ (cthickening r s)) (𝓝 0) (𝓝 (μ s)) := by
-  convert tendsto_measure_cthickening hs
-  exact h's.closure_eq.symm
---#align tendsto_measure_cthickening_of_is_closed tendsto_measure_cthickening_of_isClosed
-
 end PseudoMetricSpace
 
 /-- Given a compact set in a proper space, the measure of its `r`-closed thickenings converges to

--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Basic.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Basic.lean
@@ -1507,6 +1507,50 @@ theorem measure_eq_measure_preimage_add_measure_tsum_Ico_zpow [MeasurableSpace �
   rw [A, B, C, add_assoc]
 #align measure_eq_measure_preimage_add_measure_tsum_Ico_zpow measure_eq_measure_preimage_add_measure_tsum_Ico_zpow
 
+section PseudoEMetricSpace
+
+variable [PseudoEMetricSpace α] [MeasurableSpace α] [OpensMeasurableSpace α] [MeasurableSpace β]
+
+open Metric EMetric
+
+/-- If a set has a closed thickening with finite measure, then the measure of its `r`-closed
+thickenings converges to the measure of its closure as `r` tends to `0`. -/
+theorem tendsto_measure_cthickening {μ : Measure α} {s : Set α}
+    (hs : ∃ R > 0, μ (cthickening R s) ≠ ∞) :
+    Tendsto (fun r => μ (cthickening r s)) (𝓝 0) (𝓝 (μ (closure s))) := by
+  have A : Tendsto (fun r => μ (cthickening r s)) (𝓝[Ioi 0] 0) (𝓝 (μ (closure s))) := by
+    rw [closure_eq_iInter_cthickening]
+    exact
+      tendsto_measure_biInter_gt (fun r _ => isClosed_cthickening.measurableSet)
+        (fun i j _ ij => cthickening_mono ij _) hs
+  have B : Tendsto (fun r => μ (cthickening r s)) (𝓝[Iic 0] 0) (𝓝 (μ (closure s))) := by
+    apply Tendsto.congr' _ tendsto_const_nhds
+    filter_upwards [self_mem_nhdsWithin (α := ℝ)] with _ hr
+    rw [cthickening_of_nonpos hr]
+  convert B.sup A
+  exact (nhds_left_sup_nhds_right' 0).symm
+#align tendsto_measure_cthickening tendsto_measure_cthickening
+
+/-- If a closed set has a closed thickening with finite measure, then the measure of its `r`-closed
+thickenings converges to its measure as `r` tends to `0`. -/
+theorem tendsto_measure_cthickening_of_isClosed {μ : Measure α} {s : Set α}
+    (hs : ∃ R > 0, μ (cthickening R s) ≠ ∞) (h's : IsClosed s) :
+    Tendsto (fun r => μ (cthickening r s)) (𝓝 0) (𝓝 (μ s)) := by
+  convert tendsto_measure_cthickening hs
+  exact h's.closure_eq.symm
+#align tendsto_measure_cthickening_of_is_closed tendsto_measure_cthickening_of_isClosed
+
+@[measurability]
+theorem measurable_infEdist {s : Set α} : Measurable fun x => infEdist x s :=
+  (continuous_infEdist (s := s)).measurable
+
+@[measurability]
+theorem Measurable.infEdist {f : β → α} (hf : Measurable f) {s : Set α} :
+    Measurable fun x => infEdist (f x) s :=
+  measurable_infEdist.comp hf
+
+end PseudoEMetricSpace
+
 section PseudoMetricSpace
 
 variable [PseudoMetricSpace α] [MeasurableSpace α] [OpensMeasurableSpace α]
@@ -1577,7 +1621,7 @@ end
 
 /-- If a set has a closed thickening with finite measure, then the measure of its `r`-closed
 thickenings converges to the measure of its closure as `r` tends to `0`. -/
-theorem tendsto_measure_cthickening {μ : Measure α} {s : Set α}
+theorem tendsto_measure_cthickening'' {μ : Measure α} {s : Set α}
     (hs : ∃ R > 0, μ (cthickening R s) ≠ ∞) :
     Tendsto (fun r => μ (cthickening r s)) (𝓝 0) (𝓝 (μ (closure s))) := by
   have A : Tendsto (fun r => μ (cthickening r s)) (𝓝[Ioi 0] 0) (𝓝 (μ (closure s))) := by
@@ -1591,16 +1635,16 @@ theorem tendsto_measure_cthickening {μ : Measure α} {s : Set α}
     rw [cthickening_of_nonpos hr]
   convert B.sup A
   exact (nhds_left_sup_nhds_right' 0).symm
-#align tendsto_measure_cthickening tendsto_measure_cthickening
+--#align tendsto_measure_cthickening tendsto_measure_cthickening
 
 /-- If a closed set has a closed thickening with finite measure, then the measure of its `r`-closed
 thickenings converges to its measure as `r` tends to `0`. -/
-theorem tendsto_measure_cthickening_of_isClosed {μ : Measure α} {s : Set α}
+theorem tendsto_measure_cthickening_of_isClosed'' {μ : Measure α} {s : Set α}
     (hs : ∃ R > 0, μ (cthickening R s) ≠ ∞) (h's : IsClosed s) :
     Tendsto (fun r => μ (cthickening r s)) (𝓝 0) (𝓝 (μ s)) := by
   convert tendsto_measure_cthickening hs
   exact h's.closure_eq.symm
-#align tendsto_measure_cthickening_of_is_closed tendsto_measure_cthickening_of_isClosed
+--#align tendsto_measure_cthickening_of_is_closed tendsto_measure_cthickening_of_isClosed
 
 end PseudoMetricSpace
 

--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Basic.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Basic.lean
@@ -1508,7 +1508,7 @@ theorem measure_eq_measure_preimage_add_measure_tsum_Ico_zpow [MeasurableSpace �
 #align measure_eq_measure_preimage_add_measure_tsum_Ico_zpow measure_eq_measure_preimage_add_measure_tsum_Ico_zpow
 
 section PseudoEMetricSpace
-
+/-
 variable [PseudoEMetricSpace α] [MeasurableSpace α] [OpensMeasurableSpace α] [MeasurableSpace β]
 
 open Metric EMetric
@@ -1531,14 +1531,23 @@ theorem tendsto_measure_cthickening {μ : Measure α} {s : Set α}
   exact (nhds_left_sup_nhds_right' 0).symm
 #align tendsto_measure_cthickening tendsto_measure_cthickening
 
-/-- If a closed set has a closed thickening with finite measure, then the measure of its `r`-closed
-thickenings converges to its measure as `r` tends to `0`. -/
+/-- If a closed set has a closed thickening with finite measure, then the measure of its closed
+`r`-thickenings converge to its measure as `r` tends to `0`. -/
 theorem tendsto_measure_cthickening_of_isClosed {μ : Measure α} {s : Set α}
     (hs : ∃ R > 0, μ (cthickening R s) ≠ ∞) (h's : IsClosed s) :
     Tendsto (fun r => μ (cthickening r s)) (𝓝 0) (𝓝 (μ s)) := by
   convert tendsto_measure_cthickening hs
   exact h's.closure_eq.symm
 #align tendsto_measure_cthickening_of_is_closed tendsto_measure_cthickening_of_isClosed
+
+/-- If a set has a thickening with finite measure, then the measures of its `r`-thickenings
+converge to the measure of its closure as `r > 0` tends to `0`. -/
+theorem tendsto_measure_thickening {μ : Measure α} {s : Set α}
+    (hs : ∃ R > 0, μ (thickening R s) ≠ ∞) :
+    Tendsto (fun r => μ (thickening r s)) (𝓝[>] 0) (𝓝 (μ (closure s))) := by
+  rw [closure_eq_iInter_thickening]
+  exact tendsto_measure_biInter_gt (fun r _ => isOpen_thickening.measurableSet)
+      (fun i j _ ij => thickening_mono ij _) hs
 
 @[measurability]
 theorem measurable_infEdist {s : Set α} : Measurable fun x => infEdist x s :=
@@ -1548,7 +1557,7 @@ theorem measurable_infEdist {s : Set α} : Measurable fun x => infEdist x s :=
 theorem Measurable.infEdist {f : β → α} (hf : Measurable f) {s : Set α} :
     Measurable fun x => infEdist (f x) s :=
   measurable_infEdist.comp hf
-
+ -/
 end PseudoEMetricSpace
 
 section PseudoMetricSpace
@@ -1621,16 +1630,6 @@ end
 
 end PseudoMetricSpace
 
-/-- Given a compact set in a proper space, the measure of its `r`-closed thickenings converges to
-its measure as `r` tends to `0`. -/
-theorem tendsto_measure_cthickening_of_isCompact [MetricSpace α] [MeasurableSpace α]
-    [OpensMeasurableSpace α] [ProperSpace α] {μ : Measure α} [IsFiniteMeasureOnCompacts μ]
-    {s : Set α} (hs : IsCompact s) :
-    Tendsto (fun r => μ (Metric.cthickening r s)) (𝓝 0) (𝓝 (μ s)) :=
-  tendsto_measure_cthickening_of_isClosed ⟨1, zero_lt_one, hs.bounded.cthickening.measure_lt_top.ne⟩
-    hs.isClosed
-#align tendsto_measure_cthickening_of_is_compact tendsto_measure_cthickening_of_isCompact
-
 section PseudoEMetricSpace
 
 variable [PseudoEMetricSpace α] [MeasurableSpace α] [OpensMeasurableSpace α]
@@ -1665,6 +1664,46 @@ theorem Measurable.infEdist {f : β → α} (hf : Measurable f) {s : Set α} :
   measurable_infEdist.comp hf
 #align measurable.inf_edist Measurable.infEdist
 
+--variable [PseudoEMetricSpace α] [MeasurableSpace α] [OpensMeasurableSpace α] [MeasurableSpace β]
+
+open Metric EMetric
+
+/-- If a set has a closed thickening with finite measure, then the measure of its `r`-closed
+thickenings converges to the measure of its closure as `r` tends to `0`. -/
+theorem tendsto_measure_cthickening {μ : Measure α} {s : Set α}
+    (hs : ∃ R > 0, μ (cthickening R s) ≠ ∞) :
+    Tendsto (fun r => μ (cthickening r s)) (𝓝 0) (𝓝 (μ (closure s))) := by
+  have A : Tendsto (fun r => μ (cthickening r s)) (𝓝[Ioi 0] 0) (𝓝 (μ (closure s))) := by
+    rw [closure_eq_iInter_cthickening]
+    exact
+      tendsto_measure_biInter_gt (fun r _ => isClosed_cthickening.measurableSet)
+        (fun i j _ ij => cthickening_mono ij _) hs
+  have B : Tendsto (fun r => μ (cthickening r s)) (𝓝[Iic 0] 0) (𝓝 (μ (closure s))) := by
+    apply Tendsto.congr' _ tendsto_const_nhds
+    filter_upwards [self_mem_nhdsWithin (α := ℝ)] with _ hr
+    rw [cthickening_of_nonpos hr]
+  convert B.sup A
+  exact (nhds_left_sup_nhds_right' 0).symm
+#align tendsto_measure_cthickening tendsto_measure_cthickening
+
+/-- If a closed set has a closed thickening with finite measure, then the measure of its closed
+`r`-thickenings converge to its measure as `r` tends to `0`. -/
+theorem tendsto_measure_cthickening_of_isClosed {μ : Measure α} {s : Set α}
+    (hs : ∃ R > 0, μ (cthickening R s) ≠ ∞) (h's : IsClosed s) :
+    Tendsto (fun r => μ (cthickening r s)) (𝓝 0) (𝓝 (μ s)) := by
+  convert tendsto_measure_cthickening hs
+  exact h's.closure_eq.symm
+#align tendsto_measure_cthickening_of_is_closed tendsto_measure_cthickening_of_isClosed
+
+/-- If a set has a thickening with finite measure, then the measures of its `r`-thickenings
+converge to the measure of its closure as `r > 0` tends to `0`. -/
+theorem tendsto_measure_thickening {μ : Measure α} {s : Set α}
+    (hs : ∃ R > 0, μ (thickening R s) ≠ ∞) :
+    Tendsto (fun r => μ (thickening r s)) (𝓝[>] 0) (𝓝 (μ (closure s))) := by
+  rw [closure_eq_iInter_thickening]
+  exact tendsto_measure_biInter_gt (fun r _ => isOpen_thickening.measurableSet)
+      (fun i j _ ij => thickening_mono ij _) hs
+
 variable [SecondCountableTopology α]
 
 @[measurability]
@@ -1685,6 +1724,16 @@ theorem AEMeasurable.edist {f g : β → α} {μ : Measure β} (hf : AEMeasurabl
 #align ae_measurable.edist AEMeasurable.edist
 
 end PseudoEMetricSpace
+
+/-- Given a compact set in a proper space, the measure of its `r`-closed thickenings converges to
+its measure as `r` tends to `0`. -/
+theorem tendsto_measure_cthickening_of_isCompact [MetricSpace α] [MeasurableSpace α]
+    [OpensMeasurableSpace α] [ProperSpace α] {μ : Measure α} [IsFiniteMeasureOnCompacts μ]
+    {s : Set α} (hs : IsCompact s) :
+    Tendsto (fun r => μ (Metric.cthickening r s)) (𝓝 0) (𝓝 (μ s)) :=
+  tendsto_measure_cthickening_of_isClosed ⟨1, zero_lt_one, hs.bounded.cthickening.measure_lt_top.ne⟩
+    hs.isClosed
+#align tendsto_measure_cthickening_of_is_compact tendsto_measure_cthickening_of_isCompact
 
 namespace Real
 


### PR DESCRIPTION
This PR mainly makes the generalization so that `tendsto_measure_cthickening` and `tendsto_measure_cthickening_of_isClosed` assume `[PseudoEMetricSpace]` instead of `[PseudoMetricSpace]` (the proofs require no changes, but the generality seems valuable).

Also the counterparts `tendsto_measure_thickening` and `tendsto_measure_thickening_of_isClosed` for open thickenings (instead of closed thickenings) are added.

---

The diffs show almost exactly the same deletions and additions (modulo minor docstring edits). The actual difference is that the `section PseudoEMetricSpace`, where the results are moved, has the `variable`-line giving the more general assumption compared to the `section PseudoMetricSpace`, where the results were originally.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
