### PR TITLE
[Merged by Bors] - feat: characterizations of `IsBigO` along `atTop`

### DIFF
--- a/Mathlib/Analysis/Asymptotics/Asymptotics.lean
+++ b/Mathlib/Analysis/Asymptotics/Asymptotics.lean
@@ -2197,7 +2197,7 @@ theorem IsLittleO.nat_cast_atTop {R : Type _} [StrictOrderedSemiring R] [Archime
     (fun (n:ℕ) => f n) =o[atTop] (fun n => g n) :=
   IsLittleO.comp_tendsto h tendsto_nat_cast_atTop_atTop
 
-theorem isBigO_atTop_iff_dep_const {α : Type _} [SemilatticeSup α] [Nonempty α]
+theorem isBigO_atTop_iff_eventually_exists {α : Type _} [SemilatticeSup α] [Nonempty α]
     {f : α → E} {g : α → F} : f =O[atTop] g ↔ ∀ᶠ n₀ in atTop, ∃ c, ∀ n ≥ n₀, ‖f n‖ ≤ c * ‖g n‖ := by
   refine ⟨fun h => ?mp, fun h => ?mpr⟩
   case mp =>
@@ -2215,7 +2215,7 @@ theorem isBigO_atTop_iff_dep_const {α : Type _} [SemilatticeSup α] [Nonempty �
     rw [eventually_atTop]
     exact ⟨n₀, h⟩
 
-theorem isBigO_atTop_iff_dep_const' {α : Type _}
+theorem isBigO_atTop_iff_eventually_exists_pos {α : Type _}
     [SemilatticeSup α] [Nonempty α] {f : α → G} {g : α → G'} :
     f =O[atTop] g ↔ ∀ᶠ n₀ in atTop, ∃ c > 0, ∀ n ≥ n₀, c * ‖f n‖ ≤ ‖g n‖ := by
   refine ⟨fun h => ?mp, fun h => ?mpr⟩

--- a/Mathlib/Analysis/Asymptotics/Asymptotics.lean
+++ b/Mathlib/Analysis/Asymptotics/Asymptotics.lean
@@ -2197,6 +2197,44 @@ theorem IsLittleO.nat_cast_atTop {R : Type _} [StrictOrderedSemiring R] [Archime
     (fun (n:ℕ) => f n) =o[atTop] (fun n => g n) :=
   IsLittleO.comp_tendsto h tendsto_nat_cast_atTop_atTop
 
+theorem isBigO_atTop_iff_dep_const {α : Type _} [SemilatticeSup α] [Nonempty α]
+    {f : α → E} {g : α → F} : f =O[atTop] g ↔ ∀ᶠ n₀ in atTop, ∃ c, ∀ n ≥ n₀, ‖f n‖ ≤ c * ‖g n‖ := by
+  refine ⟨fun h => ?mp, fun h => ?mpr⟩
+  case mp =>
+    rw [eventually_atTop]
+    obtain ⟨c, hc⟩ := isBigO_iff.mp h
+    rw [eventually_atTop] at hc
+    obtain ⟨n₀, hc⟩ := hc
+    exact ⟨n₀, fun n₁ hn₁ => ⟨c, fun n hn => hc n <| hn₁.trans hn⟩⟩
+  case mpr =>
+    rw [isBigO_iff]
+    rw [eventually_atTop] at h
+    obtain ⟨n₀, h⟩ := h
+    obtain ⟨c, h⟩ := h n₀ (le_refl _)
+    refine ⟨c, ?_⟩
+    rw [eventually_atTop]
+    exact ⟨n₀, h⟩
+
+theorem isBigO_atTop_iff_dep_const' {α : Type _}
+    [SemilatticeSup α] [Nonempty α] {f : α → G} {g : α → G'} :
+    f =O[atTop] g ↔ ∀ᶠ n₀ in atTop, ∃ c > 0, ∀ n ≥ n₀, c * ‖f n‖ ≤ ‖g n‖ := by
+  refine ⟨fun h => ?mp, fun h => ?mpr⟩
+  case mp =>
+    rw [isBigO_iff''] at h
+    obtain ⟨c, ⟨hc_mem, hc⟩⟩ := h
+    filter_upwards [eventually_forall_ge_atTop.mpr hc] with x hx
+    exact ⟨c, ⟨hc_mem, hx⟩⟩
+  case mpr =>
+    rw [isBigO_iff'']
+    rw [eventually_atTop] at h
+    obtain ⟨n₀, hn₀⟩ := h
+    have hn₀ := hn₀ n₀ (le_refl _)
+    obtain ⟨c, ⟨hc_pos, hc⟩⟩ := hn₀
+    refine ⟨c, ⟨hc_pos, ?_⟩⟩
+    rw [eventually_atTop]
+    exact ⟨n₀, hc⟩
+
+
 end Asymptotics
 
 open Asymptotics

--- a/Mathlib/Analysis/Asymptotics/Asymptotics.lean
+++ b/Mathlib/Analysis/Asymptotics/Asymptotics.lean
@@ -2199,41 +2199,12 @@ theorem IsLittleO.nat_cast_atTop {R : Type _} [StrictOrderedSemiring R] [Archime
 
 theorem isBigO_atTop_iff_eventually_exists {α : Type _} [SemilatticeSup α] [Nonempty α]
     {f : α → E} {g : α → F} : f =O[atTop] g ↔ ∀ᶠ n₀ in atTop, ∃ c, ∀ n ≥ n₀, ‖f n‖ ≤ c * ‖g n‖ := by
-  refine ⟨fun h => ?mp, fun h => ?mpr⟩
-  case mp =>
-    rw [eventually_atTop]
-    obtain ⟨c, hc⟩ := isBigO_iff.mp h
-    rw [eventually_atTop] at hc
-    obtain ⟨n₀, hc⟩ := hc
-    exact ⟨n₀, fun n₁ hn₁ => ⟨c, fun n hn => hc n <| hn₁.trans hn⟩⟩
-  case mpr =>
-    rw [isBigO_iff]
-    rw [eventually_atTop] at h
-    obtain ⟨n₀, h⟩ := h
-    obtain ⟨c, h⟩ := h n₀ (le_refl _)
-    refine ⟨c, ?_⟩
-    rw [eventually_atTop]
-    exact ⟨n₀, h⟩
+  rw [isBigO_iff, exists_eventually_atTop]
 
 theorem isBigO_atTop_iff_eventually_exists_pos {α : Type _}
     [SemilatticeSup α] [Nonempty α] {f : α → G} {g : α → G'} :
     f =O[atTop] g ↔ ∀ᶠ n₀ in atTop, ∃ c > 0, ∀ n ≥ n₀, c * ‖f n‖ ≤ ‖g n‖ := by
-  refine ⟨fun h => ?mp, fun h => ?mpr⟩
-  case mp =>
-    rw [isBigO_iff''] at h
-    obtain ⟨c, ⟨hc_mem, hc⟩⟩ := h
-    filter_upwards [eventually_forall_ge_atTop.mpr hc] with x hx
-    exact ⟨c, ⟨hc_mem, hx⟩⟩
-  case mpr =>
-    rw [isBigO_iff'']
-    rw [eventually_atTop] at h
-    obtain ⟨n₀, hn₀⟩ := h
-    have hn₀ := hn₀ n₀ (le_refl _)
-    obtain ⟨c, ⟨hc_pos, hc⟩⟩ := hn₀
-    refine ⟨c, ⟨hc_pos, ?_⟩⟩
-    rw [eventually_atTop]
-    exact ⟨n₀, hc⟩
-
+  simp_rw [isBigO_iff'', ← exists_prop, Subtype.exists', exists_eventually_atTop]
 
 end Asymptotics
 

--- a/Mathlib/Order/BoundedOrder.lean
+++ b/Mathlib/Order/BoundedOrder.lean
@@ -589,6 +589,22 @@ theorem Antitone.ball {P : β → α → Prop} {s : Set β} (hP : ∀ x ∈ s, A
     Antitone fun y => ∀ x ∈ s, P x y := fun _ _ hy h x hx => hP x hx hy (h x hx)
 #align antitone.ball Antitone.ball
 
+theorem Monotone.exists {P : β → α → Prop} (hP : ∀ x, Monotone (P x)) :
+    Monotone fun y => ∃ x, P x y :=
+  fun _ _ hy ⟨x, hx⟩ ↦ ⟨x, hP x hy hx⟩
+
+theorem Antitone.exists {P : β → α → Prop} (hP : ∀ x, Antitone (P x)) :
+    Antitone fun y => ∃ x, P x y :=
+  fun _ _ hy ⟨x, hx⟩ ↦ ⟨x, hP x hy hx⟩
+
+theorem forall_ge_iff {P : α → Prop} {x₀ : α} (hP : Monotone P) :
+    (∀ x ≥ x₀, P x) ↔ P x₀ :=
+  ⟨fun H ↦ H x₀ le_rfl, fun H _ hx ↦ hP hx H⟩
+
+theorem forall_le_iff {P : α → Prop} {x₀ : α} (hP : Antitone P) :
+    (∀ x ≤ x₀, P x) ↔ P x₀ :=
+  ⟨fun H ↦ H x₀ le_rfl, fun H _ hx ↦ hP hx H⟩
+
 end Preorder
 
 section SemilatticeSup

--- a/Mathlib/Order/Filter/AtTopBot.lean
+++ b/Mathlib/Order/Filter/AtTopBot.lean
@@ -327,6 +327,18 @@ theorem Eventually.exists_forall_of_atBot [SemilatticeInf α] [Nonempty α] {p :
   eventually_atBot.mp h
 #align filter.eventually.exists_forall_of_at_bot Filter.Eventually.exists_forall_of_atBot
 
+lemma exists_eventually_atTop [SemilatticeSup α] [Nonempty α] {r : α → β → Prop} :
+    (∃ b, ∀ᶠ a in atTop, r a b) ↔ ∀ᶠ a₀ in atTop, ∃ b, ∀ a ≥ a₀, r a b := by
+  simp_rw [eventually_atTop, ← exists_swap (α := α)]
+  exact exists_congr fun a ↦ .symm <| forall_ge_iff <| Monotone.exists fun _ _ _ hb H n hn ↦
+    H n (hb.trans hn)
+
+lemma exists_eventually_atBot [SemilatticeInf α] [Nonempty α] {r : α → β → Prop} :
+    (∃ b, ∀ᶠ a in atBot, r a b) ↔ ∀ᶠ a₀ in atBot, ∃ b, ∀ a ≤ a₀, r a b := by
+  simp_rw [eventually_atBot, ← exists_swap (α := α)]
+  exact exists_congr fun a ↦ .symm <| forall_le_iff <| Antitone.exists fun _ _ _ hb H n hn ↦
+    H n (hn.trans hb)
+
 theorem frequently_atTop [SemilatticeSup α] [Nonempty α] {p : α → Prop} :
     (∃ᶠ x in atTop, p x) ↔ ∀ a, ∃ b ≥ a, p b :=
   atTop_basis.frequently_iff.trans <| by simp

--- a/Mathlib/Topology/Basic.lean
+++ b/Mathlib/Topology/Basic.lean
@@ -1068,7 +1068,7 @@ instance nhds_neBot {a : α} : NeBot (𝓝 a) :=
 
 theorem tendsto_nhds_of_eventually_eq {f : β → α} {a : α} (h : ∀ᶠ x in l, f x = a) :
     Tendsto f l (𝓝 a) :=
-  Tendsto.mono_right (by rwa [tendsto_pure]) (pure_le_nhds a)
+  tendsto_const_nhds.congr' (.symm h)
 
 /-!
 ### Cluster points

--- a/Mathlib/Topology/Basic.lean
+++ b/Mathlib/Topology/Basic.lean
@@ -1066,6 +1066,10 @@ instance nhds_neBot {a : α} : NeBot (𝓝 a) :=
   neBot_of_le (pure_le_nhds a)
 #align nhds_ne_bot nhds_neBot
 
+theorem tendsto_nhds_of_eventually_eq {f : β → α} {a : α} (h : ∀ᶠ x in l, f x = a) :
+    Tendsto f l (𝓝 a) :=
+  Tendsto.mono_right (by rwa [tendsto_pure]) (pure_le_nhds a)
+
 /-!
 ### Cluster points
 


### PR DESCRIPTION
This PR adds a way to characterize `IsBigO` along the `atTop` filter, for cases where we want the constant to depend on a "starting point" `n₀`.

It also adds the lemma `tendsto_nhds_of_eventually_eq`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
