### PR TITLE
chore: bump to nightly-2023-07-25

### DIFF
--- a/Mathlib/CategoryTheory/Monoidal/Free/Coherence.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Free/Coherence.lean
@@ -299,7 +299,9 @@ def normalizeIso : tensorFunc C ≅ normalize' C :=
           obtain rfl : X₃ = Y₃ := φ.1.1
           simp only [discrete_functor_map_eq_id, tensor_id]
           rfl
-        rw [NatTrans.comp_app, NatTrans.comp_app] at h₁ h₂ ⊢
+        rw [NatTrans.comp_app, NatTrans.comp_app] at h₁
+        rw [NatTrans.comp_app, NatTrans.comp_app] at h₂
+        rw [NatTrans.comp_app, NatTrans.comp_app]
         dsimp [NatIso.ofComponents, normalizeMapAux, whiskeringRight, whiskerRight,
           Functor.comp, Discrete.natTrans] at h₁ h₂ h₃ ⊢
         rw [mk_tensor, associator_inv_naturality_assoc, ← tensor_comp_assoc, h₁,

--- a/Mathlib/Data/Int/Units.lean
+++ b/Mathlib/Data/Int/Units.lean
@@ -105,7 +105,10 @@ theorem isUnit_mul_self {a : ℤ} (ha : IsUnit a) : a * a = 1 :=
 -- Porting note: this was proven in mathlib3 with `tidy` which hasn't been ported yet
 theorem isUnit_add_isUnit_eq_isUnit_add_isUnit {a b c d : ℤ} (ha : IsUnit a) (hb : IsUnit b)
     (hc : IsUnit c) (hd : IsUnit d) : a + b = c + d ↔ a = c ∧ b = d ∨ a = d ∧ b = c := by
-  rw [isUnit_iff] at ha hb hc hd
+  rw [isUnit_iff] at ha
+  rw [isUnit_iff] at hb
+  rw [isUnit_iff] at hc
+  rw [isUnit_iff] at hd
   cases ha <;> cases hb <;> cases hc <;> cases hd <;>
       subst a <;> subst b <;> subst c <;> subst d <;>
     simp

--- a/Mathlib/Data/Option/Basic.lean
+++ b/Mathlib/Data/Option/Basic.lean
@@ -176,7 +176,8 @@ theorem pmap_some (f : ∀ a : α, p a → β) {x : α} (h : p x) :
 #align option.pmap_some Option.pmap_some
 
 theorem mem_pmem {a : α} (h : ∀ a ∈ x, p a) (ha : a ∈ x) : f a (h a ha) ∈ pmap f x h := by
-  rw [mem_def] at ha ⊢
+  rw [mem_def] at ha
+  rw [mem_def]
   subst ha
   rfl
 #align option.mem_pmem Option.mem_pmem

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -16,7 +16,7 @@
   {"git":
    {"url": "https://github.com/gebner/quote4",
     "subDir?": null,
-    "rev": "ae84bd82cca324dc958583d6f1ae08429877dcb0",
+    "rev": "81cc13c524a68d0072561dbac276cd61b65872a6",
     "name": "Qq",
     "inputRev?": "master"}},
   {"git":
@@ -26,8 +26,8 @@
     "name": "aesop",
     "inputRev?": "master"}},
   {"git":
-   {"url": "https://github.com/leanprover/std4",
+   {"url": "https://github.com/semorrison/std4",
     "subDir?": null,
-    "rev": "53508cb436494bb09ee427f95682968e7cda091a",
+    "rev": "9da736064ecf164320465ae1263fcb395ff667d0",
     "name": "std",
-    "inputRev?": "main"}}]}
+    "inputRev?": "bump-nightly-2023-07-25"}}]}

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -41,7 +41,7 @@ lean_exe checkYaml where
 meta if get_config? doc = some "on" then -- do not download and build doc-gen4 by default
 require «doc-gen4» from git "https://github.com/leanprover/doc-gen4" @ "main"
 
-require std from git "https://github.com/leanprover/std4" @ "main"
+require std from git "https://github.com/semorrison/std4" @ "bump-nightly-2023-07-25"
 require Qq from git "https://github.com/gebner/quote4" @ "master"
 require aesop from git "https://github.com/JLimperg/aesop" @ "master"
 require Cli from git "https://github.com/mhuisi/lean4-cli.git" @ "nightly"

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2023-07-15
+leanprover/lean4:nightly-2023-07-25


### PR DESCRIPTION
This is WIP, but looks to be tedious. We may want to ask for https://github.com/leanprover/lean4/pull/2317 to be reverted?

This depends on the Std4 bump PR https://github.com/leanprover/std4/pull/202

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
