### PR TITLE
[Merged by Bors] - refactor(Topology/ContinuousFunction/Algebra): lattice ordered group gives inf/sup formula

### DIFF
--- a/Mathlib/Algebra/Order/LatticeGroup.lean
+++ b/Mathlib/Algebra/Order/LatticeGroup.lean
@@ -3,7 +3,7 @@ Copyright (c) 2021 Christopher Hoskin. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Christopher Hoskin
 -/
-import Mathlib.Algebra.GroupPower.Basic
+import Mathlib.Algebra.GroupPower.Basic -- Needed for squares
 import Mathlib.Algebra.Order.Group.Abs
 import Mathlib.Algebra.Invertible
 import Mathlib.Algebra.Module.Basic
@@ -61,7 +61,6 @@ lattices.
 lattice, ordered, group
 -/
 
--- Needed for squares
 universe u v
 
 variable {α : Type u} {β : Type v} [Lattice α] [CommGroup α]

--- a/Mathlib/Algebra/Order/LatticeGroup.lean
+++ b/Mathlib/Algebra/Order/LatticeGroup.lean
@@ -61,8 +61,6 @@ lattices.
 lattice, ordered, group
 -/
 
-
--- Needed for squares
 -- Needed for squares
 universe u v
 
@@ -121,7 +119,6 @@ theorem inf_mul_sup [CovariantClass α α (· * ·) (· ≤ ·)] (a b : α) : (a
     _ = a * b := by rw [mul_comm, inv_mul_cancel_right]
 #align inf_mul_sup inf_mul_sup
 #align inf_add_sup inf_add_sup
-
 
 namespace LatticeOrderedCommGroup
 

--- a/Mathlib/Algebra/Order/LatticeGroup.lean
+++ b/Mathlib/Algebra/Order/LatticeGroup.lean
@@ -73,7 +73,7 @@ variable {α : Type u} {β : Type v}
 @[to_additive] -- see Note [lower instance priority]
 instance LinearOrderedCommGroup.to_covariant_class (α : Type u)
   [LinearOrderedCommGroup α] : CovariantClass α α (· * · ) (· ≤ ·) :=
-{ elim := fun a b c bc => OrderedCommGroup.mul_le_mul_left _ _ bc a }
+{ elim := fun a _ _ bc => OrderedCommGroup.mul_le_mul_left _ _ bc a }
 
 
 section

--- a/Mathlib/Algebra/Order/LatticeGroup.lean
+++ b/Mathlib/Algebra/Order/LatticeGroup.lean
@@ -5,6 +5,8 @@ Authors: Christopher Hoskin
 -/
 import Mathlib.Algebra.GroupPower.Basic
 import Mathlib.Algebra.Order.Group.Abs
+import Mathlib.Algebra.Invertible
+import Mathlib.Algebra.Module.Basic
 import Mathlib.Order.Closure
 
 #align_import algebra.order.lattice_group from "leanprover-community/mathlib"@"5dc275ec639221ca4d5f56938eb966f6ad9bc89f"
@@ -62,9 +64,21 @@ lattice, ordered, group
 
 -- Needed for squares
 -- Needed for squares
-universe u
+universe u v
 
-variable {α : Type u} [Lattice α] [CommGroup α]
+variable {α : Type u} {β : Type v}
+
+-- A linearly ordered additive commutative group is a lattice ordered commutative group
+
+@[to_additive] -- see Note [lower instance priority]
+instance LinearOrderedCommGroup.to_covariant_class (α : Type u)
+  [LinearOrderedCommGroup α] : CovariantClass α α (· * · ) (· ≤ ·) :=
+{ elim := fun a b c bc => OrderedCommGroup.mul_le_mul_left _ _ bc a }
+
+
+section
+
+variable [Lattice α] [CommGroup α]
 
 -- Special case of Bourbaki A.VI.9 (1)
 -- c + (a ⊔ b) = (c + a) ⊔ (c + b)
@@ -120,7 +134,11 @@ theorem inf_mul_sup [CovariantClass α α (· * ·) (· ≤ ·)] (a b : α) : (a
 #align inf_mul_sup inf_mul_sup
 #align inf_add_sup inf_add_sup
 
+end
+
 namespace LatticeOrderedCommGroup
+
+variable [Lattice α] [CommGroup α]
 
 -- see Note [lower instance priority]
 /--
@@ -571,11 +589,11 @@ theorem mabs_mul_le [CovariantClass α α (· * ·) (· ≤ ·)] (a b : α) : |a
 
 -- |a - b| = |b - a|
 @[to_additive]
-theorem abs_inv_comm (a b : α) : |a / b| = |b / a| := by
+theorem abs_div_comm (a b : α) : |a / b| = |b / a| := by
   dsimp only [Abs.abs]
   rw [inv_div a b, ← inv_inv (a / b), inv_div, sup_comm]
-#align lattice_ordered_comm_group.abs_inv_comm LatticeOrderedCommGroup.abs_inv_comm
-#align lattice_ordered_comm_group.abs_neg_comm LatticeOrderedCommGroup.abs_neg_comm
+#align lattice_ordered_comm_group.abs_inv_comm LatticeOrderedCommGroup.abs_div_comm
+#align lattice_ordered_comm_group.abs_neg_comm LatticeOrderedCommGroup.abs_sub_comm
 
 -- | |a| - |b| | ≤ |a - b|
 @[to_additive]
@@ -586,7 +604,7 @@ theorem abs_abs_div_abs_le [CovariantClass α α (· * ·) (· ≤ ·)] (a b : �
   · apply div_le_iff_le_mul.2
     convert mabs_mul_le (a / b) b
     rw [div_mul_cancel']
-  · rw [div_eq_mul_inv, mul_inv_rev, inv_inv, mul_inv_le_iff_le_mul, abs_inv_comm]
+  · rw [div_eq_mul_inv, mul_inv_rev, inv_inv, mul_inv_le_iff_le_mul, abs_div_comm]
     convert mabs_mul_le (b / a) a
     · rw [div_mul_cancel']
 #align lattice_ordered_comm_group.abs_abs_div_abs_le LatticeOrderedCommGroup.abs_abs_div_abs_le
@@ -594,9 +612,43 @@ theorem abs_abs_div_abs_le [CovariantClass α α (· * ·) (· ≤ ·)] (a b : �
 
 end LatticeOrderedCommGroup
 
+section invertible
+
+variable (α)
+variable [Semiring α] [Invertible (2 : α)] [Lattice β] [AddCommGroup β] [Module α β]
+  [CovariantClass β β (· + ·) (· ≤ ·)]
+
+lemma inf_eq_half_smul_add_sub_abs_sub (x y : β) :
+  x ⊓ y = (⅟2 : α) • (x + y - |y - x|) :=
+by rw [←LatticeOrderedCommGroup.two_inf_eq_add_sub_abs_sub x y, two_smul, ←two_smul α,
+    smul_smul, invOf_mul_self, one_smul]
+
+lemma sup_eq_half_smul_add_add_abs_sub (x y : β) :
+  x ⊔ y = (⅟2 : α) • (x + y + |y - x|) :=
+by rw [←LatticeOrderedCommGroup.two_sup_eq_add_add_abs_sub x y, two_smul, ←two_smul α,
+    smul_smul, invOf_mul_self, one_smul]
+
+end invertible
+
+section DivisionSemiring
+
+variable (α)
+variable [DivisionSemiring α] [NeZero (2 : α)] [Lattice β] [AddCommGroup β] [Module α β]
+  [CovariantClass β β (· + ·) (· ≤ ·)]
+
+lemma inf_eq_half_smul_add_sub_abs_sub' (x y : β) : x ⊓ y = (2⁻¹ : α) • (x + y - |y - x|) := by
+  letI := invertibleOfNonzero (two_ne_zero' α)
+  exact inf_eq_half_smul_add_sub_abs_sub α x y
+
+lemma sup_eq_half_smul_add_add_abs_sub' (x y : β) : x ⊔ y = (2⁻¹ : α) • (x + y + |y - x|) := by
+  letI := invertibleOfNonzero (two_ne_zero' α)
+  exact sup_eq_half_smul_add_add_abs_sub α x y
+
+end DivisionSemiring
+
 namespace LatticeOrderedAddCommGroup
 
-variable {β : Type u} [Lattice β] [AddCommGroup β]
+variable [Lattice β] [AddCommGroup β]
 
 section solid
 

--- a/Mathlib/Algebra/Order/LatticeGroup.lean
+++ b/Mathlib/Algebra/Order/LatticeGroup.lean
@@ -3,7 +3,6 @@ Copyright (c) 2021 Christopher Hoskin. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Christopher Hoskin
 -/
-import Mathlib.Algebra.GroupPower.Basic -- Needed for squares
 import Mathlib.Algebra.Order.Group.Abs
 import Mathlib.Algebra.Invertible
 import Mathlib.Algebra.Module.Basic

--- a/Mathlib/Algebra/Order/LatticeGroup.lean
+++ b/Mathlib/Algebra/Order/LatticeGroup.lean
@@ -66,19 +66,7 @@ lattice, ordered, group
 -- Needed for squares
 universe u v
 
-variable {α : Type u} {β : Type v}
-
--- A linearly ordered additive commutative group is a lattice ordered commutative group
-
-@[to_additive] -- see Note [lower instance priority]
-instance LinearOrderedCommGroup.to_covariant_class (α : Type u)
-  [LinearOrderedCommGroup α] : CovariantClass α α (· * · ) (· ≤ ·) :=
-{ elim := fun a _ _ bc => OrderedCommGroup.mul_le_mul_left _ _ bc a }
-
-
-section
-
-variable [Lattice α] [CommGroup α]
+variable {α : Type u} {β : Type v} [Lattice α] [CommGroup α]
 
 -- Special case of Bourbaki A.VI.9 (1)
 -- c + (a ⊔ b) = (c + a) ⊔ (c + b)
@@ -134,11 +122,8 @@ theorem inf_mul_sup [CovariantClass α α (· * ·) (· ≤ ·)] (a b : α) : (a
 #align inf_mul_sup inf_mul_sup
 #align inf_add_sup inf_add_sup
 
-end
 
 namespace LatticeOrderedCommGroup
-
-variable [Lattice α] [CommGroup α]
 
 -- see Note [lower instance priority]
 /--

--- a/Mathlib/Topology/ContinuousFunction/Algebra.lean
+++ b/Mathlib/Topology/ContinuousFunction/Algebra.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison, Nicolò Cavalleri
 -/
 import Mathlib.Algebra.Algebra.Pi
+import Mathlib.Algebra.Order.LatticeGroup
 import Mathlib.Algebra.Periodic
 import Mathlib.Algebra.Algebra.Subalgebra.Basic
 import Mathlib.Algebra.Star.StarAlgHom
@@ -900,45 +901,27 @@ We now provide formulas for `f ⊓ g` and `f ⊔ g`, where `f g : C(α, β)`,
 in terms of `ContinuousMap.abs`.
 -/
 
-
-section
-
-variable {R : Type _} [LinearOrderedField R]
-
--- TODO:
--- This lemma (and the next) could go all the way back in `Algebra.Order.Field`,
--- except that it is tedious to prove without tactics.
--- Rather than stranding it at some intermediate location,
--- it's here, immediately prior to the point of use.
-theorem min_eq_half_add_sub_abs_sub {x y : R} : min x y = 2⁻¹ * (x + y - |x - y|) := by
-  cases' le_total x y with h h <;> field_simp [h, abs_of_nonneg, abs_of_nonpos, mul_two]
-  abel
-#align min_eq_half_add_sub_abs_sub min_eq_half_add_sub_abs_sub
-
-theorem max_eq_half_add_add_abs_sub {x y : R} : max x y = 2⁻¹ * (x + y + |x - y|) := by
-  cases' le_total x y with h h <;> field_simp [h, abs_of_nonneg, abs_of_nonpos, mul_two]
-  abel
-#align max_eq_half_add_add_abs_sub max_eq_half_add_add_abs_sub
-
-end
-
 namespace ContinuousMap
 
 section Lattice
 
 variable {α : Type _} [TopologicalSpace α]
 
-variable {β : Type _} [LinearOrderedField β] [TopologicalSpace β] [OrderTopology β]
-  [TopologicalRing β]
+variable {β : Type _} [TopologicalSpace β]
 
-theorem inf_eq (f g : C(α, β)) : f ⊓ g = (2⁻¹ : β) • (f + g - |f - g|) :=
-  ext fun x => by simpa using min_eq_half_add_sub_abs_sub
-#align continuous_map.inf_eq ContinuousMap.inf_eq
+/-! C(α, β) is a lattice ordered group -/
 
--- Not sure why this is grosser than `inf_eq`:
-theorem sup_eq (f g : C(α, β)) : f ⊔ g = (2⁻¹ : β) • (f + g + |f - g|) :=
-  ext fun x => by simpa [mul_add] using @max_eq_half_add_add_abs_sub _ _ (f x) (g x)
-#align continuous_map.sup_eq ContinuousMap.sup_eq
+@[to_additive]
+instance covariant_class_mul_le_left [PartialOrder β] [Mul β] [ContinuousMul β]
+  [CovariantClass β β (· * ·) (· ≤ ·)] :
+  CovariantClass C(α, β) C(α, β) (· * ·) (· ≤ ·) :=
+⟨fun _ _ _ hg₁₂ x => mul_le_mul_left' (hg₁₂ x) _⟩
+
+@[to_additive]
+instance covariant_class_mul_le_right [PartialOrder β] [Mul β] [ContinuousMul β]
+  [CovariantClass β β (Function.swap (· * ·)) (· ≤ ·)] :
+  CovariantClass C(α, β) C(α, β) (Function.swap (· * ·)) (· ≤ ·) :=
+⟨fun _ _ _ hg₁₂ x => mul_le_mul_right' (hg₁₂ x) _⟩
 
 end Lattice
 

--- a/Mathlib/Topology/ContinuousFunction/Algebra.lean
+++ b/Mathlib/Topology/ContinuousFunction/Algebra.lean
@@ -909,7 +909,7 @@ variable {α : Type _} [TopologicalSpace α]
 
 variable {β : Type _} [TopologicalSpace β]
 
-/-! C(α, β) is a lattice ordered group -/
+/-! `C(α, β)`is a lattice ordered group -/
 
 @[to_additive]
 instance covariant_class_mul_le_left [PartialOrder β] [Mul β] [ContinuousMul β]

--- a/Mathlib/Topology/ContinuousFunction/StoneWeierstrass.lean
+++ b/Mathlib/Topology/ContinuousFunction/StoneWeierstrass.lean
@@ -118,7 +118,7 @@ theorem abs_mem_subalgebra_closure (A : Subalgebra ℝ C(X, ℝ)) (f : A) :
 
 theorem inf_mem_subalgebra_closure (A : Subalgebra ℝ C(X, ℝ)) (f g : A) :
     (f : C(X, ℝ)) ⊓ (g : C(X, ℝ)) ∈ A.topologicalClosure := by
-  rw [(inf_eq_half_smul_add_sub_abs_sub' ℝ)]
+  rw [inf_eq_half_smul_add_sub_abs_sub' ℝ]
   refine'
     A.topologicalClosure.smul_mem
       (A.topologicalClosure.sub_mem

--- a/Mathlib/Topology/ContinuousFunction/StoneWeierstrass.lean
+++ b/Mathlib/Topology/ContinuousFunction/StoneWeierstrass.lean
@@ -118,7 +118,7 @@ theorem abs_mem_subalgebra_closure (A : Subalgebra ℝ C(X, ℝ)) (f : A) :
 
 theorem inf_mem_subalgebra_closure (A : Subalgebra ℝ C(X, ℝ)) (f g : A) :
     (f : C(X, ℝ)) ⊓ (g : C(X, ℝ)) ∈ A.topologicalClosure := by
-  rw [inf_eq]
+  rw [(inf_eq_half_smul_add_sub_abs_sub' ℝ)]
   refine'
     A.topologicalClosure.smul_mem
       (A.topologicalClosure.sub_mem
@@ -140,7 +140,7 @@ theorem inf_mem_closed_subalgebra (A : Subalgebra ℝ C(X, ℝ)) (h : IsClosed (
 
 theorem sup_mem_subalgebra_closure (A : Subalgebra ℝ C(X, ℝ)) (f g : A) :
     (f : C(X, ℝ)) ⊔ (g : C(X, ℝ)) ∈ A.topologicalClosure := by
-  rw [sup_eq]
+  rw [(sup_eq_half_smul_add_add_abs_sub' ℝ)]
   refine'
     A.topologicalClosure.smul_mem
       (A.topologicalClosure.add_mem

--- a/Mathlib/Topology/ContinuousFunction/StoneWeierstrass.lean
+++ b/Mathlib/Topology/ContinuousFunction/StoneWeierstrass.lean
@@ -140,7 +140,7 @@ theorem inf_mem_closed_subalgebra (A : Subalgebra ℝ C(X, ℝ)) (h : IsClosed (
 
 theorem sup_mem_subalgebra_closure (A : Subalgebra ℝ C(X, ℝ)) (f g : A) :
     (f : C(X, ℝ)) ⊔ (g : C(X, ℝ)) ∈ A.topologicalClosure := by
-  rw [(sup_eq_half_smul_add_add_abs_sub' ℝ)]
+  rw [sup_eq_half_smul_add_add_abs_sub' ℝ]
   refine'
     A.topologicalClosure.smul_mem
       (A.topologicalClosure.add_mem


### PR DESCRIPTION
Previously the following comment occured in `Topology.ContinuousFunction.Algebra`:

> -- TODO:
-- This lemma (and the next) could go all the way back in `Algebra.Order.Field`,
-- except that it is tedious to prove without tactics.
-- Rather than stranding it at some intermediate location,
-- it's here, immediately prior to the point of use.

Subsequently, the theory of lattice ordered groups has been developed in Mathlib (Algebra.Order.LatticeGroup). This now provides the natural "intermediate location" for these lemmas, they are an immediate consequence of `LatticeOrderedCommGroup.two_inf_eq_add_sub_abs_sub` and `LatticeOrderedCommGroup.two_sup_eq_add_add_abs_sub`. In fact we can show that `C(α, β)` is itself a lattice ordered group and hence expressions for the `inf` and `sup` (`inf_eq` and `sup_eq`) can be deduced directly from `LatticeOrderedCommGroup.two_inf_eq_add_sub_abs_sub` and `LatticeOrderedCommGroup.two_sup_eq_add_add_abs_sub`.

This was previously submitted to Mathlib https://github.com/leanprover-community/mathlib/pull/18780

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
