### PR TITLE
[Merged by Bors] - refactor(Algebra/Module/LinearMap): generalize the endomorphism algebra instance

### DIFF
--- a/Mathlib/Algebra/Algebra/Basic.lean
+++ b/Mathlib/Algebra/Algebra/Basic.lean
@@ -615,19 +615,23 @@ end MulOpposite
 
 namespace Module
 
-variable (R : Type u) (M : Type v) [CommSemiring R] [AddCommMonoid M] [Module R M]
+variable (R : Type u) (S : Type v) (M : Type w)
+variable [CommSemiring R] [Semiring S] [AddCommMonoid M] [Module R M] [Module S M]
+variable [SMulCommClass S R M] [SMul R S] [IsScalarTower R S M]
 
-instance : Algebra R (Module.End R M) :=
+instance End.instAlgebra : Algebra R (Module.End S M) :=
   Algebra.ofModule smul_mul_assoc fun r f g => (smul_comm r f g).symm
 
-theorem algebraMap_end_eq_smul_id (a : R) : (algebraMap R (End R M)) a = a • LinearMap.id :=
+-- to prove this is a special case of the above
+example : Algebra R (Module.End R M) := End.instAlgebra _ _ _
+
+theorem algebraMap_end_eq_smul_id (a : R) : algebraMap R (End S M) a = a • LinearMap.id :=
   rfl
-#align module.algebra_map_End_eq_smul_id Module.algebraMap_end_eq_smul_id
 
 @[simp]
-theorem algebraMap_end_apply (a : R) (m : M) : (algebraMap R (End R M)) a m = a • m :=
+theorem algebraMap_end_apply (a : R) (m : M) : algebraMap R (End S M) a m = a • m :=
   rfl
-#align module.algebra_map_End_apply Module.algebraMap_end_apply
+#align module.algebra_map_End_apply Module.algebraMap_end_applyₓ
 
 @[simp]
 theorem ker_algebraMap_end (K : Type u) (V : Type v) [Field K] [AddCommGroup V] [Module K V] (a : K)
@@ -639,29 +643,9 @@ section
 
 variable {R M}
 
-theorem End_isUnit_apply_inv_apply_of_isUnit {f : Module.End R M} (h : IsUnit f) (x : M) :
-    f (h.unit.inv x) = x :=
-  show (f * h.unit.inv) x = x by simp
-#align module.End_is_unit_apply_inv_apply_of_is_unit Module.End_isUnit_apply_inv_apply_of_isUnit
-
-theorem End_isUnit_inv_apply_apply_of_isUnit {f : Module.End R M} (h : IsUnit f) (x : M) :
-    h.unit.inv (f x) = x :=
-  (by simp : (h.unit.inv * f) x = x)
-#align module.End_is_unit_inv_apply_apply_of_is_unit Module.End_isUnit_inv_apply_apply_of_isUnit
-
-theorem End_isUnit_iff (f : Module.End R M) : IsUnit f ↔ Function.Bijective f :=
-  ⟨fun h =>
-    Function.bijective_iff_has_inverse.mpr <|
-      ⟨h.unit.inv,
-        ⟨End_isUnit_inv_apply_apply_of_isUnit h, End_isUnit_apply_inv_apply_of_isUnit h⟩⟩,
-    fun H =>
-    let e : M ≃ₗ[R] M := { f, Equiv.ofBijective f H with }
-    ⟨⟨_, e.symm, LinearMap.ext e.right_inv, LinearMap.ext e.left_inv⟩, rfl⟩⟩
-#align module.End_is_unit_iff Module.End_isUnit_iff
-
 theorem End_algebraMap_isUnit_inv_apply_eq_iff {x : R}
-    (h : IsUnit (algebraMap R (Module.End R M) x)) (m m' : M) :
-    (↑(h.unit⁻¹) : Module.End R M) m = m' ↔ m = x • m' :=
+    (h : IsUnit (algebraMap R (Module.End S M) x)) (m m' : M) :
+    (↑(h.unit⁻¹) : Module.End S M) m = m' ↔ m = x • m' :=
   { mp := fun H => ((congr_arg h.unit H).symm.trans (End_isUnit_apply_inv_apply_of_isUnit h _)).symm
     mpr := fun H =>
       H.symm ▸ by
@@ -671,8 +655,8 @@ theorem End_algebraMap_isUnit_inv_apply_eq_iff {x : R}
 #align module.End_algebra_map_is_unit_inv_apply_eq_iff Module.End_algebraMap_isUnit_inv_apply_eq_iff
 
 theorem End_algebraMap_isUnit_inv_apply_eq_iff' {x : R}
-    (h : IsUnit (algebraMap R (Module.End R M) x)) (m m' : M) :
-    m' = (↑h.unit⁻¹ : Module.End R M) m ↔ m = x • m' :=
+    (h : IsUnit (algebraMap R (Module.End S M) x)) (m m' : M) :
+    m' = (↑h.unit⁻¹ : Module.End S M) m ↔ m = x • m' :=
   { mp := fun H => ((congr_arg h.unit H).trans (End_isUnit_apply_inv_apply_of_isUnit h _)).symm
     mpr := fun H =>
       H.symm ▸ by

--- a/Mathlib/Algebra/Module/Equiv.lean
+++ b/Mathlib/Algebra/Module/Equiv.lean
@@ -635,6 +635,18 @@ theorem restrictScalars_inj (f g : M ≃ₗ[S] M₂) :
 
 end RestrictScalars
 
+theorem _root_.Module.End_isUnit_iff [Module R M] (f : Module.End R M) :
+    IsUnit f ↔ Function.Bijective f :=
+  ⟨fun h =>
+    Function.bijective_iff_has_inverse.mpr <|
+      ⟨h.unit.inv,
+        ⟨Module.End_isUnit_inv_apply_apply_of_isUnit h,
+        Module.End_isUnit_apply_inv_apply_of_isUnit h⟩⟩,
+    fun H =>
+    let e : M ≃ₗ[R] M := { f, Equiv.ofBijective f H with }
+    ⟨⟨_, e.symm, LinearMap.ext e.right_inv, LinearMap.ext e.left_inv⟩, rfl⟩⟩
+#align module.End_is_unit_iff Module.End_isUnit_iff
+
 section Automorphisms
 
 variable [Module R M]

--- a/Mathlib/Algebra/Module/LinearMap.lean
+++ b/Mathlib/Algebra/Module/LinearMap.lean
@@ -1102,7 +1102,6 @@ instance _root_.Module.End.smulCommClass' [SMul S R] [IsScalarTower S R M] :
   SMulCommClass.symm _ _ _
 #align module.End.smul_comm_class' Module.End.smulCommClass'
 
-
 theorem _root_.Module.End_isUnit_apply_inv_apply_of_isUnit
     {f : Module.End R M} (h : IsUnit f) (x : M) :
     f (h.unit.inv x) = x :=

--- a/Mathlib/Algebra/Module/LinearMap.lean
+++ b/Mathlib/Algebra/Module/LinearMap.lean
@@ -1102,6 +1102,19 @@ instance _root_.Module.End.smulCommClass' [SMul S R] [IsScalarTower S R M] :
   SMulCommClass.symm _ _ _
 #align module.End.smul_comm_class' Module.End.smulCommClass'
 
+
+theorem _root_.Module.End_isUnit_apply_inv_apply_of_isUnit
+    {f : Module.End R M} (h : IsUnit f) (x : M) :
+    f (h.unit.inv x) = x :=
+  show (f * h.unit.inv) x = x by simp
+#align module.End_is_unit_apply_inv_apply_of_is_unit Module.End_isUnit_apply_inv_apply_of_isUnit
+
+theorem _root_.Module.End_isUnit_inv_apply_apply_of_isUnit
+    {f : Module.End R M} (h : IsUnit f) (x : M) :
+    h.unit.inv (f x) = x :=
+  (by simp : (h.unit.inv * f) x = x)
+#align module.End_is_unit_inv_apply_apply_of_is_unit Module.End_isUnit_inv_apply_apply_of_isUnit
+
 end
 
 /-! ### Action by a module endomorphism. -/

--- a/Mathlib/Algebra/Module/LocalizedModule.lean
+++ b/Mathlib/Algebra/Module/LocalizedModule.lean
@@ -1000,7 +1000,7 @@ theorem mk'_mul_mk'_of_map_mul {M M' : Type _} [Semiring M] [Semiring M'] [Modul
     [IsLocalizedModule S f] (m₁ m₂ : M) (s₁ s₂ : S) :
     mk' f m₁ s₁ * mk' f m₂ s₂ = mk' f (m₁ * m₂) (s₁ * s₂) := by
   symm
-  apply (Module.End_algebraMap_isUnit_inv_apply_eq_iff _ _ _).mpr
+  apply (Module.End_algebraMap_isUnit_inv_apply_eq_iff _ _ _ _).mpr
   simp_rw [Submonoid.coe_mul, ← smul_eq_mul]
   rw [smul_smul_smul_comm, ← mk'_smul, ← mk'_smul]
   simp_rw [← Submonoid.smul_def, mk'_cancel, smul_eq_mul, hf]

--- a/docs/undergrad.yaml
+++ b/docs/undergrad.yaml
@@ -18,7 +18,7 @@ Linear algebra:
     linear map: 'LinearMap'
     range of a linear map: 'LinearMap.range'
     kernel of a linear map: 'LinearMap.ker'
-    algebra of endomorphisms of a vector space: 'Module.instAlgebraEndToSemiringSemiring'
+    algebra of endomorphisms of a vector space: 'Module.End.instAlgebra'
     general linear group: 'LinearMap.GeneralLinearGroup'
   Duality:
     dual vector space: 'Module.Dual'


### PR DESCRIPTION
Note that the module instance was already generalized; we were just missing the fact that when combined with the existing ring instance, the result was an algebra.

This also moves some lemmas about `IsUnit (_ : Module.End R M)` to an earlier file as they are nothing to do with `Algebra`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
