### PR TITLE
[Merged by Bors] - feat: simple lemmas about polynomials and their degrees

### DIFF
--- a/Mathlib/Data/Polynomial/Basic.lean
+++ b/Mathlib/Data/Polynomial/Basic.lean
@@ -729,6 +729,7 @@ theorem coeff_C_zero : coeff (C a) 0 = a :=
 theorem coeff_C_ne_zero (h : n ≠ 0) : (C a).coeff n = 0 := by rw [coeff_C, if_neg h]
 #align polynomial.coeff_C_ne_zero Polynomial.coeff_C_ne_zero
 
+@[simp]
 theorem coeff_nat_cast_ite : (Nat.cast m : R[X]).coeff n = ite (n = 0) m 0 := by
   simp only [← C_eq_nat_cast, coeff_C, Nat.cast_ite, Nat.cast_zero]
 

--- a/Mathlib/Data/Polynomial/Basic.lean
+++ b/Mathlib/Data/Polynomial/Basic.lean
@@ -729,7 +729,7 @@ theorem coeff_C_zero : coeff (C a) 0 = a :=
 theorem coeff_C_ne_zero (h : n ≠ 0) : (C a).coeff n = 0 := by rw [coeff_C, if_neg h]
 #align polynomial.coeff_C_ne_zero Polynomial.coeff_C_ne_zero
 
-theorem coeff_nat_cast_ite {n a : ℕ} : (Nat.cast a : R[X]).coeff n = ite (n = 0) a 0 := by
+theorem coeff_nat_cast_ite : (Nat.cast m : R[X]).coeff n = ite (n = 0) m 0 := by
   simp only [← C_eq_nat_cast, coeff_C, Nat.cast_ite, Nat.cast_zero]
 
 theorem C_mul_X_pow_eq_monomial : ∀ {n : ℕ}, C a * X ^ n = monomial n a

--- a/Mathlib/Data/Polynomial/Basic.lean
+++ b/Mathlib/Data/Polynomial/Basic.lean
@@ -729,6 +729,9 @@ theorem coeff_C_zero : coeff (C a) 0 = a :=
 theorem coeff_C_ne_zero (h : n ≠ 0) : (C a).coeff n = 0 := by rw [coeff_C, if_neg h]
 #align polynomial.coeff_C_ne_zero Polynomial.coeff_C_ne_zero
 
+theorem coeff_nat_cast_ite {n a : ℕ} : (Nat.cast a : R[X]).coeff n = ite (n = 0) a 0 := by
+  simp only [← C_eq_nat_cast, coeff_C, Nat.cast_ite, Nat.cast_zero]
+
 theorem C_mul_X_pow_eq_monomial : ∀ {n : ℕ}, C a * X ^ n = monomial n a
   | 0 => mul_one _
   | n + 1 => by

--- a/Mathlib/Data/Polynomial/Coeff.lean
+++ b/Mathlib/Data/Polynomial/Coeff.lean
@@ -370,11 +370,8 @@ end Coeff
 
 section cast
 
-@[simp]
 theorem nat_cast_coeff_zero {n : ℕ} {R : Type _} [Semiring R] : (n : R[X]).coeff 0 = n := by
-  induction' n with n ih
-  · simp
-  · simp [ih]
+  simp? says simp only [coeff_nat_cast_ite, ite_true]
 #align polynomial.nat_cast_coeff_zero Polynomial.nat_cast_coeff_zero
 
 @[norm_cast] -- @[simp] -- Porting note: simp can prove this

--- a/Mathlib/Data/Polynomial/Coeff.lean
+++ b/Mathlib/Data/Polynomial/Coeff.lean
@@ -371,7 +371,7 @@ end Coeff
 section cast
 
 theorem nat_cast_coeff_zero {n : ℕ} {R : Type _} [Semiring R] : (n : R[X]).coeff 0 = n := by
-  simp? says simp only [coeff_nat_cast_ite, ite_true]
+  simp only [coeff_nat_cast_ite, ite_true]
 #align polynomial.nat_cast_coeff_zero Polynomial.nat_cast_coeff_zero
 
 @[norm_cast] -- @[simp] -- Porting note: simp can prove this

--- a/Mathlib/Data/Polynomial/Degree/Definitions.lean
+++ b/Mathlib/Data/Polynomial/Degree/Definitions.lean
@@ -1077,7 +1077,7 @@ theorem coeff_pow_mul_natDegree (p : R[X]) (n : ℕ) :
       exact coeff_mul_degree_add_degree _ _
 #align polynomial.coeff_pow_mul_nat_degree Polynomial.coeff_pow_mul_natDegree
 
-theorem coeff_mul_add_of_le_natDegree_of_eq {df dg : ℕ} {g : R[X]}
+theorem coeff_mul_add_eq_of_natDegree_le {df dg : ℕ} {g : R[X]}
     (hdf : natDegree f ≤ df) (hdg : natDegree g ≤ dg) :
     (f * g).coeff (df + dg) = f.coeff df * g.coeff dg := by
   rw [coeff_mul, Finset.sum_eq_single_of_mem (df, dg)]

--- a/Mathlib/Data/Polynomial/Degree/Definitions.lean
+++ b/Mathlib/Data/Polynomial/Degree/Definitions.lean
@@ -1077,6 +1077,20 @@ theorem coeff_pow_mul_natDegree (p : R[X]) (n : ℕ) :
       exact coeff_mul_degree_add_degree _ _
 #align polynomial.coeff_pow_mul_nat_degree Polynomial.coeff_pow_mul_natDegree
 
+theorem coeff_mul_add_of_le_natDegree_of_eq {df dg : ℕ} {g : R[X]}
+    (hdf : natDegree f ≤ df) (hdg : natDegree g ≤ dg) :
+    (f * g).coeff (df + dg) = f.coeff df * g.coeff dg := by
+  rw [coeff_mul, Finset.sum_eq_single_of_mem (df, dg)]
+  · rw [Finset.Nat.mem_antidiagonal]
+  rintro ⟨df', dg'⟩ hmem hne
+  obtain h | hdf' := lt_or_le df df'
+  · rw [coeff_eq_zero_of_natDegree_lt (hdf.trans_lt h), zero_mul]
+  obtain h | hdg' := lt_or_le dg dg'
+  · rw [coeff_eq_zero_of_natDegree_lt (hdg.trans_lt h), mul_zero]
+  obtain ⟨rfl, rfl⟩ :=
+    eq_and_eq_of_le_of_le_of_add_le hdf' hdg' (Finset.Nat.mem_antidiagonal.1 hmem).ge
+  exact (hne rfl).elim
+
 theorem zero_le_degree_iff : 0 ≤ degree p ↔ p ≠ 0 := by
   rw [← not_lt, Nat.WithBot.lt_zero_iff, degree_eq_bot]
 #align polynomial.zero_le_degree_iff Polynomial.zero_le_degree_iff

--- a/Mathlib/Data/Polynomial/Degree/Lemmas.lean
+++ b/Mathlib/Data/Polynomial/Degree/Lemmas.lean
@@ -181,6 +181,18 @@ theorem coeff_pow_of_natDegree_le (pn : p.natDegree ≤ n) :
     exact mul_le_mul_of_nonneg_left pn m.zero_le
 #align polynomial.coeff_pow_of_nat_degree_le Polynomial.coeff_pow_of_natDegree_le
 
+theorem coeff_pow_of_natDegree_le_of_eq_ite [Semiring R] {m n o : ℕ} {p : R[X]}
+    (pn : natDegree p ≤ n) (mno : m * n ≤ o) :
+    coeff (p ^ m) o = if o = m * n then (coeff p n) ^ m else 0 := by
+  split_ifs with h
+  · subst h
+    rw [mul_comm]
+    apply coeff_pow_of_natDegree_le pn
+  · apply coeff_eq_zero_of_natDegree_lt
+    apply lt_of_le_of_lt ?_ (lt_of_le_of_ne mno ?_)
+    · exact natDegree_pow_le_of_le m pn
+    · exact Iff.mp ne_comm h
+
 theorem coeff_add_eq_left_of_lt (qn : q.natDegree < n) : (p + q).coeff n = p.coeff n :=
   (coeff_add _ _ _).trans <|
     (congr_arg _ <| coeff_eq_zero_of_natDegree_lt <| qn).trans <| add_zero _

--- a/Mathlib/Data/Polynomial/Degree/Lemmas.lean
+++ b/Mathlib/Data/Polynomial/Degree/Lemmas.lean
@@ -172,26 +172,25 @@ theorem coeff_mul_of_natDegree_le (pm : p.natDegree ≤ m) (qn : q.natDegree ≤
     exact natDegree_lt_coeff_mul (add_lt_add hm hn)
 #align polynomial.coeff_mul_of_nat_degree_le Polynomial.coeff_mul_of_natDegree_le
 
+-- post-porting note: the signature of this theorem changed.  it was
+-- theorem coeff_pow_of_natDegree_le (pn : p.natDegree ≤ n) :
+--     (p ^ m).coeff (n * m) = p.coeff n ^ m :=
 theorem coeff_pow_of_natDegree_le (pn : p.natDegree ≤ n) :
-    (p ^ m).coeff (n * m) = p.coeff n ^ m := by
+    (p ^ m).coeff (m * n) = p.coeff n ^ m := by
   induction' m with m hm
   · simp
-  · rw [pow_succ', pow_succ', ← hm, Nat.mul_succ, coeff_mul_of_natDegree_le _ pn]
-    refine' natDegree_pow_le.trans (le_trans _ (mul_comm _ _).le)
+  · rw [pow_succ', pow_succ', ← hm, Nat.succ_mul, coeff_mul_of_natDegree_le _ pn]
+    refine' natDegree_pow_le.trans (le_trans _ (le_refl _))
     exact mul_le_mul_of_nonneg_left pn m.zero_le
 #align polynomial.coeff_pow_of_nat_degree_le Polynomial.coeff_pow_of_natDegree_le
 
 theorem coeff_pow_of_natDegree_le_of_eq_ite {o : ℕ}
     (pn : natDegree p ≤ n) (mno : m * n ≤ o) :
     coeff (p ^ m) o = if o = m * n then (coeff p n) ^ m else 0 := by
-  split_ifs with h
-  · subst h
-    rw [mul_comm]
-    apply coeff_pow_of_natDegree_le pn
-  · apply coeff_eq_zero_of_natDegree_lt
-    apply lt_of_le_of_lt ?_ (lt_of_le_of_ne mno ?_)
-    · exact natDegree_pow_le_of_le m pn
-    · exact Iff.mp ne_comm h
+  rcases eq_or_ne o (m * n) with rfl | h
+  · simpa only [ite_true] using coeff_pow_of_natDegree_le pn
+  · simpa only [h, ite_false] using coeff_eq_zero_of_natDegree_lt $
+      lt_of_le_of_lt (natDegree_pow_le_of_le m pn) (lt_of_le_of_ne mno h.symm)
 
 theorem coeff_add_eq_left_of_lt (qn : q.natDegree < n) : (p + q).coeff n = p.coeff n :=
   (coeff_add _ _ _).trans <|

--- a/Mathlib/Data/Polynomial/Degree/Lemmas.lean
+++ b/Mathlib/Data/Polynomial/Degree/Lemmas.lean
@@ -181,7 +181,7 @@ theorem coeff_pow_of_natDegree_le (pn : p.natDegree ≤ n) :
     exact mul_le_mul_of_nonneg_left pn m.zero_le
 #align polynomial.coeff_pow_of_nat_degree_le Polynomial.coeff_pow_of_natDegree_le
 
-theorem coeff_pow_of_natDegree_le_of_eq_ite [Semiring R] {m n o : ℕ} {p : R[X]}
+theorem coeff_pow_of_natDegree_le_of_eq_ite {o : ℕ}
     (pn : natDegree p ≤ n) (mno : m * n ≤ o) :
     coeff (p ^ m) o = if o = m * n then (coeff p n) ^ m else 0 := by
   split_ifs with h

--- a/Mathlib/Data/Polynomial/Degree/Lemmas.lean
+++ b/Mathlib/Data/Polynomial/Degree/Lemmas.lean
@@ -184,7 +184,7 @@ theorem coeff_pow_of_natDegree_le (pn : p.natDegree ≤ n) :
     exact mul_le_mul_of_nonneg_left pn m.zero_le
 #align polynomial.coeff_pow_of_nat_degree_le Polynomial.coeff_pow_of_natDegree_le
 
-theorem coeff_pow_of_natDegree_le_of_eq_ite {o : ℕ}
+theorem coeff_pow_eq_ite_of_natDegree_le_of_le {o : ℕ}
     (pn : natDegree p ≤ n) (mno : m * n ≤ o) :
     coeff (p ^ m) o = if o = m * n then (coeff p n) ^ m else 0 := by
   rcases eq_or_ne o (m * n) with rfl | h

--- a/Mathlib/Data/Polynomial/Degree/Lemmas.lean
+++ b/Mathlib/Data/Polynomial/Degree/Lemmas.lean
@@ -172,9 +172,6 @@ theorem coeff_mul_of_natDegree_le (pm : p.natDegree ≤ m) (qn : q.natDegree ≤
     exact natDegree_lt_coeff_mul (add_lt_add hm hn)
 #align polynomial.coeff_mul_of_nat_degree_le Polynomial.coeff_mul_of_natDegree_le
 
--- post-porting note: the signature of this theorem changed.  it was
--- theorem coeff_pow_of_natDegree_le (pn : p.natDegree ≤ n) :
---     (p ^ m).coeff (n * m) = p.coeff n ^ m :=
 theorem coeff_pow_of_natDegree_le (pn : p.natDegree ≤ n) :
     (p ^ m).coeff (m * n) = p.coeff n ^ m := by
   induction' m with m hm

--- a/Mathlib/Data/Polynomial/EraseLead.lean
+++ b/Mathlib/Data/Polynomial/EraseLead.lean
@@ -245,6 +245,29 @@ theorem induction_with_natDegree_le (P : R[X] → Prop) (N : ℕ) (P_0 : P 0)
       exact Nat.succ_ne_zero _
 #align polynomial.induction_with_nat_degree_le Polynomial.induction_with_natDegree_le
 
+theorem coeff_mul_add_of_le_natDegree_of_eq {df dg : ℕ} {f g : R[X]}
+    (hdf : natDegree f ≤ df) (hdg : natDegree g ≤ dg) :
+    (f * g).coeff (df + dg) = f.coeff df * g.coeff dg := by
+  revert hdg g
+  apply f.induction_with_natDegree_le (P_0 := by simp)
+  · intros n r _r0 hn g hdg
+    rw [mul_assoc, coeff_C_mul, coeff_C_mul, coeff_X_pow_mul', coeff_X_pow,
+      if_pos (le_add_right hn)]
+    split_ifs with H
+    · simp [H]
+    · rw [mul_zero, zero_mul]
+      apply mul_eq_zero_of_right
+      apply coeff_eq_zero_of_natDegree_lt
+      apply hdg.trans_lt
+      rw [add_comm, Nat.add_sub_assoc hn]
+      apply Nat.lt_add_of_pos_right
+      apply Nat.sub_pos_of_lt
+      exact Ne.lt_of_le' H hn
+  · intros f g _fg _gle hf hg h hle
+    rw [add_mul, coeff_add, coeff_add, add_mul]
+    congr <;> solve_by_elim
+  · assumption
+
 /-- Let `φ : R[x] → S[x]` be an additive map, `k : ℕ` a bound, and `fu : ℕ → ℕ` a
 "sufficiently monotone" map.  Assume also that
 * `φ` maps to `0` all monomials of degree less than `k`,

--- a/Mathlib/Data/Polynomial/EraseLead.lean
+++ b/Mathlib/Data/Polynomial/EraseLead.lean
@@ -244,8 +244,8 @@ theorem induction_with_natDegree_le (P : R[X] → Prop) (N : ℕ) (P_0 : P 0)
       rw [Ne.def, leadingCoeff_eq_zero, ← card_support_eq_zero, f0]
       exact Nat.succ_ne_zero _
 #align polynomial.induction_with_nat_degree_le Polynomial.induction_with_natDegree_le
-
-theorem coeff_mul_add_of_le_natDegree_of_eq {df dg : ℕ} {f g : R[X]}
+#where
+theorem coeff_mul_add_of_le_natDegree_of_eq {df dg : ℕ} {g : R[X]}
     (hdf : natDegree f ≤ df) (hdg : natDegree g ≤ dg) :
     (f * g).coeff (df + dg) = f.coeff df * g.coeff dg := by
   revert hdg g

--- a/Mathlib/Data/Polynomial/EraseLead.lean
+++ b/Mathlib/Data/Polynomial/EraseLead.lean
@@ -245,29 +245,6 @@ theorem induction_with_natDegree_le (P : R[X] → Prop) (N : ℕ) (P_0 : P 0)
       exact Nat.succ_ne_zero _
 #align polynomial.induction_with_nat_degree_le Polynomial.induction_with_natDegree_le
 
-theorem coeff_mul_add_of_le_natDegree_of_eq {df dg : ℕ} {g : R[X]}
-    (hdf : natDegree f ≤ df) (hdg : natDegree g ≤ dg) :
-    (f * g).coeff (df + dg) = f.coeff df * g.coeff dg := by
-  revert hdg g
-  apply f.induction_with_natDegree_le (P_0 := by simp)
-  · intros n r _r0 hn g hdg
-    rw [mul_assoc, coeff_C_mul, coeff_C_mul, coeff_X_pow_mul', coeff_X_pow,
-      if_pos (le_add_right hn)]
-    split_ifs with H
-    · simp [H]
-    · rw [mul_zero, zero_mul]
-      apply mul_eq_zero_of_right
-      apply coeff_eq_zero_of_natDegree_lt
-      apply hdg.trans_lt
-      rw [add_comm, Nat.add_sub_assoc hn]
-      apply Nat.lt_add_of_pos_right
-      apply Nat.sub_pos_of_lt
-      exact Ne.lt_of_le' H hn
-  · intros f g _fg _gle hf hg h hle
-    rw [add_mul, coeff_add, coeff_add, add_mul]
-    congr <;> solve_by_elim
-  · assumption
-
 /-- Let `φ : R[x] → S[x]` be an additive map, `k : ℕ` a bound, and `fu : ℕ → ℕ` a
 "sufficiently monotone" map.  Assume also that
 * `φ` maps to `0` all monomials of degree less than `k`,

--- a/Mathlib/Data/Polynomial/EraseLead.lean
+++ b/Mathlib/Data/Polynomial/EraseLead.lean
@@ -244,7 +244,7 @@ theorem induction_with_natDegree_le (P : R[X] → Prop) (N : ℕ) (P_0 : P 0)
       rw [Ne.def, leadingCoeff_eq_zero, ← card_support_eq_zero, f0]
       exact Nat.succ_ne_zero _
 #align polynomial.induction_with_nat_degree_le Polynomial.induction_with_natDegree_le
-#where
+
 theorem coeff_mul_add_of_le_natDegree_of_eq {df dg : ℕ} {g : R[X]}
     (hdf : natDegree f ≤ df) (hdg : natDegree g ≤ dg) :
     (f * g).coeff (df + dg) = f.coeff df * g.coeff dg := by


### PR DESCRIPTION
This PR extracts some lemmas about polynomials that are helpful for the tactic `compute_degree` (#6221).

The signature of a theorem changed:
```lean
theorem coeff_pow_of_natDegree_le (pn : p.natDegree ≤ n) :
    (p ^ m).coeff (n * m) = p.coeff n ^ m  -- <-- the order of the product was `n * m`
    (p ^ m).coeff (m * n) = p.coeff n ^ m  -- <-- and it became `m * n`
```
Modified files:
```
Data/Polynomial/Basic.lean
Data/Polynomial/Degree/Lemmas.lean
Data/Polynomial/Degree/Definitions.lean
Data/Polynomial/Coeff.lean  -- for a "`simp` can prove this" golf
```

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

- [x] depends on: #6483, where `eq_and_eq_of_le_of_le_of_mul_le` moved earlier in the import hierarchy

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
