### PR TITLE
[Merged by Bors] - refactor(GroupTheory/CommutingProbability): Remove finite assumption

### DIFF
--- a/Mathlib/GroupTheory/CommutingProbability.lean
+++ b/Mathlib/GroupTheory/CommutingProbability.lean
@@ -93,11 +93,12 @@ theorem commProb_eq_one_iff [h : Nonempty M] :
   · exact pow_ne_zero 2 (Nat.cast_ne_zero.mpr card_ne_zero)
 #align comm_prob_eq_one_iff commProb_eq_one_iff
 
-variable (G : Type _) [Group G] [Finite G]
+variable (G : Type _) [Group G]
 
 theorem card_comm_eq_card_conjClasses_mul_card :
     Nat.card { p : G × G // Commute p.1 p.2 } = Nat.card (ConjClasses G) * Nat.card G := by
-  haveI := Fintype.ofFinite G
+  rcases fintypeOrInfinite G; swap
+  . rw [Nat.card_eq_zero_of_infinite, @Nat.card_eq_zero_of_infinite G, mul_zero]
   simp only [Nat.card_eq_fintype_card]
   -- Porting note: Changed `calc` proof into a `rw` proof.
   rw [card_congr (Equiv.subtypeProdEquivSigmaSubtype fun g h : G ↦ Commute g h), card_sigma,
@@ -112,11 +113,13 @@ theorem card_comm_eq_card_conjClasses_mul_card :
 
 theorem commProb_def' : commProb G = Nat.card (ConjClasses G) / Nat.card G := by
   rw [commProb, card_comm_eq_card_conjClasses_mul_card, Nat.cast_mul, sq]
-  exact mul_div_mul_right _ _ (Nat.cast_ne_zero.mpr Finite.card_pos.ne')
+  by_cases h : (Nat.card G : ℚ) = 0
+  . rw [h, zero_mul, div_zero, div_zero]
+  . exact mul_div_mul_right _ _ h
 #align comm_prob_def' commProb_def'
 
--- porting note: inserted [Group G]
-variable {G} [Group G] (H : Subgroup G)
+variable {G}
+variable [Finite G] (H : Subgroup G)
 
 theorem Subgroup.commProb_subgroup_le : commProb H ≤ commProb G * (H.index : ℚ) ^ 2 := by
   /- After rewriting with `commProb_def`, we reduce to showing that `G` has at least as many

--- a/Mathlib/GroupTheory/CommutingProbability.lean
+++ b/Mathlib/GroupTheory/CommutingProbability.lean
@@ -98,7 +98,7 @@ variable (G : Type _) [Group G]
 theorem card_comm_eq_card_conjClasses_mul_card :
     Nat.card { p : G × G // Commute p.1 p.2 } = Nat.card (ConjClasses G) * Nat.card G := by
   rcases fintypeOrInfinite G; swap
-  . rw [Nat.card_eq_zero_of_infinite, @Nat.card_eq_zero_of_infinite G, mul_zero]
+  · rw [Nat.card_eq_zero_of_infinite, @Nat.card_eq_zero_of_infinite G, mul_zero]
   simp only [Nat.card_eq_fintype_card]
   -- Porting note: Changed `calc` proof into a `rw` proof.
   rw [card_congr (Equiv.subtypeProdEquivSigmaSubtype fun g h : G ↦ Commute g h), card_sigma,
@@ -114,8 +114,8 @@ theorem card_comm_eq_card_conjClasses_mul_card :
 theorem commProb_def' : commProb G = Nat.card (ConjClasses G) / Nat.card G := by
   rw [commProb, card_comm_eq_card_conjClasses_mul_card, Nat.cast_mul, sq]
   by_cases h : (Nat.card G : ℚ) = 0
-  . rw [h, zero_mul, div_zero, div_zero]
-  . exact mul_div_mul_right _ _ h
+  · rw [h, zero_mul, div_zero, div_zero]
+  · exact mul_div_mul_right _ _ h
 #align comm_prob_def' commProb_def'
 
 variable {G}


### PR DESCRIPTION
This PR removes the finite assumption on a couple lemmas.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
