### PR TITLE
feat: IsROrC Rank Lemmas without PartialOrder and StarOrderedRing

### DIFF
--- a/Mathlib/Data/IsROrC/Basic.lean
+++ b/Mathlib/Data/IsROrC/Basic.lean
@@ -291,6 +291,14 @@ theorem norm_ofReal (r : ℝ) : ‖(r : K)‖ = |r| :=
   norm_algebraMap' K r
 #align is_R_or_C.norm_of_real IsROrC.norm_ofReal
 
+@[simp, isROrC_simps]
+theorem re_sum (f : n → K) : IsROrC.re (∑ i in s, f i) = ∑ i in s, IsROrC.re (f i) := by
+  apply map_sum _ _
+
+@[simp, isROrC_simps]
+theorem im_sum (f : n → K) : IsROrC.im (∑ i in s, f i) = ∑ i in s, IsROrC.im (f i) := by
+  apply map_sum _ _
+
 /-! ### Characteristic zero -/
 
 -- see Note [lower instance priority]

--- a/Mathlib/Data/Matrix/Rank.lean
+++ b/Mathlib/Data/Matrix/Rank.lean
@@ -8,6 +8,7 @@ import Mathlib.LinearAlgebra.Matrix.ToLin
 import Mathlib.LinearAlgebra.FiniteDimensional
 import Mathlib.LinearAlgebra.Matrix.DotProduct
 import Mathlib.Data.Complex.Module
+import Mathlib.Data.IsROrC.Basic
 
 #align_import data.matrix.rank from "leanprover-community/mathlib"@"17219820a8aa8abe85adf5dfde19af1dd1bd8ae7"
 
@@ -224,6 +225,45 @@ theorem rank_self_mul_conjTranspose (A : Matrix m n R) : (A ⬝ Aᴴ).rank = A.r
 #align matrix.rank_self_mul_conj_transpose Matrix.rank_self_mul_conjTranspose
 
 end StarOrderedField
+
+section IsROrCFields
+variable {K: Type}[IsROrC K]
+open BigOperators
+
+theorem ker_mulVecLin_conjTranspose_mul_self_R_or_C (A : Matrix m n K) :
+    LinearMap.ker (Aᴴ ⬝ A).mulVecLin = LinearMap.ker (mulVecLin A) := by
+  ext x
+  simp only [LinearMap.mem_ker, mulVecLin_apply, ← mulVec_mulVec]
+  constructor
+  · intro h
+    replace h := congr_arg (dotProduct (star x)) h
+    rwa [dotProduct_zero, dotProduct_mulVec, vecMul_conjTranspose, star_star,
+      dot_product_star_self_eq_zero_iff_R_or_C] at h
+  · intro h
+    rw [h, mulVec_zero]
+
+theorem rank_conjTranspose_mul_self_R_or_C (A : Matrix m n K) : (Aᴴ ⬝ A).rank = A.rank := by
+  dsimp only [rank]
+  refine' add_left_injective (finrank K (LinearMap.ker (mulVecLin A))) _
+  dsimp only
+  trans finrank K { x // x ∈ LinearMap.range (mulVecLin (Aᴴ ⬝ A)) } +
+    finrank K { x // x ∈ LinearMap.ker (mulVecLin (Aᴴ ⬝ A)) }
+  · rw [ker_mulVecLin_conjTranspose_mul_self_R_or_C]
+  · simp only [LinearMap.finrank_range_add_finrank_ker]
+
+@[simp]
+theorem rank_conjTranspose_R_or_C (A : Matrix m n K) : Aᴴ.rank = A.rank :=
+  le_antisymm
+    (((rank_conjTranspose_mul_self_R_or_C _).symm.trans_le <| rank_mul_le_left _ _).trans_eq <|
+      congr_arg _ <| conjTranspose_conjTranspose _)
+    ((rank_conjTranspose_mul_self_R_or_C _).symm.trans_le <| rank_mul_le_left _ _)
+
+@[simp]
+theorem rank_self_mul_conjTranspose_R_or_C (A : Matrix m n K) : (A ⬝ Aᴴ).rank = A.rank := by
+  simpa only [rank_conjTranspose_R_or_C, conjTranspose_conjTranspose] using
+    rank_conjTranspose_mul_self_R_or_C Aᴴ
+
+end IsROrCFields
 
 section LinearOrderedField
 

--- a/Mathlib/LinearAlgebra/Matrix/DotProduct.lean
+++ b/Mathlib/LinearAlgebra/Matrix/DotProduct.lean
@@ -6,6 +6,7 @@ Authors: Johannes Hölzl, Patrick Massot, Casper Putz, Anne Baanen
 import Mathlib.Algebra.Star.Order
 import Mathlib.Data.Matrix.Basic
 import Mathlib.LinearAlgebra.StdBasis
+import Mathlib.Data.IsROrC.Basic
 
 #align_import linear_algebra.matrix.dot_product from "leanprover-community/mathlib"@"31c24aa72e7b3e5ed97a8412470e904f82b81004"
 
@@ -99,5 +100,29 @@ theorem dotProduct_self_star_eq_zero [PartialOrder R] [NonUnitalRing R] [StarOrd
 #align matrix.dot_product_self_star_eq_zero Matrix.dotProduct_self_star_eq_zero
 
 end Self
+
+section IsROrCFields
+variable [Fintype n]
+variable {K: Type}[IsROrC K]
+
+lemma dot_product_star_self_eq_zero_iff_R_or_C
+    (v : n → K) : Matrix.dotProduct (star v) v = 0 ↔  v = 0 := by
+  simp_rw [Matrix.dotProduct, Pi.star_apply, ← starRingEnd_apply, IsROrC.conj_mul]
+  rw [IsROrC.ext_iff]
+  simp only [IsROrC.re_sum, IsROrC.ofReal_re, map_zero, IsROrC.im_sum, IsROrC.ofReal_im,
+    Finset.sum_const_zero, and_true]
+  constructor
+  · intro hr
+    rw [Finset.sum_eq_zero_iff_of_nonneg] at hr
+    · simp only [Finset.mem_univ, map_eq_zero, forall_true_left] at hr
+      funext i
+      exact hr i
+    · simp only [Finset.mem_univ, forall_true_left]
+      intro
+      apply IsROrC.normSq_nonneg
+  · intro h
+    rw [h]
+    simp only [Pi.zero_apply, map_zero, Finset.sum_const_zero]
+end IsROrCFields
 
 end Matrix


### PR DESCRIPTION
This PR proves three lemmas `rank_conjTranspose_R_or_C`, `rank_self_mul_conjTranspose_R_or_C` and `rank_conjTranspose_mul_self_R_or_C` which state that in $\mathbb{R}$ or $\mathbb{C}$ fields:

- $\text{rank}(A^H) = \text{rank}(A)$
- $\text{rank}(A^HA) = \text{rank}(A)$
- $\text{rank}(AA^H) = \text{rank}(A)$

These are almost the same named lemmas (without R_or_C suffix). However the original lemmas don't apply without using a `PartialOrder` and `StarOrderedRing` on the Complex Field and `IsROrC`, which seems to be a point the community is still discussing. The lemmas in this PR apply directly WITHOUT requiring `PartialOrder` and `StarOrderedRing`.

Co-authored-by: Mohanad Ahmed <m.a.m.elhassan@gmail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
