### PR TITLE
[Merged by Bors] - doc: change variable names in AtPrime.lean

### DIFF
--- a/Mathlib/RingTheory/Localization/AtPrime.lean
+++ b/Mathlib/RingTheory/Localization/AtPrime.lean
@@ -13,9 +13,9 @@ import Mathlib.RingTheory.Localization.Ideal
 
 ## Main definitions
 
- * `IsLocalization.AtPrime (I : Ideal R) [IsPrime I] (S : Type _)` expresses that `S` is a
-   localization at (the complement of) a prime ideal `I`, as an abbreviation of
-   `IsLocalization I.prime_compl S`
+ * `IsLocalization.AtPrime (P : Ideal R) [IsPrime P] (S : Type _)` expresses that `S` is a
+   localization at (the complement of) a prime ideal `P`, as an abbreviation of
+   `IsLocalization P.prime_compl S`
 
 ## Main results
 
@@ -38,19 +38,19 @@ variable [Algebra R S] {P : Type _} [CommSemiring P]
 
 section AtPrime
 
-variable (I : Ideal R) [hp : I.IsPrime]
+variable (P : Ideal R) [hp : P.IsPrime]
 
 namespace Ideal
 
-/-- The complement of a prime ideal `I ⊆ R` is a submonoid of `R`. -/
+/-- The complement of a prime ideal `P ⊆ R` is a submonoid of `R`. -/
 def primeCompl : Submonoid R where
-  carrier := (Iᶜ : Set R)
-  one_mem' := by convert I.ne_top_iff_one.1 hp.1
+  carrier := (Pᶜ : Set R)
+  one_mem' := by convert P.ne_top_iff_one.1 hp.1
   mul_mem' {x y} hnx hny hxy := Or.casesOn (hp.mem_or_mem hxy) hnx hny
 #align ideal.prime_compl Ideal.primeCompl
 
-theorem primeCompl_le_nonZeroDivisors [NoZeroDivisors R] : I.primeCompl ≤ nonZeroDivisors R :=
-  le_nonZeroDivisors_of_noZeroDivisors <| not_not_intro I.zero_mem
+theorem primeCompl_le_nonZeroDivisors [NoZeroDivisors R] : P.primeCompl ≤ nonZeroDivisors R :=
+  le_nonZeroDivisors_of_noZeroDivisors <| not_not_intro P.zero_mem
 #align ideal.prime_compl_le_non_zero_divisors Ideal.primeCompl_le_nonZeroDivisors
 
 end Ideal
@@ -58,51 +58,51 @@ end Ideal
 /-- Given a prime ideal `P`, the typeclass `IsLocalization.AtPrime S P` states that `S` is
 isomorphic to the localization of `R` at the complement of `P`. -/
 protected abbrev IsLocalization.AtPrime :=
-  IsLocalization I.primeCompl S
+  IsLocalization P.primeCompl S
 #align is_localization.at_prime IsLocalization.AtPrime
 
-/-- Given a prime ideal `P`, `Localization.AtPrime S P` is a localization of
+/-- Given a prime ideal `P`, `Localization.AtPrime P` is a localization of
 `R` at the complement of `P`, as a quotient type. -/
 protected abbrev Localization.AtPrime :=
-  Localization I.primeCompl
+  Localization P.primeCompl
 #align localization.at_prime Localization.AtPrime
 
 namespace IsLocalization
 
-theorem AtPrime.Nontrivial [IsLocalization.AtPrime S I] : Nontrivial S :=
+theorem AtPrime.Nontrivial [IsLocalization.AtPrime S P] : Nontrivial S :=
   nontrivial_of_ne (0 : S) 1 fun hze => by
     rw [← (algebraMap R S).map_one, ← (algebraMap R S).map_zero] at hze
-    obtain ⟨t, ht⟩ := (eq_iff_exists I.primeCompl S).1 hze
+    obtain ⟨t, ht⟩ := (eq_iff_exists P.primeCompl S).1 hze
     have htz : (t : R) = 0 := by simpa using ht.symm
-    exact t.2 (htz.symm ▸ I.zero_mem : ↑t ∈ I)
+    exact t.2 (htz.symm ▸ P.zero_mem : ↑t ∈ P)
 #align is_localization.at_prime.nontrivial IsLocalization.AtPrime.Nontrivial
 
-theorem AtPrime.localRing [IsLocalization.AtPrime S I] : LocalRing S :=
+theorem AtPrime.localRing [IsLocalization.AtPrime S P] : LocalRing S :=
   -- Porting Note : since I couldn't get local instance running, I just specify it manually
-  letI := AtPrime.Nontrivial S I
+  letI := AtPrime.Nontrivial S P
   LocalRing.of_nonunits_add
     (by
       intro x y hx hy hu
       cases' isUnit_iff_exists_inv.1 hu with z hxyz
-      have : ∀ {r : R} {s : I.primeCompl}, mk' S r s ∈ nonunits S → r ∈ I := fun {r s} =>
-        not_imp_comm.1 fun nr => isUnit_iff_exists_inv.2 ⟨mk' S ↑s (⟨r, nr⟩ : I.primeCompl),
-          mk'_mul_mk'_eq_one' _ _ <| show r ∈ I.primeCompl from nr⟩
-      rcases mk'_surjective I.primeCompl x with ⟨rx, sx, hrx⟩
-      rcases mk'_surjective I.primeCompl y with ⟨ry, sy, hry⟩
-      rcases mk'_surjective I.primeCompl z with ⟨rz, sz, hrz⟩
-      rw [← hrx, ← hry, ← hrz, ← mk'_add, ← mk'_mul, ← mk'_self S I.primeCompl.one_mem] at hxyz
+      have : ∀ {r : R} {s : P.primeCompl}, mk' S r s ∈ nonunits S → r ∈ P := fun {r s} =>
+        not_imp_comm.1 fun nr => isUnit_iff_exists_inv.2 ⟨mk' S ↑s (⟨r, nr⟩ : P.primeCompl),
+          mk'_mul_mk'_eq_one' _ _ <| show r ∈ P.primeCompl from nr⟩
+      rcases mk'_surjective P.primeCompl x with ⟨rx, sx, hrx⟩
+      rcases mk'_surjective P.primeCompl y with ⟨ry, sy, hry⟩
+      rcases mk'_surjective P.primeCompl z with ⟨rz, sz, hrz⟩
+      rw [← hrx, ← hry, ← hrz, ← mk'_add, ← mk'_mul, ← mk'_self S P.primeCompl.one_mem] at hxyz
       rw [← hrx] at hx
       rw [← hry] at hy
       obtain ⟨t, ht⟩ := IsLocalization.eq.1 hxyz
       simp only [mul_one, one_mul, Submonoid.coe_mul, Subtype.coe_mk] at ht
-      suffices : (t : R) * (sx * sy * sz) ∈ I
+      suffices : (t : R) * (sx * sy * sz) ∈ P
       exact
         not_or_of_not (mt hp.mem_or_mem <| not_or_of_not sx.2 sy.2) sz.2
           (hp.mem_or_mem <| (hp.mem_or_mem this).resolve_left t.2)
       rw [← ht]
       exact
-        I.mul_mem_left _ <| I.mul_mem_right _ <|
-            I.add_mem (I.mul_mem_right _ <| this hx) <| I.mul_mem_right _ <| this hy)
+        P.mul_mem_left _ <| P.mul_mem_right _ <|
+            P.add_mem (P.mul_mem_right _ <| this hx) <| P.mul_mem_right _ <| this hy)
 #align is_localization.at_prime.local_ring IsLocalization.AtPrime.localRing
 
 end IsLocalization
@@ -110,8 +110,8 @@ end IsLocalization
 namespace Localization
 
 /-- The localization of `R` at the complement of a prime ideal is a local ring. -/
-instance AtPrime.localRing : LocalRing (Localization I.primeCompl) :=
-  IsLocalization.AtPrime.localRing (Localization I.primeCompl) I
+instance AtPrime.localRing : LocalRing (Localization P.primeCompl) :=
+  IsLocalization.AtPrime.localRing (Localization P.primeCompl) P
 #align localization.at_prime.local_ring Localization.AtPrime.localRing
 
 end Localization


### PR DESCRIPTION
This commit changes the names of the prime ideal to `I` to match the docstrings. It also fixes an instance of `Localization.AtPrime` taking too many arguments in a docstring.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
