### PR TITLE
[Merged by Bors] - feat: short complexes in functor categories

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -220,6 +220,7 @@ import Mathlib.Algebra.Homology.ModuleCat
 import Mathlib.Algebra.Homology.Opposite
 import Mathlib.Algebra.Homology.QuasiIso
 import Mathlib.Algebra.Homology.ShortComplex.Basic
+import Mathlib.Algebra.Homology.ShortComplex.FunctorEquivalence
 import Mathlib.Algebra.Homology.ShortComplex.Homology
 import Mathlib.Algebra.Homology.ShortComplex.LeftHomology
 import Mathlib.Algebra.Homology.ShortComplex.RightHomology

--- a/Mathlib/Algebra/Homology/ShortComplex/FunctorEquivalence.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/FunctorEquivalence.lean
@@ -10,7 +10,7 @@ import Mathlib.Algebra.Homology.ShortComplex.Basic
 
 In this file, it is shown that if `J` and `C` are two categories (such
 that `C` has zero morphisms), then there is an equivalence of categories
-`ShortComplex.functorEquivalence J C : (ShortComplex (J ⥤ C)) ≌ (J ⥤ ShortComplex C)`.
+`ShortComplex.functorEquivalence J C : ShortComplex (J ⥤ C) ≌ J ⥤ ShortComplex C`.
 
 -/
 

--- a/Mathlib/Algebra/Homology/ShortComplex/FunctorEquivalence.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/FunctorEquivalence.lean
@@ -1,0 +1,78 @@
+/-
+Copyright (c) 2023 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+import Mathlib.Algebra.Homology.ShortComplex.Basic
+
+/-!
+# Short complexes in functor categories
+
+In this file, it is shown that if `J` and `C` are two categories (such
+that `C` has zero morphisms), then there is an equivalence of categories
+`ShortComplex.functorEquivalence J C : (ShortComplex (J ⥤ C)) ≌ (J ⥤ ShortComplex C)`.
+
+-/
+
+namespace CategoryTheory
+
+open Limits
+
+variable (J C : Type _) [Category J] [Category C] [HasZeroMorphisms C]
+
+namespace ShortComplex
+
+namespace FunctorEquivalence
+
+attribute [local simp] ShortComplex.Hom.comm₁₂ ShortComplex.Hom.comm₂₃
+
+/-- The obvious functor `(ShortComplex (J ⥤ C)) ⥤ (J ⥤ ShortComplex C)`. -/
+@[simps]
+def functor : (ShortComplex (J ⥤ C)) ⥤ (J ⥤ ShortComplex C) where
+  obj S :=
+    { obj := fun j => S.map ((evaluation J C).obj j)
+      map := fun f => S.mapNatTrans ((evaluation J C).map f) }
+  map φ :=
+    { app := fun j => ((evaluation J C).obj j).mapShortComplex.map φ }
+
+/-- The obvious functor `(J ⥤ ShortComplex C) ⥤ (ShortComplex (J ⥤ C))`. -/
+@[simps]
+def inverse : (J ⥤ ShortComplex C) ⥤ (ShortComplex (J ⥤ C)) where
+  obj F :=
+    { f := whiskerLeft F π₁Toπ₂
+      g := whiskerLeft F π₂Toπ₃
+      zero := by aesop_cat }
+  map φ := Hom.mk (whiskerRight φ π₁) (whiskerRight φ π₂) (whiskerRight φ π₃)
+    (by aesop_cat) (by aesop_cat)
+
+/-- The unit isomorphism of the equivalence
+`ShortComplex.functorEquivalence : (ShortComplex (J ⥤ C)) ≌ (J ⥤ ShortComplex C)`. -/
+@[simps!]
+def unitIso : 𝟭 _ ≅ functor J C ⋙ inverse J C :=
+  NatIso.ofComponents (fun _ => isoMk
+    (NatIso.ofComponents (fun _ => Iso.refl _) (by aesop_cat))
+    (NatIso.ofComponents (fun _ => Iso.refl _) (by aesop_cat))
+    (NatIso.ofComponents (fun _ => Iso.refl _) (by aesop_cat))
+    (by aesop_cat) (by aesop_cat)) (by aesop_cat)
+
+/-- The counit isomorphism of the equivalence
+`ShortComplex.functorEquivalence : (ShortComplex (J ⥤ C)) ≌ (J ⥤ ShortComplex C)`. -/
+@[simps!]
+def counitIso : inverse J C ⋙ functor J C ≅ 𝟭 _:=
+  NatIso.ofComponents (fun _ => NatIso.ofComponents
+    (fun _ => isoMk (Iso.refl _) (Iso.refl _) (Iso.refl _)
+      (by aesop_cat) (by aesop_cat)) (by aesop_cat)) (by aesop_cat)
+
+end FunctorEquivalence
+
+/-- The obvious equivalence `(ShortComplex (J ⥤ C)) ≌ (J ⥤ ShortComplex C)`. -/
+@[simps]
+def functorEquivalence : (ShortComplex (J ⥤ C)) ≌ (J ⥤ ShortComplex C) where
+  functor := FunctorEquivalence.functor J C
+  inverse := FunctorEquivalence.inverse J C
+  unitIso := FunctorEquivalence.unitIso J C
+  counitIso := FunctorEquivalence.counitIso J C
+
+end ShortComplex
+
+end CategoryTheory

--- a/Mathlib/Algebra/Homology/ShortComplex/FunctorEquivalence.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/FunctorEquivalence.lean
@@ -26,18 +26,18 @@ namespace FunctorEquivalence
 
 attribute [local simp] ShortComplex.Hom.comm₁₂ ShortComplex.Hom.comm₂₃
 
-/-- The obvious functor `(ShortComplex (J ⥤ C)) ⥤ (J ⥤ ShortComplex C)`. -/
+/-- The obvious functor `ShortComplex (J ⥤ C) ⥤ J ⥤ ShortComplex C`. -/
 @[simps]
-def functor : (ShortComplex (J ⥤ C)) ⥤ (J ⥤ ShortComplex C) where
+def functor : ShortComplex (J ⥤ C) ⥤ J ⥤ ShortComplex C where
   obj S :=
     { obj := fun j => S.map ((evaluation J C).obj j)
       map := fun f => S.mapNatTrans ((evaluation J C).map f) }
   map φ :=
     { app := fun j => ((evaluation J C).obj j).mapShortComplex.map φ }
 
-/-- The obvious functor `(J ⥤ ShortComplex C) ⥤ (ShortComplex (J ⥤ C))`. -/
+/-- The obvious functor `(J ⥤ ShortComplex C) ⥤ ShortComplex (J ⥤ C)`. -/
 @[simps]
-def inverse : (J ⥤ ShortComplex C) ⥤ (ShortComplex (J ⥤ C)) where
+def inverse : (J ⥤ ShortComplex C) ⥤ ShortComplex (J ⥤ C) where
   obj F :=
     { f := whiskerLeft F π₁Toπ₂
       g := whiskerLeft F π₂Toπ₃
@@ -46,7 +46,7 @@ def inverse : (J ⥤ ShortComplex C) ⥤ (ShortComplex (J ⥤ C)) where
     (by aesop_cat) (by aesop_cat)
 
 /-- The unit isomorphism of the equivalence
-`ShortComplex.functorEquivalence : (ShortComplex (J ⥤ C)) ≌ (J ⥤ ShortComplex C)`. -/
+`ShortComplex.functorEquivalence : ShortComplex (J ⥤ C) ≌ J ⥤ ShortComplex C`. -/
 @[simps!]
 def unitIso : 𝟭 _ ≅ functor J C ⋙ inverse J C :=
   NatIso.ofComponents (fun _ => isoMk
@@ -56,7 +56,7 @@ def unitIso : 𝟭 _ ≅ functor J C ⋙ inverse J C :=
     (by aesop_cat) (by aesop_cat)) (by aesop_cat)
 
 /-- The counit isomorphism of the equivalence
-`ShortComplex.functorEquivalence : (ShortComplex (J ⥤ C)) ≌ (J ⥤ ShortComplex C)`. -/
+`ShortComplex.functorEquivalence : ShortComplex (J ⥤ C) ≌ J ⥤ ShortComplex C`. -/
 @[simps!]
 def counitIso : inverse J C ⋙ functor J C ≅ 𝟭 _:=
   NatIso.ofComponents (fun _ => NatIso.ofComponents
@@ -65,9 +65,9 @@ def counitIso : inverse J C ⋙ functor J C ≅ 𝟭 _:=
 
 end FunctorEquivalence
 
-/-- The obvious equivalence `(ShortComplex (J ⥤ C)) ≌ (J ⥤ ShortComplex C)`. -/
+/-- The obvious equivalence `ShortComplex (J ⥤ C) ≌ J ⥤ ShortComplex C`. -/
 @[simps]
-def functorEquivalence : (ShortComplex (J ⥤ C)) ≌ (J ⥤ ShortComplex C) where
+def functorEquivalence : ShortComplex (J ⥤ C) ≌ J ⥤ ShortComplex C where
   functor := FunctorEquivalence.functor J C
   inverse := FunctorEquivalence.inverse J C
   unitIso := FunctorEquivalence.unitIso J C

--- a/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Zero.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Zero.lean
@@ -101,7 +101,7 @@ instance (priority := 100) preservesZeroMorphisms_of_full (F : C ⥤ D) [Full F]
       _ = 0 := by rw [F.map_comp, F.image_preimage, comp_zero]
 #align category_theory.functor.preserves_zero_morphisms_of_full CategoryTheory.Functor.preservesZeroMorphisms_of_full
 
-instance preservesZeroMorphisms_evaluation (j : D) :
+instance preservesZeroMorphisms_evaluation_obj (j : D) :
     PreservesZeroMorphisms ((evaluation D C).obj j) where
 
 end ZeroMorphisms

--- a/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Zero.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Zero.lean
@@ -101,6 +101,9 @@ instance (priority := 100) preservesZeroMorphisms_of_full (F : C ⥤ D) [Full F]
       _ = 0 := by rw [F.map_comp, F.image_preimage, comp_zero]
 #align category_theory.functor.preserves_zero_morphisms_of_full CategoryTheory.Functor.preservesZeroMorphisms_of_full
 
+instance preservesZeroMorphisms_evaluation (j : D) :
+    PreservesZeroMorphisms ((evaluation D C).obj j) where
+
 end ZeroMorphisms
 
 section ZeroObject


### PR DESCRIPTION
This PR constructs an equivalence of categories `ShortComplex (J ⥤ C) ≌ J ⥤ ShortComplex C`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
