### PR TITLE
Revert "fix: correct universe polymorphism in SlimCheck (#5796)"

### DIFF
--- a/Mathlib/Control/ULiftable.lean
+++ b/Mathlib/Control/ULiftable.lean
@@ -104,9 +104,8 @@ end ULiftable
 
 open ULift
 
-instance instULiftableId : ULiftable Id Id where
+instance : ULiftable id id where
   congr F := F
-#align id.uliftable instULiftableId
 
 /-- for specific state types, this function helps to create a uliftable instance -/
 def StateT.uliftable' {m : Type u₀ → Type v₀} {m' : Type u₁ → Type v₁} [ULiftable m m']
@@ -118,10 +117,6 @@ def StateT.uliftable' {m : Type u₀ → Type v₀} {m' : Type u₁ → Type v�
 instance {m m'} [ULiftable m m'] : ULiftable (StateT s m) (StateT (ULift s) m') :=
   StateT.uliftable' Equiv.ulift.symm
 
-instance StateT.instULiftableULiftULift {m m'} [ULiftable m m'] :
-    ULiftable (StateT (ULift.{max v₀ u₀} s) m) (StateT (ULift.{max v₁ u₀} s) m') :=
-  StateT.uliftable' <| Equiv.ulift.trans Equiv.ulift.symm
-
 /-- for specific reader monads, this function helps to create a uliftable instance -/
 def ReaderT.uliftable' {m m'} [ULiftable m m'] (F : s ≃ s') :
     ULiftable (ReaderT s m) (ReaderT s' m') where
@@ -130,10 +125,6 @@ def ReaderT.uliftable' {m m'} [ULiftable m m'] (F : s ≃ s') :
 
 instance {m m'} [ULiftable m m'] : ULiftable (ReaderT s m) (ReaderT (ULift s) m') :=
   ReaderT.uliftable' Equiv.ulift.symm
-
-instance ReaderT.instULiftableULiftULift {m m'} [ULiftable m m'] :
-    ULiftable (ReaderT (ULift.{max v₀ u₀} s) m) (ReaderT (ULift.{max v₁ u₀} s) m') :=
-  ReaderT.uliftable' <| Equiv.ulift.trans Equiv.ulift.symm
 
 /-- for specific continuation passing monads, this function helps to create a uliftable instance -/
 def ContT.uliftable' {m m'} [ULiftable m m'] (F : r ≃ r') :
@@ -144,10 +135,6 @@ def ContT.uliftable' {m m'} [ULiftable m m'] (F : r ≃ r') :
 instance {s m m'} [ULiftable m m'] : ULiftable (ContT s m) (ContT (ULift s) m') :=
   ContT.uliftable' Equiv.ulift.symm
 
-instance ContT.instULiftableULiftULift {m m'} [ULiftable m m'] :
-    ULiftable (ContT (ULift.{max v₀ u₀} s) m) (ContT (ULift.{max v₁ u₀} s) m') :=
-  ContT.uliftable' <| Equiv.ulift.trans Equiv.ulift.symm
-
 /-- for specific writer monads, this function helps to create a uliftable instance -/
 def WriterT.uliftable' {m m'} [ULiftable m m'] (F : w ≃ w') :
     ULiftable (WriterT w m) (WriterT w' m') where
@@ -156,7 +143,3 @@ def WriterT.uliftable' {m m'} [ULiftable m m'] (F : w ≃ w') :
 
 instance {m m'} [ULiftable m m'] : ULiftable (WriterT s m) (WriterT (ULift s) m') :=
   WriterT.uliftable' Equiv.ulift.symm
-
-instance WriterT.instULiftableULiftULift {m m'} [ULiftable m m'] :
-    ULiftable (WriterT (ULift.{max v₀ u₀} s) m) (WriterT (ULift.{max v₁ u₀} s) m') :=
-  WriterT.uliftable' <| Equiv.ulift.trans Equiv.ulift.symm

--- a/Mathlib/Testing/SlimCheck/Functions.lean
+++ b/Mathlib/Testing/SlimCheck/Functions.lean
@@ -497,7 +497,8 @@ instance PiInjective.sampleableExt : SampleableExt { f : ℤ → ℤ // Function
     have Hinj : Injective fun r : ℕ => -(2 * sz + 2 : ℤ) + ↑r := fun _x _y h =>
         Int.ofNat.inj (add_right_injective _ h)
     let r : InjectiveFunction ℤ :=
-      InjectiveFunction.mk xs' ys.1 ys.2.symm (ys.2.symm.nodup_iff.1 <| (List.nodup_range _).map Hinj)
+      InjectiveFunction.mk xs' ys.1 ys.2.symm
+        (ys.2.symm.nodup_iff.1 <| (List.nodup_range _).map Hinj)
     pure r
   shrink := {shrink := @InjectiveFunction.shrink ℤ _ }
 #align slim_check.injective_function.pi_injective.sampleable_ext SlimCheck.InjectiveFunction.PiInjective.sampleableExt

--- a/Mathlib/Testing/SlimCheck/Functions.lean
+++ b/Mathlib/Testing/SlimCheck/Functions.lean
@@ -49,11 +49,6 @@ their defining property is invariant through shrinking. Injective
 functions are an example of how complicated it can get.
 -/
 
-
-universe u v w
-
-variable {α : Type} {β : Type} {γ : Sort}
-
 namespace SlimCheck
 
 /-- Data structure specifying a total function using a list of pairs

--- a/Mathlib/Testing/SlimCheck/Sampleable.lean
+++ b/Mathlib/Testing/SlimCheck/Sampleable.lean
@@ -222,7 +222,7 @@ def Char.sampleable (length : Nat) (chars : List Char) (pos : 0 < chars.length) 
 instance Char.sampleableDefault : SampleableExt Char :=
   Char.sampleable 3 " 0123abcABC:,;`\\/".toList (by decide)
 
-instance Prod.sampleableExt {α : Type u} {β : Type v} [SampleableExt α] [SampleableExt β] :
+instance Prod.sampleableExt {α β : Type u} [SampleableExt α] [SampleableExt β] :
     SampleableExt (α × β) where
   proxy := Prod (proxy α) (proxy β)
   proxyRepr := inferInstance


### PR DESCRIPTION
This reverts commit fe6a0bdc715e2b574731d80a48d0d0e2a741f57f.

* This PR made #3838 impossible to proceed with (this PR would open the door to using tactics, rather than just decidability, to test candidates during `slim_check`).
* The benefit of #5796 seems minor: it is increasing universe polymorphism in meta code that is about testing concrete examples.
* My preference would be to do these in the opposite order (i.e. reinvestigate if there is scope for more universe polymorphism post #3838).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
