### PR TITLE
feat: units of Z/nZ are a fintype

### DIFF
--- a/Mathlib/Data/ZMod/Basic.lean
+++ b/Mathlib/Data/ZMod/Basic.lean
@@ -1223,7 +1223,7 @@ theorem lift_comp_castAddHom : (ZMod.lift n f).comp (Int.castAddHom (ZMod n)) = 
 
 end lift
 
-instance : (q : ℕ) → Fintype (ZMod q)ˣ
+instance (priority := 900) : (q : ℕ) → Fintype (ZMod q)ˣ
 | 0 => show Fintype ℤˣ from inferInstance
 | (_ + 1) => inferInstance
 

--- a/Mathlib/Data/ZMod/Basic.lean
+++ b/Mathlib/Data/ZMod/Basic.lean
@@ -1223,4 +1223,8 @@ theorem lift_comp_castAddHom : (ZMod.lift n f).comp (Int.castAddHom (ZMod n)) = 
 
 end lift
 
+instance : (q : ℕ) → Fintype (ZMod q)ˣ
+| 0 => show Fintype ℤˣ from inferInstance
+| (_ + 1) => inferInstance
+
 end ZMod

--- a/Mathlib/Data/ZMod/Basic.lean
+++ b/Mathlib/Data/ZMod/Basic.lean
@@ -1223,8 +1223,12 @@ theorem lift_comp_castAddHom : (ZMod.lift n f).comp (Int.castAddHom (ZMod n)) = 
 
 end lift
 
-instance (priority := 900) : (q : ℕ) → Fintype (ZMod q)ˣ
+instance (priority := 900) instFintypeUnits : (q : ℕ) → Fintype (ZMod q)ˣ
 | 0 => show Fintype ℤˣ from inferInstance
 | (_ + 1) => inferInstance
+
+example {q : ℕ} [NeZero q] : ZMod.instFintypeUnits q = _root_.instFintypeUnits := by
+  fail_if_success rfl -- The above causes an instance diamond
+  exact Subsingleton.elim _ _  -- but at lease propositionall they are equal
 
 end ZMod


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

This adds the instance that (Z/nZ)^* is finite for all n; the trick is that for n=0 Z/nZ is infinite but the units are finite anyway. However constructivist nonsense means that another proof in mathlib breaks:
```lean
theorem card_units (p : ℕ) [Fact p.Prime] : Fintype.card (ZMod p)ˣ = p - 1 := by
  rw [Fintype.card_units, card]
```
now no longer works. I fix this by reducing to 900 the priority of the instance I'm proposing to add.