### PR TITLE
[Merged by Bors] - perf (Data.Rat): reduce algebra instances for Rat

### DIFF
--- a/Mathlib/Data/Rat/Basic.lean
+++ b/Mathlib/Data/Rat/Basic.lean
@@ -36,16 +36,25 @@ rat, rationals, field, ℚ, numerator, denominator, num, denom
 namespace Rat
 
 instance field : Field ℚ :=
-  { Rat.commRing, Rat.commGroupWithZero with
-    zero := 0
-    add := (· + ·)
-    neg := Neg.neg
-    one := 1
-    mul := (· * ·)
-    inv := Inv.inv
+  { mul_inv_cancel := Rat.commGroupWithZero.mul_inv_cancel
+    inv_zero := Rat.commGroupWithZero.inv_zero
     ratCast := Rat.cast
     ratCast_mk := fun a b h1 h2 => (num_div_den _).symm
     qsmul := (· * ·) }
+
+-- instance og : Field ℚ :=
+--   { Rat.commRing, Rat.commGroupWithZero with
+--     zero := 0
+--     add := (· + ·)
+--     neg := Neg.neg
+--     one := 1
+--     mul := (· * ·)
+--     inv := Inv.inv
+--     ratCast := Rat.cast
+--     ratCast_mk := fun a b h1 h2 => (num_div_den _).symm
+--     qsmul := (· * ·) }
+--
+-- example : field = og := rfl
 
 -- Extra instances to short-circuit type class resolution
 instance divisionRing : DivisionRing ℚ := by infer_instance

--- a/Mathlib/Data/Rat/Basic.lean
+++ b/Mathlib/Data/Rat/Basic.lean
@@ -42,20 +42,6 @@ instance field : Field ℚ :=
     ratCast_mk := fun a b h1 h2 => (num_div_den _).symm
     qsmul := (· * ·) }
 
--- instance og : Field ℚ :=
---   { Rat.commRing, Rat.commGroupWithZero with
---     zero := 0
---     add := (· + ·)
---     neg := Neg.neg
---     one := 1
---     mul := (· * ·)
---     inv := Inv.inv
---     ratCast := Rat.cast
---     ratCast_mk := fun a b h1 h2 => (num_div_den _).symm
---     qsmul := (· * ·) }
---
--- example : field = og := rfl
-
 -- Extra instances to short-circuit type class resolution
 instance divisionRing : DivisionRing ℚ := by infer_instance
 

--- a/Mathlib/Data/Rat/Defs.lean
+++ b/Mathlib/Data/Rat/Defs.lean
@@ -327,13 +327,7 @@ instance commRing : CommRing ℚ where
       ← divInt_one_one, Nat.cast_add, Nat.cast_one, mul_one]
 
 instance commGroupWithZero : CommGroupWithZero ℚ :=
-  { Rat.commRing with
-    zero := 0
-    one := 1
-    mul := (· * ·)
-    inv := Inv.inv
-    div := (· / ·)
-    exists_pair_ne := ⟨0, 1, Rat.zero_ne_one⟩
+  { exists_pair_ne := ⟨0, 1, Rat.zero_ne_one⟩
     inv_zero := by
       change Rat.inv 0 = 0
       rw [Rat.inv_def]
@@ -341,6 +335,24 @@ instance commGroupWithZero : CommGroupWithZero ℚ :=
     mul_inv_cancel := Rat.mul_inv_cancel
     mul_zero := mul_zero
     zero_mul := zero_mul }
+
+-- instance commGroupWithZero' : CommGroupWithZero ℚ :=
+--   { Rat.commRing with
+--     zero := 0
+--     one := 1
+--     mul := (· * ·)
+--     inv := Inv.inv
+--     div := (· / ·)
+--     exists_pair_ne := ⟨0, 1, Rat.zero_ne_one⟩
+--     inv_zero := by
+--       change Rat.inv 0 = 0
+--       rw [Rat.inv_def]
+--       rfl
+--     mul_inv_cancel := Rat.mul_inv_cancel
+--     mul_zero := mul_zero
+--     zero_mul := zero_mul }
+--
+-- example : commGroupWithZero = commGroupWithZero' := rfl
 
 instance isDomain : IsDomain ℚ :=
   NoZeroDivisors.to_isDomain _

--- a/Mathlib/Data/Rat/Defs.lean
+++ b/Mathlib/Data/Rat/Defs.lean
@@ -336,24 +336,6 @@ instance commGroupWithZero : CommGroupWithZero ℚ :=
     mul_zero := mul_zero
     zero_mul := zero_mul }
 
--- instance commGroupWithZero' : CommGroupWithZero ℚ :=
---   { Rat.commRing with
---     zero := 0
---     one := 1
---     mul := (· * ·)
---     inv := Inv.inv
---     div := (· / ·)
---     exists_pair_ne := ⟨0, 1, Rat.zero_ne_one⟩
---     inv_zero := by
---       change Rat.inv 0 = 0
---       rw [Rat.inv_def]
---       rfl
---     mul_inv_cancel := Rat.mul_inv_cancel
---     mul_zero := mul_zero
---     zero_mul := zero_mul }
---
--- example : commGroupWithZero = commGroupWithZero' := rfl
-
 instance isDomain : IsDomain ℚ :=
   NoZeroDivisors.to_isDomain _
 


### PR DESCRIPTION
This removes the `with` pattern from the `Field` and `CommSemiGroupWithZero` instances on `Rat`.

The resulting term decreases in size by an order of magnitude (at least).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
