### PR TITLE
[Merged by Bors] - Use the IO.FS.rename to move file instead of relying on presence of mv program

### DIFF
--- a/Cache/IO.lean
+++ b/Cache/IO.lean
@@ -195,7 +195,7 @@ def validateLeanTar : IO Unit := do
     "-L", "-o", s!"{LEANTARBIN}.{ext}"]
   let _ ← runCmd "tar" #["-xf", s!"{LEANTARBIN}.{ext}",
     "-C", IO.CACHEDIR.toString, "--strip-components=1"]
-  let _ ← IO.FS.rename ((IO.CACHEDIR / s!"leantar{EXE}").toString) LEANTARBIN.toString
+  IO.FS.rename (IO.CACHEDIR / s!"leantar{EXE}").toString LEANTARBIN.toString
 
 /-- Recursively gets all files from a directory with a certain extension -/
 partial def getFilesWithExtension

--- a/Cache/IO.lean
+++ b/Cache/IO.lean
@@ -195,7 +195,7 @@ def validateLeanTar : IO Unit := do
     "-L", "-o", s!"{LEANTARBIN}.{ext}"]
   let _ ← runCmd "tar" #["-xf", s!"{LEANTARBIN}.{ext}",
     "-C", IO.CACHEDIR.toString, "--strip-components=1"]
-  let _ ← runCmd "mv" #[(IO.CACHEDIR / s!"leantar{EXE}").toString, LEANTARBIN.toString]
+  let _ ← IO.FS.rename ((IO.CACHEDIR / s!"leantar{EXE}").toString) LEANTARBIN.toString
 
 /-- Recursively gets all files from a directory with a certain extension -/
 partial def getFilesWithExtension


### PR DESCRIPTION
The Cache program after detecting that LeanTar is old downloads it and attempts to place it in the `CACHEDIR` directory. It then attempts to rename it using the `mv` command it assumes is present on the platform. On windows `cmd` and `powershell` this does not work since `mv` is actually a shell built in and not an executable. (This will however work on MinGW based shells).

@digama0 added the function `IO.FS.rename` in Lean [Lean4#2345](https://github.com/leanprover/lean4/pull/2345#issue-1816557709) which calls the standard C/C++ function `rename`. This PR uses this function to move leantar instead of the runCmd command. When this fix succeeds the output looks like the following (in powershell).

```text
PS W:\LeanStuff\graveyard_mathlib4\LeanCacheFix> lake exe cache get
leantar is too old; downloading more recent version
Attempting to download 3614 file(s)
Downloaded: 3614 file(s) [attempted 3614/3614 = 100%] (100% success)
Decompressing 3614 file(s)
unpacked in 323 ms
```

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
