### PR TITLE
[Merged by Bors] - fix(data/{Finset,Multiset}): better line breaks in Repr

### DIFF
--- a/Mathlib/Data/Finset/Sort.lean
+++ b/Mathlib/Data/Finset/Sort.lean
@@ -253,7 +253,9 @@ theorem orderEmbOfCardLe_mem (s : Finset α) {k : ℕ} (h : k ≤ s.card) (a) :
 
 end SortLinearOrder
 
-unsafe instance [Repr α] : Repr (Finset α) :=
-  ⟨fun s _ => repr s.1⟩
+unsafe instance [Repr α] : Repr (Finset α) where
+  reprPrec s _ :=
+    -- multiset uses `0` not `∅` for empty sets
+    if s.card = 0 then "∅" else repr s.1
 
 end Finset

--- a/Mathlib/Data/Multiset/Sort.lean
+++ b/Mathlib/Data/Multiset/Sort.lean
@@ -68,7 +68,11 @@ theorem sort_singleton (a : α) : sort r {a} = [a] :=
 end sort
 
 -- TODO: use a sort order if available, gh-18166
-unsafe instance [Repr α] : Repr (Multiset α) :=
-  ⟨fun s _ => "{" ++ Std.Format.joinSep (s.unquot.map repr) ", " ++ "}"⟩
+unsafe instance [Repr α] : Repr (Multiset α) where
+  reprPrec s _ :=
+    if Multiset.card s = 0 then
+      "0"
+    else
+      Std.Format.bracket "{" (Std.Format.joinSep (s.unquot.map repr) ("," ++ Std.Format.line)) "}"
 
 end Multiset

--- a/test/finset_repr.lean
+++ b/test/finset_repr.lean
@@ -1,0 +1,11 @@
+import Mathlib.Data.Finset.Sort
+
+#eval show Lean.MetaM Unit from guard <|
+  (repr (0 : Multiset (List ℕ)) |>.pretty 15) = "0"
+#eval show Lean.MetaM Unit from guard <|
+  (repr ({[1, 2, 3], [4, 5, 6]} : Multiset (List ℕ)) |>.pretty 15) = "{[1, 2, 3],\n [4, 5, 6]}"
+
+#eval show Lean.MetaM Unit from guard <|
+  (repr (∅ : Finset (List ℕ)) |>.pretty 15) = "∅"
+#eval show Lean.MetaM Unit from guard <|
+  (repr ({[1, 2, 3], [4, 5, 6]} : Finset (List ℕ)) |>.pretty 15) = "{[1, 2, 3],\n [4, 5, 6]}"


### PR DESCRIPTION
See the attached tests

Previously this gave `{[1, 2,\n 3], [4, 5, 6]}`, where the line break would be within items rather than between items.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
