### PR TITLE
[Merged by Bors] - chore(Algebra/Hom/GroupAction): add `initialize_simps_projections`

### DIFF
--- a/Mathlib/Algebra/Hom/GroupAction.lean
+++ b/Mathlib/Algebra/Hom/GroupAction.lean
@@ -181,7 +181,7 @@ def inverse (f : A →[M] B) (g : B → A) (h₁ : Function.LeftInverse g f)
       g (m • x) = g (m • f (g x)) := by rw [h₂]
       _ = g (f (m • g x)) := by rw [f.map_smul]
       _ = m • g x := by rw [h₁]
-#align mul_action_hom.inverse_to_fun MulActionHom.inverse_toFun
+#align mul_action_hom.inverse_to_fun MulActionHom.inverse_apply
 #align mul_action_hom.inverse MulActionHom.inverse
 
 end MulActionHom

--- a/Mathlib/Algebra/Hom/GroupAction.lean
+++ b/Mathlib/Algebra/Hom/GroupAction.lean
@@ -89,11 +89,12 @@ attribute [simp] map_smul
 -- porting note: removed has_coe_to_fun instance, coercions handled differently now
 #noalign mul_action_hom.has_coe_to_fun
 
-instance : SMulHomClass (X →[M'] Y) M' X Y
-    where
+instance : SMulHomClass (X →[M'] Y) M' X Y where
   coe := MulActionHom.toFun
   coe_injective' f g h := by cases f; cases g; congr
   map_smul := MulActionHom.map_smul'
+
+initialize_simps_projections MulActionHom (toFun → apply)
 
 namespace MulActionHom
 
@@ -173,8 +174,7 @@ variable {A B}
 /-- The inverse of a bijective equivariant map is equivariant. -/
 @[simps]
 def inverse (f : A →[M] B) (g : B → A) (h₁ : Function.LeftInverse g f)
-    (h₂ : Function.RightInverse g f) : B →[M] A
-    where
+    (h₂ : Function.RightInverse g f) : B →[M] A where
   toFun := g
   map_smul' m x :=
     calc
@@ -242,8 +242,7 @@ Coercion is already handled by all the HomClass constructions I believe -/
 #noalign distrib_mul_action_hom.has_coe'
 #noalign distrib_mul_action_hom.has_coe_to_fun
 
-instance : DistribMulActionHomClass (A →+[M] B) M A B
-    where
+instance : DistribMulActionHomClass (A →+[M] B) M A B where
   coe m := m.toFun
   coe_injective' f g h := by
     rcases f with ⟨tF, _, _⟩; rcases g with ⟨tG, _, _⟩
@@ -251,6 +250,8 @@ instance : DistribMulActionHomClass (A →+[M] B) M A B
   map_smul m := m.map_smul'
   map_zero := DistribMulActionHom.map_zero'
   map_add := DistribMulActionHom.map_add'
+
+initialize_simps_projections DistribMulActionHom (toFun → apply)
 
 variable {M A B}
 /- porting note: inserted following def & instance for consistent coercion behaviour,
@@ -473,8 +474,7 @@ Coercion is already handled by all the HomClass constructions I believe -/
 #noalign mul_semiring_action_hom.has_coe'
 #noalign mul_semiring_action_hom.has_coe_to_fun
 
-instance : MulSemiringActionHomClass (R →+*[M] S) M R S
-    where
+instance : MulSemiringActionHomClass (R →+*[M] S) M R S where
   coe m := m.toFun
   coe_injective' f g h := by
     rcases f with ⟨⟨tF, _, _⟩, _, _⟩; rcases g with ⟨⟨tG, _, _⟩, _, _⟩
@@ -484,6 +484,8 @@ instance : MulSemiringActionHomClass (R →+*[M] S) M R S
   map_add m := m.map_add'
   map_one := MulSemiringActionHom.map_one'
   map_mul := MulSemiringActionHom.map_mul'
+
+initialize_simps_projections MulSemiringActionHom (toFun → apply)
 
 variable {M R S}
 


### PR DESCRIPTION
Without this change the lemmas were called `*_toFun` instead of `*_apply`.

These lines should go immediately after the (transitive) `FunLike` instance is configured.

This PR also tidies some whitespace around `where`s.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
