### PR TITLE
[Merged by Bors] - fix: Mathlib/Control/ULiftable doc typos

### DIFF
--- a/Mathlib/Control/ULiftable.lean
+++ b/Mathlib/Control/ULiftable.lean
@@ -48,7 +48,7 @@ class ULiftable (f : Type u₀ → Type u₁) (g : Type v₀ → Type v₁) wher
 
 namespace ULiftable
 
-/-- The most common practical use `ULiftable` (together with `up`), this function takes
+/-- The most common practical use `ULiftable` (together with `down`), this function takes
 `x : M.{u} α` and lifts it to `M.{max u v} (ULift.{v} α)` -/
 @[reducible]
 def up {f : Type u₀ → Type u₁} {g : Type max u₀ v₀ → Type v₁} [ULiftable f g] {α} :
@@ -57,7 +57,7 @@ def up {f : Type u₀ → Type u₁} {g : Type max u₀ v₀ → Type v₁} [ULi
 #align uliftable.up ULiftable.up
 
 /-- The most common practical use of `ULiftable` (together with `up`), this function takes
-`x : M.{max u v} (ulift.{v} α)` and lowers it to `M.{u} α` -/
+`x : M.{max u v} (ULift.{v} α)` and lowers it to `M.{u} α` -/
 @[reducible]
 def down {f : Type u₀ → Type u₁} {g : Type max u₀ v₀ → Type v₁} [ULiftable f g] {α} :
     g (ULift.{v₀} α) → f α :=


### PR DESCRIPTION
small typos in docstrings

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
