### PR TITLE
[Merged by Bors] - feat: Rank of a hermitian matrix is the count of non-zero eigenvalues

### DIFF
--- a/Mathlib/Data/Matrix/Rank.lean
+++ b/Mathlib/Data/Matrix/Rank.lean
@@ -8,7 +8,9 @@ import Mathlib.LinearAlgebra.Matrix.ToLin
 import Mathlib.LinearAlgebra.FiniteDimensional
 import Mathlib.LinearAlgebra.Matrix.DotProduct
 import Mathlib.LinearAlgebra.Determinant
+import Mathlib.LinearAlgebra.Matrix.Diagonal
 import Mathlib.Data.Complex.Module
+
 
 #align_import data.matrix.rank from "leanprover-community/mathlib"@"17219820a8aa8abe85adf5dfde19af1dd1bd8ae7"
 
@@ -198,6 +200,16 @@ proof that is a simple consequence of `Matrix.rank_transpose_mul_self` and
 be replaced with a proof that uses Gaussian reduction or argues via linear combinations.
 -/
 
+section Field
+
+variable  [Field R]
+/-- The rank of a diagnonal matrix  is the count of non-zero elements on its main diagonal -/
+theorem rank_diagonal [DecidableEq m] [DecidableEq R] (w : m → R) :
+    ((Matrix.diagonal w).rank) = (Fintype.card {i // (w i) ≠ 0}) := by
+  rw [Matrix.rank, ← Matrix.toLin'_apply', FiniteDimensional.finrank, ← LinearMap.rank,
+    LinearMap.rank_diagonal, Cardinal.toNat_cast]
+
+end Field
 
 section StarOrderedField
 

--- a/Mathlib/Data/Matrix/Rank.lean
+++ b/Mathlib/Data/Matrix/Rank.lean
@@ -187,9 +187,9 @@ end CommRing
 
 section Field
 
-variable  [Field R]
+variable [Field R]
 
-/-- The rank of a diagnonal matrix  is the count of non-zero elements on its main diagonal -/
+/-- The rank of a diagnonal matrix is the count of non-zero elements on its main diagonal -/
 theorem rank_diagonal [DecidableEq m] [DecidableEq R] (w : m → R) :
     (diagonal w).rank = Fintype.card {i // (w i) ≠ 0} := by
   rw [Matrix.rank, ← Matrix.toLin'_apply', FiniteDimensional.finrank, ← LinearMap.rank,

--- a/Mathlib/Data/Matrix/Rank.lean
+++ b/Mathlib/Data/Matrix/Rank.lean
@@ -191,7 +191,7 @@ variable  [Field R]
 
 /-- The rank of a diagnonal matrix  is the count of non-zero elements on its main diagonal -/
 theorem rank_diagonal [DecidableEq m] [DecidableEq R] (w : m → R) :
-    ((Matrix.diagonal w).rank) = (Fintype.card {i // (w i) ≠ 0}) := by
+    (diagonal w).rank = Fintype.card {i // (w i) ≠ 0} := by
   rw [Matrix.rank, ← Matrix.toLin'_apply', FiniteDimensional.finrank, ← LinearMap.rank,
     LinearMap.rank_diagonal, Cardinal.toNat_cast]
 

--- a/Mathlib/Data/Matrix/Rank.lean
+++ b/Mathlib/Data/Matrix/Rank.lean
@@ -11,7 +11,6 @@ import Mathlib.LinearAlgebra.Determinant
 import Mathlib.LinearAlgebra.Matrix.Diagonal
 import Mathlib.Data.Complex.Module
 
-
 #align_import data.matrix.rank from "leanprover-community/mathlib"@"17219820a8aa8abe85adf5dfde19af1dd1bd8ae7"
 
 /-!
@@ -186,6 +185,18 @@ theorem rank_eq_finrank_span_cols (A : Matrix m n R) :
 
 end CommRing
 
+section Field
+
+variable  [Field R]
+
+/-- The rank of a diagnonal matrix  is the count of non-zero elements on its main diagonal -/
+theorem rank_diagonal [DecidableEq m] [DecidableEq R] (w : m → R) :
+    ((Matrix.diagonal w).rank) = (Fintype.card {i // (w i) ≠ 0}) := by
+  rw [Matrix.rank, ← Matrix.toLin'_apply', FiniteDimensional.finrank, ← LinearMap.rank,
+    LinearMap.rank_diagonal, Cardinal.toNat_cast]
+
+end Field
+
 /-! ### Lemmas about transpose and conjugate transpose
 
 This section contains lemmas about the rank of `Matrix.transpose` and `Matrix.conjTranspose`.
@@ -199,17 +210,6 @@ proof that is a simple consequence of `Matrix.rank_transpose_mul_self` and
 `Matrix.rank_conjTranspose_mul_self`. This proof pulls in unnecessary assumptions on `R`, and should
 be replaced with a proof that uses Gaussian reduction or argues via linear combinations.
 -/
-
-section Field
-
-variable  [Field R]
-/-- The rank of a diagnonal matrix  is the count of non-zero elements on its main diagonal -/
-theorem rank_diagonal [DecidableEq m] [DecidableEq R] (w : m → R) :
-    ((Matrix.diagonal w).rank) = (Fintype.card {i // (w i) ≠ 0}) := by
-  rw [Matrix.rank, ← Matrix.toLin'_apply', FiniteDimensional.finrank, ← LinearMap.rank,
-    LinearMap.rank_diagonal, Cardinal.toNat_cast]
-
-end Field
 
 section StarOrderedField
 

--- a/Mathlib/LinearAlgebra/Matrix/Diagonal.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Diagonal.lean
@@ -1,10 +1,11 @@
 /-
 Copyright (c) 2019 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Johannes Hölzl, Patrick Massot, Casper Putz, Anne Baanen
+Authors: Johannes Hölzl, Patrick Massot, Casper Putz, Anne Baanen, Mohanad Ahmed
 -/
 import Mathlib.LinearAlgebra.Matrix.ToLin
 import Mathlib.LinearAlgebra.FreeModule.Rank
+import Mathlib.Data.Matrix.Rank
 
 #align_import linear_algebra.matrix.diagonal from "leanprover-community/mathlib"@"b1c23399f01266afe392a0d8f71f599a0dad4f7b"
 
@@ -76,20 +77,39 @@ theorem range_diagonal [DecidableEq m] (w : m → K) :
 
 end Semifield
 
+end Matrix
+
+namespace LinearMap
+
 section Field
 
 variable {m n : Type _} [Fintype m] [Fintype n] {K : Type u} [Field K]
 
 theorem rank_diagonal [DecidableEq m] [DecidableEq K] (w : m → K) :
-    rank (toLin' (diagonal w)) = Fintype.card { i // w i ≠ 0 } := by
+    LinearMap.rank (toLin' (diagonal w)) = Fintype.card { i // w i ≠ 0 } := by
   have hu : univ ⊆ { i : m | w i = 0 }ᶜ ∪ { i : m | w i = 0 } := by rw [Set.compl_union_self]
   have hd : Disjoint { i : m | w i ≠ 0 } { i : m | w i = 0 } := disjoint_compl_left
   have B₁ := iSup_range_stdBasis_eq_iInf_ker_proj K (fun _ : m => K) hd hu (Set.toFinite _)
   have B₂ := iInfKerProjEquiv K (fun _ ↦ K) hd hu
-  rw [rank, range_diagonal, B₁, ← @rank_fun' K]
+  rw [LinearMap.rank, range_diagonal, B₁, ← @rank_fun' K]
   apply LinearEquiv.rank_eq
   apply B₂
-#align matrix.rank_diagonal Matrix.rank_diagonal
+#align matrix.rank_diagonal LinearMap.rank_diagonal
+
+end Field
+
+end LinearMap
+
+namespace Matrix
+
+section Field
+
+variable {m n : Type _} [Fintype m] [Fintype n] {K : Type u} [Field K]
+/-- The rank of a diagnonal matrix  is the count of non-zero elements on its main diagonal -/
+theorem rank_diagonal [DecidableEq m] [DecidableEq K] (w : m → K) :
+    ((Matrix.diagonal w).rank) = (Fintype.card {i // (w i) ≠ 0}) := by
+  rw [Matrix.rank, ← Matrix.toLin'_apply', FiniteDimensional.finrank, ← LinearMap.rank,
+    LinearMap.rank_diagonal, Cardinal.toNat_cast]
 
 end Field
 

--- a/Mathlib/LinearAlgebra/Matrix/Diagonal.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Diagonal.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2019 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Johannes Hölzl, Patrick Massot, Casper Putz, Anne Baanen, Mohanad Ahmed
+Authors: Johannes Hölzl, Patrick Massot, Casper Putz, Anne Baanen
 -/
 import Mathlib.LinearAlgebra.Matrix.ToLin
 import Mathlib.LinearAlgebra.FreeModule.Rank

--- a/Mathlib/LinearAlgebra/Matrix/Diagonal.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Diagonal.lean
@@ -5,7 +5,6 @@ Authors: Johannes Hölzl, Patrick Massot, Casper Putz, Anne Baanen, Mohanad Ahme
 -/
 import Mathlib.LinearAlgebra.Matrix.ToLin
 import Mathlib.LinearAlgebra.FreeModule.Rank
-import Mathlib.Data.Matrix.Rank
 
 #align_import linear_algebra.matrix.diagonal from "leanprover-community/mathlib"@"b1c23399f01266afe392a0d8f71f599a0dad4f7b"
 
@@ -99,18 +98,3 @@ theorem rank_diagonal [DecidableEq m] [DecidableEq K] (w : m → K) :
 end Field
 
 end LinearMap
-
-namespace Matrix
-
-section Field
-
-variable {m n : Type _} [Fintype m] [Fintype n] {K : Type u} [Field K]
-/-- The rank of a diagnonal matrix  is the count of non-zero elements on its main diagonal -/
-theorem rank_diagonal [DecidableEq m] [DecidableEq K] (w : m → K) :
-    ((Matrix.diagonal w).rank) = (Fintype.card {i // (w i) ≠ 0}) := by
-  rw [Matrix.rank, ← Matrix.toLin'_apply', FiniteDimensional.finrank, ← LinearMap.rank,
-    LinearMap.rank_diagonal, Cardinal.toNat_cast]
-
-end Field
-
-end Matrix

--- a/Mathlib/LinearAlgebra/Matrix/Spectrum.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Spectrum.lean
@@ -135,7 +135,7 @@ theorem det_eq_prod_eigenvalues : det A = ∏ i, (hA.eigenvalues i : 𝕜) := by
   simp_rw [Function.comp_apply]
 #align matrix.is_hermitian.det_eq_prod_eigenvalues Matrix.IsHermitian.det_eq_prod_eigenvalues
 
-/-- *spectral theorem (alternate)* (Alternate from for convenience) A hermitian matrix can be can be
+/-- *spectral theorem* (Alternate form for convenience) A hermitian matrix can be can be
 replaced by a diagonal matrix sandwiched between the eigenvector matrices. This alternate form
 allows direct rewriting of A since: $ A = V D V⁻¹$ -/
 lemma spectral_theorem' :

--- a/Mathlib/LinearAlgebra/Matrix/Spectrum.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Spectrum.lean
@@ -142,7 +142,7 @@ allows direct rewriting of A since: $ A = V D V⁻¹$ -/
 lemma spectral_theorem' :
     A = hA.eigenvectorMatrix ⬝ diagonal ((↑) ∘ hA.eigenvalues) ⬝ hA.eigenvectorMatrixInv := by
   simpa [ ← Matrix.mul_assoc, hA.eigenvectorMatrix_mul_inv, Matrix.one_mul] using
-    (congr_arg (λ x => hA.eigenvectorMatrix ⬝  x) (hA.spectral_theorem))
+    congr_arg (fun x => hA.eigenvectorMatrix ⬝ x) hA.spectral_theorem
 
 /-- rank of a hermitian matrix is the rank of after diagonalization by the eigenvector matrix -/
 lemma rank_eq_rank_diagonal : A.rank = (Matrix.diagonal hA.eigenvalues).rank := by

--- a/Mathlib/LinearAlgebra/Matrix/Spectrum.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Spectrum.lean
@@ -134,10 +134,9 @@ theorem det_eq_prod_eigenvalues : det A = ∏ i, (hA.eigenvalues i : 𝕜) := by
   simp_rw [Function.comp_apply]
 #align matrix.is_hermitian.det_eq_prod_eigenvalues Matrix.IsHermitian.det_eq_prod_eigenvalues
 
-/-- *spectral theorem (alternate)* (Alternate from for convenience) A hermitian matrix can be can be replaced by
-a diagonal matrix sandwiched between the eigenvector matrices. This alternate form allows direct
-rewriting of A since:
-$ A = V D V⁻¹$ -/
+/-- *spectral theorem (alternate)* (Alternate from for convenience) A hermitian matrix can be can be
+replaced by a diagonal matrix sandwiched between the eigenvector matrices. This alternate form
+allows direct rewriting of A since: $ A = V D V⁻¹$ -/
 lemma spectral_theorem' : A = (hA.eigenvectorMatrix) ⬝
     ((Matrix.diagonal (IsROrC.ofReal ∘ hA.eigenvalues)) ⬝ hA.eigenvectorMatrixInv) := by
   simpa [ ← Matrix.mul_assoc, hA.eigenvectorMatrix_mul_inv, Matrix.one_mul] using

--- a/Mathlib/LinearAlgebra/Matrix/Spectrum.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Spectrum.lean
@@ -3,11 +3,10 @@ Copyright (c) 2022 Alexander Bentkamp. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Alexander Bentkamp
 -/
-import Mathlib.Data.Matrix.Rank
 import Mathlib.Analysis.InnerProductSpace.Spectrum
-import Mathlib.LinearAlgebra.Matrix.Hermitian
+import Mathlib.Data.Matrix.Rank
 import Mathlib.LinearAlgebra.Matrix.Diagonal
-
+import Mathlib.LinearAlgebra.Matrix.Hermitian
 
 #align_import linear_algebra.matrix.spectrum from "leanprover-community/mathlib"@"46b633fd842bef9469441c0209906f6dddd2b4f5"
 

--- a/Mathlib/LinearAlgebra/Matrix/Spectrum.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Spectrum.lean
@@ -5,6 +5,7 @@ Authors: Alexander Bentkamp
 -/
 import Mathlib.Analysis.InnerProductSpace.Spectrum
 import Mathlib.LinearAlgebra.Matrix.Hermitian
+import Mathlib.LinearAlgebra.Matrix.Diagonal
 
 #align_import linear_algebra.matrix.spectrum from "leanprover-community/mathlib"@"46b633fd842bef9469441c0209906f6dddd2b4f5"
 
@@ -132,6 +133,29 @@ theorem det_eq_prod_eigenvalues : det A = ∏ i, (hA.eigenvalues i : 𝕜) := by
   rw [← det_mul, spectral_theorem, det_mul, mul_comm, det_diagonal]
   simp_rw [Function.comp_apply]
 #align matrix.is_hermitian.det_eq_prod_eigenvalues Matrix.IsHermitian.det_eq_prod_eigenvalues
+
+/-- *spectral theorem (alternate)* (Alternate from for convenience) A hermitian matrix can be can be replaced by
+a diagonal matrix sandwiched between the eigenvector matrices. This alternate form allows direct
+rewriting of A since:
+$ A = V D V⁻¹$ -/
+lemma spectral_theorem' : A = (hA.eigenvectorMatrix) ⬝
+    ((Matrix.diagonal (IsROrC.ofReal ∘ hA.eigenvalues)) ⬝ hA.eigenvectorMatrixInv) := by
+  simpa [ ← Matrix.mul_assoc, hA.eigenvectorMatrix_mul_inv, Matrix.one_mul] using
+    (congr_arg (λ x => hA.eigenvectorMatrix ⬝  x) (hA.spectral_theorem))
+
+/-- rank of a hermitian matrix is the rank of after diagonalization by the eigenvector matrix -/
+lemma rank_eq_rank_diagonal : A.rank = (Matrix.diagonal (hA.eigenvalues)).rank := by
+  /- Use nth_rewrite to avoid motive is not type correct error and conv tactic !!! -/
+  nth_rewrite 1 [hA.spectral_theorem']
+  have hE := isUnit_det_of_invertible (hA.eigenvectorMatrix)
+  have hiE := isUnit_det_of_invertible (hA.eigenvectorMatrixInv)
+  simp only [rank_mul_eq_right_of_isUnit_det hA.eigenvectorMatrix _ hE,
+    rank_mul_eq_left_of_isUnit_det hA.eigenvectorMatrixInv _ hiE,
+    rank_diagonal, Function.comp_apply, ne_eq, algebraMap.lift_map_eq_zero_iff]
+
+/-- rank of a hermitian matrix is the number of nonzero eigenvalues of the hermitian matrix -/
+lemma rank_eq_count_non_zero_eigs : A.rank =  (Fintype.card {i // hA.eigenvalues i ≠ 0}) := by
+  rw [rank_eq_rank_diagonal hA, Matrix.rank_diagonal]
 
 end IsHermitian
 

--- a/Mathlib/LinearAlgebra/Matrix/Spectrum.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Spectrum.lean
@@ -141,12 +141,11 @@ allows direct rewriting of A since: $ A = V D V⁻¹$ -/
 lemma spectral_theorem' :
     A = hA.eigenvectorMatrix ⬝ diagonal ((↑) ∘ hA.eigenvalues) ⬝ hA.eigenvectorMatrixInv := by
   simpa [ ← Matrix.mul_assoc, hA.eigenvectorMatrix_mul_inv, Matrix.one_mul] using
-    congr_arg (fun x => hA.eigenvectorMatrix ⬝ x) hA.spectral_theorem
+    congr_arg (hA.eigenvectorMatrix ⬝ ·) hA.spectral_theorem
 
 /-- rank of a hermitian matrix is the rank of after diagonalization by the eigenvector matrix -/
 lemma rank_eq_rank_diagonal : A.rank = (Matrix.diagonal hA.eigenvalues).rank := by
-  /- Use nth_rewrite to avoid motive is not type correct error and conv tactic !!! -/
-  nth_rewrite 1 [hA.spectral_theorem']
+  conv_lhs => rw [hA.spectral_theorem']
   have hE := isUnit_det_of_invertible (hA.eigenvectorMatrix)
   have hiE := isUnit_det_of_invertible (hA.eigenvectorMatrixInv)
   simp only [rank_mul_eq_right_of_isUnit_det hA.eigenvectorMatrix _ hE,
@@ -154,7 +153,7 @@ lemma rank_eq_rank_diagonal : A.rank = (Matrix.diagonal hA.eigenvalues).rank := 
     rank_diagonal, Function.comp_apply, ne_eq, algebraMap.lift_map_eq_zero_iff]
 
 /-- rank of a hermitian matrix is the number of nonzero eigenvalues of the hermitian matrix -/
-lemma rank_eq_count_non_zero_eigs : A.rank = Fintype.card {i // hA.eigenvalues i ≠ 0} := by
+lemma rank_eq_card_non_zero_eigs : A.rank = Fintype.card {i // hA.eigenvalues i ≠ 0} := by
   rw [rank_eq_rank_diagonal hA, Matrix.rank_diagonal]
 
 end IsHermitian

--- a/Mathlib/LinearAlgebra/Matrix/Spectrum.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Spectrum.lean
@@ -143,7 +143,7 @@ lemma spectral_theorem' :
     (congr_arg (λ x => hA.eigenvectorMatrix ⬝  x) (hA.spectral_theorem))
 
 /-- rank of a hermitian matrix is the rank of after diagonalization by the eigenvector matrix -/
-lemma rank_eq_rank_diagonal : A.rank = (Matrix.diagonal (hA.eigenvalues)).rank := by
+lemma rank_eq_rank_diagonal : A.rank = (Matrix.diagonal hA.eigenvalues).rank := by
   /- Use nth_rewrite to avoid motive is not type correct error and conv tactic !!! -/
   nth_rewrite 1 [hA.spectral_theorem']
   have hE := isUnit_det_of_invertible (hA.eigenvectorMatrix)

--- a/Mathlib/LinearAlgebra/Matrix/Spectrum.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Spectrum.lean
@@ -3,9 +3,11 @@ Copyright (c) 2022 Alexander Bentkamp. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Alexander Bentkamp
 -/
+import Mathlib.Data.Matrix.Rank
 import Mathlib.Analysis.InnerProductSpace.Spectrum
 import Mathlib.LinearAlgebra.Matrix.Hermitian
 import Mathlib.LinearAlgebra.Matrix.Diagonal
+
 
 #align_import linear_algebra.matrix.spectrum from "leanprover-community/mathlib"@"46b633fd842bef9469441c0209906f6dddd2b4f5"
 

--- a/Mathlib/LinearAlgebra/Matrix/Spectrum.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Spectrum.lean
@@ -137,8 +137,8 @@ theorem det_eq_prod_eigenvalues : det A = ∏ i, (hA.eigenvalues i : 𝕜) := by
 /-- *spectral theorem (alternate)* (Alternate from for convenience) A hermitian matrix can be can be
 replaced by a diagonal matrix sandwiched between the eigenvector matrices. This alternate form
 allows direct rewriting of A since: $ A = V D V⁻¹$ -/
-lemma spectral_theorem' : A = (hA.eigenvectorMatrix) ⬝
-    ((Matrix.diagonal (IsROrC.ofReal ∘ hA.eigenvalues)) ⬝ hA.eigenvectorMatrixInv) := by
+lemma spectral_theorem' :
+    A = hA.eigenvectorMatrix ⬝ diagonal ((↑) ∘ hA.eigenvalues) ⬝ hA.eigenvectorMatrixInv := by
   simpa [ ← Matrix.mul_assoc, hA.eigenvectorMatrix_mul_inv, Matrix.one_mul] using
     (congr_arg (λ x => hA.eigenvectorMatrix ⬝  x) (hA.spectral_theorem))
 
@@ -153,7 +153,7 @@ lemma rank_eq_rank_diagonal : A.rank = (Matrix.diagonal (hA.eigenvalues)).rank :
     rank_diagonal, Function.comp_apply, ne_eq, algebraMap.lift_map_eq_zero_iff]
 
 /-- rank of a hermitian matrix is the number of nonzero eigenvalues of the hermitian matrix -/
-lemma rank_eq_count_non_zero_eigs : A.rank =  (Fintype.card {i // hA.eigenvalues i ≠ 0}) := by
+lemma rank_eq_count_non_zero_eigs : A.rank = Fintype.card {i // hA.eigenvalues i ≠ 0} := by
   rw [rank_eq_rank_diagonal hA, Matrix.rank_diagonal]
 
 end IsHermitian


### PR DESCRIPTION
This PR provides the lemmas:

- `IsHermitian.spectral_theorem'`: a slightly modified spectral_theorem such that the hermitian matrix can be directly replaced.
$$A = VDV^{-1}\quad D = \text{diag}(d)$$
- `IsHermitian.rank_eq_count_non_zero_eigs`: the rank of a hermitian matrix is the number of non-zero eigenvalues of that matrix
$$\text{rank}(A) = \text{card} \lbrace \quad i \quad | \quad d_i \neq 0 \rbrace$$
- `IsHermitian.rank_eq_rank_diagonal`: the rank of a hermitian matrix is the same as its rank after diagonalization by the eigenvector matrix
$$\text{rank}(A) = \text{rank}(D)$$
- `Matrix.rank_diagonal`: the rank of a diagonal matrix is the number of non-zero diagonal elements. Note that this was previously the name of a lemma about LinearMaps we take that name (but keep the align to avoid disrupting the tooling).
$$\text{rank}(V)  = \text{Diag}(v) \implies \text{rank}(V) = \text{card} \lbrace \quad i \quad | \quad v_i \neq 0 \rbrace$$
- `LinearMap.rank_diagonal`: the rank of a linear map that is formed from a diagonal matrix is the number of non-zero diagonal entries. This was previously called `Matrix.rank_diagonal`.

Co-authored-by: Mohanad Ahmed <m.a.m.elhassan@gmail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
