### PR TITLE
[Merged by Bors] - feat(Algebra/Order/LatticeGroup): Add missing `abs_inv` to LatticeGroup

### DIFF
--- a/Mathlib/Algebra/Order/LatticeGroup.lean
+++ b/Mathlib/Algebra/Order/LatticeGroup.lean
@@ -189,7 +189,7 @@ theorem inv_le_abs (a : α) : a⁻¹ ≤ |a| :=
 #align lattice_ordered_comm_group.inv_le_abs LatticeOrderedCommGroup.inv_le_abs
 #align lattice_ordered_comm_group.neg_le_abs LatticeOrderedCommGroup.neg_le_abs
 
-@[to_additive]
+@[to_additive (attr := simp)]
 theorem abs_inv (a : α) : |a⁻¹| = |a| := calc
   |a⁻¹| = a⁻¹ ⊔ (a⁻¹)⁻¹ := rfl
   _ = a ⊔ a⁻¹ := by rw [inv_inv, sup_comm]

--- a/Mathlib/Algebra/Order/LatticeGroup.lean
+++ b/Mathlib/Algebra/Order/LatticeGroup.lean
@@ -189,6 +189,11 @@ theorem inv_le_abs (a : α) : a⁻¹ ≤ |a| :=
 #align lattice_ordered_comm_group.inv_le_abs LatticeOrderedCommGroup.inv_le_abs
 #align lattice_ordered_comm_group.neg_le_abs LatticeOrderedCommGroup.neg_le_abs
 
+@[to_additive]
+theorem abs_inv (a : α) : |a⁻¹| = |a| := calc
+  |a⁻¹| = a⁻¹ ⊔ (a⁻¹)⁻¹ := rfl
+  _ = a ⊔ a⁻¹ := by rw [inv_inv, sup_comm]
+
 -- 0 ≤ a⁺
 @[to_additive pos_nonneg]
 theorem one_le_pos (a : α) : 1 ≤ a⁺ :=


### PR DESCRIPTION
Adds missing `abs_inv` to LatticeGroup

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
