### PR TITLE
[Merged by Bors] - ConjTranspose multiplication of a matrix by itself is Positive Semidefinite

### DIFF
--- a/Mathlib/Data/IsROrC/Basic.lean
+++ b/Mathlib/Data/IsROrC/Basic.lean
@@ -291,6 +291,14 @@ theorem norm_ofReal (r : ℝ) : ‖(r : K)‖ = |r| :=
   norm_algebraMap' K r
 #align is_R_or_C.norm_of_real IsROrC.norm_ofReal
 
+@[simp, isROrC_simps]
+theorem re_sum (f : n → K) : IsROrC.re (∑ i in s, f i) = ∑ i in s, IsROrC.re (f i) := by
+  apply map_sum _ _
+
+@[simp, isROrC_simps]
+theorem im_sum (f : n → K) : IsROrC.im (∑ i in s, f i) = ∑ i in s, IsROrC.im (f i) := by
+  apply map_sum _ _
+
 /-! ### Characteristic zero -/
 
 -- see Note [lower instance priority]

--- a/Mathlib/Data/IsROrC/Basic.lean
+++ b/Mathlib/Data/IsROrC/Basic.lean
@@ -291,14 +291,6 @@ theorem norm_ofReal (r : ℝ) : ‖(r : K)‖ = |r| :=
   norm_algebraMap' K r
 #align is_R_or_C.norm_of_real IsROrC.norm_ofReal
 
-@[simp, isROrC_simps]
-theorem re_sum (f : n → K) : IsROrC.re (∑ i in s, f i) = ∑ i in s, IsROrC.re (f i) := by
-  apply map_sum _ _
-
-@[simp, isROrC_simps]
-theorem im_sum (f : n → K) : IsROrC.im (∑ i in s, f i) = ∑ i in s, IsROrC.im (f i) := by
-  apply map_sum _ _
-
 /-! ### Characteristic zero -/
 
 -- see Note [lower instance priority]

--- a/Mathlib/LinearAlgebra/Matrix/PosDef.lean
+++ b/Mathlib/LinearAlgebra/Matrix/PosDef.lean
@@ -3,7 +3,6 @@ Copyright (c) 2022 Alexander Bentkamp. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Alexander Bentkamp, Mohanad Ahmed
 -/
-import Mathlib.Data.IsROrC.Basic
 import Mathlib.LinearAlgebra.Matrix.Spectrum
 import Mathlib.LinearAlgebra.QuadraticForm.Basic
 
@@ -94,11 +93,9 @@ theorem posDef_toQuadraticForm' [DecidableEq n] {M : Matrix n n ℝ} (hM : M.Pos
   apply hM.2 x hx
 #align matrix.pos_def_to_quadratic_form' Matrix.posDef_toQuadraticForm'
 
-section ConjTransposeMul
-
 /-- The conjugate transpose of a matrix mulitplied by the matrix is positive semidefinite -/
 theorem posSemidef_conjTranspose_mul_self (A : Matrix m n 𝕜) : Matrix.PosSemidef (Aᴴ ⬝ A) := by
-  refine ⟨ isHermitian_transpose_mul_self _, fun x => ?_ ⟩
+  refine ⟨isHermitian_transpose_mul_self _, fun x => ?_⟩
   rw [← mulVec_mulVec, dotProduct_mulVec, vecMul_conjTranspose, star_star, dotProduct, map_sum]
   simpa [Pi.star_apply, IsROrC.star_def, IsROrC.mul_re, IsROrC.conj_re, IsROrC.conj_im, neg_mul,
     sub_neg_eq_add] using
@@ -107,8 +104,6 @@ theorem posSemidef_conjTranspose_mul_self (A : Matrix m n 𝕜) : Matrix.PosSemi
 /-- A matrix multiplied by its conjugate transpose is positive semidefinite -/
 theorem posSemidef_self_mul_conjTranspose (A : Matrix m n 𝕜) : Matrix.PosSemidef (A ⬝ Aᴴ) :=
   by simpa only [conjTranspose_conjTranspose] using posSemidef_conjTranspose_mul_self Aᴴ
-
-end ConjTransposeMul
 
 namespace PosDef
 

--- a/Mathlib/LinearAlgebra/Matrix/PosDef.lean
+++ b/Mathlib/LinearAlgebra/Matrix/PosDef.lean
@@ -182,7 +182,6 @@ theorem isPosSemidef_conjTranspose_mul_self (A : Matrix m n 𝕜) : Matrix.PosSe
 
 /-- A matrix multiplied by its conjugate transpose is positive semidefinite -/
 theorem isPosSemidef_self_mul_conjTranspose (A : Matrix m n 𝕜) : Matrix.PosSemidef (A ⬝ Aᴴ) := by
-  -- refine ⟨ isHermitian_mul_conjTranspose_self _, fun x => ?_ ⟩
   nth_rewrite 1 [← conjTranspose_conjTranspose A]
   apply isPosSemidef_conjTranspose_mul_self
 

--- a/Mathlib/LinearAlgebra/Matrix/PosDef.lean
+++ b/Mathlib/LinearAlgebra/Matrix/PosDef.lean
@@ -97,9 +97,10 @@ theorem posDef_toQuadraticForm' [DecidableEq n] {M : Matrix n n ℝ} (hM : M.Pos
 theorem posSemidef_conjTranspose_mul_self (A : Matrix m n 𝕜) : Matrix.PosSemidef (Aᴴ ⬝ A) := by
   refine ⟨isHermitian_transpose_mul_self _, fun x => ?_⟩
   rw [← mulVec_mulVec, dotProduct_mulVec, vecMul_conjTranspose, star_star, dotProduct, map_sum]
-  simpa [Pi.star_apply, IsROrC.star_def, IsROrC.mul_re, IsROrC.conj_re, IsROrC.conj_im, neg_mul,
-    sub_neg_eq_add] using
-  Finset.sum_nonneg (fun i => (fun _ => add_nonneg (mul_self_nonneg _) (mul_self_nonneg _)))
+  simp_rw [Pi.star_apply, IsROrC.star_def]
+  refine Finset.sum_nonneg fun i _ => ?_
+  -- TODO: use a `StarOrderedRing` lemma
+  simpa using add_nonneg (mul_self_nonneg _) (mul_self_nonneg _)
 
 /-- A matrix multiplied by its conjugate transpose is positive semidefinite -/
 theorem posSemidef_self_mul_conjTranspose (A : Matrix m n 𝕜) : Matrix.PosSemidef (A ⬝ Aᴴ) :=

--- a/Mathlib/LinearAlgebra/Matrix/PosDef.lean
+++ b/Mathlib/LinearAlgebra/Matrix/PosDef.lean
@@ -173,8 +173,7 @@ variable {m : Type _} [Fintype m]
 /-- The conjugate transpose of a matrix mulitplied by the matrix is positive semidefinite -/
 theorem isPosSemidef_conjTranspose_mul_self (A : Matrix m n 𝕜) : Matrix.PosSemidef (Aᴴ ⬝ A) := by
   refine ⟨ isHermitian_transpose_mul_self _, fun x => ?_ ⟩
-  rw [← mulVec_mulVec, dotProduct_mulVec, vecMul_conjTranspose, star_star, dotProduct,
-    IsROrC.re_sum]
+  rw [← mulVec_mulVec, dotProduct_mulVec, vecMul_conjTranspose, star_star, dotProduct, map_sum]
   simpa [Pi.star_apply, IsROrC.star_def, IsROrC.mul_re, IsROrC.conj_re, IsROrC.conj_im, neg_mul,
     sub_neg_eq_add] using
   Finset.sum_nonneg (fun i => (fun _ => add_nonneg (mul_self_nonneg _) (mul_self_nonneg _)))

--- a/Mathlib/LinearAlgebra/Matrix/PosDef.lean
+++ b/Mathlib/LinearAlgebra/Matrix/PosDef.lean
@@ -94,6 +94,22 @@ theorem posDef_toQuadraticForm' [DecidableEq n] {M : Matrix n n ℝ} (hM : M.Pos
   apply hM.2 x hx
 #align matrix.pos_def_to_quadratic_form' Matrix.posDef_toQuadraticForm'
 
+section ConjTransposeMul
+
+/-- The conjugate transpose of a matrix mulitplied by the matrix is positive semidefinite -/
+theorem posSemidef_conjTranspose_mul_self (A : Matrix m n 𝕜) : Matrix.PosSemidef (Aᴴ ⬝ A) := by
+  refine ⟨ isHermitian_transpose_mul_self _, fun x => ?_ ⟩
+  rw [← mulVec_mulVec, dotProduct_mulVec, vecMul_conjTranspose, star_star, dotProduct, map_sum]
+  simpa [Pi.star_apply, IsROrC.star_def, IsROrC.mul_re, IsROrC.conj_re, IsROrC.conj_im, neg_mul,
+    sub_neg_eq_add] using
+  Finset.sum_nonneg (fun i => (fun _ => add_nonneg (mul_self_nonneg _) (mul_self_nonneg _)))
+
+/-- A matrix multiplied by its conjugate transpose is positive semidefinite -/
+theorem posSemidef_self_mul_conjTranspose (A : Matrix m n 𝕜) : Matrix.PosSemidef (A ⬝ Aᴴ) :=
+  by simpa only [conjTranspose_conjTranspose] using posSemidef_conjTranspose_mul_self Aᴴ
+
+end ConjTransposeMul
+
 namespace PosDef
 
 variable {M : Matrix n n ℝ} (hM : M.PosDef)
@@ -165,23 +181,5 @@ def InnerProductSpace.ofMatrix {M : Matrix n n 𝕜} (hM : M.PosDef) :
     @InnerProductSpace 𝕜 (n → 𝕜) _ (NormedAddCommGroup.ofMatrix hM) :=
   InnerProductSpace.ofCore _
 #align matrix.inner_product_space.of_matrix Matrix.InnerProductSpace.ofMatrix
-
-section ConjTransposeMul
-
-variable {m : Type _} [Fintype m]
-
-/-- The conjugate transpose of a matrix mulitplied by the matrix is positive semidefinite -/
-theorem isPosSemidef_conjTranspose_mul_self (A : Matrix m n 𝕜) : Matrix.PosSemidef (Aᴴ ⬝ A) := by
-  refine ⟨ isHermitian_transpose_mul_self _, fun x => ?_ ⟩
-  rw [← mulVec_mulVec, dotProduct_mulVec, vecMul_conjTranspose, star_star, dotProduct, map_sum]
-  simpa [Pi.star_apply, IsROrC.star_def, IsROrC.mul_re, IsROrC.conj_re, IsROrC.conj_im, neg_mul,
-    sub_neg_eq_add] using
-  Finset.sum_nonneg (fun i => (fun _ => add_nonneg (mul_self_nonneg _) (mul_self_nonneg _)))
-
-/-- A matrix multiplied by its conjugate transpose is positive semidefinite -/
-theorem isPosSemidef_self_mul_conjTranspose (A : Matrix m n 𝕜) : Matrix.PosSemidef (A ⬝ Aᴴ) :=
-  by simpa only [conjTranspose_conjTranspose] using isPosSemidef_conjTranspose_mul_self Aᴴ
-
-end ConjTransposeMul
 
 end Matrix

--- a/Mathlib/LinearAlgebra/Matrix/PosDef.lean
+++ b/Mathlib/LinearAlgebra/Matrix/PosDef.lean
@@ -169,7 +169,6 @@ def InnerProductSpace.ofMatrix {M : Matrix n n 𝕜} (hM : M.PosDef) :
 section ConjTransposeMul
 
 variable {m : Type _} [Fintype m]
-open BigOperators
 
 /-- The conjugate transpose of a matrix mulitplied by the matrix is positive semidefinite -/
 theorem isPosSemidef_conjTranspose_mul_self (A : Matrix m n 𝕜) : Matrix.PosSemidef (Aᴴ ⬝ A) := by
@@ -181,9 +180,8 @@ theorem isPosSemidef_conjTranspose_mul_self (A : Matrix m n 𝕜) : Matrix.PosSe
   Finset.sum_nonneg (fun i => (fun _ => add_nonneg (mul_self_nonneg _) (mul_self_nonneg _)))
 
 /-- A matrix multiplied by its conjugate transpose is positive semidefinite -/
-theorem isPosSemidef_self_mul_conjTranspose (A : Matrix m n 𝕜) : Matrix.PosSemidef (A ⬝ Aᴴ) := by
-  nth_rewrite 1 [← conjTranspose_conjTranspose A]
-  apply isPosSemidef_conjTranspose_mul_self
+theorem isPosSemidef_self_mul_conjTranspose (A : Matrix m n 𝕜) : Matrix.PosSemidef (A ⬝ Aᴴ) :=
+  by simpa [conjTranspose_conjTranspose] using isPosSemidef_conjTranspose_mul_self Aᴴ
 
 end ConjTransposeMul
 

--- a/Mathlib/LinearAlgebra/Matrix/PosDef.lean
+++ b/Mathlib/LinearAlgebra/Matrix/PosDef.lean
@@ -181,7 +181,7 @@ theorem isPosSemidef_conjTranspose_mul_self (A : Matrix m n 𝕜) : Matrix.PosSe
 
 /-- A matrix multiplied by its conjugate transpose is positive semidefinite -/
 theorem isPosSemidef_self_mul_conjTranspose (A : Matrix m n 𝕜) : Matrix.PosSemidef (A ⬝ Aᴴ) :=
-  by simpa [conjTranspose_conjTranspose] using isPosSemidef_conjTranspose_mul_self Aᴴ
+  by simpa only [conjTranspose_conjTranspose] using isPosSemidef_conjTranspose_mul_self Aᴴ
 
 end ConjTransposeMul
 

--- a/Mathlib/LinearAlgebra/Matrix/PosDef.lean
+++ b/Mathlib/LinearAlgebra/Matrix/PosDef.lean
@@ -98,9 +98,7 @@ theorem posSemidef_conjTranspose_mul_self (A : Matrix m n 𝕜) : Matrix.PosSemi
   refine ⟨isHermitian_transpose_mul_self _, fun x => ?_⟩
   rw [← mulVec_mulVec, dotProduct_mulVec, vecMul_conjTranspose, star_star, dotProduct, map_sum]
   simp_rw [Pi.star_apply, IsROrC.star_def]
-  refine Finset.sum_nonneg fun i _ => ?_
-  -- TODO: use a `StarOrderedRing` lemma
-  simpa using add_nonneg (mul_self_nonneg _) (mul_self_nonneg _)
+  simpa using Finset.sum_nonneg fun i _ => add_nonneg (mul_self_nonneg _) (mul_self_nonneg _)
 
 /-- A matrix multiplied by its conjugate transpose is positive semidefinite -/
 theorem posSemidef_self_mul_conjTranspose (A : Matrix m n 𝕜) : Matrix.PosSemidef (A ⬝ Aᴴ) :=

--- a/Mathlib/LinearAlgebra/Matrix/PosDef.lean
+++ b/Mathlib/LinearAlgebra/Matrix/PosDef.lean
@@ -1,8 +1,9 @@
 /-
 Copyright (c) 2022 Alexander Bentkamp. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Alexander Bentkamp
+Authors: Alexander Bentkamp, Mohanad Ahmed
 -/
+import Mathlib.Data.IsROrC.Basic
 import Mathlib.LinearAlgebra.Matrix.Spectrum
 import Mathlib.LinearAlgebra.QuadraticForm.Basic
 
@@ -164,5 +165,27 @@ def InnerProductSpace.ofMatrix {M : Matrix n n 𝕜} (hM : M.PosDef) :
     @InnerProductSpace 𝕜 (n → 𝕜) _ (NormedAddCommGroup.ofMatrix hM) :=
   InnerProductSpace.ofCore _
 #align matrix.inner_product_space.of_matrix Matrix.InnerProductSpace.ofMatrix
+
+section ConjTransposeMul
+
+variable {m : Type _} [Fintype m]
+open BigOperators
+
+/-- The conjugate transpose of a matrix mulitplied by the matrix is positive semidefinite -/
+theorem isPosSemidef_conjTranspose_mul_self (A : Matrix m n 𝕜) : Matrix.PosSemidef (Aᴴ ⬝ A) := by
+  refine ⟨ isHermitian_transpose_mul_self _, fun x => ?_ ⟩
+  rw [← mulVec_mulVec, dotProduct_mulVec, vecMul_conjTranspose, star_star, dotProduct,
+    IsROrC.re_sum]
+  simpa [Pi.star_apply, IsROrC.star_def, IsROrC.mul_re, IsROrC.conj_re, IsROrC.conj_im, neg_mul,
+    sub_neg_eq_add] using
+  Finset.sum_nonneg (fun i => (fun _ => add_nonneg (mul_self_nonneg _) (mul_self_nonneg _)))
+
+/-- A matrix multiplied by its conjugate transpose is positive semidefinite -/
+theorem isPosSemidef_self_mul_conjTranspose (A : Matrix m n 𝕜) : Matrix.PosSemidef (A ⬝ Aᴴ) := by
+  -- refine ⟨ isHermitian_mul_conjTranspose_self _, fun x => ?_ ⟩
+  nth_rewrite 1 [← conjTranspose_conjTranspose A]
+  apply isPosSemidef_conjTranspose_mul_self
+
+end ConjTransposeMul
 
 end Matrix


### PR DESCRIPTION
This PR provides two lemmas `isPosSemidef_conjTranspose_mul_self` and `isPosSemidef_self_mul_conjTranspose` stating that for any matrix $A$ the products $A^HA$ and $AA^H$ in the `IsROrC` fields are positive semidefinite.

Co-authored-by: Mohanad Ahmed <m.a.m.elhassan@gmail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
