### PR TITLE
[Merged by Bors] - feat: short exact sequence of free modules

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -63,6 +63,7 @@ import Mathlib.Algebra.Category.ModuleCat.ChangeOfRings
 import Mathlib.Algebra.Category.ModuleCat.Colimits
 import Mathlib.Algebra.Category.ModuleCat.EpiMono
 import Mathlib.Algebra.Category.ModuleCat.FilteredColimits
+import Mathlib.Algebra.Category.ModuleCat.Free
 import Mathlib.Algebra.Category.ModuleCat.Images
 import Mathlib.Algebra.Category.ModuleCat.Kernels
 import Mathlib.Algebra.Category.ModuleCat.Limits

--- a/Mathlib/Algebra/Category/ModuleCat/Free.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Free.lean
@@ -1,4 +1,5 @@
 import Mathlib.Algebra.Category.ModuleCat.Abelian
+import Mathlib.Algebra.Category.ModuleCat.Adjunctions
 import Mathlib.Algebra.Homology.ShortExact.Preadditive
 import Mathlib.LinearAlgebra.FreeModule.Basic
 
@@ -32,6 +33,34 @@ theorem linearIndependent_leftExact : LinearIndependent R u :=
     ((LinearMap.linearIndependent_iff (f : N →ₗ[R] M)
     (LinearMap.ker_eq_bot.mpr ((mono_iff_injective _).mp hm))).mpr hv),
     LinearIndependent.of_comp g hw, disjoint_span hw hu he huv⟩
+
+def family_shortExact [Nontrivial R] {w : J → P} (hE : Epi g) (hw : LinearIndependent R w) :
+    Function.Injective (Sum.elim (f ∘ v) (g.toFun.invFun ∘ w)) := by
+  apply Function.Injective.sum_elim
+  · rw [mono_iff_injective] at hm
+    exact Function.Injective.comp hm hv.injective
+  · rw [epi_iff_surjective] at hE
+    exact Function.Injective.comp (Function.rightInverse_invFun hE).injective hw.injective
+  · intro a b h
+    apply_fun g at h
+    rw [epi_iff_surjective] at hE
+    dsimp at h
+    rw [Function.rightInverse_invFun hE] at h
+    have : g (f (v a)) = (f ≫ g) (v a) := rfl
+    rw [this, he.w] at h
+    sorry
+
+theorem linearIndependent_shortExact [Nontrivial R] {w : J → P} (hse : ShortExact f g)
+    (hw : LinearIndependent R w) :
+    LinearIndependent R (Sum.elim (f ∘ v) (g.toFun.invFun ∘ w)) := by
+  refine' linearIndependent_leftExact hv _ (family_shortExact hv hse.mono hse.epi hw)
+      hse.mono hse.exact _
+  · simp only [AddHom.toFun_eq_coe, LinearMap.coe_toAddHom, Sum.elim_comp_inr]
+    have hg := hse.epi
+    rw [ModuleCat.epi_iff_surjective] at hg
+    rwa [← Function.comp.assoc, Function.RightInverse.comp_eq_id (Function.rightInverse_invFun hg),
+      Function.comp.left_id]
+  · simp only [AddHom.toFun_eq_coe, LinearMap.coe_toAddHom, Sum.elim_comp_inl]
 
 end LinearIndependent
 
@@ -78,7 +107,25 @@ theorem span_exact (he : Exact f g) (huv : u ∘ Sum.inl = f ∘ v)
 
 end Span
 
-theorem free_shortExact {M : ModuleCat R} {f : (ModuleCat.free R).obj I ⟶ M}
-  {g : M ⟶ (ModuleCat.free R).obj} (h : ShortExact f g) : Module.Free R M := sorry
+-- def map_of_shortExact {M : ModuleCat R} {f : N ⟶ M}
+--     {g : M ⟶ P} (h : ShortExact f g) (hN : Module.Free R N) (hP : Module.Free R P) :
+
+-- #exit
+
+theorem free_shortExact' {M : ModuleCat R} {f : N ⟶ M}
+    {g : M ⟶ P} (h : ShortExact f g) (hN : Module.Free R N) (hP : Module.Free R P) :
+    Module.Free R M := by
+  let ginv : P → M := g.toFun.invFun
+  obtain ⟨I, hI⟩ := hN
+  have hlI := hI.linearIndependent
+  have hsI := le_of_eq hI.span_eq.symm
+  obtain ⟨J, hJ⟩ := hP
+  have hlJ := hJ.linearIndependent
+  have hsJ := le_of_eq hJ.span_eq.symm
+  refine' @Module.Free.of_basis _ _ _ _ _ (I ⊕ J) _
+  refine' Basis.mk _ _
+  · exact Sum.elim (f ∘ hI) (ginv ∘ hJ)
+  · sorry
+  · sorry
 
 end ModuleCat

--- a/Mathlib/Algebra/Category/ModuleCat/Free.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Free.lean
@@ -1,0 +1,84 @@
+import Mathlib.Algebra.Category.ModuleCat.Abelian
+import Mathlib.Algebra.Homology.ShortExact.Preadditive
+import Mathlib.LinearAlgebra.FreeModule.Basic
+
+namespace ModuleCat
+
+variable {I : Type _} {J : Type _} {R : Type _} [Ring R] {N P : ModuleCat R} {v : I → N}-- {w : J → P}
+
+open CategoryTheory
+
+section LinearIndependent
+
+variable (hv : LinearIndependent R v)  {M : ModuleCat R}
+  {u : I ⊕ J → M}  {f : N ⟶ M} {g : M ⟶ P}
+  (hw : LinearIndependent R (g ∘ u ∘ Sum.inr)) (hu : Function.Injective u)
+  (hm : Mono f) (he : Exact f g) (huv : u ∘ Sum.inl = f ∘ v)
+
+lemma disjoint_span_aux : Disjoint (Submodule.span R (Set.range f))
+    (Submodule.span R (Set.range (u ∘ Sum.inr))) := by
+  rw [← LinearMap.range_coe, (Submodule.span_eq (LinearMap.range f)), (exact_iff _ _).mp he]
+  exact Submodule.ker_range_disjoint (Function.Injective.comp hu Sum.inr_injective) hw
+
+lemma disjoint_span : Disjoint (Submodule.span R (Set.range (u ∘ Sum.inl)))
+    (Submodule.span R (Set.range (u ∘ Sum.inr))) := by
+  rw [huv]
+  exact Disjoint.mono_left (Submodule.span_mono (Set.range_comp_subset_range _ _))
+    (disjoint_span_aux hw hu he)
+
+theorem linearIndependent_leftExact : LinearIndependent R u :=
+  linearIndependent_sum.mpr
+  ⟨(congr_arg (fun f ↦ LinearIndependent R f) huv).mpr
+    ((LinearMap.linearIndependent_iff (f : N →ₗ[R] M)
+    (LinearMap.ker_eq_bot.mpr ((mono_iff_injective _).mp hm))).mpr hv),
+    LinearIndependent.of_comp g hw, disjoint_span hw hu he huv⟩
+
+end LinearIndependent
+
+section Span
+
+variable {M : ModuleCat R} {u : I ⊕ J → M} {f : N ⟶ M} {g : M ⟶ P}
+
+theorem span_exact (he : Exact f g) (huv : u ∘ Sum.inl = f ∘ v)
+    (huw : g ∘ u ∘ Sum.inr = w) (hv : ⊤ ≤ Submodule.span R (Set.range v))
+    (hw : ⊤ ≤ Submodule.span R (Set.range w)) : ⊤ ≤ Submodule.span R (Set.range u) := by
+  intro m _
+  have hgm : g m ∈ Submodule.span R (Set.range w) := hw Submodule.mem_top
+  rw [Finsupp.mem_span_range_iff_exists_finsupp] at hgm
+  obtain ⟨cm, hm⟩ := hgm
+  rw [← huw] at hm
+  set m' : M := Finsupp.sum cm fun j a ↦ a • (u (Sum.inr j)) with hm'
+  have hsub : m - m' ∈ LinearMap.range f
+  · rw [(exact_iff _ _).mp he]
+    simp only [LinearMap.mem_ker, map_sub, sub_eq_zero]
+    rw [← hm, map_finsupp_sum]
+    simp only [Function.comp_apply, map_smul]
+  obtain ⟨n, hnm⟩ := hsub
+  have hn : n ∈ Submodule.span R (Set.range v) := hv Submodule.mem_top
+  rw [Finsupp.mem_span_range_iff_exists_finsupp] at hn
+  obtain ⟨cn, hn⟩ := hn
+  rw [← hn, map_finsupp_sum] at hnm
+  have hmmm : m = m - m' + m'
+  · simp only [sub_add_cancel]
+  rw [hmmm, ← hnm, hm']
+  simp only [map_smul]
+  have hn' : (Finsupp.sum cn fun a b ↦ b • f (v a)) = (Finsupp.sum cn fun a b ↦ b • u (Sum.inl a))
+  · congr
+    ext a _
+    rw [(by rfl : f (v a) = (f ∘ v) a), ← huv]
+    rfl
+  rw [hn']
+  apply Submodule.add_mem
+  · rw [Finsupp.mem_span_range_iff_exists_finsupp]
+    use cn.mapDomain (Sum.inl)
+    rw [Finsupp.sum_mapDomain_index_inj Sum.inl_injective]
+  · rw [Finsupp.mem_span_range_iff_exists_finsupp]
+    use cm.mapDomain (Sum.inr)
+    rw [Finsupp.sum_mapDomain_index_inj Sum.inr_injective]
+
+end Span
+
+theorem free_shortExact {M : ModuleCat R} {f : (ModuleCat.free R).obj I ⟶ M}
+  {g : M ⟶ (ModuleCat.free R).obj} (h : ShortExact f g) : Module.Free R M := sorry
+
+end ModuleCat

--- a/Mathlib/Algebra/Category/ModuleCat/Free.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Free.lean
@@ -7,6 +7,7 @@ import Mathlib.Algebra.Category.ModuleCat.Abelian
 import Mathlib.Algebra.Category.ModuleCat.Adjunctions
 import Mathlib.Algebra.Homology.ShortExact.Preadditive
 import Mathlib.LinearAlgebra.FreeModule.Basic
+import Mathlib.LinearAlgebra.Dimension
 
 /-!
 # Exact sequences with free modules
@@ -178,5 +179,21 @@ theorem free_shortExact {M : ModuleCat R} {f : N ⟶ M}
     (span_rightExact
       (le_of_eq ((Module.Free.chooseBasis R N)).span_eq.symm)
       (le_of_eq (Module.Free.chooseBasis R P).span_eq.symm) h.epi h.exact))
+
+theorem free_shortExact_rank_add {M : ModuleCat R} {f : N ⟶ M}
+    {g : M ⟶ P} (h : ShortExact f g) [Module.Free R N] [Module.Free R P] [StrongRankCondition R] :
+    Module.rank R M = Module.rank R N + Module.rank R P := by
+  haveI := free_shortExact h
+  rw [Module.Free.rank_eq_card_chooseBasisIndex, Module.Free.rank_eq_card_chooseBasisIndex R N,
+    Module.Free.rank_eq_card_chooseBasisIndex R P, Cardinal.add_def, Cardinal.eq]
+  exact ⟨Basis.indexEquiv (Module.Free.chooseBasis R M) (Basis.mk
+    (linearIndependent_shortExact
+      (Module.Free.chooseBasis R N).linearIndependent
+      (Module.Free.chooseBasis R P).linearIndependent h)
+    (span_rightExact
+      (le_of_eq ((Module.Free.chooseBasis R N)).span_eq.symm)
+      (le_of_eq (Module.Free.chooseBasis R P).span_eq.symm) h.epi h.exact))⟩
+
+
 
 end ModuleCat

--- a/Mathlib/Algebra/Category/ModuleCat/Free.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Free.lean
@@ -194,6 +194,4 @@ theorem free_shortExact_rank_add {M : ModuleCat R} {f : N ⟶ M}
       (le_of_eq ((Module.Free.chooseBasis R N)).span_eq.symm)
       (le_of_eq (Module.Free.chooseBasis R P).span_eq.symm) h.epi h.exact))⟩
 
-
-
 end ModuleCat

--- a/Mathlib/Algebra/Category/ModuleCat/Free.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Free.lean
@@ -127,7 +127,7 @@ theorem span_exact (he : Exact f g) (huv : u ∘ Sum.inl = f ∘ v)
     rw [Finsupp.sum_mapDomain_index_inj Sum.inr_injective]
 
 /-- Given an exact sequence `N ⟶ M ⟶ P ⟶ 0` of `R`-modules and spanning
-    families `v : ι → N` and `w : ι' → M`, we get a spanning family `ι ⊕ ι' → M` -/
+    families `v : ι → N` and `w : ι' → P`, we get a spanning family `ι ⊕ ι' → M` -/
 theorem span_rightExact {w : ι' → P} (hv : ⊤ ≤ Submodule.span R (Set.range v))
     (hw : ⊤ ≤ Submodule.span R (Set.range w)) (hE : Epi g) (he : Exact f g) :
     ⊤ ≤ Submodule.span R (Set.range (Sum.elim (f ∘ v) (g.toFun.invFun ∘ w))) := by

--- a/Mathlib/Algebra/Category/ModuleCat/Free.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Free.lean
@@ -73,7 +73,7 @@ theorem family_injective_shortExact [Nontrivial R] {w : ι' → P} (hE : Epi g)
 
 
 /-- Given a short exact sequence `0 ⟶ N ⟶ M ⟶ P ⟶ 0` of `R`-modules and linearly independent
-    families `v : ι → N` and `w : ι' → M`, we get a linearly independent family `ι ⊕ ι' → M` -/
+    families `v : ι → N` and `w : ι' → P`, we get a linearly independent family `ι ⊕ ι' → M` -/
 theorem linearIndependent_shortExact {w : ι' → P}
     (hw : LinearIndependent R w) (hse : ShortExact f g) :
     LinearIndependent R (Sum.elim (f ∘ v) (g.toFun.invFun ∘ w)) := by

--- a/Mathlib/Algebra/Category/ModuleCat/Free.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Free.lean
@@ -7,7 +7,9 @@ import Mathlib.Algebra.Category.ModuleCat.Abelian
 import Mathlib.Algebra.Category.ModuleCat.Adjunctions
 import Mathlib.Algebra.Homology.ShortExact.Preadditive
 import Mathlib.LinearAlgebra.FreeModule.Basic
+import Mathlib.LinearAlgebra.FreeModule.Finite.Rank
 import Mathlib.LinearAlgebra.Dimension
+import Mathlib.LinearAlgebra.Finrank
 
 /-!
 # Exact sequences with free modules
@@ -193,5 +195,16 @@ theorem free_shortExact_rank_add {M : ModuleCat R} {f : N ⟶ M}
     (span_rightExact
       (le_of_eq ((Module.Free.chooseBasis R N)).span_eq.symm)
       (le_of_eq (Module.Free.chooseBasis R P).span_eq.symm) h.epi h.exact))⟩
+
+theorem free_shortExact_finrank_add {M : ModuleCat R} {f : N ⟶ M}
+    {g : M ⟶ P} (h : ShortExact f g) [Module.Free R N] [Module.Finite R N]
+    [Module.Free R P] [Module.Finite R P]
+    (hN : FiniteDimensional.finrank R N = n)
+    (hP : FiniteDimensional.finrank R P = p)
+    [StrongRankCondition R]:
+    FiniteDimensional.finrank R M = n + p := by
+  apply FiniteDimensional.finrank_eq_of_rank_eq
+  rw [free_shortExact_rank_add h, ← hN, ← hP]
+  simp only [Nat.cast_add, FiniteDimensional.finrank_eq_rank]
 
 end ModuleCat

--- a/Mathlib/LinearAlgebra/LinearIndependent.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent.lean
@@ -220,6 +220,38 @@ theorem LinearIndependent.map (hv : LinearIndependent R v) {f : M →ₗ[R] M'}
   exact fun _ => rfl
 #align linear_independent.map LinearIndependent.map
 
+/-- If `v` is an injective family of vectors such that `f ∘ v` is linearly independent, then `v`
+    spans a submodule disjoint from the kernel of `f` -/
+theorem Submodule.ker_range_disjoint {f : M →ₗ[R] M'} (hi : v.Injective)
+    (hv : LinearIndependent R (f ∘ v)) :
+    Disjoint (LinearMap.ker f) (Submodule.span R (Set.range v)) := by
+  rw [Submodule.disjoint_def]
+  intro m hm hmr
+  simp only [LinearMap.mem_ker] at hm
+  rw [mem_span_set] at hmr
+  obtain ⟨c, ⟨hc, hsum⟩⟩ := hmr
+  rw [← hsum, map_finsupp_sum] at hm
+  simp_rw [f.map_smul] at hm
+  dsimp [Finsupp.sum] at hm
+  rw [linearIndependent_iff'] at hv
+  specialize hv (Finset.preimage c.support v (Set.injOn_of_injective hi _))
+  rw [← Finset.sum_preimage v c.support (Set.injOn_of_injective hi _) _ _] at hm
+  · rw [← hsum]
+    apply Finset.sum_eq_zero
+    intro x hx
+    obtain ⟨y, hy⟩ := hc hx
+    rw [← hy]
+    have : c (v y) = 0
+    · apply hv (c ∘ v) hm y
+      simp only [Finset.mem_preimage, Function.comp_apply]
+      dsimp at hy
+      rwa [hy]
+    rw [this]
+    simp only [zero_smul]
+  · intro x hx hnx
+    exfalso
+    exact hnx (hc hx)
+
 /-- An injective linear map sends linearly independent families of vectors to linearly independent
 families of vectors. See also `LinearIndependent.map` for a more general statement. -/
 theorem LinearIndependent.map' (hv : LinearIndependent R v) (f : M →ₗ[R] M')


### PR DESCRIPTION
We prove that if the left and right term in a short exact sequence of modules are free, then the middle term is free as well, and related results. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
