### PR TITLE
[Merged by Bors] - feat: Positivity/Nonnegativity of Eigenvalues of PosDef/PosSemidef Matrices

### DIFF
--- a/Mathlib/LinearAlgebra/Matrix/PosDef.lean
+++ b/Mathlib/LinearAlgebra/Matrix/PosDef.lean
@@ -104,9 +104,8 @@ theorem posSemidef_conjTranspose_mul_self (A : Matrix m n 𝕜) : Matrix.PosSemi
 theorem posSemidef_self_mul_conjTranspose (A : Matrix m n 𝕜) : Matrix.PosSemidef (A ⬝ Aᴴ) :=
   by simpa only [conjTranspose_conjTranspose] using posSemidef_conjTranspose_mul_self Aᴴ
 
-namespace PosDef
 /-- The eigenvalues of a positive definite matrix are positive -/
-lemma eigenvalues_pos [DecidableEq n] [DecidableEq 𝕜] {A : Matrix n n 𝕜}
+lemma PosDef.eigenvalues_pos [DecidableEq n] [DecidableEq 𝕜] {A : Matrix n n 𝕜}
     (hA : Matrix.PosDef A) (i : n) : 0 < hA.1.eigenvalues i := by
   rw [hA.1.eigenvalues_eq]
   apply hA.2
@@ -117,18 +116,10 @@ lemma eigenvalues_pos [DecidableEq n] [DecidableEq 𝕜] {A : Matrix n n 𝕜}
   rw [h, norm_zero] at z
   exact_mod_cast z
 
-end PosDef
-
-namespace PosSemidef
-
 /-- The eigenvalues of a positive semi-definite matrix are non-negative -/
-lemma eigenvalues_nonneg [DecidableEq n] [DecidableEq 𝕜] {A : Matrix n n 𝕜}
-    (hA : Matrix.PosSemidef A) (i : n) : 0 ≤ hA.1.eigenvalues i := by
-  rw [hA.1.eigenvalues_eq]
-  apply hA.2
-
-end PosSemidef
-
+lemma PosSemidef.eigenvalues_nonneg [DecidableEq n] [DecidableEq 𝕜] {A : Matrix n n 𝕜}
+    (hA : Matrix.PosSemidef A) (i : n) : 0 ≤ hA.1.eigenvalues i :=
+  (hA.2 _).trans_eq (hA.1.eigenvalues_eq _).symm
 
 namespace PosDef
 

--- a/Mathlib/LinearAlgebra/Matrix/PosDef.lean
+++ b/Mathlib/LinearAlgebra/Matrix/PosDef.lean
@@ -107,10 +107,8 @@ theorem posSemidef_self_mul_conjTranspose (A : Matrix m n 𝕜) : Matrix.PosSemi
 /-- The eigenvalues of a positive definite matrix are positive -/
 lemma PosDef.eigenvalues_pos [DecidableEq n] [DecidableEq 𝕜] {A : Matrix n n 𝕜}
     (hA : Matrix.PosDef A) (i : n) : 0 < hA.1.eigenvalues i := by
-  rw [hA.1.eigenvalues_eq]
-  apply hA.2
-  rw [hA.1.transpose_eigenvectorMatrix_apply]
-  exact hA.1.eigenvectorBasis.orthonormal.ne_zero i
+  rw [hA.1.eigenvalues_eq, hA.1.transpose_eigenvectorMatrix_apply]
+  exact hA.2 _ <| hA.1.eigenvectorBasis.orthonormal.ne_zero i
 
 /-- The eigenvalues of a positive semi-definite matrix are non-negative -/
 lemma PosSemidef.eigenvalues_nonneg [DecidableEq n] [DecidableEq 𝕜] {A : Matrix n n 𝕜}

--- a/Mathlib/LinearAlgebra/Matrix/PosDef.lean
+++ b/Mathlib/LinearAlgebra/Matrix/PosDef.lean
@@ -105,6 +105,32 @@ theorem posSemidef_self_mul_conjTranspose (A : Matrix m n 𝕜) : Matrix.PosSemi
   by simpa only [conjTranspose_conjTranspose] using posSemidef_conjTranspose_mul_self Aᴴ
 
 namespace PosDef
+/-- The eigenvalues of a positive definite matrix are positive -/
+lemma eigenvalues_pos [DecidableEq n] [DecidableEq 𝕜] {A : Matrix n n 𝕜}
+    (hA : Matrix.PosDef A) (i : n) : 0 < hA.1.eigenvalues i := by
+  rw [hA.1.eigenvalues_eq]
+  apply hA.2
+  by_contra h
+  simp_rw [IsHermitian.eigenvectorMatrix, OrthonormalBasis.coe_toBasis,
+    Basis.toMatrix_transpose_apply,  Finsupp.coe_eq_zero, AddEquivClass.map_eq_zero_iff] at h
+  have z := hA.1.eigenvectorBasis.orthonormal.1 i
+  rw [h, norm_zero] at z
+  exact_mod_cast z
+
+end PosDef
+
+namespace PosSemidef
+
+/-- The eigenvalues of a positive semi-definite matrix are non-negative -/
+lemma eigenvalues_nonneg [DecidableEq n] [DecidableEq 𝕜] {A : Matrix n n 𝕜}
+    (hA : Matrix.PosSemidef A) (i : n) : 0 ≤ hA.1.eigenvalues i := by
+  rw [hA.1.eigenvalues_eq]
+  apply hA.2
+
+end PosSemidef
+
+
+namespace PosDef
 
 variable {M : Matrix n n ℝ} (hM : M.PosDef)
 

--- a/Mathlib/LinearAlgebra/Matrix/PosDef.lean
+++ b/Mathlib/LinearAlgebra/Matrix/PosDef.lean
@@ -109,12 +109,8 @@ lemma PosDef.eigenvalues_pos [DecidableEq n] [DecidableEq 𝕜] {A : Matrix n n 
     (hA : Matrix.PosDef A) (i : n) : 0 < hA.1.eigenvalues i := by
   rw [hA.1.eigenvalues_eq]
   apply hA.2
-  by_contra h
-  simp_rw [IsHermitian.eigenvectorMatrix, OrthonormalBasis.coe_toBasis,
-    Basis.toMatrix_transpose_apply,  Finsupp.coe_eq_zero, AddEquivClass.map_eq_zero_iff] at h
-  have z := hA.1.eigenvectorBasis.orthonormal.1 i
-  rw [h, norm_zero] at z
-  exact_mod_cast z
+  rw [hA.1.transpose_eigenvectorMatrix_apply]
+  exact hA.1.eigenvectorBasis.orthonormal.ne_zero i
 
 /-- The eigenvalues of a positive semi-definite matrix are non-negative -/
 lemma PosSemidef.eigenvalues_nonneg [DecidableEq n] [DecidableEq 𝕜] {A : Matrix n n 𝕜}

--- a/Mathlib/LinearAlgebra/Matrix/Spectrum.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Spectrum.lean
@@ -76,6 +76,11 @@ theorem eigenvectorMatrix_apply (i j : n) : hA.eigenvectorMatrix i j = hA.eigenv
     PiLp.basisFun_repr]
 #align matrix.is_hermitian.eigenvector_matrix_apply Matrix.IsHermitian.eigenvectorMatrix_apply
 
+/-- The columns of `Matrix.IsHermitian.eigenVectorMatrix` form the basis-/
+theorem transpose_eigenvectorMatrix_apply (i : n) :
+    hA.eigenvectorMatrixᵀ i = hA.eigenvectorBasis i :=
+  funext <| fun j => eigenvectorMatrix_apply hA j i
+
 theorem eigenvectorMatrixInv_apply (i j : n) :
     hA.eigenvectorMatrixInv i j = star (hA.eigenvectorBasis i j) := by
   rw [eigenvectorMatrixInv, Basis.toMatrix_apply, OrthonormalBasis.coe_toBasis_repr_apply,


### PR DESCRIPTION
Two lemmas:

- `Matrix.PosDef.eigenvalues_pos`: $$A \in k^{n\times n}, A > 0 \implies \lambda (A) >0$$
- `Matrix.PosSemidef.eigenvalues_nonneg`: $$A \in k^{n\times n}, A \geq 0 \implies \lambda (A) \geq 0$$
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
