### PR TITLE
[Merged by Bors] - chore: 'says' ignores following comments when verifying

### DIFF
--- a/Mathlib/Tactic/Says.lean
+++ b/Mathlib/Tactic/Says.lean
@@ -5,6 +5,7 @@ Authors: Kim Liesinger
 -/
 import Std.Data.String.Basic
 import Std.Tactic.GuardMsgs
+import Qq.Match
 
 /-!
 # The `says` tactic combinator.
@@ -103,8 +104,8 @@ elab_rules : tactic
     let stx ← evalTacticCapturingTryThis tac
     match result with
     | some r =>
-        let stx' := (← Lean.PrettyPrinter.ppTactic ⟨stx⟩).pretty
-        let r' := (← Lean.PrettyPrinter.ppTactic ⟨r⟩).pretty
+        let stx' := (← Lean.PrettyPrinter.ppTactic ⟨Syntax.stripPos stx⟩).pretty
+        let r' := (← Lean.PrettyPrinter.ppTactic ⟨Syntax.stripPos r⟩).pretty
         if stx' != r' then
           throwError m!"Tactic `{tac}` produced `{stx'}`,\nbut was expecting it to produce `{r'}`!"
     | none =>

--- a/test/says.lean
+++ b/test/says.lean
@@ -63,6 +63,12 @@ example : True := by
   simp says
   trivial
 
+set_option says.verify true in
+example : Nat := by
+  simp? says simp only
+  -- This is a comment to test that `says` ignores following comments.
+  exact 0
+
 set_option says.no_verify_in_CI true in
 example : True := by
   simp says


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
