### PR TITLE
Update install_macos.sh

### DIFF
--- a/scripts/install_macos.sh
+++ b/scripts/install_macos.sh
@@ -16,9 +16,8 @@ elan toolchain install stable
 elan default stable
 
 # Install and configure VS Code
-if ! which code > /dev/null; then
+if ! "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code" --install-extension leanprover.lean4 > /dev/null; then
     brew install --cask visual-studio-code
+    # Install the Lean4 VS Code extension
+    code --install-extension leanprover.lean4
 fi
-
-# Install the Lean4 VS Code extension
-code --install-extension leanprover.lean4

--- a/scripts/install_macos.sh
+++ b/scripts/install_macos.sh
@@ -16,7 +16,7 @@ elan toolchain install stable
 elan default stable
 
 # Install and configure VS Code
-if ! "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code" --install-extension leanprover.lean4 > /dev/null; then
+if ! "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code" --install-extension leanprover.lean4; then
     brew install --cask visual-studio-code
     # Install the Lean4 VS Code extension
     code --install-extension leanprover.lean4


### PR DESCRIPTION
The basic download-and-drag installation of VS Code does not add it to the PATH. So this commit calls it with its full pathname.

This script-driven install is the one advocated on the leanprover-community website and I am trying to make it a little smoother. It should work for both Intel and M1-based Macs and it would be great if the [install page](https://leanprover-community.github.io/install/macos.html) were to change to reflect that (see [here](https://github.com/leanprover-community/leanprover-community.github.io/pull/331)). However I don't really understand why we diverge at all from the approach described in the [Lean manual](https://leanprover.github.io/lean4/doc/quickstart.html).


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
