### PR TITLE
[Merged by Bors] - chore: Doc-string fixes

### DIFF
--- a/Mathlib/Algebra/Group/Commute.lean
+++ b/Mathlib/Algebra/Group/Commute.lean
@@ -43,7 +43,7 @@ section Mul
 variable {S : Type _} [Mul S]
 
 /-- Equality behind `Commute a b`; useful for rewriting. -/
-@[to_additive "Equality behind `add_commute a b`; useful for rewriting."]
+@[to_additive "Equality behind `AddCommute a b`; useful for rewriting."]
 protected theorem eq {a b : S} (h : Commute a b) : a * b = b * a :=
   h
 #align commute.eq Commute.eq
@@ -79,7 +79,7 @@ protected theorem symm_iff {a b : S} : Commute a b ↔ Commute b a :=
 instance : IsRefl S Commute :=
   ⟨Commute.refl⟩
 
--- This instance is useful for `Finset.noncomm_prod`
+-- This instance is useful for `Finset.noncommProd`
 @[to_additive]
 instance on_isRefl {f : G → S} : IsRefl G fun a b => Commute (f a) (f b) :=
   ⟨fun _ => Commute.refl _⟩

--- a/Mathlib/Algebra/Group/Units.lean
+++ b/Mathlib/Algebra/Group/Units.lean
@@ -148,7 +148,7 @@ theorem ext_iff {a b : αˣ} : a = b ↔ (a : α) = b :=
 #align units.ext_iff Units.ext_iff
 #align add_units.ext_iff AddUnits.ext_iff
 
-/-- Units have decidable equality if the base `Monoid` has deciable equality. -/
+/-- Units have decidable equality if the base `Monoid` has decidable equality. -/
 @[to_additive "Additive units have decidable equality
 if the base `AddMonoid` has deciable equality."]
 instance [DecidableEq α] : DecidableEq αˣ := fun _ _ => decidable_of_iff' _ ext_iff
@@ -408,7 +408,7 @@ end Units
 
 /-- For `a, b` in a `CommMonoid` such that `a * b = 1`, makes a unit out of `a`. -/
 @[to_additive
-  "For `a, b` in an `AddCommMonoid` such that `a + b = 0`, makes an add_unit out of `a`."]
+  "For `a, b` in an `AddCommMonoid` such that `a + b = 0`, makes an addUnit out of `a`."]
 def Units.mkOfMulEqOne [CommMonoid α] (a b : α) (hab : a * b = 1) : αˣ :=
   ⟨a, b, hab, (mul_comm b a).trans hab⟩
 #align units.mk_of_mul_eq_one Units.mkOfMulEqOne


### PR DESCRIPTION
Just some casing issues in some doc-strings in

```
Algebra.Group.Commute
Algebra.Group.Units
```

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
