### PR TITLE
[Merged by Bors] - feat(SetTheory): definition of initial ordinals, ω₁ as an ordinal, ordinal-indexed unions

### DIFF
--- a/Mathlib/SetTheory/Cardinal/Cofinality.lean
+++ b/Mathlib/SetTheory/Cardinal/Cofinality.lean
@@ -1248,3 +1248,20 @@ theorem lt_cof_power {a b : Cardinal} (ha : ℵ₀ ≤ a) (b1 : 1 < b) : a < cof
 #align cardinal.lt_cof_power Cardinal.lt_cof_power
 
 end Cardinal
+
+section Omega1
+
+namespace Ordinal
+
+open Cardinal
+open scoped Ordinal
+
+lemma sup_sequence_lt_omega_1 {α} [Countable α] (o : α → Ordinal) (ho : ∀ n, o n < ω₁) :
+  sup o < ω₁ := by
+  apply sup_lt_ord_lift _ ho
+  rw [initial, Cardinal.isRegular_aleph_one.cof_eq]
+  exact lt_of_le_of_lt mk_le_aleph0 aleph0_lt_aleph_one
+
+end Ordinal
+
+end Omega1

--- a/Mathlib/SetTheory/Cardinal/Cofinality.lean
+++ b/Mathlib/SetTheory/Cardinal/Cofinality.lean
@@ -1259,7 +1259,7 @@ open scoped Ordinal
 lemma sup_sequence_lt_omega1 {α} [Countable α] (o : α → Ordinal) (ho : ∀ n, o n < ω₁) :
     sup o < ω₁ := by
   apply sup_lt_ord_lift _ ho
-  rw [initial, Cardinal.isRegular_aleph_one.cof_eq]
+  rw [Cardinal.isRegular_aleph_one.cof_eq]
   exact lt_of_le_of_lt mk_le_aleph0 aleph0_lt_aleph_one
 
 end Ordinal

--- a/Mathlib/SetTheory/Cardinal/Cofinality.lean
+++ b/Mathlib/SetTheory/Cardinal/Cofinality.lean
@@ -1256,7 +1256,7 @@ namespace Ordinal
 open Cardinal
 open scoped Ordinal
 
-lemma sup_sequence_lt_omega_1 {α} [Countable α] (o : α → Ordinal) (ho : ∀ n, o n < ω₁) :
+lemma sup_sequence_lt_omega1 {α} [Countable α] (o : α → Ordinal) (ho : ∀ n, o n < ω₁) :
   sup o < ω₁ := by
   apply sup_lt_ord_lift _ ho
   rw [initial, Cardinal.isRegular_aleph_one.cof_eq]

--- a/Mathlib/SetTheory/Cardinal/Cofinality.lean
+++ b/Mathlib/SetTheory/Cardinal/Cofinality.lean
@@ -1257,7 +1257,7 @@ open Cardinal
 open scoped Ordinal
 
 lemma sup_sequence_lt_omega1 {α} [Countable α] (o : α → Ordinal) (ho : ∀ n, o n < ω₁) :
-  sup o < ω₁ := by
+    sup o < ω₁ := by
   apply sup_lt_ord_lift _ ho
   rw [initial, Cardinal.isRegular_aleph_one.cof_eq]
   exact lt_of_le_of_lt mk_le_aleph0 aleph0_lt_aleph_one

--- a/Mathlib/SetTheory/Cardinal/Ordinal.lean
+++ b/Mathlib/SetTheory/Cardinal/Ordinal.lean
@@ -1456,7 +1456,7 @@ namespace Ordinal
 `ω_ o` is a notation for the *initial ordinal* of cardinality
 `aleph o`. Thus, for example `ω_ 0 = ω`.
 -/
-scoped notation "ω_" => λ o ↦ ord <| aleph o
+scoped notation "ω_" o => ord <| aleph o
 
 /--
 `ω₁` is the first uncountable ordinal.

--- a/Mathlib/SetTheory/Cardinal/Ordinal.lean
+++ b/Mathlib/SetTheory/Cardinal/Ordinal.lean
@@ -1502,13 +1502,13 @@ open scoped Cardinal
 Bounding the cardinal of an ordinal-indexed union of sets.
 -/
 lemma mk_iUnion_Ordinal_le_of_le {β : Type _} {o : Ordinal} {κ : Cardinal}
-    (ho : o ≤ κ.ord) (hκ : ℵ₀ ≤ κ) (A : Ordinal → Set β)
+    (ho : o.card ≤ κ) (hκ : ℵ₀ ≤ κ) (A : Ordinal → Set β)
     (hA : ∀ j < o, #(A j) ≤ κ) :
     #(⋃ j < o, A j) ≤ κ := by
   simp_rw [← mem_Iio, biUnion_eq_iUnion, iUnion, iSup, ← o.enumIsoOut.symm.surjective.range_comp]
   apply ((mk_iUnion_le _).trans _).trans_eq (mul_eq_self hκ)
   rw [mk_ordinal_out]
-  exact mul_le_mul' (card_le_of_le_ord ho) <| ciSup_le' <| (hA _ <| typein_lt_self ·)
+  exact mul_le_mul' ho <| ciSup_le' <| (hA _ <| typein_lt_self ·)
 
 end Cardinal
 

--- a/Mathlib/SetTheory/Cardinal/Ordinal.lean
+++ b/Mathlib/SetTheory/Cardinal/Ordinal.lean
@@ -1482,10 +1482,7 @@ An initial ordinal is a limit ordinal.
 -/
 lemma isLimit_initial (i : Ordinal): (ω_ i).IsLimit := ord_isLimit (aleph0_le_aleph i)
 
-lemma omega_lt_omega1 : ω < ω₁ := by
-  have := (ord_lt_ord.mpr (aleph0_lt_aleph_one))
-  rw [ord_aleph0] at this
-  exact this
+lemma omega_lt_omega1 : ω < ω₁ := ord_aleph0.symm.trans_lt (ord_lt_ord.mpr (aleph0_lt_aleph_one))
 
 end Ordinal
 
@@ -1505,18 +1502,10 @@ open scoped Cardinal
 Bounding the cardinal of an ordinal-indexed union of sets.
 -/
 lemma mk_iUnion_Ordinal_le_of_le {β : Type _} {κ : Cardinal} {i : Ordinal}
-  (hi : i ≤ κ.ord) (hκ : ℵ₀ ≤ κ) (A : Ordinal → Set β)
-  (hA : ∀ j < i, #(A j) ≤ κ) :
-  #(⋃ j < i, A j) ≤ κ := by
-  have : (⋃ j < i, A j) = ⋃ j : i.out.α, A (@typein _ (· < ·) (by infer_instance) j)
-  · ext x; constructor
-    · rintro ⟨_, ⟨j, rfl⟩, _, ⟨hji, rfl⟩, hx⟩
-      refine mem_iUnion.2 ⟨enum (· < ·) j ?_, ?_⟩
-      · rwa [Ordinal.type_lt]
-      simpa using hx
-    · rintro ⟨_, ⟨j, rfl⟩, hx⟩
-      exact mem_iUnion₂.2 ⟨_, typein_lt_self j, hx⟩
-  rw [this]
+    (hi : i ≤ κ.ord) (hκ : ℵ₀ ≤ κ) (A : Ordinal → Set β)
+    (hA : ∀ j < i, #(A j) ≤ κ) :
+    #(⋃ j < i, A j) ≤ κ := by
+  simp_rw [← mem_Iio, biUnion_eq_iUnion, iUnion, iSup, ← i.enumIsoOut.symm.surjective.range_comp]
   apply ((mk_iUnion_le _).trans _).trans_eq (mul_eq_self hκ)
   rw [mk_ordinal_out]
   exact mul_le_mul' (card_le_of_le_ord hi) <| ciSup_le' <| (hA _ <| typein_lt_self ·)

--- a/Mathlib/SetTheory/Cardinal/Ordinal.lean
+++ b/Mathlib/SetTheory/Cardinal/Ordinal.lean
@@ -24,7 +24,7 @@ using ordinals.
   It is an order isomorphism between ordinals and cardinals.
 * The function `Cardinal.aleph` gives the infinite cardinals listed by their
   ordinal index. `aleph 0 = ℵ₀`, `aleph 1 = succ ℵ₀` is the first
-  uncountable cardinal, and so on. The related function `ordinal.initial`
+  uncountable cardinal, and so on. The related function `Ordinal.initial`
   (notation: `ω_`) gives the first ordinal of a given infinite cardinality.
   Thus `ω_ 0 = ω` and `ω_ 1` is the first uncountable ordinal.
 * The function `Cardinal.beth` enumerates the Beth cardinals. `beth 0 = ℵ₀`,
@@ -1467,7 +1467,7 @@ scoped notation "ω_" => Ordinal.initial
 scoped notation "ω₁" => Ordinal.initial 1
 
 @[simp]
-theorem cardInitial (i : Ordinal): card (initial i) = aleph i := card_ord _
+theorem card_initial (i : Ordinal): card (initial i) = aleph i := card_ord _
 
 /--
 The first (infinite) initial ordinal is `ω`.
@@ -1482,7 +1482,7 @@ An initial ordinal is a limit ordinal.
 -/
 lemma isLimit_initial (i : Ordinal): (ω_ i).IsLimit := ord_isLimit (aleph0_le_aleph i)
 
-lemma omega_lt_omega_1 : ω < ω₁ := by
+lemma omega_lt_omega1 : ω < ω₁ := by
   have := (ord_lt_ord.mpr (aleph0_lt_aleph_one))
   rw [ord_aleph0] at this
   exact this
@@ -1504,7 +1504,7 @@ open scoped Cardinal
 /--
 Bounding the cardinal of an ordinal-indexed union of sets.
 -/
-lemma mk_Union_ordinal_le_of_le {β : Type _} {κ : Cardinal} {i : Ordinal}
+lemma mk_iUnion_Ordinal_le_of_le {β : Type _} {κ : Cardinal} {i : Ordinal}
   (hi : i ≤ κ.ord) (hκ : ℵ₀ ≤ κ) (A : Ordinal → Set β)
   (hA : ∀ j < i, #(A j) ≤ κ) :
   #(⋃ j < i, A j) ≤ κ := by

--- a/Mathlib/SetTheory/Cardinal/Ordinal.lean
+++ b/Mathlib/SetTheory/Cardinal/Ordinal.lean
@@ -24,8 +24,8 @@ using ordinals.
   It is an order isomorphism between ordinals and cardinals.
 * The function `Cardinal.aleph` gives the infinite cardinals listed by their
   ordinal index. `aleph 0 = ℵ₀`, `aleph 1 = succ ℵ₀` is the first
-  uncountable cardinal, and so on. The related function `Ordinal.initial`
-  (notation: `ω_`) gives the first ordinal of a given infinite cardinality.
+  uncountable cardinal, and so on. The notation `ω_` combines the latter with `Cardinal.ord`,
+  giving an enumeration of (infinite) initial ordinals.
   Thus `ω_ 0 = ω` and `ω₁ = ω_ 1` is the first uncountable ordinal.
 * The function `Cardinal.beth` enumerates the Beth cardinals. `beth 0 = ℵ₀`,
   `beth (succ o) = 2 ^ beth o`, and for a limit ordinal `o`, `beth o` is the supremum of `beth a`
@@ -1452,41 +1452,16 @@ section Initial
 
 namespace Ordinal
 
-open Cardinal
+/--
+`ω_ o` is a notation for the *initial ordinal* of cardinality
+`aleph o`. Thus, for example `ω_ 0 = ω`.
+-/
+scoped notation "ω_" => λ o ↦ ord <| aleph o
 
 /--
-`initial o` (notation: `ω_ o`) gives the first ordinal of cardinality
-`aleph o`. Thus `ω_ 0 = ω` and `ω_ 1` is the first uncountable ordinal.
-You can also write `ω_ 1` as `ω₁`.
+`ω₁` is the first uncountable ordinal.
 -/
-def initial (o : Ordinal.{u}) : Ordinal.{u} := (aleph o).ord
-
-@[inherit_doc]
-scoped notation "ω_" => Ordinal.initial
-@[inherit_doc]
-scoped notation "ω₁" => Ordinal.initial 1
-
-@[simp]
-theorem card_initial (o : Ordinal): card (initial o) = aleph o := card_ord _
-
-/--
-The first (infinite) initial ordinal is `ω`.
--/
-@[simp]
-lemma initial0 : ω_ 0 = ω := by
-  unfold initial
-  simp
-
-/--
-An initial ordinal is a limit ordinal.
--/
-lemma isLimit_initial (o : Ordinal): (ω_ o).IsLimit := ord_isLimit (aleph0_le_aleph o)
-
-lemma omega_lt_omega1 : ω < ω₁ := ord_aleph0.symm.trans_lt (ord_lt_ord.mpr (aleph0_lt_aleph_one))
-
-end Ordinal
-
-end Initial
+scoped notation "ω₁" => ord <| aleph 1
 
 section OrdinalIndices
 /-!

--- a/Mathlib/SetTheory/Cardinal/Ordinal.lean
+++ b/Mathlib/SetTheory/Cardinal/Ordinal.lean
@@ -26,7 +26,7 @@ using ordinals.
   ordinal index. `aleph 0 = ℵ₀`, `aleph 1 = succ ℵ₀` is the first
   uncountable cardinal, and so on. The related function `Ordinal.initial`
   (notation: `ω_`) gives the first ordinal of a given infinite cardinality.
-  Thus `ω_ 0 = ω` and `ω_ 1` is the first uncountable ordinal.
+  Thus `ω_ 0 = ω` and `ω₁ = ω_ 1` is the first uncountable ordinal.
 * The function `Cardinal.beth` enumerates the Beth cardinals. `beth 0 = ℵ₀`,
   `beth (succ o) = 2 ^ beth o`, and for a limit ordinal `o`, `beth o` is the supremum of `beth a`
   for `a < o`.
@@ -1455,8 +1455,8 @@ namespace Ordinal
 open Cardinal
 
 /--
-`initial i` (notation: `ω_ i`) gives the first ordinal of cardinality
-`aleph i`. Thus `ω_ 0 = ω` and `ω_ 1` is the first uncountable ordinal.
+`initial o` (notation: `ω_ o`) gives the first ordinal of cardinality
+`aleph o`. Thus `ω_ 0 = ω` and `ω_ 1` is the first uncountable ordinal.
 You can also write `ω_ 1` as `ω₁`.
 -/
 def initial (x : Ordinal.{u}) : Ordinal.{u} := (aleph x).ord
@@ -1467,7 +1467,7 @@ scoped notation "ω_" => Ordinal.initial
 scoped notation "ω₁" => Ordinal.initial 1
 
 @[simp]
-theorem card_initial (i : Ordinal): card (initial i) = aleph i := card_ord _
+theorem card_initial (o : Ordinal): card (initial o) = aleph o := card_ord _
 
 /--
 The first (infinite) initial ordinal is `ω`.
@@ -1480,7 +1480,7 @@ lemma initial0 : ω_ 0 = ω := by
 /--
 An initial ordinal is a limit ordinal.
 -/
-lemma isLimit_initial (i : Ordinal): (ω_ i).IsLimit := ord_isLimit (aleph0_le_aleph i)
+lemma isLimit_initial (o : Ordinal): (ω_ o).IsLimit := ord_isLimit (aleph0_le_aleph o)
 
 lemma omega_lt_omega1 : ω < ω₁ := ord_aleph0.symm.trans_lt (ord_lt_ord.mpr (aleph0_lt_aleph_one))
 
@@ -1501,14 +1501,14 @@ open scoped Cardinal
 /--
 Bounding the cardinal of an ordinal-indexed union of sets.
 -/
-lemma mk_iUnion_Ordinal_le_of_le {β : Type _} {κ : Cardinal} {i : Ordinal}
-    (hi : i ≤ κ.ord) (hκ : ℵ₀ ≤ κ) (A : Ordinal → Set β)
-    (hA : ∀ j < i, #(A j) ≤ κ) :
-    #(⋃ j < i, A j) ≤ κ := by
-  simp_rw [← mem_Iio, biUnion_eq_iUnion, iUnion, iSup, ← i.enumIsoOut.symm.surjective.range_comp]
+lemma mk_iUnion_Ordinal_le_of_le {β : Type _} {o : Ordinal} {κ : Cardinal}
+    (ho : o ≤ κ.ord) (hκ : ℵ₀ ≤ κ) (A : Ordinal → Set β)
+    (hA : ∀ j < o, #(A j) ≤ κ) :
+    #(⋃ j < o, A j) ≤ κ := by
+  simp_rw [← mem_Iio, biUnion_eq_iUnion, iUnion, iSup, ← o.enumIsoOut.symm.surjective.range_comp]
   apply ((mk_iUnion_le _).trans _).trans_eq (mul_eq_self hκ)
   rw [mk_ordinal_out]
-  exact mul_le_mul' (card_le_of_le_ord hi) <| ciSup_le' <| (hA _ <| typein_lt_self ·)
+  exact mul_le_mul' (card_le_of_le_ord ho) <| ciSup_le' <| (hA _ <| typein_lt_self ·)
 
 end Cardinal
 

--- a/Mathlib/SetTheory/Cardinal/Ordinal.lean
+++ b/Mathlib/SetTheory/Cardinal/Ordinal.lean
@@ -1463,6 +1463,8 @@ scoped notation "ω_" => λ o ↦ ord <| aleph o
 -/
 scoped notation "ω₁" => ord <| aleph 1
 
+lemma omega_lt_omega1 : ω < ω₁ := ord_aleph0.symm.trans_lt (ord_lt_ord.mpr (aleph0_lt_aleph_one))
+
 section OrdinalIndices
 /-!
 ### Cardinal operations with ordinal indices

--- a/Mathlib/SetTheory/Cardinal/Ordinal.lean
+++ b/Mathlib/SetTheory/Cardinal/Ordinal.lean
@@ -1459,7 +1459,7 @@ open Cardinal
 `aleph o`. Thus `ω_ 0 = ω` and `ω_ 1` is the first uncountable ordinal.
 You can also write `ω_ 1` as `ω₁`.
 -/
-def initial (x : Ordinal.{u}) : Ordinal.{u} := (aleph x).ord
+def initial (o : Ordinal.{u}) : Ordinal.{u} := (aleph o).ord
 
 @[inherit_doc]
 scoped notation "ω_" => Ordinal.initial
@@ -1501,12 +1501,12 @@ open scoped Cardinal
 /--
 Bounding the cardinal of an ordinal-indexed union of sets.
 -/
-lemma mk_iUnion_Ordinal_le_of_le {β : Type _} {o : Ordinal} {κ : Cardinal}
-    (ho : o.card ≤ κ) (hκ : ℵ₀ ≤ κ) (A : Ordinal → Set β)
-    (hA : ∀ j < o, #(A j) ≤ κ) :
-    #(⋃ j < o, A j) ≤ κ := by
+lemma mk_iUnion_Ordinal_le_of_le {β : Type _} {o : Ordinal} {c : Cardinal}
+    (ho : o.card ≤ c) (hc : ℵ₀ ≤ c) (A : Ordinal → Set β)
+    (hA : ∀ j < o, #(A j) ≤ c) :
+    #(⋃ j < o, A j) ≤ c := by
   simp_rw [← mem_Iio, biUnion_eq_iUnion, iUnion, iSup, ← o.enumIsoOut.symm.surjective.range_comp]
-  apply ((mk_iUnion_le _).trans _).trans_eq (mul_eq_self hκ)
+  apply ((mk_iUnion_le _).trans _).trans_eq (mul_eq_self hc)
   rw [mk_ordinal_out]
   exact mul_le_mul' ho <| ciSup_le' <| (hA _ <| typein_lt_self ·)
 

--- a/Mathlib/SetTheory/Cardinal/Ordinal.lean
+++ b/Mathlib/SetTheory/Cardinal/Ordinal.lean
@@ -1455,8 +1455,8 @@ namespace Ordinal
 open Cardinal
 
 /--
-`Initial i` (notation: `ω_ i`) gives the first ordinal of cardinality
-`Aleph i`. Thus `ω_ 0 = ω` and `ω_ 1` is the first uncountable ordinal.
+`initial i` (notation: `ω_ i`) gives the first ordinal of cardinality
+`aleph i`. Thus `ω_ 0 = ω` and `ω_ 1` is the first uncountable ordinal.
 You can also write `ω_ 1` as `ω₁`.
 -/
 def initial (x : Ordinal.{u}) : Ordinal.{u} := (aleph x).ord

--- a/Mathlib/SetTheory/Ordinal/Basic.lean
+++ b/Mathlib/SetTheory/Ordinal/Basic.lean
@@ -1390,7 +1390,7 @@ The converse, however, is false (for instance, `i = ω+1` and `κ = ℵ₀`).
 -/
 lemma card_le_of_le_ord {κ : Cardinal} {i : Ordinal} (hi : i ≤ κ.ord) :
   i.card ≤ κ := by
-  rw [← card_ord κ] ; exact Ordinal.card_le_card hi
+  rw [← card_ord κ]; exact Ordinal.card_le_card hi
 
 @[mono]
 theorem ord_strictMono : StrictMono ord :=

--- a/Mathlib/SetTheory/Ordinal/Basic.lean
+++ b/Mathlib/SetTheory/Ordinal/Basic.lean
@@ -1382,15 +1382,15 @@ theorem lt_ord_succ_card (o : Ordinal) : o < (succ o.card).ord :=
 #align cardinal.lt_ord_succ_card Cardinal.lt_ord_succ_card
 
 /--
-A variation on `Cardinal.lt_ord` using `≤`: If `i` is no greater than the
-initial ordinal of cardinality `κ`, then the cardinal of any of its realizations
-is no greater than `κ`.
+A variation on `Cardinal.lt_ord` using `≤`: If `o` is no greater than the
+initial ordinal of cardinality `c`, then the cardinal of any of its realizations
+is no greater than `c`.
 
-The converse, however, is false (for instance, `i = ω+1` and `κ = ℵ₀`).
+The converse, however, is false (for instance, `o = ω+1` and `c = ℵ₀`).
 -/
-lemma card_le_of_le_ord {c : Cardinal} {o : Ordinal} (hi : o ≤ c.ord) :
-    i.card ≤ κ := by
-  rw [← card_ord κ]; exact Ordinal.card_le_card hi
+lemma card_le_of_le_ord {c : Cardinal} {o : Ordinal} (ho : o ≤ c.ord) :
+    o.card ≤ c := by
+  rw [← card_ord c]; exact Ordinal.card_le_card ho
 
 @[mono]
 theorem ord_strictMono : StrictMono ord :=

--- a/Mathlib/SetTheory/Ordinal/Basic.lean
+++ b/Mathlib/SetTheory/Ordinal/Basic.lean
@@ -1381,6 +1381,9 @@ theorem lt_ord_succ_card (o : Ordinal) : o < (succ o.card).ord :=
   lt_ord.2 <| lt_succ _
 #align cardinal.lt_ord_succ_card Cardinal.lt_ord_succ_card
 
+theorem card_le_iff {o : Ordinal} {c : Cardinal} : o.card ≤ c ↔ o < (succ c).ord := by
+  rw [lt_ord, lt_succ_iff]
+
 /--
 A variation on `Cardinal.lt_ord` using `≤`: If `o` is no greater than the
 initial ordinal of cardinality `c`, then the cardinal of any of its realizations
@@ -1388,7 +1391,7 @@ is no greater than `c`.
 
 The converse, however, is false (for instance, `o = ω+1` and `c = ℵ₀`).
 -/
-lemma card_le_of_le_ord {c : Cardinal} {o : Ordinal} (ho : o ≤ c.ord) :
+lemma card_le_of_le_ord {o : Ordinal} {c : Cardinal} (ho : o ≤ c.ord) :
     o.card ≤ c := by
   rw [← card_ord c]; exact Ordinal.card_le_card ho
 

--- a/Mathlib/SetTheory/Ordinal/Basic.lean
+++ b/Mathlib/SetTheory/Ordinal/Basic.lean
@@ -1381,6 +1381,17 @@ theorem lt_ord_succ_card (o : Ordinal) : o < (succ o.card).ord :=
   lt_ord.2 <| lt_succ _
 #align cardinal.lt_ord_succ_card Cardinal.lt_ord_succ_card
 
+/--
+A variation on `Cardinal.lt_ord` using `≤`: If `i` is no greater than the
+initial ordinal of cardinality `κ`, then the cardinal of any of its realizations
+is no greater than `κ`.
+
+The converse, however, is false (for instance, `i = ω+1` and `κ = ℵ₀`).
+-/
+lemma card_le_of_le_ord {κ : Cardinal} {i : Ordinal} (hi : i ≤ κ.ord) :
+  i.card ≤ κ := by
+  rw [← card_ord κ] ; exact Ordinal.card_le_card hi
+
 @[mono]
 theorem ord_strictMono : StrictMono ord :=
   gciOrdCard.strictMono_l

--- a/Mathlib/SetTheory/Ordinal/Basic.lean
+++ b/Mathlib/SetTheory/Ordinal/Basic.lean
@@ -1388,8 +1388,8 @@ is no greater than `κ`.
 
 The converse, however, is false (for instance, `i = ω+1` and `κ = ℵ₀`).
 -/
-lemma card_le_of_le_ord {κ : Cardinal} {i : Ordinal} (hi : i ≤ κ.ord) :
-  i.card ≤ κ := by
+lemma card_le_of_le_ord {c : Cardinal} {o : Ordinal} (hi : o ≤ c.ord) :
+    i.card ≤ κ := by
   rw [← card_ord κ]; exact Ordinal.card_le_card hi
 
 @[mono]

--- a/Mathlib/SetTheory/Ordinal/Basic.lean
+++ b/Mathlib/SetTheory/Ordinal/Basic.lean
@@ -1386,8 +1386,7 @@ theorem card_le_iff {o : Ordinal} {c : Cardinal} : o.card ≤ c ↔ o < (succ c)
 
 /--
 A variation on `Cardinal.lt_ord` using `≤`: If `o` is no greater than the
-initial ordinal of cardinality `c`, then the cardinal of any of its realizations
-is no greater than `c`.
+initial ordinal of cardinality `c`, then its cardinal is no greater than `c`.
 
 The converse, however, is false (for instance, `o = ω+1` and `c = ℵ₀`).
 -/


### PR DESCRIPTION
- I setup notation for the first ordinal in each cardinality.
- `ω₁` is defined as an ordinal, not as an `out` (cf. `MeasureTheory.CardMeasurableSpace`).
- Lemma using the cofinality of `ω₁`.
- Lemma on the cardinality of ordinal-indexed `iUnion`s in preparation for material on the Borel hierarchy.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
