### PR TITLE
[Merged by Bors] - perf: add instance shortcut to remove heartbeat bump

### DIFF
--- a/Mathlib/NumberTheory/NumberField/Units.lean
+++ b/Mathlib/NumberTheory/NumberField/Units.lean
@@ -111,7 +111,9 @@ instance [NumberField K] : Fintype (torsion K) := by
   · rw [← h_ua]
     exact le_of_eq ((eq_iff_eq _ 1).mp ((mem_torsion K).mp h_tors) φ)
 
-set_option synthInstance.maxHeartbeats 30000 in
+-- a shortcut instance to stop the next instance from timing out
+instance [NumberField K] : Finite (torsion K) := inferInstance
+
 /-- The torsion subgroup is cylic. -/
 instance [NumberField K] : IsCyclic (torsion K) := subgroup_units_cyclic _
 


### PR DESCRIPTION
This removes a maxHeartbeats bump (the only one in the file).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

Is this the way we want to remove these though? On master, typeclass inference does a lot of work making the heartbeat-bumped instance, going down some very long and wrong detours. The hint is enough.