### PR TITLE
[Merged by Bors] - feat: add `auto-merge-after-CI` label

### DIFF
--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -188,13 +188,7 @@ jobs:
             --url https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/awaiting-CI \
             --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
 
-      - id: echo_labels
-        name: Echo PR labels
-        run: |
-          echo ${{ steps.PR.outputs.pr_labels }}
-
-      - # if: contains(${{ steps.PR.outputs.pr_labels }}, 'auto-merge-after-CI')
-        if: #{{ false }}
+      - if: contains(steps.PR.outputs.pr_labels, 'auto-merge-after-CI')
         name: If `auto-merge-after-CI` is present, add a `bors merge` comment.
         uses: GrantBirki/comment@v2.0.1
         with:

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -193,8 +193,8 @@ jobs:
         run: |
           echo ${{ steps.PR.outputs.pr_labels }}
 
-      - name: If `auto-merge-after-CI` is present, add a `bors merge` comment.
-        if: contains(${{ steps.PR.outputs.pr_labels }}, 'auto-merge-after-CI')
+      - if: contains(${{ steps.PR.outputs.pr_labels }}, 'auto-merge-after-CI')
+        name: If `auto-merge-after-CI` is present, add a `bors merge` comment.
         uses: GrantBirki/comment@v2.0.1
         with:
           issue-number: ${{ steps.PR.outputs.number }}

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -142,25 +142,25 @@ jobs:
         env:
           MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}
 
-      - name: build archive
-        run: lake build Archive
+      # - name: build archive
+      #   run: lake build Archive
 
-      - name: build counterexamples
-        run: lake build Counterexamples
+      # - name: build counterexamples
+      #   run: lake build Counterexamples
 
-      - name: check declarations in db files
-        run: |
-          python3 scripts/yaml_check.py docs/100.yaml docs/overview.yaml docs/undergrad.yaml
-          build/bin/checkYaml
+      # - name: check declarations in db files
+      #   run: |
+      #     python3 scripts/yaml_check.py docs/100.yaml docs/overview.yaml docs/undergrad.yaml
+      #     build/bin/checkYaml
 
-      - name: test mathlib
-        run: make -j 8 test
+      # - name: test mathlib
+      #   run: make -j 8 test
 
-      - name: lint mathlib
-        uses: liskin/gh-problem-matcher-wrap@v2
-        with:
-          linters: gcc
-          run: env LEAN_ABORT_ON_PANIC=1 make lint
+      # - name: lint mathlib
+      #   uses: liskin/gh-problem-matcher-wrap@v2
+      #   with:
+      #     linters: gcc
+      #     run: env LEAN_ABORT_ON_PANIC=1 make lint
 
   final:
     name: Post-CI job

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -142,25 +142,25 @@ jobs:
         env:
           MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}
 
-      # - name: build archive
-      #   run: lake build Archive
+      - name: build archive
+        run: lake build Archive
 
-      # - name: build counterexamples
-      #   run: lake build Counterexamples
+      - name: build counterexamples
+        run: lake build Counterexamples
 
-      # - name: check declarations in db files
-      #   run: |
-      #     python3 scripts/yaml_check.py docs/100.yaml docs/overview.yaml docs/undergrad.yaml
-      #     build/bin/checkYaml
+      - name: check declarations in db files
+        run: |
+          python3 scripts/yaml_check.py docs/100.yaml docs/overview.yaml docs/undergrad.yaml
+          build/bin/checkYaml
 
-      # - name: test mathlib
-      #   run: make -j 8 test
+      - name: test mathlib
+        run: make -j 8 test
 
-      # - name: lint mathlib
-      #   uses: liskin/gh-problem-matcher-wrap@v2
-      #   with:
-      #     linters: gcc
-      #     run: env LEAN_ABORT_ON_PANIC=1 make lint
+      - name: lint mathlib
+        uses: liskin/gh-problem-matcher-wrap@v2
+        with:
+          linters: gcc
+          run: env LEAN_ABORT_ON_PANIC=1 make lint
 
   final:
     name: Post-CI job

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -188,11 +188,16 @@ jobs:
             --url https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/awaiting-CI \
             --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
 
+      - id: echo_labels
+        name: Echo PR labels
+        run: |
+          echo ${{ steps.PR.outputs.pr_labels }}
+
       - name: If `auto-merge-after-CI` is present, add a `bors merge` comment.
-        if: contains( ${{ steps.PR.outputs.pr_labels }}, 'auto-merge-after-CI')
+        if: contains(${{ steps.PR.outputs.pr_labels }}, 'auto-merge-after-CI')
         uses: GrantBirki/comment@v2.0.1
         with:
-          issue-number: ${{ github.event.issue.number }}
+          issue-number: ${{ steps.PR.outputs.number }}
           body: |
             As this PR is labelled `auto-merge-after-CI`, we are now sending it to bors:
 

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -188,43 +188,8 @@ jobs:
             --url https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/awaiting-CI \
             --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
 
-      - name: Get PR labels
-        id: pr_labels
-        uses: octokit/graphql-action@v2.x
-        with:
-          query: |
-            query PR($owner: String!, $repo: String!, $number: Int!) {
-              repository(owner:$owner, name:$repo) {
-                pullRequest(number:$number) {
-                  labels(first:100) {
-                    nodes {
-                      name
-                    }
-                  }
-                }
-              }
-            }
-          owner: ${{ github.repository_owner }}
-          repo: ${{ github.event.repository.name }}
-          number: ${{ github.event.pull_request.number }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Check for the `auto-merge-after-CI` label.
-        id: check_label
-        run: |
-          LABELS=$(jq -r '.data.repository.pullRequest.labels.nodes[] | .name' <<< "${{ steps.pr_labels.outputs.data }}")
-          if echo "${LABELS}" | grep -q 'auto-merge-after-CI'; then
-            echo "AUTO_MERGE=true" >> $GITHUB_ENV
-          else
-            echo "AUTO_MERGE=false" >> $GITHUB_ENV
-
-      - name: Run if label exists
-        if: ${{ env.AUTO_MERGE == 'true' }}
-        run: |
-          echo "This will run if the PR has the 'my-label' label"
-
-      - name: If `AUTO_MERGE` is set, add a `bors merge` comment.
+      - name: If `auto-merge-after-CI` is present, add a `bors merge` comment.
+        if: contains( ${{ steps.PR.outputs.pr_labels }}, 'auto-merge-after-CI')
         uses: GrantBirki/comment@v2.0.1
         with:
           issue-number: ${{ github.event.issue.number }}

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -192,6 +192,7 @@ jobs:
         name: If `auto-merge-after-CI` is present, add a `bors merge` comment.
         uses: GrantBirki/comment@v2.0.1
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ steps.PR.outputs.number }}
           body: |
             As this PR is labelled `auto-merge-after-CI`, we are now sending it to bors:

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -192,7 +192,7 @@ jobs:
         name: If `auto-merge-after-CI` is present, add a `bors merge` comment.
         uses: GrantBirki/comment@v2.0.1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.AUTO_MERGE_TOKEN }}
           issue-number: ${{ steps.PR.outputs.number }}
           body: |
             As this PR is labelled `auto-merge-after-CI`, we are now sending it to bors:

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -187,3 +187,48 @@ jobs:
           curl --request DELETE \
             --url https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/awaiting-CI \
             --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
+
+      - name: Get PR labels
+        id: pr_labels
+        uses: octokit/graphql-action@v2.x
+        with:
+          query: |
+            query PR($owner: String!, $repo: String!, $number: Int!) {
+              repository(owner:$owner, name:$repo) {
+                pullRequest(number:$number) {
+                  labels(first:100) {
+                    nodes {
+                      name
+                    }
+                  }
+                }
+              }
+            }
+          owner: ${{ github.repository_owner }}
+          repo: ${{ github.event.repository.name }}
+          number: ${{ github.event.pull_request.number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check for the `auto-merge-after-CI` label.
+        id: check_label
+        run: |
+          LABELS=$(jq -r '.data.repository.pullRequest.labels.nodes[] | .name' <<< "${{ steps.pr_labels.outputs.data }}")
+          if echo "${LABELS}" | grep -q 'auto-merge-after-CI'; then
+            echo "AUTO_MERGE=true" >> $GITHUB_ENV
+          else
+            echo "AUTO_MERGE=false" >> $GITHUB_ENV
+
+      - name: Run if label exists
+        if: ${{ env.AUTO_MERGE == 'true' }}
+        run: |
+          echo "This will run if the PR has the 'my-label' label"
+
+      - name: If `AUTO_MERGE` is set, add a `bors merge` comment.
+        uses: GrantBirki/comment@v2.0.1
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            As this PR is labelled `auto-merge-after-CI`, we are now sending it to bors:
+
+            bors merge

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -192,9 +192,9 @@ jobs:
         name: Echo PR labels
         run: |
           echo ${{ steps.PR.outputs.pr_labels }}
-          echo ${{ steps.PR.outputs.pr_labels }}
 
-      - if: contains(${{ steps.PR.outputs.pr_labels }}, 'auto-merge-after-CI')
+      - # if: contains(${{ steps.PR.outputs.pr_labels }}, 'auto-merge-after-CI')
+        if: #{{ false }}
         name: If `auto-merge-after-CI` is present, add a `bors merge` comment.
         uses: GrantBirki/comment@v2.0.1
         with:

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -192,6 +192,7 @@ jobs:
         name: Echo PR labels
         run: |
           echo ${{ steps.PR.outputs.pr_labels }}
+          echo ${{ steps.PR.outputs.pr_labels }}
 
       - if: contains(${{ steps.PR.outputs.pr_labels }}, 'auto-merge-after-CI')
         name: If `auto-merge-after-CI` is present, add a `bors merge` comment.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -194,6 +194,11 @@ jobs:
             --url https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/awaiting-CI \
             --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
 
+      - id: echo labels
+        name: Echo PR labels
+        run: |
+          echo ${{ steps.PR.outputs.pr_labels }}
+
       - name: If `auto-merge-after-CI` is present, add a `bors merge` comment.
         if: contains(${{ steps.PR.outputs.pr_labels }}, 'auto-merge-after-CI')
         uses: GrantBirki/comment@v2.0.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -194,13 +194,7 @@ jobs:
             --url https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/awaiting-CI \
             --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
 
-      - id: echo_labels
-        name: Echo PR labels
-        run: |
-          echo ${{ steps.PR.outputs.pr_labels }}
-
-      - # if: contains(${{ steps.PR.outputs.pr_labels }}, 'auto-merge-after-CI')
-        if: #{{ false }}
+      - if: contains(steps.PR.outputs.pr_labels, 'auto-merge-after-CI')
         name: If `auto-merge-after-CI` is present, add a `bors merge` comment.
         uses: GrantBirki/comment@v2.0.1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,25 +148,25 @@ jobs:
         env:
           MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}
 
-      - name: build archive
-        run: lake build Archive
+      # - name: build archive
+      #   run: lake build Archive
 
-      - name: build counterexamples
-        run: lake build Counterexamples
+      # - name: build counterexamples
+      #   run: lake build Counterexamples
 
-      - name: check declarations in db files
-        run: |
-          python3 scripts/yaml_check.py docs/100.yaml docs/overview.yaml docs/undergrad.yaml
-          build/bin/checkYaml
+      # - name: check declarations in db files
+      #   run: |
+      #     python3 scripts/yaml_check.py docs/100.yaml docs/overview.yaml docs/undergrad.yaml
+      #     build/bin/checkYaml
 
-      - name: test mathlib
-        run: make -j 8 test
+      # - name: test mathlib
+      #   run: make -j 8 test
 
-      - name: lint mathlib
-        uses: liskin/gh-problem-matcher-wrap@v2
-        with:
-          linters: gcc
-          run: env LEAN_ABORT_ON_PANIC=1 make lint
+      # - name: lint mathlib
+      #   uses: liskin/gh-problem-matcher-wrap@v2
+      #   with:
+      #     linters: gcc
+      #     run: env LEAN_ABORT_ON_PANIC=1 make lint
 
   final:
     name: Post-CI job

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -198,6 +198,7 @@ jobs:
         name: Echo PR labels
         run: |
           echo ${{ steps.PR.outputs.pr_labels }}
+          echo ${{ steps.PR.outputs.pr_labels }}
 
       - if: contains(${{ steps.PR.outputs.pr_labels }}, 'auto-merge-after-CI')
         name: If `auto-merge-after-CI` is present, add a `bors merge` comment.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,25 +148,25 @@ jobs:
         env:
           MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}
 
-      # - name: build archive
-      #   run: lake build Archive
+      - name: build archive
+        run: lake build Archive
 
-      # - name: build counterexamples
-      #   run: lake build Counterexamples
+      - name: build counterexamples
+        run: lake build Counterexamples
 
-      # - name: check declarations in db files
-      #   run: |
-      #     python3 scripts/yaml_check.py docs/100.yaml docs/overview.yaml docs/undergrad.yaml
-      #     build/bin/checkYaml
+      - name: check declarations in db files
+        run: |
+          python3 scripts/yaml_check.py docs/100.yaml docs/overview.yaml docs/undergrad.yaml
+          build/bin/checkYaml
 
-      # - name: test mathlib
-      #   run: make -j 8 test
+      - name: test mathlib
+        run: make -j 8 test
 
-      # - name: lint mathlib
-      #   uses: liskin/gh-problem-matcher-wrap@v2
-      #   with:
-      #     linters: gcc
-      #     run: env LEAN_ABORT_ON_PANIC=1 make lint
+      - name: lint mathlib
+        uses: liskin/gh-problem-matcher-wrap@v2
+        with:
+          linters: gcc
+          run: env LEAN_ABORT_ON_PANIC=1 make lint
 
   final:
     name: Post-CI job

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -198,6 +198,7 @@ jobs:
         name: If `auto-merge-after-CI` is present, add a `bors merge` comment.
         uses: GrantBirki/comment@v2.0.1
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ steps.PR.outputs.number }}
           body: |
             As this PR is labelled `auto-merge-after-CI`, we are now sending it to bors:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -193,3 +193,48 @@ jobs:
           curl --request DELETE \
             --url https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/awaiting-CI \
             --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
+
+      - name: Get PR labels
+        id: pr_labels
+        uses: octokit/graphql-action@v2.x
+        with:
+          query: |
+            query PR($owner: String!, $repo: String!, $number: Int!) {
+              repository(owner:$owner, name:$repo) {
+                pullRequest(number:$number) {
+                  labels(first:100) {
+                    nodes {
+                      name
+                    }
+                  }
+                }
+              }
+            }
+          owner: ${{ github.repository_owner }}
+          repo: ${{ github.event.repository.name }}
+          number: ${{ github.event.pull_request.number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check for the `auto-merge-after-CI` label.
+        id: check_label
+        run: |
+          LABELS=$(jq -r '.data.repository.pullRequest.labels.nodes[] | .name' <<< "${{ steps.pr_labels.outputs.data }}")
+          if echo "${LABELS}" | grep -q 'auto-merge-after-CI'; then
+            echo "AUTO_MERGE=true" >> $GITHUB_ENV
+          else
+            echo "AUTO_MERGE=false" >> $GITHUB_ENV
+
+      - name: Run if label exists
+        if: ${{ env.AUTO_MERGE == 'true' }}
+        run: |
+          echo "This will run if the PR has the 'my-label' label"
+
+      - name: If `AUTO_MERGE` is set, add a `bors merge` comment.
+        uses: GrantBirki/comment@v2.0.1
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            As this PR is labelled `auto-merge-after-CI`, we are now sending it to bors:
+
+            bors merge

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -199,8 +199,8 @@ jobs:
         run: |
           echo ${{ steps.PR.outputs.pr_labels }}
 
-      - name: If `auto-merge-after-CI` is present, add a `bors merge` comment.
-        if: contains(${{ steps.PR.outputs.pr_labels }}, 'auto-merge-after-CI')
+      - if: contains(${{ steps.PR.outputs.pr_labels }}, 'auto-merge-after-CI')
+        name: If `auto-merge-after-CI` is present, add a `bors merge` comment.
         uses: GrantBirki/comment@v2.0.1
         with:
           issue-number: ${{ steps.PR.outputs.number }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -195,7 +195,7 @@ jobs:
             --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
 
       - name: If `auto-merge-after-CI` is present, add a `bors merge` comment.
-        if: contains( ${{ steps.PR.outputs.pr_labels }}, 'auto-merge-after-CI')
+        if: contains(${{ steps.PR.outputs.pr_labels }}, 'auto-merge-after-CI')
         uses: GrantBirki/comment@v2.0.1
         with:
           issue-number: ${{ steps.PR.outputs.number }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -198,9 +198,9 @@ jobs:
         name: Echo PR labels
         run: |
           echo ${{ steps.PR.outputs.pr_labels }}
-          echo ${{ steps.PR.outputs.pr_labels }}
 
-      - if: contains(${{ steps.PR.outputs.pr_labels }}, 'auto-merge-after-CI')
+      - # if: contains(${{ steps.PR.outputs.pr_labels }}, 'auto-merge-after-CI')
+        if: #{{ false }}
         name: If `auto-merge-after-CI` is present, add a `bors merge` comment.
         uses: GrantBirki/comment@v2.0.1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -194,43 +194,8 @@ jobs:
             --url https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/awaiting-CI \
             --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
 
-      - name: Get PR labels
-        id: pr_labels
-        uses: octokit/graphql-action@v2.x
-        with:
-          query: |
-            query PR($owner: String!, $repo: String!, $number: Int!) {
-              repository(owner:$owner, name:$repo) {
-                pullRequest(number:$number) {
-                  labels(first:100) {
-                    nodes {
-                      name
-                    }
-                  }
-                }
-              }
-            }
-          owner: ${{ github.repository_owner }}
-          repo: ${{ github.event.repository.name }}
-          number: ${{ github.event.pull_request.number }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Check for the `auto-merge-after-CI` label.
-        id: check_label
-        run: |
-          LABELS=$(jq -r '.data.repository.pullRequest.labels.nodes[] | .name' <<< "${{ steps.pr_labels.outputs.data }}")
-          if echo "${LABELS}" | grep -q 'auto-merge-after-CI'; then
-            echo "AUTO_MERGE=true" >> $GITHUB_ENV
-          else
-            echo "AUTO_MERGE=false" >> $GITHUB_ENV
-
-      - name: Run if label exists
-        if: ${{ env.AUTO_MERGE == 'true' }}
-        run: |
-          echo "This will run if the PR has the 'my-label' label"
-
-      - name: If `AUTO_MERGE` is set, add a `bors merge` comment.
+      - name: If `auto-merge-after-CI` is present, add a `bors merge` comment.
+        if: contains( ${{ steps.PR.outputs.pr_labels }}, 'auto-merge-after-CI')
         uses: GrantBirki/comment@v2.0.1
         with:
           issue-number: ${{ github.event.issue.number }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -198,7 +198,7 @@ jobs:
         if: contains( ${{ steps.PR.outputs.pr_labels }}, 'auto-merge-after-CI')
         uses: GrantBirki/comment@v2.0.1
         with:
-          issue-number: ${{ github.event.issue.number }}
+          issue-number: ${{ steps.PR.outputs.number }}
           body: |
             As this PR is labelled `auto-merge-after-CI`, we are now sending it to bors:
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -198,7 +198,7 @@ jobs:
         name: If `auto-merge-after-CI` is present, add a `bors merge` comment.
         uses: GrantBirki/comment@v2.0.1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.AUTO_MERGE_TOKEN }}
           issue-number: ${{ steps.PR.outputs.number }}
           body: |
             As this PR is labelled `auto-merge-after-CI`, we are now sending it to bors:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,26 +148,25 @@ jobs:
         env:
           MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}
 
-      # - name: build archive
-      #   run: lake build Archive
+      - name: build archive
+        run: lake build Archive
 
-      # - name: build counterexamples
-      #   run: lake build Counterexamples
+      - name: build counterexamples
+        run: lake build Counterexamples
 
-      # - name: check declarations in db files
-      #   run: |
-      #     python3 scripts/yaml_check.py docs/100.yaml docs/overview.yaml docs/undergrad.yaml
-      #     build/bin/checkYaml
+      - name: check declarations in db files
+        run: |
+          python3 scripts/yaml_check.py docs/100.yaml docs/overview.yaml docs/undergrad.yaml
+          build/bin/checkYaml
 
-      # - name: test mathlib
-      #   run: make -j 8 test
+      - name: test mathlib
+        run: make -j 8 test
 
-
-      # - name: lint mathlib
-      #   uses: liskin/gh-problem-matcher-wrap@v2
-      #   with:
-      #     linters: gcc
-      #     run: env LEAN_ABORT_ON_PANIC=1 make lint
+      - name: lint mathlib
+        uses: liskin/gh-problem-matcher-wrap@v2
+        with:
+          linters: gcc
+          run: env LEAN_ABORT_ON_PANIC=1 make lint
 
   final:
     name: Post-CI job

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -194,7 +194,7 @@ jobs:
             --url https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/awaiting-CI \
             --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
 
-      - id: echo labels
+      - id: echo_labels
         name: Echo PR labels
         run: |
           echo ${{ steps.PR.outputs.pr_labels }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -162,6 +162,7 @@ jobs:
       # - name: test mathlib
       #   run: make -j 8 test
 
+
       # - name: lint mathlib
       #   uses: liskin/gh-problem-matcher-wrap@v2
       #   with:

--- a/.github/workflows/build.yml.in
+++ b/.github/workflows/build.yml.in
@@ -175,7 +175,7 @@ jobs:
             --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
 
       - name: If `auto-merge-after-CI` is present, add a `bors merge` comment.
-        if: contains( ${{ steps.PR.outputs.pr_labels }}, 'auto-merge-after-CI')
+        if: contains(${{ steps.PR.outputs.pr_labels }}, 'auto-merge-after-CI')
         uses: GrantBirki/comment@v2.0.1
         with:
           issue-number: ${{ github.event.issue.number }}

--- a/.github/workflows/build.yml.in
+++ b/.github/workflows/build.yml.in
@@ -174,13 +174,7 @@ jobs:
             --url https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/awaiting-CI \
             --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
 
-      - id: echo_labels
-        name: Echo PR labels
-        run: |
-          echo ${{ steps.PR.outputs.pr_labels }}
-
-      - # if: contains(${{ steps.PR.outputs.pr_labels }}, 'auto-merge-after-CI')
-        if: #{{ false }}
+      - if: contains(steps.PR.outputs.pr_labels, 'auto-merge-after-CI')
         name: If `auto-merge-after-CI` is present, add a `bors merge` comment.
         uses: GrantBirki/comment@v2.0.1
         with:

--- a/.github/workflows/build.yml.in
+++ b/.github/workflows/build.yml.in
@@ -178,6 +178,7 @@ jobs:
         name: Echo PR labels
         run: |
           echo ${{ steps.PR.outputs.pr_labels }}
+          echo ${{ steps.PR.outputs.pr_labels }}
 
       - if: contains(${{ steps.PR.outputs.pr_labels }}, 'auto-merge-after-CI')
         name: If `auto-merge-after-CI` is present, add a `bors merge` comment.

--- a/.github/workflows/build.yml.in
+++ b/.github/workflows/build.yml.in
@@ -128,25 +128,25 @@ jobs:
         env:
           MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}
 
-      # - name: build archive
-      #   run: lake build Archive
+      - name: build archive
+        run: lake build Archive
 
-      # - name: build counterexamples
-      #   run: lake build Counterexamples
+      - name: build counterexamples
+        run: lake build Counterexamples
 
-      # - name: check declarations in db files
-      #   run: |
-      #     python3 scripts/yaml_check.py docs/100.yaml docs/overview.yaml docs/undergrad.yaml
-      #     build/bin/checkYaml
+      - name: check declarations in db files
+        run: |
+          python3 scripts/yaml_check.py docs/100.yaml docs/overview.yaml docs/undergrad.yaml
+          build/bin/checkYaml
 
-      # - name: test mathlib
-      #   run: make -j 8 test
+      - name: test mathlib
+        run: make -j 8 test
 
-      # - name: lint mathlib
-      #   uses: liskin/gh-problem-matcher-wrap@v2
-      #   with:
-      #     linters: gcc
-      #     run: env LEAN_ABORT_ON_PANIC=1 make lint
+      - name: lint mathlib
+        uses: liskin/gh-problem-matcher-wrap@v2
+        with:
+          linters: gcc
+          run: env LEAN_ABORT_ON_PANIC=1 make lint
 
   final:
     name: Post-CI jobJOB_NAME

--- a/.github/workflows/build.yml.in
+++ b/.github/workflows/build.yml.in
@@ -173,3 +173,48 @@ jobs:
           curl --request DELETE \
             --url https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/awaiting-CI \
             --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
+
+      - name: Get PR labels
+        id: pr_labels
+        uses: octokit/graphql-action@v2.x
+        with:
+          query: |
+            query PR($owner: String!, $repo: String!, $number: Int!) {
+              repository(owner:$owner, name:$repo) {
+                pullRequest(number:$number) {
+                  labels(first:100) {
+                    nodes {
+                      name
+                    }
+                  }
+                }
+              }
+            }
+          owner: ${{ github.repository_owner }}
+          repo: ${{ github.event.repository.name }}
+          number: ${{ github.event.pull_request.number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check for the `auto-merge-after-CI` label.
+        id: check_label
+        run: |
+          LABELS=$(jq -r '.data.repository.pullRequest.labels.nodes[] | .name' <<< "${{ steps.pr_labels.outputs.data }}")
+          if echo "${LABELS}" | grep -q 'auto-merge-after-CI'; then
+            echo "AUTO_MERGE=true" >> $GITHUB_ENV
+          else
+            echo "AUTO_MERGE=false" >> $GITHUB_ENV
+
+      - name: Run if label exists
+        if: ${{ env.AUTO_MERGE == 'true' }}
+        run: |
+          echo "This will run if the PR has the 'my-label' label"
+
+      - name: If `AUTO_MERGE` is set, add a `bors merge` comment.
+        uses: GrantBirki/comment@v2.0.1
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            As this PR is labelled `auto-merge-after-CI`, we are now sending it to bors:
+
+            bors merge

--- a/.github/workflows/build.yml.in
+++ b/.github/workflows/build.yml.in
@@ -178,6 +178,7 @@ jobs:
         name: If `auto-merge-after-CI` is present, add a `bors merge` comment.
         uses: GrantBirki/comment@v2.0.1
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ steps.PR.outputs.number }}
           body: |
             As this PR is labelled `auto-merge-after-CI`, we are now sending it to bors:

--- a/.github/workflows/build.yml.in
+++ b/.github/workflows/build.yml.in
@@ -178,7 +178,7 @@ jobs:
         name: If `auto-merge-after-CI` is present, add a `bors merge` comment.
         uses: GrantBirki/comment@v2.0.1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.AUTO_MERGE_TOKEN }}
           issue-number: ${{ steps.PR.outputs.number }}
           body: |
             As this PR is labelled `auto-merge-after-CI`, we are now sending it to bors:

--- a/.github/workflows/build.yml.in
+++ b/.github/workflows/build.yml.in
@@ -178,9 +178,9 @@ jobs:
         name: Echo PR labels
         run: |
           echo ${{ steps.PR.outputs.pr_labels }}
-          echo ${{ steps.PR.outputs.pr_labels }}
 
-      - if: contains(${{ steps.PR.outputs.pr_labels }}, 'auto-merge-after-CI')
+      - # if: contains(${{ steps.PR.outputs.pr_labels }}, 'auto-merge-after-CI')
+        if: #{{ false }}
         name: If `auto-merge-after-CI` is present, add a `bors merge` comment.
         uses: GrantBirki/comment@v2.0.1
         with:

--- a/.github/workflows/build.yml.in
+++ b/.github/workflows/build.yml.in
@@ -174,43 +174,8 @@ jobs:
             --url https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/awaiting-CI \
             --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
 
-      - name: Get PR labels
-        id: pr_labels
-        uses: octokit/graphql-action@v2.x
-        with:
-          query: |
-            query PR($owner: String!, $repo: String!, $number: Int!) {
-              repository(owner:$owner, name:$repo) {
-                pullRequest(number:$number) {
-                  labels(first:100) {
-                    nodes {
-                      name
-                    }
-                  }
-                }
-              }
-            }
-          owner: ${{ github.repository_owner }}
-          repo: ${{ github.event.repository.name }}
-          number: ${{ github.event.pull_request.number }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Check for the `auto-merge-after-CI` label.
-        id: check_label
-        run: |
-          LABELS=$(jq -r '.data.repository.pullRequest.labels.nodes[] | .name' <<< "${{ steps.pr_labels.outputs.data }}")
-          if echo "${LABELS}" | grep -q 'auto-merge-after-CI'; then
-            echo "AUTO_MERGE=true" >> $GITHUB_ENV
-          else
-            echo "AUTO_MERGE=false" >> $GITHUB_ENV
-
-      - name: Run if label exists
-        if: ${{ env.AUTO_MERGE == 'true' }}
-        run: |
-          echo "This will run if the PR has the 'my-label' label"
-
-      - name: If `AUTO_MERGE` is set, add a `bors merge` comment.
+      - name: If `auto-merge-after-CI` is present, add a `bors merge` comment.
+        if: contains( ${{ steps.PR.outputs.pr_labels }}, 'auto-merge-after-CI')
         uses: GrantBirki/comment@v2.0.1
         with:
           issue-number: ${{ github.event.issue.number }}

--- a/.github/workflows/build.yml.in
+++ b/.github/workflows/build.yml.in
@@ -174,11 +174,16 @@ jobs:
             --url https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/awaiting-CI \
             --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
 
+      - id: echo_labels
+        name: Echo PR labels
+        run: |
+          echo ${{ steps.PR.outputs.pr_labels }}
+
       - name: If `auto-merge-after-CI` is present, add a `bors merge` comment.
         if: contains(${{ steps.PR.outputs.pr_labels }}, 'auto-merge-after-CI')
         uses: GrantBirki/comment@v2.0.1
         with:
-          issue-number: ${{ github.event.issue.number }}
+          issue-number: ${{ steps.PR.outputs.number }}
           body: |
             As this PR is labelled `auto-merge-after-CI`, we are now sending it to bors:
 

--- a/.github/workflows/build.yml.in
+++ b/.github/workflows/build.yml.in
@@ -128,25 +128,25 @@ jobs:
         env:
           MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}
 
-      - name: build archive
-        run: lake build Archive
+      # - name: build archive
+      #   run: lake build Archive
 
-      - name: build counterexamples
-        run: lake build Counterexamples
+      # - name: build counterexamples
+      #   run: lake build Counterexamples
 
-      - name: check declarations in db files
-        run: |
-          python3 scripts/yaml_check.py docs/100.yaml docs/overview.yaml docs/undergrad.yaml
-          build/bin/checkYaml
+      # - name: check declarations in db files
+      #   run: |
+      #     python3 scripts/yaml_check.py docs/100.yaml docs/overview.yaml docs/undergrad.yaml
+      #     build/bin/checkYaml
 
-      - name: test mathlib
-        run: make -j 8 test
+      # - name: test mathlib
+      #   run: make -j 8 test
 
-      - name: lint mathlib
-        uses: liskin/gh-problem-matcher-wrap@v2
-        with:
-          linters: gcc
-          run: env LEAN_ABORT_ON_PANIC=1 make lint
+      # - name: lint mathlib
+      #   uses: liskin/gh-problem-matcher-wrap@v2
+      #   with:
+      #     linters: gcc
+      #     run: env LEAN_ABORT_ON_PANIC=1 make lint
 
   final:
     name: Post-CI jobJOB_NAME

--- a/.github/workflows/build.yml.in
+++ b/.github/workflows/build.yml.in
@@ -179,8 +179,8 @@ jobs:
         run: |
           echo ${{ steps.PR.outputs.pr_labels }}
 
-      - name: If `auto-merge-after-CI` is present, add a `bors merge` comment.
-        if: contains(${{ steps.PR.outputs.pr_labels }}, 'auto-merge-after-CI')
+      - if: contains(${{ steps.PR.outputs.pr_labels }}, 'auto-merge-after-CI')
+        name: If `auto-merge-after-CI` is present, add a `bors merge` comment.
         uses: GrantBirki/comment@v2.0.1
         with:
           issue-number: ${{ steps.PR.outputs.number }}

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -196,7 +196,7 @@ jobs:
         name: If `auto-merge-after-CI` is present, add a `bors merge` comment.
         uses: GrantBirki/comment@v2.0.1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.AUTO_MERGE_TOKEN }}
           issue-number: ${{ steps.PR.outputs.number }}
           body: |
             As this PR is labelled `auto-merge-after-CI`, we are now sending it to bors:

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -146,25 +146,25 @@ jobs:
         env:
           MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}
 
-      - name: build archive
-        run: lake build Archive
+      # - name: build archive
+      #   run: lake build Archive
 
-      - name: build counterexamples
-        run: lake build Counterexamples
+      # - name: build counterexamples
+      #   run: lake build Counterexamples
 
-      - name: check declarations in db files
-        run: |
-          python3 scripts/yaml_check.py docs/100.yaml docs/overview.yaml docs/undergrad.yaml
-          build/bin/checkYaml
+      # - name: check declarations in db files
+      #   run: |
+      #     python3 scripts/yaml_check.py docs/100.yaml docs/overview.yaml docs/undergrad.yaml
+      #     build/bin/checkYaml
 
-      - name: test mathlib
-        run: make -j 8 test
+      # - name: test mathlib
+      #   run: make -j 8 test
 
-      - name: lint mathlib
-        uses: liskin/gh-problem-matcher-wrap@v2
-        with:
-          linters: gcc
-          run: env LEAN_ABORT_ON_PANIC=1 make lint
+      # - name: lint mathlib
+      #   uses: liskin/gh-problem-matcher-wrap@v2
+      #   with:
+      #     linters: gcc
+      #     run: env LEAN_ABORT_ON_PANIC=1 make lint
 
   final:
     name: Post-CI job (fork)

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -191,3 +191,48 @@ jobs:
           curl --request DELETE \
             --url https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/awaiting-CI \
             --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
+
+      - name: Get PR labels
+        id: pr_labels
+        uses: octokit/graphql-action@v2.x
+        with:
+          query: |
+            query PR($owner: String!, $repo: String!, $number: Int!) {
+              repository(owner:$owner, name:$repo) {
+                pullRequest(number:$number) {
+                  labels(first:100) {
+                    nodes {
+                      name
+                    }
+                  }
+                }
+              }
+            }
+          owner: ${{ github.repository_owner }}
+          repo: ${{ github.event.repository.name }}
+          number: ${{ github.event.pull_request.number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check for the `auto-merge-after-CI` label.
+        id: check_label
+        run: |
+          LABELS=$(jq -r '.data.repository.pullRequest.labels.nodes[] | .name' <<< "${{ steps.pr_labels.outputs.data }}")
+          if echo "${LABELS}" | grep -q 'auto-merge-after-CI'; then
+            echo "AUTO_MERGE=true" >> $GITHUB_ENV
+          else
+            echo "AUTO_MERGE=false" >> $GITHUB_ENV
+
+      - name: Run if label exists
+        if: ${{ env.AUTO_MERGE == 'true' }}
+        run: |
+          echo "This will run if the PR has the 'my-label' label"
+
+      - name: If `AUTO_MERGE` is set, add a `bors merge` comment.
+        uses: GrantBirki/comment@v2.0.1
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            As this PR is labelled `auto-merge-after-CI`, we are now sending it to bors:
+
+            bors merge

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -146,25 +146,25 @@ jobs:
         env:
           MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}
 
-      # - name: build archive
-      #   run: lake build Archive
+      - name: build archive
+        run: lake build Archive
 
-      # - name: build counterexamples
-      #   run: lake build Counterexamples
+      - name: build counterexamples
+        run: lake build Counterexamples
 
-      # - name: check declarations in db files
-      #   run: |
-      #     python3 scripts/yaml_check.py docs/100.yaml docs/overview.yaml docs/undergrad.yaml
-      #     build/bin/checkYaml
+      - name: check declarations in db files
+        run: |
+          python3 scripts/yaml_check.py docs/100.yaml docs/overview.yaml docs/undergrad.yaml
+          build/bin/checkYaml
 
-      # - name: test mathlib
-      #   run: make -j 8 test
+      - name: test mathlib
+        run: make -j 8 test
 
-      # - name: lint mathlib
-      #   uses: liskin/gh-problem-matcher-wrap@v2
-      #   with:
-      #     linters: gcc
-      #     run: env LEAN_ABORT_ON_PANIC=1 make lint
+      - name: lint mathlib
+        uses: liskin/gh-problem-matcher-wrap@v2
+        with:
+          linters: gcc
+          run: env LEAN_ABORT_ON_PANIC=1 make lint
 
   final:
     name: Post-CI job (fork)

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -192,11 +192,16 @@ jobs:
             --url https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/awaiting-CI \
             --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
 
+      - id: echo_labels
+        name: Echo PR labels
+        run: |
+          echo ${{ steps.PR.outputs.pr_labels }}
+
       - name: If `auto-merge-after-CI` is present, add a `bors merge` comment.
-        if: contains( ${{ steps.PR.outputs.pr_labels }}, 'auto-merge-after-CI')
+        if: contains(${{ steps.PR.outputs.pr_labels }}, 'auto-merge-after-CI')
         uses: GrantBirki/comment@v2.0.1
         with:
-          issue-number: ${{ github.event.issue.number }}
+          issue-number: ${{ steps.PR.outputs.number }}
           body: |
             As this PR is labelled `auto-merge-after-CI`, we are now sending it to bors:
 

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -196,6 +196,7 @@ jobs:
         name: Echo PR labels
         run: |
           echo ${{ steps.PR.outputs.pr_labels }}
+          echo ${{ steps.PR.outputs.pr_labels }}
 
       - if: contains(${{ steps.PR.outputs.pr_labels }}, 'auto-merge-after-CI')
         name: If `auto-merge-after-CI` is present, add a `bors merge` comment.

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -192,43 +192,8 @@ jobs:
             --url https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/awaiting-CI \
             --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
 
-      - name: Get PR labels
-        id: pr_labels
-        uses: octokit/graphql-action@v2.x
-        with:
-          query: |
-            query PR($owner: String!, $repo: String!, $number: Int!) {
-              repository(owner:$owner, name:$repo) {
-                pullRequest(number:$number) {
-                  labels(first:100) {
-                    nodes {
-                      name
-                    }
-                  }
-                }
-              }
-            }
-          owner: ${{ github.repository_owner }}
-          repo: ${{ github.event.repository.name }}
-          number: ${{ github.event.pull_request.number }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Check for the `auto-merge-after-CI` label.
-        id: check_label
-        run: |
-          LABELS=$(jq -r '.data.repository.pullRequest.labels.nodes[] | .name' <<< "${{ steps.pr_labels.outputs.data }}")
-          if echo "${LABELS}" | grep -q 'auto-merge-after-CI'; then
-            echo "AUTO_MERGE=true" >> $GITHUB_ENV
-          else
-            echo "AUTO_MERGE=false" >> $GITHUB_ENV
-
-      - name: Run if label exists
-        if: ${{ env.AUTO_MERGE == 'true' }}
-        run: |
-          echo "This will run if the PR has the 'my-label' label"
-
-      - name: If `AUTO_MERGE` is set, add a `bors merge` comment.
+      - name: If `auto-merge-after-CI` is present, add a `bors merge` comment.
+        if: contains( ${{ steps.PR.outputs.pr_labels }}, 'auto-merge-after-CI')
         uses: GrantBirki/comment@v2.0.1
         with:
           issue-number: ${{ github.event.issue.number }}

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -196,9 +196,9 @@ jobs:
         name: Echo PR labels
         run: |
           echo ${{ steps.PR.outputs.pr_labels }}
-          echo ${{ steps.PR.outputs.pr_labels }}
 
-      - if: contains(${{ steps.PR.outputs.pr_labels }}, 'auto-merge-after-CI')
+      - # if: contains(${{ steps.PR.outputs.pr_labels }}, 'auto-merge-after-CI')
+        if: #{{ false }}
         name: If `auto-merge-after-CI` is present, add a `bors merge` comment.
         uses: GrantBirki/comment@v2.0.1
         with:

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -196,6 +196,7 @@ jobs:
         name: If `auto-merge-after-CI` is present, add a `bors merge` comment.
         uses: GrantBirki/comment@v2.0.1
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ steps.PR.outputs.number }}
           body: |
             As this PR is labelled `auto-merge-after-CI`, we are now sending it to bors:

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -197,8 +197,8 @@ jobs:
         run: |
           echo ${{ steps.PR.outputs.pr_labels }}
 
-      - name: If `auto-merge-after-CI` is present, add a `bors merge` comment.
-        if: contains(${{ steps.PR.outputs.pr_labels }}, 'auto-merge-after-CI')
+      - if: contains(${{ steps.PR.outputs.pr_labels }}, 'auto-merge-after-CI')
+        name: If `auto-merge-after-CI` is present, add a `bors merge` comment.
         uses: GrantBirki/comment@v2.0.1
         with:
           issue-number: ${{ steps.PR.outputs.number }}

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -192,13 +192,7 @@ jobs:
             --url https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/awaiting-CI \
             --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
 
-      - id: echo_labels
-        name: Echo PR labels
-        run: |
-          echo ${{ steps.PR.outputs.pr_labels }}
-
-      - # if: contains(${{ steps.PR.outputs.pr_labels }}, 'auto-merge-after-CI')
-        if: #{{ false }}
+      - if: contains(steps.PR.outputs.pr_labels, 'auto-merge-after-CI')
         name: If `auto-merge-after-CI` is present, add a `bors merge` comment.
         uses: GrantBirki/comment@v2.0.1
         with:


### PR DESCRIPTION
Immediately after the `awaiting-CI` label is removed, check if the PR is labelled `auto-merge-after-CI`, and if so have the mathlib4 bot issue a `bors merge`.

Note that for now bors is not actually listening to the mathlib4 bot, so we will have to enable that once this has been tested.

The main use case here is generating automatic bump PRs so that we can keep up with Lean 4 nightly with less busy work.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
