### PR TITLE
[Merged by Bors] - feat(RingTheory/TensorProduct): heterogenize

### DIFF
--- a/Mathlib/Algebra/Category/Ring/Constructions.lean
+++ b/Mathlib/Algebra/Category/Ring/Constructions.lean
@@ -41,7 +41,7 @@ def pushoutCocone : Limits.PushoutCocone f g := by
   letI := RingHom.toAlgebra g
   fapply Limits.PushoutCocone.mk
   show CommRingCat; exact CommRingCat.of (A ⊗[R] B)
-  show A ⟶ _; exact Algebra.TensorProduct.includeLeft.toRingHom
+  show A ⟶ _; exact Algebra.TensorProduct.includeLeftRingHom
   show B ⟶ _; exact Algebra.TensorProduct.includeRight.toRingHom
   ext r
   trans algebraMap R (A ⊗[R] B) r
@@ -55,7 +55,7 @@ theorem pushoutCocone_inl :
     (pushoutCocone f g).inl = by
       letI := f.toAlgebra
       letI := g.toAlgebra
-      exact Algebra.TensorProduct.includeLeft.toRingHom :=
+      exact Algebra.TensorProduct.includeLeftRingHom :=
   rfl
 set_option linter.uppercaseLean3 false in
 #align CommRing.pushout_cocone_inl CommRingCat.pushoutCocone_inl
@@ -128,7 +128,7 @@ def pushoutCoconeIsColimit : Limits.IsColimit (pushoutCocone f g) :=
       ext x
       change h' x = Algebra.TensorProduct.productMap f' g' x
       rw [this]
-    apply Algebra.TensorProduct.ext
+    apply Algebra.TensorProduct.ext'
     intro a b
     simp only [PushoutCocone.ι_app_left, pushoutCocone_pt, coe_of, RingHom.toMonoidHom_eq_coe,
       AlgHom.coe_mk, RingHom.coe_mk, MonoidHom.coe_coe, ← eq1, AlgHom.toRingHom_eq_coe,

--- a/Mathlib/Data/Matrix/Kronecker.lean
+++ b/Mathlib/Data/Matrix/Kronecker.lean
@@ -560,7 +560,8 @@ theorem det_kroneckerTMul [Fintype m] [Fintype n] [DecidableEq m] [DecidableEq n
     (A : Matrix m m α) (B : Matrix n n β) :
     det (A ⊗ₖₜ[R] B) = (det A ^ Fintype.card n) ⊗ₜ[R] (det B ^ Fintype.card m) := by
   refine' (det_kroneckerMapBilinear (TensorProduct.mk R α β) tmul_mul_tmul _ _).trans _
-  simp (config := { eta := false }) only [mk_apply, ← includeLeft_apply, ← includeRight_apply]
+  simp (config := { eta := false }) only [mk_apply, ← includeLeft_apply (S := R),
+    ← includeRight_apply]
   simp only [← AlgHom.mapMatrix_apply, ← AlgHom.map_det]
   simp only [includeLeft_apply, includeRight_apply, tmul_pow, tmul_mul_tmul, one_pow,
     _root_.mul_one, _root_.one_mul]

--- a/Mathlib/LinearAlgebra/TensorProduct/Tower.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Tower.lean
@@ -263,10 +263,10 @@ variable (R A M)
 /-- Heterobasic version of `TensorProduct.rid`. -/
 protected def rid : M ⊗[R] R ≃ₗ[A] M :=
   LinearEquiv.ofLinear
-    (AlgebraTensorModule.lift <| LinearMap.flip <| Algebra.lsmul _ _ _ |>.toLinearMap)
-    ((AlgebraTensorModule.mk R A M R).flip 1)
+    (lift <| Algebra.lsmul _ _ _ |>.toLinearMap |>.flip)
+    (mk R A M R |>.flip 1)
     (LinearMap.ext <| one_smul _)
-    (AlgebraTensorModule.ext <| fun _ _ => (smul_tmul _ _ _).trans <| congr_arg _ <| mul_one _)
+    (ext <| fun _ _ => smul_tmul _ _ _ |>.trans <| congr_arg _ <| mul_one _)
 
 variable {R M}
 

--- a/Mathlib/LinearAlgebra/TensorProduct/Tower.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Tower.lean
@@ -31,6 +31,7 @@ In this file, we use the convention that `M`, `N`, `P`, `Q` are all `R`-modules,
  * `TensorProduct.AlgebraTensorModule.map`
  * `TensorProduct.AlgebraTensorModule.mapBilinear`
  * `TensorProduct.AlgebraTensorModule.congr`
+ * `TensorProduct.AlgebraTensorModule.rid`
  * `TensorProduct.AlgebraTensorModule.homTensorHomMap`
  * `TensorProduct.AlgebraTensorModule.assoc`
  * `TensorProduct.AlgebraTensorModule.leftComm`
@@ -256,6 +257,21 @@ def congr (f : M ≃ₗ[A] P) (g : N ≃ₗ[R] Q) : (M ⊗[R] N) ≃ₗ[A] (P �
 @[simp] theorem congr_symm_tmul (f : M ≃ₗ[A] P) (g : N ≃ₗ[R] Q) (p : P) (q : Q) :
     (congr f g).symm (p ⊗ₜ q) = f.symm p ⊗ₜ g.symm q :=
   rfl
+
+variable (R A M)
+
+/-- Heterobasic version of `TensorProduct.rid`. -/
+protected def rid : M ⊗[R] R ≃ₗ[A] M :=
+  LinearEquiv.ofLinear
+    (AlgebraTensorModule.lift <| LinearMap.flip <| Algebra.lsmul _ _ _ |>.toLinearMap)
+    ((AlgebraTensorModule.mk R A M R).flip 1)
+    (LinearMap.ext <| one_smul _)
+    (AlgebraTensorModule.ext <| fun _ _ => (smul_tmul _ _ _).trans <| congr_arg _ <| mul_one _)
+
+variable {R M}
+
+@[simp]
+theorem rid_tmul (r : R) (m : M) : AlgebraTensorModule.rid R A M (m ⊗ₜ r) = r • m := rfl
 
 end Semiring
 

--- a/Mathlib/RingTheory/Etale.lean
+++ b/Mathlib/RingTheory/Etale.lean
@@ -440,19 +440,9 @@ instance FormallyUnramified.base_change [FormallyUnramified R A] :
   intro C _ _ I hI f₁ f₂ e
   letI := ((algebraMap B C).comp (algebraMap R B)).toAlgebra
   haveI : IsScalarTower R B C := IsScalarTower.of_algebraMap_eq' rfl
-  apply AlgHom.restrictScalars_injective R
-  apply TensorProduct.ext
-  intro b a
-  have : b ⊗ₜ[R] a = b • (1 : B) ⊗ₜ a := by rw [TensorProduct.smul_tmul', smul_eq_mul, mul_one]
-  rw [this, AlgHom.restrictScalars_apply, AlgHom.restrictScalars_apply, map_smul, map_smul]
-  congr 1
-  change
-    ((f₁.restrictScalars R).comp TensorProduct.includeRight) a =
-      ((f₂.restrictScalars R).comp TensorProduct.includeRight) a
-  congr 1
-  refine' FormallyUnramified.ext I ⟨2, hI⟩ _
-  intro x
-  exact AlgHom.congr_fun e (1 ⊗ₜ x)
+  ext : 1
+  · exact Subsingleton.elim _ _
+  · exact FormallyUnramified.ext I ⟨2, hI⟩ fun x => AlgHom.congr_fun e (1 ⊗ₜ x)
 #align algebra.formally_unramified.base_change Algebra.FormallyUnramified.base_change
 
 instance FormallySmooth.base_change [FormallySmooth R A] : FormallySmooth B (B ⊗[R] A) := by
@@ -463,7 +453,7 @@ instance FormallySmooth.base_change [FormallySmooth R A] : FormallySmooth B (B �
   refine' ⟨TensorProduct.productLeftAlgHom (Algebra.ofId B C) _, _⟩
   · exact FormallySmooth.lift I ⟨2, hI⟩ ((f.restrictScalars R).comp TensorProduct.includeRight)
   · apply AlgHom.restrictScalars_injective R
-    apply TensorProduct.ext
+    apply TensorProduct.ext'
     intro b a
     suffices algebraMap B _ b * f (1 ⊗ₜ[R] a) = f (b ⊗ₜ[R] a) by simpa [Algebra.ofId_apply]
     rw [← Algebra.smul_def, ← map_smul, TensorProduct.smul_tmul', smul_eq_mul, mul_one]

--- a/Mathlib/RingTheory/IntegralClosure.lean
+++ b/Mathlib/RingTheory/IntegralClosure.lean
@@ -708,7 +708,7 @@ theorem IsIntegral.tmul (x : A) {y : B} (h : IsIntegral R y) : IsIntegral A (x �
   · simp only [Algebra.TensorProduct.includeLeftRingHom_apply, Algebra.TensorProduct.tmul_pow,
       one_pow]
     convert (MulZeroClass.mul_zero (M₀ := A ⊗[R] B) _).symm
-    erw [Polynomial.eval₂_map, Algebra.TensorProduct.includeLeft_comp_algebraMap,
+    erw [Polynomial.eval₂_map, Algebra.TensorProduct.includeLeftRingHom_comp_algebraMap,
       ← Polynomial.eval₂_map]
     convert Polynomial.eval₂_at_apply
       (Algebra.TensorProduct.includeRight : B →ₐ[R] A ⊗[R] B).toRingHom y

--- a/Mathlib/RingTheory/PolynomialAlgebra.lean
+++ b/Mathlib/RingTheory/PolynomialAlgebra.lean
@@ -144,8 +144,7 @@ theorem invFun_add {p q} : invFun R A (p + q) = invFun R A p + invFun R A q := b
 #align poly_equiv_tensor.inv_fun_add PolyEquivTensor.invFun_add
 
 theorem invFun_monomial (n : ℕ) (a : A) :
-    invFun R A (monomial n a) =
-      includeLeft (R := R) (A := A) (B := R[X]) a * (1 : A) ⊗ₜ[R] (X : R[X]) ^ n :=
+    invFun R A (monomial n a) = (a ⊗ₜ[R] 1) * 1 ⊗ₜ[R] X ^ n :=
   eval₂_monomial _ _
 #align poly_equiv_tensor.inv_fun_monomial PolyEquivTensor.invFun_monomial
 
@@ -170,7 +169,7 @@ theorem right_inv (x : A[X]) : (toFunAlgHom R A) (invFun R A x) = x := by
   · intro p q hp hq
     simp only [invFun_add, AlgHom.map_add, hp, hq]
   · intro n a
-    rw [invFun_monomial, Algebra.TensorProduct.includeLeft_apply, Algebra.TensorProduct.tmul_pow,
+    rw [invFun_monomial, Algebra.TensorProduct.tmul_pow,
         one_pow, Algebra.TensorProduct.tmul_mul_tmul, mul_one, one_mul, toFunAlgHom_apply_tmul,
         X_pow_eq_monomial, sum_monomial_index] <;>
       simp

--- a/Mathlib/RingTheory/RingHomProperties.lean
+++ b/Mathlib/RingTheory/RingHomProperties.lean
@@ -136,7 +136,7 @@ theorem StableUnderBaseChange.mk (h₁ : RespectsIso @P)
       ∀ ⦃R S T⦄ [CommRing R] [CommRing S] [CommRing T],
         ∀ [Algebra R S] [Algebra R T],
           P (algebraMap R T) →
-            P (Algebra.TensorProduct.includeLeft.toRingHom : S →+* TensorProduct R S T)) :
+            P (Algebra.TensorProduct.includeLeftRingHom : S →+* TensorProduct R S T)) :
     StableUnderBaseChange @P := by
   introv R h H
   let e := h.symm.1.equiv

--- a/Mathlib/RingTheory/TensorProduct.lean
+++ b/Mathlib/RingTheory/TensorProduct.lean
@@ -618,27 +618,16 @@ variable (S)
 Note that if `A` is commutative this can be instantiated with `S = A`.
 -/
 protected nonrec def rid : A ⊗[R] R ≃ₐ[S] A :=
-  -- the map `fun r a ↦ a * algebraMap _ _ r`, bilinear in just the right way
-  let act : R →ₗ[R] A →ₗ[S] A :=
-    (Algebra.lsmul (A := A) S Aᵐᵒᵖ A).toLinearMap.flip.restrictScalars R ∘ₗ Algebra.linearMap R A
-  -- TODO: extract this `let` as `AlgebraTensorModule.rid` once we have
-  -- `Algebra R A → Module Rᵐᵒᵖ A`, with the above as `fun r a ↦ MulOpposite.op r • a`
-  let lin : A ⊗[R] R ≃ₗ[S] A := LinearEquiv.ofLinear
-    (AlgebraTensorModule.lift <| LinearMap.flip <| act)
-    ((AlgebraTensorModule.mk R A A R).flip 1)
-    (LinearMap.ext <| fun x => show x * algebraMap R A 1 = x by simp)
-    (AlgebraTensorModule.ext <| fun x y => show (x * algebraMap R A y) ⊗ₜ[R] 1 = x ⊗ₜ[R] y
-      by rw [←Algebra.commutes, ←_root_.Algebra.smul_def, smul_tmul, smul_eq_mul, mul_one])
-  algEquivOfLinearEquivTensorProduct lin
-    (fun a₁ a₂ r₁ r₂ => by
-      show a₁ * a₂ * algebraMap R A (r₁ * r₂) = a₁ * algebraMap R A r₁ * (a₂ * algebraMap R A r₂)
-      simp_rw [←Algebra.commutes, ←Algebra.smul_def, smul_mul_smul])
-    (fun s => show algebraMap S A s * algebraMap R A 1 = algebraMap S A s by simp)
+  algEquivOfLinearEquivTensorProduct (AlgebraTensorModule.rid R S A)
+    (fun _a₁ _a₂ _r₁ _r₂ => smul_mul_smul _ _ _ _ |>.symm)
+    (fun _s => one_smul _ _)
 #align algebra.tensor_product.rid Algebra.TensorProduct.rid
 
+variable {R A} in
 @[simp]
-theorem rid_tmul (r : R) (a : A) : TensorProduct.rid R S A (a ⊗ₜ r) = a * algebraMap _ _ r := rfl
+theorem rid_tmul (r : R) (a : A) : TensorProduct.rid R S A (a ⊗ₜ r) = r • a := rfl
 #align algebra.tensor_product.rid_tmul Algebra.TensorProduct.rid_tmul
+
 
 section
 

--- a/Mathlib/RingTheory/TensorProduct.lean
+++ b/Mathlib/RingTheory/TensorProduct.lean
@@ -1065,4 +1065,3 @@ theorem smul_def (a : A) (b : B) (m : M) : a ⊗ₜ[R] b • m = a • b • m :
 #align tensor_product.algebra.smul_def TensorProduct.Algebra.smul_def
 
 end TensorProduct.Algebra
-#lint

--- a/Mathlib/RingTheory/TensorProduct.lean
+++ b/Mathlib/RingTheory/TensorProduct.lean
@@ -618,8 +618,11 @@ variable (S)
 Note that if `A` is commutative this can be instantiated with `S = A`.
 -/
 protected nonrec def rid : A ⊗[R] R ≃ₐ[S] A :=
+  -- the map `fun r a ↦ a * algebraMap _ _ r`, bilinear in just the right way
   let act : R →ₗ[R] A →ₗ[S] A :=
     (Algebra.lsmul (A := A) S Aᵐᵒᵖ A).toLinearMap.flip.restrictScalars R ∘ₗ Algebra.linearMap R A
+  -- TODO: extract this `let` as `AlgebraTensorModule.rid` once we have
+  -- `Algebra R A → Module Rᵐᵒᵖ A`, with the above as `fun r a ↦ MulOpposite.op r • a`
   let lin : A ⊗[R] R ≃ₗ[S] A := LinearEquiv.ofLinear
     (AlgebraTensorModule.lift <| LinearMap.flip <| act)
     ((AlgebraTensorModule.mk R A A R).flip 1)

--- a/Mathlib/RingTheory/TensorProduct.lean
+++ b/Mathlib/RingTheory/TensorProduct.lean
@@ -13,25 +13,26 @@ import Mathlib.LinearAlgebra.DirectSum.Finsupp
 /-!
 # The tensor product of R-algebras
 
-Let `R` be a (semi)ring and `A` an `R`-algebra.
-In this file we:
+This file provides results about the multiplicative structure on `A ⊗[R] B` when `R` is a
+commutative (semi)ring and `A` and `B` are both `R`-algebras. On these tensor products,
+multiplication is characterized by `(a₁ ⊗ₜ b₁) * (a₂ ⊗ₜ b₂) = (a₁ * a₂) ⊗ₜ (b₁ * b₂)`.
 
-- Define the `A`-module structure on `A ⊗ M`, for an `R`-module `M`.
-- Define the `R`-algebra structure on `A ⊗ B`, for another `R`-algebra `B`.
-  and provide the structure isomorphisms
-  * `R ⊗[R] A ≃ₐ[R] A`
-  * `A ⊗[R] R ≃ₐ[R] A`
-  * `A ⊗[R] B ≃ₐ[R] B ⊗[R] A`
-  * `((A ⊗[R] B) ⊗[R] C) ≃ₐ[R] (A ⊗[R] (B ⊗[R] C))`
-
-## Main declaration
+## Main declarations
 
 - `LinearMap.baseChange A f` is the `A`-linear map `A ⊗ f`, for an `R`-linear map `f`.
+- `Algebra.TensorProduct.semiring`: the ring structure on `A ⊗[R] B` for two `R`-algebras `A`, `B`.
+- `Algebra.TensorProduct.leftAlgebra`: the `S`-algebra structure on `A ⊗[R] B`, for when `A` is
+  additionally an `S` algebra.
+- the structure isomorphisms
+  * `Algebra.TensorProduct.lid : R ⊗[R] A ≃ₐ[R] A`
+  * `Algebra.TensorProduct.rid : A ⊗[R] R ≃ₐ[S] A` (usually used with `S = R` or `S = A`)
+  * `Algebra.TensorProduct.comm : A ⊗[R] B ≃ₐ[R] B ⊗[R] A`
+  * `Algebra.TensorProduct.assoc : ((A ⊗[R] B) ⊗[R] C) ≃ₐ[R] (A ⊗[R] (B ⊗[R] C))`
 
 -/
 
 
-universe u v₁ v₂ v₃ v₄
+universe u uS v₁ v₂ v₃ v₄
 
 open scoped TensorProduct
 
@@ -330,21 +331,14 @@ theorem algebraMap_apply [SMulCommClass R S A] (r : S) :
 
 variable {C : Type v₃} [Semiring C] [Algebra R C]
 
-@[ext high]
-theorem ext {g h : A ⊗[R] B →ₐ[R] C} (H : ∀ a b, g (a ⊗ₜ b) = h (a ⊗ₜ b)) : g = h := by
-  apply @AlgHom.toLinearMap_injective R (A ⊗[R] B) C _ _ _ _ _ _ _ _
-  ext
-  simp [H]
-#align algebra.tensor_product.ext Algebra.TensorProduct.ext
-
--- TODO: with `SMulCommClass R S A` we can have this as an `S`-algebra morphism
 /-- The `R`-algebra morphism `A →ₐ[R] A ⊗[R] B` sending `a` to `a ⊗ₜ 1`. -/
-def includeLeft : A →ₐ[R] A ⊗[R] B :=
+def includeLeft [SMulCommClass R S A] : A →ₐ[S] A ⊗[R] B :=
   { includeLeftRingHom with commutes' := by simp }
 #align algebra.tensor_product.include_left Algebra.TensorProduct.includeLeft
 
 @[simp]
-theorem includeLeft_apply (a : A) : (includeLeft : A →ₐ[R] A ⊗[R] B) a = a ⊗ₜ 1 :=
+theorem includeLeft_apply [SMulCommClass R S A] (a : A) :
+    (includeLeft : A →ₐ[S] A ⊗[R] B) a = a ⊗ₜ 1 :=
   rfl
 #align algebra.tensor_product.include_left_apply Algebra.TensorProduct.includeLeft_apply
 
@@ -368,13 +362,40 @@ theorem includeRight_apply (b : B) : (includeRight : B →ₐ[R] A ⊗[R] B) b =
   rfl
 #align algebra.tensor_product.include_right_apply Algebra.TensorProduct.includeRight_apply
 
-theorem includeLeft_comp_algebraMap {R S T : Type _} [CommRing R] [CommRing S] [CommRing T]
+theorem includeLeftRingHom_comp_algebraMap {R S T : Type _} [CommRing R] [CommRing S] [CommRing T]
     [Algebra R S] [Algebra R T] :
-    (includeLeft.toRingHom.comp (algebraMap R S) : R →+* S ⊗[R] T) =
+    (includeLeftRingHom.comp (algebraMap R S) : R →+* S ⊗[R] T) =
       includeRight.toRingHom.comp (algebraMap R T) := by
   ext
   simp
-#align algebra.tensor_product.include_left_comp_algebra_map Algebra.TensorProduct.includeLeft_comp_algebraMap
+#align algebra.tensor_product.include_left_comp_algebra_map Algebra.TensorProduct.includeLeftRingHom_comp_algebraMapₓ
+
+section ext
+variable [Algebra R S] [Algebra S C] [IsScalarTower R S A] [IsScalarTower R S C]
+
+/-- A version of `TensorProduct.ext` for `AlgHom`.
+
+Using this as the `@[ext]` lemma instead of `Algebra.TensorProduct.ext'` allows `ext` to apply
+lemmas specific to `A →ₐ[S] _` and `B →ₐ[R] _`; notably this allows recursion into nested tensor
+products of algebras.
+
+See note [partially-applied ext lemmas]. -/
+@[ext high]
+theorem ext ⦃f g : (A ⊗[R] B) →ₐ[S] C⦄
+  (ha : f.comp includeLeft = g.comp includeLeft)
+  (hb : (f.restrictScalars R).comp includeRight = (g.restrictScalars R).comp includeRight) :
+    f = g := by
+  apply AlgHom.toLinearMap_injective
+  ext a b
+  have := congr_arg₂ HMul.hMul (AlgHom.congr_fun ha a) (AlgHom.congr_fun hb b)
+  dsimp at *
+  rwa [←f.map_mul, ←g.map_mul, tmul_mul_tmul, _root_.one_mul, _root_.mul_one] at this
+
+theorem ext' {g h : A ⊗[R] B →ₐ[S] C} (H : ∀ a b, g (a ⊗ₜ b) = h (a ⊗ₜ b)) : g = h :=
+  ext (AlgHom.ext <| fun _ => H _ _) (AlgHom.ext <| fun _ => H _ _)
+#align algebra.tensor_product.ext Algebra.TensorProduct.ext
+
+end ext
 
 end Semiring
 
@@ -468,24 +489,24 @@ section Monoidal
 
 section
 
-variable {R : Type u} [CommSemiring R]
+variable {R : Type u} {S : Type uS} [CommSemiring R] [CommSemiring S] [Algebra R S]
 
-variable {A : Type v₁} [Semiring A] [Algebra R A]
+variable {A : Type v₁} [Semiring A] [Algebra R A] [Algebra S A] [IsScalarTower R S A]
 
 variable {B : Type v₂} [Semiring B] [Algebra R B]
 
-variable {C : Type v₃} [Semiring C] [Algebra R C]
+variable {C : Type v₃} [Semiring C] [Algebra R C] [Algebra S C]
 
 variable {D : Type v₄} [Semiring D] [Algebra R D]
 
 /-- Build an algebra morphism from a linear map out of a tensor product,
 and evidence of multiplicativity on pure tensors.
 -/
-def algHomOfLinearMapTensorProduct (f : A ⊗[R] B →ₗ[R] C)
+def algHomOfLinearMapTensorProduct (f : A ⊗[R] B →ₗ[S] C)
     (w₁ : ∀ (a₁ a₂ : A) (b₁ b₂ : B), f ((a₁ * a₂) ⊗ₜ (b₁ * b₂)) = f (a₁ ⊗ₜ b₁) * f (a₂ ⊗ₜ b₂))
-    (w₂ : ∀ r, f ((algebraMap R A) r ⊗ₜ[R] 1) = (algebraMap R C) r) : A ⊗[R] B →ₐ[R] C :=
+    (w₂ : ∀ r, f (algebraMap S A r ⊗ₜ[R] 1) = algebraMap S C r) : A ⊗[R] B →ₐ[S] C :=
   { f with
-    map_one' := by rw [← (algebraMap R C).map_one, ← w₂, (algebraMap R A).map_one]; rfl
+    map_one' := by rw [← (algebraMap S C).map_one, ← w₂, (algebraMap S A).map_one]; rfl
     map_zero' := by simp only; rw [LinearMap.toFun_eq_coe, map_zero]
     map_mul' := fun x y => by
       simp only
@@ -506,22 +527,22 @@ def algHomOfLinearMapTensorProduct (f : A ⊗[R] B →ₗ[R] C)
 
 @[simp]
 theorem algHomOfLinearMapTensorProduct_apply (f w₁ w₂ x) :
-    (algHomOfLinearMapTensorProduct f w₁ w₂ : A ⊗[R] B →ₐ[R] C) x = f x :=
+    (algHomOfLinearMapTensorProduct f w₁ w₂ : A ⊗[R] B →ₐ[S] C) x = f x :=
   rfl
 #align algebra.tensor_product.alg_hom_of_linear_map_tensor_product_apply Algebra.TensorProduct.algHomOfLinearMapTensorProduct_apply
 
 /-- Build an algebra equivalence from a linear equivalence out of a tensor product,
 and evidence of multiplicativity on pure tensors.
 -/
-def algEquivOfLinearEquivTensorProduct (f : A ⊗[R] B ≃ₗ[R] C)
+def algEquivOfLinearEquivTensorProduct (f : A ⊗[R] B ≃ₗ[S] C)
     (w₁ : ∀ (a₁ a₂ : A) (b₁ b₂ : B), f ((a₁ * a₂) ⊗ₜ (b₁ * b₂)) = f (a₁ ⊗ₜ b₁) * f (a₂ ⊗ₜ b₂))
-    (w₂ : ∀ r, f ((algebraMap R A) r ⊗ₜ[R] 1) = (algebraMap R C) r) : A ⊗[R] B ≃ₐ[R] C :=
-  { algHomOfLinearMapTensorProduct (f : A ⊗[R] B →ₗ[R] C) w₁ w₂, f with }
+    (w₂ : ∀ r, f ((algebraMap S A) r ⊗ₜ[R] 1) = (algebraMap S C) r) : A ⊗[R] B ≃ₐ[S] C :=
+  { algHomOfLinearMapTensorProduct (f : A ⊗[R] B →ₗ[S] C) w₁ w₂, f with }
 #align algebra.tensor_product.alg_equiv_of_linear_equiv_tensor_product Algebra.TensorProduct.algEquivOfLinearEquivTensorProduct
 
 @[simp]
 theorem algEquivOfLinearEquivTensorProduct_apply (f w₁ w₂ x) :
-    (algEquivOfLinearEquivTensorProduct f w₁ w₂ : A ⊗[R] B ≃ₐ[R] C) x = f x :=
+    (algEquivOfLinearEquivTensorProduct f w₁ w₂ : A ⊗[R] B ≃ₐ[S] C) x = f x :=
   rfl
 #align algebra.tensor_product.alg_equiv_of_linear_equiv_tensor_product_apply Algebra.TensorProduct.algEquivOfLinearEquivTensorProduct_apply
 
@@ -561,11 +582,11 @@ theorem algEquivOfLinearEquivTripleTensorProduct_apply (f w₁ w₂ x) :
 
 end
 
-variable {R : Type u} [CommSemiring R]
+variable {R : Type u} {S : Type uS} [CommSemiring R] [CommSemiring S] [Algebra R S]
 
-variable {A : Type v₁} [Semiring A] [Algebra R A]
+variable {A : Type v₁} [Semiring A] [Algebra R A] [Algebra S A] [IsScalarTower R S A]
 
-variable {B : Type v₂} [Semiring B] [Algebra R B]
+variable {B : Type v₂} [Semiring B] [Algebra R B] [Algebra S B] [IsScalarTower R S B]
 
 variable {C : Type v₃} [Semiring C] [Algebra R C]
 
@@ -590,19 +611,30 @@ theorem lid_tmul (r : R) (a : A) : (TensorProduct.lid R A : R ⊗ A → A) (r �
   simp [TensorProduct.lid]
 #align algebra.tensor_product.lid_tmul Algebra.TensorProduct.lid_tmul
 
+variable (S)
+
 /-- The base ring is a right identity for the tensor product of algebra, up to algebra isomorphism.
+
+Note that if `A` is commutative this can be instantiated with `S = A`.
 -/
-protected nonrec def rid : A ⊗[R] R ≃ₐ[R] A :=
-  algEquivOfLinearEquivTensorProduct (TensorProduct.rid R A) (by
-    simp [mul_smul]
-    simp_rw [← mul_smul, mul_comm]
-    simp)
-    (by simp [Algebra.smul_def])
+protected nonrec def rid : A ⊗[R] R ≃ₐ[S] A :=
+  let act : R →ₗ[R] A →ₗ[S] A :=
+    (Algebra.lsmul (A := A) S Aᵐᵒᵖ A).toLinearMap.flip.restrictScalars R ∘ₗ Algebra.linearMap R A
+  let lin : A ⊗[R] R ≃ₗ[S] A := LinearEquiv.ofLinear
+    (AlgebraTensorModule.lift <| LinearMap.flip <| act)
+    ((AlgebraTensorModule.mk R A A R).flip 1)
+    (LinearMap.ext <| fun x => show x * algebraMap R A 1 = x by simp)
+    (AlgebraTensorModule.ext <| fun x y => show (x * algebraMap R A y) ⊗ₜ[R] 1 = x ⊗ₜ[R] y
+      by rw [←Algebra.commutes, ←_root_.Algebra.smul_def, smul_tmul, smul_eq_mul, mul_one])
+  algEquivOfLinearEquivTensorProduct lin
+    (fun a₁ a₂ r₁ r₂ => by
+      show a₁ * a₂ * algebraMap R A (r₁ * r₂) = a₁ * algebraMap R A r₁ * (a₂ * algebraMap R A r₂)
+      simp_rw [←Algebra.commutes, ←Algebra.smul_def, smul_mul_smul])
+    (fun s => show algebraMap S A s * algebraMap R A 1 = algebraMap S A s by simp)
 #align algebra.tensor_product.rid Algebra.TensorProduct.rid
 
 @[simp]
-theorem rid_tmul (r : R) (a : A) : (TensorProduct.rid R A : A ⊗ R → A) (a ⊗ₜ r) = r • a := by
-  simp [TensorProduct.rid]
+theorem rid_tmul (r : R) (a : A) : TensorProduct.rid R S A (a ⊗ₜ r) = a * algebraMap _ _ r := rfl
 #align algebra.tensor_product.rid_tmul Algebra.TensorProduct.rid_tmul
 
 section
@@ -671,29 +703,35 @@ theorem assoc_tmul (a : A) (b : B) (c : C) :
 
 end
 
-variable {R A}
+variable {R S A}
 
 /-- The tensor product of a pair of algebra morphisms. -/
-def map (f : A →ₐ[R] B) (g : C →ₐ[R] D) : A ⊗[R] C →ₐ[R] B ⊗[R] D :=
-  algHomOfLinearMapTensorProduct (_root_.TensorProduct.map f.toLinearMap g.toLinearMap) (by simp)
+def map (f : A →ₐ[S] B) (g : C →ₐ[R] D) : A ⊗[R] C →ₐ[S] B ⊗[R] D :=
+  algHomOfLinearMapTensorProduct (AlgebraTensorModule.map f.toLinearMap g.toLinearMap) (by simp)
     (by simp [AlgHom.commutes])
 #align algebra.tensor_product.map Algebra.TensorProduct.map
 
 @[simp]
-theorem map_tmul (f : A →ₐ[R] B) (g : C →ₐ[R] D) (a : A) (c : C) : map f g (a ⊗ₜ c) = f a ⊗ₜ g c :=
+theorem map_tmul (f : A →ₐ[S] B) (g : C →ₐ[R] D) (a : A) (c : C) : map f g (a ⊗ₜ c) = f a ⊗ₜ g c :=
   rfl
 #align algebra.tensor_product.map_tmul Algebra.TensorProduct.map_tmul
 
 @[simp]
-theorem map_comp_includeLeft (f : A →ₐ[R] B) (g : C →ₐ[R] D) :
+theorem map_comp_includeLeft (f : A →ₐ[S] B) (g : C →ₐ[R] D) :
     (map f g).comp includeLeft = includeLeft.comp f :=
   AlgHom.ext <| by simp
 #align algebra.tensor_product.map_comp_include_left Algebra.TensorProduct.map_comp_includeLeft
 
 @[simp]
+theorem map_restrictScalars_comp_includeRight (f : A →ₐ[S] B) (g : C →ₐ[R] D) :
+    ((map f g).restrictScalars R).comp includeRight = includeRight.comp g :=
+  AlgHom.ext <| by simp
+
+@[simp]
 theorem map_comp_includeRight (f : A →ₐ[R] B) (g : C →ₐ[R] D) :
     (map f g).comp includeRight = includeRight.comp g :=
-  AlgHom.ext <| by simp
+  map_restrictScalars_comp_includeRight f g
+
 #align algebra.tensor_product.map_comp_include_right Algebra.TensorProduct.map_comp_includeRight
 
 theorem map_range (f : A →ₐ[R] B) (g : C →ₐ[R] D) :
@@ -707,22 +745,23 @@ theorem map_range (f : A →ₐ[R] B) (g : C →ₐ[R] D) :
     exact sup_le (AlgHom.range_comp_le_range _ _) (AlgHom.range_comp_le_range _ _)
 #align algebra.tensor_product.map_range Algebra.TensorProduct.map_range
 
-/-- Construct an isomorphism between tensor products of R-algebras
-from isomorphisms between the tensor factors.
+/-- Construct an isomorphism between tensor products of an S-algebra with an R-algebra
+from S- and R- isomorphisms between the tensor factors.
 -/
-def congr (f : A ≃ₐ[R] B) (g : C ≃ₐ[R] D) : A ⊗[R] C ≃ₐ[R] B ⊗[R] D :=
-  AlgEquiv.ofAlgHom (map f g) (map f.symm g.symm) (ext fun b d => by simp) (ext fun a c => by simp)
+def congr (f : A ≃ₐ[S] B) (g : C ≃ₐ[R] D) : A ⊗[R] C ≃ₐ[S] B ⊗[R] D :=
+  AlgEquiv.ofAlgHom (map f g) (map f.symm g.symm)
+    (ext' fun b d => by simp) (ext' fun a c => by simp)
 #align algebra.tensor_product.congr Algebra.TensorProduct.congr
 
 @[simp]
-theorem congr_apply (f : A ≃ₐ[R] B) (g : C ≃ₐ[R] D) (x) :
-    congr f g x = (map (f : A →ₐ[R] B) (g : C →ₐ[R] D)) x :=
+theorem congr_apply (f : A ≃ₐ[S] B) (g : C ≃ₐ[R] D) (x) :
+    congr f g x = (map (f : A →ₐ[S] B) (g : C →ₐ[R] D)) x :=
   rfl
 #align algebra.tensor_product.congr_apply Algebra.TensorProduct.congr_apply
 
 @[simp]
-theorem congr_symm_apply (f : A ≃ₐ[R] B) (g : C ≃ₐ[R] D) (x) :
-    (congr f g).symm x = (map (f.symm : B →ₐ[R] A) (g.symm : D →ₐ[R] C)) x :=
+theorem congr_symm_apply (f : A ≃ₐ[S] B) (g : C ≃ₐ[R] D) (x) :
+    (congr f g).symm x = (map (f.symm : B →ₐ[S] A) (g.symm : D →ₐ[R] C)) x :=
   rfl
 #align algebra.tensor_product.congr_symm_apply Algebra.TensorProduct.congr_symm_apply
 
@@ -776,12 +815,11 @@ def productMap : A ⊗[R] B →ₐ[R] S :=
 #align algebra.tensor_product.product_map Algebra.TensorProduct.productMap
 
 @[simp]
-theorem productMap_apply_tmul (a : A) (b : B) : productMap f g (a ⊗ₜ b) = f a * g b := by
-  unfold productMap lmul'
-  simp
+theorem productMap_apply_tmul (a : A) (b : B) : productMap f g (a ⊗ₜ b) = f a * g b := rfl
+
 #align algebra.tensor_product.product_map_apply_tmul Algebra.TensorProduct.productMap_apply_tmul
 
-theorem productMap_left_apply (a : A) : productMap f g ((includeLeft : A →ₐ[R] A ⊗ B) a) = f a := by
+theorem productMap_left_apply (a : A) : productMap f g (a ⊗ₜ 1) = f a := by
   simp
 #align algebra.tensor_product.product_map_left_apply Algebra.TensorProduct.productMap_left_apply
 
@@ -791,7 +829,7 @@ theorem productMap_left : (productMap f g).comp includeLeft = f :=
 #align algebra.tensor_product.product_map_left Algebra.TensorProduct.productMap_left
 
 theorem productMap_right_apply (b : B) :
-    productMap f g (includeRight (R := R) (A := A) (B := B) b) = g b := by simp
+    productMap f g (1 ⊗ₜ b) = g b := by simp
 #align algebra.tensor_product.product_map_right_apply Algebra.TensorProduct.productMap_right_apply
 
 @[simp]
@@ -893,28 +931,30 @@ end Algebra
 
 namespace Module
 
-variable {R M N : Type _} [CommSemiring R]
+variable {R S A M N : Type _} [CommSemiring R] [CommSemiring S] [Semiring A]
 
 variable [AddCommMonoid M] [AddCommMonoid N]
 
-variable [Module R M] [Module R N]
+variable [Algebra R S] [Algebra S A] [Algebra R A]
+variable [Module R M] [Module S M] [Module A M] [Module R N]
+variable [IsScalarTower R A M] [IsScalarTower S A M] [IsScalarTower R S M]
 
 /-- The algebra homomorphism from `End M ⊗ End N` to `End (M ⊗ N)` sending `f ⊗ₜ g` to
-the `TensorProduct.map f g`, the tensor product of the two maps. -/
-def endTensorEndAlgHom : End R M ⊗[R] End R N →ₐ[R] End R (M ⊗[R] N) := by
-  refine' Algebra.TensorProduct.algHomOfLinearMapTensorProduct (homTensorHomMap R M N M N) _ _
-  · intro f₁ f₂ g₁ g₂
-    simp only [homTensorHomMap_apply, TensorProduct.map_mul]
-  · intro r
-    simp only [homTensorHomMap_apply]
-    ext m n
-    simp [smul_tmul]
+the `TensorProduct.map f g`, the tensor product of the two maps.
+
+This is an `AlgHom` version of `TensorProduct.AlgebraTensorModule.homTensorHomMap`. Like that
+definition, this is generalized across many different rings; namely a tower of algebras `A/S/R`. -/
+def endTensorEndAlgHom : End A M ⊗[R] End R N →ₐ[S] End A (M ⊗[R] N) :=
+  Algebra.TensorProduct.algHomOfLinearMapTensorProduct
+    (AlgebraTensorModule.homTensorHomMap R A S M N M N)
+    (fun _f₁ _f₂ _g₁ _g₂ => AlgebraTensorModule.ext fun _m _n => rfl)
+    (fun _r => AlgebraTensorModule.ext fun _m _n => rfl)
 #align module.End_tensor_End_alg_hom Module.endTensorEndAlgHom
 
-theorem endTensorEndAlgHom_apply (f : End R M) (g : End R N) :
-    endTensorEndAlgHom (R := R) (M := M) (N := N) (f ⊗ₜ[R] g) = TensorProduct.map f g := by
-  simp only [endTensorEndAlgHom, Algebra.TensorProduct.algHomOfLinearMapTensorProduct_apply,
-    homTensorHomMap_apply]
+theorem endTensorEndAlgHom_apply (f : End A M) (g : End R N) :
+    endTensorEndAlgHom (R := R) (S := S) (A := A) (M := M) (N := N) (f ⊗ₜ[R] g)
+      = AlgebraTensorModule.map f g :=
+  rfl
 #align module.End_tensor_End_alg_hom_apply Module.endTensorEndAlgHom_apply
 
 end Module
@@ -1022,3 +1062,4 @@ theorem smul_def (a : A) (b : B) (m : M) : a ⊗ₜ[R] b • m = a • b • m :
 #align tensor_product.algebra.smul_def TensorProduct.Algebra.smul_def
 
 end TensorProduct.Algebra
+#lint


### PR DESCRIPTION
This:
* Improves the module docstring, which was both out of date and not very informative
* Addresses a `TODO` to generalize `includeLeft` to commuting actions. As a result a few downstream results are changed to be about `includeLeftRingHom` or `a ⊗ₜ 1`, as carrying around the extra useless ring just makes the lemmas harder to use. Nothing seems to suffer from this change.
* Introduces `TensorProduct.AlgebraTensorModule.rid`
* Generalizes the following to work for towers of rings:
  * `Algebra.TensorProduct.algHomOfLinearMapTensorProduct`
  * `Algebra.TensorProduct.map`
  * `Algebra.TensorProduct.congr`
  * `Algebra.TensorProduct.endTensorEndAlgHom`
  * `Algebra.TensorProduct.ext` (and renames it to `Algebra.TensorProduct.ext'`)
  * `Algebra.TensorProduct.rid`
* Introduces a new `Algebra.TensorProduct.ext` which follows "partially-applied ext lemmas", and uses it to golf a proof in `RingTheory/Etale.lean`
 
I need many of these results for building `AlgEquiv`s relating to the base change of clifford algebras.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
