### PR TITLE
[Merged by Bors] - chore: bump leantar version

### DIFF
--- a/Cache/IO.lean
+++ b/Cache/IO.lean
@@ -67,7 +67,7 @@ def CURLBIN :=
 
 /-- leantar version at https://github.com/digama0/leangz -/
 def LEANTARVERSION :=
-  "0.1.4"
+  "0.1.5"
 
 def EXE := if System.Platform.isWindows then ".exe" else ""
 


### PR DESCRIPTION
This fixes the issue that leantar-0.1.4.exe was not actually statically linked on windows, reported by @MohanadAhmed . Could someone using MacOS aarch64 check that this still works? All other OSs should be unaffected.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
