### PR TITLE
[Merged by Bors] - refactor(Algebra/Order/LatticeGroup): Non-commutative Lattice Groups

### DIFF
--- a/Mathlib/Algebra/Order/LatticeGroup.lean
+++ b/Mathlib/Algebra/Order/LatticeGroup.lean
@@ -409,6 +409,38 @@ theorem pos_mul_neg
 #align lattice_ordered_comm_group.pos_mul_neg LatticeOrderedGroup.pos_mul_neg
 #align lattice_ordered_comm_group.pos_add_neg LatticeOrderedGroup.pos_add_neg
 
+@[to_additive pos_abs]
+theorem m_pos_abs [CovariantClass α α (· * ·) (· ≤ ·)] [CovariantClass α α (swap (· * ·)) (· ≤ ·)]
+    (a : α) : |a|⁺ = |a| := by
+  rw [m_pos_part_def]
+  apply sup_of_le_left
+  apply one_le_abs
+#align lattice_ordered_comm_group.m_pos_abs LatticeOrderedGroup.m_pos_abs
+#align lattice_ordered_comm_group.pos_abs LatticeOrderedGroup.pos_abs
+
+-- a ⊔ b - (a ⊓ b) = |b - a|
+@[to_additive]
+theorem sup_div_inf_eq_abs_div
+    [CovariantClass α α (· * ·) (· ≤ ·)] [CovariantClass α α (swap (· * ·)) (· ≤ ·)] (a b : α) :
+    (a ⊔ b) / (a ⊓ b) = |b / a| :=
+calc
+  (a ⊔ b) / (a ⊓ b) = (a ⊔ b) * (a ⊓ b)⁻¹ := by rw [div_eq_mul_inv]
+  _ = (a ⊔ b) * (a⁻¹ ⊔ b⁻¹) := by rw [← inv_inf_eq_sup_inv]
+  _ = (a ⊔ b) * a⁻¹ ⊔ (a ⊔ b) * b⁻¹ := by rw [mul_sup]
+  _ = (a * a⁻¹ ⊔ b * a⁻¹) ⊔ (a * b⁻¹ ⊔ b * b⁻¹) := by rw [sup_mul, sup_mul]
+  _ = (1 ⊔ b * a⁻¹) ⊔ (a * b⁻¹ ⊔ 1) := by rw [mul_right_inv, mul_right_inv]
+  _ = (1 ⊔ b / a) ⊔ (a / b ⊔ 1) := by rw [←div_eq_mul_inv, ←div_eq_mul_inv]
+  _ = 1 ⊔ b / a ⊔ (1 / (b / a) ⊔ 1) := by rw [one_div_div]
+  _ = 1 ⊔ ((b / a) ⊔ ((b / a)⁻¹ ⊔ 1)) := by rw [inv_eq_one_div, sup_assoc]
+  _ = 1 ⊔ (((b / a) ⊔ (b / a)⁻¹) ⊔ 1) := by rw [sup_assoc]
+  _ = 1 ⊔ (((b / a) ⊔ (b / a)⁻¹) ⊔ 1) := by rw [sup_assoc]
+  _= 1 ⊔ (|b / a| ⊔ 1) := by rw [abs_eq_sup_inv]
+  _= 1 ⊔ |b / a| := by rw [← m_pos_part_def, m_pos_abs]
+  _= |b / a| ⊔ 1 := by rw [sup_comm]
+  _= |b / a| := by rw [← m_pos_part_def, m_pos_abs]
+#align lattice_ordered_comm_group.sup_div_inf_eq_abs_div LatticeOrderedGroup.sup_div_inf_eq_abs_div
+#align lattice_ordered_comm_group.sup_sub_inf_eq_abs_sub LatticeOrderedGroup.sup_sub_inf_eq_abs_sub
+
 end LatticeOrderedGroup
 
 end Group
@@ -500,26 +532,6 @@ theorem m_neg_abs [CovariantClass α α (· * ·) (· ≤ ·)] (a : α) : |a|⁻
   · exact one_le_neg _
 #align lattice_ordered_comm_group.m_neg_abs LatticeOrderedCommGroup.m_neg_abs
 #align lattice_ordered_comm_group.neg_abs LatticeOrderedCommGroup.neg_abs
-
-@[to_additive pos_abs]
-theorem m_pos_abs [CovariantClass α α (· * ·) (· ≤ ·)] (a : α) : |a|⁺ = |a| := by
-  nth_rw 2 [← pos_div_neg |a|]
-  rw [div_eq_mul_inv]
-  symm
-  rw [mul_right_eq_self, inv_eq_one]
-  exact m_neg_abs a
-#align lattice_ordered_comm_group.m_pos_abs LatticeOrderedCommGroup.m_pos_abs
-#align lattice_ordered_comm_group.pos_abs LatticeOrderedCommGroup.pos_abs
-
--- a ⊔ b - (a ⊓ b) = |b - a|
-@[to_additive]
-theorem sup_div_inf_eq_abs_div [CovariantClass α α (· * ·) (· ≤ ·)] (a b : α) :
-    (a ⊔ b) / (a ⊓ b) = |b / a| := by
-  rw [sup_eq_mul_pos_div, inf_comm, inf_eq_div_pos_div, div_eq_mul_inv, div_eq_mul_inv b ((b / a)⁺),
-    mul_inv_rev, inv_inv, mul_comm, ← mul_assoc, inv_mul_cancel_right, pos_eq_neg_inv (a / b),
-    div_eq_mul_inv a b, mul_inv_rev, ← div_eq_mul_inv, inv_inv, ← pos_mul_neg]
-#align lattice_ordered_comm_group.sup_div_inf_eq_abs_div LatticeOrderedCommGroup.sup_div_inf_eq_abs_div
-#align lattice_ordered_comm_group.sup_sub_inf_eq_abs_sub LatticeOrderedCommGroup.sup_sub_inf_eq_abs_sub
 
 -- 2•(a ⊔ b) = a + b + |b - a|
 @[to_additive two_sup_eq_add_add_abs_sub]

--- a/Mathlib/Algebra/Order/LatticeGroup.lean
+++ b/Mathlib/Algebra/Order/LatticeGroup.lean
@@ -60,9 +60,15 @@ lattices.
 lattice, ordered, group
 -/
 
+open Function
+
 universe u v
 
-variable {α : Type u} {β : Type v} [Lattice α] [CommGroup α]
+variable {α : Type u} {β : Type v}
+
+section Group
+
+variable [Lattice α] [Group α]
 
 -- Special case of Bourbaki A.VI.9 (1)
 -- c + (a ⊔ b) = (c + a) ⊔ (c + b)
@@ -73,7 +79,8 @@ theorem mul_sup [CovariantClass α α (· * ·) (· ≤ ·)] (a b c : α) : c * 
 #align add_sup add_sup
 
 @[to_additive]
-theorem sup_mul [CovariantClass α α (· * ·) (· ≤ ·)] (a b c : α) : (a ⊔ b) * c = a * c ⊔ b * c :=
+theorem sup_mul [CovariantClass α α (swap (· * ·)) (· ≤ ·)] (a b c : α) :
+    (a ⊔ b) * c = a * c ⊔ b * c :=
   (OrderIso.mulRight _).map_sup _ _
 #align sup_mul sup_mul
 #align sup_add sup_add
@@ -85,7 +92,8 @@ theorem mul_inf [CovariantClass α α (· * ·) (· ≤ ·)] (a b c : α) : c * 
 #align add_inf add_inf
 
 @[to_additive]
-theorem inf_mul [CovariantClass α α (· * ·) (· ≤ ·)] (a b c : α) : (a ⊓ b) * c = a * c ⊓ b * c :=
+theorem inf_mul [CovariantClass α α (swap (· * ·)) (· ≤ ·)] (a b c : α) :
+    (a ⊓ b) * c = a * c ⊓ b * c :=
   (OrderIso.mulRight _).map_inf _ _
 #align inf_mul inf_mul
 #align inf_add inf_add
@@ -93,7 +101,8 @@ theorem inf_mul [CovariantClass α α (· * ·) (· ≤ ·)] (a b c : α) : (a �
 -- Special case of Bourbaki A.VI.9 (2)
 -- -(a ⊔ b)=(-a) ⊓ (-b)
 @[to_additive]
-theorem inv_sup_eq_inv_inf_inv [CovariantClass α α (· * ·) (· ≤ ·)] (a b : α) :
+theorem inv_sup_eq_inv_inf_inv
+    [CovariantClass α α (· * ·) (· ≤ ·)] [CovariantClass α α (swap (· * ·)) (· ≤ ·)] (a b : α) :
     (a ⊔ b)⁻¹ = a⁻¹ ⊓ b⁻¹ :=
   (OrderIso.inv α).map_sup _ _
 #align inv_sup_eq_inv_inf_inv inv_sup_eq_inv_inf_inv
@@ -101,11 +110,271 @@ theorem inv_sup_eq_inv_inf_inv [CovariantClass α α (· * ·) (· ≤ ·)] (a b
 
 -- -(a ⊓ b) = -a ⊔ -b
 @[to_additive]
-theorem inv_inf_eq_sup_inv [CovariantClass α α (· * ·) (· ≤ ·)] (a b : α) : (a ⊓ b)⁻¹ = a⁻¹ ⊔ b⁻¹ :=
+theorem inv_inf_eq_sup_inv
+    [CovariantClass α α (· * ·) (· ≤ ·)] [CovariantClass α α (swap (· * ·)) (· ≤ ·)] (a b : α) :
+    (a ⊓ b)⁻¹ = a⁻¹ ⊔ b⁻¹ :=
   (OrderIso.inv α).map_inf _ _
 #align inv_inf_eq_sup_inv inv_inf_eq_sup_inv
 #align neg_inf_eq_sup_neg neg_inf_eq_sup_neg
 
+namespace LatticeOrderedGroup
+
+-- see Note [lower instance priority]
+/--
+Let `α` be a lattice ordered commutative group with identity `1`. For an element `a` of type `α`,
+the element `a ⊔ 1` is said to be the *positive component* of `a`, denoted `a⁺`.
+-/
+@[to_additive
+      "Let `α` be a lattice ordered commutative group with identity `0`. For an element `a` of type
+      `α`,the element `a ⊔ 0` is said to be the *positive component* of `a`, denoted `a⁺`."]
+instance (priority := 100) hasOneLatticeHasPosPart : PosPart α :=
+  ⟨fun a => a ⊔ 1⟩
+#align lattice_ordered_comm_group.has_one_lattice_has_pos_part LatticeOrderedGroup.hasOneLatticeHasPosPart
+#align lattice_ordered_comm_group.has_zero_lattice_has_pos_part LatticeOrderedGroup.hasZeroLatticeHasPosPart
+
+@[to_additive pos_part_def]
+theorem m_pos_part_def (a : α) : a⁺ = a ⊔ 1 :=
+  rfl
+#align lattice_ordered_comm_group.m_pos_part_def LatticeOrderedGroup.m_pos_part_def
+#align lattice_ordered_comm_group.pos_part_def LatticeOrderedGroup.pos_part_def
+
+-- see Note [lower instance priority]
+/--
+Let `α` be a lattice ordered commutative group with identity `1`. For an element `a` of type `α`,
+the element `(-a) ⊔ 1` is said to be the *negative component* of `a`, denoted `a⁻`.
+-/
+@[to_additive
+      "Let `α` be a lattice ordered commutative group with identity `0`. For an element `a` of type
+      `α`, the element `(-a) ⊔ 0` is said to be the *negative component* of `a`, denoted `a⁻`."]
+instance (priority := 100) hasOneLatticeHasNegPart : NegPart α :=
+  ⟨fun a => a⁻¹ ⊔ 1⟩
+#align lattice_ordered_comm_group.has_one_lattice_has_neg_part LatticeOrderedGroup.hasOneLatticeHasNegPart
+#align lattice_ordered_comm_group.has_zero_lattice_has_neg_part LatticeOrderedGroup.hasZeroLatticeHasNegPart
+
+@[to_additive neg_part_def]
+theorem m_neg_part_def (a : α) : a⁻ = a⁻¹ ⊔ 1 :=
+  rfl
+#align lattice_ordered_comm_group.m_neg_part_def LatticeOrderedGroup.m_neg_part_def
+#align lattice_ordered_comm_group.neg_part_def LatticeOrderedGroup.neg_part_def
+
+@[to_additive (attr := simp)]
+theorem pos_one : (1 : α)⁺ = 1 :=
+  sup_idem
+#align lattice_ordered_comm_group.pos_one LatticeOrderedGroup.pos_one
+#align lattice_ordered_comm_group.pos_zero LatticeOrderedGroup.pos_zero
+
+@[to_additive (attr := simp)]
+theorem neg_one : (1 : α)⁻ = 1 := by rw [m_neg_part_def, inv_one, sup_idem]
+#align lattice_ordered_comm_group.neg_one LatticeOrderedGroup.neg_one
+#align lattice_ordered_comm_group.neg_zero LatticeOrderedGroup.neg_zero
+
+-- a⁻ = -(a ⊓ 0)
+@[to_additive]
+theorem neg_eq_inv_inf_one
+    [CovariantClass α α (· * ·) (· ≤ ·)] [CovariantClass α α (swap (· * ·)) (· ≤ ·)] (a : α) :
+    a⁻ = (a ⊓ 1)⁻¹ := by
+  rw [m_neg_part_def, ← inv_inj, inv_sup_eq_inv_inf_inv, inv_inv, inv_inv, inv_one]
+#align lattice_ordered_comm_group.neg_eq_inv_inf_one LatticeOrderedGroup.neg_eq_inv_inf_one
+#align lattice_ordered_comm_group.neg_eq_neg_inf_zero LatticeOrderedGroup.neg_eq_neg_inf_zero
+
+@[to_additive le_abs]
+theorem le_mabs (a : α) : a ≤ |a| :=
+  le_sup_left
+#align lattice_ordered_comm_group.le_mabs LatticeOrderedGroup.le_mabs
+#align lattice_ordered_comm_group.le_abs LatticeOrderedGroup.le_abs
+
+-- -a ≤ |a|
+@[to_additive]
+theorem inv_le_abs (a : α) : a⁻¹ ≤ |a| :=
+  le_sup_right
+#align lattice_ordered_comm_group.inv_le_abs LatticeOrderedGroup.inv_le_abs
+#align lattice_ordered_comm_group.neg_le_abs LatticeOrderedGroup.neg_le_abs
+
+@[to_additive (attr := simp)]
+theorem abs_inv (a : α) : |a⁻¹| = |a| := calc
+  |a⁻¹| = a⁻¹ ⊔ (a⁻¹)⁻¹ := rfl
+  _ = a ⊔ a⁻¹ := by rw [inv_inv, sup_comm]
+
+-- 0 ≤ a⁺
+@[to_additive pos_nonneg]
+theorem one_le_pos (a : α) : 1 ≤ a⁺ :=
+  le_sup_right
+#align lattice_ordered_comm_group.one_le_pos LatticeOrderedGroup.one_le_pos
+#align lattice_ordered_comm_group.pos_nonneg LatticeOrderedGroup.pos_nonneg
+
+-- 0 ≤ a⁻
+@[to_additive neg_nonneg]
+theorem one_le_neg (a : α) : 1 ≤ a⁻ :=
+  le_sup_right
+#align lattice_ordered_comm_group.one_le_neg LatticeOrderedGroup.one_le_neg
+#align lattice_ordered_comm_group.neg_nonneg LatticeOrderedGroup.neg_nonneg
+
+-- pos_nonpos_iff
+@[to_additive]
+theorem pos_le_one_iff {a : α} : a⁺ ≤ 1 ↔ a ≤ 1 := by
+  rw [m_pos_part_def, sup_le_iff, and_iff_left le_rfl]
+#align lattice_ordered_comm_group.pos_le_one_iff LatticeOrderedGroup.pos_le_one_iff
+#align lattice_ordered_comm_group.pos_nonpos_iff LatticeOrderedGroup.pos_nonpos_iff
+
+-- neg_nonpos_iff
+@[to_additive]
+theorem neg_le_one_iff {a : α} : a⁻ ≤ 1 ↔ a⁻¹ ≤ 1 := by
+  rw [m_neg_part_def, sup_le_iff, and_iff_left le_rfl]
+#align lattice_ordered_comm_group.neg_le_one_iff LatticeOrderedGroup.neg_le_one_iff
+#align lattice_ordered_comm_group.neg_nonpos_iff LatticeOrderedGroup.neg_nonpos_iff
+
+@[to_additive]
+theorem pos_eq_one_iff {a : α} : a⁺ = 1 ↔ a ≤ 1 :=
+  sup_eq_right
+#align lattice_ordered_comm_group.pos_eq_one_iff LatticeOrderedGroup.pos_eq_one_iff
+#align lattice_ordered_comm_group.pos_eq_zero_iff LatticeOrderedGroup.pos_eq_zero_iff
+
+@[to_additive]
+theorem neg_eq_one_iff' {a : α} : a⁻ = 1 ↔ a⁻¹ ≤ 1 :=
+  sup_eq_right
+#align lattice_ordered_comm_group.neg_eq_one_iff' LatticeOrderedGroup.neg_eq_one_iff'
+#align lattice_ordered_comm_group.neg_eq_zero_iff' LatticeOrderedGroup.neg_eq_zero_iff'
+
+@[to_additive]
+theorem neg_eq_one_iff [CovariantClass α α Mul.mul LE.le] {a : α} : a⁻ = 1 ↔ 1 ≤ a := by
+  rw [le_antisymm_iff, neg_le_one_iff, inv_le_one', and_iff_left (one_le_neg _)]
+#align lattice_ordered_comm_group.neg_eq_one_iff LatticeOrderedGroup.neg_eq_one_iff
+#align lattice_ordered_comm_group.neg_eq_zero_iff LatticeOrderedGroup.neg_eq_zero_iff
+
+@[to_additive le_pos]
+theorem m_le_pos (a : α) : a ≤ a⁺ :=
+  le_sup_left
+#align lattice_ordered_comm_group.m_le_pos LatticeOrderedGroup.m_le_pos
+#align lattice_ordered_comm_group.le_pos LatticeOrderedGroup.le_pos
+
+-- -a ≤ a⁻
+@[to_additive]
+theorem inv_le_neg (a : α) : a⁻¹ ≤ a⁻ :=
+  le_sup_left
+#align lattice_ordered_comm_group.inv_le_neg LatticeOrderedGroup.inv_le_neg
+#align lattice_ordered_comm_group.neg_le_neg LatticeOrderedGroup.neg_le_neg
+
+-- Bourbaki A.VI.12
+--  a⁻ = (-a)⁺
+@[to_additive]
+theorem neg_eq_pos_inv (a : α) : a⁻ = a⁻¹⁺ :=
+  rfl
+#align lattice_ordered_comm_group.neg_eq_pos_inv LatticeOrderedGroup.neg_eq_pos_inv
+#align lattice_ordered_comm_group.neg_eq_pos_neg LatticeOrderedGroup.neg_eq_pos_neg
+
+-- a⁺ = (-a)⁻
+@[to_additive]
+theorem pos_eq_neg_inv (a : α) : a⁺ = a⁻¹⁻ := by rw [neg_eq_pos_inv, inv_inv]
+#align lattice_ordered_comm_group.pos_eq_neg_inv LatticeOrderedGroup.pos_eq_neg_inv
+#align lattice_ordered_comm_group.pos_eq_neg_neg LatticeOrderedGroup.pos_eq_neg_neg
+
+-- We use this in Bourbaki A.VI.12 Prop 9 a)
+-- c + (a ⊓ b) = (c + a) ⊓ (c + b)
+@[to_additive]
+theorem mul_inf_eq_mul_inf_mul [CovariantClass α α (· * ·) (· ≤ ·)] (a b c : α) :
+    c * (a ⊓ b) = c * a ⊓ c * b := by
+  refine' le_antisymm _ _
+  rw [le_inf_iff, mul_le_mul_iff_left, mul_le_mul_iff_left]
+  simp
+  rw [← mul_le_mul_iff_left c⁻¹, ← mul_assoc, inv_mul_self, one_mul, le_inf_iff,
+    inv_mul_le_iff_le_mul, inv_mul_le_iff_le_mul]
+  simp
+#align lattice_ordered_comm_group.mul_inf_eq_mul_inf_mul LatticeOrderedGroup.mul_inf_eq_mul_inf_mul
+#align lattice_ordered_comm_group.add_inf_eq_add_inf_add LatticeOrderedGroup.add_inf_eq_add_inf_add
+
+-- Bourbaki A.VI.12 Prop 9 a)
+-- a = a⁺ - a⁻
+@[to_additive (attr := simp)]
+theorem pos_div_neg [CovariantClass α α (· * ·) (· ≤ ·)] (a : α) : a⁺ / a⁻ = a := by
+  symm
+  rw [div_eq_mul_inv]
+  apply eq_mul_inv_of_mul_eq
+  rw [m_neg_part_def, mul_sup, mul_one, mul_right_inv, sup_comm, m_pos_part_def]
+#align lattice_ordered_comm_group.pos_div_neg LatticeOrderedGroup.pos_div_neg
+#align lattice_ordered_comm_group.pos_sub_neg LatticeOrderedGroup.pos_sub_neg
+
+-- pos_of_nonneg
+/-- If `a` is positive, then it is equal to its positive component `a⁺`. -/
+@[to_additive "If `a` is positive, then it is equal to its positive component `a⁺`."]
+theorem pos_of_one_le (a : α) (h : 1 ≤ a) : a⁺ = a := by
+  rw [m_pos_part_def]
+  exact sup_of_le_left h
+#align lattice_ordered_comm_group.pos_of_one_le LatticeOrderedGroup.pos_of_one_le
+#align lattice_ordered_comm_group.pos_of_nonneg LatticeOrderedGroup.pos_of_nonneg
+
+-- 0 ≤ a implies a⁺ = a
+-- pos_of_nonpos
+@[to_additive]
+theorem pos_of_le_one (a : α) (h : a ≤ 1) : a⁺ = 1 :=
+  pos_eq_one_iff.mpr h
+#align lattice_ordered_comm_group.pos_of_le_one LatticeOrderedGroup.pos_of_le_one
+#align lattice_ordered_comm_group.pos_of_nonpos LatticeOrderedGroup.pos_of_nonpos
+
+@[to_additive neg_of_inv_nonneg]
+theorem neg_of_one_le_inv (a : α) (h : 1 ≤ a⁻¹) : a⁻ = a⁻¹ := by
+  rw [neg_eq_pos_inv]
+  exact pos_of_one_le _ h
+#align lattice_ordered_comm_group.neg_of_one_le_inv LatticeOrderedGroup.neg_of_one_le_inv
+#align lattice_ordered_comm_group.neg_of_inv_nonneg LatticeOrderedGroup.neg_of_inv_nonneg
+
+-- neg_of_neg_nonpos
+@[to_additive]
+theorem neg_of_inv_le_one (a : α) (h : a⁻¹ ≤ 1) : a⁻ = 1 :=
+  neg_eq_one_iff'.mpr h
+#align lattice_ordered_comm_group.neg_of_inv_le_one LatticeOrderedGroup.neg_of_inv_le_one
+#align lattice_ordered_comm_group.neg_of_neg_nonpos LatticeOrderedGroup.neg_of_neg_nonpos
+
+-- neg_of_nonpos
+@[to_additive]
+theorem neg_of_le_one [CovariantClass α α (· * ·) (· ≤ ·)] (a : α) (h : a ≤ 1) : a⁻ = a⁻¹ :=
+  sup_eq_left.2 <| one_le_inv'.2 h
+#align lattice_ordered_comm_group.neg_of_le_one LatticeOrderedGroup.neg_of_le_one
+#align lattice_ordered_comm_group.neg_of_nonpos LatticeOrderedGroup.neg_of_nonpos
+
+-- pos_eq_self_of_pos_pos
+@[to_additive]
+theorem pos_eq_self_of_one_lt_pos {α} [LinearOrder α] [CommGroup α] {x : α} (hx : 1 < x⁺) :
+    x⁺ = x := by
+  rw [m_pos_part_def, right_lt_sup, not_le] at hx
+  rw [m_pos_part_def, sup_eq_left]
+  exact hx.le
+#align lattice_ordered_comm_group.pos_eq_self_of_one_lt_pos LatticeOrderedGroup.pos_eq_self_of_one_lt_pos
+#align lattice_ordered_comm_group.pos_eq_self_of_pos_pos LatticeOrderedGroup.pos_eq_self_of_pos_pos
+
+-- neg_of_nonneg'
+@[to_additive]
+theorem neg_of_one_le [CovariantClass α α (· * ·) (· ≤ ·)] (a : α) (h : 1 ≤ a) : a⁻ = 1 :=
+  neg_eq_one_iff.mpr h
+#align lattice_ordered_comm_group.neg_of_one_le LatticeOrderedGroup.neg_of_one_le
+#align lattice_ordered_comm_group.neg_of_nonneg LatticeOrderedGroup.neg_of_nonneg
+
+-- 0 ≤ a implies |a| = a
+@[to_additive abs_of_nonneg]
+theorem mabs_of_one_le [CovariantClass α α (· * ·) (· ≤ ·)] (a : α) (h : 1 ≤ a) : |a| = a :=
+  sup_eq_left.2 <| Left.inv_le_self h
+#align lattice_ordered_comm_group.mabs_of_one_le LatticeOrderedGroup.mabs_of_one_le
+#align lattice_ordered_comm_group.abs_of_nonneg LatticeOrderedGroup.abs_of_nonneg
+
+-- |a - b| = |b - a|
+@[to_additive]
+theorem abs_div_comm (a b : α) : |a / b| = |b / a| := by
+  dsimp only [Abs.abs]
+  rw [inv_div a b, ← inv_inv (a / b), inv_div, sup_comm]
+#align lattice_ordered_comm_group.abs_inv_comm LatticeOrderedGroup.abs_div_comm
+#align lattice_ordered_comm_group.abs_neg_comm LatticeOrderedGroup.abs_sub_comm
+
+end LatticeOrderedGroup
+
+end Group
+
+
+variable [Lattice α] [CommGroup α]
+
+
+
+
+
+-- Fuchs p67
 -- Bourbaki A.VI.10 Prop 7
 -- a ⊓ b + (a ⊔ b) = a + b
 @[to_additive]
@@ -120,177 +389,7 @@ theorem inf_mul_sup [CovariantClass α α (· * ·) (· ≤ ·)] (a b : α) : (a
 
 namespace LatticeOrderedCommGroup
 
--- see Note [lower instance priority]
-/--
-Let `α` be a lattice ordered commutative group with identity `1`. For an element `a` of type `α`,
-the element `a ⊔ 1` is said to be the *positive component* of `a`, denoted `a⁺`.
--/
-@[to_additive
-      "Let `α` be a lattice ordered commutative group with identity `0`. For an element `a` of type
-      `α`,the element `a ⊔ 0` is said to be the *positive component* of `a`, denoted `a⁺`."]
-instance (priority := 100) hasOneLatticeHasPosPart : PosPart α :=
-  ⟨fun a => a ⊔ 1⟩
-#align lattice_ordered_comm_group.has_one_lattice_has_pos_part LatticeOrderedCommGroup.hasOneLatticeHasPosPart
-#align lattice_ordered_comm_group.has_zero_lattice_has_pos_part LatticeOrderedCommGroup.hasZeroLatticeHasPosPart
-
-@[to_additive pos_part_def]
-theorem m_pos_part_def (a : α) : a⁺ = a ⊔ 1 :=
-  rfl
-#align lattice_ordered_comm_group.m_pos_part_def LatticeOrderedCommGroup.m_pos_part_def
-#align lattice_ordered_comm_group.pos_part_def LatticeOrderedCommGroup.pos_part_def
-
--- see Note [lower instance priority]
-/--
-Let `α` be a lattice ordered commutative group with identity `1`. For an element `a` of type `α`,
-the element `(-a) ⊔ 1` is said to be the *negative component* of `a`, denoted `a⁻`.
--/
-@[to_additive
-      "Let `α` be a lattice ordered commutative group with identity `0`. For an element `a` of type
-      `α`, the element `(-a) ⊔ 0` is said to be the *negative component* of `a`, denoted `a⁻`."]
-instance (priority := 100) hasOneLatticeHasNegPart : NegPart α :=
-  ⟨fun a => a⁻¹ ⊔ 1⟩
-#align lattice_ordered_comm_group.has_one_lattice_has_neg_part LatticeOrderedCommGroup.hasOneLatticeHasNegPart
-#align lattice_ordered_comm_group.has_zero_lattice_has_neg_part LatticeOrderedCommGroup.hasZeroLatticeHasNegPart
-
-@[to_additive neg_part_def]
-theorem m_neg_part_def (a : α) : a⁻ = a⁻¹ ⊔ 1 :=
-  rfl
-#align lattice_ordered_comm_group.m_neg_part_def LatticeOrderedCommGroup.m_neg_part_def
-#align lattice_ordered_comm_group.neg_part_def LatticeOrderedCommGroup.neg_part_def
-
-@[to_additive (attr := simp)]
-theorem pos_one : (1 : α)⁺ = 1 :=
-  sup_idem
-#align lattice_ordered_comm_group.pos_one LatticeOrderedCommGroup.pos_one
-#align lattice_ordered_comm_group.pos_zero LatticeOrderedCommGroup.pos_zero
-
-@[to_additive (attr := simp)]
-theorem neg_one : (1 : α)⁻ = 1 := by rw [m_neg_part_def, inv_one, sup_idem]
-#align lattice_ordered_comm_group.neg_one LatticeOrderedCommGroup.neg_one
-#align lattice_ordered_comm_group.neg_zero LatticeOrderedCommGroup.neg_zero
-
--- a⁻ = -(a ⊓ 0)
-@[to_additive]
-theorem neg_eq_inv_inf_one [CovariantClass α α (· * ·) (· ≤ ·)] (a : α) : a⁻ = (a ⊓ 1)⁻¹ := by
-  rw [m_neg_part_def, ← inv_inj, inv_sup_eq_inv_inf_inv, inv_inv, inv_inv, inv_one]
-#align lattice_ordered_comm_group.neg_eq_inv_inf_one LatticeOrderedCommGroup.neg_eq_inv_inf_one
-#align lattice_ordered_comm_group.neg_eq_neg_inf_zero LatticeOrderedCommGroup.neg_eq_neg_inf_zero
-
-@[to_additive le_abs]
-theorem le_mabs (a : α) : a ≤ |a| :=
-  le_sup_left
-#align lattice_ordered_comm_group.le_mabs LatticeOrderedCommGroup.le_mabs
-#align lattice_ordered_comm_group.le_abs LatticeOrderedCommGroup.le_abs
-
--- -a ≤ |a|
-@[to_additive]
-theorem inv_le_abs (a : α) : a⁻¹ ≤ |a| :=
-  le_sup_right
-#align lattice_ordered_comm_group.inv_le_abs LatticeOrderedCommGroup.inv_le_abs
-#align lattice_ordered_comm_group.neg_le_abs LatticeOrderedCommGroup.neg_le_abs
-
-@[to_additive (attr := simp)]
-theorem abs_inv (a : α) : |a⁻¹| = |a| := calc
-  |a⁻¹| = a⁻¹ ⊔ (a⁻¹)⁻¹ := rfl
-  _ = a ⊔ a⁻¹ := by rw [inv_inv, sup_comm]
-
--- 0 ≤ a⁺
-@[to_additive pos_nonneg]
-theorem one_le_pos (a : α) : 1 ≤ a⁺ :=
-  le_sup_right
-#align lattice_ordered_comm_group.one_le_pos LatticeOrderedCommGroup.one_le_pos
-#align lattice_ordered_comm_group.pos_nonneg LatticeOrderedCommGroup.pos_nonneg
-
--- 0 ≤ a⁻
-@[to_additive neg_nonneg]
-theorem one_le_neg (a : α) : 1 ≤ a⁻ :=
-  le_sup_right
-#align lattice_ordered_comm_group.one_le_neg LatticeOrderedCommGroup.one_le_neg
-#align lattice_ordered_comm_group.neg_nonneg LatticeOrderedCommGroup.neg_nonneg
-
--- pos_nonpos_iff
-@[to_additive]
-theorem pos_le_one_iff {a : α} : a⁺ ≤ 1 ↔ a ≤ 1 := by
-  rw [m_pos_part_def, sup_le_iff, and_iff_left le_rfl]
-#align lattice_ordered_comm_group.pos_le_one_iff LatticeOrderedCommGroup.pos_le_one_iff
-#align lattice_ordered_comm_group.pos_nonpos_iff LatticeOrderedCommGroup.pos_nonpos_iff
-
--- neg_nonpos_iff
-@[to_additive]
-theorem neg_le_one_iff {a : α} : a⁻ ≤ 1 ↔ a⁻¹ ≤ 1 := by
-  rw [m_neg_part_def, sup_le_iff, and_iff_left le_rfl]
-#align lattice_ordered_comm_group.neg_le_one_iff LatticeOrderedCommGroup.neg_le_one_iff
-#align lattice_ordered_comm_group.neg_nonpos_iff LatticeOrderedCommGroup.neg_nonpos_iff
-
-@[to_additive]
-theorem pos_eq_one_iff {a : α} : a⁺ = 1 ↔ a ≤ 1 :=
-  sup_eq_right
-#align lattice_ordered_comm_group.pos_eq_one_iff LatticeOrderedCommGroup.pos_eq_one_iff
-#align lattice_ordered_comm_group.pos_eq_zero_iff LatticeOrderedCommGroup.pos_eq_zero_iff
-
-@[to_additive]
-theorem neg_eq_one_iff' {a : α} : a⁻ = 1 ↔ a⁻¹ ≤ 1 :=
-  sup_eq_right
-#align lattice_ordered_comm_group.neg_eq_one_iff' LatticeOrderedCommGroup.neg_eq_one_iff'
-#align lattice_ordered_comm_group.neg_eq_zero_iff' LatticeOrderedCommGroup.neg_eq_zero_iff'
-
-@[to_additive]
-theorem neg_eq_one_iff [CovariantClass α α Mul.mul LE.le] {a : α} : a⁻ = 1 ↔ 1 ≤ a := by
-  rw [le_antisymm_iff, neg_le_one_iff, inv_le_one', and_iff_left (one_le_neg _)]
-#align lattice_ordered_comm_group.neg_eq_one_iff LatticeOrderedCommGroup.neg_eq_one_iff
-#align lattice_ordered_comm_group.neg_eq_zero_iff LatticeOrderedCommGroup.neg_eq_zero_iff
-
-@[to_additive le_pos]
-theorem m_le_pos (a : α) : a ≤ a⁺ :=
-  le_sup_left
-#align lattice_ordered_comm_group.m_le_pos LatticeOrderedCommGroup.m_le_pos
-#align lattice_ordered_comm_group.le_pos LatticeOrderedCommGroup.le_pos
-
--- -a ≤ a⁻
-@[to_additive]
-theorem inv_le_neg (a : α) : a⁻¹ ≤ a⁻ :=
-  le_sup_left
-#align lattice_ordered_comm_group.inv_le_neg LatticeOrderedCommGroup.inv_le_neg
-#align lattice_ordered_comm_group.neg_le_neg LatticeOrderedCommGroup.neg_le_neg
-
--- Bourbaki A.VI.12
---  a⁻ = (-a)⁺
-@[to_additive]
-theorem neg_eq_pos_inv (a : α) : a⁻ = a⁻¹⁺ :=
-  rfl
-#align lattice_ordered_comm_group.neg_eq_pos_inv LatticeOrderedCommGroup.neg_eq_pos_inv
-#align lattice_ordered_comm_group.neg_eq_pos_neg LatticeOrderedCommGroup.neg_eq_pos_neg
-
--- a⁺ = (-a)⁻
-@[to_additive]
-theorem pos_eq_neg_inv (a : α) : a⁺ = a⁻¹⁻ := by rw [neg_eq_pos_inv, inv_inv]
-#align lattice_ordered_comm_group.pos_eq_neg_inv LatticeOrderedCommGroup.pos_eq_neg_inv
-#align lattice_ordered_comm_group.pos_eq_neg_neg LatticeOrderedCommGroup.pos_eq_neg_neg
-
--- We use this in Bourbaki A.VI.12 Prop 9 a)
--- c + (a ⊓ b) = (c + a) ⊓ (c + b)
-@[to_additive]
-theorem mul_inf_eq_mul_inf_mul [CovariantClass α α (· * ·) (· ≤ ·)] (a b c : α) :
-    c * (a ⊓ b) = c * a ⊓ c * b := by
-  refine' le_antisymm _ _
-  rw [le_inf_iff, mul_le_mul_iff_left, mul_le_mul_iff_left]
-  simp
-  rw [← mul_le_mul_iff_left c⁻¹, ← mul_assoc, inv_mul_self, one_mul, le_inf_iff,
-    inv_mul_le_iff_le_mul, inv_mul_le_iff_le_mul]
-  simp
-#align lattice_ordered_comm_group.mul_inf_eq_mul_inf_mul LatticeOrderedCommGroup.mul_inf_eq_mul_inf_mul
-#align lattice_ordered_comm_group.add_inf_eq_add_inf_add LatticeOrderedCommGroup.add_inf_eq_add_inf_add
-
--- Bourbaki A.VI.12 Prop 9 a)
--- a = a⁺ - a⁻
-@[to_additive (attr := simp)]
-theorem pos_div_neg [CovariantClass α α (· * ·) (· ≤ ·)] (a : α) : a⁺ / a⁻ = a := by
-  symm
-  rw [div_eq_mul_inv]
-  apply eq_mul_inv_of_mul_eq
-  rw [m_neg_part_def, mul_sup, mul_one, mul_right_inv, sup_comm, m_pos_part_def]
-#align lattice_ordered_comm_group.pos_div_neg LatticeOrderedCommGroup.pos_div_neg
-#align lattice_ordered_comm_group.pos_sub_neg LatticeOrderedCommGroup.pos_sub_neg
+open LatticeOrderedGroup
 
 -- Bourbaki A.VI.12 Prop 9 a)
 -- a⁺ ⊓ a⁻ = 0 (`a⁺` and `a⁻` are co-prime, and, since they are positive, disjoint)
@@ -460,68 +559,6 @@ theorem abs_div_sup_mul_abs_div_inf [CovariantClass α α (· * ·) (· ≤ ·)]
 #align lattice_ordered_comm_group.abs_div_sup_mul_abs_div_inf LatticeOrderedCommGroup.abs_div_sup_mul_abs_div_inf
 #align lattice_ordered_comm_group.abs_sub_sup_add_abs_sub_inf LatticeOrderedCommGroup.abs_sub_sup_add_abs_sub_inf
 
--- pos_of_nonneg
-/-- If `a` is positive, then it is equal to its positive component `a⁺`. -/
-@[to_additive "If `a` is positive, then it is equal to its positive component `a⁺`."]
-theorem pos_of_one_le (a : α) (h : 1 ≤ a) : a⁺ = a := by
-  rw [m_pos_part_def]
-  exact sup_of_le_left h
-#align lattice_ordered_comm_group.pos_of_one_le LatticeOrderedCommGroup.pos_of_one_le
-#align lattice_ordered_comm_group.pos_of_nonneg LatticeOrderedCommGroup.pos_of_nonneg
-
--- pos_eq_self_of_pos_pos
-@[to_additive]
-theorem pos_eq_self_of_one_lt_pos {α} [LinearOrder α] [CommGroup α] {x : α} (hx : 1 < x⁺) :
-    x⁺ = x := by
-  rw [m_pos_part_def, right_lt_sup, not_le] at hx
-  rw [m_pos_part_def, sup_eq_left]
-  exact hx.le
-#align lattice_ordered_comm_group.pos_eq_self_of_one_lt_pos LatticeOrderedCommGroup.pos_eq_self_of_one_lt_pos
-#align lattice_ordered_comm_group.pos_eq_self_of_pos_pos LatticeOrderedCommGroup.pos_eq_self_of_pos_pos
-
--- 0 ≤ a implies a⁺ = a
--- pos_of_nonpos
-@[to_additive]
-theorem pos_of_le_one (a : α) (h : a ≤ 1) : a⁺ = 1 :=
-  pos_eq_one_iff.mpr h
-#align lattice_ordered_comm_group.pos_of_le_one LatticeOrderedCommGroup.pos_of_le_one
-#align lattice_ordered_comm_group.pos_of_nonpos LatticeOrderedCommGroup.pos_of_nonpos
-
-@[to_additive neg_of_inv_nonneg]
-theorem neg_of_one_le_inv (a : α) (h : 1 ≤ a⁻¹) : a⁻ = a⁻¹ := by
-  rw [neg_eq_pos_inv]
-  exact pos_of_one_le _ h
-#align lattice_ordered_comm_group.neg_of_one_le_inv LatticeOrderedCommGroup.neg_of_one_le_inv
-#align lattice_ordered_comm_group.neg_of_inv_nonneg LatticeOrderedCommGroup.neg_of_inv_nonneg
-
--- neg_of_neg_nonpos
-@[to_additive]
-theorem neg_of_inv_le_one (a : α) (h : a⁻¹ ≤ 1) : a⁻ = 1 :=
-  neg_eq_one_iff'.mpr h
-#align lattice_ordered_comm_group.neg_of_inv_le_one LatticeOrderedCommGroup.neg_of_inv_le_one
-#align lattice_ordered_comm_group.neg_of_neg_nonpos LatticeOrderedCommGroup.neg_of_neg_nonpos
-
--- neg_of_nonpos
-@[to_additive]
-theorem neg_of_le_one [CovariantClass α α (· * ·) (· ≤ ·)] (a : α) (h : a ≤ 1) : a⁻ = a⁻¹ :=
-  sup_eq_left.2 <| one_le_inv'.2 h
-#align lattice_ordered_comm_group.neg_of_le_one LatticeOrderedCommGroup.neg_of_le_one
-#align lattice_ordered_comm_group.neg_of_nonpos LatticeOrderedCommGroup.neg_of_nonpos
-
--- neg_of_nonneg'
-@[to_additive]
-theorem neg_of_one_le [CovariantClass α α (· * ·) (· ≤ ·)] (a : α) (h : 1 ≤ a) : a⁻ = 1 :=
-  neg_eq_one_iff.mpr h
-#align lattice_ordered_comm_group.neg_of_one_le LatticeOrderedCommGroup.neg_of_one_le
-#align lattice_ordered_comm_group.neg_of_nonneg LatticeOrderedCommGroup.neg_of_nonneg
-
--- 0 ≤ a implies |a| = a
-@[to_additive abs_of_nonneg]
-theorem mabs_of_one_le [CovariantClass α α (· * ·) (· ≤ ·)] (a : α) (h : 1 ≤ a) : |a| = a :=
-  sup_eq_left.2 <| Left.inv_le_self h
-#align lattice_ordered_comm_group.mabs_of_one_le LatticeOrderedCommGroup.mabs_of_one_le
-#align lattice_ordered_comm_group.abs_of_nonneg LatticeOrderedCommGroup.abs_of_nonneg
-
 /-- The unary operation of taking the absolute value is idempotent. -/
 @[to_additive (attr := simp) abs_abs
   "The unary operation of taking the absolute value is idempotent."]
@@ -571,14 +608,6 @@ theorem mabs_mul_le [CovariantClass α α (· * ·) (· ≤ ·)] (a b : α) : |a
     exact mul_le_mul' (inv_le_abs _) (inv_le_abs _)
 #align lattice_ordered_comm_group.mabs_mul_le LatticeOrderedCommGroup.mabs_mul_le
 #align lattice_ordered_comm_group.abs_add_le LatticeOrderedCommGroup.abs_add_le
-
--- |a - b| = |b - a|
-@[to_additive]
-theorem abs_div_comm (a b : α) : |a / b| = |b / a| := by
-  dsimp only [Abs.abs]
-  rw [inv_div a b, ← inv_inv (a / b), inv_div, sup_comm]
-#align lattice_ordered_comm_group.abs_inv_comm LatticeOrderedCommGroup.abs_div_comm
-#align lattice_ordered_comm_group.abs_neg_comm LatticeOrderedCommGroup.abs_sub_comm
 
 -- | |a| - |b| | ≤ |a - b|
 @[to_additive]

--- a/Mathlib/Algebra/Order/LatticeGroup.lean
+++ b/Mathlib/Algebra/Order/LatticeGroup.lean
@@ -363,39 +363,26 @@ theorem abs_div_comm (a b : α) : |a / b| = |b / a| := by
 #align lattice_ordered_comm_group.abs_inv_comm LatticeOrderedGroup.abs_div_comm
 #align lattice_ordered_comm_group.abs_neg_comm LatticeOrderedGroup.abs_sub_comm
 
--- Everything above more or less as before
--- Now need to start doing something special
-
 -- In fact 0 ≤ n•a implies 0 ≤ a, see L. Fuchs, "Partially ordered algebraic systems"
 -- Chapter V, 1.E
 @[to_additive]
 lemma pow_two_semiclosed
     [CovariantClass α α (· * ·) (· ≤ ·)] [CovariantClass α α (swap (· * ·)) (· ≤ ·)] (a : α) :
     (1 : α) ≤ a^2 → 1 ≤ a := by
-  introv h
-  have s1 : (a⊓1)^2 = a⊓1 := by
-    rw [pow_two, mul_inf, inf_mul,
-     ← pow_two, mul_one, one_mul, inf_assoc, inf_left_idem, inf_comm,
-     inf_assoc]
-    rw [← right_eq_inf, inf_comm] at h
-    rw [← h]
-  rw [pow_two] at s1
-  simp at s1
-  exact s1
+  intro h
+  have e1 : (a ⊓ 1) * (a ⊓ 1) = a⊓1 := by
+    rw [mul_inf, inf_mul, ← pow_two, mul_one, one_mul, inf_assoc, inf_left_idem, inf_comm,
+     inf_assoc, (inf_of_le_left h)]
+  rw [← inf_eq_right]
+  exact mul_right_eq_self.mp e1
 
 @[to_additive abs_nonneg]
 theorem one_le_abs
     [CovariantClass α α (· * ·) (· ≤ ·)] [CovariantClass α α (swap (· * ·)) (· ≤ ·)] (a : α) :
     1 ≤ |a| := by
-  have s1: (1 : α) ≤ |a|^2 := by
-    rw [abs_eq_sup_inv]
-    rw [pow_two, mul_sup,  sup_mul,
-    ←pow_two]
-    simp
-    rw [sup_comm, ← sup_assoc]
-    apply le_sup_right
-  apply pow_two_semiclosed
-  exact s1
+  apply pow_two_semiclosed _ _
+  rw [abs_eq_sup_inv, pow_two, mul_sup,  sup_mul, ←pow_two, mul_left_inv, sup_comm, ← sup_assoc]
+  apply le_sup_right
 
 -- The proof from Bourbaki A.VI.12 Prop 9 d)
 -- |a| = a⁺ - a⁻
@@ -475,12 +462,7 @@ end LatticeOrderedGroup
 
 end Group
 
-
 variable [Lattice α] [CommGroup α]
-
-
-
-
 
 -- Fuchs p67
 -- Bourbaki A.VI.10 Prop 7

--- a/Mathlib/Algebra/Order/LatticeGroup.lean
+++ b/Mathlib/Algebra/Order/LatticeGroup.lean
@@ -397,7 +397,17 @@ theorem one_le_abs
   apply pow_two_semiclosed
   exact s1
 
-
+-- The proof from Bourbaki A.VI.12 Prop 9 d)
+-- |a| = a⁺ - a⁻
+@[to_additive]
+theorem pos_mul_neg
+    [CovariantClass α α (· * ·) (· ≤ ·)] [CovariantClass α α (swap (· * ·)) (· ≤ ·)] (a : α) :
+    |a| = a⁺ * a⁻ := by
+  rw [m_pos_part_def, sup_mul, one_mul, m_neg_part_def, mul_sup, mul_one, mul_inv_self, sup_assoc,
+    ← @sup_assoc _ _ a, sup_eq_right.2 le_sup_right]
+  exact (sup_eq_left.2 <| one_le_abs a).symm
+#align lattice_ordered_comm_group.pos_mul_neg LatticeOrderedGroup.pos_mul_neg
+#align lattice_ordered_comm_group.pos_add_neg LatticeOrderedGroup.pos_add_neg
 
 end LatticeOrderedGroup
 
@@ -500,16 +510,6 @@ theorem m_pos_abs [CovariantClass α α (· * ·) (· ≤ ·)] (a : α) : |a|⁺
   exact m_neg_abs a
 #align lattice_ordered_comm_group.m_pos_abs LatticeOrderedCommGroup.m_pos_abs
 #align lattice_ordered_comm_group.pos_abs LatticeOrderedCommGroup.pos_abs
-
--- The proof from Bourbaki A.VI.12 Prop 9 d)
--- |a| = a⁺ - a⁻
-@[to_additive]
-theorem pos_mul_neg [CovariantClass α α (· * ·) (· ≤ ·)] (a : α) : |a| = a⁺ * a⁻ := by
-  rw [m_pos_part_def, sup_mul, one_mul, m_neg_part_def, mul_sup, mul_one, mul_inv_self, sup_assoc,
-    ← @sup_assoc _ _ a, sup_eq_right.2 le_sup_right]
-  exact (sup_eq_left.2 <| one_le_abs a).symm
-#align lattice_ordered_comm_group.pos_mul_neg LatticeOrderedCommGroup.pos_mul_neg
-#align lattice_ordered_comm_group.pos_add_neg LatticeOrderedCommGroup.pos_add_neg
 
 -- a ⊔ b - (a ⊓ b) = |b - a|
 @[to_additive]

--- a/Mathlib/Algebra/Order/LatticeGroup.lean
+++ b/Mathlib/Algebra/Order/LatticeGroup.lean
@@ -421,16 +421,13 @@ theorem sup_div_inf_eq_abs_div
     [CovariantClass α α (· * ·) (· ≤ ·)] [CovariantClass α α (swap (· * ·)) (· ≤ ·)] (a b : α) :
     (a ⊔ b) / (a ⊓ b) = |b / a| :=
 calc
-  (a ⊔ b) / (a ⊓ b) = (a ⊔ b) * (a ⊓ b)⁻¹ := by rw [div_eq_mul_inv]
-  _ = (a ⊔ b) * (a⁻¹ ⊔ b⁻¹) := by rw [← inv_inf_eq_sup_inv]
-  _ = (a ⊔ b) * a⁻¹ ⊔ (a ⊔ b) * b⁻¹ := by rw [mul_sup]
-  _ = (a * a⁻¹ ⊔ b * a⁻¹) ⊔ (a * b⁻¹ ⊔ b * b⁻¹) := by rw [sup_mul, sup_mul]
-  _ = (1 ⊔ b * a⁻¹) ⊔ (a * b⁻¹ ⊔ 1) := by rw [mul_right_inv, mul_right_inv]
-  _ = (1 ⊔ b / a) ⊔ (a / b ⊔ 1) := by rw [←div_eq_mul_inv, ←div_eq_mul_inv]
+  (a ⊔ b) / (a ⊓ b) = (a ⊔ b) * (a⁻¹ ⊔ b⁻¹) := by rw [div_eq_mul_inv, ← inv_inf_eq_sup_inv]
+  _ = (a * a⁻¹ ⊔ b * a⁻¹) ⊔ (a * b⁻¹ ⊔ b * b⁻¹) := by rw [mul_sup, sup_mul, sup_mul]
+  _ = (1 ⊔ b / a) ⊔ (a / b ⊔ 1) := by
+    rw [mul_right_inv, mul_right_inv, ←div_eq_mul_inv, ←div_eq_mul_inv]
   _ = 1 ⊔ b / a ⊔ (1 / (b / a) ⊔ 1) := by rw [one_div_div]
-  _ = 1 ⊔ ((b / a) ⊔ ((b / a)⁻¹ ⊔ 1)) := by rw [inv_eq_one_div, sup_assoc]
-  _ = 1 ⊔ (((b / a) ⊔ (b / a)⁻¹) ⊔ 1) := by rw [sup_assoc]
-  _ = 1 ⊔ (((b / a) ⊔ (b / a)⁻¹) ⊔ 1) := by rw [sup_assoc]
+  _ = 1 ⊔ (b / a) ⊔ ((b / a)⁻¹ ⊔ 1) := by rw [inv_eq_one_div]
+  _ = 1 ⊔ (((b / a) ⊔ (b / a)⁻¹) ⊔ 1) := by rw [sup_assoc, sup_assoc]
   _= 1 ⊔ (|b / a| ⊔ 1) := by rw [abs_eq_sup_inv]
   _= 1 ⊔ |b / a| := by rw [← m_pos_part_def, m_pos_abs]
   _= |b / a| ⊔ 1 := by rw [sup_comm]

--- a/Mathlib/Algebra/Order/LatticeGroup.lean
+++ b/Mathlib/Algebra/Order/LatticeGroup.lean
@@ -363,6 +363,42 @@ theorem abs_div_comm (a b : α) : |a / b| = |b / a| := by
 #align lattice_ordered_comm_group.abs_inv_comm LatticeOrderedGroup.abs_div_comm
 #align lattice_ordered_comm_group.abs_neg_comm LatticeOrderedGroup.abs_sub_comm
 
+-- Everything above more or less as before
+-- Now need to start doing something special
+
+-- In fact 0 ≤ n•a implies 0 ≤ a, see L. Fuchs, "Partially ordered algebraic systems"
+-- Chapter V, 1.E
+@[to_additive]
+lemma pow_two_semiclosed
+    [CovariantClass α α (· * ·) (· ≤ ·)] [CovariantClass α α (swap (· * ·)) (· ≤ ·)] (a : α) :
+    (1 : α) ≤ a^2 → 1 ≤ a := by
+  introv h
+  have s1 : (a⊓1)^2 = a⊓1 := by
+    rw [pow_two, mul_inf, inf_mul,
+     ← pow_two, mul_one, one_mul, inf_assoc, inf_left_idem, inf_comm,
+     inf_assoc]
+    rw [← right_eq_inf, inf_comm] at h
+    rw [← h]
+  rw [pow_two] at s1
+  simp at s1
+  exact s1
+
+@[to_additive abs_nonneg]
+theorem one_le_abs
+    [CovariantClass α α (· * ·) (· ≤ ·)] [CovariantClass α α (swap (· * ·)) (· ≤ ·)] (a : α) :
+    1 ≤ |a| := by
+  have s1: (1 : α) ≤ |a|^2 := by
+    rw [abs_eq_sup_inv]
+    rw [pow_two, mul_sup,  sup_mul,
+    ←pow_two]
+    simp
+    rw [sup_comm, ← sup_assoc]
+    apply le_sup_right
+  apply pow_two_semiclosed
+  exact s1
+
+
+
 end LatticeOrderedGroup
 
 end Group
@@ -465,13 +501,6 @@ theorem m_pos_abs [CovariantClass α α (· * ·) (· ≤ ·)] (a : α) : |a|⁺
 #align lattice_ordered_comm_group.m_pos_abs LatticeOrderedCommGroup.m_pos_abs
 #align lattice_ordered_comm_group.pos_abs LatticeOrderedCommGroup.pos_abs
 
-@[to_additive abs_nonneg]
-theorem one_le_abs [CovariantClass α α (· * ·) (· ≤ ·)] (a : α) : 1 ≤ |a| := by
-  rw [← m_pos_abs]
-  exact one_le_pos _
-#align lattice_ordered_comm_group.one_le_abs LatticeOrderedCommGroup.one_le_abs
-#align lattice_ordered_comm_group.abs_nonneg LatticeOrderedCommGroup.abs_nonneg
-
 -- The proof from Bourbaki A.VI.12 Prop 9 d)
 -- |a| = a⁺ - a⁻
 @[to_additive]
@@ -512,6 +541,7 @@ theorem inf_sq_eq_mul_div_abs_div [CovariantClass α α (· * ·) (· ≤ ·)] (
 
 /-- Every lattice ordered commutative group is a distributive lattice
 -/
+-- Non-comm case needs cancellation law https://ncatlab.org/nlab/show/distributive+lattice
 @[to_additive "Every lattice ordered commutative additive group is a distributive lattice"]
 def latticeOrderedCommGroupToDistribLattice (α : Type u) [s : Lattice α] [CommGroup α]
     [CovariantClass α α (· * ·) (· ≤ ·)] : DistribLattice α :=

--- a/Mathlib/Algebra/Order/LatticeGroup.lean
+++ b/Mathlib/Algebra/Order/LatticeGroup.lean
@@ -418,6 +418,16 @@ theorem m_pos_abs [CovariantClass α α (· * ·) (· ≤ ·)] [CovariantClass �
 #align lattice_ordered_comm_group.m_pos_abs LatticeOrderedGroup.m_pos_abs
 #align lattice_ordered_comm_group.pos_abs LatticeOrderedGroup.pos_abs
 
+@[to_additive neg_abs]
+theorem m_neg_abs [CovariantClass α α (· * ·) (· ≤ ·)] [CovariantClass α α (swap (· * ·)) (· ≤ ·)]
+    (a : α) : |a|⁻ = 1 := by
+  rw [m_neg_part_def]
+  apply sup_of_le_right
+  rw [Left.inv_le_one_iff]
+  apply one_le_abs
+#align lattice_ordered_comm_group.m_neg_abs LatticeOrderedGroup.m_neg_abs
+#align lattice_ordered_comm_group.neg_abs LatticeOrderedGroup.neg_abs
+
 -- a ⊔ b - (a ⊓ b) = |b - a|
 @[to_additive]
 theorem sup_div_inf_eq_abs_div
@@ -450,6 +460,17 @@ theorem mabs_mabs [CovariantClass α α (· * ·) (· ≤ ·)] [CovariantClass �
 #align lattice_ordered_comm_group.mabs_mabs LatticeOrderedGroup.mabs_mabs
 #align lattice_ordered_comm_group.abs_abs LatticeOrderedGroup.abs_abs
 
+-- Bourbaki A.VI.12 Prop 9 a)
+-- a⁺ ⊓ a⁻ = 0 (`a⁺` and `a⁻` are co-prime, and, since they are positive, disjoint)
+@[to_additive]
+theorem pos_inf_neg_eq_one
+    [CovariantClass α α (· * ·) (· ≤ ·)] [CovariantClass α α (swap (· * ·)) (· ≤ ·)] (a : α) :
+    a⁺ ⊓ a⁻ = 1 := by
+  rw [← mul_left_inj (a⁻)⁻¹, inf_mul, one_mul, mul_right_inv, ← div_eq_mul_inv,
+    pos_div_neg, neg_eq_inv_inf_one, inv_inv]
+#align lattice_ordered_comm_group.pos_inf_neg_eq_one LatticeOrderedGroup.pos_inf_neg_eq_one
+#align lattice_ordered_comm_group.pos_inf_neg_eq_zero LatticeOrderedGroup.pos_inf_neg_eq_zero
+
 end LatticeOrderedGroup
 
 end Group
@@ -477,15 +498,6 @@ theorem inf_mul_sup [CovariantClass α α (· * ·) (· ≤ ·)] (a b : α) : (a
 namespace LatticeOrderedCommGroup
 
 open LatticeOrderedGroup
-
--- Bourbaki A.VI.12 Prop 9 a)
--- a⁺ ⊓ a⁻ = 0 (`a⁺` and `a⁻` are co-prime, and, since they are positive, disjoint)
-@[to_additive]
-theorem pos_inf_neg_eq_one [CovariantClass α α (· * ·) (· ≤ ·)] (a : α) : a⁺ ⊓ a⁻ = 1 := by
-  rw [← mul_right_inj (a⁻)⁻¹, mul_inf, mul_one, mul_left_inv, mul_comm, ← div_eq_mul_inv,
-    pos_div_neg, neg_eq_inv_inf_one, inv_inv]
-#align lattice_ordered_comm_group.pos_inf_neg_eq_one LatticeOrderedCommGroup.pos_inf_neg_eq_one
-#align lattice_ordered_comm_group.pos_inf_neg_eq_zero LatticeOrderedCommGroup.pos_inf_neg_eq_zero
 
 -- Bourbaki A.VI.12 (with a and b swapped)
 -- a⊔b = b + (a - b)⁺
@@ -529,18 +541,6 @@ theorem m_le_iff_pos_le_neg_ge [CovariantClass α α (· * ·) (· ≤ ·)] (a b
     exact div_le_div'' h.1 h.2
 #align lattice_ordered_comm_group.m_le_iff_pos_le_neg_ge LatticeOrderedCommGroup.m_le_iff_pos_le_neg_ge
 #align lattice_ordered_comm_group.le_iff_pos_le_neg_ge LatticeOrderedCommGroup.le_iff_pos_le_neg_ge
-
-@[to_additive neg_abs]
-theorem m_neg_abs [CovariantClass α α (· * ·) (· ≤ ·)] (a : α) : |a|⁻ = 1 := by
-  refine' le_antisymm _ _
-  · rw [← pos_inf_neg_eq_one a]
-    apply le_inf
-    · rw [pos_eq_neg_inv]
-      exact ((m_le_iff_pos_le_neg_ge _ _).mp (inv_le_abs a)).right
-    · exact And.right (Iff.mp (m_le_iff_pos_le_neg_ge _ _) (le_mabs a))
-  · exact one_le_neg _
-#align lattice_ordered_comm_group.m_neg_abs LatticeOrderedCommGroup.m_neg_abs
-#align lattice_ordered_comm_group.neg_abs LatticeOrderedCommGroup.neg_abs
 
 -- 2•(a ⊔ b) = a + b + |b - a|
 @[to_additive two_sup_eq_add_add_abs_sub]

--- a/Mathlib/Algebra/Order/LatticeGroup.lean
+++ b/Mathlib/Algebra/Order/LatticeGroup.lean
@@ -441,6 +441,15 @@ calc
 #align lattice_ordered_comm_group.sup_div_inf_eq_abs_div LatticeOrderedGroup.sup_div_inf_eq_abs_div
 #align lattice_ordered_comm_group.sup_sub_inf_eq_abs_sub LatticeOrderedGroup.sup_sub_inf_eq_abs_sub
 
+/-- The unary operation of taking the absolute value is idempotent. -/
+@[to_additive (attr := simp) abs_abs
+  "The unary operation of taking the absolute value is idempotent."]
+theorem mabs_mabs [CovariantClass α α (· * ·) (· ≤ ·)] [CovariantClass α α (swap (· * ·)) (· ≤ ·)]
+    (a : α) : |(|a|)| = |a| :=
+  mabs_of_one_le _ (one_le_abs _)
+#align lattice_ordered_comm_group.mabs_mabs LatticeOrderedGroup.mabs_mabs
+#align lattice_ordered_comm_group.abs_abs LatticeOrderedGroup.abs_abs
+
 end LatticeOrderedGroup
 
 end Group
@@ -600,14 +609,6 @@ theorem abs_div_sup_mul_abs_div_inf [CovariantClass α α (· * ·) (· ≤ ·)]
     _ = |a / b| := by rw [sup_div_inf_eq_abs_div]
 #align lattice_ordered_comm_group.abs_div_sup_mul_abs_div_inf LatticeOrderedCommGroup.abs_div_sup_mul_abs_div_inf
 #align lattice_ordered_comm_group.abs_sub_sup_add_abs_sub_inf LatticeOrderedCommGroup.abs_sub_sup_add_abs_sub_inf
-
-/-- The unary operation of taking the absolute value is idempotent. -/
-@[to_additive (attr := simp) abs_abs
-  "The unary operation of taking the absolute value is idempotent."]
-theorem mabs_mabs [CovariantClass α α (· * ·) (· ≤ ·)] (a : α) : |(|a|)| = |a| :=
-  mabs_of_one_le _ (one_le_abs _)
-#align lattice_ordered_comm_group.mabs_mabs LatticeOrderedCommGroup.mabs_mabs
-#align lattice_ordered_comm_group.abs_abs LatticeOrderedCommGroup.abs_abs
 
 @[to_additive abs_sup_sub_sup_le_abs]
 theorem mabs_sup_div_sup_le_mabs [CovariantClass α α (· * ·) (· ≤ ·)] (a b c : α) :

--- a/Mathlib/Algebra/Order/LatticeGroup.lean
+++ b/Mathlib/Algebra/Order/LatticeGroup.lean
@@ -16,36 +16,38 @@ import Mathlib.Order.Closure
 Lattice ordered groups were introduced by [Birkhoff][birkhoff1942].
 They form the algebraic underpinnings of vector lattices, Banach lattices, AL-space, AM-space etc.
 
-This file develops the basic theory, concentrating on the commutative case.
+This file develops the basic theory.
 
 ## Main statements
 
-- `pos_div_neg`: Every element `a` of a lattice ordered commutative group has a decomposition
-  `a⁺-a⁻` into the difference of the positive and negative component.
+- `pos_div_neg`: Every element `a` of a lattice ordered group has a decomposition `a⁺-a⁻` into the
+  difference of the positive and negative component.
 - `pos_inf_neg_eq_one`: The positive and negative components are coprime.
-- `abs_triangle`: The absolute value operation satisfies the triangle inequality.
+- `abs_triangle`: The absolute value operation satisfies the triangle inequality (stated for a
+  commutative group).
 
 It is shown that the inf and sup operations are related to the absolute value operation by a
 number of equations and inequalities.
 
 ## Notations
 
-- `a⁺ = a ⊔ 0`: The *positive component* of an element `a` of a lattice ordered commutative group
-- `a⁻ = (-a) ⊔ 0`: The *negative component* of an element `a` of a lattice ordered commutative group
-- `|a| = a⊔(-a)`: The *absolute value* of an element `a` of a lattice ordered commutative group
+- `a⁺ = a ⊔ 0`: The *positive component* of an element `a` of a lattice ordered group
+- `a⁻ = (-a) ⊔ 0`: The *negative component* of an element `a` of a lattice ordered group
+- `|a| = a⊔(-a)`: The *absolute value* of an element `a` of a lattice ordered group
 
 ## Implementation notes
 
-A lattice ordered commutative group is a type `α` satisfying:
+A lattice ordered group is a type `α` satisfying:
 
 * `[Lattice α]`
 * `[CommGroup α]`
 * `[CovariantClass α α (*) (≤)]`
+* `[CovariantClass α α (swap (· * ·)) (· ≤ ·)]`
 
-The remainder of the file establishes basic properties of lattice ordered commutative groups. A
-number of these results also hold in the non-commutative case ([Birkhoff][birkhoff1942],
-[Fuchs][fuchs1963]) but we have not developed that here, since we are primarily interested in vector
-lattices.
+The remainder of the file establishes basic properties of lattice ordered groups. It is shown that
+when the group is commutative, the lattice is distributive. This also holds in the non-commutative
+case ([Birkhoff][birkhoff1942],[Fuchs][fuchs1963]) but we do not yet have the machinery to establish
+this in Mathlib.
 
 ## References
 

--- a/Mathlib/Analysis/Normed/Order/Lattice.lean
+++ b/Mathlib/Analysis/Normed/Order/Lattice.lean
@@ -91,7 +91,7 @@ instance (priority := 100) NormedLatticeAddCommGroup.toOrderedAddCommGroup {α :
 
 variable {α : Type _} [NormedLatticeAddCommGroup α]
 
-open LatticeOrderedCommGroup HasSolidNorm
+open LatticeOrderedGroup LatticeOrderedCommGroup HasSolidNorm
 
 theorem dual_solid (a b : α) (h : b ⊓ -b ≤ a ⊓ -a) : ‖a‖ ≤ ‖b‖ := by
   apply solid

--- a/Mathlib/Probability/Martingale/Convergence.lean
+++ b/Mathlib/Probability/Martingale/Convergence.lean
@@ -175,9 +175,9 @@ theorem Submartingale.upcrossings_ae_lt_top' [IsFiniteMeasure μ] (hf : Submarti
       refine' lintegral_mono fun ω => _
       rw [ENNReal.ofReal_le_iff_le_toReal, ENNReal.coe_toReal, coe_nnnorm]
       by_cases hnonneg : 0 ≤ f n ω - a
-      · rw [LatticeOrderedCommGroup.pos_of_nonneg _ hnonneg, Real.norm_eq_abs,
+      · rw [LatticeOrderedGroup.pos_of_nonneg _ hnonneg, Real.norm_eq_abs,
           abs_of_nonneg hnonneg]
-      · rw [LatticeOrderedCommGroup.pos_of_nonpos _ (not_le.1 hnonneg).le]
+      · rw [LatticeOrderedGroup.pos_of_nonpos _ (not_le.1 hnonneg).le]
         exact norm_nonneg _
       · simp only [Ne.def, ENNReal.coe_ne_top, not_false_iff]
     · simp only [hab, Ne.def, ENNReal.ofReal_eq_zero, sub_nonpos, not_le]

--- a/Mathlib/Probability/Martingale/Upcrossing.lean
+++ b/Mathlib/Probability/Martingale/Upcrossing.lean
@@ -675,12 +675,12 @@ theorem crossing_pos_eq (hab : a < b) :
     intro i ω
     refine' ⟨fun h => _, fun h => _⟩
     · rwa [← sub_le_sub_iff_right a, ←
-        LatticeOrderedCommGroup.pos_eq_self_of_pos_pos (lt_of_lt_of_le hab' h)]
+        LatticeOrderedGroup.pos_eq_self_of_pos_pos (lt_of_lt_of_le hab' h)]
     · rw [← sub_le_sub_iff_right a] at h
-      rwa [LatticeOrderedCommGroup.pos_of_nonneg _ (le_trans hab'.le h)]
+      rwa [LatticeOrderedGroup.pos_of_nonneg _ (le_trans hab'.le h)]
   have hf' : ∀ ω i, (f i ω - a)⁺ ≤ 0 ↔ f i ω ≤ a := by
     intro ω i
-    rw [LatticeOrderedCommGroup.pos_nonpos_iff, sub_nonpos]
+    rw [LatticeOrderedGroup.pos_nonpos_iff, sub_nonpos]
   induction' n with k ih
   · refine' ⟨rfl, _⟩
     simp only [lowerCrossingTime_zero, hitting, Set.mem_Icc, Set.mem_Iic, Nat.zero_eq]
@@ -725,8 +725,8 @@ theorem mul_integral_upcrossingsBefore_le_integral_pos_part_aux [IsFiniteMeasure
     (b - a) * μ[upcrossingsBefore a b f N] ≤ μ[fun ω => (f N ω - a)⁺] := by
   refine' le_trans (le_of_eq _)
     (integral_mul_upcrossingsBefore_le_integral (hf.sub_martingale (martingale_const _ _ _)).pos
-      (fun ω => LatticeOrderedCommGroup.pos_nonneg _)
-      (fun ω => LatticeOrderedCommGroup.pos_nonneg _) (sub_pos.2 hab))
+      (fun ω => LatticeOrderedGroup.pos_nonneg _)
+      (fun ω => LatticeOrderedGroup.pos_nonneg _) (sub_pos.2 hab))
   simp_rw [sub_zero, ← upcrossingsBefore_pos_eq hab]
   rfl
 #align measure_theory.mul_integral_upcrossings_before_le_integral_pos_part_aux MeasureTheory.mul_integral_upcrossingsBefore_le_integral_pos_part_aux
@@ -742,7 +742,7 @@ theorem Submartingale.mul_integral_upcrossingsBefore_le_integral_pos_part [IsFin
   · exact mul_integral_upcrossingsBefore_le_integral_pos_part_aux hf hab
   · rw [not_lt, ← sub_nonpos] at hab
     exact le_trans (mul_nonpos_of_nonpos_of_nonneg hab (integral_nonneg fun ω => Nat.cast_nonneg _))
-      (integral_nonneg fun ω => LatticeOrderedCommGroup.pos_nonneg _)
+      (integral_nonneg fun ω => LatticeOrderedGroup.pos_nonneg _)
 #align measure_theory.submartingale.mul_integral_upcrossings_before_le_integral_pos_part MeasureTheory.Submartingale.mul_integral_upcrossingsBefore_le_integral_pos_part
 
 /-!
@@ -858,7 +858,7 @@ theorem Submartingale.mul_lintegral_upcrossings_le_lintegral_pos_part [IsFiniteM
       intro N
       rw [ofReal_integral_eq_lintegral_ofReal]
       · exact (hf.sub_martingale (martingale_const _ _ _)).pos.integrable _
-      · exact eventually_of_forall fun ω => LatticeOrderedCommGroup.pos_nonneg _
+      · exact eventually_of_forall fun ω => LatticeOrderedGroup.pos_nonneg _
     rw [lintegral_iSup']
     · simp_rw [this, ENNReal.mul_iSup, iSup_le_iff]
       intro N

--- a/Mathlib/Probability/StrongLaw.lean
+++ b/Mathlib/Probability/StrongLaw.lean
@@ -531,7 +531,7 @@ theorem strong_law_aux2 {c : ℝ} (c_one : 1 < c) :
   apply Asymptotics.isLittleO_iff.2 fun ε εpos => ?_
   obtain ⟨i, hi⟩ : ∃ i, v i < ε := ((tendsto_order.1 v_lim).2 ε εpos).exists
   filter_upwards [hω i] with n hn
-  simp only [Real.norm_eq_abs, LatticeOrderedCommGroup.abs_abs, Nat.abs_cast]
+  simp only [Real.norm_eq_abs, LatticeOrderedGroup.abs_abs, Nat.abs_cast]
   exact hn.le.trans (mul_le_mul_of_nonneg_right hi.le (Nat.cast_nonneg _))
 #align probability_theory.strong_law_aux2 ProbabilityTheory.strong_law_aux2
 


### PR DESCRIPTION
Generalise results in Algebra/Order/LatticeGroup to the case where the group is non-commutative

---

Non-commutative lattice ordered groups are also distributive, however, the proof requires the cancellation law (see e.g. https://ncatlab.org/nlab/show/distributive+lattice ) which I don't think is currently in Matlib4(?) I have therefore left this and dependent results as non-commutative only for the time being.

This PR is an incremental step towards #6376

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
