### PR TITLE
[Merged by Bors] - feat(Topology): use `OrderHomClass` for `CompactExhaustion`

### DIFF
--- a/Mathlib/Topology/SubsetProperties.lean
+++ b/Mathlib/Topology/SubsetProperties.lean
@@ -1453,7 +1453,7 @@ structure CompactExhaustion (X : Type _) [TopologicalSpace X] where
 
 namespace CompactExhaustion
 
-instance : OrderHomClass (CompactExhaustion α) ℕ (Set α) where
+instance : @RelHomClass (CompactExhaustion α) ℕ (Set α) LE.le HasSubset.subset where
   coe := toFun
   coe_injective' | ⟨_, _, _, _⟩, ⟨_, _, _, _⟩, rfl => rfl
   map_rel f _ _ h := monotone_nat_of_le_succ

--- a/Mathlib/Topology/SubsetProperties.lean
+++ b/Mathlib/Topology/SubsetProperties.lean
@@ -1443,7 +1443,7 @@ structure CompactExhaustion (X : Type _) [TopologicalSpace X] where
   /-- The sequence of compact sets that form a compact exhaustion. -/
   toFun : ℕ → Set X
   /-- The sets in the compact exhaustion are in fact compact. -/
-  is_compact' : ∀ n, IsCompact (toFun n)
+  isCompact' : ∀ n, IsCompact (toFun n)
   /-- The sets in the compact exhaustion form a sequence:
     each set is contained in the interior of the next. -/
   subset_interior_succ' : ∀ n, toFun n ⊆ interior (toFun (n + 1))
@@ -1453,14 +1453,14 @@ structure CompactExhaustion (X : Type _) [TopologicalSpace X] where
 
 namespace CompactExhaustion
 
--- porting note: todo: use `FunLike`?
-instance : CoeFun (CompactExhaustion α) fun _ => ℕ → Set α :=
-  ⟨toFun⟩
+instance : FunLike (CompactExhaustion α) ℕ fun _ => Set α where
+  coe := toFun
+  coe_injective' | ⟨_, _, _, _⟩, ⟨_, _, _, _⟩, rfl => rfl
 
 variable (K : CompactExhaustion α)
 
 protected theorem isCompact (n : ℕ) : IsCompact (K n) :=
-  K.is_compact' n
+  K.isCompact' n
 #align compact_exhaustion.is_compact CompactExhaustion.isCompact
 
 theorem subset_interior_succ (n : ℕ) : K n ⊆ interior (K (n + 1)) :=
@@ -1504,7 +1504,7 @@ theorem mem_iff_find_le {x : α} {n : ℕ} : x ∈ K n ↔ K.find x ≤ n :=
 /-- Prepend the empty set to a compact exhaustion `K n`. -/
 def shiftr : CompactExhaustion α where
   toFun n := Nat.casesOn n ∅ K
-  is_compact' n := Nat.casesOn n isCompact_empty K.isCompact
+  isCompact' n := Nat.casesOn n isCompact_empty K.isCompact
   subset_interior_succ' n := Nat.casesOn n (empty_subset _) K.subset_interior_succ
   iUnion_eq' := iUnion_eq_univ_iff.2 fun x => ⟨K.find x + 1, K.mem_find x⟩
 #align compact_exhaustion.shiftr CompactExhaustion.shiftr

--- a/Mathlib/Topology/SubsetProperties.lean
+++ b/Mathlib/Topology/SubsetProperties.lean
@@ -1453,7 +1453,7 @@ structure CompactExhaustion (X : Type _) [TopologicalSpace X] where
 
 namespace CompactExhaustion
 
-instance : @RelHomClass (CompactExhaustion α) ℕ (Set α) LE.le HasSubset.subset where
+instance : @RelHomClass (CompactExhaustion α) ℕ (Set α) LE.le HasSubset.Subset where
   coe := toFun
   coe_injective' | ⟨_, _, _, _⟩, ⟨_, _, _, _⟩, rfl => rfl
   map_rel f _ _ h := monotone_nat_of_le_succ

--- a/Mathlib/Topology/SubsetProperties.lean
+++ b/Mathlib/Topology/SubsetProperties.lean
@@ -1453,9 +1453,11 @@ structure CompactExhaustion (X : Type _) [TopologicalSpace X] where
 
 namespace CompactExhaustion
 
-instance : FunLike (CompactExhaustion α) ℕ fun _ => Set α where
+instance : OrderHomClass (CompactExhaustion α) ℕ (Set α) where
   coe := toFun
   coe_injective' | ⟨_, _, _, _⟩, ⟨_, _, _, _⟩, rfl => rfl
+  map_rel f _ _ h := monotone_nat_of_le_succ
+    (fun n ↦ (f.subset_interior_succ' n).trans interior_subset) h
 
 variable (K : CompactExhaustion α)
 
@@ -1467,14 +1469,13 @@ theorem subset_interior_succ (n : ℕ) : K n ⊆ interior (K (n + 1)) :=
   K.subset_interior_succ' n
 #align compact_exhaustion.subset_interior_succ CompactExhaustion.subset_interior_succ
 
-theorem subset_succ (n : ℕ) : K n ⊆ K (n + 1) :=
-  Subset.trans (K.subset_interior_succ n) interior_subset
-#align compact_exhaustion.subset_succ CompactExhaustion.subset_succ
-
 @[mono]
 protected theorem subset ⦃m n : ℕ⦄ (h : m ≤ n) : K m ⊆ K n :=
-  show K m ≤ K n from monotone_nat_of_le_succ K.subset_succ h
+  OrderHomClass.mono K h
 #align compact_exhaustion.subset CompactExhaustion.subset
+
+theorem subset_succ (n : ℕ) : K n ⊆ K (n + 1) := K.subset n.le_succ
+#align compact_exhaustion.subset_succ CompactExhaustion.subset_succ
 
 theorem subset_interior ⦃m n : ℕ⦄ (h : m < n) : K m ⊆ interior (K n) :=
   Subset.trans (K.subset_interior_succ m) <| interior_mono <| K.subset h

--- a/Mathlib/Topology/SubsetProperties.lean
+++ b/Mathlib/Topology/SubsetProperties.lean
@@ -1461,6 +1461,9 @@ instance : @RelHomClass (CompactExhaustion α) ℕ (Set α) LE.le HasSubset.subs
 
 variable (K : CompactExhaustion α)
 
+@[simp]
+theorem toFun_eq_coe : K.toFun = K := rfl
+
 protected theorem isCompact (n : ℕ) : IsCompact (K n) :=
   K.isCompact' n
 #align compact_exhaustion.is_compact CompactExhaustion.isCompact


### PR DESCRIPTION
Also rename `is_compact'` field to `isCompact'`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)