### PR TITLE
[Merged by Bors] - feat: add Type*/Sort* and tests

### DIFF
--- a/Mathlib/Tactic/Basic.lean
+++ b/Mathlib/Tactic/Basic.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2021 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Mario Carneiro
+Authors: Mario Carneiro, Kyle Miller
 -/
 import Lean
 import Std
@@ -30,6 +30,18 @@ syntax (name := lemma) declModifiers
     let stx := stx.modifyArg 0 (mkAtomFrom · "theorem" (canonical := true))
     stx.setKind ``Parser.Command.theorem
   pure <| stx.setKind ``Parser.Command.declaration
+
+/-- The syntax `variable (X Y ... Z : Sort*)` creates a new distinct implicit universe variable
+for each variable in the sequence. -/
+elab "Sort*" : term => do
+  let u ← Lean.Meta.mkFreshLevelMVar
+  Elab.Term.levelMVarToParam (.sort u)
+
+/-- The syntax `variable (X Y ... Z : Type*)` creates a new distinct implicit universe variable
+`> 0` for each variable in the sequence. -/
+elab "Type*" : term => do
+  let u ← Lean.Meta.mkFreshLevelMVar
+  Elab.Term.levelMVarToParam (.sort (.succ u))
 
 /-- Given two arrays of `FVarId`s, one from an old local context and the other from a new local
 context, pushes `FVarAliasInfo`s into the info tree for corresponding pairs of `FVarId`s.

--- a/test/ImplicitUniverses.lean
+++ b/test/ImplicitUniverses.lean
@@ -1,0 +1,42 @@
+import Mathlib.Tactic.Basic
+import Mathlib.Tactic.SuccessIfFailWithMsg
+
+example (x y : Type*) : sorry := by
+  success_if_fail_with_msg
+"type mismatch
+  y
+has type
+  Type u_2 : Type (u_2 + 1)
+but is expected to have type
+  Type u_1 : Type (u_1 + 1)" (exact x = y)
+  sorry
+
+example (x : Sort*) : sorry := by
+  success_if_fail_with_msg
+"type mismatch
+  Prop
+has type
+  Type : Type 1
+but is expected to have type
+  Sort u_1 : Type u_1" (exact x = Prop)
+  sorry
+
+example : sorry := by
+  success_if_fail_with_msg
+"type mismatch
+  y
+has type
+  Type u_2 : Type (u_2 + 1)
+but is expected to have type
+  Type u_1 : Type (u_1 + 1)" (exact ∀ x y : Type*, x = y)
+  sorry
+
+example : sorry := by
+ success_if_fail_with_msg
+"type mismatch
+  Prop
+has type
+  Type : Type 1
+but is expected to have type
+  Sort u_1 : Type u_1" (exact ∀ x : Sort*, x = Prop)
+ sorry


### PR DESCRIPTION
This adds Kyle Miller's elaborators for `Type*` and `Sort*` which provide implicit universe variables.

It also includes a few tests.

Co-authored-by: Kyle Miller <kmill31415@gmail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
