### PR TITLE
[Merged by Bors] - feat: counterexample to `Monic => regular` in general semirings

### DIFF
--- a/Counterexamples.lean
+++ b/Counterexamples.lean
@@ -6,6 +6,7 @@ import Counterexamples.Girard
 import Counterexamples.HomogeneousPrimeNotPrime
 import Counterexamples.LinearOrderWithPosMulPosEqZero
 import Counterexamples.MapFloor
+import Counterexamples.Monic_nonRegular
 import Counterexamples.Phillips
 import Counterexamples.Pseudoelement
 import Counterexamples.QuadraticForm

--- a/Counterexamples/Monic_nonRegular.lean
+++ b/Counterexamples/Monic_nonRegular.lean
@@ -79,7 +79,7 @@ theorem mul_example : (X + C 2 : N[X]) * (X + C 2) = (X + C 2) * (X + C 3) := by
 
 /-- The main example: multiplication by the polynomial `X + 2` is not injective,
 yet the polynomial is monic. -/
-example : Monic (X + C 2 : N[X]) ∧ ¬ IsLeftRegular (X + C 2 : N[X]) := by
+theorem Monic_and_nonLeftRegular : Monic (X + C 2 : N[X]) ∧ ¬ IsLeftRegular (X + C 2 : N[X]) := by
   constructor
   · unfold Monic leadingCoeff
     nontriviality

--- a/Counterexamples/Monic_nonRegular.lean
+++ b/Counterexamples/Monic_nonRegular.lean
@@ -40,58 +40,63 @@ instance : Zero N₃ := ⟨zero⟩
 instance : One N₃ := ⟨one⟩
 
 /-- Truncated addition on `N₃`. -/
-def add : N₃ → N₃ → N₃
+instance : Add N₃ where
+  add
   | 0, x => x
   | x, 0 => x
   | 1, 1 => two
   | _, _ => more
 
 /-- Truncated multiplication on `N₃`. -/
-def mul : N₃ → N₃ → N₃
+instance : Mul N₃ where
+  mul
   | 1, x => x
   | x, 1 => x
   | 0, _ => 0
   | _, 0 => 0
   | _, _ => more
 
-instance : CommSemiring N₃ :=
-{ add := add
-  add_assoc := by rintro ⟨⟩ <;> rintro ⟨⟩ <;> rintro ⟨⟩ <;> rfl
+instance : CommSemiring N₃ where
+  add_assoc := by rintro ⟨⟩ ⟨⟩ ⟨⟩ <;> rfl
   zero_add  := by rintro ⟨⟩ <;> rfl
   add_zero  := by rintro ⟨⟩ <;> rfl
-  add_comm  := by rintro ⟨⟩ <;> rintro ⟨⟩ <;> rfl
-  mul := mul
-  left_distrib := by rintro ⟨⟩ <;> rintro ⟨⟩ <;> rintro ⟨⟩ <;> rfl
-  right_distrib := by rintro ⟨⟩ <;> rintro ⟨⟩ <;> rintro ⟨⟩ <;> rfl
-  mul_assoc := by rintro ⟨⟩ <;> rintro ⟨⟩ <;> rintro ⟨⟩ <;> rfl
-  mul_comm := by rintro ⟨⟩ <;> rintro ⟨⟩ <;> rfl
+  add_comm  := by rintro ⟨⟩ ⟨⟩ <;> rfl
+  left_distrib := by rintro ⟨⟩ ⟨⟩ ⟨⟩ <;> rfl
+  right_distrib := by rintro ⟨⟩ ⟨⟩ ⟨⟩ <;> rfl
+  mul_assoc := by rintro ⟨⟩ ⟨⟩ ⟨⟩ <;> rfl
+  mul_comm := by rintro ⟨⟩ ⟨⟩ <;> rfl
   zero_mul := by rintro ⟨⟩ <;> rfl
   mul_zero := by rintro ⟨⟩ <;> rfl
   one_mul := by rintro ⟨⟩ <;> rfl
-  mul_one := by rintro ⟨⟩ <;> rfl }
+  mul_one := by rintro ⟨⟩ <;> rfl
 
-theorem mul_example : (X + C 2 : N₃[X]) * (X + C 2) = (X + C 2) * (X + C 3) := by
+theorem X_add_two_mul_X_add_two : (X + C 2 : N₃[X]) * (X + C 2) = (X + C 2) * (X + C 3) := by
   simp only [mul_add, add_mul, X_mul, add_assoc]
   apply congr_arg
   rw [← add_assoc, ← add_mul, ← C_add, ← C_mul, ← C_mul]
   rw [← add_assoc, ← add_mul, ← C_add]
   rfl
 
-/-- The main example: multiplication by the polynomial `X + 2` is not injective,
+/-! The main example: multiplication by the polynomial `X + 2` is not injective,
 yet the polynomial is monic. -/
-theorem Monic_and_nonLeftRegular : Monic (X + C 2 : N₃[X]) ∧ ¬ IsLeftRegular (X + C 2 : N₃[X]) := by
-  constructor
-  · unfold Monic leadingCoeff
-    nontriviality
-    rw [natDegree_X_add_C 2]
-    simp only [natDegree_X_add_C 2, coeff_C, coeff_add, coeff_X_one, ite_false, add_zero]
-  · unfold IsLeftRegular Function.Injective
-    simp only [not_forall, exists_prop]
-    refine ⟨(X + C 2), (X + C 3), mul_example, ?_⟩
-    by_contra H
-    apply_fun (coeff · 0) at H
-    simp only [coeff_add, coeff_X_zero, zero_add, coeff_C, ite_true] at H
-    cases H
+
+theorem monic_X_add_two : Monic (X + C 2 : N₃[X]) := by
+  unfold Monic leadingCoeff
+  nontriviality
+  rw [natDegree_X_add_C 2]
+  simp only [natDegree_X_add_C 2, coeff_C, coeff_add, coeff_X_one, ite_false, add_zero]
+
+theorem not_isLeftRegular_X_add_two : ¬ IsLeftRegular (X + C 2 : N₃[X]) := by
+  intro h
+  have H := h X_add_two_mul_X_add_two
+  apply_fun (coeff · 0) at H
+  simp only [coeff_add, coeff_X_zero, zero_add, coeff_C, ite_true] at H
+  cases H
+
+/-- The statement of the counterexample: not all monic polynomials over semiring are regular. -/
+theorem not_monic_implies_isLeftRegular :
+    ¬∀ {R : Type} [Semiring R] (p : R[X]), Monic p → IsLeftRegular p :=
+  fun h => not_isLeftRegular_X_add_two (h _ monic_X_add_two)
 
 end N₃
 

--- a/Counterexamples/Monic_nonRegular.lean
+++ b/Counterexamples/Monic_nonRegular.lean
@@ -25,7 +25,7 @@ It follows that multiplication by `(X + 2)` is not injective.
 -/
 open Polynomial
 
-namespace nonRegular
+namespace Counterexample.NonRegular
 
 /-- `N` is going to be a `Commsemiring` where addition and multiplication are truncated at `3`. -/
 inductive N
@@ -95,4 +95,4 @@ theorem Monic_and_nonLeftRegular : Monic (X + C 2 : N[X]) ∧ ¬ IsLeftRegular (
 
 end N
 
-end nonRegular
+end Counterexample.NonRegular

--- a/Counterexamples/Monic_nonRegular.lean
+++ b/Counterexamples/Monic_nonRegular.lean
@@ -14,7 +14,7 @@ This counterexample shows that the hypothesis `Ring R` cannot be changed to `Sem
 
 The example is very simple.
 
-The coefficient Semiring is the Semiring `N` of the natural numbers `{0, 1, 2, 3}` where the
+The coefficient Semiring is the Semiring `N₃` of the natural numbers `{0, 1, 2, 3}` where the
 standard addition and standard multiplication are truncated at `3`.
 
 The products `(X + 2) * (X + 2)` and `(X + 2) * (X + 3)` are equal to
@@ -27,34 +27,34 @@ open Polynomial
 
 namespace Counterexample.NonRegular
 
-/-- `N` is going to be a `Commsemiring` where addition and multiplication are truncated at `3`. -/
-inductive N
+/-- `N₃` is going to be a `Commsemiring` where addition and multiplication are truncated at `3`. -/
+inductive N₃
   | zero
   | one
   | two
   | more
 
-namespace N
+namespace N₃
 
-instance : Zero N := ⟨zero⟩
-instance : One N := ⟨one⟩
+instance : Zero N₃ := ⟨zero⟩
+instance : One N₃ := ⟨one⟩
 
-/-- Truncated addition on `N`. -/
-def add : N → N → N
+/-- Truncated addition on `N₃`. -/
+def add : N₃ → N₃ → N₃
   | 0, x => x
   | x, 0 => x
   | 1, 1 => two
   | _, _ => more
 
-/-- Truncated multiplication on `N`. -/
-def mul : N → N → N
+/-- Truncated multiplication on `N₃`. -/
+def mul : N₃ → N₃ → N₃
   | 1, x => x
   | x, 1 => x
   | 0, _ => 0
   | _, 0 => 0
   | _, _ => more
 
-instance : CommSemiring N :=
+instance : CommSemiring N₃ :=
 { add := add
   add_assoc := by rintro ⟨⟩ <;> rintro ⟨⟩ <;> rintro ⟨⟩ <;> rfl
   zero_add  := by rintro ⟨⟩ <;> rfl
@@ -70,7 +70,7 @@ instance : CommSemiring N :=
   one_mul := by rintro ⟨⟩ <;> rfl
   mul_one := by rintro ⟨⟩ <;> rfl }
 
-theorem mul_example : (X + C 2 : N[X]) * (X + C 2) = (X + C 2) * (X + C 3) := by
+theorem mul_example : (X + C 2 : N₃[X]) * (X + C 2) = (X + C 2) * (X + C 3) := by
   simp only [mul_add, add_mul, X_mul, add_assoc]
   apply congr_arg
   rw [← add_assoc, ← add_mul, ← C_add, ← C_mul, ← C_mul]
@@ -79,7 +79,7 @@ theorem mul_example : (X + C 2 : N[X]) * (X + C 2) = (X + C 2) * (X + C 3) := by
 
 /-- The main example: multiplication by the polynomial `X + 2` is not injective,
 yet the polynomial is monic. -/
-theorem Monic_and_nonLeftRegular : Monic (X + C 2 : N[X]) ∧ ¬ IsLeftRegular (X + C 2 : N[X]) := by
+theorem Monic_and_nonLeftRegular : Monic (X + C 2 : N₃[X]) ∧ ¬ IsLeftRegular (X + C 2 : N₃[X]) := by
   constructor
   · unfold Monic leadingCoeff
     nontriviality
@@ -93,6 +93,6 @@ theorem Monic_and_nonLeftRegular : Monic (X + C 2 : N[X]) ∧ ¬ IsLeftRegular (
     simp only [coeff_add, coeff_X_zero, zero_add, coeff_C, ite_true] at H
     cases H
 
-end N
+end N₃
 
 end Counterexample.NonRegular

--- a/Counterexamples/Monic_nonRegular.lean
+++ b/Counterexamples/Monic_nonRegular.lean
@@ -93,7 +93,7 @@ theorem not_isLeftRegular_X_add_two : ¬ IsLeftRegular (X + C 2 : N₃[X]) := by
   simp only [coeff_add, coeff_X_zero, zero_add, coeff_C, ite_true] at H
   cases H
 
-/-- The statement of the counterexample: not all monic polynomials over semiring are regular. -/
+/-- The statement of the counterexample: not all monic polynomials over semirings are regular. -/
 theorem not_monic_implies_isLeftRegular :
     ¬∀ {R : Type} [Semiring R] (p : R[X]), Monic p → IsLeftRegular p :=
   fun h => not_isLeftRegular_X_add_two (h _ monic_X_add_two)

--- a/Counterexamples/Monic_nonRegular.lean
+++ b/Counterexamples/Monic_nonRegular.lean
@@ -1,0 +1,98 @@
+/-
+Copyright (c) 2023 Damiano Testa. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Damiano Testa
+-/
+
+import Mathlib.Data.Polynomial.Monic
+
+/-!
+# `Monic` does not necessarily imply `IsRegular` in a `Semiring` with no opposites
+
+This counterexample shows that the hypothesis `Ring R` cannot be changed to `Semiring R` in
+`Polynomial.Monic.isRegular`.
+
+The example is very simple.
+
+The coefficient Semiring is the Semiring `N` of the natural numbers `{0, 1, 2, 3}` where the
+standard addition and standard multiplication are truncated at `3`.
+
+The products `(X + 2) * (X + 2)` and `(X + 2) * (X + 3)` are equal to
+`X ^ 2 + 4 * X + 4` and `X ^ 2 + 5 * X + 6` respectively.
+
+By truncation, `4, 5, 6` all mean `3` in `N`.
+It follows that multiplication by `(X + 2)` is not injective.
+-/
+open Polynomial
+
+namespace nonRegular
+
+/-- `N` is going to be a `Commsemiring` where addition and multiplication are truncated at `3`. -/
+inductive N
+  | zero
+  | one
+  | two
+  | more
+
+namespace N
+
+instance : Zero N := ⟨zero⟩
+instance : One N := ⟨one⟩
+
+/-- Truncated addition on `N`. -/
+def add : N → N → N
+  | 0, x => x
+  | x, 0 => x
+  | 1, 1 => two
+  | _, _ => more
+
+/-- Truncated multiplication on `N`. -/
+def mul : N → N → N
+  | 1, x => x
+  | x, 1 => x
+  | 0, _ => 0
+  | _, 0 => 0
+  | _, _ => more
+
+instance : CommSemiring N :=
+{ add := add
+  add_assoc := by rintro ⟨⟩ <;> rintro ⟨⟩ <;> rintro ⟨⟩ <;> rfl
+  zero_add  := by rintro ⟨⟩ <;> rfl
+  add_zero  := by rintro ⟨⟩ <;> rfl
+  add_comm  := by rintro ⟨⟩ <;> rintro ⟨⟩ <;> rfl
+  mul := mul
+  left_distrib := by rintro ⟨⟩ <;> rintro ⟨⟩ <;> rintro ⟨⟩ <;> rfl
+  right_distrib := by rintro ⟨⟩ <;> rintro ⟨⟩ <;> rintro ⟨⟩ <;> rfl
+  mul_assoc := by rintro ⟨⟩ <;> rintro ⟨⟩ <;> rintro ⟨⟩ <;> rfl
+  mul_comm := by rintro ⟨⟩ <;> rintro ⟨⟩ <;> rfl
+  zero_mul := by rintro ⟨⟩ <;> rfl
+  mul_zero := by rintro ⟨⟩ <;> rfl
+  one_mul := by rintro ⟨⟩ <;> rfl
+  mul_one := by rintro ⟨⟩ <;> rfl }
+
+theorem mul_example : (X + C 2 : N[X]) * (X + C 2) = (X + C 2) * (X + C 3) := by
+  simp only [mul_add, add_mul, X_mul, add_assoc]
+  apply congr_arg
+  rw [← add_assoc, ← add_mul, ← C_add, ← C_mul, ← C_mul]
+  rw [← add_assoc, ← add_mul, ← C_add]
+  rfl
+
+/-- The main example: multiplication by the polynomial `X + 2` is not injective,
+yet the polynomial is monic. -/
+example : Monic (X + C 2 : N[X]) ∧ ¬ IsLeftRegular (X + C 2 : N[X]) := by
+  constructor
+  · unfold Monic leadingCoeff
+    nontriviality
+    rw [natDegree_X_add_C 2]
+    simp only [natDegree_X_add_C 2, coeff_C, coeff_add, coeff_X_one, ite_false, add_zero]
+  · unfold IsLeftRegular Function.Injective
+    simp only [not_forall, exists_prop]
+    refine ⟨(X + C 2), (X + C 3), mul_example, ?_⟩
+    by_contra H
+    apply_fun (coeff · 0) at H
+    simp only [coeff_add, coeff_X_zero, zero_add, coeff_C, ite_true] at H
+    cases H
+
+end N
+
+end nonRegular


### PR DESCRIPTION
This example fixes a mistake that I made in a PR review: the implication `Monic => IsRegular` does not hold in general `Semiring`s (cf. [Polynomial.Monic.isRegular](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Data/Polynomial/Monic.html#Polynomial.Monic.isRegular) for the statement with a `Ring` hypothesis).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
