### PR TITLE
[Merged by Bors] - fix: adjust nondetermininstic LibrarySearch tests

### DIFF
--- a/test/LibrarySearch/basic.lean
+++ b/test/LibrarySearch/basic.lean
@@ -43,8 +43,8 @@ example (n m k : Nat) : n ≤ m → n + k ≤ m + k := by apply?
 #guard_msgs in
 example (ha : a > 0) (w : b ∣ c) : a * b ∣ a * c := by apply?
 
-/-- info: Try this: exact Int.one -/
-#guard_msgs in
+-- Could be any number of results (`Int.one`, `Int.zero`, etc)
+#guard_msgs (drop info) in
 example : Int := by apply?
 
 /-- info: Try this: Nat.lt.base x -/
@@ -61,8 +61,8 @@ example (P : Prop) (p : P) (np : ¬P) : false := by apply?
 #guard_msgs in
 example (X : Type) (P : Prop) (x : X) (h : ∀ x : X, x = x → P) : P := by apply?
 
-/-- info: Try this: exact fun a ↦ a -/
-#guard_msgs in
+-- Could be any number of results (`fun x ↦ x`, `id`, etc)
+#guard_msgs (drop info) in
 example (α : Prop) : α → α := by apply?
 
 -- Note: these examples no longer work after we turned off lemmas with discrimination key `#[*]`.
@@ -175,21 +175,21 @@ example (a b : ℕ) (h : a ≤ b) : f a ≤ f b := by apply?
 -- This is returning `exact []`.
 -- example (L _M : List (List ℕ)) : List ℕ := by apply? using L
 
-/-- info: Try this: exact List.iotaTR.go h P -/
-#guard_msgs in
+-- Could be any number of results
+#guard_msgs (drop info) in
 example (P _Q : List ℕ) (h : ℕ) : List ℕ := by apply? using h, P
 
-/-- info: Try this: exact List.partitionMap f l -/
-#guard_msgs in
+-- Could be any number of results
+#guard_msgs (drop info) in
 example (l : List α) (f : α → β ⊕ γ) : List β × List γ := by
   apply? using f -- partitionMap f l
 
-/-- info: Try this: exact Nat.mul n m -/
-#guard_msgs in
+-- Could be any number of results (`Nat.mul n m`, `Nat.add n m`, etc)
+#guard_msgs (drop info) in
 example (n m : ℕ) : ℕ := by apply? using n, m
 
-/-- info: Try this: exact Nat.SOM.Mon.mul P Q -/
-#guard_msgs in
+-- Could be any number of results
+#guard_msgs (drop info) in
 example (P Q : List ℕ) (_h : ℕ) : List ℕ := by apply? using P, Q
 
 -- Check that we don't use sorryAx:


### PR DESCRIPTION
Some of the tests for LibrarySearch functionality are nondetermininstic and were using `#guard_msgs` to check for specific output. This could [create spurious failures](https://github.com/leanprover-community/mathlib4/actions/runs/5810778556/job/15756601503). We switch to using `#guard_msgs (drop info)` for these tests, which still cleans up the stdout when running these tests without filtering out errors.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
