### PR TITLE
[Merged by Bors] - chore(Algebra/{ Group/UniqueProds, Order/Monoid/Basic }): move `eq_and_eq_of_le_of_le_of_mul_le` earlier

### DIFF
--- a/Mathlib/Algebra/Group/UniqueProds.lean
+++ b/Mathlib/Algebra/Group/UniqueProds.lean
@@ -203,19 +203,6 @@ instance {M} [Mul M] [UniqueProds M] : UniqueSums (Additive M) where
 
 end Additive
 
-@[to_additive]
-theorem eq_and_eq_of_le_of_le_of_mul_le {A} [Mul A] [LinearOrder A]
-    [CovariantClass A A (· * ·) (· ≤ ·)] [CovariantClass A A (Function.swap (· * ·)) (· < ·)]
-    [ContravariantClass A A (· * ·) (· ≤ ·)] {a b a0 b0 : A} (ha : a0 ≤ a) (hb : b0 ≤ b)
-    (ab : a * b ≤ a0 * b0) : a = a0 ∧ b = b0 := by
-  haveI := Mul.to_covariantClass_right A
-  have ha' : ¬a0 * b0 < a * b → ¬a0 < a := mt fun h ↦ mul_lt_mul_of_lt_of_le h hb
-  have hb' : ¬a0 * b0 < a * b → ¬b0 < b := mt fun h ↦ mul_lt_mul_of_le_of_lt ha h
-  push_neg at ha' hb'
-  exact ⟨ha.antisymm' (ha' ab), hb.antisymm' (hb' ab)⟩
-#align eq_and_eq_of_le_of_le_of_mul_le eq_and_eq_of_le_of_le_of_mul_le
-#align eq_and_eq_of_le_of_le_of_add_le eq_and_eq_of_le_of_le_of_add_le
-
 -- see Note [lower instance priority]
 /-- This instance asserts that if `A` has a multiplication, a linear order, and multiplication
 is 'very monotone', then `A` also has `UniqueProds`. -/

--- a/Mathlib/Algebra/Order/Monoid/Basic.lean
+++ b/Mathlib/Algebra/Order/Monoid/Basic.lean
@@ -77,3 +77,16 @@ def OrderEmbedding.mulRight {α : Type _} [Mul α] [LinearOrder α]
 #align order_embedding.add_right OrderEmbedding.addRight
 #align order_embedding.mul_right_apply OrderEmbedding.mulRight_apply
 #align order_embedding.add_right_apply OrderEmbedding.addRight_apply
+
+@[to_additive]
+theorem eq_and_eq_of_le_of_le_of_mul_le [Mul α] [LinearOrder α]
+    [CovariantClass α α (· * ·) (· ≤ ·)] [CovariantClass α α (Function.swap (· * ·)) (· < ·)]
+    [ContravariantClass α α (· * ·) (· ≤ ·)] {a b a0 b0 : α} (ha : a0 ≤ a) (hb : b0 ≤ b)
+    (ab : a * b ≤ a0 * b0) : a = a0 ∧ b = b0 := by
+  haveI := Mul.to_covariantClass_right α
+  have ha' : ¬a0 * b0 < a * b → ¬a0 < a := mt (mul_lt_mul_of_lt_of_le · hb)
+  have hb' : ¬a0 * b0 < a * b → ¬b0 < b := mt (mul_lt_mul_of_le_of_lt ha ·)
+  push_neg at ha' hb'
+  exact ⟨ha.antisymm' (ha' ab), hb.antisymm' (hb' ab)⟩
+#align eq_and_eq_of_le_of_le_of_mul_le eq_and_eq_of_le_of_le_of_mul_le
+#align eq_and_eq_of_le_of_le_of_add_le eq_and_eq_of_le_of_le_of_add_le


### PR DESCRIPTION
This move was suggested in #6220.  In fact, the lemma is a general fact about an inequality involving multiplications and did not really belong in the file where it was.

Affected files:
```
Algebra.Group.UniqueProds
Algebra.Order.Monoid.Basic
```

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
