### PR TITLE
[Merged by Bors] - feat: Mul by invertible matrices is injective even for rectangular matrices

### DIFF
--- a/Mathlib/LinearAlgebra/Matrix/NonsingularInverse.lean
+++ b/Mathlib/LinearAlgebra/Matrix/NonsingularInverse.lean
@@ -356,15 +356,19 @@ theorem mul_inv_eq_iff_eq_mul_of_invertible (A B C : Matrix n n α) [Invertible 
    fun h => by rw [h, mul_inv_cancel_right_of_invertible]⟩
 #align matrix.mul_inv_eq_iff_eq_mul_of_invertible Matrix.mul_inv_eq_iff_eq_mul_of_invertible
 
-lemma mul_left_injective_of_invertible
-    {m: Type} [Fintype m] [DecidableEq m] (P : Matrix m m α) [Invertible P] :
-    Function.Injective (fun (x : Matrix m n α) => P ⬝ x) :=
-  fun _ _ h => by simpa only [inv_mul_cancel_left_of_invertible] using (congr_arg (P⁻¹ ⬝ ·) h)
+lemma mul_right_injective_of_invertible [Invertible A] :
+    Function.Injective (fun (x : Matrix n m α) => A ⬝ x) :=
+  fun _ _ h => by simpa only [inv_mul_cancel_left_of_invertible] using (congr_arg (A⁻¹ ⬝ ·) h)
 
-lemma mul_right_injective_of_invertible
-    {m: Type} [Fintype m] [DecidableEq m] (P : Matrix m m α) [Invertible P] :
-    Function.Injective (fun (x : Matrix n m α) => x ⬝ P) :=
-  fun a x hax => by simpa only [mul_inv_cancel_right_of_invertible] using (congr_arg (· ⬝ P⁻¹) hax)
+lemma mul_left_injective_of_invertible [Invertible A] :
+    Function.Injective (fun (x : Matrix m n α) => x ⬝ A) :=
+  fun a x hax => by simpa only [mul_inv_cancel_right_of_invertible] using (congr_arg (· ⬝ A⁻¹) hax)
+
+lemma mul_right_inj_of_invertible [Invertible A] {x y : Matrix n m α} : A ⬝ x = A ⬝ y ↔ x = y :=
+  (mul_right_injective_of_invertible A).eq_iff
+
+lemma mul_left_inj_of_invertible [Invertible A] {x y : Matrix m n α} : x ⬝ A = y ⬝ A ↔ x = y :=
+  (mul_left_injective_of_invertible A).eq_iff
 
 theorem nonsing_inv_cancel_or_zero : A⁻¹ ⬝ A = 1 ∧ A ⬝ A⁻¹ = 1 ∨ A⁻¹ = 0 := by
   by_cases h : IsUnit A.det

--- a/Mathlib/LinearAlgebra/Matrix/NonsingularInverse.lean
+++ b/Mathlib/LinearAlgebra/Matrix/NonsingularInverse.lean
@@ -356,12 +356,12 @@ theorem mul_inv_eq_iff_eq_mul_of_invertible (A B C : Matrix n n α) [Invertible 
    fun h => by rw [h, mul_inv_cancel_right_of_invertible]⟩
 #align matrix.mul_inv_eq_iff_eq_mul_of_invertible Matrix.mul_inv_eq_iff_eq_mul_of_invertible
 
-lemma Matrix.mul_left_injective_of_invertible
+lemma mul_left_injective_of_invertible
     {m: Type} [Fintype m] [DecidableEq m] (P : Matrix m m α) [Invertible P] :
     Function.Injective (fun (x : Matrix m n α) => P ⬝ x) :=
   fun _ _ h => by simpa only [inv_mul_cancel_left_of_invertible] using (congr_arg (P⁻¹ ⬝ ·) h)
 
-lemma Matrix.mul_right_injective_of_invertible
+lemma mul_right_injective_of_invertible
     {m: Type} [Fintype m] [DecidableEq m] (P : Matrix m m α) [Invertible P] :
     Function.Injective (fun (x : Matrix n m α) => x ⬝ P) :=
   fun a x hax => by simpa only [mul_inv_cancel_right_of_invertible] using (congr_arg (· ⬝ P⁻¹) hax)

--- a/Mathlib/LinearAlgebra/Matrix/NonsingularInverse.lean
+++ b/Mathlib/LinearAlgebra/Matrix/NonsingularInverse.lean
@@ -356,6 +356,16 @@ theorem mul_inv_eq_iff_eq_mul_of_invertible (A B C : Matrix n n α) [Invertible 
    fun h => by rw [h, mul_inv_cancel_right_of_invertible]⟩
 #align matrix.mul_inv_eq_iff_eq_mul_of_invertible Matrix.mul_inv_eq_iff_eq_mul_of_invertible
 
+lemma Matrix.mul_left_injective_of_invertible
+    {m: Type} [Fintype m] [DecidableEq m] (P : Matrix m m α) [Invertible P] :
+    Function.Injective (fun (x : Matrix m n α) => P ⬝ x) :=
+  fun _ _ h => by simpa only [inv_mul_cancel_left_of_invertible] using (congr_arg (P⁻¹ ⬝ ·) h)
+
+lemma Matrix.mul_right_injective_of_invertible
+    {m: Type} [Fintype m] [DecidableEq m] (P : Matrix m m α) [Invertible P] :
+    Function.Injective (fun (x : Matrix n m α) => x ⬝ P) :=
+  fun a x hax => by simpa only [mul_inv_cancel_right_of_invertible] using (congr_arg (· ⬝ P⁻¹) hax)
+
 theorem nonsing_inv_cancel_or_zero : A⁻¹ ⬝ A = 1 ∧ A ⬝ A⁻¹ = 1 ∨ A⁻¹ = 0 := by
   by_cases h : IsUnit A.det
   · exact Or.inl ⟨nonsing_inv_mul _ h, mul_nonsing_inv _ h⟩

--- a/Mathlib/LinearAlgebra/Matrix/NonsingularInverse.lean
+++ b/Mathlib/LinearAlgebra/Matrix/NonsingularInverse.lean
@@ -358,11 +358,11 @@ theorem mul_inv_eq_iff_eq_mul_of_invertible (A B C : Matrix n n α) [Invertible 
 
 lemma mul_right_injective_of_invertible [Invertible A] :
     Function.Injective (fun (x : Matrix n m α) => A ⬝ x) :=
-  fun _ _ h => by simpa only [inv_mul_cancel_left_of_invertible] using (congr_arg (A⁻¹ ⬝ ·) h)
+  fun _ _ h => by simpa only [inv_mul_cancel_left_of_invertible] using congr_arg (A⁻¹ ⬝ ·) h
 
 lemma mul_left_injective_of_invertible [Invertible A] :
     Function.Injective (fun (x : Matrix m n α) => x ⬝ A) :=
-  fun a x hax => by simpa only [mul_inv_cancel_right_of_invertible] using (congr_arg (· ⬝ A⁻¹) hax)
+  fun a x hax => by simpa only [mul_inv_cancel_right_of_invertible] using congr_arg (· ⬝ A⁻¹) hax
 
 lemma mul_right_inj_of_invertible [Invertible A] {x y : Matrix n m α} : A ⬝ x = A ⬝ y ↔ x = y :=
   (mul_right_injective_of_invertible A).eq_iff


### PR DESCRIPTION
Multiplication by invertible matrices from the left or right is injective. Note that [`mul_left_injective₀`](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/GroupWithZero/Defs.html#mul_left_injective%E2%82%80) and friends don't apply because they would require similar (square) matrices.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
