### PR TITLE
[Merged by Bors] - feat: intervals with rational bounds generate the real Borel sigma algebra

### DIFF
--- a/Mathlib/Algebra/Order/Archimedean.lean
+++ b/Mathlib/Algebra/Order/Archimedean.lean
@@ -292,6 +292,12 @@ theorem le_of_forall_lt_rat_imp_le (h : ∀ q : ℚ, y < q → x ≤ q) : x ≤ 
     hx.not_le <| h _ hy
 #align le_of_forall_lt_rat_imp_le le_of_forall_lt_rat_imp_le
 
+theorem le_iff_forall_rat_lt_imp_le : x ≤ y ↔ ∀ q : ℚ, (q : α) < x → (q : α) ≤ y :=
+  ⟨fun hxy _ hqx ↦ hqx.le.trans hxy, le_of_forall_rat_lt_imp_le⟩
+
+theorem le_iff_forall_lt_rat_imp_le : x ≤ y ↔ ∀ q : ℚ, y < q → x ≤ q :=
+  ⟨fun hxy _ hqx ↦ hxy.trans hqx.le, le_of_forall_lt_rat_imp_le⟩
+
 theorem eq_of_forall_rat_lt_iff_lt (h : ∀ q : ℚ, (q : α) < x ↔ (q : α) < y) : x = y :=
   (le_of_forall_rat_lt_imp_le fun q hq => ((h q).1 hq).le).antisymm <|
     le_of_forall_rat_lt_imp_le fun q hq => ((h q).2 hq).le

--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Basic.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Basic.lean
@@ -1698,100 +1698,68 @@ theorem borel_eq_generateFrom_Ioo_rat :
 #align real.borel_eq_generate_from_Ioo_rat Real.borel_eq_generateFrom_Ioo_rat
 
 theorem borel_eq_generateFrom_Iio_rat : borel ℝ = .generateFrom (⋃ a : ℚ, {Iio (a : ℝ)}) := by
-  let g : MeasurableSpace ℝ := .generateFrom (⋃ a : ℚ, {Iio (a : ℝ)})
-  refine' le_antisymm _ _
-  · rw [borel_eq_generateFrom_Ioo_rat]
-    refine' generateFrom_le fun t => _
-    simp only [mem_iUnion, mem_singleton_iff]
-    rintro ⟨a, b, _, rfl⟩
-    rw [(Set.ext fun x => by
-          suffices x < ↑b → (↑a < x ↔ ∃ i : ℚ, a < i ∧ ↑i ≤ x) by simpa
-          refine' fun _ => ⟨fun h => _, fun ⟨i, hai, hix⟩ => (Rat.cast_lt.2 hai).trans_le hix⟩
-          rcases exists_rat_btwn h with ⟨c, ac, cx⟩
-          exact ⟨c, Rat.cast_lt.1 ac, cx.le⟩
-            : Ioo (a : ℝ) b = (⋃ c > a, (Iio (c : ℝ))ᶜ) ∩ Iio (b : ℝ))]
-    · have hg : ∀ q : ℚ, MeasurableSet[g] (Iio (q : ℝ)) := fun q =>
-        GenerateMeasurable.basic (Iio (q : ℝ)) (by simp)
-      refine' MeasurableSet.inter _ (hg _)
-      exact MeasurableSet.biUnion (to_countable _) fun c _ => (hg _).compl
-  · refine' MeasurableSpace.generateFrom_le fun _ => _
-    simp only [mem_iUnion, mem_singleton_iff]
-    rintro ⟨r, rfl⟩
-    exact @measurableSet_Iio _ _ (borel ℝ) _ _ _ _
-#align real.borel_eq_generate_from_Iio_rat Real.borel_eq_generateFrom_Iio_rat
+  rw [borel_eq_generateFrom_Iio]
+  refine le_antisymm
+    (generateFrom_le ?_)
+    (generateFrom_mono <| iUnion_subset fun q ↦ singleton_subset_iff.mpr <| mem_range_self _)
+  rintro _ ⟨a, rfl⟩
+  have : IsLUB (range ((↑) : ℚ → ℝ) ∩ Iio a) a := by
+    simp [isLUB_iff_le_iff, mem_upperBounds, ← le_iff_forall_rat_lt_imp_le]
+  rw [← this.biUnion_Iio_eq, ← image_univ, ← image_inter_preimage, univ_inter, biUnion_image]
+  exact MeasurableSet.biUnion (to_countable _)
+    fun b _ => GenerateMeasurable.basic (Iio (b : ℝ)) (by simp)
 
 theorem borel_eq_generateFrom_Ioi_rat : borel ℝ = .generateFrom (⋃ a : ℚ, {Ioi (a : ℝ)}) := by
-  refine' le_antisymm _ _
-  · rw [borel_eq_generateFrom_Iio_rat]
-    refine' generateFrom_le fun t => _
-    simp only [mem_iUnion, mem_singleton_iff]
-    rintro ⟨b, _, rfl⟩
-    have : Iio (b : ℝ) = ⋃ c < b, (Ioi (c : ℝ))ᶜ := by
-      ext x
-      simp only [mem_Iio, compl_Ioi, mem_iUnion, mem_Iic, exists_prop]
-      refine ⟨fun h ↦ ?_, fun ⟨i, hib, bxi⟩ ↦ bxi.trans_lt (Rat.cast_lt.2 hib)⟩
-      rcases exists_rat_btwn h with ⟨c, xc, cb⟩
-      exact ⟨c, Rat.cast_lt.1 cb, xc.le⟩
-    rw [this]
-    have hg : ∀ q : ℚ, MeasurableSet[.generateFrom (⋃ a : ℚ, {Ioi (a : ℝ)})] (Ioi (q : ℝ)) :=
-      fun q => GenerateMeasurable.basic (Ioi (q : ℝ)) (by simp)
-    exact MeasurableSet.biUnion (to_countable _) fun c _ => (hg _).compl
-  · refine' MeasurableSpace.generateFrom_le fun _ => _
-    simp only [mem_iUnion, mem_singleton_iff]
-    rintro ⟨r, rfl⟩
-    exact measurableSet_Ioi
+  rw [borel_eq_generateFrom_Ioi]
+  refine le_antisymm
+    (generateFrom_le ?_)
+    (generateFrom_mono <| iUnion_subset fun q ↦ singleton_subset_iff.mpr <| mem_range_self _)
+  rintro _ ⟨a, rfl⟩
+  have : IsGLB (range ((↑) : ℚ → ℝ) ∩ Iio a) a := by
+    simp [isLUB_iff_le_iff, mem_upperBounds, ← le_iff_forall_rat_lt_imp_le]
+  rw [← this.biUnion_Ioi_eq, ← image_univ, ← image_inter_preimage, univ_inter, biUnion_image]
+  exact MeasurableSet.biUnion (to_countable _)
+    fun b _ => GenerateMeasurable.basic (Ioi (b : ℝ)) (by simp)
 
 theorem borel_eq_generateFrom_Iic_rat : borel ℝ = .generateFrom (⋃ a : ℚ, {Iic (a : ℝ)}) := by
-  refine' le_antisymm _ _
-  · rw [borel_eq_generateFrom_Ioi_rat]
-    refine generateFrom_le fun t ht => ?_
-    simp only [iUnion_singleton_eq_range, mem_range] at ht
-    obtain ⟨y, rfl⟩ := ht
-    rw [← compl_Iic]
-    refine MeasurableSet.compl (GenerateMeasurable.basic _ ?_)
-    simp only [iUnion_singleton_eq_range, mem_range, exists_apply_eq_apply]
-  · refine MeasurableSpace.generateFrom_le fun s hs => ?_
-    simp only [iUnion_singleton_eq_range, mem_range] at hs
-    obtain ⟨y, rfl⟩ := hs
-    exact measurableSet_Iic
+  rw [borel_eq_generateFrom_Ioi_rat, iUnion_singleton_eq_range, iUnion_singleton_eq_range]
+  refine le_antisymm (generateFrom_le ?_) (generateFrom_le ?_) <;>
+  rintro _ ⟨q, rfl⟩ <;>
+  dsimp only <;>
+  [rw [← compl_Iic]; rw [← compl_Ioi]] <;>
+  exact MeasurableSet.compl (GenerateMeasurable.basic _ (mem_range_self q))
 
 theorem borel_eq_generateFrom_Ici_rat : borel ℝ = .generateFrom (⋃ a : ℚ, {Ici (a : ℝ)}) := by
-  refine' le_antisymm _ _
-  · rw [borel_eq_generateFrom_Iio_rat]
-    refine generateFrom_le fun t ht => ?_
-    simp only [iUnion_singleton_eq_range, mem_range] at ht
-    obtain ⟨y, rfl⟩ := ht
-    rw [← compl_Ici]
-    refine MeasurableSet.compl (GenerateMeasurable.basic _ ?_)
-    simp only [iUnion_singleton_eq_range, mem_range, exists_apply_eq_apply]
-  · refine MeasurableSpace.generateFrom_le fun s hs => ?_
-    simp only [iUnion_singleton_eq_range, mem_range] at hs
-    obtain ⟨y, rfl⟩ := hs
-    exact measurableSet_Ici
+  rw [borel_eq_generateFrom_Iio_rat, iUnion_singleton_eq_range, iUnion_singleton_eq_range]
+  refine le_antisymm (generateFrom_le ?_) (generateFrom_le ?_) <;>
+  rintro _ ⟨q, rfl⟩ <;>
+  dsimp only <;>
+  [rw [← compl_Ici]; rw [← compl_Iio]] <;>
+  exact MeasurableSet.compl (GenerateMeasurable.basic _ (mem_range_self q))
 
 theorem isPiSystem_Ioo_rat :
-    @IsPiSystem ℝ (⋃ (a : ℚ) (b : ℚ) (_ : a < b), {Ioo (a : ℝ) (b : ℝ)}) := by
+    IsPiSystem (⋃ (a : ℚ) (b : ℚ) (_ : a < b), {Ioo (a : ℝ) (b : ℝ)}) := by
   convert isPiSystem_Ioo ((↑) : ℚ → ℝ) ((↑) : ℚ → ℝ)
   ext x
   simp [eq_comm]
 #align real.is_pi_system_Ioo_rat Real.isPiSystem_Ioo_rat
 
-theorem isPiSystem_Iio_rat : @IsPiSystem ℝ (⋃ a : ℚ, {Iio (a : ℝ)}) := by
+theorem isPiSystem_Iio_rat : IsPiSystem (⋃ a : ℚ, {Iio (a : ℝ)}) := by
   convert isPiSystem_image_Iio (((↑) : ℚ → ℝ) '' univ)
   ext x
   simp only [iUnion_singleton_eq_range, mem_range, image_univ, mem_image, exists_exists_eq_and]
 
-theorem isPiSystem_Ioi_rat : @IsPiSystem ℝ (⋃ a : ℚ, {Ioi (a : ℝ)}) := by
+theorem isPiSystem_Ioi_rat : IsPiSystem (⋃ a : ℚ, {Ioi (a : ℝ)}) := by
   convert isPiSystem_image_Ioi (((↑) : ℚ → ℝ) '' univ)
   ext x
   simp only [iUnion_singleton_eq_range, mem_range, image_univ, mem_image, exists_exists_eq_and]
 
-theorem isPiSystem_Iic_rat : @IsPiSystem ℝ (⋃ a : ℚ, {Iic (a : ℝ)}) := by
+theorem isPiSystem_Iic_rat : IsPiSystem (⋃ a : ℚ, {Iic (a : ℝ)}) := by
   convert isPiSystem_image_Iic (((↑) : ℚ → ℝ) '' univ)
   ext x
   simp only [iUnion_singleton_eq_range, mem_range, image_univ, mem_image, exists_exists_eq_and]
 
-theorem isPiSystem_Ici_rat : @IsPiSystem ℝ (⋃ a : ℚ, {Ici (a : ℝ)}) := by
+theorem isPiSystem_Ici_rat : IsPiSystem (⋃ a : ℚ, {Ici (a : ℝ)}) := by
   convert isPiSystem_image_Ici (((↑) : ℚ → ℝ) '' univ)
   ext x
   simp only [iUnion_singleton_eq_range, mem_range, image_univ, mem_image, exists_exists_eq_and]

--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Basic.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Basic.lean
@@ -1697,12 +1697,107 @@ theorem borel_eq_generateFrom_Ioo_rat :
   isTopologicalBasis_Ioo_rat.borel_eq_generateFrom
 #align real.borel_eq_generate_from_Ioo_rat Real.borel_eq_generateFrom_Ioo_rat
 
+theorem borel_eq_generateFrom_Iio_rat : borel ℝ = .generateFrom (⋃ a : ℚ, {Iio (a : ℝ)}) := by
+  let g : MeasurableSpace ℝ := .generateFrom (⋃ a : ℚ, {Iio (a : ℝ)})
+  refine' le_antisymm _ _
+  · rw [borel_eq_generateFrom_Ioo_rat]
+    refine' generateFrom_le fun t => _
+    simp only [mem_iUnion, mem_singleton_iff]
+    rintro ⟨a, b, _, rfl⟩
+    rw [(Set.ext fun x => by
+          suffices x < ↑b → (↑a < x ↔ ∃ i : ℚ, a < i ∧ ↑i ≤ x) by simpa
+          refine' fun _ => ⟨fun h => _, fun ⟨i, hai, hix⟩ => (Rat.cast_lt.2 hai).trans_le hix⟩
+          rcases exists_rat_btwn h with ⟨c, ac, cx⟩
+          exact ⟨c, Rat.cast_lt.1 ac, cx.le⟩
+            : Ioo (a : ℝ) b = (⋃ c > a, (Iio (c : ℝ))ᶜ) ∩ Iio (b : ℝ))]
+    · have hg : ∀ q : ℚ, MeasurableSet[g] (Iio (q : ℝ)) := fun q =>
+        GenerateMeasurable.basic (Iio (q : ℝ)) (by simp)
+      refine' MeasurableSet.inter _ (hg _)
+      exact MeasurableSet.biUnion (to_countable _) fun c _ => (hg _).compl
+  · refine' MeasurableSpace.generateFrom_le fun _ => _
+    simp only [mem_iUnion, mem_singleton_iff]
+    rintro ⟨r, rfl⟩
+    exact @measurableSet_Iio _ _ (borel ℝ) _ _ _ _
+#align real.borel_eq_generate_from_Iio_rat Real.borel_eq_generateFrom_Iio_rat
+
+theorem borel_eq_generateFrom_Ioi_rat : borel ℝ = .generateFrom (⋃ a : ℚ, {Ioi (a : ℝ)}) := by
+  let g : MeasurableSpace ℝ := .generateFrom (⋃ a : ℚ, {Ioi (a : ℝ)})
+  refine' le_antisymm _ _
+  · rw [borel_eq_generateFrom_Ioo_rat]
+    refine' generateFrom_le fun t => _
+    simp only [mem_iUnion, mem_singleton_iff]
+    rintro ⟨a, b, _, rfl⟩
+    have : Ioo (a : ℝ) b = Ioi (a : ℝ) ∩ (⋃ c < b, (Ioi (c : ℝ))ᶜ) := by
+      ext x
+      simp only [gt_iff_lt, Rat.cast_lt, not_lt, ge_iff_le, Rat.cast_le, mem_Ioo, compl_Ioi,
+        mem_inter_iff, mem_Ioi, mem_iUnion, mem_Iic, exists_prop, and_congr_right_iff]
+      refine fun _ ↦ ⟨fun h ↦ ?_, fun ⟨i, hib, bxi⟩ ↦ bxi.trans_lt (Rat.cast_lt.2 hib)⟩
+      rcases exists_rat_btwn h with ⟨c, xc, cb⟩
+      exact ⟨c, Rat.cast_lt.1 cb, xc.le⟩
+    rw [this]
+    have hg : ∀ q : ℚ, MeasurableSet[g] (Ioi (q : ℝ)) := fun q =>
+      GenerateMeasurable.basic (Ioi (q : ℝ)) (by simp)
+    refine MeasurableSet.inter (hg _) ?_
+    exact MeasurableSet.biUnion (to_countable _) fun c _ => (hg _).compl
+  · refine' MeasurableSpace.generateFrom_le fun _ => _
+    simp only [mem_iUnion, mem_singleton_iff]
+    rintro ⟨r, rfl⟩
+    exact @measurableSet_Ioi _ _ (borel ℝ) _ _ _ _
+
+theorem borel_eq_generateFrom_Iic_rat : borel ℝ = .generateFrom (⋃ a : ℚ, {Iic (a : ℝ)}) := by
+  refine' le_antisymm _ _
+  · rw [borel_eq_generateFrom_Ioi_rat]
+    refine generateFrom_le fun t ht => ?_
+    simp only [iUnion_singleton_eq_range, mem_range] at ht
+    obtain ⟨y, rfl⟩ := ht
+    rw [← compl_Iic]
+    refine MeasurableSet.compl (GenerateMeasurable.basic _ ?_)
+    simp only [iUnion_singleton_eq_range, mem_range, exists_apply_eq_apply]
+  · refine MeasurableSpace.generateFrom_le fun s hs => ?_
+    simp only [iUnion_singleton_eq_range, mem_range] at hs
+    obtain ⟨y, rfl⟩ := hs
+    exact measurableSet_Iic
+
+theorem borel_eq_generateFrom_Ici_rat : borel ℝ = .generateFrom (⋃ a : ℚ, {Ici (a : ℝ)}) := by
+  refine' le_antisymm _ _
+  · rw [borel_eq_generateFrom_Iio_rat]
+    refine generateFrom_le fun t ht => ?_
+    simp only [iUnion_singleton_eq_range, mem_range] at ht
+    obtain ⟨y, rfl⟩ := ht
+    rw [← compl_Ici]
+    refine MeasurableSet.compl (GenerateMeasurable.basic _ ?_)
+    simp only [iUnion_singleton_eq_range, mem_range, exists_apply_eq_apply]
+  · refine MeasurableSpace.generateFrom_le fun s hs => ?_
+    simp only [iUnion_singleton_eq_range, mem_range] at hs
+    obtain ⟨y, rfl⟩ := hs
+    exact measurableSet_Ici
+
 theorem isPiSystem_Ioo_rat :
     @IsPiSystem ℝ (⋃ (a : ℚ) (b : ℚ) (_ : a < b), {Ioo (a : ℝ) (b : ℝ)}) := by
   convert isPiSystem_Ioo ((↑) : ℚ → ℝ) ((↑) : ℚ → ℝ)
   ext x
   simp [eq_comm]
 #align real.is_pi_system_Ioo_rat Real.isPiSystem_Ioo_rat
+
+theorem isPiSystem_Iio_rat : @IsPiSystem ℝ (⋃ a : ℚ, {Iio (a : ℝ)}) := by
+  convert isPiSystem_image_Iio (((↑) : ℚ → ℝ) '' univ)
+  ext x
+  simp only [iUnion_singleton_eq_range, mem_range, image_univ, mem_image, exists_exists_eq_and]
+
+theorem isPiSystem_Ioi_rat : @IsPiSystem ℝ (⋃ a : ℚ, {Ioi (a : ℝ)}) := by
+  convert isPiSystem_image_Ioi (((↑) : ℚ → ℝ) '' univ)
+  ext x
+  simp only [iUnion_singleton_eq_range, mem_range, image_univ, mem_image, exists_exists_eq_and]
+
+theorem isPiSystem_Iic_rat : @IsPiSystem ℝ (⋃ a : ℚ, {Iic (a : ℝ)}) := by
+  convert isPiSystem_image_Iic (((↑) : ℚ → ℝ) '' univ)
+  ext x
+  simp only [iUnion_singleton_eq_range, mem_range, image_univ, mem_image, exists_exists_eq_and]
+
+theorem isPiSystem_Ici_rat : @IsPiSystem ℝ (⋃ a : ℚ, {Ici (a : ℝ)}) := by
+  convert isPiSystem_image_Ici (((↑) : ℚ → ℝ) '' univ)
+  ext x
+  simp only [iUnion_singleton_eq_range, mem_range, image_univ, mem_image, exists_exists_eq_and]
 
 /-- The intervals `(-(n + 1), (n + 1))` form a finite spanning sets in the set of open intervals
 with rational endpoints for a locally finite measure `μ` on `ℝ`. -/
@@ -1728,30 +1823,6 @@ theorem measure_ext_Ioo_rat {μ ν : Measure ℝ} [IsLocallyFiniteMeasure μ]
     rintro _ ⟨a, b, -, rfl⟩
     apply h
 #align real.measure_ext_Ioo_rat Real.measure_ext_Ioo_rat
-
-theorem borel_eq_generateFrom_Iio_rat : borel ℝ = .generateFrom (⋃ a : ℚ, {Iio (a : ℝ)}) := by
-  let g : MeasurableSpace ℝ := .generateFrom (⋃ a : ℚ, {Iio (a : ℝ)})
-  refine' le_antisymm _ _
-  · rw [borel_eq_generateFrom_Ioo_rat]
-    refine' generateFrom_le fun t => _
-    simp only [mem_iUnion, mem_singleton_iff]
-    rintro ⟨a, b, _, rfl⟩
-    rw [(Set.ext fun x => by
-          suffices x < ↑b → (↑a < x ↔ ∃ i : ℚ, a < i ∧ ↑i ≤ x) by simpa
-          refine' fun _ => ⟨fun h => _, fun ⟨i, hai, hix⟩ => (Rat.cast_lt.2 hai).trans_le hix⟩
-          rcases exists_rat_btwn h with ⟨c, ac, cx⟩
-          exact ⟨c, Rat.cast_lt.1 ac, cx.le⟩
-            : Ioo (a : ℝ) b = (⋃ c > a, (Iio (c : ℝ))ᶜ) ∩ Iio (b : ℝ))]
-    · have hg : ∀ q : ℚ, MeasurableSet[g] (Iio (q : ℝ)) := fun q =>
-        GenerateMeasurable.basic (Iio (q : ℝ)) (by simp)
-      refine' @MeasurableSet.inter _ g _ _ _ (hg _)
-      refine' @MeasurableSet.biUnion _ _ g _ _ (to_countable _) fun c _ => _
-      exact @MeasurableSet.compl _ _ g (hg _)
-  · refine' MeasurableSpace.generateFrom_le fun _ => _
-    simp only [mem_iUnion, mem_singleton_iff]
-    rintro ⟨r, rfl⟩
-    exact @measurableSet_Iio _ _ (borel ℝ) _ _ _ _
-#align real.borel_eq_generate_from_Iio_rat Real.borel_eq_generateFrom_Iio_rat
 
 end Real
 

--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Basic.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Basic.lean
@@ -1715,8 +1715,8 @@ theorem borel_eq_generateFrom_Ioi_rat : borel ℝ = .generateFrom (⋃ a : ℚ, 
     (generateFrom_le ?_)
     (generateFrom_mono <| iUnion_subset fun q ↦ singleton_subset_iff.mpr <| mem_range_self _)
   rintro _ ⟨a, rfl⟩
-  have : IsGLB (range ((↑) : ℚ → ℝ) ∩ Iio a) a := by
-    simp [isLUB_iff_le_iff, mem_upperBounds, ← le_iff_forall_rat_lt_imp_le]
+  have : IsGLB (range ((↑) : ℚ → ℝ) ∩ Ioi a) a := by
+    simp [isGLB_iff_le_iff, mem_lowerBounds, ← le_iff_forall_lt_rat_imp_le]
   rw [← this.biUnion_Ioi_eq, ← image_univ, ← image_inter_preimage, univ_inter, biUnion_image]
   exact MeasurableSet.biUnion (to_countable _)
     fun b _ => GenerateMeasurable.basic (Ioi (b : ℝ)) (by simp)

--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Basic.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Basic.lean
@@ -1721,28 +1721,25 @@ theorem borel_eq_generateFrom_Iio_rat : borel ℝ = .generateFrom (⋃ a : ℚ, 
 #align real.borel_eq_generate_from_Iio_rat Real.borel_eq_generateFrom_Iio_rat
 
 theorem borel_eq_generateFrom_Ioi_rat : borel ℝ = .generateFrom (⋃ a : ℚ, {Ioi (a : ℝ)}) := by
-  let g : MeasurableSpace ℝ := .generateFrom (⋃ a : ℚ, {Ioi (a : ℝ)})
   refine' le_antisymm _ _
-  · rw [borel_eq_generateFrom_Ioo_rat]
+  · rw [borel_eq_generateFrom_Iio_rat]
     refine' generateFrom_le fun t => _
     simp only [mem_iUnion, mem_singleton_iff]
-    rintro ⟨a, b, _, rfl⟩
-    have : Ioo (a : ℝ) b = Ioi (a : ℝ) ∩ (⋃ c < b, (Ioi (c : ℝ))ᶜ) := by
+    rintro ⟨b, _, rfl⟩
+    have : Iio (b : ℝ) = ⋃ c < b, (Ioi (c : ℝ))ᶜ := by
       ext x
-      simp only [gt_iff_lt, Rat.cast_lt, not_lt, ge_iff_le, Rat.cast_le, mem_Ioo, compl_Ioi,
-        mem_inter_iff, mem_Ioi, mem_iUnion, mem_Iic, exists_prop, and_congr_right_iff]
-      refine fun _ ↦ ⟨fun h ↦ ?_, fun ⟨i, hib, bxi⟩ ↦ bxi.trans_lt (Rat.cast_lt.2 hib)⟩
+      simp only [mem_Iio, compl_Ioi, mem_iUnion, mem_Iic, exists_prop]
+      refine ⟨fun h ↦ ?_, fun ⟨i, hib, bxi⟩ ↦ bxi.trans_lt (Rat.cast_lt.2 hib)⟩
       rcases exists_rat_btwn h with ⟨c, xc, cb⟩
       exact ⟨c, Rat.cast_lt.1 cb, xc.le⟩
     rw [this]
-    have hg : ∀ q : ℚ, MeasurableSet[g] (Ioi (q : ℝ)) := fun q =>
-      GenerateMeasurable.basic (Ioi (q : ℝ)) (by simp)
-    refine MeasurableSet.inter (hg _) ?_
+    have hg : ∀ q : ℚ, MeasurableSet[.generateFrom (⋃ a : ℚ, {Ioi (a : ℝ)})] (Ioi (q : ℝ)) :=
+      fun q => GenerateMeasurable.basic (Ioi (q : ℝ)) (by simp)
     exact MeasurableSet.biUnion (to_countable _) fun c _ => (hg _).compl
   · refine' MeasurableSpace.generateFrom_le fun _ => _
     simp only [mem_iUnion, mem_singleton_iff]
     rintro ⟨r, rfl⟩
-    exact @measurableSet_Ioi _ _ (borel ℝ) _ _ _ _
+    exact measurableSet_Ioi
 
 theorem borel_eq_generateFrom_Iic_rat : borel ℝ = .generateFrom (⋃ a : ℚ, {Iic (a : ℝ)}) := by
   refine' le_antisymm _ _

--- a/Mathlib/MeasureTheory/PiSystem.lean
+++ b/Mathlib/MeasureTheory/PiSystem.lean
@@ -149,6 +149,19 @@ theorem isPiSystem_Ioi : IsPiSystem (range Ioi : Set (Set α)) :=
   @image_univ α _ Ioi ▸ isPiSystem_image_Ioi univ
 #align is_pi_system_Ioi isPiSystem_Ioi
 
+theorem isPiSystem_image_Iic (s : Set α) : IsPiSystem (Iic '' s) := by
+  rintro _ ⟨a, ha, rfl⟩ _ ⟨b, hb, rfl⟩ -
+  exact ⟨a ⊓ b, inf_ind a b ha hb, Iic_inter_Iic.symm⟩
+
+theorem isPiSystem_Iic : IsPiSystem (range Iic : Set (Set α)) :=
+  @image_univ α _ Iic ▸ isPiSystem_image_Iic univ
+
+theorem isPiSystem_image_Ici (s : Set α) : IsPiSystem (Ici '' s) :=
+  @isPiSystem_image_Iic αᵒᵈ _ s
+
+theorem isPiSystem_Ici : IsPiSystem (range Ici : Set (Set α)) :=
+  @image_univ α _ Ici ▸ isPiSystem_image_Ici univ
+
 -- porting note: change `∃ (_ : p l u), _` to `_ ∧ _`
 theorem isPiSystem_Ixx_mem {Ixx : α → α → Set α} {p : α → α → Prop}
     (Hne : ∀ {a b}, (Ixx a b).Nonempty → p a b)

--- a/Mathlib/MeasureTheory/PiSystem.lean
+++ b/Mathlib/MeasureTheory/PiSystem.lean
@@ -155,12 +155,14 @@ theorem isPiSystem_image_Iic (s : Set α) : IsPiSystem (Iic '' s) := by
 
 theorem isPiSystem_Iic : IsPiSystem (range Iic : Set (Set α)) :=
   @image_univ α _ Iic ▸ isPiSystem_image_Iic univ
+#align is_pi_system_Iic isPiSystem_Iic
 
 theorem isPiSystem_image_Ici (s : Set α) : IsPiSystem (Ici '' s) :=
   @isPiSystem_image_Iic αᵒᵈ _ s
 
 theorem isPiSystem_Ici : IsPiSystem (range Ici : Set (Set α)) :=
   @image_univ α _ Ici ▸ isPiSystem_image_Ici univ
+#align is_pi_system_Ici isPiSystem_Ici
 
 -- porting note: change `∃ (_ : p l u), _` to `_ ∧ _`
 theorem isPiSystem_Ixx_mem {Ixx : α → α → Set α} {p : α → α → Prop}

--- a/Mathlib/Probability/Kernel/CondCdf.lean
+++ b/Mathlib/Probability/Kernel/CondCdf.lean
@@ -169,16 +169,6 @@ theorem lintegral_iInf_directed_of_measurable {mα : MeasurableSpace α} [Counta
       · exact iInf_le (fun b => ∫⁻ a, f b a ∂μ) _
 #align lintegral_infi_directed_of_measurable lintegral_iInf_directed_of_measurable
 
--- todo: move to measure_theory/pi_system
-theorem isPiSystem_Iic [SemilatticeInf α] : @IsPiSystem α (range Iic) := by
-  rintro s ⟨us, rfl⟩ t ⟨ut, rfl⟩ _; rw [Iic_inter_Iic]; exact ⟨us ⊓ ut, rfl⟩
-#align is_pi_system_Iic isPiSystem_Iic
-
--- todo: move to measure_theory/pi_system
-theorem isPiSystem_Ici [SemilatticeSup α] : @IsPiSystem α (range Ici) := by
-  rintro s ⟨us, rfl⟩ t ⟨ut, rfl⟩ _; rw [Ici_inter_Ici]; exact ⟨us ⊔ ut, rfl⟩
-#align is_pi_system_Ici isPiSystem_Ici
-
 end AuxLemmasToBeMoved
 
 namespace MeasureTheory.Measure


### PR DESCRIPTION
Add `borel_eq_generateFrom_Ioi_rat`, `borel_eq_generateFrom_Ici_rat`, `borel_eq_generateFrom_Iic_rat` (we already have the `Iio` result). Also prove that these sets of intervals are pi-systems.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
