### PR TITLE
[Merged by Bors] - feat(GroupTheory/SpecificGroups/Dihedral): Conjugacy classes in odd dihedral groups

### DIFF
--- a/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
@@ -204,6 +204,7 @@ theorem exponent : Monoid.exponent (DihedralGroup n) = lcm n 2 := by
       exact (orderOf_sr 0).symm
 #align dihedral_group.exponent DihedralGroup.exponent
 
+/-- If n is odd, then the Dihedral group of order 2n has n*(n+3) pairs of commuting elements. -/
 def OddCommuteEquiv (hn : Odd n) : { p : DihedralGroup n × DihedralGroup n // Commute p.1 p.2 } ≃
     ZMod n ⊕ ZMod n ⊕ ZMod n ⊕ ZMod n × ZMod n :=
   let u := ZMod.unitOfCoprime 2 (Nat.prime_two.coprime_iff_not_dvd.mpr hn.not_two_dvd_nat)
@@ -220,10 +221,10 @@ def OddCommuteEquiv (hn : Odd n) : { p : DihedralGroup n × DihedralGroup n // C
       | Sum.inr (Sum.inr (Sum.inr ⟨i, j⟩)) => ⟨⟨r i, r j⟩, congrArg r (add_comm i j)⟩
     left_inv := by
       rintro ⟨⟨i | i, j | j⟩, h⟩
-      . rfl
-      . simpa [sub_eq_add_neg, neg_eq_iff_add_eq_zero, hu, eq_comm (a := i) (b := 0)] using h.eq
-      . simpa [sub_eq_add_neg, eq_neg_iff_add_eq_zero, hu, eq_comm (a := j) (b := 0)] using h.eq
-      . replace h := r.inj h
+      · rfl
+      · simpa [sub_eq_add_neg, neg_eq_iff_add_eq_zero, hu, eq_comm (a := i) (b := 0)] using h.eq
+      · simpa [sub_eq_add_neg, eq_neg_iff_add_eq_zero, hu, eq_comm (a := j) (b := 0)] using h.eq
+      · replace h := r.inj h
         rw [←neg_sub, neg_eq_iff_add_eq_zero, hu, sub_eq_zero] at h
         rw [Subtype.ext_iff, Prod.ext_iff, sr.injEq, sr.injEq, h, and_self, ←two_mul]
         apply u.inv_mul_cancel_left

--- a/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
@@ -230,7 +230,7 @@ def OddCommuteEquiv (hn : Odd n) : { p : DihedralGroup n × DihedralGroup n // C
         replace h := r.inj h
         rw [←neg_sub, neg_eq_iff_add_eq_zero, hu, sub_eq_zero] at h
         rw [Subtype.ext_iff, Prod.ext_iff, sr.injEq, sr.injEq, h, and_self, ←two_mul]
-        apply u.inv_mul_cancel_left
+        exact u.inv_mul_cancel_left j
     right_inv := fun
       | .inl i => rfl
       | .inr (.inl j) => rfl

--- a/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
@@ -128,8 +128,8 @@ theorem card [NeZero n] : Fintype.card (DihedralGroup n) = 2 * n := by
 
 theorem nat_card : Nat.card (DihedralGroup n) = 2 * n := by
   cases n
-  . rw [Nat.card_eq_zero_of_infinite]
-  . rw [Nat.card_eq_fintype_card, card]
+  · rw [Nat.card_eq_zero_of_infinite]
+  · rw [Nat.card_eq_fintype_card, card]
 
 @[simp]
 theorem r_one_pow (k : ℕ) : (r 1 : DihedralGroup n) ^ k = r k := by

--- a/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
@@ -238,7 +238,7 @@ def OddCommuteEquiv (hn : Odd n) : { p : DihedralGroup n × DihedralGroup n // C
         congrArg (Sum.inr ∘ Sum.inr ∘ Sum.inl) $ two_mul (u⁻¹ * k) ▸ u.mul_inv_cancel_left k
       | .inr (.inr (.inr ⟨i, j⟩)) => rfl }
 
-lemma card_conjClasses_dihedralGroup_odd (hn : Odd n) :
+lemma nat_card_conjClasses_odd (hn : Odd n) :
     Nat.card (ConjClasses (DihedralGroup n)) = (n + 3) / 2 := by
   have hn' : NeZero n := ⟨hn.pos.ne'⟩
   have h := card_comm_eq_card_conjClasses_mul_card (DihedralGroup n)
@@ -246,5 +246,9 @@ lemma card_conjClasses_dihedralGroup_odd (hn : Odd n) :
       Nat.card_prod, Nat.card_zmod, Nat.card_eq_fintype_card] at h
   rw [←Nat.div_eq_of_eq_mul_right Fintype.card_pos h, card, ←Nat.mul_div_mul_right _ 2 hn.pos]
   ring_nf
+
+lemma fintype_card_conjClasses_odd [Fintype (ConjClasses (DihedralGroup n))] (hn : Odd n) :
+    Fintype.card (ConjClasses (DihedralGroup n)) = (n + 3) / 2 := by
+  rw [←Nat.card_eq_fintype_card, nat_card_conjClasses_odd hn]
 
 end DihedralGroup

--- a/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
@@ -126,6 +126,11 @@ theorem card [NeZero n] : Fintype.card (DihedralGroup n) = 2 * n := by
   rw [← Fintype.card_eq.mpr ⟨fintypeHelper⟩, Fintype.card_sum, ZMod.card, two_mul]
 #align dihedral_group.card DihedralGroup.card
 
+theorem nat_card : Nat.card (DihedralGroup n) = 2 * n := by
+  cases n
+  . rw [Nat.card_eq_zero_of_infinite]
+  . rw [Nat.card_eq_fintype_card, card]
+
 @[simp]
 theorem r_one_pow (k : ℕ) : (r 1 : DihedralGroup n) ^ k = r k := by
   induction' k with k IH
@@ -204,7 +209,8 @@ theorem exponent : Monoid.exponent (DihedralGroup n) = lcm n 2 := by
       exact (orderOf_sr 0).symm
 #align dihedral_group.exponent DihedralGroup.exponent
 
-/-- If n is odd, then the Dihedral group of order 2n has n*(n+3) pairs of commuting elements. -/
+/-- If n is odd, then the Dihedral group of order $2n$ has $n(n+3)$ pairs (represented as
+$n + n + n + n*n$) of commuting elements. -/
 @[simps]
 def OddCommuteEquiv (hn : Odd n) : { p : DihedralGroup n × DihedralGroup n // Commute p.1 p.2 } ≃
     ZMod n ⊕ ZMod n ⊕ ZMod n ⊕ ZMod n × ZMod n :=
@@ -238,17 +244,17 @@ def OddCommuteEquiv (hn : Odd n) : { p : DihedralGroup n × DihedralGroup n // C
         congrArg (Sum.inr ∘ Sum.inr ∘ Sum.inl) $ two_mul (u⁻¹ * k) ▸ u.mul_inv_cancel_left k
       | .inr (.inr (.inr ⟨i, j⟩)) => rfl }
 
-lemma nat_card_conjClasses_odd (hn : Odd n) :
-    Nat.card (ConjClasses (DihedralGroup n)) = (n + 3) / 2 := by
+/-- If n is odd, then the Dihedral group of order 2n has n*(n+3) pairs of commuting elements. -/
+lemma card_commute_odd (hn : Odd n) :
+    Nat.card { p : DihedralGroup n × DihedralGroup n // Commute p.1 p.2 } = n * (n + 3) := by
   have hn' : NeZero n := ⟨hn.pos.ne'⟩
-  have h := card_comm_eq_card_conjClasses_mul_card (DihedralGroup n)
-  rw [mul_comm, Nat.card_congr (OddCommuteEquiv hn), Nat.card_sum, Nat.card_sum, Nat.card_sum,
-      Nat.card_prod, Nat.card_zmod, Nat.card_eq_fintype_card] at h
-  rw [←Nat.div_eq_of_eq_mul_right Fintype.card_pos h, card, ←Nat.mul_div_mul_right _ 2 hn.pos]
-  ring_nf
+  simp_rw [Nat.card_congr (OddCommuteEquiv hn), Nat.card_sum, Nat.card_prod, Nat.card_zmod]
+  ring
 
-lemma fintype_card_conjClasses_odd [Fintype (ConjClasses (DihedralGroup n))] (hn : Odd n) :
-    Fintype.card (ConjClasses (DihedralGroup n)) = (n + 3) / 2 := by
-  rw [←Nat.card_eq_fintype_card, nat_card_conjClasses_odd hn]
+lemma card_conjClasses_odd (hn : Odd n) :
+    Nat.card (ConjClasses (DihedralGroup n)) = (n + 3) / 2 := by
+  rw [←Nat.mul_div_mul_left _ 2 hn.pos, ← card_commute_odd hn, mul_comm,
+    card_comm_eq_card_conjClasses_mul_card, nat_card, Nat.mul_div_left _ (mul_pos two_pos hn.pos)]
+
 
 end DihedralGroup

--- a/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
@@ -244,7 +244,7 @@ def OddCommuteEquiv (hn : Odd n) : { p : DihedralGroup n × DihedralGroup n // C
         congrArg (Sum.inr ∘ Sum.inr ∘ Sum.inl) $ two_mul (u⁻¹ * k) ▸ u.mul_inv_cancel_left k
       | .inr (.inr (.inr ⟨i, j⟩)) => rfl }
 
-/-- If n is odd, then the Dihedral group of order 2n has n*(n+3) pairs of commuting elements. -/
+/-- If n is odd, then the Dihedral group of order $2n$ has $n(n+3)$ pairs of commuting elements. -/
 lemma card_commute_odd (hn : Odd n) :
     Nat.card { p : DihedralGroup n × DihedralGroup n // Commute p.1 p.2 } = n * (n + 3) := by
   have hn' : NeZero n := ⟨hn.pos.ne'⟩


### PR DESCRIPTION
This PR counts conjugacy classes in odd dihedral groups. The even case is a bit harder due to the half-rotation being central.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
