### PR TITLE
[Merged by Bors] - chore(Analysis/InnerProductSpace/PiL2): Make EuclideanSpace.equiv an `abbrev`

### DIFF
--- a/Mathlib/Analysis/InnerProductSpace/PiL2.lean
+++ b/Mathlib/Analysis/InnerProductSpace/PiL2.lean
@@ -212,17 +212,14 @@ end
 
 variable (ι 𝕜)
 
--- TODO : This should be generalized to `PiLp` with finite dimensional factors.
-/-- `PiLp.linearEquiv` upgraded to a continuous linear map between `EuclideanSpace 𝕜 ι`
-and `ι → 𝕜`. -/
-@[simps! toLinearEquiv_apply apply toLinearEquiv_symm_apply symm_apply]
-def EuclideanSpace.equiv : EuclideanSpace 𝕜 ι ≃L[𝕜] ι → 𝕜 :=
-  (PiLp.linearEquiv 2 𝕜 fun _ : ι => 𝕜).toContinuousLinearEquiv
+/-- A shorthand for `PiLp.continuousLinearEquiv`. -/
+abbrev EuclideanSpace.equiv : EuclideanSpace 𝕜 ι ≃L[𝕜] ι → 𝕜 :=
+  PiLp.continuousLinearEquiv 2 𝕜 _
 #align euclidean_space.equiv EuclideanSpace.equiv
-#align euclidean_space.equiv_to_linear_equiv_apply EuclideanSpace.equiv_toLinearEquiv_apply
-#align euclidean_space.equiv_apply EuclideanSpace.equiv_apply
-#align euclidean_space.equiv_to_linear_equiv_symm_apply EuclideanSpace.equiv_toLinearEquiv_symm_apply
-#align euclidean_space.equiv_symm_apply EuclideanSpace.equiv_symm_apply
+#noalign euclidean_space.equiv_to_linear_equiv_apply
+#noalign euclidean_space.equiv_apply
+#noalign euclidean_space.equiv_to_linear_equiv_symm_apply
+#noalign euclidean_space.equiv_symm_apply
 
 variable {ι 𝕜}
 


### PR DESCRIPTION
This definition already exists elsewhere more generally, but this spelling is admittedly easier to find.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
