### PR TITLE
[Merged by Bors] - chore: fix lakefile

### DIFF
--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -14,15 +14,15 @@
     "name": "Cli",
     "inputRev?": "nightly"}},
   {"git":
-   {"url": "https://github.com/semorrison/quote4",
+   {"url": "https://github.com/gebner/quote4",
     "subDir?": null,
-    "rev": "b3247bea1ac270586c773f89fde821a044eac724",
+    "rev": "81cc13c524a68d0072561dbac276cd61b65872a6",
     "name": "Qq",
-    "inputRev?": "instance_names"}},
+    "inputRev?": "master"}},
   {"git":
    {"url": "https://github.com/JLimperg/aesop",
     "subDir?": null,
-    "rev": "354432d437fb37738ed93ac6988669d78a870ed0",
+    "rev": "d13a9666e6f430b940ef8d092f1219e964b52a09",
     "name": "aesop",
     "inputRev?": "master"}},
   {"git":

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -22,7 +22,7 @@
   {"git":
    {"url": "https://github.com/JLimperg/aesop",
     "subDir?": null,
-    "rev": "d13a9666e6f430b940ef8d092f1219e964b52a09",
+    "rev": "354432d437fb37738ed93ac6988669d78a870ed0",
     "name": "aesop",
     "inputRev?": "master"}},
   {"git":

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -42,7 +42,7 @@ meta if get_config? doc = some "on" then -- do not download and build doc-gen4 b
 require «doc-gen4» from git "https://github.com/leanprover/doc-gen4" @ "main"
 
 require std from git "https://github.com/leanprover/std4" @ "main"
-require Qq from git "https://github.com/semorrison/quote4" @ "instance_names"
+require Qq from git "https://github.com/gebner/quote4" @ "master"
 require aesop from git "https://github.com/JLimperg/aesop" @ "master"
 require Cli from git "https://github.com/mhuisi/lean4-cli.git" @ "nightly"
 require proofwidgets from git "https://github.com/EdAyers/ProofWidgets4" @ "v0.0.13"


### PR DESCRIPTION
My PR https://github.com/leanprover-community/mathlib4/pull/6423 modified the lakefile to point to a branch of the `Qq` library, but this had only been necessary during my local testing against a patched version of Lean. I should not have committed this change, and we should not have merged it to `master`.

It's harmless, I think, but should be reverted asap.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
