### PR TITLE
[Merged by Bors] - feat: generalize algebraic pullback instances

### DIFF
--- a/Mathlib/Algebra/GroupWithZero/InjSurj.lean
+++ b/Mathlib/Algebra/GroupWithZero/InjSurj.lean
@@ -22,7 +22,7 @@ section MulZeroClass
 
 variable [MulZeroClass M₀] {a b : M₀}
 
-/-- Pullback a `MulZeroClass` instance along an injective function.
+/-- Pull back a `MulZeroClass` instance along an injective function.
 See note [reducible non-instances]. -/
 @[reducible]
 protected def Function.Injective.mulZeroClass [Mul M₀'] [Zero M₀'] (f : M₀' → M₀) (hf : Injective f)
@@ -33,7 +33,7 @@ protected def Function.Injective.mulZeroClass [Mul M₀'] [Zero M₀'] (f : M₀
   mul_zero a := hf <| by simp only [mul, zero, mul_zero]
 #align function.injective.mul_zero_class Function.Injective.mulZeroClass
 
-/-- Pushforward a `MulZeroClass` instance along a surjective function.
+/-- Push forward a `MulZeroClass` instance along a surjective function.
 See note [reducible non-instances]. -/
 @[reducible]
 protected def Function.Surjective.mulZeroClass [Mul M₀'] [Zero M₀'] (f : M₀ → M₀')
@@ -49,15 +49,30 @@ end MulZeroClass
 
 section NoZeroDivisors
 
-/-- Pushforward a `NoZeroDivisors` instance along an injective function. -/
-protected theorem Function.Injective.noZeroDivisors [Mul M₀] [Zero M₀] [Mul M₀'] [Zero M₀']
-    [NoZeroDivisors M₀'] (f : M₀ → M₀') (hf : Injective f) (zero : f 0 = 0)
-    (mul : ∀ x y, f (x * y) = f x * f y) : NoZeroDivisors M₀ :=
+variable [Mul M₀] [Zero M₀] [Mul M₀'] [Zero M₀']
+  (f : M₀ → M₀') (hf : Injective f) (zero : f 0 = 0) (mul : ∀ x y, f (x * y) = f x * f y)
+
+/-- Pull back a `NoZeroDivisors` instance along an injective function. -/
+protected theorem Function.Injective.noZeroDivisors [NoZeroDivisors M₀'] : NoZeroDivisors M₀ :=
   { eq_zero_or_eq_zero_of_mul_eq_zero := fun H =>
       have : f _ * f _ = 0 := by rw [← mul, H, zero]
       (eq_zero_or_eq_zero_of_mul_eq_zero this).imp
         (fun H => hf <| by rwa [zero]) fun H => hf <| by rwa [zero] }
 #align function.injective.no_zero_divisors Function.Injective.noZeroDivisors
+
+protected theorem Function.Injective.isLeftCancelMulZero
+    [IsLeftCancelMulZero M₀'] : IsLeftCancelMulZero M₀ :=
+  { mul_left_cancel_of_ne_zero := fun Hne He => by
+      have := congr_arg f He
+      rw [mul, mul] at this
+      exact hf (mul_left_cancel₀ (fun Hfa => Hne <| hf <| by rw [Hfa, zero]) this) }
+
+protected theorem Function.Injective.isRightCancelMulZero
+    [IsRightCancelMulZero M₀'] : IsRightCancelMulZero M₀ :=
+  { mul_right_cancel_of_ne_zero := fun Hne He => by
+      have := congr_arg f He
+      rw [mul, mul] at this
+      exact hf (mul_right_cancel₀ (fun Hfa => Hne <| hf <| by rw [Hfa, zero]) this) }
 
 end NoZeroDivisors
 
@@ -65,7 +80,7 @@ section MulZeroOneClass
 
 variable [MulZeroOneClass M₀]
 
-/-- Pullback a `MulZeroOneClass` instance along an injective function.
+/-- Pull back a `MulZeroOneClass` instance along an injective function.
 See note [reducible non-instances]. -/
 @[reducible]
 protected def Function.Injective.mulZeroOneClass [Mul M₀'] [Zero M₀'] [One M₀'] (f : M₀' → M₀)
@@ -74,7 +89,7 @@ protected def Function.Injective.mulZeroOneClass [Mul M₀'] [Zero M₀'] [One M
   { hf.mulZeroClass f zero mul, hf.mulOneClass f one mul with }
 #align function.injective.mul_zero_one_class Function.Injective.mulZeroOneClass
 
-/-- Pushforward a `MulZeroOneClass` instance along a surjective function.
+/-- Push forward a `MulZeroOneClass` instance along a surjective function.
 See note [reducible non-instances]. -/
 @[reducible]
 protected def Function.Surjective.mulZeroOneClass [Mul M₀'] [Zero M₀'] [One M₀'] (f : M₀ → M₀')
@@ -87,7 +102,7 @@ end MulZeroOneClass
 
 section SemigroupWithZero
 
-/-- Pullback a `SemigroupWithZero` along an injective function.
+/-- Pull back a `SemigroupWithZero` along an injective function.
 See note [reducible non-instances]. -/
 @[reducible]
 protected def Function.Injective.semigroupWithZero [Zero M₀'] [Mul M₀'] [SemigroupWithZero M₀]
@@ -96,7 +111,7 @@ protected def Function.Injective.semigroupWithZero [Zero M₀'] [Mul M₀'] [Sem
   { hf.mulZeroClass f zero mul, ‹Zero M₀'›, hf.semigroup f mul with }
 #align function.injective.semigroup_with_zero Function.Injective.semigroupWithZero
 
-/-- Pushforward a `SemigroupWithZero` along a surjective function.
+/-- Push forward a `SemigroupWithZero` along a surjective function.
 See note [reducible non-instances]. -/
 @[reducible]
 protected def Function.Surjective.semigroupWithZero [SemigroupWithZero M₀] [Zero M₀'] [Mul M₀']
@@ -109,7 +124,7 @@ end SemigroupWithZero
 
 section MonoidWithZero
 
-/-- Pullback a `MonoidWithZero` along an injective function.
+/-- Pull back a `MonoidWithZero` along an injective function.
 See note [reducible non-instances]. -/
 @[reducible]
 protected def Function.Injective.monoidWithZero [Zero M₀'] [Mul M₀'] [One M₀'] [Pow M₀' ℕ]
@@ -119,7 +134,7 @@ protected def Function.Injective.monoidWithZero [Zero M₀'] [Mul M₀'] [One M�
   { hf.monoid f one mul npow, hf.mulZeroClass f zero mul with }
 #align function.injective.monoid_with_zero Function.Injective.monoidWithZero
 
-/-- Pushforward a `MonoidWithZero` along a surjective function.
+/-- Push forward a `MonoidWithZero` along a surjective function.
 See note [reducible non-instances]. -/
 @[reducible]
 protected def Function.Surjective.monoidWithZero [Zero M₀'] [Mul M₀'] [One M₀'] [Pow M₀' ℕ]
@@ -129,7 +144,7 @@ protected def Function.Surjective.monoidWithZero [Zero M₀'] [Mul M₀'] [One M
   { hf.monoid f one mul npow, hf.mulZeroClass f zero mul with }
 #align function.surjective.monoid_with_zero Function.Surjective.monoidWithZero
 
-/-- Pullback a `CommMonoidWithZero` along an injective function.
+/-- Pull back a `CommMonoidWithZero` along an injective function.
 See note [reducible non-instances]. -/
 @[reducible]
 protected def Function.Injective.commMonoidWithZero [Zero M₀'] [Mul M₀'] [One M₀'] [Pow M₀' ℕ]
@@ -139,7 +154,7 @@ protected def Function.Injective.commMonoidWithZero [Zero M₀'] [Mul M₀'] [On
   { hf.commMonoid f one mul npow, hf.mulZeroClass f zero mul with }
 #align function.injective.comm_monoid_with_zero Function.Injective.commMonoidWithZero
 
-/-- Pushforward a `CommMonoidWithZero` along a surjective function.
+/-- Push forward a `CommMonoidWithZero` along a surjective function.
 See note [reducible non-instances]. -/
 @[reducible]
 protected def Function.Surjective.commMonoidWithZero [Zero M₀'] [Mul M₀'] [One M₀'] [Pow M₀' ℕ]
@@ -155,7 +170,7 @@ section CancelMonoidWithZero
 
 variable [CancelMonoidWithZero M₀] {a b c : M₀}
 
-/-- Pullback a `CancelMonoidWithZero` along an injective function.
+/-- Pull back a `CancelMonoidWithZero` along an injective function.
 See note [reducible non-instances]. -/
 @[reducible]
 protected def Function.Injective.cancelMonoidWithZero [Zero M₀'] [Mul M₀'] [One M₀'] [Pow M₀' ℕ]
@@ -175,7 +190,7 @@ section CancelCommMonoidWithZero
 
 variable [CancelCommMonoidWithZero M₀] {a b c : M₀}
 
-/-- Pullback a `CancelCommMonoidWithZero` along an injective function.
+/-- Pull back a `CancelCommMonoidWithZero` along an injective function.
 See note [reducible non-instances]. -/
 @[reducible]
 protected def Function.Injective.cancelCommMonoidWithZero [Zero M₀'] [Mul M₀'] [One M₀'] [Pow M₀' ℕ]
@@ -191,7 +206,7 @@ section GroupWithZero
 
 variable [GroupWithZero G₀] {a b c g h x : G₀}
 
-/-- Pullback a `GroupWithZero` along an injective function.
+/-- Pull back a `GroupWithZero` along an injective function.
 See note [reducible non-instances]. -/
 @[reducible]
 protected def Function.Injective.groupWithZero [Zero G₀'] [Mul G₀'] [One G₀'] [Inv G₀'] [Div G₀']
@@ -207,7 +222,7 @@ protected def Function.Injective.groupWithZero [Zero G₀'] [Mul G₀'] [One G�
       erw [one, mul, inv, mul_inv_cancel ((hf.ne_iff' zero).2 hx)] }
 #align function.injective.group_with_zero Function.Injective.groupWithZero
 
-/-- Pushforward a `GroupWithZero` along a surjective function.
+/-- Push forward a `GroupWithZero` along a surjective function.
 See note [reducible non-instances]. -/
 @[reducible]
 protected def Function.Surjective.groupWithZero [Zero G₀'] [Mul G₀'] [One G₀'] [Inv G₀'] [Div G₀']
@@ -229,7 +244,7 @@ section CommGroupWithZero
 
 variable [CommGroupWithZero G₀] {a b c d : G₀}
 
-/-- Pullback a `CommGroupWithZero` along an injective function.
+/-- Pull back a `CommGroupWithZero` along an injective function.
 See note [reducible non-instances]. -/
 @[reducible]
 protected def Function.Injective.commGroupWithZero [Zero G₀'] [Mul G₀'] [One G₀'] [Inv G₀']
@@ -240,7 +255,7 @@ protected def Function.Injective.commGroupWithZero [Zero G₀'] [Mul G₀'] [One
   { hf.groupWithZero f zero one mul inv div npow zpow, hf.commSemigroup f mul with }
 #align function.injective.comm_group_with_zero Function.Injective.commGroupWithZero
 
-/-- Pushforward a `CommGroupWithZero` along a surjective function.
+/-- Push forward a `CommGroupWithZero` along a surjective function.
 See note [reducible non-instances]. -/
 protected def Function.Surjective.commGroupWithZero [Zero G₀'] [Mul G₀'] [One G₀'] [Inv G₀']
     [Div G₀'] [Pow G₀' ℕ] [Pow G₀' ℤ] (h01 : (0 : G₀') ≠ 1) (f : G₀ → G₀') (hf : Surjective f)

--- a/Mathlib/Algebra/Hom/Equiv/Basic.lean
+++ b/Mathlib/Algebra/Hom/Equiv/Basic.lean
@@ -143,18 +143,22 @@ instance (priority := 100) instMonoidHomClass
         _ = e 1 * e (MulEquivClass.toEquivLike.inv e (1 : N) : M) :=
           congr_arg _ (MulEquivClass.toEquivLike.right_inv e 1).symm
         _ = e (MulEquivClass.toEquivLike.inv e (1 : N)) := by rw [← map_mul, one_mul]
-        _ = 1 := MulEquivClass.toEquivLike.right_inv e 1
-         }
+        _ = 1 := MulEquivClass.toEquivLike.right_inv e 1 }
+
+-- See note [lower instance priority]
+instance (priority := 100) toZeroHomClass
+    [MulZeroClass α] [MulZeroClass β] [MulEquivClass F α β] :
+    ZeroHomClass F α β where
+  map_zero := fun e =>
+    calc
+      e 0 = e 0 * e (EquivLike.inv e 0) := by rw [← map_mul, zero_mul]
+        _ = 0 := by simp
 
 -- See note [lower instance priority]
 instance (priority := 100) toMonoidWithZeroHomClass
     [MulZeroOneClass α] [MulZeroOneClass β] [MulEquivClass F α β] :
-  MonoidWithZeroHomClass F α β :=
-  { MulEquivClass.instMonoidHomClass _ with
-    map_zero := fun e =>
-      calc
-        e 0 = e 0 * e (EquivLike.inv e 0) := by rw [← map_mul, zero_mul]
-        _ = 0 := by simp }
+    MonoidWithZeroHomClass F α β :=
+  { MulEquivClass.instMonoidHomClass F, MulEquivClass.toZeroHomClass F with }
 #align mul_equiv_class.to_monoid_with_zero_hom_class MulEquivClass.toMonoidWithZeroHomClass
 
 variable {F}

--- a/Mathlib/Algebra/Ring/Equiv.lean
+++ b/Mathlib/Algebra/Ring/Equiv.lean
@@ -3,6 +3,7 @@ Copyright (c) 2018 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Callum Sutton, Yury Kudryashov
 -/
+import Mathlib.Algebra.Field.Defs
 import Mathlib.Algebra.Group.Opposite
 import Mathlib.Algebra.Hom.Ring
 import Mathlib.Logic.Equiv.Set
@@ -42,18 +43,18 @@ Equiv, MulEquiv, AddEquiv, RingEquiv, MulAut, AddAut, RingAut
 variable {F α β R S S' : Type*}
 
 
-/-- makes a `NonUnitalRingHom` from the bijective inverse of a `NonUnitalRingHom` -/  
+/-- makes a `NonUnitalRingHom` from the bijective inverse of a `NonUnitalRingHom` -/
 @[simps] def NonUnitalRingHom.inverse
     [NonUnitalNonAssocSemiring R] [NonUnitalNonAssocSemiring S]
     (f : R →ₙ+* S) (g : S → R)
     (h₁ : Function.LeftInverse g f) (h₂ : Function.RightInverse g f) : S →ₙ+* R :=
   { (f : R →+ S).inverse g h₁ h₂, (f : R →ₙ* S).inverse g h₁ h₂ with toFun := g }
 
-/-- makes a `RingHom` from the bijective inverse of a `RingHom` -/  
+/-- makes a `RingHom` from the bijective inverse of a `RingHom` -/
 @[simps] def RingHom.inverse [NonAssocSemiring R] [NonAssocSemiring S]
     (f : RingHom R S) (g : S → R)
     (h₁ : Function.LeftInverse g f) (h₂ : Function.RightInverse g f) : S →+* R :=
-  { (f : OneHom R S).inverse g h₁, 
+  { (f : OneHom R S).inverse g h₁,
     (f : MulHom R S).inverse g h₁ h₂,
     (f : R →+ S).inverse g h₁ h₂ with toFun := g }
 
@@ -864,24 +865,34 @@ theorem symm_trans_self (e : R ≃+* S) : e.symm.trans e = RingEquiv.refl S :=
   ext e.right_inv
 #align ring_equiv.symm_trans_self RingEquiv.symm_trans_self
 
+end RingEquiv
+
+namespace MulEquiv
+
 /-- If two rings are isomorphic, and the second doesn't have zero divisors,
 then so does the first. -/
-protected theorem noZeroDivisors {A : Type*} (B : Type*) [Ring A] [Ring B] [NoZeroDivisors B]
-    (e : A ≃+* B) : NoZeroDivisors A :=
-  { eq_zero_or_eq_zero_of_mul_eq_zero := fun {x y} hxy => by
-      have : e x * e y = 0 := by rw [← e.map_mul, hxy, e.map_zero]
-      simpa using eq_zero_or_eq_zero_of_mul_eq_zero this }
-#align ring_equiv.no_zero_divisors RingEquiv.noZeroDivisors
+protected theorem noZeroDivisors {A : Type*} (B : Type*) [MulZeroClass A] [MulZeroClass B]
+    [NoZeroDivisors B] (e : A ≃* B) : NoZeroDivisors A :=
+  e.injective.noZeroDivisors e (map_zero e) (map_mul e)
+#noalign ring_equiv.no_zero_divisors
 
 /-- If two rings are isomorphic, and the second is a domain, then so is the first. -/
-protected theorem isDomain {A : Type*} (B : Type*) [Ring A] [Ring B] [IsDomain B] (e : A ≃+* B) :
-    IsDomain A := by
-  haveI : Nontrivial A := ⟨⟨e.symm 0, e.symm 1, e.symm.injective.ne zero_ne_one⟩⟩
-  haveI := e.noZeroDivisors B
-  exact NoZeroDivisors.to_isDomain _
-#align ring_equiv.is_domain RingEquiv.isDomain
+protected theorem isDomain {A : Type*} (B : Type*) [Semiring A] [Semiring B] [IsDomain B]
+    (e : A ≃* B) : IsDomain A :=
+  { e.injective.isLeftCancelMulZero e (map_zero e) (map_mul e),
+    e.injective.isRightCancelMulZero e (map_zero e) (map_mul e) with
+    exists_pair_ne := ⟨e.symm 0, e.symm 1, e.symm.injective.ne zero_ne_one⟩ }
+#noalign ring_equiv.is_domain
 
-end RingEquiv
+protected theorem isField {A : Type*} (B : Type*) [Semiring A] [Semiring B] (hB : IsField B)
+    (e : A ≃* B) : IsField A where
+  exists_pair_ne := have ⟨x, y, h⟩ := hB.exists_pair_ne; ⟨e.symm x, e.symm y, e.symm.injective.ne h⟩
+  mul_comm := fun x y => e.injective <| by rw [map_mul, map_mul, hB.mul_comm]
+  mul_inv_cancel := fun h => by
+    obtain ⟨a', he⟩ := hB.mul_inv_cancel ((e.injective.ne h).trans_eq <| map_zero e)
+    exact ⟨e.symm a', e.injective <| by rw [map_mul, map_one, e.apply_symm_apply, he]⟩
+
+end MulEquiv
 
 -- guard against import creep
 assert_not_exists Fintype

--- a/Mathlib/AlgebraicGeometry/Properties.lean
+++ b/Mathlib/AlgebraicGeometry/Properties.lean
@@ -241,7 +241,7 @@ instance is_irreducible_of_isIntegral [IsIntegral X] : IrreducibleSpace X.carrie
     (X.sheaf.isProductOfDisjoint ⟨_, hS.1⟩ ⟨_, hT.1⟩ ?_).conePointUniqueUpToIso
       (CommRingCat.prodFanIsLimit _ _)
   apply (config := { allowSynthFailures := true }) false_of_nontrivial_of_product_domain
-  · exact e.symm.commRingCatIsoToRingEquiv.isDomain _
+  · exact e.symm.commRingCatIsoToRingEquiv.toMulEquiv.isDomain _
   · apply X.toLocallyRingedSpace.component_nontrivial
   · apply X.toLocallyRingedSpace.component_nontrivial
   · ext x
@@ -292,7 +292,7 @@ theorem isIntegralOfOpenImmersion {X Y : Scheme} (f : X ⟶ Y) [H : IsOpenImmers
     apply (config := { allowSynthFailures := true }) IsIntegral.component_integral
     refine' ⟨⟨_, _, hU.some.prop, rfl⟩⟩
   exact (asIso <| f.1.c.app (op <| H.base_open.isOpenMap.functor.obj U) :
-    Y.presheaf.obj _ ≅ _).symm.commRingCatIsoToRingEquiv.isDomain _
+    Y.presheaf.obj _ ≅ _).symm.commRingCatIsoToRingEquiv.toMulEquiv.isDomain _
 #align algebraic_geometry.is_integral_of_open_immersion AlgebraicGeometry.isIntegralOfOpenImmersion
 
 instance {R : CommRingCat} [H : IsDomain R] :
@@ -304,8 +304,8 @@ instance {R : CommRingCat} [IsDomain R] : IsIntegral (Scheme.Spec.obj <| op R) :
 
 theorem affine_isIntegral_iff (R : CommRingCat) :
     IsIntegral (Scheme.Spec.obj <| op R) ↔ IsDomain R :=
-  ⟨fun _ => RingEquiv.isDomain ((Scheme.Spec.obj <| op R).presheaf.obj (op ⊤))
-    (asIso <| toSpecΓ R).commRingCatIsoToRingEquiv, fun _ => inferInstance⟩
+  ⟨fun _ => MulEquiv.isDomain ((Scheme.Spec.obj <| op R).presheaf.obj (op ⊤))
+    (asIso <| toSpecΓ R).commRingCatIsoToRingEquiv.toMulEquiv, fun _ => inferInstance⟩
 #align algebraic_geometry.affine_is_integral_iff AlgebraicGeometry.affine_isIntegral_iff
 
 theorem isIntegralOfIsAffineIsDomain [IsAffine X] [Nonempty X.carrier]

--- a/Mathlib/RingTheory/DedekindDomain/IntegralClosure.lean
+++ b/Mathlib/RingTheory/DedekindDomain/IntegralClosure.lean
@@ -68,7 +68,7 @@ then `L` is the localization of the integral closure `C` of `A` in `L` at `A⁰`
 theorem IsIntegralClosure.isLocalization [IsSeparable K L] [NoZeroSMulDivisors A L] :
     IsLocalization (Algebra.algebraMapSubmonoid C A⁰) L := by
   haveI : IsDomain C :=
-    (IsIntegralClosure.equiv A C L (integralClosure A L)).toRingEquiv.isDomain (integralClosure A L)
+    (IsIntegralClosure.equiv A C L (integralClosure A L)).toMulEquiv.isDomain (integralClosure A L)
   haveI : NoZeroSMulDivisors A C := IsIntegralClosure.noZeroSMulDivisors A L
   refine' ⟨_, fun z => _, fun {x y} => ⟨fun h => ⟨1, _⟩, _⟩⟩
   · rintro ⟨_, x, hx, rfl⟩

--- a/Mathlib/RingTheory/Polynomial/Quotient.lean
+++ b/Mathlib/RingTheory/Polynomial/Quotient.lean
@@ -162,7 +162,7 @@ theorem polynomialQuotientEquivQuotientPolynomial_map_mk (I : Ideal R) (f : R[X]
 /-- If `P` is a prime ideal of `R`, then `R[x]/(P)` is an integral domain. -/
 theorem isDomain_map_C_quotient {P : Ideal R} (_ : IsPrime P) :
     IsDomain (R[X] ⧸ (map (C : R →+* R[X]) P : Ideal R[X])) :=
-  RingEquiv.isDomain (Polynomial (R ⧸ P)) (polynomialQuotientEquivQuotientPolynomial P).symm
+  MulEquiv.isDomain (Polynomial (R ⧸ P)) (polynomialQuotientEquivQuotientPolynomial P).symm
 #align ideal.is_domain_map_C_quotient Ideal.isDomain_map_C_quotient
 
 /-- Given any ring `R` and an ideal `I` of `R[X]`, we get a map `R → R[x] → R[x]/I`.


### PR DESCRIPTION
Generalizes RingEquiv.noZeroDivisors and RingEquiv.isDomain to MulEquiv

Adds Function.Injective.isLeft/RightCancelMulZero, MulEquiv.toZeroHomClass, and MulEquiv.isField (the last one is useful for #6309)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
