### PR TITLE
[Merged by Bors] - feat: add some regularity results for multivariable polynomials

### DIFF
--- a/Mathlib/Algebra/Regular/Pow.lean
+++ b/Mathlib/Algebra/Regular/Pow.lean
@@ -5,6 +5,7 @@ Authors: Damiano Testa
 -/
 import Mathlib.Algebra.Hom.Iterate
 import Mathlib.Algebra.Regular.Basic
+import Mathlib.Algebra.BigOperators.Basic
 
 #align_import algebra.regular.pow from "leanprover-community/mathlib"@"46a64b5b4268c594af770c44d9e502afc6a515cb"
 
@@ -64,3 +65,34 @@ theorem IsRegular.pow_iff {n : ℕ} (n0 : 0 < n) : IsRegular (a ^ n) ↔ IsRegul
 #align is_regular.pow_iff IsRegular.pow_iff
 
 end Monoid
+
+section CommMonoid
+
+open BigOperators
+
+variable {ι R : Type*} [CommMonoid R] [Nontrivial R] {s : Finset ι} {f : ι → R}
+
+lemma IsLeftRegular.prod (h : ∀ i ∈ s, IsLeftRegular (f i)) :
+    IsLeftRegular (∏ i in s, f i) := by
+  classical
+  induction' s using Finset.induction_on with j t hj ht
+  · exact isRegular_one.left
+  · rw [Finset.prod_insert hj]
+    have hbr : IsLeftRegular (f j) := h _ (t.mem_insert_self j)
+    exact hbr.mul (ht fun a ha ↦ h a (Finset.mem_insert_of_mem ha))
+
+lemma IsRightRegular.prod (h : ∀ i ∈ s, IsRightRegular (f i)) :
+    IsRightRegular (∏ i in s, f i) := by
+  classical
+  induction' s using Finset.induction_on with j t hj ht
+  · exact isRegular_one.right
+  · rw [Finset.prod_insert hj]
+    have hbr : IsRightRegular (f j) := h _ (t.mem_insert_self j)
+    exact hbr.mul (ht fun a ha ↦ h a (Finset.mem_insert_of_mem ha))
+
+lemma IsRegular.prod (h : ∀ i ∈ s, IsRegular (f i)) :
+    IsRegular (∏ i in s, f i) :=
+  ⟨IsLeftRegular.prod fun a ha ↦ (h a ha).left,
+   IsRightRegular.prod fun a ha ↦ (h a ha).right⟩
+
+end CommMonoid

--- a/Mathlib/Algebra/Regular/Pow.lean
+++ b/Mathlib/Algebra/Regular/Pow.lean
@@ -70,25 +70,15 @@ section CommMonoid
 
 open BigOperators
 
-variable {ι R : Type*} [CommMonoid R] [Nontrivial R] {s : Finset ι} {f : ι → R}
+variable {ι R : Type*} [CommMonoid R] {s : Finset ι} {f : ι → R}
 
 lemma IsLeftRegular.prod (h : ∀ i ∈ s, IsLeftRegular (f i)) :
-    IsLeftRegular (∏ i in s, f i) := by
-  classical
-  induction' s using Finset.induction_on with j t hj ht
-  · exact isRegular_one.left
-  · rw [Finset.prod_insert hj]
-    have hbr : IsLeftRegular (f j) := h _ (t.mem_insert_self j)
-    exact hbr.mul (ht fun a ha ↦ h a (Finset.mem_insert_of_mem ha))
+    IsLeftRegular (∏ i in s, f i) :=
+  s.prod_induction _ _ (@IsLeftRegular.mul R _) isRegular_one.left h
 
 lemma IsRightRegular.prod (h : ∀ i ∈ s, IsRightRegular (f i)) :
-    IsRightRegular (∏ i in s, f i) := by
-  classical
-  induction' s using Finset.induction_on with j t hj ht
-  · exact isRegular_one.right
-  · rw [Finset.prod_insert hj]
-    have hbr : IsRightRegular (f j) := h _ (t.mem_insert_self j)
-    exact hbr.mul (ht fun a ha ↦ h a (Finset.mem_insert_of_mem ha))
+    IsRightRegular (∏ i in s, f i) :=
+  s.prod_induction _ _ (@IsRightRegular.mul R _) isRegular_one.right h
 
 lemma IsRegular.prod (h : ∀ i ∈ s, IsRegular (f i)) :
     IsRegular (∏ i in s, f i) :=

--- a/Mathlib/Data/MvPolynomial/Basic.lean
+++ b/Mathlib/Data/MvPolynomial/Basic.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Johan Commelin, Mario Carneiro
 -/
 import Mathlib.Algebra.Algebra.Tower
+import Mathlib.Algebra.Regular.Pow
 import Mathlib.Algebra.MonoidAlgebra.Support
 import Mathlib.Data.Finsupp.Antidiagonal
 import Mathlib.Order.SymmDiff
@@ -844,6 +845,19 @@ theorem C_dvd_iff_dvd_coeff (r : R) (φ : MvPolynomial σ R) : C r ∣ φ ↔ �
       · rw [not_mem_support_iff] at hi
         rwa [MulZeroClass.mul_zero]
 #align mv_polynomial.C_dvd_iff_dvd_coeff MvPolynomial.C_dvd_iff_dvd_coeff
+
+@[simp] lemma isRegular_X : IsRegular (X n : MvPolynomial σ R) := by
+  suffices : IsLeftRegular (X n : MvPolynomial σ R)
+  · exact ⟨this, this.right_of_commute $ Commute.all _⟩
+  intro P Q (hPQ : (X n) * P = (X n) * Q)
+  ext i
+  rw [← coeff_X_mul i n P, hPQ, coeff_X_mul i n Q]
+
+@[simp] lemma isRegular_X_pow (k : ℕ) : IsRegular (X n ^ k : MvPolynomial σ R) := isRegular_X.pow k
+
+@[simp] lemma isRegular_prod_X (s : Finset σ) :
+    IsRegular (∏ n in s, X n : MvPolynomial σ R) :=
+  IsRegular.prod fun _ _ ↦ isRegular_X
 
 end Coeff
 


### PR DESCRIPTION
The goal (which is achieved) is to make things like this work:
```lean
example {s : Finset σ} {n : σ} {k : ℕ} {p : MvPolynomial σ R} :
    p * (∏ n in s, X n) * X n ^ k = 0 ↔ p = 0 := by
  simp
```

---

We may (or may not) wish to rename the file `Algebra.Regular.Pow`.

Intended to help with #6139

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
