### PR TITLE
[Merged by Bors] - feat: weaken assumptions on Polynomial.map lemmas

### DIFF
--- a/Mathlib/Data/Polynomial/FieldDivision.lean
+++ b/Mathlib/Data/Polynomial/FieldDivision.lean
@@ -143,6 +143,26 @@ theorem map_ne_zero [Semiring S] [Nontrivial S] {f : R →+* S} (hp : p ≠ 0) :
   mt (map_eq_zero f).1 hp
 #align polynomial.map_ne_zero Polynomial.map_ne_zero
 
+@[simp]
+theorem degree_map [Semiring S] [Nontrivial S] (p : R[X]) (f : R →+* S) : degree (p.map f) = degree p :=
+  p.degree_map_eq_of_injective f.injective
+#align polynomial.degree_map Polynomial.degree_map
+
+@[simp]
+theorem natDegree_map [Semiring S] [Nontrivial S] (f : R →+* S) : natDegree (p.map f) = natDegree p :=
+  natDegree_eq_of_degree_eq (degree_map _ f)
+#align polynomial.nat_degree_map Polynomial.natDegree_map
+
+@[simp]
+theorem leadingCoeff_map [Semiring S] [Nontrivial S] (f : R →+* S) :
+    leadingCoeff (p.map f) = f (leadingCoeff p) := by
+  simp only [← coeff_natDegree, coeff_map f, natDegree_map]
+#align polynomial.leading_coeff_map Polynomial.leadingCoeff_map
+
+theorem monic_map_iff [Semiring S] [Nontrivial S] {f : R →+* S} {p : R[X]} : (p.map f).Monic ↔ p.Monic := by
+  rw [Monic, leadingCoeff_map, ← f.map_one, Function.Injective.eq_iff f.injective, Monic]
+#align polynomial.monic_map_iff Polynomial.monic_map_iff
+
 end DivisionRing
 
 section Field
@@ -271,26 +291,6 @@ theorem degree_div_lt (hp : p ≠ 0) (hq : 0 < degree q) : degree (p / q) < degr
       degree_divByMonic_lt _ (monic_mul_leadingCoeff_inv hq0) hp
         (by rw [degree_mul_leadingCoeff_inv _ hq0]; exact hq)
 #align polynomial.degree_div_lt Polynomial.degree_div_lt
-
-@[simp]
-theorem degree_map [DivisionRing k] (p : R[X]) (f : R →+* k) : degree (p.map f) = degree p :=
-  p.degree_map_eq_of_injective f.injective
-#align polynomial.degree_map Polynomial.degree_map
-
-@[simp]
-theorem natDegree_map [DivisionRing k] (f : R →+* k) : natDegree (p.map f) = natDegree p :=
-  natDegree_eq_of_degree_eq (degree_map _ f)
-#align polynomial.nat_degree_map Polynomial.natDegree_map
-
-@[simp]
-theorem leadingCoeff_map [DivisionRing k] (f : R →+* k) :
-    leadingCoeff (p.map f) = f (leadingCoeff p) := by
-  simp only [← coeff_natDegree, coeff_map f, natDegree_map]
-#align polynomial.leading_coeff_map Polynomial.leadingCoeff_map
-
-theorem monic_map_iff [DivisionRing k] {f : R →+* k} {p : R[X]} : (p.map f).Monic ↔ p.Monic := by
-  rw [Monic, leadingCoeff_map, ← f.map_one, Function.Injective.eq_iff f.injective, Monic]
-#align polynomial.monic_map_iff Polynomial.monic_map_iff
 
 theorem isUnit_map [Field k] (f : R →+* k) : IsUnit (p.map f) ↔ IsUnit p := by
   simp_rw [isUnit_iff_degree_eq_zero, degree_map]

--- a/Mathlib/Data/Polynomial/FieldDivision.lean
+++ b/Mathlib/Data/Polynomial/FieldDivision.lean
@@ -144,12 +144,14 @@ theorem map_ne_zero [Semiring S] [Nontrivial S] {f : R →+* S} (hp : p ≠ 0) :
 #align polynomial.map_ne_zero Polynomial.map_ne_zero
 
 @[simp]
-theorem degree_map [Semiring S] [Nontrivial S] (p : R[X]) (f : R →+* S) : degree (p.map f) = degree p :=
+theorem degree_map [Semiring S] [Nontrivial S] (p : R[X]) (f : R →+* S) :
+    degree (p.map f) = degree p :=
   p.degree_map_eq_of_injective f.injective
 #align polynomial.degree_map Polynomial.degree_map
 
 @[simp]
-theorem natDegree_map [Semiring S] [Nontrivial S] (f : R →+* S) : natDegree (p.map f) = natDegree p :=
+theorem natDegree_map [Semiring S] [Nontrivial S] (f : R →+* S) :
+    natDegree (p.map f) = natDegree p :=
   natDegree_eq_of_degree_eq (degree_map _ f)
 #align polynomial.nat_degree_map Polynomial.natDegree_map
 
@@ -159,7 +161,8 @@ theorem leadingCoeff_map [Semiring S] [Nontrivial S] (f : R →+* S) :
   simp only [← coeff_natDegree, coeff_map f, natDegree_map]
 #align polynomial.leading_coeff_map Polynomial.leadingCoeff_map
 
-theorem monic_map_iff [Semiring S] [Nontrivial S] {f : R →+* S} {p : R[X]} : (p.map f).Monic ↔ p.Monic := by
+theorem monic_map_iff [Semiring S] [Nontrivial S] {f : R →+* S} {p : R[X]} :
+    (p.map f).Monic ↔ p.Monic := by
   rw [Monic, leadingCoeff_map, ← f.map_one, Function.Injective.eq_iff f.injective, Monic]
 #align polynomial.monic_map_iff Polynomial.monic_map_iff
 


### PR DESCRIPTION
The assumptions on these lemmas seem to be too strong - `R` does not need to be a field, only a division ring, and `S` does not need to be a division ring, only a nontrivial semiring.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
