### PR TITLE
[Merged by Bors] - fix(LinearAlgebra/Dimension): make LinearMap.rank an abbrev

### DIFF
--- a/Mathlib/LinearAlgebra/Dimension.lean
+++ b/Mathlib/LinearAlgebra/Dimension.lean
@@ -1318,7 +1318,7 @@ variable [Ring K] [AddCommGroup V] [Module K V] [AddCommGroup V₁] [Module K V�
 variable [AddCommGroup V'] [Module K V']
 
 /-- `rank f` is the rank of a `LinearMap` `f`, defined as the dimension of `f.range`. -/
-def rank (f : V →ₗ[K] V') : Cardinal :=
+abbrev rank (f : V →ₗ[K] V') : Cardinal :=
   Module.rank K (LinearMap.range f)
 #align linear_map.rank LinearMap.rank
 


### PR DESCRIPTION
Previously, a statement like:

```lean
import Mathlib.LinearAlgebra.Dimension
import Mathlib.Tactic

variable {K : Type} [Field K]
variable {V W : Type} [AddCommGroup V] [AddCommGroup W] [Module K V] [Module K W]
variable {L : V →ₗ[K] W}

open LinearMap (ker)
open Module (rank)

example : rank K V = L.rank + rank K (ker L) := by
    sorry
```

required rewriting `LinearMap.rank` before manually finding the existence of `rank_range_add_rank_ker`.

After this change though, `exact?` successfully finds the lemma / solves the above.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
