### PR TITLE
feat: make VSCode search exclude .ilean files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,4 +7,7 @@
   "files.insertFinalNewline": true,
   "files.trimFinalNewlines": true,
   "files.trimTrailingWhitespace": true,
+  "search.exclude": {
+    "**/*.ilean": true
+  }
 }


### PR DESCRIPTION
Not sure if there is a special procedure or reasoning behind changes to `.vscode/settings.json`, but should we exclude `.ilean` files from VSCode search? It seems to me I almost never want to look at these files, yet they often come up when searching.

Maybe another way this could be done is to exclude `build/**` from search entirely?

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
