### PR TITLE
[Merged by Bors] - feat: push-forwards of finite measures and probability measures

### DIFF
--- a/Mathlib/MeasureTheory/Measure/FiniteMeasure.lean
+++ b/Mathlib/MeasureTheory/Measure/FiniteMeasure.lean
@@ -22,11 +22,16 @@ measure is continuous.
 ## Main definitions
 
 The main definitions are
- * the type `MeasureTheory.FiniteMeasure Ω` with the topology of weak convergence;
- * `MeasureTheory.FiniteMeasure.toWeakDualBCNN : FiniteMeasure Ω → (WeakDual ℝ≥0 (Ω →ᵇ ℝ≥0))`
-   allowing to interpret a finite measure as a continuous linear functional on the space of
+ * `MeasureTheory.FiniteMeasure Ω`: The type of finite measures on `Ω` with the topology of weak
+   convergence of measures.
+ * `MeasureTheory.FiniteMeasure.toWeakDualBCNN : FiniteMeasure Ω → (WeakDual ℝ≥0 (Ω →ᵇ ℝ≥0))`:
+   Interpret a finite measure as a continuous linear functional on the space of
    bounded continuous nonnegative functions on `Ω`. This is used for the definition of the
    topology of weak convergence.
+ * `MeasureTheory.FiniteMeasure.map`: The push-forward `f* μ` of a finite measure `μ` on `Ω`
+   along a measurable function `f : Ω → Ω'`.
+ * `MeasureTheory.FiniteMeasure.mapClm`: The push-forward along a given continuous `f : Ω → Ω'`
+   as a continuous linear map `f* : FiniteMeasure Ω →L[ℝ≥0] FiniteMeasure Ω'`.
 
 ## Main results
 
@@ -39,6 +44,8 @@ The main definitions are
    of weak convergence of measures. A similar characterization by the convergence of integrals (in
    the `MeasureTheory.lintegral` sense) of all bounded continuous nonnegative functions is
    `MeasureTheory.FiniteMeasure.tendsto_iff_forall_lintegral_tendsto`.
+ * `MeasureTheory.FiniteMeasure.continuous_map`: For a continuous function `f : Ω → Ω'`, the
+   push-forward of finite measures `f* : FiniteMeasure Ω → FiniteMeasure Ω'` is continuous.
 
 ## Implementation notes
 
@@ -796,19 +803,19 @@ lemma map_apply_of_aemeasurable (ν : FiniteMeasure Ω) {f : Ω → Ω'} (f_aemb
   map_apply_of_aemeasurable ν f_mble.aemeasurable A_mble
 
 @[simp] lemma map_add {f : Ω → Ω'} (f_mble : Measurable f) (ν₁ ν₂ : FiniteMeasure Ω)  :
-    FiniteMeasure.map (ν₁ + ν₂) f = FiniteMeasure.map ν₁ f + FiniteMeasure.map ν₂ f := by
+    (ν₁ + ν₂).map f = ν₁.map f + ν₂.map f := by
   ext s s_mble
   simp [map_apply' _ f_mble.aemeasurable s_mble, toMeasure_add]
 
 @[simp] lemma map_smul {f : Ω → Ω'} (f_mble : Measurable f) (c : ℝ≥0) (ν : FiniteMeasure Ω)  :
-    FiniteMeasure.map (c • ν) f = c • FiniteMeasure.map ν f := by
+    (c • ν).map f = c • (ν.map f) := by
   ext s s_mble
   simp [map_apply' _ f_mble.aemeasurable s_mble, toMeasure_smul]
 
 /-- The push-forward of a finite measure by a function between measurable spaces as a linear map. -/
 noncomputable def mapHom {f : Ω → Ω'} (f_mble : Measurable f) :
     FiniteMeasure Ω →ₗ[ℝ≥0] FiniteMeasure Ω' where
-  toFun := fun ν ↦ FiniteMeasure.map ν f
+  toFun := fun ν ↦ ν.map f
   map_add' := map_add f_mble
   map_smul' := map_smul f_mble
 

--- a/Mathlib/MeasureTheory/Measure/FiniteMeasure.lean
+++ b/Mathlib/MeasureTheory/Measure/FiniteMeasure.lean
@@ -805,7 +805,6 @@ lemma map_apply_of_aemeasurable (ν : FiniteMeasure Ω) {f : Ω → Ω'} (f_aemb
   ext s s_mble
   simp [map_apply' _ f_mble.aemeasurable s_mble, toMeasure_smul]
 
--- Q: Naming?
 /-- The push-forward of a finite measure by a function between measurable spaces as a linear map. -/
 noncomputable def mapHom {f : Ω → Ω'} (f_mble : Measurable f) :
     FiniteMeasure Ω →ₗ[ℝ≥0] FiniteMeasure Ω' where

--- a/Mathlib/MeasureTheory/Measure/FiniteMeasure.lean
+++ b/Mathlib/MeasureTheory/Measure/FiniteMeasure.lean
@@ -771,29 +771,28 @@ variable {Ω Ω' : Type _} [MeasurableSpace Ω] [MeasurableSpace Ω']
 /-- The push-forward of a finite measure by a function between measurable spaces. -/
 noncomputable def map (ν : FiniteMeasure Ω) (f : Ω → Ω') : FiniteMeasure Ω' :=
   ⟨(ν : Measure Ω).map f, by
-    refine ⟨?_⟩
+    constructor
     by_cases f_aemble : AEMeasurable f ν
     · rw [Measure.map_apply_of_aemeasurable f_aemble MeasurableSet.univ]
       exact measure_lt_top (↑ν) (f ⁻¹' univ)
     · simp [Measure.map, f_aemble]⟩
 
---#check Subtype.map
--- Q: Can I tell Lean not to use `Subtype.map` but instead `FiniteMeasure.map`
--- when `ν.map` is written?
+/-- Note that this is an equality of elements of `ℝ≥0∞`. See also
+`MeasureTheory.FiniteMeasure.map_apply` for the corresponding equality as elements of `ℝ≥0`. -/
 lemma map_apply' (ν : FiniteMeasure Ω) {f : Ω → Ω'} (f_aemble : AEMeasurable f ν)
     {A : Set Ω'} (A_mble : MeasurableSet A) :
-    (FiniteMeasure.map ν f : Measure Ω') A = (ν : Measure Ω) (f ⁻¹' A) :=
+    (ν.map f : Measure Ω') A = (ν : Measure Ω) (f ⁻¹' A) :=
   Measure.map_apply_of_aemeasurable f_aemble A_mble
 
 lemma map_apply_of_aemeasurable (ν : FiniteMeasure Ω) {f : Ω → Ω'} (f_aemble : AEMeasurable f ν)
     {A : Set Ω'} (A_mble : MeasurableSet A) :
-    (FiniteMeasure.map ν f) A = ν (f ⁻¹' A) := by
-  have key := FiniteMeasure.map_apply' ν f_aemble A_mble
-  exact (ENNReal.toNNReal_eq_toNNReal_iff' (measure_ne_top _ _) (measure_ne_top _ _)).mpr key
+    ν.map f A = ν (f ⁻¹' A) := by
+  have := ν.map_apply' f_aemble A_mble
+  exact (ENNReal.toNNReal_eq_toNNReal_iff' (measure_ne_top _ _) (measure_ne_top _ _)).mpr this
 
 @[simp] lemma map_apply (ν : FiniteMeasure Ω) {f : Ω → Ω'} (f_mble : Measurable f)
     {A : Set Ω'} (A_mble : MeasurableSet A) :
-    (FiniteMeasure.map ν f) A = ν (f ⁻¹' A) :=
+    ν.map f A = ν (f ⁻¹' A) :=
   map_apply_of_aemeasurable ν f_mble.aemeasurable A_mble
 
 @[simp] lemma map_add {f : Ω → Ω'} (f_mble : Measurable f) (ν₁ ν₂ : FiniteMeasure Ω)  :
@@ -820,14 +819,14 @@ variable [TopologicalSpace Ω'] [BorelSpace Ω']
 /-- If `f : X → Y` is continuous and `Y` is equipped with the Borel sigma algebra, then
 (weak) convergence of `FiniteMeasure`s on `X` implies (weak) convergence of the push-forwards
 of these measures by `f`. -/
-lemma tendsto_map_of_tendsto_of_continuous {L : Filter ι}
+lemma tendsto_map_of_tendsto_of_continuous {ι : Type*} {L : Filter ι}
     (νs : ι → FiniteMeasure Ω) (ν : FiniteMeasure Ω) (lim : Tendsto νs L (𝓝 ν))
     {f : Ω → Ω'} (f_cont : Continuous f) :
-    Tendsto (fun i ↦ FiniteMeasure.map (νs i) f) L (𝓝 (FiniteMeasure.map ν f)) := by
+    Tendsto (fun i ↦ (νs i).map f) L (𝓝 (ν.map f)) := by
   rw [FiniteMeasure.tendsto_iff_forall_lintegral_tendsto] at lim ⊢
   intro g
   convert lim (g.compContinuous ⟨f, f_cont⟩) <;>
-  · simp [FiniteMeasure.map]
+  · simp only [map, compContinuous_apply, ContinuousMap.coe_mk]
     refine lintegral_map ?_ f_cont.measurable
     exact (ENNReal.continuous_coe.comp g.continuous).measurable
 
@@ -839,12 +838,11 @@ lemma continuous_map {f : Ω → Ω'} (f_cont : Continuous f) :
   rw [continuous_iff_continuousAt]
   exact fun _ ↦ tendsto_map_of_tendsto_of_continuous _ _ continuous_id.continuousAt f_cont
 
--- Q: Naming?
 /-- The push-forward of a finite measure by a continuous function between Borel spaces as
 a continuous linear map. -/
-noncomputable def mapCLM {f : Ω → Ω'} (f_cont : Continuous f) :
+noncomputable def mapClm {f : Ω → Ω'} (f_cont : Continuous f) :
     FiniteMeasure Ω →L[ℝ≥0] FiniteMeasure Ω' where
-  toFun := fun ν ↦ FiniteMeasure.map ν f
+  toFun := fun ν ↦ ν.map f
   map_add' := map_add f_cont.measurable
   map_smul' := map_smul f_cont.measurable
   cont := continuous_map f_cont

--- a/Mathlib/MeasureTheory/Measure/FiniteMeasure.lean
+++ b/Mathlib/MeasureTheory/Measure/FiniteMeasure.lean
@@ -762,12 +762,64 @@ theorem tendsto_iff_forall_integral_tendsto {γ : Type*} {F : Filter γ} {μs : 
   exact Tendsto.sub tends_pos tends_neg
 #align measure_theory.finite_measure.tendsto_iff_forall_integral_tendsto MeasureTheory.FiniteMeasure.tendsto_iff_forall_integral_tendsto
 
-end FiniteMeasureConvergenceByBoundedContinuousFunctions
+end FiniteMeasureConvergenceByBoundedContinuousFunctions -- section
 
--- section
-end FiniteMeasure
+section map
 
--- namespace
-end MeasureTheory
+variable {Ω Ω' : Type _} [MeasurableSpace Ω] [MeasurableSpace Ω']
 
--- namespace
+/-- The push-forward of a finite measure by a function between measurable spaces. -/
+noncomputable def map (ν : FiniteMeasure Ω) (f : Ω → Ω') : FiniteMeasure Ω' :=
+  ⟨(ν : Measure Ω).map f, by
+    refine ⟨?_⟩
+    by_cases f_mble : AEMeasurable f ν
+    · by_cases f_mble' : Measurable f
+      · simp [Measure.map_apply f_mble' MeasurableSet.univ, IsFiniteMeasure.measure_univ_lt_top]
+      · sorry -- Corner case: f not measurable but a.e.-measurable...
+    · simp [Measure.map, f_mble]⟩
+
+--#check Subtype.map
+-- Q: Can I tell Lean not to use `Subtype.map` in place of `FiniteMeasure.map`?
+lemma map_apply' (ν : FiniteMeasure Ω) {f : Ω → Ω'} (f_mble : Measurable f)
+    {A : Set Ω'} (A_mble : MeasurableSet A) :
+    (FiniteMeasure.map ν f : Measure Ω') A = (ν : Measure Ω) (f ⁻¹' A) := by
+  exact Measure.map_apply (μ := ν) f_mble A_mble
+
+-- Q: Can I tell Lean not to use `Subtype.map` in place of `FiniteMeasure.map`?
+--    ...and `Subtype.map` in place of `FiniteMeasure.map`?
+lemma map_apply (ν : FiniteMeasure Ω) {f : Ω → Ω'} (f_mble : Measurable f)
+    {A : Set Ω'} (A_mble : MeasurableSet A) :
+    (FiniteMeasure.map ν f) A = ν (f ⁻¹' A) := by
+  have key := FiniteMeasure.map_apply' ν f_mble A_mble
+  exact (ENNReal.toNNReal_eq_toNNReal_iff' (measure_ne_top _ _) (measure_ne_top _ _)).mpr key
+
+variable [TopologicalSpace Ω] [OpensMeasurableSpace Ω]
+variable [TopologicalSpace Ω'] [BorelSpace Ω']
+
+/-- If `f : X → Y` is continuous and `Y` is equipped with the Borel sigma algebra, then
+(weak) convergence of `FiniteMeasure`s on `X` implies (weak) convergence of the push-forwards
+of these measures by `f`. -/
+lemma tendsto_map_of_tendsto_of_continuous {L : Filter ι}
+    (νs : ι → FiniteMeasure Ω) (ν : FiniteMeasure Ω) (lim : Tendsto νs L (𝓝 ν))
+    {f : Ω → Ω'} (f_cont : Continuous f) :
+    Tendsto (fun i ↦ FiniteMeasure.map (νs i) f) L (𝓝 (FiniteMeasure.map ν f)) := by
+  rw [FiniteMeasure.tendsto_iff_forall_lintegral_tendsto] at lim ⊢
+  intro g
+  convert lim (g.compContinuous ⟨f, f_cont⟩) <;>
+  · simp [FiniteMeasure.map]
+    refine lintegral_map ?_ f_cont.measurable
+    exact (ENNReal.continuous_coe.comp g.continuous).measurable
+
+/-- If `f : X → Y` is continuous and `Y` is equipped with the Borel sigma algebra, then
+the push-forward of finite measures `f* : FiniteMeasure X → FiniteMeasure Y` is continuous
+(in the topologies of weak convergence of measures). -/
+lemma continuous_map {f : Ω → Ω'} (f_cont : Continuous f) :
+    Continuous (fun ν ↦ FiniteMeasure.map ν f) := by
+  rw [continuous_iff_continuousAt]
+  exact fun _ ↦ tendsto_map_of_tendsto_of_continuous _ _ continuous_id.continuousAt f_cont
+
+end map -- section
+
+end FiniteMeasure -- namespace
+
+end MeasureTheory -- namespace

--- a/Mathlib/MeasureTheory/Measure/FiniteMeasure.lean
+++ b/Mathlib/MeasureTheory/Measure/FiniteMeasure.lean
@@ -778,20 +778,19 @@ noncomputable def map (ν : FiniteMeasure Ω) (f : Ω → Ω') : FiniteMeasure �
     · simp [Measure.map, f_aemble]⟩
 
 --#check Subtype.map
--- Q: Can I tell Lean not to use `Subtype.map` in place of `FiniteMeasure.map`?
+-- Q: Can I tell Lean not to use `Subtype.map` but instead `FiniteMeasure.map`
+-- when `ν.map` is written?
 lemma map_apply' (ν : FiniteMeasure Ω) {f : Ω → Ω'} (f_aemble : AEMeasurable f ν)
     {A : Set Ω'} (A_mble : MeasurableSet A) :
     (FiniteMeasure.map ν f : Measure Ω') A = (ν : Measure Ω) (f ⁻¹' A) :=
   Measure.map_apply_of_aemeasurable f_aemble A_mble
 
--- Q: Can I tell Lean not to use `Subtype.map` in place of `FiniteMeasure.map`?
 lemma map_apply_of_aemeasurable (ν : FiniteMeasure Ω) {f : Ω → Ω'} (f_aemble : AEMeasurable f ν)
     {A : Set Ω'} (A_mble : MeasurableSet A) :
     (FiniteMeasure.map ν f) A = ν (f ⁻¹' A) := by
   have key := FiniteMeasure.map_apply' ν f_aemble A_mble
   exact (ENNReal.toNNReal_eq_toNNReal_iff' (measure_ne_top _ _) (measure_ne_top _ _)).mpr key
 
--- Q: Can I tell Lean not to use `Subtype.map` in place of `FiniteMeasure.map`?
 @[simp] lemma map_apply (ν : FiniteMeasure Ω) {f : Ω → Ω'} (f_mble : Measurable f)
     {A : Set Ω'} (A_mble : MeasurableSet A) :
     (FiniteMeasure.map ν f) A = ν (f ⁻¹' A) :=
@@ -807,6 +806,7 @@ lemma map_apply_of_aemeasurable (ν : FiniteMeasure Ω) {f : Ω → Ω'} (f_aemb
   ext s s_mble
   simp [map_apply' _ f_mble.aemeasurable s_mble, toMeasure_smul]
 
+-- Q: Naming?
 /-- The push-forward of a finite measure by a function between measurable spaces as a linear map. -/
 noncomputable def mapHom {f : Ω → Ω'} (f_mble : Measurable f) :
     FiniteMeasure Ω →ₗ[ℝ≥0] FiniteMeasure Ω' where
@@ -839,6 +839,7 @@ lemma continuous_map {f : Ω → Ω'} (f_cont : Continuous f) :
   rw [continuous_iff_continuousAt]
   exact fun _ ↦ tendsto_map_of_tendsto_of_continuous _ _ continuous_id.continuousAt f_cont
 
+-- Q: Naming?
 /-- The push-forward of a finite measure by a continuous function between Borel spaces as
 a continuous linear map. -/
 noncomputable def mapCLM {f : Ω → Ω'} (f_cont : Continuous f) :

--- a/Mathlib/MeasureTheory/Measure/ProbabilityMeasure.lean
+++ b/Mathlib/MeasureTheory/Measure/ProbabilityMeasure.lean
@@ -28,6 +28,8 @@ The main definitions are
    a finite measure;
  * `MeasureTheory.FiniteMeasure.normalize`: Normalize a finite measure to a probability measure
    (returns junk for the zero measure).
+ * `MeasureTheory.ProbabilityMeasure.map`: The push-forward `f* μ` of a probability measure
+   `μ` on `Ω` along a measurable function `f : Ω → Ω'`.
 
 ## Main results
 
@@ -41,6 +43,9 @@ The main definitions are
  * `MeasureTheory.FiniteMeasure.tendsto_normalize_iff_tendsto`: The convergence of finite
    measures to a nonzero limit is characterized by the convergence of the probability-normalized
    versions and of the total masses.
+ * `MeasureTheory.ProbabilityMeasure.continuous_map`: For a continuous function `f : Ω → Ω'`, the
+   push-forward of probability measures `f* : ProbabilityMeasure Ω → ProbabilityMeasure Ω'` is
+   continuous.
 
 TODO:
  * Probability measures form a convex space.
@@ -532,8 +537,8 @@ distribution) of the push-forwards of these measures by `f`. -/
 lemma tendsto_map_of_tendsto_of_continuous {ι : Type*} {L : Filter ι}
     (νs : ι → ProbabilityMeasure Ω) (ν : ProbabilityMeasure Ω) (lim : Tendsto νs L (𝓝 ν))
     {f : Ω → Ω'} (f_cont : Continuous f) :
-    Tendsto (fun i ↦ ProbabilityMeasure.map (νs i) f_cont.measurable.aemeasurable) L
-      (𝓝 (ProbabilityMeasure.map ν f_cont.measurable.aemeasurable)) := by
+    Tendsto (fun i ↦ (νs i).map f_cont.measurable.aemeasurable) L
+      (𝓝 (ν.map f_cont.measurable.aemeasurable)) := by
   rw [ProbabilityMeasure.tendsto_iff_forall_lintegral_tendsto] at lim ⊢
   intro g
   convert lim (g.compContinuous ⟨f, f_cont⟩) <;>

--- a/Mathlib/MeasureTheory/Measure/ProbabilityMeasure.lean
+++ b/Mathlib/MeasureTheory/Measure/ProbabilityMeasure.lean
@@ -505,23 +505,22 @@ noncomputable def map (ν : ProbabilityMeasure Ω) {f : Ω → Ω'} (f_aemble : 
    ⟨by simp only [Measure.map_apply_of_aemeasurable f_aemble MeasurableSet.univ,
                   preimage_univ, measure_univ]⟩⟩
 
---#check Subtype.map
--- Q: Can I tell Lean not to use `Subtype.map` but instead `ProbabilityMeasure.map`
--- when `ν.map` is written?
+/-- Note that this is an equality of elements of `ℝ≥0∞`. See also
+`MeasureTheory.ProbabilityMeasure.map_apply` for the corresponding equality as elements of `ℝ≥0`. -/
 lemma map_apply' (ν : ProbabilityMeasure Ω) {f : Ω → Ω'} (f_aemble : AEMeasurable f ν)
     {A : Set Ω'} (A_mble : MeasurableSet A) :
-    (ProbabilityMeasure.map ν f_aemble : Measure Ω') A = (ν : Measure Ω) (f ⁻¹' A) :=
+    (ν.map f_aemble : Measure Ω') A = (ν : Measure Ω) (f ⁻¹' A) :=
   Measure.map_apply_of_aemeasurable f_aemble A_mble
 
 lemma map_apply_of_aemeasurable (ν : ProbabilityMeasure Ω) {f : Ω → Ω'}
     (f_aemble : AEMeasurable f ν) {A : Set Ω'} (A_mble : MeasurableSet A) :
-    (ProbabilityMeasure.map ν f_aemble) A = ν (f ⁻¹' A) := by
-  have key := ProbabilityMeasure.map_apply' ν f_aemble A_mble
-  exact (ENNReal.toNNReal_eq_toNNReal_iff' (measure_ne_top _ _) (measure_ne_top _ _)).mpr key
+    (ν.map f_aemble) A = ν (f ⁻¹' A) := by
+  have := ν.map_apply' f_aemble A_mble
+  exact (ENNReal.toNNReal_eq_toNNReal_iff' (measure_ne_top _ _) (measure_ne_top _ _)).mpr this
 
 @[simp] lemma map_apply (ν : ProbabilityMeasure Ω) {f : Ω → Ω'} (f_aemble : AEMeasurable f ν)
     {A : Set Ω'} (A_mble : MeasurableSet A) :
-    (ProbabilityMeasure.map ν f_aemble) A = ν (f ⁻¹' A) :=
+    (ν.map f_aemble) A = ν (f ⁻¹' A) :=
   map_apply_of_aemeasurable ν f_aemble A_mble
 
 variable [TopologicalSpace Ω] [OpensMeasurableSpace Ω]
@@ -530,7 +529,7 @@ variable [TopologicalSpace Ω'] [BorelSpace Ω']
 /-- If `f : X → Y` is continuous and `Y` is equipped with the Borel sigma algebra, then
 convergence (in distribution) of `ProbabilityMeasure`s on `X` implies convergence (in
 distribution) of the push-forwards of these measures by `f`. -/
-lemma tendsto_map_of_tendsto_of_continuous {L : Filter ι}
+lemma tendsto_map_of_tendsto_of_continuous {ι : Type*} {L : Filter ι}
     (νs : ι → ProbabilityMeasure Ω) (ν : ProbabilityMeasure Ω) (lim : Tendsto νs L (𝓝 ν))
     {f : Ω → Ω'} (f_cont : Continuous f) :
     Tendsto (fun i ↦ ProbabilityMeasure.map (νs i) f_cont.measurable.aemeasurable) L
@@ -538,7 +537,7 @@ lemma tendsto_map_of_tendsto_of_continuous {L : Filter ι}
   rw [ProbabilityMeasure.tendsto_iff_forall_lintegral_tendsto] at lim ⊢
   intro g
   convert lim (g.compContinuous ⟨f, f_cont⟩) <;>
-  · simp [ProbabilityMeasure.map]
+  · simp only [map, compContinuous_apply, ContinuousMap.coe_mk]
     refine lintegral_map ?_ f_cont.measurable
     exact (ENNReal.continuous_coe.comp g.continuous).measurable
 

--- a/Mathlib/MeasureTheory/Measure/ProbabilityMeasure.lean
+++ b/Mathlib/MeasureTheory/Measure/ProbabilityMeasure.lean
@@ -499,7 +499,7 @@ variable {Ω Ω' : Type _} [MeasurableSpace Ω] [MeasurableSpace Ω']
 namespace ProbabilityMeasure
 
 /-- The push-forward of a probability measure by a measurable function. -/
-noncomputable def map (ν : ProbabilityMeasure Ω) {f : Ω → Ω'} (f_aemble : AEMeasurable f) :
+noncomputable def map (ν : ProbabilityMeasure Ω) {f : Ω → Ω'} (f_aemble : AEMeasurable f ν) :
     ProbabilityMeasure Ω' :=
   ⟨(ν : Measure Ω).map f,
    ⟨by simp only [Measure.map_apply_of_aemeasurable f_aemble MeasurableSet.univ,
@@ -509,21 +509,21 @@ noncomputable def map (ν : ProbabilityMeasure Ω) {f : Ω → Ω'} (f_aemble : 
 -- Q: Can I tell Lean not to use `Subtype.map` in place of `ProbabilityMeasure.map`?
 lemma map_apply' (ν : ProbabilityMeasure Ω) {f : Ω → Ω'} (f_aemble : AEMeasurable f ν)
     {A : Set Ω'} (A_mble : MeasurableSet A) :
-    (ProbabilityMeasure.map ν f : Measure Ω') A = (ν : Measure Ω) (f ⁻¹' A) :=
+    (ProbabilityMeasure.map ν f_aemble : Measure Ω') A = (ν : Measure Ω) (f ⁻¹' A) :=
   Measure.map_apply_of_aemeasurable f_aemble A_mble
 
 -- Q: Can I tell Lean not to use `Subtype.map` in place of `ProbabilityMeasure.map`?
 lemma map_apply_of_aemeasurable (ν : ProbabilityMeasure Ω) {f : Ω → Ω'}
     (f_aemble : AEMeasurable f ν) {A : Set Ω'} (A_mble : MeasurableSet A) :
-    (ProbabilityMeasure.map ν f) A = ν (f ⁻¹' A) := by
+    (ProbabilityMeasure.map ν f_aemble) A = ν (f ⁻¹' A) := by
   have key := ProbabilityMeasure.map_apply' ν f_aemble A_mble
   exact (ENNReal.toNNReal_eq_toNNReal_iff' (measure_ne_top _ _) (measure_ne_top _ _)).mpr key
 
 -- Q: Can I tell Lean not to use `Subtype.map` in place of `ProbabilityMeasure.map`?
-@[simp] lemma map_apply (ν : ProbabilityMeasure Ω) {f : Ω → Ω'} (f_mble : Measurable f)
+@[simp] lemma map_apply (ν : ProbabilityMeasure Ω) {f : Ω → Ω'} (f_aemble : AEMeasurable f ν)
     {A : Set Ω'} (A_mble : MeasurableSet A) :
-    (FiniteMeasure.map ν f) A = ν (f ⁻¹' A) :=
-  map_apply_of_aemeasurable ν f_mble.aemeasurable A_mble
+    (ProbabilityMeasure.map ν f_aemble) A = ν (f ⁻¹' A) :=
+  map_apply_of_aemeasurable ν f_aemble A_mble
 
 variable [TopologicalSpace Ω] [OpensMeasurableSpace Ω]
 variable [TopologicalSpace Ω'] [BorelSpace Ω']
@@ -534,8 +534,8 @@ distribution) of the push-forwards of these measures by `f`. -/
 lemma tendsto_map_of_tendsto_of_continuous {L : Filter ι}
     (νs : ι → ProbabilityMeasure Ω) (ν : ProbabilityMeasure Ω) (lim : Tendsto νs L (𝓝 ν))
     {f : Ω → Ω'} (f_cont : Continuous f) :
-    Tendsto (fun i ↦ ProbabilityMeasure.map (νs i) f_cont.measurable) L
-      (𝓝 (ProbabilityMeasure.map ν f_cont.measurable)) := by
+    Tendsto (fun i ↦ ProbabilityMeasure.map (νs i) f_cont.measurable.aemeasurable) L
+      (𝓝 (ProbabilityMeasure.map ν f_cont.measurable.aemeasurable)) := by
   rw [ProbabilityMeasure.tendsto_iff_forall_lintegral_tendsto] at lim ⊢
   intro g
   convert lim (g.compContinuous ⟨f, f_cont⟩) <;>
@@ -547,7 +547,7 @@ lemma tendsto_map_of_tendsto_of_continuous {L : Filter ι}
 the push-forward of probability measures `f* : ProbabilityMeasure X → ProbabilityMeasure Y`
 is continuous (in the topologies of convergence in distribution). -/
 lemma continuous_map {f : Ω → Ω'} (f_cont : Continuous f) :
-    Continuous (fun ν ↦ ProbabilityMeasure.map ν f_cont.measurable) := by
+    Continuous (fun ν ↦ ProbabilityMeasure.map ν f_cont.measurable.aemeasurable) := by
   rw [continuous_iff_continuousAt]
   exact fun _ ↦ tendsto_map_of_tendsto_of_continuous _ _ continuous_id.continuousAt f_cont
 

--- a/Mathlib/MeasureTheory/Measure/ProbabilityMeasure.lean
+++ b/Mathlib/MeasureTheory/Measure/ProbabilityMeasure.lean
@@ -488,10 +488,65 @@ theorem tendsto_normalize_iff_tendsto {γ : Type*} {F : Filter γ} {μs : γ →
     refine' ⟨tendsto_normalize_of_tendsto μs_lim nonzero, μs_lim.mass⟩
 #align measure_theory.finite_measure.tendsto_normalize_iff_tendsto MeasureTheory.FiniteMeasure.tendsto_normalize_iff_tendsto
 
-end FiniteMeasure
+end FiniteMeasure --namespace
 
---namespace
-end NormalizeFiniteMeasure
+end NormalizeFiniteMeasure -- section
 
--- section
-end MeasureTheory
+section map
+
+variable {Ω Ω' : Type _} [MeasurableSpace Ω] [MeasurableSpace Ω']
+
+namespace ProbabilityMeasure
+
+/-- The push-forward of a probability measure by a measurable function. -/
+noncomputable def map (ν : ProbabilityMeasure Ω) {f : Ω → Ω'} (f_mble : Measurable f) :
+    ProbabilityMeasure Ω' :=
+  ⟨(ν : Measure Ω).map f,
+   ⟨by simp only [Measure.map_apply f_mble MeasurableSet.univ, preimage_univ, measure_univ]⟩⟩
+
+--#check Subtype.map
+-- Q: Can I tell Lean not to use `Subtype.map` in place of `FiniteMeasure.map`?
+lemma map_apply' (ν : ProbabilityMeasure Ω) {f : Ω → Ω'} (f_mble : Measurable f)
+    {A : Set Ω'} (A_mble : MeasurableSet A) :
+    (ProbabilityMeasure.map ν f_mble : Measure Ω') A = (ν : Measure Ω) (f ⁻¹' A) := by
+  exact Measure.map_apply (μ := ν) f_mble A_mble
+
+-- Q: Can I tell Lean not to use `Subtype.map` in place of `FiniteMeasure.map`?
+--    ...and `Subtype.map` in place of `FiniteMeasure.map`?
+lemma map_apply (ν : ProbabilityMeasure Ω) {f : Ω → Ω'} (f_mble : Measurable f)
+    {A : Set Ω'} (A_mble : MeasurableSet A) :
+    (ProbabilityMeasure.map ν f_mble) A = ν (f ⁻¹' A) := by
+  have key := ProbabilityMeasure.map_apply' ν f_mble A_mble
+  exact (ENNReal.toNNReal_eq_toNNReal_iff' (measure_ne_top _ _) (measure_ne_top _ _)).mpr key
+
+variable [TopologicalSpace Ω] [OpensMeasurableSpace Ω]
+variable [TopologicalSpace Ω'] [BorelSpace Ω']
+
+/-- If `f : X → Y` is continuous and `Y` is equipped with the Borel sigma algebra, then
+convergence (in distribution) of `ProbabilityMeasure`s on `X` implies convergence (in
+distribution) of the push-forwards of these measures by `f`. -/
+lemma tendsto_map_of_tendsto_of_continuous {L : Filter ι}
+    (νs : ι → ProbabilityMeasure Ω) (ν : ProbabilityMeasure Ω) (lim : Tendsto νs L (𝓝 ν))
+    {f : Ω → Ω'} (f_cont : Continuous f) :
+    Tendsto (fun i ↦ ProbabilityMeasure.map (νs i) f_cont.measurable) L
+      (𝓝 (ProbabilityMeasure.map ν f_cont.measurable)) := by
+  rw [ProbabilityMeasure.tendsto_iff_forall_lintegral_tendsto] at lim ⊢
+  intro g
+  convert lim (g.compContinuous ⟨f, f_cont⟩) <;>
+  · simp [ProbabilityMeasure.map]
+    refine lintegral_map ?_ f_cont.measurable
+    exact (ENNReal.continuous_coe.comp g.continuous).measurable
+
+/-- If `f : X → Y` is continuous and `Y` is equipped with the Borel sigma algebra, then
+the push-forward of probability measures `f* : ProbabilityMeasure X → ProbabilityMeasure Y`
+is continuous (in the topologies of convergence in distribution). -/
+lemma continuous_map {f : Ω → Ω'} (f_cont : Continuous f) :
+    Continuous (fun ν ↦ ProbabilityMeasure.map ν f_cont.measurable) := by
+  rw [continuous_iff_continuousAt]
+  exact fun _ ↦ tendsto_map_of_tendsto_of_continuous _ _ continuous_id.continuousAt f_cont
+
+end ProbabilityMeasure -- namespace
+
+end map -- section
+
+end MeasureTheory -- namespace

--- a/Mathlib/MeasureTheory/Measure/ProbabilityMeasure.lean
+++ b/Mathlib/MeasureTheory/Measure/ProbabilityMeasure.lean
@@ -506,20 +506,19 @@ noncomputable def map (ν : ProbabilityMeasure Ω) {f : Ω → Ω'} (f_aemble : 
                   preimage_univ, measure_univ]⟩⟩
 
 --#check Subtype.map
--- Q: Can I tell Lean not to use `Subtype.map` in place of `ProbabilityMeasure.map`?
+-- Q: Can I tell Lean not to use `Subtype.map` but instead `ProbabilityMeasure.map`
+-- when `ν.map` is written?
 lemma map_apply' (ν : ProbabilityMeasure Ω) {f : Ω → Ω'} (f_aemble : AEMeasurable f ν)
     {A : Set Ω'} (A_mble : MeasurableSet A) :
     (ProbabilityMeasure.map ν f_aemble : Measure Ω') A = (ν : Measure Ω) (f ⁻¹' A) :=
   Measure.map_apply_of_aemeasurable f_aemble A_mble
 
--- Q: Can I tell Lean not to use `Subtype.map` in place of `ProbabilityMeasure.map`?
 lemma map_apply_of_aemeasurable (ν : ProbabilityMeasure Ω) {f : Ω → Ω'}
     (f_aemble : AEMeasurable f ν) {A : Set Ω'} (A_mble : MeasurableSet A) :
     (ProbabilityMeasure.map ν f_aemble) A = ν (f ⁻¹' A) := by
   have key := ProbabilityMeasure.map_apply' ν f_aemble A_mble
   exact (ENNReal.toNNReal_eq_toNNReal_iff' (measure_ne_top _ _) (measure_ne_top _ _)).mpr key
 
--- Q: Can I tell Lean not to use `Subtype.map` in place of `ProbabilityMeasure.map`?
 @[simp] lemma map_apply (ν : ProbabilityMeasure Ω) {f : Ω → Ω'} (f_aemble : AEMeasurable f ν)
     {A : Set Ω'} (A_mble : MeasurableSet A) :
     (ProbabilityMeasure.map ν f_aemble) A = ν (f ⁻¹' A) :=

--- a/Mathlib/MeasureTheory/Measure/ProbabilityMeasure.lean
+++ b/Mathlib/MeasureTheory/Measure/ProbabilityMeasure.lean
@@ -499,25 +499,31 @@ variable {Ω Ω' : Type _} [MeasurableSpace Ω] [MeasurableSpace Ω']
 namespace ProbabilityMeasure
 
 /-- The push-forward of a probability measure by a measurable function. -/
-noncomputable def map (ν : ProbabilityMeasure Ω) {f : Ω → Ω'} (f_mble : Measurable f) :
+noncomputable def map (ν : ProbabilityMeasure Ω) {f : Ω → Ω'} (f_aemble : AEMeasurable f) :
     ProbabilityMeasure Ω' :=
   ⟨(ν : Measure Ω).map f,
-   ⟨by simp only [Measure.map_apply f_mble MeasurableSet.univ, preimage_univ, measure_univ]⟩⟩
+   ⟨by simp only [Measure.map_apply_of_aemeasurable f_aemble MeasurableSet.univ,
+                  preimage_univ, measure_univ]⟩⟩
 
 --#check Subtype.map
--- Q: Can I tell Lean not to use `Subtype.map` in place of `FiniteMeasure.map`?
-lemma map_apply' (ν : ProbabilityMeasure Ω) {f : Ω → Ω'} (f_mble : Measurable f)
+-- Q: Can I tell Lean not to use `Subtype.map` in place of `ProbabilityMeasure.map`?
+lemma map_apply' (ν : ProbabilityMeasure Ω) {f : Ω → Ω'} (f_aemble : AEMeasurable f ν)
     {A : Set Ω'} (A_mble : MeasurableSet A) :
-    (ProbabilityMeasure.map ν f_mble : Measure Ω') A = (ν : Measure Ω) (f ⁻¹' A) := by
-  exact Measure.map_apply (μ := ν) f_mble A_mble
+    (ProbabilityMeasure.map ν f : Measure Ω') A = (ν : Measure Ω) (f ⁻¹' A) :=
+  Measure.map_apply_of_aemeasurable f_aemble A_mble
 
--- Q: Can I tell Lean not to use `Subtype.map` in place of `FiniteMeasure.map`?
---    ...and `Subtype.map` in place of `FiniteMeasure.map`?
-lemma map_apply (ν : ProbabilityMeasure Ω) {f : Ω → Ω'} (f_mble : Measurable f)
-    {A : Set Ω'} (A_mble : MeasurableSet A) :
-    (ProbabilityMeasure.map ν f_mble) A = ν (f ⁻¹' A) := by
-  have key := ProbabilityMeasure.map_apply' ν f_mble A_mble
+-- Q: Can I tell Lean not to use `Subtype.map` in place of `ProbabilityMeasure.map`?
+lemma map_apply_of_aemeasurable (ν : ProbabilityMeasure Ω) {f : Ω → Ω'}
+    (f_aemble : AEMeasurable f ν) {A : Set Ω'} (A_mble : MeasurableSet A) :
+    (ProbabilityMeasure.map ν f) A = ν (f ⁻¹' A) := by
+  have key := ProbabilityMeasure.map_apply' ν f_aemble A_mble
   exact (ENNReal.toNNReal_eq_toNNReal_iff' (measure_ne_top _ _) (measure_ne_top _ _)).mpr key
+
+-- Q: Can I tell Lean not to use `Subtype.map` in place of `ProbabilityMeasure.map`?
+@[simp] lemma map_apply (ν : ProbabilityMeasure Ω) {f : Ω → Ω'} (f_mble : Measurable f)
+    {A : Set Ω'} (A_mble : MeasurableSet A) :
+    (FiniteMeasure.map ν f) A = ν (f ⁻¹' A) :=
+  map_apply_of_aemeasurable ν f_mble.aemeasurable A_mble
 
 variable [TopologicalSpace Ω] [OpensMeasurableSpace Ω]
 variable [TopologicalSpace Ω'] [BorelSpace Ω']


### PR DESCRIPTION
Add push-forwards of finite measures and probability measures, and prove that push-forwards under continuous functions are continuous (w.r.t. the topologies of weak convergence of measures).

Besides being a natural addition to the API, this should enable simple proofs of, for example, continuity of some parametric distributions (multi-dimensional gaussians, exponential distribution, ...) with respect to their parameters.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
