### PR TITLE
[Merged by Bors] - chore: move all UniformSpace-related notations in scope Uniformity

### DIFF
--- a/Mathlib/Topology/UniformSpace/AbsoluteValue.lean
+++ b/Mathlib/Topology/UniformSpace/AbsoluteValue.lean
@@ -25,7 +25,7 @@ follows exactly the same path.
 absolute value, uniform spaces
 -/
 
-open Set Function Filter Topology
+open Set Function Filter Uniformity
 
 namespace AbsoluteValue
 

--- a/Mathlib/Topology/UniformSpace/Basic.lean
+++ b/Mathlib/Topology/UniformSpace/Basic.lean
@@ -356,7 +356,7 @@ def uniformity (α : Type u) [UniformSpace α] : Filter (α × α) :=
 
 set_option quotPrecheck false in
 /-- Notation for the uniformity filter with respect to a non-standard `UniformSpace` instance. -/
-scoped[Topology] notation "𝓤[" u "]" => @uniformity _ u
+scoped[Uniformity] notation "𝓤[" u "]" => @uniformity _ u
 
 @[ext]
 theorem uniformSpace_eq : ∀ {u₁ u₂ : UniformSpace α}, 𝓤[u₁] = 𝓤[u₂] → u₁ = u₂
@@ -1088,7 +1088,7 @@ def UniformContinuous [UniformSpace β] (f : α → β) :=
 
 set_option quotPrecheck false in
 /-- Notation for uniform continuity with respect to non-standard `UniformSpace` instances. -/
-scoped[Topology] notation "UniformContinuous[" u₁ ", " u₂ "]" => @UniformContinuous _ _ u₁ u₂
+scoped[Uniformity] notation "UniformContinuous[" u₁ ", " u₂ "]" => @UniformContinuous _ _ u₁ u₂
 
 /- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
 /-- A function `f : α → β` is *uniformly continuous* on `s : Set α` if `(f x, f y)` tends to


### PR DESCRIPTION
Currently we have [Uniformity.term𝓤](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Topology/UniformSpace/Basic.html#Uniformity.term%F0%9D%93%A4) but [Topology.«term𝓤[_]»](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Topology/UniformSpace/Basic.html#Topology.%C2%ABterm%F0%9D%93%A4[_]%C2%BB), which is really confusing.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
