### PR TITLE
[Merged by Bors] - feat(Tactic/MoveAdd): port `move_add`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3150,6 +3150,7 @@ import Mathlib.Tactic.Monotonicity
 import Mathlib.Tactic.Monotonicity.Attr
 import Mathlib.Tactic.Monotonicity.Basic
 import Mathlib.Tactic.Monotonicity.Lemmas
+import Mathlib.Tactic.MoveAdd
 import Mathlib.Tactic.NoncommRing
 import Mathlib.Tactic.Nontriviality
 import Mathlib.Tactic.Nontriviality.Core

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -89,6 +89,7 @@ import Mathlib.Tactic.Monotonicity
 import Mathlib.Tactic.Monotonicity.Attr
 import Mathlib.Tactic.Monotonicity.Basic
 import Mathlib.Tactic.Monotonicity.Lemmas
+import Mathlib.Tactic.MoveAdd
 import Mathlib.Tactic.NoncommRing
 import Mathlib.Tactic.Nontriviality
 import Mathlib.Tactic.Nontriviality.Core

--- a/Mathlib/Tactic/MoveAdd.lean
+++ b/Mathlib/Tactic/MoveAdd.lean
@@ -420,9 +420,9 @@ In this case the syntax requires providing first a term whose head symbol is the
 E.g. `move_oper (0 + 0) [...]` is the same as `move_add`, while `move_oper (max 0 0) [...]`
 rearranges `max`s.
 -/
-elab (name := moveOperTac) "move_oper" "(" oper:term ")" rws:rwRuleSeq  dbg:"-debug"? : tactic => do
+elab (name := moveOperTac) "move_oper" "(" id:ident ")" rws:rwRuleSeq  dbg:"-debug"? : tactic => do
   -- parse the operation
-  let op := (← Term.elabTerm oper none).getAppFn.constName
+  let op := id.getId
   -- parse the list of terms
   let (instr, (unmatched, stxs), dbgMsg) ← unifyMovements (← parseArrows rws) op
                                                               (← instantiateMVars (← getMainTarget))
@@ -440,9 +440,13 @@ elab (name := moveOperTac) "move_oper" "(" oper:term ")" rws:rwRuleSeq  dbg:"-de
   replaceMainGoal (← reorderAndSimp (← getMainGoal) op instr)
 
 @[inherit_doc moveOperTac]
-elab "move_add" rws:rwRuleSeq : tactic => do evalTactic (← `(tactic| move_oper (0 + 0) $rws))
+elab "move_add" rws:rwRuleSeq : tactic => do
+  let hadd := mkIdent ``HAdd.hAdd
+  evalTactic (← `(tactic| move_oper ($hadd) $rws))
 
 @[inherit_doc moveOperTac]
-elab "move_mul" rws:rwRuleSeq : tactic => do evalTactic (← `(tactic| move_oper (1 * 1) $rws))
+elab "move_mul" rws:rwRuleSeq : tactic => do
+  let hmul := mkIdent ``HMul.hMul
+  evalTactic (← `(tactic| move_oper ($hmul) $rws))
 
 end parsing

--- a/Mathlib/Tactic/MoveAdd.lean
+++ b/Mathlib/Tactic/MoveAdd.lean
@@ -27,7 +27,7 @@ A term preceded by `←` gets moved to the left, while a term without `←` gets
   * `move_add [← a]` changes the goal to `0 < if a + b < a + b + c then a + b else a + b`
     (`a` again moved to the left in three sums).
 
-* Longer iputs: `move_add [..., a, ..., ← b, ...]`
+* Longer inputs: `move_add [..., a, ..., ← b, ...]`
 
   If the list contains more than one term, the tactic effectively tries to move each term preceded
   by `←` to the left, each term not preceded by `←` to the right
@@ -108,7 +108,7 @@ namespace Mathlib.MoveAdd
 section ExprProcessing
 
 section reorder
-variable {α :Type*} [BEq α]
+variable {α : Type*} [BEq α]
 
 /-!
 ##  Reordering the variables
@@ -138,11 +138,8 @@ def uniquify : List α → List (α × ℕ)
 
 variable [Inhabited α]
 
-/--  `weight L` takes a list of pairs `(a, h?)` where
-* `a` is a term of some type `α` and
-* `h?` is a `Bool`ean
-
-and returns a function `α → ℤ`.
+/-- Return a sorting key so that all `(a, true)`s are in the list's order
+and sorted before all `(a, false)`s, which are also in the list's order.
 Although `weight` does not require this, we use `weight` in the case where the list obtained
 from `L` by only keeping the first component (i.e. `L.map Prod.fst`) has no duplicates.
 The properties that we mention here assume that this is the case.
@@ -168,9 +165,9 @@ match L.find? (Prod.fst · == a) with
 following the requirements imposed by `instructions : List (α × Bool)`.
 
 These are the requirements:
-* elements of `toReorder` that appear with `true` in `instructions appear at the
+* elements of `toReorder` that appear with `true` in `instructions` appear at the
   *beginning* of the reordered list, in the order in which they appear in `instructions`;
-* similarly, elements of `toReorder` that appear with `false` in `instructions appear at the
+* similarly, elements of `toReorder` that appear with `false` in `instructions` appear at the
   *end* of the reordered list, in the order in which they appear in `instructions`;
 * finally, elements of `toReorder` that do not appear in `instructions` appear "in the middle"
   with the order that they had in `toReorder`.

--- a/Mathlib/Tactic/MoveAdd.lean
+++ b/Mathlib/Tactic/MoveAdd.lean
@@ -15,6 +15,11 @@ The tactic `move_add` rearranges summands in expressions.
 The tactic takes as input a list of terms, each one optionally preceded by `←`.
 A term preceded by `←` gets moved to the left, while a term without `←` gets moved to the right.
 
+* Empty input: `move_add []`
+
+  In this case, the effect of `move_add []` is equivalent to `simp only [← add_assoc]`:
+  essentially the tactic removes all visible parentheses.
+
 * Singleton input: `move_add [a]` and `move_add [← a]`
 
   If `⊢ b + a + c` is (a summand in) the goal, then

--- a/Mathlib/Tactic/MoveAdd.lean
+++ b/Mathlib/Tactic/MoveAdd.lean
@@ -172,7 +172,7 @@ def weight (L : List (α × Bool)) (a : α) : ℤ :=
     | some (_, b) => if b then - l + (L.indexOf (a, b) : ℤ) else (L.indexOf (a, b) + 1 : ℤ)
     | none => 0
 
-/--  `reorderUsing toReorder instructions` produces a reordering of `toReorder : List α`,
+/-- `reorderUsing toReorder instructions` produces a reordering of `toReorder : List α`,
 following the requirements imposed by `instructions : List (α × Bool)`.
 
 These are the requirements:
@@ -215,7 +215,7 @@ def prepareOp (sum : Expr) : Expr :=
   let opargs := sum.getAppArgs
   (opargs.toList.take (opargs.size - 2)).foldl (fun x y => Expr.app x y) sum.getAppFn
 
-/--  `sumList prepOp exs` assumes that `prepOp` is an `Expr`ession representing a binary operation
+/-- `sumList prepOp exs` assumes that `prepOp` is an `Expr`ession representing a binary operation
 already fully applied up until its last two arguments and assumes that the last two arguments
 are the operands of the operation.
 Such an expression is the result of `prepareOp`.
@@ -235,7 +235,7 @@ open Meta
 variable (op : Name)
 
 variable (R : Expr) in
-/--  If `sum` is an expression consisting of repeated applications of `op`, then `getAddends`
+/-- If `sum` is an expression consisting of repeated applications of `op`, then `getAddends`
 returns the Array of those recursively determined arguments whose type is DefEq to `R`. -/
 partial def getAddends (sum : Expr) : MetaM (Array Expr) := do
   if sum.isAppOf op then
@@ -289,7 +289,7 @@ def permuteExpr (tgt : Expr) (instructions : List (Expr × Bool)) : MetaM Expr :
     permTgt := permTgt.replace (if · == old then new else none)
   return permTgt
 
-/--  `pairUp L R` takes to lists `L R : List Expr` as inputs.
+/-- `pairUp L R` takes to lists `L R : List Expr` as inputs.
 It scans the elements of `L`, looking for a corresponding `DefEq` `Expr`ession in `R`.
 If it finds one such element `d`, then it sets the element `d : R` aside, removing it from `R`, and
 it continues with the matching on the remainder of `L` and on `R.erase d`.
@@ -305,7 +305,7 @@ Example:
   let L := [mkNatLit 0, (← mkFreshExprMVar (some (mkConst ``Nat))), mkNatLit 0] -- i.e. [0, _, 0]
   let R := [mkNatLit 0, mkNatLit 0,                                 mkNatLit 1] -- i.e. [0, 1]
   dbg_trace f!"{(← pairUp L R)}"
-/-  output:
+/- output:
 `([0, 0], [0])`
 the output LHS list `[0, 0]` consists of the first `0` and the `MVarId`.
 the output RHS list `[0]` corresponds to the last `0` in `L`.
@@ -407,7 +407,7 @@ def parseArrows : TSyntax `Lean.Parser.Tactic.rwRuleSeq → TermElabM (Array (Ex
 
 initialize registerTraceClass `Tactic.move_oper
 
-/--  The tactic `move_add` rearranges summands of expressions.
+/-- The tactic `move_add` rearranges summands of expressions.
 Calling `move_add [a, ← b, ...]` matches `a, b,...` with summands in the main goal.
 It then moves `a` to the far right and `b` to the far left of each addition in which they appear.
 The side to which the summands are moved is determined by the presence or absence of the arrow `←`.

--- a/Mathlib/Tactic/MoveAdd.lean
+++ b/Mathlib/Tactic/MoveAdd.lean
@@ -189,25 +189,6 @@ let reorder := uToReorder.qsort fun x y =>
     | _, _ => weight uInstructions x ≤ weight uInstructions y
 (reorder.map Prod.fst).toList
 
-section tactic
-open Mathlib.MoveAdd
-
-#guard (uniquify [ 0,      1,      0,      1,      0,      3] =
-                 [(0, 0), (1, 0), (0, 1), (1, 1), (0, 2), (3, 0)])
-
-#guard
-  (let dat := [(0, true), (1, false), (2, true)]
-   (#[0, 1, 2, 3, 4].qsort (fun x y => (weight dat x) ≤ (weight dat y)) = #[0, 2, 3, 4, 1]))
-
-#guard false = ( reorderUsing [0, 1, 2] [(0, false)] = [1, 2, 0] &&
-                 reorderUsing [0, 1, 2] [(1, true)] = [1, 0, 2] &&
-                 reorderUsing [0, 1, 2] [(1, true), (0, false)] != [1, 2, 0])
-
-#guard reorderUsing [1, 5, 4, 3, 2, 1] [(3, true), (2, false), (1, false)] =
-                        [3, 5, 4, 1, 2, 1]
-
-end tactic
-
 end reorder
 
 end ExprProcessing

--- a/Mathlib/Tactic/MoveAdd.lean
+++ b/Mathlib/Tactic/MoveAdd.lean
@@ -419,10 +419,10 @@ There is a multiplicative variant, called `move_mul`.
 
 There is also a general tactic for a "binary associative commutative operation": `move_oper`.
 In this case the syntax requires providing first a term whose head symbol is the operation.
-E.g. `move_oper (HAdd.hAdd) [...]` is the same as `move_add`, while `move_oper (Max.max) [...]`
+E.g. `move_oper HAdd.hAdd [...]` is the same as `move_add`, while `move_oper Max.max [...]`
 rearranges `max`s.
 -/
-elab (name := moveOperTac) "move_oper" "(" id:ident ")" rws:rwRuleSeq : tactic => do
+elab (name := moveOperTac) "move_oper" id:ident rws:rwRuleSeq : tactic => do
   -- parse the operation
   let op := id.getId
   -- parse the list of terms
@@ -438,11 +438,11 @@ elab (name := moveOperTac) "move_oper" "(" id:ident ")" rws:rwRuleSeq : tactic =
 @[inherit_doc moveOperTac]
 elab "move_add" rws:rwRuleSeq : tactic => do
   let hadd := mkIdent ``HAdd.hAdd
-  evalTactic (← `(tactic| move_oper ($hadd) $rws))
+  evalTactic (← `(tactic| move_oper $hadd $rws))
 
 @[inherit_doc moveOperTac]
 elab "move_mul" rws:rwRuleSeq : tactic => do
   let hmul := mkIdent ``HMul.hMul
-  evalTactic (← `(tactic| move_oper ($hmul) $rws))
+  evalTactic (← `(tactic| move_oper $hmul $rws))
 
 end parsing

--- a/Mathlib/Tactic/MoveAdd.lean
+++ b/Mathlib/Tactic/MoveAdd.lean
@@ -257,7 +257,8 @@ def pairUp : List (Expr × Bool × Syntax) → List Expr →
   | (m::ms), l => do
     match ← l.findM? (isDefEq · m.1) with
       | none => let (found, unfound) := ← pairUp ms l; return (found, m::unfound)
-      | some d => let (found, unfound) := ← pairUp ms (l.erase d); return ((d, m.2.1)::found, unfound)
+      | some d => let (found, unfound) := ← pairUp ms (l.erase d)
+                  return ((d, m.2.1)::found, unfound)
   | _, _ => return ([], [])
 
 open Elab.Tactic

--- a/Mathlib/Tactic/MoveAdd.lean
+++ b/Mathlib/Tactic/MoveAdd.lean
@@ -372,15 +372,14 @@ for the operation `op` in the expression `tgt`, returning
   should be thrown;
 * an array of debugging messages.
 -/
-def unifyMovements (pairs : Array (Expr × Bool × Syntax)) (op : Name) (tgt : Expr) :
+def unifyMovements (data : Array (Expr × Bool × Syntax)) (op : Name) (tgt : Expr) :
     MetaM (List (Expr × Bool) × (List MessageData × List Syntax) × Array MessageData) := do
---  let pairs ← parseArrows rws
   let ops ← getOps op tgt
   let atoms := (ops.map Prod.fst).flatten.toList.filter (!isBVar ·)
   -- `instr` are the unified user-provided terms, `neverMatched` are non-unified ones
-  let (instr, neverMatched) := ← pairUp pairs.toList atoms
+  let (instr, neverMatched) := ← pairUp data.toList atoms
   let dbgMsg := #[m!"Matching of input variables:\n* pre-match:  {
-    pairs.map (Prod.snd ∘ Prod.snd)}\n* post-match: {instr}",
+    data.map (Prod.snd ∘ Prod.snd)}\n* post-match: {instr}",
     m!"\nMaximum number of iterations: {ops.size}"]
   -- if there are `neverMatched` terms, return the parsed terms and the syntax
   let errMsg := neverMatched.map fun (t, a, stx) => (if a then m!"← {t}" else m!"{t}", stx)

--- a/Mathlib/Tactic/MoveAdd.lean
+++ b/Mathlib/Tactic/MoveAdd.lean
@@ -58,7 +58,7 @@ namespace Mathlib.MoveAdd
 section ExprProcessing
 
 section reorder
-variable [BEq α]
+variable {α :Type*} [BEq α]
 
 /-!
 ##  Reordering the variables

--- a/Mathlib/Tactic/MoveAdd.lean
+++ b/Mathlib/Tactic/MoveAdd.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Arthur Paulino, Damiano Testa
 -/
 import Mathlib.Algebra.Group.Basic
+import Mathlib.Init.Order.LinearOrder
 
 /-!
 
@@ -280,8 +281,8 @@ def rankSums (op : Name) (tgt : Expr) (instructions : List (Expr × Bool)) :
     let reord := reorderUsing addends.toList instructions
     let resummed := sumList1 (prepareOp sum) reord
     if (resummed != sum) then return some (sum, resummed) else return none
-  let _ : LE (Expr × Expr) := { le := fun f g => g.1.size  ≤ f.1.size }
-  return (candidates.toList.reduceOption.toArray.qsort (· ≤ ·)).toList
+  return (candidates.toList.reduceOption.toArray.qsort
+    (fun x y : Expr × Expr ↦ (y.1.size  ≤ x.1.size))).toList
 
 /-- `permuteExpr op tgt instructions` takes the same input as `rankSums` and returns the
 expression obtained from `tgt` by replacing all `old_sum`s by the corresponding `new_sum`.

--- a/Mathlib/Tactic/MoveAdd.lean
+++ b/Mathlib/Tactic/MoveAdd.lean
@@ -226,7 +226,7 @@ partial def getOps (sum : Expr) : MetaM (Array ((Array Expr) × Expr)) := do
   let (first, rest) := if summands.size == 1 then (#[], sum.getExprInputs) else
     (#[(summands, sum)], summands)
   let rest ← rest.mapM getOps
-  return rest.foldl Array.append  first
+  return rest.foldl Array.append first
 
 /-- `prepareOp sum` takes an `Expr`ession as input.  It assumes that `sum` is a well-formed
 term representing a repeated application of a binary operation and that the summands are the

--- a/Mathlib/Tactic/MoveAdd.lean
+++ b/Mathlib/Tactic/MoveAdd.lean
@@ -215,9 +215,12 @@ def prepareOp (sum : Expr) : Expr :=
   let opargs := sum.getAppArgs
   (opargs.toList.take (opargs.size - 2)).foldl (fun x y => Expr.app x y) sum.getAppFn
 
-/--  `sumList op exs` assumes that `op` is the `Name` of a binary operation.
-If `exs` is the list `[e₁, e₂, ..., eₙ]` of `Expr`essions, then `sumList` returns
-`op (op( ... op (op e₁ e₂) e₃) ... eₙ)`.
+/--  `sumList prepOp exs` assumes that `prepOp` is an `Expr`ession representing a binary operation
+already fully applied up until its last two arguments and assumes that the last two arguments
+are the operands of the operation.
+Such an expression is the result of `prepareOp`.
+If `exs` is the list `[e₁, e₂, ..., eₙ]` of `Expr`essions, then `sumList prepOp exs` returns
+`prepOp (prepOp( ... prepOp (prepOp e₁ e₂) e₃) ... eₙ)`.
 -/
 partial
 def sumList (prepOp : Expr) : List Expr → Expr

--- a/Mathlib/Tactic/MoveAdd.lean
+++ b/Mathlib/Tactic/MoveAdd.lean
@@ -285,6 +285,8 @@ def permuteExpr (tgt : Expr) (instructions : List (Expr × Bool)) : MetaM Expr :
   let permInstructions ← rankSums op tgt instructions
   if permInstructions == [] then throwError "The goal is already in the required form"
   let mut permTgt := tgt
+  -- We cannot do `Expr.replace` all at once here, we need to follow
+  -- the order of the instructions.
   for (old, new) in permInstructions do
     permTgt := permTgt.replace (if · == old then new else none)
   return permTgt

--- a/Mathlib/Tactic/MoveAdd.lean
+++ b/Mathlib/Tactic/MoveAdd.lean
@@ -83,7 +83,7 @@ operation and replaces them by their reordered versions.
 Once that is done, it tries to replace the initial goal with the permuted one by using `simp`.
 
 Currently, no attempt is made at guiding `simp` by doing a `congr`-like destruction of the goal.
-I, DT, already have code for this improvement, but am leaving it for a later PR.
+This will be the content of a later PR.
 -/
 
 open Lean Expr

--- a/test/MoveAdd.lean
+++ b/test/MoveAdd.lean
@@ -1,6 +1,8 @@
 import Mathlib.Tactic.MoveAdd
 import Mathlib.Data.Nat.Basic
 
+universe u
+
 section tactic
 open Mathlib.MoveAdd
 
@@ -24,8 +26,8 @@ run_cmd if reorderUsing [1, 5, 4, 3, 2, 1] [(3, true), (2, false), (1, false)] �
 
 end tactic
 
-section add
 variable {R : Type u}
+section add
 
 section semigroup
 variable [AddCommSemigroup R] {a b c d e f g h : R}
@@ -66,7 +68,7 @@ example [Mul R] (h : a * c + c + b * c = a * d + d + b * d) :
   exact h
 
 end semigroup
-variable [AddCommMonoidWithOne R] [Mul R] {X r s t u : R} (C D E : R → R)
+variable [AddCommMonoidWithOne R] [Mul R] {f g h X r s t u : R} (C D E : R → R)
 
 example (he : E (C r * D X + D X * h + 7 + 42 + f) = C r * D X + h * D X + 7 + 42 + g) :
     E (7 + f + (C r * D X + 42) + D X * h) = C r * D X + h * D X + g + 7 + 42 := by

--- a/test/MoveAdd.lean
+++ b/test/MoveAdd.lean
@@ -1,0 +1,96 @@
+import Mathlib.Tactic.MoveAdd
+import Mathlib.Data.Nat.Basic
+
+section tactic
+open Mathlib.MoveAdd
+
+run_cmd if uniquify [ 0,      1,      0,      1,      0,      3] ≠
+                    [(0, 0), (1, 0), (0, 1), (1, 1), (0, 2), (3, 0)] then
+          throwError "'uniquify' is not uniquifying"
+
+run_cmd
+  let dat := [(0, true), (1, false), (2, true)]
+  if (#[0, 1, 2, 3, 4].qsort (fun x y => (weight dat x) ≤ (weight dat y)) != #[0, 2, 3, 4, 1]) then
+    throwError "The sorting order induced by 'wtFnc' does not seem to have the required properties"
+
+run_cmd if false = (reorderUsing [0, 1, 2] [(0, false)] = [1, 2, 0] &&
+                    reorderUsing [0, 1, 2] [(1, true)] = [1, 0, 2] &&
+                    reorderUsing [0, 1, 2] [(1, true), (0, false)] = [1, 2, 0]) then
+          throwError "'reorderUsing' is not reordering properly"
+
+run_cmd if reorderUsing [1, 5, 4, 3, 2, 1] [(3, true), (2, false), (1, false)] ≠
+                        [3, 5, 4, 1, 2, 1] then
+          throwError "'reorderUsing' is not reordering properly"
+
+end tactic
+
+section add
+variable {R : Type u}
+
+section semigroup
+variable [AddCommSemigroup R] {a b c d e f g h : R}
+
+example (h : a + b + c = d) : b + (a + c) = d := by
+  move_add [← a]
+  assumption
+
+example : let k := c + (a + b); k = a + b + c := by
+  move_add [← a, c]
+  rfl
+
+example (h : b + a = b + c + a) : a + b = a + b + c :=
+by move_add [a]; assumption
+
+example [Mul R] [Neg R] : a + (b + c + a) * (- (d + e) + e) + f + g =
+    (c + b + a) * (e + - (e + d)) + g + f + a := by
+  move_add [b, d, g, f, a, e]; rfl
+
+example (h : d + b + a = b + a → d + c + a = c + a) : a + d + b = b + a → d + c + a = a + c := by
+  move_add [a]
+  assumption
+
+example [DecidableEq R] : if b + a = c + a then a + b = c + a else a + b ≠ c + a := by
+  move_add [← a]
+  split_ifs with h <;>
+  exact h
+
+example (h : a + c + b = a + d + b) : c + b + a = b + a + d := by
+  move_add [← a, b]  -- Goal before `exact h`: `a + c + b = a + d + b`
+  exact h
+
+example [Mul R] (h : a * c + c + b * c = a * d + d + b * d) :
+    c + b * c + a * c = a * d + d + b * d := by
+  -- the first input `_ * c` unifies with `b * c` and moves to the right
+  -- the second input `_ * c` unifies with `a * c` and moves to the left
+  move_add [_ * c, ← _ * c] -- Goal before `exact h`: `a * c + c + b * c = a * d + d + b * d`
+  exact h
+
+end semigroup
+variable [AddCommMonoidWithOne R] [Mul R] {X r s t u : R} (C D E : R → R)
+
+example (he : E (C r * D X + D X * h + 7 + 42 + f) = C r * D X + h * D X + 7 + 42 + g) :
+    E (7 + f + (C r * D X + 42) + D X * h) = C r * D X + h * D X + g + 7 + 42 := by
+  -- move `7, 42, f, g` to the right of their respective sides
+  move_add [(7 : R), (42 : R), f, g]
+  assumption
+
+end add
+
+example [CommSemigroup R] (a b c d : R) (h : a * b * c = d) : b * (a * c) = d := by
+  move_mul [← a]
+  assumption
+
+example (a b : ℕ) : a + max a b = max b a + a := by
+  move_oper (max 0 0) [← a]
+  move_oper (0 + 0) [a]
+  rfl
+
+example {R : Type u} [CommSemigroup R] {a b : R} :
+    ∀ x : R, ∃ y : R, a * x * b * y = x * y * b * a := by
+  move_mul [a, b]
+  exact fun x ↦ ⟨x, rfl⟩
+
+example {R : Type u} [Add R] [CommSemigroup R] {a b c d e f g : R} :
+    a * (b * c * a) * ((d * e) * e) * f * g = (c * b * a) * (e * (e * d)) * g * f * a := by
+  move_mul [a, a, b, c, d, e, f]
+  rfl

--- a/test/MoveAdd.lean
+++ b/test/MoveAdd.lean
@@ -83,7 +83,7 @@ open Mathlib.MoveAdd
 
 #guard
   (let dat := [(0, true), (1, false), (2, true)]
-   (#[0, 1, 2, 3, 4].qsort (fun x y => (weight dat x) ≤ (weight dat y)) = #[0, 2, 3, 4, 1]))
+   #[0, 1, 2, 3, 4].qsort (weight dat · ≤ weight dat ·) = #[0, 2, 3, 4, 1])
 
 #guard false = ( reorderUsing [0, 1, 2] [(0, false)] = [1, 2, 0] &&
                  reorderUsing [0, 1, 2] [(1, true)] = [1, 0, 2] &&

--- a/test/MoveAdd.lean
+++ b/test/MoveAdd.lean
@@ -60,8 +60,8 @@ example [CommSemigroup R] (a b c d : R) (h : a * b * c = d) : b * (a * c) = d :=
   assumption
 
 example (a b : ℕ) : a + max a b = max b a + a := by
-  move_oper (Max.max) [← a]
-  move_oper (HAdd.hAdd) [a]
+  move_oper Max.max [← a]
+  move_oper HAdd.hAdd [a]
   rfl
 
 example {R : Type u} [CommSemigroup R] {a b : R} :

--- a/test/MoveAdd.lean
+++ b/test/MoveAdd.lean
@@ -73,3 +73,23 @@ example {R : Type u} [Add R] [CommSemigroup R] {a b c d e f g : R} :
     a * (b * c * a) * ((d * e) * e) * f * g = (c * b * a) * (e * (e * d)) * g * f * a := by
   move_mul [a, a, b, c, d, e, f]
   rfl
+
+-- Testing internals of the tactic `move_add`.
+section tactic
+open Mathlib.MoveAdd
+
+#guard (uniquify [ 0,      1,      0,      1,      0,      3] =
+                 [(0, 0), (1, 0), (0, 1), (1, 1), (0, 2), (3, 0)])
+
+#guard
+  (let dat := [(0, true), (1, false), (2, true)]
+   (#[0, 1, 2, 3, 4].qsort (fun x y => (weight dat x) ≤ (weight dat y)) = #[0, 2, 3, 4, 1]))
+
+#guard false = ( reorderUsing [0, 1, 2] [(0, false)] = [1, 2, 0] &&
+                 reorderUsing [0, 1, 2] [(1, true)] = [1, 0, 2] &&
+                 reorderUsing [0, 1, 2] [(1, true), (0, false)] != [1, 2, 0])
+
+#guard reorderUsing [1, 5, 4, 3, 2, 1] [(3, true), (2, false), (1, false)] =
+                        [3, 5, 4, 1, 2, 1]
+
+end tactic

--- a/test/MoveAdd.lean
+++ b/test/MoveAdd.lean
@@ -60,8 +60,8 @@ example [CommSemigroup R] (a b c d : R) (h : a * b * c = d) : b * (a * c) = d :=
   assumption
 
 example (a b : ℕ) : a + max a b = max b a + a := by
-  move_oper (max 0 0) [← a]
-  move_oper (0 + 0) [a]
+  move_oper (Max.max) [← a]
+  move_oper (HAdd.hAdd) [a]
   rfl
 
 example {R : Type u} [CommSemigroup R] {a b : R} :

--- a/test/MoveAdd.lean
+++ b/test/MoveAdd.lean
@@ -3,29 +3,6 @@ import Mathlib.Data.Nat.Basic
 
 universe u
 
-section tactic
-open Mathlib.MoveAdd
-
-run_cmd if uniquify [ 0,      1,      0,      1,      0,      3] ≠
-                    [(0, 0), (1, 0), (0, 1), (1, 1), (0, 2), (3, 0)] then
-          throwError "'uniquify' is not uniquifying"
-
-run_cmd
-  let dat := [(0, true), (1, false), (2, true)]
-  if (#[0, 1, 2, 3, 4].qsort (fun x y => (weight dat x) ≤ (weight dat y)) != #[0, 2, 3, 4, 1]) then
-    throwError "The sorting order induced by 'wtFnc' does not seem to have the required properties"
-
-run_cmd if false = (reorderUsing [0, 1, 2] [(0, false)] = [1, 2, 0] &&
-                    reorderUsing [0, 1, 2] [(1, true)] = [1, 0, 2] &&
-                    reorderUsing [0, 1, 2] [(1, true), (0, false)] = [1, 2, 0]) then
-          throwError "'reorderUsing' is not reordering properly"
-
-run_cmd if reorderUsing [1, 5, 4, 3, 2, 1] [(3, true), (2, false), (1, false)] ≠
-                        [3, 5, 4, 1, 2, 1] then
-          throwError "'reorderUsing' is not reordering properly"
-
-end tactic
-
 variable {R : Type u}
 section add
 


### PR DESCRIPTION
This PR is a short implementation of the `move_add` tactic.

It is intended as a preliminary port, featuring the reordering strategy and a very naïve proof-algorithm.

A more refined version with a more robust proof will appear in a later PR.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
