### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Bicategory): composition as a functor

### DIFF
--- a/Mathlib/CategoryTheory/Bicategory/Basic.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Basic.lean
@@ -3,7 +3,7 @@ Copyright (c) 2021 Yuma Mizuno. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yuma Mizuno
 -/
-import Mathlib.CategoryTheory.Iso
+import Mathlib.CategoryTheory.NatIso
 
 #align_import category_theory.bicategory.basic from "leanprover-community/mathlib"@"4c19a16e4b705bf135cf9a80ac18fcc99c438514"
 
@@ -486,6 +486,67 @@ theorem unitors_equal : (λ_ (𝟙 a)).hom = (ρ_ (𝟙 a)).hom := by
 @[simp]
 theorem unitors_inv_equal : (λ_ (𝟙 a)).inv = (ρ_ (𝟙 a)).inv := by simp [Iso.inv_eq_inv]
 #align category_theory.bicategory.unitors_inv_equal CategoryTheory.Bicategory.unitors_inv_equal
+
+section
+
+attribute [local simp] whisker_exchange
+
+/-- Precomposition of a 1-morphism as a functor. -/
+@[simps]
+def precomp (c : B) (f : a ⟶ b) : (b ⟶ c) ⥤ (a ⟶ c) where
+  obj := (f ≫ ·)
+  map := (f ◁ ·)
+
+/-- Precomposition of a 1-morphism as a functor from the category of 1-morphisms `a ⟶ b` into the
+category of functors `(b ⟶ c) ⥤ (a ⟶ c)`. -/
+@[simps]
+def precomping (a b c : B) : (a ⟶ b) ⥤ (b ⟶ c) ⥤ (a ⟶ c) where
+  obj f := precomp c f
+  map η := ⟨(η ▷ ·), _⟩
+
+/-- Postcomposition of a 1-morphism as a functor. -/
+@[simps]
+def postcomp (a : B) (f : b ⟶ c) : (a ⟶ b) ⥤ (a ⟶ c) where
+  obj := (· ≫ f)
+  map := (· ▷ f)
+
+/-- Postcomposition of a 1-morphism as a functor from the category of 1-morphisms `b ⟶ c` into the
+category of functors `(a ⟶ b) ⥤ (a ⟶ c)`. -/
+@[simps]
+def postcomping (a b c : B) : (b ⟶ c) ⥤ (a ⟶ b) ⥤ (a ⟶ c) where
+  obj f := postcomp a f
+  map η := ⟨(· ◁ η), _⟩
+
+/-- Left component of the associator as a natural isomorphism. -/
+@[simps!]
+def associatorNatIsoLeft (a : B) (g : b ⟶ c) (h : c ⟶ d) :
+    (postcomping a ..).obj g ⋙ (postcomping ..).obj h ≅ (postcomping ..).obj (g ≫ h) :=
+  NatIso.ofComponents (α_ · g h)
+
+/-- Middle component of the associator as a natural isomorphism. -/
+@[simps!]
+def associatorNatIsoMiddle (f : a ⟶ b) (h : c ⟶ d) :
+    (precomping ..).obj f ⋙ (postcomping ..).obj h ≅
+      (postcomping ..).obj h ⋙ (precomping ..).obj f :=
+  NatIso.ofComponents (α_ f · h)
+
+/-- Right component of the associator as a natural isomorphism. -/
+@[simps!]
+def associatorNatIsoRight (f : a ⟶ b) (g : b ⟶ c) (d : B) :
+    (precomping _ _ d).obj (f ≫ g) ≅ (precomping ..).obj g ⋙ (precomping ..).obj f :=
+  NatIso.ofComponents (α_ f g ·)
+
+/-- Left unitor as a natural isomorphism. -/
+@[simps!]
+def leftUnitorNatIso (a b : B) : (precomping _ _ b).obj (𝟙 a) ≅ 𝟭 (a ⟶ b) :=
+  NatIso.ofComponents (λ_ ·)
+
+/-- Right unitor as a natural isomorphism. -/
+@[simps!]
+def rightUnitorNatIso (a b : B) : (postcomping a _ _).obj (𝟙 b) ≅ 𝟭 (a ⟶ b) :=
+  NatIso.ofComponents (ρ_ ·)
+
+end
 
 end Bicategory
 

--- a/Mathlib/CategoryTheory/Bicategory/Basic.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Basic.lean
@@ -500,7 +500,7 @@ def precomp (c : B) (f : a ⟶ b) : (b ⟶ c) ⥤ (a ⟶ c) where
 /-- Precomposition of a 1-morphism as a functor from the category of 1-morphisms `a ⟶ b` into the
 category of functors `(b ⟶ c) ⥤ (a ⟶ c)`. -/
 @[simps]
-def precomping (a b c : B) : (a ⟶ b) ⥤ (b ⟶ c) ⥤ (a ⟶ c) where
+def precomposing (a b c : B) : (a ⟶ b) ⥤ (b ⟶ c) ⥤ (a ⟶ c) where
   obj f := precomp c f
   map η := ⟨(η ▷ ·), _⟩
 
@@ -513,37 +513,37 @@ def postcomp (a : B) (f : b ⟶ c) : (a ⟶ b) ⥤ (a ⟶ c) where
 /-- Postcomposition of a 1-morphism as a functor from the category of 1-morphisms `b ⟶ c` into the
 category of functors `(a ⟶ b) ⥤ (a ⟶ c)`. -/
 @[simps]
-def postcomping (a b c : B) : (b ⟶ c) ⥤ (a ⟶ b) ⥤ (a ⟶ c) where
+def postcomposing (a b c : B) : (b ⟶ c) ⥤ (a ⟶ b) ⥤ (a ⟶ c) where
   obj f := postcomp a f
   map η := ⟨(· ◁ η), _⟩
 
 /-- Left component of the associator as a natural isomorphism. -/
 @[simps!]
 def associatorNatIsoLeft (a : B) (g : b ⟶ c) (h : c ⟶ d) :
-    (postcomping a ..).obj g ⋙ (postcomping ..).obj h ≅ (postcomping ..).obj (g ≫ h) :=
+    (postcomposing a ..).obj g ⋙ (postcomposing ..).obj h ≅ (postcomposing ..).obj (g ≫ h) :=
   NatIso.ofComponents (α_ · g h)
 
 /-- Middle component of the associator as a natural isomorphism. -/
 @[simps!]
 def associatorNatIsoMiddle (f : a ⟶ b) (h : c ⟶ d) :
-    (precomping ..).obj f ⋙ (postcomping ..).obj h ≅
-      (postcomping ..).obj h ⋙ (precomping ..).obj f :=
+    (precomposing ..).obj f ⋙ (postcomposing ..).obj h ≅
+      (postcomposing ..).obj h ⋙ (precomposing ..).obj f :=
   NatIso.ofComponents (α_ f · h)
 
 /-- Right component of the associator as a natural isomorphism. -/
 @[simps!]
 def associatorNatIsoRight (f : a ⟶ b) (g : b ⟶ c) (d : B) :
-    (precomping _ _ d).obj (f ≫ g) ≅ (precomping ..).obj g ⋙ (precomping ..).obj f :=
+    (precomposing _ _ d).obj (f ≫ g) ≅ (precomposing ..).obj g ⋙ (precomposing ..).obj f :=
   NatIso.ofComponents (α_ f g ·)
 
 /-- Left unitor as a natural isomorphism. -/
 @[simps!]
-def leftUnitorNatIso (a b : B) : (precomping _ _ b).obj (𝟙 a) ≅ 𝟭 (a ⟶ b) :=
+def leftUnitorNatIso (a b : B) : (precomposing _ _ b).obj (𝟙 a) ≅ 𝟭 (a ⟶ b) :=
   NatIso.ofComponents (λ_ ·)
 
 /-- Right unitor as a natural isomorphism. -/
 @[simps!]
-def rightUnitorNatIso (a b : B) : (postcomping a _ _).obj (𝟙 b) ≅ 𝟭 (a ⟶ b) :=
+def rightUnitorNatIso (a b : B) : (postcomposing a _ _).obj (𝟙 b) ≅ 𝟭 (a ⟶ b) :=
   NatIso.ofComponents (ρ_ ·)
 
 end


### PR DESCRIPTION
This PR shows that the composition of 1-morphism is a functor, and the associators and the unitors are natural isomorphisms.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
