### PR TITLE
[Merged by Bors] - feat(GroupTheory/CommutingProbability): Group with commuting probability exactly 1/n

### DIFF
--- a/Mathlib/GroupTheory/CommutingProbability.lean
+++ b/Mathlib/GroupTheory/CommutingProbability.lean
@@ -153,6 +153,7 @@ lemma div_four_lt : {n : ℕ} → (h0 : n ≠ 0) → (h1 : n ≠ 1) → n / 4 + 
 | 0 | 1 | 2 | 3 => by decide
 | n + 4 => by intros; linarith [n.add_div_right four_pos, n.div_le_self 4]
 
+/-- A list of Dihedral groups whose product will have commuting probability `1 / n`. -/
 def reciprocalFactors (n : ℕ) : List ℕ :=
   if h0 : n = 0 then [0]
   else if h1 : n = 1 then []
@@ -163,6 +164,7 @@ def reciprocalFactors (n : ℕ) : List ℕ :=
     have := div_four_lt h0 h1
     n % 4 * n :: reciprocalFactors (n / 4 + 1)
 
+/-- A finite product of Dihedral groups. -/
 def Product (l : List ℕ) : Type :=
   ∀ i : Fin l.length, DihedralGroup l[i]
 

--- a/Mathlib/GroupTheory/CommutingProbability.lean
+++ b/Mathlib/GroupTheory/CommutingProbability.lean
@@ -151,8 +151,8 @@ private lemma div_two_lt {n : ℕ} (h0 : n ≠ 0) : n / 2 < n :=
   Nat.div_lt_self (Nat.pos_of_ne_zero h0) (lt_add_one 1)
 
 private lemma div_four_lt : {n : ℕ} → (h0 : n ≠ 0) → (h1 : n ≠ 1) → n / 4 + 1 < n
-| 0 | 1 | 2 | 3 => by decide
-| n + 4 => by intros; linarith [n.add_div_right four_pos, n.div_le_self 4]
+  | 0 | 1 | 2 | 3 => by decide
+  | n + 4 => by intros; linarith [n.add_div_right four_pos, n.div_le_self 4]
 
 /-- A list of Dihedral groups whose product will have commuting probability `1 / n`. -/
 def reciprocalFactors (n : ℕ) : List ℕ :=
@@ -169,6 +169,16 @@ def reciprocalFactors (n : ℕ) : List ℕ :=
 
 @[simp] lemma reciprocalFactors_one : reciprocalFactors 1 = [] := rfl
 
+lemma reciprocalFactors_def :
+    reciprocalFactors n =
+      if h0 : n = 0 then [0]
+      else if h1 : n = 1 then []
+      else if 2 ∣ n then
+        3 :: reciprocalFactors (n / 2)
+      else
+        n % 4 * n :: reciprocalFactors (n / 4 + 1) := by
+  conv_lhs => unfold reciprocalFactors
+
 /-- A finite product of Dihedral groups. -/
 abbrev Product (l : List ℕ) : Type :=
   ∀ i : Fin l.length, DihedralGroup l[i]
@@ -180,18 +190,10 @@ lemma commProb_cons (n : ℕ) (l : List ℕ) :
     commProb (Product (n :: l)) = commProb (DihedralGroup n) * commProb (Product l) := by
   simp [Product, commProb_pi, Fin.prod_univ_succ]
 
-lemma commProb_product (l : List ℕ) :
-    commProb (Product l) = (l.map (fun k => commProb (DihedralGroup k))).prod := by
-  induction' l with n l h
-  · rw [commProb_nil, List.map_nil, List.prod_nil]
-  · rw [commProb_cons, List.map_cons, List.prod_cons, h]
-
 /-- Construction of a group with commuting probability `1 / n`. -/
 theorem commProb_reciprocal (n : ℕ) :
     commProb (Product (reciprocalFactors n)) = 1 / n := by
-  rw [commProb_product]
-  unfold reciprocalFactors
-  rw [←commProb_product]
+  rw [reciprocalFactors_def]
   by_cases h0 : n = 0
   · rw [dif_pos h0, commProb_cons, commProb_nil, mul_one, h0, Nat.cast_zero, div_zero]
     apply commProb_eq_zero_of_infinite

--- a/Mathlib/GroupTheory/CommutingProbability.lean
+++ b/Mathlib/GroupTheory/CommutingProbability.lean
@@ -150,10 +150,7 @@ lemma aux1 {n : ℕ} (h0 : n ≠ 0) : n / 2 < n :=
   Nat.div_lt_self (Nat.pos_of_ne_zero h0) (lt_add_one 1)
 
 lemma aux2 : {n : ℕ} → (h0 : n ≠ 0) → (h1 : n ≠ 1) → n / 4 + 1 < n
-| 0 => by decide
-| 1 => by decide
-| 2 => by decide
-| 3 => by decide
+| 0 | 1 | 2 | 3 => by decide
 | n + 4 => by intros; linarith [n.add_div_right four_pos, n.div_le_self 4]
 
 def reciprocalFactors (n : ℕ) : List ℕ :=

--- a/Mathlib/GroupTheory/CommutingProbability.lean
+++ b/Mathlib/GroupTheory/CommutingProbability.lean
@@ -139,17 +139,17 @@ theorem inv_card_commutator_le_commProb : (↑(Nat.card (commutator G)))⁻¹ �
 -- Construction of group with commuting probability 1/n
 namespace DihedralGroup
 
-lemma commProb_odd (n : ℕ) (hn : Odd n) :
+lemma commProb_odd {n : ℕ} (hn : Odd n) :
     commProb (DihedralGroup n) = (n + 3) / (4 * n) := by
   rw [commProb_def', DihedralGroup.card_conjClasses_odd hn, nat_card]
   qify [show 2 ∣ n + 3 by rw [Nat.dvd_iff_mod_eq_zero, Nat.add_mod, Nat.odd_iff.mp hn]; rfl]
   rw [div_div, ← mul_assoc]
   congr
 
-lemma aux1 {n : ℕ} (h0 : n ≠ 0) : n / 2 < n :=
+lemma div_two_lt {n : ℕ} (h0 : n ≠ 0) : n / 2 < n :=
   Nat.div_lt_self (Nat.pos_of_ne_zero h0) (lt_add_one 1)
 
-lemma aux2 : {n : ℕ} → (h0 : n ≠ 0) → (h1 : n ≠ 1) → n / 4 + 1 < n
+lemma div_four_lt : {n : ℕ} → (h0 : n ≠ 0) → (h1 : n ≠ 1) → n / 4 + 1 < n
 | 0 | 1 | 2 | 3 => by decide
 | n + 4 => by intros; linarith [n.add_div_right four_pos, n.div_le_self 4]
 
@@ -157,10 +157,10 @@ def reciprocalFactors (n : ℕ) : List ℕ :=
   if h0 : n = 0 then [0]
   else if h1 : n = 1 then []
   else if 2 ∣ n then
-    have := aux1 h0
+    have := div_two_lt h0
     3 :: reciprocalFactors (n / 2)
   else
-    have := aux2 h0 h1
+    have := div_four_lt h0 h1
     n % 4 * n :: reciprocalFactors (n / 4 + 1)
 
 def Product (l : List ℕ) : Type :=
@@ -169,48 +169,47 @@ def Product (l : List ℕ) : Type :=
 instance (l : List ℕ) : Group (Product l) := Pi.group
 
 lemma commProb_nil : commProb (Product []) = 1 := by
-  simp_rw [Product, commProb_pi]
+  simp [Product, commProb_pi]
 
 lemma commProb_cons (n : ℕ) (l : List ℕ) :
     commProb (Product (n :: l)) = commProb (DihedralGroup n) * commProb (Product l) := by
-  simp_rw [Product, commProb_pi, List.length_cons, Fin.prod_univ_succ, List.map_cons, List.prod_cons]
-  rfl
+  simp [Product, commProb_pi, Fin.prod_univ_succ]
 
 lemma commProb_product (l : List ℕ) :
     commProb (Product l) = (l.map (fun k => commProb (DihedralGroup k))).prod := by
   induction' l with n l h
-  . rw [commProb_nil, List.map_nil, List.prod_nil]
-  . rw [commProb_cons, List.map_cons, List.prod_cons, h]
+  · rw [commProb_nil, List.map_nil, List.prod_nil]
+  · rw [commProb_cons, List.map_cons, List.prod_cons, h]
 
+/-- Construction of a group with commuting probability `1 / n`. -/
 theorem commProb_reciprocal (n : ℕ) :
     commProb (Product (reciprocalFactors n)) = 1 / n := by
   rw [commProb_product]
   unfold reciprocalFactors
   rw [←commProb_product]
   by_cases h0 : n = 0
-  . rw [dif_pos h0, commProb_cons, commProb_nil, mul_one, h0, Nat.cast_zero, div_zero]
+  · rw [dif_pos h0, commProb_cons, commProb_nil, mul_one, h0, Nat.cast_zero, div_zero]
     apply commProb_eq_zero_of_infinite
-  . by_cases h1 : n = 1
-    . rw [dif_neg h0, dif_pos h1, commProb_nil, h1, Nat.cast_one, div_one]
-    . by_cases h2 : 2 ∣  n
-      . have := aux1 h0
+  · by_cases h1 : n = 1
+    · rw [dif_neg h0, dif_pos h1, commProb_nil, h1, Nat.cast_one, div_one]
+    · by_cases h2 : 2 ∣ n
+      · have := div_two_lt h0
         rw [dif_neg h0, dif_neg h1, if_pos h2, commProb_cons, commProb_reciprocal (n / 2),
-            commProb_odd 3 (by norm_num)]
+            commProb_odd (by norm_num)]
         field_simp [h0]
         norm_num
-      . have := aux2 h0 h1
+      · have := div_four_lt h0 h1
         have key : n % 4 = 1 ∨ n % 4 = 3 := Nat.odd_mod_four_iff.mp (Nat.two_dvd_ne_zero.mp h2)
-        rw [dif_neg h0, dif_neg h1, if_neg h2, commProb_cons, commProb_reciprocal (n / 4 + 1),
-            commProb_odd (n % 4 * n)]
-        . rw [div_mul_div_comm, mul_one, div_eq_div_iff] <;> norm_cast
-          . have : (n % 4) ^ 2 + 3 = n % 4 * 4 := by rcases key with h | h <;> rw [h] <;> norm_num
-            calc ((n % 4) * n + 3) * n = (n % 4 * (4 * (n / 4)) + n % 4 * 4) * n :=
-                by rw [←this, sq, ←add_assoc, ←mul_add, Nat.div_add_mod]
-              _ = 1 * (4 * (n % 4 * n) * (n / 4 + 1)) := by ring
-          . have : n % 4 ≠ 0 := by rcases key with h | h <;> rw [h] <;> norm_num
-            positivity
-        . have : ¬ 2 ∣ n % 4 := by rcases key with h | h <;> rw [h] <;> norm_num
-          rw [Nat.two_dvd_ne_zero, ← Nat.odd_iff] at h2 this
-          exact this.mul h2
+        have hn : Odd (n % 4) := by rcases key with h | h <;> rw [h] <;> norm_num
+        rw [dif_neg h0, dif_neg h1, if_neg h2]
+        rw [Nat.two_dvd_ne_zero, ← Nat.odd_iff] at h2
+        rw [commProb_cons, commProb_reciprocal (n / 4 + 1), commProb_odd (hn.mul h2)]
+        rw [div_mul_div_comm, mul_one, div_eq_div_iff, one_mul] <;> norm_cast
+        · have : (n % 4) ^ 2 + 3 = n % 4 * 4 := by rcases key with h | h <;> rw [h] <;> norm_num
+          calc ((n % 4) * n + 3) * n = (n % 4 * (4 * (n / 4)) + n % 4 * 4) * n :=
+              by rw [←this, sq, ←add_assoc, ←mul_add, Nat.div_add_mod]
+            _ = (4 * (n % 4 * n) * (n / 4 + 1)) := by ring
+        · have := hn.pos.ne'
+          positivity
 
 end DihedralGroup

--- a/Mathlib/GroupTheory/CommutingProbability.lean
+++ b/Mathlib/GroupTheory/CommutingProbability.lean
@@ -159,31 +159,30 @@ def reciprocalFactors (n : ℕ) : List ℕ :=
   if h0 : n = 0 then [0]
   else if h1 : n = 1 then []
   else if Even n then
-    have := div_two_lt h0
     3 :: reciprocalFactors (n / 2)
   else
-    have := div_four_lt h0 h1
     n % 4 * n :: reciprocalFactors (n / 4 + 1)
+decreasing_by
+  simp_wf
+  first | exact div_two_lt h0 | exact div_four_lt h0 h1
 
 @[simp] lemma reciprocalFactors_zero : reciprocalFactors 0 = [0] := rfl
 
 @[simp] lemma reciprocalFactors_one : reciprocalFactors 1 = [] := rfl
 
-@[nolint unusedHavesSuffices] lemma reciprocalFactors_even {n : ℕ} (h0 : n ≠ 0) (h2 : Even n) :
+lemma reciprocalFactors_even {n : ℕ} (h0 : n ≠ 0) (h2 : Even n) :
     reciprocalFactors n = 3 :: reciprocalFactors (n / 2) := by
   have h1 : n ≠ 1
   · rintro rfl
     norm_num at h2
-  conv_lhs => unfold reciprocalFactors
-  rw [dif_neg h0, dif_neg h1, if_pos h2]
+  rw [reciprocalFactors, dif_neg h0, dif_neg h1, if_pos h2]
 
-@[nolint unusedHavesSuffices] lemma reciprocalFactors_odd {n : ℕ} (h1 : n ≠ 1) (h2 : Odd n) :
+lemma reciprocalFactors_odd {n : ℕ} (h1 : n ≠ 1) (h2 : Odd n) :
     reciprocalFactors n = n % 4 * n :: reciprocalFactors (n / 4 + 1) := by
   have h0 : n ≠ 0
   · rintro rfl
     norm_num at h2
-  conv_lhs => unfold reciprocalFactors
-  rw [dif_neg h0, dif_neg h1, if_neg (Nat.odd_iff_not_even.mp h2)]
+  rw [reciprocalFactors, dif_neg h0, dif_neg h1, if_neg (Nat.odd_iff_not_even.mp h2)]
 
 /-- A finite product of Dihedral groups. -/
 abbrev Product (l : List ℕ) : Type :=

--- a/Mathlib/GroupTheory/CommutingProbability.lean
+++ b/Mathlib/GroupTheory/CommutingProbability.lean
@@ -8,6 +8,9 @@ import Mathlib.GroupTheory.Abelianization
 import Mathlib.GroupTheory.GroupAction.ConjAct
 import Mathlib.GroupTheory.GroupAction.Quotient
 import Mathlib.GroupTheory.Index
+import Mathlib.GroupTheory.SpecificGroups.Dihedral
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Qify
 
 #align_import group_theory.commuting_probability from "leanprover-community/mathlib"@"dc6c365e751e34d100e80fe6e314c3c3e0fd2988"
 
@@ -132,3 +135,85 @@ theorem inv_card_commutator_le_commProb : (↑(Nat.card (commutator G)))⁻¹ �
     (le_trans (ge_of_eq (commProb_eq_one_iff.mpr (Abelianization.commGroup G).mul_comm))
       (commutator G).commProb_quotient_le)
 #align inv_card_commutator_le_comm_prob inv_card_commutator_le_commProb
+
+-- Construction of group with commuting probability 1/n
+namespace DihedralGroup
+
+lemma commProb_odd (n : ℕ) (hn : Odd n) :
+    commProb (DihedralGroup n) = (n + 3) / (4 * n) := by
+  rw [commProb_def', DihedralGroup.card_conjClasses_odd hn, nat_card]
+  qify [show 2 ∣ n + 3 by rw [Nat.dvd_iff_mod_eq_zero, Nat.add_mod, Nat.odd_iff.mp hn]; rfl]
+  rw [div_div, ← mul_assoc]
+  congr
+
+lemma aux1 {n : ℕ} (h0 : n ≠ 0) : n / 2 < n :=
+  Nat.div_lt_self (Nat.pos_of_ne_zero h0) (lt_add_one 1)
+
+lemma aux2 : {n : ℕ} → (h0 : n ≠ 0) → (h1 : n ≠ 1) → n / 4 + 1 < n
+| 0 => by decide
+| 1 => by decide
+| 2 => by decide
+| 3 => by decide
+| n + 4 => by intros; linarith [n.add_div_right four_pos, n.div_le_self 4]
+
+def reciprocalFactors (n : ℕ) : List ℕ :=
+  if h0 : n = 0 then [0]
+  else if h1 : n = 1 then []
+  else if 2 ∣ n then
+    have := aux1 h0
+    3 :: reciprocalFactors (n / 2)
+  else
+    have := aux2 h0 h1
+    n % 4 * n :: reciprocalFactors (n / 4 + 1)
+
+def Product (l : List ℕ) : Type :=
+  ∀ i : Fin l.length, DihedralGroup l[i]
+
+instance (l : List ℕ) : Group (Product l) := Pi.group
+
+lemma commProb_nil : commProb (Product []) = 1 := by
+  simp_rw [Product, commProb_pi]
+
+lemma commProb_cons (n : ℕ) (l : List ℕ) :
+    commProb (Product (n :: l)) = commProb (DihedralGroup n) * commProb (Product l) := by
+  simp_rw [Product, commProb_pi, List.length_cons, Fin.prod_univ_succ, List.map_cons, List.prod_cons]
+  rfl
+
+lemma commProb_product (l : List ℕ) :
+    commProb (Product l) = (l.map (fun k => commProb (DihedralGroup k))).prod := by
+  induction' l with n l h
+  . rw [commProb_nil, List.map_nil, List.prod_nil]
+  . rw [commProb_cons, List.map_cons, List.prod_cons, h]
+
+theorem commProb_reciprocal (n : ℕ) :
+    commProb (Product (reciprocalFactors n)) = 1 / n := by
+  rw [commProb_product]
+  unfold reciprocalFactors
+  rw [←commProb_product]
+  by_cases h0 : n = 0
+  . rw [dif_pos h0, commProb_cons, commProb_nil, mul_one, h0, Nat.cast_zero, div_zero]
+    apply commProb_eq_zero_of_infinite
+  . by_cases h1 : n = 1
+    . rw [dif_neg h0, dif_pos h1, commProb_nil, h1, Nat.cast_one, div_one]
+    . by_cases h2 : 2 ∣  n
+      . have := aux1 h0
+        rw [dif_neg h0, dif_neg h1, if_pos h2, commProb_cons, commProb_reciprocal (n / 2),
+            commProb_odd 3 (by norm_num)]
+        field_simp [h0]
+        norm_num
+      . have := aux2 h0 h1
+        have key : n % 4 = 1 ∨ n % 4 = 3 := Nat.odd_mod_four_iff.mp (Nat.two_dvd_ne_zero.mp h2)
+        rw [dif_neg h0, dif_neg h1, if_neg h2, commProb_cons, commProb_reciprocal (n / 4 + 1),
+            commProb_odd (n % 4 * n)]
+        . rw [div_mul_div_comm, mul_one, div_eq_div_iff] <;> norm_cast
+          . have : (n % 4) ^ 2 + 3 = n % 4 * 4 := by rcases key with h | h <;> rw [h] <;> norm_num
+            calc ((n % 4) * n + 3) * n = (n % 4 * (4 * (n / 4)) + n % 4 * 4) * n :=
+                by rw [←this, sq, ←add_assoc, ←mul_add, Nat.div_add_mod]
+              _ = 1 * (4 * (n % 4 * n) * (n / 4 + 1)) := by ring
+          . have : n % 4 ≠ 0 := by rcases key with h | h <;> rw [h] <;> norm_num
+            positivity
+        . have : ¬ 2 ∣ n % 4 := by rcases key with h | h <;> rw [h] <;> norm_num
+          rw [Nat.two_dvd_ne_zero, ← Nat.odd_iff] at h2 this
+          exact this.mul h2
+
+end DihedralGroup

--- a/Mathlib/GroupTheory/CommutingProbability.lean
+++ b/Mathlib/GroupTheory/CommutingProbability.lean
@@ -10,6 +10,7 @@ import Mathlib.GroupTheory.GroupAction.Quotient
 import Mathlib.GroupTheory.Index
 import Mathlib.GroupTheory.SpecificGroups.Dihedral
 import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.LinearCombination
 import Mathlib.Tactic.Qify
 
 #align_import group_theory.commuting_probability from "leanprover-community/mathlib"@"dc6c365e751e34d100e80fe6e314c3c3e0fd2988"
@@ -201,16 +202,15 @@ theorem commProb_reciprocal (n : ℕ) :
         field_simp [h0]
         norm_num
       · have := div_four_lt h0 h1
+        rw [dif_neg h0, dif_neg h1, if_neg h2, commProb_cons, commProb_reciprocal (n / 4 + 1)]
         have key : n % 4 = 1 ∨ n % 4 = 3 := Nat.odd_mod_four_iff.mp (Nat.two_dvd_ne_zero.mp h2)
         have hn : Odd (n % 4) := by rcases key with h | h <;> rw [h] <;> norm_num
-        rw [dif_neg h0, dif_neg h1, if_neg h2]
-        rw [Nat.two_dvd_ne_zero, ← Nat.odd_iff] at h2
-        rw [commProb_cons, commProb_reciprocal (n / 4 + 1), commProb_odd (hn.mul h2)]
+        rw [commProb_odd (hn.mul (Nat.odd_iff.mpr (Nat.two_dvd_ne_zero.mp h2)))]
         rw [div_mul_div_comm, mul_one, div_eq_div_iff, one_mul] <;> norm_cast
-        · have : (n % 4) ^ 2 + 3 = n % 4 * 4 := by rcases key with h | h <;> rw [h] <;> norm_num
-          calc ((n % 4) * n + 3) * n = (n % 4 * (4 * (n / 4)) + n % 4 * 4) * n :=
-              by rw [←this, sq, ←add_assoc, ←mul_add, Nat.div_add_mod]
-            _ = (4 * (n % 4 * n) * (n / 4 + 1)) := by ring
+        · have h0 : (n % 4) ^ 2 + 3 = n % 4 * 4 := by rcases key with h | h <;> rw [h] <;> norm_num
+          have h1 := (Nat.div_add_mod n 4).symm
+          zify at h0 h1 ⊢
+          linear_combination (h0 + h1 * (n % 4)) * n
         · have := hn.pos.ne'
           positivity
 

--- a/Mathlib/GroupTheory/CommutingProbability.lean
+++ b/Mathlib/GroupTheory/CommutingProbability.lean
@@ -147,10 +147,10 @@ lemma commProb_odd {n : ℕ} (hn : Odd n) :
   rw [div_div, ← mul_assoc]
   congr
 
-lemma div_two_lt {n : ℕ} (h0 : n ≠ 0) : n / 2 < n :=
+private lemma div_two_lt {n : ℕ} (h0 : n ≠ 0) : n / 2 < n :=
   Nat.div_lt_self (Nat.pos_of_ne_zero h0) (lt_add_one 1)
 
-lemma div_four_lt : {n : ℕ} → (h0 : n ≠ 0) → (h1 : n ≠ 1) → n / 4 + 1 < n
+private lemma div_four_lt : {n : ℕ} → (h0 : n ≠ 0) → (h1 : n ≠ 1) → n / 4 + 1 < n
 | 0 | 1 | 2 | 3 => by decide
 | n + 4 => by intros; linarith [n.add_div_right four_pos, n.div_le_self 4]
 
@@ -165,11 +165,13 @@ def reciprocalFactors (n : ℕ) : List ℕ :=
     have := div_four_lt h0 h1
     n % 4 * n :: reciprocalFactors (n / 4 + 1)
 
-/-- A finite product of Dihedral groups. -/
-def Product (l : List ℕ) : Type :=
-  ∀ i : Fin l.length, DihedralGroup l[i]
+@[simp] lemma reciprocalFactors_zero : reciprocalFactors 0 = [0] := rfl
 
-instance (l : List ℕ) : Group (Product l) := Pi.group
+@[simp] lemma reciprocalFactors_one : reciprocalFactors 1 = [] := rfl
+
+/-- A finite product of Dihedral groups. -/
+abbrev Product (l : List ℕ) : Type :=
+  ∀ i : Fin l.length, DihedralGroup l[i]
 
 lemma commProb_nil : commProb (Product []) = 1 := by
   simp [Product, commProb_pi]

--- a/Mathlib/GroupTheory/CommutingProbability.lean
+++ b/Mathlib/GroupTheory/CommutingProbability.lean
@@ -158,7 +158,7 @@ private lemma div_four_lt : {n : ℕ} → (h0 : n ≠ 0) → (h1 : n ≠ 1) → 
 def reciprocalFactors (n : ℕ) : List ℕ :=
   if h0 : n = 0 then [0]
   else if h1 : n = 1 then []
-  else if 2 ∣ n then
+  else if Even n then
     have := div_two_lt h0
     3 :: reciprocalFactors (n / 2)
   else
@@ -169,21 +169,21 @@ def reciprocalFactors (n : ℕ) : List ℕ :=
 
 @[simp] lemma reciprocalFactors_one : reciprocalFactors 1 = [] := rfl
 
-@[simp] lemma reciprocalFactors_even {n : ℕ} (h0 : n ≠ 0) (h2 : Even n) :
+@[nolint unusedHavesSuffices] lemma reciprocalFactors_even {n : ℕ} (h0 : n ≠ 0) (h2 : Even n) :
     reciprocalFactors n = 3 :: reciprocalFactors (n / 2) := by
   have h1 : n ≠ 1
   · rintro rfl
     norm_num at h2
   conv_lhs => unfold reciprocalFactors
-  rw [dif_neg h0, dif_neg h1, if_pos h2.two_dvd]
+  rw [dif_neg h0, dif_neg h1, if_pos h2]
 
-@[simp] lemma reciprocalFactors_odd {n : ℕ} (h1 : n ≠ 1) (h2 : Odd n) :
+@[nolint unusedHavesSuffices] lemma reciprocalFactors_odd {n : ℕ} (h1 : n ≠ 1) (h2 : Odd n) :
     reciprocalFactors n = n % 4 * n :: reciprocalFactors (n / 4 + 1) := by
   have h0 : n ≠ 0
   · rintro rfl
     norm_num at h2
   conv_lhs => unfold reciprocalFactors
-  rw [dif_neg h0, dif_neg h1, if_neg h2.not_two_dvd_nat]
+  rw [dif_neg h0, dif_neg h1, if_neg (Nat.odd_iff_not_even.mp h2)]
 
 /-- A finite product of Dihedral groups. -/
 abbrev Product (l : List ℕ) : Type :=
@@ -214,8 +214,7 @@ theorem commProb_reciprocal (n : ℕ) :
     rw [reciprocalFactors_odd h1 h2, commProb_cons, commProb_reciprocal (n / 4 + 1)]
     have key : n % 4 = 1 ∨ n % 4 = 3 := Nat.odd_mod_four_iff.mp (Nat.odd_iff.mp h2)
     have hn : Odd (n % 4) := by rcases key with h | h <;> rw [h] <;> norm_num
-    rw [commProb_odd (hn.mul h2)]
-    rw [div_mul_div_comm, mul_one, div_eq_div_iff, one_mul] <;> norm_cast
+    rw [commProb_odd (hn.mul h2), div_mul_div_comm, mul_one, div_eq_div_iff, one_mul] <;> norm_cast
     · have h0 : (n % 4) ^ 2 + 3 = n % 4 * 4 := by rcases key with h | h <;> rw [h] <;> norm_num
       have h1 := (Nat.div_add_mod n 4).symm
       zify at h0 h1 ⊢


### PR DESCRIPTION
This PR constructs a group with commuting probability exactly 1/n as a product of dihedral groups.

Besides independent interest, this construction is useful for handling factors of 1/n (e.g., the end of this blog post: https://randompermutations.com/2015/02/06/commuting-probability-of-compact-groups/).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
