### PR TITLE
[Merged by Bors] - fix(NumberTheory/PythagoreanTriples): clear unnecessary hypothesis of `PythagoreanTriple.classification`

### DIFF
--- a/Mathlib/NumberTheory/PythagoreanTriples.lean
+++ b/Mathlib/NumberTheory/PythagoreanTriples.lean
@@ -679,6 +679,7 @@ theorem classification :
         (x = k * (m ^ 2 - n ^ 2) ∧ y = k * (2 * m * n) ∨
             x = k * (2 * m * n) ∧ y = k * (m ^ 2 - n ^ 2)) ∧
           (z = k * (m ^ 2 + n ^ 2) ∨ z = -k * (m ^ 2 + n ^ 2)) := by
+  clear h
   constructor
   · intro h
     obtain ⟨k, m, n, H⟩ := h.classified


### PR DESCRIPTION
The `rcases` tactic causes this theorem to pull in an unused assumption, as per [this Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/rcases.20modifies.20assumptions/near/371582124).

Before this PR, `PythagoreanTriple.classification` includes an unnecessary `h`:
```lean
theorem PythagoreanTriple.classification {x y z : ℤ} (h : PythagoreanTriple x y z) :
  PythagoreanTriple x y z ↔
    ∃ k m n,
      (x = k * (m ^ 2 - n ^ 2) ∧ y = k * (2 * m * n) ∨ x = k * (2 * m * n) ∧ y = k * (m ^ 2 - n ^ 2)) ∧
        (z = k * (m ^ 2 + n ^ 2) ∨ z = -k * (m ^ 2 + n ^ 2))
```

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
