### PR TITLE
feat(Topology/Order/Basic): show that suprema and infima are in closure if they exist

### DIFF
--- a/Mathlib/Topology/Order/Basic.lean
+++ b/Mathlib/Topology/Order/Basic.lean
@@ -2648,6 +2648,12 @@ theorem Antitone.map_iSup_of_continuousAt' {ι : Sort*} [Nonempty ι] {f : α �
   rfl
 #align antitone.map_supr_of_continuous_at' Antitone.map_iSup_of_continuousAt'
 
+theorem csSup_mem_closure {s : Set α} (hs : s.Nonempty) (H : BddAbove s) : sSup s ∈ closure s :=
+  (isLUB_csSup hs H).mem_closure hs
+
+theorem csInf_mem_closure {s : Set α} (hs : s.Nonempty) (H : BddBelow s) : sInf s ∈ closure s :=
+  (isGLB_csInf hs H).mem_closure hs
+
 end ConditionallyCompleteLinearOrder
 
 section CompleteLinearOrder


### PR DESCRIPTION
Adds two lemmas that generalize `sSup_mem_closure`, `sInf_mem_closure` to conditionally complete linear orders.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
