### PR TITLE
feat: automatically try `cache get` before build

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -64,6 +64,7 @@ partial def pipeLines (i o : IO.FS.Stream) : BaseIO Unit := do
       discard <| o.putStr ln |>.toBaseIO
       pipeLines i o
 
+-- When run as `lake build -KnoCacheGet`, do not invoke `lake exe cache get` automatically.
 def noCacheGet := get_config? noCacheGet |>.isSome
 
 /-- A target which performs `lake exe cache get`. -/

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -64,8 +64,12 @@ partial def pipeLines (i o : IO.FS.Stream) : BaseIO Unit := do
       discard <| o.putStr ln |>.toBaseIO
       pipeLines i o
 
+def noCacheGet := get_config? noCacheGet |>.isSome
+
 /-- A target which performs `lake exe cache get`. -/
 target cacheGet : Unit := do
+  if noCacheGet then
+    return .nil
   let cache ← cache.fetch
   cache.bindSync fun fname _ => do
   -- Pipe output directly to `stderr` so progress is visible and no `stdout:` prefix is produced.

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -28,11 +28,13 @@ package mathlib where
 lean_lib Mathlib where
   moreLeanArgs := moreLeanArgs
   weakLeanArgs := weakLeanArgs
+  extraDepTargets := #[`cacheGet]
 
 @[default_target]
 lean_exe runLinter where
   root := `scripts.runLinter
   supportInterpreter := true
+  extraDepTargets := #[`cacheGet]
 
 @[default_target]
 lean_exe checkYaml where
@@ -55,6 +57,13 @@ lean_lib Cache where
 
 lean_exe cache where
   root := `Cache.Main
+
+/-- A target which performs `lake exe cache get`. -/
+target cacheGet : Unit := do
+  let cache ← cache.fetch
+  cache.bindSync fun fname _ => do
+  proc {cmd := fname.toString, args := #["get"], env := ← getAugmentedEnv}
+  return ((), .nil)
 
 lean_lib MathlibExtras where
   roots := #[`MathlibExtras]


### PR DESCRIPTION
---

A quick proof-of-concept. With this, `lake build` will always try `cache get` before building mathlib.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
