### PR TITLE
[Merged by Bors] - chore(Analysis/NormedSpace/MatrixExponential): remove Lean 3 TC workarounds

### DIFF
--- a/Mathlib/Analysis/NormedSpace/MatrixExponential.lean
+++ b/Mathlib/Analysis/NormedSpace/MatrixExponential.lean
@@ -50,12 +50,6 @@ results for general rings are instead stated about `Ring.inverse`:
 * `Matrix.exp_conj`
 * `Matrix.exp_conj'`
 
-## Implementation notes
-
-This file runs into some sharp edges on typeclass search in lean 3, especially regarding pi types.
-To work around this, we copy a handful of instances for when lean can't find them by itself.
-Hopefully we will be able to remove these in Lean 4.
-
 ## TODO
 
 * Show that `Matrix.det (exp 𝕂 A) = exp 𝕂 (Matrix.trace A)`
@@ -67,35 +61,6 @@ Hopefully we will be able to remove these in Lean 4.
 
 
 open scoped Matrix BigOperators
-
-section HacksForPiInstanceSearch
-
-/-- A special case of `Pi.instTopologicalRing` for when `R` is not dependently typed. -/
-instance Function.topologicalRing (I : Type*) (R : Type*) [NonUnitalRing R] [TopologicalSpace R]
-    [TopologicalRing R] : TopologicalRing (I → R) :=
-  Pi.instTopologicalRing
-#align function.topological_ring Function.topologicalRing
-
-/-- A special case of `Function.algebra` for when A is a `Ring` not a `Semiring` -/
-instance Function.algebraRing (I : Type*) {R : Type*} (A : Type*) [CommSemiring R] [Ring A]
-    [Algebra R A] : Algebra R (I → A) :=
-  Pi.algebra _ _
-#align function.algebra_ring Function.algebraRing
-
-/-- A special case of `Pi.algebra` for when `f = λ i, Matrix (m i) (m i) A`. -/
-instance Pi.matrixAlgebra (I R A : Type*) (m : I → Type*) [CommSemiring R] [Semiring A]
-    [Algebra R A] [∀ i, Fintype (m i)] [∀ i, DecidableEq (m i)] :
-    Algebra R (∀ i, Matrix (m i) (m i) A) :=
-  @Pi.algebra I R (fun i => Matrix (m i) (m i) A) _ _ fun _ => Matrix.instAlgebra
-#align pi.matrix_algebra Pi.matrixAlgebra
-
-/-- A special case of `Pi.instTopologicalRing` for when `f = λ i, Matrix (m i) (m i) A`. -/
-instance Pi.matrix_topologicalRing (I A : Type*) (m : I → Type*) [Ring A] [TopologicalSpace A]
-    [TopologicalRing A] [∀ i, Fintype (m i)] : TopologicalRing (∀ i, Matrix (m i) (m i) A) :=
-  @Pi.instTopologicalRing _ (fun i => Matrix (m i) (m i) A) _ _ fun _ => Matrix.topologicalRing
-#align pi.matrix_topological_ring Pi.matrix_topologicalRing
-
-end HacksForPiInstanceSearch
 
 variable (𝕂 : Type*) {m n p : Type*} {n' : m → Type*} {𝔸 : Type*}
 


### PR DESCRIPTION
The file still compiles without these, so I guess as predicted we no longer need them. They were certainly needed in Lean 3.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
