### PR TITLE
[Merged by Bors] - docs: fix monoidal category docstring

### DIFF
--- a/Mathlib/CategoryTheory/Monoidal/Braided.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Braided.lean
@@ -17,9 +17,8 @@ as well as braided functors.
 
 ## Implementation note
 
-We make `BraidedMonoidalCategory` another typeclass, but then have `SymmetricMonoidalCategory`
-extend this. The rationale is that we are not carrying any additional data,
-just requiring a property.
+We make `BraidedCategory` another typeclass, but then have `SymmetricCategory` extend this.
+The rationale is that we are not carrying any additional data, just requiring a property.
 
 ## Future work
 


### PR DESCRIPTION
Seems like the classes are called `BraidedCategory` and `SymmetricCategory`, so I changed the docstring to reflect this.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
