### PR TITLE
feat: Reduced Spectral Theorem

### DIFF
--- a/Mathlib/LinearAlgebra/Matrix/Spectrum.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Spectrum.lean
@@ -161,6 +161,37 @@ lemma rank_eq_rank_diagonal : A.rank = (Matrix.diagonal hA.eigenvalues).rank := 
 lemma rank_eq_card_non_zero_eigs : A.rank = Fintype.card {i // hA.eigenvalues i ≠ 0} := by
   rw [rank_eq_rank_diagonal hA, Matrix.rank_diagonal]
 
+/-- # Reduced Spectral Theorem
+For A hermitian matrix A with rank A.rank ≤ n, we can eliminate the zero eigenvalues and their
+corresponding eigenvectors from the (alternate) spectral theroem. As such the matrix A can be written as:
+$$A = V₁ D V₁ᴴ$$
+where
+V₁ : n × r is the matrix of eigenvector with non-zero associated eigenvalues.
+D is r × r is the diagonal matrix containing only non-zero eigenvalues.
+with r = A.rank being the rank of the matrix -/
+noncomputable def fin_rank_equiv_eigs_ne_zero : {i // hA.eigenvalues i ≠ 0} ≃ Fin (A.rank) :=
+  Fintype.equivFinOfCardEq (rank_eq_card_non_zero_eigs _).symm
+
+noncomputable def fin_size_sub_rank_equiv_eigs_eq_zero :
+    {i // ¬ hA.eigenvalues i ≠ 0} ≃ Fin (Fintype.card n - A.rank) := by
+  apply Fintype.equivFinOfCardEq
+  rw [Fintype.card_subtype_compl, rank_eq_card_non_zero_eigs]
+
+noncomputable def fin_size_equiv_eigs :
+    {i // hA.eigenvalues i ≠ 0} ⊕ {i // ¬hA.eigenvalues i ≠ 0}  ≃ n := by
+  apply  Fintype.equivOfCardEq
+  rw [Fintype.card_sum, ← rank_eq_card_non_zero_eigs, Fintype.card_subtype_compl, ←
+    rank_eq_card_non_zero_eigs, ← Nat.add_sub_assoc, Nat.add_sub_cancel_left]
+  exact Matrix.rank_le_card_width _
+
+noncomputable def fin_size_equiv_rank_sum_compl :
+    Fin (A.rank) ⊕ Fin (Fintype.card n - A.rank) ≃ n := by
+  let s1 : {i // hA.eigenvalues i ≠ 0} ⊕ {i // ¬hA.eigenvalues i ≠ 0} ≃
+      Fin (A.rank) ⊕ Fin (Fintype.card n - A.rank) :=
+    Equiv.sumCongr (fin_rank_equiv_eigs_ne_zero _) (fin_size_sub_rank_equiv_eigs_eq_zero _)
+  apply Equiv.trans s1.symm (fin_size_equiv_eigs _)
+
+
 end IsHermitian
 
 end Matrix


### PR DESCRIPTION
For A hermitian matrix $A : n \times n$ with rank $A.rank \leq n$, we can eliminate the zero eigenvalues and their corresponding eigenvectors from the (alternate) spectral theorem. As such the matrix $A$ can be written as: $$A = V₁ D V₁ᴴ$$ where
- $V₁$ : $n \times r$ is the matrix of eigenvector with non-zero associated eigenvalues.
- $D$ is $r \times r$ is the diagonal matrix containing only non-zero eigenvalues on its main diagonal.
with $r = A.rank$ being the rank of the matrix

Towards that goal we make several equivalence definitions:

- `{i // hA.eigenvalues i ≠ 0} ≃ Fin (A.rank)` the set of non-zero eigenvalues can be indexed by the numbers from 0 to (r - 1).
- `{i // ¬ hA.eigenvalues i ≠ 0} ≃ Fin (n - A.rank)` the set of non-zero eigenvalues can be indexed by the numbers from 0 to (n - r - 1).
- `{i // hA.eigenvalues i ≠ 0} ⊕ {i // ¬hA.eigenvalues i ≠ 0}  ≃ n`: the index set of the matrix (together with the associated eigenvector matrix and eigenvalues matrix ) can be partitioned into two complement groups the ones corresponding to non-zero eigenvalues and the ones corresponding to zero eigenvalues.
- We can then put the previous definitions together to obtain a: `Fin (A.rank) ⊕ Fin (Fintype.card n - A.rank) ≃ n`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
