### PR TITLE
feat: the induced shift on the target category of a functor

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1145,6 +1145,7 @@ import Mathlib.CategoryTheory.Products.Bifunctor
 import Mathlib.CategoryTheory.Quotient
 import Mathlib.CategoryTheory.Shift.Basic
 import Mathlib.CategoryTheory.Shift.CommShift
+import Mathlib.CategoryTheory.Shift.Induced
 import Mathlib.CategoryTheory.Sigma.Basic
 import Mathlib.CategoryTheory.Simple
 import Mathlib.CategoryTheory.SingleObj

--- a/Mathlib/CategoryTheory/Shift/Induced.lean
+++ b/Mathlib/CategoryTheory/Shift/Induced.lean
@@ -1,0 +1,250 @@
+/-
+Copyright (c) 2023 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+import Mathlib.CategoryTheory.Shift.CommShift
+
+/-!
+# Shift induced from a category to another
+
+In this file, we introduce a sufficient condition on a functor
+`F : C ⥤ D` so that a shift on `C` by a monoid `A` induces a shift on `D`.
+More precisely, when the functor `(D ⥤ D) ⥤ C ⥤ D` given
+by the precomposition with `F` is fully faithful, and that
+all the shift functors on `C` can be lifted to functors `D ⥤ D`
+(i.e. we have functors `s a : D ⥤ D` for all `a : A`, and isomorphisms
+`F ⋙ s a ≅ shiftFunctor C a ⋙ F`), then these functors `s a` are
+the shift functors of a term of type `HasShift D A`.
+
+As this condition on the functor `F` is satisfied for quotient and localization
+functors, the main construction `HasShift.induced` in this file shall be
+used for both quotient and localized shifts.
+
+-/
+
+namespace CategoryTheory
+
+variable {C D : Type _} [Category C] [Category D]
+  (F : C ⥤ D) {A : Type _} [AddMonoid A] [HasShift C A]
+  (s : A → D ⥤ D) (i : ∀ a, F ⋙ s a ≅ shiftFunctor C a ⋙ F)
+  (hF : Nonempty (Full ((whiskeringLeft C D D).obj F)) ∧ Faithful ((whiskeringLeft C D D).obj F))
+
+namespace HasShift
+
+namespace Induced
+
+/-- The `zero` field of the `ShiftMkCore` structure for the induced shift. -/
+noncomputable def zero : s 0 ≅ 𝟭 D :=
+  letI := hF.1.some
+  have := hF.2
+  ((whiskeringLeft C D D).obj F).preimageIso ((i 0) ≪≫
+    isoWhiskerRight (shiftFunctorZero C A) F ≪≫ F.leftUnitor ≪≫ F.rightUnitor.symm)
+
+/-- The `add` field of the `ShiftMkCore` structure for the induced shift. -/
+noncomputable def add (a b : A) : s (a + b) ≅ s a ⋙ s b :=
+  letI := hF.1.some
+  have := hF.2
+  ((whiskeringLeft C D D).obj F).preimageIso
+    (i (a + b) ≪≫ isoWhiskerRight (shiftFunctorAdd C a b) F ≪≫
+      Functor.associator _ _ _ ≪≫
+        isoWhiskerLeft _ (i b).symm ≪≫ (Functor.associator _ _ _).symm ≪≫
+        isoWhiskerRight (i a).symm _ ≪≫ Functor.associator _ _ _)
+
+@[simp]
+lemma zero_hom_app_obj (X : C) :
+    (zero F s i hF).hom.app (F.obj X) =
+      (i 0).hom.app X ≫ F.map ((shiftFunctorZero C A).hom.app X) := by
+  letI := hF.1.some
+  have := hF.2
+  have h : whiskerLeft F (zero F s i hF).hom = _ :=
+    ((whiskeringLeft C D D).obj F).image_preimage _
+  exact (NatTrans.congr_app h X).trans (by simp)
+
+@[simp]
+lemma zero_inv_app_obj (X : C) :
+    (zero F s i hF).inv.app (F.obj X) =
+      F.map ((shiftFunctorZero C A).inv.app X) ≫ (i 0).inv.app X := by
+  letI := hF.1.some
+  have := hF.2
+  have h : whiskerLeft F (zero F s i hF).inv = _ :=
+    ((whiskeringLeft C D D).obj F).image_preimage _
+  exact (NatTrans.congr_app h X).trans (by simp)
+
+@[simp]
+lemma add_hom_app_obj (a b : A) (X : C) :
+    (add F s i hF a b).hom.app (F.obj X) =
+      (i (a + b)).hom.app X ≫ F.map ((shiftFunctorAdd C a b).hom.app X) ≫
+        (i b).inv.app ((shiftFunctor C a).obj X) ≫ (s b).map ((i a).inv.app X) := by
+  letI := hF.1.some
+  have := hF.2
+  have h : whiskerLeft F (add F s i hF a b).hom = _ :=
+    ((whiskeringLeft C D D).obj F).image_preimage _
+  exact (NatTrans.congr_app h X).trans (by simp)
+
+@[simp]
+lemma add_inv_app_obj (a b : A) (X : C) :
+    (add F s i hF a b).inv.app (F.obj X) =
+      (s b).map ((i a).hom.app X) ≫ (i b).hom.app ((shiftFunctor C a).obj X) ≫
+        F.map ((shiftFunctorAdd C a b).inv.app X) ≫ (i (a + b)).inv.app X := by
+  letI := hF.1.some
+  have := hF.2
+  have h : whiskerLeft F (add F s i hF a b).inv = _ :=
+    ((whiskeringLeft C D D).obj F).image_preimage _
+  exact (NatTrans.congr_app h X).trans (by simp)
+
+end Induced
+
+variable (A)
+
+/-- When `F : C ⥤ D` is a functor satisfying suitable technical assumptions,
+this is the induced term of type `HasShift D A` deduced from `[HasShift C A]`. -/
+noncomputable def induced : HasShift D A :=
+  hasShiftMk D A
+    { F := s
+      zero := Induced.zero F s i hF
+      add := Induced.add F s i hF
+      zero_add_hom_app := fun n => by
+        have := hF.2
+        suffices (Induced.add F s i hF 0 n).hom =
+          eqToHom (by rw [zero_add]; rfl) ≫ whiskerRight (Induced.zero F s i hF).inv (s n) by
+          intro X
+          simpa using NatTrans.congr_app this X
+        apply ((whiskeringLeft C D D).obj F).map_injective
+        ext X
+        have eq := dcongr_arg (fun a => (i a).hom.app X) (zero_add n)
+        dsimp
+        simp only [Induced.add_hom_app_obj, eq, shiftFunctorAdd_zero_add_hom_app,
+          Functor.map_comp, eqToHom_map, Category.assoc, eqToHom_trans_assoc,
+          eqToHom_refl, Category.id_comp, eqToHom_app, Induced.zero_inv_app_obj]
+        erw [← NatTrans.naturality_assoc, Iso.hom_inv_id_app_assoc]
+        rfl
+      add_zero_hom_app := fun n => by
+        have := hF.2
+        suffices (Induced.add F s i hF n 0).hom =
+            eqToHom (by rw [add_zero]; rfl) ≫ whiskerLeft (s n) (Induced.zero F s i hF).inv  by
+          intro X
+          simpa using NatTrans.congr_app this X
+        apply ((whiskeringLeft C D D).obj F).map_injective
+        ext X
+        dsimp
+        erw [Induced.add_hom_app_obj, dcongr_arg (fun a => (i a).hom.app X) (add_zero n),
+          ← cancel_mono ((s 0).map ((i n).hom.app X)), Category.assoc,
+          Category.assoc, Category.assoc, Category.assoc, Category.assoc,
+          Category.assoc, ← (s 0).map_comp, Iso.inv_hom_id_app, Functor.map_id, Category.comp_id,
+          ← NatTrans.naturality, Induced.zero_inv_app_obj,
+          shiftFunctorAdd_add_zero_hom_app]
+        simp [eqToHom_map, eqToHom_app]
+      assoc_hom_app := fun m₁ m₂ m₃ => by
+        have := hF.2
+        suffices (Induced.add F s i hF (m₁ + m₂) m₃).hom ≫
+            whiskerRight (Induced.add F s i hF m₁ m₂).hom (s m₃) =
+            eqToHom (by rw [add_assoc]) ≫ (Induced.add F s i hF m₁ (m₂ + m₃)).hom ≫
+              whiskerLeft (s m₁) (Induced.add F s i hF m₂ m₃).hom by
+          intro X
+          simpa using NatTrans.congr_app this X
+        apply ((whiskeringLeft C D D).obj F).map_injective
+        ext X
+        dsimp
+        have eq := F.congr_map (shiftFunctorAdd'_assoc_hom_app
+          m₁ m₂ m₃ _ _ (m₁+m₂+m₃) rfl rfl rfl X)
+        simp only [shiftFunctorAdd'_eq_shiftFunctorAdd] at eq
+        simp only [Functor.comp_obj, Functor.map_comp, shiftFunctorAdd',
+          Iso.trans_hom, eqToIso.hom, NatTrans.comp_app, eqToHom_app,
+          Category.assoc] at eq
+        rw [← cancel_mono ((s m₃).map ((s m₂).map ((i m₁).hom.app X)))]
+        simp only [Induced.add_hom_app_obj, Category.assoc, Functor.map_comp]
+        slice_lhs 4 5 =>
+          erw [← Functor.map_comp, Iso.inv_hom_id_app, Functor.map_id]
+        erw [Category.id_comp]
+        slice_lhs 6 7 =>
+          erw [← Functor.map_comp, ← Functor.map_comp, Iso.inv_hom_id_app,
+            (s m₂).map_id, (s m₃).map_id]
+        erw [Category.comp_id, ←NatTrans.naturality_assoc, reassoc_of% eq,
+          dcongr_arg (fun a => (i a).hom.app X) (add_assoc m₁ m₂ m₃).symm]
+        simp only [Functor.comp_obj, eqToHom_map, eqToHom_app, NatTrans.naturality_assoc,
+          Induced.add_hom_app_obj, Functor.comp_map, Category.assoc, Iso.inv_hom_id_app_assoc,
+          eqToHom_trans_assoc, eqToHom_refl, Category.id_comp, Category.comp_id,
+          ← Functor.map_comp, Iso.inv_hom_id_app, Functor.map_id] }
+
+end HasShift
+
+@[simp]
+lemma shiftFunctor_of_induced (a : A) :
+    letI := HasShift.induced F A s i hF
+    shiftFunctor D a = s a := by
+  rfl
+
+variable (A)
+
+@[simp]
+lemma shiftFunctorZero_hom_app_obj_of_induced (X : C) :
+    letI := HasShift.induced F A s i hF
+    (shiftFunctorZero D A).hom.app (F.obj X) =
+      (i 0).hom.app X ≫ F.map ((shiftFunctorZero C A).hom.app X) := by
+  letI := HasShift.induced F A s i
+  simp only [ShiftMkCore.shiftFunctorZero_eq, HasShift.Induced.zero_hom_app_obj]
+
+@[simp]
+lemma shiftFunctorZero_inv_app_obj_of_induced (X : C) :
+    letI := HasShift.induced F A s i hF
+    (shiftFunctorZero D A).inv.app (F.obj X) =
+      F.map ((shiftFunctorZero C A).inv.app X) ≫ (i 0).inv.app X := by
+  letI := HasShift.induced F A s i
+  simp only [ShiftMkCore.shiftFunctorZero_eq, HasShift.Induced.zero_inv_app_obj]
+
+variable {A}
+
+@[simp]
+lemma shiftFunctorAdd_hom_app_obj_of_induced (a b : A) (X : C) :
+    letI := HasShift.induced F A s i hF
+    (shiftFunctorAdd D a b).hom.app (F.obj X) =
+      (i (a + b)).hom.app X ≫
+        F.map ((shiftFunctorAdd C a b).hom.app X) ≫
+        (i b).inv.app ((shiftFunctor C a).obj X) ≫
+        (s b).map ((i a).inv.app X) := by
+  letI := HasShift.induced F A s i
+  simp only [ShiftMkCore.shiftFunctorAdd_eq, HasShift.Induced.add_hom_app_obj]
+
+@[simp]
+lemma induced_add_inv_app_obj (a b : A) (X : C) :
+    letI := HasShift.induced F A s i hF
+    (shiftFunctorAdd D a b).inv.app (F.obj X) =
+      (s b).map ((i a).hom.app X) ≫
+      (i b).hom.app ((shiftFunctor C a).obj X) ≫
+      F.map ((shiftFunctorAdd C a b).inv.app X) ≫
+      (i (a + b)).inv.app X := by
+  letI := HasShift.induced F A s i
+  simp only [ShiftMkCore.shiftFunctorAdd_eq, HasShift.Induced.add_inv_app_obj]
+
+variable (A)
+
+/-- When the target category of a functor `F : C ⥤ D` is equipped with
+the induced shift, this is the compatibility of `F` with the shifts on
+the categories `C` and `D`. -/
+def Functor.CommShift.ofInduced :
+    letI := HasShift.induced F A s i hF
+    F.CommShift A := by
+  letI := HasShift.induced F A s i hF
+  exact
+    { iso := fun a => (i a).symm
+      zero := by
+        ext X
+        dsimp
+        simp only [isoZero_hom_app, shiftFunctorZero_inv_app_obj_of_induced,
+          ← F.map_comp_assoc, Iso.hom_inv_id_app, F.map_id, Category.id_comp]
+      add := fun a b => by
+        ext X
+        dsimp
+        simp only [isoAdd_hom_app, Iso.symm_hom, induced_add_inv_app_obj,
+          shiftFunctor_of_induced]
+        erw [← Functor.map_comp_assoc, Iso.inv_hom_id_app, Functor.map_id,
+          Category.id_comp, Iso.inv_hom_id_app_assoc, ←F.map_comp_assoc, Iso.hom_inv_id_app,
+          F.map_id, Category.id_comp] }
+
+lemma Functor.commShiftIso_eq_ofInduced (a : A) :
+    letI := HasShift.induced F A s i hF
+    letI := Functor.CommShift.ofInduced F A s i hF
+    F.commShiftIso a = (i a).symm := rfl
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/Shift/Induced.lean
+++ b/Mathlib/CategoryTheory/Shift/Induced.lean
@@ -56,7 +56,6 @@ lemma zero_hom_app_obj (X : C) :
     (zero F s i hF).hom.app (F.obj X) =
       (i 0).hom.app X ≫ F.map ((shiftFunctorZero C A).hom.app X) := by
   letI := hF.1.some
-  have := hF.2
   have h : whiskerLeft F (zero F s i hF).hom = _ :=
     ((whiskeringLeft C D D).obj F).image_preimage _
   exact (NatTrans.congr_app h X).trans (by simp)
@@ -66,7 +65,6 @@ lemma zero_inv_app_obj (X : C) :
     (zero F s i hF).inv.app (F.obj X) =
       F.map ((shiftFunctorZero C A).inv.app X) ≫ (i 0).inv.app X := by
   letI := hF.1.some
-  have := hF.2
   have h : whiskerLeft F (zero F s i hF).inv = _ :=
     ((whiskeringLeft C D D).obj F).image_preimage _
   exact (NatTrans.congr_app h X).trans (by simp)
@@ -77,7 +75,6 @@ lemma add_hom_app_obj (a b : A) (X : C) :
       (i (a + b)).hom.app X ≫ F.map ((shiftFunctorAdd C a b).hom.app X) ≫
         (i b).inv.app ((shiftFunctor C a).obj X) ≫ (s b).map ((i a).inv.app X) := by
   letI := hF.1.some
-  have := hF.2
   have h : whiskerLeft F (add F s i hF a b).hom = _ :=
     ((whiskeringLeft C D D).obj F).image_preimage _
   exact (NatTrans.congr_app h X).trans (by simp)
@@ -88,7 +85,6 @@ lemma add_inv_app_obj (a b : A) (X : C) :
       (s b).map ((i a).hom.app X) ≫ (i b).hom.app ((shiftFunctor C a).obj X) ≫
         F.map ((shiftFunctorAdd C a b).inv.app X) ≫ (i (a + b)).inv.app X := by
   letI := hF.1.some
-  have := hF.2
   have h : whiskerLeft F (add F s i hF a b).inv = _ :=
     ((whiskeringLeft C D D).obj F).image_preimage _
   exact (NatTrans.congr_app h X).trans (by simp)


### PR DESCRIPTION
This PR shows that under suitable assumptions on a functor `F : C ⥤ D`, a shift by a monoid `A` on `C` induces a shift on the category `D`.

---

This was merged by mistake into master on 2023-08-18, and immediately reverted.

There will be separate PR which develop this API for quotient and localization functors. (Using #6626 this will give the shift on the homotopy category of cochain complexes. Much later, this will give the shift on the derived category of an abelian category.)

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
