### PR TITLE
feat(..Polynomial..): `MvPolynomial`s have no zero divisors

### DIFF
--- a/Mathlib/Algebra/MonoidAlgebra/NoZeroDivisors.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/NoZeroDivisors.lean
@@ -37,8 +37,38 @@ The conditions on `A` imposed in `NoZeroDivisors.of_left_ordered` are sometimes 
 The conditions on `A` imposed in `NoZeroDivisors.of_right_ordered` are sometimes referred to as
 `right-ordered`.
 
+* `NoZeroDivisors.biOrdered` shows that if `R` is a semiring with no non-zero zero-divisors,
+  `A` has an addition, a linear order and both addition on the left and addition on the right are
+  strictly monotone functions, then `AddMonoidAlgebra R A` has no non-zero zero-divisors.
+
 These conditions are sufficient, but not necessary.  As mentioned above, *Kaplansky's Conjecture*
 asserts that `A` being torsion-free may be enough.
+
+
+###  Remarks
+To prove `NoZeroDivisors.biOrdered`,
+we use `CovariantClass` assumptions on `A`.  In combination with `LinearOrder A`, these
+assumptions actually imply that `A` is cancellative.  However, cancellativity alone in not enough.
+Indeed, using `ZMod 2`, that is `ℤ / 2 ℤ`, as the grading type `A`, there are examples of
+`AddMonoidAlgebra`s containing non-zero zero divisors:
+```lean
+import Mathlib.Data.ZMod.Defs
+import Mathlib.Algebra.MonoidAlgebra.Basic
+
+open Finsupp AddMonoidAlgebra
+
+example {R} [Ring R] [Nontrivial R] :
+  ∃ x y : AddMonoidAlgebra R (ZMod 2), x * y = 0 ∧ x ≠ 0 ∧ y ≠ 0 :=
+by
+  --  use `[1 (mod 2)] - 1` and `[1 (mod 2)] + 1`, the rest is easy
+  refine ⟨of' _ _ 1 - AddMonoidAlgebra.single 0 1, of' _ _ 1 +  AddMonoidAlgebra.single 0 1, ?_, ?_⟩
+  · simp [sub_mul, mul_add, single_mul_single, sub_eq_zero]; rfl
+  · simp only [of'_apply, sub_eq_add_neg, ne_eq, ← eq_neg_iff_add_eq_zero.not, neg_neg]
+    rw [← Finsupp.single_neg, single_eq_single_iff, single_eq_single_iff]
+    simp
+```
+In this case, the grading type is the additive monoid `ZMod 2` which is an abelian group
+(and, in particular, it is cancellative).
 -/
 
 

--- a/Mathlib/Algebra/MonoidAlgebra/NoZeroDivisors.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/NoZeroDivisors.lean
@@ -206,8 +206,7 @@ of the support of `f` (e.g. the product is `0` if "top" is not a maximum).
 The corresponding statement for a general product `f * g` is `AddMonoidAlgebra.mul_apply_of_le`.
 It is proved with a further `CovariantClass` assumption. -/
 theorem single_mul_apply_of_le (r : R) (ft : ∀ a ∈ f.support, a ≤ t) :
-  -- the `HMul` is really ugly, how can I avoid it?
-  (@HMul.hMul (AddMonoidAlgebra R A) _ _ _ (Finsupp.single a r) f) (a + t) = r * f t := by
+  ((AddMonoidAlgebra.single a r) * f) (a + t) = r * f t := by
   classical
   simp only [id_eq]
   nth_rw 1 [← f.erase_add_single t]
@@ -228,8 +227,7 @@ of the support of `f` (e.g. the product is `0` if "bottom" is not a minimum).
 The corresponding statement for a general product `f * g` is `AddMonoidAlgebra.mul_apply_of_le'`.
 It is proved with a further `CovariantClass` assumption. -/
 theorem single_mul_apply_of_le' (r : R) (fb : ∀ a ∈ f.support, b ≤ a) :
-  -- the `HMul` is really ugly, how can I avoid it?
-  (@HMul.hMul (AddMonoidAlgebra R A) _ _ _ (Finsupp.single a r) f) (a + b) = r * f b :=
+  ((AddMonoidAlgebra.single a r) * f) (a + b) = r * f b :=
 @single_mul_apply_of_le _ Aᵒᵈ _ _ _ _ _ _ _ _ fb
 
 variable [CovariantClass A A (Function.swap (· + ·)) (· < ·)]
@@ -271,17 +269,16 @@ section LinearOrder
 variable [NoZeroDivisors R] [Add A] [LinearOrder A] [CovariantClass A A (· + ·) (· < ·)]
   [CovariantClass A A (Function.swap (· + ·)) (· < ·)]
 
-protected theorem NoZeroDivisors.biOrdered : NoZeroDivisors (AddMonoidAlgebra R A) :=
-by
-  constructor
+protected theorem NoZeroDivisors.biOrdered : NoZeroDivisors (AddMonoidAlgebra R A) := ⟨by
   intros f g fg
   contrapose! fg
-  apply_fun (fun x : AddMonoidAlgebra R A ↦ x (f.support.max' (Finsupp.support_nonempty_iff.mpr fg.1)
+  apply_fun (fun x ↦ x (f.support.max' (Finsupp.support_nonempty_iff.mpr fg.1)
     + g.support.max' (Finsupp.support_nonempty_iff.mpr fg.2)))
   simp only [Finsupp.coe_zero, Pi.zero_apply]
-  rw [mul_apply_of_le] <;> try exact Finset.le_max' _
+  rw [mul_apply_of_le] <;>
+    try exact Finset.le_max' _
   refine mul_ne_zero_iff.mpr ⟨?_, ?_⟩ <;>
-  exact Finsupp.mem_support_iff.mp (Finset.max'_mem _ _)
+    exact Finsupp.mem_support_iff.mp (Finset.max'_mem _ _)⟩
 
 end LinearOrder
 

--- a/Mathlib/Algebra/MonoidAlgebra/NoZeroDivisors.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/NoZeroDivisors.lean
@@ -199,7 +199,7 @@ section PartialOrder
 variable [PartialOrder A] [CovariantClass A A (· + ·) (· < ·)] {a t b : A}
   {f g : AddMonoidAlgebra R A}
 
-/--  The "top" element of `Finsupp.single a r * f`  is the product of `r` and
+/--  The "top" element of `AddMonoidAlgebra.single a r * f` is the product of `r` and
 the "top" element of `f`.  Here, "top" is simply an upper bound for the elements
 of the support of `f` (e.g. the product is `0` if "top" is not a maximum).
 The corresponding statement for a general product `f * g` is `AddMonoidAlgebra.mul_apply_of_le`.
@@ -220,7 +220,7 @@ theorem single_mul_apply_of_le (r : R) (ft : ∀ a ∈ f.support, a ≤ t) :
   refine WithBot.coe_lt_coe.mpr ((ft _ (Finset.mem_of_mem_erase xs)).lt_of_ne ?_)
   exact Finset.ne_of_mem_erase xs
 
-/--  The "bottom" element of `Finsupp.single a r * f`  is the product of `r` and
+/--  The "bottom" element of `Finsupp.single a r * f` is the product of `r` and
 the "bottom" element of `f`.  Here, "bottom" is simply a lower bound for the elements
 of the support of `f` (e.g. the product is `0` if "bottom" is not a minimum).
 The corresponding statement for a general product `f * g` is `AddMonoidAlgebra.mul_apply_of_le'`.
@@ -231,7 +231,7 @@ theorem single_mul_apply_of_le' (r : R) (fb : ∀ a ∈ f.support, b ≤ a) :
 
 variable [CovariantClass A A (Function.swap (· + ·)) (· < ·)]
 
-/--  The "top" element of `f * g`  is the product of the "top" elements of `f` and of `g`.
+/--  The "top" element of `f * g` is the product of the "top" elements of `f` and of `g`.
 Here, "top" is simply an upper bound for the elements of the support of the corresponding
 polynomial (e.g. the product is `0` if "top" is not a maximum). -/
 theorem mul_apply_of_le (fa : ∀ i ∈ f.support, i ≤ a) (gt : ∀ i ∈ g.support, i ≤ t) :
@@ -247,7 +247,7 @@ theorem mul_apply_of_le (fa : ∀ i ∈ f.support, i ≤ a) (gt : ∀ i ∈ g.su
   haveI : CovariantClass A A (· + ·) (· ≤ ·) := Add.to_covariantClass_left A
   exact fun x xa xf y yg ↦ (add_lt_add_of_lt_of_le ((fa _ xf).lt_of_ne xa) (gt _ yg)).ne'
 
-/--  The "bottom" element of `f * g`  is the product of the "bottom" elements of `f` and of `g`.
+/--  The "bottom" element of `f * g` is the product of the "bottom" elements of `f` and of `g`.
 Here, "bottom" is simply a lower bound for the elements of the support of the corresponding
 polynomial (e.g. the product is `0` if "bottom" is not a minimum). -/
 theorem mul_apply_of_le' (fa : ∀ i ∈ f.support, a ≤ i) (gb : ∀ i ∈ g.support, b ≤ i) :

--- a/Mathlib/Algebra/MonoidAlgebra/NoZeroDivisors.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/NoZeroDivisors.lean
@@ -83,7 +83,7 @@ theorem Right.exists_add_of_mem_support_single_mul [AddRightCancelSemigroup A]
 
 /-- If `R` is a semiring with no non-trivial zero-divisors and `A` is a left-ordered add right
 cancel semigroup, then `AddMonoidAlgebra R A` also contains no non-zero zero-divisors. -/
-theorem NoZeroDivisors.of_left_ordered [NoZeroDivisors R] [AddRightCancelSemigroup A]
+instance NoZeroDivisors.of_left_ordered [NoZeroDivisors R] [AddRightCancelSemigroup A]
     [LinearOrder A] [CovariantClass A A (· + ·) (· < ·)] : NoZeroDivisors (AddMonoidAlgebra R A) :=
   ⟨@fun f g fg => by
     contrapose! fg
@@ -160,5 +160,101 @@ theorem NoZeroDivisors.of_right_ordered [NoZeroDivisors R] [AddLeftCancelSemigro
 #align add_monoid_algebra.no_zero_divisors.of_right_ordered AddMonoidAlgebra.NoZeroDivisors.of_right_ordered
 
 end LeftOrRightOrderability
+
+set_option autoImplicit false
+
+section Covariant_lt
+variable [Add A]
+
+section PartialOrder
+variable [PartialOrder A] [CovariantClass A A (· + ·) (· < ·)] {a t b : A}
+  {f g : AddMonoidAlgebra R A}
+
+/--  The "top" element of `Finsupp.single a r * f`  is the product of `r` and
+the "top" element of `f`.  Here, "top" is simply an upper bound for the elements
+of the support of `f` (e.g. the product is `0` if "top" is not a maximum).
+The corresponding statement for a general product `f * g` is `AddMonoidAlgebra.mul_apply_of_le`.
+It is proved with a further `CovariantClass` assumption. -/
+theorem single_mul_apply_of_le (r : R) (ft : ∀ a ∈ f.support, a ≤ t) :
+  -- the `HMul` is really ugly, how can I avoid it?
+  (@HMul.hMul (AddMonoidAlgebra R A) _ _ _ (Finsupp.single a r) f) (a + t) = r * f t := by
+  classical
+  simp only [id_eq]
+  nth_rw 1 [← f.erase_add_single t]
+  rw [mul_add, single_mul_single, Finsupp.add_apply, Finsupp.single_eq_same]
+  convert zero_add _
+  refine Finsupp.not_mem_support_iff.mp (fun h ↦ ?_)
+  refine not_not.mpr ((support_mul (Finsupp.single a r) (f.erase t)) h) ?_
+  simp only [Finsupp.mem_support_single, Finset.mem_biUnion, Ne.def, Finset.mem_singleton,
+    exists_prop, not_exists, not_and, and_imp, forall_eq, Finsupp.support_erase]
+  intros _ x xs
+  refine (add_lt_add_left (WithBot.coe_lt_coe.mp ?_) _).ne'
+  refine WithBot.coe_lt_coe.mpr ((ft _ (Finset.mem_of_mem_erase xs)).lt_of_ne ?_)
+  exact Finset.ne_of_mem_erase xs
+
+/--  The "bottom" element of `Finsupp.single a r * f`  is the product of `r` and
+the "bottom" element of `f`.  Here, "bottom" is simply a lower bound for the elements
+of the support of `f` (e.g. the product is `0` if "bottom" is not a minimum).
+The corresponding statement for a general product `f * g` is `AddMonoidAlgebra.mul_apply_of_le'`.
+It is proved with a further `CovariantClass` assumption. -/
+theorem single_mul_apply_of_le' (r : R) (fb : ∀ a ∈ f.support, b ≤ a) :
+  -- the `HMul` is really ugly, how can I avoid it?
+  (@HMul.hMul (AddMonoidAlgebra R A) _ _ _ (Finsupp.single a r) f) (a + b) = r * f b :=
+@single_mul_apply_of_le _ Aᵒᵈ _ _ _ _ _ _ _ _ fb
+
+variable [CovariantClass A A (Function.swap (· + ·)) (· < ·)]
+
+/--  The "top" element of `f * g`  is the product of the "top" elements of `f` and of `g`.
+Here, "top" is simply an upper bound for the elements of the support of the corresponding
+polynomial (e.g. the product is `0` if "top" is not a maximum). -/
+theorem mul_apply_of_le (fa : ∀ i ∈ f.support, i ≤ a) (gt : ∀ i ∈ g.support, i ≤ t) :
+  (f * g) (a + t) = f a * g t :=
+by
+  classical
+  nth_rw 1 [← f.erase_add_single a]
+  rw [add_mul, Finsupp.add_apply, single_mul_apply_of_le _ gt]
+  convert zero_add _
+  refine Finsupp.not_mem_support_iff.mp (fun h ↦ ?_)
+  refine not_not.mpr ((support_mul _ g) h) ?_
+  simp only [Finsupp.support_erase, Finset.mem_biUnion, Finset.mem_erase, Ne.def,
+    Finset.mem_singleton, exists_prop, not_exists, not_and, and_imp]
+  haveI : CovariantClass A A (· + ·) (· ≤ ·) := Add.to_covariantClass_left A
+  exact fun x xa xf y yg ↦ (add_lt_add_of_lt_of_le ((fa _ xf).lt_of_ne xa) (gt _ yg)).ne'
+
+/--  The "bottom" element of `f * g`  is the product of the "bottom" elements of `f` and of `g`.
+Here, "bottom" is simply a lower bound for the elements of the support of the corresponding
+polynomial (e.g. the product is `0` if "bottom" is not a minimum). -/
+theorem mul_apply_of_le' (fa : ∀ i ∈ f.support, a ≤ i) (gb : ∀ i ∈ g.support, b ≤ i) :
+  (f * g) (a + b) = f a * g b :=
+@mul_apply_of_le _ Aᵒᵈ _ _ _ _ _ _ _ _ _ fa gb
+
+theorem mul_apply_eq_zero_of_lt (fa : ∀ i ∈ f.support, a ≤ i) (gb : ∀ i ∈ g.support, b < i) :
+  (f * g) (a + b) = 0 :=
+by
+  rw [mul_apply_of_le' fa (fun x hx ↦ ((gb _ hx).le))]
+  convert mul_zero _
+  exact Finsupp.not_mem_support_iff.mp (fun bg ↦ (lt_irrefl b (gb b bg)).elim)
+
+end PartialOrder
+
+section LinearOrder
+variable [NoZeroDivisors R] [Add A] [LinearOrder A] [CovariantClass A A (· + ·) (· < ·)]
+  [CovariantClass A A (Function.swap (· + ·)) (· < ·)]
+
+protected theorem NoZeroDivisors.biOrdered : NoZeroDivisors (AddMonoidAlgebra R A) :=
+by
+  constructor
+  intros f g fg
+  contrapose! fg
+  apply_fun (fun x : AddMonoidAlgebra R A ↦ x (f.support.max' (Finsupp.support_nonempty_iff.mpr fg.1)
+    + g.support.max' (Finsupp.support_nonempty_iff.mpr fg.2)))
+  simp only [Finsupp.coe_zero, Pi.zero_apply]
+  rw [mul_apply_of_le] <;> try exact Finset.le_max' _
+  refine mul_ne_zero_iff.mpr ⟨?_, ?_⟩ <;>
+  exact Finsupp.mem_support_iff.mp (Finset.max'_mem _ _)
+
+end LinearOrder
+
+end Covariant_lt
 
 end AddMonoidAlgebra

--- a/Mathlib/Algebra/MonoidAlgebra/NoZeroDivisors.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/NoZeroDivisors.lean
@@ -58,8 +58,7 @@ import Mathlib.Algebra.MonoidAlgebra.Basic
 open Finsupp AddMonoidAlgebra
 
 example {R} [Ring R] [Nontrivial R] :
-  ∃ x y : AddMonoidAlgebra R (ZMod 2), x * y = 0 ∧ x ≠ 0 ∧ y ≠ 0 :=
-by
+  ∃ x y : AddMonoidAlgebra R (ZMod 2), x * y = 0 ∧ x ≠ 0 ∧ y ≠ 0 := by
   --  use `[1 (mod 2)] - 1` and `[1 (mod 2)] + 1`, the rest is easy
   refine ⟨of' _ _ 1 - AddMonoidAlgebra.single 0 1, of' _ _ 1 +  AddMonoidAlgebra.single 0 1, ?_, ?_⟩
   · simp [sub_mul, mul_add, single_mul_single, sub_eq_zero]; rfl
@@ -236,8 +235,7 @@ variable [CovariantClass A A (Function.swap (· + ·)) (· < ·)]
 Here, "top" is simply an upper bound for the elements of the support of the corresponding
 polynomial (e.g. the product is `0` if "top" is not a maximum). -/
 theorem mul_apply_of_le (fa : ∀ i ∈ f.support, i ≤ a) (gt : ∀ i ∈ g.support, i ≤ t) :
-  (f * g) (a + t) = f a * g t :=
-by
+  (f * g) (a + t) = f a * g t := by
   classical
   nth_rw 1 [← f.erase_add_single a]
   rw [add_mul, Finsupp.add_apply, single_mul_apply_of_le _ gt]
@@ -257,8 +255,7 @@ theorem mul_apply_of_le' (fa : ∀ i ∈ f.support, a ≤ i) (gb : ∀ i ∈ g.s
 @mul_apply_of_le _ Aᵒᵈ _ _ _ _ _ _ _ _ _ fa gb
 
 theorem mul_apply_eq_zero_of_lt (fa : ∀ i ∈ f.support, a ≤ i) (gb : ∀ i ∈ g.support, b < i) :
-  (f * g) (a + b) = 0 :=
-by
+  (f * g) (a + b) = 0 := by
   rw [mul_apply_of_le' fa (fun x hx ↦ ((gb _ hx).le))]
   convert mul_zero _
   exact Finsupp.not_mem_support_iff.mp (fun bg ↦ (lt_irrefl b (gb b bg)).elim)

--- a/Mathlib/Data/MvPolynomial/Basic.lean
+++ b/Mathlib/Data/MvPolynomial/Basic.lean
@@ -4,9 +4,12 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Johan Commelin, Mario Carneiro
 -/
 import Mathlib.Algebra.Algebra.Tower
+import Mathlib.Algebra.MonoidAlgebra.NoZeroDivisors
 import Mathlib.Algebra.Regular.Pow
 import Mathlib.Algebra.MonoidAlgebra.Support
 import Mathlib.Data.Finsupp.Antidiagonal
+import Mathlib.Data.Finsupp.Lex
+import Mathlib.Order.Extension.Linear
 import Mathlib.Order.SymmDiff
 import Mathlib.RingTheory.Adjoin.Basic
 
@@ -158,6 +161,18 @@ instance smulCommClass_right [CommSemiring S₁] [DistribSMul R S₁] [SMulCommC
 instance unique [CommSemiring R] [Subsingleton R] : Unique (MvPolynomial σ R) :=
   AddMonoidAlgebra.unique
 #align mv_polynomial.unique MvPolynomial.unique
+
+open AddMonoidAlgebra Finsupp.Lex in
+instance instNoZeroDivisorsMvPolynomial [CommSemiring R] [nz : NoZeroDivisors R] :
+    NoZeroDivisors (MvPolynomial σ R) := by
+  let _ : LinearOrder σ := by
+    let _ : PartialOrder σ :=
+    { le := (· = ·)
+      le_refl := fun a ↦ rfl
+      le_trans := fun a b c => Eq.trans
+      le_antisymm := fun a b ab _ => ab }
+    exact instLinearOrderLinearExtension
+  exact @NoZeroDivisors.of_left_ordered R (σ →₀ ℕ) _ nz _ linearOrder covariantClass_lt_left
 
 end Instances
 

--- a/Mathlib/Data/Polynomial/RingDivision.lean
+++ b/Mathlib/Data/Polynomial/RingDivision.lean
@@ -4,11 +4,12 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes, Johannes Hölzl, Scott Morrison, Jens Wagemaker, Johan Commelin
 -/
 import Mathlib.Algebra.CharZero.Infinite
+import Mathlib.Algebra.MonoidAlgebra.NoZeroDivisors
+import Mathlib.Algebra.Polynomial.BigOperators
 import Mathlib.Data.Polynomial.AlgebraMap
 import Mathlib.Data.Polynomial.Degree.Lemmas
 import Mathlib.Data.Polynomial.Div
 import Mathlib.RingTheory.Localization.FractionRing
-import Mathlib.Algebra.Polynomial.BigOperators
 
 #align_import data.polynomial.ring_division from "leanprover-community/mathlib"@"8efcf8022aac8e01df8d302dcebdbc25d6a886c8"
 
@@ -126,16 +127,11 @@ section NoZeroDivisors
 
 variable [Semiring R] [NoZeroDivisors R] {p q : R[X]}
 
-instance : NoZeroDivisors R[X] where
-  eq_zero_or_eq_zero_of_mul_eq_zero h := by
-    rw [← leadingCoeff_eq_zero, ← leadingCoeff_eq_zero]
-    refine' eq_zero_or_eq_zero_of_mul_eq_zero _
-    rw [← leadingCoeff_zero, ← leadingCoeff_mul, h]
+instance : NoZeroDivisors R[X] := ⟨fun h => by apply_fun toFinsuppIso R at h; simpa using h⟩
 
-theorem natDegree_mul (hp : p ≠ 0) (hq : q ≠ 0) : (p*q).natDegree = p.natDegree + q.natDegree := by
-  rw [← WithBot.coe_eq_coe, ← Nat.cast_withBot, ←degree_eq_natDegree (mul_ne_zero hp hq),
-    WithBot.coe_add, ← Nat.cast_withBot, ←degree_eq_natDegree hp, ← Nat.cast_withBot,
-    ← degree_eq_natDegree hq, degree_mul]
+theorem natDegree_mul (hp : p ≠ 0) (hq : q ≠ 0) : (p*q).natDegree = p.natDegree + q.natDegree :=
+  natDegree_eq_of_le_of_coeff_ne_zero natDegree_mul_le $
+  ne_of_eq_of_ne (coeff_mul_of_natDegree_le le_rfl le_rfl) (by simp [hp, hq])
 #align polynomial.nat_degree_mul Polynomial.natDegree_mul
 
 theorem trailingDegree_mul : (p * q).trailingDegree = p.trailingDegree + q.trailingDegree := by
@@ -143,9 +139,7 @@ theorem trailingDegree_mul : (p * q).trailingDegree = p.trailingDegree + q.trail
   · rw [hp, MulZeroClass.zero_mul, trailingDegree_zero, top_add]
   by_cases hq : q = 0
   · rw [hq, MulZeroClass.mul_zero, trailingDegree_zero, add_top]
-  · rw [trailingDegree_eq_natTrailingDegree hp, trailingDegree_eq_natTrailingDegree hq,
-    trailingDegree_eq_natTrailingDegree (mul_ne_zero hp hq), natTrailingDegree_mul hp hq]
-    apply WithTop.coe_add
+  exact trailingDegree_mul' (by simp [hp, hq])
 #align polynomial.trailing_degree_mul Polynomial.trailingDegree_mul
 
 @[simp]

--- a/Mathlib/RingTheory/Polynomial/Basic.lean
+++ b/Mathlib/RingTheory/Polynomial/Basic.lean
@@ -1078,49 +1078,6 @@ instance isNoetherianRing [Finite σ] [IsNoetherianRing R] :
       (renameEquiv R (Fintype.equivFin σ).symm).toRingEquiv isNoetherianRing_fin
 #align mv_polynomial.is_noetherian_ring MvPolynomial.isNoetherianRing
 
-/-- Auxiliary lemma:
-Multivariate polynomials over an integral domain
-with variables indexed by `Fin n` form an integral domain.
-This fact is proven inductively,
-and then used to prove the general case without any finiteness hypotheses.
-See `MvPolynomial.noZeroDivisors` for the general case. -/
-theorem noZeroDivisors_fin (R : Type u) [CommSemiring R] [NoZeroDivisors R] :
-    ∀ n : ℕ, NoZeroDivisors (MvPolynomial (Fin n) R)
-  | 0 => (MvPolynomial.isEmptyAlgEquiv R _).injective.noZeroDivisors _ (map_zero _) (map_mul _)
-  | n + 1 =>
-    haveI := noZeroDivisors_fin R n
-    (MvPolynomial.finSuccEquiv R n).injective.noZeroDivisors _ (map_zero _) (map_mul _)
-#align mv_polynomial.no_zero_divisors_fin MvPolynomial.noZeroDivisors_fin
-
-/-- Auxiliary definition:
-Multivariate polynomials in finitely many variables over an integral domain form an integral domain.
-This fact is proven by transport of structure from the `MvPolynomial.noZeroDivisors_fin`,
-and then used to prove the general case without finiteness hypotheses.
-See `MvPolynomial.noZeroDivisors` for the general case. -/
-theorem noZeroDivisors_of_finite (R : Type u) (σ : Type v) [CommSemiring R] [Finite σ]
-    [NoZeroDivisors R] : NoZeroDivisors (MvPolynomial σ R) := by
-  cases nonempty_fintype σ
-  haveI := noZeroDivisors_fin R (Fintype.card σ)
-  exact (renameEquiv R (Fintype.equivFin σ)).injective.noZeroDivisors _ (map_zero _) (map_mul _)
-#align mv_polynomial.no_zero_divisors_of_finite MvPolynomial.noZeroDivisors_of_finite
-
-instance {R : Type u} [CommSemiring R] [NoZeroDivisors R] {σ : Type v} :
-    NoZeroDivisors (MvPolynomial σ R) :=
-  ⟨fun {p} {q} h => by
-    obtain ⟨s, p, rfl⟩ := exists_finset_rename p
-    obtain ⟨t, q, rfl⟩ := exists_finset_rename q
-    have :
-        rename (Subtype.map id (Finset.subset_union_left s t) :
-          { x // x ∈ s } → { x // x ∈ s ∪ t }) p *
-        rename (Subtype.map id (Finset.subset_union_right s t) :
-          { x // x ∈ t } → { x // x ∈ s ∪ t }) q =
-        0 := by
-      apply rename_injective _ Subtype.val_injective
-      simpa using h
-    letI that := MvPolynomial.noZeroDivisors_of_finite R { x // x ∈ s ∪ t }
-    rw [mul_eq_zero] at this
-    apply this.imp <;> intro that <;> simpa using congr_arg (rename Subtype.val) that⟩
-
 /-- The multivariate polynomial ring over an integral domain is an integral domain. -/
 instance {R : Type u} {σ : Type v} [CommRing R] [IsDomain R] :
     IsDomain (MvPolynomial σ R) := by


### PR DESCRIPTION
This PR continues #6627, placing the `NoZeroDivisors` instance on `MvPolynomial`s and removing auxiliary intermediate results that are no longer needed.

Affected files:
```
Data/MvPolynomial/Basic.lean
Data/Polynomial/RingDivision.lean
RingTheory/Polynomial/Basic.lean
```

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

- [x] depends on: #6227 for the `NoZeroDivisors` instance on `AddMonoidAlgebra`s

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
