### PR TITLE
[Merged by Bors] - fix (LinearAlgebra.Dual): delete `instFunLikeDual`

### DIFF
--- a/Mathlib/LinearAlgebra/Dual.lean
+++ b/Mathlib/LinearAlgebra/Dual.lean
@@ -124,6 +124,10 @@ namespace Dual
 
 instance : Inhabited (Dual R M) := ⟨0⟩
 
+-- Note: TC synthesis creates goals of the form `Semiring ?=` which cannot
+-- unify with `R` for some reason. As such, it is currently problematics
+-- [Zulip](https://leanprover.zulipchat.com/#narrow/stream/113488-general/
+-- topic/Module.2EDual.20and.20linear.20maps)
 instance (priority := low) : FunLike (Dual R M) M fun _ => R :=
   inferInstanceAs (FunLike (M →ₗ[R] R) M fun _ => R)
 

--- a/Mathlib/LinearAlgebra/Dual.lean
+++ b/Mathlib/LinearAlgebra/Dual.lean
@@ -124,13 +124,6 @@ namespace Dual
 
 instance : Inhabited (Dual R M) := ⟨0⟩
 
--- Note: TC synthesis creates goals of the form `Semiring ?=` which cannot
--- unify with `R` for some reason. As such, it is currently problematics
--- [Zulip](https://leanprover.zulipchat.com/#narrow/stream/113488-general/
--- topic/Module.2EDual.20and.20linear.20maps)
-instance (priority := low) : FunLike (Dual R M) M fun _ => R :=
-  inferInstanceAs (FunLike (M →ₗ[R] R) M fun _ => R)
-
 /-- Maps a module M to the dual of the dual of M. See `Module.erange_coe` and
 `Module.evalEquiv`. -/
 def eval : M →ₗ[R] Dual R (Dual R M) :=

--- a/Mathlib/LinearAlgebra/Dual.lean
+++ b/Mathlib/LinearAlgebra/Dual.lean
@@ -124,7 +124,7 @@ namespace Dual
 
 instance : Inhabited (Dual R M) := ⟨0⟩
 
-instance : FunLike (Dual R M) M fun _ => R :=
+instance (priority := low) : FunLike (Dual R M) M fun _ => R :=
   inferInstanceAs (FunLike (M →ₗ[R] R) M fun _ => R)
 
 /-- Maps a module M to the dual of the dual of M. See `Module.erange_coe` and


### PR DESCRIPTION
It seems that Lean can find `LinearMap.instFunLike` just fine now. Furthermore, `Module.Dual.instFunLikeDual` was causing TC synthesis to fail. We delete it. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

See [Zulip](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Module.2EDual.20and.20linear.20maps)

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
