### PR TITLE
[Merged by Bors] - chore: improve cross-links between ULift equivalences

### DIFF
--- a/Mathlib/Algebra/Module/ULift.lean
+++ b/Mathlib/Algebra/Module/ULift.lean
@@ -160,15 +160,15 @@ instance module' [Semiring R] [AddCommMonoid M] [Module R M] : Module R (ULift M
     smul_add := smul_add }
 #align ulift.module' ULift.module'
 
-/-- The `R`-linear equivalence between `ULift M` and `M`. -/
+/-- The `R`-linear equivalence between `ULift M` and `M`.
+
+This is a linear version of `AddEquiv.ulift`. -/
 @[simps apply symm_apply]
 def moduleEquiv [Semiring R] [AddCommMonoid M] [Module R M] : ULift.{w} M ≃ₗ[R] M where
   toFun := ULift.down
   invFun := ULift.up
   map_smul' _ _ := rfl
-  map_add' _ _ := rfl
-  left_inv := ULift.up_down
-  right_inv := ULift.down_up.{v, w}
+  __ := AddEquiv.ulift
 #align ulift.module_equiv ULift.moduleEquiv
 
 end ULift

--- a/Mathlib/Topology/Algebra/Module/Basic.lean
+++ b/Mathlib/Topology/Algebra/Module/Basic.lean
@@ -2257,11 +2257,11 @@ variable {M₁} {R₄ : Type*} [Semiring R₄] [Module R₄ M₄] {σ₃₄ : R�
   [RingHomInvPair σ₃₄ σ₄₃] [RingHomInvPair σ₄₃ σ₃₄] {σ₂₄ : R₂ →+* R₄} {σ₁₄ : R₁ →+* R₄}
   [RingHomCompTriple σ₂₁ σ₁₄ σ₂₄] [RingHomCompTriple σ₂₄ σ₄₃ σ₂₃] [RingHomCompTriple σ₁₃ σ₃₄ σ₁₄]
 
-/-- The continuous linear equivalence between `ULift M₁` and `M₁`. -/
+/-- The continuous linear equivalence between `ULift M₁` and `M₁`.
+
+This is a continuous version of `ULift.moduleEquiv`. -/
 def ulift : ULift M₁ ≃L[R₁] M₁ :=
-  { Equiv.ulift with
-    map_add' := fun _x _y => rfl
-    map_smul' := fun _c _x => rfl
+  { ULift.moduleEquiv with
     continuous_toFun := continuous_uLift_down
     continuous_invFun := continuous_uLift_up }
 #align continuous_linear_equiv.ulift ContinuousLinearEquiv.ulift


### PR DESCRIPTION
The names are all over the place, leading me to believe that `ULift.moduleEquiv` didn't exist. Cross-linking to the other equivs (via code and comments) makes them easier to find.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
