### PR TITLE
[Merged by Bors] - feat: missing results about StarAlgHom.codRestrict

### DIFF
--- a/Mathlib/Algebra/Algebra/NonUnitalSubalgebra.lean
+++ b/Mathlib/Algebra/Algebra/NonUnitalSubalgebra.lean
@@ -432,24 +432,30 @@ theorem range_comp_le_range (f : A →ₙₐ[R] B) (g : B →ₙₐ[R] C) :
     NonUnitalAlgHom.range (g.comp f) ≤ NonUnitalAlgHom.range g :=
   SetLike.coe_mono (Set.range_comp_subset_range f g)
 
+section codRestrict
+
+variable {S : Type*} [SetLike S B] [NonUnitalSubsemiringClass S B] [SMulMemClass S R B]
+
 /-- Restrict the codomain of a non-unital algebra homomorphism. -/
-def codRestrict (f : F) (S : NonUnitalSubalgebra R B) (hf : ∀ x, f x ∈ S) : A →ₙₐ[R] S :=
-  { NonUnitalRingHom.codRestrict (f : A →ₙ+* B) S.toNonUnitalSubsemiring hf with
+def codRestrict (f : F) (s : S) (hf : ∀ x, f x ∈ s) : A →ₙₐ[R] s :=
+  { NonUnitalRingHom.codRestrict (f : A →ₙ+* B) s hf with
     map_smul' := fun r a => Subtype.ext <| map_smul f r a }
 
 @[simp]
-theorem subtype_comp_codRestrict (f : F) (S : NonUnitalSubalgebra R B) (hf : ∀ x : A, f x ∈ S) :
-    (NonUnitalSubalgebraClass.subtype S).comp (NonUnitalAlgHom.codRestrict f S hf) = f :=
+theorem subtype_comp_codRestrict (f : F) (s : S) (hf : ∀ x : A, f x ∈ s) :
+    (NonUnitalSubalgebraClass.subtype s).comp (NonUnitalAlgHom.codRestrict f s hf) = f :=
   NonUnitalAlgHom.ext fun _ => rfl
 
 @[simp]
-theorem coe_codRestrict (f : F) (S : NonUnitalSubalgebra R B) (hf : ∀ x, f x ∈ S) (x : A) :
-    ↑(NonUnitalAlgHom.codRestrict f S hf x) = f x :=
+theorem coe_codRestrict (f : F) (s : S) (hf : ∀ x, f x ∈ s) (x : A) :
+    NonUnitalAlgHom.codRestrict f s hf x = f x :=
   rfl
 
-theorem injective_codRestrict (f : F) (S : NonUnitalSubalgebra R B) (hf : ∀ x : A, f x ∈ S) :
-    Function.Injective (NonUnitalAlgHom.codRestrict f S hf) ↔ Function.Injective f :=
+theorem injective_codRestrict (f : F) (s : S) (hf : ∀ x : A, f x ∈ s) :
+    Function.Injective (NonUnitalAlgHom.codRestrict f s hf) ↔ Function.Injective f :=
   ⟨fun H _x _y hxy => H <| Subtype.eq hxy, fun H _x _y hxy => H (congr_arg Subtype.val hxy : _)⟩
+
+end codRestrict
 
 /-- Restrict the codomain of an alg_hom `f` to `f.range`.
 

--- a/Mathlib/Algebra/Algebra/NonUnitalSubalgebra.lean
+++ b/Mathlib/Algebra/Algebra/NonUnitalSubalgebra.lean
@@ -432,30 +432,24 @@ theorem range_comp_le_range (f : A →ₙₐ[R] B) (g : B →ₙₐ[R] C) :
     NonUnitalAlgHom.range (g.comp f) ≤ NonUnitalAlgHom.range g :=
   SetLike.coe_mono (Set.range_comp_subset_range f g)
 
-section codRestrict
-
-variable {S : Type*} [SetLike S B] [NonUnitalSubsemiringClass S B] [SMulMemClass S R B]
-
 /-- Restrict the codomain of a non-unital algebra homomorphism. -/
-def codRestrict (f : F) (s : S) (hf : ∀ x, f x ∈ s) : A →ₙₐ[R] s :=
-  { NonUnitalRingHom.codRestrict (f : A →ₙ+* B) s hf with
+def codRestrict (f : F) (S : NonUnitalSubalgebra R B) (hf : ∀ x, f x ∈ S) : A →ₙₐ[R] S :=
+  { NonUnitalRingHom.codRestrict (f : A →ₙ+* B) S.toNonUnitalSubsemiring hf with
     map_smul' := fun r a => Subtype.ext <| map_smul f r a }
 
 @[simp]
-theorem subtype_comp_codRestrict (f : F) (s : S) (hf : ∀ x : A, f x ∈ s) :
-    (NonUnitalSubalgebraClass.subtype s).comp (NonUnitalAlgHom.codRestrict f s hf) = f :=
+theorem subtype_comp_codRestrict (f : F) (S : NonUnitalSubalgebra R B) (hf : ∀ x : A, f x ∈ S) :
+    (NonUnitalSubalgebraClass.subtype S).comp (NonUnitalAlgHom.codRestrict f S hf) = f :=
   NonUnitalAlgHom.ext fun _ => rfl
 
 @[simp]
-theorem coe_codRestrict (f : F) (s : S) (hf : ∀ x, f x ∈ s) (x : A) :
-    NonUnitalAlgHom.codRestrict f s hf x = f x :=
+theorem coe_codRestrict (f : F) (S : NonUnitalSubalgebra R B) (hf : ∀ x, f x ∈ S) (x : A) :
+    ↑(NonUnitalAlgHom.codRestrict f S hf x) = f x :=
   rfl
 
-theorem injective_codRestrict (f : F) (s : S) (hf : ∀ x : A, f x ∈ s) :
-    Function.Injective (NonUnitalAlgHom.codRestrict f s hf) ↔ Function.Injective f :=
+theorem injective_codRestrict (f : F) (S : NonUnitalSubalgebra R B) (hf : ∀ x : A, f x ∈ S) :
+    Function.Injective (NonUnitalAlgHom.codRestrict f S hf) ↔ Function.Injective f :=
   ⟨fun H _x _y hxy => H <| Subtype.eq hxy, fun H _x _y hxy => H (congr_arg Subtype.val hxy : _)⟩
-
-end codRestrict
 
 /-- Restrict the codomain of an alg_hom `f` to `f.range`.
 

--- a/Mathlib/Algebra/Star/Subalgebra.lean
+++ b/Mathlib/Algebra/Star/Subalgebra.lean
@@ -793,14 +793,14 @@ protected def codRestrict (f : A →⋆ₐ[R] B) (S : StarSubalgebra R B) (hf : 
   map_star' := fun x => Subtype.ext (map_star f x)
 
 @[simp]
-theorem subtype_comp_codRestrict (f : A →⋆ₐ[R] B) (S : StarSubalgebra R B)
-    (hf : ∀ x : A, f x ∈ S) : S.subtype.comp (f.codRestrict S hf) = f :=
-  StarAlgHom.ext fun _ => rfl
-
-@[simp]
 theorem coe_codRestrict (f : A →⋆ₐ[R] B) (S : StarSubalgebra R B) (hf : ∀ x, f x ∈ S) (x : A) :
     f.codRestrict S hf x = f x :=
   rfl
+
+@[simp]
+theorem subtype_comp_codRestrict (f : A →⋆ₐ[R] B) (S : StarSubalgebra R B)
+    (hf : ∀ x : A, f x ∈ S) : S.subtype.comp (f.codRestrict S hf) = f :=
+  StarAlgHom.ext <| coe_codRestrict _ S hf
 
 theorem injective_codRestrict (f : A →⋆ₐ[R] B) (S : StarSubalgebra R B) (hf : ∀ x : A, f x ∈ S) :
     Function.Injective (StarAlgHom.codRestrict f S hf) ↔ Function.Injective f :=

--- a/Mathlib/Algebra/Star/Subalgebra.lean
+++ b/Mathlib/Algebra/Star/Subalgebra.lean
@@ -794,7 +794,7 @@ protected def codRestrict (f : A →⋆ₐ[R] B) (S : StarSubalgebra R B) (hf : 
 
 @[simp]
 theorem coe_codRestrict (f : A →⋆ₐ[R] B) (S : StarSubalgebra R B) (hf : ∀ x, f x ∈ S) (x : A) :
-    f.codRestrict S hf x = f x :=
+    ↑(f.codRestrict S hf x) = f x :=
   rfl
 
 @[simp]

--- a/Mathlib/Algebra/Star/Subalgebra.lean
+++ b/Mathlib/Algebra/Star/Subalgebra.lean
@@ -792,6 +792,20 @@ protected def codRestrict (f : A →⋆ₐ[R] B) (S : StarSubalgebra R B) (hf : 
   toAlgHom := AlgHom.codRestrict f.toAlgHom S.toSubalgebra hf
   map_star' := fun x => Subtype.ext (map_star f x)
 
+@[simp]
+theorem subtype_comp_codRestrict (f : A →⋆ₐ[R] B) (S : StarSubalgebra R B)
+    (hf : ∀ x : A, f x ∈ S) : S.subtype.comp (f.codRestrict S hf) = f :=
+  StarAlgHom.ext fun _ => rfl
+
+@[simp]
+theorem coe_codRestrict (f : A →⋆ₐ[R] B) (S : StarSubalgebra R B) (hf : ∀ x, f x ∈ S) (x : A) :
+    f.codRestrict S hf x = f x :=
+  rfl
+
+theorem injective_codRestrict (f : A →⋆ₐ[R] B) (S : StarSubalgebra R B) (hf : ∀ x : A, f x ∈ S) :
+    Function.Injective (StarAlgHom.codRestrict f S hf) ↔ Function.Injective f :=
+  ⟨fun H _x _y hxy => H <| Subtype.eq hxy, fun H _x _y hxy => H (congr_arg Subtype.val hxy : _)⟩
+
 /-- Restriction of the codomain of a `StarAlgHom` to its range. -/
 def rangeRestrict (f : A →⋆ₐ[R] B) : A →⋆ₐ[R] f.range :=
   StarAlgHom.codRestrict f _ fun x => ⟨x, rfl⟩


### PR DESCRIPTION
This is a step towards making sure that all the `codRestrict` APIs are similar, but they're still not similar enough in wether they take bundled subobjects/morphisms or subobject/morphism classes.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Noticed while reviewing #6372

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
