### PR TITLE
[Merged by Bors] - feat(RingTheory/FiniteType): generalize some results to non-commutative rings

### DIFF
--- a/Mathlib/FieldTheory/SplittingField/Construction.lean
+++ b/Mathlib/FieldTheory/SplittingField/Construction.lean
@@ -206,7 +206,7 @@ theorem adjoin_rootSet (n : ℕ) :
     rw [roots_mul hmf0, Polynomial.map_sub, map_X, map_C, roots_X_sub_C, Multiset.toFinset_add,
       Finset.coe_union, Multiset.toFinset_singleton, Finset.coe_singleton,
       Algebra.adjoin_union_eq_adjoin_adjoin, ← Set.image_singleton,
-      Algebra.adjoin_algebraMap K (AdjoinRoot f.factor) (SplittingFieldAux n f.removeFactor),
+      Algebra.adjoin_algebraMap K (SplittingFieldAux n f.removeFactor),
       AdjoinRoot.adjoinRoot_eq_top, Algebra.map_top]
     /- Porting note: was `rw [IsScalarTower.adjoin_range_toAlgHom K (AdjoinRoot f.factor)
         (SplittingFieldAux n f.removeFactor)]` -/

--- a/Mathlib/RingTheory/Adjoin/Basic.lean
+++ b/Mathlib/RingTheory/Adjoin/Basic.lean
@@ -311,8 +311,6 @@ theorem adjoin_algebraMap_image_union_eq_adjoin_adjoin (s : Set S) (t : Set A) :
         Algebra.adjoin_algebraMap R A s ▸ ⟨x, x.prop, rfl⟩)
         (Set.Subset.trans (Set.subset_union_right _ _) subset_adjoin))
 
-
-
 theorem adjoin_adjoin_of_tower (s : Set A) : adjoin S (adjoin R s : Set A) = adjoin S s := by
   apply le_antisymm (adjoin_le _)
   · exact adjoin_mono subset_adjoin
@@ -325,7 +323,7 @@ theorem adjoin_adjoin_of_tower (s : Set A) : adjoin S (adjoin R s : Set A) = adj
 #align algebra.adjoin_adjoin_of_tower Algebra.adjoin_adjoin_of_tower
 
 @[simp]
-theorem adjoin_top:
+theorem adjoin_top :
     adjoin (⊤ : Subalgebra R S) t = (adjoin S t).restrictScalars (⊤ : Subalgebra R S) :=
   let equivTop : Subalgebra (⊤ : Subalgebra R S) A ≃o Subalgebra S A :=
     { toFun := fun s => { s with algebraMap_mem' := fun r => s.algebraMap_mem ⟨r, trivial⟩ }
@@ -337,6 +335,7 @@ theorem adjoin_top:
     (adjoin_le <| show t ⊆ adjoin S t from subset_adjoin)
     (equivTop.symm_apply_le.mpr <|
       adjoin_le <| show t ⊆ adjoin (⊤ : Subalgebra R S) t from subset_adjoin)
+
 end Semiring
 
 section CommSemiring

--- a/Mathlib/RingTheory/Adjoin/Basic.lean
+++ b/Mathlib/RingTheory/Adjoin/Basic.lean
@@ -23,21 +23,22 @@ adjoin, algebra
 -/
 
 
-universe u v w
+universe uR uS uA uB
 
 open Pointwise
 
 open Submodule Subsemiring
 
-variable {R : Type u} {A : Type v} {B : Type w}
+variable {R : Type uR} {S : Type uS} {A : Type uA} {B : Type uB}
 
 namespace Algebra
 
 section Semiring
 
-variable [CommSemiring R] [Semiring A] [Semiring B]
+variable [CommSemiring R] [CommSemiring S] [Semiring A] [Semiring B]
 
-variable [Algebra R A] [Algebra R B] {s t : Set A}
+variable [Algebra R S] [Algebra R A] [Algebra S A] [Algebra R B] [IsScalarTower R S A]
+variable {s t : Set A}
 
 theorem subset_adjoin : s ⊆ adjoin R s :=
   Algebra.gc.le_u_l s
@@ -292,6 +293,50 @@ theorem self_mem_adjoin_singleton (x : A) : x ∈ adjoin R ({x} : Set A) :=
   Algebra.subset_adjoin (Set.mem_singleton_iff.mpr rfl)
 #align algebra.self_mem_adjoin_singleton Algebra.self_mem_adjoin_singleton
 
+variable (A) in
+theorem adjoin_algebraMap (s : Set S) :
+    adjoin R (algebraMap S A '' s) = (adjoin R s).map (IsScalarTower.toAlgHom R S A) :=
+  adjoin_image R (IsScalarTower.toAlgHom R S A) s
+#align algebra.adjoin_algebra_map Algebra.adjoin_algebraMap
+
+theorem adjoin_algebraMap_image_union_eq_adjoin_adjoin (s : Set S) (t : Set A) :
+    adjoin R (algebraMap S A '' s ∪ t) = (adjoin (adjoin R s) t).restrictScalars R :=
+  le_antisymm
+    (closure_mono <|
+      Set.union_subset (Set.range_subset_iff.2 fun r => Or.inl ⟨algebraMap R (adjoin R s) r,
+        (IsScalarTower.algebraMap_apply _ _ _ _).symm⟩)
+        (Set.union_subset_union_left _ fun _ ⟨_x, hx, hxs⟩ => hxs ▸ ⟨⟨_, subset_adjoin hx⟩, rfl⟩))
+    (closure_le.2 <|
+      Set.union_subset (Set.range_subset_iff.2 fun x => adjoin_mono (Set.subset_union_left _ _) <|
+        Algebra.adjoin_algebraMap R A s ▸ ⟨x, x.prop, rfl⟩)
+        (Set.Subset.trans (Set.subset_union_right _ _) subset_adjoin))
+
+
+
+theorem adjoin_adjoin_of_tower (s : Set A) : adjoin S (adjoin R s : Set A) = adjoin S s := by
+  apply le_antisymm (adjoin_le _)
+  · exact adjoin_mono subset_adjoin
+  · change adjoin R s ≤ (adjoin S s).restrictScalars R
+    refine' adjoin_le _
+    -- porting note: unclear why this was broken
+    have : (Subalgebra.restrictScalars R (adjoin S s) : Set A) = adjoin S s := rfl
+    rw [this]
+    exact subset_adjoin
+#align algebra.adjoin_adjoin_of_tower Algebra.adjoin_adjoin_of_tower
+
+@[simp]
+theorem adjoin_top:
+    adjoin (⊤ : Subalgebra R S) t = (adjoin S t).restrictScalars (⊤ : Subalgebra R S) :=
+  let equivTop : Subalgebra (⊤ : Subalgebra R S) A ≃o Subalgebra S A :=
+    { toFun := fun s => { s with algebraMap_mem' := fun r => s.algebraMap_mem ⟨r, trivial⟩ }
+      invFun := fun s => s.restrictScalars _
+      left_inv := fun _ => SetLike.coe_injective rfl
+      right_inv := fun _ => SetLike.coe_injective rfl
+      map_rel_iff' := @fun _ _ => Iff.rfl }
+  le_antisymm
+    (adjoin_le <| show t ⊆ adjoin S t from subset_adjoin)
+    (equivTop.symm_apply_le.mpr <|
+      adjoin_le <| show t ⊆ adjoin (⊤ : Subalgebra R S) t from subset_adjoin)
 end Semiring
 
 section CommSemiring
@@ -303,14 +348,8 @@ variable [Algebra R A] {s t : Set A}
 variable (R s t)
 
 theorem adjoin_union_eq_adjoin_adjoin :
-    adjoin R (s ∪ t) = (adjoin (adjoin R s) t).restrictScalars R :=
-  le_antisymm
-    (closure_mono <|
-      Set.union_subset (Set.range_subset_iff.2 fun r => Or.inl ⟨algebraMap R (adjoin R s) r, rfl⟩)
-        (Set.union_subset_union_left _ fun _x hxs => ⟨⟨_, subset_adjoin hxs⟩, rfl⟩))
-    (closure_le.2 <|
-      Set.union_subset (Set.range_subset_iff.2 fun x => adjoin_mono (Set.subset_union_left _ _) x.2)
-        (Set.Subset.trans (Set.subset_union_right _ _) subset_adjoin))
+    adjoin R (s ∪ t) = (adjoin (adjoin R s) t).restrictScalars R := by
+  simpa using adjoin_algebraMap_image_union_eq_adjoin_adjoin R s t
 #align algebra.adjoin_union_eq_adjoin_adjoin Algebra.adjoin_union_eq_adjoin_adjoin
 
 theorem adjoin_union_coe_submodule :
@@ -319,18 +358,6 @@ theorem adjoin_union_coe_submodule :
   rw [adjoin_eq_span, adjoin_eq_span, adjoin_eq_span, span_mul_span]
   congr 1 with z; simp [Submonoid.closure_union, Submonoid.mem_sup, Set.mem_mul]
 #align algebra.adjoin_union_coe_submodule Algebra.adjoin_union_coe_submodule
-
-theorem adjoin_adjoin_of_tower [Semiring B] [Algebra R B] [Algebra A B] [IsScalarTower R A B]
-    (s : Set B) : adjoin A (adjoin R s : Set B) = adjoin A s := by
-  apply le_antisymm (adjoin_le _)
-  · exact adjoin_mono subset_adjoin
-  · change adjoin R s ≤ (adjoin A s).restrictScalars R
-    refine' adjoin_le _
-    -- porting note: unclear why this was broken
-    have : (Subalgebra.restrictScalars R (adjoin A s) : Set B) = adjoin A s := rfl
-    rw [this]
-    exact subset_adjoin
-#align algebra.adjoin_adjoin_of_tower Algebra.adjoin_adjoin_of_tower
 
 variable {R}
 

--- a/Mathlib/RingTheory/Adjoin/Tower.lean
+++ b/Mathlib/RingTheory/Adjoin/Tower.lean
@@ -27,13 +27,6 @@ variable (R : Type u) (S : Type v) (A : Type w) (B : Type u₁)
 
 namespace Algebra
 
-theorem adjoin_algebraMap (R : Type u) (S : Type v) (A : Type w) [CommSemiring R] [CommSemiring S]
-    [Semiring A] [Algebra R S] [Algebra S A] [Algebra R A] [IsScalarTower R S A] (s : Set S) :
-    adjoin R (algebraMap S A '' s) = (adjoin R s).map (IsScalarTower.toAlgHom R S A) :=
-  le_antisymm (adjoin_le <| Set.image_subset_iff.2 fun y hy => ⟨y, subset_adjoin hy, rfl⟩)
-    (Subalgebra.map_le.2 <| adjoin_le fun y hy => subset_adjoin ⟨y, hy, rfl⟩)
-#align algebra.adjoin_algebra_map Algebra.adjoin_algebraMap
-
 theorem adjoin_restrictScalars (C D E : Type*) [CommSemiring C] [CommSemiring D] [CommSemiring E]
     [Algebra C D] [Algebra C E] [Algebra D E] [IsScalarTower C D E] (S : Set E) :
     (Algebra.adjoin D S).restrictScalars C =
@@ -71,15 +64,14 @@ section
 
 open Classical
 
-theorem Algebra.fg_trans' {R S A : Type*} [CommSemiring R] [CommSemiring S] [CommSemiring A]
+theorem Algebra.fg_trans' {R S A : Type*} [CommSemiring R] [CommSemiring S] [Semiring A]
     [Algebra R S] [Algebra S A] [Algebra R A] [IsScalarTower R S A] (hRS : (⊤ : Subalgebra R S).FG)
     (hSA : (⊤ : Subalgebra S A).FG) : (⊤ : Subalgebra R A).FG :=
   let ⟨s, hs⟩ := hRS
   let ⟨t, ht⟩ := hSA
   ⟨s.image (algebraMap S A) ∪ t, by
-    rw [Finset.coe_union, Finset.coe_image, Algebra.adjoin_union_eq_adjoin_adjoin,
-      Algebra.adjoin_algebraMap, hs, Algebra.map_top, IsScalarTower.adjoin_range_toAlgHom, ht,
-      Subalgebra.restrictScalars_top]⟩
+    rw [Finset.coe_union, Finset.coe_image, Algebra.adjoin_algebraMap_image_union_eq_adjoin_adjoin,
+      hs, Algebra.adjoin_top, ht, Subalgebra.restrictScalars_top, Subalgebra.restrictScalars_top]⟩
 #align algebra.fg_trans' Algebra.fg_trans'
 
 end

--- a/Mathlib/RingTheory/FiniteType.lean
+++ b/Mathlib/RingTheory/FiniteType.lean
@@ -48,7 +48,7 @@ namespace Finite
 
 open Submodule Set
 
-variable {R M N}
+variable {R S M N}
 
 section Algebra
 
@@ -104,7 +104,7 @@ theorem of_restrictScalars_finiteType [Algebra S A] [IsScalarTower R S A] [hA : 
   exact le (eq_top_iff.1 hS b)
 #align algebra.finite_type.of_restrict_scalars_finite_type Algebra.FiniteType.of_restrictScalars_finiteType
 
-variable {R A B}
+variable {R S A B}
 
 theorem of_surjective (hRA : FiniteType R A) (f : A →ₐ[R] B) (hf : Surjective f) : FiniteType R B :=
   ⟨by

--- a/Mathlib/RingTheory/FiniteType.lean
+++ b/Mathlib/RingTheory/FiniteType.lean
@@ -31,7 +31,8 @@ open BigOperators Polynomial
 
 section ModuleAndAlgebra
 
-variable (R) (A : Type u) (B M N : Type*)
+universe uR uS uA uB uM uN
+variable (R : Type uR) (S : Type uS) (A : Type uA) (B : Type uB) (M : Type uM) (N : Type uN)
 
 /-- An algebra over a commutative semiring is of `FiniteType` if it is finitely generated
 over the base ring as algebra. -/
@@ -65,11 +66,10 @@ end Module
 
 namespace Algebra
 
-variable [CommRing R] [CommRing A] [Algebra R A] [CommRing B] [Algebra R B]
-
-variable [AddCommGroup M] [Module R M]
-
-variable [AddCommGroup N] [Module R N]
+variable [CommSemiring R] [CommSemiring S] [Semiring A] [Semiring B]
+variable [Algebra R S] [Algebra R A] [Algebra R B]
+variable [AddCommMonoid M] [Module R M]
+variable [AddCommMonoid N] [Module R N]
 
 namespace FiniteType
 
@@ -93,12 +93,12 @@ protected theorem mvPolynomial (ι : Type*) [Finite ι] : FiniteType R (MvPolyno
         exact MvPolynomial.adjoin_range_X⟩⟩
 #align algebra.finite_type.mv_polynomial Algebra.FiniteType.mvPolynomial
 
-theorem of_restrictScalars_finiteType [Algebra A B] [IsScalarTower R A B] [hB : FiniteType R B] :
-    FiniteType A B := by
-  obtain ⟨S, hS⟩ := hB.out
-  refine' ⟨⟨S, eq_top_iff.2 fun b => _⟩⟩
-  have le : adjoin R (S : Set B) ≤ Subalgebra.restrictScalars R (adjoin A S) := by
-    apply (Algebra.adjoin_le _ : adjoin R (S : Set B) ≤ Subalgebra.restrictScalars R (adjoin A ↑S))
+theorem of_restrictScalars_finiteType [Algebra S A] [IsScalarTower R S A] [hA : FiniteType R A] :
+    FiniteType S A := by
+  obtain ⟨s, hS⟩ := hA.out
+  refine' ⟨⟨s, eq_top_iff.2 fun b => _⟩⟩
+  have le : adjoin R (s : Set A) ≤ Subalgebra.restrictScalars R (adjoin S s) := by
+    apply (Algebra.adjoin_le _ : adjoin R (s : Set A) ≤ Subalgebra.restrictScalars R (adjoin S ↑s))
     simp only [Subalgebra.coe_restrictScalars]
     exact Algebra.subset_adjoin
   exact le (eq_top_iff.1 hS b)
@@ -116,21 +116,21 @@ theorem equiv (hRA : FiniteType R A) (e : A ≃ₐ[R] B) : FiniteType R B :=
   hRA.of_surjective e e.surjective
 #align algebra.finite_type.equiv Algebra.FiniteType.equiv
 
-theorem trans [Algebra A B] [IsScalarTower R A B] (hRA : FiniteType R A) (hAB : FiniteType A B) :
-    FiniteType R B :=
-  ⟨fg_trans' hRA.1 hAB.1⟩
+theorem trans [Algebra S A] [IsScalarTower R S A] (hRS : FiniteType R S) (hSA : FiniteType S A) :
+    FiniteType R A :=
+  ⟨fg_trans' hRS.1 hSA.1⟩
 #align algebra.finite_type.trans Algebra.FiniteType.trans
 
 /-- An algebra is finitely generated if and only if it is a quotient
 of a polynomial ring whose variables are indexed by a finset. -/
 theorem iff_quotient_mvPolynomial :
-    FiniteType R A ↔
-      ∃ (s : Finset A) (f : MvPolynomial { x // x ∈ s } R →ₐ[R] A), Surjective f := by
+    FiniteType R S ↔
+      ∃ (s : Finset S) (f : MvPolynomial { x // x ∈ s } R →ₐ[R] S), Surjective f := by
   constructor
   · rintro ⟨s, hs⟩
     use s, MvPolynomial.aeval (↑)
     intro x
-    have hrw : (↑s : Set A) = fun x : A => x ∈ s.val := rfl
+    have hrw : (↑s : Set S) = fun x : S => x ∈ s.val := rfl
     rw [← Set.mem_range, ← AlgHom.coe_range, ← adjoin_eq_range, ← hrw, hs]
     exact Set.mem_univ x
   · rintro ⟨s, ⟨f, hsur⟩⟩
@@ -139,12 +139,12 @@ theorem iff_quotient_mvPolynomial :
 
 /-- An algebra is finitely generated if and only if it is a quotient
 of a polynomial ring whose variables are indexed by a fintype. -/
-theorem iff_quotient_mvPolynomial' : FiniteType R A ↔
-    ∃ (ι : Type u) (_ : Fintype ι) (f : MvPolynomial ι R →ₐ[R] A), Surjective f := by
+theorem iff_quotient_mvPolynomial' : FiniteType R S ↔
+    ∃ (ι : Type uS) (_ : Fintype ι) (f : MvPolynomial ι R →ₐ[R] S), Surjective f := by
   constructor
   · rw [iff_quotient_mvPolynomial]
     rintro ⟨s, ⟨f, hsur⟩⟩
-    use { x : A // x ∈ s }, inferInstance, f
+    use { x : S // x ∈ s }, inferInstance, f
   · rintro ⟨ι, ⟨hfintype, ⟨f, hsur⟩⟩⟩
     letI : Fintype ι := hfintype
     exact FiniteType.of_surjective (FiniteType.mvPolynomial R ι) f hsur
@@ -153,7 +153,7 @@ theorem iff_quotient_mvPolynomial' : FiniteType R A ↔
 /-- An algebra is finitely generated if and only if it is a quotient of a polynomial ring in `n`
 variables. -/
 theorem iff_quotient_mvPolynomial'' :
-    FiniteType R A ↔ ∃ (n : ℕ) (f : MvPolynomial (Fin n) R →ₐ[R] A), Surjective f := by
+    FiniteType R S ↔ ∃ (n : ℕ) (f : MvPolynomial (Fin n) R →ₐ[R] S), Surjective f := by
   constructor
   · rw [iff_quotient_mvPolynomial']
     rintro ⟨ι, hfintype, ⟨f, hsur⟩⟩
@@ -178,8 +178,7 @@ theorem isNoetherianRing (R S : Type*) [CommRing R] [CommRing S] [Algebra R S]
   rfl
 #align algebra.finite_type.is_noetherian_ring Algebra.FiniteType.isNoetherianRing
 
-theorem _root_.Subalgebra.fg_iff_finiteType {R A : Type*} [CommSemiring R]
-    [Semiring A] [Algebra R A] (S : Subalgebra R A) : S.FG ↔ Algebra.FiniteType R S :=
+theorem _root_.Subalgebra.fg_iff_finiteType (S : Subalgebra R A) : S.FG ↔ Algebra.FiniteType R S :=
   S.fg_top.symm.trans ⟨fun h => ⟨h⟩, fun h => h.out⟩
 #align subalgebra.fg_iff_finite_type Subalgebra.fg_iff_finiteType
 
@@ -237,7 +236,7 @@ theorem comp {g : B →+* C} {f : A →+* B} (hg : g.FiniteType) (hf : f.FiniteT
   let _ : Algebra A B := f.toAlgebra
   let _ : Algebra A C := (g.comp f).toAlgebra
   let _ : Algebra B C := g.toAlgebra
-  exact @Algebra.FiniteType.trans A B C _ _ f.toAlgebra _ (g.comp f).toAlgebra g.toAlgebra
+  exact @Algebra.FiniteType.trans A B C _ _ _ f.toAlgebra (g.comp f).toAlgebra g.toAlgebra
     ⟨by
       intro a b c
       simp [Algebra.smul_def, RingHom.map_mul, mul_assoc]


### PR DESCRIPTION
I was hoping to use this in combination with #6680 to show the `TensorAlgebra` is finitely generated, where I needed to generalize `FiniteType.equiv`; but it turns out that the `FiniteType` instance on `MonoidAlgebra` also isn't generalized!

The summary here is:
* Move `Algebra.adjoin_algebraMap` from `Mathlib/RingTheory/Adjoin/Tower.lean` to `Mathlib/RingTheory/Adjoin/Basic.lean` and golf the proof to oblivion
* Provide an alternative statement of `adjoin_union_eq_adjoin_adjoin`, `adjoin_algebraMap_image_union_eq_adjoin_adjoin`, which works in non-commutative rings, and use it along with a new `adjoin_top` lemma to prove `Algebra.fg_trans'` more generally.
* Introduce a new `S` variable throughout, with the convention that `R` and `S` are commutative, `A` and `B` remain not-necessarily-commutative, and `A/S/R` is a tower of algebras.
* Apply some zero-effort generalizations to semirings.
 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
