### PR TITLE
[Merged by Bors] - fix(CategoryTheory/Localization/Construction): restore universe polymorphism

### DIFF
--- a/Mathlib/CategoryTheory/Localization/Construction.lean
+++ b/Mathlib/CategoryTheory/Localization/Construction.lean
@@ -43,7 +43,9 @@ open CategoryTheory.Category
 
 namespace CategoryTheory
 
-variable {C : Type*} [Category C] (W : MorphismProperty C) {D : Type*} [Category D]
+-- category universes first for convenience
+universe uC' uD' uC uD
+variable {C : Type uC} [Category.{uC'} C] (W : MorphismProperty C) {D : Type uD} [Category.{uD'} D]
 
 namespace Localization
 


### PR DESCRIPTION
[Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/.236499.20broke.20universe.20polymorphism/near/384284680).

Without explicit universes, `CategoryTheory.Localization.Construction.relations` (and everything downstream) was inferred as taking `Category.{u,u} C`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
