### PR TITLE
[Merged by Bors] - chore (Algebra.Field.Defs): remove unused structure instances

### DIFF
--- a/Mathlib/Algebra/Field/Defs.lean
+++ b/Mathlib/Algebra/Field/Defs.lean
@@ -106,7 +106,7 @@ class DivisionRing (K : Type u) extends Ring K, DivInvMonoid K, Nontrivial K, Ra
 
 -- see Note [lower instance priority]
 instance (priority := 100) DivisionRing.toDivisionSemiring [DivisionRing α] : DivisionSemiring α :=
-  { ‹DivisionRing α›, (inferInstance : Semiring α) with }
+  { ‹DivisionRing α› with }
 #align division_ring.to_division_semiring DivisionRing.toDivisionSemiring
 
 /-- A `Semifield` is a `CommSemiring` with multiplicative inverses for nonzero elements. -/
@@ -170,7 +170,7 @@ variable [Field K]
 
 -- see Note [lower instance priority]
 instance (priority := 100) Field.toSemifield : Semifield K :=
-  { ‹Field K›, (inferInstance : Semiring K) with }
+  { ‹Field K› with }
 #align field.to_semifield Field.toSemifield
 
 end Field


### PR DESCRIPTION
In both `Division.toDivisionSemiring` and `Field.toSemiField`, an extra unused `Semiring` instance is provided to construct the instance. This removes them.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

These are remnants of the port. See comments on [Zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Field.2EtoSemifield). 

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
