### PR TITLE
[Merged by Bors] - feat: multiplicative morphism properties

### DIFF
--- a/Mathlib/CategoryTheory/MorphismProperty.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty.lean
@@ -726,8 +726,7 @@ class IsMultiplicative (W : MorphismProperty C) extends W.ContainsIdentities : P
   stableUnderComposition : W.StableUnderComposition
 
 lemma comp_mem (W : MorphismProperty C) {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) (hf : W f) (hg : W g)
-    [IsMultiplicative W] :
-    W (f ≫ g) :=
+    [IsMultiplicative W] : W (f ≫ g) :=
   IsMultiplicative.stableUnderComposition f g hf hg
 
 namespace IsMultiplicative

--- a/Mathlib/CategoryTheory/MorphismProperty.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty.lean
@@ -708,8 +708,14 @@ namespace ContainsIdentities
 instance op (W : MorphismProperty C) [W.ContainsIdentities] :
     W.op.ContainsIdentities := ⟨fun X => W.id_mem X.unop⟩
 
-lemma unop (W : MorphismProperty Cᵒᵖ) [W.ContainsIdentities] :
+instance unop (W : MorphismProperty Cᵒᵖ) [W.ContainsIdentities] :
     W.unop.ContainsIdentities := ⟨fun X => W.id_mem (Opposite.op X)⟩
+
+lemma of_op (W : MorphismProperty C) [W.op.ContainsIdentities] :
+    W.ContainsIdentities := (inferInstance : W.op.unop.ContainsIdentities)
+
+lemma of_unop (W : MorphismProperty Cᵒᵖ) [W.unop.ContainsIdentities] :
+    W.ContainsIdentities := (inferInstance : W.unop.op.ContainsIdentities)
 
 end ContainsIdentities
 
@@ -729,9 +735,15 @@ namespace IsMultiplicative
 instance op (W : MorphismProperty C) [IsMultiplicative W] : IsMultiplicative W.op where
   stableUnderComposition := fun _ _ _ f g hf hg => W.comp_mem g.unop f.unop hg hf
 
-lemma unop (W : MorphismProperty Cᵒᵖ) [IsMultiplicative W] : IsMultiplicative W.unop where
+instance unop (W : MorphismProperty Cᵒᵖ) [IsMultiplicative W] : IsMultiplicative W.unop where
   id_mem' _ := W.id_mem _
   stableUnderComposition := fun _ _ _ f g hf hg => W.comp_mem g.op f.op hg hf
+
+lemma of_op (W : MorphismProperty C) [IsMultiplicative W.op] : IsMultiplicative W :=
+  (inferInstance : IsMultiplicative W.op.unop)
+
+lemma of_unop (W : MorphismProperty Cᵒᵖ) [IsMultiplicative W.unop] : IsMultiplicative W :=
+  (inferInstance : IsMultiplicative W.unop.op)
 
 end IsMultiplicative
 

--- a/Mathlib/CategoryTheory/MorphismProperty.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty.lean
@@ -695,6 +695,46 @@ theorem bijective_respectsIso : (MorphismProperty.bijective C).RespectsIso :=
 
 end Bijective
 
+/-- Typeclass expressing that a morphism property contain identities. -/
+class ContainsIdentities (W : MorphismProperty C) : Prop :=
+  /-- for all `X : C`, the identity of `X` satisfies the morphism property -/
+  id_mem' : ∀ (X : C), W (𝟙 X)
+
+lemma id_mem (W : MorphismProperty C) [W.ContainsIdentities] (X : C) :
+  W (𝟙 X) := ContainsIdentities.id_mem' X
+
+namespace ContainsIdentities
+
+instance op (W : MorphismProperty C) [W.ContainsIdentities] :
+    W.op.ContainsIdentities := ⟨fun X => W.id_mem X.unop⟩
+
+lemma unop (W : MorphismProperty Cᵒᵖ) [W.ContainsIdentities] :
+    W.unop.ContainsIdentities := ⟨fun X => W.id_mem (Opposite.op X)⟩
+
+end ContainsIdentities
+
+/-- A morphism property is multiplicative if it contains identities and is stable by
+composition. -/
+class IsMultiplicative (W : MorphismProperty C) extends W.ContainsIdentities : Prop :=
+  /-- compatibility of  -/
+  stableUnderComposition : W.StableUnderComposition
+
+lemma comp_mem (W : MorphismProperty C) {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) (hf : W f) (hg : W g)
+    [IsMultiplicative W] :
+    W (f ≫ g) :=
+  IsMultiplicative.stableUnderComposition f g hf hg
+
+namespace IsMultiplicative
+
+instance op (W : MorphismProperty C) [IsMultiplicative W] : IsMultiplicative W.op where
+  stableUnderComposition := fun _ _ _ f g hf hg => W.comp_mem g.unop f.unop hg hf
+
+lemma unop (W : MorphismProperty Cᵒᵖ) [IsMultiplicative W] : IsMultiplicative W.unop where
+  id_mem' _ := W.id_mem _
+  stableUnderComposition := fun _ _ _ f g hf hg => W.comp_mem g.op f.op hg hf
+
+end IsMultiplicative
+
 end MorphismProperty
 
 end CategoryTheory


### PR DESCRIPTION
This PR introduces the notion of multiplicative morphism property, i.e. contains identities and is stable under composition.

---

`ContainsIdentities` and `IsMultiplicative` are typeclasses because it will be useful in future developments of the localization of categories (e.g. calculus of fractions, localization of triangulated categories).

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
