### PR TITLE
[Merged by Bors] - feat: cochains of morphisms between cochain complexes

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -221,6 +221,7 @@ import Mathlib.Algebra.Homology.HomologicalComplex
 import Mathlib.Algebra.Homology.Homology
 import Mathlib.Algebra.Homology.Homotopy
 import Mathlib.Algebra.Homology.HomotopyCategory
+import Mathlib.Algebra.Homology.HomotopyCategory.HomComplex
 import Mathlib.Algebra.Homology.ImageToKernel
 import Mathlib.Algebra.Homology.LocalCohomology
 import Mathlib.Algebra.Homology.ModuleCat

--- a/Mathlib/Algebra/Homology/HomotopyCategory/HomComplex.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/HomComplex.lean
@@ -239,7 +239,7 @@ lemma comp_zero_cochain_v (z₁ : Cochain F G n) (z₂ : Cochain G K 0) (p q : �
 
 @[simp]
 lemma zero_cochain_comp_v (z₁ : Cochain F G 0) (z₂ : Cochain G K n) (p q : ℤ) (hpq : p + n = q) :
-      (z₁.comp z₂ (zero_add n)).v p q hpq = z₁.v p p (add_zero p) ≫ z₂.v p q hpq :=
+    (z₁.comp z₂ (zero_add n)).v p q hpq = z₁.v p p (add_zero p) ≫ z₂.v p q hpq :=
   comp_v z₁ z₂ (zero_add n) p p q (add_zero p) hpq
 
 /-- The associativity of the composition of cochains. -/

--- a/Mathlib/Algebra/Homology/HomotopyCategory/HomComplex.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/HomComplex.lean
@@ -23,7 +23,7 @@ If `α : Cochain K L n`, we shall define `α.v p q hpq : F.X p ⟶ G.X q`.
 TODO:
 * Define the differential `Cochain K L n ⟶ Cochain K L m`, and develop the API.
 * Identify morphisms of complexes to `0`-cocycles.
-* Identify homotopies to `-1`-cochains satisfying certain relation.
+* Identify homotopies to `-1`-cochains satisfying certain relations.
 * Behaviour with respect to shifting the cochain complexes `K` and `L`.
 
 -/

--- a/Mathlib/Algebra/Homology/HomotopyCategory/HomComplex.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/HomComplex.lean
@@ -1,0 +1,265 @@
+/-
+Copyright (c) 2023 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+import Mathlib.Algebra.Homology.Homotopy
+import Mathlib.Tactic.Linarith
+
+/-! The cochain complex of homomorphisms between cochain complexes
+
+If `K` and `L` are cochain complexes (indexed by `ℤ`) in a preadditive category,
+there is a cochain complex of abelian groups whose `0`-cocycles identify to
+morphisms `K ⟶ L`. Informally, in degree `n`, this complex shall consist of
+cochains of degree `n` from `K` to `L`, i.e. arbitrary families for morphisms
+`K.X p ⟶ L.X (p + n)`.
+
+In order to avoid type theoretic issues, a cochain of degree `n : ℤ`
+(i.e. a term of type of `Cochain K L n`) shall be defined here
+as the data of a morphism `F.X p ⟶ G.X q` for all triplets
+`⟨p, q, hpq⟩` where `p` and `q` are integers and `hpq : p + n = q`.
+If `α : Cochain K L n`, we shall define `α.v p q hpq : F.X p ⟶ G.X q`.
+
+TODO:
+* Define the differential `Cochain K L n ⟶ Cochain K L m`, and develop the API.
+* Identify morphisms of complexes to `0`-cocycles.
+* Identify homotopies to `-1`-cochains satisfying certain relation.
+* Behaviour with respect to shifting the cochain complexes `K` and `L`.
+
+-/
+
+open CategoryTheory Category
+
+universe v u
+
+variable {C : Type u} [Category.{v} C] [Preadditive C]
+
+namespace CochainComplex
+
+section
+
+variable {F G K L : CochainComplex C ℤ} (n m : ℤ)
+
+namespace HomComplex
+
+/-- A term of type `HomComplex.Triplet n` consists of two integers `p` and `q`
+such that `p + n = q`. (This type is introduced so that the instance
+`AddCommGroup (Cochain F G n)` defined below can be found automatically.) -/
+structure Triplet (n : ℤ) where
+  /-- a first integer -/
+  p : ℤ
+  /-- a second integer -/
+  q : ℤ
+  /-- the condition on the two integers -/
+  hpq : p + n = q
+
+variable (F G)
+
+/-- A cochain of degree `n : ℤ` between to cochain complexes `F` and `G` consists
+of a family of morphisms `F.X p ⟶ G.X q` whenever `p + n = q`, i.e. for all
+triplets in `HomComplex.Triplet n`. -/
+def Cochain := ∀ (T : Triplet n), F.X T.p ⟶ G.X T.q
+
+instance : AddCommGroup (Cochain F G n) := by
+  dsimp only [Cochain]
+  infer_instance
+
+namespace Cochain
+
+variable {F G n}
+
+/-- A practical constructor for cochains. -/
+def mk (v : ∀ (p q : ℤ) (_ : p + n = q), F.X p ⟶ G.X q) : Cochain F G n :=
+  fun ⟨p, q, hpq⟩ => v p q hpq
+
+/-- The value of a cochain on a triplet `⟨p, q, hpq⟩`. -/
+@[pp_dot]
+def v (γ : Cochain F G n) (p q : ℤ) (hpq : p + n = q) :
+  F.X p ⟶ G.X q := γ ⟨p, q, hpq⟩
+
+@[simp]
+lemma mk_v (v : ∀ (p q : ℤ) (_ : p + n = q), F.X p ⟶ G.X q) (p q : ℤ) (hpq : p + n = q) :
+    (Cochain.mk v).v p q hpq = v p q hpq := rfl
+
+lemma congr_v {z₁ z₂ : Cochain F G n} (h : z₁ = z₂) (p q : ℤ) (hpq : p + n = q) :
+  z₁.v p q hpq = z₂.v p q hpq := by subst h; rfl
+
+@[ext]
+lemma ext (z₁ z₂ : Cochain F G n)
+    (h : ∀ (T : Triplet n), z₁.v T.p T.q T.hpq = z₂.v T.p T.q T.hpq) : z₁ = z₂ :=
+  funext h
+
+@[ext 1100]
+lemma ext₀ (z₁ z₂ : Cochain F G 0)
+    (h : ∀ (p : ℤ), z₁.v p p (add_zero p) = z₂.v p p (add_zero p)) : z₁ = z₂ := by
+    ext ⟨p, q, hpq⟩
+    obtain rfl : q = p := by rw [← hpq, add_zero]
+    exact h q
+
+@[simp]
+lemma zero_v {n : ℤ} (p q : ℤ) (hpq : p + n = q) :
+    (0 : Cochain F G n).v p q hpq = 0 := rfl
+
+@[simp]
+lemma add_v {n : ℤ} (z₁ z₂ : Cochain F G n) (p q : ℤ) (hpq : p + n = q) :
+    (z₁+z₂).v p q hpq = z₁.v p q hpq + z₂.v p q hpq := rfl
+
+@[simp]
+lemma sub_v {n : ℤ} (z₁ z₂ : Cochain F G n) (p q : ℤ) (hpq : p + n = q) :
+    (z₁-z₂).v p q hpq = z₁.v p q hpq - z₂.v p q hpq := rfl
+
+@[simp]
+lemma neg_v {n : ℤ} (z : Cochain F G n) (p q : ℤ) (hpq : p + n = q) :
+    (-z).v p q hpq = - (z.v p q hpq) := rfl
+
+@[simp]
+lemma zsmul_v {n k : ℤ} (z : Cochain F G n) (p q : ℤ) (hpq : p + n = q) :
+    (k • z).v p q hpq = k • (z.v p q hpq) := rfl
+
+/-- A cochain of degree `0` from `F` to `G` can be constructed from a family
+of morphisms `F.X p ⟶ G.X p` for all `p : ℤ`. -/
+def ofHoms (ψ : ∀ (p : ℤ), F.X p ⟶ G.X p) : Cochain F G 0 :=
+Cochain.mk (fun p q hpq => ψ p ≫ eqToHom (by rw [← hpq, add_zero]))
+
+@[simp]
+lemma ofHoms_v (ψ : ∀ (p : ℤ), F.X p ⟶ G.X p) (p : ℤ) :
+    (ofHoms ψ).v p p (add_zero p) = ψ p := by
+  simp only [ofHoms, mk_v, eqToHom_refl, comp_id]
+
+@[simp]
+lemma ofHoms_zero : ofHoms (fun p => (0 : F.X p ⟶ G.X p)) = 0 := by aesop_cat
+
+@[simp]
+lemma ofHoms_v_comp_d (ψ : ∀ (p : ℤ), F.X p ⟶ G.X p) (p q q' : ℤ) (hpq : p + 0 = q) :
+    (ofHoms ψ).v p q hpq ≫ G.d q q' = ψ p ≫ G.d p q' := by
+  rw [add_zero] at hpq
+  subst hpq
+  rw [ofHoms_v]
+
+@[simp]
+lemma d_comp_ofHoms_v (ψ : ∀ (p : ℤ), F.X p ⟶ G.X p) (p' p q  : ℤ) (hpq : p + 0 = q) :
+    F.d p' p ≫ (ofHoms ψ).v p q hpq = F.d p' q ≫ ψ q := by
+  rw [add_zero] at hpq
+  subst hpq
+  rw [ofHoms_v]
+
+/-- The `0`-cochain attached to a morphism of cochain complexes. -/
+def ofHom (φ : F ⟶ G) : Cochain F G 0 := ofHoms (fun p => φ.f p)
+
+variable (F G)
+
+@[simp]
+lemma ofHom_zero : ofHom (0 : F ⟶ G) = 0 := by
+  simp only [ofHom, HomologicalComplex.zero_f_apply, ofHoms_zero]
+
+variable {F G}
+
+@[simp]
+lemma ofHom_v (φ : F ⟶ G) (p : ℤ) : (ofHom φ).v p p (add_zero p) = φ.f p := by
+  simp only [ofHom, ofHoms_v]
+
+@[simp]
+lemma ofHom_v_comp_d (φ : F ⟶ G) (p q q' : ℤ) (hpq : p + 0 = q) :
+    (ofHom φ).v p q hpq ≫ G.d q q' = φ.f p ≫ G.d p q' :=
+by simp only [ofHom, ofHoms_v_comp_d]
+
+@[simp]
+lemma d_comp_ofHom_v (φ : F ⟶ G) (p' p q  : ℤ) (hpq : p + 0 = q) :
+    F.d p' p ≫ (ofHom φ).v p q hpq = F.d p' q ≫ φ.f q := by
+  simp only [ofHom, d_comp_ofHoms_v]
+
+@[simp]
+lemma ofHom_add (φ₁ φ₂ : F ⟶ G) :
+    Cochain.ofHom (φ₁ + φ₂) = Cochain.ofHom φ₁ + Cochain.ofHom φ₂ := by aesop_cat
+
+@[simp]
+lemma ofHom_sub (φ₁ φ₂ : F ⟶ G) :
+    Cochain.ofHom (φ₁ - φ₂) = Cochain.ofHom φ₁ - Cochain.ofHom φ₂ := by aesop_cat
+
+@[simp]
+lemma ofHom_neg (φ : F ⟶ G) :
+    Cochain.ofHom (-φ) = -Cochain.ofHom φ := by aesop_cat
+
+/-- The cochain of degree `-1` given by an homotopy between two morphism of complexes. -/
+def ofHomotopy {φ₁ φ₂ : F ⟶ G} (ho : Homotopy φ₁ φ₂) : Cochain F G (-1) :=
+  Cochain.mk (fun p q _ => ho.hom p q)
+
+@[simp]
+lemma ofHomotopy_ofEq {φ₁ φ₂ : F ⟶ G} (h : φ₁ = φ₂) :
+    ofHomotopy (Homotopy.ofEq h) = 0 := by rfl
+
+@[simp]
+lemma ofHomotopy_refl (φ : F ⟶ G) :
+    ofHomotopy (Homotopy.refl φ) = 0 := by rfl
+
+@[reassoc]
+lemma v_comp_XIsoOfEq_hom
+    (γ : Cochain F G n) (p q q' : ℤ) (hpq : p + n = q) (hq' : q = q') :
+    γ.v p q hpq ≫ (HomologicalComplex.XIsoOfEq G hq').hom = γ.v p q' (by rw [← hq', hpq]) := by
+  subst hq'
+  simp only [HomologicalComplex.XIsoOfEq, eqToIso_refl, Iso.refl_hom, comp_id]
+
+@[reassoc]
+lemma v_comp_XIsoOfEq_inv
+    (γ : Cochain F G n) (p q q' : ℤ) (hpq : p + n = q) (hq' : q' = q) :
+    γ.v p q hpq ≫ (HomologicalComplex.XIsoOfEq G hq').inv = γ.v p q' (by rw [hq', hpq]) := by
+  subst hq'
+  simp only [HomologicalComplex.XIsoOfEq, eqToIso_refl, Iso.refl_inv, comp_id]
+
+/-- The composition of cochains. -/
+@[pp_dot]
+def comp {n₁ n₂ n₁₂ : ℤ} (z₁ : Cochain F G n₁) (z₂ : Cochain G K n₂) (h : n₁ + n₂ = n₁₂) :
+    Cochain F K n₁₂ :=
+  Cochain.mk (fun p q hpq => z₁.v p (p + n₁) rfl ≫ z₂.v (p + n₁) q (by linarith))
+
+/-! If `z₁` is a cochain of degree `n₁` and `z₂` is a cochain of degree `n₂`, and that
+we have a relation `h : n₁ + n₂ = n₁₂`, then `z₁.comp z₂ h` is a cochain of degree `n₁₂`.
+The following lemma `comp_v` computes the value of this composition `z₁.comp z₂ h`
+on a triplet `⟨p₁, p₃, _⟩` (with `p₁ + n₁₂ = p₃`). In order to use this lemma,
+we need to provide an intermediate integer `p₂` such that `p₁ + n₁ = p₂`.
+It is advisable to use a `p₂` that has good definitional properties
+(i.e. `p₁ + n₁` is not always the best choice.)
+
+When `z₁` or `z₂` is a `0`-cochain, there is a better choice of `p₂`, and this leads
+to the two simplification lemmas `comp_zero_cochain_v` and `zero_cochain_comp_v`.
+
+-/
+
+lemma comp_v {n₁ n₂ n₁₂ : ℤ} (z₁ : Cochain F G n₁) (z₂ : Cochain G K n₂) (h : n₁ + n₂ = n₁₂)
+    (p₁ p₂ p₃ : ℤ) (h₁ : p₁ + n₁ = p₂) (h₂ : p₂ + n₂ = p₃) :
+    (z₁.comp z₂ h).v p₁ p₃ (by rw [← h₂, ← h₁, ← h, add_assoc]) =
+      z₁.v p₁ p₂ h₁ ≫ z₂.v p₂ p₃ h₂ := by
+  subst h₁ ; rfl
+
+
+@[simp]
+lemma comp_zero_cochain_v (z₁ : Cochain F G n) (z₂ : Cochain G K 0) (p q : ℤ) (hpq : p + n = q) :
+    (z₁.comp z₂ (add_zero n)).v p q hpq = z₁.v p q hpq ≫ z₂.v q q (add_zero q) :=
+  comp_v z₁ z₂ (add_zero n) p q q hpq (add_zero q)
+
+@[simp]
+lemma zero_cochain_comp_v (z₁ : Cochain F G 0) (z₂ : Cochain G K n) (p q : ℤ) (hpq : p + n = q) :
+      (z₁.comp z₂ (zero_add n)).v p q hpq = z₁.v p p (add_zero p) ≫ z₂.v p q hpq :=
+  comp_v z₁ z₂ (zero_add n) p p q (add_zero p) hpq
+
+/-- The associativity of the composition of cochains. -/
+lemma comp_assoc {n₁ n₂ n₃ n₁₂ n₂₃ n₁₂₃ : ℤ}
+      (z₁ : Cochain F G n₁) (z₂ : Cochain G K n₂) (z₃ : Cochain K L n₃)
+      (h₁₂ : n₁ + n₂ = n₁₂) (h₂₃ : n₂ + n₃ = n₂₃) (h₁₂₃ : n₁ + n₂ + n₃ = n₁₂₃) :
+      (z₁.comp z₂ h₁₂).comp z₃ (show n₁₂ + n₃ = n₁₂₃ by rw [← h₁₂, h₁₂₃]) =
+        z₁.comp (z₂.comp z₃ h₂₃) (by rw [← h₂₃, ← h₁₂₃, add_assoc]) := by
+  substs h₁₂ h₂₃ h₁₂₃
+  ext ⟨p, q, hpq⟩
+  dsimp
+  rw [comp_v _ _ rfl p (p + n₁ + n₂) q (by linarith) (by linarith),
+    comp_v z₁ z₂ rfl p (p + n₁) (p + n₁ + n₂) (by linarith) (by linarith),
+    comp_v z₁ (z₂.comp z₃ rfl) (add_assoc n₁ n₂ n₃).symm p (p + n₁) q (by linarith) (by linarith),
+    comp_v z₂ z₃ rfl (p + n₁) (p + n₁ + n₂) q (by linarith) (by linarith), assoc]
+
+end Cochain
+
+end HomComplex
+
+end
+
+end CochainComplex

--- a/Mathlib/Algebra/Homology/HomotopyCategory/HomComplex.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/HomComplex.lean
@@ -119,7 +119,7 @@ lemma zsmul_v {n k : ℤ} (z : Cochain F G n) (p q : ℤ) (hpq : p + n = q) :
 /-- A cochain of degree `0` from `F` to `G` can be constructed from a family
 of morphisms `F.X p ⟶ G.X p` for all `p : ℤ`. -/
 def ofHoms (ψ : ∀ (p : ℤ), F.X p ⟶ G.X p) : Cochain F G 0 :=
-Cochain.mk (fun p q hpq => ψ p ≫ eqToHom (by rw [← hpq, add_zero]))
+  Cochain.mk (fun p q hpq => ψ p ≫ eqToHom (by rw [← hpq, add_zero]))
 
 @[simp]
 lemma ofHoms_v (ψ : ∀ (p : ℤ), F.X p ⟶ G.X p) (p : ℤ) :

--- a/Mathlib/Algebra/Homology/HomotopyCategory/HomComplex.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/HomComplex.lean
@@ -229,7 +229,7 @@ lemma comp_v {n₁ n₂ n₁₂ : ℤ} (z₁ : Cochain F G n₁) (z₂ : Cochain
     (p₁ p₂ p₃ : ℤ) (h₁ : p₁ + n₁ = p₂) (h₂ : p₂ + n₂ = p₃) :
     (z₁.comp z₂ h).v p₁ p₃ (by rw [← h₂, ← h₁, ← h, add_assoc]) =
       z₁.v p₁ p₂ h₁ ≫ z₂.v p₂ p₃ h₂ := by
-  subst h₁ ; rfl
+  subst h₁; rfl
 
 
 @[simp]

--- a/Mathlib/Algebra/Homology/HomotopyCategory/HomComplex.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/HomComplex.lean
@@ -102,11 +102,11 @@ lemma zero_v {n : ℤ} (p q : ℤ) (hpq : p + n = q) :
 
 @[simp]
 lemma add_v {n : ℤ} (z₁ z₂ : Cochain F G n) (p q : ℤ) (hpq : p + n = q) :
-    (z₁+z₂).v p q hpq = z₁.v p q hpq + z₂.v p q hpq := rfl
+    (z₁ + z₂).v p q hpq = z₁.v p q hpq + z₂.v p q hpq := rfl
 
 @[simp]
 lemma sub_v {n : ℤ} (z₁ z₂ : Cochain F G n) (p q : ℤ) (hpq : p + n = q) :
-    (z₁-z₂).v p q hpq = z₁.v p q hpq - z₂.v p q hpq := rfl
+    (z₁ - z₂).v p q hpq = z₁.v p q hpq - z₂.v p q hpq := rfl
 
 @[simp]
 lemma neg_v {n : ℤ} (z : Cochain F G n) (p q : ℤ) (hpq : p + n = q) :

--- a/Mathlib/Algebra/Homology/HomotopyCategory/HomComplex.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/HomComplex.lean
@@ -244,10 +244,10 @@ lemma zero_cochain_comp_v (z₁ : Cochain F G 0) (z₂ : Cochain G K n) (p q : �
 
 /-- The associativity of the composition of cochains. -/
 lemma comp_assoc {n₁ n₂ n₃ n₁₂ n₂₃ n₁₂₃ : ℤ}
-      (z₁ : Cochain F G n₁) (z₂ : Cochain G K n₂) (z₃ : Cochain K L n₃)
-      (h₁₂ : n₁ + n₂ = n₁₂) (h₂₃ : n₂ + n₃ = n₂₃) (h₁₂₃ : n₁ + n₂ + n₃ = n₁₂₃) :
-      (z₁.comp z₂ h₁₂).comp z₃ (show n₁₂ + n₃ = n₁₂₃ by rw [← h₁₂, h₁₂₃]) =
-        z₁.comp (z₂.comp z₃ h₂₃) (by rw [← h₂₃, ← h₁₂₃, add_assoc]) := by
+    (z₁ : Cochain F G n₁) (z₂ : Cochain G K n₂) (z₃ : Cochain K L n₃)
+    (h₁₂ : n₁ + n₂ = n₁₂) (h₂₃ : n₂ + n₃ = n₂₃) (h₁₂₃ : n₁ + n₂ + n₃ = n₁₂₃) :
+    (z₁.comp z₂ h₁₂).comp z₃ (show n₁₂ + n₃ = n₁₂₃ by rw [← h₁₂, h₁₂₃]) =
+      z₁.comp (z₂.comp z₃ h₂₃) (by rw [← h₂₃, ← h₁₂₃, add_assoc]) := by
   substs h₁₂ h₂₃ h₁₂₃
   ext ⟨p, q, hpq⟩
   dsimp


### PR DESCRIPTION
This PR starts the construction of the cochain complex of morphisms from a cochain complex to another.

---

(I am sorry this PR is a little bit longer than the norm, but I wanted to include the composition of cochains.)

If `F` and `G` are two cochain complexes (indexed by the integers), I roughly define an element in `Cochain F G n` to be the datum of morphisms `F.X p ⟶ G.X q` for all integers `p` and `q` such that `p + n = q`. (Before I chose this design, I also experimented with a simpler definition : `F.X p ⟶ G.X (p+n)` for all `p`, but this lead to a nightmare of `eqToHom` popping everywhere.)

These cochains shall play a critical role in the study of the mapping cone of a morphism of cochain complexes, and in the verification of the axioms of triangulated categories for the homotopy category, which is the reason why this PR creates the file `Algebra.Homology.HomotopyCategory.HomComplex`.

(Note: the composition of cochains would be an example of an instance of the type class of graded heterogeneous multiplications which I attempted to introduce in #6678. I wish that the current API for graded types could be generalized in order to involve three graded types (i.e. some `HMul` rather than just `Mul` and `SMul`), and that the data would involve a multiplication `X a → Y b → Z c` whenever `a + b = c` rather than just `X a → Y b → Z (a + b).`, see the discussion there #6678. However, there is no hurry about a design decision here, because I shall not need more graded heterogeneous multiplications until the construction of the derived category of an abelian category and its triangulated structure is over...)

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
