### PR TITLE
[Merged by Bors] - chore(LinearAlgebra/DFinsupp): remove dependency on `Basis`

### DIFF
--- a/Mathlib/Algebra/DirectSum/Module.lean
+++ b/Mathlib/Algebra/DirectSum/Module.lean
@@ -5,6 +5,7 @@ Authors: Kenny Lau
 -/
 import Mathlib.Algebra.DirectSum.Basic
 import Mathlib.LinearAlgebra.DFinsupp
+import Mathlib.LinearAlgebra.Basis
 
 #align_import algebra.direct_sum.module from "leanprover-community/mathlib"@"6623e6af705e97002a9054c1c05a980180276fc1"
 

--- a/Mathlib/LinearAlgebra/DFinsupp.lean
+++ b/Mathlib/LinearAlgebra/DFinsupp.lean
@@ -4,7 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Kenny Lau
 -/
 import Mathlib.Data.Finsupp.ToDFinsupp
-import Mathlib.LinearAlgebra.Basis
+import Mathlib.LinearAlgebra.Finsupp
+import Mathlib.LinearAlgebra.LinearIndependent
 
 #align_import linear_algebra.dfinsupp from "leanprover-community/mathlib"@"a148d797a1094ab554ad4183a4ad6f130358ef64"
 
@@ -279,19 +280,6 @@ theorem coprodMap_apply_single (f : ∀ i : ι, M i →ₗ[R] N) (i : ι) (x : M
   simp [coprodMap_apply]
 
 end CoprodMap
-
-section Basis
-
-/-- The direct sum of free modules is free.
-
-Note that while this is stated for `DFinsupp` not `DirectSum`, the types are defeq. -/
-noncomputable def basis {η : ι → Type*} (b : ∀ i, Basis (η i) R (M i)) :
-    Basis (Σi, η i) R (Π₀ i, M i) :=
-  .ofRepr
-    ((mapRange.linearEquiv fun i => (b i).repr).trans (sigmaFinsuppLequivDFinsupp R).symm)
-#align dfinsupp.basis DFinsupp.basis
-
-end Basis
 
 end DFinsupp
 

--- a/Mathlib/LinearAlgebra/FinsuppVectorSpace.lean
+++ b/Mathlib/LinearAlgebra/FinsuppVectorSpace.lean
@@ -3,8 +3,8 @@ Copyright (c) 2019 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl
 -/
-import Mathlib.LinearAlgebra.StdBasis
 import Mathlib.LinearAlgebra.DFinsupp
+import Mathlib.LinearAlgebra.StdBasis
 
 #align_import linear_algebra.finsupp_vector_space from "leanprover-community/mathlib"@"59628387770d82eb6f6dd7b7107308aa2509ec95"
 

--- a/Mathlib/LinearAlgebra/FinsuppVectorSpace.lean
+++ b/Mathlib/LinearAlgebra/FinsuppVectorSpace.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl
 -/
 import Mathlib.LinearAlgebra.StdBasis
+import Mathlib.LinearAlgebra.DFinsupp
 
 #align_import linear_algebra.finsupp_vector_space from "leanprover-community/mathlib"@"59628387770d82eb6f6dd7b7107308aa2509ec95"
 
@@ -135,6 +136,25 @@ theorem coe_basisSingleOne : (Finsupp.basisSingleOne : ι → ι →₀ R) = fun
 end Semiring
 
 end Finsupp
+
+
+namespace DFinsupp
+
+variable {ι : Type*} {R : Type*} {M : ι → Type*}
+
+variable [Semiring R] [∀ i, AddCommMonoid (M i)] [∀ i, Module R (M i)]
+
+/-- The direct sum of free modules is free.
+
+Note that while this is stated for `DFinsupp` not `DirectSum`, the types are defeq. -/
+noncomputable def basis {η : ι → Type*} (b : ∀ i, Basis (η i) R (M i)) :
+    Basis (Σi, η i) R (Π₀ i, M i) :=
+  .ofRepr
+    ((mapRange.linearEquiv fun i => (b i).repr).trans (sigmaFinsuppLequivDFinsupp R).symm)
+#align dfinsupp.basis DFinsupp.basis
+
+end DFinsupp
+
 
 /-! TODO: move this section to an earlier file. -/
 

--- a/Mathlib/LinearAlgebra/FinsuppVectorSpace.lean
+++ b/Mathlib/LinearAlgebra/FinsuppVectorSpace.lean
@@ -137,11 +137,8 @@ end Semiring
 
 end Finsupp
 
-
 namespace DFinsupp
-
 variable {ι : Type*} {R : Type*} {M : ι → Type*}
-
 variable [Semiring R] [∀ i, AddCommMonoid (M i)] [∀ i, Module R (M i)]
 
 /-- The direct sum of free modules is free.
@@ -154,7 +151,6 @@ noncomputable def basis {η : ι → Type*} (b : ∀ i, Basis (η i) R (M i)) :
 #align dfinsupp.basis DFinsupp.basis
 
 end DFinsupp
-
 
 /-! TODO: move this section to an earlier file. -/
 


### PR DESCRIPTION
The motivation here is to explore re-defining `Basis` with `DFinsupp` instead of `Finsupp`, in order to make it computable.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
