### PR TITLE
[Merged by Bors] - feat(LinearAlgebra/Lagrange): Generalize typeclasses.

### DIFF
--- a/Mathlib/LinearAlgebra/Lagrange.lean
+++ b/Mathlib/LinearAlgebra/Lagrange.lean
@@ -139,10 +139,123 @@ namespace Lagrange
 
 open Polynomial
 
-variable {F : Type*} [Field F]
+section Nodal
+
+variable {R : Type*} [CommRing R] {ι : Type*}
+variable {s : Finset ι} {v : ι → R}
+
+open Finset Polynomial
+
+/-- `nodal s v` is the unique monic polynomial whose roots are the nodes defined by `v` and `s`.
+
+That is, the roots of `nodal s v` are exactly the image of `v` on `s`,
+with appropriate multiplicity.
+
+We can use `nodal` to define the barycentric forms of the evaluated interpolant.
+-/
+
+def nodal (s : Finset ι) (v : ι → R) : R[X] :=
+  ∏ i in s, (X - C (v i))
+#align lagrange.nodal Lagrange.nodal
+
+theorem nodal_eq (s : Finset ι) (v : ι → R) : nodal s v = ∏ i in s, (X - C (v i)) :=
+  rfl
+#align lagrange.nodal_eq Lagrange.nodal_eq
+
+@[simp]
+theorem nodal_empty : nodal ∅ v = 1 := by
+  rfl
+#align lagrange.nodal_empty Lagrange.nodal_empty
+
+@[simp]
+theorem natDegree_nodal [Nontrivial R] : (nodal s v).natDegree = s.card := by
+  simp_rw [nodal, natDegree_prod_of_monic (h := fun i _ => monic_X_sub_C (v i)),
+    natDegree_X_sub_C, sum_const, smul_eq_mul, mul_one]
+
+theorem nodal_ne_zero [Nontrivial R] : nodal s v ≠ 0 := by
+rcases s.eq_empty_or_nonempty with (rfl | h)
+· exact one_ne_zero
+· apply ne_zero_of_natDegree_gt (n := 0)
+  simp only [natDegree_nodal, h.card_pos]
+
+@[simp]
+theorem degree_nodal [Nontrivial R] : (nodal s v).degree = s.card := by
+  simp_rw [degree_eq_natDegree (nodal_ne_zero), natDegree_nodal]
+#align lagrange.degree_nodal Lagrange.degree_nodal
+
+theorem nodal_monic : (nodal s v).Monic :=
+  monic_prod_of_monic s (fun i ↦ X - C (v i)) fun i _ ↦ monic_X_sub_C (v i)
+
+theorem eval_nodal {x : R} : (nodal s v).eval x = ∏ i in s, (x - v i) := by
+  simp_rw [nodal, eval_prod, eval_sub, eval_X, eval_C]
+#align lagrange.eval_nodal Lagrange.eval_nodal
+
+theorem eval_nodal_at_node {i : ι} (hi : i ∈ s) : eval (v i) (nodal s v) = 0 := by
+  rw [eval_nodal]
+  exact s.prod_eq_zero hi (sub_self (v i))
+
+#align lagrange.eval_nodal_at_node Lagrange.eval_nodal_at_node
+
+theorem eval_nodal_not_at_node [Nontrivial R] [NoZeroDivisors R] {x : R}
+(hx : ∀ i ∈ s, x ≠ v i) : eval x (nodal s v) ≠ 0 := by
+  simp_rw [nodal, eval_prod, prod_ne_zero_iff, eval_sub, eval_X, eval_C, sub_ne_zero]
+  exact hx
+#align lagrange.eval_nodal_not_at_node Lagrange.eval_nodal_not_at_node
+
+theorem nodal_eq_mul_nodal_erase [DecidableEq ι] {i : ι} (hi : i ∈ s) :
+    nodal s v = (X - C (v i)) * nodal (s.erase i) v := by
+    simp_rw [nodal, Finset.mul_prod_erase _ (fun x => X - C (v x)) hi]
+#align lagrange.nodal_eq_mul_nodal_erase Lagrange.nodal_eq_mul_nodal_erase
+
+theorem X_sub_C_dvd_nodal (v : ι → R) {i : ι} (hi : i ∈ s) : X - C (v i) ∣ nodal s v :=
+  ⟨_, by classical exact nodal_eq_mul_nodal_erase hi⟩
+set_option linter.uppercaseLean3 false in
+#align lagrange.X_sub_C_dvd_nodal Lagrange.X_sub_C_dvd_nodal
+
+theorem nodal_insert_eq_nodal [DecidableEq ι] {i : ι} (hi : i ∉ s) :
+nodal (insert i s) v = (X - C (v i)) * nodal s v := by
+  simp_rw [nodal, prod_insert hi]
+#align lagrange.nodal_insert_eq_nodal Lagrange.nodal_insert_eq_nodal
+
+theorem derivative_nodal [DecidableEq ι] :
+derivative (nodal s v) = ∑ i in s, nodal (s.erase i) v := by
+  refine' s.induction_on _ fun i t hit IH => _
+  · rw [nodal_empty, derivative_one, sum_empty]
+  · rw [nodal_insert_eq_nodal hit, derivative_mul, IH, derivative_sub, derivative_X, derivative_C,
+      sub_zero, one_mul, sum_insert hit, mul_sum, erase_insert hit, add_right_inj]
+    refine' sum_congr rfl fun j hjt => _
+    rw [t.erase_insert_of_ne (ne_of_mem_of_not_mem hjt hit).symm,
+      nodal_insert_eq_nodal (mem_of_mem_erase.mt hit)]
+#align lagrange.derivative_nodal Lagrange.derivative_nodal
+
+theorem eval_nodal_derivative_eval_node_eq [DecidableEq ι] {i : ι} (hi : i ∈ s) :
+    eval (v i) (derivative (nodal s v)) = eval (v i) (nodal (s.erase i) v) := by
+  rw [derivative_nodal, eval_finset_sum, ← add_sum_erase _ _ hi, add_right_eq_self]
+  exact sum_eq_zero fun j hj => (eval_nodal_at_node (mem_erase.mpr ⟨(mem_erase.mp hj).1.symm, hi⟩))
+#align lagrange.eval_nodal_derivative_eval_node_eq Lagrange.eval_nodal_derivative_eval_node_eq
+
+/-- The vanishing polynomial on a multiplicative subgroup is of the form X ^ n - 1. -/
+@[simp] theorem nodal_subgroup_eq_X_pow_card_sub_one [IsDomain R]
+  (G : Subgroup Rˣ) [Fintype G] :
+  nodal (G : Set Rˣ).toFinset ((↑) : Rˣ → R) = X ^ (Fintype.card G) - 1 := by
+  have h : degree (1 : R[X]) < degree ((X : R[X]) ^ Fintype.card G) := by simp [Fintype.card_pos]
+  apply eq_of_degree_le_of_eval_index_eq (v := ((↑) : Rˣ → R)) (G : Set Rˣ).toFinset
+  · exact Set.injOn_of_injective Units.ext _
+  · simp
+  · rw [degree_sub_eq_left_of_degree_lt h, degree_nodal, Set.toFinset_card, degree_pow, degree_X,
+      nsmul_eq_mul, mul_one, Nat.cast_inj]
+    exact rfl
+  · rw [nodal_monic, leadingCoeff_sub_of_degree_lt h, monic_X_pow]
+  · intros i hi
+    rw [eval_nodal_at_node hi]
+    replace hi : i ∈ G := by simpa using hi
+    obtain ⟨g, rfl⟩ : ∃ g : G, g.val = i := ⟨⟨i, hi⟩, rfl⟩
+    simp [← Units.val_pow_eq_pow_val, ← Subgroup.coe_pow G]
+
+end Nodal
 
 section BasisDivisor
-
+variable {F : Type*} [Field F]
 variable {x y : F}
 
 /-- `basisDivisor x y` is the unique linear or constant polynomial such that
@@ -203,9 +316,10 @@ end BasisDivisor
 
 section Basis
 
-open Finset
+variable {F : Type*} [Field F] {ι : Type*} [DecidableEq ι]
+variable {s : Finset ι} {v : ι → F} {i j : ι}
 
-variable {ι : Type*} [DecidableEq ι] {s : Finset ι} {v : ι → F} {i j : ι}
+open Finset
 
 /-- Lagrange basis polynomials indexed by `s : Finset ι`, defined at nodes `v i` for a
 map `v : ι → F`. For `i, j ∈ s`, `basis s v i` evaluates to 0 at `v j` for `i ≠ j`. When
@@ -307,9 +421,10 @@ end Basis
 
 section Interpolate
 
-open Finset
+variable {F : Type*} [Field F] {ι : Type*} [DecidableEq ι]
+variable {s t : Finset ι} {i j : ι} {v : ι → F} (r r' : ι → F)
 
-variable {ι : Type*} [DecidableEq ι] {s t : Finset ι} {i j : ι} {v : ι → F} (r r' : ι → F)
+open Finset
 
 /-- Lagrange interpolation: given a finset `s : Finset ι`, a nodal map `v : ι → F` injective on
 `s` and a value function `r : ι → F`, `interpolate s v r` is the unique
@@ -493,94 +608,12 @@ theorem interpolate_eq_add_interpolate_erase (hvs : Set.InjOn v s) (hi : i ∈ s
 
 end Interpolate
 
-section Nodal
+section NodalWeight
 
-open Finset Polynomial
+variable {F : Type*} [Field F] {ι : Type*} [DecidableEq ι]
+variable {s : Finset ι} {v : ι → F} {i : ι}
 
-variable {ι : Type*} {s : Finset ι} {v : ι → F} {i : ι} (r : ι → F) {x : F}
-
-/-- `nodal s v` is the unique monic polynomial whose roots are the nodes defined by `v` and `s`.
-
-That is, the roots of `nodal s v` are exactly the image of `v` on `s`,
-with appropriate multiplicity.
-
-We can use `nodal` to define the barycentric forms of the evaluated interpolant.
--/
-
-def nodal (s : Finset ι) (v : ι → F) : F[X] :=
-  ∏ i in s, (X - C (v i))
-#align lagrange.nodal Lagrange.nodal
-
-theorem nodal_eq (s : Finset ι) (v : ι → F) : nodal s v = ∏ i in s, (X - C (v i)) :=
-  rfl
-#align lagrange.nodal_eq Lagrange.nodal_eq
-
-@[simp]
-theorem nodal_empty : nodal ∅ v = 1 := by
-  rfl
-#align lagrange.nodal_empty Lagrange.nodal_empty
-
-@[simp]
-theorem degree_nodal : (nodal s v).degree = s.card := by
-  simp_rw [nodal, degree_prod, degree_X_sub_C, sum_const, Nat.smul_one_eq_coe]
-#align lagrange.degree_nodal Lagrange.degree_nodal
-
-theorem nodal_monic : (nodal s v).Monic :=
-  monic_prod_of_monic s (fun i ↦ X - C (v i)) fun i _ ↦ monic_X_sub_C (v i)
-
-theorem eval_nodal {x : F} : (nodal s v).eval x = ∏ i in s, (x - v i) := by
-  simp_rw [nodal, eval_prod, eval_sub, eval_X, eval_C]
-#align lagrange.eval_nodal Lagrange.eval_nodal
-
-theorem eval_nodal_at_node (hi : i ∈ s) : eval (v i) (nodal s v) = 0 := by
-  rw [eval_nodal, prod_eq_zero_iff]
-  exact ⟨i, hi, sub_eq_zero_of_eq rfl⟩
-#align lagrange.eval_nodal_at_node Lagrange.eval_nodal_at_node
-
-theorem eval_nodal_not_at_node (hx : ∀ i ∈ s, x ≠ v i) : eval x (nodal s v) ≠ 0 := by
-  simp_rw [nodal, eval_prod, prod_ne_zero_iff, eval_sub, eval_X, eval_C, sub_ne_zero]
-  exact hx
-#align lagrange.eval_nodal_not_at_node Lagrange.eval_nodal_not_at_node
-
-theorem nodal_eq_mul_nodal_erase [DecidableEq ι] (hi : i ∈ s) :
-    nodal s v = (X - C (v i)) * nodal (s.erase i) v := by
-    simp_rw [nodal, Finset.mul_prod_erase _ (fun x => X - C (v x)) hi]
-#align lagrange.nodal_eq_mul_nodal_erase Lagrange.nodal_eq_mul_nodal_erase
-
-theorem X_sub_C_dvd_nodal (v : ι → F) (hi : i ∈ s) : X - C (v i) ∣ nodal s v :=
-  ⟨_, by classical exact nodal_eq_mul_nodal_erase hi⟩
-set_option linter.uppercaseLean3 false in
-#align lagrange.X_sub_C_dvd_nodal Lagrange.X_sub_C_dvd_nodal
-
-variable [DecidableEq ι]
-
-theorem nodal_erase_eq_nodal_div (hi : i ∈ s) :
-    nodal (s.erase i) v = nodal s v / (X - C (v i)) := by
-  rw [nodal_eq_mul_nodal_erase hi, EuclideanDomain.mul_div_cancel_left]
-  exact X_sub_C_ne_zero _
-#align lagrange.nodal_erase_eq_nodal_div Lagrange.nodal_erase_eq_nodal_div
-
-theorem nodal_insert_eq_nodal (hi : i ∉ s) : nodal (insert i s) v = (X - C (v i)) * nodal s v := by
-  simp_rw [nodal, prod_insert hi]
-#align lagrange.nodal_insert_eq_nodal Lagrange.nodal_insert_eq_nodal
-
-theorem derivative_nodal : Polynomial.derivative (nodal s v) = ∑ i in s, nodal (s.erase i) v := by
-  refine' Finset.induction_on s _ fun _ _ hit IH => _
-  · rw [nodal_empty, derivative_one, sum_empty]
-  · rw [nodal_insert_eq_nodal hit, derivative_mul, IH, derivative_sub, derivative_X, derivative_C,
-      sub_zero, one_mul, sum_insert hit, mul_sum, erase_insert hit, add_right_inj]
-    refine' sum_congr rfl fun j hjt => _
-    rw [nodal_erase_eq_nodal_div (mem_insert_of_mem hjt), nodal_insert_eq_nodal hit,
-      EuclideanDomain.mul_div_assoc _ (X_sub_C_dvd_nodal v hjt), nodal_erase_eq_nodal_div hjt]
-#align lagrange.derivative_nodal Lagrange.derivative_nodal
-
-theorem eval_nodal_derivative_eval_node_eq (hi : i ∈ s) :
-    eval (v i) (Polynomial.derivative (nodal s v)) = eval (v i) (nodal (s.erase i) v) := by
-  rw [derivative_nodal, eval_finset_sum, ← add_sum_erase _ _ hi, add_right_eq_self]
-  refine' sum_eq_zero fun j hj => _
-  simp_rw [nodal, eval_prod, eval_sub, eval_X, eval_C, prod_eq_zero_iff, mem_erase]
-  exact ⟨i, ⟨(mem_erase.mp hj).1.symm, hi⟩, sub_eq_zero_of_eq rfl⟩
-#align lagrange.eval_nodal_derivative_eval_node_eq Lagrange.eval_nodal_derivative_eval_node_eq
+open Finset
 
 /-- This defines the nodal weight for a given set of node indexes and node mapping function `v`. -/
 def nodalWeight (s : Finset ι) (v : ι → F) (i : ι) :=
@@ -591,6 +624,12 @@ theorem nodalWeight_eq_eval_nodal_erase_inv :
     nodalWeight s v i = (eval (v i) (nodal (s.erase i) v))⁻¹ := by
   rw [eval_nodal, nodalWeight, prod_inv_distrib]
 #align lagrange.nodal_weight_eq_eval_nodal_erase_inv Lagrange.nodalWeight_eq_eval_nodal_erase_inv
+
+theorem nodal_erase_eq_nodal_div (hi : i ∈ s) :
+    nodal (s.erase i) v = nodal s v / (X - C (v i)) := by
+  rw [nodal_eq_mul_nodal_erase hi, EuclideanDomain.mul_div_cancel_left]
+  exact X_sub_C_ne_zero _
+#align lagrange.nodal_erase_eq_nodal_div Lagrange.nodal_erase_eq_nodal_div
 
 theorem nodalWeight_eq_eval_nodal_derative (hi : i ∈ s) :
     nodalWeight s v i = (eval (v i) (Polynomial.derivative (nodal s v)))⁻¹ := by
@@ -603,6 +642,15 @@ theorem nodalWeight_ne_zero (hvs : Set.InjOn v s) (hi : i ∈ s) : nodalWeight s
   rcases mem_erase.mp hj with ⟨hij, hj⟩
   refine' inv_ne_zero (sub_ne_zero_of_ne (mt (hvs.eq_iff hi hj).mp hij.symm))
 #align lagrange.nodal_weight_ne_zero Lagrange.nodalWeight_ne_zero
+
+end NodalWeight
+
+section LagrangeInterpolant
+
+variable {F : Type*} [Field F] {ι : Type*} [DecidableEq ι]
+variable {s : Finset ι} {v : ι → F} (r : ι → F) {i : ι} {x : F}
+
+open Finset
 
 theorem basis_eq_prod_sub_inv_mul_nodal_div (hi : i ∈ s) :
     Lagrange.basis s v i = C (nodalWeight s v i) * (nodal s v / (X - C (v i))) := by
@@ -650,23 +698,6 @@ theorem eval_interpolate_not_at_node' (hvs : Set.InjOn v s) (hs : s.Nonempty)
   simp only [mul_div_mul_left _ _ (eval_nodal_not_at_node hx), Pi.one_apply, mul_one]
 #align lagrange.eval_interpolate_not_at_node' Lagrange.eval_interpolate_not_at_node'
 
-/-- The vanishing polynomial on a multiplicative subgroup is of the form X ^ n - 1. -/
-@[simp] theorem nodal_subgroup_eq_X_pow_card_sub_one (G : Subgroup Fˣ) [Fintype G] :
-  nodal (G : Set Fˣ).toFinset ((↑) : Fˣ → F) = X ^ (Fintype.card G) - 1 := by
-  have h : degree (1 : F[X]) < degree ((X : F[X]) ^ Fintype.card G) := by simp [Fintype.card_pos]
-  apply eq_of_degree_le_of_eval_index_eq (v := ((↑) : Fˣ → F)) (G : Set Fˣ).toFinset
-  · exact Set.injOn_of_injective Units.ext _
-  · simp
-  · rw [degree_sub_eq_left_of_degree_lt h, degree_nodal, Set.toFinset_card, degree_pow, degree_X,
-      nsmul_eq_mul, mul_one, Nat.cast_inj]
-    exact rfl
-  · rw [nodal_monic, leadingCoeff_sub_of_degree_lt h, monic_X_pow]
-  · intros i hi
-    rw [eval_nodal_at_node hi]
-    replace hi : i ∈ G := by simpa using hi
-    obtain ⟨g, rfl⟩ : ∃ g : G, g.val = i := ⟨⟨i, hi⟩, rfl⟩
-    simp [← Units.val_pow_eq_pow_val, ← Subgroup.coe_pow G]
-
-end Nodal
+end LagrangeInterpolant
 
 end Lagrange

--- a/Mathlib/LinearAlgebra/Lagrange.lean
+++ b/Mathlib/LinearAlgebra/Lagrange.lean
@@ -645,7 +645,7 @@ theorem nodalWeight_ne_zero (hvs : Set.InjOn v s) (hi : i ∈ s) : nodalWeight s
 
 end NodalWeight
 
-section LagrangeInterpolant
+section LagrangeBarycentric
 
 variable {F : Type*} [Field F] {ι : Type*} [DecidableEq ι]
 variable {s : Finset ι} {v : ι → F} (r : ι → F) {i : ι} {x : F}
@@ -698,6 +698,6 @@ theorem eval_interpolate_not_at_node' (hvs : Set.InjOn v s) (hs : s.Nonempty)
   simp only [mul_div_mul_left _ _ (eval_nodal_not_at_node hx), Pi.one_apply, mul_one]
 #align lagrange.eval_interpolate_not_at_node' Lagrange.eval_interpolate_not_at_node'
 
-end LagrangeInterpolant
+end LagrangeBarycentric
 
 end Lagrange

--- a/Mathlib/LinearAlgebra/Lagrange.lean
+++ b/Mathlib/LinearAlgebra/Lagrange.lean
@@ -139,121 +139,6 @@ namespace Lagrange
 
 open Polynomial
 
-section Nodal
-
-variable {R : Type*} [CommRing R] {ι : Type*}
-variable {s : Finset ι} {v : ι → R}
-
-open Finset Polynomial
-
-/-- `nodal s v` is the unique monic polynomial whose roots are the nodes defined by `v` and `s`.
-
-That is, the roots of `nodal s v` are exactly the image of `v` on `s`,
-with appropriate multiplicity.
-
-We can use `nodal` to define the barycentric forms of the evaluated interpolant.
--/
-
-def nodal (s : Finset ι) (v : ι → R) : R[X] :=
-  ∏ i in s, (X - C (v i))
-#align lagrange.nodal Lagrange.nodal
-
-theorem nodal_eq (s : Finset ι) (v : ι → R) : nodal s v = ∏ i in s, (X - C (v i)) :=
-  rfl
-#align lagrange.nodal_eq Lagrange.nodal_eq
-
-@[simp]
-theorem nodal_empty : nodal ∅ v = 1 := by
-  rfl
-#align lagrange.nodal_empty Lagrange.nodal_empty
-
-@[simp]
-theorem natDegree_nodal [Nontrivial R] : (nodal s v).natDegree = s.card := by
-  simp_rw [nodal, natDegree_prod_of_monic (h := fun i _ => monic_X_sub_C (v i)),
-    natDegree_X_sub_C, sum_const, smul_eq_mul, mul_one]
-
-theorem nodal_ne_zero [Nontrivial R] : nodal s v ≠ 0 := by
-rcases s.eq_empty_or_nonempty with (rfl | h)
-· exact one_ne_zero
-· apply ne_zero_of_natDegree_gt (n := 0)
-  simp only [natDegree_nodal, h.card_pos]
-
-@[simp]
-theorem degree_nodal [Nontrivial R] : (nodal s v).degree = s.card := by
-  simp_rw [degree_eq_natDegree (nodal_ne_zero), natDegree_nodal]
-#align lagrange.degree_nodal Lagrange.degree_nodal
-
-theorem nodal_monic : (nodal s v).Monic :=
-  monic_prod_of_monic s (fun i ↦ X - C (v i)) fun i _ ↦ monic_X_sub_C (v i)
-
-theorem eval_nodal {x : R} : (nodal s v).eval x = ∏ i in s, (x - v i) := by
-  simp_rw [nodal, eval_prod, eval_sub, eval_X, eval_C]
-#align lagrange.eval_nodal Lagrange.eval_nodal
-
-theorem eval_nodal_at_node {i : ι} (hi : i ∈ s) : eval (v i) (nodal s v) = 0 := by
-  rw [eval_nodal]
-  exact s.prod_eq_zero hi (sub_self (v i))
-
-#align lagrange.eval_nodal_at_node Lagrange.eval_nodal_at_node
-
-theorem eval_nodal_not_at_node [Nontrivial R] [NoZeroDivisors R] {x : R}
-(hx : ∀ i ∈ s, x ≠ v i) : eval x (nodal s v) ≠ 0 := by
-  simp_rw [nodal, eval_prod, prod_ne_zero_iff, eval_sub, eval_X, eval_C, sub_ne_zero]
-  exact hx
-#align lagrange.eval_nodal_not_at_node Lagrange.eval_nodal_not_at_node
-
-theorem nodal_eq_mul_nodal_erase [DecidableEq ι] {i : ι} (hi : i ∈ s) :
-    nodal s v = (X - C (v i)) * nodal (s.erase i) v := by
-    simp_rw [nodal, Finset.mul_prod_erase _ (fun x => X - C (v x)) hi]
-#align lagrange.nodal_eq_mul_nodal_erase Lagrange.nodal_eq_mul_nodal_erase
-
-theorem X_sub_C_dvd_nodal (v : ι → R) {i : ι} (hi : i ∈ s) : X - C (v i) ∣ nodal s v :=
-  ⟨_, by classical exact nodal_eq_mul_nodal_erase hi⟩
-set_option linter.uppercaseLean3 false in
-#align lagrange.X_sub_C_dvd_nodal Lagrange.X_sub_C_dvd_nodal
-
-theorem nodal_insert_eq_nodal [DecidableEq ι] {i : ι} (hi : i ∉ s) :
-nodal (insert i s) v = (X - C (v i)) * nodal s v := by
-  simp_rw [nodal, prod_insert hi]
-#align lagrange.nodal_insert_eq_nodal Lagrange.nodal_insert_eq_nodal
-
-theorem derivative_nodal [DecidableEq ι] :
-derivative (nodal s v) = ∑ i in s, nodal (s.erase i) v := by
-  refine' s.induction_on _ fun i t hit IH => _
-  · rw [nodal_empty, derivative_one, sum_empty]
-  · rw [nodal_insert_eq_nodal hit, derivative_mul, IH, derivative_sub, derivative_X, derivative_C,
-      sub_zero, one_mul, sum_insert hit, mul_sum, erase_insert hit, add_right_inj]
-    refine' sum_congr rfl fun j hjt => _
-    rw [t.erase_insert_of_ne (ne_of_mem_of_not_mem hjt hit).symm,
-      nodal_insert_eq_nodal (mem_of_mem_erase.mt hit)]
-#align lagrange.derivative_nodal Lagrange.derivative_nodal
-
-theorem eval_nodal_derivative_eval_node_eq [DecidableEq ι] {i : ι} (hi : i ∈ s) :
-    eval (v i) (derivative (nodal s v)) = eval (v i) (nodal (s.erase i) v) := by
-  rw [derivative_nodal, eval_finset_sum, ← add_sum_erase _ _ hi, add_right_eq_self]
-  exact sum_eq_zero fun j hj => (eval_nodal_at_node (mem_erase.mpr ⟨(mem_erase.mp hj).1.symm, hi⟩))
-#align lagrange.eval_nodal_derivative_eval_node_eq Lagrange.eval_nodal_derivative_eval_node_eq
-
-/-- The vanishing polynomial on a multiplicative subgroup is of the form X ^ n - 1. -/
-@[simp] theorem nodal_subgroup_eq_X_pow_card_sub_one [IsDomain R]
-  (G : Subgroup Rˣ) [Fintype G] :
-  nodal (G : Set Rˣ).toFinset ((↑) : Rˣ → R) = X ^ (Fintype.card G) - 1 := by
-  have h : degree (1 : R[X]) < degree ((X : R[X]) ^ Fintype.card G) := by simp [Fintype.card_pos]
-  apply eq_of_degree_le_of_eval_index_eq (v := ((↑) : Rˣ → R)) (G : Set Rˣ).toFinset
-  · exact Set.injOn_of_injective Units.ext _
-  · simp
-  · rw [degree_sub_eq_left_of_degree_lt h, degree_nodal, Set.toFinset_card, degree_pow, degree_X,
-      nsmul_eq_mul, mul_one, Nat.cast_inj]
-    exact rfl
-  · rw [nodal_monic, leadingCoeff_sub_of_degree_lt h, monic_X_pow]
-  · intros i hi
-    rw [eval_nodal_at_node hi]
-    replace hi : i ∈ G := by simpa using hi
-    obtain ⟨g, rfl⟩ : ∃ g : G, g.val = i := ⟨⟨i, hi⟩, rfl⟩
-    simp [← Units.val_pow_eq_pow_val, ← Subgroup.coe_pow G]
-
-end Nodal
-
 section BasisDivisor
 variable {F : Type*} [Field F]
 variable {x y : F}
@@ -607,6 +492,121 @@ theorem interpolate_eq_add_interpolate_erase (hvs : Set.InjOn v s) (hi : i ∈ s
 #align lagrange.interpolate_eq_add_interpolate_erase Lagrange.interpolate_eq_add_interpolate_erase
 
 end Interpolate
+
+section Nodal
+
+variable {R : Type*} [CommRing R] {ι : Type*}
+variable {s : Finset ι} {v : ι → R}
+
+open Finset Polynomial
+
+/-- `nodal s v` is the unique monic polynomial whose roots are the nodes defined by `v` and `s`.
+
+That is, the roots of `nodal s v` are exactly the image of `v` on `s`,
+with appropriate multiplicity.
+
+We can use `nodal` to define the barycentric forms of the evaluated interpolant.
+-/
+
+def nodal (s : Finset ι) (v : ι → R) : R[X] :=
+  ∏ i in s, (X - C (v i))
+#align lagrange.nodal Lagrange.nodal
+
+theorem nodal_eq (s : Finset ι) (v : ι → R) : nodal s v = ∏ i in s, (X - C (v i)) :=
+  rfl
+#align lagrange.nodal_eq Lagrange.nodal_eq
+
+@[simp]
+theorem nodal_empty : nodal ∅ v = 1 := by
+  rfl
+#align lagrange.nodal_empty Lagrange.nodal_empty
+
+@[simp]
+theorem natDegree_nodal [Nontrivial R] : (nodal s v).natDegree = s.card := by
+  simp_rw [nodal, natDegree_prod_of_monic (h := fun i _ => monic_X_sub_C (v i)),
+    natDegree_X_sub_C, sum_const, smul_eq_mul, mul_one]
+
+theorem nodal_ne_zero [Nontrivial R] : nodal s v ≠ 0 := by
+rcases s.eq_empty_or_nonempty with (rfl | h)
+· exact one_ne_zero
+· apply ne_zero_of_natDegree_gt (n := 0)
+  simp only [natDegree_nodal, h.card_pos]
+
+@[simp]
+theorem degree_nodal [Nontrivial R] : (nodal s v).degree = s.card := by
+  simp_rw [degree_eq_natDegree (nodal_ne_zero), natDegree_nodal]
+#align lagrange.degree_nodal Lagrange.degree_nodal
+
+theorem nodal_monic : (nodal s v).Monic :=
+  monic_prod_of_monic s (fun i ↦ X - C (v i)) fun i _ ↦ monic_X_sub_C (v i)
+
+theorem eval_nodal {x : R} : (nodal s v).eval x = ∏ i in s, (x - v i) := by
+  simp_rw [nodal, eval_prod, eval_sub, eval_X, eval_C]
+#align lagrange.eval_nodal Lagrange.eval_nodal
+
+theorem eval_nodal_at_node {i : ι} (hi : i ∈ s) : eval (v i) (nodal s v) = 0 := by
+  rw [eval_nodal]
+  exact s.prod_eq_zero hi (sub_self (v i))
+
+#align lagrange.eval_nodal_at_node Lagrange.eval_nodal_at_node
+
+theorem eval_nodal_not_at_node [Nontrivial R] [NoZeroDivisors R] {x : R}
+(hx : ∀ i ∈ s, x ≠ v i) : eval x (nodal s v) ≠ 0 := by
+  simp_rw [nodal, eval_prod, prod_ne_zero_iff, eval_sub, eval_X, eval_C, sub_ne_zero]
+  exact hx
+#align lagrange.eval_nodal_not_at_node Lagrange.eval_nodal_not_at_node
+
+theorem nodal_eq_mul_nodal_erase [DecidableEq ι] {i : ι} (hi : i ∈ s) :
+    nodal s v = (X - C (v i)) * nodal (s.erase i) v := by
+    simp_rw [nodal, Finset.mul_prod_erase _ (fun x => X - C (v x)) hi]
+#align lagrange.nodal_eq_mul_nodal_erase Lagrange.nodal_eq_mul_nodal_erase
+
+theorem X_sub_C_dvd_nodal (v : ι → R) {i : ι} (hi : i ∈ s) : X - C (v i) ∣ nodal s v :=
+  ⟨_, by classical exact nodal_eq_mul_nodal_erase hi⟩
+set_option linter.uppercaseLean3 false in
+#align lagrange.X_sub_C_dvd_nodal Lagrange.X_sub_C_dvd_nodal
+
+theorem nodal_insert_eq_nodal [DecidableEq ι] {i : ι} (hi : i ∉ s) :
+nodal (insert i s) v = (X - C (v i)) * nodal s v := by
+  simp_rw [nodal, prod_insert hi]
+#align lagrange.nodal_insert_eq_nodal Lagrange.nodal_insert_eq_nodal
+
+theorem derivative_nodal [DecidableEq ι] :
+derivative (nodal s v) = ∑ i in s, nodal (s.erase i) v := by
+  refine' s.induction_on _ fun i t hit IH => _
+  · rw [nodal_empty, derivative_one, sum_empty]
+  · rw [nodal_insert_eq_nodal hit, derivative_mul, IH, derivative_sub, derivative_X, derivative_C,
+      sub_zero, one_mul, sum_insert hit, mul_sum, erase_insert hit, add_right_inj]
+    refine' sum_congr rfl fun j hjt => _
+    rw [t.erase_insert_of_ne (ne_of_mem_of_not_mem hjt hit).symm,
+      nodal_insert_eq_nodal (mem_of_mem_erase.mt hit)]
+#align lagrange.derivative_nodal Lagrange.derivative_nodal
+
+theorem eval_nodal_derivative_eval_node_eq [DecidableEq ι] {i : ι} (hi : i ∈ s) :
+    eval (v i) (derivative (nodal s v)) = eval (v i) (nodal (s.erase i) v) := by
+  rw [derivative_nodal, eval_finset_sum, ← add_sum_erase _ _ hi, add_right_eq_self]
+  exact sum_eq_zero fun j hj => (eval_nodal_at_node (mem_erase.mpr ⟨(mem_erase.mp hj).1.symm, hi⟩))
+#align lagrange.eval_nodal_derivative_eval_node_eq Lagrange.eval_nodal_derivative_eval_node_eq
+
+/-- The vanishing polynomial on a multiplicative subgroup is of the form X ^ n - 1. -/
+@[simp] theorem nodal_subgroup_eq_X_pow_card_sub_one [IsDomain R]
+  (G : Subgroup Rˣ) [Fintype G] :
+  nodal (G : Set Rˣ).toFinset ((↑) : Rˣ → R) = X ^ (Fintype.card G) - 1 := by
+  have h : degree (1 : R[X]) < degree ((X : R[X]) ^ Fintype.card G) := by simp [Fintype.card_pos]
+  apply eq_of_degree_le_of_eval_index_eq (v := ((↑) : Rˣ → R)) (G : Set Rˣ).toFinset
+  · exact Set.injOn_of_injective Units.ext _
+  · simp
+  · rw [degree_sub_eq_left_of_degree_lt h, degree_nodal, Set.toFinset_card, degree_pow, degree_X,
+      nsmul_eq_mul, mul_one, Nat.cast_inj]
+    exact rfl
+  · rw [nodal_monic, leadingCoeff_sub_of_degree_lt h, monic_X_pow]
+  · intros i hi
+    rw [eval_nodal_at_node hi]
+    replace hi : i ∈ G := by simpa using hi
+    obtain ⟨g, rfl⟩ : ∃ g : G, g.val = i := ⟨⟨i, hi⟩, rfl⟩
+    simp [← Units.val_pow_eq_pow_val, ← Subgroup.coe_pow G]
+
+end Nodal
 
 section NodalWeight
 


### PR DESCRIPTION
Generalize some key definitions in the definition of Lagrange interpolation.

In particular, the definition of the nodal polynomial does not need to be over a field. 

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
