### PR TITLE
[Merged by Bors] - feat: Elements less than some value of a sorted tuple are at the beginning of the tuple.

### DIFF
--- a/Mathlib/Data/Fin/Tuple/Sort.lean
+++ b/Mathlib/Data/Fin/Tuple/Sort.lean
@@ -8,7 +8,6 @@ import Mathlib.Data.List.FinRange
 import Mathlib.Data.Prod.Lex
 import Mathlib.GroupTheory.Perm.Basic
 import Mathlib.Data.Fin.Interval
-import Mathlib.Tactic.FinCases
 
 #align_import data.fin.tuple.sort from "leanprover-community/mathlib"@"8631e2d5ea77f6c13054d9151d82b83069680cb1"
 
@@ -110,15 +109,6 @@ theorem monotone_sort (f : Fin n → α) : Monotone (f ∘ sort f) := by
 #align tuple.monotone_sort Tuple.monotone_sort
 
 end Tuple
-
-theorem Fintype.card_fin_lt_of_le {m n : ℕ} (h : m ≤ n) :
-    Fintype.card {i : Fin n // i < m} = m := by
-  conv_rhs => rw [← Fintype.card_fin m]
-  apply Fintype.card_congr
-  exact { toFun := fun ⟨⟨i, _⟩, hi⟩ ↦ ⟨i, hi⟩
-          invFun := fun ⟨i, hi⟩ ↦ ⟨⟨i, lt_of_lt_of_le hi h⟩, hi⟩
-          left_inv := fun i ↦ rfl
-          right_inv := fun i ↦ rfl }
 
 namespace Tuple
 

--- a/Mathlib/Data/Fin/Tuple/Sort.lean
+++ b/Mathlib/Data/Fin/Tuple/Sort.lean
@@ -148,33 +148,17 @@ lemma Fintype.card_fin_lt_nat (m g : ℕ) (h : g ≤ m) : Fintype.card {i : Fin 
     fun x => ⟨⟨x, (lt_of_lt_of_le (Fin.is_lt x) h)⟩, x.prop⟩,
     fun x => by simp, fun x => by simp⟩
 
-theorem sort_ge_at_end_of_monotone {α} [LinearOrder α] (m r: ℕ)(f : Fin m → α) (a : α)
+theorem sort_lt_at_start_of_monotone' {α} [LinearOrder α] (m : ℕ)(f : Fin m → α) (a : α)
     (h_sorted : Monotone f)
     (j : Fin m) :
     f j ≤ a → (j < Fintype.card {i // f i ≤ a}) := by
-  -- by_cases hm : m = 0
-  -- · exfalso
-  --   apply (ne_of_lt (Fin.size_pos j)) hm.symm
-  -- by_cases hf : Fintype.card {i // f i ≤ a} = 0
-  -- · intro h
-  --   exfalso
-  --   have : Nonempty {i // f i ≤ a} := by apply Nonempty.intro ⟨j, h⟩
-  --   refine' (ne_of_lt (Fintype.card_pos_iff.2 this)) hf.symm
-  -- by_cases hfm : Fintype.card {i // f i ≤ a} = m
-  -- · contrapose!
-  --   rw [hfm]
-  --   intro h
-  --   exfalso
-  --   refine' (not_lt.2 h) (Fin.is_lt j)
-
-  -- have hm : 1 ≤ m := Nat.pos_of_ne_zero hm
-  -- have hf : 1 ≤ Fintype.card {i // f i ≤ a} := Nat.pos_of_ne_zero hf
   intro h
   by_contra' hc
-  have he := Fintype.card_eq.2 (Nonempty.intro (Equiv.sumCompl (
-      fun x : {i // f i ≤ a} => (x < (Fintype.card {i // f i ≤ a})))))
   let p := fun x : Fin m => f x ≤ a
   let q := fun x : Fin m => (x < (Fintype.card {i // f i ≤ a}))
+
+  have he := Fintype.card_eq.2 $ Nonempty.intro $ Equiv.sumCompl
+    $ fun x : {i // f i ≤ a} => (x < (Fintype.card {i // f i ≤ a}))
   have h4 : Fintype.card {j : {x : Fin m // p x} // q j} = Fintype.card {j // q j} := by
     exact (Fintype.card_eq.2 (Nonempty.intro (@Equiv.subtypeSubtypeEquivSubtype _ p q
       (by apply sort_lt_at_start_of_monotone m f a h_sorted) ) ) )
@@ -184,6 +168,12 @@ theorem sort_ge_at_end_of_monotone {α} [LinearOrder α] (m r: ℕ)(f : Fin m �
   apply (ne_of_lt this) he.symm
   conv_rhs => rw [← Fintype.card_fin m]
   exact Fintype.card_subtype_le _
+
+theorem sort_lt_at_start_of_monotone_iff {α} [LinearOrder α] (m : ℕ) (f : Fin m → α) (a : α)
+    (h_sorted : Monotone f)
+    (j : Fin m) :
+    (j < Fintype.card {i // f i ≤ a})  ↔ f j ≤ a :=
+  ⟨sort_lt_at_start_of_monotone m f a h_sorted j, sort_lt_at_start_of_monotone' _ _ _ h_sorted _⟩
 
 
 end Tuple

--- a/Mathlib/Data/Fin/Tuple/Sort.lean
+++ b/Mathlib/Data/Fin/Tuple/Sort.lean
@@ -121,10 +121,10 @@ theorem sort_lt_at_start_of_monotone {α} [LinearOrder α] (m : ℕ) (f : Fin m 
   exact fun hij => (h.trans_le <| h_sorted <| le_of_not_lt hij).not_le
 /- Proofs by Ruben Van de Velde, Eric {Rodriguez and Wieser} -/
 
-def Equiv.subtypeSubtype_comm  {α : Type} (p q : α → Prop) :
-    (Subtype fun x => (p x) ∧ (q x)) ≃ (Subtype fun x => (q x) ∧ (p x)) := by
-  simp_rw [and_comm]
-  apply Equiv.refl
+-- def Equiv.subtypeSubtype_comm  {α : Type} (p q : α → Prop) :
+--     (Subtype fun x => (p x) ∧ (q x)) ≃ (Subtype fun x => (q x) ∧ (p x)) := by
+--   simp_rw [and_comm]
+--   apply Equiv.refl
 
 lemma Fintype.card_eq_subtypeSubtype_comm {α : Type} [Fintype α] (p q : α → Prop)
     [DecidablePred p] [DecidablePred q] : Fintype.card (Subtype fun x => (p x) ∧ (q x)) =

--- a/Mathlib/Data/Fin/Tuple/Sort.lean
+++ b/Mathlib/Data/Fin/Tuple/Sort.lean
@@ -121,11 +121,6 @@ theorem sort_lt_at_start_of_monotone {α} [LinearOrder α] (m : ℕ) (f : Fin m 
   exact fun hij => (h.trans_le <| h_sorted <| le_of_not_lt hij).not_le
 /- Proofs by Ruben Van de Velde, Eric {Rodriguez and Wieser} -/
 
--- def Equiv.subtypeSubtype_comm  {α : Type} (p q : α → Prop) :
---     (Subtype fun x => (p x) ∧ (q x)) ≃ (Subtype fun x => (q x) ∧ (p x)) := by
---   simp_rw [and_comm]
---   apply Equiv.refl
-
 lemma Fintype.card_eq_subtypeSubtype_comm {α : Type} [Fintype α] (p q : α → Prop)
     [DecidablePred p] [DecidablePred q] : Fintype.card (Subtype fun x => (p x) ∧ (q x)) =
       Fintype.card (Subtype fun x => (q x) ∧ (p x)) := by
@@ -154,17 +149,16 @@ theorem sort_lt_at_start_of_monotone' {α} [LinearOrder α] (m : ℕ)(f : Fin m 
   by_contra' hc
   let p := fun x : Fin m => f x ≤ a
   let q := fun x : Fin m => (x < (Fintype.card {i // f i ≤ a}))
+  let q' := fun x : {i // f i ≤ a} => q x
 
-  have he := Fintype.card_congr $ Equiv.sumCompl $
-    fun x : {i // f i ≤ a} => (x < (Fintype.card {i // f i ≤ a}))
+  have he := Fintype.card_congr $ Equiv.sumCompl $ q'
+  have h4 := (Fintype.card_congr (@Equiv.subtypeSubtypeEquivSubtype _ p q
+    (sort_lt_at_start_of_monotone m f a h_sorted _)))
+  have hw : 0 < Fintype.card {j : {x : Fin m // p x} // ¬q' j} :=
+    Fintype.card_pos_iff.2 (Nonempty.intro ⟨⟨j, h⟩, not_lt.2 hc⟩)
 
-  have h4 : Fintype.card {j : {x : Fin m // p x} // q j} = Fintype.card {j // q j} := by
-    exact (Fintype.card_congr (@Equiv.subtypeSubtypeEquivSubtype _ p q
-      (by apply sort_lt_at_start_of_monotone m f a h_sorted) ) )
   rw [Fintype.card_sum, h4, Fintype.card_fin_lt_nat, add_right_eq_self] at he
-  have : 0 < Fintype.card {j : {x : Fin m // p x} // ¬q j} := by
-    apply Fintype.card_pos_iff.2 (Nonempty.intro ⟨⟨j, h⟩, not_lt.2 hc⟩)
-  apply (ne_of_lt this) he.symm
+  apply (ne_of_lt hw) he.symm
   conv_rhs => rw [← Fintype.card_fin m]
   exact Fintype.card_subtype_le _
 

--- a/Mathlib/Data/Fin/Tuple/Sort.lean
+++ b/Mathlib/Data/Fin/Tuple/Sort.lean
@@ -143,7 +143,7 @@ theorem lt_card_le_iff_apply_le_of_monotone {α} [LinearOrder α] (m : ℕ) (f :
     simp_rw [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_Iio]
     exact fun hij => (h.trans_le <| h_sorted <| le_of_not_lt hij).not_le
 
-theorem lt_card_ge_iff_apply_ge_of_monotone {α} [LinearOrder α] (m : ℕ) (f : Fin m → α) (a : α)
+theorem lt_card_ge_iff_apply_ge_of_antitone {α} [LinearOrder α] (m : ℕ) (f : Fin m → α) (a : α)
     (h_sorted : Antitone f)
     (j : Fin m) :
     (j < Fintype.card {i // a ≤ f i})  ↔ a ≤ f j :=

--- a/Mathlib/Data/Fin/Tuple/Sort.lean
+++ b/Mathlib/Data/Fin/Tuple/Sort.lean
@@ -109,7 +109,8 @@ theorem monotone_sort (f : Fin n → α) : Monotone (f ∘ sort f) := by
   exact (monotone_proj f).comp (graphEquiv₂ f).monotone
 #align tuple.monotone_sort Tuple.monotone_sort
 
-/-- All the elements `· ≤ a` appear the start of a sorted tuple -/
+/-- A sorted tuple with `m` elements and exactly `Fintype.card {i // f i ≤ a}` less than a has the
+elements at the start `≤ a` -/
 theorem sort_lt_at_start_of_monotone {α} [LinearOrder α] (m : ℕ) (f : Fin m → α) (a : α)
     (h_sorted : Monotone f)
     (j : Fin m) (h : j < Fintype.card {i // f i ≤ a}) :
@@ -140,6 +141,8 @@ lemma Fintype.card_fin_lt_nat (m g : ℕ) (h : g ≤ m) : Fintype.card {i : Fin 
   exact ⟨ fun x => ⟨x, x.prop⟩, fun x => ⟨⟨x, (lt_of_lt_of_le (Fin.is_lt x) h)⟩, x.prop⟩,
     fun x => by simp, fun x => by simp⟩
 
+/--In sorted tuple with `m` elements and with `Fintype.card {i // f i ≤ a}` elements less than `a`,
+ all the `· ≤ a` appear the start of a sorted tuple -/
 theorem sort_lt_at_start_of_monotone' {α} [LinearOrder α] (m : ℕ)(f : Fin m → α) (a : α)
     (h_sorted : Monotone f)
     (j : Fin m) :

--- a/Mathlib/Data/Fin/Tuple/Sort.lean
+++ b/Mathlib/Data/Fin/Tuple/Sort.lean
@@ -119,7 +119,6 @@ theorem sort_lt_at_start_of_monotone {α} [LinearOrder α] (m : ℕ) (f : Fin m 
   refine Finset.card_mono (fun i => Function.mtr ?_)
   simp_rw [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_Iio]
   exact fun hij => (h.trans_le <| h_sorted <| le_of_not_lt hij).not_le
-/- Proofs by Ruben Van de Velde, Eric {Rodriguez and Wieser}, Junyan Xu -/
 
 lemma Fintype.card_eq_subtypeSubtype_comm {α : Type} [Fintype α] (p q : α → Prop)
     [DecidablePred p] [DecidablePred q] : Fintype.card (Subtype fun x => (p x) ∧ (q x)) =

--- a/Mathlib/Data/Fin/Tuple/Sort.lean
+++ b/Mathlib/Data/Fin/Tuple/Sort.lean
@@ -109,15 +109,23 @@ theorem monotone_sort (f : Fin n → α) : Monotone (f ∘ sort f) := by
   exact (monotone_proj f).comp (graphEquiv₂ f).monotone
 #align tuple.monotone_sort Tuple.monotone_sort
 
-lemma Fintype.card_fin_lt_nat (m g : ℕ) (h : g ≤ m) : Fintype.card {i : Fin m // i < g } = g := by
+end Tuple
+
+theorem Fintype.card_fin_lt_nat (m g : ℕ) (h : g ≤ m) : Fintype.card {i : Fin m // i < g } = g := by
   conv_rhs => rw [← Fintype.card_fin g]
   apply Fintype.card_congr
   exact ⟨ fun x => ⟨x, x.prop⟩, fun x => ⟨⟨x, (lt_of_lt_of_le (Fin.is_lt x) h)⟩, x.prop⟩,
     fun x => by simp, fun x => by simp⟩
 
+namespace Tuple
+
+open List
+
+variable {n : ℕ} {α : Type*}
+
 /-- A sorted tuple with `m` elements and exactly `Fintype.card {i // f i ≤ a}` less than `a`, has
 the elements at the start, and vice versa -/
-theorem lt_card_le_iff_apply_le_of_monotone {α} [PartialOrder α] [DecidableRel (α := α) LE.le]
+theorem lt_card_le_iff_apply_le_of_monotone [PartialOrder α] [DecidableRel (α := α) LE.le]
     {m : ℕ} (f : Fin m → α) (a : α) (h_sorted : Monotone f) (j : Fin m) :
     j < Fintype.card {i // f i ≤ a} ↔ f j ≤ a := by
   suffices h1 : ∀ k : Fin m, (k < Fintype.card {i // f i ≤ a}) → f k ≤ a
@@ -144,18 +152,10 @@ theorem lt_card_le_iff_apply_le_of_monotone {α} [PartialOrder α] [DecidableRel
     apply h
     exact (h_sorted (le_of_not_lt hij)).trans hia
 
-theorem lt_card_ge_iff_apply_ge_of_antitone {α} [PartialOrder α] [DecidableRel (α := α) LE.le]
+theorem lt_card_ge_iff_apply_ge_of_antitone [PartialOrder α] [DecidableRel (α := α) LE.le]
     {m : ℕ} (f : Fin m → α) (a : α) (h_sorted : Antitone f) (j : Fin m) :
     j < Fintype.card {i // a ≤ f i} ↔ a ≤ f j :=
   lt_card_le_iff_apply_le_of_monotone _ (OrderDual.toDual a) h_sorted.dual_right j
-
-end Tuple
-
-namespace Tuple
-
-open List
-
-variable {n : ℕ} {α : Type*}
 
 /-- If two permutations of a tuple `f` are both monotone, then they are equal. -/
 theorem unique_monotone [PartialOrder α] {f : Fin n → α} {σ τ : Equiv.Perm (Fin n)}

--- a/Mathlib/Data/Fin/Tuple/Sort.lean
+++ b/Mathlib/Data/Fin/Tuple/Sort.lean
@@ -121,20 +121,6 @@ theorem sort_lt_at_start_of_monotone {α} [LinearOrder α] (m : ℕ) (f : Fin m 
   simp_rw [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_Iio]
   exact fun hij => (h.trans_le <| h_sorted <| le_of_not_lt hij).not_le
 
-lemma Fintype.card_eq_subtypeSubtype_comm {α : Type} [Fintype α] (p q : α → Prop)
-    [DecidablePred p] [DecidablePred q] : Fintype.card (Subtype fun x => (p x) ∧ (q x)) =
-      Fintype.card (Subtype fun x => (q x) ∧ (p x)) := by
-  apply Fintype.card_congr
-  exact ⟨fun x => ⟨x, ⟨x.2.2, x.2.1⟩⟩, fun x => ⟨x, ⟨x.2.2, x.2.1⟩⟩,
-    fun _ => by dsimp, fun _ => by dsimp ⟩
-
-lemma Fintype.card_inter_eq_card_and {α : Type} [Fintype α] (p q : α → Prop)
-    [DecidablePred p] [DecidablePred q] : Fintype.card {i : (Subtype fun x => (p x)) // (q i)} =
-      Fintype.card (Subtype fun x => (q x) ∧ (p x)) := by
-  rw [← Fintype.card_eq_subtypeSubtype_comm p q]
-  refine Fintype.card_congr ?_
-  exact Equiv.subtypeSubtypeEquivSubtypeInter (fun x ↦ p x) q
-
 lemma Fintype.card_fin_lt_nat (m g : ℕ) (h : g ≤ m) : Fintype.card {i : Fin m // i < g } = g := by
   conv_rhs => rw [← Fintype.card_fin g]
   apply Fintype.card_congr

--- a/Mathlib/Data/Fin/Tuple/Sort.lean
+++ b/Mathlib/Data/Fin/Tuple/Sort.lean
@@ -143,11 +143,11 @@ theorem lt_card_le_iff_apply_le_of_monotone {α} [LinearOrder α] (m : ℕ) (f :
     simp_rw [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_Iio]
     exact fun hij => (h.trans_le <| h_sorted <| le_of_not_lt hij).not_le
 
-theorem sort_ge_at_start_of_anittone_iff {α} [LinearOrder α] (m : ℕ) (f : Fin m → α) (a : α)
+theorem lt_card_ge_iff_apply_ge_of_monotone {α} [LinearOrder α] (m : ℕ) (f : Fin m → α) (a : α)
     (h_sorted : Antitone f)
     (j : Fin m) :
     (j < Fintype.card {i // a ≤ f i})  ↔ a ≤ f j :=
-  @sort_lt_at_start_of_monotone_iff (OrderDual α) _ m f a (monotone_toDual_comp_iff.1 h_sorted) j
+  @lt_card_le_iff_apply_le_of_monotone (OrderDual α) _ m f a (monotone_toDual_comp_iff.1 h_sorted) j
 
 end Tuple
 

--- a/Mathlib/Data/Fin/Tuple/Sort.lean
+++ b/Mathlib/Data/Fin/Tuple/Sort.lean
@@ -109,8 +109,8 @@ theorem monotone_sort (f : Fin n → α) : Monotone (f ∘ sort f) := by
   exact (monotone_proj f).comp (graphEquiv₂ f).monotone
 #align tuple.monotone_sort Tuple.monotone_sort
 
-/-- A sorted tuple with `m` elements and exactly `Fintype.card {i // f i ≤ a}` less than a has the
-elements at the start `≤ a` -/
+/-- A sorted tuple with `m` elements and exactly `Fintype.card {i // f i ≤ a}` less than `a` has the
+elements at the start -/
 theorem sort_lt_at_start_of_monotone {α} [LinearOrder α] (m : ℕ) (f : Fin m → α) (a : α)
     (h_sorted : Monotone f)
     (j : Fin m) (h : j < Fintype.card {i // f i ≤ a}) :

--- a/Mathlib/Data/Fin/Tuple/Sort.lean
+++ b/Mathlib/Data/Fin/Tuple/Sort.lean
@@ -170,9 +170,8 @@ theorem sort_lt_at_start_of_monotone_iff {α} [LinearOrder α] (m : ℕ) (f : Fi
 theorem sort_ge_at_start_of_anittone_iff {α} [LinearOrder α] (m : ℕ) (f : Fin m → α) (a : α)
     (h_sorted : Antitone f)
     (j : Fin m) :
-    (j < Fintype.card {i // a ≤ f i})  ↔ a ≤ f j := by
-  haveI h1 := @sort_lt_at_start_of_monotone_iff (OrderDual α) _ m f a
-  exact h1 (fun a b hab => h_sorted hab) j
+    (j < Fintype.card {i // a ≤ f i})  ↔ a ≤ f j :=
+  @sort_lt_at_start_of_monotone_iff (OrderDual α) _ m f a (monotone_toDual_comp_iff.1 h_sorted) j
 
 theorem sort_ge_at_start_of_antitone {α} [LinearOrder α] (m : ℕ) (f : Fin m → α) (a : α)
     (h_sorted : Antitone f)

--- a/Mathlib/Data/Fin/Tuple/Sort.lean
+++ b/Mathlib/Data/Fin/Tuple/Sort.lean
@@ -117,7 +117,8 @@ lemma Fintype.card_fin_lt_nat (m g : ℕ) (h : g ≤ m) : Fintype.card {i : Fin 
 
 /-- A sorted tuple with `m` elements and exactly `Fintype.card {i // f i ≤ a}` less than `a`, has
 the elements at the start, and vice versa -/
-theorem lt_card_le_iff_apply_le_of_monotone {α} [LinearOrder α] (m : ℕ) (f : Fin m → α) (a : α)
+theorem lt_card_le_iff_apply_le_of_monotone {α} [PartialOrder α] [DecidableRel (α := α) LE.le]
+    (m : ℕ) (f : Fin m → α) (a : α)
     (h_sorted : Monotone f)
     (j : Fin m) :
     (j < Fintype.card {i // f i ≤ a})  ↔ f j ≤ a := by
@@ -141,13 +142,17 @@ theorem lt_card_le_iff_apply_le_of_monotone {α} [LinearOrder α] (m : ℕ) (f :
     rw [← Fin.card_Iio, Fintype.card_subtype]
     refine Finset.card_mono (fun i => Function.mtr ?_)
     simp_rw [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_Iio]
-    exact fun hij => (h.trans_le <| h_sorted <| le_of_not_lt hij).not_le
+    intro hij hia
+    apply h
+    exact (h_sorted (le_of_not_lt hij)).trans hia
 
-theorem lt_card_ge_iff_apply_ge_of_antitone {α} [LinearOrder α] (m : ℕ) (f : Fin m → α) (a : α)
+theorem lt_card_ge_iff_apply_ge_of_antitone {α} [PartialOrder α] [DecidableRel (α := α) LE.le]
+    (m : ℕ) (f : Fin m → α) (a : α)
     (h_sorted : Antitone f)
     (j : Fin m) :
     (j < Fintype.card {i // a ≤ f i})  ↔ a ≤ f j :=
-  @lt_card_le_iff_apply_le_of_monotone (OrderDual α) _ m f a (monotone_toDual_comp_iff.1 h_sorted) j
+  lt_card_le_iff_apply_le_of_monotone m (OrderDual.toDual ∘ f)
+    (OrderDual.toDual a) h_sorted.dual_right j
 
 end Tuple
 

--- a/Mathlib/Data/Fin/Tuple/Sort.lean
+++ b/Mathlib/Data/Fin/Tuple/Sort.lean
@@ -117,7 +117,7 @@ lemma Fintype.card_fin_lt_nat (m g : ℕ) (h : g ≤ m) : Fintype.card {i : Fin 
 
 /-- A sorted tuple with `m` elements and exactly `Fintype.card {i // f i ≤ a}` less than `a`, has
 the elements at the start, and vice versa -/
-theorem sort_lt_at_start_of_monotone_iff {α} [LinearOrder α] (m : ℕ) (f : Fin m → α) (a : α)
+theorem lt_card_le_iff_apply_le_of_monotone {α} [LinearOrder α] (m : ℕ) (f : Fin m → α) (a : α)
     (h_sorted : Monotone f)
     (j : Fin m) :
     (j < Fintype.card {i // f i ≤ a})  ↔ f j ≤ a := by

--- a/Mathlib/Data/Fin/Tuple/Sort.lean
+++ b/Mathlib/Data/Fin/Tuple/Sort.lean
@@ -119,7 +119,7 @@ theorem sort_lt_at_start_of_monotone {α} [LinearOrder α] (m : ℕ) (f : Fin m 
   refine Finset.card_mono (fun i => Function.mtr ?_)
   simp_rw [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_Iio]
   exact fun hij => (h.trans_le <| h_sorted <| le_of_not_lt hij).not_le
-/- Proofs by Ruben Van de Velde, Eric {Rodriguez and Wieser} -/
+/- Proofs by Ruben Van de Velde, Eric {Rodriguez and Wieser}, Junyan Xu -/
 
 lemma Fintype.card_eq_subtypeSubtype_comm {α : Type} [Fintype α] (p q : α → Prop)
     [DecidablePred p] [DecidablePred q] : Fintype.card (Subtype fun x => (p x) ∧ (q x)) =

--- a/Mathlib/Data/Fin/Tuple/Sort.lean
+++ b/Mathlib/Data/Fin/Tuple/Sort.lean
@@ -168,6 +168,43 @@ theorem sort_lt_at_start_of_monotone_iff {α} [LinearOrder α] (m : ℕ) (f : Fi
     (j < Fintype.card {i // f i ≤ a})  ↔ f j ≤ a :=
   ⟨sort_lt_at_start_of_monotone m f a h_sorted j, sort_lt_at_start_of_monotone' _ _ _ h_sorted _⟩
 
+theorem sort_ge_at_start_of_antitone {α} [LinearOrder α] (m : ℕ) (f : Fin m → α) (a : α)
+    (h_sorted : Antitone f)
+    (j : Fin m) :
+    (j < Fintype.card {i // a ≤ f i})  → a ≤ f j := by
+  · contrapose!
+    intro h
+    rw [← Fin.card_Iio, Fintype.card_subtype]
+    refine Finset.card_mono (fun i => Function.mtr ?_)
+    simp_rw [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_Iio, not_lt, not_le]
+    exact fun hij => lt_of_le_of_lt (h_sorted hij) h
+
+theorem sort_ge_at_start_of_antitone' {α} [LinearOrder α] (m : ℕ) (f : Fin m → α) (a : α)
+    (h_sorted : Antitone f)
+    (j : Fin m) :
+    a ≤ f j → (j < Fintype.card {i // a ≤ f i})  := by
+  intro h
+  by_contra' hc
+  let p := fun x : Fin m => a ≤ f x
+  let q := fun x : Fin m => (x < (Fintype.card {i // a ≤ f i}))
+  let q' := fun x : {i // a ≤ f i} => q x
+
+  have he := Fintype.card_congr $ Equiv.sumCompl $ q'
+  have h4 := (Fintype.card_congr (@Equiv.subtypeSubtypeEquivSubtype _ p q
+    (sort_ge_at_start_of_antitone m f a h_sorted _)))
+  have hw : 0 < Fintype.card {j : {x : Fin m // p x} // ¬q' j} := by
+    apply Fintype.card_pos_iff.2 (Nonempty.intro ⟨⟨j, h⟩, not_lt.2 hc⟩)
+  rw [Fintype.card_sum, h4, Fintype.card_fin_lt_nat, add_right_eq_self] at he
+  apply (ne_of_lt hw) he.symm
+  conv_rhs => rw [← Fintype.card_fin m]
+  exact Fintype.card_subtype_le _
+
+theorem sort_ge_at_start_of_anittone_iff {α} [LinearOrder α] (m : ℕ) (f : Fin m → α) (a : α)
+    (h_sorted : Antitone f)
+    (j : Fin m) :
+    (j < Fintype.card {i // a ≤ f i})  ↔ a ≤ f j :=
+  ⟨sort_ge_at_start_of_antitone m f a h_sorted j, sort_ge_at_start_of_antitone' _ _ _ h_sorted _⟩
+
 
 end Tuple
 

--- a/Mathlib/Data/Fin/Tuple/Sort.lean
+++ b/Mathlib/Data/Fin/Tuple/Sort.lean
@@ -131,7 +131,7 @@ lemma Fintype.card_inter_eq_card_and {α : Type} [Fintype α] (p q : α → Prop
     [DecidablePred p] [DecidablePred q] : Fintype.card {i : (Subtype fun x => (p x)) // (q i)} =
       Fintype.card (Subtype fun x => (q x) ∧ (p x)) := by
   rw [← Fintype.card_eq_subtypeSubtype_comm p q]
-  refine' Fintype.card_eq.2 (Nonempty.intro ?_)
+  refine Fintype.card_congr ?_
   exact Equiv.subtypeSubtypeEquivSubtypeInter (fun x ↦ p x) q
 
 lemma Fintype.card_fin_lt_nat (m g : ℕ) (h : g ≤ m) : Fintype.card {i : Fin m // i < g } = g := by

--- a/Mathlib/Data/Fin/Tuple/Sort.lean
+++ b/Mathlib/Data/Fin/Tuple/Sort.lean
@@ -124,9 +124,9 @@ theorem sort_lt_at_start_of_monotone {α} [LinearOrder α] (m : ℕ) (f : Fin m 
 lemma Fintype.card_eq_subtypeSubtype_comm {α : Type} [Fintype α] (p q : α → Prop)
     [DecidablePred p] [DecidablePred q] : Fintype.card (Subtype fun x => (p x) ∧ (q x)) =
       Fintype.card (Subtype fun x => (q x) ∧ (p x)) := by
-  refine' Fintype.card_eq.2 (Nonempty.intro ?_)
-  simp_rw [and_comm]
-  apply Equiv.refl
+  apply Fintype.card_congr
+  exact ⟨fun x => ⟨x, ⟨x.2.2, x.2.1⟩⟩, fun x => ⟨x, ⟨x.2.2, x.2.1⟩⟩,
+    fun _ => by dsimp, fun _ => by dsimp ⟩
 
 lemma Fintype.card_inter_eq_card_and {α : Type} [Fintype α] (p q : α → Prop)
     [DecidablePred p] [DecidablePred q] : Fintype.card {i : (Subtype fun x => (p x)) // (q i)} =

--- a/Mathlib/Data/Fin/Tuple/Sort.lean
+++ b/Mathlib/Data/Fin/Tuple/Sort.lean
@@ -7,6 +7,7 @@ import Mathlib.Data.Finset.Sort
 import Mathlib.Data.List.FinRange
 import Mathlib.Data.Prod.Lex
 import Mathlib.GroupTheory.Perm.Basic
+import Mathlib.Data.Fin.Interval
 
 #align_import data.fin.tuple.sort from "leanprover-community/mathlib"@"8631e2d5ea77f6c13054d9151d82b83069680cb1"
 
@@ -106,6 +107,20 @@ theorem monotone_sort (f : Fin n → α) : Monotone (f ∘ sort f) := by
   rw [self_comp_sort]
   exact (monotone_proj f).comp (graphEquiv₂ f).monotone
 #align tuple.monotone_sort Tuple.monotone_sort
+
+/-- All the elements `· ≤ a` appear the start of a sorted tuple -/
+theorem sort_lt_at_start_of_monotone {α} [LinearOrder α] (m : ℕ) (f : Fin m → α) (a : α)
+    (h_sorted : Monotone f)
+    (j : Fin m) (h : j < Fintype.card {i // f i ≤ a}) :
+    f j ≤ a := by
+  contrapose! h
+  have := Fintype.card_subtype_compl (¬f · ≤ a)
+  simp_rw [not_not, not_le] at this
+  rw [this, Fintype.card_fin, tsub_le_iff_tsub_le, Fintype.card_subtype]
+  refine le_trans (by simp) (Finset.card_mono $ show Finset.Ici j ≤ _ from fun k hk ↦ ?_)
+  simp only [Finset.mem_Ici] at hk
+  exact Finset.mem_filter.mpr ⟨Finset.mem_univ _, h.trans_le (h_sorted hk)⟩
+/- Proofs by Ruben Van de Velde, Eric {Rodriguez and Wieser} -/
 
 end Tuple
 

--- a/Mathlib/Data/Fin/Tuple/Sort.lean
+++ b/Mathlib/Data/Fin/Tuple/Sort.lean
@@ -168,43 +168,24 @@ theorem sort_lt_at_start_of_monotone_iff {α} [LinearOrder α] (m : ℕ) (f : Fi
     (j < Fintype.card {i // f i ≤ a})  ↔ f j ≤ a :=
   ⟨sort_lt_at_start_of_monotone m f a h_sorted j, sort_lt_at_start_of_monotone' _ _ _ h_sorted _⟩
 
+theorem sort_ge_at_start_of_anittone_iff {α} [LinearOrder α] (m : ℕ) (f : Fin m → α) (a : α)
+    (h_sorted : Antitone f)
+    (j : Fin m) :
+    (j < Fintype.card {i // a ≤ f i})  ↔ a ≤ f j := by
+  haveI h1 := @sort_lt_at_start_of_monotone_iff (OrderDual α) _ m f a
+  exact h1 (fun a b hab => h_sorted hab) j
+
 theorem sort_ge_at_start_of_antitone {α} [LinearOrder α] (m : ℕ) (f : Fin m → α) (a : α)
     (h_sorted : Antitone f)
     (j : Fin m) :
-    (j < Fintype.card {i // a ≤ f i})  → a ≤ f j := by
-  · contrapose!
-    intro h
-    rw [← Fin.card_Iio, Fintype.card_subtype]
-    refine Finset.card_mono (fun i => Function.mtr ?_)
-    simp_rw [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_Iio, not_lt, not_le]
-    exact fun hij => lt_of_le_of_lt (h_sorted hij) h
+    (j < Fintype.card {i // a ≤ f i})  → a ≤ f j :=
+  (sort_ge_at_start_of_anittone_iff _ f a h_sorted j).1
 
 theorem sort_ge_at_start_of_antitone' {α} [LinearOrder α] (m : ℕ) (f : Fin m → α) (a : α)
     (h_sorted : Antitone f)
     (j : Fin m) :
-    a ≤ f j → (j < Fintype.card {i // a ≤ f i})  := by
-  intro h
-  by_contra' hc
-  let p := fun x : Fin m => a ≤ f x
-  let q := fun x : Fin m => (x < (Fintype.card {i // a ≤ f i}))
-  let q' := fun x : {i // a ≤ f i} => q x
-
-  have he := Fintype.card_congr $ Equiv.sumCompl $ q'
-  have h4 := (Fintype.card_congr (@Equiv.subtypeSubtypeEquivSubtype _ p q
-    (sort_ge_at_start_of_antitone m f a h_sorted _)))
-  have hw : 0 < Fintype.card {j : {x : Fin m // p x} // ¬q' j} := by
-    apply Fintype.card_pos_iff.2 (Nonempty.intro ⟨⟨j, h⟩, not_lt.2 hc⟩)
-  rw [Fintype.card_sum, h4, Fintype.card_fin_lt_nat, add_right_eq_self] at he
-  apply (ne_of_lt hw) he.symm
-  conv_rhs => rw [← Fintype.card_fin m]
-  exact Fintype.card_subtype_le _
-
-theorem sort_ge_at_start_of_anittone_iff {α} [LinearOrder α] (m : ℕ) (f : Fin m → α) (a : α)
-    (h_sorted : Antitone f)
-    (j : Fin m) :
-    (j < Fintype.card {i // a ≤ f i})  ↔ a ≤ f j :=
-  ⟨sort_ge_at_start_of_antitone m f a h_sorted j, sort_ge_at_start_of_antitone' _ _ _ h_sorted _⟩
-
+    a ≤ f j → (j < Fintype.card {i // a ≤ f i})  :=
+  (sort_ge_at_start_of_anittone_iff _ f a h_sorted j).2
 
 end Tuple
 

--- a/Mathlib/Data/Fin/Tuple/Sort.lean
+++ b/Mathlib/Data/Fin/Tuple/Sort.lean
@@ -118,23 +118,21 @@ lemma Fintype.card_fin_lt_nat (m g : ℕ) (h : g ≤ m) : Fintype.card {i : Fin 
 /-- A sorted tuple with `m` elements and exactly `Fintype.card {i // f i ≤ a}` less than `a`, has
 the elements at the start, and vice versa -/
 theorem lt_card_le_iff_apply_le_of_monotone {α} [PartialOrder α] [DecidableRel (α := α) LE.le]
-    (m : ℕ) (f : Fin m → α) (a : α)
-    (h_sorted : Monotone f)
-    (j : Fin m) :
-    (j < Fintype.card {i // f i ≤ a})  ↔ f j ≤ a := by
+    {m : ℕ} (f : Fin m → α) (a : α) (h_sorted : Monotone f) (j : Fin m) :
+    j < Fintype.card {i // f i ≤ a} ↔ f j ≤ a := by
   suffices h1 : ∀ k : Fin m, (k < Fintype.card {i // f i ≤ a}) → f k ≤ a
   refine ⟨h1 j, ?_⟩
   · intro h
     by_contra' hc
-    let p := fun x : Fin m => f x ≤ a
-    let q := fun x : Fin m => (x < (Fintype.card {i // f i ≤ a}))
-    let q' := fun x : {i // f i ≤ a} => q x
+    let p (x : Fin m) := f x ≤ a
+    let q (x : Fin m) := x < Fintype.card {i // f i ≤ a}
+    let q' (x : {i // f i ≤ a}) := q x
     have hw : 0 < Fintype.card {j : {x : Fin m // f x ≤ a} // ¬q' j} :=
       Fintype.card_pos_iff.2 (Nonempty.intro ⟨⟨j, h⟩, not_lt.2 hc⟩)
-    have he := Fintype.card_congr $ Equiv.sumCompl $ q'
+    have he := Fintype.card_congr <| Equiv.sumCompl <| q'
     have h4 := (Fintype.card_congr (@Equiv.subtypeSubtypeEquivSubtype _ p q (h1 _)))
     rw [Fintype.card_sum, h4, Fintype.card_fin_lt_nat, add_right_eq_self] at he
-    apply (ne_of_lt hw) he.symm
+    · exact hw.ne he.symm
     conv_rhs => rw [← Fintype.card_fin m]
     exact Fintype.card_subtype_le _
   · intro _ h
@@ -147,12 +145,9 @@ theorem lt_card_le_iff_apply_le_of_monotone {α} [PartialOrder α] [DecidableRel
     exact (h_sorted (le_of_not_lt hij)).trans hia
 
 theorem lt_card_ge_iff_apply_ge_of_antitone {α} [PartialOrder α] [DecidableRel (α := α) LE.le]
-    (m : ℕ) (f : Fin m → α) (a : α)
-    (h_sorted : Antitone f)
-    (j : Fin m) :
-    (j < Fintype.card {i // a ≤ f i})  ↔ a ≤ f j :=
-  lt_card_le_iff_apply_le_of_monotone m (OrderDual.toDual ∘ f)
-    (OrderDual.toDual a) h_sorted.dual_right j
+    {m : ℕ} (f : Fin m → α) (a : α) (h_sorted : Antitone f) (j : Fin m) :
+    j < Fintype.card {i // a ≤ f i} ↔ a ≤ f j :=
+  lt_card_le_iff_apply_le_of_monotone _ (OrderDual.toDual a) h_sorted.dual_right j
 
 end Tuple
 

--- a/Mathlib/Data/Fin/Tuple/Sort.lean
+++ b/Mathlib/Data/Fin/Tuple/Sort.lean
@@ -142,10 +142,8 @@ lemma Fintype.card_inter_eq_card_and {α : Type} [Fintype α] (p q : α → Prop
 
 lemma Fintype.card_fin_lt_nat (m g : ℕ) (h : g ≤ m) : Fintype.card {i : Fin m // i < g } = g := by
   conv_rhs => rw [← Fintype.card_fin g]
-  refine' Fintype.card_eq.2 (Nonempty.intro ?_)
-  refine ⟨
-    fun x => ⟨x, x.prop⟩,
-    fun x => ⟨⟨x, (lt_of_lt_of_le (Fin.is_lt x) h)⟩, x.prop⟩,
+  apply Fintype.card_congr
+  exact ⟨ fun x => ⟨x, x.prop⟩, fun x => ⟨⟨x, (lt_of_lt_of_le (Fin.is_lt x) h)⟩, x.prop⟩,
     fun x => by simp, fun x => by simp⟩
 
 theorem sort_lt_at_start_of_monotone' {α} [LinearOrder α] (m : ℕ)(f : Fin m → α) (a : α)
@@ -157,11 +155,12 @@ theorem sort_lt_at_start_of_monotone' {α} [LinearOrder α] (m : ℕ)(f : Fin m 
   let p := fun x : Fin m => f x ≤ a
   let q := fun x : Fin m => (x < (Fintype.card {i // f i ≤ a}))
 
-  have he := Fintype.card_eq.2 $ Nonempty.intro $ Equiv.sumCompl
-    $ fun x : {i // f i ≤ a} => (x < (Fintype.card {i // f i ≤ a}))
+  have he := Fintype.card_congr $ Equiv.sumCompl $
+    fun x : {i // f i ≤ a} => (x < (Fintype.card {i // f i ≤ a}))
+
   have h4 : Fintype.card {j : {x : Fin m // p x} // q j} = Fintype.card {j // q j} := by
-    exact (Fintype.card_eq.2 (Nonempty.intro (@Equiv.subtypeSubtypeEquivSubtype _ p q
-      (by apply sort_lt_at_start_of_monotone m f a h_sorted) ) ) )
+    exact (Fintype.card_congr (@Equiv.subtypeSubtypeEquivSubtype _ p q
+      (by apply sort_lt_at_start_of_monotone m f a h_sorted) ) )
   rw [Fintype.card_sum, h4, Fintype.card_fin_lt_nat, add_right_eq_self] at he
   have : 0 < Fintype.card {j : {x : Fin m // p x} // ¬q j} := by
     apply Fintype.card_pos_iff.2 (Nonempty.intro ⟨⟨j, h⟩, not_lt.2 hc⟩)

--- a/Mathlib/Data/Fintype/Card.lean
+++ b/Mathlib/Data/Fintype/Card.lean
@@ -299,6 +299,15 @@ theorem Fintype.card_fin (n : ℕ) : Fintype.card (Fin n) = n :=
   List.length_finRange n
 #align fintype.card_fin Fintype.card_fin
 
+theorem Fintype.card_fin_lt_of_le {m n : ℕ} (h : m ≤ n) :
+    Fintype.card {i : Fin n // i < m} = m := by
+  conv_rhs => rw [← Fintype.card_fin m]
+  apply Fintype.card_congr
+  exact { toFun := fun ⟨⟨i, _⟩, hi⟩ ↦ ⟨i, hi⟩
+          invFun := fun ⟨i, hi⟩ ↦ ⟨⟨i, lt_of_lt_of_le hi h⟩, hi⟩
+          left_inv := fun i ↦ rfl
+          right_inv := fun i ↦ rfl }
+
 @[simp]
 theorem Finset.card_fin (n : ℕ) : Finset.card (Finset.univ : Finset (Fin n)) = n := by
   rw [Finset.card_univ, Fintype.card_fin]


### PR DESCRIPTION
For a sorted (monotone) tuple containing n elements with exactly r elements less than or equal some value, all these elements are at the first r locations of the tuple.

Proofs by @Ruben-VandeVelde , @ericrbg @eric-wieser see [Zulip Thread](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F/topic/Sorted.20nonnegative.20tuple.20must.20have.20zero.20elements.20at.20start)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
