### PR TITLE
[Merged by Bors] - feat(Data/Sum/Basic): Add `LiftRel` lemmas.

### DIFF
--- a/Mathlib/Data/Sum/Basic.lean
+++ b/Mathlib/Data/Sum/Basic.lean
@@ -202,44 +202,31 @@ section LiftRel
 #align sum.lift_rel.swap Sum.LiftRel.swap
 #align sum.lift_rel_swap_iff Sum.liftRel_swap_iff
 
-variable {r : α → γ → Prop} {s : β → δ → Prop} {x : Sum α β} {y : Sum γ δ}
-    {a : α} {b : β} {c : γ} {d : δ}
-
-theorem liftRel_def : LiftRel r s x y ↔ (∃ a, x = inl a ∧ ∃ c, y = inl c ∧ r a c) ∨
-    (∃ b, x = inr b ∧ ∃ d, y = inr d ∧ s b d) := by
-    refine' ⟨(fun H ↦ _), (fun H ↦ _)⟩
-    · rcases H with (hac | hbd)
-      · exact Or.inl ⟨_, rfl, _, rfl, hac⟩
-      · exact Or.inr ⟨_, rfl, _, rfl, hbd⟩
-    · rcases H with (⟨_, rfl, _, rfl, hac⟩ | ⟨_, rfl, _, rfl, hbd⟩)
-      · exact liftRel_inl_inl.mpr hac
-      · exact liftRel_inr_inr.mpr hbd
-
-theorem isLeft_of_liftRel (h : LiftRel r s x y) : x.isLeft = y.isLeft := by
-    cases h <;> rfl
+theorem isLeft_eq_of_liftRel (h : LiftRel r s x y) : x.isLeft = y.isLeft := by
+  cases h <;> rfl
 
 theorem isRight_eq_of_liftRel (h : LiftRel r s x y) : x.isRight = y.isRight := by
-    cases h <;> rfl
+  rw [← Sum.not_isLeft, isLeft_eq_of_liftRel h, Sum.not_isLeft]
 
-theorem isLeft_of_liftRel_inl_fst (h : LiftRel r s (inl a) y) : y.isLeft :=
-    (isLeft_of_liftRel h).symm
+theorem isLeft_eq_of_liftRel_inl_fst (h : LiftRel r s (inl a) y) : y.isLeft :=
+(isLeft_eq_of_liftRel h).symm
 
-theorem isLeft_of_liftRel_inl_snd (h : LiftRel r s x (inl c)) : x.isLeft :=
-    isLeft_of_liftRel h
+theorem isLeft_eq_of_liftRel_inl_snd (h : LiftRel r s x (inl c)) : x.isLeft :=
+isLeft_eq_of_liftRel h
 
 theorem isRight_of_liftRel_inr_fst (h : LiftRel r s (inr b) y) : y.isRight :=
-    (isRight_eq_of_liftRel h).symm
+(isRight_eq_of_liftRel h).symm
 
 theorem isRight_of_liftRel_inr_snd (h : LiftRel r s x (inr d)) : x.isRight :=
-    isRight_eq_of_liftRel h
+isRight_eq_of_liftRel h
 
 variable {τ κ : Type*} {f : τ → Sum α β} {g : κ → Sum γ δ} {t : τ} {k : κ}
 
 theorem isLeft_apply_of_inl_fst (h : LiftRel r s (inl a) (g k)) : (g k).isLeft :=
-    isLeft_of_liftRel_inl_fst h
+isLeft_eq_of_liftRel_inl_fst h
 
 theorem isLeft_apply_of_inl_snd (h : LiftRel r s (f t) (inl c)) : (f t).isLeft :=
-    isLeft_of_liftRel_inl_snd h
+isLeft_eq_of_liftRel_inl_snd h
 
 theorem isRight_apply_of_inr_fst (h : LiftRel r s (inr b) (g k)) : (g k).isRight :=
     isRight_of_liftRel_inr_fst h
@@ -247,8 +234,8 @@ theorem isRight_apply_of_inr_fst (h : LiftRel r s (inr b) (g k)) : (g k).isRight
 theorem isRight_apply_of_inr_snd (h : LiftRel r s (f t) (inr d)) : (f t).isRight :=
     isRight_of_liftRel_inr_snd h
 
-theorem isLeft_apply_eq_of_LiftRel_apply (h : LiftRel r s (f t) y) :
-    (f t).isLeft = y.isLeft := isLeft_of_liftRel h
+theorem isLeft_apply_eq_of_LiftRel_apply (h : LiftRel r s (f t) y) : (f t).isLeft = y.isLeft :=
+isLeft_eq_of_liftRel h
 
 theorem isRight_apply_eq_of_LiftRel_apply (h : LiftRel r s x (g k)) :
     (g k).isRight = x.isRight := (isRight_eq_of_liftRel h).symm

--- a/Mathlib/Data/Sum/Basic.lean
+++ b/Mathlib/Data/Sum/Basic.lean
@@ -202,68 +202,73 @@ section LiftRel
 #align sum.lift_rel.swap Sum.LiftRel.swap
 #align sum.lift_rel_swap_iff Sum.liftRel_swap_iff
 
+mk_iff_of_inductive_prop Sum.LiftRel Sum.liftRel_iff
+
+variable {r : α → γ → Prop} {s : β → δ → Prop} {x : Sum α β} {y : Sum γ δ}
+  {a : α} {b : β} {c : γ} {d : δ}
+
 theorem isLeft_eq_of_liftRel (h : LiftRel r s x y) : x.isLeft = y.isLeft := by
   cases h <;> rfl
 
 theorem isRight_eq_of_liftRel (h : LiftRel r s x y) : x.isRight = y.isRight := by
-  rw [← Sum.not_isLeft, isLeft_eq_of_liftRel h, Sum.not_isLeft]
+  cases h <;> rfl
 
 theorem isLeft_eq_of_liftRel_inl_fst (h : LiftRel r s (inl a) y) : y.isLeft :=
-(isLeft_eq_of_liftRel h).symm
+  (isLeft_eq_of_liftRel h).symm
 
 theorem isLeft_eq_of_liftRel_inl_snd (h : LiftRel r s x (inl c)) : x.isLeft :=
-isLeft_eq_of_liftRel h
+  isLeft_eq_of_liftRel h
 
 theorem isRight_of_liftRel_inr_fst (h : LiftRel r s (inr b) y) : y.isRight :=
-(isRight_eq_of_liftRel h).symm
+  (isRight_eq_of_liftRel h).symm
 
 theorem isRight_of_liftRel_inr_snd (h : LiftRel r s x (inr d)) : x.isRight :=
-isRight_eq_of_liftRel h
+  isRight_eq_of_liftRel h
 
 variable {τ κ : Type*} {f : τ → Sum α β} {g : κ → Sum γ δ} {t : τ} {k : κ}
 
 theorem isLeft_apply_of_inl_fst (h : LiftRel r s (inl a) (g k)) : (g k).isLeft :=
-isLeft_eq_of_liftRel_inl_fst h
+  isLeft_eq_of_liftRel_inl_fst h
 
 theorem isLeft_apply_of_inl_snd (h : LiftRel r s (f t) (inl c)) : (f t).isLeft :=
-isLeft_eq_of_liftRel_inl_snd h
+  isLeft_eq_of_liftRel_inl_snd h
 
 theorem isRight_apply_of_inr_fst (h : LiftRel r s (inr b) (g k)) : (g k).isRight :=
-    isRight_of_liftRel_inr_fst h
+  isRight_of_liftRel_inr_fst h
 
 theorem isRight_apply_of_inr_snd (h : LiftRel r s (f t) (inr d)) : (f t).isRight :=
-    isRight_of_liftRel_inr_snd h
+  isRight_of_liftRel_inr_snd h
 
 theorem isLeft_apply_eq_of_LiftRel_apply (h : LiftRel r s (f t) y) : (f t).isLeft = y.isLeft :=
-isLeft_eq_of_liftRel h
+  isLeft_eq_of_liftRel h
 
 theorem isRight_apply_eq_of_LiftRel_apply (h : LiftRel r s x (g k)) :
     (g k).isRight = x.isRight := (isRight_eq_of_liftRel h).symm
 
 theorem liftRel_of_left (h : ∃ a c, r a c ∧ x = inl a ∧ y = inl c) : LiftRel r s x y :=
-(Sum.liftRel_iff ..).mpr (Or.inl h)
+  (Sum.liftRel_iff ..).mpr (Or.inl h)
 
 theorem liftRel_of_right (h : ∃ b d, s b d ∧ x = inr b ∧ y = inr d) : LiftRel r s x y :=
-(Sum.liftRel_iff ..).mpr (Or.inr h)
+  (Sum.liftRel_iff ..).mpr (Or.inr h)
 
 theorem exists_of_liftRel_left_isLeft (h₁ : LiftRel r s x y) (h₂ : x.isLeft) :
-∃ a c, r a c ∧ x = inl a ∧ y = inl c := by
+    ∃ a c, r a c ∧ x = inl a ∧ y = inl c := by
   rcases (isLeft_iff.mp h₂) with ⟨_, rfl⟩
   simp only [liftRel_iff, false_and, and_false, exists_false, or_false] at h₁
   exact h₁
 
 theorem exists_of_liftRel_right_isLeft (h₁ : LiftRel r s x y) (h₂ : y.isLeft) :
-∃ a c, r a c ∧ x = inl a ∧ y = inl c :=
-exists_of_liftRel_left_isLeft h₁ (isLeft_eq_of_liftRel h₁ ▸ h₂)
+    ∃ a c, r a c ∧ x = inl a ∧ y = inl c :=
+  exists_of_liftRel_left_isLeft h₁ (isLeft_eq_of_liftRel h₁ ▸ h₂)
 
 theorem exists_of_liftRel_left_isRight (h₁ : LiftRel r s x y) (h₂ : x.isRight) :
-∃ b d, s b d ∧ x = inr b ∧ y = inr d := by
+    ∃ b d, s b d ∧ x = inr b ∧ y = inr d := by
   rcases (isRight_iff.mp h₂) with ⟨_, rfl⟩
   simp only [liftRel_iff, false_and, and_false, exists_false, false_or] at h₁
   exact h₁
 
 theorem exists_of_liftRel_right_isRight (h₁ : LiftRel r s x y) (h₂ : y.isRight) :
-  ∃ b d, s b d ∧ x = inr b ∧ y = inr d :=
+    ∃ b d, s b d ∧ x = inr b ∧ y = inr d :=
 exists_of_liftRel_left_isRight h₁ (isRight_eq_of_liftRel h₁ ▸ h₂)
 
 end LiftRel

--- a/Mathlib/Data/Sum/Basic.lean
+++ b/Mathlib/Data/Sum/Basic.lean
@@ -201,6 +201,57 @@ section LiftRel
 #align sum.lift_rel.swap Sum.LiftRel.swap
 #align sum.lift_rel_swap_iff Sum.liftRel_swap_iff
 
+variable {r : α → γ → Prop} {s : β → δ → Prop} {x : Sum α β} {y : Sum γ δ}
+    {a : α} {b : β} {c : γ} {d : δ}
+
+theorem liftRel_def : LiftRel r s x y ↔ (∃ a, x = inl a ∧ ∃ c, y = inl c ∧ r a c) ∨
+    (∃ b, x = inr b ∧ ∃ d, y = inr d ∧ s b d) := by
+    refine' ⟨(fun H ↦ _), (fun H ↦ _)⟩
+    · rcases H with (hac | hbd)
+      · exact Or.inl ⟨_, rfl, _, rfl, hac⟩
+      · exact Or.inr ⟨_, rfl, _, rfl, hbd⟩
+    · rcases H with (⟨_, rfl, _, rfl, hac⟩ | ⟨_, rfl, _, rfl, hbd⟩)
+      · exact liftRel_inl_inl.mpr hac
+      · exact liftRel_inr_inr.mpr hbd
+
+theorem isLeft_of_liftRel (h : LiftRel r s x y) : x.isLeft = y.isLeft := by
+    cases h <;> rfl
+
+theorem isRight_eq_of_liftRel (h : LiftRel r s x y) : x.isRight = y.isRight := by
+    cases h <;> rfl
+
+theorem isLeft_of_liftRel_inl_fst (h : LiftRel r s (inl a) y) : y.isLeft :=
+    (isLeft_of_liftRel h).symm
+
+theorem isLeft_of_liftRel_inl_snd (h : LiftRel r s x (inl c)) : x.isLeft :=
+    isLeft_of_liftRel h
+
+theorem isRight_of_liftRel_inr_fst (h : LiftRel r s (inr b) y) : y.isRight :=
+    (isRight_eq_of_liftRel h).symm
+
+theorem isRight_of_liftRel_inr_snd (h : LiftRel r s x (inr d)) : x.isRight :=
+    isRight_eq_of_liftRel h
+
+variable {τ κ : Type*} {f : τ → Sum α β} {g : κ → Sum γ δ} {t : τ} {k : κ}
+
+theorem isLeft_apply_of_inl_fst (h : LiftRel r s (inl a) (g k)) : (g k).isLeft :=
+    isLeft_of_liftRel_inl_fst h
+
+theorem isLeft_apply_of_inl_snd (h : LiftRel r s (f t) (inl c)) : (f t).isLeft :=
+    isLeft_of_liftRel_inl_snd h
+
+theorem isRight_apply_of_inr_fst (h : LiftRel r s (inr b) (g k)) : (g k).isRight :=
+    isRight_of_liftRel_inr_fst h
+
+theorem isRight_apply_of_inr_snd (h : LiftRel r s (f t) (inr d)) : (f t).isRight :=
+    isRight_of_liftRel_inr_snd h
+
+theorem isLeft_apply_eq_of_LiftRel_apply (h : LiftRel r s (f t) y) :
+    (f t).isLeft = y.isLeft := isLeft_of_liftRel h
+
+theorem isRight_apply_eq_of_LiftRel_apply (h : LiftRel r s x (g k)) :
+    (g k).isRight = x.isRight := (isRight_eq_of_liftRel h).symm
+
 end LiftRel
 
 section Lex

--- a/Mathlib/Data/Sum/Basic.lean
+++ b/Mathlib/Data/Sum/Basic.lean
@@ -269,7 +269,7 @@ theorem exists_of_liftRel_left_isRight (h₁ : LiftRel r s x y) (h₂ : x.isRigh
 
 theorem exists_of_liftRel_right_isRight (h₁ : LiftRel r s x y) (h₂ : y.isRight) :
     ∃ b d, s b d ∧ x = inr b ∧ y = inr d :=
-exists_of_liftRel_left_isRight h₁ (isRight_eq_of_liftRel h₁ ▸ h₂)
+  exists_of_liftRel_left_isRight h₁ (isRight_eq_of_liftRel h₁ ▸ h₂)
 
 end LiftRel
 

--- a/Mathlib/Data/Sum/Basic.lean
+++ b/Mathlib/Data/Sum/Basic.lean
@@ -208,15 +208,11 @@ variable {r : α → γ → Prop} {s : β → δ → Prop} {x : Sum α β} {y : 
   {a : α} {b : β} {c : γ} {d : δ}
 
 theorem isLeft_congr (h : LiftRel r s x y) : x.isLeft ↔ y.isLeft := by cases h <;> rfl
-
 theorem isRight_congr (h : LiftRel r s x y) : x.isRight ↔ y.isRight := by cases h <;> rfl
 
 theorem isLeft_left (h : LiftRel r s x (inl c)) : x.isLeft := by cases h; rfl
-
 theorem isLeft_right (h : LiftRel r s (inl a) y) : y.isLeft := by cases h; rfl
-
 theorem isRight_left (h : LiftRel r s x (inr d)) : x.isRight := by cases h; rfl
-
 theorem isRight_right (h : LiftRel r s (inr b) y) : y.isRight := by cases h; rfl
 
 theorem exists_of_isLeft_left (h₁ : LiftRel r s x y) (h₂ : x.isLeft) :

--- a/Mathlib/Data/Sum/Basic.lean
+++ b/Mathlib/Data/Sum/Basic.lean
@@ -263,7 +263,7 @@ theorem exists_of_liftRel_left_isRight (h₁ : LiftRel r s x y) (h₂ : x.isRigh
   exact h₁
 
 theorem exists_of_liftRel_right_isRight (h₁ : LiftRel r s x y) (h₂ : y.isRight) :
-∃ b d, s b d ∧ x = inr b ∧ y = inr d :=
+  ∃ b d, s b d ∧ x = inr b ∧ y = inr d :=
 exists_of_liftRel_left_isRight h₁ (isRight_eq_of_liftRel h₁ ▸ h₂)
 
 end LiftRel

--- a/Mathlib/Data/Sum/Basic.lean
+++ b/Mathlib/Data/Sum/Basic.lean
@@ -240,6 +240,32 @@ isLeft_eq_of_liftRel h
 theorem isRight_apply_eq_of_LiftRel_apply (h : LiftRel r s x (g k)) :
     (g k).isRight = x.isRight := (isRight_eq_of_liftRel h).symm
 
+theorem liftRel_of_left (h : ∃ a c, r a c ∧ x = inl a ∧ y = inl c) : LiftRel r s x y :=
+(Sum.liftRel_iff ..).mpr (Or.inl h)
+
+theorem liftRel_of_right (h : ∃ b d, s b d ∧ x = inr b ∧ y = inr d) : LiftRel r s x y :=
+(Sum.liftRel_iff ..).mpr (Or.inr h)
+
+theorem exists_of_liftRel_left_isLeft (h₁ : LiftRel r s x y) (h₂ : x.isLeft) :
+∃ a c, r a c ∧ x = inl a ∧ y = inl c := by
+  rcases (isLeft_iff.mp h₂) with ⟨_, rfl⟩
+  simp only [liftRel_iff, false_and, and_false, exists_false, or_false] at h₁
+  exact h₁
+
+theorem exists_of_liftRel_right_isLeft (h₁ : LiftRel r s x y) (h₂ : y.isLeft) :
+∃ a c, r a c ∧ x = inl a ∧ y = inl c :=
+exists_of_liftRel_left_isLeft h₁ (isLeft_eq_of_liftRel h₁ ▸ h₂)
+
+theorem exists_of_liftRel_left_isRight (h₁ : LiftRel r s x y) (h₂ : x.isRight) :
+∃ b d, s b d ∧ x = inr b ∧ y = inr d := by
+  rcases (isRight_iff.mp h₂) with ⟨_, rfl⟩
+  simp only [liftRel_iff, false_and, and_false, exists_false, false_or] at h₁
+  exact h₁
+
+theorem exists_of_liftRel_right_isRight (h₁ : LiftRel r s x y) (h₂ : y.isRight) :
+∃ b d, s b d ∧ x = inr b ∧ y = inr d :=
+exists_of_liftRel_left_isRight h₁ (isRight_eq_of_liftRel h₁ ▸ h₂)
+
 end LiftRel
 
 section Lex

--- a/Mathlib/Data/Sum/Basic.lean
+++ b/Mathlib/Data/Sum/Basic.lean
@@ -211,13 +211,13 @@ theorem isLeft_congr (h : LiftRel r s x y) : x.isLeft ↔ y.isLeft := by cases h
 
 theorem isRight_congr (h : LiftRel r s x y) : x.isRight ↔ y.isRight := by cases h <;> rfl
 
-theorem isLeft_left (h : LiftRel r s x (inl c)) : x.isLeft := by cases h ; rfl
+theorem isLeft_left (h : LiftRel r s x (inl c)) : x.isLeft := by cases h; rfl
 
-theorem isLeft_right (h : LiftRel r s (inl a) y) : y.isLeft := by cases h ; rfl
+theorem isLeft_right (h : LiftRel r s (inl a) y) : y.isLeft := by cases h; rfl
 
-theorem isRight_left (h : LiftRel r s x (inr d)) : x.isRight := by cases h ; rfl
+theorem isRight_left (h : LiftRel r s x (inr d)) : x.isRight := by cases h; rfl
 
-theorem isRight_right (h : LiftRel r s (inr b) y) : y.isRight := by cases h ; rfl
+theorem isRight_right (h : LiftRel r s (inr b) y) : y.isRight := by cases h; rfl
 
 theorem exists_of_isLeft_left (h₁ : LiftRel r s x y) (h₂ : x.isLeft) :
     ∃ a c, r a c ∧ x = inl a ∧ y = inl c := by

--- a/Mathlib/Data/Sum/Basic.lean
+++ b/Mathlib/Data/Sum/Basic.lean
@@ -189,7 +189,9 @@ theorem swap_rightInverse : Function.RightInverse (@swap α β) swap :=
 #align sum.get_left_swap Sum.getLeft?_swap
 #align sum.get_right_swap Sum.getRight?_swap
 
-section LiftRel
+mk_iff_of_inductive_prop Sum.LiftRel Sum.liftRel_iff
+
+namespace LiftRel
 
 #align sum.lift_rel Sum.LiftRel
 #align sum.lift_rel_inl_inl Sum.liftRel_inl_inl
@@ -202,74 +204,39 @@ section LiftRel
 #align sum.lift_rel.swap Sum.LiftRel.swap
 #align sum.lift_rel_swap_iff Sum.liftRel_swap_iff
 
-mk_iff_of_inductive_prop Sum.LiftRel Sum.liftRel_iff
-
 variable {r : α → γ → Prop} {s : β → δ → Prop} {x : Sum α β} {y : Sum γ δ}
   {a : α} {b : β} {c : γ} {d : δ}
 
-theorem isLeft_eq_of_liftRel (h : LiftRel r s x y) : x.isLeft = y.isLeft := by
-  cases h <;> rfl
+theorem isLeft_congr (h : LiftRel r s x y) : x.isLeft ↔ y.isLeft := by cases h <;> rfl
 
-theorem isRight_eq_of_liftRel (h : LiftRel r s x y) : x.isRight = y.isRight := by
-  cases h <;> rfl
+theorem isRight_congr (h : LiftRel r s x y) : x.isRight ↔ y.isRight := by cases h <;> rfl
 
-theorem isLeft_eq_of_liftRel_inl_fst (h : LiftRel r s (inl a) y) : y.isLeft :=
-  (isLeft_eq_of_liftRel h).symm
+theorem isLeft_left (h : LiftRel r s x (inl c)) : x.isLeft := by cases h ; rfl
 
-theorem isLeft_eq_of_liftRel_inl_snd (h : LiftRel r s x (inl c)) : x.isLeft :=
-  isLeft_eq_of_liftRel h
+theorem isLeft_right (h : LiftRel r s (inl a) y) : y.isLeft := by cases h ; rfl
 
-theorem isRight_of_liftRel_inr_fst (h : LiftRel r s (inr b) y) : y.isRight :=
-  (isRight_eq_of_liftRel h).symm
+theorem isRight_left (h : LiftRel r s x (inr d)) : x.isRight := by cases h ; rfl
 
-theorem isRight_of_liftRel_inr_snd (h : LiftRel r s x (inr d)) : x.isRight :=
-  isRight_eq_of_liftRel h
+theorem isRight_right (h : LiftRel r s (inr b) y) : y.isRight := by cases h ; rfl
 
-variable {τ κ : Type*} {f : τ → Sum α β} {g : κ → Sum γ δ} {t : τ} {k : κ}
-
-theorem isLeft_apply_of_inl_fst (h : LiftRel r s (inl a) (g k)) : (g k).isLeft :=
-  isLeft_eq_of_liftRel_inl_fst h
-
-theorem isLeft_apply_of_inl_snd (h : LiftRel r s (f t) (inl c)) : (f t).isLeft :=
-  isLeft_eq_of_liftRel_inl_snd h
-
-theorem isRight_apply_of_inr_fst (h : LiftRel r s (inr b) (g k)) : (g k).isRight :=
-  isRight_of_liftRel_inr_fst h
-
-theorem isRight_apply_of_inr_snd (h : LiftRel r s (f t) (inr d)) : (f t).isRight :=
-  isRight_of_liftRel_inr_snd h
-
-theorem isLeft_apply_eq_of_LiftRel_apply (h : LiftRel r s (f t) y) : (f t).isLeft = y.isLeft :=
-  isLeft_eq_of_liftRel h
-
-theorem isRight_apply_eq_of_LiftRel_apply (h : LiftRel r s x (g k)) :
-    (g k).isRight = x.isRight := (isRight_eq_of_liftRel h).symm
-
-theorem liftRel_of_left (h : ∃ a c, r a c ∧ x = inl a ∧ y = inl c) : LiftRel r s x y :=
-  (Sum.liftRel_iff ..).mpr (Or.inl h)
-
-theorem liftRel_of_right (h : ∃ b d, s b d ∧ x = inr b ∧ y = inr d) : LiftRel r s x y :=
-  (Sum.liftRel_iff ..).mpr (Or.inr h)
-
-theorem exists_of_liftRel_left_isLeft (h₁ : LiftRel r s x y) (h₂ : x.isLeft) :
+theorem exists_of_isLeft_left (h₁ : LiftRel r s x y) (h₂ : x.isLeft) :
     ∃ a c, r a c ∧ x = inl a ∧ y = inl c := by
-  rcases (isLeft_iff.mp h₂) with ⟨_, rfl⟩
+  rcases isLeft_iff.mp h₂ with ⟨_, rfl⟩
   simp only [liftRel_iff, false_and, and_false, exists_false, or_false] at h₁
   exact h₁
 
-theorem exists_of_liftRel_right_isLeft (h₁ : LiftRel r s x y) (h₂ : y.isLeft) :
-    ∃ a c, r a c ∧ x = inl a ∧ y = inl c :=
-  exists_of_liftRel_left_isLeft h₁ (isLeft_eq_of_liftRel h₁ ▸ h₂)
+theorem exists_of_isLeft_right (h₁ : LiftRel r s x y) (h₂ : y.isLeft) :
+    ∃ a c, r a c ∧ x = inl a ∧ y = inl c := exists_of_isLeft_left h₁ ((isLeft_congr h₁).mpr h₂)
 
-theorem exists_of_liftRel_left_isRight (h₁ : LiftRel r s x y) (h₂ : x.isRight) :
+theorem exists_of_isRight_left (h₁ : LiftRel r s x y) (h₂ : x.isRight) :
     ∃ b d, s b d ∧ x = inr b ∧ y = inr d := by
-  rcases (isRight_iff.mp h₂) with ⟨_, rfl⟩
+  rcases isRight_iff.mp h₂ with ⟨_, rfl⟩
   simp only [liftRel_iff, false_and, and_false, exists_false, false_or] at h₁
   exact h₁
 
-theorem exists_of_liftRel_right_isRight (h₁ : LiftRel r s x y) (h₂ : y.isRight) :
+theorem exists_of_isRight_right (h₁ : LiftRel r s x y) (h₂ : y.isRight) :
     ∃ b d, s b d ∧ x = inr b ∧ y = inr d :=
-  exists_of_liftRel_left_isRight h₁ (isRight_eq_of_liftRel h₁ ▸ h₂)
+  exists_of_isRight_left h₁ ((isRight_congr h₁).mpr h₂)
 
 end LiftRel
 

--- a/Mathlib/Data/Sum/Basic.lean
+++ b/Mathlib/Data/Sum/Basic.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Yury G. Kudryashov
 -/
 import Mathlib.Logic.Function.Basic
+import Mathlib.Tactic.MkIffOfInductiveProp
 
 #align_import data.sum.basic from "leanprover-community/mathlib"@"bd9851ca476957ea4549eb19b40e7b5ade9428cc"
 

--- a/Mathlib/Logic/Equiv/Basic.lean
+++ b/Mathlib/Logic/Equiv/Basic.lean
@@ -384,13 +384,13 @@ end Perm
 section LiftRel
 
 variable {r : α → γ → Prop} {s : β → δ → Prop} {a : α} {b : β} {c : γ} {d : δ}
-  {x : Sum α β} {y : Sum γ δ} {e : Sum α β ≃ Sum γ δ} {f : Sum γ δ ≃ Sum α β}
+  {x : Sum α β} {y : Sum γ δ}
 
-lemma liftRel_self_apply_iff_liftRel_apply_symm_self :
+lemma liftRel_self_apply_iff_liftRel_apply_symm_self {e : Sum α β ≃ Sum γ δ} :
 (∀ x, LiftRel r s x (e x)) ↔ ∀ y, LiftRel r s (e.symm y) y := by
 simp_rw [e.forall_congr_left', apply_symm_apply]
 
-lemma liftRel_apply_self_iff_liftRel_self_apply_symm :
+lemma liftRel_apply_self_iff_liftRel_self_apply_symm {f : Sum γ δ ≃ Sum α β} :
   (∀ x, LiftRel r s (f x) x) ↔ ∀ y, LiftRel r s y (f.symm y) :=
 f.symm_symm ▸ liftRel_self_apply_iff_liftRel_apply_symm_self.symm
 

--- a/Mathlib/Logic/Equiv/Basic.lean
+++ b/Mathlib/Logic/Equiv/Basic.lean
@@ -387,7 +387,7 @@ variable {r : α → γ → Prop} {s : β → δ → Prop} {a : α} {b : β} {c 
   {x : Sum α β} {y : Sum γ δ}
 
 lemma liftRel_self_apply_iff_liftRel_apply_symm_self {e : Sum α β ≃ Sum γ δ} :
-(∀ x, LiftRel r s x (e x)) ↔ ∀ y, LiftRel r s (e.symm y) y := by
+  (∀ x, LiftRel r s x (e x)) ↔ ∀ y, LiftRel r s (e.symm y) y := by
 simp_rw [e.forall_congr_left', apply_symm_apply]
 
 lemma liftRel_apply_self_iff_liftRel_self_apply_symm {f : Sum γ δ ≃ Sum α β} :

--- a/Mathlib/Logic/Equiv/Basic.lean
+++ b/Mathlib/Logic/Equiv/Basic.lean
@@ -381,6 +381,22 @@ theorem sumCongr_refl : sumCongr (Equiv.refl α) (Equiv.refl β) = Equiv.refl (S
 
 end Perm
 
+section LiftRel
+
+variable {r : α → γ → Prop} {s : β → δ → Prop} {a : α} {b : β} {c : γ} {d : δ}
+  {x : Sum α β} {y : Sum γ δ} {e : Sum α β ≃ Sum γ δ} {f : Sum γ δ ≃ Sum α β}
+
+lemma liftRel_self_apply_iff_liftRel_apply_symm_self :
+(∀ x, LiftRel r s x (e x)) ↔ ∀ y, LiftRel r s (e.symm y) y :=
+⟨fun H cd => by convert (H (e.symm cd)) ; exact (e.apply_symm_apply _).symm,
+fun H ab => by convert (H (e ab)) ; exact (e.symm_apply_apply _).symm⟩
+
+lemma liftRel_apply_self_iff_liftRel_self_apply_symm :
+  (∀ x, LiftRel r s (f x) x) ↔ ∀ y, LiftRel r s y (f.symm y) :=
+f.symm_symm ▸ liftRel_self_apply_iff_liftRel_apply_symm_self.symm
+
+end LiftRel
+
 /-- `Bool` is equivalent the sum of two `PUnit`s. -/
 def boolEquivPUnitSumPUnit : Bool ≃ Sum PUnit.{u + 1} PUnit.{v + 1} :=
   ⟨fun b => b.casesOn (inl PUnit.unit) (inr PUnit.unit) , Sum.elim (fun _ => false) fun _ => true,

--- a/Mathlib/Logic/Equiv/Basic.lean
+++ b/Mathlib/Logic/Equiv/Basic.lean
@@ -387,9 +387,8 @@ variable {r : α → γ → Prop} {s : β → δ → Prop} {a : α} {b : β} {c 
   {x : Sum α β} {y : Sum γ δ} {e : Sum α β ≃ Sum γ δ} {f : Sum γ δ ≃ Sum α β}
 
 lemma liftRel_self_apply_iff_liftRel_apply_symm_self :
-(∀ x, LiftRel r s x (e x)) ↔ ∀ y, LiftRel r s (e.symm y) y :=
-⟨fun H cd => by convert (H (e.symm cd)) ; exact (e.apply_symm_apply _).symm,
-fun H ab => by convert (H (e ab)) ; exact (e.symm_apply_apply _).symm⟩
+(∀ x, LiftRel r s x (e x)) ↔ ∀ y, LiftRel r s (e.symm y) y := by
+simp_rw [e.forall_congr_left', apply_symm_apply]
 
 lemma liftRel_apply_self_iff_liftRel_self_apply_symm :
   (∀ x, LiftRel r s (f x) x) ↔ ∀ y, LiftRel r s y (f.symm y) :=

--- a/Mathlib/Logic/Equiv/Basic.lean
+++ b/Mathlib/Logic/Equiv/Basic.lean
@@ -381,21 +381,6 @@ theorem sumCongr_refl : sumCongr (Equiv.refl α) (Equiv.refl β) = Equiv.refl (S
 
 end Perm
 
-section LiftRel
-
-variable {r : α → γ → Prop} {s : β → δ → Prop} {a : α} {b : β} {c : γ} {d : δ}
-  {x : Sum α β} {y : Sum γ δ}
-
-lemma liftRel_self_apply_iff_liftRel_apply_symm_self {e : Sum α β ≃ Sum γ δ} :
-  (∀ x, LiftRel r s x (e x)) ↔ ∀ y, LiftRel r s (e.symm y) y := by
-simp_rw [e.forall_congr_left', apply_symm_apply]
-
-lemma liftRel_apply_self_iff_liftRel_self_apply_symm {f : Sum γ δ ≃ Sum α β} :
-  (∀ x, LiftRel r s (f x) x) ↔ ∀ y, LiftRel r s y (f.symm y) :=
-f.symm_symm ▸ liftRel_self_apply_iff_liftRel_apply_symm_self.symm
-
-end LiftRel
-
 /-- `Bool` is equivalent the sum of two `PUnit`s. -/
 def boolEquivPUnitSumPUnit : Bool ≃ Sum PUnit.{u + 1} PUnit.{v + 1} :=
   ⟨fun b => b.casesOn (inl PUnit.unit) (inr PUnit.unit) , Sum.elim (fun _ => false) fun _ => true,


### PR DESCRIPTION
Add lemmas that allow `IsLeft`/`IsRight` conclusions from `LiftRel` and allow for apply functions.

This is necessary because `cases` cannot run on statements like `LiftRel r s (f t) y`.

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
