### PR TITLE
[Merged by Bors] - fix: doc for fin_cases

### DIFF
--- a/Mathlib/Tactic/FinCases.lean
+++ b/Mathlib/Tactic/FinCases.lean
@@ -73,7 +73,7 @@ partial def finCasesAt (g : MVarId) (hyp : FVarId) : MetaM (List MVarId) := g.wi
 As an example, in
 ```
 example (f : ℕ → Prop) (p : Fin 3) (h0 : f 0) (h1 : f 1) (h2 : f 2) : f p.val := by
-  fin_cases *; simp
+  fin_cases p; simp
   all_goals assumption
 ```
 after `fin_cases p; simp`, there are three goals, `f 0`, `f 1`, and `f 2`.


### PR DESCRIPTION
With the `*`, I'm getting a syntax error, so I propose to have an example that actually works (or fixing `fin_cases` that it works with `*`.)



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
