### PR TITLE
[Merged by Bors] - chore: fix bug in `exact? using ...`

### DIFF
--- a/Mathlib/Tactic/LibrarySearch.lean
+++ b/Mathlib/Tactic/LibrarySearch.lean
@@ -138,7 +138,10 @@ def librarySearchLemma (lem : Name) (mod : DeclMod) (required : List Expr) (solv
       let subgoals ← solveByElim newGoals required (exfalso := false) (depth := solveByElimDepth)
       pure (← getMCtx, subgoals)
     catch _ =>
-      pure (← getMCtx, newGoals)
+      if required.isEmpty then
+        pure (← getMCtx, newGoals)
+      else
+        failure
 
 /--
 Returns a lazy list of the results of applying a library lemma,

--- a/test/LibrarySearch/basic.lean
+++ b/test/LibrarySearch/basic.lean
@@ -173,9 +173,9 @@ axiom F (a b : ℕ) : f a ≤ f b ↔ a ≤ b
 #guard_msgs in
 example (a b : ℕ) (h : a ≤ b) : f a ≤ f b := by apply?
 
--- FIXME `apply? using x` is apparently partially broken at present.
--- This is returning `exact []`.
--- example (L _M : List (List ℕ)) : List ℕ := by apply? using L
+/-- info: Try this: exact List.join L -/
+#guard_msgs in
+example (L _M : List (List ℕ)) : List ℕ := by apply? using L
 
 -- Could be any number of results
 #guard_msgs (drop info) in


### PR DESCRIPTION
Lemmas that generate no subgoals were being incorrectly accepted by `exact? using ...`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
