### PR TITLE
[Merged by Bors] - feat: deduplicate lemmas used by rw?

### DIFF
--- a/test/rewrites.lean
+++ b/test/rewrites.lean
@@ -133,8 +133,19 @@ info: Try this: rw [@AddCommMonoidWithOne.add_comm]
 example (n : ℕ) : let y := 3; n + y = 3 + n := by
   rw?!
 
+axiom α : Type
+axiom f : α → α
+axiom z : α
+axiom f_eq (n) : f n = z
+
 -- Check that the same lemma isn't used multiple times.
--- This used to report e.g. two redundant copies of `Nat.add_assoc`.
-lemma test (n m : ℕ) : n + m + 1 = m + n + 1 := by
+-- This used to report two redundant copies of `f_eq`.
+-- It be lovely if `rw?` could produce two *different* rewrites by `f_eq` here!
+/--
+info: Try this: rw [f_eq]
+-- z = f m
+-/
+#guard_msgs in
+lemma test : f n = f m := by
   rw?
-  rw [add_comm n m]
+  rw [f_eq, f_eq]

--- a/test/rewrites.lean
+++ b/test/rewrites.lean
@@ -4,6 +4,8 @@ import Mathlib.CategoryTheory.Category.Basic
 import Mathlib.Data.List.Basic
 import Mathlib.Algebra.Group.Basic
 
+set_option autoImplicit true
+
 -- To see the (sorted) list of lemmas that `rw?` will try rewriting by, use:
 -- set_option trace.Tactic.rewrites.lemmas true
 
@@ -130,3 +132,9 @@ info: Try this: rw [@AddCommMonoidWithOne.add_comm]
 #guard_msgs in
 example (n : ℕ) : let y := 3; n + y = 3 + n := by
   rw?!
+
+-- Check that the same lemma isn't used multiple times.
+-- This used to report e.g. two redundant copies of `Nat.add_assoc`.
+lemma test (n m : ℕ) : n + m + 1 = m + n + 1 := by
+  rw?
+  rw [add_comm n m]


### PR DESCRIPTION
Solving request 1. from @b-mehta's [zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Duplicates.20in.20rw.3F/near/381963606) post.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
