### PR TITLE
[Merged by Bors] - docs: Document conv => … equals => tactic

### DIFF
--- a/docs/Conv/Guide.lean
+++ b/docs/Conv/Guide.lean
@@ -156,6 +156,9 @@ in Lean 4 core.
 
 * `change t` changes the expression to `t` if the expression and `t` are definitionally equal.
 
+* `equals t => tacticSeq` changes the current expression, say `e`, to `t`, and asks you to prove
+   the equality `e = t`. (Std4)
+
 * `rw [thms...]` rewrites the expression using the given theorems. The syntax is similar to `rw`.
 
 * `erw [thms...]` rewrites the expression using the given theorems. The syntax is similar to `erw`.

--- a/docs/Conv/Introduction.lean
+++ b/docs/Conv/Introduction.lean
@@ -155,7 +155,7 @@ example (a b : ℕ) :
 
 ## Other tactics inside conversion mode
 
-Besides rewriting using `rw`, one can use `simp`, `dsimp`, `change`, `ring`, `norm_num`,
+Besides rewriting using `rw`, one can use `simp`, `dsimp`, `change`, `equals`, `ring`, `norm_num`,
 `push_neg`, `unfold`, among others.
 
 See the [`conv` guide](https://leanprover-community.github.io/mathlib4_docs/docs/Conv/Guide.html)


### PR DESCRIPTION
which was introduced in https://github.com/leanprover/std4/pull/204


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
