### PR TITLE
[Merged by Bors] - feat: generalize sheaf condition to only the relevant pullbacks existing

### DIFF
--- a/Mathlib/CategoryTheory/Sites/SheafOfTypes.lean
+++ b/Mathlib/CategoryTheory/Sites/SheafOfTypes.lean
@@ -155,7 +155,7 @@ using the notation defined there.
 -/
 def FamilyOfElements.PullbackCompatible (x : FamilyOfElements P R) [R.hasPullbacks] : Prop :=
   ∀ ⦃Y₁ Y₂⦄ ⦃f₁ : Y₁ ⟶ X⦄ ⦃f₂ : Y₂ ⟶ X⦄ (h₁ : R f₁) (h₂ : R f₂),
-    have := hasPullbacks.has_pullbacks h₁ h₂
+    haveI := hasPullbacks.has_pullbacks h₁ h₂
     P.map (pullback.fst : Limits.pullback f₁ f₂ ⟶ _).op (x f₁ h₁) = P.map pullback.snd.op (x f₂ h₂)
 #align category_theory.presieve.family_of_elements.pullback_compatible CategoryTheory.Presieve.FamilyOfElements.PullbackCompatible
 
@@ -164,10 +164,10 @@ theorem pullbackCompatible_iff (x : FamilyOfElements P R) [R.hasPullbacks] :
   constructor
   · intro t Y₁ Y₂ f₁ f₂ hf₁ hf₂
     apply t
-    have := hasPullbacks.has_pullbacks hf₁ hf₂
+    haveI := hasPullbacks.has_pullbacks hf₁ hf₂
     apply pullback.condition
   · intro t Y₁ Y₂ Z g₁ g₂ f₁ f₂ hf₁ hf₂ comm
-    have := hasPullbacks.has_pullbacks  hf₁ hf₂
+    haveI := hasPullbacks.has_pullbacks  hf₁ hf₂
     rw [← pullback.lift_fst _ _ comm, op_comp, FunctorToTypes.map_comp_apply, t hf₁ hf₂,
       ← FunctorToTypes.map_comp_apply, ← op_comp, pullback.lift_snd]
 #align category_theory.presieve.pullback_compatible_iff CategoryTheory.Presieve.pullbackCompatible_iff
@@ -1023,15 +1023,15 @@ contains the data used to check a family of elements for a presieve is compatibl
 -/
 @[simp] def SecondObj : Type max v₁ u₁ :=
   ∏ fun fg : (ΣY, { f : Y ⟶ X // R f }) × ΣZ, { g : Z ⟶ X // R g } =>
-    have := Presieve.hasPullbacks.has_pullbacks fg.1.2.2 fg.2.2.2
+    haveI := Presieve.hasPullbacks.has_pullbacks fg.1.2.2 fg.2.2.2
     P.obj (op (pullback fg.1.2.1 fg.2.2.1))
 #align category_theory.equalizer.presieve.second_obj CategoryTheory.Equalizer.Presieve.SecondObj
 
 /-- The map `pr₀*` of <https://stacks.math.columbia.edu/tag/00VL>. -/
 def firstMap : FirstObj P R ⟶ SecondObj P R :=
   Pi.lift fun fg =>
-  have := Presieve.hasPullbacks.has_pullbacks fg.1.2.2 fg.2.2.2
-  Pi.π _ _ ≫ P.map pullback.fst.op
+    haveI := Presieve.hasPullbacks.has_pullbacks fg.1.2.2 fg.2.2.2
+    Pi.π _ _ ≫ P.map pullback.fst.op
 #align category_theory.equalizer.presieve.first_map CategoryTheory.Equalizer.Presieve.firstMap
 
 instance [HasPullbacks C] : Inhabited (SecondObj P (⊥ : Presieve X)) :=
@@ -1040,7 +1040,7 @@ instance [HasPullbacks C] : Inhabited (SecondObj P (⊥ : Presieve X)) :=
 /-- The map `pr₁*` of <https://stacks.math.columbia.edu/tag/00VL>. -/
 def secondMap : FirstObj P R ⟶ SecondObj P R :=
   Pi.lift fun fg =>
-    have := Presieve.hasPullbacks.has_pullbacks fg.1.2.2 fg.2.2.2
+    haveI := Presieve.hasPullbacks.has_pullbacks fg.1.2.2 fg.2.2.2
     Pi.π _ _ ≫ P.map pullback.snd.op
 #align category_theory.equalizer.presieve.second_map CategoryTheory.Equalizer.Presieve.secondMap
 
@@ -1049,7 +1049,7 @@ theorem w : forkMap P R ≫ firstMap P R = forkMap P R ≫ secondMap P R := by
   ext fg
   simp only [firstMap, secondMap, forkMap]
   simp only [limit.lift_π, limit.lift_π_assoc, assoc, Fan.mk_π_app]
-  have := Presieve.hasPullbacks.has_pullbacks fg.1.2.2 fg.2.2.2
+  haveI := Presieve.hasPullbacks.has_pullbacks fg.1.2.2 fg.2.2.2
   rw [← P.map_comp, ← op_comp, pullback.condition]
   simp
 #align category_theory.equalizer.presieve.w CategoryTheory.Equalizer.Presieve.w

--- a/Mathlib/CategoryTheory/Sites/SheafOfTypes.lean
+++ b/Mathlib/CategoryTheory/Sites/SheafOfTypes.lean
@@ -153,18 +153,21 @@ Equation (5). Viewing the type `FamilyOfElements` as the middle object of the fo
 https://stacks.math.columbia.edu/tag/00VM, this condition expresses that `pr₀* (x) = pr₁* (x)`,
 using the notation defined there.
 -/
-def FamilyOfElements.PullbackCompatible (x : FamilyOfElements P R) [HasPullbacks C] : Prop :=
+def FamilyOfElements.PullbackCompatible (x : FamilyOfElements P R) [R.hasPullbacks] : Prop :=
   ∀ ⦃Y₁ Y₂⦄ ⦃f₁ : Y₁ ⟶ X⦄ ⦃f₂ : Y₂ ⟶ X⦄ (h₁ : R f₁) (h₂ : R f₂),
-    P.map (pullback.fst : pullback f₁ f₂ ⟶ _).op (x f₁ h₁) = P.map pullback.snd.op (x f₂ h₂)
+    have := hasPullbacks.has_pullbacks h₁ h₂
+    P.map (pullback.fst : Limits.pullback f₁ f₂ ⟶ _).op (x f₁ h₁) = P.map pullback.snd.op (x f₂ h₂)
 #align category_theory.presieve.family_of_elements.pullback_compatible CategoryTheory.Presieve.FamilyOfElements.PullbackCompatible
 
-theorem pullbackCompatible_iff (x : FamilyOfElements P R) [HasPullbacks C] :
+theorem pullbackCompatible_iff (x : FamilyOfElements P R) [R.hasPullbacks] :
     x.Compatible ↔ x.PullbackCompatible := by
   constructor
   · intro t Y₁ Y₂ f₁ f₂ hf₁ hf₂
     apply t
+    have := hasPullbacks.has_pullbacks hf₁ hf₂
     apply pullback.condition
   · intro t Y₁ Y₂ Z g₁ g₂ f₁ f₂ hf₁ hf₂ comm
+    have := hasPullbacks.has_pullbacks  hf₁ hf₂
     rw [← pullback.lift_fst _ _ comm, op_comp, FunctorToTypes.map_comp_apply, t hf₁ hf₂,
       ← FunctorToTypes.map_comp_apply, ← op_comp, pullback.lift_snd]
 #align category_theory.presieve.pullback_compatible_iff CategoryTheory.Presieve.pullbackCompatible_iff
@@ -1013,34 +1016,40 @@ https://stacks.math.columbia.edu/tag/00VM and the definition of `isSheafFor`.
 
 namespace Presieve
 
-variable [HasPullbacks C]
+variable [R.hasPullbacks]
 
 /-- The rightmost object of the fork diagram of https://stacks.math.columbia.edu/tag/00VM, which
 contains the data used to check a family of elements for a presieve is compatible.
 -/
 @[simp] def SecondObj : Type max v₁ u₁ :=
   ∏ fun fg : (ΣY, { f : Y ⟶ X // R f }) × ΣZ, { g : Z ⟶ X // R g } =>
+    have := Presieve.hasPullbacks.has_pullbacks fg.1.2.2 fg.2.2.2
     P.obj (op (pullback fg.1.2.1 fg.2.2.1))
 #align category_theory.equalizer.presieve.second_obj CategoryTheory.Equalizer.Presieve.SecondObj
 
 /-- The map `pr₀*` of <https://stacks.math.columbia.edu/tag/00VL>. -/
 def firstMap : FirstObj P R ⟶ SecondObj P R :=
-  Pi.lift fun _ => Pi.π _ _ ≫ P.map pullback.fst.op
+  Pi.lift fun fg =>
+  have := Presieve.hasPullbacks.has_pullbacks fg.1.2.2 fg.2.2.2
+  Pi.π _ _ ≫ P.map pullback.fst.op
 #align category_theory.equalizer.presieve.first_map CategoryTheory.Equalizer.Presieve.firstMap
 
-instance : Inhabited (SecondObj P (⊥ : Presieve X)) :=
+instance [HasPullbacks C] : Inhabited (SecondObj P (⊥ : Presieve X)) :=
   ⟨firstMap _ _ default⟩
 
 /-- The map `pr₁*` of <https://stacks.math.columbia.edu/tag/00VL>. -/
 def secondMap : FirstObj P R ⟶ SecondObj P R :=
-  Pi.lift fun _ => Pi.π _ _ ≫ P.map pullback.snd.op
+  Pi.lift fun fg =>
+    have := Presieve.hasPullbacks.has_pullbacks fg.1.2.2 fg.2.2.2
+    Pi.π _ _ ≫ P.map pullback.snd.op
 #align category_theory.equalizer.presieve.second_map CategoryTheory.Equalizer.Presieve.secondMap
 
 theorem w : forkMap P R ≫ firstMap P R = forkMap P R ≫ secondMap P R := by
   dsimp
-  ext
+  ext fg
   simp only [firstMap, secondMap, forkMap]
   simp only [limit.lift_π, limit.lift_π_assoc, assoc, Fan.mk_π_app]
+  have := Presieve.hasPullbacks.has_pullbacks fg.1.2.2 fg.2.2.2
   rw [← P.map_comp, ← op_comp, pullback.condition]
   simp
 #align category_theory.equalizer.presieve.w CategoryTheory.Equalizer.Presieve.w

--- a/Mathlib/CategoryTheory/Sites/Sieves.lean
+++ b/Mathlib/CategoryTheory/Sites/Sieves.lean
@@ -183,6 +183,13 @@ theorem functorPullback_id (R : Presieve X) : R.functorPullback (𝟭 _) = R :=
   rfl
 #align category_theory.presieve.functor_pullback_id CategoryTheory.Presieve.functorPullback_id
 
+/-- Given a presieve `R` on `X`, the predicate `R.hasPullbacks` means that for all arrows `f` and
+    `g` in `R`, the pullback of `f` and `g` exists. -/
+class hasPullbacks (R : Presieve X) : Prop where
+  has_pullbacks : ∀ {Y Z} {f : Y ⟶ X} (_ : R f) {g : Z ⟶ X} (_ : R g), HasPullback f g
+
+instance (R : Presieve X) [HasPullbacks C] : R.hasPullbacks := ⟨fun _ _ ↦ inferInstance⟩
+
 section FunctorPushforward
 
 variable {E : Type u₃} [Category.{v₃} E] (G : D ⥤ E)

--- a/Mathlib/CategoryTheory/Sites/Sieves.lean
+++ b/Mathlib/CategoryTheory/Sites/Sieves.lean
@@ -186,6 +186,7 @@ theorem functorPullback_id (R : Presieve X) : R.functorPullback (𝟭 _) = R :=
 /-- Given a presieve `R` on `X`, the predicate `R.hasPullbacks` means that for all arrows `f` and
     `g` in `R`, the pullback of `f` and `g` exists. -/
 class hasPullbacks (R : Presieve X) : Prop where
+  /-- For all arrows `f` and `g` in `R`, the pullback of `f` and `g` exists. -/
   has_pullbacks : ∀ {Y Z} {f : Y ⟶ X} (_ : R f) {g : Z ⟶ X} (_ : R g), HasPullback f g
 
 instance (R : Presieve X) [HasPullbacks C] : R.hasPullbacks := ⟨fun _ _ ↦ inferInstance⟩


### PR DESCRIPTION
We define a predicate `Presieve.hasPullbacks` which says that the pullback of every pair of arrows in the presieve exists. This allows to generalize `Equalizer.Presieve.sheaf_condition` to categories that don't necessarily have all pullbacks (such as `Stonean`). 

Co-authored-by: Riccardo Brasca @riccardobrasca [riccardo.brasca@gmail.com](mailto:riccardo.brasca@gmail.com)
Co-authored-by: Filippo A E Nuccio @faenuccio [filippo.nuccio@univ-st-etienne.fr](mailto:filippo.nuccio@univ-st-etienne.fr)


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
