### PR TITLE
[Merged by Bors] - feat(ToAdditive + UniqueProds): support `[uU]niqueProds →[uU]niqueSums`

### DIFF
--- a/Mathlib/Algebra/Group/UniqueProds.lean
+++ b/Mathlib/Algebra/Group/UniqueProds.lean
@@ -191,7 +191,7 @@ class UniqueProds (G) [Mul G] : Prop where
     ∀ {A B : Finset G} (_ : A.Nonempty) (_ : B.Nonempty), ∃ a0 ∈ A, ∃ b0 ∈ B, UniqueMul A B a0 b0
 #align unique_prods UniqueProds
 
-attribute [to_additive UniqueSums] UniqueProds
+attribute [to_additive] UniqueProds
 
 namespace Multiplicative
 
@@ -218,7 +218,7 @@ end Additive
 -- see Note [lower instance priority]
 /-- This instance asserts that if `A` has a multiplication, a linear order, and multiplication
 is 'very monotone', then `A` also has `UniqueProds`. -/
-@[to_additive Covariants.to_uniqueSums
+@[to_additive
       "This instance asserts that if `A` has an addition, a linear order, and addition
 is 'very monotone', then `A` also has `UniqueSums`."]
 instance (priority := 100) Covariants.to_uniqueProds {A} [Mul A] [LinearOrder A]

--- a/Mathlib/Tactic/ToAdditive.lean
+++ b/Mathlib/Tactic/ToAdditive.lean
@@ -798,8 +798,6 @@ def fixAbbreviation : List String → List String
   | "ZSmul" :: s                      => "ZSMul" :: fixAbbreviation s -- from `ZPow`
   | "neg" :: "Fun" :: s               => "invFun" :: fixAbbreviation s
   | "Neg" :: "Fun" :: s               => "InvFun" :: fixAbbreviation s
-  | "unique" :: "Mul" :: s            => "uniqueAdd" :: fixAbbreviation s
-  | "Unique" :: "Mul" :: s            => "UniqueAdd" :: fixAbbreviation s
   | "unique" :: "Prods" :: s          => "uniqueSums" :: fixAbbreviation s
   | "Unique" :: "Prods" :: s          => "UniqueSums" :: fixAbbreviation s
   | "order" :: "Of" :: s              => "addOrderOf" :: fixAbbreviation s

--- a/Mathlib/Tactic/ToAdditive.lean
+++ b/Mathlib/Tactic/ToAdditive.lean
@@ -731,6 +731,7 @@ def nameDict : String → List String
   | "prehaar"     => ["add", "Prehaar"]
   | "unit"        => ["add", "Unit"]
   | "units"       => ["add", "Units"]
+  | "prods"       => ["sums"]  -- convert `[uU]niqueProds` to `[uU]niqueSums`
   | "rootable"    => ["divisible"]
   | x             => [x]
 

--- a/Mathlib/Tactic/ToAdditive.lean
+++ b/Mathlib/Tactic/ToAdditive.lean
@@ -731,7 +731,6 @@ def nameDict : String → List String
   | "prehaar"     => ["add", "Prehaar"]
   | "unit"        => ["add", "Unit"]
   | "units"       => ["add", "Units"]
-  | "prods"       => ["sums"]  -- convert `[uU]niqueProds` to `[uU]niqueSums`
   | "rootable"    => ["divisible"]
   | x             => [x]
 
@@ -799,6 +798,10 @@ def fixAbbreviation : List String → List String
   | "ZSmul" :: s                      => "ZSMul" :: fixAbbreviation s -- from `ZPow`
   | "neg" :: "Fun" :: s               => "invFun" :: fixAbbreviation s
   | "Neg" :: "Fun" :: s               => "InvFun" :: fixAbbreviation s
+  | "unique" :: "Mul" :: s            => "uniqueAdd" :: fixAbbreviation s
+  | "Unique" :: "Mul" :: s            => "UniqueAdd" :: fixAbbreviation s
+  | "unique" :: "Prods" :: s          => "uniqueSums" :: fixAbbreviation s
+  | "Unique" :: "Prods" :: s          => "UniqueSums" :: fixAbbreviation s
   | "order" :: "Of" :: s              => "addOrderOf" :: fixAbbreviation s
   | "Order" :: "Of" :: s              => "AddOrderOf" :: fixAbbreviation s
   | "is"::"Of"::"Fin"::"Order"::s     => "isOfFinAddOrder" :: fixAbbreviation s


### PR DESCRIPTION
This PR adds `to_additive` support to convert
* `UniqueProds` to `UniqueSums` and
* `uniqueProds` to `uniqueSums`.

This is just the dictionary support, plus the removal of two, now correctly guessed, `to_additive` names.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
