### PR TITLE
[Merged by Bors] - feat: make mk_iff produce terms with default lambda binders in exists

### DIFF
--- a/test/MkIffOfInductive.lean
+++ b/test/MkIffOfInductive.lean
@@ -8,6 +8,12 @@ example {α : Type _} (R : α → α → Prop) (a : α) (al : List α) :
       al = List.nil ∨ ∃ (b : α) (l : List α), R a b ∧ List.Chain R b l ∧ al = b :: l :=
   test.chain_iff R a al
 
+-- check that the statement prints nicely
+/-- info: test.chain_iff.{u_1} {α : Type u_1} (R : α → α → Prop) (a✝ : α) (a✝¹ : List α) :
+  List.Chain R a✝ a✝¹ ↔ a✝¹ = [] ∨ ∃ b l, R a✝ b ∧ List.Chain R b l ∧ a✝¹ = b :: l -/
+#guard_msgs in
+#check test.chain_iff
+
 mk_iff_of_inductive_prop False    test.false_iff
 example : False ↔ False := test.false_iff
 


### PR DESCRIPTION
Previously the produced lemmas could look bad with the default exists delaborator i.e.
https://leanprover-community.github.io/mathlib4_docs/Mathlib/Data/Multiset/Basic.html#Multiset.Rel_iff

I see no reason to keep the implicitness of the original inductive in an existential

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
