### PR TITLE
[Merged by Bors] - feat: Data.Finset.NatAntidiagonal.antidiagonal_equiv_fin

### DIFF
--- a/Mathlib/Data/Finset/NatAntidiagonal.lean
+++ b/Mathlib/Data/Finset/NatAntidiagonal.lean
@@ -101,17 +101,28 @@ theorem antidiagonal_congr {n : ℕ} {p q : ℕ × ℕ} (hp : p ∈ antidiagonal
   rw [hq, ← h, hp]
 #align finset.nat.antidiagonal_congr Finset.Nat.antidiagonal_congr
 
+/-- A point in the antidiagonal is determined by its first co-ordinate (subtype version of
+`antidiagonal_congr`). This lemma is used by the `ext` tactic. -/
+@[ext] theorem antidiagonal_subtype_ext {n : ℕ} {p q : antidiagonal n} (h : p.val.1 = q.val.1) :
+    p = q := Subtype.ext ((antidiagonal_congr p.prop q.prop).mpr h)
+
 theorem antidiagonal.fst_le {n : ℕ} {kl : ℕ × ℕ} (hlk : kl ∈ antidiagonal n) : kl.1 ≤ n := by
   rw [le_iff_exists_add]
   use kl.2
   rwa [mem_antidiagonal, eq_comm] at hlk
 #align finset.nat.antidiagonal.fst_le Finset.Nat.antidiagonal.fst_le
 
+theorem antidiagonal.fst_lt {n : ℕ} {kl : ℕ × ℕ} (hlk : kl ∈ antidiagonal n) : kl.1 < (n + 1) :=
+  Nat.lt_succ_of_le $ antidiagonal.fst_le hlk
+
 theorem antidiagonal.snd_le {n : ℕ} {kl : ℕ × ℕ} (hlk : kl ∈ antidiagonal n) : kl.2 ≤ n := by
   rw [le_iff_exists_add]
   use kl.1
   rwa [mem_antidiagonal, eq_comm, add_comm] at hlk
 #align finset.nat.antidiagonal.snd_le Finset.Nat.antidiagonal.snd_le
+
+theorem antidiagonal.snd_lt {n : ℕ} {kl : ℕ × ℕ} (hlk : kl ∈ antidiagonal n) : kl.2 < (n + 1) :=
+  Nat.lt_succ_of_le $ antidiagonal.snd_le hlk
 
 theorem filter_fst_eq_antidiagonal (n m : ℕ) :
     filter (fun x : ℕ × ℕ ↦ x.fst = m) (antidiagonal n) = if m ≤ n then {(m, n - m)} else ∅ := by
@@ -202,6 +213,15 @@ def sigmaAntidiagonalEquivProd : (Σn : ℕ, antidiagonal n) ≃ ℕ × ℕ wher
 #align finset.nat.sigma_antidiagonal_equiv_prod_apply Finset.Nat.sigmaAntidiagonalEquivProd_apply
 
 end EquivProd
+
+/-- The set `antidiagonal n` is equivalent to `Fin (n+1)`, via the first projection. --/
+def antidiagonal_equiv_fin (n : ℕ) : antidiagonal n ≃ Fin (n + 1) where
+  toFun := fun ⟨⟨i, j⟩, h⟩ ↦ ⟨i, antidiagonal.fst_lt h⟩
+  invFun := fun ⟨i, h⟩ ↦ ⟨⟨i, n - i⟩, by
+    rw [mem_antidiagonal, add_comm, tsub_add_cancel_iff_le]
+    exact Nat.le_of_lt_succ h⟩
+  left_inv := by rintro ⟨⟨i, j⟩, h⟩; ext; rfl
+  right_inv := fun x ↦ rfl
 
 end Nat
 

--- a/Mathlib/Data/Finset/NatAntidiagonal.lean
+++ b/Mathlib/Data/Finset/NatAntidiagonal.lean
@@ -221,7 +221,7 @@ def antidiagonal_equiv_fin (n : ℕ) : antidiagonal n ≃ Fin (n + 1) where
     rw [mem_antidiagonal, add_comm, tsub_add_cancel_iff_le]
     exact Nat.le_of_lt_succ h⟩
   left_inv := by rintro ⟨⟨i, j⟩, h⟩; ext; rfl
-  right_inv := fun x ↦ rfl
+  right_inv x := rfl
 
 end Nat
 

--- a/Mathlib/Data/Finset/NatAntidiagonal.lean
+++ b/Mathlib/Data/Finset/NatAntidiagonal.lean
@@ -112,7 +112,7 @@ theorem antidiagonal.fst_le {n : ℕ} {kl : ℕ × ℕ} (hlk : kl ∈ antidiagon
   rwa [mem_antidiagonal, eq_comm] at hlk
 #align finset.nat.antidiagonal.fst_le Finset.Nat.antidiagonal.fst_le
 
-theorem antidiagonal.fst_lt {n : ℕ} {kl : ℕ × ℕ} (hlk : kl ∈ antidiagonal n) : kl.1 < (n + 1) :=
+theorem antidiagonal.fst_lt {n : ℕ} {kl : ℕ × ℕ} (hlk : kl ∈ antidiagonal n) : kl.1 < n + 1 :=
   Nat.lt_succ_of_le $ antidiagonal.fst_le hlk
 
 theorem antidiagonal.snd_le {n : ℕ} {kl : ℕ × ℕ} (hlk : kl ∈ antidiagonal n) : kl.2 ≤ n := by
@@ -121,7 +121,7 @@ theorem antidiagonal.snd_le {n : ℕ} {kl : ℕ × ℕ} (hlk : kl ∈ antidiagon
   rwa [mem_antidiagonal, eq_comm, add_comm] at hlk
 #align finset.nat.antidiagonal.snd_le Finset.Nat.antidiagonal.snd_le
 
-theorem antidiagonal.snd_lt {n : ℕ} {kl : ℕ × ℕ} (hlk : kl ∈ antidiagonal n) : kl.2 < (n + 1) :=
+theorem antidiagonal.snd_lt {n : ℕ} {kl : ℕ × ℕ} (hlk : kl ∈ antidiagonal n) : kl.2 < n + 1 :=
   Nat.lt_succ_of_le $ antidiagonal.snd_le hlk
 
 theorem filter_fst_eq_antidiagonal (n m : ℕ) :


### PR DESCRIPTION
as suggested by @ocfnash in https://github.com/leanprover-community/mathlib4/pull/6425#discussion_r1304089614


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
