### PR TITLE
[Merged by Bors] - chore (RingTheory.Congruence): make RingCon extend AddCon and Con

### DIFF
--- a/Mathlib/RingTheory/Congruence.lean
+++ b/Mathlib/RingTheory/Congruence.lean
@@ -86,10 +86,13 @@ instance : FunLike (RingCon R) R fun _ => R → Prop :=
       rw [Setoid.ext_iff,(show x.Rel = y.Rel from h)]
       simp}
 
-@[simp]
 theorem rel_eq_coe : c.r = c :=
   rfl
 #align ring_con.rel_eq_coe RingCon.rel_eq_coe
+
+@[simp]
+theorem toCon_coe_eq_coe : (c.toCon : R → R → Prop) = c :=
+  rfl
 
 protected theorem refl (x) : c x x :=
   c.refl' x

--- a/Mathlib/RingTheory/Congruence.lean
+++ b/Mathlib/RingTheory/Congruence.lean
@@ -36,7 +36,7 @@ Most of the time you likely want to use the `Ideal.Quotient` API that is built o
 
 /-- A congruence relation on a type with an addition and multiplication is an equivalence relation
 which preserves both. -/
-structure RingCon (R : Type*) [Add R] [Mul R] extends AddCon R, Con R where
+structure RingCon (R : Type*) [Add R] [Mul R] extends Con R, AddCon R where
 #align ring_con RingCon
 
 attribute [inherit_doc RingCon] RingCon.toCon RingCon.toAddCon

--- a/Mathlib/RingTheory/Congruence.lean
+++ b/Mathlib/RingTheory/Congruence.lean
@@ -34,16 +34,12 @@ Most of the time you likely want to use the `Ideal.Quotient` API that is built o
 -/
 
 
-/- Note: we can't extend both `AddCon R` and `MulCon R` in Lean 3 due to interactions between old-
-and new-style structures. We can revisit this in Lean 4. (After and not during the port!) -/
 /-- A congruence relation on a type with an addition and multiplication is an equivalence relation
 which preserves both. -/
 structure RingCon (R : Type*) [Add R] [Mul R] extends AddCon R, Con R where
-  -- /-- Ring congruence relations are closed under addition -/
-  -- add' : ∀ {w x y z}, r w x → r y z → r (w + y) (x + z)
-  -- /-- Ring congruence relations are closed under multiplication -/
-  -- mul' : ∀ {w x y z}, r w x → r y z → r (w * y) (x * z)
 #align ring_con RingCon
+
+attribute [inherit_doc RingCon] RingCon.toCon RingCon.toAddCon
 
 variable {α R : Type*}
 
@@ -62,8 +58,7 @@ inductive RingConGen.Rel [Add R] [Mul R] (r : R → R → Prop) : R → R → Pr
 
 /-- The inductively defined smallest ring congruence relation containing a given binary
     relation. -/
-def ringConGen [Add R] [Mul R] (r : R → R → Prop) : RingCon R
-    where
+def ringConGen [Add R] [Mul R] (r : R → R → Prop) : RingCon R where
   r := RingConGen.Rel r
   iseqv := ⟨RingConGen.Rel.refl, @RingConGen.Rel.symm _ _ _ _, @RingConGen.Rel.trans _ _ _ _⟩
   add' := RingConGen.Rel.add
@@ -76,16 +71,6 @@ section Basic
 
 variable [Add R] [Mul R] (c : RingCon R)
 
--- /-- Every `RingCon` is also an `AddCon` -/
--- def toAddCon : AddCon R :=
-  -- { c with }
--- #align ring_con.to_add_con RingCon.toAddCon
-
--- /-- Every `RingCon` is also a `Con` -/
--- def toCon : Con R :=
-  -- { c with }
--- #align ring_con.to_con RingCon.toCon
-
 --Porting note: upgrade to `FunLike`
 /-- A coercion from a congruence relation to its underlying binary relation. -/
 instance : FunLike (RingCon R) R fun _ => R → Prop :=
@@ -97,7 +82,6 @@ instance : FunLike (RingCon R) R fun _ => R → Prop :=
       rw [Setoid.ext_iff,(show x.Rel = y.Rel from h)]
       simp}
 
-@[simp]
 theorem rel_eq_coe : c.r = c :=
   rfl
 #align ring_con.rel_eq_coe RingCon.rel_eq_coe
@@ -121,11 +105,6 @@ protected theorem add {w x y z} : c w x → c y z → c (w + y) (x + z) :=
 protected theorem mul {w x y z} : c w x → c y z → c (w * y) (x * z) :=
   c.mul'
 #align ring_con.mul RingCon.mul
-
--- @[simp]
--- theorem rel_mk {s : Setoid R} {ha hm a b} : RingCon.mk s ha hm a b ↔ Setoid.r a b :=
---   Iff.rfl
--- #align ring_con.rel_mk RingCon.rel_mk
 
 instance : Inhabited (RingCon R) :=
   ⟨ringConGen EmptyRelation⟩

--- a/Mathlib/RingTheory/Congruence.lean
+++ b/Mathlib/RingTheory/Congruence.lean
@@ -39,7 +39,11 @@ which preserves both. -/
 structure RingCon (R : Type*) [Add R] [Mul R] extends Con R, AddCon R where
 #align ring_con RingCon
 
-attribute [inherit_doc RingCon] RingCon.toCon RingCon.toAddCon
+/-- The induced multiplicative congruence from a `RingCon`. -/
+add_decl_doc RingCon.toCon
+
+/-- The induced additive congruence from a `RingCon`. -/
+add_decl_doc RingCon.toAddCon
 
 variable {α R : Type*}
 
@@ -82,6 +86,7 @@ instance : FunLike (RingCon R) R fun _ => R → Prop :=
       rw [Setoid.ext_iff,(show x.Rel = y.Rel from h)]
       simp}
 
+@[simp]
 theorem rel_eq_coe : c.r = c :=
   rfl
 #align ring_con.rel_eq_coe RingCon.rel_eq_coe
@@ -108,6 +113,10 @@ protected theorem mul {w x y z} : c w x → c y z → c (w * y) (x * z) :=
 
 instance : Inhabited (RingCon R) :=
   ⟨ringConGen EmptyRelation⟩
+
+@[simp]
+theorem rel_mk {s : Con R} {h a b} : RingCon.mk s h a b ↔ @Setoid.r _ s.toSetoid a b :=
+  Iff.rfl
 
 end Basic
 


### PR DESCRIPTION
Currently `RingCon` extends `Add` and `Mul`. This changes it to extend `AddCon` and `Con` directly.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
