### PR TITLE
[Merged by Bors] - feat: allow users to expand `field_simp` into a `simp` call

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3417,6 +3417,7 @@ import Mathlib.Util.AtomM
 import Mathlib.Util.CompileInductive
 import Mathlib.Util.CountHeartbeats
 import Mathlib.Util.DummyLabelAttr
+import Mathlib.Util.DischargerAsTactic
 import Mathlib.Util.Export
 import Mathlib.Util.Imports
 import Mathlib.Util.IncludeStr

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3416,8 +3416,8 @@ import Mathlib.Util.AssertNoSorry
 import Mathlib.Util.AtomM
 import Mathlib.Util.CompileInductive
 import Mathlib.Util.CountHeartbeats
-import Mathlib.Util.DummyLabelAttr
 import Mathlib.Util.DischargerAsTactic
+import Mathlib.Util.DummyLabelAttr
 import Mathlib.Util.Export
 import Mathlib.Util.Imports
 import Mathlib.Util.IncludeStr

--- a/Mathlib/Tactic/FieldSimp.lean
+++ b/Mathlib/Tactic/FieldSimp.lean
@@ -9,6 +9,7 @@ import Lean.Meta.Tactic.Simp.Main
 import Std.Lean.Parser
 import Mathlib.Algebra.Group.Units
 import Mathlib.Tactic.NormNum.Core
+import Mathlib.Util.DischargerAsTactic
 import Qq
 
 /-!
@@ -70,6 +71,9 @@ partial def discharge (prop : Expr) : SimpM (Option Expr) :=
     else
       return none
 
+@[inherit_doc discharge]
+elab "field_simp_discharge" : tactic => wrapSimpDischarger Mathlib.Tactic.FieldSimp.discharge
+
 /--
 The goal of `field_simp` is to reduce an expression in a field to an expression of the form `n / d`
 where neither `n` nor `d` contains any division symbol, just using the simplifier (with a carefully
@@ -83,10 +87,10 @@ iterating the following steps:
 - reduce a sum to a common denominator
 
 If the goal is an equality, this simpset will also clear the denominators, so that the proof
-can normally be concluded by an application of `ring` or `ring_exp`.
+can normally be concluded by an application of `ring`.
 
 `field_simp [hx, hy]` is a short form for
-`simp (discharger := Tactic.FieldSimp.discharge) [-one_div, -mul_eq_zero, hx, hy, field_simps]`
+`simp (disch := field_simp_discharge) [-one_div, -one_divp, -mul_eq_zero, hx, hy, field_simps]`
 
 Note that this naive algorithm will not try to detect common factors in denominators to reduce the
 complexity of the resulting expression. Instead, it relies on the ability of `ring` to handle
@@ -122,7 +126,7 @@ a general (commutative) monoid/ring and partial division `/ₚ`, see `Algebra.Gr
 for the definition. Analogue to the case above, the lemma `one_divp` is removed from the simpset
 as this works against the algorithm. If you have objects with an `IsUnit x` instance like
 `(x : R) (hx : IsUnit x)`, you should lift them with
-`lift x to Rˣ using id hx, rw [IsUnit.unit_of_val_units] clear hx`
+`lift x to Rˣ using id hx; rw [IsUnit.unit_of_val_units] clear hx`
 before using `field_simp`.
 
 See also the `cancel_denoms` tactic, which tries to do a similar simplification for expressions

--- a/Mathlib/Util/DischargerAsTactic.lean
+++ b/Mathlib/Util/DischargerAsTactic.lean
@@ -9,7 +9,7 @@ import Std.Tactic.Exact
 ## Dischargers for `simp` to tactics
 
 This file defines a wrapper for `Simp.Discharger`s as regular tactics, that allows them to be
-used via the tactic frontend of `simp` via `simp (discharger := my_discharger)`.
+used via the tactic frontend of `simp` via `simp (discharger := wrapSimpDischarger my_discharger)`.
 -/
 
 open Lean Meta Elab Tactic

--- a/Mathlib/Util/DischargerAsTactic.lean
+++ b/Mathlib/Util/DischargerAsTactic.lean
@@ -1,0 +1,24 @@
+/-
+Copyright (c) 2023 Alex J. Best. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Alex J. Best
+-/
+import Std.Tactic.Exact
+
+/-!
+## Dischargers for `simp` to tactics
+
+This file defines a wrapper for `Simp.Discharger`s as regular tactics, that allows them to be
+used via the tactic frontend of `simp` via `simp (discharger := my_discharger)`.
+-/
+
+open Lean Meta Elab Tactic
+
+/-- Wrap an simp discharger (a function `Expr → SimpM (Option Expr)`) as a tactic,
+so that it can be passed as an argument to `simp (discharger := foo)`.
+This is inverse to `mkDischargeWrapper`. -/
+def wrapSimpDischarger (dis : Simp.Discharge) : TacticM Unit := do
+  let eS : Lean.Meta.Simp.State := {}
+  let eC : Lean.Meta.Simp.Context := {}
+  let (some a, _) ← liftM <| StateRefT'.run (ReaderT.run (dis <| ← getMainTarget) eC) eS | failure
+  (← getMainGoal).assignIfDefeq a

--- a/test/FieldSimp.lean
+++ b/test/FieldSimp.lean
@@ -63,3 +63,8 @@ example (x : ℚ) (h₀ : x ≠ 0) :
 example {x y z w : ℚ} (h : x / y = z / w) (hy : y ≠ 0) (hw : w ≠ 0) : x * w = z * y := by
   field_simp at h
   assumption
+
+-- An example of "unfolding" `field_simps` to its "definition"
+example {aa : ℚ} (ha : (aa : ℚ) ≠ 0) (hb : 2 * aa = 3) : (1 : ℚ) / aa = 2/ 3 := by
+  simp (disch := field_simp_discharge) [-one_div, -one_divp, -mul_eq_zero, field_simps]
+  rw [hb]


### PR DESCRIPTION
This should allow users to debug what `field_simp` is doing more easily.
And a little bit of miscellaneous cleanup of the field_simp doc.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
