### PR TITLE
[Merged by Bors] - feat: pullbacks in Stonean where one map is an open embedding

### DIFF
--- a/Mathlib/Topology/Category/Stonean/EffectiveEpi.lean
+++ b/Mathlib/Topology/Category/Stonean/EffectiveEpi.lean
@@ -244,9 +244,9 @@ theorem _root_.CategoryTheory.EffectiveEpiFamily.toCompHaus
 instance instPrecoherent: Precoherent Stonean.{u} := by
   constructor
   intro B₁ B₂ f α _ X₁ π₁ h₁
-  refine ⟨α, inferInstance, fun a => (pullback f (π₁ a)).presentation, fun a =>
-    toCompHaus.preimage (presentation.π _ ≫ (pullback.fst _ _)), ?_, id, fun a =>
-    toCompHaus.preimage (presentation.π _ ≫ (pullback.snd _ _ )), fun a => ?_⟩
+  refine ⟨α, inferInstance, fun a => (CompHaus.pullback f (π₁ a)).presentation, fun a =>
+    toCompHaus.preimage (presentation.π _ ≫ (CompHaus.pullback.fst _ _)), ?_, id, fun a =>
+    toCompHaus.preimage (presentation.π _ ≫ (CompHaus.pullback.snd _ _ )), fun a => ?_⟩
   · refine ((effectiveEpiFamily_tfae _ _).out 0 2).2 (fun b => ?_)
     have h₁' := ((CompHaus.effectiveEpiFamily_tfae _ _).out 0 2).1 h₁.toCompHaus
     obtain ⟨a, x, h⟩ := h₁' (f b)

--- a/Mathlib/Topology/Category/Stonean/Limits.lean
+++ b/Mathlib/Topology/Category/Stonean/Limits.lean
@@ -152,8 +152,7 @@ def pullback : Stonean where
       exact IsCompact.image isCompact_univ i.continuous
     is_hausdorff := by
       dsimp [TopCat.of]
-      exact inferInstance
-  }
+      exact inferInstance }
   extrDisc := by
     constructor
     intro U hU

--- a/Mathlib/Topology/Category/Stonean/Limits.lean
+++ b/Mathlib/Topology/Category/Stonean/Limits.lean
@@ -263,25 +263,22 @@ section Isos
 @[simps]
 noncomputable
 def pullbackIsoPullback : Stonean.pullback f hi ≅
-    @Limits.pullback _ _ _ _ _ f i (HasPullbackOpenEmbedding f hi) where
-  hom :=
-    haveI : HasPullback f i := HasPullbackOpenEmbedding f hi
-    Limits.pullback.lift (pullback.fst _ hi) (pullback.snd _ hi) (pullback.condition f hi)
-  inv :=
-    haveI : HasPullback f i := HasPullbackOpenEmbedding f hi
-    pullback.lift f hi Limits.pullback.fst Limits.pullback.snd Limits.pullback.condition
-  hom_inv_id :=
-    haveI : HasPullback f i := HasPullbackOpenEmbedding f hi
-    pullback.hom_ext f hi _ _ (by simp only [pullback.cone_pt, Category.assoc,
-      pullback.lift_fst, limit.lift_π, PullbackCone.mk_pt, PullbackCone.mk_π_app, Category.id_comp])
-  inv_hom_id := by
-    haveI : HasPullback f i := HasPullbackOpenEmbedding f hi
-    refine' Limits.pullback.hom_ext (k := (pullback.lift f hi Limits.pullback.fst
-      Limits.pullback.snd Limits.pullback.condition ≫ Limits.pullback.lift
-      (pullback.fst _ hi) (pullback.snd _ hi) (pullback.condition f hi))) _ _
-    · simp only [Category.assoc, limit.lift_π, PullbackCone.mk_pt, PullbackCone.mk_π_app,
-        pullback.lift_fst, Category.id_comp]
-    · rw [Category.id_comp, Category.assoc, Limits.pullback.lift_snd, pullback.lift_snd]
+    @Limits.pullback _ _ _ _ _ f i (HasPullbackOpenEmbedding f hi) :=
+  haveI : HasPullback f i := HasPullbackOpenEmbedding f hi
+  { hom :=
+      Limits.pullback.lift (pullback.fst _ hi) (pullback.snd _ hi) (pullback.condition f hi)
+    inv :=
+      pullback.lift f hi Limits.pullback.fst Limits.pullback.snd Limits.pullback.condition
+    hom_inv_id :=
+      pullback.hom_ext f hi _ _ (by simp only [pullback.cone_pt, Category.assoc,
+        pullback.lift_fst, limit.lift_π, PullbackCone.mk_pt, PullbackCone.mk_π_app, Category.id_comp])
+    inv_hom_id := by
+      refine' Limits.pullback.hom_ext (k := (pullback.lift f hi Limits.pullback.fst
+        Limits.pullback.snd Limits.pullback.condition ≫ Limits.pullback.lift
+        (pullback.fst _ hi) (pullback.snd _ hi) (pullback.condition f hi))) _ _
+      · simp only [Category.assoc, limit.lift_π, PullbackCone.mk_pt, PullbackCone.mk_π_app,
+          pullback.lift_fst, Category.id_comp]
+      · rw [Category.id_comp, Category.assoc, Limits.pullback.lift_snd, pullback.lift_snd] }
 
 end Isos
 

--- a/Mathlib/Topology/Category/Stonean/Limits.lean
+++ b/Mathlib/Topology/Category/Stonean/Limits.lean
@@ -270,8 +270,8 @@ def pullbackIsoPullback : Stonean.pullback f hi ≅
     inv :=
       pullback.lift f hi Limits.pullback.fst Limits.pullback.snd Limits.pullback.condition
     hom_inv_id :=
-      pullback.hom_ext f hi _ _ (by simp only [pullback.cone_pt, Category.assoc,
-        pullback.lift_fst, limit.lift_π, PullbackCone.mk_pt, PullbackCone.mk_π_app, Category.id_comp])
+      pullback.hom_ext f hi _ _ (by simp only [pullback.cone_pt, Category.assoc, pullback.lift_fst,
+        limit.lift_π, PullbackCone.mk_pt, PullbackCone.mk_π_app, Category.id_comp])
     inv_hom_id := by
       refine' Limits.pullback.hom_ext (k := (pullback.lift f hi Limits.pullback.fst
         Limits.pullback.snd Limits.pullback.condition ≫ Limits.pullback.lift

--- a/Mathlib/Topology/Category/Stonean/Limits.lean
+++ b/Mathlib/Topology/Category/Stonean/Limits.lean
@@ -27,7 +27,7 @@ This section defines the finite Coproduct of a finite family
 of profinite spaces `X : α → Stonean.{u}`
 
 Notes: The content is mainly copied from
-`Mathlib/Topology/Category/CompHaus/ExplicitLimits.lean`
+`Mathlib/Topology/Category/CompHaus/Limits.lean`
 -/
 section FiniteCoproducts
 

--- a/Mathlib/Topology/Category/Stonean/Limits.lean
+++ b/Mathlib/Topology/Category/Stonean/Limits.lean
@@ -1,19 +1,18 @@
 /-
 Copyright (c) 2023 Adam Topaz. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Adam Topaz
+Authors: Adam Topaz, Dagur Asgeirsson, Filippo A. E. Nuccio, Riccardo Brasca
 -/
 import Mathlib.Topology.Category.Stonean.Basic
 /-!
-# Explicit (co)limits in Extremally disconnected sets
+# Explicit (co)limits in the category of Stonean spaces
 
 This file describes some explicit (co)limits in `Stonean`
 
 ## Overview
 
-We define explicit finite coproducts in `Stonean` as sigma types (disjoint unions).
-
-TODO: Define pullbacks of open embeddings.
+We define explicit finite coproducts in `Stonean` as sigma types (disjoint unions) and explicit
+pullbacks where one of the maps is an open embedding
 
 -/
 
@@ -129,3 +128,164 @@ Limits.IsColimit.coconePointUniqueUpToIso
 end FiniteCoproducts
 
 end Stonean
+
+section Pullback
+
+open CategoryTheory Limits
+
+namespace Stonean
+
+variable {X Y Z : Stonean} (f : X ⟶ Z) {i : Y ⟶ Z} (hi : OpenEmbedding i)
+
+/--
+The pullback of a morphism `f` and an open embedding `i` in `Stonean`, constructed explicitly as
+the preimage under `f`of the image of `i` with the subspace topology.
+-/
+def pullback : Stonean where
+  compHaus := {
+    toTop := TopCat.of (f ⁻¹' (Set.range i))
+    is_compact := by
+      dsimp [TopCat.of]
+      rw [← isCompact_iff_compactSpace]
+      refine IsClosed.isCompact (IsClosed.preimage f.continuous (IsCompact.isClosed ?_))
+      simp only [← Set.image_univ]
+      exact IsCompact.image isCompact_univ i.continuous
+    is_hausdorff := by
+      dsimp [TopCat.of]
+      exact inferInstance
+  }
+  extrDisc := by
+    constructor
+    intro U hU
+    dsimp at U
+    have h : IsClopen (f ⁻¹' (Set.range i))
+    · constructor
+      · exact IsOpen.preimage f.continuous hi.open_range
+      · refine' IsClosed.preimage f.continuous _
+        apply IsCompact.isClosed
+        simp only [← Set.image_univ]
+        exact IsCompact.image isCompact_univ i.continuous
+    have hU' : IsOpen (Subtype.val '' U) := h.1.openEmbedding_subtype_val.isOpenMap U hU
+    have := ExtremallyDisconnected.open_closure _ hU'
+    rw [h.2.closedEmbedding_subtype_val.closure_image_eq U] at this
+    suffices hhU : closure U = Subtype.val ⁻¹' (Subtype.val '' (closure U))
+    · rw [hhU]
+      exact isOpen_induced this
+    exact ((closure U).preimage_image_eq Subtype.coe_injective).symm
+
+/-- The projection from the pullback to the first component. -/
+def pullback.fst : pullback f hi ⟶ X :=
+  ⟨Subtype.val, continuous_subtype_val⟩
+
+/-- The projection from the pullback to the second component. -/
+noncomputable
+def pullback.snd : pullback f hi ⟶ Y :=
+  ⟨(Homeomorph.ofEmbedding i hi.toEmbedding).symm ∘
+    Set.MapsTo.restrict f _ _ (Set.mapsTo_preimage f (Set.range i)),
+    (Homeomorph.ofEmbedding i hi.toEmbedding).symm.continuous.comp (Continuous.restrict
+    (Set.mapsTo_preimage f (Set.range i)) f.continuous)⟩
+
+/--
+Construct a morphism to the explicit pullback given morphisms to the factors
+which are compatible with the maps to the base.
+This is essentially the universal property of the pullback.
+-/
+def pullback.lift {X Y Z W : Stonean} (f : X ⟶ Z) {i : Y ⟶ Z} (hi : OpenEmbedding i)
+    (a : W ⟶ X) (b : W ⟶ Y) (w : a ≫ f = b ≫ i) :
+    W ⟶ pullback f hi where
+  toFun := fun z => ⟨a z, by
+    simp only [Set.mem_preimage]
+    use (b z)
+    exact congr_fun (FunLike.ext'_iff.mp w.symm) z⟩
+  continuous_toFun := by
+    apply Continuous.subtype_mk
+    exact a.continuous
+
+lemma pullback.condition {X Y Z : Stonean.{u}} (f : X ⟶ Z) {i : Y ⟶ Z}
+    (hi : OpenEmbedding i) : pullback.fst f hi ≫ f = pullback.snd f hi ≫ i := by
+  ext ⟨x, h⟩
+  simp only [Set.mem_preimage] at h
+  obtain ⟨y, hy⟩ := h
+  simp only [fst, snd, comp_apply]
+  change f x = _
+  rw [← hy, @ContinuousMap.coe_mk _ _ (Stonean.instTopologicalSpace (pullback f hi)) _ _ _]
+  congr
+  apply_fun (Homeomorph.ofEmbedding i hi.toEmbedding)
+  simpa only [Homeomorph.ofEmbedding, Homeomorph.homeomorph_mk_coe, Equiv.ofInjective_apply,
+    Homeomorph.homeomorph_mk_coe_symm, Set.MapsTo.restrict, Subtype.map, Function.comp_apply,
+    Equiv.apply_symm_apply, Subtype.mk.injEq]
+
+@[reassoc (attr := simp)]
+lemma pullback.lift_fst {W : Stonean} (a : W ⟶ X) (b : W ⟶ Y) (w : a ≫ f = b ≫ i) :
+  pullback.lift f hi a b w ≫ pullback.fst f hi = a := rfl
+
+@[reassoc (attr := simp)]
+lemma pullback.lift_snd {X Y Z W : Stonean} (f : X ⟶ Z) {i : Y ⟶ Z} (hi : OpenEmbedding i)
+    (a : W ⟶ X) (b : W ⟶ Y) (w : a ≫ f = b ≫ i) :
+    pullback.lift f hi a b w ≫ Stonean.pullback.snd f hi = b := by
+  congr
+  ext z
+  have := congr_fun (FunLike.ext'_iff.mp w.symm) z
+  have h : i (b z) = f (a z) := this
+  suffices : b z = (Homeomorph.ofEmbedding i hi.toEmbedding).symm (⟨f (a z), by rw [← h] ; simp⟩)
+  · exact this.symm
+  apply_fun (Homeomorph.ofEmbedding i hi.toEmbedding)
+  simpa only [Homeomorph.ofEmbedding, Homeomorph.homeomorph_mk_coe, Equiv.ofInjective_apply,
+    Homeomorph.homeomorph_mk_coe_symm, Equiv.apply_symm_apply, Subtype.mk.injEq]
+
+/-- The pullback cone whose cone point is the explicit pullback. -/
+@[simps! pt π]
+noncomputable
+def pullback.cone : Limits.PullbackCone f i :=
+  Limits.PullbackCone.mk (pullback.fst f hi) (pullback.snd f hi) (pullback.condition f hi)
+
+lemma pullback.hom_ext {X Y Z W : Stonean} (f : X ⟶ Z) {i : Y ⟶ Z} (hi : OpenEmbedding i)
+    (a : W ⟶ (pullback.cone f hi).pt) (b : W ⟶ (pullback.cone f hi).pt)
+    (hfst : a ≫ pullback.fst f hi = b ≫ pullback.fst f hi) : a = b := by
+  ext z
+  apply_fun (fun q => q z) at hfst
+  apply Subtype.ext
+  exact hfst
+
+/-- The explicit pullback cone is a limit cone. -/
+def pullback.isLimit  : IsLimit (pullback.cone f hi) :=
+  Limits.PullbackCone.isLimitAux _
+    (fun s => pullback.lift f hi s.fst s.snd s.condition)
+    (fun _ => pullback.lift_fst _ _ _ _ _)
+    (fun _ => pullback.lift_snd _ _ _ _ _)
+    (fun _ _ hm => pullback.hom_ext _ _ _ _ (hm .left))
+
+instance HasPullbackOpenEmbedding : HasPullback f i :=
+  ⟨pullback.cone f hi, pullback.isLimit f hi⟩
+
+section Isos
+
+/-- The isomorphism from the explicit pullback to the abstract pullback. -/
+@[simps]
+noncomputable
+def pullbackIsoPullback : Stonean.pullback f hi ≅
+    @Limits.pullback _ _ _ _ _ f i (HasPullbackOpenEmbedding f hi) where
+  hom :=
+    haveI : HasPullback f i := HasPullbackOpenEmbedding f hi
+    Limits.pullback.lift (pullback.fst _ hi) (pullback.snd _ hi) (pullback.condition f hi)
+  inv :=
+    haveI : HasPullback f i := HasPullbackOpenEmbedding f hi
+    pullback.lift f hi Limits.pullback.fst Limits.pullback.snd Limits.pullback.condition
+  hom_inv_id :=
+    haveI : HasPullback f i := HasPullbackOpenEmbedding f hi
+    pullback.hom_ext f hi _ _ (by simp only [pullback.cone_pt, Category.assoc,
+      pullback.lift_fst, limit.lift_π, PullbackCone.mk_pt, PullbackCone.mk_π_app, Category.id_comp])
+  inv_hom_id := by
+    haveI : HasPullback f i := HasPullbackOpenEmbedding f hi
+    refine' Limits.pullback.hom_ext (k := (pullback.lift f hi Limits.pullback.fst
+      Limits.pullback.snd Limits.pullback.condition ≫ Limits.pullback.lift
+      (pullback.fst _ hi) (pullback.snd _ hi) (pullback.condition f hi))) _ _
+    · simp only [Category.assoc, limit.lift_π, PullbackCone.mk_pt, PullbackCone.mk_π_app,
+        pullback.lift_fst, Category.id_comp]
+    · rw [Category.id_comp, Category.assoc, Limits.pullback.lift_snd, pullback.lift_snd]
+
+end Isos
+
+end Stonean
+
+end Pullback

--- a/Mathlib/Topology/Category/Stonean/Limits.lean
+++ b/Mathlib/Topology/Category/Stonean/Limits.lean
@@ -255,7 +255,7 @@ def pullback.isLimit  : IsLimit (pullback.cone f hi) :=
     (fun _ => pullback.lift_snd _ _ _ _ _)
     (fun _ _ hm => pullback.hom_ext _ _ _ _ (hm .left))
 
-instance HasPullbackOpenEmbedding : HasPullback f i :=
+lemma HasPullbackOpenEmbedding : HasPullback f i :=
   ⟨pullback.cone f hi, pullback.isLimit f hi⟩
 
 section Isos

--- a/Mathlib/Topology/Category/Stonean/Limits.lean
+++ b/Mathlib/Topology/Category/Stonean/Limits.lean
@@ -227,7 +227,7 @@ lemma pullback.lift_snd {X Y Z W : Stonean} (f : X ⟶ Z) {i : Y ⟶ Z} (hi : Op
   ext z
   have := congr_fun (FunLike.ext'_iff.mp w.symm) z
   have h : i (b z) = f (a z) := this
-  suffices : b z = (Homeomorph.ofEmbedding i hi.toEmbedding).symm (⟨f (a z), by rw [← h] ; simp⟩)
+  suffices : b z = (Homeomorph.ofEmbedding i hi.toEmbedding).symm (⟨f (a z), by rw [← h]; simp⟩)
   · exact this.symm
   apply_fun (Homeomorph.ofEmbedding i hi.toEmbedding)
   simpa only [Homeomorph.ofEmbedding, Homeomorph.homeomorph_mk_coe, Equiv.ofInjective_apply,


### PR DESCRIPTION
We define pullbacks in `Stonean` of pairs `f`, `i` where `i` is an open embedding, explicitly as the inverse image under `f` of the image of `i`.

Co-authored-by: Riccardo Brasca @riccardobrasca [riccardo.brasca@gmail.com](mailto:riccardo.brasca@gmail.com)
Co-authored-by: Filippo A E Nuccio @faenuccio [filippo.nuccio@univ-st-etienne.fr](mailto:filippo.nuccio@univ-st-etienne.fr)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
