### PR TITLE
[Merged by Bors] - feat: have library search use the whole range for replacement

### DIFF
--- a/Mathlib/Tactic/LibrarySearch.lean
+++ b/Mathlib/Tactic/LibrarySearch.lean
@@ -277,11 +277,11 @@ def exact? (tk : Syntax) (required : Option (Array (TSyntax `term))) (requireClo
     else
       addExactSuggestion tk (← instantiateMVars (mkMVar mvar)).headBeta
 
-elab_rules : tactic | `(tactic| exact?%$tk $[using $[$required],*]?) => do
-  exact? tk required true
+elab_rules : tactic | `(tactic| exact? $[using $[$required],*]?) => do
+  exact? (← getRef) required true
 
-elab_rules : tactic | `(tactic| apply?%$tk $[using $[$required],*]?) => do
-  exact? tk required false
+elab_rules : tactic | `(tactic| apply? $[using $[$required],*]?) => do
+  exact? (← getRef) required false
 
 elab tk:"library_search" : tactic => do
   logWarning ("`library_search` has been renamed to `apply?`" ++


### PR DESCRIPTION
previously `apply? using h` would replace to `refine blah using h` rather than `refine blah`.

This also changes the diagnostic message to be on the whole syntax `apply? using h` rather than just the `apply?` bit, which seems fine to me.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
