### PR TITLE
[Merged by Bors] - refactor(LinearAlgebra/CliffordAlgebra/Conjugation): expose implementation details of 'reverse'

### DIFF
--- a/Mathlib/Algebra/Algebra/Equiv.lean
+++ b/Mathlib/Algebra/Algebra/Equiv.lean
@@ -603,7 +603,7 @@ theorem toAlgHom_toLinearMap : (e : A₁ →ₐ[R] A₂).toLinearMap = e.toLinea
 #align alg_equiv.to_alg_hom_to_linear_map AlgEquiv.toAlgHom_toLinearMap
 
 theorem toLinearMap_ofAlgHom (f : A₁ →ₐ[R] A₂) (g : A₂ →ₐ[R] A₁) (h₁ h₂) :
-    (ofAlgHom f g h₁ h₂).toLinearMap = f :=
+    (ofAlgHom f g h₁ h₂).toLinearMap = f.toLinearMap :=
   LinearMap.ext fun _ => rfl
 
 @[simp]

--- a/Mathlib/Algebra/Algebra/Equiv.lean
+++ b/Mathlib/Algebra/Algebra/Equiv.lean
@@ -602,6 +602,10 @@ theorem toAlgHom_toLinearMap : (e : A₁ →ₐ[R] A₂).toLinearMap = e.toLinea
   rfl
 #align alg_equiv.to_alg_hom_to_linear_map AlgEquiv.toAlgHom_toLinearMap
 
+theorem toLinearMap_ofAlgHom (f : A₁ →ₐ[R] A₂) (g : A₂ →ₐ[R] A₁) (h₁ h₂) :
+    (ofAlgHom f g h₁ h₂).toLinearMap = f :=
+  LinearMap.ext fun _ => rfl
+
 @[simp]
 theorem toLinearEquiv_toLinearMap : e.toLinearEquiv.toLinearMap = e.toLinearMap :=
   rfl

--- a/Mathlib/LinearAlgebra/CliffordAlgebra/Conjugation.lean
+++ b/Mathlib/LinearAlgebra/CliffordAlgebra/Conjugation.lean
@@ -80,19 +80,24 @@ section Reverse
 
 open MulOpposite
 
-/-- `CliffordAlgebra.reverse` as an `AlgEquiv` to the opposite algebra -/
-def reverseOp : CliffordAlgebra Q ≃ₐ[R] (CliffordAlgebra Q)ᵐᵒᵖ :=
-  letI hom : CliffordAlgebra Q →ₐ[R] (CliffordAlgebra Q)ᵐᵒᵖ := CliffordAlgebra.lift Q
-      ⟨(MulOpposite.opLinearEquiv R).toLinearMap ∘ₗ ι Q, fun m => unop_injective <| by simp⟩
-  AlgEquiv.ofAlgHom hom (AlgHom.opComm hom)
-    (AlgHom.unop.injective <| hom_ext <| LinearMap.ext <| fun _ => by simp)
-    (hom_ext <| LinearMap.ext <| fun _ => by simp)
+/-- `CliffordAlgebra.reverse` as an `AlgHom` to the opposite algebra -/
+def reverseOp : CliffordAlgebra Q →ₐ[R] (CliffordAlgebra Q)ᵐᵒᵖ :=
+  CliffordAlgebra.lift Q
+    ⟨(MulOpposite.opLinearEquiv R).toLinearMap ∘ₗ ι Q, fun m => unop_injective <| by simp⟩
 
 @[simp]
 theorem reverseOp_ι (m : M) : reverseOp (ι Q m) = op (ι Q m) := lift_ι_apply _ _ _
 
+/-- `CliffordAlgebra.reverseEquiv` as an `AlgEquiv` to the opposite algebra -/
+@[simps! apply]
+def reverseOpEquiv : CliffordAlgebra Q ≃ₐ[R] (CliffordAlgebra Q)ᵐᵒᵖ :=
+  AlgEquiv.ofAlgHom reverseOp (AlgHom.opComm reverseOp)
+    (AlgHom.unop.injective <| hom_ext <| LinearMap.ext <| fun _ => by simp)
+    (hom_ext <| LinearMap.ext <| fun _ => by simp)
+
 @[simp]
-theorem reverseOp_opComm : AlgEquiv.opComm (reverseOp (Q := Q)) = reverseOp.symm := rfl
+theorem reverseOpEquiv_opComm :
+  AlgEquiv.opComm (reverseOpEquiv (Q := Q)) = reverseOpEquiv.symm := rfl
 
 /-- Grade reversion, inverting the multiplication order of basis vectors.
 Also called *transpose* in some literature. -/
@@ -127,7 +132,7 @@ theorem reverse.map_mul (a b : CliffordAlgebra Q) :
 
 @[simp]
 theorem reverse_involutive : Function.Involutive (reverse (Q := Q)) :=
-  AlgHom.congr_fun reverseOp.symm_comp
+  AlgHom.congr_fun reverseOpEquiv.symm_comp
 #align clifford_algebra.reverse_involutive CliffordAlgebra.reverse_involutive
 
 @[simp]

--- a/Mathlib/LinearAlgebra/CliffordAlgebra/Conjugation.lean
+++ b/Mathlib/LinearAlgebra/CliffordAlgebra/Conjugation.lean
@@ -80,13 +80,19 @@ section Reverse
 
 open MulOpposite
 
-/-- `CliffordAlgebra.reverse` as an `AlgHom` to the opposite algebra -/
-def reverseOp : CliffordAlgebra Q →ₐ[R] (CliffordAlgebra Q)ᵐᵒᵖ :=
-  CliffordAlgebra.lift Q
-    ⟨(MulOpposite.opLinearEquiv R).toLinearMap ∘ₗ ι Q, fun m => unop_injective <| by simp⟩
+/-- `CliffordAlgebra.reverse` as an `AlgEquiv` to the opposite algebra -/
+def reverseOp : CliffordAlgebra Q ≃ₐ[R] (CliffordAlgebra Q)ᵐᵒᵖ :=
+  letI hom : CliffordAlgebra Q →ₐ[R] (CliffordAlgebra Q)ᵐᵒᵖ := CliffordAlgebra.lift Q
+      ⟨(MulOpposite.opLinearEquiv R).toLinearMap ∘ₗ ι Q, fun m => unop_injective <| by simp⟩
+  AlgEquiv.ofAlgHom hom (AlgHom.opComm hom)
+    (AlgHom.unop.injective <| hom_ext <| LinearMap.ext <| fun _ => by simp)
+    (hom_ext <| LinearMap.ext <| fun _ => by simp)
 
 @[simp]
 theorem reverseOp_ι (m : M) : reverseOp (ι Q m) = op (ι Q m) := lift_ι_apply _ _ _
+
+@[simp]
+theorem reverseOp_opComm : AlgEquiv.opComm (reverseOp (Q := Q)) = reverseOp.symm := rfl
 
 /-- Grade reversion, inverting the multiplication order of basis vectors.
 Also called *transpose* in some literature. -/
@@ -120,22 +126,14 @@ theorem reverse.map_mul (a b : CliffordAlgebra Q) :
 #align clifford_algebra.reverse.map_mul CliffordAlgebra.reverse.map_mul
 
 @[simp]
-theorem reverse_comp_reverse :
-    reverse.comp reverse = (LinearMap.id : _ →ₗ[R] CliffordAlgebra Q) := by
-  ext m
-  simp only [LinearMap.id_apply, LinearMap.comp_apply]
-  induction m using CliffordAlgebra.induction
-  -- simp can close these goals, but is slow
-  case h_grade0 => rw [reverse.commutes, reverse.commutes]
-  case h_grade1 => rw [reverse_ι, reverse_ι]
-  case h_mul a b ha hb => rw [reverse.map_mul, reverse.map_mul, ha, hb]
-  case h_add a b ha hb => rw [reverse.map_add, reverse.map_add, ha, hb]
-#align clifford_algebra.reverse_comp_reverse CliffordAlgebra.reverse_comp_reverse
+theorem reverse_involutive : Function.Involutive (reverse (Q := Q)) :=
+  AlgHom.congr_fun reverseOp.symm_comp
+#align clifford_algebra.reverse_involutive CliffordAlgebra.reverse_involutive
 
 @[simp]
-theorem reverse_involutive : Function.Involutive (reverse (Q := Q)) :=
-  LinearMap.congr_fun reverse_comp_reverse
-#align clifford_algebra.reverse_involutive CliffordAlgebra.reverse_involutive
+theorem reverse_comp_reverse :
+    reverse.comp reverse = (LinearMap.id : _ →ₗ[R] CliffordAlgebra Q) :=
+  LinearMap.ext reverse_involutive
 
 @[simp]
 theorem reverse_reverse : ∀ a : CliffordAlgebra Q, reverse (reverse a) = a :=

--- a/Mathlib/LinearAlgebra/CliffordAlgebra/Conjugation.lean
+++ b/Mathlib/LinearAlgebra/CliffordAlgebra/Conjugation.lean
@@ -80,14 +80,23 @@ section Reverse
 
 open MulOpposite
 
+/-- `CliffordAlgebra.reverse` as an `AlgHom` to the opposite algebra -/
+def reverseOp : CliffordAlgebra Q →ₐ[R] (CliffordAlgebra Q)ᵐᵒᵖ :=
+  CliffordAlgebra.lift Q
+    ⟨(MulOpposite.opLinearEquiv R).toLinearMap ∘ₗ ι Q, fun m => unop_injective <| by simp⟩
+
+@[simp]
+theorem reverseOp_ι (m : M) : reverseOp (ι Q m) = op (ι Q m) := lift_ι_apply _ _ _
+
 /-- Grade reversion, inverting the multiplication order of basis vectors.
 Also called *transpose* in some literature. -/
 def reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q :=
-  (opLinearEquiv R).symm.toLinearMap.comp
-    (CliffordAlgebra.lift Q
-        ⟨(MulOpposite.opLinearEquiv R).toLinearMap.comp (ι Q), fun m =>
-          unop_injective <| by simp⟩).toLinearMap
+  (opLinearEquiv R).symm.toLinearMap.comp reverseOp.toLinearMap
 #align clifford_algebra.reverse CliffordAlgebra.reverse
+
+@[simp] theorem unop_reverseOp (x : CliffordAlgebra Q) : (reverseOp x).unop = reverse x := rfl
+
+@[simp] theorem op_reverse (x : CliffordAlgebra Q) : op (reverse x) = reverseOp x := rfl
 
 @[simp]
 theorem reverse_ι (m : M) : reverse (ι Q m) = ι Q m := by simp [reverse]
@@ -95,19 +104,19 @@ theorem reverse_ι (m : M) : reverse (ι Q m) = ι Q m := by simp [reverse]
 
 @[simp]
 theorem reverse.commutes (r : R) :
-    reverse (algebraMap R (CliffordAlgebra Q) r) = algebraMap R _ r := by simp [reverse]
+    reverse (algebraMap R (CliffordAlgebra Q) r) = algebraMap R _ r :=
+  op_injective <| reverseOp.commutes r
 #align clifford_algebra.reverse.commutes CliffordAlgebra.reverse.commutes
 
 @[simp]
-theorem reverse.map_one : reverse (1 : CliffordAlgebra Q) = 1 := by
-  convert reverse.commutes (Q := Q) (1 : R) <;> simp
+theorem reverse.map_one : reverse (1 : CliffordAlgebra Q) = 1 :=
+  op_injective reverseOp.map_one
 #align clifford_algebra.reverse.map_one CliffordAlgebra.reverse.map_one
 
 @[simp]
 theorem reverse.map_mul (a b : CliffordAlgebra Q) :
-  -- porting note: can't infer `Q`
-  reverse (a * b) = reverse b * reverse a := by
-  simp [reverse]
+    reverse (a * b) = reverse b * reverse a :=
+  op_injective (reverseOp.map_mul a b)
 #align clifford_algebra.reverse.map_mul CliffordAlgebra.reverse.map_mul
 
 @[simp]
@@ -174,7 +183,6 @@ section List
 /-- Taking the reverse of the product a list of $n$ vectors lifted via `ι` is equivalent to
 taking the product of the reverse of that list. -/
 theorem reverse_prod_map_ι :
-  -- porting note: can't infer `Q`
     ∀ l : List M, reverse (l.map <| ι Q).prod = (l.map <| ι Q).reverse.prod
   | [] => by simp
   | x::xs => by simp [reverse_prod_map_ι xs]
@@ -249,7 +257,8 @@ theorem submodule_map_reverse_eq_comap (p : Submodule R (CliffordAlgebra Q)) :
 theorem ι_range_map_reverse :
     (ι Q).range.map (reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q)
       = LinearMap.range (ι Q) := by
-  rw [reverse, Submodule.map_comp, ι_range_map_lift, LinearMap.range_comp, ← Submodule.map_comp]
+  rw [reverse, reverseOp, Submodule.map_comp, ι_range_map_lift, LinearMap.range_comp,
+    ← Submodule.map_comp]
   exact Submodule.map_id _
 #align clifford_algebra.ι_range_map_reverse CliffordAlgebra.ι_range_map_reverse
 
@@ -310,7 +319,6 @@ theorem involute_mem_evenOdd_iff {x : CliffordAlgebra Q} {n : ZMod 2} :
 
 @[simp]
 theorem reverse_mem_evenOdd_iff {x : CliffordAlgebra Q} {n : ZMod 2} :
-    -- porting note: cannot infer `Q`
     reverse x ∈ evenOdd Q n ↔ x ∈ evenOdd Q n :=
   SetLike.ext_iff.mp (evenOdd_comap_reverse Q n) x
 #align clifford_algebra.reverse_mem_even_odd_iff CliffordAlgebra.reverse_mem_evenOdd_iff


### PR DESCRIPTION
Having the fully-bundled `AlgHom` (to `MulOpposite`) is occasionally useful for building larger `AlgHom`s, especially if the `MulOpposite` can be cancelled out later.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
