### PR TITLE
[Merged by Bors] - chore(Data/Finset/NatAntidiagonal): naming of antidiagonalEquivFin

### DIFF
--- a/Mathlib/Data/Finset/NatAntidiagonal.lean
+++ b/Mathlib/Data/Finset/NatAntidiagonal.lean
@@ -215,7 +215,8 @@ def sigmaAntidiagonalEquivProd : (Σn : ℕ, antidiagonal n) ≃ ℕ × ℕ wher
 end EquivProd
 
 /-- The set `antidiagonal n` is equivalent to `Fin (n+1)`, via the first projection. --/
-def antidiagonal_equiv_fin (n : ℕ) : antidiagonal n ≃ Fin (n + 1) where
+@[simps]
+def antidiagonalEquivFin (n : ℕ) : antidiagonal n ≃ Fin (n + 1) where
   toFun := fun ⟨⟨i, j⟩, h⟩ ↦ ⟨i, antidiagonal.fst_lt h⟩
   invFun := fun ⟨i, h⟩ ↦ ⟨⟨i, n - i⟩, by
     rw [mem_antidiagonal, add_comm, tsub_add_cancel_iff_le]


### PR DESCRIPTION
and add `simps`, as pointed out by @eric-wieser in
https://github.com/leanprover-community/mathlib4/pull/6766#pullrequestreview-1595354618


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
