### PR TITLE
[Merged by Bors] - chore: cleanup a few porting notes and friends relating to alias

### DIFF
--- a/Mathlib/Analysis/Convex/Hull.lean
+++ b/Mathlib/Analysis/Convex/Hull.lean
@@ -112,11 +112,7 @@ theorem convexHull_nonempty_iff : (convexHull 𝕜 s).Nonempty ↔ s.Nonempty :=
   exact not_congr convexHull_empty_iff
 #align convex_hull_nonempty_iff convexHull_nonempty_iff
 
--- Porting note: `alias` cannot be protected.
---alias convexHull_nonempty_iff ↔ _ Set.Nonempty.convexHull
---attribute [protected] Set.Nonempty.convexHull
-protected theorem Set.Nonempty.convexHull (h : s.Nonempty) : (convexHull 𝕜 s).Nonempty :=
-convexHull_nonempty_iff.2 h
+protected alias ⟨_, Set.Nonempty.convexHull⟩ := convexHull_nonempty_iff
 #align set.nonempty.convex_hull Set.Nonempty.convexHull
 
 theorem segment_subset_convexHull (hx : x ∈ s) (hy : y ∈ s) : segment 𝕜 x y ⊆ convexHull 𝕜 s :=

--- a/Mathlib/Data/Set/Function.lean
+++ b/Mathlib/Data/Set/Function.lean
@@ -1737,8 +1737,7 @@ theorem monotoneOn_of_rightInvOn_of_mapsTo {α β : Sort _} [PartialOrder α] [L
 theorem antitoneOn_of_rightInvOn_of_mapsTo {α β : Sort _} [PartialOrder α] [LinearOrder β]
     {φ : β → α} {ψ : α → β} {t : Set β} {s : Set α} (hφ : AntitoneOn φ t)
     (φψs : Set.RightInvOn ψ φ s) (ψts : Set.MapsTo ψ s t) : AntitoneOn ψ s :=
-  MonotoneOn.dual_right (monotoneOn_of_rightInvOn_of_mapsTo (AntitoneOn.dual_left hφ) φψs ψts)
--- Porting note: dot notation for `*.dual_*` didn't work
+  (monotoneOn_of_rightInvOn_of_mapsTo hφ.dual_left φψs ψts).dual_right
 #align function.antitone_on_of_right_inv_on_of_maps_to Function.antitoneOn_of_rightInvOn_of_mapsTo
 
 end Function

--- a/Mathlib/Data/Set/Image.lean
+++ b/Mathlib/Data/Set/Image.lean
@@ -875,21 +875,18 @@ theorem range_id' : (range fun x : α => x) = univ :=
 
 @[simp]
 theorem _root_.Prod.range_fst [Nonempty β] : range (Prod.fst : α × β → α) = univ :=
-  Function.Surjective.range_eq Prod.fst_surjective
-  -- Porting note: should be `Prod.fst_surjective.range_eq` if dot notation works
+  Prod.fst_surjective.range_eq
 #align prod.range_fst Prod.range_fst
 
 @[simp]
 theorem _root_.Prod.range_snd [Nonempty α] : range (Prod.snd : α × β → β) = univ :=
-  Function.Surjective.range_eq Prod.snd_surjective
-  -- Porting note: should be `Prod.snd_surjective.range_eq` if dot notation works
+  Prod.snd_surjective.range_eq
 #align prod.range_snd Prod.range_snd
 
 @[simp]
 theorem range_eval {ι : Type*} {α : ι → Sort _} [∀ i, Nonempty (α i)] (i : ι) :
     range (eval i : (∀ i, α i) → α i) = univ :=
-  Function.Surjective.range_eq (surjective_eval i)
-  -- Porting note: should be `(surjective_eval i).range_eq` if dot notation works
+  (surjective_eval i).range_eq
 #align set.range_eval Set.range_eval
 
 theorem range_inl : range (@Sum.inl α β) = {x | Sum.isLeft x} := by ext (_|_) <;> simp
@@ -1335,7 +1332,7 @@ theorem Injective.image_injective (hf : Injective f) : Injective (image f) := by
 theorem Surjective.preimage_subset_preimage_iff {s t : Set β} (hf : Surjective f) :
     f ⁻¹' s ⊆ f ⁻¹' t ↔ s ⊆ t := by
   apply Set.preimage_subset_preimage_iff
-  rw [Function.Surjective.range_eq hf]
+  rw [hf.range_eq]
   apply subset_univ
 #align function.surjective.preimage_subset_preimage_iff Function.Surjective.preimage_subset_preimage_iff
 

--- a/Mathlib/Data/Set/Intervals/ProjIcc.lean
+++ b/Mathlib/Data/Set/Intervals/ProjIcc.lean
@@ -163,7 +163,7 @@ theorem range_projIic : range (projIic a) = univ := projIic_surjective.range_eq
 
 @[simp]
 theorem range_projIcc : range (projIcc a b h) = univ :=
-  Function.Surjective.range_eq (projIcc_surjective h)
+  (projIcc_surjective h).range_eq
 #align set.range_proj_Icc Set.range_projIcc
 
 theorem monotone_projIci : Monotone (projIci a) := fun _ _ => max_le_max le_rfl

--- a/Mathlib/GroupTheory/Submonoid/Operations.lean
+++ b/Mathlib/GroupTheory/Submonoid/Operations.lean
@@ -953,7 +953,7 @@ theorem comap_equiv_eq_map_symm (f : N ≃* M) (K : Submonoid M) :
 
 @[to_additive (attr := simp)]
 theorem map_equiv_top (f : M ≃* N) : (⊤ : Submonoid M).map f.toMonoidHom = ⊤ :=
-  SetLike.coe_injective <| Set.image_univ.trans (Function.Surjective.range_eq f.surjective)
+  SetLike.coe_injective <| Set.image_univ.trans f.surjective.range_eq
 #align submonoid.map_equiv_top Submonoid.map_equiv_top
 #align add_submonoid.map_equiv_top AddSubmonoid.map_equiv_top
 

--- a/Mathlib/Logic/Lemmas.lean
+++ b/Mathlib/Logic/Lemmas.lean
@@ -19,12 +19,9 @@ would result in less delta-reduced statements.
 -/
 
 
-alias ⟨HEq.eq, Eq.heq⟩ := heq_iff_eq
+protected alias ⟨HEq.eq, Eq.heq⟩ := heq_iff_eq
 #align heq.eq HEq.eq
 #align eq.heq Eq.heq
-
--- Porting note: we may need to modify `alias` so we can make aliases protected at creation.
--- attribute [protected] HEq.eq Eq.heq
 
 variable {α : Sort*} {p q r : Prop} [Decidable p] [Decidable q] {a b c : α}
 

--- a/Mathlib/Order/BoundedOrder.lean
+++ b/Mathlib/Order/BoundedOrder.lean
@@ -623,10 +623,9 @@ section SemilatticeInf
 
 variable [SemilatticeInf α]
 
--- Porting note: was `hP.dual_left`
 theorem exists_le_and_iff_exists {P : α → Prop} {x₀ : α} (hP : Antitone P) :
     (∃ x, x ≤ x₀ ∧ P x) ↔ ∃ x, P x :=
-  exists_ge_and_iff_exists <| Antitone.dual_left hP
+  exists_ge_and_iff_exists <| hP.dual_left
 #align exists_le_and_iff_exists exists_le_and_iff_exists
 
 end SemilatticeInf

--- a/Mathlib/Order/Monotone/Monovary.lean
+++ b/Mathlib/Order/Monotone/Monovary.lean
@@ -319,7 +319,7 @@ protected theorem Monotone.monovary (hf : Monotone f) (hg : Monotone g) : Monova
 #align monotone.monovary Monotone.monovary
 
 protected theorem Monotone.antivary (hf : Monotone f) (hg : Antitone g) : Antivary f g :=
-  (hf.monovary (Antitone.dual_right hg)).dual_right
+  (hf.monovary hg.dual_right).dual_right
 #align monotone.antivary Monotone.antivary
 
 protected theorem Antitone.monovary (hf : Antitone f) (hg : Antitone g) : Monovary f g :=
@@ -327,7 +327,7 @@ protected theorem Antitone.monovary (hf : Antitone f) (hg : Antitone g) : Monova
 #align antitone.monovary Antitone.monovary
 
 protected theorem Antitone.antivary (hf : Antitone f) (hg : Monotone g) : Antivary f g :=
-  (hf.monovary (Monotone.dual_right hg)).dual_right
+  (hf.monovary hg.dual_right).dual_right
 #align antitone.antivary Antitone.antivary
 
 protected theorem MonotoneOn.monovaryOn (hf : MonotoneOn f s) (hg : MonotoneOn g s) :
@@ -336,7 +336,7 @@ protected theorem MonotoneOn.monovaryOn (hf : MonotoneOn f s) (hg : MonotoneOn g
 
 protected theorem MonotoneOn.antivaryOn (hf : MonotoneOn f s) (hg : AntitoneOn g s) :
     AntivaryOn f g s :=
-  (hf.monovaryOn (AntitoneOn.dual_right hg)).dual_right
+  (hf.monovaryOn hg.dual_right).dual_right
 #align monotone_on.antivary_on MonotoneOn.antivaryOn
 
 protected theorem AntitoneOn.monovaryOn (hf : AntitoneOn f s) (hg : AntitoneOn g s) :
@@ -346,7 +346,7 @@ protected theorem AntitoneOn.monovaryOn (hf : AntitoneOn f s) (hg : AntitoneOn g
 
 protected theorem AntitoneOn.antivaryOn (hf : AntitoneOn f s) (hg : MonotoneOn g s) :
     AntivaryOn f g s :=
-  (hf.monovaryOn (MonotoneOn.dual_right hg)).dual_right
+  (hf.monovaryOn hg.dual_right).dual_right
 #align antitone_on.antivary_on AntitoneOn.antivaryOn
 
 end Preorder

--- a/Mathlib/Order/RelIso/Set.lean
+++ b/Mathlib/Order/RelIso/Set.lean
@@ -45,7 +45,7 @@ namespace RelIso
 
 @[simp]
 theorem range_eq (e : r ≃r s) : Set.range e = Set.univ :=
-  Function.Surjective.range_eq e.surjective
+  e.surjective.range_eq
 #align rel_iso.range_eq RelIso.range_eq
 
 end RelIso

--- a/Mathlib/Topology/Basic.lean
+++ b/Mathlib/Topology/Basic.lean
@@ -626,10 +626,7 @@ theorem dense_closure {s : Set α} : Dense (closure s) ↔ Dense s := by
   rw [Dense, Dense, closure_closure]
 #align dense_closure dense_closure
 
--- porting note: todo: use `alias` + `@[protected]`
-protected lemma Dense.closure {s : Set α} (h : Dense s) : Dense (closure s) :=
-  dense_closure.2 h
-
+protected alias ⟨_, Dense.closure⟩ := dense_closure
 alias ⟨Dense.of_closure, _⟩ := dense_closure
 #align dense.of_closure Dense.of_closure
 #align dense.closure Dense.closure

--- a/Mathlib/Topology/SubsetProperties.lean
+++ b/Mathlib/Topology/SubsetProperties.lean
@@ -1747,16 +1747,10 @@ theorem isIrreducible_iff_closure {s : Set α} : IsIrreducible (closure s) ↔ I
   and_congr closure_nonempty_iff isPreirreducible_iff_closure
 #align is_irreducible_iff_closure isIrreducible_iff_closure
 
--- porting note: todo: use `alias` + `@[protected]`
-protected lemma IsPreirreducible.closure {s : Set α} (h : IsPreirreducible s) :
-    IsPreirreducible (closure s) :=
-  isPreirreducible_iff_closure.2 h
+protected alias ⟨_, IsPreirreducible.closure⟩ := isPreirreducible_iff_closure
 #align is_preirreducible.closure IsPreirreducible.closure
 
--- porting note: todo: use `alias` + `@[protected]`
-protected lemma IsIrreducible.closure {s : Set α} (h : IsIrreducible s) :
-    IsIrreducible (closure s) :=
-  isIrreducible_iff_closure.2 h
+protected alias ⟨_, IsIrreducible.closure⟩ := isIrreducible_iff_closure
 #align is_irreducible.closure IsIrreducible.closure
 
 theorem exists_preirreducible (s : Set α) (H : IsPreirreducible s) :


### PR DESCRIPTION
- After the new alias command we can now do `protected alias`
- alias at some point broke dot notation by unfolding (see #1022) this was fixed in #1058 but the library was not fixed up there

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
