### PR TITLE
[Merged by Bors] - chore(Topology/Sheaves/Forget): port an example from a comment

### DIFF
--- a/Mathlib/Topology/Sheaves/Forget.lean
+++ b/Mathlib/Topology/Sheaves/Forget.lean
@@ -234,14 +234,17 @@ set_option linter.uppercaseLean3 false in
 As an example, we now have everything we need to check the sheaf condition
 for a presheaf of commutative rings, merely by checking the sheaf condition
 for the underlying sheaf of types.
-```
-import algebra.category.Ring.limits
-example (X : Top) (F : presheaf CommRing X) (h : presheaf.is_sheaf (F ⋙ (forget CommRing))) :
-  F.is_sheaf :=
-(is_sheaf_iff_is_sheaf_comp (forget CommRing) F).mpr h
+```lean
+example (X : TopCat) (F : Presheaf CommRingCat X)
+    (h : Presheaf.IsSheaf (F ⋙ (forget CommRingCat))) :
+    F.IsSheaf :=
+(isSheaf_iff_isSheaf_comp (forget CommRingCat) F).mpr h
 ```
 -/
-
+example (X : TopCat) (F : Presheaf CommRingCat X)
+    (h : Presheaf.IsSheaf (F ⋙ (forget CommRingCat))) :
+    F.IsSheaf :=
+(isSheaf_iff_isSheaf_comp (forget CommRingCat) F).mpr h
 
 end Presheaf
 


### PR DESCRIPTION
I left the example in the docs, so that it shows up in doc-gen, and I duplicated it outside of the docs, so that it does not rot.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
