### PR TITLE
[Merged by Bors] - lint(scripts/lint-style): Add linting for lower-case clashes

### DIFF
--- a/scripts/lint-style.sh
+++ b/scripts/lint-style.sh
@@ -53,3 +53,13 @@ then
 	echo "$executable_files"
 	exit 1
 fi
+
+# 2.2 Check that there are no filenames with the same lower-case reduction
+
+upper_lower_clashes="$(git ls-files | sort --ignore-case | uniq -D --ignore-case)"
+
+if [ -n "${upper_lower_clashes}" ]; then
+	printf $'The following files have the same lower-case form:\n\n%s\n
+Please, make sure to avoid such clashes!\n' "${upper_lower_clashes}"
+	exit 1
+fi

--- a/scripts/lint-style.sh
+++ b/scripts/lint-style.sh
@@ -56,10 +56,11 @@ fi
 
 # 2.2 Check that there are no filenames with the same lower-case reduction
 
-upper_lower_clashes="$(git ls-files | sort --ignore-case | uniq -D --ignore-case)"
+# `uniq -D`: print all duplicate lines
+ignore_case_clashes="$(git ls-files | sort --ignore-case | uniq -D --ignore-case)"
 
-if [ -n "${upper_lower_clashes}" ]; then
+if [ -n "${ignore_case_clashes}" ]; then
 	printf $'The following files have the same lower-case form:\n\n%s\n
-Please, make sure to avoid such clashes!\n' "${upper_lower_clashes}"
+Please, make sure to avoid such clashes!\n' "${ignore_case_clashes}"
 	exit 1
 fi


### PR DESCRIPTION
Introduce a global check on git-managed filenames in the whole repository, making sure that the filenames are distinct also up to upper/lower casing.

Fixes an issue that came up when two file names that only differed by their casing were imported in a case-insensitive operating system.

As a check, I pushed [branch#adomani/testUpperLowerLinter](https://github.com/leanprover-community/mathlib4/tree/adomani/testUpperLowerLinter) from this PR containing `CODe_OF_CONDUCT.md` alongside `CODE_OF_CONDUCT.md`.  The [linter failed](https://github.com/leanprover-community/mathlib4/actions/runs/5997399826/job/16263715177) on that branch.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
