### PR TITLE
feat: extensive regular coverage

### DIFF
--- a/Mathlib/CategoryTheory/Category/Basic.lean
+++ b/Mathlib/CategoryTheory/Category/Basic.lean
@@ -353,6 +353,24 @@ theorem epi_of_epi_fac {X Y Z : C} {f : X ⟶ Y} {g : Y ⟶ Z} {h : X ⟶ Z} [Ep
   subst h; exact epi_of_epi f g
 #align category_theory.epi_of_epi_fac CategoryTheory.epi_of_epi_fac
 
+variable (C) in
+/-- Describes the property that epimorphisms can be "pulled back" along any morphism. This is
+satisfied e.g. by categories that have pullbacks that preserve epimorphisms (like `Profinite` and
+`CompHaus`), and categories where every object is projective (like  `Stonean`). -/
+class EpiStable : Prop where
+/-- For `X`, `Y`, `Z`, `f`, `g` like in the diagram, where `g` is an epi, there exists an object
+`W`, a morphism `i : W ⟶ Z` and an epi `h : W ⟶ X` making the diagram commute.
+```
+W --i-→ Z
+|       |
+h       g
+↓       ↓
+X --f-→ Y
+
+```-/
+  exists_fac : ∀ {X Y Z : C} (f : X ⟶ Y) (g : Z ⟶ Y) [Epi g],
+    (∃ (W : C) (h : W ⟶ X) (_ : Epi h) (i : W ⟶ Z), i ≫ g = h ≫ f)
+
 end
 
 section

--- a/Mathlib/CategoryTheory/Limits/Shapes/Diagonal.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Diagonal.lean
@@ -146,6 +146,25 @@ def pullbackDiagonalMapIso :
         · simp only [condition_assoc, Category.assoc, diagonal_snd, Category.comp_id,
             limit.lift_π, PullbackCone.mk_pt, PullbackCone.mk_π_app,
             limit.lift_π_assoc, cospan_right])
+  hom_inv_id := by
+    ext
+    · simp only [Category.assoc, limit.lift_π, PullbackCone.mk_pt, cospan_left,
+        PullbackCone.mk_π_app, Functor.const_obj_obj, cospan_one, cospan_right, limit.lift_π_assoc,
+        pullback_diagonal_map_snd_fst_fst, Category.id_comp]
+    · simp only [Category.assoc, limit.lift_π, PullbackCone.mk_pt, cospan_left,
+        PullbackCone.mk_π_app, Functor.const_obj_obj, cospan_one, cospan_right, Category.comp_id,
+        Category.id_comp]
+    · simp only [Category.assoc, limit.lift_π, PullbackCone.mk_pt, cospan_left,
+        PullbackCone.mk_π_app, Functor.const_obj_obj, cospan_one, cospan_right, Category.comp_id,
+        Category.id_comp]
+  inv_hom_id := by
+    ext
+    · simp only [Category.assoc, limit.lift_π, PullbackCone.mk_pt, PullbackCone.mk_π_app,
+        limit.lift_π_assoc, cospan_left, Functor.const_obj_obj, cospan_one, cospan_right,
+        Category.comp_id, Category.id_comp]
+    · simp only [Category.assoc, limit.lift_π, PullbackCone.mk_pt, PullbackCone.mk_π_app,
+        limit.lift_π_assoc, cospan_left, Functor.const_obj_obj, cospan_one, cospan_right,
+        Category.comp_id, Category.id_comp]
 #align category_theory.limits.pullback_diagonal_map_iso CategoryTheory.Limits.pullbackDiagonalMapIso
 
 @[reassoc (attr := simp)]

--- a/Mathlib/CategoryTheory/Limits/Shapes/FiniteProducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/FiniteProducts.lean
@@ -105,7 +105,7 @@ instance [HasPullbacksOfInclusions C] {X Z : C} {α : Type _} (f : X ⟶ Z) {Y :
     HasPullback f (i a) := HasPullbacksOfInclusions.has_pullback f i a
 
 /-- If `C` has pullbacks then it has the pullbacks relevant to `HasPullbacksOfInclusions` -/
-instance (priority := 10) [HasPullbacks C] :
+instance (priority := 5) [HasPullbacks C] :
   HasPullbacksOfInclusions C := ⟨fun _ _ _ => inferInstance⟩
 
 /-- A category is *extensive* if it has all finite coproducts and those coproducts are preserved

--- a/Mathlib/CategoryTheory/Limits/Shapes/FiniteProducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/FiniteProducts.lean
@@ -105,15 +105,15 @@ instance [HasPullbacksOfInclusions C] {X Z : C} {α : Type _} (f : X ⟶ Z) {Y :
     HasPullback f (i a) := HasPullbacksOfInclusions.has_pullback f i a
 
 /-- If `C` has pullbacks then it has the pullbacks relevant to `HasPullbacksOfInclusions`. -/
-instance (priority := 1) [HasPullbacks C] :
+instance (priority := 10) [HasPullbacks C] :
   HasPullbacksOfInclusions C := ⟨fun _ _ _ => inferInstance⟩
 
--- /-- A category is *extensive* if it has all finite coproducts and those coproducts are preserved
--- by pullbacks (we only require the relevant pullbacks to exist, via `HasPullbacksOfInclusions`). -/
--- class Extensive extends HasFiniteCoproducts C, HasPullbacksOfInclusions C : Prop where
---   /-- Pulling back an isomorphism from a coproduct yields an isomorphism. -/
---   sigma_desc_iso : ∀ {α : Type} [Fintype α] {X : C} {Z : α → C} (π : (a : α) → Z a ⟶ X)
---     {Y : C} (f : Y ⟶ X) (_ : IsIso (Sigma.desc π)),
---     IsIso (Sigma.desc ((fun _ ↦ pullback.fst) : (a : α) → pullback f (π a) ⟶ _))
+/-- A category is *extensive* if it has all finite coproducts and those coproducts are preserved
+by pullbacks (we only require the relevant pullbacks to exist, via `HasPullbacksOfInclusions`). -/
+class Extensive extends HasFiniteCoproducts C, HasPullbacksOfInclusions C : Prop where
+  /-- Pulling back an isomorphism from a coproduct yields an isomorphism. -/
+  sigma_desc_iso : ∀ {α : Type} [Fintype α] {X : C} {Z : α → C} (π : (a : α) → Z a ⟶ X)
+    {Y : C} (f : Y ⟶ X) (_ : IsIso (Sigma.desc π)),
+    IsIso (Sigma.desc ((fun _ ↦ pullback.fst) : (a : α) → pullback f (π a) ⟶ _))
 
 end CategoryTheory.Limits

--- a/Mathlib/CategoryTheory/Limits/Shapes/FiniteProducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/FiniteProducts.lean
@@ -105,7 +105,7 @@ instance [HasPullbacksOfInclusions C] {X Z : C} {α : Type _} (f : X ⟶ Z) {Y :
     HasPullback f (i a) := HasPullbacksOfInclusions.has_pullback f i a
 
 /-- If `C` has pullbacks then it has the pullbacks relevant to `HasPullbacksOfInclusions` -/
-instance (priority := 5) [HasPullbacks C] :
+instance (priority := 1) [HasPullbacks C] :
   HasPullbacksOfInclusions C := ⟨fun _ _ _ => inferInstance⟩
 
 /-- A category is *extensive* if it has all finite coproducts and those coproducts are preserved

--- a/Mathlib/CategoryTheory/Limits/Shapes/FiniteProducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/FiniteProducts.lean
@@ -105,7 +105,7 @@ instance [HasPullbacksOfInclusions C] {X Z : C} {α : Type _} (f : X ⟶ Z) {Y :
     HasPullback f (i a) := HasPullbacksOfInclusions.has_pullback f i a
 
 /-- If `C` has pullbacks then it has the pullbacks relevant to `HasPullbacksOfInclusions`. -/
-instance (priority := 10) [HasPullbacks C] :
+instance (priority := 1) [HasPullbacks C] :
   HasPullbacksOfInclusions C := ⟨fun _ _ _ => inferInstance⟩
 
 /-- A category is *extensive* if it has all finite coproducts and those coproducts are preserved

--- a/Mathlib/CategoryTheory/Limits/Shapes/FiniteProducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/FiniteProducts.lean
@@ -91,4 +91,27 @@ theorem hasFiniteCoproducts_of_hasCoproducts [HasCoproducts.{w} C] : HasFiniteCo
   ⟨fun _ => hasColimitsOfShape_of_equivalence (Discrete.equivalence Equiv.ulift.{w})⟩
 #align category_theory.limits.has_finite_coproducts_of_has_coproducts CategoryTheory.Limits.hasFiniteCoproducts_of_hasCoproducts
 
+/-- Describes the property of having pullbacks of morphsims into a finite coproduct, where one
+of the morphisms is an inclusion map into the coproduct (up to isomorphism). -/
+class HasPullbacksOfInclusions : Prop where
+    /-- For any morphism `f : X ⟶ Z`, where `Z` is the coproduct of `i : (a : α) → Y a ⟶ Z` with
+    `α` finite, the pullback of `f` and `i a` exists for every `a : α`. -/
+    has_pullback : ∀ {X Z : C} {α : Type _} (f : X ⟶ Z) {Y : (a : α) → C}
+    (i : (a : α) → Y a ⟶ Z) [Fintype α] [HasCoproduct Y] [IsIso (Sigma.desc i)] (a : α),
+    HasPullback f (i a)
+
+instance [HasPullbacksOfInclusions C] {X Z : C} {α : Type _} (f : X ⟶ Z) {Y : (a : α) → C}
+    (i : (a : α) → Y a ⟶ Z) [Fintype α] [HasCoproduct Y] [IsIso (Sigma.desc i)] (a : α) :
+    HasPullback f (i a) := HasPullbacksOfInclusions.has_pullback f i a
+
+instance [HasPullbacks C] : HasPullbacksOfInclusions C := ⟨fun _ _ _ => inferInstance⟩
+
+/-- A category is *extensive* if it has all finite coproducts and those coproducts are preserved
+by pullbacks (we only require the relevant pullbacks to exist, via `HasPullbacksOfInclusions`). -/
+class Extensive extends HasFiniteCoproducts C, HasPullbacksOfInclusions C : Prop where
+  /-- Pulling back an isomorphism from a coproduct yields an isomorphism. -/
+  sigma_desc_iso : ∀ {α : Type} [Fintype α] {X : C} {Z : α → C} (π : (a : α) → Z a ⟶ X)
+    {Y : C} (f : Y ⟶ X) (_ : IsIso (Sigma.desc π)),
+    IsIso (Sigma.desc ((fun _ ↦ pullback.fst) : (a : α) → pullback f (π a) ⟶ _))
+
 end CategoryTheory.Limits

--- a/Mathlib/CategoryTheory/Limits/Shapes/FiniteProducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/FiniteProducts.lean
@@ -104,7 +104,9 @@ instance [HasPullbacksOfInclusions C] {X Z : C} {α : Type _} (f : X ⟶ Z) {Y :
     (i : (a : α) → Y a ⟶ Z) [Fintype α] [HasCoproduct Y] [IsIso (Sigma.desc i)] (a : α) :
     HasPullback f (i a) := HasPullbacksOfInclusions.has_pullback f i a
 
-instance [HasPullbacks C] : HasPullbacksOfInclusions C := ⟨fun _ _ _ => inferInstance⟩
+/-- If `C` has pullbacks then it has the pullbacks relevant to `HasPullbacksOfInclusions` -/
+instance (priority := 10) [HasPullbacks C] :
+  HasPullbacksOfInclusions C := ⟨fun _ _ _ => inferInstance⟩
 
 /-- A category is *extensive* if it has all finite coproducts and those coproducts are preserved
 by pullbacks (we only require the relevant pullbacks to exist, via `HasPullbacksOfInclusions`). -/

--- a/Mathlib/CategoryTheory/Limits/Shapes/FiniteProducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/FiniteProducts.lean
@@ -104,16 +104,16 @@ instance [HasPullbacksOfInclusions C] {X Z : C} {α : Type _} (f : X ⟶ Z) {Y :
     (i : (a : α) → Y a ⟶ Z) [Fintype α] [HasCoproduct Y] [IsIso (Sigma.desc i)] (a : α) :
     HasPullback f (i a) := HasPullbacksOfInclusions.has_pullback f i a
 
-/-- If `C` has pullbacks then it has the pullbacks relevant to `HasPullbacksOfInclusions` -/
+/-- If `C` has pullbacks then it has the pullbacks relevant to `HasPullbacksOfInclusions`. -/
 instance (priority := 1) [HasPullbacks C] :
   HasPullbacksOfInclusions C := ⟨fun _ _ _ => inferInstance⟩
 
-/-- A category is *extensive* if it has all finite coproducts and those coproducts are preserved
-by pullbacks (we only require the relevant pullbacks to exist, via `HasPullbacksOfInclusions`). -/
-class Extensive extends HasFiniteCoproducts C, HasPullbacksOfInclusions C : Prop where
-  /-- Pulling back an isomorphism from a coproduct yields an isomorphism. -/
-  sigma_desc_iso : ∀ {α : Type} [Fintype α] {X : C} {Z : α → C} (π : (a : α) → Z a ⟶ X)
-    {Y : C} (f : Y ⟶ X) (_ : IsIso (Sigma.desc π)),
-    IsIso (Sigma.desc ((fun _ ↦ pullback.fst) : (a : α) → pullback f (π a) ⟶ _))
+-- /-- A category is *extensive* if it has all finite coproducts and those coproducts are preserved
+-- by pullbacks (we only require the relevant pullbacks to exist, via `HasPullbacksOfInclusions`). -/
+-- class Extensive extends HasFiniteCoproducts C, HasPullbacksOfInclusions C : Prop where
+--   /-- Pulling back an isomorphism from a coproduct yields an isomorphism. -/
+--   sigma_desc_iso : ∀ {α : Type} [Fintype α] {X : C} {Z : α → C} (π : (a : α) → Z a ⟶ X)
+--     {Y : C} (f : Y ⟶ X) (_ : IsIso (Sigma.desc π)),
+--     IsIso (Sigma.desc ((fun _ ↦ pullback.fst) : (a : α) → pullback f (π a) ⟶ _))
 
 end CategoryTheory.Limits

--- a/Mathlib/CategoryTheory/Sites/Coverage.lean
+++ b/Mathlib/CategoryTheory/Sites/Coverage.lean
@@ -509,9 +509,9 @@ instance {X : C} (S : Presieve X) [S.extensive]
     simp only [Equalizer.forkMap, Category.assoc, limit.lift_π, Fan.mk_pt, Fan.mk_π_app,
       Category.id_comp]
     obtain ⟨a, ha⟩ := sigma_surjective π f
-    rw [firstObj_to_base, Category.assoc, Category.assoc, Category.assoc, ← Functor.map_comp, ← op_inv,
-      ← op_comp, ← ha, comp_inv_desc_eq_ι, ← Functor.map_comp, opCoproductIsoProduct_inv_comp_ι,
-      PreservesProduct.isoInvCompMap F a]
+    rw [firstObj_to_base, Category.assoc, Category.assoc, Category.assoc, ← Functor.map_comp,
+      ← op_inv, ← op_comp, ← ha, comp_inv_desc_eq_ι, ← Functor.map_comp,
+      opCoproductIsoProduct_inv_comp_ι, PreservesProduct.isoInvCompMap F a]
     simp only [prod_map, Category.comp_id, limit.lift_π, Fan.mk_pt, Fan.mk_π_app]
 
 end ExtensiveSheafConditionProof

--- a/Mathlib/CategoryTheory/Sites/Sieves.lean
+++ b/Mathlib/CategoryTheory/Sites/Sieves.lean
@@ -6,7 +6,7 @@ Authors: Bhavik Mehta, E. W. Ayers
 import Mathlib.Order.CompleteLattice
 import Mathlib.CategoryTheory.Over
 import Mathlib.CategoryTheory.Yoneda
-import Mathlib.CategoryTheory.Limits.Shapes.Pullbacks
+import Mathlib.CategoryTheory.Limits.Shapes.FiniteProducts
 import Mathlib.Data.Set.Lattice
 
 #align_import category_theory.sites.sieves from "leanprover-community/mathlib"@"239d882c4fb58361ee8b3b39fb2091320edef10a"
@@ -190,6 +190,20 @@ class hasPullbacks (R : Presieve X) : Prop where
   has_pullbacks : ∀ {Y Z} {f : Y ⟶ X} (_ : R f) {g : Z ⟶ X} (_ : R g), HasPullback f g
 
 instance (R : Presieve X) [HasPullbacks C] : R.hasPullbacks := ⟨fun _ _ ↦ inferInstance⟩
+
+/-- A presieve is *extensive* if it is finite and its arrows induce an isomorphism from the
+coproduct to the target. -/
+class extensive [HasFiniteCoproducts C] (R : Presieve X) : Prop where
+  /-- `R` consists of a finite collection of arrows that together induce an isomorphism from the
+  coproduct of their sources. -/
+  arrows_sigma_desc_iso : ∃ (α : Type) (_ : Fintype α) (Z : α → C) (π : (a : α) → (Z a ⟶ X)),
+    R = Presieve.ofArrows Z π ∧ IsIso (Sigma.desc π)
+
+/-- A presieve is *regular* if it consists of a single epimorphism. -/
+class regular (R : Presieve X) : Prop where
+  /-- `R` consists of a single epimorphism. -/
+  single_epi : ∃ (Y : C) (f : Y ⟶ X), R = Presieve.ofArrows (fun (_ : Unit) ↦ Y)
+    (fun (_ : Unit) ↦ f) ∧ Epi f
 
 section FunctorPushforward
 


### PR DESCRIPTION
Main results: 

- Finite jointly isomorphic (`extensive`) and singleton epimorphic (`regular`) presieves together form a coverage. 
- Finite-product preserving presheaves on extensive categories are sheaves for `extensive` presieves.

Co-authored-by: Riccardo Brasca @riccardobrasca [riccardo.brasca@gmail.com](mailto:riccardo.brasca@gmail.com)
Co-authored-by: Filippo A E Nuccio @faenuccio [filippo.nuccio@univ-st-etienne.fr](mailto:filippo.nuccio@univ-st-etienne.fr)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
