### PR TITLE
[Merged by Bors] - chore: Undo adding a heavy import in MeasureTheory.Integral.Lebesgue.

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2408,6 +2408,7 @@ import Mathlib.MeasureTheory.Integral.CircleTransform
 import Mathlib.MeasureTheory.Integral.DivergenceTheorem
 import Mathlib.MeasureTheory.Integral.ExpDecay
 import Mathlib.MeasureTheory.Integral.FundThmCalculus
+import Mathlib.MeasureTheory.Integral.Indicator
 import Mathlib.MeasureTheory.Integral.IntegrableOn
 import Mathlib.MeasureTheory.Integral.IntegralEqImproper
 import Mathlib.MeasureTheory.Integral.IntervalAverage

--- a/Mathlib/MeasureTheory/Integral/Indicator.lean
+++ b/Mathlib/MeasureTheory/Integral/Indicator.lean
@@ -18,9 +18,9 @@ in `Mathlib.MeasureTheory.Integral.Lebesgue`.
 
 ## Todo
 
-The result `measurableSet_of_tendsto_indicator` could be proved without integration, if we
-had convergence of measures results for countably generated filters. Ideally, the present
-file would then become unnecessary: lemmas such as
+The result `MeasureTheory.tendsto_measure_of_tendsto_indicator` here could be proved without
+integration, if we had convergence of measures results for countably generated filters. Ideally,
+the present file would then become unnecessary: lemmas such as
 `MeasureTheory.tendsto_measure_of_ae_tendsto_indicator` would not need integration so could be
 moved out of `Mathlib.MeasureTheory.Integral.Lebesgue`, and the lemmas in this file could be
 moved to, e.g., `Mathlib.MeasureTheory.Constructions.BorelSpace.Metrizable`.

--- a/Mathlib/MeasureTheory/Integral/Indicator.lean
+++ b/Mathlib/MeasureTheory/Integral/Indicator.lean
@@ -16,8 +16,14 @@ This file has a few measure theoretic or integration-related results on indicato
 This file exists to avoid importing `Mathlib.MeasureTheory.Constructions.BorelSpace.Metrizable`
 in `Mathlib.MeasureTheory.Integral.Lebesgue`.
 
-If other results besides those related to indicators require similar imports, the file could be
-renamed appropriately.
+## Todo
+
+The result `measurableSet_of_tendsto_indicator` could be proved without integration, if we
+had convergence of measures results for countably generated filters. Ideally, the present
+file would then become unnecessary: lemmas such as
+`MeasureTheory.tendsto_measure_of_ae_tendsto_indicator` would not need integration so could be
+moved out of `Mathlib.MeasureTheory.Integral.Lebesgue`, and the lemmas in this file could be
+moved to, e.g., `Mathlib.MeasureTheory.Constructions.BorelSpace.Metrizable`.
 
 -/
 

--- a/Mathlib/MeasureTheory/Integral/Indicator.lean
+++ b/Mathlib/MeasureTheory/Integral/Indicator.lean
@@ -1,0 +1,52 @@
+/-
+Copyright (c) 2023 Kalle Kytölä. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kalle Kytölä
+-/
+import Mathlib.MeasureTheory.Integral.Lebesgue
+import Mathlib.MeasureTheory.Constructions.BorelSpace.Metrizable
+
+/-!
+# Results about indicator functions, their integrals, and measures
+
+This file has a few measure theoretic or integration-related results on indicator functions.
+
+## Implementation notes
+
+This file exists to avoid importing `Mathlib.MeasureTheory.Constructions.BorelSpace.Metrizable`
+in `Mathlib.MeasureTheory.Integral.Lebesgue`.
+
+If other results besides those related to indicators require similar imports, the file could be
+renamed appropriately.
+
+-/
+
+namespace MeasureTheory
+
+section TendstoIndicator
+
+/-- If the indicators of measurable sets `Aᵢ` tend pointwise to the indicator of a set `A`
+and we eventually have `Aᵢ ⊆ B` for some set `B` of finite measure, then the measures of `Aᵢ`
+tend to the measure of `A`. -/
+lemma tendsto_measure_of_tendsto_indicator [NeBot L] {μ : Measure α}
+    (As_mble : ∀ i, MeasurableSet (As i)) {B : Set α} (B_mble : MeasurableSet B)
+    (B_finmeas : μ B ≠ ∞) (As_le_B : ∀ᶠ i in L, As i ⊆ B)
+    (h_lim : Tendsto (fun i ↦ (As i).indicator (1 : α → ℝ≥0∞)) L (𝓝 (A.indicator 1))) :
+    Tendsto (fun i ↦ μ (As i)) L (𝓝 (μ A)) := by
+  apply tendsto_measure_of_ae_tendsto_indicator L ?_ As_mble B_mble B_finmeas As_le_B
+  · exact eventually_of_forall (by simpa only [tendsto_pi_nhds] using h_lim)
+  · exact measurableSet_of_tendsto_indicator L As_mble h_lim
+
+/-- If `μ` is a finite measure and the indicators of measurable sets `Aᵢ` tend pointwise to
+the indicator of a set `A`, then the measures `μ Aᵢ` tend to the measure `μ A`. -/
+lemma tendsto_measure_of_tendsto_indicator_of_isFiniteMeasure [NeBot L]
+    (μ : Measure α) [IsFiniteMeasure μ] (As_mble : ∀ i, MeasurableSet (As i))
+    (h_lim : Tendsto (fun i ↦ (As i).indicator (1 : α → ℝ≥0∞)) L (𝓝 (A.indicator 1))) :
+    Tendsto (fun i ↦ μ (As i)) L (𝓝 (μ A)) := by
+  apply tendsto_measure_of_ae_tendsto_indicator_of_isFiniteMeasure L ?_ As_mble
+  · exact eventually_of_forall (by simpa only [tendsto_pi_nhds] using h_lim)
+  · exact measurableSet_of_tendsto_indicator L As_mble h_lim
+
+end TendstoIndicator -- section
+
+end MeasureTheory

--- a/Mathlib/MeasureTheory/Integral/Indicator.lean
+++ b/Mathlib/MeasureTheory/Integral/Indicator.lean
@@ -25,6 +25,11 @@ namespace MeasureTheory
 
 section TendstoIndicator
 
+open Filter ENNReal Topology
+
+variable {α : Type*} [MeasurableSpace α] {A : Set α}
+variable {ι : Type*} (L : Filter ι) [IsCountablyGenerated L] {As : ι → Set α}
+
 /-- If the indicators of measurable sets `Aᵢ` tend pointwise to the indicator of a set `A`
 and we eventually have `Aᵢ ⊆ B` for some set `B` of finite measure, then the measures of `Aᵢ`
 tend to the measure of `A`. -/

--- a/Mathlib/MeasureTheory/Integral/Lebesgue.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue.lean
@@ -7,7 +7,6 @@ import Mathlib.Dynamics.Ergodic.MeasurePreserving
 import Mathlib.MeasureTheory.Function.SimpleFunc
 import Mathlib.MeasureTheory.Measure.MutuallySingular
 import Mathlib.MeasureTheory.Measure.Count
-import Mathlib.MeasureTheory.Constructions.BorelSpace.Metrizable
 
 #align_import measure_theory.integral.lebesgue from "leanprover-community/mathlib"@"c14c8fcde993801fca8946b0d80131a1a81d1520"
 
@@ -29,6 +28,8 @@ We introduce the following notation for the lower Lebesgue integral of a functio
   to the canonical measure `volume`, defined as `∫⁻ x, f x ∂(volume.restrict s)`.
 
 -/
+
+assert_not_exists NormedSpace
 
 set_option autoImplicit true
 
@@ -2146,28 +2147,6 @@ lemma tendsto_measure_of_ae_tendsto_indicator_of_isFiniteMeasure [IsCountablyGen
     Tendsto (fun i ↦ μ (As i)) L (𝓝 (μ A)) :=
   tendsto_measure_of_ae_tendsto_indicator L A_mble As_mble MeasurableSet.univ
     (measure_ne_top μ univ) (eventually_of_forall (fun i ↦ subset_univ (As i))) h_lim
-
-/-- If the indicators of measurable sets `Aᵢ` tend pointwise to the indicator of a set `A`
-and we eventually have `Aᵢ ⊆ B` for some set `B` of finite measure, then the measures of `Aᵢ`
-tend to the measure of `A`. -/
-lemma tendsto_measure_of_tendsto_indicator [NeBot L] {μ : Measure α}
-    (As_mble : ∀ i, MeasurableSet (As i)) {B : Set α} (B_mble : MeasurableSet B)
-    (B_finmeas : μ B ≠ ∞) (As_le_B : ∀ᶠ i in L, As i ⊆ B)
-    (h_lim : Tendsto (fun i ↦ (As i).indicator (1 : α → ℝ≥0∞)) L (𝓝 (A.indicator 1))) :
-    Tendsto (fun i ↦ μ (As i)) L (𝓝 (μ A)) := by
-  apply tendsto_measure_of_ae_tendsto_indicator L ?_ As_mble B_mble B_finmeas As_le_B
-  · exact eventually_of_forall (by simpa only [tendsto_pi_nhds] using h_lim)
-  · exact measurableSet_of_tendsto_indicator L As_mble h_lim
-
-/-- If `μ` is a finite measure and the indicators of measurable sets `Aᵢ` tend pointwise to
-the indicator of a set `A`, then the measures `μ Aᵢ` tend to the measure `μ A`. -/
-lemma tendsto_measure_of_tendsto_indicator_of_isFiniteMeasure [NeBot L]
-    (μ : Measure α) [IsFiniteMeasure μ] (As_mble : ∀ i, MeasurableSet (As i))
-    (h_lim : Tendsto (fun i ↦ (As i).indicator (1 : α → ℝ≥0∞)) L (𝓝 (A.indicator 1))) :
-    Tendsto (fun i ↦ μ (As i)) L (𝓝 (μ A)) := by
-  apply tendsto_measure_of_ae_tendsto_indicator_of_isFiniteMeasure L ?_ As_mble
-  · exact eventually_of_forall (by simpa only [tendsto_pi_nhds] using h_lim)
-  · exact measurableSet_of_tendsto_indicator L As_mble h_lim
 
 end TendstoIndicator -- section
 

--- a/Mathlib/MeasureTheory/Integral/Lebesgue.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue.lean
@@ -2115,8 +2115,8 @@ end SigmaFinite
 
 section TendstoIndicator
 
-variable {α : Type _} [MeasurableSpace α] {A : Set α}
-variable {ι : Type _} (L : Filter ι) [IsCountablyGenerated L] {As : ι → Set α}
+variable {α : Type*} [MeasurableSpace α] {A : Set α}
+variable {ι : Type*} (L : Filter ι) [IsCountablyGenerated L] {As : ι → Set α}
 
 /-- If the indicators of measurable sets `Aᵢ` tend pointwise almost everywhere to the indicator
 of a measurable set `A` and we eventually have `Aᵢ ⊆ B` for some set `B` of finite measure, then


### PR DESCRIPTION
Create a new file `MeasureTheory.Integral.Indicator` to undo adding the import of `MeasureTheory.Constructions.BorelSpace.Metrizable` in `MeasureTheory.Integral.Lebesgue` introduced in #6225.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
