### PR TITLE
WIP: experimenting with HPow as a right action and HSMul as a left action

### DIFF
--- a/Archive/Imo/Imo1962Q4.lean
+++ b/Archive/Imo/Imo1962Q4.lean
@@ -17,8 +17,6 @@ Since Lean does not have a concept of "simplest form", we just express what is
 in fact the simplest form of the set of solutions, and then prove it equals the set of solutions.
 -/
 
-local macro_rules | `($x ^ $y) => `(HPow.hPow $x $y) -- Porting note: See issue lean4#2220
-
 open Real
 
 open scoped Real

--- a/Archive/Imo/Imo2001Q2.lean
+++ b/Archive/Imo/Imo2001Q2.lean
@@ -32,8 +32,6 @@ open Real
 
 variable {a b c : ℝ}
 
-local macro_rules | `($x ^ $y) => `(HPow.hPow $x $y) -- Porting note: See issue lean4#2220
-
 namespace Imo2001Q2
 
 theorem bound (ha : 0 < a) (hb : 0 < b) (hc : 0 < c) :

--- a/Archive/Imo/Imo2008Q3.lean
+++ b/Archive/Imo/Imo2008Q3.lean
@@ -31,8 +31,6 @@ Then `p = 2n + k ≥ 2n + √(p - 4) = 2n + √(2n + k - 4) > √(2n)` and we ar
 
 open Real
 
-local macro_rules | `($x ^ $y) => `(HPow.hPow $x $y) -- Porting note: See issue lean4#2220
-
 namespace Imo2008Q3
 
 theorem p_lemma (p : ℕ) (hpp : Nat.Prime p) (hp_mod_4_eq_1 : p ≡ 1 [MOD 4]) (hp_gt_20 : p > 20) :

--- a/Archive/Imo/Imo2013Q5.lean
+++ b/Archive/Imo/Imo2013Q5.lean
@@ -32,8 +32,6 @@ https://www.imo-official.org/problems/IMO2013SL.pdf
 
 open scoped BigOperators
 
-local macro_rules | `($x ^ $y) => `(HPow.hPow $x $y) -- Porting note: See issue lean4#2220
-
 namespace Imo2013Q5
 
 theorem le_of_all_pow_lt_succ {x y : ℝ} (hx : 1 < x) (hy : 1 < y)

--- a/Archive/Imo/Imo2019Q4.lean
+++ b/Archive/Imo/Imo2019Q4.lean
@@ -29,8 +29,6 @@ individually.
 
 open scoped Nat BigOperators
 
-local macro_rules | `($x ^ $y) => `(HPow.hPow $x $y) -- Porting note: See issue lean4#2220
-
 open Nat hiding zero_le Prime
 
 open Finset multiplicity

--- a/Archive/Sensitivity.lean
+++ b/Archive/Sensitivity.lean
@@ -400,7 +400,7 @@ theorem exists_eigenvalue (H : Set (Q m.succ)) (hH : Card H ≥ 2 ^ m + 1) :
   let img := range (g m)
   suffices 0 < dim (W ⊓ img) by
     exact_mod_cast exists_mem_ne_zero_of_rank_pos this
-  have dim_le : dim (W ⊔ img) ≤ 2 ^ (m + 1) := by
+  have dim_le : dim (W ⊔ img) ≤ 2 ^ (m + 1 : Cardinal) := by
     convert ← rank_submodule_le (W ⊔ img)
     rw [← Nat.cast_succ]
     apply dim_V

--- a/Archive/Wiedijk100Theorems/AbelRuffini.lean
+++ b/Archive/Wiedijk100Theorems/AbelRuffini.lean
@@ -31,8 +31,6 @@ namespace AbelRuffini
 
 set_option linter.uppercaseLean3 false
 
-local macro_rules | `($x ^ $y) => `(HPow.hPow $x $y) -- Porting note: See issue lean4#2220
-
 open Function Polynomial Polynomial.Gal Ideal
 
 open scoped Polynomial

--- a/Archive/Wiedijk100Theorems/AreaOfACircle.lean
+++ b/Archive/Wiedijk100Theorems/AreaOfACircle.lean
@@ -43,9 +43,6 @@ to the n-ball.
 -/
 
 
-
-local macro_rules | `($x ^ $y) => `(HPow.hPow $x $y) -- Porting note: See issue lean4#2220
-
 open Set Real MeasureTheory intervalIntegral
 
 open scoped Real NNReal

--- a/Archive/Wiedijk100Theorems/HeronsFormula.lean
+++ b/Archive/Wiedijk100Theorems/HeronsFormula.lean
@@ -25,8 +25,6 @@ open Real EuclideanGeometry
 
 open scoped Real EuclideanGeometry
 
-local macro_rules | `($x ^ $y) => `(HPow.hPow $x $y) -- Porting note: See issue lean4#2220
-
 namespace Theorems100
 
 local notation "√" => Real.sqrt

--- a/Archive/Wiedijk100Theorems/SumOfPrimeReciprocalsDiverges.lean
+++ b/Archive/Wiedijk100Theorems/SumOfPrimeReciprocalsDiverges.lean
@@ -240,7 +240,7 @@ theorem Real.tendsto_sum_one_div_prime_atTop :
   have h4 :=
     calc
       (card M' : ℝ) ≤ 2 ^ k * x.sqrt := by exact_mod_cast card_le_two_pow_mul_sqrt
-      _ = 2 ^ k * ↑(2 ^ (k + 1)) := by rw [Nat.sqrt_eq]
+      _ = 2 ^ k * (2 ^ (k + 1) : ℕ) := by rw [Nat.sqrt_eq]
       _ = x / 2 := by field_simp [mul_right_comm, ← pow_succ']
   refine' lt_irrefl (x : ℝ) _
   calc

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3446,3 +3446,4 @@ import Mathlib.Util.Tactic
 import Mathlib.Util.Time
 import Mathlib.Util.WhatsNew
 import Mathlib.Util.WithWeakNamespace
+import Mathlib.binop2

--- a/Mathlib/Algebra/Algebra/NonUnitalSubalgebra.lean
+++ b/Mathlib/Algebra/Algebra/NonUnitalSubalgebra.lean
@@ -269,7 +269,7 @@ protected theorem coe_sub {R : Type u} {A : Type v} [CommRing R] [Ring A] [Algeb
 
 @[simp, norm_cast]
 theorem coe_smul [Semiring R'] [SMul R' R] [Module R' A] [IsScalarTower R' R A] (r : R') (x : S) :
-    (r • x : A) = r • (x : A) :=
+    ↑(r • x) = r • (x : A) :=
   rfl
 
 protected theorem coe_eq_zero {x : S} : (x : A) = 0 ↔ x = 0 :=

--- a/Mathlib/Algebra/CharP/LocalRing.lean
+++ b/Mathlib/Algebra/CharP/LocalRing.lean
@@ -51,7 +51,7 @@ theorem charP_zero_or_prime_power (R : Type*) [CommRing R] [LocalRing R] (q : �
     -- Let `b` be the inverse of `a`.
     cases' a_unit.exists_left_inv with a_inv h_inv_mul_a
     have rn_cast_zero : ↑(r ^ n) = (0 : R) := by
-      rw [← @mul_one R _ (r ^ n), mul_comm, ←Classical.choose_spec a_unit.exists_left_inv,
+      rw [← @mul_one R _ ↑(r ^ n), mul_comm, ←Classical.choose_spec a_unit.exists_left_inv,
         mul_assoc, ← Nat.cast_mul, ←q_eq_a_mul_rn, CharP.cast_eq_zero R q]
       simp
     have q_eq_rn := Nat.dvd_antisymm ((CharP.cast_eq_zero_iff R q (r ^ n)).mp rn_cast_zero) rn_dvd_q

--- a/Mathlib/Algebra/CharZero/Quotient.lean
+++ b/Mathlib/Algebra/CharZero/Quotient.lean
@@ -53,7 +53,7 @@ end AddSubgroup
 namespace QuotientAddGroup
 
 theorem zmultiples_zsmul_eq_zsmul_iff {ψ θ : R ⧸ AddSubgroup.zmultiples p} {z : ℤ} (hz : z ≠ 0) :
-    z • ψ = z • θ ↔ ∃ k : Fin z.natAbs, ψ = θ + (k : ℕ) • (p / z : R) := by
+    z • ψ = z • θ ↔ ∃ k : Fin z.natAbs, ψ = θ + ((k : ℕ) • (p / z : R) :) := by
   induction ψ using Quotient.inductionOn'
   induction θ using Quotient.inductionOn'
   -- Porting note: Introduced Zp notation to shorten lines

--- a/Mathlib/Algebra/GeomSum.lean
+++ b/Mathlib/Algebra/GeomSum.lean
@@ -145,7 +145,7 @@ theorem geom_sum₂_self {α : Type*} [CommRing α] (x : α) (n : ℕ) :
     ∑ i in Finset.range n, x ^ i * x ^ (n - 1 - i) =
         ∑ i in Finset.range n, x ^ (i + (n - 1 - i)) :=
       by simp_rw [← pow_add]
-    _ = ∑ i in Finset.range n, x ^ (n - 1) :=
+    _ = ∑ _i in Finset.range n, x ^ (n - 1) :=
       Finset.sum_congr rfl fun i hi =>
         congr_arg _ <| add_tsub_cancel_of_le <| Nat.le_pred_of_lt <| Finset.mem_range.1 hi
     _ = (Finset.range n).card • x ^ (n - 1) := Finset.sum_const _

--- a/Mathlib/Algebra/Group/Defs.lean
+++ b/Mathlib/Algebra/Group/Defs.lean
@@ -57,6 +57,9 @@ class HVAdd (α : Type u) (β : Type v) (γ : outParam (Type w)) where
 /--
 The notation typeclass for heterogeneous scalar multiplication.
 This enables the notation `a • b : γ` where `a : α`, `b : β`.
+
+It is assumed to represent an action on the left in some sense.
+When elaborating `a • b`, coercions get propagated to `b` and not to `a`.
 -/
 class HSMul (α : Type u) (β : Type v) (γ : outParam (Type w)) where
   /-- `a • b` computes the product of `a` and `b`.
@@ -86,6 +89,8 @@ class SMul (M : Type*) (α : Type _) where
 infixl:65 " +ᵥ " => HVAdd.hVAdd
 infixl:65 " -ᵥ " => VSub.vsub
 infixr:73 " • " => HSMul.hSMul
+
+macro_rules | `($x • $y) => `(leftact% HSMul.hSMul $x $y)
 
 attribute [to_additive existing] Mul Div HMul instHMul HDiv instHDiv HSMul
 attribute [to_additive (reorder := 1 2) SMul] Pow

--- a/Mathlib/Algebra/Jordan/Basic.lean
+++ b/Mathlib/Algebra/Jordan/Basic.lean
@@ -168,7 +168,6 @@ variable {A} [NonUnitalNonAssocRing A] [IsCommJordan A]
 The endomorphisms on an additive monoid `AddMonoid.End` form a `Ring`, and this may be equipped
 with a Lie Bracket via `Ring.bracket`.
 -/
---local macro_rules | `($x • $y) => `(HSMul.hSMul $x $y)
 
 theorem two_nsmul_lie_lmul_lmul_add_eq_lie_lmul_lmul_add (a b : A) :
     2 • (⁅L a, L (a * b)⁆ + ⁅L b, L (b * a)⁆) = ⁅L (a * a), L b⁆ + ⁅L (b * b), L a⁆ := by

--- a/Mathlib/Algebra/Jordan/Basic.lean
+++ b/Mathlib/Algebra/Jordan/Basic.lean
@@ -168,7 +168,7 @@ variable {A} [NonUnitalNonAssocRing A] [IsCommJordan A]
 The endomorphisms on an additive monoid `AddMonoid.End` form a `Ring`, and this may be equipped
 with a Lie Bracket via `Ring.bracket`.
 -/
-
+--local macro_rules | `($x • $y) => `(HSMul.hSMul $x $y)
 
 theorem two_nsmul_lie_lmul_lmul_add_eq_lie_lmul_lmul_add (a b : A) :
     2 • (⁅L a, L (a * b)⁆ + ⁅L b, L (b * a)⁆) = ⁅L (a * a), L b⁆ + ⁅L (b * b), L a⁆ := by
@@ -208,7 +208,7 @@ private theorem aux1 {a b c : A} :
   rw [add_lie, add_lie]
   iterate 15 rw [lie_add]
 
-set_option maxHeartbeats 300000 in
+set_option maxHeartbeats 350000 in
 private theorem aux2 {a b c : A} :
     ⁅L a, L (a * a)⁆ + ⁅L a, L (b * b)⁆ + ⁅L a, L (c * c)⁆ +
     ⁅L a, 2 • L (a * b)⁆ + ⁅L a, 2 • L (c * a)⁆ + ⁅L a, 2 • L (b * c)⁆ +
@@ -223,6 +223,7 @@ private theorem aux2 {a b c : A} :
     (2 • ⁅L a, L (b * c)⁆ + 2 • ⁅L b, L (c * a)⁆ + 2 • ⁅L c, L (a * b)⁆) := by
   rw [(commute_lmul_lmul_sq a).lie_eq, (commute_lmul_lmul_sq b).lie_eq,
     (commute_lmul_lmul_sq c).lie_eq, zero_add, add_zero, add_zero]
+  dsimp only -- for beta reducing terms such as (fun x ↦ AddMonoid.End A) (b * c)
   simp only [lie_nsmul]
   abel
 

--- a/Mathlib/Algebra/Module/DedekindDomain.lean
+++ b/Mathlib/Algebra/Module/DedekindDomain.lean
@@ -39,7 +39,7 @@ torsion submodules, where `I = ∏ i, p i ^ e i` is its unique decomposition in 
 theorem isInternal_prime_power_torsion_of_is_torsion_by_ideal {I : Ideal R} (hI : I ≠ ⊥)
     (hM : Module.IsTorsionBySet R M I) :
     DirectSum.IsInternal fun p : (factors I).toFinset =>
-      torsionBySet R M ((p : Ideal R) ^ (factors I).count ↑p) := by
+      torsionBySet R M (p ^ (factors I).count ↑p : Ideal R) := by
   let P := factors I
   have prime_of_mem := fun p (hp : p ∈ P.toFinset) =>
     prime_of_factor p (Multiset.mem_toFinset.mp hp)
@@ -66,7 +66,7 @@ theorem isInternal_prime_power_torsion_of_is_torsion_by_ideal {I : Ideal R} (hI 
 `e i` are their multiplicities. -/
 theorem isInternal_prime_power_torsion [Module.Finite R M] (hM : Module.IsTorsion R M) :
     DirectSum.IsInternal fun p : (factors (⊤ : Submodule R M).annihilator).toFinset =>
-      torsionBySet R M ((p : Ideal R) ^ (factors (⊤ : Submodule R M).annihilator).count ↑p) := by
+      torsionBySet R M (p ^ (factors (⊤ : Submodule R M).annihilator).count ↑p : Ideal R) := by
   have hM' := Module.isTorsionBySet_annihilator_top R M
   have hI := Submodule.annihilator_top_inter_nonZeroDivisors hM
   refine' isInternal_prime_power_torsion_of_is_torsion_by_ideal _ hM'
@@ -78,7 +78,7 @@ theorem isInternal_prime_power_torsion [Module.Finite R M] (hM : Module.IsTorsio
 `p i ^ e i`-torsion submodules for some prime ideals `p i` and numbers `e i`.-/
 theorem exists_isInternal_prime_power_torsion [Module.Finite R M] (hM : Module.IsTorsion R M) :
     ∃ (P : Finset <| Ideal R) (_ : DecidableEq P) (_ : ∀ p ∈ P, Prime p) (e : P → ℕ),
-      DirectSum.IsInternal fun p : P => torsionBySet R M ((p : Ideal R) ^ e p) :=
+      DirectSum.IsInternal fun p : P => torsionBySet R M (p ^ e p : Ideal R) :=
   ⟨_, _, fun p hp => prime_of_factor p (Multiset.mem_toFinset.mp hp), _,
     isInternal_prime_power_torsion hM⟩
 #align submodule.exists_is_internal_prime_power_torsion Submodule.exists_isInternal_prime_power_torsion

--- a/Mathlib/Algebra/Module/Injective.lean
+++ b/Mathlib/Algebra/Module/Injective.lean
@@ -414,7 +414,7 @@ def extensionOfMaxAdjoin (h : Module.Baer R Q) (y : N) : ExtensionOf i f where
             ↑(r • ExtensionOfMaxAdjoin.fst i a) + (r • ExtensionOfMaxAdjoin.snd i a) • y := by
           rw [ExtensionOfMaxAdjoin.eqn, smul_add, smul_eq_mul, mul_smul]
           rfl
-        rw [ExtensionOfMaxAdjoin.extensionToFun_wd i f h (r • a) _ _ eq1, LinearMap.map_smul,
+        rw [ExtensionOfMaxAdjoin.extensionToFun_wd i f h (r • a :) _ _ eq1, LinearMap.map_smul,
           LinearPMap.map_smul, ← smul_add]
         congr }
   is_extension m := by

--- a/Mathlib/Algebra/Order/Interval.lean
+++ b/Mathlib/Algebra/Order/Interval.lean
@@ -304,7 +304,7 @@ namespace NonemptyInterval
 
 @[to_additive]
 theorem coe_pow_interval [OrderedCommMonoid α] (s : NonemptyInterval α) (n : ℕ) :
-    (s ^ n : Interval α) = (s : Interval α) ^ n :=
+    ↑(s ^ n) = (s : Interval α) ^ n :=
   map_pow (⟨⟨(↑), coe_one_interval⟩, coe_mul_interval⟩ : NonemptyInterval α →* Interval α) _ _
 #align nonempty_interval.coe_pow_interval NonemptyInterval.coe_pow_interval
 #align nonempty_interval.coe_nsmul_interval NonemptyInterval.coe_nsmul_interval

--- a/Mathlib/Algebra/Order/Positive/Ring.lean
+++ b/Mathlib/Algebra/Order/Positive/Ring.lean
@@ -109,7 +109,7 @@ instance : Pow { x : R // 0 < x } ℕ :=
 
 @[simp]
 theorem val_pow (x : { x : R // 0 < x }) (n : ℕ) :
-    (x ^ n : R) = (x : R) ^ n :=
+    ↑(x ^ n) = (x : R) ^ n :=
   rfl
 #align positive.coe_pow Positive.val_pow
 

--- a/Mathlib/Algebra/Star/NonUnitalSubalgebra.lean
+++ b/Mathlib/Algebra/Star/NonUnitalSubalgebra.lean
@@ -280,7 +280,7 @@ protected theorem coe_sub {R : Type u} {A : Type v} [CommRing R] [NonUnitalRing 
 
 @[simp, norm_cast]
 theorem coe_smul [Semiring R'] [SMul R' R] [Module R' A] [IsScalarTower R' R A] (r : R') (x : S) :
-    (r • x : A) = r • (x : A) :=
+    ↑(r • x) = r • (x : A) :=
   rfl
 
 protected theorem coe_eq_zero {x : S} : (x : A) = 0 ↔ x = 0 :=

--- a/Mathlib/Analysis/Analytic/Basic.lean
+++ b/Mathlib/Analysis/Analytic/Basic.lean
@@ -325,7 +325,7 @@ theorem radius_eq_top_iff_summable_norm (p : FormalMultilinearSeries 𝕜 E F) :
 
 /-- If the radius of `p` is positive, then `‖pₙ‖` grows at most geometrically. -/
 theorem le_mul_pow_of_radius_pos (p : FormalMultilinearSeries 𝕜 E F) (h : 0 < p.radius) :
-    ∃ (C r : _) (hC : 0 < C) (hr : 0 < r), ∀ n, ‖p n‖ ≤ C * r ^ n := by
+    ∃ (C r : _) (_hC : 0 < C) (_hr : 0 < r), ∀ n, ‖p n‖ ≤ C * r ^ n := by
   rcases ENNReal.lt_iff_exists_nnreal_btwn.1 h with ⟨r, r0, rlt⟩
   have rpos : 0 < (r : ℝ) := by simp [ENNReal.coe_pos.1 r0]
   rcases norm_le_div_pow_of_pos_of_lt_radius p rpos rlt with ⟨C, Cpos, hCp⟩

--- a/Mathlib/Analysis/Fourier/AddCircle.lean
+++ b/Mathlib/Analysis/Fourier/AddCircle.lean
@@ -148,12 +148,12 @@ section Monomials
 /-- The family of exponential monomials `fun x => exp (2 π i n x / T)`, parametrized by `n : ℤ` and
 considered as bundled continuous maps from `ℝ / ℤ • T` to `ℂ`. -/
 def fourier (n : ℤ) : C(AddCircle T, ℂ) where
-  toFun x := toCircle (n • x)
+  toFun x := toCircle (n • x :) -- Porting note: `:)` to avoid elaboration timeout
   continuous_toFun := continuous_induced_dom.comp <| continuous_toCircle.comp <| continuous_zsmul _
 #align fourier fourier
 
 @[simp]
-theorem fourier_apply {n : ℤ} {x : AddCircle T} : fourier n x = toCircle (n • x) :=
+theorem fourier_apply {n : ℤ} {x : AddCircle T} : fourier n x = toCircle ↑(n • x) :=
   rfl
 #align fourier_apply fourier_apply
 
@@ -167,9 +167,10 @@ theorem fourier_coe_apply {n : ℤ} {x : ℝ} :
   congr 1; ring
 #align fourier_coe_apply fourier_coe_apply
 
+-- Porting note: `:)` to avoid elaboration timeout
 @[simp]
 theorem fourier_coe_apply' {n : ℤ} {x : ℝ} :
-    toCircle (n • (x : AddCircle T)) = Complex.exp (2 * π * Complex.I * n * x / T) := by
+    toCircle (n • (x : AddCircle T) :) = Complex.exp (2 * π * Complex.I * n * x / T) := by
   rw [← fourier_apply]; exact fourier_coe_apply
 
 -- @[simp] -- Porting note: simp normal form is `fourier_zero'`
@@ -203,8 +204,9 @@ theorem fourier_neg {n : ℤ} {x : AddCircle T} : fourier (-n) x = conj (fourier
     neg_smul, mul_neg]
 #align fourier_neg fourier_neg
 
+-- Porting note: `:)` to avoid elaboration timeout
 @[simp]
-theorem fourier_neg' {n : ℤ} {x : AddCircle T} : @toCircle T (-(n • x)) = conj (fourier n x) := by
+theorem fourier_neg' {n : ℤ} {x : AddCircle T} : @toCircle T (-(n • x) :) = conj (fourier n x) := by
   rw [← neg_smul, ← fourier_apply]; exact fourier_neg
 
 -- @[simp] -- Porting note: simp normal form is `fourier_add'`
@@ -212,9 +214,10 @@ theorem fourier_add {m n : ℤ} {x : AddCircle T} : fourier (m+n) x = fourier m 
   simp_rw [fourier_apply, add_zsmul, toCircle_add, coe_mul_unitSphere]
 #align fourier_add fourier_add
 
+-- Porting note: `:)` to avoid elaboration timeout
 @[simp]
 theorem fourier_add' {m n : ℤ} {x : AddCircle T} :
-    toCircle ((m + n) • x) = fourier m x * fourier n x := by
+    toCircle ((m + n) • x :) = fourier m x * fourier n x := by
   rw [← fourier_apply]; exact fourier_add
 
 theorem fourier_norm [Fact (0 < T)] (n : ℤ) : ‖@fourier T n‖ = 1 := by
@@ -366,8 +369,9 @@ theorem fourierCoeff_eq_intervalIntegral (f : AddCircle T → E) (n : ℤ) (a : 
     ← smul_assoc, smul_eq_mul, one_div_mul_cancel hT.out.ne', one_smul]
 #align fourier_coeff_eq_interval_integral fourierCoeff_eq_intervalIntegral
 
+-- Porting note: `:)` to avoid elaboration timeout
 theorem fourierCoeff.const_smul (f : AddCircle T → E) (c : ℂ) (n : ℤ) :
-    fourierCoeff (c • f) n = c • fourierCoeff f n := by
+    fourierCoeff (c • f :) n = c • fourierCoeff f n := by
   simp_rw [fourierCoeff, Pi.smul_apply, ← smul_assoc, smul_eq_mul, mul_comm, ← smul_eq_mul,
     smul_assoc, integral_smul]
 #align fourier_coeff.const_smul fourierCoeff.const_smul

--- a/Mathlib/Analysis/Fourier/RiemannLebesgueLemma.lean
+++ b/Mathlib/Analysis/Fourier/RiemannLebesgueLemma.lean
@@ -74,7 +74,8 @@ variable [CompleteSpace E]
 
 -- Porting note: binary operations appear not to work?
 -- local notation "i" => fun w => (1 / (2 * ‖w‖ ^ 2)) • w
-local notation "i" => fun (w : V) => HDiv.hDiv (1 : ℝ) (HMul.hMul (2 : ℝ) (HPow.hPow ‖w‖ 2)) • w
+local notation "i" => fun (w : V) =>
+  HSMul.hSMul (HDiv.hDiv (1 : ℝ) (HMul.hMul (2 : ℝ) (HPow.hPow ‖w‖ 2))) w
 
 /-- Shifting `f` by `(1 / (2 * ‖w‖ ^ 2)) • w` negates the integral in the Riemann-Lebesgue lemma. -/
 theorem fourier_integral_half_period_translate {w : V} (hw : w ≠ 0) :

--- a/Mathlib/Analysis/InnerProductSpace/Rayleigh.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Rayleigh.lean
@@ -242,7 +242,7 @@ namespace IsSymmetric
 /-- The supremum of the Rayleigh quotient of a symmetric operator `T` on a nontrivial
 finite-dimensional vector space is an eigenvalue for that operator. -/
 theorem hasEigenvalue_iSup_of_finiteDimensional (hT : T.IsSymmetric) :
-    HasEigenvalue T ↑(⨆ x : { x : E // x ≠ 0 }, IsROrC.re ⟪T x, x⟫ / ‖(x : E)‖ ^ 2) := by
+    HasEigenvalue T (⨆ x : { x : E // x ≠ 0 }, IsROrC.re ⟪T x, x⟫ / ‖(x : E)‖ ^ 2 : ℝ) := by
   haveI := FiniteDimensional.proper_isROrC 𝕜 E
   let T' := hT.toSelfAdjoint
   obtain ⟨x, hx⟩ : ∃ x : E, x ≠ 0 := exists_ne 0
@@ -262,7 +262,7 @@ theorem hasEigenvalue_iSup_of_finiteDimensional (hT : T.IsSymmetric) :
 /-- The infimum of the Rayleigh quotient of a symmetric operator `T` on a nontrivial
 finite-dimensional vector space is an eigenvalue for that operator. -/
 theorem hasEigenvalue_iInf_of_finiteDimensional (hT : T.IsSymmetric) :
-    HasEigenvalue T ↑(⨅ x : { x : E // x ≠ 0 }, IsROrC.re ⟪T x, x⟫ / ‖(x : E)‖ ^ 2) := by
+    HasEigenvalue T (⨅ x : { x : E // x ≠ 0 }, IsROrC.re ⟪T x, x⟫ / ‖(x : E)‖ ^ 2 : ℝ) := by
   haveI := FiniteDimensional.proper_isROrC 𝕜 E
   let T' := hT.toSelfAdjoint
   obtain ⟨x, hx⟩ : ∃ x : E, x ≠ 0 := exists_ne 0

--- a/Mathlib/Analysis/MeanInequalities.lean
+++ b/Mathlib/Analysis/MeanInequalities.lean
@@ -98,8 +98,6 @@ set_option linter.uppercaseLean3 false
 
 noncomputable section
 
-local macro_rules | `($x ^ $y) => `(HPow.hPow $x $y) -- Porting note: See issue lean4#2220
-
 variable {ι : Type u} (s : Finset ι)
 
 section GeomMeanLEArithMean

--- a/Mathlib/Analysis/MellinTransform.lean
+++ b/Mathlib/Analysis/MellinTransform.lean
@@ -150,7 +150,7 @@ theorem mellin_comp_mul_left (f : ℝ → E) (s : ℂ) {a : ℝ} (ha : 0 < a) :
     rw [Ne.def, cpow_eq_zero_iff, ofReal_eq_zero, not_and_or]
     exact Or.inl ha.ne'
   rw [set_integral_congr measurableSet_Ioi this, integral_smul,
-    integral_comp_mul_left_Ioi (fun u ↦ ↑u ^ (s - 1) • f u) _ ha,
+    integral_comp_mul_left_Ioi (fun u ↦ (u : ℂ) ^ (s - 1) • f u) _ ha,
     mul_zero, ← Complex.coe_smul, ← mul_smul, sub_eq_add_neg,
     cpow_add _ _ (ofReal_ne_zero.mpr ha.ne'), cpow_one, abs_of_pos (inv_pos.mpr ha), ofReal_inv,
     mul_assoc, mul_comm, inv_mul_cancel_right₀ (ofReal_ne_zero.mpr ha.ne')]
@@ -386,7 +386,7 @@ theorem mellin_hasDerivAt_of_isBigO_rpow [CompleteSpace E] [NormedSpace ℂ E] {
       rwa [sub_re, sub_le_iff_le_add, ← sub_le_iff_le_add'] at hz'
   have h5 : IntegrableOn bound (Ioi 0) := by
     simp_rw [add_mul, mul_assoc]
-    suffices ∀ {j : ℝ} (hj : b < j) (hj' : j < a),
+    suffices ∀ {j : ℝ}, b < j → j < a →
         IntegrableOn (fun t : ℝ => t ^ (j - 1) * (|log t| * ‖f t‖)) (Ioi 0) volume by
       refine' Integrable.add (this _ _) (this _ _)
       all_goals linarith

--- a/Mathlib/Analysis/NormedSpace/DualNumber.lean
+++ b/Mathlib/Analysis/NormedSpace/DualNumber.lean
@@ -37,7 +37,7 @@ theorem exp_eps : exp 𝕜 (eps : DualNumber R) = 1 + eps :=
 
 @[simp]
 theorem exp_smul_eps (r : R) : exp 𝕜 (r • eps : DualNumber R) = 1 + r • eps := by
-  rw [eps, ← inr_smul, exp_inr, Nat.cast_one]
+  rw [eps, ← inr_smul, exp_inr]
 #align dual_number.exp_smul_eps DualNumber.exp_smul_eps
 
 end DualNumber

--- a/Mathlib/Analysis/NormedSpace/Multilinear.lean
+++ b/Mathlib/Analysis/NormedSpace/Multilinear.lean
@@ -224,7 +224,7 @@ theorem norm_image_sub_le_of_bound {C : ℝ} (hC : 0 ≤ C) (H : ∀ m, ‖f m�
   calc
     ‖f m₁ - f m₂‖ ≤ C * ∑ i, ∏ j, if j = i then ‖m₁ i - m₂ i‖ else max ‖m₁ j‖ ‖m₂ j‖ :=
       f.norm_image_sub_le_of_bound' hC H m₁ m₂
-    _ ≤ C * ∑ i, ‖m₁ - m₂‖ * max ‖m₁‖ ‖m₂‖ ^ (Fintype.card ι - 1) := by gcongr; apply A
+    _ ≤ C * ∑ _i, ‖m₁ - m₂‖ * max ‖m₁‖ ‖m₂‖ ^ (Fintype.card ι - 1) := by gcongr; apply A
     _ = C * Fintype.card ι * max ‖m₁‖ ‖m₂‖ ^ (Fintype.card ι - 1) * ‖m₁ - m₂‖ := by
       rw [sum_const, card_univ, nsmul_eq_mul]
       ring

--- a/Mathlib/Analysis/NormedSpace/QuaternionExponential.lean
+++ b/Mathlib/Analysis/NormedSpace/QuaternionExponential.lean
@@ -66,8 +66,6 @@ theorem hasSum_expSeries_of_imaginary {q : Quaternion ℝ} (hq : q.re = 0) {c s 
       _ = ↑((-1 : ℝ) ^ n * ‖q‖ ^ (2 * n) / k) := ?_
     · congr 1
       rw [neg_pow, normSq_eq_norm_mul_self, pow_mul, sq]
-      push_cast
-      rfl
     · rw [← coe_mul_eq_smul, div_eq_mul_inv]
       norm_cast
       ring_nf

--- a/Mathlib/Analysis/SpecialFunctions/Gamma/Basic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Gamma/Basic.lean
@@ -208,7 +208,7 @@ theorem partialGamma_add_one {s : ℂ} (hs : 0 < s.re) {X : ℝ} (hX : 0 ≤ X) 
     intro x hx
     have d1 : HasDerivAt (fun y : ℝ => (-y).exp) (-(-x).exp) x := by
       simpa using (hasDerivAt_neg x).exp
-    have d2 : HasDerivAt (fun y : ℝ => ↑y ^ s) (s * x ^ (s - 1)) x := by
+    have d2 : HasDerivAt (fun y : ℝ => (y : ℂ) ^ s) (s * x ^ (s - 1)) x := by
       have t := @HasDerivAt.cpow_const _ _ _ s (hasDerivAt_id ↑x) ?_
       simpa only [mul_one] using t.comp_ofReal
       simpa only [id.def, ofReal_re, ofReal_im, Ne.def, eq_self_iff_true, not_true, or_false_iff,

--- a/Mathlib/Analysis/SpecialFunctions/Gamma/Beta.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Gamma/Beta.lean
@@ -290,13 +290,13 @@ theorem GammaSeq_eq_approx_Gamma_integral {s : ℂ} (hs : 0 < re s) {n : ℕ} (h
 /-- The main techical lemma for `GammaSeq_tendsto_Gamma`, expressing the integral defining the
 Gamma function for `0 < re s` as the limit of a sequence of integrals over finite intervals. -/
 theorem approx_Gamma_integral_tendsto_Gamma_integral {s : ℂ} (hs : 0 < re s) :
-    Tendsto (fun n : ℕ => ∫ x : ℝ in (0)..n, ↑((1 - x / n) ^ n) * (x : ℂ) ^ (s - 1)) atTop
+    Tendsto (fun n : ℕ => ∫ x : ℝ in (0)..n, ((1 - x / n) ^ n : ℝ) * (x : ℂ) ^ (s - 1)) atTop
       (𝓝 <| Gamma s) := by
   rw [Gamma_eq_integral hs]
   -- We apply dominated convergence to the following function, which we will show is uniformly
   -- bounded above by the Gamma integrand `exp (-x) * x ^ (re s - 1)`.
   let f : ℕ → ℝ → ℂ := fun n =>
-    indicator (Ioc 0 (n : ℝ)) fun x : ℝ => ↑((1 - x / n) ^ n) * (x : ℂ) ^ (s - 1)
+    indicator (Ioc 0 (n : ℝ)) fun x : ℝ => ((1 - x / n) ^ n : ℝ) * (x : ℂ) ^ (s - 1)
   -- integrability of f
   have f_ible : ∀ n : ℕ, Integrable (f n) (volume.restrict (Ioi 0)) := by
     intro n
@@ -311,10 +311,10 @@ theorem approx_Gamma_integral_tendsto_Gamma_integral {s : ℂ} (hs : 0 < re s) :
         ((continuous_const.sub (continuous_id'.div_const ↑n)).pow n)
   -- pointwise limit of f
   have f_tends : ∀ x : ℝ, x ∈ Ioi (0 : ℝ) →
-      Tendsto (fun n : ℕ => f n x) atTop (𝓝 <| ↑(Real.exp (-x)) * (x : ℂ) ^ (s - 1)) := by
+      Tendsto (fun n : ℕ => f n x) atTop (𝓝 <| (Real.exp (-x)) * (x : ℂ) ^ (s - 1)) := by
     intro x hx
     apply Tendsto.congr'
-    show ∀ᶠ n : ℕ in atTop, ↑((1 - x / n) ^ n) * (x : ℂ) ^ (s - 1) = f n x
+    show ∀ᶠ n : ℕ in atTop, ((1 - x / n) ^ n : ℝ) * (x : ℂ) ^ (s - 1) = f n x
     · refine' Eventually.mp (eventually_ge_atTop ⌈x⌉₊) (eventually_of_forall fun n hn => _)
       rw [Nat.ceil_le] at hn
       dsimp only
@@ -324,7 +324,7 @@ theorem approx_Gamma_integral_tendsto_Gamma_integral {s : ℂ} (hs : 0 < re s) :
       refine' (Tendsto.comp (continuous_ofReal.tendsto _) _).const_mul _
       convert tendsto_one_plus_div_pow_exp (-x) using 1
       ext1 n
-      rw [neg_div, ← sub_eq_add_neg]; norm_cast
+      rw [neg_div, ← sub_eq_add_neg]
   -- let `convert` identify the remaining goals
   convert tendsto_integral_of_dominated_convergence _ (fun n => (f_ible n).1)
     (Real.GammaIntegral_convergent hs) _

--- a/Mathlib/Analysis/SpecialFunctions/Pow/Continuity.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Continuity.lean
@@ -21,8 +21,6 @@ open Classical Real Topology NNReal ENNReal Filter BigOperators ComplexConjugate
 
 open Filter Finset Set
 
-local macro_rules | `($x ^ $y) => `(HPow.hPow $x $y) -- Porting note: See issue lean4#2220
-
 section CpowLimits
 
 /-!

--- a/Mathlib/Analysis/SpecialFunctions/Pow/Deriv.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Deriv.lean
@@ -237,9 +237,9 @@ theorem hasDerivAt_ofReal_cpow {x : ℝ} (hx : x ≠ 0) {r : ℂ} (hr : r ≠ -1
     rw [mul_add ((π : ℂ) * _), mul_one, exp_add, exp_pi_mul_I, mul_comm (_ : ℂ) (-1 : ℂ),
       neg_one_mul]
     simp_rw [mul_neg, ← neg_mul, ← ofReal_neg]
-    suffices HasDerivAt (fun y : ℝ => ↑(-y) ^ (r + 1)) (-(r + 1) * ↑(-x) ^ r) x by
+    suffices HasDerivAt (fun y : ℝ => ((-y :) : ℂ) ^ (r + 1)) (-(r + 1) * ((-x :) : ℂ) ^ r) x by
       convert this.neg.mul_const _ using 1; ring
-    suffices HasDerivAt (fun y : ℝ => ↑y ^ (r + 1)) ((r + 1) * ↑(-x) ^ r) (-x) by
+    suffices HasDerivAt (fun y : ℝ => (y : ℂ) ^ (r + 1)) ((r + 1) * ((-x :) : ℂ) ^ r) (-x) by
       convert @HasDerivAt.scomp ℝ _ ℂ _ _ x ℝ _ _ _ _ _ _ _ _ this (hasDerivAt_neg x) using 1
       rw [real_smul, ofReal_neg 1, ofReal_one]; ring
     suffices HasDerivAt (fun y : ℂ => y ^ (r + 1)) ((r + 1) * ↑(-x) ^ r) ↑(-x) by
@@ -331,7 +331,7 @@ lemma differentiableAt_rpow_const_of_ne (p : ℝ) {x : ℝ} (hx : x ≠ 0) :
   (hasStrictDerivAt_rpow_const_of_ne hx p).differentiableAt
 
 lemma differentiableOn_rpow_const (p : ℝ) :
-    DifferentiableOn ℝ (fun x => x ^ p) {0}ᶜ :=
+    DifferentiableOn ℝ (fun x => (x : ℝ) ^ p) {0}ᶜ :=
   fun _ hx => (Real.differentiableAt_rpow_const_of_ne p hx).differentiableWithinAt
 
 /-- This lemma says that `fun x => a ^ x` is strictly differentiable for `a < 0`. Note that these

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Angle.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Angle.lean
@@ -183,7 +183,7 @@ theorem two_zsmul_eq_iff {ψ θ : Angle} : (2 : ℤ) • ψ = (2 : ℤ) • θ �
   -- Porting note: no `Int.natAbs_bit0` anymore
   have : Int.natAbs 2 = 2 := rfl
   rw [zsmul_eq_iff two_ne_zero, this, Fin.exists_fin_two, Fin.val_zero,
-    Fin.val_one, zero_smul, coe_zero, add_zero, one_smul, Int.cast_two,
+    Fin.val_one, zero_smul, add_zero, one_smul, Int.cast_two,
     mul_div_cancel_left (_ : ℝ) two_ne_zero]
 #align real.angle.two_zsmul_eq_iff Real.Angle.two_zsmul_eq_iff
 
@@ -223,7 +223,7 @@ theorem neg_ne_self_iff {θ : Angle} : -θ ≠ θ ↔ θ ≠ 0 ∧ θ ≠ π := 
 #align real.angle.neg_ne_self_iff Real.Angle.neg_ne_self_iff
 
 theorem two_nsmul_eq_pi_iff {θ : Angle} : (2 : ℕ) • θ = π ↔ θ = (π / 2 : ℝ) ∨ θ = (-π / 2 : ℝ) := by
-  have h : (π : Angle) = (2 : ℕ) • (π / 2 : ℝ) := by rw [two_nsmul, add_halves]
+  have h : (π : Angle) = ((2 : ℕ) • (π / 2 : ℝ) :) := by rw [two_nsmul, add_halves]
   nth_rw 1 [h]
   rw [coe_nsmul, two_nsmul_eq_iff]
   -- Porting note: `congr` didn't simplify the goal of iff of `Or`s

--- a/Mathlib/CategoryTheory/Action.lean
+++ b/Mathlib/CategoryTheory/Action.lean
@@ -160,7 +160,7 @@ def endMulEquivSubgroup (H : Subgroup G) : End (objEquiv G (G ⧸ H) ↑(1 : G))
 #align category_theory.action_category.End_mul_equiv_subgroup CategoryTheory.ActionCategory.endMulEquivSubgroup
 
 /-- A target vertex `t` and a scalar `g` determine a morphism in the action groupoid. -/
-def homOfPair (t : X) (g : G) : @Quiver.Hom (ActionCategory G X) _ (g⁻¹ • t) t :=
+def homOfPair (t : X) (g : G) : @Quiver.Hom (ActionCategory G X) _ (g⁻¹ • t :) t :=
   Subtype.mk g (smul_inv_smul g t)
 #align category_theory.action_category.hom_of_pair CategoryTheory.ActionCategory.homOfPair
 

--- a/Mathlib/Combinatorics/Additive/Behrend.lean
+++ b/Mathlib/Combinatorics/Additive/Behrend.lean
@@ -248,7 +248,8 @@ theorem exists_large_sphere_aux (n d : ℕ) : ∃ k ∈ range (n * (d - 1) ^ 2 +
     exact (cast_add_one_pos _).ne'
 #align behrend.exists_large_sphere_aux Behrend.exists_large_sphere_aux
 
-theorem exists_large_sphere (n d : ℕ) : ∃ k, ((d ^ n :) / (n * d ^ 2 :) : ℝ) ≤ (sphere n d k).card := by
+theorem exists_large_sphere (n d : ℕ) :
+    ∃ k, ((d ^ n :) / (n * d ^ 2 :) : ℝ) ≤ (sphere n d k).card := by
   obtain ⟨k, -, hk⟩ := exists_large_sphere_aux n d
   refine' ⟨k, _⟩
   obtain rfl | hn := n.eq_zero_or_pos

--- a/Mathlib/Combinatorics/Additive/Behrend.lean
+++ b/Mathlib/Combinatorics/Additive/Behrend.lean
@@ -239,7 +239,7 @@ that we then optimize by tweaking the parameters. The (almost) optimal parameter
 
 
 theorem exists_large_sphere_aux (n d : ℕ) : ∃ k ∈ range (n * (d - 1) ^ 2 + 1),
-    (↑(d ^ n) / (↑(n * (d - 1) ^ 2) + 1) : ℝ) ≤ (sphere n d k).card := by
+    (↑(d ^ n) / ((n * (d - 1) ^ 2 :) + 1) : ℝ) ≤ (sphere n d k).card := by
   refine' exists_le_card_fiber_of_nsmul_le_card_of_maps_to (fun x hx => _) nonempty_range_succ _
   · rw [mem_range, lt_succ_iff]
     exact sum_sq_le_of_mem_box hx
@@ -248,14 +248,13 @@ theorem exists_large_sphere_aux (n d : ℕ) : ∃ k ∈ range (n * (d - 1) ^ 2 +
     exact (cast_add_one_pos _).ne'
 #align behrend.exists_large_sphere_aux Behrend.exists_large_sphere_aux
 
-theorem exists_large_sphere (n d : ℕ) : ∃ k, (d ^ n / ↑(n * d ^ 2) : ℝ) ≤ (sphere n d k).card := by
+theorem exists_large_sphere (n d : ℕ) : ∃ k, ((d ^ n :) / (n * d ^ 2 :) : ℝ) ≤ (sphere n d k).card := by
   obtain ⟨k, -, hk⟩ := exists_large_sphere_aux n d
   refine' ⟨k, _⟩
   obtain rfl | hn := n.eq_zero_or_pos
   · simp
   obtain rfl | hd := d.eq_zero_or_pos
   · simp
-  rw [rpow_nat_cast, ← cast_pow]
   refine' (div_le_div_of_le_left _ _ _).trans hk
   · exact cast_nonneg _
   · exact cast_add_one_pos _
@@ -268,7 +267,7 @@ theorem exists_large_sphere (n d : ℕ) : ∃ k, (d ^ n / ↑(n * d ^ 2) : ℝ) 
   exact one_le_cast.2 hd
 #align behrend.exists_large_sphere Behrend.exists_large_sphere
 
-theorem bound_aux' (n d : ℕ) : (d ^ n / ↑(n * d ^ 2) : ℝ) ≤ rothNumberNat ((2 * d - 1) ^ n) :=
+theorem bound_aux' (n d : ℕ) : ((d ^ n :) / (n * d ^ 2 :) : ℝ) ≤ rothNumberNat ((2 * d - 1) ^ n) :=
   let ⟨_, h⟩ := exists_large_sphere n d
   h.trans <| cast_le.2 <| card_sphere_le_rothNumberNat _ _ _
 #align behrend.bound_aux' Behrend.bound_aux'
@@ -276,8 +275,8 @@ theorem bound_aux' (n d : ℕ) : (d ^ n / ↑(n * d ^ 2) : ℝ) ≤ rothNumberNa
 theorem bound_aux (hd : d ≠ 0) (hn : 2 ≤ n) :
     (d ^ (n - 2) / n : ℝ) ≤ rothNumberNat ((2 * d - 1) ^ n) := by
   convert bound_aux' n d using 1
-  rw [cast_mul, cast_pow, mul_comm, ← div_div, ← cast_two, ← cast_sub hn, rpow_nat_cast,
-    rpow_nat_cast, pow_sub₀ _ (cast_ne_zero.2 hd) hn, ← div_eq_mul_inv]
+  rw [cast_mul, cast_pow, mul_comm, ← div_div, pow_sub₀ _ _ hn, ← div_eq_mul_inv, cast_pow]
+  rwa [cast_ne_zero]
 #align behrend.bound_aux Behrend.bound_aux
 
 open scoped Filter Topology
@@ -432,7 +431,8 @@ theorem le_N (hN : 2 ≤ N) : (2 * dValue N - 1) ^ nValue N ≤ N := by
   apply this.trans
   suffices ((2 * dValue N) ^ nValue N : ℝ) ≤ N by exact_mod_cast this
   suffices i : (2 * dValue N : ℝ) ≤ (N : ℝ) ^ (1 / nValue N : ℝ)
-  · apply (rpow_le_rpow (mul_nonneg zero_le_two (cast_nonneg _)) i (cast_nonneg _)).trans
+  · rw [← rpow_nat_cast]
+    apply (rpow_le_rpow (mul_nonneg zero_le_two (cast_nonneg _)) i (cast_nonneg _)).trans
     rw [← rpow_mul (cast_nonneg _), one_div_mul_cancel, rpow_one]
     rw [cast_ne_zero]
     apply (nValue_pos hN).ne'
@@ -487,7 +487,6 @@ theorem roth_lower_bound_explicit (hN : 4096 ≤ N) :
   have hn₂ : 2 ≤ n := two_le_nValue (hN.trans' <| by norm_num1)
   have : (2 * dValue N - 1) ^ n ≤ N := le_N (hN.trans' <| by norm_num1)
   refine' ((bound_aux hd.ne' hn₂).trans <| cast_le.2 <| rothNumberNat.mono this).trans_lt' _
-  conv_rhs => rw [← cast_two, ← cast_sub hn₂, rpow_nat_cast]
   refine' (div_lt_div_of_lt hn <| pow_lt_pow_of_lt_left (bound hN) _ _).trans_le' _
   · exact div_nonneg (rpow_nonneg_of_nonneg (cast_nonneg _) _) (exp_pos _).le
   · exact tsub_pos_of_lt (three_le_nValue <| hN.trans' <| by norm_num1)
@@ -521,7 +520,7 @@ theorem exp_four_lt : exp 4 < 64 := by
 
 theorem four_zero_nine_six_lt_exp_sixteen : 4096 < exp 16 := by
   rw [← log_lt_iff_lt_exp (show (0 : ℝ) < 4096 by norm_num), show (4096 : ℝ) = 2 ^ 12 by norm_cast,
-    log_rpow zero_lt_two]
+    ← rpow_nat_cast, log_rpow zero_lt_two, cast_ofNat]
   have : 12 * (0.6931471808 : ℝ) < 16 := by norm_num
   linarith [log_two_lt_d9]
 #align behrend.four_zero_nine_six_lt_exp_sixteen Behrend.four_zero_nine_six_lt_exp_sixteen

--- a/Mathlib/Combinatorics/SimpleGraph/Regularity/Bound.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Regularity/Bound.lean
@@ -32,8 +32,6 @@ This entire file is internal to the proof of Szemerédi Regularity Lemma.
 
 open Finset Fintype Function Real
 
-local macro_rules | `($x ^ $y) => `(HPow.hPow $x $y) -- Porting note: See issue lean4#2220
-
 open BigOperators
 
 namespace SzemerediRegularity

--- a/Mathlib/Combinatorics/SimpleGraph/Regularity/Chunk.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Regularity/Chunk.lean
@@ -39,8 +39,6 @@ Once ported to mathlib4, this file will be a great golfing ground for Heather's 
 
 open Finpartition Finset Fintype Rel Nat
 
-local macro_rules | `($x ^ $y) => `(HPow.hPow $x $y) -- Porting note: See issue lean4#2220
-
 open scoped BigOperators Classical SzemerediRegularity.Positivity
 
 namespace SzemerediRegularity

--- a/Mathlib/Combinatorics/SimpleGraph/Regularity/Energy.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Regularity/Energy.lean
@@ -32,8 +32,6 @@ open BigOperators
 variable {α : Type*} [DecidableEq α] {s : Finset α} (P : Finpartition s) (G : SimpleGraph α)
   [DecidableRel G.Adj]
 
-local macro_rules | `($x ^ $y) => `(HPow.hPow $x $y) -- Porting note: See issue lean4#2220
-
 namespace Finpartition
 
 /-- The energy of a partition, also known as index. Auxiliary quantity for Szemerédi's regularity

--- a/Mathlib/Combinatorics/SimpleGraph/Regularity/Increment.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Regularity/Increment.lean
@@ -38,8 +38,6 @@ Once ported to mathlib4, this file will be a great golfing ground for Heather's 
 
 open Finset Fintype SimpleGraph SzemerediRegularity
 
-local macro_rules | `($x ^ $y) => `(HPow.hPow $x $y) -- Porting note: See issue lean4#2220
-
 open scoped BigOperators Classical SzemerediRegularity.Positivity
 
 variable {α : Type*} [Fintype α] {P : Finpartition (univ : Finset α)} (hP : P.IsEquipartition)

--- a/Mathlib/Combinatorics/SimpleGraph/Regularity/Lemma.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Regularity/Lemma.lean
@@ -68,8 +68,6 @@ open Finpartition Finset Fintype Function SzemerediRegularity
 
 open scoped Classical
 
-local macro_rules | `($x ^ $y) => `(HPow.hPow $x $y) -- Porting note: See issue lean4#2220
-
 variable {α : Type*} [Fintype α] (G : SimpleGraph α) {ε : ℝ} {l : ℕ}
 
 /-- Effective **Szemerédi Regularity Lemma**: For any sufficiently large graph, there is an

--- a/Mathlib/Data/Complex/Basic.lean
+++ b/Mathlib/Data/Complex/Basic.lean
@@ -372,10 +372,10 @@ variable {R : Type*} [SMul R ℝ]
 instance instSMulRealComplex : SMul R ℂ where
   smul r x := ⟨r • x.re - 0 * x.im, r • x.im + 0 * x.re⟩
 
-theorem smul_re (r : R) (z : ℂ) : (r • z).re = r • z.re := by simp [(· • ·), SMul.smul]
+theorem smul_re (r : R) (z : ℂ) : (r • z).re = r • z.re := by simp [HSMul.hSMul, SMul.smul]
 #align complex.smul_re Complex.smul_re
 
-theorem smul_im (r : R) (z : ℂ) : (r • z).im = r • z.im := by simp [(· • ·), SMul.smul]
+theorem smul_im (r : R) (z : ℂ) : (r • z).im = r • z.im := by simp [HSMul.hSMul, SMul.smul]
 #align complex.smul_im Complex.smul_im
 
 @[simp]

--- a/Mathlib/Data/Int/Bitwise.lean
+++ b/Mathlib/Data/Int/Bitwise.lean
@@ -430,12 +430,12 @@ theorem shiftl_sub (m : ℤ) (n : ℕ) (k : ℤ) : shiftl m (n - k) = shiftr (sh
   shiftl_add _ _ _
 #align int.shiftl_sub Int.shiftl_sub
 
-theorem shiftl_eq_mul_pow : ∀ (m : ℤ) (n : ℕ), shiftl m n = m * ↑(2 ^ n)
+theorem shiftl_eq_mul_pow : ∀ (m : ℤ) (n : ℕ), shiftl m n = m * (2 ^ n : ℕ)
   | (m : ℕ), _ => congr_arg ((↑) : ℕ → ℤ) (by simp)
   | -[_+1], _ => @congr_arg ℕ ℤ _ _ (fun i => -i) (Nat.shiftLeft'_tt_eq_mul_pow _ _)
 #align int.shiftl_eq_mul_pow Int.shiftl_eq_mul_pow
 
-theorem shiftr_eq_div_pow : ∀ (m : ℤ) (n : ℕ), shiftr m n = m / ↑(2 ^ n)
+theorem shiftr_eq_div_pow : ∀ (m : ℤ) (n : ℕ), shiftr m n = m / (2 ^ n : ℕ)
   | (m : ℕ), n => by rw [shiftr_coe_nat, Nat.shiftRight_eq_div_pow _ _]; simp
   | -[m+1], n => by
     rw [shiftr_negSucc, negSucc_ediv, Nat.shiftRight_eq_div_pow]; rfl

--- a/Mathlib/Data/PNat/Prime.lean
+++ b/Mathlib/Data/PNat/Prime.lean
@@ -295,7 +295,7 @@ theorem gcd_eq_left {m n : ℕ+} : m ∣ n → m.gcd n = m := by
   apply Nat.gcd_eq_left h
 #align pnat.gcd_eq_left PNat.gcd_eq_left
 
-theorem Coprime.pow {m n : ℕ+} (k l : ℕ) (h : m.Coprime n) : (m ^ k).coprime (n ^ l) := by
+theorem Coprime.pow {m n : ℕ+} (k l : ℕ) (h : m.Coprime n) : (m ^ k : ℕ).coprime (n ^ l) := by
   rw [← coprime_coe] at *; apply Nat.coprime.pow; apply h
 #align pnat.coprime.pow PNat.Coprime.pow
 

--- a/Mathlib/Data/Polynomial/Laurent.lean
+++ b/Mathlib/Data/Polynomial/Laurent.lean
@@ -579,7 +579,7 @@ instance : Module R[X] R[T;T⁻¹] :=
   Module.compHom _ Polynomial.toLaurent
 
 instance (R : Type*) [Semiring R] : IsScalarTower R[X] R[X] R[T;T⁻¹] where
-  smul_assoc x y z := by simp only [(· • ·), SMul.smul, SMul.comp.smul, map_mul, mul_assoc]
+  smul_assoc x y z := by simp only [HSMul.hSMul, SMul.smul, SMul.comp.smul, map_mul, mul_assoc]
 
 end Semiring
 

--- a/Mathlib/Data/Rat/Cast.lean
+++ b/Mathlib/Data/Rat/Cast.lean
@@ -283,7 +283,7 @@ theorem cast_mk (a b : ℤ) : (a /. b : α) = a / b := by
 #align rat.cast_mk Rat.cast_mk
 
 @[simp, norm_cast]
-theorem cast_pow (q) (k : ℕ) : ((q : ℚ) ^ k : α) = (q : α) ^ k :=
+theorem cast_pow (q) (k : ℕ) : ((q ^ k : ℚ) : α) = (q : α) ^ k :=
   (castHom α).map_pow q k
 #align rat.cast_pow Rat.cast_pow
 

--- a/Mathlib/FieldTheory/PrimitiveElement.lean
+++ b/Mathlib/FieldTheory/PrimitiveElement.lean
@@ -61,7 +61,7 @@ theorem exists_primitive_element_of_finite_top [Finite E] : ∃ α : E, F⟮α�
     exact F⟮α.val⟯.zero_mem
   · obtain ⟨n, hn⟩ := Set.mem_range.mp (hα (Units.mk0 x hx))
     simp only at hn
-    rw [show x = α ^ n by norm_cast; rw [hn, Units.val_mk0], Units.val_zpow_eq_zpow_val]
+    rw [show x = α ^ n by norm_cast; rw [hn, Units.val_mk0]]
     exact zpow_mem (mem_adjoin_simple_self F (E := E) ↑α) n
 #align field.exists_primitive_element_of_finite_top Field.exists_primitive_element_of_finite_top
 

--- a/Mathlib/FieldTheory/Subfield.lean
+++ b/Mathlib/FieldTheory/Subfield.lean
@@ -109,7 +109,7 @@ instance (s : S) : SMul ℚ s :=
   ⟨fun a x => ⟨a • (x : K), rat_smul_mem s a x⟩⟩
 
 @[simp]
-theorem coe_rat_smul (s : S) (a : ℚ) (x : s) : (a • x : K) = a • (x : K) :=
+theorem coe_rat_smul (s : S) (a : ℚ) (x : s) : ↑(a • x) = a • (x : K) :=
   rfl
 #align subfield_class.coe_rat_smul SubfieldClass.coe_rat_smul
 

--- a/Mathlib/Geometry/Euclidean/Angle/Oriented/Basic.lean
+++ b/Mathlib/Geometry/Euclidean/Angle/Oriented/Basic.lean
@@ -515,7 +515,6 @@ theorem oangle_add {x y z : V} (hx : x ≠ 0) (hy : y ≠ 0) (hz : z ≠ 0) :
   rw [← Complex.arg_mul_coe_angle, o.kahler_mul y x z]
   congr 1
   convert Complex.arg_real_mul _ (_ : 0 < ‖y‖ ^ 2) using 2
-  · norm_cast
   · have : 0 < ‖y‖ := by simpa using hy
     positivity
   · exact o.kahler_ne_zero hx hy

--- a/Mathlib/GroupTheory/GroupAction/Defs.lean
+++ b/Mathlib/GroupTheory/GroupAction/Defs.lean
@@ -630,9 +630,9 @@ def compHom [Monoid N] (g : N →* M) :
     MulAction N α where
   smul := SMul.comp.smul g
   -- Porting note: was `by simp [g.map_one, MulAction.one_smul]`
-  one_smul _ := by simp [(· • ·)]; apply MulAction.one_smul
+  one_smul _ := by simp [HSMul.hSMul]; apply MulAction.one_smul
   -- Porting note: was `by simp [g.map_mul, MulAction.mul_smul]`
-  mul_smul _ _ _ := by simp [(· • ·)]; apply MulAction.mul_smul
+  mul_smul _ _ _ := by simp [HSMul.hSMul]; apply MulAction.mul_smul
 #align mul_action.comp_hom MulAction.compHom
 #align add_action.comp_hom AddAction.compHom
 

--- a/Mathlib/GroupTheory/GroupAction/Quotient.lean
+++ b/Mathlib/GroupTheory/GroupAction/Quotient.lean
@@ -101,7 +101,7 @@ theorem Quotient.smul_mk [QuotientAction β H] (b : β) (a : α) :
 
 @[to_additive (attr := simp)]
 theorem Quotient.smul_coe [QuotientAction β H] (b : β) (a : α) :
-    b • (a : α ⧸ H) = (b • a : α ⧸ H) :=
+    b • (a : α ⧸ H) = (↑(b • a) : α ⧸ H) :=
   rfl
 #align mul_action.quotient.smul_coe MulAction.Quotient.smul_coe
 #align add_action.quotient.vadd_coe AddAction.Quotient.vadd_coe

--- a/Mathlib/GroupTheory/GroupAction/SubMulAction/Pointwise.lean
+++ b/Mathlib/GroupTheory/GroupAction/SubMulAction/Pointwise.lean
@@ -117,14 +117,14 @@ instance : Monoid (SubMulAction R M) :=
     mul := (· * ·)
     one := 1 }
 
-theorem coe_pow (p : SubMulAction R M) : ∀ {n : ℕ} (_ : n ≠ 0), (p ^ n : Set M) = ((p : Set M) ^ n)
+theorem coe_pow (p : SubMulAction R M) : ∀ {n : ℕ} (_ : n ≠ 0), ↑(p ^ n) = (p : Set M) ^ n
   | 0, hn => (hn rfl).elim
   | 1, _ => by rw [pow_one, pow_one]
   | n + 2, _ => by
     rw [pow_succ _ (n + 1), pow_succ _ (n + 1), coe_mul, coe_pow _ n.succ_ne_zero]
 #align sub_mul_action.coe_pow SubMulAction.coe_pow
 
-theorem subset_coe_pow (p : SubMulAction R M) : ∀ {n : ℕ}, ((p : Set M) ^ n) ⊆ (p ^ n : Set M)
+theorem subset_coe_pow (p : SubMulAction R M) : ∀ {n : ℕ}, ((p : Set M) ^ n) ⊆ ↑(p ^ n)
   | 0 => by
     rw [pow_zero, pow_zero]
     exact subset_coe_one

--- a/Mathlib/GroupTheory/Submonoid/Operations.lean
+++ b/Mathlib/GroupTheory/Submonoid/Operations.lean
@@ -560,7 +560,7 @@ attribute [to_additive existing nSMul] nPow
 
 @[to_additive (attr := simp, norm_cast)]
 theorem coe_pow {M} [Monoid M] {A : Type*} [SetLike A M] [SubmonoidClass A M] {S : A} (x : S)
-    (n : ℕ) : (x ^ n : M) = (x : M) ^ n :=
+    (n : ℕ) : ↑(x ^ n) = (x : M) ^ n :=
   rfl
 #align submonoid_class.coe_pow SubmonoidClass.coe_pow
 #align add_submonoid_class.coe_nsmul AddSubmonoidClass.coe_nsmul

--- a/Mathlib/LinearAlgebra/Alternating.lean
+++ b/Mathlib/LinearAlgebra/Alternating.lean
@@ -259,8 +259,7 @@ theorem smul_apply (c : S) (m : ι → M) : (c • f) m = c • f m :=
 #align alternating_map.smul_apply AlternatingMap.smul_apply
 
 @[norm_cast]
-theorem coe_smul (c : S) : (c • f : MultilinearMap R (fun _ : ι => M) N) =
-    c • (f : MultilinearMap R (fun _ : ι => M) N) :=
+theorem coe_smul (c : S) : ↑(c • f) = c • (f : MultilinearMap R (fun _ : ι => M) N) :=
   rfl
 #align alternating_map.coe_smul AlternatingMap.coe_smul
 

--- a/Mathlib/LinearAlgebra/Matrix/Polynomial.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Polynomial.lean
@@ -35,8 +35,9 @@ open Polynomial Matrix Equiv.Perm
 
 namespace Polynomial
 
+set_option maxHeartbeats 65000 in
 theorem natDegree_det_X_add_C_le (A B : Matrix n n α) :
-    natDegree (det ((X : α[X]) • A.map C + B.map C)) ≤ Fintype.card n := by
+    natDegree (det ((X : α[X]) • A.map C + B.map C : Matrix n n α[X])) ≤ Fintype.card n := by
   rw [det_apply]
   refine' (natDegree_sum_le _ _).trans _
   refine' Multiset.max_nat_le_of_forall_le _ _ _
@@ -44,18 +45,19 @@ theorem natDegree_det_X_add_C_le (A B : Matrix n n α) :
     Multiset.mem_map, exists_imp, Finset.mem_univ_val]
   intro g
   calc
-    natDegree (sign g • ∏ i : n, (X • A.map C + B.map C) (g i) i) ≤
-        natDegree (∏ i : n, (X • A.map C + B.map C) (g i) i) := by
+    natDegree (sign g • ∏ i : n, (X • A.map C + B.map C : Matrix n n α[X]) (g i) i) ≤
+        natDegree (∏ i : n, (X • A.map C + B.map C : Matrix n n α[X]) (g i) i) := by
       cases' Int.units_eq_one_or (sign g) with sg sg
       · rw [sg, one_smul]
       · rw [sg, Units.neg_smul, one_smul, natDegree_neg]
-    _ ≤ ∑ i : n, natDegree (((X : α[X]) • A.map C + B.map C) (g i) i) :=
-      (natDegree_prod_le (Finset.univ : Finset n) fun i : n => (X • A.map C + B.map C) (g i) i)
+    _ ≤ ∑ i : n, natDegree (((X : α[X]) • A.map C + B.map C : Matrix n n α[X]) (g i) i) :=
+      (natDegree_prod_le (Finset.univ : Finset n) fun i : n =>
+        (X • A.map C + B.map C : Matrix n n α[X]) (g i) i)
     _ ≤ Finset.univ.card • 1 := (Finset.sum_le_card_nsmul _ _ 1 fun (i : n) _ => ?_)
     _ ≤ Fintype.card n := by simp [mul_one, Algebra.id.smul_eq_mul, Finset.card_univ]
 
   calc
-    natDegree (((X : α[X]) • A.map C + B.map C) (g i) i) =
+    natDegree (((X : α[X]) • A.map C + B.map C : Matrix n n α[X]) (g i) i) =
         natDegree ((X : α[X]) * C (A (g i) i) + C (B (g i) i)) :=
       by simp
     _ ≤ max (natDegree ((X : α[X]) * C (A (g i) i))) (natDegree (C (B (g i) i))) :=

--- a/Mathlib/LinearAlgebra/QuadraticForm/Complex.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/Complex.lean
@@ -40,7 +40,7 @@ noncomputable def isometryEquivSumSquares [DecidableEq ι] (w' : ι → ℂ) :
   erw [basisRepr_apply, weightedSumSquares_apply, weightedSumSquares_apply]
   refine' sum_congr rfl fun j hj => _
   have hsum : (∑ i : ι, v i • ((isUnit_iff_ne_zero.2 <| hw' i).unit : ℂ) • (Pi.basisFun ℂ ι) i) j =
-      v j • w j ^ (-(1 / 2 : ℂ)) := by
+      v j • (w j : ℂ) ^ (-(1 / 2 : ℂ)) := by
     rw [Finset.sum_apply, sum_eq_single j, Pi.basisFun_apply, IsUnit.unit_spec,
       LinearMap.stdBasis_apply, Pi.smul_apply, Pi.smul_apply, Function.update_same, smul_eq_mul,
       smul_eq_mul, smul_eq_mul, mul_one]

--- a/Mathlib/MeasureTheory/Function/UniformIntegrable.lean
+++ b/Mathlib/MeasureTheory/Function/UniformIntegrable.lean
@@ -958,11 +958,9 @@ theorem uniformIntegrable_average (hp : 1 ≤ p) {f : ℕ → α → ℝ} (hf : 
     refine' le_trans _ (_ : ↑(↑n : ℝ≥0)⁻¹ * (n • C : ℝ≥0∞) ≤ C)
     · refine' (ENNReal.mul_le_mul_left hn ENNReal.coe_ne_top).2 _
       conv_rhs => rw [← Finset.card_range n]
-      -- Porting note: Originally `exact Finset.sum_le_card_nsmul _ _ _ fun i hi => hC i`
-      convert Finset.sum_le_card_nsmul _ _ _ fun i _ => hC i
-      rw [ENNReal.coe_smul]
+      exact Finset.sum_le_card_nsmul _ _ _ fun i _ => hC i
     · simp only [ENNReal.coe_eq_zero, inv_eq_zero, Nat.cast_eq_zero] at hn
-      rw [ENNReal.coe_smul, nsmul_eq_mul, ← mul_assoc, ENNReal.coe_inv, ENNReal.coe_nat,
+      rw [nsmul_eq_mul, ← mul_assoc, ENNReal.coe_inv, ENNReal.coe_nat,
         ENNReal.inv_mul_cancel _ (ENNReal.nat_ne_top _), one_mul]
       all_goals simpa only [Ne.def, Nat.cast_eq_zero]
 #align measure_theory.uniform_integrable_average MeasureTheory.uniformIntegrable_average

--- a/Mathlib/MeasureTheory/Integral/Bochner.lean
+++ b/Mathlib/MeasureTheory/Integral/Bochner.lean
@@ -1323,17 +1323,13 @@ theorem Memℒp.snorm_eq_integral_rpow_norm {f : α → H} {p : ℝ≥0∞} (hp1
   have A : ∫⁻ a : α, ENNReal.ofReal (‖f a‖ ^ p.toReal) ∂μ = ∫⁻ a : α, ‖f a‖₊ ^ p.toReal ∂μ := by
     apply lintegral_congr
     intro x
-    rw [← ofReal_rpow_of_nonneg (norm_nonneg _) toReal_nonneg, ofReal_norm_eq_coe_nnnorm,
-      -- Porting note: Here and below `ENNReal.coe_rpow_of_nonneg` was not needed
-      ← ENNReal.coe_rpow_of_nonneg _ toReal_nonneg]
+    rw [← ofReal_rpow_of_nonneg (norm_nonneg _) toReal_nonneg, ofReal_norm_eq_coe_nnnorm]
   simp only [snorm_eq_lintegral_rpow_nnnorm hp1 hp2, one_div]
   rw [integral_eq_lintegral_of_nonneg_ae]; rotate_left
   · exact eventually_of_forall fun x => Real.rpow_nonneg_of_nonneg (norm_nonneg _) _
   · exact (hf.aestronglyMeasurable.norm.aemeasurable.pow_const _).aestronglyMeasurable
   rw [A, ← ofReal_rpow_of_nonneg toReal_nonneg (inv_nonneg.2 toReal_nonneg), ofReal_toReal]
-  · simp_rw [← ENNReal.coe_rpow_of_nonneg _ toReal_nonneg]
-  · simp_rw [← ENNReal.coe_rpow_of_nonneg _ toReal_nonneg]
-    exact (lintegral_rpow_nnnorm_lt_top_of_snorm_lt_top hp1 hp2 hf.2).ne
+  exact (lintegral_rpow_nnnorm_lt_top_of_snorm_lt_top hp1 hp2 hf.2).ne
 #align measure_theory.mem_ℒp.snorm_eq_integral_rpow_norm MeasureTheory.Memℒp.snorm_eq_integral_rpow_norm
 
 end NormedAddCommGroup

--- a/Mathlib/MeasureTheory/Measure/Haar/NormedSpace.lean
+++ b/Mathlib/MeasureTheory/Measure/Haar/NormedSpace.lean
@@ -13,8 +13,6 @@ import Mathlib.MeasureTheory.Integral.Bochner
 
 -/
 
-local macro_rules | `($x ^ $y) => `(HPow.hPow $x $y) -- Porting note: See issue lean4#2220
-
 noncomputable section
 
 open scoped NNReal ENNReal Pointwise BigOperators Topology
@@ -137,7 +135,7 @@ theorem integrable_comp_smul_iff {E : Type*} [NormedAddCommGroup E] [NormedSpace
     (f : E → F) {R : ℝ} (hR : R ≠ 0) : Integrable (fun x => f (R • x)) μ ↔ Integrable f μ := by
   -- reduce to one-way implication
   suffices
-    ∀ {g : E → F} (hg : Integrable g μ) {S : ℝ} (hS : S ≠ 0), Integrable (fun x => g (S • x)) μ by
+    ∀ {g : E → F} (_hg : Integrable g μ) {S : ℝ} (_hS : S ≠ 0), Integrable (fun x => g (S • x)) μ by
     refine' ⟨fun hf => _, fun hf => this hf hR⟩
     convert this hf (inv_ne_zero hR)
     rw [← mul_smul, mul_inv_cancel hR, one_smul]

--- a/Mathlib/MeasureTheory/Measure/Haar/Quotient.lean
+++ b/Mathlib/MeasureTheory/Measure/Haar/Quotient.lean
@@ -86,7 +86,7 @@ theorem MeasureTheory.IsFundamentalDomain.smulInvariantMeasure_map [μ.IsMulLeft
     rintro ⟨γ, γ_in_Γ⟩
     ext x
     have : π (x * MulOpposite.unop γ) = π x := by simpa [QuotientGroup.eq'] using γ_in_Γ
-    simp only [(· • ·), ← this, mem_preimage]
+    simp only [HSMul.hSMul, ← this, mem_preimage]
     rfl
 #align measure_theory.is_fundamental_domain.smul_invariant_measure_map MeasureTheory.IsFundamentalDomain.smulInvariantMeasure_map
 #align measure_theory.is_add_fundamental_domain.vadd_invariant_measure_map MeasureTheory.IsAddFundamentalDomain.vaddInvariantMeasure_map

--- a/Mathlib/MeasureTheory/Measure/ProbabilityMeasure.lean
+++ b/Mathlib/MeasureTheory/Measure/ProbabilityMeasure.lean
@@ -318,7 +318,7 @@ total mass. -/
 def normalize : ProbabilityMeasure Ω :=
   if zero : μ.mass = 0 then ⟨Measure.dirac ‹Nonempty Ω›.some, Measure.dirac.isProbabilityMeasure⟩
   else
-    { val := μ.mass⁻¹ • μ
+    { val := ↑(μ.mass⁻¹ • μ)
       property := by
         refine' ⟨_⟩
         -- porting note: paying the price that this isn't `simp` lemma now.

--- a/Mathlib/NumberTheory/Basic.lean
+++ b/Mathlib/NumberTheory/Basic.lean
@@ -30,7 +30,7 @@ theorem dvd_sub_pow_of_dvd_sub {R : Type*} [CommRing R] {p : ℕ} {a b : R} (h :
     (k : ℕ) : (p ^ (k + 1) : R) ∣ a ^ p ^ k - b ^ p ^ k := by
   induction' k with k ih
   · rwa [pow_one, pow_zero, pow_one, pow_one]
-  rw [pow_succ' p k, pow_mul, pow_mul, ← geom_sum₂_mul, pow_succ, Nat.cast_mul]
+  rw [pow_succ' p k, pow_mul, pow_mul, ← geom_sum₂_mul, pow_succ]
   refine' mul_dvd_mul _ ih
   let f : R →+* R ⧸ span {(p : R)} := mk (span {(p : R)})
   have hf : ∀ r : R, (p : R) ∣ r ↔ f r = 0 := fun r ↦ by rw [eq_zero_iff_mem, mem_span_singleton]

--- a/Mathlib/NumberTheory/Bernoulli.lean
+++ b/Mathlib/NumberTheory/Bernoulli.lean
@@ -356,9 +356,8 @@ theorem sum_range_pow (n p : ℕ) :
     -- key step: a chain of equalities of power series
     -- porting note: altered proof slightly
     rw [← mul_right_inj' hexp, mul_comm]
-    simp only [← cast_pow]
     rw [←exp_pow_sum, geom_sum_mul, h_r, ← bernoulliPowerSeries_mul_exp_sub_one,
-    bernoulliPowerSeries, mul_right_comm]
+      bernoulliPowerSeries, mul_right_comm]
     simp only [mul_comm, mul_eq_mul_left_iff, hexp, or_false]
     refine' Eq.trans (mul_eq_mul_right_iff.mpr _) (Eq.trans h_cauchy _)
     · left

--- a/Mathlib/NumberTheory/Bertrand.lean
+++ b/Mathlib/NumberTheory/Bertrand.lean
@@ -99,17 +99,15 @@ theorem real_main_inequality {x : ℝ} (n_large : (512 : ℝ) ≤ x) :
   · have : sqrt (2 * 512) = 32 :=
       (sqrt_eq_iff_mul_self_eq_of_pos (by norm_num1)).mpr (by norm_num1)
     rw [hf, log_nonpos_iff (hf' _ _), this, div_le_one] <;> norm_num1
-    have : (512 : ℝ) = 2 ^ (9 : ℕ)
-    · rw [rpow_nat_cast 2 9]; norm_num1
-    conv_lhs => rw [this]
-    have : (1024 : ℝ) = 2 ^ (10 : ℕ)
-    · rw [rpow_nat_cast 2 10]; norm_num1
-    rw [this, ← rpow_mul, ← rpow_add] <;> norm_num1
-    have : (4 : ℝ) = 2 ^ (2 : ℕ)
-    · rw [rpow_nat_cast 2 2]; norm_num1
-    rw [this, ← rpow_mul] <;> norm_num1
-    apply rpow_le_rpow_of_exponent_le <;> norm_num1
-    apply rpow_pos_of_pos four_pos
+    · conv in 512 => equals 2 ^ 9 => norm_num1
+      conv in 1024 => equals 2 ^ 10 => norm_num1
+      conv in 32 => rw [← Nat.cast_ofNat]
+      rw [rpow_nat_cast, ← pow_mul, ← pow_add]
+      conv in 4 => equals 2 ^ (2 : ℝ) => rw [rpow_two]; norm_num1
+      rw [← rpow_mul, ← rpow_nat_cast]
+      apply rpow_le_rpow_of_exponent_le
+      all_goals norm_num1
+    · apply rpow_pos_of_pos four_pos
  #align bertrand.real_main_inequality Bertrand.real_main_inequality
 
 end Bertrand

--- a/Mathlib/NumberTheory/ClassNumber/Finite.lean
+++ b/Mathlib/NumberTheory/ClassNumber/Finite.lean
@@ -224,7 +224,8 @@ theorem exists_mem_finsetApprox (a : S) {b} (hb : b ≠ (0 : R)) :
   have dim_pos := Fintype.card_pos_iff.mpr bS.index_nonempty
   set ε : ℝ := normBound abv bS ^ (-1 / Fintype.card ι : ℝ) with ε_eq
   have hε : 0 < ε := Real.rpow_pos_of_pos (Int.cast_pos.mpr (normBound_pos abv bS)) _
-  have ε_le : (normBound abv bS : ℝ) * (abv b • ε) ^ Fintype.card ι ≤ abv b ^ Fintype.card ι := by
+  have ε_le : (normBound abv bS : ℝ) * (abv b • ε) ^ (Fintype.card ι : ℝ)
+                ≤ abv b ^ (Fintype.card ι : ℝ) := by
     have := normBound_pos abv bS
     have := abv.nonneg b
     rw [ε_eq, Algebra.smul_def, eq_intCast, mul_rpow, ← rpow_mul, div_mul_cancel, rpow_neg_one,

--- a/Mathlib/NumberTheory/LegendreSymbol/JacobiSymbol.lean
+++ b/Mathlib/NumberTheory/LegendreSymbol/JacobiSymbol.lean
@@ -480,7 +480,7 @@ theorem mod_right' (a : ℕ) {b : ℕ} (hb : Odd b) : J(a | b) = J(a | b % (4 * 
     rw [χ₄_nat_mod_four, χ₄_nat_mod_four (b % (4 * a)), mod_mod_of_dvd b (dvd_mul_right 4 a)]
   · rw [mod_left ↑(b % _), mod_left b, Int.coe_nat_mod, Int.emod_emod_of_dvd b]
     simp only [ha₂, Nat.cast_mul, ← mul_assoc]
-    exact dvd_mul_left (a' : ℤ) (↑4 * ↑(2 ^ e))
+    exact dvd_mul_left (a' : ℤ) (↑4 * (2 ^ e :))
   -- porting note: In mathlib3, it was written `cases' e`. In Lean 4, this resulted in the choice
   -- of a name other than e (for the case distinction of line 482) so we indicate the name
   -- to use explicitly.

--- a/Mathlib/NumberTheory/Liouville/LiouvilleNumber.lean
+++ b/Mathlib/NumberTheory/Liouville/LiouvilleNumber.lean
@@ -172,7 +172,7 @@ theorem remainder_lt (n : ℕ) {m : ℝ} (m2 : 2 ≤ m) : remainder m n < 1 / (m
 /-- The sum of the `k` initial terms of the Liouville number to base `m` is a ratio of natural
 numbers where the denominator is `m ^ k!`. -/
 theorem partialSum_eq_rat {m : ℕ} (hm : 0 < m) (k : ℕ) :
-    ∃ p : ℕ, partialSum m k = p / (m ^ k ! : ℝ) := by
+    ∃ p : ℕ, partialSum m k = p / ((m ^ k ! :) : ℝ) := by
   induction' k with k h
   · exact ⟨1, by rw [partialSum, range_one, sum_singleton, Nat.cast_one, Nat.factorial,
       pow_one, pow_one]⟩
@@ -196,7 +196,7 @@ theorem liouville_liouvilleNumber {m : ℕ} (hm : 2 ≤ m) : Liouville (liouvill
   intro n
   -- the first `n` terms sum to `p / m ^ k!`
   rcases partialSum_eq_rat (zero_lt_two.trans_le hm) n with ⟨p, hp⟩
-  refine' ⟨p, m ^ n !, by rw [Nat.cast_pow]; exact one_lt_pow mZ1 n.factorial_ne_zero, _⟩
+  refine' ⟨p, m ^ n !, by exact one_lt_pow mZ1 n.factorial_ne_zero, _⟩
   push_cast
   rw [Nat.cast_pow] at hp
   -- separate out the sum of the first `n` terms and the rest

--- a/Mathlib/NumberTheory/Multiplicity.lean
+++ b/Mathlib/NumberTheory/Multiplicity.lean
@@ -109,7 +109,7 @@ theorem odd_sq_dvd_geom_sum₂_sub (hp : Odd p) :
     _ =
         mk (span {s})
             (∑ x : ℕ in Finset.range p, a ^ (x - 1) * (a ^ (p - 1 - x) * (↑p * (b * ↑x)))) +
-          mk (span {s}) (∑ x : ℕ in Finset.range p, a ^ (p - 1)) := by
+          mk (span {s}) (∑ _x : ℕ in Finset.range p, a ^ (p - 1)) := by
       rw [add_right_inj]
       have : ∀ (x : ℕ), (hx : x ∈ range p) → a ^ (x + (p - 1 - x)) = a ^ (p - 1) := by
         intro x hx

--- a/Mathlib/NumberTheory/NumberField/Units.lean
+++ b/Mathlib/NumberTheory/NumberField/Units.lean
@@ -67,10 +67,10 @@ variable {K}
 
 theorem coe_mul (x y : (𝓞 K)ˣ) : ((x * y : (𝓞 K)ˣ) : K) = (x : K) * (y : K) := rfl
 
-theorem coe_pow (x : (𝓞 K)ˣ) (n : ℕ) : (x ^ n : K) = (x : K) ^ n := by
+theorem coe_pow (x : (𝓞 K)ˣ) (n : ℕ) : (↑(x ^ n) : K) = (x : K) ^ n := by
   rw [← SubmonoidClass.coe_pow, ← val_pow_eq_pow_val]
 
-theorem coe_zpow (x : (𝓞 K)ˣ) (n : ℤ) : (x ^ n : K) = (x : K) ^ n := by
+theorem coe_zpow (x : (𝓞 K)ˣ) (n : ℤ) : (↑(x ^ n) : K) = (x : K) ^ n := by
   change ((Units.coeHom K).comp (map (algebraMap (𝓞 K) K))) (x ^ n) = _
   exact map_zpow _ x n
 

--- a/Mathlib/NumberTheory/Padics/PadicIntegers.lean
+++ b/Mathlib/NumberTheory/Padics/PadicIntegers.lean
@@ -357,7 +357,8 @@ theorem norm_int_lt_one_iff_dvd (k : ℤ) : ‖(k : ℤ_[p])‖ < 1 ↔ (p : ℤ
 
 theorem norm_int_le_pow_iff_dvd {k : ℤ} {n : ℕ} :
     ‖(k : ℤ_[p])‖ ≤ (p : ℝ) ^ (-n : ℤ) ↔ (p ^ n : ℤ) ∣ k :=
-  suffices ‖(k : ℚ_[p])‖ ≤ (p : ℝ) ^ (-n : ℤ) ↔ ↑(p ^ n) ∣ k by simpa [norm_int_cast_eq_padic_norm]
+  suffices ‖(k : ℚ_[p])‖ ≤ (p : ℝ) ^ (-n : ℤ) ↔ (p ^ n : ℤ) ∣ k by
+    simpa [norm_int_cast_eq_padic_norm]
   padicNormE.norm_int_le_pow_iff_dvd _ _
 #align padic_int.norm_int_le_pow_iff_dvd PadicInt.norm_int_le_pow_iff_dvd
 

--- a/Mathlib/NumberTheory/Padics/RingHoms.lean
+++ b/Mathlib/NumberTheory/Padics/RingHoms.lean
@@ -146,7 +146,7 @@ theorem zmod_congr_of_sub_mem_span_aux (n : ℕ) (x : ℤ_[p]) (a b : ℤ)
   rw [← dvd_neg, neg_sub] at ha
   have := dvd_add ha hb
   rwa [sub_eq_add_neg, sub_eq_add_neg, add_assoc, neg_add_cancel_left, ← sub_eq_add_neg, ←
-    Int.cast_sub, pow_p_dvd_int_iff, Nat.cast_pow] at this
+    Int.cast_sub, pow_p_dvd_int_iff] at this
 #align padic_int.zmod_congr_of_sub_mem_span_aux PadicInt.zmod_congr_of_sub_mem_span_aux
 
 theorem zmod_congr_of_sub_mem_span (n : ℕ) (x : ℤ_[p]) (a b : ℕ)

--- a/Mathlib/NumberTheory/Zsqrtd/QuadraticReciprocity.lean
+++ b/Mathlib/NumberTheory/Zsqrtd/QuadraticReciprocity.lean
@@ -23,8 +23,6 @@ open Zsqrtd Complex
 
 open scoped ComplexConjugate
 
-local macro_rules | `($x ^ $y) => `(HPow.hPow $x $y) -- Porting note: See issue lean4#2220
-
 local notation "ℤ[i]" => GaussianInt
 
 namespace GaussianInt
@@ -89,7 +87,7 @@ theorem prime_of_nat_prime_of_mod_four_eq_three (p : ℕ) [hp : Fact p.Prime] (h
   irreducible_iff_prime.1 <|
     by_contradiction fun hpi =>
       let ⟨a, b, hab⟩ := sq_add_sq_of_nat_prime_of_not_irreducible p hpi
-      have : ∀ a b : ZMod 4, a ^ 2 + b ^ 2 ≠ p := by
+      have : ∀ a b : ZMod 4, a ^ 2 + b ^ 2 ≠ ↑p := by
         erw [← ZMod.nat_cast_mod p 4, hp3]; exact by decide
       this a b (hab ▸ by simp)
 #align gaussian_int.prime_of_nat_prime_of_mod_four_eq_three GaussianInt.prime_of_nat_prime_of_mod_four_eq_three

--- a/Mathlib/RingTheory/GradedAlgebra/HomogeneousLocalization.lean
+++ b/Mathlib/RingTheory/GradedAlgebra/HomogeneousLocalization.lean
@@ -342,7 +342,7 @@ instance : SMul α (HomogeneousLocalization 𝒜 x) where
   smul m := Quotient.map' (m • ·) fun c1 c2 (h : Localization.mk _ _ = Localization.mk _ _) => by
     change Localization.mk _ _ = Localization.mk _ _
     simp only [num_smul, den_smul]
-    convert congr_arg (fun z : at x => m • z) h <;> rw [Localization.smul_mk] <;> rfl
+    convert congr(m • $h) <;> rw [Localization.smul_mk]
 
 @[simp]
 theorem smul_val (y : HomogeneousLocalization 𝒜 x) (n : α) : (n • y).val = n • y.val := by

--- a/Mathlib/RingTheory/RootsOfUnity/Basic.lean
+++ b/Mathlib/RingTheory/RootsOfUnity/Basic.lean
@@ -129,7 +129,7 @@ theorem map_rootsOfUnity (f : Mˣ →* Nˣ) (k : ℕ+) : (rootsOfUnity k M).map 
 
 @[norm_cast]
 theorem rootsOfUnity.coe_pow [CommMonoid R] (ζ : rootsOfUnity k R) (m : ℕ) :
-    ((ζ ^ m : Rˣ) : R) = ((ζ : Rˣ) : R) ^ m := by
+    (((ζ ^ m :) : Rˣ) : R) = ((ζ : Rˣ) : R) ^ m := by
   rw [Subgroup.coe_pow, Units.val_pow_eq_pow_val]
 #align roots_of_unity.coe_pow rootsOfUnity.coe_pow
 

--- a/Mathlib/RingTheory/TensorProduct.lean
+++ b/Mathlib/RingTheory/TensorProduct.lean
@@ -1005,43 +1005,43 @@ https://leanprover.zulipchat.com/#narrow/stream/144837-PR-reviews/topic/.234773.
 -/
 protected def module : Module (A ⊗[R] B) M where
   smul x m := moduleAux x m
-  zero_smul m := by simp only [(· • ·), map_zero, LinearMap.zero_apply]
-  smul_zero x := by simp only [(· • ·), map_zero]
-  smul_add x m₁ m₂ := by simp only [(· • ·), map_add]
-  add_smul x y m := by simp only [(· • ·), map_add, LinearMap.add_apply]
+  zero_smul m := by simp only [HSMul.hSMul, map_zero, LinearMap.zero_apply]
+  smul_zero x := by simp only [HSMul.hSMul, map_zero]
+  smul_add x m₁ m₂ := by simp only [HSMul.hSMul, map_add]
+  add_smul x y m := by simp only [HSMul.hSMul, map_add, LinearMap.add_apply]
   one_smul m := by
     -- porting note: was one `simp only` not two in lean 3
-    simp only [(· • ·), Algebra.TensorProduct.one_def]
+    simp only [HSMul.hSMul, Algebra.TensorProduct.one_def]
     simp only [moduleAux_apply, one_smul]
   mul_smul x y m := by
     refine TensorProduct.induction_on x ?_ ?_ ?_ <;> refine TensorProduct.induction_on y ?_ ?_ ?_
-    · simp only [(· • ·), mul_zero, map_zero, LinearMap.zero_apply]
+    · simp only [HSMul.hSMul, mul_zero, map_zero, LinearMap.zero_apply]
     · intro a b
-      simp only [(· • ·), zero_mul, map_zero, LinearMap.zero_apply]
+      simp only [HSMul.hSMul, zero_mul, map_zero, LinearMap.zero_apply]
     · intro z w _ _
-      simp only [(· • ·), zero_mul, map_zero, LinearMap.zero_apply]
+      simp only [HSMul.hSMul, zero_mul, map_zero, LinearMap.zero_apply]
     · intro a b
-      simp only [(· • ·), mul_zero, map_zero, LinearMap.zero_apply]
+      simp only [HSMul.hSMul, mul_zero, map_zero, LinearMap.zero_apply]
     · intro a₁ b₁ a₂ b₂
       -- porting note; was one `simp only` not two and a `rw` in mathlib3
-      simp only [(· • ·), Algebra.TensorProduct.tmul_mul_tmul]
+      simp only [HSMul.hSMul, Algebra.TensorProduct.tmul_mul_tmul]
       simp only [moduleAux_apply, mul_smul]
       rw [smul_comm a₁ b₂]
     · intro z w hz hw a b
       --porting note: was one `simp only` but random stuff doesn't work
-      simp only [(· • ·)] at hz hw ⊢
+      simp only [HSMul.hSMul] at hz hw ⊢
       simp only [moduleAux_apply]
       rw [mul_add]  -- simp only doesn't work
       simp only [LinearMap.map_add, LinearMap.add_apply, moduleAux_apply, hz, hw, smul_add]
     · intro z w _ _
-      simp only [(· • ·), mul_zero, map_zero, LinearMap.zero_apply]
+      simp only [HSMul.hSMul, mul_zero, map_zero, LinearMap.zero_apply]
     · intro a b z w hz hw
-      simp only [(· • ·)] at hz hw
-      simp only [(· • ·), LinearMap.map_add, add_mul, LinearMap.add_apply, hz, hw]
+      simp only [HSMul.hSMul] at hz hw
+      simp only [HSMul.hSMul, LinearMap.map_add, add_mul, LinearMap.add_apply, hz, hw]
     · intro u v _ _ z w hz hw
-      simp only [(· • ·)] at hz hw
+      simp only [HSMul.hSMul] at hz hw
       -- porting note: no idea why this is such a struggle
-      simp only [(· • ·)]
+      simp only [HSMul.hSMul]
       rw [add_mul, LinearMap.map_add, LinearMap.add_apply, hz, hw]
       simp only [LinearMap.map_add, LinearMap.add_apply]
       rw [add_add_add_comm]

--- a/Mathlib/RingTheory/WittVector/Defs.lean
+++ b/Mathlib/RingTheory/WittVector/Defs.lean
@@ -371,12 +371,12 @@ theorem neg_coeff (x : 𝕎 R) (n : ℕ) : (-x).coeff n = peval (wittNeg p n) ![
 
 theorem nsmul_coeff (m : ℕ) (x : 𝕎 R) (n : ℕ) :
     (m • x).coeff n = peval (wittNSMul p m n) ![x.coeff] := by
-  simp [(· • ·), SMul.smul, eval, Matrix.cons_fin_one, coeff_mk]
+  simp [HSMul.hSMul, SMul.smul, eval, Matrix.cons_fin_one, coeff_mk]
 #align witt_vector.nsmul_coeff WittVector.nsmul_coeff
 
 theorem zsmul_coeff (m : ℤ) (x : 𝕎 R) (n : ℕ) :
     (m • x).coeff n = peval (wittZSMul p m n) ![x.coeff] := by
-  simp [(· • ·), SMul.smul, eval, Matrix.cons_fin_one, coeff_mk]
+  simp [HSMul.hSMul, SMul.smul, eval, Matrix.cons_fin_one, coeff_mk]
 #align witt_vector.zsmul_coeff WittVector.zsmul_coeff
 
 theorem pow_coeff (m : ℕ) (x : 𝕎 R) (n : ℕ) : (x ^ m).coeff n = peval (wittPow p m n) ![x.coeff] :=

--- a/Mathlib/RingTheory/WittVector/Defs.lean
+++ b/Mathlib/RingTheory/WittVector/Defs.lean
@@ -380,7 +380,7 @@ theorem zsmul_coeff (m : ℤ) (x : 𝕎 R) (n : ℕ) :
 #align witt_vector.zsmul_coeff WittVector.zsmul_coeff
 
 theorem pow_coeff (m : ℕ) (x : 𝕎 R) (n : ℕ) : (x ^ m).coeff n = peval (wittPow p m n) ![x.coeff] :=
-  by simp [(· ^ ·), Pow.pow, eval, Matrix.cons_fin_one, coeff_mk]
+  by simp [HPow.hPow, Pow.pow, eval, Matrix.cons_fin_one, coeff_mk]
 #align witt_vector.pow_coeff WittVector.pow_coeff
 
 theorem add_coeff_zero (x y : 𝕎 R) : (x + y).coeff 0 = x.coeff 0 + y.coeff 0 := by

--- a/Mathlib/RingTheory/WittVector/DiscreteValuationRing.lean
+++ b/Mathlib/RingTheory/WittVector/DiscreteValuationRing.lean
@@ -30,8 +30,6 @@ When `k` is also a field, this `b` can be chosen to be a unit of `𝕎 k`.
 
 noncomputable section
 
-local macro_rules | `($x ^ $y) => `(HPow.hPow $x $y) -- Porting note: See issue lean4#2220
-
 namespace WittVector
 
 variable {p : ℕ} [hp : Fact p.Prime]

--- a/Mathlib/RingTheory/WittVector/Frobenius.lean
+++ b/Mathlib/RingTheory/WittVector/Frobenius.lean
@@ -191,7 +191,7 @@ theorem map_frobeniusPoly (n : ℕ) :
     have aux : ∀ k : ℕ, (p : ℚ)^ k ≠ 0 := by
       intro; apply pow_ne_zero; exact_mod_cast hp.1.ne_zero
     simpa [aux, -one_div, field_simps] using this.symm
-  rw [mul_comm _ (p : ℚ), mul_assoc, Nat.cast_pow, mul_assoc, ← pow_add,
+  rw [mul_comm _ (p : ℚ), mul_assoc, mul_assoc, ← pow_add,
     map_frobeniusPoly.key₂ p hi.le hj, Nat.cast_mul, Nat.cast_pow]
   ring
 #align witt_vector.map_frobenius_poly WittVector.map_frobeniusPoly

--- a/Mathlib/RingTheory/WittVector/StructurePolynomial.lean
+++ b/Mathlib/RingTheory/WittVector/StructurePolynomial.lean
@@ -232,7 +232,7 @@ theorem C_p_pow_dvd_bind₁_rename_wittPolynomial_sub_sum (Φ : MvPolynomial idx
         m < n →
           map (Int.castRingHom ℚ) (wittStructureInt p Φ m) =
             wittStructureRat p (map (Int.castRingHom ℚ) Φ) m) :
-    (C (p ^ n : ℤ) : MvPolynomial (idx × ℕ) ℤ) ∣
+    (C ((p ^ n : ℕ) : ℤ) : MvPolynomial (idx × ℕ) ℤ) ∣
       bind₁ (fun b : idx => rename (fun i => (b, i)) (wittPolynomial p ℤ n)) Φ -
         ∑ i in range n, C ((p : ℤ) ^ i) * wittStructureInt p Φ i ^ p ^ (n - i) := by
   cases' n with n
@@ -262,7 +262,6 @@ theorem C_p_pow_dvd_bind₁_rename_wittPolynomial_sub_sum (Φ : MvPolynomial idx
   apply mul_dvd_mul_left ((p : MvPolynomial (idx × ℕ) ℤ) ^ k)
   rw [show p ^ (n + 1 - k) = p * p ^ (n - k) by rw [← pow_succ, ← tsub_add_eq_add_tsub hk]]
   rw [pow_mul]
-  rw [← Nat.cast_pow] -- Porting note: added
   -- the machine!
   apply dvd_sub_pow_of_dvd_sub
   rw [← C_eq_coe_nat, C_dvd_iff_zmod, RingHom.map_sub, sub_eq_zero, map_expand, RingHom.map_pow,

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -493,7 +493,7 @@ local infixr:0 "^'" => @HPow.hPow Cardinal Cardinal Cardinal.instPowCardinal
 -- -- mathport name: cardinal.pow.nat
 local infixr:80 " ^ℕ " => @HPow.hPow Cardinal ℕ Cardinal instHPow
 
-theorem power_def (α β) : #α ^ #β = #(β → α) :=
+theorem power_def (α β : Type u) : #α ^ #β = #(β → α) :=
   rfl
 #align cardinal.power_def Cardinal.power_def
 
@@ -508,12 +508,12 @@ theorem lift_power (a b : Cardinal.{u}) : lift.{v} (a ^ b) = ((lift.{v} a) ^ (li
 #align cardinal.lift_power Cardinal.lift_power
 
 @[simp]
-theorem power_zero {a : Cardinal} : (a ^ 0) = 1 :=
+theorem power_zero {a : Cardinal} : (a ^ (0 : Cardinal)) = 1 :=
   inductionOn a fun _ => mk_eq_one _
 #align cardinal.power_zero Cardinal.power_zero
 
 @[simp]
-theorem power_one {a : Cardinal.{u}} : (a ^ 1) = a :=
+theorem power_one {a : Cardinal.{u}} : (a ^ (1 : Cardinal)) = a :=
   inductionOn a fun α => mk_congr (Equiv.funUnique (ULift.{u} (Fin 1)) α)
 #align cardinal.power_one Cardinal.power_one
 
@@ -538,9 +538,9 @@ instance commSemiring : CommSemiring Cardinal.{u} where
   mul_comm := mul_comm'
   left_distrib a b c := inductionOn₃ a b c fun α β γ => mk_congr <| Equiv.prodSumDistrib α β γ
   right_distrib a b c := inductionOn₃ a b c fun α β γ => mk_congr <| Equiv.sumProdDistrib α β γ
-  npow n c := c^n
+  npow n c := c ^ (n : Cardinal)
   npow_zero := @power_zero
-  npow_succ n c := show (c ^ (n + 1 : ℕ)) = c * (c ^ n)
+  npow_succ n c := show (c ^ ((n + 1 : ℕ) : Cardinal)) = c * (c ^ (n : Cardinal))
     by rw [Cardinal.cast_succ, power_add, power_one, mul_comm']
   natCast := (fun n => lift.{u} #(Fin n) : ℕ → Cardinal.{u})
   natCast_zero := rfl
@@ -563,7 +563,7 @@ theorem power_bit1 (a b : Cardinal) : (a ^ bit1 b) = (a ^ b) * (a ^ b) * a := by
 end deprecated
 
 @[simp]
-theorem one_power {a : Cardinal} : (1 ^ a) = 1 :=
+theorem one_power {a : Cardinal} : (1 ^ a : Cardinal) = 1 :=
   inductionOn a fun _ => mk_eq_one _
 #align cardinal.one_power Cardinal.one_power
 
@@ -578,7 +578,7 @@ theorem mk_Prop : #Prop = 2 := by simp
 #align cardinal.mk_Prop Cardinal.mk_Prop
 
 @[simp]
-theorem zero_power {a : Cardinal} : a ≠ 0 → (0 ^ a) = 0 :=
+theorem zero_power {a : Cardinal} : a ≠ 0 → (0 ^ a : Cardinal) = 0 :=
   inductionOn a fun _ heq =>
     mk_eq_zero_iff.2 <|
       isEmpty_pi.2 <|
@@ -586,7 +586,7 @@ theorem zero_power {a : Cardinal} : a ≠ 0 → (0 ^ a) = 0 :=
         ⟨a, inferInstance⟩
 #align cardinal.zero_power Cardinal.zero_power
 
-theorem power_ne_zero {a : Cardinal} (b) : a ≠ 0 → (a ^ b) ≠ 0 :=
+theorem power_ne_zero {a : Cardinal} (b : Cardinal) : a ≠ 0 → (a ^ b) ≠ 0 :=
   inductionOn₂ a b fun _ _ h =>
     let ⟨a⟩ := mk_ne_zero_iff.1 h
     mk_ne_zero_iff.2 ⟨fun _ => a⟩
@@ -1346,7 +1346,7 @@ theorem card_le_of_finset {α} (s : Finset α) : (s.card : Cardinal) ≤ #α :=
 -- Porting note: was `simp`. LHS is not normal form.
 -- @[simp, norm_cast]
 @[norm_cast]
-theorem natCast_pow {m n : ℕ} : (↑(m ^ n) : Cardinal) = (m^n) := by
+theorem natCast_pow {m n : ℕ} : (↑(m ^ n) : Cardinal) = (m : Cardinal) ^ (n : Cardinal) := by
   induction n <;> simp [pow_succ', power_add, *, Pow.pow]
 #align cardinal.nat_cast_pow Cardinal.natCast_pow
 
@@ -2386,14 +2386,14 @@ theorem three_le {α : Type*} (h : 3 ≤ #α) (x : α) (y : α) : ∃ z : α, z 
 
 /-- The function `a ^< b`, defined as the supremum of `a ^ c` for `c < b`. -/
 def powerlt (a b : Cardinal.{u}) : Cardinal.{u} :=
-  ⨆ c : Iio b, a^c
+  ⨆ c : Iio b, a ^ (c : Cardinal)
 #align cardinal.powerlt Cardinal.powerlt
 
 @[inherit_doc]
 infixl:80 " ^< " => powerlt
 
 theorem le_powerlt {b c : Cardinal.{u}} (a) (h : c < b) : (a^c) ≤ a ^< b := by
-  refine le_ciSup (f := fun y : Iio b => a^y) ?_ ⟨c, h⟩
+  refine le_ciSup (f := fun y : Iio b => a ^ (y : Cardinal)) ?_ ⟨c, h⟩
   rw [← image_eq_range]
   exact bddAbove_image.{u, u} _ bddAbove_Iio
 #align cardinal.le_powerlt Cardinal.le_powerlt

--- a/Mathlib/SetTheory/Cardinal/Divisibility.lean
+++ b/Mathlib/SetTheory/Cardinal/Divisibility.lean
@@ -150,7 +150,8 @@ theorem isPrimePow_iff {a : Cardinal} : IsPrimePow a ↔ ℵ₀ ≤ a ∨ ∃ n 
     ⟨_, fun ⟨n, han, p, k, hp, hk, h⟩ =>
           ⟨p, k, nat_is_prime_iff.2 hp, hk, by rw [han]; exact_mod_cast h⟩⟩
   rintro ⟨p, k, hp, hk, hpk⟩
-  have key : p ^ 1 ≤ ↑a := by rw [←hpk]; apply power_le_power_left hp.ne_zero; exact_mod_cast hk
+  have key : p ^ (1 : Cardinal) ≤ ↑a := by
+    rw [←hpk]; apply power_le_power_left hp.ne_zero; exact_mod_cast hk
   rw [power_one] at key
   lift p to ℕ using key.trans_lt (nat_lt_aleph0 a)
   exact ⟨a, rfl, p, k, nat_is_prime_iff.mp hp, hk, by exact_mod_cast hpk⟩

--- a/Mathlib/SetTheory/Ordinal/Exponential.lean
+++ b/Mathlib/SetTheory/Ordinal/Exponential.lean
@@ -42,12 +42,12 @@ theorem zero_opow' (a : Ordinal) : (0^a) = 1 - a := by simp only [opow_def, if_t
 #align ordinal.zero_opow' Ordinal.zero_opow'
 
 @[simp]
-theorem zero_opow {a : Ordinal} (a0 : a ≠ 0) : (0^a) = 0 := by
+theorem zero_opow {a : Ordinal} (a0 : a ≠ 0) : (0 : Ordinal) ^ a = 0 := by
   rwa [zero_opow', Ordinal.sub_eq_zero_iff_le, one_le_iff_ne_zero]
 #align ordinal.zero_opow Ordinal.zero_opow
 
 @[simp]
-theorem opow_zero (a : Ordinal) : (a^0) = 1 := by
+theorem opow_zero (a : Ordinal) : a ^ (0 : Ordinal) = 1 := by
   by_cases h : a = 0
   · simp only [opow_def, if_pos h, sub_zero]
   · simp only [opow_def, if_neg h, limitRecOn_zero]
@@ -74,12 +74,12 @@ theorem lt_opow_of_limit {a b c : Ordinal} (b0 : b ≠ 0) (h : IsLimit c) :
 #align ordinal.lt_opow_of_limit Ordinal.lt_opow_of_limit
 
 @[simp]
-theorem opow_one (a : Ordinal) : (a^1) = a := by
+theorem opow_one (a : Ordinal) : a ^ (1 : Ordinal) = a := by
   rw [← succ_zero, opow_succ]; simp only [opow_zero, one_mul]
 #align ordinal.opow_one Ordinal.opow_one
 
 @[simp]
-theorem one_opow (a : Ordinal) : (1^a) = 1 := by
+theorem one_opow (a : Ordinal) : (1 ^ a : Ordinal) = 1 := by
   induction a using limitRecOn with
   | H₁ => simp only [opow_zero]
   | H₂ _ ih =>
@@ -90,8 +90,8 @@ theorem one_opow (a : Ordinal) : (1^a) = 1 := by
     exact ⟨fun H => by simpa only [opow_zero] using H 0 l.pos, fun H b' h => by rwa [IH _ h]⟩
 #align ordinal.one_opow Ordinal.one_opow
 
-theorem opow_pos {a : Ordinal} (b) (a0 : 0 < a) : 0 < (a^b) := by
-  have h0 : 0 < (a^0) := by simp only [opow_zero, zero_lt_one]
+theorem opow_pos {a : Ordinal} (b : Ordinal) (a0 : 0 < a) : 0 < a ^ b := by
+  have h0 : 0 < a ^ (0 : Ordinal) := by simp only [opow_zero, zero_lt_one]
   induction b using limitRecOn with
   | H₁ => exact h0
   | H₂ b IH =>
@@ -101,7 +101,7 @@ theorem opow_pos {a : Ordinal} (b) (a0 : 0 < a) : 0 < (a^b) := by
     exact (lt_opow_of_limit (Ordinal.pos_iff_ne_zero.1 a0) l).2 ⟨0, l.pos, h0⟩
 #align ordinal.opow_pos Ordinal.opow_pos
 
-theorem opow_ne_zero {a : Ordinal} (b) (a0 : a ≠ 0) : (a^b) ≠ 0 :=
+theorem opow_ne_zero {a : Ordinal} (b : Ordinal) (a0 : a ≠ 0) : a ^ b ≠ 0 :=
   Ordinal.pos_iff_ne_zero.1 <| opow_pos b <| Ordinal.pos_iff_ne_zero.2 a0
 #align ordinal.opow_ne_zero Ordinal.opow_ne_zero
 
@@ -143,7 +143,7 @@ theorem opow_le_opow_right {a b c : Ordinal} (h₁ : 0 < a) (h₂ : b ≤ c) : (
     simp only [one_opow, le_refl]
 #align ordinal.opow_le_opow_right Ordinal.opow_le_opow_right
 
-theorem opow_le_opow_left {a b : Ordinal} (c) (ab : a ≤ b) : (a^c) ≤ (b^c) := by
+theorem opow_le_opow_left {a b : Ordinal} (c : Ordinal) (ab : a ≤ b) : (a^c) ≤ (b^c) := by
   by_cases a0 : a = 0
   -- Porting note: `le_refl` is required.
   · subst a
@@ -210,7 +210,7 @@ theorem opow_add (a b c : Ordinal) : a^(b + c) = (a^b) * (a^c) := by
 theorem opow_one_add (a b : Ordinal) : a^(1 + b) = a * (a^b) := by rw [opow_add, opow_one]
 #align ordinal.opow_one_add Ordinal.opow_one_add
 
-theorem opow_dvd_opow (a) {b c : Ordinal} (h : b ≤ c) : (a^b) ∣ (a^c) :=
+theorem opow_dvd_opow (a : Ordinal) {b c : Ordinal} (h : b ≤ c) : (a^b) ∣ (a^c) :=
   ⟨a^(c - b), by rw [← opow_add, Ordinal.add_sub_cancel_of_le h]⟩
 #align ordinal.opow_dvd_opow Ordinal.opow_dvd_opow
 
@@ -258,7 +258,7 @@ def log (b : Ordinal) (x : Ordinal) : Ordinal :=
 #align ordinal.log Ordinal.log
 
 /-- The set in the definition of `log` is nonempty. -/
-theorem log_nonempty {b x : Ordinal} (h : 1 < b) : { o | x < (b^o) }.Nonempty :=
+theorem log_nonempty {b x : Ordinal} (h : 1 < b) : { o : Ordinal | x < (b^o) }.Nonempty :=
   ⟨_, succ_le_iff.1 (right_le_opow _ h)⟩
 #align ordinal.log_nonempty Ordinal.log_nonempty
 
@@ -296,8 +296,8 @@ theorem log_one_left : ∀ b, log 1 b = 0 :=
 #align ordinal.log_one_left Ordinal.log_one_left
 
 theorem succ_log_def {b x : Ordinal} (hb : 1 < b) (hx : x ≠ 0) :
-    succ (log b x) = sInf { o | x < (b^o) } := by
-  let t := sInf { o | x < (b^o) }
+    succ (log b x) = sInf { o : Ordinal | x < b ^ o } := by
+  let t := sInf { o : Ordinal | x < b ^ o }
   have : x < (b^t) := csInf_mem (log_nonempty hb)
   rcases zero_or_succ_or_limit t with (h | h | h)
   · refine' ((one_le_iff_ne_zero.2 hx).not_lt _).elim
@@ -393,7 +393,8 @@ theorem log_mod_opow_log_lt_log_self {b o : Ordinal} (hb : 1 < b) (ho : o ≠ 0)
     exact opow_pos _ (zero_lt_one.trans hb)
 #align ordinal.log_mod_opow_log_lt_log_self Ordinal.log_mod_opow_log_lt_log_self
 
-theorem opow_mul_add_pos {b v : Ordinal} (hb : b ≠ 0) (u) (hv : v ≠ 0) (w) : 0 < (b^u) * v + w :=
+theorem opow_mul_add_pos {b v : Ordinal} (hb : b ≠ 0) (u : Ordinal) (hv : v ≠ 0) (w) :
+    0 < b ^ u * v + w :=
   (opow_pos u <| Ordinal.pos_iff_ne_zero.2 hb).trans_le <|
     (le_mul_left _ <| Ordinal.pos_iff_ne_zero.2 hv).trans <| le_add_right _ _
 #align ordinal.opow_mul_add_pos Ordinal.opow_mul_add_pos
@@ -451,19 +452,19 @@ theorem add_log_le_log_mul {x y : Ordinal} (b : Ordinal) (hx : x ≠ 0) (hy : y 
 /-! ### Interaction with `Nat.cast` -/
 
 @[simp, norm_cast]
-theorem nat_cast_opow (m : ℕ) : ∀ n : ℕ, ((m ^ n : ℕ) : Ordinal) = (m^n)
+theorem nat_cast_opow (m : ℕ) : ∀ n : ℕ, ↑(m ^ n : ℕ) = (m : Ordinal) ^ (n : Ordinal)
   | 0 => by simp
   | n + 1 => by
     rw [pow_succ', nat_cast_mul, nat_cast_opow m n, Nat.cast_succ, add_one_eq_succ, opow_succ]
 #align ordinal.nat_cast_opow Ordinal.nat_cast_opow
 
-theorem sup_opow_nat {o : Ordinal} (ho : 0 < o) : (sup fun n : ℕ => o^n) = (o^ω) := by
+theorem sup_opow_nat {o : Ordinal} (ho : 0 < o) : (sup fun n : ℕ => o ^ (n : Ordinal)) = o ^ ω := by
   rcases lt_or_eq_of_le (one_le_iff_pos.2 ho) with (ho₁ | rfl)
   · exact (opow_isNormal ho₁).apply_omega
   · rw [one_opow]
     refine' le_antisymm (sup_le fun n => by rw [one_opow]) _
-    convert le_sup (fun n : ℕ => 1^n) 0
-    rw [Nat.cast_zero, opow_zero]
+    convert le_sup (fun n : ℕ => (1 : Ordinal) ^ n) 0
+    rw [one_opow, one_pow]
 #align ordinal.sup_opow_nat Ordinal.sup_opow_nat
 
 end Ordinal

--- a/Mathlib/SetTheory/Ordinal/Notation.lean
+++ b/Mathlib/SetTheory/Ordinal/Notation.lean
@@ -828,12 +828,12 @@ instance nf_opow (o₁ o₂) [NF o₁] [NF o₂] : NF (o₁ ^ o₂) := by
   haveI := (nf_repr_split' e₂).1
   cases' a with a0 n a'
   · cases' m with m
-    · by_cases o₂ = 0 <;> simp [(· ^ ·), Pow.pow, pow, opow, opowAux2, *]
+    · by_cases o₂ = 0 <;> simp [HPow.hPow, Pow.pow, pow, opow, opowAux2, *]
     · by_cases m = 0
-      · simp only [(· ^ ·), Pow.pow, pow, opow, opowAux2, *, zero_def]
-      · simp only [(· ^ ·), Pow.pow, pow, opow, opowAux2, mulNat_eq_mul, ofNat, *]
+      · simp only [HPow.hPow, Pow.pow, pow, opow, opowAux2, *, zero_def]
+      · simp only [HPow.hPow, Pow.pow, pow, opow, opowAux2, mulNat_eq_mul, ofNat, *]
         infer_instance
-  · simp [(· ^ ·),Pow.pow,pow, opow, opowAux2, e₁, e₂, split_eq_scale_split' e₂]
+  · simp [HPow.hPow, Pow.pow,pow, opow, opowAux2, e₁, e₂, split_eq_scale_split' e₂]
     have := na.fst
     cases' k with k <;> simp
     · infer_instance
@@ -885,9 +885,9 @@ set_option linter.unusedVariables false in
 theorem repr_opow_aux₂ {a0 a'} [N0 : NF a0] [Na' : NF a'] (m : ℕ) (d : ω ∣ repr a')
     (e0 : repr a0 ≠ 0) (h : repr a' + m < (ω ^ repr a0)) (n : ℕ+) (k : ℕ) :
     let R := repr (opowAux 0 a0 (oadd a0 n a' * ofNat m) k m)
-    (k ≠ 0 → R < ((ω ^ repr a0) ^ succ ↑k)) ∧
-      ((ω ^ repr a0) ^ k) * ((ω ^ repr a0) * (n : ℕ) + repr a') + R =
-        ((ω ^ repr a0) * (n : ℕ) + repr a' + m) ^ succ ↑k := by
+    (k ≠ 0 → R < ((ω ^ repr a0) ^ succ (k : Ordinal))) ∧
+      ((ω ^ repr a0) ^ (k : Ordinal)) * ((ω ^ repr a0) * (n : ℕ) + repr a') + R =
+        ((ω ^ repr a0) * (n : ℕ) + repr a' + m) ^ (succ ↑k : Ordinal) := by
   intro R'
   haveI No : NF (oadd a0 n a') :=
     N0.oadd n (Na'.below_of_lt' <| lt_of_le_of_lt (le_add_right _ _) h)
@@ -897,15 +897,16 @@ theorem repr_opow_aux₂ {a0 a'} [N0 : NF a0] [Na' : NF a'] (m : ℕ) (d : ω �
   let R := repr (opowAux 0 a0 (oadd a0 n a' * ofNat m) k m)
   let ω0 := ω ^ repr a0
   let α' := ω0 * n + repr a'
-  change (k ≠ 0 → R < (ω0 ^ succ ↑k)) ∧ (ω0 ^ k) * α' + R = (α' + m) ^ succ ↑k at IH
-  have RR : R' = (ω0 ^ k) * (α' * m) + R := by
+  change (k ≠ 0 → R < (ω0 ^ succ (k : Ordinal))) ∧ (ω0 ^ (k : Ordinal)) * α' + R
+    = (α' + m) ^ (succ ↑k : Ordinal) at IH
+  have RR : R' = ω0 ^ (k : Ordinal) * (α' * m) + R := by
     by_cases h : m = 0
     · simp only [h, ONote.ofNat, Nat.cast_zero, zero_add, ONote.repr, mul_zero, ONote.opowAux,
         add_zero]
     · simp only [ONote.repr_scale, ONote.repr, ONote.mulNat_eq_mul, ONote.opowAux, ONote.repr_ofNat,
         ONote.repr_mul, ONote.repr_add, Ordinal.opow_mul, ONote.zero_add]
   have α0 : 0 < α' := by simpa [lt_def, repr] using oadd_pos a0 n a'
-  have ω00 : 0 < (ω0 ^ k) := opow_pos _ (opow_pos _ omega_pos)
+  have ω00 : 0 < ω0 ^ (k : Ordinal) := opow_pos _ (opow_pos _ omega_pos)
   have Rl : R < ω ^ (repr a0 * succ ↑k) := by
     by_cases k0 : k = 0
     · simp [k0]
@@ -930,21 +931,22 @@ theorem repr_opow_aux₂ {a0 a'} [N0 : NF a0] [Na' : NF a'] (m : ℕ) (d : ω �
           (opow_le_opow_right omega_pos <|
             mul_le_mul_left' (succ_le_succ_iff.2 (nat_cast_le.2 (le_of_lt k.lt_succ_self))) _)
   calc
-    (ω0 ^ k.succ) * α' + R'
-    _ = (ω0 ^ succ ↑k) * α' + ((ω0 ^ k) * α' * m + R) := by rw [nat_cast_succ, RR, ← mul_assoc]
-    _ = ((ω0 ^ k) * α' + R) * α' + ((ω0 ^ k) * α' + R) * m := ?_
-    _ = (α' + m) ^ succ ↑k.succ := by rw [← mul_add, nat_cast_succ, opow_succ, IH.2]
+    (ω0 ^ (k.succ : Ordinal)) * α' + R'
+    _ = (ω0 ^ succ (k : Ordinal)) * α' + ((ω0 ^ (k : Ordinal)) * α' * m + R) :=
+        by rw [nat_cast_succ, RR, ← mul_assoc]
+    _ = ((ω0 ^ (k : Ordinal)) * α' + R) * α' + ((ω0 ^ (k : Ordinal)) * α' + R) * m := ?_
+    _ = (α' + m) ^ succ (k.succ : Ordinal) := by rw [← mul_add, nat_cast_succ, opow_succ, IH.2]
   congr 1
   · have αd : ω ∣ α' :=
       dvd_add (dvd_mul_of_dvd_left (by simpa using opow_dvd_opow ω (one_le_iff_ne_zero.2 e0)) _) d
-    rw [mul_add (ω0^k), add_assoc, ← mul_assoc, ← opow_succ,
+    rw [mul_add (ω0 ^ (k : Ordinal)), add_assoc, ← mul_assoc, ← opow_succ,
       add_mul_limit _ (isLimit_iff_omega_dvd.2 ⟨ne_of_gt α0, αd⟩), mul_assoc,
       @mul_omega_dvd n (nat_cast_pos.2 n.pos) (nat_lt_omega _) _ αd]
     apply @add_absorp _ (repr a0 * succ ↑k)
     · refine' principal_add_omega_opow _ _ Rl
       rw [opow_mul, opow_succ, Ordinal.mul_lt_mul_iff_left ω00]
       exact No.snd'.repr_lt
-    · have := mul_le_mul_left' (one_le_iff_pos.2 <| nat_cast_pos.2 n.pos) (ω0^succ k)
+    · have := mul_le_mul_left' (one_le_iff_pos.2 <| nat_cast_pos.2 n.pos) (ω0 ^ succ (k : Ordinal))
       rw [opow_mul]
       simpa [-opow_succ]
   · cases m

--- a/Mathlib/SetTheory/Ordinal/Principal.lean
+++ b/Mathlib/SetTheory/Ordinal/Principal.lean
@@ -202,7 +202,7 @@ theorem principal_add_omega_opow (o : Ordinal) : Principal (· + ·) (omega^o) :
 
 /-- The main characterization theorem for additive principal ordinals. -/
 theorem principal_add_iff_zero_or_omega_opow {o : Ordinal} :
-    Principal (· + ·) o ↔ o = 0 ∨ ∃ a, o = (omega^a) := by
+    Principal (· + ·) o ↔ o = 0 ∨ ∃ a : Ordinal, o = omega ^ a := by
   rcases eq_or_ne o 0 with (rfl | ho)
   · simp only [principal_zero, Or.inl]
   · rw [principal_add_iff_add_left_eq_self]
@@ -371,7 +371,7 @@ theorem principal_add_of_principal_mul_opow {o b : Ordinal} (hb : 1 < b)
 
 /-- The main characterization theorem for multiplicative principal ordinals. -/
 theorem principal_mul_iff_le_two_or_omega_opow_opow {o : Ordinal} :
-    Principal (· * ·) o ↔ o ≤ 2 ∨ ∃ a, o = (omega^omega^a) := by
+    Principal (· * ·) o ↔ o ≤ 2 ∨ ∃ a : Ordinal, o = omega ^ omega ^ a := by
   refine' ⟨fun ho => _, _⟩
   · cases' le_or_lt o 2 with ho₂ ho₂
     · exact Or.inl ho₂

--- a/Mathlib/Tactic/Common.lean
+++ b/Mathlib/Tactic/Common.lean
@@ -116,3 +116,5 @@ import Mathlib.Tactic.WLOG
 import Mathlib.Util.CountHeartbeats
 import Mathlib.Util.Imports
 import Mathlib.Util.WhatsNew
+
+import Mathlib.binop2

--- a/Mathlib/Topology/Algebra/Module/Basic.lean
+++ b/Mathlib/Topology/Algebra/Module/Basic.lean
@@ -585,13 +585,13 @@ theorem smul_apply (c : S₂) (f : M₁ →SL[σ₁₂] M₂) (x : M₁) : (c �
 
 @[simp, norm_cast]
 theorem coe_smul (c : S₂) (f : M₁ →SL[σ₁₂] M₂) :
-    (c • f : M₁ →ₛₗ[σ₁₂] M₂) = c • (f : M₁ →ₛₗ[σ₁₂] M₂) :=
+    ↑(c • f) = c • (f : M₁ →ₛₗ[σ₁₂] M₂) :=
   rfl
 #align continuous_linear_map.coe_smul ContinuousLinearMap.coe_smul
 
 @[simp, norm_cast]
 theorem coe_smul' (c : S₂) (f : M₁ →SL[σ₁₂] M₂) :
-    (c • f : M₁ → M₂) = c • (f : M₁ → M₂) :=
+    ↑(c • f) = c • (f : M₁ → M₂) :=
   rfl
 #align continuous_linear_map.coe_smul' ContinuousLinearMap.coe_smul'
 

--- a/Mathlib/Topology/Algebra/Module/Cardinality.lean
+++ b/Mathlib/Topology/Algebra/Module/Cardinality.lean
@@ -81,9 +81,9 @@ lemma cardinal_eq_of_mem_nhds_zero
     rw [zero_smul] at this
     filter_upwards [this hs] with n (hn : (c ^ n)⁻¹ • x ∈ s)
     exact (mem_smul_set_iff_inv_smul_mem₀ (cn_ne n) _ _).2 hn
-  have B : ∀ n, #(c^n • s) = #s := by
+  have B : ∀ n, #(c^n • s :) = #s := by
     intro n
-    have : c^n • s ≃ s :=
+    have : (c^n • s :) ≃ s :=
     { toFun := fun x ↦ ⟨(c^n)⁻¹ • x.1, (mem_smul_set_iff_inv_smul_mem₀ (cn_ne n) _ _).1 x.2⟩
       invFun := fun x ↦ ⟨(c^n) • x.1, smul_mem_smul_set x.2⟩
       left_inv := fun x ↦ by simp [smul_smul, mul_inv_cancel (cn_ne n)]

--- a/Mathlib/Topology/Algebra/Nonarchimedean/AdicTopology.lean
+++ b/Mathlib/Topology/Algebra/Nonarchimedean/AdicTopology.lean
@@ -140,7 +140,7 @@ def openAddSubgroup (n : ℕ) : @OpenAddSubgroup R _ I.adicTopology := by
   letI := I.adicTopology
   refine ⟨(I ^ n).toAddSubgroup, ?_⟩
   convert (I.adic_basis.toRing_subgroups_basis.openAddSubgroup n).isOpen
-  change (↑(I ^ n) : Set R) = (I ^ n • (⊤ : Ideal R) : Set R)
+  change (↑(I ^ n) : Set R) = ↑(I ^ n • (⊤ : Ideal R))
   simp [smul_top_eq_map, Algebra.id.map_eq_id, map_id, restrictScalars_self]
 #align ideal.open_add_subgroup Ideal.openAddSubgroup
 

--- a/Mathlib/Topology/Algebra/Nonarchimedean/AdicTopology.lean
+++ b/Mathlib/Topology/Algebra/Nonarchimedean/AdicTopology.lean
@@ -66,7 +66,7 @@ theorem adic_basis (I : Ideal R) : SubmodulesRingBasis fun n : ℕ => (I ^ n •
       rintro a ⟨x, hx, rfl⟩
       exact (I ^ n).smul_mem r hx
     mul := by
-      suffices ∀ i : ℕ, ∃ j : ℕ, (I ^ j: Set R) * (I ^ j : Set R) ⊆ (I ^ i : Set R) by
+      suffices ∀ i : ℕ, ∃ j : ℕ, (↑(I ^ j) * ↑(I ^ j) : Set R) ⊆ (↑(I ^ i) : Set R) by
         simpa only [smul_top_eq_map, Algebra.id.map_eq_id, map_id] using this
       intro n
       use n
@@ -140,7 +140,7 @@ def openAddSubgroup (n : ℕ) : @OpenAddSubgroup R _ I.adicTopology := by
   letI := I.adicTopology
   refine ⟨(I ^ n).toAddSubgroup, ?_⟩
   convert (I.adic_basis.toRing_subgroups_basis.openAddSubgroup n).isOpen
-  change (I ^ n : Set R) = (I ^ n • (⊤ : Ideal R) : Set R)
+  change (↑(I ^ n) : Set R) = (I ^ n • (⊤ : Ideal R) : Set R)
   simp [smul_top_eq_map, Algebra.id.map_eq_id, map_id, restrictScalars_self]
 #align ideal.open_add_subgroup Ideal.openAddSubgroup
 

--- a/Mathlib/Topology/MetricSpace/GromovHausdorff.lean
+++ b/Mathlib/Topology/MetricSpace/GromovHausdorff.lean
@@ -1002,8 +1002,6 @@ def auxGluing (n : ℕ) : AuxGluingStruct (X n) :=
       isom := (toGlueR_isometry _ _).comp (isometry_optimalGHInjr (X n) (X (n + 1))) }
 #align Gromov_Hausdorff.aux_gluing GromovHausdorff.auxGluing
 
-local macro_rules | `($x ^ $y) => `(HPow.hPow $x $y) -- Porting note: See issue lean4#2220
-
 /-- The Gromov-Hausdorff space is complete. -/
 instance : CompleteSpace GHSpace := by
   set d := fun n : ℕ ↦ ((1 : ℝ) / 2) ^ n

--- a/Mathlib/Topology/MetricSpace/HausdorffDimension.lean
+++ b/Mathlib/Topology/MetricSpace/HausdorffDimension.lean
@@ -519,7 +519,7 @@ theorem dimH_ball_pi (x : ι → ℝ) {r : ℝ} (hr : 0 < r) :
     exact fun x _ y _ => Subsingleton.elim x y
   · rw [← ENNReal.coe_nat]
     have : μH[Fintype.card ι] (Metric.ball x r) = ENNReal.ofReal ((2 * r) ^ Fintype.card ι) := by
-      rw [hausdorffMeasure_pi_real, Real.volume_pi_ball _ hr, rpow_nat_cast]
+      rw [hausdorffMeasure_pi_real, Real.volume_pi_ball _ hr]
     refine dimH_of_hausdorffMeasure_ne_zero_ne_top ?_ ?_ <;> rw [NNReal.coe_nat_cast, this]
     · simp [pow_pos (mul_pos (zero_lt_two' ℝ) hr)]
     · exact ENNReal.ofReal_ne_top

--- a/Mathlib/binop2.lean
+++ b/Mathlib/binop2.lean
@@ -1,0 +1,472 @@
+/-
+Copyright (c) 2021 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Leonardo de Moura
+-/
+import Lean.Elab.App
+import Lean.Elab.BuiltinNotation
+
+/-! # Auxiliary elaboration functions: AKA custom elaborators -/
+
+/-
+Overrides to Lean/Elab/Extra.lean by Kyle Miller
+
+Includes elaborators for left and right actions (for `HPow.hPow`).
+-/
+
+namespace Lean.Elab.Term
+open Meta
+
+namespace OpV2
+/-!
+
+The elaborator for `binop%`, `binop_lazy%`, and `unop%` terms.
+
+It works as follows:
+
+1- Expand macros.
+2- Convert `Syntax` object corresponding to the `binop%` (`binop_lazy%` and `unop%`) term into a `Tree`.
+   The `toTree` method visits nested `binop%` (`binop_lazy%` and `unop%`) terms and parentheses.
+3- Synthesize pending metavariables without applying default instances and using the
+   `(mayPostpone := true)`.
+4- Tries to compute a maximal type for the tree computed at step 2.
+   We say a type α is smaller than type β if there is a (nondependent) coercion from α to β.
+   We are currently ignoring the case we may have cycles in the coercion graph.
+   If there are "uncomparable" types α and β in the tree, we skip the next step.
+   We say two types are "uncomparable" if there isn't a coercion between them.
+   Note that two types may be "uncomparable" because some typing information may still be missing.
+5- We traverse the tree and inject coercions to the "maximal" type when needed.
+
+Recall that the coercions are expanded eagerly by the elaborator.
+
+Properties:
+
+a) Given `n : Nat` and `i : Nat`, it can successfully elaborate `n + i` and `i + n`. Recall that Lean 3
+   fails on the former.
+
+b) The coercions are inserted in the "leaves" like in Lean 3.
+
+c) There are no coercions "hidden" inside instances, and we can elaborate
+```
+axiom Int.add_comm (i j : Int) : i + j = j + i
+
+example (n : Nat) (i : Int) : n + i = i + n := by
+  rw [Int.add_comm]
+```
+Recall that the `rw` tactic used to fail because our old `binop%` elaborator would hide
+coercions inside of a `HAdd` instance.
+
+Remarks:
+
+In the new `binop%` and related elaborators the decision whether a coercion will be inserted or not
+is made at `binop%` elaboration time. This was not the case in the old elaborator.
+For example, an instance, such as `HAdd Int ?m ?n`, could be created when executing
+the `binop%` elaborator, and only resolved much later. We try to minimize this problem
+by synthesizing pending metavariables at step 3.
+
+For types containing heterogeneous operators (e.g., matrix multiplication), step 4 will fail
+and we will skip coercion insertion. For example, `x : Matrix Real 5 4` and `y : Matrix Real 4 8`,
+there is no coercion `Matrix Real 5 4` from `Matrix Real 4 8` and vice-versa, but
+`x * y` is elaborated successfully and has type `Matrix Real 5 8`.
+-/
+
+section
+open Parser
+
+/-- Left action; the right argument can participate in the operator coercion elaborator. -/
+syntax (name := leftact) "leftact% " ident ppSpace term:max ppSpace term:max : term
+
+/-- Right action; the left argument can participate in the operator coercion elaborator. -/
+syntax (name := rightact) "rightact% " ident ppSpace term:max ppSpace term:max : term
+
+end
+
+private inductive Tree where
+  /--
+  Leaf of the tree.
+  We store the `infoTrees` generated when elaborating `val`. These trees become
+  subtrees of the infotree nodes generated for `op` nodes.
+  -/
+  | term (ref : Syntax) (infoTrees : PersistentArray InfoTree) (val : Expr)
+  /--
+  `ref` is the original syntax that expanded into `binop%`.
+  -/
+  | binop (ref : Syntax) (lazy : Bool) (f : Expr) (lhs rhs : Tree)
+  /--
+  `ref` is the original syntax that expanded into `unop%`.
+  -/
+  | unop (ref : Syntax) (f : Expr) (arg : Tree)
+  /--
+  `ref` is the original syntax that expanded into `action%`.
+  `right` is whether this is a right action (vs a left action); if it is a right (resp. left)
+  action, then the `rhs` (resp. `lhs`) is not processed.
+  -/
+  | action (ref : Syntax) (right : Bool) (f : Expr) (lhs rhs : Tree)
+  /--
+  Used for assembling the info tree. We store this information
+  to make sure "go to definition" behaves similarly to notation defined without using `binop%` helper elaborator.
+  -/
+  | macroExpansion (macroName : Name) (stx stx' : Syntax) (nested : Tree)
+
+
+private partial def toTree (s : Syntax) : TermElabM Tree := do
+  /-
+  Remark: ew used to use `expandMacros` here, but this is a bad idiom
+  because we do not record the macro expansion information in the info tree.
+  We now manually expand the notation in the `go` function, and save
+  the macro declaration names in the `op` nodes.
+  -/
+  let result ← go s
+  synthesizeSyntheticMVars (mayPostpone := true)
+  return result
+where
+  go (s : Syntax) := do
+    match s with
+    | `(binop% $f $lhs $rhs) => processBinOp (lazy := false) s f lhs rhs
+    | `(binop_lazy% $f $lhs $rhs) => processBinOp (lazy := true) s f lhs rhs
+    | `(unop% $f $arg) => processUnOp s f arg
+    | `(leftact% $f $lhs $rhs) => processAction (right := false) s f lhs rhs
+    | `(rightact% $f $lhs $rhs) => processAction (right := true) s f lhs rhs
+    | `(($e)) =>
+      if hasCDot e then
+        processLeaf s
+      else
+        go e
+    | _ =>
+      withRef s do
+        match (← liftMacroM <| expandMacroImpl? (← getEnv) s) with
+        | some (macroName, s?) =>
+          let s' ← liftMacroM <| liftExcept s?
+          withPushMacroExpansionStack s s' do
+            return .macroExpansion macroName s s' (← go s')
+        | none => processLeaf s
+
+  processBinOp (ref : Syntax) (f lhs rhs : Syntax) (lazy : Bool) := do
+    let some f ← resolveId? f | throwUnknownConstant f.getId
+    return .binop (lazy := lazy) ref f (← go lhs) (← go rhs)
+
+  processUnOp (ref : Syntax) (f arg : Syntax) := do
+    let some f ← resolveId? f | throwUnknownConstant f.getId
+    return .unop ref f (← go arg)
+
+  processAction (ref : Syntax) (f lhs rhs : Syntax) (right : Bool) := do
+    let some f ← resolveId? f | throwUnknownConstant f.getId
+    if right then
+      return .action ref right f (← go lhs) (← processLeaf rhs)
+    else
+      return .action ref right f (← processLeaf lhs) (← go rhs)
+
+  processLeaf (s : Syntax) := do
+    let e ← elabTerm s none
+    let info ← getResetInfoTrees
+    return .term s info e
+
+-- Auxiliary function used at `analyze`
+private def hasCoe (fromType toType : Expr) : TermElabM Bool := do
+  if (← getEnv).contains ``CoeT then
+    withLocalDeclD `x fromType fun x => do
+    match ← coerceSimple? x toType with
+    | .some _ => return true
+    | .none   => return false
+    | .undef  => return false -- TODO: should we do something smarter here?
+  else
+    return false
+
+private structure AnalyzeResult where
+  max?            : Option Expr := none
+  hasUncomparable : Bool := false -- `true` if there are two types `α` and `β` where we don't have coercions in any direction.
+
+private def isUnknow : Expr → Bool
+  | .mvar ..        => true
+  | .app f _        => isUnknow f
+  | .letE _ _ _ b _ => isUnknow b
+  | .mdata _ b      => isUnknow b
+  | _               => false
+
+private def analyze (t : Tree) (expectedType? : Option Expr) : TermElabM AnalyzeResult := do
+  let max? ←
+    match expectedType? with
+    | none => pure none
+    | some expectedType =>
+      let expectedType ← instantiateMVars expectedType
+      if isUnknow expectedType then pure none else pure (some expectedType)
+  (go t *> get).run' { max? }
+where
+   go (t : Tree) : StateRefT AnalyzeResult TermElabM Unit := do
+     unless (← get).hasUncomparable do
+       match t with
+       | .macroExpansion _ _ _ nested => go nested
+       | .binop _ _ _ lhs rhs => go lhs; go rhs
+       | .unop _ _ arg => go arg
+       | .action _ right _ lhs rhs => if right then go lhs else go rhs
+       | .term _ _ val =>
+         let type ← instantiateMVars (← inferType val)
+         unless isUnknow type do
+           match (← get).max? with
+           | none     => modify fun s => { s with max? := type }
+           | some max =>
+             unless (← withNewMCtxDepth <| isDefEqGuarded max type) do
+               if (← hasCoe type max) then
+                 return ()
+               else if (← hasCoe max type) then
+                 modify fun s => { s with max? := type }
+               else
+                 trace[Elab.binop] "uncomparable types: {max}, {type}"
+                 modify fun s => { s with hasUncomparable := true }
+
+private def mkBinOp (lazy : Bool) (f : Expr) (lhs rhs : Expr) : TermElabM Expr := do
+  let mut rhs := rhs
+  if lazy then
+    rhs ← mkFunUnit rhs
+  elabAppArgs f #[] #[Arg.expr lhs, Arg.expr rhs] (expectedType? := none) (explicit := false) (ellipsis := false) (resultIsOutParamSupport := false)
+
+private def mkUnOp (f : Expr) (arg : Expr) : TermElabM Expr := do
+  elabAppArgs f #[] #[Arg.expr arg] (expectedType? := none) (explicit := false) (ellipsis := false) (resultIsOutParamSupport := false)
+
+private def toExprCore (t : Tree) : TermElabM Expr := do
+  match t with
+  | .term _ trees e =>
+    modifyInfoState (fun s => { s with trees := s.trees ++ trees }); return e
+  | .binop ref lazy f lhs rhs =>
+    withRef ref <| withInfoContext' ref (mkInfo := mkTermInfo .anonymous ref) do
+      mkBinOp lazy f (← toExprCore lhs) (← toExprCore rhs)
+  | .unop ref f arg =>
+    withRef ref <| withInfoContext' ref (mkInfo := mkTermInfo .anonymous ref) do
+      mkUnOp f (← toExprCore arg)
+  | .action ref _ f lhs rhs =>
+    withRef ref <| withInfoContext' ref (mkInfo := mkTermInfo .anonymous ref) do
+      mkBinOp false f (← toExprCore lhs) (← toExprCore rhs)
+  | .macroExpansion macroName stx stx' nested =>
+    withRef stx <| withInfoContext' stx (mkInfo := mkTermInfo macroName stx) do
+      withMacroExpansion stx stx' do
+        toExprCore nested
+
+/--
+  Auxiliary function to decide whether we should coerce `f`'s argument to `maxType` or not.
+  - `f` is a binary operator.
+  - `lhs == true` (`lhs == false`) if are trying to coerce the left-argument (right-argument).
+  This function assumes `f` is a heterogeneous operator (e.g., `HAdd.hAdd`, `HMul.hMul`, etc).
+  It returns true IF
+  - `f` is a constant of the form `Cls.op` where `Cls` is a class name, and
+  - `maxType` is of the form `C ...` where `C` is a constant, and
+  - There are more than one default instance. That is, it assumes the class `Cls` for the heterogeneous operator `f`, and
+    always has the monomorphic instance. (e.g., for `HAdd`, we have `instance [Add α] : HAdd α α α`), and
+  - If `lhs == true`, then there is a default instance of the form `Cls _ (C ..) _`, and
+  - If `lhs == false`, then there is a default instance of the form `Cls (C ..) _ _`.
+
+  The motivation is to support default instances such as
+  ```
+  @[default_instance high]
+  instance [Mul α] : HMul α (Array α) (Array α) where
+    hMul a as := as.map (a * ·)
+
+  #eval 2 * #[3, 4, 5]
+  ```
+  If the type of an argument is unknown we should not coerce it to `maxType` because it would prevent
+  the default instance above from being even tried.
+-/
+private def hasHeterogeneousDefaultInstances (f : Expr) (maxType : Expr) (lhs : Bool) : MetaM Bool := do
+  let .const fName .. := f | return false
+  let .const typeName .. := maxType.getAppFn | return false
+  let className := fName.getPrefix
+  let defInstances ← getDefaultInstances className
+  if defInstances.length ≤ 1 then return false
+  for (instName, _) in defInstances do
+    if let .app (.app (.app _heteroClass lhsType) rhsType) _resultType :=
+        (← getConstInfo instName).type.getForallBody then
+      if  lhs && rhsType.isAppOf typeName then return true
+      if !lhs && lhsType.isAppOf typeName then return true
+  return false
+
+/--
+  Return `true` if polymorphic function `f` has a homogenous instance of `maxType`.
+  The coercions to `maxType` only makes sense if such instance exists.
+
+  For example, suppose `maxType` is `Int`, and `f` is `HPow.hPow`. Then,
+  adding coercions to `maxType` only make sense if we have an instance `HPow Int Int Int`.
+-/
+private def hasHomogeneousInstance (f : Expr) (maxType : Expr) : MetaM Bool := do
+  let .const fName .. := f | return false
+  let className := fName.getPrefix
+  try
+    let inst ← mkAppM className #[maxType, maxType, maxType]
+    return (← trySynthInstance inst) matches .some _
+  catch _ =>
+    return false
+
+mutual
+  /--
+    Try to coerce elements in the `t` to `maxType` when needed.
+    If the type of an element in `t` is unknown we only coerce it to `maxType` if `maxType` does not have heterogeneous
+    default instances. This extra check is approximated by `hasHeterogeneousDefaultInstances`.
+
+    Remark: If `maxType` does not implement heterogeneous default instances, we do want to assign unknown types `?m` to
+    `maxType` because it produces better type information propagation. Our test suite has many tests that would break if
+    we don't do this. For example, consider the term
+    ```
+    eq_of_isEqvAux a b hsz (i+1) (Nat.succ_le_of_lt h) heqv.2
+    ```
+    `Nat.succ_le_of_lt h` type depends on `i+1`, but `i+1` only reduces to `Nat.succ i` if we know that `1` is a `Nat`.
+    There are several other examples like that in our test suite, and one can find them by just replacing the
+    `← hasHeterogeneousDefaultInstances f maxType lhs` test with `true`
+
+
+    Remark: if `hasHeterogeneousDefaultInstances` implementation is not good enough we should refine it in the future.
+  -/
+  private partial def applyCoe (t : Tree) (maxType : Expr) (isPred : Bool) : TermElabM Tree := do
+    go t none false isPred
+  where
+    go (t : Tree) (f? : Option Expr) (lhs : Bool) (isPred : Bool) : TermElabM Tree := do
+      match t with
+      | .binop ref lazy f lhs rhs =>
+        /-
+          We only keep applying coercions to `maxType` if `f` is predicate or
+          `f` has a homogenous instance with `maxType`. See `hasHomogeneousInstance` for additional details.
+
+          Remark: We assume `binrel%` elaborator is only used with homogenous predicates.
+        -/
+        if (← pure isPred <||> hasHomogeneousInstance f maxType) then
+          return .binop ref lazy f (← go lhs f true false) (← go rhs f false false)
+        else
+          let r ← withRef ref do
+            mkBinOp lazy f (← toExpr lhs none) (← toExpr rhs none)
+          let infoTrees ← getResetInfoTrees
+          return .term ref infoTrees r
+      | .unop ref f arg =>
+        return .unop ref f (← go arg none false false)
+      | .action ref right f lhs rhs =>
+        if right then
+          return .action ref right f (← go lhs none false false) rhs
+        else
+          return .action ref right f lhs (← go rhs none false false)
+      | .term ref trees e =>
+        let type ← instantiateMVars (← inferType e)
+        trace[Elab.binop] "visiting {e} : {type} =?= {maxType}"
+        if isUnknow type then
+          if let some f := f? then
+            if (← hasHeterogeneousDefaultInstances f maxType lhs) then
+              -- See comment at `hasHeterogeneousDefaultInstances`
+              return t
+        if (← isDefEqGuarded maxType type) then
+          return t
+        else
+          trace[Elab.binop] "added coercion: {e} : {type} => {maxType}"
+          withRef ref <| return .term ref trees (← mkCoe maxType e)
+      | .macroExpansion macroName stx stx' nested =>
+        withRef stx <| withPushMacroExpansionStack stx stx' do
+          return .macroExpansion macroName stx stx' (← go nested f? lhs isPred)
+
+  private partial def toExpr (tree : Tree) (expectedType? : Option Expr) : TermElabM Expr := do
+    let r ← analyze tree expectedType?
+    trace[Elab.binop] "hasUncomparable: {r.hasUncomparable}, maxType: {r.max?}"
+    if r.hasUncomparable || r.max?.isNone then
+      let result ← toExprCore tree
+      ensureHasType expectedType? result
+    else
+      let result ← toExprCore (← applyCoe tree r.max?.get! (isPred := false))
+      trace[Elab.binop] "result: {result}"
+      ensureHasType expectedType? result
+
+end
+
+def elabOp : TermElab := fun stx expectedType? => do
+  toExpr (← toTree stx) expectedType?
+
+@[term_elab binop]
+def elabBinOp : TermElab := elabOp
+
+@[term_elab binop_lazy]
+def elabBinOpLazy : TermElab := elabOp
+
+@[term_elab unop]
+def elabUnOp : TermElab := elabOp
+
+@[term_elab leftact]
+def elabLeftAct : TermElab := elabOp
+
+@[term_elab rightact]
+def elabRightAct : TermElab := elabOp
+
+/--
+  Elaboration functionf for `binrel%` and `binrel_no_prop%` notations.
+  We use the infrastructure for `binop%` to make sure we propagate information between the left and right hand sides
+  of a binary relation.
+
+  Recall that the `binrel_no_prop%` notation is used for relations such as `==` which do not support `Prop`, but
+  we still want to be able to write `(5 > 2) == (2 > 1)`.
+-/
+def elabBinRelCore (noProp : Bool) (stx : Syntax) (expectedType? : Option Expr) : TermElabM Expr :=  do
+  match (← resolveId? stx[1]) with
+  | some f => withSynthesizeLight do
+    /-
+    We used to use `withSynthesize (mayPostpone := true)` here instead of `withSynthesizeLight` here.
+    Recall that `withSynthesizeLight` is equivalent to `withSynthesize (mayPostpone := true) (synthesizeDefault := false)`.
+    It seems too much to apply default instances at binary relations. For example, we cannot elaborate
+    ```
+    def as : List Int := [-1, 2, 0, -3, 4]
+    #eval as.map fun a => ite (a ≥ 0) [a] []
+    ```
+    The problem is that when elaborating `a ≥ 0` we don't know yet that `a` is an `Int`.
+    Then, by applying default instances, we apply the default instance to `0` that forces it to become an `Int`,
+    and Lean infers that `a` has type `Nat`.
+    Then, later we get a type error because `as` is `List Int` instead of `List Nat`.
+    This behavior is quite counterintuitive since if we avoid this elaborator by writing
+    ```
+    def as : List Int := [-1, 2, 0, -3, 4]
+    #eval as.map fun a => ite (GE.ge a 0) [a] []
+    ```
+    everything works.
+    However, there is a drawback of using `withSynthesizeLight` instead of `withSynthesize (mayPostpone := true)`.
+    The following cannot be elaborated
+    ```
+    have : (0 == 1) = false := rfl
+    ```
+    We get a type error at `rfl`. `0 == 1` only reduces to `false` after we have applied the default instances that force
+    the numeral to be `Nat`. We claim this is defensible behavior because the same happens if we do not use this elaborator.
+    ```
+    have : (BEq.beq 0 1) = false := rfl
+    ```
+    We can improve this failure in the future by applying default instances before reporting a type mismatch.
+    -/
+    let lhs ← withRef stx[2] <| toTree stx[2]
+    let rhs ← withRef stx[3] <| toTree stx[3]
+    let tree := .binop (lazy := false) stx f lhs rhs
+    let r ← analyze tree none
+    trace[Elab.binrel] "hasUncomparable: {r.hasUncomparable}, maxType: {r.max?}"
+    if r.hasUncomparable || r.max?.isNone then
+      -- Use default elaboration strategy + `toBoolIfNecessary`
+      let lhs ← toExprCore lhs
+      let rhs ← toExprCore rhs
+      let lhs ← toBoolIfNecessary lhs
+      let rhs ← toBoolIfNecessary rhs
+      let lhsType ← inferType lhs
+      let rhs ← ensureHasType lhsType rhs
+      elabAppArgs f #[] #[Arg.expr lhs, Arg.expr rhs] expectedType? (explicit := false) (ellipsis := false) (resultIsOutParamSupport := false)
+    else
+      let mut maxType := r.max?.get!
+      /- If `noProp == true` and `maxType` is `Prop`, then set `maxType := Bool`. `See toBoolIfNecessary` -/
+      if noProp then
+        if (← withNewMCtxDepth <| isDefEq maxType (mkSort levelZero)) then
+          maxType := Lean.mkConst ``Bool
+      let result ← toExprCore (← applyCoe tree maxType (isPred := true))
+      trace[Elab.binrel] "result: {result}"
+      return result
+  | none   => throwUnknownConstant stx[1].getId
+where
+  /-- If `noProp == true` and `e` has type `Prop`, then coerce it to `Bool`. -/
+  toBoolIfNecessary (e : Expr) : TermElabM Expr := do
+    if noProp then
+      -- We use `withNewMCtxDepth` to make sure metavariables are not assigned
+      if (← withNewMCtxDepth <| isDefEq (← inferType e) (mkSort levelZero)) then
+        return (← ensureHasType (Lean.mkConst ``Bool) e)
+    return e
+
+@[term_elab binrel] def elabBinRel : TermElab := elabBinRelCore false
+
+@[term_elab binrel_no_prop] def elabBinRelNoProp : TermElab := elabBinRelCore true
+
+end OpV2
+
+macro_rules | `($x ^ $y)   => `(rightact% HPow.hPow $x $y)
+
+end Lean.Elab.Term

--- a/test/positivity.lean
+++ b/test/positivity.lean
@@ -184,7 +184,7 @@ example [LinearOrderedSemifield α] (a : α) : 0 < a ^ (0 : ℤ) := by positivit
 
 example {a b : ℝ} (ha : 0 ≤ a) : 0 ≤ a ^ b := by positivity
 example {a b : ℝ} (ha : 0 < a) : 0 < a ^ b := by positivity
-example {a : ℝ≥0} {b : ℝ} (ha : 0 < a) : 0 < a ^ b := by positivity
+example {a : ℝ≥0} {b : ℝ} (ha : 0 < a) : 0 < (a : ℝ) ^ b := by positivity
 -- example {a : ℝ≥0∞} {b : ℝ} (ha : 0 < a) (hb : 0 ≤ b) : 0 < a ^ b := by positivity
 -- example {a : ℝ≥0∞} {b : ℝ} (ha : 0 < a) (hb : 0 < b) : 0 < a ^ b := by positivity
 example {a : ℝ} : 0 < a ^ 0 := by positivity


### PR DESCRIPTION
This is experimenting with some changes to the unary/binary operation elaborator that aim to address [lean4#2220](https://github.com/leanprover/lean4/issues/2220)

It adds two variants of `binop%`: `leftact%` and `rightact%`. Whereas `binop%` looks at both arguments when doing its coercion computations, `leftact%` only looks at the right argument and `rightact%` only looks at the left.

Exponentiation is best thought of as being a right action. For example, in `2 ^ n + x` with `x : Real` and `n : Nat`, then this should leave `n` as a `Nat` but elaborate `2` as a `Real` (this is the monoid action of `Nat` on `Real`).

The main changes to mathlib that are needed are using `(a ^ b :)` to essentially switch to the `local macro_rules` solution for the given expression, using `↑(a ^ b)` if it's more convenient, or giving type ascriptions to the exponent, like in `a ^ (2 : Ordinal)`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
