### PR TITLE
[Merged by Bors] - feat: change junk value for supremum of unbounded sets

### DIFF
--- a/Mathlib/Algebra/Order/Nonneg/Ring.lean
+++ b/Mathlib/Algebra/Order/Nonneg/Ring.lean
@@ -89,15 +89,10 @@ The `Set.Ici` data fields are definitionally equal, but that requires unfolding 
 definitions, so type-class inference won't see this. -/
 @[reducible]
 protected noncomputable def conditionallyCompleteLinearOrderBot [ConditionallyCompleteLinearOrder α]
-    {a : α} (h : sSup ∅ ≤ a) : ConditionallyCompleteLinearOrderBot { x : α // a ≤ x } :=
+    (a : α) : ConditionallyCompleteLinearOrderBot { x : α // a ≤ x } :=
   { Nonneg.orderBot, Nonneg.conditionallyCompleteLinearOrder with
-    csSup_empty :=
-      (Function.funext_iff.1 (@subset_sSup_def α (Set.Ici a) _ ⟨⟨a, le_rfl⟩⟩) ∅).trans <|
-        Subtype.eq <| by
-          rw [bot_eq]
-          cases' h.lt_or_eq with h2 h2
-          · simp [h2.not_le]
-          simp [h2] }
+    csSup_empty := by
+      rw [@subset_sSup_def α (Set.Ici a) _ _ ⟨⟨a, le_rfl⟩⟩]; simp [bot_eq] }
 #align nonneg.conditionally_complete_linear_order_bot Nonneg.conditionallyCompleteLinearOrderBot
 
 instance inhabited [Preorder α] {a : α} : Inhabited { x : α // a ≤ x } :=

--- a/Mathlib/Data/Nat/Lattice.lean
+++ b/Mathlib/Data/Nat/Lattice.lean
@@ -135,10 +135,10 @@ noncomputable instance : ConditionallyCompleteLinearOrderBot ℕ :=
       trivial
     csSup_of_not_bddAbove := by
       intro s hs
-      simp only [mem_univ, forall_true_left, sSup]
-      rw [dif_neg, dif_neg]
-      · simp only [not_exists, not_forall, not_le]
-        exact fun n ↦ ⟨n+1, lt.base n⟩
+      simp only [mem_univ, forall_true_left, sSup,
+        mem_empty_iff_false, IsEmpty.forall_iff, forall_const, exists_const, dite_true]
+      rw [dif_neg]
+      · exact le_antisymm (zero_le _) (find_le trivial)
       · exact hs
     csInf_of_not_bddBelow := fun s hs ↦ by simp at hs }
 

--- a/Mathlib/Data/Real/NNReal.lean
+++ b/Mathlib/Data/Real/NNReal.lean
@@ -484,13 +484,22 @@ theorem bddBelow_coe (s : Set ℝ≥0) : BddBelow (((↑) : ℝ≥0 → ℝ) '' 
 #align nnreal.bdd_below_coe NNReal.bddBelow_coe
 
 noncomputable instance : ConditionallyCompleteLinearOrderBot ℝ≥0 :=
-  Nonneg.conditionallyCompleteLinearOrderBot Real.sSup_empty.le
+  Nonneg.conditionallyCompleteLinearOrderBot 0
 
 @[norm_cast]
-theorem coe_sSup (s : Set ℝ≥0) : (↑(sSup s) : ℝ) = sSup (((↑) : ℝ≥0 → ℝ) '' s) :=
-  Eq.symm <|
-    @subset_sSup_of_within ℝ (Set.Ici 0) _ ⟨(0 : ℝ≥0)⟩ s <|
-      Real.sSup_nonneg _ fun _y ⟨x, _, hy⟩ => hy ▸ x.2
+theorem coe_sSup (s : Set ℝ≥0) : (↑(sSup s) : ℝ) = sSup (((↑) : ℝ≥0 → ℝ) '' s) := by
+  rcases Set.eq_empty_or_nonempty s with rfl|hs
+  · simp
+  by_cases H : BddAbove s
+  · have A : sSup (Subtype.val '' s) ∈ Set.Ici 0 := by
+      apply Real.sSup_nonneg
+      rintro - ⟨y, -, rfl⟩
+      exact y.2
+    exact (@subset_sSup_of_within ℝ (Set.Ici (0 : ℝ)) _ _ (_) s hs H A).symm
+  · simp only [csSup_of_not_bddAbove H, csSup_empty, bot_eq_zero', NNReal.coe_zero]
+    apply (Real.sSup_of_not_bddAbove ?_).symm
+    contrapose! H
+    exact bddAbove_coe.1 H
 #align nnreal.coe_Sup NNReal.coe_sSup
 
 @[simp, norm_cast] -- porting note: add `simp`
@@ -499,10 +508,15 @@ theorem coe_iSup {ι : Sort*} (s : ι → ℝ≥0) : (↑(⨆ i, s i) : ℝ) = �
 #align nnreal.coe_supr NNReal.coe_iSup
 
 @[norm_cast]
-theorem coe_sInf (s : Set ℝ≥0) : (↑(sInf s) : ℝ) = sInf (((↑) : ℝ≥0 → ℝ) '' s) :=
-  Eq.symm <|
-    @subset_sInf_of_within ℝ (Set.Ici 0) _ ⟨(0 : ℝ≥0)⟩ s <|
-      Real.sInf_nonneg _ fun _y ⟨x, _, hy⟩ => hy ▸ x.2
+theorem coe_sInf (s : Set ℝ≥0) : (↑(sInf s) : ℝ) = sInf (((↑) : ℝ≥0 → ℝ) '' s) := by
+  rcases Set.eq_empty_or_nonempty s with rfl|hs
+  · simp only [Set.image_empty, Real.sInf_empty, NNReal.coe_eq_zero]
+    exact @subset_sInf_emptyset ℝ (Set.Ici (0 : ℝ)) _ _ (_)
+  have A : sInf (Subtype.val '' s) ∈ Set.Ici 0 := by
+    apply Real.sInf_nonneg
+    rintro - ⟨y, -, rfl⟩
+    exact y.2
+  exact (@subset_sInf_of_within ℝ (Set.Ici (0 : ℝ)) _ _ (_) s hs (OrderBot.bddBelow s) A).symm
 #align nnreal.coe_Inf NNReal.coe_sInf
 
 @[simp]

--- a/Mathlib/Order/CompleteLatticeIntervals.lean
+++ b/Mathlib/Order/CompleteLatticeIntervals.lean
@@ -30,9 +30,9 @@ variable {α : Type*} (s : Set α)
 
 section SupSet
 
-variable [Preorder α ][SupSet α]
+variable [Preorder α] [SupSet α]
 
-/-- `SupSet` structure on a nonempty subset `s` of an object with `SupSet`. This definition is
+/-- `SupSet` structure on a nonempty subset `s` of a preorder with `SupSet`. This definition is
 non-canonical (it uses `default s`); it should be used only as here, as an auxiliary instance in the
 construction of the `ConditionallyCompleteLinearOrder` structure. -/
 noncomputable def subsetSupSet [Inhabited s] : SupSet s where
@@ -72,7 +72,7 @@ section InfSet
 
 variable [Preorder α] [InfSet α]
 
-/-- `InfSet` structure on a nonempty subset `s` of an object with `InfSet`. This definition is
+/-- `InfSet` structure on a nonempty subset `s` of an preorder with `InfSet`. This definition is
 non-canonical (it uses `default s`); it should be used only as here, as an auxiliary instance in the
 construction of the `ConditionallyCompleteLinearOrder` structure. -/
 noncomputable def subsetInfSet [Inhabited s] : InfSet s where

--- a/Mathlib/Order/CompleteLatticeIntervals.lean
+++ b/Mathlib/Order/CompleteLatticeIntervals.lean
@@ -72,7 +72,7 @@ section InfSet
 
 variable [Preorder α] [InfSet α]
 
-/-- `InfSet` structure on a nonempty subset `s` of an preorder with `InfSet`. This definition is
+/-- `InfSet` structure on a nonempty subset `s` of a preorder with `InfSet`. This definition is
 non-canonical (it uses `default s`); it should be used only as here, as an auxiliary instance in the
 construction of the `ConditionallyCompleteLinearOrder` structure. -/
 noncomputable def subsetInfSet [Inhabited s] : InfSet s where

--- a/Mathlib/Order/CompleteLatticeIntervals.lean
+++ b/Mathlib/Order/CompleteLatticeIntervals.lean
@@ -30,15 +30,15 @@ variable {α : Type*} (s : Set α)
 
 section SupSet
 
-variable [SupSet α]
+variable [Preorder α ][SupSet α]
 
 /-- `SupSet` structure on a nonempty subset `s` of an object with `SupSet`. This definition is
 non-canonical (it uses `default s`); it should be used only as here, as an auxiliary instance in the
 construction of the `ConditionallyCompleteLinearOrder` structure. -/
 noncomputable def subsetSupSet [Inhabited s] : SupSet s where
   sSup t :=
-    if ht : sSup ((↑) '' t : Set α) ∈ s
-    then ⟨sSup ((↑) '' t : Set α), ht⟩
+    if ht : t.Nonempty ∧ BddAbove t ∧ sSup ((↑) '' t : Set α) ∈ s
+    then ⟨sSup ((↑) '' t : Set α), ht.2.2⟩
     else default
 #align subset_has_Sup subsetSupSet
 
@@ -47,29 +47,38 @@ attribute [local instance] subsetSupSet
 @[simp]
 theorem subset_sSup_def [Inhabited s] :
     @sSup s _ = fun t =>
-      if ht : sSup ((↑) '' t : Set α) ∈ s
-      then ⟨sSup ((↑) '' t : Set α), ht⟩
+      if ht : t.Nonempty ∧ BddAbove t ∧ sSup ((↑) '' t : Set α) ∈ s
+      then ⟨sSup ((↑) '' t : Set α), ht.2.2⟩
       else default :=
   rfl
 #align subset_Sup_def subset_sSup_def
 
-theorem subset_sSup_of_within [Inhabited s] {t : Set s} (h : sSup ((↑) '' t : Set α) ∈ s) :
-    sSup ((↑) '' t : Set α) = (@sSup s _ t : α) := by simp [dif_pos h]
+theorem subset_sSup_of_within [Inhabited s] {t : Set s}
+    (h' : t.Nonempty) (h'' : BddAbove t)  (h : sSup ((↑) '' t : Set α) ∈ s) :
+    sSup ((↑) '' t : Set α) = (@sSup s _ t : α) := by simp [dif_pos, h, h', h'']
 #align subset_Sup_of_within subset_sSup_of_within
+
+theorem subset_sSup_emptyset [Inhabited s] :
+    sSup (∅ : Set s) = default := by
+  simp [sSup]
+
+theorem subset_sSup_of_not_bddAbove [Inhabited s] {t : Set s} (ht : ¬BddAbove t) :
+    sSup t = default := by
+  simp [sSup, ht]
 
 end SupSet
 
 section InfSet
 
-variable [InfSet α]
+variable [Preorder α] [InfSet α]
 
 /-- `InfSet` structure on a nonempty subset `s` of an object with `InfSet`. This definition is
 non-canonical (it uses `default s`); it should be used only as here, as an auxiliary instance in the
 construction of the `ConditionallyCompleteLinearOrder` structure. -/
 noncomputable def subsetInfSet [Inhabited s] : InfSet s where
   sInf t :=
-    if ht : sInf ((↑) '' t : Set α) ∈ s
-    then ⟨sInf ((↑) '' t : Set α), ht⟩
+    if ht : t.Nonempty ∧ BddBelow t ∧ sInf ((↑) '' t : Set α) ∈ s
+    then ⟨sInf ((↑) '' t : Set α), ht.2.2⟩
     else default
 #align subset_has_Inf subsetInfSet
 
@@ -78,15 +87,24 @@ attribute [local instance] subsetInfSet
 @[simp]
 theorem subset_sInf_def [Inhabited s] :
     @sInf s _ = fun t =>
-      if ht : sInf ((↑) '' t : Set α) ∈ s
-      then ⟨sInf ((↑) '' t : Set α), ht⟩ else
+      if ht : t.Nonempty ∧ BddBelow t ∧ sInf ((↑) '' t : Set α) ∈ s
+      then ⟨sInf ((↑) '' t : Set α), ht.2.2⟩ else
       default :=
   rfl
 #align subset_Inf_def subset_sInf_def
 
-theorem subset_sInf_of_within [Inhabited s] {t : Set s} (h : sInf ((↑) '' t : Set α) ∈ s) :
-    sInf ((↑) '' t : Set α) = (@sInf s _ t : α) := by simp [dif_pos h]
+theorem subset_sInf_of_within [Inhabited s] {t : Set s}
+    (h' : t.Nonempty) (h'' : BddBelow t) (h : sInf ((↑) '' t : Set α) ∈ s) :
+    sInf ((↑) '' t : Set α) = (@sInf s _ t : α) := by simp [dif_pos, h, h', h'']
 #align subset_Inf_of_within subset_sInf_of_within
+
+theorem subset_sInf_emptyset [Inhabited s] :
+    sInf (∅ : Set s) = default := by
+  simp [sInf]
+
+theorem subset_sInf_of_not_bddBelow [Inhabited s] {t : Set s} (ht : ¬BddBelow t) :
+    sInf t = default := by
+  simp [sInf, ht]
 
 end InfSet
 
@@ -95,40 +113,6 @@ variable [ConditionallyCompleteLinearOrder α]
 attribute [local instance] subsetSupSet
 
 attribute [local instance] subsetInfSet
-
-lemma sSup_subtype_eq_sSup_univ_of_not_bddAbove {s : Set α} [Inhabited s]
-    (t : Set s) (ht : ¬BddAbove t) : sSup t = sSup univ := by
-  have A : ∀ (u : Set s), ¬BddAbove u → BddAbove (Subtype.val '' u) →
-      sSup ((↑) '' u : Set α) ∉ s := by
-    intro u hu Hu
-    contrapose! hu
-    refine ⟨⟨_, hu⟩, ?_⟩
-    rintro ⟨x, xs⟩ hx
-    simp only [Subtype.mk_le_mk]
-    apply le_csSup Hu
-    exact ⟨⟨x, xs⟩, hx, rfl⟩
-  by_cases Ht : BddAbove ((↑) '' t : Set α)
-  · have I1 : sSup ((↑) '' t : Set α) ∉ s := A t ht Ht
-    have I2 : sSup ((↑) '' (univ : Set s) : Set α) ∉ s := by
-      apply A
-      · contrapose! ht; exact ht.mono (subset_univ _)
-      · refine ⟨sSup ((↑) '' t : Set α), ?_⟩
-        rintro - ⟨⟨x, hx⟩, -, rfl⟩
-        simp [BddAbove, not_nonempty_iff_eq_empty] at ht
-        have : ⟨x, hx⟩ ∉ upperBounds t := by simp [ht]
-        obtain ⟨⟨y, ys⟩, yt, hy⟩ : ∃ y, y ∈ t ∧ { val := x, property := hx } < y :=
-          by simpa only [Subtype.mk_le_mk, not_forall, not_le, exists_prop, exists_and_right,
-            mem_upperBounds]
-        refine le_trans (le_of_lt hy) ?_
-        exact le_csSup Ht ⟨⟨y, ys⟩, yt, rfl⟩
-    simp only [sSup, I1, I2, dite_false]
-  · have I : ¬BddAbove ((↑) '' (univ : Set s) : Set α) := by
-      contrapose! Ht; exact Ht.mono (image_subset Subtype.val (subset_univ _))
-    have X : sSup ((↑) '' t : Set α) = sSup (univ : Set α) :=
-      ConditionallyCompleteLinearOrder.csSup_of_not_bddAbove _ Ht
-    have Y : sSup ((↑) '' (univ : Set s) : Set α) = sSup (univ : Set α) :=
-      ConditionallyCompleteLinearOrder.csSup_of_not_bddAbove _ I
-    simp only [sSup, X, Y]
 
 /-- For a nonempty subset of a conditionally complete linear order to be a conditionally complete
 linear order, it suffices that it contain the `sSup` of all its nonempty bounded-above subsets, and
@@ -139,28 +123,25 @@ noncomputable def subsetConditionallyCompleteLinearOrder [Inhabited s]
     (h_Sup : ∀ {t : Set s} (_ : t.Nonempty) (_h_bdd : BddAbove t), sSup ((↑) '' t : Set α) ∈ s)
     (h_Inf : ∀ {t : Set s} (_ : t.Nonempty) (_h_bdd : BddBelow t), sInf ((↑) '' t : Set α) ∈ s) :
     ConditionallyCompleteLinearOrder s :=
-  { -- The following would be a more natural way to finish, but gives a "deep recursion" error:
-      -- simpa [subset_Sup_of_within (h_Sup t)] using
-      --   (strict_mono_coe s).monotone.le_cSup_image hct h_bdd,
-    subsetSupSet s, subsetInfSet s, DistribLattice.toLattice, (inferInstance : LinearOrder s) with
+  { subsetSupSet s, subsetInfSet s, DistribLattice.toLattice, (inferInstance : LinearOrder s) with
     le_csSup := by
       rintro t c h_bdd hct
-      rw [← Subtype.coe_le_coe, ← subset_sSup_of_within s (h_Sup ⟨c, hct⟩ h_bdd)]
+      rw [← Subtype.coe_le_coe, ← subset_sSup_of_within s ⟨c, hct⟩ h_bdd (h_Sup ⟨c, hct⟩ h_bdd)]
       exact (Subtype.mono_coe _).le_csSup_image hct h_bdd
     csSup_le := by
       rintro t B ht hB
-      rw [← Subtype.coe_le_coe, ← subset_sSup_of_within s (h_Sup ht ⟨B, hB⟩)]
+      rw [← Subtype.coe_le_coe, ← subset_sSup_of_within s ht ⟨B, hB⟩ (h_Sup ht ⟨B, hB⟩)]
       exact (Subtype.mono_coe s).csSup_image_le ht hB
     le_csInf := by
       intro t B ht hB
-      rw [← Subtype.coe_le_coe, ← subset_sInf_of_within s (h_Inf ht ⟨B, hB⟩)]
+      rw [← Subtype.coe_le_coe, ← subset_sInf_of_within s ht ⟨B, hB⟩ (h_Inf ht ⟨B, hB⟩)]
       exact (Subtype.mono_coe s).le_csInf_image ht hB
     csInf_le := by
       rintro t c h_bdd hct
-      rw [← Subtype.coe_le_coe, ← subset_sInf_of_within s (h_Inf ⟨c, hct⟩ h_bdd)]
+      rw [← Subtype.coe_le_coe, ← subset_sInf_of_within s ⟨c, hct⟩ h_bdd (h_Inf ⟨c, hct⟩ h_bdd)]
       exact (Subtype.mono_coe s).csInf_image_le hct h_bdd
-    csSup_of_not_bddAbove := sSup_subtype_eq_sSup_univ_of_not_bddAbove
-    csInf_of_not_bddBelow := @sSup_subtype_eq_sSup_univ_of_not_bddAbove αᵒᵈ _ _ _ }
+    csSup_of_not_bddAbove := fun t ht ↦ by simp [ht]
+    csInf_of_not_bddBelow := fun t ht ↦ by simp [ht] }
 #align subset_conditionally_complete_linear_order subsetConditionallyCompleteLinearOrder
 
 section OrdConnected

--- a/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
+++ b/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
@@ -201,10 +201,10 @@ class ConditionallyCompleteLinearOrder (α : Type*) extends ConditionallyComplet
   /-- In a `ConditionallyCompleteLinearOrder`, we assume the order relations are all decidable. -/
   decidableLT : DecidableRel (· < · : α → α → Prop) :=
     @decidableLTOfDecidableLE _ _ decidableLE
-  /-- If a set is not bounded above, its supremum is by convention `Sup univ`. -/
-  csSup_of_not_bddAbove : ∀ s, ¬BddAbove s → sSup s = sSup (univ : Set α)
-  /-- If a set is not bounded below, its infimum is by convention `Inf univ`. -/
-  csInf_of_not_bddBelow : ∀ s, ¬BddBelow s → sInf s = sInf (univ : Set α)
+  /-- If a set is not bounded above, its supremum is by convention `Sup ∅`. -/
+  csSup_of_not_bddAbove : ∀ s, ¬BddAbove s → sSup s = sSup (∅ : Set α)
+  /-- If a set is not bounded below, its infimum is by convention `Inf ∅`. -/
+  csInf_of_not_bddBelow : ∀ s, ¬BddBelow s → sInf s = sInf (∅ : Set α)
 #align conditionally_complete_linear_order ConditionallyCompleteLinearOrder
 
 instance (α : Type*) [ConditionallyCompleteLinearOrder α] : LinearOrder α :=
@@ -295,11 +295,9 @@ noncomputable def IsWellOrder.conditionallyCompleteLinearOrderBot (α : Type*)
     csSup_empty := by simpa using eq_bot_iff.2 (not_lt.1 <| h.wf.not_lt_min _ _ <| mem_univ ⊥)
     csSup_of_not_bddAbove := by
       intro s H
-      have A : ¬(BddAbove (univ : Set α)) := by
-        contrapose! H; exact H.mono (subset_univ _)
       have B : ¬((upperBounds s).Nonempty) := H
-      have C : ¬((upperBounds (univ : Set α)).Nonempty) := A
-      simp [sSup, B, C]
+      simp only [B, dite_false, upperBounds_empty, univ_nonempty, dite_true]
+      exact le_antisymm bot_le (WellFounded.min_le _ (mem_univ _))
     csInf_of_not_bddBelow := fun s H ↦ (H (OrderBot.bddBelow s)).elim }
 #align is_well_order.conditionally_complete_linear_order_bot IsWellOrder.conditionallyCompleteLinearOrderBot
 
@@ -883,6 +881,40 @@ theorem ciInf_pos {p : Prop} {f : p → α} (hp : p) : ⨅ h : p, f h = f hp :=
   @ciSup_pos αᵒᵈ _ _ _ hp
 #align cinfi_pos ciInf_pos
 
+lemma ciSup_neg {p : Prop} {f : p → α} (hp : ¬ p) :
+    ⨆ (h : p), f h = sSup (∅ : Set α) := by
+  rw [iSup]
+  congr
+  rw [range_eq_empty_iff]
+  exact { false := hp }
+
+lemma ciInf_neg {p : Prop} {f : p → α} (hp : ¬ p) :
+    ⨅ (h : p), f h = sInf (∅ : Set α) :=
+  @ciSup_neg αᵒᵈ _ _ _ hp
+
+lemma ciSup_eq_ite {p : Prop} [Decidable p] {f : p → α} :
+    (⨆ h : p, f h) = if h : p then f h else sSup (∅ : Set α) := by
+  by_cases H : p <;> simp [ciSup_neg, H]
+
+lemma ciInf_eq_ite {p : Prop} [Decidable p] {f : p → α} :
+    (⨅ h : p, f h) = if h : p then f h else sInf (∅ : Set α) :=
+  ciSup_eq_ite (α := αᵒᵈ)
+
+theorem cbiSup_eq_of_forall {p : ι → Prop} {f : Subtype p → α} (hp : ∀ i, p i) :
+    ⨆ (i) (h : p i), f ⟨i, h⟩ = iSup f := by
+  simp only [hp, ciSup_unique]
+  simp only [iSup]
+  congr
+  apply Subset.antisymm
+  · rintro - ⟨i, rfl⟩
+    simp [hp i]
+  · rintro - ⟨i, rfl⟩
+    simp
+
+theorem cbiInf_eq_of_forall {p : ι → Prop} {f : Subtype p → α} (hp : ∀ i, p i) :
+    ⨅ (i) (h : p i), f ⟨i, h⟩ = iInf f :=
+  cbiSup_eq_of_forall (α := αᵒᵈ) hp
+
 /-- Introduction rule to prove that `b` is the supremum of `f`: it suffices to check that `b`
 is larger than `f i` for all `i`, and that this is not the case of any `w<b`.
 See `iSup_eq_of_forall_le_of_forall_lt_exists_gt` for a version in complete lattices. -/
@@ -928,6 +960,19 @@ theorem csSup_eq_of_is_forall_le_of_forall_le_imp_ge (hs : s.Nonempty) (h_is_ub 
     (h_b_le_ub : ∀ ub, (∀ a ∈ s, a ≤ ub) → b ≤ ub) : sSup s = b :=
   (csSup_le hs h_is_ub).antisymm ((h_b_le_ub _) fun _ => le_csSup ⟨b, h_is_ub⟩)
 #align cSup_eq_of_is_forall_le_of_forall_le_imp_ge csSup_eq_of_is_forall_le_of_forall_le_imp_ge
+
+lemma Set.Iic_ciInf [Nonempty ι] {f : ι → α} (hf : BddBelow (range f)) :
+    Iic (⨅ i, f i) = ⋂ i, Iic (f i) := by
+  apply Subset.antisymm
+  · rintro x hx - ⟨i, rfl⟩
+    exact hx.trans (ciInf_le hf _)
+  · rintro x hx
+    apply le_ciInf
+    simpa using hx
+
+lemma Set.Ici_ciSup [Nonempty ι] {f : ι → α} (hf : BddAbove (range f)) :
+    Ici (⨆ i, f i) = ⋂ i, Ici (f i) :=
+  Iic_ciInf (α := αᵒᵈ) hf
 
 end ConditionallyCompleteLattice
 
@@ -978,11 +1023,19 @@ theorem exists_lt_of_ciInf_lt [Nonempty ι] {f : ι → α} (h : iInf f < a) : �
   @exists_lt_of_lt_ciSup αᵒᵈ _ _ _ _ _ h
 #align exists_lt_of_cinfi_lt exists_lt_of_ciInf_lt
 
-theorem csSup_of_not_bddAbove {s : Set α} (hs : ¬BddAbove s) : sSup s = sSup univ :=
+theorem csSup_of_not_bddAbove {s : Set α} (hs : ¬BddAbove s) : sSup s = sSup ∅ :=
   ConditionallyCompleteLinearOrder.csSup_of_not_bddAbove s hs
 
-theorem csInf_of_not_bddBelow {s : Set α} (hs : ¬BddBelow s) : sInf s = sInf univ :=
+theorem csSup_eq_univ_of_not_bddAbove {s : Set α} (hs : ¬BddAbove s) : sSup s = sSup univ := by
+  rw [csSup_of_not_bddAbove hs, csSup_of_not_bddAbove (s := univ)]
+  contrapose! hs
+  exact hs.mono (subset_univ _)
+
+theorem csInf_of_not_bddBelow {s : Set α} (hs : ¬BddBelow s) : sInf s = sInf ∅ :=
   ConditionallyCompleteLinearOrder.csInf_of_not_bddBelow s hs
+
+theorem csInf_eq_univ_of_not_bddBelow {s : Set α} (hs : ¬BddBelow s) : sInf s = sInf univ :=
+  csSup_eq_univ_of_not_bddAbove (α := αᵒᵈ) hs
 
 /-- When every element of a set `s` is bounded by an element of a set `t`, and conversely, then
 `s` and `t` have the same supremum. This holds even when the sets may be empty or unbounded. -/
@@ -1023,6 +1076,61 @@ theorem csInf_eq_csInf_of_forall_exists_le {s t : Set α}
     (hs : ∀ x ∈ s, ∃ y ∈ t, y ≤ x) (ht : ∀ y ∈ t, ∃ x ∈ s, x ≤ y) :
     sInf s = sInf t :=
   @csSup_eq_csSup_of_forall_exists_le αᵒᵈ _ s t hs ht
+
+lemma sSup_iUnion_Iic (f : ι → α) : sSup (⋃ (i : ι), Iic (f i)) = ⨆ i, f i := by
+  apply csSup_eq_csSup_of_forall_exists_le
+  · rintro x ⟨-, ⟨i, rfl⟩, hi⟩
+    exact ⟨f i, mem_range_self _, hi⟩
+  · rintro x ⟨i, rfl⟩
+    exact ⟨f i, mem_iUnion_of_mem i le_rfl, le_rfl⟩
+
+lemma sInf_iUnion_Ici (f : ι → α) : sInf (⋃ (i : ι), Ici (f i)) = ⨅ i, f i :=
+  sSup_iUnion_Iic (α := αᵒᵈ) f
+
+theorem cbiSup_eq_of_not_forall {p : ι → Prop} {f : Subtype p → α} (hp : ¬ (∀ i, p i)) :
+    ⨆ (i) (h : p i), f ⟨i, h⟩ = iSup f ⊔ sSup ∅ := by
+  classical
+  rcases not_forall.1 hp with ⟨i₀, hi₀⟩
+  have : Nonempty ι := ⟨i₀⟩
+  simp only [ciSup_eq_ite]
+  by_cases H : BddAbove (range f)
+  · have B : BddAbove (range fun i ↦ if h : p i then f ⟨i, h⟩ else sSup ∅) := by
+      rcases H with ⟨c, hc⟩
+      refine ⟨c ⊔ sSup ∅, ?_⟩
+      rintro - ⟨i, rfl⟩
+      by_cases hi : p i
+      · simp only [hi, dite_true, ge_iff_le, le_sup_iff, hc (mem_range_self _), true_or]
+      · simp only [hi, dite_false, ge_iff_le, le_sup_right]
+    apply le_antisymm
+    · apply ciSup_le (fun i ↦ ?_)
+      by_cases hi : p i
+      · simp only [hi, dite_true, ge_iff_le, le_sup_iff]
+        left
+        exact le_ciSup H _
+      · simp [hi]
+    · apply sup_le
+      · rcases isEmpty_or_nonempty (Subtype p) with hp|hp
+        · simp [iSup_of_empty']
+          convert le_ciSup B i₀
+          simp [hi₀]
+        · apply ciSup_le
+          rintro ⟨i, hi⟩
+          convert le_ciSup B i
+          simp [hi]
+      · convert le_ciSup B i₀
+        simp [hi₀]
+  · have : iSup f = sSup (∅ : Set α) := csSup_of_not_bddAbove H
+    simp only [this, le_refl, sup_of_le_left]
+    apply csSup_of_not_bddAbove
+    contrapose! H
+    apply H.mono
+    rintro - ⟨i, rfl⟩
+    convert mem_range_self i.1
+    simp [i.2]
+
+theorem cbiInf_eq_of_not_forall {p : ι → Prop} {f : Subtype p → α} (hp : ¬ (∀ i, p i)) :
+    ⨅ (i) (h : p i), f ⟨i, h⟩ = iInf f ⊓ sInf ∅ :=
+  cbiSup_eq_of_not_forall (α := αᵒᵈ) hp
 
 open Function
 


### PR DESCRIPTION
We switch from `sSup univ` to `sSup ∅` for the supremum of unbounded sets in a conditionally complete linear order. These quantities already coincide for all concrete instances in mathlib. With the new convention one gets additionally the theorem
```lean
theorem cbiSup_eq_of_not_forall {p : ι → Prop} {f : Subtype p → α} (hp : ¬ (∀ i, p i)) :
    ⨆ (i) (h : p i), f ⟨i, h⟩ = iSup f ⊔ sSup ∅
```
which will be convenient for general measurability statements.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
