### PR TITLE
[Merged by Bors] - chore(test/*): quiet unusedVariables

### DIFF
--- a/test/LibrarySearch/IsCompact.lean
+++ b/test/LibrarySearch/IsCompact.lean
@@ -2,7 +2,6 @@ import Mathlib.Topology.Instances.Real
 import Mathlib.Topology.Algebra.Order.Compact
 import Mathlib.Tactic.LibrarySearch
 
-set_option linter.unusedVariables false in
-example (f : ℝ → ℝ) {K : Set ℝ} (hK : IsCompact K) : ∃ x ∈ K, ∀ y ∈ K, f x ≤ f y := by
+example (f : ℝ → ℝ) {K : Set ℝ} (_hK : IsCompact K) : ∃ x ∈ K, ∀ y ∈ K, f x ≤ f y := by
   fail_if_success exact?
   apply? -- Verify that this includes: `refine IsCompact.exists_forall_le hK ?_ ?_`

--- a/test/LibrarySearch/IsCompact.lean
+++ b/test/LibrarySearch/IsCompact.lean
@@ -2,6 +2,7 @@ import Mathlib.Topology.Instances.Real
 import Mathlib.Topology.Algebra.Order.Compact
 import Mathlib.Tactic.LibrarySearch
 
+set_option linter.unusedVariables false in
 example (f : ℝ → ℝ) {K : Set ℝ} (hK : IsCompact K) : ∃ x ∈ K, ∀ y ∈ K, f x ≤ f y := by
   fail_if_success exact?
   apply? -- Verify that this includes: `refine IsCompact.exists_forall_le hK ?_ ?_`

--- a/test/LibrarySearch/IsCompact.lean
+++ b/test/LibrarySearch/IsCompact.lean
@@ -4,4 +4,4 @@ import Mathlib.Tactic.LibrarySearch
 
 example (f : ℝ → ℝ) {K : Set ℝ} (_hK : IsCompact K) : ∃ x ∈ K, ∀ y ∈ K, f x ≤ f y := by
   fail_if_success exact?
-  apply? -- Verify that this includes: `refine IsCompact.exists_forall_le hK ?_ ?_`
+  apply? -- Verify that this includes: `refine IsCompact.exists_forall_le _hK ?_ ?_`

--- a/test/Set.lean
+++ b/test/Set.lean
@@ -34,6 +34,7 @@ example (x : Nat) (h : x - x = 0) : x = x := by
   set! p : x - x = 0 := h with _eq2
   rfl
 
+set_option linter.unusedVariables false in
 example : True := by
   set g : Nat → Int := (fun ε => ε) with h
   trivial
@@ -46,6 +47,7 @@ elab "test" : term => do
 
 -- this will timeout if test is elaborated multiple times
 set_option maxHeartbeats 3000 in
+set_option linter.unusedVariables false in
 example {a b c d e f g h : Nat} : 1 = 1 := by
   set a : Nat := test with h
   trivial

--- a/test/Set.lean
+++ b/test/Set.lean
@@ -34,9 +34,8 @@ example (x : Nat) (h : x - x = 0) : x = x := by
   set! p : x - x = 0 := h with _eq2
   rfl
 
-set_option linter.unusedVariables false in
 example : True := by
-  set g : Nat → Int := (fun ε => ε) with h
+  set g : Nat → Int := (fun ε => ε) with _h
   trivial
 
 -- simulate a slow to elaborate term
@@ -47,7 +46,6 @@ elab "test" : term => do
 
 -- this will timeout if test is elaborated multiple times
 set_option maxHeartbeats 3000 in
-set_option linter.unusedVariables false in
 example {a b c d e f g h : Nat} : 1 = 1 := by
-  set a : Nat := test with h
+  set a : Nat := test with _h
   trivial

--- a/test/Set.lean
+++ b/test/Set.lean
@@ -46,6 +46,6 @@ elab "test" : term => do
 
 -- this will timeout if test is elaborated multiple times
 set_option maxHeartbeats 3000 in
-example {a b c d e f g h : Nat} : 1 = 1 := by
+example {_a _b _c _d _e _f _g _h : Nat} : 1 = 1 := by
   set a : Nat := test with _h
   trivial

--- a/test/congrm.lean
+++ b/test/congrm.lean
@@ -23,8 +23,7 @@ example {a b c d : ℕ} :
     guard_target = c + a.pred = c + d.pred
     sorry
 
-set_option linter.unusedVariables false in
-example {a b : ℕ} (h : a = b) : (fun y : ℕ => ∀ z, a + a = z) = (fun x => ∀ z, b + a = z) := by
+example {a b : ℕ} (h : a = b) : (fun y : ℕ => ∀ z, a + a = z) = (fun _x => ∀ z, b + a = z) := by
   congrm fun x => ∀ w, ?_ + a = w
   guard_hyp x : ℕ
   guard_hyp w : ℕ

--- a/test/congrm.lean
+++ b/test/congrm.lean
@@ -23,6 +23,7 @@ example {a b c d : ℕ} :
     guard_target = c + a.pred = c + d.pred
     sorry
 
+set_option linter.unusedVariables false in
 example {a b : ℕ} (h : a = b) : (fun y : ℕ => ∀ z, a + a = z) = (fun x => ∀ z, b + a = z) := by
   congrm fun x => ∀ w, ?_ + a = w
   guard_hyp x : ℕ

--- a/test/interval_cases.lean
+++ b/test/interval_cases.lean
@@ -146,6 +146,7 @@ example (n : ℕ) : n % 2 = 0 ∨ n % 2 = 1 := by
                --^ hover says `hrv : r = 1` and jumps to `hrv :` above
 
 /- https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/interval_cases.20bug -/
+set_option linter.unusedVariables false in
 example {x : ℕ} (hx2 : x < 2) (h : False) : False := by
   have : x ≤ 1
   -- `interval_cases` deliberately not focussed,

--- a/test/interval_cases.lean
+++ b/test/interval_cases.lean
@@ -146,9 +146,8 @@ example (n : ℕ) : n % 2 = 0 ∨ n % 2 = 1 := by
                --^ hover says `hrv : r = 1` and jumps to `hrv :` above
 
 /- https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/interval_cases.20bug -/
-set_option linter.unusedVariables false in
 example {x : ℕ} (hx2 : x < 2) (h : False) : False := by
-  have : x ≤ 1
+  have _this : x ≤ 1
   -- `interval_cases` deliberately not focussed,
   -- this is testing that the `interval_cases` only acts on `have` side goal, not on both
   interval_cases x

--- a/test/slim_check.lean
+++ b/test/slim_check.lean
@@ -92,6 +92,7 @@ issue: 1 < 0 does not hold
 --   admit
 --   trivial
 
+set_option linter.unusedVariables false in
 example : true := by
   have : ∀ x ∈ [1,2,3], x < 4
   slim_check (config := { randomSeed := some 257, quiet := true })
@@ -99,6 +100,7 @@ example : true := by
   trivial
 
 -- Making sure that the context is used
+set_option linter.unusedVariables false in
 example : true := by
   have : ∀ n : ℕ, n = n
   · intro n

--- a/test/slim_check.lean
+++ b/test/slim_check.lean
@@ -92,17 +92,15 @@ issue: 1 < 0 does not hold
 --   admit
 --   trivial
 
-set_option linter.unusedVariables false in
 example : true := by
-  have : ∀ x ∈ [1,2,3], x < 4
+  have _this : ∀ x ∈ [1,2,3], x < 4
   slim_check (config := { randomSeed := some 257, quiet := true })
     -- success
   trivial
 
 -- Making sure that the context is used
-set_option linter.unusedVariables false in
 example : true := by
-  have : ∀ n : ℕ, n = n
+  have _this : ∀ n : ℕ, n = n
   · intro n
     cases n
     · slim_check (config := { randomSeed := some 257, quiet := true })


### PR DESCRIPTION
~~Quiets the `unused_variables` linter in the appropriate tests.~~
(Introduces and) prefixes unused variables with `_` in test files.

Affected files:
```
test/congrm.lean
test/interval_cases.lean
test/LibrarySearch/IsCompact.lean
test/Set.lean
test/slim_check.lean
```

[Zulip discussion](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/noisy.20tests)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
