### PR TITLE
fix: bug in `change` and preparation for lean4#2435 bugfix

### DIFF
--- a/Mathlib/Tactic/Basic.lean
+++ b/Mathlib/Tactic/Basic.lean
@@ -117,7 +117,7 @@ def _root_.Lean.MVarId.changeLocalDecl' (mvarId : MVarId) (fvarId : FVarId) (typ
     | _ => throwTacticEx `changeLocalDecl mvarId "unexpected auxiliary target"
   return mvarId
 
-/-- Exactly like `Lean.Elab.Tactic.filterOldMVars`, but uses `List`s instead of `Array`s. Discards 
+/-- Exactly like `Lean.Elab.Tactic.filterOldMVars`, but uses `List`s instead of `Array`s. Discards
 all mvars that were created before `mvarCounterSaved` was recorded. -/
 private def filterOldMVarsList (mvarIds : List MVarId) (mvarCounterSaved : Nat)
     : MetaM (List MVarId) := do

--- a/Mathlib/Tactic/Basic.lean
+++ b/Mathlib/Tactic/Basic.lean
@@ -117,6 +117,13 @@ def _root_.Lean.MVarId.changeLocalDecl' (mvarId : MVarId) (fvarId : FVarId) (typ
     | _ => throwTacticEx `changeLocalDecl mvarId "unexpected auxiliary target"
   return mvarId
 
+/-- Exactly like `Lean.Elab.Tactic.filterOldMVars`, but uses `List`s instead of `Array`s. Discards 
+all mvars that were created before `mvarCounterSaved` was recorded. -/
+private def filterOldMVarsList (mvarIds : List MVarId) (mvarCounterSaved : Nat)
+    : MetaM (List MVarId) := do
+  let mctx ← getMCtx
+  return mvarIds.filter fun mvarId => (mctx.getDecl mvarId |>.index) >= mvarCounterSaved
+
 /-- `change` can be used to replace the main goal or its local
 variables with definitionally equal ones.
 


### PR DESCRIPTION
leanprover/lean4#2435 fixes a bug in `elabTermWithHoles` (used in `refine`) wherein pre-existing natural mvars were being erroneously discarded by `refine` (and thus could be erroneously closed). However, `change` was taking advantage of this broken feature to discard an intermediate, temporary natural mvar used in its implemention. Once lean4#2435 landed, `change` broke mathlib by introducing this intermediate mvar as a spurious unsovled goal.

This PR both prepares `change` for lean4#2435 and identifies and fixes a minor bug in `change` arising from the same part of the implementation, wherein `change` would duplicate metavariables appearing in the type in the infoview. (This is a cosmetic bug only; the same `mvarId` is shown twice.) For example,
```
example : True := by
  have h2 : Nat.succ 0 = ?a := sorry
  change 1 = ?a at h2 -- yields 2 case `a`'s in the infoview
```

---

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
