### PR TITLE
[Merged by Bors] - fix: handling of newlines in CI comments to Lean4

### DIFF
--- a/scripts/lean-pr-testing-comments.sh
+++ b/scripts/lean-pr-testing-comments.sh
@@ -73,13 +73,13 @@ if [[ "$branch_name" =~ ^lean-pr-testing-([0-9]+)$ ]]; then
   branch="[lean-pr-testing-$pr_number](https://github.com/leanprover-community/mathlib4/compare/master...lean-pr-testing-$pr_number)"
   # Depending on the success/failure, set the appropriate message
   if [ "$LINT_OUTCOME" == "success" ]; then
-    message="✅ Mathlib branch $branch has successfully built against this PR. ($current_time)"
+    message="- ✅ Mathlib branch $branch has successfully built against this PR. ($current_time)"
   elif [ "$TEST_OUTCOME" == "success" ]; then
-    message="❌ Mathlib branch $branch built against this PR, but linting failed. ($current_time) [View Log]($WORKFLOW_URL)"
+    message="- ❌ Mathlib branch $branch built against this PR, but linting failed. ($current_time) [View Log]($WORKFLOW_URL)"
   elif [ "$BUILD_OUTCOME" == "success" ]; then
-    message="❌ Mathlib branch $branch built against this PR, but testing failed. ($current_time) [View Log]($WORKFLOW_URL)"
+    message="- ❌ Mathlib branch $branch built against this PR, but testing failed. ($current_time) [View Log]($WORKFLOW_URL)"
   else
-    message="💥 Mathlib branch $branch failed against this PR. ($current_time) [View Log]($WORKFLOW_URL)"
+    message="- 💥 Mathlib branch $branch failed against this PR. ($current_time) [View Log]($WORKFLOW_URL)"
   fi
 
   echo "$message"
@@ -92,7 +92,7 @@ if [[ "$branch_name" =~ ^lean-pr-testing-([0-9]+)$ ]]; then
       -X POST \
       -H "Authorization: token $TOKEN" \
       -H "Accept: application/vnd.github.v3+json" \
-      -d "$(jq --null-input --arg val "- $message" '{"body": $val}')" \
+      -d "$(jq --null-input --arg val "$message" '{"body": $val}')" \
       "https://api.github.com/repos/leanprover/lean4/issues/$pr_number/comments"
   else
     # Append new result to the existing comment
@@ -101,7 +101,7 @@ if [[ "$branch_name" =~ ^lean-pr-testing-([0-9]+)$ ]]; then
       -X PATCH \
       -H "Authorization: token $TOKEN" \
       -H "Accept: application/vnd.github.v3+json" \
-      -d "$(jq --null-input --arg existing "$existing_comment_body" --arg message "$message" '{"body":($existing + "\n- " + $message)}')" \
+      -d "$(jq --null-input --arg existing "$existing_comment_body" --arg message "$message" '{"body":($existing + "\n" + $message)}')" \
       "https://api.github.com/repos/leanprover/lean4/issues/comments/$existing_comment_id"
   fi
 fi

--- a/scripts/lean-pr-testing-comments.sh
+++ b/scripts/lean-pr-testing-comments.sh
@@ -97,12 +97,11 @@ if [[ "$branch_name" =~ ^lean-pr-testing-([0-9]+)$ ]]; then
   else
     # Append new result to the existing comment
     echo "Appending to existing comment at leanprover/lean4/issues/$pr_number/comments"
-    updated_comment_body="$existing_comment_body\n- $message"
     curl -L -s \
       -X PATCH \
       -H "Authorization: token $TOKEN" \
       -H "Accept: application/vnd.github.v3+json" \
-      -d "$(jq --null-input --arg val "- $updated_comment_body" '{"body": $val}')" \
+      -d "$(jq --null-input --arg existing "$existing_comment_body" --arg message "$message" '{"body":($existing + "\n- " + $message)}')" \
       "https://api.github.com/repos/leanprover/lean4/issues/comments/$existing_comment_id"
   fi
 fi


### PR DESCRIPTION
I didn't get escaping right the [first time](https://github.com/leanprover-community/mathlib4/pull/6866#discussion_r1311279563).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
