### PR TITLE
[Merged by Bors] - feat(Algebra/Category/ModuleCat): composition of restriction of scalar functors

### DIFF
--- a/Mathlib/Algebra/Category/ModuleCat/ChangeOfRings.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/ChangeOfRings.lean
@@ -43,7 +43,7 @@ set_option linter.uppercaseLean3 false -- Porting note: Module
 
 namespace CategoryTheory.ModuleCat
 
-universe v u₁ u₂
+universe v u₁ u₂ u₃
 
 namespace RestrictScalars
 
@@ -124,6 +124,83 @@ instance (priority := 100) sMulCommClass_mk {R : Type u₁} {S : Type u₂} [Rin
   @SMulCommClass.mk R S M (_) _
    <| fun r s m => (by simp [← mul_smul, mul_comm] : f r • s • m = s • f r • m)
 #align category_theory.Module.smul_comm_class_mk CategoryTheory.ModuleCat.sMulCommClass_mk
+
+/-- Semilinear maps `M →ₛₗ[f] N` identify to
+morphisms `M ⟶ (ModuleCat.restrictScalars f).obj N`. -/
+@[simps]
+def semilinearMapAddEquiv {R : Type u₁} {S : Type u₂} [Ring R] [Ring S] (f : R →+* S)
+    (M : ModuleCat.{v} R) (N : ModuleCat.{v} S) :
+    (M →ₛₗ[f] N) ≃+ (M ⟶ (ModuleCat.restrictScalars f).obj N) where
+  toFun g :=
+    { toFun := g
+      map_add' := by simp
+      map_smul' := by simp }
+  invFun g :=
+    { toFun := g
+      map_add' := by simp
+      map_smul' := g.map_smul }
+  left_inv g := rfl
+  right_inv g := rfl
+  map_add' g₁ g₂ := rfl
+
+section
+
+variable {R : Type u₁} [Ring R] (f : R →+* R) (hf : f = RingHom.id R)
+
+/-- The restriction of scalars by a ring morphism that is the identity identify to the
+identity functor. -/
+def restrictScalarsId' : ModuleCat.restrictScalars.{v} f ≅ 𝟭 _ := by subst hf; rfl
+
+@[simp]
+lemma restrictScalarsId'_inv_apply (M : ModuleCat R) (x : M) :
+    (restrictScalarsId' f hf).inv.app M x = x := by
+  subst hf
+  rfl
+
+@[simp]
+lemma restrictScalarsId'_hom_apply (M : ModuleCat R) (x : M) :
+    (restrictScalarsId' f hf).hom.app M x = x := by
+  subst hf
+  rfl
+
+variable (R)
+
+/-- The restriction of scalars by the identity morphisms identify to the
+identity functor. -/
+abbrev restrictScalarsId := restrictScalarsId'.{v} (RingHom.id R) rfl
+
+end
+
+section
+
+variable {R₁ : Type u₁} {R₂ : Type u₂} {R₃ : Type u₃} [Ring R₁] [Ring R₂] [Ring R₃]
+  (f : R₁ →+* R₂) (g : R₂ →+* R₃) (gf : R₁ →+* R₃) (hgf : gf = g.comp f)
+
+/-- The restriction of scalars by a composition of ring morphisms identify to the
+composition of the restriction of scalars functors. -/
+def restrictScalarsComp' :
+    ModuleCat.restrictScalars.{v} gf ≅
+      ModuleCat.restrictScalars g ⋙ ModuleCat.restrictScalars f := by
+  subst hgf
+  rfl
+
+@[simp]
+lemma restrictScalarsComp'_hom_apply (M : ModuleCat R₃) (x : M) :
+    (restrictScalarsComp' f g gf hgf).hom.app M x = x := by
+  subst hgf
+  rfl
+
+@[simp]
+lemma restrictScalarsComp'_inv_apply (M : ModuleCat R₃) (x : M) :
+    (restrictScalarsComp' f g gf hgf).inv.app M x = x := by
+  subst hgf
+  rfl
+
+/-- The restriction of scalars by a composition of ring morphisms identify to the
+composition of the restriction of scalars functors. -/
+abbrev restrictScalarsComp := restrictScalarsComp'.{v} f g _ rfl
+
+end
 
 open TensorProduct
 

--- a/Mathlib/Algebra/Category/ModuleCat/ChangeOfRings.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/ChangeOfRings.lean
@@ -13,24 +13,24 @@ import Mathlib.RingTheory.TensorProduct
 
 ## Main definitions
 
-* `CategoryTheory.ModuleCat.restrictScalars`: given rings `R, S` and a ring homomorphism `R ⟶ S`,
+* `ModuleCat.restrictScalars`: given rings `R, S` and a ring homomorphism `R ⟶ S`,
   then `restrictScalars : Module S ⥤ Module R` is defined by `M ↦ M` where `M : S-module` is seen
   as `R-module` by `r • m := f r • m` and `S`-linear map `l : M ⟶ M'` is `R`-linear as well.
 
-* `CategoryTheory.ModuleCat.extendScalars`: given **commutative** rings `R, S` and ring homomorphism
+* `ModuleCat.extendScalars`: given **commutative** rings `R, S` and ring homomorphism
   `f : R ⟶ S`, then `extendScalars : Module R ⥤ Module S` is defined by `M ↦ S ⨂ M` where the
   module structure is defined by `s • (s' ⊗ m) := (s * s') ⊗ m` and `R`-linear map `l : M ⟶ M'`
   is sent to `S`-linear map `s ⊗ m ↦ s ⊗ l m : S ⨂ M ⟶ S ⨂ M'`.
 
-* `CategoryTheory.ModuleCat.coextendScalars`: given rings `R, S` and a ring homomorphism `R ⟶ S`
+* `ModuleCat.coextendScalars`: given rings `R, S` and a ring homomorphism `R ⟶ S`
   then `coextendScalars : Module R ⥤ Module S` is defined by `M ↦ (S →ₗ[R] M)` where `S` is seen as
   `R-module` by restriction of scalars and `l ↦ l ∘ _`.
 
 ## Main results
 
-* `CategoryTheory.ModuleCat.extendRestrictScalarsAdj`: given commutative rings `R, S` and a ring
+* `ModuleCat.extendRestrictScalarsAdj`: given commutative rings `R, S` and a ring
   homomorphism `f : R →+* S`, the extension and restriction of scalars by `f` are adjoint functors.
-* `CategoryTheory.ModuleCat.restrictCoextendScalarsAdj`: given rings `R, S` and a ring homomorphism
+* `ModuleCat.restrictCoextendScalarsAdj`: given rings `R, S` and a ring homomorphism
   `f : R ⟶ S` then `coextendScalars f` is the right adjoint of `restrictScalars f`.
 
 ## List of notations
@@ -41,7 +41,9 @@ Let `R, S` be rings and `f : R →+* S`
 
 set_option linter.uppercaseLean3 false -- Porting note: Module
 
-namespace CategoryTheory.ModuleCat
+open CategoryTheory
+
+namespace ModuleCat
 
 universe v u₁ u₂ u₃
 
@@ -56,14 +58,14 @@ variable (M : ModuleCat.{v} S)
 def obj' : ModuleCat R where
   carrier := M
   isModule := Module.compHom M f
-#align category_theory.Module.restrict_scalars.obj' CategoryTheory.ModuleCat.RestrictScalars.obj'
+#align category_theory.Module.restrict_scalars.obj' ModuleCat.RestrictScalars.obj'
 
 /-- Given an `S`-linear map `g : M → M'` between `S`-modules, `g` is also `R`-linear between `M` and
 `M'` by means of restriction of scalars.
 -/
 def map' {M M' : ModuleCat.{v} S} (g : M ⟶ M') : obj' f M ⟶ obj' f M' :=
   { g with map_smul' := fun r => g.map_smul (f r) }
-#align category_theory.Module.restrict_scalars.map' CategoryTheory.ModuleCat.RestrictScalars.map'
+#align category_theory.Module.restrict_scalars.map' ModuleCat.RestrictScalars.map'
 
 end RestrictScalars
 
@@ -77,7 +79,7 @@ def restrictScalars {R : Type u₁} {S : Type u₂} [Ring R] [Ring S] (f : R →
   map := RestrictScalars.map' f
   map_id _ := LinearMap.ext fun _ => rfl
   map_comp _ _ := LinearMap.ext fun _ => rfl
-#align category_theory.Module.restrict_scalars CategoryTheory.ModuleCat.restrictScalars
+#align category_theory.Module.restrict_scalars ModuleCat.restrictScalars
 
 instance {R : Type u₁} {S : Type u₂} [CommRing R] [CommRing S] (f : R →+* S) :
     CategoryTheory.Faithful (restrictScalars.{v} f) where
@@ -98,13 +100,13 @@ instance {R : Type u₁} {S : Type u₂} [Ring R] [Ring S] {f : R →+* S}
 theorem restrictScalars.map_apply {R : Type u₁} {S : Type u₂} [Ring R] [Ring S] (f : R →+* S)
     {M M' : ModuleCat.{v} S} (g : M ⟶ M') (x) : (restrictScalars f).map g x = g x :=
   rfl
-#align category_theory.Module.restrict_scalars.map_apply CategoryTheory.ModuleCat.restrictScalars.map_apply
+#align category_theory.Module.restrict_scalars.map_apply ModuleCat.restrictScalars.map_apply
 
 @[simp]
 theorem restrictScalars.smul_def {R : Type u₁} {S : Type u₂} [Ring R] [Ring S] (f : R →+* S)
     {M : ModuleCat.{v} S} (r : R) (m : (restrictScalars f).obj M) : r • m = (f r • m : M) :=
   rfl
-#align category_theory.Module.restrict_scalars.smul_def CategoryTheory.ModuleCat.restrictScalars.smul_def
+#align category_theory.Module.restrict_scalars.smul_def ModuleCat.restrictScalars.smul_def
 
 theorem restrictScalars.smul_def' {R : Type u₁} {S : Type u₂} [Ring R] [Ring S] (f : R →+* S)
     {M : ModuleCat.{v} S} (r : R) (m : M) :
@@ -112,7 +114,7 @@ theorem restrictScalars.smul_def' {R : Type u₁} {S : Type u₂} [Ring R] [Ring
     let m' : (restrictScalars f).obj M := m
     (r • m' : (restrictScalars f).obj M) = (f r • m : M) :=
   rfl
-#align category_theory.Module.restrict_scalars.smul_def' CategoryTheory.ModuleCat.restrictScalars.smul_def'
+#align category_theory.Module.restrict_scalars.smul_def' ModuleCat.restrictScalars.smul_def'
 
 
 instance (priority := 100) sMulCommClass_mk {R : Type u₁} {S : Type u₂} [Ring R] [CommRing S]
@@ -123,7 +125,7 @@ instance (priority := 100) sMulCommClass_mk {R : Type u₁} {S : Type u₂} [Rin
   have : SMul R M := (RestrictScalars.obj' f (ModuleCat.mk M)).isModule.toSMul
   @SMulCommClass.mk R S M (_) _
    <| fun r s m => (by simp [← mul_smul, mul_comm] : f r • s • m = s • f r • m)
-#align category_theory.Module.smul_comm_class_mk CategoryTheory.ModuleCat.sMulCommClass_mk
+#align category_theory.Module.smul_comm_class_mk ModuleCat.sMulCommClass_mk
 
 /-- Semilinear maps `M →ₛₗ[f] N` identify to
 morphisms `M ⟶ (ModuleCat.restrictScalars f).obj N`. -/
@@ -206,7 +208,7 @@ open TensorProduct
 
 variable {R : Type u₁} {S : Type u₂} [CommRing R] [CommRing S] (f : R →+* S)
 
-section CategoryTheory.ModuleCat.Unbundled
+section ModuleCat.Unbundled
 
 variable (M : Type v) [AddCommMonoid M] [Module R M]
 
@@ -228,7 +230,7 @@ variable (M : ModuleCat.{v} R)
 -/
 def obj' : ModuleCat S :=
   ⟨TensorProduct R ((restrictScalars f).obj ⟨S⟩) M⟩
-#align category_theory.Module.extend_scalars.obj' CategoryTheory.ModuleCat.ExtendScalars.obj'
+#align category_theory.Module.extend_scalars.obj' ModuleCat.ExtendScalars.obj'
 
 /-- Extension of scalars is a functor where an `R`-module `M` is sent to `S ⊗ M` and
 `l : M1 ⟶ M2` is sent to `s ⊗ m ↦ s ⊗ l m`
@@ -236,7 +238,7 @@ def obj' : ModuleCat S :=
 def map' {M1 M2 : ModuleCat.{v} R} (l : M1 ⟶ M2) : obj' f M1 ⟶ obj' f M2 :=
   by-- The "by apply" part makes this require 75% fewer heartbeats to process (#16371).
   apply @LinearMap.baseChange R S M1 M2 _ _ ((algebraMap S _).comp f).toAlgebra _ _ _ _ l
-#align category_theory.Module.extend_scalars.map' CategoryTheory.ModuleCat.ExtendScalars.map'
+#align category_theory.Module.extend_scalars.map' ModuleCat.ExtendScalars.map'
 
 theorem map'_id {M : ModuleCat.{v} R} : map' f (𝟙 M) = 𝟙 _ :=
   LinearMap.ext fun x : obj' f M => by
@@ -248,7 +250,7 @@ theorem map'_id {M : ModuleCat.{v} R} : map' f (𝟙 M) = 𝟙 _ :=
     · -- Porting note: issues with synthesizing Algebra R S
       erw [@LinearMap.baseChange_tmul R S M M _ _ (_), ModuleCat.id_apply]
     · rw [map_add, ihx, ihy]
-#align category_theory.Module.extend_scalars.map'_id CategoryTheory.ModuleCat.ExtendScalars.map'_id
+#align category_theory.Module.extend_scalars.map'_id ModuleCat.ExtendScalars.map'_id
 
 theorem map'_comp {M₁ M₂ M₃ : ModuleCat.{v} R} (l₁₂ : M₁ ⟶ M₂) (l₂₃ : M₂ ⟶ M₃) :
     map' f (l₁₂ ≫ l₂₃) = map' f l₁₂ ≫ map' f l₂₃ :=
@@ -258,7 +260,7 @@ theorem map'_comp {M₁ M₂ M₃ : ModuleCat.{v} R} (l₁₂ : M₁ ⟶ M₂) (
     · rfl
     · rfl
     · rw [map_add, map_add, ihx, ihy] -- Porting note: simp again failing where rw succeeds
-#align category_theory.Module.extend_scalars.map'_comp CategoryTheory.ModuleCat.ExtendScalars.map'_comp
+#align category_theory.Module.extend_scalars.map'_comp ModuleCat.ExtendScalars.map'_comp
 
 end ExtendScalars
 
@@ -271,7 +273,7 @@ def extendScalars {R : Type u₁} {S : Type u₂} [CommRing R] [CommRing S] (f :
   map l := ExtendScalars.map' f l
   map_id _ := ExtendScalars.map'_id f
   map_comp := ExtendScalars.map'_comp f
-#align category_theory.Module.extend_scalars CategoryTheory.ModuleCat.extendScalars
+#align category_theory.Module.extend_scalars ModuleCat.extendScalars
 
 namespace ExtendScalars
 
@@ -283,13 +285,13 @@ variable {R : Type u₁} {S : Type u₂} [CommRing R] [CommRing S] (f : R →+* 
 protected theorem smul_tmul {M : ModuleCat.{v} R} (s s' : S) (m : M) :
     s • (s'⊗ₜ[R,f]m : (extendScalars f).obj M) = (s * s')⊗ₜ[R,f]m :=
   rfl
-#align category_theory.Module.extend_scalars.smul_tmul CategoryTheory.ModuleCat.ExtendScalars.smul_tmul
+#align category_theory.Module.extend_scalars.smul_tmul ModuleCat.ExtendScalars.smul_tmul
 
 @[simp]
 theorem map_tmul {M M' : ModuleCat.{v} R} (g : M ⟶ M') (s : S) (m : M) :
     (extendScalars f).map g (s⊗ₜ[R,f]m) = s⊗ₜ[R,f]g m :=
   rfl
-#align category_theory.Module.extend_scalars.map_tmul CategoryTheory.ModuleCat.ExtendScalars.map_tmul
+#align category_theory.Module.extend_scalars.map_tmul ModuleCat.ExtendScalars.map_tmul
 
 end ExtendScalars
 
@@ -318,25 +320,25 @@ instance hasSMul : SMul S <| (restrictScalars f).obj ⟨S⟩ →ₗ[R] M where
         dsimp
         rw [← LinearMap.map_smul]
         erw [smul_eq_mul, smul_eq_mul, mul_assoc] }
-#align category_theory.Module.coextend_scalars.has_smul CategoryTheory.ModuleCat.CoextendScalars.hasSMul
+#align category_theory.Module.coextend_scalars.has_smul ModuleCat.CoextendScalars.hasSMul
 
 @[simp]
 theorem smul_apply' (s : S) (g : (restrictScalars f).obj ⟨S⟩ →ₗ[R] M) (s' : S) :
     (s • g) s' = g (s' * s : S) :=
   rfl
-#align category_theory.Module.coextend_scalars.smul_apply' CategoryTheory.ModuleCat.CoextendScalars.smul_apply'
+#align category_theory.Module.coextend_scalars.smul_apply' ModuleCat.CoextendScalars.smul_apply'
 
 instance mulAction : MulAction S <| (restrictScalars f).obj ⟨S⟩ →ₗ[R] M :=
   { CoextendScalars.hasSMul f _ with
     one_smul := fun g => LinearMap.ext fun s : S => by simp
     mul_smul := fun (s t : S) g => LinearMap.ext fun x : S => by simp [mul_assoc] }
-#align category_theory.Module.coextend_scalars.mul_action CategoryTheory.ModuleCat.CoextendScalars.mulAction
+#align category_theory.Module.coextend_scalars.mul_action ModuleCat.CoextendScalars.mulAction
 
 instance distribMulAction : DistribMulAction S <| (restrictScalars f).obj ⟨S⟩ →ₗ[R] M :=
   { CoextendScalars.mulAction f _ with
     smul_add := fun s g h => LinearMap.ext fun t : S => by simp
     smul_zero := fun s => LinearMap.ext fun t : S => by simp }
-#align category_theory.Module.coextend_scalars.distrib_mul_action CategoryTheory.ModuleCat.CoextendScalars.distribMulAction
+#align category_theory.Module.coextend_scalars.distrib_mul_action ModuleCat.CoextendScalars.distribMulAction
 
 /-- `S` acts on Hom(S, M) by `s • g = x ↦ g (x • s)`, this action defines an `S`-module structure on
 Hom(S, M).
@@ -345,7 +347,7 @@ instance isModule : Module S <| (restrictScalars f).obj ⟨S⟩ →ₗ[R] M :=
   { CoextendScalars.distribMulAction f _ with
     add_smul := fun s1 s2 g => LinearMap.ext fun x : S => by simp [mul_add, LinearMap.map_add]
     zero_smul := fun g => LinearMap.ext fun x : S => by simp [LinearMap.map_zero] }
-#align category_theory.Module.coextend_scalars.is_module CategoryTheory.ModuleCat.CoextendScalars.isModule
+#align category_theory.Module.coextend_scalars.is_module ModuleCat.CoextendScalars.isModule
 
 end Unbundled
 
@@ -355,7 +357,7 @@ variable (M : ModuleCat.{v} R)
 scalar multiplication defined by `s • l := x ↦ l (x • s)`-/
 def obj' : ModuleCat S :=
   ⟨(restrictScalars f).obj ⟨S⟩ →ₗ[R] M⟩
-#align category_theory.Module.coextend_scalars.obj' CategoryTheory.ModuleCat.CoextendScalars.obj'
+#align category_theory.Module.coextend_scalars.obj' ModuleCat.CoextendScalars.obj'
 
 instance : CoeFun (obj' f M) fun _ => S → M where coe g := g.toFun
 
@@ -367,7 +369,7 @@ def map' {M M' : ModuleCat R} (g : M ⟶ M') : obj' f M ⟶ obj' f M' where
   map_add' _ _ := LinearMap.comp_add _ _ _
   map_smul' s h := LinearMap.ext fun t : S => by dsimp; rw [smul_apply',smul_apply']; simp
   -- Porting note: smul_apply' not working in simp
-#align category_theory.Module.coextend_scalars.map' CategoryTheory.ModuleCat.CoextendScalars.map'
+#align category_theory.Module.coextend_scalars.map' ModuleCat.CoextendScalars.map'
 
 end CoextendScalars
 
@@ -382,7 +384,7 @@ def coextendScalars {R : Type u₁} {S : Type u₂} [Ring R] [Ring S] (f : R →
   map := CoextendScalars.map' f
   map_id _ := LinearMap.ext fun _ => LinearMap.ext fun _ => rfl
   map_comp _ _ := LinearMap.ext fun _ => LinearMap.ext fun _ => rfl
-#align category_theory.Module.coextend_scalars CategoryTheory.ModuleCat.coextendScalars
+#align category_theory.Module.coextend_scalars ModuleCat.coextendScalars
 
 namespace CoextendScalars
 
@@ -395,13 +397,13 @@ instance (M : ModuleCat R) : CoeFun ((coextendScalars f).obj M) fun _ => S → M
 theorem smul_apply (M : ModuleCat R) (g : (coextendScalars f).obj M) (s s' : S) :
     (s • g) s' = g (s' * s) :=
   rfl
-#align category_theory.Module.coextend_scalars.smul_apply CategoryTheory.ModuleCat.CoextendScalars.smul_apply
+#align category_theory.Module.coextend_scalars.smul_apply ModuleCat.CoextendScalars.smul_apply
 
 @[simp]
 theorem map_apply {M M' : ModuleCat R} (g : M ⟶ M') (x) (s : S) :
     (coextendScalars f).map g x s = g (x s) :=
   rfl
-#align category_theory.Module.coextend_scalars.map_apply CategoryTheory.ModuleCat.CoextendScalars.map_apply
+#align category_theory.Module.coextend_scalars.map_apply ModuleCat.CoextendScalars.map_apply
 
 end CoextendScalars
 
@@ -435,11 +437,11 @@ def HomEquiv.fromRestriction {X : ModuleCat R} {Y : ModuleCat S}
       rw [smul_add, map_add]
   map_smul' := fun (s : S) (y : Y) => LinearMap.ext fun t : S => by
       -- Porting note: used to be simp [mul_smul]
-      rw [RingHom.id_apply, LinearMap.coe_mk, CategoryTheory.ModuleCat.CoextendScalars.smul_apply',
+      rw [RingHom.id_apply, LinearMap.coe_mk, ModuleCat.CoextendScalars.smul_apply',
         LinearMap.coe_mk]
       dsimp
       rw [mul_smul]
-#align category_theory.Module.restriction_coextension_adj.hom_equiv.from_restriction CategoryTheory.ModuleCat.RestrictionCoextensionAdj.HomEquiv.fromRestriction
+#align category_theory.Module.restriction_coextension_adj.hom_equiv.from_restriction ModuleCat.RestrictionCoextensionAdj.HomEquiv.fromRestriction
 
 /-- Given `R`-module X and `S`-module Y, any `g : Y ⟶ (coextendScalars f).obj X`
 corresponds to `(restrictScalars f).obj Y ⟶ X` by `y ↦ g y 1`
@@ -457,7 +459,7 @@ def HomEquiv.toRestriction {X Y} (g : Y ⟶ (coextendScalars f).obj X) : (restri
     rw [← LinearMap.coe_toAddHom, ←AddHom.toFun_eq_coe]
     rw [CoextendScalars.smul_apply (s := f r) (g := g y) (s' := 1), one_mul]
     rw [AddHom.toFun_eq_coe, LinearMap.coe_toAddHom]
-#align category_theory.Module.restriction_coextension_adj.hom_equiv.to_restriction CategoryTheory.ModuleCat.RestrictionCoextensionAdj.HomEquiv.toRestriction
+#align category_theory.Module.restriction_coextension_adj.hom_equiv.to_restriction ModuleCat.RestrictionCoextensionAdj.HomEquiv.toRestriction
 
 -- Porting note: add to address timeout in unit'
 def app' (Y : ModuleCat S) : Y →ₗ[S] (restrictScalars f ⋙ coextendScalars f).obj Y :=
@@ -498,7 +500,7 @@ protected def unit' : 𝟭 (ModuleCat S) ⟶ restrictScalars f ⋙ coextendScala
         restrictScalars.map_apply f]
       change s • (g y) = g (s • y)
       rw [map_smul]
-#align category_theory.Module.restriction_coextension_adj.unit' CategoryTheory.ModuleCat.RestrictionCoextensionAdj.unit'
+#align category_theory.Module.restriction_coextension_adj.unit' ModuleCat.RestrictionCoextensionAdj.unit'
 
 /-- The natural transformation from the composition of coextension and restriction of scalars to
 identity functor.
@@ -521,7 +523,7 @@ protected def counit' : coextendScalars f ⋙ restrictScalars f ⟶ 𝟭 (Module
   naturality X X' g := LinearMap.ext fun h => by
     rw [ModuleCat.coe_comp]
     rfl
-#align category_theory.Module.restriction_coextension_adj.counit' CategoryTheory.ModuleCat.RestrictionCoextensionAdj.counit'
+#align category_theory.Module.restriction_coextension_adj.counit' ModuleCat.RestrictionCoextensionAdj.counit'
 
 end RestrictionCoextensionAdj
 
@@ -553,7 +555,7 @@ def restrictCoextendScalarsAdj {R : Type u₁} {S : Type u₂} [Ring R] [Ring S]
     rw [coe_comp, Function.comp]
     change _ = (((restrictScalars f).map g) x).toFun (1 : S)
     rw [AddHom.toFun_eq_coe, LinearMap.coe_toAddHom, restrictScalars.map_apply]
-#align category_theory.Module.restrict_coextend_scalars_adj CategoryTheory.ModuleCat.restrictCoextendScalarsAdj
+#align category_theory.Module.restrict_coextend_scalars_adj ModuleCat.restrictCoextendScalarsAdj
 
 instance {R : Type u₁} {S : Type u₂} [Ring R] [Ring S] (f : R →+* S) :
     CategoryTheory.IsLeftAdjoint (restrictScalars f) :=
@@ -588,7 +590,7 @@ def HomEquiv.toRestrictScalars {X Y} (g : (extendScalars f).obj X ⟶ Y) :
     rw [RestrictScalars.smul_def, ← LinearMap.map_smul]
     erw [tmul_smul]
     congr
-#align category_theory.Module.extend_restrict_scalars_adj.hom_equiv.to_restrict_scalars CategoryTheory.ModuleCat.ExtendRestrictScalarsAdj.HomEquiv.toRestrictScalars
+#align category_theory.Module.extend_restrict_scalars_adj.hom_equiv.to_restrict_scalars ModuleCat.ExtendRestrictScalarsAdj.HomEquiv.toRestrictScalars
 
 -- Porting note: forced to break apart fromExtendScalars due to timeouts
 /--
@@ -637,7 +639,7 @@ def HomEquiv.fromExtendScalars {X Y} (g : X ⟶ (restrictScalars f).obj Y) :
       change (s * s') • (g x) = s • s' • (g x)
       rw [mul_smul]
     · rw [smul_add, map_add, ih1, ih2, map_add, smul_add]
-#align category_theory.Module.extend_restrict_scalars_adj.hom_equiv.from_extend_scalars CategoryTheory.ModuleCat.ExtendRestrictScalarsAdj.HomEquiv.fromExtendScalars
+#align category_theory.Module.extend_restrict_scalars_adj.hom_equiv.from_extend_scalars ModuleCat.ExtendRestrictScalarsAdj.HomEquiv.fromExtendScalars
 
 /-- Given `R`-module X and `S`-module Y, `S`-linear linear maps `(extendScalars f).obj X ⟶ Y`
 bijectively correspond to `R`-linear maps `X ⟶ (restrictScalars f).obj Y`.
@@ -665,7 +667,7 @@ def homEquiv {X Y} :
       LinearMap.coe_mk, LinearMap.coe_mk]
     dsimp
     rw [one_smul]
-#align category_theory.Module.extend_restrict_scalars_adj.hom_equiv CategoryTheory.ModuleCat.ExtendRestrictScalarsAdj.homEquiv
+#align category_theory.Module.extend_restrict_scalars_adj.hom_equiv ModuleCat.ExtendRestrictScalarsAdj.homEquiv
 
 /--
 For any `R`-module X, there is a natural `R`-linear map from `X` to `X ⨂ S` by sending `x ↦ x ⊗ 1`
@@ -678,7 +680,7 @@ def Unit.map {X} : X ⟶ (extendScalars f ⋙ restrictScalars f).obj X where
     letI m1 : Module R S := Module.compHom S f
     -- Porting note: used to be rfl
     dsimp; rw [←TensorProduct.smul_tmul,TensorProduct.smul_tmul']
-#align category_theory.Module.extend_restrict_scalars_adj.unit.map CategoryTheory.ModuleCat.ExtendRestrictScalarsAdj.Unit.map
+#align category_theory.Module.extend_restrict_scalars_adj.unit.map ModuleCat.ExtendRestrictScalarsAdj.Unit.map
 
 /--
 The natural transformation from identity functor on `R`-module to the composition of extension and
@@ -687,7 +689,7 @@ restriction of scalars.
 @[simps]
 def unit : 𝟭 (ModuleCat R) ⟶ extendScalars f ⋙ restrictScalars.{max v u₂,u₁,u₂} f where
   app _ := Unit.map.{u₁,u₂,v} f
-#align category_theory.Module.extend_restrict_scalars_adj.unit CategoryTheory.ModuleCat.ExtendRestrictScalarsAdj.unit
+#align category_theory.Module.extend_restrict_scalars_adj.unit ModuleCat.ExtendRestrictScalarsAdj.unit
 
 /-- For any `S`-module Y, there is a natural `R`-linear map from `S ⨂ Y` to `Y` by
 `s ⊗ y ↦ s • y`
@@ -724,7 +726,7 @@ def Counit.map {Y} : (restrictScalars f ⋙ extendScalars f).obj Y ⟶ Y := by
       change (s * s') • y = s • s' • y
       rw [mul_smul]
     · rw [smul_add, map_add, map_add, ih1, ih2, smul_add]
-#align category_theory.Module.extend_restrict_scalars_adj.counit.map CategoryTheory.ModuleCat.ExtendRestrictScalarsAdj.Counit.map
+#align category_theory.Module.extend_restrict_scalars_adj.counit.map ModuleCat.ExtendRestrictScalarsAdj.Counit.map
 
 -- Porting note: this file has to probably be reworked when
 -- coercions and instance synthesis are fixed for concrete categories
@@ -754,7 +756,7 @@ def counit : restrictScalars.{max v u₂,u₁,u₂} f ⋙ extendScalars f ⟶ �
       rw [map_smul]
     · rw [map_add,map_add]
       congr 1
-#align category_theory.Module.extend_restrict_scalars_adj.counit CategoryTheory.ModuleCat.ExtendRestrictScalarsAdj.counit
+#align category_theory.Module.extend_restrict_scalars_adj.counit ModuleCat.ExtendRestrictScalarsAdj.counit
 end ExtendRestrictScalarsAdj
 
 /-- Given commutative rings `R, S` and a ring hom `f : R →+* S`, the extension and restriction of
@@ -783,7 +785,7 @@ def extendRestrictScalarsAdj {R : Type u₁} {S : Type u₂} [CommRing R] [CommR
         rfl
       · rw [map_add,map_add]
         congr 1
-#align category_theory.Module.extend_restrict_scalars_adj CategoryTheory.ModuleCat.extendRestrictScalarsAdj
+#align category_theory.Module.extend_restrict_scalars_adj ModuleCat.extendRestrictScalarsAdj
 
 instance {R : Type u₁} {S : Type u₂} [CommRing R] [CommRing S] (f : R →+* S) :
     CategoryTheory.IsLeftAdjoint (extendScalars f) :=
@@ -793,4 +795,4 @@ instance {R : Type u₁} {S : Type u₂} [CommRing R] [CommRing S] (f : R →+* 
     CategoryTheory.IsRightAdjoint (restrictScalars f) :=
   ⟨_, extendRestrictScalarsAdj f⟩
 
-end CategoryTheory.ModuleCat
+end ModuleCat

--- a/Mathlib/Algebra/Category/ModuleCat/ChangeOfRings.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/ChangeOfRings.lean
@@ -462,6 +462,7 @@ def HomEquiv.toRestriction {X Y} (g : Y ⟶ (coextendScalars f).obj X) : (restri
 #align category_theory.Module.restriction_coextension_adj.hom_equiv.to_restriction ModuleCat.RestrictionCoextensionAdj.HomEquiv.toRestriction
 
 -- Porting note: add to address timeout in unit'
+/-- Auxiliary definition for `unit'` -/
 def app' (Y : ModuleCat S) : Y →ₗ[S] (restrictScalars f ⋙ coextendScalars f).obj Y :=
   { toFun := fun y : Y =>
       { toFun := fun s : S => (s • y : Y)

--- a/Mathlib/Algebra/Category/ModuleCat/ChangeOfRings.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/ChangeOfRings.lean
@@ -155,15 +155,11 @@ def restrictScalarsId' : ModuleCat.restrictScalars.{v} f ≅ 𝟭 _ := by subst 
 
 @[simp]
 lemma restrictScalarsId'_inv_apply (M : ModuleCat R) (x : M) :
-    (restrictScalarsId' f hf).inv.app M x = x := by
-  subst hf
-  rfl
+    (restrictScalarsId' f hf).inv.app M x = x := by subst hf; rfl
 
 @[simp]
 lemma restrictScalarsId'_hom_apply (M : ModuleCat R) (x : M) :
-    (restrictScalarsId' f hf).hom.app M x = x := by
-  subst hf
-  rfl
+    (restrictScalarsId' f hf).hom.app M x = x := by subst hf; rfl
 
 variable (R)
 
@@ -182,21 +178,14 @@ variable {R₁ : Type u₁} {R₂ : Type u₂} {R₃ : Type u₃} [Ring R₁] [R
 composition of the restriction of scalars functors. -/
 def restrictScalarsComp' :
     ModuleCat.restrictScalars.{v} gf ≅
-      ModuleCat.restrictScalars g ⋙ ModuleCat.restrictScalars f := by
-  subst hgf
-  rfl
-
+      ModuleCat.restrictScalars g ⋙ ModuleCat.restrictScalars f := by subst hgf; rfl
 @[simp]
 lemma restrictScalarsComp'_hom_apply (M : ModuleCat R₃) (x : M) :
-    (restrictScalarsComp' f g gf hgf).hom.app M x = x := by
-  subst hgf
-  rfl
+    (restrictScalarsComp' f g gf hgf).hom.app M x = x := by subst hgf; rfl
 
 @[simp]
 lemma restrictScalarsComp'_inv_apply (M : ModuleCat R₃) (x : M) :
-    (restrictScalarsComp' f g gf hgf).inv.app M x = x := by
-  subst hgf
-  rfl
+    (restrictScalarsComp' f g gf hgf).inv.app M x = x := by subst hgf; rfl
 
 /-- The restriction of scalars by a composition of ring morphisms identify to the
 composition of the restriction of scalars functors. -/


### PR DESCRIPTION
This PR studies the behaviour of restriction of scalars functors with respect to composition.

---
(This PR also relates semilinear maps and linear maps to a restriction of scalars. It also fixes a namespace problem: as `ModuleCat` is in the root namespace, there is no reason to introduce `CategoryTheory.ModuleCat` in the `ChangeOfRings` file. I hope the diff is still readable...)

In order to construct limits in the category of presheaves of modules over a presheaf of rings `R`, it is important to study the properties of the restriction of scalars functors, and how they behave with respect to composition (in more abstract terms, there is a prefibered category of modules over the (opposite) category of rings, and the restriction of scalars functors are the direct image functors, and we want to show it is a fibered category, i.e. direct image functors compose well).

Actually, the restriction of scalars functors behave very well, as the composition of two restriction of scalars functors is defeq to the restriction of scalars of the composition. However, if we try to apply this to the restriction of scalars for ring morphisms `R.map f`, then `R.map (f ≫ g) = R.map f ≫ R.map g` is no longer a defeq, which is the reason why I have introduced `restrictScalarsComp'` which takes as an input an equality `gf = g.comp f`.


<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
