### PR TITLE
[Merged by Bors] - fix: use token when CI merges to nightly-testing

### DIFF
--- a/.github/workflows/nightly_bump_toolchain.yml
+++ b/.github/workflows/nightly_bump_toolchain.yml
@@ -13,6 +13,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         ref: nightly-testing # checkout nightly-testing branch
+        token: ${{ secrets.NIGHTLY_TESTING }}
 
     - name: Get latest release tag from leanprover/lean4-nightly
       id: get-latest-release

--- a/.github/workflows/nightly_merge_master.yml
+++ b/.github/workflows/nightly_merge_master.yml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          token: ${{ secrets.NIGHTLY_TESTING }}
 
       - name: Configure Git User
         run: |


### PR DESCRIPTION
If we use the default tokens, then further workflows are not triggered by the pushes here.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
