### PR TITLE
[Merged by Bors] - fix: set `vsc` variable properly in debian install script

### DIFF
--- a/scripts/install_debian.sh
+++ b/scripts/install_debian.sh
@@ -12,7 +12,7 @@ rm elan-init.sh
 
 # The following test is needed in case VScode or VSCodium was installed by other
 # means (e.g. using Ubuntu snap)
-vsc="$(which code || which codium)"
+vsc="$(which code 2>/dev/null || which codium 2>/dev/null)"
 if [ -z "$vsc" ]; then
   wget -O code.deb https://go.microsoft.com/fwlink/?LinkID=760868
   sudo apt install -y ./code.deb


### PR DESCRIPTION
This simply redirects standard error to `/dev/null` in the `which` commands so that it doesn't set the `vsc` variable to garbage.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
