### PR TITLE
[Merged by Bors] - feat(Equicontinuity): equicontinuous family converges on a closed set

### DIFF
--- a/Mathlib/Topology/UniformSpace/Equicontinuity.lean
+++ b/Mathlib/Topology/UniformSpace/Equicontinuity.lean
@@ -533,6 +533,20 @@ theorem Filter.Tendsto.uniformContinuous_of_uniformEquicontinuous {l : Filter ι
     ⟨f, mem_closure_of_tendsto h₁ <| eventually_of_forall mem_range_self⟩
 #align filter.tendsto.uniform_continuous_of_uniform_equicontinuous Filter.Tendsto.uniformContinuous_of_uniformEquicontinuous
 
+/-- If `F : ι → X → α`` is an equicontinuous family of functions,
+`f : X → α` is a continuous function, and `l` is a filter on `ι`,
+then `{x | Filter.Tendsto (F · x) l (𝓝 (f x))}` is a closed set. -/
+theorem Equicontinuous.isClosed_setOf_tendsto {l : Filter ι} {F : ι → X → α} {f : X → α}
+    (hF : Equicontinuous F) (hf : Continuous f) :
+    IsClosed {x | Tendsto (F · x) l (𝓝 (f x))} := by
+  simp only [isClosed_iff_frequently, mem_setOf_eq,
+    (nhds_basis_uniformity (𝓤 α).basis_sets).tendsto_right_iff]
+  intro x hx U hU
+  rcases comp_comp_symm_mem_uniformity_sets hU with ⟨V, hV, hVs, hVU⟩
+  rcases (hx.and_eventually <| (hF x V hV).and (hf.continuousAt (ball_mem_nhds _ hV))).exists
+    with ⟨y, hy, hyV, hfV⟩
+  exact (hy V hV).mono fun i hi ↦ hVU ⟨_, ⟨_, hyV i, hi⟩, (mem_ball_symmetry hVs).2 hfV⟩
+
 end
 
 end


### PR DESCRIPTION
If `F : ι → X → α` is an equicontinuous family of functions
and `f : X → α` is a continuous function,
then `{x | Tendsto (F · x) l (𝓝 (f x))}` is a closed set.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)