### PR TITLE
[Merged by Bors] - chore: minimize imports in NormNum.Core

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3079,12 +3079,14 @@ import Mathlib.Tactic.NormCast.Tactic
 import Mathlib.Tactic.NormNum
 import Mathlib.Tactic.NormNum.Basic
 import Mathlib.Tactic.NormNum.BigOperators
+import Mathlib.Tactic.NormNum.CharZero
 import Mathlib.Tactic.NormNum.Core
 import Mathlib.Tactic.NormNum.GCD
 import Mathlib.Tactic.NormNum.IsCoprime
 import Mathlib.Tactic.NormNum.LegendreSymbol
 import Mathlib.Tactic.NormNum.NatFib
 import Mathlib.Tactic.NormNum.NatSqrt
+import Mathlib.Tactic.NormNum.OrderedRing
 import Mathlib.Tactic.NormNum.Prime
 import Mathlib.Tactic.NthRewrite
 import Mathlib.Tactic.Observe

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -96,12 +96,14 @@ import Mathlib.Tactic.NormCast.Tactic
 import Mathlib.Tactic.NormNum
 import Mathlib.Tactic.NormNum.Basic
 import Mathlib.Tactic.NormNum.BigOperators
+import Mathlib.Tactic.NormNum.CharZero
 import Mathlib.Tactic.NormNum.Core
 import Mathlib.Tactic.NormNum.GCD
 import Mathlib.Tactic.NormNum.IsCoprime
 import Mathlib.Tactic.NormNum.LegendreSymbol
 import Mathlib.Tactic.NormNum.NatFib
 import Mathlib.Tactic.NormNum.NatSqrt
+import Mathlib.Tactic.NormNum.OrderedRing
 import Mathlib.Tactic.NormNum.Prime
 import Mathlib.Tactic.NthRewrite
 import Mathlib.Tactic.Observe

--- a/Mathlib/Tactic/NormNum/Basic.lean
+++ b/Mathlib/Tactic/NormNum/Basic.lean
@@ -4,6 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Thomas Murrills
 -/
 import Mathlib.Tactic.NormNum.Core
+import Mathlib.Tactic.NormNum.CharZero
+import Mathlib.Tactic.NormNum.OrderedRing
+import Mathlib.Data.Rat.Cast
 import Mathlib.Tactic.HaveI
 import Mathlib.Algebra.GroupPower.Lemmas
 import Mathlib.Algebra.Order.Invertible

--- a/Mathlib/Tactic/NormNum/CharZero.lean
+++ b/Mathlib/Tactic/NormNum/CharZero.lean
@@ -1,0 +1,55 @@
+/-
+Copyright (c) 2022 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro
+-/
+import Mathlib.Tactic.NormNum.Core
+import Mathlib.Algebra.CharZero.Defs
+
+/-!
+# Helper functions for synthesizing `CharZero` expressions.
+-/
+
+set_option autoImplicit true
+
+open Lean Meta Qq
+
+namespace Mathlib.Meta.NormNum
+
+/-- Helper function to synthesize a typed `CharZero α` expression given `Ring α`. -/
+def inferCharZeroOfRing {α : Q(Type u)} (_i : Q(Ring $α) := by with_reducible assumption) :
+    MetaM Q(CharZero $α) :=
+  return ← synthInstanceQ (q(CharZero $α) : Q(Prop)) <|>
+    throwError "not a characteristic zero ring"
+
+/-- Helper function to synthesize a typed `CharZero α` expression given `Ring α`, if it exists. -/
+def inferCharZeroOfRing? {α : Q(Type u)} (_i : Q(Ring $α) := by with_reducible assumption) :
+    MetaM (Option Q(CharZero $α)) :=
+  return (← trySynthInstanceQ (q(CharZero $α) : Q(Prop))).toOption
+
+/-- Helper function to synthesize a typed `CharZero α` expression given `AddMonoidWithOne α`. -/
+def inferCharZeroOfAddMonoidWithOne {α : Q(Type u)}
+    (_i : Q(AddMonoidWithOne $α) := by with_reducible assumption) : MetaM Q(CharZero $α) :=
+  return ← synthInstanceQ (q(CharZero $α) : Q(Prop)) <|>
+    throwError "not a characteristic zero AddMonoidWithOne"
+
+/-- Helper function to synthesize a typed `CharZero α` expression given `AddMonoidWithOne α`, if it
+exists. -/
+def inferCharZeroOfAddMonoidWithOne? {α : Q(Type u)}
+    (_i : Q(AddMonoidWithOne $α) := by with_reducible assumption) :
+      MetaM (Option Q(CharZero $α)) :=
+  return (← trySynthInstanceQ (q(CharZero $α) : Q(Prop))).toOption
+
+/-- Helper function to synthesize a typed `CharZero α` expression given `DivisionRing α`. -/
+def inferCharZeroOfDivisionRing {α : Q(Type u)}
+    (_i : Q(DivisionRing $α) := by with_reducible assumption) : MetaM Q(CharZero $α) :=
+  return ← synthInstanceQ (q(CharZero $α) : Q(Prop)) <|>
+    throwError "not a characteristic zero division ring"
+
+/-- Helper function to synthesize a typed `CharZero α` expression given `DivisionRing α`, if it
+exists. -/
+def inferCharZeroOfDivisionRing? {α : Q(Type u)}
+    (_i : Q(DivisionRing $α) := by with_reducible assumption) : MetaM (Option Q(CharZero $α)) :=
+  return (← trySynthInstanceQ (q(CharZero $α) : Q(Prop))).toOption
+
+end Mathlib.Meta.NormNum

--- a/Mathlib/Tactic/NormNum/Core.lean
+++ b/Mathlib/Tactic/NormNum/Core.lean
@@ -5,11 +5,10 @@ Authors: Mario Carneiro
 -/
 import Std.Lean.Parser
 import Std.Lean.Meta.DiscrTree
+import Mathlib.Algebra.Field.Defs
 import Mathlib.Algebra.Invertible
-import Mathlib.Data.Rat.Cast
 import Mathlib.Data.Nat.Basic
-import Mathlib.Data.Int.Basic
-import Mathlib.Tactic.Conv
+import Mathlib.Data.Int.Cast.Basic
 import Mathlib.Util.Qq
 
 /-!
@@ -125,9 +124,6 @@ def rawIntLitNatAbs (n : Q(ℤ)) : (m : Q(ℕ)) × Q(Int.natAbs $n = $m) :=
 /-- A shortcut (non)instance for `AddMonoidWithOne ℕ` to shrink generated proofs. -/
 def instAddMonoidWithOneNat : AddMonoidWithOne ℕ := inferInstance
 
-/-- A shortcut (non)instance for `Ring ℤ` to shrink generated proofs. -/
-def instRingInt : Ring ℤ := inferInstance
-
 /--
 Assert that an element of a ring is equal to `num / denom`
 (and `denom` is invertible so that this makes sense).
@@ -186,12 +182,6 @@ def mkRawRatLit (q : ℚ) : Q(ℚ) :=
   let nlit : Q(ℤ) := mkRawIntLit q.num
   let dlit : Q(ℕ) := mkRawNatLit q.den
   q(mkRat $nlit $dlit)
-
-/-- A shortcut (non)instance for `Ring ℚ` to shrink generated proofs. -/
-def instRingRat : Ring ℚ := inferInstance
-
-/-- A shortcut (non)instance for `DivisionRing ℚ` to shrink generated proofs. -/
-def instDivisionRingRat : DivisionRing ℚ := inferInstance
 
 /-- The result of `norm_num` running on an expression `x` of type `α`.
 Untyped version of `Result`. -/
@@ -293,60 +283,10 @@ def inferRing (α : Q(Type u)) : MetaM Q(Ring $α) :=
 def inferDivisionRing (α : Q(Type u)) : MetaM Q(DivisionRing $α) :=
   return ← synthInstanceQ (q(DivisionRing $α) : Q(Type u)) <|> throwError "not a division ring"
 
-/-- Helper function to synthesize a typed `OrderedSemiring α` expression. -/
-def inferOrderedSemiring (α : Q(Type u)) : MetaM Q(OrderedSemiring $α) :=
-  return ← synthInstanceQ (q(OrderedSemiring $α) : Q(Type u)) <|>
-    throwError "not an ordered semiring"
-
-/-- Helper function to synthesize a typed `OrderedRing α` expression. -/
-def inferOrderedRing (α : Q(Type u)) : MetaM Q(OrderedRing $α) :=
-  return ← synthInstanceQ (q(OrderedRing $α) : Q(Type u)) <|> throwError "not an ordered ring"
-
-/-- Helper function to synthesize a typed `LinearOrderedField α` expression. -/
-def inferLinearOrderedField (α : Q(Type u)) : MetaM Q(LinearOrderedField $α) :=
-  return ← synthInstanceQ (q(LinearOrderedField $α) : Q(Type u)) <|>
-    throwError "not a linear ordered field"
-
-/-- Helper function to synthesize a typed `CharZero α` expression given `Ring α`. -/
-def inferCharZeroOfRing {α : Q(Type u)} (_i : Q(Ring $α) := by with_reducible assumption) :
-    MetaM Q(CharZero $α) :=
-  return ← synthInstanceQ (q(CharZero $α) : Q(Prop)) <|>
-    throwError "not a characteristic zero ring"
-
-/-- Helper function to synthesize a typed `CharZero α` expression given `Ring α`, if it exists. -/
-def inferCharZeroOfRing? {α : Q(Type u)} (_i : Q(Ring $α) := by with_reducible assumption) :
-    MetaM (Option Q(CharZero $α)) :=
-  return (← trySynthInstanceQ (q(CharZero $α) : Q(Prop))).toOption
-
-/-- Helper function to synthesize a typed `CharZero α` expression given `AddMonoidWithOne α`. -/
-def inferCharZeroOfAddMonoidWithOne {α : Q(Type u)}
-    (_i : Q(AddMonoidWithOne $α) := by with_reducible assumption) : MetaM Q(CharZero $α) :=
-  return ← synthInstanceQ (q(CharZero $α) : Q(Prop)) <|>
-    throwError "not a characteristic zero AddMonoidWithOne"
-
-/-- Helper function to synthesize a typed `CharZero α` expression given `AddMonoidWithOne α`, if it
-exists. -/
-def inferCharZeroOfAddMonoidWithOne? {α : Q(Type u)}
-    (_i : Q(AddMonoidWithOne $α) := by with_reducible assumption) :
-      MetaM (Option Q(CharZero $α)) :=
-  return (← trySynthInstanceQ (q(CharZero $α) : Q(Prop))).toOption
-
-/-- Helper function to synthesize a typed `CharZero α` expression given `DivisionRing α`. -/
-def inferCharZeroOfDivisionRing {α : Q(Type u)}
-    (_i : Q(DivisionRing $α) := by with_reducible assumption) : MetaM Q(CharZero $α) :=
-  return ← synthInstanceQ (q(CharZero $α) : Q(Prop)) <|>
-    throwError "not a characteristic zero division ring"
-
 /-- Helper function to synthesize a typed `OfScientific α` expression given `DivisionRing α`. -/
 def inferOfScientific (α : Q(Type u)) : MetaM Q(OfScientific $α) :=
   return ← synthInstanceQ (q(OfScientific $α) : Q(Type u)) <|>
     throwError "does not support scientific notation"
-
-/-- Helper function to synthesize a typed `CharZero α` expression given `DivisionRing α`, if it
-exists. -/
-def inferCharZeroOfDivisionRing? {α : Q(Type u)}
-    (_i : Q(DivisionRing $α) := by with_reducible assumption) : MetaM (Option Q(CharZero $α)) :=
-  return (← trySynthInstanceQ (q(CharZero $α) : Q(Prop))).toOption
 
 /-- Helper function to synthesize a typed `RatCast α` expression. -/
 def inferRatCast (α : Q(Type u)) : MetaM Q(RatCast $α) :=

--- a/Mathlib/Tactic/NormNum/OrderedRing.lean
+++ b/Mathlib/Tactic/NormNum/OrderedRing.lean
@@ -1,0 +1,33 @@
+/-
+Copyright (c) 2022 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro
+-/
+import Mathlib.Tactic.NormNum.Core
+import Mathlib.Algebra.Order.Field.Defs
+
+/-!
+# Helper functions for working with ordered rings.
+-/
+
+set_option autoImplicit true
+
+open Lean Meta Qq
+
+namespace Mathlib.Meta.NormNum
+
+/-- Helper function to synthesize a typed `OrderedSemiring α` expression. -/
+def inferOrderedSemiring (α : Q(Type u)) : MetaM Q(OrderedSemiring $α) :=
+  return ← synthInstanceQ (q(OrderedSemiring $α) : Q(Type u)) <|>
+    throwError "not an ordered semiring"
+
+/-- Helper function to synthesize a typed `OrderedRing α` expression. -/
+def inferOrderedRing (α : Q(Type u)) : MetaM Q(OrderedRing $α) :=
+  return ← synthInstanceQ (q(OrderedRing $α) : Q(Type u)) <|> throwError "not an ordered ring"
+
+/-- Helper function to synthesize a typed `LinearOrderedField α` expression. -/
+def inferLinearOrderedField (α : Q(Type u)) : MetaM Q(LinearOrderedField $α) :=
+  return ← synthInstanceQ (q(LinearOrderedField $α) : Q(Type u)) <|>
+    throwError "not a linear ordered field"
+
+end Mathlib.Meta.NormNum

--- a/Mathlib/Tactic/Positivity/Basic.lean
+++ b/Mathlib/Tactic/Positivity/Basic.lean
@@ -5,6 +5,7 @@ Authors: Mario Carneiro, Heather Macbeth, Yaël Dillies
 -/
 import Std.Lean.Parser
 import Mathlib.Data.Int.Order.Basic
+import Mathlib.Data.Int.CharZero
 import Mathlib.Data.Nat.Factorial.Basic
 import Mathlib.Tactic.Positivity.Core
 import Mathlib.Tactic.HaveI

--- a/Mathlib/Tactic/Positivity/Core.lean
+++ b/Mathlib/Tactic/Positivity/Core.lean
@@ -10,6 +10,7 @@ import Mathlib.Order.Basic
 import Mathlib.Algebra.Order.Invertible
 import Mathlib.Algebra.Order.Ring.Defs
 import Mathlib.Data.Nat.Cast.Basic
+import Mathlib.Data.Int.Cast.Lemmas
 import Qq
 
 /-!


### PR DESCRIPTION
Reducing the imports in `Mathlib.Tactic.NormNum.Core` a bit.

(I was thinking about whether it might be possible to upstream some of `norm_num`. As is it has a lot of prerequisites!)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
