### PR TITLE
[Merged by Bors] - chore: separate NeZero dependency from Nat/Cast/Defs

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1599,6 +1599,7 @@ import Mathlib.Data.Nat.Bitwise
 import Mathlib.Data.Nat.Cast.Basic
 import Mathlib.Data.Nat.Cast.Defs
 import Mathlib.Data.Nat.Cast.Field
+import Mathlib.Data.Nat.Cast.NeZero
 import Mathlib.Data.Nat.Cast.Prod
 import Mathlib.Data.Nat.Cast.WithTop
 import Mathlib.Data.Nat.Choose.Basic

--- a/Mathlib/Algebra/CharZero/Defs.lean
+++ b/Mathlib/Algebra/CharZero/Defs.lean
@@ -5,6 +5,7 @@ Authors: Mario Carneiro
 -/
 import Mathlib.Data.Int.Cast.Defs
 import Mathlib.Tactic.NormCast.Tactic
+import Mathlib.Algebra.NeZero
 
 #align_import algebra.char_zero.defs from "leanprover-community/mathlib"@"d6aae1bcbd04b8de2022b9b83a5b5b10e10c777d"
 

--- a/Mathlib/Algebra/Ring/Defs.lean
+++ b/Mathlib/Algebra/Ring/Defs.lean
@@ -6,7 +6,6 @@ Authors: Jeremy Avigad, Leonardo de Moura, Floris van Doorn, Yury Kudryashov, Ne
 import Mathlib.Algebra.Group.Basic
 import Mathlib.Algebra.GroupWithZero.Defs
 import Mathlib.Data.Int.Cast.Defs
-import Mathlib.Logic.Nontrivial
 
 #align_import algebra.ring.defs from "leanprover-community/mathlib"@"76de8ae01554c3b37d66544866659ff174e66e1f"
 

--- a/Mathlib/Data/Nat/Cast/Basic.lean
+++ b/Mathlib/Data/Nat/Cast/Basic.lean
@@ -9,6 +9,7 @@ import Mathlib.Algebra.Hom.Ring
 import Mathlib.Algebra.Order.Group.Abs
 import Mathlib.Algebra.Ring.Commute
 import Mathlib.Data.Nat.Order.Basic
+import Mathlib.Data.Nat.Cast.NeZero
 import Mathlib.Algebra.Group.Opposite
 
 #align_import data.nat.cast.basic from "leanprover-community/mathlib"@"acebd8d49928f6ed8920e502a6c90674e75bd441"

--- a/Mathlib/Data/Nat/Cast/Defs.lean
+++ b/Mathlib/Data/Nat/Cast/Defs.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Gabriel Ebner
 -/
 import Mathlib.Algebra.Group.Defs
-import Mathlib.Algebra.NeZero
 
 #align_import data.nat.cast.defs from "leanprover-community/mathlib"@"a148d797a1094ab554ad4183a4ad6f130358ef64"
 
@@ -206,22 +205,6 @@ protected def AddMonoidWithOne.binary {R : Type*} [AddMonoid R] [One R] : AddMon
       letI : AddMonoidWithOne R := AddMonoidWithOne.unary
       rw [Nat.binCast_eq, Nat.binCast_eq, Nat.cast_succ] }
 #align add_monoid_with_one.binary AddMonoidWithOne.binary
-
-namespace NeZero
-
-lemma natCast_ne (n : ℕ) (R) [AddMonoidWithOne R] [h : NeZero (n : R)] :
-  (n : R) ≠ 0 := h.out
-#align ne_zero.nat_cast_ne NeZero.natCast_ne
-
-lemma of_neZero_natCast (R) [AddMonoidWithOne R] {n : ℕ} [h : NeZero (n : R)] : NeZero n :=
-  ⟨by rintro rfl; exact h.out Nat.cast_zero⟩
-#align ne_zero.of_ne_zero_coe NeZero.of_neZero_natCast
-
-lemma pos_of_neZero_natCast (R) [AddMonoidWithOne R] {n : ℕ} [NeZero (n : R)] : 0 < n :=
-  Nat.pos_of_ne_zero (of_neZero_natCast R).out
-#align ne_zero.pos_of_ne_zero_coe NeZero.pos_of_neZero_natCast
-
-end NeZero
 
 theorem one_add_one_eq_two [AddMonoidWithOne α] : 1 + 1 = (2 : α) := by
   rw [←Nat.cast_one, ←Nat.cast_add]

--- a/Mathlib/Data/Nat/Cast/NeZero.lean
+++ b/Mathlib/Data/Nat/Cast/NeZero.lean
@@ -1,0 +1,28 @@
+
+/-
+Copyright (c) 2014 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro, Gabriel Ebner
+-/
+import Mathlib.Data.Nat.Cast.Defs
+import Mathlib.Algebra.NeZero
+
+/-!
+# Lemmas about nonzero elements of an `AddMonoidWithOne`
+-/
+
+namespace NeZero
+
+lemma natCast_ne (n : ℕ) (R) [AddMonoidWithOne R] [h : NeZero (n : R)] :
+  (n : R) ≠ 0 := h.out
+#align ne_zero.nat_cast_ne NeZero.natCast_ne
+
+lemma of_neZero_natCast (R) [AddMonoidWithOne R] {n : ℕ} [h : NeZero (n : R)] : NeZero n :=
+  ⟨by rintro rfl; exact h.out Nat.cast_zero⟩
+#align ne_zero.of_ne_zero_coe NeZero.of_neZero_natCast
+
+lemma pos_of_neZero_natCast (R) [AddMonoidWithOne R] {n : ℕ} [NeZero (n : R)] : 0 < n :=
+  Nat.pos_of_ne_zero (of_neZero_natCast R).out
+#align ne_zero.pos_of_ne_zero_coe NeZero.pos_of_neZero_natCast
+
+end NeZero

--- a/Mathlib/Data/Nat/Cast/NeZero.lean
+++ b/Mathlib/Data/Nat/Cast/NeZero.lean
@@ -1,4 +1,3 @@
-
 /-
 Copyright (c) 2014 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.


### PR DESCRIPTION
I'm trying to remove any extraneous material from the core definitions in the algebraic hierarchy that are used in tactics.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
