### PR TITLE
[Merged by Bors] - chore: remove @[defaultTarget] from checkYaml and runLinter

### DIFF
--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -180,7 +180,7 @@ jobs:
       - name: check declarations in db files
         run: |
           python3 scripts/yaml_check.py docs/100.yaml docs/overview.yaml docs/undergrad.yaml
-          build/bin/checkYaml
+          lake exe checkYaml
 
       - name: test mathlib
         id: test
@@ -191,7 +191,7 @@ jobs:
         uses: liskin/gh-problem-matcher-wrap@v2
         with:
           linters: gcc
-          run: env LEAN_ABORT_ON_PANIC=1 make lint
+          run: env LEAN_ABORT_ON_PANIC=1 lake exe runLinter
 
       - name: Post comments for lean-pr-testing branch
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -186,7 +186,7 @@ jobs:
       - name: check declarations in db files
         run: |
           python3 scripts/yaml_check.py docs/100.yaml docs/overview.yaml docs/undergrad.yaml
-          build/bin/checkYaml
+          lake exe checkYaml
 
       - name: test mathlib
         id: test
@@ -197,7 +197,7 @@ jobs:
         uses: liskin/gh-problem-matcher-wrap@v2
         with:
           linters: gcc
-          run: env LEAN_ABORT_ON_PANIC=1 make lint
+          run: env LEAN_ABORT_ON_PANIC=1 lake exe runLinter
 
       - name: Post comments for lean-pr-testing branch
         if: always()

--- a/.github/workflows/build.yml.in
+++ b/.github/workflows/build.yml.in
@@ -166,7 +166,7 @@ jobs:
       - name: check declarations in db files
         run: |
           python3 scripts/yaml_check.py docs/100.yaml docs/overview.yaml docs/undergrad.yaml
-          build/bin/checkYaml
+          lake exe checkYaml
 
       - name: test mathlib
         id: test
@@ -177,7 +177,7 @@ jobs:
         uses: liskin/gh-problem-matcher-wrap@v2
         with:
           linters: gcc
-          run: env LEAN_ABORT_ON_PANIC=1 make lint
+          run: env LEAN_ABORT_ON_PANIC=1 lake exe runLinter
 
       - name: Post comments for lean-pr-testing branch
         if: always()

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -184,7 +184,7 @@ jobs:
       - name: check declarations in db files
         run: |
           python3 scripts/yaml_check.py docs/100.yaml docs/overview.yaml docs/undergrad.yaml
-          build/bin/checkYaml
+          lake exe checkYaml
 
       - name: test mathlib
         id: test
@@ -195,7 +195,7 @@ jobs:
         uses: liskin/gh-problem-matcher-wrap@v2
         with:
           linters: gcc
-          run: env LEAN_ABORT_ON_PANIC=1 make lint
+          run: env LEAN_ABORT_ON_PANIC=1 lake exe runLinter
 
       - name: Post comments for lean-pr-testing branch
         if: always()

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -13,4 +13,4 @@ test/%.run: build
 	lake env lean test/$*
 
 lint: build
-	./build/bin/runLinter
+	env LEAN_ABORT_ON_PANIC=1 lake exe runLinter

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -29,12 +29,10 @@ lean_lib Mathlib where
   moreLeanArgs := moreLeanArgs
   weakLeanArgs := weakLeanArgs
 
-@[default_target]
 lean_exe runLinter where
   root := `scripts.runLinter
   supportInterpreter := true
 
-@[default_target]
 lean_exe checkYaml where
   root := `scripts.checkYaml
   supportInterpreter := true


### PR DESCRIPTION
Having `@[defaultTarget]` on `checkYaml` and `runLinter` meant that these were compiled every time someone ran `lake build`. This involves compilation steps, which are not provided by the cache, and so `lake build` could be noisy even with Mathlib was otherwise ready to use:

```
% lake build
[976/3736] Compiling Mathlib.Tactic.ToLevel
[981/3736] Compiling Mathlib.Lean.CoreM
[982/3736] Compiling Mathlib.Tactic.PPWithUniv
[990/3736] Compiling Mathlib.Util.WhatsNew
[990/3736] Compiling Mathlib.Mathport.Rename
[990/3736] Compiling Mathlib.Tactic.DeriveToExpr
[991/3736] Compiling Mathlib.Tactic.ToExpr
[1011/3736] Building scripts.checkYaml
[1016/3736] Building scripts.runLinter
[2414/3736] Compiling scripts.checkYaml
[2891/3736] Compiling scripts.runLinter
[3736/3736] Linking runLinter
[3736/3736] Linking checkYaml
```
(possibly followed by a page of linking warnings for people on older macos)

As these are not compiled by `lake build` anymore, we make sure to use `lake exe` at the point of use rather than assuming the binary is already there.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
