### PR TITLE
[Merged by Bors] - feat: `Nat.lcm_mul_left` and `Nat.lcm_mul_right`

### DIFF
--- a/Mathlib/Data/Int/GCD.lean
+++ b/Mathlib/Data/Int/GCD.lean
@@ -499,6 +499,12 @@ theorem lcm_dvd {i j k : ℤ} : i ∣ k → j ∣ k → (lcm i j : ℤ) ∣ k :=
   exact coe_nat_dvd_left.mpr (Nat.lcm_dvd (natAbs_dvd_natAbs.mpr hi) (natAbs_dvd_natAbs.mpr hj))
 #align int.lcm_dvd Int.lcm_dvd
 
+theorem lcm_mul_left {m n k : ℤ} : (m * n).lcm (m * k) = natAbs m * n.lcm k := by
+  simp_rw [Int.lcm, natAbs_mul, Nat.lcm_mul_left]
+
+theorem lcm_mul_right {m n k : ℤ} : (m * n).lcm (k * n) = m.lcm k * natAbs n := by
+  simp_rw [Int.lcm, natAbs_mul, Nat.lcm_mul_right]
+
 end Int
 
 @[to_additive gcd_nsmul_eq_zero]

--- a/Mathlib/Data/Nat/GCD/Basic.lean
+++ b/Mathlib/Data/Nat/GCD/Basic.lean
@@ -104,13 +104,10 @@ theorem lcm_pos {m n : ℕ} : 0 < m → 0 < n → 0 < m.lcm n := by
 #align nat.lcm_pos Nat.lcm_pos
 
 theorem lcm_mul_left {m n k : ℕ} : (m * n).lcm (m * k) = m * n.lcm k := by
-  unfold lcm
-  by_cases hm : m = 0
-  · simp_rw [hm, zero_mul]
-  rw [gcd_mul_left, ←Nat.div_div_eq_div_mul, mul_assoc, Nat.mul_div_cancel_left
-    _ (Nat.pos_of_ne_zero hm), ←Nat.mul_div_assoc, Nat.mul_left_comm]
-  calc _ ∣ n := gcd_dvd_left ..
-       _ ∣ _ := Nat.dvd_mul_right ..
+  apply dvd_antisymm
+  · exact lcm_dvd (mul_dvd_mul_left m (dvd_lcm_left n k)) (mul_dvd_mul_left m (dvd_lcm_right n k))
+  · have h : m ∣ lcm (m * n) (m * k) := (dvd_mul_right m n).trans (dvd_lcm_left (m * n) (m * k))
+    rw [←dvd_div_iff h, lcm_dvd_iff, dvd_div_iff h, dvd_div_iff h, ←lcm_dvd_iff]
 
 theorem lcm_mul_right {m n k : ℕ} : (m * n).lcm (k * n) = m.lcm k * n := by
   simp_rw [mul_comm]; rw [mul_comm]

--- a/Mathlib/Data/Nat/GCD/Basic.lean
+++ b/Mathlib/Data/Nat/GCD/Basic.lean
@@ -110,8 +110,7 @@ theorem lcm_mul_left {m n k : ℕ} : (m * n).lcm (m * k) = m * n.lcm k := by
     rw [←dvd_div_iff h, lcm_dvd_iff, dvd_div_iff h, dvd_div_iff h, ←lcm_dvd_iff]
 
 theorem lcm_mul_right {m n k : ℕ} : (m * n).lcm (k * n) = m.lcm k * n := by
-  simp_rw [mul_comm]; rw [mul_comm]
-  exact lcm_mul_left
+ rw [mul_comm, mul_comm k n, lcm_mul_left, mul_comm]
 
 /-!
 ### `coprime`

--- a/Mathlib/Data/Nat/GCD/Basic.lean
+++ b/Mathlib/Data/Nat/GCD/Basic.lean
@@ -103,6 +103,19 @@ theorem lcm_pos {m n : ℕ} : 0 < m → 0 < n → 0 < m.lcm n := by
   exact lcm_ne_zero
 #align nat.lcm_pos Nat.lcm_pos
 
+theorem lcm_mul_left {m n k : ℕ} : (m * n).lcm (m * k) = m * n.lcm k := by
+  unfold lcm
+  by_cases hm : m = 0
+  · simp_rw [hm, zero_mul]
+  rw [gcd_mul_left, ←Nat.div_div_eq_div_mul, mul_assoc, Nat.mul_div_cancel_left
+    _ (Nat.pos_of_ne_zero hm), ←Nat.mul_div_assoc, Nat.mul_left_comm]
+  calc _ ∣ n := gcd_dvd_left ..
+       _ ∣ _ := Nat.dvd_mul_right ..
+
+theorem lcm_mul_right {m n k : ℕ} : (m * n).lcm (k * n) = m.lcm k * n := by
+  simp_rw [mul_comm]; rw [mul_comm]
+  exact lcm_mul_left
+
 /-!
 ### `coprime`
 


### PR DESCRIPTION
Add two lemmas about `Nat.lcm`. These results mirror [Nat.gcd_mul_left](https://leanprover-community.github.io/mathlib4_docs/Std/Data/Nat/Gcd.html#Nat.gcd_mul_left) present in Std.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Note we do have the more general [gcd_mul_left](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/GCDMonoid/Basic.html#gcd_mul_left), which includes a `normalize` that  becomes trivial in the `Nat` case.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
