### PR TITLE
[Merged by Bors] - feat: control labels from comments

### DIFF
--- a/.github/workflows/labels_from_comment.yml
+++ b/.github/workflows/labels_from_comment.yml
@@ -1,0 +1,43 @@
+# This workflow allows any user to add one of the `awaiting-review`, `awaiting-author`, or `WIP` labels,
+# by commenting on the PR or issue.
+# Other labels from this set are removed automatically at the same time.
+
+name: Label PR based on Comment
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  update-label:
+    if: github.event.issue.pull_request != null && (contains(github.event.comment.body, 'awaiting-review') || contains(github.event.comment.body, 'awaiting-author') || contains(github.event.comment.body, 'WIP'))
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Add label based on comment
+      uses: actions/github-script@v6
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          const { owner, repo, number: issue_number  } = context.issue;
+          const commentLines = context.payload.comment.body.split('\r\n');
+
+          const awaitingReview = commentLines.includes('awaiting-review');
+          const awaitingAuthor = commentLines.includes('awaiting-author');
+          const wip = commentLines.includes('WIP');
+
+          if (awaitingReview || awaitingAuthor || wip) {
+            await github.rest.issues.removeLabel({ owner, repo, issue_number, name: 'awaiting-review' }).catch(() => {});
+            await github.rest.issues.removeLabel({ owner, repo, issue_number, name: 'awaiting-author' }).catch(() => {});
+            await github.rest.issues.removeLabel({ owner, repo, issue_number, name: 'WIP' }).catch(() => {});
+          }
+
+          if (awaitingReview) {
+            await github.rest.issues.addLabels({ owner, repo, issue_number, labels: ['awaiting-review'] });
+          }
+          if (awaitingAuthor) {
+            await github.rest.issues.addLabels({ owner, repo, issue_number, labels: ['awaiting-author'] });
+          }
+          if (wip) {
+            await github.rest.issues.addLabels({ owner, repo, issue_number, labels: ['WIP'] });
+          }


### PR DESCRIPTION
Same implementation as at Lean and Std, by request from @jcommelin.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
