### PR TITLE
[Merged by Bors] - feat: add an error when eqns will not have desired effect

### DIFF
--- a/Mathlib/Tactic/Eqns.lean
+++ b/Mathlib/Tactic/Eqns.lean
@@ -36,7 +36,10 @@ initialize eqnsAttribute : NameMapExtension (Array Name) ←
     name  := `eqns
     descr := "Overrides the equation lemmas for a declaration to the provided list"
     add   := fun
-    | _, `(attr| eqns $[$names]*) =>
+    | declName, `(attr| eqns $[$names]*) => do
+      if let some _ := Meta.eqnsExt.getState (← getEnv) |>.map.find? declName then
+        throwError "There already exist stored eqns for '{declName}' registering new equations{
+            "\n"}will not have the desired effect."
       names.mapM resolveGlobalConstNoOverloadWithInfo
     | _, _ => Lean.Elab.throwUnsupportedSyntax }
 

--- a/test/eqns.lean
+++ b/test/eqns.lean
@@ -26,7 +26,7 @@ theorem t_def' : t = 1 := by rw [t]
 error: There already exist stored eqns for 't' registering new equations
 will not have the desired effect supported
 -/
-#guard_msgs in
+#guard_msgs(error) in
 attribute [eqns t_def] t
 -- the above should error as the
 example (n : Nat) : t = n := by

--- a/test/eqns.lean
+++ b/test/eqns.lean
@@ -1,4 +1,5 @@
 import Mathlib.Tactic.Eqns
+import Std.Tactic.GuardMsgs
 
 def transpose {m n} (A : m → n → Nat) : n → m → Nat
   | i, j => A j i
@@ -14,3 +15,20 @@ theorem transpose_const {m n} (c : Nat) :
   fail_if_success {simp [transpose]}
   funext i j -- the rw below does not work without this line
   rw [transpose]
+
+def t : Nat := 0 + 1
+
+theorem t_def : t = 1 := rfl
+-- this rw causes lean to generate equations itself for t before the user can register them
+theorem t_def' : t = 1 := by rw [t]
+
+/--
+error: There already exist stored eqns for 't' registering new equations
+will not have the desired effect supported
+-/
+#guard_msgs in
+attribute [eqns t_def] t
+-- the above should error as the
+example (n : Nat) : t = n := by
+  rw [t]
+  sorry

--- a/test/eqns.lean
+++ b/test/eqns.lean
@@ -28,7 +28,7 @@ will not have the desired effect supported
 -/
 #guard_msgs in
 attribute [eqns t_def] t
--- the above should error as the
+-- the above should error as the above equation would not have changed the output of the below
 example (n : Nat) : t = n := by
   rw [t]
   sorry

--- a/test/eqns.lean
+++ b/test/eqns.lean
@@ -24,7 +24,7 @@ theorem t_def' : t = 1 := by rw [t]
 
 /--
 error: There already exist stored eqns for 't' registering new equations
-will not have the desired effect supported
+will not have the desired effect.
 -/
 #guard_msgs(error) in
 attribute [eqns t_def] t


### PR DESCRIPTION
Due to the implementation at https://github.com/leanprover/lean4/blob/a7efe5b60e86b26fefd4795b46d66af369b97329/src/Lean/Meta/Eqns.lean#L83-L96 currently registering eqns will not work if lean already registered some eqns itself.

As a bandaid we make the eqns attribute check and error in this case.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
