### PR TITLE
[Merged by Bors] - feat: add some lemmas for Haar measures

### DIFF
--- a/Mathlib/LinearAlgebra/Basis.lean
+++ b/Mathlib/LinearAlgebra/Basis.lean
@@ -356,6 +356,9 @@ theorem map_apply (i) : b.map f i = f (b i) :=
   rfl
 #align basis.map_apply Basis.map_apply
 
+theorem coe_map : (b.map f : ι → M') = f ∘ b :=
+  rfl
+
 end Map
 
 section MapCoeffs

--- a/Mathlib/MeasureTheory/Measure/Haar/Basic.lean
+++ b/Mathlib/MeasureTheory/Measure/Haar/Basic.lean
@@ -698,13 +698,13 @@ theorem haarMeasure_unique (μ : Measure G) [SigmaFinite μ] [IsMulLeftInvariant
 #align measure_theory.measure.haar_measure_unique MeasureTheory.Measure.haarMeasure_unique
 #align measure_theory.measure.add_haar_measure_unique MeasureTheory.Measure.addHaarMeasure_unique
 
-/-- Let `K₀ K₁ : TopologicalSpace.PositiveCompacts G`, then `K₁` defines the same Haar measure as
-`K₀` iff it has measure `1` for the Haar measure defined by `K₀`. -/
+/-- Let `μ` be a  σ-finite left invariant measure on `G`. Then `μ` is equal to the Haar measure
+defined by `K₀` iff `μ K₀ = 1`. -/
 @[to_additive]
-theorem haarMeasure_eq_iff (K₀ K₁ : PositiveCompacts G) :
-    haarMeasure K₀ = haarMeasure K₁ ↔ (haarMeasure K₀) K₁ = 1 :=
-  ⟨fun h => h.symm ▸ haarMeasure_self,
-    fun h => by rw [haarMeasure_unique (haarMeasure K₀) K₁, h, one_smul]⟩
+theorem haarMeasure_eq_iff (K₀ : PositiveCompacts G) (μ : Measure G) [SigmaFinite μ]
+    [IsMulLeftInvariant μ] :
+    haarMeasure K₀ = μ ↔ μ K₀ = 1 :=
+  ⟨fun h => h.symm ▸ haarMeasure_self, fun h => by rw [haarMeasure_unique μ K₀, h, one_smul]⟩
 
 example [LocallyCompactSpace G] (μ : Measure G) [IsHaarMeasure μ] (K₀ : PositiveCompacts G) :
     μ = μ K₀.1 • haarMeasure K₀ :=

--- a/Mathlib/MeasureTheory/Measure/Haar/Basic.lean
+++ b/Mathlib/MeasureTheory/Measure/Haar/Basic.lean
@@ -700,9 +700,9 @@ theorem haarMeasure_unique (μ : Measure G) [SigmaFinite μ] [IsMulLeftInvariant
 
 @[to_additive]
 theorem  haarMeasure_eq (K₀ K₁ : TopologicalSpace.PositiveCompacts G) :
-    haarMeasure K₀ = haarMeasure K₁ ↔ (haarMeasure K₀) K₁ = 1 := by
-    refine ⟨fun h => h.symm ▸ haarMeasure_self,
-      fun h => by rw [haarMeasure_unique (haarMeasure K₀) K₁, h, one_smul]⟩
+    haarMeasure K₀ = haarMeasure K₁ ↔ (haarMeasure K₀) K₁ = 1 :=
+  ⟨fun h => h.symm ▸ haarMeasure_self,
+    fun h => by rw [haarMeasure_unique (haarMeasure K₀) K₁, h, one_smul]⟩
 
 example [LocallyCompactSpace G] (μ : Measure G) [IsHaarMeasure μ] (K₀ : PositiveCompacts G) :
     μ = μ K₀.1 • haarMeasure K₀ :=

--- a/Mathlib/MeasureTheory/Measure/Haar/Basic.lean
+++ b/Mathlib/MeasureTheory/Measure/Haar/Basic.lean
@@ -701,7 +701,7 @@ theorem haarMeasure_unique (μ : Measure G) [SigmaFinite μ] [IsMulLeftInvariant
 /-- Let `K₀ K₁ : TopologicalSpace.PositiveCompacts G`, then `K₁` defines the same Haar measure as
 `K₀` iff it has measure `1` for the Haar measure defined by `K₀`. -/
 @[to_additive]
-theorem haarMeasure_eq_iff (K₀ K₁ : TopologicalSpace.PositiveCompacts G) :
+theorem haarMeasure_eq_iff (K₀ K₁ : PositiveCompacts G) :
     haarMeasure K₀ = haarMeasure K₁ ↔ (haarMeasure K₀) K₁ = 1 :=
   ⟨fun h => h.symm ▸ haarMeasure_self,
     fun h => by rw [haarMeasure_unique (haarMeasure K₀) K₁, h, one_smul]⟩

--- a/Mathlib/MeasureTheory/Measure/Haar/Basic.lean
+++ b/Mathlib/MeasureTheory/Measure/Haar/Basic.lean
@@ -698,6 +698,12 @@ theorem haarMeasure_unique (μ : Measure G) [SigmaFinite μ] [IsMulLeftInvariant
 #align measure_theory.measure.haar_measure_unique MeasureTheory.Measure.haarMeasure_unique
 #align measure_theory.measure.add_haar_measure_unique MeasureTheory.Measure.addHaarMeasure_unique
 
+@[to_additive]
+theorem  haarMeasure_eq (K₀ K₁ : TopologicalSpace.PositiveCompacts G) :
+    haarMeasure K₀ = haarMeasure K₁ ↔ (haarMeasure K₀) K₁ = 1 := by
+    refine ⟨fun h => h.symm ▸ haarMeasure_self,
+      fun h => by rw [haarMeasure_unique (haarMeasure K₀) K₁, h, one_smul]⟩
+
 example [LocallyCompactSpace G] (μ : Measure G) [IsHaarMeasure μ] (K₀ : PositiveCompacts G) :
     μ = μ K₀.1 • haarMeasure K₀ :=
   haarMeasure_unique μ K₀

--- a/Mathlib/MeasureTheory/Measure/Haar/Basic.lean
+++ b/Mathlib/MeasureTheory/Measure/Haar/Basic.lean
@@ -698,8 +698,10 @@ theorem haarMeasure_unique (μ : Measure G) [SigmaFinite μ] [IsMulLeftInvariant
 #align measure_theory.measure.haar_measure_unique MeasureTheory.Measure.haarMeasure_unique
 #align measure_theory.measure.add_haar_measure_unique MeasureTheory.Measure.addHaarMeasure_unique
 
+/-- Let `K₀ K₁ : TopologicalSpace.PositiveCompacts G`, then `K₁` defines the same Haar measure as
+`K₀` iff it has measure `1` for the Haar measure defined by `K₀`. -/
 @[to_additive]
-theorem  haarMeasure_eq (K₀ K₁ : TopologicalSpace.PositiveCompacts G) :
+theorem haarMeasure_eq_iff (K₀ K₁ : TopologicalSpace.PositiveCompacts G) :
     haarMeasure K₀ = haarMeasure K₁ ↔ (haarMeasure K₀) K₁ = 1 :=
   ⟨fun h => h.symm ▸ haarMeasure_self,
     fun h => by rw [haarMeasure_unique (haarMeasure K₀) K₁, h, one_smul]⟩

--- a/Mathlib/MeasureTheory/Measure/Haar/Basic.lean
+++ b/Mathlib/MeasureTheory/Measure/Haar/Basic.lean
@@ -698,7 +698,7 @@ theorem haarMeasure_unique (μ : Measure G) [SigmaFinite μ] [IsMulLeftInvariant
 #align measure_theory.measure.haar_measure_unique MeasureTheory.Measure.haarMeasure_unique
 #align measure_theory.measure.add_haar_measure_unique MeasureTheory.Measure.addHaarMeasure_unique
 
-/-- Let `μ` be a  σ-finite left invariant measure on `G`. Then `μ` is equal to the Haar measure
+/-- Let `μ` be a σ-finite left invariant measure on `G`. Then `μ` is equal to the Haar measure
 defined by `K₀` iff `μ K₀ = 1`. -/
 @[to_additive]
 theorem haarMeasure_eq_iff (K₀ : PositiveCompacts G) (μ : Measure G) [SigmaFinite μ]

--- a/Mathlib/MeasureTheory/Measure/Haar/OfBasis.lean
+++ b/Mathlib/MeasureTheory/Measure/Haar/OfBasis.lean
@@ -226,21 +226,20 @@ instance IsAddHaarMeasure_basis_addHaar (b : Basis ι ℝ E) : IsAddHaarMeasure 
   rw [Basis.addHaar]; exact Measure.isAddHaarMeasure_addHaarMeasure _
 #align is_add_haar_measure_basis_add_haar IsAddHaarMeasure_basis_addHaar
 
-instance [TopologicalSpace.SecondCountableTopology E] (b : Basis ι ℝ E) :
+instance [SecondCountableTopology E] (b : Basis ι ℝ E) :
     SigmaFinite b.addHaar := by
-  rw [Basis.addHaar_def]; exact MeasureTheory.Measure.sigmaFinite_addHaarMeasure
+  rw [Basis.addHaar_def]; exact sigmaFinite_addHaarMeasure
 
 /-- Let `b` and `b'` two bases of `E`. The basis `b'` defines the same Haar measure as the basis
 `b` iff the parallelepiped defined by `b'` has measure `1` for the Haar measure defined by `b`. -/
-theorem Basis.addHaar_eq_iff {ι' : Type*} [Fintype ι'] [TopologicalSpace.SecondCountableTopology E]
+theorem Basis.addHaar_eq_iff [SecondCountableTopology E]
     {b : Basis ι ℝ E} {b' : Basis ι' ℝ E} :
     b.addHaar = b'.addHaar ↔ b.addHaar b'.parallelepiped = 1 := by
   rw [Basis.addHaar_def, Basis.addHaar_def]
-  exact Measure.addHaarMeasure_eq_iff b.parallelepiped b'.parallelepiped
+  exact addHaarMeasure_eq_iff b.parallelepiped b'.parallelepiped
 
 @[simp]
-theorem Basis.addHaar_reindex {ι ι' E : Type*} [Fintype ι] [Fintype ι'] [NormedAddCommGroup E]
-    [NormedSpace ℝ E] [MeasurableSpace E] [BorelSpace E] (b : Basis ι ℝ E) (e : ι ≃ ι') :
+theorem Basis.addHaar_reindex (b : Basis ι ℝ E) (e : ι ≃ ι') :
     (b.reindex e).addHaar = b.addHaar := by
   rw [Basis.addHaar, b.parallelepiped_reindex e, ← Basis.addHaar]
 

--- a/Mathlib/MeasureTheory/Measure/Haar/OfBasis.lean
+++ b/Mathlib/MeasureTheory/Measure/Haar/OfBasis.lean
@@ -230,7 +230,7 @@ instance [SecondCountableTopology E] (b : Basis ι ℝ E) :
     SigmaFinite b.addHaar := by
   rw [Basis.addHaar_def]; exact sigmaFinite_addHaarMeasure
 
-/-- Let `μ` be a  σ-finite left invariant measure on `E`. Then `μ` is equal to the Haar measure
+/-- Let `μ` be a σ-finite left invariant measure on `E`. Then `μ` is equal to the Haar measure
 defined by `b` iff the parallelepiped defined by `b` has measure `1` for `μ`. -/
 theorem Basis.addHaar_eq_iff [SecondCountableTopology E] (b : Basis ι ℝ E) (μ : Measure E)
     [SigmaFinite μ] [IsAddLeftInvariant μ] :

--- a/Mathlib/MeasureTheory/Measure/Haar/OfBasis.lean
+++ b/Mathlib/MeasureTheory/Measure/Haar/OfBasis.lean
@@ -226,6 +226,22 @@ instance IsAddHaarMeasure_basis_addHaar (b : Basis ι ℝ E) : IsAddHaarMeasure 
   rw [Basis.addHaar]; exact Measure.isAddHaarMeasure_addHaarMeasure _
 #align is_add_haar_measure_basis_add_haar IsAddHaarMeasure_basis_addHaar
 
+instance [TopologicalSpace.SecondCountableTopology E] (b : Basis ι ℝ E) :
+    SigmaFinite b.addHaar := by
+  rw [Basis.addHaar_def]; exact MeasureTheory.Measure.sigmaFinite_addHaarMeasure
+  
+theorem Basis.addHaar_eq  {ι' : Type*} [Fintype ι'] [TopologicalSpace.SecondCountableTopology E]
+    {b : Basis ι ℝ E} {b' : Basis ι' ℝ E} :
+    b.addHaar = b'.addHaar ↔ b.addHaar b'.parallelepiped = 1 := by
+  rw [Basis.addHaar_def, Basis.addHaar_def]
+  exact Measure.addHaarMeasure_eq b.parallelepiped b'.parallelepiped
+
+@[simp]
+theorem Basis.addHaar_reindex {ι ι' E : Type*} [Fintype ι] [Fintype ι'] [NormedAddCommGroup E]
+    [NormedSpace ℝ E] [MeasurableSpace E] [BorelSpace E] (b : Basis ι ℝ E) (e : ι ≃ ι') :
+    (b.reindex e).addHaar = b.addHaar := by
+  rw [Basis.addHaar, b.parallelepiped_reindex e, ← Basis.addHaar]
+
 theorem Basis.addHaar_self (b : Basis ι ℝ E) : b.addHaar (_root_.parallelepiped b) = 1 := by
   rw [Basis.addHaar]; exact addHaarMeasure_self
 #align basis.add_haar_self Basis.addHaar_self

--- a/Mathlib/MeasureTheory/Measure/Haar/OfBasis.lean
+++ b/Mathlib/MeasureTheory/Measure/Haar/OfBasis.lean
@@ -230,13 +230,13 @@ instance [SecondCountableTopology E] (b : Basis ι ℝ E) :
     SigmaFinite b.addHaar := by
   rw [Basis.addHaar_def]; exact sigmaFinite_addHaarMeasure
 
-/-- Let `b` and `b'` two bases of `E`. The basis `b'` defines the same Haar measure as the basis
-`b` iff the parallelepiped defined by `b'` has measure `1` for the Haar measure defined by `b`. -/
-theorem Basis.addHaar_eq_iff [SecondCountableTopology E]
-    {b : Basis ι ℝ E} {b' : Basis ι' ℝ E} :
-    b.addHaar = b'.addHaar ↔ b.addHaar b'.parallelepiped = 1 := by
-  rw [Basis.addHaar_def, Basis.addHaar_def]
-  exact addHaarMeasure_eq_iff b.parallelepiped b'.parallelepiped
+/-- Let `μ` be a  σ-finite left invariant measure on `E`. Then `μ` is equal to the Haar measure
+defined by `b` iff the parallelepiped defined by `b` has measure `1` for `μ`. -/
+theorem Basis.addHaar_eq_iff [SecondCountableTopology E] (b : Basis ι ℝ E) (μ : Measure E)
+    [SigmaFinite μ] [IsAddLeftInvariant μ] :
+    b.addHaar = μ ↔ μ b.parallelepiped = 1 := by
+  rw [Basis.addHaar_def]
+  exact addHaarMeasure_eq_iff b.parallelepiped μ
 
 @[simp]
 theorem Basis.addHaar_reindex (b : Basis ι ℝ E) (e : ι ≃ ι') :

--- a/Mathlib/MeasureTheory/Measure/Haar/OfBasis.lean
+++ b/Mathlib/MeasureTheory/Measure/Haar/OfBasis.lean
@@ -230,11 +230,13 @@ instance [TopologicalSpace.SecondCountableTopology E] (b : Basis ι ℝ E) :
     SigmaFinite b.addHaar := by
   rw [Basis.addHaar_def]; exact MeasureTheory.Measure.sigmaFinite_addHaarMeasure
 
-theorem Basis.addHaar_eq  {ι' : Type*} [Fintype ι'] [TopologicalSpace.SecondCountableTopology E]
+/-- Let `b` and `b'` two bases of `E`. The basis `b'` defines the same Haar measure as the basis
+`b` iff the parallelepiped defined by `b'` has measure `1` for Haar measure defined by `b`. -/
+theorem Basis.addHaar_eq_iff {ι' : Type*} [Fintype ι'] [TopologicalSpace.SecondCountableTopology E]
     {b : Basis ι ℝ E} {b' : Basis ι' ℝ E} :
     b.addHaar = b'.addHaar ↔ b.addHaar b'.parallelepiped = 1 := by
   rw [Basis.addHaar_def, Basis.addHaar_def]
-  exact Measure.addHaarMeasure_eq b.parallelepiped b'.parallelepiped
+  exact Measure.addHaarMeasure_eq_iff b.parallelepiped b'.parallelepiped
 
 @[simp]
 theorem Basis.addHaar_reindex {ι ι' E : Type*} [Fintype ι] [Fintype ι'] [NormedAddCommGroup E]

--- a/Mathlib/MeasureTheory/Measure/Haar/OfBasis.lean
+++ b/Mathlib/MeasureTheory/Measure/Haar/OfBasis.lean
@@ -229,7 +229,7 @@ instance IsAddHaarMeasure_basis_addHaar (b : Basis ι ℝ E) : IsAddHaarMeasure 
 instance [TopologicalSpace.SecondCountableTopology E] (b : Basis ι ℝ E) :
     SigmaFinite b.addHaar := by
   rw [Basis.addHaar_def]; exact MeasureTheory.Measure.sigmaFinite_addHaarMeasure
-  
+
 theorem Basis.addHaar_eq  {ι' : Type*} [Fintype ι'] [TopologicalSpace.SecondCountableTopology E]
     {b : Basis ι ℝ E} {b' : Basis ι' ℝ E} :
     b.addHaar = b'.addHaar ↔ b.addHaar b'.parallelepiped = 1 := by

--- a/Mathlib/MeasureTheory/Measure/Haar/OfBasis.lean
+++ b/Mathlib/MeasureTheory/Measure/Haar/OfBasis.lean
@@ -231,7 +231,7 @@ instance [TopologicalSpace.SecondCountableTopology E] (b : Basis ι ℝ E) :
   rw [Basis.addHaar_def]; exact MeasureTheory.Measure.sigmaFinite_addHaarMeasure
 
 /-- Let `b` and `b'` two bases of `E`. The basis `b'` defines the same Haar measure as the basis
-`b` iff the parallelepiped defined by `b'` has measure `1` for Haar measure defined by `b`. -/
+`b` iff the parallelepiped defined by `b'` has measure `1` for the Haar measure defined by `b`. -/
 theorem Basis.addHaar_eq_iff {ι' : Type*} [Fintype ι'] [TopologicalSpace.SecondCountableTopology E]
     {b : Basis ι ℝ E} {b' : Basis ι' ℝ E} :
     b.addHaar = b'.addHaar ↔ b.addHaar b'.parallelepiped = 1 := by

--- a/Mathlib/MeasureTheory/Measure/Lebesgue/EqHaar.lean
+++ b/Mathlib/MeasureTheory/Measure/Lebesgue/EqHaar.lean
@@ -70,10 +70,6 @@ def TopologicalSpace.PositiveCompacts.piIcc01 (ι : Type*) [Fintype ι] :
       imp_true_iff, zero_lt_one]
 #align topological_space.positive_compacts.pi_Icc01 TopologicalSpace.PositiveCompacts.piIcc01
 
-theorem TopologicalSpace.PositiveCompacts.piIcc01_measurable (ι : Type*) [Fintype ι] :
-    MeasurableSet (TopologicalSpace.PositiveCompacts.piIcc01 ι : Set (ι → ℝ)) := by
-  exact MeasurableSet.pi countable_univ (fun _ _ => measurableSet_Icc)
-
 /-- The parallelepiped formed from the standard basis for `ι → ℝ` is `[0,1]^ι` -/
 theorem Basis.parallelepiped_basisFun (ι : Type*) [Fintype ι] :
     (Pi.basisFun ℝ ι).parallelepiped = TopologicalSpace.PositiveCompacts.piIcc01 ι :=
@@ -87,9 +83,7 @@ theorem Basis.parallelepiped_basisFun (ι : Type*) [Fintype ι] :
  theorem Basis.parallelepiped_eq_map  {ι E : Type*} [Fintype ι] [NormedAddCommGroup E]
     [NormedSpace ℝ E] (b : Basis ι ℝ E) :
     b.parallelepiped = (TopologicalSpace.PositiveCompacts.piIcc01 ι).map b.equivFun.symm
-    b.equivFunL.symm.continuous
-      (by have := FiniteDimensional.of_fintype_basis b
-          exact LinearMap.isOpenMap_of_finiteDimensional _ b.equivFun.symm.surjective) := by
+      b.equivFunL.symm.continuous b.equivFunL.symm.isOpenMap := by
   rw [← Basis.parallelepiped_basisFun]
   refine (congrArg _ ?_).trans (Basis.parallelepiped_map _ _)
   classical
@@ -97,15 +91,9 @@ theorem Basis.parallelepiped_basisFun (ι : Type*) [Fintype ι] :
   simp only [map_apply, Pi.basisFun_apply, equivFun_symm_apply, LinearMap.stdBasis_apply',
     Finset.sum_univ_ite]
 
-theorem Basis.parallelepiped_measurable {ι E : Type*} [Fintype ι] [NormedAddCommGroup E]
-    [NormedSpace ℝ E] [MeasurableSpace E] [OpensMeasurableSpace E] (b : Basis ι ℝ E) :
-    MeasurableSet (b.parallelepiped : Set E) := by
-  rw [Basis.parallelepiped_eq_map, PositiveCompacts.coe_map, LinearEquiv.image_symm_eq_preimage]
-  exact (continuous_equivFun_basis _).measurable (PositiveCompacts.piIcc01_measurable ι)
-
 open MeasureTheory MeasureTheory.Measure
 
-theorem Basis.addHaar_map {ι E F : Type*} [Fintype ι] [NormedAddCommGroup E]
+theorem Basis.map_addHaar {ι E F : Type*} [Fintype ι] [NormedAddCommGroup E]
     [NormedSpace ℝ E] [MeasurableSpace E] [BorelSpace E] (b : Basis ι ℝ E)
     [NormedAddCommGroup F] [NormedSpace ℝ F] [TopologicalSpace.SecondCountableTopology F]
     [SigmaCompactSpace F] [MeasurableSpace F] [BorelSpace F] (f : E ≃L[ℝ] F) :
@@ -114,7 +102,7 @@ theorem Basis.addHaar_map {ι E F : Type*} [Fintype ι] [NormedAddCommGroup E]
   AddEquiv.isAddHaarMeasure_map b.addHaar f.toAddEquiv f.continuous f.symm.continuous
   have : SigmaFinite (map f b.addHaar) := MeasureTheory.Measure.IsAddHaarMeasure.sigmaFinite _
   rw [(map f b.addHaar).addHaarMeasure_unique (b.map f.toLinearEquiv).parallelepiped,
-    Measure.map_apply f.continuous.measurable (parallelepiped_measurable _),
+    Measure.map_apply f.continuous.measurable (PositiveCompacts.isCompact _).measurableSet,
     Basis.coe_parallelepiped, Basis.coe_map]
   erw [← image_parallelepiped, f.toEquiv.preimage_image, addHaar_self]
   rw [one_smul, Basis.addHaar]

--- a/Mathlib/MeasureTheory/Measure/Lebesgue/EqHaar.lean
+++ b/Mathlib/MeasureTheory/Measure/Lebesgue/EqHaar.lean
@@ -118,7 +118,7 @@ theorem Basis.addHaar_map {ι E F : Type*} [Fintype ι] [NormedAddCommGroup E]
     Basis.coe_parallelepiped, Basis.coe_map]
   erw [← image_parallelepiped, f.toEquiv.preimage_image, addHaar_self]
   rw [one_smul, Basis.addHaar]
-  
+
 namespace MeasureTheory
 
 open Measure TopologicalSpace.PositiveCompacts FiniteDimensional

--- a/Mathlib/MeasureTheory/Measure/Lebesgue/EqHaar.lean
+++ b/Mathlib/MeasureTheory/Measure/Lebesgue/EqHaar.lean
@@ -82,7 +82,7 @@ theorem Basis.parallelepiped_basisFun (ι : Type*) [Fintype ι] :
  /-- A parallelepiped can be expressed on the standard basis. -/
  theorem Basis.parallelepiped_eq_map  {ι E : Type*} [Fintype ι] [NormedAddCommGroup E]
     [NormedSpace ℝ E] (b : Basis ι ℝ E) :
-    b.parallelepiped = (TopologicalSpace.PositiveCompacts.piIcc01 ι).map b.equivFun.symm
+    b.parallelepiped = (PositiveCompacts.piIcc01 ι).map b.equivFun.symm
       b.equivFunL.symm.continuous b.equivFunL.symm.isOpenMap := by
   rw [← Basis.parallelepiped_basisFun]
   refine (congrArg _ ?_).trans (Basis.parallelepiped_map _ _)
@@ -95,12 +95,12 @@ open MeasureTheory MeasureTheory.Measure
 
 theorem Basis.map_addHaar {ι E F : Type*} [Fintype ι] [NormedAddCommGroup E]
     [NormedSpace ℝ E] [MeasurableSpace E] [BorelSpace E] (b : Basis ι ℝ E)
-    [NormedAddCommGroup F] [NormedSpace ℝ F] [TopologicalSpace.SecondCountableTopology F]
+    [NormedAddCommGroup F] [NormedSpace ℝ F] [SecondCountableTopology F]
     [SigmaCompactSpace F] [MeasurableSpace F] [BorelSpace F] (f : E ≃L[ℝ] F) :
     map f b.addHaar = (b.map f.toLinearEquiv).addHaar := by
   have : IsAddHaarMeasure (map f b.addHaar) :=
   AddEquiv.isAddHaarMeasure_map b.addHaar f.toAddEquiv f.continuous f.symm.continuous
-  have : SigmaFinite (map f b.addHaar) := MeasureTheory.Measure.IsAddHaarMeasure.sigmaFinite _
+  have : SigmaFinite (map f b.addHaar) := IsAddHaarMeasure.sigmaFinite _
   rw [(map f b.addHaar).addHaarMeasure_unique (b.map f.toLinearEquiv).parallelepiped,
     Measure.map_apply f.continuous.measurable (PositiveCompacts.isCompact _).measurableSet,
     Basis.coe_parallelepiped, Basis.coe_map]

--- a/Mathlib/MeasureTheory/Measure/Lebesgue/EqHaar.lean
+++ b/Mathlib/MeasureTheory/Measure/Lebesgue/EqHaar.lean
@@ -79,33 +79,29 @@ theorem Basis.parallelepiped_basisFun (ι : Type*) [Fintype ι] :
     · exact zero_le_one
 #align basis.parallelepiped_basis_fun Basis.parallelepiped_basisFun
 
- /-- A parallelepiped can be expressed on the standard basis. -/
- theorem Basis.parallelepiped_eq_map  {ι E : Type*} [Fintype ι] [NormedAddCommGroup E]
+/-- A parallelepiped can be expressed on the standard basis. -/
+theorem Basis.parallelepiped_eq_map  {ι E : Type*} [Fintype ι] [NormedAddCommGroup E]
     [NormedSpace ℝ E] (b : Basis ι ℝ E) :
     b.parallelepiped = (PositiveCompacts.piIcc01 ι).map b.equivFun.symm
       b.equivFunL.symm.continuous b.equivFunL.symm.isOpenMap := by
-  rw [← Basis.parallelepiped_basisFun]
-  refine (congrArg _ ?_).trans (Basis.parallelepiped_map _ _)
   classical
-  ext
-  simp only [map_apply, Pi.basisFun_apply, equivFun_symm_apply, LinearMap.stdBasis_apply',
+  rw [← Basis.parallelepiped_basisFun, ← Basis.parallelepiped_map]
+  congr
+  ext; simp only [map_apply, Pi.basisFun_apply, equivFun_symm_apply, LinearMap.stdBasis_apply',
     Finset.sum_univ_ite]
 
 open MeasureTheory MeasureTheory.Measure
 
 theorem Basis.map_addHaar {ι E F : Type*} [Fintype ι] [NormedAddCommGroup E]
-    [NormedSpace ℝ E] [MeasurableSpace E] [BorelSpace E] (b : Basis ι ℝ E)
-    [NormedAddCommGroup F] [NormedSpace ℝ F] [SecondCountableTopology F]
+    [NormedSpace ℝ E] [MeasurableSpace E] [BorelSpace E] [SecondCountableTopology E]
+    (b : Basis ι ℝ E) [NormedAddCommGroup F] [NormedSpace ℝ F] [SecondCountableTopology F]
     [SigmaCompactSpace F] [MeasurableSpace F] [BorelSpace F] (f : E ≃L[ℝ] F) :
     map f b.addHaar = (b.map f.toLinearEquiv).addHaar := by
   have : IsAddHaarMeasure (map f b.addHaar) :=
-  AddEquiv.isAddHaarMeasure_map b.addHaar f.toAddEquiv f.continuous f.symm.continuous
-  have : SigmaFinite (map f b.addHaar) := IsAddHaarMeasure.sigmaFinite _
-  rw [(map f b.addHaar).addHaarMeasure_unique (b.map f.toLinearEquiv).parallelepiped,
-    Measure.map_apply f.continuous.measurable (PositiveCompacts.isCompact _).measurableSet,
-    Basis.coe_parallelepiped, Basis.coe_map]
+    AddEquiv.isAddHaarMeasure_map b.addHaar f.toAddEquiv f.continuous f.symm.continuous
+  rw [eq_comm, Basis.addHaar_eq_iff, Measure.map_apply f.continuous.measurable
+    (PositiveCompacts.isCompact _).measurableSet, Basis.coe_parallelepiped, Basis.coe_map]
   erw [← image_parallelepiped, f.toEquiv.preimage_image, addHaar_self]
-  rw [one_smul, Basis.addHaar]
 
 namespace MeasureTheory
 

--- a/Mathlib/MeasureTheory/Measure/Lebesgue/EqHaar.lean
+++ b/Mathlib/MeasureTheory/Measure/Lebesgue/EqHaar.lean
@@ -95,7 +95,7 @@ open MeasureTheory MeasureTheory.Measure
 theorem Basis.map_addHaar {ι E F : Type*} [Fintype ι] [NormedAddCommGroup E] [NormedAddCommGroup F]
     [NormedSpace ℝ E] [NormedSpace ℝ F] [MeasurableSpace E] [MeasurableSpace F] [BorelSpace E]
     [BorelSpace F] [SecondCountableTopology F] [SigmaCompactSpace F]
-    (b : Basis ι ℝ E)  (f : E ≃L[ℝ] F) :
+    (b : Basis ι ℝ E) (f : E ≃L[ℝ] F) :
     map f b.addHaar = (b.map f.toLinearEquiv).addHaar := by
   have : IsAddHaarMeasure (map f b.addHaar) :=
     AddEquiv.isAddHaarMeasure_map b.addHaar f.toAddEquiv f.continuous f.symm.continuous

--- a/Mathlib/MeasureTheory/Measure/Lebesgue/EqHaar.lean
+++ b/Mathlib/MeasureTheory/Measure/Lebesgue/EqHaar.lean
@@ -70,6 +70,10 @@ def TopologicalSpace.PositiveCompacts.piIcc01 (ι : Type*) [Fintype ι] :
       imp_true_iff, zero_lt_one]
 #align topological_space.positive_compacts.pi_Icc01 TopologicalSpace.PositiveCompacts.piIcc01
 
+theorem TopologicalSpace.PositiveCompacts.piIcc01_measurable (ι : Type*) [Fintype ι] :
+    MeasurableSet (TopologicalSpace.PositiveCompacts.piIcc01 ι : Set (ι → ℝ)) := by
+  exact MeasurableSet.pi countable_univ (fun _ _ => measurableSet_Icc)
+
 /-- The parallelepiped formed from the standard basis for `ι → ℝ` is `[0,1]^ι` -/
 theorem Basis.parallelepiped_basisFun (ι : Type*) [Fintype ι] :
     (Pi.basisFun ℝ ι).parallelepiped = TopologicalSpace.PositiveCompacts.piIcc01 ι :=
@@ -79,6 +83,42 @@ theorem Basis.parallelepiped_basisFun (ι : Type*) [Fintype ι] :
     · exact zero_le_one
 #align basis.parallelepiped_basis_fun Basis.parallelepiped_basisFun
 
+ /-- A parallelepiped can be expressed on the standard basis. -/
+ theorem Basis.parallelepiped_eq_map  {ι E : Type*} [Fintype ι] [NormedAddCommGroup E]
+    [NormedSpace ℝ E] (b : Basis ι ℝ E) :
+    b.parallelepiped = (TopologicalSpace.PositiveCompacts.piIcc01 ι).map b.equivFun.symm
+    b.equivFunL.symm.continuous
+      (by have := FiniteDimensional.of_fintype_basis b
+          exact LinearMap.isOpenMap_of_finiteDimensional _ b.equivFun.symm.surjective) := by
+  rw [← Basis.parallelepiped_basisFun]
+  refine (congrArg _ ?_).trans (Basis.parallelepiped_map _ _)
+  classical
+  ext
+  simp only [map_apply, Pi.basisFun_apply, equivFun_symm_apply, LinearMap.stdBasis_apply',
+    Finset.sum_univ_ite]
+
+theorem Basis.parallelepiped_measurable {ι E : Type*} [Fintype ι] [NormedAddCommGroup E]
+    [NormedSpace ℝ E] [MeasurableSpace E] [OpensMeasurableSpace E] (b : Basis ι ℝ E) :
+    MeasurableSet (b.parallelepiped : Set E) := by
+  rw [Basis.parallelepiped_eq_map, PositiveCompacts.coe_map, LinearEquiv.image_symm_eq_preimage]
+  exact (continuous_equivFun_basis _).measurable (PositiveCompacts.piIcc01_measurable ι)
+
+open MeasureTheory MeasureTheory.Measure
+
+theorem Basis.addHaar_map {ι E F : Type*} [Fintype ι] [NormedAddCommGroup E]
+    [NormedSpace ℝ E] [MeasurableSpace E] [BorelSpace E] (b : Basis ι ℝ E)
+    [NormedAddCommGroup F] [NormedSpace ℝ F] [TopologicalSpace.SecondCountableTopology F]
+    [SigmaCompactSpace F] [MeasurableSpace F] [BorelSpace F] (f : E ≃L[ℝ] F) :
+    map f b.addHaar = (b.map f.toLinearEquiv).addHaar := by
+  have : IsAddHaarMeasure (map f b.addHaar) :=
+  AddEquiv.isAddHaarMeasure_map b.addHaar f.toAddEquiv f.continuous f.symm.continuous
+  have : SigmaFinite (map f b.addHaar) := MeasureTheory.Measure.IsAddHaarMeasure.sigmaFinite _
+  rw [(map f b.addHaar).addHaarMeasure_unique (b.map f.toLinearEquiv).parallelepiped,
+    Measure.map_apply f.continuous.measurable (parallelepiped_measurable _),
+    Basis.coe_parallelepiped, Basis.coe_map]
+  erw [← image_parallelepiped, f.toEquiv.preimage_image, addHaar_self]
+  rw [one_smul, Basis.addHaar]
+  
 namespace MeasureTheory
 
 open Measure TopologicalSpace.PositiveCompacts FiniteDimensional

--- a/Mathlib/MeasureTheory/Measure/Lebesgue/EqHaar.lean
+++ b/Mathlib/MeasureTheory/Measure/Lebesgue/EqHaar.lean
@@ -92,10 +92,10 @@ theorem Basis.parallelepiped_eq_map  {ι E : Type*} [Fintype ι] [NormedAddCommG
 
 open MeasureTheory MeasureTheory.Measure
 
-theorem Basis.map_addHaar {ι E F : Type*} [Fintype ι] [NormedAddCommGroup E]
-    [NormedSpace ℝ E] [MeasurableSpace E] [BorelSpace E] [SecondCountableTopology E]
-    (b : Basis ι ℝ E) [NormedAddCommGroup F] [NormedSpace ℝ F] [SecondCountableTopology F]
-    [SigmaCompactSpace F] [MeasurableSpace F] [BorelSpace F] (f : E ≃L[ℝ] F) :
+theorem Basis.map_addHaar {ι E F : Type*} [Fintype ι] [NormedAddCommGroup E] [NormedAddCommGroup F]
+    [NormedSpace ℝ E] [NormedSpace ℝ F] [MeasurableSpace E] [MeasurableSpace F] [BorelSpace E]
+    [BorelSpace F] [SecondCountableTopology F] [SigmaCompactSpace F]
+    (b : Basis ι ℝ E)  (f : E ≃L[ℝ] F) :
     map f b.addHaar = (b.map f.toLinearEquiv).addHaar := by
   have : IsAddHaarMeasure (map f b.addHaar) :=
     AddEquiv.isAddHaarMeasure_map b.addHaar f.toAddEquiv f.continuous f.symm.continuous

--- a/Mathlib/Topology/Algebra/Module/Basic.lean
+++ b/Mathlib/Topology/Algebra/Module/Basic.lean
@@ -1890,6 +1890,9 @@ theorem coe_toHomeomorph (e : M₁ ≃SL[σ₁₂] M₂) : ⇑e.toHomeomorph = e
   rfl
 #align continuous_linear_equiv.coe_to_homeomorph ContinuousLinearEquiv.coe_toHomeomorph
 
+theorem isOpenMap (e : M₁ ≃SL[σ₁₂] M₂) : IsOpenMap e :=
+  (ContinuousLinearEquiv.toHomeomorph e).isOpenMap
+
 theorem image_closure (e : M₁ ≃SL[σ₁₂] M₂) (s : Set M₁) : e '' closure s = closure (e '' s) :=
   e.toHomeomorph.image_closure s
 #align continuous_linear_equiv.image_closure ContinuousLinearEquiv.image_closure


### PR DESCRIPTION
We prove some lemmas that will be useful in following PRs #6832 and #7037, mainly:
```lean
theorem Basis.addHaar_eq {b : Basis ι ℝ E} {b' : Basis ι' ℝ E} :
     b.addHaar = b'.addHaar ↔ b.addHaar b'.parallelepiped = 1

theorem Basis.parallelepiped_eq_map (b : Basis ι ℝ E) :
     b.parallelepiped = (TopologicalSpace.PositiveCompacts.piIcc01 ι).map b.equivFun.symm
       b.equivFunL.symm.continuous

theorem Basis.addHaar_map (b : Basis ι ℝ E) (f : E ≃L[ℝ] F) :
    map f b.addHaar = (b.map f.toLinearEquiv).addHaar
```

Co-authored-by: Eric Wieser <wieser.eric@gmail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
