### PR TITLE
[Merged by Bors] - feat: the quotient category is preadditive

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1159,6 +1159,7 @@ import Mathlib.CategoryTheory.Products.Associator
 import Mathlib.CategoryTheory.Products.Basic
 import Mathlib.CategoryTheory.Products.Bifunctor
 import Mathlib.CategoryTheory.Quotient
+import Mathlib.CategoryTheory.Quotient.Preadditive
 import Mathlib.CategoryTheory.Shift.Basic
 import Mathlib.CategoryTheory.Shift.CommShift
 import Mathlib.CategoryTheory.Shift.Induced

--- a/Mathlib/Algebra/Homology/HomotopyCategory.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory.lean
@@ -38,10 +38,10 @@ def homotopic : HomRel (HomologicalComplex V c) := fun _ _ f g => Nonempty (Homo
 #align homotopic homotopic
 
 instance homotopy_congruence : Congruence (homotopic V c) where
-  isEquiv :=
+  equivalence :=
     { refl := fun C => ⟨Homotopy.refl C⟩
-      symm := fun _ _ ⟨w⟩ => ⟨w.symm⟩
-      trans := fun _ _ _ ⟨w₁⟩ ⟨w₂⟩ => ⟨w₁.trans w₂⟩ }
+      symm := fun ⟨w⟩ => ⟨w.symm⟩
+      trans := fun ⟨w₁⟩ ⟨w₂⟩ => ⟨w₁.trans w₂⟩ }
   compLeft := fun _ _ _ ⟨i⟩ => ⟨i.compLeft _⟩
   compRight := fun _ ⟨i⟩ => ⟨i.compRight _⟩
 #align homotopy_congruence homotopy_congruence

--- a/Mathlib/CategoryTheory/Localization/Construction.lean
+++ b/Mathlib/CategoryTheory/Localization/Construction.lean
@@ -185,7 +185,7 @@ theorem fac : W.Q ⋙ lift G hG = G :=
     (by
       intro X Y f
       simp only [Functor.comp_map, eqToHom_refl, comp_id, id_comp]
-      dsimp [MorphismProperty.Q, Quot.liftOn]
+      dsimp [MorphismProperty.Q, Quot.liftOn, Quotient.functor]
       rw [composePath_toPath])
 #align category_theory.localization.construction.fac CategoryTheory.Localization.Construction.fac
 

--- a/Mathlib/CategoryTheory/Quotient.lean
+++ b/Mathlib/CategoryTheory/Quotient.lean
@@ -148,7 +148,7 @@ lemma compClosure_iff_self [h : Congruence r] {X Y : C} (f g : X ⟶ Y) :
 theorem compClosure_eq_self [h : Congruence r] :
     CompClosure r = r := by
   ext
-  simp only [compClosure_iff_sel]
+  simp only [compClosure_iff_self]
 
 theorem functor_map_eq_iff [h : Congruence r] {X Y : C} (f f' : X ⟶ Y) :
     (functor r).map f = (functor r).map f' ↔ r f f' := by

--- a/Mathlib/CategoryTheory/Quotient.lean
+++ b/Mathlib/CategoryTheory/Quotient.lean
@@ -37,14 +37,12 @@ variable {C : Type _} [Category C] (r : HomRel C)
 from left and right. -/
 class Congruence : Prop where
   /-- `r` is an equivalence on every hom-set. -/
-  isEquiv : ∀ {X Y}, IsEquiv _ (@r X Y)
+  equivalence : ∀ {X Y}, _root_.Equivalence (@r X Y)
   /-- Precomposition with an arrow respects `r`. -/
   compLeft : ∀ {X Y Z} (f : X ⟶ Y) {g g' : Y ⟶ Z}, r g g' → r (f ≫ g) (f ≫ g')
   /-- Postcomposition with an arrow respects `r`. -/
   compRight : ∀ {X Y Z} {f f' : X ⟶ Y} (g : Y ⟶ Z), r f f' → r (f ≫ g) (f' ≫ g)
 #align category_theory.congruence CategoryTheory.Congruence
-
-attribute [instance] Congruence.isEquiv
 
 /-- A type synonym for `C`, thought of as the objects of the quotient category. -/
 @[ext]
@@ -138,23 +136,23 @@ protected theorem sound {a b : C} {f₁ f₂ : a ⟶ b} (h : r f₁ f₂) :
   simpa using Quot.sound (CompClosure.intro (𝟙 a) f₁ f₂ (𝟙 b) h)
 #align category_theory.quotient.sound CategoryTheory.Quotient.sound
 
+@[simp]
+lemma compClosure_iff_self [h : Congruence r] {X Y : C} (f g : X ⟶ Y) :
+    CompClosure r f g ↔ r f g := by
+  constructor
+  . intro hfg
+    induction' hfg with m m' hm
+    exact Congruence.compLeft _ (Congruence.compRight _ (by assumption))
+  . exact CompClosure.of _ _ _
+
+theorem compClosure_eq_self [h : Congruence r] :
+    CompClosure r = r := by aesop_cat
+
 theorem functor_map_eq_iff [h : Congruence r] {X Y : C} (f f' : X ⟶ Y) :
     (functor r).map f = (functor r).map f' ↔ r f f' := by
-  constructor
-  · erw [Quot.eq]
-    intro h
-    induction' h with m m' hm
-    · cases hm
-      apply Congruence.compLeft
-      apply Congruence.compRight
-      assumption
-    · haveI := (h.isEquiv : IsEquiv _ (@r X Y))
-      -- porting note: had to add this line for `refl` (and name the `Congruence` argument)
-      apply refl
-    · apply symm
-      assumption
-    · apply _root_.trans <;> assumption
-  · apply Quotient.sound
+  dsimp
+  rw [Equivalence.quot_mk_eq_iff, compClosure_eq_self r]
+  simpa only [compClosure_eq_self r] using h.equivalence
 #align category_theory.quotient.functor_map_eq_iff CategoryTheory.Quotient.functor_map_eq_iff
 
 variable {D : Type _} [Category D] (F : C ⥤ D)

--- a/Mathlib/CategoryTheory/Quotient.lean
+++ b/Mathlib/CategoryTheory/Quotient.lean
@@ -140,10 +140,10 @@ protected theorem sound {a b : C} {f₁ f₂ : a ⟶ b} (h : r f₁ f₂) :
 lemma compClosure_iff_self [h : Congruence r] {X Y : C} (f g : X ⟶ Y) :
     CompClosure r f g ↔ r f g := by
   constructor
-  . intro hfg
+  · intro hfg
     induction' hfg with m m' hm
     exact Congruence.compLeft _ (Congruence.compRight _ (by assumption))
-  . exact CompClosure.of _ _ _
+  · exact CompClosure.of _ _ _
 
 theorem compClosure_eq_self [h : Congruence r] :
     CompClosure r = r := by aesop_cat

--- a/Mathlib/CategoryTheory/Quotient.lean
+++ b/Mathlib/CategoryTheory/Quotient.lean
@@ -110,13 +110,16 @@ instance category : Category (Quotient r) where
 #align category_theory.quotient.category CategoryTheory.Quotient.category
 
 /-- The functor from a category to its quotient. -/
-@[simps]
 def functor : C ⥤ Quotient r where
   obj a := { as := a }
   map := @fun _ _ f ↦ Quot.mk _ f
 #align category_theory.quotient.functor CategoryTheory.Quotient.functor
 
-noncomputable instance fullFunctor : Full (functor r) where preimage := @fun X Y f ↦ Quot.out f
+noncomputable instance fullFunctor : Full (functor r) where
+  preimage := @fun X Y f ↦ Quot.out f
+  witness f := by
+    dsimp [functor]
+    simp
 
 instance : EssSurj (functor r)
     where mem_essImage Y :=
@@ -152,7 +155,7 @@ theorem compClosure_eq_self [h : Congruence r] :
 
 theorem functor_map_eq_iff [h : Congruence r] {X Y : C} (f f' : X ⟶ Y) :
     (functor r).map f = (functor r).map f' ↔ r f f' := by
-  dsimp
+  dsimp [functor]
   rw [Equivalence.quot_mk_eq_iff, compClosure_eq_self r]
   simpa only [compClosure_eq_self r] using h.equivalence
 #align category_theory.quotient.functor_map_eq_iff CategoryTheory.Quotient.functor_map_eq_iff
@@ -161,7 +164,6 @@ variable {D : Type _} [Category D] (F : C ⥤ D)
   (H : ∀ (x y : C) (f₁ f₂ : x ⟶ y), r f₁ f₂ → F.map f₁ = F.map f₂)
 
 /-- The induced functor on the quotient category. -/
-@[simps]
 def lift : Quotient r ⥤ D where
   obj a := F.obj a.as
   map := @fun a b hf ↦
@@ -180,6 +182,7 @@ theorem lift_spec : functor r ⋙ lift r F H = F := by
   · rintro X
     rfl
   · rintro X Y f
+    dsimp [lift, functor]
     simp
 #align category_theory.quotient.lift_spec CategoryTheory.Quotient.lift_spec
 
@@ -214,7 +217,7 @@ theorem lift.isLift_inv (X : C) : (lift.isLift r F H).inv.app X = 𝟙 (F.obj X)
 theorem lift_map_functor_map {X Y : C} (f : X ⟶ Y) :
     (lift r F H).map ((functor r).map f) = F.map f := by
   rw [← NatIso.naturality_1 (lift.isLift r F H)]
-  dsimp
+  dsimp [lift, functor]
   simp
 #align category_theory.quotient.lift_map_functor_map CategoryTheory.Quotient.lift_map_functor_map
 

--- a/Mathlib/CategoryTheory/Quotient.lean
+++ b/Mathlib/CategoryTheory/Quotient.lean
@@ -136,7 +136,6 @@ protected theorem sound {a b : C} {f₁ f₂ : a ⟶ b} (h : r f₁ f₂) :
   simpa using Quot.sound (CompClosure.intro (𝟙 a) f₁ f₂ (𝟙 b) h)
 #align category_theory.quotient.sound CategoryTheory.Quotient.sound
 
-@[simp]
 lemma compClosure_iff_self [h : Congruence r] {X Y : C} (f g : X ⟶ Y) :
     CompClosure r f g ↔ r f g := by
   constructor
@@ -145,8 +144,11 @@ lemma compClosure_iff_self [h : Congruence r] {X Y : C} (f g : X ⟶ Y) :
     exact Congruence.compLeft _ (Congruence.compRight _ (by assumption))
   · exact CompClosure.of _ _ _
 
+@[simp]
 theorem compClosure_eq_self [h : Congruence r] :
-    CompClosure r = r := by aesop_cat
+    CompClosure r = r := by
+  ext
+  simp only [compClosure_iff_sel]
 
 theorem functor_map_eq_iff [h : Congruence r] {X Y : C} (f f' : X ⟶ Y) :
     (functor r).map f = (functor r).map f' ↔ r f f' := by

--- a/Mathlib/CategoryTheory/Quotient/Preadditive.lean
+++ b/Mathlib/CategoryTheory/Quotient/Preadditive.lean
@@ -55,13 +55,13 @@ with the addition. -/
 def preadditive : Preadditive (Quotient r) where
   homGroup P Q :=
     { add := Preadditive.add r hr
-      add_assoc := by rintro ⟨_⟩ ⟨_⟩ ⟨_⟩ ; exact congr_arg (functor r).map (add_assoc _ _ _)
+      add_assoc := by rintro ⟨_⟩ ⟨_⟩ ⟨_⟩; exact congr_arg (functor r).map (add_assoc _ _ _)
       zero := Quot.mk _ 0
-      zero_add := by rintro ⟨_⟩ ; exact congr_arg (functor r).map (zero_add _)
-      add_zero := by rintro ⟨_⟩ ; exact congr_arg (functor r).map (add_zero _)
-      add_comm := by rintro ⟨_⟩ ⟨_⟩ ; exact congr_arg (functor r).map (add_comm _ _)
+      zero_add := by rintro ⟨_⟩; exact congr_arg (functor r).map (zero_add _)
+      add_zero := by rintro ⟨_⟩; exact congr_arg (functor r).map (add_zero _)
+      add_comm := by rintro ⟨_⟩ ⟨_⟩; exact congr_arg (functor r).map (add_comm _ _)
       neg := Preadditive.neg r hr
-      add_left_neg := by rintro ⟨_⟩ ; exact congr_arg (functor r).map (add_left_neg _) }
+      add_left_neg := by rintro ⟨_⟩; exact congr_arg (functor r).map (add_left_neg _) }
   add_comp := by
     rintro _ _ _ ⟨_⟩ ⟨_⟩ ⟨_⟩
     exact congr_arg (functor r).map (by apply Preadditive.add_comp)

--- a/Mathlib/CategoryTheory/Quotient/Preadditive.lean
+++ b/Mathlib/CategoryTheory/Quotient/Preadditive.lean
@@ -1,0 +1,80 @@
+/-
+Copyright (c) 2023 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+import Mathlib.CategoryTheory.Quotient
+import Mathlib.CategoryTheory.Preadditive.AdditiveFunctor
+
+/-!
+# The quotient category is preadditive
+
+If an equivalence relation `r : HomRel C` on the morphisms of a preadditive category
+is compatible with the addition, then the quotient category `Quotient r` is also
+preadditive.
+
+-/
+
+namespace CategoryTheory
+
+namespace Quotient
+
+variable {C : Type _} [Category C] [Preadditive C] (r : HomRel C) [Congruence r]
+  (hr : ∀ ⦃X Y : C⦄ (f₁ f₂ g₁ g₂ : X ⟶ Y) (_ : r f₁ f₂) (_ : r g₁ g₂), r (f₁ + g₁) (f₂ + g₂))
+
+namespace Preadditive
+
+/-- The addition on the morphisms in the category `Quotient r` when `r` is compatible
+with the addition. -/
+def add {X Y : Quotient r} (f g : X ⟶ Y) : X ⟶ Y :=
+  Quot.liftOn₂ f g (fun a b => Quot.mk _ (a + b))
+    (fun f g₁ g₂ h₁₂ => by
+      simp only [compClosure_iff_self] at h₁₂
+      erw [functor_map_eq_iff]
+      exact hr _ _ _ _ (Congruence.isEquiv.refl f) h₁₂)
+    (fun f₁ f₂ g h₁₂ => by
+      simp only [compClosure_iff_self] at h₁₂
+      erw [functor_map_eq_iff]
+      exact hr _ _ _ _ h₁₂ (Congruence.isEquiv.refl g))
+
+/-- The negation on the morphisms in the category `Quotient r` when `r` is compatible
+with the addition. -/
+def neg {X Y : Quotient r} (f : X ⟶ Y) : X ⟶ Y :=
+  Quot.liftOn f (fun a => Quot.mk _ (-a))
+    (fun f g => by
+      intro hfg
+      simp only [compClosure_iff_self] at hfg
+      erw [functor_map_eq_iff]
+      apply Congruence.isEquiv.symm
+      convert hr f g _ _ hfg (Congruence.isEquiv.refl (-f-g)) using 1 <;> abel)
+
+end Preadditive
+
+/-- The preadditive structure on the category `Quotient r` when `r` is compatible
+with the addition. -/
+def preadditive : Preadditive (Quotient r) where
+  homGroup P Q :=
+    { add := Preadditive.add r hr
+      add_assoc := by rintro ⟨_⟩ ⟨_⟩ ⟨_⟩ ; exact congr_arg (functor r).map (add_assoc _ _ _)
+      zero := Quot.mk _ 0
+      zero_add := by rintro ⟨_⟩ ; exact congr_arg (functor r).map (zero_add _)
+      add_zero := by rintro ⟨_⟩ ; exact congr_arg (functor r).map (add_zero _)
+      add_comm := by rintro ⟨_⟩ ⟨_⟩ ; exact congr_arg (functor r).map (add_comm _ _)
+      neg := Preadditive.neg r hr
+      add_left_neg := by rintro ⟨_⟩ ; exact congr_arg (functor r).map (add_left_neg _) }
+  add_comp := by
+    rintro _ _ _ ⟨_⟩ ⟨_⟩ ⟨_⟩
+    exact congr_arg (functor r).map (by apply Preadditive.add_comp)
+  comp_add := by
+    rintro _ _ _ ⟨_⟩ ⟨_⟩ ⟨_⟩
+    exact congr_arg (functor r).map (by apply Preadditive.comp_add)
+
+lemma functor_additive :
+    letI := preadditive r hr
+    (functor r).Additive :=
+  letI := preadditive r hr
+  { map_add := rfl }
+
+end Quotient
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/Quotient/Preadditive.lean
+++ b/Mathlib/CategoryTheory/Quotient/Preadditive.lean
@@ -31,11 +31,11 @@ def add {X Y : Quotient r} (f g : X ⟶ Y) : X ⟶ Y :=
     (fun f g₁ g₂ h₁₂ => by
       simp only [compClosure_iff_self] at h₁₂
       erw [functor_map_eq_iff]
-      exact hr _ _ _ _ (Congruence.isEquiv.refl f) h₁₂)
+      exact hr _ _ _ _ (Congruence.equivalence.refl f) h₁₂)
     (fun f₁ f₂ g h₁₂ => by
       simp only [compClosure_iff_self] at h₁₂
       erw [functor_map_eq_iff]
-      exact hr _ _ _ _ h₁₂ (Congruence.isEquiv.refl g))
+      exact hr _ _ _ _ h₁₂ (Congruence.equivalence.refl g))
 
 /-- The negation on the morphisms in the category `Quotient r` when `r` is compatible
 with the addition. -/
@@ -45,8 +45,8 @@ def neg {X Y : Quotient r} (f : X ⟶ Y) : X ⟶ Y :=
       intro hfg
       simp only [compClosure_iff_self] at hfg
       erw [functor_map_eq_iff]
-      apply Congruence.isEquiv.symm
-      convert hr f g _ _ hfg (Congruence.isEquiv.refl (-f-g)) using 1 <;> abel)
+      apply Congruence.equivalence.symm
+      convert hr f g _ _ hfg (Congruence.equivalence.refl (-f-g)) using 1 <;> abel)
 
 end Preadditive
 

--- a/Mathlib/Data/Quot.lean
+++ b/Mathlib/Data/Quot.lean
@@ -837,11 +837,11 @@ end Quotient
 lemma Equivalence.quot_mk_eq_iff {α : Type _} {r : α → α → Prop} (h : Equivalence r) (x y : α) :
     Quot.mk r x = Quot.mk r y ↔ r x y := by
   constructor
-  . rw [Quot.eq]
+  · rw [Quot.eq]
     intro hxy
     induction hxy with
     | rel _ _ H => exact H
     | refl _ => exact h.refl _
     | symm _ _ _ H => exact h.symm H
     | trans _ _ _ _ _ h₁₂ h₂₃ => exact h.trans h₁₂ h₂₃
-  . exact Quot.sound
+  · exact Quot.sound

--- a/Mathlib/Data/Quot.lean
+++ b/Mathlib/Data/Quot.lean
@@ -833,3 +833,15 @@ instance (q₁ : Quotient s₁) (q₂ : Quotient s₂) (f : α → β → Prop)
   Quotient.lift₂.decidablePred _ h _ _
 
 end Quotient
+
+lemma Equivalence.quot_mk_eq_iff {α : Type _} {r : α → α → Prop} (h : Equivalence r) (x y : α) :
+    Quot.mk r x = Quot.mk r y ↔ r x y := by
+  constructor
+  . rw [Quot.eq]
+    intro hxy
+    induction hxy with
+    | rel _ _ H => exact H
+    | refl _ => exact h.refl _
+    | symm _ _ _ H => exact h.symm H
+    | trans _ _ _ _ _ h₁₂ h₂₃ => exact h.trans h₁₂ h₂₃
+  . exact Quot.sound

--- a/Mathlib/Data/Quot.lean
+++ b/Mathlib/Data/Quot.lean
@@ -834,6 +834,7 @@ instance (q₁ : Quotient s₁) (q₂ : Quotient s₂) (f : α → β → Prop)
 
 end Quotient
 
+@[simp]
 lemma Equivalence.quot_mk_eq_iff {α : Type _} {r : α → α → Prop} (h : Equivalence r) (x y : α) :
     Quot.mk r x = Quot.mk r y ↔ r x y := by
   constructor


### PR DESCRIPTION
It is shown in this PR that when an equivalence relation on morphisms in a preadditive category is compatible with the addition, then the quotient category is preadditive.

---

This PR also replaces `IsEquiv` by `_root_.Equivalence` for the definition of `Congruence`, and adds a basic lemma `Equivalence.quot_mk_eq_iff`.


<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
