### PR TITLE
[Merged by Bors] - chore(RingTheory/Nilpotent): untwine two universes

### DIFF
--- a/Mathlib/RingTheory/Nilpotent.lean
+++ b/Mathlib/RingTheory/Nilpotent.lean
@@ -30,7 +30,7 @@ universe u v
 
 open BigOperators
 
-variable {R S : Type u} {x y : R}
+variable {R S : Type*} {x y : R}
 
 /-- An element is said to be nilpotent if some natural-number-power of it equals zero.
 


### PR DESCRIPTION
A simple replacement: `R S : Type u` changes to `R S : Type*`.  Before this change, the example below failed:
```lean
variable {A B : Type*} [MonoidWithZero A] [MonoidWithZero B]

example {a : A} (ha : IsNilpotent a) (f : A →*₀ B) : IsNilpotent (f a) := by
  exact ha.map f
```

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
