### PR TITLE
[Merged by Bors] - chore: fix docstrings, names and aligns about paracompacity of emetric spaces

### DIFF
--- a/Mathlib/Topology/EMetricSpace/Paracompact.lean
+++ b/Mathlib/Topology/EMetricSpace/Paracompact.lean
@@ -15,9 +15,9 @@ import Mathlib.Topology.Paracompact
 
 In this file we provide two instances:
 
-* `EMetric.ParacompactSpace`: a `PseudoEMetricSpace` is paracompact; formalization is based
+* `EMetric.instParacompactSpace`: a `PseudoEMetricSpace` is paracompact; formalization is based
   on [MR0236876];
-* `EMetric.normal_of_metric`: an `EMetricSpace` is a normal topological space.
+* `EMetric.instNormalSpace`: an `EMetricSpace` is a normal topological space.
 
 ## TODO
 
@@ -37,7 +37,7 @@ namespace EMetric
 -- See note [lower instance priority]
 /-- A `PseudoEMetricSpace` is always a paracompact space. Formalization is based
 on [MR0236876]. -/
-instance (priority := 100) [PseudoEMetricSpace α] : ParacompactSpace α := by
+instance (priority := 100) instParacompactSpace [PseudoEMetricSpace α] : ParacompactSpace α := by
   /- We start with trivial observations about `1 / 2 ^ k`. Here and below we use `1 / 2 ^ k` in
     the comments and `2⁻¹ ^ k` in the code. -/
   have pow_pos : ∀ k : ℕ, (0 : ℝ≥0∞) < 2⁻¹ ^ k := fun k =>
@@ -164,10 +164,11 @@ instance (priority := 100) [PseudoEMetricSpace α] : ParacompactSpace α := by
     simp only [mem_iUnion]
     refine' ⟨I.1, _, I.2, hI, rfl⟩
     exact not_lt.1 fun hlt => (Hgt I.1 hlt I.2).le_bot hI.choose_spec
+#align emetric.paracompact_space EMetric.instParacompactSpace
 
 -- see Note [lower instance priority]
-instance (priority := 100) normal_of_emetric [EMetricSpace α] : NormalSpace α :=
+instance (priority := 100) instNormalSpace [EMetricSpace α] : NormalSpace α :=
   normal_of_paracompact_t2
-#align emetric.normal_of_emetric EMetric.normal_of_emetric
+#align emetric.normal_of_emetric EMetric.instNormalSpace
 
 end EMetric

--- a/Mathlib/Topology/Paracompact.lean
+++ b/Mathlib/Topology/Paracompact.lean
@@ -34,7 +34,7 @@ We also prove the following facts.
 * Every paracompact Hausdorff space is normal. This statement is not an instance to avoid loops in
   the instance graph.
 
-* Every `EMetricSpace` is a paracompact space, see instance `EMetricSpace.ParacompactSpace` in
+* Every `EMetricSpace` is a paracompact space, see instance `EMetric.instParacompactSpace` in
   `Topology/EMetricSpace/Paracompact`.
 
 ## TODO


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
