### PR TITLE
[Merged by Bors] - chore(Util/Imports): accumulate imports in find_home to log once

### DIFF
--- a/Mathlib/Util/Imports.lean
+++ b/Mathlib/Util/Imports.lean
@@ -175,6 +175,9 @@ Find locations as high as possible in the import hierarchy
 where the named declaration could live.
 -/
 elab "#find_home" n:ident : command => do
+  let stx ← getRef
+  let mut homes := #[]
   let n ← resolveGlobalConstNoOverloadWithInfo n
   for i in (← Elab.Command.liftCoreM do n.findHome) do
-    logInfo i
+    homes := homes.push i
+  logInfoAt stx[0] m!"{homes}"


### PR DESCRIPTION
Currently, `#find_home` prints each possible import separately.  This PR makes it print them all as a single list.

It also makes sure that the results are displayed at `#find_home` alone, rather than the whole `#find_home new_lemma` call.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
