### PR TITLE
[Merged by Bors] - fix: `replace` does not work when importing `Mathlib.Tactic.Replace`

### DIFF
--- a/Mathlib/Tactic/Replace.lean
+++ b/Mathlib/Tactic/Replace.lean
@@ -3,7 +3,7 @@ Copyright (c) 2017 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Arthur Paulino, Mario Carneiro
 -/
-import Std
+import Std.Tactic.Replace
 import Mathlib.Tactic.Have
 
 namespace Mathlib.Tactic

--- a/Mathlib/Tactic/Replace.lean
+++ b/Mathlib/Tactic/Replace.lean
@@ -3,7 +3,7 @@ Copyright (c) 2017 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Arthur Paulino, Mario Carneiro
 -/
-import Lean
+import Std
 import Mathlib.Tactic.Have
 
 namespace Mathlib.Tactic

--- a/test/Replace.lean
+++ b/test/Replace.lean
@@ -7,6 +7,11 @@ import Mathlib.Tactic.Replace
 
 set_option linter.unusedVariables false
 
+/-- Test the `:=` syntax works -/
+example {A B : Type} (h : A) (f : A → B) : B := by
+  replace h := f h
+  exact h
+
 -- tests without `:=`, creating a new subgoal
 
 example (z : Int) : Nat := by


### PR DESCRIPTION
`replace a := f a` does not work when only importing `Mathlib.Tactic.Replace`.

---

Without this import, the following MWE fails ([webeditor](https://lean.math.hhu.de/#code=import%20Mathlib.Tactic.Replace%0A--%20import%20Std%0A%0Aexample%20(h%20%3A%20A)%20(f%20%3A%20A%20%E2%86%92%20B)%20%3A%20B%20%3A%3D%20by%0A%20%20replace%20h%20%3A%3D%20f%20h%20--%20Syntax%20error%3A%20%22expected%20command%22%0A%20%20exact%20h%0A)):

```lean
import Mathlib.Tactic.Replace
-- import Std

example (h : A) (f : A → B) : B := by
  replace h := f h -- Syntax error: "expected command"
  exact h
```

A minimal import from within Mathlib to add would be `import Mathlib.Tactic.Basic`. Would that be preferred?

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
