### PR TITLE
[Merged by Bors] - chore: delete redundant commented-out positivity test

### DIFF
--- a/test/positivity.lean
+++ b/test/positivity.lean
@@ -165,8 +165,6 @@ example {a b : ℚ} (ha : 3 < a) (hb : 4 ≤ b) : 0 < 3 + a * b / 7 + b + 7 + 14
 
 example {a b : ℤ} (ha : 3 < a) (hb : 4 ≤ b) : 0 < 3 + a * b / 7 + b + 7 + 14 := by positivity
 
--- example {a : ℤ} (ha : 0 < a) : 0 < a / a := by positivity
-
 /-! ### Exponentiation -/
 
 example [OrderedSemiring α] [Nontrivial α] (a : α) : 0 < a ^ 0 := by positivity


### PR DESCRIPTION
In #1391, this exact test was added farther up in the file (along with other integer division tests):
https://github.com/leanprover-community/mathlib4/blob/a5c7037917334676f4a8af94f2c98f773adae880/test/positivity.lean#L128

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
