### PR TITLE
fix: remove a heartbeat bump

### DIFF
--- a/Mathlib/RepresentationTheory/GroupCohomology/Basic.lean
+++ b/Mathlib/RepresentationTheory/GroupCohomology/Basic.lean
@@ -183,7 +183,7 @@ variable [Group G] (n) (A : Rep k G)
 
 open InhomogeneousCochains
 
-set_option maxHeartbeats 2400000 in
+set_option maxHeartbeats 800000 in
 /-- Given a `k`-linear `G`-representation `A`, this is the complex of inhomogeneous cochains
 $$0 \to \mathrm{Fun}(G^0, A) \to \mathrm{Fun}(G^1, A) \to \mathrm{Fun}(G^2, A) \to \dots$$
 which calculates the group cohomology of `A`. -/
@@ -210,7 +210,7 @@ noncomputable abbrev inhomogeneousCochains : CochainComplex (ModuleCat k) ℕ :=
     exact map_zero _
 #align group_cohomology.inhomogeneous_cochains GroupCohomology.inhomogeneousCochains
 
-set_option maxHeartbeats 2000000 in
+set_option maxHeartbeats 4000000 in
 /-- Given a `k`-linear `G`-representation `A`, the complex of inhomogeneous cochains is isomorphic
 to `Hom(P, A)`, where `P` is the standard resolution of `k` as a trivial `G`-representation. -/
 def inhomogeneousCochainsIso : inhomogeneousCochains A ≅ linearYonedaObjResolution A := by
@@ -220,7 +220,13 @@ def inhomogeneousCochainsIso : inhomogeneousCochains A ≅ linearYonedaObjResolu
   rintro i j (h : i + 1 = j)
   subst h
   simp only [CochainComplex.of_d, d_eq, Category.assoc, Iso.symm_hom, Iso.hom_inv_id,
+    Category.comp_id, aux_equiv]
+  erw [LinearEquiv.refl_trans]
+  erw [LinearEquiv.refl_trans]
+  simp only [Iso.symm_hom, Iso.hom_inv_id,
     Category.comp_id]
+  done
+
 #align group_cohomology.inhomogeneous_cochains_iso GroupCohomology.inhomogeneousCochainsIso
 
 end GroupCohomology
@@ -232,6 +238,21 @@ of inhomogeneous cochains. -/
 def groupCohomology [Group G] (A : Rep k G) (n : ℕ) : ModuleCat k :=
   (inhomogeneousCochains A).homology n
 #align group_cohomology groupCohomology
+
+-- variable [Group G] (A : Rep k G) (n : ℕ)
+
+-- count_heartbeats in
+-- example : HomologicalComplex.homology
+--                     (HomologicalComplex.unop
+--                       ((CategoryTheory.Functor.mapHomologicalComplex
+--                             ((CategoryTheory.linearYoneda k (Rep k G)).obj A).rightOp (ComplexShape.down ℕ)).obj
+--                         (GroupCohomology.resolution k G)))
+--                     n = (homologyFunctor (ModuleCat k) (ComplexShape.up ℕ) n).obj
+--                     (GroupCohomology.linearYonedaObjResolution A) := by
+--   unfold GroupCohomology.linearYonedaObjResolution
+--   -- quick with this; super-slow without
+--   --rw [homologyFunctor_obj]
+--   rfl
 
 set_option maxHeartbeats 3200000 in
 /-- The `n`th group cohomology of a `k`-linear `G`-representation `A` is isomorphic to

--- a/Mathlib/RepresentationTheory/GroupCohomology/Basic.lean
+++ b/Mathlib/RepresentationTheory/GroupCohomology/Basic.lean
@@ -244,13 +244,13 @@ variable [Group G] (A : Rep k G) (n : ℕ)
 
 count_heartbeats in
 example : HomologicalComplex.homology
-                    (HomologicalComplex.unop
-                      ((CategoryTheory.Functor.mapHomologicalComplex
-                            ((CategoryTheory.linearYoneda k (Rep k G)).obj A).rightOp (ComplexShape.down ℕ)).obj
-                        (GroupCohomology.resolution k G)))
-                    n = (homologyFunctor (ModuleCat k) (ComplexShape.up ℕ) n).obj
-                    (GroupCohomology.linearYonedaObjResolution A) := by
-  unfold GroupCohomology.linearYonedaObjResolution
+  (HomologicalComplex.unop
+    ((CategoryTheory.Functor.mapHomologicalComplex
+          ((CategoryTheory.linearYoneda k (Rep k G)).obj A).rightOp (ComplexShape.down ℕ)).obj
+      (GroupCohomology.resolution k G)))
+  n = (homologyFunctor (ModuleCat k) (ComplexShape.up ℕ) n).obj
+  (GroupCohomology.linearYonedaObjResolution A) := by
+unfold GroupCohomology.linearYonedaObjResolution
   -- quick with this; super-slow without
   --rw [homologyFunctor_obj]
   rfl

--- a/Mathlib/RepresentationTheory/GroupCohomology/Basic.lean
+++ b/Mathlib/RepresentationTheory/GroupCohomology/Basic.lean
@@ -239,20 +239,22 @@ def groupCohomology [Group G] (A : Rep k G) (n : ℕ) : ModuleCat k :=
   (inhomogeneousCochains A).homology n
 #align group_cohomology groupCohomology
 
--- variable [Group G] (A : Rep k G) (n : ℕ)
+/-
+variable [Group G] (A : Rep k G) (n : ℕ)
 
--- count_heartbeats in
--- example : HomologicalComplex.homology
---                     (HomologicalComplex.unop
---                       ((CategoryTheory.Functor.mapHomologicalComplex
---                             ((CategoryTheory.linearYoneda k (Rep k G)).obj A).rightOp (ComplexShape.down ℕ)).obj
---                         (GroupCohomology.resolution k G)))
---                     n = (homologyFunctor (ModuleCat k) (ComplexShape.up ℕ) n).obj
---                     (GroupCohomology.linearYonedaObjResolution A) := by
---   unfold GroupCohomology.linearYonedaObjResolution
---   -- quick with this; super-slow without
---   --rw [homologyFunctor_obj]
---   rfl
+count_heartbeats in
+example : HomologicalComplex.homology
+                    (HomologicalComplex.unop
+                      ((CategoryTheory.Functor.mapHomologicalComplex
+                            ((CategoryTheory.linearYoneda k (Rep k G)).obj A).rightOp (ComplexShape.down ℕ)).obj
+                        (GroupCohomology.resolution k G)))
+                    n = (homologyFunctor (ModuleCat k) (ComplexShape.up ℕ) n).obj
+                    (GroupCohomology.linearYonedaObjResolution A) := by
+  unfold GroupCohomology.linearYonedaObjResolution
+  -- quick with this; super-slow without
+  --rw [homologyFunctor_obj]
+  rfl
+-/
 
 set_option maxHeartbeats 3200000 in
 /-- The `n`th group cohomology of a `k`-linear `G`-representation `A` is isomorphic to

--- a/Mathlib/RepresentationTheory/GroupCohomology/Basic.lean
+++ b/Mathlib/RepresentationTheory/GroupCohomology/Basic.lean
@@ -116,16 +116,27 @@ def d [Monoid G] (n : ℕ) (A : Rep k G) : ((Fin n → G) → A) →ₗ[k] (Fin 
 
 variable [Group G] (n) (A : Rep k G)
 
-/- Porting note: linter says the statement doesn't typecheck, so we add `@[nolint checkType]` -/
-set_option maxHeartbeats 700000 in
+-- The reason to make the below declaration explicit is that whilst the terms are definitionally
+-- equal, they're not syntactically equal and the `k`-module structures are hence not obviously
+-- equal; they are, but this seems to involve a lot of unfolding. Note that the definition
+-- unfolds to `id`.
+
+/-- An auxiliary isomorphism between two definitionally equal `k`-modules which shows up
+in the definition `InhomogeneousCochains.d_eq`. -/
+def aux_equiv :
+    ((Opposite.op (HomologicalComplex.X (GroupCohomology.resolution k G) n)).unop ⟶ A) ≃ₗ[k]
+    (Rep.ofMulAction k G (Fin (n + 1) → G) ⟶ A) := LinearEquiv.refl k _
+
 /-- The theorem that our isomorphism `Fun(Gⁿ, A) ≅ Hom(k[Gⁿ⁺¹], A)` (where the righthand side is
 morphisms in `Rep k G`) commutes with the differentials in the complex of inhomogeneous cochains
 and the homogeneous `linearYonedaObjResolution`. -/
-@[nolint checkType] theorem d_eq :
+theorem d_eq :
     d n A =
-      (diagonalHomEquiv n A).toModuleIso.inv ≫
+      -- adding (foo n A).trans makes everything quick and the same proof still works
+      ((aux_equiv n A).trans (diagonalHomEquiv n A)).toModuleIso.inv ≫
         (linearYonedaObjResolution A).d n (n + 1) ≫
-          (diagonalHomEquiv (n + 1) A).toModuleIso.hom := by
+          -- also add it here
+          ((aux_equiv (n + 1) A).trans (diagonalHomEquiv (n + 1) A)).toModuleIso.hom := by
   ext f g
 /- Porting note: broken proof was
   simp only [ModuleCat.coe_comp, LinearEquiv.coe_coe, Function.comp_apply,


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

An interesting phenomenon here: we have two k-modules X and Y, and X=Y with quick `rfl` proof, but the equality isn't syntactic and typeclass inference finds k-module structures on `X` and `Y` which are not obviously equal. They are, but `rfl` takes a long time to check this. On master right now this defeq abuse causes a huge slowdown in the declaration `d_eq`. We bump up the equality to a k-linear isomorphism (which costs some time, but not enough to need a heartbeat bump) but then we use the isomorphism explicitly in `d_eq`, which saves far more time (and in particular enables us to remove a 700000 heartbeat bump).
