### PR TITLE
[Merged by Bors] - docs: make `sub_neg` refer to `sub_neg_eq_add`

### DIFF
--- a/Mathlib/Algebra/Order/Group/Defs.lean
+++ b/Mathlib/Algebra/Order/Group/Defs.lean
@@ -890,7 +890,7 @@ alias ⟨lt_of_sub_pos, sub_pos_of_lt⟩ := sub_pos
 #align lt_of_sub_pos lt_of_sub_pos
 #align sub_pos_of_lt sub_pos_of_lt
 
-@[to_additive (attr := simp) sub_neg "For a - -b = a + b, see `sub_neg_eq_add`."]
+@[to_additive (attr := simp) sub_neg "For `a - -b = a + b`, see `sub_neg_eq_add`."]
 theorem div_lt_one' : a / b < 1 ↔ a < b := by
   rw [← mul_lt_mul_iff_right b, one_mul, div_eq_mul_inv, inv_mul_cancel_right]
 #align div_lt_one' div_lt_one'

--- a/Mathlib/Algebra/Order/Group/Defs.lean
+++ b/Mathlib/Algebra/Order/Group/Defs.lean
@@ -890,7 +890,7 @@ alias ⟨lt_of_sub_pos, sub_pos_of_lt⟩ := sub_pos
 #align lt_of_sub_pos lt_of_sub_pos
 #align sub_pos_of_lt sub_pos_of_lt
 
-@[to_additive (attr := simp) sub_neg]
+@[to_additive (attr := simp) sub_neg "For a - -b = a + b, see `sub_neg_eq_add`."]
 theorem div_lt_one' : a / b < 1 ↔ a < b := by
   rw [← mul_lt_mul_iff_right b, one_mul, div_eq_mul_inv, inv_mul_cancel_right]
 #align div_lt_one' div_lt_one'


### PR DESCRIPTION
I'm not a fan of this naming :/


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
