### PR TITLE
refactor: generalize IsIntegrallyClosed away from fraction fields

### DIFF
--- a/Mathlib/Algebra/GCDMonoid/IntegrallyClosed.lean
+++ b/Mathlib/Algebra/GCDMonoid/IntegrallyClosed.lean
@@ -36,7 +36,7 @@ instance (priority := 100) GCDMonoid.toIsIntegrallyClosed : IsIntegrallyClosed R
   ⟨fun {X} ⟨p, hp₁, hp₂⟩ => by
     obtain ⟨x, y, hg, he⟩ := IsLocalization.surj_of_gcd_domain (nonZeroDivisors R) X
     have :=
-      Polynomial.dvd_pow_natDegree_of_eval₂_eq_zero (IsFractionRing.injective R <| A)
+      Polynomial.dvd_pow_natDegree_of_eval₂_eq_zero (IsFractionRing.injective R A)
         hp₁ y x _ hp₂ (by rw [mul_comm, he])
     have : IsUnit y := by
       rw [isUnit_iff_dvd_one, ← one_pow]

--- a/Mathlib/Algebra/GCDMonoid/IntegrallyClosed.lean
+++ b/Mathlib/Algebra/GCDMonoid/IntegrallyClosed.lean
@@ -30,11 +30,13 @@ theorem IsLocalization.surj_of_gcd_domain (M : Submonoid R) [IsLocalization M A]
   rw [Subtype.coe_mk, hy', ← mul_comm y', mul_assoc]; conv_lhs => rw [hx']
 #align is_localization.surj_of_gcd_domain IsLocalization.surj_of_gcd_domain
 
-instance (priority := 100) GCDMonoid.toIsIntegrallyClosed : IsIntegrallyClosed R :=
+variable [IsFractionRing R A]
+
+instance (priority := 100) GCDMonoid.toIsIntegrallyClosed : IsIntegrallyClosed R A :=
   ⟨fun {X} ⟨p, hp₁, hp₂⟩ => by
     obtain ⟨x, y, hg, he⟩ := IsLocalization.surj_of_gcd_domain (nonZeroDivisors R) X
     have :=
-      Polynomial.dvd_pow_natDegree_of_eval₂_eq_zero (IsFractionRing.injective R <| FractionRing R)
+      Polynomial.dvd_pow_natDegree_of_eval₂_eq_zero (IsFractionRing.injective R <| A)
         hp₁ y x _ hp₂ (by rw [mul_comm, he])
     have : IsUnit y := by
       rw [isUnit_iff_dvd_one, ← one_pow]

--- a/Mathlib/FieldTheory/Minpoly/IsIntegrallyClosed.lean
+++ b/Mathlib/FieldTheory/Minpoly/IsIntegrallyClosed.lean
@@ -42,7 +42,7 @@ section
 variable (K L : Type*) [Field K] [Algebra R K] [IsFractionRing R K] [Field L] [Algebra R L]
   [Algebra S L] [Algebra K L] [IsScalarTower R K L] [IsScalarTower R S L]
 
-variable [IsIntegrallyClosed R]
+variable [IsIntegrallyClosed R K]
 
 /-- For integrally closed domains, the minimal polynomial over the ring is the same as the minimal
 polynomial over the fraction field. See `minpoly.isIntegrallyClosed_eq_field_fractions'` if
@@ -71,7 +71,7 @@ end
 
 variable [IsDomain S] [NoZeroSMulDivisors R S]
 
-variable [IsIntegrallyClosed R]
+variable [IsIntegrallyClosed R (FractionRing R)]
 
 /-- For integrally closed rings, the minimal polynomial divides any polynomial that has the
   integral element as root. See also `minpoly.dvd` which relaxes the assumptions on `S`

--- a/Mathlib/NumberTheory/FunctionField.lean
+++ b/Mathlib/NumberTheory/FunctionField.lean
@@ -132,8 +132,8 @@ variable [FunctionField Fq F]
 instance : IsFractionRing (ringOfIntegers Fq F) F :=
   integralClosure.isFractionRing_of_finite_extension (RatFunc Fq) F
 
-instance : IsIntegrallyClosed (ringOfIntegers Fq F) :=
-  integralClosure.isIntegrallyClosedOfFiniteExtension (RatFunc Fq)
+instance : IsIntegrallyClosed (ringOfIntegers Fq F) F :=
+  integralClosure.isIntegrallyClosed
 
 instance [IsSeparable (RatFunc Fq) F] : IsNoetherian Fq[X] (ringOfIntegers Fq F) :=
   IsIntegralClosure.isNoetherian _ (RatFunc Fq) F _

--- a/Mathlib/NumberTheory/KummerDedekind.lean
+++ b/Mathlib/NumberTheory/KummerDedekind.lean
@@ -214,7 +214,7 @@ namespace KummerDedekind
 
 open scoped BigOperators Polynomial Classical
 
-variable [IsDomain R] [IsIntegrallyClosed R]
+variable [IsDomain R] [IsIntegrallyClosed R (FractionRing R)]
 
 variable [IsDomain S] [IsDedekindDomain S]
 

--- a/Mathlib/NumberTheory/NumberField/Basic.lean
+++ b/Mathlib/NumberTheory/NumberField/Basic.lean
@@ -105,8 +105,8 @@ instance [NumberField K] : IsFractionRing (𝓞 K) K :=
 instance : IsIntegralClosure (𝓞 K) ℤ K :=
   integralClosure.isIntegralClosure _ _
 
-instance [NumberField K] : IsIntegrallyClosed (𝓞 K) :=
-  integralClosure.isIntegrallyClosedOfFiniteExtension ℚ
+instance [NumberField K] : IsIntegrallyClosed (𝓞 K) K :=
+  integralClosure.isIntegrallyClosed
 
 theorem isIntegral_coe (x : 𝓞 K) : IsIntegral ℤ (x : K) :=
   x.2

--- a/Mathlib/RingTheory/Bezout.lean
+++ b/Mathlib/RingTheory/Bezout.lean
@@ -97,7 +97,8 @@ attribute [local instance] toGCDDomain
 
 -- Note that the proof depends on the `local attribute [instance]` above, and is thus necessary to
 -- be stated.
-instance (priority := 100) [IsDomain R] [IsBezout R] : IsIntegrallyClosed R := by
+instance (priority := 100) {K : Type*} [Field K] [Algebra R K]
+    [IsDomain R] [IsBezout R] [IsFractionRing R K] : IsIntegrallyClosed R K := by
   classical exact GCDMonoid.toIsIntegrallyClosed
 
 theorem _root_.Function.Surjective.isBezout {S : Type v} [CommRing S] (f : R →+* S)

--- a/Mathlib/RingTheory/DedekindDomain/Basic.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Basic.lean
@@ -103,8 +103,16 @@ This is the default implementation, but there are equivalent definitions,
 TODO: Prove that these are actually equivalent definitions.
 -/
 class IsDedekindDomain
-  extends IsDomain A, IsNoetherian A A, DimensionLEOne A, IsIntegrallyClosed A : Prop
+  extends IsDomain A, IsNoetherian A A, DimensionLEOne A, IsIntegrallyClosed A (FractionRing A) :
+  Prop
 #align is_dedekind_domain IsDedekindDomain
+
+/--
+A Dedekind domain is integrally closed, for any choice for field of fractions.
+-/
+theorem IsDedekindDomain.isIntegrallyClosed (K : Type*) [Field K] [Algebra A K] [IsFractionRing A K]
+    [IsDedekindDomain A] : IsIntegrallyClosed A K :=
+  (IsLocalization.algEquiv A⁰ _ K).isIntegrallyClosed_iff.mp IsDedekindDomain.toIsIntegrallyClosed
 
 /-- An integral domain is a Dedekind domain iff and only if it is
 Noetherian, has dimension ≤ 1, and is integrally closed in a given fraction field.
@@ -114,8 +122,8 @@ theorem isDedekindDomain_iff (K : Type*) [Field K] [Algebra A K] [IsFractionRing
       IsDomain A ∧ IsNoetherianRing A ∧ DimensionLEOne A ∧
         ∀ {x : K}, IsIntegral A x → ∃ y, algebraMap A K y = x :=
   ⟨fun _ => ⟨inferInstance, inferInstance, inferInstance,
-             fun {_} => (isIntegrallyClosed_iff K).mp inferInstance⟩,
-   fun ⟨hid, hr, hd, hi⟩ => { hid, hr, hd, (isIntegrallyClosed_iff K).mpr @hi with }⟩
+             fun {_} => (isIntegrallyClosed_fractionRing_iff (FractionRing A) K).mp inferInstance⟩,
+   fun ⟨hid, hr, hd, hi⟩ => { hid, hr, hd, (isIntegrallyClosed_fractionRing_iff _ K).mpr @hi with }⟩
 #align is_dedekind_domain_iff isDedekindDomain_iff
 
 -- See library note [lower instance priority]

--- a/Mathlib/RingTheory/DedekindDomain/Dvr.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Dvr.lean
@@ -102,7 +102,7 @@ theorem IsLocalization.isDedekindDomain [IsDedekindDomain A] {M : Submonoid A} (
   · exact Ring.DimensionLEOne.localization Aₘ hM
   · intro x hx
     obtain ⟨⟨y, y_mem⟩, hy⟩ := hx.exists_multiple_integral_of_isLocalization M _
-    obtain ⟨z, hz⟩ := (isIntegrallyClosed_iff _).mp IsDedekindDomain.toIsIntegrallyClosed hy
+    obtain ⟨z, hz⟩ := (IsIntegrallyClosed_iff _ _).mp IsDedekindDomain.toIsIntegrallyClosed hy
     refine' ⟨IsLocalization.mk' Aₘ z ⟨y, y_mem⟩, (IsLocalization.lift_mk'_spec _ _ _ _).mpr _⟩
     rw [hz, ← Algebra.smul_def]
     rfl

--- a/Mathlib/RingTheory/DedekindDomain/Ideal.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Ideal.lean
@@ -293,12 +293,12 @@ theorem isNoetherianRing : IsNoetherianRing A := by
   exact I.fg_of_isUnit (IsFractionRing.injective A (FractionRing A)) (h.isUnit hI)
 #align is_dedekind_domain_inv.is_noetherian_ring IsDedekindDomainInv.isNoetherianRing
 
-theorem integrallyClosed : IsIntegrallyClosed A := by
+theorem integrallyClosed : IsIntegrallyClosed A K := by
   -- It suffices to show that for integral `x`,
   -- `A[x]` (which is a fractional ideal) is in fact equal to `A`.
   refine ⟨fun {x hx} => ?_⟩
-  rw [← Set.mem_range, ← Algebra.mem_bot, ← Subalgebra.mem_toSubmodule, Algebra.toSubmodule_bot, ←
-    coe_spanSingleton A⁰ (1 : FractionRing A), spanSingleton_one, ←
+  rw [← Set.mem_range, ← Algebra.mem_bot, ← Subalgebra.mem_toSubmodule, Algebra.toSubmodule_bot,
+    ← coe_spanSingleton A⁰ (1 : K), spanSingleton_one, ←
     FractionalIdeal.adjoinIntegral_eq_one_of_isUnit x hx (h.isUnit _)]
   · exact mem_adjoinIntegral_self A⁰ x hx
   · exact fun h => one_ne_zero (eq_zero_iff.mp h 1 (Algebra.adjoin A {x}).one_mem)
@@ -492,6 +492,7 @@ theorem coe_ideal_mul_inv [h : IsDedekindDomain A] (I : Ideal A) (hI0 : I ≠ �
   · rw [hJ0, inv_zero']; exact zero_le _
   intro x hx
   -- In particular, we'll show all `x ∈ J⁻¹` are integral.
+  have := IsDedekindDomain.isIntegrallyClosed A K
   suffices x ∈ integralClosure A K by
     rwa [IsIntegrallyClosed.integralClosure_eq_bot, Algebra.mem_bot, Set.mem_range,
       ← mem_one_iff] at this

--- a/Mathlib/RingTheory/DedekindDomain/IntegralClosure.lean
+++ b/Mathlib/RingTheory/DedekindDomain/IntegralClosure.lean
@@ -93,7 +93,7 @@ variable [FiniteDimensional K L]
 variable {A K L}
 
 theorem IsIntegralClosure.range_le_span_dualBasis [IsSeparable K L] {ι : Type*} [Fintype ι]
-    [DecidableEq ι] (b : Basis ι K L) (hb_int : ∀ i, IsIntegral A (b i)) [IsIntegrallyClosed A] :
+    [DecidableEq ι] (b : Basis ι K L) (hb_int : ∀ i, IsIntegral A (b i)) [IsIntegrallyClosed A K] :
     LinearMap.range ((Algebra.linearMap C L).restrictScalars A) ≤
     Submodule.span A (Set.range <| (traceForm K L).dualBasis (traceForm_nondegenerate K L) b) := by
   let db := (traceForm K L).dualBasis (traceForm_nondegenerate K L) b
@@ -119,7 +119,7 @@ theorem IsIntegralClosure.range_le_span_dualBasis [IsSeparable K L] {ι : Type*}
 #align is_integral_closure.range_le_span_dual_basis IsIntegralClosure.range_le_span_dualBasis
 
 theorem integralClosure_le_span_dualBasis [IsSeparable K L] {ι : Type*} [Fintype ι] [DecidableEq ι]
-    (b : Basis ι K L) (hb_int : ∀ i, IsIntegral A (b i)) [IsIntegrallyClosed A] :
+    (b : Basis ι K L) (hb_int : ∀ i, IsIntegral A (b i)) [IsIntegrallyClosed A K] :
     Subalgebra.toSubmodule (integralClosure A L) ≤
     Submodule.span A (Set.range <| (traceForm K L).dualBasis (traceForm_nondegenerate K L) b) := by
   refine' le_trans _ (IsIntegralClosure.range_le_span_dualBasis (integralClosure A L) b hb_int)
@@ -187,7 +187,7 @@ variable [IsSeparable K L]
 /- If `L` is a finite separable extension of `K = Frac(A)`, where `A` is
 integrally closed and Noetherian, the integral closure `C` of `A` in `L` is
 Noetherian over `A`. -/
-theorem IsIntegralClosure.isNoetherian [IsIntegrallyClosed A] [IsNoetherianRing A] :
+theorem IsIntegralClosure.isNoetherian [IsIntegrallyClosed A K] [IsNoetherianRing A] :
     IsNoetherian A C := by
   haveI := Classical.decEq L
   obtain ⟨s, b, hb_int⟩ := FiniteDimensional.exists_is_basis_integral A K L
@@ -204,7 +204,7 @@ theorem IsIntegralClosure.isNoetherian [IsIntegrallyClosed A] [IsNoetherianRing 
 /- If `L` is a finite separable extension of `K = Frac(A)`, where `A` is
 integrally closed and Noetherian, the integral closure `C` of `A` in `L` is
 Noetherian. -/
-theorem IsIntegralClosure.isNoetherianRing [IsIntegrallyClosed A] [IsNoetherianRing A] :
+theorem IsIntegralClosure.isNoetherianRing [IsIntegrallyClosed A K] [IsNoetherianRing A] :
     IsNoetherianRing C :=
   isNoetherianRing_iff.mpr <| isNoetherian_of_tower A (IsIntegralClosure.isNoetherian A K L C)
 #align is_integral_closure.is_noetherian_ring IsIntegralClosure.isNoetherianRing
@@ -237,7 +237,7 @@ variable {A K}
 /- If `L` is a finite separable extension of `K = Frac(A)`, where `A` is
 integrally closed and Noetherian, the integral closure of `A` in `L` is
 Noetherian. -/
-theorem integralClosure.isNoetherianRing [IsIntegrallyClosed A] [IsNoetherianRing A] :
+theorem integralClosure.isNoetherianRing [IsIntegrallyClosed A K] [IsNoetherianRing A] :
     IsNoetherianRing (integralClosure A L) :=
   IsIntegralClosure.isNoetherianRing A K L (integralClosure A L)
 #align integral_closure.is_noetherian_ring integralClosure.isNoetherianRing
@@ -253,9 +253,10 @@ and `C := integralClosure A L`.
 -/
 theorem IsIntegralClosure.isDedekindDomain [IsDedekindDomain A] : IsDedekindDomain C :=
   have : IsFractionRing C L := IsIntegralClosure.isFractionRing_of_finite_extension A K L C
+  have : IsIntegrallyClosed A K := IsDedekindDomain.isIntegrallyClosed A K
   { IsIntegralClosure.isNoetherianRing A K L C,
     Ring.DimensionLEOne.isIntegralClosure A L C,
-    (isIntegrallyClosed_iff L).mpr fun {x} hx =>
+    (isIntegrallyClosed_fractionRing_iff _ L).mpr fun {x} hx =>
       ⟨IsIntegralClosure.mk' C x (isIntegral_trans (IsIntegralClosure.isIntegral_algebra A L) _ hx),
         IsIntegralClosure.algebraMap_mk' _ _ _⟩ with : IsDedekindDomain C }
 #align is_integral_closure.is_dedekind_domain IsIntegralClosure.isDedekindDomain

--- a/Mathlib/RingTheory/DedekindDomain/SelmerGroup.lean
+++ b/Mathlib/RingTheory/DedekindDomain/SelmerGroup.lean
@@ -215,6 +215,7 @@ theorem fromUnit_ker [hn : Fact <| 0 < n] :
     have hi : ↑(_ ^ n : Kˣ)⁻¹ = algebraMap R K _ := by exact congr_arg Units.inv hx
     rw [Units.val_pow_eq_pow_val] at hv
     rw [← inv_pow, Units.inv_mk, Units.val_pow_eq_pow_val] at hi
+    have := IsDedekindDomain.isIntegrallyClosed R K
     rcases IsIntegrallyClosed.exists_algebraMap_eq_of_isIntegral_pow (R := R) (x := v) hn.out
         (hv.symm ▸ isIntegral_algebraMap) with
       ⟨v', rfl⟩

--- a/Mathlib/RingTheory/DiscreteValuationRing/TFAE.lean
+++ b/Mathlib/RingTheory/DiscreteValuationRing/TFAE.lean
@@ -154,7 +154,8 @@ theorem DiscreteValuationRing.TFAE [IsNoetherianRing R] [LocalRing R] [IsDomain 
     (h : ¬IsField R) :
     List.TFAE
       [DiscreteValuationRing R, ValuationRing R, IsDedekindDomain R,
-        IsIntegrallyClosed R ∧ ∃! P : Ideal R, P ≠ ⊥ ∧ P.IsPrime, (maximalIdeal R).IsPrincipal,
+        IsIntegrallyClosed R (FractionRing R) ∧ ∃! P : Ideal R, P ≠ ⊥ ∧ P.IsPrime,
+        (maximalIdeal R).IsPrincipal,
         FiniteDimensional.finrank (ResidueField R) (CotangentSpace R) = 1,
         ∀ (I) (_ : I ≠ ⊥), ∃ n : ℕ, I = maximalIdeal R ^ n] := by
   have ne_bot := Ring.ne_bot_of_isMaximal_of_not_isField (maximalIdeal.isMaximal R) h

--- a/Mathlib/RingTheory/Discriminant.lean
+++ b/Mathlib/RingTheory/Discriminant.lean
@@ -331,7 +331,7 @@ separable extension of `K`. Let `B : PowerBasis K L` be such that `IsIntegral R 
 Then for all, `z : L` that are integral over `R`, we have
 `(discr K B.basis) • z ∈ adjoin R ({B.gen} : set L)`. -/
 theorem discr_mul_isIntegral_mem_adjoin [IsSeparable K L] [IsIntegrallyClosed R K]
-    [IsFractionRing R K] {B : PowerBasis K L} (hint : IsIntegral R B.gen) {z : L}
+    {B : PowerBasis K L} (hint : IsIntegral R B.gen) {z : L}
     (hz : IsIntegral R z) : discr K B.basis • z ∈ adjoin R ({B.gen} : Set L) := by
   have hinv : IsUnit (traceMatrix K B.basis).det := by
     simpa [← discr_def] using discr_isUnit_of_basis _ B.basis

--- a/Mathlib/RingTheory/Discriminant.lean
+++ b/Mathlib/RingTheory/Discriminant.lean
@@ -330,7 +330,7 @@ theorem discr_eq_discr_of_toMatrix_coeff_isIntegral [NumberField K] {b : Basis �
 separable extension of `K`. Let `B : PowerBasis K L` be such that `IsIntegral R B.gen`.
 Then for all, `z : L` that are integral over `R`, we have
 `(discr K B.basis) • z ∈ adjoin R ({B.gen} : set L)`. -/
-theorem discr_mul_isIntegral_mem_adjoin [IsSeparable K L] [IsIntegrallyClosed R]
+theorem discr_mul_isIntegral_mem_adjoin [IsSeparable K L] [IsIntegrallyClosed R K]
     [IsFractionRing R K] {B : PowerBasis K L} (hint : IsIntegral R B.gen) {z : L}
     (hz : IsIntegral R z) : discr K B.basis • z ∈ adjoin R ({B.gen} : Set L) := by
   have hinv : IsUnit (traceMatrix K B.basis).det := by

--- a/Mathlib/RingTheory/IntegrallyClosed.lean
+++ b/Mathlib/RingTheory/IntegrallyClosed.lean
@@ -111,8 +111,8 @@ end Algebra
 
 section FractionRing
 
-variable (K : Type*) [Field K] [Algebra R K] [IsFractionRing R K]
-variable (K' : Type*) [Field K'] [Algebra R K'] [IsFractionRing R K']
+variable (K : Type*) [CommRing K] [Algebra R K] [IsFractionRing R K]
+variable (K' : Type*) [CommRing K'] [Algebra R K'] [IsFractionRing R K']
 
 /-- `R` is integrally closed iff all integral elements of its fraction field `K`
 are also elements of `R`. -/
@@ -180,7 +180,7 @@ section Injective
 -- TODO: this section can be generalized from `IsFractionRing` to any `Algebra` that is injective,
 -- but there is no way to hook that assumption up to the typeclass system.
 
-variable {K : Type*} [Field K] [Algebra R K] [ifr : IsFractionRing R K]
+variable {K : Type*} [CommRing K] [Algebra R K] [ifr : IsFractionRing R K]
 
 variable [iic : IsIntegrallyClosed R K]
 

--- a/Mathlib/RingTheory/IntegrallyClosed.lean
+++ b/Mathlib/RingTheory/IntegrallyClosed.lean
@@ -25,6 +25,33 @@ integral over `R`. A special case of integrally closed rings are the Dedekind do
   states `R` is integrally closed in `A` iff it is integrally closed in `A'`.
 * `isIntegrallyClosed_fractionRing_iff K`, where `K` is a fraction field of `R`, states `R`
   is integrally closed iff it is the integral closure of `R` in `K`
+
+## TODO: Related notions
+
+The following definitions are closely related, especially in their applications in Mathlib.
+
+A *normal domain* is a domain that is integrally closed in its field of fractions.
+[Stacks: normal domain](https://stacks.math.columbia.edu/tag/0309)
+Normal domains are the major usecase of `IsIntegrallyClosed` at the time of writing, and we have
+quite a few results that can be moved wholesale to a new `NormalDomain` definition.
+
+A normal ring means that localizations at all prime ideals are normal domains.
+[Stacks: normal ring](https://stacks.math.columbia.edu/tag/00GV)
+This implies integral closedness in its `FractionRing`,
+[Stacks: Lemma 10.37.12](https://stacks.math.columbia.edu/tag/034M)
+but is equivalent to it only under some conditions (reduced + finitely many minimal primes),
+[Stacks: Lemma 10.37.16](https://stacks.math.columbia.edu/tag/034M)
+in which case it's also equivalent to being a finite product of normal domains.
+
+We'd need to add these conditions if we want exactly the products of Dedekind domains.
+
+In fact noetherianity is sufficient to guarantee finitely many minimal primes, so `IsDedekindRing`
+could be defined as `IsReduced`, `IsNoetherian`, `Ring.DimensionLEOne`, and either
+`IsIntegrallyClosed` or `NormalDomain`. If we use `NormalDomain` then `IsReduced` is automatic,
+but we could also consider a version of `NormalDomain` that only requires the localizations are
+`IsIntegrallyClosed` in their `FractionRings` but may not be domains,
+and that may not equivalent to the ring itself being `IsIntegallyClosed` in its `FractionRing`
+(even for noetherian rings?).
 -/
 
 

--- a/Mathlib/RingTheory/IntegrallyClosed.lean
+++ b/Mathlib/RingTheory/IntegrallyClosed.lean
@@ -31,18 +31,18 @@ integral over `R`. A special case of integrally closed rings are the Dedekind do
 The following definitions are closely related, especially in their applications in Mathlib.
 
 A *normal domain* is a domain that is integrally closed in its field of fractions.
-[Stacks: normal domain](https://stacks.math.columbia.edu/tag/0309)
-Normal domains are the major usecase of `IsIntegrallyClosed` at the time of writing, and we have
+[Stacks: normal domain](https://stacks.math.columbia.edu/tag/037B#0309)
+Normal domains are the major use case of `IsIntegrallyClosed` at the time of writing, and we have
 quite a few results that can be moved wholesale to a new `NormalDomain` definition.
 In fact, before PR #6126 `IsIntegrallyClosed` was exactly defined to be a normal domain.
 (So you might want to copy some of its API when you define normal domains.)
 
 A normal ring means that localizations at all prime ideals are normal domains.
-[Stacks: normal ring](https://stacks.math.columbia.edu/tag/00GV)
+[Stacks: normal ring](https://stacks.math.columbia.edu/tag/037B#00GV)
 This implies integral closedness in its `FractionRing`,
-[Stacks: Lemma 10.37.12](https://stacks.math.columbia.edu/tag/034M)
+[Stacks: Tag 034M](https://stacks.math.columbia.edu/tag/037B#034M)
 but is equivalent to it only under some conditions (reduced + finitely many minimal primes),
-[Stacks: Lemma 10.37.16](https://stacks.math.columbia.edu/tag/034M)
+[Stacks: Tag 030C](https://stacks.math.columbia.edu/tag/037B#030C)
 in which case it's also equivalent to being a finite product of normal domains.
 
 We'd need to add these conditions if we want exactly the products of Dedekind domains.
@@ -96,7 +96,7 @@ theorem isIntegrallyClosed_iff_isIntegralClosure (h : Function.Injective (algebr
 
 variable {A' : Type*} [CommRing A'] [Algebra R A']
 
-theorem AlgebraMap.isIntegrallyClosed (f : A →ₐ[R] A') (hf : Function.Injective ↑f)
+theorem AlgebraMap.isIntegrallyClosed (f : A →ₐ[R] A') (hf : Function.Injective f)
     (h : IsIntegrallyClosed R A') :
     IsIntegrallyClosed R A :=
   ⟨fun hx => let ⟨y, hy⟩ := h.algebraMap_eq_of_integral (map_isIntegral f hx)

--- a/Mathlib/RingTheory/IntegrallyClosed.lean
+++ b/Mathlib/RingTheory/IntegrallyClosed.lean
@@ -34,6 +34,8 @@ A *normal domain* is a domain that is integrally closed in its field of fraction
 [Stacks: normal domain](https://stacks.math.columbia.edu/tag/0309)
 Normal domains are the major usecase of `IsIntegrallyClosed` at the time of writing, and we have
 quite a few results that can be moved wholesale to a new `NormalDomain` definition.
+In fact, before PR #6126 `IsIntegrallyClosed` was exactly defined to be a normal domain.
+(So you might want to copy some of its API when you define normal domains.)
 
 A normal ring means that localizations at all prime ideals are normal domains.
 [Stacks: normal ring](https://stacks.math.columbia.edu/tag/00GV)

--- a/Mathlib/RingTheory/IsAdjoinRoot.lean
+++ b/Mathlib/RingTheory/IsAdjoinRoot.lean
@@ -730,7 +730,8 @@ end IsAdjoinRoot
 
 namespace IsAdjoinRootMonic
 
-theorem minpoly_eq [IsDomain R] [IsDomain S] [NoZeroSMulDivisors R S] [IsIntegrallyClosed R (FractionRing R)]
+theorem minpoly_eq [IsDomain R] [IsDomain S] [NoZeroSMulDivisors R S]
+    [IsIntegrallyClosed R (FractionRing R)]
     (h : IsAdjoinRootMonic S f) (hirr : Irreducible f) : minpoly R h.root = f :=
   let ⟨q, hq⟩ := minpoly.isIntegrallyClosed_dvd h.isIntegral_root h.aeval_root
   symm <|

--- a/Mathlib/RingTheory/IsAdjoinRoot.lean
+++ b/Mathlib/RingTheory/IsAdjoinRoot.lean
@@ -730,7 +730,7 @@ end IsAdjoinRoot
 
 namespace IsAdjoinRootMonic
 
-theorem minpoly_eq [IsDomain R] [IsDomain S] [NoZeroSMulDivisors R S] [IsIntegrallyClosed R]
+theorem minpoly_eq [IsDomain R] [IsDomain S] [NoZeroSMulDivisors R S] [IsIntegrallyClosed R (FractionRing R)]
     (h : IsAdjoinRootMonic S f) (hirr : Irreducible f) : minpoly R h.root = f :=
   let ⟨q, hq⟩ := minpoly.isIntegrallyClosed_dvd h.isIntegral_root h.aeval_root
   symm <|
@@ -749,7 +749,7 @@ section Algebra
 open AdjoinRoot IsAdjoinRoot minpoly PowerBasis IsAdjoinRootMonic Algebra
 
 theorem Algebra.adjoin.powerBasis'_minpoly_gen [IsDomain R] [IsDomain S] [NoZeroSMulDivisors R S]
-    [IsIntegrallyClosed R] {x : S} (hx' : IsIntegral R x) :
+    [IsIntegrallyClosed R (FractionRing R)] {x : S} (hx' : IsIntegral R x) :
     minpoly R x = minpoly R (Algebra.adjoin.powerBasis' hx').gen := by
   haveI := isDomain_of_prime (prime_of_isIntegrallyClosed hx')
   haveI :=

--- a/Mathlib/RingTheory/Polynomial/Eisenstein/IsIntegral.lean
+++ b/Mathlib/RingTheory/Polynomial/Eisenstein/IsIntegral.lean
@@ -126,7 +126,7 @@ variable {K : Type v} {L : Type z} {p : R} [CommRing R] [Field K] [Field L]
 
 variable [Algebra K L] [Algebra R L] [Algebra R K] [IsScalarTower R K L] [IsSeparable K L]
 
-variable [IsDomain R] [IsFractionRing R K] [IsIntegrallyClosed R]
+variable [IsDomain R] [IsFractionRing R K] [IsIntegrallyClosed R K]
 
 local notation "𝓟" => Submodule.span R {(p : R)}
 

--- a/Mathlib/RingTheory/Polynomial/GaussLemma.lean
+++ b/Mathlib/RingTheory/Polynomial/GaussLemma.lean
@@ -74,7 +74,7 @@ variable [IsDomain R] [IsFractionRing R K]
 
 /-- If `K = Frac(R)` and `g : K[X]` divides a monic polynomial with coefficients in `R`, then
     `g * (C g.leadingCoeff⁻¹)` has coefficients in `R` -/
-theorem IsIntegrallyClosed.eq_map_mul_C_of_dvd [IsIntegrallyClosed R] {f : R[X]} (hf : f.Monic)
+theorem IsIntegrallyClosed.eq_map_mul_C_of_dvd [IsIntegrallyClosed R K] {f : R[X]} (hf : f.Monic)
     {g : K[X]} (hg : g ∣ f.map (algebraMap R K)) :
     ∃ g' : R[X], g'.map (algebraMap R K) * (C <| leadingCoeff g) = g := by
   have g_ne_0 : g ≠ 0 := ne_zero_of_dvd_ne_zero (Monic.ne_zero <| hf.map (algebraMap R K)) hg
@@ -150,7 +150,7 @@ open IsIntegrallyClosed
 
 /-- **Gauss's Lemma** for integrally closed domains states that a monic polynomial is irreducible
   iff it is irreducible in the fraction field. -/
-theorem Monic.irreducible_iff_irreducible_map_fraction_map [IsIntegrallyClosed R] {p : R[X]}
+theorem Monic.irreducible_iff_irreducible_map_fraction_map [IsIntegrallyClosed R K] {p : R[X]}
     (h : p.Monic) : Irreducible p ↔ Irreducible (p.map <| algebraMap R K) := by
   /- The ← direction follows from `IsPrimitive.irreducible_of_irreducible_map_of_injective`.
        For the → direction, it is enought to show that if `(p.map $ algebraMap R K) = a * b` and
@@ -188,13 +188,13 @@ theorem Monic.irreducible_iff_irreducible_map_fraction_map [IsIntegrallyClosed R
 /-- Integrally closed domains are precisely the domains for in which Gauss's lemma holds
     for monic polynomials -/
 theorem isIntegrallyClosed_iff' :
-    IsIntegrallyClosed R ↔
+    IsIntegrallyClosed R K ↔
       ∀ p : R[X], p.Monic → (Irreducible p ↔ Irreducible (p.map <| algebraMap R K)) := by
   constructor
   · intro hR p hp; exact Monic.irreducible_iff_irreducible_map_fraction_map hp
   · intro H
     refine'
-      (isIntegrallyClosed_iff K).mpr fun {x} hx =>
+      (IsIntegrallyClosed_iff _ K).mpr fun {x} hx =>
         RingHom.mem_range.mp <| minpoly.mem_range_of_degree_eq_one R x _
     rw [← Monic.degree_map (minpoly.monic hx) (algebraMap R K)]
     apply
@@ -202,7 +202,7 @@ theorem isIntegrallyClosed_iff' :
     rw [IsRoot, eval_map, ← aeval_def, minpoly.aeval R x]
 #align polynomial.is_integrally_closed_iff' Polynomial.isIntegrallyClosed_iff'
 
-theorem Monic.dvd_of_fraction_map_dvd_fraction_map [IsIntegrallyClosed R] {p q : R[X]}
+theorem Monic.dvd_of_fraction_map_dvd_fraction_map [IsIntegrallyClosed R K] {p q : R[X]}
     (hp : p.Monic) (hq : q.Monic)
     (h : q.map (algebraMap R K) ∣ p.map (algebraMap R K)) : q ∣ p := by
   obtain ⟨r, hr⟩ := h
@@ -213,7 +213,7 @@ theorem Monic.dvd_of_fraction_map_dvd_fraction_map [IsIntegrallyClosed R] {p q :
   · exact Monic.of_mul_monic_left (hq.map (algebraMap R K)) (by simpa [← hr] using hp.map _)
 #align polynomial.monic.dvd_of_fraction_map_dvd_fraction_map Polynomial.Monic.dvd_of_fraction_map_dvd_fraction_map
 
-theorem Monic.dvd_iff_fraction_map_dvd_fraction_map [IsIntegrallyClosed R] {p q : R[X]}
+theorem Monic.dvd_iff_fraction_map_dvd_fraction_map [IsIntegrallyClosed R K] {p q : R[X]}
     (hp : p.Monic) (hq : q.Monic) : q.map (algebraMap R K) ∣ p.map (algebraMap R K) ↔ q ∣ p :=
   ⟨fun h => hp.dvd_of_fraction_map_dvd_fraction_map hq h, fun ⟨a, b⟩ =>
     ⟨a.map (algebraMap R K), b.symm ▸ Polynomial.map_mul (algebraMap R K)⟩⟩

--- a/Mathlib/RingTheory/Polynomial/RationalRoot.lean
+++ b/Mathlib/RingTheory/Polynomial/RationalRoot.lean
@@ -130,7 +130,7 @@ theorem integer_of_integral {x : K} : IsIntegral A x → IsInteger A x := fun �
 #align unique_factorization_monoid.integer_of_integral UniqueFactorizationMonoid.integer_of_integral
 
 -- See library note [lower instance priority]
-instance (priority := 100) instIsIntegrallyClosed : IsIntegrallyClosed A :=
+instance (priority := 100) instIsIntegrallyClosed : IsIntegrallyClosed A K :=
   ⟨fun {_} => integer_of_integral⟩
 #align unique_factorization_monoid.is_integrally_closed UniqueFactorizationMonoid.instIsIntegrallyClosed
 

--- a/Mathlib/RingTheory/RootsOfUnity/Minpoly.lean
+++ b/Mathlib/RingTheory/RootsOfUnity/Minpoly.lean
@@ -81,7 +81,7 @@ theorem minpoly_dvd_expand {p : ℕ} (hdiv : ¬p ∣ n) :
     minpoly ℤ μ ∣ expand ℤ p (minpoly ℤ (μ ^ p)) := by
   rcases n.eq_zero_or_pos with (rfl | hpos)
   · simp_all
-  letI : IsIntegrallyClosed ℤ := GCDMonoid.toIsIntegrallyClosed
+  letI : IsIntegrallyClosed ℤ ℚ := GCDMonoid.toIsIntegrallyClosed
   refine' minpoly.isIntegrallyClosed_dvd (h.isIntegral hpos) _
   · rw [aeval_def, coe_expand, ← comp, eval₂_eq_eval_map, map_comp, Polynomial.map_pow, map_X,
       eval_comp, eval_pow, eval_X, ← eval₂_eq_eval_map, ← aeval_def]

--- a/Mathlib/RingTheory/Valuation/Integral.lean
+++ b/Mathlib/RingTheory/Valuation/Integral.lean
@@ -63,7 +63,7 @@ variable [Algebra O K] [IsFractionRing O K]
 
 variable (hv : Integers v O)
 
-theorem integrallyClosed : IsIntegrallyClosed O :=
+theorem integrallyClosed : IsIntegrallyClosed O K :=
   (IsIntegrallyClosed.integralClosure_eq_bot_iff K).mp (Valuation.Integers.integralClosure hv)
 #align valuation.integers.integrally_closed Valuation.Integers.integrallyClosed
 


### PR DESCRIPTION
Instead of saying `IsIntegrallyClosed R` means the ring `R` contains all integral elements of the ring of fractions, we follow, as suggested by @alreadydone in the review for #6126, the convention by the Stacks project and paramerize over an arbitrary algebra `A`: `IsIntegrallyClosed R A` means `R` contains all integral elements of `A`.
    
Most results generalize straightforwardly. The general algorithm: if the fraction field is already there, use that. Otherwise use `FractionRing R`.

TODO: generalize away from `IsFractionRing` if they are not needed.

---

- [x] depends on: #6126

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
