### PR TITLE
[Merged by Bors] - chore: fix typo

### DIFF
--- a/Mathlib/NumberTheory/FLT/Basic.lean
+++ b/Mathlib/NumberTheory/FLT/Basic.lean
@@ -11,7 +11,7 @@ import Mathlib.Tactic.TFAE
 /-!
 # Statement of Fermat's Last Theorem
 
-This file states the Fermat Last Theorem. We provide a statement over a general semiring with
+This file states Fermat's Last Theorem. We provide a statement over a general semiring with
 specific exponent, along with the usual statement over the naturals.
 -/
 


### PR DESCRIPTION
This PR fixes a typo from #6508.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
