### PR TITLE
refactor(Real/CauSeq): use `FunLike` instead of `CoeFun`

### DIFF
--- a/Mathlib/Data/Complex/Exponential.lean
+++ b/Mathlib/Data/Complex/Exponential.lean
@@ -1458,10 +1458,9 @@ theorem sum_le_exp_of_nonneg {x : ℝ} (hx : 0 ≤ x) (n : ℕ) : ∑ i in range
   calc
     ∑ i in range n, x ^ i / i ! ≤ lim (⟨_, isCauSeq_re (exp' x)⟩ : CauSeq ℝ Abs.abs) := by
       refine' le_lim (CauSeq.le_of_exists ⟨n, fun j hj => _⟩)
-      simp only [exp', const_apply, re_sum]
+      simp only [exp', mk_to_fun, const_apply, re_sum]
       norm_cast
-      rw [← Nat.add_sub_of_le hj, Finset.sum_range_add]
-      refine' le_add_of_nonneg_right (sum_nonneg fun i _ => _)
+      refine sum_le_sum_of_subset_of_nonneg (range_mono hj) fun _ _ _ ↦ ?_
       positivity
     _ = exp x := by rw [exp, Complex.exp, ← cauSeqRe, lim_re]
 #align real.sum_le_exp_of_nonneg Real.sum_le_exp_of_nonneg

--- a/Mathlib/Data/Real/CauSeq.lean
+++ b/Mathlib/Data/Real/CauSeq.lean
@@ -143,14 +143,13 @@ instance : FunLike (CauSeq β abv) ℕ fun _ => β where
   coe := Subtype.val
   coe_injective' := Subtype.val_injective
 
--- Porting note: Remove coeFn theorem
-/-@[simp]
-theorem mk_to_fun (f) (hf : IsCauSeq abv f) : @coeFn (CauSeq β abv) _ _ ⟨f, hf⟩ = f :=
-  rfl -/
-#noalign cau_seq.mk_to_fun
+@[simp]
+theorem mk_to_fun (f) (hf : IsCauSeq abv f) : @FunLike.coe (CauSeq β abv) _ _ _ ⟨f, hf⟩ = f :=
+  rfl
+#align cau_seq.mk_to_fun CauSeq.mk_to_fun
 
 theorem ext {f g : CauSeq β abv} (h : ∀ i, f i = g i) : f = g :=
-  Subtype.eq (funext h)
+  FunLike.ext _ _ h
 #align cau_seq.ext CauSeq.ext
 
 theorem isCauSeq (f : CauSeq β abv) : IsCauSeq abv f :=

--- a/Mathlib/Data/Real/CauSeqCompletion.lean
+++ b/Mathlib/Data/Real/CauSeqCompletion.lean
@@ -374,7 +374,7 @@ theorem lim_mul_lim (f g : CauSeq β abv) : lim f * lim g = lim (f * g) :=
       have h :
         const abv (lim f * lim g) - f * g =
           (const abv (lim f) - f) * g + const abv (lim f) * (const abv (lim g) - g) := by
-              apply Subtype.ext
+              apply FunLike.ext'
               rw [coe_add]
               simp [sub_mul, mul_sub]
       rw [h]

--- a/Mathlib/NumberTheory/Padics/PadicNumbers.lean
+++ b/Mathlib/NumberTheory/Padics/PadicNumbers.lean
@@ -604,9 +604,8 @@ theorem defn (f : PadicSeq p) {ε : ℚ} (hε : 0 < ε) :
   by_contra' h
   cases' cauchy₂ f hε with N hN
   rcases h N with ⟨i, hi, hge⟩
-  have hne : ¬f - const (padicNorm p) (f i) ≈ 0 := by
-    intro h
-    unfold PadicSeq.norm at hge; split_ifs at hge
+  have hne : ¬f - const (padicNorm p) (f i) ≈ 0 := fun h ↦ by
+    rw [PadicSeq.norm, dif_pos h] at hge
     exact not_lt_of_ge hge hε
   unfold PadicSeq.norm at hge; split_ifs at hge; exact not_le_of_gt hε hge
   apply not_le_of_gt _ hge


### PR DESCRIPTION
Co-authored-by: Gabriel Ebner <gebner@gebner.org>

---

Cherry-picked from #1219

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)