### PR TITLE
[Merged by Bors] - feat(LinearAlgebra/QuadraticForm/Prod): products are commutative up to isomorphism

### DIFF
--- a/Mathlib/LinearAlgebra/QuadraticForm/Prod.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/Prod.lean
@@ -73,6 +73,22 @@ theorem Equivalent.prod {Q₁ : QuadraticForm R M₁} {Q₂ : QuadraticForm R M�
   Nonempty.map2 IsometryEquiv.prod e₁ e₂
 #align quadratic_form.equivalent.prod QuadraticForm.Equivalent.prod
 
+/-- `LinearEquiv.prodComm` is isometric. -/
+@[simps!]
+def IsometryEquiv.prodComm (Q₁ : QuadraticForm R M₁) (Q₂ : QuadraticForm R M₂) :
+    (Q₁.prod Q₂).IsometryEquiv (Q₂.prod Q₁) where
+  toLinearEquiv := LinearEquiv.prodComm _ _ _
+  map_app' _ := add_comm _ _
+
+/-- `LinearEquiv.prodProdProdComm` is isometric. -/
+@[simps!]
+def IsometryEquiv.prodProdProdComm
+    (Q₁ : QuadraticForm R M₁) (Q₂ : QuadraticForm R M₂)
+    (Q₃ : QuadraticForm R N₁) (Q₄ : QuadraticForm R N₂) :
+    ((Q₁.prod Q₂).prod (Q₃.prod Q₄)).IsometryEquiv ((Q₁.prod Q₃).prod (Q₂.prod Q₄)) where
+  toLinearEquiv := LinearEquiv.prodProdProdComm _ _ _ _ _
+  map_app' _ := add_add_add_comm _ _ _ _
+
 /-- If a product is anisotropic then its components must be. The converse is not true. -/
 theorem anisotropic_of_prod {R} [OrderedRing R] [Module R M₁] [Module R M₂]
     {Q₁ : QuadraticForm R M₁} {Q₂ : QuadraticForm R M₂} (h : (Q₁.prod Q₂).Anisotropic) :


### PR DESCRIPTION
Surprisingly we're missing the whole tower of bundled `Equiv.prodAssoc` definitions, so this PR omits those too.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
