### PR TITLE
[Merged by Bors] - docs(HNN Extension): add names of Higman and Neumann

### DIFF
--- a/Mathlib/GroupTheory/HNNExtension.lean
+++ b/Mathlib/GroupTheory/HNNExtension.lean
@@ -11,10 +11,11 @@ import Mathlib.GroupTheory.Complement
 
 ## HNN Extensions of Groups
 
-This file defines the HNN extensions of a group `G`, `HNNExtension G A B φ`. Given a group `G`,
+This file defines the HNN extension of a group `G`, `HNNExtension G A B φ`. Given a group `G`,
 subgroups `A` and `B` and an isomorphism `φ` of `A` and `B`, we adjoin a letter `t` to `G`, such
 that for any `a ∈ A`, the conjugate of `of a` by `t` is `of (φ a)`, where `of` is the canonical map
-from `G` into the `HNNExtension`.
+from `G` into the `HNNExtension`. This construction is named after Graham Higman, Bernhard Neumann
+and Hanna Neumann.
 
 ## Main definitions
 


### PR DESCRIPTION
---
As requested by @urkud . I've added the names of Graham Higman, Hanna Neumann and Bernhard Neumann to the docs.
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
