### PR TITLE
feat: nowhere dense and meagre sets

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1983,6 +1983,7 @@ import Mathlib.Geometry.Manifold.Instances.Sphere
 import Mathlib.Geometry.Manifold.Instances.UnitsOfNormedAlgebra
 import Mathlib.Geometry.Manifold.LocalInvariantProperties
 import Mathlib.Geometry.Manifold.MFDeriv
+import Mathlib.Geometry.Manifold.MeasureZero
 import Mathlib.Geometry.Manifold.Metrizable
 import Mathlib.Geometry.Manifold.PartitionOfUnity
 import Mathlib.Geometry.Manifold.Sheaf.Basic

--- a/Mathlib/Geometry/Manifold/MeasureZero.lean
+++ b/Mathlib/Geometry/Manifold/MeasureZero.lean
@@ -1,0 +1,154 @@
+/-
+Copyright (c) 2023 Michael Rothgang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Michael Rothgang.
+-/
+import Mathlib.Geometry.Manifold.SmoothManifoldWithCorners
+import Mathlib.Topology.MetricSpace.Polish
+import Mathlib.MeasureTheory.Measure.Haar.Basic
+
+/-!
+# Measure zero subsets of a manifold
+
+Defines the notion of "measure zero" subsets on a finite-dimensional topological manifold.
+
+Let $M$ be a finite-dimensional manifold. While $M$ is a measurable space (for instance, pull back the Lebesgue measure on each chart and use a partition of unity) , it has no canonical measure. However, there is a natural notion of *measure zero* subsets of $M$: a subset $A\subset M$ has measure zero iff for each chart $(\phi, U)$ of $M$ the set $\phi(U\cap A)\subset R^n$ has measure zero (w.r.t. to any additive Haar measure).
+
+Measure zero sets are closed under subsets and countable unions, hence their complement defines the *almost everywhere filter* on a manifold. Measure zero subsets have empty interior, hence closed measure zero sets are nowhere dense.
+
+**TODO**
+- show that if $M$ is a normed space with Haar measure $\mu$, a set $A ⊆ M$ has measure zero iff $μ A = 0$.
+- show the same if $M$ is a manifold with a suitable measure $\mu$. If `MeasureZero` were defined using `IsOpenPosMeasure` on a chart, that would probably be a suitable class on `M`.
+- include manifolds with boundary: in `open_implies_empty`, one needs to show that an open subset of `M` includes an interior point of `M`. (The current definition of manifolds with boundary seems to be too general for that.)
+
+
+## Main results
+- `MeasureZero`: Prop for measure zero subsets in `M`
+- `MeasureZero.mono`: measure zero subsets are closed under subsets
+- `MeasureZero.union` and `MeasureZero.iUnion`: measure zero subsets are closed under countable unions
+- `MeasureZero.ae`: the complements of measure zero sets form a filter, the **almost everywhere filter**.
+- `open_implies_empty`: an open measure zero subset is empty
+- `MeasureZero_implies_empty_interior`: a measure zero subset has empty interior.
+
+## References
+See [Hirsch76], chapter 3.1 for the definition of measure zero subsets in a manifold.
+-/
+
+open MeasureTheory Measure Function TopologicalSpace Set
+set_option autoImplicit false
+
+variable
+  -- Let `M` be a finite-dimensional (topological) manifold without boundary over the pair `(E, H)`.
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] {H : Type*} [TopologicalSpace H]
+  (I : ModelWithCorners ℝ E H) {M : Type*} [TopologicalSpace M] [ChartedSpace H M] [I.Boundaryless]
+  [FiniteDimensional ℝ E] [MeasurableSpace E] [BorelSpace E]
+variable {I}
+
+/- A measure zero subset of an n-dimensional manifold $M$ is a subset $S ⊆ M$ such that
+for all charts $(φ, U)$ of $M$, $φ(U ∩ S) ⊆ ℝ^n$ has measure zero. -/
+variable (I) in
+def MeasureZero (s : Set M) : Prop :=
+  ∀ (μ : Measure E) [IsAddHaarMeasure μ], ∀ e ∈ atlas H M, μ (I ∘ e '' (e.source ∩ s)) = 0
+
+namespace MeasureZero
+/-- Having measure zero is monotone: a subset of a set with measure zero has measure zero. -/
+protected lemma mono {s t : Set M} (hst : s ⊆ t) (ht : MeasureZero I t) :
+    (MeasureZero I s) := by
+  intro μ hμ e he
+  have : I ∘ e '' (e.source ∩ s) ⊆  I ∘ e '' (e.source ∩ t) := by
+    apply image_subset
+    exact inter_subset_inter_right e.source hst
+  exact measure_mono_null this (ht μ e he)
+
+/- The empty set has measure zero. -/
+protected lemma empty : MeasureZero I (∅: Set M) := by
+  intro μ _ e _
+  simp only [comp_apply, inter_empty, image_empty, OuterMeasure.empty']
+
+/- The countable index union of measure zero sets has measure zero. -/
+protected lemma iUnion { ι : Type* } [Encodable ι] { s : ι → Set M }
+  (hs : ∀ n : ι, MeasureZero I (s n)) : MeasureZero I (⋃ (n : ι),  s n) := by
+  intro μ hμ e he
+  have : I ∘ e '' (e.source ∩ (⋃ (n : ι),  s n)) = ⋃ (n : ι), I ∘ e '' (e.source ∩ s n) := by
+    rw [inter_iUnion]
+    exact image_iUnion
+  -- union of null sets is a null set
+  simp_all only [comp_apply, OuterMeasure.iUnion_null_iff]
+  intro i
+  apply hs
+  exact he
+
+/- The finite union of measure zero sets has measure zero. -/
+protected lemma union { s t : Set M } (hs : MeasureZero I s) (ht : MeasureZero I t)
+    : MeasureZero I (s ∪ t) := by
+  let u : Bool → Set M := fun b ↦ cond b s t
+  have : ∀ i : Bool, MeasureZero I (u i) := by
+    intro i
+    cases i
+    · exact ht
+    · exact hs
+  rw [union_eq_iUnion]
+  exact MeasureZero.iUnion this
+
+/-- The “almost everywhere” filter of co-measure zero sets in a manifold. -/
+def ModelWithCorners.ae
+    { E : Type* } [NormedAddCommGroup E] [NormedSpace ℝ E]
+    { F : Type*} [TopologicalSpace F] (I : ModelWithCorners ℝ E F)
+    { M : Type* } [TopologicalSpace M] [ChartedSpace F M]
+    [SmoothManifoldWithCorners I M] [FiniteDimensional ℝ E]
+    [MeasurableSpace E] : Filter M where
+  sets := { s | MeasureZero I sᶜ }
+  univ_sets := by
+    rw [@mem_setOf, compl_univ]
+    apply MeasureZero.empty
+  inter_sets hx hy:= by
+    simp only [mem_setOf_eq] at *
+    rw [compl_inter]
+    exact hx.union hy
+  sets_of_superset hs hst := hs.mono (Iff.mpr compl_subset_compl hst)
+
+/-- An open set of measure zero is empty. -/
+protected lemma open_implies_empty {s : Set M} (h₁s : IsOpen s) (h₂s : MeasureZero I s): s = ∅ := by
+  suffices ∀ e ∈ atlas H M, (e.source ∩ s) = ∅ by
+    by_contra h
+    obtain ⟨x, hx⟩ : Set.Nonempty s := Iff.mp nmem_singleton_empty h
+    specialize this (chartAt H x) (chart_mem_atlas H x)
+    have h₂: x ∈ (chartAt H x).toLocalEquiv.source ∩ s := by
+      constructor
+      simp
+      exact hx
+    rw [this] at h₂
+    contradiction
+
+  intro e he
+  simp [MeasureZero] at h₂s
+  -- choose any measure μ that's a Haar measure
+  obtain ⟨K''⟩ : Nonempty (PositiveCompacts E) := PositiveCompacts.nonempty'
+  let μ : Measure E := addHaarMeasure K''
+  -- by h₂s μ e, we have μ (I∘e '' s) = 0
+  specialize h₂s μ e he
+  by_contra h
+  -- in particular, e.source ∩ s is an open subset contained in that, hence has measure zero
+  have h' : Set.Nonempty (interior (I ∘ e '' (e.source ∩ s))) := by
+    have : Set.Nonempty (I ∘ e '' (e.source ∩ s)) := by
+      exact (Iff.mp Set.nmem_singleton_empty h).image _
+    have : IsOpen (e '' (e.source ∩ s)) := by
+        apply e.image_open_of_open'
+        exact h₁s
+    have : IsOpen (I ∘ e '' (e.source ∩ s)) := by
+      rw [Set.image_comp]
+      apply I.toHomeomorph.isOpenMap
+      apply this
+    rwa [this.interior_eq]
+  apply (measure_pos_of_nonempty_interior (μ := μ) h').ne'
+  exact h₂s
+
+/- A subset of a manifold `M` with measure zero has empty interior.
+
+In particular, a *closed* measure zero subset of M is nowhere dense.
+(Closedness is required: there are generalised Cantor sets of positive Lebesgue measure.) -/
+protected lemma MeasureZero_implies_empty_interior {s : Set M}
+    (h₂s : MeasureZero I s) : (interior s) = ∅ := by
+  have : MeasureZero I (interior s) := h₂s.mono interior_subset
+  apply MeasureZero.open_implies_empty isOpen_interior this
+end MeasureZero

--- a/Mathlib/Geometry/Manifold/MeasureZero.lean
+++ b/Mathlib/Geometry/Manifold/MeasureZero.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2023 Michael Rothgang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Michael Rothgang.
+Authors: Michael Rothgang
 -/
 import Mathlib.Geometry.Manifold.SmoothManifoldWithCorners
 import Mathlib.Topology.MetricSpace.Polish
@@ -12,41 +12,51 @@ import Mathlib.MeasureTheory.Measure.Haar.Basic
 
 Defines the notion of "measure zero" subsets on a finite-dimensional topological manifold.
 
-Let $M$ be a finite-dimensional manifold. While $M$ is a measurable space (for instance, pull back the Lebesgue measure on each chart and use a partition of unity) , it has no canonical measure. However, there is a natural notion of *measure zero* subsets of $M$: a subset $A\subset M$ has measure zero iff for each chart $(\phi, U)$ of $M$ the set $\phi(U\cap A)\subset R^n$ has measure zero (w.r.t. to any additive Haar measure).
+Let $M$ be a finite-dimensional manifold. While $M$ is a measurable space
+(for instance, pull back the Lebesgue measure on each chart and use a partition of unity),
+it has no canonical measure. However, there is a natural notion of *measure zero* subsets of $M$:
+a subset $A\subset M$ has measure zero iff for each chart $(\phi, U)$ of $M$ the set
+$\phi(U\cap A)\subset R^n$ has measure zero (w.r.t. to any additive Haar measure).
 
-Measure zero sets are closed under subsets and countable unions, hence their complement defines the *almost everywhere filter* on a manifold. Measure zero subsets have empty interior, hence closed measure zero sets are nowhere dense.
+Measure zero sets are closed under subsets and countable unions, hence their complement defines
+the **almost everywhere filter** on a manifold. Measure zero subsets have empty interior,
+hence closed measure zero sets are nowhere dense.
 
 **TODO**
-- show that if $M$ is a normed space with Haar measure $\mu$, a set $A ⊆ M$ has measure zero iff $μ A = 0$.
-- show the same if $M$ is a manifold with a suitable measure $\mu$. If `MeasureZero` were defined using `IsOpenPosMeasure` on a chart, that would probably be a suitable class on `M`.
-- include manifolds with boundary: in `open_implies_empty`, one needs to show that an open subset of `M` includes an interior point of `M`. (The current definition of manifolds with boundary seems to be too general for that.)
+- show that if $M$ is a normed space with Haar measure $\mu$,
+  a set $A ⊆ M$ has measure zero iff $μ A = 0$.
+- show the same if $M$ is a manifold with a suitable measure $\mu$. If `MeasureZero` were defined
+using `IsOpenPosMeasure` on a chart, "suitable" probably would mean that.
+- include manifolds with boundary: in `open_implies_empty`, one needs to show that
+an open subset of `M` includes an interior point of `M`. (The current definition of
+manifolds with boundary seems to be too general for that.)
 
 
 ## Main results
 - `MeasureZero`: Prop for measure zero subsets in `M`
 - `MeasureZero.mono`: measure zero subsets are closed under subsets
-- `MeasureZero.union` and `MeasureZero.iUnion`: measure zero subsets are closed under countable unions
-- `MeasureZero.ae`: the complements of measure zero sets form a filter, the **almost everywhere filter**.
+- `MeasureZero.union`, `MeasureZero.iUnion`: measure zero subsets are closed under countable unions
+- `MeasureZero.ae`: the complements of measure zero sets form the **almost everywhere filter**.
 - `open_implies_empty`: an open measure zero subset is empty
 - `MeasureZero_implies_empty_interior`: a measure zero subset has empty interior.
 
 ## References
-See [Hirsch76], chapter 3.1 for the definition of measure zero subsets in a manifold.
+See [Hirsch, Differential Topology](Hirsch76), chapter 3.1 for this definition.
 -/
 
 open MeasureTheory Measure Function TopologicalSpace Set
 set_option autoImplicit false
 
 variable
-  -- Let `M` be a finite-dimensional (topological) manifold without boundary over the pair `(E, H)`.
+  -- Let `M` be a finite-dimensional topological manifold without boundary over the pair `(E, H)`.
   {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] {H : Type*} [TopologicalSpace H]
   (I : ModelWithCorners ℝ E H) {M : Type*} [TopologicalSpace M] [ChartedSpace H M] [I.Boundaryless]
   [FiniteDimensional ℝ E] [MeasurableSpace E] [BorelSpace E]
 variable {I}
 
-/- A measure zero subset of an n-dimensional manifold $M$ is a subset $S ⊆ M$ such that
-for all charts $(φ, U)$ of $M$, $φ(U ∩ S) ⊆ ℝ^n$ has measure zero. -/
 variable (I) in
+/-- A measure zero subset of an n-dimensional manifold $M$ is a subset $S ⊆ M$ such that
+for all charts $(φ, U)$ of $M$, $φ(U ∩ S) ⊆ ℝ^n$ has measure zero. -/
 def MeasureZero (s : Set M) : Prop :=
   ∀ (μ : Measure E) [IsAddHaarMeasure μ], ∀ e ∈ atlas H M, μ (I ∘ e '' (e.source ∩ s)) = 0
 
@@ -60,12 +70,12 @@ protected lemma mono {s t : Set M} (hst : s ⊆ t) (ht : MeasureZero I t) :
     exact inter_subset_inter_right e.source hst
   exact measure_mono_null this (ht μ e he)
 
-/- The empty set has measure zero. -/
+/-- The empty set has measure zero. -/
 protected lemma empty : MeasureZero I (∅: Set M) := by
   intro μ _ e _
   simp only [comp_apply, inter_empty, image_empty, OuterMeasure.empty']
 
-/- The countable index union of measure zero sets has measure zero. -/
+/-- A countable indexed union of measure zero sets has measure zero. -/
 protected lemma iUnion { ι : Type* } [Encodable ι] { s : ι → Set M }
   (hs : ∀ n : ι, MeasureZero I (s n)) : MeasureZero I (⋃ (n : ι),  s n) := by
   intro μ hμ e he
@@ -78,7 +88,7 @@ protected lemma iUnion { ι : Type* } [Encodable ι] { s : ι → Set M }
   apply hs
   exact he
 
-/- The finite union of measure zero sets has measure zero. -/
+/-- A finite union of measure zero sets has measure zero. -/
 protected lemma union { s t : Set M } (hs : MeasureZero I s) (ht : MeasureZero I t)
     : MeasureZero I (s ∪ t) := by
   let u : Bool → Set M := fun b ↦ cond b s t
@@ -94,9 +104,7 @@ protected lemma union { s t : Set M } (hs : MeasureZero I s) (ht : MeasureZero I
 def ModelWithCorners.ae
     { E : Type* } [NormedAddCommGroup E] [NormedSpace ℝ E]
     { F : Type*} [TopologicalSpace F] (I : ModelWithCorners ℝ E F)
-    { M : Type* } [TopologicalSpace M] [ChartedSpace F M]
-    [SmoothManifoldWithCorners I M] [FiniteDimensional ℝ E]
-    [MeasurableSpace E] : Filter M where
+    { M : Type* } [TopologicalSpace M] [ChartedSpace F M] [MeasurableSpace E] : Filter M where
   sets := { s | MeasureZero I sᶜ }
   univ_sets := by
     rw [@mem_setOf, compl_univ]
@@ -108,7 +116,8 @@ def ModelWithCorners.ae
   sets_of_superset hs hst := hs.mono (Iff.mpr compl_subset_compl hst)
 
 /-- An open set of measure zero is empty. -/
-protected lemma open_implies_empty {s : Set M} (h₁s : IsOpen s) (h₂s : MeasureZero I s): s = ∅ := by
+protected lemma open_implies_empty {s : Set M} (h₁s : IsOpen s) (h₂s : MeasureZero I s)
+    : s = ∅ := by
   suffices ∀ e ∈ atlas H M, (e.source ∩ s) = ∅ by
     by_contra h
     obtain ⟨x, hx⟩ : Set.Nonempty s := Iff.mp nmem_singleton_empty h
@@ -122,13 +131,13 @@ protected lemma open_implies_empty {s : Set M} (h₁s : IsOpen s) (h₂s : Measu
 
   intro e he
   simp [MeasureZero] at h₂s
-  -- choose any measure μ that's a Haar measure
+  -- Choose any Haar measure μ on E.
   obtain ⟨K''⟩ : Nonempty (PositiveCompacts E) := PositiveCompacts.nonempty'
   let μ : Measure E := addHaarMeasure K''
-  -- by h₂s μ e, we have μ (I∘e '' s) = 0
+  -- By h₂s μ e, we have μ (I∘e '' s) = 0.
   specialize h₂s μ e he
   by_contra h
-  -- in particular, e.source ∩ s is an open subset contained in that, hence has measure zero
+  -- In particular, e.source ∩ s is an open subset contained in that set, hence has measure zero.
   have h' : Set.Nonempty (interior (I ∘ e '' (e.source ∩ s))) := by
     have : Set.Nonempty (I ∘ e '' (e.source ∩ s)) := by
       exact (Iff.mp Set.nmem_singleton_empty h).image _
@@ -143,7 +152,7 @@ protected lemma open_implies_empty {s : Set M} (h₁s : IsOpen s) (h₂s : Measu
   apply (measure_pos_of_nonempty_interior (μ := μ) h').ne'
   exact h₂s
 
-/- A subset of a manifold `M` with measure zero has empty interior.
+/-- A subset of a manifold `M` with measure zero has empty interior.
 
 In particular, a *closed* measure zero subset of M is nowhere dense.
 (Closedness is required: there are generalised Cantor sets of positive Lebesgue measure.) -/

--- a/Mathlib/Geometry/Manifold/MeasureZero.lean
+++ b/Mathlib/Geometry/Manifold/MeasureZero.lean
@@ -76,7 +76,7 @@ protected lemma empty : MeasureZero I (∅: Set M) := by
   simp only [comp_apply, inter_empty, image_empty, OuterMeasure.empty']
 
 /-- A countable indexed union of measure zero sets has measure zero. -/
-protected lemma iUnion { ι : Type* } [Encodable ι] { s : ι → Set M }
+protected lemma iUnion {ι : Type*} [Encodable ι] {s : ι → Set M}
   (hs : ∀ n : ι, MeasureZero I (s n)) : MeasureZero I (⋃ (n : ι),  s n) := by
   intro μ hμ e he
   have : I ∘ e '' (e.source ∩ (⋃ (n : ι),  s n)) = ⋃ (n : ι), I ∘ e '' (e.source ∩ s n) := by
@@ -89,8 +89,8 @@ protected lemma iUnion { ι : Type* } [Encodable ι] { s : ι → Set M }
   exact he
 
 /-- A finite union of measure zero sets has measure zero. -/
-protected lemma union { s t : Set M } (hs : MeasureZero I s) (ht : MeasureZero I t)
-    : MeasureZero I (s ∪ t) := by
+protected lemma union {s t : Set M} (hs : MeasureZero I s) (ht : MeasureZero I t):
+    MeasureZero I (s ∪ t) := by
   let u : Bool → Set M := fun b ↦ cond b s t
   have : ∀ i : Bool, MeasureZero I (u i) := by
     intro i
@@ -102,9 +102,9 @@ protected lemma union { s t : Set M } (hs : MeasureZero I s) (ht : MeasureZero I
 
 /-- The “almost everywhere” filter of co-measure zero sets in a manifold. -/
 def ModelWithCorners.ae
-    { E : Type* } [NormedAddCommGroup E] [NormedSpace ℝ E]
-    { F : Type*} [TopologicalSpace F] (I : ModelWithCorners ℝ E F)
-    { M : Type* } [TopologicalSpace M] [ChartedSpace F M] [MeasurableSpace E] : Filter M where
+    {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+    {F : Type*} [TopologicalSpace F] (I : ModelWithCorners ℝ E F)
+    {M : Type*} [TopologicalSpace M] [ChartedSpace F M] [MeasurableSpace E] : Filter M where
   sets := { s | MeasureZero I sᶜ }
   univ_sets := by
     rw [@mem_setOf, compl_univ]
@@ -116,8 +116,8 @@ def ModelWithCorners.ae
   sets_of_superset hs hst := hs.mono (Iff.mpr compl_subset_compl hst)
 
 /-- An open set of measure zero is empty. -/
-protected lemma open_implies_empty {s : Set M} (h₁s : IsOpen s) (h₂s : MeasureZero I s)
-    : s = ∅ := by
+protected lemma open_implies_empty {s : Set M} (h₁s : IsOpen s) (h₂s : MeasureZero I s):
+    s = ∅ := by
   suffices ∀ e ∈ atlas H M, (e.source ∩ s) = ∅ by
     by_contra h
     obtain ⟨x, hx⟩ : Set.Nonempty s := Iff.mp nmem_singleton_empty h

--- a/Mathlib/Topology/Meagre.lean
+++ b/Mathlib/Topology/Meagre.lean
@@ -1,0 +1,148 @@
+/-
+Copyright (c) 2023 Michael Rothgang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Michael Rothgang
+-/
+import Mathlib.Topology.GDelta
+
+/-!
+## Nowhere dense and meagre sets
+Define nowhere dense and meagre sets (`IsNowhereDense` and `IsMeagre`, respectively)
+and prove their basic properties.
+
+Main properties:
+- `closure_nowhere_dense`: the closure of a nowhere dense set is nowhere dense
+- `closed_nowhere_dense_iff_complement`: a closed set is nowhere dense iff
+its complement is open and dense
+- `meagre_iff_complement_comeagre`: a set is nowhere dense iff its complement is `residual`.
+- `empty_mono`: subsets of meagre sets are meagre
+- `meagre_iUnion`: countable unions of meagre sets are meagre
+-/
+
+open Function TopologicalSpace Set
+set_option autoImplicit false
+
+variable {α : Type*} [TopologicalSpace α]
+
+/-- A set is nowhere dense iff its closure has empty interior. -/
+def IsNowhereDense (s : Set α) := IsEmpty (interior (closure s))
+
+/-- A closed set is nowhere dense iff its interior is empty. -/
+lemma closed_nowhere_dense_iff {s : Set α} (hs : IsClosed s) : IsNowhereDense s ↔ IsEmpty (interior s) := by
+  rw [IsNowhereDense, IsClosed.closure_eq hs]
+
+/-- If a set `s` is nowhere dense, so is its closure.-/
+lemma closure_nowhere_dense {s : Set α} (hs : IsNowhereDense s) : IsNowhereDense (closure s) := by
+  rw [IsNowhereDense, closure_closure]
+  exact hs
+
+/-- A nowhere dense set `s` is contained in a closed nowhere dense set (namely, its closure). -/
+lemma nowhere_dense_contained_in_closed_nowhere_dense {s : Set α} (hs : IsNowhereDense s) :
+    ∃ t : Set α, s ⊆ t ∧ IsNowhereDense t ∧ IsClosed t := by
+  use closure s
+  exact ⟨subset_closure, ⟨closure_nowhere_dense hs, isClosed_closure⟩⟩
+
+/-- A set `s` is closed and nowhere dense iff its complement `sᶜ` is open and dense. -/
+lemma closed_nowhere_dense_iff_complement {s : Set α} :
+    IsClosed s ∧ IsNowhereDense s ↔ IsOpen sᶜ ∧ Dense sᶜ := by
+  constructor
+  · rintro ⟨hclosed, hNowhereDense⟩
+    constructor
+    · exact Iff.mpr isOpen_compl_iff hclosed
+    · rw [← interior_eq_empty_iff_dense_compl]
+      rw [closed_nowhere_dense_iff hclosed] at hNowhereDense
+      exact Iff.mp isEmpty_coe_sort hNowhereDense
+  · rintro ⟨hopen, hdense⟩
+    constructor
+    · exact { isOpen_compl := hopen }
+    · have : IsClosed s := by exact { isOpen_compl := hopen }
+      rw [closed_nowhere_dense_iff this, isEmpty_coe_sort, interior_eq_empty_iff_dense_compl]
+      exact hdense
+
+/-- A set is **meagre** iff it is contained in the countable union of nowhere dense sets. -/
+def IsMeagre (s : Set α) := ∃ S : Set (Set α), (∀ t ∈ S, IsNowhereDense t) ∧ S.Countable ∧ s ⊆ ⋃₀ S
+
+-- TODO: prove and move to the right place!
+lemma sUnion_subset_closure {s : Set (Set α)} : ⋃₀ s ⊆ ⋃₀ (closure '' s) := by sorry
+
+-- /-- A set is meagre iff its complement is residual (or comeagre). -/
+lemma meagre_iff_complement_comeagre {s : Set α} : IsMeagre s ↔ sᶜ ∈ residual α := by
+  constructor
+  · rintro ⟨s', ⟨hnowhereDense, hcountable, hss'⟩⟩
+    -- Passing to the closure, assume all U_i are closed nowhere dense.
+    let s'' := closure '' s'
+    have hnowhereDense' : ∀ (t : Set α), t ∈ s'' → IsClosed t ∧ IsNowhereDense t := by
+      rintro t ⟨x, hx, hclosed⟩
+      rw [← hclosed]
+      exact ⟨isClosed_closure, closure_nowhere_dense (hnowhereDense x hx)⟩
+    have hcountable' : Set.Countable s'' := Countable.image hcountable _
+    have hss'' : s ⊆ ⋃₀ s'' := calc
+      s ⊆ ⋃₀ s' := hss'
+      _ ⊆ ⋃₀ s'' := sUnion_subset_closure
+    -- Then each U_i^c is open and dense.
+    have h : ∀ (t : Set α), t ∈ s'' → IsOpen tᶜ ∧ Dense tᶜ  :=
+      fun t ht ↦ Iff.mp closed_nowhere_dense_iff_complement (hnowhereDense' t ht)
+    let complement := compl '' s''
+    have h' : ∀ (t : Set α), t ∈ complement → IsOpen t ∧ Dense t := by
+      rintro t ⟨x, hx, hcompl⟩
+      rw [← hcompl]
+      exact h x hx
+    -- and we compute ⋂ U_iᶜ ⊆ sᶜ, completing the proof.
+    have h2: ⋂₀ complement ⊆ sᶜ := calc ⋂₀ complement
+        _ = (⋃₀ s'')ᶜ := by rw [←compl_sUnion]
+        _ ⊆ sᶜ := Iff.mpr compl_subset_compl hss''
+    rw [mem_residual_iff]
+    use complement
+    constructor
+    · intro t ht
+      exact (h' t ht).1
+    · constructor
+      · intro t ht
+        exact (h' t ht).2
+      · exact ⟨Countable.image hcountable' compl, h2⟩
+  · intro hs -- suppose sᶜ is comeagre, then sᶜ ⊇ ⋂ U i for open dense sets U_i
+    rw [mem_residual_iff] at hs
+    rcases hs with ⟨s', ⟨hopen, hdense, hcountable, hss'⟩⟩
+    have h : s ⊆ ⋃₀ (compl '' s') := calc
+      s = sᶜᶜ := by rw [compl_compl s]
+      _ ⊆ (⋂₀ s')ᶜ := Iff.mpr compl_subset_compl hss'
+      _ = ⋃₀ (compl '' s') := by rw [compl_sInter]
+    -- Each u_iᶜ is closed and nowhere dense, hence nowhere dense.
+    have : ∀ t : Set α, t ∈ s' → IsClosed tᶜ ∧ IsNowhereDense tᶜ := by
+      intro t ht
+      have : IsOpen tᶜᶜ ∧ Dense tᶜᶜ := by
+        rw [compl_compl]
+        exact ⟨hopen t ht, hdense t ht⟩
+      exact Iff.mpr closed_nowhere_dense_iff_complement this
+    have : ∀ t : Set α, t ∈ s' → IsNowhereDense tᶜ := fun t ht ↦ (this t ht).2
+    -- Thus (s'')ᶜ =s is meagre.
+    rw [IsMeagre]
+    use compl '' s'
+    constructor
+    · rintro t ⟨x, hx, hcompl⟩
+      rw [← hcompl]
+      exact this x hx
+    · constructor
+      · exact Countable.image hcountable _
+      · apply h
+
+/-- The empty set is meagre. -/
+lemma meagre_empty : IsMeagre (∅ : Set α) := by
+  rw [meagre_iff_complement_comeagre, compl_empty, ← Filter.eventuallyEq_univ]
+
+/-- Subsets of meagre sets are meagre. -/
+lemma meagre_mono {s t: Set α} (hs : IsMeagre s) (hts: t ⊆ s) : IsMeagre t := by
+  rw [← compl_subset_compl] at hts
+  rw [meagre_iff_complement_comeagre] at *
+  exact Filter.mem_of_superset hs hts
+
+/-- A finite intersection of meagre sets is meagre. -/
+-- xxx is this superfluous? I presume it is?
+lemma meagre_inter {s t : Set α} (hs : IsMeagre s) : IsMeagre (s ∩ t) :=
+  meagre_mono hs (inter_subset_left s t)
+
+/-- A countable union of meagre sets is meagre. -/
+lemma meagre_iUnion {s : ℕ → Set α} (hs : ∀ n : ℕ, IsMeagre (s n)) :
+    IsMeagre (⋃ (n : ℕ), (s n)) := by
+  simp only [meagre_iff_complement_comeagre, compl_iUnion] at *
+  exact Iff.mpr countable_iInter_mem hs

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -1,4 +1,3 @@
-% Encoding: UTF-8
 
 # To normalize:
 # bibtool --preserve.key.case=on --preserve.keys=on --pass.comments=on --print.use.tab=off -s -i docs/references.bib -o docs/references.bib
@@ -1297,6 +1296,20 @@
   year          = {1952}
 }
 
+@Book{            hirsch76,
+  title         = {{Differential topology.}},
+  publisher     = {Springer, New York, NY},
+  year          = {1976},
+  author        = {Morris W. {Hirsch}},
+  volume        = {33},
+  fjournal      = {{Graduate Texts in Mathematics}},
+  issn          = {0072-5285},
+  journal       = {{Grad. Texts Math.}},
+  language      = {English},
+  msc2010       = {57-01 57Rxx 34C40 54Cxx 55M25 55R25 58A05 58E05 57N05},
+  zbl           = {0356.57001}
+}
+
 @Unpublished{     hochsterunpublished,
   title         = {Local cohomology},
   author        = {Hochster, Mel},
@@ -2536,18 +2549,4 @@
   mrnumber      = {1563550},
   doi           = {10.1090/S0002-9904-1937-06565-7},
   url           = {https://doi.org/10.1090/S0002-9904-1937-06565-7}
-}
-
-@Book{            hirsch76,
-  title     = {{Differential topology.}},
-  publisher = {Springer, New York, NY},
-  year      = {1976},
-  author    = {Morris W. {Hirsch}},
-  volume    = {33},
-  fjournal  = {{Graduate Texts in Mathematics}},
-  issn      = {0072-5285},
-  journal   = {{Grad. Texts Math.}},
-  language  = {English},
-  msc2010   = {57-01 57Rxx 34C40 54Cxx 55M25 55R25 58A05 58E05 57N05},
-  zbl       = {0356.57001},
 }

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -1,3 +1,4 @@
+% Encoding: UTF-8
 
 # To normalize:
 # bibtool --preserve.key.case=on --preserve.keys=on --pass.comments=on --print.use.tab=off -s -i docs/references.bib -o docs/references.bib
@@ -2535,4 +2536,18 @@
   mrnumber      = {1563550},
   doi           = {10.1090/S0002-9904-1937-06565-7},
   url           = {https://doi.org/10.1090/S0002-9904-1937-06565-7}
+}
+
+@Book{            hirsch76,
+  title     = {{Differential topology.}},
+  publisher = {Springer, New York, NY},
+  year      = {1976},
+  author    = {Morris W. {Hirsch}},
+  volume    = {33},
+  fjournal  = {{Graduate Texts in Mathematics}},
+  issn      = {0072-5285},
+  journal   = {{Grad. Texts Math.}},
+  language  = {English},
+  msc2010   = {57-01 57Rxx 34C40 54Cxx 55M25 55R25 58A05 58E05 57N05},
+  zbl       = {0356.57001},
 }


### PR DESCRIPTION
Define nowhere dense and meagre sets and show their basic properties.
Meagre sets are defined as the complement of a comeagre(=residual) sets
(and shown to be equivalent to the standard definition); we deduce their API from the API for comeagre sets.

-------------

I'm still pretty new to Lean, hence am open to learning new and exciting ways to golf this! :-)

Unresolved questions
- Where should these results go? Should they stay in a separate file or be merged with `GDelta.lean`? (Is there a file `FSigma.lean`?
- Does mathlib prefer American spelling? Then I can adjust :joy: 
- I'm very open to suggestions for better lemma names, still learning here.