### PR TITLE
[Merged by Bors] - chore: golf linearIsometry_apply_dfinsupp_sum_single

### DIFF
--- a/Mathlib/Analysis/InnerProductSpace/l2Space.lean
+++ b/Mathlib/Analysis/InnerProductSpace/l2Space.lean
@@ -243,11 +243,7 @@ protected theorem linearIsometry_apply_single {i : ι} (x : G i) :
 @[simp]
 protected theorem linearIsometry_apply_dfinsupp_sum_single (W₀ : Π₀ i : ι, G i) :
     hV.linearIsometry (W₀.sum (lp.single 2)) = W₀.sum fun i => V i := by
-  have :
-    hV.linearIsometry (∑ i in W₀.support, lp.single 2 i (W₀ i)) =
-      ∑ i in W₀.support, hV.linearIsometry (lp.single 2 i (W₀ i)) :=
-    hV.linearIsometry.toLinearMap.map_sum
-  simp (config := { contextual := true }) [DFinsupp.sum, this]
+  simp
 #align orthogonal_family.linear_isometry_apply_dfinsupp_sum_single OrthogonalFamily.linearIsometry_apply_dfinsupp_sum_single
 
 /-- The canonical linear isometry from the `lp 2` of a mutually orthogonal family of subspaces of


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

This fails the simpNF ("simp can prove this") linter both before and after my change locally, but apparently not in CI. Not sure what's up with that.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
