### PR TITLE
chore: split powers out of Associated.lean

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -19,6 +19,7 @@ import Mathlib.Algebra.Algebra.Tower
 import Mathlib.Algebra.Algebra.Unitization
 import Mathlib.Algebra.AlgebraicCard
 import Mathlib.Algebra.Associated
+import Mathlib.Algebra.AssociatedPow
 import Mathlib.Algebra.BigOperators.Associated
 import Mathlib.Algebra.BigOperators.Basic
 import Mathlib.Algebra.BigOperators.Fin

--- a/Mathlib/Algebra/AssociatedPow.lean
+++ b/Mathlib/Algebra/AssociatedPow.lean
@@ -1,0 +1,184 @@
+/-
+Copyright (c) 2018 Johannes Hölzl. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Johannes Hölzl, Jens Wagemaker
+-/
+
+import Mathlib.Algebra.Associated
+import Mathlib.Algebra.Divisibility.Basic
+import Mathlib.Algebra.GroupPower.Lemmas
+import Mathlib.Algebra.Parity
+
+#align_import algebra.associated from "leanprover-community/mathlib"@"2f3994e1b117b1e1da49bcfb67334f33460c3ce4"
+
+/-!
+# Powers of associated, prime, and irreducible elements.
+-/
+
+variable {α : Type*} {β : Type*} {γ : Type*} {δ : Type*}
+
+theorem Prime.pow_dvd_of_dvd_mul_left [CancelCommMonoidWithZero α] {p a b : α} (hp : Prime p)
+    (n : ℕ) (h : ¬p ∣ a) (h' : p ^ n ∣ a * b) : p ^ n ∣ b := by
+  induction' n with n ih
+  · rw [pow_zero]
+    exact one_dvd b
+  · obtain ⟨c, rfl⟩ := ih (dvd_trans (pow_dvd_pow p n.le_succ) h')
+    rw [pow_succ']
+    apply mul_dvd_mul_left _ ((hp.dvd_or_dvd _).resolve_left h)
+    rwa [← mul_dvd_mul_iff_left (pow_ne_zero n hp.ne_zero), ← pow_succ', mul_left_comm]
+#align prime.pow_dvd_of_dvd_mul_left Prime.pow_dvd_of_dvd_mul_left
+
+theorem Prime.pow_dvd_of_dvd_mul_right [CancelCommMonoidWithZero α] {p a b : α} (hp : Prime p)
+    (n : ℕ) (h : ¬p ∣ b) (h' : p ^ n ∣ a * b) : p ^ n ∣ a := by
+  rw [mul_comm] at h'
+  exact hp.pow_dvd_of_dvd_mul_left n h h'
+#align prime.pow_dvd_of_dvd_mul_right Prime.pow_dvd_of_dvd_mul_right
+
+theorem Prime.dvd_of_pow_dvd_pow_mul_pow_of_square_not_dvd [CancelCommMonoidWithZero α] {p a b : α}
+    {n : ℕ} (hp : Prime p) (hpow : p ^ n.succ ∣ a ^ n.succ * b ^ n) (hb : ¬p ^ 2 ∣ b) : p ∣ a := by
+  -- Suppose `p ∣ b`, write `b = p * x` and `hy : a ^ n.succ * b ^ n = p ^ n.succ * y`.
+  cases' hp.dvd_or_dvd ((dvd_pow_self p (Nat.succ_ne_zero n)).trans hpow) with H hbdiv
+  · exact hp.dvd_of_dvd_pow H
+  obtain ⟨x, rfl⟩ := hp.dvd_of_dvd_pow hbdiv
+  obtain ⟨y, hy⟩ := hpow
+  -- Then we can divide out a common factor of `p ^ n` from the equation `hy`.
+  have : a ^ n.succ * x ^ n = p * y := by
+    refine' mul_left_cancel₀ (pow_ne_zero n hp.ne_zero) _
+    rw [← mul_assoc _ p, ← pow_succ', ← hy, mul_pow, ← mul_assoc (a ^ n.succ), mul_comm _ (p ^ n),
+      mul_assoc]
+  -- So `p ∣ a` (and we're done) or `p ∣ x`, which can't be the case since it implies `p^2 ∣ b`.
+  refine' hp.dvd_of_dvd_pow ((hp.dvd_or_dvd ⟨_, this⟩).resolve_right fun hdvdx => hb _)
+  obtain ⟨z, rfl⟩ := hp.dvd_of_dvd_pow hdvdx
+  rw [pow_two, ← mul_assoc]
+  exact dvd_mul_right _ _
+#align prime.dvd_of_pow_dvd_pow_mul_pow_of_square_not_dvd Prime.dvd_of_pow_dvd_pow_mul_pow_of_square_not_dvd
+
+theorem prime_pow_succ_dvd_mul {α : Type*} [CancelCommMonoidWithZero α] {p x y : α} (h : Prime p)
+    {i : ℕ} (hxy : p ^ (i + 1) ∣ x * y) : p ^ (i + 1) ∣ x ∨ p ∣ y := by
+  rw [or_iff_not_imp_right]
+  intro hy
+  induction' i with i ih generalizing x
+  · rw [pow_one] at hxy ⊢
+    exact (h.dvd_or_dvd hxy).resolve_right hy
+  rw [pow_succ] at hxy ⊢
+  obtain ⟨x', rfl⟩ := (h.dvd_or_dvd (dvd_of_mul_right_dvd hxy)).resolve_right hy
+  rw [mul_assoc] at hxy
+  exact mul_dvd_mul_left p (ih ((mul_dvd_mul_iff_left h.ne_zero).mp hxy))
+#align prime_pow_succ_dvd_mul prime_pow_succ_dvd_mul
+
+theorem of_irreducible_pow {α} [Monoid α] {x : α} {n : ℕ} (hn : n ≠ 1) :
+    Irreducible (x ^ n) → IsUnit x := by
+  obtain hn | hn := hn.lt_or_lt
+  · simp only [Nat.lt_one_iff.mp hn, IsEmpty.forall_iff, not_irreducible_one, pow_zero]
+  intro h
+  obtain ⟨k, rfl⟩ := Nat.exists_eq_add_of_lt hn
+  rw [pow_succ, add_comm] at h
+  exact (or_iff_left_of_imp isUnit_pow_succ_iff.mp).mp (of_irreducible_mul h)
+#align of_irreducible_pow of_irreducible_pow
+
+section CommMonoid
+
+variable [CommMonoid α] {a : α}
+
+theorem Irreducible.not_square (ha : Irreducible a) : ¬IsSquare a := by
+  rintro ⟨b, rfl⟩
+  simp only [irreducible_mul_iff, or_self_iff] at ha
+  exact ha.1.not_unit ha.2
+#align irreducible.not_square Irreducible.not_square
+
+theorem IsSquare.not_irreducible (ha : IsSquare a) : ¬Irreducible a := fun h => h.not_square ha
+#align is_square.not_irreducible IsSquare.not_irreducible
+
+end CommMonoid
+
+section CancelCommMonoidWithZero
+
+variable [CancelCommMonoidWithZero α] {a p : α}
+
+theorem succ_dvd_or_succ_dvd_of_succ_sum_dvd_mul (hp : Prime p) {a b : α} {k l : ℕ} :
+    p ^ k ∣ a → p ^ l ∣ b → p ^ (k + l + 1) ∣ a * b → p ^ (k + 1) ∣ a ∨ p ^ (l + 1) ∣ b :=
+  fun ⟨x, hx⟩ ⟨y, hy⟩ ⟨z, hz⟩ =>
+  have h : p ^ (k + l) * (x * y) = p ^ (k + l) * (p * z) := by
+    simpa [mul_comm, pow_add, hx, hy, mul_assoc, mul_left_comm] using hz
+  have hp0 : p ^ (k + l) ≠ 0 := pow_ne_zero _ hp.ne_zero
+  have hpd : p ∣ x * y := ⟨z, by rwa [mul_right_inj' hp0] at h⟩
+  (hp.dvd_or_dvd hpd).elim
+    (fun ⟨d, hd⟩ => Or.inl ⟨d, by simp [*, pow_succ, mul_comm, mul_left_comm, mul_assoc]⟩)
+    fun ⟨d, hd⟩ => Or.inr ⟨d, by simp [*, pow_succ, mul_comm, mul_left_comm, mul_assoc]⟩
+#align succ_dvd_or_succ_dvd_of_succ_sum_dvd_mul succ_dvd_or_succ_dvd_of_succ_sum_dvd_mul
+
+theorem Prime.not_square (hp : Prime p) : ¬IsSquare p :=
+  hp.irreducible.not_square
+#align prime.not_square Prime.not_square
+
+theorem IsSquare.not_prime (ha : IsSquare a) : ¬Prime a := fun h => h.not_square ha
+#align is_square.not_prime IsSquare.not_prime
+
+theorem pow_not_prime {n : ℕ} (hn : n ≠ 1) : ¬Prime (a ^ n) := fun hp =>
+  hp.not_unit <| IsUnit.pow _ <| of_irreducible_pow hn <| hp.irreducible
+#align pow_not_prime pow_not_prime
+
+end CancelCommMonoidWithZero
+
+/-- Notation for two elements of a monoid are associated, i.e.
+if one of them is another one multiplied by a unit on the right.-/
+local infixl:50 " ~ᵤ " => Associated
+
+theorem Associated.of_pow_associated_of_prime [CancelCommMonoidWithZero α] {p₁ p₂ : α} {k₁ k₂ : ℕ}
+    (hp₁ : Prime p₁) (hp₂ : Prime p₂) (hk₁ : 0 < k₁) (h : p₁ ^ k₁ ~ᵤ p₂ ^ k₂) : p₁ ~ᵤ p₂ := by
+  have : p₁ ∣ p₂ ^ k₂ := by
+    rw [← h.dvd_iff_dvd_right]
+    apply dvd_pow_self _ hk₁.ne'
+  rw [← hp₁.dvd_prime_iff_associated hp₂]
+  exact hp₁.dvd_of_dvd_pow this
+#align associated.of_pow_associated_of_prime Associated.of_pow_associated_of_prime
+
+theorem Associated.of_pow_associated_of_prime' [CancelCommMonoidWithZero α] {p₁ p₂ : α} {k₁ k₂ : ℕ}
+    (hp₁ : Prime p₁) (hp₂ : Prime p₂) (hk₂ : 0 < k₂) (h : p₁ ^ k₁ ~ᵤ p₂ ^ k₂) : p₁ ~ᵤ p₂ :=
+  (h.symm.of_pow_associated_of_prime hp₂ hp₁ hk₂).symm
+#align associated.of_pow_associated_of_prime' Associated.of_pow_associated_of_prime'
+
+section UniqueUnits₀
+
+variable {R : Type*} [CancelCommMonoidWithZero R] [Unique Rˣ] {p₁ p₂ : R} {k₁ k₂ : ℕ}
+
+theorem eq_of_prime_pow_eq (hp₁ : Prime p₁) (hp₂ : Prime p₂) (hk₁ : 0 < k₁)
+    (h : p₁ ^ k₁ = p₂ ^ k₂) : p₁ = p₂ := by
+  rw [← associated_iff_eq] at h ⊢
+  apply h.of_pow_associated_of_prime hp₁ hp₂ hk₁
+#align eq_of_prime_pow_eq eq_of_prime_pow_eq
+
+theorem eq_of_prime_pow_eq' (hp₁ : Prime p₁) (hp₂ : Prime p₂) (hk₁ : 0 < k₂)
+    (h : p₁ ^ k₁ = p₂ ^ k₂) : p₁ = p₂ := by
+  rw [← associated_iff_eq] at h ⊢
+  apply h.of_pow_associated_of_prime' hp₁ hp₂ hk₁
+#align eq_of_prime_pow_eq' eq_of_prime_pow_eq'
+
+end UniqueUnits₀
+
+section CancelCommMonoidWithZero
+
+theorem pow_injective_of_not_unit [CancelCommMonoidWithZero α] {q : α} (hq : ¬IsUnit q)
+    (hq' : q ≠ 0) : Function.Injective fun n : ℕ => q ^ n := by
+  refine' injective_of_lt_imp_ne fun n m h => DvdNotUnit.ne ⟨pow_ne_zero n hq', q ^ (m - n), _, _⟩
+  · exact not_isUnit_of_not_isUnit_dvd hq (dvd_pow (dvd_refl _) (Nat.sub_pos_of_lt h).ne')
+  · exact (pow_mul_pow_sub q h.le).symm
+#align pow_injective_of_not_unit pow_injective_of_not_unit
+
+theorem dvd_prime_pow [CancelCommMonoidWithZero α] {p q : α} (hp : Prime p) (n : ℕ) :
+    q ∣ p ^ n ↔ ∃ i ≤ n, Associated q (p ^ i) := by
+  induction' n with n ih generalizing q
+  · simp [← isUnit_iff_dvd_one, associated_one_iff_isUnit]
+  refine' ⟨fun h => _, fun ⟨i, hi, hq⟩ => hq.dvd.trans (pow_dvd_pow p hi)⟩
+  rw [pow_succ] at h
+  rcases hp.left_dvd_or_dvd_right_of_dvd_mul h with (⟨q, rfl⟩ | hno)
+  · rw [mul_dvd_mul_iff_left hp.ne_zero, ih] at h
+    rcases h with ⟨i, hi, hq⟩
+    refine' ⟨i + 1, Nat.succ_le_succ hi, (hq.mul_left p).trans _⟩
+    rw [pow_succ]
+    rfl
+  · obtain ⟨i, hi, hq⟩ := ih.mp hno
+    exact ⟨i, hi.trans n.le_succ, hq⟩
+#align dvd_prime_pow dvd_prime_pow
+
+end CancelCommMonoidWithZero


### PR DESCRIPTION
This is a pretty low-level file with fairly heavy dependencies, a number of which are only needed for results relating to powers. This seems like a relatively clear cut-off point.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

I'm opening this PR for comments before going through and fixing all the import issues.

If we're interested in reducing the dependencies even more:

- Moving `dvdNotUnit_of_dvdNotUnit_associated` allows dropping `Mathlib.Algebra.GroupWithZero.Units.Basic`
- Moving `MulEquiv.prime_iff` allows dropping `Mathlib.Algebra.Hom.Equiv.Basic`
- Moving `comap_prime` allows dropping `Mathlib.Algebra.Hom.Units`
- Moving `Associates` allows dropping `Mathlib.Algebra.Order.Monoid.Canonical.Defs`

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
