### PR TITLE
[Merged by Bors] - docs(Algebra/MonoidAlgebra/Basic): fix order of arguments in docs

### DIFF
--- a/Mathlib/Algebra/MonoidAlgebra/Basic.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Basic.lean
@@ -30,8 +30,8 @@ in the same way, and then define the convolution product on these.
 
 When the domain is additive, this is used to define polynomials:
 ```
-Polynomial α := AddMonoidAlgebra α ℕ
-MvPolynomial σ α := AddMonoidAlgebra α (σ →₀ ℕ)
+Polynomial R := AddMonoidAlgebra R ℕ
+MvPolynomial σ α := AddMonoidAlgebra R (σ →₀ ℕ)
 ```
 
 When the domain is multiplicative, e.g. a group, this will be used to define the group ring.

--- a/Mathlib/Algebra/MonoidAlgebra/Basic.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Basic.lean
@@ -30,8 +30,8 @@ in the same way, and then define the convolution product on these.
 
 When the domain is additive, this is used to define polynomials:
 ```
-Polynomial α := AddMonoidAlgebra ℕ α
-MvPolynomial σ α := AddMonoidAlgebra (σ →₀ ℕ) α
+Polynomial α := AddMonoidAlgebra α ℕ
+MvPolynomial σ α := AddMonoidAlgebra α (σ →₀ ℕ)
 ```
 
 When the domain is multiplicative, e.g. a group, this will be used to define the group ring.


### PR DESCRIPTION
The arguments to `AddMonoidAlgebra` were reversed with respect to normal use in the module docs.  They also used `α` instead of `R`.  For reference, these are the actual definitions:

```lean
-- Data/MvPolynomial/Basic
def MvPolynomial (σ : Type*) (R : Type*) [CommSemiring R] :=
  AddMonoidAlgebra R (σ →₀ ℕ)

-- Data/Polynomial/Basic
structure Polynomial (R : Type*) [Semiring R] where ofFinsupp ::
  toFinsupp : AddMonoidAlgebra R ℕ
```

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
