### PR TITLE
[Merged by Bors] - feat: beta% term elaborator

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3515,6 +3515,7 @@ import Mathlib.Util.Superscript
 import Mathlib.Util.Syntax
 import Mathlib.Util.SynthesizeUsing
 import Mathlib.Util.Tactic
+import Mathlib.Util.TermBeta
 import Mathlib.Util.Time
 import Mathlib.Util.WhatsNew
 import Mathlib.Util.WithWeakNamespace

--- a/Mathlib/Util/TermBeta.lean
+++ b/Mathlib/Util/TermBeta.lean
@@ -1,0 +1,38 @@
+/-
+Copyright (c) 2023 Kyle Miller. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kyle Miller
+-/
+import Lean
+
+/-! `beta%` term elaborator
+
+The `beta% f x1 ... xn` term elaborator elaborates the expression
+`f x1 ... xn` and then does one level of beta reduction.
+That is, if `f` is a lambda then it will substitute its arguments.
+
+The purpose of this is to support substitutions in notations such as
+`∀ i, beta% p i` so that `p i` gets beta reduced when `p` is a lambda.
+-/
+
+namespace Mathlib.Util.TermBeta
+
+open Lean Elab Term
+
+/-- `beta% t` elaborates `t` and then if the result is in the form
+`f x1 ... xn` where `f` is a (nested) lambda expression,
+it will substitute all of its arguments by beta reduction.
+This does not recursively do beta reduction, nor will it do
+beta reduction of subexpressions.
+
+In particular, `t` is elaborated, its metavariables are instantiated,
+and then `Lean.Expr.headBeta` is applied. -/
+syntax (name := betaStx) "beta% " term : term
+
+@[term_elab betaStx, inherit_doc betaStx]
+def elabBeta : TermElab := fun stx expectedType? =>
+  match stx with
+  | `(beta% $t) => do
+    let e ← elabTerm t expectedType?
+    return (← instantiateMVars e).headBeta
+  | _ => throwUnsupportedSyntax

--- a/test/TermBeta.lean
+++ b/test/TermBeta.lean
@@ -30,3 +30,8 @@ set_option pp.unicode.fun true
 
 /-- info: true && false : Bool -/
 #guard_msgs in #check beta% (· && ·) true false
+
+abbrev reducibleId : Bool → Bool := fun x => x
+
+/-- info: reducibleId true : Bool -/
+#guard_msgs in #check reducibleId true

--- a/test/TermBeta.lean
+++ b/test/TermBeta.lean
@@ -1,6 +1,9 @@
 import Mathlib.Util.TermBeta
 import Std.Tactic.GuardMsgs
 
+-- On command line, tests format functions with => rather than ↦ without this.
+set_option pp.unicode.fun true
+
 /-- info: (fun x ↦ x) true : Bool -/
 #guard_msgs in #check (fun x => x) true
 

--- a/test/TermBeta.lean
+++ b/test/TermBeta.lean
@@ -1,0 +1,29 @@
+import Mathlib.Util.TermBeta
+import Std.Tactic.GuardMsgs
+
+/-- info: (fun x ↦ x) true : Bool -/
+#guard_msgs in #check (fun x => x) true
+
+/-- info: true : Bool -/
+#guard_msgs in #check beta% (fun x => x) true
+
+/-- info: (fun x y ↦ (x, y)) true : Bool → Bool × Bool -/
+#guard_msgs in #check (fun (x y : Bool) => (x, y)) true
+
+/-- info: fun y ↦ (true, y) : Bool → Bool × Bool -/
+#guard_msgs in #check beta% (fun (x y : Bool) => (x, y)) true
+
+/-- info: (fun x ↦ cond x) true 1 : Nat → Nat -/
+#guard_msgs in #check (fun (x : Bool) => cond x) true 1
+
+/-- info: cond true 1 : Nat → Nat -/
+#guard_msgs in #check beta% (fun (x : Bool) => cond x) true 1
+
+/-- info: ∀ (i : Nat), 0 ≤ i : Prop -/
+#guard_msgs in #check ∀ i : Nat, beta% (fun j => 0 ≤ j) i
+
+/-- info: (fun x x_1 ↦ x && x_1) true false : Bool -/
+#guard_msgs in #check (· && ·) true false
+
+/-- info: true && false : Bool -/
+#guard_msgs in #check beta% (· && ·) true false


### PR DESCRIPTION
Defines a `beta% t` syntax that elaborates `t` and then does one level of beta reduction using `Lean.Expr.headBeta`. This is useful for defining notations that insert a function under a binder and want to substitute the bound variable, for example `∀ i, beta% p i`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
