### PR TITLE
[Merged by Bors] - chore: disable `pp.proof.withType` globally

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -4,6 +4,7 @@ open Lake DSL
 
 def moreServerArgs := #[
   "-Dpp.unicode.fun=true", -- pretty-prints `fun a ↦ b`
+  "-Dpp.proofs.withType=false",
   "-DautoImplicit=false",
   "-DrelaxedAutoImplicit=false"
 ]


### PR DESCRIPTION
Related [Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Pretty.20printing.20.60proofs.2EWithType.60)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
