### PR TITLE
[Merged by Bors] - feat: strong law of large numbers for vector-valued random variables

### DIFF
--- a/Mathlib/MeasureTheory/Function/SimpleFunc.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFunc.lean
@@ -1315,7 +1315,7 @@ protected theorem induction {α γ} [MeasurableSpace α] [AddMonoid γ] {P : Sim
 /-- In a topological vector space, the addition of a measurable function and a simple function is
 measurable. -/
 theorem _root_.Measurable.add_simpleFunc
-    {E : Type*} [MeasurableSpace α] [MeasurableSpace E] [AddGroup E] [MeasurableAdd E]
+    {E : Type*} {_ : MeasurableSpace α} [MeasurableSpace E] [AddGroup E] [MeasurableAdd E]
     {g : α → E} (hg : Measurable g) (f : SimpleFunc α E) :
     Measurable (g + (f : α → E)) := by
   classical
@@ -1340,7 +1340,7 @@ theorem _root_.Measurable.add_simpleFunc
 /-- In a topological vector space, the addition of a simple function and a measurable function is
 measurable. -/
 theorem _root_.Measurable.simpleFunc_add
-    {E : Type*} [MeasurableSpace α] [MeasurableSpace E] [AddGroup E] [MeasurableAdd E]
+    {E : Type*} {_ : MeasurableSpace α} [MeasurableSpace E] [AddGroup E] [MeasurableAdd E]
     {g : α → E} (hg : Measurable g) (f : SimpleFunc α E) :
     Measurable ((f : α → E) + g) := by
   classical

--- a/Mathlib/MeasureTheory/Function/SimpleFunc.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFunc.lean
@@ -1312,6 +1312,33 @@ protected theorem induction {α γ} [MeasurableSpace α] [AddMonoid γ] {P : Sim
     · simp [piecewise_eq_of_not_mem _ _ _ hy, -piecewise_eq_indicator]
 #align measure_theory.simple_func.induction MeasureTheory.SimpleFunc.induction
 
+/-- In a topological vector space, the addition of a measurable function and a simple function is
+measurable. -/
+theorem _root_.Measurable.add_simpleFunc
+    {E : Type*} [MeasurableSpace α] [MeasurableSpace E] [AddGroup E] [MeasurableAdd E]
+    {g : α → E} (hg : Measurable g) (f : SimpleFunc α E) :
+    Measurable (g + (f : α → E)) := by
+  classical
+  apply SimpleFunc.induction (P := fun φ ↦ Measurable (fun x ↦ g x + φ x)) ?_ ?_ f
+  · intro c s hs
+    simp only [SimpleFunc.const_zero, SimpleFunc.coe_piecewise, SimpleFunc.coe_const,
+      SimpleFunc.coe_zero]
+    change Measurable (g + s.piecewise (Function.const α c) (0 : α → E))
+    rw [← piecewise_same s g, ← piecewise_add]
+    exact Measurable.piecewise hs (hg.add_const _) (hg.add_const _)
+  · intro f f' hff' hf hf'
+    have : (fun x ↦ g x + (f + f') x)
+        = (Function.support f).piecewise (g + (f : α → E)) (g + f') := by
+      ext x
+      by_cases hx : x ∈ Function.support f
+      · simpa only [SimpleFunc.coe_add, Pi.add_apply, Function.mem_support, ne_eq, not_not,
+          Set.piecewise_eq_of_mem _ _ _ hx, _root_.add_right_inj, add_right_eq_self]
+          using Set.disjoint_left.1 hff' hx
+      · simpa only [SimpleFunc.coe_add, Pi.add_apply, Function.mem_support, ne_eq, not_not,
+          Set.piecewise_eq_of_not_mem _ _ _ hx, _root_.add_right_inj, add_left_eq_self] using hx
+    rw [this]
+    exact Measurable.piecewise f.measurableSet_support hf hf'
+
 end SimpleFunc
 
 end MeasureTheory

--- a/Mathlib/MeasureTheory/Function/SimpleFunc.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFunc.lean
@@ -1319,15 +1319,13 @@ theorem _root_.Measurable.add_simpleFunc
     {g : α → E} (hg : Measurable g) (f : SimpleFunc α E) :
     Measurable (g + (f : α → E)) := by
   classical
-  apply SimpleFunc.induction (P := fun φ ↦ Measurable (fun x ↦ g x + φ x)) ?_ ?_ f
-  · intro c s hs
-    simp only [SimpleFunc.const_zero, SimpleFunc.coe_piecewise, SimpleFunc.coe_const,
+  induction' f using SimpleFunc.induction with c s hs f f' hff' hf hf'
+  · simp only [SimpleFunc.const_zero, SimpleFunc.coe_piecewise, SimpleFunc.coe_const,
       SimpleFunc.coe_zero]
     change Measurable (g + s.piecewise (Function.const α c) (0 : α → E))
     rw [← piecewise_same s g, ← piecewise_add]
     exact Measurable.piecewise hs (hg.add_const _) (hg.add_const _)
-  · intro f f' hff' hf hf'
-    have : (fun x ↦ g x + (f + f') x)
+  · have : (g + ↑(f + f'))
         = (Function.support f).piecewise (g + (f : α → E)) (g + f') := by
       ext x
       by_cases hx : x ∈ Function.support f
@@ -1336,6 +1334,31 @@ theorem _root_.Measurable.add_simpleFunc
           using Set.disjoint_left.1 hff' hx
       · simpa only [SimpleFunc.coe_add, Pi.add_apply, Function.mem_support, ne_eq, not_not,
           Set.piecewise_eq_of_not_mem _ _ _ hx, _root_.add_right_inj, add_left_eq_self] using hx
+    rw [this]
+    exact Measurable.piecewise f.measurableSet_support hf hf'
+
+/-- In a topological vector space, the addition of a simple function and a measurable function is
+measurable. -/
+theorem _root_.Measurable.simpleFunc_add
+    {E : Type*} [MeasurableSpace α] [MeasurableSpace E] [AddGroup E] [MeasurableAdd E]
+    {g : α → E} (hg : Measurable g) (f : SimpleFunc α E) :
+    Measurable ((f : α → E) + g) := by
+  classical
+  induction' f using SimpleFunc.induction with c s hs f f' hff' hf hf'
+  · simp only [SimpleFunc.const_zero, SimpleFunc.coe_piecewise, SimpleFunc.coe_const,
+      SimpleFunc.coe_zero]
+    change Measurable (s.piecewise (Function.const α c) (0 : α → E) + g)
+    rw [← piecewise_same s g, ← piecewise_add]
+    exact Measurable.piecewise hs (hg.const_add _) (hg.const_add _)
+  · have : (↑(f + f') + g)
+        = (Function.support f).piecewise ((f : α → E) + g) (f' + g) := by
+      ext x
+      by_cases hx : x ∈ Function.support f
+      · simpa only [coe_add, Pi.add_apply, Function.mem_support, ne_eq, not_not,
+          Set.piecewise_eq_of_mem _ _ _ hx, _root_.add_left_inj, add_right_eq_self]
+          using Set.disjoint_left.1 hff' hx
+      · simpa only [SimpleFunc.coe_add, Pi.add_apply, Function.mem_support, ne_eq, not_not,
+          Set.piecewise_eq_of_not_mem _ _ _ hx, _root_.add_left_inj, add_left_eq_self] using hx
     rw [this]
     exact Measurable.piecewise f.measurableSet_support hf hf'
 

--- a/Mathlib/MeasureTheory/Function/StronglyMeasurable/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/StronglyMeasurable/Basic.lean
@@ -466,7 +466,7 @@ protected theorem smul_const {𝕜} [TopologicalSpace 𝕜] [SMul 𝕜 β] [Cont
 function is measurable. Note that this is not true without further second-countability assumptions
 for the addition of two measurable functions. -/
 theorem _root_.Measurable.add_stronglyMeasurable
-    {α E : Type*} [MeasurableSpace α] [AddGroup E] [TopologicalSpace E]
+    {α E : Type*} {_ : MeasurableSpace α} [AddGroup E] [TopologicalSpace E]
     [MeasurableSpace E] [BorelSpace E] [ContinuousAdd E] [PseudoMetrizableSpace E]
     {g f : α → E} (hg : Measurable g) (hf : StronglyMeasurable f) :
     Measurable (g + f) := by
@@ -480,7 +480,7 @@ theorem _root_.Measurable.add_stronglyMeasurable
 function is measurable. Note that this is not true without further second-countability assumptions
 for the subtraction of two measurable functions. -/
 theorem _root_.Measurable.sub_stronglyMeasurable
-    {α E : Type*} [MeasurableSpace α] [AddCommGroup E] [TopologicalSpace E]
+    {α E : Type*} {_ : MeasurableSpace α} [AddCommGroup E] [TopologicalSpace E]
     [MeasurableSpace E] [BorelSpace E] [ContinuousAdd E] [ContinuousNeg E] [PseudoMetrizableSpace E]
     {g f : α → E} (hg : Measurable g) (hf : StronglyMeasurable f) :
     Measurable (g - f) := by
@@ -491,7 +491,7 @@ theorem _root_.Measurable.sub_stronglyMeasurable
 function is measurable. Note that this is not true without further second-countability assumptions
 for the addition of two measurable functions. -/
 theorem _root_.Measurable.stronglyMeasurable_add
-    {α E : Type*} [MeasurableSpace α] [AddGroup E] [TopologicalSpace E]
+    {α E : Type*} {_ : MeasurableSpace α} [AddGroup E] [TopologicalSpace E]
     [MeasurableSpace E] [BorelSpace E] [ContinuousAdd E] [PseudoMetrizableSpace E]
     {g f : α → E} (hg : Measurable g) (hf : StronglyMeasurable f) :
     Measurable (f + g) := by

--- a/Mathlib/MeasureTheory/Function/StronglyMeasurable/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/StronglyMeasurable/Basic.lean
@@ -487,6 +487,20 @@ theorem _root_.Measurable.sub_stronglyMeasurable
   rw [sub_eq_add_neg]
   exact hg.add_stronglyMeasurable hf.neg
 
+/-- In a normed vector space, the addition of a strongly measurable function and a measurable
+function is measurable. Note that this is not true without further second-countability assumptions
+for the addition of two measurable functions. -/
+theorem _root_.Measurable.stronglyMeasurable_add
+    {α E : Type*} [MeasurableSpace α] [AddGroup E] [TopologicalSpace E]
+    [MeasurableSpace E] [BorelSpace E] [ContinuousAdd E] [PseudoMetrizableSpace E]
+    {g f : α → E} (hg : Measurable g) (hf : StronglyMeasurable f) :
+    Measurable (f + g) := by
+  rcases hf with ⟨φ, hφ⟩
+  have : Tendsto (fun n x ↦ φ n x + g x) atTop (𝓝 (f + g)) :=
+    tendsto_pi_nhds.2 (fun x ↦ (hφ x).add tendsto_const_nhds)
+  apply measurable_of_tendsto_metrizable (fun n ↦ ?_) this
+  exact hg.simpleFunc_add _
+
 end Arithmetic
 
 section MulAction

--- a/Mathlib/MeasureTheory/Function/StronglyMeasurable/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/StronglyMeasurable/Basic.lean
@@ -462,6 +462,31 @@ protected theorem smul_const {𝕜} [TopologicalSpace 𝕜] [SMul 𝕜 β] [Cont
 #align measure_theory.strongly_measurable.smul_const MeasureTheory.StronglyMeasurable.smul_const
 #align measure_theory.strongly_measurable.vadd_const MeasureTheory.StronglyMeasurable.vadd_const
 
+/-- In a normed vector space, the addition of a measurable function and a strongly measurable
+function is measurable. Note that this is not true without further second-countability assumptions
+for the addition of two measurable functions. -/
+theorem _root_.Measurable.add_stronglyMeasurable
+    {α E : Type*} [MeasurableSpace α] [AddGroup E] [TopologicalSpace E]
+    [MeasurableSpace E] [BorelSpace E] [ContinuousAdd E] [PseudoMetrizableSpace E]
+    {g f : α → E} (hg : Measurable g) (hf : StronglyMeasurable f) :
+    Measurable (g + f) := by
+  rcases hf with ⟨φ, hφ⟩
+  have : Tendsto (fun n x ↦ g x + φ n x) atTop (𝓝 (g + f)) :=
+    tendsto_pi_nhds.2 (fun x ↦ tendsto_const_nhds.add (hφ x))
+  apply measurable_of_tendsto_metrizable (fun n ↦ ?_) this
+  exact hg.add_simpleFunc _
+
+/-- In a normed vector space, the subtraction of a measurable function and a strongly measurable
+function is measurable. Note that this is not true without further second-countability assumptions
+for the subtraction of two measurable functions. -/
+theorem _root_.Measurable.sub_stronglyMeasurable
+    {α E : Type*} [MeasurableSpace α] [AddCommGroup E] [TopologicalSpace E]
+    [MeasurableSpace E] [BorelSpace E] [ContinuousAdd E] [ContinuousNeg E] [PseudoMetrizableSpace E]
+    {g f : α → E} (hg : Measurable g) (hf : StronglyMeasurable f) :
+    Measurable (g - f) := by
+  rw [sub_eq_add_neg]
+  exact hg.add_stronglyMeasurable hf.neg
+
 end Arithmetic
 
 section MulAction
@@ -2107,3 +2132,6 @@ end MeasureTheory
 
 -- Guard against import creep
 assert_not_exists InnerProductSpace
+
+
+open Set TopologicalSpace

--- a/Mathlib/MeasureTheory/Function/StronglyMeasurable/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/StronglyMeasurable/Basic.lean
@@ -2132,6 +2132,3 @@ end MeasureTheory
 
 -- Guard against import creep
 assert_not_exists InnerProductSpace
-
-
-open Set TopologicalSpace

--- a/Mathlib/MeasureTheory/Function/UniformIntegrable.lean
+++ b/Mathlib/MeasureTheory/Function/UniformIntegrable.lean
@@ -917,23 +917,20 @@ theorem uniformIntegrable_iff [IsFiniteMeasure μ] (hp : 1 ≤ p) (hp' : p ≠ �
 #align measure_theory.uniform_integrable_iff MeasureTheory.uniformIntegrable_iff
 
 /-- The averaging of a uniformly integrable sequence is also uniformly integrable. -/
-theorem uniformIntegrable_average (hp : 1 ≤ p) {f : ℕ → α → ℝ} (hf : UniformIntegrable f p μ) :
-    UniformIntegrable (fun n => (∑ i in Finset.range n, f i) / (n : α → ℝ)) p μ := by
+theorem uniformIntegrable_average
+    {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+    [MeasurableSpace E] [BorelSpace E]
+    (hp : 1 ≤ p) {f : ℕ → α → E} (hf : UniformIntegrable f p μ) :
+    UniformIntegrable (fun (n : ℕ) => (n : ℝ)⁻¹ • (∑ i in Finset.range n, f i)) p μ := by
   obtain ⟨hf₁, hf₂, hf₃⟩ := hf
   refine' ⟨fun n => _, fun ε hε => _, _⟩
-  · simp_rw [div_eq_mul_inv]
-    exact (Finset.aestronglyMeasurable_sum' _ fun i _ => hf₁ i).mul
-      (aestronglyMeasurable_const : AEStronglyMeasurable (fun _ => (↑n : ℝ)⁻¹) μ)
+  · exact (Finset.aestronglyMeasurable_sum' _ fun i _ => hf₁ i).const_smul _
   · obtain ⟨δ, hδ₁, hδ₂⟩ := hf₂ hε
     refine' ⟨δ, hδ₁, fun n s hs hle => _⟩
-    simp_rw [div_eq_mul_inv, Finset.sum_mul, Set.indicator_finset_sum]
-    refine' le_trans (snorm_sum_le (fun i _ => ((hf₁ i).mul_const (↑n)⁻¹).indicator hs) hp) _
-    have : ∀ i, s.indicator (f i * (n : α → ℝ)⁻¹) = (↑n : ℝ)⁻¹ • s.indicator (f i) := by
-      intro i
-      rw [mul_comm, (_ : (↑n)⁻¹ * f i = fun ω => (↑n : ℝ)⁻¹ • f i ω)]
-      · rw [Set.indicator_const_smul s (↑n : ℝ)⁻¹ (f i)]
-        rfl
-      · rfl
+    simp_rw [Finset.smul_sum, Set.indicator_finset_sum]
+    refine' le_trans (snorm_sum_le (fun i _ => ((hf₁ i).const_smul _).indicator hs) hp) _
+    have : ∀ i, s.indicator ((n : ℝ) ⁻¹ • f i) = (↑n : ℝ)⁻¹ • s.indicator (f i) :=
+      fun i ↦ indicator_const_smul _ _ _
     simp_rw [this, snorm_const_smul, ← Finset.mul_sum, nnnorm_inv, Real.nnnorm_coe_nat]
     by_cases hn : (↑(↑n : ℝ≥0)⁻¹ : ℝ≥0∞) = 0
     · simp only [hn, zero_mul, zero_le]
@@ -946,13 +943,9 @@ theorem uniformIntegrable_average (hp : 1 ≤ p) {f : ℕ → α → ℝ} (hf : 
         ENNReal.inv_mul_cancel _ (ENNReal.nat_ne_top _), one_mul]
       all_goals simpa only [Ne.def, Nat.cast_eq_zero]
   · obtain ⟨C, hC⟩ := hf₃
-    simp_rw [div_eq_mul_inv, Finset.sum_mul]
-    refine' ⟨C, fun n => (snorm_sum_le (fun i _ => (hf₁ i).mul_const (↑n)⁻¹) hp).trans _⟩
-    have : ∀ i, (fun ω => f i ω * (↑n)⁻¹) = (↑n : ℝ)⁻¹ • fun ω => f i ω := by
-      intro i
-      ext ω
-      simp only [mul_comm, Pi.smul_apply, Algebra.id.smul_eq_mul]
-    simp_rw [this, snorm_const_smul, ← Finset.mul_sum, nnnorm_inv, Real.nnnorm_coe_nat]
+    simp_rw [Finset.smul_sum]
+    refine' ⟨C, fun n => (snorm_sum_le (fun i _ => (hf₁ i).const_smul _) hp).trans _⟩
+    simp_rw [snorm_const_smul, ← Finset.mul_sum, nnnorm_inv, Real.nnnorm_coe_nat]
     by_cases hn : (↑(↑n : ℝ≥0)⁻¹ : ℝ≥0∞) = 0
     · simp only [hn, zero_mul, zero_le]
     refine' le_trans _ (_ : ↑(↑n : ℝ≥0)⁻¹ * (n • C : ℝ≥0∞) ≤ C)
@@ -965,8 +958,17 @@ theorem uniformIntegrable_average (hp : 1 ≤ p) {f : ℕ → α → ℝ} (hf : 
       rw [ENNReal.coe_smul, nsmul_eq_mul, ← mul_assoc, ENNReal.coe_inv, ENNReal.coe_nat,
         ENNReal.inv_mul_cancel _ (ENNReal.nat_ne_top _), one_mul]
       all_goals simpa only [Ne.def, Nat.cast_eq_zero]
-#align measure_theory.uniform_integrable_average MeasureTheory.uniformIntegrable_average
+
+/-- The averaging of a uniformly integrable real-valued sequence is also uniformly integrable. -/
+theorem uniformIntegrable_average_real (hp : 1 ≤ p) {f : ℕ → α → ℝ} (hf : UniformIntegrable f p μ) :
+    UniformIntegrable (fun n => (∑ i in Finset.range n, f i) / (n : α → ℝ)) p μ := by
+  convert uniformIntegrable_average hp hf using 2 with n
+  ext x
+  simp [div_eq_inv_mul]
+#align measure_theory.uniform_integrable_average MeasureTheory.uniformIntegrable_average_real
 
 end UniformIntegrable
 
 end MeasureTheory
+
+#lint

--- a/Mathlib/MeasureTheory/Function/UniformIntegrable.lean
+++ b/Mathlib/MeasureTheory/Function/UniformIntegrable.lean
@@ -919,7 +919,6 @@ theorem uniformIntegrable_iff [IsFiniteMeasure μ] (hp : 1 ≤ p) (hp' : p ≠ �
 /-- The averaging of a uniformly integrable sequence is also uniformly integrable. -/
 theorem uniformIntegrable_average
     {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
-    [MeasurableSpace E] [BorelSpace E]
     (hp : 1 ≤ p) {f : ℕ → α → E} (hf : UniformIntegrable f p μ) :
     UniformIntegrable (fun (n : ℕ) => (n : ℝ)⁻¹ • (∑ i in Finset.range n, f i)) p μ := by
   obtain ⟨hf₁, hf₂, hf₃⟩ := hf
@@ -970,5 +969,3 @@ theorem uniformIntegrable_average_real (hp : 1 ≤ p) {f : ℕ → α → ℝ} (
 end UniformIntegrable
 
 end MeasureTheory
-
-#lint

--- a/Mathlib/MeasureTheory/Integral/Bochner.lean
+++ b/Mathlib/MeasureTheory/Integral/Bochner.lean
@@ -1445,6 +1445,14 @@ theorem tendsto_integral_approxOn_of_measurable_of_range_subset [MeasurableSpace
   exact eventually_of_forall fun x => subset_closure (hs (Set.mem_union_left _ (mem_range_self _)))
 #align measure_theory.tendsto_integral_approx_on_of_measurable_of_range_subset MeasureTheory.tendsto_integral_approxOn_of_measurable_of_range_subset
 
+theorem tendsto_integral_approxOn_of_measurable' [MeasurableSpace E] [BorelSpace E] {f : α → E}
+    (fmeas : Measurable f) (hf : Integrable f μ) [SeparableSpace (range f ∪ {0} : Set E)] :
+    Tendsto (fun n ↦ ∫ x, SimpleFunc.approxOn f fmeas (range f ∪ {0}) 0 (by simp) n x ∂μ) atTop
+      (𝓝 (∫ x, f x ∂μ)) := by
+  convert tendsto_integral_approxOn_of_measurable_of_range_subset fmeas hf _ Subset.rfl
+  rw [SimpleFunc.integral_eq_integral]
+  exact integrable_approxOn_range fmeas hf _
+
 variable {ν : Measure α}
 
 theorem integral_add_measure {f : α → G} (hμ : Integrable f μ) (hν : Integrable f ν) :

--- a/Mathlib/MeasureTheory/Integral/Bochner.lean
+++ b/Mathlib/MeasureTheory/Integral/Bochner.lean
@@ -1445,13 +1445,16 @@ theorem tendsto_integral_approxOn_of_measurable_of_range_subset [MeasurableSpace
   exact eventually_of_forall fun x => subset_closure (hs (Set.mem_union_left _ (mem_range_self _)))
 #align measure_theory.tendsto_integral_approx_on_of_measurable_of_range_subset MeasureTheory.tendsto_integral_approxOn_of_measurable_of_range_subset
 
-theorem tendsto_integral_approxOn_of_measurable' [MeasurableSpace E] [BorelSpace E] {f : α → E}
+theorem tendsto_integral_norm_approxOn_sub [MeasurableSpace E] [BorelSpace E] {f : α → E}
     (fmeas : Measurable f) (hf : Integrable f μ) [SeparableSpace (range f ∪ {0} : Set E)] :
-    Tendsto (fun n ↦ ∫ x, SimpleFunc.approxOn f fmeas (range f ∪ {0}) 0 (by simp) n x ∂μ) atTop
-      (𝓝 (∫ x, f x ∂μ)) := by
-  convert tendsto_integral_approxOn_of_measurable_of_range_subset fmeas hf _ Subset.rfl
-  rw [SimpleFunc.integral_eq_integral]
-  exact integrable_approxOn_range fmeas hf _
+    Tendsto (fun n ↦ ∫ x, ‖SimpleFunc.approxOn f fmeas (range f ∪ {0}) 0 (by simp) n x - f x‖ ∂μ)
+      atTop (𝓝 0) := by
+  convert (tendsto_toReal zero_ne_top).comp (tendsto_approxOn_range_L1_nnnorm fmeas hf) with n
+  rw [integral_norm_eq_lintegral_nnnorm]
+  · simp
+  · apply (SimpleFunc.aestronglyMeasurable _).sub
+    apply (stronglyMeasurable_iff_measurable_separable.2 ⟨fmeas, ?_⟩ ).aestronglyMeasurable
+    exact (isSeparable_of_separableSpace_subtype (range f ∪ {0})).mono (subset_union_left _ _)
 
 variable {ν : Measure α}
 

--- a/Mathlib/Probability/IdentDistrib.lean
+++ b/Mathlib/Probability/IdentDistrib.lean
@@ -120,6 +120,15 @@ protected theorem of_ae_eq {g : α → γ} (hf : AEMeasurable f μ) (heq : f =�
     map_eq := Measure.map_congr heq }
 #align probability_theory.ident_distrib.of_ae_eq ProbabilityTheory.IdentDistrib.of_ae_eq
 
+lemma _root_.MeasureTheory.AEMeasurable.identDistrib_mk
+    (hf : AEMeasurable f μ) : IdentDistrib f (hf.mk f) μ μ :=
+  IdentDistrib.of_ae_eq hf hf.ae_eq_mk
+
+lemma _root_.MeasureTheory.AEStronglyMeasurable.identDistrib_mk
+    [TopologicalSpace γ] [PseudoMetrizableSpace γ] [BorelSpace γ]
+    (hf : AEStronglyMeasurable f μ) : IdentDistrib f (hf.mk f) μ μ :=
+  IdentDistrib.of_ae_eq hf.aemeasurable hf.ae_eq_mk
+
 theorem measure_mem_eq (h : IdentDistrib f g μ ν) {s : Set γ} (hs : MeasurableSet s) :
     μ (f ⁻¹' s) = ν (g ⁻¹' s) := by
   rw [← Measure.map_apply_of_aemeasurable h.aemeasurable_fst hs, ←

--- a/Mathlib/Probability/IdentDistrib.lean
+++ b/Mathlib/Probability/IdentDistrib.lean
@@ -306,7 +306,7 @@ section UniformIntegrable
 open TopologicalSpace
 
 variable {E : Type*} [MeasurableSpace E] [NormedAddCommGroup E] [BorelSpace E]
-  [SecondCountableTopology E] {μ : Measure α} [IsFiniteMeasure μ]
+  {μ : Measure α} [IsFiniteMeasure μ]
 
 /-- This lemma is superseded by `Memℒp.uniformIntegrable_of_identDistrib` which only requires
 `AEStronglyMeasurable`. -/
@@ -318,17 +318,21 @@ theorem Memℒp.uniformIntegrable_of_identDistrib_aux {ι : Type*} {f : ι → �
   swap; · exact ⟨0, fun i => False.elim (hι <| Nonempty.intro i)⟩
   obtain ⟨C, hC₁, hC₂⟩ := hℒp.snorm_indicator_norm_ge_pos_le μ (hfmeas _) hε
   refine' ⟨⟨C, hC₁.le⟩, fun i => le_trans (le_of_eq _) hC₂⟩
-  have : {x : α | (⟨C, hC₁.le⟩ : ℝ≥0) ≤ ‖f i x‖₊}.indicator (f i) =
-      (fun x : E => if (⟨C, hC₁.le⟩ : ℝ≥0) ≤ ‖x‖₊ then x else 0) ∘ f i := by
+  have : {x | (⟨C, hC₁.le⟩ : ℝ≥0) ≤ ‖f i x‖₊} = {x | C ≤ ‖f i x‖} := by
+    ext x
+    simp_rw [← norm_toNNReal]
+    exact Real.le_toNNReal_iff_coe_le (norm_nonneg _)
+  rw [this, ← snorm_norm, ← snorm_norm (Set.indicator _ _)]
+  simp_rw [norm_indicator_eq_indicator_norm, coe_nnnorm]
+  let F : E → ℝ := (fun x : E => if (⟨C, hC₁.le⟩ : ℝ≥0) ≤ ‖x‖₊ then ‖x‖ else 0)
+  have F_meas : Measurable F := by
+    apply measurable_norm.indicator (measurableSet_le measurable_const measurable_nnnorm)
+  have : ∀ k, (fun x ↦ Set.indicator {x | C ≤ ‖f k x‖} (fun a ↦ ‖f k a‖) x) = F ∘ f k := by
+    intro k
     ext x
     simp only [Set.indicator, Set.mem_setOf_eq]; norm_cast
-  simp_rw [coe_nnnorm, this]
-  rw [← snorm_map_measure _ (hf i).aemeasurable_fst, (hf i).map_eq,
-    snorm_map_measure _ (hf j).aemeasurable_fst]
-  · rfl
-  all_goals
-    exact_mod_cast aestronglyMeasurable_id.indicator
-      (measurableSet_le measurable_const measurable_nnnorm)
+  rw [this, this, ← snorm_map_measure F_meas.aestronglyMeasurable (hf i).aemeasurable_fst,
+    (hf i).map_eq, snorm_map_measure F_meas.aestronglyMeasurable (hf j).aemeasurable_fst]
 #align probability_theory.mem_ℒp.uniform_integrable_of_ident_distrib_aux ProbabilityTheory.Memℒp.uniformIntegrable_of_identDistrib_aux
 
 /-- A sequence of identically distributed Lᵖ functions is p-uniformly integrable. -/

--- a/Mathlib/Probability/StrongLaw.lean
+++ b/Mathlib/Probability/StrongLaw.lean
@@ -645,7 +645,7 @@ end StrongLawNonneg
 /-- **Strong law of large numbers**, almost sure version: if `X n` is a sequence of independent
 identically distributed integrable real-valued random variables, then `∑ i in range n, X i / n`
 converges almost surely to `𝔼[X 0]`. We give here the strong version, due to Etemadi, that only
-requires pairwise independence. Supersed by `strong_law_ae`, which works for random variables
+requires pairwise independence. Superseded by `strong_law_ae`, which works for random variables
 taking values in any Banach space. -/
 theorem strong_law_ae_real (X : ℕ → Ω → ℝ) (hint : Integrable (X 0))
     (hindep : Pairwise fun i j => IndepFun (X i) (X j)) (hident : ∀ i, IdentDistrib (X i) (X 0)) :
@@ -731,7 +731,7 @@ lemma strong_law_ae_of_measurable
     (X : ℕ → Ω → E) (hint : Integrable (X 0)) (h' : StronglyMeasurable (X 0))
     (hindep : Pairwise (fun i j ↦ IndepFun (X i) (X j))) (hident : ∀ i, IdentDistrib (X i) (X 0)) :
     ∀ᵐ ω, Tendsto (fun n : ℕ ↦ (n : ℝ) ⁻¹ • (∑ i in range n, X i ω)) atTop (𝓝 𝔼[X 0]) := by
-  /- Choose a simple function `φ` such that  `φ (X 0)` approximates well enough `X 0` -- this is
+  /- Choose a simple function `φ` such that `φ (X 0)` approximates well enough `X 0` -- this is
   possible as `X 0` is strongly measurable. Then `φ (X n)` approximates well `X n`.
   Then the strong law for `φ (X n)` implies the strong law for `X n`, up to a small
   error controlled by `n⁻¹ ∑_{i=0}^{n-1} ‖X i - φ (X i)‖`. This one is also controlled thanks

--- a/Mathlib/Probability/StrongLaw.lean
+++ b/Mathlib/Probability/StrongLaw.lean
@@ -835,8 +835,7 @@ theorem strong_law_ae
   have : 𝔼[X 0] = 𝔼[Y 0] := integral_congr_ae (AEStronglyMeasurable.ae_eq_mk (A 0).1)
   rw [this]
   apply Tendsto.congr (fun n ↦ ?_) h₂
-  congr
-  ext i
+  congr with i
   exact (h₁ i).symm
 
 end StrongLawVectorSpace
@@ -849,7 +848,7 @@ variable {Ω : Type*} [MeasureSpace Ω] [IsProbabilityMeasure (ℙ : Measure Ω)
 
 /-- **Strong law of large numbers**, Lᵖ version: if `X n` is a sequence of independent
 identically distributed random variables in Lᵖ, then `n⁻¹ • ∑ i in range n, X i`
-converges in `Lᵖ to `𝔼[X 0]`. -/
+converges in `Lᵖ` to `𝔼[X 0]`. -/
 theorem strong_law_Lp {p : ℝ≥0∞} (hp : 1 ≤ p) (hp' : p ≠ ∞) (X : ℕ → Ω → E) (hℒp : Memℒp (X 0) p)
     (hindep : Pairwise fun i j => IndepFun (X i) (X j)) (hident : ∀ i, IdentDistrib (X i) (X 0)) :
     Tendsto (fun (n : ℕ) => snorm (fun ω => (n : ℝ) ⁻¹ • (∑ i in range n, X i ω) - 𝔼[X 0]) p ℙ)

--- a/Mathlib/Probability/StrongLaw.lean
+++ b/Mathlib/Probability/StrongLaw.lean
@@ -780,17 +780,27 @@ theorem strong_law_ae_f_measurable
       simp_rw [I]
       apply (hident i).comp (G_meas k) -/
   filter_upwards [A, B] with ω hω h'ω
-  clear hω h'ω
   rw [tendsto_iff_norm_sub_tendsto_zero, tendsto_order]
   refine ⟨fun c hc ↦ eventually_of_forall (fun n ↦ hc.trans_le (norm_nonneg _)), ?_⟩
   intro ε (εpos : 0 < ε)
   have δ : ℝ := sorry
   have δpos : 0 < δ := sorry
-  have : ∃ k, ∫ ω, ‖(X 0 - Y k 0) ω‖ < δ := by
-    have A := tendsto_integral_approxOn_of_measurable_of_range_subset h'.measurable hint _ Subset.rfl
-    simp [SimpleFunc.integral_eq_integral] at A
-    have Z := SimpleFunc.tendsto_approxOn_range_L1_nnnorm h'.measurable hint
-    have T := (tendsto_order.1 Z).2
+  obtain ⟨k, hk⟩ : ∃ k, ∫ ω, ‖(X 0 - Y k 0) ω‖ < δ := by
+    sorry /-simp_rw [Pi.sub_apply, norm_sub_rev (X 0 _)]
+    exact ((tendsto_order.1 (tendsto_integral_norm_approxOn_sub h'.measurable hint)).2 δ
+      δpos).exists -/
+  have A : ∀ᶠ n in atTop, (∑ i in range n, ‖(X i - Y k i) ω‖) / n < δ :=
+    sorry -- (tendsto_order.1 (h'ω k)).2 δ hk
+  have B : ∀ᶠ (n : ℕ) in atTop, ‖(n : ℝ) ⁻¹ • (∑ i in range n, Y k i ω) - 𝔼[Y k 0]‖ < δ := by
+    specialize hω k
+    rw [tendsto_iff_norm_sub_tendsto_zero] at hω
+    exact (tendsto_order.1 hω).2 δ δpos
+  clear hω h'ω
+  filter_upwards [A, B] with n hn h'n
+  calc ‖(n : ℝ)⁻¹ • ∑ i in Finset.range n, X i ω - ∫ (a : Ω), X 0 a‖ < ε := sorry
+
+
+
 
 
 

--- a/Mathlib/Probability/StrongLaw.lean
+++ b/Mathlib/Probability/StrongLaw.lean
@@ -61,9 +61,6 @@ open Set (indicator)
 
 open scoped Topology BigOperators MeasureTheory ProbabilityTheory ENNReal NNReal
 
-open Set TopologicalSpace
-
-
 namespace ProbabilityTheory
 
 /-! ### Prerequisites on truncations -/
@@ -766,10 +763,10 @@ theorem strong_law_ae_f_measurable
   let Y : ℕ → ℕ → Ω → E := fun k i ↦ (φ k) ∘ (X i)
   have A : ∀ᵐ ω, ∀ k,
       Tendsto (fun n : ℕ ↦ (n : ℝ) ⁻¹ • (∑ i in range n, Y k i ω)) atTop (𝓝 𝔼[Y k 0]) :=
-    ae_all_iff.2 (fun k ↦ strong_law_ae_simpleFunc_comp X h'.measurable hindep hident (φ k))
+    sorry  -- ae_all_iff.2 (fun k ↦ strong_law_ae_simpleFunc_comp X h'.measurable hindep hident (φ k))
   have B : ∀ᵐ ω, ∀ k, Tendsto (fun n : ℕ ↦ (∑ i in range n, ‖(X i - Y k i) ω‖) / n)
         atTop (𝓝 𝔼[(fun ω ↦ ‖(X 0 - Y k 0) ω‖)]) := by
-    apply ae_all_iff.2 (fun k ↦ ?_)
+    sorry /-apply ae_all_iff.2 (fun k ↦ ?_)
     let G : ℕ → E → ℝ := fun k x ↦ ‖x - φ k x‖
     have G_meas : ∀ k, Measurable (G k) :=
       fun k ↦ (measurable_id.sub_stronglyMeasurable (φ k).stronglyMeasurable).norm
@@ -781,8 +778,16 @@ theorem strong_law_ae_f_measurable
       exact (hindep hij).comp (G_meas k) (G_meas k)
     · intro i
       simp_rw [I]
-      apply (hident i).comp (G_meas k)
+      apply (hident i).comp (G_meas k) -/
   filter_upwards [A, B] with ω hω h'ω
+  rw [tendsto_iff_norm_sub_tendsto_zero, tendsto_order]
+  refine ⟨fun c hc ↦ eventually_of_forall (fun n ↦ hc.trans_le (norm_nonneg _)), ?_⟩
+  intro ε (εpos : 0 < ε)
+  have δ : ℝ := sorry
+  have δpos : 0 < δ := sorry
+  have : ∃ k, ∫ ω, ‖(X 0 - Y k 0) ω‖ < δ := by
+    have Z := SimpleFunc.tendsto_approxOn_range_L1_nnnorm h'.measurable hint
+    have T := (tendsto_order.1 Z).2
 
 
 

--- a/Mathlib/Probability/StrongLaw.lean
+++ b/Mathlib/Probability/StrongLaw.lean
@@ -780,12 +780,15 @@ theorem strong_law_ae_f_measurable
       simp_rw [I]
       apply (hident i).comp (G_meas k) -/
   filter_upwards [A, B] with ω hω h'ω
+  clear hω h'ω
   rw [tendsto_iff_norm_sub_tendsto_zero, tendsto_order]
   refine ⟨fun c hc ↦ eventually_of_forall (fun n ↦ hc.trans_le (norm_nonneg _)), ?_⟩
   intro ε (εpos : 0 < ε)
   have δ : ℝ := sorry
   have δpos : 0 < δ := sorry
   have : ∃ k, ∫ ω, ‖(X 0 - Y k 0) ω‖ < δ := by
+    have A := tendsto_integral_approxOn_of_measurable_of_range_subset h'.measurable hint _ Subset.rfl
+    simp [SimpleFunc.integral_eq_integral] at A
     have Z := SimpleFunc.tendsto_approxOn_range_L1_nnnorm h'.measurable hint
     have T := (tendsto_order.1 Z).2
 

--- a/Mathlib/Probability/StrongLaw.lean
+++ b/Mathlib/Probability/StrongLaw.lean
@@ -640,8 +640,9 @@ end StrongLawNonneg
 /-- **Strong law of large numbers**, almost sure version: if `X n` is a sequence of independent
 identically distributed integrable real-valued random variables, then `∑ i in range n, X i / n`
 converges almost surely to `𝔼[X 0]`. We give here the strong version, due to Etemadi, that only
-requires pairwise independence. -/
-theorem strong_law_ae (X : ℕ → Ω → ℝ) (hint : Integrable (X 0))
+requires pairwise independence. Supersed by `strong_law_ae`, which works for random variables
+taking values in any Banach space. -/
+theorem strong_law_ae_real (X : ℕ → Ω → ℝ) (hint : Integrable (X 0))
     (hindep : Pairwise fun i j => IndepFun (X i) (X j)) (hident : ∀ i, IdentDistrib (X i) (X 0)) :
     ∀ᵐ ω, Tendsto (fun n : ℕ => (∑ i in range n, X i ω) / n) atTop (𝓝 𝔼[X 0]) := by
   let pos : ℝ → ℝ := fun x => max x 0
@@ -659,7 +660,7 @@ theorem strong_law_ae (X : ℕ → Ω → ℝ) (hint : Integrable (X 0))
   · simp only [← sub_div, ← sum_sub_distrib, max_zero_sub_max_neg_zero_eq_self, Function.comp_apply]
   · simp only [← integral_sub hint.pos_part hint.neg_part, max_zero_sub_max_neg_zero_eq_self,
       Function.comp_apply]
-#align probability_theory.strong_law_ae ProbabilityTheory.strong_law_ae
+#align probability_theory.strong_law_ae ProbabilityTheory.strong_law_ae_real
 
 end StrongLawAe
 
@@ -681,7 +682,7 @@ theorem strong_law_Lp {p : ℝ≥0∞} (hp : 1 ≤ p) (hp' : p ≠ ∞) (X : ℕ
     simp_rw [div_eq_mul_inv]
     exact AEStronglyMeasurable.mul_const (aestronglyMeasurable_sum _ fun i _ => hmeas i) _
   refine' tendsto_Lp_of_tendstoInMeasure _ hp hp' havg (memℒp_const _) _
-    (tendstoInMeasure_of_tendsto_ae havg (strong_law_ae _ hint hindep hident))
+    (tendstoInMeasure_of_tendsto_ae havg (strong_law_ae_real _ hint hindep hident))
   rw [(_ : (fun n ω => (∑ i in range n, X i ω) / ↑n) = fun n => (∑ i in range n, X i) / ↑n)]
   · exact (uniformIntegrable_average hp <|
       Memℒp.uniformIntegrable_of_identDistrib hp hp' hℒp hident).2.1
@@ -701,43 +702,48 @@ variable {Ω : Type*} [MeasureSpace Ω] [IsProbabilityMeasure (ℙ : Measure Ω)
 
 open Set TopologicalSpace
 
-local infixr:25 " →ₛ " => SimpleFunc
-
-
-/-- **Strong law of large numbers**, almost sure version: if `X n` is a sequence of independent
-identically distributed integrable real-valued random variables, then `∑ i in range n, X i / n`
-converges almost surely to `𝔼[X 0]`. We give here the strong version, due to Etemadi, that only
-requires pairwise independence. -/
-theorem strong_law_ae_f_measurablezarbi [MeasurableSpace E] [BorelSpace E]
-    (X : ℕ → Ω → E) {Z : Ω → E} (hint : Integrable Z) (h' : ∀ i, StronglyMeasurable (X i))
-    (hindep : Pairwise fun i j => IndepFun (X i) (X j)) (hident : ∀ i, IdentDistrib (X i) Z)
-    (φ : E →ₛ E) :
-    ∀ᵐ ω, Tendsto (fun n : ℕ ↦ (n : ℝ) ⁻¹ • (∑ i in range n, φ (X i ω))) atTop (𝓝 𝔼[φ ∘ Z]) := by
+theorem strong_law_ae_simpleFunc_comp [MeasurableSpace E] [BorelSpace E]
+    (X : ℕ → Ω → E) (h' : Measurable (X 0))
+    (hindep : Pairwise (fun i j ↦ IndepFun (X i) (X j))) (hident : ∀ i, IdentDistrib (X i) (X 0))
+    (φ : SimpleFunc E E) : ∀ᵐ ω,
+      Tendsto (fun n : ℕ ↦ (n : ℝ) ⁻¹ • (∑ i in range n, φ (X i ω))) atTop (𝓝 𝔼[φ ∘ (X 0)]) := by
   classical
   refine SimpleFunc.induction (P := fun ψ ↦ ∀ᵐ ω,
-    Tendsto (fun n : ℕ ↦ (n : ℝ) ⁻¹ • (∑ i in range n, ψ (X i ω))) atTop (𝓝 𝔼[ψ ∘ Z])) ?_ ?_ φ
+    Tendsto (fun n : ℕ ↦ (n : ℝ) ⁻¹ • (∑ i in range n, ψ (X i ω))) atTop (𝓝 𝔼[ψ ∘ (X 0)])) ?_ ?_ φ
   · intro c s hs
     simp only [SimpleFunc.const_zero, SimpleFunc.coe_piecewise, SimpleFunc.coe_const,
       SimpleFunc.coe_zero, piecewise_eq_indicator, Function.comp_apply]
     let F : E → ℝ := indicator s 1
+    have F_meas : Measurable F := (measurable_indicator_const_iff 1).2 hs
     let Y : ℕ → Ω → ℝ := fun n ↦ F ∘ (X n)
     have : ∀ᵐ (ω : Ω), Tendsto (fun (n : ℕ) ↦ (n : ℝ)⁻¹ • ∑ i in Finset.range n, Y i ω)
         atTop (𝓝 𝔼[Y 0]) := by
       simp only [Pi.const_one, smul_eq_mul, ← div_eq_inv_mul]
-      apply strong_law_ae
-      · sorry
-      · intro i j hij
-        apply IndepFun.comp (hindep hij) <;>
-        apply (measurable_indicator_const_iff 1).2 hs
-      · intro i
-        sorry
-    sorry
-  · sorry
-
-
-#exit
-
-
+      apply strong_law_ae_real
+      · exact SimpleFunc.integrable_of_isFiniteMeasure
+          ((SimpleFunc.piecewise s hs (SimpleFunc.const _ (1 : ℝ))
+            (SimpleFunc.const _ (0 : ℝ))).comp (X 0) h')
+      · exact fun i j hij ↦ IndepFun.comp (hindep hij) F_meas F_meas
+      · exact fun i ↦ (hident i).comp F_meas
+    filter_upwards [this] with ω hω
+    have I : indicator s (Function.const E c) = (fun x ↦ (indicator s (1 : E → ℝ) x) • c) := by
+      ext
+      rw [← indicator_smul_const_apply]
+      congr! 1
+      ext
+      simp
+    simp only [I, integral_smul_const]
+    convert Tendsto.smul_const hω c using 1
+    simp [← sum_smul, smul_smul]
+  · rintro φ ψ - hφ hψ
+    filter_upwards [hφ, hψ] with ω hωφ hωψ
+    convert hωφ.add hωψ using 1
+    · simp [sum_add_distrib]
+    · congr 1
+      rw [← integral_add]
+      · rfl
+      · exact (φ.comp (X 0) h').integrable_of_isFiniteMeasure
+      · exact (ψ.comp (X 0) h').integrable_of_isFiniteMeasure
 
 
 /-- **Strong law of large numbers**, almost sure version: if `X n` is a sequence of independent
@@ -745,27 +751,17 @@ identically distributed integrable real-valued random variables, then `∑ i in 
 converges almost surely to `𝔼[X 0]`. We give here the strong version, due to Etemadi, that only
 requires pairwise independence. -/
 theorem strong_law_ae_f_measurable [MeasurableSpace E] [BorelSpace E]
-    (X : ℕ → Ω → E) {Z : Ω → E} (hint : Integrable Z) (h' : ∀ i, StronglyMeasurable (X i))
-    (hindep : Pairwise fun i j => IndepFun (X i) (X j)) (hident : ∀ i, IdentDistrib (X i) Z) :
-    ∀ᵐ ω, Tendsto (fun n : ℕ ↦ (n : ℝ) ⁻¹ • (∑ i in range n, X i ω)) atTop (𝓝 𝔼[Z]) := by
-  let s : Set E := (⋃ (n : ℕ), Set.range (X n)) ∪ {0}
-  have h₀ : 0 ∈ s := sorry
-  have : Nonempty s := ⟨0, h₀⟩
-  have : SeparableSpace s := ((isSeparable_iUnion (fun i ↦ (h' i).isSeparable_range)).union
-    (finite_singleton _).isSeparable).separableSpace
-  let Y : ℕ → ℕ → Ω → E := fun k i ↦ SimpleFunc.approxOn (X i) (h' i).measurable s 0 h₀ k
-  let φ := SimpleFunc.nearestPt (fun k => Nat.casesOn k 0 ((↑) ∘ denseSeq s) : ℕ → E)
-  have Y_eq_comp : ∀ k i, Y k i = (φ k) ∘ (X i) := fun k i ↦ rfl
-  have : ∀ k i, IdentDistrib (Y k i) (Y k 0) := by
-    intro k i
-    have : IdentDistrib (X i) (X 0) := (hident i).trans (hident 0).symm
-    rw [Y_eq_comp, Y_eq_comp]
-    apply IdentDistrib.comp this (φ k).measurable
-  have : ∀ k, Pairwise (fun i j ↦ IndepFun (Y k i) (Y k j)) := by
-    intro k i j hij
-    rw [Y_eq_comp, Y_eq_comp]
-    have Z := hindep hij
-    apply IndepFun.comp (hindep hij) (φ k).measurable (φ k).measurable
+    (X : ℕ → Ω → E) (h' : StronglyMeasurable (X 0))
+    (hindep : Pairwise (fun i j ↦ IndepFun (X i) (X j))) (hident : ∀ i, IdentDistrib (X i) (X 0)) :
+    ∀ᵐ ω, Tendsto (fun n : ℕ ↦ (n : ℝ) ⁻¹ • (∑ i in range n, X i ω)) atTop (𝓝 𝔼[X 0]) := by
+  let s : Set E := Set.range (X 0) ∪ {0}
+  have zero_s : 0 ∈ s := by simp
+  have : SeparableSpace s := h'.separableSpace_range_union_singleton
+  have : Nonempty s := ⟨0, zero_s⟩
+  let φ : ℕ → (SimpleFunc E E) :=
+    SimpleFunc.nearestPt (fun k => Nat.casesOn k 0 ((↑) ∘ denseSeq s) : ℕ → E)
+  let Y : ℕ → ℕ → Ω → E := fun k i ↦ (φ k) ∘ (X i)
+
 
 
 
@@ -801,31 +797,7 @@ theorem strong_law_ae_f
   ext i
   exact (h₁ i).symm
 
-
-
-
-
-
-
 #exit
-
-  let pos : ℝ → ℝ := fun x => max x 0
-  let neg : ℝ → ℝ := fun x => max (-x) 0
-  have posm : Measurable pos := measurable_id'.max measurable_const
-  have negm : Measurable neg := measurable_id'.neg.max measurable_const
-  have A: ∀ᵐ ω, Tendsto (fun n : ℕ => (∑ i in range n, (pos ∘ X i) ω) / n) atTop (𝓝 𝔼[pos ∘ X 0]) :=
-    strong_law_aux7 _ hint.pos_part (fun i j hij => (hindep hij).comp posm posm)
-      (fun i => (hident i).comp posm) fun i ω => le_max_right _ _
-  have B: ∀ᵐ ω, Tendsto (fun n : ℕ => (∑ i in range n, (neg ∘ X i) ω) / n) atTop (𝓝 𝔼[neg ∘ X 0]) :=
-    strong_law_aux7 _ hint.neg_part (fun i j hij => (hindep hij).comp negm negm)
-      (fun i => (hident i).comp negm) fun i ω => le_max_right _ _
-  filter_upwards [A, B] with ω hωpos hωneg
-  convert hωpos.sub hωneg using 1
-  · simp only [← sub_div, ← sum_sub_distrib, max_zero_sub_max_neg_zero_eq_self, Function.comp_apply]
-  · simp only [← integral_sub hint.pos_part hint.neg_part, max_zero_sub_max_neg_zero_eq_self,
-      Function.comp_apply]
-#align probability_theory.strong_law_ae ProbabilityTheory.strong_law_ae
-
 
 
 end ProbabilityTheory

--- a/Mathlib/Probability/StrongLaw.lean
+++ b/Mathlib/Probability/StrongLaw.lean
@@ -692,4 +692,120 @@ set_option linter.uppercaseLean3 false in
 
 end StrongLawLp
 
+
+section glouk
+
+variable {Ω : Type*} [MeasureSpace Ω] [IsProbabilityMeasure (ℙ : Measure Ω)]
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [CompleteSpace E]
+  [MeasurableSpace E] [BorelSpace E]
+
+open Set TopologicalSpace
+
+local infixr:25 " →ₛ " => SimpleFunc
+
+
+/-- **Strong law of large numbers**, almost sure version: if `X n` is a sequence of independent
+identically distributed integrable real-valued random variables, then `∑ i in range n, X i / n`
+converges almost surely to `𝔼[X 0]`. We give here the strong version, due to Etemadi, that only
+requires pairwise independence. -/
+theorem strong_law_ae_f_measurablezarbi [MeasurableSpace E] [BorelSpace E]
+    (X : ℕ → Ω → E) {Z : Ω → E} (hint : Integrable Z) (h' : ∀ i, StronglyMeasurable (X i))
+    (hindep : Pairwise fun i j => IndepFun (X i) (X j)) (hident : ∀ i, IdentDistrib (X i) Z)
+    (φ : E →ₛ E) :
+    ∀ᵐ ω, Tendsto (fun n : ℕ ↦ (n : ℝ) ⁻¹ • (∑ i in range n, φ (X i ω))) atTop (𝓝 𝔼[φ ∘ Z]) := by
+  apply SimpleFunc.induction
+
+
+
+
+
+
+/-- **Strong law of large numbers**, almost sure version: if `X n` is a sequence of independent
+identically distributed integrable real-valued random variables, then `∑ i in range n, X i / n`
+converges almost surely to `𝔼[X 0]`. We give here the strong version, due to Etemadi, that only
+requires pairwise independence. -/
+theorem strong_law_ae_f_measurable [MeasurableSpace E] [BorelSpace E]
+    (X : ℕ → Ω → E) {Z : Ω → E} (hint : Integrable Z) (h' : ∀ i, StronglyMeasurable (X i))
+    (hindep : Pairwise fun i j => IndepFun (X i) (X j)) (hident : ∀ i, IdentDistrib (X i) Z) :
+    ∀ᵐ ω, Tendsto (fun n : ℕ ↦ (n : ℝ) ⁻¹ • (∑ i in range n, X i ω)) atTop (𝓝 𝔼[Z]) := by
+  let s : Set E := (⋃ (n : ℕ), Set.range (X n)) ∪ {0}
+  have h₀ : 0 ∈ s := sorry
+  have : Nonempty s := ⟨0, h₀⟩
+  have : SeparableSpace s := ((isSeparable_iUnion (fun i ↦ (h' i).isSeparable_range)).union
+    (finite_singleton _).isSeparable).separableSpace
+  let Y : ℕ → ℕ → Ω → E := fun k i ↦ SimpleFunc.approxOn (X i) (h' i).measurable s 0 h₀ k
+  let φ := SimpleFunc.nearestPt (fun k => Nat.casesOn k 0 ((↑) ∘ denseSeq s) : ℕ → E)
+  have Y_eq_comp : ∀ k i, Y k i = (φ k) ∘ (X i) := fun k i ↦ rfl
+  have : ∀ k i, IdentDistrib (Y k i) (Y k 0) := by
+    intro k i
+    have : IdentDistrib (X i) (X 0) := (hident i).trans (hident 0).symm
+    rw [Y_eq_comp, Y_eq_comp]
+    apply IdentDistrib.comp this (φ k).measurable
+  have : ∀ k, Pairwise (fun i j ↦ IndepFun (Y k i) (Y k j)) := by
+    intro k i j hij
+    rw [Y_eq_comp, Y_eq_comp]
+    have Z := hindep hij
+    apply IndepFun.comp (hindep hij) (φ k).measurable (φ k).measurable
+
+
+
+#exit
+
+#where
+
+lemma _root_.MeasureTheory.AEMeasurable.identDistrib_mk
+    {Ω : Type*} {_ : MeasurableSpace Ω} {μ : Measure Ω}
+    {f : Ω → E} (hf : AEMeasurable f μ) : IdentDistrib f (hf.mk f) μ μ :=
+  IdentDistrib.of_ae_eq hf hf.ae_eq_mk
+
+lemma _root_.MeasureTheory.AEStronglyMeasurable.identDistrib_mk
+    {Ω : Type*} {_ : MeasurableSpace Ω} {μ : Measure Ω}
+    {f : Ω → E} (hf : AEStronglyMeasurable f μ) : IdentDistrib f (hf.mk f) μ μ :=
+  IdentDistrib.of_ae_eq hf.aemeasurable hf.ae_eq_mk
+
+theorem strong_law_ae_f
+    (X : ℕ → Ω → E) {Z : Ω → E} (hint : Integrable Z)
+    (hindep : Pairwise (fun i j ↦ IndepFun (X i) (X j))) (hident : ∀ i, IdentDistrib (X i) Z) :
+    ∀ᵐ ω, Tendsto (fun n : ℕ ↦ (n : ℝ) ⁻¹ • (∑ i in range n, X i ω)) atTop (𝓝 𝔼[Z]) := by
+  have A : ∀ i, Integrable (X i) := fun i ↦ (hident i).integrable_iff.2 hint
+  let Y : ℕ → Ω → E := fun i ↦ (A i).1.mk (X i)
+  have B : ∀ᵐ ω, ∀ n, X n ω = Y n ω :=
+    ae_all_iff.2 (fun i ↦ AEStronglyMeasurable.ae_eq_mk (A i).1)
+  have C : ∀ᵐ ω, Tendsto (fun n : ℕ ↦ (n : ℝ) ⁻¹ • (∑ i in range n, Y i ω)) atTop (𝓝 𝔼[Z]) :=
+    strong_law_ae_f_measurable Y hint (fun i ↦ (A i).1.stronglyMeasurable_mk)
+      (fun i j hij ↦ IndepFun.ae_eq (hindep hij) (A i).1.ae_eq_mk (A j).1.ae_eq_mk)
+      (fun i ↦ (A i).1.identDistrib_mk.symm.trans (hident i))
+  filter_upwards [B, C] with ω h₁ h₂
+  apply Tendsto.congr (fun n ↦ ?_) h₂
+  congr
+  ext i
+  exact (h₁ i).symm
+
+
+
+
+
+
+
+#exit
+
+  let pos : ℝ → ℝ := fun x => max x 0
+  let neg : ℝ → ℝ := fun x => max (-x) 0
+  have posm : Measurable pos := measurable_id'.max measurable_const
+  have negm : Measurable neg := measurable_id'.neg.max measurable_const
+  have A: ∀ᵐ ω, Tendsto (fun n : ℕ => (∑ i in range n, (pos ∘ X i) ω) / n) atTop (𝓝 𝔼[pos ∘ X 0]) :=
+    strong_law_aux7 _ hint.pos_part (fun i j hij => (hindep hij).comp posm posm)
+      (fun i => (hident i).comp posm) fun i ω => le_max_right _ _
+  have B: ∀ᵐ ω, Tendsto (fun n : ℕ => (∑ i in range n, (neg ∘ X i) ω) / n) atTop (𝓝 𝔼[neg ∘ X 0]) :=
+    strong_law_aux7 _ hint.neg_part (fun i j hij => (hindep hij).comp negm negm)
+      (fun i => (hident i).comp negm) fun i ω => le_max_right _ _
+  filter_upwards [A, B] with ω hωpos hωneg
+  convert hωpos.sub hωneg using 1
+  · simp only [← sub_div, ← sum_sub_distrib, max_zero_sub_max_neg_zero_eq_self, Function.comp_apply]
+  · simp only [← integral_sub hint.pos_part hint.neg_part, max_zero_sub_max_neg_zero_eq_self,
+      Function.comp_apply]
+#align probability_theory.strong_law_ae ProbabilityTheory.strong_law_ae
+
+
+
 end ProbabilityTheory

--- a/Mathlib/Probability/StrongLaw.lean
+++ b/Mathlib/Probability/StrongLaw.lean
@@ -725,7 +725,7 @@ lemma strong_law_ae_simpleFunc_comp (X : ℕ → Ω → E) (h' : Measurable (X 0
       · exact (ψ.comp (X 0) h').integrable_of_isFiniteMeasure
 
 /-- Preliminary lemma for the strong law of large numbers for vector-valued random variables,
-assuming full measurability in addition to integrability. This is weakened to ae measurability in
+assuming measurability in addition to integrability. This is weakened to ae measurability in
 the full version `ProbabilityTheory.strong_law_ae`. -/
 lemma strong_law_ae_of_measurable
     (X : ℕ → Ω → E) (hint : Integrable (X 0)) (h' : StronglyMeasurable (X 0))

--- a/Mathlib/Probability/StrongLaw.lean
+++ b/Mathlib/Probability/StrongLaw.lean
@@ -732,9 +732,9 @@ lemma strong_law_ae_of_measurable
     (hindep : Pairwise (fun i j ↦ IndepFun (X i) (X j))) (hident : ∀ i, IdentDistrib (X i) (X 0)) :
     ∀ᵐ ω, Tendsto (fun n : ℕ ↦ (n : ℝ) ⁻¹ • (∑ i in range n, X i ω)) atTop (𝓝 𝔼[X 0]) := by
   /- Choose a simple function `φ` such that  `φ (X 0)` approximates well enough `X 0` -- this is
-  possible as `X 0` is integrable and therefore ae strongly measurable. Then `φ (X n)` approximates
-  well `X n`. Then the strong law for `φ (X n)` implies the strong law for `X n`, up to a small
-  error controlled by `n⁻¹ ∑_{i=0}^{n-1} ‖X i - φ (X i)‖` . This one is also controlled thanks
+  possible as `X 0` is strongly measurable. Then `φ (X n)` approximates well `X n`.
+  Then the strong law for `φ (X n)` implies the strong law for `X n`, up to a small
+  error controlled by `n⁻¹ ∑_{i=0}^{n-1} ‖X i - φ (X i)‖`. This one is also controlled thanks
   to the one-dimensional law of large numbers: it converges ae to `𝔼[‖X 0 - φ (X 0)‖]`, which
   is arbitrarily small for well chosen `φ`. -/
   let s : Set E := Set.range (X 0) ∪ {0}
@@ -820,6 +820,8 @@ theorem strong_law_ae
     (X : ℕ → Ω → E) (hint : Integrable (X 0))
     (hindep : Pairwise (fun i j ↦ IndepFun (X i) (X j))) (hident : ∀ i, IdentDistrib (X i) (X 0)) :
     ∀ᵐ ω, Tendsto (fun n : ℕ ↦ (n : ℝ) ⁻¹ • (∑ i in range n, X i ω)) atTop (𝓝 𝔼[X 0]) := by
+  -- we reduce to the case of strongly measurable random variables, by using `Y i` which is strongly
+  -- measurable and ae equal to `X i`.
   have A : ∀ i, Integrable (X i) := fun i ↦ (hident i).integrable_iff.2 hint
   let Y : ℕ → Ω → E := fun i ↦ (A i).1.mk (X i)
   have B : ∀ᵐ ω, ∀ n, X n ω = Y n ω :=

--- a/Mathlib/Probability/StrongLaw.lean
+++ b/Mathlib/Probability/StrongLaw.lean
@@ -713,9 +713,26 @@ theorem strong_law_ae_f_measurablezarbi [MeasurableSpace E] [BorelSpace E]
     (hindep : Pairwise fun i j => IndepFun (X i) (X j)) (hident : ∀ i, IdentDistrib (X i) Z)
     (φ : E →ₛ E) :
     ∀ᵐ ω, Tendsto (fun n : ℕ ↦ (n : ℝ) ⁻¹ • (∑ i in range n, φ (X i ω))) atTop (𝓝 𝔼[φ ∘ Z]) := by
-  apply SimpleFunc.induction
+  classical
+  refine SimpleFunc.induction (P := fun ψ ↦ ∀ᵐ ω,
+    Tendsto (fun n : ℕ ↦ (n : ℝ) ⁻¹ • (∑ i in range n, ψ (X i ω))) atTop (𝓝 𝔼[ψ ∘ Z])) ?_ ?_ φ
+  · intro c s hs
+    simp only [SimpleFunc.const_zero, SimpleFunc.coe_piecewise, SimpleFunc.coe_const,
+      SimpleFunc.coe_zero, piecewise_eq_indicator, Function.comp_apply]
+    let Y : ℕ → Ω → ℝ := fun n ω ↦ s.indicator (Function.const E (1 : ℝ)) (X n ω)
+    have : ∀ᵐ (ω : Ω), Tendsto (fun (n : ℕ) ↦ (n : ℝ)⁻¹ • ∑ i in Finset.range n, Y i ω)
+        atTop (𝓝 𝔼[Y 0]) := by
+      simp only [Pi.const_one, smul_eq_mul, ← div_eq_inv_mul]
+      apply strong_law_ae
+
+      --have : Integrable (X 0) := sorry
+      --apply (integrable_indicator_iff hs).2
+
+    sorry
+  · sorry
 
 
+#exit
 
 
 

--- a/Mathlib/Probability/StrongLaw.lean
+++ b/Mathlib/Probability/StrongLaw.lean
@@ -719,15 +719,18 @@ theorem strong_law_ae_f_measurablezarbi [MeasurableSpace E] [BorelSpace E]
   · intro c s hs
     simp only [SimpleFunc.const_zero, SimpleFunc.coe_piecewise, SimpleFunc.coe_const,
       SimpleFunc.coe_zero, piecewise_eq_indicator, Function.comp_apply]
-    let Y : ℕ → Ω → ℝ := fun n ω ↦ s.indicator (Function.const E (1 : ℝ)) (X n ω)
+    let F : E → ℝ := indicator s 1
+    let Y : ℕ → Ω → ℝ := fun n ↦ F ∘ (X n)
     have : ∀ᵐ (ω : Ω), Tendsto (fun (n : ℕ) ↦ (n : ℝ)⁻¹ • ∑ i in Finset.range n, Y i ω)
         atTop (𝓝 𝔼[Y 0]) := by
       simp only [Pi.const_one, smul_eq_mul, ← div_eq_inv_mul]
       apply strong_law_ae
-
-      --have : Integrable (X 0) := sorry
-      --apply (integrable_indicator_iff hs).2
-
+      · sorry
+      · intro i j hij
+        apply IndepFun.comp (hindep hij) <;>
+        apply (measurable_indicator_const_iff 1).2 hs
+      · intro i
+        sorry
     sorry
   · sorry
 

--- a/Mathlib/Probability/StrongLaw.lean
+++ b/Mathlib/Probability/StrongLaw.lean
@@ -855,7 +855,8 @@ theorem strong_law_Lp {p : ℝ≥0∞} (hp : 1 ≤ p) (hp' : p ≠ ∞) (X : ℕ
   have hmeas : ∀ i, AEStronglyMeasurable (X i) ℙ := fun i =>
     (hident i).aestronglyMeasurable_iff.2 hℒp.1
   have hint : Integrable (X 0) ℙ := hℒp.integrable hp
-  have havg : ∀ (n : ℕ), AEStronglyMeasurable (fun ω => (n : ℝ) ⁻¹ • (∑ i in range n, X i ω)) ℙ := by
+  have havg : ∀ (n : ℕ),
+      AEStronglyMeasurable (fun ω => (n : ℝ) ⁻¹ • (∑ i in range n, X i ω)) ℙ := by
     intro n
     exact AEStronglyMeasurable.const_smul (aestronglyMeasurable_sum _ fun i _ => hmeas i) _
   refine' tendsto_Lp_of_tendstoInMeasure _ hp hp' havg (memℒp_const _) _

--- a/Mathlib/Probability/StrongLaw.lean
+++ b/Mathlib/Probability/StrongLaw.lean
@@ -665,36 +665,6 @@ theorem strong_law_ae_real (X : ℕ → Ω → ℝ) (hint : Integrable (X 0))
 
 end StrongLawAeReal
 
-section StrongLawLp
-
-variable {Ω : Type*} [MeasureSpace Ω] [IsProbabilityMeasure (ℙ : Measure Ω)]
-
-/-- **Strong law of large numbers**, Lᵖ version: if `X n` is a sequence of independent
-identically distributed real-valued random variables in Lᵖ, then `∑ i in range n, X i / n`
-converges in Lᵖ to `𝔼[X 0]`. -/
-theorem strong_law_Lp {p : ℝ≥0∞} (hp : 1 ≤ p) (hp' : p ≠ ∞) (X : ℕ → Ω → ℝ) (hℒp : Memℒp (X 0) p)
-    (hindep : Pairwise fun i j => IndepFun (X i) (X j)) (hident : ∀ i, IdentDistrib (X i) (X 0)) :
-    Tendsto (fun n => snorm (fun ω => (∑ i in range n, X i ω) / n - 𝔼[X 0]) p ℙ) atTop (𝓝 0) := by
-  have hmeas : ∀ i, AEStronglyMeasurable (X i) ℙ := fun i =>
-    (hident i).aestronglyMeasurable_iff.2 hℒp.1
-  have hint : Integrable (X 0) ℙ := hℒp.integrable hp
-  have havg : ∀ n, AEStronglyMeasurable (fun ω => (∑ i in range n, X i ω) / n) ℙ := by
-    intro n
-    simp_rw [div_eq_mul_inv]
-    exact AEStronglyMeasurable.mul_const (aestronglyMeasurable_sum _ fun i _ => hmeas i) _
-  refine' tendsto_Lp_of_tendstoInMeasure _ hp hp' havg (memℒp_const _) _
-    (tendstoInMeasure_of_tendsto_ae havg (strong_law_ae_real _ hint hindep hident))
-  rw [(_ : (fun n ω => (∑ i in range n, X i ω) / ↑n) = fun n => (∑ i in range n, X i) / ↑n)]
-  · exact (uniformIntegrable_average hp <|
-      Memℒp.uniformIntegrable_of_identDistrib hp hp' hℒp hident).2.1
-  · ext n ω
-    simp only [Pi.coe_nat, Pi.div_apply, sum_apply]
-set_option linter.uppercaseLean3 false in
-#align probability_theory.strong_law_Lp ProbabilityTheory.strong_law_Lp
-
-end StrongLawLp
-
-
 section StrongLawVectorSpace
 
 variable {Ω : Type*} [MeasureSpace Ω] [IsProbabilityMeasure (ℙ : Measure Ω)]
@@ -853,6 +823,38 @@ theorem strong_law_ae
   exact (h₁ i).symm
 
 end StrongLawVectorSpace
+
+section StrongLawLp
+
+variable {Ω : Type*} [MeasureSpace Ω] [IsProbabilityMeasure (ℙ : Measure Ω)]
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [CompleteSpace E]
+  [MeasurableSpace E] [BorelSpace E]
+
+/-- **Strong law of large numbers**, Lᵖ version: if `X n` is a sequence of independent
+identically distributed real-valued random variables in Lᵖ, then `∑ i in range n, X i / n`
+converges in Lᵖ to `𝔼[X 0]`. -/
+theorem strong_law_Lp {p : ℝ≥0∞} (hp : 1 ≤ p) (hp' : p ≠ ∞) (X : ℕ → Ω → E) (hℒp : Memℒp (X 0) p)
+    (hindep : Pairwise fun i j => IndepFun (X i) (X j)) (hident : ∀ i, IdentDistrib (X i) (X 0)) :
+    Tendsto (fun (n : ℕ) => snorm (fun ω => (n : ℝ) ⁻¹ • (∑ i in range n, X i ω) - 𝔼[X 0]) p ℙ)
+      atTop (𝓝 0) := by
+  have hmeas : ∀ i, AEStronglyMeasurable (X i) ℙ := fun i =>
+    (hident i).aestronglyMeasurable_iff.2 hℒp.1
+  have hint : Integrable (X 0) ℙ := hℒp.integrable hp
+  have havg : ∀ (n : ℕ), AEStronglyMeasurable (fun ω => (n : ℝ) ⁻¹ • (∑ i in range n, X i ω)) ℙ := by
+    intro n
+    exact AEStronglyMeasurable.const_smul (aestronglyMeasurable_sum _ fun i _ => hmeas i) _
+  refine' tendsto_Lp_of_tendstoInMeasure _ hp hp' havg (memℒp_const _) _
+    (tendstoInMeasure_of_tendsto_ae havg (strong_law_ae _ hint hindep hident))
+  rw [(_ : (fun (n : ℕ) ω => (n : ℝ)⁻¹ • (∑ i in range n, X i ω)) = fun (n : ℕ) => (n : ℝ)⁻¹ • (∑ i in range n, X i))]
+  · exact (uniformIntegrable_average hp <|
+      Memℒp.uniformIntegrable_of_identDistrib hp hp' hℒp hident).2.1
+  · ext n ω
+    simp only [Pi.coe_nat, Pi.div_apply, sum_apply]
+set_option linter.uppercaseLean3 false in
+#align probability_theory.strong_law_Lp ProbabilityTheory.strong_law_Lp
+
+end StrongLawLp
+
 
 
 end ProbabilityTheory

--- a/Mathlib/Probability/StrongLaw.lean
+++ b/Mathlib/Probability/StrongLaw.lean
@@ -219,14 +219,15 @@ theorem IdentDistrib.truncation {β : Type*} [MeasurableSpace β] {ν : Measure 
 
 end Truncation
 
-section StrongLawAe
+section StrongLawAeReal
 
 variable {Ω : Type*} [MeasureSpace Ω] [IsProbabilityMeasure (ℙ : Measure Ω)]
 
 section MomentEstimates
 
 theorem sum_prob_mem_Ioc_le {X : Ω → ℝ} (hint : Integrable X) (hnonneg : 0 ≤ X) {K : ℕ} {N : ℕ}
-    (hKN : K ≤ N): ∑ j in range K, ℙ {ω | X ω ∈ Set.Ioc (j : ℝ) N} ≤ ENNReal.ofReal (𝔼[X] + 1) := by
+    (hKN : K ≤ N) :
+    ∑ j in range K, ℙ {ω | X ω ∈ Set.Ioc (j : ℝ) N} ≤ ENNReal.ofReal (𝔼[X] + 1) := by
   let ρ : Measure ℝ := Measure.map X ℙ
   haveI : IsProbabilityMeasure ρ := isProbabilityMeasure_map hint.aemeasurable
   have A : ∑ j in range K, ∫ _ in j..N, (1 : ℝ) ∂ρ ≤ 𝔼[X] + 1 :=
@@ -662,7 +663,7 @@ theorem strong_law_ae_real (X : ℕ → Ω → ℝ) (hint : Integrable (X 0))
       Function.comp_apply]
 #align probability_theory.strong_law_ae ProbabilityTheory.strong_law_ae_real
 
-end StrongLawAe
+end StrongLawAeReal
 
 section StrongLawLp
 
@@ -694,7 +695,7 @@ set_option linter.uppercaseLean3 false in
 end StrongLawLp
 
 
-section glouk
+section StrongLawVectorSpace
 
 variable {Ω : Type*} [MeasureSpace Ω] [IsProbabilityMeasure (ℙ : Measure Ω)]
   {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [CompleteSpace E]
@@ -745,12 +746,11 @@ theorem strong_law_ae_simpleFunc_comp [MeasurableSpace E] [BorelSpace E]
       · exact (φ.comp (X 0) h').integrable_of_isFiniteMeasure
       · exact (ψ.comp (X 0) h').integrable_of_isFiniteMeasure
 
-
 /-- **Strong law of large numbers**, almost sure version: if `X n` is a sequence of independent
-identically distributed integrable real-valued random variables, then `∑ i in range n, X i / n`
-converges almost surely to `𝔼[X 0]`. We give here the strong version, due to Etemadi, that only
-requires pairwise independence. -/
-theorem strong_law_ae_f_measurable
+identically distributed integrable random variables taking values in a Banach space,
+then `n⁻¹ • ∑ i in range n, X i` converges almost surely to `𝔼[X 0]`. We give here the strong
+version, due to Etemadi, that only requires pairwise independence. -/
+theorem strong_law_ae_of_measurable
     (X : ℕ → Ω → E) (hint : Integrable (X 0)) (h' : StronglyMeasurable (X 0))
     (hindep : Pairwise (fun i j ↦ IndepFun (X i) (X j))) (hident : ∀ i, IdentDistrib (X i) (X 0)) :
     ∀ᵐ ω, Tendsto (fun n : ℕ ↦ (n : ℝ) ⁻¹ • (∑ i in range n, X i ω)) atTop (𝓝 𝔼[X 0]) := by
@@ -763,10 +763,10 @@ theorem strong_law_ae_f_measurable
   let Y : ℕ → ℕ → Ω → E := fun k i ↦ (φ k) ∘ (X i)
   have A : ∀ᵐ ω, ∀ k,
       Tendsto (fun n : ℕ ↦ (n : ℝ) ⁻¹ • (∑ i in range n, Y k i ω)) atTop (𝓝 𝔼[Y k 0]) :=
-    sorry  -- ae_all_iff.2 (fun k ↦ strong_law_ae_simpleFunc_comp X h'.measurable hindep hident (φ k))
+    ae_all_iff.2 (fun k ↦ strong_law_ae_simpleFunc_comp X h'.measurable hindep hident (φ k))
   have B : ∀ᵐ ω, ∀ k, Tendsto (fun n : ℕ ↦ (∑ i in range n, ‖(X i - Y k i) ω‖) / n)
         atTop (𝓝 𝔼[(fun ω ↦ ‖(X 0 - Y k 0) ω‖)]) := by
-    sorry /-apply ae_all_iff.2 (fun k ↦ ?_)
+    apply ae_all_iff.2 (fun k ↦ ?_)
     let G : ℕ → E → ℝ := fun k x ↦ ‖x - φ k x‖
     have G_meas : ∀ k, Measurable (G k) :=
       fun k ↦ (measurable_id.sub_stronglyMeasurable (φ k).stronglyMeasurable).norm
@@ -778,38 +778,48 @@ theorem strong_law_ae_f_measurable
       exact (hindep hij).comp (G_meas k) (G_meas k)
     · intro i
       simp_rw [I]
-      apply (hident i).comp (G_meas k) -/
+      apply (hident i).comp (G_meas k)
   filter_upwards [A, B] with ω hω h'ω
   rw [tendsto_iff_norm_sub_tendsto_zero, tendsto_order]
   refine ⟨fun c hc ↦ eventually_of_forall (fun n ↦ hc.trans_le (norm_nonneg _)), ?_⟩
   intro ε (εpos : 0 < ε)
-  have δ : ℝ := sorry
-  have δpos : 0 < δ := sorry
+  obtain ⟨δ, δpos, hδ⟩ : ∃ δ, 0 < δ ∧ δ + δ + δ < ε := ⟨ε/4, by positivity, by linarith⟩
   obtain ⟨k, hk⟩ : ∃ k, ∫ ω, ‖(X 0 - Y k 0) ω‖ < δ := by
-    sorry /-simp_rw [Pi.sub_apply, norm_sub_rev (X 0 _)]
+    simp_rw [Pi.sub_apply, norm_sub_rev (X 0 _)]
     exact ((tendsto_order.1 (tendsto_integral_norm_approxOn_sub h'.measurable hint)).2 δ
-      δpos).exists -/
-  have A : ∀ᶠ n in atTop, (∑ i in range n, ‖(X i - Y k i) ω‖) / n < δ :=
-    sorry -- (tendsto_order.1 (h'ω k)).2 δ hk
-  have B : ∀ᶠ (n : ℕ) in atTop, ‖(n : ℝ) ⁻¹ • (∑ i in range n, Y k i ω) - 𝔼[Y k 0]‖ < δ := by
+      δpos).exists
+  have : ‖𝔼[Y k 0] - 𝔼[X 0]‖ < δ := by
+    rw [norm_sub_rev, ← integral_sub hint]
+    · exact (norm_integral_le_integral_norm _).trans_lt hk
+    · exact ((φ k).comp (X 0) h'.measurable).integrable_of_isFiniteMeasure
+  have I : ∀ᶠ n in atTop, (∑ i in range n, ‖(X i - Y k i) ω‖) / n < δ :=
+    (tendsto_order.1 (h'ω k)).2 δ hk
+  have J : ∀ᶠ (n : ℕ) in atTop, ‖(n : ℝ) ⁻¹ • (∑ i in range n, Y k i ω) - 𝔼[Y k 0]‖ < δ := by
     specialize hω k
     rw [tendsto_iff_norm_sub_tendsto_zero] at hω
     exact (tendsto_order.1 hω).2 δ δpos
   clear hω h'ω
-  filter_upwards [A, B] with n hn h'n
-  calc ‖(n : ℝ)⁻¹ • ∑ i in Finset.range n, X i ω - ∫ (a : Ω), X 0 a‖ < ε := sorry
-
-
-
-
-
-
-
-
-
-#exit
-
-#where
+  filter_upwards [I, J] with n hn h'n
+  calc
+  ‖(n : ℝ)⁻¹ • ∑ i in Finset.range n, X i ω - 𝔼[X 0]‖
+    = ‖(n : ℝ)⁻¹ • ∑ i in Finset.range n, (X i ω - Y k i ω) +
+        ((n : ℝ)⁻¹ • ∑ i in Finset.range n, Y k i ω - 𝔼[Y k 0]) + (𝔼[Y k 0] - 𝔼[X 0])‖ := by
+      congr
+      simp only [Function.comp_apply, sum_sub_distrib, smul_sub]
+      abel
+  _ ≤ ‖(n : ℝ)⁻¹ • ∑ i in Finset.range n, (X i ω - Y k i ω)‖ +
+        ‖(n : ℝ)⁻¹ • ∑ i in Finset.range n, Y k i ω - 𝔼[Y k 0]‖ + ‖𝔼[Y k 0] - 𝔼[X 0]‖ :=
+      norm_add₃_le _ _ _
+  _ ≤ (∑ i in Finset.range n, ‖X i ω - Y k i ω‖) / n + δ + δ := by
+      gcongr
+      simp only [Function.comp_apply, norm_smul, norm_inv, IsROrC.norm_natCast,
+        div_eq_inv_mul, inv_pos, Nat.cast_pos, inv_lt_zero]
+      gcongr
+      exact norm_sum_le _ _
+  _ ≤ δ + δ + δ := by
+      gcongr
+      exact hn.le
+  _ < ε := hδ
 
 lemma _root_.MeasureTheory.AEMeasurable.identDistrib_mk
     {Ω : Type*} {_ : MeasurableSpace Ω} {μ : Measure Ω}
@@ -821,25 +831,28 @@ lemma _root_.MeasureTheory.AEStronglyMeasurable.identDistrib_mk
     {f : Ω → E} (hf : AEStronglyMeasurable f μ) : IdentDistrib f (hf.mk f) μ μ :=
   IdentDistrib.of_ae_eq hf.aemeasurable hf.ae_eq_mk
 
-theorem strong_law_ae_f
-    (X : ℕ → Ω → E) {Z : Ω → E} (hint : Integrable Z)
-    (hindep : Pairwise (fun i j ↦ IndepFun (X i) (X j))) (hident : ∀ i, IdentDistrib (X i) Z) :
-    ∀ᵐ ω, Tendsto (fun n : ℕ ↦ (n : ℝ) ⁻¹ • (∑ i in range n, X i ω)) atTop (𝓝 𝔼[Z]) := by
+theorem strong_law_ae
+    (X : ℕ → Ω → E) (hint : Integrable (X 0))
+    (hindep : Pairwise (fun i j ↦ IndepFun (X i) (X j))) (hident : ∀ i, IdentDistrib (X i) (X 0)) :
+    ∀ᵐ ω, Tendsto (fun n : ℕ ↦ (n : ℝ) ⁻¹ • (∑ i in range n, X i ω)) atTop (𝓝 𝔼[X 0]) := by
   have A : ∀ i, Integrable (X i) := fun i ↦ (hident i).integrable_iff.2 hint
   let Y : ℕ → Ω → E := fun i ↦ (A i).1.mk (X i)
   have B : ∀ᵐ ω, ∀ n, X n ω = Y n ω :=
     ae_all_iff.2 (fun i ↦ AEStronglyMeasurable.ae_eq_mk (A i).1)
-  have C : ∀ᵐ ω, Tendsto (fun n : ℕ ↦ (n : ℝ) ⁻¹ • (∑ i in range n, Y i ω)) atTop (𝓝 𝔼[Z]) :=
-    strong_law_ae_f_measurable Y hint (fun i ↦ (A i).1.stronglyMeasurable_mk)
+  have Yint: Integrable (Y 0) := Integrable.congr hint (AEStronglyMeasurable.ae_eq_mk (A 0).1)
+  have C : ∀ᵐ ω, Tendsto (fun n : ℕ ↦ (n : ℝ) ⁻¹ • (∑ i in range n, Y i ω)) atTop (𝓝 𝔼[Y 0]) := by
+    apply strong_law_ae_of_measurable Y Yint ((A 0).1.stronglyMeasurable_mk)
       (fun i j hij ↦ IndepFun.ae_eq (hindep hij) (A i).1.ae_eq_mk (A j).1.ae_eq_mk)
-      (fun i ↦ (A i).1.identDistrib_mk.symm.trans (hident i))
+      (fun i ↦ ((A i).1.identDistrib_mk.symm.trans (hident i)).trans (A 0).1.identDistrib_mk)
   filter_upwards [B, C] with ω h₁ h₂
+  have : 𝔼[X 0] = 𝔼[Y 0] := integral_congr_ae (AEStronglyMeasurable.ae_eq_mk (A 0).1)
+  rw [this]
   apply Tendsto.congr (fun n ↦ ?_) h₂
   congr
   ext i
   exact (h₁ i).symm
 
-#exit
+end StrongLawVectorSpace
 
 
 end ProbabilityTheory

--- a/Mathlib/Probability/StrongLaw.lean
+++ b/Mathlib/Probability/StrongLaw.lean
@@ -846,8 +846,9 @@ theorem strong_law_Lp {p : ℝ≥0∞} (hp : 1 ≤ p) (hp' : p ≠ ∞) (X : ℕ
   refine' tendsto_Lp_of_tendstoInMeasure _ hp hp' havg (memℒp_const _) _
     (tendstoInMeasure_of_tendsto_ae havg (strong_law_ae _ hint hindep hident))
   rw [(_ : (fun (n : ℕ) ω => (n : ℝ)⁻¹ • (∑ i in range n, X i ω)) = fun (n : ℕ) => (n : ℝ)⁻¹ • (∑ i in range n, X i))]
-  · exact (uniformIntegrable_average hp <|
-      Memℒp.uniformIntegrable_of_identDistrib hp hp' hℒp hident).2.1
+  · apply UniformIntegrable.unifIntegrable
+    apply uniformIntegrable_average hp
+    exact Memℒp.uniformIntegrable_of_identDistrib hp hp' hℒp hident
   · ext n ω
     simp only [Pi.coe_nat, Pi.div_apply, sum_apply]
 set_option linter.uppercaseLean3 false in


### PR DESCRIPTION
We already have the strong law of large numbers for real-valued integrable random variables. We generalize it to general vector-valued integrable random variables. This does not require any second-countability assumptions as integrable functions can by definition be approximated by simple functions, for which the result is deduced from the one-dimensional one.

Along the way, we extend a few lemmas in the library from the real case to the vector case, and remove unneeded second-countability assumptions.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
