### PR TITLE
[Merged by Bors] - feat(LinearAlgebra/QuadraticForm/TensorProduct): commutativity and associativity

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2321,6 +2321,7 @@ import Mathlib.LinearAlgebra.QuadraticForm.IsometryEquiv
 import Mathlib.LinearAlgebra.QuadraticForm.Prod
 import Mathlib.LinearAlgebra.QuadraticForm.Real
 import Mathlib.LinearAlgebra.QuadraticForm.TensorProduct
+import Mathlib.LinearAlgebra.QuadraticForm.TensorProduct.Isometries
 import Mathlib.LinearAlgebra.Quotient
 import Mathlib.LinearAlgebra.QuotientPi
 import Mathlib.LinearAlgebra.Ray

--- a/Mathlib/LinearAlgebra/BilinearForm.lean
+++ b/Mathlib/LinearAlgebra/BilinearForm.lean
@@ -528,6 +528,11 @@ theorem BilinForm.toLin_symm :
 #align bilin_form.to_lin_symm BilinForm.toLin_symm
 
 @[simp, norm_cast]
+theorem LinearMap.toBilin_apply (f : M₂ →ₗ[R₂] M₂ →ₗ[R₂] R₂) (x y : M₂) :
+    toBilin f x y = f x y :=
+  rfl
+
+@[simp, norm_cast]
 theorem BilinForm.toLin_apply (x : M₂) : ⇑(BilinForm.toLin B₂ x) = B₂ x :=
   rfl
 #align bilin_form.to_lin_apply BilinForm.toLin_apply

--- a/Mathlib/LinearAlgebra/QuadraticForm/Basic.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/Basic.lean
@@ -751,7 +751,22 @@ theorem polar_toQuadraticForm (x y : M) : polar (toQuadraticForm B) x y = B x y 
 theorem polarBilin_toQuadraticForm : polarBilin (toQuadraticForm B) = B + flip' B :=
   BilinForm.ext polar_toQuadraticForm
 
+@[simp] theorem _root_.QuadraticForm.toQuadraticForm_polarBilin (Q : QuadraticForm R M) :
+    toQuadraticForm (polarBilin Q) = 2 • Q :=
+  QuadraticForm.ext <| fun x => (polar_self _ x).trans <| by simp
+
+theorem  _root_.QuadraticForm.polarBilin_injective (h : IsUnit (2 : R)) :
+    Function.Injective (polarBilin : QuadraticForm R M → _) :=
+  fun Q₁ Q₂ h₁₂ => QuadraticForm.ext fun x => h.mul_left_cancel <| by
+    simpa using FunLike.congr_fun (congr_arg toQuadraticForm h₁₂) x
+
+variable {N : Type v}
 variable [CommRing S] [Algebra S R] [Module S M] [IsScalarTower S R M]
+variable [AddCommGroup N] [Module R N]
+
+theorem _root_.QuadraticForm.polarBilin_comp (Q : QuadraticForm R N) (f : M →ₗ[R] N) :
+    polarBilin (Q.comp f) = BilinForm.comp (polarBilin Q) f f :=
+  BilinForm.ext <| fun x y => by simp [polar]
 
 theorem _root_.LinearMap.compQuadraticForm_polar (f : R →ₗ[S] S) (Q : QuadraticForm R M) (x y : M) :
     polar (f.compQuadraticForm Q) x y = f (polar Q x y) := by

--- a/Mathlib/LinearAlgebra/QuadraticForm/TensorProduct.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/TensorProduct.lean
@@ -80,25 +80,23 @@ theorem polarBilin_tmul [Invertible (2 : A)] (Q₁ : QuadraticForm A M₁) (Q₂
 @[simp]
 theorem tmul_comp_tensorComm (Q₁ : QuadraticForm R M₁) (Q₂ : QuadraticForm R M₂) :
     (Q₂.tmul Q₁).comp (TensorProduct.comm R M₁ M₂) = Q₁.tmul Q₂ := by
-  refine QuadraticForm.polarBilin_injective (isUnit_of_invertible _) ?_
+  refine (QuadraticForm.associated_rightInverse R).injective ?_
   apply BilinForm.toLin.injective
   ext m₁ m₂ m₁' m₂'
-  dsimp [-polarBilin_apply]
-  simp only [polarBilin_tmul, QuadraticForm.polarBilin_comp]
-  dsimp [QuadraticForm.comp]
-  rw [mul_comm (polar _ _ _)]
+  dsimp [-associated_apply]
+  simp only [associated_tmul, QuadraticForm.associated_comp]
+  exact mul_comm _ _
 
 @[simp]
 theorem tmul_comp_tensorAssoc
     (Q₁ : QuadraticForm R M₁) (Q₂ : QuadraticForm R M₂) (Q₃ : QuadraticForm R M₃) :
     (Q₁.tmul (Q₂.tmul Q₃)).comp (TensorProduct.assoc R M₁ M₂ M₃) = (Q₁.tmul Q₂).tmul Q₃ := by
-  refine QuadraticForm.polarBilin_injective (isUnit_of_invertible _) ?_
+  refine (QuadraticForm.associated_rightInverse R).injective ?_
   apply BilinForm.toLin.injective
   ext m₁ m₂ m₁' m₂' m₁'' m₂''
-  dsimp [-polarBilin_apply]
-  simp only [polarBilin_tmul, QuadraticForm.polarBilin_comp]
-  dsimp [QuadraticForm.comp]
-  rw [mul_assoc (polar _ _ _)]
+  dsimp [-associated_apply]
+  simp only [associated_tmul, QuadraticForm.associated_comp]
+  exact mul_assoc _ _ _
 
 /-- `TensorProduct.comm` preserves tensor products of quadratic forms. -/
 @[simps]

--- a/Mathlib/LinearAlgebra/QuadraticForm/TensorProduct.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/TensorProduct.lean
@@ -17,9 +17,9 @@ import Mathlib.LinearAlgebra.QuadraticForm.IsometryEquiv
 
 -/
 
-universe uR uA uM₁ uM₂
+universe uR uA uM₁ uM₂ uM₃
 
-variable {R : Type uR} {A : Type uA} {M₁ : Type uM₁} {M₂ : Type uM₂}
+variable {R : Type uR} {A : Type uA} {M₁ : Type uM₁} {M₂ : Type uM₂} {M₃ : Type uM₃}
 
 open TensorProduct
 
@@ -27,10 +27,10 @@ namespace QuadraticForm
 
 section CommRing
 variable [CommRing R] [CommRing A]
-variable [AddCommGroup M₁] [AddCommGroup M₂]
+variable [AddCommGroup M₁] [AddCommGroup M₂] [AddCommGroup M₃]
 variable [Algebra R A] [Module R M₁] [Module A M₁]
 variable [SMulCommClass R A M₁] [SMulCommClass A R M₁] [IsScalarTower R A M₁]
-variable [Module R M₂] [Invertible (2 : R)]
+variable [Module R M₂] [Module R M₃] [Invertible (2 : R)]
 
 
 variable (R A) in
@@ -77,24 +77,42 @@ theorem polarBilin_tmul [Invertible (2 : A)] (Q₁ : QuadraticForm A M₁) (Q₂
   rw [smul_comm (_ : A) (_ : ℕ), ← smul_assoc, two_smul _ (_ : A), invOf_two_add_invOf_two,
     one_smul]
 
+@[simp]
 theorem tmul_comp_tensorComm (Q₁ : QuadraticForm R M₁) (Q₂ : QuadraticForm R M₂) :
-    (Q₂.tmul Q₁).comp (TensorProduct.comm R M₁ M₂) = (Q₁.tmul Q₂) := by
+    (Q₂.tmul Q₁).comp (TensorProduct.comm R M₁ M₂) = Q₁.tmul Q₂ := by
   refine QuadraticForm.polarBilin_injective (isUnit_of_invertible _) ?_
   apply BilinForm.toLin.injective
   ext m₁ m₂ m₁' m₂'
   dsimp [-polarBilin_apply]
   simp only [polarBilin_tmul, QuadraticForm.polarBilin_comp]
   dsimp [QuadraticForm.comp]
-  sorry
+  rw [mul_comm (polar _ _ _)]
 
+@[simp]
+theorem tmul_comp_tensorAssoc
+    (Q₁ : QuadraticForm R M₁) (Q₂ : QuadraticForm R M₂) (Q₃ : QuadraticForm R M₃) :
+    (Q₁.tmul (Q₂.tmul Q₃)).comp (TensorProduct.assoc R M₁ M₂ M₃) = (Q₁.tmul Q₂).tmul Q₃ := by
+  refine QuadraticForm.polarBilin_injective (isUnit_of_invertible _) ?_
+  apply BilinForm.toLin.injective
+  ext m₁ m₂ m₁' m₂' m₁'' m₂''
+  dsimp [-polarBilin_apply]
+  simp only [polarBilin_tmul, QuadraticForm.polarBilin_comp]
+  dsimp [QuadraticForm.comp]
+  rw [mul_assoc (polar _ _ _)]
+
+/-- `TensorProduct.comm` preserves tensor products of quadratic forms. -/
+@[simps]
 def tensorComm (Q₁ : QuadraticForm R M₁) (Q₂ : QuadraticForm R M₂) :
     (Q₁.tmul Q₂).IsometryEquiv (Q₂.tmul Q₁) where
   toLinearEquiv := TensorProduct.comm R M₁ M₂
-  map_app' x := by
-    have := FunLike.congr_fun (tmul_comp_tensorComm Q₁ Q₂) x
-    sorry
+  map_app' x := FunLike.congr_fun (tmul_comp_tensorComm Q₁ Q₂) x
 
-#exit
+/-- `TensorProduct.assoc` preserves tensor products of quadratic forms. -/
+@[simps]
+def tensorAssoc (Q₁ : QuadraticForm R M₁) (Q₂ : QuadraticForm R M₂) (Q₃ : QuadraticForm R M₃) :
+    ((Q₁.tmul Q₂).tmul Q₃).IsometryEquiv (Q₁.tmul (Q₂.tmul Q₃)) where
+  toLinearEquiv := TensorProduct.assoc R M₁ M₂ M₃
+  map_app' x := FunLike.congr_fun (tmul_comp_tensorAssoc Q₁ Q₂ Q₃) x
 
 variable (A) in
 /-- The base change of a quadratic form. -/

--- a/Mathlib/LinearAlgebra/QuadraticForm/TensorProduct.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/TensorProduct.lean
@@ -5,7 +5,6 @@ Authors: Eric Wieser
 -/
 import Mathlib.LinearAlgebra.BilinearForm.TensorProduct
 import Mathlib.LinearAlgebra.QuadraticForm.Basic
-import Mathlib.LinearAlgebra.QuadraticForm.IsometryEquiv
 
 /-!
 # The quadratic form on a tensor product
@@ -17,9 +16,9 @@ import Mathlib.LinearAlgebra.QuadraticForm.IsometryEquiv
 
 -/
 
-universe uR uA uM₁ uM₂ uM₃
+universe uR uA uM₁ uM₂
 
-variable {R : Type uR} {A : Type uA} {M₁ : Type uM₁} {M₂ : Type uM₂} {M₃ : Type uM₃}
+variable {R : Type uR} {A : Type uA} {M₁ : Type uM₁} {M₂ : Type uM₂}
 
 open TensorProduct
 
@@ -27,10 +26,10 @@ namespace QuadraticForm
 
 section CommRing
 variable [CommRing R] [CommRing A]
-variable [AddCommGroup M₁] [AddCommGroup M₂] [AddCommGroup M₃]
+variable [AddCommGroup M₁] [AddCommGroup M₂]
 variable [Algebra R A] [Module R M₁] [Module A M₁]
 variable [SMulCommClass R A M₁] [SMulCommClass A R M₁] [IsScalarTower R A M₁]
-variable [Module R M₂] [Module R M₃] [Invertible (2 : R)]
+variable [Module R M₂] [Invertible (2 : R)]
 
 
 variable (R A) in
@@ -76,41 +75,6 @@ theorem polarBilin_tmul [Invertible (2 : A)] (Q₁ : QuadraticForm A M₁) (Q₂
     ←smul_tmul', map_nsmul, associated_tmul]
   rw [smul_comm (_ : A) (_ : ℕ), ← smul_assoc, two_smul _ (_ : A), invOf_two_add_invOf_two,
     one_smul]
-
-@[simp]
-theorem tmul_comp_tensorComm (Q₁ : QuadraticForm R M₁) (Q₂ : QuadraticForm R M₂) :
-    (Q₂.tmul Q₁).comp (TensorProduct.comm R M₁ M₂) = Q₁.tmul Q₂ := by
-  refine (QuadraticForm.associated_rightInverse R).injective ?_
-  apply BilinForm.toLin.injective
-  ext m₁ m₂ m₁' m₂'
-  dsimp [-associated_apply]
-  simp only [associated_tmul, QuadraticForm.associated_comp]
-  exact mul_comm _ _
-
-@[simp]
-theorem tmul_comp_tensorAssoc
-    (Q₁ : QuadraticForm R M₁) (Q₂ : QuadraticForm R M₂) (Q₃ : QuadraticForm R M₃) :
-    (Q₁.tmul (Q₂.tmul Q₃)).comp (TensorProduct.assoc R M₁ M₂ M₃) = (Q₁.tmul Q₂).tmul Q₃ := by
-  refine (QuadraticForm.associated_rightInverse R).injective ?_
-  apply BilinForm.toLin.injective
-  ext m₁ m₂ m₁' m₂' m₁'' m₂''
-  dsimp [-associated_apply]
-  simp only [associated_tmul, QuadraticForm.associated_comp]
-  exact mul_assoc _ _ _
-
-/-- `TensorProduct.comm` preserves tensor products of quadratic forms. -/
-@[simps!]
-def tensorComm (Q₁ : QuadraticForm R M₁) (Q₂ : QuadraticForm R M₂) :
-    (Q₁.tmul Q₂).IsometryEquiv (Q₂.tmul Q₁) where
-  toLinearEquiv := TensorProduct.comm R M₁ M₂
-  map_app' x := FunLike.congr_fun (tmul_comp_tensorComm Q₁ Q₂) x
-
-/-- `TensorProduct.assoc` preserves tensor products of quadratic forms. -/
-@[simps!]
-def tensorAssoc (Q₁ : QuadraticForm R M₁) (Q₂ : QuadraticForm R M₂) (Q₃ : QuadraticForm R M₃) :
-    ((Q₁.tmul Q₂).tmul Q₃).IsometryEquiv (Q₁.tmul (Q₂.tmul Q₃)) where
-  toLinearEquiv := TensorProduct.assoc R M₁ M₂ M₃
-  map_app' x := FunLike.congr_fun (tmul_comp_tensorAssoc Q₁ Q₂ Q₃) x
 
 variable (A) in
 /-- The base change of a quadratic form. -/

--- a/Mathlib/LinearAlgebra/QuadraticForm/TensorProduct.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/TensorProduct.lean
@@ -99,14 +99,14 @@ theorem tmul_comp_tensorAssoc
   exact mul_assoc _ _ _
 
 /-- `TensorProduct.comm` preserves tensor products of quadratic forms. -/
-@[simps]
+@[simps!]
 def tensorComm (Q₁ : QuadraticForm R M₁) (Q₂ : QuadraticForm R M₂) :
     (Q₁.tmul Q₂).IsometryEquiv (Q₂.tmul Q₁) where
   toLinearEquiv := TensorProduct.comm R M₁ M₂
   map_app' x := FunLike.congr_fun (tmul_comp_tensorComm Q₁ Q₂) x
 
 /-- `TensorProduct.assoc` preserves tensor products of quadratic forms. -/
-@[simps]
+@[simps!]
 def tensorAssoc (Q₁ : QuadraticForm R M₁) (Q₂ : QuadraticForm R M₂) (Q₃ : QuadraticForm R M₃) :
     ((Q₁.tmul Q₂).tmul Q₃).IsometryEquiv (Q₁.tmul (Q₂.tmul Q₃)) where
   toLinearEquiv := TensorProduct.assoc R M₁ M₂ M₃

--- a/Mathlib/LinearAlgebra/QuadraticForm/TensorProduct.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/TensorProduct.lean
@@ -5,6 +5,7 @@ Authors: Eric Wieser
 -/
 import Mathlib.LinearAlgebra.BilinearForm.TensorProduct
 import Mathlib.LinearAlgebra.QuadraticForm.Basic
+import Mathlib.LinearAlgebra.QuadraticForm.IsometryEquiv
 
 /-!
 # The quadratic form on a tensor product
@@ -75,6 +76,25 @@ theorem polarBilin_tmul [Invertible (2 : A)] (Q₁ : QuadraticForm A M₁) (Q₂
     ←smul_tmul', map_nsmul, associated_tmul]
   rw [smul_comm (_ : A) (_ : ℕ), ← smul_assoc, two_smul _ (_ : A), invOf_two_add_invOf_two,
     one_smul]
+
+theorem tmul_comp_tensorComm (Q₁ : QuadraticForm R M₁) (Q₂ : QuadraticForm R M₂) :
+    (Q₂.tmul Q₁).comp (TensorProduct.comm R M₁ M₂) = (Q₁.tmul Q₂) := by
+  refine QuadraticForm.polarBilin_injective (isUnit_of_invertible _) ?_
+  apply BilinForm.toLin.injective
+  ext m₁ m₂ m₁' m₂'
+  dsimp [-polarBilin_apply]
+  simp only [polarBilin_tmul, QuadraticForm.polarBilin_comp]
+  dsimp [QuadraticForm.comp]
+  sorry
+
+def tensorComm (Q₁ : QuadraticForm R M₁) (Q₂ : QuadraticForm R M₂) :
+    (Q₁.tmul Q₂).IsometryEquiv (Q₂.tmul Q₁) where
+  toLinearEquiv := TensorProduct.comm R M₁ M₂
+  map_app' x := by
+    have := FunLike.congr_fun (tmul_comp_tensorComm Q₁ Q₂) x
+    sorry
+
+#exit
 
 variable (A) in
 /-- The base change of a quadratic form. -/

--- a/Mathlib/LinearAlgebra/QuadraticForm/TensorProduct/Isometries.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/TensorProduct/Isometries.lean
@@ -13,22 +13,63 @@ These results are separate from the definition of `QuadraticForm.tmul` as that f
 
 ## Main definitions
 
+* `QuadraticForm.Isometry.tmul`: `TensorProduct.map` as a `QuadraticForm.Isometry`
 * `QuadraticForm.tensorComm`: `TensorProduct.comm` as a `QuadraticForm.IsometryEquiv`
 * `QuadraticForm.tensorAssoc`: `TensorProduct.assoc` as a `QuadraticForm.IsometryEquiv`
 * `QuadraticForm.tensorRId`: `TensorProduct.rid` as a `QuadraticForm.IsometryEquiv`
 * `QuadraticForm.tensorLId`: `TensorProduct.lid` as a `QuadraticForm.IsometryEquiv`
 -/
 
-universe uR uM₁ uM₂ uM₃
-variable {R : Type uR} {M₁ : Type uM₁} {M₂ : Type uM₂} {M₃ : Type uM₃}
+universe uR uM₁ uM₂ uM₃ uM₄
+variable {R : Type uR} {M₁ : Type uM₁} {M₂ : Type uM₂} {M₃ : Type uM₃} {M₄ : Type uM₄}
 
 open scoped TensorProduct
 
 namespace QuadraticForm
 
 variable [CommRing R]
-variable [AddCommGroup M₁] [AddCommGroup M₂] [AddCommGroup M₃]
-variable [Module R M₁] [Module R M₂] [Module R M₃] [Invertible (2 : R)]
+variable [AddCommGroup M₁] [AddCommGroup M₂] [AddCommGroup M₃] [AddCommGroup M₄]
+variable [Module R M₁] [Module R M₂] [Module R M₃] [Module R M₄] [Invertible (2 : R)]
+
+@[simp]
+theorem tmul_comp_tensorMap
+    {Q₁ : QuadraticForm R M₁} {Q₂ : QuadraticForm R M₂}
+    {Q₃ : QuadraticForm R M₃} {Q₄ : QuadraticForm R M₄}
+    (f : Q₁ →qᵢ Q₂) (g : Q₃ →qᵢ Q₄) :
+    (Q₂.tmul Q₄).comp (TensorProduct.map f.toLinearMap g.toLinearMap) = Q₁.tmul Q₃ := by
+  have h₁ : Q₁ = Q₂.comp f.toLinearMap := QuadraticForm.ext fun x => (f.map_app x).symm
+  have h₃ : Q₃ = Q₄.comp g.toLinearMap := QuadraticForm.ext fun x => (g.map_app x).symm
+  refine (QuadraticForm.associated_rightInverse R).injective <| BilinForm.toLin.injective ?_
+  ext m₁ m₃ m₁' m₃'
+  simp [-associated_apply, h₁, h₃, associated_tmul]
+
+@[simp]
+theorem tmul_tensorMap_apply
+    {Q₁ : QuadraticForm R M₁} {Q₂ : QuadraticForm R M₂}
+    {Q₃ : QuadraticForm R M₃} {Q₄ : QuadraticForm R M₄}
+    (f : Q₁ →qᵢ Q₂) (g : Q₃ →qᵢ Q₄) (x : M₁ ⊗[R] M₃) :
+    Q₂.tmul Q₄ (TensorProduct.map f.toLinearMap g.toLinearMap x) = Q₁.tmul Q₃ x :=
+  FunLike.congr_fun (tmul_comp_tensorMap f g) x
+
+namespace Isometry
+
+/-- `TensorProduct.map` for `Quadraticform.Isometry`s -/
+def tmul
+    {Q₁ : QuadraticForm R M₁} {Q₂ : QuadraticForm R M₂}
+    {Q₃ : QuadraticForm R M₃} {Q₄ : QuadraticForm R M₄}
+    (f : Q₁ →qᵢ Q₂) (g : Q₃ →qᵢ Q₄) : (Q₁.tmul Q₃) →qᵢ (Q₂.tmul Q₄) where
+  toLinearMap := TensorProduct.map f.toLinearMap g.toLinearMap
+  map_app' := tmul_tensorMap_apply f g
+
+@[simp]
+theorem tmul_apply
+    {Q₁ : QuadraticForm R M₁} {Q₂ : QuadraticForm R M₂}
+    {Q₃ : QuadraticForm R M₃} {Q₄ : QuadraticForm R M₄}
+    (f : Q₁ →qᵢ Q₂) (g : Q₃ →qᵢ Q₄) (x : M₁ ⊗[R] M₃) :
+    f.tmul g x = TensorProduct.map f.toLinearMap g.toLinearMap x :=
+  rfl
+
+end Isometry
 
 section tensorComm
 

--- a/Mathlib/LinearAlgebra/QuadraticForm/TensorProduct/Isometries.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/TensorProduct/Isometries.lean
@@ -152,7 +152,7 @@ theorem comp_tensorLId_eq (Q₂ : QuadraticForm R M₂) :
 @[simp]
 theorem tmul_tensorLId_apply
     (Q₂ : QuadraticForm R M₂) (x : R ⊗[R] M₂) :
-    Q₂ (TensorProduct.lid R M₂ x) = Q₂.tmul (sq (R := R)) x :=
+    Q₂ (TensorProduct.lid R M₂ x) = (sq (R := R)).tmul Q₂ x :=
   FunLike.congr_fun (comp_tensorLId_eq Q₂) x
 
 /-- `TensorProduct.lid` preserves tensor products of quadratic forms. -/

--- a/Mathlib/LinearAlgebra/QuadraticForm/TensorProduct/Isometries.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/TensorProduct/Isometries.lean
@@ -87,18 +87,18 @@ theorem tmul_tensorAssoc_apply
 def tensorAssoc (Q₁ : QuadraticForm R M₁) (Q₂ : QuadraticForm R M₂) (Q₃ : QuadraticForm R M₃) :
     ((Q₁.tmul Q₂).tmul Q₃).IsometryEquiv (Q₁.tmul (Q₂.tmul Q₃)) where
   toLinearEquiv := TensorProduct.assoc R M₁ M₂ M₃
-  map_app' := tmul_comp_tensorAssoc Q₁ Q₂ Q₃
+  map_app' := tmul_tensorAssoc_apply Q₁ Q₂ Q₃
 
 @[simp] lemma tensorAssoc_apply
     (Q₁ : QuadraticForm R M₁) (Q₂ : QuadraticForm R M₂) (Q₃ : QuadraticForm R M₃)
     (x : (M₁ ⊗[R] M₂) ⊗[R] M₃) :
-    tensorAssoc Q₁ Q₂ x = TensorProduct.assoc R M₁ M₂ M₃ x :=
+    tensorAssoc Q₁ Q₂ Q₃ x = TensorProduct.assoc R M₁ M₂ M₃ x :=
   rfl
 
 @[simp] lemma tensorAssoc_symm_apply
     (Q₁ : QuadraticForm R M₁) (Q₂ : QuadraticForm R M₂) (Q₃ : QuadraticForm R M₃)
     (x : M₁ ⊗[R] (M₂ ⊗[R] M₃)) :
-    (tensorAssoc Q₁ Q₂ Q₃).symm x = (TensorProduct.assoc R M₁ M₂ M₃).symm x).symm x :=
+    (tensorAssoc Q₁ Q₂ Q₃).symm x = (TensorProduct.assoc R M₁ M₂ M₃).symm x :=
   rfl
 
 end tensorAssoc

--- a/Mathlib/LinearAlgebra/QuadraticForm/TensorProduct/Isometries.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/TensorProduct/Isometries.lean
@@ -15,6 +15,8 @@ These results are separate from the definition of `QuadraticForm.tmul` as that f
 
 * `QuadraticForm.tensorComm`: `TensorProduct.comm` as a `QuadraticForm.IsometryEquiv`
 * `QuadraticForm.tensorAssoc`: `TensorProduct.assoc` as a `QuadraticForm.IsometryEquiv`
+* `QuadraticForm.tensorRId`: `TensorProduct.rid` as a `QuadraticForm.IsometryEquiv`
+* `QuadraticForm.tensorLId`: `TensorProduct.lid` as a `QuadraticForm.IsometryEquiv`
 -/
 
 universe uR uM₁ uM₂ uM₃
@@ -102,5 +104,71 @@ def tensorAssoc (Q₁ : QuadraticForm R M₁) (Q₂ : QuadraticForm R M₂) (Q�
   rfl
 
 end tensorAssoc
+
+section tensorRId
+
+theorem comp_tensorRId_eq (Q₁ : QuadraticForm R M₁) :
+    Q₁.comp (TensorProduct.rid R M₁) = Q₁.tmul (sq (R := R)) := by
+  refine (QuadraticForm.associated_rightInverse R).injective ?_
+  apply BilinForm.toLin.injective
+  ext m₁ m₁'
+  dsimp [-associated_apply]
+  simp only [associated_tmul, QuadraticForm.associated_comp]
+  simp [-associated_apply, one_mul]
+
+@[simp]
+theorem tmul_tensorRId_apply
+    (Q₁ : QuadraticForm R M₁) (x : M₁ ⊗[R] R) :
+    Q₁ (TensorProduct.rid R M₁ x) = Q₁.tmul (sq (R := R)) x :=
+  FunLike.congr_fun (comp_tensorRId_eq Q₁) x
+
+/-- `TensorProduct.rid` preserves tensor products of quadratic forms. -/
+def tensorRId (Q₁ : QuadraticForm R M₁):
+    (Q₁.tmul (sq (R := R))).IsometryEquiv Q₁ where
+  toLinearEquiv := TensorProduct.rid R M₁
+  map_app' := tmul_tensorRId_apply Q₁
+
+@[simp] lemma tensorRId_apply (Q₁ : QuadraticForm R M₁) (x : M₁ ⊗[R] R) :
+    tensorRId Q₁ x = TensorProduct.rid R M₁ x :=
+  rfl
+
+@[simp] lemma tensorRId_symm_apply (Q₁ : QuadraticForm R M₁) (x : M₂) :
+    (tensorRId Q₁).symm = (TensorProduct.rid R M₁).symm x :=
+  rfl
+
+end tensorRId
+
+section tensorLId
+
+theorem comp_tensorLId_eq (Q₂ : QuadraticForm R M₂) :
+    Q₂.comp (TensorProduct.lid R M₂) = (sq (R := R)).tmul Q₂ := by
+  refine (QuadraticForm.associated_rightInverse R).injective ?_
+  apply BilinForm.toLin.injective
+  ext m₂ m₂'
+  dsimp [-associated_apply]
+  simp only [associated_tmul, QuadraticForm.associated_comp]
+  simp [-associated_apply, one_mul]
+
+@[simp]
+theorem tmul_tensorLId_apply
+    (Q₂ : QuadraticForm R M₂) (x : M₂ ⊗[R] R) :
+    Q₂ (TensorProduct.lid R M₂ x) = Q₂.tmul (sq (R := R)) x :=
+  FunLike.congr_fun (comp_tensorLId_eq Q₂) x
+
+/-- `TensorProduct.lid` preserves tensor products of quadratic forms. -/
+def tensorLId (Q₂ : QuadraticForm R M₂):
+    (Q₂.tmul (sq (R := R))).IsometryEquiv Q₂ where
+  toLinearEquiv := TensorProduct.lid R M₂
+  map_app' := tmul_tensorLId_apply Q₂
+
+@[simp] lemma tensorLId_apply (Q₂ : QuadraticForm R M₂) (x : R ⊗[R] M₂) :
+    tensorLId Q₂ x = TensorProduct.lid R M₂ x :=
+  rfl
+
+@[simp] lemma tensorLId_symm_apply (Q₂ : QuadraticForm R M₂) (x : M₂) :
+    (tensorLId Q₂).symm = (TensorProduct.lid R M₂).symm x :=
+  rfl
+
+end tensorLId
 
 end QuadraticForm

--- a/Mathlib/LinearAlgebra/QuadraticForm/TensorProduct/Isometries.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/TensorProduct/Isometries.lean
@@ -1,0 +1,84 @@
+/-
+Copyright (c) 2023 Eric Wieser. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Eric Wieser
+-/
+import Mathlib.LinearAlgebra.QuadraticForm.TensorProduct
+import Mathlib.LinearAlgebra.QuadraticForm.IsometryEquiv
+
+/-!
+# Linear equivalences of tensor products as isometries
+
+These results are separate from the definition of `QuadraticForm.tmul` as that file is very slow.
+
+## Main definitions
+
+* `QuadraticForm.tensorComm`: `TensorProduct.comm` as a `QuadraticForm.IsometryEquiv`
+* `QuadraticForm.tensorAssoc`: `TensorProduct.assoc` as a `QuadraticForm.IsometryEquiv`
+-/
+
+universe uR uM₁ uM₂ uM₃
+variable {R : Type uR} {M₁ : Type uM₁} {M₂ : Type uM₂} {M₃ : Type uM₃}
+
+namespace QuadraticForm
+variable [CommRing R]
+variable [AddCommGroup M₁] [AddCommGroup M₂] [AddCommGroup M₃]
+variable [Module R M₁] [Module R M₂] [Module R M₃] [Invertible (2 : R)]
+
+@[simp]
+theorem tmul_comp_tensorComm (Q₁ : QuadraticForm R M₁) (Q₂ : QuadraticForm R M₂) :
+    (Q₂.tmul Q₁).comp (TensorProduct.comm R M₁ M₂) = Q₁.tmul Q₂ := by
+  refine (QuadraticForm.associated_rightInverse R).injective ?_
+  apply BilinForm.toLin.injective
+  ext m₁ m₂ m₁' m₂'
+  dsimp [-associated_apply]
+  simp only [associated_tmul, QuadraticForm.associated_comp]
+  exact mul_comm _ _
+
+
+
+@[simp]
+theorem tmul_comp_tensorAssoc
+    (Q₁ : QuadraticForm R M₁) (Q₂ : QuadraticForm R M₂) (Q₃ : QuadraticForm R M₃) :
+    (Q₁.tmul (Q₂.tmul Q₃)).comp (TensorProduct.assoc R M₁ M₂ M₃) = (Q₁.tmul Q₂).tmul Q₃ := by
+  refine (QuadraticForm.associated_rightInverse R).injective ?_
+  apply BilinForm.toLin.injective
+  ext m₁ m₂ m₁' m₂' m₁'' m₂''
+  dsimp [-associated_apply]
+  simp only [associated_tmul, QuadraticForm.associated_comp]
+  exact mul_assoc _ _ _
+
+/-- `TensorProduct.comm` preserves tensor products of quadratic forms. -/
+def tensorComm (Q₁ : QuadraticForm R M₁) (Q₂ : QuadraticForm R M₂) :
+    (Q₁.tmul Q₂).IsometryEquiv (Q₂.tmul Q₁) where
+  toLinearEquiv := TensorProduct.comm R M₁ M₂
+  map_app' x := FunLike.congr_fun (tmul_comp_tensorComm Q₁ Q₂) x
+
+@[simp] lemma tensorComm_apply (Q₁ : QuadraticForm R M₁) (Q₂ : QuadraticForm R M₂)
+    (x : M₁ ⊗[R] M₂) :
+    tensorComm Q₁ Q₂ x = TensorProduct.comm R M₁ M₂ x :=
+  rfl
+
+@[simp] lemma tensorComm_symm (Q₁ : QuadraticForm R M₁) (Q₂ : QuadraticForm R M₂) :
+    (tensorComm Q₁ Q₂).symm = tensorComm Q₂ Q₁ :=
+  rfl
+
+/-- `TensorProduct.assoc` preserves tensor products of quadratic forms. -/
+def tensorAssoc (Q₁ : QuadraticForm R M₁) (Q₂ : QuadraticForm R M₂) (Q₃ : QuadraticForm R M₃) :
+    ((Q₁.tmul Q₂).tmul Q₃).IsometryEquiv (Q₁.tmul (Q₂.tmul Q₃)) where
+  toLinearEquiv := TensorProduct.assoc R M₁ M₂ M₃
+  map_app' x := FunLike.congr_fun (tmul_comp_tensorAssoc Q₁ Q₂ Q₃) x
+
+@[simp] lemma tensorAssoc_apply
+    (Q₁ : QuadraticForm R M₁) (Q₂ : QuadraticForm R M₂) (Q₃ : QuadraticForm R M₃)
+    (x : (M₁ ⊗[R] M₂) ⊗[R] M₃) :
+    tensorAssoc Q₁ Q₂ x = TensorProduct.assoc R M₁ M₂ M₃ x :=
+  rfl
+
+@[simp] lemma tensorAssoc_symm_apply
+    (Q₁ : QuadraticForm R M₁) (Q₂ : QuadraticForm R M₂) (Q₃ : QuadraticForm R M₃)
+    (x : M₁ ⊗[R] (M₂ ⊗[R] M₃)) :
+    (tensorAssoc Q₁ Q₂ Q₃).symm x = (TensorProduct.assoc R M₁ M₂ M₃).symm x).symm x :=
+  rfl
+
+end QuadraticForm

--- a/Mathlib/LinearAlgebra/QuadraticForm/TensorProduct/Isometries.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/TensorProduct/Isometries.lean
@@ -132,8 +132,8 @@ def tensorRId (Q₁ : QuadraticForm R M₁):
     tensorRId Q₁ x = TensorProduct.rid R M₁ x :=
   rfl
 
-@[simp] lemma tensorRId_symm_apply (Q₁ : QuadraticForm R M₁) (x : M₂) :
-    (tensorRId Q₁).symm = (TensorProduct.rid R M₁).symm x :=
+@[simp] lemma tensorRId_symm_apply (Q₁ : QuadraticForm R M₁) (x : M₁) :
+    (tensorRId Q₁).symm x = (TensorProduct.rid R M₁).symm x :=
   rfl
 
 end tensorRId
@@ -147,17 +147,17 @@ theorem comp_tensorLId_eq (Q₂ : QuadraticForm R M₂) :
   ext m₂ m₂'
   dsimp [-associated_apply]
   simp only [associated_tmul, QuadraticForm.associated_comp]
-  simp [-associated_apply, one_mul]
+  simp [-associated_apply, mul_one]
 
 @[simp]
 theorem tmul_tensorLId_apply
-    (Q₂ : QuadraticForm R M₂) (x : M₂ ⊗[R] R) :
+    (Q₂ : QuadraticForm R M₂) (x : R ⊗[R] M₂) :
     Q₂ (TensorProduct.lid R M₂ x) = Q₂.tmul (sq (R := R)) x :=
   FunLike.congr_fun (comp_tensorLId_eq Q₂) x
 
 /-- `TensorProduct.lid` preserves tensor products of quadratic forms. -/
 def tensorLId (Q₂ : QuadraticForm R M₂):
-    (Q₂.tmul (sq (R := R))).IsometryEquiv Q₂ where
+    ((sq (R := R)).tmul Q₂).IsometryEquiv Q₂ where
   toLinearEquiv := TensorProduct.lid R M₂
   map_app' := tmul_tensorLId_apply Q₂
 
@@ -166,7 +166,7 @@ def tensorLId (Q₂ : QuadraticForm R M₂):
   rfl
 
 @[simp] lemma tensorLId_symm_apply (Q₂ : QuadraticForm R M₂) (x : M₂) :
-    (tensorLId Q₂).symm = (TensorProduct.lid R M₂).symm x :=
+    (tensorLId Q₂).symm x = (TensorProduct.lid R M₂).symm x :=
   rfl
 
 end tensorLId

--- a/Mathlib/LinearAlgebra/QuadraticForm/TensorProduct/Isometries.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/TensorProduct/Isometries.lean
@@ -20,10 +20,15 @@ These results are separate from the definition of `QuadraticForm.tmul` as that f
 universe uR uM₁ uM₂ uM₃
 variable {R : Type uR} {M₁ : Type uM₁} {M₂ : Type uM₂} {M₃ : Type uM₃}
 
+open scoped TensorProduct
+
 namespace QuadraticForm
+
 variable [CommRing R]
 variable [AddCommGroup M₁] [AddCommGroup M₂] [AddCommGroup M₃]
 variable [Module R M₁] [Module R M₂] [Module R M₃] [Invertible (2 : R)]
+
+section tensorComm
 
 @[simp]
 theorem tmul_comp_tensorComm (Q₁ : QuadraticForm R M₁) (Q₂ : QuadraticForm R M₂) :
@@ -35,7 +40,30 @@ theorem tmul_comp_tensorComm (Q₁ : QuadraticForm R M₁) (Q₂ : QuadraticForm
   simp only [associated_tmul, QuadraticForm.associated_comp]
   exact mul_comm _ _
 
+@[simp]
+theorem tmul_tensorComm_apply
+    (Q₁ : QuadraticForm R M₁) (Q₂ : QuadraticForm R M₂) (x : M₁ ⊗[R] M₂) :
+    Q₂.tmul Q₁ (TensorProduct.comm R M₁ M₂ x) = Q₁.tmul Q₂ x :=
+  FunLike.congr_fun (tmul_comp_tensorComm Q₁ Q₂) x
 
+/-- `TensorProduct.comm` preserves tensor products of quadratic forms. -/
+def tensorComm (Q₁ : QuadraticForm R M₁) (Q₂ : QuadraticForm R M₂) :
+    (Q₁.tmul Q₂).IsometryEquiv (Q₂.tmul Q₁) where
+  toLinearEquiv := TensorProduct.comm R M₁ M₂
+  map_app' := tmul_tensorComm_apply Q₁ Q₂
+
+@[simp] lemma tensorComm_apply (Q₁ : QuadraticForm R M₁) (Q₂ : QuadraticForm R M₂)
+    (x : M₁ ⊗[R] M₂) :
+    tensorComm Q₁ Q₂ x = TensorProduct.comm R M₁ M₂ x :=
+  rfl
+
+@[simp] lemma tensorComm_symm (Q₁ : QuadraticForm R M₁) (Q₂ : QuadraticForm R M₂) :
+    (tensorComm Q₁ Q₂).symm = tensorComm Q₂ Q₁ :=
+  rfl
+
+end tensorComm
+
+section tensorAssoc
 
 @[simp]
 theorem tmul_comp_tensorAssoc
@@ -48,26 +76,18 @@ theorem tmul_comp_tensorAssoc
   simp only [associated_tmul, QuadraticForm.associated_comp]
   exact mul_assoc _ _ _
 
-/-- `TensorProduct.comm` preserves tensor products of quadratic forms. -/
-def tensorComm (Q₁ : QuadraticForm R M₁) (Q₂ : QuadraticForm R M₂) :
-    (Q₁.tmul Q₂).IsometryEquiv (Q₂.tmul Q₁) where
-  toLinearEquiv := TensorProduct.comm R M₁ M₂
-  map_app' x := FunLike.congr_fun (tmul_comp_tensorComm Q₁ Q₂) x
-
-@[simp] lemma tensorComm_apply (Q₁ : QuadraticForm R M₁) (Q₂ : QuadraticForm R M₂)
-    (x : M₁ ⊗[R] M₂) :
-    tensorComm Q₁ Q₂ x = TensorProduct.comm R M₁ M₂ x :=
-  rfl
-
-@[simp] lemma tensorComm_symm (Q₁ : QuadraticForm R M₁) (Q₂ : QuadraticForm R M₂) :
-    (tensorComm Q₁ Q₂).symm = tensorComm Q₂ Q₁ :=
-  rfl
+@[simp]
+theorem tmul_tensorAssoc_apply
+    (Q₁ : QuadraticForm R M₁) (Q₂ : QuadraticForm R M₂) (Q₃ : QuadraticForm R M₃)
+    (x : (M₁ ⊗[R] M₂) ⊗[R] M₃):
+    Q₁.tmul (Q₂.tmul Q₃) (TensorProduct.assoc R M₁ M₂ M₃ x) = (Q₁.tmul Q₂).tmul Q₃ x :=
+  FunLike.congr_fun (tmul_comp_tensorAssoc Q₁ Q₂ Q₃) x
 
 /-- `TensorProduct.assoc` preserves tensor products of quadratic forms. -/
 def tensorAssoc (Q₁ : QuadraticForm R M₁) (Q₂ : QuadraticForm R M₂) (Q₃ : QuadraticForm R M₃) :
     ((Q₁.tmul Q₂).tmul Q₃).IsometryEquiv (Q₁.tmul (Q₂.tmul Q₃)) where
   toLinearEquiv := TensorProduct.assoc R M₁ M₂ M₃
-  map_app' x := FunLike.congr_fun (tmul_comp_tensorAssoc Q₁ Q₂ Q₃) x
+  map_app' := tmul_comp_tensorAssoc Q₁ Q₂ Q₃
 
 @[simp] lemma tensorAssoc_apply
     (Q₁ : QuadraticForm R M₁) (Q₂ : QuadraticForm R M₂) (Q₃ : QuadraticForm R M₃)
@@ -80,5 +100,7 @@ def tensorAssoc (Q₁ : QuadraticForm R M₁) (Q₂ : QuadraticForm R M₂) (Q�
     (x : M₁ ⊗[R] (M₂ ⊗[R] M₃)) :
     (tensorAssoc Q₁ Q₂ Q₃).symm x = (TensorProduct.assoc R M₁ M₂ M₃).symm x).symm x :=
   rfl
+
+end tensorAssoc
 
 end QuadraticForm


### PR DESCRIPTION
This was discussed at LFTCM regarding the Grothendieck-Witt ring of quadratic forms.

These could eventually be used to show that #6987 forms a braided monoidal category.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

cc @mmasdeu
