### PR TITLE
chore: refactor of AtomM

### DIFF
--- a/Mathlib/Tactic/Ring/Basic.lean
+++ b/Mathlib/Tactic/Ring/Basic.lean
@@ -879,11 +879,9 @@ Evaluates an atom, an expression where `ring` can find no additional structure.
 * `a = a ^ 1 * 1 + 0`
 -/
 def evalAtom (e : Q($α)) : AtomM (Result (ExSum sα) e) := do
-  let r ← (← read).evalAtom e
-  have e' : Q($α) := r.expr
-  let i ← addAtom e'
+  let ⟨i, ⟨(e' : Q($α)), proof?, _⟩⟩ ← addAtomWithResult e
   let ve' := (ExBase.atom i (e := e')).toProd (ExProd.mkNat sℕ 1).2 |>.toSum
-  pure ⟨_, ve', match r.proof? with
+  pure ⟨_, ve', match proof? with
   | none => (q(atom_pf $e) : Expr)
   | some (p : Q($e = $e')) => (q(atom_pf' $p) : Expr)⟩
 


### PR DESCRIPTION
There's no functional change here. I just found it weird that `AtomM.Context` was carrying around `evalAtom`, but none of the `AtomM` functions used it, and instead internal users had to retrieve it and use it themselves.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
