### PR TITLE
[Merged by Bors] - refactor: more readable error message when `borelize` fails

### DIFF
--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Basic.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Basic.lean
@@ -230,13 +230,21 @@ def addBorelInstance (e : Expr) : TacticM Unit := do
 /-- Given a type `e`, an assumption `i : MeasurableSpace e`, and an instance `[BorelSpace e]`,
 replace `i` with `borel e`. -/
 def borelToRefl (e : Expr) (i : FVarId) : TacticM Unit := do
-  let t ← Lean.Elab.Term.exprToSyntax e
+  let te ← Lean.Elab.Term.exprToSyntax e
   evalTactic <| ← `(tactic|
-    have := @BorelSpace.measurable_eq $t _ _ _)
-  liftMetaTactic fun m => return [← subst m i]
+    have := @BorelSpace.measurable_eq $te _ _ _)
+  try
+    liftMetaTactic fun m => return [← subst m i]
+  catch _ =>
+    let et ← synthInstance (← mkAppOptM ``TopologicalSpace #[e])
+    throwError
+      (m!"`‹TopologicalSpace {e}› := {et}" ++ MessageData.ofFormat Format.line ++
+        m!"depends on" ++ MessageData.ofFormat Format.line ++
+        m!"{Expr.fvar i} : MeasurableSpace {e}`" ++ MessageData.ofFormat Format.line ++
+        "so `borelize` isn't avaliable")
   evalTactic <| ← `(tactic|
     refine_lift
-      letI : MeasurableSpace $t := borel $t
+      letI : MeasurableSpace $te := borel $te
       ?_)
 
 /-- Given a type `$t`, if there is an assumption `[i : MeasurableSpace $t]`, then try to prove


### PR DESCRIPTION
`borelize X` fails when `‹TopologicalSpace X›` depends on `i : MeasurableSpace X`, but this message isn't readable:
```lean
failed to create binder due to failure when reverting variable dependencies
```
This is probrem in this case:
https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/borelize.20gives.20.22failed.20to.20create.20binder.2E.2E.2E.22

This PR make  error messages more readable:
```lean
‹TopologicalSpace X› := (expr depends on i)"
depends on
i : MeasurableSpace X
so `borelize` isn't avaliable
```

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
