### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Monoidal/Transport): generalize to a faithful functor

### DIFF
--- a/Mathlib/Algebra/Category/FGModuleCat/Basic.lean
+++ b/Mathlib/Algebra/Category/FGModuleCat/Basic.lean
@@ -220,7 +220,8 @@ instance closedPredicateModuleFinite :
 instance : MonoidalClosed (FGModuleCat K) := by
   dsimp [FGModuleCat]
   -- Porting note: was `infer_instance`
-  exact MonoidalCategory.fullMonoidalClosedSubcategory _
+  exact MonoidalCategory.fullMonoidalClosedSubcategory
+    (fun V : ModuleCat.{u} K => Module.Finite K V)
 
 variable (V W : FGModuleCat K)
 

--- a/Mathlib/Algebra/Category/FGModuleCat/Basic.lean
+++ b/Mathlib/Algebra/Category/FGModuleCat/Basic.lean
@@ -156,7 +156,7 @@ instance monoidalPredicate_module_finite :
 
 instance : MonoidalCategory (FGModuleCat R) := by
   dsimp [FGModuleCat]
-  show_term infer_instance
+  infer_instance
 
 open MonoidalCategory
 

--- a/Mathlib/Algebra/Category/FGModuleCat/Basic.lean
+++ b/Mathlib/Algebra/Category/FGModuleCat/Basic.lean
@@ -156,7 +156,7 @@ instance monoidalPredicate_module_finite :
 
 instance : MonoidalCategory (FGModuleCat R) := by
   dsimp [FGModuleCat]
-  infer_instance
+  show_term infer_instance
 
 open MonoidalCategory
 

--- a/Mathlib/CategoryTheory/FullSubcategory.lean
+++ b/Mathlib/CategoryTheory/FullSubcategory.lean
@@ -118,7 +118,7 @@ instance FullSubcategory.category : Category.{v} (FullSubcategory Z) :=
 lemma FullSubcategory.id_def (X : FullSubcategory Z) : 𝟙 X = 𝟙 X.obj := rfl
 
 lemma FullSubcategory.comp_def {X Y Z : FullSubcategory Z} (f : X ⟶ Y) (g : Y ⟶ Z) :
-  f ≫ g = (f ≫ g : X.obj ⟶ Z.obj) := rfl
+    f ≫ g = (f ≫ g : X.obj ⟶ Z.obj) := rfl
 
 /-- The forgetful functor from a full subcategory into the original category
 ("forgetting" the condition).

--- a/Mathlib/CategoryTheory/FullSubcategory.lean
+++ b/Mathlib/CategoryTheory/FullSubcategory.lean
@@ -113,6 +113,13 @@ instance FullSubcategory.category : Category.{v} (FullSubcategory Z) :=
   InducedCategory.category FullSubcategory.obj
 #align category_theory.full_subcategory.category CategoryTheory.FullSubcategory.category
 
+-- these lemmas are not particularly well-typed, so would probably be dangerous as simp lemmas
+
+lemma id_def (X : FullSubcategory Z) : 𝟙 X = 𝟙 X.obj := rfl
+
+lemma comp_def {X Y Z : FullSubcategory Z} (f : X ⟶ Y) (g : Y ⟶ Z) :
+  f ≫ g = (f ≫ g : X.obj ⟶ Z.obj) := rfl
+
 /-- The forgetful functor from a full subcategory into the original category
 ("forgetting" the condition).
 -/

--- a/Mathlib/CategoryTheory/FullSubcategory.lean
+++ b/Mathlib/CategoryTheory/FullSubcategory.lean
@@ -115,9 +115,9 @@ instance FullSubcategory.category : Category.{v} (FullSubcategory Z) :=
 
 -- these lemmas are not particularly well-typed, so would probably be dangerous as simp lemmas
 
-lemma id_def (X : FullSubcategory Z) : 𝟙 X = 𝟙 X.obj := rfl
+lemma FullSubcategory.id_def (X : FullSubcategory Z) : 𝟙 X = 𝟙 X.obj := rfl
 
-lemma comp_def {X Y Z : FullSubcategory Z} (f : X ⟶ Y) (g : Y ⟶ Z) :
+lemma FullSubcategory.comp_def {X Y Z : FullSubcategory Z} (f : X ⟶ Y) (g : Y ⟶ Z) :
   f ≫ g = (f ≫ g : X.obj ⟶ Z.obj) := rfl
 
 /-- The forgetful functor from a full subcategory into the original category

--- a/Mathlib/CategoryTheory/Monoidal/Subcategory.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Subcategory.lean
@@ -53,8 +53,7 @@ When `P` is a monoidal predicate, the full subcategory for `P` inherits the mono
   `C`.
 -/
 instance fullMonoidalSubcategory : MonoidalCategory (FullSubcategory P) :=
-  Monoidal.induced
-    (F := fullSubcategoryInclusion P)
+  Monoidal.induced (fullSubcategoryInclusion P)
     { tensorObj := fun X Y => ⟨X.1 ⊗ Y.1, prop_tensor X.2 Y.2⟩
       μIsoSymm := fun X Y => eqToIso rfl
       whiskerLeft := fun X _ _ f ↦ X.1 ◁ f

--- a/Mathlib/CategoryTheory/Monoidal/Subcategory.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Subcategory.lean
@@ -228,8 +228,8 @@ instance fullMonoidalClosedSubcategory : MonoidalClosed (FullSubcategory P) wher
           counit :=
           { app := fun Y => (ihom.ev X.1).app Y.1
             naturality := fun Y Z f => ihom.ev_naturality X.1 f }
-          left_triangle := by ext Y; simp; exact ihom.ev_coev X.1 Y.1
-          right_triangle := by ext Y; simp; exact ihom.coev_ev X.1 Y.1 } } }
+          left_triangle := by ext Y; simp
+          right_triangle := by ext Y; simp } } }
 #align category_theory.monoidal_category.full_monoidal_closed_subcategory CategoryTheory.MonoidalCategory.fullMonoidalClosedSubcategory
 
 @[simp]

--- a/Mathlib/CategoryTheory/Monoidal/Subcategory.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Subcategory.lean
@@ -5,6 +5,7 @@ Authors: Antoine Labelle
 -/
 import Mathlib.CategoryTheory.Monoidal.Braided
 import Mathlib.CategoryTheory.Monoidal.Linear
+import Mathlib.CategoryTheory.Monoidal.Transport
 import Mathlib.CategoryTheory.Preadditive.AdditiveFunctor
 import Mathlib.CategoryTheory.Linear.LinearFunctor
 import Mathlib.CategoryTheory.Closed.Monoidal
@@ -51,27 +52,21 @@ variable [MonoidalPredicate P]
 When `P` is a monoidal predicate, the full subcategory for `P` inherits the monoidal structure of
   `C`.
 -/
-instance fullMonoidalSubcategory : MonoidalCategory (FullSubcategory P) where
-  tensorObj X Y := ⟨X.1 ⊗ Y.1, prop_tensor X.2 Y.2⟩
-  tensorHom f g := f ⊗ g
-  tensorHom_def f g := tensorHom_def (C := C) f g
-  whiskerLeft := fun X _ _ f ↦ X.1 ◁ f
-  whiskerRight := fun f Y ↦ (fun f ↦ f ▷ Y.1) f
-  tensorUnit' := ⟨𝟙_ C, prop_id⟩
-  associator X Y Z :=
-    ⟨(α_ X.1 Y.1 Z.1).hom, (α_ X.1 Y.1 Z.1).inv, hom_inv_id (α_ X.1 Y.1 Z.1),
-      inv_hom_id (α_ X.1 Y.1 Z.1)⟩
-  whiskerLeft_id X Y := whiskerLeft_id X.1 Y.1
-  id_whiskerRight X Y := id_whiskerRight X.1 Y.1
-  leftUnitor X := ⟨(λ_ X.1).hom, (λ_ X.1).inv, hom_inv_id (λ_ X.1), inv_hom_id (λ_ X.1)⟩
-  rightUnitor X := ⟨(ρ_ X.1).hom, (ρ_ X.1).inv, hom_inv_id (ρ_ X.1), inv_hom_id (ρ_ X.1)⟩
-  tensor_id X Y := tensor_id X.1 Y.1
-  tensor_comp f₁ f₂ g₁ g₂ := @tensor_comp C _ _ _ _ _ _ _ _ f₁ f₂ g₁ g₂
-  associator_naturality f₁ f₂ f₃ := @associator_naturality C _ _ _ _ _ _ _ _ f₁ f₂ f₃
-  leftUnitor_naturality f := @leftUnitor_naturality C _ _ _ _ f
-  rightUnitor_naturality f := @rightUnitor_naturality C _ _ _ _ f
-  pentagon W X Y Z := pentagon W.1 X.1 Y.1 Z.1
-  triangle X Y := triangle X.1 Y.1
+instance fullMonoidalSubcategory : MonoidalCategory (FullSubcategory P) :=
+  Monoidal.induced
+    (e := fullSubcategoryInclusion P)
+    (tensorObj := fun X Y => ⟨X.1 ⊗ Y.1, prop_tensor X.2 Y.2⟩)
+    (μIsoSymm := fun X Y => eqToIso rfl)
+    (whiskerLeft := fun X _ _ f ↦ X.1 ◁ f)
+    (whiskerRight := @fun X₁ X₂ (f : X₁.1 ⟶ X₂.1) Y ↦ (f ▷ Y.1 :))
+    (tensorHom := fun f g => f ⊗ g)
+    (tensorUnit' := ⟨𝟙_ C, prop_id⟩)
+    (εIsoSymm := eqToIso rfl)
+    (associator := fun X Y Z =>
+      ⟨(α_ X.1 Y.1 Z.1).hom, (α_ X.1 Y.1 Z.1).inv, hom_inv_id (α_ X.1 Y.1 Z.1),
+        inv_hom_id (α_ X.1 Y.1 Z.1)⟩)
+    (leftUnitor := fun X => ⟨(λ_ X.1).hom, (λ_ X.1).inv, hom_inv_id (λ_ X.1), inv_hom_id (λ_ X.1)⟩)
+    (rightUnitor := fun X => ⟨(ρ_ X.1).hom, (ρ_ X.1).inv, hom_inv_id (ρ_ X.1), inv_hom_id (ρ_ X.1)⟩)
 #align category_theory.monoidal_category.full_monoidal_subcategory CategoryTheory.MonoidalCategory.fullMonoidalSubcategory
 
 /-- The forgetful monoidal functor from a full monoidal subcategory into the original category

--- a/Mathlib/CategoryTheory/Monoidal/Subcategory.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Subcategory.lean
@@ -116,6 +116,8 @@ end
 
 variable {P} {P' : C → Prop} [MonoidalPredicate P']
 
+-- needed for `aesop_cat`
+attribute [simp] comp_def id_def in
 /-- An implication of predicates `P → P'` induces a monoidal functor between full monoidal
 subcategories. -/
 @[simps]
@@ -124,19 +126,6 @@ def fullMonoidalSubcategory.map (h : ∀ ⦃X⦄, P X → P' X) :
   toFunctor := FullSubcategory.map h
   ε := 𝟙 _
   μ X Y := 𝟙 _
-  -- `aesop_cat` can't do the `erw`
-  left_unitality X := by
-    dsimp only
-    simp
-    erw [tensor_id, Category.id_comp]
-  right_unitality X := by
-    dsimp only
-    simp
-    erw [tensor_id, Category.id_comp]
-  associativity X Y Z := by
-    dsimp only
-    simp
-    erw [tensor_id, tensor_id, Category.comp_id, Category.id_comp]
 
 #align category_theory.monoidal_category.full_monoidal_subcategory.map CategoryTheory.MonoidalCategory.fullMonoidalSubcategory.map
 

--- a/Mathlib/CategoryTheory/Monoidal/Subcategory.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Subcategory.lean
@@ -117,7 +117,7 @@ end
 variable {P} {P' : C → Prop} [MonoidalPredicate P']
 
 -- needed for `aesop_cat`
-attribute [simp] comp_def id_def in
+attribute [simp] FullSubcategory.comp_def FullSubcategory.id_def in
 /-- An implication of predicates `P → P'` induces a monoidal functor between full monoidal
 subcategories. -/
 @[simps]

--- a/Mathlib/CategoryTheory/Monoidal/Subcategory.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Subcategory.lean
@@ -56,12 +56,12 @@ instance fullMonoidalSubcategory : MonoidalCategory (FullSubcategory P) :=
   Monoidal.induced
     (F := fullSubcategoryInclusion P)
     (tensorObj := fun X Y => ⟨X.1 ⊗ Y.1, prop_tensor X.2 Y.2⟩)
-    (μIsoSymm := fun X Y => 𝟙 _)
+    (μIsoSymm := fun X Y => eqToIso rfl)
     (whiskerLeft := fun X _ _ f ↦ X.1 ◁ f)
     (whiskerRight := @fun X₁ X₂ (f : X₁.1 ⟶ X₂.1) Y ↦ (f ▷ Y.1 :))
     (tensorHom := fun f g => f ⊗ g)
     (tensorUnit' := ⟨𝟙_ C, prop_id⟩)
-    (εIsoSymm := 𝟙 _)
+    (εIsoSymm := eqToIso rfl)
     (associator := fun X Y Z =>
       ⟨(α_ X.1 Y.1 Z.1).hom, (α_ X.1 Y.1 Z.1).inv, hom_inv_id (α_ X.1 Y.1 Z.1),
         inv_hom_id (α_ X.1 Y.1 Z.1)⟩)

--- a/Mathlib/CategoryTheory/Monoidal/Subcategory.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Subcategory.lean
@@ -54,14 +54,14 @@ When `P` is a monoidal predicate, the full subcategory for `P` inherits the mono
 -/
 instance fullMonoidalSubcategory : MonoidalCategory (FullSubcategory P) :=
   Monoidal.induced
-    (e := fullSubcategoryInclusion P)
+    (F := fullSubcategoryInclusion P)
     (tensorObj := fun X Y => ⟨X.1 ⊗ Y.1, prop_tensor X.2 Y.2⟩)
-    (μIsoSymm := fun X Y => eqToIso rfl)
+    (μIsoSymm := fun X Y => 𝟙 _)
     (whiskerLeft := fun X _ _ f ↦ X.1 ◁ f)
     (whiskerRight := @fun X₁ X₂ (f : X₁.1 ⟶ X₂.1) Y ↦ (f ▷ Y.1 :))
     (tensorHom := fun f g => f ⊗ g)
     (tensorUnit' := ⟨𝟙_ C, prop_id⟩)
-    (εIsoSymm := eqToIso rfl)
+    (εIsoSymm := 𝟙 _)
     (associator := fun X Y Z =>
       ⟨(α_ X.1 Y.1 Z.1).hom, (α_ X.1 Y.1 Z.1).inv, hom_inv_id (α_ X.1 Y.1 Z.1),
         inv_hom_id (α_ X.1 Y.1 Z.1)⟩)

--- a/Mathlib/CategoryTheory/Monoidal/Subcategory.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Subcategory.lean
@@ -55,18 +55,20 @@ When `P` is a monoidal predicate, the full subcategory for `P` inherits the mono
 instance fullMonoidalSubcategory : MonoidalCategory (FullSubcategory P) :=
   Monoidal.induced
     (F := fullSubcategoryInclusion P)
-    (tensorObj := fun X Y => ⟨X.1 ⊗ Y.1, prop_tensor X.2 Y.2⟩)
-    (μIsoSymm := fun X Y => eqToIso rfl)
-    (whiskerLeft := fun X _ _ f ↦ X.1 ◁ f)
-    (whiskerRight := @fun X₁ X₂ (f : X₁.1 ⟶ X₂.1) Y ↦ (f ▷ Y.1 :))
-    (tensorHom := fun f g => f ⊗ g)
-    (tensorUnit' := ⟨𝟙_ C, prop_id⟩)
-    (εIsoSymm := eqToIso rfl)
-    (associator := fun X Y Z =>
-      ⟨(α_ X.1 Y.1 Z.1).hom, (α_ X.1 Y.1 Z.1).inv, hom_inv_id (α_ X.1 Y.1 Z.1),
-        inv_hom_id (α_ X.1 Y.1 Z.1)⟩)
-    (leftUnitor := fun X => ⟨(λ_ X.1).hom, (λ_ X.1).inv, hom_inv_id (λ_ X.1), inv_hom_id (λ_ X.1)⟩)
-    (rightUnitor := fun X => ⟨(ρ_ X.1).hom, (ρ_ X.1).inv, hom_inv_id (ρ_ X.1), inv_hom_id (ρ_ X.1)⟩)
+    { tensorObj := fun X Y => ⟨X.1 ⊗ Y.1, prop_tensor X.2 Y.2⟩
+      μIsoSymm := fun X Y => eqToIso rfl
+      whiskerLeft := fun X _ _ f ↦ X.1 ◁ f
+      whiskerRight := @fun X₁ X₂ (f : X₁.1 ⟶ X₂.1) Y ↦ (f ▷ Y.1 :)
+      tensorHom := fun f g => f ⊗ g
+      tensorUnit' := ⟨𝟙_ C, prop_id⟩
+      εIsoSymm := eqToIso rfl
+      associator := fun X Y Z =>
+        ⟨(α_ X.1 Y.1 Z.1).hom, (α_ X.1 Y.1 Z.1).inv, hom_inv_id (α_ X.1 Y.1 Z.1),
+          inv_hom_id (α_ X.1 Y.1 Z.1)⟩
+      leftUnitor := fun X =>
+        ⟨(λ_ X.1).hom, (λ_ X.1).inv, hom_inv_id (λ_ X.1), inv_hom_id (λ_ X.1)⟩
+      rightUnitor := fun X =>
+        ⟨(ρ_ X.1).hom, (ρ_ X.1).inv, hom_inv_id (ρ_ X.1), inv_hom_id (ρ_ X.1)⟩ }
 #align category_theory.monoidal_category.full_monoidal_subcategory CategoryTheory.MonoidalCategory.fullMonoidalSubcategory
 
 /-- The forgetful monoidal functor from a full monoidal subcategory into the original category
@@ -122,6 +124,20 @@ def fullMonoidalSubcategory.map (h : ∀ ⦃X⦄, P X → P' X) :
   toFunctor := FullSubcategory.map h
   ε := 𝟙 _
   μ X Y := 𝟙 _
+  -- `aesop_cat` can't do the `erw`
+  left_unitality X := by
+    dsimp only
+    simp
+    erw [tensor_id, Category.id_comp]
+  right_unitality X := by
+    dsimp only
+    simp
+    erw [tensor_id, Category.id_comp]
+  associativity X Y Z := by
+    dsimp only
+    simp
+    erw [tensor_id, tensor_id, Category.comp_id, Category.id_comp]
+
 #align category_theory.monoidal_category.full_monoidal_subcategory.map CategoryTheory.MonoidalCategory.fullMonoidalSubcategory.map
 
 instance fullMonoidalSubcategory.mapFull (h : ∀ ⦃X⦄, P X → P' X) :

--- a/Mathlib/CategoryTheory/Monoidal/Transport.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Transport.lean
@@ -203,7 +203,7 @@ def fromInduced (F : D ⥤ C) [Faithful F] (fData : InducingFunctorData F):
 /-- Transport a monoidal structure along an equivalence of (plain) categories.
 -/
 def transport (e : C ≌ D) : MonoidalCategory.{v₂} D :=
-  induced (F := e.inverse)
+  induced e.inverse
     { tensorObj := fun X Y => e.functor.obj (e.inverse.obj X ⊗ e.inverse.obj Y)
       μIsoSymm := fun X Y => (e.unitIso.app _).symm
       whiskerLeft := fun X _ _ f ↦ e.functor.map (e.inverse.obj X ◁ e.inverse.map f)

--- a/Mathlib/CategoryTheory/Monoidal/Transport.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Transport.lean
@@ -95,33 +95,7 @@ abbrev induced (F : D ⥤ C) [Faithful F]
   tensor_comp {X₁ Y₁ Z₁ X₂ Y₂ Z₂} f₁ f₂ g₁ g₂ := F.map_injective <| by aesop_cat
   whiskerLeft_id X Y := F.map_injective <| by simp [whiskerLeft_eq]
   id_whiskerRight X Y := F.map_injective <| by simp [whiskerRight_eq]
-  associator_naturality {X₁ X₂ X₃ Y₁ Y₂ Y₃} f₁ f₂ f₃ := F.map_injective <| by
-    have := associator_naturality (F.map f₁) (F.map f₂) (F.map f₃)
-    dsimp
-    simp [associator_eq, tensorHom_eq]
-    simp_rw [←assoc, ←tensor_comp, assoc, Iso.inv_hom_id, ←assoc]
-    congr 1
-    conv_rhs => rw [←comp_id (F.map f₁), ←id_comp (F.map f₁)]
-    simp only [tensor_comp]
-    simp only [tensor_id, comp_id, assoc, tensor_inv_hom_id_assoc, id_comp]
-    slice_rhs 2 3 => rw [←this]
-    simp only [← assoc, Iso.inv_hom_id, comp_id]
-    congr 2
-    simp_rw [←tensor_comp, id_comp]
-  leftUnitor_naturality {X Y : D} f := F.map_injective <| by
-    have := leftUnitor_naturality (F.map f)
-    dsimp
-    simp only [Functor.map_comp, tensorHom_eq, Functor.map_id, leftUnitor_eq, Iso.trans_assoc,
-      Iso.trans_hom, tensorIso_hom, Iso.refl_hom, assoc, Iso.inv_hom_id_assoc,
-      id_tensor_comp_tensor_id_assoc, Iso.cancel_iso_hom_left]
-    rw [←this, ←assoc, ←tensor_comp, id_comp, comp_id]
-  rightUnitor_naturality {X Y : D} f := F.map_injective <| by
-    have := rightUnitor_naturality (F.map f)
-    dsimp
-    simp only [Functor.map_comp, tensorHom_eq, Functor.map_id, rightUnitor_eq, Iso.trans_assoc,
-      Iso.trans_hom, tensorIso_hom, Iso.refl_hom, assoc, Iso.inv_hom_id_assoc,
-      tensor_id_comp_id_tensor_assoc, Iso.cancel_iso_hom_left]
-    rw [←this, ←assoc, ←tensor_comp, id_comp, comp_id]
+  triangle X Y := F.map_injective <| by aesop_cat
   pentagon W X Y Z := F.map_injective <| by
     have := MonoidalCategory.pentagon (F.obj W) (F.obj X) (F.obj Y) (F.obj Z)
     dsimp
@@ -144,7 +118,33 @@ abbrev induced (F : D ⥤ C) [Faithful F]
     rw [assoc]
     congr 1
     rw [←associator_naturality, tensor_id]
-  triangle X Y := F.map_injective <| by aesop_cat
+  leftUnitor_naturality {X Y : D} f := F.map_injective <| by
+    have := leftUnitor_naturality (F.map f)
+    dsimp
+    simp only [Functor.map_comp, tensorHom_eq, Functor.map_id, leftUnitor_eq, Iso.trans_assoc,
+      Iso.trans_hom, tensorIso_hom, Iso.refl_hom, assoc, Iso.inv_hom_id_assoc,
+      id_tensor_comp_tensor_id_assoc, Iso.cancel_iso_hom_left]
+    rw [←this, ←assoc, ←tensor_comp, id_comp, comp_id]
+  rightUnitor_naturality {X Y : D} f := F.map_injective <| by
+    have := rightUnitor_naturality (F.map f)
+    dsimp
+    simp only [Functor.map_comp, tensorHom_eq, Functor.map_id, rightUnitor_eq, Iso.trans_assoc,
+      Iso.trans_hom, tensorIso_hom, Iso.refl_hom, assoc, Iso.inv_hom_id_assoc,
+      tensor_id_comp_id_tensor_assoc, Iso.cancel_iso_hom_left]
+    rw [←this, ←assoc, ←tensor_comp, id_comp, comp_id]
+  associator_naturality {X₁ X₂ X₃ Y₁ Y₂ Y₃} f₁ f₂ f₃ := F.map_injective <| by
+    have := associator_naturality (F.map f₁) (F.map f₂) (F.map f₃)
+    dsimp
+    simp [associator_eq, tensorHom_eq]
+    simp_rw [←assoc, ←tensor_comp, assoc, Iso.inv_hom_id, ←assoc]
+    congr 1
+    conv_rhs => rw [←comp_id (F.map f₁), ←id_comp (F.map f₁)]
+    simp only [tensor_comp]
+    simp only [tensor_id, comp_id, assoc, tensor_inv_hom_id_assoc, id_comp]
+    slice_rhs 2 3 => rw [←this]
+    simp only [← assoc, Iso.inv_hom_id, comp_id]
+    congr 2
+    simp_rw [←tensor_comp, id_comp]
 
 /-- Transport a monoidal structure along an equivalence of (plain) categories.
 -/

--- a/Mathlib/CategoryTheory/Monoidal/Transport.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Transport.lean
@@ -38,7 +38,7 @@ variable {D : Type u₂} [Category.{v₂} D]
 /-- Induce a monoidal structure along an faithful functor of (plain) categories,
 -/
 @[simps]
-def induced (e : D ⥤ C) [Faithful e]
+abbrev induced (e : D ⥤ C) [Faithful e]
     (tensorObj : D → D → D)
     (μIsoSymm : ∀ X Y,
       e.obj (tensorObj X Y) ≅ e.obj X ⊗ e.obj Y)

--- a/Mathlib/CategoryTheory/Monoidal/Transport.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Transport.lean
@@ -163,7 +163,8 @@ abbrev transport (e : C ≌ D) : MonoidalCategory.{v₂} D :=
     (associator := fun X Y Z =>
       e.functor.mapIso
         (((e.unitIso.app _).symm ⊗ Iso.refl _) ≪≫
-          α_ (e.inverse.obj X) (e.inverse.obj Y) (e.inverse.obj Z) ≪≫ (Iso.refl _ ⊗ e.unitIso.app _)))
+          α_ (e.inverse.obj X) (e.inverse.obj Y) (e.inverse.obj Z) ≪≫
+          (Iso.refl _ ⊗ e.unitIso.app _)))
     (leftUnitor := fun X =>
       e.functor.mapIso (((e.unitIso.app _).symm ⊗ Iso.refl _) ≪≫ λ_ (e.inverse.obj X)) ≪≫
         e.counitIso.app _)

--- a/Mathlib/CategoryTheory/Monoidal/Transport.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Transport.lean
@@ -206,7 +206,7 @@ def fromInduced (F : D ⥤ C) [Faithful F]
 -/
 @[simps
   tensorObj whiskerLeft whiskerRight tensorHom tensorUnit' associator leftUnitor rightUnitor]
-abbrev transport (e : C ≌ D) : MonoidalCategory.{v₂} D :=
+def transport (e : C ≌ D) : MonoidalCategory.{v₂} D :=
   induced
     (F := e.inverse)
     (tensorObj := fun X Y => e.functor.obj (e.inverse.obj X ⊗ e.inverse.obj Y))

--- a/Mathlib/CategoryTheory/Monoidal/Transport.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Transport.lean
@@ -11,8 +11,13 @@ import Mathlib.CategoryTheory.Monoidal.NaturalTransformation
 # Transport a monoidal structure along an equivalence.
 
 When `C` and `D` are equivalent as categories,
-we can transport a monoidal structure on `C` along the equivalence,
-obtaining a monoidal structure on `D`.
+we can transport a monoidal structure on `C` along the equivalence as
+`CategoryTheory.Monoidal.transport`, obtaining a monoidal structure on `D`.
+
+More generally, we can transport the lawfulness of a monoidal structure along a suitable faithful
+functor, as `CategoryTheory.Monoidal.induced`.
+The comparison is analogous to the difference between `Equiv.monoid` and
+`Function.Injective.Monoid`.
 
 We then upgrade the original functor and its inverse to monoidal functors
 with respect to the new monoidal structure on `D`.
@@ -148,7 +153,7 @@ abbrev induced (F : D ⥤ C) [Faithful F]
 
 /-- Transport a monoidal structure along an equivalence of (plain) categories.
 -/
-@[simps!
+@[simps
   tensorObj whiskerLeft whiskerRight tensorHom tensorUnit' associator leftUnitor rightUnitor]
 abbrev transport (e : C ≌ D) : MonoidalCategory.{v₂} D :=
   induced

--- a/Mathlib/CategoryTheory/Monoidal/Transport.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Transport.lean
@@ -40,8 +40,16 @@ variable {C : Type u₁} [Category.{v₁} C] [MonoidalCategory.{v₁} C]
 
 variable {D : Type u₂} [Category.{v₂} D]
 
-/-- Induce the lawfulness of the monoidal structure along an faithful functor of (plain) categories,
-where the operations are already defined on the destination type `D`. -/
+/--
+Induce the lawfulness of the monoidal structure along an faithful functor of (plain) categories,
+where the operations are already defined on the destination type `D`.
+
+The functor `F` must preserve all the data parts of the monoidal structure between the two
+categories.
+
+Note that `μIsoSymm` and `εIsoSymm` correspond to the reversed versions of
+`CategoryTheory.LaxMonoidalFunctor.μIso` and `CategoryTheory.LaxMonoidalFunctor.εIso`.
+-/
 abbrev induced (F : D ⥤ C) [Faithful F]
     (tensorObj : D → D → D)
     (μIsoSymm : ∀ X Y,

--- a/Mathlib/CategoryTheory/Monoidal/Transport.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Transport.lean
@@ -35,6 +35,8 @@ variable {C : Type u₁} [Category.{v₁} C] [MonoidalCategory.{v₁} C]
 
 variable {D : Type u₂} [Category.{v₂} D]
 
+/-- Induce a monoidal structure along an faithful functor of (plain) categories,
+-/
 @[simps]
 def induced (e : D ⥤ C) [Faithful e]
     (tensorObj : D → D → D)
@@ -43,48 +45,109 @@ def induced (e : D ⥤ C) [Faithful e]
     (whiskerLeft : ∀ (X : D) {Y₁ Y₂ : D} (f : Y₁ ⟶ Y₂), tensorObj X Y₁ ⟶ tensorObj X Y₂)
     (whiskerLeft_eq : ∀ (X : D) {Y₁ Y₂ : D} (f : Y₁ ⟶ Y₂),
       e.map (whiskerLeft X f)
-        = (tensorObjIso _ _).hom ≫ (e.obj X ◁ e.map f) ≫ (tensorObjIso _ _).inv)
+        = (tensorObjIso _ _).hom ≫ (e.obj X ◁ e.map f) ≫ (tensorObjIso _ _).inv
+      := by aesop_cat)
     (whiskerRight : ∀ {X₁ X₂ : D} (f : X₁ ⟶ X₂) (Y : D), tensorObj X₁ Y ⟶ tensorObj X₂ Y)
     (whiskerRight_eq : ∀ {X₁ X₂ : D} (f : X₁ ⟶ X₂) (Y : D),
       e.map (whiskerRight f Y)
-        = (tensorObjIso _ _).hom ≫ (e.map f ▷ e.obj Y) ≫ (tensorObjIso _ _).inv)
+        = (tensorObjIso _ _).hom ≫ (e.map f ▷ e.obj Y) ≫ (tensorObjIso _ _).inv
+      := by aesop_cat)
     (tensorHom :
       ∀ {X₁ Y₁ X₂ Y₂ : D} (f : X₁ ⟶ Y₁) (g: X₂ ⟶ Y₂), tensorObj X₁ X₂ ⟶ tensorObj Y₁ Y₂)
     (tensorHom_eq :
       ∀ {X₁ Y₁ X₂ Y₂ : D} (f : X₁ ⟶ Y₁) (g: X₂ ⟶ Y₂),
         e.map (tensorHom f g)
-          = (tensorObjIso _ _).hom ≫ (e.map f ⊗ e.map g) ≫ (tensorObjIso _ _).inv)
+          = (tensorObjIso _ _).hom ≫ (e.map f ⊗ e.map g) ≫ (tensorObjIso _ _).inv
+      := by aesop_cat)
     (tensorUnit' : D)
     (tensorUnit'Iso : e.obj tensorUnit' ≅ 𝟙_ _)
     (associator : ∀ X Y Z : D, tensorObj (tensorObj X Y) Z ≅ tensorObj X (tensorObj Y Z))
     (associator_eq : ∀ X Y Z : D,
-      e.mapIso (associator X Y Z) =
-        (tensorObjIso _ _ ≪≫ _) ≪≫ α_ (e.obj X) (e.obj Y) (e.obj Z) ≪≫ _)
+      e.map (associator X Y Z).hom =
+        ((tensorObjIso _ _ ≪≫ (tensorObjIso _ _ ⊗ .refl _))
+          ≪≫ α_ (e.obj X) (e.obj Y) (e.obj Z)
+          ≪≫ ((.refl _ ⊗ (tensorObjIso _ _).symm) ≪≫ (tensorObjIso _ _).symm)).hom
+      := by aesop_cat)
     (leftUnitor : ∀ X : D, tensorObj tensorUnit' X ≅ X)
     (leftUnitor_eq : ∀ X : D,
-      e.mapIso (leftUnitor X) =
-        (tensorObjIso _ _ ≪≫ _) ≪≫ λ_ (e.obj X))
+      e.map (leftUnitor X).hom =
+        ((tensorObjIso _ _ ≪≫ (tensorUnit'Iso ⊗ .refl _)) ≪≫ λ_ (e.obj X)).hom
+      := by aesop_cat)
     (rightUnitor : ∀ X : D, tensorObj X tensorUnit' ≅ X)
     (rightUnitor_eq : ∀ X : D,
-      e.mapIso (rightUnitor X) =
-        (tensorObjIso _ _ ≪≫ _) ≪≫ ρ_ (e.obj X)) :
+      e.map (rightUnitor X).hom =
+        ((tensorObjIso _ _ ≪≫ (.refl _ ⊗ tensorUnit'Iso)) ≪≫ ρ_ (e.obj X)).hom
+      := by aesop_cat) :
     MonoidalCategory.{v₂} D where
-  tensorObj := tensorObj
-  whiskerLeft := whiskerLeft
-  whiskerRight := whiskerRight
-  tensorHom := tensorHom
-  tensorUnit' := tensorUnit'
-  associator := associator
-  leftUnitor := leftUnitor
-  rightUnitor := rightUnitor
+      tensorObj := tensorObj
+      whiskerLeft := whiskerLeft
+      whiskerRight := whiskerRight
+      tensorHom := tensorHom
+      tensorUnit' := tensorUnit'
+      associator := associator
+      leftUnitor := leftUnitor
+      rightUnitor := rightUnitor
+      tensorHom_def {X₁ Y₁ X₂ Y₂} f g := e.map_injective <| by
+        dsimp
+        rw [tensorHom_eq, Functor.map_comp, whiskerRight_eq, whiskerLeft_eq]
+        sorry
+      tensor_id X₁ X₂ := e.map_injective <| by
+        dsimp
+        sorry
+      tensor_comp {X₁ Y₁ Z₁ X₂ Y₂ Z₂} f₁ f₂ g₁ g₂ := e.map_injective <| by
+        dsimp
+        sorry
+      whiskerLeft_id X Y := e.map_injective <| by simp [whiskerLeft_eq]
+      id_whiskerRight X Y := e.map_injective <| by simp [whiskerRight_eq]
+      associator_naturality {X₁ X₂ X₃ Y₁ Y₂ Y₃} f₁ f₂ f₃ := e.map_injective <| by
+        simp [associator_eq, tensorHom_eq]
+        aesop_cat
+      leftUnitor_naturality {X Y : D} f := e.map_injective <| by
+        simp [leftUnitor_eq, tensorHom_eq]
+        sorry
+      rightUnitor_naturality {X Y : D} f := e.map_injective <| by
+        simp [rightUnitor_eq, tensorHom_eq]
+        sorry
+      pentagon W X Y Z := e.map_injective <| by
+        have := MonoidalCategory.pentagon (e.obj W) (e.obj X) (e.obj Y) (e.obj Z)
+        simp [associator_eq, tensorHom_eq]
+        congr 2
+        simp only [←assoc]
+        congr 2
+        simp
+        aesop_cat
+      triangle X Y :=  e.map_injective <| by aesop_cat
 
+/-- Transport a monoidal structure along an equivalence of (plain) categories.
+-/
+@[simps!
+  tensorObj whiskerLeft whiskerRight tensorHom tensorUnit associator leftUnitor rightUnitor]
+def transport (e : C ≌ D) : MonoidalCategory.{v₂} D :=
+  induced
+    (e := e.inverse)
+    (tensorObj := fun X Y => e.functor.obj (e.inverse.obj X ⊗ e.inverse.obj Y))
+    (tensorObjIso := fun X Y => (e.unitIso.app _).symm)
+    (whiskerLeft := fun X _ _ f ↦ e.functor.map (e.inverse.obj X ◁ e.inverse.map f))
+    (whiskerRight := fun f X ↦ e.functor.map (e.inverse.map f ▷ e.inverse.obj X))
+    (tensorHom := fun f g => e.functor.map (e.inverse.map f ⊗ e.inverse.map g))
+    (tensorUnit' := e.functor.obj (𝟙_ C))
+    (tensorUnit'Iso := (e.unitIso.app _).symm)
+    (associator := fun X Y Z =>
+      e.functor.mapIso
+        (((e.unitIso.app _).symm ⊗ Iso.refl _) ≪≫
+          α_ (e.inverse.obj X) (e.inverse.obj Y) (e.inverse.obj Z) ≪≫ (Iso.refl _ ⊗ e.unitIso.app _)))
+    (leftUnitor := fun X =>
+      e.functor.mapIso (((e.unitIso.app _).symm ⊗ Iso.refl _) ≪≫ λ_ (e.inverse.obj X)) ≪≫
+        e.counitIso.app _)
+    (rightUnitor := fun X =>
+      e.functor.mapIso ((Iso.refl _ ⊗ (e.unitIso.app _).symm) ≪≫ ρ_ (e.inverse.obj X)) ≪≫
+        e.counitIso.app _)
 
-#exit
 -- porting note: it was @[simps {attrs := [`_refl_lemma]}]
 /-- Transport a monoidal structure along an equivalence of (plain) categories.
 -/
 @[simps]
-def transport (e : C ≌ D) : MonoidalCategory.{v₂} D where
+def transport' (e : C ≌ D) : MonoidalCategory.{v₂} D where
   tensorObj X Y := e.functor.obj (e.inverse.obj X ⊗ e.inverse.obj Y)
   whiskerLeft := fun X _ _ f ↦ e.functor.map (e.inverse.obj X ◁ e.inverse.map f)
   whiskerRight := fun f X ↦ e.functor.map (e.inverse.map f ▷ e.inverse.obj X)

--- a/Mathlib/CategoryTheory/Monoidal/Transport.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Transport.lean
@@ -202,8 +202,6 @@ def fromInduced (F : D ⥤ C) [Faithful F] (fData : InducingFunctorData F):
 
 /-- Transport a monoidal structure along an equivalence of (plain) categories.
 -/
-@[simps!
-  tensorObj whiskerLeft whiskerRight tensorHom tensorUnit' associator leftUnitor rightUnitor]
 def transport (e : C ≌ D) : MonoidalCategory.{v₂} D :=
   induced (F := e.inverse)
     { tensorObj := fun X Y => e.functor.obj (e.inverse.obj X ⊗ e.inverse.obj Y)

--- a/Mathlib/CategoryTheory/Monoidal/Transport.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Transport.lean
@@ -40,6 +40,53 @@ variable {C : Type u₁} [Category.{v₁} C] [MonoidalCategory.{v₁} C]
 
 variable {D : Type u₂} [Category.{v₂} D]
 
+/-- The data needed to induce a `MonoidalCategory` via the functor `F`; namely, pre-existing
+definitions of `⊗`, `𝟙_`, `▷`, `◁` that are preserved by `F`.
+
+Note that `μIsoSymm` and `εIsoSymm` correspond to the reversed versions of
+`CategoryTheory.LaxMonoidalFunctor.μIso` and `CategoryTheory.LaxMonoidalFunctor.εIso`.
+-/
+structure InducingFunctorData (F : D ⥤ C) where
+  tensorObj : D → D → D
+  μIsoSymm : ∀ X Y,
+    F.obj (tensorObj X Y) ≅ F.obj X ⊗ F.obj Y
+  whiskerLeft : ∀ (X : D) {Y₁ Y₂ : D} (_f : Y₁ ⟶ Y₂), tensorObj X Y₁ ⟶ tensorObj X Y₂
+  whiskerLeft_eq : ∀ (X : D) {Y₁ Y₂ : D} (f : Y₁ ⟶ Y₂),
+    F.map (whiskerLeft X f)
+      = (μIsoSymm _ _).hom ≫ (F.obj X ◁ F.map f) ≫ (μIsoSymm _ _).inv :=
+    by aesop_cat
+  whiskerRight : ∀ {X₁ X₂ : D} (_f : X₁ ⟶ X₂) (Y : D), tensorObj X₁ Y ⟶ tensorObj X₂ Y
+  whiskerRight_eq : ∀ {X₁ X₂ : D} (f : X₁ ⟶ X₂) (Y : D),
+    F.map (whiskerRight f Y)
+      = (μIsoSymm _ _).hom ≫ (F.map f ▷ F.obj Y) ≫ (μIsoSymm _ _).inv :=
+    by aesop_cat
+  tensorHom :
+    ∀ {X₁ Y₁ X₂ Y₂ : D} (_f : X₁ ⟶ Y₁) (_g : X₂ ⟶ Y₂), tensorObj X₁ X₂ ⟶ tensorObj Y₁ Y₂
+  tensorHom_eq :
+    ∀ {X₁ Y₁ X₂ Y₂ : D} (f : X₁ ⟶ Y₁) (g : X₂ ⟶ Y₂),
+      F.map (tensorHom f g)
+        = (μIsoSymm _ _).hom ≫ (F.map f ⊗ F.map g) ≫ (μIsoSymm _ _).inv :=
+    by aesop_cat
+  tensorUnit' : D
+  εIsoSymm : F.obj tensorUnit' ≅ 𝟙_ _
+  associator : ∀ X Y Z : D, tensorObj (tensorObj X Y) Z ≅ tensorObj X (tensorObj Y Z)
+  associator_eq : ∀ X Y Z : D,
+    F.map (associator X Y Z).hom =
+      ((μIsoSymm _ _ ≪≫ (μIsoSymm _ _ ⊗ .refl _))
+        ≪≫ α_ (F.obj X) (F.obj Y) (F.obj Z)
+        ≪≫ ((.refl _ ⊗ (μIsoSymm _ _).symm) ≪≫ (μIsoSymm _ _).symm)).hom :=
+    by aesop_cat
+  leftUnitor : ∀ X : D, tensorObj tensorUnit' X ≅ X
+  leftUnitor_eq : ∀ X : D,
+    F.map (leftUnitor X).hom =
+      ((μIsoSymm _ _ ≪≫ (εIsoSymm ⊗ .refl _)) ≪≫ λ_ (F.obj X)).hom :=
+    by aesop_cat
+  rightUnitor : ∀ X : D, tensorObj X tensorUnit' ≅ X
+  rightUnitor_eq : ∀ X : D,
+    F.map (rightUnitor X).hom =
+      ((μIsoSymm _ _ ≪≫ (.refl _ ⊗ εIsoSymm)) ≪≫ ρ_ (F.obj X)).hom :=
+    by aesop_cat
+
 /--
 Induce the lawfulness of the monoidal structure along an faithful functor of (plain) categories,
 where the operations are already defined on the destination type `D`.
@@ -47,75 +94,33 @@ where the operations are already defined on the destination type `D`.
 The functor `F` must preserve all the data parts of the monoidal structure between the two
 categories.
 
-Note that `μIsoSymm` and `εIsoSymm` correspond to the reversed versions of
-`CategoryTheory.LaxMonoidalFunctor.μIso` and `CategoryTheory.LaxMonoidalFunctor.εIso`.
 -/
-@[simps
-  tensorObj whiskerLeft whiskerRight tensorHom tensorUnit' associator leftUnitor rightUnitor]
-abbrev induced (F : D ⥤ C) [Faithful F]
-    (tensorObj : D → D → D)
-    (μIsoSymm : ∀ X Y,
-      F.obj (tensorObj X Y) ≅ F.obj X ⊗ F.obj Y)
-    (whiskerLeft : ∀ (X : D) {Y₁ Y₂ : D} (_f : Y₁ ⟶ Y₂), tensorObj X Y₁ ⟶ tensorObj X Y₂)
-    (whiskerLeft_eq : ∀ (X : D) {Y₁ Y₂ : D} (f : Y₁ ⟶ Y₂),
-      F.map (whiskerLeft X f)
-        = (μIsoSymm _ _).hom ≫ (F.obj X ◁ F.map f) ≫ (μIsoSymm _ _).inv :=
-      by aesop_cat)
-    (whiskerRight : ∀ {X₁ X₂ : D} (_f : X₁ ⟶ X₂) (Y : D), tensorObj X₁ Y ⟶ tensorObj X₂ Y)
-    (whiskerRight_eq : ∀ {X₁ X₂ : D} (f : X₁ ⟶ X₂) (Y : D),
-      F.map (whiskerRight f Y)
-        = (μIsoSymm _ _).hom ≫ (F.map f ▷ F.obj Y) ≫ (μIsoSymm _ _).inv :=
-      by aesop_cat)
-    (tensorHom :
-      ∀ {X₁ Y₁ X₂ Y₂ : D} (_f : X₁ ⟶ Y₁) (_g : X₂ ⟶ Y₂), tensorObj X₁ X₂ ⟶ tensorObj Y₁ Y₂)
-    (tensorHom_eq :
-      ∀ {X₁ Y₁ X₂ Y₂ : D} (f : X₁ ⟶ Y₁) (g : X₂ ⟶ Y₂),
-        F.map (tensorHom f g)
-          = (μIsoSymm _ _).hom ≫ (F.map f ⊗ F.map g) ≫ (μIsoSymm _ _).inv :=
-      by aesop_cat)
-    (tensorUnit' : D)
-    (εIsoSymm : F.obj tensorUnit' ≅ 𝟙_ _)
-    (associator : ∀ X Y Z : D, tensorObj (tensorObj X Y) Z ≅ tensorObj X (tensorObj Y Z))
-    (associator_eq : ∀ X Y Z : D,
-      F.map (associator X Y Z).hom =
-        ((μIsoSymm _ _ ≪≫ (μIsoSymm _ _ ⊗ .refl _))
-          ≪≫ α_ (F.obj X) (F.obj Y) (F.obj Z)
-          ≪≫ ((.refl _ ⊗ (μIsoSymm _ _).symm) ≪≫ (μIsoSymm _ _).symm)).hom :=
-      by aesop_cat)
-    (leftUnitor : ∀ X : D, tensorObj tensorUnit' X ≅ X)
-    (leftUnitor_eq : ∀ X : D,
-      F.map (leftUnitor X).hom =
-        ((μIsoSymm _ _ ≪≫ (εIsoSymm ⊗ .refl _)) ≪≫ λ_ (F.obj X)).hom :=
-      by aesop_cat)
-    (rightUnitor : ∀ X : D, tensorObj X tensorUnit' ≅ X)
-    (rightUnitor_eq : ∀ X : D,
-      F.map (rightUnitor X).hom =
-        ((μIsoSymm _ _ ≪≫ (.refl _ ⊗ εIsoSymm)) ≪≫ ρ_ (F.obj X)).hom :=
-      by aesop_cat) :
+@[simps]
+abbrev induced (F : D ⥤ C) [Faithful F] (fData : InducingFunctorData F):
     MonoidalCategory.{v₂} D where
   -- the data fields are exactly as provided
-  tensorObj := tensorObj
-  whiskerLeft := whiskerLeft
-  whiskerRight := whiskerRight
-  tensorHom := tensorHom
-  tensorUnit' := tensorUnit'
-  associator := associator
-  leftUnitor := leftUnitor
-  rightUnitor := rightUnitor
+  tensorObj := fData.tensorObj
+  whiskerLeft := fData.whiskerLeft
+  whiskerRight := fData.whiskerRight
+  tensorHom := fData.tensorHom
+  tensorUnit' := fData.tensorUnit'
+  associator := fData.associator
+  leftUnitor := fData.leftUnitor
+  rightUnitor := fData.rightUnitor
   tensorHom_def {X₁ Y₁ X₂ Y₂} f g := F.map_injective <| by
     dsimp
-    rw [tensorHom_eq, Functor.map_comp, whiskerRight_eq, whiskerLeft_eq]
+    rw [fData.tensorHom_eq, Functor.map_comp, fData.whiskerRight_eq, fData.whiskerLeft_eq]
     simp only [tensorHom_def, assoc, Iso.inv_hom_id_assoc]
-  tensor_id X₁ X₂ := F.map_injective <| by aesop_cat
-  tensor_comp {X₁ Y₁ Z₁ X₂ Y₂ Z₂} f₁ f₂ g₁ g₂ := F.map_injective <| by aesop_cat
-  whiskerLeft_id X Y := F.map_injective <| by simp [whiskerLeft_eq]
-  id_whiskerRight X Y := F.map_injective <| by simp [whiskerRight_eq]
-  triangle X Y := F.map_injective <| by aesop_cat
+  tensor_id X₁ X₂ := F.map_injective <| by cases fData; aesop_cat
+  tensor_comp {X₁ Y₁ Z₁ X₂ Y₂ Z₂} f₁ f₂ g₁ g₂ := F.map_injective <| by cases fData; aesop_cat
+  whiskerLeft_id X Y := F.map_injective <| by simp [fData.whiskerLeft_eq]
+  id_whiskerRight X Y := F.map_injective <| by simp [fData.whiskerRight_eq]
+  triangle X Y := F.map_injective <| by cases fData; aesop_cat
   pentagon W X Y Z := F.map_injective <| by
     have := MonoidalCategory.pentagon (F.obj W) (F.obj X) (F.obj Y) (F.obj Z)
     dsimp
-    simp only [Functor.map_comp, tensorHom_eq, associator_eq, Iso.trans_assoc, Iso.trans_hom,
-      tensorIso_hom, Iso.refl_hom, Iso.symm_hom, Functor.map_id, comp_tensor_id,
+    simp only [Functor.map_comp, fData.tensorHom_eq, fData.associator_eq, Iso.trans_assoc,
+      Iso.trans_hom, tensorIso_hom, Iso.refl_hom, Iso.symm_hom, Functor.map_id, comp_tensor_id,
       associator_conjugation, tensor_id, assoc, id_tensor_comp, Iso.inv_hom_id_assoc,
       tensor_inv_hom_id_assoc, id_comp, inv_hom_id_tensor_assoc, id_tensor_comp_tensor_id_assoc,
       Iso.cancel_iso_hom_left]
@@ -136,21 +141,21 @@ abbrev induced (F : D ⥤ C) [Faithful F]
   leftUnitor_naturality {X Y : D} f := F.map_injective <| by
     have := leftUnitor_naturality (F.map f)
     dsimp
-    simp only [Functor.map_comp, tensorHom_eq, Functor.map_id, leftUnitor_eq, Iso.trans_assoc,
-      Iso.trans_hom, tensorIso_hom, Iso.refl_hom, assoc, Iso.inv_hom_id_assoc,
+    simp only [Functor.map_comp, fData.tensorHom_eq, Functor.map_id, fData.leftUnitor_eq,
+      Iso.trans_assoc, Iso.trans_hom, tensorIso_hom, Iso.refl_hom, assoc, Iso.inv_hom_id_assoc,
       id_tensor_comp_tensor_id_assoc, Iso.cancel_iso_hom_left]
     rw [←this, ←assoc, ←tensor_comp, id_comp, comp_id]
   rightUnitor_naturality {X Y : D} f := F.map_injective <| by
     have := rightUnitor_naturality (F.map f)
     dsimp
-    simp only [Functor.map_comp, tensorHom_eq, Functor.map_id, rightUnitor_eq, Iso.trans_assoc,
-      Iso.trans_hom, tensorIso_hom, Iso.refl_hom, assoc, Iso.inv_hom_id_assoc,
+    simp only [Functor.map_comp, fData.tensorHom_eq, Functor.map_id, fData.rightUnitor_eq,
+      Iso.trans_assoc, Iso.trans_hom, tensorIso_hom, Iso.refl_hom, assoc, Iso.inv_hom_id_assoc,
       tensor_id_comp_id_tensor_assoc, Iso.cancel_iso_hom_left]
     rw [←this, ←assoc, ←tensor_comp, id_comp, comp_id]
   associator_naturality {X₁ X₂ X₃ Y₁ Y₂ Y₃} f₁ f₂ f₃ := F.map_injective <| by
     have := associator_naturality (F.map f₁) (F.map f₂) (F.map f₃)
     dsimp
-    simp [associator_eq, tensorHom_eq]
+    simp [fData.associator_eq, fData.tensorHom_eq]
     simp_rw [←assoc, ←tensor_comp, assoc, Iso.inv_hom_id, ←assoc]
     congr 1
     conv_rhs => rw [←comp_id (F.map f₁), ←id_comp (F.map f₁)]
@@ -166,67 +171,42 @@ abbrev induced (F : D ⥤ C) [Faithful F]
 We can upgrade `F` to a monoidal functor from `D` to `E` with the induced structure.
 -/
 @[simps]
-def fromInduced (F : D ⥤ C) [Faithful F]
-    (tensorObj μIsoSymm)
-    (whiskerLeft whiskerLeft_eq)
-    (whiskerRight whiskerRight_eq)
-    (tensorHom tensorHom_eq)
-    (tensorUnit' εIsoSymm)
-    (associator associator_eq)
-    (leftUnitor leftUnitor_eq)
-    (rightUnitor rightUnitor_eq) :
-    letI := induced F
-      tensorObj μIsoSymm
-      whiskerLeft whiskerLeft_eq
-      whiskerRight whiskerRight_eq
-      tensorHom tensorHom_eq
-      tensorUnit' εIsoSymm
-      associator associator_eq
-      leftUnitor leftUnitor_eq
-      rightUnitor rightUnitor_eq
+def fromInduced (F : D ⥤ C) [Faithful F] (fData : InducingFunctorData F):
+    letI := induced F fData
     MonoidalFunctor D C :=
-  letI := induced F
-      tensorObj μIsoSymm
-      whiskerLeft whiskerLeft_eq
-      whiskerRight whiskerRight_eq
-      tensorHom tensorHom_eq
-      tensorUnit' εIsoSymm
-      associator associator_eq
-      leftUnitor leftUnitor_eq
-      rightUnitor rightUnitor_eq
+  letI := induced F fData
   { toFunctor := F
-    ε := εIsoSymm.inv
-    μ := fun X Y => (μIsoSymm X Y).inv
-    μ_natural := by aesop_cat
-    associativity := by aesop_cat
-    left_unitality := by aesop_cat
-    right_unitality := by aesop_cat }
+    ε := fData.εIsoSymm.inv
+    μ := fun X Y => (fData.μIsoSymm X Y).inv
+    μ_natural := by cases fData; aesop_cat
+    associativity := by cases fData; aesop_cat
+    left_unitality := by cases fData; aesop_cat
+    right_unitality := by cases fData; aesop_cat }
 
 /-- Transport a monoidal structure along an equivalence of (plain) categories.
 -/
-@[simps
+@[simps!
   tensorObj whiskerLeft whiskerRight tensorHom tensorUnit' associator leftUnitor rightUnitor]
 def transport (e : C ≌ D) : MonoidalCategory.{v₂} D :=
-  induced
-    (F := e.inverse)
-    (tensorObj := fun X Y => e.functor.obj (e.inverse.obj X ⊗ e.inverse.obj Y))
-    (μIsoSymm := fun X Y => (e.unitIso.app _).symm)
-    (whiskerLeft := fun X _ _ f ↦ e.functor.map (e.inverse.obj X ◁ e.inverse.map f))
-    (whiskerRight := fun f X ↦ e.functor.map (e.inverse.map f ▷ e.inverse.obj X))
-    (tensorHom := fun f g => e.functor.map (e.inverse.map f ⊗ e.inverse.map g))
-    (tensorUnit' := e.functor.obj (𝟙_ C))
-    (εIsoSymm := (e.unitIso.app _).symm)
-    (associator := fun X Y Z =>
-      e.functor.mapIso
-        (((e.unitIso.app _).symm ⊗ Iso.refl _) ≪≫
-          α_ (e.inverse.obj X) (e.inverse.obj Y) (e.inverse.obj Z) ≪≫
-          (Iso.refl _ ⊗ e.unitIso.app _)))
-    (leftUnitor := fun X =>
-      e.functor.mapIso (((e.unitIso.app _).symm ⊗ Iso.refl _) ≪≫ λ_ (e.inverse.obj X)) ≪≫
-        e.counitIso.app _)
-    (rightUnitor := fun X =>
-      e.functor.mapIso ((Iso.refl _ ⊗ (e.unitIso.app _).symm) ≪≫ ρ_ (e.inverse.obj X)) ≪≫
-        e.counitIso.app _)
+  induced (F := e.inverse)
+    { tensorObj := fun X Y => e.functor.obj (e.inverse.obj X ⊗ e.inverse.obj Y)
+      μIsoSymm := fun X Y => (e.unitIso.app _).symm
+      whiskerLeft := fun X _ _ f ↦ e.functor.map (e.inverse.obj X ◁ e.inverse.map f)
+      whiskerRight := fun f X ↦ e.functor.map (e.inverse.map f ▷ e.inverse.obj X)
+      tensorHom := fun f g => e.functor.map (e.inverse.map f ⊗ e.inverse.map g)
+      tensorUnit' := e.functor.obj (𝟙_ C)
+      εIsoSymm := (e.unitIso.app _).symm
+      associator := fun X Y Z =>
+        e.functor.mapIso
+          (((e.unitIso.app _).symm ⊗ Iso.refl _) ≪≫
+            α_ (e.inverse.obj X) (e.inverse.obj Y) (e.inverse.obj Z) ≪≫
+            (Iso.refl _ ⊗ e.unitIso.app _))
+      leftUnitor := fun X =>
+        e.functor.mapIso (((e.unitIso.app _).symm ⊗ Iso.refl _) ≪≫ λ_ (e.inverse.obj X)) ≪≫
+          e.counitIso.app _
+      rightUnitor := fun X =>
+        e.functor.mapIso ((Iso.refl _ ⊗ (e.unitIso.app _).symm) ≪≫ ρ_ (e.inverse.obj X)) ≪≫
+          e.counitIso.app _ }
 #align category_theory.monoidal.transport CategoryTheory.Monoidal.transport
 
 /-- A type synonym for `D`, which will carry the transported monoidal structure. -/
@@ -245,9 +225,7 @@ instance (e : C ≌ D) : Inhabited (Transported e) :=
 /-- We can upgrade `e.inverse` to a monoidal functor from `D` with the transported structure to `C`.
 -/
 @[simps!]
-def fromTransported (e : C ≌ D) : MonoidalFunctor (Transported e) C := by
-  dsimp only [transport, Transported.instMonoidalCategory]
-  exact fromInduced e.inverse _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+def fromTransported (e : C ≌ D) : MonoidalFunctor (Transported e) C := fromInduced e.inverse _
 #align category_theory.monoidal.from_transported CategoryTheory.Monoidal.fromTransported
 
 instance instIsEquivalence_fromTransported (e : C ≌ D) :

--- a/Mathlib/CategoryTheory/Monoidal/Transport.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Transport.lean
@@ -35,50 +35,50 @@ variable {C : Type u₁} [Category.{v₁} C] [MonoidalCategory.{v₁} C]
 
 variable {D : Type u₂} [Category.{v₂} D]
 
-/-- Induce a monoidal structure along an faithful functor of (plain) categories,
--/
-@[simps]
-abbrev induced (e : D ⥤ C) [Faithful e]
+/-- Induce the lawfulness of the monoidal structure along an faithful functor of (plain) categories,
+where the operations are already defined on the destination type `D`. -/
+abbrev induced (F : D ⥤ C) [Faithful F]
     (tensorObj : D → D → D)
     (μIsoSymm : ∀ X Y,
-      e.obj (tensorObj X Y) ≅ e.obj X ⊗ e.obj Y)
+      F.obj (tensorObj X Y) ≅ F.obj X ⊗ F.obj Y)
     (whiskerLeft : ∀ (X : D) {Y₁ Y₂ : D} (_f : Y₁ ⟶ Y₂), tensorObj X Y₁ ⟶ tensorObj X Y₂)
     (whiskerLeft_eq : ∀ (X : D) {Y₁ Y₂ : D} (f : Y₁ ⟶ Y₂),
-      e.map (whiskerLeft X f)
-        = (μIsoSymm _ _).hom ≫ (e.obj X ◁ e.map f) ≫ (μIsoSymm _ _).inv :=
+      F.map (whiskerLeft X f)
+        = (μIsoSymm _ _).hom ≫ (F.obj X ◁ F.map f) ≫ (μIsoSymm _ _).inv :=
       by aesop_cat)
     (whiskerRight : ∀ {X₁ X₂ : D} (_f : X₁ ⟶ X₂) (Y : D), tensorObj X₁ Y ⟶ tensorObj X₂ Y)
     (whiskerRight_eq : ∀ {X₁ X₂ : D} (f : X₁ ⟶ X₂) (Y : D),
-      e.map (whiskerRight f Y)
-        = (μIsoSymm _ _).hom ≫ (e.map f ▷ e.obj Y) ≫ (μIsoSymm _ _).inv :=
+      F.map (whiskerRight f Y)
+        = (μIsoSymm _ _).hom ≫ (F.map f ▷ F.obj Y) ≫ (μIsoSymm _ _).inv :=
       by aesop_cat)
     (tensorHom :
       ∀ {X₁ Y₁ X₂ Y₂ : D} (_f : X₁ ⟶ Y₁) (_g : X₂ ⟶ Y₂), tensorObj X₁ X₂ ⟶ tensorObj Y₁ Y₂)
     (tensorHom_eq :
       ∀ {X₁ Y₁ X₂ Y₂ : D} (f : X₁ ⟶ Y₁) (g : X₂ ⟶ Y₂),
-        e.map (tensorHom f g)
-          = (μIsoSymm _ _).hom ≫ (e.map f ⊗ e.map g) ≫ (μIsoSymm _ _).inv :=
+        F.map (tensorHom f g)
+          = (μIsoSymm _ _).hom ≫ (F.map f ⊗ F.map g) ≫ (μIsoSymm _ _).inv :=
       by aesop_cat)
     (tensorUnit' : D)
-    (εIsoSymm : e.obj tensorUnit' ≅ 𝟙_ _)
+    (εIsoSymm : F.obj tensorUnit' ≅ 𝟙_ _)
     (associator : ∀ X Y Z : D, tensorObj (tensorObj X Y) Z ≅ tensorObj X (tensorObj Y Z))
     (associator_eq : ∀ X Y Z : D,
-      e.map (associator X Y Z).hom =
+      F.map (associator X Y Z).hom =
         ((μIsoSymm _ _ ≪≫ (μIsoSymm _ _ ⊗ .refl _))
-          ≪≫ α_ (e.obj X) (e.obj Y) (e.obj Z)
+          ≪≫ α_ (F.obj X) (F.obj Y) (F.obj Z)
           ≪≫ ((.refl _ ⊗ (μIsoSymm _ _).symm) ≪≫ (μIsoSymm _ _).symm)).hom :=
       by aesop_cat)
     (leftUnitor : ∀ X : D, tensorObj tensorUnit' X ≅ X)
     (leftUnitor_eq : ∀ X : D,
-      e.map (leftUnitor X).hom =
-        ((μIsoSymm _ _ ≪≫ (εIsoSymm ⊗ .refl _)) ≪≫ λ_ (e.obj X)).hom :=
+      F.map (leftUnitor X).hom =
+        ((μIsoSymm _ _ ≪≫ (εIsoSymm ⊗ .refl _)) ≪≫ λ_ (F.obj X)).hom :=
       by aesop_cat)
     (rightUnitor : ∀ X : D, tensorObj X tensorUnit' ≅ X)
     (rightUnitor_eq : ∀ X : D,
-      e.map (rightUnitor X).hom =
-        ((μIsoSymm _ _ ≪≫ (.refl _ ⊗ εIsoSymm)) ≪≫ ρ_ (e.obj X)).hom :=
+      F.map (rightUnitor X).hom =
+        ((μIsoSymm _ _ ≪≫ (.refl _ ⊗ εIsoSymm)) ≪≫ ρ_ (F.obj X)).hom :=
       by aesop_cat) :
     MonoidalCategory.{v₂} D where
+      -- the data fields are exactly as provided
       tensorObj := tensorObj
       whiskerLeft := whiskerLeft
       whiskerRight := whiskerRight
@@ -87,43 +87,43 @@ abbrev induced (e : D ⥤ C) [Faithful e]
       associator := associator
       leftUnitor := leftUnitor
       rightUnitor := rightUnitor
-      tensorHom_def {X₁ Y₁ X₂ Y₂} f g := e.map_injective <| by
+      tensorHom_def {X₁ Y₁ X₂ Y₂} f g := F.map_injective <| by
         dsimp
         rw [tensorHom_eq, Functor.map_comp, whiskerRight_eq, whiskerLeft_eq]
         simp only [tensorHom_def, assoc, Iso.inv_hom_id_assoc]
-      tensor_id X₁ X₂ := e.map_injective <| by aesop_cat
-      tensor_comp {X₁ Y₁ Z₁ X₂ Y₂ Z₂} f₁ f₂ g₁ g₂ := e.map_injective <| by aesop_cat
-      whiskerLeft_id X Y := e.map_injective <| by simp [whiskerLeft_eq]
-      id_whiskerRight X Y := e.map_injective <| by simp [whiskerRight_eq]
-      associator_naturality {X₁ X₂ X₃ Y₁ Y₂ Y₃} f₁ f₂ f₃ := e.map_injective <| by
-        have := associator_naturality (e.map f₁) (e.map f₂) (e.map f₃)
+      tensor_id X₁ X₂ := F.map_injective <| by aesop_cat
+      tensor_comp {X₁ Y₁ Z₁ X₂ Y₂ Z₂} f₁ f₂ g₁ g₂ := F.map_injective <| by aesop_cat
+      whiskerLeft_id X Y := F.map_injective <| by simp [whiskerLeft_eq]
+      id_whiskerRight X Y := F.map_injective <| by simp [whiskerRight_eq]
+      associator_naturality {X₁ X₂ X₃ Y₁ Y₂ Y₃} f₁ f₂ f₃ := F.map_injective <| by
+        have := associator_naturality (F.map f₁) (F.map f₂) (F.map f₃)
         dsimp
         simp [associator_eq, tensorHom_eq]
         simp_rw [←assoc, ←tensor_comp, assoc, Iso.inv_hom_id, ←assoc]
         congr 1
-        conv_rhs => rw [←comp_id (e.map f₁), ←id_comp (e.map f₁)]
+        conv_rhs => rw [←comp_id (F.map f₁), ←id_comp (F.map f₁)]
         simp only [tensor_comp]
         simp only [tensor_id, comp_id, assoc, tensor_inv_hom_id_assoc, id_comp]
         slice_rhs 2 3 => rw [←this]
         simp only [← assoc, Iso.inv_hom_id, comp_id]
         congr 2
         simp_rw [←tensor_comp, id_comp]
-      leftUnitor_naturality {X Y : D} f := e.map_injective <| by
-        have := leftUnitor_naturality (e.map f)
+      leftUnitor_naturality {X Y : D} f := F.map_injective <| by
+        have := leftUnitor_naturality (F.map f)
         dsimp
         simp only [Functor.map_comp, tensorHom_eq, Functor.map_id, leftUnitor_eq, Iso.trans_assoc,
           Iso.trans_hom, tensorIso_hom, Iso.refl_hom, assoc, Iso.inv_hom_id_assoc,
           id_tensor_comp_tensor_id_assoc, Iso.cancel_iso_hom_left]
         rw [←this, ←assoc, ←tensor_comp, id_comp, comp_id]
-      rightUnitor_naturality {X Y : D} f := e.map_injective <| by
-        have := rightUnitor_naturality (e.map f)
+      rightUnitor_naturality {X Y : D} f := F.map_injective <| by
+        have := rightUnitor_naturality (F.map f)
         dsimp
         simp only [Functor.map_comp, tensorHom_eq, Functor.map_id, rightUnitor_eq, Iso.trans_assoc,
           Iso.trans_hom, tensorIso_hom, Iso.refl_hom, assoc, Iso.inv_hom_id_assoc,
           tensor_id_comp_id_tensor_assoc, Iso.cancel_iso_hom_left]
         rw [←this, ←assoc, ←tensor_comp, id_comp, comp_id]
-      pentagon W X Y Z := e.map_injective <| by
-        have := MonoidalCategory.pentagon (e.obj W) (e.obj X) (e.obj Y) (e.obj Z)
+      pentagon W X Y Z := F.map_injective <| by
+        have := MonoidalCategory.pentagon (F.obj W) (F.obj X) (F.obj Y) (F.obj Z)
         dsimp
         simp only [Functor.map_comp, tensorHom_eq, associator_eq, Iso.trans_assoc, Iso.trans_hom,
           tensorIso_hom, Iso.refl_hom, Iso.symm_hom, Functor.map_id, comp_tensor_id,
@@ -139,20 +139,20 @@ abbrev induced (e : D ⥤ C) [Faithful e]
         simp only [assoc]
         congr 1
         rw [Iso.inv_comp_eq]
-        conv_lhs => rw [←id_comp (𝟙 (e.obj W)), tensor_comp]
+        conv_lhs => rw [←id_comp (𝟙 (F.obj W)), tensor_comp]
         slice_lhs 0 2 => rw [this]
         rw [assoc]
         congr 1
         rw [←associator_naturality, tensor_id]
-      triangle X Y := e.map_injective <| by aesop_cat
+      triangle X Y := F.map_injective <| by aesop_cat
 
 /-- Transport a monoidal structure along an equivalence of (plain) categories.
 -/
 @[simps!
   tensorObj whiskerLeft whiskerRight tensorHom tensorUnit' associator leftUnitor rightUnitor]
-def transport (e : C ≌ D) : MonoidalCategory.{v₂} D :=
+abbrev transport (e : C ≌ D) : MonoidalCategory.{v₂} D :=
   induced
-    (e := e.inverse)
+    (F := e.inverse)
     (tensorObj := fun X Y => e.functor.obj (e.inverse.obj X ⊗ e.inverse.obj Y))
     (μIsoSymm := fun X Y => (e.unitIso.app _).symm)
     (whiskerLeft := fun X _ _ f ↦ e.functor.map (e.inverse.obj X ◁ e.inverse.map f))

--- a/Mathlib/CategoryTheory/Monoidal/Transport.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Transport.lean
@@ -204,6 +204,8 @@ def fromInduced (F : D ⥤ C) [Faithful F]
 
 /-- Transport a monoidal structure along an equivalence of (plain) categories.
 -/
+@[simps
+  tensorObj whiskerLeft whiskerRight tensorHom tensorUnit' associator leftUnitor rightUnitor]
 abbrev transport (e : C ≌ D) : MonoidalCategory.{v₂} D :=
   induced
     (F := e.inverse)

--- a/Mathlib/CategoryTheory/Monoidal/Transport.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Transport.lean
@@ -78,73 +78,73 @@ abbrev induced (F : D ⥤ C) [Faithful F]
         ((μIsoSymm _ _ ≪≫ (.refl _ ⊗ εIsoSymm)) ≪≫ ρ_ (F.obj X)).hom :=
       by aesop_cat) :
     MonoidalCategory.{v₂} D where
-      -- the data fields are exactly as provided
-      tensorObj := tensorObj
-      whiskerLeft := whiskerLeft
-      whiskerRight := whiskerRight
-      tensorHom := tensorHom
-      tensorUnit' := tensorUnit'
-      associator := associator
-      leftUnitor := leftUnitor
-      rightUnitor := rightUnitor
-      tensorHom_def {X₁ Y₁ X₂ Y₂} f g := F.map_injective <| by
-        dsimp
-        rw [tensorHom_eq, Functor.map_comp, whiskerRight_eq, whiskerLeft_eq]
-        simp only [tensorHom_def, assoc, Iso.inv_hom_id_assoc]
-      tensor_id X₁ X₂ := F.map_injective <| by aesop_cat
-      tensor_comp {X₁ Y₁ Z₁ X₂ Y₂ Z₂} f₁ f₂ g₁ g₂ := F.map_injective <| by aesop_cat
-      whiskerLeft_id X Y := F.map_injective <| by simp [whiskerLeft_eq]
-      id_whiskerRight X Y := F.map_injective <| by simp [whiskerRight_eq]
-      associator_naturality {X₁ X₂ X₃ Y₁ Y₂ Y₃} f₁ f₂ f₃ := F.map_injective <| by
-        have := associator_naturality (F.map f₁) (F.map f₂) (F.map f₃)
-        dsimp
-        simp [associator_eq, tensorHom_eq]
-        simp_rw [←assoc, ←tensor_comp, assoc, Iso.inv_hom_id, ←assoc]
-        congr 1
-        conv_rhs => rw [←comp_id (F.map f₁), ←id_comp (F.map f₁)]
-        simp only [tensor_comp]
-        simp only [tensor_id, comp_id, assoc, tensor_inv_hom_id_assoc, id_comp]
-        slice_rhs 2 3 => rw [←this]
-        simp only [← assoc, Iso.inv_hom_id, comp_id]
-        congr 2
-        simp_rw [←tensor_comp, id_comp]
-      leftUnitor_naturality {X Y : D} f := F.map_injective <| by
-        have := leftUnitor_naturality (F.map f)
-        dsimp
-        simp only [Functor.map_comp, tensorHom_eq, Functor.map_id, leftUnitor_eq, Iso.trans_assoc,
-          Iso.trans_hom, tensorIso_hom, Iso.refl_hom, assoc, Iso.inv_hom_id_assoc,
-          id_tensor_comp_tensor_id_assoc, Iso.cancel_iso_hom_left]
-        rw [←this, ←assoc, ←tensor_comp, id_comp, comp_id]
-      rightUnitor_naturality {X Y : D} f := F.map_injective <| by
-        have := rightUnitor_naturality (F.map f)
-        dsimp
-        simp only [Functor.map_comp, tensorHom_eq, Functor.map_id, rightUnitor_eq, Iso.trans_assoc,
-          Iso.trans_hom, tensorIso_hom, Iso.refl_hom, assoc, Iso.inv_hom_id_assoc,
-          tensor_id_comp_id_tensor_assoc, Iso.cancel_iso_hom_left]
-        rw [←this, ←assoc, ←tensor_comp, id_comp, comp_id]
-      pentagon W X Y Z := F.map_injective <| by
-        have := MonoidalCategory.pentagon (F.obj W) (F.obj X) (F.obj Y) (F.obj Z)
-        dsimp
-        simp only [Functor.map_comp, tensorHom_eq, associator_eq, Iso.trans_assoc, Iso.trans_hom,
-          tensorIso_hom, Iso.refl_hom, Iso.symm_hom, Functor.map_id, comp_tensor_id,
-          associator_conjugation, tensor_id, assoc, id_tensor_comp, Iso.inv_hom_id_assoc,
-          tensor_inv_hom_id_assoc, id_comp, inv_hom_id_tensor_assoc, id_tensor_comp_tensor_id_assoc,
-          Iso.cancel_iso_hom_left]
-        congr 1
-        simp only [←assoc]
-        congr 2
-        simp only [assoc, ←tensor_comp, id_comp, Iso.inv_hom_id, tensor_id]
-        congr 1
-        conv_rhs => rw [←tensor_id_comp_id_tensor]
-        simp only [assoc]
-        congr 1
-        rw [Iso.inv_comp_eq]
-        conv_lhs => rw [←id_comp (𝟙 (F.obj W)), tensor_comp]
-        slice_lhs 0 2 => rw [this]
-        rw [assoc]
-        congr 1
-        rw [←associator_naturality, tensor_id]
-      triangle X Y := F.map_injective <| by aesop_cat
+  -- the data fields are exactly as provided
+  tensorObj := tensorObj
+  whiskerLeft := whiskerLeft
+  whiskerRight := whiskerRight
+  tensorHom := tensorHom
+  tensorUnit' := tensorUnit'
+  associator := associator
+  leftUnitor := leftUnitor
+  rightUnitor := rightUnitor
+  tensorHom_def {X₁ Y₁ X₂ Y₂} f g := F.map_injective <| by
+    dsimp
+    rw [tensorHom_eq, Functor.map_comp, whiskerRight_eq, whiskerLeft_eq]
+    simp only [tensorHom_def, assoc, Iso.inv_hom_id_assoc]
+  tensor_id X₁ X₂ := F.map_injective <| by aesop_cat
+  tensor_comp {X₁ Y₁ Z₁ X₂ Y₂ Z₂} f₁ f₂ g₁ g₂ := F.map_injective <| by aesop_cat
+  whiskerLeft_id X Y := F.map_injective <| by simp [whiskerLeft_eq]
+  id_whiskerRight X Y := F.map_injective <| by simp [whiskerRight_eq]
+  associator_naturality {X₁ X₂ X₃ Y₁ Y₂ Y₃} f₁ f₂ f₃ := F.map_injective <| by
+    have := associator_naturality (F.map f₁) (F.map f₂) (F.map f₃)
+    dsimp
+    simp [associator_eq, tensorHom_eq]
+    simp_rw [←assoc, ←tensor_comp, assoc, Iso.inv_hom_id, ←assoc]
+    congr 1
+    conv_rhs => rw [←comp_id (F.map f₁), ←id_comp (F.map f₁)]
+    simp only [tensor_comp]
+    simp only [tensor_id, comp_id, assoc, tensor_inv_hom_id_assoc, id_comp]
+    slice_rhs 2 3 => rw [←this]
+    simp only [← assoc, Iso.inv_hom_id, comp_id]
+    congr 2
+    simp_rw [←tensor_comp, id_comp]
+  leftUnitor_naturality {X Y : D} f := F.map_injective <| by
+    have := leftUnitor_naturality (F.map f)
+    dsimp
+    simp only [Functor.map_comp, tensorHom_eq, Functor.map_id, leftUnitor_eq, Iso.trans_assoc,
+      Iso.trans_hom, tensorIso_hom, Iso.refl_hom, assoc, Iso.inv_hom_id_assoc,
+      id_tensor_comp_tensor_id_assoc, Iso.cancel_iso_hom_left]
+    rw [←this, ←assoc, ←tensor_comp, id_comp, comp_id]
+  rightUnitor_naturality {X Y : D} f := F.map_injective <| by
+    have := rightUnitor_naturality (F.map f)
+    dsimp
+    simp only [Functor.map_comp, tensorHom_eq, Functor.map_id, rightUnitor_eq, Iso.trans_assoc,
+      Iso.trans_hom, tensorIso_hom, Iso.refl_hom, assoc, Iso.inv_hom_id_assoc,
+      tensor_id_comp_id_tensor_assoc, Iso.cancel_iso_hom_left]
+    rw [←this, ←assoc, ←tensor_comp, id_comp, comp_id]
+  pentagon W X Y Z := F.map_injective <| by
+    have := MonoidalCategory.pentagon (F.obj W) (F.obj X) (F.obj Y) (F.obj Z)
+    dsimp
+    simp only [Functor.map_comp, tensorHom_eq, associator_eq, Iso.trans_assoc, Iso.trans_hom,
+      tensorIso_hom, Iso.refl_hom, Iso.symm_hom, Functor.map_id, comp_tensor_id,
+      associator_conjugation, tensor_id, assoc, id_tensor_comp, Iso.inv_hom_id_assoc,
+      tensor_inv_hom_id_assoc, id_comp, inv_hom_id_tensor_assoc, id_tensor_comp_tensor_id_assoc,
+      Iso.cancel_iso_hom_left]
+    congr 1
+    simp only [←assoc]
+    congr 2
+    simp only [assoc, ←tensor_comp, id_comp, Iso.inv_hom_id, tensor_id]
+    congr 1
+    conv_rhs => rw [←tensor_id_comp_id_tensor]
+    simp only [assoc]
+    congr 1
+    rw [Iso.inv_comp_eq]
+    conv_lhs => rw [←id_comp (𝟙 (F.obj W)), tensor_comp]
+    slice_lhs 0 2 => rw [this]
+    rw [assoc]
+    congr 1
+    rw [←associator_naturality, tensor_id]
+  triangle X Y := F.map_injective <| by aesop_cat
 
 /-- Transport a monoidal structure along an equivalence of (plain) categories.
 -/

--- a/Mathlib/CategoryTheory/Monoidal/Transport.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Transport.lean
@@ -40,44 +40,44 @@ variable {D : Type u₂} [Category.{v₂} D]
 @[simps]
 def induced (e : D ⥤ C) [Faithful e]
     (tensorObj : D → D → D)
-    (tensorObjIso : ∀ X Y,
+    (μIsoSymm : ∀ X Y,
       e.obj (tensorObj X Y) ≅ e.obj X ⊗ e.obj Y)
     (whiskerLeft : ∀ (X : D) {Y₁ Y₂ : D} (f : Y₁ ⟶ Y₂), tensorObj X Y₁ ⟶ tensorObj X Y₂)
     (whiskerLeft_eq : ∀ (X : D) {Y₁ Y₂ : D} (f : Y₁ ⟶ Y₂),
       e.map (whiskerLeft X f)
-        = (tensorObjIso _ _).hom ≫ (e.obj X ◁ e.map f) ≫ (tensorObjIso _ _).inv
-      := by aesop_cat)
+        = (μIsoSymm _ _).hom ≫ (e.obj X ◁ e.map f) ≫ (μIsoSymm _ _).inv :=
+      by aesop_cat)
     (whiskerRight : ∀ {X₁ X₂ : D} (f : X₁ ⟶ X₂) (Y : D), tensorObj X₁ Y ⟶ tensorObj X₂ Y)
     (whiskerRight_eq : ∀ {X₁ X₂ : D} (f : X₁ ⟶ X₂) (Y : D),
       e.map (whiskerRight f Y)
-        = (tensorObjIso _ _).hom ≫ (e.map f ▷ e.obj Y) ≫ (tensorObjIso _ _).inv
-      := by aesop_cat)
+        = (μIsoSymm _ _).hom ≫ (e.map f ▷ e.obj Y) ≫ (μIsoSymm _ _).inv :=
+      by aesop_cat)
     (tensorHom :
       ∀ {X₁ Y₁ X₂ Y₂ : D} (f : X₁ ⟶ Y₁) (g: X₂ ⟶ Y₂), tensorObj X₁ X₂ ⟶ tensorObj Y₁ Y₂)
     (tensorHom_eq :
       ∀ {X₁ Y₁ X₂ Y₂ : D} (f : X₁ ⟶ Y₁) (g: X₂ ⟶ Y₂),
         e.map (tensorHom f g)
-          = (tensorObjIso _ _).hom ≫ (e.map f ⊗ e.map g) ≫ (tensorObjIso _ _).inv
-      := by aesop_cat)
+          = (μIsoSymm _ _).hom ≫ (e.map f ⊗ e.map g) ≫ (μIsoSymm _ _).inv :=
+      by aesop_cat)
     (tensorUnit' : D)
-    (tensorUnit'Iso : e.obj tensorUnit' ≅ 𝟙_ _)
+    (εIsoSymm : e.obj tensorUnit' ≅ 𝟙_ _)
     (associator : ∀ X Y Z : D, tensorObj (tensorObj X Y) Z ≅ tensorObj X (tensorObj Y Z))
     (associator_eq : ∀ X Y Z : D,
       e.map (associator X Y Z).hom =
-        ((tensorObjIso _ _ ≪≫ (tensorObjIso _ _ ⊗ .refl _))
+        ((μIsoSymm _ _ ≪≫ (μIsoSymm _ _ ⊗ .refl _))
           ≪≫ α_ (e.obj X) (e.obj Y) (e.obj Z)
-          ≪≫ ((.refl _ ⊗ (tensorObjIso _ _).symm) ≪≫ (tensorObjIso _ _).symm)).hom
-      := by aesop_cat)
+          ≪≫ ((.refl _ ⊗ (μIsoSymm _ _).symm) ≪≫ (μIsoSymm _ _).symm)).hom :=
+      by aesop_cat)
     (leftUnitor : ∀ X : D, tensorObj tensorUnit' X ≅ X)
     (leftUnitor_eq : ∀ X : D,
       e.map (leftUnitor X).hom =
-        ((tensorObjIso _ _ ≪≫ (tensorUnit'Iso ⊗ .refl _)) ≪≫ λ_ (e.obj X)).hom
-      := by aesop_cat)
+        ((μIsoSymm _ _ ≪≫ (εIsoSymm ⊗ .refl _)) ≪≫ λ_ (e.obj X)).hom :=
+      by aesop_cat)
     (rightUnitor : ∀ X : D, tensorObj X tensorUnit' ≅ X)
     (rightUnitor_eq : ∀ X : D,
       e.map (rightUnitor X).hom =
-        ((tensorObjIso _ _ ≪≫ (.refl _ ⊗ tensorUnit'Iso)) ≪≫ ρ_ (e.obj X)).hom
-      := by aesop_cat) :
+        ((μIsoSymm _ _ ≪≫ (.refl _ ⊗ εIsoSymm)) ≪≫ ρ_ (e.obj X)).hom :=
+      by aesop_cat) :
     MonoidalCategory.{v₂} D where
       tensorObj := tensorObj
       whiskerLeft := whiskerLeft
@@ -101,7 +101,7 @@ def induced (e : D ⥤ C) [Faithful e]
       id_whiskerRight X Y := e.map_injective <| by simp [whiskerRight_eq]
       associator_naturality {X₁ X₂ X₃ Y₁ Y₂ Y₃} f₁ f₂ f₃ := e.map_injective <| by
         simp [associator_eq, tensorHom_eq]
-        aesop_cat
+        sorry
       leftUnitor_naturality {X Y : D} f := e.map_injective <| by
         simp [leftUnitor_eq, tensorHom_eq]
         sorry
@@ -115,23 +115,23 @@ def induced (e : D ⥤ C) [Faithful e]
         simp only [←assoc]
         congr 2
         simp
-        aesop_cat
+        sorry
       triangle X Y :=  e.map_injective <| by aesop_cat
 
 /-- Transport a monoidal structure along an equivalence of (plain) categories.
 -/
 @[simps!
-  tensorObj whiskerLeft whiskerRight tensorHom tensorUnit associator leftUnitor rightUnitor]
+  tensorObj whiskerLeft whiskerRight tensorHom tensorUnit' associator leftUnitor rightUnitor]
 def transport (e : C ≌ D) : MonoidalCategory.{v₂} D :=
   induced
     (e := e.inverse)
     (tensorObj := fun X Y => e.functor.obj (e.inverse.obj X ⊗ e.inverse.obj Y))
-    (tensorObjIso := fun X Y => (e.unitIso.app _).symm)
+    (μIsoSymm := fun X Y => (e.unitIso.app _).symm)
     (whiskerLeft := fun X _ _ f ↦ e.functor.map (e.inverse.obj X ◁ e.inverse.map f))
     (whiskerRight := fun f X ↦ e.functor.map (e.inverse.map f ▷ e.inverse.obj X))
     (tensorHom := fun f g => e.functor.map (e.inverse.map f ⊗ e.inverse.map g))
     (tensorUnit' := e.functor.obj (𝟙_ C))
-    (tensorUnit'Iso := (e.unitIso.app _).symm)
+    (εIsoSymm := (e.unitIso.app _).symm)
     (associator := fun X Y Z =>
       e.functor.mapIso
         (((e.unitIso.app _).symm ⊗ Iso.refl _) ≪≫
@@ -146,6 +146,7 @@ def transport (e : C ≌ D) : MonoidalCategory.{v₂} D :=
 -- porting note: it was @[simps {attrs := [`_refl_lemma]}]
 /-- Transport a monoidal structure along an equivalence of (plain) categories.
 -/
+-- TODO: delete this once the `sorry`s above are filled
 @[simps]
 def transport' (e : C ≌ D) : MonoidalCategory.{v₂} D where
   tensorObj X Y := e.functor.obj (e.inverse.obj X ⊗ e.inverse.obj Y)

--- a/Mathlib/CategoryTheory/Monoidal/Transport.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Transport.lean
@@ -35,6 +35,51 @@ variable {C : Type u₁} [Category.{v₁} C] [MonoidalCategory.{v₁} C]
 
 variable {D : Type u₂} [Category.{v₂} D]
 
+@[simps]
+def induced (e : D ⥤ C) [Faithful e]
+    (tensorObj : D → D → D)
+    (tensorObjIso : ∀ X Y,
+      e.obj (tensorObj X Y) ≅ e.obj X ⊗ e.obj Y)
+    (whiskerLeft : ∀ (X : D) {Y₁ Y₂ : D} (f : Y₁ ⟶ Y₂), tensorObj X Y₁ ⟶ tensorObj X Y₂)
+    (whiskerLeft_eq : ∀ (X : D) {Y₁ Y₂ : D} (f : Y₁ ⟶ Y₂),
+      e.map (whiskerLeft X f)
+        = (tensorObjIso _ _).hom ≫ (e.obj X ◁ e.map f) ≫ (tensorObjIso _ _).inv)
+    (whiskerRight : ∀ {X₁ X₂ : D} (f : X₁ ⟶ X₂) (Y : D), tensorObj X₁ Y ⟶ tensorObj X₂ Y)
+    (whiskerRight_eq : ∀ {X₁ X₂ : D} (f : X₁ ⟶ X₂) (Y : D),
+      e.map (whiskerRight f Y)
+        = (tensorObjIso _ _).hom ≫ (e.map f ▷ e.obj Y) ≫ (tensorObjIso _ _).inv)
+    (tensorHom :
+      ∀ {X₁ Y₁ X₂ Y₂ : D} (f : X₁ ⟶ Y₁) (g: X₂ ⟶ Y₂), tensorObj X₁ X₂ ⟶ tensorObj Y₁ Y₂)
+    (tensorHom_eq :
+      ∀ {X₁ Y₁ X₂ Y₂ : D} (f : X₁ ⟶ Y₁) (g: X₂ ⟶ Y₂),
+        e.map (tensorHom f g)
+          = (tensorObjIso _ _).hom ≫ (e.map f ⊗ e.map g) ≫ (tensorObjIso _ _).inv)
+    (tensorUnit' : D)
+    (tensorUnit'Iso : e.obj tensorUnit' ≅ 𝟙_ _)
+    (associator : ∀ X Y Z : D, tensorObj (tensorObj X Y) Z ≅ tensorObj X (tensorObj Y Z))
+    (associator_eq : ∀ X Y Z : D,
+      e.mapIso (associator X Y Z) =
+        (tensorObjIso _ _ ≪≫ _) ≪≫ α_ (e.obj X) (e.obj Y) (e.obj Z) ≪≫ _)
+    (leftUnitor : ∀ X : D, tensorObj tensorUnit' X ≅ X)
+    (leftUnitor_eq : ∀ X : D,
+      e.mapIso (leftUnitor X) =
+        (tensorObjIso _ _ ≪≫ _) ≪≫ λ_ (e.obj X))
+    (rightUnitor : ∀ X : D, tensorObj X tensorUnit' ≅ X)
+    (rightUnitor_eq : ∀ X : D,
+      e.mapIso (rightUnitor X) =
+        (tensorObjIso _ _ ≪≫ _) ≪≫ ρ_ (e.obj X)) :
+    MonoidalCategory.{v₂} D where
+  tensorObj := tensorObj
+  whiskerLeft := whiskerLeft
+  whiskerRight := whiskerRight
+  tensorHom := tensorHom
+  tensorUnit' := tensorUnit'
+  associator := associator
+  leftUnitor := leftUnitor
+  rightUnitor := rightUnitor
+
+
+#exit
 -- porting note: it was @[simps {attrs := [`_refl_lemma]}]
 /-- Transport a monoidal structure along an equivalence of (plain) categories.
 -/

--- a/Mathlib/CategoryTheory/Monoidal/Transport.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Transport.lean
@@ -42,12 +42,10 @@ variable {D : Type u₂} [Category.{v₂} D]
 
 /-- The data needed to induce a `MonoidalCategory` via the functor `F`; namely, pre-existing
 definitions of `⊗`, `𝟙_`, `▷`, `◁` that are preserved by `F`.
-
-Note that `μIsoSymm` and `εIsoSymm` correspond to the reversed versions of
-`CategoryTheory.LaxMonoidalFunctor.μIso` and `CategoryTheory.LaxMonoidalFunctor.εIso`.
 -/
 structure InducingFunctorData (F : D ⥤ C) where
   tensorObj : D → D → D
+  /-- Analogous to the reversed version of `CategoryTheory.LaxMonoidalFunctor.μIso` -/
   μIsoSymm : ∀ X Y,
     F.obj (tensorObj X Y) ≅ F.obj X ⊗ F.obj Y
   whiskerLeft : ∀ (X : D) {Y₁ Y₂ : D} (_f : Y₁ ⟶ Y₂), tensorObj X Y₁ ⟶ tensorObj X Y₂
@@ -68,6 +66,7 @@ structure InducingFunctorData (F : D ⥤ C) where
         = (μIsoSymm _ _).hom ≫ (F.map f ⊗ F.map g) ≫ (μIsoSymm _ _).inv :=
     by aesop_cat
   tensorUnit' : D
+  /-- Analogous to the reversed version of `CategoryTheory.LaxMonoidalFunctor.εIso` -/
   εIsoSymm : F.obj tensorUnit' ≅ 𝟙_ _
   associator : ∀ X Y Z : D, tensorObj (tensorObj X Y) Z ≅ tensorObj X (tensorObj Y Z)
   associator_eq : ∀ X Y Z : D,
@@ -86,6 +85,24 @@ structure InducingFunctorData (F : D ⥤ C) where
     F.map (rightUnitor X).hom =
       ((μIsoSymm _ _ ≪≫ (.refl _ ⊗ εIsoSymm)) ≪≫ ρ_ (F.obj X)).hom :=
     by aesop_cat
+
+attribute [inherit_doc MonoidalCategory.tensorObj] InducingFunctorData.tensorObj
+attribute [inherit_doc MonoidalCategory.whiskerLeft] InducingFunctorData.whiskerLeft
+attribute [inherit_doc MonoidalCategory.whiskerRight] InducingFunctorData.whiskerRight
+attribute [inherit_doc MonoidalCategory.tensorHom] InducingFunctorData.tensorHom
+attribute [inherit_doc MonoidalCategory.tensorUnit'] InducingFunctorData.tensorUnit'
+attribute [inherit_doc MonoidalCategory.associator] InducingFunctorData.associator
+attribute [inherit_doc MonoidalCategory.leftUnitor] InducingFunctorData.leftUnitor
+attribute [inherit_doc MonoidalCategory.rightUnitor] InducingFunctorData.rightUnitor
+
+-- these are theorems so don't need docstrings (std4#217)
+attribute [nolint docBlame]
+  InducingFunctorData.whiskerLeft_eq
+  InducingFunctorData.whiskerRight_eq
+  InducingFunctorData.tensorHom_eq
+  InducingFunctorData.associator_eq
+  InducingFunctorData.leftUnitor_eq
+  InducingFunctorData.rightUnitor_eq
 
 /--
 Induce the lawfulness of the monoidal structure along an faithful functor of (plain) categories,

--- a/Mathlib/CategoryTheory/Monoidal/Transport.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Transport.lean
@@ -42,20 +42,20 @@ abbrev induced (e : D ⥤ C) [Faithful e]
     (tensorObj : D → D → D)
     (μIsoSymm : ∀ X Y,
       e.obj (tensorObj X Y) ≅ e.obj X ⊗ e.obj Y)
-    (whiskerLeft : ∀ (X : D) {Y₁ Y₂ : D} (f : Y₁ ⟶ Y₂), tensorObj X Y₁ ⟶ tensorObj X Y₂)
+    (whiskerLeft : ∀ (X : D) {Y₁ Y₂ : D} (_f : Y₁ ⟶ Y₂), tensorObj X Y₁ ⟶ tensorObj X Y₂)
     (whiskerLeft_eq : ∀ (X : D) {Y₁ Y₂ : D} (f : Y₁ ⟶ Y₂),
       e.map (whiskerLeft X f)
         = (μIsoSymm _ _).hom ≫ (e.obj X ◁ e.map f) ≫ (μIsoSymm _ _).inv :=
       by aesop_cat)
-    (whiskerRight : ∀ {X₁ X₂ : D} (f : X₁ ⟶ X₂) (Y : D), tensorObj X₁ Y ⟶ tensorObj X₂ Y)
+    (whiskerRight : ∀ {X₁ X₂ : D} (_f : X₁ ⟶ X₂) (Y : D), tensorObj X₁ Y ⟶ tensorObj X₂ Y)
     (whiskerRight_eq : ∀ {X₁ X₂ : D} (f : X₁ ⟶ X₂) (Y : D),
       e.map (whiskerRight f Y)
         = (μIsoSymm _ _).hom ≫ (e.map f ▷ e.obj Y) ≫ (μIsoSymm _ _).inv :=
       by aesop_cat)
     (tensorHom :
-      ∀ {X₁ Y₁ X₂ Y₂ : D} (f : X₁ ⟶ Y₁) (g: X₂ ⟶ Y₂), tensorObj X₁ X₂ ⟶ tensorObj Y₁ Y₂)
+      ∀ {X₁ Y₁ X₂ Y₂ : D} (_f : X₁ ⟶ Y₁) (_g : X₂ ⟶ Y₂), tensorObj X₁ X₂ ⟶ tensorObj Y₁ Y₂)
     (tensorHom_eq :
-      ∀ {X₁ Y₁ X₂ Y₂ : D} (f : X₁ ⟶ Y₁) (g: X₂ ⟶ Y₂),
+      ∀ {X₁ Y₁ X₂ Y₂ : D} (f : X₁ ⟶ Y₁) (g : X₂ ⟶ Y₂),
         e.map (tensorHom f g)
           = (μIsoSymm _ _).hom ≫ (e.map f ⊗ e.map g) ≫ (μIsoSymm _ _).inv :=
       by aesop_cat)
@@ -90,33 +90,61 @@ abbrev induced (e : D ⥤ C) [Faithful e]
       tensorHom_def {X₁ Y₁ X₂ Y₂} f g := e.map_injective <| by
         dsimp
         rw [tensorHom_eq, Functor.map_comp, whiskerRight_eq, whiskerLeft_eq]
-        sorry
-      tensor_id X₁ X₂ := e.map_injective <| by
-        dsimp
-        sorry
-      tensor_comp {X₁ Y₁ Z₁ X₂ Y₂ Z₂} f₁ f₂ g₁ g₂ := e.map_injective <| by
-        dsimp
-        sorry
+        simp only [tensorHom_def, assoc, Iso.inv_hom_id_assoc]
+      tensor_id X₁ X₂ := e.map_injective <| by aesop_cat
+      tensor_comp {X₁ Y₁ Z₁ X₂ Y₂ Z₂} f₁ f₂ g₁ g₂ := e.map_injective <| by aesop_cat
       whiskerLeft_id X Y := e.map_injective <| by simp [whiskerLeft_eq]
       id_whiskerRight X Y := e.map_injective <| by simp [whiskerRight_eq]
       associator_naturality {X₁ X₂ X₃ Y₁ Y₂ Y₃} f₁ f₂ f₃ := e.map_injective <| by
+        have := associator_naturality (e.map f₁) (e.map f₂) (e.map f₃)
+        dsimp
         simp [associator_eq, tensorHom_eq]
-        sorry
+        simp_rw [←assoc, ←tensor_comp, assoc, Iso.inv_hom_id, ←assoc]
+        congr 1
+        conv_rhs => rw [←comp_id (e.map f₁), ←id_comp (e.map f₁)]
+        simp only [tensor_comp]
+        simp only [tensor_id, comp_id, assoc, tensor_inv_hom_id_assoc, id_comp]
+        slice_rhs 2 3 => rw [←this]
+        simp only [← assoc, Iso.inv_hom_id, comp_id]
+        congr 2
+        simp_rw [←tensor_comp, id_comp]
       leftUnitor_naturality {X Y : D} f := e.map_injective <| by
-        simp [leftUnitor_eq, tensorHom_eq]
-        sorry
+        have := leftUnitor_naturality (e.map f)
+        dsimp
+        simp only [Functor.map_comp, tensorHom_eq, Functor.map_id, leftUnitor_eq, Iso.trans_assoc,
+          Iso.trans_hom, tensorIso_hom, Iso.refl_hom, assoc, Iso.inv_hom_id_assoc,
+          id_tensor_comp_tensor_id_assoc, Iso.cancel_iso_hom_left]
+        rw [←this, ←assoc, ←tensor_comp, id_comp, comp_id]
       rightUnitor_naturality {X Y : D} f := e.map_injective <| by
-        simp [rightUnitor_eq, tensorHom_eq]
-        sorry
+        have := rightUnitor_naturality (e.map f)
+        dsimp
+        simp only [Functor.map_comp, tensorHom_eq, Functor.map_id, rightUnitor_eq, Iso.trans_assoc,
+          Iso.trans_hom, tensorIso_hom, Iso.refl_hom, assoc, Iso.inv_hom_id_assoc,
+          tensor_id_comp_id_tensor_assoc, Iso.cancel_iso_hom_left]
+        rw [←this, ←assoc, ←tensor_comp, id_comp, comp_id]
       pentagon W X Y Z := e.map_injective <| by
         have := MonoidalCategory.pentagon (e.obj W) (e.obj X) (e.obj Y) (e.obj Z)
-        simp [associator_eq, tensorHom_eq]
-        congr 2
+        dsimp
+        simp only [Functor.map_comp, tensorHom_eq, associator_eq, Iso.trans_assoc, Iso.trans_hom,
+          tensorIso_hom, Iso.refl_hom, Iso.symm_hom, Functor.map_id, comp_tensor_id,
+          associator_conjugation, tensor_id, assoc, id_tensor_comp, Iso.inv_hom_id_assoc,
+          tensor_inv_hom_id_assoc, id_comp, inv_hom_id_tensor_assoc, id_tensor_comp_tensor_id_assoc,
+          Iso.cancel_iso_hom_left]
+        congr 1
         simp only [←assoc]
         congr 2
-        simp
-        sorry
-      triangle X Y :=  e.map_injective <| by aesop_cat
+        simp only [assoc, ←tensor_comp, id_comp, Iso.inv_hom_id, tensor_id]
+        congr 1
+        conv_rhs => rw [←tensor_id_comp_id_tensor]
+        simp only [assoc]
+        congr 1
+        rw [Iso.inv_comp_eq]
+        conv_lhs => rw [←id_comp (𝟙 (e.obj W)), tensor_comp]
+        slice_lhs 0 2 => rw [this]
+        rw [assoc]
+        congr 1
+        rw [←associator_naturality, tensor_id]
+      triangle X Y := e.map_injective <| by aesop_cat
 
 /-- Transport a monoidal structure along an equivalence of (plain) categories.
 -/
@@ -142,119 +170,6 @@ def transport (e : C ≌ D) : MonoidalCategory.{v₂} D :=
     (rightUnitor := fun X =>
       e.functor.mapIso ((Iso.refl _ ⊗ (e.unitIso.app _).symm) ≪≫ ρ_ (e.inverse.obj X)) ≪≫
         e.counitIso.app _)
-
--- porting note: it was @[simps {attrs := [`_refl_lemma]}]
-/-- Transport a monoidal structure along an equivalence of (plain) categories.
--/
--- TODO: delete this once the `sorry`s above are filled
-@[simps]
-def transport' (e : C ≌ D) : MonoidalCategory.{v₂} D where
-  tensorObj X Y := e.functor.obj (e.inverse.obj X ⊗ e.inverse.obj Y)
-  whiskerLeft := fun X _ _ f ↦ e.functor.map (e.inverse.obj X ◁ e.inverse.map f)
-  whiskerRight := fun f X ↦ e.functor.map (e.inverse.map f ▷ e.inverse.obj X)
-  tensorHom_def := by simp [tensorHom_def]
-  tensorHom f g := e.functor.map (e.inverse.map f ⊗ e.inverse.map g)
-  tensorUnit' := e.functor.obj (𝟙_ C)
-  associator X Y Z :=
-    e.functor.mapIso
-      (((e.unitIso.app _).symm ⊗ Iso.refl _) ≪≫
-        α_ (e.inverse.obj X) (e.inverse.obj Y) (e.inverse.obj Z) ≪≫ (Iso.refl _ ⊗ e.unitIso.app _))
-  leftUnitor X :=
-    e.functor.mapIso (((e.unitIso.app _).symm ⊗ Iso.refl _) ≪≫ λ_ (e.inverse.obj X)) ≪≫
-      e.counitIso.app _
-  rightUnitor X :=
-    e.functor.mapIso ((Iso.refl _ ⊗ (e.unitIso.app _).symm) ≪≫ ρ_ (e.inverse.obj X)) ≪≫
-      e.counitIso.app _
-  triangle X Y := by
-    dsimp
-    simp only [Iso.hom_inv_id_app_assoc, comp_tensor_id, Equivalence.unit_inverse_comp, assoc,
-      Equivalence.inv_fun_map, comp_id, Functor.map_comp, id_tensor_comp, e.inverse.map_id]
-    simp only [← e.functor.map_comp]
-    congr 2
-    slice_lhs 2 3 =>
-      rw [← id_tensor_comp]
-      simp
-    rw [Category.id_comp, ← associator_naturality_assoc, triangle]
-  pentagon W X Y Z := by
-    dsimp
-    simp only [Iso.hom_inv_id_app_assoc, comp_tensor_id, assoc, Equivalence.inv_fun_map,
-      Functor.map_comp, id_tensor_comp, e.inverse.map_id]
-    simp only [← e.functor.map_comp]
-    congr 2
-    slice_lhs 4 5 =>
-      rw [← comp_tensor_id, Iso.hom_inv_id_app]
-      dsimp
-      rw [tensor_id]
-    simp only [Category.id_comp, Category.assoc]
-    slice_lhs 5 6 =>
-      rw [← id_tensor_comp, Iso.hom_inv_id_app]
-      dsimp
-      rw [tensor_id]
-    simp only [Category.id_comp, Category.assoc]
-    slice_rhs 2 3 => rw [id_tensor_comp_tensor_id, ← tensor_id_comp_id_tensor]
-    slice_rhs 1 2 => rw [← tensor_id, ← associator_naturality]
-    slice_rhs 3 4 => rw [← tensor_id, associator_naturality]
-    slice_rhs 2 3 => rw [← pentagon]
-    simp only [Category.assoc]
-    congr 2
-    slice_lhs 1 2 => rw [associator_naturality]
-    simp only [Category.assoc]
-    congr 1
-    slice_lhs 1 2 =>
-      rw [← id_tensor_comp, ← comp_tensor_id, Iso.hom_inv_id_app]
-      dsimp
-      rw [tensor_id, tensor_id]
-    simp only [Category.id_comp, Category.assoc]
-  leftUnitor_naturality f := by
-    dsimp
-    simp only [Functor.map_comp, Functor.map_id, Category.assoc]
-    erw [← e.counitIso.hom.naturality]
-    simp only [Functor.comp_map, ← e.functor.map_comp_assoc]
-    congr 2
-    rw [id_tensor_comp_tensor_id_assoc, ← tensor_id_comp_id_tensor_assoc,
-      leftUnitor_naturality]
-  rightUnitor_naturality f := by
-    dsimp
-    simp only [Functor.map_comp, Functor.map_id, Category.assoc]
-    erw [← e.counitIso.hom.naturality]
-    simp only [Functor.comp_map, ← e.functor.map_comp_assoc]
-    congr 2
-    erw [tensor_id_comp_id_tensor_assoc, ← id_tensor_comp_tensor_id_assoc,
-      rightUnitor_naturality]
-  associator_naturality f₁ f₂ f₃ := by
-    dsimp
-    simp only [Equivalence.inv_fun_map, Functor.map_comp, Category.assoc]
-    simp only [← e.functor.map_comp]
-    congr 1
-    conv_lhs => rw [← tensor_id_comp_id_tensor]
-    slice_lhs 2 3 => rw [id_tensor_comp_tensor_id, ← tensor_id_comp_id_tensor, ← tensor_id]
-    simp only [Category.assoc]
-    slice_lhs 3 4 => rw [associator_naturality]
-    conv_lhs => simp only [comp_tensor_id]
-    slice_lhs 3 4 =>
-      rw [← comp_tensor_id, Iso.hom_inv_id_app]
-      dsimp
-      rw [tensor_id]
-    simp only [Category.id_comp, Category.assoc]
-    slice_lhs 2 3 => rw [associator_naturality]
-    simp only [Category.assoc]
-    congr 2
-    slice_lhs 1 1 => rw [← tensor_id_comp_id_tensor]
-    slice_lhs 2 3 => rw [← id_tensor_comp, tensor_id_comp_id_tensor]
-    slice_lhs 1 2 => rw [tensor_id_comp_id_tensor]
-    conv_rhs =>
-      congr
-      · skip
-      · rw [← id_tensor_comp_tensor_id, id_tensor_comp]
-    simp only [Category.assoc]
-    slice_rhs 1 2 =>
-      rw [← id_tensor_comp, Iso.hom_inv_id_app]
-      dsimp
-      rw [tensor_id]
-    simp only [Category.id_comp, Category.assoc]
-    conv_rhs => rw [id_tensor_comp]
-    slice_rhs 2 3 => rw [id_tensor_comp_tensor_id, ← tensor_id_comp_id_tensor]
-    slice_rhs 1 2 => rw [id_tensor_comp_tensor_id]
 #align category_theory.monoidal.transport CategoryTheory.Monoidal.transport
 
 /-- A type synonym for `D`, which will carry the transported monoidal structure. -/

--- a/Mathlib/RepresentationTheory/Action.lean
+++ b/Mathlib/RepresentationTheory/Action.lean
@@ -473,7 +473,7 @@ open MonoidalCategory
 
 variable [MonoidalCategory V]
 
-instance : MonoidalCategory (Action V G) :=
+instance instMonoidalCategory : MonoidalCategory (Action V G) :=
   Monoidal.transport (Action.functorCategoryEquivalence _ _).symm
 
 @[simp]
@@ -633,12 +633,6 @@ theorem functorCategoryMonoidalEquivalence.μ_app (A B : Action V G) :
   -- porting note: Lean3 was able to see through some defeq, as the mathlib3 proof was
   --   show (𝟙 A.V ⊗ 𝟙 B.V) ≫ 𝟙 (A.V ⊗ B.V) ≫ (𝟙 A.V ⊗ 𝟙 B.V) = 𝟙 (A.V ⊗ B.V)
   --   simp only [monoidal_category.tensor_id, category.comp_id]
-  dsimp [Equivalence.unit]
-  erw [Category.id_comp]
-  rw [NatIso.isIso_inv_app, IsIso.inv_comp_eq]
-  erw [MonoidalCategory.tensor_id]
-  erw [(functorCategoryEquivalence V G).inverse.map_id,
-    (functorCategoryEquivalence V G).functor.map_id, Category.id_comp]
   rfl
 set_option linter.uppercaseLean3 false in
 #align Action.functor_category_monoidal_equivalence.μ_app Action.functorCategoryMonoidalEquivalence.μ_app

--- a/Mathlib/RepresentationTheory/Action.lean
+++ b/Mathlib/RepresentationTheory/Action.lean
@@ -561,10 +561,11 @@ set_option linter.uppercaseLean3 false in
 
 variable (V G)
 
+set_option maxHeartbeats 400000 in
 /-- When `V` is monoidal the forgetful functor `Action V G` to `V` is monoidal. -/
 @[simps]
 def forgetMonoidal : MonoidalFunctor (Action V G) V :=
-  { Action.forget _ _ with
+  { toFunctor := Action.forget _ _
     ε := 𝟙 _
     μ := fun X Y => 𝟙 _ }
 set_option linter.uppercaseLean3 false in
@@ -579,6 +580,7 @@ section
 
 variable [BraidedCategory V]
 
+set_option maxHeartbeats 400000 in
 instance : BraidedCategory (Action V G) :=
   braidedCategoryOfFaithful (forgetMonoidal V G) (fun X Y => mkIso (β_ _ _)
     (fun g => by simp [FunctorCategoryEquivalence.inverse])) (by aesop_cat)

--- a/Mathlib/RepresentationTheory/Action.lean
+++ b/Mathlib/RepresentationTheory/Action.lean
@@ -977,29 +977,27 @@ variable {W : Type (u + 1)} [LargeCategory W] [MonoidalCategory V] [MonoidalCate
 /-- A monoidal functor induces a monoidal functor between
 the categories of `G`-actions within those categories. -/
 @[simps]
-def mapAction : MonoidalFunctor (Action V G) (Action W G) :=
-  { F.toFunctor.mapAction G with
-    ε :=
-      { hom := F.ε
-        comm := fun g => by
-          dsimp [FunctorCategoryEquivalence.inverse, Functor.mapAction]
-          rw [Category.id_comp, F.map_id, Category.comp_id] }
-    μ := fun X Y =>
-      { hom := F.μ X.V Y.V
-        comm := fun g => F.toLaxMonoidalFunctor.μ_natural (X.ρ g) (Y.ρ g) }
-    ε_isIso := by infer_instance
-    μ_isIso := by infer_instance
-    μ_natural := by intros; ext; simp
-    associativity := by intros; ext; simp
-    left_unitality := by intros; ext; simp
-    right_unitality := by
-      intros
-      ext
-      dsimp
-      simp only [MonoidalCategory.rightUnitor_conjugation,
-        LaxMonoidalFunctor.right_unitality, Category.id_comp, Category.assoc,
-        LaxMonoidalFunctor.right_unitality_inv_assoc, Category.comp_id, Iso.hom_inv_id]
-      rw [← F.map_comp, Iso.inv_hom_id, F.map_id, Category.comp_id] }
+def mapAction : MonoidalFunctor (Action V G) (Action W G) where
+  toFunctor := F.toFunctor.mapAction G
+  ε :=
+    { hom := F.ε
+      comm := fun g => by
+        dsimp [FunctorCategoryEquivalence.inverse, Functor.mapAction]
+        rw [Category.id_comp, F.map_id, Category.comp_id] }
+  μ := fun X Y =>
+    { hom := F.μ X.V Y.V
+      comm := fun g => F.toLaxMonoidalFunctor.μ_natural (X.ρ g) (Y.ρ g) }
+  -- using `dsimp` before `simp` speeds these up
+  μ_natural {X Y X' Y'} f g := by ext; dsimp; simp
+  associativity X Y Z := by ext; dsimp; simp
+  left_unitality X := by ext; dsimp; simp
+  right_unitality X := by
+    ext
+    dsimp
+    simp only [MonoidalCategory.rightUnitor_conjugation,
+      LaxMonoidalFunctor.right_unitality, Category.id_comp, Category.assoc,
+      LaxMonoidalFunctor.right_unitality_inv_assoc, Category.comp_id, Iso.hom_inv_id]
+    rw [← F.map_comp, Iso.inv_hom_id, F.map_id, Category.comp_id]
 set_option linter.uppercaseLean3 false in
 #align category_theory.monoidal_functor.map_Action CategoryTheory.MonoidalFunctor.mapAction
 

--- a/Mathlib/RepresentationTheory/Action.lean
+++ b/Mathlib/RepresentationTheory/Action.lean
@@ -509,7 +509,7 @@ set_option linter.uppercaseLean3 false in
 -- porting note: removed @[simp] as the simpNF linter complains
 theorem associator_hom_hom {X Y Z : Action V G} :
     Hom.hom (α_ X Y Z).hom = (α_ X.V Y.V Z.V).hom := by
-  dsimp [Monoidal.transport_associator]
+  dsimp [Monoidal.induced_associator]
   simp
 set_option linter.uppercaseLean3 false in
 #align Action.associator_hom_hom Action.associator_hom_hom
@@ -517,35 +517,35 @@ set_option linter.uppercaseLean3 false in
 -- porting note: removed @[simp] as the simpNF linter complains
 theorem associator_inv_hom {X Y Z : Action V G} :
     Hom.hom (α_ X Y Z).inv = (α_ X.V Y.V Z.V).inv := by
-  dsimp [Monoidal.transport_associator]
+  dsimp [Monoidal.induced_associator]
   simp
 set_option linter.uppercaseLean3 false in
 #align Action.associator_inv_hom Action.associator_inv_hom
 
 -- porting note: removed @[simp] as the simpNF linter complains
 theorem leftUnitor_hom_hom {X : Action V G} : Hom.hom (λ_ X).hom = (λ_ X.V).hom := by
-  dsimp [Monoidal.transport_leftUnitor]
+  dsimp [Monoidal.induced_leftUnitor]
   simp
 set_option linter.uppercaseLean3 false in
 #align Action.left_unitor_hom_hom Action.leftUnitor_hom_hom
 
 -- porting note: removed @[simp] as the simpNF linter complains
 theorem leftUnitor_inv_hom {X : Action V G} : Hom.hom (λ_ X).inv = (λ_ X.V).inv := by
-  dsimp [Monoidal.transport_leftUnitor]
+  dsimp [Monoidal.induced_leftUnitor]
   simp
 set_option linter.uppercaseLean3 false in
 #align Action.left_unitor_inv_hom Action.leftUnitor_inv_hom
 
 -- porting note: removed @[simp] as the simpNF linter complains
 theorem rightUnitor_hom_hom {X : Action V G} : Hom.hom (ρ_ X).hom = (ρ_ X.V).hom := by
-  dsimp [Monoidal.transport_rightUnitor]
+  dsimp [Monoidal.induced_rightUnitor]
   simp
 set_option linter.uppercaseLean3 false in
 #align Action.right_unitor_hom_hom Action.rightUnitor_hom_hom
 
 -- porting note: removed @[simp] as the simpNF linter complains
 theorem rightUnitor_inv_hom {X : Action V G} : Hom.hom (ρ_ X).inv = (ρ_ X.V).inv := by
-  dsimp [Monoidal.transport_rightUnitor]
+  dsimp [Monoidal.induced_rightUnitor]
   simp
 set_option linter.uppercaseLean3 false in
 #align Action.right_unitor_inv_hom Action.rightUnitor_inv_hom

--- a/Mathlib/RepresentationTheory/Rep.lean
+++ b/Mathlib/RepresentationTheory/Rep.lean
@@ -477,14 +477,16 @@ set_option linter.uppercaseLean3 false in
 
 variable {A B C}
 
-@[simp]
+-- `simpNF` times out
+@[simp, nolint simpNF]
 theorem MonoidalClosed.linearHomEquiv_hom (f : A ⊗ B ⟶ C) :
     (MonoidalClosed.linearHomEquiv A B C f).hom = (TensorProduct.curry f.hom).flip :=
   rfl
 set_option linter.uppercaseLean3 false in
 #align Rep.monoidal_closed.linear_hom_equiv_hom Rep.MonoidalClosed.linearHomEquiv_hom
 
-@[simp]
+-- `simpNF` times out
+@[simp, nolint simpNF]
 theorem MonoidalClosed.linearHomEquivComm_hom (f : A ⊗ B ⟶ C) :
     (MonoidalClosed.linearHomEquivComm A B C f).hom = TensorProduct.curry f.hom :=
   rfl


### PR DESCRIPTION
I needed this to transfer the monoidal structure from `ModuleCat` to `QuadraticModuleCat`, but would also work for transferring the same structure from `ModuleCat` to `AlgebraCat`.

The changes are:

* A new `CategoryTheory.Monoidal.induced` definition, proven from scratch with slightly uglier proofs than what `transport` used. The new proofs use `simp` rather more than targeted slice commands, mainly due to lack of patience on my part.
* `CategoryTheory.Monoidal.transport` now has a trivial implementation in terms of `induced`, as does `CategoryTheory.MonoidalCategory.fullMonoidalSubcategory` (though this was already fairly trivial)
* `CategoryTheory.Monoidal.laxToTransported` has been removed, as it's just a less useful version of `CategoryTheory.Monoidal.toTransported`
* `CategoryTheory.Monoidal.toTransported` has been golfed to oblivion, as it now falls out trivially by showing `fromTransported` first.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
