### PR TITLE
[Merged by Bors] - feat (Data/Matrix/Blocks): simp lemmas for toBlocks of diagonal matrices

### DIFF
--- a/Mathlib/Data/Matrix/Block.lean
+++ b/Mathlib/Data/Matrix/Block.lean
@@ -302,14 +302,14 @@ theorem fromBlocks_diagonal (d₁ : l → α) (d₂ : m → α) :
 
 @[simp]
 lemma toBlocks₁₁_diagonal (v : l ⊕ m → α) :
-    toBlocks₁₁ (diagonal v) = diagonal ( fun i => v (Sum.inl i) ) := by
+    toBlocks₁₁ (diagonal v) = diagonal (fun i => v (Sum.inl i)) := by
   unfold toBlocks₁₁
   funext i j
   simp only [ne_eq, Sum.inl.injEq, of_apply, diagonal_apply]
 
 @[simp]
 lemma toBlocks₂₂_diagonal (v : l ⊕ m → α) :
-    toBlocks₂₂ (diagonal v) = diagonal ( fun i => v (Sum.inr i) ) := by
+    toBlocks₂₂ (diagonal v) = diagonal (fun i => v (Sum.inr i)) := by
   unfold toBlocks₂₂
   funext i j
   simp only [ne_eq, Sum.inr.injEq, of_apply, diagonal_apply]

--- a/Mathlib/Data/Matrix/Block.lean
+++ b/Mathlib/Data/Matrix/Block.lean
@@ -300,6 +300,26 @@ theorem fromBlocks_diagonal (d₁ : l → α) (d₂ : m → α) :
   rcases i with ⟨⟩ <;> rcases j with ⟨⟩ <;> simp [diagonal]
 #align matrix.from_blocks_diagonal Matrix.fromBlocks_diagonal
 
+@[simp]
+lemma toBlocks₁₁_diagonal (v : l ⊕ m → α) :
+    toBlocks₁₁ (diagonal v) = diagonal ( fun i => v (Sum.inl i) ) := by
+  unfold toBlocks₁₁
+  funext i j
+  simp only [ne_eq, Sum.inl.injEq, of_apply, diagonal_apply]
+
+@[simp]
+lemma toBlocks₂₂_diagonal (v : l ⊕ m → α) :
+    toBlocks₂₂ (diagonal v) = diagonal ( fun i => v (Sum.inr i) ) := by
+  unfold toBlocks₂₂
+  funext i j
+  simp only [ne_eq, Sum.inr.injEq, of_apply, diagonal_apply]
+
+@[simp]
+lemma toBlocks₁₂_diagonal (v : l ⊕ m → α) : toBlocks₁₂ (diagonal v) = 0 := rfl
+
+@[simp]
+lemma toBlocks₂₁_diagonal (v : l ⊕ m → α) : toBlocks₂₁ (diagonal v) = 0 := rfl
+
 end Zero
 
 section HasZeroHasOne


### PR DESCRIPTION
Lemmas `toBlocks₁₁_diagonal`, `toBlocks₂₂_diagonal`, `toBlocks₁₂_diagonal`, `toBlocks₂₁_diagonal` to make dealing with sub blocks of diagonal matrices a bit easier

Useful for PR #6042 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
