### PR TITLE
[Merged by Bors] - fix: make linarith recognize not-equals when splitNe is true

### DIFF
--- a/Mathlib/Lean/Expr/Basic.lean
+++ b/Mathlib/Lean/Expr/Basic.lean
@@ -349,7 +349,12 @@ def zero? (e : Expr) : Bool :=
   | some 0 => true
   | _ => false
 
-/-- `Lean.Expr.le? p` take `e : Expr` as input.
+/-- Tests is if an expression matches either `x ≠ y` or `¬ (x = y)`.
+If it matches, returns `some (type, x, y)`. -/
+def ne?' (e : Expr) : Option (Expr × Expr × Expr) :=
+  e.ne? <|> (e.not? >>= Expr.eq?)
+
+/-- `Lean.Expr.le? e` takes `e : Expr` as input.
 If `e` represents `a ≤ b`, then it returns `some (t, a, b)`, where `t` is the Type of `a`,
 otherwise, it returns `none`. -/
 @[inline] def le? (p : Expr) : Option (Expr × Expr × Expr) := do

--- a/Mathlib/Tactic/Linarith/Frontend.lean
+++ b/Mathlib/Tactic/Linarith/Frontend.lean
@@ -327,6 +327,8 @@ by linarith
 ```
 
 `linarith` will use all appropriate hypotheses and the negation of the goal, if applicable.
+Disequality hypotheses require case splitting and are not normally considered
+(see the `splitNe` option below).
 
 `linarith [t1, t2, t3]` will additionally use proof terms `t1, t2, t3`.
 
@@ -350,6 +352,10 @@ optional arguments:
   it will only unfold `reducible` definitions.
 * If `split_hypotheses` is true, `linarith` will split conjunctions in the context into separate
   hypotheses.
+* If `splitNe` is `true`, `linarith` will case split on disequality hypotheses.
+  For a given `x ≠ y` hypothesis, `linarith` is run with both `x < y` and `x > y`,
+  and so this runs linarith exponentially many times with respect to th enumber of
+  disequality hypotheses. (False by default.)
 * If `exfalso` is false, `linarith` will fail when the goal is neither an inequality nor `false`.
   (True by default.)
 * `restrict_type` (not yet implemented in mathlib4)

--- a/Mathlib/Tactic/Linarith/Frontend.lean
+++ b/Mathlib/Tactic/Linarith/Frontend.lean
@@ -354,7 +354,7 @@ optional arguments:
   hypotheses.
 * If `splitNe` is `true`, `linarith` will case split on disequality hypotheses.
   For a given `x ≠ y` hypothesis, `linarith` is run with both `x < y` and `x > y`,
-  and so this runs linarith exponentially many times with respect to th enumber of
+  and so this runs linarith exponentially many times with respect to the number of
   disequality hypotheses. (False by default.)
 * If `exfalso` is false, `linarith` will fail when the goal is neither an inequality nor `false`.
   (True by default.)

--- a/Mathlib/Tactic/Linarith/Preprocessing.lean
+++ b/Mathlib/Tactic/Linarith/Preprocessing.lean
@@ -388,7 +388,7 @@ This produces `2^n` branches when there are `n` such hypotheses in the input.
 -/
 partial def removeNe_aux : MVarId → List Expr → MetaM (List Branch) := fun g hs => do
   let some (e, α, a, b) ← hs.findSomeM? (fun e : Expr => do
-    let some (α, a, b) := (← inferType e).ne? | return none
+    let some (α, a, b) := (← inferType e).ne?' | return none
     return some (e, α, a, b)) | return [(g, hs)]
   let [ng1, ng2] ← g.apply (← mkAppOptM ``Or.elim #[none, none, ← g.getType,
       ← mkAppOptM ``lt_or_gt_of_ne #[α, none, a, b, e]]) | failure

--- a/test/linarith.lean
+++ b/test/linarith.lean
@@ -463,17 +463,28 @@ lemma works {a b : ℕ} (hab : a ≤ b) (h : b < a) : false := by
 
 end T
 
-example (a b c : ℚ) (h : a ≠ b) (h3 : b ≠ c) (h2 : a ≥ b) : b ≠ c :=
-by linarith (config := {splitNe := true})
+example (a b c : ℚ) (h : a ≠ b) (h3 : b ≠ c) (h2 : a ≥ b) : b ≠ c := by
+  linarith (config := {splitNe := true})
 
-example (a b c : ℚ) (h : a ≠ b) (h2 : a ≥ b) (h3 : b ≠ c) : a > b :=
-by linarith (config := {splitNe := true})
+example (a b c : ℚ) (h : a ≠ b) (h2 : a ≥ b) (h3 : b ≠ c) : a > b := by
+  linarith (config := {splitNe := true})
 
-example (a b : ℕ) (h1 : b ≠ a) (h2 : b ≤ a) : b < a :=
-by linarith (config := {splitNe := true})
+example (a b : ℕ) (h1 : b ≠ a) (h2 : b ≤ a) : b < a := by
+  linarith (config := {splitNe := true})
 
-example (a b : ℕ) (h1 : b ≠ a) (h2 : ¬a < b) : b < a :=
-by linarith (config := {splitNe := true})
+example (a b : ℕ) (h1 : b ≠ a) (h2 : ¬a < b) : b < a := by
+  linarith (config := {splitNe := true})
+
+section
+-- Regression test for issue that splitNe didn't see `¬ a = b`
+
+example (a b : Nat) (h1 : a < b + 1) (h2 : a ≠ b) : a < b := by
+  linarith (config := {splitNe := true})
+
+example (a b : Nat) (h1 : a < b + 1) (h2 : ¬ a = b) : a < b := by
+  linarith (config := {splitNe := true})
+
+end
 
 example (x y : ℚ) (h₁ : 0 ≤ y) (h₂ : y ≤ x) : y * x ≤ x * x := by nlinarith
 


### PR DESCRIPTION
This is fixing an error discovered in an example reported by Dan Velleman [on Zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/.E2.9C.94.20Strange.20linarith.20behavior/near/390786695).


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
