### PR TITLE
[Merged by Bors] - feat: injectivity of multiplication with matrices whose product is 1

### DIFF
--- a/Mathlib/LinearAlgebra/Matrix/NonsingularInverse.lean
+++ b/Mathlib/LinearAlgebra/Matrix/NonsingularInverse.lean
@@ -347,6 +347,26 @@ lemma mul_right_inj_of_invertible [Invertible A] {x y : Matrix n m α} : A * x =
 lemma mul_left_inj_of_invertible [Invertible A] {x y : Matrix m n α} : x * A = y * A ↔ x = y :=
   (mul_left_injective_of_invertible A).eq_iff
 
+section InjectiveMul
+variable [Fintype m] [DecidableEq m]
+variable [Fintype l] [DecidableEq l]
+
+lemma Matrix.mul_left_injective_of_inv (A : Matrix m n α) (B : Matrix n m α) (h : A * B = 1) :
+    Function.Injective (fun x : Matrix l m α => x * A) := by
+  intro u v g
+  replace g := congr_arg (fun x => x * B) g
+  dsimp at g
+  rwa [Matrix.mul_assoc, Matrix.mul_assoc, h, Matrix.mul_one, Matrix.mul_one] at g
+
+lemma Matrix.mul_right_injective_of_inv (A : Matrix m n α) (B : Matrix n m α) (h : A * B = 1) :
+    Function.Injective (fun x : Matrix m l α => B * x) := by
+  intro u v g
+  replace g := congr_arg (fun x => A * x) g
+  dsimp at g
+  rwa [← Matrix.mul_assoc, ←Matrix.mul_assoc, h, Matrix.one_mul, Matrix.one_mul] at g
+
+end InjectiveMul
+
 theorem nonsing_inv_cancel_or_zero : A⁻¹ * A = 1 ∧ A * A⁻¹ = 1 ∨ A⁻¹ = 0 := by
   by_cases h : IsUnit A.det
   · exact Or.inl ⟨nonsing_inv_mul _ h, mul_nonsing_inv _ h⟩

--- a/Mathlib/LinearAlgebra/Matrix/NonsingularInverse.lean
+++ b/Mathlib/LinearAlgebra/Matrix/NonsingularInverse.lean
@@ -351,14 +351,14 @@ section InjectiveMul
 variable [Fintype m] [DecidableEq m]
 variable [Fintype l] [DecidableEq l]
 
-lemma Matrix.mul_left_injective_of_inv (A : Matrix m n α) (B : Matrix n m α) (h : A * B = 1) :
+lemma mul_left_injective_of_inv (A : Matrix m n α) (B : Matrix n m α) (h : A * B = 1) :
     Function.Injective (fun x : Matrix l m α => x * A) := by
   intro u v g
   replace g := congr_arg (fun x => x * B) g
   dsimp at g
   rwa [Matrix.mul_assoc, Matrix.mul_assoc, h, Matrix.mul_one, Matrix.mul_one] at g
 
-lemma Matrix.mul_right_injective_of_inv (A : Matrix m n α) (B : Matrix n m α) (h : A * B = 1) :
+lemma mul_right_injective_of_inv (A : Matrix m n α) (B : Matrix n m α) (h : A * B = 1) :
     Function.Injective (fun x : Matrix m l α => B * x) := by
   intro u v g
   replace g := congr_arg (fun x => A * x) g

--- a/Mathlib/LinearAlgebra/Matrix/NonsingularInverse.lean
+++ b/Mathlib/LinearAlgebra/Matrix/NonsingularInverse.lean
@@ -352,18 +352,12 @@ variable [Fintype m] [DecidableEq m]
 variable [Fintype l] [DecidableEq l]
 
 lemma mul_left_injective_of_inv (A : Matrix m n α) (B : Matrix n m α) (h : A * B = 1) :
-    Function.Injective (fun x : Matrix l m α => x * A) := by
-  intro u v g
-  replace g := congr_arg (fun x => x * B) g
-  dsimp at g
-  rwa [Matrix.mul_assoc, Matrix.mul_assoc, h, Matrix.mul_one, Matrix.mul_one] at g
+    Function.Injective (fun x : Matrix l m α => x * A) :=
+  fun _ _ g => by simpa only [Matrix.mul_assoc, Matrix.mul_one, h] using congr_arg (· * B) g
 
 lemma mul_right_injective_of_inv (A : Matrix m n α) (B : Matrix n m α) (h : A * B = 1) :
-    Function.Injective (fun x : Matrix m l α => B * x) := by
-  intro u v g
-  replace g := congr_arg (fun x => A * x) g
-  dsimp at g
-  rwa [← Matrix.mul_assoc, ←Matrix.mul_assoc, h, Matrix.one_mul, Matrix.one_mul] at g
+    Function.Injective (fun x : Matrix m l α => B * x) :=
+  fun _ _ g => by simpa only [← Matrix.mul_assoc, Matrix.one_mul, h] using congr_arg (A * ·) g
 
 end InjectiveMul
 


### PR DESCRIPTION
Given two matrices $A$ and $B$ whose product is 1 $AB = 1$, then left multiplication/right multiplication with these matrices from the appropriate side is an injection.

Suggested by @Vierkantor  in PR #6042 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
