### PR TITLE
fix: make tensor product noncomputable

### DIFF
--- a/Mathlib/Algebra/Algebra/Bilinear.lean
+++ b/Mathlib/Algebra/Algebra/Bilinear.lean
@@ -36,6 +36,7 @@ def mul : A →ₗ[R] A →ₗ[R] A :=
 #align linear_map.mul LinearMap.mul
 
 /-- The multiplication map on a non-unital algebra, as an `R`-linear map from `A ⊗[R] A` to `A`. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def mul' : A ⊗[R] A →ₗ[R] A :=
   TensorProduct.lift (mul R A)
 #align linear_map.mul' LinearMap.mul'

--- a/Mathlib/Algebra/Algebra/Bilinear.lean
+++ b/Mathlib/Algebra/Algebra/Bilinear.lean
@@ -36,7 +36,7 @@ def mul : A →ₗ[R] A →ₗ[R] A :=
 #align linear_map.mul LinearMap.mul
 
 /-- The multiplication map on a non-unital algebra, as an `R`-linear map from `A ⊗[R] A` to `A`. -/
-def mul' : A ⊗[R] A →ₗ[R] A :=
+noncomputable def mul' : A ⊗[R] A →ₗ[R] A :=
   TensorProduct.lift (mul R A)
 #align linear_map.mul' LinearMap.mul'
 

--- a/Mathlib/Algebra/Category/ModuleCat/ChangeOfRings.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/ChangeOfRings.lean
@@ -218,14 +218,14 @@ variable (M : ModuleCat.{v} R)
 
 /-- Extension of scalars turn an `R`-module into `S`-module by M ↦ S ⨂ M
 -/
-def obj' : ModuleCat S :=
+noncomputable def obj' : ModuleCat S :=
   ⟨TensorProduct R ((restrictScalars f).obj ⟨S⟩) M⟩
 #align category_theory.Module.extend_scalars.obj' ModuleCat.ExtendScalars.obj'
 
 /-- Extension of scalars is a functor where an `R`-module `M` is sent to `S ⊗ M` and
 `l : M1 ⟶ M2` is sent to `s ⊗ m ↦ s ⊗ l m`
 -/
-def map' {M1 M2 : ModuleCat.{v} R} (l : M1 ⟶ M2) : obj' f M1 ⟶ obj' f M2 :=
+noncomputable def map' {M1 M2 : ModuleCat.{v} R} (l : M1 ⟶ M2) : obj' f M1 ⟶ obj' f M2 :=
   by-- The "by apply" part makes this require 75% fewer heartbeats to process (#16371).
   apply @LinearMap.baseChange R S M1 M2 _ _ ((algebraMap S _).comp f).toAlgebra _ _ _ _ l
 #align category_theory.Module.extend_scalars.map' ModuleCat.ExtendScalars.map'
@@ -257,7 +257,8 @@ end ExtendScalars
 /-- Extension of scalars is a functor where an `R`-module `M` is sent to `S ⊗ M` and
 `l : M1 ⟶ M2` is sent to `s ⊗ m ↦ s ⊗ l m`
 -/
-def extendScalars {R : Type u₁} {S : Type u₂} [CommRing R] [CommRing S] (f : R →+* S) :
+noncomputable def extendScalars {R : Type u₁} {S : Type u₂} [CommRing R] [CommRing S]
+    (f : R →+* S) :
     ModuleCat R ⥤ ModuleCat S where
   obj M := ExtendScalars.obj' f M
   map l := ExtendScalars.map' f l
@@ -571,7 +572,7 @@ map `S ⨂ X → Y`, there is a `X ⟶ (restrictScalars f).obj Y`, i.e. `R`-line
 `x ↦ g (1 ⊗ x)`.
 -/
 @[simps apply]
-def HomEquiv.toRestrictScalars {X Y} (g : (extendScalars f).obj X ⟶ Y) :
+noncomputable def HomEquiv.toRestrictScalars {X Y} (g : (extendScalars f).obj X ⟶ Y) :
     X ⟶ (restrictScalars f).obj Y where
   toFun x := g <| (1 : S)⊗ₜ[R,f]x
   map_add' _ _ := by dsimp; rw [tmul_add, map_add]
@@ -606,7 +607,7 @@ Given `R`-module X and `S`-module Y and a map `X ⟶ (restrictScalars f).obj Y`,
 `s ⊗ x ↦ s • g x`.
 -/
 @[simps apply]
-def HomEquiv.fromExtendScalars {X Y} (g : X ⟶ (restrictScalars f).obj Y) :
+noncomputable def HomEquiv.fromExtendScalars {X Y} (g : X ⟶ (restrictScalars f).obj Y) :
     (extendScalars f).obj X ⟶ Y := by
   letI m1 : Module R S := Module.compHom S f; letI m2 : Module R Y := Module.compHom Y f
   refine {toFun := fun z => TensorProduct.lift ?_ z, map_add' := ?_, map_smul' := ?_}
@@ -637,7 +638,7 @@ def HomEquiv.fromExtendScalars {X Y} (g : X ⟶ (restrictScalars f).obj Y) :
 bijectively correspond to `R`-linear maps `X ⟶ (restrictScalars f).obj Y`.
 -/
 @[simps symm_apply]
-def homEquiv {X Y} :
+noncomputable def homEquiv {X Y} :
     ((extendScalars f).obj X ⟶ Y) ≃ (X ⟶ (restrictScalars.{max v u₂,u₁,u₂} f).obj Y) where
   toFun := HomEquiv.toRestrictScalars.{u₁,u₂,v} f
   invFun := HomEquiv.fromExtendScalars.{u₁,u₂,v} f
@@ -665,7 +666,7 @@ def homEquiv {X Y} :
 For any `R`-module X, there is a natural `R`-linear map from `X` to `X ⨂ S` by sending `x ↦ x ⊗ 1`
 -/
 -- @[simps] Porting note: not in normal form and not used
-def Unit.map {X} : X ⟶ (extendScalars f ⋙ restrictScalars f).obj X where
+noncomputable def Unit.map {X} : X ⟶ (extendScalars f ⋙ restrictScalars f).obj X where
   toFun x := (1 : S)⊗ₜ[R,f]x
   map_add' x x' := by dsimp; rw [TensorProduct.tmul_add]
   map_smul' r x := by
@@ -679,7 +680,8 @@ The natural transformation from identity functor on `R`-module to the compositio
 restriction of scalars.
 -/
 @[simps]
-def unit : 𝟭 (ModuleCat R) ⟶ extendScalars f ⋙ restrictScalars.{max v u₂,u₁,u₂} f where
+noncomputable def unit :
+    𝟭 (ModuleCat R) ⟶ extendScalars f ⋙ restrictScalars.{max v u₂,u₁,u₂} f where
   app _ := Unit.map.{u₁,u₂,v} f
 #align category_theory.Module.extend_restrict_scalars_adj.unit ModuleCat.ExtendRestrictScalarsAdj.unit
 
@@ -687,7 +689,7 @@ def unit : 𝟭 (ModuleCat R) ⟶ extendScalars f ⋙ restrictScalars.{max v u�
 `s ⊗ y ↦ s • y`
 -/
 @[simps apply]
-def Counit.map {Y} : (restrictScalars f ⋙ extendScalars f).obj Y ⟶ Y := by
+noncomputable def Counit.map {Y} : (restrictScalars f ⋙ extendScalars f).obj Y ⟶ Y := by
   letI m1 : Module R S := Module.compHom S f
   letI m2 : Module R Y := Module.compHom Y f
   refine'
@@ -729,7 +731,8 @@ attribute [nolint simpNF] Counit.map_apply
 identity functor on `S`-module.
 -/
 @[simps app]
-def counit : restrictScalars.{max v u₂,u₁,u₂} f ⋙ extendScalars f ⟶ 𝟭 (ModuleCat S) where
+noncomputable def counit :
+    restrictScalars.{max v u₂,u₁,u₂} f ⋙ extendScalars f ⟶ 𝟭 (ModuleCat S) where
   app _ := Counit.map.{u₁,u₂,v} f
   naturality Y Y' g := by
     -- Porting note: this is very annoying; fix instances in concrete categories
@@ -755,7 +758,8 @@ end ExtendRestrictScalarsAdj
 scalars by `f` are adjoint to each other.
 -/
 -- @[simps] -- Porting note: removed not in normal form and not used
-def extendRestrictScalarsAdj {R : Type u₁} {S : Type u₂} [CommRing R] [CommRing S] (f : R →+* S) :
+noncomputable def extendRestrictScalarsAdj {R : Type u₁} {S : Type u₂} [CommRing R] [CommRing S]
+    (f : R →+* S) :
     extendScalars.{u₁,u₂,max v u₂} f ⊣ restrictScalars.{max v u₂,u₁,u₂} f where
   homEquiv _ _ := ExtendRestrictScalarsAdj.homEquiv.{v,u₁,u₂} f
   unit := ExtendRestrictScalarsAdj.unit.{v,u₁,u₂} f
@@ -779,11 +783,11 @@ def extendRestrictScalarsAdj {R : Type u₁} {S : Type u₂} [CommRing R] [CommR
         congr 1
 #align category_theory.Module.extend_restrict_scalars_adj ModuleCat.extendRestrictScalarsAdj
 
-instance {R : Type u₁} {S : Type u₂} [CommRing R] [CommRing S] (f : R →+* S) :
+noncomputable instance {R : Type u₁} {S : Type u₂} [CommRing R] [CommRing S] (f : R →+* S) :
     CategoryTheory.IsLeftAdjoint (extendScalars f) :=
   ⟨_, extendRestrictScalarsAdj f⟩
 
-instance {R : Type u₁} {S : Type u₂} [CommRing R] [CommRing S] (f : R →+* S) :
+noncomputable instance {R : Type u₁} {S : Type u₂} [CommRing R] [CommRing S] (f : R →+* S) :
     CategoryTheory.IsRightAdjoint (restrictScalars f) :=
   ⟨_, extendRestrictScalarsAdj f⟩
 

--- a/Mathlib/Algebra/Category/ModuleCat/ChangeOfRings.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/ChangeOfRings.lean
@@ -218,6 +218,7 @@ variable (M : ModuleCat.{v} R)
 
 /-- Extension of scalars turn an `R`-module into `S`-module by M ↦ S ⨂ M
 -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def obj' : ModuleCat S :=
   ⟨TensorProduct R ((restrictScalars f).obj ⟨S⟩) M⟩
 #align category_theory.Module.extend_scalars.obj' ModuleCat.ExtendScalars.obj'
@@ -225,6 +226,7 @@ noncomputable def obj' : ModuleCat S :=
 /-- Extension of scalars is a functor where an `R`-module `M` is sent to `S ⊗ M` and
 `l : M1 ⟶ M2` is sent to `s ⊗ m ↦ s ⊗ l m`
 -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def map' {M1 M2 : ModuleCat.{v} R} (l : M1 ⟶ M2) : obj' f M1 ⟶ obj' f M2 :=
   by-- The "by apply" part makes this require 75% fewer heartbeats to process (#16371).
   apply @LinearMap.baseChange R S M1 M2 _ _ ((algebraMap S _).comp f).toAlgebra _ _ _ _ l
@@ -257,6 +259,7 @@ end ExtendScalars
 /-- Extension of scalars is a functor where an `R`-module `M` is sent to `S ⊗ M` and
 `l : M1 ⟶ M2` is sent to `s ⊗ m ↦ s ⊗ l m`
 -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def extendScalars {R : Type u₁} {S : Type u₂} [CommRing R] [CommRing S]
     (f : R →+* S) :
     ModuleCat R ⥤ ModuleCat S where
@@ -571,6 +574,7 @@ Given `R`-module X and `S`-module Y and a map `g : (extendScalars f).obj X ⟶ Y
 map `S ⨂ X → Y`, there is a `X ⟶ (restrictScalars f).obj Y`, i.e. `R`-linear map `X ⟶ Y` by
 `x ↦ g (1 ⊗ x)`.
 -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 @[simps apply]
 noncomputable def HomEquiv.toRestrictScalars {X Y} (g : (extendScalars f).obj X ⟶ Y) :
     X ⟶ (restrictScalars f).obj Y where
@@ -607,6 +611,7 @@ Given `R`-module X and `S`-module Y and a map `X ⟶ (restrictScalars f).obj Y`,
 `s ⊗ x ↦ s • g x`.
 -/
 @[simps apply]
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def HomEquiv.fromExtendScalars {X Y} (g : X ⟶ (restrictScalars f).obj Y) :
     (extendScalars f).obj X ⟶ Y := by
   letI m1 : Module R S := Module.compHom S f; letI m2 : Module R Y := Module.compHom Y f
@@ -638,6 +643,7 @@ noncomputable def HomEquiv.fromExtendScalars {X Y} (g : X ⟶ (restrictScalars f
 bijectively correspond to `R`-linear maps `X ⟶ (restrictScalars f).obj Y`.
 -/
 @[simps symm_apply]
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def homEquiv {X Y} :
     ((extendScalars f).obj X ⟶ Y) ≃ (X ⟶ (restrictScalars.{max v u₂,u₁,u₂} f).obj Y) where
   toFun := HomEquiv.toRestrictScalars.{u₁,u₂,v} f
@@ -666,6 +672,7 @@ noncomputable def homEquiv {X Y} :
 For any `R`-module X, there is a natural `R`-linear map from `X` to `X ⨂ S` by sending `x ↦ x ⊗ 1`
 -/
 -- @[simps] Porting note: not in normal form and not used
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def Unit.map {X} : X ⟶ (extendScalars f ⋙ restrictScalars f).obj X where
   toFun x := (1 : S)⊗ₜ[R,f]x
   map_add' x x' := by dsimp; rw [TensorProduct.tmul_add]
@@ -680,6 +687,7 @@ The natural transformation from identity functor on `R`-module to the compositio
 restriction of scalars.
 -/
 @[simps]
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def unit :
     𝟭 (ModuleCat R) ⟶ extendScalars f ⋙ restrictScalars.{max v u₂,u₁,u₂} f where
   app _ := Unit.map.{u₁,u₂,v} f
@@ -689,6 +697,7 @@ noncomputable def unit :
 `s ⊗ y ↦ s • y`
 -/
 @[simps apply]
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def Counit.map {Y} : (restrictScalars f ⋙ extendScalars f).obj Y ⟶ Y := by
   letI m1 : Module R S := Module.compHom S f
   letI m2 : Module R Y := Module.compHom Y f
@@ -731,6 +740,7 @@ attribute [nolint simpNF] Counit.map_apply
 identity functor on `S`-module.
 -/
 @[simps app]
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def counit :
     restrictScalars.{max v u₂,u₁,u₂} f ⋙ extendScalars f ⟶ 𝟭 (ModuleCat S) where
   app _ := Counit.map.{u₁,u₂,v} f
@@ -758,6 +768,7 @@ end ExtendRestrictScalarsAdj
 scalars by `f` are adjoint to each other.
 -/
 -- @[simps] -- Porting note: removed not in normal form and not used
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def extendRestrictScalarsAdj {R : Type u₁} {S : Type u₂} [CommRing R] [CommRing S]
     (f : R →+* S) :
     extendScalars.{u₁,u₂,max v u₂} f ⊣ restrictScalars.{max v u₂,u₁,u₂} f where
@@ -783,10 +794,12 @@ noncomputable def extendRestrictScalarsAdj {R : Type u₁} {S : Type u₂} [Comm
         congr 1
 #align category_theory.Module.extend_restrict_scalars_adj ModuleCat.extendRestrictScalarsAdj
 
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable instance {R : Type u₁} {S : Type u₂} [CommRing R] [CommRing S] (f : R →+* S) :
     CategoryTheory.IsLeftAdjoint (extendScalars f) :=
   ⟨_, extendRestrictScalarsAdj f⟩
 
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable instance {R : Type u₁} {S : Type u₂} [CommRing R] [CommRing S] (f : R →+* S) :
     CategoryTheory.IsRightAdjoint (restrictScalars f) :=
   ⟨_, extendRestrictScalarsAdj f⟩

--- a/Mathlib/Algebra/Category/ModuleCat/Monoidal/Basic.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Monoidal/Basic.lean
@@ -51,23 +51,23 @@ open TensorProduct
 attribute [local ext] TensorProduct.ext
 
 /-- (implementation) tensor product of R-modules -/
-def tensorObj (M N : ModuleCat R) : ModuleCat R :=
+noncomputable def tensorObj (M N : ModuleCat R) : ModuleCat R :=
   ModuleCat.of R (M ⊗[R] N)
 #align Module.monoidal_category.tensor_obj ModuleCat.MonoidalCategory.tensorObj
 
 /-- (implementation) tensor product of morphisms R-modules -/
-def tensorHom {M N M' N' : ModuleCat R} (f : M ⟶ N) (g : M' ⟶ N') :
+noncomputable def tensorHom {M N M' N' : ModuleCat R} (f : M ⟶ N) (g : M' ⟶ N') :
     tensorObj M M' ⟶ tensorObj N N' :=
   TensorProduct.map f g
 #align Module.monoidal_category.tensor_hom ModuleCat.MonoidalCategory.tensorHom
 
 /-- (implementation) left whiskering for R-modules -/
-def whiskerLeft (M : ModuleCat R) {N₁ N₂ : ModuleCat R} (f : N₁ ⟶ N₂) :
+noncomputable def whiskerLeft (M : ModuleCat R) {N₁ N₂ : ModuleCat R} (f : N₁ ⟶ N₂) :
     tensorObj M N₁ ⟶ tensorObj M N₂ :=
   f.lTensor M
 
 /-- (implementation) right whiskering for R-modules -/
-def whiskerRight {M₁ M₂ : ModuleCat R} (f : M₁ ⟶ M₂) (N : ModuleCat R) :
+noncomputable def whiskerRight {M₁ M₂ : ModuleCat R} (f : M₁ ⟶ M₂) (N : ModuleCat R) :
     tensorObj M₁ N ⟶ tensorObj M₂ N :=
   f.rTensor N
 
@@ -85,7 +85,7 @@ theorem tensor_comp {X₁ Y₁ Z₁ X₂ Y₂ Z₂ : ModuleCat R} (f₁ : X₁ �
 #align Module.monoidal_category.tensor_comp ModuleCat.MonoidalCategory.tensor_comp
 
 /-- (implementation) the associator for R-modules -/
-def associator (M : ModuleCat.{v} R) (N : ModuleCat.{w} R) (K : ModuleCat.{x} R) :
+noncomputable def associator (M : ModuleCat.{v} R) (N : ModuleCat.{w} R) (K : ModuleCat.{x} R) :
     tensorObj (tensorObj M N) K ≅ tensorObj M (tensorObj N K) :=
   (TensorProduct.assoc R M N K).toModuleIso
 #align Module.monoidal_category.associator ModuleCat.MonoidalCategory.associator
@@ -144,7 +144,7 @@ theorem pentagon (W X Y Z : ModuleCat R) :
 #align Module.monoidal_category.pentagon ModuleCat.MonoidalCategory.pentagon
 
 /-- (implementation) the left unitor for R-modules -/
-def leftUnitor (M : ModuleCat.{u} R) : ModuleCat.of R (R ⊗[R] M) ≅ M :=
+noncomputable def leftUnitor (M : ModuleCat.{u} R) : ModuleCat.of R (R ⊗[R] M) ≅ M :=
   (LinearEquiv.toModuleIso (TensorProduct.lid R M) : of R (R ⊗ M) ≅ of R M).trans (ofSelfIso M)
 #align Module.monoidal_category.left_unitor ModuleCat.MonoidalCategory.leftUnitor
 
@@ -163,7 +163,7 @@ theorem leftUnitor_naturality {M N : ModuleCat R} (f : M ⟶ N) :
 #align Module.monoidal_category.left_unitor_naturality ModuleCat.MonoidalCategory.leftUnitor_naturality
 
 /-- (implementation) the right unitor for R-modules -/
-def rightUnitor (M : ModuleCat.{u} R) : ModuleCat.of R (M ⊗[R] R) ≅ M :=
+noncomputable def rightUnitor (M : ModuleCat.{u} R) : ModuleCat.of R (M ⊗[R] R) ≅ M :=
   (LinearEquiv.toModuleIso (TensorProduct.rid R M) : of R (M ⊗ R) ≅ of R M).trans (ofSelfIso M)
 #align Module.monoidal_category.right_unitor ModuleCat.MonoidalCategory.rightUnitor
 
@@ -197,7 +197,8 @@ end MonoidalCategory
 
 open MonoidalCategory
 
-instance monoidalCategory : MonoidalCategory (ModuleCat.{u} R) := MonoidalCategory.ofTensorHom
+noncomputable instance monoidalCategory : MonoidalCategory (ModuleCat.{u} R) :=
+  MonoidalCategory.ofTensorHom
   -- data
   (tensorObj := MonoidalCategory.tensorObj)
   (tensorHom := @tensorHom _ _)

--- a/Mathlib/Algebra/Category/ModuleCat/Monoidal/Basic.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Monoidal/Basic.lean
@@ -51,22 +51,26 @@ open TensorProduct
 attribute [local ext] TensorProduct.ext
 
 /-- (implementation) tensor product of R-modules -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def tensorObj (M N : ModuleCat R) : ModuleCat R :=
   ModuleCat.of R (M ⊗[R] N)
 #align Module.monoidal_category.tensor_obj ModuleCat.MonoidalCategory.tensorObj
 
 /-- (implementation) tensor product of morphisms R-modules -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def tensorHom {M N M' N' : ModuleCat R} (f : M ⟶ N) (g : M' ⟶ N') :
     tensorObj M M' ⟶ tensorObj N N' :=
   TensorProduct.map f g
 #align Module.monoidal_category.tensor_hom ModuleCat.MonoidalCategory.tensorHom
 
 /-- (implementation) left whiskering for R-modules -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def whiskerLeft (M : ModuleCat R) {N₁ N₂ : ModuleCat R} (f : N₁ ⟶ N₂) :
     tensorObj M N₁ ⟶ tensorObj M N₂ :=
   f.lTensor M
 
 /-- (implementation) right whiskering for R-modules -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def whiskerRight {M₁ M₂ : ModuleCat R} (f : M₁ ⟶ M₂) (N : ModuleCat R) :
     tensorObj M₁ N ⟶ tensorObj M₂ N :=
   f.rTensor N
@@ -85,6 +89,7 @@ theorem tensor_comp {X₁ Y₁ Z₁ X₂ Y₂ Z₂ : ModuleCat R} (f₁ : X₁ �
 #align Module.monoidal_category.tensor_comp ModuleCat.MonoidalCategory.tensor_comp
 
 /-- (implementation) the associator for R-modules -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def associator (M : ModuleCat.{v} R) (N : ModuleCat.{w} R) (K : ModuleCat.{x} R) :
     tensorObj (tensorObj M N) K ≅ tensorObj M (tensorObj N K) :=
   (TensorProduct.assoc R M N K).toModuleIso
@@ -144,6 +149,7 @@ theorem pentagon (W X Y Z : ModuleCat R) :
 #align Module.monoidal_category.pentagon ModuleCat.MonoidalCategory.pentagon
 
 /-- (implementation) the left unitor for R-modules -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def leftUnitor (M : ModuleCat.{u} R) : ModuleCat.of R (R ⊗[R] M) ≅ M :=
   (LinearEquiv.toModuleIso (TensorProduct.lid R M) : of R (R ⊗ M) ≅ of R M).trans (ofSelfIso M)
 #align Module.monoidal_category.left_unitor ModuleCat.MonoidalCategory.leftUnitor
@@ -163,6 +169,7 @@ theorem leftUnitor_naturality {M N : ModuleCat R} (f : M ⟶ N) :
 #align Module.monoidal_category.left_unitor_naturality ModuleCat.MonoidalCategory.leftUnitor_naturality
 
 /-- (implementation) the right unitor for R-modules -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def rightUnitor (M : ModuleCat.{u} R) : ModuleCat.of R (M ⊗[R] R) ≅ M :=
   (LinearEquiv.toModuleIso (TensorProduct.rid R M) : of R (M ⊗ R) ≅ of R M).trans (ofSelfIso M)
 #align Module.monoidal_category.right_unitor ModuleCat.MonoidalCategory.rightUnitor
@@ -197,6 +204,7 @@ end MonoidalCategory
 
 open MonoidalCategory
 
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable instance monoidalCategory : MonoidalCategory (ModuleCat.{u} R) :=
   MonoidalCategory.ofTensorHom
   -- data

--- a/Mathlib/Algebra/Category/ModuleCat/Monoidal/Closed.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Monoidal/Closed.lean
@@ -25,7 +25,7 @@ variable {R : Type u} [CommRing R]
 /-- Auxiliary definition for the `MonoidalClosed` instance on `Module R`.
 (This is only a separate definition in order to speed up typechecking. )
 -/
-def monoidalClosedHomEquiv (M N P : ModuleCat.{u} R) :
+noncomputable def monoidalClosedHomEquiv (M N P : ModuleCat.{u} R) :
     ((MonoidalCategory.tensorLeft M).obj N ⟶ P) ≃
       (N ⟶ ((linearCoyoneda R (ModuleCat R)).obj (op M)).obj P) where
   toFun f := LinearMap.compr₂ (TensorProduct.mk R N M) ((β_ N M).hom ≫ f)
@@ -40,7 +40,7 @@ def monoidalClosedHomEquiv (M N P : ModuleCat.{u} R) :
 set_option linter.uppercaseLean3 false in
 #align Module.monoidal_closed_hom_equiv ModuleCat.monoidalClosedHomEquiv
 
-instance : MonoidalClosed (ModuleCat.{u} R) where
+noncomputable instance : MonoidalClosed (ModuleCat.{u} R) where
   closed M :=
     { isAdj :=
         { right := (linearCoyoneda R (ModuleCat.{u} R)).obj (op M)

--- a/Mathlib/Algebra/Category/ModuleCat/Monoidal/Closed.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Monoidal/Closed.lean
@@ -25,6 +25,7 @@ variable {R : Type u} [CommRing R]
 /-- Auxiliary definition for the `MonoidalClosed` instance on `Module R`.
 (This is only a separate definition in order to speed up typechecking. )
 -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def monoidalClosedHomEquiv (M N P : ModuleCat.{u} R) :
     ((MonoidalCategory.tensorLeft M).obj N ⟶ P) ≃
       (N ⟶ ((linearCoyoneda R (ModuleCat R)).obj (op M)).obj P) where
@@ -40,6 +41,7 @@ noncomputable def monoidalClosedHomEquiv (M N P : ModuleCat.{u} R) :
 set_option linter.uppercaseLean3 false in
 #align Module.monoidal_closed_hom_equiv ModuleCat.monoidalClosedHomEquiv
 
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable instance : MonoidalClosed (ModuleCat.{u} R) where
   closed M :=
     { isAdj :=

--- a/Mathlib/Algebra/Category/ModuleCat/Monoidal/Symmetric.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Monoidal/Symmetric.lean
@@ -22,7 +22,7 @@ namespace ModuleCat
 variable {R : Type u} [CommRing R]
 
 /-- (implementation) the braiding for R-modules -/
-def braiding (M N : ModuleCat.{u} R) : M ⊗ N ≅ N ⊗ M :=
+noncomputable def braiding (M N : ModuleCat.{u} R) : M ⊗ N ≅ N ⊗ M :=
   LinearEquiv.toModuleIso (TensorProduct.comm R M N)
 set_option linter.uppercaseLean3 false in
 #align Module.braiding ModuleCat.braiding
@@ -62,7 +62,7 @@ set_option linter.uppercaseLean3 false in
 attribute [local ext] TensorProduct.ext
 
 /-- The symmetric monoidal structure on `Module R`. -/
-instance symmetricCategory : SymmetricCategory (ModuleCat.{u} R) where
+noncomputable instance symmetricCategory : SymmetricCategory (ModuleCat.{u} R) where
   braiding := braiding
   braiding_naturality f g := braiding_naturality f g
   hexagon_forward := hexagon_forward

--- a/Mathlib/Algebra/Category/ModuleCat/Monoidal/Symmetric.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Monoidal/Symmetric.lean
@@ -22,6 +22,7 @@ namespace ModuleCat
 variable {R : Type u} [CommRing R]
 
 /-- (implementation) the braiding for R-modules -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def braiding (M N : ModuleCat.{u} R) : M ⊗ N ≅ N ⊗ M :=
   LinearEquiv.toModuleIso (TensorProduct.comm R M N)
 set_option linter.uppercaseLean3 false in
@@ -62,6 +63,7 @@ set_option linter.uppercaseLean3 false in
 attribute [local ext] TensorProduct.ext
 
 /-- The symmetric monoidal structure on `Module R`. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable instance symmetricCategory : SymmetricCategory (ModuleCat.{u} R) where
   braiding := braiding
   braiding_naturality f g := braiding_naturality f g

--- a/Mathlib/Algebra/Category/Ring/Constructions.lean
+++ b/Mathlib/Algebra/Category/Ring/Constructions.lean
@@ -36,7 +36,7 @@ section Pushout
 variable {R A B : CommRingCat.{u}} (f : R ⟶ A) (g : R ⟶ B)
 
 /-- The explicit cocone with tensor products as the fibered product in `CommRingCat`. -/
-def pushoutCocone : Limits.PushoutCocone f g := by
+noncomputable def pushoutCocone : Limits.PushoutCocone f g := by
   letI := RingHom.toAlgebra f
   letI := RingHom.toAlgebra g
   fapply Limits.PushoutCocone.mk
@@ -81,7 +81,7 @@ set_option linter.uppercaseLean3 false in
 #align CommRing.pushout_cocone_X CommRingCat.pushoutCocone_pt
 
 /-- Verify that the `pushout_cocone` is indeed the colimit. -/
-def pushoutCoconeIsColimit : Limits.IsColimit (pushoutCocone f g) :=
+noncomputable def pushoutCoconeIsColimit : Limits.IsColimit (pushoutCocone f g) :=
   Limits.PushoutCocone.isColimitAux' _ fun s => by
     letI := RingHom.toAlgebra f
     letI := RingHom.toAlgebra g

--- a/Mathlib/Algebra/Category/Ring/Constructions.lean
+++ b/Mathlib/Algebra/Category/Ring/Constructions.lean
@@ -36,6 +36,7 @@ section Pushout
 variable {R A B : CommRingCat.{u}} (f : R ⟶ A) (g : R ⟶ B)
 
 /-- The explicit cocone with tensor products as the fibered product in `CommRingCat`. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def pushoutCocone : Limits.PushoutCocone f g := by
   letI := RingHom.toAlgebra f
   letI := RingHom.toAlgebra g
@@ -81,6 +82,7 @@ set_option linter.uppercaseLean3 false in
 #align CommRing.pushout_cocone_X CommRingCat.pushoutCocone_pt
 
 /-- Verify that the `pushout_cocone` is indeed the colimit. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def pushoutCoconeIsColimit : Limits.IsColimit (pushoutCocone f g) :=
   Limits.PushoutCocone.isColimitAux' _ fun s => by
     letI := RingHom.toAlgebra f

--- a/Mathlib/Algebra/Lie/BaseChange.lean
+++ b/Mathlib/Algebra/Lie/BaseChange.lean
@@ -38,6 +38,7 @@ namespace ExtendScalars
 variable [CommRing R] [CommRing A] [Algebra R A] [LieRing L] [LieAlgebra R L]
 
 /-- The Lie bracket on the extension of a Lie algebra `L` over `R` by an algebra `A` over `R`. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 private noncomputable def bracket' : A ⊗[R] L →ₗ[A] A ⊗[R] L →ₗ[A] A ⊗[R] L :=
   TensorProduct.curry <|
     TensorProduct.AlgebraTensorModule.map
@@ -48,6 +49,7 @@ private noncomputable def bracket' : A ⊗[R] L →ₗ[A] A ⊗[R] L →ₗ[A] A
 private theorem bracket'_tmul (s t : A) (x y : L) :
     bracket' R A L (s ⊗ₜ[R] x) (t ⊗ₜ[R] y) = (s * t) ⊗ₜ ⁅x, y⁆ := rfl
 
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable instance : Bracket (A ⊗[R] L) (A ⊗[R] L) where bracket x y := bracket' R A L x y
 
 private theorem bracket_def (x y : A ⊗[R] L) : ⁅x, y⁆ = bracket' R A L x y :=
@@ -103,12 +105,14 @@ private theorem bracket_leibniz_lie (x y z : A ⊗[R] L) :
     rw [map_add, LinearMap.add_apply, LinearMap.add_apply, LinearMap.add_apply, map_add, map_add,
       LinearMap.add_apply, h₁, h₂, add_add_add_comm]
 
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable instance : LieRing (A ⊗[R] L) where
   add_lie x y z := by simp only [bracket_def, LinearMap.add_apply, LinearMap.map_add]
   lie_add x y z := by simp only [bracket_def, LinearMap.map_add]
   lie_self := bracket_lie_self R A L
   leibniz_lie := bracket_leibniz_lie R A L
 
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable instance lieAlgebra :
     LieAlgebra A (A ⊗[R] L) where lie_smul _a _x _y := map_smul _ _ _
 #align lie_algebra.extend_scalars.lie_algebra LieAlgebra.ExtendScalars.lieAlgebra

--- a/Mathlib/Algebra/Lie/BaseChange.lean
+++ b/Mathlib/Algebra/Lie/BaseChange.lean
@@ -38,7 +38,7 @@ namespace ExtendScalars
 variable [CommRing R] [CommRing A] [Algebra R A] [LieRing L] [LieAlgebra R L]
 
 /-- The Lie bracket on the extension of a Lie algebra `L` over `R` by an algebra `A` over `R`. -/
-private def bracket' : A ⊗[R] L →ₗ[A] A ⊗[R] L →ₗ[A] A ⊗[R] L :=
+private noncomputable def bracket' : A ⊗[R] L →ₗ[A] A ⊗[R] L →ₗ[A] A ⊗[R] L :=
   TensorProduct.curry <|
     TensorProduct.AlgebraTensorModule.map
         (LinearMap.mul' A A) (LieModule.toModuleHom R L L : L ⊗[R] L →ₗ[R] L) ∘ₗ
@@ -48,7 +48,7 @@ private def bracket' : A ⊗[R] L →ₗ[A] A ⊗[R] L →ₗ[A] A ⊗[R] L :=
 private theorem bracket'_tmul (s t : A) (x y : L) :
     bracket' R A L (s ⊗ₜ[R] x) (t ⊗ₜ[R] y) = (s * t) ⊗ₜ ⁅x, y⁆ := rfl
 
-instance : Bracket (A ⊗[R] L) (A ⊗[R] L) where bracket x y := bracket' R A L x y
+noncomputable instance : Bracket (A ⊗[R] L) (A ⊗[R] L) where bracket x y := bracket' R A L x y
 
 private theorem bracket_def (x y : A ⊗[R] L) : ⁅x, y⁆ = bracket' R A L x y :=
   rfl
@@ -103,13 +103,13 @@ private theorem bracket_leibniz_lie (x y z : A ⊗[R] L) :
     rw [map_add, LinearMap.add_apply, LinearMap.add_apply, LinearMap.add_apply, map_add, map_add,
       LinearMap.add_apply, h₁, h₂, add_add_add_comm]
 
-instance : LieRing (A ⊗[R] L) where
+noncomputable instance : LieRing (A ⊗[R] L) where
   add_lie x y z := by simp only [bracket_def, LinearMap.add_apply, LinearMap.map_add]
   lie_add x y z := by simp only [bracket_def, LinearMap.map_add]
   lie_self := bracket_lie_self R A L
   leibniz_lie := bracket_leibniz_lie R A L
 
-instance lieAlgebra : LieAlgebra A (A ⊗[R] L) where lie_smul _a _x _y := map_smul _ _ _
+noncomputable instance lieAlgebra : LieAlgebra A (A ⊗[R] L) where lie_smul _a _x _y := map_smul _ _ _
 #align lie_algebra.extend_scalars.lie_algebra LieAlgebra.ExtendScalars.lieAlgebra
 
 end ExtendScalars

--- a/Mathlib/Algebra/Lie/BaseChange.lean
+++ b/Mathlib/Algebra/Lie/BaseChange.lean
@@ -109,7 +109,8 @@ noncomputable instance : LieRing (A ⊗[R] L) where
   lie_self := bracket_lie_self R A L
   leibniz_lie := bracket_leibniz_lie R A L
 
-noncomputable instance lieAlgebra : LieAlgebra A (A ⊗[R] L) where lie_smul _a _x _y := map_smul _ _ _
+noncomputable instance lieAlgebra :
+    LieAlgebra A (A ⊗[R] L) where lie_smul _a _x _y := map_smul _ _ _
 #align lie_algebra.extend_scalars.lie_algebra LieAlgebra.ExtendScalars.lieAlgebra
 
 end ExtendScalars

--- a/Mathlib/Algebra/Lie/TensorProduct.lean
+++ b/Mathlib/Algebra/Lie/TensorProduct.lean
@@ -47,11 +47,13 @@ attribute [local ext] TensorProduct.ext
 /-- It is useful to define the bracket via this auxiliary function so that we have a type-theoretic
 expression of the fact that `L` acts by linear endomorphisms. It simplifies the proofs in
 `lieRingModule` below. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def hasBracketAux (x : L) : Module.End R (M ⊗[R] N) :=
   (toEndomorphism R L M x).rTensor N + (toEndomorphism R L N x).lTensor M
 #align tensor_product.lie_module.has_bracket_aux TensorProduct.LieModule.hasBracketAux
 
 /-- The tensor product of two Lie modules is a Lie ring module. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable instance lieRingModule : LieRingModule L (M ⊗[R] N) where
   bracket x := hasBracketAux x
   add_lie x y t := by
@@ -91,6 +93,7 @@ variable (R L M N P Q)
 
 /-- The universal property for tensor product of modules of a Lie algebra: the `R`-linear
 tensor-hom adjunction is equivariant with respect to the `L` action. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def lift : (M →ₗ[R] N →ₗ[R] P) ≃ₗ⁅R,L⁆ M ⊗[R] N →ₗ[R] P :=
   { TensorProduct.lift.equiv R M N P with
     map_lie' := fun {x f} => by
@@ -109,6 +112,7 @@ theorem lift_apply (f : M →ₗ[R] N →ₗ[R] P) (m : M) (n : N) : lift R L M 
 
 Note that maps `f` of type `M →ₗ⁅R,L⁆ N →ₗ[R] P` are exactly those `R`-bilinear maps satisfying
 `⁅x, f m n⁆ = f ⁅x, m⁆ n + f m ⁅x, n⁆` for all `x, m, n` (see e.g, `LieModuleHom.map_lie₂`). -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def liftLie : (M →ₗ⁅R,L⁆ N →ₗ[R] P) ≃ₗ[R] M ⊗[R] N →ₗ⁅R,L⁆ P :=
   maxTrivLinearMapEquivLieModuleHom.symm ≪≫ₗ ↑(maxTrivEquiv (lift R L M N P)) ≪≫ₗ
     maxTrivLinearMapEquivLieModuleHom
@@ -134,6 +138,7 @@ variable {R L M N P Q}
 
 /-- A pair of Lie module morphisms `f : M → P` and `g : N → Q`, induce a Lie module morphism:
 `M ⊗ N → P ⊗ Q`. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable nonrec def map (f : M →ₗ⁅R,L⁆ P) (g : N →ₗ⁅R,L⁆ Q) : M ⊗[R] N →ₗ⁅R,L⁆ P ⊗[R] Q :=
   { map (f : M →ₗ[R] P) (g : N →ₗ[R] Q) with
     map_lie' := fun {x t} => by
@@ -159,6 +164,7 @@ nonrec theorem map_tmul (f : M →ₗ⁅R,L⁆ P) (g : N →ₗ⁅R,L⁆ Q) (m :
 #align tensor_product.lie_module.map_tmul TensorProduct.LieModule.map_tmul
 
 /-- Given Lie submodules `M' ⊆ M` and `N' ⊆ N`, this is the natural map: `M' ⊗ N' → M ⊗ N`. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def mapIncl (M' : LieSubmodule R L M) (N' : LieSubmodule R L N) :
     M' ⊗[R] N' →ₗ⁅R,L⁆ M ⊗[R] N :=
   map M'.incl N'.incl
@@ -185,6 +191,7 @@ variable [LieRing L] [LieAlgebra R L]
 variable [AddCommGroup M] [Module R M] [LieRingModule L M] [LieModule R L M]
 
 /-- The action of the Lie algebra on one of its modules, regarded as a morphism of Lie modules. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def toModuleHom : L ⊗[R] M →ₗ⁅R,L⁆ M :=
   TensorProduct.LieModule.liftLie R L L M M
     { (toEndomorphism R L M : L →ₗ[R] M →ₗ[R] M) with

--- a/Mathlib/Algebra/Lie/TensorProduct.lean
+++ b/Mathlib/Algebra/Lie/TensorProduct.lean
@@ -47,12 +47,12 @@ attribute [local ext] TensorProduct.ext
 /-- It is useful to define the bracket via this auxiliary function so that we have a type-theoretic
 expression of the fact that `L` acts by linear endomorphisms. It simplifies the proofs in
 `lieRingModule` below. -/
-def hasBracketAux (x : L) : Module.End R (M ⊗[R] N) :=
+noncomputable def hasBracketAux (x : L) : Module.End R (M ⊗[R] N) :=
   (toEndomorphism R L M x).rTensor N + (toEndomorphism R L N x).lTensor M
 #align tensor_product.lie_module.has_bracket_aux TensorProduct.LieModule.hasBracketAux
 
 /-- The tensor product of two Lie modules is a Lie ring module. -/
-instance lieRingModule : LieRingModule L (M ⊗[R] N) where
+noncomputable instance lieRingModule : LieRingModule L (M ⊗[R] N) where
   bracket x := hasBracketAux x
   add_lie x y t := by
     simp only [hasBracketAux, LinearMap.lTensor_add, LinearMap.rTensor_add, LieHom.map_add,
@@ -91,7 +91,7 @@ variable (R L M N P Q)
 
 /-- The universal property for tensor product of modules of a Lie algebra: the `R`-linear
 tensor-hom adjunction is equivariant with respect to the `L` action. -/
-def lift : (M →ₗ[R] N →ₗ[R] P) ≃ₗ⁅R,L⁆ M ⊗[R] N →ₗ[R] P :=
+noncomputable def lift : (M →ₗ[R] N →ₗ[R] P) ≃ₗ⁅R,L⁆ M ⊗[R] N →ₗ[R] P :=
   { TensorProduct.lift.equiv R M N P with
     map_lie' := fun {x f} => by
       ext m n
@@ -109,7 +109,7 @@ theorem lift_apply (f : M →ₗ[R] N →ₗ[R] P) (m : M) (n : N) : lift R L M 
 
 Note that maps `f` of type `M →ₗ⁅R,L⁆ N →ₗ[R] P` are exactly those `R`-bilinear maps satisfying
 `⁅x, f m n⁆ = f ⁅x, m⁆ n + f m ⁅x, n⁆` for all `x, m, n` (see e.g, `LieModuleHom.map_lie₂`). -/
-def liftLie : (M →ₗ⁅R,L⁆ N →ₗ[R] P) ≃ₗ[R] M ⊗[R] N →ₗ⁅R,L⁆ P :=
+noncomputable def liftLie : (M →ₗ⁅R,L⁆ N →ₗ[R] P) ≃ₗ[R] M ⊗[R] N →ₗ⁅R,L⁆ P :=
   maxTrivLinearMapEquivLieModuleHom.symm ≪≫ₗ ↑(maxTrivEquiv (lift R L M N P)) ≪≫ₗ
     maxTrivLinearMapEquivLieModuleHom
 #align tensor_product.lie_module.lift_lie TensorProduct.LieModule.liftLie
@@ -134,7 +134,7 @@ variable {R L M N P Q}
 
 /-- A pair of Lie module morphisms `f : M → P` and `g : N → Q`, induce a Lie module morphism:
 `M ⊗ N → P ⊗ Q`. -/
-nonrec def map (f : M →ₗ⁅R,L⁆ P) (g : N →ₗ⁅R,L⁆ Q) : M ⊗[R] N →ₗ⁅R,L⁆ P ⊗[R] Q :=
+noncomputable nonrec def map (f : M →ₗ⁅R,L⁆ P) (g : N →ₗ⁅R,L⁆ Q) : M ⊗[R] N →ₗ⁅R,L⁆ P ⊗[R] Q :=
   { map (f : M →ₗ[R] P) (g : N →ₗ[R] Q) with
     map_lie' := fun {x t} => by
       simp only [LinearMap.toFun_eq_coe]
@@ -159,7 +159,8 @@ nonrec theorem map_tmul (f : M →ₗ⁅R,L⁆ P) (g : N →ₗ⁅R,L⁆ Q) (m :
 #align tensor_product.lie_module.map_tmul TensorProduct.LieModule.map_tmul
 
 /-- Given Lie submodules `M' ⊆ M` and `N' ⊆ N`, this is the natural map: `M' ⊗ N' → M ⊗ N`. -/
-def mapIncl (M' : LieSubmodule R L M) (N' : LieSubmodule R L N) : M' ⊗[R] N' →ₗ⁅R,L⁆ M ⊗[R] N :=
+noncomputable def mapIncl (M' : LieSubmodule R L M) (N' : LieSubmodule R L N) :
+    M' ⊗[R] N' →ₗ⁅R,L⁆ M ⊗[R] N :=
   map M'.incl N'.incl
 #align tensor_product.lie_module.map_incl TensorProduct.LieModule.mapIncl
 
@@ -184,7 +185,7 @@ variable [LieRing L] [LieAlgebra R L]
 variable [AddCommGroup M] [Module R M] [LieRingModule L M] [LieModule R L M]
 
 /-- The action of the Lie algebra on one of its modules, regarded as a morphism of Lie modules. -/
-def toModuleHom : L ⊗[R] M →ₗ⁅R,L⁆ M :=
+noncomputable def toModuleHom : L ⊗[R] M →ₗ⁅R,L⁆ M :=
   TensorProduct.LieModule.liftLie R L L M M
     { (toEndomorphism R L M : L →ₗ[R] M →ₗ[R] M) with
       map_lie' := fun {x m} => by ext n; simp [LieRing.of_associative_ring_bracket] }

--- a/Mathlib/Algebra/Lie/Weights.lean
+++ b/Mathlib/Algebra/Lie/Weights.lean
@@ -339,7 +339,7 @@ def rootSpaceWeightSpaceProductAux {χ₁ χ₂ χ₃ : H → R} (hχ : χ₁ + 
 -- See https://github.com/leanprover-community/mathlib4/issues/5028
 /-- Given a nilpotent Lie subalgebra `H ⊆ L` together with `χ₁ χ₂ : H → R`, there is a natural
 `R`-bilinear product of root vectors and weight vectors, compatible with the actions of `H`. -/
-def rootSpaceWeightSpaceProduct (χ₁ χ₂ χ₃ : H → R) (hχ : χ₁ + χ₂ = χ₃) :
+noncomputable def rootSpaceWeightSpaceProduct (χ₁ χ₂ χ₃ : H → R) (hχ : χ₁ + χ₂ = χ₃) :
     rootSpace H χ₁ ⊗[R] weightSpace M χ₂ →ₗ⁅R,H⁆ weightSpace M χ₃ :=
   liftLie R H (rootSpace H χ₁) (weightSpace M χ₂) (weightSpace M χ₃)
     { toLinearMap := rootSpaceWeightSpaceProductAux R L H M hχ
@@ -361,7 +361,7 @@ theorem coe_rootSpaceWeightSpaceProduct_tmul (χ₁ χ₂ χ₃ : H → R) (hχ 
 
 /-- Given a nilpotent Lie subalgebra `H ⊆ L` together with `χ₁ χ₂ : H → R`, there is a natural
 `R`-bilinear product of root vectors, compatible with the actions of `H`. -/
-def rootSpaceProduct (χ₁ χ₂ χ₃ : H → R) (hχ : χ₁ + χ₂ = χ₃) :
+noncomputable def rootSpaceProduct (χ₁ χ₂ χ₃ : H → R) (hχ : χ₁ + χ₂ = χ₃) :
     rootSpace H χ₁ ⊗[R] rootSpace H χ₂ →ₗ⁅R,H⁆ rootSpace H χ₃ :=
   rootSpaceWeightSpaceProduct R L H L χ₁ χ₂ χ₃ hχ
 #align lie_algebra.root_space_product LieAlgebra.rootSpaceProduct

--- a/Mathlib/Algebra/Lie/Weights.lean
+++ b/Mathlib/Algebra/Lie/Weights.lean
@@ -339,6 +339,7 @@ def rootSpaceWeightSpaceProductAux {χ₁ χ₂ χ₃ : H → R} (hχ : χ₁ + 
 -- See https://github.com/leanprover-community/mathlib4/issues/5028
 /-- Given a nilpotent Lie subalgebra `H ⊆ L` together with `χ₁ χ₂ : H → R`, there is a natural
 `R`-bilinear product of root vectors and weight vectors, compatible with the actions of `H`. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def rootSpaceWeightSpaceProduct (χ₁ χ₂ χ₃ : H → R) (hχ : χ₁ + χ₂ = χ₃) :
     rootSpace H χ₁ ⊗[R] weightSpace M χ₂ →ₗ⁅R,H⁆ weightSpace M χ₃ :=
   liftLie R H (rootSpace H χ₁) (weightSpace M χ₂) (weightSpace M χ₃)
@@ -361,6 +362,7 @@ theorem coe_rootSpaceWeightSpaceProduct_tmul (χ₁ χ₂ χ₃ : H → R) (hχ 
 
 /-- Given a nilpotent Lie subalgebra `H ⊆ L` together with `χ₁ χ₂ : H → R`, there is a natural
 `R`-bilinear product of root vectors, compatible with the actions of `H`. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def rootSpaceProduct (χ₁ χ₂ χ₃ : H → R) (hχ : χ₁ + χ₂ = χ₃) :
     rootSpace H χ₁ ⊗[R] rootSpace H χ₂ →ₗ⁅R,H⁆ rootSpace H χ₃ :=
   rootSpaceWeightSpaceProduct R L H L χ₁ χ₂ χ₃ hχ

--- a/Mathlib/CategoryTheory/Monoidal/Internal/Module.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Internal/Module.lean
@@ -41,7 +41,7 @@ namespace MonModuleEquivalenceAlgebra
 -- Porting note : `simps(!)` doesn't work, I guess we will see what `simp` lemmas are needed and
 -- add them manually
 -- @[simps!]
-instance Ring_of_Mon_ (A : Mon_ (ModuleCat.{u} R)) : Ring A.X :=
+noncomputable instance Ring_of_Mon_ (A : Mon_ (ModuleCat.{u} R)) : Ring A.X :=
   { (inferInstance : AddCommGroup A.X) with
     one := A.one (1 : R)
     mul := fun x y => A.mul (x ⊗ₜ y)
@@ -93,7 +93,7 @@ theorem algebraMap (A : Mon_ (ModuleCat.{u} R)) (r : R) : algebraMap R A.X r = A
 /-- Converting a monoid object in `ModuleCat R` to a bundled algebra.
 -/
 @[simps!]
-def functor : Mon_ (ModuleCat.{u} R) ⥤ AlgebraCat R where
+noncomputable def functor : Mon_ (ModuleCat.{u} R) ⥤ AlgebraCat R where
   obj A := AlgebraCat.of R A.X
   map {A B} f :=
     { f.hom.toAddMonoidHom with
@@ -106,7 +106,7 @@ def functor : Mon_ (ModuleCat.{u} R) ⥤ AlgebraCat R where
 /-- Converting a bundled algebra to a monoid object in `ModuleCat R`.
 -/
 @[simps]
-def inverseObj (A : AlgebraCat.{u} R) : Mon_ (ModuleCat.{u} R) where
+noncomputable def inverseObj (A : AlgebraCat.{u} R) : Mon_ (ModuleCat.{u} R) where
   X := ModuleCat.of R A
   one := Algebra.linearMap R A
   mul := LinearMap.mul' R A
@@ -156,7 +156,7 @@ def inverseObj (A : AlgebraCat.{u} R) : Mon_ (ModuleCat.{u} R) where
 /-- Converting a bundled algebra to a monoid object in `ModuleCat R`.
 -/
 @[simps]
-def inverse : AlgebraCat.{u} R ⥤ Mon_ (ModuleCat.{u} R) where
+noncomputable def inverse : AlgebraCat.{u} R ⥤ Mon_ (ModuleCat.{u} R) where
   obj := inverseObj
   map f :=
     { hom := f.toLinearMap
@@ -172,7 +172,7 @@ set_option maxHeartbeats 500000 in
 /-- The category of internal monoid objects in `ModuleCat R`
 is equivalent to the category of "native" bundled `R`-algebras.
 -/
-def monModuleEquivalenceAlgebra : Mon_ (ModuleCat.{u} R) ≌ AlgebraCat R where
+noncomputable def monModuleEquivalenceAlgebra : Mon_ (ModuleCat.{u} R) ≌ AlgebraCat R where
   functor := functor
   inverse := inverse
   unitIso :=
@@ -226,7 +226,7 @@ def monModuleEquivalenceAlgebra : Mon_ (ModuleCat.{u} R) ≌ AlgebraCat R where
 /-- The equivalence `Mon_ (ModuleCat R) ≌ AlgebraCat R`
 is naturally compatible with the forgetful functors to `ModuleCat R`.
 -/
-def monModuleEquivalenceAlgebraForget :
+noncomputable def monModuleEquivalenceAlgebraForget :
     MonModuleEquivalenceAlgebra.functor ⋙ forget₂ (AlgebraCat.{u} R) (ModuleCat.{u} R) ≅
       Mon_.forget (ModuleCat.{u} R) :=
   NatIso.ofComponents

--- a/Mathlib/CategoryTheory/Monoidal/Internal/Module.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Internal/Module.lean
@@ -41,6 +41,7 @@ namespace MonModuleEquivalenceAlgebra
 -- Porting note : `simps(!)` doesn't work, I guess we will see what `simp` lemmas are needed and
 -- add them manually
 -- @[simps!]
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable instance Ring_of_Mon_ (A : Mon_ (ModuleCat.{u} R)) : Ring A.X :=
   { (inferInstance : AddCommGroup A.X) with
     one := A.one (1 : R)
@@ -93,6 +94,7 @@ theorem algebraMap (A : Mon_ (ModuleCat.{u} R)) (r : R) : algebraMap R A.X r = A
 /-- Converting a monoid object in `ModuleCat R` to a bundled algebra.
 -/
 @[simps!]
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def functor : Mon_ (ModuleCat.{u} R) ⥤ AlgebraCat R where
   obj A := AlgebraCat.of R A.X
   map {A B} f :=
@@ -106,6 +108,7 @@ noncomputable def functor : Mon_ (ModuleCat.{u} R) ⥤ AlgebraCat R where
 /-- Converting a bundled algebra to a monoid object in `ModuleCat R`.
 -/
 @[simps]
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def inverseObj (A : AlgebraCat.{u} R) : Mon_ (ModuleCat.{u} R) where
   X := ModuleCat.of R A
   one := Algebra.linearMap R A
@@ -156,6 +159,7 @@ noncomputable def inverseObj (A : AlgebraCat.{u} R) : Mon_ (ModuleCat.{u} R) whe
 /-- Converting a bundled algebra to a monoid object in `ModuleCat R`.
 -/
 @[simps]
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def inverse : AlgebraCat.{u} R ⥤ Mon_ (ModuleCat.{u} R) where
   obj := inverseObj
   map f :=
@@ -172,6 +176,7 @@ set_option maxHeartbeats 500000 in
 /-- The category of internal monoid objects in `ModuleCat R`
 is equivalent to the category of "native" bundled `R`-algebras.
 -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def monModuleEquivalenceAlgebra : Mon_ (ModuleCat.{u} R) ≌ AlgebraCat R where
   functor := functor
   inverse := inverse
@@ -226,6 +231,7 @@ noncomputable def monModuleEquivalenceAlgebra : Mon_ (ModuleCat.{u} R) ≌ Algeb
 /-- The equivalence `Mon_ (ModuleCat R) ≌ AlgebraCat R`
 is naturally compatible with the forgetful functors to `ModuleCat R`.
 -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def monModuleEquivalenceAlgebraForget :
     MonModuleEquivalenceAlgebra.functor ⋙ forget₂ (AlgebraCat.{u} R) (ModuleCat.{u} R) ≅
       Mon_.forget (ModuleCat.{u} R) :=

--- a/Mathlib/Data/Matrix/Kronecker.lean
+++ b/Mathlib/Data/Matrix/Kronecker.lean
@@ -434,7 +434,7 @@ variable [Module R α] [Module R β] [Module R γ]
 /-- The Kronecker tensor product. This is just a shorthand for `kroneckerMap (⊗ₜ)`.
 Prefer the notation `⊗ₖₜ` rather than this definition. -/
 @[simp]
-def kroneckerTMul : Matrix l m α → Matrix n p β → Matrix (l × n) (m × p) (α ⊗[R] β) :=
+noncomputable def kroneckerTMul : Matrix l m α → Matrix n p β → Matrix (l × n) (m × p) (α ⊗[R] β) :=
   kroneckerMap (· ⊗ₜ ·)
 #align matrix.kronecker_tmul Matrix.kroneckerTMul
 
@@ -452,7 +452,7 @@ theorem kroneckerTMul_apply (A : Matrix l m α) (B : Matrix n p β) (i₁ i₂ j
 #align matrix.kronecker_tmul_apply Matrix.kroneckerTMul_apply
 
 /-- `Matrix.kronecker` as a bilinear map. -/
-def kroneckerTMulBilinear :
+noncomputable def kroneckerTMulBilinear :
     Matrix l m α →ₗ[R] Matrix n p β →ₗ[R] Matrix (l × n) (m × p) (α ⊗[R] β) :=
   kroneckerMapBilinear (TensorProduct.mk R α β)
 #align matrix.kronecker_tmul_bilinear Matrix.kroneckerTMulBilinear

--- a/Mathlib/Data/Matrix/Kronecker.lean
+++ b/Mathlib/Data/Matrix/Kronecker.lean
@@ -434,6 +434,7 @@ variable [Module R α] [Module R β] [Module R γ]
 /-- The Kronecker tensor product. This is just a shorthand for `kroneckerMap (⊗ₜ)`.
 Prefer the notation `⊗ₖₜ` rather than this definition. -/
 @[simp]
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def kroneckerTMul : Matrix l m α → Matrix n p β → Matrix (l × n) (m × p) (α ⊗[R] β) :=
   kroneckerMap (· ⊗ₜ ·)
 #align matrix.kronecker_tmul Matrix.kroneckerTMul
@@ -452,6 +453,7 @@ theorem kroneckerTMul_apply (A : Matrix l m α) (B : Matrix n p β) (i₁ i₂ j
 #align matrix.kronecker_tmul_apply Matrix.kroneckerTMul_apply
 
 /-- `Matrix.kronecker` as a bilinear map. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def kroneckerTMulBilinear :
     Matrix l m α →ₗ[R] Matrix n p β →ₗ[R] Matrix (l × n) (m × p) (α ⊗[R] β) :=
   kroneckerMapBilinear (TensorProduct.mk R α β)

--- a/Mathlib/LinearAlgebra/Alternating.lean
+++ b/Mathlib/LinearAlgebra/Alternating.lean
@@ -999,6 +999,7 @@ open Equiv
 variable [DecidableEq ιa] [DecidableEq ιb]
 
 /-- summand used in `AlternatingMap.domCoprod` -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def domCoprod.summand (a : AlternatingMap R' Mᵢ N₁ ιa)
     (b : AlternatingMap R' Mᵢ N₂ ιb)
     (σ : Perm.ModSumCongr ιa ιb) : MultilinearMap R' (fun _ : Sum ιa ιb => Mᵢ) (N₁ ⊗[R'] N₂) :=
@@ -1111,6 +1112,7 @@ The specialized version can be obtained by combining this definition with `finSu
 `LinearMap.mul'`.
 -/
 @[simps]
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def domCoprod (a : AlternatingMap R' Mᵢ N₁ ιa) (b : AlternatingMap R' Mᵢ N₂ ιb) :
     AlternatingMap R' Mᵢ (N₁ ⊗[R'] N₂) (Sum ιa ιb) :=
   { ∑ σ : Perm.ModSumCongr ιa ιb, domCoprod.summand a b σ with
@@ -1135,6 +1137,7 @@ theorem domCoprod_coe (a : AlternatingMap R' Mᵢ N₁ ιa) (b : AlternatingMap 
 
 /-- A more bundled version of `AlternatingMap.domCoprod` that maps
 `((ι₁ → N) → N₁) ⊗ ((ι₂ → N) → N₂)` to `(ι₁ ⊕ ι₂ → N) → N₁ ⊗ N₂`. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def domCoprod' :
     AlternatingMap R' Mᵢ N₁ ιa ⊗[R'] AlternatingMap R' Mᵢ N₂ ιb →ₗ[R']
       AlternatingMap R' Mᵢ (N₁ ⊗[R'] N₂) (Sum ιa ιb) :=

--- a/Mathlib/LinearAlgebra/Alternating.lean
+++ b/Mathlib/LinearAlgebra/Alternating.lean
@@ -999,7 +999,8 @@ open Equiv
 variable [DecidableEq ιa] [DecidableEq ιb]
 
 /-- summand used in `AlternatingMap.domCoprod` -/
-def domCoprod.summand (a : AlternatingMap R' Mᵢ N₁ ιa) (b : AlternatingMap R' Mᵢ N₂ ιb)
+noncomputable def domCoprod.summand (a : AlternatingMap R' Mᵢ N₁ ιa)
+    (b : AlternatingMap R' Mᵢ N₂ ιb)
     (σ : Perm.ModSumCongr ιa ιb) : MultilinearMap R' (fun _ : Sum ιa ιb => Mᵢ) (N₁ ⊗[R'] N₂) :=
   Quotient.liftOn' σ
     (fun σ =>
@@ -1110,7 +1111,7 @@ The specialized version can be obtained by combining this definition with `finSu
 `LinearMap.mul'`.
 -/
 @[simps]
-def domCoprod (a : AlternatingMap R' Mᵢ N₁ ιa) (b : AlternatingMap R' Mᵢ N₂ ιb) :
+noncomputable def domCoprod (a : AlternatingMap R' Mᵢ N₁ ιa) (b : AlternatingMap R' Mᵢ N₂ ιb) :
     AlternatingMap R' Mᵢ (N₁ ⊗[R'] N₂) (Sum ιa ιb) :=
   { ∑ σ : Perm.ModSumCongr ιa ιb, domCoprod.summand a b σ with
     toFun := fun v => (⇑(∑ σ : Perm.ModSumCongr ιa ιb, domCoprod.summand a b σ)) v
@@ -1134,7 +1135,7 @@ theorem domCoprod_coe (a : AlternatingMap R' Mᵢ N₁ ιa) (b : AlternatingMap 
 
 /-- A more bundled version of `AlternatingMap.domCoprod` that maps
 `((ι₁ → N) → N₁) ⊗ ((ι₂ → N) → N₂)` to `(ι₁ ⊕ ι₂ → N) → N₁ ⊗ N₂`. -/
-def domCoprod' :
+noncomputable def domCoprod' :
     AlternatingMap R' Mᵢ N₁ ιa ⊗[R'] AlternatingMap R' Mᵢ N₂ ιb →ₗ[R']
       AlternatingMap R' Mᵢ (N₁ ⊗[R'] N₂) (Sum ιa ιb) :=
   TensorProduct.lift <| by

--- a/Mathlib/LinearAlgebra/BilinearForm/TensorProduct.lean
+++ b/Mathlib/LinearAlgebra/BilinearForm/TensorProduct.lean
@@ -42,7 +42,8 @@ variable (R A) in
 
 Note this is heterobasic; the bilinear form on the left can take values in an (commutative) algebra
 over the ring in which the right bilinear form is valued. -/
-def tensorDistrib : BilinForm A M₁ ⊗[R] BilinForm R M₂ →ₗ[A] BilinForm A (M₁ ⊗[R] M₂) :=
+noncomputable def tensorDistrib :
+    BilinForm A M₁ ⊗[R] BilinForm R M₂ →ₗ[A] BilinForm A (M₁ ⊗[R] M₂) :=
   ((TensorProduct.AlgebraTensorModule.tensorTensorTensorComm R A M₁ M₂ M₁ M₂).dualMap
     ≪≫ₗ (TensorProduct.lift.equiv A (M₁ ⊗[R] M₂) (M₁ ⊗[R] M₂) A).symm
     ≪≫ₗ LinearMap.toBilin).toLinearMap
@@ -64,7 +65,8 @@ theorem tensorDistrib_tmul (B₁ : BilinForm A M₁) (B₂ : BilinForm R M₂) (
 
 /-- The tensor product of two bilinear forms, a shorthand for dot notation. -/
 @[reducible]
-protected def tmul (B₁ : BilinForm A M₁) (B₂ : BilinForm R M₂) : BilinForm A (M₁ ⊗[R] M₂) :=
+protected noncomputable def tmul (B₁ : BilinForm A M₁) (B₂ : BilinForm R M₂) :
+    BilinForm A (M₁ ⊗[R] M₂) :=
   tensorDistrib R A (B₁ ⊗ₜ[R] B₂)
 #align bilin_form.tmul BilinForm.tmul
 
@@ -79,7 +81,7 @@ lemma IsSymm.tmul {B₁ : BilinForm A M₁} {B₂ : BilinForm R M₂}
 
 variable (A) in
 /-- The base change of a bilinear form. -/
-protected def baseChange (B : BilinForm R M₂) : BilinForm A (A ⊗[R] M₂) :=
+protected noncomputable def baseChange (B : BilinForm R M₂) : BilinForm A (A ⊗[R] M₂) :=
   BilinForm.tmul (R := R) (A := A) (M₁ := A) (M₂ := M₂) (LinearMap.toBilin <| LinearMap.mul A A) B
 
 @[simp]

--- a/Mathlib/LinearAlgebra/BilinearForm/TensorProduct.lean
+++ b/Mathlib/LinearAlgebra/BilinearForm/TensorProduct.lean
@@ -42,6 +42,7 @@ variable (R A) in
 
 Note this is heterobasic; the bilinear form on the left can take values in an (commutative) algebra
 over the ring in which the right bilinear form is valued. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def tensorDistrib :
     BilinForm A M₁ ⊗[R] BilinForm R M₂ →ₗ[A] BilinForm A (M₁ ⊗[R] M₂) :=
   ((TensorProduct.AlgebraTensorModule.tensorTensorTensorComm R A M₁ M₂ M₁ M₂).dualMap
@@ -65,6 +66,7 @@ theorem tensorDistrib_tmul (B₁ : BilinForm A M₁) (B₂ : BilinForm R M₂) (
 
 /-- The tensor product of two bilinear forms, a shorthand for dot notation. -/
 @[reducible]
+-- `noncomputable` is a performance workaround for mathlib4#7103
 protected noncomputable def tmul (B₁ : BilinForm A M₁) (B₂ : BilinForm R M₂) :
     BilinForm A (M₁ ⊗[R] M₂) :=
   tensorDistrib R A (B₁ ⊗ₜ[R] B₂)
@@ -81,6 +83,7 @@ lemma IsSymm.tmul {B₁ : BilinForm A M₁} {B₂ : BilinForm R M₂}
 
 variable (A) in
 /-- The base change of a bilinear form. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 protected noncomputable def baseChange (B : BilinForm R M₂) : BilinForm A (A ⊗[R] M₂) :=
   BilinForm.tmul (R := R) (A := A) (M₁ := A) (M₂ := M₂) (LinearMap.toBilin <| LinearMap.mul A A) B
 

--- a/Mathlib/LinearAlgebra/Contraction.lean
+++ b/Mathlib/LinearAlgebra/Contraction.lean
@@ -47,19 +47,19 @@ variable [DecidableEq ι] [Fintype ι] (b : Basis ι R M)
 
 -- Porting note: doesn't like implicit ring in the tensor product
 /-- The natural left-handed pairing between a module and its dual. -/
-def contractLeft : Module.Dual R M ⊗[R] M →ₗ[R] R :=
+noncomputable def contractLeft : Module.Dual R M ⊗[R] M →ₗ[R] R :=
   (uncurry _ _ _ _).toFun LinearMap.id
 #align contract_left contractLeft
 
 -- Porting note: doesn't like implicit ring in the tensor product
 /-- The natural right-handed pairing between a module and its dual. -/
-def contractRight : M ⊗[R] Module.Dual R M →ₗ[R] R :=
+noncomputable def contractRight : M ⊗[R] Module.Dual R M →ₗ[R] R :=
   (uncurry _ _ _ _).toFun (LinearMap.flip LinearMap.id)
 #align contract_right contractRight
 
 -- Porting note: doesn't like implicit ring in the tensor product
 /-- The natural map associating a linear map to the tensor product of two modules. -/
-def dualTensorHom : Module.Dual R M ⊗[R] N →ₗ[R] M →ₗ[R] N :=
+noncomputable def dualTensorHom : Module.Dual R M ⊗[R] N →ₗ[R] M →ₗ[R] N :=
   let M' := Module.Dual R M
   (uncurry R M' N (M →ₗ[R] N) : _ → M' ⊗ N →ₗ[R] M →ₗ[R] N) LinearMap.smulRightₗ
 #align dual_tensor_hom dualTensorHom

--- a/Mathlib/LinearAlgebra/Contraction.lean
+++ b/Mathlib/LinearAlgebra/Contraction.lean
@@ -47,18 +47,21 @@ variable [DecidableEq ι] [Fintype ι] (b : Basis ι R M)
 
 -- Porting note: doesn't like implicit ring in the tensor product
 /-- The natural left-handed pairing between a module and its dual. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def contractLeft : Module.Dual R M ⊗[R] M →ₗ[R] R :=
   (uncurry _ _ _ _).toFun LinearMap.id
 #align contract_left contractLeft
 
 -- Porting note: doesn't like implicit ring in the tensor product
 /-- The natural right-handed pairing between a module and its dual. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def contractRight : M ⊗[R] Module.Dual R M →ₗ[R] R :=
   (uncurry _ _ _ _).toFun (LinearMap.flip LinearMap.id)
 #align contract_right contractRight
 
 -- Porting note: doesn't like implicit ring in the tensor product
 /-- The natural map associating a linear map to the tensor product of two modules. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def dualTensorHom : Module.Dual R M ⊗[R] N →ₗ[R] M →ₗ[R] N :=
   let M' := Module.Dual R M
   (uncurry R M' N (M →ₗ[R] N) : _ → M' ⊗ N →ₗ[R] M →ₗ[R] N) LinearMap.smulRightₗ

--- a/Mathlib/LinearAlgebra/DirectSum/TensorProduct.lean
+++ b/Mathlib/LinearAlgebra/DirectSum/TensorProduct.lean
@@ -50,7 +50,7 @@ variable [∀ i₁, Module R (M₁ i₁)] [Module R M₁'] [∀ i₂, Module R (
 
 /-- The linear equivalence `(⨁ i₁, M₁ i₁) ⊗ (⨁ i₂, M₂ i₂) ≃ (⨁ i₁, ⨁ i₂, M₁ i₁ ⊗ M₂ i₂)`, i.e.
 "tensor product distributes over direct sum". -/
-protected def directSum :
+protected noncomputable def directSum :
     ((⨁ i₁, M₁ i₁) ⊗[R] ⨁ i₂, M₂ i₂) ≃ₗ[R] ⨁ i : ι₁ × ι₂, M₁ i.1 ⊗[R] M₂ i.2 := by
   -- porting note: entirely rewritten to allow unification to happen one step at a time
   refine LinearEquiv.ofLinear (R := R) (R₂ := R) ?toFun ?invFun ?left ?right
@@ -120,7 +120,7 @@ protected def directSum :
 #align tensor_product.direct_sum TensorProduct.directSum
 
 /-- Tensor products distribute over a direct sum on the left . -/
-def directSumLeft : (⨁ i₁, M₁ i₁) ⊗[R] M₂' ≃ₗ[R] ⨁ i, M₁ i ⊗[R] M₂' :=
+noncomputable def directSumLeft : (⨁ i₁, M₁ i₁) ⊗[R] M₂' ≃ₗ[R] ⨁ i, M₁ i ⊗[R] M₂' :=
   LinearEquiv.ofLinear
     (lift <|
       DirectSum.toModule R _ _ fun i =>
@@ -141,7 +141,7 @@ def directSumLeft : (⨁ i₁, M₁ i₁) ⊗[R] M₂' ≃ₗ[R] ⨁ i, M₁ i �
 #align tensor_product.direct_sum_left TensorProduct.directSumLeft
 
 /-- Tensor products distribute over a direct sum on the right. -/
-def directSumRight : (M₁' ⊗[R] ⨁ i, M₂ i) ≃ₗ[R] ⨁ i, M₁' ⊗[R] M₂ i :=
+noncomputable def directSumRight : (M₁' ⊗[R] ⨁ i, M₂ i) ≃ₗ[R] ⨁ i, M₁' ⊗[R] M₂ i :=
   TensorProduct.comm R _ _ ≪≫ₗ directSumLeft R M₂ M₁' ≪≫ₗ
     DFinsupp.mapRange.linearEquiv fun _ => TensorProduct.comm R _ _
 #align tensor_product.direct_sum_right TensorProduct.directSumRight

--- a/Mathlib/LinearAlgebra/DirectSum/TensorProduct.lean
+++ b/Mathlib/LinearAlgebra/DirectSum/TensorProduct.lean
@@ -50,6 +50,7 @@ variable [∀ i₁, Module R (M₁ i₁)] [Module R M₁'] [∀ i₂, Module R (
 
 /-- The linear equivalence `(⨁ i₁, M₁ i₁) ⊗ (⨁ i₂, M₂ i₂) ≃ (⨁ i₁, ⨁ i₂, M₁ i₁ ⊗ M₂ i₂)`, i.e.
 "tensor product distributes over direct sum". -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 protected noncomputable def directSum :
     ((⨁ i₁, M₁ i₁) ⊗[R] ⨁ i₂, M₂ i₂) ≃ₗ[R] ⨁ i : ι₁ × ι₂, M₁ i.1 ⊗[R] M₂ i.2 := by
   -- porting note: entirely rewritten to allow unification to happen one step at a time
@@ -120,6 +121,7 @@ protected noncomputable def directSum :
 #align tensor_product.direct_sum TensorProduct.directSum
 
 /-- Tensor products distribute over a direct sum on the left . -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def directSumLeft : (⨁ i₁, M₁ i₁) ⊗[R] M₂' ≃ₗ[R] ⨁ i, M₁ i ⊗[R] M₂' :=
   LinearEquiv.ofLinear
     (lift <|
@@ -141,6 +143,7 @@ noncomputable def directSumLeft : (⨁ i₁, M₁ i₁) ⊗[R] M₂' ≃ₗ[R] �
 #align tensor_product.direct_sum_left TensorProduct.directSumLeft
 
 /-- Tensor products distribute over a direct sum on the right. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def directSumRight : (M₁' ⊗[R] ⨁ i, M₂ i) ≃ₗ[R] ⨁ i, M₁' ⊗[R] M₂ i :=
   TensorProduct.comm R _ _ ≪≫ₗ directSumLeft R M₂ M₁' ≪≫ₗ
     DFinsupp.mapRange.linearEquiv fun _ => TensorProduct.comm R _ _

--- a/Mathlib/LinearAlgebra/Multilinear/TensorProduct.lean
+++ b/Mathlib/LinearAlgebra/Multilinear/TensorProduct.lean
@@ -43,7 +43,7 @@ to the simple case defined here. See [this zulip thread](
 https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there.20code.20for.20X.3F/topic/Instances.20on.20.60sum.2Eelim.20A.20B.20i.60/near/218484619).
 -/
 @[simps apply]
-def domCoprod (a : MultilinearMap R (fun _ : ι₁ => N) N₁)
+noncomputable def domCoprod (a : MultilinearMap R (fun _ : ι₁ => N) N₁)
     (b : MultilinearMap R (fun _ : ι₂ => N) N₂) :
     MultilinearMap R (fun _ : Sum ι₁ ι₂ => N) (N₁ ⊗[R] N₂) where
   toFun v := (a fun i => v (Sum.inl i)) ⊗ₜ b fun i => v (Sum.inr i)
@@ -59,7 +59,7 @@ def domCoprod (a : MultilinearMap R (fun _ : ι₁ => N) N₁)
 
 /-- A more bundled version of `MultilinearMap.domCoprod` that maps
 `((ι₁ → N) → N₁) ⊗ ((ι₂ → N) → N₂)` to `(ι₁ ⊕ ι₂ → N) → N₁ ⊗ N₂`. -/
-def domCoprod' :
+noncomputable def domCoprod' :
     MultilinearMap R (fun _ : ι₁ => N) N₁ ⊗[R] MultilinearMap R (fun _ : ι₂ => N) N₂ →ₗ[R]
       MultilinearMap R (fun _ : Sum ι₁ ι₂ => N) (N₁ ⊗[R] N₂) :=
   TensorProduct.lift <|

--- a/Mathlib/LinearAlgebra/Multilinear/TensorProduct.lean
+++ b/Mathlib/LinearAlgebra/Multilinear/TensorProduct.lean
@@ -43,6 +43,7 @@ to the simple case defined here. See [this zulip thread](
 https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there.20code.20for.20X.3F/topic/Instances.20on.20.60sum.2Eelim.20A.20B.20i.60/near/218484619).
 -/
 @[simps apply]
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def domCoprod (a : MultilinearMap R (fun _ : ι₁ => N) N₁)
     (b : MultilinearMap R (fun _ : ι₂ => N) N₂) :
     MultilinearMap R (fun _ : Sum ι₁ ι₂ => N) (N₁ ⊗[R] N₂) where
@@ -59,6 +60,7 @@ noncomputable def domCoprod (a : MultilinearMap R (fun _ : ι₁ => N) N₁)
 
 /-- A more bundled version of `MultilinearMap.domCoprod` that maps
 `((ι₁ → N) → N₁) ⊗ ((ι₂ → N) → N₂)` to `(ι₁ ⊕ ι₂ → N) → N₁ ⊗ N₂`. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def domCoprod' :
     MultilinearMap R (fun _ : ι₁ => N) N₁ ⊗[R] MultilinearMap R (fun _ : ι₂ => N) N₂ →ₗ[R]
       MultilinearMap R (fun _ : Sum ι₁ ι₂ => N) (N₁ ⊗[R] N₂) :=

--- a/Mathlib/LinearAlgebra/PiTensorProduct.lean
+++ b/Mathlib/LinearAlgebra/PiTensorProduct.lean
@@ -582,6 +582,7 @@ theorem subsingletonEquiv_apply_tprod [Subsingleton ι] (i : ι) (f : ι → M) 
 section Tmul
 
 /-- Collapse a `TensorProduct` of `PiTensorProduct`s. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 private noncomputable def tmul :
     ((⨂[R] _ : ι, M) ⊗[R] ⨂[R] _ : ι₂, M) →ₗ[R] ⨂[R] _ : Sum ι ι₂, M :=
   TensorProduct.lift
@@ -598,6 +599,7 @@ private theorem tmul_apply (a : ι → M) (b : ι₂ → M) :
   rfl
 
 /-- Expand `PiTensorProduct` into a `TensorProduct` of two factors. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 private noncomputable def tmulSymm :
     (⨂[R] _ : Sum ι ι₂, M) →ₗ[R] (⨂[R] _ : ι, M) ⊗[R] ⨂[R] _ : ι₂, M :=
   -- by using tactic mode, we avoid the need for a lot of `@`s and `_`s
@@ -616,6 +618,7 @@ attribute [local ext] TensorProduct.ext
 
 For simplicity, this is defined only for homogeneously- (rather than dependently-) typed components.
 -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def tmulEquiv : ((⨂[R] _ : ι, M) ⊗[R] ⨂[R] _ : ι₂, M) ≃ₗ[R] ⨂[R] _ : Sum ι ι₂, M :=
   LinearEquiv.ofLinear tmul tmulSymm
     (by

--- a/Mathlib/LinearAlgebra/PiTensorProduct.lean
+++ b/Mathlib/LinearAlgebra/PiTensorProduct.lean
@@ -582,7 +582,8 @@ theorem subsingletonEquiv_apply_tprod [Subsingleton ι] (i : ι) (f : ι → M) 
 section Tmul
 
 /-- Collapse a `TensorProduct` of `PiTensorProduct`s. -/
-private def tmul : ((⨂[R] _ : ι, M) ⊗[R] ⨂[R] _ : ι₂, M) →ₗ[R] ⨂[R] _ : Sum ι ι₂, M :=
+private noncomputable def tmul :
+    ((⨂[R] _ : ι, M) ⊗[R] ⨂[R] _ : ι₂, M) →ₗ[R] ⨂[R] _ : Sum ι ι₂, M :=
   TensorProduct.lift
     { toFun := fun a ↦
         PiTensorProduct.lift <|
@@ -597,7 +598,8 @@ private theorem tmul_apply (a : ι → M) (b : ι₂ → M) :
   rfl
 
 /-- Expand `PiTensorProduct` into a `TensorProduct` of two factors. -/
-private def tmulSymm : (⨂[R] _ : Sum ι ι₂, M) →ₗ[R] (⨂[R] _ : ι, M) ⊗[R] ⨂[R] _ : ι₂, M :=
+private noncomputable def tmulSymm :
+    (⨂[R] _ : Sum ι ι₂, M) →ₗ[R] (⨂[R] _ : ι, M) ⊗[R] ⨂[R] _ : ι₂, M :=
   -- by using tactic mode, we avoid the need for a lot of `@`s and `_`s
   PiTensorProduct.lift <| MultilinearMap.domCoprod (tprod R) (tprod R)
 
@@ -614,7 +616,7 @@ attribute [local ext] TensorProduct.ext
 
 For simplicity, this is defined only for homogeneously- (rather than dependently-) typed components.
 -/
-def tmulEquiv : ((⨂[R] _ : ι, M) ⊗[R] ⨂[R] _ : ι₂, M) ≃ₗ[R] ⨂[R] _ : Sum ι ι₂, M :=
+noncomputable def tmulEquiv : ((⨂[R] _ : ι, M) ⊗[R] ⨂[R] _ : ι₂, M) ≃ₗ[R] ⨂[R] _ : Sum ι ι₂, M :=
   LinearEquiv.ofLinear tmul tmulSymm
     (by
       ext x

--- a/Mathlib/LinearAlgebra/QuadraticForm/TensorProduct/Isometries.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/TensorProduct/Isometries.lean
@@ -54,6 +54,7 @@ theorem tmul_tensorMap_apply
 namespace Isometry
 
 /-- `TensorProduct.map` for `Quadraticform.Isometry`s -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def tmul
     {Q₁ : QuadraticForm R M₁} {Q₂ : QuadraticForm R M₂}
     {Q₃ : QuadraticForm R M₃} {Q₄ : QuadraticForm R M₄}
@@ -90,6 +91,7 @@ theorem tmul_tensorComm_apply
   FunLike.congr_fun (tmul_comp_tensorComm Q₁ Q₂) x
 
 /-- `TensorProduct.comm` preserves tensor products of quadratic forms. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def tensorComm (Q₁ : QuadraticForm R M₁) (Q₂ : QuadraticForm R M₂) :
     (Q₁.tmul Q₂).IsometryEquiv (Q₂.tmul Q₁) where
   toLinearEquiv := TensorProduct.comm R M₁ M₂
@@ -127,6 +129,7 @@ theorem tmul_tensorAssoc_apply
   FunLike.congr_fun (tmul_comp_tensorAssoc Q₁ Q₂ Q₃) x
 
 /-- `TensorProduct.assoc` preserves tensor products of quadratic forms. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def tensorAssoc (Q₁ : QuadraticForm R M₁) (Q₂ : QuadraticForm R M₂)
     (Q₃ : QuadraticForm R M₃) :
     ((Q₁.tmul Q₂).tmul Q₃).IsometryEquiv (Q₁.tmul (Q₂.tmul Q₃)) where
@@ -165,6 +168,7 @@ theorem tmul_tensorRId_apply
   FunLike.congr_fun (comp_tensorRId_eq Q₁) x
 
 /-- `TensorProduct.rid` preserves tensor products of quadratic forms. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def tensorRId (Q₁ : QuadraticForm R M₁):
     (Q₁.tmul (sq (R := R))).IsometryEquiv Q₁ where
   toLinearEquiv := TensorProduct.rid R M₁
@@ -198,6 +202,7 @@ theorem tmul_tensorLId_apply
   FunLike.congr_fun (comp_tensorLId_eq Q₂) x
 
 /-- `TensorProduct.lid` preserves tensor products of quadratic forms. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def tensorLId (Q₂ : QuadraticForm R M₂):
     ((sq (R := R)).tmul Q₂).IsometryEquiv Q₂ where
   toLinearEquiv := TensorProduct.lid R M₂

--- a/Mathlib/LinearAlgebra/QuadraticForm/TensorProduct/Isometries.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/TensorProduct/Isometries.lean
@@ -54,7 +54,7 @@ theorem tmul_tensorMap_apply
 namespace Isometry
 
 /-- `TensorProduct.map` for `Quadraticform.Isometry`s -/
-def tmul
+noncomputable def tmul
     {Q₁ : QuadraticForm R M₁} {Q₂ : QuadraticForm R M₂}
     {Q₃ : QuadraticForm R M₃} {Q₄ : QuadraticForm R M₄}
     (f : Q₁ →qᵢ Q₂) (g : Q₃ →qᵢ Q₄) : (Q₁.tmul Q₃) →qᵢ (Q₂.tmul Q₄) where
@@ -90,7 +90,7 @@ theorem tmul_tensorComm_apply
   FunLike.congr_fun (tmul_comp_tensorComm Q₁ Q₂) x
 
 /-- `TensorProduct.comm` preserves tensor products of quadratic forms. -/
-def tensorComm (Q₁ : QuadraticForm R M₁) (Q₂ : QuadraticForm R M₂) :
+noncomputable def tensorComm (Q₁ : QuadraticForm R M₁) (Q₂ : QuadraticForm R M₂) :
     (Q₁.tmul Q₂).IsometryEquiv (Q₂.tmul Q₁) where
   toLinearEquiv := TensorProduct.comm R M₁ M₂
   map_app' := tmul_tensorComm_apply Q₁ Q₂
@@ -127,7 +127,8 @@ theorem tmul_tensorAssoc_apply
   FunLike.congr_fun (tmul_comp_tensorAssoc Q₁ Q₂ Q₃) x
 
 /-- `TensorProduct.assoc` preserves tensor products of quadratic forms. -/
-def tensorAssoc (Q₁ : QuadraticForm R M₁) (Q₂ : QuadraticForm R M₂) (Q₃ : QuadraticForm R M₃) :
+noncomputable def tensorAssoc (Q₁ : QuadraticForm R M₁) (Q₂ : QuadraticForm R M₂)
+    (Q₃ : QuadraticForm R M₃) :
     ((Q₁.tmul Q₂).tmul Q₃).IsometryEquiv (Q₁.tmul (Q₂.tmul Q₃)) where
   toLinearEquiv := TensorProduct.assoc R M₁ M₂ M₃
   map_app' := tmul_tensorAssoc_apply Q₁ Q₂ Q₃
@@ -164,7 +165,7 @@ theorem tmul_tensorRId_apply
   FunLike.congr_fun (comp_tensorRId_eq Q₁) x
 
 /-- `TensorProduct.rid` preserves tensor products of quadratic forms. -/
-def tensorRId (Q₁ : QuadraticForm R M₁):
+noncomputable def tensorRId (Q₁ : QuadraticForm R M₁):
     (Q₁.tmul (sq (R := R))).IsometryEquiv Q₁ where
   toLinearEquiv := TensorProduct.rid R M₁
   map_app' := tmul_tensorRId_apply Q₁
@@ -197,7 +198,7 @@ theorem tmul_tensorLId_apply
   FunLike.congr_fun (comp_tensorLId_eq Q₂) x
 
 /-- `TensorProduct.lid` preserves tensor products of quadratic forms. -/
-def tensorLId (Q₂ : QuadraticForm R M₂):
+noncomputable def tensorLId (Q₂ : QuadraticForm R M₂):
     ((sq (R := R)).tmul Q₂).IsometryEquiv Q₂ where
   toLinearEquiv := TensorProduct.lid R M₂
   map_app' := tmul_tensorLId_apply Q₂

--- a/Mathlib/LinearAlgebra/TensorAlgebra/ToTensorPower.lean
+++ b/Mathlib/LinearAlgebra/TensorAlgebra/ToTensorPower.lean
@@ -91,6 +91,7 @@ theorem ofDirectSum_of_tprod {n} (x : Fin n → M) :
 #align tensor_algebra.of_direct_sum_of_tprod TensorAlgebra.ofDirectSum_of_tprod
 
 /-- The canonical map from the tensor algebra to a direct sum of tensor powers. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def toDirectSum : TensorAlgebra R M →ₐ[R] ⨁ n, (⨂[R]^n) M :=
   TensorAlgebra.lift R <|
     DirectSum.lof R ℕ (fun n => (⨂[R]^n) M) _ ∘ₗ
@@ -176,6 +177,7 @@ theorem toDirectSum_ofDirectSum (x : ⨁ n, (⨂[R]^n) M) :
 
 /-- The tensor algebra is isomorphic to a direct sum of tensor powers. -/
 @[simps!]
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def equivDirectSum : TensorAlgebra R M ≃ₐ[R] ⨁ n, (⨂[R]^n) M :=
   AlgEquiv.ofAlgHom toDirectSum ofDirectSum toDirectSum_comp_ofDirectSum
     ofDirectSum_comp_toDirectSum

--- a/Mathlib/LinearAlgebra/TensorAlgebra/ToTensorPower.lean
+++ b/Mathlib/LinearAlgebra/TensorAlgebra/ToTensorPower.lean
@@ -91,7 +91,7 @@ theorem ofDirectSum_of_tprod {n} (x : Fin n → M) :
 #align tensor_algebra.of_direct_sum_of_tprod TensorAlgebra.ofDirectSum_of_tprod
 
 /-- The canonical map from the tensor algebra to a direct sum of tensor powers. -/
-def toDirectSum : TensorAlgebra R M →ₐ[R] ⨁ n, (⨂[R]^n) M :=
+noncomputable def toDirectSum : TensorAlgebra R M →ₐ[R] ⨁ n, (⨂[R]^n) M :=
   TensorAlgebra.lift R <|
     DirectSum.lof R ℕ (fun n => (⨂[R]^n) M) _ ∘ₗ
       (LinearEquiv.symm <| PiTensorProduct.subsingletonEquiv (0 : Fin 1) : M ≃ₗ[R] _).toLinearMap
@@ -176,7 +176,7 @@ theorem toDirectSum_ofDirectSum (x : ⨁ n, (⨂[R]^n) M) :
 
 /-- The tensor algebra is isomorphic to a direct sum of tensor powers. -/
 @[simps!]
-def equivDirectSum : TensorAlgebra R M ≃ₐ[R] ⨁ n, (⨂[R]^n) M :=
+noncomputable def equivDirectSum : TensorAlgebra R M ≃ₐ[R] ⨁ n, (⨂[R]^n) M :=
   AlgEquiv.ofAlgHom toDirectSum ofDirectSum toDirectSum_comp_ofDirectSum
     ofDirectSum_comp_toDirectSum
 #align tensor_algebra.equiv_direct_sum TensorAlgebra.equivDirectSum

--- a/Mathlib/LinearAlgebra/TensorPower.lean
+++ b/Mathlib/LinearAlgebra/TensorPower.lean
@@ -76,11 +76,13 @@ theorem gOne_def : ₜ1 = tprod R (@Fin.elim0' M) :=
 #align tensor_power.ghas_one_def TensorPower.gOne_def
 
 /-- A variant of `PiTensorProduct.tmulEquiv` with the result indexed by `Fin (n + m)`. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def mulEquiv {n m : ℕ} : (⨂[R]^n) M ⊗[R] (⨂[R]^m) M ≃ₗ[R] (⨂[R]^(n + m)) M :=
   (tmulEquiv R M).trans (reindex R M finSumFinEquiv)
 #align tensor_power.mul_equiv TensorPower.mulEquiv
 
 /-- As a graded monoid, `⨂[R]^i M` has a `(*) : ⨂[R]^i M → ⨂[R]^j M → ⨂[R]^(i + j) M`. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable instance gMul : GradedMonoid.GMul fun i => (⨂[R]^i) M where
   mul {i j} a b :=
     (TensorProduct.mk R _ _).compr₂ (↑(mulEquiv : _ ≃ₗ[R] (⨂[R]^(i + j)) M)) a b
@@ -214,6 +216,7 @@ theorem mul_assoc {na nb nc} (a : (⨂[R]^na) M) (b : (⨂[R]^nb) M) (c : (⨂[R
 #align tensor_power.mul_assoc TensorPower.mul_assoc
 
 -- for now we just use the default for the `gnpow` field as it's easier.
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable instance gmonoid : GradedMonoid.GMonoid fun i => (⨂[R]^i) M :=
   { TensorPower.gMul, TensorPower.gOne with
     one_mul := fun a => gradedMonoid_eq_of_cast (zero_add _) (one_mul _)
@@ -253,6 +256,7 @@ theorem algebraMap₀_mul_algebraMap₀ (r s : R) :
   exact algebraMap₀_mul r (@algebraMap₀ R M _ _ _ s)
 #align tensor_power.algebra_map₀_mul_algebra_map₀ TensorPower.algebraMap₀_mul_algebraMap₀
 
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable instance gsemiring : DirectSum.GSemiring fun i => (⨂[R]^i) M :=
   { TensorPower.gmonoid with
     mul_zero := fun a => LinearMap.map_zero _
@@ -264,6 +268,7 @@ noncomputable instance gsemiring : DirectSum.GSemiring fun i => (⨂[R]^i) M :=
     natCast_succ := fun n => by simp only [Nat.cast_succ, map_add, algebraMap₀_one] }
 #align tensor_power.gsemiring TensorPower.gsemiring
 
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable example : Semiring (⨁ n : ℕ, (⨂[R]^n) M) := by infer_instance
 
 /-- The tensor powers form a graded algebra.
@@ -291,6 +296,7 @@ theorem galgebra_toFun_def (r : R) :
   rfl
 #align tensor_power.galgebra_to_fun_def TensorPower.galgebra_toFun_def
 
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable example : Algebra R (⨁ n : ℕ, (⨂[R]^n) M) := by infer_instance
 
 end TensorPower

--- a/Mathlib/LinearAlgebra/TensorPower.lean
+++ b/Mathlib/LinearAlgebra/TensorPower.lean
@@ -76,12 +76,12 @@ theorem gOne_def : ₜ1 = tprod R (@Fin.elim0' M) :=
 #align tensor_power.ghas_one_def TensorPower.gOne_def
 
 /-- A variant of `PiTensorProduct.tmulEquiv` with the result indexed by `Fin (n + m)`. -/
-def mulEquiv {n m : ℕ} : (⨂[R]^n) M ⊗[R] (⨂[R]^m) M ≃ₗ[R] (⨂[R]^(n + m)) M :=
+noncomputable def mulEquiv {n m : ℕ} : (⨂[R]^n) M ⊗[R] (⨂[R]^m) M ≃ₗ[R] (⨂[R]^(n + m)) M :=
   (tmulEquiv R M).trans (reindex R M finSumFinEquiv)
 #align tensor_power.mul_equiv TensorPower.mulEquiv
 
 /-- As a graded monoid, `⨂[R]^i M` has a `(*) : ⨂[R]^i M → ⨂[R]^j M → ⨂[R]^(i + j) M`. -/
-instance gMul : GradedMonoid.GMul fun i => (⨂[R]^i) M where
+noncomputable instance gMul : GradedMonoid.GMul fun i => (⨂[R]^i) M where
   mul {i j} a b :=
     (TensorProduct.mk R _ _).compr₂ (↑(mulEquiv : _ ≃ₗ[R] (⨂[R]^(i + j)) M)) a b
 #align tensor_power.ghas_mul TensorPower.gMul
@@ -214,7 +214,7 @@ theorem mul_assoc {na nb nc} (a : (⨂[R]^na) M) (b : (⨂[R]^nb) M) (c : (⨂[R
 #align tensor_power.mul_assoc TensorPower.mul_assoc
 
 -- for now we just use the default for the `gnpow` field as it's easier.
-instance gmonoid : GradedMonoid.GMonoid fun i => (⨂[R]^i) M :=
+noncomputable instance gmonoid : GradedMonoid.GMonoid fun i => (⨂[R]^i) M :=
   { TensorPower.gMul, TensorPower.gOne with
     one_mul := fun a => gradedMonoid_eq_of_cast (zero_add _) (one_mul _)
     mul_one := fun a => gradedMonoid_eq_of_cast (add_zero _) (mul_one _)
@@ -253,7 +253,7 @@ theorem algebraMap₀_mul_algebraMap₀ (r s : R) :
   exact algebraMap₀_mul r (@algebraMap₀ R M _ _ _ s)
 #align tensor_power.algebra_map₀_mul_algebra_map₀ TensorPower.algebraMap₀_mul_algebraMap₀
 
-instance gsemiring : DirectSum.GSemiring fun i => (⨂[R]^i) M :=
+noncomputable instance gsemiring : DirectSum.GSemiring fun i => (⨂[R]^i) M :=
   { TensorPower.gmonoid with
     mul_zero := fun a => LinearMap.map_zero _
     zero_mul := fun b => LinearMap.map_zero₂ _ _
@@ -264,7 +264,7 @@ instance gsemiring : DirectSum.GSemiring fun i => (⨂[R]^i) M :=
     natCast_succ := fun n => by simp only [Nat.cast_succ, map_add, algebraMap₀_one] }
 #align tensor_power.gsemiring TensorPower.gsemiring
 
-example : Semiring (⨁ n : ℕ, (⨂[R]^n) M) := by infer_instance
+noncomputable example : Semiring (⨁ n : ℕ, (⨂[R]^n) M) := by infer_instance
 
 /-- The tensor powers form a graded algebra.
 
@@ -291,6 +291,6 @@ theorem galgebra_toFun_def (r : R) :
   rfl
 #align tensor_power.galgebra_to_fun_def TensorPower.galgebra_toFun_def
 
-example : Algebra R (⨁ n : ℕ, (⨂[R]^n) M) := by infer_instance
+noncomputable example : Algebra R (⨁ n : ℕ, (⨂[R]^n) M) := by infer_instance
 
 end TensorPower

--- a/Mathlib/LinearAlgebra/TensorProduct.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct.lean
@@ -71,6 +71,7 @@ variable (R)
 
 /-- The tensor product of two modules `M` and `N` over the same commutative semiring `R`.
 The localized notations are `M ⊗ N` and `M ⊗[R] N`, accessed by `open scoped TensorProduct`. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def TensorProduct : Type _ :=
   (addConGen (TensorProduct.Eqv R M N)).Quotient
 #align tensor_product TensorProduct
@@ -88,18 +89,22 @@ section Module
 
 -- porting note: This is added as a local instance for `SMul.aux`.
 -- For some reason type-class inference in Lean 3 unfolded this definition.
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def addMonoid : AddMonoid (M ⊗[R] N) :=
   { (addConGen (TensorProduct.Eqv R M N)).addMonoid with }
 
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable instance addZeroClass : AddZeroClass (M ⊗[R] N) :=
   { (addConGen (TensorProduct.Eqv R M N)).addMonoid with }
 
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable instance addCommSemigroup : AddCommSemigroup (M ⊗[R] N) :=
   { (addConGen (TensorProduct.Eqv R M N)).addMonoid with
     add_comm := fun x y =>
       AddCon.induction_on₂ x y fun _ _ =>
         Quotient.sound' <| AddConGen.Rel.of _ _ <| Eqv.add_comm _ _ }
 
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable instance : Inhabited (M ⊗[R] N) :=
   ⟨0⟩
 
@@ -107,6 +112,7 @@ variable (R) {M N}
 
 /-- The canonical function `M → N → M ⊗ N`. The localized notations are `m ⊗ₜ n` and `m ⊗ₜ[R] n`,
 accessed by `open scoped TensorProduct`. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def tmul (m : M) (n : N) : M ⊗[R] N :=
   AddCon.mk' _ <| FreeAddMonoid.of (m, n)
 #align tensor_product.tmul TensorProduct.tmul
@@ -177,8 +183,7 @@ end
 
 /-- Note that this provides the default `compatible_smul R R M N` instance through
 `IsScalarTower.left`. -/
-instance (priority := 100) CompatibleSMul.isScalarTower [SMul R' R]
-    [IsScalarTower R' R M]
+instance (priority := 100) CompatibleSMul.isScalarTower [SMul R' R] [IsScalarTower R' R M]
     [DistribMulAction R' N] [IsScalarTower R' R N] : CompatibleSMul R R' M N :=
   ⟨fun r m n => by
     conv_lhs => rw [← one_smul R m]
@@ -195,6 +200,7 @@ theorem smul_tmul [DistribMulAction R' N] [CompatibleSMul R R' M N] (r : R') (m 
 
 attribute [local instance] addMonoid
 /-- Auxiliary function to defining scalar multiplication on tensor product. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def SMul.aux {R' : Type*} [SMul R' M] (r : R') : FreeAddMonoid (M × N) →+ M ⊗[R] N :=
   FreeAddMonoid.lift fun p : M × N => (r • p.1) ⊗ₜ p.2
 #align tensor_product.smul.aux TensorProduct.SMul.aux
@@ -219,6 +225,7 @@ action. Two natural ways in which this situation arises are:
 Note that in the special case that `R = R'`, since `R` is commutative, we just get the usual scalar
 action on a tensor product of two modules. This special case is important enough that, for
 performance reasons, we define it explicitly below. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable instance leftHasSMul : SMul R' (M ⊗[R] N) :=
   ⟨fun r =>
     (addConGen (TensorProduct.Eqv R M N)).lift (SMul.aux r : _ →+ M ⊗[R] N) <|
@@ -238,6 +245,7 @@ noncomputable instance leftHasSMul : SMul R' (M ⊗[R] N) :=
           (AddCon.ker_rel _).2 <| by simp_rw [map_add, add_comm]⟩
 #align tensor_product.left_has_smul TensorProduct.leftHasSMul
 
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable instance : SMul R (M ⊗[R] N) :=
   TensorProduct.leftHasSMul
 
@@ -271,6 +279,7 @@ protected theorem add_smul (r s : R'') (x : M ⊗[R] N) : (r + s) • x = r • 
     rw [ihx, ihy, add_add_add_comm]
 #align tensor_product.add_smul TensorProduct.add_smul
 
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable instance addCommMonoid : AddCommMonoid (M ⊗[R] N) :=
   { TensorProduct.addCommSemigroup _ _,
     TensorProduct.addZeroClass _ _ with
@@ -279,6 +288,7 @@ noncomputable instance addCommMonoid : AddCommMonoid (M ⊗[R] N) :=
     nsmul_succ := by simp only [TensorProduct.one_smul, TensorProduct.add_smul, add_comm,
       forall_const] }
 
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable instance leftDistribMulAction : DistribMulAction R' (M ⊗[R] N) :=
   have : ∀ (r : R') (m : M) (n : N), r • m ⊗ₜ[R] n = (r • m) ⊗ₜ n := fun _ _ _ => rfl
   { smul := (· • ·)
@@ -292,6 +302,7 @@ noncomputable instance leftDistribMulAction : DistribMulAction R' (M ⊗[R] N) :
     smul_zero := TensorProduct.smul_zero }
 #align tensor_product.left_distrib_mul_action TensorProduct.leftDistribMulAction
 
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable instance : DistribMulAction R (M ⊗[R] N) :=
   TensorProduct.leftDistribMulAction
 
@@ -309,17 +320,18 @@ theorem smul_tmul_smul (r s : R) (m : M) (n : N) : (r • m) ⊗ₜ[R] (s • n)
   simp_rw [smul_tmul, tmul_smul, mul_smul]
 #align tensor_product.smul_tmul_smul TensorProduct.smul_tmul_smul
 
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable instance leftModule : Module R'' (M ⊗[R] N) :=
   { TensorProduct.leftDistribMulAction with
     add_smul := TensorProduct.add_smul
     zero_smul := TensorProduct.zero_smul }
 #align tensor_product.left_module TensorProduct.leftModule
 
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable instance : Module R (M ⊗[R] N) :=
   TensorProduct.leftModule
 
-instance [Module R''ᵐᵒᵖ M] [IsCentralScalar R'' M] :
-    IsCentralScalar R'' (M ⊗[R] N) where
+instance [Module R''ᵐᵒᵖ M] [IsCentralScalar R'' M] : IsCentralScalar R'' (M ⊗[R] N) where
   op_smul_eq_smul r x :=
     x.induction_on (by rw [smul_zero, smul_zero])
       (fun x y => by rw [smul_tmul', smul_tmul', op_smul_eq_smul]) fun x y hx hy => by
@@ -332,7 +344,8 @@ variable {R'₂ : Type*} [Monoid R'₂] [DistribMulAction R'₂ M]
 variable [SMulCommClass R R'₂ M]
 
 /-- `SMulCommClass R' R'₂ M` implies `SMulCommClass R' R'₂ (M ⊗[R] N)` -/
-instance smulCommClass_left [SMulCommClass R' R'₂ M] :
+-- `noncomputable` is a performance workaround for mathlib4#7103
+noncomputable instance smulCommClass_left [SMulCommClass R' R'₂ M] :
     SMulCommClass R' R'₂ (M ⊗[R] N) where
   smul_comm r' r'₂ x :=
     TensorProduct.induction_on x (by simp_rw [TensorProduct.smul_zero])
@@ -343,7 +356,8 @@ instance smulCommClass_left [SMulCommClass R' R'₂ M] :
 variable [SMul R'₂ R']
 
 /-- `IsScalarTower R'₂ R' M` implies `IsScalarTower R'₂ R' (M ⊗[R] N)` -/
-instance isScalarTower_left [IsScalarTower R'₂ R' M] :
+-- `noncomputable` is a performance workaround for mathlib4#7103
+noncomputable instance isScalarTower_left [IsScalarTower R'₂ R' M] :
     IsScalarTower R'₂ R' (M ⊗[R] N) :=
   ⟨fun s r x =>
     x.induction_on (by simp)
@@ -355,7 +369,8 @@ variable [DistribMulAction R'₂ N] [DistribMulAction R' N]
 variable [CompatibleSMul R R'₂ M N] [CompatibleSMul R R' M N]
 
 /-- `IsScalarTower R'₂ R' N` implies `IsScalarTower R'₂ R' (M ⊗[R] N)` -/
-instance isScalarTower_right [IsScalarTower R'₂ R' N] :
+-- `noncomputable` is a performance workaround for mathlib4#7103
+noncomputable instance isScalarTower_right [IsScalarTower R'₂ R' N] :
     IsScalarTower R'₂ R' (M ⊗[R] N) :=
   ⟨fun s r x =>
     x.induction_on (by simp)
@@ -367,7 +382,8 @@ end
 
 /-- A short-cut instance for the common case, where the requirements for the `compatible_smul`
 instances are sufficient. -/
-instance isScalarTower [SMul R' R] [IsScalarTower R' R M] :
+-- `noncomputable` is a performance workaround for mathlib4#7103
+noncomputable instance isScalarTower [SMul R' R] [IsScalarTower R' R M] :
     IsScalarTower R' R (M ⊗[R] N) :=
   TensorProduct.isScalarTower_left
 #align tensor_product.is_scalar_tower TensorProduct.isScalarTower
@@ -376,6 +392,7 @@ instance isScalarTower [SMul R' R] [IsScalarTower R' R M] :
 variable (R M N)
 
 /-- The canonical bilinear map `M → N → M ⊗[R] N`. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def mk : M →ₗ[R] N →ₗ[R] M ⊗[R] N :=
   LinearMap.mk₂ R (· ⊗ₜ ·) add_tmul (fun c m n => by simp_rw [smul_tmul, tmul_smul])
     tmul_add tmul_smul
@@ -570,6 +587,7 @@ variable (R M N P)
 /-- A linear equivalence constructing a linear map `M ⊗ N → P` given a bilinear map `M → N → P`
 with the property that its composition with the canonical bilinear map `M → N → M ⊗ N` is
 the given bilinear map `M → N → P`. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def lift.equiv : (M →ₗ[R] N →ₗ[R] P) ≃ₗ[R] M ⊗[R] N →ₗ[R] P :=
   { uncurry R M N P with
     invFun := fun f => (mk R M N).compr₂ f
@@ -591,6 +609,7 @@ theorem lift.equiv_symm_apply (f : M ⊗[R] N →ₗ[R] P) (m : M) (n : N) :
 
 /-- Given a linear map `M ⊗ N → P`, compose it with the canonical bilinear map `M → N → M ⊗ N` to
 form a bilinear map `M → N → P`. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def lcurry : (M ⊗[R] N →ₗ[R] P) →ₗ[R] M →ₗ[R] N →ₗ[R] P :=
   (lift.equiv R M N P).symm
 #align tensor_product.lcurry TensorProduct.lcurry
@@ -604,6 +623,7 @@ theorem lcurry_apply (f : M ⊗[R] N →ₗ[R] P) (m : M) (n : N) : lcurry R M N
 
 /-- Given a linear map `M ⊗ N → P`, compose it with the canonical bilinear map `M → N → M ⊗ N` to
 form a bilinear map `M → N → P`. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def curry (f : M ⊗[R] N →ₗ[R] P) : M →ₗ[R] N →ₗ[R] P :=
   lcurry R M N P f
 #align tensor_product.curry TensorProduct.curry
@@ -648,6 +668,7 @@ variable (R M)
 
 /-- The base ring is a left identity for the tensor product of modules, up to linear equivalence.
 -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 protected noncomputable def lid : R ⊗[R] M ≃ₗ[R] M :=
   LinearEquiv.ofLinear (lift <| LinearMap.lsmul R M) (mk R R M 1) (LinearMap.ext fun _ => by simp)
     (ext' fun r m => by simp; rw [← tmul_smul, ← smul_tmul, smul_eq_mul, mul_one])
@@ -671,6 +692,7 @@ variable (R M N)
 
 /-- The tensor product of modules is commutative, up to linear equivalence.
 -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 protected noncomputable def comm : M ⊗[R] N ≃ₗ[R] N ⊗[R] M :=
   LinearEquiv.ofLinear (lift (mk R N M).flip) (lift (mk R M N).flip) (ext' fun _ _ => rfl)
     (ext' fun _ _ => rfl)
@@ -694,6 +716,7 @@ variable (R M)
 
 /-- The base ring is a right identity for the tensor product of modules, up to linear equivalence.
 -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 protected noncomputable def rid : M ⊗[R] R ≃ₗ[R] M :=
   LinearEquiv.trans (TensorProduct.comm R M R) (TensorProduct.lid R M)
 #align tensor_product.rid TensorProduct.rid
@@ -717,6 +740,7 @@ section
 variable (R M N P)
 
 /-- The associator for tensor product of R-modules, as a linear equivalence. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 protected noncomputable def assoc : (M ⊗[R] N) ⊗[R] P ≃ₗ[R] M ⊗[R] N ⊗[R] P := by
   refine
       LinearEquiv.ofLinear (lift <| lift <| comp (lcurry R _ _ _) <| mk _ _ _)
@@ -744,6 +768,7 @@ theorem assoc_symm_tmul (m : M) (n : N) (p : P) :
 #align tensor_product.assoc_symm_tmul TensorProduct.assoc_symm_tmul
 
 /-- The tensor product of a pair of linear maps between modules. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def map (f : M →ₗ[R] P) (g : N →ₗ[R] Q) : M ⊗[R] N →ₗ[R] P ⊗[R] Q :=
   lift <| comp (compl₂ (mk _ _ _) g) f
 #align tensor_product.map TensorProduct.map
@@ -769,6 +794,7 @@ theorem map_range_eq_span_tmul (f : M →ₗ[R] P) (g : N →ₗ[R] Q) :
 
 /-- Given submodules `p ⊆ P` and `q ⊆ Q`, this is the natural map: `p ⊗ q → P ⊗ Q`. -/
 @[simp]
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def mapIncl (p : Submodule R P) (q : Submodule R Q) : p ⊗[R] q →ₗ[R] P ⊗[R] Q :=
   map p.subtype q.subtype
 #align tensor_product.map_incl TensorProduct.mapIncl
@@ -840,22 +866,26 @@ theorem map_smul_right (r : R) (f : M →ₗ[R] P) (g : N →ₗ[R] Q) : map f (
 variable (R M N P Q)
 
 /-- The tensor product of a pair of linear maps between modules, bilinear in both maps. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def mapBilinear : (M →ₗ[R] P) →ₗ[R] (N →ₗ[R] Q) →ₗ[R] M ⊗[R] N →ₗ[R] P ⊗[R] Q :=
   LinearMap.mk₂ R map map_add_left map_smul_left map_add_right map_smul_right
 #align tensor_product.map_bilinear TensorProduct.mapBilinear
 
 /-- The canonical linear map from `P ⊗[R] (M →ₗ[R] Q)` to `(M →ₗ[R] P ⊗[R] Q)` -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def lTensorHomToHomLTensor : P ⊗[R] (M →ₗ[R] Q) →ₗ[R] M →ₗ[R] P ⊗[R] Q :=
   TensorProduct.lift (llcomp R M Q _ ∘ₗ mk R P Q)
 #align tensor_product.ltensor_hom_to_hom_ltensor TensorProduct.lTensorHomToHomLTensor
 
 /-- The canonical linear map from `(M →ₗ[R] P) ⊗[R] Q` to `(M →ₗ[R] P ⊗[R] Q)` -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def rTensorHomToHomRTensor : (M →ₗ[R] P) ⊗[R] Q →ₗ[R] M →ₗ[R] P ⊗[R] Q :=
   TensorProduct.lift (llcomp R M P _ ∘ₗ (mk R P Q).flip).flip
 #align tensor_product.rtensor_hom_to_hom_rtensor TensorProduct.rTensorHomToHomRTensor
 
 /-- The linear map from `(M →ₗ P) ⊗ (N →ₗ Q)` to `(M ⊗ N →ₗ P ⊗ Q)` sending `f ⊗ₜ g` to
 the `TensorProduct.map f g`, the tensor product of the two maps. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def homTensorHomMap : (M →ₗ[R] P) ⊗[R] (N →ₗ[R] Q) →ₗ[R] M ⊗[R] N →ₗ[R] P ⊗[R] Q :=
   lift (mapBilinear R M N P Q)
 #align tensor_product.hom_tensor_hom_map TensorProduct.homTensorHomMap
@@ -889,6 +919,7 @@ end
 
 /-- If `M` and `P` are linearly equivalent and `N` and `Q` are linearly equivalent
 then `M ⊗ N` and `P ⊗ Q` are linearly equivalent. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def congr (f : M ≃ₗ[R] P) (g : N ≃ₗ[R] Q) : M ⊗[R] N ≃ₗ[R] P ⊗[R] Q :=
   LinearEquiv.ofLinear (map f g) (map f.symm g.symm)
     (ext' fun m n => by simp)
@@ -910,6 +941,7 @@ theorem congr_symm_tmul (f : M ≃ₗ[R] P) (g : N ≃ₗ[R] Q) (p : P) (q : Q) 
 variable (R M N P Q)
 
 /-- A tensor product analogue of `mul_left_comm`. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def leftComm : M ⊗[R] N ⊗[R] P ≃ₗ[R] N ⊗[R] M ⊗[R] P :=
   let e₁ := (TensorProduct.assoc R M N P).symm
   let e₂ := congr (TensorProduct.comm R M N) (1 : P ≃ₗ[R] P)
@@ -942,6 +974,7 @@ combined with this definition, yields a bilinear multiplication on `M ⊗ N`:
 the `TensorProduct.semiring` instance (currently defined "by hand" using `TensorProduct.mul`).
 
 See also `mul_mul_mul_comm`. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def tensorTensorTensorComm :
     (M ⊗[R] N) ⊗[R] P ⊗[R] Q ≃ₗ[R] (M ⊗[R] P) ⊗[R] N ⊗[R] Q :=
   let e₁ := TensorProduct.assoc R M N (P ⊗[R] Q)
@@ -975,6 +1008,7 @@ E.g., composition of linear maps gives a map `(M → N) ⊗ (N → P) → (M →
 `(M.dual ⊗ N) ⊗ (N.dual ⊗ P) → (M.dual ⊗ P)`, which agrees with the application of `contractRight`
 on `N ⊗ N.dual` after the suitable rebracketting.
 -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def tensorTensorTensorAssoc :
     (M ⊗[R] N) ⊗[R] P ⊗[R] Q ≃ₗ[R] (M ⊗[R] N ⊗[R] P) ⊗[R] Q :=
   (TensorProduct.assoc R (M ⊗[R] N) P Q).symm ≪≫ₗ
@@ -1003,11 +1037,13 @@ namespace LinearMap
 variable {N}
 
 /-- `lTensor M f : M ⊗ N →ₗ M ⊗ P` is the natural linear map induced by `f : N →ₗ P`. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def lTensor (f : N →ₗ[R] P) : M ⊗[R] N →ₗ[R] M ⊗[R] P :=
   TensorProduct.map id f
 #align linear_map.ltensor LinearMap.lTensor
 
 /-- `rTensor f M : N₁ ⊗ M →ₗ N₂ ⊗ M` is the natural linear map induced by `f : N₁ →ₗ N₂`. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def rTensor (f : N →ₗ[R] P) : N ⊗[R] M →ₗ[R] P ⊗[R] M :=
   TensorProduct.map f id
 #align linear_map.rtensor LinearMap.rTensor
@@ -1029,6 +1065,7 @@ open TensorProduct
 attribute [local ext high] TensorProduct.ext
 
 /-- `lTensorHom M` is the natural linear map that sends a linear map `f : N →ₗ P` to `M ⊗ f`. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def lTensorHom : (N →ₗ[R] P) →ₗ[R] M ⊗[R] N →ₗ[R] M ⊗[R] P where
   toFun := lTensor M
   map_add' f g := by
@@ -1041,6 +1078,7 @@ noncomputable def lTensorHom : (N →ₗ[R] P) →ₗ[R] M ⊗[R] N →ₗ[R] M 
 #align linear_map.ltensor_hom LinearMap.lTensorHom
 
 /-- `rTensorHom M` is the natural linear map that sends a linear map `f : N →ₗ P` to `M ⊗ f`. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def rTensorHom : (N →ₗ[R] P) →ₗ[R] N ⊗[R] M →ₗ[R] P ⊗[R] M where
   toFun f := f.rTensor M
   map_add' f g := by
@@ -1212,6 +1250,7 @@ open LinearMap
 variable (R)
 
 /-- Auxiliary function to defining negation multiplication on tensor product. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def Neg.aux : FreeAddMonoid (M × N) →+ M ⊗[R] N :=
   FreeAddMonoid.lift fun p : M × N => (-p.1) ⊗ₜ p.2
 #align tensor_product.neg.aux TensorProduct.Neg.aux
@@ -1222,6 +1261,7 @@ theorem Neg.aux_of (m : M) (n : N) : Neg.aux R (FreeAddMonoid.of (m, n)) = (-m) 
   rfl
 #align tensor_product.neg.aux_of TensorProduct.Neg.aux_of
 
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable instance neg : Neg (M ⊗[R] N) where
   neg :=
     (addConGen (TensorProduct.Eqv R M N)).lift (Neg.aux R) <|
@@ -1254,6 +1294,7 @@ protected theorem add_left_neg (x : M ⊗[R] N) : -x + x = 0 :=
     rw [hx, hy, add_zero]
 #align tensor_product.add_left_neg TensorProduct.add_left_neg
 
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable instance addCommGroup : AddCommGroup (M ⊗[R] N) :=
   { TensorProduct.addCommMonoid with
     neg := Neg.neg
@@ -1299,8 +1340,7 @@ instance CompatibleSMul.int : CompatibleSMul R ℤ M N :=
       fun r ih => by simpa [sub_smul, tmul_sub, sub_tmul] using ih⟩
 #align tensor_product.compatible_smul.int TensorProduct.CompatibleSMul.int
 
-instance CompatibleSMul.unit {S} [Monoid S] [DistribMulAction S M]
-    [DistribMulAction S N]
+instance CompatibleSMul.unit {S} [Monoid S] [DistribMulAction S M] [DistribMulAction S N]
     [CompatibleSMul R S M N] : CompatibleSMul R Sˣ M N :=
   ⟨fun s m n => (CompatibleSMul.smul_tmul (s : S) m n : _)⟩
 #align tensor_product.compatible_smul.unit TensorProduct.CompatibleSMul.unit

--- a/Mathlib/LinearAlgebra/TensorProduct.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct.lean
@@ -78,10 +78,8 @@ noncomputable def TensorProduct : Type _ :=
 variable {R}
 
 set_option quotPrecheck false in
-/-- foobar -/
 scoped[TensorProduct] infixl:100 " ⊗ " => TensorProduct _
 
-/-- foobar -/
 scoped[TensorProduct] notation:100 M " ⊗[" R "] " N:100 => TensorProduct R M N
 
 namespace TensorProduct
@@ -90,7 +88,6 @@ section Module
 
 -- porting note: This is added as a local instance for `SMul.aux`.
 -- For some reason type-class inference in Lean 3 unfolded this definition.
-/-- foobar -/
 noncomputable def addMonoid : AddMonoid (M ⊗[R] N) :=
   { (addConGen (TensorProduct.Eqv R M N)).addMonoid with }
 
@@ -116,10 +113,8 @@ noncomputable def tmul (m : M) (n : N) : M ⊗[R] N :=
 
 variable {R}
 
-/-- foobar -/
 infixl:100 " ⊗ₜ " => tmul _
 
-/-- foobar -/
 notation:100 x " ⊗ₜ[" R "] " y:100 => tmul R x y
 
 -- porting note: make the arguments of induction_on explicit
@@ -175,7 +170,6 @@ needed if `TensorProduct.smul_tmul`, `TensorProduct.smul_tmul'`, or `TensorProdu
 used.
 -/
 class CompatibleSMul [DistribMulAction R' N] : Prop where
-  /-- foobar -/
   smul_tmul : ∀ (r : R') (m : M) (n : N), (r • m) ⊗ₜ n = m ⊗ₜ[R] (r • n)
 #align tensor_product.compatible_smul TensorProduct.CompatibleSMul
 

--- a/Mathlib/LinearAlgebra/TensorProduct.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct.lean
@@ -78,8 +78,10 @@ noncomputable def TensorProduct : Type _ :=
 variable {R}
 
 set_option quotPrecheck false in
+/-- foobar -/
 scoped[TensorProduct] infixl:100 " ⊗ " => TensorProduct _
 
+/-- foobar -/
 scoped[TensorProduct] notation:100 M " ⊗[" R "] " N:100 => TensorProduct R M N
 
 namespace TensorProduct
@@ -88,6 +90,7 @@ section Module
 
 -- porting note: This is added as a local instance for `SMul.aux`.
 -- For some reason type-class inference in Lean 3 unfolded this definition.
+/-- foobar -/
 noncomputable def addMonoid : AddMonoid (M ⊗[R] N) :=
   { (addConGen (TensorProduct.Eqv R M N)).addMonoid with }
 
@@ -113,8 +116,10 @@ noncomputable def tmul (m : M) (n : N) : M ⊗[R] N :=
 
 variable {R}
 
+/-- foobar -/
 infixl:100 " ⊗ₜ " => tmul _
 
+/-- foobar -/
 notation:100 x " ⊗ₜ[" R "] " y:100 => tmul R x y
 
 -- porting note: make the arguments of induction_on explicit
@@ -170,6 +175,7 @@ needed if `TensorProduct.smul_tmul`, `TensorProduct.smul_tmul'`, or `TensorProdu
 used.
 -/
 class CompatibleSMul [DistribMulAction R' N] : Prop where
+  /-- foobar -/
   smul_tmul : ∀ (r : R') (m : M) (n : N), (r • m) ⊗ₜ n = m ⊗ₜ[R] (r • n)
 #align tensor_product.compatible_smul TensorProduct.CompatibleSMul
 
@@ -1336,4 +1342,3 @@ theorem rTensor_neg (f : N →ₗ[R] P) : (-f).rTensor M = -f.rTensor M := by
 end LinearMap
 
 end Ring
-#lint

--- a/Mathlib/LinearAlgebra/TensorProduct.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct.lean
@@ -177,7 +177,7 @@ end
 
 /-- Note that this provides the default `compatible_smul R R M N` instance through
 `IsScalarTower.left`. -/
-noncomputable instance (priority := 100) CompatibleSMul.isScalarTower [SMul R' R]
+instance (priority := 100) CompatibleSMul.isScalarTower [SMul R' R]
     [IsScalarTower R' R M]
     [DistribMulAction R' N] [IsScalarTower R' R N] : CompatibleSMul R R' M N :=
   ⟨fun r m n => by
@@ -318,7 +318,7 @@ noncomputable instance leftModule : Module R'' (M ⊗[R] N) :=
 noncomputable instance : Module R (M ⊗[R] N) :=
   TensorProduct.leftModule
 
-noncomputable instance [Module R''ᵐᵒᵖ M] [IsCentralScalar R'' M] :
+instance [Module R''ᵐᵒᵖ M] [IsCentralScalar R'' M] :
     IsCentralScalar R'' (M ⊗[R] N) where
   op_smul_eq_smul r x :=
     x.induction_on (by rw [smul_zero, smul_zero])
@@ -332,7 +332,7 @@ variable {R'₂ : Type*} [Monoid R'₂] [DistribMulAction R'₂ M]
 variable [SMulCommClass R R'₂ M]
 
 /-- `SMulCommClass R' R'₂ M` implies `SMulCommClass R' R'₂ (M ⊗[R] N)` -/
-noncomputable instance smulCommClass_left [SMulCommClass R' R'₂ M] :
+instance smulCommClass_left [SMulCommClass R' R'₂ M] :
     SMulCommClass R' R'₂ (M ⊗[R] N) where
   smul_comm r' r'₂ x :=
     TensorProduct.induction_on x (by simp_rw [TensorProduct.smul_zero])
@@ -343,7 +343,7 @@ noncomputable instance smulCommClass_left [SMulCommClass R' R'₂ M] :
 variable [SMul R'₂ R']
 
 /-- `IsScalarTower R'₂ R' M` implies `IsScalarTower R'₂ R' (M ⊗[R] N)` -/
-noncomputable instance isScalarTower_left [IsScalarTower R'₂ R' M] :
+instance isScalarTower_left [IsScalarTower R'₂ R' M] :
     IsScalarTower R'₂ R' (M ⊗[R] N) :=
   ⟨fun s r x =>
     x.induction_on (by simp)
@@ -355,7 +355,7 @@ variable [DistribMulAction R'₂ N] [DistribMulAction R' N]
 variable [CompatibleSMul R R'₂ M N] [CompatibleSMul R R' M N]
 
 /-- `IsScalarTower R'₂ R' N` implies `IsScalarTower R'₂ R' (M ⊗[R] N)` -/
-noncomputable instance isScalarTower_right [IsScalarTower R'₂ R' N] :
+instance isScalarTower_right [IsScalarTower R'₂ R' N] :
     IsScalarTower R'₂ R' (M ⊗[R] N) :=
   ⟨fun s r x =>
     x.induction_on (by simp)
@@ -367,7 +367,7 @@ end
 
 /-- A short-cut instance for the common case, where the requirements for the `compatible_smul`
 instances are sufficient. -/
-noncomputable instance isScalarTower [SMul R' R] [IsScalarTower R' R M] :
+instance isScalarTower [SMul R' R] [IsScalarTower R' R M] :
     IsScalarTower R' R (M ⊗[R] N) :=
   TensorProduct.isScalarTower_left
 #align tensor_product.is_scalar_tower TensorProduct.isScalarTower
@@ -461,7 +461,7 @@ variable (f : M →ₗ[R] N →ₗ[R] P)
 /-- Auxiliary function to constructing a linear map `M ⊗ N → P` given a bilinear map `M → N → P`
 with the property that its composition with the canonical bilinear map `M → N → M ⊗ N` is
 the given bilinear map `M → N → P`. -/
-noncomputable def liftAux : M ⊗[R] N →+ P :=
+def liftAux : M ⊗[R] N →+ P :=
   (addConGen (TensorProduct.Eqv R M N)).lift (FreeAddMonoid.lift fun p : M × N => f p.1 p.2) <|
     AddCon.addConGen_le fun x y hxy =>
       match x, y, hxy with
@@ -497,7 +497,7 @@ variable (f)
 /-- Constructing a linear map `M ⊗ N → P` given a bilinear map `M → N → P` with the property that
 its composition with the canonical bilinear map `M → N → M ⊗ N` is
 the given bilinear map `M → N → P`. -/
-noncomputable def lift : M ⊗[R] N →ₗ[R] P :=
+def lift : M ⊗[R] N →ₗ[R] P :=
   { liftAux f with map_smul' := liftAux.smul }
 #align tensor_product.lift TensorProduct.lift
 
@@ -554,7 +554,7 @@ variable (R M N P)
 /-- Linearly constructing a linear map `M ⊗ N → P` given a bilinear map `M → N → P`
 with the property that its composition with the canonical bilinear map `M → N → M ⊗ N` is
 the given bilinear map `M → N → P`. -/
-noncomputable def uncurry : (M →ₗ[R] N →ₗ[R] P) →ₗ[R] M ⊗[R] N →ₗ[R] P :=
+def uncurry : (M →ₗ[R] N →ₗ[R] P) →ₗ[R] M ⊗[R] N →ₗ[R] P :=
   LinearMap.flip <| lift <| LinearMap.lflip.comp (LinearMap.flip LinearMap.id)
 #align tensor_product.uncurry TensorProduct.uncurry
 
@@ -1293,13 +1293,13 @@ When `R` is a `Ring` we get the required `TensorProduct.compatible_smul` instanc
 `IsScalarTower`, but when it is only a `Semiring` we need to build it from scratch.
 The instance diamond in `compatible_smul` doesn't matter because it's in `Prop`.
 -/
-noncomputable instance CompatibleSMul.int : CompatibleSMul R ℤ M N :=
+instance CompatibleSMul.int : CompatibleSMul R ℤ M N :=
   ⟨fun r m n =>
     Int.induction_on r (by simp) (fun r ih => by simpa [add_smul, tmul_add, add_tmul] using ih)
       fun r ih => by simpa [sub_smul, tmul_sub, sub_tmul] using ih⟩
 #align tensor_product.compatible_smul.int TensorProduct.CompatibleSMul.int
 
-noncomputable instance CompatibleSMul.unit {S} [Monoid S] [DistribMulAction S M]
+instance CompatibleSMul.unit {S} [Monoid S] [DistribMulAction S M]
     [DistribMulAction S N]
     [CompatibleSMul R S M N] : CompatibleSMul R Sˣ M N :=
   ⟨fun s m n => (CompatibleSMul.smul_tmul (s : S) m n : _)⟩

--- a/Mathlib/LinearAlgebra/TensorProduct.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct.lean
@@ -177,7 +177,8 @@ end
 
 /-- Note that this provides the default `compatible_smul R R M N` instance through
 `IsScalarTower.left`. -/
-noncomputable instance (priority := 100) CompatibleSMul.isScalarTower [SMul R' R] [IsScalarTower R' R M]
+noncomputable instance (priority := 100) CompatibleSMul.isScalarTower [SMul R' R]
+    [IsScalarTower R' R M]
     [DistribMulAction R' N] [IsScalarTower R' R N] : CompatibleSMul R R' M N :=
   ⟨fun r m n => by
     conv_lhs => rw [← one_smul R m]
@@ -317,7 +318,8 @@ noncomputable instance leftModule : Module R'' (M ⊗[R] N) :=
 noncomputable instance : Module R (M ⊗[R] N) :=
   TensorProduct.leftModule
 
-noncomputable instance [Module R''ᵐᵒᵖ M] [IsCentralScalar R'' M] : IsCentralScalar R'' (M ⊗[R] N) where
+noncomputable instance [Module R''ᵐᵒᵖ M] [IsCentralScalar R'' M] :
+    IsCentralScalar R'' (M ⊗[R] N) where
   op_smul_eq_smul r x :=
     x.induction_on (by rw [smul_zero, smul_zero])
       (fun x y => by rw [smul_tmul', smul_tmul', op_smul_eq_smul]) fun x y hx hy => by
@@ -330,7 +332,8 @@ variable {R'₂ : Type*} [Monoid R'₂] [DistribMulAction R'₂ M]
 variable [SMulCommClass R R'₂ M]
 
 /-- `SMulCommClass R' R'₂ M` implies `SMulCommClass R' R'₂ (M ⊗[R] N)` -/
-noncomputable instance smulCommClass_left [SMulCommClass R' R'₂ M] : SMulCommClass R' R'₂ (M ⊗[R] N) where
+noncomputable instance smulCommClass_left [SMulCommClass R' R'₂ M] :
+    SMulCommClass R' R'₂ (M ⊗[R] N) where
   smul_comm r' r'₂ x :=
     TensorProduct.induction_on x (by simp_rw [TensorProduct.smul_zero])
       (fun m n => by simp_rw [smul_tmul', smul_comm]) fun x y ihx ihy => by
@@ -340,7 +343,8 @@ noncomputable instance smulCommClass_left [SMulCommClass R' R'₂ M] : SMulCommC
 variable [SMul R'₂ R']
 
 /-- `IsScalarTower R'₂ R' M` implies `IsScalarTower R'₂ R' (M ⊗[R] N)` -/
-noncomputable instance isScalarTower_left [IsScalarTower R'₂ R' M] : IsScalarTower R'₂ R' (M ⊗[R] N) :=
+noncomputable instance isScalarTower_left [IsScalarTower R'₂ R' M] :
+    IsScalarTower R'₂ R' (M ⊗[R] N) :=
   ⟨fun s r x =>
     x.induction_on (by simp)
       (fun m n => by rw [smul_tmul', smul_tmul', smul_tmul', smul_assoc]) fun x y ihx ihy => by
@@ -351,7 +355,8 @@ variable [DistribMulAction R'₂ N] [DistribMulAction R' N]
 variable [CompatibleSMul R R'₂ M N] [CompatibleSMul R R' M N]
 
 /-- `IsScalarTower R'₂ R' N` implies `IsScalarTower R'₂ R' (M ⊗[R] N)` -/
-noncomputable instance isScalarTower_right [IsScalarTower R'₂ R' N] : IsScalarTower R'₂ R' (M ⊗[R] N) :=
+noncomputable instance isScalarTower_right [IsScalarTower R'₂ R' N] :
+    IsScalarTower R'₂ R' (M ⊗[R] N) :=
   ⟨fun s r x =>
     x.induction_on (by simp)
       (fun m n => by rw [← tmul_smul, ← tmul_smul, ← tmul_smul, smul_assoc]) fun x y ihx ihy => by
@@ -362,7 +367,8 @@ end
 
 /-- A short-cut instance for the common case, where the requirements for the `compatible_smul`
 instances are sufficient. -/
-noncomputable instance isScalarTower [SMul R' R] [IsScalarTower R' R M] : IsScalarTower R' R (M ⊗[R] N) :=
+noncomputable instance isScalarTower [SMul R' R] [IsScalarTower R' R M] :
+    IsScalarTower R' R (M ⊗[R] N) :=
   TensorProduct.isScalarTower_left
 #align tensor_product.is_scalar_tower TensorProduct.isScalarTower
 
@@ -936,7 +942,8 @@ combined with this definition, yields a bilinear multiplication on `M ⊗ N`:
 the `TensorProduct.semiring` instance (currently defined "by hand" using `TensorProduct.mul`).
 
 See also `mul_mul_mul_comm`. -/
-noncomputable def tensorTensorTensorComm : (M ⊗[R] N) ⊗[R] P ⊗[R] Q ≃ₗ[R] (M ⊗[R] P) ⊗[R] N ⊗[R] Q :=
+noncomputable def tensorTensorTensorComm :
+    (M ⊗[R] N) ⊗[R] P ⊗[R] Q ≃ₗ[R] (M ⊗[R] P) ⊗[R] N ⊗[R] Q :=
   let e₁ := TensorProduct.assoc R M N (P ⊗[R] Q)
   let e₂ := congr (1 : M ≃ₗ[R] M) (leftComm R N P Q)
   let e₃ := (TensorProduct.assoc R M P (N ⊗[R] Q)).symm
@@ -968,7 +975,8 @@ E.g., composition of linear maps gives a map `(M → N) ⊗ (N → P) → (M →
 `(M.dual ⊗ N) ⊗ (N.dual ⊗ P) → (M.dual ⊗ P)`, which agrees with the application of `contractRight`
 on `N ⊗ N.dual` after the suitable rebracketting.
 -/
-noncomputable def tensorTensorTensorAssoc : (M ⊗[R] N) ⊗[R] P ⊗[R] Q ≃ₗ[R] (M ⊗[R] N ⊗[R] P) ⊗[R] Q :=
+noncomputable def tensorTensorTensorAssoc :
+    (M ⊗[R] N) ⊗[R] P ⊗[R] Q ≃ₗ[R] (M ⊗[R] N ⊗[R] P) ⊗[R] Q :=
   (TensorProduct.assoc R (M ⊗[R] N) P Q).symm ≪≫ₗ
     congr (TensorProduct.assoc R M N P) (1 : Q ≃ₗ[R] Q)
 #align tensor_product.tensor_tensor_tensor_assoc TensorProduct.tensorTensorTensorAssoc
@@ -1291,7 +1299,8 @@ noncomputable instance CompatibleSMul.int : CompatibleSMul R ℤ M N :=
       fun r ih => by simpa [sub_smul, tmul_sub, sub_tmul] using ih⟩
 #align tensor_product.compatible_smul.int TensorProduct.CompatibleSMul.int
 
-noncomputable instance CompatibleSMul.unit {S} [Monoid S] [DistribMulAction S M] [DistribMulAction S N]
+noncomputable instance CompatibleSMul.unit {S} [Monoid S] [DistribMulAction S M]
+    [DistribMulAction S N]
     [CompatibleSMul R S M N] : CompatibleSMul R Sˣ M N :=
   ⟨fun s m n => (CompatibleSMul.smul_tmul (s : S) m n : _)⟩
 #align tensor_product.compatible_smul.unit TensorProduct.CompatibleSMul.unit
@@ -1327,3 +1336,4 @@ theorem rTensor_neg (f : N →ₗ[R] P) : (-f).rTensor M = -f.rTensor M := by
 end LinearMap
 
 end Ring
+#lint

--- a/Mathlib/LinearAlgebra/TensorProduct.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct.lean
@@ -71,7 +71,7 @@ variable (R)
 
 /-- The tensor product of two modules `M` and `N` over the same commutative semiring `R`.
 The localized notations are `M ⊗ N` and `M ⊗[R] N`, accessed by `open scoped TensorProduct`. -/
-def TensorProduct : Type _ :=
+noncomputable def TensorProduct : Type _ :=
   (addConGen (TensorProduct.Eqv R M N)).Quotient
 #align tensor_product TensorProduct
 
@@ -88,26 +88,26 @@ section Module
 
 -- porting note: This is added as a local instance for `SMul.aux`.
 -- For some reason type-class inference in Lean 3 unfolded this definition.
-def addMonoid : AddMonoid (M ⊗[R] N) :=
+noncomputable def addMonoid : AddMonoid (M ⊗[R] N) :=
   { (addConGen (TensorProduct.Eqv R M N)).addMonoid with }
 
-instance addZeroClass : AddZeroClass (M ⊗[R] N) :=
+noncomputable instance addZeroClass : AddZeroClass (M ⊗[R] N) :=
   { (addConGen (TensorProduct.Eqv R M N)).addMonoid with }
 
-instance addCommSemigroup : AddCommSemigroup (M ⊗[R] N) :=
+noncomputable instance addCommSemigroup : AddCommSemigroup (M ⊗[R] N) :=
   { (addConGen (TensorProduct.Eqv R M N)).addMonoid with
     add_comm := fun x y =>
       AddCon.induction_on₂ x y fun _ _ =>
         Quotient.sound' <| AddConGen.Rel.of _ _ <| Eqv.add_comm _ _ }
 
-instance : Inhabited (M ⊗[R] N) :=
+noncomputable instance : Inhabited (M ⊗[R] N) :=
   ⟨0⟩
 
 variable (R) {M N}
 
 /-- The canonical function `M → N → M ⊗ N`. The localized notations are `m ⊗ₜ n` and `m ⊗ₜ[R] n`,
 accessed by `open scoped TensorProduct`. -/
-def tmul (m : M) (n : N) : M ⊗[R] N :=
+noncomputable def tmul (m : M) (n : N) : M ⊗[R] N :=
   AddCon.mk' _ <| FreeAddMonoid.of (m, n)
 #align tensor_product.tmul TensorProduct.tmul
 
@@ -177,7 +177,7 @@ end
 
 /-- Note that this provides the default `compatible_smul R R M N` instance through
 `IsScalarTower.left`. -/
-instance (priority := 100) CompatibleSMul.isScalarTower [SMul R' R] [IsScalarTower R' R M]
+noncomputable instance (priority := 100) CompatibleSMul.isScalarTower [SMul R' R] [IsScalarTower R' R M]
     [DistribMulAction R' N] [IsScalarTower R' R N] : CompatibleSMul R R' M N :=
   ⟨fun r m n => by
     conv_lhs => rw [← one_smul R m]
@@ -194,7 +194,7 @@ theorem smul_tmul [DistribMulAction R' N] [CompatibleSMul R R' M N] (r : R') (m 
 
 attribute [local instance] addMonoid
 /-- Auxiliary function to defining scalar multiplication on tensor product. -/
-def SMul.aux {R' : Type*} [SMul R' M] (r : R') : FreeAddMonoid (M × N) →+ M ⊗[R] N :=
+noncomputable def SMul.aux {R' : Type*} [SMul R' M] (r : R') : FreeAddMonoid (M × N) →+ M ⊗[R] N :=
   FreeAddMonoid.lift fun p : M × N => (r • p.1) ⊗ₜ p.2
 #align tensor_product.smul.aux TensorProduct.SMul.aux
 attribute [-instance] addMonoid
@@ -218,7 +218,7 @@ action. Two natural ways in which this situation arises are:
 Note that in the special case that `R = R'`, since `R` is commutative, we just get the usual scalar
 action on a tensor product of two modules. This special case is important enough that, for
 performance reasons, we define it explicitly below. -/
-instance leftHasSMul : SMul R' (M ⊗[R] N) :=
+noncomputable instance leftHasSMul : SMul R' (M ⊗[R] N) :=
   ⟨fun r =>
     (addConGen (TensorProduct.Eqv R M N)).lift (SMul.aux r : _ →+ M ⊗[R] N) <|
       AddCon.addConGen_le fun x y hxy =>
@@ -237,7 +237,7 @@ instance leftHasSMul : SMul R' (M ⊗[R] N) :=
           (AddCon.ker_rel _).2 <| by simp_rw [map_add, add_comm]⟩
 #align tensor_product.left_has_smul TensorProduct.leftHasSMul
 
-instance : SMul R (M ⊗[R] N) :=
+noncomputable instance : SMul R (M ⊗[R] N) :=
   TensorProduct.leftHasSMul
 
 protected theorem smul_zero (r : R') : r • (0 : M ⊗[R] N) = 0 :=
@@ -270,7 +270,7 @@ protected theorem add_smul (r s : R'') (x : M ⊗[R] N) : (r + s) • x = r • 
     rw [ihx, ihy, add_add_add_comm]
 #align tensor_product.add_smul TensorProduct.add_smul
 
-instance addCommMonoid : AddCommMonoid (M ⊗[R] N) :=
+noncomputable instance addCommMonoid : AddCommMonoid (M ⊗[R] N) :=
   { TensorProduct.addCommSemigroup _ _,
     TensorProduct.addZeroClass _ _ with
     nsmul := fun n v => n • v
@@ -278,7 +278,7 @@ instance addCommMonoid : AddCommMonoid (M ⊗[R] N) :=
     nsmul_succ := by simp only [TensorProduct.one_smul, TensorProduct.add_smul, add_comm,
       forall_const] }
 
-instance leftDistribMulAction : DistribMulAction R' (M ⊗[R] N) :=
+noncomputable instance leftDistribMulAction : DistribMulAction R' (M ⊗[R] N) :=
   have : ∀ (r : R') (m : M) (n : N), r • m ⊗ₜ[R] n = (r • m) ⊗ₜ n := fun _ _ _ => rfl
   { smul := (· • ·)
     smul_add := fun r x y => TensorProduct.smul_add r x y
@@ -291,7 +291,7 @@ instance leftDistribMulAction : DistribMulAction R' (M ⊗[R] N) :=
     smul_zero := TensorProduct.smul_zero }
 #align tensor_product.left_distrib_mul_action TensorProduct.leftDistribMulAction
 
-instance : DistribMulAction R (M ⊗[R] N) :=
+noncomputable instance : DistribMulAction R (M ⊗[R] N) :=
   TensorProduct.leftDistribMulAction
 
 theorem smul_tmul' (r : R') (m : M) (n : N) : r • m ⊗ₜ[R] n = (r • m) ⊗ₜ n :=
@@ -308,16 +308,16 @@ theorem smul_tmul_smul (r s : R) (m : M) (n : N) : (r • m) ⊗ₜ[R] (s • n)
   simp_rw [smul_tmul, tmul_smul, mul_smul]
 #align tensor_product.smul_tmul_smul TensorProduct.smul_tmul_smul
 
-instance leftModule : Module R'' (M ⊗[R] N) :=
+noncomputable instance leftModule : Module R'' (M ⊗[R] N) :=
   { TensorProduct.leftDistribMulAction with
     add_smul := TensorProduct.add_smul
     zero_smul := TensorProduct.zero_smul }
 #align tensor_product.left_module TensorProduct.leftModule
 
-instance : Module R (M ⊗[R] N) :=
+noncomputable instance : Module R (M ⊗[R] N) :=
   TensorProduct.leftModule
 
-instance [Module R''ᵐᵒᵖ M] [IsCentralScalar R'' M] : IsCentralScalar R'' (M ⊗[R] N) where
+noncomputable instance [Module R''ᵐᵒᵖ M] [IsCentralScalar R'' M] : IsCentralScalar R'' (M ⊗[R] N) where
   op_smul_eq_smul r x :=
     x.induction_on (by rw [smul_zero, smul_zero])
       (fun x y => by rw [smul_tmul', smul_tmul', op_smul_eq_smul]) fun x y hx hy => by
@@ -330,7 +330,7 @@ variable {R'₂ : Type*} [Monoid R'₂] [DistribMulAction R'₂ M]
 variable [SMulCommClass R R'₂ M]
 
 /-- `SMulCommClass R' R'₂ M` implies `SMulCommClass R' R'₂ (M ⊗[R] N)` -/
-instance smulCommClass_left [SMulCommClass R' R'₂ M] : SMulCommClass R' R'₂ (M ⊗[R] N) where
+noncomputable instance smulCommClass_left [SMulCommClass R' R'₂ M] : SMulCommClass R' R'₂ (M ⊗[R] N) where
   smul_comm r' r'₂ x :=
     TensorProduct.induction_on x (by simp_rw [TensorProduct.smul_zero])
       (fun m n => by simp_rw [smul_tmul', smul_comm]) fun x y ihx ihy => by
@@ -340,7 +340,7 @@ instance smulCommClass_left [SMulCommClass R' R'₂ M] : SMulCommClass R' R'₂ 
 variable [SMul R'₂ R']
 
 /-- `IsScalarTower R'₂ R' M` implies `IsScalarTower R'₂ R' (M ⊗[R] N)` -/
-instance isScalarTower_left [IsScalarTower R'₂ R' M] : IsScalarTower R'₂ R' (M ⊗[R] N) :=
+noncomputable instance isScalarTower_left [IsScalarTower R'₂ R' M] : IsScalarTower R'₂ R' (M ⊗[R] N) :=
   ⟨fun s r x =>
     x.induction_on (by simp)
       (fun m n => by rw [smul_tmul', smul_tmul', smul_tmul', smul_assoc]) fun x y ihx ihy => by
@@ -351,7 +351,7 @@ variable [DistribMulAction R'₂ N] [DistribMulAction R' N]
 variable [CompatibleSMul R R'₂ M N] [CompatibleSMul R R' M N]
 
 /-- `IsScalarTower R'₂ R' N` implies `IsScalarTower R'₂ R' (M ⊗[R] N)` -/
-instance isScalarTower_right [IsScalarTower R'₂ R' N] : IsScalarTower R'₂ R' (M ⊗[R] N) :=
+noncomputable instance isScalarTower_right [IsScalarTower R'₂ R' N] : IsScalarTower R'₂ R' (M ⊗[R] N) :=
   ⟨fun s r x =>
     x.induction_on (by simp)
       (fun m n => by rw [← tmul_smul, ← tmul_smul, ← tmul_smul, smul_assoc]) fun x y ihx ihy => by
@@ -362,7 +362,7 @@ end
 
 /-- A short-cut instance for the common case, where the requirements for the `compatible_smul`
 instances are sufficient. -/
-instance isScalarTower [SMul R' R] [IsScalarTower R' R M] : IsScalarTower R' R (M ⊗[R] N) :=
+noncomputable instance isScalarTower [SMul R' R] [IsScalarTower R' R M] : IsScalarTower R' R (M ⊗[R] N) :=
   TensorProduct.isScalarTower_left
 #align tensor_product.is_scalar_tower TensorProduct.isScalarTower
 
@@ -370,7 +370,7 @@ instance isScalarTower [SMul R' R] [IsScalarTower R' R M] : IsScalarTower R' R (
 variable (R M N)
 
 /-- The canonical bilinear map `M → N → M ⊗[R] N`. -/
-def mk : M →ₗ[R] N →ₗ[R] M ⊗[R] N :=
+noncomputable def mk : M →ₗ[R] N →ₗ[R] M ⊗[R] N :=
   LinearMap.mk₂ R (· ⊗ₜ ·) add_tmul (fun c m n => by simp_rw [smul_tmul, tmul_smul])
     tmul_add tmul_smul
 #align tensor_product.mk TensorProduct.mk
@@ -455,7 +455,7 @@ variable (f : M →ₗ[R] N →ₗ[R] P)
 /-- Auxiliary function to constructing a linear map `M ⊗ N → P` given a bilinear map `M → N → P`
 with the property that its composition with the canonical bilinear map `M → N → M ⊗ N` is
 the given bilinear map `M → N → P`. -/
-def liftAux : M ⊗[R] N →+ P :=
+noncomputable def liftAux : M ⊗[R] N →+ P :=
   (addConGen (TensorProduct.Eqv R M N)).lift (FreeAddMonoid.lift fun p : M × N => f p.1 p.2) <|
     AddCon.addConGen_le fun x y hxy =>
       match x, y, hxy with
@@ -491,7 +491,7 @@ variable (f)
 /-- Constructing a linear map `M ⊗ N → P` given a bilinear map `M → N → P` with the property that
 its composition with the canonical bilinear map `M → N → M ⊗ N` is
 the given bilinear map `M → N → P`. -/
-def lift : M ⊗[R] N →ₗ[R] P :=
+noncomputable def lift : M ⊗[R] N →ₗ[R] P :=
   { liftAux f with map_smul' := liftAux.smul }
 #align tensor_product.lift TensorProduct.lift
 
@@ -548,7 +548,7 @@ variable (R M N P)
 /-- Linearly constructing a linear map `M ⊗ N → P` given a bilinear map `M → N → P`
 with the property that its composition with the canonical bilinear map `M → N → M ⊗ N` is
 the given bilinear map `M → N → P`. -/
-def uncurry : (M →ₗ[R] N →ₗ[R] P) →ₗ[R] M ⊗[R] N →ₗ[R] P :=
+noncomputable def uncurry : (M →ₗ[R] N →ₗ[R] P) →ₗ[R] M ⊗[R] N →ₗ[R] P :=
   LinearMap.flip <| lift <| LinearMap.lflip.comp (LinearMap.flip LinearMap.id)
 #align tensor_product.uncurry TensorProduct.uncurry
 
@@ -564,7 +564,7 @@ variable (R M N P)
 /-- A linear equivalence constructing a linear map `M ⊗ N → P` given a bilinear map `M → N → P`
 with the property that its composition with the canonical bilinear map `M → N → M ⊗ N` is
 the given bilinear map `M → N → P`. -/
-def lift.equiv : (M →ₗ[R] N →ₗ[R] P) ≃ₗ[R] M ⊗[R] N →ₗ[R] P :=
+noncomputable def lift.equiv : (M →ₗ[R] N →ₗ[R] P) ≃ₗ[R] M ⊗[R] N →ₗ[R] P :=
   { uncurry R M N P with
     invFun := fun f => (mk R M N).compr₂ f
     left_inv := fun _ => LinearMap.ext₂ fun _ _ => lift.tmul _ _
@@ -585,7 +585,7 @@ theorem lift.equiv_symm_apply (f : M ⊗[R] N →ₗ[R] P) (m : M) (n : N) :
 
 /-- Given a linear map `M ⊗ N → P`, compose it with the canonical bilinear map `M → N → M ⊗ N` to
 form a bilinear map `M → N → P`. -/
-def lcurry : (M ⊗[R] N →ₗ[R] P) →ₗ[R] M →ₗ[R] N →ₗ[R] P :=
+noncomputable def lcurry : (M ⊗[R] N →ₗ[R] P) →ₗ[R] M →ₗ[R] N →ₗ[R] P :=
   (lift.equiv R M N P).symm
 #align tensor_product.lcurry TensorProduct.lcurry
 
@@ -598,7 +598,7 @@ theorem lcurry_apply (f : M ⊗[R] N →ₗ[R] P) (m : M) (n : N) : lcurry R M N
 
 /-- Given a linear map `M ⊗ N → P`, compose it with the canonical bilinear map `M → N → M ⊗ N` to
 form a bilinear map `M → N → P`. -/
-def curry (f : M ⊗[R] N →ₗ[R] P) : M →ₗ[R] N →ₗ[R] P :=
+noncomputable def curry (f : M ⊗[R] N →ₗ[R] P) : M →ₗ[R] N →ₗ[R] P :=
   lcurry R M N P f
 #align tensor_product.curry TensorProduct.curry
 
@@ -642,7 +642,7 @@ variable (R M)
 
 /-- The base ring is a left identity for the tensor product of modules, up to linear equivalence.
 -/
-protected def lid : R ⊗[R] M ≃ₗ[R] M :=
+protected noncomputable def lid : R ⊗[R] M ≃ₗ[R] M :=
   LinearEquiv.ofLinear (lift <| LinearMap.lsmul R M) (mk R R M 1) (LinearMap.ext fun _ => by simp)
     (ext' fun r m => by simp; rw [← tmul_smul, ← smul_tmul, smul_eq_mul, mul_one])
 #align tensor_product.lid TensorProduct.lid
@@ -665,7 +665,7 @@ variable (R M N)
 
 /-- The tensor product of modules is commutative, up to linear equivalence.
 -/
-protected def comm : M ⊗[R] N ≃ₗ[R] N ⊗[R] M :=
+protected noncomputable def comm : M ⊗[R] N ≃ₗ[R] N ⊗[R] M :=
   LinearEquiv.ofLinear (lift (mk R N M).flip) (lift (mk R M N).flip) (ext' fun _ _ => rfl)
     (ext' fun _ _ => rfl)
 #align tensor_product.comm TensorProduct.comm
@@ -688,7 +688,7 @@ variable (R M)
 
 /-- The base ring is a right identity for the tensor product of modules, up to linear equivalence.
 -/
-protected def rid : M ⊗[R] R ≃ₗ[R] M :=
+protected noncomputable def rid : M ⊗[R] R ≃ₗ[R] M :=
   LinearEquiv.trans (TensorProduct.comm R M R) (TensorProduct.lid R M)
 #align tensor_product.rid TensorProduct.rid
 
@@ -711,7 +711,7 @@ section
 variable (R M N P)
 
 /-- The associator for tensor product of R-modules, as a linear equivalence. -/
-protected def assoc : (M ⊗[R] N) ⊗[R] P ≃ₗ[R] M ⊗[R] N ⊗[R] P := by
+protected noncomputable def assoc : (M ⊗[R] N) ⊗[R] P ≃ₗ[R] M ⊗[R] N ⊗[R] P := by
   refine
       LinearEquiv.ofLinear (lift <| lift <| comp (lcurry R _ _ _) <| mk _ _ _)
         (lift <| comp (uncurry R _ _ _) <| curry <| mk _ _ _)
@@ -738,7 +738,7 @@ theorem assoc_symm_tmul (m : M) (n : N) (p : P) :
 #align tensor_product.assoc_symm_tmul TensorProduct.assoc_symm_tmul
 
 /-- The tensor product of a pair of linear maps between modules. -/
-def map (f : M →ₗ[R] P) (g : N →ₗ[R] Q) : M ⊗[R] N →ₗ[R] P ⊗[R] Q :=
+noncomputable def map (f : M →ₗ[R] P) (g : N →ₗ[R] Q) : M ⊗[R] N →ₗ[R] P ⊗[R] Q :=
   lift <| comp (compl₂ (mk _ _ _) g) f
 #align tensor_product.map TensorProduct.map
 
@@ -763,7 +763,7 @@ theorem map_range_eq_span_tmul (f : M →ₗ[R] P) (g : N →ₗ[R] Q) :
 
 /-- Given submodules `p ⊆ P` and `q ⊆ Q`, this is the natural map: `p ⊗ q → P ⊗ Q`. -/
 @[simp]
-def mapIncl (p : Submodule R P) (q : Submodule R Q) : p ⊗[R] q →ₗ[R] P ⊗[R] Q :=
+noncomputable def mapIncl (p : Submodule R P) (q : Submodule R Q) : p ⊗[R] q →ₗ[R] P ⊗[R] Q :=
   map p.subtype q.subtype
 #align tensor_product.map_incl TensorProduct.mapIncl
 
@@ -834,23 +834,23 @@ theorem map_smul_right (r : R) (f : M →ₗ[R] P) (g : N →ₗ[R] Q) : map f (
 variable (R M N P Q)
 
 /-- The tensor product of a pair of linear maps between modules, bilinear in both maps. -/
-def mapBilinear : (M →ₗ[R] P) →ₗ[R] (N →ₗ[R] Q) →ₗ[R] M ⊗[R] N →ₗ[R] P ⊗[R] Q :=
+noncomputable def mapBilinear : (M →ₗ[R] P) →ₗ[R] (N →ₗ[R] Q) →ₗ[R] M ⊗[R] N →ₗ[R] P ⊗[R] Q :=
   LinearMap.mk₂ R map map_add_left map_smul_left map_add_right map_smul_right
 #align tensor_product.map_bilinear TensorProduct.mapBilinear
 
 /-- The canonical linear map from `P ⊗[R] (M →ₗ[R] Q)` to `(M →ₗ[R] P ⊗[R] Q)` -/
-def lTensorHomToHomLTensor : P ⊗[R] (M →ₗ[R] Q) →ₗ[R] M →ₗ[R] P ⊗[R] Q :=
+noncomputable def lTensorHomToHomLTensor : P ⊗[R] (M →ₗ[R] Q) →ₗ[R] M →ₗ[R] P ⊗[R] Q :=
   TensorProduct.lift (llcomp R M Q _ ∘ₗ mk R P Q)
 #align tensor_product.ltensor_hom_to_hom_ltensor TensorProduct.lTensorHomToHomLTensor
 
 /-- The canonical linear map from `(M →ₗ[R] P) ⊗[R] Q` to `(M →ₗ[R] P ⊗[R] Q)` -/
-def rTensorHomToHomRTensor : (M →ₗ[R] P) ⊗[R] Q →ₗ[R] M →ₗ[R] P ⊗[R] Q :=
+noncomputable def rTensorHomToHomRTensor : (M →ₗ[R] P) ⊗[R] Q →ₗ[R] M →ₗ[R] P ⊗[R] Q :=
   TensorProduct.lift (llcomp R M P _ ∘ₗ (mk R P Q).flip).flip
 #align tensor_product.rtensor_hom_to_hom_rtensor TensorProduct.rTensorHomToHomRTensor
 
 /-- The linear map from `(M →ₗ P) ⊗ (N →ₗ Q)` to `(M ⊗ N →ₗ P ⊗ Q)` sending `f ⊗ₜ g` to
 the `TensorProduct.map f g`, the tensor product of the two maps. -/
-def homTensorHomMap : (M →ₗ[R] P) ⊗[R] (N →ₗ[R] Q) →ₗ[R] M ⊗[R] N →ₗ[R] P ⊗[R] Q :=
+noncomputable def homTensorHomMap : (M →ₗ[R] P) ⊗[R] (N →ₗ[R] Q) →ₗ[R] M ⊗[R] N →ₗ[R] P ⊗[R] Q :=
   lift (mapBilinear R M N P Q)
 #align tensor_product.hom_tensor_hom_map TensorProduct.homTensorHomMap
 
@@ -883,7 +883,7 @@ end
 
 /-- If `M` and `P` are linearly equivalent and `N` and `Q` are linearly equivalent
 then `M ⊗ N` and `P ⊗ Q` are linearly equivalent. -/
-def congr (f : M ≃ₗ[R] P) (g : N ≃ₗ[R] Q) : M ⊗[R] N ≃ₗ[R] P ⊗[R] Q :=
+noncomputable def congr (f : M ≃ₗ[R] P) (g : N ≃ₗ[R] Q) : M ⊗[R] N ≃ₗ[R] P ⊗[R] Q :=
   LinearEquiv.ofLinear (map f g) (map f.symm g.symm)
     (ext' fun m n => by simp)
     (ext' fun m n => by simp)
@@ -904,7 +904,7 @@ theorem congr_symm_tmul (f : M ≃ₗ[R] P) (g : N ≃ₗ[R] Q) (p : P) (q : Q) 
 variable (R M N P Q)
 
 /-- A tensor product analogue of `mul_left_comm`. -/
-def leftComm : M ⊗[R] N ⊗[R] P ≃ₗ[R] N ⊗[R] M ⊗[R] P :=
+noncomputable def leftComm : M ⊗[R] N ⊗[R] P ≃ₗ[R] N ⊗[R] M ⊗[R] P :=
   let e₁ := (TensorProduct.assoc R M N P).symm
   let e₂ := congr (TensorProduct.comm R M N) (1 : P ≃ₗ[R] P)
   let e₃ := TensorProduct.assoc R N M P
@@ -936,7 +936,7 @@ combined with this definition, yields a bilinear multiplication on `M ⊗ N`:
 the `TensorProduct.semiring` instance (currently defined "by hand" using `TensorProduct.mul`).
 
 See also `mul_mul_mul_comm`. -/
-def tensorTensorTensorComm : (M ⊗[R] N) ⊗[R] P ⊗[R] Q ≃ₗ[R] (M ⊗[R] P) ⊗[R] N ⊗[R] Q :=
+noncomputable def tensorTensorTensorComm : (M ⊗[R] N) ⊗[R] P ⊗[R] Q ≃ₗ[R] (M ⊗[R] P) ⊗[R] N ⊗[R] Q :=
   let e₁ := TensorProduct.assoc R M N (P ⊗[R] Q)
   let e₂ := congr (1 : M ≃ₗ[R] M) (leftComm R N P Q)
   let e₃ := (TensorProduct.assoc R M P (N ⊗[R] Q)).symm
@@ -968,7 +968,7 @@ E.g., composition of linear maps gives a map `(M → N) ⊗ (N → P) → (M →
 `(M.dual ⊗ N) ⊗ (N.dual ⊗ P) → (M.dual ⊗ P)`, which agrees with the application of `contractRight`
 on `N ⊗ N.dual` after the suitable rebracketting.
 -/
-def tensorTensorTensorAssoc : (M ⊗[R] N) ⊗[R] P ⊗[R] Q ≃ₗ[R] (M ⊗[R] N ⊗[R] P) ⊗[R] Q :=
+noncomputable def tensorTensorTensorAssoc : (M ⊗[R] N) ⊗[R] P ⊗[R] Q ≃ₗ[R] (M ⊗[R] N ⊗[R] P) ⊗[R] Q :=
   (TensorProduct.assoc R (M ⊗[R] N) P Q).symm ≪≫ₗ
     congr (TensorProduct.assoc R M N P) (1 : Q ≃ₗ[R] Q)
 #align tensor_product.tensor_tensor_tensor_assoc TensorProduct.tensorTensorTensorAssoc
@@ -995,12 +995,12 @@ namespace LinearMap
 variable {N}
 
 /-- `lTensor M f : M ⊗ N →ₗ M ⊗ P` is the natural linear map induced by `f : N →ₗ P`. -/
-def lTensor (f : N →ₗ[R] P) : M ⊗[R] N →ₗ[R] M ⊗[R] P :=
+noncomputable def lTensor (f : N →ₗ[R] P) : M ⊗[R] N →ₗ[R] M ⊗[R] P :=
   TensorProduct.map id f
 #align linear_map.ltensor LinearMap.lTensor
 
 /-- `rTensor f M : N₁ ⊗ M →ₗ N₂ ⊗ M` is the natural linear map induced by `f : N₁ →ₗ N₂`. -/
-def rTensor (f : N →ₗ[R] P) : N ⊗[R] M →ₗ[R] P ⊗[R] M :=
+noncomputable def rTensor (f : N →ₗ[R] P) : N ⊗[R] M →ₗ[R] P ⊗[R] M :=
   TensorProduct.map f id
 #align linear_map.rtensor LinearMap.rTensor
 
@@ -1021,7 +1021,7 @@ open TensorProduct
 attribute [local ext high] TensorProduct.ext
 
 /-- `lTensorHom M` is the natural linear map that sends a linear map `f : N →ₗ P` to `M ⊗ f`. -/
-def lTensorHom : (N →ₗ[R] P) →ₗ[R] M ⊗[R] N →ₗ[R] M ⊗[R] P where
+noncomputable def lTensorHom : (N →ₗ[R] P) →ₗ[R] M ⊗[R] N →ₗ[R] M ⊗[R] P where
   toFun := lTensor M
   map_add' f g := by
     ext x y
@@ -1033,7 +1033,7 @@ def lTensorHom : (N →ₗ[R] P) →ₗ[R] M ⊗[R] N →ₗ[R] M ⊗[R] P where
 #align linear_map.ltensor_hom LinearMap.lTensorHom
 
 /-- `rTensorHom M` is the natural linear map that sends a linear map `f : N →ₗ P` to `M ⊗ f`. -/
-def rTensorHom : (N →ₗ[R] P) →ₗ[R] N ⊗[R] M →ₗ[R] P ⊗[R] M where
+noncomputable def rTensorHom : (N →ₗ[R] P) →ₗ[R] N ⊗[R] M →ₗ[R] P ⊗[R] M where
   toFun f := f.rTensor M
   map_add' f g := by
     ext x y
@@ -1204,7 +1204,7 @@ open LinearMap
 variable (R)
 
 /-- Auxiliary function to defining negation multiplication on tensor product. -/
-def Neg.aux : FreeAddMonoid (M × N) →+ M ⊗[R] N :=
+noncomputable def Neg.aux : FreeAddMonoid (M × N) →+ M ⊗[R] N :=
   FreeAddMonoid.lift fun p : M × N => (-p.1) ⊗ₜ p.2
 #align tensor_product.neg.aux TensorProduct.Neg.aux
 
@@ -1214,7 +1214,7 @@ theorem Neg.aux_of (m : M) (n : N) : Neg.aux R (FreeAddMonoid.of (m, n)) = (-m) 
   rfl
 #align tensor_product.neg.aux_of TensorProduct.Neg.aux_of
 
-instance neg : Neg (M ⊗[R] N) where
+noncomputable instance neg : Neg (M ⊗[R] N) where
   neg :=
     (addConGen (TensorProduct.Eqv R M N)).lift (Neg.aux R) <|
       AddCon.addConGen_le fun x y hxy =>
@@ -1246,7 +1246,7 @@ protected theorem add_left_neg (x : M ⊗[R] N) : -x + x = 0 :=
     rw [hx, hy, add_zero]
 #align tensor_product.add_left_neg TensorProduct.add_left_neg
 
-instance addCommGroup : AddCommGroup (M ⊗[R] N) :=
+noncomputable instance addCommGroup : AddCommGroup (M ⊗[R] N) :=
   { TensorProduct.addCommMonoid with
     neg := Neg.neg
     sub := _
@@ -1285,13 +1285,13 @@ When `R` is a `Ring` we get the required `TensorProduct.compatible_smul` instanc
 `IsScalarTower`, but when it is only a `Semiring` we need to build it from scratch.
 The instance diamond in `compatible_smul` doesn't matter because it's in `Prop`.
 -/
-instance CompatibleSMul.int : CompatibleSMul R ℤ M N :=
+noncomputable instance CompatibleSMul.int : CompatibleSMul R ℤ M N :=
   ⟨fun r m n =>
     Int.induction_on r (by simp) (fun r ih => by simpa [add_smul, tmul_add, add_tmul] using ih)
       fun r ih => by simpa [sub_smul, tmul_sub, sub_tmul] using ih⟩
 #align tensor_product.compatible_smul.int TensorProduct.CompatibleSMul.int
 
-instance CompatibleSMul.unit {S} [Monoid S] [DistribMulAction S M] [DistribMulAction S N]
+noncomputable instance CompatibleSMul.unit {S} [Monoid S] [DistribMulAction S M] [DistribMulAction S N]
     [CompatibleSMul R S M N] : CompatibleSMul R Sˣ M N :=
   ⟨fun s m n => (CompatibleSMul.smul_tmul (s : S) m n : _)⟩
 #align tensor_product.compatible_smul.unit TensorProduct.CompatibleSMul.unit

--- a/Mathlib/LinearAlgebra/TensorProduct/Opposite.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Opposite.lean
@@ -27,6 +27,7 @@ open MulOpposite
 
 /-- `MulOpposite` distributes over `TensorProduct`. Note this is an `S`-algebra morphism, where
 `A/S/R` is a tower of algebras. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def opAlgEquiv : Aᵐᵒᵖ ⊗[R] Bᵐᵒᵖ ≃ₐ[S] (A ⊗[R] B)ᵐᵒᵖ :=
   letI e₁ : Aᵐᵒᵖ ⊗[R] Bᵐᵒᵖ ≃ₗ[S] (A ⊗[R] B)ᵐᵒᵖ :=
     TensorProduct.AlgebraTensorModule.congr

--- a/Mathlib/LinearAlgebra/TensorProduct/Opposite.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Opposite.lean
@@ -27,7 +27,7 @@ open MulOpposite
 
 /-- `MulOpposite` distributes over `TensorProduct`. Note this is an `S`-algebra morphism, where
 `A/S/R` is a tower of algebras. -/
-def opAlgEquiv : Aᵐᵒᵖ ⊗[R] Bᵐᵒᵖ ≃ₐ[S] (A ⊗[R] B)ᵐᵒᵖ :=
+noncomputable def opAlgEquiv : Aᵐᵒᵖ ⊗[R] Bᵐᵒᵖ ≃ₐ[S] (A ⊗[R] B)ᵐᵒᵖ :=
   letI e₁ : Aᵐᵒᵖ ⊗[R] Bᵐᵒᵖ ≃ₗ[S] (A ⊗[R] B)ᵐᵒᵖ :=
     TensorProduct.AlgebraTensorModule.congr
       (opLinearEquiv S).symm (opLinearEquiv R).symm ≪≫ₗ opLinearEquiv S

--- a/Mathlib/LinearAlgebra/TensorProduct/Prod.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Prod.lean
@@ -28,7 +28,7 @@ variable [Module R M₁] [Module R M₂] [Module R M₃]
 attribute [ext] TensorProduct.ext
 
 /-- Tensor products distribute over a product on the right. -/
-def prodRight : M₁ ⊗[R] (M₂ × M₃) ≃ₗ[R] ((M₁ ⊗[R] M₂) × (M₁ ⊗[R] M₃)) :=
+noncomputable def prodRight : M₁ ⊗[R] (M₂ × M₃) ≃ₗ[R] ((M₁ ⊗[R] M₂) × (M₁ ⊗[R] M₃)) :=
   LinearEquiv.ofLinear
     (lift <|
       LinearMap.prodMapLinear R M₂ M₃ (M₁ ⊗[R] M₂) (M₁ ⊗[R] M₃) R
@@ -48,7 +48,7 @@ def prodRight : M₁ ⊗[R] (M₂ × M₃) ≃ₗ[R] ((M₁ ⊗[R] M₂) × (M�
   (LinearEquiv.symm_apply_eq _).mpr rfl
 
 /-- Tensor products distribute over a product on the left . -/
-def prodLeft : (M₁ × M₂) ⊗[R] M₃ ≃ₗ[R] ((M₁ ⊗[R] M₃) × (M₂ ⊗[R] M₃)) :=
+noncomputable def prodLeft : (M₁ × M₂) ⊗[R] M₃ ≃ₗ[R] ((M₁ ⊗[R] M₃) × (M₂ ⊗[R] M₃)) :=
   TensorProduct.comm _ _ _
     ≪≫ₗ TensorProduct.prodRight R _ _ _
     ≪≫ₗ (TensorProduct.comm R _ _).prod (TensorProduct.comm R _ _)

--- a/Mathlib/LinearAlgebra/TensorProduct/Prod.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Prod.lean
@@ -28,6 +28,7 @@ variable [Module R M₁] [Module R M₂] [Module R M₃]
 attribute [ext] TensorProduct.ext
 
 /-- Tensor products distribute over a product on the right. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def prodRight : M₁ ⊗[R] (M₂ × M₃) ≃ₗ[R] ((M₁ ⊗[R] M₂) × (M₁ ⊗[R] M₃)) :=
   LinearEquiv.ofLinear
     (lift <|
@@ -48,6 +49,7 @@ noncomputable def prodRight : M₁ ⊗[R] (M₂ × M₃) ≃ₗ[R] ((M₁ ⊗[R]
   (LinearEquiv.symm_apply_eq _).mpr rfl
 
 /-- Tensor products distribute over a product on the left . -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def prodLeft : (M₁ × M₂) ⊗[R] M₃ ≃ₗ[R] ((M₁ ⊗[R] M₃) × (M₂ ⊗[R] M₃)) :=
   TensorProduct.comm _ _ _
     ≪≫ₗ TensorProduct.prodRight R _ _ _

--- a/Mathlib/LinearAlgebra/TensorProduct/Tower.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Tower.lean
@@ -84,7 +84,7 @@ theorem smul_eq_lsmul_rTensor (a : A) (x : M ⊗[R] N) : a • x = (lsmul R R M 
 Given a linear map `M ⊗[R] N →[A] P`, compose it with the canonical
 bilinear map `M →[A] N →[R] M ⊗[R] N` to form a bilinear map `M →[A] N →[R] P`. -/
 @[simps]
-nonrec def curry (f : M ⊗[R] N →ₗ[A] P) : M →ₗ[A] N →ₗ[R] P :=
+noncomputable nonrec def curry (f : M ⊗[R] N →ₗ[A] P) : M →ₗ[A] N →ₗ[R] P :=
   { curry (f.restrictScalars R) with
     toFun := curry (f.restrictScalars R)
     map_smul' := fun c x => LinearMap.ext fun y => f.map_smul c (x ⊗ₜ y) }
@@ -116,7 +116,7 @@ theorem ext {g h : M ⊗[R] N →ₗ[A] P} (H : ∀ x y, g (x ⊗ₜ y) = h (x �
 Constructing a linear map `M ⊗[R] N →[A] P` given a bilinear map `M →[A] N →[R] P` with the
 property that its composition with the canonical bilinear map `M →[A] N →[R] M ⊗[R] N` is
 the given bilinear map `M →[A] N →[R] P`. -/
-nonrec def lift (f : M →ₗ[A] N →ₗ[R] P) : M ⊗[R] N →ₗ[A] P :=
+noncomputable nonrec def lift (f : M →ₗ[A] N →ₗ[R] P) : M ⊗[R] N →ₗ[A] P :=
   { lift (f.restrictScalars R) with
     map_smul' := fun c =>
       show
@@ -149,7 +149,7 @@ Linearly constructing a linear map `M ⊗[R] N →[A] P` given a bilinear map `M
 with the property that its composition with the canonical bilinear map `M →[A] N →[R] M ⊗[R] N` is
 the given bilinear map `M →[A] N →[R] P`. -/
 @[simps]
-def uncurry : (M →ₗ[A] N →ₗ[R] P) →ₗ[B] M ⊗[R] N →ₗ[A] P where
+noncomputable def uncurry : (M →ₗ[A] N →ₗ[R] P) →ₗ[B] M ⊗[R] N →ₗ[A] P where
   toFun := lift
   map_add' _ _ := ext fun x y => by simp only [lift_tmul, add_apply]
   map_smul' _ _ := ext fun x y => by simp only [lift_tmul, smul_apply, RingHom.id_apply]
@@ -161,7 +161,7 @@ def uncurry : (M →ₗ[A] N →ₗ[R] P) →ₗ[B] M ⊗[R] N →ₗ[A] P where
 Given a linear map `M ⊗[R] N →[A] P`, compose it with the canonical
 bilinear map `M →[A] N →[R] M ⊗[R] N` to form a bilinear map `M →[A] N →[R] P`. -/
 @[simps]
-def lcurry : (M ⊗[R] N →ₗ[A] P) →ₗ[B] M →ₗ[A] N →ₗ[R] P where
+noncomputable def lcurry : (M ⊗[R] N →ₗ[A] P) →ₗ[B] M →ₗ[A] N →ₗ[R] P where
   toFun := curry
   map_add' _ _ := rfl
   map_smul' _ _ := rfl
@@ -173,7 +173,7 @@ def lcurry : (M ⊗[R] N →ₗ[A] P) →ₗ[B] M →ₗ[A] N →ₗ[R] P where
 A linear equivalence constructing a linear map `M ⊗[R] N →[A] P` given a
 bilinear map `M →[A] N →[R] P` with the property that its composition with the
 canonical bilinear map `M →[A] N →[R] M ⊗[R] N` is the given bilinear map `M →[A] N →[R] P`. -/
-def lift.equiv : (M →ₗ[A] N →ₗ[R] P) ≃ₗ[B] M ⊗[R] N →ₗ[A] P :=
+noncomputable def lift.equiv : (M →ₗ[A] N →ₗ[R] P) ≃ₗ[B] M ⊗[R] N →ₗ[A] P :=
   LinearEquiv.ofLinear (uncurry R A B M N P) (lcurry R A B M N P)
     (LinearMap.ext fun _ => ext fun x y => lift_tmul _ x y)
     (LinearMap.ext fun f => LinearMap.ext fun x => LinearMap.ext fun y => lift_tmul f x y)
@@ -184,7 +184,7 @@ def lift.equiv : (M →ₗ[A] N →ₗ[R] P) ≃ₗ[B] M ⊗[R] N →ₗ[A] P :=
 
 The canonical bilinear map `M →[A] N →[R] M ⊗[R] N`. -/
 @[simps! apply]
-nonrec def mk : M →ₗ[A] N →ₗ[R] M ⊗[R] N :=
+noncomputable nonrec def mk : M →ₗ[A] N →ₗ[R] M ⊗[R] N :=
   { mk R M N with map_smul' := fun _ _ => rfl }
 #align tensor_product.algebra_tensor_module.mk TensorProduct.AlgebraTensorModule.mk
 #align tensor_product.algebra_tensor_module.mk_apply TensorProduct.AlgebraTensorModule.mk_apply
@@ -192,7 +192,7 @@ nonrec def mk : M →ₗ[A] N →ₗ[R] M ⊗[R] N :=
 variable {R A B M N P Q}
 
 /-- Heterobasic version of `TensorProduct.map` -/
-def map (f : M →ₗ[A] P) (g : N →ₗ[R] Q) : M ⊗[R] N →ₗ[A] P ⊗[R] Q :=
+noncomputable def map (f : M →ₗ[A] P) (g : N →ₗ[R] Q) : M ⊗[R] N →ₗ[A] P ⊗[R] Q :=
   lift <|
     { toFun := fun h => h ∘ₗ g,
       map_add' := fun h₁ h₂ => LinearMap.add_comp g h₂ h₁,
@@ -241,7 +241,7 @@ theorem map_smul_left (b : B) (f : M →ₗ[A] P) (g : N →ₗ[R] Q) : map (b �
 variable (R A B M N P Q)
 
 /-- Heterobasic version of `TensorProduct.map_bilinear` -/
-def mapBilinear : (M →ₗ[A] P) →ₗ[B] (N →ₗ[R] Q) →ₗ[R] (M ⊗[R] N →ₗ[A] P ⊗[R] Q) :=
+noncomputable def mapBilinear : (M →ₗ[A] P) →ₗ[B] (N →ₗ[R] Q) →ₗ[R] (M ⊗[R] N →ₗ[A] P ⊗[R] Q) :=
   LinearMap.mk₂' _ _ map map_add_left map_smul_left map_add_right map_smul_right
 
 variable {R A B M N P Q}
@@ -254,7 +254,7 @@ theorem mapBilinear_apply (f : M →ₗ[A] P) (g : N →ₗ[R] Q) :
 variable (R A B M N P Q)
 
 /-- Heterobasic version of `TensorProduct.homTensorHomMap` -/
-def homTensorHomMap : ((M →ₗ[A] P) ⊗[R] (N →ₗ[R] Q)) →ₗ[B] (M ⊗[R] N →ₗ[A] P ⊗[R] Q) :=
+noncomputable def homTensorHomMap : ((M →ₗ[A] P) ⊗[R] (N →ₗ[R] Q)) →ₗ[B] (M ⊗[R] N →ₗ[A] P ⊗[R] Q) :=
   lift <| mapBilinear R A B M N P Q
 
 variable {R A B M N P Q}
@@ -264,7 +264,7 @@ variable {R A B M N P Q}
   rfl
 
 /-- Heterobasic version of `TensorProduct.congr` -/
-def congr (f : M ≃ₗ[A] P) (g : N ≃ₗ[R] Q) : (M ⊗[R] N) ≃ₗ[A] (P ⊗[R] Q) :=
+noncomputable def congr (f : M ≃ₗ[A] P) (g : N ≃ₗ[R] Q) : (M ⊗[R] N) ≃ₗ[A] (P ⊗[R] Q) :=
   LinearEquiv.ofLinear (map f g) (map f.symm g.symm)
     (ext fun _m _n => congr_arg₂ (· ⊗ₜ ·) (f.apply_symm_apply _) (g.apply_symm_apply _))
     (ext fun _m _n => congr_arg₂ (· ⊗ₜ ·) (f.symm_apply_apply _) (g.symm_apply_apply _))
@@ -296,7 +296,7 @@ theorem congr_mul (f₁ f₂ : M ≃ₗ[A] M) (g₁ g₂ : N ≃ₗ[R] N) :
 variable (R A M)
 
 /-- Heterobasic version of `TensorProduct.rid`. -/
-protected def rid : M ⊗[R] R ≃ₗ[A] M :=
+protected noncomputable def rid : M ⊗[R] R ≃ₗ[A] M :=
   LinearEquiv.ofLinear
     (lift <| Algebra.lsmul _ _ _ |>.toLinearMap |>.flip)
     (mk R A M R |>.flip 1)
@@ -337,7 +337,7 @@ Linear equivalence between `(M ⊗[A] N) ⊗[R] P` and `M ⊗[A] (N ⊗[R] P)`.
 
 Note this is especially useful with `A = R` (where it is a "more linear" version of
 `TensorProduct.assoc`), or with `B = A`. -/
-def assoc : (M ⊗[A] P) ⊗[R] Q ≃ₗ[B] M ⊗[A] (P ⊗[R] Q) :=
+noncomputable def assoc : (M ⊗[A] P) ⊗[R] Q ≃ₗ[B] M ⊗[A] (P ⊗[R] Q) :=
   LinearEquiv.ofLinear
     (lift <| lift <| lcurry R A B P Q _ ∘ₗ mk A B M (P ⊗[R] Q))
     (lift <| uncurry R A B P Q _ ∘ₗ curry (mk R B _ Q))
@@ -363,7 +363,7 @@ end assoc
 section leftComm
 
 /-- Heterobasic version of `TensorProduct.leftComm` -/
-def leftComm : M ⊗[A] (P ⊗[R] Q) ≃ₗ[A] P ⊗[A] (M ⊗[R] Q) :=
+noncomputable def leftComm : M ⊗[A] (P ⊗[R] Q) ≃ₗ[A] P ⊗[A] (M ⊗[R] Q) :=
   let e₁ := (assoc R A A M P Q).symm
   let e₂ := congr (TensorProduct.comm A M P) (1 : Q ≃ₗ[R] Q)
   let e₃ := assoc R A A P M Q
@@ -386,7 +386,7 @@ end leftComm
 section rightComm
 
 /-- A tensor product analogue of `mul_right_comm`. -/
-def rightComm : (M ⊗[A] P) ⊗[R] Q ≃ₗ[A] (M ⊗[R] Q) ⊗[A] P :=
+noncomputable def rightComm : (M ⊗[A] P) ⊗[R] Q ≃ₗ[A] (M ⊗[R] Q) ⊗[A] P :=
   LinearEquiv.ofLinear
     (lift <| TensorProduct.lift <| LinearMap.flip <|
       lcurry R A A M Q ((M ⊗[R] Q) ⊗[A] P) ∘ₗ (mk A A (M ⊗[R] Q) P).flip)
@@ -417,7 +417,7 @@ end rightComm
 section tensorTensorTensorComm
 
 /-- Heterobasic version of `tensorTensorTensorComm`. -/
-def tensorTensorTensorComm :
+noncomputable def tensorTensorTensorComm :
   (M ⊗[R] N) ⊗[A] (P ⊗[R] Q) ≃ₗ[A] (M ⊗[A] P) ⊗[R] (N ⊗[R] Q) :=
 (assoc R A A (M ⊗[R] N) P Q).symm
   ≪≫ₗ congr (rightComm R A M P N).symm (1 : Q ≃ₗ[R] Q)

--- a/Mathlib/LinearAlgebra/TensorProduct/Tower.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Tower.lean
@@ -254,7 +254,8 @@ theorem mapBilinear_apply (f : M →ₗ[A] P) (g : N →ₗ[R] Q) :
 variable (R A B M N P Q)
 
 /-- Heterobasic version of `TensorProduct.homTensorHomMap` -/
-noncomputable def homTensorHomMap : ((M →ₗ[A] P) ⊗[R] (N →ₗ[R] Q)) →ₗ[B] (M ⊗[R] N →ₗ[A] P ⊗[R] Q) :=
+noncomputable def homTensorHomMap :
+    ((M →ₗ[A] P) ⊗[R] (N →ₗ[R] Q)) →ₗ[B] (M ⊗[R] N →ₗ[A] P ⊗[R] Q) :=
   lift <| mapBilinear R A B M N P Q
 
 variable {R A B M N P Q}

--- a/Mathlib/LinearAlgebra/TensorProduct/Tower.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Tower.lean
@@ -84,6 +84,7 @@ theorem smul_eq_lsmul_rTensor (a : A) (x : M ⊗[R] N) : a • x = (lsmul R R M 
 Given a linear map `M ⊗[R] N →[A] P`, compose it with the canonical
 bilinear map `M →[A] N →[R] M ⊗[R] N` to form a bilinear map `M →[A] N →[R] P`. -/
 @[simps]
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable nonrec def curry (f : M ⊗[R] N →ₗ[A] P) : M →ₗ[A] N →ₗ[R] P :=
   { curry (f.restrictScalars R) with
     toFun := curry (f.restrictScalars R)
@@ -116,6 +117,7 @@ theorem ext {g h : M ⊗[R] N →ₗ[A] P} (H : ∀ x y, g (x ⊗ₜ y) = h (x �
 Constructing a linear map `M ⊗[R] N →[A] P` given a bilinear map `M →[A] N →[R] P` with the
 property that its composition with the canonical bilinear map `M →[A] N →[R] M ⊗[R] N` is
 the given bilinear map `M →[A] N →[R] P`. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable nonrec def lift (f : M →ₗ[A] N →ₗ[R] P) : M ⊗[R] N →ₗ[A] P :=
   { lift (f.restrictScalars R) with
     map_smul' := fun c =>
@@ -149,6 +151,7 @@ Linearly constructing a linear map `M ⊗[R] N →[A] P` given a bilinear map `M
 with the property that its composition with the canonical bilinear map `M →[A] N →[R] M ⊗[R] N` is
 the given bilinear map `M →[A] N →[R] P`. -/
 @[simps]
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def uncurry : (M →ₗ[A] N →ₗ[R] P) →ₗ[B] M ⊗[R] N →ₗ[A] P where
   toFun := lift
   map_add' _ _ := ext fun x y => by simp only [lift_tmul, add_apply]
@@ -161,6 +164,7 @@ noncomputable def uncurry : (M →ₗ[A] N →ₗ[R] P) →ₗ[B] M ⊗[R] N →
 Given a linear map `M ⊗[R] N →[A] P`, compose it with the canonical
 bilinear map `M →[A] N →[R] M ⊗[R] N` to form a bilinear map `M →[A] N →[R] P`. -/
 @[simps]
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def lcurry : (M ⊗[R] N →ₗ[A] P) →ₗ[B] M →ₗ[A] N →ₗ[R] P where
   toFun := curry
   map_add' _ _ := rfl
@@ -173,6 +177,7 @@ noncomputable def lcurry : (M ⊗[R] N →ₗ[A] P) →ₗ[B] M →ₗ[A] N →�
 A linear equivalence constructing a linear map `M ⊗[R] N →[A] P` given a
 bilinear map `M →[A] N →[R] P` with the property that its composition with the
 canonical bilinear map `M →[A] N →[R] M ⊗[R] N` is the given bilinear map `M →[A] N →[R] P`. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def lift.equiv : (M →ₗ[A] N →ₗ[R] P) ≃ₗ[B] M ⊗[R] N →ₗ[A] P :=
   LinearEquiv.ofLinear (uncurry R A B M N P) (lcurry R A B M N P)
     (LinearMap.ext fun _ => ext fun x y => lift_tmul _ x y)
@@ -184,6 +189,7 @@ noncomputable def lift.equiv : (M →ₗ[A] N →ₗ[R] P) ≃ₗ[B] M ⊗[R] N 
 
 The canonical bilinear map `M →[A] N →[R] M ⊗[R] N`. -/
 @[simps! apply]
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable nonrec def mk : M →ₗ[A] N →ₗ[R] M ⊗[R] N :=
   { mk R M N with map_smul' := fun _ _ => rfl }
 #align tensor_product.algebra_tensor_module.mk TensorProduct.AlgebraTensorModule.mk
@@ -192,6 +198,7 @@ noncomputable nonrec def mk : M →ₗ[A] N →ₗ[R] M ⊗[R] N :=
 variable {R A B M N P Q}
 
 /-- Heterobasic version of `TensorProduct.map` -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def map (f : M →ₗ[A] P) (g : N →ₗ[R] Q) : M ⊗[R] N →ₗ[A] P ⊗[R] Q :=
   lift <|
     { toFun := fun h => h ∘ₗ g,
@@ -241,6 +248,7 @@ theorem map_smul_left (b : B) (f : M →ₗ[A] P) (g : N →ₗ[R] Q) : map (b �
 variable (R A B M N P Q)
 
 /-- Heterobasic version of `TensorProduct.map_bilinear` -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def mapBilinear : (M →ₗ[A] P) →ₗ[B] (N →ₗ[R] Q) →ₗ[R] (M ⊗[R] N →ₗ[A] P ⊗[R] Q) :=
   LinearMap.mk₂' _ _ map map_add_left map_smul_left map_add_right map_smul_right
 
@@ -254,6 +262,7 @@ theorem mapBilinear_apply (f : M →ₗ[A] P) (g : N →ₗ[R] Q) :
 variable (R A B M N P Q)
 
 /-- Heterobasic version of `TensorProduct.homTensorHomMap` -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def homTensorHomMap :
     ((M →ₗ[A] P) ⊗[R] (N →ₗ[R] Q)) →ₗ[B] (M ⊗[R] N →ₗ[A] P ⊗[R] Q) :=
   lift <| mapBilinear R A B M N P Q
@@ -265,6 +274,7 @@ variable {R A B M N P Q}
   rfl
 
 /-- Heterobasic version of `TensorProduct.congr` -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def congr (f : M ≃ₗ[A] P) (g : N ≃ₗ[R] Q) : (M ⊗[R] N) ≃ₗ[A] (P ⊗[R] Q) :=
   LinearEquiv.ofLinear (map f g) (map f.symm g.symm)
     (ext fun _m _n => congr_arg₂ (· ⊗ₜ ·) (f.apply_symm_apply _) (g.apply_symm_apply _))
@@ -297,6 +307,7 @@ theorem congr_mul (f₁ f₂ : M ≃ₗ[A] M) (g₁ g₂ : N ≃ₗ[R] N) :
 variable (R A M)
 
 /-- Heterobasic version of `TensorProduct.rid`. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 protected noncomputable def rid : M ⊗[R] R ≃ₗ[A] M :=
   LinearEquiv.ofLinear
     (lift <| Algebra.lsmul _ _ _ |>.toLinearMap |>.flip)
@@ -338,6 +349,7 @@ Linear equivalence between `(M ⊗[A] N) ⊗[R] P` and `M ⊗[A] (N ⊗[R] P)`.
 
 Note this is especially useful with `A = R` (where it is a "more linear" version of
 `TensorProduct.assoc`), or with `B = A`. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def assoc : (M ⊗[A] P) ⊗[R] Q ≃ₗ[B] M ⊗[A] (P ⊗[R] Q) :=
   LinearEquiv.ofLinear
     (lift <| lift <| lcurry R A B P Q _ ∘ₗ mk A B M (P ⊗[R] Q))
@@ -364,6 +376,7 @@ end assoc
 section leftComm
 
 /-- Heterobasic version of `TensorProduct.leftComm` -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def leftComm : M ⊗[A] (P ⊗[R] Q) ≃ₗ[A] P ⊗[A] (M ⊗[R] Q) :=
   let e₁ := (assoc R A A M P Q).symm
   let e₂ := congr (TensorProduct.comm A M P) (1 : Q ≃ₗ[R] Q)
@@ -387,6 +400,7 @@ end leftComm
 section rightComm
 
 /-- A tensor product analogue of `mul_right_comm`. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def rightComm : (M ⊗[A] P) ⊗[R] Q ≃ₗ[A] (M ⊗[R] Q) ⊗[A] P :=
   LinearEquiv.ofLinear
     (lift <| TensorProduct.lift <| LinearMap.flip <|
@@ -418,6 +432,7 @@ end rightComm
 section tensorTensorTensorComm
 
 /-- Heterobasic version of `tensorTensorTensorComm`. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def tensorTensorTensorComm :
   (M ⊗[R] N) ⊗[A] (P ⊗[R] Q) ≃ₗ[A] (M ⊗[A] P) ⊗[R] (N ⊗[R] Q) :=
 (assoc R A A (M ⊗[R] N) P Q).symm

--- a/Mathlib/RepresentationTheory/Basic.lean
+++ b/Mathlib/RepresentationTheory/Basic.lean
@@ -356,7 +356,7 @@ open TensorProduct
 /-- Given representations of `G` on `V` and `W`, there is a natural representation of `G` on their
 tensor product `V ⊗[k] W`.
 -/
-def tprod : Representation k G (V ⊗[k] W) where
+noncomputable def tprod : Representation k G (V ⊗[k] W) where
   toFun g := TensorProduct.map (ρV g) (ρW g)
   map_one' := by simp only [_root_.map_one, TensorProduct.map_one]
   map_mul' g h := by simp only [_root_.map_mul, TensorProduct.map_mul]

--- a/Mathlib/RepresentationTheory/Basic.lean
+++ b/Mathlib/RepresentationTheory/Basic.lean
@@ -356,6 +356,7 @@ open TensorProduct
 /-- Given representations of `G` on `V` and `W`, there is a natural representation of `G` on their
 tensor product `V ⊗[k] W`.
 -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def tprod : Representation k G (V ⊗[k] W) where
   toFun g := TensorProduct.map (ρV g) (ρW g)
   map_one' := by simp only [_root_.map_one, TensorProduct.map_one]

--- a/Mathlib/RepresentationTheory/FdRep.lean
+++ b/Mathlib/RepresentationTheory/FdRep.lean
@@ -110,7 +110,7 @@ theorem forget₂_ρ (V : FdRep k G) : ((forget₂ (FdRep k G) (Rep k G)).obj V)
 #align fdRep.forget₂_ρ FdRep.forget₂_ρ
 
 -- Verify that the monoidal structure is available.
-example : MonoidalCategory (FdRep k G) := by infer_instance
+noncomputable example : MonoidalCategory (FdRep k G) := by infer_instance
 
 example : MonoidalPreadditive (FdRep k G) := by infer_instance
 

--- a/Mathlib/RepresentationTheory/FdRep.lean
+++ b/Mathlib/RepresentationTheory/FdRep.lean
@@ -110,6 +110,7 @@ theorem forget₂_ρ (V : FdRep k G) : ((forget₂ (FdRep k G) (Rep k G)).obj V)
 #align fdRep.forget₂_ρ FdRep.forget₂_ρ
 
 -- Verify that the monoidal structure is available.
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable example : MonoidalCategory (FdRep k G) := by infer_instance
 
 example : MonoidalPreadditive (FdRep k G) := by infer_instance

--- a/Mathlib/RepresentationTheory/Rep.lean
+++ b/Mathlib/RepresentationTheory/Rep.lean
@@ -374,6 +374,7 @@ set_option linter.uppercaseLean3 false in
 /-- Given a `k`-linear `G`-representation `A`, this is the Hom-set bijection in the adjunction
 `A ⊗ - ⊣ ihom(A, -)`. It sends `f : A ⊗ B ⟶ C` to a `Rep k G` morphism defined by currying the
 `k`-linear map underlying `f`, giving a map `A →ₗ[k] B →ₗ[k] C`, then flipping the arguments. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def homEquiv (A B C : Rep k G) : (A ⊗ B ⟶ C) ≃ (B ⟶ (Rep.ihom A).obj C) where
   toFun f :=
     { hom := (TensorProduct.curry f.hom).flip
@@ -418,6 +419,7 @@ theorem homEquiv_symm_apply_hom (f : B ⟶ (Rep.ihom A).obj C) :
 set_option linter.uppercaseLean3 false in
 #align Rep.hom_equiv_symm_apply_hom Rep.homEquiv_symm_apply_hom
 
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable instance : MonoidalClosed (Rep k G) where
   closed := fun A =>
   { isAdj :=
@@ -461,6 +463,7 @@ variable (A B C)
 
 /-- There is a `k`-linear isomorphism between the sets of representation morphisms`Hom(A ⊗ B, C)`
 and `Hom(B, Homₖ(A, C))`. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def MonoidalClosed.linearHomEquiv : (A ⊗ B ⟶ C) ≃ₗ[k] B ⟶ A ⟶[Rep k G] C :=
   { (ihom.adjunction A).homEquiv _ _ with
     map_add' := fun _ _ => rfl
@@ -470,6 +473,7 @@ noncomputable def MonoidalClosed.linearHomEquiv : (A ⊗ B ⟶ C) ≃ₗ[k] B �
 
 /-- There is a `k`-linear isomorphism between the sets of representation morphisms`Hom(A ⊗ B, C)`
 and `Hom(A, Homₖ(B, C))`. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def MonoidalClosed.linearHomEquivComm : (A ⊗ B ⟶ C) ≃ₗ[k] A ⟶ B ⟶[Rep k G] C :=
   Linear.homCongr k (β_ A B) (Iso.refl _) ≪≫ₗ MonoidalClosed.linearHomEquiv _ _ _
 set_option linter.uppercaseLean3 false in
@@ -516,6 +520,7 @@ variable {k G : Type u} [CommRing k] [Monoid G] {V W : Type u} [AddCommGroup V] 
   [Module k V] [Module k W] (ρ : Representation k G V) (τ : Representation k G W)
 
 /-- Tautological isomorphism to help Lean in typechecking. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def repOfTprodIso : Rep.of (ρ.tprod τ) ≅ Rep.of ρ ⊗ Rep.of τ :=
   Iso.refl _
 set_option linter.uppercaseLean3 false in
@@ -543,6 +548,7 @@ namespace Rep
 variable {k G : Type u} [CommRing k] [Monoid G]
 
 -- Verify that the symmetric monoidal structure is available.
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable example : SymmetricCategory (Rep k G) := by infer_instance
 
 example : MonoidalPreadditive (Rep k G) := by infer_instance

--- a/Mathlib/RepresentationTheory/Rep.lean
+++ b/Mathlib/RepresentationTheory/Rep.lean
@@ -374,7 +374,7 @@ set_option linter.uppercaseLean3 false in
 /-- Given a `k`-linear `G`-representation `A`, this is the Hom-set bijection in the adjunction
 `A ⊗ - ⊣ ihom(A, -)`. It sends `f : A ⊗ B ⟶ C` to a `Rep k G` morphism defined by currying the
 `k`-linear map underlying `f`, giving a map `A →ₗ[k] B →ₗ[k] C`, then flipping the arguments. -/
-def homEquiv (A B C : Rep k G) : (A ⊗ B ⟶ C) ≃ (B ⟶ (Rep.ihom A).obj C) where
+noncomputable def homEquiv (A B C : Rep k G) : (A ⊗ B ⟶ C) ≃ (B ⟶ (Rep.ihom A).obj C) where
   toFun f :=
     { hom := (TensorProduct.curry f.hom).flip
       comm := fun g => by
@@ -418,7 +418,7 @@ theorem homEquiv_symm_apply_hom (f : B ⟶ (Rep.ihom A).obj C) :
 set_option linter.uppercaseLean3 false in
 #align Rep.hom_equiv_symm_apply_hom Rep.homEquiv_symm_apply_hom
 
-instance : MonoidalClosed (Rep k G) where
+noncomputable instance : MonoidalClosed (Rep k G) where
   closed := fun A =>
   { isAdj :=
     { right := Rep.ihom A
@@ -461,7 +461,7 @@ variable (A B C)
 
 /-- There is a `k`-linear isomorphism between the sets of representation morphisms`Hom(A ⊗ B, C)`
 and `Hom(B, Homₖ(A, C))`. -/
-def MonoidalClosed.linearHomEquiv : (A ⊗ B ⟶ C) ≃ₗ[k] B ⟶ A ⟶[Rep k G] C :=
+noncomputable def MonoidalClosed.linearHomEquiv : (A ⊗ B ⟶ C) ≃ₗ[k] B ⟶ A ⟶[Rep k G] C :=
   { (ihom.adjunction A).homEquiv _ _ with
     map_add' := fun _ _ => rfl
     map_smul' := fun _ _ => rfl }
@@ -470,7 +470,7 @@ def MonoidalClosed.linearHomEquiv : (A ⊗ B ⟶ C) ≃ₗ[k] B ⟶ A ⟶[Rep k 
 
 /-- There is a `k`-linear isomorphism between the sets of representation morphisms`Hom(A ⊗ B, C)`
 and `Hom(A, Homₖ(B, C))`. -/
-def MonoidalClosed.linearHomEquivComm : (A ⊗ B ⟶ C) ≃ₗ[k] A ⟶ B ⟶[Rep k G] C :=
+noncomputable def MonoidalClosed.linearHomEquivComm : (A ⊗ B ⟶ C) ≃ₗ[k] A ⟶ B ⟶[Rep k G] C :=
   Linear.homCongr k (β_ A B) (Iso.refl _) ≪≫ₗ MonoidalClosed.linearHomEquiv _ _ _
 set_option linter.uppercaseLean3 false in
 #align Rep.monoidal_closed.linear_hom_equiv_comm Rep.MonoidalClosed.linearHomEquivComm
@@ -516,7 +516,7 @@ variable {k G : Type u} [CommRing k] [Monoid G] {V W : Type u} [AddCommGroup V] 
   [Module k V] [Module k W] (ρ : Representation k G V) (τ : Representation k G W)
 
 /-- Tautological isomorphism to help Lean in typechecking. -/
-def repOfTprodIso : Rep.of (ρ.tprod τ) ≅ Rep.of ρ ⊗ Rep.of τ :=
+noncomputable def repOfTprodIso : Rep.of (ρ.tprod τ) ≅ Rep.of ρ ⊗ Rep.of τ :=
   Iso.refl _
 set_option linter.uppercaseLean3 false in
 #align representation.Rep_of_tprod_iso Representation.repOfTprodIso
@@ -543,7 +543,7 @@ namespace Rep
 variable {k G : Type u} [CommRing k] [Monoid G]
 
 -- Verify that the symmetric monoidal structure is available.
-example : SymmetricCategory (Rep k G) := by infer_instance
+noncomputable example : SymmetricCategory (Rep k G) := by infer_instance
 
 example : MonoidalPreadditive (Rep k G) := by infer_instance
 

--- a/Mathlib/RingTheory/Finiteness.lean
+++ b/Mathlib/RingTheory/Finiteness.lean
@@ -631,7 +631,8 @@ end Finite
 end Module
 
 /-- Porting note: reminding Lean about this instance for Module.Finite.base_change -/
-local instance [CommSemiring R] [Semiring A] [Algebra R A] [AddCommMonoid M] [Module R M] :
+noncomputable local instance [CommSemiring R] [Semiring A] [Algebra R A] [AddCommMonoid M]
+    [Module R M] :
   Module A (TensorProduct R A M) :=
   haveI : SMulCommClass R A A := IsScalarTower.to_smulCommClass
   TensorProduct.leftModule

--- a/Mathlib/RingTheory/Finiteness.lean
+++ b/Mathlib/RingTheory/Finiteness.lean
@@ -631,6 +631,7 @@ end Finite
 end Module
 
 /-- Porting note: reminding Lean about this instance for Module.Finite.base_change -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable local instance [CommSemiring R] [Semiring A] [Algebra R A] [AddCommMonoid M]
     [Module R M] :
   Module A (TensorProduct R A M) :=

--- a/Mathlib/RingTheory/Kaehler.lean
+++ b/Mathlib/RingTheory/Kaehler.lean
@@ -44,6 +44,7 @@ universe u v
 variable (R : Type u) (S : Type v) [CommRing R] [CommRing S] [Algebra R S]
 
 /-- The kernel of the multiplication map `S ⊗[R] S →ₐ[R] S`. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable abbrev KaehlerDifferential.ideal : Ideal (S ⊗[R] S) :=
   RingHom.ker (TensorProduct.lmul' R : S ⊗[R] S →ₐ[R] S)
 #align kaehler_differential.ideal KaehlerDifferential.ideal
@@ -59,6 +60,7 @@ variable {R}
 variable {M : Type*} [AddCommGroup M] [Module R M] [Module S M] [IsScalarTower R S M]
 
 /-- For a `R`-derivation `S → M`, this is the map `S ⊗[R] S →ₗ[S] M` sending `s ⊗ₜ t ↦ s • D t`. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def Derivation.tensorProductTo (D : Derivation R S M) : S ⊗[R] S →ₗ[S] M :=
   TensorProduct.AlgebraTensorModule.lift ((LinearMap.lsmul S (S →ₗ[R] M)).flip D.toLinearMap)
 #align derivation.tensor_product_to Derivation.tensorProductTo
@@ -145,10 +147,12 @@ def KaehlerDifferential : Type _ :=
   (KaehlerDifferential.ideal R S).Cotangent
 #align kaehler_differential KaehlerDifferential
 
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable instance : AddCommGroup (KaehlerDifferential R S) := by
   unfold KaehlerDifferential
   infer_instance
 
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable instance KaehlerDifferential.module : Module (S ⊗[R] S) (KaehlerDifferential R S) :=
   Ideal.Cotangent.moduleOfTower _
 #align kaehler_differential.module KaehlerDifferential.module
@@ -157,6 +161,7 @@ notation:100 "Ω[" S "⁄" R "]" => KaehlerDifferential R S
 
 instance : Nonempty (Ω[S⁄R]) := ⟨0⟩
 
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable instance KaehlerDifferential.module' {R' : Type*} [CommRing R'] [Algebra R' S]
   [SMulCommClass R R' S] :
     Module R' (Ω[S⁄R]) :=
@@ -179,12 +184,14 @@ instance KaehlerDifferential.isScalarTower' : IsScalarTower R (S ⊗[R] S) (Ω[S
 #align kaehler_differential.is_scalar_tower' KaehlerDifferential.isScalarTower'
 
 /-- The quotient map `I → Ω[S⁄R]` with `I` being the kernel of `S ⊗[R] S → S`. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def KaehlerDifferential.fromIdeal :
     KaehlerDifferential.ideal R S →ₗ[S ⊗[R] S] Ω[S⁄R] :=
   (KaehlerDifferential.ideal R S).toCotangent
 #align kaehler_differential.from_ideal KaehlerDifferential.fromIdeal
 
 /-- (Implementation) The underlying linear map of the derivation into `Ω[S⁄R]`. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def KaehlerDifferential.DLinearMap : S →ₗ[R] Ω[S⁄R] :=
   ((KaehlerDifferential.fromIdeal R S).restrictScalars R).comp
     ((TensorProduct.includeRight.toLinearMap - TensorProduct.includeLeft.toLinearMap :
@@ -203,6 +210,7 @@ set_option linter.uppercaseLean3 false in
 #align kaehler_differential.D_linear_map_apply KaehlerDifferential.DLinearMap_apply
 
 /-- The universal derivation into `Ω[S⁄R]`. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def KaehlerDifferential.D : Derivation R S (Ω[S⁄R]) :=
   { toLinearMap := KaehlerDifferential.DLinearMap R S
     map_one_eq_zero' := by
@@ -255,6 +263,7 @@ theorem KaehlerDifferential.span_range_derivation :
 variable {R S}
 
 /-- The linear map from `Ω[S⁄R]`, associated with a derivation. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def Derivation.liftKaehlerDifferential (D : Derivation R S M) : Ω[S⁄R] →ₗ[S] M := by
   refine LinearMap.comp ((((KaehlerDifferential.ideal R S) •
     (⊤ : Submodule (S ⊗[R] S) (KaehlerDifferential.ideal R S))).restrictScalars S).liftQ ?_ ?_)
@@ -338,6 +347,7 @@ theorem KaehlerDifferential.tensorProductTo_surjective :
 
 /-- The `S`-linear maps from `Ω[S⁄R]` to `M` are (`S`-linearly) equivalent to `R`-derivations
 from `S` to `M`.  -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def KaehlerDifferential.linearMapEquivDerivation :
     (Ω[S⁄R] →ₗ[S] M) ≃ₗ[S] Derivation R S M :=
   { Derivation.llcomp.flip <| KaehlerDifferential.D R S with
@@ -348,6 +358,7 @@ noncomputable def KaehlerDifferential.linearMapEquivDerivation :
 #align kaehler_differential.linear_map_equiv_derivation KaehlerDifferential.linearMapEquivDerivation
 
 /-- The quotient ring of `S ⊗ S ⧸ J ^ 2` by `Ω[S⁄R]` is isomorphic to `S`. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def KaehlerDifferential.quotientCotangentIdealRingEquiv :
     (S ⊗ S ⧸ KaehlerDifferential.ideal R S ^ 2) ⧸ (KaehlerDifferential.ideal R S).cotangentIdeal ≃+*
       S := by
@@ -361,6 +372,7 @@ noncomputable def KaehlerDifferential.quotientCotangentIdealRingEquiv :
 #align kaehler_differential.quotient_cotangent_ideal_ring_equiv KaehlerDifferential.quotientCotangentIdealRingEquiv
 
 /-- The quotient ring of `S ⊗ S ⧸ J ^ 2` by `Ω[S⁄R]` is isomorphic to `S` as an `S`-algebra. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def KaehlerDifferential.quotientCotangentIdeal :
     ((S ⊗ S ⧸ KaehlerDifferential.ideal R S ^ 2) ⧸
         (KaehlerDifferential.ideal R S).cotangentIdeal) ≃ₐ[S] S :=
@@ -627,6 +639,7 @@ A --→ B
 ↑     ↑
 |     |
 R --→ S -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def KaehlerDifferential.map : Ω[A⁄R] →ₗ[A] Ω[B⁄S] :=
   Derivation.liftKaehlerDifferential
     (((KaehlerDifferential.D S B).restrictScalars R).compAlgebraMap A)

--- a/Mathlib/RingTheory/Kaehler.lean
+++ b/Mathlib/RingTheory/Kaehler.lean
@@ -44,7 +44,7 @@ universe u v
 variable (R : Type u) (S : Type v) [CommRing R] [CommRing S] [Algebra R S]
 
 /-- The kernel of the multiplication map `S ⊗[R] S →ₐ[R] S`. -/
-abbrev KaehlerDifferential.ideal : Ideal (S ⊗[R] S) :=
+noncomputable abbrev KaehlerDifferential.ideal : Ideal (S ⊗[R] S) :=
   RingHom.ker (TensorProduct.lmul' R : S ⊗[R] S →ₐ[R] S)
 #align kaehler_differential.ideal KaehlerDifferential.ideal
 
@@ -59,7 +59,7 @@ variable {R}
 variable {M : Type*} [AddCommGroup M] [Module R M] [Module S M] [IsScalarTower R S M]
 
 /-- For a `R`-derivation `S → M`, this is the map `S ⊗[R] S →ₗ[S] M` sending `s ⊗ₜ t ↦ s • D t`. -/
-def Derivation.tensorProductTo (D : Derivation R S M) : S ⊗[R] S →ₗ[S] M :=
+noncomputable def Derivation.tensorProductTo (D : Derivation R S M) : S ⊗[R] S →ₗ[S] M :=
   TensorProduct.AlgebraTensorModule.lift ((LinearMap.lsmul S (S →ₗ[R] M)).flip D.toLinearMap)
 #align derivation.tensor_product_to Derivation.tensorProductTo
 
@@ -145,11 +145,11 @@ def KaehlerDifferential : Type _ :=
   (KaehlerDifferential.ideal R S).Cotangent
 #align kaehler_differential KaehlerDifferential
 
-instance : AddCommGroup (KaehlerDifferential R S) := by
+noncomputable instance : AddCommGroup (KaehlerDifferential R S) := by
   unfold KaehlerDifferential
   infer_instance
 
-instance KaehlerDifferential.module : Module (S ⊗[R] S) (KaehlerDifferential R S) :=
+noncomputable instance KaehlerDifferential.module : Module (S ⊗[R] S) (KaehlerDifferential R S) :=
   Ideal.Cotangent.moduleOfTower _
 #align kaehler_differential.module KaehlerDifferential.module
 
@@ -157,7 +157,7 @@ notation:100 "Ω[" S "⁄" R "]" => KaehlerDifferential R S
 
 instance : Nonempty (Ω[S⁄R]) := ⟨0⟩
 
-instance KaehlerDifferential.module' {R' : Type*} [CommRing R'] [Algebra R' S]
+noncomputable instance KaehlerDifferential.module' {R' : Type*} [CommRing R'] [Algebra R' S]
   [SMulCommClass R R' S] :
     Module R' (Ω[S⁄R]) :=
   Submodule.Quotient.module' _
@@ -179,12 +179,13 @@ instance KaehlerDifferential.isScalarTower' : IsScalarTower R (S ⊗[R] S) (Ω[S
 #align kaehler_differential.is_scalar_tower' KaehlerDifferential.isScalarTower'
 
 /-- The quotient map `I → Ω[S⁄R]` with `I` being the kernel of `S ⊗[R] S → S`. -/
-def KaehlerDifferential.fromIdeal : KaehlerDifferential.ideal R S →ₗ[S ⊗[R] S] Ω[S⁄R] :=
+noncomputable def KaehlerDifferential.fromIdeal :
+    KaehlerDifferential.ideal R S →ₗ[S ⊗[R] S] Ω[S⁄R] :=
   (KaehlerDifferential.ideal R S).toCotangent
 #align kaehler_differential.from_ideal KaehlerDifferential.fromIdeal
 
 /-- (Implementation) The underlying linear map of the derivation into `Ω[S⁄R]`. -/
-def KaehlerDifferential.DLinearMap : S →ₗ[R] Ω[S⁄R] :=
+noncomputable def KaehlerDifferential.DLinearMap : S →ₗ[R] Ω[S⁄R] :=
   ((KaehlerDifferential.fromIdeal R S).restrictScalars R).comp
     ((TensorProduct.includeRight.toLinearMap - TensorProduct.includeLeft.toLinearMap :
             S →ₗ[R] S ⊗[R] S).codRestrict
@@ -202,7 +203,7 @@ set_option linter.uppercaseLean3 false in
 #align kaehler_differential.D_linear_map_apply KaehlerDifferential.DLinearMap_apply
 
 /-- The universal derivation into `Ω[S⁄R]`. -/
-def KaehlerDifferential.D : Derivation R S (Ω[S⁄R]) :=
+noncomputable def KaehlerDifferential.D : Derivation R S (Ω[S⁄R]) :=
   { toLinearMap := KaehlerDifferential.DLinearMap R S
     map_one_eq_zero' := by
       dsimp [KaehlerDifferential.DLinearMap_apply]
@@ -254,7 +255,7 @@ theorem KaehlerDifferential.span_range_derivation :
 variable {R S}
 
 /-- The linear map from `Ω[S⁄R]`, associated with a derivation. -/
-def Derivation.liftKaehlerDifferential (D : Derivation R S M) : Ω[S⁄R] →ₗ[S] M := by
+noncomputable def Derivation.liftKaehlerDifferential (D : Derivation R S M) : Ω[S⁄R] →ₗ[S] M := by
   refine LinearMap.comp ((((KaehlerDifferential.ideal R S) •
     (⊤ : Submodule (S ⊗[R] S) (KaehlerDifferential.ideal R S))).restrictScalars S).liftQ ?_ ?_)
     (Submodule.Quotient.restrictScalarsEquiv S _).symm.toLinearMap
@@ -337,7 +338,8 @@ theorem KaehlerDifferential.tensorProductTo_surjective :
 
 /-- The `S`-linear maps from `Ω[S⁄R]` to `M` are (`S`-linearly) equivalent to `R`-derivations
 from `S` to `M`.  -/
-def KaehlerDifferential.linearMapEquivDerivation : (Ω[S⁄R] →ₗ[S] M) ≃ₗ[S] Derivation R S M :=
+noncomputable def KaehlerDifferential.linearMapEquivDerivation :
+    (Ω[S⁄R] →ₗ[S] M) ≃ₗ[S] Derivation R S M :=
   { Derivation.llcomp.flip <| KaehlerDifferential.D R S with
     invFun := Derivation.liftKaehlerDifferential
     left_inv := fun _ =>
@@ -346,7 +348,7 @@ def KaehlerDifferential.linearMapEquivDerivation : (Ω[S⁄R] →ₗ[S] M) ≃�
 #align kaehler_differential.linear_map_equiv_derivation KaehlerDifferential.linearMapEquivDerivation
 
 /-- The quotient ring of `S ⊗ S ⧸ J ^ 2` by `Ω[S⁄R]` is isomorphic to `S`. -/
-def KaehlerDifferential.quotientCotangentIdealRingEquiv :
+noncomputable def KaehlerDifferential.quotientCotangentIdealRingEquiv :
     (S ⊗ S ⧸ KaehlerDifferential.ideal R S ^ 2) ⧸ (KaehlerDifferential.ideal R S).cotangentIdeal ≃+*
       S := by
   have : Function.RightInverse (TensorProduct.includeLeft (R := R) (A := S) (B := S))
@@ -359,7 +361,7 @@ def KaehlerDifferential.quotientCotangentIdealRingEquiv :
 #align kaehler_differential.quotient_cotangent_ideal_ring_equiv KaehlerDifferential.quotientCotangentIdealRingEquiv
 
 /-- The quotient ring of `S ⊗ S ⧸ J ^ 2` by `Ω[S⁄R]` is isomorphic to `S` as an `S`-algebra. -/
-def KaehlerDifferential.quotientCotangentIdeal :
+noncomputable def KaehlerDifferential.quotientCotangentIdeal :
     ((S ⊗ S ⧸ KaehlerDifferential.ideal R S ^ 2) ⧸
         (KaehlerDifferential.ideal R S).cotangentIdeal) ≃ₐ[S] S :=
   { KaehlerDifferential.quotientCotangentIdealRingEquiv R S with
@@ -625,7 +627,7 @@ A --→ B
 ↑     ↑
 |     |
 R --→ S -/
-def KaehlerDifferential.map : Ω[A⁄R] →ₗ[A] Ω[B⁄S] :=
+noncomputable def KaehlerDifferential.map : Ω[A⁄R] →ₗ[A] Ω[B⁄S] :=
   Derivation.liftKaehlerDifferential
     (((KaehlerDifferential.D S B).restrictScalars R).compAlgebraMap A)
 #align kaehler_differential.map KaehlerDifferential.map

--- a/Mathlib/RingTheory/MatrixAlgebra.lean
+++ b/Mathlib/RingTheory/MatrixAlgebra.lean
@@ -53,6 +53,7 @@ theorem toFunBilinear_apply (a : A) (m : Matrix n n R) :
 The function underlying `(A ⊗[R] Matrix n n R) →ₐ[R] Matrix n n A`,
 as an `R`-linear map.
 -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def toFunLinear : A ⊗[R] Matrix n n R →ₗ[R] Matrix n n A :=
   TensorProduct.lift (toFunBilinear R A n)
 #align matrix_equiv_tensor.to_fun_linear MatrixEquivTensor.toFunLinear
@@ -61,6 +62,7 @@ variable [DecidableEq n] [Fintype n]
 
 /-- The function `(A ⊗[R] Matrix n n R) →ₐ[R] Matrix n n A`, as an algebra homomorphism.
 -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def toFunAlgHom : A ⊗[R] Matrix n n R →ₐ[R] Matrix n n A :=
   algHomOfLinearMapTensorProduct (toFunLinear R A n)
     (by
@@ -88,6 +90,7 @@ theorem toFunAlgHom_apply (a : A) (m : Matrix n n R) :
 The bare function `Matrix n n A → A ⊗[R] Matrix n n R`.
 (We don't need to show that it's an algebra map, thankfully --- just that it's an inverse.)
 -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def invFun (M : Matrix n n A) : A ⊗[R] Matrix n n R :=
   ∑ p : n × n, M p.1 p.2 ⊗ₜ stdBasisMatrix p.1 p.2 1
 #align matrix_equiv_tensor.inv_fun MatrixEquivTensor.invFun
@@ -139,6 +142,7 @@ theorem left_inv (M : A ⊗[R] Matrix n n R) : invFun R A n (toFunAlgHom R A n M
 
 The equivalence, ignoring the algebra structure, `(A ⊗[R] Matrix n n R) ≃ Matrix n n A`.
 -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def equiv : A ⊗[R] Matrix n n R ≃ Matrix n n A where
   toFun := toFunAlgHom R A n
   invFun := invFun R A n
@@ -152,6 +156,7 @@ variable [Fintype n] [DecidableEq n]
 
 /-- The `R`-algebra isomorphism `Matrix n n A ≃ₐ[R] (A ⊗[R] Matrix n n R)`.
 -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def matrixEquivTensor : Matrix n n A ≃ₐ[R] A ⊗[R] Matrix n n R :=
   AlgEquiv.symm { MatrixEquivTensor.toFunAlgHom R A n, MatrixEquivTensor.equiv R A n with }
 #align matrix_equiv_tensor matrixEquivTensor

--- a/Mathlib/RingTheory/MatrixAlgebra.lean
+++ b/Mathlib/RingTheory/MatrixAlgebra.lean
@@ -53,7 +53,7 @@ theorem toFunBilinear_apply (a : A) (m : Matrix n n R) :
 The function underlying `(A ⊗[R] Matrix n n R) →ₐ[R] Matrix n n A`,
 as an `R`-linear map.
 -/
-def toFunLinear : A ⊗[R] Matrix n n R →ₗ[R] Matrix n n A :=
+noncomputable def toFunLinear : A ⊗[R] Matrix n n R →ₗ[R] Matrix n n A :=
   TensorProduct.lift (toFunBilinear R A n)
 #align matrix_equiv_tensor.to_fun_linear MatrixEquivTensor.toFunLinear
 
@@ -61,7 +61,7 @@ variable [DecidableEq n] [Fintype n]
 
 /-- The function `(A ⊗[R] Matrix n n R) →ₐ[R] Matrix n n A`, as an algebra homomorphism.
 -/
-def toFunAlgHom : A ⊗[R] Matrix n n R →ₐ[R] Matrix n n A :=
+noncomputable def toFunAlgHom : A ⊗[R] Matrix n n R →ₐ[R] Matrix n n A :=
   algHomOfLinearMapTensorProduct (toFunLinear R A n)
     (by
       intros
@@ -88,7 +88,7 @@ theorem toFunAlgHom_apply (a : A) (m : Matrix n n R) :
 The bare function `Matrix n n A → A ⊗[R] Matrix n n R`.
 (We don't need to show that it's an algebra map, thankfully --- just that it's an inverse.)
 -/
-def invFun (M : Matrix n n A) : A ⊗[R] Matrix n n R :=
+noncomputable def invFun (M : Matrix n n A) : A ⊗[R] Matrix n n R :=
   ∑ p : n × n, M p.1 p.2 ⊗ₜ stdBasisMatrix p.1 p.2 1
 #align matrix_equiv_tensor.inv_fun MatrixEquivTensor.invFun
 
@@ -139,7 +139,7 @@ theorem left_inv (M : A ⊗[R] Matrix n n R) : invFun R A n (toFunAlgHom R A n M
 
 The equivalence, ignoring the algebra structure, `(A ⊗[R] Matrix n n R) ≃ Matrix n n A`.
 -/
-def equiv : A ⊗[R] Matrix n n R ≃ Matrix n n A where
+noncomputable def equiv : A ⊗[R] Matrix n n R ≃ Matrix n n A where
   toFun := toFunAlgHom R A n
   invFun := invFun R A n
   left_inv := left_inv R A n
@@ -152,7 +152,7 @@ variable [Fintype n] [DecidableEq n]
 
 /-- The `R`-algebra isomorphism `Matrix n n A ≃ₐ[R] (A ⊗[R] Matrix n n R)`.
 -/
-def matrixEquivTensor : Matrix n n A ≃ₐ[R] A ⊗[R] Matrix n n R :=
+noncomputable def matrixEquivTensor : Matrix n n A ≃ₐ[R] A ⊗[R] Matrix n n R :=
   AlgEquiv.symm { MatrixEquivTensor.toFunAlgHom R A n, MatrixEquivTensor.equiv R A n with }
 #align matrix_equiv_tensor matrixEquivTensor
 

--- a/Mathlib/RingTheory/TensorProduct.lean
+++ b/Mathlib/RingTheory/TensorProduct.lean
@@ -58,6 +58,7 @@ variable (r : R) (f g : M →ₗ[R] N)
 variable (A)
 
 /-- `baseChange A f` for `f : M →ₗ[R] N` is the `A`-linear map `A ⊗[R] M →ₗ[A] A ⊗[R] N`. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def baseChange (f : M →ₗ[R] N) : A ⊗[R] M →ₗ[A] A ⊗[R] N :=
   AlgebraTensorModule.map (LinearMap.id : A →ₗ[A] A) f
 #align linear_map.base_change LinearMap.baseChange
@@ -96,6 +97,7 @@ variable (R A M N)
 
 /-- `baseChange` as a linear map. -/
 @[simps]
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def baseChangeHom : (M →ₗ[R] N) →ₗ[R] A ⊗[R] M →ₗ[A] A ⊗[R] N where
   toFun := baseChange A
   map_add' := baseChange_add
@@ -157,6 +159,7 @@ The multiplication map on `A ⊗[R] B`,
 for a fixed pure tensor in the first argument,
 as an `R`-linear map.
 -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def mulAux (a₁ : A) (b₁ : B) : A ⊗[R] B →ₗ[R] A ⊗[R] B :=
   TensorProduct.map (LinearMap.mulLeft R a₁) (LinearMap.mulLeft R b₁)
 #align algebra.tensor_product.mul_aux Algebra.TensorProduct.mulAux
@@ -171,6 +174,7 @@ theorem mulAux_apply (a₁ a₂ : A) (b₁ b₂ : B) :
 The multiplication map on `A ⊗[R] B`,
 as an `R`-bilinear map.
 -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def mul : A ⊗[R] B →ₗ[R] A ⊗[R] B →ₗ[R] A ⊗[R] B :=
   TensorProduct.lift <|
     LinearMap.mk₂ R mulAux
@@ -213,12 +217,14 @@ protected theorem mul_one (x : A ⊗[R] B) : mul x (1 ⊗ₜ 1) = x := by
   refine TensorProduct.induction_on x ?_ ?_ ?_ <;> simp (config := { contextual := true })
 #align algebra.tensor_product.mul_one Algebra.TensorProduct.mul_one
 
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable instance : One (A ⊗[R] B) where one := 1 ⊗ₜ 1
 
 theorem one_def : (1 : A ⊗[R] B) = (1 : A) ⊗ₜ (1 : B) :=
   rfl
 #align algebra.tensor_product.one_def Algebra.TensorProduct.one_def
 
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable instance : AddMonoidWithOne (A ⊗[R] B) where
   natCast n := n ⊗ₜ 1
   natCast_zero := by simp
@@ -226,9 +232,11 @@ noncomputable instance : AddMonoidWithOne (A ⊗[R] B) where
 
 theorem natCast_def (n : ℕ) : (n : A ⊗[R] B) = (n : A) ⊗ₜ (1 : B) := rfl
 
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable instance : AddCommMonoid (A ⊗[R] B) := by infer_instance
 
 -- providing this instance separately makes some downstream code substantially faster
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable instance instMul : Mul (A ⊗[R] B) where
   mul a b := mul a b
 
@@ -240,6 +248,7 @@ theorem tmul_mul_tmul (a₁ a₂ : A) (b₁ b₂ : B) :
 
 -- note: we deliberately do not provide any fields that overlap with `AddMonoidWithOne` as this
 -- appears to help performance.
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable instance instSemiring : Semiring (A ⊗[R] B) where
   left_distrib a b c := by simp [HMul.hMul, Mul.mul]
   right_distrib a b c := by simp [HMul.hMul, Mul.mul]
@@ -260,6 +269,7 @@ theorem tmul_pow (a : A) (b : B) (k : ℕ) : a ⊗ₜ[R] b ^ k = (a ^ k) ⊗ₜ[
 
 /-- The ring morphism `A →+* A ⊗[R] B` sending `a` to `a ⊗ₜ 1`. -/
 @[simps]
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def includeLeftRingHom : A →+* A ⊗[R] B where
   toFun a := a ⊗ₜ 1
   map_zero' := by simp
@@ -302,6 +312,7 @@ instance (priority := 100) sMulCommClass_right [Monoid S] [DistribMulAction S A]
 
 variable [CommSemiring S] [Algebra S A]
 
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable instance leftAlgebra [SMulCommClass R S A] : Algebra S (A ⊗[R] B) :=
   { commutes' := fun r x => by
       dsimp only [RingHom.toFun_eq_coe, RingHom.comp_apply, includeLeftRingHom_apply]
@@ -317,6 +328,7 @@ example : (algebraNat : Algebra ℕ (ℕ ⊗[ℕ] B)) = leftAlgebra := rfl
 
 -- This is for the `undergrad.yaml` list.
 /-- The tensor product of two `R`-algebras is an `R`-algebra. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable instance instAlgebra : Algebra R (A ⊗[R] B) :=
   inferInstance
 
@@ -327,6 +339,7 @@ theorem algebraMap_apply [SMulCommClass R S A] (r : S) :
 #align algebra.tensor_product.algebra_map_apply Algebra.TensorProduct.algebraMap_apply
 
 /-- The `R`-algebra morphism `A →ₐ[R] A ⊗[R] B` sending `a` to `a ⊗ₜ 1`. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def includeLeft [SMulCommClass R S A] : A →ₐ[S] A ⊗[R] B :=
   { includeLeftRingHom with commutes' := by simp }
 #align algebra.tensor_product.include_left Algebra.TensorProduct.includeLeft
@@ -338,6 +351,7 @@ theorem includeLeft_apply [SMulCommClass R S A] (a : A) :
 #align algebra.tensor_product.include_left_apply Algebra.TensorProduct.includeLeft_apply
 
 /-- The algebra morphism `B →ₐ[R] A ⊗[R] B` sending `b` to `1 ⊗ₜ b`. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def includeRight : B →ₐ[R] A ⊗[R] B where
   toFun b := 1 ⊗ₜ b
   map_zero' := by simp
@@ -398,6 +412,7 @@ variable [CommRing R]
 variable [Ring A] [Algebra R A]
 variable [Ring B] [Algebra R B]
 
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable instance instRing : Ring (A ⊗[R] B) where
   zsmul := SubNegMonoid.zsmul
   zsmul_zero' := SubNegMonoid.zsmul_zero'
@@ -421,6 +436,7 @@ variable [CommRing R]
 variable [CommRing A] [Algebra R A]
 variable [CommRing B] [Algebra R B]
 
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable instance instCommRing : CommRing (A ⊗[R] B) :=
   { toRing := inferInstance
     mul_comm := fun x y => by
@@ -443,6 +459,7 @@ section RightAlgebra
 /-- `S ⊗[R] T` has a `T`-algebra structure. This is not a global instance or else the action of
 `S` on `S ⊗[R] S` would be ambiguous. -/
 @[reducible]
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def rightAlgebra : Algebra B (A ⊗[R] B) :=
   (Algebra.TensorProduct.includeRight.toRingHom : B →+* A ⊗[R] B).toAlgebra
 #align algebra.tensor_product.right_algebra Algebra.TensorProduct.rightAlgebra
@@ -460,11 +477,13 @@ end CommRing
 /-- Verify that typeclass search finds the ring structure on `A ⊗[ℤ] B`
 when `A` and `B` are merely rings, by treating both as `ℤ`-algebras.
 -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable example [Ring A] [Ring B] : Ring (A ⊗[ℤ] B) := by infer_instance
 
 /-- Verify that typeclass search finds the comm_ring structure on `A ⊗[ℤ] B`
 when `A` and `B` are merely comm_rings, by treating both as `ℤ`-algebras.
 -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable example [CommRing A] [CommRing B] : CommRing (A ⊗[ℤ] B) := by infer_instance
 
 /-!
@@ -578,6 +597,7 @@ variable (R A)
 
 /-- The base ring is a left identity for the tensor product of algebra, up to algebra isomorphism.
 -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 protected noncomputable nonrec def lid : R ⊗[R] A ≃ₐ[R] A :=
   algEquivOfLinearEquivTensorProduct (TensorProduct.lid R A) (by
     simp only [mul_smul, lid_tmul, Algebra.smul_mul_assoc, Algebra.mul_smul_comm]
@@ -597,6 +617,7 @@ variable (S)
 
 Note that if `A` is commutative this can be instantiated with `S = A`.
 -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 protected noncomputable nonrec def rid : A ⊗[R] R ≃ₐ[S] A :=
   algEquivOfLinearEquivTensorProduct (AlgebraTensorModule.rid R S A)
     (fun _a₁ _a₂ _r₁ _r₂ => smul_mul_smul _ _ _ _ |>.symm)
@@ -615,6 +636,7 @@ variable (B)
 
 /-- The tensor product of R-algebras is commutative, up to algebra isomorphism.
 -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 protected noncomputable def comm : A ⊗[R] B ≃ₐ[R] B ⊗[R] A :=
   algEquivOfLinearEquivTensorProduct (_root_.TensorProduct.comm R A B) (by simp)
   fun r => by
@@ -657,6 +679,7 @@ variable (A B C)
 
 -- porting note: much nicer than Lean 3 proof
 /-- The associator for tensor product of R-algebras, as an algebra isomorphism. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 protected noncomputable def assoc : (A ⊗[R] B) ⊗[R] C ≃ₐ[R] A ⊗[R] B ⊗[R] C :=
   algEquivOfLinearEquivTripleTensorProduct
     (_root_.TensorProduct.assoc R A B C)
@@ -678,6 +701,7 @@ end
 variable {R S A}
 
 /-- The tensor product of a pair of algebra morphisms. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def map (f : A →ₐ[S] B) (g : C →ₐ[R] D) : A ⊗[R] C →ₐ[S] B ⊗[R] D :=
   algHomOfLinearMapTensorProduct (AlgebraTensorModule.map f.toLinearMap g.toLinearMap) (by simp)
     (by simp [AlgHom.commutes])
@@ -728,6 +752,7 @@ theorem map_range (f : A →ₐ[R] B) (g : C →ₐ[R] D) :
 /-- Construct an isomorphism between tensor products of an S-algebra with an R-algebra
 from S- and R- isomorphisms between the tensor factors.
 -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def congr (f : A ≃ₐ[S] B) (g : C ≃ₐ[R] D) : A ⊗[R] C ≃ₐ[S] B ⊗[R] D :=
   AlgEquiv.ofAlgHom (map f g) (map f.symm g.symm)
     (ext' fun b d => by simp) (ext' fun a c => by simp)
@@ -770,6 +795,7 @@ variable (f : A →ₐ[R] S) (g : B →ₐ[R] S)
 variable (R)
 
 /-- `LinearMap.mul'` is an `AlgHom` on commutative rings. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def lmul' : S ⊗[R] S →ₐ[R] S :=
   algHomOfLinearMapTensorProduct (LinearMap.mul' R S)
     (fun a₁ a₂ b₁ b₂ => by simp only [LinearMap.mul'_apply, mul_mul_mul_comm]) fun r => by
@@ -800,6 +826,7 @@ theorem lmul'_comp_includeRight : (lmul' R : _ →ₐ[R] S).comp includeRight = 
 /-- If `S` is commutative, for a pair of morphisms `f : A →ₐ[R] S`, `g : B →ₐ[R] S`,
 We obtain a map `A ⊗[R] B →ₐ[R] S` that commutes with `f`, `g` via `a ⊗ b ↦ f(a) * g(b)`.
 -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def productMap : A ⊗[R] B →ₐ[R] S :=
   (lmul' R).comp (TensorProduct.map f g)
 #align algebra.tensor_product.product_map Algebra.TensorProduct.productMap
@@ -846,6 +873,7 @@ variable [CommSemiring C] [Algebra R C] [Algebra S C] [IsScalarTower R S C]
 `·/S/R`), then the product map of `f : A →ₐ[S] C` and `g : B →ₐ[R] C` is an `S`-algebra
 homomorphism. -/
 @[simps!]
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def productLeftAlgHom (f : A →ₐ[S] C) (g : B →ₐ[R] C) : A ⊗[R] B →ₐ[S] C :=
   { (productMap (f.restrictScalars R) g).toRingHom with
     commutes' := fun r => by
@@ -932,6 +960,7 @@ the `TensorProduct.map f g`, the tensor product of the two maps.
 
 This is an `AlgHom` version of `TensorProduct.AlgebraTensorModule.homTensorHomMap`. Like that
 definition, this is generalized across many different rings; namely a tower of algebras `A/S/R`. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def endTensorEndAlgHom : End A M ⊗[R] End R N →ₐ[S] End A (M ⊗[R] N) :=
   Algebra.TensorProduct.algHomOfLinearMapTensorProduct
     (AlgebraTensorModule.homTensorHomMap R A S M N M N)
@@ -968,6 +997,7 @@ variable [IsScalarTower R A M] [IsScalarTower R B M]
 
 /-- An auxiliary definition, used for constructing the `Module (A ⊗[R] B) M` in
 `TensorProduct.Algebra.module` below. -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 noncomputable def moduleAux : A ⊗[R] B →ₗ[R] M →ₗ[R] M :=
   TensorProduct.lift
     { toFun := fun a => a • (Algebra.lsmul R R M : B →ₐ[R] Module.End R M).toLinearMap
@@ -999,6 +1029,7 @@ multiplication, and one from this would-be instance. Arguably we could live with
 case the real fix is to address the ambiguity in notation, probably along the lines outlined here:
 https://leanprover.zulipchat.com/#narrow/stream/144837-PR-reviews/topic/.234773.20base.20change/near/240929258
 -/
+-- `noncomputable` is a performance workaround for mathlib4#7103
 protected noncomputable def module : Module (A ⊗[R] B) M where
   smul x m := moduleAux x m
   zero_smul m := by simp only [(· • ·), map_zero, LinearMap.zero_apply]

--- a/Mathlib/RingTheory/TensorProduct.lean
+++ b/Mathlib/RingTheory/TensorProduct.lean
@@ -58,7 +58,7 @@ variable (r : R) (f g : M →ₗ[R] N)
 variable (A)
 
 /-- `baseChange A f` for `f : M →ₗ[R] N` is the `A`-linear map `A ⊗[R] M →ₗ[A] A ⊗[R] N`. -/
-def baseChange (f : M →ₗ[R] N) : A ⊗[R] M →ₗ[A] A ⊗[R] N :=
+noncomputable def baseChange (f : M →ₗ[R] N) : A ⊗[R] M →ₗ[A] A ⊗[R] N :=
   AlgebraTensorModule.map (LinearMap.id : A →ₗ[A] A) f
 #align linear_map.base_change LinearMap.baseChange
 
@@ -96,7 +96,7 @@ variable (R A M N)
 
 /-- `baseChange` as a linear map. -/
 @[simps]
-def baseChangeHom : (M →ₗ[R] N) →ₗ[R] A ⊗[R] M →ₗ[A] A ⊗[R] N where
+noncomputable def baseChangeHom : (M →ₗ[R] N) →ₗ[R] A ⊗[R] M →ₗ[A] A ⊗[R] N where
   toFun := baseChange A
   map_add' := baseChange_add
   map_smul' := baseChange_smul
@@ -157,7 +157,7 @@ The multiplication map on `A ⊗[R] B`,
 for a fixed pure tensor in the first argument,
 as an `R`-linear map.
 -/
-def mulAux (a₁ : A) (b₁ : B) : A ⊗[R] B →ₗ[R] A ⊗[R] B :=
+noncomputable def mulAux (a₁ : A) (b₁ : B) : A ⊗[R] B →ₗ[R] A ⊗[R] B :=
   TensorProduct.map (LinearMap.mulLeft R a₁) (LinearMap.mulLeft R b₁)
 #align algebra.tensor_product.mul_aux Algebra.TensorProduct.mulAux
 
@@ -171,7 +171,7 @@ theorem mulAux_apply (a₁ a₂ : A) (b₁ b₂ : B) :
 The multiplication map on `A ⊗[R] B`,
 as an `R`-bilinear map.
 -/
-def mul : A ⊗[R] B →ₗ[R] A ⊗[R] B →ₗ[R] A ⊗[R] B :=
+noncomputable def mul : A ⊗[R] B →ₗ[R] A ⊗[R] B →ₗ[R] A ⊗[R] B :=
   TensorProduct.lift <|
     LinearMap.mk₂ R mulAux
       (fun x₁ x₂ y =>
@@ -213,23 +213,23 @@ protected theorem mul_one (x : A ⊗[R] B) : mul x (1 ⊗ₜ 1) = x := by
   refine TensorProduct.induction_on x ?_ ?_ ?_ <;> simp (config := { contextual := true })
 #align algebra.tensor_product.mul_one Algebra.TensorProduct.mul_one
 
-instance : One (A ⊗[R] B) where one := 1 ⊗ₜ 1
+noncomputable instance : One (A ⊗[R] B) where one := 1 ⊗ₜ 1
 
 theorem one_def : (1 : A ⊗[R] B) = (1 : A) ⊗ₜ (1 : B) :=
   rfl
 #align algebra.tensor_product.one_def Algebra.TensorProduct.one_def
 
-instance : AddMonoidWithOne (A ⊗[R] B) where
+noncomputable instance : AddMonoidWithOne (A ⊗[R] B) where
   natCast n := n ⊗ₜ 1
   natCast_zero := by simp
   natCast_succ n := by simp [add_tmul, one_def]
 
 theorem natCast_def (n : ℕ) : (n : A ⊗[R] B) = (n : A) ⊗ₜ (1 : B) := rfl
 
-instance : AddCommMonoid (A ⊗[R] B) := by infer_instance
+noncomputable instance : AddCommMonoid (A ⊗[R] B) := by infer_instance
 
 -- providing this instance separately makes some downstream code substantially faster
-instance instMul : Mul (A ⊗[R] B) where
+noncomputable instance instMul : Mul (A ⊗[R] B) where
   mul a b := mul a b
 
 @[simp]
@@ -240,7 +240,7 @@ theorem tmul_mul_tmul (a₁ a₂ : A) (b₁ b₂ : B) :
 
 -- note: we deliberately do not provide any fields that overlap with `AddMonoidWithOne` as this
 -- appears to help performance.
-instance instSemiring : Semiring (A ⊗[R] B) where
+noncomputable instance instSemiring : Semiring (A ⊗[R] B) where
   left_distrib a b c := by simp [HMul.hMul, Mul.mul]
   right_distrib a b c := by simp [HMul.hMul, Mul.mul]
   zero_mul a := by simp [HMul.hMul, Mul.mul]
@@ -260,7 +260,7 @@ theorem tmul_pow (a : A) (b : B) (k : ℕ) : a ⊗ₜ[R] b ^ k = (a ^ k) ⊗ₜ[
 
 /-- The ring morphism `A →+* A ⊗[R] B` sending `a` to `a ⊗ₜ 1`. -/
 @[simps]
-def includeLeftRingHom : A →+* A ⊗[R] B where
+noncomputable def includeLeftRingHom : A →+* A ⊗[R] B where
   toFun a := a ⊗ₜ 1
   map_zero' := by simp
   map_add' := by simp [add_tmul]
@@ -302,7 +302,7 @@ instance (priority := 100) sMulCommClass_right [Monoid S] [DistribMulAction S A]
 
 variable [CommSemiring S] [Algebra S A]
 
-instance leftAlgebra [SMulCommClass R S A] : Algebra S (A ⊗[R] B) :=
+noncomputable instance leftAlgebra [SMulCommClass R S A] : Algebra S (A ⊗[R] B) :=
   { commutes' := fun r x => by
       dsimp only [RingHom.toFun_eq_coe, RingHom.comp_apply, includeLeftRingHom_apply]
       rw [algebraMap_eq_smul_one, ← smul_tmul', ← one_def, mul_smul_comm, smul_mul_assoc, mul_one,
@@ -317,7 +317,7 @@ example : (algebraNat : Algebra ℕ (ℕ ⊗[ℕ] B)) = leftAlgebra := rfl
 
 -- This is for the `undergrad.yaml` list.
 /-- The tensor product of two `R`-algebras is an `R`-algebra. -/
-instance instAlgebra : Algebra R (A ⊗[R] B) :=
+noncomputable instance instAlgebra : Algebra R (A ⊗[R] B) :=
   inferInstance
 
 @[simp]
@@ -327,7 +327,7 @@ theorem algebraMap_apply [SMulCommClass R S A] (r : S) :
 #align algebra.tensor_product.algebra_map_apply Algebra.TensorProduct.algebraMap_apply
 
 /-- The `R`-algebra morphism `A →ₐ[R] A ⊗[R] B` sending `a` to `a ⊗ₜ 1`. -/
-def includeLeft [SMulCommClass R S A] : A →ₐ[S] A ⊗[R] B :=
+noncomputable def includeLeft [SMulCommClass R S A] : A →ₐ[S] A ⊗[R] B :=
   { includeLeftRingHom with commutes' := by simp }
 #align algebra.tensor_product.include_left Algebra.TensorProduct.includeLeft
 
@@ -338,7 +338,7 @@ theorem includeLeft_apply [SMulCommClass R S A] (a : A) :
 #align algebra.tensor_product.include_left_apply Algebra.TensorProduct.includeLeft_apply
 
 /-- The algebra morphism `B →ₐ[R] A ⊗[R] B` sending `b` to `1 ⊗ₜ b`. -/
-def includeRight : B →ₐ[R] A ⊗[R] B where
+noncomputable def includeRight : B →ₐ[R] A ⊗[R] B where
   toFun b := 1 ⊗ₜ b
   map_zero' := by simp
   map_add' := by simp [tmul_add]
@@ -398,7 +398,7 @@ variable [CommRing R]
 variable [Ring A] [Algebra R A]
 variable [Ring B] [Algebra R B]
 
-instance instRing : Ring (A ⊗[R] B) where
+noncomputable instance instRing : Ring (A ⊗[R] B) where
   zsmul := SubNegMonoid.zsmul
   zsmul_zero' := SubNegMonoid.zsmul_zero'
   zsmul_succ' := SubNegMonoid.zsmul_succ'
@@ -421,7 +421,7 @@ variable [CommRing R]
 variable [CommRing A] [Algebra R A]
 variable [CommRing B] [Algebra R B]
 
-instance instCommRing : CommRing (A ⊗[R] B) :=
+noncomputable instance instCommRing : CommRing (A ⊗[R] B) :=
   { toRing := inferInstance
     mul_comm := fun x y => by
       refine TensorProduct.induction_on x ?_ ?_ ?_
@@ -443,7 +443,7 @@ section RightAlgebra
 /-- `S ⊗[R] T` has a `T`-algebra structure. This is not a global instance or else the action of
 `S` on `S ⊗[R] S` would be ambiguous. -/
 @[reducible]
-def rightAlgebra : Algebra B (A ⊗[R] B) :=
+noncomputable def rightAlgebra : Algebra B (A ⊗[R] B) :=
   (Algebra.TensorProduct.includeRight.toRingHom : B →+* A ⊗[R] B).toAlgebra
 #align algebra.tensor_product.right_algebra Algebra.TensorProduct.rightAlgebra
 
@@ -460,12 +460,12 @@ end CommRing
 /-- Verify that typeclass search finds the ring structure on `A ⊗[ℤ] B`
 when `A` and `B` are merely rings, by treating both as `ℤ`-algebras.
 -/
-example [Ring A] [Ring B] : Ring (A ⊗[ℤ] B) := by infer_instance
+noncomputable example [Ring A] [Ring B] : Ring (A ⊗[ℤ] B) := by infer_instance
 
 /-- Verify that typeclass search finds the comm_ring structure on `A ⊗[ℤ] B`
 when `A` and `B` are merely comm_rings, by treating both as `ℤ`-algebras.
 -/
-example [CommRing A] [CommRing B] : CommRing (A ⊗[ℤ] B) := by infer_instance
+noncomputable example [CommRing A] [CommRing B] : CommRing (A ⊗[ℤ] B) := by infer_instance
 
 /-!
 We now build the structure maps for the symmetric monoidal category of `R`-algebras.
@@ -578,7 +578,7 @@ variable (R A)
 
 /-- The base ring is a left identity for the tensor product of algebra, up to algebra isomorphism.
 -/
-protected nonrec def lid : R ⊗[R] A ≃ₐ[R] A :=
+protected noncomputable nonrec def lid : R ⊗[R] A ≃ₐ[R] A :=
   algEquivOfLinearEquivTensorProduct (TensorProduct.lid R A) (by
     simp only [mul_smul, lid_tmul, Algebra.smul_mul_assoc, Algebra.mul_smul_comm]
     simp_rw [← mul_smul, mul_comm]
@@ -597,7 +597,7 @@ variable (S)
 
 Note that if `A` is commutative this can be instantiated with `S = A`.
 -/
-protected nonrec def rid : A ⊗[R] R ≃ₐ[S] A :=
+protected noncomputable nonrec def rid : A ⊗[R] R ≃ₐ[S] A :=
   algEquivOfLinearEquivTensorProduct (AlgebraTensorModule.rid R S A)
     (fun _a₁ _a₂ _r₁ _r₂ => smul_mul_smul _ _ _ _ |>.symm)
     (fun _s => one_smul _ _)
@@ -615,7 +615,7 @@ variable (B)
 
 /-- The tensor product of R-algebras is commutative, up to algebra isomorphism.
 -/
-protected def comm : A ⊗[R] B ≃ₐ[R] B ⊗[R] A :=
+protected noncomputable def comm : A ⊗[R] B ≃ₐ[R] B ⊗[R] A :=
   algEquivOfLinearEquivTensorProduct (_root_.TensorProduct.comm R A B) (by simp)
   fun r => by
     trans r • (1 : B) ⊗ₜ[R] (1 : A)
@@ -657,7 +657,7 @@ variable (A B C)
 
 -- porting note: much nicer than Lean 3 proof
 /-- The associator for tensor product of R-algebras, as an algebra isomorphism. -/
-protected def assoc : (A ⊗[R] B) ⊗[R] C ≃ₐ[R] A ⊗[R] B ⊗[R] C :=
+protected noncomputable def assoc : (A ⊗[R] B) ⊗[R] C ≃ₐ[R] A ⊗[R] B ⊗[R] C :=
   algEquivOfLinearEquivTripleTensorProduct
     (_root_.TensorProduct.assoc R A B C)
     Algebra.TensorProduct.assoc_aux_1
@@ -678,7 +678,7 @@ end
 variable {R S A}
 
 /-- The tensor product of a pair of algebra morphisms. -/
-def map (f : A →ₐ[S] B) (g : C →ₐ[R] D) : A ⊗[R] C →ₐ[S] B ⊗[R] D :=
+noncomputable def map (f : A →ₐ[S] B) (g : C →ₐ[R] D) : A ⊗[R] C →ₐ[S] B ⊗[R] D :=
   algHomOfLinearMapTensorProduct (AlgebraTensorModule.map f.toLinearMap g.toLinearMap) (by simp)
     (by simp [AlgHom.commutes])
 #align algebra.tensor_product.map Algebra.TensorProduct.map
@@ -728,7 +728,7 @@ theorem map_range (f : A →ₐ[R] B) (g : C →ₐ[R] D) :
 /-- Construct an isomorphism between tensor products of an S-algebra with an R-algebra
 from S- and R- isomorphisms between the tensor factors.
 -/
-def congr (f : A ≃ₐ[S] B) (g : C ≃ₐ[R] D) : A ⊗[R] C ≃ₐ[S] B ⊗[R] D :=
+noncomputable def congr (f : A ≃ₐ[S] B) (g : C ≃ₐ[R] D) : A ⊗[R] C ≃ₐ[S] B ⊗[R] D :=
   AlgEquiv.ofAlgHom (map f g) (map f.symm g.symm)
     (ext' fun b d => by simp) (ext' fun a c => by simp)
 #align algebra.tensor_product.congr Algebra.TensorProduct.congr
@@ -770,7 +770,7 @@ variable (f : A →ₐ[R] S) (g : B →ₐ[R] S)
 variable (R)
 
 /-- `LinearMap.mul'` is an `AlgHom` on commutative rings. -/
-def lmul' : S ⊗[R] S →ₐ[R] S :=
+noncomputable def lmul' : S ⊗[R] S →ₐ[R] S :=
   algHomOfLinearMapTensorProduct (LinearMap.mul' R S)
     (fun a₁ a₂ b₁ b₂ => by simp only [LinearMap.mul'_apply, mul_mul_mul_comm]) fun r => by
     simp only [LinearMap.mul'_apply, _root_.mul_one]
@@ -800,7 +800,7 @@ theorem lmul'_comp_includeRight : (lmul' R : _ →ₐ[R] S).comp includeRight = 
 /-- If `S` is commutative, for a pair of morphisms `f : A →ₐ[R] S`, `g : B →ₐ[R] S`,
 We obtain a map `A ⊗[R] B →ₐ[R] S` that commutes with `f`, `g` via `a ⊗ b ↦ f(a) * g(b)`.
 -/
-def productMap : A ⊗[R] B →ₐ[R] S :=
+noncomputable def productMap : A ⊗[R] B →ₐ[R] S :=
   (lmul' R).comp (TensorProduct.map f g)
 #align algebra.tensor_product.product_map Algebra.TensorProduct.productMap
 
@@ -846,7 +846,7 @@ variable [CommSemiring C] [Algebra R C] [Algebra S C] [IsScalarTower R S C]
 `·/S/R`), then the product map of `f : A →ₐ[S] C` and `g : B →ₐ[R] C` is an `S`-algebra
 homomorphism. -/
 @[simps!]
-def productLeftAlgHom (f : A →ₐ[S] C) (g : B →ₐ[R] C) : A ⊗[R] B →ₐ[S] C :=
+noncomputable def productLeftAlgHom (f : A →ₐ[S] C) (g : B →ₐ[R] C) : A ⊗[R] B →ₐ[S] C :=
   { (productMap (f.restrictScalars R) g).toRingHom with
     commutes' := fun r => by
       dsimp
@@ -932,7 +932,7 @@ the `TensorProduct.map f g`, the tensor product of the two maps.
 
 This is an `AlgHom` version of `TensorProduct.AlgebraTensorModule.homTensorHomMap`. Like that
 definition, this is generalized across many different rings; namely a tower of algebras `A/S/R`. -/
-def endTensorEndAlgHom : End A M ⊗[R] End R N →ₐ[S] End A (M ⊗[R] N) :=
+noncomputable def endTensorEndAlgHom : End A M ⊗[R] End R N →ₐ[S] End A (M ⊗[R] N) :=
   Algebra.TensorProduct.algHomOfLinearMapTensorProduct
     (AlgebraTensorModule.homTensorHomMap R A S M N M N)
     (fun _f₁ _f₂ _g₁ _g₂ => AlgebraTensorModule.ext fun _m _n => rfl)
@@ -968,7 +968,7 @@ variable [IsScalarTower R A M] [IsScalarTower R B M]
 
 /-- An auxiliary definition, used for constructing the `Module (A ⊗[R] B) M` in
 `TensorProduct.Algebra.module` below. -/
-def moduleAux : A ⊗[R] B →ₗ[R] M →ₗ[R] M :=
+noncomputable def moduleAux : A ⊗[R] B →ₗ[R] M →ₗ[R] M :=
   TensorProduct.lift
     { toFun := fun a => a • (Algebra.lsmul R R M : B →ₐ[R] Module.End R M).toLinearMap
       map_add' := fun r t => by
@@ -999,7 +999,7 @@ multiplication, and one from this would-be instance. Arguably we could live with
 case the real fix is to address the ambiguity in notation, probably along the lines outlined here:
 https://leanprover.zulipchat.com/#narrow/stream/144837-PR-reviews/topic/.234773.20base.20change/near/240929258
 -/
-protected def module : Module (A ⊗[R] B) M where
+protected noncomputable def module : Module (A ⊗[R] B) M where
   smul x m := moduleAux x m
   zero_smul m := by simp only [(· • ·), map_zero, LinearMap.zero_apply]
   smul_zero x := by simp only [(· • ·), map_zero]


### PR DESCRIPTION
Making the definition of [TensorProduct](https://leanprover-community.github.io/mathlib4_docs/Mathlib/LinearAlgebra/TensorProduct.html#TensorProduct) noncomputable breaks about 30 files because hundreds of other definitions need to be made noncomputable as a consequence. This PR makes this change and then fixes the breakage. It was inspired by #7265 -- I wondered what kind of effect the change would have on (a) total olean size and (b) compilation time.

Total olean size goes down from 3.11 gigs to 2.96 gigs, an approx 153 megabyte saving (or 4.9%). Perhaps surprising from just one definition, that I'm pretty sure nobody is ever going to #eval anyway (NB there are more definitions with this property in mathlib). Examples of individual olean changes: `LinearAlgebra/TensorProduct/Tower.olean` (the largest olean file on current master) goes down from 16 megs to 2.4 megs, and `LinearAlgebra/TensorProduct.olean` (the second largest) goes down from 13 megs to 3.6 megs.

Total wall clock compile time of mathlib becomes faster by around 1%, CPU instructions are down by 1.6%, linting got faster by 2% (according to [speedcenter]( http://speed.lean-fro.org/mathlib4/compare/f923c955-6f71-4f1e-8cd4-142ba0fd1e48/to/78372017-b26e-4b9c-aadb-2b620036b07f)). Many definitions now become much faster -- for example compilation of the definition [LieAlgebra.rootSpaceWeightSpaceProduct](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/Lie/Weights.html#LieAlgebra.rootSpaceWeightSpaceProduct) drops from 29 seconds to 2 seconds. No changes needed to be made to any of mathlib other than making lots of definitions and instances noncomputable.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
