### PR TITLE
[Merged by Bors] - perf: change one instance in coprods of groups

### DIFF
--- a/Mathlib/GroupTheory/Coprod/Basic.lean
+++ b/Mathlib/GroupTheory/Coprod/Basic.lean
@@ -463,7 +463,10 @@ section ToProd
 
 variable {M N : Type*} [Monoid M] [Monoid N]
 
-@[to_additive] instance : Monoid (M ∗ N) := Con.monoid _
+@[to_additive] instance : Monoid (M ∗ N) :=
+  { mul_assoc := (Con.monoid _).mul_assoc
+    one_mul := (Con.monoid _).one_mul
+    mul_one := (Con.monoid _).mul_one }
 
 /-- The natural projection `M ∗ N →* M`. -/
 @[to_additive "The natural projection `AddMonoid.Coprod M N →+ M`."]


### PR DESCRIPTION
---
This fixed a simp failure in #6803 . If it is defined like this, then there is no need to unfold `Con.monoid` when checking defeq.
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
