### PR TITLE
[Merged by Bors] - feat(RingTheory/PowerSeries): add lemmas on formal power series

### DIFF
--- a/Mathlib/RingTheory/PowerSeries/Basic.lean
+++ b/Mathlib/RingTheory/PowerSeries/Basic.lean
@@ -1858,6 +1858,15 @@ theorem natDegree_trunc_lt (f : R⟦X⟧) (n) : (trunc (n + 1) f).natDegree < n 
 
 @[simp] lemma trunc_zero' {f : R⟦X⟧} : trunc 0 f = 0 := rfl
 
+theorem degree_trunc_lt (f : R⟦X⟧) (n) : (trunc n f).degree < n := by
+  rw [degree_lt_iff_coeff_zero]
+  intros
+  rw [coeff_trunc]
+  split_ifs with h
+  · rw [←not_le] at h;
+    contradiction
+  · rfl
+
 theorem eval₂_trunc_eq_sum_range {S : Type*} [Semiring S] (s : S) (G : R →+* S) (n) (f : R⟦X⟧) :
     (trunc n f).eval₂ G s = ∑ i in range n, G (coeff R i f) * s ^ i := by
   cases n with

--- a/Mathlib/RingTheory/PowerSeries/Basic.lean
+++ b/Mathlib/RingTheory/PowerSeries/Basic.lean
@@ -2824,7 +2824,7 @@ theorem coeff_coe_trunc_of_lt {n m} {f : R⟦X⟧} (h : n < m) :
     coeff R n (trunc m f) = coeff R n f := by
   rwa [coeff_coe, coeff_trunc, if_pos]
 
-/-- The `n`-th coefficient of a`f*g` may be calculated
+/-- The `n`-th coefficient of `f*g` may be calculated
 from the truncations of `f` and `g`.-/
 theorem coeff_mul_eq_coeff_trunc_mul_trunc₂ {n a b} (f g) (ha : n < a) (hb : n < b) :
     coeff R n (f * g) = coeff R n (trunc a f * trunc b g) := by

--- a/Mathlib/RingTheory/PowerSeries/Basic.lean
+++ b/Mathlib/RingTheory/PowerSeries/Basic.lean
@@ -1785,7 +1785,11 @@ theorem rescale_mul (a b : R) : rescale (a * b) = (rescale b).comp (rescale a) :
   simp [← rescale_rescale]
 #align power_series.rescale_mul PowerSeries.rescale_mul
 
+end CommSemiring
+
 section Trunc
+variable [Semiring R]
+open Finset Nat
 
 /-- The `n`th truncation of a formal power series to a polynomial -/
 def trunc (n : ℕ) (φ : PowerSeries R) : R[X] :=
@@ -1832,9 +1836,55 @@ theorem trunc_add (n) (φ ψ : PowerSeries R) : trunc n (φ + ψ) = trunc n φ +
     · rw [zero_add]
 #align power_series.trunc_add PowerSeries.trunc_add
 
+/--
+`R⟦X⟧` is notation for `PowerSeries R`,
+the semiring of formal power series in one variable over a semiring `R`.
+-/
+scoped notation:9000 R "⟦X⟧" => PowerSeries R
+
+theorem trunc_succ (f : R⟦X⟧) (n : ℕ) :
+    trunc n.succ f = trunc n f + Polynomial.monomial n (coeff R n f) := by
+  rw [trunc, Ico_zero_eq_range, sum_range_succ, trunc, Ico_zero_eq_range]
+
+theorem natDegree_trunc_lt (f : R⟦X⟧) (n) : (trunc (n + 1) f).natDegree < n + 1 := by
+  rw [lt_succ_iff, natDegree_le_iff_coeff_eq_zero]
+  intros
+  rw [coeff_trunc]
+  split_ifs with h
+  · rw [lt_succ, ←not_lt] at h
+    contradiction
+  · rfl
+
+@[simp] lemma trunc_zero' {f : R⟦X⟧} : trunc 0 f = 0 := rfl
+
+theorem eval₂_trunc_eq_sum_range {S : Type*} [Semiring S] {s : S} {G : R →+* S} {n} {f : R⟦X⟧} :
+    (trunc n f).eval₂ G s = ∑ i in range n, G (coeff R i f) * s ^ i := by
+  cases n with
+  | zero =>
+    rw [trunc_zero', range_zero, sum_empty, eval₂_zero]
+  | succ n =>
+    have := natDegree_trunc_lt f n
+    rw [eval₂_eq_sum_range' (hn := this)]
+    apply sum_congr rfl
+    intro _ h
+    rw [mem_range] at h
+    congr
+    rw [coeff_trunc, if_pos h]
+
+@[simp] theorem trunc_X {n} : trunc (n + 2) X = (Polynomial.X : R[X]) := by
+  ext d
+  rw [coeff_trunc, coeff_X]
+  split_ifs with h₁ h₂
+  · rw [h₂, coeff_X_one]
+  · rw [coeff_X_of_ne_one h₂]
+  · rw [coeff_X_of_ne_one]
+    intro hd
+    apply h₁
+    rw [hd]
+    exact n.one_lt_succ_succ
+
 end Trunc
 
-end CommSemiring
 
 section Ring
 
@@ -2632,6 +2682,14 @@ theorem coe_pow (n : ℕ) : ((φ ^ n : R[X]) : PowerSeries R) = (φ : PowerSerie
   coeToPowerSeries.ringHom.map_pow _ _
 #align polynomial.coe_pow Polynomial.coe_pow
 
+theorem eval₂_C_X_eq_coe : φ.eval₂ (PowerSeries.C R) PowerSeries.X = ↑φ := by
+  nth_rw 2 [←eval₂_C_X (p := φ)]
+  rw [←coeToPowerSeries.ringHom_apply, eval₂_eq_sum_range, eval₂_eq_sum_range, map_sum]
+  apply Finset.sum_congr rfl
+  intros
+  rw [map_mul, map_pow, coeToPowerSeries.ringHom_apply,
+    coeToPowerSeries.ringHom_apply, coe_C, coe_X]
+
 variable (A : Type*) [Semiring A] [Algebra R A]
 
 /-- The coercion from polynomials to power series
@@ -2651,6 +2709,8 @@ theorem coeToPowerSeries.algHom_apply :
 end Polynomial
 
 namespace PowerSeries
+
+section Algebra
 
 variable {R A : Type*} [CommSemiring R] [CommSemiring A] [Algebra R A] (f : PowerSeries R)
 
@@ -2679,4 +2739,85 @@ theorem algebraMap_apply'' :
   rfl
 #align power_series.algebra_map_apply'' PowerSeries.algebraMap_apply''
 
+end Algebra
+
+section Trunc
+/-
+Lemmas in this section involve the coercion `R[X] → R⟦X⟧`, so they may only be stated in the case
+`R` is commutative. This is because the coercion is an `R`-algebra map.
+-/
+variable {R : Type*} [CommSemiring R]
+
+open Nat hiding pow_succ pow_zero
+open Polynomial BigOperators Finset Finset.Nat
+
+theorem trunc_trunc_of_le {n m} (f : R⟦X⟧) (hnm : n ≤ m := by rfl) :
+    trunc n ↑(trunc m f) = trunc n f := by
+  ext d
+  rw [coeff_trunc, coeff_trunc, coeff_coe]
+  split_ifs with h
+  · rw [coeff_trunc, if_pos <| lt_of_lt_of_le h hnm]
+  · rfl
+
+@[simp] theorem trunc_trunc {n} (f : R⟦X⟧) : trunc n ↑(trunc n f) = trunc n f :=
+  trunc_trunc_of_le f
+
+@[simp] theorem trunc_trunc_mul {n} (f g : R ⟦X⟧) :
+    trunc n ( (trunc n f) * g : R⟦X⟧ ) = trunc n ( f * g ) := by
+  ext m
+  rw [coeff_trunc, coeff_trunc]
+  split_ifs with h
+  · rw [coeff_mul, coeff_mul, sum_congr rfl]
+    intro _ hab
+    have ha := lt_of_le_of_lt (antidiagonal.fst_le hab) h
+    rw [coeff_coe, coeff_trunc, if_pos ha]
+  · rfl
+
+@[simp] theorem trunc_mul_trunc {n} (f g : R ⟦X⟧) :
+    trunc n ( f * (trunc n g) : R⟦X⟧ ) = trunc n ( f * g ) := by
+  rw [mul_comm, trunc_trunc_mul, mul_comm]
+
+theorem trunc_trunc_mul_trunc {n} (f g : R⟦X⟧) :
+    trunc n (trunc n f * trunc n g : R⟦X⟧) = trunc n (f * g) := by
+  rw [trunc_trunc_mul, trunc_mul_trunc]
+
+@[simp] theorem trunc_trunc_pow (f : R⟦X⟧) (n a : ℕ) :
+    trunc n ((trunc n f : R⟦X⟧) ^ a) = trunc n (f ^ a) := by
+  induction a with
+  | zero =>
+    rw [pow_zero, pow_zero]
+  | succ a ih =>
+    rw [pow_succ, pow_succ, trunc_trunc_mul, ←trunc_trunc_mul_trunc, ih, trunc_trunc_mul_trunc]
+
+theorem trunc_coe_eq_self {n} {f : R[X]} (hn : natDegree f < n) : trunc n (f : R⟦X⟧) = f := by
+  rw [←Polynomial.coe_inj]
+  ext m
+  rw [coeff_coe, coeff_trunc]
+  split
+  case inl h => rfl
+  case inr h =>
+    rw [not_lt] at h
+    rw [coeff_coe]; symm
+    exact coeff_eq_zero_of_natDegree_lt <| lt_of_lt_of_le hn h
+
+/-- The function `coeff n : R⟦X⟧ → R` is continuous. I.e. `coeff n f` depends only on a sufficiently
+long truncation of the power series `f`.-/
+theorem coeff_stable {n m} {f : R⟦X⟧} (h : n < m) :
+    coeff R n f = coeff R n (trunc m f) := by
+  rwa [coeff_coe, coeff_trunc, if_pos]
+
+/-- The `n`-th coefficient of a`f*g` may be calculated
+from the truncations of `f` and `g`.-/
+theorem coeff_mul_stable₂ {n a b} (f g) (ha : n < a) (hb : n < b) :
+    coeff R n (f * g) = coeff R n (trunc a f * trunc b g) := by
+  symm
+  rw [←succ_le] at ha hb
+  rw [coeff_stable n.lt_succ_self, ←trunc_trunc_mul_trunc, trunc_trunc_of_le f ha,
+    trunc_trunc_of_le g hb, trunc_trunc_mul_trunc, ←coeff_stable n.lt_succ_self]
+
+theorem coeff_mul_stable {d n} (f g) (h : d < n) :
+    coeff R d (f * g) = coeff R d (trunc n f * trunc n g) :=
+  coeff_mul_stable₂ f g h h
+
+end Trunc
 end PowerSeries

--- a/Mathlib/RingTheory/PowerSeries/Basic.lean
+++ b/Mathlib/RingTheory/PowerSeries/Basic.lean
@@ -1863,7 +1863,7 @@ theorem degree_trunc_lt (f : R⟦X⟧) (n) : (trunc n f).degree < n := by
   intros
   rw [coeff_trunc]
   split_ifs with h
-  · rw [←not_le] at h;
+  · rw [←not_le] at h
     contradiction
   · rfl
 

--- a/Mathlib/RingTheory/PowerSeries/Basic.lean
+++ b/Mathlib/RingTheory/PowerSeries/Basic.lean
@@ -2802,22 +2802,21 @@ theorem trunc_coe_eq_self {n} {f : R[X]} (hn : natDegree f < n) : trunc n (f : R
 
 /-- The function `coeff n : R⟦X⟧ → R` is continuous. I.e. `coeff n f` depends only on a sufficiently
 long truncation of the power series `f`.-/
-theorem coeff_stable {n m} {f : R⟦X⟧} (h : n < m) :
+theorem coeff_eq_of_lt {n m} {f : R⟦X⟧} (h : n < m) :
     coeff R n f = coeff R n (trunc m f) := by
   rwa [coeff_coe, coeff_trunc, if_pos]
 
 /-- The `n`-th coefficient of a`f*g` may be calculated
 from the truncations of `f` and `g`.-/
-theorem coeff_mul_stable₂ {n a b} (f g) (ha : n < a) (hb : n < b) :
+theorem coeff_mul_eq_coeff_trunc_mul_trunc₂ {n a b} (f g) (ha : n < a) (hb : n < b) :
     coeff R n (f * g) = coeff R n (trunc a f * trunc b g) := by
   symm
-  rw [←succ_le] at ha hb
-  rw [coeff_stable n.lt_succ_self, ←trunc_trunc_mul_trunc, trunc_trunc_of_le f ha,
-    trunc_trunc_of_le g hb, trunc_trunc_mul_trunc, ←coeff_stable n.lt_succ_self]
+  rw [coeff_eq_of_lt n.lt_succ_self, ←trunc_trunc_mul_trunc, trunc_trunc_of_le f ha,
+    trunc_trunc_of_le g hb, trunc_trunc_mul_trunc, ←coeff_eq_of_lt n.lt_succ_self]
 
-theorem coeff_mul_stable {d n} (f g) (h : d < n) :
+theorem coeff_mul_eq_coeff_trunc_mul_trunc {d n} (f g) (h : d < n) :
     coeff R d (f * g) = coeff R d (trunc n f * trunc n g) :=
-  coeff_mul_stable₂ f g h h
+  coeff_mul_eq_coeff_trunc_mul_trunc₂ f g h h
 
 end Trunc
 end PowerSeries

--- a/Mathlib/RingTheory/PowerSeries/Basic.lean
+++ b/Mathlib/RingTheory/PowerSeries/Basic.lean
@@ -1857,7 +1857,7 @@ theorem natDegree_trunc_lt (f : R⟦X⟧) (n) : (trunc (n + 1) f).natDegree < n 
 
 @[simp] lemma trunc_zero' {f : R⟦X⟧} : trunc 0 f = 0 := rfl
 
-theorem eval₂_trunc_eq_sum_range {S : Type*} [Semiring S] {s : S} {G : R →+* S} {n} {f : R⟦X⟧} :
+theorem eval₂_trunc_eq_sum_range {S : Type*} [Semiring S] (s : S) (G : R →+* S) (n) (f : R⟦X⟧) :
     (trunc n f).eval₂ G s = ∑ i in range n, G (coeff R i f) * s ^ i := by
   cases n with
   | zero =>
@@ -1871,7 +1871,7 @@ theorem eval₂_trunc_eq_sum_range {S : Type*} [Semiring S] {s : S} {G : R →+*
     congr
     rw [coeff_trunc, if_pos h]
 
-@[simp] theorem trunc_X {n} : trunc (n + 2) X = (Polynomial.X : R[X]) := by
+@[simp] theorem trunc_X (n) : trunc (n + 2) X = (Polynomial.X : R[X]) := by
   ext d
   rw [coeff_trunc, coeff_X]
   split_ifs with h₁ h₂
@@ -2763,7 +2763,7 @@ theorem trunc_trunc_of_le {n m} (f : R⟦X⟧) (hnm : n ≤ m := by rfl) :
   trunc_trunc_of_le f
 
 @[simp] theorem trunc_trunc_mul {n} (f g : R ⟦X⟧) :
-    trunc n ( (trunc n f) * g : R⟦X⟧ ) = trunc n ( f * g ) := by
+    trunc n ((trunc n f) * g : R⟦X⟧) = trunc n (f * g) := by
   ext m
   rw [coeff_trunc, coeff_trunc]
   split_ifs with h
@@ -2774,7 +2774,7 @@ theorem trunc_trunc_of_le {n m} (f : R⟦X⟧) (hnm : n ≤ m := by rfl) :
   · rfl
 
 @[simp] theorem trunc_mul_trunc {n} (f g : R ⟦X⟧) :
-    trunc n ( f * (trunc n g) : R⟦X⟧ ) = trunc n ( f * g ) := by
+    trunc n (f * (trunc n g) : R⟦X⟧) = trunc n (f * g) := by
   rw [mul_comm, trunc_trunc_mul, mul_comm]
 
 theorem trunc_trunc_mul_trunc {n} (f g : R⟦X⟧) :

--- a/Mathlib/RingTheory/PowerSeries/Basic.lean
+++ b/Mathlib/RingTheory/PowerSeries/Basic.lean
@@ -1240,59 +1240,66 @@ section
 -- Porting note: not available in Lean 4
 -- local reducible PowerSeries
 
-instance [Inhabited R] : Inhabited (PowerSeries R) := by
+
+/--
+`R⟦X⟧` is notation for `PowerSeries R`,
+the semiring of formal power series in one variable over a semiring `R`.
+-/
+scoped notation:9000 R "⟦X⟧" => PowerSeries R
+
+instance [Inhabited R] : Inhabited R⟦X⟧ := by
   dsimp only [PowerSeries]
   infer_instance
 
-instance [Zero R] : Zero (PowerSeries R) := by
+instance [Zero R] : Zero R⟦X⟧ := by
   dsimp only [PowerSeries]
   infer_instance
 
-instance [AddMonoid R] : AddMonoid (PowerSeries R) := by
+instance [AddMonoid R] : AddMonoid R⟦X⟧ := by
   dsimp only [PowerSeries]
   infer_instance
 
-instance [AddGroup R] : AddGroup (PowerSeries R) := by
+instance [AddGroup R] : AddGroup R⟦X⟧ := by
   dsimp only [PowerSeries]
   infer_instance
 
-instance [AddCommMonoid R] : AddCommMonoid (PowerSeries R) := by
+instance [AddCommMonoid R] : AddCommMonoid R⟦X⟧ := by
   dsimp only [PowerSeries]
   infer_instance
 
-instance [AddCommGroup R] : AddCommGroup (PowerSeries R) := by
+instance [AddCommGroup R] : AddCommGroup R⟦X⟧ := by
   dsimp only [PowerSeries]
   infer_instance
 
-instance [Semiring R] : Semiring (PowerSeries R) := by
+instance [Semiring R] : Semiring R⟦X⟧ := by
   dsimp only [PowerSeries]
   infer_instance
 
-instance [CommSemiring R] : CommSemiring (PowerSeries R) := by
+instance [CommSemiring R] : CommSemiring R⟦X⟧ := by
   dsimp only [PowerSeries]
   infer_instance
 
-instance [Ring R] : Ring (PowerSeries R) := by
+instance [Ring R] : Ring R⟦X⟧ := by
   dsimp only [PowerSeries]
   infer_instance
 
-instance [CommRing R] : CommRing (PowerSeries R) := by
+instance [CommRing R] : CommRing R⟦X⟧ := by
   dsimp only [PowerSeries]
   infer_instance
 
-instance [Nontrivial R] : Nontrivial (PowerSeries R) := by
+instance [Nontrivial R] : Nontrivial R⟦X⟧ := by
   dsimp only [PowerSeries]
   infer_instance
 
-instance {A} [Semiring R] [AddCommMonoid A] [Module R A] : Module R (PowerSeries A) := by
+instance {A} [Semiring R] [AddCommMonoid A] [Module R A] : Module R A⟦X⟧ := by
   dsimp only [PowerSeries]
   infer_instance
 
 instance {A S} [Semiring R] [Semiring S] [AddCommMonoid A] [Module R A] [Module S A] [SMul R S]
-    [IsScalarTower R S A] : IsScalarTower R S (PowerSeries A) :=
+    [IsScalarTower R S A] : IsScalarTower R S A⟦X⟧ :=
   Pi.isScalarTower
 
-instance {A} [Semiring A] [CommSemiring R] [Algebra R A] : Algebra R (PowerSeries A) := by
+instance {A} [Semiring A] [CommSemiring R] [Algebra R A] : Algebra R A⟦X⟧ := by
   dsimp only [PowerSeries]
   infer_instance
 
@@ -1303,12 +1310,12 @@ section Semiring
 variable (R) [Semiring R]
 
 /-- The `n`th coefficient of a formal power series.-/
-def coeff (n : ℕ) : PowerSeries R →ₗ[R] R :=
+def coeff (n : ℕ) : R⟦X⟧ →ₗ[R] R :=
   MvPowerSeries.coeff R (single () n)
 #align power_series.coeff PowerSeries.coeff
 
 /-- The `n`th monomial with coefficient `a` as formal power series.-/
-def monomial (n : ℕ) : R →ₗ[R] PowerSeries R :=
+def monomial (n : ℕ) : R →ₗ[R] R⟦X⟧ :=
   MvPowerSeries.monomial R (single () n)
 #align power_series.monomial PowerSeries.monomial
 
@@ -1320,7 +1327,7 @@ theorem coeff_def {s : Unit →₀ ℕ} {n : ℕ} (h : s () = n) : coeff R n = M
 
 /-- Two formal power series are equal if all their coefficients are equal.-/
 @[ext]
-theorem ext {φ ψ : PowerSeries R} (h : ∀ n, coeff R n φ = coeff R n ψ) : φ = ψ :=
+theorem ext {φ ψ : R⟦X⟧} (h : ∀ n, coeff R n φ = coeff R n ψ) : φ = ψ :=
   MvPowerSeries.ext fun n => by
     rw [← coeff_def]
     · apply h
@@ -1328,12 +1335,12 @@ theorem ext {φ ψ : PowerSeries R} (h : ∀ n, coeff R n φ = coeff R n ψ) : �
 #align power_series.ext PowerSeries.ext
 
 /-- Two formal power series are equal if all their coefficients are equal.-/
-theorem ext_iff {φ ψ : PowerSeries R} : φ = ψ ↔ ∀ n, coeff R n φ = coeff R n ψ :=
+theorem ext_iff {φ ψ : R⟦X⟧} : φ = ψ ↔ ∀ n, coeff R n φ = coeff R n ψ :=
   ⟨fun h n => congr_arg (coeff R n) h, ext⟩
 #align power_series.ext_iff PowerSeries.ext_iff
 
 /-- Constructor for formal power series.-/
-def mk {R} (f : ℕ → R) : PowerSeries R := fun s => f (s ())
+def mk {R} (f : ℕ → R) : R⟦X⟧ := fun s => f (s ())
 #align power_series.mk PowerSeries.mk
 
 @[simp]
@@ -1365,12 +1372,12 @@ theorem coeff_comp_monomial (n : ℕ) : (coeff R n).comp (monomial R n) = Linear
 variable (R)
 
 /-- The constant coefficient of a formal power series. -/
-def constantCoeff : PowerSeries R →+* R :=
+def constantCoeff : R⟦X⟧ →+* R :=
   MvPowerSeries.constantCoeff Unit R
 #align power_series.constant_coeff PowerSeries.constantCoeff
 
 /-- The constant formal power series.-/
-def C : R →+* PowerSeries R :=
+def C : R →+* R⟦X⟧ :=
   MvPowerSeries.C Unit R
 set_option linter.uppercaseLean3 false in
 #align power_series.C PowerSeries.C
@@ -1378,12 +1385,12 @@ set_option linter.uppercaseLean3 false in
 variable {R}
 
 /-- The variable of the formal power series ring.-/
-def X : PowerSeries R :=
+def X : R⟦X⟧ :=
   MvPowerSeries.X ()
 set_option linter.uppercaseLean3 false in
 #align power_series.X PowerSeries.X
 
-theorem commute_X (φ : PowerSeries R) : Commute φ X :=
+theorem commute_X (φ : R⟦X⟧) : Commute φ X :=
   MvPowerSeries.commute_X _ _
 set_option linter.uppercaseLean3 false in
 #align power_series.commute_X PowerSeries.commute_X
@@ -1394,7 +1401,7 @@ theorem coeff_zero_eq_constantCoeff : ⇑(coeff R 0) = constantCoeff R := by
   rfl
 #align power_series.coeff_zero_eq_constant_coeff PowerSeries.coeff_zero_eq_constantCoeff
 
-theorem coeff_zero_eq_constantCoeff_apply (φ : PowerSeries R) : coeff R 0 φ = constantCoeff R φ :=
+theorem coeff_zero_eq_constantCoeff_apply (φ : R⟦X⟧) : coeff R 0 φ = constantCoeff R φ :=
   by rw [coeff_zero_eq_constantCoeff]
 #align power_series.coeff_zero_eq_constant_coeff_apply PowerSeries.coeff_zero_eq_constantCoeff_apply
 
@@ -1408,7 +1415,7 @@ theorem monomial_zero_eq_C_apply (a : R) : monomial R 0 a = C R a := by simp
 set_option linter.uppercaseLean3 false in
 #align power_series.monomial_zero_eq_C_apply PowerSeries.monomial_zero_eq_C_apply
 
-theorem coeff_C (n : ℕ) (a : R) : coeff R n (C R a : PowerSeries R) = if n = 0 then a else 0 := by
+theorem coeff_C (n : ℕ) (a : R) : coeff R n (C R a : R⟦X⟧) = if n = 0 then a else 0 := by
   rw [← monomial_zero_eq_C_apply, coeff_monomial]
 set_option linter.uppercaseLean3 false in
 #align power_series.coeff_C PowerSeries.coeff_C
@@ -1419,59 +1426,59 @@ theorem coeff_zero_C (a : R) : coeff R 0 (C R a) = a := by
 set_option linter.uppercaseLean3 false in
 #align power_series.coeff_zero_C PowerSeries.coeff_zero_C
 
-theorem X_eq : (X : PowerSeries R) = monomial R 1 1 :=
+theorem X_eq : (X : R⟦X⟧) = monomial R 1 1 :=
   rfl
 set_option linter.uppercaseLean3 false in
 #align power_series.X_eq PowerSeries.X_eq
 
-theorem coeff_X (n : ℕ) : coeff R n (X : PowerSeries R) = if n = 1 then 1 else 0 := by
+theorem coeff_X (n : ℕ) : coeff R n (X : R⟦X⟧) = if n = 1 then 1 else 0 := by
   rw [X_eq, coeff_monomial]
 set_option linter.uppercaseLean3 false in
 #align power_series.coeff_X PowerSeries.coeff_X
 
 @[simp]
-theorem coeff_zero_X : coeff R 0 (X : PowerSeries R) = 0 := by
+theorem coeff_zero_X : coeff R 0 (X : R⟦X⟧) = 0 := by
   rw [coeff, Finsupp.single_zero, X, MvPowerSeries.coeff_zero_X]
 set_option linter.uppercaseLean3 false in
 #align power_series.coeff_zero_X PowerSeries.coeff_zero_X
 
 @[simp]
-theorem coeff_one_X : coeff R 1 (X : PowerSeries R) = 1 := by rw [coeff_X, if_pos rfl]
+theorem coeff_one_X : coeff R 1 (X : R⟦X⟧) = 1 := by rw [coeff_X, if_pos rfl]
 set_option linter.uppercaseLean3 false in
 #align power_series.coeff_one_X PowerSeries.coeff_one_X
 
 @[simp]
-theorem X_ne_zero [Nontrivial R] : (X : PowerSeries R) ≠ 0 := fun H => by
+theorem X_ne_zero [Nontrivial R] : (X : R⟦X⟧) ≠ 0 := fun H => by
   simpa only [coeff_one_X, one_ne_zero, map_zero] using congr_arg (coeff R 1) H
 set_option linter.uppercaseLean3 false in
 #align power_series.X_ne_zero PowerSeries.X_ne_zero
 
-theorem X_pow_eq (n : ℕ) : (X : PowerSeries R) ^ n = monomial R n 1 :=
+theorem X_pow_eq (n : ℕ) : (X : R⟦X⟧) ^ n = monomial R n 1 :=
   MvPowerSeries.X_pow_eq _ n
 set_option linter.uppercaseLean3 false in
 #align power_series.X_pow_eq PowerSeries.X_pow_eq
 
-theorem coeff_X_pow (m n : ℕ) : coeff R m ((X : PowerSeries R) ^ n) = if m = n then 1 else 0 := by
+theorem coeff_X_pow (m n : ℕ) : coeff R m ((X : R⟦X⟧) ^ n) = if m = n then 1 else 0 := by
   rw [X_pow_eq, coeff_monomial]
 set_option linter.uppercaseLean3 false in
 #align power_series.coeff_X_pow PowerSeries.coeff_X_pow
 
 @[simp]
-theorem coeff_X_pow_self (n : ℕ) : coeff R n ((X : PowerSeries R) ^ n) = 1 := by
+theorem coeff_X_pow_self (n : ℕ) : coeff R n ((X : R⟦X⟧) ^ n) = 1 := by
   rw [coeff_X_pow, if_pos rfl]
 set_option linter.uppercaseLean3 false in
 #align power_series.coeff_X_pow_self PowerSeries.coeff_X_pow_self
 
 @[simp]
-theorem coeff_one (n : ℕ) : coeff R n (1 : PowerSeries R) = if n = 0 then 1 else 0 :=
+theorem coeff_one (n : ℕ) : coeff R n (1 : R⟦X⟧) = if n = 0 then 1 else 0 :=
   coeff_C n 1
 #align power_series.coeff_one PowerSeries.coeff_one
 
-theorem coeff_zero_one : coeff R 0 (1 : PowerSeries R) = 1 :=
+theorem coeff_zero_one : coeff R 0 (1 : R⟦X⟧) = 1 :=
   coeff_zero_C 1
 #align power_series.coeff_zero_one PowerSeries.coeff_zero_one
 
-theorem coeff_mul (n : ℕ) (φ ψ : PowerSeries R) :
+theorem coeff_mul (n : ℕ) (φ ψ : R⟦X⟧) :
     coeff R n (φ * ψ) = ∑ p in Finset.Nat.antidiagonal n, coeff R p.1 φ * coeff R p.2 ψ := by
   -- `rw` can't see that `PowerSeries = MvPowerSeries Unit`, so use `.trans`
   refine (MvPowerSeries.coeff_mul _ φ ψ).trans ?_
@@ -1480,13 +1487,13 @@ theorem coeff_mul (n : ℕ) (φ ψ : PowerSeries R) :
 #align power_series.coeff_mul PowerSeries.coeff_mul
 
 @[simp]
-theorem coeff_mul_C (n : ℕ) (φ : PowerSeries R) (a : R) : coeff R n (φ * C R a) = coeff R n φ * a :=
+theorem coeff_mul_C (n : ℕ) (φ : R⟦X⟧) (a : R) : coeff R n (φ * C R a) = coeff R n φ * a :=
   MvPowerSeries.coeff_mul_C _ φ a
 set_option linter.uppercaseLean3 false in
 #align power_series.coeff_mul_C PowerSeries.coeff_mul_C
 
 @[simp]
-theorem coeff_C_mul (n : ℕ) (φ : PowerSeries R) (a : R) : coeff R n (C R a * φ) = a * coeff R n φ :=
+theorem coeff_C_mul (n : ℕ) (φ : R⟦X⟧) (a : R) : coeff R n (C R a * φ) = a * coeff R n φ :=
   MvPowerSeries.coeff_C_mul _ φ a
 set_option linter.uppercaseLean3 false in
 #align power_series.coeff_C_mul PowerSeries.coeff_C_mul
@@ -1497,14 +1504,14 @@ theorem coeff_smul {S : Type*} [Semiring S] [Module R S] (n : ℕ) (φ : PowerSe
   rfl
 #align power_series.coeff_smul PowerSeries.coeff_smul
 
-theorem smul_eq_C_mul (f : PowerSeries R) (a : R) : a • f = C R a * f := by
+theorem smul_eq_C_mul (f : R⟦X⟧) (a : R) : a • f = C R a * f := by
   ext
   simp
 set_option linter.uppercaseLean3 false in
 #align power_series.smul_eq_C_mul PowerSeries.smul_eq_C_mul
 
 @[simp]
-theorem coeff_succ_mul_X (n : ℕ) (φ : PowerSeries R) : coeff R (n + 1) (φ * X) = coeff R n φ := by
+theorem coeff_succ_mul_X (n : ℕ) (φ : R⟦X⟧) : coeff R (n + 1) (φ * X) = coeff R n φ := by
   simp only [coeff, Finsupp.single_add]
   convert φ.coeff_add_mul_monomial (single () n) (single () 1) _
   rw [mul_one]
@@ -1512,7 +1519,7 @@ set_option linter.uppercaseLean3 false in
 #align power_series.coeff_succ_mul_X PowerSeries.coeff_succ_mul_X
 
 @[simp]
-theorem coeff_succ_X_mul (n : ℕ) (φ : PowerSeries R) : coeff R (n + 1) (X * φ) = coeff R n φ := by
+theorem coeff_succ_X_mul (n : ℕ) (φ : R⟦X⟧) : coeff R (n + 1) (X * φ) = coeff R n φ := by
   simp only [coeff, Finsupp.single_add, add_comm n 1]
   convert φ.coeff_add_monomial_mul (single () 1) (single () n) _
   rw [one_mul]
@@ -1549,11 +1556,11 @@ theorem constantCoeff_X : constantCoeff R X = 0 :=
 set_option linter.uppercaseLean3 false in
 #align power_series.constant_coeff_X PowerSeries.constantCoeff_X
 
-theorem coeff_zero_mul_X (φ : PowerSeries R) : coeff R 0 (φ * X) = 0 := by simp
+theorem coeff_zero_mul_X (φ : R⟦X⟧) : coeff R 0 (φ * X) = 0 := by simp
 set_option linter.uppercaseLean3 false in
 #align power_series.coeff_zero_mul_X PowerSeries.coeff_zero_mul_X
 
-theorem coeff_zero_X_mul (φ : PowerSeries R) : coeff R 0 (X * φ) = 0 := by simp
+theorem coeff_zero_X_mul (φ : R⟦X⟧) : coeff R 0 (X * φ) = 0 := by simp
 set_option linter.uppercaseLean3 false in
 #align power_series.coeff_zero_X_mul PowerSeries.coeff_zero_X_mul
 
@@ -1562,13 +1569,13 @@ set_option linter.uppercaseLean3 false in
 section
 
 theorem coeff_C_mul_X_pow (x : R) (k n : ℕ) :
-    coeff R n (C R x * X ^ k : PowerSeries R) = if n = k then x else 0 := by
+    coeff R n (C R x * X ^ k : R⟦X⟧) = if n = k then x else 0 := by
   simp [X_pow_eq, coeff_monomial]
 set_option linter.uppercaseLean3 false in
 #align power_series.coeff_C_mul_X_pow PowerSeries.coeff_C_mul_X_pow
 
 @[simp]
-theorem coeff_mul_X_pow (p : PowerSeries R) (n d : ℕ) :
+theorem coeff_mul_X_pow (p : R⟦X⟧) (n d : ℕ) :
     coeff R (d + n) (p * X ^ n) = coeff R d p := by
   rw [coeff_mul, Finset.sum_eq_single (d, n), coeff_X_pow, if_pos rfl, mul_one]
   · rintro ⟨i, j⟩ h1 h2
@@ -1583,7 +1590,7 @@ set_option linter.uppercaseLean3 false in
 #align power_series.coeff_mul_X_pow PowerSeries.coeff_mul_X_pow
 
 @[simp]
-theorem coeff_X_pow_mul (p : PowerSeries R) (n d : ℕ) :
+theorem coeff_X_pow_mul (p : R⟦X⟧) (n d : ℕ) :
     coeff R (d + n) (X ^ n * p) = coeff R d p := by
   rw [coeff_mul, Finset.sum_eq_single (n, d), coeff_X_pow, if_pos rfl, one_mul]
   · rintro ⟨i, j⟩ h1 h2
@@ -1598,7 +1605,7 @@ theorem coeff_X_pow_mul (p : PowerSeries R) (n d : ℕ) :
 set_option linter.uppercaseLean3 false in
 #align power_series.coeff_X_pow_mul PowerSeries.coeff_X_pow_mul
 
-theorem coeff_mul_X_pow' (p : PowerSeries R) (n d : ℕ) :
+theorem coeff_mul_X_pow' (p : R⟦X⟧) (n d : ℕ) :
     coeff R d (p * X ^ n) = ite (n ≤ d) (coeff R (d - n) p) 0 := by
   split_ifs with h
   · rw [← tsub_add_cancel_of_le h, coeff_mul_X_pow, add_tsub_cancel_right]
@@ -1608,7 +1615,7 @@ theorem coeff_mul_X_pow' (p : PowerSeries R) (n d : ℕ) :
 set_option linter.uppercaseLean3 false in
 #align power_series.coeff_mul_X_pow' PowerSeries.coeff_mul_X_pow'
 
-theorem coeff_X_pow_mul' (p : PowerSeries R) (n d : ℕ) :
+theorem coeff_X_pow_mul' (p : R⟦X⟧) (n d : ℕ) :
     coeff R d (X ^ n * p) = ite (n ≤ d) (coeff R (d - n) p) 0 := by
   split_ifs with h
   · rw [← tsub_add_cancel_of_le h, coeff_X_pow_mul]
@@ -1624,12 +1631,12 @@ set_option linter.uppercaseLean3 false in
 end
 
 /-- If a formal power series is invertible, then so is its constant coefficient.-/
-theorem isUnit_constantCoeff (φ : PowerSeries R) (h : IsUnit φ) : IsUnit (constantCoeff R φ) :=
+theorem isUnit_constantCoeff (φ : R⟦X⟧) (h : IsUnit φ) : IsUnit (constantCoeff R φ) :=
   MvPowerSeries.isUnit_constantCoeff φ h
 #align power_series.is_unit_constant_coeff PowerSeries.isUnit_constantCoeff
 
 /-- Split off the constant coefficient. -/
-theorem eq_shift_mul_X_add_const (φ : PowerSeries R) :
+theorem eq_shift_mul_X_add_const (φ : R⟦X⟧) :
     φ = (mk fun p => coeff R (p + 1) φ) * X + C R (constantCoeff R φ) := by
   ext (_ | n)
   · simp only [Nat.zero_eq, coeff_zero_eq_constantCoeff, map_add, map_mul, constantCoeff_X,
@@ -1640,7 +1647,7 @@ set_option linter.uppercaseLean3 false in
 #align power_series.eq_shift_mul_X_add_const PowerSeries.eq_shift_mul_X_add_const
 
 /-- Split off the constant coefficient. -/
-theorem eq_X_mul_shift_add_const (φ : PowerSeries R) :
+theorem eq_X_mul_shift_add_const (φ : R⟦X⟧) :
     φ = (X * mk fun p => coeff R (p + 1) φ) + C R (constantCoeff R φ) := by
   ext (_ | n)
   · simp only [Nat.zero_eq, coeff_zero_eq_constantCoeff, map_add, map_mul, constantCoeff_X,
@@ -1657,12 +1664,12 @@ variable {S : Type*} {T : Type*} [Semiring S] [Semiring T]
 variable (f : R →+* S) (g : S →+* T)
 
 /-- The map between formal power series induced by a map on the coefficients.-/
-def map : PowerSeries R →+* PowerSeries S :=
+def map : R⟦X⟧ →+* S⟦X⟧ :=
   MvPowerSeries.map _ f
 #align power_series.map PowerSeries.map
 
 @[simp]
-theorem map_id : (map (RingHom.id R) : PowerSeries R → PowerSeries R) = id :=
+theorem map_id : (map (RingHom.id R) : R⟦X⟧ → R⟦X⟧) = id :=
   rfl
 #align power_series.map_id PowerSeries.map_id
 
@@ -1671,7 +1678,7 @@ theorem map_comp : map (g.comp f) = (map g).comp (map f) :=
 #align power_series.map_comp PowerSeries.map_comp
 
 @[simp]
-theorem coeff_map (n : ℕ) (φ : PowerSeries R) : coeff S n (map f φ) = f (coeff R n φ) :=
+theorem coeff_map (n : ℕ) (φ : R⟦X⟧) : coeff S n (map f φ) = f (coeff R n φ) :=
   rfl
 #align power_series.coeff_map PowerSeries.coeff_map
 
@@ -1691,8 +1698,8 @@ set_option linter.uppercaseLean3 false in
 
 end Map
 
-theorem X_pow_dvd_iff {n : ℕ} {φ : PowerSeries R} :
-    (X : PowerSeries R) ^ n ∣ φ ↔ ∀ m, m < n → coeff R m φ = 0 := by
+theorem X_pow_dvd_iff {n : ℕ} {φ : R⟦X⟧} :
+    (X : R⟦X⟧) ^ n ∣ φ ↔ ∀ m, m < n → coeff R m φ = 0 := by
   convert@MvPowerSeries.X_pow_dvd_iff Unit R _ () n φ
   constructor <;> intro h m hm
   · rw [Finsupp.unique_single m]
@@ -1702,8 +1709,8 @@ theorem X_pow_dvd_iff {n : ℕ} {φ : PowerSeries R} :
 set_option linter.uppercaseLean3 false in
 #align power_series.X_pow_dvd_iff PowerSeries.X_pow_dvd_iff
 
-theorem X_dvd_iff {φ : PowerSeries R} : (X : PowerSeries R) ∣ φ ↔ constantCoeff R φ = 0 := by
-  rw [← pow_one (X : PowerSeries R), X_pow_dvd_iff, ← coeff_zero_eq_constantCoeff_apply]
+theorem X_dvd_iff {φ : R⟦X⟧} : (X : R⟦X⟧) ∣ φ ↔ constantCoeff R φ = 0 := by
+  rw [← pow_one (X : R⟦X⟧), X_pow_dvd_iff, ← coeff_zero_eq_constantCoeff_apply]
   constructor <;> intro h
   · exact h 0 zero_lt_one
   · intro m hm
@@ -1720,7 +1727,7 @@ variable [CommSemiring R]
 open Finset Nat
 
 /-- The ring homomorphism taking a power series `f(X)` to `f(aX)`. -/
-noncomputable def rescale (a : R) : PowerSeries R →+* PowerSeries R where
+noncomputable def rescale (a : R) : R⟦X⟧ →+* R⟦X⟧ where
   toFun f := PowerSeries.mk fun n => a ^ n * PowerSeries.coeff R n f
   map_zero' := by
     ext
@@ -1746,7 +1753,7 @@ noncomputable def rescale (a : R) : PowerSeries R →+* PowerSeries R where
 #align power_series.rescale PowerSeries.rescale
 
 @[simp]
-theorem coeff_rescale (f : PowerSeries R) (a : R) (n : ℕ) :
+theorem coeff_rescale (f : R⟦X⟧) (a : R) (n : ℕ) :
     coeff R n (rescale a f) = a ^ n * coeff R n f :=
   coeff_mk n (fun n ↦ a ^ n * (coeff R n) f)
 #align power_series.coeff_rescale PowerSeries.coeff_rescale
@@ -1763,7 +1770,7 @@ theorem rescale_zero_apply : rescale 0 X = C R (constantCoeff R X) := by simp
 #align power_series.rescale_zero_apply PowerSeries.rescale_zero_apply
 
 @[simp]
-theorem rescale_one : rescale 1 = RingHom.id (PowerSeries R) := by
+theorem rescale_one : rescale 1 = RingHom.id R⟦X⟧ := by
   ext
   simp only [coeff_rescale, one_pow, one_mul, RingHom.id_apply]
 #align power_series.rescale_one PowerSeries.rescale_one
@@ -1773,7 +1780,7 @@ theorem rescale_mk (f : ℕ → R) (a : R) : rescale a (mk f) = mk fun n : ℕ =
   rw [coeff_rescale, coeff_mk, coeff_mk]
 #align power_series.rescale_mk PowerSeries.rescale_mk
 
-theorem rescale_rescale (f : PowerSeries R) (a b : R) :
+theorem rescale_rescale (f : R⟦X⟧) (a b : R) :
     rescale b (rescale a f) = rescale (a * b) f := by
   ext n
   simp_rw [coeff_rescale]
@@ -1792,24 +1799,24 @@ variable [Semiring R]
 open Finset Nat
 
 /-- The `n`th truncation of a formal power series to a polynomial -/
-def trunc (n : ℕ) (φ : PowerSeries R) : R[X] :=
+def trunc (n : ℕ) (φ : R⟦X⟧) : R[X] :=
   ∑ m in Ico 0 n, Polynomial.monomial m (coeff R m φ)
 #align power_series.trunc PowerSeries.trunc
 
-theorem coeff_trunc (m) (n) (φ : PowerSeries R) :
+theorem coeff_trunc (m) (n) (φ : R⟦X⟧) :
     (trunc n φ).coeff m = if m < n then coeff R m φ else 0 := by
   simp [trunc, Polynomial.coeff_sum, Polynomial.coeff_monomial, Nat.lt_succ_iff]
 #align power_series.coeff_trunc PowerSeries.coeff_trunc
 
 @[simp]
-theorem trunc_zero (n) : trunc n (0 : PowerSeries R) = 0 :=
+theorem trunc_zero (n) : trunc n (0 : R⟦X⟧) = 0 :=
   Polynomial.ext fun m => by
     rw [coeff_trunc, LinearMap.map_zero, Polynomial.coeff_zero]
     split_ifs <;> rfl
 #align power_series.trunc_zero PowerSeries.trunc_zero
 
 @[simp]
-theorem trunc_one (n) : trunc (n + 1) (1 : PowerSeries R) = 1 :=
+theorem trunc_one (n) : trunc (n + 1) (1 : R⟦X⟧) = 1 :=
   Polynomial.ext fun m => by
     rw [coeff_trunc, coeff_one, Polynomial.coeff_one]
     split_ifs with h _ h'
@@ -1828,19 +1835,13 @@ set_option linter.uppercaseLean3 false in
 #align power_series.trunc_C PowerSeries.trunc_C
 
 @[simp]
-theorem trunc_add (n) (φ ψ : PowerSeries R) : trunc n (φ + ψ) = trunc n φ + trunc n ψ :=
+theorem trunc_add (n) (φ ψ : R⟦X⟧) : trunc n (φ + ψ) = trunc n φ + trunc n ψ :=
   Polynomial.ext fun m => by
     simp only [coeff_trunc, AddMonoidHom.map_add, Polynomial.coeff_add]
     split_ifs with H
     · rfl
     · rw [zero_add]
 #align power_series.trunc_add PowerSeries.trunc_add
-
-/--
-`R⟦X⟧` is notation for `PowerSeries R`,
-the semiring of formal power series in one variable over a semiring `R`.
--/
-scoped notation:9000 R "⟦X⟧" => PowerSeries R
 
 theorem trunc_succ (f : R⟦X⟧) (n : ℕ) :
     trunc n.succ f = trunc n f + Polynomial.monomial n (coeff R n f) := by
@@ -1899,11 +1900,11 @@ section Ring
 variable [Ring R]
 
 /-- Auxiliary function used for computing inverse of a power series -/
-protected def inv.aux : R → PowerSeries R → PowerSeries R :=
+protected def inv.aux : R → R⟦X⟧ → R⟦X⟧ :=
   MvPowerSeries.inv.aux
 #align power_series.inv.aux PowerSeries.inv.aux
 
-theorem coeff_inv_aux (n : ℕ) (a : R) (φ : PowerSeries R) :
+theorem coeff_inv_aux (n : ℕ) (a : R) (φ : R⟦X⟧) :
     coeff R n (inv.aux a φ) =
       if n = 0 then a
       else
@@ -1947,11 +1948,11 @@ theorem coeff_inv_aux (n : ℕ) (a : R) (φ : PowerSeries R) :
 #align power_series.coeff_inv_aux PowerSeries.coeff_inv_aux
 
 /-- A formal power series is invertible if the constant coefficient is invertible.-/
-def invOfUnit (φ : PowerSeries R) (u : Rˣ) : PowerSeries R :=
+def invOfUnit (φ : R⟦X⟧) (u : Rˣ) : R⟦X⟧ :=
   MvPowerSeries.invOfUnit φ u
 #align power_series.inv_of_unit PowerSeries.invOfUnit
 
-theorem coeff_invOfUnit (n : ℕ) (φ : PowerSeries R) (u : Rˣ) :
+theorem coeff_invOfUnit (n : ℕ) (φ : R⟦X⟧) (u : Rˣ) :
     coeff R n (invOfUnit φ u) =
       if n = 0 then ↑u⁻¹
       else
@@ -1962,24 +1963,24 @@ theorem coeff_invOfUnit (n : ℕ) (φ : PowerSeries R) (u : Rˣ) :
 #align power_series.coeff_inv_of_unit PowerSeries.coeff_invOfUnit
 
 @[simp]
-theorem constantCoeff_invOfUnit (φ : PowerSeries R) (u : Rˣ) :
+theorem constantCoeff_invOfUnit (φ : R⟦X⟧) (u : Rˣ) :
     constantCoeff R (invOfUnit φ u) = ↑u⁻¹ := by
   rw [← coeff_zero_eq_constantCoeff_apply, coeff_invOfUnit, if_pos rfl]
 #align power_series.constant_coeff_inv_of_unit PowerSeries.constantCoeff_invOfUnit
 
-theorem mul_invOfUnit (φ : PowerSeries R) (u : Rˣ) (h : constantCoeff R φ = u) :
+theorem mul_invOfUnit (φ : R⟦X⟧) (u : Rˣ) (h : constantCoeff R φ = u) :
     φ * invOfUnit φ u = 1 :=
   MvPowerSeries.mul_invOfUnit φ u <| h
 #align power_series.mul_inv_of_unit PowerSeries.mul_invOfUnit
 
 /-- Two ways of removing the constant coefficient of a power series are the same. -/
-theorem sub_const_eq_shift_mul_X (φ : PowerSeries R) :
+theorem sub_const_eq_shift_mul_X (φ : R⟦X⟧) :
     φ - C R (constantCoeff R φ) = (PowerSeries.mk fun p => coeff R (p + 1) φ) * X :=
   sub_eq_iff_eq_add.mpr (eq_shift_mul_X_add_const φ)
 set_option linter.uppercaseLean3 false in
 #align power_series.sub_const_eq_shift_mul_X PowerSeries.sub_const_eq_shift_mul_X
 
-theorem sub_const_eq_X_mul_shift (φ : PowerSeries R) :
+theorem sub_const_eq_X_mul_shift (φ : R⟦X⟧) :
     φ - C R (constantCoeff R φ) = X * PowerSeries.mk fun p => coeff R (p + 1) φ :=
   sub_eq_iff_eq_add.mpr (eq_X_mul_shift_add_const φ)
 set_option linter.uppercaseLean3 false in
@@ -2005,12 +2006,12 @@ set_option linter.uppercaseLean3 false in
 #align power_series.rescale_neg_one_X PowerSeries.rescale_neg_one_X
 
 /-- The ring homomorphism taking a power series `f(X)` to `f(-X)`. -/
-noncomputable def evalNegHom : PowerSeries A →+* PowerSeries A :=
+noncomputable def evalNegHom : A⟦X⟧ →+* A⟦X⟧ :=
   rescale (-1 : A)
 #align power_series.eval_neg_hom PowerSeries.evalNegHom
 
 @[simp]
-theorem evalNegHom_X : evalNegHom (X : PowerSeries A) = -X :=
+theorem evalNegHom_X : evalNegHom (X : A⟦X⟧) = -X :=
   rescale_neg_one_X
 set_option linter.uppercaseLean3 false in
 #align power_series.eval_neg_hom_X PowerSeries.evalNegHom_X
@@ -2021,7 +2022,7 @@ section Domain
 
 variable [Ring R]
 
-theorem eq_zero_or_eq_zero_of_mul_eq_zero [NoZeroDivisors R] (φ ψ : PowerSeries R) (h : φ * ψ = 0) :
+theorem eq_zero_or_eq_zero_of_mul_eq_zero [NoZeroDivisors R] (φ ψ : R⟦X⟧) (h : φ * ψ = 0) :
     φ = 0 ∨ ψ = 0 := by
   rw [or_iff_not_imp_left]
   intro H
@@ -2060,10 +2061,10 @@ theorem eq_zero_or_eq_zero_of_mul_eq_zero [NoZeroDivisors R] (φ ψ : PowerSerie
     rw [Finset.Nat.mem_antidiagonal]
 #align power_series.eq_zero_or_eq_zero_of_mul_eq_zero PowerSeries.eq_zero_or_eq_zero_of_mul_eq_zero
 
-instance [NoZeroDivisors R] : NoZeroDivisors (PowerSeries R) where
+instance [NoZeroDivisors R] : NoZeroDivisors R⟦X⟧ where
   eq_zero_or_eq_zero_of_mul_eq_zero := eq_zero_or_eq_zero_of_mul_eq_zero _ _
 
-instance [IsDomain R] : IsDomain (PowerSeries R) :=
+instance [IsDomain R] : IsDomain R⟦X⟧ :=
   NoZeroDivisors.to_isDomain _
 
 end Domain
@@ -2074,8 +2075,8 @@ variable [CommRing R] [IsDomain R]
 
 /-- The ideal spanned by the variable in the power series ring
  over an integral domain is a prime ideal.-/
-theorem span_X_isPrime : (Ideal.span ({X} : Set (PowerSeries R))).IsPrime := by
-  suffices Ideal.span ({X} : Set (PowerSeries R)) = RingHom.ker (constantCoeff R) by
+theorem span_X_isPrime : (Ideal.span ({X} : Set R⟦X⟧)).IsPrime := by
+  suffices Ideal.span ({X} : Set R⟦X⟧) = RingHom.ker (constantCoeff R) by
     rw [this]
     exact RingHom.ker_isPrime _
   apply Ideal.ext
@@ -2085,7 +2086,7 @@ set_option linter.uppercaseLean3 false in
 #align power_series.span_X_is_prime PowerSeries.span_X_isPrime
 
 /-- The variable of the power series ring over an integral domain is prime.-/
-theorem X_prime : Prime (X : PowerSeries R) := by
+theorem X_prime : Prime (X : R⟦X⟧) := by
   rw [← Ideal.span_singleton_prime]
   · exact span_X_isPrime
   · intro h
@@ -2116,7 +2117,7 @@ instance map.isLocalRingHom : IsLocalRingHom (map f) :=
 
 variable [LocalRing R] [LocalRing S]
 
-instance : LocalRing (PowerSeries R) :=
+instance : LocalRing R⟦X⟧ :=
   { inferInstanceAs <| LocalRing <| MvPowerSeries Unit R with }
 
 
@@ -2126,16 +2127,16 @@ section Algebra
 
 variable {A : Type*} [CommSemiring R] [Semiring A] [Algebra R A]
 
-theorem C_eq_algebraMap {r : R} : C R r = (algebraMap R (PowerSeries R)) r :=
+theorem C_eq_algebraMap {r : R} : C R r = (algebraMap R R⟦X⟧) r :=
   rfl
 set_option linter.uppercaseLean3 false in
 #align power_series.C_eq_algebra_map PowerSeries.C_eq_algebraMap
 
-theorem algebraMap_apply {r : R} : algebraMap R (PowerSeries A) r = C A (algebraMap R A r) :=
+theorem algebraMap_apply {r : R} : algebraMap R A⟦X⟧ r = C A (algebraMap R A r) :=
   MvPowerSeries.algebraMap_apply
 #align power_series.algebra_map_apply PowerSeries.algebraMap_apply
 
-instance [Nontrivial R] : Nontrivial (Subalgebra R (PowerSeries R)) :=
+instance [Nontrivial R] : Nontrivial (Subalgebra R R⟦X⟧) :=
   { inferInstanceAs <| Nontrivial <| Subalgebra R <| MvPowerSeries Unit R with }
 
 end Algebra
@@ -2257,7 +2258,7 @@ section OrderBasic
 
 open multiplicity
 
-variable [Semiring R] {φ : PowerSeries R}
+variable [Semiring R] {φ : R⟦X⟧}
 
 theorem exists_coeff_ne_zero_iff_ne_zero : (∃ n : ℕ, coeff R n φ ≠ 0) ↔ φ ≠ 0 := by
   refine' not_iff_not.mp _
@@ -2267,13 +2268,13 @@ theorem exists_coeff_ne_zero_iff_ne_zero : (∃ n : ℕ, coeff R n φ ≠ 0) ↔
 
 /-- The order of a formal power series `φ` is the greatest `n : PartENat`
 such that `X^n` divides `φ`. The order is `⊤` if and only if `φ = 0`. -/
-def order (φ : PowerSeries R) : PartENat :=
+def order (φ : R⟦X⟧) : PartENat :=
   if h : φ = 0 then ⊤ else Nat.find (exists_coeff_ne_zero_iff_ne_zero.mpr h)
 #align power_series.order PowerSeries.order
 
 /-- The order of the `0` power series is infinite.-/
 @[simp]
-theorem order_zero : order (0 : PowerSeries R) = ⊤ :=
+theorem order_zero : order (0 : R⟦X⟧) = ⊤ :=
   dif_pos rfl
 #align power_series.order_zero PowerSeries.order_zero
 
@@ -2316,7 +2317,7 @@ theorem coeff_of_lt_order (n : ℕ) (h : ↑n < order φ) : coeff R n φ = 0 := 
 
 /-- The `0` power series is the unique power series with infinite order.-/
 @[simp]
-theorem order_eq_top {φ : PowerSeries R} : φ.order = ⊤ ↔ φ = 0 := by
+theorem order_eq_top {φ : R⟦X⟧} : φ.order = ⊤ ↔ φ = 0 := by
   constructor
   · intro h
     ext n
@@ -2328,7 +2329,7 @@ theorem order_eq_top {φ : PowerSeries R} : φ.order = ⊤ ↔ φ = 0 := by
 
 /-- The order of a formal power series is at least `n` if
 the `i`th coefficient is `0` for all `i < n`.-/
-theorem nat_le_order (φ : PowerSeries R) (n : ℕ) (h : ∀ i < n, coeff R i φ = 0) : ↑n ≤ order φ := by
+theorem nat_le_order (φ : R⟦X⟧) (n : ℕ) (h : ∀ i < n, coeff R i φ = 0) : ↑n ≤ order φ := by
   by_contra H; rw [not_le] at H
   have : (order φ).Dom := PartENat.dom_of_le_natCast H.le
   rw [← PartENat.natCast_get this, PartENat.coe_lt_coe] at H
@@ -2337,7 +2338,7 @@ theorem nat_le_order (φ : PowerSeries R) (n : ℕ) (h : ∀ i < n, coeff R i φ
 
 /-- The order of a formal power series is at least `n` if
 the `i`th coefficient is `0` for all `i < n`.-/
-theorem le_order (φ : PowerSeries R) (n : PartENat) (h : ∀ i : ℕ, ↑i < n → coeff R i φ = 0) :
+theorem le_order (φ : R⟦X⟧) (n : PartENat) (h : ∀ i : ℕ, ↑i < n → coeff R i φ = 0) :
     n ≤ order φ := by
   induction n using PartENat.casesOn
   · show _ ≤ _
@@ -2350,7 +2351,7 @@ theorem le_order (φ : PowerSeries R) (n : PartENat) (h : ∀ i : ℕ, ↑i < n 
 
 /-- The order of a formal power series is exactly `n` if the `n`th coefficient is nonzero,
 and the `i`th coefficient is `0` for all `i < n`.-/
-theorem order_eq_nat {φ : PowerSeries R} {n : ℕ} :
+theorem order_eq_nat {φ : R⟦X⟧} {n : ℕ} :
     order φ = n ↔ coeff R n φ ≠ 0 ∧ ∀ i, i < n → coeff R i φ = 0 := by
   rcases eq_or_ne φ 0 with (rfl | hφ)
   · simpa using (PartENat.natCast_ne_top _).symm
@@ -2359,7 +2360,7 @@ theorem order_eq_nat {φ : PowerSeries R} {n : ℕ} :
 
 /-- The order of a formal power series is exactly `n` if the `n`th coefficient is nonzero,
 and the `i`th coefficient is `0` for all `i < n`.-/
-theorem order_eq {φ : PowerSeries R} {n : PartENat} :
+theorem order_eq {φ : R⟦X⟧} {n : PartENat} :
     order φ = n ↔ (∀ i : ℕ, ↑i = n → coeff R i φ ≠ 0) ∧ ∀ i : ℕ, ↑i < n → coeff R i φ = 0 := by
   induction n using PartENat.casesOn
   · rw [order_eq_top]
@@ -2377,12 +2378,12 @@ theorem order_eq {φ : PowerSeries R} {n : PartENat} :
 
 /-- The order of the sum of two formal power series
  is at least the minimum of their orders.-/
-theorem le_order_add (φ ψ : PowerSeries R) : min (order φ) (order ψ) ≤ order (φ + ψ) := by
+theorem le_order_add (φ ψ : R⟦X⟧) : min (order φ) (order ψ) ≤ order (φ + ψ) := by
   refine' le_order _ _ _
   simp (config := { contextual := true }) [coeff_of_lt_order]
 #align power_series.le_order_add PowerSeries.le_order_add
 
-private theorem order_add_of_order_eq.aux (φ ψ : PowerSeries R) (_h : order φ ≠ order ψ)
+private theorem order_add_of_order_eq.aux (φ ψ : R⟦X⟧) (_h : order φ ≠ order ψ)
     (H : order φ < order ψ) : order (φ + ψ) ≤ order φ ⊓ order ψ := by
   suffices order (φ + ψ) = order φ by
     rw [le_inf_iff, this]
@@ -2400,7 +2401,7 @@ private theorem order_add_of_order_eq.aux (φ ψ : PowerSeries R) (_h : order φ
 
 /-- The order of the sum of two formal power series
  is the minimum of their orders if their orders differ.-/
-theorem order_add_of_order_eq (φ ψ : PowerSeries R) (h : order φ ≠ order ψ) :
+theorem order_add_of_order_eq (φ ψ : R⟦X⟧) (h : order φ ≠ order ψ) :
     order (φ + ψ) = order φ ⊓ order ψ := by
   refine' le_antisymm _ (le_order_add _ _)
   by_cases H₁ : order φ < order ψ
@@ -2412,7 +2413,7 @@ theorem order_add_of_order_eq (φ ψ : PowerSeries R) (h : order φ ≠ order ψ
 
 /-- The order of the product of two formal power series
  is at least the sum of their orders.-/
-theorem order_mul_ge (φ ψ : PowerSeries R) : order φ + order ψ ≤ order (φ * ψ) := by
+theorem order_mul_ge (φ ψ : R⟦X⟧) : order φ + order ψ ≤ order (φ * ψ) := by
   apply le_order
   intro n hn; rw [coeff_mul, Finset.sum_eq_zero]
   rintro ⟨i, j⟩ hij
@@ -2447,7 +2448,7 @@ theorem order_monomial_of_ne_zero (n : ℕ) (a : R) (h : a ≠ 0) : order (monom
 
 /-- If `n` is strictly smaller than the order of `ψ`, then the `n`th coefficient of its product
 with any other power series is `0`. -/
-theorem coeff_mul_of_lt_order {φ ψ : PowerSeries R} {n : ℕ} (h : ↑n < ψ.order) :
+theorem coeff_mul_of_lt_order {φ ψ : R⟦X⟧} {n : ℕ} (h : ↑n < ψ.order) :
     coeff R n (φ * ψ) = 0 := by
   suffices : coeff R n (φ * ψ) = ∑ p in Finset.Nat.antidiagonal n, 0
   rw [this, Finset.sum_const_zero]
@@ -2460,13 +2461,13 @@ theorem coeff_mul_of_lt_order {φ ψ : PowerSeries R} {n : ℕ} (h : ↑n < ψ.o
   linarith
 #align power_series.coeff_mul_of_lt_order PowerSeries.coeff_mul_of_lt_order
 
-theorem coeff_mul_one_sub_of_lt_order {R : Type*} [CommRing R] {φ ψ : PowerSeries R} (n : ℕ)
+theorem coeff_mul_one_sub_of_lt_order {R : Type*} [CommRing R] {φ ψ : R⟦X⟧} (n : ℕ)
     (h : ↑n < ψ.order) : coeff R n (φ * (1 - ψ)) = coeff R n φ := by
   simp [coeff_mul_of_lt_order h, mul_sub]
 #align power_series.coeff_mul_one_sub_of_lt_order PowerSeries.coeff_mul_one_sub_of_lt_order
 
 theorem coeff_mul_prod_one_sub_of_lt_order {R ι : Type*} [CommRing R] (k : ℕ) (s : Finset ι)
-    (φ : PowerSeries R) (f : ι → PowerSeries R) :
+    (φ : R⟦X⟧) (f : ι → R⟦X⟧) :
     (∀ i ∈ s, ↑k < (f i).order) → coeff R k (φ * ∏ i in s, (1 - f i)) = coeff R k φ := by
   induction' s using Finset.induction_on with a s ha ih t
   · simp
@@ -2490,7 +2491,7 @@ theorem X_pow_order_dvd (h : (order φ).Dom) : X ^ (order φ).get h ∣ φ := by
 set_option linter.uppercaseLean3 false in
 #align power_series.X_pow_order_dvd PowerSeries.X_pow_order_dvd
 
-theorem order_eq_multiplicity_X {R : Type*} [Semiring R] (φ : PowerSeries R) :
+theorem order_eq_multiplicity_X {R : Type*} [Semiring R] (φ : R⟦X⟧) :
     order φ = multiplicity X φ := by
   rcases eq_or_ne φ 0 with (rfl | hφ)
   · simp
@@ -2521,20 +2522,20 @@ variable [Semiring R] [Nontrivial R]
 
 /-- The order of the formal power series `1` is `0`.-/
 @[simp]
-theorem order_one : order (1 : PowerSeries R) = 0 := by
+theorem order_one : order (1 : R⟦X⟧) = 0 := by
   simpa using order_monomial_of_ne_zero 0 (1 : R) one_ne_zero
 #align power_series.order_one PowerSeries.order_one
 
 /-- The order of the formal power series `X` is `1`.-/
 @[simp]
-theorem order_X : order (X : PowerSeries R) = 1 := by
+theorem order_X : order (X : R⟦X⟧) = 1 := by
   simpa only [Nat.cast_one] using order_monomial_of_ne_zero 1 (1 : R) one_ne_zero
 set_option linter.uppercaseLean3 false in
 #align power_series.order_X PowerSeries.order_X
 
 /-- The order of the formal power series `X^n` is `n`.-/
 @[simp]
-theorem order_X_pow (n : ℕ) : order ((X : PowerSeries R) ^ n) = n := by
+theorem order_X_pow (n : ℕ) : order ((X : R⟦X⟧) ^ n) = n := by
   rw [X_pow_eq, order_monomial_of_ne_zero]
   exact one_ne_zero
 set_option linter.uppercaseLean3 false in
@@ -2549,7 +2550,7 @@ variable [CommRing R] [IsDomain R]
 
 /-- The order of the product of two formal power series over an integral domain
  is the sum of their orders.-/
-theorem order_mul (φ ψ : PowerSeries R) : order (φ * ψ) = order φ + order ψ := by
+theorem order_mul (φ ψ : R⟦X⟧) : order (φ * ψ) = order φ + order ψ := by
   simp_rw [order_eq_multiplicity_X]
   exact multiplicity.mul X_prime
 #align power_series.order_mul PowerSeries.order_mul
@@ -2720,30 +2721,30 @@ namespace PowerSeries
 
 section Algebra
 
-variable {R A : Type*} [CommSemiring R] [CommSemiring A] [Algebra R A] (f : PowerSeries R)
+variable {R A : Type*} [CommSemiring R] [CommSemiring A] [Algebra R A] (f : R⟦X⟧)
 
-instance algebraPolynomial : Algebra R[X] (PowerSeries A) :=
+instance algebraPolynomial : Algebra R[X] A⟦X⟧ :=
   RingHom.toAlgebra (Polynomial.coeToPowerSeries.algHom A).toRingHom
 #align power_series.algebra_polynomial PowerSeries.algebraPolynomial
 
-instance algebraPowerSeries : Algebra (PowerSeries R) (PowerSeries A) :=
+instance algebraPowerSeries : Algebra R⟦X⟧ A⟦X⟧ :=
   (map (algebraMap R A)).toAlgebra
 #align power_series.algebra_power_series PowerSeries.algebraPowerSeries
 
 -- see Note [lower instance priority]
 instance (priority := 100) algebraPolynomial' {A : Type*} [CommSemiring A] [Algebra R A[X]] :
-    Algebra R (PowerSeries A) :=
+    Algebra R A⟦X⟧ :=
   RingHom.toAlgebra <| Polynomial.coeToPowerSeries.ringHom.comp (algebraMap R A[X])
 #align power_series.algebra_polynomial' PowerSeries.algebraPolynomial'
 
 variable (A)
 
-theorem algebraMap_apply' (p : R[X]) : algebraMap R[X] (PowerSeries A) p = map (algebraMap R A) p :=
+theorem algebraMap_apply' (p : R[X]) : algebraMap R[X] A⟦X⟧ p = map (algebraMap R A) p :=
   rfl
 #align power_series.algebra_map_apply' PowerSeries.algebraMap_apply'
 
 theorem algebraMap_apply'' :
-    algebraMap (PowerSeries R) (PowerSeries A) f = map (algebraMap R A) f :=
+    algebraMap R⟦X⟧ A⟦X⟧ f = map (algebraMap R A) f :=
   rfl
 #align power_series.algebra_map_apply'' PowerSeries.algebraMap_apply''
 

--- a/Mathlib/RingTheory/PowerSeries/Basic.lean
+++ b/Mathlib/RingTheory/PowerSeries/Basic.lean
@@ -1883,6 +1883,14 @@ theorem eval₂_trunc_eq_sum_range {S : Type*} [Semiring S] (s : S) (G : R →+*
     rw [hd]
     exact n.one_lt_succ_succ
 
+lemma trunc_X_of {n : ℕ} (hn : 2 ≤ n) : trunc n X = (Polynomial.X : R[X]) := by
+  cases n with
+  | zero => contradiction
+  | succ n =>
+    cases n with
+    | zero => contradiction
+    | succ n => exact trunc_X n
+
 end Trunc
 
 

--- a/Mathlib/RingTheory/PowerSeries/Basic.lean
+++ b/Mathlib/RingTheory/PowerSeries/Basic.lean
@@ -2802,8 +2802,8 @@ theorem trunc_coe_eq_self {n} {f : R[X]} (hn : natDegree f < n) : trunc n (f : R
 
 /-- The function `coeff n : R⟦X⟧ → R` is continuous. I.e. `coeff n f` depends only on a sufficiently
 long truncation of the power series `f`.-/
-theorem coeff_eq_of_lt {n m} {f : R⟦X⟧} (h : n < m) :
-    coeff R n f = coeff R n (trunc m f) := by
+theorem coeff_coe_trunc_of_lt {n m} {f : R⟦X⟧} (h : n < m) :
+    coeff R n (trunc m f) = coeff R n f := by
   rwa [coeff_coe, coeff_trunc, if_pos]
 
 /-- The `n`-th coefficient of a`f*g` may be calculated
@@ -2811,8 +2811,8 @@ from the truncations of `f` and `g`.-/
 theorem coeff_mul_eq_coeff_trunc_mul_trunc₂ {n a b} (f g) (ha : n < a) (hb : n < b) :
     coeff R n (f * g) = coeff R n (trunc a f * trunc b g) := by
   symm
-  rw [coeff_eq_of_lt n.lt_succ_self, ←trunc_trunc_mul_trunc, trunc_trunc_of_le f ha,
-    trunc_trunc_of_le g hb, trunc_trunc_mul_trunc, ←coeff_eq_of_lt n.lt_succ_self]
+  rw [←coeff_coe_trunc_of_lt n.lt_succ_self, ←trunc_trunc_mul_trunc, trunc_trunc_of_le f ha,
+    trunc_trunc_of_le g hb, trunc_trunc_mul_trunc, coeff_coe_trunc_of_lt n.lt_succ_self]
 
 theorem coeff_mul_eq_coeff_trunc_mul_trunc {d n} (f g) (h : d < n) :
     coeff R d (f * g) = coeff R d (trunc n f * trunc n g) :=


### PR DESCRIPTION
Add lemmas on truncation of pormal power series

---

Add several lemmas on truncation of power series in one variable to RingTheory/PowerSeries/Basic. These are needed in another PR that I'm working on.

Also, define `PowerSeries.trunc n : PowerSeries R \to R[X]` for a Semiring R, rather than a CommSemiring. (For this, it's only necessary to change "variable [CommSemiring R]" to "variable [Semiring R]" on line 1791.


[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
