### PR TITLE
[Merged by Bors] - refactor: No need for CachedData in library_search and rw?

### DIFF
--- a/Mathlib/Tactic/Cache.lean
+++ b/Mathlib/Tactic/Cache.lean
@@ -180,12 +180,3 @@ def DiscrTreeCache.getMatch (c : DiscrTreeCache α) (e : Expr) : MetaM (Array α
   -- `DiscrTree.getMatch` returns results in batches, with more specific lemmas coming later.
   -- Hence we reverse this list, so we try out more specific lemmas earlier.
   return (← locals.getMatch e).reverse ++ (← imports.getMatch e).reverse
-
-/--
-A structure that holds the cached discrimination tree,
-and possibly a pointer to a memory region, if we unpickled the tree from disk.
--/
-structure CachedData (α : Type) where
-  pointer? : Option CompactedRegion
-  cache : DiscrTreeCache α
-deriving Nonempty

--- a/Mathlib/Tactic/LibrarySearch.lean
+++ b/Mathlib/Tactic/LibrarySearch.lean
@@ -92,18 +92,17 @@ def cachePath : IO FilePath :=
   catch _ =>
     return "build" / "lib" / "MathlibExtras" / "LibrarySearch.extra"
 
-initialize cachedData : CachedData (Name × DeclMod) ← unsafe do
-  let path ← cachePath
-  if (← path.pathExists) then
-    let (d, r) ← unpickle (DiscrTree (Name × DeclMod) true) path
-    return ⟨r, ← DiscrTreeCache.mk "apply?: using cache" processLemma (init := some d)⟩
-  else
-    return ⟨none, ← buildDiscrTree⟩
-
 /--
 Retrieve the current current of lemmas.
 -/
-def librarySearchLemmas : DiscrTreeCache (Name × DeclMod) := cachedData.cache
+initialize librarySearchLemmas : DiscrTreeCache (Name × DeclMod) ← unsafe do
+  let path ← cachePath
+  if (← path.pathExists) then
+    let (d, _r) ← unpickle (DiscrTree (Name × DeclMod) true) path
+    -- We can drop the `CompactedRegion` value; we do not plan to free it
+    DiscrTreeCache.mk "apply?: using cache" processLemma (init := some d)
+  else
+    buildDiscrTree
 
 /-- Shortcut for calling `solveByElim`. -/
 def solveByElim (goals : List MVarId) (required : List Expr) (exfalso := false) (depth) := do

--- a/Mathlib/Tactic/Rewrites.lean
+++ b/Mathlib/Tactic/Rewrites.lean
@@ -113,18 +113,17 @@ def cachePath : IO FilePath :=
   catch _ =>
     return "build" / "lib" / "MathlibExtras" / "Rewrites.extra"
 
-initialize cachedData : CachedData (Name × Bool × Nat) ← unsafe do
-  let path ← cachePath
-  if (← path.pathExists) then
-    let (d, r) ← unpickle (DiscrTree (Name × Bool × Nat) true) path
-    return ⟨r, ← DiscrTreeCache.mk "rw?: using cache" processLemma (init := some d)⟩
-  else
-    return ⟨none, ← buildDiscrTree⟩
-
 /--
 Retrieve the current cache of lemmas.
 -/
-def rewriteLemmas : DiscrTreeCache (Name × Bool × Nat) := cachedData.cache
+initialize rewriteLemmas : DiscrTreeCache (Name × Bool × Nat) ← unsafe do
+  let path ← cachePath
+  if (← path.pathExists) then
+    let (d, _r) ← unpickle (DiscrTree (Name × Bool × Nat) true) path
+    -- We can drop the `CompactedRegion` value; we do not plan to free it
+    DiscrTreeCache.mk "rw?: using cache" processLemma (init := some d)
+  else
+    buildDiscrTree
 
 /-- Data structure recording a potential rewrite to report from the `rw?` tactic. -/
 structure RewriteResult where


### PR DESCRIPTION
Previously, `Mathlib.Tactic.Cache` defined a `CachedData` data structure
to keep a reference to the `CompactedRegion` that we get when unpickling
the cache from a file, but it was never used.

It also seems to be the case that keeping that reference is not
necessary to keep the unpickled data alive. (It is the other way around:
The data stays alive until `.free` is called explicitly, which we do not
plan to do here.)

Therefore, to simplify the code, this PR removes `CachedData`. This came
out of working on `#find` in #6363


---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
