### PR TITLE
[Merged by Bors] - feat: locally Lipschitz maps

### DIFF
--- a/Mathlib/Analysis/Calculus/ContDiff.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff.lean
@@ -2064,6 +2064,12 @@ theorem ContDiffAt.exists_lipschitzOnWith {f : E' → F'} {x : E'} (hf : ContDif
   (hf.hasStrictFDerivAt le_rfl).exists_lipschitzOnWith
 #align cont_diff_at.exists_lipschitz_on_with ContDiffAt.exists_lipschitzOnWith
 
+/-- If `f` is `C^1`, it is locally Lipschitz. -/
+lemma ContDiff.locallyLipschitz {f : E → F} (hf : ContDiff ℝ 1 f) : LocallyLipschitz f := by
+  intro x
+  rcases (ContDiffAt.exists_lipschitzOnWith (ContDiff.contDiffAt hf)) with ⟨K, t, ht, hf⟩
+  use K, t
+
 /-- A `C^1` function with compact support is Lipschitz. -/
 theorem ContDiff.lipschitzWith_of_hasCompactSupport {f : E' → F'} {n : ℕ∞}
     (hf : HasCompactSupport f) (h'f : ContDiff 𝕂 n f) (hn : 1 ≤ n) :

--- a/Mathlib/Analysis/Calculus/ContDiff.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff.lean
@@ -2067,7 +2067,7 @@ theorem ContDiffAt.exists_lipschitzOnWith {f : E' → F'} {x : E'} (hf : ContDif
 /-- If `f` is `C^1`, it is locally Lipschitz. -/
 lemma ContDiff.locallyLipschitz {f : E' → F'} (hf : ContDiff 𝕂 1 f) : LocallyLipschitz f := by
   intro x
-  rcases (ContDiffAt.exists_lipschitzOnWith (ContDiff.contDiffAt hf)) with ⟨K, t, ht, hf⟩
+  rcases hf.contDiffAt.exists_lipschitzOnWith with ⟨K, t, ht, hf⟩
   use K, t
 
 /-- A `C^1` function with compact support is Lipschitz. -/

--- a/Mathlib/Analysis/Calculus/ContDiff.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff.lean
@@ -2065,7 +2065,7 @@ theorem ContDiffAt.exists_lipschitzOnWith {f : E' → F'} {x : E'} (hf : ContDif
 #align cont_diff_at.exists_lipschitz_on_with ContDiffAt.exists_lipschitzOnWith
 
 /-- If `f` is `C^1`, it is locally Lipschitz. -/
-lemma ContDiff.locallyLipschitz {f : E → F} (hf : ContDiff ℝ 1 f) : LocallyLipschitz f := by
+lemma ContDiff.locallyLipschitz {f : E' → F'} (hf : ContDiff 𝕂 1 f) : LocallyLipschitz f := by
   intro x
   rcases (ContDiffAt.exists_lipschitzOnWith (ContDiff.contDiffAt hf)) with ⟨K, t, ht, hf⟩
   use K, t

--- a/Mathlib/Topology/MetricSpace/Lipschitz.lean
+++ b/Mathlib/Topology/MetricSpace/Lipschitz.lean
@@ -620,35 +620,9 @@ protected lemma comp  {f : β → γ} {g : α → β}
   -- g is Lipschitz on t ∋ x, f is Lipschitz on u ∋ g(x)
   rcases hg x with ⟨Kg, t, ht, hgL⟩
   rcases hf (g x) with ⟨Kf, u, hu, hfL⟩
-  -- idea: shrink t to ensure it is mapped to u
-  -- more precisely: restrict g to t' := t ∩ g⁻¹(u); the preimage of u under g':=g∣t.
-  let g' := t.restrict g
-  set t' : Set α := ↑(g' ⁻¹' u) with ht'
-  have h₁ : t' = t ∩ g ⁻¹' u := by
-    rw [ht']
-    ext1 y
-    simp [Lean.Internal.coeM]
-    aesop
-  have h₂ : t' ∈ 𝓝 x := by -- FIXME: surely, there is a nicer proof
-    -- by ht, t contains an open subset U
-    rcases (mem_nhds_iff.mp ht) with ⟨U, hUt, hUopen, hxU⟩
-    -- similarly, u contains an open subset V
-    rcases (mem_nhds_iff.mp hu) with ⟨V, hVt, hVopen, hgxV⟩
-    -- by continuity, g⁻¹(u) contains the open subset g⁻¹(V)
-    have : ContinuousOn g U := (hgL.mono hUt).continuousOn
-    have h : IsOpen (U ∩ (g ⁻¹' V)) := this.preimage_open_of_open hUopen hVopen
-    have : U ∩ (g ⁻¹' V) ⊆ t' := by rw [h₁]; apply inter_subset_inter hUt (preimage_mono hVt)
-    -- now, U ∩ g⁻¹(V) is an open subset contained in t'
-    rw [mem_nhds_iff]
-    use U ∩ (g ⁻¹' V)
-    exact ⟨this, ⟨h, ⟨hxU, hgxV⟩⟩⟩
-  have : g '' t' ⊆ u := by calc g '' t'
-    _ = g '' (t ∩ g ⁻¹' u) := by rw [h₁]
-    _ ⊆ g '' t ∩ g '' (g ⁻¹' u) := by apply image_inter_subset
-    _ ⊆ g '' t ∩ u := by gcongr; apply image_preimage_subset
-    _ ⊆ u := inter_subset_right _ _
-  use Kf * Kg, t'
-  exact ⟨h₂, hfL.comp (hgL.mono coe_subset) (mapsTo'.mpr this)⟩
+  refine ⟨Kf * Kg, t ∩ g⁻¹' u, inter_mem ht (hg.continuous.continuousAt hu), ?_⟩ 
+  exact hfL.comp (hgL.mono (inter_subset_left _ _))
+    ((mapsTo_preimage g u).mono_left (inter_subset_right _ _))
 
 /-- If `f` and `g` are locally Lipschitz, so is the induced map `f × g` to the product type. -/
 protected lemma prod {f : α → β} (hf : LocallyLipschitz f) {g : α → γ} (hg : LocallyLipschitz g) :

--- a/Mathlib/Topology/MetricSpace/Lipschitz.lean
+++ b/Mathlib/Topology/MetricSpace/Lipschitz.lean
@@ -535,6 +535,13 @@ protected theorem comp {g : β → γ} {t : Set β} {Kg : ℝ≥0} (hg : Lipschi
   lipschitzOnWith_iff_restrict.mpr <| hg.to_restrict.comp (hf.to_restrict_mapsTo hmaps)
 #align lipschitz_on_with.comp LipschitzOnWith.comp
 
+/-- If `f` and `g` are Lipschitz on `s`, so is the induced map `f × g` to the product type. -/
+protected theorem prod {g : α → γ} {Kf Kg : ℝ≥0} (hf : LipschitzOnWith Kf f s)
+    (hg : LipschitzOnWith Kg g s) : LipschitzOnWith (max Kf Kg) (fun x => (f x, g x)) s := by
+  intro _ hx _ hy
+  rw [ENNReal.coe_mono.map_max, Prod.edist_eq, ENNReal.max_mul]
+  exact max_le_max (hf hx hy) (hg hx hy)
+
 end EMetric
 
 section Metric
@@ -620,7 +627,7 @@ protected lemma comp  {f : β → γ} {g : α → β}
   -- g is Lipschitz on t ∋ x, f is Lipschitz on u ∋ g(x)
   rcases hg x with ⟨Kg, t, ht, hgL⟩
   rcases hf (g x) with ⟨Kf, u, hu, hfL⟩
-  refine ⟨Kf * Kg, t ∩ g⁻¹' u, inter_mem ht (hg.continuous.continuousAt hu), ?_⟩ 
+  refine ⟨Kf * Kg, t ∩ g⁻¹' u, inter_mem ht (hg.continuous.continuousAt hu), ?_⟩
   exact hfL.comp (hgL.mono (inter_subset_left _ _))
     ((mapsTo_preimage g u).mono_left (inter_subset_right _ _))
 
@@ -630,14 +637,8 @@ protected lemma prod {f : α → β} (hf : LocallyLipschitz f) {g : α → γ} (
   intro x
   rcases hf x with ⟨Kf, t₁, h₁t, hfL⟩
   rcases hg x with ⟨Kg, t₂, h₂t, hgL⟩
-  use max Kf Kg, t₁ ∩ t₂
-  constructor
-  · exact Filter.inter_mem h₁t h₂t
-  · intro y hy z hz
-    have h₁ : edist (f y) (f z) ≤ Kf * edist y z := hfL.mono (inter_subset_left t₁ t₂) hy hz
-    have h₂ : edist (g y) (g z) ≤ Kg * edist y z := hgL.mono (inter_subset_right t₁ t₂) hy hz
-    rw [ENNReal.coe_mono.map_max, Prod.edist_eq, ENNReal.max_mul]
-    exact max_le_max h₁ h₂
+  refine ⟨max Kf Kg, t₁ ∩ t₂, Filter.inter_mem h₁t h₂t, ?_⟩
+  exact (hfL.mono (inter_subset_left t₁ t₂)).prod (hgL.mono (inter_subset_right t₁ t₂))
 
 protected theorem prod_mk_left (a : α) : LocallyLipschitz (Prod.mk a : β → α × β) :=
   (LipschitzWith.prod_mk_left a).locallyLipschitz

--- a/Mathlib/Topology/MetricSpace/Lipschitz.lean
+++ b/Mathlib/Topology/MetricSpace/Lipschitz.lean
@@ -301,10 +301,10 @@ theorem edist_iterate_succ_le_geometric {f : α → α} (hf : LipschitzWith K f)
   simpa only [ENNReal.coe_pow] using (hf.iterate n) x (f x)
 #align lipschitz_with.edist_iterate_succ_le_geometric LipschitzWith.edist_iterate_succ_le_geometric
 
-protected theorem mul {f g : Function.End α} {Kf Kg} (hf : LipschitzWith Kf f)
+protected theorem mul_end {f g : Function.End α} {Kf Kg} (hf : LipschitzWith Kf f)
     (hg : LipschitzWith Kg g) : LipschitzWith (Kf * Kg) (f * g : Function.End α) :=
   hf.comp hg
-#align lipschitz_with.mul LipschitzWith.mul
+#align lipschitz_with.mul LipschitzWith.mul_end
 
 /-- The product of a list of Lipschitz continuous endomorphisms is a Lipschitz continuous
 endomorphism. -/
@@ -313,16 +313,16 @@ protected theorem list_prod (f : ι → Function.End α) (K : ι → ℝ≥0)
   | [] => by simpa using LipschitzWith.id
   | i::l => by
     simp only [List.map_cons, List.prod_cons]
-    exact (h i).mul (LipschitzWith.list_prod f K h l)
+    exact (h i).mul_end (LipschitzWith.list_prod f K h l)
 #align lipschitz_with.list_prod LipschitzWith.list_prod
 
-protected theorem pow {f : Function.End α} {K} (h : LipschitzWith K f) :
+protected theorem pow_end {f : Function.End α} {K} (h : LipschitzWith K f) :
     ∀ n : ℕ, LipschitzWith (K ^ n) (f ^ n : Function.End α)
   | 0 => by simpa only [pow_zero] using LipschitzWith.id
   | n + 1 => by
     rw [pow_succ, pow_succ]
-    exact h.mul (LipschitzWith.pow h n)
-#align lipschitz_with.pow LipschitzWith.pow
+    exact h.mul_end (LipschitzWith.pow_end h n)
+#align lipschitz_with.pow LipschitzWith.pow_end
 
 end EMetric
 

--- a/Mathlib/Topology/MetricSpace/Lipschitz.lean
+++ b/Mathlib/Topology/MetricSpace/Lipschitz.lean
@@ -650,15 +650,15 @@ protected theorem iterate {f : α → α} (hf : LocallyLipschitz f) : ∀ n, Loc
   | 0 => by simpa only [pow_zero] using LocallyLipschitz.id
   | n + 1 => by rw [iterate_add, iterate_one]; exact (hf.iterate n).comp hf
 
-protected theorem mul {f g : Function.End α} (hf : LocallyLipschitz f)
+protected theorem mul_end {f g : Function.End α} (hf : LocallyLipschitz f)
     (hg : LocallyLipschitz g) : LocallyLipschitz (f * g : Function.End α) := hf.comp hg
 
-protected theorem pow {f : Function.End α} (h : LocallyLipschitz f) :
+protected theorem pow_end {f : Function.End α} (h : LocallyLipschitz f) :
     ∀ n : ℕ, LocallyLipschitz (f ^ n : Function.End α)
   | 0 => by simpa only [pow_zero] using LocallyLipschitz.id
   | n + 1 => by
     rw [pow_succ]
-    exact h.mul (h.pow n)
+    exact h.mul_end (h.pow_end n)
 
 section Real
 variable {f g : α → ℝ}
@@ -683,6 +683,7 @@ theorem min_const (hf : LocallyLipschitz f) (a : ℝ) : LocallyLipschitz fun x =
 
 theorem const_min (hf : LocallyLipschitz f) (a : ℝ) : LocallyLipschitz fun x => min a (f x) := by
   simpa [min_comm] using (hf.min_const a)
+
 end Real
 end LocallyLipschitz
 

--- a/Mathlib/Topology/MetricSpace/Lipschitz.lean
+++ b/Mathlib/Topology/MetricSpace/Lipschitz.lean
@@ -122,7 +122,7 @@ theorem MapsTo.lipschitzOnWith_iff_restrict [PseudoEMetricSpace α] [PseudoEMetr
 alias ⟨LipschitzOnWith.to_restrict_mapsTo, _⟩ := MapsTo.lipschitzOnWith_iff_restrict
 #align lipschitz_on_with.to_restrict_maps_to LipschitzOnWith.to_restrict_mapsTo
 
-/-- `f : α → β` is called **locally Lipschitz continuous** iff every point `p ∈ α`
+/-- `f : α → β` is called **locally Lipschitz continuous** iff every point `x`
 has a neighourhood on which `f` is Lipschitz. -/
 def LocallyLipschitz [PseudoEMetricSpace α] [PseudoEMetricSpace β] (f : α → β) : Prop :=
   ∀ x : α, ∃ K, ∃ t ∈ 𝓝 x, LipschitzOnWith K f t
@@ -594,11 +594,8 @@ namespace LocallyLipschitz
 variable [PseudoEMetricSpace α] [PseudoEMetricSpace β] [PseudoEMetricSpace γ] {f : α → β}
 
 /-- A Lipschitz function is locally Lipschitz. -/
-protected lemma of_Lipschitz {K : ℝ≥0} (hf : LipschitzWith K f) : LocallyLipschitz f := by
-  intro x
-  use K, univ
-  rw [lipschitzOn_univ]
-  exact ⟨Filter.univ_mem, hf⟩
+protected lemma of_Lipschitz {K : ℝ≥0} (hf : LipschitzWith K f) : LocallyLipschitz f :=
+  fun _ ↦ ⟨K, ⟨univ, ⟨Filter.univ_mem, Iff.mpr (lipschitzOn_univ) hf⟩⟩⟩
 
 /-- The identity function is locally Lipschitz. -/
 protected lemma id : LocallyLipschitz (@id α) := LocallyLipschitz.of_Lipschitz (LipschitzWith.id)

--- a/Mathlib/Topology/MetricSpace/Lipschitz.lean
+++ b/Mathlib/Topology/MetricSpace/Lipschitz.lean
@@ -608,7 +608,7 @@ protected lemma const (b : β) : LocallyLipschitz (fun _ : α ↦ b) :=
 /-- A locally Lipschitz function is continuous. (The converse is false: for example,
 $x ↦ \sqrt{x}$ is continuous, but not locally Lipschitz at 0.) -/
 protected theorem continuous {f : α → β} (hf : LocallyLipschitz f) : Continuous f := by
-  apply Iff.mpr continuous_iff_continuousAt
+  apply continuous_iff_continuousAt.mpr
   intro x
   rcases (hf x) with ⟨K, t, ht, hK⟩
   exact (hK.continuousOn).continuousAt ht
@@ -623,25 +623,17 @@ protected lemma comp  {f : β → γ} {g : α → β}
   -- idea: shrink t to ensure it is mapped to u
   -- more precisely: restrict g to t' := t ∩ g⁻¹(u); the preimage of u under g':=g∣t.
   let g' := t.restrict g
-  let t' : Set α := ↑(g' ⁻¹' u)
-  -- The following is mathematically obvious; the sorries are merely wrestling with coercions.
+  set t' : Set α := ↑(g' ⁻¹' u) with ht'
   have h₁ : t' = t ∩ g ⁻¹' u := by
-    apply Iff.mpr (Subset.antisymm_iff)
-    constructor
-    · intro x hx
-      constructor
-      · exact coe_subset hx
-      · -- as x ∈ t', we can apply g' (and land in u by definition), so g'(x)=g(x) ∈ u
-        sorry
-    · intro x hx
-      rcases hx with ⟨ht, hgu⟩
-      -- as x ∈ t, we can write g(x)=g'(x); the rhs lies in u, so x ∈ g⁻¹(u) also
-      sorry
-  have h₂ : t' ∈ 𝓝 x := by -- FIXME: the following is a tour de force; there must be a nicer proof
+    rw [ht']
+    ext1 y
+    simp [Lean.Internal.coeM]
+    aesop
+  have h₂ : t' ∈ 𝓝 x := by -- FIXME: surely, there is a nicer proof
     -- by ht, t contains an open subset U
-    rcases (Iff.mp (mem_nhds_iff) ht) with ⟨U, hUt, hUopen, hxU⟩
+    rcases (mem_nhds_iff.mp ht) with ⟨U, hUt, hUopen, hxU⟩
     -- similarly, u contains an open subset V
-    rcases (Iff.mp (mem_nhds_iff) hu) with ⟨V, hVt, hVopen, hgxV⟩
+    rcases (mem_nhds_iff.mp hu) with ⟨V, hVt, hVopen, hgxV⟩
     -- by continuity, g⁻¹(u) contains the open subset g⁻¹(V)
     have : ContinuousOn g U := (hgL.mono hUt).continuousOn
     have h : IsOpen (U ∩ (g ⁻¹' V)) := this.preimage_open_of_open hUopen hVopen
@@ -656,7 +648,7 @@ protected lemma comp  {f : β → γ} {g : α → β}
     _ ⊆ g '' t ∩ u := by gcongr; apply image_preimage_subset
     _ ⊆ u := inter_subset_right _ _
   use Kf * Kg, t'
-  exact ⟨h₂, hfL.comp (hgL.mono coe_subset) (Iff.mpr mapsTo' this)⟩
+  exact ⟨h₂, hfL.comp (hgL.mono coe_subset) (mapsTo'.mpr this)⟩
 
 /-- If `f` and `g` are locally Lipschitz, so is the induced map `f × g` to the product type. -/
 protected lemma prod {f : α → β} (hf : LocallyLipschitz f) {g : α → γ} (hg : LocallyLipschitz g) :

--- a/Mathlib/Topology/MetricSpace/Lipschitz.lean
+++ b/Mathlib/Topology/MetricSpace/Lipschitz.lean
@@ -594,7 +594,8 @@ namespace LocallyLipschitz
 variable [PseudoEMetricSpace α] [PseudoEMetricSpace β] [PseudoEMetricSpace γ] {f : α → β}
 
 /-- A Lipschitz function is locally Lipschitz. -/
-protected lemma _root_.LipschitzWith.locally {K : ℝ≥0} (hf : LipschitzWith K f) : LocallyLipschitz f :=
+protected lemma _root_.LipschitzWith.locally {K : ℝ≥0} (hf : LipschitzWith K f) :
+    LocallyLipschitz f :=
   fun _ ↦ ⟨K, ⟨univ, ⟨Filter.univ_mem, Iff.mpr (lipschitzOn_univ) hf⟩⟩⟩
 
 /-- The identity function is locally Lipschitz. -/

--- a/Mathlib/Topology/MetricSpace/Lipschitz.lean
+++ b/Mathlib/Topology/MetricSpace/Lipschitz.lean
@@ -594,15 +594,15 @@ namespace LocallyLipschitz
 variable [PseudoEMetricSpace α] [PseudoEMetricSpace β] [PseudoEMetricSpace γ] {f : α → β}
 
 /-- A Lipschitz function is locally Lipschitz. -/
-protected lemma of_Lipschitz {K : ℝ≥0} (hf : LipschitzWith K f) : LocallyLipschitz f :=
+protected lemma _root_.LipschitzWith.locally {K : ℝ≥0} (hf : LipschitzWith K f) : LocallyLipschitz f :=
   fun _ ↦ ⟨K, ⟨univ, ⟨Filter.univ_mem, Iff.mpr (lipschitzOn_univ) hf⟩⟩⟩
 
 /-- The identity function is locally Lipschitz. -/
-protected lemma id : LocallyLipschitz (@id α) := LocallyLipschitz.of_Lipschitz (LipschitzWith.id)
+protected lemma id : LocallyLipschitz (@id α) := LipschitzWith.id.locally
 
 /-- Constant functions are locally Lipschitz. -/
 protected lemma const (b : β) : LocallyLipschitz (fun _ : α ↦ b) :=
-  LocallyLipschitz.of_Lipschitz (LipschitzWith.const b)
+  (LipschitzWith.const b).locally
 
 /-- A locally Lipschitz function is continuous. (The converse is false: for example,
 $x ↦ \sqrt{x}$ is continuous, but not locally Lipschitz at 0.) -/
@@ -673,10 +673,10 @@ protected lemma prod {f : α → β} (hf : LocallyLipschitz f) {g : α → γ} (
     exact max_le_max h₁ h₂
 
 protected theorem prod_mk_left (a : α) : LocallyLipschitz (Prod.mk a : β → α × β) :=
-  LocallyLipschitz.of_Lipschitz (LipschitzWith.prod_mk_left a)
+  (LipschitzWith.prod_mk_left a).locally
 
 protected theorem prod_mk_right (b : β) : LocallyLipschitz (fun a : α => (a, b)) :=
-  LocallyLipschitz.of_Lipschitz (LipschitzWith.prod_mk_right b)
+  (LipschitzWith.prod_mk_right b).locally
 
 protected theorem iterate {f : α → α} (hf : LocallyLipschitz f) : ∀ n, LocallyLipschitz f^[n]
   | 0 => by simpa only [pow_zero] using LocallyLipschitz.id
@@ -696,17 +696,13 @@ section Real
 variable {f g : α → ℝ}
 /-- The minimum of locally Lipschitz functions is locally Lipschitz. -/
 protected lemma min (hf : LocallyLipschitz f) (hg : LocallyLipschitz g) :
-    LocallyLipschitz (fun x => min (f x) (g x)) := by
-  let m : ℝ × ℝ → ℝ := fun p ↦ min p.1 p.2
-  have h : LocallyLipschitz m := LocallyLipschitz.of_Lipschitz lipschitzWith_min
-  exact h.comp (hf.prod hg)
+    LocallyLipschitz (fun x => min (f x) (g x)) :=
+  lipschitzWith_min.locally.comp (hf.prod hg)
 
 /-- The maximum of locally Lipschitz functions is locally Lipschitz. -/
 protected lemma max (hf : LocallyLipschitz f) (hg : LocallyLipschitz g) :
-    LocallyLipschitz (fun x => max (f x) (g x)) := by
-  let m : ℝ × ℝ → ℝ := fun p ↦ max p.1 p.2
-  have h : LocallyLipschitz m := LocallyLipschitz.of_Lipschitz lipschitzWith_max
-  exact h.comp (hf.prod hg)
+    LocallyLipschitz (fun x => max (f x) (g x)) :=
+  lipschitzWith_max.locally.comp (hf.prod hg)
 
 theorem max_const (hf : LocallyLipschitz f) (a : ℝ) : LocallyLipschitz fun x => max (f x) a :=
   hf.max (LocallyLipschitz.const a)

--- a/Mathlib/Topology/MetricSpace/Lipschitz.lean
+++ b/Mathlib/Topology/MetricSpace/Lipschitz.lean
@@ -596,7 +596,7 @@ variable [PseudoEMetricSpace α] [PseudoEMetricSpace β] [PseudoEMetricSpace γ]
 /-- A Lipschitz function is locally Lipschitz. -/
 protected lemma _root_.LipschitzWith.locally {K : ℝ≥0} (hf : LipschitzWith K f) :
     LocallyLipschitz f :=
-  fun _ ↦ ⟨K, ⟨univ, ⟨Filter.univ_mem, Iff.mpr (lipschitzOn_univ) hf⟩⟩⟩
+  fun _ ↦ ⟨K, univ, Filter.univ_mem, lipschitzOn_univ.mpr hf⟩
 
 /-- The identity function is locally Lipschitz. -/
 protected lemma id : LocallyLipschitz (@id α) := LipschitzWith.id.locally

--- a/Mathlib/Topology/MetricSpace/Lipschitz.lean
+++ b/Mathlib/Topology/MetricSpace/Lipschitz.lean
@@ -614,7 +614,7 @@ protected theorem continuous {f : α → β} (hf : LocallyLipschitz f) : Continu
   apply Iff.mpr continuous_iff_continuousAt
   intro x
   rcases (hf x) with ⟨K, t, ht, hK⟩
-  exact ContinuousOn.continuousAt (LipschitzOnWith.continuousOn hK) ht
+  exact ContinuousOn.continuousAt (hK.continuousOn) ht
 
 /-- The composition of locally Lipschitz functions is locally Lipschitz. --/
 protected lemma comp  {f : β → γ} {g : α → β}
@@ -646,8 +646,8 @@ protected lemma comp  {f : β → γ} {g : α → β}
     -- similarly, u contains an open subset V
     rcases (Iff.mp (mem_nhds_iff) hu) with ⟨V, hVt, hVopen, hgxV⟩
     -- by continuity, g⁻¹(u) contains the open subset g⁻¹(V)
-    have : ContinuousOn g U := LipschitzOnWith.continuousOn (LipschitzOnWith.mono hgL hUt)
-    have h : IsOpen (U ∩ (g ⁻¹' V)) := ContinuousOn.preimage_open_of_open this hUopen hVopen
+    have : ContinuousOn g U := (hgL.mono hUt).continuousOn
+    have h : IsOpen (U ∩ (g ⁻¹' V)) := this.preimage_open_of_open hUopen hVopen
     have : U ∩ (g ⁻¹' V) ⊆ t' := by rw [h₁]; apply inter_subset_inter hUt (preimage_mono hVt)
     -- now, U ∩ g⁻¹(V) is an open subset contained in t'
     rw [mem_nhds_iff]
@@ -659,7 +659,7 @@ protected lemma comp  {f : β → γ} {g : α → β}
     _ ⊆ g '' t ∩ u := by gcongr; apply image_preimage_subset
     _ ⊆ u := by apply inter_subset_right
   use Kf * Kg, t'
-  exact ⟨h₂, LipschitzOnWith.comp hfL (hgL.mono coe_subset) (Iff.mpr mapsTo' this)⟩
+  exact ⟨h₂, hfL.comp (hgL.mono coe_subset) (Iff.mpr mapsTo' this)⟩
 
 /-- If `f` and `g` are locally Lipschitz, so is the induced map `f × g` to the product type. -/
 protected lemma prod {f : α → β} (hf : LocallyLipschitz f) {g : α → γ} (hg : LocallyLipschitz g) :
@@ -671,10 +671,8 @@ protected lemma prod {f : α → β} (hf : LocallyLipschitz f) {g : α → γ} (
   constructor
   · exact Filter.inter_mem h₁t h₂t
   · intro y hy z hz
-    have h₁ : edist (f y) (f z) ≤ Kf * edist y z := by
-      exact LipschitzOnWith.mono hfL (inter_subset_left t₁ t₂) hy hz
-    have h₂ : edist (g y) (g z) ≤ Kg * edist y z := by
-      exact LipschitzOnWith.mono hgL (inter_subset_right t₁ t₂) hy hz
+    have h₁ : edist (f y) (f z) ≤ Kf * edist y z := hfL.mono (inter_subset_left t₁ t₂) hy hz
+    have h₂ : edist (g y) (g z) ≤ Kg * edist y z := hgL.mono (inter_subset_right t₁ t₂) hy hz
     rw [ENNReal.coe_mono.map_max, Prod.edist_eq, ENNReal.max_mul]
     exact max_le_max h₁ h₂
 

--- a/Mathlib/Topology/MetricSpace/Lipschitz.lean
+++ b/Mathlib/Topology/MetricSpace/Lipschitz.lean
@@ -19,8 +19,8 @@ A map `f : α → β` between two (extended) metric spaces is called *Lipschitz 
 with constant `K ≥ 0` if for all `x, y` we have `edist (f x) (f y) ≤ K * edist x y`.
 For a metric space, the latter inequality is equivalent to `dist (f x) (f y) ≤ K * dist x y`.
 There is also a version asserting this inequality only for `x` and `y` in some set `s`.
-Finally, `f : α → β` is called *locally Lipschitz continuous* if and only if
-each `x : α` has a neighbourhood on which `f` is Lipschitz continuous (w.r.t. to some constant).
+Finally, `f : α → β` is called *locally Lipschitz continuous* if each `x : α` has a neighbourhood
+on which `f` is Lipschitz continuous (with some constant).
 
 In this file we provide various ways to prove that various combinations of Lipschitz continuous
 functions are Lipschitz continuous. We also prove that Lipschitz continuous functions are
@@ -52,7 +52,7 @@ open Filter Function Set Topology NNReal ENNReal Bornology
 
 variable {α : Type u} {β : Type v} {γ : Type w} {ι : Type x}
 
-/-- A function `f` is Lipschitz continuous with constant `K ≥ 0` if for all `x, y`
+/-- A function `f` is **Lipschitz continuous** with constant `K ≥ 0` if for all `x, y`
 we have `dist (f x) (f y) ≤ K * dist x y`. -/
 def LipschitzWith [PseudoEMetricSpace α] [PseudoEMetricSpace β] (K : ℝ≥0) (f : α → β) :=
   ∀ x y, edist (f x) (f y) ≤ K * edist x y
@@ -68,12 +68,17 @@ alias ⟨LipschitzWith.dist_le_mul, LipschitzWith.of_dist_le_mul⟩ := lipschitz
 #align lipschitz_with.dist_le_mul LipschitzWith.dist_le_mul
 #align lipschitz_with.of_dist_le_mul LipschitzWith.of_dist_le_mul
 
-/-- A function `f` is Lipschitz continuous with constant `K ≥ 0` on `s` if for all `x, y` in `s`
-we have `dist (f x) (f y) ≤ K * dist x y`. -/
+/-- A function `f` is **Lipschitz continuous** with constant `K ≥ 0` **on `s`** if
+for all `x, y` in `s` we have `dist (f x) (f y) ≤ K * dist x y`. -/
 def LipschitzOnWith [PseudoEMetricSpace α] [PseudoEMetricSpace β] (K : ℝ≥0) (f : α → β)
     (s : Set α) :=
   ∀ ⦃x⦄, x ∈ s → ∀ ⦃y⦄, y ∈ s → edist (f x) (f y) ≤ K * edist x y
 #align lipschitz_on_with LipschitzOnWith
+
+/-- `f : α → β` is called **locally Lipschitz continuous** iff every point `x`
+has a neighourhood on which `f` is Lipschitz. -/
+def LocallyLipschitz [PseudoEMetricSpace α] [PseudoEMetricSpace β] (f : α → β) : Prop :=
+  ∀ x : α, ∃ K, ∃ t ∈ 𝓝 x, LipschitzOnWith K f t
 
 /-- Every function is Lipschitz on the empty set (with any Lipschitz constant). -/
 @[simp]
@@ -121,11 +126,6 @@ theorem MapsTo.lipschitzOnWith_iff_restrict [PseudoEMetricSpace α] [PseudoEMetr
 
 alias ⟨LipschitzOnWith.to_restrict_mapsTo, _⟩ := MapsTo.lipschitzOnWith_iff_restrict
 #align lipschitz_on_with.to_restrict_maps_to LipschitzOnWith.to_restrict_mapsTo
-
-/-- `f : α → β` is called **locally Lipschitz continuous** iff every point `x`
-has a neighourhood on which `f` is Lipschitz. -/
-def LocallyLipschitz [PseudoEMetricSpace α] [PseudoEMetricSpace β] (f : α → β) : Prop :=
-  ∀ x : α, ∃ K, ∃ t ∈ 𝓝 x, LipschitzOnWith K f t
 
 namespace LipschitzWith
 
@@ -599,11 +599,11 @@ protected lemma _root_.LipschitzWith.locallyLipschitz {K : ℝ≥0} (hf : Lipsch
   fun _ ↦ ⟨K, univ, Filter.univ_mem, lipschitzOn_univ.mpr hf⟩
 
 /-- The identity function is locally Lipschitz. -/
-protected lemma id : LocallyLipschitz (@id α) := LipschitzWith.id.locally
+protected lemma id : LocallyLipschitz (@id α) := LipschitzWith.id.locallyLipschitz
 
 /-- Constant functions are locally Lipschitz. -/
 protected lemma const (b : β) : LocallyLipschitz (fun _ : α ↦ b) :=
-  (LipschitzWith.const b).locally
+  (LipschitzWith.const b).locallyLipschitz
 
 /-- A locally Lipschitz function is continuous. (The converse is false: for example,
 $x ↦ \sqrt{x}$ is continuous, but not locally Lipschitz at 0.) -/
@@ -666,10 +666,10 @@ protected lemma prod {f : α → β} (hf : LocallyLipschitz f) {g : α → γ} (
     exact max_le_max h₁ h₂
 
 protected theorem prod_mk_left (a : α) : LocallyLipschitz (Prod.mk a : β → α × β) :=
-  (LipschitzWith.prod_mk_left a).locally
+  (LipschitzWith.prod_mk_left a).locallyLipschitz
 
 protected theorem prod_mk_right (b : β) : LocallyLipschitz (fun a : α => (a, b)) :=
-  (LipschitzWith.prod_mk_right b).locally
+  (LipschitzWith.prod_mk_right b).locallyLipschitz
 
 protected theorem iterate {f : α → α} (hf : LocallyLipschitz f) : ∀ n, LocallyLipschitz f^[n]
   | 0 => by simpa only [pow_zero] using LocallyLipschitz.id
@@ -690,12 +690,12 @@ variable {f g : α → ℝ}
 /-- The minimum of locally Lipschitz functions is locally Lipschitz. -/
 protected lemma min (hf : LocallyLipschitz f) (hg : LocallyLipschitz g) :
     LocallyLipschitz (fun x => min (f x) (g x)) :=
-  lipschitzWith_min.locally.comp (hf.prod hg)
+  lipschitzWith_min.locallyLipschitz.comp (hf.prod hg)
 
 /-- The maximum of locally Lipschitz functions is locally Lipschitz. -/
 protected lemma max (hf : LocallyLipschitz f) (hg : LocallyLipschitz g) :
     LocallyLipschitz (fun x => max (f x) (g x)) :=
-  lipschitzWith_max.locally.comp (hf.prod hg)
+  lipschitzWith_max.locallyLipschitz.comp (hf.prod hg)
 
 theorem max_const (hf : LocallyLipschitz f) (a : ℝ) : LocallyLipschitz fun x => max (f x) a :=
   hf.max (LocallyLipschitz.const a)

--- a/Mathlib/Topology/MetricSpace/Lipschitz.lean
+++ b/Mathlib/Topology/MetricSpace/Lipschitz.lean
@@ -24,7 +24,7 @@ each `x : α` has a neighbourhood on which `f` is Lipschitz continuous (w.r.t. t
 
 In this file we provide various ways to prove that various combinations of Lipschitz continuous
 functions are Lipschitz continuous. We also prove that Lipschitz continuous functions are
-uniformly continuous. Locally Lipschitz functions are continuous.
+uniformly continuous, and that locally Lipschitz functions are continuous.
 
 ## Main definitions and lemmas
 
@@ -594,7 +594,7 @@ namespace LocallyLipschitz
 variable [PseudoEMetricSpace α] [PseudoEMetricSpace β] [PseudoEMetricSpace γ] {f : α → β}
 
 /-- A Lipschitz function is locally Lipschitz. -/
-protected lemma _root_.LipschitzWith.locally {K : ℝ≥0} (hf : LipschitzWith K f) :
+protected lemma _root_.LipschitzWith.locallyLipschitz {K : ℝ≥0} (hf : LipschitzWith K f) :
     LocallyLipschitz f :=
   fun _ ↦ ⟨K, univ, Filter.univ_mem, lipschitzOn_univ.mpr hf⟩
 


### PR DESCRIPTION
Define locally Lipschitz maps and show their basic properties.
In particular, they are continuous and stable under composition and products.
As an application, we conclude that C¹ maps are locally Lipschitz.

--------

I've gone through the entire file; all API for Lipschitz maps (where this makes sense) has a counterpart for locally Lipschitz maps.

Left for the future:
- sum and scalar multiples of a locally Lipschitz function valued in a normed space is locally Lipschitz
(hence, locally Lipschitz functions form a submodule of the ring of continuous functions)
- locally Lipschitz maps are a submonoid of $\text{End}(\alpha)$
- both of these also hold for Lipschitz maps (on a set)