### PR TITLE
[Merged by Bors] - chore(CategoryTheory): swapping the names of opOp and unopUnop

### DIFF
--- a/Mathlib/CategoryTheory/Opposites.lean
+++ b/Mathlib/CategoryTheory/Opposites.lean
@@ -105,25 +105,25 @@ variable (C)
 
 /-- The functor from the double-opposite of a category to the underlying category. -/
 @[simps]
-def unopUnop' : Cᵒᵖᵒᵖ ⥤ C where
+def unopUnop : Cᵒᵖᵒᵖ ⥤ C where
   obj X := unop (unop X)
   map f := f.unop.unop
-#align category_theory.op_op CategoryTheory.unopUnop'
+#align category_theory.op_op CategoryTheory.unopUnop
 
 /-- The functor from a category to its double-opposite.  -/
 @[simps]
-def opOp' : C ⥤ Cᵒᵖᵒᵖ where
+def opOp : C ⥤ Cᵒᵖᵒᵖ where
   obj X := op (op X)
   map f := f.op.op
-#align category_theory.unop_unop CategoryTheory.opOp'
+#align category_theory.unop_unop CategoryTheory.opOp
 
 /-- The double opposite category is equivalent to the original. -/
 @[simps]
 def opOpEquivalence : Cᵒᵖᵒᵖ ≌ C where
-  functor := unopUnop' C
-  inverse := opOp' C
+  functor := unopUnop C
+  inverse := opOp C
   unitIso := Iso.refl (𝟭 Cᵒᵖᵒᵖ)
-  counitIso := Iso.refl (opOp' C ⋙ unopUnop' C)
+  counitIso := Iso.refl (opOp C ⋙ unopUnop C)
 #align category_theory.op_op_equivalence CategoryTheory.opOpEquivalence
 
 end

--- a/Mathlib/CategoryTheory/Opposites.lean
+++ b/Mathlib/CategoryTheory/Opposites.lean
@@ -105,25 +105,25 @@ variable (C)
 
 /-- The functor from the double-opposite of a category to the underlying category. -/
 @[simps]
-def opOp : Cᵒᵖᵒᵖ ⥤ C where
+def unopUnop' : Cᵒᵖᵒᵖ ⥤ C where
   obj X := unop (unop X)
   map f := f.unop.unop
-#align category_theory.op_op CategoryTheory.opOp
+#align category_theory.op_op CategoryTheory.unopUnop'
 
 /-- The functor from a category to its double-opposite.  -/
 @[simps]
-def unopUnop : C ⥤ Cᵒᵖᵒᵖ where
+def opOp' : C ⥤ Cᵒᵖᵒᵖ where
   obj X := op (op X)
   map f := f.op.op
-#align category_theory.unop_unop CategoryTheory.unopUnop
+#align category_theory.unop_unop CategoryTheory.opOp'
 
 /-- The double opposite category is equivalent to the original. -/
 @[simps]
 def opOpEquivalence : Cᵒᵖᵒᵖ ≌ C where
-  functor := opOp C
-  inverse := unopUnop C
+  functor := unopUnop' C
+  inverse := opOp' C
   unitIso := Iso.refl (𝟭 Cᵒᵖᵒᵖ)
-  counitIso := Iso.refl (unopUnop C ⋙ opOp C)
+  counitIso := Iso.refl (opOp' C ⋙ unopUnop' C)
 #align category_theory.op_op_equivalence CategoryTheory.opOpEquivalence
 
 end


### PR DESCRIPTION
This PR swaps the names of `opOp` and `unopUnop` which are the functors of the equivalence of categories `opOpEquivalence : Cᵒᵖᵒᵖ ≌ C`. As `Opposite.op` is the map `C → Cᵒᵖ`, the functor `C ⥤ Cᵒᵖᵒᵖ` should be named `opOp` and the functor `Cᵒᵖᵒᵖ ⥤ C` should be named `unopUnop`. It was previously the opposite; this PR fixes this.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
