### PR TITLE
chore: truncate long keys in DiscrTrees

### DIFF
--- a/Mathlib/Tactic/LibrarySearch.lean
+++ b/Mathlib/Tactic/LibrarySearch.lean
@@ -69,6 +69,13 @@ def addLemma (name : Name) (constInfo : ConstantInfo)
     (lemmas : DiscrTree (Name × DeclMod) true) : MetaM (DiscrTree (Name × DeclMod) true) := do
   let mut lemmas := lemmas
   for (key, value) in ← processLemma name constInfo do
+    -- To avoid stack overflows in processing the `DiscrTree`,
+    -- we truncate any excessively long keys.
+    -- As of 2023-09-24, this only affected 12 declarations.
+    -- It's possible that this truncation still allows us to find these declarations
+    -- or that a slightly more careful truncation would do so,
+    -- but this would require further investigation.
+    let key := key[:1000].toArray
     lemmas := lemmas.insertIfSpecific key value
   return lemmas
 

--- a/Mathlib/Tactic/Propose.lean
+++ b/Mathlib/Tactic/Propose.lean
@@ -50,7 +50,11 @@ initialize proposeLemmas : DeclCache (DiscrTree Name true) ←
       let (mvars, _, _) ← forallMetaTelescope constInfo.type
       let mut lemmas := lemmas
       for m in mvars do
-        lemmas := lemmas.insertIfSpecific (← DiscrTree.mkPath (← inferType m)) name
+        let key := (← DiscrTree.mkPath (← inferType m))
+        -- To avoid stack overflows in processing the `DiscrTree`,
+        -- we truncate any excessively long keys.
+        let key := key[:1000].toArray
+        lemmas := lemmas.insertIfSpecific key name
       pure lemmas
 
 /-- Shortcut for calling `solveByElim`. -/

--- a/Mathlib/Tactic/Rewrites.lean
+++ b/Mathlib/Tactic/Rewrites.lean
@@ -90,6 +90,9 @@ def addLemma (name : Name) (constInfo : ConstantInfo)
     (lemmas : DiscrTree (Name × Bool × Nat) true) : MetaM (DiscrTree (Name × Bool × Nat) true) := do
   let mut lemmas := lemmas
   for (key, value) in ← processLemma name constInfo do
+    -- To avoid stack overflows in processing the `DiscrTree`,
+    -- we truncate any excessively long keys.
+    let key := key[:1000].toArray
     lemmas := lemmas.insertIfSpecific key value
   return lemmas
 


### PR DESCRIPTION
Per discussion on [zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/CI.20failure.20when.20building.20MathlibExtras).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
