### PR TITLE
chore: bump gh-problem-matcher github action, to silence confusing messages

### DIFF
--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -146,7 +146,7 @@ jobs:
 
       - name: build mathlib
         id: build
-        uses: liskin/gh-problem-matcher-wrap@v2
+        uses: liskin/gh-problem-matcher-wrap@v2.0.2
         with:
           linters: gcc
           run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,7 +152,7 @@ jobs:
 
       - name: build mathlib
         id: build
-        uses: liskin/gh-problem-matcher-wrap@v2
+        uses: liskin/gh-problem-matcher-wrap@v2.0.2
         with:
           linters: gcc
           run: |

--- a/.github/workflows/build.yml.in
+++ b/.github/workflows/build.yml.in
@@ -132,7 +132,7 @@ jobs:
 
       - name: build mathlib
         id: build
-        uses: liskin/gh-problem-matcher-wrap@v2
+        uses: liskin/gh-problem-matcher-wrap@v2.0.2
         with:
           linters: gcc
           run: |

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -150,7 +150,7 @@ jobs:
 
       - name: build mathlib
         id: build
-        uses: liskin/gh-problem-matcher-wrap@v2
+        uses: liskin/gh-problem-matcher-wrap@v2.0.2
         with:
           linters: gcc
           run: |


### PR DESCRIPTION
Resolving a [confusion](https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/tarski.20axiom.20geometry/near/392618240) reported on zulip, and recently patched in the Github action. https://github.com/liskin/gh-problem-matcher-wrap/pull/16


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
