### PR TITLE
[Merged by Bors] - chore: attempt to fix broken links in docs

### DIFF
--- a/Mathlib/Algebra/Star/StarAlgHom.lean
+++ b/Mathlib/Algebra/Star/StarAlgHom.lean
@@ -512,7 +512,7 @@ end Unital
 
 /-! ### Operations on the product type
 
-Note that this is copied from [`NonUnitalAlg`](Mathlib/Algebra/Hom/NonUnitalAlg). -/
+Note that this is copied from [`Algebra.Hom.NonUnitalAlg`](../Hom/NonUnitalAlg). -/
 
 
 namespace NonUnitalStarAlgHom

--- a/Mathlib/Algebra/Star/StarAlgHom.lean
+++ b/Mathlib/Algebra/Star/StarAlgHom.lean
@@ -512,7 +512,7 @@ end Unital
 
 /-! ### Operations on the product type
 
-Note that this is copied from [`Algebra/Hom/NonUnitalAlg`](NonUnitalAlg). -/
+Note that this is copied from [`NonUnitalAlg`](Mathlib/Algebra/Hom/NonUnitalAlg). -/
 
 
 namespace NonUnitalStarAlgHom

--- a/Mathlib/Analysis/NormedSpace/Exponential.lean
+++ b/Mathlib/Analysis/NormedSpace/Exponential.lean
@@ -84,7 +84,7 @@ variable {𝔸}
 It is defined as the sum of the `FormalMultilinearSeries` `expSeries 𝕂 𝔸`.
 
 Note that when `𝔸 = Matrix n n 𝕂`, this is the **Matrix Exponential**; see
-[`Analysis.NormedSpace.MatrixExponential`](Mathlib/Analysis.NormedSpace.MatrixExponential) for lemmas specific to that
+[`Analysis.NormedSpace.MatrixExponential`](./MatrixExponential) for lemmas specific to that
 case. -/
 noncomputable def exp (x : 𝔸) : 𝔸 :=
   (expSeries 𝕂 𝔸).sum x

--- a/Mathlib/Analysis/NormedSpace/Exponential.lean
+++ b/Mathlib/Analysis/NormedSpace/Exponential.lean
@@ -84,7 +84,7 @@ variable {𝔸}
 It is defined as the sum of the `FormalMultilinearSeries` `expSeries 𝕂 𝔸`.
 
 Note that when `𝔸 = Matrix n n 𝕂`, this is the **Matrix Exponential**; see
-[`Analysis.NormedSpace.MatrixExponential`](../MatrixExponential) for lemmas specific to that
+[`Analysis.NormedSpace.MatrixExponential`](Mathlib/Analysis.NormedSpace.MatrixExponential) for lemmas specific to that
 case. -/
 noncomputable def exp (x : 𝔸) : 𝔸 :=
   (expSeries 𝕂 𝔸).sum x

--- a/Mathlib/Data/List/BigOperators/Basic.lean
+++ b/Mathlib/Data/List/BigOperators/Basic.lean
@@ -13,7 +13,7 @@ import Mathlib.Data.List.Forall2
 
 This file provides basic results about `List.prod`, `List.sum`, which calculate the product and sum
 of elements of a list and `List.alternating_prod`, `List.alternating_sum`, their alternating
-counterparts. These are defined in [`Data.List.Defs`](Mathlib/Data/List/Defs).
+counterparts. These are defined in [`Data.List.Defs`](./Defs).
 -/
 
 

--- a/Mathlib/Data/List/BigOperators/Basic.lean
+++ b/Mathlib/Data/List/BigOperators/Basic.lean
@@ -13,7 +13,7 @@ import Mathlib.Data.List.Forall2
 
 This file provides basic results about `List.prod`, `List.sum`, which calculate the product and sum
 of elements of a list and `List.alternating_prod`, `List.alternating_sum`, their alternating
-counterparts. These are defined in [`Data.List.Defs`](./defs).
+counterparts. These are defined in [`Data.List.Defs`](Mathlib/Data/List/Defs).
 -/
 
 


### PR DESCRIPTION
For example, the page of [`Mathlib.Data.List.BigOperators.Basic`](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Data/List/BigOperators/Basic.html) is trying to link to [`Mathlib.Data.List.Defs`](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Data/List/Defs.html) using `./defs` but that becomes `../../../../././defs` and a broken link.

---

Assuming that the four `../../../../` are added by the HTML generator because we are four directories deep in `Mathlib/Data/List/BigOperators`, I changed the `./defs` to  `Mathlib/Data/List/Defs`.

The [code search for `](.`](https://github.com/search?q=repo%3Aleanprover-community%2Fmathlib4+%5D%28.&type=code) returned two similar problems in other files.

I have to admit that I do not actually understand how the documentation is built. ~~The [Readme](https://github.com/leanprover-community/mathlib4/blob/master/README.md) mentions https://github.com/leanprover-community/doc-gen4 but that does not exist.~~ (fixed, it's at https://github.com/leanprover/doc-gen4)

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
