### PR TITLE
[Merged by Bors] - feat: SameCycle.equivalence and SameCycle.setoid

### DIFF
--- a/Mathlib/GroupTheory/Perm/Cycle/Basic.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/Basic.lean
@@ -100,11 +100,12 @@ theorem SameCycle.trans : SameCycle f x y → SameCycle f y z → SameCycle f x 
   fun ⟨i, hi⟩ ⟨j, hj⟩ => ⟨j + i, by rw [zpow_add, mul_apply, hi, hj]⟩
 #align equiv.perm.same_cycle.trans Equiv.Perm.SameCycle.trans
 
+variable (f) in
 theorem SameCycle.equivalence : Equivalence (SameCycle f) :=
   ⟨SameCycle.refl f, SameCycle.symm, SameCycle.trans⟩
 
-def SameCycle.setoid (f : Perm α) : Setoid α :=
-  ⟨SameCycle f, SameCycle.equivalence⟩
+def SameCycle.setoid (f : Perm α) : Setoid α where
+  iseqv := SameCycle.equivalence f
 
 @[simp]
 theorem sameCycle_one : SameCycle 1 x y ↔ x = y := by simp [SameCycle]

--- a/Mathlib/GroupTheory/Perm/Cycle/Basic.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/Basic.lean
@@ -104,6 +104,7 @@ variable (f) in
 theorem SameCycle.equivalence : Equivalence (SameCycle f) :=
   ⟨SameCycle.refl f, SameCycle.symm, SameCycle.trans⟩
 
+/-- The setoid defined by the `SameCycle` relation. -/
 def SameCycle.setoid (f : Perm α) : Setoid α where
   iseqv := SameCycle.equivalence f
 

--- a/Mathlib/GroupTheory/Perm/Cycle/Basic.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/Basic.lean
@@ -100,6 +100,12 @@ theorem SameCycle.trans : SameCycle f x y → SameCycle f y z → SameCycle f x 
   fun ⟨i, hi⟩ ⟨j, hj⟩ => ⟨j + i, by rw [zpow_add, mul_apply, hi, hj]⟩
 #align equiv.perm.same_cycle.trans Equiv.Perm.SameCycle.trans
 
+theorem SameCycle.equivalence : Equivalence (SameCycle f) :=
+  ⟨SameCycle.refl f, SameCycle.symm, SameCycle.trans⟩
+
+def SameCycle.setoid (f : Perm α) : Setoid α :=
+  ⟨SameCycle f, SameCycle.equivalence⟩
+
 @[simp]
 theorem sameCycle_one : SameCycle 1 x y ↔ x = y := by simp [SameCycle]
 #align equiv.perm.same_cycle_one Equiv.Perm.sameCycle_one


### PR DESCRIPTION
I'm exploring @kmill's combinatorial maps work and these two definitions are part of it:

https://github.com/kmill/lean-graphs/blob/bd3139daf81c0f41ce5ade951195858cdf038bd2/src/myequiv.lean#L72-L76

Co-authored-by: Eric Wieser <wieser.eric@gmail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
