### PR TITLE
[Merged by Bors] - chore(scripts/lean-pr-testing-comments.sh): better link target

### DIFF
--- a/scripts/lean-pr-testing-comments.sh
+++ b/scripts/lean-pr-testing-comments.sh
@@ -70,7 +70,7 @@ if [[ "$branch_name" =~ ^lean-pr-testing-([0-9]+)$ ]]; then
   existing_comment_id=$(echo "$existing_comment" | jq -r .id)
   existing_comment_body=$(echo "$existing_comment" | jq -r .body)
 
-  branch="[lean-pr-testing-$pr_number](https://github.com/leanprover-community/mathlib4/compare/master...lean-pr-testing-$pr_number)"
+  branch="[lean-pr-testing-$pr_number](https://github.com/leanprover-community/mathlib4/compare/nightly-testing...lean-pr-testing-$pr_number)"
   # Depending on the success/failure, set the appropriate message
   if [ "$LINT_OUTCOME" == "cancelled" ] || [ "$TEST_OUTCOME" == "cancelled" ] || [ "$BUILD_OUTCOME" == "cancelled" ]; then
     message="- 🟡 Mathlib branch $branch build against this PR was cancelled. ($current_time) [View Log]($WORKFLOW_URL)"


### PR DESCRIPTION
previously, it would link to
<https://github.com/leanprover-community/mathlib4/compare/master...lean-pr-testing-2577>,
which contains lots and lots of commits unrelated to the Lean PR. It
seems cleaner to use
<https://github.com/leanprover-community/mathlib4/compare/nightly-testing...lean-pr-testing-2577>,
