### PR TITLE
[Merged by Bors] - feat: Pointwise set difference, complement

### DIFF
--- a/Mathlib/Combinatorics/SetFamily/Shadow.lean
+++ b/Mathlib/Combinatorics/SetFamily/Shadow.lean
@@ -277,22 +277,16 @@ theorem mem_upShadow_iff_exists_mem_card_add :
 
 @[simp] lemma shadow_compls : ∂ 𝒜ᶜˢ = (∂⁺ 𝒜)ᶜˢ := by
   ext s
-  simp only [mem_image, exists_prop, mem_shadow_iff, mem_upShadow_iff]
-  constructor
-  · rintro ⟨_, ⟨s, hs, rfl⟩, a, ha, rfl⟩
-    exact ⟨insert a s, ⟨s, hs, a, mem_compl.1 ha, rfl⟩, compl_insert⟩
-  · rintro ⟨_, ⟨s, hs, a, ha, rfl⟩, rfl⟩
-    exact ⟨sᶜ, ⟨s, hs, rfl⟩, a, mem_compl.2 ha, compl_insert.symm⟩
-#align finset.up_shadow_image_compl Finset.upShadow_image_compl
+  simp only [mem_image, exists_prop, mem_shadow_iff, mem_upShadow_iff, mem_compls]
+  refine (compl_involutive.toPerm _).exists_congr_left.trans ?_
+  simp [←compl_involutive.eq_iff]
+#align finset.up_shadow_image_compl Finset.shadow_compls
 
 @[simp] lemma upShadow_compls : ∂⁺ 𝒜ᶜˢ = (∂ 𝒜)ᶜˢ := by
   ext s
-  simp only [mem_image, exists_prop, mem_shadow_iff, mem_upShadow_iff]
-  constructor
-  · rintro ⟨_, ⟨s, hs, rfl⟩, a, ha, rfl⟩
-    exact ⟨s.erase a, ⟨s, hs, a, not_mem_compl.1 ha, rfl⟩, compl_erase⟩
-  · rintro ⟨_, ⟨s, hs, a, ha, rfl⟩, rfl⟩
-    exact ⟨sᶜ, ⟨s, hs, rfl⟩, a, not_mem_compl.2 ha, compl_erase.symm⟩
+  simp only [mem_image, exists_prop, mem_shadow_iff, mem_upShadow_iff, mem_compls]
+  refine (compl_involutive.toPerm _).exists_congr_left.trans ?_
+  simp [←compl_involutive.eq_iff]
 #align finset.shadow_image_compl Finset.upShadow_compls
 
 end UpShadow

--- a/Mathlib/Combinatorics/SetFamily/Shadow.lean
+++ b/Mathlib/Combinatorics/SetFamily/Shadow.lean
@@ -20,7 +20,7 @@ to projecting each finset down once in all available directions.
 
 * `Finset.shadow`: The shadow of a set family. Everything we can get by removing a new element from
   some set.
-* `Finset.up_shadow`: The upper shadow of a set family. Everything we can get by adding an element
+* `Finset.upShadow`: The upper shadow of a set family. Everything we can get by adding an element
   to some set.
 
 ## Notation
@@ -275,27 +275,25 @@ theorem mem_upShadow_iff_exists_mem_card_add :
     rfl
 #align finset.mem_up_shadow_iff_exists_mem_card_add Finset.mem_upShadow_iff_exists_mem_card_add
 
-@[simp]
-theorem shadow_image_compl : (∂ 𝒜).image compl = ∂⁺ (𝒜.image compl) := by
+@[simp] lemma shadow_compls : ∂ 𝒜ᶜˢ = (∂⁺ 𝒜)ᶜˢ := by
   ext s
   simp only [mem_image, exists_prop, mem_shadow_iff, mem_upShadow_iff]
   constructor
-  · rintro ⟨_, ⟨s, hs, a, ha, rfl⟩, rfl⟩
-    exact ⟨sᶜ, ⟨s, hs, rfl⟩, a, not_mem_compl.2 ha, compl_erase.symm⟩
-  · rintro ⟨_, ⟨s, hs, rfl⟩, a, ha, rfl⟩
-    exact ⟨s.erase a, ⟨s, hs, a, not_mem_compl.1 ha, rfl⟩, compl_erase⟩
-#align finset.shadow_image_compl Finset.shadow_image_compl
-
-@[simp]
-theorem upShadow_image_compl : (∂⁺ 𝒜).image compl = ∂ (𝒜.image compl) := by
-  ext s
-  simp only [mem_image, exists_prop, mem_shadow_iff, mem_upShadow_iff]
-  constructor
-  · rintro ⟨_, ⟨s, hs, a, ha, rfl⟩, rfl⟩
-    exact ⟨sᶜ, ⟨s, hs, rfl⟩, a, mem_compl.2 ha, compl_insert.symm⟩
   · rintro ⟨_, ⟨s, hs, rfl⟩, a, ha, rfl⟩
     exact ⟨insert a s, ⟨s, hs, a, mem_compl.1 ha, rfl⟩, compl_insert⟩
+  · rintro ⟨_, ⟨s, hs, a, ha, rfl⟩, rfl⟩
+    exact ⟨sᶜ, ⟨s, hs, rfl⟩, a, mem_compl.2 ha, compl_insert.symm⟩
 #align finset.up_shadow_image_compl Finset.upShadow_image_compl
+
+@[simp] lemma upShadow_compls : ∂⁺ 𝒜ᶜˢ = (∂ 𝒜)ᶜˢ := by
+  ext s
+  simp only [mem_image, exists_prop, mem_shadow_iff, mem_upShadow_iff]
+  constructor
+  · rintro ⟨_, ⟨s, hs, rfl⟩, a, ha, rfl⟩
+    exact ⟨s.erase a, ⟨s, hs, a, not_mem_compl.1 ha, rfl⟩, compl_erase⟩
+  · rintro ⟨_, ⟨s, hs, a, ha, rfl⟩, rfl⟩
+    exact ⟨sᶜ, ⟨s, hs, rfl⟩, a, not_mem_compl.2 ha, compl_erase.symm⟩
+#align finset.shadow_image_compl Finset.upShadow_compls
 
 end UpShadow
 

--- a/Mathlib/Combinatorics/SetFamily/Shadow.lean
+++ b/Mathlib/Combinatorics/SetFamily/Shadow.lean
@@ -3,7 +3,7 @@ Copyright (c) 2021 Bhavik Mehta. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta, Alena Gusakov, Yaël Dillies
 -/
-import Mathlib.Data.Finset.Slice
+import Mathlib.Data.Finset.Sups
 import Mathlib.Logic.Function.Iterate
 
 #align_import combinatorics.set_family.shadow from "leanprover-community/mathlib"@"f7fc89d5d5ff1db2d1242c7bb0e9062ce47ef47c"

--- a/Mathlib/Data/Finset/Sups.lean
+++ b/Mathlib/Data/Finset/Sups.lean
@@ -16,17 +16,21 @@ This file defines a few binary operations on `Finset α` for use in set family c
 
 ## Main declarations
 
-* `s ⊻ t`: Finset of elements of the form `a ⊔ b` where `a ∈ s`, `b ∈ t`.
-* `s ⊼ t`: Finset of elements of the form `a ⊓ b` where `a ∈ s`, `b ∈ t`.
+* `Finset.sups s t`: Finset of elements of the form `a ⊔ b` where `a ∈ s`, `b ∈ t`.
+* `Finset.infss t`: Finset of elements of the form `a ⊓ b` where `a ∈ s`, `b ∈ t`.
 * `Finset.disjSups s t`: Finset of elements of the form `a ⊔ b` where `a ∈ s`, `b ∈ t` and `a`
   and `b` are disjoint.
+* `Finset.diffs`: Finset of elements of the form `a \ b` where `a ∈ s`, `b ∈ t`.
+* `Finset.compls`: Finset of elements of the form `aᶜ` where `a ∈ s`.
 
 ## Notation
 
 We define the following notation in locale `FinsetFamily`:
-* `s ⊻ t`
-* `s ⊼ t`
+* `s ⊻ t` for `Finset.sups`
+* `s ⊼ t` for `Finset.infs`
 * `s ○ t` for `Finset.disjSups s t`
+* `s \\ t` for `Finset.diffs`
+* `sᶜˢ` for `Finset.compls`
 
 ## References
 
@@ -95,12 +99,10 @@ theorem sups_subset_right : s₁ ⊆ s₂ → s₁ ⊻ t ⊆ s₂ ⊻ t :=
   image₂_subset_right
 #align finset.sups_subset_right Finset.sups_subset_right
 
-theorem image_subset_sups_left : b ∈ t → (s.image fun a => a ⊔ b) ⊆ s ⊻ t :=
-  image_subset_image₂_left
+lemma image_subset_sups_left : b ∈ t → s.image (· ⊔ b) ⊆ s ⊻ t := image_subset_image₂_left
 #align finset.image_subset_sups_left Finset.image_subset_sups_left
 
-theorem image_subset_sups_right : a ∈ s → t.image (a ⊔ ·) ⊆ s ⊻ t :=
-  image_subset_image₂_right (f := (· ⊔ ·))
+lemma image_subset_sups_right : a ∈ s → t.image (a ⊔ ·) ⊆ s ⊻ t := image_subset_image₂_right
 #align finset.image_subset_sups_right Finset.image_subset_sups_right
 
 theorem forall_sups_iff {p : α → Prop} : (∀ c ∈ s ⊻ t, p c) ↔ ∀ a ∈ s, ∀ b ∈ t, p (a ⊔ b) :=
@@ -144,14 +146,10 @@ theorem sups_eq_empty : s ⊻ t = ∅ ↔ s = ∅ ∨ t = ∅ :=
   image₂_eq_empty_iff
 #align finset.sups_eq_empty Finset.sups_eq_empty
 
-@[simp]
-theorem singleton_sups : {a} ⊻ t = t.image fun b => a ⊔ b :=
-  image₂_singleton_left
+@[simp] lemma singleton_sups : {a} ⊻ t = t.image (a ⊔ ·) := image₂_singleton_left
 #align finset.singleton_sups Finset.singleton_sups
 
-@[simp]
-theorem sups_singleton : s ⊻ {b} = s.image fun a => a ⊔ b :=
-  image₂_singleton_right
+@[simp] lemma sups_singleton : s ⊻ {b} = s.image (· ⊔ b) := image₂_singleton_right
 #align finset.sups_singleton Finset.sups_singleton
 
 theorem singleton_sups_singleton : ({a} ⊻ {b} : Finset α) = {a ⊔ b} :=
@@ -181,12 +179,10 @@ theorem subset_sups {s t : Set α} :
 
 variable (s t u)
 
-theorem biUnion_image_sup_left : (s.biUnion fun a => t.image <| (· ⊔ ·) a) = s ⊻ t :=
-  biUnion_image_left
+lemma biUnion_image_sup_left : s.biUnion (fun a ↦ t.image (a ⊔ ·)) = s ⊻ t := biUnion_image_left
 #align finset.bUnion_image_sup_left Finset.biUnion_image_sup_left
 
-theorem biUnion_image_sup_right : (t.biUnion fun b => s.image fun a => a ⊔ b) = s ⊻ t :=
-  biUnion_image_right
+lemma biUnion_image_sup_right : t.biUnion (fun b ↦ s.image (· ⊔ b)) = s ⊻ t := biUnion_image_right
 #align finset.bUnion_image_sup_right Finset.biUnion_image_sup_right
 
 -- Porting note: simpNF linter doesn't like @[simp]
@@ -269,12 +265,10 @@ theorem infs_subset_right : s₁ ⊆ s₂ → s₁ ⊼ t ⊆ s₂ ⊼ t :=
   image₂_subset_right
 #align finset.infs_subset_right Finset.infs_subset_right
 
-theorem image_subset_infs_left : b ∈ t → (s.image fun a => a ⊓ b) ⊆ s ⊼ t :=
-  image_subset_image₂_left
+lemma image_subset_infs_left : b ∈ t → s.image (· ⊓ b) ⊆ s ⊼ t := image_subset_image₂_left
 #align finset.image_subset_infs_left Finset.image_subset_infs_left
 
-theorem image_subset_infs_right : a ∈ s → t.image (a ⊓ ·) ⊆ s ⊼ t :=
-  image_subset_image₂_right (f := (· ⊓ ·))
+lemma image_subset_infs_right : a ∈ s → t.image (a ⊓ ·) ⊆ s ⊼ t := image_subset_image₂_right
 #align finset.image_subset_infs_right Finset.image_subset_infs_right
 
 theorem forall_infs_iff {p : α → Prop} : (∀ c ∈ s ⊼ t, p c) ↔ ∀ a ∈ s, ∀ b ∈ t, p (a ⊓ b) :=
@@ -318,14 +312,10 @@ theorem infs_eq_empty : s ⊼ t = ∅ ↔ s = ∅ ∨ t = ∅ :=
   image₂_eq_empty_iff
 #align finset.infs_eq_empty Finset.infs_eq_empty
 
-@[simp]
-theorem singleton_infs : {a} ⊼ t = t.image fun b => a ⊓ b :=
-  image₂_singleton_left
+@[simp] lemma singleton_infs : {a} ⊼ t = t.image (a ⊓ ·) := image₂_singleton_left
 #align finset.singleton_infs Finset.singleton_infs
 
-@[simp]
-theorem infs_singleton : s ⊼ {b} = s.image fun a => a ⊓ b :=
-  image₂_singleton_right
+@[simp] lemma infs_singleton : s ⊼ {b} = s.image (· ⊓ b) := image₂_singleton_right
 #align finset.infs_singleton Finset.infs_singleton
 
 theorem singleton_infs_singleton : ({a} ⊼ {b} : Finset α) = {a ⊓ b} :=
@@ -355,12 +345,10 @@ theorem subset_infs {s t : Set α} :
 
 variable (s t u)
 
-theorem biUnion_image_inf_left : (s.biUnion fun a => t.image <| (· ⊓ ·) a) = s ⊼ t :=
-  biUnion_image_left
+lemma biUnion_image_inf_left : s.biUnion (fun a ↦ t.image (a ⊓ ·)) = s ⊼ t := biUnion_image_left
 #align finset.bUnion_image_inf_left Finset.biUnion_image_inf_left
 
-theorem biUnion_image_inf_right : (t.biUnion fun b => s.image fun a => a ⊓ b) = s ⊼ t :=
-  biUnion_image_right
+lemma biUnion_image_inf_right : t.biUnion (fun b ↦ s.image (· ⊓ b)) = s ⊼ t := biUnion_image_right
 #align finset.bUnion_image_inf_right Finset.biUnion_image_inf_right
 
 -- Porting note: simpNF linter doesn't like @[simp]
@@ -589,11 +577,9 @@ lemma diffs_subset : s₁ ⊆ s₂ → t₁ ⊆ t₂ → s₁ \\ t₁ ⊆ s₂ \
 lemma diffs_subset_left : t₁ ⊆ t₂ → s \\ t₁ ⊆ s \\ t₂ := image₂_subset_left
 lemma diffs_subset_right : s₁ ⊆ s₂ → s₁ \\ t ⊆ s₂ \\ t := image₂_subset_right
 
-lemma image_subset_diffs_left : b ∈ t → (s.image fun a ↦ a \ b) ⊆ s \\ t :=
-  image_subset_image₂_left
+lemma image_subset_diffs_left : b ∈ t → s.image (· \ b) ⊆ s \\ t := image_subset_image₂_left
 
-lemma image_subset_diffs_right : a ∈ s → t.image (a \ ·) ⊆ s \\ t :=
-  image_subset_image₂_right (f := (· \ ·))
+lemma image_subset_diffs_right : a ∈ s → t.image (a \ ·) ⊆ s \\ t := image_subset_image₂_right
 
 lemma forall_mem_diffs {p : α → Prop} : (∀ c ∈ s \\ t, p c) ↔ ∀ a ∈ s, ∀ b ∈ t, p (a \ b) :=
   forall_image₂_iff
@@ -611,8 +597,8 @@ lemma Nonempty.of_diffs_right : (s \\ t).Nonempty → t.Nonempty := Nonempty.of_
 @[simp] lemma diffs_empty : s \\ ∅ = ∅ := image₂_empty_right
 @[simp] lemma diffs_eq_empty : s \\ t = ∅ ↔ s = ∅ ∨ t = ∅ := image₂_eq_empty_iff
 
-@[simp] lemma singleton_diffs : {a} \\ t = t.image fun b ↦ a \ b := image₂_singleton_left
-@[simp] lemma diffs_singleton : s \\ {b} = s.image fun a ↦ a \ b := image₂_singleton_right
+@[simp] lemma singleton_diffs : {a} \\ t = t.image (a \ ·) := image₂_singleton_left
+@[simp] lemma diffs_singleton : s \\ {b} = s.image (· \ b) := image₂_singleton_right
 lemma singleton_diffs_singleton : ({a} \\ {b} : Finset α) = {a \ b} := image₂_singleton
 
 lemma diffs_union_left : (s₁ ∪ s₂) \\ t = s₁ \\ t ∪ s₂ \\ t := image₂_union_left
@@ -627,10 +613,8 @@ lemma subset_diffs {s t : Set α} :
 
 variable (s t u)
 
-lemma biUnion_image_sdiff_left : s.biUnion (fun a ↦ t.image $ (· \ ·) a) = s \\ t :=
-  biUnion_image_left
-
-lemma biUnion_image_sdiff_right : t.biUnion (fun b ↦ s.image fun a ↦ a \ b) = s \\ t :=
+lemma biUnion_image_sdiff_left : s.biUnion (fun a ↦ t.image (a \ ·)) = s \\ t := biUnion_image_left
+lemma biUnion_image_sdiff_right : t.biUnion (fun b ↦ s.image (· \ b)) = s \\ t :=
   biUnion_image_right
 
 lemma image_sdiff_product (s t : Finset α) : (s ×ˢ t).image (uncurry (· \ ·)) = s \\ t :=
@@ -643,7 +627,7 @@ end Diffs
 section Compls
 variable [BooleanAlgebra α] (s s₁ s₂ t t₁ t₂ u v : Finset α)
 
-/-- `s` is the finset of elements of the form `a ⊓ b` where `a ∈ s`, `b ∈ t`. -/
+/-- `sᶜˢ` is the finset of elements of the form `aᶜ` where `a ∈ s`. -/
 def compls : Finset α → Finset α := map ⟨compl, compl_injective⟩
 
 @[inherit_doc]

--- a/Mathlib/Data/Finset/Sups.lean
+++ b/Mathlib/Data/Finset/Sups.lean
@@ -17,7 +17,7 @@ This file defines a few binary operations on `Finset α` for use in set family c
 ## Main declarations
 
 * `Finset.sups s t`: Finset of elements of the form `a ⊔ b` where `a ∈ s`, `b ∈ t`.
-* `Finset.infss t`: Finset of elements of the form `a ⊓ b` where `a ∈ s`, `b ∈ t`.
+* `Finset.infs s t`: Finset of elements of the form `a ⊓ b` where `a ∈ s`, `b ∈ t`.
 * `Finset.disjSups s t`: Finset of elements of the form `a ⊔ b` where `a ∈ s`, `b ∈ t` and `a`
   and `b` are disjoint.
 * `Finset.diffs`: Finset of elements of the form `a \ b` where `a ∈ s`, `b ∈ t`.

--- a/Mathlib/Data/Finset/Sups.lean
+++ b/Mathlib/Data/Finset/Sups.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
 import Mathlib.Data.Finset.NAry
+import Mathlib.Data.Finset.Slice
 import Mathlib.Data.Set.Sups
 
 #align_import data.finset.sups from "leanprover-community/mathlib"@"20715f4ac6819ef2453d9e5106ecd086a5dc2a5e"
@@ -552,5 +553,164 @@ theorem disjSups_disjSups_disjSups_comm : s ○ t ○ (u ○ v) = s ○ u ○ (t
 #align finset.disj_sups_disj_sups_disj_sups_comm Finset.disjSups_disjSups_disjSups_comm
 
 end DistribLattice
+section Diffs
+variable [GeneralizedBooleanAlgebra α] (s s₁ s₂ t t₁ t₂ u v : Finset α)
 
+/-- `s \\ t` is the finset of elements of the form `a \ b` where `a ∈ s`, `b ∈ t`. -/
+def diffs : Finset α → Finset α → Finset α := image₂ (· \ ·)
+
+@[inherit_doc]
+scoped[FinsetFamily] infixl:74 " \\\\ " => Finset.diffs
+  -- This notation is meant to have higher precedence than `\` and `⊓`, but still within the
+  -- realm of other binary notation
+
+open FinsetFamily
+
+variable {s t} {a b c : α}
+
+@[simp] lemma mem_diffs : c ∈ s \\ t ↔ ∃ a ∈ s, ∃ b ∈ t, a \ b = c := by simp [(· \\ ·)]
+
+variable (s t)
+
+@[simp, norm_cast] lemma coe_diffs : (↑(s \\ t) : Set α) = Set.image2 (· \ ·) s t :=
+  coe_image₂ _ _ _
+
+lemma card_diffs_le : (s \\ t).card ≤ s.card * t.card := card_image₂_le _ _ _
+
+lemma card_diffs_iff :
+    (s \\ t).card = s.card * t.card ↔ (s ×ˢ t : Set (α × α)).InjOn fun x ↦ x.1 \ x.2 :=
+  card_image₂_iff
+
+variable {s s₁ s₂ t t₁ t₂ u}
+
+lemma sdiff_mem_diffs : a ∈ s → b ∈ t → a \ b ∈ s \\ t := mem_image₂_of_mem
+
+lemma diffs_subset : s₁ ⊆ s₂ → t₁ ⊆ t₂ → s₁ \\ t₁ ⊆ s₂ \\ t₂ := image₂_subset
+lemma diffs_subset_left : t₁ ⊆ t₂ → s \\ t₁ ⊆ s \\ t₂ := image₂_subset_left
+lemma diffs_subset_right : s₁ ⊆ s₂ → s₁ \\ t ⊆ s₂ \\ t := image₂_subset_right
+
+lemma image_subset_diffs_left : b ∈ t → (s.image fun a ↦ a \ b) ⊆ s \\ t :=
+  image_subset_image₂_left
+
+lemma image_subset_diffs_right : a ∈ s → t.image (a \ ·) ⊆ s \\ t :=
+  image_subset_image₂_right (f := (· \ ·))
+
+lemma forall_mem_diffs {p : α → Prop} : (∀ c ∈ s \\ t, p c) ↔ ∀ a ∈ s, ∀ b ∈ t, p (a \ b) :=
+  forall_image₂_iff
+
+@[simp] lemma diffs_subset_iff : s \\ t ⊆ u ↔ ∀ a ∈ s, ∀ b ∈ t, a \ b ∈ u := image₂_subset_iff
+
+@[simp] lemma diffs_nonempty : (s \\ t).Nonempty ↔ s.Nonempty ∧ t.Nonempty := image₂_nonempty_iff
+
+protected lemma Nonempty.diffs : s.Nonempty → t.Nonempty → (s \\ t).Nonempty := Nonempty.image₂
+
+lemma Nonempty.of_diffs_left : (s \\ t).Nonempty → s.Nonempty := Nonempty.of_image₂_left
+lemma Nonempty.of_diffs_right : (s \\ t).Nonempty → t.Nonempty := Nonempty.of_image₂_right
+
+@[simp] lemma empty_diffs : ∅ \\ t = ∅ := image₂_empty_left
+@[simp] lemma diffs_empty : s \\ ∅ = ∅ := image₂_empty_right
+@[simp] lemma diffs_eq_empty : s \\ t = ∅ ↔ s = ∅ ∨ t = ∅ := image₂_eq_empty_iff
+
+@[simp] lemma singleton_diffs : {a} \\ t = t.image fun b ↦ a \ b := image₂_singleton_left
+@[simp] lemma diffs_singleton : s \\ {b} = s.image fun a ↦ a \ b := image₂_singleton_right
+lemma singleton_diffs_singleton : ({a} \\ {b} : Finset α) = {a \ b} := image₂_singleton
+
+lemma diffs_union_left : (s₁ ∪ s₂) \\ t = s₁ \\ t ∪ s₂ \\ t := image₂_union_left
+lemma diffs_union_right : s \\ (t₁ ∪ t₂) = s \\ t₁ ∪ s \\ t₂ := image₂_union_right
+
+lemma diffs_inter_subset_left : (s₁ ∩ s₂) \\ t ⊆ s₁ \\ t ∩ s₂ \\ t := image₂_inter_subset_left
+lemma diffs_inter_subset_right : s \\ (t₁ ∩ t₂) ⊆ s \\ t₁ ∩ s \\ t₂ := image₂_inter_subset_right
+
+lemma subset_diffs {s t : Set α} :
+    ↑u ⊆ Set.image2 (· \ ·) s t → ∃ s' t' : Finset α, ↑s' ⊆ s ∧ ↑t' ⊆ t ∧ u ⊆ s' \\ t' :=
+  subset_image₂
+
+variable (s t u)
+
+lemma biUnion_image_sdiff_left : s.biUnion (fun a ↦ t.image $ (· \ ·) a) = s \\ t :=
+  biUnion_image_left
+
+lemma biUnion_image_sdiff_right : t.biUnion (fun b ↦ s.image fun a ↦ a \ b) = s \\ t :=
+  biUnion_image_right
+
+lemma image_sdiff_product (s t : Finset α) : (s ×ˢ t).image (uncurry (· \ ·)) = s \\ t :=
+  image_uncurry_product _ _ _
+
+lemma diffs_right_comm : s \\ t \\ u = s \\ u \\ t := image₂_right_comm sdiff_right_comm
+
+end Diffs
+
+section Compls
+variable [BooleanAlgebra α] (s s₁ s₂ t t₁ t₂ u v : Finset α)
+
+/-- `s` is the finset of elements of the form `a ⊓ b` where `a ∈ s`, `b ∈ t`. -/
+def compls : Finset α → Finset α := map ⟨compl, compl_injective⟩
+
+@[inherit_doc]
+scoped[FinsetFamily] postfix:max "ᶜˢ" => Finset.compls
+
+open FinsetFamily
+
+variable {s t} {a b c : α}
+
+@[simp] lemma mem_compls : a ∈ sᶜˢ ↔ aᶜ ∈ s := by
+  rw [Iff.comm, ←mem_map' ⟨compl, compl_injective⟩, Embedding.coeFn_mk, compl_compl, compls]
+
+variable (s t)
+
+@[simp] lemma image_compl : s.image compl = sᶜˢ := by simp [compls, map_eq_image]
+
+@[simp, norm_cast] lemma coe_compls : (↑sᶜˢ : Set α) = compl '' ↑s := coe_map _ _
+
+@[simp] lemma card_compls : sᶜˢ.card = s.card := card_map _
+
+variable {s s₁ s₂ t t₁ t₂ u}
+
+lemma compl_mem_compls : a ∈ s → aᶜ ∈ sᶜˢ := mem_map_of_mem _
+@[simp] lemma compls_subset_compls : s₁ᶜˢ ⊆ s₂ᶜˢ ↔ s₁ ⊆ s₂ := map_subset_map
+lemma forall_mem_compls {p : α → Prop} : (∀ a ∈ sᶜˢ, p a) ↔ ∀ a ∈ s, p aᶜ := forall_mem_map
+lemma exists_compls_iff {p : α → Prop} : (∃ a ∈ sᶜˢ, p a) ↔ ∃ a ∈ s, p aᶜ := by aesop
+
+@[simp] lemma compls_compls (s : Finset α) : sᶜˢᶜˢ = s := by ext; simp
+
+lemma compls_subset_iff : sᶜˢ ⊆ t ↔ s ⊆ tᶜˢ := by rw [←compls_subset_compls, compls_compls]
+
+@[simp] lemma compls_nonempty : sᶜˢ.Nonempty ↔ s.Nonempty := map_nonempty
+
+protected alias ⟨Nonempty.of_compls, Nonempty.compls⟩ := compls_nonempty
+
+@[simp] lemma compls_empty : (∅ : Finset α)ᶜˢ = ∅ := map_empty _
+@[simp] lemma compls_eq_empty : sᶜˢ = ∅ ↔ s = ∅ := map_eq_empty
+@[simp] lemma compls_singleton (a : α) : {a}ᶜˢ = {aᶜ} := map_singleton _ _
+@[simp] lemma compls_univ [Fintype α] : (univ : Finset α)ᶜˢ = univ := by ext; simp
+@[simp] lemma compls_union (s t : Finset α) : (s ∪ t)ᶜˢ = sᶜˢ ∪ tᶜˢ := map_union _ _
+@[simp] lemma compls_inter (s t : Finset α) : (s ∩ t)ᶜˢ = sᶜˢ ∩ tᶜˢ := map_inter _ _
+
+@[simp] lemma compls_infs (s t : Finset α) : (s ⊼ t)ᶜˢ = sᶜˢ ⊻ tᶜˢ := by
+  simp_rw [←image_compl]; exact image_image₂_distrib λ _ _ ↦ compl_inf
+
+@[simp] lemma compls_sups (s t : Finset α) : (s ⊻ t)ᶜˢ = sᶜˢ ⊼ tᶜˢ := by
+  simp_rw [←image_compl]; exact image_image₂_distrib λ _ _ ↦ compl_sup
+
+@[simp] lemma infs_compls_eq_diffs (s t : Finset α) : s ⊼ tᶜˢ = s \\ t := by
+  ext; simp [sdiff_eq]; aesop
+
+@[simp] lemma compls_infs_eq_diffs (s t : Finset α) : sᶜˢ ⊼ t = t \\ s := by
+  rw [infs_comm, infs_compls_eq_diffs]
+
+@[simp] lemma diffs_compls_eq_infs (s t : Finset α) : s \\ tᶜˢ = s ⊼ t := by
+  rw [←infs_compls_eq_diffs, compls_compls]
+
+variable [Fintype α] {𝒜 : Finset (Finset α)} {n : ℕ}
+
+protected lemma _root_.Set.Sized.compls (h𝒜 : (𝒜 : Set (Finset α)).Sized n) :
+    (𝒜ᶜˢ : Set (Finset α)).Sized (Fintype.card α - n) :=
+  Finset.forall_mem_compls.2 $ λ s hs ↦ by rw [Finset.card_compl, h𝒜 hs]
+
+lemma sized_compls (hn : n ≤ Fintype.card α) :
+    (𝒜ᶜˢ : Set (Finset α)).Sized n ↔ (𝒜 : Set (Finset α)).Sized (Fintype.card α - n) where
+  mp h𝒜 := by simpa using h𝒜.compls
+  mpr h𝒜 := by simpa only [tsub_tsub_cancel_of_le hn] using h𝒜.compls
+
+end Compls
 end Finset


### PR DESCRIPTION
Define `Finset.diffs` and `Finset.compls`, the pointwise set difference of two finsets and pointwise complement of a finset.

`diffs` appears in the statement of the Marica-Schönheim inequality and `compls` in the proof.

Also fix the corresponding statements for `sups` and `infs` to use the new `·` notation.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
