### PR TITLE
[Merged by Bors] - refactor(Lean.Meta.DiscrTree): Stackless `mapArrays`

### DIFF
--- a/Mathlib/Lean/Meta/DiscrTree.lean
+++ b/Mathlib/Lean/Meta/DiscrTree.lean
@@ -54,7 +54,7 @@ partial def getSubexpressionMatches (d : DiscrTree α s) (e : Expr) : MetaM (Arr
 variable {m : Type → Type} [Monad m]
 
 
-/-- A better representaton for lists-of-quadruples -/
+/-- A representation of lists-of-quadruples with a smaller memory footprint. -/
 private inductive Ctxt (α β γ δ : Type)
   | empty : Ctxt α β γ δ
   | ctxt : α → β → γ → δ → Ctxt α β γ δ → Ctxt α β γ δ

--- a/Mathlib/Lean/Meta/DiscrTree.lean
+++ b/Mathlib/Lean/Meta/DiscrTree.lean
@@ -64,8 +64,8 @@ partial def Trie.mapArrays (t : Trie α s) (f : Array α → Array β) : Trie β
   let .node vs0 cs0 := t
   go Ctxt.empty #[] (f vs0) cs0.toList
 where
-  /- This implementation as a single tail-recursive function is chosen to not blow the
-     interpreter stack when the `Trie` is very deep -/
+  /-- This implementation as a single tail-recursive function is chosen to not blow the
+      interpreter stack when the `Trie` is very deep -/
   go  | .empty, cs, vs, []                   => .node vs cs
       | .ctxt cs vs todo k ps, cs', vs', []  => go ps (cs.push (k, .node vs' cs')) vs todo
       | ps, cs, vs, (k, .node vs' cs')::todo => go (.ctxt cs vs todo k ps) #[] (f vs') cs'.toList

--- a/Mathlib/Lean/Meta/DiscrTree.lean
+++ b/Mathlib/Lean/Meta/DiscrTree.lean
@@ -68,9 +68,10 @@ where
       interpreter stack when the `Trie` is very deep -/
   go cs vs todo ps :=
     if todo.isEmpty then
+      let c := .node vs cs
       match ps with
-      | .empty => .node vs cs
-      | .ctxt cs' vs' todo k ps => go (cs.push (k, .node vs' cs')) vs todo ps
+      | .empty => c
+      | .ctxt cs' vs' todo k ps => go (cs'.push (k, c)) vs' todo ps
     else
       let (k, .node vs' cs') := todo.back
       go (.mkEmpty cs'.size) (f vs') cs'.reverse (.ctxt cs vs todo.pop k ps)

--- a/Mathlib/Lean/Meta/DiscrTree.lean
+++ b/Mathlib/Lean/Meta/DiscrTree.lean
@@ -54,21 +54,26 @@ partial def getSubexpressionMatches (d : DiscrTree α s) (e : Expr) : MetaM (Arr
 variable {m : Type → Type} [Monad m]
 
 
-/-- A representation of lists-of-quadruples with a smaller memory footprint. -/
-private inductive Ctxt (α β γ δ : Type)
-  | empty : Ctxt α β γ δ
-  | ctxt : α → β → γ → δ → Ctxt α β γ δ → Ctxt α β γ δ
+/-- The explicit stack of `Trie.mapArrays` -/
+private inductive Ctxt {α β s}
+  | empty : Ctxt
+  | ctxt : Array (Key s × Trie β s) → Array β → Array (Key s × Trie α s) → Key s → Ctxt → Ctxt
 
 /-- Apply a function to the array of values at each node in a `DiscrTree`. -/
 partial def Trie.mapArrays (t : Trie α s) (f : Array α → Array β) : Trie β s :=
   let .node vs0 cs0 := t
-  go Ctxt.empty #[] (f vs0) cs0.toList
+  go (.mkEmpty cs0.size) (f vs0) cs0.reverse Ctxt.empty
 where
   /-- This implementation as a single tail-recursive function is chosen to not blow the
       interpreter stack when the `Trie` is very deep -/
-  go  | .empty, cs, vs, []                   => .node vs cs
-      | .ctxt cs vs todo k ps, cs', vs', []  => go ps (cs.push (k, .node vs' cs')) vs todo
-      | ps, cs, vs, (k, .node vs' cs')::todo => go (.ctxt cs vs todo k ps) #[] (f vs') cs'.toList
+  go cs vs todo ps :=
+    if todo.isEmpty then
+      match ps with
+      | .empty => .node vs cs
+      | .ctxt cs' vs' todo k ps => go (cs.push (k, .node vs' cs')) vs todo ps
+    else
+      let (k, .node vs' cs') := todo.back
+      go (.mkEmpty cs'.size) (f vs') cs'.reverse (.ctxt cs vs todo.pop k ps)
 
 /-- Apply a function to the array of values at each node in a `DiscrTree`. -/
 def mapArrays (d : DiscrTree α s) (f : Array α → Array β) : DiscrTree β s :=


### PR DESCRIPTION
the naive implementation of `mapArrays`, when run in the interpreter, can
stack overflow when creating the `find_theorems` cache in CI, this
blocks #7244.

While more fundamental fixes are possible (e.g. a Trie structure that
cannot be that deep, https://github.com/leanprover/lean4/pull/2577),
simply rewriting `mapArrays` to be a single tail-recursive function
(which the interpreter is able to execute without using stack space)
should prevent more unrelated PRs from failing CI.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
