### PR TITLE
fix: missing files linter error

### DIFF
--- a/scripts/lint-style.py
+++ b/scripts/lint-style.py
@@ -336,7 +336,9 @@ fix = "--fix" in sys.argv
 argv = (arg for arg in sys.argv[1:] if arg != "--fix")
 
 for filename in argv:
-    lint(Path(filename), fix=fix)
+    file = Path(filename)
+    if file.exists():
+        lint(file, fix=fix)
 
 if new_exceptions:
     exit(1)


### PR DESCRIPTION
The script lint-style.sh attempts to run the linter on all files obtained from git ls-files. If a file has been deleted, it will cause an error. So, I have added a check to verify the file's existence before processing it.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
