### PR TITLE
[Merged by Bors] - feat: prove equality of `Nat.bitwise` and `Nat.bitwise'`

### DIFF
--- a/Mathlib/Data/Int/Bitwise.lean
+++ b/Mathlib/Data/Int/Bitwise.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad
 -/
 import Mathlib.Data.Int.Basic
+import Mathlib.Data.Nat.Bitwise
 import Mathlib.Data.Nat.Pow
 import Mathlib.Data.Nat.Size
 import Mathlib.Init.Data.Int.Bitwise
@@ -205,9 +206,9 @@ theorem testBit_zero (b) : ∀ n, testBit (bit b n) 0 = b
 theorem testBit_succ (m b) : ∀ n, testBit (bit b n) (Nat.succ m) = testBit n m
   | (n : ℕ) => by rw [bit_coe_nat]; apply Nat.testBit_succ
   | -[n+1] => by
-    dsimp [testBit]
+    dsimp only [testBit]
     simp only [bit_negSucc]
-    cases b <;> simp [Nat.testBit_succ]
+    cases b <;> simp only [Bool.not_false, Bool.not_true, Nat.testBit_succ]
 #align int.test_bit_succ Int.testBit_succ
 
 -- Porting note: TODO

--- a/Mathlib/Data/Int/Bitwise.lean
+++ b/Mathlib/Data/Int/Bitwise.lean
@@ -333,10 +333,10 @@ theorem lnot_bit (b) : ∀ n, lnot (bit b n) = bit (not b) (lnot n)
 theorem testBit_bitwise (f : Bool → Bool → Bool) (m n k) :
     testBit (bitwise f m n) k = f (testBit m k) (testBit n k) := by
   cases m <;> cases n <;> simp only [testBit, bitwise, natBitwise]
-  · by_cases h : f false false <;> simp [h]
-  · by_cases h : f false true <;> simp [h]
-  · by_cases h : f true false <;> simp [h]
-  · by_cases h : f true true <;> simp [h]
+  · by_cases h : f false false <;> simp [h, -Nat.bitwise'_eq_bitwise]
+  · by_cases h : f false true <;> simp [h, -Nat.bitwise'_eq_bitwise]
+  · by_cases h : f true false <;> simp [h, -Nat.bitwise'_eq_bitwise]
+  · by_cases h : f true true <;> simp [h, -Nat.bitwise'_eq_bitwise]
 #align int.test_bit_bitwise Int.testBit_bitwise
 
 @[simp]

--- a/Mathlib/Data/Int/Bitwise.lean
+++ b/Mathlib/Data/Int/Bitwise.lean
@@ -333,10 +333,10 @@ theorem lnot_bit (b) : ∀ n, lnot (bit b n) = bit (not b) (lnot n)
 theorem testBit_bitwise (f : Bool → Bool → Bool) (m n k) :
     testBit (bitwise f m n) k = f (testBit m k) (testBit n k) := by
   cases m <;> cases n <;> simp only [testBit, bitwise, natBitwise]
-  · by_cases h : f false false <;> simp [h, -Nat.bitwise'_eq_bitwise]
-  · by_cases h : f false true <;> simp [h, -Nat.bitwise'_eq_bitwise]
-  · by_cases h : f true false <;> simp [h, -Nat.bitwise'_eq_bitwise]
-  · by_cases h : f true true <;> simp [h, -Nat.bitwise'_eq_bitwise]
+  · by_cases h : f false false <;> simp [h]
+  · by_cases h : f false true <;> simp [h]
+  · by_cases h : f true false <;> simp [h]
+  · by_cases h : f true true <;> simp [h]
 #align int.test_bit_bitwise Int.testBit_bitwise
 
 @[simp]

--- a/Mathlib/Data/Nat/Bitwise.lean
+++ b/Mathlib/Data/Nat/Bitwise.lean
@@ -363,11 +363,10 @@ lemma bitwise_zero_right {n : Nat} : bitwise f n 0 = if f true false then n else
 -/
 @[simp]
 theorem bitwise'_zero_right' {m : Nat} :
-    bitwise' f m 0 = cond (f true false) m 0 := by
+    bitwise' f m 0 = if f true false then m else 0 := by
   unfold bitwise' binaryRec
-  simp only [if_true, if_false, dite_false]
-  split_ifs with hx
-  <;> simp only [bit_decomp, eq_mpr_eq_cast, cast_eq, binaryRec_zero, hx, Bool.cond_self]
+  simp only [Bool.cond_eq_ite, eq_mpr_eq_cast, cast_eq, dite_eq_ite]
+  split_ifs with hx <;> simp only [bit_decomp, binaryRec_zero, hx]
 
 @[simp]
 lemma bitwise_zero : bitwise f 0 0 = 0 := by

--- a/Mathlib/Data/Nat/Bitwise.lean
+++ b/Mathlib/Data/Nat/Bitwise.lean
@@ -56,18 +56,18 @@ lemma bitwise'_bit' {f : Bool → Bool → Bool} (a : Bool) (m : Nat) (b : Bool)
   · apply Or.inr ham
 
 @[simp]
-lemma bitwise_zero_left {m : Nat} : bitwise f 0 m = if f false true then m else 0 :=
+lemma bitwise_zero_left (m : Nat) : bitwise f 0 m = if f false true then m else 0 :=
   rfl
 
 @[simp]
-lemma bitwise_zero_right {n : Nat} : bitwise f n 0 = if f true false then n else 0 := by
+lemma bitwise_zero_right (n : Nat) : bitwise f n 0 = if f true false then n else 0 := by
   unfold bitwise
   simp only [ite_self, decide_False, Nat.zero_div, ite_true, ite_eq_right_iff]
   rintro ⟨⟩
   split_ifs <;> rfl
 
 @[simp]
-theorem bitwise'_zero_right {m : Nat} :
+theorem bitwise'_zero_right (m : Nat) :
     bitwise' f m 0 = bif f true false then m else 0 := by
   unfold bitwise' binaryRec
   simp only [Bool.cond_eq_ite, eq_mpr_eq_cast, cast_eq, dite_eq_ite]

--- a/Mathlib/Data/Nat/Bitwise.lean
+++ b/Mathlib/Data/Nat/Bitwise.lean
@@ -77,7 +77,7 @@ lemma bitwise_zero : bitwise f 0 0 = 0 := by
   simp only [bitwise_zero_right, ite_self]
 
 @[simp]
-lemma bitwise_ne_zero {n m : Nat} (hn : n ≠ 0) (hm : m ≠ 0) :
+lemma bitwise_of_ne_zero {n m : Nat} (hn : n ≠ 0) (hm : m ≠ 0) :
     bitwise f n m =
     bitwise f (n / 2) (m / 2) + bitwise f (n / 2) (m / 2)
       + if f (bodd n) (bodd m) then 1 else 0 := by
@@ -88,7 +88,7 @@ lemma bitwise_ne_zero {n m : Nat} (hn : n ≠ 0) (hm : m ≠ 0) :
   split_ifs <;> rfl
 
 @[simp]
-lemma bitwise'_ne_zero {n m : Nat} (hn : n ≠ 0) (hm : m ≠ 0) :
+lemma bitwise'_of_ne_zero {n m : Nat} (hn : n ≠ 0) (hm : m ≠ 0) :
     bitwise' f n m =
     bitwise' f (div2 n) (div2 m) + bitwise' f (div2 n) (div2 m)
       + if f (bodd n) (bodd m) then 1 else 0 := by
@@ -120,7 +120,7 @@ lemma bitwise'_eq_bitwise (f) : bitwise' f = bitwise f := by
   · simp only [bitwise_zero_left, bitwise'_zero_left, Bool.cond_eq_ite]
   · simp only [bitwise_zero_right, bitwise'_zero_right, Bool.cond_eq_ite]
   · specialize ih ((x+1) / 2) (div_lt_self' ..)
-    simp only [bitwise_ne_zero, bitwise'_ne_zero, div2_val, ih, ne_eq, succ_ne_zero,
+    simp only [bitwise_of_ne_zero, bitwise'_of_ne_zero, div2_val, ih, ne_eq, succ_ne_zero,
       not_false_eq_true]
 
 theorem lor'_eq_lor : lor' = lor :=

--- a/Mathlib/Data/Nat/Bitwise.lean
+++ b/Mathlib/Data/Nat/Bitwise.lean
@@ -354,14 +354,20 @@ lemma bitwise_zero_right {n : Nat} : bitwise f n 0 = if f true false then n else
   rintro ⟨⟩
   split_ifs <;> rfl
 
-#check bitwise'_zero_right
-
+/-
+  This theorem already exists as `bitwise'_zero_right` in `Mathlib.Init.Data.Nat.Bitwise`, but that
+  one has the dreaded `f false false = false` assumption.
+  The following proof does not need this assumption, but instead relies on `eq_mpr_eq_cast` from
+  `Mathlib.Logic.Basic`. Since the other version exists in an `Init` file, we probably don't
+  want to add this dependency there
+-/
 @[simp]
 theorem bitwise'_zero_right' (f : Bool → Bool → Bool) (m) :
     bitwise' f m 0 = cond (f true false) m 0 := by
   unfold bitwise' binaryRec
   simp only [if_true, if_false, dite_false]
-  split_ifs with hx <;> simp? [hx, bit_decomp]
+  split_ifs with hx
+  <;> simp only [bit_decomp, eq_mpr_eq_cast, cast_eq, binaryRec_zero, hx, Bool.cond_self]
 
 @[simp]
 lemma bitwise_zero : bitwise f 0 0 = 0 := by
@@ -375,12 +381,9 @@ lemma bitwise_eq_bitwise' (f) : bitwise f = bitwise' f := by
   by_cases h1 : x = 0 <;> by_cases h2 : y = 0
   · simp only [h1, h2, bitwise_zero, bitwise'_zero]
   · simp only [h1, bitwise_zero_left, bitwise'_zero_left]
-    split_ifs with h <;> simp [h]
-  · simp only [h2, bitwise_zero_right]
-    unfold bitwise' binaryRec
-    simp only [h1, h2, if_true, if_false, dite_false]
-    split_ifs with hx <;>
-    simp [hx, bit_decomp]
+    split_ifs with h <;> simp only [h, cond_true, cond_false]
+  · simp only [h2, bitwise_zero_right, bitwise'_zero_right']
+    split_ifs with hx <;> simp only [hx, cond_true, cond_false]
   · unfold bitwise
     rw [mod_two_of_bodd, mod_two_of_bodd, if_neg h1, if_neg h2]
     conv_rhs => rw [← bit_decomp x, ← bit_decomp y]

--- a/Mathlib/Data/Nat/Bitwise.lean
+++ b/Mathlib/Data/Nat/Bitwise.lean
@@ -110,7 +110,6 @@ lemma bitwise'_succ {n m : Nat} :
   cases f (!bodd n) (!bodd m)
   <;> simp only [Bool.cond_eq_ite, ite_false, add_zero, ite_true]
 
-@[simp]
 lemma bitwise'_eq_bitwise (f) : bitwise' f = bitwise f := by
   funext x y
   induction' x using Nat.strongInductionOn with x ih generalizing y

--- a/Mathlib/Data/Nat/Bitwise.lean
+++ b/Mathlib/Data/Nat/Bitwise.lean
@@ -56,7 +56,7 @@ lemma bitwise'_bit' {f : Bool → Bool → Bool} (a : Bool) (m : Nat) (b : Bool)
   · apply Or.inr ham
 
 @[simp]
-lemma bitwise_zero_left {m : Nat} : bitwise f 0 m = if f false true then m else 0 := by
+lemma bitwise_zero_left {m : Nat} : bitwise f 0 m = if f false true then m else 0 :=
   rfl
 
 @[simp]

--- a/Mathlib/Data/Nat/Bitwise.lean
+++ b/Mathlib/Data/Nat/Bitwise.lean
@@ -164,7 +164,7 @@ theorem testBit_two_pow (n m : ℕ) : testBit (2 ^ n) m = (n = m) := by
 
 @[simp]
 theorem bitwise'_zero_right {f : Bool → Bool → Bool} {m : Nat} :
-    bitwise' f m 0 = if f true false then m else 0 := by
+    bitwise' f m 0 = bif f true false then m else 0 := by
   unfold bitwise' binaryRec
   simp only [Bool.cond_eq_ite, eq_mpr_eq_cast, cast_eq, dite_eq_ite]
   split_ifs with hx <;> simp only [bit_decomp, binaryRec_zero, hx]

--- a/Mathlib/Data/Nat/Bitwise.lean
+++ b/Mathlib/Data/Nat/Bitwise.lean
@@ -73,7 +73,6 @@ theorem bitwise'_zero_right {m : Nat} :
   simp only [Bool.cond_eq_ite, eq_mpr_eq_cast, cast_eq, dite_eq_ite]
   split_ifs with hx <;> simp only [bit_decomp, binaryRec_zero, hx]
 
-@[simp]
 lemma bitwise_zero : bitwise f 0 0 = 0 := by
   simp only [bitwise_zero_right, ite_self]
 

--- a/Mathlib/Data/Nat/Bitwise.lean
+++ b/Mathlib/Data/Nat/Bitwise.lean
@@ -332,7 +332,6 @@ theorem lor'_zero (n : ℕ) : lor' n 0 = n := by simp [lor']
 /-- Proving associativity of bitwise operations in general essentially boils down to a huge case
     distinction, so it is shorter to use this tactic instead of proving it in the general case. -/
 macro "bitwise_assoc_tac" : tactic => set_option hygiene false in `(tactic| (
-  -- simp
   induction' n using Nat.binaryRec with b n hn generalizing m k
   · simp
   induction' m using Nat.binaryRec with b' m hm

--- a/Mathlib/Data/Nat/Bitwise.lean
+++ b/Mathlib/Data/Nat/Bitwise.lean
@@ -336,8 +336,7 @@ lemma div2_eq_zero {x : ℕ} :
 lemma bitwise'_bit' {f : Bool → Bool → Bool} (a : Bool) (m : Nat) (b : Bool) (n : Nat)
     (ham : m = 0 → a = true) (hbn : n = 0 → b = true) :
     bitwise' f (bit a m) (bit b n) = bit (f a b) (bitwise' f m n) := by
-  unfold bitwise'
-  rw [binaryRec_eq', binaryRec_eq']
+  rw [bitwise', binaryRec_eq', binaryRec_eq']
   · apply Or.inr hbn
   · apply Or.inr ham
 

--- a/Mathlib/Data/Nat/Bitwise.lean
+++ b/Mathlib/Data/Nat/Bitwise.lean
@@ -407,20 +407,13 @@ lemma bitwise'_succ {n m : Nat} :
 
 lemma bitwise_eq_bitwise' (f) : bitwise f = bitwise' f := by
   funext x y
-  induction' hk : x + y using Nat.strongInductionOn with k ih generalizing x y
-  cases x <;> cases y
+  induction' x using Nat.strongInductionOn with x ih generalizing y
+  cases' x with x <;> cases' y with y
   · simp only [bitwise_zero, bitwise'_zero]
   · simp only [bitwise_zero_left, bitwise'_zero_left, Bool.cond_eq_ite]
   · simp only [bitwise_zero_right, bitwise'_zero_right', Bool.cond_eq_ite]
-  next x y =>
-    simp only [bitwise_succ, bitwise'_succ, div2_val,
-      ih (div2 (x+1) + div2 (y+1))
-          (by rw [←hk, div2_val, div2_val]
-              apply add_lt_add
-              <;> (apply bitwise_rec_lemma; simp)
-              )
-          ((x+1)/2) ((y+1)/2) (by simp only [div2_val])
-    ]
+  · specialize ih ((x+1) / 2) (div_lt_self' ..)
+    simp only [bitwise_succ, bitwise'_succ, div2_val, ih]
 
 end
 

--- a/Mathlib/Data/Nat/Bitwise.lean
+++ b/Mathlib/Data/Nat/Bitwise.lean
@@ -77,36 +77,39 @@ lemma bitwise_zero : bitwise f 0 0 = 0 := by
   simp only [bitwise_zero_right, ite_self]
 
 @[simp]
-lemma bitwise_succ {n m : Nat} :
-    bitwise f (n + 1) (m + 1) =
-    bitwise f ((n+1) / 2) ((m+1) / 2) + bitwise f ((n+1) / 2) ((m+1) / 2)
-      + if f (!bodd n) (!bodd m) then 1 else 0 := by
+lemma bitwise_ne_zero {n m : Nat} (hn : n ≠ 0) (hm : m ≠ 0) :
+    bitwise f n m =
+    bitwise f (n / 2) (m / 2) + bitwise f (n / 2) (m / 2)
+      + if f (bodd n) (bodd m) then 1 else 0 := by
   conv_lhs => { unfold bitwise }
-  have mod_two_iff_bod x : ((x+1) % 2 = 1 : Bool) = !bodd x := by
+  have mod_two_iff_bod x : (x % 2 = 1 : Bool) = bodd x := by
     simp [mod_two_of_bodd, cond]; cases bodd x <;> rfl
-  simp only [add_eq_zero_iff, and_false, ite_false, mod_two_iff_bod]
+  simp only [hn, hm, add_eq_zero_iff, and_false, ite_false, mod_two_iff_bod]
   split_ifs <;> rfl
 
 @[simp]
-lemma bitwise'_succ {n m : Nat} :
-    bitwise' f (n + 1) (m + 1) =
-    bitwise' f (div2 (n + 1)) (div2 (m + 1)) + bitwise' f (div2 (n + 1)) (div2 (m + 1))
-      + if f (!bodd n) (!bodd m) then 1 else 0 := by
-  conv_lhs => { rw [←bit_decomp (n + 1), ←bit_decomp (m + 1)] }
-  simp only [bodd_succ, div2_succ, Bool.cond_eq_ite]
+lemma bitwise'_ne_zero {n m : Nat} (hn : n ≠ 0) (hm : m ≠ 0) :
+    bitwise' f n m =
+    bitwise' f (div2 n) (div2 m) + bitwise' f (div2 n) (div2 m)
+      + if f (bodd n) (bodd m) then 1 else 0 := by
+  conv_lhs => { rw [←bit_decomp n, ←bit_decomp m] }
   rw [bitwise'_bit', bit]
   case ham =>
-    rcases n with ⟨⟩|⟨⟩|n
+    rcases n with ⟨⟩|⟨⟩|x
     <;> simp only [div2_succ, cond, bodd_succ, Bool.not_not]
-    cases bodd n <;> simp only [Bool.not_false, Bool.not_true, succ_ne_zero, IsEmpty.forall_iff,
-      ite_true, ite_false]
+    · contradiction
+    · cases bodd x
+      <;> simp only [Bool.not_false, Bool.not_true, succ_ne_zero, IsEmpty.forall_iff,
+        ite_true, ite_false]
   case hbn =>
-    rcases m with ⟨⟩|⟨⟩|m
+    rcases m with ⟨⟩|⟨⟩|x
     <;> simp only [div2_succ, cond, bodd_succ, Bool.not_not]
-    cases bodd m <;> simp only [Bool.not_false, Bool.not_true, succ_ne_zero, IsEmpty.forall_iff,
-      ite_true, ite_false]
+    · contradiction
+    · cases bodd x
+      <;> simp only [Bool.not_false, Bool.not_true, succ_ne_zero, IsEmpty.forall_iff,
+        ite_true, ite_false]
   simp [bit1, bit0]
-  cases f (!bodd n) (!bodd m)
+  cases f (bodd n) (bodd m)
   <;> simp only [Bool.cond_eq_ite, ite_false, add_zero, ite_true]
 
 lemma bitwise'_eq_bitwise (f) : bitwise' f = bitwise f := by
@@ -117,7 +120,8 @@ lemma bitwise'_eq_bitwise (f) : bitwise' f = bitwise f := by
   · simp only [bitwise_zero_left, bitwise'_zero_left, Bool.cond_eq_ite]
   · simp only [bitwise_zero_right, bitwise'_zero_right, Bool.cond_eq_ite]
   · specialize ih ((x+1) / 2) (div_lt_self' ..)
-    simp only [bitwise_succ, bitwise'_succ, div2_val, ih]
+    simp only [bitwise_ne_zero, bitwise'_ne_zero, div2_val, ih, ne_eq, succ_ne_zero,
+      not_false_eq_true]
 
 theorem lor'_eq_lor : lor' = lor :=
   bitwise'_eq_bitwise _

--- a/Mathlib/Data/Nat/Bitwise.lean
+++ b/Mathlib/Data/Nat/Bitwise.lean
@@ -319,8 +319,8 @@ theorem lt_lxor'_cases {a b c : ℕ} (h : a < lxor' b c) : lxor' a c < b ∨ lxo
   (or_iff_right fun h' => (h.asymm h').elim).1 <| lxor'_trichotomy h.ne
 #align nat.lt_lxor_cases Nat.lt_lxor'_cases
 
-lemma div2_succ_succ (x) :
-    div2 (x + 2) = (div2 x) + 1 := by
+lemma div2_add_two (x) :
+    div2 (x + 2) = div2 x + 1 := by
   simp only [div2_succ, bodd_succ, Bool.cond_not]
   cases bodd x <;> simp only [cond_false, cond_true]
 
@@ -328,13 +328,12 @@ lemma div2_eq_zero {x : ℕ} :
     div2 x = 0 → x = 0 ∨ x = 1 := by
   intro h
   rcases x with ⟨⟩ | ⟨⟩ | x
-  next => apply Or.inl rfl
-  next => apply Or.inr rfl
-  next =>
-    rw[div2_succ_succ] at h
+  · apply Or.inl rfl
+  · apply Or.inr rfl
+  · rw[div2_add_two] at h
     contradiction
 
-lemma bitwise'_bit' {f : Bool → Bool → Bool} (a m b n)
+lemma bitwise'_bit' {f : Bool → Bool → Bool} (a : Bool) (m : Nat) (b : Bool) (n : Nat)
     (ham : m = 0 → a = true) (hbn : n = 0 → b = true) :
     bitwise' f (bit a m) (bit b n) = bit (f a b) (bitwise' f m n) := by
   unfold bitwise'
@@ -344,8 +343,7 @@ lemma bitwise'_bit' {f : Bool → Bool → Bool} (a m b n)
 
 lemma bitwise_eq_bitwise' (f) : bitwise f = bitwise' f := by
   funext x y
-  have ⟨k, hk⟩ : ∃ k, k = x+y := by use x+y
-  induction' k using Nat.strongInductionOn with k ih generalizing x y
+  induction' hk : x + y using Nat.strongInductionOn with k ih generalizing x y
   by_cases h1 : x = 0 <;> by_cases h2 : y = 0
   · unfold bitwise
     simp [h1, h2]
@@ -362,7 +360,7 @@ lemma bitwise_eq_bitwise' (f) : bitwise f = bitwise' f := by
       <;> cases' hy: bodd y
       <;> ring_nf
       <;> rw [ih (div2 x + div2 y)
-              (by rw [hk, div2_val, div2_val]
+              (by rw [←hk, div2_val, div2_val]
                   simp[add_lt_add (bitwise_rec_lemma h1) (bitwise_rec_lemma h2)])
               (x/2) (y/2) (by simp[div2_val])]
       <;> simp [h1, h2, hx, hy, bit_val, div2_val, mul_comm, add_comm]

--- a/Mathlib/Data/Nat/Bitwise.lean
+++ b/Mathlib/Data/Nat/Bitwise.lean
@@ -78,22 +78,18 @@ lemma bitwise_zero : bitwise f 0 0 = 0 := by
 
 @[simp]
 lemma bitwise_of_ne_zero {n m : Nat} (hn : n ≠ 0) (hm : m ≠ 0) :
-    bitwise f n m =
-    bitwise f (n / 2) (m / 2) + bitwise f (n / 2) (m / 2)
-      + if f (bodd n) (bodd m) then 1 else 0 := by
+    bitwise f n m = bit (f (bodd n) (bodd m)) (bitwise f (n / 2) (m / 2)) := by
   conv_lhs => { unfold bitwise }
   have mod_two_iff_bod x : (x % 2 = 1 : Bool) = bodd x := by
     simp [mod_two_of_bodd, cond]; cases bodd x <;> rfl
-  simp only [hn, hm, add_eq_zero_iff, and_false, ite_false, mod_two_iff_bod]
+  simp only [hn, hm, mod_two_iff_bod, ite_false, bit, bit1, bit0, Bool.cond_eq_ite]
   split_ifs <;> rfl
 
 @[simp]
 lemma bitwise'_of_ne_zero {n m : Nat} (hn : n ≠ 0) (hm : m ≠ 0) :
-    bitwise' f n m =
-    bitwise' f (div2 n) (div2 m) + bitwise' f (div2 n) (div2 m)
-      + if f (bodd n) (bodd m) then 1 else 0 := by
+    bitwise' f n m = bit (f (bodd n) (bodd m)) (bitwise' f (n / 2) (m / 2)) := by
   conv_lhs => { rw [←bit_decomp n, ←bit_decomp m] }
-  rw [bitwise'_bit', bit]
+  rw [bitwise'_bit', bit, div2_val, div2_val]
   case ham =>
     rcases n with ⟨⟩|⟨⟩|x
     <;> simp only [div2_succ, cond, bodd_succ, Bool.not_not]
@@ -108,9 +104,6 @@ lemma bitwise'_of_ne_zero {n m : Nat} (hn : n ≠ 0) (hm : m ≠ 0) :
     · cases bodd x
       <;> simp only [Bool.not_false, Bool.not_true, succ_ne_zero, IsEmpty.forall_iff,
         ite_true, ite_false]
-  simp [bit1, bit0]
-  cases f (bodd n) (bodd m)
-  <;> simp only [Bool.cond_eq_ite, ite_false, add_zero, ite_true]
 
 lemma bitwise'_eq_bitwise (f) : bitwise' f = bitwise f := by
   funext x y
@@ -120,8 +113,7 @@ lemma bitwise'_eq_bitwise (f) : bitwise' f = bitwise f := by
   · simp only [bitwise_zero_left, bitwise'_zero_left, Bool.cond_eq_ite]
   · simp only [bitwise_zero_right, bitwise'_zero_right, Bool.cond_eq_ite]
   · specialize ih ((x+1) / 2) (div_lt_self' ..)
-    simp only [bitwise_of_ne_zero, bitwise'_of_ne_zero, div2_val, ih, ne_eq, succ_ne_zero,
-      not_false_eq_true]
+    simp only [ne_eq, succ_ne_zero, not_false_eq_true, bitwise'_of_ne_zero, ih, bitwise_of_ne_zero]
 
 theorem lor'_eq_lor : lor' = lor :=
   bitwise'_eq_bitwise _

--- a/Mathlib/Data/Nat/Bitwise.lean
+++ b/Mathlib/Data/Nat/Bitwise.lean
@@ -91,19 +91,15 @@ lemma bitwise'_of_ne_zero {n m : Nat} (hn : n ≠ 0) (hm : m ≠ 0) :
   conv_lhs => { rw [←bit_decomp n, ←bit_decomp m] }
   rw [bitwise'_bit', bit, div2_val, div2_val]
   case ham =>
-    rcases n with ⟨⟩|⟨⟩|x
-    <;> simp only [div2_succ, cond, bodd_succ, Bool.not_not]
+    obtain ⟨⟩ | n := n
     · contradiction
-    · cases bodd x
-      <;> simp only [Bool.not_false, Bool.not_true, succ_ne_zero, IsEmpty.forall_iff,
-        ite_true, ite_false]
+    · simp only [div2_succ, cond, bodd_succ, Bool.not_not]
+      cases bodd n <;> simp
   case hbn =>
-    rcases m with ⟨⟩|⟨⟩|x
-    <;> simp only [div2_succ, cond, bodd_succ, Bool.not_not]
+    obtain ⟨⟩ | m := m
     · contradiction
-    · cases bodd x
-      <;> simp only [Bool.not_false, Bool.not_true, succ_ne_zero, IsEmpty.forall_iff,
-        ite_true, ite_false]
+    · simp only [div2_succ, cond, bodd_succ, Bool.not_not]
+      cases bodd m <;> simp
 
 lemma bitwise'_eq_bitwise (f) : bitwise' f = bitwise f := by
   funext x y

--- a/Mathlib/Data/Num/Lemmas.lean
+++ b/Mathlib/Data/Num/Lemmas.lean
@@ -5,6 +5,7 @@ Authors: Mario Carneiro
 -/
 import Mathlib.Data.Num.Bitwise
 import Mathlib.Data.Int.CharZero
+import Mathlib.Data.Nat.Bitwise
 import Mathlib.Data.Nat.GCD.Basic
 import Mathlib.Data.Nat.PSub
 import Mathlib.Data.Nat.Size
@@ -922,7 +923,7 @@ theorem bitwise'_to_nat {f : Num → Num → Num} {g : Bool → Bool → Bool} (
     any_goals assumption
     any_goals rw [Nat.bitwise'_zero, p11]; cases g true true <;> rfl
     any_goals rw [Nat.bitwise'_zero_left, this, ← bit_to_nat, p1b]
-    any_goals rw [Nat.bitwise'_zero_right _ gff, this, ← bit_to_nat, pb1]
+    any_goals rw [Nat.bitwise'_zero_right, this, ← bit_to_nat, pb1]
     all_goals
       rw [← show ∀ n : PosNum, ↑(p m n) = Nat.bitwise' g ↑m ↑n from IH]
       rw [← bit_to_nat, pbb]

--- a/Mathlib/Init/Data/Nat/Bitwise.lean
+++ b/Mathlib/Init/Data/Nat/Bitwise.lean
@@ -409,13 +409,6 @@ theorem bitwise'_zero_left (f : Bool → Bool → Bool) (n) :
 #align nat.bitwise_zero_left Nat.bitwise'_zero_left
 
 @[simp]
-theorem bitwise'_zero_right (f : Bool → Bool → Bool) (h : f false false = false) (m) :
-    bitwise' f m 0 = cond (f true false) m 0 := by
-  unfold bitwise'; apply bitCasesOn m; intros; rw [binaryRec_eq, binaryRec_zero]
-  exact bitwise'_bit_aux h
-#align nat.bitwise_zero_right Nat.bitwise'_zero_right
-
-@[simp]
 theorem bitwise'_zero (f : Bool → Bool → Bool) : bitwise' f 0 0 = 0 := by
   rw [bitwise'_zero_left]
   cases f false true <;> rfl
@@ -440,18 +433,6 @@ theorem bitwise'_bit {f : Bool → Bool → Bool} (h : f false false = false) (a
       · rw [← bitwise'_bit_aux h, ftf] }
   · exact bitwise'_bit_aux h
 #align nat.bitwise_bit Nat.bitwise'_bit
-
-theorem bitwise'_swap {f : Bool → Bool → Bool} (h : f false false = false) :
-    bitwise' (Function.swap f) = Function.swap (bitwise' f) := by
-  funext m n; revert n
-  dsimp [Function.swap]
-  apply binaryRec _ _ m <;> intro n
-  · rw [bitwise'_zero_left, bitwise'_zero_right]
-    exact h
-  · intros a ih m'
-    apply bitCasesOn m'; intro b n'
-    rw [bitwise'_bit, bitwise'_bit, ih] <;> exact h
-#align nat.bitwise_swap Nat.bitwise'_swap
 
 -- Porting note:
 -- If someone wants to merge `bitwise` and `bitwise'`

--- a/Mathlib/Init/Data/Nat/Bitwise.lean
+++ b/Mathlib/Init/Data/Nat/Bitwise.lean
@@ -434,11 +434,6 @@ theorem bitwise'_bit {f : Bool → Bool → Bool} (h : f false false = false) (a
   · exact bitwise'_bit_aux h
 #align nat.bitwise_bit Nat.bitwise'_bit
 
--- @[simp]
--- theorem bitwise_bit {f : Bool → Bool → Bool} (h : f false false = false) (a m b n) :
---     bitwise f (bit a m) (bit b n) = bit (f a b) (bitwise f m n) := by
---   simp only [bitwise_eq_bitwise', bitwise'_bit h]
-
 @[simp]
 theorem lor'_bit : ∀ a m b n, lor' (bit a m) (bit b n) = bit (a || b) (lor' m n) :=
   bitwise'_bit rfl

--- a/Mathlib/Init/Data/Nat/Bitwise.lean
+++ b/Mathlib/Init/Data/Nat/Bitwise.lean
@@ -408,7 +408,6 @@ theorem bitwise'_zero_left (f : Bool → Bool → Bool) (n) :
   unfold bitwise'; rw [binaryRec_zero]
 #align nat.bitwise_zero_left Nat.bitwise'_zero_left
 
-@[simp]
 theorem bitwise'_zero (f : Bool → Bool → Bool) : bitwise' f 0 0 = 0 := by
   rw [bitwise'_zero_left]
   cases f false true <;> rfl

--- a/Mathlib/Init/Data/Nat/Bitwise.lean
+++ b/Mathlib/Init/Data/Nat/Bitwise.lean
@@ -434,14 +434,6 @@ theorem bitwise'_bit {f : Bool → Bool → Bool} (h : f false false = false) (a
   · exact bitwise'_bit_aux h
 #align nat.bitwise_bit Nat.bitwise'_bit
 
--- Porting note:
--- If someone wants to merge `bitwise` and `bitwise'`
--- (and similarly `lor` / `lor'` and `land` / `land'`)
--- they could start by proving the next theorem:
--- lemma bitwise_eq_bitwise' (f : Bool → Bool → Bool) :
---     bitwise f = bitwise' f := by
---   sorry
-
 -- @[simp]
 -- theorem bitwise_bit {f : Bool → Bool → Bool} (h : f false false = false) (a m b n) :
 --     bitwise f (bit a m) (bit b n) = bit (f a b) (bitwise f m n) := by


### PR DESCRIPTION
This PR proves that `Nat.bitwise` (from core) and `Nat.bitwise'` (from mathlib) are equal

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

This proof has been extracted from #5920, and follows the advice from https://github.com/leanprover-community/mathlib4/pull/5920#discussion_r1321066176
