### PR TITLE
[Merged by Bors] - chore: replace Nat.digits_add_two_add_one with a syntactic matching simp lemma

### DIFF
--- a/Mathlib/Data/Nat/Digits.lean
+++ b/Mathlib/Data/Nat/Digits.lean
@@ -121,7 +121,7 @@ theorem digits_add_two_add_one (b n : ℕ) :
 #align nat.digits_add_two_add_one Nat.digits_add_two_add_one
 
 @[simp]
-lemma digits_of_two_le_of_pos (hm : 2 ≤ m) (hn : 0 < n) :
+lemma digits_of_two_le_of_pos {m : ℕ} (hm : 2 ≤ m) (hn : 0 < n) :
     Nat.digits m n = n % m :: Nat.digits m (n / m) := by
   rw [Nat.eq_add_of_sub_eq hm rfl, Nat.eq_add_of_sub_eq hn rfl, Nat.digits_add_two_add_one]
 

--- a/Mathlib/Data/Nat/Digits.lean
+++ b/Mathlib/Data/Nat/Digits.lean
@@ -120,6 +120,11 @@ theorem digits_add_two_add_one (b n : ℕ) :
   simp [digits, digitsAux_def]
 #align nat.digits_add_two_add_one Nat.digits_add_two_add_one
 
+@[simp]
+lemma digits_of_two_le_of_pos (hm : 2 ≤ m) (hn : 0 < n) :
+    Nat.digits m n = n % m :: Nat.digits m (n / m) := by
+  rw [Nat.eq_add_of_sub_eq hm rfl, Nat.eq_add_of_sub_eq hn rfl, Nat.digits_add_two_add_one]
+
 theorem digits_def' :
     ∀ {b : ℕ} (_ : 1 < b) {n : ℕ} (_ : 0 < n), digits b n = (n % b) :: digits b (n / b)
   | 0, h => absurd h (by decide)

--- a/Mathlib/Data/Nat/Digits.lean
+++ b/Mathlib/Data/Nat/Digits.lean
@@ -598,7 +598,7 @@ theorem digits_two_eq_bits (n : ℕ) : digits 2 n = n.bits.map fun b => cond b 1
   · rw [digits_def' one_lt_two]
     · simpa [Nat.bit, Nat.bit0_val n]
     · simpa [pos_iff_ne_zero, bit_eq_zero_iff]
-  · simpa [Nat.bit, Nat.bit1_val n, add_comm, digits_add 2 one_lt_two 1 n]
+  · simpa [Nat.bit, Nat.bit1_val n, add_comm, digits_add 2 one_lt_two 1 n, Nat.add_mul_div_left]
 #align nat.digits_two_eq_bits Nat.digits_two_eq_bits
 
 /-! ### Modular Arithmetic -/

--- a/Mathlib/Data/Nat/Digits.lean
+++ b/Mathlib/Data/Nat/Digits.lean
@@ -121,9 +121,9 @@ theorem digits_add_two_add_one (b n : ℕ) :
 #align nat.digits_add_two_add_one Nat.digits_add_two_add_one
 
 @[simp]
-lemma digits_of_two_le_of_pos {m : ℕ} (hm : 2 ≤ m) (hn : 0 < n) :
-    Nat.digits m n = n % m :: Nat.digits m (n / m) := by
-  rw [Nat.eq_add_of_sub_eq hm rfl, Nat.eq_add_of_sub_eq hn rfl, Nat.digits_add_two_add_one]
+lemma digits_of_two_le_of_pos {b : ℕ} (hm : 2 ≤ b) (hn : 0 < n) :
+    Nat.digits b n = n % b :: Nat.digits b (n / b) := by
+  rw [Nat.eq_add_of_sub_eq hb rfl, Nat.eq_add_of_sub_eq hn rfl, Nat.digits_add_two_add_one]
 
 theorem digits_def' :
     ∀ {b : ℕ} (_ : 1 < b) {n : ℕ} (_ : 0 < n), digits b n = (n % b) :: digits b (n / b)

--- a/Mathlib/Data/Nat/Digits.lean
+++ b/Mathlib/Data/Nat/Digits.lean
@@ -121,7 +121,7 @@ theorem digits_add_two_add_one (b n : ℕ) :
 #align nat.digits_add_two_add_one Nat.digits_add_two_add_one
 
 @[simp]
-lemma digits_of_two_le_of_pos {b : ℕ} (hm : 2 ≤ b) (hn : 0 < n) :
+lemma digits_of_two_le_of_pos {b : ℕ} (hb : 2 ≤ b) (hn : 0 < n) :
     Nat.digits b n = n % b :: Nat.digits b (n / b) := by
   rw [Nat.eq_add_of_sub_eq hb rfl, Nat.eq_add_of_sub_eq hn rfl, Nat.digits_add_two_add_one]
 

--- a/Mathlib/Data/Nat/Digits.lean
+++ b/Mathlib/Data/Nat/Digits.lean
@@ -115,7 +115,6 @@ theorem digits_one_succ (n : ℕ) : digits 1 (n + 1) = 1 :: digits 1 n :=
   rfl
 #align nat.digits_one_succ Nat.digits_one_succ
 
-@[simp]
 theorem digits_add_two_add_one (b n : ℕ) :
     digits (b + 2) (n + 1) = ((n + 1) % (b + 2)) :: digits (b + 2) ((n + 1) / (b + 2)) := by
   simp [digits, digitsAux_def]


### PR DESCRIPTION
This seems more useful once the theory is set up.
Previously
```
Nat.digits 10 (n + 1) = l
```
would simp to
```
(n + 1) % (8 + 2) :: Nat.digits (8 + 2) ((n + 1) / (8 + 2)) = l
```
now it simps to
```
(n + 1) % 10 :: Nat.digits 10 ((n + 1) / 10) = l
```


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
