### PR TITLE
[Merged by Bors] - feat(Data/Setoid/Partition): equivalence classes and quotient

### DIFF
--- a/Mathlib/Data/Setoid/Partition.lean
+++ b/Mathlib/Data/Setoid/Partition.lean
@@ -199,7 +199,7 @@ theorem sUnion_classes (r : Setoid α) : ⋃₀ r.classes = Set.univ :=
 
 /-- The equivalence between the type of equivalence classes of an equivalence relation and its
 quotient. -/
-noncomputable def classes_equiv_quotient (r : Setoid α) : Quotient r ≃ Setoid.classes r := by
+noncomputable def classesEquivQuotient (r : Setoid α) : Quotient r ≃ Setoid.classes r := by
   let f (a : α) : Setoid.classes r := ⟨{ x | Setoid.r x a }, Setoid.mem_classes r a⟩
   have f_respects_relation (a b : α) (a_rel_b : Setoid.r a b) : f a = f b := by
     rw [Subtype.mk.injEq]
@@ -218,6 +218,14 @@ noncomputable def classes_equiv_quotient (r : Setoid α) : Quotient r ≃ Setoid
   · rw [Quot.surjective_lift]
     intro ⟨c, a, hc⟩
     exact ⟨a, Subtype.ext hc.symm⟩
+
+lemma classesEquivQuotient_mk_eq (r : Setoid α) (a : α)
+    : classesEquivQuotient r (Quotient.mk r a) = ⟨{ x | r.Rel x a }, Setoid.mem_classes r a⟩ :=
+  rfl
+
+lemma classesEquivQuotient_mk_coe_eq (r : Setoid α) (a : α)
+    : (classesEquivQuotient r (Quotient.mk r a) : Set α) = { x | r.Rel x a } :=
+  Subtype.ext_iff_val.mp (classesEquivQuotient_mk_eq r a)
 
 section Partition
 

--- a/Mathlib/Data/Setoid/Partition.lean
+++ b/Mathlib/Data/Setoid/Partition.lean
@@ -208,19 +208,16 @@ noncomputable def classes_equiv_quotient (r : Setoid α) : Quotient r ≃ Setoid
   apply Equiv.ofBijective (Quot.lift f f_respects_relation)
   constructor
   · intro (q_a : Quotient r) (q_b : Quotient r) h_eq
-    obtain ⟨a, ha⟩ := Quotient.exists_rep q_a
-    obtain ⟨b, hb⟩ := Quotient.exists_rep q_b
-    simp only [←ha, ←hb, Quotient.lift_mk, Subtype.mk.injEq] at *
+    induction' q_a using Quotient.ind with a
+    induction' q_b using Quotient.ind with b
+    simp only [Subtype.ext_iff, Quotient.lift_mk, Subtype.ext_iff] at h_eq
     apply Quotient.sound
     show a ∈ { x | Setoid.r x b }
     rw [←h_eq]
     exact Setoid.refl a
-  · simp only [Quot.surjective_lift f_respects_relation]
+  · rw [Quot.surjective_lift]
     intro ⟨c, a, hc⟩
-    have a_in_c : a ∈ c := by rw [hc]; exact Setoid.refl' r a
-    exists a
-    rw [Subtype.mk.injEq]
-    exact Setoid.eq_of_mem_classes (Setoid.mem_classes r a) (Setoid.refl a) ⟨a, hc⟩ a_in_c
+    exact ⟨a, Subtype.ext hc.symm⟩
 
 section Partition
 

--- a/Mathlib/Data/Setoid/Partition.lean
+++ b/Mathlib/Data/Setoid/Partition.lean
@@ -197,7 +197,8 @@ theorem sUnion_classes (r : Setoid α) : ⋃₀ r.classes = Set.univ :=
   Set.eq_univ_of_forall fun x => Set.mem_sUnion.2 ⟨{ y | r.Rel y x }, ⟨x, rfl⟩, Setoid.refl _⟩
 #align setoid.sUnion_classes Setoid.sUnion_classes
 
-/-- The equivalence between the type of equivalence classes of an equivalence relation and its quotient. -/
+/-- The equivalence between the type of equivalence classes of an equivalence relation and its
+quotient. -/
 noncomputable def classes_equiv_quotient (r : Setoid α) : Quotient r ≃ Setoid.classes r := by
   let f (a : α) : Setoid.classes r := ⟨{ x | Setoid.r x a }, Setoid.mem_classes r a⟩
   have f_respects_relation (a b : α) (a_rel_b : Setoid.r a b) : f a = f b := by
@@ -206,7 +207,7 @@ noncomputable def classes_equiv_quotient (r : Setoid α) : Quotient r ≃ Setoid
         (Setoid.mem_classes r b) (Setoid.refl b)
   apply Equiv.ofBijective (Quot.lift f f_respects_relation)
   constructor
-  . intro (q_a : Quotient r) (q_b : Quotient r) h_eq
+  · intro (q_a : Quotient r) (q_b : Quotient r) h_eq
     obtain ⟨a, ha⟩ := Quotient.exists_rep q_a
     obtain ⟨b, hb⟩ := Quotient.exists_rep q_b
     simp only [←ha, ←hb, Quotient.lift_mk, Subtype.mk.injEq] at *
@@ -214,7 +215,7 @@ noncomputable def classes_equiv_quotient (r : Setoid α) : Quotient r ≃ Setoid
     show a ∈ { x | Setoid.r x b }
     rw [←h_eq]
     exact Setoid.refl a
-  . simp only [Quot.surjective_lift f_respects_relation]
+  · simp only [Quot.surjective_lift f_respects_relation]
     intro ⟨c, c_in_cls⟩
     obtain ⟨a, a_in_c⟩ := Set.nonempty_iff_ne_empty.mpr <| fun c_empty : c = ∅ ↦ by
       rw [c_empty] at c_in_cls; exact Setoid.empty_not_mem_classes c_in_cls

--- a/Mathlib/Data/Setoid/Partition.lean
+++ b/Mathlib/Data/Setoid/Partition.lean
@@ -197,6 +197,31 @@ theorem sUnion_classes (r : Setoid α) : ⋃₀ r.classes = Set.univ :=
   Set.eq_univ_of_forall fun x => Set.mem_sUnion.2 ⟨{ y | r.Rel y x }, ⟨x, rfl⟩, Setoid.refl _⟩
 #align setoid.sUnion_classes Setoid.sUnion_classes
 
+/-- The equivalence between the type of equivalence classes of an equivalence relation and its quotient. -/
+noncomputable def classes_equiv_quotient (r : Setoid α) : Quotient r ≃ Setoid.classes r := by
+  let f (a : α) : Setoid.classes r := ⟨{ x | Setoid.r x a }, Setoid.mem_classes r a⟩
+  have f_respects_relation (a b : α) (a_rel_b : Setoid.r a b) : f a = f b := by
+    rw [Subtype.mk.injEq]
+    exact Setoid.eq_of_mem_classes (Setoid.mem_classes r a) (Setoid.symm a_rel_b)
+        (Setoid.mem_classes r b) (Setoid.refl b)
+  apply Equiv.ofBijective (Quot.lift f f_respects_relation)
+  constructor
+  . intro (q_a : Quotient r) (q_b : Quotient r) h_eq
+    obtain ⟨a, ha⟩ := Quotient.exists_rep q_a
+    obtain ⟨b, hb⟩ := Quotient.exists_rep q_b
+    simp only [←ha, ←hb, Quotient.lift_mk, Subtype.mk.injEq] at *
+    apply Quotient.sound
+    show a ∈ { x | Setoid.r x b }
+    rw [←h_eq]
+    exact Setoid.refl a
+  . simp only [Quot.surjective_lift f_respects_relation]
+    intro ⟨c, c_in_cls⟩
+    obtain ⟨a, a_in_c⟩ := Set.nonempty_iff_ne_empty.mpr <| fun c_empty : c = ∅ ↦ by
+      rw [c_empty] at c_in_cls; exact Setoid.empty_not_mem_classes c_in_cls
+    exists a
+    rw [Subtype.mk.injEq]
+    exact Setoid.eq_of_mem_classes (Setoid.mem_classes r a) (Setoid.refl a) c_in_cls a_in_c
+
 section Partition
 
 /- ./././Mathport/Syntax/Translate/Basic.lean:628:2:

--- a/Mathlib/Data/Setoid/Partition.lean
+++ b/Mathlib/Data/Setoid/Partition.lean
@@ -216,12 +216,11 @@ noncomputable def classes_equiv_quotient (r : Setoid α) : Quotient r ≃ Setoid
     rw [←h_eq]
     exact Setoid.refl a
   · simp only [Quot.surjective_lift f_respects_relation]
-    intro ⟨c, c_in_cls⟩
-    obtain ⟨a, a_in_c⟩ := Set.nonempty_iff_ne_empty.mpr <| fun c_empty : c = ∅ ↦ by
-      rw [c_empty] at c_in_cls; exact Setoid.empty_not_mem_classes c_in_cls
+    intro ⟨c, a, hc⟩
+    have a_in_c : a ∈ c := by rw [hc]; exact Setoid.refl' r a
     exists a
     rw [Subtype.mk.injEq]
-    exact Setoid.eq_of_mem_classes (Setoid.mem_classes r a) (Setoid.refl a) c_in_cls a_in_c
+    exact Setoid.eq_of_mem_classes (Setoid.mem_classes r a) (Setoid.refl a) ⟨a, hc⟩ a_in_c
 
 section Partition
 

--- a/Mathlib/Data/Setoid/Partition.lean
+++ b/Mathlib/Data/Setoid/Partition.lean
@@ -219,12 +219,12 @@ noncomputable def classesEquivQuotient (r : Setoid α) : Quotient r ≃ Setoid.c
     intro ⟨c, a, hc⟩
     exact ⟨a, Subtype.ext hc.symm⟩
 
-lemma classesEquivQuotient_mk_eq (r : Setoid α) (a : α)
-    : classesEquivQuotient r (Quotient.mk r a) = ⟨{ x | r.Rel x a }, Setoid.mem_classes r a⟩ :=
+lemma classesEquivQuotient_mk_eq (r : Setoid α) (a : α) :
+    classesEquivQuotient r (Quotient.mk r a) = ⟨{ x | r.Rel x a }, Setoid.mem_classes r a⟩ :=
   rfl
 
-lemma classesEquivQuotient_mk_coe_eq (r : Setoid α) (a : α)
-    : (classesEquivQuotient r (Quotient.mk r a) : Set α) = { x | r.Rel x a } :=
+lemma classesEquivQuotient_mk_coe_eq (r : Setoid α) (a : α) :
+    (classesEquivQuotient r (Quotient.mk r a) : Set α) = { x | r.Rel x a } :=
   Subtype.ext_iff_val.mp (classesEquivQuotient_mk_eq r a)
 
 section Partition

--- a/Mathlib/Data/Setoid/Partition.lean
+++ b/Mathlib/Data/Setoid/Partition.lean
@@ -219,13 +219,10 @@ noncomputable def classesEquivQuotient (r : Setoid α) : Quotient r ≃ Setoid.c
     intro ⟨c, a, hc⟩
     exact ⟨a, Subtype.ext hc.symm⟩
 
+@[simp]
 lemma classesEquivQuotient_mk_eq (r : Setoid α) (a : α) :
-    classesEquivQuotient r (Quotient.mk r a) = ⟨{ x | r.Rel x a }, Setoid.mem_classes r a⟩ :=
-  rfl
-
-lemma classesEquivQuotient_mk_coe_eq (r : Setoid α) (a : α) :
     (classesEquivQuotient r (Quotient.mk r a) : Set α) = { x | r.Rel x a } :=
-  Subtype.ext_iff_val.mp (classesEquivQuotient_mk_eq r a)
+  (@Subtype.ext_iff_val _ _ _ ⟨{ x | r.Rel x a }, Setoid.mem_classes r a⟩).mp rfl
 
 section Partition
 

--- a/Mathlib/Data/Setoid/Partition.lean
+++ b/Mathlib/Data/Setoid/Partition.lean
@@ -197,9 +197,9 @@ theorem sUnion_classes (r : Setoid α) : ⋃₀ r.classes = Set.univ :=
   Set.eq_univ_of_forall fun x => Set.mem_sUnion.2 ⟨{ y | r.Rel y x }, ⟨x, rfl⟩, Setoid.refl _⟩
 #align setoid.sUnion_classes Setoid.sUnion_classes
 
-/-- The equivalence between the type of equivalence classes of an equivalence relation and its
-quotient. -/
-noncomputable def classesEquivQuotient (r : Setoid α) : Quotient r ≃ Setoid.classes r := by
+/-- The equivalence between the quotient by an equivalence relation and its
+type of equivalence classes. -/
+noncomputable def quotientEquivClasses (r : Setoid α) : Quotient r ≃ Setoid.classes r := by
   let f (a : α) : Setoid.classes r := ⟨{ x | Setoid.r x a }, Setoid.mem_classes r a⟩
   have f_respects_relation (a b : α) (a_rel_b : Setoid.r a b) : f a = f b := by
     rw [Subtype.mk.injEq]
@@ -220,8 +220,8 @@ noncomputable def classesEquivQuotient (r : Setoid α) : Quotient r ≃ Setoid.c
     exact ⟨a, Subtype.ext hc.symm⟩
 
 @[simp]
-lemma classesEquivQuotient_mk_eq (r : Setoid α) (a : α) :
-    (classesEquivQuotient r (Quotient.mk r a) : Set α) = { x | r.Rel x a } :=
+lemma quotientEquivClasses_mk_eq (r : Setoid α) (a : α) :
+    (quotientEquivClasses r (Quotient.mk r a) : Set α) = { x | r.Rel x a } :=
   (@Subtype.ext_iff_val _ _ _ ⟨{ x | r.Rel x a }, Setoid.mem_classes r a⟩).mp rfl
 
 section Partition


### PR DESCRIPTION
Adds the equivalence between the type of equivalence classes of an equivalence relation and its quotient.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
