### PR TITLE
[Merged by Bors] - feat(Tactic/ExtendDoc): add `extend_doc` command

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3104,6 +3104,7 @@ import Mathlib.Tactic.Existsi
 import Mathlib.Tactic.Explode
 import Mathlib.Tactic.Explode.Datatypes
 import Mathlib.Tactic.Explode.Pretty
+import Mathlib.Tactic.ExtendDoc
 import Mathlib.Tactic.ExtractGoal
 import Mathlib.Tactic.ExtractLets
 import Mathlib.Tactic.FBinop

--- a/Mathlib/Order/RelSeries.lean
+++ b/Mathlib/Order/RelSeries.lean
@@ -67,7 +67,7 @@ lemma rel_of_lt [IsTrans α r] (x : RelSeries r) {i j : Fin (x.length + 1)} (h :
 
 lemma rel_or_eq_of_le [IsTrans α r] (x : RelSeries r) {i j : Fin (x.length + 1)} (h : i ≤ j) :
     r (x i) (x j) ∨ x i = x j :=
-  h.lt_or_eq.imp (x.rel_of_lt ·) (congrArg x.toFun ·)
+  h.lt_or_eq.imp (x.rel_of_lt ·) (by rw [·])
 
 /--
 Given two relations `r, s` on `α` such that `r ≤ s`, any relation series of `r` induces a relation

--- a/Mathlib/Order/RelSeries.lean
+++ b/Mathlib/Order/RelSeries.lean
@@ -67,7 +67,7 @@ lemma rel_of_lt [IsTrans α r] (x : RelSeries r) {i j : Fin (x.length + 1)} (h :
 
 lemma rel_or_eq_of_le [IsTrans α r] (x : RelSeries r) {i j : Fin (x.length + 1)} (h : i ≤ j) :
     r (x i) (x j) ∨ x i = x j :=
-  h.lt_or_eq.imp (x.rel_of_lt ·) (by rw [·])
+  h.lt_or_eq.imp (x.rel_of_lt ·) (congrArg x.toFun ·)
 
 /--
 Given two relations `r, s` on `α` such that `r ≤ s`, any relation series of `r` induces a relation

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -45,6 +45,7 @@ import Mathlib.Tactic.Existsi
 import Mathlib.Tactic.Explode
 import Mathlib.Tactic.Explode.Datatypes
 import Mathlib.Tactic.Explode.Pretty
+import Mathlib.Tactic.ExtendDoc
 import Mathlib.Tactic.ExtractGoal
 import Mathlib.Tactic.ExtractLets
 import Mathlib.Tactic.FBinop

--- a/Mathlib/Tactic/Basic.lean
+++ b/Mathlib/Tactic/Basic.lean
@@ -6,6 +6,7 @@ Authors: Mario Carneiro, Kyle Miller
 import Lean
 import Std
 import Mathlib.Tactic.PPWithUniv
+import Mathlib.Tactic.ExtendDoc
 
 set_option autoImplicit true
 

--- a/Mathlib/Tactic/ExtendDoc.lean
+++ b/Mathlib/Tactic/ExtendDoc.lean
@@ -27,6 +27,7 @@ namespace Mathlib.Tactic.ExtendDocs
 /-- `extend_docs <declName> before <prefix_string> after <suffix_string>` extends the
 docs of `<declName>` by adding `<prefix_string>` before and `<suffix_string>` after. -/
 syntax "extend_docs" ident (colGt "before" str)? (colGt "after" str)? : command
+
 open Lean in
 elab_rules : command
   | `(command| extend_docs $na:ident $[before $bef:str]? $[after $aft:str]?) => do
@@ -38,16 +39,3 @@ elab_rules : command
     addDocString declName <| bef ++ oldDoc ++ aft
 
 end Mathlib.Tactic.ExtendDocs
-
-/- redefine `rw`, since I cannot find a way to replace the doc-string of a declaration that
-has been defined in an earlier file.
-The "new" `rw` inherits the docs of `rewrite`. -/
-open Lean.Parser.Tactic Lean in
-@[inherit_doc rewriteSeq]
-macro (name := my_rw) "rw" c:(config)? s:rwRuleSeq l:(location)? : tactic =>
-  `(tactic| (rw $(c)? $s $(l)?))
-
--- now we add to the docs of the "new" `rw` the prefix that we want.
-extend_docs my_rw
-  before "`rw` is like `rewrite` (see below), but also tries to close the goal by \"cheap\"
-    (reducible) `rfl` afterwards."

--- a/Mathlib/Tactic/ExtendDoc.lean
+++ b/Mathlib/Tactic/ExtendDoc.lean
@@ -1,0 +1,31 @@
+import Lean.Elab.ElabRules
+
+namespace Mathlib.Tactic.ExtendDocs
+
+/-- `extend_docs <declName> before <prefix_string> after <suffix_string>` extends the
+docs of `<declName>` by adding `<prefix_string>` before and `<suffix_string>` after. -/
+syntax "extend_docs" ident (colGt "before" str)? (colGt "after" str)? : command
+open Lean in
+elab_rules : command
+  | `(command| extend_docs $na:ident $[before $bef:str]? $[after $aft:str]?) => do
+    if bef.isNone && aft.isNone then throwError "expected at least one of 'before' or 'after'"
+    let declName ← Elab.resolveGlobalConstNoOverloadWithInfo na
+    let bef := if bef.isNone then "" else (bef.get!).getString ++ "\n\n"
+    let aft := if aft.isNone then "" else "\n\n" ++ (aft.get!).getString
+    let oldDoc := (← findDocString? (← getEnv) declName).getD ""
+    addDocString declName <| bef ++ oldDoc ++ aft
+
+end Mathlib.Tactic.ExtendDocs
+
+/- redefine `rw`, since I cannot find a way to replace the doc-string of a declaration that
+has been defined in an earlier file.
+The "new" `rw` inherits the docs of `rewrite`. -/
+open Lean.Parser.Tactic Lean in
+@[inherit_doc rewriteSeq]
+macro (name := my_rw) "rw" c:(config)? s:rwRuleSeq l:(location)? : tactic =>
+  `(tactic| (rw $(c)? $s $(l)?))
+
+-- now we add to the docs of the "new" `rw` the prefix that we want.
+extend_docs my_rw
+  before "`rw` is like `rewrite` (see below), but also tries to close the goal by \"cheap\"
+    (reducible) `rfl` afterwards."

--- a/Mathlib/Tactic/ExtendDoc.lean
+++ b/Mathlib/Tactic/ExtendDoc.lean
@@ -1,4 +1,26 @@
+/-
+Copyright (c) 2023 Damiano Testa. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Damiano Testa
+-/
+
 import Lean.Elab.ElabRules
+
+/-!
+#  `extend_doc` command
+
+In a file where declaration `decl` is defined, writing
+```lean
+extend_doc decl
+  before "I will be added as a prefix to the docs of `decl`"
+  after "I will be added as a suffix to the docs of `decl`"
+```
+
+does what is probably clear: it extends the doc-string of `decl` by adding the string of
+`before` at the beginning and the string of `after` at the end.
+
+At least one of `before` and `after` must appear, but either one of them is optional.
+-/
 
 namespace Mathlib.Tactic.ExtendDocs
 


### PR DESCRIPTION
This PR is related to [Issue leanprover/lean4#2622](https://github.com/leanprover/lean4/issues/2622).

In the file where declaration `decl` is defined, writing
```lean
extend_doc decl
  before "I will be added as a prefix to the docs of `decl`"
  after "I will be added as a suffix to the docs of `decl`"
```

does what is probably clear: it extends the doc-string of `decl` by adding the string immediately following `before` at the beginning and the string immediately following`after` at the end.

This is useful, for instance, when the docs of `decl` are obtained via `inherit_doc`.

[Zulip discussion](https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/tactic.20docstrings)

By way of example, I redefine the docs over `rw`.  The new doc-string is

```lean
`rw` is like `rewrite` (see below), but also tries to close the goal by "cheap" (reducible) `rfl` afterwards.

`rewrite [e]` applies identity `e` as a rewrite rule to the target of the main goal.
If `e` is preceded by left arrow (`←` or `<-`), the rewrite is applied in the reverse direction.
If `e` is a defined constant, then the equational theorems associated with `e` are used.
This provides a convenient way to unfold `e`.
- `rewrite [e₁, ..., eₙ]` applies the given rules sequentially.
- `rewrite [e] at l` rewrites `e` at location(s) `l`, where `l` is either `*` or a
  list of hypotheses in the local context. In the latter case, a turnstile `⊢` or `|-`
  can also be used, to signify the target of the goal.

Using `rw (config := {occs := .pos L}) [e]`,
where `L : List Nat`, you can control which "occurrences" are rewritten.
(This option applies to each rule, so usually this will only be used with a single rule.)
Occurrences count from `1`.
At the first occurrence, whether allowed or not,
arguments of the rewrite rule `e` may be instantiated,
restricting which later rewrites can be found.
`{occs := .neg L}` allows skipping specified occurrences.
```

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
