### PR TITLE
[Merged by Bors] - feat(Topology/Separation): filter of codiscrete sets

### DIFF
--- a/Mathlib/Topology/Separation.lean
+++ b/Mathlib/Topology/Separation.lean
@@ -1682,6 +1682,40 @@ instance {ι : Type*} {π : ι → Type*} [∀ i, TopologicalSpace (π i)] [∀ 
     RegularSpace (∀ i, π i) :=
   regularSpace_iInf fun _ => regularSpace_induced _
 
+/-- In a regular space, the union of two discrete closed subsets is discrete. -/
+lemma discreteTopology_union {S T : Set α} (hS : DiscreteTopology S) (hS' : IsClosed S)
+    (hT : DiscreteTopology T) (hT' : IsClosed T) : DiscreteTopology ↑(S ∪ T) := by
+  simp_rw [discreteTopology_subtype_iff, ←disjoint_iff] at hS hT ⊢
+  intro x h
+  wlog hx : x ∈ S generalizing S T
+  · simp_rw [union_comm S T] at this h ⊢
+    exact this hT' hS' hT hS h (((mem_union _ _ _).mp h).resolve_right hx)
+  rw [←sup_principal, disjoint_sup_right]
+  by_cases hx' : x ∈ T
+  exacts [⟨hS x hx, hT x hx'⟩, ⟨hS x hx, (RegularSpace.regular hT' hx').symm.mono
+      nhdsWithin_le_nhds principal_le_nhdsSet⟩]
+
+section codiscrete_filter
+
+/-- In a regular space, intersections of codiscrete sets are codiscrete. -/
+lemma IsCodiscrete.inter {U V : Set α}
+    (hU : IsCodiscrete U) (hV : IsCodiscrete V) : IsCodiscrete (U ∩ V) := by
+  refine ⟨hU.1.inter hV.1, ?_⟩
+  rw [compl_inter]
+  rw [IsCodiscrete, ← isClosed_compl_iff] at hU hV
+  exact discreteTopology_union hU.2 hU.1 hV.2 hV.1
+
+variable (α)
+
+/-- The filter of codiscrete subsets, in a regular space. -/
+def Filter.Codiscrete [RegularSpace α] : Filter α where
+  sets := IsCodiscrete
+  univ_sets := isCodiscrete_univ
+  sets_of_superset := IsCodiscrete.mono
+  inter_sets := IsCodiscrete.inter
+
+end codiscrete_filter
+
 end RegularSpace
 
 section T3

--- a/Mathlib/Topology/Separation.lean
+++ b/Mathlib/Topology/Separation.lean
@@ -1682,44 +1682,6 @@ instance {ι : Type*} {π : ι → Type*} [∀ i, TopologicalSpace (π i)] [∀ 
     RegularSpace (∀ i, π i) :=
   regularSpace_iInf fun _ => regularSpace_induced _
 
-/-- In a regular space, the union of two discrete closed subsets is discrete. -/
-lemma discreteTopology_union {S T : Set α} (hS : DiscreteTopology S) (hS' : IsClosed S)
-    (hT : DiscreteTopology T) (hT' : IsClosed T) : DiscreteTopology ↑(S ∪ T) := by
-  simp_rw [discreteTopology_subtype_iff, ←disjoint_iff] at hS hT ⊢
-  intro x h
-  wlog hx : x ∈ S generalizing S T
-  · simp_rw [union_comm S T] at this h ⊢
-    exact this hT' hS' hT hS h (((mem_union _ _ _).mp h).resolve_right hx)
-  rw [←sup_principal, disjoint_sup_right]
-  by_cases hx' : x ∈ T
-  exacts [⟨hS x hx, hT x hx'⟩, ⟨hS x hx, (RegularSpace.regular hT' hx').symm.mono
-      nhdsWithin_le_nhds principal_le_nhdsSet⟩]
-
-section codiscrete_filter
-
-variable (α)
-
-/-- In a regular space, the open sets with with discrete complement form a filter. -/
-def Filter.Codiscrete [RegularSpace α] : Filter α where
-  sets := {U | IsOpen U ∧ DiscreteTopology ↑Uᶜ}
-  univ_sets := ⟨isOpen_univ, compl_univ.symm ▸ Subsingleton.discreteTopology⟩
-  sets_of_superset := by
-    intro U V ⟨hU, hU'⟩ hV
-    rw [←isClosed_compl_iff] at hU
-    rw [←compl_subset_compl] at hV
-    refine ⟨?_, DiscreteTopology.of_subset hU' hV⟩
-    simpa only [Subtype.image_preimage_val, inter_eq_self_of_subset_left hV,
-      isClosed_compl_iff] using hU.closedEmbedding_subtype_val.isClosedMap _ (isClosed_discrete
-      (Subtype.val ⁻¹' Vᶜ))
-  inter_sets := by
-    intro U V ⟨hU, hU'⟩ ⟨hV, hV'⟩
-    refine ⟨hU.inter hV, ?_⟩
-    rw [compl_inter]
-    rw [← isClosed_compl_iff] at hU hV
-    exact discreteTopology_union hU' hU hV' hV
-
-end codiscrete_filter
-
 end RegularSpace
 
 section T3

--- a/Mathlib/Topology/Separation.lean
+++ b/Mathlib/Topology/Separation.lean
@@ -1697,22 +1697,26 @@ lemma discreteTopology_union {S T : Set α} (hS : DiscreteTopology S) (hS' : IsC
 
 section codiscrete_filter
 
-/-- In a regular space, intersections of codiscrete sets are codiscrete. -/
-lemma IsCodiscrete.inter {U V : Set α}
-    (hU : IsCodiscrete U) (hV : IsCodiscrete V) : IsCodiscrete (U ∩ V) := by
-  refine ⟨hU.1.inter hV.1, ?_⟩
-  rw [compl_inter]
-  rw [IsCodiscrete, ← isClosed_compl_iff] at hU hV
-  exact discreteTopology_union hU.2 hU.1 hV.2 hV.1
-
 variable (α)
 
-/-- The filter of codiscrete subsets, in a regular space. -/
+/-- In a regular space, the open sets with with discrete complement form a filter. -/
 def Filter.Codiscrete [RegularSpace α] : Filter α where
-  sets := IsCodiscrete
-  univ_sets := isCodiscrete_univ
-  sets_of_superset := IsCodiscrete.mono
-  inter_sets := IsCodiscrete.inter
+  sets := {U | IsOpen U ∧ DiscreteTopology ↑Uᶜ}
+  univ_sets := ⟨isOpen_univ, compl_univ.symm ▸ Subsingleton.discreteTopology⟩
+  sets_of_superset := by
+    intro U V ⟨hU, hU'⟩ hV
+    rw [←isClosed_compl_iff] at hU
+    rw [←compl_subset_compl] at hV
+    refine ⟨?_, DiscreteTopology.of_subset hU' hV⟩
+    simpa only [Subtype.image_preimage_val, inter_eq_self_of_subset_left hV,
+      isClosed_compl_iff] using hU.closedEmbedding_subtype_val.isClosedMap _ (isClosed_discrete
+      (Subtype.val ⁻¹' Vᶜ))
+  inter_sets := by
+    intro U V ⟨hU, hU'⟩ ⟨hV, hV'⟩
+    refine ⟨hU.inter hV, ?_⟩
+    rw [compl_inter]
+    rw [← isClosed_compl_iff] at hU hV
+    exact discreteTopology_union hU' hU hV' hV
 
 end codiscrete_filter
 

--- a/Mathlib/Topology/SubsetProperties.lean
+++ b/Mathlib/Topology/SubsetProperties.lean
@@ -2041,3 +2041,35 @@ theorem IsPreirreducible.preimage {Z : Set α} (hZ : IsPreirreducible Z) {f : β
 #align is_preirreducible.preimage IsPreirreducible.preimage
 
 end Preirreducible
+
+section codiscrete_filter
+
+/-- Criterion for a subset `S ⊆ α` to be closed and discrete in terms of the punctured
+neighbourhood filter at an arbitrary point of `α`. (Compare `discreteTopology_subtype_iff`.) -/
+theorem isClosed_and_discrete_iff {S : Set α} : IsClosed S ∧ DiscreteTopology S ↔
+    ∀ x, Disjoint (𝓝[≠] x) (𝓟 S) := by
+  rw [discreteTopology_subtype_iff, isClosed_iff_clusterPt, ← forall_and]
+  congrm (∀ x, ?_)
+  rw [← not_imp_not, clusterPt_iff_not_disjoint, not_not, ←disjoint_iff]
+  constructor <;> intro H
+  · by_cases hx : x ∈ S
+    exacts [H.2 hx, (H.1 hx).mono_left nhdsWithin_le_nhds]
+  · refine ⟨fun hx ↦ ?_, fun _ ↦ H⟩
+    simpa [disjoint_iff, nhdsWithin, inf_assoc, hx] using H
+
+variable (α)
+
+/-- In a regular space, the open sets with with discrete complement form a filter. -/
+def Filter.Codiscrete : Filter α where
+  sets := {U | IsOpen U ∧ DiscreteTopology ↑Uᶜ}
+  univ_sets := ⟨isOpen_univ, compl_univ.symm ▸ Subsingleton.discreteTopology⟩
+  sets_of_superset := by
+    intro U V hU hV
+    simp_rw [←isClosed_compl_iff, isClosed_and_discrete_iff] at hU ⊢
+    exact fun x ↦ (hU x).mono_right (principal_mono.mpr $ compl_subset_compl.mpr hV)
+  inter_sets := by
+    intro U V hU hV
+    simp_rw [←isClosed_compl_iff, isClosed_and_discrete_iff] at hU hV ⊢
+    exact fun x ↦ compl_inter U V ▸ sup_principal ▸ disjoint_sup_right.mpr ⟨hU x, hV x⟩
+
+end codiscrete_filter

--- a/Mathlib/Topology/SubsetProperties.lean
+++ b/Mathlib/Topology/SubsetProperties.lean
@@ -2041,3 +2041,32 @@ theorem IsPreirreducible.preimage {Z : Set α} (hZ : IsPreirreducible Z) {f : β
 #align is_preirreducible.preimage IsPreirreducible.preimage
 
 end Preirreducible
+
+section codiscrete
+
+/-- The empty subset of any topological space is a discrete set in its
+subspace topology. -/
+lemma discreteTopology_emptyset : DiscreteTopology ↑(∅ : Set α) :=
+  discreteTopology_iff_nhds.mpr (fun x ↦ False.elim x.property)
+
+/-- We say a set `U` in a topological space `α` is *codiscrete* if it is
+open with discrete complement. -/
+def IsCodiscrete (U : Set α) : Prop := IsOpen U ∧ DiscreteTopology ↑Uᶜ
+
+/-- The universe is codiscrete. -/
+lemma isCodiscrete_univ : IsCodiscrete (univ : Set α) :=
+⟨isOpen_univ, compl_univ.symm ▸ discreteTopology_emptyset⟩
+
+/-- A superset of a codiscrete set is codiscrete. -/
+lemma IsCodiscrete.mono {U V : Set α} (hU : IsCodiscrete U) (hV : U ⊆ V) :
+    IsCodiscrete V := by
+  cases' hU with hU hU'
+  rw [←isClosed_compl_iff] at hU
+  rw [←compl_subset_compl] at hV
+  refine ⟨?_, DiscreteTopology.of_subset hU' hV⟩
+  let f : ↑Uᶜ → α := Subtype.val
+  have he := hU.closedEmbedding_subtype_val
+  simpa only [Subtype.image_preimage_val, inter_eq_self_of_subset_left hV, 
+    isClosed_compl_iff] using he.isClosedMap _ (isClosed_discrete (f ⁻¹' Vᶜ))
+
+end codiscrete

--- a/Mathlib/Topology/SubsetProperties.lean
+++ b/Mathlib/Topology/SubsetProperties.lean
@@ -2060,7 +2060,7 @@ theorem isClosed_and_discrete_iff {S : Set α} : IsClosed S ∧ DiscreteTopology
 variable (α)
 
 /-- In any topological space, the open sets with with discrete complement form a filter. -/
-def Filter.Codiscrete : Filter α where
+def Filter.codiscrete : Filter α where
   sets := {U | IsOpen U ∧ DiscreteTopology ↑Uᶜ}
   univ_sets := ⟨isOpen_univ, compl_univ.symm ▸ Subsingleton.discreteTopology⟩
   sets_of_superset := by

--- a/Mathlib/Topology/SubsetProperties.lean
+++ b/Mathlib/Topology/SubsetProperties.lean
@@ -2066,7 +2066,7 @@ lemma IsCodiscrete.mono {U V : Set α} (hU : IsCodiscrete U) (hV : U ⊆ V) :
   refine ⟨?_, DiscreteTopology.of_subset hU' hV⟩
   let f : ↑Uᶜ → α := Subtype.val
   have he := hU.closedEmbedding_subtype_val
-  simpa only [Subtype.image_preimage_val, inter_eq_self_of_subset_left hV, 
+  simpa only [Subtype.image_preimage_val, inter_eq_self_of_subset_left hV,
     isClosed_compl_iff] using he.isClosedMap _ (isClosed_discrete (f ⁻¹' Vᶜ))
 
 end codiscrete

--- a/Mathlib/Topology/SubsetProperties.lean
+++ b/Mathlib/Topology/SubsetProperties.lean
@@ -2059,14 +2059,14 @@ theorem isClosed_and_discrete_iff {S : Set α} : IsClosed S ∧ DiscreteTopology
 
 variable (α)
 
-/-- In a regular space, the open sets with with discrete complement form a filter. -/
+/-- In any topological space, the open sets with with discrete complement form a filter. -/
 def Filter.Codiscrete : Filter α where
   sets := {U | IsOpen U ∧ DiscreteTopology ↑Uᶜ}
   univ_sets := ⟨isOpen_univ, compl_univ.symm ▸ Subsingleton.discreteTopology⟩
   sets_of_superset := by
     intro U V hU hV
     simp_rw [←isClosed_compl_iff, isClosed_and_discrete_iff] at hU ⊢
-    exact fun x ↦ (hU x).mono_right (principal_mono.mpr $ compl_subset_compl.mpr hV)
+    exact fun x ↦ (hU x).mono_right (principal_mono.mpr <| compl_subset_compl.mpr hV)
   inter_sets := by
     intro U V hU hV
     simp_rw [←isClosed_compl_iff, isClosed_and_discrete_iff] at hU hV ⊢

--- a/Mathlib/Topology/SubsetProperties.lean
+++ b/Mathlib/Topology/SubsetProperties.lean
@@ -2041,32 +2041,3 @@ theorem IsPreirreducible.preimage {Z : Set α} (hZ : IsPreirreducible Z) {f : β
 #align is_preirreducible.preimage IsPreirreducible.preimage
 
 end Preirreducible
-
-section codiscrete
-
-/-- The empty subset of any topological space is a discrete set in its
-subspace topology. -/
-lemma discreteTopology_emptyset : DiscreteTopology ↑(∅ : Set α) :=
-  discreteTopology_iff_nhds.mpr (fun x ↦ False.elim x.property)
-
-/-- We say a set `U` in a topological space `α` is *codiscrete* if it is
-open with discrete complement. -/
-def IsCodiscrete (U : Set α) : Prop := IsOpen U ∧ DiscreteTopology ↑Uᶜ
-
-/-- The universe is codiscrete. -/
-lemma isCodiscrete_univ : IsCodiscrete (univ : Set α) :=
-⟨isOpen_univ, compl_univ.symm ▸ discreteTopology_emptyset⟩
-
-/-- A superset of a codiscrete set is codiscrete. -/
-lemma IsCodiscrete.mono {U V : Set α} (hU : IsCodiscrete U) (hV : U ⊆ V) :
-    IsCodiscrete V := by
-  cases' hU with hU hU'
-  rw [←isClosed_compl_iff] at hU
-  rw [←compl_subset_compl] at hV
-  refine ⟨?_, DiscreteTopology.of_subset hU' hV⟩
-  let f : ↑Uᶜ → α := Subtype.val
-  have he := hU.closedEmbedding_subtype_val
-  simpa only [Subtype.image_preimage_val, inter_eq_self_of_subset_left hV,
-    isClosed_compl_iff] using he.isClosedMap _ (isClosed_discrete (f ⁻¹' Vᶜ))
-
-end codiscrete


### PR DESCRIPTION
This PR shows that, in any topological space, the sets whose complement is discrete and closed form a filter. (The only somewhat nontrivial step is to check that unions of discrete closed sets are discrete.)

This is intended as a preliminary for introducing meromorphic functions on opens in $\mathbb{C}$ (which are, by definition, holomorphic on a co-discrete set). 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
