### PR TITLE
[Merged by Bors] - chore: remove some Aesop calls in Category.Basic

### DIFF
--- a/Mathlib/CategoryTheory/Category/Basic.lean
+++ b/Mathlib/CategoryTheory/Category/Basic.lean
@@ -215,14 +215,12 @@ scoped infixr:80 " ≫= " => whisker_eq
 
 theorem eq_of_comp_left_eq {f g : X ⟶ Y} (w : ∀ {Z : C} (h : Y ⟶ Z), f ≫ h = g ≫ h) :
     f = g := by
-  convert w (𝟙 Y) <;>
-  aesop
+  convert w (𝟙 Y) <;> simp
 #align category_theory.eq_of_comp_left_eq CategoryTheory.eq_of_comp_left_eq
 
 theorem eq_of_comp_right_eq {f g : Y ⟶ Z} (w : ∀ {X : C} (h : X ⟶ Y), h ≫ f = h ≫ g) :
     f = g := by
-  convert w (𝟙 Y) <;>
-  aesop
+  convert w (𝟙 Y) <;> simp
 #align category_theory.eq_of_comp_right_eq CategoryTheory.eq_of_comp_right_eq
 
 theorem eq_of_comp_left_eq' (f g : X ⟶ Y)
@@ -237,12 +235,12 @@ theorem eq_of_comp_right_eq' (f g : Y ⟶ Z)
 
 theorem id_of_comp_left_id (f : X ⟶ X) (w : ∀ {Y : C} (g : X ⟶ Y), f ≫ g = g) : f = 𝟙 X := by
   convert w (𝟙 X)
-  aesop
+  simp
 #align category_theory.id_of_comp_left_id CategoryTheory.id_of_comp_left_id
 
 theorem id_of_comp_right_id (f : X ⟶ X) (w : ∀ {Y : C} (g : Y ⟶ X), g ≫ f = g) : f = 𝟙 X := by
   convert w (𝟙 X)
-  aesop
+  simp
 #align category_theory.id_of_comp_right_id CategoryTheory.id_of_comp_right_id
 
 theorem comp_ite {P : Prop} [Decidable P] {X Y Z : C} (f : X ⟶ Y) (g g' : Y ⟶ Z) :


### PR DESCRIPTION
This is in preparation for the next Aesop version, which will include a change to the handling of simp theorems. That change can affect the order in which simp lemmas are applied. Some Aesop calls in CategoryTheory.Category.Basic were sensitive to this ordering, so I've replaced them with simpler proofs.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
