### PR TITLE
[Merged by Bors] - fix: restore simp confluence for `qify [(h : n ∣ m)]`

### DIFF
--- a/Mathlib/Data/Int/CharZero.lean
+++ b/Mathlib/Data/Int/CharZero.lean
@@ -62,8 +62,8 @@ theorem cast_div_charZero {k : Type*} [DivisionRing k] [CharZero k] {m n : ℤ} 
 
 -- Necessary for confluence with `ofNat_ediv` and `cast_div_charZero`.
 @[simp, norm_cast]
-theorem cast_div_ofNat_charZero {k : Type*} [DivisionRing k] [CharZero k] {m n : ℕ} (n_dvd : n ∣ m) :
-    (((m : ℤ) / (n : ℤ) : ℤ) : k) = m / n := by
+theorem cast_div_ofNat_charZero {k : Type*} [DivisionRing k] [CharZero k] {m n : ℕ}
+    (n_dvd : n ∣ m) : (((m : ℤ) / (n : ℤ) : ℤ) : k) = m / n := by
   rw [cast_div_charZero (Int.ofNat_dvd.mpr n_dvd), cast_ofNat, cast_ofNat]
 
 end Int

--- a/Mathlib/Data/Int/CharZero.lean
+++ b/Mathlib/Data/Int/CharZero.lean
@@ -60,6 +60,11 @@ theorem cast_div_charZero {k : Type*} [DivisionRing k] [CharZero k] {m n : ℤ} 
   · exact cast_div n_dvd (cast_ne_zero.mpr hn)
 #align int.cast_div_char_zero Int.cast_div_charZero
 
+-- Necessary for confluence with `ofNat_ediv` (from `zify_simps`) and `cast_div_charZero`.
+@[simp, norm_cast]
+theorem cast_div_ofNat_charZero {k : Type*} [DivisionRing k] [CharZero k] {m n : ℕ} (n_dvd : n ∣ m) :
+    (((m : ℤ) / (n : ℤ) : ℤ) : k) = m / n := by rw [cast_div_charZero (Int.ofNat_dvd.mpr n_dvd), cast_ofNat, cast_ofNat]
+
 end Int
 
 theorem RingHom.injective_int {α : Type*} [NonAssocRing α] (f : ℤ →+* α) [CharZero α] :

--- a/Mathlib/Data/Int/CharZero.lean
+++ b/Mathlib/Data/Int/CharZero.lean
@@ -60,7 +60,7 @@ theorem cast_div_charZero {k : Type*} [DivisionRing k] [CharZero k] {m n : ℤ} 
   · exact cast_div n_dvd (cast_ne_zero.mpr hn)
 #align int.cast_div_char_zero Int.cast_div_charZero
 
--- Necessary for confluence with `ofNat_ediv` (from `zify_simps`) and `cast_div_charZero`.
+-- Necessary for confluence with `ofNat_ediv` and `cast_div_charZero`.
 @[simp, norm_cast]
 theorem cast_div_ofNat_charZero {k : Type*} [DivisionRing k] [CharZero k] {m n : ℕ} (n_dvd : n ∣ m) :
     (((m : ℤ) / (n : ℤ) : ℤ) : k) = m / n := by

--- a/Mathlib/Data/Int/CharZero.lean
+++ b/Mathlib/Data/Int/CharZero.lean
@@ -63,7 +63,8 @@ theorem cast_div_charZero {k : Type*} [DivisionRing k] [CharZero k] {m n : ℤ} 
 -- Necessary for confluence with `ofNat_ediv` (from `zify_simps`) and `cast_div_charZero`.
 @[simp, norm_cast]
 theorem cast_div_ofNat_charZero {k : Type*} [DivisionRing k] [CharZero k] {m n : ℕ} (n_dvd : n ∣ m) :
-    (((m : ℤ) / (n : ℤ) : ℤ) : k) = m / n := by rw [cast_div_charZero (Int.ofNat_dvd.mpr n_dvd), cast_ofNat, cast_ofNat]
+    (((m : ℤ) / (n : ℤ) : ℤ) : k) = m / n := by
+  rw [cast_div_charZero (Int.ofNat_dvd.mpr n_dvd), cast_ofNat, cast_ofNat]
 
 end Int
 

--- a/test/Qify.lean
+++ b/test/Qify.lean
@@ -17,3 +17,8 @@ example (a b c : ℕ) (h : a - b = c) (hab : b ≤ a) : a = c + b := by
 example (a b c : ℤ) (h : a / b = c) (hab : b ∣ a) (hb : b ≠ 0) : a = c * b := by
   qify [hab] at h hb ⊢
   exact (div_eq_iff hb).1 h
+
+-- Regression test for mathlib4#7480
+example (a b c : ℕ) (h : a / b = c) (hab : b ∣ a) (hb : b ≠ 0) : a = c * b := by
+  qify [hab] at h hb ⊢
+  exact (div_eq_iff hb).1 h


### PR DESCRIPTION
Fixes #7480 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
