### PR TITLE
[Merged by Bors] - feat: support `zify` on divisibility propositions

### DIFF
--- a/Mathlib/Tactic/Zify.lean
+++ b/Mathlib/Tactic/Zify.lean
@@ -95,3 +95,6 @@ def zifyProof (simpArgs : Option (Syntax.TSepArray `Lean.Parser.Tactic.simpStar 
 @[zify_simps] lemma nat_cast_lt (a b : ℕ) : a < b ↔ (a : ℤ) < (b : ℤ) := Int.ofNat_lt.symm
 @[zify_simps] lemma nat_cast_ne (a b : ℕ) : a ≠ b ↔ (a : ℤ) ≠ (b : ℤ) := by
   simp only [ne_eq, Int.cast_eq_cast_iff_Nat]
+@[zify_simps] lemma nat_cast_dvd (a b : ℕ) : a ∣ b ↔ (a : ℤ) ∣ (b : ℤ) := Int.ofNat_dvd.symm
+-- TODO: is it worth adding lemmas for Prime and Coprime as well?
+-- Doing so in this file would require adding imports.

--- a/test/Zify.lean
+++ b/test/Zify.lean
@@ -45,3 +45,8 @@ example (a b c : ℕ) (h : a + b ≠ c) : True := by
   zify at h
   guard_hyp h : (a + b : ℤ) ≠ c
   trivial
+
+example (a b c : ℕ) (h : a - b ∣ c) (h2 : b ≤ a) : True := by
+  zify [h2] at h
+  guard_hyp h : (a : ℤ) - b ∣ c
+  trivial


### PR DESCRIPTION
---
I don't personally have a use case for this but it seems harmless. I noticed this was missing when trying to convert a divisibility hypothesis into ℤ so I could use it with `qify` as a workaround to #7480.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
