### PR TITLE
[Merged by Bors] - refactor(NumberTheory/FLT): Define Fermat's Last Theorem for fixed exponent

### DIFF
--- a/Mathlib/NumberTheory/FLT/Basic.lean
+++ b/Mathlib/NumberTheory/FLT/Basic.lean
@@ -22,11 +22,11 @@ def FermatLastTheoremWith (α : Type*) [Semiring α] (n : ℕ) : Prop :=
   ∀ a b c : α, a ≠ 0 → b ≠ 0 → c ≠ 0 → a ^ n + b ^ n ≠ c ^ n
 
 /-- Statement of Fermat's Last Theorem for a given exponent. -/
-def FermatLastTheoremFor (n : ℕ) := FermatLastTheoremWith ℕ n
+def FermatLastTheoremFor (n : ℕ) : Prop := FermatLastTheoremWith ℕ n
 
 /-- Statement of Fermat's Last Theorem: `a ^ n + b ^ n = c ^ n` has no nontrivial integer solution
 when `n ≥ 3`. -/
-def FermatLastTheorem := ∀ n ≥ 3, FermatLastTheoremFor n
+def FermatLastTheorem : Prop := ∀ n ≥ 3, FermatLastTheoremFor n
 
 variable {α : Type*} [Semiring α] [NoZeroDivisors α] {m n : ℕ}
 

--- a/Mathlib/NumberTheory/FLT/Basic.lean
+++ b/Mathlib/NumberTheory/FLT/Basic.lean
@@ -21,9 +21,12 @@ open List
 def FermatLastTheoremWith (α : Type*) [Semiring α] (n : ℕ) : Prop :=
   ∀ a b c : α, a ≠ 0 → b ≠ 0 → c ≠ 0 → a ^ n + b ^ n ≠ c ^ n
 
+/-- Statement of Fermat's Last Theorem for a given exponent. -/
+def FermatLastTheoremFor (n : ℕ) := FermatLastTheoremWith ℕ n
+
 /-- Statement of Fermat's Last Theorem: `a ^ n + b ^ n = c ^ n` has no nontrivial integer solution
 when `n ≥ 3`. -/
-def FermatLastTheorem : Prop := ∀ n ≥ 3, FermatLastTheoremWith ℕ n
+def FermatLastTheorem := ∀ n ≥ 3, FermatLastTheoremFor n
 
 variable {α : Type*} [Semiring α] [NoZeroDivisors α] {m n : ℕ}
 
@@ -94,3 +97,12 @@ lemma fermatLastTheoremWith_nat_int_rat_tfae (n : ℕ) :
   · rintro h a b c
     exact_mod_cast h a b c
   tfae_finish
+
+lemma fermatLastTheoremFor_iff_nat {n : ℕ} : FermatLastTheoremFor n ↔ FermatLastTheoremWith ℕ n :=
+  Iff.rfl
+
+lemma fermatLastTheoremFor_iff_int {n : ℕ} : FermatLastTheoremFor n ↔ FermatLastTheoremWith ℤ n :=
+  (fermatLastTheoremWith_nat_int_rat_tfae n).out 0 1
+
+lemma fermatLastTheoremFor_iff_rat {n : ℕ} : FermatLastTheoremFor n ↔ FermatLastTheoremWith ℚ n :=
+  (fermatLastTheoremWith_nat_int_rat_tfae n).out 0 2

--- a/Mathlib/NumberTheory/FLT/Basic.lean
+++ b/Mathlib/NumberTheory/FLT/Basic.lean
@@ -28,6 +28,15 @@ def FermatLastTheoremFor (n : ℕ) : Prop := FermatLastTheoremWith ℕ n
 when `n ≥ 3`. -/
 def FermatLastTheorem : Prop := ∀ n ≥ 3, FermatLastTheoremFor n
 
+lemma fermatLastTheorem_zero : FermatLastTheoremFor 0 :=
+  fun _ _ _ _ _ _ ↦ by norm_num
+
+lemma not_fermatLastTheorem_one : ¬ FermatLastTheoremFor 1 :=
+  fun h ↦ h 1 1 2 (by norm_num) (by norm_num) (by norm_num) (by norm_num)
+
+lemma not_fermatLastTheorem_two : ¬ FermatLastTheoremFor 2 :=
+  fun h ↦ h 3 4 5 (by norm_num) (by norm_num) (by norm_num) (by norm_num)
+
 variable {α : Type*} [Semiring α] [NoZeroDivisors α] {m n : ℕ}
 
 lemma FermatLastTheoremWith.mono (hmn : m ∣ n) (hm : FermatLastTheoremWith α m) :
@@ -36,6 +45,10 @@ lemma FermatLastTheoremWith.mono (hmn : m ∣ n) (hm : FermatLastTheoremWith α 
   obtain ⟨k, rfl⟩ := hmn
   simp_rw [pow_mul']
   refine hm _ _ _ ?_ ?_ ?_ <;> exact pow_ne_zero _ ‹_›
+
+lemma FermatLastTheoremFor.mono (hmn : m ∣ n) (hm : FermatLastTheoremFor m) :
+    FermatLastTheoremFor n := by
+  exact FermatLastTheoremWith.mono hmn hm
 
 lemma fermatLastTheoremWith_nat_int_rat_tfae (n : ℕ) :
     TFAE [FermatLastTheoremWith ℕ n, FermatLastTheoremWith ℤ n, FermatLastTheoremWith ℚ n] := by

--- a/Mathlib/NumberTheory/FLT/Basic.lean
+++ b/Mathlib/NumberTheory/FLT/Basic.lean
@@ -28,13 +28,13 @@ def FermatLastTheoremFor (n : ℕ) : Prop := FermatLastTheoremWith ℕ n
 when `n ≥ 3`. -/
 def FermatLastTheorem : Prop := ∀ n ≥ 3, FermatLastTheoremFor n
 
-lemma fermatLastTheorem_zero : FermatLastTheoremFor 0 :=
+lemma fermatLastTheoremFor_zero : FermatLastTheoremFor 0 :=
   fun _ _ _ _ _ _ ↦ by norm_num
 
-lemma not_fermatLastTheorem_one : ¬ FermatLastTheoremFor 1 :=
+lemma not_fermatLastTheoremFor_one : ¬ FermatLastTheoremFor 1 :=
   fun h ↦ h 1 1 2 (by norm_num) (by norm_num) (by norm_num) (by norm_num)
 
-lemma not_fermatLastTheorem_two : ¬ FermatLastTheoremFor 2 :=
+lemma not_fermatLastTheoremFor_two : ¬ FermatLastTheoremFor 2 :=
   fun h ↦ h 3 4 5 (by norm_num) (by norm_num) (by norm_num) (by norm_num)
 
 variable {α : Type*} [Semiring α] [NoZeroDivisors α] {m n : ℕ}

--- a/Mathlib/NumberTheory/FLT/Four.lean
+++ b/Mathlib/NumberTheory/FLT/Four.lean
@@ -305,7 +305,8 @@ theorem not_fermat_42 {a b c : ℤ} (ha : a ≠ 0) (hb : b ≠ 0) : a ^ 4 + b ^ 
   apply Fermat42.not_minimal hf h2 hp
 #align not_fermat_42 not_fermat_42
 
-theorem fermatLastTheoremFour : FermatLastTheoremWith ℤ 4 := by
+theorem fermatLastTheoremFour : FermatLastTheoremFor 4 := by
+  rw [fermatLastTheoremFor_iff_int]
   intro a b c ha hb _ heq
   apply @not_fermat_42 _ _ (c ^ 2) ha hb
   rw [heq]; ring


### PR DESCRIPTION
This PR adds a definition of Fermat's Last Theorem for fixed exponent. The motivation for this is that `FermatLastTheoremWith ℕ n`, `FermatLastTheoremWith ℤ n`, and `FermatLastTheoremWith ℚ n` are all equivalent, so it would be nice to have a canonical name, rather than sometimes referring to one and sometimes referring to another.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
