### PR TITLE
[Merged by Bors] - feat: unreachableTactic support for `notation3`

### DIFF
--- a/Mathlib/Mathport/Notation.lean
+++ b/Mathlib/Mathport/Notation.lean
@@ -408,7 +408,7 @@ for the notation.
 This command can be used in mathlib4 but it has an uncertain future and was created primarily
 for backward compatibility.
 -/
-elab doc:(docComment)? attrs?:(Parser.Term.attributes)? attrKind:Term.attrKind
+elab (name := notation3) doc:(docComment)? attrs?:(Parser.Term.attributes)? attrKind:Term.attrKind
     "notation3" prec?:(precedence)? name?:(namedName)? prio?:(namedPrio)? pp?:(prettyPrintOpt)?
     ppSpace items:(notation3Item)+ " => " val:term : command => do
   -- We use raw `Name`s for variables. This maps variable names back to the
@@ -553,3 +553,5 @@ elab doc:(docComment)? attrs?:(Parser.Term.attributes)? attrKind:Term.attrKind
       logWarning s!"Could not generate matchers for a delaborator, so notation will not be pretty{
         ""} printed. Consider either adjusting the expansions or use{
         ""} `notation3 (prettyPrint := false)`."
+
+initialize Std.Linter.UnreachableTactic.addIgnoreTacticKind ``«notation3»

--- a/test/notation3.lean
+++ b/test/notation3.lean
@@ -83,3 +83,24 @@ def myId (x : α) := x
 notation3 "BAD " c "; " (x", "* => foldl (a b => b) c) " DAB" => myId x
 /-- info: myId 3 : ℕ -/
 #guard_msgs in #check BAD 1; 2, 3 DAB
+
+section
+/--
+warning: Could not generate matchers for a delaborator, so notation will not be pretty printed.
+Consider either adjusting the expansions or use `notation3 (prettyPrint := false)`.
+-/
+#guard_msgs in local notation3 "#" n => Fin.mk n (by decide)
+end
+
+section
+local notation3 (prettyPrint := false) "#" n => Fin.mk n (by decide)
+
+example : Fin 5 := #1
+
+/--
+error: failed to reduce to 'true'
+  false
+-/
+#guard_msgs in example : Fin 5 := #6
+
+end


### PR DESCRIPTION
This is needed to avoid a `unreachableTactic` lint warning when using `by tac` inside `notation3`. (The same thing is built in for the other `notation` variants.)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
