### PR TITLE
[Merged by Bors] - chore: rename CanonicallyOrderedAddMonoid to ..AddCommMonoid

### DIFF
--- a/Mathlib/Algebra/Associated.lean
+++ b/Mathlib/Algebra/Associated.lean
@@ -1156,7 +1156,7 @@ theorem one_or_eq_of_le_of_prime : ∀ p m : Associates α, Prime p → m ≤ p 
           exact Or.inl <| bot_unique <| Associates.le_of_mul_le_mul_left d m 1 ‹d ≠ 0› this
 #align associates.one_or_eq_of_le_of_prime Associates.one_or_eq_of_le_of_prime
 
-instance : CanonicallyOrderedMonoid (Associates α) where
+instance : CanonicallyOrderedCommMonoid (Associates α) where
     exists_mul_of_le := fun h => h
     le_self_mul := fun _ b => ⟨b, rfl⟩
     bot_le := fun _ => one_le

--- a/Mathlib/Algebra/BigOperators/Basic.lean
+++ b/Mathlib/Algebra/BigOperators/Basic.lean
@@ -1425,7 +1425,7 @@ theorem eq_prod_range_div' {M : Type*} [CommGroup M] (f : ℕ → M) (n : ℕ) :
 reduces to the difference of the last and first terms
 when the function we are summing is monotone.
 -/
-theorem sum_range_tsub [CanonicallyOrderedAddMonoid α] [Sub α] [OrderedSub α]
+theorem sum_range_tsub [CanonicallyOrderedAddCommMonoid α] [Sub α] [OrderedSub α]
     [ContravariantClass α α (· + ·) (· ≤ ·)] {f : ℕ → α} (h : Monotone f) (n : ℕ) :
     ∑ i in range n, (f (i + 1) - f i) = f n - f 0 := by
   apply sum_range_induction

--- a/Mathlib/Algebra/BigOperators/Multiset/Basic.lean
+++ b/Mathlib/Algebra/BigOperators/Multiset/Basic.lean
@@ -448,7 +448,7 @@ theorem prod_eq_one [CommMonoid α] {m : Multiset α} (h : ∀ x ∈ m, x = (1 :
 #align multiset.sum_eq_zero Multiset.sum_eq_zero
 
 @[to_additive]
-theorem le_prod_of_mem [CanonicallyOrderedMonoid α] {m : Multiset α} {a : α} (h : a ∈ m) :
+theorem le_prod_of_mem [CanonicallyOrderedCommMonoid α] {m : Multiset α} {a : α} (h : a ∈ m) :
     a ≤ m.prod := by
   obtain ⟨m', rfl⟩ := exists_cons_of_mem h
   rw [prod_cons]

--- a/Mathlib/Algebra/BigOperators/Multiset/Lemmas.lean
+++ b/Mathlib/Algebra/BigOperators/Multiset/Lemmas.lean
@@ -20,7 +20,7 @@ theorem dvd_prod [CommMonoid α] {s : Multiset α} {a : α} : a ∈ s → a ∣ 
 #align multiset.dvd_prod Multiset.dvd_prod
 
 @[to_additive]
-theorem prod_eq_one_iff [CanonicallyOrderedMonoid α] {m : Multiset α} :
+theorem prod_eq_one_iff [CanonicallyOrderedCommMonoid α] {m : Multiset α} :
     m.prod = 1 ↔ ∀ x ∈ m, x = (1 : α) :=
   Quotient.inductionOn m fun l => by simpa using List.prod_eq_one_iff l
 #align multiset.prod_eq_one_iff Multiset.prod_eq_one_iff

--- a/Mathlib/Algebra/BigOperators/Order.lean
+++ b/Mathlib/Algebra/BigOperators/Order.lean
@@ -390,9 +390,9 @@ theorem card_le_card_biUnion_add_one {s : Finset ι} {f : ι → Finset α} (hf 
 
 end DoubleCounting
 
-section CanonicallyOrderedMonoid
+section CanonicallyOrderedCommMonoid
 
-variable [CanonicallyOrderedMonoid M] {f : ι → M} {s t : Finset ι}
+variable [CanonicallyOrderedCommMonoid M] {f : ι → M} {s t : Finset ι}
 
 @[to_additive (attr := simp) sum_eq_zero_iff]
 theorem prod_eq_one_iff' : ∏ x in s, f x = 1 ↔ ∀ x ∈ s, f x = 1 :=
@@ -427,7 +427,7 @@ theorem prod_le_prod_of_ne_one' (h : ∀ x ∈ s, f x ≠ 1 → x ∈ t) :
 #align finset.prod_le_prod_of_ne_one' Finset.prod_le_prod_of_ne_one'
 #align finset.sum_le_sum_of_ne_zero Finset.sum_le_sum_of_ne_zero
 
-end CanonicallyOrderedMonoid
+end CanonicallyOrderedCommMonoid
 
 section OrderedCancelCommMonoid
 

--- a/Mathlib/Algebra/DirectSum/Internal.lean
+++ b/Mathlib/Algebra/DirectSum/Internal.lean
@@ -218,11 +218,11 @@ theorem coe_mul_of_apply_add [AddRightCancelMonoid ι] [SetLike.GradedMonoid A] 
 
 end coe
 
-section CanonicallyOrderedAddMonoid
+section CanonicallyOrderedAddCommMonoid
 
 variable [Semiring R] [SetLike σ R] [AddSubmonoidClass σ R] (A : ι → σ)
 
-variable [CanonicallyOrderedAddMonoid ι] [SetLike.GradedMonoid A]
+variable [CanonicallyOrderedAddCommMonoid ι] [SetLike.GradedMonoid A]
 
 theorem coe_of_mul_apply_of_not_le {i : ι} (r : A i) (r' : ⨁ i, A i) (n : ι) (h : ¬i ≤ n) :
     ((of (fun i => A i) i r * r') n : R) = 0 := by
@@ -251,7 +251,7 @@ theorem coe_mul_of_apply_of_not_le (r : ⨁ i, A i) {i : ι} (r' : A i) (n : ι)
 variable [Sub ι] [OrderedSub ι] [ContravariantClass ι ι (· + ·) (· ≤ ·)]
 
 /- The following two lemmas only require the same hypotheses as `eq_tsub_iff_add_eq_of_le`, but we
-  state them for `CanonicallyOrderedAddMonoid` + the above three typeclasses for convenience. -/
+  state them for `CanonicallyOrderedAddCommMonoid` + the above three typeclasses for convenience. -/
 theorem coe_mul_of_apply_of_le (r : ⨁ i, A i) {i : ι} (r' : A i) (n : ι) (h : i ≤ n) :
     ((r * of (fun i => A i) i r') n : R) = r (n - i) * r' :=
   coe_mul_of_apply_aux _ _ _ fun _x => (eq_tsub_iff_add_eq_of_le h).symm
@@ -274,7 +274,7 @@ theorem coe_of_mul_apply {i : ι} (r : A i) (r' : ⨁ i, A i) (n : ι) [Decidabl
   exacts [coe_of_mul_apply_of_le _ _ _ n h, coe_of_mul_apply_of_not_le _ _ _ n h]
 #align direct_sum.coe_of_mul_apply DirectSum.coe_of_mul_apply
 
-end CanonicallyOrderedAddMonoid
+end CanonicallyOrderedAddCommMonoid
 
 end DirectSum
 

--- a/Mathlib/Algebra/IndicatorFunction.lean
+++ b/Mathlib/Algebra/IndicatorFunction.lean
@@ -893,9 +893,9 @@ theorem mulIndicator_iUnion_apply {ι : Sort*} {M : Type*} [CompleteLattice M] [
 
 end Order
 
-section CanonicallyOrderedMonoid
+section CanonicallyOrderedCommMonoid
 
-variable [CanonicallyOrderedMonoid M]
+variable [CanonicallyOrderedCommMonoid M]
 
 @[to_additive]
 theorem mulIndicator_le_self (s : Set α) (f : α → M) : mulIndicator s f ≤ f :=
@@ -917,7 +917,7 @@ theorem mulIndicator_le {s : Set α} {f g : α → M} (hfg : ∀ a ∈ s, f a �
 #align set.mul_indicator_le Set.mulIndicator_le
 #align set.indicator_le Set.indicator_le
 
-end CanonicallyOrderedMonoid
+end CanonicallyOrderedCommMonoid
 
 theorem indicator_le_indicator_nonneg {β} [LinearOrder β] [Zero β] (s : Set α) (f : α → β) :
     s.indicator f ≤ { x | 0 ≤ f x }.indicator f := by

--- a/Mathlib/Algebra/Lie/Subalgebra.lean
+++ b/Mathlib/Algebra/Lie/Subalgebra.lean
@@ -535,7 +535,7 @@ instance addCommMonoid : AddCommMonoid (LieSubalgebra R L)
   add_zero _ := sup_bot_eq
   add_comm _ _ := sup_comm
 
-instance : CanonicallyOrderedAddMonoid (LieSubalgebra R L) :=
+instance : CanonicallyOrderedAddCommMonoid (LieSubalgebra R L) :=
   { LieSubalgebra.addCommMonoid,
     LieSubalgebra.completeLattice with
     add_le_add_left := fun _a _b ↦ sup_le_sup_left

--- a/Mathlib/Algebra/Module/Submodule/Pointwise.lean
+++ b/Mathlib/Algebra/Module/Submodule/Pointwise.lean
@@ -172,7 +172,7 @@ theorem zero_eq_bot : (0 : Submodule R M) = ⊥ :=
   rfl
 #align submodule.zero_eq_bot Submodule.zero_eq_bot
 
-instance : CanonicallyOrderedAddMonoid (Submodule R M) :=
+instance : CanonicallyOrderedAddCommMonoid (Submodule R M) :=
   { Submodule.pointwiseAddCommMonoid,
     Submodule.completeLattice with
     add_le_add_left := fun _a _b => sup_le_sup_left

--- a/Mathlib/Algebra/Order/Field/Canonical/Defs.lean
+++ b/Mathlib/Algebra/Order/Field/Canonical/Defs.lean
@@ -30,7 +30,7 @@ instance (priority := 100) CanonicallyLinearOrderedSemifield.toLinearOrderedComm
 #align canonically_linear_ordered_semifield.to_linear_ordered_comm_group_with_zero CanonicallyLinearOrderedSemifield.toLinearOrderedCommGroupWithZero
 
 -- See note [lower instance priority]
-instance (priority := 100) CanonicallyLinearOrderedSemifield.toCanonicallyLinearOrderedAddMonoid
-    [CanonicallyLinearOrderedSemifield α] : CanonicallyLinearOrderedAddMonoid α :=
+instance (priority := 100) CanonicallyLinearOrderedSemifield.toCanonicallyLinearOrderedAddCommMonoid
+    [CanonicallyLinearOrderedSemifield α] : CanonicallyLinearOrderedAddCommMonoid α :=
   { ‹CanonicallyLinearOrderedSemifield α› with }
-#align canonically_linear_ordered_semifield.to_canonically_linear_ordered_add_monoid CanonicallyLinearOrderedSemifield.toCanonicallyLinearOrderedAddMonoid
+#align canonically_linear_ordered_semifield.to_canonically_linear_ordered_add_monoid CanonicallyLinearOrderedSemifield.toCanonicallyLinearOrderedAddCommMonoid

--- a/Mathlib/Algebra/Order/Kleene.lean
+++ b/Mathlib/Algebra/Order/Kleene.lean
@@ -167,15 +167,15 @@ theorem add_le (ha : a ≤ c) (hb : b ≤ c) : a + b ≤ c :=
 #align add_le add_le
 
 -- See note [lower instance priority]
-instance (priority := 100) IdemSemiring.toCanonicallyOrderedAddMonoid :
-    CanonicallyOrderedAddMonoid α :=
+instance (priority := 100) IdemSemiring.toCanonicallyOrderedAddCommMonoid :
+    CanonicallyOrderedAddCommMonoid α :=
   { ‹IdemSemiring α› with
     add_le_add_left := fun a b hbc c ↦ by
       simp_rw [add_eq_sup]
       exact sup_le_sup_left hbc _
     exists_add_of_le := fun h ↦ ⟨_, h.add_eq_right.symm⟩
     le_self_add := fun a b ↦ add_eq_right_iff_le.1 <| by rw [← add_assoc, add_idem] }
-#align idem_semiring.to_canonically_ordered_add_monoid IdemSemiring.toCanonicallyOrderedAddMonoid
+#align idem_semiring.to_canonically_ordered_add_monoid IdemSemiring.toCanonicallyOrderedAddCommMonoid
 
 -- See note [lower instance priority]
 instance (priority := 100) IdemSemiring.toCovariantClass_mul_le :

--- a/Mathlib/Algebra/Order/Monoid/Canonical/Defs.lean
+++ b/Mathlib/Algebra/Order/Monoid/Canonical/Defs.lean
@@ -319,9 +319,9 @@ theorem of_gt {M} [CanonicallyOrderedAddCommMonoid M] {x y : M} (h : x < y) : Ne
 -- 1 < p is still an often-used `Fact`, due to `Nat.Prime` implying it, and it implying `Nontrivial`
 -- on `ZMod`'s ring structure. We cannot just set this to be any `x < y`, else that becomes a
 -- metavariable and it will hugely slow down typeclass inference.
-instance (priority := 10) of_gt' [CanonicallyOrderedAddCommMonoid M] [One M] {y : M} [Fact (1 < y)] :
+instance (priority := 10) of_gt' [CanonicallyOrderedAddCommMonoid M] [One M] {y : M}
   -- Porting note: Fact.out has different type signature from mathlib3
-  NeZero y := of_gt <| @Fact.out (1 < y) _
+  [Fact (1 < y)] : NeZero y := of_gt <| @Fact.out (1 < y) _
 #align ne_zero.of_gt' NeZero.of_gt'
 
 set_option linter.deprecated false in
@@ -340,7 +340,8 @@ class CanonicallyLinearOrderedAddCommMonoid (α : Type*)
 /-- A canonically linear-ordered monoid is a canonically ordered monoid
     whose ordering is a linear order. -/
 @[to_additive]
-class CanonicallyLinearOrderedCommMonoid (α : Type*) extends CanonicallyOrderedCommMonoid α, LinearOrder α
+class CanonicallyLinearOrderedCommMonoid (α : Type*) extends CanonicallyOrderedCommMonoid α,
+  LinearOrder α
 #align canonically_linear_ordered_monoid CanonicallyLinearOrderedCommMonoid
 
 section CanonicallyLinearOrderedCommMonoid

--- a/Mathlib/Algebra/Order/Monoid/Canonical/Defs.lean
+++ b/Mathlib/Algebra/Order/Monoid/Canonical/Defs.lean
@@ -333,26 +333,26 @@ end NeZero
 
 /-- A canonically linear-ordered additive monoid is a canonically ordered additive monoid
     whose ordering is a linear order. -/
-class CanonicallyLinearOrderedAddMonoid (α : Type*)
+class CanonicallyLinearOrderedAddCommMonoid (α : Type*)
   extends CanonicallyOrderedAddCommMonoid α, LinearOrder α
-#align canonically_linear_ordered_add_monoid CanonicallyLinearOrderedAddMonoid
+#align canonically_linear_ordered_add_monoid CanonicallyLinearOrderedAddCommMonoid
 
 /-- A canonically linear-ordered monoid is a canonically ordered monoid
     whose ordering is a linear order. -/
 @[to_additive]
-class CanonicallyLinearOrderedMonoid (α : Type*) extends CanonicallyOrderedCommMonoid α, LinearOrder α
-#align canonically_linear_ordered_monoid CanonicallyLinearOrderedMonoid
+class CanonicallyLinearOrderedCommMonoid (α : Type*) extends CanonicallyOrderedCommMonoid α, LinearOrder α
+#align canonically_linear_ordered_monoid CanonicallyLinearOrderedCommMonoid
 
-section CanonicallyLinearOrderedMonoid
+section CanonicallyLinearOrderedCommMonoid
 
-variable [CanonicallyLinearOrderedMonoid α]
+variable [CanonicallyLinearOrderedCommMonoid α]
 
 -- see Note [lower instance priority]
 @[to_additive]
-instance (priority := 100) CanonicallyLinearOrderedMonoid.semilatticeSup : SemilatticeSup α :=
+instance (priority := 100) CanonicallyLinearOrderedCommMonoid.semilatticeSup : SemilatticeSup α :=
   { LinearOrder.toLattice with }
-#align canonically_linear_ordered_monoid.semilattice_sup CanonicallyLinearOrderedMonoid.semilatticeSup
-#align canonically_linear_ordered_add_monoid.semilattice_sup CanonicallyLinearOrderedAddMonoid.semilatticeSup
+#align canonically_linear_ordered_monoid.semilattice_sup CanonicallyLinearOrderedCommMonoid.semilatticeSup
+#align canonically_linear_ordered_add_monoid.semilattice_sup CanonicallyLinearOrderedAddCommMonoid.semilatticeSup
 
 @[to_additive]
 theorem min_mul_distrib (a b c : α) : min a (b * c) = min a (min a b * min a c) := by
@@ -392,4 +392,4 @@ theorem bot_eq_one' : (⊥ : α) = 1 :=
 #align bot_eq_one' bot_eq_one'
 #align bot_eq_zero' bot_eq_zero'
 
-end CanonicallyLinearOrderedMonoid
+end CanonicallyLinearOrderedCommMonoid

--- a/Mathlib/Algebra/Order/Monoid/Canonical/Defs.lean
+++ b/Mathlib/Algebra/Order/Monoid/Canonical/Defs.lean
@@ -23,7 +23,7 @@ variable {α : Type u}
 
 /-- An `OrderedCommMonoid` with one-sided 'division' in the sense that
 if `a ≤ b`, there is some `c` for which `a * c = b`. This is a weaker version
-of the condition on canonical orderings defined by `CanonicallyOrderedMonoid`. -/
+of the condition on canonical orderings defined by `CanonicallyOrderedCommMonoid`. -/
 class ExistsMulOfLE (α : Type u) [Mul α] [LE α] : Prop where
   /-- For `a ≤ b`, `a` left divides `b` -/
   exists_mul_of_le : ∀ {a b : α}, a ≤ b → ∃ c : α, b = a * c
@@ -31,7 +31,7 @@ class ExistsMulOfLE (α : Type u) [Mul α] [LE α] : Prop where
 
 /-- An `OrderedAddCommMonoid` with one-sided 'subtraction' in the sense that
 if `a ≤ b`, then there is some `c` for which `a + c = b`. This is a weaker version
-of the condition on canonical orderings defined by `CanonicallyOrderedAddMonoid`. -/
+of the condition on canonical orderings defined by `CanonicallyOrderedAddCommMonoid`. -/
 class ExistsAddOfLE (α : Type u) [Add α] [LE α] : Prop where
   /-- For `a ≤ b`, there is a `c` so `b = a + c`. -/
   exists_add_of_le : ∀ {a b : α}, a ≤ b → ∃ c : α, b = a + c
@@ -97,21 +97,21 @@ end ExistsMulOfLE
   which is to say, `a ≤ b` iff there exists `c` with `b = a + c`.
   This is satisfied by the natural numbers, for example, but not
   the integers or other nontrivial `OrderedAddCommGroup`s. -/
-class CanonicallyOrderedAddMonoid (α : Type*) extends OrderedAddCommMonoid α, Bot α where
+class CanonicallyOrderedAddCommMonoid (α : Type*) extends OrderedAddCommMonoid α, Bot α where
   /-- `⊥` is the least element -/
   protected bot_le : ∀ x : α, ⊥ ≤ x
   /-- For `a ≤ b`, there is a `c` so `b = a + c`. -/
   protected exists_add_of_le : ∀ {a b : α}, a ≤ b → ∃ c, b = a + c
   /-- For any `a` and `b`, `a ≤ a + b` -/
   protected le_self_add : ∀ a b : α, a ≤ a + b
-#align canonically_ordered_add_monoid CanonicallyOrderedAddMonoid
+#align canonically_ordered_add_monoid CanonicallyOrderedAddCommMonoid
 
 
 -- see Note [lower instance priority]
-instance (priority := 100) CanonicallyOrderedAddMonoid.toOrderBot (α : Type u)
-    [h : CanonicallyOrderedAddMonoid α] : OrderBot α :=
+instance (priority := 100) CanonicallyOrderedAddCommMonoid.toOrderBot (α : Type u)
+    [h : CanonicallyOrderedAddCommMonoid α] : OrderBot α :=
   { h with }
-#align canonically_ordered_add_monoid.to_order_bot CanonicallyOrderedAddMonoid.toOrderBot
+#align canonically_ordered_add_monoid.to_order_bot CanonicallyOrderedAddCommMonoid.toOrderBot
 
 /-- A canonically ordered monoid is an ordered commutative monoid
   in which the ordering coincides with the divisibility relation,
@@ -123,37 +123,37 @@ instance (priority := 100) CanonicallyOrderedAddMonoid.toOrderBot (α : Type u)
   be more natural that collections of all things ≥ 1).
 -/
 @[to_additive]
-class CanonicallyOrderedMonoid (α : Type*) extends OrderedCommMonoid α, Bot α where
+class CanonicallyOrderedCommMonoid (α : Type*) extends OrderedCommMonoid α, Bot α where
   /-- `⊥` is the least element -/
   protected bot_le : ∀ x : α, ⊥ ≤ x
   /-- For `a ≤ b`, there is a `c` so `b = a * c`. -/
   protected exists_mul_of_le : ∀ {a b : α}, a ≤ b → ∃ c, b = a * c
   /-- For any `a` and `b`, `a ≤ a * b` -/
   protected le_self_mul : ∀ a b : α, a ≤ a * b
-#align canonically_ordered_monoid CanonicallyOrderedMonoid
+#align canonically_ordered_monoid CanonicallyOrderedCommMonoid
 
 -- see Note [lower instance priority]
 @[to_additive existing]
-instance (priority := 100) CanonicallyOrderedMonoid.toOrderBot (α : Type u)
-    [h : CanonicallyOrderedMonoid α] : OrderBot α :=
+instance (priority := 100) CanonicallyOrderedCommMonoid.toOrderBot (α : Type u)
+    [h : CanonicallyOrderedCommMonoid α] : OrderBot α :=
   { h with }
-#align canonically_ordered_monoid.to_order_bot CanonicallyOrderedMonoid.toOrderBot
+#align canonically_ordered_monoid.to_order_bot CanonicallyOrderedCommMonoid.toOrderBot
 
 -- see Note [lower instance priority]
 @[to_additive]
-instance (priority := 100) CanonicallyOrderedMonoid.existsMulOfLE (α : Type u)
-    [h : CanonicallyOrderedMonoid α] : ExistsMulOfLE α :=
+instance (priority := 100) CanonicallyOrderedCommMonoid.existsMulOfLE (α : Type u)
+    [h : CanonicallyOrderedCommMonoid α] : ExistsMulOfLE α :=
   { h with }
-#align canonically_ordered_monoid.has_exists_mul_of_le CanonicallyOrderedMonoid.existsMulOfLE
-#align canonically_ordered_add_monoid.has_exists_add_of_le CanonicallyOrderedAddMonoid.existsAddOfLE
+#align canonically_ordered_monoid.has_exists_mul_of_le CanonicallyOrderedCommMonoid.existsMulOfLE
+#align canonically_ordered_add_monoid.has_exists_add_of_le CanonicallyOrderedAddCommMonoid.existsAddOfLE
 
-section CanonicallyOrderedMonoid
+section CanonicallyOrderedCommMonoid
 
-variable [CanonicallyOrderedMonoid α] {a b c d : α}
+variable [CanonicallyOrderedCommMonoid α] {a b c d : α}
 
 @[to_additive]
 theorem le_self_mul : a ≤ a * c :=
-  CanonicallyOrderedMonoid.le_self_mul _ _
+  CanonicallyOrderedCommMonoid.le_self_mul _ _
 #align le_self_mul le_self_mul
 #align le_self_add le_self_add
 
@@ -227,7 +227,7 @@ theorem bot_eq_one : (⊥ : α) = 1 :=
 #align bot_eq_zero bot_eq_zero
 
 --TODO: This is a special case of `mul_eq_one`. We need the instance
--- `CanonicallyOrderedMonoid α → Unique αˣ`
+-- `CanonicallyOrderedCommMonoid α → Unique αˣ`
 @[to_additive (attr := simp)]
 theorem mul_eq_one_iff : a * b = 1 ↔ a = 1 ∧ b = 1 :=
   mul_eq_one_iff' (one_le _) (one_le _)
@@ -300,32 +300,32 @@ theorem lt_iff_exists_mul [CovariantClass α α (· * ·) (· < ·)] : a < b ↔
 #align lt_iff_exists_mul lt_iff_exists_mul
 #align lt_iff_exists_add lt_iff_exists_add
 
-end CanonicallyOrderedMonoid
+end CanonicallyOrderedCommMonoid
 
-theorem pos_of_gt {M : Type*} [CanonicallyOrderedAddMonoid M] {n m : M} (h : n < m) : 0 < m :=
+theorem pos_of_gt {M : Type*} [CanonicallyOrderedAddCommMonoid M] {n m : M} (h : n < m) : 0 < m :=
   lt_of_le_of_lt (zero_le _) h
 #align pos_of_gt pos_of_gt
 
 namespace NeZero
 
-theorem pos {M} (a : M) [CanonicallyOrderedAddMonoid M] [NeZero a] : 0 < a :=
+theorem pos {M} (a : M) [CanonicallyOrderedAddCommMonoid M] [NeZero a] : 0 < a :=
   (zero_le a).lt_of_ne <| NeZero.out.symm
 #align ne_zero.pos NeZero.pos
 
-theorem of_gt {M} [CanonicallyOrderedAddMonoid M] {x y : M} (h : x < y) : NeZero y :=
+theorem of_gt {M} [CanonicallyOrderedAddCommMonoid M] {x y : M} (h : x < y) : NeZero y :=
   of_pos <| pos_of_gt h
 #align ne_zero.of_gt NeZero.of_gt
 
 -- 1 < p is still an often-used `Fact`, due to `Nat.Prime` implying it, and it implying `Nontrivial`
 -- on `ZMod`'s ring structure. We cannot just set this to be any `x < y`, else that becomes a
 -- metavariable and it will hugely slow down typeclass inference.
-instance (priority := 10) of_gt' [CanonicallyOrderedAddMonoid M] [One M] {y : M} [Fact (1 < y)] :
+instance (priority := 10) of_gt' [CanonicallyOrderedAddCommMonoid M] [One M] {y : M} [Fact (1 < y)] :
   -- Porting note: Fact.out has different type signature from mathlib3
   NeZero y := of_gt <| @Fact.out (1 < y) _
 #align ne_zero.of_gt' NeZero.of_gt'
 
 set_option linter.deprecated false in
-instance bit0 {M} [CanonicallyOrderedAddMonoid M] {x : M} [NeZero x] : NeZero (bit0 x) :=
+instance bit0 {M} [CanonicallyOrderedAddCommMonoid M] {x : M} [NeZero x] : NeZero (bit0 x) :=
   of_pos <| bit0_pos <| NeZero.pos x
 #align ne_zero.bit0 NeZero.bit0
 
@@ -334,13 +334,13 @@ end NeZero
 /-- A canonically linear-ordered additive monoid is a canonically ordered additive monoid
     whose ordering is a linear order. -/
 class CanonicallyLinearOrderedAddMonoid (α : Type*)
-  extends CanonicallyOrderedAddMonoid α, LinearOrder α
+  extends CanonicallyOrderedAddCommMonoid α, LinearOrder α
 #align canonically_linear_ordered_add_monoid CanonicallyLinearOrderedAddMonoid
 
 /-- A canonically linear-ordered monoid is a canonically ordered monoid
     whose ordering is a linear order. -/
 @[to_additive]
-class CanonicallyLinearOrderedMonoid (α : Type*) extends CanonicallyOrderedMonoid α, LinearOrder α
+class CanonicallyLinearOrderedMonoid (α : Type*) extends CanonicallyOrderedCommMonoid α, LinearOrder α
 #align canonically_linear_ordered_monoid CanonicallyLinearOrderedMonoid
 
 section CanonicallyLinearOrderedMonoid

--- a/Mathlib/Algebra/Order/Monoid/Prod.lean
+++ b/Mathlib/Algebra/Order/Monoid/Prod.lean
@@ -36,8 +36,8 @@ instance [LE α] [LE β] [Mul α] [Mul β] [ExistsMulOfLE α] [ExistsMulOfLE β]
     ⟨(c, d), ext hc hd⟩⟩
 
 @[to_additive]
-instance [CanonicallyOrderedMonoid α] [CanonicallyOrderedMonoid β] :
-    CanonicallyOrderedMonoid (α × β) :=
+instance [CanonicallyOrderedCommMonoid α] [CanonicallyOrderedCommMonoid β] :
+    CanonicallyOrderedCommMonoid (α × β) :=
   { (inferInstance : OrderedCommMonoid _), (inferInstance : OrderBot _),
     (inferInstance : ExistsMulOfLE _) with
       le_self_mul := fun _ _ ↦ ⟨le_self_mul, le_self_mul⟩ }

--- a/Mathlib/Algebra/Order/Monoid/TypeTags.lean
+++ b/Mathlib/Algebra/Order/Monoid/TypeTags.lean
@@ -106,11 +106,11 @@ instance Additive.canonicallyOrderedAddCommMonoid [CanonicallyOrderedCommMonoid 
   { Additive.orderedAddCommMonoid, Additive.orderBot, Additive.existsAddOfLe with
     le_self_add := @le_self_mul α _ }
 
-instance Multiplicative.canonicallyLinearOrderedMonoid [CanonicallyLinearOrderedAddMonoid α] :
-    CanonicallyLinearOrderedMonoid (Multiplicative α) :=
+instance Multiplicative.canonicallyLinearOrderedCommMonoid [CanonicallyLinearOrderedAddCommMonoid α] :
+    CanonicallyLinearOrderedCommMonoid (Multiplicative α) :=
   { Multiplicative.canonicallyOrderedCommMonoid, Multiplicative.linearOrder with }
 
-instance [CanonicallyLinearOrderedMonoid α] : CanonicallyLinearOrderedAddMonoid (Additive α) :=
+instance [CanonicallyLinearOrderedCommMonoid α] : CanonicallyLinearOrderedAddCommMonoid (Additive α) :=
   { Additive.canonicallyOrderedAddCommMonoid, Additive.linearOrder with }
 
 namespace Additive

--- a/Mathlib/Algebra/Order/Monoid/TypeTags.lean
+++ b/Mathlib/Algebra/Order/Monoid/TypeTags.lean
@@ -96,22 +96,22 @@ instance Multiplicative.existsMulOfLe [Add α] [LE α] [ExistsAddOfLE α] :
 instance Additive.existsAddOfLe [Mul α] [LE α] [ExistsMulOfLE α] : ExistsAddOfLE (Additive α) :=
   ⟨@exists_mul_of_le α _ _ _⟩
 
-instance Multiplicative.canonicallyOrderedMonoid [CanonicallyOrderedAddMonoid α] :
-    CanonicallyOrderedMonoid (Multiplicative α) :=
+instance Multiplicative.CanonicallyOrderedCommMonoid [CanonicallyOrderedAddCommMonoid α] :
+    CanonicallyOrderedCommMonoid (Multiplicative α) :=
   { Multiplicative.orderedCommMonoid, Multiplicative.orderBot,
     Multiplicative.existsMulOfLe with le_self_mul := @le_self_add α _ }
 
-instance Additive.canonicallyOrderedAddMonoid [CanonicallyOrderedMonoid α] :
-    CanonicallyOrderedAddMonoid (Additive α) :=
+instance Additive.CanonicallyOrderedAddCommMonoid [CanonicallyOrderedCommMonoid α] :
+    CanonicallyOrderedAddCommMonoid (Additive α) :=
   { Additive.orderedAddCommMonoid, Additive.orderBot, Additive.existsAddOfLe with
     le_self_add := @le_self_mul α _ }
 
 instance Multiplicative.canonicallyLinearOrderedMonoid [CanonicallyLinearOrderedAddMonoid α] :
     CanonicallyLinearOrderedMonoid (Multiplicative α) :=
-  { Multiplicative.canonicallyOrderedMonoid, Multiplicative.linearOrder with }
+  { Multiplicative.CanonicallyOrderedCommMonoid, Multiplicative.linearOrder with }
 
 instance [CanonicallyLinearOrderedMonoid α] : CanonicallyLinearOrderedAddMonoid (Additive α) :=
-  { Additive.canonicallyOrderedAddMonoid, Additive.linearOrder with }
+  { Additive.CanonicallyOrderedAddCommMonoid, Additive.linearOrder with }
 
 namespace Additive
 

--- a/Mathlib/Algebra/Order/Monoid/TypeTags.lean
+++ b/Mathlib/Algebra/Order/Monoid/TypeTags.lean
@@ -106,11 +106,13 @@ instance Additive.canonicallyOrderedAddCommMonoid [CanonicallyOrderedCommMonoid 
   { Additive.orderedAddCommMonoid, Additive.orderBot, Additive.existsAddOfLe with
     le_self_add := @le_self_mul α _ }
 
-instance Multiplicative.canonicallyLinearOrderedCommMonoid [CanonicallyLinearOrderedAddCommMonoid α] :
+instance Multiplicative.canonicallyLinearOrderedCommMonoid
+    [CanonicallyLinearOrderedAddCommMonoid α] :
     CanonicallyLinearOrderedCommMonoid (Multiplicative α) :=
   { Multiplicative.canonicallyOrderedCommMonoid, Multiplicative.linearOrder with }
 
-instance [CanonicallyLinearOrderedCommMonoid α] : CanonicallyLinearOrderedAddCommMonoid (Additive α) :=
+instance [CanonicallyLinearOrderedCommMonoid α] :
+    CanonicallyLinearOrderedAddCommMonoid (Additive α) :=
   { Additive.canonicallyOrderedAddCommMonoid, Additive.linearOrder with }
 
 namespace Additive

--- a/Mathlib/Algebra/Order/Monoid/TypeTags.lean
+++ b/Mathlib/Algebra/Order/Monoid/TypeTags.lean
@@ -96,22 +96,22 @@ instance Multiplicative.existsMulOfLe [Add α] [LE α] [ExistsAddOfLE α] :
 instance Additive.existsAddOfLe [Mul α] [LE α] [ExistsMulOfLE α] : ExistsAddOfLE (Additive α) :=
   ⟨@exists_mul_of_le α _ _ _⟩
 
-instance Multiplicative.CanonicallyOrderedCommMonoid [CanonicallyOrderedAddCommMonoid α] :
+instance Multiplicative.canonicallyOrderedCommMonoid [CanonicallyOrderedAddCommMonoid α] :
     CanonicallyOrderedCommMonoid (Multiplicative α) :=
   { Multiplicative.orderedCommMonoid, Multiplicative.orderBot,
     Multiplicative.existsMulOfLe with le_self_mul := @le_self_add α _ }
 
-instance Additive.CanonicallyOrderedAddCommMonoid [CanonicallyOrderedCommMonoid α] :
+instance Additive.canonicallyOrderedAddCommMonoid [CanonicallyOrderedCommMonoid α] :
     CanonicallyOrderedAddCommMonoid (Additive α) :=
   { Additive.orderedAddCommMonoid, Additive.orderBot, Additive.existsAddOfLe with
     le_self_add := @le_self_mul α _ }
 
 instance Multiplicative.canonicallyLinearOrderedMonoid [CanonicallyLinearOrderedAddMonoid α] :
     CanonicallyLinearOrderedMonoid (Multiplicative α) :=
-  { Multiplicative.CanonicallyOrderedCommMonoid, Multiplicative.linearOrder with }
+  { Multiplicative.canonicallyOrderedCommMonoid, Multiplicative.linearOrder with }
 
 instance [CanonicallyLinearOrderedMonoid α] : CanonicallyLinearOrderedAddMonoid (Additive α) :=
-  { Additive.CanonicallyOrderedAddCommMonoid, Additive.linearOrder with }
+  { Additive.canonicallyOrderedAddCommMonoid, Additive.linearOrder with }
 
 namespace Additive
 

--- a/Mathlib/Algebra/Order/Monoid/WithTop.lean
+++ b/Mathlib/Algebra/Order/Monoid/WithTop.lean
@@ -393,7 +393,7 @@ instance canonicallyOrderedAddCommMonoid [CanonicallyOrderedAddCommMonoid α] :
       | (a : α), (b : α) => WithTop.coe_le_coe.2 le_self_add
       | ⊤, (b : α) => le_rfl }
 
-instance [CanonicallyLinearOrderedAddMonoid α] : CanonicallyLinearOrderedAddMonoid (WithTop α) :=
+instance [CanonicallyLinearOrderedAddCommMonoid α] : CanonicallyLinearOrderedAddCommMonoid (WithTop α) :=
   { WithTop.canonicallyOrderedAddCommMonoid, WithTop.linearOrder with }
 
 @[simp, norm_cast]

--- a/Mathlib/Algebra/Order/Monoid/WithTop.lean
+++ b/Mathlib/Algebra/Order/Monoid/WithTop.lean
@@ -383,7 +383,7 @@ instance existsAddOfLE [LE α] [Add α] [ExistsAddOfLE α] : ExistsAddOfLE (With
       exact ⟨c, rfl⟩
     | ⊤, (b : α) => fun h => (not_top_le_coe _ h).elim⟩
 
-instance CanonicallyOrderedAddCommMonoid [CanonicallyOrderedAddCommMonoid α] :
+instance canonicallyOrderedAddCommMonoid [CanonicallyOrderedAddCommMonoid α] :
     CanonicallyOrderedAddCommMonoid (WithTop α) :=
   { WithTop.orderBot, WithTop.orderedAddCommMonoid, WithTop.existsAddOfLE with
     le_self_add := fun a b =>
@@ -394,7 +394,7 @@ instance CanonicallyOrderedAddCommMonoid [CanonicallyOrderedAddCommMonoid α] :
       | ⊤, (b : α) => le_rfl }
 
 instance [CanonicallyLinearOrderedAddMonoid α] : CanonicallyLinearOrderedAddMonoid (WithTop α) :=
-  { WithTop.CanonicallyOrderedAddCommMonoid, WithTop.linearOrder with }
+  { WithTop.canonicallyOrderedAddCommMonoid, WithTop.linearOrder with }
 
 @[simp, norm_cast]
 theorem coe_nat [AddMonoidWithOne α] (n : ℕ) : ((n : α) : WithTop α) = n :=

--- a/Mathlib/Algebra/Order/Monoid/WithTop.lean
+++ b/Mathlib/Algebra/Order/Monoid/WithTop.lean
@@ -383,8 +383,8 @@ instance existsAddOfLE [LE α] [Add α] [ExistsAddOfLE α] : ExistsAddOfLE (With
       exact ⟨c, rfl⟩
     | ⊤, (b : α) => fun h => (not_top_le_coe _ h).elim⟩
 
-instance canonicallyOrderedAddMonoid [CanonicallyOrderedAddMonoid α] :
-    CanonicallyOrderedAddMonoid (WithTop α) :=
+instance CanonicallyOrderedAddCommMonoid [CanonicallyOrderedAddCommMonoid α] :
+    CanonicallyOrderedAddCommMonoid (WithTop α) :=
   { WithTop.orderBot, WithTop.orderedAddCommMonoid, WithTop.existsAddOfLE with
     le_self_add := fun a b =>
       match a, b with
@@ -394,7 +394,7 @@ instance canonicallyOrderedAddMonoid [CanonicallyOrderedAddMonoid α] :
       | ⊤, (b : α) => le_rfl }
 
 instance [CanonicallyLinearOrderedAddMonoid α] : CanonicallyLinearOrderedAddMonoid (WithTop α) :=
-  { WithTop.canonicallyOrderedAddMonoid, WithTop.linearOrder with }
+  { WithTop.CanonicallyOrderedAddCommMonoid, WithTop.linearOrder with }
 
 @[simp, norm_cast]
 theorem coe_nat [AddMonoidWithOne α] (n : ℕ) : ((n : α) : WithTop α) = n :=

--- a/Mathlib/Algebra/Order/Monoid/WithTop.lean
+++ b/Mathlib/Algebra/Order/Monoid/WithTop.lean
@@ -393,7 +393,8 @@ instance canonicallyOrderedAddCommMonoid [CanonicallyOrderedAddCommMonoid α] :
       | (a : α), (b : α) => WithTop.coe_le_coe.2 le_self_add
       | ⊤, (b : α) => le_rfl }
 
-instance [CanonicallyLinearOrderedAddCommMonoid α] : CanonicallyLinearOrderedAddCommMonoid (WithTop α) :=
+instance [CanonicallyLinearOrderedAddCommMonoid α] :
+    CanonicallyLinearOrderedAddCommMonoid (WithTop α) :=
   { WithTop.canonicallyOrderedAddCommMonoid, WithTop.linearOrder with }
 
 @[simp, norm_cast]

--- a/Mathlib/Algebra/Order/Monoid/WithZero/Defs.lean
+++ b/Mathlib/Algebra/Order/Monoid/WithZero/Defs.lean
@@ -177,7 +177,8 @@ end CanonicallyOrderedCommMonoid
 section CanonicallyLinearOrderedCommMonoid
 
 instance canonicallyLinearOrderedAddCommMonoid (α : Type*)
-    [CanonicallyLinearOrderedAddCommMonoid α] : CanonicallyLinearOrderedAddCommMonoid (WithZero α) :=
+    [CanonicallyLinearOrderedAddCommMonoid α] :
+    CanonicallyLinearOrderedAddCommMonoid (WithZero α) :=
   { WithZero.canonicallyOrderedAddCommMonoid, WithZero.linearOrder with }
 #align with_zero.canonically_linear_ordered_add_monoid WithZero.canonicallyLinearOrderedAddCommMonoid
 

--- a/Mathlib/Algebra/Order/Monoid/WithZero/Defs.lean
+++ b/Mathlib/Algebra/Order/Monoid/WithZero/Defs.lean
@@ -174,13 +174,13 @@ instance canonicallyOrderedAddCommMonoid [CanonicallyOrderedAddCommMonoid α] :
 
 end CanonicallyOrderedCommMonoid
 
-section CanonicallyLinearOrderedMonoid
+section CanonicallyLinearOrderedCommMonoid
 
-instance canonicallyLinearOrderedAddMonoid (α : Type*)
-    [CanonicallyLinearOrderedAddMonoid α] : CanonicallyLinearOrderedAddMonoid (WithZero α) :=
+instance canonicallyLinearOrderedAddCommMonoid (α : Type*)
+    [CanonicallyLinearOrderedAddCommMonoid α] : CanonicallyLinearOrderedAddCommMonoid (WithZero α) :=
   { WithZero.canonicallyOrderedAddCommMonoid, WithZero.linearOrder with }
-#align with_zero.canonically_linear_ordered_add_monoid WithZero.canonicallyLinearOrderedAddMonoid
+#align with_zero.canonically_linear_ordered_add_monoid WithZero.canonicallyLinearOrderedAddCommMonoid
 
-end CanonicallyLinearOrderedMonoid
+end CanonicallyLinearOrderedCommMonoid
 
 end WithZero

--- a/Mathlib/Algebra/Order/Monoid/WithZero/Defs.lean
+++ b/Mathlib/Algebra/Order/Monoid/WithZero/Defs.lean
@@ -30,10 +30,10 @@ instance (priority := 100) LinearOrderedCommMonoidWithZero.toZeroLeOneClass
   { ‹LinearOrderedCommMonoidWithZero α› with }
 #align linear_ordered_comm_monoid_with_zero.to_zero_le_one_class LinearOrderedCommMonoidWithZero.toZeroLeOneClass
 
-instance (priority := 100) CanonicallyOrderedAddCommMonoid.toZeroLeOneClass
+instance (priority := 100) canonicallyOrderedAddCommMonoid.toZeroLeOneClass
     [CanonicallyOrderedAddCommMonoid α] [One α] : ZeroLEOneClass α :=
   ⟨zero_le 1⟩
-#align canonically_ordered_add_monoid.to_zero_le_one_class CanonicallyOrderedAddCommMonoid.toZeroLeOneClass
+#align canonically_ordered_add_monoid.to_zero_le_one_class canonicallyOrderedAddCommMonoid.toZeroLeOneClass
 
 namespace WithZero
 
@@ -159,7 +159,7 @@ instance existsAddOfLE [Add α] [Preorder α] [ExistsAddOfLE α] :
 
 -- This instance looks absurd: a monoid already has a zero
 /-- Adding a new zero to a canonically ordered additive monoid produces another one. -/
-instance CanonicallyOrderedAddCommMonoid [CanonicallyOrderedAddCommMonoid α] :
+instance canonicallyOrderedAddCommMonoid [CanonicallyOrderedAddCommMonoid α] :
     CanonicallyOrderedAddCommMonoid (WithZero α) :=
   { WithZero.orderBot,
     WithZero.orderedAddCommMonoid _root_.zero_le,
@@ -170,7 +170,7 @@ instance CanonicallyOrderedAddCommMonoid [CanonicallyOrderedAddCommMonoid α] :
       induction b using WithZero.cases_on
       · exact le_rfl
       · exact WithZero.coe_le_coe.2 le_self_add }
-#align with_zero.canonically_ordered_add_monoid WithZero.CanonicallyOrderedAddCommMonoid
+#align with_zero.canonically_ordered_add_monoid WithZero.canonicallyOrderedAddCommMonoid
 
 end CanonicallyOrderedCommMonoid
 
@@ -178,7 +178,7 @@ section CanonicallyLinearOrderedMonoid
 
 instance canonicallyLinearOrderedAddMonoid (α : Type*)
     [CanonicallyLinearOrderedAddMonoid α] : CanonicallyLinearOrderedAddMonoid (WithZero α) :=
-  { WithZero.CanonicallyOrderedAddCommMonoid, WithZero.linearOrder with }
+  { WithZero.canonicallyOrderedAddCommMonoid, WithZero.linearOrder with }
 #align with_zero.canonically_linear_ordered_add_monoid WithZero.canonicallyLinearOrderedAddMonoid
 
 end CanonicallyLinearOrderedMonoid

--- a/Mathlib/Algebra/Order/Monoid/WithZero/Defs.lean
+++ b/Mathlib/Algebra/Order/Monoid/WithZero/Defs.lean
@@ -30,10 +30,10 @@ instance (priority := 100) LinearOrderedCommMonoidWithZero.toZeroLeOneClass
   { ‹LinearOrderedCommMonoidWithZero α› with }
 #align linear_ordered_comm_monoid_with_zero.to_zero_le_one_class LinearOrderedCommMonoidWithZero.toZeroLeOneClass
 
-instance (priority := 100) CanonicallyOrderedAddMonoid.toZeroLeOneClass
-    [CanonicallyOrderedAddMonoid α] [One α] : ZeroLEOneClass α :=
+instance (priority := 100) CanonicallyOrderedAddCommMonoid.toZeroLeOneClass
+    [CanonicallyOrderedAddCommMonoid α] [One α] : ZeroLEOneClass α :=
   ⟨zero_le 1⟩
-#align canonically_ordered_add_monoid.to_zero_le_one_class CanonicallyOrderedAddMonoid.toZeroLeOneClass
+#align canonically_ordered_add_monoid.to_zero_le_one_class CanonicallyOrderedAddCommMonoid.toZeroLeOneClass
 
 namespace WithZero
 
@@ -143,7 +143,7 @@ protected def orderedAddCommMonoid [OrderedAddCommMonoid α] (zero_le : ∀ a : 
     add_le_add_left := @add_le_add_left _ _ _ (WithZero.covariantClass_add_le zero_le).. }
 #align with_zero.ordered_add_comm_monoid WithZero.orderedAddCommMonoid
 
-section CanonicallyOrderedMonoid
+section CanonicallyOrderedCommMonoid
 
 instance existsAddOfLE [Add α] [Preorder α] [ExistsAddOfLE α] :
     ExistsAddOfLE (WithZero α) :=
@@ -159,8 +159,8 @@ instance existsAddOfLE [Add α] [Preorder α] [ExistsAddOfLE α] :
 
 -- This instance looks absurd: a monoid already has a zero
 /-- Adding a new zero to a canonically ordered additive monoid produces another one. -/
-instance canonicallyOrderedAddMonoid [CanonicallyOrderedAddMonoid α] :
-    CanonicallyOrderedAddMonoid (WithZero α) :=
+instance CanonicallyOrderedAddCommMonoid [CanonicallyOrderedAddCommMonoid α] :
+    CanonicallyOrderedAddCommMonoid (WithZero α) :=
   { WithZero.orderBot,
     WithZero.orderedAddCommMonoid _root_.zero_le,
     WithZero.existsAddOfLE with
@@ -170,15 +170,15 @@ instance canonicallyOrderedAddMonoid [CanonicallyOrderedAddMonoid α] :
       induction b using WithZero.cases_on
       · exact le_rfl
       · exact WithZero.coe_le_coe.2 le_self_add }
-#align with_zero.canonically_ordered_add_monoid WithZero.canonicallyOrderedAddMonoid
+#align with_zero.canonically_ordered_add_monoid WithZero.CanonicallyOrderedAddCommMonoid
 
-end CanonicallyOrderedMonoid
+end CanonicallyOrderedCommMonoid
 
 section CanonicallyLinearOrderedMonoid
 
 instance canonicallyLinearOrderedAddMonoid (α : Type*)
     [CanonicallyLinearOrderedAddMonoid α] : CanonicallyLinearOrderedAddMonoid (WithZero α) :=
-  { WithZero.canonicallyOrderedAddMonoid, WithZero.linearOrder with }
+  { WithZero.CanonicallyOrderedAddCommMonoid, WithZero.linearOrder with }
 #align with_zero.canonically_linear_ordered_add_monoid WithZero.canonicallyLinearOrderedAddMonoid
 
 end CanonicallyLinearOrderedMonoid

--- a/Mathlib/Algebra/Order/Nonneg/Ring.lean
+++ b/Mathlib/Algebra/Order/Nonneg/Ring.lean
@@ -318,17 +318,17 @@ def coeRingHom [OrderedSemiring α] : { x : α // 0 ≤ x } →+* α :=
     map_add' := Nonneg.coe_add }
 #align nonneg.coe_ring_hom Nonneg.coeRingHom
 
-instance CanonicallyOrderedAddCommMonoid [OrderedRing α] :
+instance canonicallyOrderedAddCommMonoid [OrderedRing α] :
     CanonicallyOrderedAddCommMonoid { x : α // 0 ≤ x } :=
   { Nonneg.orderedAddCommMonoid, Nonneg.orderBot with
     le_self_add := fun _ b => le_add_of_nonneg_right b.2
     exists_add_of_le := fun {a b} h =>
       ⟨⟨b - a, sub_nonneg_of_le h⟩, Subtype.ext (add_sub_cancel'_right _ _).symm⟩ }
-#align nonneg.canonically_ordered_add_monoid Nonneg.CanonicallyOrderedAddCommMonoid
+#align nonneg.canonically_ordered_add_monoid Nonneg.canonicallyOrderedAddCommMonoid
 
 instance canonicallyOrderedCommSemiring [OrderedCommRing α] [NoZeroDivisors α] :
     CanonicallyOrderedCommSemiring { x : α // 0 ≤ x } :=
-  { Nonneg.CanonicallyOrderedAddCommMonoid, Nonneg.orderedCommSemiring with
+  { Nonneg.canonicallyOrderedAddCommMonoid, Nonneg.orderedCommSemiring with
     eq_zero_or_eq_zero_of_mul_eq_zero := by
       rintro ⟨a, ha⟩ ⟨b, hb⟩
       simp only [mk_mul_mk, mk_eq_zero, mul_eq_zero, imp_self]}
@@ -336,7 +336,7 @@ instance canonicallyOrderedCommSemiring [OrderedCommRing α] [NoZeroDivisors α]
 
 instance canonicallyLinearOrderedAddMonoid [LinearOrderedRing α] :
     CanonicallyLinearOrderedAddMonoid { x : α // 0 ≤ x } :=
-  { Subtype.linearOrder _, Nonneg.CanonicallyOrderedAddCommMonoid with }
+  { Subtype.linearOrder _, Nonneg.canonicallyOrderedAddCommMonoid with }
 #align nonneg.canonically_linear_ordered_add_monoid Nonneg.canonicallyLinearOrderedAddMonoid
 
 section LinearOrder

--- a/Mathlib/Algebra/Order/Nonneg/Ring.lean
+++ b/Mathlib/Algebra/Order/Nonneg/Ring.lean
@@ -24,7 +24,7 @@ When `α` is `ℝ`, this will give us some properties about `ℝ≥0`.
 
 ## Main declarations
 
-* `{x : α // 0 ≤ x}` is a `CanonicallyLinearOrderedAddMonoid` if `α` is a `LinearOrderedRing`.
+* `{x : α // 0 ≤ x}` is a `CanonicallyLinearOrderedAddCommMonoid` if `α` is a `LinearOrderedRing`.
 
 ## Implementation Notes
 
@@ -334,10 +334,10 @@ instance canonicallyOrderedCommSemiring [OrderedCommRing α] [NoZeroDivisors α]
       simp only [mk_mul_mk, mk_eq_zero, mul_eq_zero, imp_self]}
 #align nonneg.canonically_ordered_comm_semiring Nonneg.canonicallyOrderedCommSemiring
 
-instance canonicallyLinearOrderedAddMonoid [LinearOrderedRing α] :
-    CanonicallyLinearOrderedAddMonoid { x : α // 0 ≤ x } :=
+instance canonicallyLinearOrderedAddCommMonoid [LinearOrderedRing α] :
+    CanonicallyLinearOrderedAddCommMonoid { x : α // 0 ≤ x } :=
   { Subtype.linearOrder _, Nonneg.canonicallyOrderedAddCommMonoid with }
-#align nonneg.canonically_linear_ordered_add_monoid Nonneg.canonicallyLinearOrderedAddMonoid
+#align nonneg.canonically_linear_ordered_add_monoid Nonneg.canonicallyLinearOrderedAddCommMonoid
 
 section LinearOrder
 

--- a/Mathlib/Algebra/Order/Nonneg/Ring.lean
+++ b/Mathlib/Algebra/Order/Nonneg/Ring.lean
@@ -318,17 +318,17 @@ def coeRingHom [OrderedSemiring α] : { x : α // 0 ≤ x } →+* α :=
     map_add' := Nonneg.coe_add }
 #align nonneg.coe_ring_hom Nonneg.coeRingHom
 
-instance canonicallyOrderedAddMonoid [OrderedRing α] :
-    CanonicallyOrderedAddMonoid { x : α // 0 ≤ x } :=
+instance CanonicallyOrderedAddCommMonoid [OrderedRing α] :
+    CanonicallyOrderedAddCommMonoid { x : α // 0 ≤ x } :=
   { Nonneg.orderedAddCommMonoid, Nonneg.orderBot with
     le_self_add := fun _ b => le_add_of_nonneg_right b.2
     exists_add_of_le := fun {a b} h =>
       ⟨⟨b - a, sub_nonneg_of_le h⟩, Subtype.ext (add_sub_cancel'_right _ _).symm⟩ }
-#align nonneg.canonically_ordered_add_monoid Nonneg.canonicallyOrderedAddMonoid
+#align nonneg.canonically_ordered_add_monoid Nonneg.CanonicallyOrderedAddCommMonoid
 
 instance canonicallyOrderedCommSemiring [OrderedCommRing α] [NoZeroDivisors α] :
     CanonicallyOrderedCommSemiring { x : α // 0 ≤ x } :=
-  { Nonneg.canonicallyOrderedAddMonoid, Nonneg.orderedCommSemiring with
+  { Nonneg.CanonicallyOrderedAddCommMonoid, Nonneg.orderedCommSemiring with
     eq_zero_or_eq_zero_of_mul_eq_zero := by
       rintro ⟨a, ha⟩ ⟨b, hb⟩
       simp only [mk_mul_mk, mk_eq_zero, mul_eq_zero, imp_self]}
@@ -336,7 +336,7 @@ instance canonicallyOrderedCommSemiring [OrderedCommRing α] [NoZeroDivisors α]
 
 instance canonicallyLinearOrderedAddMonoid [LinearOrderedRing α] :
     CanonicallyLinearOrderedAddMonoid { x : α // 0 ≤ x } :=
-  { Subtype.linearOrder _, Nonneg.canonicallyOrderedAddMonoid with }
+  { Subtype.linearOrder _, Nonneg.CanonicallyOrderedAddCommMonoid with }
 #align nonneg.canonically_linear_ordered_add_monoid Nonneg.canonicallyLinearOrderedAddMonoid
 
 section LinearOrder

--- a/Mathlib/Algebra/Order/Pi.lean
+++ b/Mathlib/Algebra/Order/Pi.lean
@@ -49,8 +49,8 @@ instance existsMulOfLe {ι : Type*} {α : ι → Type*} [∀ i, LE (α i)] [∀ 
 @[to_additive
       "The product of a family of canonically ordered additive monoids is
 a canonically ordered additive monoid."]
-instance {ι : Type*} {Z : ι → Type*} [∀ i, CanonicallyOrderedMonoid (Z i)] :
-    CanonicallyOrderedMonoid (∀ i, Z i) :=
+instance {ι : Type*} {Z : ι → Type*} [∀ i, CanonicallyOrderedCommMonoid (Z i)] :
+    CanonicallyOrderedCommMonoid (∀ i, Z i) :=
   { Pi.orderBot, Pi.orderedCommMonoid, Pi.existsMulOfLe with
     le_self_mul := fun _ _ _ => le_self_mul }
 

--- a/Mathlib/Algebra/Order/Ring/Canonical.lean
+++ b/Mathlib/Algebra/Order/Ring/Canonical.lean
@@ -13,7 +13,7 @@ import Mathlib.GroupTheory.GroupAction.Defs
 # Canonically ordered rings and semirings.
 
 * `CanonicallyOrderedCommSemiring`
-  - `CanonicallyOrderedAddMonoid` & multiplication & `*` respects `≤` & no zero divisors
+  - `CanonicallyOrderedAddCommMonoid` & multiplication & `*` respects `≤` & no zero divisors
   - `CommSemiring` & `a ≤ b ↔ ∃ c, b = a + c` & no zero divisors
 
 ## TODO
@@ -33,7 +33,7 @@ variable {α : Type u} {β : Type*}
 /-- A canonically ordered commutative semiring is an ordered, commutative semiring in which `a ≤ b`
 iff there exists `c` with `b = a + c`. This is satisfied by the natural numbers, for example, but
 not the integers or other ordered groups. -/
-class CanonicallyOrderedCommSemiring (α : Type*) extends CanonicallyOrderedAddMonoid α,
+class CanonicallyOrderedCommSemiring (α : Type*) extends CanonicallyOrderedAddCommMonoid α,
     CommSemiring α where
   /-- No zero divisors. -/
   protected eq_zero_or_eq_zero_of_mul_eq_zero : ∀ {a b : α}, a * b = 0 → a = 0 ∨ b = 0

--- a/Mathlib/Algebra/Order/Ring/WithTop.lean
+++ b/Mathlib/Algebra/Order/Ring/WithTop.lean
@@ -199,7 +199,7 @@ instance commSemiring [Nontrivial α] : CommSemiring (WithTop α) :=
       rw [mul_comm, distrib', mul_comm b, mul_comm c] }
 
 instance [Nontrivial α] : CanonicallyOrderedCommSemiring (WithTop α) :=
-  { WithTop.commSemiring, WithTop.CanonicallyOrderedAddCommMonoid with
+  { WithTop.commSemiring, WithTop.canonicallyOrderedAddCommMonoid with
   eq_zero_or_eq_zero_of_mul_eq_zero := eq_zero_or_eq_zero_of_mul_eq_zero}
 
 /-- A version of `WithTop.map` for `RingHom`s. -/

--- a/Mathlib/Algebra/Order/Ring/WithTop.lean
+++ b/Mathlib/Algebra/Order/Ring/WithTop.lean
@@ -190,7 +190,7 @@ private theorem distrib' (a b c : WithTop α) : (a + b) * c = a * c + b * c := b
     repeat' first | rfl |exact congr_arg some (add_mul _ _ _)
 
 /-- This instance requires `CanonicallyOrderedCommSemiring` as it is the smallest class
-that derives from both `NonAssocNonUnitalSemiring` and `CanonicallyOrderedAddMonoid`, both
+that derives from both `NonAssocNonUnitalSemiring` and `CanonicallyOrderedAddCommMonoid`, both
 of which are required for distributivity. -/
 instance commSemiring [Nontrivial α] : CommSemiring (WithTop α) :=
   { WithTop.addCommMonoidWithOne, WithTop.commMonoidWithZero with
@@ -199,7 +199,7 @@ instance commSemiring [Nontrivial α] : CommSemiring (WithTop α) :=
       rw [mul_comm, distrib', mul_comm b, mul_comm c] }
 
 instance [Nontrivial α] : CanonicallyOrderedCommSemiring (WithTop α) :=
-  { WithTop.commSemiring, WithTop.canonicallyOrderedAddMonoid with
+  { WithTop.commSemiring, WithTop.CanonicallyOrderedAddCommMonoid with
   eq_zero_or_eq_zero_of_mul_eq_zero := eq_zero_or_eq_zero_of_mul_eq_zero}
 
 /-- A version of `WithTop.map` for `RingHom`s. -/

--- a/Mathlib/Algebra/Order/Sub/Canonical.lean
+++ b/Mathlib/Algebra/Order/Sub/Canonical.lean
@@ -307,9 +307,9 @@ end ExistsAddOfLE
 /-! ### Lemmas in a canonically ordered monoid. -/
 
 
-section CanonicallyOrderedAddMonoid
+section CanonicallyOrderedAddCommMonoid
 
-variable [CanonicallyOrderedAddMonoid α] [Sub α] [OrderedSub α] {a b c d : α}
+variable [CanonicallyOrderedAddCommMonoid α] [Sub α] [OrderedSub α] {a b c d : α}
 
 theorem add_tsub_cancel_iff_le : a + (b - a) = b ↔ a ≤ b :=
   ⟨fun h => le_iff_exists_add.mpr ⟨b - a, h.symm⟩, add_tsub_cancel_of_le⟩
@@ -394,20 +394,20 @@ theorem tsub_right_inj (hba : b ≤ a) (hca : c ≤ a) : a - b = a - c ↔ b = c
 
 variable (α)
 
-/-- A `CanonicallyOrderedAddMonoid` with ordered subtraction and order-reflecting addition is
+/-- A `CanonicallyOrderedAddCommMonoid` with ordered subtraction and order-reflecting addition is
 cancellative. This is not an instance as it would form a typeclass loop.
 
 See note [reducible non-instances]. -/
 @[reducible]
-def CanonicallyOrderedAddMonoid.toAddCancelCommMonoid : AddCancelCommMonoid α :=
+def CanonicallyOrderedAddCommMonoid.toAddCancelCommMonoid : AddCancelCommMonoid α :=
   { (by infer_instance : AddCommMonoid α) with
     add_left_cancel := fun a b c h => by
       simpa only [add_tsub_cancel_left] using congr_arg (fun x => x - a) h }
-#align canonically_ordered_add_monoid.to_add_cancel_comm_monoid CanonicallyOrderedAddMonoid.toAddCancelCommMonoid
+#align canonically_ordered_add_monoid.to_add_cancel_comm_monoid CanonicallyOrderedAddCommMonoid.toAddCancelCommMonoid
 
 end Contra
 
-end CanonicallyOrderedAddMonoid
+end CanonicallyOrderedAddCommMonoid
 
 /-! ### Lemmas in a linearly canonically ordered monoid. -/
 

--- a/Mathlib/Algebra/Order/Sub/Canonical.lean
+++ b/Mathlib/Algebra/Order/Sub/Canonical.lean
@@ -412,9 +412,9 @@ end CanonicallyOrderedAddCommMonoid
 /-! ### Lemmas in a linearly canonically ordered monoid. -/
 
 
-section CanonicallyLinearOrderedAddMonoid
+section CanonicallyLinearOrderedAddCommMonoid
 
-variable [CanonicallyLinearOrderedAddMonoid α] [Sub α] [OrderedSub α] {a b c d : α}
+variable [CanonicallyLinearOrderedAddCommMonoid α] [Sub α] [OrderedSub α] {a b c d : α}
 
 @[simp]
 theorem tsub_pos_iff_lt : 0 < a - b ↔ b < a := by rw [tsub_pos_iff_not_le, not_le]
@@ -509,4 +509,4 @@ theorem tsub_add_min : a - b + min a b = a := by
   apply min_le_left
 #align tsub_add_min tsub_add_min
 
-end CanonicallyLinearOrderedAddMonoid
+end CanonicallyLinearOrderedAddCommMonoid

--- a/Mathlib/Algebra/Order/Sub/Defs.lean
+++ b/Mathlib/Algebra/Order/Sub/Defs.lean
@@ -22,9 +22,9 @@ subtraction on a canonically ordered monoid (`ℕ`, `Multiset`, `PartENat`, `ENN
 ## Implementation details
 
 `OrderedSub` is a mixin type-class, so that we can use the results in this file even in cases
-where we don't have a `CanonicallyOrderedAddMonoid` instance
+where we don't have a `CanonicallyOrderedAddCommMonoid` instance
 (even though that is our main focus). Conversely, this means we can use
-`CanonicallyOrderedAddMonoid` without necessarily having to define a subtraction.
+`CanonicallyOrderedAddCommMonoid` without necessarily having to define a subtraction.
 
 The results in this file are ordered by the type-class assumption needed to prove it.
 This means that similar results might not be close to each other. Furthermore, we don't prove

--- a/Mathlib/Algebra/Order/Sub/WithTop.lean
+++ b/Mathlib/Algebra/Order/Sub/WithTop.lean
@@ -59,8 +59,8 @@ theorem map_sub [Sub β] [Zero β] {f : α → β} (h : ∀ x y, f (x - y) = f x
 #align with_top.map_sub WithTop.map_sub
 
 end
-
-variable [CanonicallyOrderedAddMonoid α] [Sub α] [OrderedSub α]
+/-
+variable [CanonicallyOrderedAddCommMonoid α] [Sub α] [OrderedSub α]
 
 instance : OrderedSub (WithTop α) := by
   constructor
@@ -69,5 +69,5 @@ instance : OrderedSub (WithTop α) := by
   induction x using WithTop.recTopCoe; · simp
   induction z using WithTop.recTopCoe; · simp
   norm_cast; exact tsub_le_iff_right
-
+-/
 end WithTop

--- a/Mathlib/Algebra/Order/Sub/WithTop.lean
+++ b/Mathlib/Algebra/Order/Sub/WithTop.lean
@@ -59,7 +59,7 @@ theorem map_sub [Sub β] [Zero β] {f : α → β} (h : ∀ x y, f (x - y) = f x
 #align with_top.map_sub WithTop.map_sub
 
 end
-/-
+
 variable [CanonicallyOrderedAddCommMonoid α] [Sub α] [OrderedSub α]
 
 instance : OrderedSub (WithTop α) := by
@@ -69,5 +69,5 @@ instance : OrderedSub (WithTop α) := by
   induction x using WithTop.recTopCoe; · simp
   induction z using WithTop.recTopCoe; · simp
   norm_cast; exact tsub_le_iff_right
--/
+
 end WithTop

--- a/Mathlib/Algebra/PUnitInstances.lean
+++ b/Mathlib/Algebra/PUnitInstances.lean
@@ -112,7 +112,7 @@ theorem norm_unit_eq {x : PUnit} : normUnit x = 1 :=
   rfl
 #align punit.norm_unit_eq PUnit.norm_unit_eq
 
-instance CanonicallyOrderedAddCommMonoid: CanonicallyOrderedAddCommMonoid PUnit := by
+instance canonicallyOrderedAddCommMonoid: CanonicallyOrderedAddCommMonoid PUnit := by
   refine'
     { PUnit.commRing, PUnit.completeBooleanAlgebra with
       exists_add_of_le := fun {_ _} _ => ⟨unit, Subsingleton.elim _ _⟩.. } <;>
@@ -120,7 +120,7 @@ instance CanonicallyOrderedAddCommMonoid: CanonicallyOrderedAddCommMonoid PUnit 
     trivial
 
 instance linearOrderedCancelAddCommMonoid: LinearOrderedCancelAddCommMonoid PUnit where
-  __ := PUnit.CanonicallyOrderedAddCommMonoid
+  __ := PUnit.canonicallyOrderedAddCommMonoid
   __ := PUnit.linearOrder
   le_of_add_le_add_left _ _ _ _ := trivial
   add_le_add_left := by intros; rfl

--- a/Mathlib/Algebra/PUnitInstances.lean
+++ b/Mathlib/Algebra/PUnitInstances.lean
@@ -112,7 +112,7 @@ theorem norm_unit_eq {x : PUnit} : normUnit x = 1 :=
   rfl
 #align punit.norm_unit_eq PUnit.norm_unit_eq
 
-instance canonicallyOrderedAddMonoid: CanonicallyOrderedAddMonoid PUnit := by
+instance CanonicallyOrderedAddCommMonoid: CanonicallyOrderedAddCommMonoid PUnit := by
   refine'
     { PUnit.commRing, PUnit.completeBooleanAlgebra with
       exists_add_of_le := fun {_ _} _ => ⟨unit, Subsingleton.elim _ _⟩.. } <;>
@@ -120,7 +120,7 @@ instance canonicallyOrderedAddMonoid: CanonicallyOrderedAddMonoid PUnit := by
     trivial
 
 instance linearOrderedCancelAddCommMonoid: LinearOrderedCancelAddCommMonoid PUnit where
-  __ := PUnit.canonicallyOrderedAddMonoid
+  __ := PUnit.CanonicallyOrderedAddCommMonoid
   __ := PUnit.linearOrder
   le_of_add_le_add_left _ _ _ _ := trivial
   add_le_add_left := by intros; rfl

--- a/Mathlib/Algebra/Parity.lean
+++ b/Mathlib/Algebra/Parity.lean
@@ -411,7 +411,7 @@ section CanonicallyOrderedCommSemiring
 
 variable [CanonicallyOrderedCommSemiring α]
 
--- this holds more generally in a `CanonicallyOrderedAddMonoid` if we refactor `Odd` to use
+-- this holds more generally in a `CanonicallyOrderedAddCommMonoid` if we refactor `Odd` to use
 -- either `2 • t` or `t + t` instead of `2 * t`.
 theorem Odd.pos [Nontrivial α] {n : α} (hn : Odd n) : 0 < n := by
   obtain ⟨k, rfl⟩ := hn

--- a/Mathlib/Algebra/Parity.lean
+++ b/Mathlib/Algebra/Parity.lean
@@ -218,7 +218,7 @@ theorem Even.isSquare_zpow [Group α] {n : ℤ} : Even n → ∀ a : α, IsSquar
 #align even.zsmul' Even.zsmul'
 
 -- `Odd.tsub` requires `CanonicallyLinearOrderedSemiring`, which we don't have
-theorem Even.tsub [CanonicallyLinearOrderedAddMonoid α] [Sub α] [OrderedSub α]
+theorem Even.tsub [CanonicallyLinearOrderedAddCommMonoid α] [Sub α] [OrderedSub α]
     [ContravariantClass α α (· + ·) (· ≤ ·)] {m n : α} (hm : Even m) (hn : Even n) :
     Even (m - n) := by
   obtain ⟨a, rfl⟩ := hm

--- a/Mathlib/Data/DFinsupp/Interval.lean
+++ b/Mathlib/Data/DFinsupp/Interval.lean
@@ -207,7 +207,7 @@ section CanonicallyOrdered
 
 variable [DecidableEq ι] [∀ i, DecidableEq (α i)]
 
-variable [∀ i, CanonicallyOrderedAddMonoid (α i)] [∀ i, LocallyFiniteOrder (α i)]
+variable [∀ i, CanonicallyOrderedAddCommMonoid (α i)] [∀ i, LocallyFiniteOrder (α i)]
 
 variable (f : Π₀ i, α i)
 

--- a/Mathlib/Data/DFinsupp/Lex.lean
+++ b/Mathlib/Data/DFinsupp/Lex.lean
@@ -194,7 +194,8 @@ section OrderedAddMonoid
 
 variable [LinearOrder ι]
 
-instance Lex.orderBot [∀ i, CanonicallyOrderedAddCommMonoid (α i)] : OrderBot (Lex (Π₀ i, α i)) where
+instance Lex.orderBot [∀ i, CanonicallyOrderedAddCommMonoid (α i)] :
+    OrderBot (Lex (Π₀ i, α i)) where
   bot := 0
   bot_le _ := DFinsupp.toLex_monotone bot_le
 

--- a/Mathlib/Data/DFinsupp/Lex.lean
+++ b/Mathlib/Data/DFinsupp/Lex.lean
@@ -194,7 +194,7 @@ section OrderedAddMonoid
 
 variable [LinearOrder ι]
 
-instance Lex.orderBot [∀ i, CanonicallyOrderedAddMonoid (α i)] : OrderBot (Lex (Π₀ i, α i)) where
+instance Lex.orderBot [∀ i, CanonicallyOrderedAddCommMonoid (α i)] : OrderBot (Lex (Π₀ i, α i)) where
   bot := 0
   bot_le _ := DFinsupp.toLex_monotone bot_le
 

--- a/Mathlib/Data/DFinsupp/Order.lean
+++ b/Mathlib/Data/DFinsupp/Order.lean
@@ -140,11 +140,11 @@ instance [∀ i, OrderedAddCommMonoid (α i)] [∀ i, ContravariantClass (α i) 
     ContravariantClass (Π₀ i, α i) (Π₀ i, α i) (· + ·) (· ≤ ·) :=
   ⟨fun _ _ _ H i ↦ le_of_add_le_add_left (H i)⟩
 
-section CanonicallyOrderedAddMonoid
+section CanonicallyOrderedAddCommMonoid
 
 -- porting note: Split into 2 lines to satisfy the unusedVariables linter.
 variable (α)
-variable [∀ i, CanonicallyOrderedAddMonoid (α i)]
+variable [∀ i, CanonicallyOrderedAddCommMonoid (α i)]
 
 instance : OrderBot (Π₀ i, α i) where
   bot := 0
@@ -216,7 +216,7 @@ variable (α)
 instance : OrderedSub (Π₀ i, α i) :=
   ⟨fun _ _ _ ↦ forall_congr' fun _ ↦ tsub_le_iff_right⟩
 
-instance : CanonicallyOrderedAddMonoid (Π₀ i, α i) :=
+instance : CanonicallyOrderedAddCommMonoid (Π₀ i, α i) :=
   { (inferInstance : OrderBot (DFinsupp α)),
     (inferInstance : OrderedAddCommMonoid (DFinsupp α)) with
     exists_add_of_le := by
@@ -247,7 +247,7 @@ theorem subset_support_tsub : f.support \ g.support ⊆ (f - g).support := by
   simp (config := { contextual := true }) [subset_iff]
 #align dfinsupp.subset_support_tsub DFinsupp.subset_support_tsub
 
-end CanonicallyOrderedAddMonoid
+end CanonicallyOrderedAddCommMonoid
 
 section CanonicallyLinearOrderedAddMonoid
 

--- a/Mathlib/Data/DFinsupp/Order.lean
+++ b/Mathlib/Data/DFinsupp/Order.lean
@@ -249,9 +249,9 @@ theorem subset_support_tsub : f.support \ g.support ⊆ (f - g).support := by
 
 end CanonicallyOrderedAddCommMonoid
 
-section CanonicallyLinearOrderedAddMonoid
+section CanonicallyLinearOrderedAddCommMonoid
 
-variable [∀ i, CanonicallyLinearOrderedAddMonoid (α i)] [DecidableEq ι] {f g : Π₀ i, α i}
+variable [∀ i, CanonicallyLinearOrderedAddCommMonoid (α i)] [DecidableEq ι] {f g : Π₀ i, α i}
 
 @[simp]
 theorem support_inf : (f ⊓ g).support = f.support ∩ g.support := by
@@ -273,6 +273,6 @@ nonrec theorem disjoint_iff : Disjoint f g ↔ Disjoint f.support g.support := b
   rfl
 #align dfinsupp.disjoint_iff DFinsupp.disjoint_iff
 
-end CanonicallyLinearOrderedAddMonoid
+end CanonicallyLinearOrderedAddCommMonoid
 
 end DFinsupp

--- a/Mathlib/Data/DFinsupp/WellFounded.lean
+++ b/Mathlib/Data/DFinsupp/WellFounded.lean
@@ -170,7 +170,7 @@ theorem Lex.wellFounded' [IsTrichotomous ι r] (hr : WellFounded (Function.swap 
 end Zero
 
 instance Lex.wellFoundedLT [LT ι] [IsTrichotomous ι (· < ·)] [hι : WellFoundedGT ι]
-    [∀ i, CanonicallyOrderedAddMonoid (α i)] [hα : ∀ i, WellFoundedLT (α i)] :
+    [∀ i, CanonicallyOrderedAddCommMonoid (α i)] [hα : ∀ i, WellFoundedLT (α i)] :
     WellFoundedLT (Lex (Π₀ i, α i)) :=
   ⟨Lex.wellFounded' (fun _ a => (zero_le a).not_lt) (fun i => (hα i).wf) hι.wf⟩
 #align dfinsupp.lex.well_founded_lt DFinsupp.Lex.wellFoundedLT
@@ -232,7 +232,7 @@ protected theorem DFinsupp.wellFoundedLT [∀ i, Zero (α i)] [∀ i, Preorder (
     exact ⟨i, fun j hj ↦ Quot.sound (he j hj), hl⟩⟩
 #align dfinsupp.well_founded_lt DFinsupp.wellFoundedLT
 
-instance DFinsupp.wellFoundedLT' [∀ i, CanonicallyOrderedAddMonoid (α i)]
+instance DFinsupp.wellFoundedLT' [∀ i, CanonicallyOrderedAddCommMonoid (α i)]
     [∀ i, WellFoundedLT (α i)] : WellFoundedLT (Π₀ i, α i) :=
   DFinsupp.wellFoundedLT fun _i a => (zero_le a).not_lt
 #align dfinsupp.well_founded_lt' DFinsupp.wellFoundedLT'

--- a/Mathlib/Data/ENat/Basic.lean
+++ b/Mathlib/Data/ENat/Basic.lean
@@ -31,7 +31,7 @@ def ENat : Type :=
 deriving Zero,
   -- AddCommMonoidWithOne,
   CanonicallyOrderedCommSemiring, Nontrivial,
-  LinearOrder, Bot, Top, CanonicallyLinearOrderedAddMonoid, Sub,
+  LinearOrder, Bot, Top, CanonicallyLinearOrderedAddCommMonoid, Sub,
   LinearOrderedAddCommMonoidWithTop, WellFoundedRelation, Inhabited
   -- OrderBot, OrderTop, OrderedSub, SuccOrder, WellFoundedLt, CharZero
 #align enat ENat

--- a/Mathlib/Data/ENat/Basic.lean
+++ b/Mathlib/Data/ENat/Basic.lean
@@ -47,7 +47,7 @@ namespace ENat
 --Porting note: instances that derive failed to find
 instance : OrderBot ℕ∞ := WithTop.orderBot
 instance : OrderTop ℕ∞ := WithTop.orderTop
---instance : OrderedSub ℕ∞ := inferInstanceAs (OrderedSub (WithTop ℕ))
+instance : OrderedSub ℕ∞ := inferInstanceAs (OrderedSub (WithTop ℕ))
 instance : SuccOrder ℕ∞ := inferInstanceAs (SuccOrder (WithTop ℕ))
 instance : WellFoundedLT ℕ∞ := inferInstanceAs (WellFoundedLT (WithTop ℕ))
 instance : CharZero ℕ∞ := inferInstanceAs (CharZero (WithTop ℕ))

--- a/Mathlib/Data/ENat/Basic.lean
+++ b/Mathlib/Data/ENat/Basic.lean
@@ -47,7 +47,7 @@ namespace ENat
 --Porting note: instances that derive failed to find
 instance : OrderBot ℕ∞ := WithTop.orderBot
 instance : OrderTop ℕ∞ := WithTop.orderTop
-instance : OrderedSub ℕ∞ := inferInstanceAs (OrderedSub (WithTop ℕ))
+--instance : OrderedSub ℕ∞ := inferInstanceAs (OrderedSub (WithTop ℕ))
 instance : SuccOrder ℕ∞ := inferInstanceAs (SuccOrder (WithTop ℕ))
 instance : WellFoundedLT ℕ∞ := inferInstanceAs (WellFoundedLT (WithTop ℕ))
 instance : CharZero ℕ∞ := inferInstanceAs (CharZero (WithTop ℕ))

--- a/Mathlib/Data/Finsupp/Interval.lean
+++ b/Mathlib/Data/Finsupp/Interval.lean
@@ -138,7 +138,7 @@ end Lattice
 
 section CanonicallyOrdered
 
-variable [CanonicallyOrderedAddMonoid α] [LocallyFiniteOrder α]
+variable [CanonicallyOrderedAddCommMonoid α] [LocallyFiniteOrder α]
 
 variable (f : ι →₀ α)
 

--- a/Mathlib/Data/Finsupp/Lex.lean
+++ b/Mathlib/Data/Finsupp/Lex.lean
@@ -151,7 +151,7 @@ section OrderedAddMonoid
 
 variable [LinearOrder α]
 
-instance Lex.orderBot [CanonicallyOrderedAddMonoid N] : OrderBot (Lex (α →₀ N)) where
+instance Lex.orderBot [CanonicallyOrderedAddCommMonoid N] : OrderBot (Lex (α →₀ N)) where
   bot := 0
   bot_le _ := Finsupp.toLex_monotone bot_le
 

--- a/Mathlib/Data/Finsupp/Order.lean
+++ b/Mathlib/Data/Finsupp/Order.lean
@@ -146,9 +146,9 @@ instance contravariantClass [OrderedAddCommMonoid α] [ContravariantClass α α 
     ContravariantClass (ι →₀ α) (ι →₀ α) (· + ·) (· ≤ ·) :=
   ⟨fun _f _g _h H x => le_of_add_le_add_left <| H x⟩
 
-section CanonicallyOrderedAddMonoid
+section CanonicallyOrderedAddCommMonoid
 
-variable [CanonicallyOrderedAddMonoid α]
+variable [CanonicallyOrderedAddCommMonoid α]
 
 instance orderBot : OrderBot (ι →₀ α) where
   bot := 0
@@ -193,7 +193,7 @@ instance tsub : Sub (ι →₀ α) :=
 instance orderedSub : OrderedSub (ι →₀ α) :=
   ⟨fun _n _m _k => forall_congr' fun _x => tsub_le_iff_right⟩
 
-instance : CanonicallyOrderedAddMonoid (ι →₀ α) :=
+instance : CanonicallyOrderedAddCommMonoid (ι →₀ α) :=
   { Finsupp.orderBot,
     Finsupp.orderedAddCommMonoid with
     exists_add_of_le := fun {f g} h => ⟨g - f, ext fun x => (add_tsub_cancel_of_le <| h x).symm⟩
@@ -226,7 +226,7 @@ theorem subset_support_tsub [DecidableEq ι] {f1 f2 : ι →₀ α} :
   simp (config := { contextual := true }) [subset_iff]
 #align finsupp.subset_support_tsub Finsupp.subset_support_tsub
 
-end CanonicallyOrderedAddMonoid
+end CanonicallyOrderedAddCommMonoid
 
 section CanonicallyLinearOrderedAddMonoid
 

--- a/Mathlib/Data/Finsupp/Order.lean
+++ b/Mathlib/Data/Finsupp/Order.lean
@@ -228,9 +228,9 @@ theorem subset_support_tsub [DecidableEq ι] {f1 f2 : ι →₀ α} :
 
 end CanonicallyOrderedAddCommMonoid
 
-section CanonicallyLinearOrderedAddMonoid
+section CanonicallyLinearOrderedAddCommMonoid
 
-variable [CanonicallyLinearOrderedAddMonoid α]
+variable [CanonicallyLinearOrderedAddCommMonoid α]
 
 @[simp]
 theorem support_inf [DecidableEq ι] (f g : ι →₀ α) : (f ⊓ g).support = f.support ∩ g.support := by
@@ -254,7 +254,7 @@ nonrec theorem disjoint_iff {f g : ι →₀ α} : Disjoint f g ↔ Disjoint f.s
     rfl
 #align finsupp.disjoint_iff Finsupp.disjoint_iff
 
-end CanonicallyLinearOrderedAddMonoid
+end CanonicallyLinearOrderedAddCommMonoid
 
 /-! ### Some lemmas about `ℕ` -/
 

--- a/Mathlib/Data/Finsupp/WellFounded.lean
+++ b/Mathlib/Data/Finsupp/WellFounded.lean
@@ -53,7 +53,7 @@ theorem Lex.wellFounded' [IsTrichotomous α r] (hr : WellFounded (Function.swap 
 #align finsupp.lex.well_founded' Finsupp.Lex.wellFounded'
 
 instance Lex.wellFoundedLT {α N} [LT α] [IsTrichotomous α (· < ·)] [hα : WellFoundedGT α]
-    [CanonicallyOrderedAddMonoid N] [hN : WellFoundedLT N] : WellFoundedLT (Lex (α →₀ N)) :=
+    [CanonicallyOrderedAddCommMonoid N] [hN : WellFoundedLT N] : WellFoundedLT (Lex (α →₀ N)) :=
   ⟨Lex.wellFounded' (fun n => (zero_le n).not_lt) hN.wf hα.wf⟩
 #align finsupp.lex.well_founded_lt Finsupp.Lex.wellFoundedLT
 
@@ -74,7 +74,7 @@ protected theorem wellFoundedLT [Zero N] [Preorder N] [WellFoundedLT N] (hbot : 
   ⟨InvImage.wf toDFinsupp (DFinsupp.wellFoundedLT fun _ a => hbot a).wf⟩
 #align finsupp.well_founded_lt Finsupp.wellFoundedLT
 
-instance wellFoundedLT' {N} [CanonicallyOrderedAddMonoid N] [WellFoundedLT N] :
+instance wellFoundedLT' {N} [CanonicallyOrderedAddCommMonoid N] [WellFoundedLT N] :
     WellFoundedLT (α →₀ N) :=
   Finsupp.wellFoundedLT fun a => (zero_le a).not_lt
 #align finsupp.well_founded_lt' Finsupp.wellFoundedLT'

--- a/Mathlib/Data/List/BigOperators/Basic.lean
+++ b/Mathlib/Data/List/BigOperators/Basic.lean
@@ -474,7 +474,7 @@ theorem eq_of_prod_take_eq [LeftCancelMonoid M] {L L' : List M} (h : L.length = 
 #align list.eq_of_sum_take_eq List.eq_of_sum_take_eq
 
 @[to_additive]
-theorem monotone_prod_take [CanonicallyOrderedMonoid M] (L : List M) :
+theorem monotone_prod_take [CanonicallyOrderedCommMonoid M] (L : List M) :
     Monotone fun i => (L.take i).prod := by
   refine' monotone_nat_of_le_succ fun n => _
   cases' lt_or_le n L.length with h h

--- a/Mathlib/Data/List/BigOperators/Lemmas.lean
+++ b/Mathlib/Data/List/BigOperators/Lemmas.lean
@@ -53,7 +53,7 @@ theorem pow_card_le_prod [Monoid M] [Preorder M]
 #align list.card_nsmul_le_sum List.card_nsmul_le_sum
 
 @[to_additive]
-theorem prod_eq_one_iff [CanonicallyOrderedMonoid M] (l : List M) :
+theorem prod_eq_one_iff [CanonicallyOrderedCommMonoid M] (l : List M) :
     l.prod = 1 ↔ ∀ x ∈ l, x = (1 : M) :=
   ⟨all_one_of_le_one_le_of_prod_eq_one fun _ _ => one_le _, fun h => by
     rw [List.eq_replicate.2 ⟨_, h⟩, prod_replicate, one_pow]; exact (length l); rfl⟩

--- a/Mathlib/Data/List/EditDistance/Bounds.lean
+++ b/Mathlib/Data/List/EditDistance/Bounds.lean
@@ -20,7 +20,7 @@ to produce lower bounds on the final result.
 
 set_option autoImplicit true
 
-variable {C : Levenshtein.Cost α β δ} [CanonicallyLinearOrderedAddMonoid δ]
+variable {C : Levenshtein.Cost α β δ} [CanonicallyLinearOrderedAddCommMonoid δ]
 
 theorem suffixLevenshtein_minimum_le_levenshtein_cons (xs : List α) (y ys) :
     (suffixLevenshtein C xs ys).1.minimum ≤ levenshtein C xs (y :: ys) := by

--- a/Mathlib/Data/List/EditDistance/Estimator.lean
+++ b/Mathlib/Data/List/EditDistance/Estimator.lean
@@ -25,7 +25,7 @@ to avoid needing the entire edit distance calculation in unlikely search paths.
 
 set_option autoImplicit true
 
-variable {α β δ : Type} [CanonicallyLinearOrderedAddMonoid δ]
+variable {α β δ : Type} [CanonicallyLinearOrderedAddCommMonoid δ]
     (C : Levenshtein.Cost α β δ) (xs : List α) (ys : List β)
 
 /--
@@ -133,7 +133,7 @@ instance [∀ a : δ × ℕ, WellFoundedGT { x // x ≤ a }] :
   Estimator.fstInst (Thunk.mk fun _ => _) (Thunk.mk fun _ => _) (estimator' C xs ys)
 
 /-- The initial estimator for Levenshtein distances. -/
-instance [CanonicallyLinearOrderedAddMonoid δ]
+instance [CanonicallyLinearOrderedAddCommMonoid δ]
     (C : Levenshtein.Cost α β δ) (xs : List α) (ys : List β) :
     Bot (LevenshteinEstimator C xs ys) where
   bot :=

--- a/Mathlib/Data/Multiset/Basic.lean
+++ b/Mathlib/Data/Multiset/Basic.lean
@@ -659,7 +659,7 @@ theorem le_iff_exists_add {s t : Multiset α} : s ≤ t ↔ ∃ u, t = s + u :=
     fun ⟨_u, e⟩ => e.symm ▸ le_add_right _ _⟩
 #align multiset.le_iff_exists_add Multiset.le_iff_exists_add
 
-instance : CanonicallyOrderedAddMonoid (Multiset α) where
+instance : CanonicallyOrderedAddCommMonoid (Multiset α) where
   __ := inferInstanceAs (OrderBot (Multiset α))
   le_self_add := le_add_right
   exists_add_of_le h := leInductionOn h fun s =>

--- a/Mathlib/Data/Multiset/Fold.lean
+++ b/Mathlib/Data/Multiset/Fold.lean
@@ -124,7 +124,7 @@ end Fold
 
 section Order
 
-theorem max_le_of_forall_le {α : Type*} [CanonicallyLinearOrderedAddMonoid α] (l : Multiset α)
+theorem max_le_of_forall_le {α : Type*} [CanonicallyLinearOrderedAddCommMonoid α] (l : Multiset α)
     (n : α) (h : ∀ x ∈ l, x ≤ n) : l.fold max ⊥ ≤ n := by
   induction l using Quotient.inductionOn
   simpa using List.max_le_of_forall_le _ _ h

--- a/Mathlib/Data/Nat/Interval.lean
+++ b/Mathlib/Data/Nat/Interval.lean
@@ -15,7 +15,7 @@ intervals as finsets and fintypes.
 
 ## TODO
 
-Some lemmas can be generalized using `OrderedGroup`, `CanonicallyOrderedMonoid` or `SuccOrder`
+Some lemmas can be generalized using `OrderedGroup`, `CanonicallyOrderedCommMonoid` or `SuccOrder`
 and subsequently be moved upstream to `Data.Finset.LocallyFinite`.
 -/
 

--- a/Mathlib/Data/Nat/Order/Basic.lean
+++ b/Mathlib/Data/Nat/Order/Basic.lean
@@ -74,7 +74,7 @@ instance canonicallyOrderedCommSemiring : CanonicallyOrderedCommSemiring ℕ :=
     eq_zero_or_eq_zero_of_mul_eq_zero := Nat.eq_zero_of_mul_eq_zero }
 
 instance canonicallyLinearOrderedAddMonoid : CanonicallyLinearOrderedAddMonoid ℕ :=
-  { (inferInstance : CanonicallyOrderedAddMonoid ℕ), Nat.linearOrder with }
+  { (inferInstance : CanonicallyOrderedAddCommMonoid ℕ), Nat.linearOrder with }
 
 variable {m n k l : ℕ}
 

--- a/Mathlib/Data/Nat/Order/Basic.lean
+++ b/Mathlib/Data/Nat/Order/Basic.lean
@@ -73,7 +73,7 @@ instance canonicallyOrderedCommSemiring : CanonicallyOrderedCommSemiring ℕ :=
     le_self_add := Nat.le_add_right,
     eq_zero_or_eq_zero_of_mul_eq_zero := Nat.eq_zero_of_mul_eq_zero }
 
-instance canonicallyLinearOrderedAddMonoid : CanonicallyLinearOrderedAddMonoid ℕ :=
+instance canonicallyLinearOrderedAddCommMonoid : CanonicallyLinearOrderedAddCommMonoid ℕ :=
   { (inferInstance : CanonicallyOrderedAddCommMonoid ℕ), Nat.linearOrder with }
 
 variable {m n k l : ℕ}

--- a/Mathlib/Data/Nat/PartENat.lean
+++ b/Mathlib/Data/Nat/PartENat.lean
@@ -21,7 +21,7 @@ implementation. Use `ℕ∞` instead unless you care about computability.
 The following instances are defined:
 
 * `OrderedAddCommMonoid PartENat`
-* `CanonicallyOrderedAddMonoid PartENat`
+* `CanonicallyOrderedAddCommMonoid PartENat`
 * `CompleteLinearOrder PartENat`
 
 There is no additive analogue of `MonoidWithZero`; if there were then `PartENat` could
@@ -426,7 +426,7 @@ noncomputable instance orderedAddCommMonoid : OrderedAddCommMonoid PartENat :=
         ⟨fun h => And.intro (dom_natCast _) (h₁ h.2), fun h => by
           simpa only [coe_add_get] using add_le_add_left (h₂ _) c⟩ }
 
-noncomputable instance : CanonicallyOrderedAddMonoid PartENat :=
+noncomputable instance : CanonicallyOrderedAddCommMonoid PartENat :=
   { PartENat.semilatticeSup, PartENat.orderBot,
     PartENat.orderedAddCommMonoid with
     le_self_add := fun a b =>

--- a/Mathlib/Data/PNat/Factors.lean
+++ b/Mathlib/Data/PNat/Factors.lean
@@ -23,12 +23,12 @@ the multiplicity of `p` in this factors multiset being the p-adic valuation of `
 -/
 
 -- Porting note: `deriving` contained
--- Inhabited, CanonicallyOrderedAddMonoid, DistribLattice, SemilatticeSup, OrderBot, Sub, OrderedSub
+-- Inhabited, CanonicallyOrderedAddCommMonoid, DistribLattice, SemilatticeSup, OrderBot, Sub, OrderedSub
 /-- The type of multisets of prime numbers.  Unique factorization
  gives an equivalence between this set and ℕ+, as we will formalize
  below. -/
 def PrimeMultiset :=
-  Multiset Nat.Primes deriving Inhabited, CanonicallyOrderedAddMonoid, DistribLattice,
+  Multiset Nat.Primes deriving Inhabited, CanonicallyOrderedAddCommMonoid, DistribLattice,
   SemilatticeSup, Sub
 #align prime_multiset PrimeMultiset
 

--- a/Mathlib/Data/PNat/Factors.lean
+++ b/Mathlib/Data/PNat/Factors.lean
@@ -22,8 +22,8 @@ the multiplicity of `p` in this factors multiset being the p-adic valuation of `
 * `FactorMultiset n`: Multiset of prime factors of `n`.
 -/
 
--- Porting note: `deriving` contained
--- Inhabited, CanonicallyOrderedAddCommMonoid, DistribLattice, SemilatticeSup, OrderBot, Sub, OrderedSub
+-- Porting note: `deriving` contained Inhabited, CanonicallyOrderedAddCommMonoid, DistribLattice,
+-- SemilatticeSup, OrderBot, Sub, OrderedSub
 /-- The type of multisets of prime numbers.  Unique factorization
  gives an equivalence between this set and ℕ+, as we will formalize
  below. -/

--- a/Mathlib/Data/Real/ENNReal.lean
+++ b/Mathlib/Data/Real/ENNReal.lean
@@ -104,8 +104,8 @@ noncomputable instance : CompleteLinearOrder ℝ≥0∞ :=
 
 instance : DenselyOrdered ℝ≥0∞ := inferInstanceAs (DenselyOrdered (WithTop ℝ≥0))
 
-noncomputable instance : CanonicallyLinearOrderedAddMonoid ℝ≥0∞ :=
-  inferInstanceAs (CanonicallyLinearOrderedAddMonoid (WithTop ℝ≥0))
+noncomputable instance : CanonicallyLinearOrderedAddCommMonoid ℝ≥0∞ :=
+  inferInstanceAs (CanonicallyLinearOrderedAddCommMonoid (WithTop ℝ≥0))
 
 noncomputable instance instSub : Sub ℝ≥0∞ := inferInstanceAs (Sub (WithTop ℝ≥0))
 noncomputable instance : OrderedSub ℝ≥0∞ := inferInstanceAs (OrderedSub (WithTop ℝ≥0))

--- a/Mathlib/Data/Real/ENNReal.lean
+++ b/Mathlib/Data/Real/ENNReal.lean
@@ -108,7 +108,7 @@ noncomputable instance : CanonicallyLinearOrderedAddMonoid ℝ≥0∞ :=
   inferInstanceAs (CanonicallyLinearOrderedAddMonoid (WithTop ℝ≥0))
 
 noncomputable instance instSub : Sub ℝ≥0∞ := inferInstanceAs (Sub (WithTop ℝ≥0))
-noncomputable instance : OrderedSub ℝ≥0∞ := sorry -- inferInstanceAs (OrderedSub (WithTop ℝ≥0))
+noncomputable instance : OrderedSub ℝ≥0∞ := inferInstanceAs (OrderedSub (WithTop ℝ≥0))
 
 noncomputable instance : LinearOrderedAddCommMonoidWithTop ℝ≥0∞ :=
   inferInstanceAs (LinearOrderedAddCommMonoidWithTop (WithTop ℝ≥0))

--- a/Mathlib/Data/Real/ENNReal.lean
+++ b/Mathlib/Data/Real/ENNReal.lean
@@ -108,7 +108,7 @@ noncomputable instance : CanonicallyLinearOrderedAddMonoid ℝ≥0∞ :=
   inferInstanceAs (CanonicallyLinearOrderedAddMonoid (WithTop ℝ≥0))
 
 noncomputable instance instSub : Sub ℝ≥0∞ := inferInstanceAs (Sub (WithTop ℝ≥0))
-noncomputable instance : OrderedSub ℝ≥0∞ := inferInstanceAs (OrderedSub (WithTop ℝ≥0))
+noncomputable instance : OrderedSub ℝ≥0∞ := sorry -- inferInstanceAs (OrderedSub (WithTop ℝ≥0))
 
 noncomputable instance : LinearOrderedAddCommMonoidWithTop ℝ≥0∞ :=
   inferInstanceAs (LinearOrderedAddCommMonoidWithTop (WithTop ℝ≥0))

--- a/Mathlib/Data/Real/NNReal.lean
+++ b/Mathlib/Data/Real/NNReal.lean
@@ -32,7 +32,7 @@ a.k.a. the interval `[0, ∞)`. We also define the following operations and stru
   - `OrderedCommSemiring ℝ≥0`;
   - `CanonicallyOrderedCommSemiring ℝ≥0`;
   - `LinearOrderedCommGroupWithZero ℝ≥0`;
-  - `CanonicallyLinearOrderedAddMonoid ℝ≥0`;
+  - `CanonicallyLinearOrderedAddCommMonoid ℝ≥0`;
   - `Archimedean ℝ≥0`;
   - `ConditionallyCompleteLinearOrderBot ℝ≥0`.
 
@@ -420,7 +420,7 @@ example : OrderBot ℝ≥0 := by infer_instance
 
 example : PartialOrder ℝ≥0 := by infer_instance
 
-noncomputable example : CanonicallyLinearOrderedAddMonoid ℝ≥0 := by infer_instance
+noncomputable example : CanonicallyLinearOrderedAddCommMonoid ℝ≥0 := by infer_instance
 
 noncomputable example : LinearOrderedAddCommMonoid ℝ≥0 := by infer_instance
 

--- a/Mathlib/Data/Set/Card.lean
+++ b/Mathlib/Data/Set/Card.lean
@@ -122,7 +122,7 @@ theorem Finite.encard_lt_top (h : s.Finite) : s.encard < ⊤ := by
   refine' h.induction_on (by simpa using WithTop.zero_lt_top) _
   rintro a t hat _ ht'
   rw [encard_insert_of_not_mem hat]
-  sorry --exact lt_tsub_iff_right.1 ht'
+  exact lt_tsub_iff_right.1 ht'
 
 theorem Finite.encard_eq_coe (h : s.Finite) : s.encard = ENat.toNat s.encard :=
   (ENat.coe_toNat h.encard_lt_top.ne).symm
@@ -225,7 +225,7 @@ theorem encard_le_encard_diff_add_encard (s t : Set α) : s.encard ≤ (s \ t).e
   (encard_mono (subset_union_left s t)).trans_eq (encard_diff_add_encard _ _).symm
 
 theorem tsub_encard_le_encard_diff (s t : Set α) : s.encard - t.encard ≤ (s \ t).encard := by
-  sorry --rw [tsub_le_iff_left, add_comm]; apply encard_le_encard_diff_add_encard
+  rw [tsub_le_iff_left, add_comm]; apply encard_le_encard_diff_add_encard
 
 theorem encard_add_encard_compl (s : Set α) : s.encard + sᶜ.encard = (univ : Set α).encard := by
   rw [←encard_union_eq disjoint_compl_right, union_compl_self]
@@ -246,8 +246,8 @@ theorem encard_diff_singleton_add_one (h : a ∈ s) :
 
 theorem encard_diff_singleton_of_mem (h : a ∈ s) :
     (s \ {a}).encard = s.encard - 1 := by
-  sorry /-rw [←encard_diff_singleton_add_one h, ←WithTop.add_right_cancel_iff WithTop.one_ne_top,
-    tsub_add_cancel_of_le (self_le_add_left _ _)]-/
+  rw [←encard_diff_singleton_add_one h, ←WithTop.add_right_cancel_iff WithTop.one_ne_top,
+    tsub_add_cancel_of_le (self_le_add_left _ _)]
 
 theorem encard_tsub_one_le_encard_diff_singleton (s : Set α) (x : α) :
     s.encard - 1 ≤ (s \ {x}).encard := by

--- a/Mathlib/Data/Set/Card.lean
+++ b/Mathlib/Data/Set/Card.lean
@@ -122,7 +122,7 @@ theorem Finite.encard_lt_top (h : s.Finite) : s.encard < ⊤ := by
   refine' h.induction_on (by simpa using WithTop.zero_lt_top) _
   rintro a t hat _ ht'
   rw [encard_insert_of_not_mem hat]
-  exact lt_tsub_iff_right.1 ht'
+  sorry --exact lt_tsub_iff_right.1 ht'
 
 theorem Finite.encard_eq_coe (h : s.Finite) : s.encard = ENat.toNat s.encard :=
   (ENat.coe_toNat h.encard_lt_top.ne).symm
@@ -225,7 +225,7 @@ theorem encard_le_encard_diff_add_encard (s t : Set α) : s.encard ≤ (s \ t).e
   (encard_mono (subset_union_left s t)).trans_eq (encard_diff_add_encard _ _).symm
 
 theorem tsub_encard_le_encard_diff (s t : Set α) : s.encard - t.encard ≤ (s \ t).encard := by
-  rw [tsub_le_iff_left, add_comm]; apply encard_le_encard_diff_add_encard
+  sorry --rw [tsub_le_iff_left, add_comm]; apply encard_le_encard_diff_add_encard
 
 theorem encard_add_encard_compl (s : Set α) : s.encard + sᶜ.encard = (univ : Set α).encard := by
   rw [←encard_union_eq disjoint_compl_right, union_compl_self]
@@ -246,8 +246,8 @@ theorem encard_diff_singleton_add_one (h : a ∈ s) :
 
 theorem encard_diff_singleton_of_mem (h : a ∈ s) :
     (s \ {a}).encard = s.encard - 1 := by
-  rw [←encard_diff_singleton_add_one h, ←WithTop.add_right_cancel_iff WithTop.one_ne_top,
-    tsub_add_cancel_of_le (self_le_add_left _ _)]
+  sorry /-rw [←encard_diff_singleton_add_one h, ←WithTop.add_right_cancel_iff WithTop.one_ne_top,
+    tsub_add_cancel_of_le (self_le_add_left _ _)]-/
 
 theorem encard_tsub_one_le_encard_diff_singleton (s : Set α) (x : α) :
     s.encard - 1 ≤ (s \ {x}).encard := by

--- a/Mathlib/Dynamics/Flow.lean
+++ b/Mathlib/Dynamics/Flow.lean
@@ -70,7 +70,8 @@ theorem IsFwInvariant.isInvariant [CanonicallyOrderedAddCommMonoid τ] {ϕ : τ 
 
 /-- If `τ` is a `CanonicallyOrderedAddCommMonoid` (e.g., `ℕ` or `ℝ≥0`), then the notions
 `IsFwInvariant` and `IsInvariant` are equivalent. -/
-theorem isFwInvariant_iff_isInvariant [CanonicallyOrderedAddCommMonoid τ] {ϕ : τ → α → α} {s : Set α} :
+theorem isFwInvariant_iff_isInvariant [CanonicallyOrderedAddCommMonoid τ] {ϕ : τ → α → α}
+    {s : Set α} :
     IsFwInvariant ϕ s ↔ IsInvariant ϕ s :=
   ⟨IsFwInvariant.isInvariant, IsInvariant.isFwInvariant⟩
 #align is_fw_invariant_iff_is_invariant isFwInvariant_iff_isInvariant

--- a/Mathlib/Dynamics/Flow.lean
+++ b/Mathlib/Dynamics/Flow.lean
@@ -62,15 +62,15 @@ theorem IsInvariant.isFwInvariant [Preorder τ] [Zero τ] {ϕ : τ → α → α
     (h : IsInvariant ϕ s) : IsFwInvariant ϕ s := fun t _ht => h t
 #align is_invariant.is_fw_invariant IsInvariant.isFwInvariant
 
-/-- If `τ` is a `CanonicallyOrderedAddMonoid` (e.g., `ℕ` or `ℝ≥0`), then the notions
+/-- If `τ` is a `CanonicallyOrderedAddCommMonoid` (e.g., `ℕ` or `ℝ≥0`), then the notions
 `IsFwInvariant` and `IsInvariant` are equivalent. -/
-theorem IsFwInvariant.isInvariant [CanonicallyOrderedAddMonoid τ] {ϕ : τ → α → α} {s : Set α}
+theorem IsFwInvariant.isInvariant [CanonicallyOrderedAddCommMonoid τ] {ϕ : τ → α → α} {s : Set α}
     (h : IsFwInvariant ϕ s) : IsInvariant ϕ s := fun t => h (zero_le t)
 #align is_fw_invariant.is_invariant IsFwInvariant.isInvariant
 
-/-- If `τ` is a `CanonicallyOrderedAddMonoid` (e.g., `ℕ` or `ℝ≥0`), then the notions
+/-- If `τ` is a `CanonicallyOrderedAddCommMonoid` (e.g., `ℕ` or `ℝ≥0`), then the notions
 `IsFwInvariant` and `IsInvariant` are equivalent. -/
-theorem isFwInvariant_iff_isInvariant [CanonicallyOrderedAddMonoid τ] {ϕ : τ → α → α} {s : Set α} :
+theorem isFwInvariant_iff_isInvariant [CanonicallyOrderedAddCommMonoid τ] {ϕ : τ → α → α} {s : Set α} :
     IsFwInvariant ϕ s ↔ IsInvariant ϕ s :=
   ⟨IsFwInvariant.isInvariant, IsInvariant.isFwInvariant⟩
 #align is_fw_invariant_iff_is_invariant isFwInvariant_iff_isInvariant

--- a/Mathlib/Order/Filter/Germ.lean
+++ b/Mathlib/Order/Filter/Germ.lean
@@ -844,8 +844,8 @@ instance existsMulOfLE [Mul β] [LE β] [ExistsMulOfLE β] : ExistsMulOfLE (Germ
     rw [dif_pos hx, hc]
 
 @[to_additive]
-instance canonicallyOrderedMonoid [CanonicallyOrderedMonoid β] :
-    CanonicallyOrderedMonoid (Germ l β) :=
+instance CanonicallyOrderedCommMonoid [CanonicallyOrderedCommMonoid β] :
+    CanonicallyOrderedCommMonoid (Germ l β) :=
   { orderedCommMonoid, orderBot, existsMulOfLE with
     le_self_mul := fun x y ↦ inductionOn₂ x y fun _ _ ↦ eventually_of_forall fun _ ↦ le_self_mul }
 

--- a/Mathlib/Order/Height.lean
+++ b/Mathlib/Order/Height.lean
@@ -156,7 +156,7 @@ theorem chainHeight_of_isEmpty [IsEmpty α] : s.chainHeight = 0 :=
 
 theorem le_chainHeight_add_nat_iff {n m : ℕ} :
     ↑n ≤ s.chainHeight + m ↔ ∃ l ∈ s.subchain, n ≤ length l + m := by
-  simp_rw [← tsub_le_iff_right, ← ENat.coe_sub, (le_chainHeight_TFAE s (n - m)).out 0 2]
+  sorry -- simp_rw [← tsub_le_iff_right, ← ENat.coe_sub, (le_chainHeight_TFAE s (n - m)).out 0 2]
 #align set.le_chain_height_add_nat_iff Set.le_chainHeight_add_nat_iff
 
 theorem chainHeight_add_le_chainHeight_add (s : Set α) (t : Set β) (n m : ℕ) :

--- a/Mathlib/Order/Height.lean
+++ b/Mathlib/Order/Height.lean
@@ -156,7 +156,7 @@ theorem chainHeight_of_isEmpty [IsEmpty α] : s.chainHeight = 0 :=
 
 theorem le_chainHeight_add_nat_iff {n m : ℕ} :
     ↑n ≤ s.chainHeight + m ↔ ∃ l ∈ s.subchain, n ≤ length l + m := by
-  sorry -- simp_rw [← tsub_le_iff_right, ← ENat.coe_sub, (le_chainHeight_TFAE s (n - m)).out 0 2]
+  simp_rw [← tsub_le_iff_right, ← ENat.coe_sub, (le_chainHeight_TFAE s (n - m)).out 0 2]
 #align set.le_chain_height_add_nat_iff Set.le_chainHeight_add_nat_iff
 
 theorem chainHeight_add_le_chainHeight_add (s : Set α) (t : Set β) (n m : ℕ) :

--- a/Mathlib/RingTheory/GradedAlgebra/Basic.lean
+++ b/Mathlib/RingTheory/GradedAlgebra/Basic.lean
@@ -243,7 +243,7 @@ open SetLike.GradedMonoid DirectSum
 
 variable [Semiring A] [DecidableEq ι]
 
-variable [CanonicallyOrderedAddMonoid ι]
+variable [CanonicallyOrderedAddCommMonoid ι]
 
 variable [SetLike σ A] [AddSubmonoidClass σ A] (𝒜 : ι → σ) [GradedRing 𝒜]
 

--- a/Mathlib/RingTheory/GradedAlgebra/HomogeneousIdeal.lean
+++ b/Mathlib/RingTheory/GradedAlgebra/HomogeneousIdeal.lean
@@ -634,19 +634,19 @@ variable [Semiring A]
 
 variable [DecidableEq ι]
 
-variable [CanonicallyOrderedAddMonoid ι]
+variable [CanonicallyOrderedAddCommMonoid ι]
 
 variable [SetLike σ A] [AddSubmonoidClass σ A] (𝒜 : ι → σ) [GradedRing 𝒜]
 
 open GradedRing SetLike.GradedMonoid DirectSum
 
-/-- For a graded ring `⨁ᵢ 𝒜ᵢ` graded by a `CanonicallyOrderedAddMonoid ι`, the irrelevant ideal
+/-- For a graded ring `⨁ᵢ 𝒜ᵢ` graded by a `CanonicallyOrderedAddCommMonoid ι`, the irrelevant ideal
 refers to `⨁_{i>0} 𝒜ᵢ`, or equivalently `{a | a₀ = 0}`. This definition is used in `Proj`
 construction where `ι` is always `ℕ` so the irrelevant ideal is simply elements with `0` as
 0-th coordinate.
 
 # Future work
-Here in the definition, `ι` is assumed to be `CanonicallyOrderedAddMonoid`. However, the notion
+Here in the definition, `ι` is assumed to be `CanonicallyOrderedAddCommMonoid`. However, the notion
 of irrelevant ideal makes sense in a more general setting by defining it as the ideal of elements
 with `0` as i-th coordinate for all `i ≤ 0`, i.e. `{a | ∀ (i : ι), i ≤ 0 → aᵢ = 0}`.
 -/

--- a/Mathlib/RingTheory/MvPolynomial/WeightedHomogeneous.lean
+++ b/Mathlib/RingTheory/MvPolynomial/WeightedHomogeneous.lean
@@ -441,11 +441,11 @@ end WeightedHomogeneousComponent
 
 end AddCommMonoid
 
-section CanonicallyOrderedAddMonoid
+section CanonicallyOrderedAddCommMonoid
 
-variable [CanonicallyOrderedAddMonoid M] {w : σ → M} (φ : MvPolynomial σ R)
+variable [CanonicallyOrderedAddCommMonoid M] {w : σ → M} (φ : MvPolynomial σ R)
 
-/-- If `M` is a `CanonicallyOrderedAddMonoid`, then the `weightedHomogeneousComponent`
+/-- If `M` is a `CanonicallyOrderedAddCommMonoid`, then the `weightedHomogeneousComponent`
   of weighted degree `0` of a polynomial is its constant coefficient. -/
 @[simp]
 theorem weightedHomogeneousComponent_zero [NoZeroSMulDivisors ℕ M] (hw : ∀ i : σ, w i ≠ 0) :
@@ -463,6 +463,6 @@ theorem weightedHomogeneousComponent_zero [NoZeroSMulDivisors ℕ M] (hw : ∀ i
     exact ⟨i, hi, hw i⟩
 #align mv_polynomial.weighted_homogeneous_component_zero MvPolynomial.weightedHomogeneousComponent_zero
 
-end CanonicallyOrderedAddMonoid
+end CanonicallyOrderedAddCommMonoid
 
 end MvPolynomial

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -692,7 +692,7 @@ instance canonicallyOrderedCommSemiring : CanonicallyOrderedCommSemiring Cardina
       inductionOn₂ a b fun α β => by
         simpa only [mul_def, mk_eq_zero_iff, isEmpty_prod] using id }
 
-instance : CanonicallyLinearOrderedAddMonoid Cardinal.{u} :=
+instance : CanonicallyLinearOrderedAddCommMonoid Cardinal.{u} :=
   { Cardinal.canonicallyOrderedCommSemiring, Cardinal.linearOrder with }
 
 -- Computable instance to prevent a non-computable one being found via the one above

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -696,7 +696,7 @@ instance : CanonicallyLinearOrderedAddMonoid Cardinal.{u} :=
   { Cardinal.canonicallyOrderedCommSemiring, Cardinal.linearOrder with }
 
 -- Computable instance to prevent a non-computable one being found via the one above
-instance : CanonicallyOrderedAddMonoid Cardinal.{u} :=
+instance : CanonicallyOrderedAddCommMonoid Cardinal.{u} :=
   { Cardinal.canonicallyOrderedCommSemiring with }
 
 instance : LinearOrderedCommMonoidWithZero Cardinal.{u} :=

--- a/Mathlib/Tactic/Positivity/Core.lean
+++ b/Mathlib/Tactic/Positivity/Core.lean
@@ -201,9 +201,9 @@ def normNumPositivity (e : Q($α)) : MetaM (Strictness zα pα e) := catchNone d
       haveI' w : decide ($n < 0) =Q true := ⟨⟩
       pure (.nonzero q(nz_of_isRat $p $w))
 
-/-- Attempts to prove that `e ≥ 0` using `zero_le` in a `CanonicallyOrderedAddMonoid`. -/
+/-- Attempts to prove that `e ≥ 0` using `zero_le` in a `CanonicallyOrderedAddCommMonoid`. -/
 def positivityCanon (e : Q($α)) : MetaM (Strictness zα pα e) := do
-  let _i ← synthInstanceQ (q(CanonicallyOrderedAddMonoid $α) : Q(Type u))
+  let _i ← synthInstanceQ (q(CanonicallyOrderedAddCommMonoid $α) : Q(Type u))
   assumeInstancesCommute
   pure (.nonnegative q(zero_le $e))
 

--- a/Mathlib/Topology/Algebra/InfiniteSum/Order.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Order.lean
@@ -190,9 +190,9 @@ theorem tsum_pos (hsum : Summable g) (hg : ∀ i, 0 ≤ g i) (i : ι) (hi : 0 < 
 
 end OrderedAddCommGroup
 
-section CanonicallyOrderedAddMonoid
+section CanonicallyOrderedAddCommMonoid
 
-variable [CanonicallyOrderedAddMonoid α] [TopologicalSpace α] [OrderClosedTopology α] {f : ι → α}
+variable [CanonicallyOrderedAddCommMonoid α] [TopologicalSpace α] [OrderClosedTopology α] {f : ι → α}
   {a : α}
 
 theorem le_hasSum' (hf : HasSum f a) (i : ι) : f i ≤ a :=
@@ -219,7 +219,7 @@ theorem isLUB_hasSum' (hf : HasSum f a) : IsLUB (Set.range fun s => ∑ i in s, 
   isLUB_of_tendsto_atTop (Finset.sum_mono_set f) hf
 #align is_lub_has_sum' isLUB_hasSum'
 
-end CanonicallyOrderedAddMonoid
+end CanonicallyOrderedAddCommMonoid
 
 section LinearOrder
 

--- a/Mathlib/Topology/Algebra/InfiniteSum/Order.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Order.lean
@@ -192,8 +192,8 @@ end OrderedAddCommGroup
 
 section CanonicallyOrderedAddCommMonoid
 
-variable [CanonicallyOrderedAddCommMonoid α] [TopologicalSpace α] [OrderClosedTopology α] {f : ι → α}
-  {a : α}
+variable [CanonicallyOrderedAddCommMonoid α] [TopologicalSpace α] [OrderClosedTopology α]
+  {f : ι → α} {a : α}
 
 theorem le_hasSum' (hf : HasSum f a) (i : ι) : f i ≤ a :=
   le_hasSum hf i fun _ _ => zero_le _
@@ -238,8 +238,9 @@ theorem hasSum_of_isLUB_of_nonneg [LinearOrderedAddCommMonoid α] [TopologicalSp
   tendsto_atTop_isLUB (Finset.sum_mono_set_of_nonneg h) hf
 #align has_sum_of_is_lub_of_nonneg hasSum_of_isLUB_of_nonneg
 
-theorem hasSum_of_isLUB [CanonicallyLinearOrderedAddCommMonoid α] [TopologicalSpace α] [OrderTopology α]
-    {f : ι → α} (b : α) (hf : IsLUB (Set.range fun s => ∑ i in s, f i) b) : HasSum f b :=
+theorem hasSum_of_isLUB [CanonicallyLinearOrderedAddCommMonoid α] [TopologicalSpace α]
+    [OrderTopology α] {f : ι → α} (b : α) (hf : IsLUB (Set.range fun s => ∑ i in s, f i) b) :
+    HasSum f b :=
   tendsto_atTop_isLUB (Finset.sum_mono_set f) hf
 #align has_sum_of_is_lub hasSum_of_isLUB
 

--- a/Mathlib/Topology/Algebra/InfiniteSum/Order.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Order.lean
@@ -238,7 +238,7 @@ theorem hasSum_of_isLUB_of_nonneg [LinearOrderedAddCommMonoid α] [TopologicalSp
   tendsto_atTop_isLUB (Finset.sum_mono_set_of_nonneg h) hf
 #align has_sum_of_is_lub_of_nonneg hasSum_of_isLUB_of_nonneg
 
-theorem hasSum_of_isLUB [CanonicallyLinearOrderedAddMonoid α] [TopologicalSpace α] [OrderTopology α]
+theorem hasSum_of_isLUB [CanonicallyLinearOrderedAddCommMonoid α] [TopologicalSpace α] [OrderTopology α]
     {f : ι → α} (b : α) (hf : IsLUB (Set.range fun s => ∑ i in s, f i) b) : HasSum f b :=
   tendsto_atTop_isLUB (Finset.sum_mono_set f) hf
 #align has_sum_of_is_lub hasSum_of_isLUB


### PR DESCRIPTION
Renames:


`CanonicallyOrderedMonoid` ->
`CanonicallyOrderedCommMonoid`

`CanonicallyOrderedAddMonoid` ->
`CanonicallyOrderedAddCommMonoid`

`CanonicallyLinearOrderedMonoid` ->
`CanonicallyLinearOrderedCommMonoid`

`CanonicallyLinearOrderedAddMonoid` ->
`CanonicallyLinearOrderedAddCommMonoid`

---
