### PR TITLE
[Merged by Bors] - refactor: purge aesop_cat_nonterminal

### DIFF
--- a/Mathlib/Algebra/Category/ModuleCat/Algebra.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Algebra.lean
@@ -65,7 +65,11 @@ instance linearOverField : Linear k (ModuleCat.{v} A) where
   homModule M N := LinearMap.module
   smul_comp := by
     -- Porting note: this was automatic by `aesop_cat`
-    intros; ext; erw [LinearMap.map_smul_of_tower]; rfl
+    intros
+    ext
+    dsimp only [coe_comp, Function.comp_apply]
+    rw [LinearMap.smul_apply, LinearMap.map_smul_of_tower]
+    rfl
 #align Module.linear_over_field ModuleCat.linearOverField
 
 end ModuleCat

--- a/Mathlib/Algebra/Category/ModuleCat/Algebra.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Algebra.lean
@@ -65,9 +65,7 @@ instance linearOverField : Linear k (ModuleCat.{v} A) where
   homModule M N := LinearMap.module
   smul_comp := by
     -- Porting note: this was automatic by `aesop_cat`
-    aesop_cat_nonterminal
-    rw [LinearMap.smul_apply, LinearMap.smul_apply, LinearMap.map_smul_of_tower]
-    rfl
+    intros; ext; erw [LinearMap.map_smul_of_tower]; rfl
 #align Module.linear_over_field ModuleCat.linearOverField
 
 end ModuleCat

--- a/Mathlib/CategoryTheory/Bicategory/Basic.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Basic.lean
@@ -227,7 +227,7 @@ instance whiskerLeft_isIso (f : a ⟶ b) {g h : b ⟶ c} (η : g ⟶ h) [IsIso �
 @[simp]
 theorem inv_whiskerLeft (f : a ⟶ b) {g h : b ⟶ c} (η : g ⟶ h) [IsIso η] :
     inv (f ◁ η) = f ◁ inv η := by
-  aesop_cat_nonterminal
+  apply IsIso.inv_eq_of_hom_inv_id
   simp only [← whiskerLeft_comp, whiskerLeft_id, IsIso.hom_inv_id]
 #align category_theory.bicategory.inv_whisker_left CategoryTheory.Bicategory.inv_whiskerLeft
 
@@ -246,7 +246,7 @@ instance whiskerRight_isIso {f g : a ⟶ b} (η : f ⟶ g) (h : b ⟶ c) [IsIso 
 @[simp]
 theorem inv_whiskerRight {f g : a ⟶ b} (η : f ⟶ g) (h : b ⟶ c) [IsIso η] :
     inv (η ▷ h) = inv η ▷ h := by
-  aesop_cat_nonterminal
+  apply IsIso.inv_eq_of_hom_inv_id
   simp only [← comp_whiskerRight, id_whiskerRight, IsIso.hom_inv_id]
 #align category_theory.bicategory.inv_whisker_right CategoryTheory.Bicategory.inv_whiskerRight
 

--- a/Mathlib/CategoryTheory/Category/Basic.lean
+++ b/Mathlib/CategoryTheory/Category/Basic.lean
@@ -140,6 +140,9 @@ macro (name := aesop_cat_nonterminal) "aesop_cat_nonterminal" c:Aesop.tactic_cla
 -- We turn on `ext` inside `aesop_cat`.
 attribute [aesop safe tactic (rule_sets [CategoryTheory])] Std.Tactic.Ext.extCore'
 
+-- We turn on the mathlib version of `rfl` inside `aesop_cat`.
+attribute [aesop safe tactic (rule_sets [CategoryTheory])] Mathlib.Tactic.rflTac
+
 -- Porting note:
 -- Workaround for issue discussed at https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/Failure.20of.20TC.20search.20in.20.60simp.60.20with.20.60etaExperiment.60.2E
 -- now that etaExperiment is always on.

--- a/Mathlib/CategoryTheory/Limits/IsLimit.lean
+++ b/Mathlib/CategoryTheory/Limits/IsLimit.lean
@@ -602,7 +602,7 @@ def descCoconeMorphism {t : Cocone F} (h : IsColimit t) (s : Cocone F) : t ⟶ s
 
 theorem uniq_cocone_morphism {s t : Cocone F} (h : IsColimit t) {f f' : t ⟶ s} : f = f' :=
   have : ∀ {g : t ⟶ s}, g = h.descCoconeMorphism s := by
-    intro g; aesop_cat_nonterminal; exact h.uniq _ _ g.w
+    intro g; ext; exact h.uniq _ _ g.w
   this.trans this.symm
 #align category_theory.limits.is_colimit.uniq_cocone_morphism CategoryTheory.Limits.IsColimit.uniq_cocone_morphism
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/WidePullbacks.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/WidePullbacks.lean
@@ -153,11 +153,11 @@ def equivalenceOfEquiv (J' : Type w') (h : J ≃ J') : WidePullbackShape J ≌ W
   functor := wideCospan none (fun j => some (h j)) fun j => Hom.term (h j)
   inverse := wideCospan none (fun j => some (h.invFun j)) fun j => Hom.term (h.invFun j)
   unitIso :=
-    NatIso.ofComponents (fun j => by aesop_cat_nonterminal; repeat rfl) fun f => by
-      simp only [eq_iff_true_of_subsingleton]
+    NatIso.ofComponents (fun j => by aesop_cat) fun f =>
+      by simp only [eq_iff_true_of_subsingleton]
   counitIso :=
-    NatIso.ofComponents (fun j => by aesop_cat_nonterminal; repeat rfl) fun f => by
-      simp only [eq_iff_true_of_subsingleton]
+    NatIso.ofComponents (fun j => by aesop_cat)
+      fun f => by simp only [eq_iff_true_of_subsingleton]
 #align category_theory.limits.wide_pullback_shape.equivalence_of_equiv CategoryTheory.Limits.WidePullbackShape.equivalenceOfEquiv
 
 /-- Lifting universe and morphism levels preserves wide pullback diagrams. -/
@@ -273,10 +273,10 @@ def equivalenceOfEquiv (J' : Type w') (h : J ≃ J') : WidePushoutShape J ≌ Wi
   functor := wideSpan none (fun j => some (h j)) fun j => Hom.init (h j)
   inverse := wideSpan none (fun j => some (h.invFun j)) fun j => Hom.init (h.invFun j)
   unitIso :=
-    NatIso.ofComponents (fun j => by aesop_cat_nonterminal; repeat rfl) fun f => by
+    NatIso.ofComponents (fun j => by aesop_cat) fun f => by
       simp only [eq_iff_true_of_subsingleton]
   counitIso :=
-    NatIso.ofComponents (fun j => by aesop_cat_nonterminal; repeat rfl) fun f => by
+    NatIso.ofComponents (fun j => by aesop_cat) fun f => by
       simp only [eq_iff_true_of_subsingleton]
 
 /-- Lifting universe and morphism levels preserves wide pushout diagrams. -/

--- a/Mathlib/CategoryTheory/Monoidal/Category.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Category.lean
@@ -244,8 +244,7 @@ instance tensor_isIso {W X Y Z : C} (f : W ⟶ X) [IsIso f] (g : Y ⟶ Z) [IsIso
 @[simp]
 theorem inv_tensor {W X Y Z : C} (f : W ⟶ X) [IsIso f] (g : Y ⟶ Z) [IsIso g] :
     inv (f ⊗ g) = inv f ⊗ inv g := by
-  -- Porting note: Replaced `ext` with `aesop_cat_nonterminal`
-  aesop_cat_nonterminal
+  apply IsIso.inv_eq_of_hom_inv_id
   simp [← tensor_comp]
 #align category_theory.monoidal_category.inv_tensor CategoryTheory.MonoidalCategory.inv_tensor
 

--- a/Mathlib/CategoryTheory/Opposites.lean
+++ b/Mathlib/CategoryTheory/Opposites.lean
@@ -154,13 +154,13 @@ instance isIso_unop {X Y : Cᵒᵖ} (f : X ⟶ Y) [IsIso f] : IsIso f.unop :=
 
 @[simp]
 theorem op_inv {X Y : C} (f : X ⟶ Y) [IsIso f] : (inv f).op = inv f.op := by
-  aesop_cat_nonterminal
+  apply IsIso.eq_inv_of_hom_inv_id
   rw [← op_comp, IsIso.inv_hom_id, op_id]
 #align category_theory.op_inv CategoryTheory.op_inv
 
 @[simp]
 theorem unop_inv {X Y : Cᵒᵖ} (f : X ⟶ Y) [IsIso f] : (inv f).unop = inv f.unop := by
-  aesop_cat_nonterminal
+  apply IsIso.eq_inv_of_hom_inv_id
   rw [← unop_comp, IsIso.inv_hom_id, unop_id]
 #align category_theory.unop_inv CategoryTheory.unop_inv
 

--- a/Mathlib/CategoryTheory/Over.lean
+++ b/Mathlib/CategoryTheory/Over.lean
@@ -299,7 +299,8 @@ variable {D : Type u₂} [Category.{v₂} D]
 def post (F : T ⥤ D) : Over X ⥤ Over (F.obj X)
     where
   obj Y := mk <| F.map Y.hom
-  map f := Over.homMk (F.map f.left) (by aesop_cat_nonterminal; erw [← F.map_comp, w])
+  map f := Over.homMk (F.map f.left)
+    (by simp only [Functor.id_obj, mk_left, Functor.const_obj_obj, mk_hom, ← F.map_comp, w])
 #align category_theory.over.post CategoryTheory.Over.post
 
 end
@@ -536,7 +537,8 @@ variable {D : Type u₂} [Category.{v₂} D]
 @[simps]
 def post {X : T} (F : T ⥤ D) : Under X ⥤ Under (F.obj X) where
   obj Y := mk <| F.map Y.hom
-  map f := Under.homMk (F.map f.right) (by aesop_cat_nonterminal; erw [← F.map_comp, w])
+  map f := Under.homMk (F.map f.right)
+    (by simp only [Functor.id_obj, Functor.const_obj_obj, mk_right, mk_hom, ← F.map_comp, w])
 #align category_theory.under.post CategoryTheory.Under.post
 
 end

--- a/Mathlib/CategoryTheory/Sums/Basic.lean
+++ b/Mathlib/CategoryTheory/Sums/Basic.lean
@@ -147,10 +147,8 @@ namespace Swap
 /-- `swap` gives an equivalence between `C ⊕ D` and `D ⊕ C`. -/
 def equivalence : Sum C D ≌ Sum D C :=
   Equivalence.mk (swap C D) (swap D C)
-    (NatIso.ofComponents (fun X => eqToIso (by cases X <;> rfl))
-      (by aesop_cat (add norm simp swap)))
-    (NatIso.ofComponents (fun X => eqToIso (by cases X <;> rfl))
-      (by aesop_cat (add norm simp swap)))
+    (NatIso.ofComponents (fun X => eqToIso (by cases X <;> rfl)))
+    (NatIso.ofComponents (fun X => eqToIso (by cases X <;> rfl)))
 #align category_theory.sum.swap.equivalence CategoryTheory.Sum.Swap.equivalence
 
 instance isEquivalence : IsEquivalence (swap C D) :=

--- a/Mathlib/CategoryTheory/Sums/Basic.lean
+++ b/Mathlib/CategoryTheory/Sums/Basic.lean
@@ -58,6 +58,14 @@ instance sum : Category.{v₁} (Sum C D) where
     | inr X, inr Y, inr Z, inr W => Category.assoc f g h
 #align category_theory.sum CategoryTheory.sum
 
+@[aesop norm -10 destruct (rule_sets [CategoryTheory])]
+theorem hom_inl_inr_false {X : C} {Y : D} (f : Sum.inl X ⟶ Sum.inr Y) : False := by
+  cases f
+
+@[aesop norm -10 destruct (rule_sets [CategoryTheory])]
+theorem hom_inr_inl_false {X : C} {Y : D} (f : Sum.inr X ⟶ Sum.inl Y) : False := by
+  cases f
+
 /- Porting note: seems similar to Mathlib4#1036 issue so marked as nolint  -/
 @[simp, nolint simpComm]
 theorem sum_comp_inl {P Q R : C} (f : (inl P : Sum C D) ⟶ inl Q) (g : (inl Q : Sum C D) ⟶ inl R) :
@@ -136,15 +144,13 @@ theorem swap_map_inr {X Y : D} {f : inr X ⟶ inr Y} : (swap C D).map f = f :=
 
 namespace Swap
 
-/- Porting note: had to manually call `cases f` for `f : PEmpty` -/
-
 /-- `swap` gives an equivalence between `C ⊕ D` and `D ⊕ C`. -/
 def equivalence : Sum C D ≌ Sum D C :=
   Equivalence.mk (swap C D) (swap D C)
     (NatIso.ofComponents (fun X => eqToIso (by cases X <;> rfl))
-      (by simp only [swap]; aesop_cat_nonterminal; cases f; cases f))
+      (by aesop_cat (add norm simp swap)))
     (NatIso.ofComponents (fun X => eqToIso (by cases X <;> rfl))
-      (by simp only [swap]; aesop_cat_nonterminal; cases f; cases f))
+      (by aesop_cat (add norm simp swap)))
 #align category_theory.sum.swap.equivalence CategoryTheory.Sum.Swap.equivalence
 
 instance isEquivalence : IsEquivalence (swap C D) :=
@@ -176,17 +182,11 @@ def sum (F : A ⥤ B) (G : C ⥤ D) : Sum A C ⥤ Sum B D
     match X, Y, f with
     | inl X, inl Y, f => F.map f
     | inr X, inr Y, f => G.map f
-  map_id := @fun X => by cases X <;> aesop_cat_nonterminal; erw [F.map_id]; rfl; erw [G.map_id]; rfl
+  map_id := @fun X => by cases X <;> (erw [Functor.map_id]; rfl)
   map_comp := @fun X Y Z f g =>
     match X, Y, Z, f, g with
-    | inl X, inl Y, inl Z, f, g => by
-      aesop_cat_nonterminal <;>
-      erw [F.map_comp] <;>
-      rfl
-    | inr X, inr Y, inr Z, f, g => by
-      aesop_cat_nonterminal <;>
-      erw [G.map_comp] <;>
-      rfl
+    | inl X, inl Y, inl Z, f, g => by erw [F.map_comp]; rfl
+    | inr X, inr Y, inr Z, f, g => by erw [G.map_comp]; rfl
 #align category_theory.functor.sum CategoryTheory.Functor.sum
 
 @[simp]
@@ -224,8 +224,8 @@ def sum {F G : A ⥤ B} {H I : C ⥤ D} (α : F ⟶ G) (β : H ⟶ I) : F.sum H 
     | inr X => β.app X
   naturality X Y f :=
     match X, Y, f with
-    | inl X, inl Y, f => by aesop_cat_nonterminal <;> erw [α.naturality] <;> rfl
-    | inr X, inr Y, f => by aesop_cat_nonterminal <;> erw [β.naturality] <;> rfl
+    | inl X, inl Y, f => by erw [α.naturality]; rfl
+    | inr X, inr Y, f => by erw [β.naturality]; rfl
 #align category_theory.nat_trans.sum CategoryTheory.NatTrans.sum
 
 @[simp]

--- a/Mathlib/Tactic/Relation/Rfl.lean
+++ b/Mathlib/Tactic/Relation/Rfl.lean
@@ -74,8 +74,12 @@ def _root_.Lean.MVarId.rfl (goal : MVarId) : MetaM Unit := do
 This tactic applies to a goal whose target has the form `x ~ x`, where `~` is a reflexive
 relation, that is, a relation which has a reflexive lemma tagged with the attribute [refl].
 -/
+def rflTac : TacticM Unit :=
+  withMainContext do liftMetaFinishingTactic (·.rfl)
+
+@[inherit_doc rflTac]
 elab_rules : tactic
-| `(tactic| rfl) => withMainContext do liftMetaFinishingTactic (·.rfl)
+| `(tactic| rfl) => rflTac
 
 /-- Helper theorem for `Lean.MVar.liftReflToEq`. -/
 private theorem rel_of_eq_and_refl {α : Sort _} {R : α → α → Prop}


### PR DESCRIPTION
`aesop_cat_nonterminal` is a non-terminal variant of `aesop`. It's not supposed to be used in production code since it's even worse than non-terminal `simp`. However, there were a few occurrences left (presumably from the port), which this PR removes.

The only nontrivial change is that I add mathlib's `rfl` tactic to the `CategoryTheory` Aesop rule set.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
