### PR TITLE
[Merged by Bors] - style: rename `Stream'.nth` to `Stream'.get`

### DIFF
--- a/Mathlib/Algebra/ContinuedFractions/Computation/TerminatesIffRat.lean
+++ b/Mathlib/Algebra/ContinuedFractions/Computation/TerminatesIffRat.lean
@@ -218,7 +218,7 @@ theorem coe_of_s_get?_rat_eq :
   simp only [Stream'.Seq.get?]
   rw [← IntFractPair.coe_stream'_rat_eq v_eq_q]
   rcases succ_nth_stream_eq : IntFractPair.stream q (n + 1) with (_ | ⟨_, _⟩) <;>
-    simp [Stream'.map, Stream'.nth, succ_nth_stream_eq]
+    simp [Stream'.map, Stream'.get, succ_nth_stream_eq]
 #align generalized_continued_fraction.coe_of_s_nth_rat_eq GeneralizedContinuedFraction.coe_of_s_get?_rat_eq
 
 theorem coe_of_s_rat_eq : ((of q).s.map (Pair.map ((↑))) : Stream'.Seq <| Pair K) = (of v).s := by

--- a/Mathlib/Algebra/ContinuedFractions/Computation/Translations.lean
+++ b/Mathlib/Algebra/ContinuedFractions/Computation/Translations.lean
@@ -266,7 +266,7 @@ theorem of_s_head_aux (v : K) : (of v).s.get? 0 = (IntFractPair.stream v 1).bind
   rw [of, IntFractPair.seq1]
   simp only [of, Stream'.Seq.map_tail, Stream'.Seq.map, Stream'.Seq.tail, Stream'.Seq.head,
     Stream'.Seq.get?, Stream'.map]
-  rw [← Stream'.nth_succ, Stream'.nth, Option.map]
+  rw [← Stream'.get_succ, Stream'.get, Option.map]
   split <;> simp_all only [Option.some_bind, Option.none_bind, Function.comp_apply]
 #align generalized_continued_fraction.of_s_head_aux GeneralizedContinuedFraction.of_s_head_aux
 

--- a/Mathlib/Combinatorics/Hindman.lean
+++ b/Mathlib/Combinatorics/Hindman.lean
@@ -252,7 +252,7 @@ set_option linter.uppercaseLean3 false in
 #align hindman.FS_iter_tail_sub_FS Hindman.FS_iter_tail_sub_FS
 
 @[to_additive]
-theorem FP.singleton {M} [Semigroup M] (a : Stream' M) (i : ℕ) : a.nth i ∈ FP a := by
+theorem FP.singleton {M} [Semigroup M] (a : Stream' M) (i : ℕ) : a.get i ∈ FP a := by
   induction' i with i ih generalizing a
   · apply FP.head
   · apply FP.tail
@@ -264,7 +264,7 @@ set_option linter.uppercaseLean3 false in
 
 @[to_additive]
 theorem FP.mul_two {M} [Semigroup M] (a : Stream' M) (i j : ℕ) (ij : i < j) :
-    a.nth i * a.nth j ∈ FP a := by
+    a.get i * a.get j ∈ FP a := by
   refine' FP_drop_subset_FP _ i _
   rw [← Stream'.head_drop]
   apply FP.cons
@@ -272,7 +272,7 @@ theorem FP.mul_two {M} [Semigroup M] (a : Stream' M) (i j : ℕ) (ij : i < j) :
   -- Porting note: need to fix breakage of Set notation
   change _ ∈ FP _
   have := FP.singleton (a.drop i).tail d
-  rw [Stream'.tail_eq_drop, Stream'.nth_drop, Stream'.nth_drop] at this
+  rw [Stream'.tail_eq_drop, Stream'.get_drop, Stream'.get_drop] at this
   convert this
   rw [hd, add_comm, Nat.succ_add, Nat.add_succ]
 set_option linter.uppercaseLean3 false in
@@ -282,7 +282,7 @@ set_option linter.uppercaseLean3 false in
 
 @[to_additive]
 theorem FP.finset_prod {M} [CommMonoid M] (a : Stream' M) (s : Finset ℕ) (hs : s.Nonempty) :
-    (s.prod fun i => a.nth i) ∈ FP a := by
+    (s.prod fun i => a.get i) ∈ FP a := by
   refine' FP_drop_subset_FP _ (s.min' hs) _
   induction' s using Finset.strongInduction with s ih
   rw [← Finset.mul_prod_erase _ _ (s.min'_mem hs), ← Stream'.head_drop]

--- a/Mathlib/Control/LawfulFix.lean
+++ b/Mathlib/Control/LawfulFix.lean
@@ -124,7 +124,7 @@ theorem le_f_of_mem_approx {x} : x ∈ approxChain f → x ≤ f x := by
 #align part.fix.le_f_of_mem_approx Part.Fix.le_f_of_mem_approx
 
 theorem approx_mem_approxChain {i} : approx f i ∈ approxChain f :=
-  Stream'.mem_of_nth_eq rfl
+  Stream'.mem_of_get_eq rfl
 #align part.fix.approx_mem_approx_chain Part.Fix.approx_mem_approxChain
 
 end Fix

--- a/Mathlib/Data/Seq/Computation.lean
+++ b/Mathlib/Data/Seq/Computation.lean
@@ -254,7 +254,7 @@ theorem corec_eq (f : β → Sum α β) (b : β) : destruct (corec f b) = rmap (
   dsimp [corec, destruct]
   rw [show Stream'.corec' (Corec.f f) (Sum.inr b) 0 =
     Sum.rec Option.some (λ _ => none) (f b) by
-    dsimp [Corec.f, Stream'.corec', Stream'.corec, Stream'.map, Stream'.nth, Stream'.iterate]
+    dsimp [Corec.f, Stream'.corec', Stream'.corec, Stream'.map, Stream'.get, Stream'.iterate]
     match (f b) with
     | Sum.inl x => rfl
     | Sum.inr x => rfl
@@ -360,7 +360,7 @@ theorem terminates_of_mem {s : Computation α} {a : α} (h : a ∈ s) : Terminat
 theorem terminates_def (s : Computation α) : Terminates s ↔ ∃ n, (s.1 n).isSome :=
   ⟨fun ⟨⟨a, n, h⟩⟩ =>
     ⟨n, by
-      dsimp [Stream'.nth] at h
+      dsimp [Stream'.get] at h
       rw [← h]
       exact rfl⟩,
     fun ⟨n, h⟩ => ⟨⟨Option.get _ h, n, (Option.eq_some_of_isSome h).symm⟩⟩⟩
@@ -646,7 +646,7 @@ def terminatesRecOn
 def map (f : α → β) : Computation α → Computation β
   | ⟨s, al⟩ =>
     ⟨s.map fun o => Option.casesOn o none (some ∘ f), fun n b => by
-      dsimp [Stream'.map, Stream'.nth]
+      dsimp [Stream'.map, Stream'.get]
       induction' e : s n with a <;> intro h
       · contradiction
       · rw [al e]; exact h⟩

--- a/Mathlib/Data/Seq/Seq.lean
+++ b/Mathlib/Data/Seq/Seq.lean
@@ -28,7 +28,7 @@ coinductive seq (α : Type u) : Type u
 | nil : seq α
 | cons : α → seq α → seq α
 -/
-/-- A stream `s : Option α` is a sequence if `s.nth n = none` implies `s.nth (n + 1) = none`.
+/-- A stream `s : Option α` is a sequence if `s.get n = none` implies `s.get (n + 1) = none`.
 -/
 def IsSeq {α : Type u} (s : Stream' (Option α)) : Prop :=
   ∀ {n : ℕ}, s n = none → s (n + 1) = none
@@ -289,7 +289,7 @@ def recOn {C : Seq α → Sort v} (s : Seq α) (h1 : C nil) (h2 : ∀ x s, C (co
 
 theorem mem_rec_on {C : Seq α → Prop} {a s} (M : a ∈ s)
     (h1 : ∀ b s', a = b ∨ C s' → C (cons b s')) : C s := by
-  cases' M with k e; unfold Stream'.nth at e
+  cases' M with k e; unfold Stream'.get at e
   induction' k with k IH generalizing s
   · have TH : s = cons a (tail s) := by
       apply destruct_eq_cons
@@ -341,7 +341,7 @@ def corec (f : β → Option (α × β)) (b : β) : Seq α := by
 @[simp]
 theorem corec_eq (f : β → Option (α × β)) (b : β) :
     destruct (corec f b) = omap (corec f) (f b) := by
-  dsimp [corec, destruct, nth]
+  dsimp [corec, destruct, get]
   -- porting note: next two lines were `change`...`with`...
   have h: Stream'.corec' (Corec.f f) (some b) 0 = (Corec.f f (some b)).1 := rfl
   rw [h]
@@ -447,9 +447,9 @@ theorem ofList_nil : ofList [] = (nil : Seq α) :=
 #align stream.seq.of_list_nil Stream'.Seq.ofList_nil
 
 @[simp]
-theorem ofList_nth (l : List α) (n : ℕ) : (ofList l).get? n = l.get? n :=
+theorem ofList_get (l : List α) (n : ℕ) : (ofList l).get? n = l.get? n :=
   rfl
-#align stream.seq.of_list_nth Stream'.Seq.ofList_nth
+#align stream.seq.of_list_nth Stream'.Seq.ofList_get
 
 @[simp]
 theorem ofList_cons (a : α) (l : List α) : ofList (a::l) = cons a (ofList l) := by
@@ -520,7 +520,7 @@ def append (s₁ s₂ : Seq α) : Seq α :=
 def map (f : α → β) : Seq α → Seq β
   | ⟨s, al⟩ =>
     ⟨s.map (Option.map f), fun {n} => by
-      dsimp [Stream'.map, Stream'.nth]
+      dsimp [Stream'.map, Stream'.get]
       induction' e : s n with e <;> intro
       · rw [al e]
         assumption

--- a/Mathlib/Data/Seq/WSeq.lean
+++ b/Mathlib/Data/Seq/WSeq.lean
@@ -881,10 +881,10 @@ def toSeq (s : WSeq α) [Productive s] : Seq α :=
    fun {n} h => by
     cases e : Computation.get (get? s (n + 1))
     · assumption
-    have := mem_of_get_eq _ e
+    have := Computation.mem_of_get_eq _ e
     simp [get?] at this h
     cases' head_some_of_head_tail_some this with a' h'
-    have := mem_unique h' (@mem_of_get_eq _ _ _ _ h)
+    have := mem_unique h' (@Computation.mem_of_get_eq _ _ _ _ h)
     contradiction⟩
 #align stream.wseq.to_seq Stream'.WSeq.toSeq
 
@@ -966,7 +966,7 @@ theorem mem_cons (s : WSeq α) (a) : a ∈ cons a s :=
 #align stream.wseq.mem_cons Stream'.WSeq.mem_cons
 
 theorem mem_of_mem_tail {s : WSeq α} {a} : a ∈ tail s → a ∈ s := by
-  intro h; have := h; cases' h with n e; revert s; simp [Stream'.nth]
+  intro h; have := h; cases' h with n e; revert s; simp [Stream'.get]
   induction' n with n IH <;> intro s <;> induction' s using WSeq.recOn with x s s <;>
     simp <;> intro m e <;>
     injections

--- a/Mathlib/Data/Stream/Defs.lean
+++ b/Mathlib/Data/Stream/Defs.lean
@@ -32,49 +32,49 @@ def cons (a : α) (s : Stream' α) : Stream' α
 
 scoped infixr:67 " :: " => cons
 
-/-- `n`-th element of a stream. -/
-def nth (s : Stream' α) (n : ℕ) : α := s n
-#align stream.nth Stream'.nth
+/-- Get the `n`-th element of a stream. -/
+def get (s : Stream' α) (n : ℕ) : α := s n
+#align stream.nth Stream'.get
 
-/-- Head of a stream: `Stream'.head s = Stream'.nth s 0`. -/
-abbrev head (s : Stream' α) : α := s.nth 0
+/-- Head of a stream: `Stream'.head s = Stream'.get s 0`. -/
+abbrev head (s : Stream' α) : α := s.get 0
 #align stream.head Stream'.head
 
 /-- Tail of a stream: `Stream'.tail (h :: t) = t`. -/
-def tail (s : Stream' α) : Stream' α := fun i => s.nth (i + 1)
+def tail (s : Stream' α) : Stream' α := fun i => s.get (i + 1)
 #align stream.tail Stream'.tail
 
 /-- Drop first `n` elements of a stream. -/
-def drop (n : Nat) (s : Stream' α) : Stream' α := fun i => s.nth (i + n)
+def drop (n : Nat) (s : Stream' α) : Stream' α := fun i => s.get (i + n)
 #align stream.drop Stream'.drop
 
 /-- Proposition saying that all elements of a stream satisfy a predicate. -/
-def All (p : α → Prop) (s : Stream' α) := ∀ n, p (nth s n)
+def All (p : α → Prop) (s : Stream' α) := ∀ n, p (get s n)
 #align stream.all Stream'.All
 
 /-- Proposition saying that at least one element of a stream satisfies a predicate. -/
-def Any (p : α → Prop) (s : Stream' α) := ∃ n, p (nth s n)
+def Any (p : α → Prop) (s : Stream' α) := ∃ n, p (get s n)
 #align stream.any Stream'.Any
 
-/-- `a ∈ s` means that `a = Stream'.nth n s` for some `n`. -/
+/-- `a ∈ s` means that `a = Stream'.get n s` for some `n`. -/
 instance : Membership α (Stream' α) :=
   ⟨fun a s => Any (fun b => a = b) s⟩
 
 /-- Apply a function `f` to all elements of a stream `s`. -/
-def map (f : α → β) (s : Stream' α) : Stream' β := fun n => f (nth s n)
+def map (f : α → β) (s : Stream' α) : Stream' β := fun n => f (get s n)
 #align stream.map Stream'.map
 
 /-- Zip two streams using a binary operation:
-`Stream'.nth n (Stream'.zip f s₁ s₂) = f (Stream'.nth s₁) (Stream'.nth s₂)`. -/
+`Stream'.get n (Stream'.zip f s₁ s₂) = f (Stream'.get s₁) (Stream'.get s₂)`. -/
 def zip (f : α → β → δ) (s₁ : Stream' α) (s₂ : Stream' β) : Stream' δ :=
-  fun n => f (nth s₁ n) (nth s₂ n)
+  fun n => f (get s₁ n) (get s₂ n)
 #align stream.zip Stream'.zip
 
 /-- Enumerate a stream by tagging each element with its index. -/
-def enum (s : Stream' α) : Stream' (ℕ × α) := fun n => (n, s.nth n)
+def enum (s : Stream' α) : Stream' (ℕ × α) := fun n => (n, s.get n)
 #align stream.enum Stream'.enum
 
-/-- The constant stream: `Stream'.nth n (Stream'.const a) = a`. -/
+/-- The constant stream: `Stream'.get n (Stream'.const a) = a`. -/
 def const (a : α) : Stream' α := fun _ => a
 #align stream.const Stream'.const
 
@@ -180,13 +180,13 @@ def pure (a : α) : Stream' α :=
 #align stream.pure Stream'.pure
 
 /-- Given a stream of functions and a stream of values, apply `n`-th function to `n`-th value. -/
-def apply (f : Stream' (α → β)) (s : Stream' α) : Stream' β := fun n => (nth f n) (nth s n)
+def apply (f : Stream' (α → β)) (s : Stream' α) : Stream' β := fun n => (get f n) (get s n)
 #align stream.apply Stream'.apply
 
 infixl:75 " ⊛ " => apply
 -- PORTING NOTE: "input as \o*" was here but doesn't work for the above notation
 
-/-- The stream of natural numbers: `Stream'.nth n Stream'.nats = n`. -/
+/-- The stream of natural numbers: `Stream'.get n Stream'.nats = n`. -/
 def nats : Stream' Nat := fun n => n
 #align stream.nats Stream'.nats
 

--- a/Mathlib/Data/Stream/Init.lean
+++ b/Mathlib/Data/Stream/Init.lean
@@ -34,14 +34,14 @@ protected theorem eta (s : Stream' α) : (head s::tail s) = s :=
 #align stream.eta Stream'.eta
 
 @[ext]
-protected theorem ext {s₁ s₂ : Stream' α} : (∀ n, nth s₁ n = nth s₂ n) → s₁ = s₂ :=
+protected theorem ext {s₁ s₂ : Stream' α} : (∀ n, get s₁ n = get s₂ n) → s₁ = s₂ :=
   fun h => funext h
 #align stream.ext Stream'.ext
 
 @[simp]
-theorem nth_zero_cons (a : α) (s : Stream' α) : nth (a::s) 0 = a :=
+theorem get_zero_cons (a : α) (s : Stream' α) : get (a::s) 0 = a :=
   rfl
-#align stream.nth_zero_cons Stream'.nth_zero_cons
+#align stream.nth_zero_cons Stream'.get_zero_cons
 
 @[simp]
 theorem head_cons (a : α) (s : Stream' α) : head (a::s) = a :=
@@ -54,9 +54,9 @@ theorem tail_cons (a : α) (s : Stream' α) : tail (a::s) = s :=
 #align stream.tail_cons Stream'.tail_cons
 
 @[simp]
-theorem nth_drop (n m : Nat) (s : Stream' α) : nth (drop m s) n = nth s (n + m) :=
+theorem get_drop (n m : Nat) (s : Stream' α) : get (drop m s) n = get s (n + m) :=
   rfl
-#align stream.nth_drop Stream'.nth_drop
+#align stream.nth_drop Stream'.get_drop
 
 theorem tail_eq_drop (s : Stream' α) : tail s = drop 1 s :=
   rfl
@@ -67,7 +67,7 @@ theorem drop_drop (n m : Nat) (s : Stream' α) : drop n (drop m s) = drop (n + m
   ext; simp [Nat.add_assoc]
 #align stream.drop_drop Stream'.drop_drop
 
-@[simp] theorem nth_tail {s : Stream' α} : s.tail.nth n = s.nth (n + 1) := rfl
+@[simp] theorem get_tail {s : Stream' α} : s.tail.get n = s.get (n + 1) := rfl
 
 @[simp] theorem tail_drop' {s : Stream' α} : tail (drop i s) = s.drop (i+1) := by
   ext; simp [add_comm, add_assoc, add_left_comm]
@@ -77,14 +77,14 @@ theorem drop_drop (n m : Nat) (s : Stream' α) : drop n (drop m s) = drop (n + m
 theorem tail_drop (n : Nat) (s : Stream' α) : tail (drop n s) = drop n (tail s) := by simp
 #align stream.tail_drop Stream'.tail_drop
 
-theorem nth_succ (n : Nat) (s : Stream' α) : nth s (succ n) = nth (tail s) n :=
+theorem get_succ (n : Nat) (s : Stream' α) : get s (succ n) = get (tail s) n :=
   rfl
-#align stream.nth_succ Stream'.nth_succ
+#align stream.nth_succ Stream'.get_succ
 
 @[simp]
-theorem nth_succ_cons (n : Nat) (s : Stream' α) (x : α) : nth (x::s) n.succ = nth s n :=
+theorem get_succ_cons (n : Nat) (s : Stream' α) (x : α) : get (x::s) n.succ = get s n :=
   rfl
-#align stream.nth_succ_cons Stream'.nth_succ_cons
+#align stream.nth_succ_cons Stream'.get_succ_cons
 
 @[simp] theorem drop_zero {s : Stream' α} : s.drop 0 = s := rfl
 
@@ -92,12 +92,12 @@ theorem drop_succ (n : Nat) (s : Stream' α) : drop (succ n) s = drop n (tail s)
   rfl
 #align stream.drop_succ Stream'.drop_succ
 
-theorem head_drop (a : Stream' α) (n : ℕ) : (a.drop n).head = a.nth n := by simp
+theorem head_drop (a : Stream' α) (n : ℕ) : (a.drop n).head = a.get n := by simp
 #align stream.head_drop Stream'.head_drop
 
 theorem cons_injective2 : Function.Injective2 (cons : α → Stream' α → Stream' α) := fun x y s t h =>
-  ⟨by rw [← nth_zero_cons x s, h, nth_zero_cons],
-    Stream'.ext fun n => by rw [← nth_succ_cons n _ x, h, nth_succ_cons]⟩
+  ⟨by rw [← get_zero_cons x s, h, get_zero_cons],
+    Stream'.ext fun n => by rw [← get_succ_cons n _ x, h, get_succ_cons]⟩
 #align stream.cons_injective2 Stream'.cons_injective2
 
 theorem cons_injective_left (s : Stream' α) : Function.Injective fun x => cons x s :=
@@ -108,11 +108,11 @@ theorem cons_injective_right (x : α) : Function.Injective (cons x) :=
   cons_injective2.right _
 #align stream.cons_injective_right Stream'.cons_injective_right
 
-theorem all_def (p : α → Prop) (s : Stream' α) : All p s = ∀ n, p (nth s n) :=
+theorem all_def (p : α → Prop) (s : Stream' α) : All p s = ∀ n, p (get s n) :=
   rfl
 #align stream.all_def Stream'.all_def
 
-theorem any_def (p : α → Prop) (s : Stream' α) : Any p s = ∃ n, p (nth s n) :=
+theorem any_def (p : α → Prop) (s : Stream' α) : Any p s = ∃ n, p (get s n) :=
   rfl
 #align stream.any_def Stream'.any_def
 
@@ -122,7 +122,7 @@ theorem mem_cons (a : α) (s : Stream' α) : a ∈ a::s :=
 #align stream.mem_cons Stream'.mem_cons
 
 theorem mem_cons_of_mem {a : α} {s : Stream' α} (b : α) : a ∈ s → a ∈ b::s := fun ⟨n, h⟩ =>
-  Exists.intro (succ n) (by rw [nth_succ, tail_cons, h])
+  Exists.intro (succ n) (by rw [get_succ, tail_cons, h])
 #align stream.mem_cons_of_mem Stream'.mem_cons_of_mem
 
 theorem eq_or_mem_of_mem_cons {a b : α} {s : Stream' α} : (a ∈ b::s) → a = b ∨ a ∈ s :=
@@ -131,13 +131,13 @@ theorem eq_or_mem_of_mem_cons {a b : α} {s : Stream' α} : (a ∈ b::s) → a =
   · left
     exact h
   · right
-    rw [nth_succ, tail_cons] at h
+    rw [get_succ, tail_cons] at h
     exact ⟨n', h⟩
 #align stream.eq_or_mem_of_mem_cons Stream'.eq_or_mem_of_mem_cons
 
-theorem mem_of_nth_eq {n : Nat} {s : Stream' α} {a : α} : a = nth s n → a ∈ s := fun h =>
+theorem mem_of_get_eq {n : Nat} {s : Stream' α} {a : α} : a = get s n → a ∈ s := fun h =>
   Exists.intro n h
-#align stream.mem_of_nth_eq Stream'.mem_of_nth_eq
+#align stream.mem_of_nth_eq Stream'.mem_of_get_eq
 
 section Map
 
@@ -148,9 +148,9 @@ theorem drop_map (n : Nat) (s : Stream' α) : drop n (map f s) = map f (drop n s
 #align stream.drop_map Stream'.drop_map
 
 @[simp]
-theorem nth_map (n : Nat) (s : Stream' α) : nth (map f s) n = f (nth s n) :=
+theorem get_map (n : Nat) (s : Stream' α) : get (map f s) n = f (get s n) :=
   rfl
-#align stream.nth_map Stream'.nth_map
+#align stream.nth_map Stream'.get_map
 
 theorem tail_map (s : Stream' α) : tail (map f s) = map f (tail s) := rfl
 #align stream.tail_map Stream'.tail_map
@@ -184,11 +184,11 @@ theorem map_tail (s : Stream' α) : map f (tail s) = tail (map f s) :=
 #align stream.map_tail Stream'.map_tail
 
 theorem mem_map {a : α} {s : Stream' α} : a ∈ s → f a ∈ map f s := fun ⟨n, h⟩ =>
-  Exists.intro n (by rw [nth_map, h])
+  Exists.intro n (by rw [get_map, h])
 #align stream.mem_map Stream'.mem_map
 
 theorem exists_of_mem_map {f} {b : β} {s : Stream' α} : b ∈ map f s → ∃ a, a ∈ s ∧ f a = b :=
-  fun ⟨n, h⟩ => ⟨nth s n, ⟨n, rfl⟩, h.symm⟩
+  fun ⟨n, h⟩ => ⟨get s n, ⟨n, rfl⟩, h.symm⟩
 #align stream.exists_of_mem_map Stream'.exists_of_mem_map
 
 end Map
@@ -203,10 +203,10 @@ theorem drop_zip (n : Nat) (s₁ : Stream' α) (s₂ : Stream' β) :
 #align stream.drop_zip Stream'.drop_zip
 
 @[simp]
-theorem nth_zip (n : Nat) (s₁ : Stream' α) (s₂ : Stream' β) :
-    nth (zip f s₁ s₂) n = f (nth s₁ n) (nth s₂ n) :=
+theorem get_zip (n : Nat) (s₁ : Stream' α) (s₂ : Stream' β) :
+    get (zip f s₁ s₂) n = f (get s₁ n) (get s₂ n) :=
   rfl
-#align stream.nth_zip Stream'.nth_zip
+#align stream.nth_zip Stream'.get_zip
 
 theorem head_zip (s₁ : Stream' α) (s₂ : Stream' β) : head (zip f s₁ s₂) = f (head s₁) (head s₂) :=
   rfl
@@ -223,9 +223,9 @@ theorem zip_eq (s₁ : Stream' α) (s₂ : Stream' β) :
 #align stream.zip_eq Stream'.zip_eq
 
 @[simp]
-theorem nth_enum (s : Stream' α) (n : ℕ) : nth (enum s) n = (n, s.nth n) :=
+theorem get_enum (s : Stream' α) (n : ℕ) : get (enum s) n = (n, s.get n) :=
   rfl
-#align stream.nth_enum Stream'.nth_enum
+#align stream.nth_enum Stream'.get_enum
 
 theorem enum_eq_zip (s : Stream' α) : enum s = zip Prod.mk nats s :=
   rfl
@@ -255,9 +255,9 @@ theorem map_const (f : α → β) (a : α) : map f (const a) = const (f a) :=
 #align stream.map_const Stream'.map_const
 
 @[simp]
-theorem nth_const (n : Nat) (a : α) : nth (const a) n = a :=
+theorem get_const (n : Nat) (a : α) : get (const a) n = a :=
   rfl
-#align stream.nth_const Stream'.nth_const
+#align stream.nth_const Stream'.get_const
 
 @[simp]
 theorem drop_const (n : Nat) (a : α) : drop n (const a) = const a :=
@@ -269,15 +269,15 @@ theorem head_iterate (f : α → α) (a : α) : head (iterate f a) = a :=
   rfl
 #align stream.head_iterate Stream'.head_iterate
 
-theorem nth_succ_iterate' (n : Nat) (f : α → α) (a : α) :
-    nth (iterate f a) (succ n) = f (nth (iterate f a) n) := rfl
+theorem get_succ_iterate' (n : Nat) (f : α → α) (a : α) :
+    get (iterate f a) (succ n) = f (get (iterate f a) n) := rfl
 
 theorem tail_iterate (f : α → α) (a : α) : tail (iterate f a) = iterate f (f a) := by
   ext n
-  rw [nth_tail]
+  rw [get_tail]
   induction' n with n' ih
   · rfl
-  · rw [nth_succ_iterate', ih, nth_succ_iterate']
+  · rw [get_succ_iterate', ih, get_succ_iterate']
 #align stream.tail_iterate Stream'.tail_iterate
 
 theorem iterate_eq (f : α → α) (a : α) : iterate f a = a::iterate f (f a) := by
@@ -286,13 +286,13 @@ theorem iterate_eq (f : α → α) (a : α) : iterate f a = a::iterate f (f a) :
 #align stream.iterate_eq Stream'.iterate_eq
 
 @[simp]
-theorem nth_zero_iterate (f : α → α) (a : α) : nth (iterate f a) 0 = a :=
+theorem get_zero_iterate (f : α → α) (a : α) : get (iterate f a) 0 = a :=
   rfl
-#align stream.nth_zero_iterate Stream'.nth_zero_iterate
+#align stream.nth_zero_iterate Stream'.get_zero_iterate
 
-theorem nth_succ_iterate (n : Nat) (f : α → α) (a : α) :
-    nth (iterate f a) (succ n) = nth (iterate f (f a)) n := by rw [nth_succ, tail_iterate]
-#align stream.nth_succ_iterate Stream'.nth_succ_iterate
+theorem get_succ_iterate (n : Nat) (f : α → α) (a : α) :
+    get (iterate f a) (succ n) = get (iterate f (f a)) n := by rw [get_succ, tail_iterate]
+#align stream.nth_succ_iterate Stream'.get_succ_iterate
 
 section Bisim
 
@@ -308,17 +308,17 @@ def IsBisimulation :=
       head s₁ = head s₂ ∧ tail s₁ ~ tail s₂
 #align stream.is_bisimulation Stream'.IsBisimulation
 
-theorem nth_of_bisim (bisim : IsBisimulation R) :
-    ∀ {s₁ s₂} (n), s₁ ~ s₂ → nth s₁ n = nth s₂ n ∧ drop (n + 1) s₁ ~ drop (n + 1) s₂
+theorem get_of_bisim (bisim : IsBisimulation R) :
+    ∀ {s₁ s₂} (n), s₁ ~ s₂ → get s₁ n = get s₂ n ∧ drop (n + 1) s₁ ~ drop (n + 1) s₂
   | _, _, 0, h => bisim h
   | _, _, n + 1, h =>
     match bisim h with
-    | ⟨_, trel⟩ => nth_of_bisim bisim n trel
-#align stream.nth_of_bisim Stream'.nth_of_bisim
+    | ⟨_, trel⟩ => get_of_bisim bisim n trel
+#align stream.nth_of_bisim Stream'.get_of_bisim
 
 -- If two streams are bisimilar, then they are equal
 theorem eq_of_bisim (bisim : IsBisimulation R) : ∀ {s₁ s₂}, s₁ ~ s₂ → s₁ = s₂ := fun r =>
-  Stream'.ext fun n => And.left (nth_of_bisim R bisim n r)
+  Stream'.ext fun n => And.left (get_of_bisim R bisim n r)
 #align stream.eq_of_bisim Stream'.eq_of_bisim
 
 end Bisim
@@ -361,8 +361,8 @@ theorem map_iterate (f : α → α) (a : α) : iterate f (f a) = map f (iterate 
   funext n
   induction' n with n' ih
   · rfl
-  · unfold map iterate nth
-    rw [map, nth] at ih
+  · unfold map iterate get
+    rw [map, get] at ih
     rw [iterate]
     exact congrArg f ih
 #align stream.map_iterate Stream'.map_iterate
@@ -399,17 +399,17 @@ theorem unfolds_eq (g : α → β) (f : α → α) (a : α) : unfolds g f a = g 
   unfold unfolds; rw [corec_eq]
 #align stream.unfolds_eq Stream'.unfolds_eq
 
-theorem nth_unfolds_head_tail : ∀ (n : Nat) (s : Stream' α),
-    nth (unfolds head tail s) n = nth s n := by
+theorem get_unfolds_head_tail : ∀ (n : Nat) (s : Stream' α),
+    get (unfolds head tail s) n = get s n := by
   intro n; induction' n with n' ih
   · intro s
     rfl
   · intro s
-    rw [nth_succ, nth_succ, unfolds_eq, tail_cons, ih]
-#align stream.nth_unfolds_head_tail Stream'.nth_unfolds_head_tail
+    rw [get_succ, get_succ, unfolds_eq, tail_cons, ih]
+#align stream.nth_unfolds_head_tail Stream'.get_unfolds_head_tail
 
 theorem unfolds_head_eq : ∀ s : Stream' α, unfolds head tail s = s := fun s =>
-  Stream'.ext fun n => nth_unfolds_head_tail n s
+  Stream'.ext fun n => get_unfolds_head_tail n s
 #align stream.unfolds_head_eq Stream'.unfolds_head_eq
 
 theorem interleave_eq (s₁ s₂ : Stream' α) : s₁ ⋈ s₂ = head s₁::head s₂::(tail s₁ ⋈ tail s₂) := by
@@ -426,33 +426,33 @@ theorem interleave_tail_tail (s₁ s₂ : Stream' α) : tail s₁ ⋈ tail s₂ 
   rw [interleave_eq s₁ s₂]; rfl
 #align stream.interleave_tail_tail Stream'.interleave_tail_tail
 
-theorem nth_interleave_left : ∀ (n : Nat) (s₁ s₂ : Stream' α),
-    nth (s₁ ⋈ s₂) (2 * n) = nth s₁ n
+theorem get_interleave_left : ∀ (n : Nat) (s₁ s₂ : Stream' α),
+    get (s₁ ⋈ s₂) (2 * n) = get s₁ n
   | 0, s₁, s₂ => rfl
   | n + 1, s₁, s₂ => by
-    change nth (s₁ ⋈ s₂) (succ (succ (2 * n))) = nth s₁ (succ n)
-    rw [nth_succ, nth_succ, interleave_eq, tail_cons, tail_cons]
+    change get (s₁ ⋈ s₂) (succ (succ (2 * n))) = get s₁ (succ n)
+    rw [get_succ, get_succ, interleave_eq, tail_cons, tail_cons]
     have : n < succ n := Nat.lt_succ_self n
-    rw [nth_interleave_left n (tail s₁) (tail s₂)]
+    rw [get_interleave_left n (tail s₁) (tail s₂)]
     rfl
-#align stream.nth_interleave_left Stream'.nth_interleave_left
+#align stream.nth_interleave_left Stream'.get_interleave_left
 
-theorem nth_interleave_right : ∀ (n : Nat) (s₁ s₂ : Stream' α),
-    nth (s₁ ⋈ s₂) (2 * n + 1) = nth s₂ n
+theorem get_interleave_right : ∀ (n : Nat) (s₁ s₂ : Stream' α),
+    get (s₁ ⋈ s₂) (2 * n + 1) = get s₂ n
   | 0, s₁, s₂ => rfl
   | n + 1, s₁, s₂ => by
-    change nth (s₁ ⋈ s₂) (succ (succ (2 * n + 1))) = nth s₂ (succ n)
-    rw [nth_succ, nth_succ, interleave_eq, tail_cons, tail_cons,
-      nth_interleave_right n (tail s₁) (tail s₂)]
+    change get (s₁ ⋈ s₂) (succ (succ (2 * n + 1))) = get s₂ (succ n)
+    rw [get_succ, get_succ, interleave_eq, tail_cons, tail_cons,
+      get_interleave_right n (tail s₁) (tail s₂)]
     rfl
-#align stream.nth_interleave_right Stream'.nth_interleave_right
+#align stream.nth_interleave_right Stream'.get_interleave_right
 
 theorem mem_interleave_left {a : α} {s₁ : Stream' α} (s₂ : Stream' α) : a ∈ s₁ → a ∈ s₁ ⋈ s₂ :=
-  fun ⟨n, h⟩ => Exists.intro (2 * n) (by rw [h, nth_interleave_left])
+  fun ⟨n, h⟩ => Exists.intro (2 * n) (by rw [h, get_interleave_left])
 #align stream.mem_interleave_left Stream'.mem_interleave_left
 
 theorem mem_interleave_right {a : α} {s₁ : Stream' α} (s₂ : Stream' α) : a ∈ s₂ → a ∈ s₁ ⋈ s₂ :=
-  fun ⟨n, h⟩ => Exists.intro (2 * n + 1) (by rw [h, nth_interleave_right])
+  fun ⟨n, h⟩ => Exists.intro (2 * n + 1) (by rw [h, get_interleave_right])
 #align stream.mem_interleave_right Stream'.mem_interleave_right
 
 theorem odd_eq (s : Stream' α) : odd s = even (tail s) :=
@@ -498,23 +498,23 @@ theorem interleave_even_odd (s₁ : Stream' α) : even s₁ ⋈ odd s₁ = s₁ 
     rfl
 #align stream.interleave_even_odd Stream'.interleave_even_odd
 
-theorem nth_even : ∀ (n : Nat) (s : Stream' α), nth (even s) n = nth s (2 * n)
+theorem get_even : ∀ (n : Nat) (s : Stream' α), get (even s) n = get s (2 * n)
   | 0, s => rfl
   | succ n, s => by
-    change nth (even s) (succ n) = nth s (succ (succ (2 * n)))
-    rw [nth_succ, nth_succ, tail_even, nth_even n]; rfl
-#align stream.nth_even Stream'.nth_even
+    change get (even s) (succ n) = get s (succ (succ (2 * n)))
+    rw [get_succ, get_succ, tail_even, get_even n]; rfl
+#align stream.nth_even Stream'.get_even
 
-theorem nth_odd : ∀ (n : Nat) (s : Stream' α), nth (odd s) n = nth s (2 * n + 1) := fun n s => by
-  rw [odd_eq, nth_even]; rfl
-#align stream.nth_odd Stream'.nth_odd
+theorem get_odd : ∀ (n : Nat) (s : Stream' α), get (odd s) n = get s (2 * n + 1) := fun n s => by
+  rw [odd_eq, get_even]; rfl
+#align stream.nth_odd Stream'.get_odd
 
 theorem mem_of_mem_even (a : α) (s : Stream' α) : a ∈ even s → a ∈ s := fun ⟨n, h⟩ =>
-  Exists.intro (2 * n) (by rw [h, nth_even])
+  Exists.intro (2 * n) (by rw [h, get_even])
 #align stream.mem_of_mem_even Stream'.mem_of_mem_even
 
 theorem mem_of_mem_odd (a : α) (s : Stream' α) : a ∈ odd s → a ∈ s := fun ⟨n, h⟩ =>
-  Exists.intro (2 * n + 1) (by rw [h, nth_odd])
+  Exists.intro (2 * n + 1) (by rw [h, get_odd])
 #align stream.mem_of_mem_odd Stream'.mem_of_mem_odd
 
 theorem nil_append_stream (s : Stream' α) : appendStream' [] s = s :=
@@ -578,9 +578,9 @@ theorem take_succ (n : Nat) (s : Stream' α) : take (succ n) s = head s::take n 
 
 @[simp] theorem take_succ_cons (n : Nat) (s : Stream' α) : take (n+1) (a::s) = a :: take n s := rfl
 
-theorem take_succ' {s : Stream' α} : ∀ n, s.take (n+1) = s.take n ++ [s.nth n]
+theorem take_succ' {s : Stream' α} : ∀ n, s.take (n+1) = s.take n ++ [s.get n]
   | 0 => rfl
-  | n+1 => by rw [take_succ, take_succ' n, ← List.cons_append, ← take_succ, nth_tail]
+  | n+1 => by rw [take_succ, take_succ' n, ← List.cons_append, ← take_succ, get_tail]
 
 @[simp]
 theorem length_take (n : ℕ) (s : Stream' α) : (take n s).length = n := by
@@ -593,15 +593,15 @@ theorem take_take {s : Stream' α} : ∀ {m n}, (s.take n).take m = s.take (min 
   | m, 0 => by rw [zero_min, take_zero, List.take_nil]
   | m+1, n+1 => by rw [take_succ, List.take_cons, Nat.min_succ_succ, take_succ, take_take]
 
-@[simp] theorem concat_take_nth {s : Stream' α} : s.take n ++ [s.nth n] = s.take (n+1) :=
+@[simp] theorem concat_take_get {s : Stream' α} : s.take n ++ [s.get n] = s.take (n+1) :=
   (take_succ' n).symm
 
-theorem get?_take {s : Stream' α} : ∀ {k n}, k < n → (s.take n).get? k = s.nth k
+theorem get?_take {s : Stream' α} : ∀ {k n}, k < n → (s.take n).get? k = s.get k
   | 0, n+1, _ => rfl
-  | k+1, n+1, h => by rw [take_succ, List.get?, get?_take (Nat.lt_of_succ_lt_succ h), nth_succ]
+  | k+1, n+1, h => by rw [take_succ, List.get?, get?_take (Nat.lt_of_succ_lt_succ h), get_succ]
 
 theorem get?_take_succ (n : Nat) (s : Stream' α) :
-    List.get? (take (succ n) s) n = some (nth s n) :=
+    List.get? (take (succ n) s) n = some (get s n) :=
   get?_take (Nat.lt_succ_self n)
 #align stream.nth_take_succ Stream'.get?_take_succ
 
@@ -629,7 +629,7 @@ theorem take_theorem (s₁ s₂ : Stream' α) : (∀ n : Nat, take n s₁ = take
   · have aux := h 1
     simp [take] at aux
     exact aux
-  · have h₁ : some (nth s₁ (succ n)) = some (nth s₂ (succ n)) := by
+  · have h₁ : some (get s₁ (succ n)) = some (get s₂ (succ n)) := by
       rw [← get?_take_succ, ← get?_take_succ, h (succ (succ n))]
     injection h₁
 #align stream.take_theorem Stream'.take_theorem
@@ -669,13 +669,13 @@ theorem tails_eq (s : Stream' α) : tails s = tail s::tails (tail s) := by
 #align stream.tails_eq Stream'.tails_eq
 
 @[simp]
-theorem nth_tails : ∀ (n : Nat) (s : Stream' α), nth (tails s) n = drop n (tail s) := by
+theorem get_tails : ∀ (n : Nat) (s : Stream' α), get (tails s) n = drop n (tail s) := by
   intro n; induction' n with n' ih
   · intros
     rfl
   · intro s
-    rw [nth_succ, drop_succ, tails_eq, tail_cons, ih]
-#align stream.nth_tails Stream'.nth_tails
+    rw [get_succ, drop_succ, tails_eq, tail_cons, ih]
+#align stream.nth_tails Stream'.get_tails
 
 theorem tails_eq_iterate (s : Stream' α) : tails s = iterate tail (tail s) :=
   rfl
@@ -697,39 +697,39 @@ theorem inits_tail (s : Stream' α) : inits (tail s) = initsCore [head (tail s)]
   rfl
 #align stream.inits_tail Stream'.inits_tail
 
-theorem cons_nth_inits_core :
+theorem cons_get_inits_core :
     ∀ (a : α) (n : Nat) (l : List α) (s : Stream' α),
-      (a::nth (initsCore l s) n) = nth (initsCore (a::l) s) n := by
+      (a::get (initsCore l s) n) = get (initsCore (a::l) s) n := by
   intro a n
   induction' n with n' ih
   · intros
     rfl
   · intro l s
-    rw [nth_succ, inits_core_eq, tail_cons, ih, inits_core_eq (a::l) s]
+    rw [get_succ, inits_core_eq, tail_cons, ih, inits_core_eq (a::l) s]
     rfl
-#align stream.cons_nth_inits_core Stream'.cons_nth_inits_core
+#align stream.cons_nth_inits_core Stream'.cons_get_inits_core
 
 @[simp]
-theorem nth_inits : ∀ (n : Nat) (s : Stream' α), nth (inits s) n = take (succ n) s := by
+theorem get_inits : ∀ (n : Nat) (s : Stream' α), get (inits s) n = take (succ n) s := by
   intro n; induction' n with n' ih
   · intros
     rfl
   · intros
-    rw [nth_succ, take_succ, ← ih, tail_inits, inits_tail, cons_nth_inits_core]
-#align stream.nth_inits Stream'.nth_inits
+    rw [get_succ, take_succ, ← ih, tail_inits, inits_tail, cons_get_inits_core]
+#align stream.nth_inits Stream'.get_inits
 
 theorem inits_eq (s : Stream' α) :
     inits s = [head s]::map (List.cons (head s)) (inits (tail s)) := by
   apply Stream'.ext; intro n
   cases n
   · rfl
-  · rw [nth_inits, nth_succ, tail_cons, nth_map, nth_inits]
+  · rw [get_inits, get_succ, tail_cons, get_map, get_inits]
     rfl
 #align stream.inits_eq Stream'.inits_eq
 
 theorem zip_inits_tails (s : Stream' α) : zip appendStream' (inits s) (tails s) = const s := by
   apply Stream'.ext; intro n
-  rw [nth_zip, nth_inits, nth_tails, nth_const, take_succ, cons_append_stream, append_take_drop,
+  rw [get_zip, get_inits, get_tails, get_const, take_succ, cons_append_stream, append_take_drop,
     Stream'.eta]
 #align stream.zip_inits_tails Stream'.zip_inits_tails
 
@@ -755,13 +755,13 @@ theorem map_eq_apply (f : α → β) (s : Stream' α) : map f s = pure f ⊛ s :
   rfl
 #align stream.map_eq_apply Stream'.map_eq_apply
 
-theorem nth_nats (n : Nat) : nth nats n = n :=
+theorem get_nats (n : Nat) : get nats n = n :=
   rfl
-#align stream.nth_nats Stream'.nth_nats
+#align stream.nth_nats Stream'.get_nats
 
 theorem nats_eq : nats = cons 0 (map succ nats) := by
   apply Stream'.ext; intro n
-  cases n; rfl; rw [nth_succ]; rfl
+  cases n; rfl; rw [get_succ]; rfl
 #align stream.nats_eq Stream'.nats_eq
 
 end Stream'


### PR DESCRIPTION
Many of `nth` (e.g. `list.nth`, `stream.seq.nth`) are renamed to `get?` in Mathlib 4, but `Stream'.nth` had been remained as it.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
