### PR TITLE
[Merged by Bors] - chore: make CanonicallyLinearOrdered[Add]CommMonoid extend more

### DIFF
--- a/Mathlib/Algebra/Order/Monoid/Canonical/Defs.lean
+++ b/Mathlib/Algebra/Order/Monoid/Canonical/Defs.lean
@@ -334,19 +334,21 @@ end NeZero
 /-- A canonically linear-ordered additive monoid is a canonically ordered additive monoid
     whose ordering is a linear order. -/
 class CanonicallyLinearOrderedAddCommMonoid (α : Type*)
-  extends CanonicallyOrderedAddCommMonoid α, LinearOrder α
+  extends CanonicallyOrderedAddCommMonoid α, LinearOrderedAddCommMonoid α
 #align canonically_linear_ordered_add_monoid CanonicallyLinearOrderedAddCommMonoid
 
 /-- A canonically linear-ordered monoid is a canonically ordered monoid
     whose ordering is a linear order. -/
 @[to_additive]
-class CanonicallyLinearOrderedCommMonoid (α : Type*) extends CanonicallyOrderedCommMonoid α,
-  LinearOrder α
+class CanonicallyLinearOrderedCommMonoid (α : Type*)
+  extends CanonicallyOrderedCommMonoid α, LinearOrderedCommMonoid α
 #align canonically_linear_ordered_monoid CanonicallyLinearOrderedCommMonoid
 
 section CanonicallyLinearOrderedCommMonoid
 
 variable [CanonicallyLinearOrderedCommMonoid α]
+
+attribute [to_additive existing] CanonicallyLinearOrderedCommMonoid.toLinearOrderedCommMonoid
 
 -- see Note [lower instance priority]
 @[to_additive]
@@ -392,9 +394,5 @@ theorem bot_eq_one' : (⊥ : α) = 1 :=
   bot_eq_one
 #align bot_eq_one' bot_eq_one'
 #align bot_eq_zero' bot_eq_zero'
-
-@[to_additive]
-instance CanonicallyLinearOrderedCommMonoid.linearOrderedCommMonoid : LinearOrderedCommMonoid α :=
-  { ‹CanonicallyLinearOrderedCommMonoid α› with }
 
 end CanonicallyLinearOrderedCommMonoid

--- a/Mathlib/Algebra/Order/Monoid/Canonical/Defs.lean
+++ b/Mathlib/Algebra/Order/Monoid/Canonical/Defs.lean
@@ -393,4 +393,8 @@ theorem bot_eq_one' : (⊥ : α) = 1 :=
 #align bot_eq_one' bot_eq_one'
 #align bot_eq_zero' bot_eq_zero'
 
+@[to_additive]
+instance CanonicallyLinearOrderedCommMonoid.linearOrderedCommMonoid : LinearOrderedCommMonoid α :=
+  { ‹CanonicallyLinearOrderedCommMonoid α› with }
+
 end CanonicallyLinearOrderedCommMonoid

--- a/Mathlib/Algebra/Order/Monoid/Canonical/Defs.lean
+++ b/Mathlib/Algebra/Order/Monoid/Canonical/Defs.lean
@@ -344,11 +344,11 @@ class CanonicallyLinearOrderedCommMonoid (α : Type*)
   extends CanonicallyOrderedCommMonoid α, LinearOrderedCommMonoid α
 #align canonically_linear_ordered_monoid CanonicallyLinearOrderedCommMonoid
 
+attribute [to_additive existing] CanonicallyLinearOrderedCommMonoid.toLinearOrderedCommMonoid
+
 section CanonicallyLinearOrderedCommMonoid
 
 variable [CanonicallyLinearOrderedCommMonoid α]
-
-attribute [to_additive existing] CanonicallyLinearOrderedCommMonoid.toLinearOrderedCommMonoid
 
 -- see Note [lower instance priority]
 @[to_additive]

--- a/Mathlib/Algebra/Order/Monoid/Canonical/Defs.lean
+++ b/Mathlib/Algebra/Order/Monoid/Canonical/Defs.lean
@@ -394,7 +394,7 @@ theorem bot_eq_one' : (⊥ : α) = 1 :=
 #align bot_eq_zero' bot_eq_zero'
 
 @[to_additive]
-instance CanonicallyLinearOrderedCommMonoid.linearOrderedCommMonoid : LinearOrderedCommMonoid α :=
+instance CanonicallyLinearOrderedCommMonoid.toLinearOrderedCommMonoid : LinearOrderedCommMonoid α :=
   { ‹CanonicallyLinearOrderedCommMonoid α› with }
 
 end CanonicallyLinearOrderedCommMonoid


### PR DESCRIPTION
Originally:
```
class CanonicallyLinearOrderedAddCommMonoid (α : Type*)
  extends CanonicallyOrderedAddCommMonoid α, LinearOrder α

class CanonicallyLinearOrderedCommMonoid (α : Type*) extends CanonicallyOrderedCommMonoid α,
  LinearOrder α
```
Now:
```
class CanonicallyLinearOrderedAddCommMonoid (α : Type*)
  extends CanonicallyOrderedAddCommMonoid α, LinearOrderedAddCommMonoid α

class CanonicallyLinearOrderedCommMonoid (α : Type*)
  extends CanonicallyOrderedCommMonoid α, LinearOrderedCommMonoid α
```

It gives the same union of properties as before, but now we have two more conversions for free:
`CanonicallyLinearOrderedAddCommMonoid ` -> `LinearOrderedAddCommMonoid `
`CanonicallyLinearOrderedCommMonoid ` -> `LinearOrderedCommMonoid `

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
