### PR TITLE
[Merged by Bors] - feat: analogue of iSup.prod for sets

### DIFF
--- a/Mathlib/Data/Set/Lattice.lean
+++ b/Mathlib/Data/Set/Lattice.lean
@@ -1873,8 +1873,7 @@ theorem iUnion_prod {ι ι' α β} (s : ι → Set α) (t : ι' → Set β) :
 #align set.Union_prod Set.iUnion_prod
 
 /-- Analogue of `iSup.prod` for sets. -/
-lemma Set.iUnion_prod' (f : β × γ → Set α) : ⋃ x : β × γ, f x = ⋃ (i : β) (j : γ), (f ⟨i, j⟩) := by
-  symm
+lemma iUnion_prod' (f : β × γ → Set α) : ⋃ x : β × γ, f x = ⋃ (i : β) (j : γ), f (i, j) := by
   simp only [iUnion, iSup_eq_iUnion, iSup_prod]
 
 /- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/

--- a/Mathlib/Data/Set/Lattice.lean
+++ b/Mathlib/Data/Set/Lattice.lean
@@ -1872,9 +1872,9 @@ theorem iUnion_prod {ι ι' α β} (s : ι → Set α) (t : ι' → Set β) :
   simp
 #align set.Union_prod Set.iUnion_prod
 
-/-- Analogue of `iSup.prod` for sets. -/
-lemma iUnion_prod' (f : β × γ → Set α) : ⋃ x : β × γ, f x = ⋃ (i : β) (j : γ), f (i, j) := by
-  simp only [iUnion, iSup_eq_iUnion, iSup_prod]
+/-- Analogue of `iSup_prod` for sets. -/
+lemma iUnion_prod' (f : β × γ → Set α) : ⋃ x : β × γ, f x = ⋃ (i : β) (j : γ), f (i, j) :=
+  iSup_prod
 
 /- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
 /- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/

--- a/Mathlib/Data/Set/Lattice.lean
+++ b/Mathlib/Data/Set/Lattice.lean
@@ -1873,8 +1873,9 @@ theorem iUnion_prod {ι ι' α β} (s : ι → Set α) (t : ι' → Set β) :
 #align set.Union_prod Set.iUnion_prod
 
 /-- Analogue of `iSup.prod` for sets. -/
-lemma Set.iUnion_prod' {X Y Z : Type*} (f : X × Y → Set Z) :
-    ⋃ (x : X) (y : Y), (f ⟨x, y⟩) = ⋃ t : X × Y, (f t) := by
+lemma Set.iUnion_prod' (f : α × β → Set γ) :
+    ⋃ t : α × β, (f t) = ⋃ (x : α) (y : β), (f ⟨x, y⟩) := by
+  symm
   simp only [iUnion, iSup_eq_iUnion, iSup_prod]
 
 /- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/

--- a/Mathlib/Data/Set/Lattice.lean
+++ b/Mathlib/Data/Set/Lattice.lean
@@ -1873,8 +1873,7 @@ theorem iUnion_prod {ι ι' α β} (s : ι → Set α) (t : ι' → Set β) :
 #align set.Union_prod Set.iUnion_prod
 
 /-- Analogue of `iSup.prod` for sets. -/
-lemma Set.iUnion_prod' (f : α × β → Set γ) :
-    ⋃ t : α × β, (f t) = ⋃ (x : α) (y : β), (f ⟨x, y⟩) := by
+lemma Set.iUnion_prod' (f : β × γ → Set α) : ⋃ x : β × γ, f x = ⋃ (i : β) (j : γ), (f ⟨i, j⟩) := by
   symm
   simp only [iUnion, iSup_eq_iUnion, iSup_prod]
 

--- a/Mathlib/Data/Set/Lattice.lean
+++ b/Mathlib/Data/Set/Lattice.lean
@@ -1872,6 +1872,11 @@ theorem iUnion_prod {ι ι' α β} (s : ι → Set α) (t : ι' → Set β) :
   simp
 #align set.Union_prod Set.iUnion_prod
 
+/-- Analogue of `iSup.prod` for sets. -/
+lemma Set.iUnion_prod' {X Y Z : Type*} (f : X × Y → Set Z) :
+    ⋃ (x : X) (y : Y), (f ⟨x, y⟩) = ⋃ t : X × Y, (f t) := by
+  simp only [iUnion, iSup_eq_iUnion, iSup_prod]
+
 /- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
 /- ./././Mathport/Syntax/Translate/Expr.lean:177:8: unsupported: ambiguous notation -/
 theorem iUnion_prod_of_monotone [SemilatticeSup α] {s : α → Set β} {t : α → Set γ} (hs : Monotone s)


### PR DESCRIPTION
-----------

As suggested [on Zulip](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F/topic/iUnion.20is.20compatible.20with.20product.20of.20types/near/395079870).

Feedback on the lemma name is appreciated; `iUnion_prod` is already taken by a different lemma.
