### PR TITLE
feat: QuotientGroup.equivOfEq

### DIFF
--- a/Mathlib/Algebra/Hom/Equiv/Basic.lean
+++ b/Mathlib/Algebra/Hom/Equiv/Basic.lean
@@ -487,8 +487,7 @@ theorem self_trans_symm (e : M ≃* N) : e.trans e.symm = refl M :=
 #align mul_equiv.self_trans_symm MulEquiv.self_trans_symm
 #align add_equiv.self_trans_symm AddEquiv.self_trans_symm
 
--- Porting note: `simp` can prove this
-@[to_additive]
+@[to_additive (attr := simp)]
 theorem coe_monoidHom_refl {M} [MulOneClass M] : (refl M : M →* M) = MonoidHom.id M := rfl
 #align mul_equiv.coe_monoid_hom_refl MulEquiv.coe_monoidHom_refl
 #align add_equiv.coe_add_monoid_hom_refl AddEquiv.coe_addMonoidHom_refl

--- a/Mathlib/GroupTheory/QuotientGroup.lean
+++ b/Mathlib/GroupTheory/QuotientGroup.lean
@@ -345,6 +345,14 @@ theorem congr_symm (e : G ≃* H) (he : G'.map ↑e = H') :
   rfl
 #align quotient_group.congr_symm QuotientGroup.congr_symm
 
+/-- The isomorphism of quotient groups induced by an equality of normal subgroups. -/
+def equivOfEq {N M : Subgroup G} [N.Normal] [M.Normal] (h : N = M) : G ⧸ N ≃* G ⧸ M :=
+congr N M (MulEquiv.refl G) (by simp [h])
+
+@[simp]
+theorem equivOfEq_mk {N M : Subgroup G} [N.Normal] [M.Normal] (h : N = M) (x : G) :
+    equivOfEq h (mk x) = mk x := rfl
+
 end congr
 
 variable (φ : G →* H)


### PR DESCRIPTION
For consistency with `RingTheory` add a definition `equivOfEq {N M : Subgroup G} [N.Normal] [M.Normal] (h : N = M) : G ⧸ N ≃* G ⧸ M`. We currently have only a more general version.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
