### PR TITLE
feat: APIs of `Function.extend f g e'` when `f` is injective

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2381,6 +2381,7 @@ import Mathlib.Logic.Equiv.Nat
 import Mathlib.Logic.Equiv.Option
 import Mathlib.Logic.Equiv.Set
 import Mathlib.Logic.Equiv.TransferInstance
+import Mathlib.Logic.Function.ApiForExtend
 import Mathlib.Logic.Function.Basic
 import Mathlib.Logic.Function.Conjugate
 import Mathlib.Logic.Function.Iterate

--- a/Mathlib/Logic/Function/ApiForExtend.lean
+++ b/Mathlib/Logic/Function/ApiForExtend.lean
@@ -1,0 +1,49 @@
+/-
+Copyright (c) 2023 Wen Yang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Wen Yang
+-/
+import Mathlib.Data.Set.Function
+
+/-!
+# APIs For `Function.extend`
+
+## Tags
+
+extend
+-/
+
+set_option autoImplicit true
+open Function Set
+variable {α : Sort u} (f : α → β) (g : α → γ) (e' : β → γ)
+
+namespace Function
+
+/-! ### Properties of `extend f g e'` when `f` is injective -/
+section injective
+
+variable (hf_i : Injective f)
+
+theorem Injective.extend_image_eq : range g = (extend f g e') '' (range f) := by
+  ext x
+  simp [hf_i.extend_apply]
+
+theorem Injective.extend_injOn : Injective g ↔ InjOn (extend f g e') (range f) := by
+  rw [@injOn_iff_injective]
+  unfold Injective
+  simp [hf_i.extend_apply, hf_i.eq_iff]
+
+theorem Injective.extend_surjOn : Surjective g ↔ SurjOn (extend f g e') (range f) univ := by
+  rw [@surjOn_iff_surjective]
+  unfold Surjective
+  simp [hf_i.extend_apply, hf_i.eq_iff]
+
+theorem Injective.extend_bijOn : Bijective g ↔ BijOn (extend f g e') (range f) univ := by
+  unfold Bijective BijOn
+  rw [← hf_i.extend_injOn, ← hf_i.extend_surjOn]
+  simp only [iff_and_self, and_imp]
+  exact fun _ _ ↦ mapsTo_univ (extend f g e') (range f)
+
+end injective
+
+end Function


### PR DESCRIPTION
We characterizes `range g`, `Injective g`, `Surjective g` and `Bijective g` in terms of `extend f g e'`.​

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
