### PR TITLE
[Merged by Bors] - doc: Clarify the use case of `Function.extend`

### DIFF
--- a/Mathlib/Logic/Function/Basic.lean
+++ b/Mathlib/Logic/Function/Basic.lean
@@ -705,9 +705,8 @@ This definition only makes sense when `f a₁ = f a₂ → g a₁ = g a₂` (spe
 In particular this holds if `f` is injective.
 
 A typical use case is when extending a function from the subtype to the entire type. If you want to
-extend `g : {b : β // p b} → γ` to a function `β → γ` and do not care about the junk value, you
-should use `Function.extend Subtype.val g (Classical.arbitrary _)`. Note this assumes `γ` is
-nonempty. -/
+extend `g : {b : β // p b} → γ` by zero to a function `β → γ`, you should use
+`Function.extend Subtype.val g 0`. If you do not care about the junk value, you can replace `0` `Classical.arbitrary _` (assuming `γ` is nonempty). -/
 def extend (f : α → β) (g : α → γ) (j : β → γ) : β → γ := fun b ↦
   if h : ∃ a, f a = b then g (Classical.choose h) else j b
 #align function.extend Function.extend

--- a/Mathlib/Logic/Function/Basic.lean
+++ b/Mathlib/Logic/Function/Basic.lean
@@ -698,16 +698,16 @@ variable {α β γ : Sort*} {f : α → β}
 
 /-- Extension of a function `g : α → γ` along a function `f : α → β`.
 
-For every `a : α`, `f a` is sent to `g a`. `f` might not be surjective, so we use a junk value
-function `j : β → γ` by sending `b : β` not in the range of `f` to `e b`.
+For every `a : α`, `f a` is sent to `g a`. `f` might not be surjective, so we use an auxiliary
+function `j : β → γ` by sending `b : β` not in the range of `f` to `j b`. If you do not care about
+the behavior outside the range, `j` can be used as a junk value by setting it to be `0` or
+`Classical.arbitrary` (assuming `γ` is nonempty).
 
 This definition only makes sense when `f a₁ = f a₂ → g a₁ = g a₂` (spelled `g.FactorsThrough f`).
 In particular this holds if `f` is injective.
 
-A typical use case is when extending a function from a subtype to the entire type. If you want to
-extend `g : {b : β // p b} → γ` by zero to a function `β → γ`, you should use
-`Function.extend Subtype.val g 0`. If you do not care about the junk value, you can replace `0` by
-`Classical.arbitrary _` (assuming `γ` is nonempty). -/
+A typical use case is extending a function from a subtype to the entire type. If you wish to extend
+`g : {b : β // p b} → γ` to a function `β → γ`, you should use `Function.extend Subtype.val g j`. -/
 def extend (f : α → β) (g : α → γ) (j : β → γ) : β → γ := fun b ↦
   if h : ∃ a, f a = b then g (Classical.choose h) else j b
 #align function.extend Function.extend

--- a/Mathlib/Logic/Function/Basic.lean
+++ b/Mathlib/Logic/Function/Basic.lean
@@ -696,15 +696,20 @@ attribute [local instance] Classical.propDecidable
 
 variable {α β γ : Sort*} {f : α → β}
 
-/-- `extend f g e'` extends a function `g : α → γ`
-along a function `f : α → β` to a function `β → γ`,
-by using the values of `g` on the range of `f`
-and the values of an auxiliary function `e' : β → γ` elsewhere.
+/-- Extension of a function `g : α → γ` along a function `f : α → β`.
 
-Mostly useful when `f` is injective, or more generally when `g.factors_through f` -/
--- Explicit Sort so that `α` isn't inferred to be Prop via `exists_prop_decidable`
-def extend {α : Sort u} {β γ} (f : α → β) (g : α → γ) (e' : β → γ) : β → γ := fun b ↦
-  if h : ∃ a, f a = b then g (Classical.choose h) else e' b
+For every `a : α`, `f a` is sent to `g a`. `f` might not be surjective, so we use a junk value
+function `j : β → γ` by sending `b : β` not in the range of `f` to `e b`.
+
+This definition only makes sense when `f a₁ = f a₂ → g a₁ = g a₂` (spelled `g.FactorsThrough f`).
+In particular this holds if `f` is injective.
+
+A typical use case is when extending a function from the subtype to the entire type. If you want to
+extend `g : {b : β // p b} → γ` to a function `β → γ` and do not care about the junk value, you
+should use `Function.extend Subtype.val g (Classical.arbitrary _)`. Note this assumes `γ` is
+nonempty. -/
+def extend (f : α → β) (g : α → γ) (j : β → γ) : β → γ := fun b ↦
+  if h : ∃ a, f a = b then g (Classical.choose h) else j b
 #align function.extend Function.extend
 
 /-- g factors through f : `f a = f b → g a = g b` -/
@@ -718,9 +723,9 @@ theorem extend_def (f : α → β) (g : α → γ) (e' : β → γ) (b : β) [De
   congr
 #align function.extend_def Function.extend_def
 
-lemma Injective.FactorsThrough (hf : Injective f) (g : α → γ) : g.FactorsThrough f :=
+lemma Injective.factorsThrough (hf : Injective f) (g : α → γ) : g.FactorsThrough f :=
   fun _ _ h => congr_arg g (hf h)
-#align function.injective.factors_through Function.Injective.FactorsThrough
+#align function.injective.factors_through Function.Injective.factorsThrough
 
 lemma FactorsThrough.extend_apply {g : α → γ} (hf : g.FactorsThrough f) (e' : β → γ) (a : α) :
     extend f g e' (f a) = g a := by
@@ -731,7 +736,7 @@ lemma FactorsThrough.extend_apply {g : α → γ} (hf : g.FactorsThrough f) (e' 
 @[simp]
 theorem Injective.extend_apply (hf : Injective f) (g : α → γ) (e' : β → γ) (a : α) :
     extend f g e' (f a) = g a :=
-  (hf.FactorsThrough g).extend_apply e' a
+  (hf.factorsThrough g).extend_apply e' a
 #align function.injective.extend_apply Function.Injective.extend_apply
 
 @[simp]
@@ -765,7 +770,7 @@ lemma FactorsThrough.apply_extend {δ} {g : α → γ} (hf : FactorsThrough g f)
 
 lemma Injective.apply_extend {δ} (hf : Injective f) (F : γ → δ) (g : α → γ) (e' : β → γ) (b : β) :
     F (extend f g e' b) = extend f (F ∘ g) (F ∘ e') b :=
-  (hf.FactorsThrough g).apply_extend F e' b
+  (hf.factorsThrough g).apply_extend F e' b
 #align function.injective.apply_extend Function.Injective.apply_extend
 
 theorem extend_injective (hf : Injective f) (e' : β → γ) : Injective fun g ↦ extend f g e' := by

--- a/Mathlib/Logic/Function/Basic.lean
+++ b/Mathlib/Logic/Function/Basic.lean
@@ -703,8 +703,8 @@ function `j : β → γ` by sending `b : β` not in the range of `f` to `j b`. I
 the behavior outside the range, `j` can be used as a junk value by setting it to be `0` or
 `Classical.arbitrary` (assuming `γ` is nonempty).
 
-This definition only makes sense when `f a₁ = f a₂ → g a₁ = g a₂` (spelled `g.FactorsThrough f`).
-In particular this holds if `f` is injective.
+This definition is mathematically meaningful only when `f a₁ = f a₂ → g a₁ = g a₂` (spelled
+`g.FactorsThrough f`). In particular this holds if `f` is injective.
 
 A typical use case is extending a function from a subtype to the entire type. If you wish to extend
 `g : {b : β // p b} → γ` to a function `β → γ`, you should use `Function.extend Subtype.val g j`. -/

--- a/Mathlib/Logic/Function/Basic.lean
+++ b/Mathlib/Logic/Function/Basic.lean
@@ -704,9 +704,10 @@ function `j : β → γ` by sending `b : β` not in the range of `f` to `e b`.
 This definition only makes sense when `f a₁ = f a₂ → g a₁ = g a₂` (spelled `g.FactorsThrough f`).
 In particular this holds if `f` is injective.
 
-A typical use case is when extending a function from the subtype to the entire type. If you want to
+A typical use case is when extending a function from a subtype to the entire type. If you want to
 extend `g : {b : β // p b} → γ` by zero to a function `β → γ`, you should use
-`Function.extend Subtype.val g 0`. If you do not care about the junk value, you can replace `0` `Classical.arbitrary _` (assuming `γ` is nonempty). -/
+`Function.extend Subtype.val g 0`. If you do not care about the junk value, you can replace `0` by
+`Classical.arbitrary _` (assuming `γ` is nonempty). -/
 def extend (f : α → β) (g : α → γ) (j : β → γ) : β → γ := fun b ↦
   if h : ∃ a, f a = b then g (Classical.choose h) else j b
 #align function.extend Function.extend


### PR DESCRIPTION
Confusion was recently expressed so as to how to use `Function.extend`. This is an attempt to clear it up.

Also fix the name of `Injective.factorsThrough`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
