### PR TITLE
[Merged by Bors] - chore(Topology/../Order): weaken TC assumptions

### DIFF
--- a/Mathlib/Topology/Algebra/Order/Compact.lean
+++ b/Mathlib/Topology/Algebra/Order/Compact.lean
@@ -381,10 +381,10 @@ end ConditionallyCompleteLinearOrder
 ### Min and max elements of a compact set
 -/
 
-section OrderClosedTopology
+section InfSup
 
-variable {α β γ : Type*} [ConditionallyCompleteLinearOrder α] [TopologicalSpace α]
-  [TopologicalSpace β] [TopologicalSpace γ]
+variable {α β : Type*} [ConditionallyCompleteLinearOrder α] [TopologicalSpace α]
+  [TopologicalSpace β]
 
 theorem IsCompact.sInf_mem [ClosedIicTopology α] {s : Set α} (hs : IsCompact s)
     (ne_s : s.Nonempty) : sInf s ∈ s :=
@@ -442,6 +442,12 @@ theorem IsCompact.exists_sSup_image_eq [ClosedIciTopology α] {s : Set β} (hs :
   IsCompact.exists_sInf_image_eq (α := αᵒᵈ) hs ne_s
 #align is_compact.exists_Sup_image_eq IsCompact.exists_sSup_image_eq
 
+end InfSup
+
+section ExistsExtr
+
+variable {α β : Type*} [LinearOrder α] [TopologicalSpace α] [TopologicalSpace β]
+
 theorem IsCompact.exists_isMinOn_mem_subset [ClosedIicTopology α] {f : β → α} {s t : Set β}
     {z : β} (ht : IsCompact t) (hf : ContinuousOn f t) (hz : z ∈ t)
     (hfz : ∀ z' ∈ t \ s, f z < f z') : ∃ x ∈ s, IsMinOn f t x :=
@@ -477,7 +483,7 @@ theorem IsCompact.exists_isLocalMax_mem_open [ClosedIciTopology α] {f : β → 
   let ⟨x, hxs, h⟩ := ht.exists_isMaxOn_mem_subset hf hz hfz
   ⟨x, hxs, h.isLocalMax <| mem_nhds_iff.2 ⟨s, hst, hs, hxs⟩⟩
 
-end OrderClosedTopology
+end ExistsExtr
 
 variable {α β γ : Type*} [ConditionallyCompleteLinearOrder α] [TopologicalSpace α]
   [OrderTopology α] [TopologicalSpace β] [TopologicalSpace γ]


### PR DESCRIPTION
Generalize some lemmas from `ConditionallyCompleteLinearOrder`
to `LinearOrder`.
Also drop an unused `variable`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)