### PR TITLE
[Merged by Bors] - chore: relax typeclass assumptions in two modular lattice lemmas

### DIFF
--- a/Mathlib/Order/ModularLattice.lean
+++ b/Mathlib/Order/ModularLattice.lean
@@ -409,12 +409,12 @@ theorem disjoint_sup_left_of_disjoint_sup_right [Lattice α] [OrderBot α]
   rwa [sup_comm, disjoint_comm] at hsup
 #align disjoint.disjoint_sup_left_of_disjoint_sup_right Disjoint.disjoint_sup_left_of_disjoint_sup_right
 
-theorem isCompl_sup_right_of_isCompl_sup_left [CompleteLattice α] [IsModularLattice α]
+theorem isCompl_sup_right_of_isCompl_sup_left [Lattice α] [BoundedOrder α] [IsModularLattice α]
     (h : Disjoint a b) (hcomp : IsCompl (a ⊔ b) c) :
     IsCompl a (b ⊔ c) :=
   ⟨h.disjoint_sup_right_of_disjoint_sup_left hcomp.disjoint, codisjoint_assoc.mp hcomp.codisjoint⟩
 
-theorem isCompl_sup_left_of_isCompl_sup_right [CompleteLattice α] [IsModularLattice α]
+theorem isCompl_sup_left_of_isCompl_sup_right [Lattice α] [BoundedOrder α] [IsModularLattice α]
     (h : Disjoint b c) (hcomp : IsCompl a (b ⊔ c)) :
     IsCompl (a ⊔ b) c :=
   ⟨h.disjoint_sup_left_of_disjoint_sup_right hcomp.disjoint, codisjoint_assoc.mpr hcomp.codisjoint⟩


### PR DESCRIPTION
Co-authored-by: Junyan Xu <junyanxumath@gmail.com> @alreadydone


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
