### PR TITLE
[Merged by Bors] - fix(RingTheory/GradedAlgebra/Basic): rewrite `simps` lemma by hand

### DIFF
--- a/Mathlib/RingTheory/GradedAlgebra/Basic.lean
+++ b/Mathlib/RingTheory/GradedAlgebra/Basic.lean
@@ -202,13 +202,31 @@ namespace DirectSum
 
 /-- If `A` is graded by `ι` with degree `i` component `𝒜 i`, then it is isomorphic as
 an algebra to a direct sum of components. -/
-@[simps!]
+-- Porting note: deleted [simps] and added the corresponding lemmas by hand
 def decomposeAlgEquiv : A ≃ₐ[R] ⨁ i, 𝒜 i :=
   AlgEquiv.symm
     { (decomposeAddEquiv 𝒜).symm with
       map_mul' := (coeAlgHom 𝒜).map_mul
       commutes' := (coeAlgHom 𝒜).commutes }
 #align direct_sum.decompose_alg_equiv DirectSum.decomposeAlgEquiv
+
+@[simp]
+lemma decomposeAlgEquiv_apply (a : A) :
+    decomposeAlgEquiv 𝒜 a = decompose 𝒜 a := rfl
+
+@[simp]
+lemma decomposeAlgEquiv_symm_apply (a : ⨁ i, 𝒜 i) :
+    (decomposeAlgEquiv 𝒜).symm a = (decompose 𝒜).symm a := rfl
+
+@[simp]
+lemma decompose_algebraMap (r : R) :
+    decompose 𝒜 (algebraMap R A r) = algebraMap R (⨁ i, 𝒜 i) r :=
+  (decomposeAlgEquiv 𝒜).commutes r
+
+@[simp]
+lemma decompose_symm_algebraMap (r : R) :
+    (decompose 𝒜).symm (algebraMap R (⨁ i, 𝒜 i) r) = algebraMap R A r :=
+  (decomposeAlgEquiv 𝒜).symm.commutes r
 
 end DirectSum
 


### PR DESCRIPTION
The simps lemmas generated here were bad.
The porting note matches the one on `decomposeAddEquiv` which also needed manual lemmas.

This also adds new lemmas that help keep `simp` confluent.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
