### PR TITLE
[Merged by Bors] - feat(Algebra/DirectSum/Algebra): graded multiplication as a bilinear map

### DIFF
--- a/Mathlib/Algebra/DirectSum/Algebra.lean
+++ b/Mathlib/Algebra/DirectSum/Algebra.lean
@@ -49,14 +49,26 @@ class GAlgebra where
   toFun : R →+ A 0
   map_one : toFun 1 = GradedMonoid.GOne.one
   map_mul :
-    ∀ r s, GradedMonoid.mk _ (toFun (r * s)) = ⟨_, GradedMonoid.GMul.mul (toFun r) (toFun s)⟩
-  commutes : ∀ r x, GradedMonoid.mk _ (toFun r) * x = x * ⟨_, toFun r⟩
-  smul_def : ∀ (r) (x : GradedMonoid A), GradedMonoid.mk x.1 (r • x.2) = ⟨_, toFun r⟩ * x
+    ∀ r s, GradedMonoid.mk _ (toFun (r * s)) = .mk _ (GradedMonoid.GMul.mul (toFun r) (toFun s))
+  commutes : ∀ (r) (x : GradedMonoid A), .mk _ (toFun r) * x = x * .mk _ (toFun r)
+  smul_def : ∀ (r) (x : GradedMonoid A), r • x = .mk _ (toFun r) * x
 #align direct_sum.galgebra DirectSum.GAlgebra
 
 end
 
 variable [Semiring B] [GAlgebra R A] [Algebra R B]
+
+instance _root_.GradedMonoid.smulCommClass_right :
+    SMulCommClass R (GradedMonoid A) (GradedMonoid A) where
+  smul_comm s x y := by
+    dsimp
+    rw [GAlgebra.smul_def, GAlgebra.smul_def, ←mul_assoc, GAlgebra.commutes, mul_assoc]
+
+instance _root_.GradedMonoid.isScalarTower_right :
+    IsScalarTower R (GradedMonoid A) (GradedMonoid A) where
+  smul_assoc s x y := by
+    dsimp
+    rw [GAlgebra.smul_def, GAlgebra.smul_def, ←mul_assoc, GAlgebra.commutes, mul_assoc]
 
 instance : Algebra R (⨁ i, A i) where
   toFun := (DirectSum.of A 0).comp GAlgebra.toFun
@@ -122,6 +134,20 @@ theorem algHom_ext' ⦃f g : (⨁ i, A i) →ₐ[R] B⦄
 theorem algHom_ext ⦃f g : (⨁ i, A i) →ₐ[R] B⦄ (h : ∀ i x, f (of A i x) = g (of A i x)) : f = g :=
   algHom_ext' R A fun i => LinearMap.ext <| h i
 #align direct_sum.alg_hom_ext DirectSum.algHom_ext
+
+/-- The piecewise multiplication from the `Mul` instance, as a bundled linear homomorphism.
+
+This is the graded version of `LinearMap.mul`, and the linear version of `DirectSum.gMulHom` -/
+@[simps]
+def gMulLHom {i j} : A i →ₗ[R] A j →ₗ[R] A (i + j) where
+  toFun a :=
+    { toFun := fun b => GradedMonoid.GMul.mul a b
+      map_smul' := fun r x => by
+        injection (smul_comm r (GradedMonoid.mk _ a) (GradedMonoid.mk _ x)).symm
+      map_add' := GNonUnitalNonAssocSemiring.mul_add _ }
+  map_smul' r x := LinearMap.ext fun y => by
+    injection smul_assoc r (GradedMonoid.mk _ x) (GradedMonoid.mk _ y)
+  map_add' _ _ := LinearMap.ext fun _ => GNonUnitalNonAssocSemiring.add_mul _ _ _
 
 end DirectSum
 

--- a/Mathlib/Algebra/GradedMonoid.lean
+++ b/Mathlib/Algebra/GradedMonoid.lean
@@ -26,7 +26,7 @@ forms an additively-graded monoid. The typeclasses are:
 * `GradedMonoid.GMonoid A`
 * `GradedMonoid.GCommMonoid A`
 
-With the `SigmaGraded` locale open, these respectively imbue:
+These respectively imbue:
 
 * `One (GradedMonoid A)`
 * `Mul (GradedMonoid A)`
@@ -108,6 +108,35 @@ instance {A : ι → Type*} [Inhabited ι] [Inhabited (A default)] : Inhabited (
 def mk {A : ι → Type*} : ∀ i, A i → GradedMonoid A :=
   Sigma.mk
 #align graded_monoid.mk GradedMonoid.mk
+
+/-! ### Actions -/
+
+section actions
+
+/-- If `R` acts on each `A i`, then it acts on `GradedMonoid A` via the `.2` projection. -/
+instance {α} {A : ι → Type*} [∀ i, SMul α (A i)] : SMul α (GradedMonoid A) where
+  smul r g := GradedMonoid.mk g.1 (r • g.2)
+
+theorem smul_mk {α} {A : ι → Type*} [∀ i, SMul α (A i)] {i} (c : α) (a : A i) :
+    c • mk i a = mk i (c • a) :=
+  rfl
+
+instance {α β} {A : ι → Type*} [∀ i, SMul α (A i)] [∀ i, SMul β (A i)]
+    [∀ i, SMulCommClass α β (A i)] :
+    SMulCommClass α β (GradedMonoid A) where
+  smul_comm a b g := Sigma.ext rfl <| heq_of_eq <| smul_comm a b g.2
+
+instance {α β} {A : ι → Type*} [SMul α β] [∀ i, SMul α (A i)] [∀ i, SMul β (A i)]
+    [∀ i, IsScalarTower α β (A i)] :
+    IsScalarTower α β (GradedMonoid A) where
+  smul_assoc a b g := Sigma.ext rfl <| heq_of_eq <| smul_assoc a b g.2
+
+instance {α} {A : ι → Type*} [Monoid α] [∀ i, MulAction α (A i)] :
+    MulAction α (GradedMonoid A) where
+  one_smul g := Sigma.ext rfl <| heq_of_eq <| one_smul _ g.2
+  mul_smul r₁ r₂ g := Sigma.ext rfl <| heq_of_eq <| mul_smul r₁ r₂ g.2
+
+end actions
 
 /-! ### Typeclasses -/
 


### PR DESCRIPTION
Also adds some missing actions on `GradedMonoid` which cleans up the definition of `DirectSum.GAlgebra` slightly.

This also replaces `(⟨i, x⟩ : GradedMonoid _)` with `.mk i x` as the former uses `Sigma.mk` instead of `GradedMonoid.mk`, which is annoying for `rw`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
