### PR TITLE
[Merged by Bors] - feat(MeasureTheory/../Prod): add lemmas about `NullMeasurableSet`

### DIFF
--- a/Mathlib/MeasureTheory/Constructions/Prod/Basic.lean
+++ b/Mathlib/MeasureTheory/Constructions/Prod/Basic.lean
@@ -584,7 +584,7 @@ lemma nullMeasurableSet_prod_of_ne_zero {s : Set α} {t : Set β} (hs : μ s ≠
     NullMeasurableSet (s ×ˢ t) (μ.prod ν) ↔ NullMeasurableSet s μ ∧ NullMeasurableSet t ν :=
   ⟨fun h ↦ ⟨h.left_of_prod ht, h.right_of_prod hs⟩, fun ⟨hs, ht⟩ ↦ hs.prod ht⟩
 
-/-- The product of two set is null measurable
+/-- The product of two sets is null measurable
 if and only if both of them are null measurable or one of them has measure zero. -/
 lemma nullMeasurableSet_prod {s : Set α} {t : Set β} :
     NullMeasurableSet (s ×ˢ t) (μ.prod ν) ↔

--- a/Mathlib/MeasureTheory/Constructions/Prod/Basic.lean
+++ b/Mathlib/MeasureTheory/Constructions/Prod/Basic.lean
@@ -298,12 +298,12 @@ instance prod.measureSpace {α β} [MeasureSpace α] [MeasureSpace β] : Measure
   volume := volume.prod volume
 #align measure_theory.measure.prod.measure_space MeasureTheory.Measure.prod.measureSpace
 
-variable [SigmaFinite ν]
-
 theorem volume_eq_prod (α β) [MeasureSpace α] [MeasureSpace β] :
     (volume : Measure (α × β)) = (volume : Measure α).prod (volume : Measure β) :=
   rfl
 #align measure_theory.measure.volume_eq_prod MeasureTheory.Measure.volume_eq_prod
+
+variable [SigmaFinite ν]
 
 theorem prod_apply {s : Set (α × β)} (hs : MeasurableSet s) :
     μ.prod ν s = ∫⁻ x, ν (Prod.mk x ⁻¹' s) ∂μ := by
@@ -459,9 +459,32 @@ theorem ae_ae_of_ae_prod {p : α × β → Prop} (h : ∀ᵐ z ∂μ.prod ν, p 
   measure_ae_null_of_prod_null h
 #align measure_theory.measure.ae_ae_of_ae_prod MeasureTheory.Measure.ae_ae_of_ae_prod
 
+theorem ae_ae_eq_curry_of_prod {f g : α × β → γ} (h : f =ᵐ[μ.prod ν] g) :
+    ∀ᵐ x ∂μ, curry f x =ᵐ[ν] curry g x :=
+  ae_ae_of_ae_prod h
+
+theorem ae_ae_eq_of_ae_eq_uncurry {f g : α → β → γ} (h : uncurry f =ᵐ[μ.prod ν] uncurry g) :
+    ∀ᵐ x ∂μ, f x =ᵐ[ν] g x :=
+  ae_ae_eq_curry_of_prod h
+
 theorem ae_prod_mem_iff_ae_ae_mem {s : Set (α × β)} (hs : MeasurableSet s) :
     (∀ᵐ z ∂μ.prod ν, z ∈ s) ↔ ∀ᵐ x ∂μ, ∀ᵐ y ∂ν, (x, y) ∈ s :=
   measure_prod_null hs.compl
+
+theorem quasiMeasurePreserving_fst : QuasiMeasurePreserving Prod.fst (μ.prod ν) μ := by
+  refine' ⟨measurable_fst, AbsolutelyContinuous.mk fun s hs h2s => _⟩
+  rw [map_apply measurable_fst hs, ← prod_univ, prod_prod, h2s, zero_mul]
+#align measure_theory.measure.quasi_measure_preserving_fst MeasureTheory.Measure.quasiMeasurePreserving_fst
+
+theorem quasiMeasurePreserving_snd : QuasiMeasurePreserving Prod.snd (μ.prod ν) ν := by
+  refine' ⟨measurable_snd, AbsolutelyContinuous.mk fun s hs h2s => _⟩
+  rw [map_apply measurable_snd hs, ← univ_prod, prod_prod, h2s, mul_zero]
+#align measure_theory.measure.quasi_measure_preserving_snd MeasureTheory.Measure.quasiMeasurePreserving_snd
+
+lemma set_prod_ae_eq {s s' : Set α} {t t' : Set β} (hs : s =ᵐ[μ] s') (ht : t =ᵐ[ν] t') :
+    (s ×ˢ t : Set (α × β)) =ᵐ[μ.prod ν] (s' ×ˢ t' : Set (α × β)) :=
+  (quasiMeasurePreserving_fst.preimage_ae_eq hs).inter
+    (quasiMeasurePreserving_snd.preimage_ae_eq ht)
 
 lemma measure_prod_compl_eq_zero {s : Set α} {t : Set β}
     (s_ae_univ : μ sᶜ = 0) (t_ae_univ : ν tᶜ = 0) :
@@ -472,19 +495,19 @@ lemma measure_prod_compl_eq_zero {s : Set α} {t : Set β}
 
 lemma _root_.MeasureTheory.NullMeasurableSet.prod {s : Set α} {t : Set β}
     (s_mble : NullMeasurableSet s μ) (t_mble : NullMeasurableSet t ν) :
-    NullMeasurableSet (s ×ˢ t) (μ.prod ν) := by
-  obtain ⟨s₀, ⟨mble_s₀, s_aeeq_s₀⟩⟩ := s_mble
-  obtain ⟨t₀, ⟨mble_t₀, t_aeeq_t₀⟩⟩ := t_mble
-  refine ⟨s₀ ×ˢ t₀, ⟨mble_s₀.prod mble_t₀, ?_⟩⟩
-  rw [Measure.ae, Filter.eventuallyEq_iff_exists_mem] at *
-  simp only [Filter.mem_mk, mem_setOf_eq] at *
-  rcases s_aeeq_s₀ with ⟨u, ⟨u_mem, s_eq_s₀⟩⟩
-  rcases t_aeeq_t₀ with ⟨v, ⟨v_mem, t_eq_t₀⟩⟩
-  refine ⟨u ×ˢ v, ⟨measure_prod_compl_eq_zero u_mem v_mem, ?_⟩⟩
-  intro p hp
-  change (p ∈ s ×ˢ t) = (p ∈ s₀ ×ˢ t₀)
-  simp [show p.fst ∈ s ↔ p.fst ∈ s₀ from Iff.of_eq (s_eq_s₀ hp.1),
-        show p.snd ∈ t ↔ p.snd ∈ t₀ from Iff.of_eq (t_eq_t₀ hp.2)]
+    NullMeasurableSet (s ×ˢ t) (μ.prod ν) :=
+  let ⟨s₀, mble_s₀, s_aeeq_s₀⟩ := s_mble
+  let ⟨t₀, mble_t₀, t_aeeq_t₀⟩ := t_mble
+  ⟨s₀ ×ˢ t₀, ⟨mble_s₀.prod mble_t₀, set_prod_ae_eq s_aeeq_s₀ t_aeeq_t₀⟩⟩
+
+/-- If `s ×ˢ t` is a null measurable set and `μ s ≠ 0`, then `t` is a null measurable set. -/
+lemma _root_.MeasureTheory.NullMeasurableSet.right_of_prod {s : Set α} {t : Set β}
+    (h : NullMeasurableSet (s ×ˢ t) (μ.prod ν)) (hs : μ s ≠ 0) : NullMeasurableSet t ν := by
+  rcases h with ⟨u, hum, hu⟩
+  obtain ⟨x, hxs, hx⟩ : ∃ x ∈ s, (Prod.mk x ⁻¹' (s ×ˢ t)) =ᵐ[ν] (Prod.mk x ⁻¹' u) :=
+    ((frequently_ae_iff.2 hs).and_eventually (ae_ae_eq_curry_of_prod hu)).exists
+  refine ⟨Prod.mk x ⁻¹' u, measurable_prod_mk_left hum, ?_⟩
+  rwa [mk_preimage_prod_right hxs] at hx
 
 /-- `μ.prod ν` has finite spanning sets in rectangles of finite spanning sets. -/
 noncomputable def FiniteSpanningSetsIn.prod {ν : Measure β} {C : Set (Set α)} {D : Set (Set β)}
@@ -498,16 +521,6 @@ noncomputable def FiniteSpanningSetsIn.prod {ν : Measure β} {C : Set (Set α)}
     exact mul_lt_top (hμ.finite _).ne (hν.finite _).ne
   · simp_rw [iUnion_unpair_prod, hμ.spanning, hν.spanning, univ_prod_univ]
 #align measure_theory.measure.finite_spanning_sets_in.prod MeasureTheory.Measure.FiniteSpanningSetsIn.prod
-
-theorem quasiMeasurePreserving_fst : QuasiMeasurePreserving Prod.fst (μ.prod ν) μ := by
-  refine' ⟨measurable_fst, AbsolutelyContinuous.mk fun s hs h2s => _⟩
-  rw [map_apply measurable_fst hs, ← prod_univ, prod_prod, h2s, zero_mul]
-#align measure_theory.measure.quasi_measure_preserving_fst MeasureTheory.Measure.quasiMeasurePreserving_fst
-
-theorem quasiMeasurePreserving_snd : QuasiMeasurePreserving Prod.snd (μ.prod ν) ν := by
-  refine' ⟨measurable_snd, AbsolutelyContinuous.mk fun s hs h2s => _⟩
-  rw [map_apply measurable_snd hs, ← univ_prod, prod_prod, h2s, mul_zero]
-#align measure_theory.measure.quasi_measure_preserving_snd MeasureTheory.Measure.quasiMeasurePreserving_snd
 
 variable [SigmaFinite μ]
 
@@ -558,12 +571,33 @@ theorem prod_apply_symm {s : Set (α × β)} (hs : MeasurableSet s) :
   rfl
 #align measure_theory.measure.prod_apply_symm MeasureTheory.Measure.prod_apply_symm
 
+/-- If `s ×ˢ t` is a null measurable set and `ν t ≠ 0`, then `s` is a null measurable set. -/
+lemma _root_.MeasureTheory.NullMeasurableSet.left_of_prod {s : Set α} {t : Set β}
+    (h : NullMeasurableSet (s ×ˢ t) (μ.prod ν)) (ht : ν t ≠ 0) : NullMeasurableSet s μ := by
+  refine .right_of_prod ?_ ht
+  rw [← preimage_swap_prod]
+  exact h.preimage measurePreserving_swap.quasiMeasurePreserving
+
+/-- The product of two non-null sets is null measurable
+if and only if both of them are null measurable. -/
+lemma nullMeasurableSet_prod_of_ne_zero {s : Set α} {t : Set β} (hs : μ s ≠ 0) (ht : ν t ≠ 0) :
+    NullMeasurableSet (s ×ˢ t) (μ.prod ν) ↔ NullMeasurableSet s μ ∧ NullMeasurableSet t ν :=
+  ⟨fun h ↦ ⟨h.left_of_prod ht, h.right_of_prod hs⟩, fun ⟨hs, ht⟩ ↦ hs.prod ht⟩
+
+/-- The product of two set is null measurable
+if and only if both of them are null measurable or one of them has measure zero. -/
+lemma nullMeasurableSet_prod {s : Set α} {t : Set β} :
+    NullMeasurableSet (s ×ˢ t) (μ.prod ν) ↔
+      NullMeasurableSet s μ ∧ NullMeasurableSet t ν ∨ μ s = 0 ∨ ν t = 0 := by
+  rcases eq_or_ne (μ s) 0 with hs | hs; · simp [NullMeasurableSet.of_null, *]
+  rcases eq_or_ne (ν t) 0 with ht | ht; · simp [NullMeasurableSet.of_null, *]
+  simp [*, nullMeasurableSet_prod_of_ne_zero]
+
 theorem prodAssoc_prod [SigmaFinite τ] :
     map MeasurableEquiv.prodAssoc ((μ.prod ν).prod τ) = μ.prod (ν.prod τ) := by
-  refine'
-    (prod_eq_generateFrom generateFrom_measurableSet generateFrom_prod isPiSystem_measurableSet
-        isPiSystem_prod μ.toFiniteSpanningSetsIn
-        (ν.toFiniteSpanningSetsIn.prod τ.toFiniteSpanningSetsIn) _).symm
+  refine' (prod_eq_generateFrom generateFrom_measurableSet generateFrom_prod
+    isPiSystem_measurableSet isPiSystem_prod μ.toFiniteSpanningSetsIn
+    (ν.toFiniteSpanningSetsIn.prod τ.toFiniteSpanningSetsIn) _).symm
   rintro s hs _ ⟨t, u, ht, hu, rfl⟩; rw [mem_setOf_eq] at hs ht hu
   simp_rw [map_apply (MeasurableEquiv.measurable _) (hs.prod (ht.prod hu)),
     MeasurableEquiv.prodAssoc, MeasurableEquiv.coe_mk, Equiv.prod_assoc_preimage, prod_prod,
@@ -571,7 +605,6 @@ theorem prodAssoc_prod [SigmaFinite τ] :
 #align measure_theory.measure.prod_assoc_prod MeasureTheory.Measure.prodAssoc_prod
 
 /-! ### The product of specific measures -/
-
 
 theorem prod_restrict (s : Set α) (t : Set β) :
     (μ.restrict s).prod (ν.restrict t) = (μ.prod ν).restrict (s ×ˢ t) := by


### PR DESCRIPTION
Also golf a proof.

The informal proof was provided by Felix Weilacher on [Zulip](https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/Product.20of.20nonmeasurable.20sets).

Co-authored-by: @Felix-Weilacher


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
