### PR TITLE
[Merged by Bors] - refactor(LinearAlgebra/QuadraticForm/Basic): remove non-commutativity support

### DIFF
--- a/Counterexamples/QuadraticForm.lean
+++ b/Counterexamples/QuadraticForm.lean
@@ -51,7 +51,7 @@ theorem B_ne_zero : B F ≠ 0 := fun h => by simpa using BilinForm.congr_fun h (
 This disproves a weaker version of `QuadraticForm.associated_left_inverse`.
 -/
 theorem BilinForm.not_injOn_toQuadraticForm_isSymm.{u} :
-    ¬∀ {R M : Type u} [Semiring R] [AddCommMonoid M], ∀ [Module R M],
+    ¬∀ {R M : Type u} [CommSemiring R] [AddCommMonoid M], ∀ [Module R M],
       Set.InjOn (toQuadraticForm : BilinForm R M → QuadraticForm R M) {B | B.IsSymm} := by
   intro h
   let F := ULift.{u} (ZMod 2)

--- a/Mathlib/LinearAlgebra/CliffordAlgebra/Contraction.lean
+++ b/Mathlib/LinearAlgebra/CliffordAlgebra/Contraction.lean
@@ -289,7 +289,7 @@ theorem changeForm.neg_proof : (-B).toQuadraticForm = Q - Q' :=
 #align clifford_algebra.change_form.neg_proof CliffordAlgebra.changeForm.neg_proof
 
 theorem changeForm.associated_neg_proof [Invertible (2 : R)] :
-    (QuadraticForm.associated (R₁ := R) (M := M) (-Q)).toQuadraticForm = 0 - Q := by
+    (QuadraticForm.associated (R := R) (M := M) (-Q)).toQuadraticForm = 0 - Q := by
   simp [QuadraticForm.toQuadraticForm_associated]
 #align clifford_algebra.change_form.associated_neg_proof CliffordAlgebra.changeForm.associated_neg_proof
 

--- a/Mathlib/LinearAlgebra/Matrix/PosDef.lean
+++ b/Mathlib/LinearAlgebra/Matrix/PosDef.lean
@@ -164,14 +164,15 @@ variable {n : Type*} [Fintype n]
 
 theorem posDef_of_toMatrix' [DecidableEq n] {Q : QuadraticForm ℝ (n → ℝ)}
     (hQ : Q.toMatrix'.PosDef) : Q.PosDef := by
-  rw [← toQuadraticForm_associated ℝ Q, ← BilinForm.toMatrix'.left_inv ((associatedHom ℝ) Q)]
+  rw [← toQuadraticForm_associated ℝ Q,
+    ← BilinForm.toMatrix'.left_inv ((associatedHom (R := ℝ) ℝ) Q)]
   apply Matrix.posDef_toQuadraticForm' hQ
 #align quadratic_form.pos_def_of_to_matrix' QuadraticForm.posDef_of_toMatrix'
 
 theorem posDef_toMatrix' [DecidableEq n] {Q : QuadraticForm ℝ (n → ℝ)} (hQ : Q.PosDef) :
     Q.toMatrix'.PosDef := by
   rw [← toQuadraticForm_associated ℝ Q, ←
-    BilinForm.toMatrix'.left_inv ((associatedHom ℝ) Q)] at hQ
+    BilinForm.toMatrix'.left_inv ((associatedHom (R := ℝ) ℝ) Q)] at hQ
   apply Matrix.posDef_of_toQuadraticForm' (isSymm_toMatrix' Q) hQ
 #align quadratic_form.pos_def_to_matrix' QuadraticForm.posDef_toMatrix'
 

--- a/Mathlib/LinearAlgebra/QuadraticForm/Basic.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/Basic.lean
@@ -13,14 +13,15 @@ import Mathlib.LinearAlgebra.Matrix.Symmetric
 # Quadratic forms
 
 This file defines quadratic forms over a `R`-module `M`.
-A quadratic form on a ring `R` is a map `Q : M → R` such that:
+A quadratic form on a commutative ring `R` is a map `Q : M → R` such that:
+
 * `QuadraticForm.map_smul`: `Q (a • x) = a * a * Q x`
 * `QuadraticForm.polar_add_left`, `QuadraticForm.polar_add_right`,
   `QuadraticForm.polar_smul_left`, `QuadraticForm.polar_smul_right`:
   the map `QuadraticForm.polar Q := fun x y ↦ Q (x + y) - Q x - Q y` is bilinear.
 
-This notion generalizes to semirings using the approach in [izhakian2016][] which requires that
-there be a (possibly non-unique) companion bilinear form `B` such that
+This notion generalizes to commutative semirings using the approach in [izhakian2016][] which
+requires that there be a (possibly non-unique) companion bilinear form `B` such that
 `∀ x y, Q (x + y) = Q x + Q y + B x y`. Over a ring, this `B` is precisely `QuadraticForm.polar Q`.
 
 To build a `QuadraticForm` from the `polar` axioms, use `QuadraticForm.ofPolar`.

--- a/Mathlib/LinearAlgebra/QuadraticForm/Basic.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/Basic.lean
@@ -48,9 +48,19 @@ and composition with linear maps `f`, `Q.comp f x = Q (f x)`.
 
 ## Notation
 
-In this file, the variable `R` is used when a `CommSemiring` structure.
+In this file, the variable `R` is used when a `CommSemiring` structure is available.
 
 The variable `S` is used when `R` itself has a `•` action.
+
+## Implementation notes
+
+While the definition and many results make sense if we drop commutativity assumptions,
+the correct definition of a quadratic form in the noncommutative setting would require
+substantial refactors from the current version, such that $Q(rm) = rQ(m)r^*$ for some
+suitable conjugation $r^*$.
+
+The [Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/Quadratic.20Maps/near/395529867)
+has some further discusion.
 
 ## References
 

--- a/Mathlib/LinearAlgebra/QuadraticForm/Basic.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/Basic.lean
@@ -47,10 +47,7 @@ and composition with linear maps `f`, `Q.comp f x = Q (f x)`.
 
 ## Notation
 
-In this file, the variable `R` is used when a `Ring` structure is sufficient and
-`R₁` is used when specifically a `CommRing` is required. This allows us to keep
-`[Module R M]` and `[Module R₁ M]` assumptions in the variables without
-confusion between `*` from `Ring` and `*` from `CommRing`.
+In this file, the variable `R` is used when a `CommSemiring` structure.
 
 The variable `S` is used when `R` itself has a `•` action.
 
@@ -69,13 +66,13 @@ universe u v w
 
 variable {S T : Type*}
 
-variable {R R₁ : Type*} {M : Type*}
+variable {R : Type*} {M : Type*}
 
 open BigOperators
 
 section Polar
 
-variable [Ring R] [CommRing R₁] [AddCommGroup M]
+variable [CommRing R] [AddCommGroup M]
 
 namespace QuadraticForm
 
@@ -115,7 +112,8 @@ theorem polar_add_left_iff {f : M → R} {x x' y : M} :
     add_right_comm (f (x + y)), add_left_inj]
 #align quadratic_form.polar_add_left_iff QuadraticForm.polar_add_left_iff
 
-theorem polar_comp {F : Type*} [Ring S] [AddMonoidHomClass F R S] (f : M → R) (g : F) (x y : M) :
+theorem polar_comp {F : Type*} [CommRing S] [AddMonoidHomClass F R S]
+    (f : M → R) (g : F) (x y : M) :
     polar (g ∘ f) x y = g (polar f x y) := by
   simp only [polar, Pi.smul_apply, Function.comp_apply, map_sub]
 #align quadratic_form.polar_comp QuadraticForm.polar_comp
@@ -127,7 +125,8 @@ end Polar
 /-- A quadratic form over a module.
 
 For a more familiar constructor when `R` is a ring, see `QuadraticForm.ofPolar`. -/
-structure QuadraticForm (R : Type u) (M : Type v) [Semiring R] [AddCommMonoid M] [Module R M] where
+structure QuadraticForm (R : Type u) (M : Type v) [CommSemiring R] [AddCommMonoid M] [Module R M]
+    where
   toFun : M → R
   toFun_smul : ∀ (a : R) (x : M), toFun (a • x) = a * a * toFun x
   exists_companion' : ∃ B : BilinForm R M, ∀ x y, toFun (x + y) = toFun x + toFun y + B x y
@@ -137,7 +136,7 @@ namespace QuadraticForm
 
 section FunLike
 
-variable [Semiring R] [AddCommMonoid M] [Module R M]
+variable [CommSemiring R] [AddCommMonoid M] [Module R M]
 
 variable {Q Q' : QuadraticForm R M}
 
@@ -196,9 +195,9 @@ theorem copy_eq (Q : QuadraticForm R M) (Q' : M → R) (h : Q' = ⇑Q) : Q.copy 
 
 end FunLike
 
-section Semiring
+section CommSemiring
 
-variable [Semiring R] [AddCommMonoid M] [Module R M]
+variable [CommSemiring R] [AddCommMonoid M] [Module R M]
 
 variable (Q : QuadraticForm R M)
 
@@ -237,11 +236,11 @@ theorem map_smul_of_tower [CommSemiring S] [Algebra S R] [Module S M] [IsScalarT
   rw [← IsScalarTower.algebraMap_smul R a x, map_smul, ← RingHom.map_mul, Algebra.smul_def]
 #align quadratic_form.map_smul_of_tower QuadraticForm.map_smul_of_tower
 
-end Semiring
+end CommSemiring
 
-section Ring
+section CommRing
 
-variable [Ring R] [CommRing R₁] [AddCommGroup M]
+variable [CommRing R] [AddCommGroup M]
 
 variable [Module R M] (Q : QuadraticForm R M)
 
@@ -356,11 +355,11 @@ theorem choose_exists_companion : Q.exists_companion.choose = polarBilin Q :=
     rw [polarBilin_apply, polar, Q.exists_companion.choose_spec, sub_sub, add_sub_cancel']
 #align quadratic_form.some_exists_companion QuadraticForm.choose_exists_companion
 
-end Ring
+end CommRing
 
 section SemiringOperators
 
-variable [Semiring R] [AddCommMonoid M] [Module R M]
+variable [CommSemiring R] [AddCommMonoid M] [Module R M]
 
 section SMul
 
@@ -369,7 +368,7 @@ variable [SMulCommClass S R R] [SMulCommClass T R R]
 
 /-- `QuadraticForm R M` inherits the scalar action from any algebra over `R`.
 
-When `R` is commutative, this provides an `R`-action via `Algebra.id`. -/
+This provides an `R`-action via `Algebra.id`. -/
 instance : SMul S (QuadraticForm R M) :=
   ⟨fun a Q =>
     { toFun := a • ⇑Q
@@ -492,7 +491,7 @@ end SemiringOperators
 
 section RingOperators
 
-variable [Ring R] [AddCommGroup M] [Module R M]
+variable [CommRing R] [AddCommGroup M] [Module R M]
 
 instance : Neg (QuadraticForm R M) :=
   ⟨fun Q =>
@@ -533,7 +532,7 @@ end RingOperators
 
 section Comp
 
-variable [Semiring R] [AddCommMonoid M] [Module R M]
+variable [CommSemiring R] [AddCommMonoid M] [Module R M]
 
 variable {N : Type v} [AddCommMonoid N] [Module R N]
 
@@ -605,13 +604,13 @@ theorem linMulLin_comp (f g : M →ₗ[R] R) (h : N →ₗ[R] M) :
 
 variable {n : Type*}
 
-/-- `sq` is the quadratic form mapping the vector `x : R₁` to `x * x` -/
+/-- `sq` is the quadratic form mapping the vector `x : R` to `x * x` -/
 @[simps!]
 def sq : QuadraticForm R R :=
   linMulLin LinearMap.id LinearMap.id
 #align quadratic_form.sq QuadraticForm.sq
 
-/-- `proj i j` is the quadratic form mapping the vector `x : n → R₁` to `x i * x j` -/
+/-- `proj i j` is the quadratic form mapping the vector `x : n → R` to `x i * x j` -/
 def proj (i j : n) : QuadraticForm R (n → R) :=
   linMulLin (@LinearMap.proj _ _ _ (fun _ => R) _ _ i) (@LinearMap.proj _ _ _ (fun _ => R) _ _ j)
 #align quadratic_form.proj QuadraticForm.proj
@@ -640,7 +639,7 @@ open QuadraticForm
 
 section Semiring
 
-variable [Semiring R] [AddCommMonoid M] [Module R M]
+variable [CommSemiring R] [AddCommMonoid M] [Module R M]
 
 variable {B : BilinForm R M}
 
@@ -728,7 +727,7 @@ end Semiring
 
 section Ring
 
-variable [Ring R] [AddCommGroup M] [Module R M]
+variable [CommRing R] [AddCommGroup M] [Module R M]
 
 variable {B : BilinForm R M}
 
@@ -786,7 +785,7 @@ open BilinForm
 
 section AssociatedHom
 
-variable [Ring R] [CommRing R₁] [AddCommGroup M] [Module R M] [Module R₁ M]
+variable [CommRing R] [AddCommGroup M] [Module R M]
 
 variable (S) [CommSemiring S] [Algebra S R]
 
@@ -800,6 +799,8 @@ Over a commutative ring, use `QuadraticForm.associated`, which gives an `R`-line
 general ring with no nontrivial distinguished commutative subring, use `QuadraticForm.associated'`,
 which gives an additive homomorphism (or more precisely a `ℤ`-linear map.) -/
 def associatedHom : QuadraticForm R M →ₗ[S] BilinForm R M :=
+  -- TODO: this `center` stuff is vertigial from an incorrect non-commutative version, but we leave
+  -- it behind to make a future refactor to a *correct* non-commutative version easier in future.
   (⟨⅟2, Set.invOf_mem_center (Set.ofNat_mem_center _ _)⟩ : Submonoid.center R) •
     { toFun := polarBilin
       map_add' := fun _x _y => BilinForm.ext <| polar_add _ _
@@ -885,27 +886,27 @@ end AssociatedHom
 
 section Associated
 
-variable [CommSemiring S] [CommRing R₁] [AddCommGroup M] [Algebra S R₁] [Module R₁ M]
+variable [CommSemiring S] [CommRing R] [AddCommGroup M] [Algebra S R] [Module R M]
 
-variable [Invertible (2 : R₁)]
+variable [Invertible (2 : R)]
 
 -- Note:  When possible, rather than writing lemmas about `associated`, write a lemma applying to
 -- the more general `associatedHom` and place it in the previous section.
 /-- `associated` is the linear map that sends a quadratic form over a commutative ring to its
 associated symmetric bilinear form. -/
-abbrev associated : QuadraticForm R₁ M →ₗ[R₁] BilinForm R₁ M :=
-  associatedHom R₁
+abbrev associated : QuadraticForm R M →ₗ[R] BilinForm R M :=
+  associatedHom R
 #align quadratic_form.associated QuadraticForm.associated
 
 variable (S) in
 theorem coe_associatedHom :
-    ⇑(associatedHom S : QuadraticForm R₁ M →ₗ[S] BilinForm R₁ M) = associated :=
+    ⇑(associatedHom S : QuadraticForm R M →ₗ[S] BilinForm R M) = associated :=
   rfl
 
 @[simp]
-theorem associated_linMulLin (f g : M →ₗ[R₁] R₁) :
-    associated (R₁ := R₁) (linMulLin f g) =
-      ⅟ (2 : R₁) • (BilinForm.linMulLin f g + BilinForm.linMulLin g f) := by
+theorem associated_linMulLin (f g : M →ₗ[R] R) :
+    associated (R := R) (linMulLin f g) =
+      ⅟ (2 : R) • (BilinForm.linMulLin f g + BilinForm.linMulLin g f) := by
   ext
   simp only [smul_add, Algebra.id.smul_eq_mul, BilinForm.linMulLin_apply,
     QuadraticForm.linMulLin_apply, BilinForm.smul_apply, associated_apply, BilinForm.add_apply,
@@ -914,7 +915,7 @@ theorem associated_linMulLin (f g : M →ₗ[R₁] R₁) :
 #align quadratic_form.associated_lin_mul_lin QuadraticForm.associated_linMulLin
 
 @[simp]
-lemma associated_sq : associated (R₁ := R₁) sq = LinearMap.toBilin (LinearMap.mul R₁ R₁) :=
+lemma associated_sq : associated (R := R) sq = LinearMap.toBilin (LinearMap.mul R R) :=
   (associated_linMulLin (LinearMap.id) (LinearMap.id)).trans <|
     by simp only [smul_add, invOf_two_smul_add_invOf_two_smul]; rfl
 
@@ -924,7 +925,7 @@ section Anisotropic
 
 section Semiring
 
-variable [Semiring R] [AddCommMonoid M] [Module R M]
+variable [CommSemiring R] [AddCommMonoid M] [Module R M]
 
 /-- An anisotropic quadratic form is zero only on zero vectors. -/
 def Anisotropic (Q : QuadraticForm R M) : Prop :=
@@ -945,7 +946,7 @@ end Semiring
 
 section Ring
 
-variable [Ring R] [AddCommGroup M] [Module R M]
+variable [CommRing R] [AddCommGroup M] [Module R M]
 
 /-- The associated bilinear form of an anisotropic quadratic form is nondegenerate. -/
 theorem nondegenerate_of_anisotropic [Invertible (2 : R)] (Q : QuadraticForm R M)
@@ -962,7 +963,7 @@ end Anisotropic
 
 section PosDef
 
-variable {R₂ : Type u} [OrderedRing R₂] [AddCommMonoid M] [Module R₂ M]
+variable {R₂ : Type u} [OrderedCommRing R₂] [AddCommMonoid M] [Module R₂ M]
 
 variable {Q₂ : QuadraticForm R₂ M}
 
@@ -1023,28 +1024,28 @@ The determinant of the matrix is the discriminant of the quadratic form.
 
 variable {n : Type w} [Fintype n] [DecidableEq n]
 
-variable [CommRing R₁] [AddCommMonoid M] [Module R₁ M]
+variable [CommRing R] [AddCommMonoid M] [Module R M]
 
 /-- `M.toQuadraticForm'` is the map `fun x ↦ col x * M * row x` as a quadratic form. -/
-def Matrix.toQuadraticForm' (M : Matrix n n R₁) : QuadraticForm R₁ (n → R₁) :=
+def Matrix.toQuadraticForm' (M : Matrix n n R) : QuadraticForm R (n → R) :=
   M.toBilin'.toQuadraticForm
 #align matrix.to_quadratic_form' Matrix.toQuadraticForm'
 
-variable [Invertible (2 : R₁)]
+variable [Invertible (2 : R)]
 
 /-- A matrix representation of the quadratic form. -/
-def QuadraticForm.toMatrix' (Q : QuadraticForm R₁ (n → R₁)) : Matrix n n R₁ :=
-  BilinForm.toMatrix' (associated (R₁ := R₁) Q)
+def QuadraticForm.toMatrix' (Q : QuadraticForm R (n → R)) : Matrix n n R :=
+  BilinForm.toMatrix' (associated (R := R) Q)
 #align quadratic_form.to_matrix' QuadraticForm.toMatrix'
 
 open QuadraticForm
 
-theorem QuadraticForm.toMatrix'_smul (a : R₁) (Q : QuadraticForm R₁ (n → R₁)) :
+theorem QuadraticForm.toMatrix'_smul (a : R) (Q : QuadraticForm R (n → R)) :
     (a • Q).toMatrix' = a • Q.toMatrix' := by
   simp only [toMatrix', LinearEquiv.map_smul, LinearMap.map_smul]
 #align quadratic_form.to_matrix'_smul QuadraticForm.toMatrix'_smul
 
-theorem QuadraticForm.isSymm_toMatrix' (Q : QuadraticForm R₁ (n → R₁)) : Q.toMatrix'.IsSymm := by
+theorem QuadraticForm.isSymm_toMatrix' (Q : QuadraticForm R (n → R)) : Q.toMatrix'.IsSymm := by
   ext i j
   rw [toMatrix', Matrix.transpose_apply, BilinForm.toMatrix'_apply, BilinForm.toMatrix'_apply,
     associated_isSymm]
@@ -1056,14 +1057,14 @@ namespace QuadraticForm
 
 variable {n : Type w} [Fintype n]
 
-variable [CommRing R₁] [DecidableEq n] [Invertible (2 : R₁)]
+variable [CommRing R] [DecidableEq n] [Invertible (2 : R)]
 
 variable {m : Type w} [DecidableEq m] [Fintype m]
 
 open Matrix
 
 @[simp]
-theorem toMatrix'_comp (Q : QuadraticForm R₁ (m → R₁)) (f : (n → R₁) →ₗ[R₁] m → R₁) :
+theorem toMatrix'_comp (Q : QuadraticForm R (m → R)) (f : (n → R) →ₗ[R] m → R) :
     (Q.comp f).toMatrix' = (LinearMap.toMatrix' f)ᵀ * Q.toMatrix' * (LinearMap.toMatrix' f) := by
   ext
   simp only [QuadraticForm.associated_comp, BilinForm.toMatrix'_comp, toMatrix']
@@ -1071,18 +1072,18 @@ theorem toMatrix'_comp (Q : QuadraticForm R₁ (m → R₁)) (f : (n → R₁) �
 
 section Discriminant
 
-variable {Q : QuadraticForm R₁ (n → R₁)}
+variable {Q : QuadraticForm R (n → R)}
 
 /-- The discriminant of a quadratic form generalizes the discriminant of a quadratic polynomial. -/
-def discr (Q : QuadraticForm R₁ (n → R₁)) : R₁ :=
+def discr (Q : QuadraticForm R (n → R)) : R :=
   Q.toMatrix'.det
 #align quadratic_form.discr QuadraticForm.discr
 
-theorem discr_smul (a : R₁) : (a • Q).discr = a ^ Fintype.card n * Q.discr := by
+theorem discr_smul (a : R) : (a • Q).discr = a ^ Fintype.card n * Q.discr := by
   simp only [discr, toMatrix'_smul, Matrix.det_smul]
 #align quadratic_form.discr_smul QuadraticForm.discr_smul
 
-theorem discr_comp (f : (n → R₁) →ₗ[R₁] n → R₁) :
+theorem discr_comp (f : (n → R) →ₗ[R] n → R) :
     (Q.comp f).discr = f.toMatrix'.det * f.toMatrix'.det * Q.discr := by
   simp only [Matrix.det_transpose, mul_left_comm, QuadraticForm.toMatrix'_comp, mul_comm,
     Matrix.det_mul, discr]
@@ -1100,7 +1101,7 @@ namespace BilinForm
 
 section Semiring
 
-variable [Semiring R] [AddCommMonoid M] [Module R M]
+variable [CommSemiring R] [AddCommMonoid M] [Module R M]
 
 /-- A bilinear form is nondegenerate if the quadratic form it is associated with is anisotropic. -/
 theorem nondegenerate_of_anisotropic {B : BilinForm R M} (hB : B.toQuadraticForm.Anisotropic) :
@@ -1109,7 +1110,7 @@ theorem nondegenerate_of_anisotropic {B : BilinForm R M} (hB : B.toQuadraticForm
 
 end Semiring
 
-variable [Ring R] [AddCommGroup M] [Module R M]
+variable [CommRing R] [AddCommGroup M] [Module R M]
 
 /-- There exists a non-null vector with respect to any symmetric, nonzero bilinear form `B`
 on a module `M` over a ring `R` with invertible `2`, i.e. there exists some
@@ -1180,9 +1181,7 @@ namespace QuadraticForm
 
 open Finset BilinForm
 
-variable {M₁ : Type*} [Semiring R] [CommSemiring R₁] [AddCommMonoid M] [AddCommMonoid M₁]
-
-variable [Module R M] [Module R M₁]
+variable [CommSemiring R] [AddCommMonoid M] [Module R M]
 
 variable {ι : Type*} [Fintype ι] {v : Basis ι R M}
 
@@ -1200,38 +1199,38 @@ theorem basisRepr_apply (Q : QuadraticForm R M) (w : ι → R) :
 
 section
 
-variable (R₁)
+variable (R)
 
 /-- The weighted sum of squares with respect to some weight as a quadratic form.
 
-The weights are applied using `•`; typically this definition is used either with `S = R₁` or
-`[Algebra S R₁]`, although this is stated more generally. -/
-def weightedSumSquares [Monoid S] [DistribMulAction S R₁] [SMulCommClass S R₁ R₁] (w : ι → S) :
-    QuadraticForm R₁ (ι → R₁) :=
+The weights are applied using `•`; typically this definition is used either with `S = R` or
+`[Algebra S R]`, although this is stated more generally. -/
+def weightedSumSquares [Monoid S] [DistribMulAction S R] [SMulCommClass S R R] (w : ι → S) :
+    QuadraticForm R (ι → R) :=
   ∑ i : ι, w i • proj i i
 #align quadratic_form.weighted_sum_squares QuadraticForm.weightedSumSquares
 
 end
 
 @[simp]
-theorem weightedSumSquares_apply [Monoid S] [DistribMulAction S R₁] [SMulCommClass S R₁ R₁]
-    (w : ι → S) (v : ι → R₁) : weightedSumSquares R₁ w v = ∑ i : ι, w i • (v i * v i) :=
+theorem weightedSumSquares_apply [Monoid S] [DistribMulAction S R] [SMulCommClass S R R]
+    (w : ι → S) (v : ι → R) : weightedSumSquares R w v = ∑ i : ι, w i • (v i * v i) :=
   QuadraticForm.sum_apply _ _ _
 #align quadratic_form.weighted_sum_squares_apply QuadraticForm.weightedSumSquares_apply
 
 /-- On an orthogonal basis, the basis representation of `Q` is just a sum of squares. -/
-theorem basisRepr_eq_of_iIsOrtho {R₁ M} [CommRing R₁] [AddCommGroup M] [Module R₁ M]
-    [Invertible (2 : R₁)] (Q : QuadraticForm R₁ M) (v : Basis ι R₁ M)
-    (hv₂ : (associated (R₁ := R₁) Q).iIsOrtho v) :
+theorem basisRepr_eq_of_iIsOrtho {R M} [CommRing R] [AddCommGroup M] [Module R M]
+    [Invertible (2 : R)] (Q : QuadraticForm R M) (v : Basis ι R M)
+    (hv₂ : (associated (R := R) Q).iIsOrtho v) :
     Q.basisRepr v = weightedSumSquares _ fun i => Q (v i) := by
   ext w
-  rw [basisRepr_apply, ← @associated_eq_self_apply R₁, sum_left, weightedSumSquares_apply]
+  rw [basisRepr_apply, ← @associated_eq_self_apply R, sum_left, weightedSumSquares_apply]
   refine' sum_congr rfl fun j hj => _
-  rw [← @associated_eq_self_apply R₁, sum_right, sum_eq_single_of_mem j hj]
+  rw [← @associated_eq_self_apply R, sum_right, sum_eq_single_of_mem j hj]
   · rw [smul_left, smul_right, smul_eq_mul]
     ring
   · intro i _ hij
-    rw [smul_left, smul_right, show associatedHom R₁ Q (v j) (v i) = 0 from hv₂ hij.symm,
+    rw [smul_left, smul_right, show associatedHom R Q (v j) (v i) = 0 from hv₂ hij.symm,
       mul_zero, mul_zero]
 set_option linter.uppercaseLean3 false in
 #align quadratic_form.basis_repr_eq_of_is_Ortho QuadraticForm.basisRepr_eq_of_iIsOrtho

--- a/Mathlib/LinearAlgebra/QuadraticForm/Complex.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/Complex.lean
@@ -72,7 +72,7 @@ noncomputable def isometryEquivSumSquaresUnits [DecidableEq ι] (w : ι → Unit
 /-- A nondegenerate quadratic form on the complex numbers is equivalent to
 the sum of squares, i.e. `weightedSumSquares` with weight `fun (i : ι) => 1`. -/
 theorem equivalent_sum_squares {M : Type*} [AddCommGroup M] [Module ℂ M] [FiniteDimensional ℂ M]
-    (Q : QuadraticForm ℂ M) (hQ : (associated (R₁ := ℂ) Q).Nondegenerate) :
+    (Q : QuadraticForm ℂ M) (hQ : (associated (R := ℂ) Q).Nondegenerate) :
     Equivalent Q (weightedSumSquares ℂ (1 : Fin (FiniteDimensional.finrank ℂ M) → ℂ)) :=
   let ⟨w, ⟨hw₁⟩⟩ := Q.equivalent_weightedSumSquares_units_of_nondegenerate' hQ
   ⟨hw₁.trans (isometryEquivSumSquaresUnits w)⟩
@@ -80,8 +80,8 @@ theorem equivalent_sum_squares {M : Type*} [AddCommGroup M] [Module ℂ M] [Fini
 
 /-- All nondegenerate quadratic forms on the complex numbers are equivalent. -/
 theorem complex_equivalent {M : Type*} [AddCommGroup M] [Module ℂ M] [FiniteDimensional ℂ M]
-    (Q₁ Q₂ : QuadraticForm ℂ M) (hQ₁ : (associated (R₁ := ℂ) Q₁).Nondegenerate)
-    (hQ₂ : (associated (R₁ := ℂ) Q₂).Nondegenerate) : Equivalent Q₁ Q₂ :=
+    (Q₁ Q₂ : QuadraticForm ℂ M) (hQ₁ : (associated (R := ℂ) Q₁).Nondegenerate)
+    (hQ₂ : (associated (R := ℂ) Q₂).Nondegenerate) : Equivalent Q₁ Q₂ :=
   (Q₁.equivalent_sum_squares hQ₁).trans (Q₂.equivalent_sum_squares hQ₂).symm
 #align quadratic_form.complex_equivalent QuadraticForm.complex_equivalent
 

--- a/Mathlib/LinearAlgebra/QuadraticForm/Isometry.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/Isometry.lean
@@ -21,7 +21,7 @@ variable {ι R M M₁ M₂ M₃ M₄ : Type*}
 
 namespace QuadraticForm
 
-variable [Semiring R]
+variable [CommSemiring R]
 variable [AddCommMonoid M]
 variable [AddCommMonoid M₁] [AddCommMonoid M₂] [AddCommMonoid M₃] [AddCommMonoid M₄]
 variable [Module R M] [Module R M₁] [Module R M₂] [Module R M₃] [Module R M₄]

--- a/Mathlib/LinearAlgebra/QuadraticForm/IsometryEquiv.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/IsometryEquiv.lean
@@ -27,7 +27,7 @@ variable {ι R K M M₁ M₂ M₃ V : Type*}
 
 namespace QuadraticForm
 
-variable [Semiring R]
+variable [CommSemiring R]
 
 variable [AddCommMonoid M] [AddCommMonoid M₁] [AddCommMonoid M₂] [AddCommMonoid M₃]
 
@@ -151,7 +151,7 @@ variable [Field K] [Invertible (2 : K)] [AddCommGroup V] [Module K V]
 squares. -/
 noncomputable def isometryEquivWeightedSumSquares (Q : QuadraticForm K V)
     (v : Basis (Fin (FiniteDimensional.finrank K V)) K V)
-    (hv₁ : (associated (R₁ := K) Q).iIsOrtho v) :
+    (hv₁ : (associated (R := K) Q).iIsOrtho v) :
     Q.IsometryEquiv (weightedSumSquares K fun i => Q (v i)) := by
   let iso := Q.isometryEquivBasisRepr v
   refine' ⟨iso, fun m => _⟩
@@ -170,7 +170,7 @@ theorem equivalent_weightedSumSquares (Q : QuadraticForm K V) :
 #align quadratic_form.equivalent_weighted_sum_squares QuadraticForm.equivalent_weightedSumSquares
 
 theorem equivalent_weightedSumSquares_units_of_nondegenerate' (Q : QuadraticForm K V)
-    (hQ : (associated (R₁ := K) Q).Nondegenerate) :
+    (hQ : (associated (R := K) Q).Nondegenerate) :
     ∃ w : Fin (FiniteDimensional.finrank K V) → Kˣ, Equivalent Q (weightedSumSquares K w) := by
   obtain ⟨v, hv₁⟩ := exists_orthogonal_basis (associated_isSymm K Q)
   have hv₂ := hv₁.not_isOrtho_basis_self_of_nondegenerate hQ

--- a/Mathlib/LinearAlgebra/QuadraticForm/Prod.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/Prod.lean
@@ -36,7 +36,7 @@ universe u v w
 
 variable {ι : Type*} {R : Type*} {M₁ M₂ N₁ N₂ : Type*} {Mᵢ Nᵢ : ι → Type*}
 
-variable [Semiring R]
+variable [CommSemiring R]
 
 variable [AddCommMonoid M₁] [AddCommMonoid M₂] [AddCommMonoid N₁] [AddCommMonoid N₂]
 
@@ -90,7 +90,7 @@ def IsometryEquiv.prodProdProdComm
   map_app' _ := add_add_add_comm _ _ _ _
 
 /-- If a product is anisotropic then its components must be. The converse is not true. -/
-theorem anisotropic_of_prod {R} [OrderedRing R] [Module R M₁] [Module R M₂]
+theorem anisotropic_of_prod {R} [OrderedCommRing R] [Module R M₁] [Module R M₂]
     {Q₁ : QuadraticForm R M₁} {Q₂ : QuadraticForm R M₂} (h : (Q₁.prod Q₂).Anisotropic) :
     Q₁.Anisotropic ∧ Q₂.Anisotropic := by
   simp_rw [Anisotropic, prod_apply, Prod.forall, Prod.mk_eq_zero] at h
@@ -103,8 +103,9 @@ theorem anisotropic_of_prod {R} [OrderedRing R] [Module R M₁] [Module R M₂]
     rw [hx, add_zero, map_zero]
 #align quadratic_form.anisotropic_of_prod QuadraticForm.anisotropic_of_prod
 
-theorem nonneg_prod_iff {R} [OrderedRing R] [Module R M₁] [Module R M₂] {Q₁ : QuadraticForm R M₁}
-    {Q₂ : QuadraticForm R M₂} : (∀ x, 0 ≤ (Q₁.prod Q₂) x) ↔ (∀ x, 0 ≤ Q₁ x) ∧ ∀ x, 0 ≤ Q₂ x := by
+theorem nonneg_prod_iff {R} [OrderedCommRing R] [Module R M₁] [Module R M₂]
+    {Q₁ : QuadraticForm R M₁} {Q₂ : QuadraticForm R M₂} :
+    (∀ x, 0 ≤ (Q₁.prod Q₂) x) ↔ (∀ x, 0 ≤ Q₁ x) ∧ ∀ x, 0 ≤ Q₂ x := by
   simp_rw [Prod.forall, prod_apply]
   constructor
   · intro h
@@ -115,8 +116,9 @@ theorem nonneg_prod_iff {R} [OrderedRing R] [Module R M₁] [Module R M₂] {Q�
     exact add_nonneg (h₁ x₁) (h₂ x₂)
 #align quadratic_form.nonneg_prod_iff QuadraticForm.nonneg_prod_iff
 
-theorem posDef_prod_iff {R} [OrderedRing R] [Module R M₁] [Module R M₂] {Q₁ : QuadraticForm R M₁}
-    {Q₂ : QuadraticForm R M₂} : (Q₁.prod Q₂).PosDef ↔ Q₁.PosDef ∧ Q₂.PosDef := by
+theorem posDef_prod_iff {R} [OrderedCommRing R] [Module R M₁] [Module R M₂]
+    {Q₁ : QuadraticForm R M₁} {Q₂ : QuadraticForm R M₂} :
+    (Q₁.prod Q₂).PosDef ↔ Q₁.PosDef ∧ Q₂.PosDef := by
   simp_rw [posDef_iff_nonneg, nonneg_prod_iff]
   constructor
   · rintro ⟨⟨hle₁, hle₂⟩, ha⟩
@@ -129,8 +131,9 @@ theorem posDef_prod_iff {R} [OrderedRing R] [Module R M₁] [Module R M₂] {Q�
     rwa [Prod.mk_eq_zero]
 #align quadratic_form.pos_def_prod_iff QuadraticForm.posDef_prod_iff
 
-theorem PosDef.prod {R} [OrderedRing R] [Module R M₁] [Module R M₂] {Q₁ : QuadraticForm R M₁}
-    {Q₂ : QuadraticForm R M₂} (h₁ : Q₁.PosDef) (h₂ : Q₂.PosDef) : (Q₁.prod Q₂).PosDef :=
+theorem PosDef.prod {R} [OrderedCommRing R] [Module R M₁] [Module R M₂]
+    {Q₁ : QuadraticForm R M₁} {Q₂ : QuadraticForm R M₂} (h₁ : Q₁.PosDef) (h₂ : Q₂.PosDef) :
+    (Q₁.prod Q₂).PosDef :=
   posDef_prod_iff.mpr ⟨h₁, h₂⟩
 #align quadratic_form.pos_def.prod QuadraticForm.PosDef.prod
 
@@ -166,7 +169,7 @@ theorem Equivalent.pi [Fintype ι] {Q : ∀ i, QuadraticForm R (Mᵢ i)}
 #align quadratic_form.equivalent.pi QuadraticForm.Equivalent.pi
 
 /-- If a family is anisotropic then its components must be. The converse is not true. -/
-theorem anisotropic_of_pi [Fintype ι] {R} [OrderedRing R] [∀ i, Module R (Mᵢ i)]
+theorem anisotropic_of_pi [Fintype ι] {R} [OrderedCommRing R] [∀ i, Module R (Mᵢ i)]
     {Q : ∀ i, QuadraticForm R (Mᵢ i)} (h : (pi Q).Anisotropic) : ∀ i, (Q i).Anisotropic := by
   simp_rw [Anisotropic, pi_apply, Function.funext_iff, Pi.zero_apply] at h
   intro i x hx
@@ -181,7 +184,7 @@ theorem anisotropic_of_pi [Fintype ι] {R} [OrderedRing R] [∀ i, Module R (M�
   · rw [Pi.single_eq_of_ne hji, map_zero]
 #align quadratic_form.anisotropic_of_pi QuadraticForm.anisotropic_of_pi
 
-theorem nonneg_pi_iff [Fintype ι] {R} [OrderedRing R] [∀ i, Module R (Mᵢ i)]
+theorem nonneg_pi_iff [Fintype ι] {R} [OrderedCommRing R] [∀ i, Module R (Mᵢ i)]
     {Q : ∀ i, QuadraticForm R (Mᵢ i)} : (∀ x, 0 ≤ pi Q x) ↔ ∀ i x, 0 ≤ Q i x := by
   simp_rw [pi, sum_apply, comp_apply, LinearMap.proj_apply]
   constructor
@@ -195,7 +198,7 @@ theorem nonneg_pi_iff [Fintype ι] {R} [OrderedRing R] [∀ i, Module R (Mᵢ i)
     exact Finset.sum_nonneg fun i _ => h i (x i)
 #align quadratic_form.nonneg_pi_iff QuadraticForm.nonneg_pi_iff
 
-theorem posDef_pi_iff [Fintype ι] {R} [OrderedRing R] [∀ i, Module R (Mᵢ i)]
+theorem posDef_pi_iff [Fintype ι] {R} [OrderedCommRing R] [∀ i, Module R (Mᵢ i)]
     {Q : ∀ i, QuadraticForm R (Mᵢ i)} : (pi Q).PosDef ↔ ∀ i, (Q i).PosDef := by
   simp_rw [posDef_iff_nonneg, nonneg_pi_iff]
   constructor

--- a/Mathlib/LinearAlgebra/QuadraticForm/Real.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/Real.lean
@@ -78,7 +78,7 @@ noncomputable def isometryEquivSignWeightedSumSquares [DecidableEq ι] (w : ι �
 /-- **Sylvester's law of inertia**: A nondegenerate real quadratic form is equivalent to a weighted
 sum of squares with the weights being ±1. -/
 theorem equivalent_one_neg_one_weighted_sum_squared {M : Type*} [AddCommGroup M] [Module ℝ M]
-    [FiniteDimensional ℝ M] (Q : QuadraticForm ℝ M) (hQ : (associated (R₁ := ℝ) Q).Nondegenerate) :
+    [FiniteDimensional ℝ M] (Q : QuadraticForm ℝ M) (hQ : (associated (R := ℝ) Q).Nondegenerate) :
     ∃ w : Fin (FiniteDimensional.finrank ℝ M) → ℝ,
       (∀ i, w i = -1 ∨ w i = 1) ∧ Equivalent Q (weightedSumSquares ℝ w) :=
   let ⟨w, ⟨hw₁⟩⟩ := Q.equivalent_weightedSumSquares_units_of_nondegenerate' hQ

--- a/Mathlib/LinearAlgebra/QuadraticForm/TensorProduct.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/TensorProduct.lean
@@ -66,8 +66,8 @@ protected noncomputable abbrev tmul (Q₁ : QuadraticForm A M₁) (Q₂ : Quadra
   tensorDistrib R A (Q₁ ⊗ₜ[R] Q₂)
 
 theorem associated_tmul [Invertible (2 : A)] (Q₁ : QuadraticForm A M₁) (Q₂ : QuadraticForm R M₂) :
-    associated (R₁ := A) (Q₁.tmul Q₂)
-      = (associated (R₁ := A) Q₁).tmul (associated (R₁ := R) Q₂) := by
+    associated (R := A) (Q₁.tmul Q₂)
+      = (associated (R := A) Q₁).tmul (associated (R := R) Q₂) := by
   rw [QuadraticForm.tmul, tensorDistrib, BilinForm.tmul]
   dsimp
   convert associated_left_inverse A ((associated_isSymm A Q₁).tmul (associated_isSymm R Q₂))
@@ -91,7 +91,7 @@ theorem baseChange_tmul (Q : QuadraticForm R M₂) (a : A) (m₂ : M₂) :
   tensorDistrib_tmul _ _ _ _
 
 theorem associated_baseChange [Invertible (2 : A)] (Q : QuadraticForm R M₂)  :
-    associated (R₁ := A) (Q.baseChange A) = (associated (R₁ := R) Q).baseChange A := by
+    associated (R := A) (Q.baseChange A) = (associated (R := R) Q).baseChange A := by
   dsimp only [QuadraticForm.baseChange, BilinForm.baseChange]
   rw [associated_tmul (QuadraticForm.sq (R := A)) Q, associated_sq]
 


### PR DESCRIPTION
As discussed [on Zulip](https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/Quadratic.20Maps/near/395529867), this generalization seems nonsensical as currently implemented.


There are sensible ways to make this generalization, but they are much larger refactors, and in the meantime the current generalization is useless anyway.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
