### PR TITLE
perf: try to speed up ideal quotient =?= submodule quotient

### DIFF
--- a/Mathlib/RingTheory/Ideal/Quotient.lean
+++ b/Mathlib/RingTheory/Ideal/Quotient.lean
@@ -70,7 +70,11 @@ protected def ringCon (I : Ideal R) : RingCon R :=
 #align ideal.quotient.ring_con Ideal.Quotient.ringCon
 
 instance commRing (I : Ideal R) : CommRing (R ⧸ I) :=
-    inferInstanceAs (CommRing (Quotient.ringCon I).Quotient)
+  { inferInstanceAs (CommRing (Quotient.ringCon I).Quotient) with
+    -- Help unification with the submonoid instances by ensuring the right unfolding happens.
+    toRing.toSemiring.toAddCommMonoid := (Submodule.Quotient.addCommGroup _).toAddCommMonoid
+    toRing.toNeg := (Submodule.Quotient.addCommGroup _).toNeg
+    toRing.toSub := (Submodule.Quotient.addCommGroup _).toSub }
 #align ideal.quotient.comm_ring Ideal.Quotient.commRing
 
 -- Sanity test to make sure no diamonds have emerged in `commRing`

--- a/Mathlib/RingTheory/Ideal/Quotient.lean
+++ b/Mathlib/RingTheory/Ideal/Quotient.lean
@@ -71,7 +71,7 @@ protected def ringCon (I : Ideal R) : RingCon R :=
 
 instance commRing (I : Ideal R) : CommRing (R ⧸ I) :=
   { inferInstanceAs (CommRing (Quotient.ringCon I).Quotient) with
-    -- Help unification with the submonoid instances by ensuring the right unfolding happens.
+    -- Help unification with the submodule instances by ensuring the right unfolding happens.
     toRing.toSemiring.toAddCommMonoid := (Submodule.Quotient.addCommGroup _).toAddCommMonoid
     toRing.toNeg := (Submodule.Quotient.addCommGroup _).toNeg
     toRing.toSub := (Submodule.Quotient.addCommGroup _).toSub }


### PR DESCRIPTION
The idea behind this change is that `Ideal.Quotient` is defined in terms of `Submodule.Quotient`, but Lean spends a lot of time inferring whether the `CommRing` structure on the ideal quotient indeed gives the `AddCommGroup` structure of the submodule quotient.

The change to the field structure on `DirectLimit` caused the elaboration time on my machine to go from 30 seconds (before this PR) or 2-3 minutes (after the initial commit) to 2 seconds.

Zulip thread: https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/.237584.20speed.20up.20.60Ideal.2EQuotient.2EcommRing.60.20instance

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
