### PR TITLE
[Merged by Bors] - chore: use `zeta = false` in `push_neg`

### DIFF
--- a/Mathlib/Tactic/PushNeg.lean
+++ b/Mathlib/Tactic/PushNeg.lean
@@ -108,7 +108,7 @@ partial def transformNegation (e : Expr) : SimpM Simp.Step := do
 /-- Common entry point to `push_neg` as a conv. -/
 def pushNegCore (tgt : Expr) : MetaM Simp.Result := do
   let myctx : Simp.Context :=
-    { config := { eta := true },
+    { config := { eta := true, zeta := false },
       simpTheorems := #[ ]
       congrTheorems := (← getSimpCongrTheorems) }
   (·.1) <$> Simp.main tgt myctx (methods := { pre := transformNegation })

--- a/test/push_neg.lean
+++ b/test/push_neg.lean
@@ -124,7 +124,7 @@ example (r : LinearOrder α) (s : Preorder α) (a b : α) : ¬(r.lt a b → s.lt
   guard_target = r.lt a b ∧ ¬ s.lt a b
   exact test_sorry
 
--- make sure that `push_neg` does not expand `let` definitions
+-- check that `push_neg` does not expand `let` definitions
 example (h : p ∧ q) : ¬¬(p ∧ q) := by
   let r := p ∧ q
   change ¬¬r

--- a/test/push_neg.lean
+++ b/test/push_neg.lean
@@ -124,6 +124,14 @@ example (r : LinearOrder α) (s : Preorder α) (a b : α) : ¬(r.lt a b → s.lt
   guard_target = r.lt a b ∧ ¬ s.lt a b
   exact test_sorry
 
+-- make sure that `push_neg` does not expand `let` definitions
+example (h : p ∧ q) : ¬¬(p ∧ q) := by
+  let r := p ∧ q
+  change ¬¬r
+  push_neg
+  guard_target =ₛ r
+  exact h
+
 section use_distrib
 set_option push_neg.use_distrib true
 


### PR DESCRIPTION
There is no reason to expand local definitions while pushing negations inside a formula.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
