### PR TITLE
[Merged by Bors] - feat(Data/Num): use bitwise notation

### DIFF
--- a/Mathlib/Data/Num/Bitwise.lean
+++ b/Mathlib/Data/Num/Bitwise.lean
@@ -34,6 +34,10 @@ def lor : PosNum → PosNum → PosNum
   | bit1 p, bit1 q => bit1 (lor p q)
 #align pos_num.lor PosNum.lor
 
+instance : OrOp PosNum where or := PosNum.lor
+
+@[simp] lemma lor_eq_or (p q : PosNum) : p.lor q = p ||| q := rfl
+
 /-- Bitwise "and" for `PosNum`. -/
 def land : PosNum → PosNum → Num
   | 1, bit0 _ => 0
@@ -45,6 +49,10 @@ def land : PosNum → PosNum → Num
   | bit1 p, bit0 q => Num.bit0 (land p q)
   | bit1 p, bit1 q => Num.bit1 (land p q)
 #align pos_num.land PosNum.land
+
+instance : HAnd PosNum PosNum Num where hAnd := PosNum.land
+
+@[simp] lemma land_eq_and (p q : PosNum) : p.land q = p &&& q := rfl
 
 /-- Bitwise `fun a b ↦ a && !b` for `PosNum`. For example, `ldiff 5 9 = 4`:
 ```
@@ -78,6 +86,10 @@ def lxor : PosNum → PosNum → Num
   | bit1 p, bit1 q => Num.bit0 (lxor p q)
 #align pos_num.lxor PosNum.lxor
 
+instance : HXor PosNum PosNum Num where hXor := PosNum.lxor
+
+@[simp] lemma lxor_eq_xor (p q : PosNum) : p.lxor q = p ^^^ q := rfl
+
 /-- `a.testBit n` is `true` iff the `n`-th bit (starting from the LSB) in the binary representation
       of `a` is active. If the size of `a` is less than `n`, this evaluates to `false`. -/
 def testBit : PosNum → Nat → Bool
@@ -102,9 +114,14 @@ def shiftl : PosNum → Nat → PosNum
   | p, n + 1 => shiftl p.bit0 n
 #align pos_num.shiftl PosNum.shiftl
 
+instance : HShiftLeft PosNum Nat PosNum where hShiftLeft := PosNum.shiftl
+
+@[simp] lemma shiftl_eq_shiftLeft (p : PosNum) (n : Nat) : p.shiftl n = p <<< n := rfl
+
+
 -- Porting note: `PosNum.shiftl` is defined as tail-recursive in Lean4.
 --               This theorem ensures the definition is same to one in Lean3.
-theorem shiftl_succ_eq_bit0_shiftl : ∀ (p : PosNum) (n : Nat), shiftl p n.succ = bit0 (shiftl p n)
+theorem shiftl_succ_eq_bit0_shiftl : ∀ (p : PosNum) (n : Nat), p <<< n.succ = bit0 (p <<< n)
   | _, 0       => rfl
   | p, .succ n => shiftl_succ_eq_bit0_shiftl p.bit0 n
 
@@ -116,23 +133,35 @@ def shiftr : PosNum → Nat → Num
   | bit1 p, n + 1 => shiftr p n
 #align pos_num.shiftr PosNum.shiftr
 
+instance : HShiftRight PosNum Nat Num where hShiftRight := PosNum.shiftr
+
+@[simp] lemma shiftr_eq_shiftRight (p : PosNum) (n : Nat) : p.shiftr n = p >>> n := rfl
+
 end PosNum
 
 namespace Num
 
 /-- Bitwise "or" for `Num`. -/
-def lor : Num → Num → Num
+protected def lor : Num → Num → Num
   | 0, q => q
   | p, 0 => p
-  | pos p, pos q => pos (p.lor q)
-#align num.lor Num.lor
+  | pos p, pos q => pos (p ||| q)
+#align num.lor OrOp.or
+
+instance : OrOp Num where or := Num.lor
+
+@[simp] lemma lor_eq_or (p q : Num) : p.lor q = p ||| q := rfl
 
 /-- Bitwise "and" for `Num`. -/
 def land : Num → Num → Num
   | 0, _ => 0
   | _, 0 => 0
-  | pos p, pos q => p.land q
+  | pos p, pos q => p &&& q
 #align num.land Num.land
+
+instance : AndOp Num where and := Num.land
+
+@[simp] lemma land_eq_and (p q : Num) : p.land q = p &&& q := rfl
 
 /-- Bitwise `fun a b ↦ a && !b` for `Num`. For example, `ldiff 5 9 = 4`:
 ```
@@ -152,20 +181,32 @@ def ldiff : Num → Num → Num
 def lxor : Num → Num → Num
   | 0, q => q
   | p, 0 => p
-  | pos p, pos q => p.lxor q
+  | pos p, pos q => p ^^^ q
 #align num.lxor Num.lxor
+
+instance : Xor Num where xor := Num.lxor
+
+@[simp] lemma lxor_eq_xor (p q : Num) : p.lxor q = p ^^^ q := rfl
 
 /-- Left-shift the binary representation of a `Num`. -/
 def shiftl : Num → Nat → Num
   | 0, _ => 0
-  | pos p, n => pos (p.shiftl n)
+  | pos p, n => pos (p <<< n)
 #align num.shiftl Num.shiftl
+
+instance : HShiftLeft Num Nat Num where hShiftLeft := Num.shiftl
+
+@[simp] lemma shiftl_eq_shiftLeft (p : Num) (n : Nat) : p.shiftl n = p <<< n := rfl
 
 /-- Right-shift the binary representation of a `Num`. -/
 def shiftr : Num → Nat → Num
   | 0, _ => 0
-  | pos p, n => p.shiftr n
+  | pos p, n => p >>> n
 #align num.shiftr Num.shiftr
+
+instance : HShiftRight Num Nat Num where hShiftRight := Num.shiftr
+
+@[simp] lemma shiftr_eq_shiftRight (p : Num) (n : Nat) : p.shiftr n = p >>> n := rfl
 
 /-- `a.testBit n` is `true` iff the `n`-th bit (starting from the LSB) in the binary representation
       of `a` is active. If the size of `a` is less than `n`, this evaluates to `false`. -/

--- a/Mathlib/Data/Num/Lemmas.lean
+++ b/Mathlib/Data/Num/Lemmas.lean
@@ -930,7 +930,7 @@ theorem bitwise'_to_nat {f : Num → Num → Num} {g : Bool → Bool → Bool} (
 #align num.bitwise_to_nat Num.bitwise'_to_nat
 
 @[simp, norm_cast]
-theorem lor'_to_nat : ∀ m n, (lor m n : ℕ) = Nat.lor' m n := by
+theorem lor'_to_nat : ∀ m n : Num, ↑(m ||| n) = Nat.lor' m n := by
   -- Porting note: A name of an implicit local hypothesis is not available so
   --               `cases_type*` is used.
   apply bitwise'_to_nat fun x y => pos (PosNum.lor x y) <;>
@@ -938,41 +938,42 @@ theorem lor'_to_nat : ∀ m n, (lor m n : ℕ) = Nat.lor' m n := by
 #align num.lor_to_nat Num.lor'_to_nat
 
 @[simp, norm_cast]
-theorem land'_to_nat : ∀ m n, (land m n : ℕ) = Nat.land' m n := by
+theorem land'_to_nat : ∀ m n : Num, ↑(m &&& n) = Nat.land' m n := by
   apply bitwise'_to_nat PosNum.land <;> intros <;> (try cases_type* Bool) <;> rfl
 #align num.land_to_nat Num.land'_to_nat
 
 @[simp, norm_cast]
-theorem ldiff'_to_nat : ∀ m n, (ldiff m n : ℕ) = Nat.ldiff' m n := by
+theorem ldiff'_to_nat : ∀ m n : Num, (ldiff m n : ℕ) = Nat.ldiff' m n := by
   apply bitwise'_to_nat PosNum.ldiff <;> intros <;> (try cases_type* Bool) <;> rfl
 #align num.ldiff_to_nat Num.ldiff'_to_nat
 
 @[simp, norm_cast]
-theorem lxor'_to_nat : ∀ m n, (lxor m n : ℕ) = Nat.lxor' m n := by
+theorem lxor'_to_nat : ∀ m n : Num, ↑(m ^^^ n) = Nat.lxor' m n := by
   apply bitwise'_to_nat PosNum.lxor <;> intros <;> (try cases_type* Bool) <;> rfl
 #align num.lxor_to_nat Num.lxor'_to_nat
 
 @[simp, norm_cast]
-theorem shiftl_to_nat (m n) : (shiftl m n : ℕ) = (m : ℕ) <<< (n : ℕ) := by
-  cases m <;> dsimp only [shiftl]
+theorem shiftl_to_nat (m : Num) (n : Nat) : ↑(m <<< n) = (m : ℕ) <<< (n : ℕ) := by
+  cases m <;> dsimp only [←shiftl_eq_shiftLeft, shiftl]
   · symm
     apply Nat.zero_shiftLeft
   simp only [cast_pos]
   induction' n with n IH
   · rfl
   simp [PosNum.shiftl_succ_eq_bit0_shiftl, Nat.shiftLeft_succ, IH,
-        Nat.bit0_val, pow_succ, ← mul_assoc, mul_comm]
+        Nat.bit0_val, pow_succ, ← mul_assoc, mul_comm,
+        -shiftl_eq_shiftLeft, -PosNum.shiftl_eq_shiftLeft, shiftl]
 #align num.shiftl_to_nat Num.shiftl_to_nat
 
 @[simp, norm_cast]
 
-theorem shiftr_to_nat (m n) : (shiftr m n : ℕ) = (m : ℕ) >>> (n : ℕ)  := by
-  cases' m with m <;> dsimp only [shiftr];
+theorem shiftr_to_nat (m : Num) (n : Nat) : ↑(m >>> n) = (m : ℕ) >>> (n : ℕ)  := by
+  cases' m with m <;> dsimp only [←shiftr_eq_shiftRight, shiftr];
   · symm
     apply Nat.zero_shiftRight
   induction' n with n IH generalizing m
   · cases m <;> rfl
-  cases' m with m m <;> dsimp only [PosNum.shiftr]
+  cases' m with m m <;> dsimp only [PosNum.shiftr, ←PosNum.shiftr_eq_shiftRight]
   · rw [Nat.shiftRight_eq_div_pow]
     symm
     apply Nat.div_eq_of_lt


### PR DESCRIPTION
This enables the existing `|||`, `&&&`, `<<<`, `>>>`, and `^^^` notation for `Num` and `PosNum`, and makes them simp-normal form.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
