### PR TITLE
[Merged by Bors] - chore: mark Homeomorph.isCompact_{pre}image simp

### DIFF
--- a/Mathlib/Topology/Homeomorph.lean
+++ b/Mathlib/Topology/Homeomorph.lean
@@ -258,10 +258,12 @@ protected theorem secondCountableTopology [TopologicalSpace.SecondCountableTopol
   h.inducing.secondCountableTopology
 #align homeomorph.second_countable_topology Homeomorph.secondCountableTopology
 
+@[simp]
 theorem isCompact_image {s : Set α} (h : α ≃ₜ β) : IsCompact (h '' s) ↔ IsCompact s :=
   h.embedding.isCompact_iff_isCompact_image.symm
 #align homeomorph.is_compact_image Homeomorph.isCompact_image
 
+@[simp]
 theorem isCompact_preimage {s : Set β} (h : α ≃ₜ β) : IsCompact (h ⁻¹' s) ↔ IsCompact s := by
   rw [← image_symm]; exact h.symm.isCompact_image
 #align homeomorph.is_compact_preimage Homeomorph.isCompact_preimage


### PR DESCRIPTION
The analogous lemmas for open, closed, preconnected, connected sets are all tagged simp.

------
@eric-wieser suggested doing so for the analogous lemma of sigma-compact sets in #7576 (which passed the simp linter).
Let's see what CI would say about these two.