### PR TITLE
[Merged by Bors] - feat: `MonoidalCategory (AlgebraCat R)`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -37,6 +37,7 @@ import Mathlib.Algebra.Bounds
 import Mathlib.Algebra.Category.AlgebraCat.Basic
 import Mathlib.Algebra.Category.AlgebraCat.Limits
 import Mathlib.Algebra.Category.AlgebraCat.Monoidal
+import Mathlib.Algebra.Category.AlgebraCat.Symmetric
 import Mathlib.Algebra.Category.BoolRing
 import Mathlib.Algebra.Category.FGModuleCat.Basic
 import Mathlib.Algebra.Category.FGModuleCat.Limits

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -36,6 +36,7 @@ import Mathlib.Algebra.BigOperators.RingEquiv
 import Mathlib.Algebra.Bounds
 import Mathlib.Algebra.Category.AlgebraCat.Basic
 import Mathlib.Algebra.Category.AlgebraCat.Limits
+import Mathlib.Algebra.Category.AlgebraCat.Monoidal
 import Mathlib.Algebra.Category.BoolRing
 import Mathlib.Algebra.Category.FGModuleCat.Basic
 import Mathlib.Algebra.Category.FGModuleCat.Limits

--- a/Mathlib/Algebra/Algebra/Basic.lean
+++ b/Mathlib/Algebra/Algebra/Basic.lean
@@ -458,7 +458,7 @@ end id
 
 section PUnit
 
-instance _root_.PUnit.algebra : Algebra R PUnit where
+instance _root_.PUnit.algebra : Algebra R PUnit.{v + 1} where
   toFun _ := PUnit.unit
   map_one' := rfl
   map_mul' _ _ := rfl

--- a/Mathlib/Algebra/Category/AlgebraCat/Basic.lean
+++ b/Mathlib/Algebra/Category/AlgebraCat/Basic.lean
@@ -84,6 +84,16 @@ instance hasForgetToModule : HasForget₂ (AlgebraCat.{v} R) (ModuleCat.{v} R) w
       map := fun f => ModuleCat.ofHom f.toLinearMap }
 #align Algebra.has_forget_to_Module AlgebraCat.hasForgetToModule
 
+@[simp]
+lemma forget₂_module_obj (X : AlgebraCat.{v} R) :
+    (forget₂ (AlgebraCat.{v} R) (ModuleCat.{v} R)).obj X = ModuleCat.of R X :=
+  rfl
+
+@[simp]
+lemma forget₂_module_map {X Y : AlgebraCat.{v} R} (f : X ⟶ Y) :
+    (forget₂ (AlgebraCat.{v} R) (ModuleCat.{v} R)).map f = ModuleCat.ofHom f.toLinearMap :=
+  rfl
+
 /-- The object in the category of R-algebras associated to a type equipped with the appropriate
 typeclasses. -/
 def of (X : Type v) [Ring X] [Algebra R X] : AlgebraCat.{v} R :=

--- a/Mathlib/Algebra/Category/AlgebraCat/Monoidal.lean
+++ b/Mathlib/Algebra/Category/AlgebraCat/Monoidal.lean
@@ -60,7 +60,7 @@ open MonoidalCategory
         (forget₂ _ (ModuleCat R) |>.obj Z)).hom := by
   rfl
 
-count_heartbeats in
+set_option maxHeartbeats 400000 in
 @[simp] theorem forget₂_map_associator_inv (X Y Z : AlgebraCat.{u} R) :
     (forget₂ (AlgebraCat R) (ModuleCat R)).map (associator X Y Z).inv
       = (α_

--- a/Mathlib/Algebra/Category/AlgebraCat/Monoidal.lean
+++ b/Mathlib/Algebra/Category/AlgebraCat/Monoidal.lean
@@ -93,7 +93,8 @@ noncomputable instance instMonoidalCategory : MonoidalCategory (AlgebraCat.{u} R
         erw [Category.id_comp, Category.comp_id, MonoidalCategory.tensor_id, Category.comp_id]
       leftUnitor := fun X => (Algebra.TensorProduct.lid R X).toAlgebraIso
       rightUnitor := fun X => (Algebra.TensorProduct.rid R R X).toAlgebraIso
-      rightUnitor_eq := sorry }
+      rightUnitor_eq := fun X => congr_arg LinearEquiv.toLinearMap <|
+        TensorProduct.AlgebraTensorModule.rid_eq_rid R X }
 
 variable (R) in
 /-- `forget₂ (AlgebraCat R) (ModuleCat R)` as a monoidal functor. -/

--- a/Mathlib/Algebra/Category/AlgebraCat/Monoidal.lean
+++ b/Mathlib/Algebra/Category/AlgebraCat/Monoidal.lean
@@ -108,6 +108,4 @@ instance : Faithful (toModuleCatMonoidalFunctor R).toFunctor :=
 
 end
 
-#print instMonoidalCategory
-
 end AlgebraCat

--- a/Mathlib/Algebra/Category/AlgebraCat/Monoidal.lean
+++ b/Mathlib/Algebra/Category/AlgebraCat/Monoidal.lean
@@ -73,7 +73,7 @@ end instMonoidalCategory
 
 open instMonoidalCategory
 
-set_option maxHeartbeats 1600000 in
+set_option maxHeartbeats 800000 in
 noncomputable instance instMonoidalCategory : MonoidalCategory (AlgebraCat.{u} R) :=
   Monoidal.induced
     (forget₂ (AlgebraCat R) (ModuleCat R))
@@ -86,15 +86,17 @@ noncomputable instance instMonoidalCategory : MonoidalCategory (AlgebraCat.{u} R
       εIsoSymm := eqToIso rfl
       associator := associator
       associator_eq := fun X Y Z => by
-        save
         dsimp only [forget₂_module_obj, forget₂_map_associator_hom]
         simp only [eqToIso_refl, Iso.refl_trans, Iso.refl_symm, Iso.trans_hom, tensorIso_hom,
           Iso.refl_hom, MonoidalCategory.tensor_id]
         erw [Category.id_comp, Category.comp_id, MonoidalCategory.tensor_id, Category.comp_id]
       leftUnitor := fun X => (Algebra.TensorProduct.lid R X).toAlgebraIso
       rightUnitor := fun X => (Algebra.TensorProduct.rid R R X).toAlgebraIso
-      rightUnitor_eq := fun X => congr_arg LinearEquiv.toLinearMap <|
-        TensorProduct.AlgebraTensorModule.rid_eq_rid R X }
+      rightUnitor_eq := fun X => by
+        dsimp
+        erw [Category.id_comp, MonoidalCategory.tensor_id, Category.id_comp]
+        exact congr_arg LinearEquiv.toLinearMap <|
+          TensorProduct.AlgebraTensorModule.rid_eq_rid R X }
 
 variable (R) in
 /-- `forget₂ (AlgebraCat R) (ModuleCat R)` as a monoidal functor. -/
@@ -105,5 +107,7 @@ instance : Faithful (toModuleCatMonoidalFunctor R).toFunctor :=
   forget₂_faithful _ _
 
 end
+
+#print instMonoidalCategory
 
 end AlgebraCat

--- a/Mathlib/Algebra/Category/AlgebraCat/Monoidal.lean
+++ b/Mathlib/Algebra/Category/AlgebraCat/Monoidal.lean
@@ -52,7 +52,7 @@ noncomputable abbrev associator (X Y Z : AlgebraCat.{u} R) :
 
 open MonoidalCategory
 
-@[simp] theorem forget₂_map_associator_hom (X Y Z : AlgebraCat.{u} R) :
+theorem forget₂_map_associator_hom (X Y Z : AlgebraCat.{u} R) :
     (forget₂ (AlgebraCat R) (ModuleCat R)).map (associator X Y Z).hom
       = (α_
         (forget₂ _ (ModuleCat R) |>.obj X)
@@ -61,7 +61,7 @@ open MonoidalCategory
   rfl
 
 set_option maxHeartbeats 400000 in
-@[simp] theorem forget₂_map_associator_inv (X Y Z : AlgebraCat.{u} R) :
+theorem forget₂_map_associator_inv (X Y Z : AlgebraCat.{u} R) :
     (forget₂ (AlgebraCat R) (ModuleCat R)).map (associator X Y Z).inv
       = (α_
         (forget₂ _ (ModuleCat R) |>.obj X)

--- a/Mathlib/Algebra/Category/AlgebraCat/Monoidal.lean
+++ b/Mathlib/Algebra/Category/AlgebraCat/Monoidal.lean
@@ -53,8 +53,8 @@ noncomputable abbrev associator (X Y Z : AlgebraCat.{u} R) :
 open MonoidalCategory
 
 theorem forget₂_map_associator_hom (X Y Z : AlgebraCat.{u} R) :
-    (forget₂ (AlgebraCat R) (ModuleCat R)).map (associator X Y Z).hom
-      = (α_
+    (forget₂ (AlgebraCat R) (ModuleCat R)).map (associator X Y Z).hom =
+      (α_
         (forget₂ _ (ModuleCat R) |>.obj X)
         (forget₂ _ (ModuleCat R) |>.obj Y)
         (forget₂ _ (ModuleCat R) |>.obj Z)).hom := by
@@ -62,8 +62,8 @@ theorem forget₂_map_associator_hom (X Y Z : AlgebraCat.{u} R) :
 
 set_option maxHeartbeats 400000 in
 theorem forget₂_map_associator_inv (X Y Z : AlgebraCat.{u} R) :
-    (forget₂ (AlgebraCat R) (ModuleCat R)).map (associator X Y Z).inv
-      = (α_
+    (forget₂ (AlgebraCat R) (ModuleCat R)).map (associator X Y Z).inv =
+      (α_
         (forget₂ _ (ModuleCat R) |>.obj X)
         (forget₂ _ (ModuleCat R) |>.obj Y)
         (forget₂ _ (ModuleCat R) |>.obj Z)).inv := by

--- a/Mathlib/Algebra/Category/AlgebraCat/Monoidal.lean
+++ b/Mathlib/Algebra/Category/AlgebraCat/Monoidal.lean
@@ -1,0 +1,115 @@
+/-
+Copyright (c) 2023 Eric Wieser. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Eric Wieser
+-/
+import Mathlib.CategoryTheory.Monoidal.Braided
+import Mathlib.CategoryTheory.Monoidal.Transport
+import Mathlib.Algebra.Category.AlgebraCat.Basic
+import Mathlib.Algebra.Category.ModuleCat.Monoidal.Basic
+import Mathlib.RingTheory.TensorProduct
+
+/-!
+# The monoidal category structure on R-algebras
+-/
+
+open CategoryTheory
+
+universe v u
+
+variable {R : Type u} [CommRing R]
+
+namespace AlgebraCat
+
+noncomputable section
+
+namespace instMonoidalCategory
+
+open scoped TensorProduct
+
+/-- Auxiliary definition used to fight a timeout when building
+`AlgebraCat.instMonoidalCategory`. -/
+@[simps!]
+noncomputable abbrev tensorObj (X Y : AlgebraCat.{u} R) : AlgebraCat.{u} R :=
+  of R (X ⊗[R] Y)
+
+/-- Auxiliary definition used to fight a timeout when building
+`AlgebraCat.instMonoidalCategory`. -/
+noncomputable abbrev tensorHom {W X Y Z : AlgebraCat.{u} R} (f : W ⟶ X) (g : Y ⟶ Z) :
+    tensorObj W Y ⟶ tensorObj X Z :=
+  Algebra.TensorProduct.map f g
+
+/-- Auxiliary definition used to fight a timeout when building
+`AlgebraCat.instMonoidalCategory`. -/
+@[simps!]
+abbrev tensorUnit : AlgebraCat.{u} R := of R R
+
+/-- Auxiliary definition used to fight a timeout when building
+`AlgebraCat.instMonoidalCategory`. -/
+noncomputable abbrev associator (X Y Z : AlgebraCat.{u} R) :
+    tensorObj (tensorObj X Y) Z ≅ tensorObj X (tensorObj Y Z) :=
+  (Algebra.TensorProduct.assoc R X Y Z).toAlgebraIso
+
+open MonoidalCategory
+
+@[simp] theorem forget₂_map_associator_hom (X Y Z : AlgebraCat.{u} R) :
+    (forget₂ (AlgebraCat R) (ModuleCat R)).map (associator X Y Z).hom
+      = (α_
+        (forget₂ _ (ModuleCat R) |>.obj X)
+        (forget₂ _ (ModuleCat R) |>.obj Y)
+        (forget₂ _ (ModuleCat R) |>.obj Z)).hom := by
+  rfl
+
+count_heartbeats in
+@[simp] theorem forget₂_map_associator_inv (X Y Z : AlgebraCat.{u} R) :
+    (forget₂ (AlgebraCat R) (ModuleCat R)).map (associator X Y Z).inv
+      = (α_
+        (forget₂ _ (ModuleCat R) |>.obj X)
+        (forget₂ _ (ModuleCat R) |>.obj Y)
+        (forget₂ _ (ModuleCat R) |>.obj Z)).inv := by
+  rfl
+
+end instMonoidalCategory
+
+open instMonoidalCategory
+
+set_option maxHeartbeats 1600000 in
+noncomputable instance instMonoidalCategory : MonoidalCategory (AlgebraCat.{u} R) :=
+  Monoidal.induced
+    (forget₂ (AlgebraCat R) (ModuleCat R))
+    { tensorObj := instMonoidalCategory.tensorObj
+      μIsoSymm := fun X Y => eqToIso rfl
+      whiskerLeft := fun X _ _ f => tensorHom (𝟙 _) f
+      whiskerRight := @fun X₁ X₂ (f : X₁ ⟶ X₂) Y => tensorHom f (𝟙 _)
+      tensorHom := tensorHom
+      tensorUnit' := tensorUnit
+      εIsoSymm := eqToIso rfl
+      associator := associator
+      associator_eq := by
+        save
+        dsimp only [forget₂_module_obj, forget₂_map_associator_hom]
+        simp only [eqToIso_refl, Iso.refl_trans, Iso.refl_symm, Iso.trans_hom, tensorIso_hom,
+          Iso.refl_hom, MonoidalCategory.tensor_id]
+        erw [Category.id_comp, Category.comp_id, MonoidalCategory.tensor_id, Category.comp_id]
+        rfl
+        -- intros X Y Z
+        -- dsimp only [AlgEquiv.toAlgebraIso_hom, eqToIso_refl, Iso.refl_symm, Iso.trans_hom, Iso.refl_hom, tensorIso_hom]
+        -- dsimp
+        -- simp
+        -- rw [one_tensorHom]
+        -- rfl
+      leftUnitor := fun X => (Algebra.TensorProduct.lid R X).toAlgebraIso
+      rightUnitor := fun X => (Algebra.TensorProduct.rid R R X).toAlgebraIso
+      rightUnitor_eq := sorry }
+
+variable (R) in
+/-- `forget₂ (AlgebraCat R) (ModuleCat R)` as a monoidal functor. -/
+def toModuleCatMonoidalFunctor : MonoidalFunctor (AlgebraCat.{u} R) (ModuleCat.{u} R) :=
+  Monoidal.fromInduced (forget₂ (AlgebraCat R) (ModuleCat R)) _
+
+instance : Faithful (toModuleCatMonoidalFunctor R).toFunctor :=
+  forget₂_faithful _ _
+
+end
+
+end AlgebraCat

--- a/Mathlib/Algebra/Category/AlgebraCat/Monoidal.lean
+++ b/Mathlib/Algebra/Category/AlgebraCat/Monoidal.lean
@@ -78,12 +78,12 @@ noncomputable instance instMonoidalCategory : MonoidalCategory (AlgebraCat.{u} R
   Monoidal.induced
     (forget₂ (AlgebraCat R) (ModuleCat R))
     { tensorObj := instMonoidalCategory.tensorObj
-      μIsoSymm := fun X Y => eqToIso rfl
+      μIsoSymm := fun X Y => Iso.refl _
       whiskerLeft := fun X _ _ f => tensorHom (𝟙 _) f
       whiskerRight := @fun X₁ X₂ (f : X₁ ⟶ X₂) Y => tensorHom f (𝟙 _)
       tensorHom := tensorHom
       tensorUnit' := tensorUnit
-      εIsoSymm := eqToIso rfl
+      εIsoSymm := Iso.refl _
       associator := associator
       associator_eq := fun X Y Z => by
         dsimp only [forget₂_module_obj, forget₂_map_associator_hom]

--- a/Mathlib/Algebra/Category/AlgebraCat/Monoidal.lean
+++ b/Mathlib/Algebra/Category/AlgebraCat/Monoidal.lean
@@ -85,19 +85,12 @@ noncomputable instance instMonoidalCategory : MonoidalCategory (AlgebraCat.{u} R
       tensorUnit' := tensorUnit
       εIsoSymm := eqToIso rfl
       associator := associator
-      associator_eq := by
+      associator_eq := fun X Y Z => by
         save
         dsimp only [forget₂_module_obj, forget₂_map_associator_hom]
         simp only [eqToIso_refl, Iso.refl_trans, Iso.refl_symm, Iso.trans_hom, tensorIso_hom,
           Iso.refl_hom, MonoidalCategory.tensor_id]
         erw [Category.id_comp, Category.comp_id, MonoidalCategory.tensor_id, Category.comp_id]
-        rfl
-        -- intros X Y Z
-        -- dsimp only [AlgEquiv.toAlgebraIso_hom, eqToIso_refl, Iso.refl_symm, Iso.trans_hom, Iso.refl_hom, tensorIso_hom]
-        -- dsimp
-        -- simp
-        -- rw [one_tensorHom]
-        -- rfl
       leftUnitor := fun X => (Algebra.TensorProduct.lid R X).toAlgebraIso
       rightUnitor := fun X => (Algebra.TensorProduct.rid R R X).toAlgebraIso
       rightUnitor_eq := sorry }

--- a/Mathlib/Algebra/Category/AlgebraCat/Symmetric.lean
+++ b/Mathlib/Algebra/Category/AlgebraCat/Symmetric.lean
@@ -1,0 +1,44 @@
+/-
+Copyright (c) 2023 Eric Wieser. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Eric Wieser
+-/
+import Mathlib.Algebra.Category.AlgebraCat.Monoidal
+import Mathlib.Algebra.Category.ModuleCat.Monoidal.Symmetric
+
+/-!
+# The monoidal structure on `AlgebraCat` is symmetric.
+
+In this file we show:
+
+* `AlgebraCat.instSymmetricCategory : SymmetricCategory (AlgebraCat.{u} R)`
+-/
+open CategoryTheory
+
+
+noncomputable section
+
+universe v u
+
+variable {R : Type u} [CommRing R]
+
+namespace AlgebraCat
+
+instance : BraidedCategory (AlgebraCat.{u} R) :=
+  braidedCategoryOfFaithful (toModuleCatMonoidalFunctor R)
+    (fun X Y => (Algebra.TensorProduct.comm R X Y).toAlgebraIso)
+    (fun _X _Y => by aesop_cat)
+
+variable (R) in
+/-- `forget₂ (AlgebraCat R) (ModuleCat R)` as a braided functor. -/
+@[simps toMonoidalFunctor]
+def toModuleCatBraidedFunctor : BraidedFunctor (AlgebraCat.{u} R) (ModuleCat.{u} R) where
+  toMonoidalFunctor := toModuleCatMonoidalFunctor R
+
+instance : Faithful (toModuleCatBraidedFunctor R).toFunctor :=
+  forget₂_faithful _ _
+
+instance instSymmetricCategory : SymmetricCategory (AlgebraCat.{u} R) :=
+  symmetricCategoryOfFaithful (toModuleCatBraidedFunctor R)
+
+end AlgebraCat

--- a/Mathlib/Algebra/Category/AlgebraCat/Symmetric.lean
+++ b/Mathlib/Algebra/Category/AlgebraCat/Symmetric.lean
@@ -27,7 +27,7 @@ namespace AlgebraCat
 instance : BraidedCategory (AlgebraCat.{u} R) :=
   braidedCategoryOfFaithful (toModuleCatMonoidalFunctor R)
     (fun X Y => (Algebra.TensorProduct.comm R X Y).toAlgebraIso)
-    (fun _X _Y => by aesop_cat)
+    (by aesop_cat)
 
 variable (R) in
 /-- `forget₂ (AlgebraCat R) (ModuleCat R)` as a braided functor. -/

--- a/Mathlib/LinearAlgebra/TensorProduct/Tower.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Tower.lean
@@ -303,6 +303,9 @@ protected def rid : M ⊗[R] R ≃ₗ[A] M :=
     (LinearMap.ext <| one_smul _)
     (ext <| fun _ _ => smul_tmul _ _ _ |>.trans <| congr_arg _ <| mul_one _)
 
+theorem rid_eq_rid : AlgebraTensorModule.rid R R M = TensorProduct.rid R M :=
+  LinearEquiv.toLinearMap_injective <| TensorProduct.ext' fun _ _ => rfl
+
 variable {R M}
 
 @[simp]

--- a/Mathlib/RingTheory/TensorProduct.lean
+++ b/Mathlib/RingTheory/TensorProduct.lean
@@ -788,6 +788,9 @@ protected def comm : A ⊗[R] B ≃ₐ[R] B ⊗[R] A :=
   algEquivOfLinearEquivTensorProduct (_root_.TensorProduct.comm R A B) (fun _ _ _ _ => rfl) rfl
 #align algebra.tensor_product.comm Algebra.TensorProduct.comm
 
+@[simp] theorem comm_toLinearEquiv :
+    (Algebra.TensorProduct.comm R A B).toLinearEquiv = _root_.TensorProduct.comm R A B := rfl
+
 @[simp]
 theorem comm_tmul (a : A) (b : B) :
     (TensorProduct.comm R A B : A ⊗[R] B → B ⊗[R] A) (a ⊗ₜ b) = b ⊗ₜ a :=
@@ -896,6 +899,10 @@ def congr (f : A ≃ₐ[S] B) (g : C ≃ₐ[R] D) : A ⊗[R] C ≃ₐ[S] B ⊗[R
   AlgEquiv.ofAlgHom (map f g) (map f.symm g.symm)
     (ext' fun b d => by simp) (ext' fun a c => by simp)
 #align algebra.tensor_product.congr Algebra.TensorProduct.congr
+
+@[simp] theorem congr_toLinearEquiv (f : A ≃ₐ[S] B) (g : C ≃ₐ[R] D) :
+    (Algebra.TensorProduct.congr f g).toLinearEquiv =
+      TensorProduct.AlgebraTensorModule.congr f.toLinearEquiv g.toLinearEquiv := rfl
 
 @[simp]
 theorem congr_apply (f : A ≃ₐ[S] B) (g : C ≃ₐ[R] D) (x) :

--- a/Mathlib/RingTheory/TensorProduct.lean
+++ b/Mathlib/RingTheory/TensorProduct.lean
@@ -750,6 +750,9 @@ protected nonrec def lid : R ⊗[R] A ≃ₐ[R] A :=
     (by simp [Algebra.smul_def])
 #align algebra.tensor_product.lid Algebra.TensorProduct.lid
 
+@[simp] theorem lid_toLinearEquiv :
+    (TensorProduct.lid R A).toLinearEquiv = _root_.TensorProduct.lid R A := rfl
+
 @[simp]
 theorem lid_tmul (r : R) (a : A) : (TensorProduct.lid R A : R ⊗ A → A) (r ⊗ₜ a) = r • a := rfl
 #align algebra.tensor_product.lid_tmul Algebra.TensorProduct.lid_tmul
@@ -765,6 +768,9 @@ protected nonrec def rid : A ⊗[R] R ≃ₐ[S] A :=
     (fun _a₁ _a₂ _r₁ _r₂ => smul_mul_smul _ _ _ _ |>.symm)
     (one_smul _ _)
 #align algebra.tensor_product.rid Algebra.TensorProduct.rid
+
+@[simp] theorem rid_toLinearEquiv :
+    (TensorProduct.rid R S A).toLinearEquiv = AlgebraTensorModule.rid R S A := rfl
 
 variable {R A} in
 @[simp]
@@ -809,7 +815,7 @@ theorem assoc_aux_2 : (TensorProduct.assoc R A B C) ((1 ⊗ₜ[R] 1) ⊗ₜ[R] 1
   rfl
 #align algebra.tensor_product.assoc_aux_2 Algebra.TensorProduct.assoc_aux_2ₓ
 
-variable (A B C)
+variable (R A B C)
 
 -- porting note: much nicer than Lean 3 proof
 /-- The associator for tensor product of R-algebras, as an algebra isomorphism. -/
@@ -820,12 +826,14 @@ protected def assoc : (A ⊗[R] B) ⊗[R] C ≃ₐ[R] A ⊗[R] B ⊗[R] C :=
     Algebra.TensorProduct.assoc_aux_2
 #align algebra.tensor_product.assoc Algebra.TensorProduct.assoc
 
+@[simp] theorem assoc_toLinearEquiv :
+  (Algebra.TensorProduct.assoc R A B C).toLinearEquiv = _root_.TensorProduct.assoc R A B C := rfl
+
 variable {A B C}
 
 @[simp]
 theorem assoc_tmul (a : A) (b : B) (c : C) :
-    (_root_.TensorProduct.assoc R A B C : (A ⊗[R] B) ⊗[R] C → A ⊗[R] B ⊗[R] C) (a ⊗ₜ b ⊗ₜ c) =
-      a ⊗ₜ (b ⊗ₜ c) :=
+    Algebra.TensorProduct.assoc R A B C (a ⊗ₜ b ⊗ₜ c) = a ⊗ₜ (b ⊗ₜ c) :=
   rfl
 #align algebra.tensor_product.assoc_tmul Algebra.TensorProduct.assoc_tmul
 


### PR DESCRIPTION
Some of these proofs are a little awkward as they have to fight with:

* non-reducible type issues with `Quiver.Hom` vs `AlgHom`
* mazes of coercions between `AlgEquiv` and `LinearMap`
* defeqs not matching between module and algebra tensor product

This also corrects an accidental mis-statement of `Algebra.TensorProduct.assoc_tmul`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
-->

- [x] depends on: #7237

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)


This follows the pattern set by (the unmerged) #7244


