### PR TITLE
[Merged by Bors] - chore: improve defeq for `Sup` and `sSup` of `LieSubmodule`s

### DIFF
--- a/Mathlib/Algebra/Lie/Submodule.lean
+++ b/Mathlib/Algebra/Lie/Submodule.lean
@@ -497,6 +497,12 @@ theorem iSup_coe_toSubmodule {ι} (p : ι → LieSubmodule R L M) :
     (↑(⨆ i, p i) : Submodule R M) = ⨆ i, (p i : Submodule R M) := by
   rw [iSup, sSup_coe_toSubmodule]; ext; simp [Submodule.mem_sSup, Submodule.mem_iSup]
 
+lemma iSup_induction {ι} (N : ι → LieSubmodule R L M) {C : M → Prop} {x : M}
+    (hx : x ∈ ⨆ i, N i) (hN : ∀ i, ∀ y ∈ N i, C y) (h0 : C 0)
+    (hadd : ∀ y z, C y → C z → C (y + z)) : C x := by
+  rw [← LieSubmodule.mem_coeSubmodule, LieSubmodule.iSup_coe_toSubmodule] at hx
+  exact Submodule.iSup_induction (C := C) (fun i ↦ (N i : Submodule R M)) hx hN h0 hadd
+
 /-- The set of Lie submodules of a Lie module form a complete lattice. -/
 instance : CompleteLattice (LieSubmodule R L M) :=
   { sInf_le := fun s a ha ↦ by

--- a/Mathlib/Algebra/Lie/Submodule.lean
+++ b/Mathlib/Algebra/Lie/Submodule.lean
@@ -430,6 +430,10 @@ theorem sInf_coe_toSubmodule (S : Set (LieSubmodule R L M)) :
   rfl
 #align lie_submodule.Inf_coe_to_submodule LieSubmodule.sInf_coe_toSubmodule
 
+theorem sInf_coe_toSubmodule' (S : Set (LieSubmodule R L M)) :
+    (↑(sInf S) : Submodule R M) = ⨅ N ∈ S, (N : Submodule R M) := by
+  rw [sInf_coe_toSubmodule, ← Set.image, sInf_image]
+
 @[simp]
 theorem iInf_coe_toSubmodule {ι} (p : ι → LieSubmodule R L M) :
     (↑(⨅ i, p i) : Submodule R M) = ⨅ i, (p i : Submodule R M) := by
@@ -492,6 +496,10 @@ theorem sSup_coe_toSubmodule (S : Set (LieSubmodule R L M)) :
     (↑(sSup S) : Submodule R M) = sSup {(s : Submodule R M) | s ∈ S} :=
   rfl
 
+theorem sSup_coe_toSubmodule' (S : Set (LieSubmodule R L M)) :
+    (↑(sSup S) : Submodule R M) = ⨆ N ∈ S, (N : Submodule R M) := by
+  rw [sSup_coe_toSubmodule, ← Set.image, sSup_image]
+
 @[simp]
 theorem iSup_coe_toSubmodule {ι} (p : ι → LieSubmodule R L M) :
     (↑(⨆ i, p i) : Submodule R M) = ⨆ i, (p i : Submodule R M) := by
@@ -499,20 +507,9 @@ theorem iSup_coe_toSubmodule {ι} (p : ι → LieSubmodule R L M) :
 
 /-- The set of Lie submodules of a Lie module form a complete lattice. -/
 instance : CompleteLattice (LieSubmodule R L M) :=
-  { sInf_le := fun s a ha ↦ by
-      rw [← coeSubmodule_le_coeSubmodule, sInf_coe_toSubmodule]; exact sInf_le ⟨a, ha, rfl⟩
-    le_sInf := fun s a ha ↦ by rw [← coeSubmodule_le_coeSubmodule, sInf_coe_toSubmodule]; simpa
-    le_top := fun _ _ _ ↦ trivial
-    bot_le := fun _ ↦ bot_le (α := Submodule R M)
-    sup_le := fun _ _ _ ↦ sup_le (α := Submodule R M)
-    le_sup_right := fun _ _ ↦ le_sup_right (α := Submodule R M)
-    le_sup_left := fun _ _ ↦ le_sup_left (α := Submodule R M)
-    sSup_le := fun s a ha ↦ by rw [← coeSubmodule_le_coeSubmodule, sSup_coe_toSubmodule]; simpa
-    le_sSup := fun s a ha ↦ by
-      rw [← coeSubmodule_le_coeSubmodule, sSup_coe_toSubmodule]; exact le_sSup ⟨a, ha, rfl⟩
-    le_inf := fun _ _ _ ↦ le_inf (α := Submodule R M)
-    inf_le_left := fun _ _ _ ↦ And.left
-    inf_le_right := fun _ _ _ ↦ And.right }
+  { coeSubmodule_injective.completeLattice toSubmodule sup_coe_toSubmodule inf_coe_toSubmodule
+      sSup_coe_toSubmodule' sInf_coe_toSubmodule' rfl rfl with
+    toPartialOrder := SetLike.instPartialOrder }
 
 theorem mem_iSup_of_mem {ι} {b : M} {N : ι → LieSubmodule R L M} (i : ι) (h : b ∈ N i) :
     b ∈ ⨆ i, N i :=

--- a/Mathlib/Algebra/Lie/Submodule.lean
+++ b/Mathlib/Algebra/Lie/Submodule.lean
@@ -451,18 +451,18 @@ theorem iInf_coe {ι} (p : ι → LieSubmodule R L M) : (↑(⨅ i, p i) : Set M
 theorem mem_iInf {ι} (p : ι → LieSubmodule R L M) {x} : (x ∈ ⨅ i, p i) ↔ ∀ i, x ∈ p i := by
   rw [← SetLike.mem_coe, iInf_coe, Set.mem_iInter]; rfl
 
-instance : Sup (LieSubmodule R L M) :=
-  ⟨fun N N' ↦
+instance : Sup (LieSubmodule R L M) where
+  sup N N' :=
     { toSubmodule := (N : Submodule R M) ⊔ (N' : Submodule R M)
       lie_mem := by
         rintro x m (hm : m ∈ (N : Submodule R M) ⊔ (N' : Submodule R M))
         change ⁅x, m⁆ ∈ (N : Submodule R M) ⊔ (N' : Submodule R M)
         rw [Submodule.mem_sup] at hm ⊢
         obtain ⟨y, hy, z, hz, rfl⟩ := hm
-        exact ⟨⁅x, y⁆, N.lie_mem hy, ⁅x, z⁆, N'.lie_mem hz, (lie_add _ _ _).symm⟩ }⟩
+        exact ⟨⁅x, y⁆, N.lie_mem hy, ⁅x, z⁆, N'.lie_mem hz, (lie_add _ _ _).symm⟩ }
 
-instance : SupSet (LieSubmodule R L M) :=
-  ⟨fun S ↦
+instance : SupSet (LieSubmodule R L M) where
+  sSup S :=
     { toSubmodule := sSup {(p : Submodule R M) | p ∈ S}
       lie_mem := by
         intro x m (hm : m ∈ sSup {(p : Submodule R M) | p ∈ S})
@@ -479,7 +479,7 @@ instance : SupSet (LieSubmodule R L M) :=
           refine add_mem ?_ (ih (Subset.trans (by simp) hs) hu)
           obtain ⟨p, hp, rfl⟩ : ∃ p ∈ S, ↑p = q := hs (Finset.mem_insert_self q t)
           suffices p ≤ sSup {(p : Submodule R M) | p ∈ S} by exact this (p.lie_mem hm')
-          exact le_sSup ⟨p, hp, rfl⟩ }⟩
+          exact le_sSup ⟨p, hp, rfl⟩ }
 
 @[norm_cast, simp]
 theorem sup_coe_toSubmodule :
@@ -509,14 +509,14 @@ instance : CompleteLattice (LieSubmodule R L M) :=
       rw [← coeSubmodule_le_coeSubmodule, sInf_coe_toSubmodule]; exact sInf_le ⟨a, ha, rfl⟩
     le_sInf := fun s a ha ↦ by rw [← coeSubmodule_le_coeSubmodule, sInf_coe_toSubmodule]; simpa
     le_top := fun _ _ _ ↦ trivial
-    bot_le := fun N _ h ↦ by rw [mem_bot] at h; rw [h]; exact N.zero_mem'
+    bot_le := fun _ ↦ bot_le (α := Submodule R M)
     sup_le := fun _ _ _ ↦ sup_le (α := Submodule R M)
     le_sup_right := fun _ _ ↦ le_sup_right (α := Submodule R M)
     le_sup_left := fun _ _ ↦ le_sup_left (α := Submodule R M)
     sSup_le := fun s a ha ↦ by rw [← coeSubmodule_le_coeSubmodule, sSup_coe_toSubmodule]; simpa
     le_sSup := fun s a ha ↦ by
       rw [← coeSubmodule_le_coeSubmodule, sSup_coe_toSubmodule]; exact le_sSup ⟨a, ha, rfl⟩
-    le_inf := fun N₁ N₂ N₃ h₁₂ h₁₃ m hm ↦ ⟨h₁₂ hm, h₁₃ hm⟩
+    le_inf := fun _ _ _ ↦ le_inf (α := Submodule R M)
     inf_le_left := fun _ _ _ ↦ And.left
     inf_le_right := fun _ _ _ ↦ And.right }
 

--- a/Mathlib/LinearAlgebra/Finsupp.lean
+++ b/Mathlib/LinearAlgebra/Finsupp.lean
@@ -1182,6 +1182,17 @@ theorem Submodule.mem_iSup_iff_exists_finset {ι : Sort _} {p : ι → Submodule
     iSup_mono (fun i => (iSup_const_le : _ ≤ p i)) hs⟩
 #align submodule.mem_supr_iff_exists_finset Submodule.mem_iSup_iff_exists_finset
 
+theorem Submodule.mem_sSup_iff_exists_finset {S : Set (Submodule R M)} {m : M} :
+    m ∈ sSup S ↔ ∃ s : Finset (Submodule R M), ↑s ⊆ S ∧ m ∈ ⨆ i ∈ s, i := by
+  rw [sSup_eq_iSup, iSup_subtype', Submodule.mem_iSup_iff_exists_finset]
+  refine ⟨fun ⟨s, hs⟩ ↦ ⟨s.map (Function.Embedding.subtype S), ?_, ?_⟩,
+          fun ⟨s, hsS, hs⟩ ↦ ⟨s.preimage (↑) (Subtype.coe_injective.injOn _), ?_⟩⟩
+  · simpa using fun x _ ↦ x.property
+  · suffices m ∈ ⨆ (i) (hi : i ∈ S) (_ : ⟨i, hi⟩ ∈ s), i by simpa
+    rwa [iSup_subtype']
+  · have : ⨆ (i) (_ : i ∈ S ∧ i ∈ s), i = ⨆ (i) (_ : i ∈ s), i := by convert rfl; aesop
+    simpa only [Finset.mem_preimage, iSup_subtype, iSup_and', this]
+
 theorem mem_span_finset {s : Finset M} {x : M} :
     x ∈ span R (↑s : Set M) ↔ ∃ f : M → R, ∑ i in s, f i • i = x :=
   ⟨fun hx =>

--- a/Mathlib/LinearAlgebra/Span.lean
+++ b/Mathlib/LinearAlgebra/Span.lean
@@ -706,6 +706,10 @@ theorem mem_iSup {ι : Sort*} (p : ι → Submodule R M) {m : M} :
   simp only [span_singleton_le_iff_mem]
 #align submodule.mem_supr Submodule.mem_iSup
 
+theorem mem_sSup {s : Set (Submodule R M)} {m : M} :
+    (m ∈ sSup s) ↔ ∀ N, (∀ p ∈ s, p ≤ N) → m ∈ N := by
+  simp_rw [sSup_eq_iSup, Submodule.mem_iSup, iSup_le_iff]
+
 section
 
 /-- For every element in the span of a set, there exists a finite subset of the set


### PR DESCRIPTION
The point is that the following four lemmas are now all true by definition:

- `LieSubmodule.inf_coe_toSubmodule`
- `LieSubmodule.sInf_coe_toSubmodule`
- `LieSubmodule.sup_coe_toSubmodule` [previously existed but not true by definition]
- `LieSubmodule.sSup_coe_toSubmodule` [previously did not exist]

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
