### PR TITLE
[Merged by Bors] - chore(LinearAlgebra/Basic): change a `CommSemiring`instance to a `Semiring` instance

### DIFF
--- a/Mathlib/LinearAlgebra/Basic.lean
+++ b/Mathlib/LinearAlgebra/Basic.lean
@@ -2334,7 +2334,7 @@ end Submodule
 
 namespace Submodule
 
-variable [CommSemiring R] [CommSemiring R₂]
+variable [Semiring R] [Semiring R₂]
 
 variable [AddCommMonoid M] [AddCommMonoid M₂] [Module R M] [Module R₂ M₂]
 
@@ -2391,6 +2391,24 @@ theorem orderIsoMapComap_symm_apply' (e : M ≃ₛₗ[τ₁₂] M₂) (p : Submo
     (orderIsoMapComap e).symm p = map e.symm p :=
   p.comap_equiv_eq_map_symm _
 #align submodule.order_iso_map_comap_symm_apply' Submodule.orderIsoMapComap_symm_apply'
+
+end Submodule
+
+namespace Submodule
+
+variable [CommSemiring R] [CommSemiring R₂]
+
+variable [AddCommMonoid M] [AddCommMonoid M₂] [Module R M] [Module R₂ M₂]
+
+variable [AddCommMonoid N] [AddCommMonoid N₂] [Module R N] [Module R N₂]
+
+variable {τ₁₂ : R →+* R₂} {τ₂₁ : R₂ →+* R}
+
+variable [RingHomInvPair τ₁₂ τ₂₁] [RingHomInvPair τ₂₁ τ₁₂]
+
+variable (p : Submodule R M) (q : Submodule R₂ M₂)
+
+variable (pₗ : Submodule R N) (qₗ : Submodule R N₂)
 
 theorem comap_le_comap_smul (fₗ : N →ₗ[R] N₂) (c : R) : comap fₗ qₗ ≤ comap (c • fₗ) qₗ := by
   rw [SetLike.le_def]

--- a/Mathlib/LinearAlgebra/Basic.lean
+++ b/Mathlib/LinearAlgebra/Basic.lean
@@ -2392,6 +2392,15 @@ theorem orderIsoMapComap_symm_apply' (e : M ≃ₛₗ[τ₁₂] M₂) (p : Submo
   p.comap_equiv_eq_map_symm _
 #align submodule.order_iso_map_comap_symm_apply' Submodule.orderIsoMapComap_symm_apply'
 
+theorem inf_comap_le_comap_add (f₁ f₂ : M →ₛₗ[τ₁₂] M₂) :
+    comap f₁ q ⊓ comap f₂ q ≤ comap (f₁ + f₂) q := by
+  rw [SetLike.le_def]
+  intro m h
+  change f₁ m + f₂ m ∈ q
+  change f₁ m ∈ q ∧ f₂ m ∈ q at h
+  apply q.add_mem h.1 h.2
+#align submodule.inf_comap_le_comap_add Submodule.inf_comap_le_comap_add
+
 end Submodule
 
 namespace Submodule
@@ -2417,15 +2426,6 @@ theorem comap_le_comap_smul (fₗ : N →ₗ[R] N₂) (c : R) : comap fₗ qₗ 
   change fₗ m ∈ qₗ at h
   apply qₗ.smul_mem _ h
 #align submodule.comap_le_comap_smul Submodule.comap_le_comap_smul
-
-theorem inf_comap_le_comap_add (f₁ f₂ : M →ₛₗ[τ₁₂] M₂) :
-    comap f₁ q ⊓ comap f₂ q ≤ comap (f₁ + f₂) q := by
-  rw [SetLike.le_def]
-  intro m h
-  change f₁ m + f₂ m ∈ q
-  change f₁ m ∈ q ∧ f₂ m ∈ q at h
-  apply q.add_mem h.1 h.2
-#align submodule.inf_comap_le_comap_add Submodule.inf_comap_le_comap_add
 
 /-- Given modules `M`, `M₂` over a commutative ring, together with submodules `p ⊆ M`, `q ⊆ M₂`,
 the set of maps $\{f ∈ Hom(M, M₂) | f(p) ⊆ q \}$ is a submodule of `Hom(M, M₂)`. -/


### PR DESCRIPTION
Generalize `mem_map_equiv` and likes to `Semiring` (previously used `CommSemiring` instances).

---

I need this for an other project.
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
