### PR TITLE
[Merged by Bors] - feat: homology isomorphism for a functor which preserves homology

### DIFF
--- a/Mathlib/Algebra/Homology/ShortComplex/PreservesHomology.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/PreservesHomology.lean
@@ -341,6 +341,185 @@ instance hasHomology_of_preserves' [S.HasHomology] [F.PreservesLeftHomologyOf S]
     (F.mapShortComplex.obj S).HasHomology :=
   by dsimp; infer_instance
 
+section
+
+variable
+  (hl : S.LeftHomologyData) (hr : S.RightHomologyData)
+  {S₁ S₂ : ShortComplex C} (φ : S₁ ⟶ S₂)
+  (hl₁ : S₁.LeftHomologyData) (hr₁ : S₁.RightHomologyData)
+  (hl₂ : S₂.LeftHomologyData) (hr₂ : S₂.RightHomologyData)
+  (h₁ : S₁.HomologyData) (h₂ : S₂.HomologyData)
+  (F : C ⥤ D) [F.PreservesZeroMorphisms]
+
+namespace LeftHomologyData
+
+variable [hl₁.IsPreservedBy F] [hl₂.IsPreservedBy F]
+
+lemma map_cyclesMap' : F.map (ShortComplex.cyclesMap' φ hl₁ hl₂) =
+    ShortComplex.cyclesMap' (F.mapShortComplex.map φ) (hl₁.map F) (hl₂.map F) := by
+  have γ : ShortComplex.LeftHomologyMapData φ hl₁ hl₂ := default
+  rw [γ.cyclesMap'_eq, (γ.map F).cyclesMap'_eq,  ShortComplex.LeftHomologyMapData.map_φK]
+
+lemma map_leftHomologyMap' : F.map (ShortComplex.leftHomologyMap' φ hl₁ hl₂) =
+    ShortComplex.leftHomologyMap' (F.mapShortComplex.map φ) (hl₁.map F) (hl₂.map F) := by
+  have γ : ShortComplex.LeftHomologyMapData φ hl₁ hl₂ := default
+  rw [γ.leftHomologyMap'_eq, (γ.map F).leftHomologyMap'_eq,
+    ShortComplex.LeftHomologyMapData.map_φH]
+
+end LeftHomologyData
+
+namespace RightHomologyData
+
+variable [hr₁.IsPreservedBy F] [hr₂.IsPreservedBy F]
+
+lemma map_opcyclesMap' : F.map (ShortComplex.opcyclesMap' φ hr₁ hr₂) =
+    ShortComplex.opcyclesMap' (F.mapShortComplex.map φ) (hr₁.map F) (hr₂.map F) := by
+  have γ : ShortComplex.RightHomologyMapData φ hr₁ hr₂ := default
+  rw [γ.opcyclesMap'_eq, (γ.map F).opcyclesMap'_eq,  ShortComplex.RightHomologyMapData.map_φQ]
+
+lemma map_rightHomologyMap' : F.map (ShortComplex.rightHomologyMap' φ hr₁ hr₂) =
+    ShortComplex.rightHomologyMap' (F.mapShortComplex.map φ) (hr₁.map F) (hr₂.map F) := by
+  have γ : ShortComplex.RightHomologyMapData φ hr₁ hr₂ := default
+  rw [γ.rightHomologyMap'_eq, (γ.map F).rightHomologyMap'_eq,
+    ShortComplex.RightHomologyMapData.map_φH]
+
+end RightHomologyData
+
+lemma HomologyData.map_homologyMap'
+    [h₁.left.IsPreservedBy F] [h₁.right.IsPreservedBy F]
+    [h₂.left.IsPreservedBy F] [h₂.right.IsPreservedBy F] :
+    F.map (ShortComplex.homologyMap' φ h₁ h₂) =
+      ShortComplex.homologyMap' (F.mapShortComplex.map φ) (h₁.map F) (h₂.map F) :=
+  LeftHomologyData.map_leftHomologyMap' _ _ _ _
+
+/-- When a functor `F` preserves the left homology of a short complex `S`, this is the
+canonical isomorphism `(S.map F).cycles ≅ F.obj S.cycles`. -/
+noncomputable def mapCyclesIso [S.HasLeftHomology] [F.PreservesLeftHomologyOf S] :
+    (S.map F).cycles ≅ F.obj S.cycles :=
+  (S.leftHomologyData.map F).cyclesIso
+
+/-- When a functor `F` preserves the left homology of a short complex `S`, this is the
+canonical isomorphism `(S.map F).leftHomology ≅ F.obj S.leftHomology`. -/
+noncomputable def mapLeftHomologyIso [S.HasLeftHomology] [F.PreservesLeftHomologyOf S] :
+    (S.map F).leftHomology ≅ F.obj S.leftHomology :=
+  (S.leftHomologyData.map F).leftHomologyIso
+
+/-- When a functor `F` preserves the right homology of a short complex `S`, this is the
+canonical isomorphism `(S.map F).opcycles ≅ F.obj S.opcycles`. -/
+noncomputable def mapOpcyclesIso [S.HasRightHomology] [F.PreservesRightHomologyOf S] :
+    (S.map F).opcycles ≅ F.obj S.opcycles :=
+  (S.rightHomologyData.map F).opcyclesIso
+
+/-- When a functor `F` preserves the right homology of a short complex `S`, this is the
+canonical isomorphism `(S.map F).rightHomology ≅ F.obj S.rightHomology`. -/
+noncomputable def mapRightHomologyIso [S.HasRightHomology] [F.PreservesRightHomologyOf S] :
+    (S.map F).rightHomology ≅ F.obj S.rightHomology :=
+  (S.rightHomologyData.map F).rightHomologyIso
+
+/-- When a functor `F` preserves the left homology of a short complex `S`, this is the
+canonical isomorphism `(S.map F).homology ≅ F.obj S.homology`. -/
+noncomputable def mapHomologyIso [S.HasHomology] [(S.map F).HasHomology]
+    [F.PreservesLeftHomologyOf S] :
+    (S.map F).homology ≅ F.obj S.homology :=
+  (S.homologyData.left.map F).homologyIso
+
+/-- When a functor `F` preserves the right homology of a short complex `S`, this is the
+canonical isomorphism `(S.map F).homology ≅ F.obj S.homology`. -/
+noncomputable def mapHomologyIso' [S.HasHomology] [(S.map F).HasHomology]
+    [F.PreservesRightHomologyOf S] :
+    (S.map F).homology ≅ F.obj S.homology :=
+  (S.homologyData.right.map F).homologyIso ≪≫ F.mapIso S.homologyData.right.homologyIso.symm
+
+variable {S}
+
+lemma LeftHomologyData.mapCyclesIso_eq [S.HasLeftHomology]
+    [F.PreservesLeftHomologyOf S] :
+    S.mapCyclesIso F = (hl.map F).cyclesIso ≪≫ F.mapIso hl.cyclesIso.symm := by
+  ext
+  dsimp [mapCyclesIso, cyclesIso]
+  simp only [map_cyclesMap', ← cyclesMap'_comp, Functor.map_id, comp_id,
+    Functor.mapShortComplex_obj]
+
+lemma LeftHomologyData.mapLeftHomologyIso_eq [S.HasLeftHomology]
+    [F.PreservesLeftHomologyOf S] :
+    S.mapLeftHomologyIso F = (hl.map F).leftHomologyIso ≪≫ F.mapIso hl.leftHomologyIso.symm := by
+  ext
+  dsimp [mapLeftHomologyIso, leftHomologyIso]
+  simp only [map_leftHomologyMap', ← leftHomologyMap'_comp, Functor.map_id, comp_id,
+    Functor.mapShortComplex_obj]
+
+lemma RightHomologyData.mapOpcyclesIso_eq [S.HasRightHomology]
+    [F.PreservesRightHomologyOf S] :
+    S.mapOpcyclesIso F = (hr.map F).opcyclesIso ≪≫ F.mapIso hr.opcyclesIso.symm := by
+  ext
+  dsimp [mapOpcyclesIso, opcyclesIso]
+  simp only [map_opcyclesMap', ← opcyclesMap'_comp, Functor.map_id, comp_id,
+    Functor.mapShortComplex_obj]
+
+lemma RightHomologyData.mapRightHomologyIso_eq [S.HasRightHomology]
+    [F.PreservesRightHomologyOf S] :
+    S.mapRightHomologyIso F = (hr.map F).rightHomologyIso ≪≫
+      F.mapIso hr.rightHomologyIso.symm := by
+  ext
+  dsimp [mapRightHomologyIso, rightHomologyIso]
+  simp only [map_rightHomologyMap', ← rightHomologyMap'_comp, Functor.map_id, comp_id,
+    Functor.mapShortComplex_obj]
+
+lemma LeftHomologyData.mapHomologyIso_eq [S.HasHomology]
+    [(S.map F).HasHomology] [F.PreservesLeftHomologyOf S] :
+    S.mapHomologyIso F = (hl.map F).homologyIso ≪≫ F.mapIso hl.homologyIso.symm := by
+  ext
+  dsimp only [mapHomologyIso, homologyIso, ShortComplex.leftHomologyIso,
+    leftHomologyMapIso', leftHomologyIso, Functor.mapIso,
+    Iso.symm, Iso.trans, Iso.refl]
+  simp only [F.map_comp, map_leftHomologyMap', ← leftHomologyMap'_comp, comp_id,
+    Functor.map_id, Functor.mapShortComplex_obj]
+
+lemma RightHomologyData.mapHomologyIso'_eq [S.HasHomology]
+    [(S.map F).HasHomology] [F.PreservesRightHomologyOf S] :
+    S.mapHomologyIso' F = (hr.map F).homologyIso ≪≫ F.mapIso hr.homologyIso.symm := by
+  ext
+  dsimp only [Iso.trans, Iso.symm, Iso.refl, Functor.mapIso, mapHomologyIso', homologyIso,
+    rightHomologyIso, rightHomologyMapIso', ShortComplex.rightHomologyIso]
+  simp only [assoc, F.map_comp, map_rightHomologyMap', ← rightHomologyMap'_comp_assoc]
+
+@[reassoc]
+lemma mapCyclesIso_hom_naturality [S₁.HasLeftHomology] [S₂.HasLeftHomology]
+    [F.PreservesLeftHomologyOf S₁] [F.PreservesLeftHomologyOf S₂] :
+    cyclesMap (F.mapShortComplex.map φ) ≫ (S₂.mapCyclesIso F).hom =
+      (S₁.mapCyclesIso F).hom ≫ F.map (cyclesMap φ) := by
+  dsimp only [cyclesMap, mapCyclesIso, LeftHomologyData.cyclesIso, cyclesMapIso', Iso.refl]
+  simp only [LeftHomologyData.map_cyclesMap', Functor.mapShortComplex_obj, ← cyclesMap'_comp,
+    comp_id, id_comp]
+
+@[reassoc]
+lemma mapCyclesIso_inv_naturality [S₁.HasLeftHomology] [S₂.HasLeftHomology]
+    [F.PreservesLeftHomologyOf S₁] [F.PreservesLeftHomologyOf S₂] :
+    F.map (cyclesMap φ) ≫ (S₂.mapCyclesIso F).inv =
+      (S₁.mapCyclesIso F).inv ≫ cyclesMap (F.mapShortComplex.map φ) := by
+  rw [← cancel_epi (S₁.mapCyclesIso F).hom, ← mapCyclesIso_hom_naturality_assoc,
+    Iso.hom_inv_id, comp_id, Iso.hom_inv_id_assoc]
+
+@[reassoc]
+lemma mapLeftHomologyIso_hom_naturality [S₁.HasLeftHomology] [S₂.HasLeftHomology]
+    [F.PreservesLeftHomologyOf S₁] [F.PreservesLeftHomologyOf S₂] :
+    leftHomologyMap (F.mapShortComplex.map φ) ≫ (S₂.mapLeftHomologyIso F).hom =
+      (S₁.mapLeftHomologyIso F).hom ≫ F.map (leftHomologyMap φ) := by
+  dsimp only [leftHomologyMap, mapLeftHomologyIso, LeftHomologyData.leftHomologyIso,
+    leftHomologyMapIso', Iso.refl]
+  simp only [LeftHomologyData.map_leftHomologyMap', Functor.mapShortComplex_obj,
+    ← leftHomologyMap'_comp, comp_id, id_comp]
+
+@[reassoc]
+lemma mapLeftHomologyIso_inv_naturality [S₁.HasLeftHomology] [S₂.HasLeftHomology]
+    [F.PreservesLeftHomologyOf S₁] [F.PreservesLeftHomologyOf S₂] :
+    F.map (leftHomologyMap φ) ≫ (S₂.mapLeftHomologyIso F).inv =
+      (S₁.mapLeftHomologyIso F).inv ≫ leftHomologyMap (F.mapShortComplex.map φ) := by
+  rw [← cancel_epi (S₁.mapLeftHomologyIso F).hom, ← mapLeftHomologyIso_hom_naturality_assoc,
+    Iso.hom_inv_id, comp_id, Iso.hom_inv_id_assoc]
+
+end
+
 end ShortComplex
 
 end CategoryTheory

--- a/Mathlib/Algebra/Homology/ShortComplex/PreservesHomology.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/PreservesHomology.lean
@@ -292,10 +292,10 @@ def PreservesRightHomologyOf.mk' (h : S.RightHomologyData) [h.IsPreservedBy F] :
   isPreservedBy h' :=
     { f := ShortComplex.RightHomologyData.IsPreservedBy.hf h F
       g' := by
+        have := ShortComplex.RightHomologyData.IsPreservedBy.hg' h F
         let e : parallelPair h.g' 0 ≅ parallelPair h'.g' 0 :=
           parallelPair.ext (ShortComplex.opcyclesMapIso' (Iso.refl S) h h') (Iso.refl _)
             (by simp) (by simp)
-        have := ShortComplex.RightHomologyData.IsPreservedBy.hg' h F
         exact preservesLimitOfIsoDiagram F e }
 
 end Functor

--- a/Mathlib/Algebra/Homology/ShortComplex/PreservesHomology.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/PreservesHomology.lean
@@ -141,6 +141,206 @@ def LeftHomologyMapData.map {φ : S₁ ⟶ S₂} {h₁ : S₁.LeftHomologyData}
   commf' := by simpa only [LeftHomologyData.map_f', F.map_comp] using F.congr_map ψ.commf'
   commπ := by simpa only [F.map_comp] using F.congr_map ψ.commπ
 
+namespace RightHomologyData
+
+variable (h : S.RightHomologyData) (F : C ⥤ D)
+
+/-- A right homology data `h` of a short complex `S` is preserved by a functor `F` is
+`F` preserves the cokernel of `S.f : S.X₁ ⟶ S.X₂` and the kernel of `h.g' : h.Q ⟶ S.X₃`. -/
+class IsPreservedBy [F.PreservesZeroMorphisms] where
+  /-- the functor preserves the cokernel of `S.f : S.X₁ ⟶ S.X₂`. -/
+  f : PreservesColimit (parallelPair S.f 0) F
+  /-- the functor preserves the kernel of `h.g' : h.Q ⟶ S.X₃`. -/
+  g' : PreservesLimit (parallelPair h.g' 0) F
+
+variable [F.PreservesZeroMorphisms]
+
+noncomputable instance isPreservedByOfPreservesHomology [F.PreservesHomology] :
+    h.IsPreservedBy F where
+  f := Functor.PreservesHomology.preservesCokernel F _
+  g' := Functor.PreservesHomology.preservesKernel F _
+
+variable [h.IsPreservedBy F]
+
+/-- When a right homology data is preserved by a functor `F`, this functor
+preserves the cokernel of `S.f : S.X₁ ⟶ S.X₂`. -/
+def IsPreservedBy.hf : PreservesColimit (parallelPair S.f 0) F :=
+  @IsPreservedBy.f _ _ _ _ _ _ _ h F _ _
+
+/-- When a right homology data `h` is preserved by a functor `F`, this functor
+preserves the kernel of `h.g' : h.Q ⟶ S.X₃`. -/
+def IsPreservedBy.hg' : PreservesLimit (parallelPair h.g' 0) F :=
+  @IsPreservedBy.g' _ _ _ _ _ _ _ h F _ _
+
+/-- When a right homology data `h` of a short complex `S` is preserved by a functor `F`,
+this is the induced right homology data `h.map F` for the short complex `S.map F`. -/
+@[simps]
+noncomputable def map : (S.map F).RightHomologyData := by
+  have := IsPreservedBy.hf h F
+  have := IsPreservedBy.hg' h F
+  have wp : F.map S.f ≫ F.map h.p = 0 := by rw [← F.map_comp, h.wp, F.map_zero]
+  have hp := CokernelCofork.mapIsColimit _ h.hp F
+  let g' : F.obj h.Q ⟶ F.obj S.X₃ := hp.desc (CokernelCofork.ofπ (S.map F).g (S.map F).zero)
+  have hg' : g' = F.map h.g' := by
+    apply Cofork.IsColimit.hom_ext hp
+    rw [Cofork.IsColimit.π_desc hp]
+    simp only [Cofork.π_ofπ, CokernelCofork.map_π, map_g, ← F.map_comp, p_g']
+  have wι : F.map h.ι ≫ g' = 0 := by rw [hg', ← F.map_comp, ι_g', F.map_zero]
+  have hι : IsLimit (KernelFork.ofι (F.map h.ι) wι) := by
+    let e : parallelPair g' 0 ≅ parallelPair (F.map h.g') 0 :=
+      parallelPair.ext (Iso.refl _) (Iso.refl _) (by simpa using hg') (by simp)
+    refine' IsLimit.postcomposeHomEquiv e _
+      (IsLimit.ofIsoLimit (KernelFork.mapIsLimit _ h.hι' F) _)
+    exact Fork.ext (Iso.refl _) (by simp)
+  exact
+    { Q := F.obj h.Q
+      H := F.obj h.H
+      p := F.map h.p
+      ι := F.map h.ι
+      wp := wp
+      hp := hp
+      wι := wι
+      hι := hι }
+
+@[simp]
+lemma map_g' : (h.map F).g' = F.map h.g' := by
+  rw [← cancel_epi (h.map F).p, p_g', map_g, map_p, ← F.map_comp, p_g']
+
+end RightHomologyData
+
+/-- Given a right homology map data `ψ : RightHomologyMapData φ h₁ h₂` such that
+both right homology data `h₁` and `h₂` are preserved by a functor `F`, this is
+the induced right homology map data for the morphism `F.mapShortComplex.map φ`. -/
+@[simps]
+def RightHomologyMapData.map {φ : S₁ ⟶ S₂} {h₁ : S₁.RightHomologyData}
+    {h₂ : S₂.RightHomologyData} (ψ : RightHomologyMapData φ h₁ h₂) (F : C ⥤ D)
+    [F.PreservesZeroMorphisms] [h₁.IsPreservedBy F] [h₂.IsPreservedBy F] :
+    RightHomologyMapData (F.mapShortComplex.map φ) (h₁.map F) (h₂.map F) where
+  φQ := F.map ψ.φQ
+  φH := F.map ψ.φH
+  commp := by simpa only [F.map_comp] using F.congr_map ψ.commp
+  commg' := by simpa only [RightHomologyData.map_g', F.map_comp] using F.congr_map ψ.commg'
+  commι := by simpa only [F.map_comp] using F.congr_map ψ.commι
+
+/-- When a homology data `h` of a short complex `S` is such that both `h.left` and
+`h.right` are preserved by a functor `F`, this is the induced homology data
+`h.map F` for the short complex `S.map F`. -/
+@[simps]
+noncomputable def HomologyData.map (h : S.HomologyData) (F : C ⥤ D) [F.PreservesZeroMorphisms]
+    [h.left.IsPreservedBy F] [h.right.IsPreservedBy F] :
+    (S.map F).HomologyData where
+  left := h.left.map F
+  right := h.right.map F
+  iso := F.mapIso h.iso
+  comm := by simpa only [F.map_comp] using F.congr_map h.comm
+
+/-- Given a homology map data `ψ : HomologyMapData φ h₁ h₂` such that
+`h₁.left`, `h₁.right`, `h₂.left` and `h₂.right` are all preserved by a functor `F`, this is
+the induced homology map data for the morphism `F.mapShortComplex.map φ`. -/
+@[simps]
+def HomologyMapData.map {φ : S₁ ⟶ S₂} {h₁ : S₁.HomologyData} {h₂ : S₂.HomologyData}
+    (ψ : HomologyMapData φ h₁ h₂) (F : C ⥤ D) [F.PreservesZeroMorphisms]
+    [h₁.left.IsPreservedBy F] [h₁.right.IsPreservedBy F]
+    [h₂.left.IsPreservedBy F] [h₂.right.IsPreservedBy F] :
+    HomologyMapData (F.mapShortComplex.map φ) (h₁.map F) (h₂.map F) where
+  left := ψ.left.map F
+  right := ψ.right.map F
+
+end ShortComplex
+
+namespace Functor
+
+variable (F : C ⥤ D) [PreservesZeroMorphisms F] (S : ShortComplex C) {S₁ S₂ : ShortComplex C}
+
+/-- A functor preserves the left homology of a short complex `S` if it preserves all the
+left homology data of `S`. -/
+class PreservesLeftHomologyOf where
+  /-- the functor preserves all the left homology data of the short complex -/
+  isPreservedBy : ∀ (h : S.LeftHomologyData), h.IsPreservedBy F
+
+/-- A functor preserves the right homology of a short complex `S` if it preserves all the
+right homology data of `S`. -/
+class PreservesRightHomologyOf where
+  /-- the functor preserves all the right homology data of the short complex -/
+  isPreservedBy : ∀ (h : S.RightHomologyData), h.IsPreservedBy F
+
+noncomputable instance PreservesHomology.preservesLeftHomologyOf [F.PreservesHomology] :
+    F.PreservesLeftHomologyOf S := ⟨inferInstance⟩
+
+noncomputable instance PreservesHomology.preservesRightHomologyOf [F.PreservesHomology] :
+    F.PreservesRightHomologyOf S := ⟨inferInstance⟩
+
+variable {S}
+
+/-- If a functor preserves a certain left homology data of a short complex `S`, then it
+preserves the left homology of `S`. -/
+def PreservesLeftHomologyOf.mk' (h : S.LeftHomologyData) [h.IsPreservedBy F] :
+    F.PreservesLeftHomologyOf S where
+  isPreservedBy h' :=
+    { g := ShortComplex.LeftHomologyData.IsPreservedBy.hg h F
+      f' := by
+        have := ShortComplex.LeftHomologyData.IsPreservedBy.hf' h F
+        let e : parallelPair h.f' 0 ≅ parallelPair h'.f' 0 :=
+          parallelPair.ext (Iso.refl _) (ShortComplex.cyclesMapIso' (Iso.refl S) h h')
+            (by simp) (by simp)
+        exact preservesColimitOfIsoDiagram F e }
+
+/-- If a functor preserves a certain right homology data of a short complex `S`, then it
+preserves the right homology of `S`. -/
+def PreservesRightHomologyOf.mk' (h : S.RightHomologyData) [h.IsPreservedBy F] :
+    F.PreservesRightHomologyOf S where
+  isPreservedBy h' :=
+    { f := ShortComplex.RightHomologyData.IsPreservedBy.hf h F
+      g' := by
+        let e : parallelPair h.g' 0 ≅ parallelPair h'.g' 0 :=
+          parallelPair.ext (ShortComplex.opcyclesMapIso' (Iso.refl S) h h') (Iso.refl _)
+            (by simp) (by simp)
+        have := ShortComplex.RightHomologyData.IsPreservedBy.hg' h F
+        exact preservesLimitOfIsoDiagram F e }
+
+end Functor
+
+namespace ShortComplex
+
+variable {S : ShortComplex C} (h₁ : S.LeftHomologyData) (h₂ : S.RightHomologyData)
+  (F : C ⥤ D) [F.PreservesZeroMorphisms]
+
+instance LeftHomologyData.isPreservedByOfPreserves [F.PreservesLeftHomologyOf S] :
+    h₁.IsPreservedBy F :=
+  Functor.PreservesLeftHomologyOf.isPreservedBy _
+
+instance RightHomologyData.isPreservedByOfPreserves [F.PreservesRightHomologyOf S] :
+    h₂.IsPreservedBy F :=
+  Functor.PreservesRightHomologyOf.isPreservedBy _
+
+variable (S)
+
+instance hasLeftHomology_of_preserves [S.HasLeftHomology] [F.PreservesLeftHomologyOf S] :
+    (S.map F).HasLeftHomology :=
+  HasLeftHomology.mk' (S.leftHomologyData.map F)
+
+instance hasLeftHomology_of_preserves' [S.HasLeftHomology] [F.PreservesLeftHomologyOf S] :
+    (F.mapShortComplex.obj S).HasLeftHomology :=
+  by dsimp; infer_instance
+
+instance hasRightHomology_of_preserves [S.HasRightHomology] [F.PreservesRightHomologyOf S] :
+    (S.map F).HasRightHomology :=
+  HasRightHomology.mk' (S.rightHomologyData.map F)
+
+instance hasRightHomology_of_preserves' [S.HasRightHomology] [F.PreservesRightHomologyOf S] :
+    (F.mapShortComplex.obj S).HasRightHomology :=
+  by dsimp; infer_instance
+
+instance hasHomology_of_preserves [S.HasHomology] [F.PreservesLeftHomologyOf S]
+    [F.PreservesRightHomologyOf S] :
+    (S.map F).HasHomology :=
+  HasHomology.mk' (S.homologyData.map F)
+
+instance hasHomology_of_preserves' [S.HasHomology] [F.PreservesLeftHomologyOf S]
+    [F.PreservesRightHomologyOf S] :
+    (F.mapShortComplex.obj S).HasHomology :=
+  by dsimp; infer_instance
+
 end ShortComplex
 
 end CategoryTheory


### PR DESCRIPTION
When a functor `F` preserves the homology of a short complex `S`, it is shown in this PR that there is an isomorphism `(S.map F).homology ≅ F.obj S.homology`.

---

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
