### PR TITLE
[Merged by Bors] - chore(Topology/GDelta.lean): rename type variables

### DIFF
--- a/Mathlib/Topology/GDelta.lean
+++ b/Mathlib/Topology/GDelta.lean
@@ -143,7 +143,7 @@ section T1Space
 
 variable [T1Space X]
 
-theorem isGδ_compl_singleton (a : X) : IsGδ ({a}ᶜ : Set X) :=
+theorem isGδ_compl_singleton (x : X) : IsGδ ({x}ᶜ : Set X) :=
   isOpen_compl_singleton.isGδ
 #align is_Gδ_compl_singleton isGδ_compl_singleton
 
@@ -166,8 +166,8 @@ theorem Finset.isGδ_compl (s : Finset X) : IsGδ (sᶜ : Set X) :=
 
 variable [FirstCountableTopology X]
 
-theorem isGδ_singleton (a : X) : IsGδ ({a} : Set X) := by
-  rcases (nhds_basis_opens a).exists_antitone_subbasis with ⟨U, hU, h_basis⟩
+theorem isGδ_singleton (x : X) : IsGδ ({x} : Set X) := by
+  rcases (nhds_basis_opens x).exists_antitone_subbasis with ⟨U, hU, h_basis⟩
   rw [← biInter_basis_nhds h_basis.toHasBasis]
   exact isGδ_biInter (to_countable _) fun n _ => (hU n).2.isGδ
 #align is_Gδ_singleton isGδ_singleton

--- a/Mathlib/Topology/GDelta.lean
+++ b/Mathlib/Topology/GDelta.lean
@@ -46,55 +46,55 @@ noncomputable section
 
 open Topology TopologicalSpace Filter Encodable Set
 
-variable {α β γ ι : Type*}
+variable {X Y ι : Type*}
 
 set_option linter.uppercaseLean3 false
 
 section IsGδ
 
-variable [TopologicalSpace α]
+variable [TopologicalSpace X]
 
 /-- A Gδ set is a countable intersection of open sets. -/
-def IsGδ (s : Set α) : Prop :=
-  ∃ T : Set (Set α), (∀ t ∈ T, IsOpen t) ∧ T.Countable ∧ s = ⋂₀ T
+def IsGδ (s : Set X) : Prop :=
+  ∃ T : Set (Set X), (∀ t ∈ T, IsOpen t) ∧ T.Countable ∧ s = ⋂₀ T
 #align is_Gδ IsGδ
 
 /-- An open set is a Gδ set. -/
-theorem IsOpen.isGδ {s : Set α} (h : IsOpen s) : IsGδ s :=
+theorem IsOpen.isGδ {s : Set X} (h : IsOpen s) : IsGδ s :=
   ⟨{s}, by simp [h], countable_singleton _, (Set.sInter_singleton _).symm⟩
 #align is_open.is_Gδ IsOpen.isGδ
 
 @[simp]
-theorem isGδ_empty : IsGδ (∅ : Set α) :=
+theorem isGδ_empty : IsGδ (∅ : Set X) :=
   isOpen_empty.isGδ
 #align is_Gδ_empty isGδ_empty
 
 @[simp]
-theorem isGδ_univ : IsGδ (univ : Set α) :=
+theorem isGδ_univ : IsGδ (univ : Set X) :=
   isOpen_univ.isGδ
 #align is_Gδ_univ isGδ_univ
 
-theorem isGδ_biInter_of_open {I : Set ι} (hI : I.Countable) {f : ι → Set α}
+theorem isGδ_biInter_of_open {I : Set ι} (hI : I.Countable) {f : ι → Set X}
     (hf : ∀ i ∈ I, IsOpen (f i)) : IsGδ (⋂ i ∈ I, f i) :=
   ⟨f '' I, by rwa [ball_image_iff], hI.image _, by rw [sInter_image]⟩
 #align is_Gδ_bInter_of_open isGδ_biInter_of_open
 
 -- porting note: TODO: generalize to `Sort*` + `Countable _`
-theorem isGδ_iInter_of_open [Encodable ι] {f : ι → Set α} (hf : ∀ i, IsOpen (f i)) :
+theorem isGδ_iInter_of_open [Encodable ι] {f : ι → Set X} (hf : ∀ i, IsOpen (f i)) :
     IsGδ (⋂ i, f i) :=
   ⟨range f, by rwa [forall_range_iff], countable_range _, by rw [sInter_range]⟩
 #align is_Gδ_Inter_of_open isGδ_iInter_of_open
 
 -- porting note: TODO: generalize to `Sort*` + `Countable _`
 /-- The intersection of an encodable family of Gδ sets is a Gδ set. -/
-theorem isGδ_iInter [Encodable ι] {s : ι → Set α} (hs : ∀ i, IsGδ (s i)) : IsGδ (⋂ i, s i) := by
+theorem isGδ_iInter [Encodable ι] {s : ι → Set X} (hs : ∀ i, IsGδ (s i)) : IsGδ (⋂ i, s i) := by
   choose T hTo hTc hTs using hs
   obtain rfl : s = fun i => ⋂₀ T i := funext hTs
   refine' ⟨⋃ i, T i, _, countable_iUnion hTc, (sInter_iUnion _).symm⟩
   simpa [@forall_swap ι] using hTo
 #align is_Gδ_Inter isGδ_iInter
 
-theorem isGδ_biInter {s : Set ι} (hs : s.Countable) {t : ∀ i ∈ s, Set α}
+theorem isGδ_biInter {s : Set ι} (hs : s.Countable) {t : ∀ i ∈ s, Set X}
     (ht : ∀ (i) (hi : i ∈ s), IsGδ (t i hi)) : IsGδ (⋂ i ∈ s, t i ‹_›) := by
   rw [biInter_eq_iInter]
   haveI := hs.toEncodable
@@ -102,17 +102,17 @@ theorem isGδ_biInter {s : Set ι} (hs : s.Countable) {t : ∀ i ∈ s, Set α}
 #align is_Gδ_bInter isGδ_biInter
 
 /-- A countable intersection of Gδ sets is a Gδ set. -/
-theorem isGδ_sInter {S : Set (Set α)} (h : ∀ s ∈ S, IsGδ s) (hS : S.Countable) : IsGδ (⋂₀ S) := by
+theorem isGδ_sInter {S : Set (Set X)} (h : ∀ s ∈ S, IsGδ s) (hS : S.Countable) : IsGδ (⋂₀ S) := by
   simpa only [sInter_eq_biInter] using isGδ_biInter hS h
 #align is_Gδ_sInter isGδ_sInter
 
-theorem IsGδ.inter {s t : Set α} (hs : IsGδ s) (ht : IsGδ t) : IsGδ (s ∩ t) := by
+theorem IsGδ.inter {s t : Set X} (hs : IsGδ s) (ht : IsGδ t) : IsGδ (s ∩ t) := by
   rw [inter_eq_iInter]
   exact isGδ_iInter (Bool.forall_bool.2 ⟨ht, hs⟩)
 #align is_Gδ.inter IsGδ.inter
 
 /-- The union of two Gδ sets is a Gδ set. -/
-theorem IsGδ.union {s t : Set α} (hs : IsGδ s) (ht : IsGδ t) : IsGδ (s ∪ t) := by
+theorem IsGδ.union {s t : Set X} (hs : IsGδ s) (ht : IsGδ t) : IsGδ (s ∪ t) := by
   rcases hs with ⟨S, Sopen, Scount, rfl⟩
   rcases ht with ⟨T, Topen, Tcount, rfl⟩
   rw [sInter_union_sInter]
@@ -123,17 +123,17 @@ theorem IsGδ.union {s t : Set α} (hs : IsGδ s) (ht : IsGδ t) : IsGδ (s ∪ 
 
 -- porting note: TODO: add `iUnion` and `sUnion` versions
 /-- The union of finitely many Gδ sets is a Gδ set. -/
-theorem isGδ_biUnion {s : Set ι} (hs : s.Finite) {f : ι → Set α} (h : ∀ i ∈ s, IsGδ (f i)) :
+theorem isGδ_biUnion {s : Set ι} (hs : s.Finite) {f : ι → Set X} (h : ∀ i ∈ s, IsGδ (f i)) :
     IsGδ (⋃ i ∈ s, f i) := by
   refine' Finite.induction_on hs (by simp) _ h
   simp only [ball_insert_iff, biUnion_insert]
   exact fun _ _ ihs H => H.1.union (ihs H.2)
 #align is_Gδ_bUnion isGδ_biUnion
 
--- Porting note: Did not recognize notation 𝓤 α, needed to replace with uniformity α
-theorem IsClosed.isGδ {α} [UniformSpace α] [IsCountablyGenerated (uniformity α)] {s : Set α}
+-- Porting note: Did not recognize notation 𝓤 X, needed to replace with uniformity X
+theorem IsClosed.isGδ {X} [UniformSpace X] [IsCountablyGenerated (uniformity X)] {s : Set X}
     (hs : IsClosed s) : IsGδ s := by
-  rcases(@uniformity_hasBasis_open α _).exists_antitone_subbasis with ⟨U, hUo, hU, -⟩
+  rcases(@uniformity_hasBasis_open X _).exists_antitone_subbasis with ⟨U, hUo, hU, -⟩
   rw [← hs.closure_eq, ← hU.biInter_biUnion_ball]
   refine' isGδ_biInter (to_countable _) fun n _ => IsOpen.isGδ _
   exact isOpen_biUnion fun x _ => UniformSpace.isOpen_ball _ (hUo _).2
@@ -141,38 +141,38 @@ theorem IsClosed.isGδ {α} [UniformSpace α] [IsCountablyGenerated (uniformity 
 
 section T1Space
 
-variable [T1Space α]
+variable [T1Space X]
 
-theorem isGδ_compl_singleton (a : α) : IsGδ ({a}ᶜ : Set α) :=
+theorem isGδ_compl_singleton (a : X) : IsGδ ({a}ᶜ : Set X) :=
   isOpen_compl_singleton.isGδ
 #align is_Gδ_compl_singleton isGδ_compl_singleton
 
-theorem Set.Countable.isGδ_compl {s : Set α} (hs : s.Countable) : IsGδ sᶜ := by
+theorem Set.Countable.isGδ_compl {s : Set X} (hs : s.Countable) : IsGδ sᶜ := by
   rw [← biUnion_of_singleton s, compl_iUnion₂]
   exact isGδ_biInter hs fun x _ => isGδ_compl_singleton x
 #align set.countable.is_Gδ_compl Set.Countable.isGδ_compl
 
-theorem Set.Finite.isGδ_compl {s : Set α} (hs : s.Finite) : IsGδ sᶜ :=
+theorem Set.Finite.isGδ_compl {s : Set X} (hs : s.Finite) : IsGδ sᶜ :=
   hs.countable.isGδ_compl
 #align set.finite.is_Gδ_compl Set.Finite.isGδ_compl
 
-theorem Set.Subsingleton.isGδ_compl {s : Set α} (hs : s.Subsingleton) : IsGδ sᶜ :=
+theorem Set.Subsingleton.isGδ_compl {s : Set X} (hs : s.Subsingleton) : IsGδ sᶜ :=
   hs.finite.isGδ_compl
 #align set.subsingleton.is_Gδ_compl Set.Subsingleton.isGδ_compl
 
-theorem Finset.isGδ_compl (s : Finset α) : IsGδ (sᶜ : Set α) :=
+theorem Finset.isGδ_compl (s : Finset X) : IsGδ (sᶜ : Set X) :=
   s.finite_toSet.isGδ_compl
 #align finset.is_Gδ_compl Finset.isGδ_compl
 
-variable [FirstCountableTopology α]
+variable [FirstCountableTopology X]
 
-theorem isGδ_singleton (a : α) : IsGδ ({a} : Set α) := by
+theorem isGδ_singleton (a : X) : IsGδ ({a} : Set X) := by
   rcases (nhds_basis_opens a).exists_antitone_subbasis with ⟨U, hU, h_basis⟩
   rw [← biInter_basis_nhds h_basis.toHasBasis]
   exact isGδ_biInter (to_countable _) fun n _ => (hU n).2.isGδ
 #align is_Gδ_singleton isGδ_singleton
 
-theorem Set.Finite.isGδ {s : Set α} (hs : s.Finite) : IsGδ s :=
+theorem Set.Finite.isGδ {s : Set X} (hs : s.Finite) : IsGδ s :=
   Finite.induction_on hs isGδ_empty fun _ _ hs => (isGδ_singleton _).union hs
 #align set.finite.is_Gδ Set.Finite.isGδ
 
@@ -182,12 +182,12 @@ end IsGδ
 
 section ContinuousAt
 
-variable [TopologicalSpace α]
+variable [TopologicalSpace X]
 
 /-- The set of points where a function is continuous is a Gδ set. -/
-theorem isGδ_setOf_continuousAt [UniformSpace β] [IsCountablyGenerated (uniformity β)] (f : α → β) :
+theorem isGδ_setOf_continuousAt [UniformSpace Y] [IsCountablyGenerated (uniformity Y)] (f : X → Y) :
     IsGδ { x | ContinuousAt f x } := by
-  obtain ⟨U, _, hU⟩ := (@uniformity_hasBasis_open_symmetric β _).exists_antitone_subbasis
+  obtain ⟨U, _, hU⟩ := (@uniformity_hasBasis_open_symmetric Y _).exists_antitone_subbasis
   simp only [Uniform.continuousAt_iff_prod, nhds_prod_eq]
   simp only [(nhds_basis_opens _).prod_self.tendsto_iff hU.toHasBasis, forall_prop_of_true,
     setOf_forall, id]
@@ -200,24 +200,24 @@ end ContinuousAt
 
 section residual
 
-variable [TopologicalSpace α]
+variable [TopologicalSpace X]
 
 /-- A set `s` is called *residual* if it includes a countable intersection of dense open sets. -/
-def residual (α : Type*) [TopologicalSpace α] : Filter α :=
+def residual (X : Type*) [TopologicalSpace X] : Filter X :=
   Filter.countableGenerate { t | IsOpen t ∧ Dense t }
 #align residual residual
 
-instance countableInterFilter_residual : CountableInterFilter (residual α) := by
+instance countableInterFilter_residual : CountableInterFilter (residual X) := by
   rw [residual]; infer_instance
 #align countable_Inter_filter_residual countableInterFilter_residual
 
 /-- Dense open sets are residual. -/
-theorem residual_of_dense_open {s : Set α} (ho : IsOpen s) (hd : Dense s) : s ∈ residual α :=
+theorem residual_of_dense_open {s : Set X} (ho : IsOpen s) (hd : Dense s) : s ∈ residual X :=
   CountableGenerateSets.basic ⟨ho, hd⟩
 #align residual_of_dense_open residual_of_dense_open
 
 /-- Dense Gδ sets are residual. -/
-theorem residual_of_dense_Gδ {s : Set α} (ho : IsGδ s) (hd : Dense s) : s ∈ residual α := by
+theorem residual_of_dense_Gδ {s : Set X} (ho : IsGδ s) (hd : Dense s) : s ∈ residual X := by
   rcases ho with ⟨T, To, Tct, rfl⟩
   exact
     (countable_sInter_mem Tct).mpr fun t tT =>
@@ -225,9 +225,9 @@ theorem residual_of_dense_Gδ {s : Set α} (ho : IsGδ s) (hd : Dense s) : s ∈
 #align residual_of_dense_Gδ residual_of_dense_Gδ
 
 /-- A set is residual iff it includes a countable intersection of dense open sets. -/
-theorem mem_residual_iff {s : Set α} :
-    s ∈ residual α ↔
-      ∃ S : Set (Set α), (∀ t ∈ S, IsOpen t) ∧ (∀ t ∈ S, Dense t) ∧ S.Countable ∧ ⋂₀ S ⊆ s :=
+theorem mem_residual_iff {s : Set X} :
+    s ∈ residual X ↔
+      ∃ S : Set (Set X), (∀ t ∈ S, IsOpen t) ∧ (∀ t ∈ S, Dense t) ∧ S.Countable ∧ ⋂₀ S ⊆ s :=
   mem_countableGenerate_iff.trans <| by simp_rw [subset_def, mem_setOf, forall_and, and_assoc]
 #align mem_residual_iff mem_residual_iff
 
@@ -235,61 +235,61 @@ end residual
 
 section meagre
 open Function TopologicalSpace Set
-variable {α : Type*} [TopologicalSpace α]
+variable {X : Type*} [TopologicalSpace X]
 
 /-- A set is called **nowhere dense** iff its closure has empty interior. -/
-def IsNowhereDense (s : Set α) := interior (closure s) = ∅
+def IsNowhereDense (s : Set X) := interior (closure s) = ∅
 
 /-- The empty set is nowhere dense. -/
 @[simp]
-lemma isNowhereDense_of_empty : IsNowhereDense (∅ : Set α) := by
+lemma isNowhereDense_of_empty : IsNowhereDense (∅ : Set X) := by
   rw [IsNowhereDense, closure_empty, interior_empty]
 
 /-- A closed set is nowhere dense iff its interior is empty. -/
-lemma IsClosed.isNowhereDense_iff {s : Set α} (hs : IsClosed s) :
+lemma IsClosed.isNowhereDense_iff {s : Set X} (hs : IsClosed s) :
     IsNowhereDense s ↔ interior s = ∅ := by
   rw [IsNowhereDense, IsClosed.closure_eq hs]
 
 /-- If a set `s` is nowhere dense, so is its closure.-/
-protected lemma IsNowhereDense.closure {s : Set α} (hs : IsNowhereDense s) :
+protected lemma IsNowhereDense.closure {s : Set X} (hs : IsNowhereDense s) :
     IsNowhereDense (closure s) := by
   rwa [IsNowhereDense, closure_closure]
 
 /-- A nowhere dense set `s` is contained in a closed nowhere dense set (namely, its closure). -/
-lemma IsNowhereDense.subset_of_closed_nowhereDense {s : Set α} (hs : IsNowhereDense s) :
-    ∃ t : Set α, s ⊆ t ∧ IsNowhereDense t ∧ IsClosed t :=
+lemma IsNowhereDense.subset_of_closed_nowhereDense {s : Set X} (hs : IsNowhereDense s) :
+    ∃ t : Set X, s ⊆ t ∧ IsNowhereDense t ∧ IsClosed t :=
   ⟨closure s, subset_closure, ⟨hs.closure, isClosed_closure⟩⟩
 
 /-- A set `s` is closed and nowhere dense iff its complement `sᶜ` is open and dense. -/
-lemma closed_isNowhereDense_iff_compl {s : Set α} :
+lemma closed_isNowhereDense_iff_compl {s : Set X} :
     IsClosed s ∧ IsNowhereDense s ↔ IsOpen sᶜ ∧ Dense sᶜ := by
   rw [and_congr_right IsClosed.isNowhereDense_iff,
     isOpen_compl_iff, interior_eq_empty_iff_dense_compl]
 
 /-- A set is called **meagre** iff its complement is a residual (or comeagre) set. -/
-def IsMeagre (s : Set α) := sᶜ ∈ residual α
+def IsMeagre (s : Set X) := sᶜ ∈ residual X
 
 /-- The empty set is meagre. -/
-lemma meagre_empty : IsMeagre (∅ : Set α) := by
+lemma meagre_empty : IsMeagre (∅ : Set X) := by
   rw [IsMeagre, compl_empty]
   exact Filter.univ_mem
 
 /-- Subsets of meagre sets are meagre. -/
-lemma IsMeagre.mono {s t : Set α} (hs : IsMeagre s) (hts: t ⊆ s) : IsMeagre t :=
+lemma IsMeagre.mono {s t : Set X} (hs : IsMeagre s) (hts: t ⊆ s) : IsMeagre t :=
   Filter.mem_of_superset hs (compl_subset_compl.mpr hts)
 
 /-- An intersection with a meagre set is meagre. -/
-lemma IsMeagre.inter {s t : Set α} (hs : IsMeagre s) : IsMeagre (s ∩ t) :=
+lemma IsMeagre.inter {s t : Set X} (hs : IsMeagre s) : IsMeagre (s ∩ t) :=
   hs.mono (inter_subset_left s t)
 
 /-- A countable union of meagre sets is meagre. -/
-lemma meagre_iUnion {s : ℕ → Set α} (hs : ∀ n, IsMeagre (s n)) : IsMeagre (⋃ n, s n) := by
+lemma meagre_iUnion {s : ℕ → Set X} (hs : ∀ n, IsMeagre (s n)) : IsMeagre (⋃ n, s n) := by
   rw [IsMeagre, compl_iUnion]
   exact countable_iInter_mem.mpr hs
 
 /-- A set is meagre iff it is contained in a countable union of nowhere dense sets. -/
-lemma meagre_iff_countable_union_nowhereDense {s : Set α} : IsMeagre s ↔
-    ∃ S : Set (Set α), (∀ t ∈ S, IsNowhereDense t) ∧ S.Countable ∧ s ⊆ ⋃₀ S := by
+lemma meagre_iff_countable_union_nowhereDense {s : Set X} : IsMeagre s ↔
+    ∃ S : Set (Set X), (∀ t ∈ S, IsNowhereDense t) ∧ S.Countable ∧ s ⊆ ⋃₀ S := by
   rw [IsMeagre, mem_residual_iff, compl_bijective.surjective.image_surjective.exists]
   simp_rw [← and_assoc, ← forall_and, ball_image_iff, ← closed_isNowhereDense_iff_compl,
     sInter_image, ← compl_iUnion₂, compl_subset_compl, ← sUnion_eq_biUnion, and_assoc]


### PR DESCRIPTION
Greek letters for topological spaces are outdated, use letters X, Y, Z instead.
[Zulip discussion](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Naming.20convention.3A.20topological.20spaces/near/395769893).

---------

I'm following my checklist [here](https://github.com/leanprover-community/mathlib4/pull/7589#issuecomment-1755212582).
Best reviewed commit by commit. (Before this change, the names X, Y or Z were not used in this file.)