### PR TITLE
chore (Topology): some universe tweaks

### DIFF
--- a/Mathlib/Topology/Basic.lean
+++ b/Mathlib/Topology/Basic.lean
@@ -58,7 +58,7 @@ noncomputable section
 
 open Set Filter
 
-universe u v w
+universe u
 
 /-!
 ### Topological spaces
@@ -95,7 +95,8 @@ def TopologicalSpace.ofClosed {α : Type u} (T : Set (Set α)) (empty_mem : ∅ 
 
 section TopologicalSpace
 
-variable {α : Type u} {β : Type v} {ι : Sort w} {a : α} {s s₁ s₂ t : Set α} {p p₁ p₂ : α → Prop}
+universe uα uβ
+variable {α : Type uα} {β : Type uβ} {ι : Sort w} {a : α} {s s₁ s₂ t : Set α} {p p₁ p₂ : α → Prop}
 
 /-- `IsOpen s` means that `s` is open in the ambient topological space on `α` -/
 def IsOpen [TopologicalSpace α] : Set α → Prop := TopologicalSpace.IsOpen

--- a/Mathlib/Topology/Clopen.lean
+++ b/Mathlib/Topology/Clopen.lean
@@ -20,9 +20,8 @@ A clopen set is a set that is both open and closed.
 
 open Set Filter Topology TopologicalSpace Classical
 
-universe u v
-
-variable {α : Type u} {β : Type v} {ι : Type*} {π : ι → Type*}
+universe uα uβ uι uπ
+variable {α : Type uα} {β : Type uβ} {ι : Type uι} {π : ι → Type uπ}
 
 variable [TopologicalSpace α] [TopologicalSpace β] {s t : Set α}
 

--- a/Mathlib/Topology/Compactness/Compact.lean
+++ b/Mathlib/Topology/Compactness/Compact.lean
@@ -30,9 +30,9 @@ We define the following properties for sets in a topological space:
 -/
 open Set Filter Topology TopologicalSpace Classical
 
-universe u v
+universe u v uβ uι
 
-variable {α : Type u} {β : Type v} {ι : Type*} {π : ι → Type*}
+variable {α : Type u} {β : Type uβ} {ι : Type uι} {π : ι → Type*}
 
 variable [TopologicalSpace α] [TopologicalSpace β] {s t : Set α}
 

--- a/Mathlib/Topology/Compactness/Paracompact.lean
+++ b/Mathlib/Topology/Compactness/Paracompact.lean
@@ -51,7 +51,7 @@ open Set Filter Function
 
 open Filter Topology
 
-universe u v w
+universe u v uι uy
 
 /-- A topological space is called paracompact, if every open covering of this space admits a locally
 finite refinement. We use the same universe for all types in the definition to avoid creating a
@@ -66,7 +66,7 @@ class ParacompactSpace (X : Type v) [TopologicalSpace X] : Prop where
         LocallyFinite t ∧ ∀ b, ∃ a, t b ⊆ s a
 #align paracompact_space ParacompactSpace
 
-variable {ι : Type u} {X : Type v} {Y : Type w} [TopologicalSpace X] [TopologicalSpace Y]
+variable {ι : Type uι} {X : Type v} {Y : Type uy} [TopologicalSpace X] [TopologicalSpace Y]
 
 /-- Any open cover of a paracompact space has a locally finite *precise* refinement, that is,
 one indexed on the same type with each open set contained in the corresponding original one. -/

--- a/Mathlib/Topology/Compactness/SigmaCompact.lean
+++ b/Mathlib/Topology/Compactness/SigmaCompact.lean
@@ -13,9 +13,8 @@ subspaces.
 -/
 open Set Filter Topology TopologicalSpace Classical
 
-universe u v
-
-variable {α : Type u} {β : Type v} {ι : Type*} {π : ι → Type*}
+universe u uα uβ uι uπ
+variable {α : Type uα} {β : Type uβ} {ι : Type uι} {π : ι → Type uπ}
 
 variable [TopologicalSpace α] [TopologicalSpace β] {s t : Set α}
 /-- A σ-compact space is a space that is the union of a countable collection of compact subspaces.

--- a/Mathlib/Topology/Connected.lean
+++ b/Mathlib/Topology/Connected.lean
@@ -45,9 +45,8 @@ https://ncatlab.org/nlab/show/too+simple+to+be+simple#relationship_to_biased_def
 open Set Function Topology TopologicalSpace Relation
 open scoped Classical
 
-universe u v
-
-variable {α : Type u} {β : Type v} {ι : Type*} {π : ι → Type*} [TopologicalSpace α]
+universe u uα uβ uι uπ
+variable {α : Type uα} {β : Type uβ} {ι : Type uι} {π : ι → Type uπ} [TopologicalSpace α]
   {s t u v : Set α}
 
 section Preconnected
@@ -1242,7 +1241,7 @@ section LocallyConnectedSpace
 of connected *open* sets. Note that it is equivalent to each point having a basis of connected
 (non necessarily open) sets but in a non-trivial way, so we choose this definition and prove the
 equivalence later in `locallyConnectedSpace_iff_connected_basis`. -/
-class LocallyConnectedSpace (α : Type*) [TopologicalSpace α] : Prop where
+class LocallyConnectedSpace (α : Type u) [TopologicalSpace α] : Prop where
   /-- Open connected neighborhoods form a basis of the neighborhoods filter. -/
   open_connected_basis : ∀ x, (𝓝 x).HasBasis (fun s : Set α => IsOpen s ∧ x ∈ s ∧ IsConnected s) id
 #align locally_connected_space LocallyConnectedSpace
@@ -1576,7 +1575,7 @@ end TotallySeparated
 section connectedComponentSetoid
 
 /-- The setoid of connected components of a topological space -/
-def connectedComponentSetoid (α : Type*) [TopologicalSpace α] : Setoid α :=
+def connectedComponentSetoid (α : Type u) [TopologicalSpace α] : Setoid α :=
   ⟨fun x y => connectedComponent x = connectedComponent y,
     ⟨fun x => by trivial, fun h1 => h1.symm, fun h1 h2 => h1.trans h2⟩⟩
 #align connected_component_setoid connectedComponentSetoid

--- a/Mathlib/Topology/ExtremallyDisconnected.lean
+++ b/Mathlib/Topology/ExtremallyDisconnected.lean
@@ -30,8 +30,6 @@ compact Hausdorff spaces.
 [Gleason, *Projective topological spaces*][gleason1958]
 -/
 
-set_option autoImplicit true
-
 noncomputable section
 
 open Classical Function Set
@@ -40,7 +38,7 @@ universe u
 
 section
 
-variable (X : Type u) [TopologicalSpace X]
+variable (X : Type u) [TopologicalSpace X] {ι : Type*}
 
 /-- An extremally disconnected topological space is a space
 in which the closure of every open set is open. -/
@@ -135,7 +133,7 @@ end
 
 section
 
-variable {A D E : Type u} [TopologicalSpace A] [TopologicalSpace D] [TopologicalSpace E]
+variable {A D E : Type*} [TopologicalSpace A] [TopologicalSpace D] [TopologicalSpace E]
 
 /-- Lemma 2.4 in [Gleason, *Projective topological spaces*][gleason1958]:
 a continuous surjection $\pi$ from a compact space $D$ to a Fréchet space $A$ restricts to

--- a/Mathlib/Topology/LocalExtr.lean
+++ b/Mathlib/Topology/LocalExtr.lean
@@ -32,10 +32,8 @@ Here is the list of statements specific to these two types of filters:
   `IsLocal* f a`.
 -/
 
-
-universe u v w x
-
-variable {α : Type u} {β : Type v} {γ : Type w} {δ : Type x} [TopologicalSpace α]
+universe uα uβ uγ uδ
+variable {α : Type uα} {β : Type uβ} {γ : Type uγ} {δ : Type uδ} [TopologicalSpace α]
 
 open Set Filter Topology
 
@@ -628,4 +626,3 @@ theorem Filter.EventuallyEq.isLocalExtr_iff {f g : α → β} {a : α} (heq : f 
 #align filter.eventually_eq.is_local_extr_iff Filter.EventuallyEq.isLocalExtr_iff
 
 end Eventually
-

--- a/Mathlib/Topology/MetricSpace/Lipschitz.lean
+++ b/Mathlib/Topology/MetricSpace/Lipschitz.lean
@@ -46,11 +46,10 @@ argument, and return `LipschitzWith (Real.toNNReal K) f`.
 
 set_option autoImplicit true
 
-universe u v w x
-
 open Filter Function Set Topology NNReal ENNReal Bornology
 
-variable {α : Type u} {β : Type v} {γ : Type w} {ι : Type x}
+universe uα uβ uγ uι
+variable {α : Type uα} {β : Type uβ} {γ : Type uγ} {ι : Type uι}
 
 /-- A function `f` is **Lipschitz continuous** with constant `K ≥ 0` if for all `x, y`
 we have `dist (f x) (f y) ≤ K * dist x y`. -/
@@ -231,7 +230,7 @@ theorem subtype_mk (hf : LipschitzWith K f) {p : β → Prop} (hp : ∀ x, p (f 
   hf
 #align lipschitz_with.subtype_mk LipschitzWith.subtype_mk
 
-protected theorem eval {α : ι → Type u} [∀ i, PseudoEMetricSpace (α i)] [Fintype ι] (i : ι) :
+protected theorem eval {α : ι → Type*} [∀ i, PseudoEMetricSpace (α i)] [Fintype ι] (i : ι) :
     LipschitzWith 1 (Function.eval i : (∀ i, α i) → α i) :=
   LipschitzWith.of_edist_le fun f g => by convert edist_le_pi_edist f g i
 #align lipschitz_with.eval LipschitzWith.eval

--- a/Mathlib/Topology/PartitionOfUnity.lean
+++ b/Mathlib/Topology/PartitionOfUnity.lean
@@ -75,8 +75,6 @@ partition of unity, bump function, Urysohn's lemma, normal space, paracompact sp
 -/
 
 
-universe u v
-
 open Function Set Filter
 
 open BigOperators Topology Classical
@@ -127,7 +125,8 @@ structure BumpCovering (ι X : Type*) [TopologicalSpace X] (s : Set X := univ) w
   eventuallyEq_one' : ∀ x ∈ s, ∃ i, toFun i =ᶠ[𝓝 x] 1
 #align bump_covering BumpCovering
 
-variable {ι : Type u} {X : Type v} [TopologicalSpace X]
+universe uι uX
+variable {ι : Type uι} {X : Type uX} [TopologicalSpace X]
 
 namespace PartitionOfUnity
 

--- a/Mathlib/Topology/ProperMap.lean
+++ b/Mathlib/Topology/ProperMap.lean
@@ -67,13 +67,11 @@ so don't hesitate to have a look!
 * [Stacks: Characterizing proper maps](https://stacks.math.columbia.edu/tag/005M)
 -/
 
-set_option autoImplicit true
-
 open Filter Topology Function Set
 open Prod (fst snd)
 
-
-
+universe u uX uY uZ uW uι
+variable {X : Type uX} {Y : Type uY} {Z : Type uZ} {W : Type uW} {ι : Type uι}
 variable [TopologicalSpace X] [TopologicalSpace Y] [TopologicalSpace Z] [TopologicalSpace W]
   {f : X → Y}
 
@@ -288,8 +286,7 @@ theorem IsProperMap.universally_closed (Z) [TopologicalSpace Z] (h : IsProperMap
 `(Prod.map f id : X × Filter X → Y × Filter X)` is closed. This is stronger than
 `isProperMap_iff_universally_closed` since it shows that there's only one space to check to get
 properness, but in most cases it doesn't matter. -/
-theorem isProperMap_iff_isClosedMap_filter {X : Type*} {Y : Type*} [TopologicalSpace X]
-    [TopologicalSpace Y] {f : X → Y} :
+theorem isProperMap_iff_isClosedMap_filter {f : X → Y} :
     IsProperMap f ↔ Continuous f ∧ IsClosedMap
       (Prod.map f id : X × Filter X → Y × Filter X) := by
   constructor <;> intro H
@@ -332,8 +329,7 @@ theorem isProperMap_iff_isClosedMap_filter {X : Type*} {Y : Type*} [TopologicalS
 `(Prod.map f id : X × Ultrafilter X → Y × Ultrafilter X)` is closed. This is stronger than
 `isProperMap_iff_universally_closed` since it shows that there's only one space to check to get
 properness, but in most cases it doesn't matter. -/
-theorem isProperMap_iff_isClosedMap_ultrafilter {X : Type*} {Y : Type*} [TopologicalSpace X]
-    [TopologicalSpace Y] {f : X → Y} :
+theorem isProperMap_iff_isClosedMap_ultrafilter {f : X → Y} :
     IsProperMap f ↔ Continuous f ∧ IsClosedMap
       (Prod.map f id : X × Ultrafilter X → Y × Ultrafilter X) := by
   -- The proof is basically the same as above.
@@ -360,8 +356,7 @@ have this restriction.
 
 This is taken as the definition of properness in
 [N. Bourbaki, *General Topology*][bourbaki1966]. -/
-theorem isProperMap_iff_universally_closed {X : Type u} {Y : Type*} [TopologicalSpace X]
-    [TopologicalSpace Y] {f : X → Y} :
+theorem isProperMap_iff_universally_closed {X : Type u} [TopologicalSpace X] {f : X → Y} :
     IsProperMap f ↔ Continuous f ∧ ∀ (Z : Type u) [TopologicalSpace Z],
       IsClosedMap (Prod.map f id : X × Z → Y × Z) := by
   constructor <;> intro H

--- a/Mathlib/Topology/ProperMap.lean
+++ b/Mathlib/Topology/ProperMap.lean
@@ -288,7 +288,7 @@ theorem IsProperMap.universally_closed (Z) [TopologicalSpace Z] (h : IsProperMap
 `(Prod.map f id : X × Filter X → Y × Filter X)` is closed. This is stronger than
 `isProperMap_iff_universally_closed` since it shows that there's only one space to check to get
 properness, but in most cases it doesn't matter. -/
-theorem isProperMap_iff_isClosedMap_filter {X : Type u} {Y : Type v} [TopologicalSpace X]
+theorem isProperMap_iff_isClosedMap_filter {X : Type*} {Y : Type*} [TopologicalSpace X]
     [TopologicalSpace Y] {f : X → Y} :
     IsProperMap f ↔ Continuous f ∧ IsClosedMap
       (Prod.map f id : X × Filter X → Y × Filter X) := by
@@ -332,7 +332,7 @@ theorem isProperMap_iff_isClosedMap_filter {X : Type u} {Y : Type v} [Topologica
 `(Prod.map f id : X × Ultrafilter X → Y × Ultrafilter X)` is closed. This is stronger than
 `isProperMap_iff_universally_closed` since it shows that there's only one space to check to get
 properness, but in most cases it doesn't matter. -/
-theorem isProperMap_iff_isClosedMap_ultrafilter {X : Type u} {Y : Type v} [TopologicalSpace X]
+theorem isProperMap_iff_isClosedMap_ultrafilter {X : Type*} {Y : Type*} [TopologicalSpace X]
     [TopologicalSpace Y] {f : X → Y} :
     IsProperMap f ↔ Continuous f ∧ IsClosedMap
       (Prod.map f id : X × Ultrafilter X → Y × Ultrafilter X) := by
@@ -360,7 +360,7 @@ have this restriction.
 
 This is taken as the definition of properness in
 [N. Bourbaki, *General Topology*][bourbaki1966]. -/
-theorem isProperMap_iff_universally_closed {X : Type u} {Y : Type v} [TopologicalSpace X]
+theorem isProperMap_iff_universally_closed {X : Type u} {Y : Type*} [TopologicalSpace X]
     [TopologicalSpace Y] {f : X → Y} :
     IsProperMap f ↔ Continuous f ∧ ∀ (Z : Type u) [TopologicalSpace Z],
       IsClosedMap (Prod.map f id : X × Z → Y × Z) := by

--- a/Mathlib/Topology/Separation.lean
+++ b/Mathlib/Topology/Separation.lean
@@ -91,9 +91,8 @@ https://en.wikipedia.org/wiki/Separation_axiom
 open Function Set Filter Topology TopologicalSpace
 open scoped Classical
 
-universe u v
-
-variable {α : Type u} {β : Type v} [TopologicalSpace α]
+universe u v uα uβ
+variable {α : Type uα} {β : Type uβ} [TopologicalSpace α]
 
 section Separation
 


### PR DESCRIPTION
Mostly giving universes explicit/nicer names.
In two files (`ExtremallyDisconnected` and `ProperMap`), remove autoImplicit true.
(My understanding is that this is desired; happy to revert otherwise.)