### PR TITLE
feat: making CategoryTheory.Preadditive.comp_zsmul a simp lemma

### DIFF
--- a/Mathlib/CategoryTheory/Preadditive/Basic.lean
+++ b/Mathlib/CategoryTheory/Preadditive/Basic.lean
@@ -163,18 +163,22 @@ theorem comp_neg : f ≫ (-g) = -f ≫ g :=
 theorem neg_comp_neg : (-f) ≫ (-g) = f ≫ g := by simp
 #align category_theory.preadditive.neg_comp_neg CategoryTheory.Preadditive.neg_comp_neg
 
+@[simp]
 theorem nsmul_comp (n : ℕ) : (n • f) ≫ g = n • f ≫ g :=
   map_nsmul (rightComp P g) n f
 #align category_theory.preadditive.nsmul_comp CategoryTheory.Preadditive.nsmul_comp
 
+@[simp]
 theorem comp_nsmul (n : ℕ) : f ≫ (n • g) = n • f ≫ g :=
   map_nsmul (leftComp R f) n g
 #align category_theory.preadditive.comp_nsmul CategoryTheory.Preadditive.comp_nsmul
 
+@[simp]
 theorem zsmul_comp (n : ℤ) : (n • f) ≫ g = n • f ≫ g :=
   map_zsmul (rightComp P g) n f
 #align category_theory.preadditive.zsmul_comp CategoryTheory.Preadditive.zsmul_comp
 
+@[simp]
 theorem comp_zsmul (n : ℤ) : f ≫ (n • g) = n • f ≫ g :=
   map_zsmul (leftComp R f) n g
 #align category_theory.preadditive.comp_zsmul CategoryTheory.Preadditive.comp_zsmul


### PR DESCRIPTION
In order to have better automation, this PR makes `CategoryTheory.Preadditive.comp_zsmul` and variants simp lemmas.

---

`Linear.comp_smul` and `Linear.smul_comp` are already simp lemmas, so that it should not be a problem.

Actually, the linter complains that `Preadditive.zsmul_comp` is a duplicate of `Linear.smul_comp`, so that if we want to use automation, we have to import `CategoryTheory.Linear.Basic`.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
