### PR TITLE
[Merged by Bors] - chore: remove unnecessary Subsingleton.elim from aesop_cat

### DIFF
--- a/Mathlib/CategoryTheory/Category/Basic.lean
+++ b/Mathlib/CategoryTheory/Category/Basic.lean
@@ -143,11 +143,6 @@ attribute [aesop safe tactic (rule_sets [CategoryTheory])] Std.Tactic.Ext.extCor
 -- We turn on the mathlib version of `rfl` inside `aesop_cat`.
 attribute [aesop safe tactic (rule_sets [CategoryTheory])] Mathlib.Tactic.rflTac
 
--- Porting note:
--- Workaround for issue discussed at https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/Failure.20of.20TC.20search.20in.20.60simp.60.20with.20.60etaExperiment.60.2E
--- now that etaExperiment is always on.
-attribute [aesop safe (rule_sets [CategoryTheory])] Subsingleton.elim
-
 /-- The typeclass `Category C` describes morphisms associated to objects of type `C`.
 The universe levels of the objects and morphisms are unconstrained, and will often need to be
 specified explicitly, as `Category.{v} C`. (See also `LargeCategory` and `SmallCategory`.)


### PR DESCRIPTION
I think this was a workaround that is no longer necessary. If CI disagrees I'll just close this.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
