### PR TITLE
feat: power up aesop with rfl/intro

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3147,6 +3147,7 @@ import Mathlib.SetTheory.ZFC.Basic
 import Mathlib.SetTheory.ZFC.Ordinal
 import Mathlib.Tactic
 import Mathlib.Tactic.Abel
+import Mathlib.Tactic.Aesop
 import Mathlib.Tactic.ApplyAt
 import Mathlib.Tactic.ApplyCongr
 import Mathlib.Tactic.ApplyFun

--- a/Mathlib/CategoryTheory/Category/Basic.lean
+++ b/Mathlib/CategoryTheory/Category/Basic.lean
@@ -77,15 +77,6 @@ Often, however, it's not even necessary to include the `.{v}`.
 If it is omitted a "free" universe will be used.
 -/
 
-namespace Std.Tactic.Ext
-open Lean Elab Tactic
-
-/-- A wrapper for `ext` that we can pass to `aesop`. -/
-def extCore' : TacticM Unit := do
-  evalTactic (← `(tactic| ext))
-
-end Std.Tactic.Ext
-
 universe v u
 
 namespace CategoryTheory
@@ -116,7 +107,7 @@ use in auto-params.
 -/
 macro (name := aesop_cat) "aesop_cat" c:Aesop.tactic_clause* : tactic =>
 `(tactic|
-  aesop $c* (options := { introsTransparency? := some .default, terminal := true })
+  aesop $c* (options := { terminal := true })
             (simp_options := { decide := true })
   (rule_sets [$(Lean.mkIdent `CategoryTheory):ident]))
 
@@ -125,7 +116,7 @@ We also use `aesop_cat?` to pass along a `Try this` suggestion when using `aesop
 -/
 macro (name := aesop_cat?) "aesop_cat?" c:Aesop.tactic_clause* : tactic =>
 `(tactic|
-  aesop? $c* (options := { introsTransparency? := some .default, terminal := true })
+  aesop? $c* (options := { terminal := true })
   (rule_sets [$(Lean.mkIdent `CategoryTheory):ident]))
 /--
 A variant of `aesop_cat` which does not fail when it is unable to solve the
@@ -134,15 +125,8 @@ nonterminal `simp`.
 -/
 macro (name := aesop_cat_nonterminal) "aesop_cat_nonterminal" c:Aesop.tactic_clause* : tactic =>
   `(tactic|
-    aesop $c* (options := { introsTransparency? := some .default, warnOnNonterminal := false })
+    aesop $c* (options := { warnOnNonterminal := false })
     (rule_sets [$(Lean.mkIdent `CategoryTheory):ident]))
-
-
--- We turn on `ext` inside `aesop_cat`.
-attribute [aesop safe tactic (rule_sets [CategoryTheory])] Std.Tactic.Ext.extCore'
-
--- We turn on the mathlib version of `rfl` inside `aesop_cat`.
-attribute [aesop safe tactic (rule_sets [CategoryTheory])] Mathlib.Tactic.rflTac
 
 -- Porting note:
 -- Workaround for issue discussed at https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/Failure.20of.20TC.20search.20in.20.60simp.60.20with.20.60etaExperiment.60.2E

--- a/Mathlib/CategoryTheory/Category/Init.lean
+++ b/Mathlib/CategoryTheory/Category/Init.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jannis Limperg
 -/
 
-import Aesop
+import Mathlib.Tactic.Aesop
 
 /-!
 # Category Theory Rule Set

--- a/Mathlib/Combinatorics/SimpleGraph/Init.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Init.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jannis Limperg
 -/
 
-import Aesop
+import Mathlib.Tactic.Aesop
 
 /-!
 # SimpleGraph Rule Set

--- a/Mathlib/Data/Option/Basic.lean
+++ b/Mathlib/Data/Option/Basic.lean
@@ -8,7 +8,7 @@ import Mathlib.Data.Option.Defs
 import Mathlib.Logic.IsEmpty
 import Mathlib.Logic.Relator
 import Mathlib.Util.CompileInductive
-import Aesop
+import Mathlib.Tactic.Aesop
 
 #align_import data.option.basic from "leanprover-community/mathlib"@"f340f229b1f461aa1c8ee11e0a172d0a3b301a4a"
 

--- a/Mathlib/Data/Sym/Sym2/Init.lean
+++ b/Mathlib/Data/Sym/Sym2/Init.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jannis Limperg
 -/
 
-import Aesop
+import Mathlib.Tactic.Aesop
 
 /-!
 # Sym2 Rule Set

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -1,4 +1,5 @@
 import Mathlib.Tactic.Abel
+import Mathlib.Tactic.Aesop
 import Mathlib.Tactic.ApplyAt
 import Mathlib.Tactic.ApplyCongr
 import Mathlib.Tactic.ApplyFun

--- a/Mathlib/Tactic/Aesop.lean
+++ b/Mathlib/Tactic/Aesop.lean
@@ -1,0 +1,28 @@
+/-
+Copyright (c) Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Scott Morrison
+-/
+import Aesop
+import Mathlib.Tactic.Relation.Rfl
+import Std.Tactic.Ext
+
+/-!
+# Configuration of `aesop` for Mathlib.
+
+We add `intro` as an unsafe rule (so it can be backtracked if it doesn't work out).
+Adding `intro` has the effect of allowing looking inside default transparency definitions for
+lambdas.
+
+We add Mathlib's version of `rfl`.
+-/
+
+open Lean Elab Tactic in
+def Aesop.intro : TacticM Unit := do evalTactic (← `(tactic| intro))
+
+-- We turn on `intro` inside `aesop` as an unsafe rule,
+-- so we can attempt introductions through default reducibility definitions.
+attribute [aesop unsafe tactic] Aesop.intro
+
+-- We turn on the mathlib version of `rfl` inside `aesop`.
+attribute [aesop safe tactic] Mathlib.Tactic.rflTac

--- a/Mathlib/Tactic/Common.lean
+++ b/Mathlib/Tactic/Common.lean
@@ -5,11 +5,11 @@ Authors: Scott Morrison
 -/
 
 -- First import Aesop and Qq
-import Aesop
 import Qq
 
 -- Now import all tactics defined in Mathlib that do not require theory files.
 import Mathlib.Mathport.Rename
+import Mathlib.Tactic.Aesop
 import Mathlib.Tactic.ApplyCongr
 -- ApplyFun imports `Mathlib.Order.Monotone.Basic`
 -- import Mathlib.Tactic.ApplyFun

--- a/Mathlib/Tactic/Continuity/Init.lean
+++ b/Mathlib/Tactic/Continuity/Init.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jannis Limperg
 -/
 
-import Aesop
+import Mathlib.Tactic.Aesop
 
 /-!
 # Continuity Rule Set

--- a/Mathlib/Tactic/Measurability/Init.lean
+++ b/Mathlib/Tactic/Measurability/Init.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Miyahara Kō
 -/
 
-import Aesop
+import Mathlib.Tactic.Aesop
 
 /-!
 # Measurability Rule Set

--- a/Mathlib/Topology/Sheaves/Init.lean
+++ b/Mathlib/Topology/Sheaves/Init.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jujian Zhang
 -/
 
-import Aesop
+import Mathlib.Tactic.Aesop
 
 /-!
 # Rule sets related to topological (pre)sheaves


### PR DESCRIPTION
I propose just powering up `aesop` in Mathlib with `intro` (marked `unsafe` so it can be backtracked), and Mathlib's `rfl`.

`intro` here enables looking through default transparency definitions for lambda; `tidy` used to do this.

I'll benchmark before anyone should take this as a serious proposal.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
