### PR TITLE
[Merged by Bors] - feat: add `peel` tactic

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3185,6 +3185,7 @@ import Mathlib.Tactic.NormNum.Result
 import Mathlib.Tactic.NthRewrite
 import Mathlib.Tactic.Observe
 import Mathlib.Tactic.PPWithUniv
+import Mathlib.Tactic.Peel
 import Mathlib.Tactic.PermuteGoals
 import Mathlib.Tactic.Polyrith
 import Mathlib.Tactic.Positivity

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -114,6 +114,7 @@ import Mathlib.Tactic.NormNum.Result
 import Mathlib.Tactic.NthRewrite
 import Mathlib.Tactic.Observe
 import Mathlib.Tactic.PPWithUniv
+import Mathlib.Tactic.Peel
 import Mathlib.Tactic.PermuteGoals
 import Mathlib.Tactic.Polyrith
 import Mathlib.Tactic.Positivity

--- a/Mathlib/Tactic/Peel.lean
+++ b/Mathlib/Tactic/Peel.lean
@@ -15,6 +15,10 @@ to introduce variables with the supplied names.
 
 Alternatively, one can provide a numeric argument as in `peel 4 h` which will peel 4 quantifiers off
 the expressions automatically name the introduced variables.
+
+In addition, the user may supply a term `e` via `... using e` in order to close the goal
+immediately. In particular, `peel h using e` is equivalent to `peel h; exact e`. The `using` syntax
+may be paired with any of the other features of `peel`.
 -/
 
 open Lean Expr Meta Elab Tactic Mathlib.Tactic
@@ -50,11 +54,15 @@ Note that in this example, `h` and the goal are logically equivalent statements,
 autoname the introduced variables, but they may be inaccessible. However, in this case the user must
 still introduce a single name such as `with h_peel` for the new hypothesis.
 
+In addition, the user may supply a term `e` via `... using e` in order to close the goal
+immediately. In particular, `peel h using e` is equivalent to `peel h; exact e`. The `using` syntax
+may be paired with any of the other features of `peel`.
+
 This tactic works by repeatedly applying `forall_imp`, `Exists.imp`, `Filter.Eventually.mp`,
 `Filter.Frequently.mp`, and `Filter.eventually_of_forall` and introducing the variables as these
 are applied.
 -/
-syntax (name := peel) "peel" (num)? (ppSpace colGt term) (withArgs)? : tactic
+syntax (name := peel) "peel" (num)? (ppSpace colGt term) (withArgs)? (usingArg)? : tactic
 
 private lemma and_imp_left_of_imp_imp {p q r : Prop} (h : r → p → q) : r ∧ p → r ∧ q := by tauto
 
@@ -158,3 +166,7 @@ elab_rules : tactic
   | `(tactic| peel $e:term) => withMainContext do peelArgs (← elabTerm e none) []
   | `(tactic| peel $e:term $h:withArgs) => withMainContext do
     peelArgs (← elabTerm e none) <| ((← getWithArgs h).map Syntax.getId).toList
+
+macro_rules
+  | `(tactic| peel $[$n:num]? $e:term $[$h:withArgs]? using $u:term) =>
+    `(tactic| peel $[$n:num]? $e:term $[$h:withArgs]?; exact $u)

--- a/Mathlib/Tactic/Peel.lean
+++ b/Mathlib/Tactic/Peel.lean
@@ -1,0 +1,137 @@
+/-
+Copyright (c) 2023 Jireh Loreaux. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jireh Loreaux
+-/
+import Mathlib.Order.Filter.Basic
+import Mathlib.Tactic.Basic
+
+/-!
+# The `peel` tactic
+
+`peel h with idents*` tries to apply `forall_imp` (or `Exists.imp`, or `Filter.Eventually.mp`,
+`Filter.Frequently.mp` and `Filter.eventually_of_forall`) with the argument `h` and uses `idents*`
+to introduce variables with the supplied names.
+-/
+
+open Lean Expr Meta Qq Elab Tactic
+
+private lemma and_imp_left_of_imp_imp {p q r : Prop} (h : r → p → q) : r ∧ p → r ∧ q := by tauto
+
+def peelQuantifier (goal : MVarId) (e : Expr) (n : Option Name := none) (n' : Option Name := none) :
+    MetaM (List MVarId) := goal.withContext do
+  let ty : Q(Prop) ← whnfR (← inferType e)
+  let target : Q(Prop) ← whnfR (← goal.getType)
+  let freshName ← mkFreshUserName `h_peel
+  unless (← isProp ty) && (← isProp target) do
+    return [goal]
+  match ty, target with
+    | .forallE _ t₁ b₁ _, .forallE n₂ t₂ b₂ c => do
+      unless ← isDefEq (← whnfR t₁) (← whnfR t₂) do
+        return [goal]
+      let all_imp ← mkFreshExprMVar <| ← withoutModifyingState <| withLocalDecl n₂ c t₂ fun x => do
+        mkForallFVars #[x] (← mkArrow (b₁.instantiate1 x) (b₂.instantiate1 x))
+      goal.assign (← mkAppM ``forall_imp #[all_imp, e])
+      let (_, new_goal) ← all_imp.mvarId!.introN 2 [n.getD n₂, n'.getD freshName]
+      return [new_goal]
+    | ~q(∃ x : $α₁, $p x), ~q(∃ x : $α₂, $q x) => do
+      unless ← isDefEq (← whnfR α₁) (← whnfR α₂) do
+        return [goal]
+      let p : Q($α₂ → Prop) := p
+      let e : Q(∃ x : $α₂, $p x) := e
+      let all_imp : Q(∀ x : $α₂, $p x → $q x) ← mkFreshExprMVar q(∀ x : $α₂, $p x → $q x)
+      goal.assign q(Exists.imp $all_imp $e)
+      let (_, new_goal) ← all_imp.mvarId!.introN 2 [n.getD `_, n'.getD freshName]
+      return [new_goal]
+    | ~q($r ∧ $p), ~q($r' ∧ $q) => do
+      unless ← isDefEq q($r) q($r') do
+        return [goal]
+      let and_imp : Q($r' → $p → $q) ← mkFreshExprMVar q($r' → $p → $q)
+      let e : Q($r' ∧ $p) := e
+      goal.assign q(and_imp_left_of_imp_imp $and_imp $e)
+      let (_, new_goal) ← and_imp.mvarId!.introN 2 [n.getD `_, n'.getD freshName]
+      return [new_goal]
+    | ~q(∀ᶠ (x : $α₁) in $f₁, $p x), ~q(∀ᶠ (x : $α₂) in $f₂, $q x) => do
+      unless (← isDefEq (← whnfR α₁) (← whnfR α₂)) && (← isDefEq (← whnfR f₁) (← whnfR f₂)) do
+        return [goal]
+      let p : Q($α₂ → Prop) := p
+      let e : Q(∀ᶠ (x : $α₂) in $f₂, $p x) := e
+      let all_imp : Q(∀ x : $α₂, $p x → $q x) ← mkFreshExprMVar q(∀ x : $α₂, $p x → $q x)
+      goal.assign q(Filter.Eventually.mp $e (Filter.eventually_of_forall $all_imp))
+      let (_, new_goal) ← all_imp.mvarId!.introN 2 [n.getD `_, n'.getD freshName]
+      return [new_goal]
+    | ~q(∃ᶠ (x : $α₁) in $f₁, $p x), ~q(∃ᶠ (x : $α₂) in $f₂, $q x) => do
+      unless (← isDefEq (← whnfR α₁) (← whnfR α₂)) && (← isDefEq (← whnfR f₁) (← whnfR f₂)) do
+        return [goal]
+      let p : Q($α₂ → Prop) := p
+      let e : Q(∃ᶠ (x : $α₂) in $f₂, $p x) := e
+      let all_imp : Q(∀ x : $α₂, $p x → $q x) ← mkFreshExprMVar q(∀ x : $α₂, $p x → $q x)
+      goal.assign q(Filter.Frequently.mp $e (Filter.eventually_of_forall $all_imp))
+      let (_, new_goal) ← all_imp.mvarId!.introN 2 [n.getD `_, n'.getD freshName]
+      return [new_goal]
+    | _, _ => do
+      return [goal]
+
+def peelTacAux (e : TSyntax `term) (n : Option (TSyntax `ident)) (n' : Option (TSyntax `ident)) :
+    TacticM Unit := withMainContext do
+  let e ← Elab.Term.elabTerm e none
+  match n, n' with
+    | .some n₁, .some n₂ => liftMetaTactic (peelQuantifier · e (.some n₂.getId) (.some n₁.getId))
+    | .none, .some n₂ => liftMetaTactic (peelQuantifier · e (.some n₂.getId))
+    | .some n₁, .none => liftMetaTactic (peelQuantifier · e (n' := .some n₁.getId))
+    | .none, .none => liftMetaTactic (peelQuantifier · e)
+
+
+/--
+Peels matching quantifiers off of a given term and the goal and introduces the relevant variables.
+
+Given `p q : ℕ → Prop`, `h : ∀ x, p x`, and a goal `⊢ : ∀ x, q x`, the tactic `peel h with h' x`
+will introduce `x : ℕ`, `h' : p x` into the context and the new goal will be `⊢ q x`. This works
+with `∃`, as well as `∀ᶠ` and `∃ᶠ`, and it can even be applied to a sequence of quantifiers. Note
+that this is a logically weaker setup, so using this tactic is not always feasible.
+
+For a more complex example, given a hypothesis and a goal:
+```
+h : ∀ ε > (0 : ℝ), ∃ N : ℕ, ∀ n ≥ N, 1 / (n + 1 : ℝ) < ε
+⊢ ∀ ε > (0 : ℝ), ∃ N : ℕ, ∀ n ≥ N, 1 / (n + 1 : ℝ) ≤ ε
+```
+(which differ only in `<`/`≤`), applying `peel h with h_peel ε hε N n hn` will yield a tactic state:
+```
+h : ∀ ε > (0 : ℝ), ∃ N : ℕ, ∀ n ≥ N, 1 / (n + 1 : ℝ) < ε
+ε : ℝ
+hε : 0 < ε
+N n : ℕ
+hn : N ≤ n
+h_peel : 1 / (n + 1 : ℝ) < ε
+⊢ 1 / (n + 1 : ℝ) ≤ ε
+```
+and the goal can be closed with `exact h_peel.le`.
+Note that in this example, `h` and the goal are logically equivalent statements, but `peel`
+*cannot* be immediately applied to show that the goal implies `h`.
+
+`peel` can take an optional numeric argument prior to the supplied hypothesis; in which case it will
+autoname the introduced variables, but they may be inaccessible. However, in this case the user must
+still introduce a single name such as `with h_peel` for the new hypothesis.
+
+This tactic works by repeatedly applying `forall_imp`, `Exists.imp`, `Filter.Eventually.mp`,
+`Filter.Frequently.mp`, and `Filter.eventually_of_forall` and introducing the variables as these
+are applied.
+-/
+syntax (name := peel) "peel" (num)? (ppSpace term) (Mathlib.Tactic.withArgs)? : tactic
+@[tactic peel] def peelTac : Tactic := fun stx => do
+  match stx with
+    | `(tactic| peel $e:term) => peelTacAux e .none .none
+    | `(tactic| peel $e:term with $n₁:ident) => peelTacAux e (.some n₁) .none
+    | `(tactic| peel $e:term with $n₁:ident $n₂:ident) => peelTacAux e (.some n₁) (.some n₂)
+    | `(tactic| peel $e:term with $n₁:ident $n₂:ident $n₃:ident*) =>
+        evalTactic (← `(tactic| peel $e:term with $n₁ $n₂; have h' := $n₁; clear $n₁;
+          peel h' with $n₁ $n₃:ident*; clear h'))
+    | `(tactic| peel $n:num $e:term with $h₁:ident) =>
+      match n.getNat with
+        | 0 => pure ()
+        | 1 => evalTactic (← `(tactic| peel $e:term with $h₁))
+        | k + 2 =>
+          let j := Syntax.mkNumLit <| toString (k + 1)
+          evalTactic (← `(tactic| peel $e:term with $h₁; have h' := $h₁; clear $h₁;
+            peel $j h' with $h₁; clear h'))
+    | _ => Elab.throwUnsupportedSyntax

--- a/Mathlib/Tactic/Peel.lean
+++ b/Mathlib/Tactic/Peel.lean
@@ -136,14 +136,14 @@ def peelQuantifier (goal : MVarId) (e : Expr) (n : Option Name := none) (n' : Op
 variables. The expression `e`, with quantifiers removed, is assigned the default name `this`. -/
 def peelNum (e : Expr) (n : Nat) : TacticM Unit := withMainContext do
   match n with
-  | 0 => pure ()
-  | 1 => let _ ← liftMetaTacticAux (peelQuantifier · e (n' := `this))
-  | n + 2 =>
-    let fvar? ← liftMetaTacticAux (peelQuantifier · e (n' := `this))
-    if let some fvarId := fvar? then
-      peelNum (.fvar fvarId) (n + 1)
-      let mvarId ← (← getMainGoal).clear fvarId
-      replaceMainGoal [mvarId]
+    | 0 => pure ()
+    | 1 => let _ ← liftMetaTacticAux (peelQuantifier · e (n' := `this))
+    | n + 2 =>
+      let fvar? ← liftMetaTacticAux (peelQuantifier · e (n' := `this))
+      if let some fvarId := fvar? then
+        peelNum (.fvar fvarId) (n + 1)
+        let mvarId ← (← getMainGoal).clear fvarId
+        replaceMainGoal [mvarId]
 
 /-- Given a list `l` of names, this continues to peel quantifiers off of the expression `e` and
 the main goal and introduces variables with the provided names until the list of names is exhausted.
@@ -151,15 +151,15 @@ Note: the first name in the list is used for the name of the expression `e` with
 removed. If `l` is empty, one quantifier is removed with the default name `this`. -/
 def peelArgs (e : Expr) (l : List Name) : TacticM Unit := withMainContext do
   match l with
-  | [] => let _ ← liftMetaTacticAux (peelQuantifier · e (n' := `this))
-  | [h] => let _ ← liftMetaTacticAux (peelQuantifier · e (n' := h))
-  | [h₁, h₂] => let _ ← liftMetaTacticAux (peelQuantifier · e h₂ h₁)
-  | h₁ :: h₂ :: h₃ :: hs =>
-    let fvar? ← liftMetaTacticAux (peelQuantifier · e h₂ h₁)
-    if let some fvarId := fvar? then
-      peelArgs (.fvar fvarId) (h₁ :: h₃ :: hs)
-      let mvarId ← (← getMainGoal).clear fvarId
-      replaceMainGoal [mvarId]
+    | [] => let _ ← liftMetaTacticAux (peelQuantifier · e (n' := `this))
+    | [h] => let _ ← liftMetaTacticAux (peelQuantifier · e (n' := h))
+    | [h₁, h₂] => let _ ← liftMetaTacticAux (peelQuantifier · e h₂ h₁)
+    | h₁ :: h₂ :: h₃ :: hs =>
+      let fvar? ← liftMetaTacticAux (peelQuantifier · e h₂ h₁)
+      if let some fvarId := fvar? then
+        peelArgs (.fvar fvarId) (h₁ :: h₃ :: hs)
+        let mvarId ← (← getMainGoal).clear fvarId
+        replaceMainGoal [mvarId]
 
 elab_rules : tactic
   | `(tactic| peel $n:num $e:term) => withMainContext do peelNum (← elabTerm e none) n.getNat

--- a/Mathlib/Tactic/Peel.lean
+++ b/Mathlib/Tactic/Peel.lean
@@ -172,11 +172,13 @@ private lemma Filter.frequently_congr {α : Type*} {f : Filter α} {p : α → P
   all_goals refine (Frequently.mp · (h.mono fun _ => ?_))
   exacts [Iff.mp, Iff.mpr]
 
+/-- Peel off a single quantifier from an `↔`. -/
 def peelIffAux : TacticM Unit := withMainContext do
   evalTactic (← `(tactic|
     apply_rules [forall_congr', exists_congr, Filter.eventually_congr,
       Filter.eventually_of_forall, Filter.frequently_congr]))
 
+/-- Peel off `n` quantifiers from an `↔`. -/
 def peelNumIff (n : Nat) : TacticM Unit := withMainContext do
   match n with
     | 0 => pure ()
@@ -187,6 +189,8 @@ def peelNumIff (n : Nat) : TacticM Unit := withMainContext do
       replaceMainGoal [new_goal]
       peelNumIff n
 
+/-- Peel off quantifiers from an `↔` and assign the names given in `l` to the introduced
+variables. -/
 def peelArgsIff (l : List Name) : TacticM Unit := withMainContext do
   match l with
     | [] => pure ()

--- a/Mathlib/Tactic/Peel.lean
+++ b/Mathlib/Tactic/Peel.lean
@@ -54,7 +54,12 @@ Note that in this example, `h` and the goal are logically equivalent statements,
 autoname the introduced variables, but they may be inaccessible. However, in this case the user must
 still introduce a single name such as `with h_peel` for the new hypothesis.
 
-In addition, the user may supply a term `e` via `... using e` in order to close the goal
+In addition, `peel` supports goals of the form `(∀ x, p x) ↔ ∀ x, q x`, or likewise for any
+other quantifier. In this case, there is no hypothesis or term to supply, but otherwise the syntax
+is the same. So for such goals, the syntax is `peel 1` or `peel with x`, and after which the
+resulting goal is `p x ↔ q x`.
+
+Finally, the user may supply a term `e` via `... using e` in order to close the goal
 immediately. In particular, `peel h using e` is equivalent to `peel h; exact e`. The `using` syntax
 may be paired with any of the other features of `peel`.
 
@@ -62,7 +67,7 @@ This tactic works by repeatedly applying `forall_imp`, `Exists.imp`, `Filter.Eve
 `Filter.Frequently.mp`, and `Filter.eventually_of_forall` and introducing the variables as these
 are applied.
 -/
-syntax (name := peel) "peel" (num)? (ppSpace colGt term) (withArgs)? (usingArg)? : tactic
+syntax (name := peel) "peel" (num)? (ppSpace colGt term)? (withArgs)? (usingArg)? : tactic
 
 private lemma and_imp_left_of_imp_imp {p q r : Prop} (h : r → p → q) : r ∧ p → r ∧ q := by tauto
 
@@ -161,12 +166,46 @@ def peelArgs (e : Expr) (l : List Name) : TacticM Unit := withMainContext do
         let mvarId ← (← getMainGoal).clear fvarId
         replaceMainGoal [mvarId]
 
+private lemma Filter.frequently_congr {α : Type*} {f : Filter α} {p : α → Prop} {q : α → Prop}
+    (h : ∀ᶠ (x : α) in f, p x ↔ q x) : (∃ᶠ (x : α) in f, p x) ↔ ∃ᶠ (x : α) in f, q x := by
+  constructor
+  all_goals refine (Frequently.mp · (h.mono fun _ => ?_))
+  exacts [Iff.mp, Iff.mpr]
+
+def peelIffAux : TacticM Unit := withMainContext do
+  evalTactic (← `(tactic|
+    apply_rules [forall_congr', exists_congr, Filter.eventually_congr,
+      Filter.eventually_of_forall, Filter.frequently_congr]))
+
+def peelNumIff (n : Nat) : TacticM Unit := withMainContext do
+  match n with
+    | 0 => pure ()
+    | n + 1 =>
+      peelIffAux
+      let goal ← getMainGoal
+      let (_, new_goal) ← goal.intro1P
+      replaceMainGoal [new_goal]
+      peelNumIff n
+
+def peelArgsIff (l : List Name) : TacticM Unit := withMainContext do
+  match l with
+    | [] => pure ()
+    | h :: hs =>
+      peelIffAux
+      let goal ← getMainGoal
+      let (_, new_goal) ← goal.intro h
+      replaceMainGoal [new_goal]
+      peelArgsIff hs
+
 elab_rules : tactic
   | `(tactic| peel $n:num $e:term) => withMainContext do peelNum (← elabTerm e none) n.getNat
   | `(tactic| peel $e:term) => withMainContext do peelArgs (← elabTerm e none) []
   | `(tactic| peel $e:term $h:withArgs) => withMainContext do
     peelArgs (← elabTerm e none) <| ((← getWithArgs h).map Syntax.getId).toList
+  | `(tactic| peel $n:num) => peelNumIff n.getNat
+  | `(tactic| peel $h:withArgs) => withMainContext do
+    peelArgsIff ((← getWithArgs h).map Syntax.getId).toList
 
 macro_rules
-  | `(tactic| peel $[$n:num]? $e:term $[$h:withArgs]? using $u:term) =>
-    `(tactic| peel $[$n:num]? $e:term $[$h:withArgs]?; exact $u)
+  | `(tactic| peel $[$n:num]? $[$e:term]? $[$h:withArgs]? using $u:term) =>
+    `(tactic| peel $[$n:num]? $[$e:term]? $[$h:withArgs]?; exact $u)

--- a/Mathlib/Tactic/Peel.lean
+++ b/Mathlib/Tactic/Peel.lean
@@ -57,7 +57,9 @@ still introduce a single name such as `with h_peel` for the new hypothesis.
 In addition, `peel` supports goals of the form `(∀ x, p x) ↔ ∀ x, q x`, or likewise for any
 other quantifier. In this case, there is no hypothesis or term to supply, but otherwise the syntax
 is the same. So for such goals, the syntax is `peel 1` or `peel with x`, and after which the
-resulting goal is `p x ↔ q x`.
+resulting goal is `p x ↔ q x`. The `congr!` tactic also applies to goals of this form, but `peel`
+supports them both because it is simple to do so, and for pedagogical purposes. Moreover, since
+`peel` *only* applies to quantifiers, its behavior is a bit more predictable.
 
 Finally, the user may supply a term `e` via `... using e` in order to close the goal
 immediately. In particular, `peel h using e` is equivalent to `peel h; exact e`. The `using` syntax

--- a/Mathlib/Tactic/Peel.lean
+++ b/Mathlib/Tactic/Peel.lean
@@ -97,6 +97,14 @@ private theorem frequently_imp {α : Type*} {p q : α → Prop} {f : Filter α}
     (hq : ∀ (x : α), p x → q x) (hp : ∃ᶠ (x : α) in f, p x) : ∃ᶠ (x : α) in f, q x :=
   Filter.Frequently.mp hp (Filter.eventually_of_forall hq)
 
+private theorem eventually_congr {α : Type*} {p q : α → Prop} {f : Filter α}
+    (hq : ∀ (x : α), p x ↔ q x) : (∀ᶠ (x : α) in f, p x) ↔ ∀ᶠ (x : α) in f, q x := by
+  congr! 2; exact hq _
+
+private theorem frequently_congr {α : Type*} {p q : α → Prop} {f : Filter α}
+    (hq : ∀ (x : α), p x ↔ q x) : (∃ᶠ (x : α) in f, p x) ↔ ∃ᶠ (x : α) in f, q x := by
+  congr! 2; exact hq _
+
 /-- The list of constants that are regarded as being quantifiers. -/
 def quantifiers : List Name :=
   [``Exists, ``And, ``Filter.Eventually, ``Filter.Frequently]
@@ -194,14 +202,6 @@ partial def peelUnbounded (e : Expr) (n? : Option Name) (unfold : Bool := false)
     return true
   else
     return false
-
-private theorem eventually_congr {α : Type*} {p q : α → Prop} {f : Filter α}
-    (hq : ∀ (x : α), p x ↔ q x) : (∀ᶠ (x : α) in f, p x) ↔ ∀ᶠ (x : α) in f, q x := by
-  congr! 2; exact hq _
-
-private theorem frequently_congr {α : Type*} {p q : α → Prop} {f : Filter α}
-    (hq : ∀ (x : α), p x ↔ q x) : (∃ᶠ (x : α) in f, p x) ↔ ∃ᶠ (x : α) in f, q x := by
-  congr! 2; exact hq _
 
 /-- Peel off a single quantifier from an `↔`. -/
 def peelIffAux : TacticM Unit := do

--- a/Mathlib/Tactic/Peel.lean
+++ b/Mathlib/Tactic/Peel.lean
@@ -85,9 +85,9 @@ def peelQuantifier (goal : MVarId) (e : Expr) (n : Option Name := none) (n' : Op
     MetaM (Option FVarId × List MVarId) := goal.withContext do
   let ty ← whnfR (← inferType e)
   let target ← whnfR (← goal.getType)
-  let freshName ← mkFreshUserName `h_peel
+  let n' ← n'.getDM (mkFreshUserName `h_peel)
   unless (← isProp ty) && (← isProp target) do
-    return (.none, [goal])
+    return (none, [goal])
   match ty.getAppFnArgs, target.getAppFnArgs with
     | (``Exists, #[_, .lam _ t₁ b₁ _]), (``Exists, #[_, .lam n₂ t₂ b₂ c]) =>
       unless ← isDefEq t₁ t₂ do
@@ -127,7 +127,7 @@ def peelQuantifier (goal : MVarId) (e : Expr) (n : Option Name := none) (n' : Op
     | _, _ =>
       match ty, target with
         | .forallE _ t₁ b₁ _, .forallE n₂ t₂ b₂ c => do
-          unless ← isDefEq (← whnfR t₁) (← whnfR t₂) do
+          unless ← isDefEq t₁ t₂ do
             return (.none, [goal])
           let all_imp ← mkFreshExprMVar <| ← withoutModifyingState <|
             withLocalDecl n₂ c t₂ fun x => do

--- a/Mathlib/Tactic/Peel.lean
+++ b/Mathlib/Tactic/Peel.lean
@@ -89,10 +89,12 @@ def peelQuantifier (goal : MVarId) (e : Expr) (n : Option Name := none) (n' : Op
   let target ← whnfR (← goal.getType)
   let n' ← n'.getDM (mkFreshUserName `h_peel)
   unless (← isProp ty) && (← isProp target) do
+    logError m!"either {← ppExpr ty} or {← ppExpr target} is not a proposition"
     return (none, [goal])
   match ty.getAppFnArgs, target.getAppFnArgs with
     | (``Exists, #[_, .lam _ t₁ b₁ _]), (``Exists, #[_, .lam n₂ t₂ b₂ c]) =>
       unless ← isDefEq t₁ t₂ do
+        logError m!"{← ppExpr t₁} and {← ppExpr t₂} are not definitionally equal"
         return (none, [goal])
       let all_imp ← mkFreshExprMVar <| ← withLocalDecl n₂ c t₂ fun x => do
         mkForallFVars #[x] (← mkArrow (b₁.instantiate1 x) (b₂.instantiate1 x))
@@ -101,6 +103,7 @@ def peelQuantifier (goal : MVarId) (e : Expr) (n : Option Name := none) (n' : Op
       return (fvars[1]!, [new_goal])
     | (``And, #[r₁, p]), (``And, #[r₂, q]) =>
       unless ← isDefEq r₁ r₂ do
+        logError m!"{← ppExpr r₁} and {← ppExpr r₂} are not definitionally equal"
         return (none, [goal])
       let and_imp ← mkFreshExprMVar <| ← mkArrow r₂ (← mkArrow p q)
       goal.assign (← mkAppM ``and_imp_left_of_imp_imp #[and_imp, e])
@@ -109,6 +112,7 @@ def peelQuantifier (goal : MVarId) (e : Expr) (n : Option Name := none) (n' : Op
     | (``Filter.Eventually, #[_, .lam _ _ b₁ _, f₁]),
         (``Filter.Eventually, #[_, .lam n₂ t₂ b₂ c, f₂]) =>
       unless ← isDefEq f₁ f₂ do
+        logError m!"{← ppExpr f₁} and {← ppExpr f₂} are not definitionally equal"
         return (none, [goal])
       let all_imp ← mkFreshExprMVar <| ← withoutModifyingState <| withLocalDecl n₂ c t₂ fun x => do
         mkForallFVars #[x] (← mkArrow (b₁.instantiate1 x) (b₂.instantiate1 x))
@@ -119,6 +123,7 @@ def peelQuantifier (goal : MVarId) (e : Expr) (n : Option Name := none) (n' : Op
     | (``Filter.Frequently, #[_, .lam _ _ b₁ _, f₁]),
         (``Filter.Frequently, #[_, .lam n₂ t₂ b₂ c, f₂]) =>
       unless ← isDefEq f₁ f₂ do
+        logError m!"{← ppExpr f₁} and {← ppExpr f₂} are not definitionally equal"
         return (none, [goal])
       let all_imp ← mkFreshExprMVar <| ← withoutModifyingState <| withLocalDecl n₂ c t₂ fun x => do
         mkForallFVars #[x] (← mkArrow (b₁.instantiate1 x) (b₂.instantiate1 x))
@@ -137,7 +142,9 @@ def peelQuantifier (goal : MVarId) (e : Expr) (n : Option Name := none) (n' : Op
           goal.assign (← mkAppM ``forall_imp #[all_imp, e])
           let (fvars, new_goal) ← all_imp.mvarId!.introN 2 [n.getD n₂, n']
           return (fvars[1]!, [new_goal])
-        | _, _ => return (none, [goal])
+        | _, _ => do
+          logError m!"could not match {← ppExpr ty} and {← ppExpr target} as quantified expressions"
+          return (none, [goal])
 
 /-- Peels `n` quantifiers off the expression `e` and the main goal without naming the introduced
 variables. The expression `e`, with quantifiers removed, is assigned the default name `this`. -/

--- a/Mathlib/Tactic/Peel.lean
+++ b/Mathlib/Tactic/Peel.lean
@@ -57,7 +57,9 @@ still introduce a single name such as `with h_peel` for the new hypothesis.
 In addition, `peel` supports goals of the form `(∀ x, p x) ↔ ∀ x, q x`, or likewise for any
 other quantifier. In this case, there is no hypothesis or term to supply, but otherwise the syntax
 is the same. So for such goals, the syntax is `peel 1` or `peel with x`, and after which the
-resulting goal is `p x ↔ q x`. The `congr!` tactic can also be applied to goals of this form using `congr! 1 with x`. While `congr!` applies congruence lemmas in general, `peel` can be relied upon to only apply to outermost quantifiers.
+resulting goal is `p x ↔ q x`. The `congr!` tactic can also be applied to goals of this form using
+`congr! 1 with x`. While `congr!` applies congruence lemmas in general, `peel` can be relied upon
+to only apply to outermost quantifiers.
 
 Finally, the user may supply a term `e` via `... using e` in order to close the goal
 immediately. In particular, `peel h using e` is equivalent to `peel h; exact e`. The `using` syntax

--- a/Mathlib/Tactic/Peel.lean
+++ b/Mathlib/Tactic/Peel.lean
@@ -93,51 +93,51 @@ def peelQuantifier (goal : MVarId) (e : Expr) (n : Option Name := none) (n' : Op
   match ty.getAppFnArgs, target.getAppFnArgs with
     | (``Exists, #[_, .lam _ t₁ b₁ _]), (``Exists, #[_, .lam n₂ t₂ b₂ c]) =>
       unless ← isDefEq t₁ t₂ do
-        return (.none, [goal])
+        return (none, [goal])
       let all_imp ← mkFreshExprMVar <| ← withoutModifyingState <| withLocalDecl n₂ c t₂ fun x => do
         mkForallFVars #[x] (← mkArrow (b₁.instantiate1 x) (b₂.instantiate1 x))
       goal.assign (← mkAppM ``Exists.imp #[all_imp, e])
-      let (fvars, new_goal) ← all_imp.mvarId!.introN 2 [n.getD n₂, n'.getD freshName]
+      let (fvars, new_goal) ← all_imp.mvarId!.introN 2 [n.getD n₂, n']
       return (fvars[1]!, [new_goal])
     | (``And, #[r₁, p]), (``And, #[r₂, q]) =>
       unless ← isDefEq r₁ r₂ do
-        return (.none, [goal])
+        return (none, [goal])
       let and_imp ← mkFreshExprMVar <| ← mkArrow r₂ (← mkArrow p q)
       goal.assign (← mkAppM ``and_imp_left_of_imp_imp #[and_imp, e])
-      let (fvars, new_goal) ← and_imp.mvarId!.introN 2 [n.getD `_, n'.getD freshName]
+      let (fvars, new_goal) ← and_imp.mvarId!.introN 2 [n.getD `_, n']
       return (fvars[1]!, [new_goal])
     | (``Filter.Eventually, #[_, .lam _ _ b₁ _, f₁]),
         (``Filter.Eventually, #[_, .lam n₂ t₂ b₂ c, f₂]) =>
       unless ← isDefEq f₁ f₂ do
-        return (.none, [goal])
+        return (none, [goal])
       let all_imp ← mkFreshExprMVar <| ← withoutModifyingState <| withLocalDecl n₂ c t₂ fun x => do
         mkForallFVars #[x] (← mkArrow (b₁.instantiate1 x) (b₂.instantiate1 x))
       let event_forall ← mkAppOptM ``Filter.eventually_of_forall #[none, none, f₂, all_imp]
       goal.assign (← mkAppM ``Filter.Eventually.mp #[e, event_forall])
-      let (fvars, new_goal) ← all_imp.mvarId!.introN 2 [n.getD n₂, n'.getD freshName]
+      let (fvars, new_goal) ← all_imp.mvarId!.introN 2 [n.getD n₂, n']
       return (fvars[1]!, [new_goal])
     | (``Filter.Frequently, #[_, .lam _ _ b₁ _, f₁]),
         (``Filter.Frequently, #[_, .lam n₂ t₂ b₂ c, f₂]) =>
       unless ← isDefEq f₁ f₂ do
-        return (.none, [goal])
+        return (none, [goal])
       let all_imp ← mkFreshExprMVar <| ← withoutModifyingState <| withLocalDecl n₂ c t₂ fun x => do
         mkForallFVars #[x] (← mkArrow (b₁.instantiate1 x) (b₂.instantiate1 x))
       let event_forall ← mkAppOptM ``Filter.eventually_of_forall #[none, none, f₂, all_imp]
       goal.assign (← mkAppM ``Filter.Frequently.mp #[e, event_forall])
-      let (fvars, new_goal) ← all_imp.mvarId!.introN 2 [n.getD n₂, n'.getD freshName]
+      let (fvars, new_goal) ← all_imp.mvarId!.introN 2 [n.getD n₂, n']
       return (fvars[1]!, [new_goal])
     | _, _ =>
       match ty, target with
         | .forallE _ t₁ b₁ _, .forallE n₂ t₂ b₂ c => do
           unless ← isDefEq t₁ t₂ do
-            return (.none, [goal])
+            return (none, [goal])
           let all_imp ← mkFreshExprMVar <| ← withoutModifyingState <|
             withLocalDecl n₂ c t₂ fun x => do
               mkForallFVars #[x] (← mkArrow (b₁.instantiate1 x) (b₂.instantiate1 x))
           goal.assign (← mkAppM ``forall_imp #[all_imp, e])
-          let (fvars, new_goal) ← all_imp.mvarId!.introN 2 [n.getD n₂, n'.getD freshName]
+          let (fvars, new_goal) ← all_imp.mvarId!.introN 2 [n.getD n₂, n']
           return (fvars[1]!, [new_goal])
-        | _, _ => return (.none, [goal])
+        | _, _ => return (none, [goal])
 
 /-- Peels `n` quantifiers off the expression `e` and the main goal without naming the introduced
 variables. The expression `e`, with quantifiers removed, is assigned the default name `this`. -/

--- a/Mathlib/Tactic/Peel.lean
+++ b/Mathlib/Tactic/Peel.lean
@@ -223,7 +223,9 @@ def peelArgsIff (l : List Name) : TacticM Unit := withMainContext do
 
 elab_rules : tactic
   | `(tactic| peel $[$num?:num]? $e:term $[with $n? $l?*]?) => withMainContext do
-    let e ← elabTerm e none
+    /- we use `elabTermForApply` instead of `elabTerm` so that terms passed to `peel` can contain
+    quantifiers with implicit bound variables without causing errors or requiring `@`.  -/
+    let e ← elabTermForApply e false
     let n? := n?.bind fun n => if n.raw.isIdent then pure n.raw.getId else none
     let l := (l?.getD #[]).map getNameOfIdent' |>.toList
     -- If num is not present and if there are any provided variable names,

--- a/Mathlib/Tactic/Peel.lean
+++ b/Mathlib/Tactic/Peel.lean
@@ -13,8 +13,8 @@ import Mathlib.Tactic.Basic
 `Filter.Frequently.mp` and `Filter.eventually_of_forall`) with the argument `h` and uses `idents*`
 to introduce variables with the supplied names, giving the "peeled" argument the name `h'`.
 
-Alternatively, one can provide a numeric argument as in `peel 4 h` which will peel 4 quantifiers off
-the expressions automatically name the introduced variables.
+One can provide a numeric argument as in `peel 4 h` which will peel 4 quantifiers off
+the expressions automatically name any variables not specifically named in the `with` clause.
 
 In addition, the user may supply a term `e` via `... using e` in order to close the goal
 immediately. In particular, `peel h using e` is equivalent to `peel h; exact e`. The `using` syntax
@@ -65,9 +65,6 @@ h_peel : 1 / (n + 1 : ℝ) < ε
 and the goal can be closed with `exact h_peel.le`.
 Note that in this example, `h` and the goal are logically equivalent statements, but `peel`
 *cannot* be immediately applied to show that the goal implies `h`.
-
-`peel` can take an optional numeric argument prior to the supplied hypothesis; in which case it will
-autoname the introduced variables, but they will be inaccessible.
 
 In addition, `peel` supports goals of the form `(∀ x, p x) ↔ ∀ x, q x`, or likewise for any
 other quantifier. In this case, there is no hypothesis or term to supply, but otherwise the syntax

--- a/Mathlib/Tactic/Peel.lean
+++ b/Mathlib/Tactic/Peel.lean
@@ -57,9 +57,7 @@ still introduce a single name such as `with h_peel` for the new hypothesis.
 In addition, `peel` supports goals of the form `(∀ x, p x) ↔ ∀ x, q x`, or likewise for any
 other quantifier. In this case, there is no hypothesis or term to supply, but otherwise the syntax
 is the same. So for such goals, the syntax is `peel 1` or `peel with x`, and after which the
-resulting goal is `p x ↔ q x`. The `congr!` tactic also applies to goals of this form, but `peel`
-supports them both because it is simple to do so, and for pedagogical purposes. Moreover, since
-`peel` *only* applies to quantifiers, its behavior is a bit more predictable.
+resulting goal is `p x ↔ q x`. The `congr!` tactic can also be applied to goals of this form using `congr! 1 with x`. While `congr!` applies congruence lemmas in general, `peel` can be relied upon to only apply to outermost quantifiers.
 
 Finally, the user may supply a term `e` via `... using e` in order to close the goal
 immediately. In particular, `peel h using e` is equivalent to `peel h; exact e`. The `using` syntax

--- a/Mathlib/Tactic/Peel.lean
+++ b/Mathlib/Tactic/Peel.lean
@@ -94,7 +94,7 @@ def peelQuantifier (goal : MVarId) (e : Expr) (n : Option Name := none) (n' : Op
   match ty.getAppFnArgs, target.getAppFnArgs with
     | (``Exists, #[_, .lam _ t₁ b₁ _]), (``Exists, #[_, .lam n₂ t₂ b₂ c]) =>
       unless ← isDefEq t₁ t₂ do
-        logError m!"{← ppExpr t₁} and {← ppExpr t₂} are not definitionally equal"
+        logError m!"matched ∃, but {← ppExpr t₁} and {← ppExpr t₂} are not definitionally equal"
         return (none, [goal])
       let all_imp ← mkFreshExprMVar <| ← withLocalDecl n₂ c t₂ fun x => do
         mkForallFVars #[x] (← mkArrow (b₁.instantiate1 x) (b₂.instantiate1 x))
@@ -103,7 +103,7 @@ def peelQuantifier (goal : MVarId) (e : Expr) (n : Option Name := none) (n' : Op
       return (fvars[1]!, [new_goal])
     | (``And, #[r₁, p]), (``And, #[r₂, q]) =>
       unless ← isDefEq r₁ r₂ do
-        logError m!"{← ppExpr r₁} and {← ppExpr r₂} are not definitionally equal"
+        logError m!"matched ∧, but {← ppExpr r₁} and {← ppExpr r₂} are not definitionally equal"
         return (none, [goal])
       let and_imp ← mkFreshExprMVar <| ← mkArrow r₂ (← mkArrow p q)
       goal.assign (← mkAppM ``and_imp_left_of_imp_imp #[and_imp, e])
@@ -112,7 +112,7 @@ def peelQuantifier (goal : MVarId) (e : Expr) (n : Option Name := none) (n' : Op
     | (``Filter.Eventually, #[_, .lam _ _ b₁ _, f₁]),
         (``Filter.Eventually, #[_, .lam n₂ t₂ b₂ c, f₂]) =>
       unless ← isDefEq f₁ f₂ do
-        logError m!"{← ppExpr f₁} and {← ppExpr f₂} are not definitionally equal"
+        logError m!"matched ∀ᶠ, but {← ppExpr f₁} and {← ppExpr f₂} are not definitionally equal"
         return (none, [goal])
       let all_imp ← mkFreshExprMVar <| ← withoutModifyingState <| withLocalDecl n₂ c t₂ fun x => do
         mkForallFVars #[x] (← mkArrow (b₁.instantiate1 x) (b₂.instantiate1 x))
@@ -123,7 +123,7 @@ def peelQuantifier (goal : MVarId) (e : Expr) (n : Option Name := none) (n' : Op
     | (``Filter.Frequently, #[_, .lam _ _ b₁ _, f₁]),
         (``Filter.Frequently, #[_, .lam n₂ t₂ b₂ c, f₂]) =>
       unless ← isDefEq f₁ f₂ do
-        logError m!"{← ppExpr f₁} and {← ppExpr f₂} are not definitionally equal"
+        logError m!"matched ∃ᶠ, but {← ppExpr f₁} and {← ppExpr f₂} are not definitionally equal"
         return (none, [goal])
       let all_imp ← mkFreshExprMVar <| ← withoutModifyingState <| withLocalDecl n₂ c t₂ fun x => do
         mkForallFVars #[x] (← mkArrow (b₁.instantiate1 x) (b₂.instantiate1 x))
@@ -135,6 +135,7 @@ def peelQuantifier (goal : MVarId) (e : Expr) (n : Option Name := none) (n' : Op
       match ty, target with
         | .forallE _ t₁ b₁ _, .forallE n₂ t₂ b₂ c => do
           unless ← isDefEq t₁ t₂ do
+            logError m!"matched ∀, but {← ppExpr t₁} and {← ppExpr t₂} are not definitionally equal"
             return (none, [goal])
           let all_imp ← mkFreshExprMVar <| ← withoutModifyingState <|
             withLocalDecl n₂ c t₂ fun x => do

--- a/Mathlib/Tactic/Peel.lean
+++ b/Mathlib/Tactic/Peel.lean
@@ -94,7 +94,7 @@ def peelQuantifier (goal : MVarId) (e : Expr) (n : Option Name := none) (n' : Op
     | (``Exists, #[_, .lam _ t₁ b₁ _]), (``Exists, #[_, .lam n₂ t₂ b₂ c]) =>
       unless ← isDefEq t₁ t₂ do
         return (none, [goal])
-      let all_imp ← mkFreshExprMVar <| ← withoutModifyingState <| withLocalDecl n₂ c t₂ fun x => do
+      let all_imp ← mkFreshExprMVar <| ← withLocalDecl n₂ c t₂ fun x => do
         mkForallFVars #[x] (← mkArrow (b₁.instantiate1 x) (b₂.instantiate1 x))
       goal.assign (← mkAppM ``Exists.imp #[all_imp, e])
       let (fvars, new_goal) ← all_imp.mvarId!.introN 2 [n.getD n₂, n']

--- a/test/peel.lean
+++ b/test/peel.lean
@@ -68,6 +68,22 @@ example (x y : ℚ) (h : ∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N, x + n = y + ε) :
   peel 3 (h ε hε)
   linarith
 
+example (x y : ℝ) : (∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N, x + n = y + ε) ↔
+    ∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N, x - ε = y  - n := by
+  peel with ε hε N n hn
+  constructor
+  all_goals
+    intro
+    linarith
+
+example (x y : ℝ) : (∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N, x + n = y + ε) ↔
+    ∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N, x - ε = y  - n := by
+  peel 5
+  constructor
+  all_goals
+    intro
+    linarith
+
 example : (∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N, 1 / (n + 1 : ℚ) < ε) ↔
     ∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N, 1 / (n + 1 : ℚ) ≤ ε := by
   refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩

--- a/test/peel.lean
+++ b/test/peel.lean
@@ -3,6 +3,38 @@ import Mathlib.Topology.Instances.Real
 
 open Filter Topology
 
+example (p q : Nat → Prop) (h₁ : ∀ x, p x) (h₂ : ∀ x, p x → q x) : ∀ y, q y := by
+  peel 1 h₁
+  exact h₂ _ this
+
+example (p q : Nat → Nat → Prop) (h₁ : ∀ x y, p x y) (h₂ : ∀ x y, p x y → q x y) :
+    ∀ u v, q u v := by
+  peel 2 h₁
+  exact h₂ _ _ this
+
+example (p q : Nat → Prop) (h₁ : ∀ x, p x) (h₂ : ∀ x, p x → q x) : ∀ y, q y := by
+  peel h₁
+  exact h₂ _ this
+
+example (p q : Nat → Nat → Prop) (h₁ : ∀ x y, p x y) (h₂ : ∀ x y, p x y → q x y) :
+    ∀ u v, q u v := by
+  peel h₁
+  peel this
+  exact h₂ _ _ this
+
+example (p q : Nat → Prop) (h₁ : ∀ x, p x) (h₂ : ∀ x, p x → q x) : ∀ y, q y := by
+  peel h₁ with foo
+  exact h₂ _ foo
+
+example (p q : Nat → Prop) (h₁ : ∀ x, p x) (h₂ : ∀ x, p x → q x) : ∀ y, q y := by
+  peel h₁ with foo w
+  exact h₂ w foo
+
+example (p q : Nat → Nat → Prop) (h₁ : ∀ x y, p x y) (h₂ : ∀ x y, p x y → q x y) :
+    ∀ u v, q u v := by
+  peel h₁ with h_peel s t
+  exact h₂ s t h_peel
+
 example (p q : Nat → Prop) (h : ∀ y, p y) (h₁ : ∀ z, p z → q z) : ∀ x, q x := by
   peel h
   exact h₁ _ <| by assumption
@@ -25,17 +57,17 @@ example (p q : ℝ → ℝ → Prop) (h : ∀ ε > 0, ∃ δ > 0, p ε δ)
 example (x y : ℚ) (h : ∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N, x + n = y + ε) :
     ∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N, x - ε = y  - n := by
   intro ε hε
-  peel 3 (h ε hε) with h_peel
+  peel 3 (h ε hε)
   linarith
 
 example : (∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N, 1 / (n + 1 : ℚ) < ε) ↔
     ∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N, 1 / (n + 1 : ℚ) ≤ ε := by
   refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
-  · peel 5 h with h'
-    exact h'.le
+  · peel 5 h
+    exact this.le
   · intro ε hε
-    peel 3 h (ε / 2) (half_pos hε) with h'
-    exact h'.trans_lt (half_lt_self hε)
+    peel 3 h (ε / 2) (half_pos hε)
+    exact this.trans_lt (half_lt_self hε)
 
 example {f : ℝ → ℝ} (h : ∀ x : ℝ, ∀ᶠ y in 𝓝 x, |f y - f x| ≤ |y - x|) :
     ∀ x : ℝ, ∀ᶠ y in 𝓝 x, |f y - f x| ^ 2 ≤ |y - x| ^ 2 := by

--- a/test/peel.lean
+++ b/test/peel.lean
@@ -98,3 +98,16 @@ example (α : Type*) (f : Filter α) (p q : α → Prop) (h : ∀ᶠ x in f, p x
     ∀ᶠ x in f, q x := by
   peel h with h_peel x
   exact h₁ x h_peel
+
+example {R : Type*} [CommRing R] (h : ∀ x : R, ∃ y : R, x + y = 2) :
+    ∀ x : R, ∃ y : R, (x + y) ^ 2 = 4 := by
+  peel 2 h
+  rw [this]
+  ring
+
+example {G : Type*} [Group G] [TopologicalSpace G] [TopologicalGroup G]
+    (h : ∀ᶠ x in 𝓝 (1 : G), ∃ᶠ y in 𝓝 x, x * y⁻¹ = 1) :
+    ∀ᶠ x in 𝓝 (1 : G), ∃ᶠ y in 𝓝 x, x ^ 2 = y ^ 2 := by
+  peel h with h_peel a b
+  observe : a = b⁻¹⁻¹
+  simp [this]

--- a/test/peel.lean
+++ b/test/peel.lean
@@ -16,6 +16,9 @@ example (p q : Nat → Prop) (h₁ : ∀ x, p x) (h₂ : ∀ x, p x → q x) : �
   peel h₁
   exact h₂ _ this
 
+example (p q : Nat → Prop) (h₁ : ∀ x, p x) (h₂ : ∀ x, p x → q x) : ∀ y, q y := by
+  peel h₁ using h₂ _ this
+
 example (p q : Nat → Nat → Prop) (h₁ : ∀ x y, p x y) (h₂ : ∀ x y, p x y → q x y) :
     ∀ u v, q u v := by
   peel h₁
@@ -54,6 +57,11 @@ example (p q : ℝ → ℝ → Prop) (h : ∀ ε > 0, ∃ δ > 0, p ε δ)
   peel h with h ε hε δ hδ
   exact hpq ε δ hε hδ h
 
+example (p q : ℝ → ℝ → Prop) (h : ∀ ε > 0, ∃ δ > 0, p ε δ)
+    (hpq : ∀ x y, x > 0 → y > 0 → p x y → q x y) :
+    ∀ ε > 0, ∃ δ > 0, q ε δ := by
+  peel h with h ε hε δ hδ using hpq ε δ hε hδ h
+
 example (x y : ℚ) (h : ∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N, x + n = y + ε) :
     ∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N, x - ε = y  - n := by
   intro ε hε
@@ -68,6 +76,13 @@ example : (∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N, 1 / (n + 1 : ℚ) < ε) ↔
   · intro ε hε
     peel 3 h (ε / 2) (half_pos hε)
     exact this.trans_lt (half_lt_self hε)
+
+example : (∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N, 1 / (n + 1 : ℚ) < ε) ↔
+    ∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N, 1 / (n + 1 : ℚ) ≤ ε := by
+  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
+  · peel 5 h using this.le
+  · intro ε hε
+    peel 3 h (ε / 2) (half_pos hε) using this.trans_lt (half_lt_self hε)
 
 example {f : ℝ → ℝ} (h : ∀ x : ℝ, ∀ᶠ y in 𝓝 x, |f y - f x| ≤ |y - x|) :
     ∀ x : ℝ, ∀ᶠ y in 𝓝 x, |f y - f x| ^ 2 ≤ |y - x| ^ 2 := by

--- a/test/peel.lean
+++ b/test/peel.lean
@@ -1,0 +1,53 @@
+import Mathlib.Tactic.Peel
+import Mathlib.Topology.Instances.Real
+
+open Filter Topology
+
+example (p q : Nat → Prop) (h : ∀ y, p y) (h₁ : ∀ z, p z → q z) : ∀ x, q x := by
+  peel h
+  exact h₁ _ <| by assumption
+
+example (p q : Nat → Prop) (h : ∃ y, p y) (h₁ : ∀ z, p z → q z) : ∃ x, q x := by
+  peel h with h x
+  exact h₁ x h
+
+example (x y : ℝ) (h : ∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N, x + n = y + ε) :
+    ∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N, x - ε = y  - n := by
+  peel h with h_peel ε hε N n hn
+  linarith
+
+example (p q : ℝ → ℝ → Prop) (h : ∀ ε > 0, ∃ δ > 0, p ε δ)
+    (hpq : ∀ x y, x > 0 → y > 0 → p x y → q x y) :
+    ∀ ε > 0, ∃ δ > 0, q ε δ := by
+  peel h with h ε hε δ hδ
+  exact hpq ε δ hε hδ h
+
+example (x y : ℚ) (h : ∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N, x + n = y + ε) :
+    ∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N, x - ε = y  - n := by
+  intro ε hε
+  peel 3 (h ε hε) with h_peel
+  linarith
+
+example : (∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N, 1 / (n + 1 : ℚ) < ε) ↔
+    ∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N, 1 / (n + 1 : ℚ) ≤ ε := by
+  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
+  · peel 5 h with h'
+    exact h'.le
+  · intro ε hε
+    peel 3 h (ε / 2) (half_pos hε) with h'
+    exact h'.trans_lt (half_lt_self hε)
+
+example {f : ℝ → ℝ} (h : ∀ x : ℝ, ∀ᶠ y in 𝓝 x, |f y - f x| ≤ |y - x|) :
+    ∀ x : ℝ, ∀ᶠ y in 𝓝 x, |f y - f x| ^ 2 ≤ |y - x| ^ 2 := by
+  peel h with h_peel x y
+  gcongr
+
+example (α : Type*) (f g : Filter α) (p q : α → α → Prop) (h : ∀ᶠ x in f, ∃ᶠ y in g, p x y)
+    (h₁ : ∀ x y, p x y → q x y) : ∀ᶠ x in f, ∃ᶠ y in g, q x y := by
+  peel h with h_peel x y
+  exact h₁ x y h_peel
+
+example (α : Type*) (f : Filter α) (p q : α → Prop) (h : ∀ᶠ x in f, p x) (h₁ : ∀ x, p x → q x) :
+    ∀ᶠ x in f, q x := by
+  peel h with h_peel x
+  exact h₁ x h_peel

--- a/test/peel.lean
+++ b/test/peel.lean
@@ -11,7 +11,13 @@ example (p q : Nat → Prop) (h₁ : ∀ x, p x) (h₂ : ∀ x, p x → q x) : �
   guard_target =ₐ q y
   exact h₂ _ this
 
-example (p q : Nat → Nat → Prop) (h₁ : ∀ x y, p x y) (h₂ : ∀ x y, p x y → q x y) :
+example (p q : Nat → Prop) (h₁ : ∀ {x}, p x) (h₂ : ∀ x, p x → q x) : ∀ y, q y := by
+  peel 1 h₁
+  rename_i y
+  guard_target =ₐ q y
+  exact h₂ _ this
+
+example (p q : Nat → Nat → Prop) (h₁ : ∀ {x y}, p x y) (h₂ : ∀ x y, p x y → q x y) :
     ∀ u v, q u v := by
   peel 2 h₁
   rename_i u v

--- a/test/peel.lean
+++ b/test/peel.lean
@@ -183,6 +183,22 @@ example {G : Type*} [Group G] [TopologicalSpace G] [TopologicalGroup G]
   observe : a = b⁻¹⁻¹
   simp [this]
 
+/-! ## Unfolding definitions -/
+
+example {α β γ : Type*} {f : α → β} {g : β → γ} (h : Function.Injective (g ∘ f)) :
+    Function.Injective f := by
+  peel 2 h with _ x y
+  intro hf
+  apply this
+  congrm(g $hf)
+
+example {α β γ : Type*} {f : α → β} {g : β → γ} (h : Function.Surjective (g ∘ f)) :
+    Function.Surjective g := by
+  peel 1 h with _ y
+  fail_if_success peel this
+  obtain ⟨x, rfl⟩ := this
+  exact ⟨f x, rfl⟩
+
 /-! ## Error messages -/
 
 /--

--- a/test/peel.lean
+++ b/test/peel.lean
@@ -7,17 +7,20 @@ open Filter Topology
 
 example (p q : Nat → Prop) (h₁ : ∀ x, p x) (h₂ : ∀ x, p x → q x) : ∀ y, q y := by
   peel 1 h₁
+  rename_i y
   guard_target =ₐ q y
   exact h₂ _ this
 
 example (p q : Nat → Nat → Prop) (h₁ : ∀ x y, p x y) (h₂ : ∀ x y, p x y → q x y) :
     ∀ u v, q u v := by
   peel 2 h₁
+  rename_i u v
   guard_target =ₐ q u v
   exact h₂ _ _ this
 
 example (p q : Nat → Prop) (h₁ : ∀ x, p x) (h₂ : ∀ x, p x → q x) : ∀ y, q y := by
   peel h₁
+  rename_i y
   guard_target =ₐ q y
   exact h₂ _ this
 
@@ -27,12 +30,13 @@ example (p q : Nat → Prop) (h₁ : ∀ x, p x) (h₂ : ∀ x, p x → q x) : �
 example (p q : Nat → Nat → Prop) (h₁ : ∀ x y, p x y) (h₂ : ∀ x y, p x y → q x y) :
     ∀ u v, q u v := by
   peel h₁
-  peel this
+  rename_i u v
   guard_target =ₐ q u v
   exact h₂ _ _ this
 
 example (p q : Nat → Prop) (h₁ : ∀ x, p x) (h₂ : ∀ x, p x → q x) : ∀ y, q y := by
   peel h₁ with foo
+  rename_i y
   guard_target =ₐ q y
   exact h₂ _ foo
 
@@ -49,6 +53,7 @@ example (p q : Nat → Nat → Prop) (h₁ : ∀ x y, p x y) (h₂ : ∀ x y, p 
 
 example (p q : Nat → Prop) (h : ∀ y, p y) (h₁ : ∀ z, p z → q z) : ∀ x, q x := by
   peel h
+  rename_i x
   guard_target =ₐ q x
   exact h₁ _ <| by assumption
 
@@ -66,9 +71,9 @@ example (x y : ℝ) (h : ∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N, x + n = y + ε) :
 example (x y : ℝ) (h : ∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N, x + n = y + ε) :
     ∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N, x - ε = y - n := by
   peel h
-  peel 2 this
-  peel this
-  peel this
+  fail_if_success peel 2 this
+  peel 0 this
+  fail_if_success peel this
   linarith
 
 example (p q : ℝ → ℝ → Prop) (h : ∀ ε > 0, ∃ δ > 0, p ε δ)
@@ -109,12 +114,21 @@ example : (∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N, 1 / (n + 1 : ℚ) < ε) ↔
   · intro ε hε
     peel 3 h (ε / 2) (half_pos hε) using this.trans_lt (half_lt_self hε)
 
+def toInf (f : ℕ → ℕ) : Prop := ∀ m, ∃ n, ∀ n' ≥ n, m ≤ f n'
+
+example (f : ℕ → ℕ) (h : toInf f) : toInf (fun n => 2 * f n) := by
+  peel h with this m n n' h
+  dsimp
+  linarith
+
 /-! ## Use with `↔` goals -/
 
 example (x y : ℚ) (h : ∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N, x + n = y + ε) :
     ∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N, x - ε = y - n := by
   intro ε hε
   peel 3 (h ε hε)
+  rename_i _ n _
+  guard_hyp this : x + ↑n = y + ε
   guard_target =ₐ x - ε = y - n
   linarith
 
@@ -161,43 +175,60 @@ example {G : Type*} [Group G] [TopologicalSpace G] [TopologicalGroup G]
 /-! ## Error messages -/
 
 /--
-error: could not match x = y and x = y as quantified expressions
+error: Tactic 'peel' could not match quantifiers in
+  x = y
+and
+  x = y
 -/
-#guard_msgs in
-example (x y : ℝ) (h : x = y) : x = y := by
+#guard_msgs in example (x y : ℝ) (h : x = y) : x = y := by
   peel h
 
 /--
-error: could not match ∃ y, ∀ (x : ℕ), x ≠ y and ∀ (x : ℕ), ∃ y, x ≠ y as quantified expressions
+error: Tactic 'peel' could not match quantifiers in
+  ∃ y, ∀ (x : ℕ), x ≠ y
+and
+  ∀ (x : ℕ), ∃ y, x ≠ y
 -/
 #guard_msgs in
 example (h : ∃ y : ℕ, ∀ x, x ≠ y) : ∀ x : ℕ, ∃ y, x ≠ y := by
   peel h
 
 /--
-error: matched ∀, but ℕ and ℤ are not definitionally equal
+error: Tactic 'peel' could not match quantifiers in
+  ∀ (n : ℕ), 0 ≤ n
+and
+  ∀ (n : ℤ), 0 ≤ n
 -/
 #guard_msgs in
 example (h : ∀ n : ℕ, 0 ≤ n) : ∀ n : ℤ, 0 ≤ n := by
   peel h
 
 /--
-error: matched ∃, but ℕ and ℤ are not definitionally equal
+error: Tactic 'peel' could not match quantifiers in
+  ∃ n, 0 ≤ n
+and
+  ∃ n, 0 ≤ n
 -/
 #guard_msgs in
 example (h : ∃ n : ℕ, 0 ≤ n) : ∃ n : ℤ, 0 ≤ n := by
-  peel h
+  peel 1 h
 
 /--
-error: matched ∃ᶠ, but atTop and atBot are not definitionally equal
+error: Tactic 'peel' could not match quantifiers in
+  ∃ᶠ (n : ℕ) in atTop, 0 ≤ n
+and
+  ∃ᶠ (n : ℕ) in atBot, 0 ≤ n
 -/
 #guard_msgs in
 example (h : ∃ᶠ n : ℕ in atTop, 0 ≤ n) : ∃ᶠ n : ℕ in atBot, 0 ≤ n := by
-  peel h
+  peel 1 h
 
 /--
-error: matched ∀ᶠ, but atTop and atBot are not definitionally equal
+error: Tactic 'peel' could not match quantifiers in
+  ∀ᶠ (n : ℕ) in atTop, 0 ≤ n
+and
+  ∀ᶠ (n : ℕ) in atBot, 0 ≤ n
 -/
 #guard_msgs in
 example (h : ∀ᶠ n : ℕ in atTop, 0 ≤ n) : ∀ᶠ n : ℕ in atBot, 0 ≤ n := by
-  peel h
+  peel 1 h

--- a/test/peel.lean
+++ b/test/peel.lean
@@ -131,13 +131,6 @@ example : (∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N, 1 / (n + 1 : ℚ) < ε) ↔
   · intro ε hε
     peel 3 h (ε / 2) (half_pos hε) using this.trans_lt (half_lt_self hε)
 
-def toInf (f : ℕ → ℕ) : Prop := ∀ m, ∃ n, ∀ n' ≥ n, m ≤ f n'
-
-example (f : ℕ → ℕ) (h : toInf f) : toInf (fun n => 2 * f n) := by
-  peel h with this m n n' h
-  dsimp
-  linarith
-
 /-! ## Use with `↔` goals -/
 
 example (x y : ℚ) (h : ∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N, x + n = y + ε) :
@@ -204,6 +197,13 @@ example {α β γ : Type*} {f : α → β} {g : β → γ} (h : Function.Surject
   fail_if_success peel this
   obtain ⟨x, rfl⟩ := this
   exact ⟨f x, rfl⟩
+
+def toInf (f : ℕ → ℕ) : Prop := ∀ m, ∃ n, ∀ n' ≥ n, m ≤ f n'
+
+example (f : ℕ → ℕ) (h : toInf f) : toInf (fun n => 2 * f n) := by
+  peel h with this m n n' h
+  dsimp
+  linarith
 
 /-! ## Error messages -/
 

--- a/test/peel.lean
+++ b/test/peel.lean
@@ -45,6 +45,17 @@ example (p q : Nat → Prop) (h₁ : ∀ x, p x) (h₂ : ∀ x, p x → q x) : �
   guard_target =ₐ q w
   exact h₂ w foo
 
+example (p q : Nat → Prop) (h₁ : ∀ x, p x) (h₂ : ∀ x, p x → q x) : ∀ y, q y := by
+  peel h₁ with foo _
+  rename_i w
+  guard_target =ₐ q w
+  exact h₂ w foo
+
+example (p q : Nat → Prop) (h₁ : ∀ x, p x) (h₂ : ∀ x, p x → q x) : ∀ y, q y := by
+  peel h₁ with _ w
+  guard_target =ₐ q w
+  exact h₂ w this
+
 example (p q : Nat → Nat → Prop) (h₁ : ∀ x y, p x y) (h₂ : ∀ x y, p x y → q x y) :
     ∀ u v, q u v := by
   peel h₁ with h_peel s t

--- a/test/peel.lean
+++ b/test/peel.lean
@@ -178,7 +178,15 @@ example (h : ∃ y : ℕ, ∀ x, x ≠ y) : ∀ x : ℕ, ∃ y, x ≠ y := by
   exact fun x => ⟨y, hy x⟩
 
 /--
-error: ℕ and ℤ are not definitionally equal
+error: matched ∀, but ℕ and ℤ are not definitionally equal
+-/
+#guard_msgs in
+example (h : ∀ n : ℕ, 0 ≤ n) : ∀ n : ℤ, 0 ≤ n := by
+  peel h
+  admit
+
+/--
+error: matched ∃, but ℕ and ℤ are not definitionally equal
 -/
 #guard_msgs in
 example (h : ∃ n : ℕ, 0 ≤ n) : ∃ n : ℤ, 0 ≤ n := by
@@ -186,7 +194,7 @@ example (h : ∃ n : ℕ, 0 ≤ n) : ∃ n : ℤ, 0 ≤ n := by
   admit
 
 /--
-error: atTop and atBot are not definitionally equal
+error: matched ∃ᶠ, but atTop and atBot are not definitionally equal
 -/
 #guard_msgs in
 example (h : ∃ᶠ n : ℕ in atTop, 0 ≤ n) : ∃ᶠ n : ℕ in atBot, 0 ≤ n := by
@@ -194,7 +202,7 @@ example (h : ∃ᶠ n : ℕ in atTop, 0 ≤ n) : ∃ᶠ n : ℕ in atBot, 0 ≤ 
   admit
 
 /--
-error: atTop and atBot are not definitionally equal
+error: matched ∀ᶠ, but atTop and atBot are not definitionally equal
 -/
 #guard_msgs in
 example (h : ∀ᶠ n : ℕ in atTop, 0 ≤ n) : ∀ᶠ n : ℕ in atBot, 0 ≤ n := by

--- a/test/peel.lean
+++ b/test/peel.lean
@@ -166,7 +166,6 @@ error: could not match x = y and x = y as quantified expressions
 #guard_msgs in
 example (x y : ℝ) (h : x = y) : x = y := by
   peel h
-  exact h
 
 /--
 error: could not match ∃ y, ∀ (x : ℕ), x ≠ y and ∀ (x : ℕ), ∃ y, x ≠ y as quantified expressions
@@ -174,8 +173,6 @@ error: could not match ∃ y, ∀ (x : ℕ), x ≠ y and ∀ (x : ℕ), ∃ y, x
 #guard_msgs in
 example (h : ∃ y : ℕ, ∀ x, x ≠ y) : ∀ x : ℕ, ∃ y, x ≠ y := by
   peel h
-  obtain ⟨y, hy⟩ := h
-  exact fun x => ⟨y, hy x⟩
 
 /--
 error: matched ∀, but ℕ and ℤ are not definitionally equal
@@ -183,7 +180,6 @@ error: matched ∀, but ℕ and ℤ are not definitionally equal
 #guard_msgs in
 example (h : ∀ n : ℕ, 0 ≤ n) : ∀ n : ℤ, 0 ≤ n := by
   peel h
-  admit
 
 /--
 error: matched ∃, but ℕ and ℤ are not definitionally equal
@@ -191,7 +187,6 @@ error: matched ∃, but ℕ and ℤ are not definitionally equal
 #guard_msgs in
 example (h : ∃ n : ℕ, 0 ≤ n) : ∃ n : ℤ, 0 ≤ n := by
   peel h
-  admit
 
 /--
 error: matched ∃ᶠ, but atTop and atBot are not definitionally equal
@@ -199,7 +194,6 @@ error: matched ∃ᶠ, but atTop and atBot are not definitionally equal
 #guard_msgs in
 example (h : ∃ᶠ n : ℕ in atTop, 0 ≤ n) : ∃ᶠ n : ℕ in atBot, 0 ≤ n := by
   peel h
-  admit
 
 /--
 error: matched ∀ᶠ, but atTop and atBot are not definitionally equal
@@ -207,4 +201,3 @@ error: matched ∀ᶠ, but atTop and atBot are not definitionally equal
 #guard_msgs in
 example (h : ∀ᶠ n : ℕ in atTop, 0 ≤ n) : ∀ᶠ n : ℕ in atBot, 0 ≤ n := by
   peel h
-  admit

--- a/test/peel.lean
+++ b/test/peel.lean
@@ -3,17 +3,22 @@ import Mathlib.Topology.Instances.Real
 
 open Filter Topology
 
+/-! ## General usage -/
+
 example (p q : Nat → Prop) (h₁ : ∀ x, p x) (h₂ : ∀ x, p x → q x) : ∀ y, q y := by
   peel 1 h₁
+  guard_target =ₐ q y
   exact h₂ _ this
 
 example (p q : Nat → Nat → Prop) (h₁ : ∀ x y, p x y) (h₂ : ∀ x y, p x y → q x y) :
     ∀ u v, q u v := by
   peel 2 h₁
+  guard_target =ₐ q u v
   exact h₂ _ _ this
 
 example (p q : Nat → Prop) (h₁ : ∀ x, p x) (h₂ : ∀ x, p x → q x) : ∀ y, q y := by
   peel h₁
+  guard_target =ₐ q y
   exact h₂ _ this
 
 example (p q : Nat → Prop) (h₁ : ∀ x, p x) (h₂ : ∀ x, p x → q x) : ∀ y, q y := by
@@ -23,38 +28,54 @@ example (p q : Nat → Nat → Prop) (h₁ : ∀ x y, p x y) (h₂ : ∀ x y, p 
     ∀ u v, q u v := by
   peel h₁
   peel this
+  guard_target =ₐ q u v
   exact h₂ _ _ this
 
 example (p q : Nat → Prop) (h₁ : ∀ x, p x) (h₂ : ∀ x, p x → q x) : ∀ y, q y := by
   peel h₁ with foo
+  guard_target =ₐ q y
   exact h₂ _ foo
 
 example (p q : Nat → Prop) (h₁ : ∀ x, p x) (h₂ : ∀ x, p x → q x) : ∀ y, q y := by
   peel h₁ with foo w
+  guard_target =ₐ q w
   exact h₂ w foo
 
 example (p q : Nat → Nat → Prop) (h₁ : ∀ x y, p x y) (h₂ : ∀ x y, p x y → q x y) :
     ∀ u v, q u v := by
   peel h₁ with h_peel s t
+  guard_target =ₐ q s t
   exact h₂ s t h_peel
 
 example (p q : Nat → Prop) (h : ∀ y, p y) (h₁ : ∀ z, p z → q z) : ∀ x, q x := by
   peel h
+  guard_target =ₐ q x
   exact h₁ _ <| by assumption
 
 example (p q : Nat → Prop) (h : ∃ y, p y) (h₁ : ∀ z, p z → q z) : ∃ x, q x := by
-  peel h with h x
-  exact h₁ x h
+  peel h with h a
+  guard_target =ₐ q a
+  exact h₁ a h
 
 example (x y : ℝ) (h : ∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N, x + n = y + ε) :
-    ∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N, x - ε = y  - n := by
+    ∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N, x - ε = y - n := by
   peel h with h_peel ε hε N n hn
+  guard_target =ₐ x - ε = y - n
+  linarith
+
+example (x y : ℝ) (h : ∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N, x + n = y + ε) :
+    ∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N, x - ε = y - n := by
+  peel h
+  peel 2 this
+  peel this
+  peel this
   linarith
 
 example (p q : ℝ → ℝ → Prop) (h : ∀ ε > 0, ∃ δ > 0, p ε δ)
     (hpq : ∀ x y, x > 0 → y > 0 → p x y → q x y) :
     ∀ ε > 0, ∃ δ > 0, q ε δ := by
   peel h with h ε hε δ hδ
+  guard_target =ₐ q ε δ
   exact hpq ε δ hε hδ h
 
 example (p q : ℝ → ℝ → Prop) (h : ∀ ε > 0, ∃ δ > 0, p ε δ)
@@ -62,27 +83,15 @@ example (p q : ℝ → ℝ → Prop) (h : ∀ ε > 0, ∃ δ > 0, p ε δ)
     ∀ ε > 0, ∃ δ > 0, q ε δ := by
   peel h with h ε hε δ hδ using hpq ε δ hε hδ h
 
-example (x y : ℚ) (h : ∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N, x + n = y + ε) :
-    ∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N, x - ε = y  - n := by
-  intro ε hε
-  peel 3 (h ε hε)
-  linarith
-
 example (x y : ℝ) : (∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N, x + n = y + ε) ↔
-    ∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N, x - ε = y  - n := by
-  peel with ε hε N n hn
-  constructor
-  all_goals
-    intro
-    linarith
-
-example (x y : ℝ) : (∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N, x + n = y + ε) ↔
-    ∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N, x - ε = y  - n := by
+    ∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N, x - ε = y - n := by
   peel 5
   constructor
   all_goals
     intro
     linarith
+
+/-! ## Usage after other tactics and with multiple goals -/
 
 example : (∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N, 1 / (n + 1 : ℚ) < ε) ↔
     ∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N, 1 / (n + 1 : ℚ) ≤ ε := by
@@ -100,6 +109,25 @@ example : (∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N, 1 / (n + 1 : ℚ) < ε) ↔
   · intro ε hε
     peel 3 h (ε / 2) (half_pos hε) using this.trans_lt (half_lt_self hε)
 
+/-! ## Use with `↔` goals -/
+
+example (x y : ℚ) (h : ∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N, x + n = y + ε) :
+    ∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N, x - ε = y - n := by
+  intro ε hε
+  peel 3 (h ε hε)
+  guard_target =ₐ x - ε = y - n
+  linarith
+
+example (x y : ℝ) : (∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N, x + n = y + ε) ↔
+    ∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N, x - ε = y - n := by
+  peel with ε hε N n hn
+  constructor
+  all_goals
+    intro
+    linarith
+
+/-! ## Eventually and frequently -/
+
 example {f : ℝ → ℝ} (h : ∀ x : ℝ, ∀ᶠ y in 𝓝 x, |f y - f x| ≤ |y - x|) :
     ∀ x : ℝ, ∀ᶠ y in 𝓝 x, |f y - f x| ^ 2 ≤ |y - x| ^ 2 := by
   peel h with h_peel x y
@@ -115,6 +143,8 @@ example (α : Type*) (f : Filter α) (p q : α → Prop) (h : ∀ᶠ x in f, p x
   peel h with h_peel x
   exact h₁ x h_peel
 
+/-! ## Type classes -/
+
 example {R : Type*} [CommRing R] (h : ∀ x : R, ∃ y : R, x + y = 2) :
     ∀ x : R, ∃ y : R, (x + y) ^ 2 = 4 := by
   peel 2 h
@@ -127,3 +157,46 @@ example {G : Type*} [Group G] [TopologicalSpace G] [TopologicalGroup G]
   peel h with h_peel a b
   observe : a = b⁻¹⁻¹
   simp [this]
+
+/-! ## Error messages -/
+
+/--
+error: could not match x = y and x = y as quantified expressions
+-/
+#guard_msgs in
+example (x y : ℝ) (h : x = y) : x = y := by
+  peel h
+  exact h
+
+/--
+error: could not match ∃ y, ∀ (x : ℕ), x ≠ y and ∀ (x : ℕ), ∃ y, x ≠ y as quantified expressions
+-/
+#guard_msgs in
+example (h : ∃ y : ℕ, ∀ x, x ≠ y) : ∀ x : ℕ, ∃ y, x ≠ y := by
+  peel h
+  obtain ⟨y, hy⟩ := h
+  exact fun x => ⟨y, hy x⟩
+
+/--
+error: ℕ and ℤ are not definitionally equal
+-/
+#guard_msgs in
+example (h : ∃ n : ℕ, 0 ≤ n) : ∃ n : ℤ, 0 ≤ n := by
+  peel h
+  admit
+
+/--
+error: atTop and atBot are not definitionally equal
+-/
+#guard_msgs in
+example (h : ∃ᶠ n : ℕ in atTop, 0 ≤ n) : ∃ᶠ n : ℕ in atBot, 0 ≤ n := by
+  peel h
+  admit
+
+/--
+error: atTop and atBot are not definitionally equal
+-/
+#guard_msgs in
+example (h : ∀ᶠ n : ℕ in atTop, 0 ≤ n) : ∀ᶠ n : ℕ in atBot, 0 ≤ n := by
+  peel h
+  admit


### PR DESCRIPTION
As requested on [Zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Logical.20congruence.20or.20weakening.20tactic).

Given `p q : ℕ → Prop`, `h : ∀ x, p x`, and a goal `⊢ : ∀ x, q x`, the tactic `peel h with h' x` will introduce `x : ℕ`, `h' : p x` into the context and the new goal will be `⊢ q x`. This works with `∃`, as well as `∀ᶠ` and `∃ᶠ`, and it can even be applied to a sequence of quantifiers.

For a more complex example, given a hypothesis and a goal:
```
h : ∀ ε > (0 : ℝ), ∃ N : ℕ, ∀ n ≥ N, 1 / (n + 1 : ℝ) < ε
⊢ ∀ ε > (0 : ℝ), ∃ N : ℕ, ∀ n ≥ N, 1 / (n + 1 : ℝ) ≤ ε
```
(which differ only in `<`/`≤`), applying `peel h with h_peel ε hε N n hn` will yield a tactic state:
```
h : ∀ ε > (0 : ℝ), ∃ N : ℕ, ∀ n ≥ N, 1 / (n + 1 : ℝ) < ε
ε : ℝ
hε : 0 < ε
N n : ℕ
hn : N ≤ n
h_peel : 1 / (n + 1 : ℝ) < ε
⊢ 1 / (n + 1 : ℝ) ≤ ε
```
and the goal can be closed with `exact h_peel.le`.

Co-authored-by: Kyle Miller <kmill31415@gmail.com>

---

Note: I am completely open to renaming the tactic if a consensus is reached about a better name.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:


Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
