### PR TITLE
[Merged by Bors] - chore: remove @[simp] attribute already in Std

### DIFF
--- a/Mathlib/Data/Int/Cast/Defs.lean
+++ b/Mathlib/Data/Int/Cast/Defs.lean
@@ -26,8 +26,6 @@ Preferentially, the homomorphism is written as a coercion.
 
 universe u
 
-attribute [simp] Int.ofNat_eq_coe
-
 /-- Default value for `IntCast.intCast` in an `AddGroupWithOne`. -/
 protected def Int.castDef {R : Type u} [NatCast R] [Neg R] : ℤ → R
   | (n : ℕ) => n
@@ -63,4 +61,3 @@ class AddCommGroupWithOne (R : Type u)
 #align add_comm_group_with_one.to_add_comm_group AddCommGroupWithOne.toAddCommGroup
 #align add_comm_group_with_one.to_add_group_with_one AddCommGroupWithOne.toAddGroupWithOne
 #align add_comm_group_with_one.to_add_comm_monoid_with_one AddCommGroupWithOne.toAddCommMonoidWithOne
-


### PR DESCRIPTION
This attribute is already there at the point of definition in Std now.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
