### PR TITLE
[Merged by Bors] - fix: add missing `DecidableEq` arguments

### DIFF
--- a/Mathlib/Data/Polynomial/Derivative.lean
+++ b/Mathlib/Data/Polynomial/Derivative.lean
@@ -21,7 +21,7 @@ noncomputable section
 
 open Finset
 
-open BigOperators Classical Polynomial
+open BigOperators Polynomial
 
 namespace Polynomial
 
@@ -200,6 +200,7 @@ theorem degree_derivative_lt {p : R[X]} (hp : p ≠ 0) : p.derivative.degree < p
 #align polynomial.degree_derivative_lt Polynomial.degree_derivative_lt
 
 theorem degree_derivative_le {p : R[X]} : p.derivative.degree ≤ p.degree :=
+  letI := Classical.decEq R
   if H : p = 0 then le_of_eq <| by rw [H, derivative_zero] else (degree_derivative_lt H).le
 #align polynomial.degree_derivative_le Polynomial.degree_derivative_le
 
@@ -548,7 +549,7 @@ theorem derivative_eval₂_C (p q : R[X]) :
 set_option linter.uppercaseLean3 false in
 #align polynomial.derivative_eval₂_C Polynomial.derivative_eval₂_C
 
-theorem derivative_prod {s : Multiset ι} {f : ι → R[X]} :
+theorem derivative_prod [DecidableEq ι] {s : Multiset ι} {f : ι → R[X]} :
     derivative (Multiset.map f s).prod =
       (Multiset.map (fun i => (Multiset.map f (s.erase i)).prod * derivative (f i)) s).sum := by
   refine' Multiset.induction_on s (by simp) fun i s h => _
@@ -635,7 +636,8 @@ theorem iterate_derivative_comp_one_sub_X (p : R[X]) (k : ℕ) :
 set_option linter.uppercaseLean3 false in
 #align polynomial.iterate_derivative_comp_one_sub_X Polynomial.iterate_derivative_comp_one_sub_X
 
-theorem eval_multiset_prod_X_sub_C_derivative {S : Multiset R} {r : R} (hr : r ∈ S) :
+theorem eval_multiset_prod_X_sub_C_derivative [DecidableEq R]
+    {S : Multiset R} {r : R} (hr : r ∈ S) :
     eval r (derivative (Multiset.map (fun a => X - C a) S).prod) =
       (Multiset.map (fun a => r - a) (S.erase r)).prod := by
   nth_rw 1 [← Multiset.cons_erase hr]

--- a/Mathlib/Data/Polynomial/Splits.lean
+++ b/Mathlib/Data/Polynomial/Splits.lean
@@ -32,7 +32,7 @@ irreducible factors over `L` have degree `1`.
 
 noncomputable section
 
-open Classical BigOperators Polynomial
+open BigOperators Polynomial
 
 universe u v w
 
@@ -61,6 +61,7 @@ theorem splits_zero : Splits i (0 : K[X]) :=
 #align polynomial.splits_zero Polynomial.splits_zero
 
 theorem splits_of_map_eq_C {f : K[X]} {a : L} (h : f.map i = C a) : Splits i f :=
+  letI := Classical.decEq L
   if ha : a = 0 then Or.inl (h.trans (ha.symm ▸ C_0))
   else
     Or.inr fun hg ⟨p, hp⟩ =>
@@ -109,6 +110,7 @@ theorem splits_of_natDegree_eq_one {f : K[X]} (hf : natDegree f = 1) : Splits i 
 #align polynomial.splits_of_nat_degree_eq_one Polynomial.splits_of_natDegree_eq_one
 
 theorem splits_mul {f g : K[X]} (hf : Splits i f) (hg : Splits i g) : Splits i (f * g) :=
+  letI := Classical.decEq L
   if h : (f * g).map i = 0 then Or.inl h
   else
     Or.inr @fun p hp hpf =>
@@ -150,6 +152,7 @@ set_option linter.uppercaseLean3 false in
 
 theorem splits_prod {ι : Type u} {s : ι → K[X]} {t : Finset ι} :
     (∀ j ∈ t, (s j).Splits i) → (∏ x in t, s x).Splits i := by
+  classical
   refine' Finset.induction_on t (fun _ => splits_one i) fun a t hat ih ht => _
   rw [Finset.forall_mem_insert] at ht; rw [Finset.prod_insert hat]
   exact splits_mul i ht.1 (ih ht.2)
@@ -171,6 +174,7 @@ theorem splits_id_iff_splits {f : K[X]} : (f.map i).Splits (RingHom.id L) ↔ f.
 
 theorem exists_root_of_splits' {f : K[X]} (hs : Splits i f) (hf0 : degree (f.map i) ≠ 0) :
     ∃ x, eval₂ i x f = 0 :=
+  letI := Classical.decEq L
   if hf0' : f.map i = 0 then by simp [eval₂_eq_eval_map, hf0']
   else
     let ⟨g, hg⟩ :=
@@ -253,12 +257,12 @@ theorem splits_of_splits_of_dvd {f g : K[X]} (hf0 : f ≠ 0) (hf : Splits i f) (
   exact (splits_of_splits_mul i hf0 hf).1
 #align polynomial.splits_of_splits_of_dvd Polynomial.splits_of_splits_of_dvd
 
-theorem splits_of_splits_gcd_left {f g : K[X]} (hf0 : f ≠ 0) (hf : Splits i f) :
+theorem splits_of_splits_gcd_left [DecidableEq K] {f g : K[X]} (hf0 : f ≠ 0) (hf : Splits i f) :
     Splits i (EuclideanDomain.gcd f g) :=
   Polynomial.splits_of_splits_of_dvd i hf0 hf (EuclideanDomain.gcd_dvd_left f g)
 #align polynomial.splits_of_splits_gcd_left Polynomial.splits_of_splits_gcd_left
 
-theorem splits_of_splits_gcd_right {f g : K[X]} (hg0 : g ≠ 0) (hg : Splits i g) :
+theorem splits_of_splits_gcd_right [DecidableEq K] {f g : K[X]} (hg0 : g ≠ 0) (hg : Splits i g) :
     Splits i (EuclideanDomain.gcd f g) :=
   Polynomial.splits_of_splits_of_dvd i hg0 hg (EuclideanDomain.gcd_dvd_right f g)
 #align polynomial.splits_of_splits_gcd_right Polynomial.splits_of_splits_gcd_right
@@ -270,6 +274,7 @@ theorem splits_mul_iff {f g : K[X]} (hf : f ≠ 0) (hg : g ≠ 0) :
 
 theorem splits_prod_iff {ι : Type u} {s : ι → K[X]} {t : Finset ι} :
     (∀ j ∈ t, s j ≠ 0) → ((∏ x in t, s x).Splits i ↔ ∀ j ∈ t, (s j).Splits i) := by
+  classical
   refine'
     Finset.induction_on t (fun _ =>
         ⟨fun _ _ h => by simp only [Finset.not_mem_empty] at h, fun _ => splits_one i⟩)
@@ -390,6 +395,7 @@ open UniqueFactorizationMonoid Associates
 
 theorem splits_of_exists_multiset {f : K[X]} {s : Multiset L}
     (hs : f.map i = C (i f.leadingCoeff) * (s.map fun a : L => X - C a).prod) : Splits i f :=
+  letI := Classical.decEq K
   if hf0 : f = 0 then hf0.symm ▸ splits_zero i
   else
     Or.inr @fun p hp hdp => by
@@ -445,7 +451,7 @@ theorem splits_iff_card_roots {p : K[X]} :
     exact (C_leadingCoeff_mul_prod_multiset_X_sub_C hroots).symm
 #align polynomial.splits_iff_card_roots Polynomial.splits_iff_card_roots
 
-theorem aeval_root_derivative_of_splits [Algebra K L] {P : K[X]} (hmo : P.Monic)
+theorem aeval_root_derivative_of_splits [Algebra K L] [DecidableEq L] {P : K[X]} (hmo : P.Monic)
     (hP : P.Splits (algebraMap K L)) {r : L} (hr : r ∈ P.aroots L) :
     aeval r (Polynomial.derivative P) =
     (((P.aroots L).erase r).map fun a => r - a).prod := by


### PR DESCRIPTION
These make the lemmas strictly more (syntactically) general.

As usual, the way to find these is to remove `open Classical` and fix what breaks.
Usually this means adding `classical` to the start of the proof, but there are lots of weird term-mode proofs here for which adding a more surgical `letI := Classical.decEq` is easier.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
