### PR TITLE
[Merged by Bors] - chore(Algebra/BigOperators/Finsupp): sums of `Finsupp.single`

### DIFF
--- a/Mathlib/Algebra/BigOperators/Finsupp.lean
+++ b/Mathlib/Algebra/BigOperators/Finsupp.lean
@@ -484,7 +484,7 @@ theorem univ_sum_single [Fintype α] [AddCommMonoid M] (f : α →₀ M) :
 
 @[simp]
 theorem univ_sum_single_apply [AddCommMonoid M] [Fintype α] (i : α) (m : M) :
-    (∑ j : α, single i m j) = m := by
+    ∑ j : α, single i m j = m := by
   -- Porting note: rewrite due to leaky classical in lean3
   classical rw [single, coe_mk, Finset.sum_pi_single']
   simp
@@ -492,7 +492,7 @@ theorem univ_sum_single_apply [AddCommMonoid M] [Fintype α] (i : α) (m : M) :
 
 @[simp]
 theorem univ_sum_single_apply' [AddCommMonoid M] [Fintype α] (i : α) (m : M) :
-    (∑ j : α, single j m i) = m := by
+    ∑ j : α, single j m i = m := by
   -- Porting note: rewrite due to leaky classical in lean3
   simp_rw [single, coe_mk]
   classical rw [Finset.sum_pi_single]

--- a/Mathlib/Algebra/BigOperators/Finsupp.lean
+++ b/Mathlib/Algebra/BigOperators/Finsupp.lean
@@ -485,7 +485,7 @@ theorem univ_sum_single [Fintype α] [AddCommMonoid M] (f : α →₀ M) :
 @[simp]
 theorem univ_sum_single_apply [AddCommMonoid M] [Fintype α] (i : α) (m : M) :
     (∑ j : α, single i m j) = m := by
--- Porting note: rewrite due to leaky classical in lean3
+  -- Porting note: rewrite due to leaky classical in lean3
   classical rw [single, coe_mk, Finset.sum_pi_single']
   simp
 #align finsupp.sum_univ_single Finsupp.univ_sum_single_apply

--- a/Mathlib/Algebra/BigOperators/Finsupp.lean
+++ b/Mathlib/Algebra/BigOperators/Finsupp.lean
@@ -474,22 +474,37 @@ theorem sum_single [AddCommMonoid M] (f : α →₀ M) : f.sum single = f :=
   FunLike.congr_fun liftAddHom_singleAddHom f
 #align finsupp.sum_single Finsupp.sum_single
 
+/-- The `Finsupp` version of `Finset.univ_sum_single` -/
 @[simp]
-theorem sum_univ_single [AddCommMonoid M] [Fintype α] (i : α) (m : M) :
-    (∑ j : α, (single i m) j) = m := by
+theorem univ_sum_single [Fintype α] [AddCommMonoid M] (f : α →₀ M) :
+    ∑ a : α, single a (f a) = f := by
+  conv_rhs => rw [←sum_single f]
+  refine (Finset.sum_subset (subset_univ _) fun a _ ha => ?_).symm
+  rw [not_mem_support_iff.mp ha, single_zero]
+
+@[simp]
+theorem univ_sum_single_apply [AddCommMonoid M] [Fintype α] (i : α) (m : M) :
+    (∑ j : α, single i m j) = m := by
 -- Porting note: rewrite due to leaky classical in lean3
   classical rw [single, coe_mk, Finset.sum_pi_single']
   simp
-#align finsupp.sum_univ_single Finsupp.sum_univ_single
+#align finsupp.sum_univ_single Finsupp.univ_sum_single_apply
 
 @[simp]
-theorem sum_univ_single' [AddCommMonoid M] [Fintype α] (i : α) (m : M) :
-    (∑ j : α, (single j m) i) = m := by
--- Porting note: rewrite due to leaky classical in lean3
+theorem univ_sum_single_apply' [AddCommMonoid M] [Fintype α] (i : α) (m : M) :
+    (∑ j : α, single j m i) = m := by
+  -- Porting note: rewrite due to leaky classical in lean3
   simp_rw [single, coe_mk]
   classical rw [Finset.sum_pi_single]
   simp
-#align finsupp.sum_univ_single' Finsupp.sum_univ_single'
+#align finsupp.sum_univ_single' Finsupp.univ_sum_single_apply'
+
+
+theorem equivFunOnFinite_symm_eq_sum [Fintype α] [AddCommMonoid M] (f : α → M) :
+    equivFunOnFinite.symm f = ∑ a, Finsupp.single a (f a) := by
+  rw [←univ_sum_single (equivFunOnFinite.symm f)]
+  ext
+  simp
 
 -- Porting note: simp can prove this
 -- @[simp]

--- a/Mathlib/Algebra/BigOperators/Finsupp.lean
+++ b/Mathlib/Algebra/BigOperators/Finsupp.lean
@@ -478,9 +478,9 @@ theorem sum_single [AddCommMonoid M] (f : α →₀ M) : f.sum single = f :=
 @[simp]
 theorem univ_sum_single [Fintype α] [AddCommMonoid M] (f : α →₀ M) :
     ∑ a : α, single a (f a) = f := by
-  conv_rhs => rw [←sum_single f]
-  refine (Finset.sum_subset (subset_univ _) fun a _ ha => ?_).symm
-  rw [not_mem_support_iff.mp ha, single_zero]
+  classical
+  refine FunLike.coe_injective ?_
+  simp_rw [coe_finset_sum, single_eq_pi_single, Finset.univ_sum_single]
 
 @[simp]
 theorem univ_sum_single_apply [AddCommMonoid M] [Fintype α] (i : α) (m : M) :


### PR DESCRIPTION
This adds a new lemma to match the existing `Pi` lemma, and renames the existing lemmas to avoid inconsistent naming.

The `equivFunOnFinite` lemma is motivated by #6657.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
