### PR TITLE
[Merged by Bors] - chore: remove some unnecessary 'open private'

### DIFF
--- a/Mathlib/Tactic/ApplyCongr.lean
+++ b/Mathlib/Tactic/ApplyCongr.lean
@@ -18,7 +18,6 @@ rewriting inside the operand of a `Finset.sum`.
 
 open Lean Expr Parser.Tactic Elab Command Elab.Tactic Meta Conv
 
-open private mkFun from Lean.Meta.AppBuilder in
 /--
 Apply a congruence lemma inside `conv` mode.
 
@@ -74,7 +73,8 @@ def Lean.Elab.Tactic.applyCongr (q : Option Expr) : TacticM Unit := do
     | none =>
       let congrTheorems ←
         (fun congrTheoremMap => congrTheoremMap.get lhsFun) <$> getSimpCongrTheorems
-      congrTheorems.mapM (fun congrTheorem => liftM <| Prod.fst <$> mkFun congrTheorem.theoremName)
+      congrTheorems.mapM (fun congrTheorem =>
+        liftM <| mkConstWithFreshMVarLevels congrTheorem.theoremName)
   if congrTheoremExprs == [] then
     throwError "No matching congr lemmas found"
   -- For every lemma:

--- a/Mathlib/Tactic/WLOG.lean
+++ b/Mathlib/Tactic/WLOG.lean
@@ -127,7 +127,6 @@ By default, the entire context is reverted. -/
 syntax (name := wlog) "wlog " binderIdent " : " term
   (" generalizing" (ppSpace colGt ident)*)? (" with " binderIdent)? : tactic
 
-open private Lean.Elab.Term.expandBinderIdent from Lean.Elab.Binders in
 elab_rules : tactic
 | `(tactic| wlog $h:binderIdent : $P:term $[ generalizing $xs*]? $[ with $H:ident]?) =>
   withMainContext do


### PR DESCRIPTION
While having a look at how bad the use of `open private` has become, found two that are trivial to remove.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
