### PR TITLE
[Merged by Bors] - CI: print lean and lake versions

### DIFF
--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -156,6 +156,11 @@ jobs:
             elan toolchain uninstall `cat lean-toolchain`
           fi
 
+      - name: print lean and lake versions
+        run: |
+          lean --version
+          lake --version
+
       - name: get cache
         run: |
           lake exe cache clean

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -162,6 +162,11 @@ jobs:
             elan toolchain uninstall `cat lean-toolchain`
           fi
 
+      - name: print lean and lake versions
+        run: |
+          lean --version
+          lake --version
+
       - name: get cache
         run: |
           lake exe cache clean

--- a/.github/workflows/build.yml.in
+++ b/.github/workflows/build.yml.in
@@ -142,6 +142,11 @@ jobs:
             elan toolchain uninstall `cat lean-toolchain`
           fi
 
+      - name: print lean and lake versions
+        run: |
+          lean --version
+          lake --version
+
       - name: get cache
         run: |
           lake exe cache clean

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -160,6 +160,11 @@ jobs:
             elan toolchain uninstall `cat lean-toolchain`
           fi
 
+      - name: print lean and lake versions
+        run: |
+          lean --version
+          lake --version
+
       - name: get cache
         run: |
           lake exe cache clean


### PR DESCRIPTION
this makes it easier to check if really the lean version was used that
was expected.

Maybe elan could be more chatty
(https://github.com/leanprover/elan/issues/111), but it doesn’t hurt to
have this here.
