### PR TITLE
[Merged by Bors] - chore(Topology/Compactness/SigmaCompact): rename type variables

### DIFF
--- a/Mathlib/Topology/Compactness/SigmaCompact.lean
+++ b/Mathlib/Topology/Compactness/SigmaCompact.lean
@@ -17,7 +17,7 @@ open Set Filter Topology TopologicalSpace Classical
 
 universe u v
 
-variable {α : Type u} {β : Type v} {ι : Type*} {π : ι → Type*}
+variable {α : Type*} {β : Type*} {ι : Type*} {π : ι → Type*}
 variable [TopologicalSpace α] [TopologicalSpace β] {s t : Set α}
 
 /-- A subset `s ⊆ α` is called **σ-compact** if it is the union of countably many compact sets. -/

--- a/Mathlib/Topology/Compactness/SigmaCompact.lean
+++ b/Mathlib/Topology/Compactness/SigmaCompact.lean
@@ -17,24 +17,24 @@ open Set Filter Topology TopologicalSpace Classical
 
 universe u v
 
-variable {α : Type*} {β : Type*} {ι : Type*} {π : ι → Type*}
-variable [TopologicalSpace α] [TopologicalSpace β] {s t : Set α}
+variable {X : Type*} {Y : Type*} {ι : Type*} {π : ι → Type*}
+variable [TopologicalSpace X] [TopologicalSpace Y] {s t : Set X}
 
-/-- A subset `s ⊆ α` is called **σ-compact** if it is the union of countably many compact sets. -/
-def IsSigmaCompact (s : Set α) : Prop :=
-  ∃ K : ℕ → Set α, (∀ n, IsCompact (K n)) ∧ ⋃ n, K n = s
+/-- A subset `s ⊆ X` is called **σ-compact** if it is the union of countably many compact sets. -/
+def IsSigmaCompact (s : Set X) : Prop :=
+  ∃ K : ℕ → Set X, (∀ n, IsCompact (K n)) ∧ ⋃ n, K n = s
 
 /-- Compact sets are σ-compact. -/
-lemma IsCompact.isSigmaCompact {s : Set α} (hs : IsCompact s) : IsSigmaCompact s :=
+lemma IsCompact.isSigmaCompact {s : Set X} (hs : IsCompact s) : IsSigmaCompact s :=
   ⟨fun _ => s, fun _ => hs, iUnion_const _⟩
 
 /-- The empty set is σ-compact. -/
 @[simp]
-lemma isSigmaCompact_empty : IsSigmaCompact (∅ : Set α) :=
+lemma isSigmaCompact_empty : IsSigmaCompact (∅ : Set X) :=
   IsCompact.isSigmaCompact isCompact_empty
 
 /-- Countable unions of compact sets are σ-compact. -/
-lemma isSigmaCompact_iUnion_of_isCompact {ι : Type*} [hι : Countable ι] (s : ι → Set α)
+lemma isSigmaCompact_iUnion_of_isCompact {ι : Type*} [hι : Countable ι] (s : ι → Set X)
     (hcomp : ∀ i, IsCompact (s i)) : IsSigmaCompact (⋃ i, s i) := by
   rcases isEmpty_or_nonempty ι
   · simp only [iUnion_of_empty, isSigmaCompact_empty]
@@ -43,14 +43,14 @@ lemma isSigmaCompact_iUnion_of_isCompact {ι : Type*} [hι : Countable ι] (s : 
     exact ⟨s ∘ f, fun n ↦ hcomp (f n), Function.Surjective.iUnion_comp hf _⟩
 
 /-- Countable unions of compact sets are σ-compact. -/
-lemma isSigmaCompact_sUnion_of_isCompact {S : Set (Set α)} (hc : Set.Countable S)
-    (hcomp : ∀ (s : Set α), s ∈ S → IsCompact s) : IsSigmaCompact (⋃₀ S) := by
+lemma isSigmaCompact_sUnion_of_isCompact {S : Set (Set X)} (hc : Set.Countable S)
+    (hcomp : ∀ (s : Set X), s ∈ S → IsCompact s) : IsSigmaCompact (⋃₀ S) := by
   have : Countable S := countable_coe_iff.mpr hc
   rw [sUnion_eq_iUnion]
   apply isSigmaCompact_iUnion_of_isCompact _ (fun ⟨s, hs⟩ ↦ hcomp s hs)
 
 /-- Countable unions of σ-compact sets are σ-compact. -/
-lemma isSigmaCompact_iUnion {ι : Type*} [Countable ι] (s : ι → Set α)
+lemma isSigmaCompact_iUnion {ι : Type*} [Countable ι] (s : ι → Set X)
     (hcomp : ∀ i, IsSigmaCompact (s i)) : IsSigmaCompact (⋃ i, s i) := by
   -- Choose a decomposition s_i = ⋃ K_i,j for each i.
   choose K hcomp hcov using fun i ↦ hcomp i
@@ -64,13 +64,13 @@ lemma isSigmaCompact_iUnion {ι : Type*} [Countable ι] (s : ι → Set α)
   exact isSigmaCompact_iUnion_of_isCompact K.uncurry fun x ↦ (hcomp x.1 x.2)
 
 /-- Countable unions of σ-compact sets are σ-compact. -/
-lemma isSigmaCompact_sUnion (S : Set (Set α)) (hc : Set.Countable S)
-    (hcomp : ∀ s : S, IsSigmaCompact s (α := α)) : IsSigmaCompact (⋃₀ S) := by
+lemma isSigmaCompact_sUnion (S : Set (Set X)) (hc : Set.Countable S)
+    (hcomp : ∀ s : S, IsSigmaCompact s (X := X)) : IsSigmaCompact (⋃₀ S) := by
   have : Countable S := countable_coe_iff.mpr hc
   apply sUnion_eq_iUnion.symm ▸ isSigmaCompact_iUnion _ hcomp
 
 /-- Countable unions of σ-compact sets are σ-compact. -/
-lemma isSigmaCompact_biUnion {ι : Type*} {s : Set ι} {S : ι → Set α} (hc : Set.Countable s)
+lemma isSigmaCompact_biUnion {ι : Type*} {s : Set ι} {S : ι → Set X} (hc : Set.Countable s)
     (hcomp : ∀ (i : ι), i ∈ s → IsSigmaCompact (S i)) :
     IsSigmaCompact (⋃ (i : ι) (_ : i ∈ s), S i) := by
   have : Countable ↑s := countable_coe_iff.mpr hc
@@ -78,7 +78,7 @@ lemma isSigmaCompact_biUnion {ι : Type*} {s : Set ι} {S : ι → Set α} (hc :
   exact isSigmaCompact_iUnion _ (fun ⟨i', hi'⟩ ↦ hcomp i' hi')
 
 /-- A closed subset of a σ-compact set is σ-compact. -/
-lemma IsSigmaCompact.of_isClosed_subset {s t : Set α} (ht : IsSigmaCompact t)
+lemma IsSigmaCompact.of_isClosed_subset {s t : Set X} (ht : IsSigmaCompact t)
     (hs : IsClosed s) (h : s ⊆ t) : IsSigmaCompact s := by
   rcases ht with ⟨K, hcompact, hcov⟩
   refine ⟨(fun n ↦ s ∩ (K n)), fun n ↦ (hcompact n).inter_left hs, ?_⟩
@@ -86,19 +86,19 @@ lemma IsSigmaCompact.of_isClosed_subset {s t : Set α} (ht : IsSigmaCompact t)
   exact inter_eq_left.mpr h
 
 /-- If `s` is σ-compact and `f` is continuous on `s`, `f(s)` is σ-compact.-/
-lemma IsSigmaCompact.image_of_continuousOn {f : α → β} {s : Set α} (hs : IsSigmaCompact s)
+lemma IsSigmaCompact.image_of_continuousOn {f : X → Y} {s : Set X} (hs : IsSigmaCompact s)
     (hf : ContinuousOn f s) : IsSigmaCompact (f '' s) := by
   rcases hs with ⟨K, hcompact, hcov⟩
   refine ⟨fun n ↦ f '' K n, ?_, hcov.symm ▸ image_iUnion.symm⟩
   exact fun n ↦ (hcompact n).image_of_continuousOn (hf.mono (hcov.symm ▸ subset_iUnion K n))
 
 /-- If `s` is σ-compact and `f` continuous, `f(s)` is σ-compact. -/
-lemma IsSigmaCompact.image {f : α → β} (hf : Continuous f) {s : Set α} (hs : IsSigmaCompact s) :
+lemma IsSigmaCompact.image {f : X → Y} (hf : Continuous f) {s : Set X} (hs : IsSigmaCompact s) :
     IsSigmaCompact (f '' s) := hs.image_of_continuousOn hf.continuousOn
 
 /-- If `f : X → Y` is `Inducing`, the image `f '' s` of a set `s` is σ-compact
   if and only `s` is σ-compact. -/
-lemma Inducing.isSigmaCompact_iff {f : α → β} {s : Set α}
+lemma Inducing.isSigmaCompact_iff {f : X → Y} {s : Set X}
     (hf : Inducing f) : IsSigmaCompact s ↔ IsSigmaCompact (f '' s) := by
   constructor
   · exact fun h ↦ h.image hf.continuous
@@ -119,109 +119,109 @@ lemma Inducing.isSigmaCompact_iff {f : α → β} {s : Set α}
 
 /-- If `f : X → Y` is an `Embedding`, the image `f '' s` of a set `s` is σ-compact
   if and only `s` is σ-compact. -/
-lemma Embedding.isSigmaCompact_iff {f : α → β} {s : Set α}
+lemma Embedding.isSigmaCompact_iff {f : X → Y} {s : Set X}
     (hf : Embedding f) : IsSigmaCompact s ↔ IsSigmaCompact (f '' s) :=
   hf.toInducing.isSigmaCompact_iff
 
 /-- Sets of subtype are σ-compact iff the image under a coercion is. -/
-lemma Subtype.isSigmaCompact_iff {p : α → Prop} {s : Set { a // p a }} :
-    IsSigmaCompact s ↔ IsSigmaCompact ((↑) '' s : Set α) :=
+lemma Subtype.isSigmaCompact_iff {p : X → Prop} {s : Set { a // p a }} :
+    IsSigmaCompact s ↔ IsSigmaCompact ((↑) '' s : Set X) :=
   embedding_subtype_val.isSigmaCompact_iff
 
 /-- A σ-compact space is a space that is the union of a countable collection of compact subspaces.
   Note that a locally compact separable T₂ space need not be σ-compact.
   The sequence can be extracted using `compactCovering`. -/
-class SigmaCompactSpace (α : Type*) [TopologicalSpace α] : Prop where
+class SigmaCompactSpace (X : Type*) [TopologicalSpace X] : Prop where
   /-- In a σ-compact space, `Set.univ` is a σ-compact set. -/
-  isSigmaCompact_univ : IsSigmaCompact (univ : Set α)
+  isSigmaCompact_univ : IsSigmaCompact (univ : Set X)
 #align sigma_compact_space SigmaCompactSpace
 
 /-- A topological space is σ-compact iff `univ` is σ-compact. -/
-lemma isSigmaCompact_univ_iff : IsSigmaCompact (univ : Set α) ↔ SigmaCompactSpace α :=
+lemma isSigmaCompact_univ_iff : IsSigmaCompact (univ : Set X) ↔ SigmaCompactSpace X :=
   ⟨fun h => ⟨h⟩, fun h => h.1⟩
 
 /-- In a σ-compact space, `univ` is σ-compact. -/
-lemma isSigmaCompact_univ [h : SigmaCompactSpace α] : IsSigmaCompact (univ : Set α) :=
+lemma isSigmaCompact_univ [h : SigmaCompactSpace X] : IsSigmaCompact (univ : Set X) :=
   isSigmaCompact_univ_iff.mpr h
 
 /-- A topological space is σ-compact iff there exists a countable collection of compact
 subspaces that cover the entire space. -/
 lemma SigmaCompactSpace_iff_exists_compact_covering :
-    SigmaCompactSpace α ↔ ∃ K : ℕ → Set α, (∀ n, IsCompact (K n)) ∧ ⋃ n, K n = univ := by
+    SigmaCompactSpace X ↔ ∃ K : ℕ → Set X, (∀ n, IsCompact (K n)) ∧ ⋃ n, K n = univ := by
   rw [← isSigmaCompact_univ_iff, IsSigmaCompact]
 
-lemma SigmaCompactSpace.exists_compact_covering [h : SigmaCompactSpace α] :
-    ∃ K : ℕ → Set α, (∀ n, IsCompact (K n)) ∧ ⋃ n, K n = univ :=
+lemma SigmaCompactSpace.exists_compact_covering [h : SigmaCompactSpace X] :
+    ∃ K : ℕ → Set X, (∀ n, IsCompact (K n)) ∧ ⋃ n, K n = univ :=
   SigmaCompactSpace_iff_exists_compact_covering.mp h
 
 /-- If `X` is σ-compact, `im f` is σ-compact. -/
-lemma isSigmaCompact_range {f : α → β} (hf : Continuous f) [SigmaCompactSpace α] :
+lemma isSigmaCompact_range {f : X → Y} (hf : Continuous f) [SigmaCompactSpace X] :
     IsSigmaCompact (range f) :=
   image_univ ▸ isSigmaCompact_univ.image hf
 
 /-- A subset `s` is σ-compact iff `s` (with the subspace topology) is a σ-compact space. -/
-lemma isSigmaCompact_iff_isSigmaCompact_univ {s : Set α} :
+lemma isSigmaCompact_iff_isSigmaCompact_univ {s : Set X} :
     IsSigmaCompact s ↔ IsSigmaCompact (univ : Set s) := by
   rw [Subtype.isSigmaCompact_iff, image_univ, Subtype.range_coe]
 
-lemma isSigmaCompact_iff_sigmaCompactSpace {s : Set α} :
+lemma isSigmaCompact_iff_sigmaCompactSpace {s : Set X} :
     IsSigmaCompact s ↔ SigmaCompactSpace s :=
   isSigmaCompact_iff_isSigmaCompact_univ.trans isSigmaCompact_univ_iff
 
 -- see Note [lower instance priority]
-instance (priority := 200) CompactSpace.sigma_compact [CompactSpace α] : SigmaCompactSpace α :=
+instance (priority := 200) CompactSpace.sigma_compact [CompactSpace X] : SigmaCompactSpace X :=
   ⟨⟨fun _ => univ, fun _ => isCompact_univ, iUnion_const _⟩⟩
 #align compact_space.sigma_compact CompactSpace.sigma_compact
 
-theorem SigmaCompactSpace.of_countable (S : Set (Set α)) (Hc : S.Countable)
-    (Hcomp : ∀ s ∈ S, IsCompact s) (HU : ⋃₀ S = univ) : SigmaCompactSpace α :=
+theorem SigmaCompactSpace.of_countable (S : Set (Set X)) (Hc : S.Countable)
+    (Hcomp : ∀ s ∈ S, IsCompact s) (HU : ⋃₀ S = univ) : SigmaCompactSpace X :=
   ⟨(exists_seq_cover_iff_countable ⟨_, isCompact_empty⟩).2 ⟨S, Hc, Hcomp, HU⟩⟩
 #align sigma_compact_space.of_countable SigmaCompactSpace.of_countable
 
 -- see Note [lower instance priority]
 instance (priority := 100) sigmaCompactSpace_of_locally_compact_second_countable
-    [LocallyCompactSpace α] [SecondCountableTopology α] : SigmaCompactSpace α := by
-  choose K hKc hxK using fun x : α => exists_compact_mem_nhds x
+    [LocallyCompactSpace X] [SecondCountableTopology X] : SigmaCompactSpace X := by
+  choose K hKc hxK using fun x : X => exists_compact_mem_nhds x
   rcases countable_cover_nhds hxK with ⟨s, hsc, hsU⟩
   refine' SigmaCompactSpace.of_countable _ (hsc.image K) (ball_image_iff.2 fun x _ => hKc x) _
   rwa [sUnion_image]
 #align sigma_compact_space_of_locally_compact_second_countable sigmaCompactSpace_of_locally_compact_second_countable
 
 -- porting note: doesn't work on the same line
-variable (α)
-variable [SigmaCompactSpace α]
+variable (X)
+variable [SigmaCompactSpace X]
 
 open SigmaCompactSpace
 
 /-- A choice of compact covering for a `σ`-compact space, chosen to be monotone. -/
-def compactCovering : ℕ → Set α :=
+def compactCovering : ℕ → Set X :=
   Accumulate exists_compact_covering.choose
 #align compact_covering compactCovering
 
-theorem isCompact_compactCovering (n : ℕ) : IsCompact (compactCovering α n) :=
+theorem isCompact_compactCovering (n : ℕ) : IsCompact (compactCovering X n) :=
   isCompact_accumulate (Classical.choose_spec SigmaCompactSpace.exists_compact_covering).1 n
 #align is_compact_compact_covering isCompact_compactCovering
 
-theorem iUnion_compactCovering : ⋃ n, compactCovering α n = univ := by
+theorem iUnion_compactCovering : ⋃ n, compactCovering X n = univ := by
   rw [compactCovering, iUnion_accumulate]
   exact (Classical.choose_spec SigmaCompactSpace.exists_compact_covering).2
 #align Union_compact_covering iUnion_compactCovering
 
 @[mono]
-theorem compactCovering_subset ⦃m n : ℕ⦄ (h : m ≤ n) : compactCovering α m ⊆ compactCovering α n :=
+theorem compactCovering_subset ⦃m n : ℕ⦄ (h : m ≤ n) : compactCovering X m ⊆ compactCovering X n :=
   monotone_accumulate h
 #align compact_covering_subset compactCovering_subset
 
-variable {α}
+variable {X}
 
-theorem exists_mem_compactCovering (x : α) : ∃ n, x ∈ compactCovering α n :=
-  iUnion_eq_univ_iff.mp (iUnion_compactCovering α) x
+theorem exists_mem_compactCovering (x : X) : ∃ n, x ∈ compactCovering X n :=
+  iUnion_eq_univ_iff.mp (iUnion_compactCovering X) x
 #align exists_mem_compact_covering exists_mem_compactCovering
 
-instance [SigmaCompactSpace β] : SigmaCompactSpace (α × β) :=
-  ⟨⟨fun n => compactCovering α n ×ˢ compactCovering β n, fun _ =>
+instance [SigmaCompactSpace Y] : SigmaCompactSpace (X × Y) :=
+  ⟨⟨fun n => compactCovering X n ×ˢ compactCovering Y n, fun _ =>
       (isCompact_compactCovering _ _).prod (isCompact_compactCovering _ _), by
-      simp only [iUnion_prod_of_monotone (compactCovering_subset α) (compactCovering_subset β),
+      simp only [iUnion_prod_of_monotone (compactCovering_subset X) (compactCovering_subset Y),
         iUnion_compactCovering, univ_prod_univ]⟩⟩
 
 instance [Finite ι] [∀ i, TopologicalSpace (π i)] [∀ i, SigmaCompactSpace (π i)] :
@@ -232,10 +232,10 @@ instance [Finite ι] [∀ i, TopologicalSpace (π i)] [∀ i, SigmaCompactSpace 
   · simp only [iUnion_compactCovering, pi_univ]
   · exact fun i => compactCovering_subset (π i)
 
-instance [SigmaCompactSpace β] : SigmaCompactSpace (Sum α β) :=
-  ⟨⟨fun n => Sum.inl '' compactCovering α n ∪ Sum.inr '' compactCovering β n, fun n =>
-      ((isCompact_compactCovering α n).image continuous_inl).union
-        ((isCompact_compactCovering β n).image continuous_inr),
+instance [SigmaCompactSpace Y] : SigmaCompactSpace (Sum X Y) :=
+  ⟨⟨fun n => Sum.inl '' compactCovering X n ∪ Sum.inr '' compactCovering Y n, fun n =>
+      ((isCompact_compactCovering X n).image continuous_inl).union
+        ((isCompact_compactCovering Y n).image continuous_inr),
       by simp only [iUnion_union_distrib, ← image_iUnion, iUnion_compactCovering, image_univ,
         range_inl_union_range_inr]⟩⟩
 
@@ -254,34 +254,34 @@ instance [Countable ι] [∀ i, TopologicalSpace (π i)] [∀ i, SigmaCompactSpa
       refine' ⟨max k n, k, le_max_left _ _, mem_image_of_mem _ _⟩
       exact compactCovering_subset _ (le_max_right _ _) hn
 
-protected theorem ClosedEmbedding.sigmaCompactSpace {e : β → α} (he : ClosedEmbedding e) :
-    SigmaCompactSpace β :=
-  ⟨⟨fun n => e ⁻¹' compactCovering α n, fun n =>
+protected theorem ClosedEmbedding.sigmaCompactSpace {e : Y → X} (he : ClosedEmbedding e) :
+    SigmaCompactSpace Y :=
+  ⟨⟨fun n => e ⁻¹' compactCovering X n, fun n =>
       he.isCompact_preimage (isCompact_compactCovering _ _), by
       rw [← preimage_iUnion, iUnion_compactCovering, preimage_univ]⟩⟩
 #align closed_embedding.sigma_compact_space ClosedEmbedding.sigmaCompactSpace
 
 -- porting note: new lemma
-theorem IsClosed.sigmaCompactSpace {s : Set α} (hs : IsClosed s) : SigmaCompactSpace s :=
+theorem IsClosed.sigmaCompactSpace {s : Set X} (hs : IsClosed s) : SigmaCompactSpace s :=
   (closedEmbedding_subtype_val hs).sigmaCompactSpace
 
-instance [SigmaCompactSpace β] : SigmaCompactSpace (ULift.{u} β) :=
+instance [SigmaCompactSpace Y] : SigmaCompactSpace (ULift.{u} Y) :=
   ULift.closedEmbedding_down.sigmaCompactSpace
 
-/-- If `α` is a `σ`-compact space, then a locally finite family of nonempty sets of `α` can have
+/-- If `X` is a `σ`-compact space, then a locally finite family of nonempty sets of `X` can have
 only countably many elements, `Set.Countable` version. -/
-protected theorem LocallyFinite.countable_univ {ι : Type*} {f : ι → Set α} (hf : LocallyFinite f)
+protected theorem LocallyFinite.countable_univ {ι : Type*} {f : ι → Set X} (hf : LocallyFinite f)
     (hne : ∀ i, (f i).Nonempty) : (univ : Set ι).Countable := by
-  have := fun n => hf.finite_nonempty_inter_compact (isCompact_compactCovering α n)
+  have := fun n => hf.finite_nonempty_inter_compact (isCompact_compactCovering X n)
   refine (countable_iUnion fun n => (this n).countable).mono fun i _ => ?_
   rcases hne i with ⟨x, hx⟩
-  rcases iUnion_eq_univ_iff.1 (iUnion_compactCovering α) x with ⟨n, hn⟩
+  rcases iUnion_eq_univ_iff.1 (iUnion_compactCovering X) x with ⟨n, hn⟩
   exact mem_iUnion.2 ⟨n, x, hx, hn⟩
 #align locally_finite.countable_univ LocallyFinite.countable_univ
 
-/-- If `f : ι → Set α` is a locally finite covering of a σ-compact topological space by nonempty
+/-- If `f : ι → Set X` is a locally finite covering of a σ-compact topological space by nonempty
 sets, then the index type `ι` is encodable. -/
-protected noncomputable def LocallyFinite.encodable {ι : Type*} {f : ι → Set α}
+protected noncomputable def LocallyFinite.encodable {ι : Type*} {f : ι → Set X}
     (hf : LocallyFinite f) (hne : ∀ i, (f i).Nonempty) : Encodable ι :=
   @Encodable.ofEquiv _ _ (hf.countable_univ hne).toEncodable (Equiv.Set.univ _).symm
 #align locally_finite.encodable LocallyFinite.encodable
@@ -289,13 +289,13 @@ protected noncomputable def LocallyFinite.encodable {ι : Type*} {f : ι → Set
 /-- In a topological space with sigma compact topology, if `f` is a function that sends each point
 `x` of a closed set `s` to a neighborhood of `x` within `s`, then for some countable set `t ⊆ s`,
 the neighborhoods `f x`, `x ∈ t`, cover the whole set `s`. -/
-theorem countable_cover_nhdsWithin_of_sigma_compact {f : α → Set α} {s : Set α} (hs : IsClosed s)
+theorem countable_cover_nhdsWithin_of_sigma_compact {f : X → Set X} {s : Set X} (hs : IsClosed s)
     (hf : ∀ x ∈ s, f x ∈ 𝓝[s] x) : ∃ (t : _) (_ : t ⊆ s), t.Countable ∧ s ⊆ ⋃ x ∈ t, f x := by
   simp only [nhdsWithin, mem_inf_principal] at hf
   choose t ht hsub using fun n =>
-    ((isCompact_compactCovering α n).inter_right hs).elim_nhds_subcover _ fun x hx => hf x hx.right
+    ((isCompact_compactCovering X n).inter_right hs).elim_nhds_subcover _ fun x hx => hf x hx.right
   refine'
-    ⟨⋃ n, (t n : Set α), iUnion_subset fun n x hx => (ht n x hx).2,
+    ⟨⋃ n, (t n : Set X), iUnion_subset fun n x hx => (ht n x hx).2,
       countable_iUnion fun n => (t n).countable_toSet, fun x hx => mem_iUnion₂.2 _⟩
   rcases exists_mem_compactCovering x with ⟨n, hn⟩
   rcases mem_iUnion₂.1 (hsub n ⟨hn, hx⟩) with ⟨y, hyt : y ∈ t n, hyf : x ∈ s → x ∈ f y⟩
@@ -305,8 +305,8 @@ theorem countable_cover_nhdsWithin_of_sigma_compact {f : α → Set α} {s : Set
 /-- In a topological space with sigma compact topology, if `f` is a function that sends each
 point `x` to a neighborhood of `x`, then for some countable set `s`, the neighborhoods `f x`,
 `x ∈ s`, cover the whole space. -/
-theorem countable_cover_nhds_of_sigma_compact {f : α → Set α} (hf : ∀ x, f x ∈ 𝓝 x) :
-    ∃ s : Set α, s.Countable ∧ ⋃ x ∈ s, f x = univ := by
+theorem countable_cover_nhds_of_sigma_compact {f : X → Set X} (hf : ∀ x, f x ∈ 𝓝 x) :
+    ∃ s : Set X, s.Countable ∧ ⋃ x ∈ s, f x = univ := by
   simp only [← nhdsWithin_univ] at hf
   rcases countable_cover_nhdsWithin_of_sigma_compact isClosed_univ fun x _ => hf x with
     ⟨s, -, hsc, hsU⟩
@@ -337,13 +337,13 @@ structure CompactExhaustion (X : Type*) [TopologicalSpace X] where
 
 namespace CompactExhaustion
 
-instance : @RelHomClass (CompactExhaustion α) ℕ (Set α) LE.le HasSubset.Subset where
+instance : @RelHomClass (CompactExhaustion X) ℕ (Set X) LE.le HasSubset.Subset where
   coe := toFun
   coe_injective' | ⟨_, _, _, _⟩, ⟨_, _, _, _⟩, rfl => rfl
   map_rel f _ _ h := monotone_nat_of_le_succ
     (fun n ↦ (f.subset_interior_succ' n).trans interior_subset) h
 
-variable (K : CompactExhaustion α)
+variable (K : CompactExhaustion X)
 
 @[simp]
 theorem toFun_eq_coe : K.toFun = K := rfl
@@ -372,25 +372,25 @@ theorem iUnion_eq : ⋃ n, K n = univ :=
   K.iUnion_eq'
 #align compact_exhaustion.Union_eq CompactExhaustion.iUnion_eq
 
-theorem exists_mem (x : α) : ∃ n, x ∈ K n :=
+theorem exists_mem (x : X) : ∃ n, x ∈ K n :=
   iUnion_eq_univ_iff.1 K.iUnion_eq x
 #align compact_exhaustion.exists_mem CompactExhaustion.exists_mem
 
 /-- The minimal `n` such that `x ∈ K n`. -/
-protected noncomputable def find (x : α) : ℕ :=
+protected noncomputable def find (x : X) : ℕ :=
   Nat.find (K.exists_mem x)
 #align compact_exhaustion.find CompactExhaustion.find
 
-theorem mem_find (x : α) : x ∈ K (K.find x) :=
+theorem mem_find (x : X) : x ∈ K (K.find x) :=
   Nat.find_spec (K.exists_mem x)
 #align compact_exhaustion.mem_find CompactExhaustion.mem_find
 
-theorem mem_iff_find_le {x : α} {n : ℕ} : x ∈ K n ↔ K.find x ≤ n :=
+theorem mem_iff_find_le {x : X} {n : ℕ} : x ∈ K n ↔ K.find x ≤ n :=
   ⟨fun h => Nat.find_min' (K.exists_mem x) h, fun h => K.subset h <| K.mem_find x⟩
 #align compact_exhaustion.mem_iff_find_le CompactExhaustion.mem_iff_find_le
 
 /-- Prepend the empty set to a compact exhaustion `K n`. -/
-def shiftr : CompactExhaustion α where
+def shiftr : CompactExhaustion X where
   toFun n := Nat.casesOn n ∅ K
   isCompact' n := Nat.casesOn n isCompact_empty K.isCompact
   subset_interior_succ' n := Nat.casesOn n (empty_subset _) K.subset_interior_succ
@@ -398,11 +398,11 @@ def shiftr : CompactExhaustion α where
 #align compact_exhaustion.shiftr CompactExhaustion.shiftr
 
 @[simp]
-theorem find_shiftr (x : α) : K.shiftr.find x = K.find x + 1 :=
+theorem find_shiftr (x : X) : K.shiftr.find x = K.find x + 1 :=
   Nat.find_comp_succ _ _ (not_mem_empty _)
 #align compact_exhaustion.find_shiftr CompactExhaustion.find_shiftr
 
-theorem mem_diff_shiftr_find (x : α) : x ∈ K.shiftr (K.find x + 1) \ K.shiftr (K.find x) :=
+theorem mem_diff_shiftr_find (x : X) : x ∈ K.shiftr (K.find x + 1) \ K.shiftr (K.find x) :=
   ⟨K.mem_find _,
     mt K.shiftr.mem_iff_find_le.1 <| by simp only [find_shiftr, not_le, Nat.lt_succ_self]⟩
 #align compact_exhaustion.mem_diff_shiftr_find CompactExhaustion.mem_diff_shiftr_find
@@ -424,8 +424,8 @@ noncomputable def choice (X : Type*) [TopologicalSpace X] [WeaklyLocallyCompactS
     exact iUnion_mono' fun n => ⟨n + 1, subset_union_right _ _⟩
 #align compact_exhaustion.choice CompactExhaustion.choice
 
-noncomputable instance [LocallyCompactSpace α] [SigmaCompactSpace α] :
-    Inhabited (CompactExhaustion α) :=
-  ⟨CompactExhaustion.choice α⟩
+noncomputable instance [LocallyCompactSpace X] [SigmaCompactSpace X] :
+    Inhabited (CompactExhaustion X) :=
+  ⟨CompactExhaustion.choice X⟩
 
 end CompactExhaustion

--- a/Mathlib/Topology/Compactness/SigmaCompact.lean
+++ b/Mathlib/Topology/Compactness/SigmaCompact.lean
@@ -17,7 +17,7 @@ open Set Filter Topology TopologicalSpace Classical
 
 universe u v
 
-variable {X : Type*} {Y : Type*} {ι : Type*} {π : ι → Type*}
+variable {X : Type*} {Y : Type*} {ι : Type*}
 variable [TopologicalSpace X] [TopologicalSpace Y] {s t : Set X}
 
 /-- A subset `s ⊆ X` is called **σ-compact** if it is the union of countably many compact sets. -/
@@ -34,7 +34,7 @@ lemma isSigmaCompact_empty : IsSigmaCompact (∅ : Set X) :=
   IsCompact.isSigmaCompact isCompact_empty
 
 /-- Countable unions of compact sets are σ-compact. -/
-lemma isSigmaCompact_iUnion_of_isCompact {ι : Type*} [hι : Countable ι] (s : ι → Set X)
+lemma isSigmaCompact_iUnion_of_isCompact [hι : Countable ι] (s : ι → Set X)
     (hcomp : ∀ i, IsCompact (s i)) : IsSigmaCompact (⋃ i, s i) := by
   rcases isEmpty_or_nonempty ι
   · simp only [iUnion_of_empty, isSigmaCompact_empty]
@@ -50,7 +50,7 @@ lemma isSigmaCompact_sUnion_of_isCompact {S : Set (Set X)} (hc : Set.Countable S
   apply isSigmaCompact_iUnion_of_isCompact _ (fun ⟨s, hs⟩ ↦ hcomp s hs)
 
 /-- Countable unions of σ-compact sets are σ-compact. -/
-lemma isSigmaCompact_iUnion {ι : Type*} [Countable ι] (s : ι → Set X)
+lemma isSigmaCompact_iUnion [Countable ι] (s : ι → Set X)
     (hcomp : ∀ i, IsSigmaCompact (s i)) : IsSigmaCompact (⋃ i, s i) := by
   -- Choose a decomposition s_i = ⋃ K_i,j for each i.
   choose K hcomp hcov using fun i ↦ hcomp i
@@ -70,7 +70,7 @@ lemma isSigmaCompact_sUnion (S : Set (Set X)) (hc : Set.Countable S)
   apply sUnion_eq_iUnion.symm ▸ isSigmaCompact_iUnion _ hcomp
 
 /-- Countable unions of σ-compact sets are σ-compact. -/
-lemma isSigmaCompact_biUnion {ι : Type*} {s : Set ι} {S : ι → Set X} (hc : Set.Countable s)
+lemma isSigmaCompact_biUnion {s : Set ι} {S : ι → Set X} (hc : Set.Countable s)
     (hcomp : ∀ (i : ι), i ∈ s → IsSigmaCompact (S i)) :
     IsSigmaCompact (⋃ (i : ι) (_ : i ∈ s), S i) := by
   have : Countable ↑s := countable_coe_iff.mpr hc
@@ -224,13 +224,13 @@ instance [SigmaCompactSpace Y] : SigmaCompactSpace (X × Y) :=
       simp only [iUnion_prod_of_monotone (compactCovering_subset X) (compactCovering_subset Y),
         iUnion_compactCovering, univ_prod_univ]⟩⟩
 
-instance [Finite ι] [∀ i, TopologicalSpace (π i)] [∀ i, SigmaCompactSpace (π i)] :
-    SigmaCompactSpace (∀ i, π i) := by
-  refine' ⟨⟨fun n => Set.pi univ fun i => compactCovering (π i) n,
-    fun n => isCompact_univ_pi fun i => isCompact_compactCovering (π i) _, _⟩⟩
+instance [Finite ι] {X : ι → Type*} [∀ i, TopologicalSpace (X i)] [∀ i, SigmaCompactSpace (X i)] :
+    SigmaCompactSpace (∀ i, X i) := by
+  refine' ⟨⟨fun n => Set.pi univ fun i => compactCovering (X i) n,
+    fun n => isCompact_univ_pi fun i => isCompact_compactCovering (X i) _, _⟩⟩
   rw [iUnion_univ_pi_of_monotone]
   · simp only [iUnion_compactCovering, pi_univ]
-  · exact fun i => compactCovering_subset (π i)
+  · exact fun i => compactCovering_subset (X i)
 
 instance [SigmaCompactSpace Y] : SigmaCompactSpace (Sum X Y) :=
   ⟨⟨fun n => Sum.inl '' compactCovering X n ∪ Sum.inr '' compactCovering Y n, fun n =>
@@ -239,12 +239,12 @@ instance [SigmaCompactSpace Y] : SigmaCompactSpace (Sum X Y) :=
       by simp only [iUnion_union_distrib, ← image_iUnion, iUnion_compactCovering, image_univ,
         range_inl_union_range_inr]⟩⟩
 
-instance [Countable ι] [∀ i, TopologicalSpace (π i)] [∀ i, SigmaCompactSpace (π i)] :
-    SigmaCompactSpace (Σi, π i) := by
+instance [Countable ι] {X : ι → Type*} [∀ i, TopologicalSpace (X i)]
+    [∀ i, SigmaCompactSpace (X i)] : SigmaCompactSpace (Σi, X i) := by
   cases isEmpty_or_nonempty ι
   · infer_instance
   · rcases exists_surjective_nat ι with ⟨f, hf⟩
-    refine' ⟨⟨fun n => ⋃ k ≤ n, Sigma.mk (f k) '' compactCovering (π (f k)) n, fun n => _, _⟩⟩
+    refine' ⟨⟨fun n => ⋃ k ≤ n, Sigma.mk (f k) '' compactCovering (X (f k)) n, fun n => _, _⟩⟩
     · refine' (finite_le_nat _).isCompact_biUnion fun k _ => _
       exact (isCompact_compactCovering _ _).image continuous_sigmaMk
     · simp only [iUnion_eq_univ_iff, Sigma.forall, mem_iUnion]
@@ -270,7 +270,7 @@ instance [SigmaCompactSpace Y] : SigmaCompactSpace (ULift.{u} Y) :=
 
 /-- If `X` is a `σ`-compact space, then a locally finite family of nonempty sets of `X` can have
 only countably many elements, `Set.Countable` version. -/
-protected theorem LocallyFinite.countable_univ {ι : Type*} {f : ι → Set X} (hf : LocallyFinite f)
+protected theorem LocallyFinite.countable_univ {f : ι → Set X} (hf : LocallyFinite f)
     (hne : ∀ i, (f i).Nonempty) : (univ : Set ι).Countable := by
   have := fun n => hf.finite_nonempty_inter_compact (isCompact_compactCovering X n)
   refine (countable_iUnion fun n => (this n).countable).mono fun i _ => ?_

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.2.0-rc3
+leanprover/lean4:v4.2.0-rc4


### PR DESCRIPTION
Greek letters for topological spaces are outdated, use letters X, Y, Z instead.
[Zulip discussion](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Naming.20convention.3A.20topological.20spaces/near/395769893).

---------

I'm following my checklist [here](https://github.com/leanprover-community/mathlib4/pull/7589#issuecomment-1755212582).
Best reviewed commit by commit. (Before this change, the names X, Y or Z were sometimes (but inconsistently) used for topological spaces. This change makes things consistent.)

---------

Rebase of #7639 on top of latest master.

