### PR TITLE
feat: prove injectivity of Fin

### DIFF
--- a/Mathlib/Logic/Equiv/Fin.lean
+++ b/Mathlib/Logic/Equiv/Fin.lean
@@ -6,6 +6,7 @@ Authors: Kenny Lau
 import Mathlib.Data.Fin.VecNotation
 import Mathlib.Data.Int.Order.Basic
 import Mathlib.Logic.Equiv.Defs
+import Mathlib.Logic.Equiv.Option
 
 #align_import logic.equiv.fin from "leanprover-community/mathlib"@"bd835ef554f37ef9b804f0903089211f89cb370b"
 
@@ -546,3 +547,32 @@ instance subsingleton_fin_zero : Subsingleton (Fin 0) :=
 instance subsingleton_fin_one : Subsingleton (Fin 1) :=
   finOneEquiv.subsingleton
 #align subsingleton_fin_one subsingleton_fin_one
+
+def Fin.equivOfSuccEquiv (h : Fin (n+1) ≃ Fin (m+1)) : Fin n ≃ Fin m :=
+  Equiv.removeNone <| calc
+    _ ≃ Fin (n+1) := (finSuccEquiv _).symm
+    _ ≃ Fin (m+1) := h
+    _ ≃ _         := finSuccEquiv _
+
+/-!
+  ## Injectivity of Fin
+  As a corollary of these equivalences, we get that `Fin` is injective
+-/
+
+theorem Fin.inj_equiv (eqv : Fin n ≃ Fin m) : n = m := by
+  induction n generalizing m <;> cases m
+  case zero.zero      => rfl
+  case zero.succ      => exact Fin.elim0 <| eqv.symm ⟨0, by simp⟩
+  case succ.zero      => exact Fin.elim0 <| eqv ⟨0, by simp⟩
+  case succ.succ ih _ => rw [ih]; apply Fin.equivOfSuccEquiv eqv
+
+theorem Fin.inj : Fin n = Fin m → n = m :=
+  inj_equiv ∘ Equiv.cast
+
+@[simp] theorem Fin.root_cast_eq_cast (h : Fin n = Fin m) (x : Fin n) :
+    _root_.cast h x = x.cast (inj h) := by
+  cases inj h; simp
+
+@[simp] theorem Fin.eqRec_eq_cast (h : Fin n = Fin m) (x : Fin n) :
+    h ▸ x = x.cast (inj h) := by
+  cases inj h; simp


### PR DESCRIPTION
Prove that the type function `Fin` is injective, 
and use this result to rewrite `cast` and `Eq.rec` into `Fin.cast`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

The use of `cast` is generally discourages because it is difficult to work with. This PR improves the ergonomics of `cast` with equalites of the form `Fin i = Fin j` specifically, by showing that this implies that `i = j` and adding `simp`-lemmas to rewrite the `cast` into `Fin.cast`.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
