### PR TITLE
[Merged by Bors] - chore: update dependency URLs

### DIFF
--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -2,6 +2,14 @@
  "packagesDir": "lake-packages",
  "packages":
  [{"git":
+   {"url": "https://github.com/leanprover/std4",
+    "subDir?": null,
+    "rev": "a4b2584dd4468489d14e9731ff303ec6d674873f",
+    "opts": {},
+    "name": "std",
+    "inputRev?": "main",
+    "inherited": false}},
+  {"git":
    {"url": "https://github.com/gebner/quote4",
     "subDir?": null,
     "rev": "a387c0eb611857e2460cf97a8e861c944286e6b2",
@@ -10,7 +18,15 @@
     "inputRev?": "master",
     "inherited": false}},
   {"git":
-   {"url": "https://github.com/mhuisi/lean4-cli.git",
+   {"url": "https://github.com/leanprover-community/aesop",
+    "subDir?": null,
+    "rev": "b601328752091a1cfcaebdd6b6b7c30dc5ffd946",
+    "opts": {},
+    "name": "aesop",
+    "inputRev?": "master",
+    "inherited": false}},
+  {"git":
+   {"url": "https://github.com/leanprover/lean4-cli",
     "subDir?": null,
     "rev": "39229f3630d734af7d9cfb5937ddc6b41d3aa6aa",
     "opts": {},
@@ -18,27 +34,11 @@
     "inputRev?": "nightly",
     "inherited": false}},
   {"git":
-   {"url": "https://github.com/EdAyers/ProofWidgets4",
+   {"url": "https://github.com/leanprover-community/ProofWidgets4",
     "subDir?": null,
     "rev": "27715d1daf32b9657dc38cd52172d77b19bde4ba",
     "opts": {},
     "name": "proofwidgets",
     "inputRev?": "v0.0.18",
-    "inherited": false}},
-  {"git":
-   {"url": "https://github.com/JLimperg/aesop",
-    "subDir?": null,
-    "rev": "0bd8465d8a5cfdd53c1ff0fd57ca5eaa53eb455c",
-    "opts": {},
-    "name": "aesop",
-    "inputRev?": "master",
-    "inherited": false}},
-  {"git":
-   {"url": "https://github.com/leanprover/std4",
-    "subDir?": null,
-    "rev": "a4b2584dd4468489d14e9731ff303ec6d674873f",
-    "opts": {},
-    "name": "std",
-    "inputRev?": "main",
     "inherited": false}}],
  "name": "mathlib"}

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -47,7 +47,7 @@ meta if get_config? doc = some "on" then -- do not download and build doc-gen4 b
 require «doc-gen4» from git "https://github.com/leanprover/doc-gen4" @ "main"
 
 require std from git "https://github.com/leanprover/std4" @ "main"
-require Qq from git "https://github.com/gebner/quote4" @ "master"
+require Qq from git "https://github.com/leanprover-community/quote4" @ "master"
 require aesop from git "https://github.com/leanprover-community/aesop" @ "master"
 require Cli from git "https://github.com/leanprover/lean4-cli" @ "nightly"
 require proofwidgets from git "https://github.com/leanprover-community/ProofWidgets4" @ "v0.0.18"

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -30,6 +30,7 @@ lean_lib Mathlib where
   moreLeanArgs := moreLeanArgs
   weakLeanArgs := weakLeanArgs
 
+/-- `lake exe runMathlibLinter` runs the linter on all of Mathlib (or individual files). -/
 -- Due to a change in Lake at v4.1.0-rc1, we need to give this a different name
 -- than the `lean_exe runLinter` inherited from Std, or we always run that.
 -- See https://github.com/leanprover/lean4/issues/2548
@@ -37,6 +38,7 @@ lean_exe runMathlibLinter where
   root := `scripts.runMathlibLinter
   supportInterpreter := true
 
+/-- `lake exe checkYaml` verifies that all declarations referred to in `docs/*.yaml` files exist. -/
 lean_exe checkYaml where
   root := `scripts.checkYaml
   supportInterpreter := true
@@ -46,15 +48,16 @@ require «doc-gen4» from git "https://github.com/leanprover/doc-gen4" @ "main"
 
 require std from git "https://github.com/leanprover/std4" @ "main"
 require Qq from git "https://github.com/gebner/quote4" @ "master"
-require aesop from git "https://github.com/JLimperg/aesop" @ "master"
-require Cli from git "https://github.com/mhuisi/lean4-cli.git" @ "nightly"
-require proofwidgets from git "https://github.com/EdAyers/ProofWidgets4" @ "v0.0.18"
+require aesop from git "https://github.com/leanprover-community/aesop" @ "master"
+require Cli from git "https://github.com/leanprover/lean4-cli" @ "nightly"
+require proofwidgets from git "https://github.com/leanprover-community/ProofWidgets4" @ "v0.0.18"
 
 lean_lib Cache where
   moreLeanArgs := moreLeanArgs
   weakLeanArgs := weakLeanArgs
   roots := #[`Cache]
 
+/-- `lake exe cache get` retrieves precompiled `.olean` files from a central server. -/
 lean_exe cache where
   root := `Cache.Main
 
@@ -70,6 +73,7 @@ lean_lib Counterexamples where
 lean_lib ImportGraph where
   roots := #[`ImportGraph]
 
+/-- `lake exe graph` constructs import graphs in `.dot` or graphical formats. -/
 lean_exe graph where
   root := `ImportGraph.Main
   supportInterpreter := true


### PR DESCRIPTION
All of Mathlib's dependencies now live under `leanprover` or `leanprover-community`! 🎉 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
