### PR TITLE
[Merged by Bors] -  chore(Topology): minimize some imports

### DIFF
--- a/Mathlib/Topology/Clopen.lean
+++ b/Mathlib/Topology/Clopen.lean
@@ -3,14 +3,8 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro, Yury Kudryashov
 -/
-import Mathlib.Order.Filter.Pi
-import Mathlib.Topology.Bases
-import Mathlib.Data.Finset.Order
-import Mathlib.Data.Set.Accumulate
+import Mathlib.Topology.ContinuousOn
 import Mathlib.Data.Set.BoolIndicator
-import Mathlib.Topology.Bornology.Basic
-import Mathlib.Topology.LocallyFinite
-import Mathlib.Order.Minimal
 
 /-!
 # Clopen sets

--- a/Mathlib/Topology/CompactOpen.lean
+++ b/Mathlib/Topology/CompactOpen.lean
@@ -4,9 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Reid Barton
 -/
 import Mathlib.Topology.ContinuousFunction.Basic
-import Mathlib.Topology.Homeomorph
-import Mathlib.Topology.Compactness.Compact
-import Mathlib.Topology.Maps
 
 #align_import topology.compact_open from "leanprover-community/mathlib"@"4c19a16e4b705bf135cf9a80ac18fcc99c438514"
 

--- a/Mathlib/Topology/Compactness/Compact.lean
+++ b/Mathlib/Topology/Compactness/Compact.lean
@@ -3,14 +3,10 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro, Yury Kudryashov
 -/
-import Mathlib.Order.Filter.Pi
 import Mathlib.Topology.Bases
-import Mathlib.Data.Finset.Order
 import Mathlib.Data.Set.Accumulate
-import Mathlib.Data.Set.BoolIndicator
 import Mathlib.Topology.Bornology.Basic
 import Mathlib.Topology.LocallyFinite
-import Mathlib.Order.Minimal
 /-!
 # Compact sets and compact spaces
 

--- a/Mathlib/Topology/Connected/Basic.lean
+++ b/Mathlib/Topology/Connected/Basic.lean
@@ -3,7 +3,6 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro, Yury Kudryashov
 -/
-import Mathlib.Data.Set.BoolIndicator
 import Mathlib.Order.SuccPred.Relation
 import Mathlib.Topology.Clopen
 import Mathlib.Topology.Irreducible

--- a/Mathlib/Topology/Connected/PathConnected.lean
+++ b/Mathlib/Topology/Connected/PathConnected.lean
@@ -5,7 +5,6 @@ Authors: Patrick Massot
 -/
 import Mathlib.Topology.Algebra.Order.ProjIcc
 import Mathlib.Topology.CompactOpen
-import Mathlib.Topology.ContinuousFunction.Basic
 import Mathlib.Topology.UnitInterval
 
 #align_import topology.path_connected from "leanprover-community/mathlib"@"f2ce6086713c78a7f880485f7917ea547a215982"

--- a/Mathlib/Topology/EMetricSpace/Basic.lean
+++ b/Mathlib/Topology/EMetricSpace/Basic.lean
@@ -3,7 +3,6 @@ Copyright (c) 2015, 2017 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Robert Y. Lewis, Johannes Hölzl, Mario Carneiro, Sébastien Gouëzel
 -/
-import Mathlib.Data.Nat.Interval
 import Mathlib.Data.Real.ENNReal
 import Mathlib.Topology.UniformSpace.Pi
 import Mathlib.Topology.UniformSpace.UniformConvergence

--- a/Mathlib/Topology/Inseparable.lean
+++ b/Mathlib/Topology/Inseparable.lean
@@ -3,7 +3,6 @@ Copyright (c) 2021 Andrew Yang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Andrew Yang, Yury G. Kudryashov
 -/
-import Mathlib.Data.Setoid.Basic
 import Mathlib.Tactic.TFAE
 import Mathlib.Topology.ContinuousOn
 

--- a/Mathlib/Topology/MetricSpace/Lipschitz.lean
+++ b/Mathlib/Topology/MetricSpace/Lipschitz.lean
@@ -3,11 +3,10 @@ Copyright (c) 2018 Rohan Mitta. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Rohan Mitta, Kevin Buzzard, Alistair Tucker, Johannes Hölzl, Yury Kudryashov
 -/
-import Mathlib.Logic.Function.Iterate
+import Mathlib.Topology.Bornology.Hom
+import Mathlib.Topology.MetricSpace.Basic
 import Mathlib.Data.Set.Intervals.ProjIcc
 import Mathlib.Topology.Algebra.Order.Field
-import Mathlib.Topology.MetricSpace.Basic
-import Mathlib.Topology.Bornology.Hom
 import Mathlib.Tactic.GCongr
 
 #align_import topology.metric_space.lipschitz from "leanprover-community/mathlib"@"f2ce6086713c78a7f880485f7917ea547a215982"

--- a/Mathlib/Topology/MetricSpace/Lipschitz.lean
+++ b/Mathlib/Topology/MetricSpace/Lipschitz.lean
@@ -3,10 +3,10 @@ Copyright (c) 2018 Rohan Mitta. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Rohan Mitta, Kevin Buzzard, Alistair Tucker, Johannes Hölzl, Yury Kudryashov
 -/
-import Mathlib.Topology.Bornology.Hom
-import Mathlib.Topology.MetricSpace.Basic
 import Mathlib.Data.Set.Intervals.ProjIcc
 import Mathlib.Topology.Algebra.Order.Field
+import Mathlib.Topology.Bornology.Hom
+import Mathlib.Topology.MetricSpace.Basic
 
 #align_import topology.metric_space.lipschitz from "leanprover-community/mathlib"@"f2ce6086713c78a7f880485f7917ea547a215982"
 

--- a/Mathlib/Topology/MetricSpace/Lipschitz.lean
+++ b/Mathlib/Topology/MetricSpace/Lipschitz.lean
@@ -7,7 +7,6 @@ import Mathlib.Topology.Bornology.Hom
 import Mathlib.Topology.MetricSpace.Basic
 import Mathlib.Data.Set.Intervals.ProjIcc
 import Mathlib.Topology.Algebra.Order.Field
-import Mathlib.Tactic.GCongr
 
 #align_import topology.metric_space.lipschitz from "leanprover-community/mathlib"@"f2ce6086713c78a7f880485f7917ea547a215982"
 

--- a/Mathlib/Topology/NoetherianSpace.lean
+++ b/Mathlib/Topology/NoetherianSpace.lean
@@ -3,7 +3,6 @@ Copyright (c) 2022 Andrew Yang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Andrew Yang
 -/
-import Mathlib.Order.CompactlyGenerated
 import Mathlib.Topology.Sets.Closeds
 
 #align_import topology.noetherian_space from "leanprover-community/mathlib"@"dc6c365e751e34d100e80fe6e314c3c3e0fd2988"


### PR DESCRIPTION
For faster build times and clearer dependencies. No attempt at being exhaustive.

The new import in `Clopen.lean` had been transitively imported before.

----------
Rebased version of #7629, with a few additional changes. All review comments there taken into account.

Found using #minimize_imports (and checking things still build) - that command is really helpful!