### PR TITLE
[Merged by Bors] - feat: natDegree_sub_C

### DIFF
--- a/Mathlib/Data/Polynomial/Basic.lean
+++ b/Mathlib/Data/Polynomial/Basic.lean
@@ -527,6 +527,19 @@ theorem C_add : C (a + b) = C a + C b :=
   C.map_add a b
 #align polynomial.C_add Polynomial.C_add
 
+theorem C_neg : C (-a) = -C a :=
+  RingHom.map_neg C a
+#align polynomial.C_neg Polynomial.C_neg
+
+@[simp]
+theorem Polynomial.natDegree_sub_C {a : R} :
+    Polynomial.natDegree (p - Polynomial.C a) = Polynomial.natDegree p := by
+  rw [sub_eq_add_neg, ← Polynomial.C_neg, Polynomial.natDegree_add_C]
+
+theorem C_sub : C (a - b) = C a - C b :=
+  RingHom.map_sub C a b
+#align polynomial.C_sub Polynomial.C_sub
+
 @[simp]
 theorem smul_C {S} [SMulZeroClass S R] (s : S) (r : R) : s • C r = C (s • r) :=
   smul_monomial _ _ r

--- a/Mathlib/Data/Polynomial/Basic.lean
+++ b/Mathlib/Data/Polynomial/Basic.lean
@@ -527,19 +527,6 @@ theorem C_add : C (a + b) = C a + C b :=
   C.map_add a b
 #align polynomial.C_add Polynomial.C_add
 
-theorem C_neg : C (-a) = -C a :=
-  RingHom.map_neg C a
-#align polynomial.C_neg Polynomial.C_neg
-
-@[simp]
-theorem Polynomial.natDegree_sub_C {a : R} :
-    Polynomial.natDegree (p - Polynomial.C a) = Polynomial.natDegree p := by
-  rw [sub_eq_add_neg, ← Polynomial.C_neg, Polynomial.natDegree_add_C]
-
-theorem C_sub : C (a - b) = C a - C b :=
-  RingHom.map_sub C a b
-#align polynomial.C_sub Polynomial.C_sub
-
 @[simp]
 theorem smul_C {S} [SMulZeroClass S R] (s : S) (r : R) : s • C r = C (s • r) :=
   smul_monomial _ _ r
@@ -1235,6 +1222,14 @@ theorem support_neg {p : R[X]} : (-p).support = p.support := by
 
 theorem C_eq_int_cast (n : ℤ) : C (n : R) = n := by simp
 #align polynomial.C_eq_int_cast Polynomial.C_eq_int_cast
+
+theorem C_neg : C (-a) = -C a :=
+  RingHom.map_neg C a
+#align polynomial.C_neg Polynomial.C_neg
+
+theorem C_sub : C (a - b) = C a - C b :=
+  RingHom.map_sub C a b
+#align polynomial.C_sub Polynomial.C_sub
 
 end Ring
 

--- a/Mathlib/Data/Polynomial/Degree/Definitions.lean
+++ b/Mathlib/Data/Polynomial/Degree/Definitions.lean
@@ -1544,9 +1544,8 @@ theorem degree_X_sub_C (a : R) : degree (X - C a) = 1 := by
   rw [sub_eq_add_neg, ← map_neg C a, degree_X_add_C]
 #align polynomial.degree_X_sub_C Polynomial.degree_X_sub_C
 
-@[simp]
-theorem natDegree_X_sub_C (x : R) : (X - C x).natDegree = 1 :=
-  natDegree_eq_of_degree_eq_some <| degree_X_sub_C x
+theorem natDegree_X_sub_C (x : R) : (X - C x).natDegree = 1 := by
+  rw [natDegree_sub_C, natDegree_X]
 #align polynomial.nat_degree_X_sub_C Polynomial.natDegree_X_sub_C
 
 @[simp]

--- a/Mathlib/Data/Polynomial/Degree/Definitions.lean
+++ b/Mathlib/Data/Polynomial/Degree/Definitions.lean
@@ -1335,6 +1335,13 @@ section Ring
 
 variable [Ring R] {p q : R[X]}
 
+theorem degree_sub_C (hp : 0 < degree p) : degree (p - C a) = degree p := by
+  rw [sub_eq_add_neg, ← C_neg, degree_add_C hp]
+
+@[simp]
+theorem natDegree_sub_C {a : R} : natDegree (p - C a) = natDegree p := by
+  rw [sub_eq_add_neg, ← C_neg, natDegree_add_C]
+
 theorem degree_sub_le (p q : R[X]) : degree (p - q) ≤ max (degree p) (degree q) := by
   simpa only [degree_neg q] using degree_add_le p (-q)
 #align polynomial.degree_sub_le Polynomial.degree_sub_le

--- a/Mathlib/Data/Polynomial/Eval.lean
+++ b/Mathlib/Data/Polynomial/Eval.lean
@@ -1246,14 +1246,6 @@ section Ring
 
 variable [Ring R] {p q r : R[X]}
 
-theorem C_neg : C (-a) = -C a :=
-  RingHom.map_neg C a
-#align polynomial.C_neg Polynomial.C_neg
-
-theorem C_sub : C (a - b) = C a - C b :=
-  RingHom.map_sub C a b
-#align polynomial.C_sub Polynomial.C_sub
-
 @[simp]
 protected theorem map_sub {S} [Ring S] (f : R →+* S) : (p - q).map f = p.map f - q.map f :=
   (mapRingHom f).map_sub p q

--- a/Mathlib/LinearAlgebra/Matrix/Charpoly/Coeff.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Charpoly/Coeff.lean
@@ -55,7 +55,7 @@ theorem charmatrix_apply_natDegree [Nontrivial R] (i j : n) :
 
 theorem charmatrix_apply_natDegree_le (i j : n) :
     (charmatrix M i j).natDegree ≤ ite (i = j) 1 0 := by
-  split_ifs with h <;> simp [h, natDegree_X_sub_C_le, -natDegree_sub_C]
+  split_ifs with h <;> simp [h, natDegree_X_le]
 #align charmatrix_apply_nat_degree_le charmatrix_apply_natDegree_le
 
 namespace Matrix

--- a/Mathlib/LinearAlgebra/Matrix/Charpoly/Coeff.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Charpoly/Coeff.lean
@@ -55,7 +55,7 @@ theorem charmatrix_apply_natDegree [Nontrivial R] (i j : n) :
 
 theorem charmatrix_apply_natDegree_le (i j : n) :
     (charmatrix M i j).natDegree ≤ ite (i = j) 1 0 := by
-  split_ifs with h <;> simp [h, natDegree_X_sub_C_le]
+  split_ifs with h <;> simp [h, natDegree_X_sub_C_le, -natDegree_sub_C]
 #align charmatrix_apply_nat_degree_le charmatrix_apply_natDegree_le
 
 namespace Matrix


### PR DESCRIPTION
Adds `degree_sub_C, natDegree_sub_C`, analogous to `..._add_C`. 

Also relocates `C_neg` and `C_sub` to `Basic.lean` (where `C_add` is) so that the new lemmas can be in the same file as their `add` counterparts.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
