### PR TITLE
[Merged by Bors] - fix: `eta_reduce` tactic should recursively reduce

### DIFF
--- a/Mathlib/Tactic/DefEqTransformations.lean
+++ b/Mathlib/Tactic/DefEqTransformations.lean
@@ -154,7 +154,10 @@ elab "unfold_projs" : conv => runDefEqConvTactic unfoldProjs
 
 /-- Eta reduce everything -/
 def etaReduceAll (e : Expr) : MetaM Expr := do
-  transform e fun node => pure <| .continue node.etaExpanded?
+  transform e fun node =>
+    match node.etaExpandedStrict? with
+    | some e' => return .visit e'
+    | none => return .continue
 
 /--
 `eta_reduce at loc` eta reduces all sub-expressions at the given location.

--- a/test/DefEqTransformations.lean
+++ b/test/DefEqTransformations.lean
@@ -2,6 +2,8 @@ import Mathlib.Tactic.DefEqTransformations
 import Mathlib.Init.Logic
 import Std.Tactic.GuardExpr
 
+set_option autoImplicit true
+
 private axiom test_sorry : ∀ {α}, α
 namespace Tests
 
@@ -79,6 +81,12 @@ example (m n : Nat) : (m == n) = true := by
   unfold_projs
   guard_target =ₛ Nat.beq m n = true
   exact test_sorry
+
+example {α : Type u} (f : α → α) (a : α) :
+    (fun x => (fun x => f x) x) a = f a := by
+  eta_reduce
+  guard_target =ₛ f a = f a
+  rfl
 
 example (f : Nat → Nat) : (fun a => f a) = (fun a => f (f a)) := by
   eta_expand


### PR DESCRIPTION
Reported by eric-wieser in #7773


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
