### PR TITLE
[Merged by Bors] - refactor: List.All₂ to List.Forall

### DIFF
--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -4167,15 +4167,15 @@ section Forall
 variable {p q : α → Prop} {l : List α}
 
 @[simp]
-theorem Forall_cons (p : α → Prop) (x : α) : ∀ l : List α, Forall p (x :: l) ↔ p x ∧ Forall p l
+theorem forall_cons (p : α → Prop) (x : α) : ∀ l : List α, Forall p (x :: l) ↔ p x ∧ Forall p l
   | [] => (and_true_iff _).symm
   | _ :: _ => Iff.rfl
-#align list.all₂_cons List.Forall_cons
+#align list.all₂_cons List.forall_cons
 
-theorem Forall_iff_forall : ∀ {l : List α}, Forall p l ↔ ∀ x ∈ l, p x
+theorem forall_iff_forall_mem : ∀ {l : List α}, Forall p l ↔ ∀ x ∈ l, p x
   | [] => (iff_true_intro <| forall_mem_nil _).symm
-  | x :: l => by rw [forall_mem_cons, Forall_cons, Forall_iff_forall]
-#align list.all₂_iff_forall List.Forall_iff_forall
+  | x :: l => by rw [forall_mem_cons, forall_cons, forall_iff_forall_mem]
+#align list.all₂_iff_forall List.forall_iff_forall_mem
 
 theorem Forall.imp (h : ∀ x, p x → q x) : ∀ {l : List α}, Forall p l → Forall q l
   | [] => id
@@ -4183,12 +4183,12 @@ theorem Forall.imp (h : ∀ x, p x → q x) : ∀ {l : List α}, Forall p l → 
 #align list.all₂.imp List.Forall.imp
 
 @[simp]
-theorem Forall_map_iff {p : β → Prop} (f : α → β) : Forall p (l.map f) ↔ Forall (p ∘ f) l := by
+theorem forall_map_iff {p : β → Prop} (f : α → β) : Forall p (l.map f) ↔ Forall (p ∘ f) l := by
   induction l <;> simp [*]
-#align list.all₂_map_iff List.Forall_map_iff
+#align list.all₂_map_iff List.forall_map_iff
 
 instance (p : α → Prop) [DecidablePred p] : DecidablePred (Forall p) := fun _ =>
-  decidable_of_iff' _ Forall_iff_forall
+  decidable_of_iff' _ forall_iff_forall_mem
 
 end Forall
 

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -4166,9 +4166,15 @@ section Forall
 
 variable {p q : α → Prop} {l : List α}
 
+@[simp]
+theorem Forall_cons (p : α → Prop) (x : α) : ∀ l : List α, Forall p (x :: l) ↔ p x ∧ Forall p l
+  | [] => (and_true_iff _).symm
+  | _ :: _ => Iff.rfl
+#align list.all₂_cons List.Forall_cons
+
 theorem Forall_iff_forall : ∀ {l : List α}, Forall p l ↔ ∀ x ∈ l, p x
   | [] => (iff_true_intro <| forall_mem_nil _).symm
-  | x :: l => by rw [forall_mem_cons, Forall, Forall_iff_forall]
+  | x :: l => by rw [forall_mem_cons, Forall_cons, Forall_iff_forall]
 #align list.all₂_iff_forall List.Forall_iff_forall
 
 theorem Forall.imp (h : ∀ x, p x → q x) : ∀ {l : List α}, Forall p l → Forall q l

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -4160,37 +4160,31 @@ end ZipRight
 #noalign list.to_chunks_join
 #noalign list.to_chunks_length_le
 
-/-! ### all₂ -/
+/-! ### Forall -/
 
-section All₂
+section Forall
 
 variable {p q : α → Prop} {l : List α}
 
-@[simp]
-theorem all₂_cons (p : α → Prop) (x : α) : ∀ l : List α, All₂ p (x :: l) ↔ p x ∧ All₂ p l
-  | [] => (and_true_iff _).symm
-  | _ :: _ => Iff.rfl
-#align list.all₂_cons List.all₂_cons
-
-theorem all₂_iff_forall : ∀ {l : List α}, All₂ p l ↔ ∀ x ∈ l, p x
+theorem Forall_iff_forall : ∀ {l : List α}, Forall p l ↔ ∀ x ∈ l, p x
   | [] => (iff_true_intro <| forall_mem_nil _).symm
-  | x :: l => by rw [forall_mem_cons, all₂_cons, all₂_iff_forall]
-#align list.all₂_iff_forall List.all₂_iff_forall
+  | x :: l => by rw [forall_mem_cons, Forall, Forall_iff_forall]
+#align list.all₂_iff_forall List.Forall_iff_forall
 
-theorem All₂.imp (h : ∀ x, p x → q x) : ∀ {l : List α}, All₂ p l → All₂ q l
+theorem Forall.imp (h : ∀ x, p x → q x) : ∀ {l : List α}, Forall p l → Forall q l
   | [] => id
-  | x :: l => by simp; rw [←and_imp]; exact And.imp (h x) (All₂.imp h)
-#align list.all₂.imp List.All₂.imp
+  | x :: l => by simp; rw [←and_imp]; exact And.imp (h x) (Forall.imp h)
+#align list.all₂.imp List.Forall.imp
 
 @[simp]
-theorem all₂_map_iff {p : β → Prop} (f : α → β) : All₂ p (l.map f) ↔ All₂ (p ∘ f) l := by
+theorem Forall_map_iff {p : β → Prop} (f : α → β) : Forall p (l.map f) ↔ Forall (p ∘ f) l := by
   induction l <;> simp [*]
-#align list.all₂_map_iff List.all₂_map_iff
+#align list.all₂_map_iff List.Forall_map_iff
 
-instance (p : α → Prop) [DecidablePred p] : DecidablePred (All₂ p) := fun _ =>
-  decidable_of_iff' _ all₂_iff_forall
+instance (p : α → Prop) [DecidablePred p] : DecidablePred (Forall p) := fun _ =>
+  decidable_of_iff' _ Forall_iff_forall
 
-end All₂
+end Forall
 
 /-! ### Retroattributes
 

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -221,10 +221,11 @@ end mapIdxM
 #align list.forall₂ List.Forall₂
 
 /-- `l.Forall p` is equivalent to `∀ a ∈ l, p a`, but unfolds directly to a conjunction, i.e.
-`List.Forall p [0, 1, 2] = p 0 ∧ p 1 ∧ p 2 ∧ True`. -/
+`List.Forall p [0, 1, 2] = p 0 ∧ p 1 ∧ p 2`. -/
 @[simp]
 def Forall (p : α → Prop) : List α → Prop
   | [] => True
+  | x :: [] => p x
   | x :: l => p x ∧ Forall p l
 #align list.all₂ List.Forall
 

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -220,14 +220,13 @@ end mapIdxM
 #align list.sublists List.sublists
 #align list.forall₂ List.Forall₂
 
-/-- `l.All₂ p` is equivalent to `∀ a ∈ l, p a`, but unfolds directly to a conjunction, i.e.
-`List.All₂ p [0, 1, 2] = p 0 ∧ p 1 ∧ p 2`. -/
+/-- `l.Forall p` is equivalent to `∀ a ∈ l, p a`, but unfolds directly to a conjunction, i.e.
+`List.Forall p [0, 1, 2] = p 0 ∧ p 1 ∧ p 2 ∧ True`. -/
 @[simp]
-def All₂ (p : α → Prop) : List α → Prop
+def Forall (p : α → Prop) : List α → Prop
   | [] => True
-  | x :: [] => p x
-  | x :: l => p x ∧ All₂ p l
-#align list.all₂ List.All₂
+  | x :: l => p x ∧ Forall p l
+#align list.all₂ List.Forall
 
 #align list.transpose List.transpose
 #align list.sections List.sections

--- a/Mathlib/Data/List/Zip.lean
+++ b/Mathlib/Data/List/Zip.lean
@@ -61,7 +61,7 @@ theorem Forall_zipWith {f : α → β → γ} {p : γ → Prop} :
   | [], [], _ => by simp
   | a :: l₁, b :: l₂, h => by
     simp only [length_cons, succ_inj'] at h
-    simp [Forall_zipWith h]
+    simp [all₂_zipWith h]
 #align list.all₂_zip_with List.Forall_zipWith
 
 theorem lt_length_left_of_zipWith {f : α → β → γ} {i : ℕ} {l : List α} {l' : List β}

--- a/Mathlib/Data/List/Zip.lean
+++ b/Mathlib/Data/List/Zip.lean
@@ -57,7 +57,7 @@ theorem zip_swap : ∀ (l₁ : List α) (l₂ : List β), (zip l₁ l₂).map Pr
 
 theorem all₂_zipWith {f : α → β → γ} {p : γ → Prop} :
     ∀ {l₁ : List α} {l₂ : List β} (_h : length l₁ = length l₂),
-      All₂ p (zipWith f l₁ l₂) ↔ Forall₂ (fun x y => p (f x y)) l₁ l₂
+      Forall p (zipWith f l₁ l₂) ↔ Forall₂ (fun x y => p (f x y)) l₁ l₂
   | [], [], _ => by simp
   | a :: l₁, b :: l₂, h => by
     simp only [length_cons, succ_inj'] at h

--- a/Mathlib/Data/List/Zip.lean
+++ b/Mathlib/Data/List/Zip.lean
@@ -55,14 +55,14 @@ theorem zip_swap : ∀ (l₁ : List α) (l₂ : List β), (zip l₁ l₂).map Pr
 
 #align list.length_zip List.length_zip
 
-theorem all₂_zipWith {f : α → β → γ} {p : γ → Prop} :
+theorem Forall_zipWith {f : α → β → γ} {p : γ → Prop} :
     ∀ {l₁ : List α} {l₂ : List β} (_h : length l₁ = length l₂),
       Forall p (zipWith f l₁ l₂) ↔ Forall₂ (fun x y => p (f x y)) l₁ l₂
   | [], [], _ => by simp
   | a :: l₁, b :: l₂, h => by
     simp only [length_cons, succ_inj'] at h
-    simp [all₂_zipWith h]
-#align list.all₂_zip_with List.all₂_zipWith
+    simp [Forall_zipWith h]
+#align list.all₂_zip_with List.Forall_zipWith
 
 theorem lt_length_left_of_zipWith {f : α → β → γ} {i : ℕ} {l : List α} {l' : List β}
     (h : i < (zipWith f l l').length) : i < l.length := by

--- a/Mathlib/Data/List/Zip.lean
+++ b/Mathlib/Data/List/Zip.lean
@@ -55,14 +55,14 @@ theorem zip_swap : ∀ (l₁ : List α) (l₂ : List β), (zip l₁ l₂).map Pr
 
 #align list.length_zip List.length_zip
 
-theorem Forall_zipWith {f : α → β → γ} {p : γ → Prop} :
+theorem forall_zipWith {f : α → β → γ} {p : γ → Prop} :
     ∀ {l₁ : List α} {l₂ : List β} (_h : length l₁ = length l₂),
       Forall p (zipWith f l₁ l₂) ↔ Forall₂ (fun x y => p (f x y)) l₁ l₂
   | [], [], _ => by simp
   | a :: l₁, b :: l₂, h => by
     simp only [length_cons, succ_inj'] at h
-    simp [Forall_zipWith h]
-#align list.all₂_zip_with List.Forall_zipWith
+    simp [forall_zipWith h]
+#align list.all₂_zip_with List.forall_zipWith
 
 theorem lt_length_left_of_zipWith {f : α → β → γ} {i : ℕ} {l : List α} {l' : List β}
     (h : i < (zipWith f l l').length) : i < l.length := by

--- a/Mathlib/Data/List/Zip.lean
+++ b/Mathlib/Data/List/Zip.lean
@@ -61,7 +61,7 @@ theorem Forall_zipWith {f : α → β → γ} {p : γ → Prop} :
   | [], [], _ => by simp
   | a :: l₁, b :: l₂, h => by
     simp only [length_cons, succ_inj'] at h
-    simp [all₂_zipWith h]
+    simp [Forall_zipWith h]
 #align list.all₂_zip_with List.Forall_zipWith
 
 theorem lt_length_left_of_zipWith {f : α → β → γ} {i : ℕ} {l : List α} {l' : List β}

--- a/Mathlib/NumberTheory/Dioph.lean
+++ b/Mathlib/NumberTheory/Dioph.lean
@@ -351,7 +351,7 @@ theorem reindex_dioph (f : α → β) : ∀ _ : Dioph S, Dioph {v | v ∘ f ∈ 
 
 variable {β}
 
-theorem DiophList.Forall (l : List (Set <| α → ℕ)) (d : l.Forall Dioph) :
+theorem DiophList.forall (l : List (Set <| α → ℕ)) (d : l.Forall Dioph) :
     Dioph {v | l.Forall fun S : Set (α → ℕ) => v ∈ S} := by
   suffices ∃ (β : _) (pl : List (Poly (Sum α β))), ∀ v, List.Forall (fun S : Set _ => S v) l ↔
           ∃ t, List.Forall (fun p : Poly (Sum α β) => p (v ⊗ t) = 0) pl
@@ -386,9 +386,9 @@ theorem DiophList.Forall (l : List (Set <| α → ℕ)) (d : l.Forall Dioph) :
                     (fun x : Sum α γ => (v ⊗ t) ((inl ⊗ fun x : γ => inr (inr x)) x)) =
                       v ⊗ t ∘ inr
                     from funext fun s => by cases' s with a b <;> rfl] at hq ⟩⟩⟩⟩
-#align dioph.dioph_list.all₂ Dioph.DiophList.Forall
+#align dioph.dioph_list.all₂ Dioph.DiophList.forall
 
-theorem inter (d : Dioph S) (d' : Dioph S') : Dioph (S ∩ S') := DiophList.Forall [S, S'] ⟨d, d'⟩
+theorem inter (d : Dioph S) (d' : Dioph S') : Dioph (S ∩ S') := DiophList.forall [S, S'] ⟨d, d'⟩
 #align dioph.inter Dioph.inter
 
 theorem union : ∀ (_ : Dioph S) (_ : Dioph S'), Dioph (S ∪ S')

--- a/Mathlib/NumberTheory/Dioph.lean
+++ b/Mathlib/NumberTheory/Dioph.lean
@@ -267,7 +267,7 @@ theorem sumsq_nonneg (x : α → ℕ) : ∀ l, 0 ≤ sumsq l x
 theorem sumsq_eq_zero (x) : ∀ l, sumsq l x = 0 ↔ l.Forall fun a : Poly α => a x = 0
   | [] => eq_self_iff_true _
   | p::ps => by
-    rw [List.Forall_cons, ← sumsq_eq_zero _ ps]; rw [sumsq]
+    rw [List.forall_cons, ← sumsq_eq_zero _ ps]; rw [sumsq]
     exact
       ⟨fun h : p x * p x + sumsq ps x = 0 =>
         have : p x = 0 :=

--- a/Mathlib/NumberTheory/Dioph.lean
+++ b/Mathlib/NumberTheory/Dioph.lean
@@ -267,7 +267,7 @@ theorem sumsq_nonneg (x : α → ℕ) : ∀ l, 0 ≤ sumsq l x
 theorem sumsq_eq_zero (x) : ∀ l, sumsq l x = 0 ↔ l.Forall fun a : Poly α => a x = 0
   | [] => eq_self_iff_true _
   | p::ps => by
-    rw [List.Forall, ← sumsq_eq_zero _ ps]; rw [sumsq]
+    rw [List.Forall_cons, ← sumsq_eq_zero _ ps]; rw [sumsq]
     exact
       ⟨fun h : p x * p x + sumsq ps x = 0 =>
         have : p x = 0 :=
@@ -359,35 +359,36 @@ theorem DiophList.Forall (l : List (Set <| α → ℕ)) (d : l.Forall Dioph) :
     let ⟨β, pl, h⟩ := this
     ⟨β, Poly.sumsq pl, fun v => (h v).trans <| exists_congr fun t => (Poly.sumsq_eq_zero _ _).symm⟩
   induction' l with S l IH
-  case nil => exact ⟨ULift Empty, [], fun _ => by simp⟩
-  case cons l Ih => exact
+  exact ⟨ULift Empty, [], fun _ => by simp⟩
+  simp at d
+  exact
     let ⟨⟨β, p, pe⟩, dl⟩ := d
     let ⟨γ, pl, ple⟩ := IH dl
-    ⟨Sum β γ, p.map (inl ⊗ inr ∘ inl)::pl.map fun q => q.map (inl ⊗ inr ∘ inr), fun v => by
-      simp only [List.Forall, Poly.map_apply, List.Forall_map_iff]
-      exact Iff.trans (and_congr (pe v) (ple v))
-        ⟨fun ⟨⟨m, hm⟩, ⟨n, hn⟩⟩ =>
-          ⟨m ⊗ n, by
-            rw [show (v ⊗ m ⊗ n) ∘ (inl ⊗ inr ∘ inl) = v ⊗ m from
-                funext fun s => by cases' s with a b <;> rfl]; exact hm, by
-            refine List.Forall.imp (fun q hq => ?_) hn; dsimp [(· ∘ ·)]
-            rw [show
-                (fun x : Sum α γ => (v ⊗ m ⊗ n) ((inl ⊗ fun x : γ => inr (inr x)) x)) = v ⊗ n
-                from funext fun s => by cases' s with a b <;> rfl]; exact hq⟩,
-          fun ⟨t, hl, hr⟩ =>
-          ⟨⟨t ∘ inl, by
-              rwa [show (v ⊗ t) ∘ (inl ⊗ inr ∘ inl) = v ⊗ t ∘ inl from
-                funext fun s => by cases' s with a b <;> rfl] at hl⟩,
-            ⟨t ∘ inr, by
-              refine List.Forall.imp (fun q hq => ?_) hr; dsimp [(· ∘ ·)] at hq
-              rwa [show
-                (fun x : Sum α γ => (v ⊗ t) ((inl ⊗ fun x : γ => inr (inr x)) x)) =
-                  v ⊗ t ∘ inr
-                from funext fun s => by cases' s with a b <;> rfl] at hq ⟩⟩⟩⟩
+    ⟨Sum β γ, p.map (inl ⊗ inr ∘ inl)::pl.map fun q => q.map (inl ⊗ inr ∘ inr),
+      fun v => by
+      simp; exact
+        Iff.trans (and_congr (pe v) (ple v))
+          ⟨fun ⟨⟨m, hm⟩, ⟨n, hn⟩⟩ =>
+            ⟨m ⊗ n, by
+              rw [show (v ⊗ m ⊗ n) ∘ (inl ⊗ inr ∘ inl) = v ⊗ m from
+                    funext fun s => by cases' s with a b <;> rfl]; exact hm, by
+              refine List.Forall.imp (fun q hq => ?_) hn; dsimp [(· ∘ ·)]
+              rw [show
+                    (fun x : Sum α γ => (v ⊗ m ⊗ n) ((inl ⊗ fun x : γ => inr (inr x)) x)) = v ⊗ n
+                    from funext fun s => by cases' s with a b <;> rfl]; exact hq⟩,
+            fun ⟨t, hl, hr⟩ =>
+            ⟨⟨t ∘ inl, by
+                rwa [show (v ⊗ t) ∘ (inl ⊗ inr ∘ inl) = v ⊗ t ∘ inl from
+                    funext fun s => by cases' s with a b <;> rfl] at hl⟩,
+              ⟨t ∘ inr, by
+                refine List.Forall.imp (fun q hq => ?_) hr; dsimp [(· ∘ ·)] at hq
+                rwa [show
+                    (fun x : Sum α γ => (v ⊗ t) ((inl ⊗ fun x : γ => inr (inr x)) x)) =
+                      v ⊗ t ∘ inr
+                    from funext fun s => by cases' s with a b <;> rfl] at hq ⟩⟩⟩⟩
 #align dioph.dioph_list.all₂ Dioph.DiophList.Forall
 
-theorem inter (d : Dioph S) (d' : Dioph S') : Dioph (S ∩ S') :=
-  (DiophList.Forall [S, S'] ⟨d, ⟨d', trivial⟩⟩).ext (by simp)
+theorem inter (d : Dioph S) (d' : Dioph S') : Dioph (S ∩ S') := DiophList.Forall [S, S'] ⟨d, d'⟩
 #align dioph.inter Dioph.inter
 
 theorem union : ∀ (_ : Dioph S) (_ : Dioph S'), Dioph (S ∪ S')

--- a/Mathlib/Topology/MetricSpace/MetrizableUniformity.lean
+++ b/Mathlib/Topology/MetricSpace/MetrizableUniformity.lean
@@ -140,7 +140,8 @@ theorem le_two_mul_dist_ofPreNNDist (d : X → X → ℝ≥0) (dist_self : ∀ x
       rw [← not_lt, Nat.lt_iff_add_one_le, ← hL_len]
       intro hLm
       rw [mem_setOf_eq, take_all_of_le hLm, two_mul, add_le_iff_nonpos_left, nonpos_iff_eq_zero,
-          sum_eq_zero_iff, ← all₂_iff_forall, all₂_zipWith, ← chain_append_singleton_iff_forall₂]
+          sum_eq_zero_iff, ← Forall_iff_forall, Forall_zipWith,
+          ← chain_append_singleton_iff_forall₂]
           at hm <;>
         [skip; simp]
       exact hd₀ (hm.rel (mem_append.2 <| Or.inr <| mem_singleton_self _))

--- a/Mathlib/Topology/MetricSpace/MetrizableUniformity.lean
+++ b/Mathlib/Topology/MetricSpace/MetrizableUniformity.lean
@@ -140,7 +140,7 @@ theorem le_two_mul_dist_ofPreNNDist (d : X → X → ℝ≥0) (dist_self : ∀ x
       rw [← not_lt, Nat.lt_iff_add_one_le, ← hL_len]
       intro hLm
       rw [mem_setOf_eq, take_all_of_le hLm, two_mul, add_le_iff_nonpos_left, nonpos_iff_eq_zero,
-          sum_eq_zero_iff, ← Forall_iff_forall, Forall_zipWith,
+          sum_eq_zero_iff, ← forall_iff_forall_mem, forall_zipWith,
           ← chain_append_singleton_iff_forall₂]
           at hm <;>
         [skip; simp]

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.2.0-rc3
+leanprover/lean4:v4.2.0-rc4


### PR DESCRIPTION
This renames `List.All₂` to `List.Forall`, because the `₂` is highly
confusing when it usually means “two lists”, and we had users on Zulip
not find `List.Forall` because of that
(<https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F/topic/Is.20there.20List.2EForall.E2.82.82.2C.20but.20for.20one.20list.3F.20.28In.20library.20Std.29/near/397551365>)

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
