### PR TITLE
[Merged by Bors] - chore: refactor de-duplication in rw?

### DIFF
--- a/Mathlib/Tactic/Rewrites.lean
+++ b/Mathlib/Tactic/Rewrites.lean
@@ -151,6 +151,9 @@ structure RewriteResult where
   weight : Nat
   /-- The result from the `rw` tactic. -/
   result : Meta.RewriteResult
+  /-- Pretty-printed result. -/
+  -- This is an `Option` so that it can be computed lazily.
+  ppResult? : Option String
   /-- Can the new goal in `result` be closed by `with_reducible rfl`? -/
   -- This is an `Option` so that it can be computed lazily.
   rfl? : Option Bool
@@ -171,6 +174,23 @@ def RewriteResult.computeRfl (r : RewriteResult) : MetaM RewriteResult := do
       pure { r with rfl? := some true }
   catch _ =>
     pure { r with rfl? := some false }
+
+/-- Pretty print the result of the rewrite, and store it for later use. -/
+def RewriteResult.prepare_ppResult (r : RewriteResult) : MetaM RewriteResult := do
+  if let some _ := r.ppResult? then
+    return r
+  else
+    return { r with ppResult? := some ((← ppExpr r.result.eNew).pretty) }
+
+/--
+Pretty print the result of the rewrite.
+If this will be done more than once you should use `prepare_ppResult`
+-/
+def RewriteResult.ppResult (r : RewriteResult) : MetaM String :=
+  if let some pp := r.ppResult? then
+    return pp
+  else
+    return (← ppExpr r.result.eNew).pretty
 
 /-- Shortcut for calling `solveByElim`. -/
 def solveByElim (goals : List MVarId) (depth : Nat := 6) : MetaM PUnit := do
@@ -231,7 +251,7 @@ def rewritesCore (hyps : Array (Expr × Bool × Nat))
     let some result ← try? do goal.rewrite target expr symm
       | return none
     if result.mvarIds.isEmpty then
-      return some ⟨expr, symm, weight, result, none, ← getMCtx⟩
+      return some ⟨expr, symm, weight, result, none, none, ← getMCtx⟩
     else
       -- There are side conditions, which we try to discharge using local hypotheses.
       let some _ ← try? do solveByElim result.mvarIds | return none
@@ -242,19 +262,29 @@ def rewritesCore (hyps : Array (Expr × Bool × Nat))
           (expr.getArg! 3, true)
         else
           (expr, false)
-      return some ⟨expr, symm, weight, result, none, ← getMCtx⟩
+      return some ⟨expr, symm, weight, result, none, none, ← getMCtx⟩
+
+/--
+Find lemmas which can rewrite the goal, and deduplicate based on pretty-printed results.
+Note that this builds a `HashMap` containing the results, and so may consume significant memory.
+-/
+def rewritesDedup (hyps : Array (Expr × Bool × Nat))
+    (lemmas : DiscrTree (Name × Bool × Nat) s × DiscrTree (Name × Bool × Nat) s)
+    (mctx : MetavarContext)
+    (goal : MVarId) (target : Expr) : MLList MetaM RewriteResult := MLList.squash fun _ => do
+  return rewritesCore hyps lemmas mctx goal target
+    -- Don't report duplicate results.
+    -- (TODO: a config flag to disable this,
+    -- if distinct-but-pretty-print-the-same results are desirable?)
+    |>.mapM (fun r => r.prepare_ppResult)
+    |>.dedupBy (fun r => pure r.ppResult?)
 
 /-- Find lemmas which can rewrite the goal. -/
 def rewrites (hyps : Array (Expr × Bool × Nat))
     (lemmas : DiscrTree (Name × Bool × Nat) s × DiscrTree (Name × Bool × Nat) s)
     (goal : MVarId) (target : Expr) (stopAtRfl : Bool := false) (max : Nat := 20)
     (leavePercentHeartbeats : Nat := 10) : MetaM (List RewriteResult) := do
-  let results ← rewritesCore hyps lemmas (← getMCtx) goal target
-    -- Don't report duplicate results.
-    -- (TODO: we later pretty print results; save them here?)
-    -- (TODO: a config flag to disable this,
-    -- if distinct-but-pretty-print-the-same results are desirable?)
-    |>.dedupBy (fun r => do pure <| (← ppExpr r.result.eNew).pretty)
+  let results ← rewritesDedup hyps lemmas (← getMCtx) goal target
     -- Stop if we find a rewrite after which `with_reducible rfl` would succeed.
     |>.mapM RewriteResult.computeRfl -- TODO could simply not compute this if `stopAtRfl` is False
     |>.takeUpToFirst (fun r => stopAtRfl && r.rfl? = some true)


### PR DESCRIPTION
Slight refactor of how de-duplication works in `rw?`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
