### PR TITLE
[Merged by Bors] - chore: Remove DiscrTree.getElements, use std4’s `.values`

### DIFF
--- a/Mathlib/Lean/Meta/Simp.lean
+++ b/Mathlib/Lean/Meta/Simp.lean
@@ -5,6 +5,7 @@ Authors: Scott Morrison, Gabriel Ebner, Floris van Doorn
 -/
 import Lean
 import Std.Tactic.OpenPrivate
+import Std.Lean.Meta.DiscrTree
 
 /-!
 # Helper functions for using the simplifier.
@@ -21,26 +22,15 @@ def Lean.PHashSet.toList [BEq α] [Hashable α] (s : Lean.PHashSet α) : List α
 
 namespace Lean
 
-namespace Meta.DiscrTree
-
-partial def Trie.getElements : Trie α s → Array α
-  | Trie.node vs children =>
-    vs ++ children.concatMap fun (_, child) ↦ child.getElements
-
-def getElements (d : DiscrTree α s) : Array α :=
-  d.1.toList.toArray.concatMap fun (_, child) => child.getElements
-
-end Meta.DiscrTree
-
 namespace Meta.Simp
 open Elab.Tactic
 
 instance : ToFormat SimpTheorems where
   format s :=
 f!"pre:
-{s.pre.getElements.toList}
+{s.pre.values.toList}
 post:
-{s.post.getElements.toList}
+{s.post.values.toList}
 lemmaNames:
 {s.lemmaNames.toList.map (·.key)}
 toUnfold: {s.toUnfold.toList}

--- a/Mathlib/Tactic/ToAdditive.lean
+++ b/Mathlib/Tactic/ToAdditive.lean
@@ -912,10 +912,10 @@ partial def applyAttributes (stx : Syntax) (rawAttrs : Array Syntax) (thisAttr s
         ""}`@[{thisAttr} (attr := {appliedAttrs})]` to apply the attribute to both {
         src} and the target declaration {tgt}."
     warnAttr stx Std.Tactic.Ext.extExtension
-      (fun b n => (b.tree.elements.any fun t => t.declName = n)) thisAttr `ext src tgt
-    warnAttr stx Std.Tactic.reflExt (·.elements.contains ·) thisAttr `refl src tgt
-    warnAttr stx Std.Tactic.symmExt (·.elements.contains ·) thisAttr `symm src tgt
-    warnAttr stx Mathlib.Tactic.transExt (·.elements.contains ·) thisAttr `trans src tgt
+      (fun b n => (b.tree.values.any fun t => t.declName = n)) thisAttr `ext src tgt
+    warnAttr stx Std.Tactic.reflExt (·.values.contains ·) thisAttr `refl src tgt
+    warnAttr stx Std.Tactic.symmExt (·.values.contains ·) thisAttr `symm src tgt
+    warnAttr stx Mathlib.Tactic.transExt (·.values.contains ·) thisAttr `trans src tgt
     warnAttr stx Std.Tactic.Coe.coeExt (·.contains ·) thisAttr `coe src tgt
     warnParametricAttr stx Lean.Linter.deprecatedAttr thisAttr `deprecated src tgt
     -- the next line also warns for `@[to_additive, simps]`, because of the application times


### PR DESCRIPTION
it duplicates a definition found in `std4`.

In fact, it duplicates two definitions found in `std4`, so use
`.values` consistently, so that `.elements` can be dropped from `std4`
(in https://github.com/leanprover/std4/pull/285).


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
