### PR TITLE
[Merged by Bors] - chore: ignore PRs from master

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,4 +7,5 @@
   "files.insertFinalNewline": true,
   "files.trimFinalNewlines": true,
   "files.trimTrailingWhitespace": true,
+  "githubPullRequests.ignoredPullRequestBranches": ["master"]
 }


### PR DESCRIPTION
The popular (and very useful for mathlib reviewing) extension "github pull requests and issues" helpfully suggests people  are reviewing #7215 when they check out master, this is sub-optimal so we add a setting to ignore this branch.

See https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/PR.20associated.20with.20default.20branch/near/397749801

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
