### PR TITLE
(LSP) Include document version in code action [merged into nightly-testing]

### DIFF
--- a/Mathlib/Tactic/Widget/Calc.lean
+++ b/Mathlib/Tactic/Widget/Calc.lean
@@ -21,7 +21,7 @@ open Lean Server RequestM
 
 /-- Code action to create a `calc` tactic from the current goal. -/
 @[tactic_code_action calcTactic]
-def createCalc : TacticCodeAction := fun params _snap ctx _stack node => do
+def createCalc : TacticCodeAction := fun _params _snap ctx _stack node => do
   let .node (.ofTacticInfo info) _ := node | return #[]
   if info.goalsBefore.isEmpty then return #[]
   let eager := {
@@ -37,7 +37,7 @@ def createCalc : TacticCodeAction := fun params _snap ctx _stack node => do
       let goal := info.goalsBefore[0]!
       let goalFmt ← ctx.runMetaM {} <| goal.withContext do Meta.ppExpr (← goal.getType)
       return { eager with
-        edit? := some <|.ofTextEdit params.textDocument.uri
+        edit? := some <|.ofTextEdit doc.versionedIdentifier
           { range := ⟨tacPos, endPos⟩, newText := s!"calc {goalFmt} := by sorry" }
       }
   }]

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -2,12 +2,12 @@
  "packagesDir": "lake-packages",
  "packages":
  [{"git":
-   {"url": "https://github.com/leanprover/std4",
+   {"url": "https://github.com/bustercopley/std4",
     "subDir?": null,
-    "rev": "8e33f882d2281b2e108642d8c9dc982b9cf7dbf3",
+    "rev": "ba792fef93a1e680231ad8b0bc80e7c3b4e7aa5a",
     "opts": {},
     "name": "std",
-    "inputRev?": "lean-pr-testing-2688",
+    "inputRev?": "code-action-document-version-selfcontained",
     "inherited": false}},
   {"git":
    {"url": "https://github.com/leanprover-community/quote4",

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -46,7 +46,7 @@ lean_exe checkYaml where
 meta if get_config? doc = some "on" then -- do not download and build doc-gen4 by default
 require «doc-gen4» from git "https://github.com/leanprover/doc-gen4" @ "main"
 
-require std from git "https://github.com/leanprover/std4" @ "lean-pr-testing-2688"
+require std from git "https://github.com/bustercopley/std4" @ "code-action-document-version-selfcontained"
 require Qq from git "https://github.com/leanprover-community/quote4" @ "master"
 require aesop from git "https://github.com/leanprover-community/aesop" @ "master"
 require Cli from git "https://github.com/leanprover/lean4-cli" @ "nightly"

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2023-10-21
+leanprover/lean4-pr-releases:pr-release-2721


### PR DESCRIPTION
* `WorkspaceEdit.ofTextEdit` now takes a `VersionedTextDocumentIdentifier` instead of a URI
* Use the new function `EditableDocument.versionedIdentifier` to get a `VersionedTextDocumentIdentifier`

See the [Zulip topic](https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/LSP.20code.20action.20document.20version) and the two PRs below for further details.

- Depends on core Lean 4 [#2721](https://github.com/leanprover/lean4/pull/2721)
- Depends on Std [#306](https://github.com/leanprover/std4/pull/306)

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
