### PR TITLE
[Merged by Bors] - feat: more properties of homology in preadditive categories

### DIFF
--- a/Mathlib/Algebra/Homology/ShortComplex/Preadditive.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/Preadditive.lean
@@ -74,15 +74,15 @@ namespace LeftHomologyMapData
 
 variable (γ : LeftHomologyMapData φ h₁ h₂) (γ' : LeftHomologyMapData φ' h₁ h₂)
 
-/-- Given a left homology map data for morphism `φ`, this is induced left homology
+/-- Given a left homology map data for morphism `φ`, this is the induced left homology
 map data for `-φ`. -/
 @[simps]
 def neg : LeftHomologyMapData (-φ) h₁ h₂ where
   φK := -γ.φK
   φH := -γ.φH
 
-/-- Given left homology map data for morphisms `φ` and `φ'`, this is induced left homology
-map data for `φ + φ'`. -/
+/-- Given left homology map data for morphisms `φ` and `φ'`, this is
+the induced left homology map data for `φ + φ'`. -/
 @[simps]
 def add : LeftHomologyMapData (φ + φ') h₁ h₂ where
   φK := γ.φK + γ'.φK
@@ -173,6 +173,208 @@ instance cyclesFunctor_additive [HasKernels C] [HasCokernels C] :
   (cyclesFunctor C).Additive where
 
 end LeftHomology
+
+
+section RightHomology
+
+variable {φ φ' : S₁ ⟶ S₂} {h₁ : S₁.RightHomologyData} {h₂ : S₂.RightHomologyData}
+
+namespace RightHomologyMapData
+
+variable (γ : RightHomologyMapData φ h₁ h₂) (γ' : RightHomologyMapData φ' h₁ h₂)
+
+/-- Given a right homology map data for morphism `φ`, this is the induced right homology
+map data for `-φ`. -/
+@[simps]
+def neg : RightHomologyMapData (-φ) h₁ h₂ where
+  φQ := -γ.φQ
+  φH := -γ.φH
+
+/-- Given right homology map data for morphisms `φ` and `φ'`, this is the induced
+right homology map data for `φ + φ'`. -/
+@[simps]
+def add : RightHomologyMapData (φ + φ') h₁ h₂ where
+  φQ := γ.φQ + γ'.φQ
+  φH := γ.φH + γ'.φH
+
+end RightHomologyMapData
+
+variable (h₁ h₂)
+
+@[simp]
+lemma rightHomologyMap'_neg :
+    rightHomologyMap' (-φ) h₁ h₂ = -rightHomologyMap' φ h₁ h₂ := by
+  have γ : RightHomologyMapData φ h₁ h₂ := default
+  simp only [γ.rightHomologyMap'_eq, γ.neg.rightHomologyMap'_eq, RightHomologyMapData.neg_φH]
+
+@[simp]
+lemma opcyclesMap'_neg :
+    opcyclesMap' (-φ) h₁ h₂ = -opcyclesMap' φ h₁ h₂ := by
+  have γ : RightHomologyMapData φ h₁ h₂ := default
+  simp only [γ.opcyclesMap'_eq, γ.neg.opcyclesMap'_eq, RightHomologyMapData.neg_φQ]
+
+@[simp]
+lemma rightHomologyMap'_add :
+    rightHomologyMap' (φ + φ') h₁ h₂ = rightHomologyMap' φ h₁ h₂ +
+      rightHomologyMap' φ' h₁ h₂ := by
+  have γ : RightHomologyMapData φ h₁ h₂ := default
+  have γ' : RightHomologyMapData φ' h₁ h₂ := default
+  simp only [γ.rightHomologyMap'_eq, γ'.rightHomologyMap'_eq,
+    (γ.add γ').rightHomologyMap'_eq, RightHomologyMapData.add_φH]
+
+@[simp]
+lemma opcyclesMap'_add :
+    opcyclesMap' (φ + φ') h₁ h₂ = opcyclesMap' φ h₁ h₂ +
+      opcyclesMap' φ' h₁ h₂ := by
+  have γ : RightHomologyMapData φ h₁ h₂ := default
+  have γ' : RightHomologyMapData φ' h₁ h₂ := default
+  simp only [γ.opcyclesMap'_eq, γ'.opcyclesMap'_eq,
+    (γ.add γ').opcyclesMap'_eq, RightHomologyMapData.add_φQ]
+
+@[simp]
+lemma rightHomologyMap'_sub :
+    rightHomologyMap' (φ - φ') h₁ h₂ = rightHomologyMap' φ h₁ h₂ -
+      rightHomologyMap' φ' h₁ h₂ := by
+  simp only [sub_eq_add_neg, rightHomologyMap'_add, rightHomologyMap'_neg]
+
+@[simp]
+lemma opcyclesMap'_sub :
+    opcyclesMap' (φ - φ') h₁ h₂ = opcyclesMap' φ h₁ h₂ -
+      opcyclesMap' φ' h₁ h₂ := by
+  simp only [sub_eq_add_neg, opcyclesMap'_add, opcyclesMap'_neg]
+
+variable (φ φ')
+
+section
+
+variable [S₁.HasRightHomology] [S₂.HasRightHomology]
+
+@[simp]
+lemma rightHomologyMap_neg : rightHomologyMap (-φ)  = -rightHomologyMap φ :=
+  rightHomologyMap'_neg _ _
+
+@[simp]
+lemma opcyclesMap_neg : opcyclesMap (-φ) = -opcyclesMap φ :=
+  opcyclesMap'_neg _ _
+
+@[simp]
+lemma rightHomologyMap_add :
+    rightHomologyMap (φ + φ')  = rightHomologyMap φ + rightHomologyMap φ' :=
+  rightHomologyMap'_add _ _
+
+@[simp]
+lemma opcyclesMap_add : opcyclesMap (φ + φ') = opcyclesMap φ + opcyclesMap φ' :=
+  opcyclesMap'_add _ _
+
+@[simp]
+lemma rightHomologyMap_sub :
+    rightHomologyMap (φ - φ') = rightHomologyMap φ - rightHomologyMap φ' :=
+  rightHomologyMap'_sub  _ _
+
+@[simp]
+lemma opcyclesMap_sub : opcyclesMap (φ - φ') = opcyclesMap φ - opcyclesMap φ' :=
+  opcyclesMap'_sub _ _
+
+end
+
+instance rightHomologyFunctor_additive [HasKernels C] [HasCokernels C] :
+  (rightHomologyFunctor C).Additive where
+
+instance opcyclesFunctor_additive [HasKernels C] [HasCokernels C] :
+  (opcyclesFunctor C).Additive where
+
+end RightHomology
+
+section Homology
+
+variable {φ φ' : S₁ ⟶ S₂} {h₁ : S₁.HomologyData} {h₂ : S₂.HomologyData}
+
+namespace HomologyMapData
+
+variable (γ : HomologyMapData φ h₁ h₂) (γ' : HomologyMapData φ' h₁ h₂)
+
+/-- Given a homology map data for a morphism `φ`, this is the induced homology
+map data for `-φ`. -/
+@[simps]
+def neg : HomologyMapData (-φ) h₁ h₂ where
+  left := γ.left.neg
+  right := γ.right.neg
+
+/-- Given homology map data for morphisms `φ` and `φ'`, this is the induced homology
+map data for `φ + φ'`. -/
+@[simps]
+def add : HomologyMapData (φ + φ') h₁ h₂ where
+  left := γ.left.add γ'.left
+  right := γ.right.add γ'.right
+
+end HomologyMapData
+
+variable (h₁ h₂)
+
+@[simp]
+lemma homologyMap'_neg :
+    homologyMap' (-φ) h₁ h₂ = -homologyMap' φ h₁ h₂ :=
+  leftHomologyMap'_neg _ _
+
+@[simp]
+lemma homologyMap'_add :
+    homologyMap' (φ + φ') h₁ h₂ = homologyMap' φ h₁ h₂ +
+      homologyMap' φ' h₁ h₂ :=
+  leftHomologyMap'_add _ _
+
+@[simp]
+lemma homologyMap'_sub :
+    homologyMap' (φ - φ') h₁ h₂ = homologyMap' φ h₁ h₂ -
+      homologyMap' φ' h₁ h₂ :=
+  leftHomologyMap'_sub _ _
+
+variable (φ φ')
+
+section
+
+variable [S₁.HasHomology] [S₂.HasHomology]
+
+@[simp]
+lemma homologyMap_neg : homologyMap (-φ)  = -homologyMap φ :=
+  homologyMap'_neg _ _
+
+@[simp]
+lemma homologyMap_add : homologyMap (φ + φ')  = homologyMap φ + homologyMap φ' :=
+  homologyMap'_add _ _
+
+@[simp]
+lemma homologyMap_sub : homologyMap (φ - φ') = homologyMap φ - homologyMap φ' :=
+  homologyMap'_sub  _ _
+
+end
+
+instance homologyFunctor_additive [CategoryWithHomology C] :
+  (homologyFunctor C).Additive where
+
+end Homology
+
+section Homotopy
+
+variable (φ₁ φ₂ : S₁ ⟶ S₂)
+
+/-- An homotopy between two morphisms of short complexes `S₁ ⟶ S₂` consists of various
+maps and conditions which will be sufficient to show that they induce the same morphism
+in homology. -/
+@[ext]
+structure Homotopy where
+  h₀ : S₁.X₁ ⟶ S₂.X₁
+  h₀_f : h₀ ≫ S₂.f = 0 := by aesop_cat
+  h₁ : S₁.X₂ ⟶ S₂.X₁
+  h₂ : S₁.X₃ ⟶ S₂.X₂
+  h₃ : S₁.X₃ ⟶ S₂.X₃
+  g_h₃ : S₁.g ≫ h₃ = 0 := by aesop_cat
+  comm₁ : φ₁.τ₁ = S₁.f ≫ h₁ + h₀ + φ₂.τ₁ := by aesop_cat
+  comm₂ : φ₁.τ₂ = S₁.g ≫ h₂ + h₁ ≫ S₂.f + φ₂.τ₂ := by aesop_cat
+  comm₃ : φ₁.τ₃ = h₃ + h₂ ≫ S₂.g + φ₂.τ₃ := by aesop_cat
+
+attribute [reassoc (attr := simp)] Homotopy.h₀_f Homotopy.g_h₃
+
+end Homotopy
 
 end ShortComplex
 

--- a/Mathlib/Algebra/Homology/ShortComplex/Preadditive.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/Preadditive.lean
@@ -318,14 +318,12 @@ lemma homologyMap'_neg :
 
 @[simp]
 lemma homologyMap'_add :
-    homologyMap' (φ + φ') h₁ h₂ = homologyMap' φ h₁ h₂ +
-      homologyMap' φ' h₁ h₂ :=
+    homologyMap' (φ + φ') h₁ h₂ = homologyMap' φ h₁ h₂ + homologyMap' φ' h₁ h₂ :=
   leftHomologyMap'_add _ _
 
 @[simp]
 lemma homologyMap'_sub :
-    homologyMap' (φ - φ') h₁ h₂ = homologyMap' φ h₁ h₂ -
-      homologyMap' φ' h₁ h₂ :=
+    homologyMap' (φ - φ') h₁ h₂ = homologyMap' φ h₁ h₂ - homologyMap' φ' h₁ h₂ :=
   leftHomologyMap'_sub _ _
 
 variable (φ φ')

--- a/Mathlib/Algebra/Homology/ShortComplex/Preadditive.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/Preadditive.lean
@@ -360,10 +360,14 @@ maps and conditions which will be sufficient to show that they induce the same m
 in homology. -/
 @[ext]
 structure Homotopy where
+  /-- a morphism `S₁.X₁ ⟶ S₂.X₁` -/
   h₀ : S₁.X₁ ⟶ S₂.X₁
   h₀_f : h₀ ≫ S₂.f = 0 := by aesop_cat
+  /-- a morphism `S₁.X₂ ⟶ S₂.X₁` -/
   h₁ : S₁.X₂ ⟶ S₂.X₁
+  /-- a morphism `S₁.X₃ ⟶ S₂.X₂` -/
   h₂ : S₁.X₃ ⟶ S₂.X₂
+  /-- a morphism `S₁.X₃ ⟶ S₂.X₃` -/
   h₃ : S₁.X₃ ⟶ S₂.X₃
   g_h₃ : S₁.g ≫ h₃ = 0 := by aesop_cat
   comm₁ : φ₁.τ₁ = S₁.f ≫ h₁ + h₀ + φ₂.τ₁ := by aesop_cat

--- a/Mathlib/Algebra/Homology/ShortComplex/Preadditive.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/Preadditive.lean
@@ -357,7 +357,7 @@ section Homotopy
 
 variable (φ₁ φ₂ : S₁ ⟶ S₂)
 
-/-- An homotopy between two morphisms of short complexes `S₁ ⟶ S₂` consists of various
+/-- A homotopy between two morphisms of short complexes `S₁ ⟶ S₂` consists of various
 maps and conditions which will be sufficient to show that they induce the same morphism
 in homology. -/
 @[ext]

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.2.0-rc3
+leanprover/lean4:v4.2.0-rc4


### PR DESCRIPTION
This PR also introduces the notion of homotopy of morphisms between short complexes in preadditive categories.

---



<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
