### PR TITLE
[Merged by Bors] - feat (RingTheory/PowerSeries) add formal derivative operation

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2987,6 +2987,7 @@ import Mathlib.RingTheory.Polynomial.Vieta
 import Mathlib.RingTheory.PolynomialAlgebra
 import Mathlib.RingTheory.PowerBasis
 import Mathlib.RingTheory.PowerSeries.Basic
+import Mathlib.RingTheory.PowerSeries.Derivative
 import Mathlib.RingTheory.PowerSeries.WellKnown
 import Mathlib.RingTheory.Prime
 import Mathlib.RingTheory.PrincipalIdealDomain

--- a/Mathlib/RingTheory/PowerSeries/Derivative.lean
+++ b/Mathlib/RingTheory/PowerSeries/Derivative.lean
@@ -124,7 +124,8 @@ theorem fDerivative_coe (f : R[X]) : d⁄dX R f = derivative f := fDerivativeFun
 theorem trunc_fDerivative (f : R⟦X⟧) (n : ℕ) :
     trunc n (d⁄dX R f) = derivative (trunc (n + 1) f) := by apply trunc_fDerivativeFun
 
-theorem trunc_fDerivative' (f : R⟦X⟧) (n : ℕ) : trunc (n-1) (d⁄dX R f) = derivative (trunc n f) := by
+theorem trunc_fDerivative' (f : R⟦X⟧) (n : ℕ) :
+    trunc (n-1) (d⁄dX R f) = derivative (trunc n f) := by
   cases n with
   | zero =>
     simp only [zero_eq, ge_iff_le, tsub_eq_zero_of_le]

--- a/Mathlib/RingTheory/PowerSeries/Derivative.lean
+++ b/Mathlib/RingTheory/PowerSeries/Derivative.lean
@@ -107,8 +107,8 @@ variable {R}
 
 @[simp] theorem fDerivative_C (r : R) : d⁄dX R (C R r) = 0 := fDerivativeFun_C r
 
-@[simp] theorem coeff_fDerivative (f : R⟦X⟧) (n : ℕ) : coeff R n (d⁄dX R f) = coeff R (n + 1) f * (n + 1) :=
-  coeff_fDerivativeFun f n
+@[simp] theorem coeff_fDerivative (f : R⟦X⟧) (n : ℕ) :
+    coeff R n (d⁄dX R f) = coeff R (n + 1) f * (n + 1) := coeff_fDerivativeFun f n
 
 theorem fDerivative_coe (f : R[X]) : d⁄dX R f = derivative f := fDerivativeFun_coe f
 
@@ -120,7 +120,8 @@ theorem fDerivative_coe (f : R[X]) : d⁄dX R f = derivative f := fDerivativeFun
   · rw [h, cast_zero, zero_add]
   · rfl
 
-theorem trunc_fDerivative (f : R⟦X⟧) (n : ℕ) : trunc n (d⁄dX R f) = derivative (trunc (n + 1) f) := by
+theorem trunc_fDerivative (f : R⟦X⟧) (n : ℕ) :
+    trunc n (d⁄dX R f) = derivative (trunc (n + 1) f) := by
   apply Polynomial.coe_inj.mp
   rw [←fDerivative_coe]
   apply trunc_fDerivativeFun

--- a/Mathlib/RingTheory/PowerSeries/Derivative.lean
+++ b/Mathlib/RingTheory/PowerSeries/Derivative.lean
@@ -1,0 +1,176 @@
+/-
+Copyright (c) 2023 Richard M. Hill. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Richard M. Hill
+-/
+import Mathlib.RingTheory.PowerSeries.Basic
+import Mathlib.RingTheory.Derivation.Basic
+
+/-!
+# Definitions
+
+In this file we define an operation `fDerivative` (formal differentiation)
+on the ring of formal power series in one variable (over an arbitrary commutative semiring).
+
+Under suitable assumptions, we prove that two power series are equal if their derivatives
+are equal and their constant terms are equal. This will give us a simple tool for proving
+power series identities. For example, one can easily prove the power series identity
+$\exp ( \log (1+X)) = 1+X$ by differentiating twice.
+
+## Main Definition
+
+- `PowerSeries.fDerivative R : Derivation R R⟦X⟧ R⟦X⟧` the formal derivative operation.
+  This is abbreviated `d⁄dX R`.
+-/
+
+namespace PowerSeries
+
+open Polynomial Derivation Nat
+
+section CommutativeSemiring
+variable {R} [CommSemiring R]
+
+/--
+The formal derivative of a power series in one variable.
+This is defined here as a function, but will be packaged as a
+derivation `fDerivative` on `R⟦X⟧`.
+-/
+noncomputable def fDerivativeFun (f : R⟦X⟧) : R⟦X⟧ := mk λ n ↦ coeff R (n + 1) f * (n + 1)
+
+theorem coeff_fDerivativeFun (f : R⟦X⟧) (n : ℕ) :
+    coeff R n f.fDerivativeFun = coeff R (n + 1) f * (n + 1) := by
+  rw [fDerivativeFun, coeff_mk]
+
+theorem fDerivativeFun_coe (f : R[X]) : (f : R⟦X⟧).fDerivativeFun = derivative f := by
+  ext
+  rw [coeff_fDerivativeFun, coeff_coe, coeff_coe, coeff_derivative]
+
+theorem fDerivativeFun_add (f g : R⟦X⟧) :
+    fDerivativeFun (f + g) = fDerivativeFun f + fDerivativeFun g := by
+  ext
+  rw [coeff_fDerivativeFun, map_add, map_add, coeff_fDerivativeFun,
+    coeff_fDerivativeFun, add_mul]
+
+theorem fDerivativeFun_C (r : R) : fDerivativeFun (C R r) = 0 := by
+  ext n
+  rw [coeff_fDerivativeFun, coeff_C]
+  split_ifs with h
+  · cases succ_ne_zero n h
+  · rw [zero_mul, map_zero]
+
+theorem trunc_fDerivativeFun (f : R⟦X⟧) (n : ℕ) :
+    (trunc n f.fDerivativeFun : R⟦X⟧) = fDerivativeFun ↑(trunc (n + 1) f) := by
+  ext d
+  rw [coeff_coe, coeff_trunc]
+  split_ifs with h
+  · have : d + 1 < n + 1 := succ_lt_succ_iff.2 h
+    rw [coeff_fDerivativeFun, coeff_fDerivativeFun, coeff_coe, coeff_trunc, if_pos this]
+  · have : ¬d + 1 < n + 1 := by rwa [succ_lt_succ_iff]
+    rw [coeff_fDerivativeFun, coeff_coe, coeff_trunc, if_neg this, zero_mul]
+
+--A special case of `fDerivativeFun_mul`, used in its proof.
+private theorem fDerivativeFun_coe_mul_coe (f g : R[X]) : fDerivativeFun (f * g : R⟦X⟧) =
+    f * fDerivativeFun (g : R⟦X⟧) + g * fDerivativeFun (f : R⟦X⟧) := by
+  rw [←coe_mul, fDerivativeFun_coe, derivative_mul, fDerivativeFun_coe, fDerivativeFun_coe,
+    add_comm, mul_comm _ g, ←coe_mul, ←coe_mul, Polynomial.coe_add]
+
+/-- Leibniz rule for formal power series.-/
+theorem fDerivativeFun_mul (f g : R⟦X⟧) :
+    fDerivativeFun (f * g) = f • g.fDerivativeFun + g • f.fDerivativeFun := by
+  ext n
+  have h₁ : n < n + 1 := lt_succ_self n
+  have h₂ : n < n + 1 + 1 := Nat.lt_add_right _ _ _ h₁
+  rw [coeff_fDerivativeFun, map_add, coeff_mul_eq_coeff_trunc_mul_trunc _ _ (lt_succ_self _),
+    smul_eq_mul, smul_eq_mul, coeff_mul_eq_coeff_trunc_mul_trunc₂ g f.fDerivativeFun h₂ h₁,
+    coeff_mul_eq_coeff_trunc_mul_trunc₂ f g.fDerivativeFun h₂ h₁, trunc_fDerivativeFun,
+    trunc_fDerivativeFun, ←map_add, ←fDerivativeFun_coe_mul_coe, coeff_fDerivativeFun]
+
+theorem fDerivativeFun_one : fDerivativeFun (1 : R⟦X⟧) = 0 := by
+  rw [←map_one (C R), fDerivativeFun_C (1 : R)]
+
+theorem fDerivativeFun_smul (r : R) (f : R⟦X⟧) : fDerivativeFun (r • f) = r • fDerivativeFun f := by
+  rw [smul_eq_C_mul, smul_eq_C_mul, fDerivativeFun_mul, fDerivativeFun_C, smul_zero, add_zero,
+    smul_eq_mul]
+
+variable (R)
+/--The formal derivative of a formal power series.-/
+noncomputable def fDerivative : Derivation R R⟦X⟧ R⟦X⟧
+where
+  toFun             := fDerivativeFun
+  map_add'          := fDerivativeFun_add
+  map_smul'         := fDerivativeFun_smul
+  map_one_eq_zero'  := fDerivativeFun_one
+  leibniz'          := fDerivativeFun_mul
+scoped notation "d⁄dX" => fDerivative
+
+variable {R}
+
+@[simp] theorem fDerivative_C (r : R) : d⁄dX R (C R r) = 0 := fDerivativeFun_C r
+
+@[simp] theorem coeff_fDerivative (f : R⟦X⟧) (n : ℕ) : coeff R n (d⁄dX R f) = coeff R (n + 1) f * (n + 1) :=
+  coeff_fDerivativeFun f n
+
+theorem fDerivative_coe (f : R[X]) : d⁄dX R f = derivative f := fDerivativeFun_coe f
+
+@[simp] theorem fDerivative_X : d⁄dX R (X : R⟦X⟧) = 1 := by
+  ext
+  rw [coeff_fDerivative, coeff_one, coeff_X, boole_mul]
+  simp_rw [add_left_eq_self]
+  split_ifs with h
+  · rw [h, cast_zero, zero_add]
+  · rfl
+
+theorem trunc_fDerivative (f : R⟦X⟧) (n : ℕ) : trunc n (d⁄dX R f) = derivative (trunc (n + 1) f) := by
+  apply Polynomial.coe_inj.mp
+  rw [←fDerivative_coe]
+  apply trunc_fDerivativeFun
+
+theorem trunc_D' (f : R⟦X⟧) (n : ℕ) : trunc (n-1) (d⁄dX R f) = derivative (trunc n f) := by
+  cases n with
+  | zero =>
+    simp only [zero_eq, ge_iff_le, tsub_eq_zero_of_le]
+    rfl
+  | succ n =>
+    rw [succ_sub_one, trunc_fDerivative]
+
+end CommutativeSemiring
+
+/-In the next lemma, we use `smul_right_inj`, which requires not only `no_smul_divisors ℕ R`, but
+also cancellation of addition in `R`. For this reason, the next lemma is stated in the case that `R`
+is a `CommRing`.-/
+
+/-- If `f` and `g` have the same constant term and derivative, then they are equal.-/
+theorem fDerivative.ext {R} [CommRing R] [NoZeroSMulDivisors ℕ R] {f g} (hD : d⁄dX R f = d⁄dX R g)
+    (hc : constantCoeff R f = constantCoeff R g) : f = g := by
+  ext n
+  cases n with
+  | zero =>
+    rw [coeff_zero_eq_constantCoeff, hc]
+  | succ n =>
+    have equ : coeff R n (d⁄dX (R := R) f) = coeff R n (d⁄dX (R := R) g) := by rw [hD]
+    rwa [coeff_fDerivative, coeff_fDerivative, ←cast_succ, mul_comm, ←nsmul_eq_mul,
+      mul_comm, ←nsmul_eq_mul, smul_right_inj] at equ
+    exact n.succ_ne_zero
+
+@[simp] theorem dDerivative_inv {R} [CommRing R] (f : R⟦X⟧ˣ) :
+    d⁄dX R ↑(f⁻¹) = -((f⁻¹ : R⟦X⟧ˣ) : R⟦X⟧) ^ 2 * d⁄dX R f := by
+  apply Derivation.leibniz_of_mul_eq_one
+  simp
+
+@[simp] theorem fDerivative_invOf {R} [CommRing R] (f : R⟦X⟧) [Invertible f] :
+    d⁄dX R (⅟ f) = - (⅟ f) ^ 2 * d⁄dX R f := by
+  rw [Derivation.leibniz_invOf, smul_eq_mul]
+
+/-
+The following theorem is stated only in the case that `R` is a field. This is because
+there is currently no instance of `Inv R⟦X⟧` for more general base rings `R`.
+-/
+@[simp] theorem fDerivative_inv' {R} [Field R] (f : R⟦X⟧) : d⁄dX R f⁻¹ = -f⁻¹ ^ 2 * d⁄dX R f := by
+  by_cases constantCoeff R f = 0
+  · suffices : f⁻¹ = 0
+    rw [this, pow_two, zero_mul, neg_zero, zero_mul, map_zero]
+    rwa [MvPowerSeries.inv_eq_zero]
+  apply Derivation.leibniz_of_mul_eq_one
+  exact PowerSeries.inv_mul_cancel (h := h)
+
+end PowerSeries

--- a/Mathlib/RingTheory/PowerSeries/Derivative.lean
+++ b/Mathlib/RingTheory/PowerSeries/Derivative.lean
@@ -101,6 +101,7 @@ where
   map_smul'         := fDerivativeFun_smul
   map_one_eq_zero'  := fDerivativeFun_one
   leibniz'          := fDerivativeFun_mul
+/--Abbreviation of `PowerSeries.fDerivative`, the formal derivative on `R⟦X⟧`.-/
 scoped notation "d⁄dX" => fDerivative
 
 variable {R}

--- a/Mathlib/RingTheory/PowerSeries/Derivative.lean
+++ b/Mathlib/RingTheory/PowerSeries/Derivative.lean
@@ -59,19 +59,19 @@ theorem fDerivativeFun_C (r : R) : fDerivativeFun (C R r) = 0 := by
   · rw [zero_mul, map_zero]
 
 theorem trunc_fDerivativeFun (f : R⟦X⟧) (n : ℕ) :
-    (trunc n f.fDerivativeFun : R⟦X⟧) = fDerivativeFun ↑(trunc (n + 1) f) := by
+    trunc n f.fDerivativeFun = derivative (trunc (n + 1) f):= by
   ext d
-  rw [coeff_coe, coeff_trunc]
+  rw [coeff_trunc]
   split_ifs with h
   · have : d + 1 < n + 1 := succ_lt_succ_iff.2 h
-    rw [coeff_fDerivativeFun, coeff_fDerivativeFun, coeff_coe, coeff_trunc, if_pos this]
+    rw [coeff_fDerivativeFun, coeff_derivative, coeff_trunc, if_pos this]
   · have : ¬d + 1 < n + 1 := by rwa [succ_lt_succ_iff]
-    rw [coeff_fDerivativeFun, coeff_coe, coeff_trunc, if_neg this, zero_mul]
+    rw [coeff_derivative, coeff_trunc, if_neg this, zero_mul]
 
 --A special case of `fDerivativeFun_mul`, used in its proof.
 private theorem fDerivativeFun_coe_mul_coe (f g : R[X]) : fDerivativeFun (f * g : R⟦X⟧) =
-    f * fDerivativeFun (g : R⟦X⟧) + g * fDerivativeFun (f : R⟦X⟧) := by
-  rw [←coe_mul, fDerivativeFun_coe, derivative_mul, fDerivativeFun_coe, fDerivativeFun_coe,
+    f * derivative g + g * derivative f  := by
+  rw [←coe_mul, fDerivativeFun_coe, derivative_mul,
     add_comm, mul_comm _ g, ←coe_mul, ←coe_mul, Polynomial.coe_add]
 
 /-- Leibniz rule for formal power series.-/
@@ -122,12 +122,9 @@ theorem fDerivative_coe (f : R[X]) : d⁄dX R f = derivative f := fDerivativeFun
   · rfl
 
 theorem trunc_fDerivative (f : R⟦X⟧) (n : ℕ) :
-    trunc n (d⁄dX R f) = derivative (trunc (n + 1) f) := by
-  apply Polynomial.coe_inj.mp
-  rw [←fDerivative_coe]
-  apply trunc_fDerivativeFun
+    trunc n (d⁄dX R f) = derivative (trunc (n + 1) f) := by apply trunc_fDerivativeFun
 
-theorem trunc_D' (f : R⟦X⟧) (n : ℕ) : trunc (n-1) (d⁄dX R f) = derivative (trunc n f) := by
+theorem trunc_fDerivative' (f : R⟦X⟧) (n : ℕ) : trunc (n-1) (d⁄dX R f) = derivative (trunc n f) := by
   cases n with
   | zero =>
     simp only [zero_eq, ge_iff_le, tsub_eq_zero_of_le]

--- a/Mathlib/RingTheory/PowerSeries/Derivative.lean
+++ b/Mathlib/RingTheory/PowerSeries/Derivative.lean
@@ -9,7 +9,7 @@ import Mathlib.RingTheory.Derivation.Basic
 /-!
 # Definitions
 
-In this file we define an operation `fDerivative` (formal differentiation)
+In this file we define an operation `derivative` (formal differentiation)
 on the ring of formal power series in one variable (over an arbitrary commutative semiring).
 
 Under suitable assumptions, we prove that two power series are equal if their derivatives
@@ -19,7 +19,7 @@ $\exp ( \log (1+X)) = 1+X$ by differentiating twice.
 
 ## Main Definition
 
-- `PowerSeries.fDerivative R : Derivation R R⟦X⟧ R⟦X⟧` the formal derivative operation.
+- `PowerSeries.derivative R : Derivation R R⟦X⟧ R⟦X⟧` the formal derivative operation.
   This is abbreviated `d⁄dX R`.
 -/
 
@@ -33,105 +33,105 @@ variable {R} [CommSemiring R]
 /--
 The formal derivative of a power series in one variable.
 This is defined here as a function, but will be packaged as a
-derivation `fDerivative` on `R⟦X⟧`.
+derivation `derivative` on `R⟦X⟧`.
 -/
-noncomputable def fDerivativeFun (f : R⟦X⟧) : R⟦X⟧ := mk λ n ↦ coeff R (n + 1) f * (n + 1)
+noncomputable def derivativeFun (f : R⟦X⟧) : R⟦X⟧ := mk λ n ↦ coeff R (n + 1) f * (n + 1)
 
-theorem coeff_fDerivativeFun (f : R⟦X⟧) (n : ℕ) :
-    coeff R n f.fDerivativeFun = coeff R (n + 1) f * (n + 1) := by
-  rw [fDerivativeFun, coeff_mk]
+theorem coeff_derivativeFun (f : R⟦X⟧) (n : ℕ) :
+    coeff R n f.derivativeFun = coeff R (n + 1) f * (n + 1) := by
+  rw [derivativeFun, coeff_mk]
 
-theorem fDerivativeFun_coe (f : R[X]) : (f : R⟦X⟧).fDerivativeFun = derivative f := by
+theorem derivativeFun_coe (f : R[X]) : (f : R⟦X⟧).derivativeFun = derivative f := by
   ext
-  rw [coeff_fDerivativeFun, coeff_coe, coeff_coe, coeff_derivative]
+  rw [coeff_derivativeFun, coeff_coe, coeff_coe, coeff_derivative]
 
-theorem fDerivativeFun_add (f g : R⟦X⟧) :
-    fDerivativeFun (f + g) = fDerivativeFun f + fDerivativeFun g := by
+theorem derivativeFun_add (f g : R⟦X⟧) :
+    derivativeFun (f + g) = derivativeFun f + derivativeFun g := by
   ext
-  rw [coeff_fDerivativeFun, map_add, map_add, coeff_fDerivativeFun,
-    coeff_fDerivativeFun, add_mul]
+  rw [coeff_derivativeFun, map_add, map_add, coeff_derivativeFun,
+    coeff_derivativeFun, add_mul]
 
-theorem fDerivativeFun_C (r : R) : fDerivativeFun (C R r) = 0 := by
+theorem derivativeFun_C (r : R) : derivativeFun (C R r) = 0 := by
   ext n
-  rw [coeff_fDerivativeFun, coeff_C]
+  rw [coeff_derivativeFun, coeff_C]
   split_ifs with h
   · cases succ_ne_zero n h
   · rw [zero_mul, map_zero]
 
-theorem trunc_fDerivativeFun (f : R⟦X⟧) (n : ℕ) :
-    trunc n f.fDerivativeFun = derivative (trunc (n + 1) f):= by
+theorem trunc_derivativeFun (f : R⟦X⟧) (n : ℕ) :
+    trunc n f.derivativeFun = derivative (trunc (n + 1) f):= by
   ext d
   rw [coeff_trunc]
   split_ifs with h
   · have : d + 1 < n + 1 := succ_lt_succ_iff.2 h
-    rw [coeff_fDerivativeFun, coeff_derivative, coeff_trunc, if_pos this]
+    rw [coeff_derivativeFun, coeff_derivative, coeff_trunc, if_pos this]
   · have : ¬d + 1 < n + 1 := by rwa [succ_lt_succ_iff]
     rw [coeff_derivative, coeff_trunc, if_neg this, zero_mul]
 
---A special case of `fDerivativeFun_mul`, used in its proof.
-private theorem fDerivativeFun_coe_mul_coe (f g : R[X]) : fDerivativeFun (f * g : R⟦X⟧) =
+--A special case of `derivativeFun_mul`, used in its proof.
+private theorem derivativeFun_coe_mul_coe (f g : R[X]) : derivativeFun (f * g : R⟦X⟧) =
     f * derivative g + g * derivative f  := by
-  rw [←coe_mul, fDerivativeFun_coe, derivative_mul,
+  rw [←coe_mul, derivativeFun_coe, derivative_mul,
     add_comm, mul_comm _ g, ←coe_mul, ←coe_mul, Polynomial.coe_add]
 
 /-- Leibniz rule for formal power series.-/
-theorem fDerivativeFun_mul (f g : R⟦X⟧) :
-    fDerivativeFun (f * g) = f • g.fDerivativeFun + g • f.fDerivativeFun := by
+theorem derivativeFun_mul (f g : R⟦X⟧) :
+    derivativeFun (f * g) = f • g.derivativeFun + g • f.derivativeFun := by
   ext n
   have h₁ : n < n + 1 := lt_succ_self n
   have h₂ : n < n + 1 + 1 := Nat.lt_add_right _ _ _ h₁
-  rw [coeff_fDerivativeFun, map_add, coeff_mul_eq_coeff_trunc_mul_trunc _ _ (lt_succ_self _),
-    smul_eq_mul, smul_eq_mul, coeff_mul_eq_coeff_trunc_mul_trunc₂ g f.fDerivativeFun h₂ h₁,
-    coeff_mul_eq_coeff_trunc_mul_trunc₂ f g.fDerivativeFun h₂ h₁, trunc_fDerivativeFun,
-    trunc_fDerivativeFun, ←map_add, ←fDerivativeFun_coe_mul_coe, coeff_fDerivativeFun]
+  rw [coeff_derivativeFun, map_add, coeff_mul_eq_coeff_trunc_mul_trunc _ _ (lt_succ_self _),
+    smul_eq_mul, smul_eq_mul, coeff_mul_eq_coeff_trunc_mul_trunc₂ g f.derivativeFun h₂ h₁,
+    coeff_mul_eq_coeff_trunc_mul_trunc₂ f g.derivativeFun h₂ h₁, trunc_derivativeFun,
+    trunc_derivativeFun, ←map_add, ←derivativeFun_coe_mul_coe, coeff_derivativeFun]
 
-theorem fDerivativeFun_one : fDerivativeFun (1 : R⟦X⟧) = 0 := by
-  rw [←map_one (C R), fDerivativeFun_C (1 : R)]
+theorem derivativeFun_one : derivativeFun (1 : R⟦X⟧) = 0 := by
+  rw [←map_one (C R), derivativeFun_C (1 : R)]
 
-theorem fDerivativeFun_smul (r : R) (f : R⟦X⟧) : fDerivativeFun (r • f) = r • fDerivativeFun f := by
-  rw [smul_eq_C_mul, smul_eq_C_mul, fDerivativeFun_mul, fDerivativeFun_C, smul_zero, add_zero,
+theorem derivativeFun_smul (r : R) (f : R⟦X⟧) : derivativeFun (r • f) = r • derivativeFun f := by
+  rw [smul_eq_C_mul, smul_eq_C_mul, derivativeFun_mul, derivativeFun_C, smul_zero, add_zero,
     smul_eq_mul]
 
 variable (R)
 /--The formal derivative of a formal power series.-/
-noncomputable def fDerivative : Derivation R R⟦X⟧ R⟦X⟧
+noncomputable def derivative : Derivation R R⟦X⟧ R⟦X⟧
 where
-  toFun             := fDerivativeFun
-  map_add'          := fDerivativeFun_add
-  map_smul'         := fDerivativeFun_smul
-  map_one_eq_zero'  := fDerivativeFun_one
-  leibniz'          := fDerivativeFun_mul
-/--Abbreviation of `PowerSeries.fDerivative`, the formal derivative on `R⟦X⟧`.-/
-scoped notation "d⁄dX" => fDerivative
+  toFun             := derivativeFun
+  map_add'          := derivativeFun_add
+  map_smul'         := derivativeFun_smul
+  map_one_eq_zero'  := derivativeFun_one
+  leibniz'          := derivativeFun_mul
+/--Abbreviation of `PowerSeries.derivative`, the formal derivative on `R⟦X⟧`.-/
+scoped notation "d⁄dX" => derivative
 
 variable {R}
 
-@[simp] theorem fDerivative_C (r : R) : d⁄dX R (C R r) = 0 := fDerivativeFun_C r
+@[simp] theorem derivative_C (r : R) : d⁄dX R (C R r) = 0 := derivativeFun_C r
 
-@[simp] theorem coeff_fDerivative (f : R⟦X⟧) (n : ℕ) :
-    coeff R n (d⁄dX R f) = coeff R (n + 1) f * (n + 1) := coeff_fDerivativeFun f n
+theorem coeff_derivative (f : R⟦X⟧) (n : ℕ) :
+    coeff R n (d⁄dX R f) = coeff R (n + 1) f * (n + 1) := coeff_derivativeFun f n
 
-theorem fDerivative_coe (f : R[X]) : d⁄dX R f = derivative f := fDerivativeFun_coe f
+theorem derivative_coe (f : R[X]) : d⁄dX R f = Polynomial.derivative f := derivativeFun_coe f
 
-@[simp] theorem fDerivative_X : d⁄dX R (X : R⟦X⟧) = 1 := by
+@[simp] theorem derivative_X : d⁄dX R (X : R⟦X⟧) = 1 := by
   ext
-  rw [coeff_fDerivative, coeff_one, coeff_X, boole_mul]
+  rw [coeff_derivative, coeff_one, coeff_X, boole_mul]
   simp_rw [add_left_eq_self]
   split_ifs with h
   · rw [h, cast_zero, zero_add]
   · rfl
 
-theorem trunc_fDerivative (f : R⟦X⟧) (n : ℕ) :
-    trunc n (d⁄dX R f) = derivative (trunc (n + 1) f) := by apply trunc_fDerivativeFun
+theorem trunc_derivative (f : R⟦X⟧) (n : ℕ) :
+    trunc n (d⁄dX R f) = Polynomial.derivative (trunc (n + 1) f) := by apply trunc_derivativeFun
 
-theorem trunc_fDerivative' (f : R⟦X⟧) (n : ℕ) :
-    trunc (n-1) (d⁄dX R f) = derivative (trunc n f) := by
+theorem trunc_derivative' (f : R⟦X⟧) (n : ℕ) :
+    trunc (n-1) (d⁄dX R f) = Polynomial.derivative (trunc n f) := by
   cases n with
   | zero =>
     simp only [zero_eq, ge_iff_le, tsub_eq_zero_of_le]
     rfl
   | succ n =>
-    rw [succ_sub_one, trunc_fDerivative]
+    rw [succ_sub_one, trunc_derivative]
 
 end CommutativeSemiring
 
@@ -140,32 +140,32 @@ also cancellation of addition in `R`. For this reason, the next lemma is stated 
 is a `CommRing`.-/
 
 /-- If `f` and `g` have the same constant term and derivative, then they are equal.-/
-theorem fDerivative.ext {R} [CommRing R] [NoZeroSMulDivisors ℕ R] {f g} (hD : d⁄dX R f = d⁄dX R g)
+theorem derivative.ext {R} [CommRing R] [NoZeroSMulDivisors ℕ R] {f g} (hD : d⁄dX R f = d⁄dX R g)
     (hc : constantCoeff R f = constantCoeff R g) : f = g := by
   ext n
   cases n with
   | zero =>
     rw [coeff_zero_eq_constantCoeff, hc]
   | succ n =>
-    have equ : coeff R n (d⁄dX (R := R) f) = coeff R n (d⁄dX (R := R) g) := by rw [hD]
-    rwa [coeff_fDerivative, coeff_fDerivative, ←cast_succ, mul_comm, ←nsmul_eq_mul,
+    have equ : coeff R n (d⁄dX R f) = coeff R n (d⁄dX R g) := by rw [hD]
+    rwa [coeff_derivative, coeff_derivative, ←cast_succ, mul_comm, ←nsmul_eq_mul,
       mul_comm, ←nsmul_eq_mul, smul_right_inj] at equ
     exact n.succ_ne_zero
 
-@[simp] theorem dDerivative_inv {R} [CommRing R] (f : R⟦X⟧ˣ) :
-    d⁄dX R ↑(f⁻¹) = -((f⁻¹ : R⟦X⟧ˣ) : R⟦X⟧) ^ 2 * d⁄dX R f := by
+@[simp] theorem derivative_inv {R} [CommRing R] (f : R⟦X⟧ˣ) :
+    d⁄dX R ↑f⁻¹ = -(↑f⁻¹ : R⟦X⟧) ^ 2 * d⁄dX R f := by
   apply Derivation.leibniz_of_mul_eq_one
   simp
 
-@[simp] theorem fDerivative_invOf {R} [CommRing R] (f : R⟦X⟧) [Invertible f] :
-    d⁄dX R (⅟ f) = - (⅟ f) ^ 2 * d⁄dX R f := by
+@[simp] theorem derivative_invOf {R} [CommRing R] (f : R⟦X⟧) [Invertible f] :
+    d⁄dX R ⅟f = - ⅟f ^ 2 * d⁄dX R f := by
   rw [Derivation.leibniz_invOf, smul_eq_mul]
 
 /-
 The following theorem is stated only in the case that `R` is a field. This is because
 there is currently no instance of `Inv R⟦X⟧` for more general base rings `R`.
 -/
-@[simp] theorem fDerivative_inv' {R} [Field R] (f : R⟦X⟧) : d⁄dX R f⁻¹ = -f⁻¹ ^ 2 * d⁄dX R f := by
+@[simp] theorem derivative_inv' {R} [Field R] (f : R⟦X⟧) : d⁄dX R f⁻¹ = -f⁻¹ ^ 2 * d⁄dX R f := by
   by_cases constantCoeff R f = 0
   · suffices : f⁻¹ = 0
     rw [this, pow_two, zero_mul, neg_zero, zero_mul, map_zero]


### PR DESCRIPTION
Given a commutative semiring R, define the formal derivative R[[X]] \to R[[X]] and prove some basic properties.

This is a part of #7271.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
