### PR TITLE
[Merged by Bors] - fix: context handling for `use` tactic

### DIFF
--- a/test/Use.lean
+++ b/test/Use.lean
@@ -210,3 +210,8 @@ by
 -- The discharger knows about `exists_prop`.
 example (h1 : 1 > 0) : ∃ (n : Nat) (_h : n > 0), n = n := by
   use 1
+
+-- Regression test: `use` needs to elaborate its argument inside the correct local context
+example : let P : Nat → Prop := fun _x => ∃ _n : Nat, True; P 1 := by
+  intro P
+  use 1

--- a/test/Use.lean
+++ b/test/Use.lean
@@ -211,7 +211,7 @@ by
 example (h1 : 1 > 0) : ∃ (n : Nat) (_h : n > 0), n = n := by
   use 1
 
--- Regression test: `use` needs to elaborate its argument inside the correct local context
+-- Regression test: `use` needs to ensure it does calculations inside the correct local contexts
 example : let P : Nat → Prop := fun _x => ∃ _n : Nat, True; P 1 := by
   intro P
   use 1

--- a/test/Use2.lean
+++ b/test/Use2.lean
@@ -1,8 +1,0 @@
-import Mathlib.RingTheory.Ideal.Operations
-
-example {R : Type*} [CommRing R] {I J : Ideal R} {x : R} (hx : x ∈ I • J) :
-      ∃ n: ℕ, True := by
-   let P : R → Prop := fun x ↦ ∃ n : ℕ, True
-   apply Submodule.smul_induction_on (p := P) hx
-   intro a ha b hb
-   use 1

--- a/test/Use2.lean
+++ b/test/Use2.lean
@@ -1,0 +1,8 @@
+import Mathlib.RingTheory.Ideal.Operations
+
+example {R : Type*} [CommRing R] {I J : Ideal R} {x : R} (hx : x ∈ I • J) :
+      ∃ n: ℕ, True := by
+   let P : R → Prop := fun x ↦ ∃ n : ℕ, True
+   apply Submodule.smul_induction_on (p := P) hx
+   intro a ha b hb
+   use 1


### PR DESCRIPTION
Fixes error reported by Patrick Massot [on Zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/use.20bug/near/397784284).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
