### PR TITLE
Add gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.lean text eol=lf


### PR DESCRIPTION
Teach Git that Lean files should have Linux line endings.

-------

It appears from https://github.com/leanprover-community/mathlib4/pull/6498 that mathlib4 is opinionated about line endings, so here is something to make that automatic.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
