### PR TITLE
[Merged by Bors] - feat: two small lemmas about ordered lists

### DIFF
--- a/Mathlib/Data/List/Lex.lean
+++ b/Mathlib/Data/List/Lex.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
 import Mathlib.Order.RelClasses
+import Mathlib.Data.List.Basic
 
 #align_import data.list.lex from "leanprover-community/mathlib"@"d6aae1bcbd04b8de2022b9b83a5b5b10e10c777d"
 
@@ -210,5 +211,15 @@ theorem lt_iff_lex_lt [LinearOrder α] (l l' : List α) : lt l l' ↔ Lex (· < 
     | @nil a as => apply lt.nil
     | @cons a as bs _ ih => apply lt.tail <;> simp [ih]
     | @rel a as b bs h => apply lt.head; assumption
+
+theorem head!_le_of_lt [LinearOrder α] [Inhabited α] (l l' : List α) (h : lt l' l) (hl' : l' ≠ []) :
+    l'.head! ≤ l.head! := by
+  rw [lt_iff_lex_lt l' l] at h
+  by_cases hl : l = []
+  · simp only [hl, List.Lex.not_nil_right] at h
+  · by_contra hh
+    have := List.Lex.rel (r := (·<·)) (l₁ := l.tail) (l₂ := l'.tail) (not_le.mp hh)
+    rw [List.cons_head!_tail hl', List.cons_head!_tail hl] at this
+    exact asymm h this
 
 end List

--- a/Mathlib/Data/List/Sort.lean
+++ b/Mathlib/Data/List/Sort.lean
@@ -74,7 +74,7 @@ theorem head!_le_of_sorted [Inhabited α] [Preorder α] {a : α} {l : List α} (
   · exact le_rfl
   · exact le_of_lt (rel_of_sorted_cons h a (by assumption))
 
-theorem rel_head!_of_sorted' [Inhabited α] [Preorder α] {a : α} {l : List α} (h : Sorted (· > ·) l)
+theorem le_head!_of_sorted' [Inhabited α] [Preorder α] {a : α} {l : List α} (h : Sorted (· > ·) l)
     (ha : a ∈ l) : a ≤ l.head! := by
   rw [← List.cons_head!_tail (List.ne_nil_of_mem ha)] at h ha
   cases ha

--- a/Mathlib/Data/List/Sort.lean
+++ b/Mathlib/Data/List/Sort.lean
@@ -67,7 +67,7 @@ theorem rel_of_sorted_cons {a : α} {l : List α} : Sorted r (a :: l) → ∀ b 
   rel_of_pairwise_cons
 #align list.rel_of_sorted_cons List.rel_of_sorted_cons
 
-theorem rel_head!_of_sorted [Inhabited α] [Preorder α] {a : α} {l : List α} (h : Sorted (· < ·) l)
+theorem head!_le_of_sorted [Inhabited α] [Preorder α] {a : α} {l : List α} (h : Sorted (· < ·) l)
     (ha : a ∈ l) : l.head! ≤ a := by
   rw [← List.cons_head!_tail (List.ne_nil_of_mem ha)] at h ha
   cases ha

--- a/Mathlib/Data/List/Sort.lean
+++ b/Mathlib/Data/List/Sort.lean
@@ -74,6 +74,13 @@ theorem rel_head!_of_sorted [Inhabited α] [Preorder α] {a : α} {l : List α} 
   · exact le_rfl
   · exact le_of_lt (rel_of_sorted_cons h a (by assumption))
 
+theorem rel_head!_of_sorted' [Inhabited α] [Preorder α] {a : α} {l : List α} (h : Sorted (· > ·) l)
+    (ha : a ∈ l) : a ≤ l.head! := by
+  rw [← List.cons_head!_tail (List.ne_nil_of_mem ha)] at h ha
+  cases ha
+  · exact le_rfl
+  · exact le_of_lt (rel_of_sorted_cons h a (by assumption))
+
 @[simp]
 theorem sorted_cons {a : α} {l : List α} : Sorted r (a :: l) ↔ (∀ b ∈ l, r a b) ∧ Sorted r l :=
   pairwise_cons

--- a/Mathlib/Data/List/Sort.lean
+++ b/Mathlib/Data/List/Sort.lean
@@ -74,7 +74,7 @@ theorem head!_le_of_sorted [Inhabited α] [Preorder α] {a : α} {l : List α} (
   · exact le_rfl
   · exact le_of_lt (rel_of_sorted_cons h a (by assumption))
 
-theorem le_head!_of_sorted' [Inhabited α] [Preorder α] {a : α} {l : List α} (h : Sorted (· > ·) l)
+theorem le_head!_of_sorted [Inhabited α] [Preorder α] {a : α} {l : List α} (h : Sorted (· > ·) l)
     (ha : a ∈ l) : a ≤ l.head! := by
   rw [← List.cons_head!_tail (List.ne_nil_of_mem ha)] at h ha
   cases ha

--- a/Mathlib/Data/List/Sort.lean
+++ b/Mathlib/Data/List/Sort.lean
@@ -67,6 +67,13 @@ theorem rel_of_sorted_cons {a : α} {l : List α} : Sorted r (a :: l) → ∀ b 
   rel_of_pairwise_cons
 #align list.rel_of_sorted_cons List.rel_of_sorted_cons
 
+theorem rel_head!_of_sorted [Inhabited α] [Preorder α] {a : α} {l : List α} (h : Sorted (· < ·) l)
+    (ha : a ∈ l) : l.head! ≤ a := by
+  rw [← List.cons_head!_tail (List.ne_nil_of_mem ha)] at h ha
+  cases ha
+  · exact le_rfl
+  · exact le_of_lt (rel_of_sorted_cons h a (by assumption))
+
 @[simp]
 theorem sorted_cons {a : α} {l : List α} : Sorted r (a :: l) ↔ (∀ b ∈ l, r a b) ∧ Sorted r l :=
   pairwise_cons

--- a/Mathlib/Data/List/Sort.lean
+++ b/Mathlib/Data/List/Sort.lean
@@ -67,14 +67,14 @@ theorem rel_of_sorted_cons {a : α} {l : List α} : Sorted r (a :: l) → ∀ b 
   rel_of_pairwise_cons
 #align list.rel_of_sorted_cons List.rel_of_sorted_cons
 
-theorem head!_le_of_sorted [Inhabited α] [Preorder α] {a : α} {l : List α} (h : Sorted (· < ·) l)
+theorem Sorted.head!_le [Inhabited α] [Preorder α] {a : α} {l : List α} (h : Sorted (· < ·) l)
     (ha : a ∈ l) : l.head! ≤ a := by
   rw [← List.cons_head!_tail (List.ne_nil_of_mem ha)] at h ha
   cases ha
   · exact le_rfl
   · exact le_of_lt (rel_of_sorted_cons h a (by assumption))
 
-theorem le_head!_of_sorted [Inhabited α] [Preorder α] {a : α} {l : List α} (h : Sorted (· > ·) l)
+theorem Sorted.le_head! [Inhabited α] [Preorder α] {a : α} {l : List α} (h : Sorted (· > ·) l)
     (ha : a ∈ l) : a ≤ l.head! := by
   rw [← List.cons_head!_tail (List.ne_nil_of_mem ha)] at h ha
   cases ha


### PR DESCRIPTION
We prove that in a sorted list, the `head!` is the smallest element, and that if a list is lexicographically smaller than another list, then its `head!` is smaller than or equal to that of the other.


---


These are used in Nöbeling's theorem: #6286 

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
