### PR TITLE
[Merged by Bors] - chore(counterexamples): remove incorrect counterexample

### DIFF
--- a/Counterexamples/CanonicallyOrderedCommSemiringTwoMul.lean
+++ b/Counterexamples/CanonicallyOrderedCommSemiringTwoMul.lean
@@ -31,34 +31,6 @@ set_option linter.uppercaseLean3 false
 
 namespace Counterexample
 
-namespace FromBhavik
-
-/-- Bhavik Mehta's example.  There are only the initial definitions, but no proofs.  The Type
-`K` is a canonically ordered commutative semiring with the property that `2 * (1/2) ≤ 2 * 1`, even
-though it is not true that `1/2 ≤ 1`, since `1/2` and `1` are not comparable. -/
-def K : Type :=
-  Subsemiring.closure ({1.5} : Set ℚ)
-deriving CommSemiring
-#align counterexample.from_Bhavik.K Counterexample.FromBhavik.K
-
-instance : Coe K ℚ :=
-  ⟨fun x => x.1⟩
-
-instance inhabitedK : Inhabited K :=
-  ⟨0⟩
-#align counterexample.from_Bhavik.inhabited_K Counterexample.FromBhavik.inhabitedK
-
-instance : Preorder K where
-  le x y := x = y ∨ (x : ℚ) + 1 ≤ (y : ℚ)
-  le_refl x := Or.inl rfl
-  le_trans x y z xy yz := by
-    rcases xy with (rfl | xy); · apply yz
-    rcases yz with (rfl | yz); · right; apply xy
-    right
-    exact xy.trans (le_trans ((le_add_iff_nonneg_right _).mpr zero_le_one) yz)
-
-end FromBhavik
-
 theorem mem_zmod_2 (a : ZMod 2) : a = 0 ∨ a = 1 := by
   rcases a with ⟨_ | _, _ | _ | _ | _⟩
   · exact Or.inl rfl


### PR DESCRIPTION
This was a counterexample I suggested to a certain problem, and it was added to counterexamples/ without proof.
I later realised it doesn't actually work, so I'm removing it from this file. Damiano's example does still work, and provide a counterexample to the claim.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
