### PR TITLE
[Merged by Bors] - feat(Algebra/BigOperators/Order): prod_lt_prod

### DIFF
--- a/Mathlib/Algebra/BigOperators/Order.lean
+++ b/Mathlib/Algebra/BigOperators/Order.lean
@@ -649,9 +649,9 @@ theorem prod_pos (h0 : ∀ i ∈ s, 0 < f i) : 0 < ∏ i in s, f i :=
   prod_induction f (fun x ↦ 0 < x) (fun _ _ ha hb ↦ mul_pos ha hb) zero_lt_one h0
 #align finset.prod_pos Finset.prod_pos
 
-theorem prod_lt_prod {t : Finset ℕ} {f g : ℕ → R} (hf : ∀ n ∈ t, 0 < f n)
-    (hfg : ∀ n ∈ t, f n ≤ g n) (hlt : ∃ n ∈ t, f n < g n) :
-    ∏ p in t, f p < ∏ p in t, g p := by
+theorem prod_lt_prod {t : Finset ℕ} {f g : ℕ → R} (hf : ∀ i ∈ t, 0 < f i)
+    (hfg : ∀ i ∈ t, f i ≤ g i) (hlt : ∃ i ∈ t, f i < g i) :
+    ∏ i in t, f i < ∏ i in t, g i := by
   obtain ⟨i, hi, hilt⟩ := hlt
   rw [← insert_erase hi, prod_insert (not_mem_erase _ _), prod_insert (not_mem_erase _ _)]
   apply mul_lt_mul hilt
@@ -660,12 +660,12 @@ theorem prod_lt_prod {t : Finset ℕ} {f g : ℕ → R} (hf : ∀ n ∈ t, 0 < f
   · exact prod_pos fun j hj => hf j (mem_of_mem_erase hj)
   · exact le_of_lt <| (hf i hi).trans hilt
 
-theorem prod_lt_prod_of_nonempty {t : Finset ℕ} {f g : ℕ → R} (hf : ∀ n : ℕ, n ∈ t → 0 < f n)
-    (hfg : ∀ n : ℕ, n ∈ t → f n < g n) (h_ne : t.Nonempty) :
-    ∏ p in t, f p < ∏ p in t, g p := by
-  apply prod_lt_prod hf fun n hn => le_of_lt (hfg n hn)
-  obtain ⟨n, hn⟩ := h_ne
-  exact ⟨n, hn, hfg n hn⟩
+theorem prod_lt_prod_of_nonempty {t : Finset ℕ} {f g : ℕ → R} (hf : ∀ i ∈ t, 0 < f i)
+    (hfg : ∀ i ∈ t, f i < g i) (h_ne : t.Nonempty) :
+    ∏ i in t, f i < ∏ i in t, g i := by
+  apply prod_lt_prod hf fun i hi => le_of_lt (hfg i hi)
+  obtain ⟨i, hi⟩ := h_ne
+  exact ⟨i, hi, hfg i hi⟩
 
 end StrictOrderedCommSemiring
 

--- a/Mathlib/Algebra/BigOperators/Order.lean
+++ b/Mathlib/Algebra/BigOperators/Order.lean
@@ -642,16 +642,17 @@ end OrderedCommSemiring
 
 section StrictOrderedCommSemiring
 
-variable [StrictOrderedCommSemiring R] {f : ι → R} {s : Finset ι}
+variable [StrictOrderedCommSemiring R] {f g : ι → R} {s : Finset ι}
 
 -- This is also true for an ordered commutative multiplicative monoid with zero
 theorem prod_pos (h0 : ∀ i ∈ s, 0 < f i) : 0 < ∏ i in s, f i :=
   prod_induction f (fun x ↦ 0 < x) (fun _ _ ha hb ↦ mul_pos ha hb) zero_lt_one h0
 #align finset.prod_pos Finset.prod_pos
 
-theorem prod_lt_prod {t : Finset ℕ} {f g : ℕ → R} (hf : ∀ i ∈ t, 0 < f i)
-    (hfg : ∀ i ∈ t, f i ≤ g i) (hlt : ∃ i ∈ t, f i < g i) :
-    ∏ i in t, f i < ∏ i in t, g i := by
+theorem prod_lt_prod (hf : ∀ i ∈ s, 0 < f i) (hfg : ∀ i ∈ s, f i ≤ g i)
+    (hlt : ∃ i ∈ s, f i < g i) :
+    ∏ i in s, f i < ∏ i in s, g i := by
+  classical
   obtain ⟨i, hi, hilt⟩ := hlt
   rw [← insert_erase hi, prod_insert (not_mem_erase _ _), prod_insert (not_mem_erase _ _)]
   apply mul_lt_mul hilt
@@ -660,9 +661,9 @@ theorem prod_lt_prod {t : Finset ℕ} {f g : ℕ → R} (hf : ∀ i ∈ t, 0 < f
   · exact prod_pos fun j hj => hf j (mem_of_mem_erase hj)
   · exact le_of_lt <| (hf i hi).trans hilt
 
-theorem prod_lt_prod_of_nonempty {t : Finset ℕ} {f g : ℕ → R} (hf : ∀ i ∈ t, 0 < f i)
-    (hfg : ∀ i ∈ t, f i < g i) (h_ne : t.Nonempty) :
-    ∏ i in t, f i < ∏ i in t, g i := by
+theorem prod_lt_prod_of_nonempty (hf : ∀ i ∈ s, 0 < f i) (hfg : ∀ i ∈ s, f i < g i)
+    (h_ne : s.Nonempty) :
+    ∏ i in s, f i < ∏ i in s, g i := by
   apply prod_lt_prod hf fun i hi => le_of_lt (hfg i hi)
   obtain ⟨i, hi⟩ := h_ne
   exact ⟨i, hi, hfg i hi⟩

--- a/Mathlib/Algebra/BigOperators/Order.lean
+++ b/Mathlib/Algebra/BigOperators/Order.lean
@@ -642,12 +642,30 @@ end OrderedCommSemiring
 
 section StrictOrderedCommSemiring
 
-variable [StrictOrderedCommSemiring R] [Nontrivial R] {f : ι → R} {s : Finset ι}
+variable [StrictOrderedCommSemiring R] {f : ι → R} {s : Finset ι}
 
 -- This is also true for an ordered commutative multiplicative monoid with zero
 theorem prod_pos (h0 : ∀ i ∈ s, 0 < f i) : 0 < ∏ i in s, f i :=
   prod_induction f (fun x ↦ 0 < x) (fun _ _ ha hb ↦ mul_pos ha hb) zero_lt_one h0
 #align finset.prod_pos Finset.prod_pos
+
+theorem prod_lt_prod {t : Finset ℕ} {f g : ℕ → R} (hf : ∀ n ∈ t, 0 < f n)
+    (hfg : ∀ n ∈ t, f n ≤ g n) (hlt : ∃ n ∈ t, f n < g n) :
+    ∏ p in t, f p < ∏ p in t, g p := by
+  obtain ⟨i, hi, hilt⟩ := hlt
+  rw [← insert_erase hi, prod_insert (not_mem_erase _ _), prod_insert (not_mem_erase _ _)]
+  apply mul_lt_mul hilt
+  · exact prod_le_prod (fun j hj => le_of_lt (hf j (mem_of_mem_erase hj)))
+      (fun _ hj ↦ hfg _ <| mem_of_mem_erase hj)
+  · exact prod_pos fun j hj => hf j (mem_of_mem_erase hj)
+  · exact le_of_lt <| (hf i hi).trans hilt
+
+theorem prod_lt_prod_of_nonempty {t : Finset ℕ} {f g : ℕ → R} (hf : ∀ n : ℕ, n ∈ t → 0 < f n)
+    (hfg : ∀ n : ℕ, n ∈ t → f n < g n) (h_ne : t.Nonempty) :
+    ∏ p in t, f p < ∏ p in t, g p := by
+  apply prod_lt_prod hf fun n hn => le_of_lt (hfg n hn)
+  obtain ⟨n, hn⟩ := h_ne
+  exact ⟨n, hn, hfg n hn⟩
 
 end StrictOrderedCommSemiring
 


### PR DESCRIPTION
Add a product variant of [mul_lt_mul](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/Order/Ring/Defs.html#mul_lt_mul), following the pattern of [Finset.prod_lt_prod'](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/BigOperators/Order.html#Finset.prod_lt_prod'). This fills in a gap between [Finset.prod_le_prod](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/BigOperators/Order.html#Finset.prod_le_prod), [Finset.prod_le_prod'](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/BigOperators/Order.html#Finset.prod_le_prod') and [Finset.prod_lt_prod'](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/BigOperators/Order.html#Finset.prod_lt_prod').

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
