### PR TITLE
[Merged by Bors] - chore: reorder variables for `to_additive`

### DIFF
--- a/Mathlib/Data/Set/Pointwise/SMul.lean
+++ b/Mathlib/Data/Set/Pointwise/SMul.lean
@@ -86,7 +86,7 @@ theorem image2_smul : image2 SMul.smul s t = s • t :=
 #align set.image2_smul Set.image2_smul
 #align set.image2_vadd Set.image2_vadd
 
--- @[to_additive add_image_prod] -- Porting note: bug in mathlib3
+@[to_additive vadd_image_prod]
 theorem image_smul_prod : (fun x : α × β ↦ x.fst • x.snd) '' s ×ˢ t = s • t :=
   image_prod _
 #align set.image_smul_prod Set.image_smul_prod

--- a/Mathlib/Data/Set/Pointwise/SMul.lean
+++ b/Mathlib/Data/Set/Pointwise/SMul.lean
@@ -86,7 +86,7 @@ theorem image2_smul : image2 SMul.smul s t = s • t :=
 #align set.image2_smul Set.image2_smul
 #align set.image2_vadd Set.image2_vadd
 
-@[to_additive vadd_image_prod]
+-- @[to_additive add_image_prod] -- Porting note: bug in mathlib3
 theorem image_smul_prod : (fun x : α × β ↦ x.fst • x.snd) '' s ×ˢ t = s • t :=
   image_prod _
 #align set.image_smul_prod Set.image_smul_prod

--- a/Mathlib/Topology/Algebra/Group/Basic.lean
+++ b/Mathlib/Topology/Algebra/Group/Basic.lean
@@ -38,7 +38,7 @@ open Classical Set Filter TopologicalSpace Function Topology Pointwise MulOpposi
 
 universe u v w x
 
-variable {G : Type w} {α : Type u} {β : Type v} {H : Type x}
+variable {G : Type w} {H : Type x} {α : Type u} {β : Type v}
 
 section ContinuousMulGroup
 

--- a/Mathlib/Topology/Algebra/Group/Basic.lean
+++ b/Mathlib/Topology/Algebra/Group/Basic.lean
@@ -38,7 +38,7 @@ open Classical Set Filter TopologicalSpace Function Topology Pointwise MulOpposi
 
 universe u v w x
 
-variable {α : Type u} {β : Type v} {G : Type w} {H : Type x}
+variable {G : Type w} {α : Type u} {β : Type v} {H : Type x}
 
 section ContinuousMulGroup
 

--- a/Mathlib/Topology/Algebra/Monoid.lean
+++ b/Mathlib/Topology/Algebra/Monoid.lean
@@ -26,7 +26,7 @@ open Classical Set Filter TopologicalSpace
 
 open Classical Topology BigOperators Pointwise
 
-variable {ι α X M N : Type*} [TopologicalSpace X]
+variable {ι α M N X : Type*} [TopologicalSpace X]
 
 @[to_additive (attr := continuity)]
 theorem continuous_one [TopologicalSpace M] [One M] : Continuous (1 : X → M) :=


### PR DESCRIPTION
`to_additive` heuristics work best when the type to be additivized comes first. We make sure this is the case for later applications.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
