### PR TITLE
[Merged by Bors] - fix: make CI-task "check for noisy stdout lines" more verbose.

### DIFF
--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -179,7 +179,7 @@ jobs:
 
       - name: check for noisy stdout lines
         run: |
-          ! grep "stdout:" stdout.log
+          ! grep --after-context=1 "stdout:" stdout.log
 
       - name: build library_search cache
         run: lake build -KCI MathlibExtras

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -185,7 +185,7 @@ jobs:
 
       - name: check for noisy stdout lines
         run: |
-          ! grep "stdout:" stdout.log
+          ! grep --after-context=1 "stdout:" stdout.log
 
       - name: build library_search cache
         run: lake build -KCI MathlibExtras

--- a/.github/workflows/build.yml.in
+++ b/.github/workflows/build.yml.in
@@ -165,7 +165,7 @@ jobs:
 
       - name: check for noisy stdout lines
         run: |
-          ! grep "stdout:" stdout.log
+          ! grep --after-context=1 "stdout:" stdout.log
 
       - name: build library_search cache
         run: lake build -KCI MathlibExtras

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -183,7 +183,7 @@ jobs:
 
       - name: check for noisy stdout lines
         run: |
-          ! grep "stdout:" stdout.log
+          ! grep --after-context=1 "stdout:" stdout.log
 
       - name: build library_search cache
         run: lake build -KCI MathlibExtras

--- a/Mathlib/Algebra/CharP/MixedCharZero.lean
+++ b/Mathlib/Algebra/CharP/MixedCharZero.lean
@@ -379,9 +379,7 @@ theorem split_by_characteristic_localRing [LocalRing R]
     (h_mixed : ∀ p : ℕ, Nat.Prime p → MixedCharZero R p → P) : P := by
   refine' split_by_characteristic R _ h_equal h_mixed
   intro p p_pos p_char
-  have x := 4
   have p_ppow : IsPrimePow (p : ℕ) := or_iff_not_imp_left.mp (charP_zero_or_prime_power R p) p_pos
-  have y := 4
   exact h_pos p p_ppow p_char
 #align split_by_characteristic_local_ring split_by_characteristic_localRing
 

--- a/Mathlib/Algebra/CharP/MixedCharZero.lean
+++ b/Mathlib/Algebra/CharP/MixedCharZero.lean
@@ -379,7 +379,9 @@ theorem split_by_characteristic_localRing [LocalRing R]
     (h_mixed : ∀ p : ℕ, Nat.Prime p → MixedCharZero R p → P) : P := by
   refine' split_by_characteristic R _ h_equal h_mixed
   intro p p_pos p_char
+  have x := 4
   have p_ppow : IsPrimePow (p : ℕ) := or_iff_not_imp_left.mp (charP_zero_or_prime_power R p) p_pos
+  have y := 4
   exact h_pos p p_ppow p_char
 #align split_by_characteristic_local_ring split_by_characteristic_localRing
 


### PR DESCRIPTION
linter warnings print the following messages to stdout:

```
stdout:
./././MyProject/MyFile.lean:19:53: warning: unused variable `x` [linter.unusedVariables]
./././MyProject/MyFile.lean:19:53: warning: unused variable `y` [linter.unusedVariables]
```

With this change, the CI would at least print the first line after `stdout:`, partially helping with debugging.

---

I don't know how to test this.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
