### PR TITLE
[Merged by Bors] - fix: Put golden ratio notation in a specific namespace.

### DIFF
--- a/Mathlib/Data/Real/GoldenRatio.lean
+++ b/Mathlib/Data/Real/GoldenRatio.lean
@@ -40,9 +40,9 @@ def goldenConj :=
   (1 - Real.sqrt 5) / 2
 #align golden_conj goldenConj
 
-@[inherit_doc goldenRatio] scoped[Real] notation "φ" => goldenRatio
-@[inherit_doc goldenConj] scoped[Real] notation "ψ" => goldenConj
-open Real
+@[inherit_doc goldenRatio] scoped[goldenRatio] notation "φ" => goldenRatio
+@[inherit_doc goldenConj] scoped[goldenRatio] notation "ψ" => goldenConj
+open Real goldenRatio
 
 /-- The inverse of the golden ratio is the opposite of its conjugate. -/
 theorem inv_gold : φ⁻¹ = -ψ := by


### PR DESCRIPTION
The current situation blocks two very common letters if you `import Mathlib` and `open Real`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
