### PR TITLE
[Merged by Bors] - fix: accidental `getFileHash` state reset

### DIFF
--- a/Cache/Hashing.lean
+++ b/Cache/Hashing.lean
@@ -81,14 +81,13 @@ Computes the hash of a file, which mixes:
 * The hashes of the imported files that are part of `Mathlib`
 -/
 partial def getFileHash (filePath : FilePath) : HashM $ Option UInt64 := do
-  let stt ← get
-  match stt.cache.find? filePath with
+  match (← get).cache.find? filePath with
   | some hash? => return hash?
   | none =>
     let fixedPath := (← IO.getPackageDir filePath) / filePath
     if !(← fixedPath.pathExists) then
       IO.println s!"Warning: {fixedPath} not found. Skipping all files that depend on it"
-      set { stt with cache := stt.cache.insert filePath none }
+      modify fun stt => { stt with cache := stt.cache.insert filePath none }
       return none
     let content ← IO.FS.readFile fixedPath
     let fileImports := getFileImports content pkgDirs
@@ -97,7 +96,7 @@ partial def getFileHash (filePath : FilePath) : HashM $ Option UInt64 := do
       match importHash? with
       | some importHash => importHashes := importHashes.push importHash
       | none =>
-        set { stt with cache := stt.cache.insert filePath none }
+        modify fun stt => { stt with cache := stt.cache.insert filePath none }
         return none
     let rootHash := (← get).rootHash
     let pathHash := hash filePath.components


### PR DESCRIPTION
As [reported on Zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/infinite.20loop.20in.20CI.3A.20get.20cache/near/398158750). The use of `set` instead of `modify` was accidentally retaining old values of the state, which would clobber insertions and cause files to be revisited.