### PR TITLE
[Merged by Bors] - chore: fix porting note about Comma.eqToHom_right by adding simp lemmas

### DIFF
--- a/Mathlib/CategoryTheory/Elements.lean
+++ b/Mathlib/CategoryTheory/Elements.lean
@@ -246,9 +246,7 @@ theorem to_fromCostructuredArrow_eq (F : Cᵒᵖ ⥤ Type v) :
     ext x f
     convert congr_fun (X_hom.naturality f.op).symm (𝟙 X_left)
     simp
-  · intro X Y f
-    ext
-    simp [CostructuredArrow.eqToHom_left]
+  · aesop
 #align category_theory.category_of_elements.to_from_costructured_arrow_eq CategoryTheory.CategoryOfElements.to_fromCostructuredArrow_eq
 
 /-- The equivalence `F.Elementsᵒᵖ ≅ (yoneda, F)` given by yoneda lemma. -/
@@ -275,9 +273,7 @@ theorem costructuredArrow_yoneda_equivalence_naturality {F₁ F₂ : Cᵒᵖ ⥤
     congr
     ext _ f
     simpa using congr_fun (α.naturality f.op).symm (unop X).snd
-  · intro X Y f
-    ext
-    simp [CostructuredArrow.eqToHom_left]
+  · aesop
 #align category_theory.category_of_elements.costructured_arrow_yoneda_equivalence_naturality CategoryTheory.CategoryOfElements.costructuredArrow_yoneda_equivalence_naturality
 
 end CategoryOfElements

--- a/Mathlib/CategoryTheory/Functor/Flat.lean
+++ b/Mathlib/CategoryTheory/Functor/Flat.lean
@@ -191,29 +191,9 @@ theorem uniq {K : J ⥤ C} {c : Cone K} (hc : IsLimit c) (s : Cone (K ⋙ F))
     (h₂ : ∀ j : J, f₂ ≫ (F.mapCone c).π.app j = s.π.app j) : f₁ = f₂ := by
   -- We can make two cones over the diagram of `s` via `f₁` and `f₂`.
   let α₁ : (F.mapCone c).toStructuredArrow ⋙ map f₁ ⟶ s.toStructuredArrow :=
-    { app := fun X => eqToHom (by simp [← h₁])
-      naturality := fun j₁ j₂ φ => by
-        ext
-        -- porting note: Lean 3 proof was `simp` but `Comma.eqToHom_right`
-        -- isn't firing for some reason
-        -- Asked here https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/simp.20not.20using.20a.20simp.20lemma/near/353943416
-        -- I'm now doing `simp, rw [Comma.eqToHom_right, Comma.eqToHom_right], simp` but
-        -- I squeezed the first `simp`.
-        simp only [Functor.mapCone_pt, Functor.comp_obj, Cone.toStructuredArrow_obj,
-          Functor.mapCone_π_app, map_mk, mk_right, Functor.comp_map, Cone.toStructuredArrow_map,
-          comp_right, map_map_right, homMk_right]
-        rw [Comma.eqToHom_right, Comma.eqToHom_right] -- this is a `simp` lemma
-        simp }
+    { app := fun X => eqToHom (by simp [← h₁]) }
   let α₂ : (F.mapCone c).toStructuredArrow ⋙ map f₂ ⟶ s.toStructuredArrow :=
-    { app := fun X => eqToHom (by simp [← h₂])
-      naturality := fun _ _ _ => by
-        ext
-        -- porting note: see comments above. `simp` should close this goal (and did in Lean 3)
-        simp only [Functor.mapCone_pt, Functor.comp_obj, Cone.toStructuredArrow_obj,
-          Functor.mapCone_π_app, map_mk, mk_right, Functor.comp_map, Cone.toStructuredArrow_map,
-          comp_right, map_map_right, homMk_right]
-        rw [Comma.eqToHom_right, Comma.eqToHom_right] -- this is a `simp` lemma
-        simp }
+    { app := fun X => eqToHom (by simp [← h₂]) }
   let c₁ : Cone (s.toStructuredArrow ⋙ pre s.pt K F) :=
     (Cones.postcompose (whiskerRight α₁ (pre s.pt K F) : _)).obj (c.toStructuredArrowCone F f₁)
   let c₂ : Cone (s.toStructuredArrow ⋙ pre s.pt K F) :=
@@ -228,15 +208,7 @@ theorem uniq {K : J ⥤ C} {c : Cone K} (hc : IsLimit c) (s : Cone (K ⋙ F))
     intro j
     injection c₀.π.naturality (BiconeHom.left j) with _ e₁
     injection c₀.π.naturality (BiconeHom.right j) with _ e₂
-    -- porting note: Lean 3 proof now finished with `simpa using e₁.symm.trans e₂`
-    -- This doesn't work for two reasons in Lean 4: firstly it seems that Lean 4 `simp`
-    -- expands `let` definitions by default, so we have to switch this off with `zeta = false`;
-    -- secondly, `simp` is not rewriting `Comma.eqToHom_right` for some reason (just like)
-    -- 30 lines above here
-    have e₃ := e₁.symm.trans e₂
-    simp (config := {zeta := false}) at e₃ -- should turn `e₃` into the goal
-    rw [Comma.eqToHom_right, Comma.eqToHom_right] at e₃ -- this is a `simp` lemma
-    simpa (config := {zeta := false}) using e₃
+    simpa (config := {zeta := false}) using e₁.symm.trans e₂
   have : c.extend g₁.right = c.extend g₂.right := by
     unfold Cone.extend
     congr 1

--- a/Mathlib/CategoryTheory/StructuredArrow.lean
+++ b/Mathlib/CategoryTheory/StructuredArrow.lean
@@ -96,6 +96,7 @@ theorem comp_right {X Y Z : StructuredArrow S T} (f : X ⟶ Y) (g : Y ⟶ Z) :
 @[simp]
 theorem id_right (X : StructuredArrow S T) : (𝟙 X : X ⟶ X).right = 𝟙 X.right := rfl
 
+@[simp]
 theorem eqToHom_right {X Y : StructuredArrow S T} (h : X = Y) :
     (eqToHom h).right = eqToHom (by rw [h]) := by
   subst h
@@ -427,6 +428,7 @@ theorem comp_left {X Y Z : CostructuredArrow S T} (f : X ⟶ Y) (g : Y ⟶ Z) :
 @[simp]
 theorem id_left (X : CostructuredArrow S T) : (𝟙 X : X ⟶ X).left = 𝟙 X.left := rfl
 
+@[simp]
 theorem eqToHom_left {X Y : CostructuredArrow S T} (h : X = Y) :
     (eqToHom h).left = eqToHom (by rw [h]) := by
   subst h


### PR DESCRIPTION
There are two things going on here: the change in behaviour in `simp` (currently, but not for much longer, requiring `zeta := false`), and some defeq abuse that I'm resolving here by adding additional `simp` lemmas.

This will slightly clarify one of the changes required in #7847 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
