### PR TITLE
refactor: extract induced functor between FundamentalGroupoids

### DIFF
--- a/Mathlib/AlgebraicTopology/FundamentalGroupoid/Basic.lean
+++ b/Mathlib/AlgebraicTopology/FundamentalGroupoid/Basic.lean
@@ -316,33 +316,20 @@ theorem comp_eq (x y z : FundamentalGroupoid X) (p : x ⟶ y) (q : y ⟶ z) : p 
 theorem id_eq_path_refl (x : FundamentalGroupoid X) : 𝟙 x = ⟦Path.refl x⟧ := rfl
 #align fundamental_groupoid.id_eq_path_refl FundamentalGroupoid.id_eq_path_refl
 
+/-- The functor on fundamental groupoid induced by a continuous map. -/
+def map (f : C(X, Y)) : FundamentalGroupoid X ⥤ FundamentalGroupoid Y where
+  obj := f
+  map {X Y} p := p.mapFn f
+  map_id _ := rfl
+  map_comp {X Y Z} p q := Quotient.inductionOn₂ p q fun a b ↦ by
+    simp only [comp_eq, ← Path.Homotopic.map_lift, ← Path.Homotopic.comp_lift, Path.map_trans]
+
 /-- The functor sending a topological space `X` to its fundamental groupoid. -/
 def fundamentalGroupoidFunctor : TopCat ⥤ CategoryTheory.Grpd where
   obj X := { α := FundamentalGroupoid X }
-  map f :=
-    { obj := f
-      map := fun {X Y} p => by exact Path.Homotopic.Quotient.mapFn p f
-      map_id := fun X => rfl
-      map_comp := fun {x y z} p q => by
-        refine Quotient.inductionOn₂ p q fun a b => ?_
-        simp only [comp_eq, ← Path.Homotopic.map_lift, ← Path.Homotopic.comp_lift, Path.map_trans]
-        -- This was not needed before leanprover/lean4#2644
-        erw [ ← Path.Homotopic.comp_lift]; rfl}
-  map_id X := by
-    simp only
-    change _ = (⟨_, _, _⟩ : FundamentalGroupoid X ⥤ FundamentalGroupoid X)
-    congr
-    ext x y p
-    refine' Quotient.inductionOn p fun q => _
-    rw [← Path.Homotopic.map_lift]
-    conv_rhs => rw [← q.map_id]
-  map_comp f g := by
-    simp only
-    congr
-    ext x y p
-    refine' Quotient.inductionOn p fun q => _
-    simp only [Quotient.map_mk, Path.map_map, Quotient.eq']
-    rfl
+  map := map
+  map_id X := by simp only [map]; congr; ext x y ⟨p⟩; rfl
+  map_comp f g := by simp only [map]; congr; ext x y ⟨p⟩; rfl
 #align fundamental_groupoid.fundamental_groupoid_functor FundamentalGroupoid.fundamentalGroupoidFunctor
 
 scoped notation "π" => FundamentalGroupoid.fundamentalGroupoidFunctor

--- a/Mathlib/AlgebraicTopology/FundamentalGroupoid/Basic.lean
+++ b/Mathlib/AlgebraicTopology/FundamentalGroupoid/Basic.lean
@@ -45,10 +45,7 @@ def reflTransSymmAux (x : I × I) : ℝ :=
 @[continuity]
 theorem continuous_reflTransSymmAux : Continuous reflTransSymmAux := by
   refine' continuous_if_le _ _ (Continuous.continuousOn _) (Continuous.continuousOn _) _
-  · continuity
-  · continuity
-  · continuity
-  · continuity
+  iterate 4 continuity
   intro x hx
   norm_num [hx, mul_assoc]
 #align path.homotopy.continuous_refl_trans_symm_aux Path.Homotopy.continuous_reflTransSymmAux
@@ -273,47 +270,38 @@ def FundamentalGroupoid (X : Type u) := X
 
 namespace FundamentalGroupoid
 
-instance {X : Type u} [h : Inhabited X] : Inhabited (FundamentalGroupoid X) := h
+scoped notation "πₓ" => FundamentalGroupoid
 
-attribute [reducible] FundamentalGroupoid
+/-- Help the typechecker by converting a point in a groupoid back to a point in
+the underlying topological space. -/
+def toTop {X} (x : πₓ X) : X := x
+#align fundamental_groupoid.to_top FundamentalGroupoid.toTop
+
+/-- Help the typechecker by converting a point in a topological space to a
+point in the fundamental groupoid of that space. -/
+def fromTop {X} (x : X) : πₓ X := x
+#align fundamental_groupoid.from_top FundamentalGroupoid.fromTop
+
+instance {X : Type u} [h : Inhabited X] : Inhabited (FundamentalGroupoid X) := h
 
 attribute [local instance] Path.Homotopic.setoid
 
 instance : CategoryTheory.Groupoid (FundamentalGroupoid X) where
-  Hom x y := Path.Homotopic.Quotient x y
-  id x := ⟦Path.refl x⟧
-  comp {x y z} := Path.Homotopic.Quotient.comp
-  id_comp {x y} f :=
-    Quotient.inductionOn f fun a =>
-      show ⟦(Path.refl x).trans a⟧ = ⟦a⟧ from Quotient.sound ⟨Path.Homotopy.reflTrans a⟩
-  comp_id {x y} f :=
-    Quotient.inductionOn f fun a =>
-      show ⟦a.trans (Path.refl y)⟧ = ⟦a⟧ from Quotient.sound ⟨Path.Homotopy.transRefl a⟩
-  assoc {w x y z} f g h :=
-    Quotient.inductionOn₃ f g h fun p q r =>
-      show ⟦(p.trans q).trans r⟧ = ⟦p.trans (q.trans r)⟧ from
-        Quotient.sound ⟨Path.Homotopy.transAssoc p q r⟩
-  inv {x y} p :=
-    Quotient.lift (fun l : Path x y => ⟦l.symm⟧)
-      (by
-        rintro a b ⟨h⟩
-        simp only
-        rw [Quotient.eq]
-        exact ⟨h.symm₂⟩)
-      p
-  inv_comp {x y} f :=
-    Quotient.inductionOn f fun a =>
-      show ⟦a.symm.trans a⟧ = ⟦Path.refl y⟧ from
-        Quotient.sound ⟨(Path.Homotopy.reflSymmTrans a).symm⟩
-  comp_inv {x y} f :=
-    Quotient.inductionOn f fun a =>
-      show ⟦a.trans a.symm⟧ = ⟦Path.refl x⟧ from
-        Quotient.sound ⟨(Path.Homotopy.reflTransSymm a).symm⟩
+  Hom x y := Path.Homotopic.Quotient (toTop x) (toTop y)
+  id x := ⟦Path.refl (toTop x)⟧
+  comp := Path.Homotopic.Quotient.comp
+  id_comp f := Quotient.inductionOn f fun a ↦ Quotient.sound ⟨Path.Homotopy.reflTrans a⟩
+  comp_id f := Quotient.inductionOn f fun a ↦ Quotient.sound ⟨Path.Homotopy.transRefl a⟩
+  assoc f g h := Quotient.inductionOn₃ f g h
+    fun p q r ↦ Quotient.sound ⟨Path.Homotopy.transAssoc p q r⟩
+  inv p := Quotient.lift (fun l ↦ ⟦l.symm⟧) (by rintro a b ⟨h⟩; exact Quotient.sound ⟨h.symm₂⟩) p
+  inv_comp f := Quotient.inductionOn f fun a ↦ Quotient.sound ⟨(Path.Homotopy.reflSymmTrans a).symm⟩
+  comp_inv f := Quotient.inductionOn f fun a ↦ Quotient.sound ⟨(Path.Homotopy.reflTransSymm a).symm⟩
 
 theorem comp_eq (x y z : FundamentalGroupoid X) (p : x ⟶ y) (q : y ⟶ z) : p ≫ q = p.comp q := rfl
 #align fundamental_groupoid.comp_eq FundamentalGroupoid.comp_eq
 
-theorem id_eq_path_refl (x : FundamentalGroupoid X) : 𝟙 x = ⟦Path.refl x⟧ := rfl
+theorem id_eq_path_refl (x : FundamentalGroupoid X) : 𝟙 x = ⟦Path.refl (toTop x)⟧ := rfl
 #align fundamental_groupoid.id_eq_path_refl FundamentalGroupoid.id_eq_path_refl
 
 /-- The functor on fundamental groupoid induced by a continuous map. -/
@@ -333,24 +321,11 @@ def fundamentalGroupoidFunctor : TopCat ⥤ CategoryTheory.Grpd where
 #align fundamental_groupoid.fundamental_groupoid_functor FundamentalGroupoid.fundamentalGroupoidFunctor
 
 scoped notation "π" => FundamentalGroupoid.fundamentalGroupoidFunctor
-scoped notation "πₓ" => FundamentalGroupoid.fundamentalGroupoidFunctor.obj
 scoped notation "πₘ" => FundamentalGroupoid.fundamentalGroupoidFunctor.map
 
 theorem map_eq {X Y : TopCat} {x₀ x₁ : X} (f : C(X, Y)) (p : Path.Homotopic.Quotient x₀ x₁) :
     (πₘ f).map p = p.mapFn f := rfl
 #align fundamental_groupoid.map_eq FundamentalGroupoid.map_eq
-
-/-- Help the typechecker by converting a point in a groupoid back to a point in
-the underlying topological space. -/
-@[reducible]
-def toTop {X : TopCat} (x : πₓ X) : X := x
-#align fundamental_groupoid.to_top FundamentalGroupoid.toTop
-
-/-- Help the typechecker by converting a point in a topological space to a
-point in the fundamental groupoid of that space. -/
-@[reducible]
-def fromTop {X : TopCat} (x : X) : πₓ X := x
-#align fundamental_groupoid.from_top FundamentalGroupoid.fromTop
 
 /-- Help the typechecker by converting an arrow in the fundamental groupoid of
 a topological space back to a path in that space (i.e., `Path.Homotopic.Quotient`). -/

--- a/Mathlib/AlgebraicTopology/FundamentalGroupoid/Basic.lean
+++ b/Mathlib/AlgebraicTopology/FundamentalGroupoid/Basic.lean
@@ -218,32 +218,10 @@ theorem trans_assoc_reparam {x₀ x₁ x₂ x₃ : X} (p : Path x₀ x₁) (q : 
   -- TODO: why does split_ifs not reduce the ifs??????
   split_ifs with h₁ h₂ h₃ h₄ h₅
   · rfl
-  · exfalso
-    linarith
-  · exfalso
-    linarith
-  · exfalso
-    linarith
-  · exfalso
-    linarith
-  · exfalso
-    linarith
-  · exfalso
-    linarith
+  iterate 6 exfalso; linarith
   · have h : 2 * (2 * (x : ℝ)) - 1 = 2 * (2 * (↑x + 1 / 4) - 1) := by linarith
     simp [h₂, h₁, h, dif_neg (show ¬False from id), dif_pos True.intro, if_false, if_true]
-  · exfalso
-    linarith
-  · exfalso
-    linarith
-  · exfalso
-    linarith
-  · exfalso
-    linarith
-  · exfalso
-    linarith
-  · exfalso
-    linarith
+  iterate 6 exfalso; linarith
   · congr
     ring
 #align path.homotopy.trans_assoc_reparam Path.Homotopy.trans_assoc_reparam
@@ -292,8 +270,7 @@ instance : CategoryTheory.Groupoid (FundamentalGroupoid X) where
   comp := Path.Homotopic.Quotient.comp
   id_comp f := Quotient.inductionOn f fun a ↦ Quotient.sound ⟨Path.Homotopy.reflTrans a⟩
   comp_id f := Quotient.inductionOn f fun a ↦ Quotient.sound ⟨Path.Homotopy.transRefl a⟩
-  assoc f g h := Quotient.inductionOn₃ f g h
-    fun p q r ↦ Quotient.sound ⟨Path.Homotopy.transAssoc p q r⟩
+  assoc := by rintro _ _ _ _ ⟨f⟩ ⟨g⟩ ⟨h⟩; exact Quotient.sound ⟨Path.Homotopy.transAssoc f g h⟩
   inv p := Quotient.lift (fun l ↦ ⟦l.symm⟧) (by rintro a b ⟨h⟩; exact Quotient.sound ⟨h.symm₂⟩) p
   inv_comp f := Quotient.inductionOn f fun a ↦ Quotient.sound ⟨(Path.Homotopy.reflSymmTrans a).symm⟩
   comp_inv f := Quotient.inductionOn f fun a ↦ Quotient.sound ⟨(Path.Homotopy.reflTransSymm a).symm⟩
@@ -306,11 +283,10 @@ theorem id_eq_path_refl (x : FundamentalGroupoid X) : 𝟙 x = ⟦Path.refl (toT
 
 /-- The functor on fundamental groupoid induced by a continuous map. -/
 def map (f : C(X, Y)) : FundamentalGroupoid X ⥤ FundamentalGroupoid Y where
-  obj := f
-  map {X Y} p := p.mapFn f
+  obj x := fromTop (f (toTop x))
+  map p := p.mapFn f
   map_id _ := rfl
-  map_comp {X Y Z} p q := Quotient.inductionOn₂ p q fun a b ↦ by
-    simp only [comp_eq, ← Path.Homotopic.map_lift, ← Path.Homotopic.comp_lift, Path.map_trans]
+  map_comp := by rintro _ _ _ ⟨p⟩ ⟨q⟩; exact congr_arg Quotient.mk' (p.map_trans q f.2)
 
 /-- The functor sending a topological space `X` to its fundamental groupoid. -/
 def fundamentalGroupoidFunctor : TopCat ⥤ CategoryTheory.Grpd where
@@ -320,24 +296,14 @@ def fundamentalGroupoidFunctor : TopCat ⥤ CategoryTheory.Grpd where
   map_comp f g := by simp only [map]; congr; ext x y ⟨p⟩; rfl
 #align fundamental_groupoid.fundamental_groupoid_functor FundamentalGroupoid.fundamentalGroupoidFunctor
 
+scoped notation "πₘ" => FundamentalGroupoid.map
 scoped notation "π" => FundamentalGroupoid.fundamentalGroupoidFunctor
-scoped notation "πₘ" => FundamentalGroupoid.fundamentalGroupoidFunctor.map
 
 theorem map_eq {X Y : TopCat} {x₀ x₁ : X} (f : C(X, Y)) (p : Path.Homotopic.Quotient x₀ x₁) :
     (πₘ f).map p = p.mapFn f := rfl
 #align fundamental_groupoid.map_eq FundamentalGroupoid.map_eq
 
-/-- Help the typechecker by converting an arrow in the fundamental groupoid of
-a topological space back to a path in that space (i.e., `Path.Homotopic.Quotient`). -/
--- Porting note: Added `(X := X)` to the type.
-@[reducible]
-def toPath {X : TopCat} {x₀ x₁ : πₓ X} (p : x₀ ⟶ x₁) : Path.Homotopic.Quotient (X := X) x₀ x₁ := p
-#align fundamental_groupoid.to_path FundamentalGroupoid.toPath
-
-/-- Help the typechecker by converting a path in a topological space to an arrow in the
-fundamental groupoid of that space. -/
-@[reducible]
-def fromPath {X : TopCat} {x₀ x₁ : X} (p : Path.Homotopic.Quotient x₀ x₁) : x₀ ⟶ x₁ := p
-#align fundamental_groupoid.from_path FundamentalGroupoid.fromPath
+#noalign fundamental_groupoid.to_path
+#noalign fundamental_groupoid.from_path
 
 end FundamentalGroupoid

--- a/Mathlib/AlgebraicTopology/FundamentalGroupoid/FundamentalGroup.lean
+++ b/Mathlib/AlgebraicTopology/FundamentalGroupoid/FundamentalGroup.lean
@@ -85,4 +85,8 @@ abbrev fromPath {X : TopCat} {x : X} (p : Path.Homotopic.Quotient x x) : Fundame
   fromArrow p
 #align fundamental_group.from_path FundamentalGroup.fromPath
 
+/-- The group homomorphism between fundamental groups induced by a continuous map. -/
+def map (f : C(X, Y)) : FundamentalGroup X x₀ →* FundamentalGroup Y (f x₀) :=
+  (FundamentalGroupoid.map f).mapAut x₀
+
 end FundamentalGroup

--- a/Mathlib/AlgebraicTopology/FundamentalGroupoid/FundamentalGroup.lean
+++ b/Mathlib/AlgebraicTopology/FundamentalGroupoid/FundamentalGroup.lean
@@ -85,7 +85,7 @@ abbrev fromPath {X : TopCat} {x : X} (p : Path.Homotopic.Quotient x x) : Fundame
   fromArrow p
 #align fundamental_group.from_path FundamentalGroup.fromPath
 
-/-- The group homomorphism between fundamental groups induced by a continuous map. -/
+/-- The homomorphism between fundamental groups induced by a continuous map. -/
 def map (f : C(X, Y)) : FundamentalGroup X x₀ →* FundamentalGroup Y (f x₀) :=
   (FundamentalGroupoid.map f).mapAut x₀
 

--- a/Mathlib/AlgebraicTopology/FundamentalGroupoid/FundamentalGroup.lean
+++ b/Mathlib/AlgebraicTopology/FundamentalGroupoid/FundamentalGroup.lean
@@ -64,8 +64,9 @@ def fundamentalGroupMulEquivOfPathConnected [PathConnectedSpace X] :
   fundamentalGroupMulEquivOfPath (PathConnectedSpace.somePath x₀ x₁)
 #align fundamental_group.fundamental_group_mul_equiv_of_path_connected FundamentalGroup.fundamentalGroupMulEquivOfPathConnected
 
+open FundamentalGroupoid
 /-- An element of the fundamental group as an arrow in the fundamental groupoid. -/
-abbrev toArrow {X : TopCat} {x : X} (p : FundamentalGroup X x) : x ⟶ x :=
+abbrev toArrow {X : TopCat} {x : X} (p : FundamentalGroup X x) : fromTop x ⟶ fromTop x :=
   p.hom
 #align fundamental_group.to_arrow FundamentalGroup.toArrow
 
@@ -75,7 +76,7 @@ abbrev toPath {X : TopCat} {x : X} (p : FundamentalGroup X x) : Path.Homotopic.Q
 #align fundamental_group.to_path FundamentalGroup.toPath
 
 /-- An element of the fundamental group, constructed from an arrow in the fundamental groupoid. -/
-abbrev fromArrow {X : TopCat} {x : X} (p : x ⟶ x) : FundamentalGroup X x where
+abbrev fromArrow {X : TopCat} {x : X} (p : fromTop x ⟶ fromTop x) : FundamentalGroup X x where
   hom := p
   inv := CategoryTheory.Groupoid.inv p
 #align fundamental_group.from_arrow FundamentalGroup.fromArrow
@@ -87,6 +88,6 @@ abbrev fromPath {X : TopCat} {x : X} (p : Path.Homotopic.Quotient x x) : Fundame
 
 /-- The homomorphism between fundamental groups induced by a continuous map. -/
 def map (f : C(X, Y)) : FundamentalGroup X x₀ →* FundamentalGroup Y (f x₀) :=
-  (FundamentalGroupoid.map f).mapAut x₀
+  (FundamentalGroupoid.map f).mapAut (fromTop' x₀)
 
 end FundamentalGroup

--- a/Mathlib/AlgebraicTopology/FundamentalGroupoid/InducedMaps.lean
+++ b/Mathlib/AlgebraicTopology/FundamentalGroupoid/InducedMaps.lean
@@ -83,8 +83,8 @@ abbrev hcast {X : TopCat} {x₀ x₁ : X} (hx : x₀ = x₁) : fromTop x₀ ⟶ 
 #align continuous_map.homotopy.hcast ContinuousMap.Homotopy.hcast
 
 @[simp]
-theorem hcast_def {X : TopCat} {x₀ x₁ : X} (hx₀ : x₀ = x₁) : hcast hx₀ = eqToHom hx₀ :=
-  rfl
+theorem hcast_def {X : TopCat} {x₀ x₁ : X} (hx₀ : x₀ = x₁) :
+    hcast hx₀ = eqToHom (congrArg fromTop hx₀) := rfl
 #align continuous_map.homotopy.hcast_def ContinuousMap.Homotopy.hcast_def
 
 variable {X₁ X₂ Y : TopCat.{u}} {f : C(X₁, Y)} {g : C(X₂, Y)} {x₀ x₁ : X₁} {x₂ x₃ : X₂}
@@ -188,7 +188,8 @@ theorem apply_one_path : (πₘ g).map p = hcast (H.apply_one x₀).symm ≫
 
 /-- Proof that `H.evalAt x = H(0 ⟶ 1, x ⟶ x)`, with the appropriate casts -/
 theorem evalAt_eq (x : X) : ⟦H.evalAt x⟧ = hcast (H.apply_zero x).symm ≫
-    (πₘ H.uliftMap).map (prodToProdTopI uhpath01 (𝟙 x)) ≫ hcast (H.apply_one x).symm.symm := by
+    (πₘ H.uliftMap).map (prodToProdTopI uhpath01 <| 𝟙 (fromTop x)) ≫
+    hcast (H.apply_one x).symm.symm := by
   dsimp only [prodToProdTopI, uhpath01, hcast]
   refine' (@Functor.conj_eqToHom_iff_heq (πₓ Y) _ _ _ _ _ _ _ _ (H.apply_one x).symm).mpr _
   simp only [id_eq_path_refl, prodToProdTop_map, Path.Homotopic.prod_lift, map_eq, ←
@@ -197,10 +198,14 @@ theorem evalAt_eq (x : X) : ⟦H.evalAt x⟧ = hcast (H.apply_zero x).symm ≫
 #align continuous_map.homotopy.eval_at_eq ContinuousMap.Homotopy.evalAt_eq
 
 -- Finally, we show `d = f(p) ≫ H₁ = H₀ ≫ g(p)`
-theorem eq_diag_path : (πₘ f).map p ≫ ⟦H.evalAt x₁⟧ = H.diagonalPath' p ∧
-    (⟦H.evalAt x₀⟧ ≫ (πₘ g).map p : fromTop (f x₀) ⟶ fromTop (g x₁)) = H.diagonalPath' p := by
-  rw [H.apply_zero_path, H.apply_one_path, H.evalAt_eq]
-  erw [H.evalAt_eq] -- Porting note: `rw` didn't work, so using `erw`
+theorem eq_diag_path :
+    (πₘ f).map p ≫ fromPath ⟦H.evalAt x₁⟧ = H.diagonalPath' p ∧
+    fromPath ⟦H.evalAt x₀⟧ ≫ (πₘ g).map p = H.diagonalPath' p := by
+  rw [H.apply_zero_path, H.apply_one_path]
+  erw [H.evalAt_eq, H.evalAt_eq] -- Porting note: `rw` didn't work, so using `erw`
+  rw [prodToProdTopI]
+  --simp
+  sorry
   dsimp only [prodToProdTopI]
   constructor
   · slice_lhs 2 4 => rw [eqToHom_trans, eqToHom_refl] -- Porting note: this ↓ `simp` didn't do this

--- a/Mathlib/AlgebraicTopology/FundamentalGroupoid/PUnit.lean
+++ b/Mathlib/AlgebraicTopology/FundamentalGroupoid/PUnit.lean
@@ -36,9 +36,18 @@ instance {x y : FundamentalGroupoid PUnit} : Subsingleton (x ⟶ y) := by
 
 /-- Equivalence of groupoids between fundamental groupoid of punit and punit -/
 def punitEquivDiscretePUnit : FundamentalGroupoid PUnit.{u + 1} ≌ Discrete PUnit.{v + 1} :=
-  CategoryTheory.Equivalence.mk (Functor.star _) ((CategoryTheory.Functor.const _).obj PUnit.unit)
+  CategoryTheory.Equivalence.mk (Functor.star _) ((Functor.const _).obj (as PUnit.unit))
     -- Porting note: was `by decide`
-    (NatIso.ofComponents fun _ => eqToIso (by simp))
+    (NatIso.ofComponents (fun _ ↦ eqToIso <| PUnit.ext _ _) fun f ↦ by
+      --dsimp only
+      --rw [Functor.id_obj]
+      simp
+      dsimp only [hom_eq, Functor.id_map,
+        eqToIso_refl, Iso.refl_hom, Functor.comp_map, Functor.const_obj_map]
+      sorry
+      simp only [Functor.id_obj, Functor.comp_obj, Functor.const_obj_obj, hom_eq, Functor.id_map,
+        eqToIso_refl, Iso.refl_hom, Category.comp_id, Functor.comp_map, Discrete.functor_map_id]
+      )
     (Functor.punitExt _ _)
 #align fundamental_groupoid.punit_equiv_discrete_punit FundamentalGroupoid.punitEquivDiscretePUnit
 

--- a/Mathlib/AlgebraicTopology/FundamentalGroupoid/Product.lean
+++ b/Mathlib/AlgebraicTopology/FundamentalGroupoid/Product.lean
@@ -31,7 +31,7 @@ set_option linter.uppercaseLean3 false
 
 noncomputable section
 
-open scoped FundamentalGroupoid CategoryTheory
+open FundamentalGroupoid CategoryTheory
 
 namespace FundamentalGroupoidFunctor
 
@@ -55,40 +55,36 @@ theorem proj_map (i : I) (x₀ x₁ : πₓ (TopCat.of (∀ i, X i))) (p : x₀ 
 #align fundamental_groupoid_functor.proj_map FundamentalGroupoidFunctor.proj_map
 
 -- Porting note: losing the instance with a concrete category again
-instance : (i : I) → TopologicalSpace (πₓ (X i)).α := fun i => TopCat.topologicalSpace_coe (X i)
+--instance : (i : I) → TopologicalSpace (πₓ (X i)).α := fun i => TopCat.topologicalSpace_coe (X i)
 
 /-- The map taking the pi product of a family of fundamental groupoids to the fundamental
 groupoid of the pi product. This is actually an isomorphism (see `piIso`)
 -/
 @[simps]
 def piToPiTop : (∀ i, πₓ (X i)) ⥤ πₓ (TopCat.of (∀ i, X i)) where
-  obj g := g
+  obj g := fromTop fun i ↦ toTop (g i)
   map p := Path.Homotopic.pi p
-  map_id x := by
-    change (Path.Homotopic.pi fun i => 𝟙 (x i)) = _
-    simp only [FundamentalGroupoid.id_eq_path_refl, Path.Homotopic.pi_lift]
-    rfl
-  map_comp f g := (Path.Homotopic.comp_pi_eq_pi_comp f g).symm
+  map_id _ := (Path.Homotopic.pi_lift _).trans (id_eq_path_refl _).symm
+  map_comp _ _ := (Path.Homotopic.comp_pi_eq_pi_comp _ _).symm
 #align fundamental_groupoid_functor.pi_to_pi_Top FundamentalGroupoidFunctor.piToPiTop
 
 /-- Shows `piToPiTop` is an isomorphism, whose inverse is precisely the pi product
 of the induced projections. This shows that `fundamentalGroupoidFunctor` preserves products.
 -/
 @[simps]
-def piIso : CategoryTheory.Grpd.of (∀ i : I, πₓ (X i)) ≅ πₓ (TopCat.of (∀ i, X i)) where
+def piIso : Grpd.of (∀ i : I, πₓ (X i)) ≅ πₓ (TopCat.of (∀ i, X i)) where
   hom := piToPiTop X
-  inv := CategoryTheory.Functor.pi' (proj X)
+  inv := Functor.pi' (proj X)
   hom_inv_id := by
-    change piToPiTop X ⋙ CategoryTheory.Functor.pi' (proj X) = 𝟭 _
+    change piToPiTop X ⋙ Functor.pi' (proj X) = 𝟭 _
     apply CategoryTheory.Functor.ext ?_ ?_
     · intros; rfl
     · intros; ext; simp
   inv_hom_id := by
-    change CategoryTheory.Functor.pi' (proj X) ⋙ piToPiTop X = 𝟭 _
+    change Functor.pi' (proj X) ⋙ piToPiTop X = 𝟭 _
     apply CategoryTheory.Functor.ext
     · intro _ _ f
-      suffices Path.Homotopic.pi ((CategoryTheory.Functor.pi' (proj X)).map f) = f by simpa
-      change Path.Homotopic.pi (fun i => (CategoryTheory.Functor.pi' (proj X)).map f i) = _
+      change Path.Homotopic.pi (fun i ↦ _) = _
       simp
     · intros; rfl
 #align fundamental_groupoid_functor.pi_iso FundamentalGroupoidFunctor.piIso
@@ -99,7 +95,7 @@ open CategoryTheory
 
 /-- Equivalence between the categories of cones over the objects `π Xᵢ` written in two ways -/
 def coneDiscreteComp :
-    Limits.Cone (Discrete.functor X ⋙ π) ≌ Limits.Cone (Discrete.functor fun i => πₓ (X i)) :=
+    Limits.Cone (Discrete.functor X ⋙ π) ≌ Limits.Cone (Discrete.functor fun i ↦ πₓ (X i)) :=
   Limits.Cones.postcomposeEquivalence (Discrete.compNatIsoDiscrete X π)
 #align fundamental_groupoid_functor.cone_discrete_comp FundamentalGroupoidFunctor.coneDiscreteComp
 

--- a/Mathlib/Topology/Homotopy/Basic.lean
+++ b/Mathlib/Topology/Homotopy/Basic.lean
@@ -637,8 +637,8 @@ def trans (F : HomotopyRel f₀ f₁ S) (G : HomotopyRel f₁ f₂ S) : Homotopy
   prop' t x hx := by
     simp only [Homotopy.trans]
     split_ifs
-    · simp [HomotopyWith.extendProp F (2 * t) x hx, F.fst_eq_snd hx, G.fst_eq_snd hx]
-    · simp [HomotopyWith.extendProp G (2 * t - 1) x hx, F.fst_eq_snd hx, G.fst_eq_snd hx]
+    · simp [HomotopyWith.extendProp F (2 * t) x hx]
+    · simp [HomotopyWith.extendProp G (2 * t - 1) x hx, F.fst_eq_snd hx]
 #align continuous_map.homotopy_rel.trans ContinuousMap.HomotopyRel.trans
 
 theorem trans_apply (F : HomotopyRel f₀ f₁ S) (G : HomotopyRel f₁ f₂ S) (x : I × X) :

--- a/Mathlib/Topology/IsLocallyHomeomorph.lean
+++ b/Mathlib/Topology/IsLocallyHomeomorph.lean
@@ -196,7 +196,7 @@ theorem openEmbedding_of_comp (hf : IsLocallyHomeomorph g) (hgf : OpenEmbedding 
   (hgf.isLocallyHomeomorph.of_comp hf cont).openEmbedding_of_injective hgf.inj.of_comp
 
 open TopologicalSpace in
-/-- Ranges of continuous local sections of a local homeomorphism form a basis of the total space. -/
+/-- Ranges of continuous local sections of a local homeomorphism form a basis of the source space.-/
 theorem isTopologicalBasis (hf : IsLocallyHomeomorph f) : IsTopologicalBasis
     {U : Set X | ∃ V : Set Y, IsOpen V ∧ ∃ s : C(V,X), f ∘ s = (↑) ∧ Set.range s = U} := by
   refine isTopologicalBasis_of_open_of_nhds ?_ fun x U hx hU ↦ ?_


### PR DESCRIPTION
Also removes the `@[reducible]` attribute on `FundamentalGroupoid` because we don't want a Groupoid instance on every topological space; it will conflict with the Category instance from Preorder for the unit interval, for example.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
