### PR TITLE
feat(Mathlib/Tactic/Setm): implement setm tactic

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3230,6 +3230,7 @@ import Mathlib.Tactic.Says
 import Mathlib.Tactic.ScopedNS
 import Mathlib.Tactic.Set
 import Mathlib.Tactic.SetLike
+import Mathlib.Tactic.Setm
 import Mathlib.Tactic.SimpIntro
 import Mathlib.Tactic.SimpRw
 import Mathlib.Tactic.Simps.Basic

--- a/Mathlib/Tactic/Common.lean
+++ b/Mathlib/Tactic/Common.lean
@@ -84,6 +84,7 @@ import Mathlib.Tactic.RunCmd
 import Mathlib.Tactic.Says
 import Mathlib.Tactic.ScopedNS
 import Mathlib.Tactic.Set
+import Mathlib.Tactic.Setm
 import Mathlib.Tactic.SimpIntro
 import Mathlib.Tactic.SimpRw
 import Mathlib.Tactic.Simps.Basic

--- a/Mathlib/Tactic/Setm.lean
+++ b/Mathlib/Tactic/Setm.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Gareth Ma
 -/
 import Lean
+import Mathlib.Tactic.DefEqTransformations
 
 /-!
 # The `setm` tactic
@@ -68,6 +69,8 @@ def setMCore (e : Expr) (stx : TSyntax `term) : TacticM Expr := withMainContext 
           evalTactic (←`(tactic| have $ha : $a = $(←Term.exprToSyntax mvarAss) := rfl))
           mvarIdOld.assign (.fvar fvarId)
         | none => throwError "File a bug report!"
+      mvarIdOld.setUserName <| (← mkFreshUserName (← mvarIdOld.getDecl).userName)
+      mvarIdNew.setUserName <| (← mkFreshUserName (← mvarIdNew.getDecl).userName)
   else
     throwError f!"setm: pattern is not definitionally equal to the goal."
 

--- a/Mathlib/Tactic/Setm.lean
+++ b/Mathlib/Tactic/Setm.lean
@@ -21,57 +21,68 @@ initialize registerTraceClass `Tactic.setm
 TODO: Write docs
 -/
 
-syntax (name := setM) "setm " term : tactic
-elab_rules : tactic
-| `(tactic| setm $expr:term) => do
-  withMainContext do
-    /- Elaborate `expr` from a Syntax into meaningful Terms -/
-    let (origPattern, mvarIds) ← elabTermWithHoles expr none (←getMainTag) (allowNaturalHoles := true)
+def setMCore (e : Expr) (stx : TSyntax `term) : TacticM Expr := withMainContext do
+  let (origPattern, mvarIds) ← elabTermWithHoles stx none (←getMainTag) (allowNaturalHoles := true)
+  /- Named holes are by default syntheticOpaque and not assignable, so we change that -/
+  mvarIds.forM fun mvarId => mvarId.setKind .natural
+  trace[Tactic.setm] "origPattern : {← ppExpr origPattern}"
 
-    /- Named holes are by default syntheticOpaque and not assignable, so we change that -/
-    mvarIds.forM fun mvarId => mvarId.setKind .natural
-    trace[Tactic.setm] "origPattern : {origPattern}"
+  /- Create new placeholder mvars -/
+  let mvarIdsPairs ← mvarIds.mapM
+    (fun x => return (x, ←mkFreshExprMVar none (userName := (← x.getDecl).userName)))
+  let mvarIdsMap : HashMap MVarId Expr := .ofList mvarIdsPairs
 
-    /- Create new placeholder mvars -/
-    let name (x : MVarId) := do return (←x.getDecl).userName
-    let mvarIdsPairs ← mvarIds.mapM
-      (fun x => return (x, ←mkFreshExprMVar none (userName := ←name x)))
-    let mvarIdsMap := @HashMap.ofList _ _ instBEqMVarId instHashableMVarId mvarIdsPairs
+  /- newPattern is the placeholder pattern with a bunch of placeholder mvars -/
+  let newPattern := origPattern.replace fun x => match x with
+    | .mvar x => mvarIdsMap.find? x
+    | _ => none
 
-    /- newPattern is the placeholder pattern with a bunch of placeholder mvars -/
-    let newPattern := origPattern.replace (fun x =>
-      match x with
-      | .mvar x => mvarIdsMap.find? x
-      | _ => none
-    )
+  /- We let isDefEq match the given pattern -/
+  let mctx ← getMCtx
+  let mdecls := mctx.decls
+  if ←isDefEq e newPattern then
+    /- We iterate over the (old, new) vars -/
+    mvarIdsPairs.forM fun (mvarIdOld, mvarExprNew) => do
+      let mvarIdNew := mvarExprNew.mvarId!
+      match (mdecls.find! mvarIdNew).userName with
+      | Name.anonymous => return ()
+      | name =>
+        let a := mkIdent name
+        let ha := mkIdent $ name.appendBefore "h"
+        let goal ← getMainGoal
+        match (←getExprMVarAssignment? mvarIdNew) with
+        | .some mvarAss =>
+          /-
+          Here mvarIdNew is assigned to mvarAss, and mvarIdOld <-> mvarIdNew, so I
+            (1) let $a := mvarAss -- Here fvarId stores $a (?)
+            (2) have $ha : $a = mvarAss := rfl
+            (3) assign $a to mvarIdOld
+          -/
+          let mvarType ← inferType mvarAss
+          let (fvarId, goal) ← (←goal.define a.getId mvarType mvarAss).intro1P
+          replaceMainGoal [goal]
+          evalTactic (←`(tactic| have $ha : $a = $(←Term.exprToSyntax mvarAss) := rfl))
+          mvarIdOld.assign (.fvar fvarId)
+        | none => throwError "File a bug report!"
+  else
+    throwError f!"setm: pattern is not definitionally equal to the goal."
 
-    /- Let isDefEq match the given pattern -/
-    if ←isDefEq (←getMainTarget) newPattern then
-      /- Iterate over the (old, new) vars -/
-      mvarIdsPairs.forM fun (mvarIdOld, mvarExprNew) => do
-        let mvarIdNew := mvarExprNew.mvarId!
-        match ←name mvarIdNew with
-        | Name.anonymous => return ()
-        | name =>
-          let a := mkIdent name
-          let ha := mkIdent $ name.appendBefore "h"
-          let goal ← getMainGoal
-          match (←getExprMVarAssignment? mvarIdNew) with
-          | some mvAss =>
-            /-
-            Here mvarIdNew is assigned to mvAss, and mvarIdOld <-> mvarIdNew, so we
-              (1) let $a := mvAss -- Here fvarId stores $a (?)
-              (2) have $ha : $a = mvAss := rfl
-              (3) assign $a to mvarIdOld
-            -/
-            let mvarType ← inferType mvAss
-            let (fvarId, goal) ← (←goal.define a.getId mvarType mvAss).intro1P
-            replaceMainGoal [goal]
-            evalTactic (←`(tactic| have $ha : $a = $(←Term.exprToSyntax mvAss) := rfl))
-            mvarIdOld.assign (.fvar fvarId)
-          | none => throwError "setm: Ass not defined. File a bug report!"
-    else
-      throwError "setm: pattern is not definitionally equal to the goal."
+  /- At the end, return the `origPattern` -/
+  return origPattern
 
-    /- At the end, all the original mvars are replaced with the new fvars -/
-    evalTactic (←`(tactic| change $(←Term.exprToSyntax origPattern)))
+def setMLocalDecl (stx : TSyntax `term) (fvar : FVarId) : TacticM Unit := withMainContext do
+  let pattern ← setMCore (← fvar.getType) stx
+  let goal ← (← getMainGoal).changeLocalDecl fvar pattern false
+  replaceMainGoal [goal]
+
+def setMTarget (stx : TSyntax `term) : TacticM Unit := withMainContext do
+  let pattern ← setMCore (← getMainTarget) stx
+  let goal ← (← getMainGoal).change pattern false
+  replaceMainGoal [goal]
+
+elab (name := setM) "setm" ppSpace colGt stx:term loc:(location)? : tactic =>
+  let loc := (loc.map expandLocation).getD (.targets #[] true)
+  withLocation loc
+    (setMLocalDecl stx)
+    (setMTarget stx)
+    (fun _ ↦ logInfo "setm can only be applied at a single hypothesis or the target")

--- a/Mathlib/Tactic/Setm.lean
+++ b/Mathlib/Tactic/Setm.lean
@@ -45,7 +45,7 @@ def setMCore (e : Expr) (stx : TSyntax `term) : TacticM Expr := withMainContext 
   /- We let isDefEq match the given pattern -/
   let mctx ← getMCtx
   let mdecls := mctx.decls
-  if ←isDefEq e newPattern then
+  if ← isDefEq e newPattern then
     /- We iterate over the (old, new) vars -/
     mvarIdsPairs.forM fun (mvarIdOld, mvarExprNew) => do
       let mvarIdNew := mvarExprNew.mvarId!
@@ -53,7 +53,7 @@ def setMCore (e : Expr) (stx : TSyntax `term) : TacticM Expr := withMainContext 
       | Name.anonymous => return ()
       | name =>
         let a := mkIdent name
-        let ha := mkIdent $ name.appendBefore "h"
+       let ha := mkIdent <| name.appendBefore "h"
         let goal ← getMainGoal
         match (←getExprMVarAssignment? mvarIdNew) with
         | .some mvarAss =>

--- a/Mathlib/Tactic/Setm.lean
+++ b/Mathlib/Tactic/Setm.lean
@@ -1,0 +1,77 @@
+/-
+Copyright (c) 2023 Gareth Ma. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Gareth Ma
+-/
+import Mathlib.Tactic.Set
+import Mathlib.Tactic.Change
+
+/-!
+# The `setm` tactic
+
+The `setm` tactic ("`set` with matching") is TODO WRITE THIS
+-/
+
+namespace Mathlib.Tactic
+open Lean Parser Tactic Elab Tactic Meta
+
+initialize registerTraceClass `Tactic.setm
+
+/--
+TODO: Write docs
+-/
+
+syntax (name := setM) "setm " term : tactic
+elab_rules : tactic
+| `(tactic| setm $expr:term) => do
+  withMainContext do
+    /- Elaborate `expr` from a Syntax into meaningful Terms -/
+    let (origPattern, mvarIds) ← elabTermWithHoles expr none (←getMainTag) (allowNaturalHoles := true)
+
+    /- Named holes are by default syntheticOpaque and not assignable, so we change that -/
+    mvarIds.forM fun mvarId => mvarId.setKind .natural
+    trace[Tactic.setm] "origPattern : {origPattern}"
+
+    /- Create new placeholder mvars -/
+    let name (x : MVarId) := do return (←x.getDecl).userName
+    let mvarIdsPairs ← mvarIds.mapM
+      (fun x => return (x, ←mkFreshExprMVar none (userName := ←name x)))
+    let mvarIdsMap := @HashMap.ofList _ _ instBEqMVarId instHashableMVarId mvarIdsPairs
+
+    /- newPattern is the placeholder pattern with a bunch of placeholder mvars -/
+    let newPattern := origPattern.replace (fun x =>
+      match x with
+      | .mvar x => mvarIdsMap.find? x
+      | _ => none
+    )
+
+    /- Let isDefEq match the given pattern -/
+    if ←isDefEq (←getMainTarget) newPattern then
+      /- Iterate over the (old, new) vars -/
+      mvarIdsPairs.forM fun (mvarIdOld, mvarExprNew) => do
+        let mvarIdNew := mvarExprNew.mvarId!
+        match ←name mvarIdNew with
+        | Name.anonymous => return ()
+        | name =>
+          let a := mkIdent name
+          let ha := mkIdent $ name.appendBefore "h"
+          let goal ← getMainGoal
+          match (←getExprMVarAssignment? mvarIdNew) with
+          | some mvAss =>
+            /-
+            Here mvarIdNew is assigned to mvAss, and mvarIdOld <-> mvarIdNew, so we
+              (1) let $a := mvAss -- Here fvarId stores $a (?)
+              (2) have $ha : $a = mvAss := rfl
+              (3) assign $a to mvarIdOld
+            -/
+            let mvarType ← inferType mvAss
+            let (fvarId, goal) ← (←goal.define a.getId mvarType mvAss).intro1P
+            replaceMainGoal [goal]
+            evalTactic (←`(tactic| have $ha : $a = $(←Term.exprToSyntax mvAss) := rfl))
+            mvarIdOld.assign (.fvar fvarId)
+          | none => throwError "setm: Ass not defined. File a bug report!"
+    else
+      throwError "setm: pattern is not definitionally equal to the goal."
+
+    /- At the end, all the original mvars are replaced with the new fvars -/
+    evalTactic (←`(tactic| change $(←Term.exprToSyntax origPattern)))

--- a/Mathlib/Tactic/Setm.lean
+++ b/Mathlib/Tactic/Setm.lean
@@ -76,7 +76,7 @@ def setMCore (e : Expr) (stx : TSyntax `term) (loc : Location) : TacticM Unit :=
       mvarIdOld.setUserName <| (← mkFreshUserName (← mvarIdOld.getDecl).userName)
       mvarIdNew.setUserName <| (← mkFreshUserName (← mvarIdNew.getDecl).userName)
   else
-    throwError f!"setm: pattern is not definitionally equal to the goal."
+    throwError "setm: {stx} is not definitionally equal to the goal."
 
 /--
 The `setm` tactic ("`set` with matching") matches a pattern containing named holes the type of a

--- a/test/Setm.lean
+++ b/test/Setm.lean
@@ -1,0 +1,38 @@
+import Mathlib.Tactic.Setm
+
+variable {a b c : Nat}
+
+/- Basic usage -/
+example : 1 + 2 = 3 := by
+  setm ?A + ?B = (_ : Nat)
+  guard_hyp A := 1
+  guard_hyp B := 2
+  guard_hyp hA : A = 1
+  guard_hyp hB : B = 2
+  trivial
+
+/- Usage with `using` and `at` keywords -/
+example (h1 : 1 + 1 = 3) (h2 : 1 + 3 = 5) (h3 : 2 + 2 = 5) : true := by
+  setm ?A + _ = (?B : Nat) using h2 at h1 h2 h3
+  guard_hyp A := 1
+  guard_hyp B := 5
+  guard_hyp h1 : A + A = 3
+  guard_hyp h2 : A + 3 = B
+  guard_hyp h3 : 2 + 2 = B
+  trivial
+
+/- Test reusing named holes -/
+example (h : b + a = c) : a + b = c := by
+  /- setm 1-/
+  setm ?A + ?B = (_ : Nat)
+  guard_hyp A := a
+  guard_hyp B := b
+  /- clean up -/
+  unfold_let A B
+  clear hA hB A B
+  /- setm 2 -/
+  rewrite [Nat.add_comm]
+  setm ?A + ?B = (_ : Nat) at h ⊢
+  guard_hyp A := b
+  guard_hyp B := a
+  exact h


### PR DESCRIPTION
This is my first time doing metaprogramming in Lean 4, please provide feedback when you have them :)

The `setm` tactic, which stands for `set` + matching, matches a given expression with the goal and introduces new local hypotheses for the named holes specified. One of the best usage is for rearrangement proofs. As a simple example,

```lean
example : (1 + 1) + (4 * 3) - (1 + 1) = (3 * 4 : Rat) := by
  setm ?A + ?B - ?A = (?C : Rat)
  rw [show ∀ A B, A + B - A = B by intro A B ; ring_nf ]
  apply Rat.mul_comm
```

One can imagine replacing the three term expression with a 7 term algebraic expression.

This was developed with tons of help from [Zulip](https://leanprover.zulipchat.com/#narrow/stream/239415-metaprogramming-.2F-tactics/topic/Help.20with.20writing.20tactic), especially from Thomas. Thanks!

TODO:
- [X] Support `setm ... at ...` syntax, see *example 1* below
- [X] Write docs
- [ ] Use `withNewMCtxDepth`
- [X] Rename the intermediate `MVar`s, see *example 2* below
- [ ] Use `elabTermWithHolesPostponing` in conjunction with `Term.synthesizeSyntheticMVarsNoPostPoning` after `isDefEq` to handle instances

Example 1:
```lean
/- Usage with `using` and `at` keywords -/
example (h1 : 1 + 1 = 3) (h2 : 1 + 3 = 5) (h3 : 2 + 2 = 5) : true := by
  setm ?A + _ = (?B : Nat) using h2 at h1 h2 h3
  guard_hyp A := 1
  guard_hyp B := 5
  guard_hyp h1 : A + A = 3
  guard_hyp h2 : A + 3 = B
  guard_hyp h3 : 2 + 2 = B
  trivial
```

Example 2:
```lean
/- Test reusing named holes -/
example (h : b + a = c) : a + b = c := by
  /- setm 1-/
  setm ?A + ?B = (_ : Nat)
  guard_hyp A := a
  guard_hyp B := b
  /- clean up -/
  unfold_let A B
  clear hA hB A B
  /- setm 2 -/
  rewrite [Nat.add_comm]
  setm ?A + ?B = (_ : Nat) at h ⊢
  guard_hyp A := b
  guard_hyp B := a
  exact h
```
 
Co-authored-by: Jireh Loreaux <loreaujy@gmail.com>

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
