### PR TITLE
chore: replace some uses of split_ifs with split

### DIFF
--- a/Archive/Sensitivity.lean
+++ b/Archive/Sensitivity.lean
@@ -318,7 +318,7 @@ theorem f_matrix : ∀ p q : Q n, |ε q (f n (e p))| = if p ∈ q.adjacent then 
     dsimp [f]
     simp [Q.not_adjacent_zero]
   · intro p q
-    have ite_nonneg : ite (π q = π p) (1 : ℝ) 0 ≥ 0 := by split_ifs <;> norm_num
+    have ite_nonneg : ite (π q = π p) (1 : ℝ) 0 ≥ 0 := by split <;> norm_num
     dsimp only [e, ε, f, V]; rw [LinearMap.prod_apply]; dsimp; cases hp : p 0 <;> cases hq : q 0
     all_goals
       repeat rw [Bool.cond_true]

--- a/Archive/Wiedijk100Theorems/Partition.lean
+++ b/Archive/Wiedijk100Theorems/Partition.lean
@@ -141,7 +141,7 @@ theorem cut_zero {ι : Type*} (s : Finset ι) : cut s 0 = {0} := by
   -- use the definition.
   rw [cut, range_one, pi_const_singleton, map_singleton, Function.Embedding.coeFn_mk,
     filter_singleton, if_pos, singleton_inj]
-  · ext; split_ifs <;> rfl
+  · ext; split <;> rfl
   rw [sum_eq_zero_iff]
   intro x hx
   apply dif_pos hx

--- a/Archive/Wiedijk100Theorems/SumOfPrimeReciprocalsDiverges.lean
+++ b/Archive/Wiedijk100Theorems/SumOfPrimeReciprocalsDiverges.lean
@@ -86,7 +86,7 @@ theorem sum_lt_half_of_not_tendsto
       ∑ p in range n, ite (Nat.Prime p) (1 / (p : ℝ)) 0 := by
     simp only [sum_filter]
   have hf : ∀ n : ℕ, 0 ≤ ite (Nat.Prime n) (1 / (n : ℝ)) 0 := by
-    intro n; split_ifs
+    intro n; split
     · simp only [one_div, inv_nonneg, Nat.cast_nonneg]
     · exact le_rfl
   rw [h0, ← summable_iff_not_tendsto_nat_atTop_of_nonneg hf, summable_iff_vanishing] at h

--- a/Counterexamples/Phillips.lean
+++ b/Counterexamples/Phillips.lean
@@ -414,7 +414,7 @@ section
 
 
 theorem norm_indicator_le_one (s : Set α) (x : α) : ‖(indicator s (1 : α → ℝ)) x‖ ≤ 1 := by
-  simp only [indicator, Pi.one_apply]; split_ifs <;> norm_num
+  simp only [indicator, Pi.one_apply]; split <;> norm_num
 #align counterexample.phillips_1940.norm_indicator_le_one Counterexample.Phillips1940.norm_indicator_le_one
 
 /-- A functional in the dual space of bounded functions gives rise to a bounded additive measure,

--- a/Mathlib/Algebra/BigOperators/Basic.lean
+++ b/Mathlib/Algebra/BigOperators/Basic.lean
@@ -1112,7 +1112,7 @@ theorem prod_ite_index (p : Prop) [Decidable p] (s t : Finset α) (f : α → β
 @[to_additive (attr := simp)]
 theorem prod_ite_irrel (p : Prop) [Decidable p] (s : Finset α) (f g : α → β) :
     ∏ x in s, (if p then f x else g x) = if p then ∏ x in s, f x else ∏ x in s, g x := by
-  split_ifs with h <;> rfl
+  split <;> rfl
 #align finset.prod_ite_irrel Finset.prod_ite_irrel
 #align finset.sum_ite_irrel Finset.sum_ite_irrel
 
@@ -1120,7 +1120,7 @@ theorem prod_ite_irrel (p : Prop) [Decidable p] (s : Finset α) (f g : α → β
 theorem prod_dite_irrel (p : Prop) [Decidable p] (s : Finset α) (f : p → α → β) (g : ¬p → α → β) :
     ∏ x in s, (if h : p then f h x else g h x) =
       if h : p then ∏ x in s, f h x else ∏ x in s, g h x := by
-  split_ifs with h <;> rfl
+  split <;> rfl
 #align finset.prod_dite_irrel Finset.prod_dite_irrel
 #align finset.sum_dite_irrel Finset.sum_dite_irrel
 

--- a/Mathlib/Algebra/BigOperators/Finprod.lean
+++ b/Mathlib/Algebra/BigOperators/Finprod.lean
@@ -273,7 +273,7 @@ multiplicative and holds on the factors. -/
 theorem finprod_induction {f : α → M} (p : M → Prop) (hp₀ : p 1)
     (hp₁ : ∀ x y, p x → p y → p (x * y)) (hp₂ : ∀ i, p (f i)) : p (∏ᶠ i, f i) := by
   rw [finprod]
-  split_ifs
+  split
   exacts [Finset.prod_induction _ _ hp₁ hp₀ fun i _ => hp₂ _, hp₀]
 #align finprod_induction finprod_induction
 #align finsum_induction finsum_induction

--- a/Mathlib/Algebra/GroupPower/Basic.lean
+++ b/Mathlib/Algebra/GroupPower/Basic.lean
@@ -50,12 +50,12 @@ variable [Pow M ℕ]
 
 @[to_additive (attr := simp) ite_nsmul]
 theorem pow_ite (P : Prop) [Decidable P] (a : M) (b c : ℕ) :
-    (a ^ if P then b else c) = if P then a ^ b else a ^ c := by split_ifs <;> rfl
+    (a ^ if P then b else c) = if P then a ^ b else a ^ c := by split <;> rfl
 #align pow_ite pow_ite
 
 @[to_additive (attr := simp) nsmul_ite]
 theorem ite_pow (P : Prop) [Decidable P] (a b : M) (c : ℕ) :
-    (if P then a else b) ^ c = if P then a ^ c else b ^ c := by split_ifs <;> rfl
+    (if P then a else b) ^ c = if P then a ^ c else b ^ c := by split <;> rfl
 #align ite_pow ite_pow
 
 end Pow

--- a/Mathlib/Algebra/Hom/Ring/Defs.lean
+++ b/Mathlib/Algebra/Hom/Ring/Defs.lean
@@ -573,13 +573,13 @@ protected theorem map_mul (f : α →+* β) : ∀ a b, f (a * b) = f a * f b :=
 @[simp]
 theorem map_ite_zero_one {F : Type*} [RingHomClass F α β] (f : F) (p : Prop) [Decidable p] :
     f (ite p 0 1) = ite p 0 1 := by
-  split_ifs with h <;> simp [h]
+  split <;> simp_all
 #align ring_hom.map_ite_zero_one RingHom.map_ite_zero_one
 
 @[simp]
 theorem map_ite_one_zero {F : Type*} [RingHomClass F α β] (f : F) (p : Prop) [Decidable p] :
     f (ite p 1 0) = ite p 1 0 := by
-  split_ifs with h <;> simp [h]
+  split <;> simp_all
 #align ring_hom.map_ite_one_zero RingHom.map_ite_one_zero
 
 /-- `f : α →+* β` has a trivial codomain iff `f 1 = 0`. -/

--- a/Mathlib/Algebra/Homology/Additive.lean
+++ b/Mathlib/Algebra/Homology/Additive.lean
@@ -304,7 +304,7 @@ def singleMapHomologicalComplex (F : V ⥤ W) [F.Additive] (c : ComplexShape ι)
     fun f => by
     ext i
     dsimp
-    split_ifs with h <;> simp [h]
+    split <;> simp_all
 #align homological_complex.single_map_homological_complex HomologicalComplex.singleMapHomologicalComplex
 
 variable (F : V ⥤ W) [Functor.Additive F] (c)

--- a/Mathlib/Algebra/Homology/Homotopy.lean
+++ b/Mathlib/Algebra/Homology/Homotopy.lean
@@ -280,7 +280,7 @@ theorem nullHomotopicMap'_comp (hom : ∀ i j, c.Rel j i → (C.X i ⟶ D.X j)) 
   erw [nullHomotopicMap_comp]
   congr
   ext i j
-  split_ifs
+  split
   · rfl
   · rw [zero_comp]
 #align homotopy.null_homotopic_map'_comp Homotopy.nullHomotopicMap'_comp
@@ -302,7 +302,7 @@ theorem comp_nullHomotopicMap' (f : C ⟶ D) (hom : ∀ i j, c.Rel j i → (D.X 
   erw [comp_nullHomotopicMap]
   congr
   ext i j
-  split_ifs
+  split
   · rfl
   · rw [comp_zero]
 #align homotopy.comp_null_homotopic_map' Homotopy.comp_nullHomotopicMap'
@@ -326,7 +326,7 @@ theorem map_nullHomotopicMap' {W : Type*} [Category W] [Preadditive W] (G : V �
   erw [map_nullHomotopicMap]
   congr
   ext i j
-  split_ifs
+  split
   · rfl
   · rw [G.map_zero]
 #align homotopy.map_null_homotopic_map' Homotopy.map_nullHomotopicMap'
@@ -374,7 +374,7 @@ theorem nullHomotopicMap'_f {k₂ k₁ k₀ : ι} (r₂₁ : c.Rel k₂ k₁) (r
     (nullHomotopicMap' h).f k₁ = C.d k₁ k₀ ≫ h k₀ k₁ r₁₀ + h k₁ k₂ r₂₁ ≫ D.d k₂ k₁ := by
   simp only [nullHomotopicMap']
   rw [nullHomotopicMap_f r₂₁ r₁₀]
-  split_ifs
+  split
   rfl
 #align homotopy.null_homotopic_map'_f Homotopy.nullHomotopicMap'_f
 
@@ -393,7 +393,7 @@ theorem nullHomotopicMap'_f_of_not_rel_left {k₁ k₀ : ι} (r₁₀ : c.Rel k�
     (nullHomotopicMap' h).f k₀ = h k₀ k₁ r₁₀ ≫ D.d k₁ k₀ := by
   simp only [nullHomotopicMap']
   rw [nullHomotopicMap_f_of_not_rel_left r₁₀ hk₀]
-  split_ifs
+  split
   rfl
 #align homotopy.null_homotopic_map'_f_of_not_rel_left Homotopy.nullHomotopicMap'_f_of_not_rel_left
 
@@ -412,7 +412,7 @@ theorem nullHomotopicMap'_f_of_not_rel_right {k₁ k₀ : ι} (r₁₀ : c.Rel k
     (nullHomotopicMap' h).f k₁ = C.d k₁ k₀ ≫ h k₀ k₁ r₁₀ := by
   simp only [nullHomotopicMap']
   rw [nullHomotopicMap_f_of_not_rel_right r₁₀ hk₁]
-  split_ifs
+  split
   rfl
 #align homotopy.null_homotopic_map'_f_of_not_rel_right Homotopy.nullHomotopicMap'_f_of_not_rel_right
 

--- a/Mathlib/Algebra/IndicatorFunction.lean
+++ b/Mathlib/Algebra/IndicatorFunction.lean
@@ -262,7 +262,7 @@ theorem mulIndicator_comp_of_one {g : M → N} (hg : g 1 = 1) :
     mulIndicator s (g ∘ f) = g ∘ mulIndicator s f := by
   funext
   simp only [mulIndicator]
-  split_ifs <;> simp [*]
+  split <;> simp [*]
 #align set.mul_indicator_comp_of_one Set.mulIndicator_comp_of_one
 #align set.indicator_comp_of_zero Set.indicator_comp_of_zero
 
@@ -286,7 +286,7 @@ theorem mulIndicator_one_preimage (s : Set M) :
     t.mulIndicator 1 ⁻¹' s ∈ ({Set.univ, ∅} : Set (Set α)) := by
   classical
     rw [mulIndicator_one', preimage_one]
-    split_ifs <;> simp
+    split <;> simp
 #align set.mul_indicator_one_preimage Set.mulIndicator_one_preimage
 #align set.indicator_zero_preimage Set.indicator_zero_preimage
 
@@ -334,7 +334,7 @@ theorem mem_range_mulIndicator {r : M} {s : Set α} {f : α → M} :
     · tauto
     · left
       tauto
-  · rintro (⟨hr, ⟨x, hx⟩⟩ | ⟨x, ⟨hx, hxs⟩⟩) <;> use x <;> split_ifs <;> tauto
+  · rintro (⟨hr, ⟨x, hx⟩⟩ | ⟨x, ⟨hx, hxs⟩⟩) <;> use x <;> split <;> tauto
 #align set.mem_range_mul_indicator Set.mem_range_mulIndicator
 #align set.mem_range_indicator Set.mem_range_indicator
 
@@ -391,7 +391,7 @@ theorem mulIndicator_mul (s : Set α) (f g : α → M) :
     (mulIndicator s fun a => f a * g a) = fun a => mulIndicator s f a * mulIndicator s g a := by
   funext
   simp only [mulIndicator]
-  split_ifs
+  split
   · rfl
   rw [mul_one]
 #align set.mul_indicator_mul Set.mulIndicator_mul
@@ -481,7 +481,7 @@ variable {A : Type*} [AddMonoid A] [Monoid M] [DistribMulAction M A]
 theorem indicator_smul_apply (s : Set α) (r : α → M) (f : α → A) (x : α) :
     indicator s (fun x => r x • f x) x = r x • indicator s f x := by
   dsimp only [indicator]
-  split_ifs
+  split
   exacts [rfl, (smul_zero (r x)).symm]
 #align set.indicator_smul_apply Set.indicator_smul_apply
 
@@ -509,7 +509,7 @@ variable {A : Type*} [Zero A] [Zero M] [SMulWithZero M A]
 theorem indicator_smul_apply_left (s : Set α) (r : α → M) (f : α → A) (x : α) :
     indicator s (fun x => r x • f x) x = indicator s r x • f x := by
   dsimp only [indicator]
-  split_ifs
+  split
   exacts [rfl, (zero_smul _ (f x)).symm]
 
 theorem indicator_smul_left (s : Set α) (r : α → M) (f : α → A) :
@@ -706,7 +706,7 @@ theorem indicator_mul (s : Set α) (f g : α → M) :
     (indicator s fun a => f a * g a) = fun a => indicator s f a * indicator s g a := by
   funext
   simp only [indicator]
-  split_ifs
+  split
   · rfl
   rw [mul_zero]
 #align set.indicator_mul Set.indicator_mul
@@ -714,7 +714,7 @@ theorem indicator_mul (s : Set α) (f g : α → M) :
 theorem indicator_mul_left (s : Set α) (f g : α → M) :
     indicator s (fun a => f a * g a) a = indicator s f a * g a := by
   simp only [indicator]
-  split_ifs
+  split
   · rfl
   rw [zero_mul]
 #align set.indicator_mul_left Set.indicator_mul_left

--- a/Mathlib/Algebra/MonoidAlgebra/Basic.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Basic.lean
@@ -541,7 +541,7 @@ theorem mul_single_apply_aux [Mul G] (f : MonoidAlgebra k G) {r : k} {x y z : G}
         (HMul.hMul (β := MonoidAlgebra k G) f (single x r)) z =
             sum f fun a b => if a = y then b * r else 0 := by simp only [mul_apply, A, H]
         _ = if y ∈ f.support then f y * r else 0 := (f.support.sum_ite_eq' _ _)
-        _ = f y * r := by split_ifs with h <;> simp at h <;> simp [h]
+        _ = f y * r := by split <;> simp_all
 #align monoid_algebra.mul_single_apply_aux MonoidAlgebra.mul_single_apply_aux
 
 theorem mul_single_one_apply [MulOneClass G] (f : MonoidAlgebra k G) (r : k) (x : G) :
@@ -572,7 +572,7 @@ theorem single_mul_apply_aux [Mul G] (f : MonoidAlgebra k G) {r : k} {x y z : G}
           (mul_apply _ _ _).trans <| sum_single_index this
         _ = f.sum fun a b => ite (a = z) (r * b) 0 := by simp only [H]
         _ = if z ∈ f.support then r * f z else 0 := (f.support.sum_ite_eq' _ _)
-        _ = _ := by split_ifs with h <;> simp at h <;> simp [h]
+        _ = _ := by split <;> simp_all
 #align monoid_algebra.single_mul_apply_aux MonoidAlgebra.single_mul_apply_aux
 
 theorem single_one_mul_apply [MulOneClass G] (f : MonoidAlgebra k G) (r : k) (x : G) :

--- a/Mathlib/Algebra/Ring/Defs.lean
+++ b/Mathlib/Algebra/Ring/Defs.lean
@@ -193,13 +193,13 @@ end NonAssocSemiring
 
 @[to_additive]
 theorem mul_ite {α} [Mul α] (P : Prop) [Decidable P] (a b c : α) :
-    (a * if P then b else c) = if P then a * b else a * c := by split_ifs <;> rfl
+    (a * if P then b else c) = if P then a * b else a * c := by split <;> rfl
 #align mul_ite mul_ite
 #align add_ite add_ite
 
 @[to_additive]
 theorem ite_mul {α} [Mul α] (P : Prop) [Decidable P] (a b c : α) :
-    (if P then a else b) * c = if P then a * c else b * c := by split_ifs <;> rfl
+    (if P then a else b) * c = if P then a * c else b * c := by split <;> rfl
 #align ite_mul ite_mul
 #align ite_add ite_add
 

--- a/Mathlib/Algebra/Support.lean
+++ b/Mathlib/Algebra/Support.lean
@@ -485,7 +485,7 @@ theorem mulSupport_mulSingle_of_ne (h : b ≠ 1) : mulSupport (mulSingle a b) = 
 
 @[to_additive]
 theorem mulSupport_mulSingle [DecidableEq B] :
-    mulSupport (mulSingle a b) = if b = 1 then ∅ else {a} := by split_ifs with h <;> simp [h]
+    mulSupport (mulSingle a b) = if b = 1 then ∅ else {a} := by split <;> simp_all
 #align pi.mul_support_mul_single Pi.mulSupport_mulSingle
 #align pi.support_single Pi.support_single
 

--- a/Mathlib/Algebra/Tropical/Basic.lean
+++ b/Mathlib/Algebra/Tropical/Basic.lean
@@ -290,9 +290,9 @@ instance instLinearOrderTropical : LinearOrder (Tropical R) :=
     le_total := fun a b => le_total (untrop a) (untrop b)
     decidableLE := Tropical.decidableLE
     max := fun a b => trop (max (untrop a) (untrop b))
-    max_def := fun a b => untrop_injective (by simp [max_def]; split_ifs <;> simp)
+    max_def := fun a b => untrop_injective (by simp [max_def]; split <;> simp)
     min := (· + ·)
-    min_def := fun a b => untrop_injective (by simp [min_def]; split_ifs <;> simp) }
+    min_def := fun a b => untrop_injective (by simp [min_def]; split <;> simp) }
 
 @[simp]
 theorem untrop_sup (x y : Tropical R) : untrop (x ⊔ y) = untrop x ⊔ untrop y :=

--- a/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Scheme.lean
+++ b/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Scheme.lean
@@ -438,7 +438,7 @@ theorem carrier.add_mem (q : Spec.T A⁰_ f) {a b : A} (ha : a ∈ carrier f_deg
     apply GradedMonoid.toGradedMul.mul_mem (i := (j-m) • i) (j := (m + m - j) • i) <;> mem_tac_aux
     rw [← add_smul]; congr; zify [le_of_not_lt h2, le_of_not_le h1]; abel
   convert_to ∑ i in range (m + m + 1), g i ∈ q.1; swap
-  · refine' q.1.sum_mem fun j _ => nsmul_mem _ _; split_ifs
+  · refine' q.1.sum_mem fun j _ => nsmul_mem _ _; split
     exacts [q.1.zero_mem, q.1.mul_mem_left _ (hb i), q.1.mul_mem_right _ (ha i)]
   rw [HomogeneousLocalization.ext_iff_val, HomogeneousLocalization.val_mk'']
   change _ = (algebraMap (HomogeneousLocalization.Away 𝒜 f) (Localization.Away f)) _

--- a/Mathlib/AlgebraicTopology/DoldKan/Homotopies.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/Homotopies.lean
@@ -105,7 +105,7 @@ def hσ' (q : ℕ) : ∀ n m, c.Rel m n → (K[X].X n ⟶ K[X].X m) := fun n m h
 theorem hσ'_eq_zero {q n m : ℕ} (hnq : n < q) (hnm : c.Rel m n) :
     (hσ' q n m hnm : X _[n] ⟶ X _[m]) = 0 := by
   simp only [hσ', hσ]
-  split_ifs
+  split
   exact zero_comp
 #align algebraic_topology.dold_kan.hσ'_eq_zero AlgebraicTopology.DoldKan.hσ'_eq_zero
 
@@ -114,7 +114,7 @@ theorem hσ'_eq {q n a m : ℕ} (ha : n = a + q) (hnm : c.Rel m n) :
       ((-1 : ℤ) ^ a • X.σ ⟨a, Nat.lt_succ_iff.mpr (Nat.le.intro (Eq.symm ha))⟩) ≫
         eqToHom (by congr) := by
   simp only [hσ', hσ]
-  split_ifs
+  split
   · exfalso
     linarith
   · have h' := tsub_eq_of_eq_add ha
@@ -161,7 +161,7 @@ theorem hσ'_naturality (q : ℕ) (n m : ℕ) (hnm : c.Rel m n) {X Y : Simplicia
   subst h
   simp only [hσ', eqToHom_refl, comp_id]
   unfold hσ
-  split_ifs
+  split
   · rw [zero_comp, comp_zero]
   · simp only [zsmul_comp, comp_zsmul]
     erw [f.naturality]
@@ -186,7 +186,7 @@ theorem map_hσ' {D : Type*} [Category D] [Preadditive D] (G : C ⥤ D) [G.Addit
     (hσ' q n m hnm : K[((whiskering _ _).obj G).obj X].X n ⟶ _) =
       G.map (hσ' q n m hnm : K[X].X n ⟶ _) := by
   unfold hσ' hσ
-  split_ifs
+  split
   · simp only [Functor.map_zero, zero_comp]
   · simp only [eqToHom_map, Functor.map_comp, Functor.map_zsmul]
     rfl

--- a/Mathlib/AlgebraicTopology/FundamentalGroupoid/Basic.lean
+++ b/Mathlib/AlgebraicTopology/FundamentalGroupoid/Basic.lean
@@ -55,7 +55,7 @@ theorem continuous_reflTransSymmAux : Continuous reflTransSymmAux := by
 
 theorem reflTransSymmAux_mem_I (x : I × I) : reflTransSymmAux x ∈ I := by
   dsimp only [reflTransSymmAux]
-  split_ifs
+  split
   · constructor
     · apply mul_nonneg
       · apply mul_nonneg

--- a/Mathlib/Analysis/BoundedVariation.lean
+++ b/Mathlib/Analysis/BoundedVariation.lean
@@ -248,7 +248,7 @@ theorem add_point (f : α → E) {s : Set α} {x : α} (hx : x ∈ s) (u : ℕ �
   · let v i := if i ≤ n then u i else x
     have vs : ∀ i, v i ∈ s := fun i ↦ by
       simp only
-      split_ifs
+      split
       · exact us i
       · exact hx
     have hv : Monotone v := by
@@ -303,7 +303,7 @@ theorem add_point (f : α → E) {s : Set α} {x : α} (hx : x ∈ s) (u : ℕ �
       have C : ¬i + 1 = N := hi.ne.symm
       have D : i + 1 - 1 = i := Nat.pred_succ i
       rw [if_neg A, if_neg B, if_neg C, D]
-      split_ifs
+      split
       · exact hN.2.le.trans (hu (le_of_not_lt A))
       · exact hu (Nat.pred_le _)
   refine' ⟨w, n + 1, hw, ws, (mem_image _ _ _).2 ⟨N, hN.1.trans_lt (Nat.lt_succ_self n), _⟩, _⟩

--- a/Mathlib/Analysis/BoxIntegral/Box/Basic.lean
+++ b/Mathlib/Analysis/BoxIntegral/Box/Basic.lean
@@ -315,7 +315,7 @@ def mk' (l u : ι → ℝ) : WithBot (Box ι) :=
 @[simp]
 theorem mk'_eq_bot {l u : ι → ℝ} : mk' l u = ⊥ ↔ ∃ i, u i ≤ l i := by
   rw [mk']
-  split_ifs with h <;> simpa using h
+  split <;> simp_all
 #align box_integral.box.mk'_eq_bot BoxIntegral.Box.mk'_eq_bot
 
 @[simp]

--- a/Mathlib/Analysis/BoxIntegral/Box/SubboxInduction.lean
+++ b/Mathlib/Analysis/BoxIntegral/Box/SubboxInduction.lean
@@ -47,7 +47,7 @@ def splitCenterBox (I : Box ι) (s : Set ι) : Box ι where
   upper := s.piecewise I.upper fun i ↦ (I.lower i + I.upper i) / 2
   lower_lt_upper i := by
     dsimp only [Set.piecewise]
-    split_ifs <;> simp only [left_lt_add_div_two, add_div_two_lt_right, I.lower_lt_upper]
+    split <;> simp only [left_lt_add_div_two, add_div_two_lt_right, I.lower_lt_upper]
 #align box_integral.box.split_center_box BoxIntegral.Box.splitCenterBox
 
 theorem mem_splitCenterBox {s : Set ι} {y : ι → ℝ} :

--- a/Mathlib/Analysis/BoxIntegral/Partition/Tagged.lean
+++ b/Mathlib/Analysis/BoxIntegral/Partition/Tagged.lean
@@ -346,7 +346,7 @@ def disjUnion (π₁ π₂ : TaggedPrepartition I) (h : Disjoint π₁.iUnion π
   tag := π₁.boxes.piecewise π₁.tag π₂.tag
   tag_mem_Icc J := by
     dsimp only [Finset.piecewise]
-    split_ifs
+    split
     exacts [π₁.tag_mem_Icc J, π₂.tag_mem_Icc J]
 #align box_integral.tagged_prepartition.disj_union BoxIntegral.TaggedPrepartition.disjUnion
 

--- a/Mathlib/Analysis/Calculus/BumpFunction/FiniteDimension.lean
+++ b/Mathlib/Analysis/Calculus/BumpFunction/FiniteDimension.lean
@@ -517,7 +517,7 @@ instance (priority := 100) {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E
         · simp only [le_refl, zero_le_one, and_self]
       symmetric := fun R x => by
         simp only
-        split_ifs
+        split
         · simp only [y_neg, smul_neg]
         · rfl
       smooth := by

--- a/Mathlib/Analysis/Convex/Basic.lean
+++ b/Mathlib/Analysis/Convex/Basic.lean
@@ -672,7 +672,7 @@ theorem convex_stdSimplex : Convex 𝕜 (stdSimplex 𝕜 ι) := by
 variable {ι}
 
 theorem ite_eq_mem_stdSimplex (i : ι) : (fun j => ite (i = j) (1 : 𝕜) 0) ∈ stdSimplex 𝕜 ι :=
-  ⟨fun j => by simp only; split_ifs <;> norm_num, by
+  ⟨fun j => by simp only; split <;> norm_num, by
     rw [Finset.sum_ite_eq, if_pos (Finset.mem_univ _)]⟩
 #align ite_eq_mem_std_simplex ite_eq_mem_stdSimplex
 

--- a/Mathlib/Analysis/Convex/Combination.lean
+++ b/Mathlib/Analysis/Convex/Combination.lean
@@ -224,7 +224,7 @@ theorem convex_iff_sum_mem : Convex R s ↔ ∀ (t : Finset E) (w : E → R),
     · simp only [sum_pair h_cases, if_neg h_cases, if_pos trivial]
     · intro i _
       simp only
-      split_ifs <;> assumption
+      split <;> assumption
     · simp only [sum_pair h_cases, if_neg h_cases, if_pos trivial, hab]
     · intro i hi
       simp only [Finset.mem_singleton, Finset.mem_insert] at hi
@@ -357,7 +357,7 @@ theorem Finset.convexHull_eq (s : Finset E) : convexHull R ↑s =
     rw [Finset.mem_coe] at hx
     refine' ⟨_, _, _, Finset.centerMass_ite_eq _ _ _ hx⟩
     · intros
-      split_ifs
+      split
       exacts [zero_le_one, le_refl 0]
     · rw [Finset.sum_ite_eq, if_pos hx]
   · rintro x ⟨wx, hwx₀, hwx₁, rfl⟩ y ⟨wy, hwy₀, hwy₁, rfl⟩ a b ha hb hab

--- a/Mathlib/Analysis/Convex/Strict.lean
+++ b/Mathlib/Analysis/Convex/Strict.lean
@@ -308,7 +308,7 @@ theorem StrictConvex.preimage_smul (hs : StrictConvex 𝕜 s) (c : 𝕜) :
   classical
     obtain rfl | hc := eq_or_ne c 0
     · simp_rw [zero_smul, preimage_const]
-      split_ifs
+      split
       · exact strictConvex_univ
       · exact strictConvex_empty
     refine' hs.linear_preimage (LinearMap.lsmul _ _ c) _ (smul_right_injective E hc)

--- a/Mathlib/Analysis/InnerProductSpace/Basic.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Basic.lean
@@ -2091,7 +2091,7 @@ theorem OrthogonalFamily.norm_sq_diff_sum (f : ∀ i, G i) (s₁ s₂ : Finset �
   have hF : ∀ i, ‖F i‖ = ‖f i‖ := by
     intro i
     dsimp only
-    split_ifs <;> simp only [eq_self_iff_true, norm_neg]
+    split <;> simp only [eq_self_iff_true, norm_neg]
   have :
     ‖(∑ i in s₁ \ s₂, V i (F i)) + ∑ i in s₂ \ s₁, V i (F i)‖ ^ 2 =
       (∑ i in s₁ \ s₂, ‖F i‖ ^ 2) + ∑ i in s₂ \ s₁, ‖F i‖ ^ 2 := by

--- a/Mathlib/Analysis/Normed/Group/Seminorm.lean
+++ b/Mathlib/Analysis/Normed/Group/Seminorm.lean
@@ -455,7 +455,7 @@ instance toOne [DecidableEq E] : One (AddGroupSeminorm E) :=
           rw [if_pos hx, hx, zero_add, zero_add]
         · simp only
           rw [if_neg hx]
-          refine' le_add_of_le_of_nonneg _ _ <;> split_ifs <;> norm_num
+          refine' le_add_of_le_of_nonneg _ _ <;> split <;> norm_num
       neg' := fun x => by simp_rw [neg_eq_zero] }⟩
 
 @[simp]
@@ -626,7 +626,7 @@ instance toOne [DecidableEq E] : One (GroupSeminorm E) :=
           rw [if_pos hx, hx, one_mul, zero_add]
         · simp only
           rw [if_neg hx]
-          refine' le_add_of_le_of_nonneg _ _ <;> split_ifs <;> norm_num
+          refine' le_add_of_le_of_nonneg _ _ <;> split <;> norm_num
       inv' := fun x => by simp_rw [inv_eq_one] }⟩
 
 @[to_additive (attr := simp) existing AddGroupSeminorm.apply_one]
@@ -685,7 +685,7 @@ instance [DecidableEq E] : One (NonarchAddGroupSeminorm E) :=
         · simp_rw [if_pos hx, hx, zero_add]
           exact le_max_of_le_right (le_refl _)
         · simp_rw [if_neg hx]
-          split_ifs <;> norm_num
+          split <;> norm_num
       neg' := fun x => by simp_rw [neg_eq_zero] }⟩
 
 @[simp]

--- a/Mathlib/Analysis/Normed/Ring/Seminorm.lean
+++ b/Mathlib/Analysis/Normed/Ring/Seminorm.lean
@@ -128,7 +128,7 @@ instance [DecidableEq R] : One (RingSeminorm R) :=
         by_cases h : x * y = 0
         · refine' (if_pos h).trans_le (mul_nonneg _ _) <;>
             · change _ ≤ ite _ _ _
-              split_ifs
+              split
               exacts [le_rfl, zero_le_one]
         · change ite _ _ _ ≤ ite _ _ _ * ite _ _ _
           simp only [if_false, h, left_ne_zero_of_mul h, right_ne_zero_of_mul h, mul_one,

--- a/Mathlib/Analysis/NormedSpace/ENorm.lean
+++ b/Mathlib/Analysis/NormedSpace/ENorm.lean
@@ -133,7 +133,7 @@ instance partialOrder : PartialOrder (ENorm 𝕜 V) where
 /-- The `ENorm` sending each non-zero vector to infinity. -/
 noncomputable instance : Top (ENorm 𝕜 V) :=
   ⟨{  toFun := fun x => if x = 0 then 0 else ⊤
-      eq_zero' := fun x => by simp only; split_ifs <;> simp [*]
+      eq_zero' := fun x => by simp only; split <;> simp [*]
       map_add_le' := fun x y => by
         simp only
         split_ifs with hxy hx hy hy hx hy hy <;> try simp [*]

--- a/Mathlib/Analysis/NormedSpace/HomeomorphBall.lean
+++ b/Mathlib/Analysis/NormedSpace/HomeomorphBall.lean
@@ -124,7 +124,7 @@ def univBall (c : P) (r : ℝ) : LocalHomeomorph E P :=
 
 @[simp]
 theorem univBall_source (c : P) (r : ℝ) : (univBall c r).source = univ := by
-  unfold univBall; split_ifs <;> rfl
+  unfold univBall; split <;> rfl
 
 theorem univBall_target (c : P) {r : ℝ} (hr : 0 < r) : (univBall c r).target = ball c r := by
   rw [univBall, dif_pos hr]; rfl
@@ -137,7 +137,7 @@ theorem ball_subset_univBall_target (c : P) (r : ℝ) : ball c r ⊆ (univBall c
 
 @[simp]
 theorem univBall_apply_zero (c : P) (r : ℝ) : univBall c r 0 = c := by
-  unfold univBall; split_ifs <;> simp
+  unfold univBall; split <;> simp
 
 @[simp]
 theorem univBall_symm_apply_center (c : P) (r : ℝ) : (univBall c r).symm c = 0 := by

--- a/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
@@ -123,7 +123,7 @@ theorem log_inv_eq_ite (x : ℂ) : log x⁻¹ = if x.arg = π then -conj (log x)
   · simp_rw [log, map_add, map_mul, conj_ofReal, conj_I, normSq_eq_abs, Real.log_pow,
       Nat.cast_two, ofReal_mul, neg_add, mul_neg, neg_neg]
     norm_num; rw [two_mul] -- Porting note: added to simplify `↑2`
-    split_ifs
+    split
     · rw [add_sub_right_comm, sub_add_cancel']
     · rw [add_sub_right_comm, sub_add_cancel']
   · rwa [inv_pos, Complex.normSq_pos]

--- a/Mathlib/Analysis/SpecialFunctions/Pow/Complex.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Complex.lean
@@ -49,7 +49,7 @@ theorem cpow_zero (x : ℂ) : x ^ (0 : ℂ) = 1 := by simp [cpow_def]
 @[simp]
 theorem cpow_eq_zero_iff (x y : ℂ) : x ^ y = 0 ↔ x = 0 ∧ y ≠ 0 := by
   simp only [cpow_def]
-  split_ifs <;> simp [*, exp_ne_zero]
+  split <;> simp [*, exp_ne_zero]
 #align complex.cpow_eq_zero_iff Complex.cpow_eq_zero_iff
 
 @[simp]

--- a/Mathlib/Analysis/SpecialFunctions/Pow/Real.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Real.lean
@@ -64,7 +64,7 @@ theorem exp_one_rpow (x : ℝ) : exp 1 ^ x = exp x := by rw [← exp_mul, one_mu
 
 theorem rpow_eq_zero_iff_of_nonneg {x y : ℝ} (hx : 0 ≤ x) : x ^ y = 0 ↔ x = 0 ∧ y ≠ 0 := by
   simp only [rpow_def_of_nonneg hx]
-  split_ifs <;> simp [*, exp_ne_zero]
+  split <;> simp [*, exp_ne_zero]
 #align real.rpow_eq_zero_iff_of_nonneg Real.rpow_eq_zero_iff_of_nonneg
 
 open Real

--- a/Mathlib/Analysis/SpecificLimits/Basic.lean
+++ b/Mathlib/Analysis/SpecificLimits/Basic.lean
@@ -493,7 +493,7 @@ theorem Set.Countable.exists_pos_hasSum_le {ι : Type*} {s : Set ι} (hs : s.Cou
   rcases posSumOfEncodable hε s with ⟨f, hf0, ⟨c, hfc, hcε⟩⟩
   refine' ⟨fun i => if h : i ∈ s then f ⟨i, h⟩ else 1, fun i => _, ⟨c, _, hcε⟩⟩
   · conv_rhs => simp
-    split_ifs
+    split
     exacts [hf0 _, zero_lt_one]
   · simpa only [Subtype.coe_prop, dif_pos, Subtype.coe_eta]
 #align set.countable.exists_pos_has_sum_le Set.Countable.exists_pos_hasSum_le

--- a/Mathlib/Analysis/SpecificLimits/Normed.lean
+++ b/Mathlib/Analysis/SpecificLimits/Normed.lean
@@ -608,7 +608,7 @@ theorem Antitone.cauchySeq_series_mul_of_tendsto_zero_of_bounded (hfa : Antitone
 
 theorem norm_sum_neg_one_pow_le (n : ℕ) : ‖∑ i in range n, (-1 : ℝ) ^ i‖ ≤ 1 := by
   rw [neg_one_geom_sum]
-  split_ifs <;> norm_num
+  split <;> norm_num
 #align norm_sum_neg_one_pow_le norm_sum_neg_one_pow_le
 
 /-- The **alternating series test** for monotone sequences.

--- a/Mathlib/CategoryTheory/Extensive.lean
+++ b/Mathlib/CategoryTheory/Extensive.lean
@@ -361,7 +361,7 @@ instance types.finitaryExtensive : FinitaryExtensive (Type u) := by
     · intro s
       ext ⟨⟨x, ⟨⟩⟩, _⟩
       dsimp
-      split_ifs <;> rfl
+      split <;> rfl
     · intro s
       ext ⟨⟨x, ⟨⟩⟩, hx⟩
       dsimp
@@ -370,7 +370,7 @@ instance types.finitaryExtensive : FinitaryExtensive (Type u) := by
       · rfl
     · intro s m e₁ e₂
       ext x
-      split_ifs
+      split
       · rw [← e₁]
         rfl
       · rw [← e₂]
@@ -450,7 +450,7 @@ noncomputable def finitaryExtensiveTopCatAux (Z : TopCat.{u})
   · intro s m e₁ e₂
     ext x
     change m x = dite _ _ _
-    split_ifs
+    split
     · rw [← e₁]
       rfl
     · rw [← e₂]

--- a/Mathlib/CategoryTheory/Monoidal/Category.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Category.lean
@@ -252,12 +252,12 @@ variable {U V W X Y Z : C}
 
 theorem tensor_dite {P : Prop} [Decidable P] {W X Y Z : C} (f : W ⟶ X) (g : P → (Y ⟶ Z))
     (g' : ¬P → (Y ⟶ Z)) : (f ⊗ if h : P then g h else g' h) = if h : P then f ⊗ g h else f ⊗ g' h :=
-  by split_ifs <;> rfl
+  by split <;> rfl
 #align category_theory.monoidal_category.tensor_dite CategoryTheory.MonoidalCategory.tensor_dite
 
 theorem dite_tensor {P : Prop} [Decidable P] {W X Y Z : C} (f : W ⟶ X) (g : P → (Y ⟶ Z))
     (g' : ¬P → (Y ⟶ Z)) : (if h : P then g h else g' h) ⊗ f = if h : P then g h ⊗ f else g' h ⊗ f :=
-  by split_ifs <;> rfl
+  by split <;> rfl
 #align category_theory.monoidal_category.dite_tensor CategoryTheory.MonoidalCategory.dite_tensor
 
 @[reassoc, simp]

--- a/Mathlib/CategoryTheory/Preadditive/Injective.lean
+++ b/Mathlib/CategoryTheory/Preadditive/Injective.lean
@@ -113,7 +113,7 @@ instance (X : Type u₁) [Nonempty X] : Injective X where
       ext y
       classical
       change dite (f y ∈ Set.range f) (fun h => g (Classical.choose h)) _ = _
-      split_ifs <;> rename_i h
+      split_ifs with h
       · rw [mono_iff_injective] at mono
         erw [mono (Classical.choose_spec h)]
       · exact False.elim (h ⟨y, rfl⟩)⟩

--- a/Mathlib/CategoryTheory/Preadditive/Mat.lean
+++ b/Mathlib/CategoryTheory/Preadditive/Mat.lean
@@ -628,7 +628,7 @@ def equivalenceSingleObjInverse : Mat_ (SingleObj Rᵐᵒᵖ) ⥤ Mat R where
   map_id X := by
     ext
     simp only [Mat_.id_def, id_def]
-    split_ifs <;> rfl
+    split <;> rfl
   map_comp f g := by
     -- Porting note: this proof was automatic in mathlib3
     ext

--- a/Mathlib/Combinatorics/SimpleGraph/AdjMatrix.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/AdjMatrix.lean
@@ -108,7 +108,7 @@ theorem compl_apply_diag [Zero α] [One α] (i : V) : A.compl i i = 0 := by simp
 @[simp]
 theorem compl_apply [Zero α] [One α] (i j : V) : A.compl i j = 0 ∨ A.compl i j = 1 := by
   unfold compl
-  split_ifs <;> simp
+  split <;> simp
 #align matrix.compl_apply Matrix.compl_apply
 
 @[simp]

--- a/Mathlib/Combinatorics/SimpleGraph/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Basic.lean
@@ -1251,7 +1251,7 @@ edge is removed if present. -/
 abbrev replaceVertex : SimpleGraph V where
   Adj v w := if v = t then if w = t then False else G.Adj s w
                       else if w = t then G.Adj v s else G.Adj v w
-  symm v w := by dsimp only; split_ifs <;> simp [adj_comm]
+  symm v w := by dsimp only; split <;> simp [adj_comm]
 
 /-- There is never an `s-t` edge in `G.replaceVertex s t`. -/
 theorem not_adj_replaceVertex_same : ¬(G.replaceVertex s t).Adj s t := by simp

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity.lean
@@ -1148,7 +1148,7 @@ theorem take_spec {u v w : V} (p : G.Walk v w) (h : u ∈ p.support) :
   · cases h
     · simp!
     · simp! only
-      split_ifs with h' <;> subst_vars <;> simp [*]
+      split <;> subst_vars <;> simp [*]
 #align simple_graph.walk.take_spec SimpleGraph.Walk.take_spec
 
 theorem mem_support_iff_exists_append {V : Type u} {G : SimpleGraph V} {u v w : V}
@@ -1460,7 +1460,7 @@ theorem length_bypass_le {u v : V} (p : G.Walk u v) : p.bypass.length ≤ p.leng
   | nil => rfl
   | cons _ _ ih =>
     simp only [bypass]
-    split_ifs
+    split
     · trans
       apply length_dropUntil_le
       rw [length_cons]
@@ -1479,7 +1479,7 @@ theorem support_bypass_subset {u v : V} (p : G.Walk u v) : p.bypass.support ⊆ 
   | nil => simp!
   | cons _ _ ih =>
     simp! only
-    split_ifs
+    split
     · apply List.Subset.trans (support_dropUntil_subset _ _)
       apply List.subset_cons_of_subset
       assumption
@@ -1498,7 +1498,7 @@ theorem darts_bypass_subset {u v : V} (p : G.Walk u v) : p.bypass.darts ⊆ p.da
   | nil => simp!
   | cons _ _ ih =>
     simp! only
-    split_ifs
+    split
     · apply List.Subset.trans (darts_dropUntil_subset _ _)
       apply List.subset_cons_of_subset _ ih
     · rw [darts_cons]

--- a/Mathlib/Combinatorics/SimpleGraph/Regularity/Chunk.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Regularity/Chunk.lean
@@ -182,7 +182,7 @@ private theorem one_sub_eps_mul_card_nonuniformWitness_le_card_star (hV : V ∈ 
 
 theorem card_chunk (hm : m ≠ 0) : (chunk hP G ε hU).parts.card = 4 ^ P.parts.card := by
   unfold chunk
-  split_ifs
+  split
   · rw [card_parts_equitabilise _ _ hm, tsub_add_cancel_of_le]
     exact le_of_lt a_add_one_le_four_pow_parts_card
   · rw [card_parts_equitabilise _ _ hm, tsub_add_cancel_of_le a_add_one_le_four_pow_parts_card]

--- a/Mathlib/Combinatorics/SimpleGraph/Regularity/Uniform.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Regularity/Uniform.lean
@@ -163,7 +163,7 @@ noncomputable def nonuniformWitness (ε : 𝕜) (s t : Finset α) : Finset α :=
 
 theorem nonuniformWitness_subset (h : ¬G.IsUniform ε s t) : G.nonuniformWitness ε s t ⊆ s := by
   unfold nonuniformWitness
-  split_ifs
+  split
   · exact G.left_nonuniformWitnesses_subset h
   · exact G.right_nonuniformWitnesses_subset fun i => h i.symm
 #align simple_graph.nonuniform_witness_subset SimpleGraph.nonuniformWitness_subset
@@ -171,7 +171,7 @@ theorem nonuniformWitness_subset (h : ¬G.IsUniform ε s t) : G.nonuniformWitnes
 theorem le_card_nonuniformWitness (h : ¬G.IsUniform ε s t) :
     (s.card : 𝕜) * ε ≤ (G.nonuniformWitness ε s t).card := by
   unfold nonuniformWitness
-  split_ifs
+  split
   · exact G.left_nonuniformWitnesses_card h
   · exact G.right_nonuniformWitnesses_card fun i => h i.symm
 #align simple_graph.le_card_nonuniform_witness SimpleGraph.le_card_nonuniformWitness

--- a/Mathlib/Computability/Primrec.lean
+++ b/Mathlib/Computability/Primrec.lean
@@ -1509,14 +1509,14 @@ theorem unpair₁ {n f} (hf : @Primrec' n f) : @Primrec' n fun v => (f v).unpair
   have s := sqrt.comp₁ _ hf
   have fss := sub.comp₂ _ hf (mul.comp₂ _ s s)
   refine' (if_lt fss s fss s).of_eq fun v => _
-  simp [Nat.unpair]; split_ifs <;> rfl
+  simp [Nat.unpair]; split <;> rfl
 #align nat.primrec'.unpair₁ Nat.Primrec'.unpair₁
 
 theorem unpair₂ {n f} (hf : @Primrec' n f) : @Primrec' n fun v => (f v).unpair.2 := by
   have s := sqrt.comp₁ _ hf
   have fss := sub.comp₂ _ hf (mul.comp₂ _ s s)
   refine' (if_lt fss s s (sub.comp₂ _ fss s)).of_eq fun v => _
-  simp [Nat.unpair]; split_ifs <;> rfl
+  simp [Nat.unpair]; split <;> rfl
 #align nat.primrec'.unpair₂ Nat.Primrec'.unpair₂
 
 theorem of_prim {n f} : Primrec f → @Primrec' n f :=

--- a/Mathlib/Computability/RegularExpressions.lean
+++ b/Mathlib/Computability/RegularExpressions.lean
@@ -226,11 +226,11 @@ theorem char_rmatch_iff (a : α) (x : List α) : rmatch (char a) x ↔ x = [a] :
   · exact of_decide_eq_true rfl
   cases' x with head tail
   · rw [rmatch, deriv]
-    split_ifs
+    split
     · tauto
     · simp [List.singleton_inj]; tauto
   · rw [rmatch, rmatch, deriv]
-    split_ifs with h
+    split
     · simp only [deriv_one, zero_rmatch, cons.injEq, and_false]
     · simp only [deriv_zero, zero_rmatch, cons.injEq, and_false]
 #align regular_expression.char_rmatch_iff RegularExpression.char_rmatch_iff

--- a/Mathlib/Computability/TMToPartrec.lean
+++ b/Mathlib/Computability/TMToPartrec.lean
@@ -550,7 +550,7 @@ theorem Cont.then_eval {k k' : Cont} {v} : (k.then k').eval v = k.eval v >>= k'.
   induction' k with _ _ _ _ _ _ _ _ _ k_ih _ _ k_ih generalizing v <;>
     simp only [Cont.eval, Cont.then, bind_assoc, pure_bind, *]
   · simp only [← k_ih]
-  · split_ifs <;> [rfl; simp only [← k_ih, bind_assoc]]
+  · split <;> [rfl; simp only [← k_ih, bind_assoc]]
 #align turing.to_partrec.cont.then_eval Turing.ToPartrec.Cont.then_eval
 
 /-- The `then k` function is a "configuration homomorphism". Its operation on states is to append
@@ -586,7 +586,7 @@ theorem stepRet_then {k k' : Cont} {v} : stepRet (k.then k') v = (stepRet k v).t
   case comp =>
     rw [← stepNormal_then]
   case fix _ k_ih =>
-    split_ifs
+    split
     · rw [← k_ih]
     · rw [← stepNormal_then]
       rfl
@@ -737,7 +737,7 @@ theorem stepRet_eval {k v} : eval step (stepRet k v) = Cfg.halt <$> k.eval v := 
     rw [IH, bind_pure_comp]
   case fix f k IH =>
     rw [Cont.eval, stepRet]; simp only [bind_pure_comp]
-    split_ifs; · exact IH
+    split; · exact IH
     simp only [← bind_pure_comp, bind_assoc, cont_eval_fix (code_is_ok _)]
     congr; funext; rw [bind_pure_comp, ← IH]
     exact reaches_eval (ReflTransGen.single rfl)
@@ -1947,7 +1947,7 @@ theorem supports_biUnion {K : Option Γ' → Finset Λ'} {S} :
 #align turing.partrec_to_TM2.supports_bUnion Turing.PartrecToTM2.supports_biUnion
 
 theorem head_supports {S k q} (H : (q : Λ').Supports S) : (head k q).Supports S := fun _ => by
-  dsimp only; split_ifs <;> exact H
+  dsimp only; split <;> exact H
 #align turing.partrec_to_TM2.head_supports Turing.PartrecToTM2.head_supports
 
 theorem ret_supports {S k} (H₁ : contSupp k ⊆ S) : TM2.SupportsStmt S (tr (Λ'.ret k)) := by
@@ -1999,7 +1999,7 @@ theorem trStmts₁_supports' {S q K} (H₁ : (q : Λ').Supports S) (H₂ : trStm
 theorem trNormal_supports {S c k} (Hk : codeSupp c k ⊆ S) : (trNormal c k).Supports S := by
   induction c generalizing k <;> simp [Λ'.Supports, head]
   case zero' => exact Finset.union_subset_right Hk
-  case succ => intro; split_ifs <;> exact Finset.union_subset_right Hk
+  case succ => intro; split <;> exact Finset.union_subset_right Hk
   case tail => exact Finset.union_subset_right Hk
   case cons f fs IHf _ =>
     apply IHf

--- a/Mathlib/Computability/TuringMachine.lean
+++ b/Mathlib/Computability/TuringMachine.lean
@@ -2584,7 +2584,7 @@ theorem tr_respects_aux₂ {k : K} {q : Stmt₂₁} {v : σ} {S : ∀ k, List (�
         rw [List.getI_eq_default, List.getI_eq_default] <;>
           simp only [Nat.add_one_le_iff, h, List.length, le_of_lt, List.length_reverse,
             List.length_append, List.length_map]
-    · split_ifs <;> rw [Function.update_noteq h', ← proj_map_nth, hL]
+    · split <;> rw [Function.update_noteq h', ← proj_map_nth, hL]
       rw [Function.update_noteq h']
   case peek f =>
     rw [Function.update_eq_self]
@@ -2626,7 +2626,7 @@ theorem tr_respects_aux₂ {k : K} {q : Stmt₂₁} {v : σ} {S : ∀ k, List (�
           rw [List.getI_eq_default, List.getI_eq_default] <;>
             simp only [Nat.add_one_le_iff, h, List.length, le_of_lt, List.length_reverse,
               List.length_append, List.length_map]
-      · split_ifs <;> rw [Function.update_noteq h', ← proj_map_nth, hL]
+      · split <;> rw [Function.update_noteq h', ← proj_map_nth, hL]
         rw [Function.update_noteq h']
 #align turing.TM2to1.tr_respects_aux₂ Turing.TM2to1.tr_respects_aux₂
 

--- a/Mathlib/Data/Bool/Count.lean
+++ b/Mathlib/Data/Bool/Count.lean
@@ -114,7 +114,7 @@ theorem two_mul_count_bool_eq_ite (hl : Chain' (· ≠ ·) l) (b : Bool) :
     rw [length_cons, Nat.even_add_one, not_not] at h2
     replace hl : l.Chain' (· ≠ ·) := hl.tail
     rw [hl.two_mul_count_bool_of_even h2]
-    cases b <;> cases x <;> split_ifs <;> simp <;> contradiction
+    cases b <;> cases x <;> split <;> simp_all
 #align list.chain'.two_mul_count_bool_eq_ite List.Chain'.two_mul_count_bool_eq_ite
 
 theorem length_sub_one_le_two_mul_count_bool (hl : Chain' (· ≠ ·) l) (b : Bool) :

--- a/Mathlib/Data/DFinsupp/Basic.lean
+++ b/Mathlib/Data/DFinsupp/Basic.lean
@@ -980,7 +980,7 @@ protected theorem induction {p : (Π₀ i, β i) → Prop} (f : Π₀ i, β i) (
         · right; exact if_pos H3
         · left; exact H3
       right
-      split_ifs <;> [rfl; exact H2]
+      split <;> [rfl; exact H2]
     have H3 : ∀ aux, (⟨fun j : ι => ite (j = i) 0 (f j), Trunc.mk ⟨i ::ₘ s, aux⟩⟩ : Π₀ i, β i) =
         ⟨fun j : ι => ite (j = i) 0 (f j), Trunc.mk ⟨s, H2⟩⟩ :=
       fun _ ↦ ext fun _ => rfl
@@ -1043,24 +1043,24 @@ end AddMonoid
 @[simp]
 theorem mk_add [∀ i, AddZeroClass (β i)] {s : Finset ι} {x y : ∀ i : (↑s : Set ι), β i} :
     mk s (x + y) = mk s x + mk s y :=
-  ext fun i => by simp only [add_apply, mk_apply]; split_ifs <;> [rfl; rw [zero_add]]
+  ext fun i => by simp only [add_apply, mk_apply]; split <;> [rfl; rw [zero_add]]
 #align dfinsupp.mk_add DFinsupp.mk_add
 
 @[simp]
 theorem mk_zero [∀ i, Zero (β i)] {s : Finset ι} : mk s (0 : ∀ i : (↑s : Set ι), β i.1) = 0 :=
-  ext fun i => by simp only [mk_apply]; split_ifs <;> rfl
+  ext fun i => by simp only [mk_apply]; split <;> rfl
 #align dfinsupp.mk_zero DFinsupp.mk_zero
 
 @[simp]
 theorem mk_neg [∀ i, AddGroup (β i)] {s : Finset ι} {x : ∀ i : (↑s : Set ι), β i.1} :
     mk s (-x) = -mk s x :=
-  ext fun i => by simp only [neg_apply, mk_apply]; split_ifs <;> [rfl; rw [neg_zero]]
+  ext fun i => by simp only [neg_apply, mk_apply]; split <;> [rfl; rw [neg_zero]]
 #align dfinsupp.mk_neg DFinsupp.mk_neg
 
 @[simp]
 theorem mk_sub [∀ i, AddGroup (β i)] {s : Finset ι} {x y : ∀ i : (↑s : Set ι), β i.1} :
     mk s (x - y) = mk s x - mk s y :=
-  ext fun i => by simp only [sub_apply, mk_apply]; split_ifs <;> [rfl; rw [sub_zero]]
+  ext fun i => by simp only [sub_apply, mk_apply]; split <;> [rfl; rw [sub_zero]]
 #align dfinsupp.mk_sub DFinsupp.mk_sub
 
 /-- If `s` is a subset of `ι` then `mk_addGroupHom s` is the canonical additive
@@ -1079,7 +1079,7 @@ variable [Monoid γ] [∀ i, AddMonoid (β i)] [∀ i, DistribMulAction γ (β i
 @[simp]
 theorem mk_smul {s : Finset ι} (c : γ) (x : ∀ i : (↑s : Set ι), β (i : ι)) :
     mk s (c • x) = c • mk s x :=
-  ext fun i => by simp only [smul_apply, mk_apply]; split_ifs <;> [rfl; rw [smul_zero]]
+  ext fun i => by simp only [smul_apply, mk_apply]; split <;> [rfl; rw [smul_zero]]
 #align dfinsupp.mk_smul DFinsupp.mk_smul
 
 @[simp]

--- a/Mathlib/Data/FinEnum.lean
+++ b/Mathlib/Data/FinEnum.lean
@@ -239,7 +239,7 @@ theorem mem_pi {β : α → Type _} [FinEnum α] [∀ a, FinEnum (β a)] (xs : L
     · apply xs_ih
     · ext x h
       simp only [Pi.cons]
-      split_ifs
+      split
       · subst x
         rfl
       · rfl

--- a/Mathlib/Data/Finset/Basic.lean
+++ b/Mathlib/Data/Finset/Basic.lean
@@ -2768,7 +2768,7 @@ theorem filter_false_of_mem (h : ∀ x ∈ s, ¬p x) : s.filter p = ∅ := filte
 
 @[simp]
 theorem filter_const (p : Prop) [Decidable p] (s : Finset α) :
-    (s.filter fun _a => p) = if p then s else ∅ := by split_ifs <;> simp [*]
+    (s.filter fun _a => p) = if p then s else ∅ := by split <;> simp [*]
 #align finset.filter_const Finset.filter_const
 
 theorem filter_congr {s : Finset α} (H : ∀ x ∈ s, p x ↔ q x) : filter p s = filter q s :=
@@ -2854,7 +2854,7 @@ theorem filter_cons {a : α} (s : Finset α) (ha : a ∉ s) :
     filter p (cons a s ha) =
       (if p a then {a} else ∅ : Finset α).disjUnion (filter p s)
         (by
-          split_ifs
+          split
           · rw [disjoint_singleton_left]
             exact mem_filter.not.mpr <| mt And.left ha
           · exact disjoint_empty_left _) := by
@@ -3840,14 +3840,12 @@ def sigmaEquivOptionOfInhabited (α : Type u) [Inhabited α] [DecidableEq α] :
       invFun := Option.elim' default (↑)
       left_inv := fun x => by
         dsimp only
-        split_ifs <;> simp [*]
+        split <;> simp [*]
       right_inv := by
         rintro (_ | ⟨x, h⟩)
         · simp
         · dsimp only
-          split_ifs with hi
-          · simp [h] at hi
-          · simp }⟩
+          split_ifs <;> simp_all }⟩
 #align equiv.sigma_equiv_option_of_inhabited Equiv.sigmaEquivOptionOfInhabited
 
 end Equiv

--- a/Mathlib/Data/Finset/Fold.lean
+++ b/Mathlib/Data/Finset/Fold.lean
@@ -87,7 +87,7 @@ theorem fold_const [hd : Decidable (s = ∅)] (c : β) (h : op c (op b c) = op b
     induction' s using Finset.induction_on with x s hx IH generalizing hd
     · simp
     · simp only [Finset.fold_insert hx, IH, if_false, Finset.insert_ne_empty]
-      split_ifs
+      split
       · rw [hc.comm]
       · exact h
 #align finset.fold_const Finset.fold_const

--- a/Mathlib/Data/Finset/Sigma.lean
+++ b/Mathlib/Data/Finset/Sigma.lean
@@ -166,7 +166,7 @@ variable {f g : ∀ ⦃i⦄, α i → β i → Finset (γ i)} {a : Σi, α i} {b
 theorem sigmaLift_nonempty :
     (sigmaLift f a b).Nonempty ↔ ∃ h : a.1 = b.1, (f (h ▸ a.2) b.2).Nonempty := by
   simp_rw [nonempty_iff_ne_empty, sigmaLift]
-  split_ifs with h <;> simp [h]
+  split <;> simp_all
 #align finset.sigma_lift_nonempty Finset.sigmaLift_nonempty
 
 theorem sigmaLift_eq_empty : sigmaLift f a b = ∅ ↔ ∀ h : a.1 = b.1, f (h ▸ a.2) b.2 = ∅ := by
@@ -189,7 +189,7 @@ variable (f a b)
 theorem card_sigmaLift :
     (sigmaLift f a b).card = dite (a.1 = b.1) (fun h => (f (h ▸ a.2) b.2).card) fun _ => 0 := by
   simp_rw [sigmaLift]
-  split_ifs with h <;> simp [h]
+  split <;> simp_all
 #align finset.card_sigma_lift Finset.card_sigmaLift
 
 end SigmaLift

--- a/Mathlib/Data/Finsupp/Basic.lean
+++ b/Mathlib/Data/Finsupp/Basic.lean
@@ -1210,7 +1210,7 @@ theorem curry_apply (f : α × β →₀ M) (x : α) (y : β) : f.curry x y = f 
     have : ∀ b : α × β, single b.fst (single b.snd (f b)) x y = if b = (x, y) then f b else 0 := by
       rintro ⟨b₁, b₂⟩
       simp only [ne_eq, single_apply, Prod.ext_iff, ite_and]
-      split_ifs <;> simp [single_apply, *]
+      split <;> simp [single_apply, *]
     rw [Finsupp.curry, sum_apply, sum_apply, sum_eq_single, this, if_pos rfl]
     · intro b _ b_ne
       rw [this b, if_neg b_ne]

--- a/Mathlib/Data/PEquiv.lean
+++ b/Mathlib/Data/PEquiv.lean
@@ -215,7 +215,7 @@ def ofSet (s : Set α) [DecidablePred (· ∈ s)] :
 #align pequiv.of_set PEquiv.ofSet
 
 theorem mem_ofSet_self_iff {s : Set α} [DecidablePred (· ∈ s)] {a : α} : a ∈ ofSet s a ↔ a ∈ s :=
-  by dsimp [ofSet]; split_ifs <;> simp [*]
+  by dsimp [ofSet]; split <;> simp [*]
 #align pequiv.mem_of_set_self_iff PEquiv.mem_ofSet_self_iff
 
 theorem mem_ofSet_iff {s : Set α} [DecidablePred (· ∈ s)] {a b : α} :
@@ -345,7 +345,7 @@ theorem mem_single (a : α) (b : β) : b ∈ single a b a :=
 #align pequiv.mem_single PEquiv.mem_single
 
 theorem mem_single_iff (a₁ a₂ : α) (b₁ b₂ : β) : b₁ ∈ single a₂ b₂ a₁ ↔ a₁ = a₂ ∧ b₁ = b₂ := by
-  dsimp [single]; split_ifs <;> simp [*, eq_comm]
+  dsimp [single]; split <;> simp [*, eq_comm]
 #align pequiv.mem_single_iff PEquiv.mem_single_iff
 
 @[simp]
@@ -366,7 +366,7 @@ theorem single_trans_of_mem (a : α) {b : β} {c : γ} {f : β ≃. γ} (h : c �
     (single a b).trans f = single a c := by
   ext
   dsimp [single, PEquiv.trans]
-  split_ifs <;> simp_all
+  split <;> simp_all
 #align pequiv.single_trans_of_mem PEquiv.single_trans_of_mem
 
 theorem trans_single_of_mem {a : α} {b : β} (c : γ) {f : α ≃. β} (h : b ∈ f a) :
@@ -394,7 +394,7 @@ theorem trans_single_of_eq_none {b : β} (c : γ) {f : δ ≃. β} (h : f.symm b
   dsimp [PEquiv.trans, single]
   simp only [mem_def, bind_eq_some, iff_false, not_exists, not_and]
   intros
-  split_ifs <;> simp_all
+  split <;> simp_all
 #align pequiv.trans_single_of_eq_none PEquiv.trans_single_of_eq_none
 
 theorem single_trans_of_eq_none (a : α) {b : β} {f : β ≃. δ} (h : f b = none) :
@@ -450,8 +450,8 @@ instance [DecidableEq α] [DecidableEq β] : SemilatticeInf (α ≃. β) :=
             rw [← h2] at hg
             simp only [iff_true] at hf hg
             rw [hf, hg] }
-    inf_le_left := fun _ _ _ _ => by simp; split_ifs <;> simp [*]
-    inf_le_right := fun _ _ _ _ => by simp; split_ifs <;> simp [*]
+    inf_le_left := fun _ _ _ _ => by simp; split <;> simp [*]
+    inf_le_right := fun _ _ _ _ => by simp; split <;> simp [*]
     le_inf := fun f g h fg gh a b => by
       intro H
       have hf := fg a b H


### PR DESCRIPTION
One day I hope we can ditch `split_ifs` in favour of `split`. This just replaces some `split_ifs` with `split` in places it is trivial to do so.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
