### PR TITLE
[Merged by Bors] - chore: use Qq in new Gamma positivity extension

### DIFF
--- a/Mathlib/Analysis/SpecialFunctions/Gamma/Basic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Gamma/Basic.lean
@@ -543,15 +543,15 @@ open Lean.Meta Qq in
 /-- The `positivity` extension which identifies expressions of the form `Gamma a`. -/
 @[positivity Gamma (_ : ℝ)]
 def _root_.Mathlib.Meta.Positivity.evalGamma :
-    Mathlib.Meta.Positivity.PositivityExt where eval {_ _α} zα pα e := do
-  let (.app _ (a : Q($_α))) ← withReducible (whnf e) | throwError "not Gamma ·"
+    Mathlib.Meta.Positivity.PositivityExt where eval {_ _α} zα pα (e : Q(ℝ)) := do
+  let ~q(Gamma $a) := e | throwError "failed to match on Gamma application"
   match ← Mathlib.Meta.Positivity.core zα pα a with
   | .positive pa =>
-    let pa' ← mkAppM ``Gamma_pos_of_pos #[pa]
-    pure (.positive pa')
+    have pa' : Q(0 < $a) := pa
+    pure (.positive (q(Gamma_pos_of_pos $pa') : Q(0 < $e)))
   | .nonnegative pa =>
-    let pa' ← mkAppM ``Gamma_nonneg_of_nonneg #[pa]
-    pure (.nonnegative pa')
+    have pa' : Q(0 ≤ $a) := pa
+    pure (.nonnegative (q(Gamma_nonneg_of_nonneg $pa') : Q(0 ≤ $e)))
   | _ => pure .none
 
 /-- The Gamma function does not vanish on `ℝ` (except at non-positive integers, where the function

--- a/Mathlib/Analysis/SpecialFunctions/Gamma/Basic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Gamma/Basic.lean
@@ -546,12 +546,10 @@ def _root_.Mathlib.Meta.Positivity.evalGamma :
     Mathlib.Meta.Positivity.PositivityExt where eval {_ _α} zα pα (e : Q(ℝ)) := do
   let ~q(Gamma $a) := e | throwError "failed to match on Gamma application"
   match ← Mathlib.Meta.Positivity.core zα pα a with
-  | .positive pa =>
-    have pa' : Q(0 < $a) := pa
-    pure (.positive (q(Gamma_pos_of_pos $pa') : Q(0 < $e)))
-  | .nonnegative pa =>
-    have pa' : Q(0 ≤ $a) := pa
-    pure (.nonnegative (q(Gamma_nonneg_of_nonneg $pa') : Q(0 ≤ $e)))
+  | .positive (pa : Q(0 < $a)) =>
+    pure (.positive (q(Gamma_pos_of_pos $pa) : Q(0 < $e)))
+  | .nonnegative (pa : Q(0 ≤ $a)) =>
+    pure (.nonnegative (q(Gamma_nonneg_of_nonneg $pa) : Q(0 ≤ $e)))
   | _ => pure .none
 
 /-- The Gamma function does not vanish on `ℝ` (except at non-positive integers, where the function


### PR DESCRIPTION
Adds Qq static checking, as requested in this comment: https://github.com/leanprover-community/mathlib4/pull/7888#issuecomment-1777483059

The `have pa' : Q(..) := pa` lines are necessary to sort out typeclass instances of `LE` and `LT`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
