### PR TITLE
feat: pp.beta

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3581,6 +3581,8 @@ import Mathlib.Util.Imports
 import Mathlib.Util.IncludeStr
 import Mathlib.Util.LongNames
 import Mathlib.Util.MemoFix
+import Mathlib.Util.PPBeta
+import Mathlib.Util.PPBetaOption
 import Mathlib.Util.PiNotation
 import Mathlib.Util.Qq
 import Mathlib.Util.SleepHeartbeats

--- a/Mathlib/Util/PPBeta.lean
+++ b/Mathlib/Util/PPBeta.lean
@@ -40,6 +40,9 @@ Additional caveats:
 
 open Lean PrettyPrinter Delaborator
 
+/-- Get the state of the `pp.beta` option. -/
+def Lean.getPPBeta (o : Options) : Bool := o.get pp.beta.name false
+
 namespace Mathlib.Util.PPBeta
 
 /-- Beta reduce all expressions.

--- a/Mathlib/Util/PPBeta.lean
+++ b/Mathlib/Util/PPBeta.lean
@@ -1,0 +1,61 @@
+/-
+Copyright (c) 2023 Kyle Miller. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kyle Miller
+-/
+import Mathlib.Util.PPBetaOption
+
+/-! Add the `pp.beta` feature to the pretty printer
+
+By importing this module, you can do
+```lean
+set_option pp.beta true
+```
+and then the pretty printer will beta reduce all expressions.
+The option can see through mdata for beta reduction opportunities,
+but it will otherwise preserve mdata.
+
+This option is not recommended and can lead to very confusing situations.
+For example:
+```lean
+example {α β : Type} (f : α → β) (a : α) (b : β) (h : f a = b) :
+    (fun x ↦ f x) a = b := by
+  /-
+  α β : Type
+  f : α → β
+  a : α
+  b : β
+  h : f a = b
+  ⊢ f a = b
+  -/
+  rw [h] -- fails
+```
+
+Additional caveats:
+1. `pp.beta` is incompatible with pretty printer features that
+   store data by expression position, for example `pp.analyze`.
+2. Tooltips in the info view might display beta unreduced terms.
+   This defect is expected to be limited to just the outermost expression.
+-/
+
+open Lean PrettyPrinter Delaborator
+
+namespace Mathlib.Util.PPBeta
+
+/-- Beta reduce all expressions.
+This is incompatible with the `pp.analyze` option.
+In general it can clear `optionsPerPos`.
+Note that tooltips might still display beta-unreduced terms. -/
+def betaReduceFirst : Delab := whenPPOption getPPBeta do
+  let e ← SubExpr.getExpr
+  -- Check if there's anything beta reducible first:
+  unless (e.find? Expr.isHeadBetaTarget).isSome do failure
+  let e' ← Core.betaReduce e
+  -- Clear the options since switching to `e'` invalidates them.
+  withReader (fun ctx => {ctx with optionsPerPos := {}}) do
+    -- set `pp.beta` to false at this position to prevent looping.
+    withOptionAtCurrPos `pp.beta false do
+      withTheReader SubExpr ({· with expr := e'}) delab
+
+attribute [delab app, delab lam, delab forallE, delab letE, delab mdata, delab proj]
+  betaReduceFirst

--- a/Mathlib/Util/PPBetaOption.lean
+++ b/Mathlib/Util/PPBetaOption.lean
@@ -27,7 +27,4 @@ register_option pp.beta : Bool := {
   descr    := "(pretty printer) apply beta-reduction when pretty printing"
 }
 
-/-- Get the state of the `pp.beta` option. -/
-def getPPBeta (o : Options) : Bool := o.get pp.beta.name false
-
 end Lean

--- a/Mathlib/Util/PPBetaOption.lean
+++ b/Mathlib/Util/PPBetaOption.lean
@@ -1,0 +1,33 @@
+/-
+Copyright (c) 2023 Kyle Miller. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kyle Miller
+-/
+import Lean
+/-! # Register the `pp.beta` option itself
+
+Users should import `Mathlib.Util.PPBeta`.
+This module is merely registering the `pp.beta` option,
+which needs to be done in a separate module.
+-/
+
+namespace Lean
+
+/-!
+Note to the future: if https://github.com/leanprover/lean4/issues/715
+is addressed, then there *should* be a name collision in this file.
+In that eventuality, you may remove both this module and `Mathlib.Util.PPBeta`.
+-/
+
+/-- The `pp.beta` option enables a pretty printer that beta reduces all
+expressions. -/
+register_option pp.beta : Bool := {
+  defValue := false
+  group    := "pp"
+  descr    := "(pretty printer) apply beta-reduction when pretty printing"
+}
+
+/-- Get the state of the `pp.beta` option. -/
+def getPPBeta (o : Options) : Bool := o.get pp.beta.name false
+
+end Lean

--- a/test/PPBeta.lean
+++ b/test/PPBeta.lean
@@ -1,0 +1,20 @@
+import Mathlib.Util.PPBeta
+import Mathlib.Data.FunLike.Basic
+
+set_option pp.unicode.fun true
+
+variable (F α β : Type) [FunLike F α (fun _ => β)] (f : F) (a : α)
+
+set_option pp.beta true in
+/--
+info: ↑f a : β
+-/
+#guard_msgs in
+#check f a
+
+set_option pp.beta false in
+/--
+info: ↑f a : (fun x ↦ β) a
+-/
+#guard_msgs in
+#check f a


### PR DESCRIPTION
Un-reverting #7205 (reverted by #7774). Adds a `pp.beta` option that when set to `true` causes all terms to be beta reduced when pretty printed. This feature is problematic, but since Lean 3 had it, and since it's possible for us to implement it as mathlib code, here it is.

This is future-proof against core implementing it in the sense that [if it gets implemented](https://github.com/leanprover/lean4/issues/715) there will likely be a name collision, and then these two modules can be deleted.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
