### PR TITLE
[Merged by Bors] - feat: port positivity extension for Nat.ascFactorial

### DIFF
--- a/Mathlib/Tactic/Positivity/Basic.lean
+++ b/Mathlib/Tactic/Positivity/Basic.lean
@@ -468,6 +468,12 @@ def evalNatSucc : PositivityExt where eval {_u _α} _zα _pα e := do
 
 /-- Extension for Nat.factorial. -/
 @[positivity Nat.factorial _]
-def evalFactorial : PositivityExt where eval {_ _} _ _ e := do
-  let .app _ (a : Q(Nat)) ← whnfR e | throwError "not Nat.factorial"
+def evalFactorial : PositivityExt where eval {_ _} _ _ (e : Q(ℕ)) := do
+  let ~q(Nat.factorial $a) := e | throwError "failed to match Nat.factorial"
   pure (.positive (q(Nat.factorial_pos $a) : Expr))
+
+/-- Extension for Nat.ascFactorial. -/
+@[positivity Nat.ascFactorial _ _]
+def evalAscFactorial : PositivityExt where eval {_ _} _ _ (e : Q(ℕ)) := do
+  let ~q(Nat.ascFactorial $n $k) := e | throwError "failed to match Nat.ascFactorial"
+  pure (.positive (q(Nat.ascFactorial_pos $n $k) : Expr))

--- a/test/positivity.lean
+++ b/test/positivity.lean
@@ -246,7 +246,7 @@ example : 0 ≤ max (-3 : ℤ) 5 := by positivity
 
 example (n : ℕ) : 0 < n.succ := by positivity
 example (n : ℕ) : 0 < n ! := by positivity
--- example (n k : ℕ) : 0 < n.asc_factorial k := by positivity
+example (n k : ℕ) : 0 < n.ascFactorial k := by positivity
 
 -- example {α : Type _} (s : Finset α) (hs : s.Nonempty) : 0 < s.card := by positivity
 -- example {α : Type _} [Fintype α] [Nonempty α] : 0 < Fintype.card α := by positivity


### PR DESCRIPTION
Adds a positivity extension for `Nat.ascFactorial`. (Compare to the lean 3 version: https://github.com/leanprover-community/mathlib/blob/3365b20c2ffa7c35e47e5209b89ba9abdddf3ffe/src/tactic/positivity.lean#L762-L767)

Also updates the `Nat.factorial` positivity extension to use a more idiomatic `~q()` match.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
