### PR TITLE
[Merged by Bors] - fix: make `replace` not inadvertently close goal

### DIFF
--- a/Mathlib/Tactic/Replace.lean
+++ b/Mathlib/Tactic/Replace.lean
@@ -49,7 +49,5 @@ elab_rules : tactic
     let name := optBinderIdent.name n
     let hId? := (← getLCtx).findFromUserName? name |>.map fun d ↦ d.fvarId
     match hId? with
-    | some hId =>
-      try replaceMainGoal [goal1, ← goal2.clear hId]
-      catch | _ => pure ()
+    | some hId => replaceMainGoal [goal1, (← observing? <| goal2.clear hId).getD goal2]
     | none     => replaceMainGoal [goal1, goal2]

--- a/test/Replace.lean
+++ b/test/Replace.lean
@@ -4,8 +4,11 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Arthur Paulino
 -/
 import Mathlib.Tactic.Replace
+import Std.Tactic.GuardExpr
 
 set_option linter.unusedVariables false
+
+private axiom test_sorry : ∀ {α}, α
 
 /-- Test the `:=` syntax works -/
 example {A B : Type} (h : A) (f : A → B) : B := by
@@ -24,3 +27,15 @@ example : True := by
   replace : 2 + 2 = 4
   simp_arith
   trivial
+
+-- Regression test. `replace h` used to close goal and leave metavariables.
+-- Note that `replace h` does *not* delete `h` in this case because the type of the new `h`
+-- is a metavariable whose context includes the old `h`.
+example (h : True) : False := by
+  guard_hyp h : True
+  replace h
+  · exact true
+  guard_hyp h : Bool
+  rename_i h'
+  guard_hyp h' : True
+  exact test_sorry


### PR DESCRIPTION
If `replace` couldn't clear the hypothesis, it would accidentally leave no more goals. (Note that `pure ()` doesn't work because the main goal has already been assigned by that point so will be deleted from the goals list.)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
