### PR TITLE
add minimum_of_length_pos_mem

### DIFF
--- a/Mathlib/Data/List/MinMax.lean
+++ b/Mathlib/Data/List/MinMax.lean
@@ -449,6 +449,11 @@ theorem minimum_of_length_pos_le_iff (h : 0 < l.length) :
     minimum_of_length_pos h ≤ b ↔ l.minimum ≤ b :=
   le_maximum_of_length_pos_iff (α := αᵒᵈ) h
 
+theorem minimum_of_length_pos_mem (h : 0 < l.length) (hm : m = minimum_of_length_pos h) :
+    m ∈ l := by
+  apply minimum_mem
+  simp only [coe_minimum_of_length_pos, hm]
+
 theorem le_maximum_of_length_pos_of_mem (h : a ∈ l) (w : 0 < l.length) :
     a ≤ l.maximum_of_length_pos w := by
   simp only [le_maximum_of_length_pos_iff]


### PR DESCRIPTION
add `minimum_of_length_pos_mem` to `Mathlib/Data/List`

Co-authored-by: Eric Wieser <wieser.eric@gmail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

zulip: https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/.E2.9C.94.20how.20to.20show.20.60min_first.60.20is.20a.20permutation.3F

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
