### PR TITLE
[Merged by Bors] - refactor: introduce the new homology API for homological complex and rename the old one

### DIFF
--- a/Mathlib/Algebra/Homology/Additive.lean
+++ b/Mathlib/Algebra/Homology/Additive.lean
@@ -120,8 +120,8 @@ namespace HomologicalComplex
 instance eval_additive (i : ι) : (eval V c i).Additive where
 #align homological_complex.eval_additive HomologicalComplex.eval_additive
 
-instance cycles_additive [HasEqualizers V] : (cyclesFunctor V c i).Additive where
-#align homological_complex.cycles_additive HomologicalComplex.cycles_additive
+instance cycles'_additive [HasEqualizers V] : (cycles'Functor V c i).Additive where
+#align homological_complex.cycles_additive HomologicalComplex.cycles'_additive
 
 variable [HasImages V] [HasImageMaps V]
 
@@ -130,11 +130,11 @@ instance boundaries_additive : (boundariesFunctor V c i).Additive where
 
 variable [HasEqualizers V] [HasCokernels V]
 
-instance homology_additive : (homologyFunctor V c i).Additive where
+instance homology_additive : (homology'Functor V c i).Additive where
   map_add {_ _ f g} := by
-    dsimp [homologyFunctor]
+    dsimp [homology'Functor]
     ext
-    simp only [homology.π_map, Preadditive.comp_add, ← Preadditive.add_comp]
+    simp only [homology'.π_map, Preadditive.comp_add, ← Preadditive.add_comp]
     congr
     ext
     simp

--- a/Mathlib/Algebra/Homology/Exact.lean
+++ b/Mathlib/Algebra/Homology/Exact.lean
@@ -37,6 +37,9 @@ these results are found in `CategoryTheory/Abelian/Exact.lean`.
   categories?)
 * Two adjacent maps in a chain complex are exact iff the homology vanishes
 
+Note: It is planned that the definition in this file will be replaced by the new
+homology API, in particular by the content of `Algebra.Homology.ShortComplex.Exact`.
+
 -/
 
 
@@ -84,22 +87,22 @@ open ZeroObject
 /-- In any preadditive category,
 composable morphisms `f g` are exact iff they compose to zero and the homology vanishes.
 -/
-theorem Preadditive.exact_iff_homology_zero {A B C : V} (f : A ⟶ B) (g : B ⟶ C) :
-    Exact f g ↔ ∃ w : f ≫ g = 0, Nonempty (homology f g w ≅ 0) :=
+theorem Preadditive.exact_iff_homology'_zero {A B C : V} (f : A ⟶ B) (g : B ⟶ C) :
+    Exact f g ↔ ∃ w : f ≫ g = 0, Nonempty (homology' f g w ≅ 0) :=
   ⟨fun h => ⟨h.w, ⟨by
     haveI := h.epi
     exact cokernel.ofEpi _⟩⟩,
    fun h => by
     obtain ⟨w, ⟨i⟩⟩ := h
     exact ⟨w, Preadditive.epi_of_cokernel_zero ((cancel_mono i.hom).mp (by ext))⟩⟩
-#align category_theory.preadditive.exact_iff_homology_zero CategoryTheory.Preadditive.exact_iff_homology_zero
+#align category_theory.preadditive.exact_iff_homology_zero CategoryTheory.Preadditive.exact_iff_homology'_zero
 
 theorem Preadditive.exact_of_iso_of_exact {A₁ B₁ C₁ A₂ B₂ C₂ : V} (f₁ : A₁ ⟶ B₁) (g₁ : B₁ ⟶ C₁)
     (f₂ : A₂ ⟶ B₂) (g₂ : B₂ ⟶ C₂) (α : Arrow.mk f₁ ≅ Arrow.mk f₂) (β : Arrow.mk g₁ ≅ Arrow.mk g₂)
     (p : α.hom.right = β.hom.left) (h : Exact f₁ g₁) : Exact f₂ g₂ := by
-  rw [Preadditive.exact_iff_homology_zero] at h ⊢
+  rw [Preadditive.exact_iff_homology'_zero] at h ⊢
   rcases h with ⟨w₁, ⟨i⟩⟩
-  suffices w₂ : f₂ ≫ g₂ = 0; exact ⟨w₂, ⟨(homology.mapIso w₁ w₂ α β p).symm.trans i⟩⟩
+  suffices w₂ : f₂ ≫ g₂ = 0; exact ⟨w₂, ⟨(homology'.mapIso w₁ w₂ α β p).symm.trans i⟩⟩
   rw [← cancel_epi α.hom.left, ← cancel_mono β.inv.right, comp_zero, zero_comp, ← w₁]
   have eq₁ := β.inv.w
   have eq₂ := α.hom.w

--- a/Mathlib/Algebra/Homology/HomologicalComplex.lean
+++ b/Mathlib/Algebra/Homology/HomologicalComplex.lean
@@ -803,10 +803,25 @@ theorem mk_d_1_0 : (mk X₀ X₁ X₂ d₀ d₁ s succ).d 1 0 = d₀ := by
 #align chain_complex.mk_d_1_0 ChainComplex.mk_d_1_0
 
 @[simp]
-theorem mk_d_2_0 : (mk X₀ X₁ X₂ d₀ d₁ s succ).d 2 1 = d₁ := by
+theorem mk_d_2_1 : (mk X₀ X₁ X₂ d₀ d₁ s succ).d 2 1 = d₁ := by
   change ite (2 = 1 + 1) (𝟙 X₂ ≫ d₁) 0 = d₁
   rw [if_pos rfl, Category.id_comp]
-#align chain_complex.mk_d_2_0 ChainComplex.mk_d_2_0
+#align chain_complex.mk_d_2_0 ChainComplex.mk_d_2_1
+
+@[simp]
+lemma mk_d (n : ℕ) : (mk X₀ X₁ X₂ d₀ d₁ s succ).d (n+3) (n+2) =
+    (succ (MkStruct.flat (mkAux X₀ X₁ X₂ d₀ d₁ s succ n))).snd.fst := by
+  dsimp only [mk, of]
+  rw [dif_pos (by rfl), eqToHom_refl, id_comp]
+  rfl
+
+lemma mk_d' (n i j : ℕ) (hij : j + 1 = i) (hn : j = n + 2) :
+    (mk X₀ X₁ X₂ d₀ d₁ s succ).d i j =
+      eqToHom (by substs hn hij; rfl) ≫
+        (succ (MkStruct.flat (mkAux X₀ X₁ X₂ d₀ d₁ s succ n))).snd.fst ≫
+        eqToHom (by subst hn; rfl) := by
+  subst hij hn
+  simp only [eqToHom_refl, comp_id, id_comp, mk_d]
 
 -- TODO simp lemmas for the inductive steps? It's not entirely clear that they are needed.
 /-- A simpler inductive constructor for `ℕ`-indexed chain complexes.

--- a/Mathlib/Algebra/Homology/HomologicalComplex.lean
+++ b/Mathlib/Algebra/Homology/HomologicalComplex.lean
@@ -808,21 +808,6 @@ theorem mk_d_2_1 : (mk X₀ X₁ X₂ d₀ d₁ s succ).d 2 1 = d₁ := by
   rw [if_pos rfl, Category.id_comp]
 #align chain_complex.mk_d_2_0 ChainComplex.mk_d_2_1
 
-@[simp]
-lemma mk_d (n : ℕ) : (mk X₀ X₁ X₂ d₀ d₁ s succ).d (n+3) (n+2) =
-    (succ (MkStruct.flat (mkAux X₀ X₁ X₂ d₀ d₁ s succ n))).snd.fst := by
-  dsimp only [mk, of]
-  rw [dif_pos (by rfl), eqToHom_refl, id_comp]
-  rfl
-
-lemma mk_d' (n i j : ℕ) (hij : j + 1 = i) (hn : j = n + 2) :
-    (mk X₀ X₁ X₂ d₀ d₁ s succ).d i j =
-      eqToHom (by substs hn hij; rfl) ≫
-        (succ (MkStruct.flat (mkAux X₀ X₁ X₂ d₀ d₁ s succ n))).snd.fst ≫
-        eqToHom (by subst hn; rfl) := by
-  subst hij hn
-  simp only [eqToHom_refl, comp_id, id_comp, mk_d]
-
 -- TODO simp lemmas for the inductive steps? It's not entirely clear that they are needed.
 /-- A simpler inductive constructor for `ℕ`-indexed chain complexes.
 

--- a/Mathlib/Algebra/Homology/Homology.lean
+++ b/Mathlib/Algebra/Homology/Homology.lean
@@ -21,7 +21,7 @@ as `cyclesMap' f i` and `boundariesMap f i`.
 As a consequence we construct `homologyFunctor' i : HomologicalComplex V c ⥤ V`,
 computing the `i`-th homology.
 
-Note: Some definitions in this file have the suffix `'` so as to allow the development
+Note: Some definitions (specifically, names containing components `homology`, `cycles`, and `quasiIso`) in this file have the suffix `'` so as to allow the development
 of the new homology API of homological complex (starting from
 `Algebra.Homology.ShortComplex.HomologicalComplex`). It is planned that these definitions
 shall be removed and removed by the new API.

--- a/Mathlib/Algebra/Homology/Homology.lean
+++ b/Mathlib/Algebra/Homology/Homology.lean
@@ -21,10 +21,11 @@ as `cyclesMap' f i` and `boundariesMap f i`.
 As a consequence we construct `homologyFunctor' i : HomologicalComplex V c ⥤ V`,
 computing the `i`-th homology.
 
-Note: Some definitions (specifically, names containing components `homology`, `cycles`, and `quasiIso`) in this file have the suffix `'` so as to allow the development
-of the new homology API of homological complex (starting from
+Note: Some definitions (specifically, names containing components `homology`, `cycles`)
+in this file have the suffix `'` so as to allow the development of the
+new homology API of homological complex (starting from
 `Algebra.Homology.ShortComplex.HomologicalComplex`). It is planned that these definitions
-shall be removed and removed by the new API.
+shall be removed and replaced by the new API.
 
 -/
 

--- a/Mathlib/Algebra/Homology/Homology.lean
+++ b/Mathlib/Algebra/Homology/Homology.lean
@@ -12,14 +12,20 @@ import Mathlib.CategoryTheory.GradedObject
 /-!
 # The homology of a complex
 
-Given `C : HomologicalComplex V c`, we have `C.cycles i` and `C.boundaries i`,
+Given `C : HomologicalComplex V c`, we have `C.cycles' i` and `C.boundaries i`,
 both defined as subobjects of `C.X i`.
 
 We show these are functorial with respect to chain maps,
-as `C.cyclesMap f i` and `C.boundariesMap f i`.
+as `cyclesMap' f i` and `boundariesMap f i`.
 
-As a consequence we construct `homologyFunctor i : HomologicalComplex V c ⥤ V`,
+As a consequence we construct `homologyFunctor' i : HomologicalComplex V c ⥤ V`,
 computing the `i`-th homology.
+
+Note: Some definitions in this file have the suffix `'` so as to allow the development
+of the new homology API of homological complex (starting from
+`Algebra.Homology.ShortComplex.HomologicalComplex`). It is planned that these definitions
+shall be removed and removed by the new API.
+
 -/
 
 
@@ -44,22 +50,22 @@ section Cycles
 variable [HasKernels V]
 
 /-- The cycles at index `i`, as a subobject. -/
-abbrev cycles (i : ι) : Subobject (C.X i) :=
+abbrev cycles' (i : ι) : Subobject (C.X i) :=
   kernelSubobject (C.dFrom i)
-#align homological_complex.cycles HomologicalComplex.cycles
+#align homological_complex.cycles HomologicalComplex.cycles'
 
-theorem cycles_eq_kernelSubobject {i j : ι} (r : c.Rel i j) :
-    C.cycles i = kernelSubobject (C.d i j) :=
+theorem cycles'_eq_kernelSubobject {i j : ι} (r : c.Rel i j) :
+    C.cycles' i = kernelSubobject (C.d i j) :=
   C.kernel_from_eq_kernel r
-#align homological_complex.cycles_eq_kernel_subobject HomologicalComplex.cycles_eq_kernelSubobject
+#align homological_complex.cycles_eq_kernel_subobject HomologicalComplex.cycles'_eq_kernelSubobject
 
-/-- The underlying object of `C.cycles i` is isomorphic to `kernel (C.d i j)`,
+/-- The underlying object of `C.cycles' i` is isomorphic to `kernel (C.d i j)`,
 for any `j` such that `Rel i j`. -/
-def cyclesIsoKernel {i j : ι} (r : c.Rel i j) : (C.cycles i : V) ≅ kernel (C.d i j) :=
-  Subobject.isoOfEq _ _ (C.cycles_eq_kernelSubobject r) ≪≫ kernelSubobjectIso (C.d i j)
-#align homological_complex.cycles_iso_kernel HomologicalComplex.cyclesIsoKernel
+def cycles'IsoKernel {i j : ι} (r : c.Rel i j) : (C.cycles' i : V) ≅ kernel (C.d i j) :=
+  Subobject.isoOfEq _ _ (C.cycles'_eq_kernelSubobject r) ≪≫ kernelSubobjectIso (C.d i j)
+#align homological_complex.cycles_iso_kernel HomologicalComplex.cycles'IsoKernel
 
-theorem cycles_eq_top {i} (h : ¬c.Rel i (c.next i)) : C.cycles i = ⊤ := by
+theorem cycles_eq_top {i} (h : ¬c.Rel i (c.next i)) : C.cycles' i = ⊤ := by
   rw [eq_top_iff]
   apply le_kernelSubobject
   rw [C.dFrom_eq_zero h, comp_zero]
@@ -100,50 +106,52 @@ section
 
 variable [HasKernels V] [HasImages V]
 
-theorem boundaries_le_cycles (C : HomologicalComplex V c) (i : ι) : C.boundaries i ≤ C.cycles i :=
+theorem boundaries_le_cycles' (C : HomologicalComplex V c) (i : ι) :
+    C.boundaries i ≤ C.cycles' i :=
   image_le_kernel _ _ (C.dTo_comp_dFrom i)
-#align homological_complex.boundaries_le_cycles HomologicalComplex.boundaries_le_cycles
+#align homological_complex.boundaries_le_cycles HomologicalComplex.boundaries_le_cycles'
 
-/-- The canonical map from `boundaries i` to `cycles i`. -/
-abbrev boundariesToCycles (C : HomologicalComplex V c) (i : ι) :
-    (C.boundaries i : V) ⟶ (C.cycles i : V) :=
+/-- The canonical map from `boundaries i` to `cycles' i`. -/
+abbrev boundariesToCycles' (C : HomologicalComplex V c) (i : ι) :
+    (C.boundaries i : V) ⟶ (C.cycles' i : V) :=
   imageToKernel _ _ (C.dTo_comp_dFrom i)
-#align homological_complex.boundaries_to_cycles HomologicalComplex.boundariesToCycles
+#align homological_complex.boundaries_to_cycles HomologicalComplex.boundariesToCycles'
 
-/-- Prefer `boundariesToCycles`. -/
+/-- Prefer `boundariesToCycles'`. -/
 @[simp 1100]
-theorem imageToKernel_as_boundariesToCycles (C : HomologicalComplex V c) (i : ι) (h) :
-    (C.boundaries i).ofLE (C.cycles i) h = C.boundariesToCycles i := rfl
-#align homological_complex.image_to_kernel_as_boundaries_to_cycles HomologicalComplex.imageToKernel_as_boundariesToCycles
+theorem imageToKernel_as_boundariesToCycles' (C : HomologicalComplex V c) (i : ι) (h) :
+    (C.boundaries i).ofLE (C.cycles' i) h = C.boundariesToCycles' i := rfl
+#align homological_complex.image_to_kernel_as_boundaries_to_cycles HomologicalComplex.imageToKernel_as_boundariesToCycles'
 
 variable [HasCokernels V]
 
 /-- The homology of a complex at index `i`. -/
-abbrev homology (C : HomologicalComplex V c) (i : ι) : V :=
-  _root_.homology (C.dTo i) (C.dFrom i) (C.dTo_comp_dFrom i)
-#align homological_complex.homology HomologicalComplex.homology
+abbrev homology' (C : HomologicalComplex V c) (i : ι) : V :=
+  _root_.homology' (C.dTo i) (C.dFrom i) (C.dTo_comp_dFrom i)
+#align homological_complex.homology HomologicalComplex.homology'
 
 /-- The `j`th homology of a homological complex (as kernel of 'the differential from `Cⱼ`' modulo
 the image of 'the differential to `Cⱼ`') is isomorphic to the kernel of `d : Cⱼ → Cₖ` modulo
 the image of `d : Cᵢ → Cⱼ` when `Rel i j` and `Rel j k`. -/
-def homologyIso (C : HomologicalComplex V c) {i j k : ι} (hij : c.Rel i j) (hjk : c.Rel j k) :
-    C.homology j ≅ _root_.homology (C.d i j) (C.d j k) (C.d_comp_d i j k) :=
-  homology.mapIso _ _
+def homology'Iso (C : HomologicalComplex V c) {i j k : ι} (hij : c.Rel i j) (hjk : c.Rel j k) :
+    C.homology' j ≅ _root_.homology' (C.d i j) (C.d j k) (C.d_comp_d i j k) :=
+  homology'.mapIso _ _
     (Arrow.isoMk (C.xPrevIso hij) (Iso.refl _) <| by dsimp; rw [C.dTo_eq hij, Category.comp_id])
     (Arrow.isoMk (Iso.refl _) (C.xNextIso hjk) <| by
       dsimp
       rw [C.dFrom_comp_xNextIso hjk, Category.id_comp])
     rfl
-#align homological_complex.homology_iso HomologicalComplex.homologyIso
+#align homological_complex.homology_iso HomologicalComplex.homology'Iso
 
 end
 
 end HomologicalComplex
 
 /-- The 0th homology of a chain complex is isomorphic to the cokernel of `d : C₁ ⟶ C₀`. -/
-def ChainComplex.homologyZeroIso [HasKernels V] [HasImages V] [HasCokernels V]
-    (C : ChainComplex V ℕ) [Epi (factorThruImage (C.d 1 0))] : C.homology 0 ≅ cokernel (C.d 1 0) :=
-  (homology.mapIso _ _
+def ChainComplex.homology'ZeroIso [HasKernels V] [HasImages V] [HasCokernels V]
+    (C : ChainComplex V ℕ) [Epi (factorThruImage (C.d 1 0))] :
+    C.homology' 0 ≅ cokernel (C.d 1 0) :=
+  (homology'.mapIso _ _
       (Arrow.isoMk (C.xPrevIso rfl) (Iso.refl _) <| by
         rw [C.dTo_eq rfl]
         exact (Category.comp_id _).symm : Arrow.mk (C.dTo 0) ≅ Arrow.mk (C.d 1 0))
@@ -152,38 +160,38 @@ def ChainComplex.homologyZeroIso [HasKernels V] [HasImages V] [HasCokernels V]
           one_ne_zero <| by rwa [ChainComplex.next_nat_zero, Nat.zero_add] at h] :
         Arrow.mk (C.dFrom 0) ≅ Arrow.mk 0)
       rfl).trans <|
-    homologyOfZeroRight _
-#align chain_complex.homology_zero_iso ChainComplex.homologyZeroIso
+    homology'OfZeroRight _
+#align chain_complex.homology_zero_iso ChainComplex.homology'ZeroIso
 
 /-- The 0th cohomology of a cochain complex is isomorphic to the kernel of `d : C₀ → C₁`. -/
-def CochainComplex.homologyZeroIso [HasZeroObject V] [HasKernels V] [HasImages V] [HasCokernels V]
-    (C : CochainComplex V ℕ) : C.homology 0 ≅ kernel (C.d 0 1) :=
-  (homology.mapIso _ _
+def CochainComplex.homology'ZeroIso [HasZeroObject V] [HasKernels V] [HasImages V] [HasCokernels V]
+    (C : CochainComplex V ℕ) : C.homology' 0 ≅ kernel (C.d 0 1) :=
+  (homology'.mapIso _ _
       (Arrow.isoMk (C.xPrevIsoSelf (by rw [CochainComplex.prev_nat_zero]; exact one_ne_zero))
           (Iso.refl _) (by simp) : Arrow.mk (C.dTo 0) ≅ Arrow.mk 0)
       (Arrow.isoMk (Iso.refl _) (C.xNextIso rfl) (by simp) :
         Arrow.mk (C.dFrom 0) ≅ Arrow.mk (C.d 0 1)) <|
       by simp).trans <|
-    homologyOfZeroLeft _
-#align cochain_complex.homology_zero_iso CochainComplex.homologyZeroIso
+    homology'OfZeroLeft _
+#align cochain_complex.homology_zero_iso CochainComplex.homology'ZeroIso
 
 /-- The `n + 1`th homology of a chain complex (as kernel of 'the differential from `Cₙ₊₁`' modulo
 the image of 'the differential to `Cₙ₊₁`') is isomorphic to the kernel of `d : Cₙ₊₁ → Cₙ` modulo
 the image of `d : Cₙ₊₂ → Cₙ₊₁`. -/
-def ChainComplex.homologySuccIso [HasKernels V] [HasImages V] [HasCokernels V]
+def ChainComplex.homology'SuccIso [HasKernels V] [HasImages V] [HasCokernels V]
     (C : ChainComplex V ℕ) (n : ℕ) :
-    C.homology (n + 1) ≅ homology (C.d (n + 2) (n + 1)) (C.d (n + 1) n) (C.d_comp_d _ _ _) :=
-  C.homologyIso rfl rfl
-#align chain_complex.homology_succ_iso ChainComplex.homologySuccIso
+    C.homology' (n + 1) ≅ homology' (C.d (n + 2) (n + 1)) (C.d (n + 1) n) (C.d_comp_d _ _ _) :=
+  C.homology'Iso rfl rfl
+#align chain_complex.homology_succ_iso ChainComplex.homology'SuccIso
 
 /-- The `n + 1`th cohomology of a cochain complex (as kernel of 'the differential from `Cₙ₊₁`'
 modulo the image of 'the differential to `Cₙ₊₁`') is isomorphic to the kernel of `d : Cₙ₊₁ → Cₙ₊₂`
 modulo the image of `d : Cₙ → Cₙ₊₁`. -/
-def CochainComplex.homologySuccIso [HasKernels V] [HasImages V] [HasCokernels V]
+def CochainComplex.homology'SuccIso [HasKernels V] [HasImages V] [HasCokernels V]
     (C : CochainComplex V ℕ) (n : ℕ) :
-    C.homology (n + 1) ≅ homology (C.d n (n + 1)) (C.d (n + 1) (n + 2)) (C.d_comp_d _ _ _) :=
-  C.homologyIso rfl rfl
-#align cochain_complex.homology_succ_iso CochainComplex.homologySuccIso
+    C.homology' (n + 1) ≅ homology' (C.d n (n + 1)) (C.d (n + 1) (n + 2)) (C.d_comp_d _ _ _) :=
+  C.homology'Iso rfl rfl
+#align cochain_complex.homology_succ_iso CochainComplex.homology'SuccIso
 
 open HomologicalComplex
 
@@ -197,40 +205,40 @@ variable [HasKernels V]
 variable {C₁ C₂ C₃ : HomologicalComplex V c} (f : C₁ ⟶ C₂)
 
 /-- The morphism between cycles induced by a chain map. -/
-abbrev cyclesMap (f : C₁ ⟶ C₂) (i : ι) : (C₁.cycles i : V) ⟶ (C₂.cycles i : V) :=
-  Subobject.factorThru _ ((C₁.cycles i).arrow ≫ f.f i) (kernelSubobject_factors _ _ (by simp))
-#align cycles_map cyclesMap
+abbrev cycles'Map (f : C₁ ⟶ C₂) (i : ι) : (C₁.cycles' i : V) ⟶ (C₂.cycles' i : V) :=
+  Subobject.factorThru _ ((C₁.cycles' i).arrow ≫ f.f i) (kernelSubobject_factors _ _ (by simp))
+#align cycles_map cycles'Map
 
 -- Porting note: Originally `@[simp, reassoc.1, elementwise]`
 @[reassoc, elementwise] -- @[simp] -- Porting note: simp can prove this
-theorem cyclesMap_arrow (f : C₁ ⟶ C₂) (i : ι) :
-    cyclesMap f i ≫ (C₂.cycles i).arrow = (C₁.cycles i).arrow ≫ f.f i := by simp
-#align cycles_map_arrow cyclesMap_arrow
+theorem cycles'Map_arrow (f : C₁ ⟶ C₂) (i : ι) :
+    cycles'Map f i ≫ (C₂.cycles' i).arrow = (C₁.cycles' i).arrow ≫ f.f i := by simp
+#align cycles_map_arrow cycles'Map_arrow
 
-attribute [simp 1100] cyclesMap_arrow_assoc
-attribute [simp] cyclesMap_arrow_apply
+attribute [simp 1100] cycles'Map_arrow_assoc
+attribute [simp] cycles'Map_arrow_apply
 
 @[simp]
-theorem cyclesMap_id (i : ι) : cyclesMap (𝟙 C₁) i = 𝟙 _ := by
-  dsimp only [cyclesMap]
+theorem cycles'Map_id (i : ι) : cycles'Map (𝟙 C₁) i = 𝟙 _ := by
+  dsimp only [cycles'Map]
   simp
-#align cycles_map_id cyclesMap_id
+#align cycles_map_id cycles'Map_id
 
 @[simp]
-theorem cyclesMap_comp (f : C₁ ⟶ C₂) (g : C₂ ⟶ C₃) (i : ι) :
-    cyclesMap (f ≫ g) i = cyclesMap f i ≫ cyclesMap g i := by
-  dsimp only [cyclesMap]
+theorem cycles'Map_comp (f : C₁ ⟶ C₂) (g : C₂ ⟶ C₃) (i : ι) :
+    cycles'Map (f ≫ g) i = cycles'Map f i ≫ cycles'Map g i := by
+  dsimp only [cycles'Map]
   simp [Subobject.factorThru_right]
-#align cycles_map_comp cyclesMap_comp
+#align cycles_map_comp cycles'Map_comp
 
 variable (V c)
 
 /-- Cycles as a functor. -/
 @[simps]
-def cyclesFunctor (i : ι) : HomologicalComplex V c ⥤ V where
-  obj C := C.cycles i
-  map {C₁ C₂} f := cyclesMap f i
-#align cycles_functor cyclesFunctor
+def cycles'Functor (i : ι) : HomologicalComplex V c ⥤ V where
+  obj C := C.cycles' i
+  map {C₁ C₂} f := cycles'Map f i
+#align cycles_functor cycles'Functor
 
 end
 
@@ -270,58 +278,59 @@ variable {C₁ C₂ : HomologicalComplex V c} (f : C₁ ⟶ C₂)
 
 -- Porting note: Originally `@[simp, reassoc.1]`
 @[reassoc (attr := simp)]
-theorem boundariesToCycles_naturality (i : ι) :
-    boundariesMap f i ≫ C₂.boundariesToCycles i = C₁.boundariesToCycles i ≫ cyclesMap f i := by
+theorem boundariesToCycles'_naturality (i : ι) :
+    boundariesMap f i ≫ C₂.boundariesToCycles' i =
+      C₁.boundariesToCycles' i ≫ cycles'Map f i := by
   ext
   simp
-#align boundaries_to_cycles_naturality boundariesToCycles_naturality
+#align boundaries_to_cycles_naturality boundariesToCycles'_naturality
 
 variable (V c)
 
 /-- The natural transformation from the boundaries functor to the cycles functor. -/
 @[simps]
-def boundariesToCyclesNatTrans (i : ι) : boundariesFunctor V c i ⟶ cyclesFunctor V c i where
-  app C := C.boundariesToCycles i
-  naturality _ _ f := boundariesToCycles_naturality f i
-#align boundaries_to_cycles_nat_trans boundariesToCyclesNatTrans
+def boundariesToCycles'NatTrans (i : ι) : boundariesFunctor V c i ⟶ cycles'Functor V c i where
+  app C := C.boundariesToCycles' i
+  naturality _ _ f := boundariesToCycles'_naturality f i
+#align boundaries_to_cycles_nat_trans boundariesToCycles'NatTrans
 
 /-- The `i`-th homology, as a functor to `V`. -/
 @[simps]
-def homologyFunctor [HasCokernels V] (i : ι) : HomologicalComplex V c ⥤ V where
+def homology'Functor [HasCokernels V] (i : ι) : HomologicalComplex V c ⥤ V where
   -- It would be nice if we could just write
   -- `cokernel (boundariesToCyclesNatTrans V c i)`
   -- here, but universe implementation details get in the way...
-  obj C := C.homology i
-  map {C₁ C₂} f := homology.map _ _ (f.sqTo i) (f.sqFrom i) rfl
+  obj C := C.homology' i
+  map {C₁ C₂} f := homology'.map _ _ (f.sqTo i) (f.sqFrom i) rfl
   map_id _ := by
     simp only
     ext1
-    simp only [homology.π_map, kernelSubobjectMap_id, Hom.sqFrom_id, Category.id_comp,
+    simp only [homology'.π_map, kernelSubobjectMap_id, Hom.sqFrom_id, Category.id_comp,
       Category.comp_id]
   map_comp _ _ := by
     simp only
     ext1
-    simp only [Hom.sqFrom_comp, kernelSubobjectMap_comp, homology.π_map_assoc, homology.π_map,
+    simp only [Hom.sqFrom_comp, kernelSubobjectMap_comp, homology'.π_map_assoc, homology'.π_map,
       Category.assoc]
-#align homology_functor homologyFunctor
+#align homology_functor homology'Functor
 
 /-- The homology functor from `ι`-indexed complexes to `ι`-graded objects in `V`. -/
 @[simps]
-def gradedHomologyFunctor [HasCokernels V] : HomologicalComplex V c ⥤ GradedObject ι V where
-  obj C i := C.homology i
-  map {C C'} f i := (homologyFunctor V c i).map f
+def gradedHomology'Functor [HasCokernels V] : HomologicalComplex V c ⥤ GradedObject ι V where
+  obj C i := C.homology' i
+  map {C C'} f i := (homology'Functor V c i).map f
   map_id _ := by
     ext
     simp only [GradedObject.categoryOfGradedObjects_id]
     ext
-    simp only [homology.π_map, homologyFunctor_map, kernelSubobjectMap_id, Hom.sqFrom_id,
+    simp only [homology'.π_map, homology'Functor_map, kernelSubobjectMap_id, Hom.sqFrom_id,
       Category.id_comp, Category.comp_id]
   map_comp _ _ := by
     ext
     simp only [GradedObject.categoryOfGradedObjects_comp]
     ext
-    simp only [Hom.sqFrom_comp, kernelSubobjectMap_comp, homology.π_map_assoc, homology.π_map,
-      homologyFunctor_map, Category.assoc]
-#align graded_homology_functor gradedHomologyFunctor
+    simp only [Hom.sqFrom_comp, kernelSubobjectMap_comp, homology'.π_map_assoc, homology'.π_map,
+      homology'Functor_map, Category.assoc]
+#align graded_homology_functor gradedHomology'Functor
 
 end

--- a/Mathlib/Algebra/Homology/Homotopy.lean
+++ b/Mathlib/Algebra/Homology/Homotopy.lean
@@ -781,34 +781,34 @@ variable [HasEqualizers V] [HasCokernels V] [HasImages V] [HasImageMaps V]
 
 /-- Homotopic maps induce the same map on homology.
 -/
-theorem homology_map_eq_of_homotopy (h : Homotopy f g) (i : ι) :
-    (homologyFunctor V c i).map f = (homologyFunctor V c i).map g := by
-  dsimp [homologyFunctor]
+theorem homology'_map_eq_of_homotopy (h : Homotopy f g) (i : ι) :
+    (homology'Functor V c i).map f = (homology'Functor V c i).map g := by
+  dsimp [homology'Functor]
   apply eq_of_sub_eq_zero
   ext
-  simp only [homology.π_map, comp_zero, Preadditive.comp_sub]
+  simp only [homology'.π_map, comp_zero, Preadditive.comp_sub]
   dsimp [kernelSubobjectMap]
   simp_rw [h.comm i]
   simp only [zero_add, zero_comp, dNext_eq_dFrom_fromNext, kernelSubobject_arrow_comp_assoc,
     Preadditive.comp_add]
   rw [← Preadditive.sub_comp]
   simp only [CategoryTheory.Subobject.factorThru_add_sub_factorThru_right]
-  erw [Subobject.factorThru_ofLE (D.boundaries_le_cycles i)]
+  erw [Subobject.factorThru_ofLE (D.boundaries_le_cycles' i)]
   · simp
   · rw [prevD_eq_toPrev_dTo, ← Category.assoc]
     apply imageSubobject_factors_comp_self
-#align homology_map_eq_of_homotopy homology_map_eq_of_homotopy
+#align homology_map_eq_of_homotopy homology'_map_eq_of_homotopy
 
 /-- Homotopy equivalent complexes have isomorphic homologies. -/
 def homologyObjIsoOfHomotopyEquiv (f : HomotopyEquiv C D) (i : ι) :
-    (homologyFunctor V c i).obj C ≅ (homologyFunctor V c i).obj D where
-  hom := (homologyFunctor V c i).map f.hom
-  inv := (homologyFunctor V c i).map f.inv
+    (homology'Functor V c i).obj C ≅ (homology'Functor V c i).obj D where
+  hom := (homology'Functor V c i).map f.hom
+  inv := (homology'Functor V c i).map f.inv
   hom_inv_id := by
-    rw [← Functor.map_comp, homology_map_eq_of_homotopy f.homotopyHomInvId,
+    rw [← Functor.map_comp, homology'_map_eq_of_homotopy f.homotopyHomInvId,
       CategoryTheory.Functor.map_id]
   inv_hom_id := by
-    rw [← Functor.map_comp, homology_map_eq_of_homotopy f.homotopyInvHomId,
+    rw [← Functor.map_comp, homology'_map_eq_of_homotopy f.homotopyInvHomId,
       CategoryTheory.Functor.map_id]
 #align homology_obj_iso_of_homotopy_equiv homologyObjIsoOfHomotopyEquiv
 

--- a/Mathlib/Algebra/Homology/HomotopyCategory.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory.lean
@@ -144,34 +144,34 @@ variable (V c)
 variable [HasEqualizers V] [HasImages V] [HasImageMaps V] [HasCokernels V]
 
 /-- The `i`-th homology, as a functor from the homotopy category. -/
-def homologyFunctor (i : ι) : HomotopyCategory V c ⥤ V :=
-  CategoryTheory.Quotient.lift _ (_root_.homologyFunctor V c i) fun _ _ _ _ ⟨h⟩ =>
-    homology_map_eq_of_homotopy h i
-#align homotopy_category.homology_functor HomotopyCategory.homologyFunctor
+def homology'Functor (i : ι) : HomotopyCategory V c ⥤ V :=
+  CategoryTheory.Quotient.lift _ (_root_.homology'Functor V c i) fun _ _ _ _ ⟨h⟩ =>
+    homology'_map_eq_of_homotopy h i
+#align homotopy_category.homology_functor HomotopyCategory.homology'Functor
 
 /-- The homology functor on the homotopy category is just the usual homology functor. -/
-def homologyFactors (i : ι) :
-    quotient V c ⋙ homologyFunctor V c i ≅ _root_.homologyFunctor V c i :=
+def homology'Factors (i : ι) :
+    quotient V c ⋙ homology'Functor V c i ≅ _root_.homology'Functor V c i :=
   CategoryTheory.Quotient.lift.isLift _ _ _
-#align homotopy_category.homology_factors HomotopyCategory.homologyFactors
+#align homotopy_category.homology_factors HomotopyCategory.homology'Factors
 
 @[simp]
-theorem homologyFactors_hom_app (i : ι) (C : HomologicalComplex V c) :
-    (homologyFactors V c i).hom.app C = 𝟙 _ :=
+theorem homology'Factors_hom_app (i : ι) (C : HomologicalComplex V c) :
+    (homology'Factors V c i).hom.app C = 𝟙 _ :=
   rfl
-#align homotopy_category.homology_factors_hom_app HomotopyCategory.homologyFactors_hom_app
+#align homotopy_category.homology_factors_hom_app HomotopyCategory.homology'Factors_hom_app
 
 @[simp]
-theorem homologyFactors_inv_app (i : ι) (C : HomologicalComplex V c) :
-    (homologyFactors V c i).inv.app C = 𝟙 _ :=
+theorem homology'Factors_inv_app (i : ι) (C : HomologicalComplex V c) :
+    (homology'Factors V c i).inv.app C = 𝟙 _ :=
   rfl
-#align homotopy_category.homology_factors_inv_app HomotopyCategory.homologyFactors_inv_app
+#align homotopy_category.homology_factors_inv_app HomotopyCategory.homology'Factors_inv_app
 
-theorem homologyFunctor_map_factors (i : ι) {C D : HomologicalComplex V c} (f : C ⟶ D) :
-    (_root_.homologyFunctor V c i).map f =
-      ((homologyFunctor V c i).map ((quotient V c).map f) : _) :=
-  (CategoryTheory.Quotient.lift_map_functor_map _ (_root_.homologyFunctor V c i) _ f).symm
-#align homotopy_category.homology_functor_map_factors HomotopyCategory.homologyFunctor_map_factors
+theorem homology'Functor_map_factors (i : ι) {C D : HomologicalComplex V c} (f : C ⟶ D) :
+    (_root_.homology'Functor V c i).map f =
+      ((homology'Functor V c i).map ((quotient V c).map f) : _) :=
+  (CategoryTheory.Quotient.lift_map_functor_map _ (_root_.homology'Functor V c i) _ f).symm
+#align homotopy_category.homology_functor_map_factors HomotopyCategory.homology'Functor_map_factors
 
 end HomotopyCategory
 

--- a/Mathlib/Algebra/Homology/ImageToKernel.lean
+++ b/Mathlib/Algebra/Homology/ImageToKernel.lean
@@ -16,7 +16,12 @@ we have `image_le_kernel f g w : imageSubobject f ≤ kernelSubobject g`
 
 `imageToKernel f g w` is the corresponding morphism between objects in `C`.
 
-We define `homology f g w` of such a pair as the cokernel of `imageToKernel f g w`.
+We define `homology' f g w` of such a pair as the cokernel of `imageToKernel f g w`.
+
+Note: As part of the transition to the new homology API, `homology` is temporarily
+renamed `homology'`. It is planned that this definition shall be removed and replaced by
+`ShortComplex.homology`.
+
 -/
 
 set_option autoImplicit true
@@ -181,72 +186,72 @@ variable {A B C : V} (f : A ⟶ B) [HasImage f] (g : B ⟶ C) [HasKernel g]
 /-- The homology of a pair of morphisms `f : A ⟶ B` and `g : B ⟶ C` satisfying `f ≫ g = 0`
 is the cokernel of the `imageToKernel` morphism for `f` and `g`.
 -/
-def homology {A B C : V} (f : A ⟶ B) [HasImage f] (g : B ⟶ C) [HasKernel g] (w : f ≫ g = 0)
+def homology' {A B C : V} (f : A ⟶ B) [HasImage f] (g : B ⟶ C) [HasKernel g] (w : f ≫ g = 0)
     [HasCokernel (imageToKernel f g w)] : V :=
   cokernel (imageToKernel f g w)
-#align homology homology
+#align homology homology'
 
 section
 
 variable (w : f ≫ g = 0) [HasCokernel (imageToKernel f g w)]
 
 /-- The morphism from cycles to homology. -/
-def homology.π : (kernelSubobject g : V) ⟶ homology f g w :=
+def homology'.π : (kernelSubobject g : V) ⟶ homology' f g w :=
   cokernel.π _
-#align homology.π homology.π
+#align homology.π homology'.π
 
 @[simp]
-theorem homology.condition : imageToKernel f g w ≫ homology.π f g w = 0 :=
+theorem homology'.condition : imageToKernel f g w ≫ homology'.π f g w = 0 :=
   cokernel.condition _
-#align homology.condition homology.condition
+#align homology.condition homology'.condition
 
 /-- To construct a map out of homology, it suffices to construct a map out of the cycles
 which vanishes on boundaries.
 -/
-def homology.desc {D : V} (k : (kernelSubobject g : V) ⟶ D) (p : imageToKernel f g w ≫ k = 0) :
-    homology f g w ⟶ D :=
+def homology'.desc {D : V} (k : (kernelSubobject g : V) ⟶ D) (p : imageToKernel f g w ≫ k = 0) :
+    homology' f g w ⟶ D :=
   cokernel.desc _ k p
-#align homology.desc homology.desc
+#align homology.desc homology'.desc
 
 -- porting note: removed elementwise attribute which does not seem to be helpful here
 @[reassoc (attr := simp)]
-theorem homology.π_desc {D : V} (k : (kernelSubobject g : V) ⟶ D)
-    (p : imageToKernel f g w ≫ k = 0) : homology.π f g w ≫ homology.desc f g w k p = k := by
-  simp [homology.π, homology.desc]
-#align homology.π_desc homology.π_desc
+theorem homology'.π_desc {D : V} (k : (kernelSubobject g : V) ⟶ D)
+    (p : imageToKernel f g w ≫ k = 0) : homology'.π f g w ≫ homology'.desc f g w k p = k := by
+  simp [homology'.π, homology'.desc]
+#align homology.π_desc homology'.π_desc
 
-/-- To check two morphisms out of `homology f g w` are equal, it suffices to check on cycles. -/
+/-- To check two morphisms out of `homology' f g w` are equal, it suffices to check on cycles. -/
 @[ext]
-theorem homology.ext {D : V} {k k' : homology f g w ⟶ D}
-    (p : homology.π f g w ≫ k = homology.π f g w ≫ k') : k = k' :=
+theorem homology'.ext {D : V} {k k' : homology' f g w ⟶ D}
+    (p : homology'.π f g w ≫ k = homology'.π f g w ≫ k') : k = k' :=
   coequalizer.hom_ext p
-#align homology.ext homology.ext
+#align homology.ext homology'.ext
 
 /-- The cokernel of the map `Im f ⟶ Ker 0` is isomorphic to the cokernel of `f.` -/
-def homologyOfZeroRight [HasCokernel (imageToKernel f (0 : B ⟶ C) comp_zero)] [HasCokernel f]
+def homology'OfZeroRight [HasCokernel (imageToKernel f (0 : B ⟶ C) comp_zero)] [HasCokernel f]
     [HasCokernel (image.ι f)] [Epi (factorThruImage f)] :
-    homology f (0 : B ⟶ C) comp_zero ≅ cokernel f :=
+    homology' f (0 : B ⟶ C) comp_zero ≅ cokernel f :=
   (cokernel.mapIso _ _ (imageSubobjectIso _) ((kernelSubobjectIso 0).trans kernelZeroIsoSource)
         (by simp)).trans
     (cokernelImageι _)
-#align homology_of_zero_right homologyOfZeroRight
+#align homology_of_zero_right homology'OfZeroRight
 
 /-- The kernel of the map `Im 0 ⟶ Ker f` is isomorphic to the kernel of `f.` -/
-def homologyOfZeroLeft [HasZeroObject V] [HasKernels V] [HasImage (0 : A ⟶ B)]
+def homology'OfZeroLeft [HasZeroObject V] [HasKernels V] [HasImage (0 : A ⟶ B)]
     [HasCokernel (imageToKernel (0 : A ⟶ B) g zero_comp)] :
-    homology (0 : A ⟶ B) g zero_comp ≅ kernel g :=
+    homology' (0 : A ⟶ B) g zero_comp ≅ kernel g :=
   ((cokernelIsoOfEq <| imageToKernel_zero_left _).trans cokernelZeroIsoTarget).trans
     (kernelSubobjectIso _)
-#align homology_of_zero_left homologyOfZeroLeft
+#align homology_of_zero_left homology'OfZeroLeft
 
 /-- `homology 0 0 _` is just the middle object. -/
 @[simps]
-def homologyZeroZero [HasZeroObject V] [HasImage (0 : A ⟶ B)]
+def homology'ZeroZero [HasZeroObject V] [HasImage (0 : A ⟶ B)]
     [HasCokernel (imageToKernel (0 : A ⟶ B) (0 : B ⟶ C) zero_comp)] :
-    homology (0 : A ⟶ B) (0 : B ⟶ C) zero_comp ≅ B where
-  hom := homology.desc (0 : A ⟶ B) (0 : B ⟶ C) zero_comp (kernelSubobject 0).arrow (by simp)
-  inv := inv (kernelSubobject 0).arrow ≫ homology.π _ _ _
-#align homology_zero_zero homologyZeroZero
+    homology' (0 : A ⟶ B) (0 : B ⟶ C) zero_comp ≅ B where
+  hom := homology'.desc (0 : A ⟶ B) (0 : B ⟶ C) zero_comp (kernelSubobject 0).arrow (by simp)
+  inv := inv (kernelSubobject 0).arrow ≫ homology'.π _ _ _
+#align homology_zero_zero homology'ZeroZero
 
 end
 
@@ -281,83 +286,84 @@ variable [HasCokernel (imageToKernel f₃ g₃ w₃)]
 a pair `f g` and a pair `f' g'` satisfying `f ≫ g = 0` and `f' ≫ g' = 0`,
 we get a morphism on homology.
 -/
-def homology.map (p : α.right = β.left) : homology f g w ⟶ homology f' g' w' :=
+def homology'.map (p : α.right = β.left) : homology' f g w ⟶ homology' f' g' w' :=
   cokernel.desc _ (kernelSubobjectMap β ≫ cokernel.π _) <| by
     rw [imageSubobjectMap_comp_imageToKernel_assoc w w' α β p]
     simp only [cokernel.condition, comp_zero]
-#align homology.map homology.map
+#align homology.map homology'.map
 
 -- porting note: removed elementwise attribute which does not seem to be helpful here,
 -- the correct lemma is stated below
 @[reassoc (attr := simp)]
-theorem homology.π_map (p : α.right = β.left) :
-    homology.π f g w ≫ homology.map w w' α β p = kernelSubobjectMap β ≫ homology.π f' g' w' := by
-  simp only [homology.π, homology.map, cokernel.π_desc]
-#align homology.π_map homology.π_map
+theorem homology'.π_map (p : α.right = β.left) :
+    homology'.π f g w ≫ homology'.map w w' α β p =
+      kernelSubobjectMap β ≫ homology'.π f' g' w' := by
+  simp only [homology'.π, homology'.map, cokernel.π_desc]
+#align homology.π_map homology'.π_map
 
 section
 
 attribute [local instance] ConcreteCategory.funLike
 
 @[simp]
-lemma homology.π_map_apply [ConcreteCategory.{w} V] (p : α.right = β.left)
+lemma homology'.π_map_apply [ConcreteCategory.{w} V] (p : α.right = β.left)
     (x : (forget V).obj (Subobject.underlying.obj (kernelSubobject g))) :
-    homology.map w w' α β p (homology.π f g w x) =
-      homology.π f' g' w' (kernelSubobjectMap β x) := by
-  simp only [← comp_apply, homology.π_map w w' α β p]
+    homology'.map w w' α β p (homology'.π f g w x) =
+      homology'.π f' g' w' (kernelSubobjectMap β x) := by
+  simp only [← comp_apply, homology'.π_map w w' α β p]
 
 end
 
 @[reassoc (attr := simp), elementwise (attr := simp)]
-theorem homology.map_desc (p : α.right = β.left) {D : V} (k : (kernelSubobject g' : V) ⟶ D)
+theorem homology'.map_desc (p : α.right = β.left) {D : V} (k : (kernelSubobject g' : V) ⟶ D)
     (z : imageToKernel f' g' w' ≫ k = 0) :
-    homology.map w w' α β p ≫ homology.desc f' g' w' k z =
-      homology.desc f g w (kernelSubobjectMap β ≫ k)
+    homology'.map w w' α β p ≫ homology'.desc f' g' w' k z =
+      homology'.desc f g w (kernelSubobjectMap β ≫ k)
         (by simp only [imageSubobjectMap_comp_imageToKernel_assoc w w' α β p, z, comp_zero]) := by
   ext
-  simp only [homology.π_desc, homology.π_map_assoc]
-#align homology.map_desc homology.map_desc
+  simp only [homology'.π_desc, homology'.π_map_assoc]
+#align homology.map_desc homology'.map_desc
 
 @[simp]
-theorem homology.map_id : homology.map w w (𝟙 _) (𝟙 _) rfl = 𝟙 _ := by
+theorem homology'.map_id : homology'.map w w (𝟙 _) (𝟙 _) rfl = 𝟙 _ := by
   ext
-  simp only [homology.π_map, kernelSubobjectMap_id, Category.id_comp, Category.comp_id]
-#align homology.map_id homology.map_id
+  simp only [homology'.π_map, kernelSubobjectMap_id, Category.id_comp, Category.comp_id]
+#align homology.map_id homology'.map_id
 
 /-- Auxiliary lemma for homology computations. -/
-theorem homology.comp_right_eq_comp_left {V : Type*} [Category V] {A₁ B₁ C₁ A₂ B₂ C₂ A₃ B₃ C₃ : V}
+theorem homology'.comp_right_eq_comp_left {V : Type*} [Category V] {A₁ B₁ C₁ A₂ B₂ C₂ A₃ B₃ C₃ : V}
     {f₁ : A₁ ⟶ B₁} {g₁ : B₁ ⟶ C₁} {f₂ : A₂ ⟶ B₂} {g₂ : B₂ ⟶ C₂} {f₃ : A₃ ⟶ B₃} {g₃ : B₃ ⟶ C₃}
     {α₁ : Arrow.mk f₁ ⟶ Arrow.mk f₂} {β₁ : Arrow.mk g₁ ⟶ Arrow.mk g₂}
     {α₂ : Arrow.mk f₂ ⟶ Arrow.mk f₃} {β₂ : Arrow.mk g₂ ⟶ Arrow.mk g₃} (p₁ : α₁.right = β₁.left)
     (p₂ : α₂.right = β₂.left) : (α₁ ≫ α₂).right = (β₁ ≫ β₂).left := by
   simp only [Arrow.comp_left, Arrow.comp_right, p₁, p₂]
-#align homology.comp_right_eq_comp_left homology.comp_right_eq_comp_left
+#align homology.comp_right_eq_comp_left homology'.comp_right_eq_comp_left
 
 @[reassoc]
-theorem homology.map_comp (p₁ : α₁.right = β₁.left) (p₂ : α₂.right = β₂.left) :
-    homology.map w₁ w₂ α₁ β₁ p₁ ≫ homology.map w₂ w₃ α₂ β₂ p₂ =
-      homology.map w₁ w₃ (α₁ ≫ α₂) (β₁ ≫ β₂) (homology.comp_right_eq_comp_left p₁ p₂) := by
+theorem homology'.map_comp (p₁ : α₁.right = β₁.left) (p₂ : α₂.right = β₂.left) :
+    homology'.map w₁ w₂ α₁ β₁ p₁ ≫ homology'.map w₂ w₃ α₂ β₂ p₂ =
+      homology'.map w₁ w₃ (α₁ ≫ α₂) (β₁ ≫ β₂) (homology'.comp_right_eq_comp_left p₁ p₂) := by
   ext
-  simp only [kernelSubobjectMap_comp, homology.π_map_assoc, homology.π_map, Category.assoc]
-#align homology.map_comp homology.map_comp
+  simp only [kernelSubobjectMap_comp, homology'.π_map_assoc, homology'.π_map, Category.assoc]
+#align homology.map_comp homology'.map_comp
 
 /-- An isomorphism between two three-term complexes induces an isomorphism on homology. -/
-def homology.mapIso (α : Arrow.mk f₁ ≅ Arrow.mk f₂) (β : Arrow.mk g₁ ≅ Arrow.mk g₂)
-    (p : α.hom.right = β.hom.left) : homology f₁ g₁ w₁ ≅ homology f₂ g₂ w₂ where
-  hom := homology.map w₁ w₂ α.hom β.hom p
+def homology'.mapIso (α : Arrow.mk f₁ ≅ Arrow.mk f₂) (β : Arrow.mk g₁ ≅ Arrow.mk g₂)
+    (p : α.hom.right = β.hom.left) : homology' f₁ g₁ w₁ ≅ homology' f₂ g₂ w₂ where
+  hom := homology'.map w₁ w₂ α.hom β.hom p
   inv :=
-    homology.map w₂ w₁ α.inv β.inv
+    homology'.map w₂ w₁ α.inv β.inv
       (by
         rw [← cancel_mono α.hom.right, ← Comma.comp_right, α.inv_hom_id, Comma.id_right, p, ←
           Comma.comp_left, β.inv_hom_id, Comma.id_left]
         rfl)
   hom_inv_id := by
-    rw [homology.map_comp, ← homology.map_id]
+    rw [homology'.map_comp, ← homology'.map_id]
     congr <;> simp only [Iso.hom_inv_id]
   inv_hom_id := by
-    rw [homology.map_comp, ← homology.map_id]
+    rw [homology'.map_comp, ← homology'.map_id]
     congr <;> simp only [Iso.inv_hom_id]
-#align homology.map_iso homology.mapIso
+#align homology.map_iso homology'.mapIso
 
 end
 
@@ -377,20 +383,20 @@ variable {A B C : V} {f : A ⟶ B} {g : B ⟶ C} (w : f ≫ g = 0) {f' : A ⟶ B
 (Note the objects are not changing here.)
 -/
 @[simps]
-def homology.congr (pf : f = f') (pg : g = g') : homology f g w ≅ homology f' g' w' where
-  hom := homology.map w w' ⟨𝟙 _, 𝟙 _, by aesop_cat⟩ ⟨𝟙 _, 𝟙 _, by aesop_cat⟩ rfl
-  inv := homology.map w' w ⟨𝟙 _, 𝟙 _, by aesop_cat⟩ ⟨𝟙 _, 𝟙 _, by aesop_cat⟩ rfl
+def homology'.congr (pf : f = f') (pg : g = g') : homology' f g w ≅ homology' f' g' w' where
+  hom := homology'.map w w' ⟨𝟙 _, 𝟙 _, by aesop_cat⟩ ⟨𝟙 _, 𝟙 _, by aesop_cat⟩ rfl
+  inv := homology'.map w' w ⟨𝟙 _, 𝟙 _, by aesop_cat⟩ ⟨𝟙 _, 𝟙 _, by aesop_cat⟩ rfl
   hom_inv_id := by
     obtain rfl := pf
     obtain rfl := pg
-    rw [homology.map_comp, ← homology.map_id]
+    rw [homology'.map_comp, ← homology'.map_id]
     congr <;> aesop_cat
   inv_hom_id := by
     obtain rfl := pf
     obtain rfl := pg
-    rw [homology.map_comp, ← homology.map_id]
+    rw [homology'.map_comp, ← homology'.map_id]
     congr <;> aesop_cat
-#align homology.congr homology.congr
+#align homology.congr homology'.congr
 
 end
 
@@ -435,17 +441,17 @@ theorem imageToKernel'_kernelSubobjectIso (w : f ≫ g = 0) :
 
 variable [HasCokernels V]
 
-/-- `homology f g w` can be computed as the cokernel of `imageToKernel' f g w`.
+/-- `homology' f g w` can be computed as the cokernel of `imageToKernel' f g w`.
 -/
-def homologyIsoCokernelImageToKernel' (w : f ≫ g = 0) :
-    homology f g w ≅ cokernel (imageToKernel' f g w) where
+def homology'IsoCokernelImageToKernel' (w : f ≫ g = 0) :
+    homology' f g w ≅ cokernel (imageToKernel' f g w) where
   hom := cokernel.map _ _ (imageSubobjectIso f).hom (kernelSubobjectIso g).hom
       (by simp only [imageSubobjectIso_imageToKernel'])
   inv := cokernel.map _ _ (imageSubobjectIso f).inv (kernelSubobjectIso g).inv
       (by simp only [imageToKernel'_kernelSubobjectIso])
   hom_inv_id := by
-    -- Just calling `ext` here uses the higher priority `homology.ext`,
-    -- which precomposes with `homology.π`.
+    -- Just calling `ext` here uses the higher priority `homology'.ext`,
+    -- which precomposes with `homology'.π`.
     -- As we are trying to work in terms of `cokernel`, it is better to use `coequalizer.hom_ext`.
     apply coequalizer.hom_ext
     simp only [Iso.hom_inv_id_assoc, cokernel.π_desc, cokernel.π_desc_assoc, Category.assoc,
@@ -455,18 +461,18 @@ def homologyIsoCokernelImageToKernel' (w : f ≫ g = 0) :
     ext
     simp only [Iso.inv_hom_id_assoc, cokernel.π_desc, Category.comp_id, cokernel.π_desc_assoc,
       Category.assoc]
-#align homology_iso_cokernel_image_to_kernel' homologyIsoCokernelImageToKernel'
+#align homology_iso_cokernel_image_to_kernel' homology'IsoCokernelImageToKernel'
 
 variable [HasEqualizers V]
 
 /-- `homology f g w` can be computed as the cokernel of `kernel.lift g f w`.
 -/
-def homologyIsoCokernelLift (w : f ≫ g = 0) : homology f g w ≅ cokernel (kernel.lift g f w) := by
-  refine' homologyIsoCokernelImageToKernel' f g w ≪≫ _
+def homology'IsoCokernelLift (w : f ≫ g = 0) : homology' f g w ≅ cokernel (kernel.lift g f w) := by
+  refine' homology'IsoCokernelImageToKernel' f g w ≪≫ _
   have p : factorThruImage f ≫ imageToKernel' f g w = kernel.lift g f w := by
     ext
     simp [imageToKernel']
   exact (cokernelEpiComp _ _).symm ≪≫ cokernelIsoOfEq p
-#align homology_iso_cokernel_lift homologyIsoCokernelLift
+#align homology_iso_cokernel_lift homology'IsoCokernelLift
 
 end imageToKernel'

--- a/Mathlib/Algebra/Homology/ModuleCat.lean
+++ b/Mathlib/Algebra/Homology/ModuleCat.lean
@@ -35,8 +35,8 @@ namespace ModuleCat
 /-- To prove that two maps out of a homology group are equal,
 it suffices to check they are equal on the images of cycles.
 -/
-theorem homology_ext {L M N K : ModuleCat R} {f : L ⟶ M} {g : M ⟶ N} (w : f ≫ g = 0)
-    {h k : homology f g w ⟶ K}
+theorem homology'_ext {L M N K : ModuleCat R} {f : L ⟶ M} {g : M ⟶ N} (w : f ≫ g = 0)
+    {h k : homology' f g w ⟶ K}
     (w :
       ∀ x : LinearMap.ker g,
         h (cokernel.π (imageToKernel _ _ w) (toKernelSubobject x)) =
@@ -49,51 +49,51 @@ theorem homology_ext {L M N K : ModuleCat R} {f : L ⟶ M} {g : M ⟶ N} (w : f 
     ModuleCat.kernelIsoKer g).toLinearEquiv.toEquiv.symm.surjective n
   exact w n
 set_option linter.uppercaseLean3 false in
-#align Module.homology_ext ModuleCat.homology_ext
+#align Module.homology_ext ModuleCat.homology'_ext
 
 /-- Bundle an element `C.X i` such that `C.dFrom i x = 0` as a term of `C.cycles i`. -/
-abbrev toCycles {C : HomologicalComplex (ModuleCat.{u} R) c} {i : ι}
-    (x : LinearMap.ker (C.dFrom i)) : (C.cycles i : Type u) :=
+abbrev toCycles' {C : HomologicalComplex (ModuleCat.{u} R) c} {i : ι}
+    (x : LinearMap.ker (C.dFrom i)) : (C.cycles' i : Type u) :=
   toKernelSubobject x
 set_option linter.uppercaseLean3 false in
-#align Module.to_cycles ModuleCat.toCycles
+#align Module.to_cycles ModuleCat.toCycles'
 
 @[ext]
-theorem cycles_ext {C : HomologicalComplex (ModuleCat.{u} R) c} {i : ι}
-    {x y : (C.cycles i : Type u)}
-    (w : (C.cycles i).arrow x = (C.cycles i).arrow y) : x = y := by
-  apply_fun (C.cycles i).arrow using (ModuleCat.mono_iff_injective _).mp (cycles C i).arrow_mono
+theorem cycles'_ext {C : HomologicalComplex (ModuleCat.{u} R) c} {i : ι}
+    {x y : (C.cycles' i : Type u)}
+    (w : (C.cycles' i).arrow x = (C.cycles' i).arrow y) : x = y := by
+  apply_fun (C.cycles' i).arrow using (ModuleCat.mono_iff_injective _).mp (cycles' C i).arrow_mono
   exact w
 set_option linter.uppercaseLean3 false in
-#align Module.cycles_ext ModuleCat.cycles_ext
+#align Module.cycles_ext ModuleCat.cycles'_ext
 
 -- porting note: both proofs by `rw` were proofs by `simp` which no longer worked
 -- see https://github.com/leanprover-community/mathlib4/issues/5026
 @[simp]
-theorem cyclesMap_toCycles (f : C ⟶ D) {i : ι} (x : LinearMap.ker (C.dFrom i)) :
-    (cyclesMap f i) (toCycles x) = toCycles ⟨f.f i x.1, by
+theorem cycles'Map_toCycles' (f : C ⟶ D) {i : ι} (x : LinearMap.ker (C.dFrom i)) :
+    (cycles'Map f i) (toCycles' x) = toCycles' ⟨f.f i x.1, by
       -- This used to be `rw`, but we need `erw` after leanprover/lean4#2644
       rw [LinearMap.mem_ker]; erw [Hom.comm_from_apply, x.2, map_zero]⟩ := by
   ext
   -- This used to be `rw`, but we need `erw` after leanprover/lean4#2644
-  erw [cyclesMap_arrow_apply, toKernelSubobject_arrow, toKernelSubobject_arrow]
+  erw [cycles'Map_arrow_apply, toKernelSubobject_arrow, toKernelSubobject_arrow]
   rfl
 set_option linter.uppercaseLean3 false in
-#align Module.cycles_map_to_cycles ModuleCat.cyclesMap_toCycles
+#align Module.cycles_map_to_cycles ModuleCat.cycles'Map_toCycles'
 
 /-- Build a term of `C.homology i` from an element `C.X i` such that `C.d_from i x = 0`. -/
-abbrev toHomology {C : HomologicalComplex (ModuleCat.{u} R) c} {i : ι}
-    (x : LinearMap.ker (C.dFrom i)) : C.homology i :=
-  homology.π (C.dTo i) (C.dFrom i) _ (toCycles x)
+abbrev toHomology' {C : HomologicalComplex (ModuleCat.{u} R) c} {i : ι}
+    (x : LinearMap.ker (C.dFrom i)) : C.homology' i :=
+  homology'.π (C.dTo i) (C.dFrom i) _ (toCycles' x)
 set_option linter.uppercaseLean3 false in
-#align Module.to_homology ModuleCat.toHomology
+#align Module.to_homology ModuleCat.toHomology'
 
 @[ext]
-theorem homology_ext' {M : ModuleCat R} (i : ι) {h k : C.homology i ⟶ M}
-    (w : ∀ x : LinearMap.ker (C.dFrom i), h (toHomology x) = k (toHomology x)) : h = k :=
-  homology_ext _ w
+theorem homology'_ext' {M : ModuleCat R} (i : ι) {h k : C.homology' i ⟶ M}
+    (w : ∀ x : LinearMap.ker (C.dFrom i), h (toHomology' x) = k (toHomology' x)) : h = k :=
+  homology'_ext _ w
 set_option linter.uppercaseLean3 false in
-#align Module.homology_ext' ModuleCat.homology_ext'
+#align Module.homology_ext' ModuleCat.homology'_ext'
 
 -- porting note: `erw` had to be used instead of `simp`
 -- see https://github.com/leanprover-community/mathlib4/issues/5026
@@ -101,13 +101,13 @@ set_option linter.uppercaseLean3 false in
 specialized to the setting of `V = Module R`,
 to demonstrate the use of extensionality lemmas for homology in `Module R`. -/
 example (f g : C ⟶ D) (h : Homotopy f g) (i : ι) :
-    (homologyFunctor (ModuleCat.{u} R) c i).map f =
-      (homologyFunctor (ModuleCat.{u} R) c i).map g := by
+    (homology'Functor (ModuleCat.{u} R) c i).map f =
+      (homology'Functor (ModuleCat.{u} R) c i).map g := by
   -- To check that two morphisms out of a homology group agree, it suffices to check on cycles:
-  apply homology_ext
+  apply homology'_ext
   intro x
-  simp only [homologyFunctor_map]
-  erw [homology.π_map_apply, homology.π_map_apply]
+  simp only [homology'Functor_map]
+  erw [homology'.π_map_apply, homology'.π_map_apply]
   -- To check that two elements are equal mod boundaries, it suffices to exhibit a boundary:
   refine' cokernel_π_imageSubobject_ext _ _ ((toPrev i h.hom) x.1) _
   -- Moreover, to check that two cycles are equal, it suffices to check their underlying elements:

--- a/Mathlib/Algebra/Homology/Opposite.lean
+++ b/Mathlib/Algebra/Homology/Opposite.lean
@@ -64,23 +64,24 @@ theorem imageToKernel_unop {X Y Z : Vᵒᵖ} (f : X ⟶ Y) (g : Y ⟶ Z) (w : f 
 
 /-- Given `f, g` with `f ≫ g = 0`, the homology of `g.op, f.op` is the opposite of the homology of
 `f, g`. -/
-def homologyOp {X Y Z : V} (f : X ⟶ Y) (g : Y ⟶ Z) (w : f ≫ g = 0) :
-    homology g.op f.op (by rw [← op_comp, w, op_zero]) ≅ Opposite.op (homology f g w) :=
+def homology'Op {X Y Z : V} (f : X ⟶ Y) (g : Y ⟶ Z) (w : f ≫ g = 0) :
+    homology' g.op f.op (by rw [← op_comp, w, op_zero]) ≅ Opposite.op (homology' f g w) :=
   cokernelIsoOfEq (imageToKernel_op _ _ w) ≪≫ cokernelEpiComp _ _ ≪≫ cokernelCompIsIso _ _ ≪≫
-    cokernelOpOp _ ≪≫ (homologyIsoKernelDesc _ _ _ ≪≫
+    cokernelOpOp _ ≪≫ (homology'IsoKernelDesc _ _ _ ≪≫
     kernelIsoOfEq (by ext; simp only [image.fac, cokernel.π_desc, cokernel.π_desc_assoc]) ≪≫
     kernelCompMono _ (image.ι g)).op
-#align homology_op homologyOp
+#align homology_op homology'Op
 
 /-- Given morphisms `f, g` in `Vᵒᵖ` with `f ≫ g = 0`, the homology of `g.unop, f.unop` is the
 opposite of the homology of `f, g`. -/
-def homologyUnop {X Y Z : Vᵒᵖ} (f : X ⟶ Y) (g : Y ⟶ Z) (w : f ≫ g = 0) :
-    homology g.unop f.unop (by rw [← unop_comp, w, unop_zero]) ≅ Opposite.unop (homology f g w) :=
+def homology'Unop {X Y Z : Vᵒᵖ} (f : X ⟶ Y) (g : Y ⟶ Z) (w : f ≫ g = 0) :
+    homology' g.unop f.unop (by rw [← unop_comp, w, unop_zero]) ≅
+      Opposite.unop (homology' f g w) :=
   cokernelIsoOfEq (imageToKernel_unop _ _ w) ≪≫ cokernelEpiComp _ _ ≪≫ cokernelCompIsIso _ _ ≪≫
-    cokernelUnopUnop _ ≪≫ (homologyIsoKernelDesc _ _ _ ≪≫
+    cokernelUnopUnop _ ≪≫ (homology'IsoKernelDesc _ _ _ ≪≫
     kernelIsoOfEq (by ext; simp only [image.fac, cokernel.π_desc, cokernel.π_desc_assoc]) ≪≫
     kernelCompMono _ (image.ι g)).unop
-#align homology_unop homologyUnop
+#align homology_unop homology'Unop
 
 end
 
@@ -255,30 +256,30 @@ end
 variable [Abelian V] (C : HomologicalComplex V c) (i : ι)
 
 /-- Auxiliary tautological definition for `homologyOp`. -/
-def homologyOpDef : C.op.homology i ≅
-    _root_.homology (C.dFrom i).op (C.dTo i).op (by rw [← op_comp, C.dTo_comp_dFrom i, op_zero]) :=
+def homology'OpDef : C.op.homology' i ≅
+    _root_.homology' (C.dFrom i).op (C.dTo i).op (by rw [← op_comp, C.dTo_comp_dFrom i, op_zero]) :=
   Iso.refl _
-#align homological_complex.homology_op_def HomologicalComplex.homologyOpDef
+#align homological_complex.homology_op_def HomologicalComplex.homology'OpDef
 
 /-- Given a complex `C` of objects in `V`, the `i`th homology of its 'opposite' complex (with
 objects in `Vᵒᵖ`) is the opposite of the `i`th homology of `C`. -/
-nonrec def homologyOp : C.op.homology i ≅ Opposite.op (C.homology i) :=
-  homologyOpDef _ _ ≪≫ homologyOp _ _ _
-#align homological_complex.homology_op HomologicalComplex.homologyOp
+nonrec def homology'Op : C.op.homology' i ≅ Opposite.op (C.homology' i) :=
+  homology'OpDef _ _ ≪≫ homology'Op _ _ _
+#align homological_complex.homology_op HomologicalComplex.homology'Op
 
 /-- Auxiliary tautological definition for `homologyUnop`. -/
-def homologyUnopDef (C : HomologicalComplex Vᵒᵖ c) :
-    C.unop.homology i ≅
-      _root_.homology (C.dFrom i).unop (C.dTo i).unop
+def homology'UnopDef (C : HomologicalComplex Vᵒᵖ c) :
+    C.unop.homology' i ≅
+      _root_.homology' (C.dFrom i).unop (C.dTo i).unop
         (by rw [← unop_comp, C.dTo_comp_dFrom i, unop_zero]) :=
   Iso.refl _
-#align homological_complex.homology_unop_def HomologicalComplex.homologyUnopDef
+#align homological_complex.homology_unop_def HomologicalComplex.homology'UnopDef
 
 /-- Given a complex `C` of objects in `Vᵒᵖ`, the `i`th homology of its 'opposite' complex (with
 objects in `V`) is the opposite of the `i`th homology of `C`. -/
-nonrec def homologyUnop (C : HomologicalComplex Vᵒᵖ c) :
-    C.unop.homology i ≅ Opposite.unop (C.homology i) :=
-  homologyUnopDef _ _ ≪≫ homologyUnop _ _ _
-#align homological_complex.homology_unop HomologicalComplex.homologyUnop
+nonrec def homology'Unop (C : HomologicalComplex Vᵒᵖ c) :
+    C.unop.homology' i ≅ Opposite.unop (C.homology' i) :=
+  homology'UnopDef _ _ ≪≫ homology'Unop _ _ _
+#align homological_complex.homology_unop HomologicalComplex.homology'Unop
 
 end HomologicalComplex

--- a/Mathlib/Algebra/Homology/QuasiIso.lean
+++ b/Mathlib/Algebra/Homology/QuasiIso.lean
@@ -35,33 +35,34 @@ variable {c : ComplexShape ι} {C D E : HomologicalComplex V c}
 
 /-- A chain map is a quasi-isomorphism if it induces isomorphisms on homology.
 -/
-class QuasiIso (f : C ⟶ D) : Prop where
-  isIso : ∀ i, IsIso ((homologyFunctor V c i).map f)
-#align quasi_iso QuasiIso
+class QuasiIso' (f : C ⟶ D) : Prop where
+  isIso : ∀ i, IsIso ((homology'Functor V c i).map f)
+#align quasi_iso QuasiIso'
 
-attribute [instance] QuasiIso.isIso
+attribute [instance] QuasiIso'.isIso
 
-instance (priority := 100) quasiIso_of_iso (f : C ⟶ D) [IsIso f] : QuasiIso f where
+instance (priority := 100) quasiIso'_of_iso (f : C ⟶ D) [IsIso f] : QuasiIso' f where
   isIso i := by
-    change IsIso ((homologyFunctor V c i).mapIso (asIso f)).hom
+    change IsIso ((homology'Functor V c i).mapIso (asIso f)).hom
     infer_instance
-#align quasi_iso_of_iso quasiIso_of_iso
+#align quasi_iso_of_iso quasiIso'_of_iso
 
-instance quasiIso_comp (f : C ⟶ D) [QuasiIso f] (g : D ⟶ E) [QuasiIso g] : QuasiIso (f ≫ g) where
+instance quasiIso'_comp (f : C ⟶ D) [QuasiIso' f] (g : D ⟶ E) [QuasiIso' g] :
+    QuasiIso' (f ≫ g) where
   isIso i := by
     rw [Functor.map_comp]
     infer_instance
-#align quasi_iso_comp quasiIso_comp
+#align quasi_iso_comp quasiIso'_comp
 
-theorem quasiIso_of_comp_left (f : C ⟶ D) [QuasiIso f] (g : D ⟶ E) [QuasiIso (f ≫ g)] :
-    QuasiIso g :=
-  { isIso := fun i => IsIso.of_isIso_fac_left ((homologyFunctor V c i).map_comp f g).symm }
-#align quasi_iso_of_comp_left quasiIso_of_comp_left
+theorem quasiIso'_of_comp_left (f : C ⟶ D) [QuasiIso' f] (g : D ⟶ E) [QuasiIso' (f ≫ g)] :
+    QuasiIso' g :=
+  { isIso := fun i => IsIso.of_isIso_fac_left ((homology'Functor V c i).map_comp f g).symm }
+#align quasi_iso_of_comp_left quasiIso'_of_comp_left
 
-theorem quasiIso_of_comp_right (f : C ⟶ D) (g : D ⟶ E) [QuasiIso g] [QuasiIso (f ≫ g)] :
-    QuasiIso f :=
-  { isIso := fun i => IsIso.of_isIso_fac_right ((homologyFunctor V c i).map_comp f g).symm }
-#align quasi_iso_of_comp_right quasiIso_of_comp_right
+theorem quasiIso'_of_comp_right (f : C ⟶ D) (g : D ⟶ E) [QuasiIso' g] [QuasiIso' (f ≫ g)] :
+    QuasiIso' f :=
+  { isIso := fun i => IsIso.of_isIso_fac_right ((homology'Functor V c i).map_comp f g).symm }
+#align quasi_iso_of_comp_right quasiIso'_of_comp_right
 
 namespace HomotopyEquiv
 
@@ -71,21 +72,21 @@ variable {W : Type*} [Category W] [Preadditive W] [HasCokernels W] [HasImages W]
   [HasZeroObject W] [HasImageMaps W]
 
 /-- A homotopy equivalence is a quasi-isomorphism. -/
-theorem toQuasiIso {C D : HomologicalComplex W c} (e : HomotopyEquiv C D) : QuasiIso e.hom :=
+theorem toQuasiIso' {C D : HomologicalComplex W c} (e : HomotopyEquiv C D) : QuasiIso' e.hom :=
   ⟨fun i => by
-    refine' ⟨⟨(homologyFunctor W c i).map e.inv, _⟩⟩
-    simp only [← Functor.map_comp, ← (homologyFunctor W c i).map_id]
-    constructor <;> apply homology_map_eq_of_homotopy
+    refine' ⟨⟨(homology'Functor W c i).map e.inv, _⟩⟩
+    simp only [← Functor.map_comp, ← (homology'Functor W c i).map_id]
+    constructor <;> apply homology'_map_eq_of_homotopy
     exacts [e.homotopyHomInvId, e.homotopyInvHomId]⟩
-#align homotopy_equiv.to_quasi_iso HomotopyEquiv.toQuasiIso
+#align homotopy_equiv.to_quasi_iso HomotopyEquiv.toQuasiIso'
 
-theorem toQuasiIso_inv {C D : HomologicalComplex W c} (e : HomotopyEquiv C D) (i : ι) :
-    (@asIso _ _ _ _ _ (e.toQuasiIso.1 i)).inv = (homologyFunctor W c i).map e.inv := by
+theorem toQuasiIso'_inv {C D : HomologicalComplex W c} (e : HomotopyEquiv C D) (i : ι) :
+    (@asIso _ _ _ _ _ (e.toQuasiIso'.1 i)).inv = (homology'Functor W c i).map e.inv := by
   symm
-  haveI := e.toQuasiIso.1 i -- Porting note: Added this to get `asIso_hom` to work.
-  simp only [← Iso.hom_comp_eq_id, asIso_hom, ← Functor.map_comp, ← (homologyFunctor W c i).map_id,
-    homology_map_eq_of_homotopy e.homotopyHomInvId _]
-#align homotopy_equiv.to_quasi_iso_inv HomotopyEquiv.toQuasiIso_inv
+  haveI := e.toQuasiIso'.1 i -- Porting note: Added this to get `asIso_hom` to work.
+  simp only [← Iso.hom_comp_eq_id, asIso_hom, ← Functor.map_comp,
+    ← (homology'Functor W c i).map_id, homology'_map_eq_of_homotopy e.homotopyHomInvId _]
+#align homotopy_equiv.to_quasi_iso_inv HomotopyEquiv.toQuasiIso'_inv
 
 end
 
@@ -99,27 +100,27 @@ variable {W : Type*} [Category W] [Abelian W]
 
 section
 
-variable {X : ChainComplex W ℕ} {Y : W} (f : X ⟶ (ChainComplex.single₀ _).obj Y) [hf : QuasiIso f]
+variable {X : ChainComplex W ℕ} {Y : W} (f : X ⟶ (ChainComplex.single₀ _).obj Y) [hf : QuasiIso' f]
 
 /-- If a chain map `f : X ⟶ Y[0]` is a quasi-isomorphism, then the cokernel of the differential
 `d : X₁ → X₀` is isomorphic to `Y`. -/
 noncomputable def toSingle₀CokernelAtZeroIso : cokernel (X.d 1 0) ≅ Y :=
-  X.homologyZeroIso.symm.trans
-    ((@asIso _ _ _ _ _ (hf.1 0)).trans ((ChainComplex.homologyFunctor0Single₀ W).app Y))
+  X.homology'ZeroIso.symm.trans
+    ((@asIso _ _ _ _ _ (hf.1 0)).trans ((ChainComplex.homology'Functor0Single₀ W).app Y))
 #align homological_complex.hom.to_single₀_cokernel_at_zero_iso HomologicalComplex.Hom.toSingle₀CokernelAtZeroIso
 
-theorem toSingle₀CokernelAtZeroIso_hom_eq [hf : QuasiIso f] :
+theorem toSingle₀CokernelAtZeroIso_hom_eq [hf : QuasiIso' f] :
     f.toSingle₀CokernelAtZeroIso.hom =
       cokernel.desc (X.d 1 0) (f.f 0) (by rw [← f.2 1 0 rfl]; exact comp_zero) := by
   ext
-  dsimp only [toSingle₀CokernelAtZeroIso, ChainComplex.homologyZeroIso, homologyOfZeroRight,
-    homology.mapIso, ChainComplex.homologyFunctor0Single₀, cokernel.map]
+  dsimp only [toSingle₀CokernelAtZeroIso, ChainComplex.homology'ZeroIso, homology'OfZeroRight,
+    homology'.mapIso, ChainComplex.homology'Functor0Single₀, cokernel.map]
   dsimp [asIso]
-  simp only [cokernel.π_desc, Category.assoc, homology.map_desc, cokernel.π_desc_assoc]
-  simp [homology.desc, Iso.refl_inv (X.X 0)]
+  simp only [cokernel.π_desc, Category.assoc, homology'.map_desc, cokernel.π_desc_assoc]
+  simp [homology'.desc, Iso.refl_inv (X.X 0)]
 #align homological_complex.hom.to_single₀_cokernel_at_zero_iso_hom_eq HomologicalComplex.Hom.toSingle₀CokernelAtZeroIso_hom_eq
 
-theorem to_single₀_epi_at_zero [hf : QuasiIso f] : Epi (f.f 0) := by
+theorem to_single₀_epi_at_zero [hf : QuasiIso' f] : Epi (f.f 0) := by
   constructor
   intro Z g h Hgh
   rw [← cokernel.π_desc (X.d 1 0) (f.f 0) (by rw [← f.2 1 0 rfl]; exact comp_zero),
@@ -127,22 +128,22 @@ theorem to_single₀_epi_at_zero [hf : QuasiIso f] : Epi (f.f 0) := by
   rw [(@cancel_epi _ _ _ _ _ _ (epi_comp _ _) _ _).1 Hgh]
 #align homological_complex.hom.to_single₀_epi_at_zero HomologicalComplex.Hom.to_single₀_epi_at_zero
 
-theorem to_single₀_exact_d_f_at_zero [hf : QuasiIso f] : Exact (X.d 1 0) (f.f 0) := by
-  rw [Preadditive.exact_iff_homology_zero]
+theorem to_single₀_exact_d_f_at_zero [hf : QuasiIso' f] : Exact (X.d 1 0) (f.f 0) := by
+  rw [Preadditive.exact_iff_homology'_zero]
   have h : X.d 1 0 ≫ f.f 0 = 0 := by
     simp only [← f.2 1 0 rfl, ChainComplex.single₀_obj_X_d, comp_zero]
-  refine' ⟨h, Nonempty.intro (homologyIsoKernelDesc _ _ _ ≪≫ _)⟩
+  refine' ⟨h, Nonempty.intro (homology'IsoKernelDesc _ _ _ ≪≫ _)⟩
   suffices IsIso (cokernel.desc _ _ h) by apply kernel.ofMono
   rw [← toSingle₀CokernelAtZeroIso_hom_eq]
   infer_instance
 #align homological_complex.hom.to_single₀_exact_d_f_at_zero HomologicalComplex.Hom.to_single₀_exact_d_f_at_zero
 
-theorem to_single₀_exact_at_succ [hf : QuasiIso f] (n : ℕ) :
+theorem to_single₀_exact_at_succ [hf : QuasiIso' f] (n : ℕ) :
     Exact (X.d (n + 2) (n + 1)) (X.d (n + 1) n) :=
-  (Preadditive.exact_iff_homology_zero _ _).2
+  (Preadditive.exact_iff_homology'_zero _ _).2
     ⟨X.d_comp_d _ _ _,
-      ⟨(ChainComplex.homologySuccIso _ _).symm.trans
-          ((@asIso _ _ _ _ _ (hf.1 (n + 1))).trans homologyZeroZero)⟩⟩
+      ⟨(ChainComplex.homology'SuccIso _ _).symm.trans
+          ((@asIso _ _ _ _ _ (hf.1 (n + 1))).trans homology'ZeroZero)⟩⟩
 #align homological_complex.hom.to_single₀_exact_at_succ HomologicalComplex.Hom.to_single₀_exact_at_succ
 
 end
@@ -153,26 +154,26 @@ variable {X : CochainComplex W ℕ} {Y : W} (f : (CochainComplex.single₀ _).ob
 
 /-- If a cochain map `f : Y[0] ⟶ X` is a quasi-isomorphism, then the kernel of the differential
 `d : X₀ → X₁` is isomorphic to `Y`. -/
-noncomputable def fromSingle₀KernelAtZeroIso [hf : QuasiIso f] : kernel (X.d 0 1) ≅ Y :=
-  X.homologyZeroIso.symm.trans
+noncomputable def fromSingle₀KernelAtZeroIso [hf : QuasiIso' f] : kernel (X.d 0 1) ≅ Y :=
+  X.homology'ZeroIso.symm.trans
     ((@asIso _ _ _ _ _ (hf.1 0)).symm.trans ((CochainComplex.homologyFunctor0Single₀ W).app Y))
 #align homological_complex.hom.from_single₀_kernel_at_zero_iso HomologicalComplex.Hom.fromSingle₀KernelAtZeroIso
 
-theorem fromSingle₀KernelAtZeroIso_inv_eq [hf : QuasiIso f] :
+theorem fromSingle₀KernelAtZeroIso_inv_eq [hf : QuasiIso' f] :
     f.fromSingle₀KernelAtZeroIso.inv =
       kernel.lift (X.d 0 1) (f.f 0) (by rw [f.2 0 1 rfl]; exact zero_comp) := by
   ext
-  dsimp only [fromSingle₀KernelAtZeroIso, CochainComplex.homologyZeroIso, homologyOfZeroLeft,
-    homology.mapIso, CochainComplex.homologyFunctor0Single₀, kernel.map]
+  dsimp only [fromSingle₀KernelAtZeroIso, CochainComplex.homology'ZeroIso, homology'OfZeroLeft,
+    homology'.mapIso, CochainComplex.homologyFunctor0Single₀, kernel.map]
   simp only [Iso.trans_inv, Iso.app_inv, Iso.symm_inv, Category.assoc, equalizer_as_kernel,
     kernel.lift_ι]
   dsimp [asIso]
-  simp only [Category.assoc, homology.π_map, cokernelZeroIsoTarget_hom,
-    cokernelIsoOfEq_hom_comp_desc, kernelSubobject_arrow, homology.π_map_assoc, IsIso.inv_comp_eq]
-  simp [homology.π, kernelSubobjectMap_comp, Iso.refl_hom (X.X 0), Category.comp_id]
+  simp only [Category.assoc, homology'.π_map, cokernelZeroIsoTarget_hom,
+    cokernelIsoOfEq_hom_comp_desc, kernelSubobject_arrow, homology'.π_map_assoc, IsIso.inv_comp_eq]
+  simp [homology'.π, kernelSubobjectMap_comp, Iso.refl_hom (X.X 0), Category.comp_id]
 #align homological_complex.hom.from_single₀_kernel_at_zero_iso_inv_eq HomologicalComplex.Hom.fromSingle₀KernelAtZeroIso_inv_eq
 
-theorem from_single₀_mono_at_zero [hf : QuasiIso f] : Mono (f.f 0) := by
+theorem from_single₀_mono_at_zero [hf : QuasiIso' f] : Mono (f.f 0) := by
   constructor
   intro Z g h Hgh
   rw [← kernel.lift_ι (X.d 0 1) (f.f 0) (by rw [f.2 0 1 rfl]; exact zero_comp),
@@ -180,22 +181,22 @@ theorem from_single₀_mono_at_zero [hf : QuasiIso f] : Mono (f.f 0) := by
   rw [(@cancel_mono _ _ _ _ _ _ (mono_comp _ _) _ _).1 Hgh]
 #align homological_complex.hom.from_single₀_mono_at_zero HomologicalComplex.Hom.from_single₀_mono_at_zero
 
-theorem from_single₀_exact_f_d_at_zero [hf : QuasiIso f] : Exact (f.f 0) (X.d 0 1) := by
-  rw [Preadditive.exact_iff_homology_zero]
+theorem from_single₀_exact_f_d_at_zero [hf : QuasiIso' f] : Exact (f.f 0) (X.d 0 1) := by
+  rw [Preadditive.exact_iff_homology'_zero]
   have h : f.f 0 ≫ X.d 0 1 = 0 := by
     simp only [HomologicalComplex.Hom.comm, CochainComplex.single₀_obj_X_d, zero_comp]
-  refine' ⟨h, Nonempty.intro (homologyIsoCokernelLift _ _ _ ≪≫ _)⟩
+  refine' ⟨h, Nonempty.intro (homology'IsoCokernelLift _ _ _ ≪≫ _)⟩
   suffices IsIso (kernel.lift (X.d 0 1) (f.f 0) h) by apply cokernel.ofEpi
   rw [← fromSingle₀KernelAtZeroIso_inv_eq f]
   infer_instance
 #align homological_complex.hom.from_single₀_exact_f_d_at_zero HomologicalComplex.Hom.from_single₀_exact_f_d_at_zero
 
-theorem from_single₀_exact_at_succ [hf : QuasiIso f] (n : ℕ) :
+theorem from_single₀_exact_at_succ [hf : QuasiIso' f] (n : ℕ) :
     Exact (X.d n (n + 1)) (X.d (n + 1) (n + 2)) :=
-  (Preadditive.exact_iff_homology_zero _ _).2
+  (Preadditive.exact_iff_homology'_zero _ _).2
     ⟨X.d_comp_d _ _ _,
-      ⟨(CochainComplex.homologySuccIso _ _).symm.trans
-          ((@asIso _ _ _ _ _ (hf.1 (n + 1))).symm.trans homologyZeroZero)⟩⟩
+      ⟨(CochainComplex.homology'SuccIso _ _).symm.trans
+          ((@asIso _ _ _ _ _ (hf.1 (n + 1))).symm.trans homology'ZeroZero)⟩⟩
 #align homological_complex.hom.from_single₀_exact_at_succ HomologicalComplex.Hom.from_single₀_exact_at_succ
 
 end
@@ -207,11 +208,11 @@ end HomologicalComplex.Hom
 variable {A : Type*} [Category A] [Abelian A] {B : Type*} [Category B] [Abelian B] (F : A ⥤ B)
   [Functor.Additive F] [PreservesFiniteLimits F] [PreservesFiniteColimits F] [Faithful F]
 
-theorem CategoryTheory.Functor.quasiIso_of_map_quasiIso {C D : HomologicalComplex A c} (f : C ⟶ D)
-    (hf : QuasiIso ((F.mapHomologicalComplex _).map f)) : QuasiIso f :=
+theorem CategoryTheory.Functor.quasiIso'_of_map_quasiIso' {C D : HomologicalComplex A c}
+    (f : C ⟶ D) (hf : QuasiIso' ((F.mapHomologicalComplex _).map f)) : QuasiIso' f :=
   ⟨fun i =>
-    haveI : IsIso (F.map ((homologyFunctor A c i).map f)) := by
-      rw [← Functor.comp_map, ← NatIso.naturality_2 (F.homologyFunctorIso i) f, Functor.comp_map]
+    haveI : IsIso (F.map ((homology'Functor A c i).map f)) := by
+      rw [← Functor.comp_map, ← NatIso.naturality_2 (F.homology'FunctorIso i) f, Functor.comp_map]
       infer_instance
     isIso_of_reflects_iso _ F⟩
-#align category_theory.functor.quasi_iso_of_map_quasi_iso CategoryTheory.Functor.quasiIso_of_map_quasiIso
+#align category_theory.functor.quasi_iso_of_map_quasi_iso CategoryTheory.Functor.quasiIso'_of_map_quasiIso'

--- a/Mathlib/Algebra/Homology/ShortComplex/HomologicalComplex.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/HomologicalComplex.lean
@@ -64,4 +64,13 @@ noncomputable abbrev sc (i : ι) := (shortComplexFunctor C c i).obj K
 noncomputable abbrev isoSc' (i j k : ι) (hi : c.prev j = i) (hk : c.next j = k) :
     K.sc j ≅ K.sc' i j k := (natIsoSc' C c i j k hi hk).app K
 
+abbrev HasHomology (i : ι) := (K.sc i).HasHomology
+
+variable (i : ι) [K.HasHomology i] [L.HasHomology i] [M.HasHomology i]
+
+noncomputable def homology := (K.sc i).homology
+noncomputable def cycles := (K.sc i).cycles
+noncomputable def homologyπ : K.cycles i ⟶ K.homology i := (K.sc i).homologyπ
+noncomputable def iCycles : K.cycles i ⟶ K.X i := (K.sc i).iCycles
+
 end HomologicalComplex

--- a/Mathlib/Algebra/Homology/ShortComplex/HomologicalComplex.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/HomologicalComplex.lean
@@ -64,6 +64,8 @@ noncomputable abbrev sc (i : ι) := (shortComplexFunctor C c i).obj K
 noncomputable abbrev isoSc' (i j k : ι) (hi : c.prev j = i) (hk : c.next j = k) :
     K.sc j ≅ K.sc' i j k := (natIsoSc' C c i j k hi hk).app K
 
+/-- A homological complex `K` has homology in degree `i` if the associated
+short complex `K.sc i` has. -/
 abbrev HasHomology (i : ι) := (K.sc i).HasHomology
 
 variable (i : ι) [K.HasHomology i] [L.HasHomology i] [M.HasHomology i]

--- a/Mathlib/Algebra/Homology/ShortComplex/HomologicalComplex.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/HomologicalComplex.lean
@@ -68,9 +68,16 @@ abbrev HasHomology (i : ι) := (K.sc i).HasHomology
 
 variable (i : ι) [K.HasHomology i] [L.HasHomology i] [M.HasHomology i]
 
+/-- The homology in degree `i` of a homological complex. -/
 noncomputable def homology := (K.sc i).homology
+
+/-- The cycles in degree `i` of a homological complex. -/
 noncomputable def cycles := (K.sc i).cycles
-noncomputable def homologyπ : K.cycles i ⟶ K.homology i := (K.sc i).homologyπ
+
+/-- The inclusion of the cycles of a homological complex. -/
 noncomputable def iCycles : K.cycles i ⟶ K.X i := (K.sc i).iCycles
+
+/-- The homology class map from cycles to the homology of a homological complex. -/
+noncomputable def homologyπ : K.cycles i ⟶ K.homology i := (K.sc i).homologyπ
 
 end HomologicalComplex

--- a/Mathlib/Algebra/Homology/Single.lean
+++ b/Mathlib/Algebra/Homology/Single.lean
@@ -193,26 +193,26 @@ variable [HasEqualizers V] [HasCokernels V] [HasImages V] [HasImageMaps V]
 /-- Sending objects to chain complexes supported at `0` then taking `0`-th homology
 is the same as doing nothing.
 -/
-noncomputable def homologyFunctor0Single₀ : single₀ V ⋙ homologyFunctor V _ 0 ≅ 𝟭 V :=
-  NatIso.ofComponents (fun X => homology.congr _ _ (by simp) (by simp) ≪≫ homologyZeroZero)
+noncomputable def homology'Functor0Single₀ : single₀ V ⋙ homology'Functor V _ 0 ≅ 𝟭 V :=
+  NatIso.ofComponents (fun X => homology'.congr _ _ (by simp) (by simp) ≪≫ homology'ZeroZero)
     fun f => by
       -- Porting note: why can't `aesop_cat` do this?
       dsimp
       ext
       simp
-#align chain_complex.homology_functor_0_single₀ ChainComplex.homologyFunctor0Single₀
+#align chain_complex.homology_functor_0_single₀ ChainComplex.homology'Functor0Single₀
 
 /-- Sending objects to chain complexes supported at `0` then taking `(n+1)`-st homology
 is the same as the zero functor.
 -/
-noncomputable def homologyFunctorSuccSingle₀ (n : ℕ) :
-    single₀ V ⋙ homologyFunctor V _ (n + 1) ≅ 0 :=
+noncomputable def homology'FunctorSuccSingle₀ (n : ℕ) :
+    single₀ V ⋙ homology'Functor V _ (n + 1) ≅ 0 :=
   NatIso.ofComponents
     (fun X =>
-      homology.congr _ _ (by simp) (by simp) ≪≫
-        homologyZeroZero ≪≫ (Functor.zero_obj _).isoZero.symm)
+      homology'.congr _ _ (by simp) (by simp) ≪≫
+        homology'ZeroZero ≪≫ (Functor.zero_obj _).isoZero.symm)
     fun f => (Functor.zero_obj _).eq_of_tgt _ _
-#align chain_complex.homology_functor_succ_single₀ ChainComplex.homologyFunctorSuccSingle₀
+#align chain_complex.homology_functor_succ_single₀ ChainComplex.homology'FunctorSuccSingle₀
 
 end
 
@@ -390,8 +390,8 @@ variable [HasEqualizers V] [HasCokernels V] [HasImages V] [HasImageMaps V]
 /-- Sending objects to cochain complexes supported at `0` then taking `0`-th homology
 is the same as doing nothing.
 -/
-noncomputable def homologyFunctor0Single₀ : single₀ V ⋙ homologyFunctor V _ 0 ≅ 𝟭 V :=
-  NatIso.ofComponents (fun X => homology.congr _ _ (by simp) (by simp) ≪≫ homologyZeroZero)
+noncomputable def homologyFunctor0Single₀ : single₀ V ⋙ homology'Functor V _ 0 ≅ 𝟭 V :=
+  NatIso.ofComponents (fun X => homology'.congr _ _ (by simp) (by simp) ≪≫ homology'ZeroZero)
     fun f => by
       -- Porting note: why can't `aesop_cat` do this?
       dsimp
@@ -402,14 +402,14 @@ noncomputable def homologyFunctor0Single₀ : single₀ V ⋙ homologyFunctor V 
 /-- Sending objects to cochain complexes supported at `0` then taking `(n+1)`-st homology
 is the same as the zero functor.
 -/
-noncomputable def homologyFunctorSuccSingle₀ (n : ℕ) :
-    single₀ V ⋙ homologyFunctor V _ (n + 1) ≅ 0 :=
+noncomputable def homology'FunctorSuccSingle₀ (n : ℕ) :
+    single₀ V ⋙ homology'Functor V _ (n + 1) ≅ 0 :=
   NatIso.ofComponents
     (fun X =>
-      homology.congr _ _ (by simp) (by simp) ≪≫
-        homologyZeroZero ≪≫ (Functor.zero_obj _).isoZero.symm)
+      homology'.congr _ _ (by simp) (by simp) ≪≫
+        homology'ZeroZero ≪≫ (Functor.zero_obj _).isoZero.symm)
     fun f => (Functor.zero_obj _).eq_of_tgt _ _
-#align cochain_complex.homology_functor_succ_single₀ CochainComplex.homologyFunctorSuccSingle₀
+#align cochain_complex.homology_functor_succ_single₀ CochainComplex.homology'FunctorSuccSingle₀
 
 end
 

--- a/Mathlib/CategoryTheory/Abelian/Homology.lean
+++ b/Mathlib/CategoryTheory/Abelian/Homology.lean
@@ -12,19 +12,23 @@ import Mathlib.CategoryTheory.Limits.Preserves.Shapes.Images
 
 /-!
 
-The object `homology f g w`, where `w : f ≫ g = 0`, can be identified with either a
-cokernel or a kernel. The isomorphism with a cokernel is `homologyIsoCokernelLift`, which
+The object `homology' f g w`, where `w : f ≫ g = 0`, can be identified with either a
+cokernel or a kernel. The isomorphism with a cokernel is `homology'IsoCokernelLift`, which
 was obtained elsewhere. In the case of an abelian category, this file shows the isomorphism
 with a kernel as well.
 
-We use these isomorphisms to obtain the analogous api for `homology`:
-- `homology.ι` is the map from `homology f g w` into the cokernel of `f`.
-- `homology.π'` is the map from `kernel g` to `homology f g w`.
-- `homology.desc'` constructs a morphism from `homology f g w`, when it is viewed as a cokernel.
-- `homology.lift` constructs a morphism to `homology f g w`, when it is viewed as a kernel.
+We use these isomorphisms to obtain the analogous api for `homology'`:
+- `homology'.ι` is the map from `homology' f g w` into the cokernel of `f`.
+- `homology'.π'` is the map from `kernel g` to `homology' f g w`.
+- `homology'.desc'` constructs a morphism from `homology' f g w`, when it is viewed as a cokernel.
+- `homology'.lift` constructs a morphism to `homology' f g w`, when it is viewed as a kernel.
 - Various small lemmas are proved as well, mimicking the API for (co)kernels.
 With these definitions and lemmas, the isomorphisms between homology and a (co)kernel need not
 be used directly.
+
+Note: As part of the homology refactor, it is planned to remove the definitions in this file,
+because it can be replaced by the content of `Algebra.Homology.ShortComplex.Homology`.
+
 -/
 
 
@@ -103,98 +107,98 @@ instance (w : f ≫ g = 0) : IsIso (homologyCToK f g w) :=
 end CategoryTheory.Abelian
 
 /-- The homology associated to `f` and `g` is isomorphic to a kernel. -/
-def homologyIsoKernelDesc : homology f g w ≅ kernel (cokernel.desc f g w) :=
-  homologyIsoCokernelLift _ _ _ ≪≫ asIso (CategoryTheory.Abelian.homologyCToK _ _ _)
-#align homology_iso_kernel_desc homologyIsoKernelDesc
+def homology'IsoKernelDesc : homology' f g w ≅ kernel (cokernel.desc f g w) :=
+  homology'IsoCokernelLift _ _ _ ≪≫ asIso (CategoryTheory.Abelian.homologyCToK _ _ _)
+#align homology_iso_kernel_desc homology'IsoKernelDesc
 
-namespace homology
+namespace homology'
 
 -- `homology.π` is taken
 /-- The canonical map from the kernel of `g` to the homology of `f` and `g`. -/
-def π' : kernel g ⟶ homology f g w :=
-  cokernel.π _ ≫ (homologyIsoCokernelLift _ _ _).inv
-#align homology.π' homology.π'
+def π' : kernel g ⟶ homology' f g w :=
+  cokernel.π _ ≫ (homology'IsoCokernelLift _ _ _).inv
+#align homology.π' homology'.π'
 
 /-- The canonical map from the homology of `f` and `g` to the cokernel of `f`. -/
-def ι : homology f g w ⟶ cokernel f :=
-  (homologyIsoKernelDesc _ _ _).hom ≫ kernel.ι _
-#align homology.ι homology.ι
+def ι : homology' f g w ⟶ cokernel f :=
+  (homology'IsoKernelDesc _ _ _).hom ≫ kernel.ι _
+#align homology.ι homology'.ι
 
 /-- Obtain a morphism from the homology, given a morphism from the kernel. -/
-def desc' {W : A} (e : kernel g ⟶ W) (he : kernel.lift g f w ≫ e = 0) : homology f g w ⟶ W :=
-  (homologyIsoCokernelLift _ _ _).hom ≫ cokernel.desc _ e he
-#align homology.desc' homology.desc'
+def desc' {W : A} (e : kernel g ⟶ W) (he : kernel.lift g f w ≫ e = 0) : homology' f g w ⟶ W :=
+  (homology'IsoCokernelLift _ _ _).hom ≫ cokernel.desc _ e he
+#align homology.desc' homology'.desc'
 
 /-- Obtain a moprhism to the homology, given a morphism to the kernel. -/
-def lift {W : A} (e : W ⟶ cokernel f) (he : e ≫ cokernel.desc f g w = 0) : W ⟶ homology f g w :=
-  kernel.lift _ e he ≫ (homologyIsoKernelDesc _ _ _).inv
-#align homology.lift homology.lift
+def lift {W : A} (e : W ⟶ cokernel f) (he : e ≫ cokernel.desc f g w = 0) : W ⟶ homology' f g w :=
+  kernel.lift _ e he ≫ (homology'IsoKernelDesc _ _ _).inv
+#align homology.lift homology'.lift
 
 @[reassoc (attr := simp)]
 theorem π'_desc' {W : A} (e : kernel g ⟶ W) (he : kernel.lift g f w ≫ e = 0) :
     π' f g w ≫ desc' f g w e he = e := by
   dsimp [π', desc']
   simp
-#align homology.π'_desc' homology.π'_desc'
+#align homology.π'_desc' homology'.π'_desc'
 
 @[reassoc (attr := simp)]
 theorem lift_ι {W : A} (e : W ⟶ cokernel f) (he : e ≫ cokernel.desc f g w = 0) :
     lift f g w e he ≫ ι _ _ _ = e := by
   dsimp [ι, lift]
   simp
-#align homology.lift_ι homology.lift_ι
+#align homology.lift_ι homology'.lift_ι
 
 @[reassoc (attr := simp)]
 theorem condition_π' : kernel.lift g f w ≫ π' f g w = 0 := by
   dsimp [π']
   simp
-#align homology.condition_π' homology.condition_π'
+#align homology.condition_π' homology'.condition_π'
 
 @[reassoc (attr := simp)]
 theorem condition_ι : ι f g w ≫ cokernel.desc f g w = 0 := by
   dsimp [ι]
   simp
-#align homology.condition_ι homology.condition_ι
+#align homology.condition_ι homology'.condition_ι
 
 @[ext]
-theorem hom_from_ext {W : A} (a b : homology f g w ⟶ W)
+theorem hom_from_ext {W : A} (a b : homology' f g w ⟶ W)
     (h : π' f g w ≫ a = π' f g w ≫ b) : a = b := by
   dsimp [π'] at h
-  apply_fun fun e => (homologyIsoCokernelLift f g w).inv ≫ e
+  apply_fun fun e => (homology'IsoCokernelLift f g w).inv ≫ e
   swap
   · intro i j hh
-    apply_fun fun e => (homologyIsoCokernelLift f g w).hom ≫ e at hh
+    apply_fun fun e => (homology'IsoCokernelLift f g w).hom ≫ e at hh
     simpa using hh
   simp only [Category.assoc] at h
   exact coequalizer.hom_ext h
-#align homology.hom_from_ext homology.hom_from_ext
+#align homology.hom_from_ext homology'.hom_from_ext
 
 @[ext]
-theorem hom_to_ext {W : A} (a b : W ⟶ homology f g w) (h : a ≫ ι f g w = b ≫ ι f g w) : a = b := by
+theorem hom_to_ext {W : A} (a b : W ⟶ homology' f g w) (h : a ≫ ι f g w = b ≫ ι f g w) : a = b := by
   dsimp [ι] at h
-  apply_fun fun e => e ≫ (homologyIsoKernelDesc f g w).hom
+  apply_fun fun e => e ≫ (homology'IsoKernelDesc f g w).hom
   swap
   · intro i j hh
-    apply_fun fun e => e ≫ (homologyIsoKernelDesc f g w).inv at hh
+    apply_fun fun e => e ≫ (homology'IsoKernelDesc f g w).inv at hh
     simpa using hh
   simp only [← Category.assoc] at h
   exact equalizer.hom_ext h
-#align homology.hom_to_ext homology.hom_to_ext
+#align homology.hom_to_ext homology'.hom_to_ext
 
 @[reassoc (attr := simp)]
 theorem π'_ι : π' f g w ≫ ι f g w = kernel.ι _ ≫ cokernel.π _ := by
-  dsimp [π', ι, homologyIsoKernelDesc]
+  dsimp [π', ι, homology'IsoKernelDesc]
   simp
-#align homology.π'_ι homology.π'_ι
+#align homology.π'_ι homology'.π'_ι
 
 @[reassoc (attr := simp)]
 theorem π'_eq_π : (kernelSubobjectIso _).hom ≫ π' f g w = π _ _ _ := by
-  dsimp [π', homologyIsoCokernelLift]
+  dsimp [π', homology'IsoCokernelLift]
   simp only [← Category.assoc]
   rw [Iso.comp_inv_eq]
-  dsimp [π, homologyIsoCokernelImageToKernel']
+  dsimp [π, homology'IsoCokernelImageToKernel']
   simp
-#align homology.π'_eq_π homology.π'_eq_π
+#align homology.π'_eq_π homology'.π'_eq_π
 
 section
 
@@ -222,56 +226,56 @@ theorem π'_map (α β h) : π' _ _ _ ≫ map w w' α β h =
     simp
   rw [this]
   simp only [Category.assoc]
-  dsimp [π', homologyIsoCokernelLift]
+  dsimp [π', homology'IsoCokernelLift]
   simp only [cokernelIsoOfEq_inv_comp_desc, cokernel.π_desc_assoc]
   congr 1
   · congr
     exact h.symm
   · rw [Iso.inv_comp_eq, ← Category.assoc, Iso.eq_comp_inv]
-    dsimp [homologyIsoCokernelImageToKernel']
+    dsimp [homology'IsoCokernelImageToKernel']
     simp
-#align homology.π'_map homology.π'_map
+#align homology.π'_map homology'.π'_map
 
 -- Porting note: need to fill in f,g,f',g' in the next few results or time out
 theorem map_eq_desc'_lift_left (α β h) :
     map w w' α β h =
-      homology.desc' f g _ (homology.lift f' g' _ (kernel.ι _ ≫ β.left ≫ cokernel.π _)
+      homology'.desc' f g _ (homology'.lift f' g' _ (kernel.ι _ ≫ β.left ≫ cokernel.π _)
       (by simp)) (by
           ext
           simp only [← h, Category.assoc, zero_comp, lift_ι, kernel.lift_ι_assoc]
           erw [← reassoc_of% α.w]
           simp) := by
-  apply homology.hom_from_ext
+  apply homology'.hom_from_ext
   simp only [π'_map, π'_desc']
   dsimp [π', lift]
   rw [Iso.eq_comp_inv]
-  dsimp [homologyIsoKernelDesc]
+  dsimp [homology'IsoKernelDesc]
   ext
   simp [h]
-#align homology.map_eq_desc'_lift_left homology.map_eq_desc'_lift_left
+#align homology.map_eq_desc'_lift_left homology'.map_eq_desc'_lift_left
 
 theorem map_eq_lift_desc'_left (α β h) :
     map w w' α β h =
-      homology.lift f' g' _
-        (homology.desc' f g _ (kernel.ι _ ≫ β.left ≫ cokernel.π _)
+      homology'.lift f' g' _
+        (homology'.desc' f g _ (kernel.ι _ ≫ β.left ≫ cokernel.π _)
           (by
             simp only [kernel.lift_ι_assoc, ← h]
             erw [← reassoc_of% α.w]
             simp))
         (by
           -- Porting note: used to be ext
-          apply homology.hom_from_ext
+          apply homology'.hom_from_ext
           simp) := by
   rw [map_eq_desc'_lift_left]
   -- Porting note: once was known as ext
-  apply homology.hom_to_ext
-  apply homology.hom_from_ext
+  apply homology'.hom_to_ext
+  apply homology'.hom_from_ext
   simp
-#align homology.map_eq_lift_desc'_left homology.map_eq_lift_desc'_left
+#align homology.map_eq_lift_desc'_left homology'.map_eq_lift_desc'_left
 
 theorem map_eq_desc'_lift_right (α β h) :
     map w w' α β h =
-      homology.desc' f g _ (homology.lift f' g' _ (kernel.ι _ ≫ α.right ≫ cokernel.π _)
+      homology'.desc' f g _ (homology'.lift f' g' _ (kernel.ι _ ≫ α.right ≫ cokernel.π _)
         (by simp [h]))
         (by
           ext
@@ -281,26 +285,26 @@ theorem map_eq_desc'_lift_right (α β h) :
   rw [map_eq_desc'_lift_left]
   ext
   simp [h]
-#align homology.map_eq_desc'_lift_right homology.map_eq_desc'_lift_right
+#align homology.map_eq_desc'_lift_right homology'.map_eq_desc'_lift_right
 
 theorem map_eq_lift_desc'_right (α β h) :
     map w w' α β h =
-      homology.lift f' g' _
-        (homology.desc' f g _ (kernel.ι _ ≫ α.right ≫ cokernel.π _)
+      homology'.lift f' g' _
+        (homology'.desc' f g _ (kernel.ι _ ≫ α.right ≫ cokernel.π _)
           (by
             simp only [kernel.lift_ι_assoc]
             erw [← reassoc_of% α.w]
             simp))
         (by
           -- Porting note: once was known as ext
-          apply homology.hom_from_ext
+          apply homology'.hom_from_ext
           simp [h]) := by
   rw [map_eq_desc'_lift_right]
   -- Porting note: once was known as ext
-  apply homology.hom_to_ext
-  apply homology.hom_from_ext
+  apply homology'.hom_to_ext
+  apply homology'.hom_from_ext
   simp
-#align homology.map_eq_lift_desc'_right homology.map_eq_lift_desc'_right
+#align homology.map_eq_lift_desc'_right homology'.map_eq_lift_desc'_right
 
 @[reassoc (attr := simp)]
 theorem map_ι (α β h) :
@@ -308,14 +312,14 @@ theorem map_ι (α β h) :
       ι f g w ≫ cokernel.map f f' α.left β.left (by simp [h, β.w.symm]) := by
   rw [map_eq_lift_desc'_left, lift_ι]
   -- Porting note: once was known as ext
-  apply homology.hom_from_ext
+  apply homology'.hom_from_ext
   simp only [← Category.assoc]
   rw [π'_ι, π'_desc', Category.assoc, Category.assoc, cokernel.π_desc]
-#align homology.map_ι homology.map_ι
+#align homology.map_ι homology'.map_ι
 
 end
 
-end homology
+end homology'
 
 namespace CategoryTheory.Functor
 
@@ -323,8 +327,8 @@ variable {ι : Type*} {c : ComplexShape ι} {B : Type*} [Category B] [Abelian B]
   [Functor.Additive F] [PreservesFiniteLimits F] [PreservesFiniteColimits F]
 
 /-- When `F` is an exact additive functor, `F(Hᵢ(X)) ≅ Hᵢ(F(X))` for `X` a complex. -/
-noncomputable def homologyIso (C : HomologicalComplex A c) (j : ι) :
-    F.obj (C.homology j) ≅ ((F.mapHomologicalComplex c).obj C).homology j :=
+noncomputable def homology'Iso (C : HomologicalComplex A c) (j : ι) :
+    F.obj (C.homology' j) ≅ ((F.mapHomologicalComplex c).obj C).homology' j :=
   (PreservesCokernel.iso F _).trans
     (cokernel.mapIso _ _
       ((F.mapIso (imageSubobjectIso _)).trans
@@ -337,19 +341,19 @@ noncomputable def homologyIso (C : HomologicalComplex A c) (j : ι) :
         simp only [Category.assoc, imageToKernel_arrow]
         erw [kernelSubobject_arrow', imageSubobject_arrow']
         simp [← F.map_comp]))
-#align category_theory.functor.homology_iso CategoryTheory.Functor.homologyIso
+#align category_theory.functor.homology_iso CategoryTheory.Functor.homology'Iso
 
 /-- If `F` is an exact additive functor, then `F` commutes with `Hᵢ` (up to natural isomorphism). -/
-noncomputable def homologyFunctorIso (i : ι) :
-    homologyFunctor A c i ⋙ F ≅ F.mapHomologicalComplex c ⋙ homologyFunctor B c i :=
-  NatIso.ofComponents (fun X => homologyIso F X i) (by
+noncomputable def homology'FunctorIso (i : ι) :
+    homology'Functor A c i ⋙ F ≅ F.mapHomologicalComplex c ⋙ homology'Functor B c i :=
+  NatIso.ofComponents (fun X => homology'Iso F X i) (by
       intro X Y f
       dsimp
       rw [← Iso.inv_comp_eq, ← Category.assoc, ← Iso.eq_comp_inv]
       refine' coequalizer.hom_ext _
-      dsimp [homologyIso]
+      dsimp [homology'Iso]
       simp only [PreservesCokernel.iso_inv]
-      dsimp [homology.map]
+      dsimp [homology'.map]
       simp only [← Category.assoc, cokernel.π_desc]
       simp only [Category.assoc, cokernelComparison_map_desc, cokernel.π_desc]
       simp only [π_comp_cokernelComparison, ← F.map_comp]
@@ -362,6 +366,6 @@ noncomputable def homologyFunctorIso (i : ι) :
       rotate_right; simp
       rw [← kernel_map_comp_kernelSubobjectIso_inv]
       any_goals simp)
-#align category_theory.functor.homology_functor_iso CategoryTheory.Functor.homologyFunctorIso
+#align category_theory.functor.homology_functor_iso CategoryTheory.Functor.homology'FunctorIso
 
 end CategoryTheory.Functor

--- a/Mathlib/CategoryTheory/Abelian/InjectiveResolution.lean
+++ b/Mathlib/CategoryTheory/Abelian/InjectiveResolution.lean
@@ -329,7 +329,7 @@ variable {C : Type u} [Category.{v} C] [Abelian C]
 /-- If `X` is a cochain complex of injective objects and we have a quasi-isomorphism
 `f : Y[0] ⟶ X`, then `X` is an injective resolution of `Y`. -/
 def HomologicalComplex.Hom.fromSingle₀InjectiveResolution (X : CochainComplex C ℕ) (Y : C)
-    (f : (CochainComplex.single₀ C).obj Y ⟶ X) [QuasiIso f] (H : ∀ n, Injective (X.X n)) :
+    (f : (CochainComplex.single₀ C).obj Y ⟶ X) [QuasiIso' f] (H : ∀ n, Injective (X.X n)) :
     InjectiveResolution Y where
   cocomplex := X
   ι := f

--- a/Mathlib/CategoryTheory/Abelian/LeftDerived.lean
+++ b/Mathlib/CategoryTheory/Abelian/LeftDerived.lean
@@ -69,7 +69,7 @@ theorem exact_of_map_projectiveResolution (P : ProjectiveResolution X)
 def leftDerivedZeroToSelfApp [EnoughProjectives C] {X : C} (P : ProjectiveResolution X) :
     (F.leftDerived 0).obj X ⟶ F.obj X :=
   (leftDerivedObjIso F 0 P).hom ≫
-    homology.desc' _ _ _ (kernel.ι _ ≫ F.map (P.π.f 0))
+    homology'.desc' _ _ _ (kernel.ι _ ≫ F.map (P.π.f 0))
       (by
         rw [kernel.lift_ι_assoc,
           HomologicalComplex.dTo_eq _ (by simp : (ComplexShape.down ℕ).Rel 1 0),
@@ -85,7 +85,7 @@ def leftDerivedZeroToSelfAppInv [EnoughProjectives C] [PreservesFiniteColimits F
   have := isIso_cokernel_desc_of_exact_of_epi _ _ (exact_of_map_projectiveResolution F P)
   refine'
     (asIso (cokernel.desc _ _ (exact_of_map_projectiveResolution F P).w)).inv ≫
-      _ ≫ (homologyIsoCokernelLift _ _ _).inv ≫ (leftDerivedObjIso F 0 P).inv
+      _ ≫ (homology'IsoCokernelLift _ _ _).inv ≫ (leftDerivedObjIso F 0 P).inv
   refine' cokernel.map _ _ (𝟙 _) (kernel.lift _ (𝟙 _) (by simp)) _
   ext
   -- Porting note: this used to just be `simp`
@@ -103,11 +103,11 @@ theorem leftDerivedZeroToSelfApp_comp_inv [EnoughProjectives C] [PreservesFinite
   convert Category.comp_id (leftDerivedObjIso F 0 P).hom
   rw [← Category.assoc, ← Category.assoc, Iso.comp_inv_eq]
   -- Porting note: broken ext
-  apply homology.hom_from_ext
+  apply homology'.hom_from_ext
   simp only [← Category.assoc]
-  erw [homology.π'_desc', Category.assoc, Category.assoc, ←
+  erw [homology'.π'_desc', Category.assoc, Category.assoc, ←
     Category.assoc (F.map _), Abelian.cokernel.desc.inv _ _ (exact_of_map_projectiveResolution F P),
-    cokernel.π_desc, homology.π', Category.comp_id, Category.assoc (cokernel.π _), Iso.inv_hom_id,
+    cokernel.π_desc, homology'.π', Category.comp_id, Category.assoc (cokernel.π _), Iso.inv_hom_id,
     Category.comp_id, ← Category.assoc]
   -- Porting note: restructured proof to avoid `convert`
   conv_rhs => rw [← Category.id_comp (cokernel.π _)]
@@ -141,8 +141,8 @@ theorem leftDerivedZeroToSelfAppInv_comp [EnoughProjectives C] [PreservesFiniteC
   -- Porting note: working around 'motive is not type correct'
   simp only [Category.comp_id]
   ext
-  simp only [cokernel.π_desc_assoc, Category.assoc, cokernel.π_desc, homology.desc']
-  rw [← Category.assoc, ← Category.assoc (homologyIsoCokernelLift _ _ _).inv, Iso.inv_hom_id]
+  simp only [cokernel.π_desc_assoc, Category.assoc, cokernel.π_desc, homology'.desc']
+  rw [← Category.assoc, ← Category.assoc (homology'IsoCokernelLift _ _ _).inv, Iso.inv_hom_id]
   simp only [Category.assoc, cokernel.π_desc, kernel.lift_ι_assoc, Category.id_comp]
 #align category_theory.abelian.functor.left_derived_zero_to_self_app_inv_comp CategoryTheory.Abelian.Functor.leftDerivedZeroToSelfAppInv_comp
 
@@ -166,12 +166,12 @@ theorem leftDerived_zero_to_self_natural [EnoughProjectives C] {X : C} {Y : C} (
   rw [Functor.leftDerived_map_eq F 0 f (ProjectiveResolution.lift f P Q) (by simp), Category.assoc,
     Category.assoc, ← Category.assoc _ (F.leftDerivedObjIso 0 Q).hom, Iso.inv_hom_id,
     Category.id_comp, Category.assoc, whisker_eq]
-  dsimp only [homologyFunctor_map]
+  dsimp only [homology'Functor_map]
   -- Porting note: broken ext
-  apply homology.hom_from_ext
+  apply homology'.hom_from_ext
   simp only [HomologicalComplex.Hom.sqTo_right, mapHomologicalComplex_map_f,
-    homology.π'_map_assoc, homology.π'_desc', kernel.lift_ι_assoc, Category.assoc,
-    homology.π'_desc'_assoc, ← map_comp,
+    homology'.π'_map_assoc, homology'.π'_desc', kernel.lift_ι_assoc, Category.assoc,
+    homology'.π'_desc'_assoc, ← map_comp,
     show (ProjectiveResolution.lift f P Q).f 0 ≫ _ = _ ≫ f from
       HomologicalComplex.congr_hom (ProjectiveResolution.lift_commutes f P Q) 0]
 #align category_theory.abelian.functor.left_derived_zero_to_self_natural CategoryTheory.Abelian.Functor.leftDerived_zero_to_self_natural

--- a/Mathlib/CategoryTheory/Abelian/Projective.lean
+++ b/Mathlib/CategoryTheory/Abelian/Projective.lean
@@ -165,7 +165,7 @@ variable {C : Type u} [Category.{v} C] [Abelian C]
 then `X` is a projective resolution of `Y.` -/
 def toSingle₀ProjectiveResolution {X : ChainComplex C ℕ} {Y : C}
     -- porting note: autoporter incorrectly went for `X.pt` at the end there
-    (f : X ⟶ (ChainComplex.single₀ C).obj Y) [QuasiIso f] (H : ∀ n, Projective (X.X n)) :
+    (f : X ⟶ (ChainComplex.single₀ C).obj Y) [QuasiIso' f] (H : ∀ n, Projective (X.X n)) :
     ProjectiveResolution Y where
   complex := X
   π := f

--- a/Mathlib/CategoryTheory/Abelian/RightDerived.lean
+++ b/Mathlib/CategoryTheory/Abelian/RightDerived.lean
@@ -64,7 +64,7 @@ variable [Abelian C] [HasInjectiveResolutions C] [Abelian D]
 
 /-- The right derived functors of an additive functor. -/
 def Functor.rightDerived (F : C ⥤ D) [F.Additive] (n : ℕ) : C ⥤ D :=
-  injectiveResolutions C ⋙ F.mapHomotopyCategory _ ⋙ HomotopyCategory.homologyFunctor D _ n
+  injectiveResolutions C ⋙ F.mapHomotopyCategory _ ⋙ HomotopyCategory.homology'Functor D _ n
 #align category_theory.functor.right_derived CategoryTheory.Functor.rightDerived
 
 /-- We can compute a right derived functor using a chosen injective resolution. -/
@@ -72,11 +72,11 @@ def Functor.rightDerived (F : C ⥤ D) [F.Additive] (n : ℕ) : C ⥤ D :=
 def Functor.rightDerivedObjIso (F : C ⥤ D) [F.Additive] (n : ℕ) {X : C}
     (P : InjectiveResolution X) :
     (F.rightDerived n).obj X ≅
-      (homologyFunctor D _ n).obj ((F.mapHomologicalComplex _).obj P.cocomplex) :=
-  (HomotopyCategory.homologyFunctor D _ n).mapIso
+      (homology'Functor D _ n).obj ((F.mapHomologicalComplex _).obj P.cocomplex) :=
+  (HomotopyCategory.homology'Functor D _ n).mapIso
       (HomotopyCategory.isoOfHomotopyEquiv
         (F.mapHomotopyEquiv (InjectiveResolution.homotopyEquiv _ P))) ≪≫
-    (HomotopyCategory.homologyFactors D _ n).app _
+    (HomotopyCategory.homology'Factors D _ n).app _
 #align category_theory.functor.right_derived_obj_iso CategoryTheory.Functor.rightDerivedObjIso
 
 /-- The 0-th derived functor of `F` on an injective object `X` is just `F.obj X`. -/
@@ -84,7 +84,7 @@ def Functor.rightDerivedObjIso (F : C ⥤ D) [F.Additive] (n : ℕ) {X : C}
 def Functor.rightDerivedObjInjectiveZero (F : C ⥤ D) [F.Additive] (X : C) [Injective X] :
     (F.rightDerived 0).obj X ≅ F.obj X :=
   F.rightDerivedObjIso 0 (InjectiveResolution.self X) ≪≫
-    (homologyFunctor _ _ _).mapIso ((CochainComplex.single₀MapHomologicalComplex F).app X) ≪≫
+    (homology'Functor _ _ _).mapIso ((CochainComplex.single₀MapHomologicalComplex F).app X) ≪≫
       (CochainComplex.homologyFunctor0Single₀ D).app (F.obj X)
 #align category_theory.functor.right_derived_obj_injective_zero CategoryTheory.Functor.rightDerivedObjInjectiveZero
 
@@ -95,8 +95,8 @@ open ZeroObject
 def Functor.rightDerivedObjInjectiveSucc (F : C ⥤ D) [F.Additive] (n : ℕ) (X : C) [Injective X] :
     (F.rightDerived (n + 1)).obj X ≅ 0 :=
   F.rightDerivedObjIso (n + 1) (InjectiveResolution.self X) ≪≫
-    (homologyFunctor _ _ _).mapIso ((CochainComplex.single₀MapHomologicalComplex F).app X) ≪≫
-      (CochainComplex.homologyFunctorSuccSingle₀ D n).app (F.obj X) ≪≫ (Functor.zero_obj _).isoZero
+    (homology'Functor _ _ _).mapIso ((CochainComplex.single₀MapHomologicalComplex F).app X) ≪≫
+      (CochainComplex.homology'FunctorSuccSingle₀ D n).app (F.obj X) ≪≫ (Functor.zero_obj _).isoZero
 #align category_theory.functor.right_derived_obj_injective_succ CategoryTheory.Functor.rightDerivedObjInjectiveSucc
 
 /-- We can compute a right derived functor on a morphism using a descent of that morphism
@@ -107,12 +107,12 @@ theorem Functor.rightDerived_map_eq (F : C ⥤ D) [F.Additive] (n : ℕ) {X Y : 
     (w : Q.ι ≫ g = (CochainComplex.single₀ C).map f ≫ P.ι) :
     (F.rightDerived n).map f =
       (F.rightDerivedObjIso n Q).hom ≫
-        (homologyFunctor D _ n).map ((F.mapHomologicalComplex _).map g) ≫
+        (homology'Functor D _ n).map ((F.mapHomologicalComplex _).map g) ≫
           (F.rightDerivedObjIso n P).inv := by
   dsimp only [Functor.rightDerived, Functor.rightDerivedObjIso]
   dsimp
   simp only [Category.comp_id, Category.id_comp]
-  rw [← homologyFunctor_map, HomotopyCategory.homologyFunctor_map_factors]
+  rw [← homology'Functor_map, HomotopyCategory.homology'Functor_map_factors]
   simp only [← Functor.map_comp]
   congr 1
   apply HomotopyCategory.eq_of_homotopy
@@ -129,7 +129,7 @@ theorem Functor.rightDerived_map_eq (F : C ⥤ D) [F.Additive] (n : ℕ) {X Y : 
 def NatTrans.rightDerived {F G : C ⥤ D} [F.Additive] [G.Additive] (α : F ⟶ G) (n : ℕ) :
     F.rightDerived n ⟶ G.rightDerived n :=
   whiskerLeft (injectiveResolutions C)
-    (whiskerRight (NatTrans.mapHomotopyCategory α _) (HomotopyCategory.homologyFunctor D _ n))
+    (whiskerRight (NatTrans.mapHomotopyCategory α _) (HomotopyCategory.homology'Functor D _ n))
 #align category_theory.nat_trans.right_derived CategoryTheory.NatTrans.rightDerived
 
 @[simp]
@@ -153,12 +153,12 @@ theorem NatTrans.rightDerived_eq {F G : C ⥤ D} [F.Additive] [G.Additive] (α :
     (P : InjectiveResolution X) :
     (NatTrans.rightDerived α n).app X =
       (F.rightDerivedObjIso n P).hom ≫
-        (homologyFunctor D _ n).map ((NatTrans.mapHomologicalComplex α _).app P.cocomplex) ≫
+        (homology'Functor D _ n).map ((NatTrans.mapHomologicalComplex α _).app P.cocomplex) ≫
           (G.rightDerivedObjIso n P).inv := by
   symm
   dsimp [NatTrans.rightDerived, Functor.rightDerivedObjIso]
   simp only [Category.comp_id, Category.id_comp]
-  rw [← homologyFunctor_map, HomotopyCategory.homologyFunctor_map_factors]
+  rw [← homology'Functor_map, HomotopyCategory.homology'Functor_map_factors]
   simp only [← Functor.map_comp]
   congr 1
   apply HomotopyCategory.eq_of_homotopy
@@ -210,7 +210,7 @@ theorem exact_of_map_injectiveResolution (P : InjectiveResolution X) [PreservesF
 def rightDerivedZeroToSelfApp [EnoughInjectives C] [PreservesFiniteLimits F] {X : C}
     (P : InjectiveResolution X) : (F.rightDerived 0).obj X ⟶ F.obj X :=
   (rightDerivedObjIso F 0 P).hom ≫
-    (homologyIsoKernelDesc _ _ _).hom ≫
+    (homology'IsoKernelDesc _ _ _).hom ≫
       kernel.map _ (((F.mapHomologicalComplex (ComplexShape.up ℕ)).obj P.cocomplex).dFrom 0)
       (cokernel.desc _ (𝟙 _) (by simp)) (𝟙 _)
           (by
@@ -228,7 +228,7 @@ def rightDerivedZeroToSelfApp [EnoughInjectives C] [PreservesFiniteLimits F] {X 
 /-- Given `P : InjectiveResolution X`, a morphism `F.obj X ⟶ (F.rightDerived 0).obj X`. -/
 def rightDerivedZeroToSelfAppInv [EnoughInjectives C] {X : C} (P : InjectiveResolution X) :
     F.obj X ⟶ (F.rightDerived 0).obj X :=
-  homology.lift _ _ _ (F.map (P.ι.f 0) ≫ cokernel.π _)
+  homology'.lift _ _ _ (F.map (P.ι.f 0) ≫ cokernel.π _)
       (by
         have : (ComplexShape.up ℕ).Rel 0 1 := rfl
         rw [Category.assoc, cokernel.π_desc, HomologicalComplex.dFrom_eq _ this,
@@ -244,15 +244,15 @@ theorem rightDerivedZeroToSelfApp_comp_inv [EnoughInjectives C] [PreservesFinite
   rw [← Category.assoc, Iso.comp_inv_eq, Category.id_comp, Category.assoc, Category.assoc, ←
     Iso.eq_inv_comp, Iso.inv_hom_id]
   -- Porting note: broken ext
-  apply homology.hom_to_ext
-  apply homology.hom_from_ext
-  rw [Category.assoc, Category.assoc, homology.lift_ι, Category.id_comp]
-  erw [homology.π'_ι] -- Porting note: had to insist
+  apply homology'.hom_to_ext
+  apply homology'.hom_from_ext
+  rw [Category.assoc, Category.assoc, homology'.lift_ι, Category.id_comp]
+  erw [homology'.π'_ι] -- Porting note: had to insist
   rw [Category.assoc, ← Category.assoc _ _ (cokernel.π _),
     Abelian.kernel.lift.inv, ← Category.assoc,
     ← Category.assoc _ (kernel.ι _), Limits.kernel.lift_ι, Category.assoc, Category.assoc, ←
-    Category.assoc (homologyIsoKernelDesc _ _ _).hom _ _, ← homology.ι, ← Category.assoc]
-  erw [homology.π'_ι] -- Porting note: had to insist
+    Category.assoc (homology'IsoKernelDesc _ _ _).hom _ _, ← homology'.ι, ← Category.assoc]
+  erw [homology'.π'_ι] -- Porting note: had to insist
   rw [Category.assoc, ← Category.assoc (cokernel.π _)]
   erw [cokernel.π_desc] -- Porting note: had to insist
   rw [whisker_eq]
@@ -273,9 +273,9 @@ theorem rightDerivedZeroToSelfAppInv_comp [EnoughInjectives C] [PreservesFiniteL
   · rw [Category.id_comp]
     ext
     simp only [Limits.kernel.lift_ι_assoc,
-      Category.assoc, Limits.kernel.lift_ι, homology.lift]
+      Category.assoc, Limits.kernel.lift_ι, homology'.lift]
     rw [← Category.assoc, ← Category.assoc,
-      Category.assoc _ _ (homologyIsoKernelDesc _ _ _).hom]
+      Category.assoc _ _ (homology'IsoKernelDesc _ _ _).hom]
     simp
     -- Porting note: this used to be an instance in ML3
   · apply isIso_kernel_lift_of_exact_of_mono _ _ (exact_of_map_injectiveResolution F P)
@@ -303,13 +303,13 @@ theorem rightDerivedZeroToSelf_natural [EnoughInjectives C] {X : C} {Y : C} (f :
     Category.assoc, Category.assoc, Category.assoc, Category.assoc, Iso.inv_hom_id,
     Category.comp_id, ← Category.assoc (F.rightDerivedObjIso 0 P).inv, Iso.inv_hom_id,
     Category.id_comp]
-  dsimp only [homologyFunctor_map]
+  dsimp only [homology'Functor_map]
   -- Porting note: broken ext
-  apply homology.hom_to_ext
-  rw [Category.assoc, homology.lift_ι, Category.assoc]
-  erw [homology.map_ι] -- Porting note: need to insist
-  rw [←Category.assoc (homology.lift _ _ _ _ _) _ _]
-  erw [homology.lift_ι] -- Porting note: need to insist
+  apply homology'.hom_to_ext
+  rw [Category.assoc, homology'.lift_ι, Category.assoc]
+  erw [homology'.map_ι] -- Porting note: need to insist
+  rw [←Category.assoc (homology'.lift _ _ _ _ _) _ _]
+  erw [homology'.lift_ι] -- Porting note: need to insist
   rw [Category.assoc]
   erw [cokernel.π_desc] -- Porting note: need to insist
   rw [← Category.assoc, ← Functor.map_comp, ← Category.assoc,

--- a/Mathlib/CategoryTheory/Functor/LeftDerived.lean
+++ b/Mathlib/CategoryTheory/Functor/LeftDerived.lean
@@ -60,7 +60,7 @@ variable [Preadditive D] [HasEqualizers D] [HasCokernels D] [HasImages D] [HasIm
 
 /-- The left derived functors of an additive functor. -/
 def Functor.leftDerived (F : C ⥤ D) [F.Additive] (n : ℕ) : C ⥤ D :=
-  projectiveResolutions C ⋙ F.mapHomotopyCategory _ ⋙ HomotopyCategory.homologyFunctor D _ n
+  projectiveResolutions C ⋙ F.mapHomotopyCategory _ ⋙ HomotopyCategory.homology'Functor D _ n
 #align category_theory.functor.left_derived CategoryTheory.Functor.leftDerived
 
 -- TODO the left derived functors are additive (and linear when `F` is linear)
@@ -69,11 +69,11 @@ def Functor.leftDerived (F : C ⥤ D) [F.Additive] (n : ℕ) : C ⥤ D :=
 def Functor.leftDerivedObjIso (F : C ⥤ D) [F.Additive] (n : ℕ) {X : C}
     (P : ProjectiveResolution X) :
     (F.leftDerived n).obj X ≅
-      (homologyFunctor D _ n).obj ((F.mapHomologicalComplex _).obj P.complex) :=
-  (HomotopyCategory.homologyFunctor D _ n).mapIso
+      (homology'Functor D _ n).obj ((F.mapHomologicalComplex _).obj P.complex) :=
+  (HomotopyCategory.homology'Functor D _ n).mapIso
       (HomotopyCategory.isoOfHomotopyEquiv
         (F.mapHomotopyEquiv (ProjectiveResolution.homotopyEquiv _ P))) ≪≫
-    (HomotopyCategory.homologyFactors D _ n).app _
+    (HomotopyCategory.homology'Factors D _ n).app _
 #align category_theory.functor.left_derived_obj_iso CategoryTheory.Functor.leftDerivedObjIso
 
 section
@@ -85,8 +85,8 @@ variable [HasZeroObject D]
 def Functor.leftDerivedObjProjectiveZero (F : C ⥤ D) [F.Additive] (X : C) [Projective X] :
     (F.leftDerived 0).obj X ≅ F.obj X :=
   F.leftDerivedObjIso 0 (ProjectiveResolution.self X) ≪≫
-    (homologyFunctor _ _ _).mapIso ((ChainComplex.single₀MapHomologicalComplex F).app X) ≪≫
-      (ChainComplex.homologyFunctor0Single₀ D).app (F.obj X)
+    (homology'Functor _ _ _).mapIso ((ChainComplex.single₀MapHomologicalComplex F).app X) ≪≫
+      (ChainComplex.homology'Functor0Single₀ D).app (F.obj X)
 #align category_theory.functor.left_derived_obj_projective_zero CategoryTheory.Functor.leftDerivedObjProjectiveZero
 
 open ZeroObject
@@ -96,8 +96,8 @@ open ZeroObject
 def Functor.leftDerivedObjProjectiveSucc (F : C ⥤ D) [F.Additive] (n : ℕ) (X : C) [Projective X] :
     (F.leftDerived (n + 1)).obj X ≅ 0 :=
   F.leftDerivedObjIso (n + 1) (ProjectiveResolution.self X) ≪≫
-    (homologyFunctor _ _ _).mapIso ((ChainComplex.single₀MapHomologicalComplex F).app X) ≪≫
-      (ChainComplex.homologyFunctorSuccSingle₀ D n).app (F.obj X) ≪≫ (Functor.zero_obj _).isoZero
+    (homology'Functor _ _ _).mapIso ((ChainComplex.single₀MapHomologicalComplex F).app X) ≪≫
+      (ChainComplex.homology'FunctorSuccSingle₀ D n).app (F.obj X) ≪≫ (Functor.zero_obj _).isoZero
 #align category_theory.functor.left_derived_obj_projective_succ CategoryTheory.Functor.leftDerivedObjProjectiveSucc
 
 end
@@ -110,11 +110,11 @@ theorem Functor.leftDerived_map_eq (F : C ⥤ D) [F.Additive] (n : ℕ) {X Y : C
     (w : g ≫ Q.π = P.π ≫ (ChainComplex.single₀ C).map f) :
     (F.leftDerived n).map f =
       (F.leftDerivedObjIso n P).hom ≫
-        (homologyFunctor D _ n).map ((F.mapHomologicalComplex _).map g) ≫
+        (homology'Functor D _ n).map ((F.mapHomologicalComplex _).map g) ≫
           (F.leftDerivedObjIso n Q).inv := by
   dsimp only [Functor.leftDerived, Functor.leftDerivedObjIso]
   dsimp; simp only [Category.comp_id, Category.id_comp]
-  rw [← homologyFunctor_map, HomotopyCategory.homologyFunctor_map_factors]
+  rw [← homology'Functor_map, HomotopyCategory.homology'Functor_map_factors]
   simp only [← Functor.map_comp]
   congr 1
   apply HomotopyCategory.eq_of_homotopy
@@ -129,7 +129,7 @@ theorem Functor.leftDerived_map_eq (F : C ⥤ D) [F.Additive] (n : ℕ) {X Y : C
 def NatTrans.leftDerived {F G : C ⥤ D} [F.Additive] [G.Additive] (α : F ⟶ G) (n : ℕ) :
     F.leftDerived n ⟶ G.leftDerived n :=
   whiskerLeft (projectiveResolutions C)
-    (whiskerRight (NatTrans.mapHomotopyCategory α _) (HomotopyCategory.homologyFunctor D _ n))
+    (whiskerRight (NatTrans.mapHomotopyCategory α _) (HomotopyCategory.homology'Functor D _ n))
 #align category_theory.nat_trans.left_derived CategoryTheory.NatTrans.leftDerived
 
 @[simp]
@@ -154,12 +154,12 @@ theorem NatTrans.leftDerived_eq {F G : C ⥤ D} [F.Additive] [G.Additive] (α : 
     (P : ProjectiveResolution X) :
     (NatTrans.leftDerived α n).app X =
       (F.leftDerivedObjIso n P).hom ≫
-        (homologyFunctor D _ n).map ((NatTrans.mapHomologicalComplex α _).app P.complex) ≫
+        (homology'Functor D _ n).map ((NatTrans.mapHomologicalComplex α _).app P.complex) ≫
           (G.leftDerivedObjIso n P).inv := by
   symm
   dsimp [NatTrans.leftDerived, Functor.leftDerivedObjIso]
   simp only [Category.comp_id, Category.id_comp]
-  rw [← homologyFunctor_map, HomotopyCategory.homologyFunctor_map_factors]
+  rw [← homology'Functor_map, HomotopyCategory.homology'Functor_map_factors]
   simp only [← Functor.map_comp]
   congr 1
   apply HomotopyCategory.eq_of_homotopy

--- a/Mathlib/RepresentationTheory/GroupCohomology/Basic.lean
+++ b/Mathlib/RepresentationTheory/GroupCohomology/Basic.lean
@@ -218,7 +218,7 @@ open groupCohomology
 /-- The group cohomology of a `k`-linear `G`-representation `A`, as the cohomology of its complex
 of inhomogeneous cochains. -/
 def groupCohomology [Group G] (A : Rep k G) (n : ℕ) : ModuleCat k :=
-  (inhomogeneousCochains A).homology n
+  (inhomogeneousCochains A).homology' n
 #align group_cohomology groupCohomology
 
 /-- The `n`th group cohomology of a `k`-linear `G`-representation `A` is isomorphic to
@@ -226,6 +226,6 @@ def groupCohomology [Group G] (A : Rep k G) (n : ℕ) : ModuleCat k :=
 def groupCohomologyIsoExt [Group G] (A : Rep k G) (n : ℕ) :
     groupCohomology A n ≅ ((Ext k (Rep k G) n).obj (Opposite.op <| Rep.trivial k G k)).obj A :=
   homologyObjIsoOfHomotopyEquiv (HomotopyEquiv.ofIso (inhomogeneousCochainsIso _)) _ ≪≫
-    HomologicalComplex.homologyUnop _ _ ≪≫ (extIso k G A n).symm
+    HomologicalComplex.homology'Unop _ _ ≪≫ (extIso k G A n).symm
 set_option linter.uppercaseLean3 false in
 #align group_cohomology_iso_Ext groupCohomologyIsoExt

--- a/Mathlib/RepresentationTheory/GroupCohomology/Resolution.lean
+++ b/Mathlib/RepresentationTheory/GroupCohomology/Resolution.lean
@@ -684,7 +684,7 @@ theorem quasiIso'OfForget₂εToSingle₀ :
 #align group_cohomology.resolution.quasi_iso_of_forget₂_ε_to_single₀ groupCohomology.resolution.quasiIso'OfForget₂εToSingle₀
 
 instance : QuasiIso' (εToSingle₀ k G) :=
-  (forget₂ _ (ModuleCat.{u} k)).quasiIso_of_map_quasiIso _ (quasiIsoOfForget₂εToSingle₀ k G)
+  (forget₂ _ (ModuleCat.{u} k)).quasiIso'_of_map_quasiIso' _ (quasiIso'OfForget₂εToSingle₀ k G)
 
 end Exactness
 
@@ -710,7 +710,7 @@ standard resolution of `k` called `groupCohomology.resolution k G`. -/
 def groupCohomology.extIso (V : Rep k G) (n : ℕ) :
     ((Ext k (Rep k G) n).obj (Opposite.op <| Rep.trivial k G k)).obj V ≅
       (((((linearYoneda k (Rep k G)).obj V).rightOp.mapHomologicalComplex _).obj
-              (groupCohomology.resolution k G)).homology
+              (groupCohomology.resolution k G)).homology'
           n).unop := (((linearYoneda k (Rep k G)).obj V).rightOp.leftDerivedObjIso n
      (groupCohomology.projectiveResolution k G)).unop.symm
 set_option linter.uppercaseLean3 false in

--- a/Mathlib/RepresentationTheory/GroupCohomology/Resolution.lean
+++ b/Mathlib/RepresentationTheory/GroupCohomology/Resolution.lean
@@ -675,15 +675,15 @@ theorem εToSingle₀_comp_eq :
   exact (forget₂ToModuleCatHomotopyEquiv_f_0_eq k G).symm
 #align group_cohomology.resolution.ε_to_single₀_comp_eq groupCohomology.resolution.εToSingle₀_comp_eq
 
-theorem quasiIsoOfForget₂εToSingle₀ :
-    QuasiIso (((forget₂ _ (ModuleCat.{u} k)).mapHomologicalComplex _).map (εToSingle₀ k G)) := by
-  have h : QuasiIso (forget₂ToModuleCatHomotopyEquiv k G).hom := HomotopyEquiv.toQuasiIso _
+theorem quasiIso'OfForget₂εToSingle₀ :
+    QuasiIso' (((forget₂ _ (ModuleCat.{u} k)).mapHomologicalComplex _).map (εToSingle₀ k G)) := by
+  have h : QuasiIso' (forget₂ToModuleCatHomotopyEquiv k G).hom := HomotopyEquiv.toQuasiIso' _
   rw [← εToSingle₀_comp_eq k G] at h
   haveI := h
-  exact quasiIso_of_comp_right _ ((ChainComplex.single₀MapHomologicalComplex _).hom.app _)
+  exact quasiIso'_of_comp_right _ ((ChainComplex.single₀MapHomologicalComplex _).hom.app _)
 #align group_cohomology.resolution.quasi_iso_of_forget₂_ε_to_single₀ groupCohomology.resolution.quasiIsoOfForget₂εToSingle₀
 
-instance : QuasiIso (εToSingle₀ k G) :=
+instance : QuasiIso' (εToSingle₀ k G) :=
   (forget₂ _ (ModuleCat.{u} k)).quasiIso_of_map_quasiIso _ (quasiIsoOfForget₂εToSingle₀ k G)
 
 end Exactness

--- a/Mathlib/RepresentationTheory/GroupCohomology/Resolution.lean
+++ b/Mathlib/RepresentationTheory/GroupCohomology/Resolution.lean
@@ -681,7 +681,7 @@ theorem quasiIso'OfForget₂εToSingle₀ :
   rw [← εToSingle₀_comp_eq k G] at h
   haveI := h
   exact quasiIso'_of_comp_right _ ((ChainComplex.single₀MapHomologicalComplex _).hom.app _)
-#align group_cohomology.resolution.quasi_iso_of_forget₂_ε_to_single₀ groupCohomology.resolution.quasiIsoOfForget₂εToSingle₀
+#align group_cohomology.resolution.quasi_iso_of_forget₂_ε_to_single₀ groupCohomology.resolution.quasiIso'OfForget₂εToSingle₀
 
 instance : QuasiIso' (εToSingle₀ k G) :=
   (forget₂ _ (ModuleCat.{u} k)).quasiIso_of_map_quasiIso _ (quasiIsoOfForget₂εToSingle₀ k G)


### PR DESCRIPTION
This PR renames definitions of the current homology API (adding a `'` to `homology`, `cycles`, `QuasiIso`) so as to create space for the development of the new homology API of homological complexes: this PR also contains the new definition of `HomologicalComplex.homology` which involves the homology theory of short complexes.

---

Next, the plan is to develop this new homology API, and then make small PRs which remove the downstream uses of the old homology API, replacing these with the new API. Significant steps will include refactors of projective/injective resolutions and left/right derived functors. Enabling the use of the new homology API in the development of group cohomology is also important. (Eventually, when the old API is no longer used and when old statements all have equivalents in the new homology API, it could be removed.)

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
