### PR TITLE
[Merged by Bors] - fix(Tactic/ApplyFun): do not silence errors

### DIFF
--- a/Mathlib/Tactic/ApplyFun.lean
+++ b/Mathlib/Tactic/ApplyFun.lean
@@ -105,7 +105,8 @@ def maybeProveInjective (ginj : Expr) (using? : Option Expr) : MetaM Bool := do
       let err ← mkHasTypeButIsExpectedMsg (← inferType u) (← inferType ginj)
       throwError "Using clause {err}"
   -- Try an assumption
-  try ginj.mvarId!.assumption; return true catch _ => pure ()
+  if ←ginj.mvarId!.assumptionCore then
+    return true
   -- Try using that this is an equivalence
   -- Note: if `f` is itself a metavariable, this can cause it to become an equivalence;
   -- perhaps making sure `f` is an equivalence would be correct, but maybe users

--- a/test/apply_fun.lean
+++ b/test/apply_fun.lean
@@ -258,3 +258,14 @@ example : 1 = 1 := by
   · exact test_sorry
   apply_fun f using (g f)
   rfl
+
+
+def funFamily (_i : ℕ) : Bool → Bool := id
+
+-- `apply_fun` should not silence errors in `assumption`
+/--
+error: maximum recursion depth has been reached (use `set_option maxRecDepth <num>` to increase limit)
+-/
+#guard_msgs (error) in
+example (_h₁ : Function.Injective (funFamily ((List.range 128).map (fun _ => 0)).sum)) : true = true := by
+  apply_fun funFamily 0


### PR DESCRIPTION
`MVarId.assumption` is dangerous because you can't tell whether it failed due to a crash or no suitable assumption.

In the case of `apply_fun`, this meant the behavior would change depending on the recursion depth (or presumably heartbeat limit).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
