### PR TITLE
[Merged by Bors] - fix: `push_neg` shouldn't unfold projections

### DIFF
--- a/Mathlib/RingTheory/PowerSeries/Basic.lean
+++ b/Mathlib/RingTheory/PowerSeries/Basic.lean
@@ -769,6 +769,7 @@ theorem X_pow_dvd_iff {s : σ} {n : ℕ} {φ : MvPowerSeries σ R} :
     rintro ⟨i, j⟩ hij
     rw [coeff_X_pow, if_neg, zero_mul]
     contrapose! h
+    dsimp at h
     subst i
     rw [Finsupp.mem_antidiagonal] at hij
     rw [← hij, Finsupp.add_apply, Finsupp.single_eq_same]

--- a/Mathlib/Tactic/PushNeg.lean
+++ b/Mathlib/Tactic/PushNeg.lean
@@ -108,7 +108,7 @@ partial def transformNegation (e : Expr) : SimpM Simp.Step := do
 /-- Common entry point to `push_neg` as a conv. -/
 def pushNegCore (tgt : Expr) : MetaM Simp.Result := do
   let myctx : Simp.Context :=
-    { config := { eta := true, zeta := false },
+    { config := { eta := true, zeta := false, proj := false },
       simpTheorems := #[ ]
       congrTheorems := (← getSimpCongrTheorems) }
   (·.1) <$> Simp.main tgt myctx (methods := { pre := transformNegation })

--- a/test/push_neg.lean
+++ b/test/push_neg.lean
@@ -155,3 +155,24 @@ end use_distrib
 example (a : α) (o : Option α) (h : ¬∀ hs, o.get hs ≠ a) : ∃ hs, o.get hs = a := by
   push_neg at h
   exact h
+
+namespace no_proj
+
+structure G (V : Type) where
+  Adj : V → V → Prop
+
+def g : G Nat where
+  Adj a b := (a ≠ b) ∧ ((a ∣ b) ∨ (b ∣ a))
+
+example {p q : Nat} : ¬ g.Adj p q := by
+  rw [g]
+  guard_target =ₛ ¬ G.Adj { Adj := fun a b => (a ≠ b) ∧ ((a ∣ b) ∨ (b ∣ a)) } p q
+  push_neg
+  guard_target =ₛ ¬ G.Adj { Adj := fun a b => (a ≠ b) ∧ ((a ∣ b) ∨ (b ∣ a)) } p q
+  dsimp only
+  guard_target =ₛ ¬ ((p ≠ q) ∧ ((p ∣ q) ∨ (q ∣ p)))
+  push_neg
+  guard_target =ₛ p ≠ q → ¬p ∣ q ∧ ¬q ∣ p
+  exact test_sorry
+
+end no_proj


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
